### PR TITLE
native: fix unsigned and signed int comparison

### DIFF
--- a/vlib/v/gen/native/stmt.c.v
+++ b/vlib/v/gen/native/stmt.c.v
@@ -328,7 +328,9 @@ fn (mut g Gen) gen_flag_hash_stmt(node ast.HashStmt) {
 	} else if node.main.contains('-L') {
 		g.linker_include_paths << node.main.all_after('-L').trim_space()
 	} else if node.main.contains('-D') || node.main.contains('-I') {
-		g.v_error('`-D` and `-I` flags are not supported with the native backend', node.pos)
+		// g.v_error('`-D` and `-I` flags are not supported with the native backend', node.pos)
+		println(util.formatted_error('warn', '`-D` and `-I` flags are not supported with the native backend',
+			g.current_file.path, node.pos))
 	} else {
 		g.v_error('unknown `#flag` format: `${node.main}`', node.pos)
 	}

--- a/vlib/v/gen/native/tests/vtest_int_cmp.vv
+++ b/vlib/v/gen/native/tests/vtest_int_cmp.vv
@@ -1,0 +1,18 @@
+// taken from vlib/v/tests/int_cmp_test.v
+
+assert i8(3) > i16(-10)
+assert i16(-9) > int(-11)
+assert i64(-12) <= i8(-12)
+assert i64(-43232554) < i8(-126)
+
+assert u8(3) < u16(10)
+assert u16(40000) > u32(200)
+assert u64(18161419857654944321) >= u8(12)
+assert u64(40000) < u16(40001)
+
+assert u8(12) > i8(-12)
+assert i16(-27) < u32(65463356)
+assert u32(8543) > int(-7523)
+assert i64(-89) <= u64(567)
+assert int(-1) != u32(0xffffffff)
+assert !(u64(0xfffffffffffffffe) == i64(-2))


### PR DESCRIPTION
Fix unsigned / signed integer comparison
Add test coming from vlib/v/tests with prefix `vtest_`

I took the test from the cgen backend because it's quite complete for edge cases 