### PR TITLE
native: fix convert_int_to_string, add comments, more verbose

### DIFF
--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -466,7 +466,7 @@ fn (mut c Amd64) jmp(addr i32) i32 {
 	c.g.write8(0xe9)
 	pos := c.g.pos()
 	c.g.write32(addr) // 0xffffff
-	c.g.println('jmp ${int(pos+addr).hex2()}')
+	c.g.println('jmp ${int(pos + addr).hex2()}')
 	// return the position of jump address for placeholder
 	return i32(pos)
 }
@@ -3482,13 +3482,13 @@ fn (mut c Amd64) convert_int_to_string(a Register, b Register) {
 	c.g.write8(0x07)
 	c.g.write8(0x30)
 	c.g.println("mov BYTE PTR [rdi], '0'")
-	
+
 	// null terminate the string
 	c.inc(.rdi)
 	c.g.write8(0xc6)
 	c.g.write8(0x07)
 	c.g.write8(0x0)
-	c.g.println("mov BYTE PTR [rdi], `\0`")
+	c.g.println('mov BYTE PTR [rdi], `\0`')
 
 	end_label := c.g.labels.new_label()
 	end_jmp_addr := c.jmp(0)
@@ -3525,7 +3525,7 @@ fn (mut c Amd64) convert_int_to_string(a Register, b Register) {
 	c.g.labels.addrs[skip_minus_label] = c.g.pos()
 	c.g.println('; label ${skip_minus_label}')
 
-	c.mov_reg(Amd64Register.r12, Amd64Register.rdi) // copy the buffer position (start of the number without `-`) to r12 
+	c.mov_reg(Amd64Register.r12, Amd64Register.rdi) // copy the buffer position (start of the number without `-`) to r12
 
 	loop_label := c.g.labels.new_label()
 	loop_start := c.g.pos()
@@ -3553,13 +3553,13 @@ fn (mut c Amd64) convert_int_to_string(a Register, b Register) {
 	}
 	c.g.println('; jump to label ${loop_label}')
 	c.g.labels.addrs[loop_label] = loop_start
-	
+
 	// null terminate the string
 	c.inc(.rdi)
 	c.g.write8(0xc6)
 	c.g.write8(0x07)
 	c.g.write8(0x0)
-	c.g.println("mov BYTE PTR [rdi], `\0`")
+	c.g.println('mov BYTE PTR [rdi], `\0`')
 
 	// after all was converted, reverse the string
 	reg := c.g.get_builtin_arg_reg(.reverse_string, 0) as Amd64Register

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -3482,6 +3482,13 @@ fn (mut c Amd64) convert_int_to_string(a Register, b Register) {
 	c.g.write8(0x07)
 	c.g.write8(0x30)
 	c.g.println("mov BYTE PTR [rdi], '0'")
+	
+	// null terminate the string
+	c.inc(.rdi)
+	c.g.write8(0xc6)
+	c.g.write8(0x07)
+	c.g.write8(0x0)
+	c.g.println("mov BYTE PTR [rdi], `\0`")
 
 	end_label := c.g.labels.new_label()
 	end_jmp_addr := c.jmp(0)
@@ -3546,6 +3553,13 @@ fn (mut c Amd64) convert_int_to_string(a Register, b Register) {
 	}
 	c.g.println('; jump to label ${loop_label}')
 	c.g.labels.addrs[loop_label] = loop_start
+	
+	// null terminate the string
+	c.inc(.rdi)
+	c.g.write8(0xc6)
+	c.g.write8(0x07)
+	c.g.write8(0x0)
+	c.g.println("mov BYTE PTR [rdi], `\0`")
 
 	// after all was converted, reverse the string
 	reg := c.g.get_builtin_arg_reg(.reverse_string, 0) as Amd64Register

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -3524,23 +3524,15 @@ fn (mut c Amd64) convert_int_to_string(a Register, b Register) {
 	loop_start := c.g.pos()
 	c.g.println('; label ${loop_label}')
 
-	c.push(Amd64Register.rax)
-
 	c.mov(Amd64Register.rdx, 0) // upperhalf of the dividend
 	c.mov(Amd64Register.rbx, 10)
-	c.div_reg(.rax, .rbx)
+	c.div_reg(.rax, .rbx) // rax will be the result of the division
 	c.add8(.rdx, i32(`0`)) // rdx is the remainder, add 48 to convert it into it's ascii representation
 
 	c.g.write8(0x66)
 	c.g.write8(0x89)
 	c.g.write8(0x17)
 	c.g.println('mov BYTE PTR [rdi], rdx')
-
-	// divide the integer in rax by 10 for next iteration
-	c.pop(.rax)
-	c.mov(Amd64Register.rbx, 10)
-	c.cdq()
-	c.div_reg(.rax, .rbx)
 
 	// go to the next character
 	c.inc(.rdi)

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -3563,8 +3563,6 @@ fn (mut c Amd64) reverse_string(r Register) {
 		c.mov_reg(Amd64Register.rdi, reg)
 	}
 
-	c.mov(Amd64Register.eax, 0)
-
 	c.g.write8(0x48)
 	c.g.write8(0x8d)
 	c.g.write8(0x48)
@@ -3573,9 +3571,9 @@ fn (mut c Amd64) reverse_string(r Register) {
 
 	c.mov_reg(Amd64Register.rsi, Amd64Register.rdi)
 
-	c.g.write8(0xf2)
-	c.g.write8(0xae)
-	c.g.println('repnz scas al, BYTE PTR es:[rdi]')
+	// search for null at end of string
+	c.mov(Amd64Register.eax, 0)
+	c.cld_repne_scasb()
 
 	c.sub8(.rdi, 0x2)
 	c.cmp_reg(.rdi, .rsi)

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -1596,10 +1596,9 @@ fn (mut c Amd64) div_reg(a Amd64Register, b Amd64Register) {
 			c.g.write8(0xf8)
 		}
 		.rbx {
-			c.mov(Amd64Register.edx, 0)
 			c.g.write8(0x48)
 			c.g.write8(0xf7)
-			c.g.write8(0xfb) // idiv ebx
+			c.g.write8(0xfb)
 		}
 		.rdx {
 			c.g.write8(0x48)
@@ -1610,7 +1609,7 @@ fn (mut c Amd64) div_reg(a Amd64Register, b Amd64Register) {
 			panic('unhandled div ${b}')
 		}
 	}
-	c.g.println('idiv ${b}')
+	c.g.println('div ${b}')
 }
 
 fn (mut c Amd64) mod_reg(a Amd64Register, b Amd64Register) {

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -603,7 +603,7 @@ fn (mut c Amd64) mov_store(regptr Amd64Register, reg Amd64Register, size Size) {
 	}
 	c.g.write8(if size == ._8 { i32(0x88) } else { i32(0x89) })
 	c.g.write8(i32(reg) % 8 * 8 + i32(regptr) % 8)
-	c.g.println('mov [${regptr}], ${reg}')
+	c.g.println('mov [${regptr}], ${reg} ; size:${size}bits')
 }
 
 fn (mut c Amd64) mov_reg_to_var(var Var, r Register, config VarConfig) {
@@ -3536,10 +3536,7 @@ fn (mut c Amd64) convert_int_to_string(a Register, b Register) {
 	c.div_reg(.rax, .rbx) // rax will be the result of the division
 	c.add8(.rdx, i32(`0`)) // rdx is the remainder, add 48 to convert it into it's ascii representation
 
-	c.g.write8(0x66)
-	c.g.write8(0x89)
-	c.g.write8(0x17)
-	c.g.println('mov BYTE PTR [rdi], rdx')
+	c.mov_store(.rdi, .rdx, ._8)
 
 	// go to the next character
 	c.inc(.rdi)
@@ -3555,7 +3552,6 @@ fn (mut c Amd64) convert_int_to_string(a Register, b Register) {
 	c.g.labels.addrs[loop_label] = loop_start
 
 	// null terminate the string
-	c.inc(.rdi)
 	c.g.write8(0xc6)
 	c.g.write8(0x07)
 	c.g.write8(0x0)

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -856,9 +856,11 @@ fn (mut g Gen) allocate_string(s string, opsize i32, typ RelocType) i32 {
 	return str_pos
 }
 
+// name, size of stored type (nb of bytes), nb of items
 fn (mut g Gen) allocate_array(name string, size i32, items i32) i32 {
-	pos := g.code_gen.allocate_var(name, size, items)
-	g.stack_var_pos += (size * items)
+	g.println('; allocate array `${name}` item-size:${size} items:${items}:')
+	pos := g.code_gen.allocate_var(name, size, items) // store the lenght of the array
+	g.stack_var_pos += (size * items) // reserve space on the stack
 	return pos
 }
 
@@ -945,6 +947,7 @@ fn (mut g Gen) eval_escape_codes(str string) string {
 }
 
 fn (mut g Gen) gen_to_string(reg Register, typ ast.Type) {
+	g.println('; to_string (reg:${reg}) {')
 	if typ.is_int() {
 		buffer := g.allocate_array('itoa-buffer', 1, 32) // 32 characters should be enough
 		g.code_gen.lea_var_to_reg(g.get_builtin_arg_reg(.int_to_string, 1), buffer)
@@ -969,9 +972,11 @@ fn (mut g Gen) gen_to_string(reg Register, typ ast.Type) {
 	} else {
 		g.n_error('int-to-string conversion not implemented for type ${typ}')
 	}
+	g.println('; to_string }')
 }
 
 fn (mut g Gen) gen_var_to_string(reg Register, expr ast.Expr, var Var, config VarConfig) {
+	g.println('; var_to_string {')
 	typ := g.get_type_from_var(var)
 	if typ == ast.rune_type_idx {
 		buffer := g.code_gen.allocate_var('rune-buffer', 8, 0)
@@ -990,6 +995,7 @@ fn (mut g Gen) gen_var_to_string(reg Register, expr ast.Expr, var Var, config Va
 	} else {
 		g.n_error('int-to-string conversion not implemented for type ${typ}')
 	}
+	g.println('; var_to_string }')
 }
 
 fn (mut g Gen) is_used_by_main(node ast.FnDecl) bool {

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -856,11 +856,11 @@ fn (mut g Gen) allocate_string(s string, opsize i32, typ RelocType) i32 {
 	return str_pos
 }
 
-// name, size of stored type (nb of bytes), nb of items
+// allocates a buffer variable: name, size of stored type (nb of bytes), nb of items
 fn (mut g Gen) allocate_array(name string, size i32, items i32) i32 {
 	g.println('; allocate array `${name}` item-size:${size} items:${items}:')
-	pos := g.code_gen.allocate_var(name, size, items) // store the lenght of the array
-	g.stack_var_pos += (size * items) // reserve space on the stack
+	pos := g.code_gen.allocate_var(name, size, items) // store the lenght of the array on the stack
+	g.stack_var_pos += (size * items) // reserve space on the stack for the items
 	return pos
 }
 

--- a/vlib/v/gen/native/tests/print.vv
+++ b/vlib/v/gen/native/tests/print.vv
@@ -104,6 +104,12 @@ fn test_interpolated() {
 	println('num: ${num}; bool: ${boool}')
 }
 
+fn test_intermediate() {
+	c := 0
+	a := 'a'
+	println(c)
+}
+
 fn main() {
 	test_stdout()
 	test_stderr()
@@ -113,4 +119,5 @@ fn main() {
 	test_exprs()
 	test_sizeof()
 	test_interpolated()
+	test_intermediate()
 }

--- a/vlib/v/gen/native/tests/print.vv.out
+++ b/vlib/v/gen/native/tests/print.vv.out
@@ -21,3 +21,4 @@ false true
 sizeof: 4, 12
 this is an interpolated string
 num: 42; bool: true
+0


### PR DESCRIPTION
Adds comments to help understanding the code.
Adds more `c.g.println` calls to have an easier time in verbose native mode.
Fixes the new test by terminating the buffer used in `convert_int_to_string` with `\0` because it is assumed after when reversing it and when priting it (it tries to find it's lenght by searching `\0`). (I did not know how to name my test function.)
Adds CLD when reversing the string to prevent the case where DF would be set and REPNE SCAS would do the opposite of what is expected.