### PR TITLE
vrepl: fix empty line input slowly

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -423,16 +423,13 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 		}
 		oline := r.get_one_line(prompt) or { break }
 		line := oline.trim_space()
-		if line == '' && oline.ends_with('\n') {
+		if line == '' {
 			continue
 		}
 		if line.len <= -1 || line == 'exit' {
 			break
 		}
 		r.line = line
-		if r.line == '\n' {
-			continue
-		}
 		if r.line == 'clear' {
 			term.erase_clear()
 			continue


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #23856

Because `readline.read_line(prompt)` return a line without the ending `\n`, so remove the checking for `ends_with('\n')`.
This make vrepl response quickly to empty line input (just press `enter` key).