### PR TITLE
pref: Fix panic in parse_args_and_show_errors was called with no args.

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -104,7 +104,7 @@ pub mut:
 	is_liveshared      bool   // a shared library, that will be used in a -live main program
 	is_shared          bool   // an ordinary shared library, -shared, no matter if it is live or not
 	is_o               bool   // building an .o file
-	is_prof            bool   // benchmark every function	
+	is_prof            bool   // benchmark every function
 	is_prod            bool   // use "-O3"
 	no_prod_options    bool   // `-no-prod-options`, means do not pass any optimization flags to the C compilation, while still allowing the user to use for example `-cflags -Os` to pass custom ones
 	is_repl            bool
@@ -1079,7 +1079,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 		run_code_in_tmp_vfile_and_exit(args, mut res, '-e', 'vsh', res.eval_argument)
 	}
 
-	command_args := args[command_idx + 1..]
+	command_args := args#[command_idx + 1..]
 	if res.is_run || res.is_crun {
 		res.path = command_args[0] or { eprintln_exit('v run: no v files listed') }
 		res.run_args = command_args[1..]


### PR DESCRIPTION
Simply add #  before range in  args#[command_idx + 1..] on Spytheman's suggestion.
This  will prevent panic, but just produce an [], when there are not enough arguments.

It solves the issue : https://github.com/vlang/v/issues/23713