### PR TITLE
checker: add checker for passing multi return as arg to func that expects less param

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1631,6 +1631,14 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				}
 			} else if arg_typ_sym.info is ast.MultiReturn {
 				arg_typs := arg_typ_sym.info.types
+				if !(func.is_variadic && i >= func.params.len - 1) {
+					if arg_typ_sym.info.types.len > func.params.len {
+						c.error('trying to pass ${arg_typ_sym.info.types.len} argument(s), but function expects ${func.params.len} argument(s)',
+							node.pos)
+						continue_check = false
+						return ast.void_type
+					}
+				}
 				out: for n in 0 .. arg_typ_sym.info.types.len {
 					curr_arg := arg_typs[n]
 					multi_param := if func.is_variadic && i >= func.params.len - 1 {

--- a/vlib/v/checker/tests/call_arg_multi_return_err.out
+++ b/vlib/v/checker/tests/call_arg_multi_return_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/call_arg_multi_return_err.vv:6:6: error: assignment mismatch: 1 variable but `some_fn()` returns 2 values
+    4 | 
+    5 | fn some_fn2() {
+    6 |     ret := some_fn()
+      |         ~~
+    7 |     some_fn3(ret)
+    8 | }
+vlib/v/checker/tests/call_arg_multi_return_err.vv:7:2: error: trying to pass 2 argument(s), but function expects 1 argument(s)
+    5 | fn some_fn2() {
+    6 |     ret := some_fn()
+    7 |     some_fn3(ret)
+      |     ~~~~~~~~~~~~~
+    8 | }
+    9 |

--- a/vlib/v/checker/tests/call_arg_multi_return_err.vv
+++ b/vlib/v/checker/tests/call_arg_multi_return_err.vv
@@ -1,0 +1,10 @@
+fn some_fn() (int, int) {
+	return 0, 0
+}
+
+fn some_fn2() {
+	ret := some_fn()
+	some_fn3(ret)
+}
+
+fn some_fn3(param int) {}


### PR DESCRIPTION
Fix #23735