### PR TITLE
cgen: fix codegen for nested option fixed array

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6610,6 +6610,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 											base)};')
 									}
 								}
+								g.type_definitions.writeln('typedef ${fixed_elem_name} ${styp} [${len}];')
 							} else if !(elem_sym.info is ast.ArrayFixed && elem_sym.info.is_fn_ret) {
 								g.type_definitions.writeln('typedef ${fixed_elem_name} ${styp} [${len}];')
 							}

--- a/vlib/v/tests/options/option_nested_fixed_array_test.v
+++ b/vlib/v/tests/options/option_nested_fixed_array_test.v
@@ -1,0 +1,35 @@
+struct Test {
+	board [2][2]?Piece
+}
+
+struct Piece {
+	white bool
+}
+
+fn test_main() {
+	t := Test{
+		board: [[?Piece{
+			white: false
+		}, ?Piece{
+			white: false
+		}]!, [?Piece{
+			white: true
+		}, ?Piece{
+			white: true
+		}]!]!
+	}
+	assert '${t.board[1][1]}' == 'Option(Piece{
+    white: true
+})'
+	assert t.str() == 'Test{
+    board: [[Option(Piece{
+    white: false
+}), Option(Piece{
+    white: false
+})], [Option(Piece{
+    white: true
+}), Option(Piece{
+    white: true
+})]]
+}'
+}


### PR DESCRIPTION
Fix #23708