### PR TITLE
time: add documentation for time-related functions and ISO 8601 parsing

### DIFF
--- a/vlib/time/parse.js.v
+++ b/vlib/time/parse.js.v
@@ -19,6 +19,11 @@ pub fn parse(s string) Time {
 	return res
 }
 
+// parse_iso8601 parses the ISO 8601 time format yyyy-MM-ddTHH:mm:ss.dddddd+dd:dd as local time.
+// The fraction part is difference in milli seconds, and the last part is offset from UTC time.
+// Both can be +/- HH:mm .
+// See https://en.wikipedia.org/wiki/ISO_8601 .
+// Remarks: not all of ISO 8601 is supported; checks and support for leapseconds should be added.
 pub fn parse_iso8601(s string) !Time {
 	return parse(s)
 }

--- a/vlib/time/time.js.v
+++ b/vlib/time/time.js.v
@@ -1,5 +1,6 @@
 module time
 
+// now returns the current local time.
 pub fn now() Time {
 	mut res := Time{}
 	#let date = new Date()
@@ -15,6 +16,7 @@ pub fn now() Time {
 	return res
 }
 
+// utc returns the current UTC time.
 pub fn utc() Time {
 	mut res := Time{}
 	#let date = new Date()
@@ -61,6 +63,8 @@ fn time_with_unix(t Time) Time {
 	return res
 }
 
+// ticks returns the number of milliseconds since the UNIX epoch.
+// // On Windows ticks returns the number of milliseconds elapsed since system start.
 pub fn ticks() i64 {
 	t := i64(0)
 	#t.val = BigInt(new Date().getTime())

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -84,6 +84,7 @@ pub enum FormatDelimiter {
 	no_delimiter
 }
 
+// new returns a time struct with the calculated Unix time.
 pub fn Time.new(t Time) Time {
 	return time_with_unix(t)
 }

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -84,7 +84,7 @@ pub enum FormatDelimiter {
 	no_delimiter
 }
 
-// new returns a time struct with the calculated Unix time.
+// Time.new static method returns a time struct with the calculated Unix time.
 pub fn Time.new(t Time) Time {
 	return time_with_unix(t)
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This pull request includes several documentation improvements to the `vlib/time` module.

Documentation improvements:

* [`vlib/time/parse.js.v`](diffhunk://#diff-595d96f92385bda52b73dbaa323bb0cfd96e3265ad7b70ada08db75870da7846R22-R26): Added comments to describe the `parse_iso8601` function, explaining its purpose and limitations.
* [`vlib/time/time.js.v`](diffhunk://#diff-a822823433dd7b48150789001d5694674619ac665e7e37348079c16c91cf4b5aR3): Added comments to describe the `now`, `utc`, and `ticks` functions, explaining their return values and behavior. [[1]](diffhunk://#diff-a822823433dd7b48150789001d5694674619ac665e7e37348079c16c91cf4b5aR3) [[2]](diffhunk://#diff-a822823433dd7b48150789001d5694674619ac665e7e37348079c16c91cf4b5aR19) [[3]](diffhunk://#diff-a822823433dd7b48150789001d5694674619ac665e7e37348079c16c91cf4b5aR66-R67)
* [`vlib/time/time.v`](diffhunk://#diff-31c344f2cfe6fecdafedef24cc42ca595e29556e07d4efc67c5ab8115e199c88R87): Added a comment to describe the `Time.new` function, explaining its purpose.