### PR TITLE
sokol, audio: link against `aaudio` on Android

### DIFF
--- a/vlib/sokol/audio/audio.c.v
+++ b/vlib/sokol/audio/audio.c.v
@@ -19,6 +19,7 @@ $if linux {
 #flag windows -lole32
 #flag freebsd -L/usr/local/lib
 #flag freebsd -lasound
+#flag android -laaudio
 
 // callback function for `stream_cb` in [[C.saudio_desc](#C.saudio_desc)] when calling [audio.setup()](#setup)
 //


### PR DESCRIPTION
This fixes running the Breakout game in #23861 on Android