### PR TITLE
checker: add missing check for generic fntype type names

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -287,8 +287,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				param.typ = c.eval_array_fixed_sizes(mut size_expr, 0, arg_typ_sym.info.elem_type)
 				mut v := node.scope.find_var(param.name) or { continue }
 				v.typ = param.typ
-			}
-			if arg_typ_sym.info is ast.Struct {
+			} else if arg_typ_sym.info is ast.Struct {
 				if !param.typ.is_ptr() && arg_typ_sym.info.is_heap { // set auto_heap to promote value parameter
 					mut v := node.scope.find_var(param.name) or { continue }
 					v.is_auto_heap = true
@@ -315,6 +314,12 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 					&& arg_typ_sym.info.concrete_types.len == 0 {
 					pure_sym_name := arg_typ_sym.embed_name()
 					c.error('generic sumtype `${pure_sym_name}` in fn declaration must specify the generic type names, e.g. ${pure_sym_name}[T]',
+						param.type_pos)
+				}
+			} else if arg_typ_sym.info is ast.FnType {
+				if arg_typ_sym.info.func.generic_names.len > 0 && !param.typ.has_flag(.generic) {
+					pure_sym_name := arg_typ_sym.embed_name()
+					c.error('generic function `${pure_sym_name}` in fn declaration must specify the generic type names, e.g. ${pure_sym_name}[T]',
 						param.type_pos)
 				}
 			}

--- a/vlib/v/checker/tests/generic_fntype_err.out
+++ b/vlib/v/checker/tests/generic_fntype_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/generic_fntype_err.vv:19:15: error: cannot use `fn (int, int) int` as `fn (T, T) int` in argument 2 to `sort`
+   17 | fn main() {
+   18 |     mut a := [123, 553, 223, 126, 883, 257]
+   19 |     x := sort(a, my_cmp)
+      |                  ~~~~~~
+   20 |     println(x)
+   21 | }
+vlib/v/checker/tests/generic_fntype_err.vv:3:29: error: generic function `FnSort` in fn declaration must specify the generic type names, e.g. FnSort[T]
+    1 | type FnSort[T] = fn (const_a T, const_b T) int
+    2 | 
+    3 | fn sort[T](arr []T, sort_cb FnSort) []T {
+      |                             ~~~~~~
+    4 |     return arr
+    5 | }

--- a/vlib/v/checker/tests/generic_fntype_err.vv
+++ b/vlib/v/checker/tests/generic_fntype_err.vv
@@ -1,0 +1,21 @@
+type FnSort[T] = fn (const_a T, const_b T) int
+
+fn sort[T](arr []T, sort_cb FnSort) []T {
+	return arr
+}
+
+fn my_cmp(a int, b int) int {
+	if a == b {
+		return 0
+	}
+	if a < b {
+		return 1
+	}
+	return -1
+}
+
+fn main() {
+	mut a := [123, 553, 223, 126, 883, 257]
+	x := sort(a, my_cmp)
+	println(x)
+}


### PR DESCRIPTION
Fix #23453