### PR TITLE
checker: add missing check for IfExpr and MatchExpr with no valid type

### DIFF
--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -576,7 +576,8 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 		}
 	}
 	if node.typ == ast.none_type {
-		c.error('invalid if expression with no value type supplied beyond `none`', node.pos)
+		c.error('invalid if expression, must supply at least one value other than `none`',
+			node.pos)
 	}
 	// if only untyped literals were given default to int/f64
 	node.typ = ast.mktyp(node.typ)

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -575,6 +575,9 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			c.returns = false
 		}
 	}
+	if node.typ == ast.none_type {
+		c.error('invalid if expression with no value type supplied beyond `none`', node.pos)
+	}
 	// if only untyped literals were given default to int/f64
 	node.typ = ast.mktyp(node.typ)
 	if expr_required && !node.has_else {

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -246,7 +246,7 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 		}
 	}
 	if ret_type == ast.none_type {
-		c.error('invalid if expression, must supply at least one value other than `none`',
+		c.error('invalid match expression, must supply at least one value other than `none`',
 			node.pos)
 	}
 	node.return_type = ret_type

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -245,6 +245,10 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 			c.returns = false
 		}
 	}
+	if ret_type == ast.none_type {
+		c.error('invalid if expression, must supply at least one value other than `none`',
+			node.pos)
+	}
 	node.return_type = ret_type
 	cond_var := c.get_base_name(&node.cond)
 	if cond_var != '' {

--- a/vlib/v/checker/tests/if_expr_with_none_only.out
+++ b/vlib/v/checker/tests/if_expr_with_none_only.out
@@ -1,0 +1,10 @@
+vlib/v/checker/tests/if_expr_with_none_only.vv:2:2: warning: unused variable: `a`
+    1 | fn main() {
+    2 |     a := if true { none } else { none }
+      |     ^
+    3 | }
+vlib/v/checker/tests/if_expr_with_none_only.vv:2:7: error: invalid if expression with no value type supplied beyond `none`
+    1 | fn main() {
+    2 |     a := if true { none } else { none }
+      |          ~~
+    3 | }

--- a/vlib/v/checker/tests/if_expr_with_none_only.out
+++ b/vlib/v/checker/tests/if_expr_with_none_only.out
@@ -3,7 +3,7 @@ vlib/v/checker/tests/if_expr_with_none_only.vv:2:2: warning: unused variable: `a
     2 |     a := if true { none } else { none }
       |     ^
     3 | }
-vlib/v/checker/tests/if_expr_with_none_only.vv:2:7: error: invalid if expression with no value type supplied beyond `none`
+vlib/v/checker/tests/if_expr_with_none_only.vv:2:7: error: invalid if expression, must supply at least one value other than `none`
     1 | fn main() {
     2 |     a := if true { none } else { none }
       |          ~~

--- a/vlib/v/checker/tests/if_expr_with_none_only.vv
+++ b/vlib/v/checker/tests/if_expr_with_none_only.vv
@@ -1,0 +1,3 @@
+fn main() {
+	a := if true { none } else { none }
+}

--- a/vlib/v/checker/tests/match_expr_with_none_only.out
+++ b/vlib/v/checker/tests/match_expr_with_none_only.out
@@ -4,7 +4,7 @@ vlib/v/checker/tests/match_expr_with_none_only.vv:2:2: warning: unused variable:
       |     ^
     3 |         1 { none }
     4 |         else { none }
-vlib/v/checker/tests/match_expr_with_none_only.vv:2:7: error: invalid if expression, must supply at least one value other than `none`
+vlib/v/checker/tests/match_expr_with_none_only.vv:2:7: error: invalid match expression, must supply at least one value other than `none`
     1 | fn main() {
     2 |     a := match 1 {
       |          ~~~~~~~~~

--- a/vlib/v/checker/tests/match_expr_with_none_only.out
+++ b/vlib/v/checker/tests/match_expr_with_none_only.out
@@ -1,12 +1,12 @@
 vlib/v/checker/tests/match_expr_with_none_only.vv:2:2: warning: unused variable: `a`
     1 | fn main() {
-    2 |     a := match 1 { 
+    2 |     a := match 1 {
       |     ^
-    3 |         1 {none } 
+    3 |         1 { none }
     4 |         else { none }
 vlib/v/checker/tests/match_expr_with_none_only.vv:2:7: error: invalid if expression, must supply at least one value other than `none`
     1 | fn main() {
-    2 |     a := match 1 { 
-      |          ~~~~~~~~~~
-    3 |         1 {none } 
+    2 |     a := match 1 {
+      |          ~~~~~~~~~
+    3 |         1 { none }
     4 |         else { none }

--- a/vlib/v/checker/tests/match_expr_with_none_only.out
+++ b/vlib/v/checker/tests/match_expr_with_none_only.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/match_expr_with_none_only.vv:2:2: warning: unused variable: `a`
+    1 | fn main() {
+    2 |     a := match 1 { 
+      |     ^
+    3 |         1 {none } 
+    4 |         else { none }
+vlib/v/checker/tests/match_expr_with_none_only.vv:2:7: error: invalid if expression, must supply at least one value other than `none`
+    1 | fn main() {
+    2 |     a := match 1 { 
+      |          ~~~~~~~~~~
+    3 |         1 {none } 
+    4 |         else { none }

--- a/vlib/v/checker/tests/match_expr_with_none_only.vv
+++ b/vlib/v/checker/tests/match_expr_with_none_only.vv
@@ -1,0 +1,6 @@
+fn main() {
+	a := match 1 {
+		1 { none }
+		else { none }
+	}
+}


### PR DESCRIPTION
Fix current crash when using:

```v
fn main() {
	a := if true { none } else { none }
}
```