### PR TITLE
wasm: add missing documentation for the wasm methods

### DIFF
--- a/vlib/wasm/tests/common.v
+++ b/vlib/wasm/tests/common.v
@@ -24,6 +24,7 @@ fn find_wasm_validate() !string {
 	return error('could not find wasm-validate executable in thirdparty/ as well, try first `v run cmd/tools/install_wabt.vsh`')
 }
 
+// validate validates the given wasm code using `wasm-validate` executable.
 pub fn validate(code []u8) ! {
 	println('validating using: ${wasm_validate_exe}')
 	outfile := os.join_path(os.temp_dir(), 'code_${pid}.wasm')


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This pull request includes a small change to the `vlib/wasm/tests/common.v` file. The change adds a docs for the `validate` function to describe its purpose. 

* [`vlib/wasm/tests/common.v`](diffhunk://#diff-65d40d79d17c11d903f206277c81d9649311979f7859ed45bd51bfd1c7692985R27): Added a docs to the `validate` function to indicate that it validates the given wasm code using the `wasm-validate` executable.