### PR TITLE
Add missing license info for reserved_keywords_as_struct_field_test file

### DIFF
--- a/vlib/v/tests/reserved_keywords_as_struct_field_test.v
+++ b/vlib/v/tests/reserved_keywords_as_struct_field_test.v
@@ -1,3 +1,8 @@
+// reserved_keywords_as_struct_field_test.v
+// Copyright (c) 2021 Pasha Radchenko <ep4sh2k@gmail.com>. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
 struct Empty {}
 
 // LLNode is struct which holds data and links


### PR DESCRIPTION
Dear Vlang Community,

I recently discovered that a piece of code I wrote has been used in the V language tests without proper attribution. While I am happy to contribute to the project, I would like to request that my ownership be acknowledged, as required by the MIT License under which my code is distributed.

Details:

I initially encountered a bug in V and reported it in this issue: [#11368](https://github.com/vlang/v/issues/11368).

As part of the issue, I provided an example of my code, which can be found here: [linked_list.v](https://github.com/ep4sh/algoV/blob/master/linked_list.v).

My code was subsequently added to the V language tests in this file: [reserved_keywords_as_struct_field_test.v](https://github.com/vlang/v/blob/master/vlib/v/tests/reserved_keywords_as_struct_field_test.v).

Request:
Since my original repository includes an MIT License file, I kindly ask that you add a mention of my ownership (please check the PR) and a reference to the license in the relevant part of the code or documentation.

Thank you for your attention to this matter. I appreciate your efforts in maintaining the V language and look forward to seeing this resolved.

Best regards,
Pasha.