### PR TITLE
clipboard: add missing documentation for clipboard methods

### DIFF
--- a/vlib/clipboard/x11/clipboard.c.v
+++ b/vlib/clipboard/x11/clipboard.c.v
@@ -203,10 +203,12 @@ fn new_x11_clipboard(selection AtomType) &Clipboard {
 	return cb
 }
 
+// check_availability returns `true` if the clipboard is available for use.
 pub fn (cb &Clipboard) check_availability() bool {
 	return cb.display != C.NULL
 }
 
+// free releases the clipboard resources.
 pub fn (mut cb Clipboard) free() {
 	C.XDestroyWindow(cb.display, cb.window)
 	cb.window = Window(0)
@@ -214,6 +216,7 @@ pub fn (mut cb Clipboard) free() {
 	// XCloseDisplay(cb.display)
 }
 
+// clear clears the clipboard (sets it to an empty string).
 pub fn (mut cb Clipboard) clear() {
 	cb.mutex.lock()
 	C.XSetSelectionOwner(cb.display, cb.selection, Window(0), C.CurrentTime)
@@ -223,6 +226,7 @@ pub fn (mut cb Clipboard) clear() {
 	cb.mutex.unlock()
 }
 
+// has_ownership returns `true` if the `Clipboard` has the content ownership.
 pub fn (cb &Clipboard) has_ownership() bool {
 	return cb.is_owner
 }
@@ -248,6 +252,7 @@ pub fn (mut cb Clipboard) set_text(text string) bool {
 	return cb.is_owner
 }
 
+// get_text returns the current entry as a `string` from the clipboard.
 pub fn (mut cb Clipboard) get_text() string {
 	if cb.window == Window(0) {
 		return ''


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This adds the missing docs to the `Clipboard` class in the `vlib/clipboard/x11/clipboard.c.v` file. 

* Added a new method `check_availability` to determine if the clipboard is available for use.
* Added a new method `free` to release the clipboard resources.
* Added a new method `clear` to clear the clipboard by setting it to an empty string.
* Added a new method `has_ownership` to check if the `Clipboard` has content ownership.
* Added a new method `get_text` to retrieve the current entry from the clipboard as a string.