### PR TITLE
v.cflag: support `#flag $when_first_existing(libABC.a, /some/path/libABC.a, ...)`, without panicing (unlike `#flag $first_existing(...)`)

### DIFF
--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -516,10 +516,11 @@ pub fn msvc_string_flags(cflags []cflag.CFlag) MsvcStringFlags {
 			lib_lib := flag.value + '.lib'
 			real_libs << lib_lib
 		} else if flag.name == '-I' {
-			inc_paths << flag.format()
+			inc_paths << flag.format() or { continue }
 		} else if flag.name == '-D' {
 			defines << '/D${flag.value}'
 		} else if flag.name == '-L' {
+			// TODO: use flag.format() here as well; `#flag -L$when_first_existing(...)` is a more explicit way to achieve the same
 			lib_paths << flag.value
 			lib_paths << flag.value + os.path_separator + 'msvc'
 			// The above allows putting msvc specific .lib files in a subfolder msvc/ ,
@@ -528,6 +529,7 @@ pub fn msvc_string_flags(cflags []cflag.CFlag) MsvcStringFlags {
 			// When both a msvc .lib file and .dll file are present in the same folder,
 			// as for example for glfw3, compilation with gcc would fail.
 		} else if flag.value.ends_with('.o') {
+			// TODO: use flag.format() here as well; `#flag -L$when_first_existing(...)` is a more explicit way to achieve the same
 			// msvc expects .obj not .o
 			other_flags << '"${flag.value}bj"'
 		} else if flag.value.starts_with('-D') {

--- a/vlib/v/cflag/cflags.v
+++ b/vlib/v/cflag/cflags.v
@@ -54,8 +54,7 @@ pub fn (cf &CFlag) eval() ?string {
 				panic('>> error: none of the paths ${svalues} exist')
 			}
 			if remainder.starts_with(wexisting_literal) {
-				found, spath, delta_i, svalues := find_first_existing_path(remainder,
-					wexisting_literal)
+				found, spath, delta_i, _ := find_first_existing_path(remainder, wexisting_literal)
 				if found {
 					value_builder.write_string(spath)
 					i += delta_i

--- a/vlib/v/cflag/cflags.v
+++ b/vlib/v/cflag/cflags.v
@@ -22,28 +22,46 @@ pub fn (c &CFlag) str() string {
 }
 
 const fexisting_literal = r'$first_existing'
+const wexisting_literal = r'$when_first_existing'
+
+fn find_first_existing_path(remainder string, literal string) (bool, string, int, []string) {
+	sparams := remainder[literal.len + 1..].all_before(')')
+	delta_i := sparams.len + literal.len + 1
+	svalues := sparams.replace(',', '\n').split_into_lines().map(it.trim('\t \'"'))
+	for spath in svalues {
+		if os.exists(spath) {
+			return true, spath, delta_i, []string{}
+		}
+	}
+	return false, '', delta_i, svalues
+}
 
 // expand the flag value
-pub fn (cf &CFlag) eval() string {
+pub fn (cf &CFlag) eval() ?string {
 	mut value_builder := strings.new_builder(10 * cf.value.len)
 	cflag_eval_outer_loop: for i := 0; i < cf.value.len; i++ {
 		x := cf.value[i]
 		if x == `$` {
 			remainder := cf.value[i..]
 			if remainder.starts_with(fexisting_literal) {
-				sparams := remainder[fexisting_literal.len + 1..].all_before(')')
-				i += sparams.len + fexisting_literal.len + 1
-				svalues := sparams.replace(',', '\n').split_into_lines().map(it.trim('\t \'"'))
-				// mut found_spath := ''
-				for spath in svalues {
-					if os.exists(spath) {
-						// found_spath = spath
-						value_builder.write_string(spath)
-						continue cflag_eval_outer_loop
-					}
+				found, spath, delta_i, svalues := find_first_existing_path(remainder,
+					fexisting_literal)
+				if found {
+					value_builder.write_string(spath)
+					i += delta_i
+					continue
 				}
 				panic('>> error: none of the paths ${svalues} exist')
-				continue
+			}
+			if remainder.starts_with(wexisting_literal) {
+				found, spath, delta_i, svalues := find_first_existing_path(remainder,
+					wexisting_literal)
+				if found {
+					value_builder.write_string(spath)
+					i += delta_i
+					continue
+				}
+				return none
 			}
 		}
 		value_builder.write_string(x.ascii_str())
@@ -52,12 +70,12 @@ pub fn (cf &CFlag) eval() string {
 }
 
 // format flag
-pub fn (cf &CFlag) format() string {
+pub fn (cf &CFlag) format() ?string {
 	mut value := ''
 	if cf.cached != '' {
 		value = cf.cached
 	} else {
-		value = cf.eval()
+		value = cf.eval()?
 	}
 	if cf.name in ['-l', '-Wa', '-Wl', '-Wp'] && value != '' {
 		return '${cf.name}${value}'.trim_space()
@@ -97,7 +115,7 @@ pub fn (cflags []CFlag) c_options_without_object_files() []string {
 		if flag.value.ends_with('.o') || flag.value.ends_with('.obj') {
 			continue
 		}
-		args << flag.format()
+		args << flag.format() or { continue }
 	}
 	return args
 }
@@ -108,10 +126,10 @@ pub fn (cflags []CFlag) c_options_only_object_files() []string {
 		// TODO figure out a better way to copy cross compiling flags to the linker
 		if flag.value.ends_with('.o') || flag.value.ends_with('.obj')
 			|| (flag.name == '-l' && flag.value == 'pq') {
-			args << flag.format()
+			args << flag.format() or { continue }
 		}
 	}
-	return args
+	return args.filter(it != '')
 }
 
 pub fn (cflags []CFlag) defines_others_libs() ([]string, []string, []string) {

--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -112,6 +112,8 @@ fn (mut p Parser) hash() ast.HashStmt {
 	}
 }
 
+const error_msg = 'only `\$tmpl()`, `\$env()`, `\$embed_file()`, `\$pkgconfig()`, `\$vweb.html()`, `\$compile_error()`, `\$compile_warn()`, `\$d()` and `\$res()` comptime functions are supported right now'
+
 fn (mut p Parser) comptime_call() ast.ComptimeCall {
 	err_node := ast.ComptimeCall{
 		scope: unsafe { nil }
@@ -119,7 +121,6 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 	start_pos := p.tok.pos()
 	p.check(.dollar)
 	mut is_veb := false
-	error_msg := 'only `\$tmpl()`, `\$env()`, `\$embed_file()`, `\$pkgconfig()`, `\$vweb.html()`, `\$compile_error()`, `\$compile_warn()`, `\$d()` and `\$res()` comptime functions are supported right now'
 	if p.peek_tok.kind == .dot {
 		name := p.check_name() // skip `vweb.html()` TODO
 		if name != 'vweb' && name != 'veb' {


### PR DESCRIPTION
This PR provides a way to cleanup `vlib/sync/stdatomic/1.declarations.c.v` later.
It will look like this:
```v
$if linux {
	$if tinyc {
		$if amd64 {
			// most Linux distributions have /usr/lib/libatomic.so,
			// but Ubuntu uses gcc version specific dir
			#flag $when_first_existing('/usr/lib/gcc/x86_64-linux-gnu/6/libatomic.a','/usr/lib/gcc/x86_64-linux-gnu/7/libatomic.a','/usr/lib/gcc/x86_64-linux-gnu/8/libatomic.a','/usr/lib/gcc/x86_64-linux-gnu/9/libatomic.a','/usr/lib/gcc/x86_64-linux-gnu/10/libatomic.a','/usr/lib/gcc/x86_64-linux-gnu/11/libatomic.a','/usr/lib/gcc/x86_64-linux-gnu/12/libatomic.a','/usr/lib/gcc/x86_64-linux-gnu/13/libatomic.a','/usr/lib/gcc/x86_64-linux-gnu/14/libatomic.a')
			// Redhat/CentOS paths:
			#flag $when_first_existing('/usr/lib/gcc/x86_64-redhat-linux/6/libatomic.a','/usr/lib/gcc/x86_64-redhat-linux/7/libatomic.a','/usr/lib/gcc/x86_64-redhat-linux/8/libatomic.a','/usr/lib/gcc/x86_64-redhat-linux/9/libatomic.a','/usr/lib/gcc/x86_64-redhat-linux/10/libatomic.a','/usr/lib/gcc/x86_64-redhat-linux/11/libatomic.a','/usr/lib/gcc/x86_64-redhat-linux/12/libatomic.a','/usr/lib/gcc/x86_64-redhat-linux/13/libatomic.a','/usr/lib/gcc/x86_64-redhat-linux/14/libatomic.a')
			// Gentoo paths:
			#flag $when_first_existing('/usr/lib/gcc/x86_64-pc-linux-gnu/6/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-gnu/7/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-gnu/8/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-gnu/9/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-gnu/10/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-gnu/11/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-gnu/12/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-gnu/13/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-gnu/14/libatomic.a')
			// OpenSUSE paths:
			#flag $when_first_existing('/usr/lib64/gcc/x86_64-suse-linux/6/libatomic.a','/usr/lib64/gcc/x86_64-suse-linux/7/libatomic.a','/usr/lib64/gcc/x86_64-suse-linux/8/libatomic.a','/usr/lib64/gcc/x86_64-suse-linux/9/libatomic.a','/usr/lib64/gcc/x86_64-suse-linux/10/libatomic.a','/usr/lib64/gcc/x86_64-suse-linux/11/libatomic.a','/usr/lib64/gcc/x86_64-suse-linux/12/libatomic.a','/usr/lib64/gcc/x86_64-suse-linux/13/libatomic.a','/usr/lib64/gcc/x86_64-suse-linux/14/libatomic.a')
			// ALT Linux paths:
			#flag $when_first_existing('/usr/lib64/gcc/x86_64-alt-linux/6/libatomic.a','/usr/lib64/gcc/x86_64-alt-linux/7/libatomic.a','/usr/lib64/gcc/x86_64-alt-linux/8/libatomic.a','/usr/lib64/gcc/x86_64-alt-linux/9/libatomic.a','/usr/lib64/gcc/x86_64-alt-linux/10/libatomic.a','/usr/lib64/gcc/x86_64-alt-linux/11/libatomic.a','/usr/lib64/gcc/x86_64-alt-linux/12/libatomic.a','/usr/lib64/gcc/x86_64-alt-linux/13/libatomic.a','/usr/lib64/gcc/x86_64-alt-linux/14/libatomic.a')
			$if musl ? {
				#flag $when_first_existing('/usr/lib/gcc/x86_64-pc-linux-musl/6/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/7/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/8/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/9/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/10/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/11/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/12/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/13/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/14/libatomic.a')
			}
		}
	} $else {
		#flag -latomic
	}
}
```
With it, the passed arguments to tcc will not be as long anymore, since they will not include paths for linux distros that are != the current one.

Here is an example of the generated command passed to tcc, with `#flag $when_first_existing()`:
```
#0 13:39:49 ^ support_flag_when_first_existing ~/code/v>./v -no-retry-compilation -cc tcc -showcc /home/delian/code/misc/2025_02_21__13/x.c.v
> C compiler cmd: '/home/delian/code/v/thirdparty/tcc/tcc.exe' '@/tmp/v_1000/x.01JMM50PDMPJTAZZRW71EKJ6T0.tmp.c.rsp'
> C compiler response file "/tmp/v_1000/x.01JMM50PDMPJTAZZRW71EKJ6T0.tmp.c.rsp":
  -fwrapv -o "/home/delian/code/misc/2025_02_21__13/x" -D GC_THREADS=1 -D GC_BUILTIN_ATOMIC=1 -I "/home/delian/code/v/thirdparty/libgc/include" "/tmp/v_1000/x.01JMM50PDMPJTAZZRW71EKJ6T0.tmp.c" -std=gnu99 -D_DEFAULT_SOURCE -bt25 "/home/delian/code/v/thirdparty/tcc/lib/libgc.a" -ldl -lpthread "/usr/lib/gcc/x86_64-linux-gnu/6/libatomic.a"
#0 13:41:49 ^ support_flag_when_first_existing ~/code/v>
```