### PR TITLE
native: add support for enums of different types

### DIFF
--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -3460,7 +3460,6 @@ pub fn (mut c Amd64) allocate_var(name string, size i32, initial_val Number) i32
 		}
 	}
 
-
 	// println('allocate_var(size=$size, initial_val=$initial_val)')
 	c.g.println('mov [rbp-${int(n).hex2()}], ${initial_val} ; Allocate var `${name}`')
 	return c.g.stack_var_pos

--- a/vlib/v/gen/native/arm64.v
+++ b/vlib/v/gen/native/arm64.v
@@ -45,7 +45,7 @@ mut:
 	// arm64 specific stuff for code generation
 }
 
-fn (mut x Arm64) allocate_var(name string, size i32, initial_val i32) i32 {
+fn (mut x Arm64) allocate_var(name string, size i32, initial_val Number) i32 {
 	eprintln('TODO: allocating var on arm64 (${name}) = ${size} = ${initial_val}')
 	return 0
 }
@@ -376,11 +376,7 @@ fn (mut c Arm64) mov_reg(r1 Register, r2 Register) {
 	panic('Arm64.mov_reg() not implemented')
 }
 
-fn (mut c Arm64) mov64u(r Register, val u64) {
-	panic('Arm64.mov64u() not implemented')
-}
-
-fn (mut c Arm64) mov64(r Register, val i64) {
+fn (mut c Arm64) mov64(r Register, val Number) {
 	panic('Arm64.mov64() not implemented')
 }
 

--- a/vlib/v/gen/native/elf.v
+++ b/vlib/v/gen/native/elf.v
@@ -250,15 +250,15 @@ fn (mut g Gen) gen_program_header(p ProgramHeader) {
 	g.write64(p.offset) // p_offset
 	g.println('; p_offset')
 	g.write64(if p.vaddr == 0 {
-		segment_start
+		i64(segment_start)
 	} else {
-		p.vaddr
+		i64(p.vaddr)
 	}) // p_vaddr
 	g.println('; p_vaddr')
 	g.write64(if p.paddr == 0 {
-		segment_start
+		i64(segment_start)
 	} else {
-		p.paddr
+		i64(p.paddr)
 	}) // p_paddr
 	g.println('; p_paddr')
 	if p.filesz == 0 {
@@ -758,7 +758,7 @@ pub fn (mut g Gen) generate_linkable_elf_header() {
 
 	g.code_gen.call(placeholder)
 	g.println('; call main.main')
-	g.code_gen.mov64(g.code_gen.main_reg(), 0)
+	g.code_gen.mov64(g.code_gen.main_reg(), i64(0))
 	g.code_gen.ret()
 	g.println('; return 0')
 

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -564,7 +564,7 @@ pub fn (mut g Gen) calculate_enum_fields() {
 			if decl.is_flag {
 				match mut value {
 					i64 {
-						value = value << i64(1)
+						value = value * 2 // same as << 1 but without notice
 					}
 					u64 {
 						value = value << u64(1)

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -82,7 +82,7 @@ mut:
 	add(r Register, val i32)
 	address_size() i32
 	adr(r Arm64Register, delta i32) // Note: Temporary!
-	allocate_var(name string, size i32, initial_val i32) i32
+	allocate_var(name string, size i32, initial_val Number) i32
 	assign_stmt(node ast.AssignStmt) // TODO: make platform-independent
 	builtin_decl(builtin BuiltinFn)
 	call_addr_at(addr i32, at i64) i64
@@ -125,8 +125,7 @@ mut:
 	mov_reg(r1 Register, r2 Register)
 	mov_var_to_reg(reg Register, var Var, config VarConfig)
 	mov(r Register, val i32)
-	mov64(r Register, val i64)
-	mov64u(r Register, val u64)
+	mov64(r Register, val Number)
 	movabs(reg Register, val i64)
 	patch_relative_jmp(pos i32, addr i64)
 	prefix_expr(node ast.PrefixExpr)
@@ -202,9 +201,12 @@ mut:
 	offsets []i32
 }
 
+type Number = u64 | i64
+
 struct Enum {
+	size i32 // size of the type of the enum in bytes
 mut:
-	fields map[string]i32
+	fields map[string]Number
 }
 
 struct MultiReturn {
@@ -536,17 +538,47 @@ pub fn (mut g Gen) calculate_all_size_align() {
 
 pub fn (mut g Gen) calculate_enum_fields() {
 	for name, decl in g.table.enum_decls {
-		mut enum_vals := Enum{}
-		mut value := if decl.is_flag { i32(1) } else { i32(0) }
+		enum_size := g.get_type_size(decl.typ)
+		mut enum_vals := Enum{
+			size: i32(enum_size)
+		}
+		mut value := Number(if decl.is_flag { i64(1) } else { i64(0) })
 		for field in decl.fields {
 			if field.has_expr {
-				value = i32(g.eval.expr(field.expr, ast.int_type_idx).int_val())
+				str_val := g.eval.expr(field.expr, ast.int_type_idx).string()
+				if str_val.len >= 0 && str_val[0] == `-` {
+					value = str_val.i64()
+				} else {
+					value = str_val.u64()
+				}
 			}
-			enum_vals.fields[field.name] = value
+			match value {
+				// Dereferences the sumtype (it would get assigned by address and messed up)
+				i64 {
+					enum_vals.fields[field.name] = value as i64
+				}
+				u64 {
+					enum_vals.fields[field.name] = value as u64
+				}
+			}
 			if decl.is_flag {
-				value <<= 1
+				match mut value {
+					i64 {
+						value = value << i64(1)
+					}
+					u64 {
+						value = value << u64(1)
+					}
+				}
 			} else {
-				value++
+				match mut value {
+					i64 {
+						value++
+					}
+					u64 {
+						value++
+					}
+				}
 			}
 		}
 		g.enum_vals[name] = enum_vals
@@ -585,16 +617,30 @@ fn (mut g Gen) write32(n i32) {
 	g.buf << u8(n >> 24)
 }
 
-fn (mut g Gen) write64(n i64) {
+fn (mut g Gen) write64(n Number) {
 	// write 8 bytes
-	g.buf << u8(n)
-	g.buf << u8(n >> 8)
-	g.buf << u8(n >> 16)
-	g.buf << u8(n >> 24)
-	g.buf << u8(n >> 32)
-	g.buf << u8(n >> 40)
-	g.buf << u8(n >> 48)
-	g.buf << u8(n >> 56)
+	match n {
+		i64 {
+			g.buf << u8(n)
+			g.buf << u8(n >> 8)
+			g.buf << u8(n >> 16)
+			g.buf << u8(n >> 24)
+			g.buf << u8(n >> 32)
+			g.buf << u8(n >> 40)
+			g.buf << u8(n >> 48)
+			g.buf << u8(n >> 56)
+		}
+		u64 {
+			g.buf << u8(n)
+			g.buf << u8(n >> 8)
+			g.buf << u8(n >> 16)
+			g.buf << u8(n >> 24)
+			g.buf << u8(n >> 32)
+			g.buf << u8(n >> 40)
+			g.buf << u8(n >> 48)
+			g.buf << u8(n >> 56)
+		}
+	}
 }
 
 fn (mut g Gen) write64_at(at i64, n i64) {
@@ -757,8 +803,8 @@ fn (mut g Gen) get_type_size(raw_type ast.Type) i32 {
 			g.structs[typ.idx()] = strc
 		}
 		ast.Enum {
-			size = 4
-			align = 4
+			size = g.get_type_size(ts.info.typ)
+			align = g.get_type_align(ts.info.typ)
 		}
 		ast.MultiReturn {
 			for t in ts.info.types {
@@ -865,7 +911,7 @@ fn (mut g Gen) allocate_string(s string, opsize i32, typ RelocType) i32 {
 // allocates a buffer variable: name, size of stored type (nb of bytes), nb of items
 fn (mut g Gen) allocate_array(name string, size i32, items i32) i32 {
 	g.println('; allocate array `${name}` item-size:${size} items:${items}:')
-	pos := g.code_gen.allocate_var(name, 4, items) // store the length of the array on the stack in a 4 byte var
+	pos := g.code_gen.allocate_var(name, 4, i64(items)) // store the length of the array on the stack in a 4 byte var
 	g.stack_var_pos += (size * items) // reserve space on the stack for the items
 	return pos
 }
@@ -986,7 +1032,7 @@ fn (mut g Gen) gen_var_to_string(reg Register, expr ast.Expr, var Var, config Va
 	g.println('; var_to_string {')
 	typ := g.get_type_from_var(var)
 	if typ == ast.rune_type_idx {
-		buffer := g.code_gen.allocate_var('rune-buffer', 8, 0)
+		buffer := g.code_gen.allocate_var('rune-buffer', 8, i64(0))
 		g.code_gen.convert_rune_to_string(reg, buffer, var, config)
 	} else if typ.is_int() {
 		if typ.is_unsigned() {

--- a/vlib/v/gen/native/macho.v
+++ b/vlib/v/gen/native/macho.v
@@ -44,14 +44,14 @@ struct Reloc {
 fn (mut g Gen) macho_segment64_pagezero() {
 	g.macho_add_loadcommand(lc_segment_64, 72)
 	g.write_string_with_padding('__PAGEZERO', 16) // section name
-	g.write64(0) // vmaddr
+	g.write64(i64(0)) // vmaddr
 	if g.pref.arch == .amd64 {
 		g.write64(i64(g.get_pagesize())) // vmsize
 	} else {
 		g.write64(base_addr) // vmsize
 	}
-	g.write64(0) // fileoff
-	g.write64(0) // filesize
+	g.write64(i64(0)) // fileoff
+	g.write64(i64(0)) // filesize
 	g.write32(0) // maxprot
 	g.write32(0) // initprot
 	g.write32(0) // nsects
@@ -86,17 +86,17 @@ fn (mut g Gen) macho_segment64_linkedit() {
 	g.write_string_with_padding('__LINKEDIT', 16)
 
 	if g.pref.arch == .amd64 {
-		g.write64(0x3000) // vmaddr
-		g.write64(0x1000) // vmsize
-		g.write64(0x1000) // fileoff
+		g.write64(i64(0x3000)) // vmaddr
+		g.write64(i64(0x1000)) // vmsize
+		g.write64(i64(0x1000)) // fileoff
 	} else {
 		// g.size_pos << g.buf.len
 		// g.write64(native.base_addr + g.get_pagesize()) // vmaddr
 		g.write64(i64(g.get_pagesize()) - 0x1000) // vmaddr
-		g.write64(0) // g.get_pagesize()) // vmsize
+		g.write64(i64(0)) // g.get_pagesize()) // vmsize
 		g.write64(i64(g.get_pagesize())) // fileoff
 	}
-	g.write64(0) // filesize
+	g.write64(i64(0)) // filesize
 	g.write32(7) // maxprot
 	g.write32(3) // initprot // must be writeable
 	g.write32(0) // nsects
@@ -134,7 +134,7 @@ fn (mut g Gen) macho_segment64_text() []i32 {
 	g.write64(base_addr) // vmaddr
 
 	g.write64(i64(g.get_pagesize()) * 2) // vmsize
-	g.write64(0) // fileoff
+	g.write64(i64(0)) // fileoff
 	g.write64(i64(g.get_pagesize()) + 63) // filesize
 
 	g.write32(7) // maxprot
@@ -146,13 +146,13 @@ fn (mut g Gen) macho_segment64_text() []i32 {
 	g.write_string_with_padding('__TEXT', 16) // segment name
 	if g.pref.arch == .arm64 {
 		g.write64(base_addr + i64(g.get_pagesize())) // vmaddr
-		g.write64(0) // vmsize
+		g.write64(i64(0)) // vmsize
 		g.write32(0) // offset
 		g.write32(4) // align
 	} else {
 		g.write64(base_addr + i64(g.get_pagesize())) // vmaddr
 		patch << i32(g.buf.len)
-		g.write64(0) // vmsize
+		g.write64(i64(0)) // vmsize
 		g.write32(g.get_pagesize()) // offset
 		g.write32(0) // align
 	}
@@ -292,10 +292,10 @@ pub fn (mut g Gen) generate_macho_object_header() {
 	g.write32(0x19) // LC_SEGMENT_64
 	g.write32(0x98) // command size
 	g.zeroes(16) // segment name
-	g.write64(0) // VM address
-	g.write64(0x25) // VM size
+	g.write64(i64(0)) // VM address
+	g.write64(i64(0x25)) // VM size
 	g.write64(i64(text_offset)) // file offset
-	g.write64(0x25) // file size
+	g.write64(i64(0x25)) // file size
 	g.write32(0x7) // max vm protection
 	g.write32(0x7) // initial vm protection
 	g.write32(0x1) // # of sections
@@ -303,8 +303,8 @@ pub fn (mut g Gen) generate_macho_object_header() {
 	////
 	g.write_string_with_padding('__text', 16) // section name
 	g.write_string_with_padding('__TEXT', 16) // segment name
-	g.write64(0) // address
-	g.write64(0x25) // size
+	g.write64(i64(0)) // address
+	g.write64(i64(0x25)) // size
 	g.write32(text_offset) // offset
 	if g.pref.arch == .arm64 {
 		g.write32(4) // alignment
@@ -363,7 +363,7 @@ pub fn (mut g Gen) generate_macho_footer() {
 		// eprintln('$n + $delta')
 		g.write32_at(i64(o), n + delta)
 	}
-	g.write64(0)
+	g.write64(i64(0))
 	g.macho_patch_header()
 	if g.pref.arch == .amd64 {
 		call_delta := i32(g.main_fn_addr - g.code_start_pos) - 5

--- a/vlib/v/gen/native/pe.v
+++ b/vlib/v/gen/native/pe.v
@@ -682,10 +682,10 @@ fn (mut g Gen) gen_pe_idata() {
 
 		for func in imp.functions {
 			g.pe_dll_relocations[func] = g.pos()
-			g.write64(0) // filled in later
+			g.write64(i64(0)) // filled in later
 			g.println('; name lookup addr to "${func}"')
 		}
-		g.write64(0) // null entry
+		g.write64(i64(0)) // null entry
 		g.println('; null entry')
 		g.println('^^^ import lookup table ("${imp.name}")')
 	}

--- a/vlib/v/gen/native/stmt.c.v
+++ b/vlib/v/gen/native/stmt.c.v
@@ -251,7 +251,7 @@ fn (mut g Gen) for_in_stmt(node ast.ForInStmt) { // Work on that
 		g.println('; for ${node.val_var} in range {')
 		// for a in node.cond .. node.high {
 
-		i := g.code_gen.allocate_var(node.val_var, 8, 0) // iterator variable
+		i := g.code_gen.allocate_var(node.val_var, 8, i64(0)) // iterator variable
 		g.println('; evaluate node.cond for lower bound:')
 		g.expr(node.cond) // outputs the lower loop bound (initial value) to the main reg
 		main_reg := g.code_gen.main_reg()

--- a/vlib/v/gen/native/tests/enum.vv
+++ b/vlib/v/gen/native/tests/enum.vv
@@ -68,10 +68,107 @@ fn value_test() {
 	assert Value.e == unsafe { Value(3) }
 }
 
+enum BigI as i64 {
+        first = -3_000_000_000
+        sec
+}
+
+enum BigU as u64 {
+	first = 3_000_000_000
+	sec
+}
+
+enum SmallI as i8 {
+	first = -3
+	sec
+}
+
+enum SmallU as u8 {
+	first = 3
+	sec
+}
+
+enum MediumI as i16 {
+	first = -300
+	sec
+}
+
+enum MediumU as u16 {
+	first = 300
+	sec
+}
+
+enum NormalI as i32 {
+	first = -3_000_000
+	sec
+}
+
+enum NormalU as u32 {
+	first = 3_000_000
+	sec
+}
+
+struct DiffSizes {
+mut:
+	a BigI
+	b BigU
+	c SmallI
+	d SmallU
+	e MediumI
+	f MediumU
+	g NormalI
+	h NormalU
+}
+
+fn size_enum() {
+	a := BigI.sec
+	assert i64(a) == -2_999_999_999
+
+	b := BigU.sec
+	assert u64(b) == 3_000_000_001
+
+	c := SmallI.sec
+	assert i8(c) == -2
+
+	d := SmallU.sec
+	assert u8(d) == 4
+	
+	e := MediumI.sec
+	assert i16(e) == -299
+
+	f := MediumU.sec
+	assert u16(f) == 301
+	
+	g := NormalI.sec
+	assert i32(g) == -2_999_999
+
+	h := NormalU.sec
+	assert u32(h) == 3_000_001
+
+	mut diff := DiffSizes{}
+	diff.a = .sec
+	diff.b = .sec
+	diff.c = .sec
+	diff.d = .sec
+	diff.e = .sec
+	diff.f = .sec
+	diff.g = .sec
+	diff.h = .sec
+	assert i64(diff.a) == -2_999_999_999
+	assert u64(diff.b) == 3_000_000_001
+	assert i8(diff.c) == -2
+	assert u8(diff.d) == 4
+	assert i16(diff.e) == -299
+	assert u16(diff.f) == 301
+	assert i32(diff.g) == -2_999_999
+	assert u32(diff.h) == 3_000_001
+}
+
 fn main() {
 	enum_test()
 	match_test()
 	test_enum_variant_and_method_name_clash()
 	value_test()
+	size_enum()
 	println('OK')
 }


### PR DESCRIPTION
Add support for enums with a user-chosen type like `enum MyEnum as u8`
Instead of duplicating functions for u64 and i64, use a sumtype
Add tests for enums of different types