### PR TITLE
sokol: allow for `v -os wasm32_emscripten -o examples/tetris/tetris.html examples/tetris/` (avoid using `-sMODULARIZE`)

### DIFF
--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -41,9 +41,17 @@ $if emscripten ? {
 	#flag -DSOKOL_GLES3
 	#flag -DSOKOL_NO_ENTRY
 	#flag -s ERROR_ON_UNDEFINED_SYMBOLS=0
-	#flag -s ASSERTIONS=1
-	#flag -s MODULARIZE
 	#flag -s USE_WEBGL2
+	$if !prod {
+		#flag -s ASSERTIONS=1
+	}
+	$if prod {
+		#flag -s ASSERTIONS=0
+	}
+	// See https://emscripten.org/docs/tools_reference/settings_reference.html#modularize
+	// Note that it makes it impossible to use `v -os wasm32_emscripten -o file.html program.v` , due to:
+	// https://github.com/emscripten-core/emscripten/issues/7950
+	//	#flag -s MODULARIZE
 }
 
 // OPENGL


### PR DESCRIPTION
See <https://github.com/emscripten-core/emscripten/issues/7950> for the details.