### PR TITLE
veb: fix "error parsing request: io.Eof" error when a request body is expected, but the data is not ready yet

### DIFF
--- a/vlib/veb/tests/veb_test_server.v
+++ b/vlib/veb/tests/veb_test_server.v
@@ -50,7 +50,12 @@ fn main() {
 		}
 	}
 	eprintln('>> webserver: pid: ${os.getpid()}, started on http://localhost:${app.port}/ , with maximum runtime of ${app.timeout} milliseconds.')
-	veb.run_at[ServerApp, ServerContext](mut app, host: 'localhost', port: http_port, family: .ip)!
+	veb.run_at[ServerApp, ServerContext](mut app,
+		host:               'localhost'
+		port:               http_port
+		family:             .ip
+		timeout_in_seconds: 2
+	)!
 }
 
 // pub fn (mut app ServerApp) init_server() {

--- a/vlib/veb/veb.v
+++ b/vlib/veb/veb.v
@@ -407,7 +407,9 @@ fn handle_read[A, X](mut pv picoev.Picoev, mut params RequestParams, fd int) {
 			}
 
 			if err is io.Eof {
-				// eprintln('[veb] error parsing request: ${err}')
+				// we expect more data to be send, but an Eof error occured, meaning
+				// that there is no more data to be read from the socket.
+				// And at this point we expect that there is data to be read for the body.
 				fast_send_resp(mut conn, http.new_response(
 					status: .bad_request
 					body:   'Mismatch of body length and Content-Length header'

--- a/vlib/veb/veb.v
+++ b/vlib/veb/veb.v
@@ -400,11 +400,12 @@ fn handle_read[A, X](mut pv picoev.Picoev, mut params RequestParams, fd int) {
 
 		n := reader.read(mut buf) or {
 			if reader.total_read > 0 {
-				eprintln('got it!')
 				// the headers were parsed in this cycle, but the body has not been
 				// sent yet. No need to error
 				return
 			}
+
+			eprintln('[veb] error reading request body: ${err}')
 
 			if err is io.Eof {
 				// we expect more data to be send, but an Eof error occured, meaning


### PR DESCRIPTION
Possible fix for #22464

Currently, if a client sends request with the Content-Length > 0, veb expects some data of the body to be ready after the headers are parsed in the same picoev callback, else it shows an `Eof` error.

It is possible that a client sends the headers first and the body has not been received yet. In this case veb should wait for the connection to provide more data, but it errors. I believe this is what's causing the randomness in the error message.

This pr changes the behaviour to wait for the body data, if the headers are parsed in the same piceov callback (callback that the connection has data available).