### PR TITLE
cgen: fix array fixed assignment for `@[keep_args_alive]`

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2579,9 +2579,17 @@ fn (mut g Gen) keep_alive_call_pregen(node ast.CallExpr) int {
 		// save all arguments in temp vars (not only pointers) to make sure the
 		// evaluation order is preserved
 		expected_type := node.expected_arg_types[i]
-		typ := g.table.sym(expected_type).cname
-		g.write('${typ} __tmp_arg_${tmp_cnt_save + i} = ')
-		g.ref_or_deref_arg(arg, expected_type, node.language, false)
+		typ_sym := g.table.sym(expected_type)
+		typ := typ_sym.cname
+		if typ_sym.kind != .array_fixed {
+			g.write('${typ} __tmp_arg_${tmp_cnt_save + i} = ')
+			g.ref_or_deref_arg(arg, expected_type, node.language, false)
+		} else {
+			g.write('${typ} __tmp_arg_${tmp_cnt_save + i} = {0};')
+			g.write('memcpy(&__tmp_arg_${tmp_cnt_save + i}, ')
+			g.ref_or_deref_arg(arg, expected_type, node.language, false)
+			g.writeln(', sizeof(${typ}));')
+		}
 		g.writeln(';')
 	}
 	g.empty_line = false

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2585,7 +2585,7 @@ fn (mut g Gen) keep_alive_call_pregen(node ast.CallExpr) int {
 			g.write('${typ} __tmp_arg_${tmp_cnt_save + i} = ')
 			g.ref_or_deref_arg(arg, expected_type, node.language, false)
 		} else {
-			g.write('${typ} __tmp_arg_${tmp_cnt_save + i} = {0};')
+			g.writeln('${typ} __tmp_arg_${tmp_cnt_save + i} = {0};')
 			g.write('memcpy(&__tmp_arg_${tmp_cnt_save + i}, ')
 			g.ref_or_deref_arg(arg, expected_type, node.language, false)
 			g.writeln(', sizeof(${typ}));')

--- a/vlib/v/tests/c_function/code.c
+++ b/vlib/v/tests/c_function/code.c
@@ -1,0 +1,3 @@
+void foo(int arg[1]) {
+
+}

--- a/vlib/v/tests/c_function/code_test.c.v
+++ b/vlib/v/tests/c_function/code_test.c.v
@@ -1,0 +1,10 @@
+module main
+
+#include "@VMODROOT/code.c"
+
+@[keep_args_alive]
+fn C.foo(arg [1]int)
+
+fn test_main() {
+	C.foo([1]!)
+}

--- a/vlib/v/tests/c_function/v.mod
+++ b/vlib/v/tests/c_function/v.mod
@@ -1,0 +1,7 @@
+Module {
+	name: 'c_function'
+	description: ''
+	version: ''
+	license: ''
+	dependencies: []
+}


### PR DESCRIPTION
Fix #23804 (partial fix)

With this patch the code builds on gcc and tcc without `-cstrict`. Because it does not cover the code generating ordering issue. 