### PR TITLE
fix strconv.atof64(), return error when detect extra char after number

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -636,13 +636,13 @@ pub fn (s string) i64() i64 {
 // f32 returns the value of the string as f32 `'1.0'.f32() == f32(1)`.
 @[inline]
 pub fn (s string) f32() f32 {
-	return f32(strconv.atof64(s) or { 0 })
+	return f32(strconv.atof64(s, allow_extra_chars: true) or { 0 })
 }
 
 // f64 returns the value of the string as f64 `'1.0'.f64() == f64(1)`.
 @[inline]
 pub fn (s string) f64() f64 {
-	return strconv.atof64(s) or { 0 }
+	return strconv.atof64(s, allow_extra_chars: true) or { 0 }
 }
 
 // u8_array returns the value of the hex/bin string as u8 array.

--- a/vlib/strconv/atof.c.v
+++ b/vlib/strconv/atof.c.v
@@ -393,7 +393,7 @@ fn converter(mut pn PrepNumber) u64 {
 
 @[params]
 pub struct AtoF64Param {
-pub mut:
+pub:
 	no_extra_char bool // exact convertion, no extra char after number
 }
 
@@ -403,7 +403,7 @@ pub fn atof64(s string, param AtoF64Param) !f64 {
 		return error('expected a number found an empty string')
 	}
 	mut res := Float64u{}
-	mut res_parsing, mut pn := parser(s)
+	res_parsing, mut pn := parser(s)
 	match res_parsing {
 		.ok {
 			res.u = converter(mut pn)

--- a/vlib/strconv/atof.c.v
+++ b/vlib/strconv/atof.c.v
@@ -391,8 +391,14 @@ fn converter(mut pn PrepNumber) u64 {
 	return result
 }
 
+@[params]
+pub struct AtoF64Param {
+pub:
+	allow_extra_chars bool // allow extra characters after number
+}
+
 // atof64 parses the string `s`, and if possible, converts it into a f64 number
-pub fn atof64(s string) !f64 {
+pub fn atof64(s string, param AtoF64Param) !f64 {
 	if s.len == 0 {
 		return error('expected a number found an empty string')
 	}
@@ -415,7 +421,11 @@ pub fn atof64(s string) !f64 {
 			res.u = double_minus_infinity
 		}
 		.extra_char {
-			return error('extra char after number')
+			if param.allow_extra_chars {
+				res.u = converter(mut pn)
+			} else {
+				return error('extra char after number')
+			}
 		}
 		.invalid_number {
 			return error('not a number')

--- a/vlib/strconv/atof.c.v
+++ b/vlib/strconv/atof.c.v
@@ -391,14 +391,8 @@ fn converter(mut pn PrepNumber) u64 {
 	return result
 }
 
-@[params]
-pub struct AtoF64Param {
-pub:
-	no_extra_char bool // exact convertion, no extra char after number
-}
-
 // atof64 parses the string `s`, and if possible, converts it into a f64 number
-pub fn atof64(s string, param AtoF64Param) !f64 {
+pub fn atof64(s string) !f64 {
 	if s.len == 0 {
 		return error('expected a number found an empty string')
 	}
@@ -421,11 +415,7 @@ pub fn atof64(s string, param AtoF64Param) !f64 {
 			res.u = double_minus_infinity
 		}
 		.extra_char {
-			if param.no_extra_char {
-				return error('extra char after number')
-			} else {
-				res.u = converter(mut pn)
-			}
+			return error('extra char after number')
 		}
 		.invalid_number {
 			return error('not a number')

--- a/vlib/strconv/atof_test.c.v
+++ b/vlib/strconv/atof_test.c.v
@@ -20,6 +20,7 @@ fn test_atof() {
 		0.0,
 		-0.0,
 		31234567890123,
+		123,
 	]
 
 	// strings
@@ -31,6 +32,7 @@ fn test_atof() {
 		'0.0',
 		'-0.0',
 		'31234567890123',
+		'123xyz',
 	]
 
 	// check conversion case 1 string <=> string
@@ -88,5 +90,11 @@ fn test_atof_errors() {
 		assert false // strconv.atof64 should have failed
 	} else {
 		assert err.str() == 'not a number'
+	}
+	if x := strconv.atof64('123xyz', no_extra_char: true) {
+		eprintln('> x: ${x}')
+		assert false // strconv.atof64 should have failed
+	} else {
+		assert err.str() == 'extra char after number'
 	}
 }

--- a/vlib/strconv/atof_test.c.v
+++ b/vlib/strconv/atof_test.c.v
@@ -20,7 +20,9 @@ fn test_atof() {
 		0.0,
 		-0.0,
 		31234567890123,
-		123,
+		0.01,
+		2000,
+		-300,
 	]
 
 	// strings
@@ -32,7 +34,9 @@ fn test_atof() {
 		'0.0',
 		'-0.0',
 		'31234567890123',
-		'123xyz',
+		'1e-2',
+		'+2e+3',
+		'-3.0e+2',
 	]
 
 	// check conversion case 1 string <=> string
@@ -91,7 +95,13 @@ fn test_atof_errors() {
 	} else {
 		assert err.str() == 'not a number'
 	}
-	if x := strconv.atof64('123xyz', no_extra_char: true) {
+	if x := strconv.atof64('uu577.01') {
+		eprintln('> x: ${x}')
+		assert false // strconv.atof64 should have failed
+	} else {
+		assert err.str() == 'not a number'
+	}
+	if x := strconv.atof64('123.33xyz') {
 		eprintln('> x: ${x}')
 		assert false // strconv.atof64 should have failed
 	} else {


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR help detect extra char after number during the `atof64()` conversion.

`strconv.atof64('123xyz')` will get error `extra char after number` now.