### PR TITLE
strings.textscanner: add rune mode support; add next_line() , read_until(), substr() funcs

### DIFF
--- a/examples/mini_calculator_recursive_descent.v
+++ b/examples/mini_calculator_recursive_descent.v
@@ -77,7 +77,7 @@ fn (mut p Parser) number() !f64 {
 		}
 		break
 	}
-	return strconv.atof64(p.input[start..p.pos]) or { error('Invalid number') }
+	return strconv.atof64(p.input_bytes[start..p.pos].bytestr()) or { error('Invalid number') }
 }
 
 println('Enter expressions to calculate, e.g. `2 * (5-1)` or `exit` to quit.')

--- a/examples/mini_calculator_recursive_descent.v
+++ b/examples/mini_calculator_recursive_descent.v
@@ -77,7 +77,7 @@ fn (mut p Parser) number() !f64 {
 		}
 		break
 	}
-	return strconv.atof64(p.input_bytes[start..p.pos].bytestr()) or { error('Invalid number') }
+	return strconv.atof64(p.substr(start, p.pos)) or { error('Invalid number') }
 }
 
 println('Enter expressions to calculate, e.g. `2 * (5-1)` or `exit` to quit.')

--- a/examples/mini_calculator_recursive_descent.v
+++ b/examples/mini_calculator_recursive_descent.v
@@ -77,7 +77,7 @@ fn (mut p Parser) number() !f64 {
 		}
 		break
 	}
-	return strconv.atof64(p.substr(start, p.pos)) or { error('Invalid number') }
+	return strconv.atof64(p.input[start..p.pos]) or { error('Invalid number') }
 }
 
 println('Enter expressions to calculate, e.g. `2 * (5-1)` or `exit` to quit.')

--- a/vlib/strings/textscanner/textscanner.v
+++ b/vlib/strings/textscanner/textscanner.v
@@ -132,14 +132,15 @@ pub fn (ss &TextScanner) peek_u8() u8 {
 // ts.peek_n(1) == ts.peek() .
 @[direct_array_access; inline]
 pub fn (ss &TextScanner) peek_n(n int) int {
-	if ss.pos + n < ss.ilen {
-		if ss.config.force_rune_mode {
-			return int(ss.input_runes[ss.pos + n])
-		} else {
-			return ss.input_bytes[ss.pos + n]
-		}
+	new_pos := ss.pos + n
+	if new_pos < 0 || new_pos >= ss.ilen {
+		return -1
 	}
-	return -1
+	if ss.config.force_rune_mode {
+		return int(ss.input_runes[ss.pos + n])
+	} else {
+		return ss.input_bytes[ss.pos + n]
+	}
 }
 
 // peek_n_u8 returns the character code from the input text, at position + `n`,
@@ -149,14 +150,15 @@ pub fn (ss &TextScanner) peek_n(n int) int {
 // legitimately contain bytes with value `0`.
 @[direct_array_access; inline]
 pub fn (ss &TextScanner) peek_n_u8(n int) u8 {
-	if ss.pos + n < ss.ilen {
-		if ss.config.force_rune_mode {
-			return u8(ss.input_runes[ss.pos + n])
-		} else {
-			return ss.input_bytes[ss.pos + n]
-		}
+	new_pos := ss.pos + n
+	if new_pos < 0 || new_pos >= ss.ilen {
+		return 0
 	}
-	return 0
+	if ss.config.force_rune_mode {
+		return u8(ss.input_runes[ss.pos + n])
+	} else {
+		return ss.input_bytes[ss.pos + n]
+	}
 }
 
 // back goes back one character from the current scanner position.

--- a/vlib/strings/textscanner/textscanner.v
+++ b/vlib/strings/textscanner/textscanner.v
@@ -42,10 +42,9 @@ pub fn new(input string, config TextScannerConfig) TextScanner {
 @[unsafe]
 pub fn (mut ss TextScanner) free() {
 	unsafe {
-		if ss.input_runes.len > 0 {
+		if ss.config.force_rune_mode {
 			ss.input_runes.free()
-		}
-		if ss.input_bytes.len > 0 {
+		} else {
 			ss.input_bytes.free()
 		}
 	}

--- a/vlib/strings/textscanner/textscanner.v
+++ b/vlib/strings/textscanner/textscanner.v
@@ -359,3 +359,15 @@ pub fn (mut ss TextScanner) read_until(delimiters string) !string {
 		return ss.input_bytes[start..].bytestr()
 	}
 }
+
+// substr return a sub string of input string from start to end.
+pub fn (mut ss TextScanner) substr(start int, end int) string {
+	if start < 0 || start > ss.ilen || end < 0 || end > ss.ilen || start >= end {
+		return ''
+	}
+	if ss.config.force_rune_mode {
+		return ss.input_runes[start..end].string()
+	} else {
+		return ss.input_bytes[start..end].bytestr()
+	}
+}

--- a/vlib/strings/textscanner/textscanner.v
+++ b/vlib/strings/textscanner/textscanner.v
@@ -295,7 +295,7 @@ pub fn (mut ss TextScanner) next_line() (string, bool) {
 		if ss.config.force_rune_mode {
 			return ss.input_runes[start..].string(), false
 		} else {
-			return unsafe { tos(&ss.input_bytes[start], ss.ilen - start) }, false
+			return ss.input_bytes[start..].bytestr(), false
 		}
 	}
 	if ss.pos > ss.ilen {
@@ -304,7 +304,7 @@ pub fn (mut ss TextScanner) next_line() (string, bool) {
 	if ss.config.force_rune_mode {
 		return ss.input_runes[start..end].string(), true
 	} else {
-		return unsafe { tos(&ss.input_bytes[start], end - start) }, true
+		return ss.input_bytes[start..end].bytestr(), true
 	}
 }
 
@@ -351,11 +351,11 @@ pub fn (mut ss TextScanner) read_until(delimiters string) !string {
 			if r in delimiters_bytes {
 				end := current_pos
 				ss.pos = end + 1
-				return unsafe { tos(&ss.input_bytes[start], end - start) }
+				return ss.input_bytes[start..end].bytestr()
 			}
 			current_pos += 1
 		}
 		ss.pos = ss.ilen
-		return unsafe { tos(&ss.input_bytes[start], ss.ilen - start) }
+		return ss.input_bytes[start..].bytestr()
 	}
 }

--- a/vlib/strings/textscanner/textscanner_test.v
+++ b/vlib/strings/textscanner/textscanner_test.v
@@ -64,6 +64,11 @@ fn test_skip_n() {
 	assert s.peek() == `a`
 	s.skip_n(4)
 	assert s.peek() == -1
+
+	s.reset()
+	assert s.peek() == `a`
+	s.skip_n(-3)
+	assert s.peek() == `a`
 }
 
 fn test_peek() {
@@ -213,4 +218,53 @@ fn test_peek_n_u8() {
 	assert s.peek_n_u8(2) == `c`
 	assert s.peek_n_u8(3) == 0
 	assert s.peek_n_u8(4) == 0
+}
+
+fn test_next_line() {
+	mut s := textscanner.new('abc\r\n123\n\n8')
+	line1, end1 := s.next_line()
+	assert line1 == 'abc'
+	assert end1 == true
+
+	line2, end2 := s.next_line()
+	assert line2 == '123'
+	assert end2 == true
+
+	line3, end3 := s.next_line()
+	assert line3 == ''
+	assert end3 == true
+
+	line4, end4 := s.next_line()
+	assert line4 == '8'
+	assert end4 == false
+
+	line5, end5 := s.next_line()
+	assert line5 == ''
+	assert end5 == false
+}
+
+fn test_read_until() {
+	mut s := textscanner.new('abc\r\n12|3#')
+	t1 := s.read_until([`|`]) or { panic(err) }
+	assert t1 == 'abc\r\n12'
+
+	t2 := s.read_until([`#`]) or { panic(err) }
+	assert t2 == '3'
+	t3 := s.read_until([`#`]) or {
+		assert err.msg() == 'already at EOF'
+		'not exist'
+	}
+	assert t3 == 'not exist'
+
+	mut ss := textscanner.new('abc\r\n12|3#')
+	tt1 := ss.read_until([`|`, `#`]) or { panic(err) }
+	assert tt1 == 'abc\r\n12'
+
+	tt2 := ss.read_until([`|`, `#`]) or { panic(err) }
+	assert tt2 == '3'
+	tt3 := ss.read_until([`|`, `#`]) or {
+		assert err.msg() == 'already at EOF'
+		'not exist'
+	}
+	assert tt3 == 'not exist'
 }

--- a/vlib/strings/textscanner/textscanner_test.v
+++ b/vlib/strings/textscanner/textscanner_test.v
@@ -30,7 +30,7 @@ fn test_remaining_rune() {
 	assert s.remaining() == 3
 }
 
-fn xtest_next() {
+fn test_next() {
 	mut s := textscanner.new('abc')
 	assert s.next() == `a`
 	assert s.next() == `b`
@@ -540,4 +540,20 @@ fn test_read_until_rune() {
 		'已经到结尾了'
 	}
 	assert tt4 == '已经到结尾了'
+}
+
+fn test_substr() {
+	mut s := textscanner.new('abc\r\n12|3#')
+	assert s.substr(0, 4) == 'abc\r'
+	assert s.substr(6, 8) == '2|'
+	assert s.substr(-1, 2) == ''
+	assert s.substr(2, 500) == ''
+}
+
+fn test_substr_rune() {
+	mut s := textscanner.new('v语言♥\r\n大家好|♥3#', force_rune_mode: true)
+	assert s.substr(0, 4) == 'v语言♥'
+	assert s.substr(6, 8) == '大家'
+	assert s.substr(-1, 2) == ''
+	assert s.substr(2, 500) == ''
 }

--- a/vlib/strings/textscanner/textscanner_test.v
+++ b/vlib/strings/textscanner/textscanner_test.v
@@ -15,11 +15,36 @@ fn test_remaining() {
 	assert s.remaining() == 3
 }
 
-fn test_next() {
+fn test_remaining_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	assert s.remaining() == 3
+	s.next()
+	s.next()
+	assert s.remaining() == 1
+	s.next()
+	assert s.remaining() == 0
+	s.next()
+	s.next()
+	assert s.remaining() == 0
+	s.reset()
+	assert s.remaining() == 3
+}
+
+fn xtest_next() {
 	mut s := textscanner.new('abc')
 	assert s.next() == `a`
 	assert s.next() == `b`
 	assert s.next() == `c`
+	assert s.next() == -1
+	assert s.next() == -1
+	assert s.next() == -1
+}
+
+fn test_next_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	assert s.next() == `v`
+	assert s.next() == `语`
+	assert s.next() == `言`
 	assert s.next() == -1
 	assert s.next() == -1
 	assert s.next() == -1
@@ -38,6 +63,23 @@ fn test_skip() {
 	assert s.peek() == `b`
 	s.skip()
 	assert s.peek() == `c`
+	s.skip()
+	assert s.peek() == -1
+}
+
+fn test_skip_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	assert s.next() == `v`
+	s.skip()
+	assert s.next() == `言`
+	assert s.next() == -1
+
+	s.reset()
+	assert s.peek() == `v`
+	s.skip()
+	assert s.peek() == `语`
+	s.skip()
+	assert s.peek() == `言`
 	s.skip()
 	assert s.peek() == -1
 }
@@ -71,6 +113,35 @@ fn test_skip_n() {
 	assert s.peek() == `a`
 }
 
+fn test_skip_n_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	s.skip_n(2)
+	assert s.next() == `言`
+	assert s.next() == -1
+
+	s.reset()
+	assert s.peek() == `v`
+	s.skip_n(2)
+	assert s.peek() == `言`
+	s.skip_n(2)
+	assert s.peek() == -1
+
+	s.reset()
+	assert s.peek() == `v`
+	s.skip_n(3)
+	assert s.peek() == -1
+
+	s.reset()
+	assert s.peek() == `v`
+	s.skip_n(4)
+	assert s.peek() == -1
+
+	s.reset()
+	assert s.peek() == `v`
+	s.skip_n(-3)
+	assert s.peek() == `v`
+}
+
 fn test_peek() {
 	mut s := textscanner.new('abc')
 	assert s.peek() == `a`
@@ -80,6 +151,18 @@ fn test_peek() {
 	assert s.next() == `a`
 	assert s.next() == `b`
 	assert s.next() == `c`
+	assert s.next() == -1
+}
+
+fn test_peek_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	assert s.peek() == `v`
+	assert s.peek() == `v`
+	assert s.peek() == `v`
+
+	assert s.next() == `v`
+	assert s.next() == `语`
+	assert s.next() == `言`
 	assert s.next() == -1
 }
 
@@ -97,6 +180,20 @@ fn test_peek_n() {
 	assert s.next() == -1
 }
 
+fn test_peek_n_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	assert s.peek_n(0) == `v`
+	assert s.peek_n(1) == `语`
+	assert s.peek_n(2) == `言`
+	assert s.peek_n(3) == -1
+	assert s.peek_n(4) == -1
+
+	assert s.next() == `v`
+	assert s.next() == `语`
+	assert s.next() == `言`
+	assert s.next() == -1
+}
+
 fn test_back() {
 	mut s := textscanner.new('abc')
 	assert s.next() == `a`
@@ -109,6 +206,18 @@ fn test_back() {
 	assert s.next() == -1
 }
 
+fn test_back_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	assert s.next() == `v`
+	s.back()
+	assert s.next() == `v`
+	assert s.next() == `语`
+	s.back()
+	assert s.next() == `语`
+	assert s.next() == `言`
+	assert s.next() == -1
+}
+
 fn test_back_n() {
 	mut s := textscanner.new('abc')
 	assert s.next() == `a`
@@ -118,6 +227,17 @@ fn test_back_n() {
 	assert s.next() == `c`
 	s.back_n(2)
 	assert s.next() == `b`
+}
+
+fn test_back_n_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	assert s.next() == `v`
+	s.back_n(10)
+	assert s.next() == `v`
+	assert s.next() == `语`
+	assert s.next() == `言`
+	s.back_n(2)
+	assert s.next() == `语`
 }
 
 fn test_peek_back() {
@@ -140,12 +260,42 @@ fn test_peek_back() {
 	assert s.peek_back() == `b`
 }
 
+fn test_peek_back_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	assert s.next() == `v`
+	assert s.next() == `语`
+	// check that calling .peek_back() multiple times
+	// does not change the state:
+	assert s.peek_back() == `v`
+	assert s.peek_back() == `v`
+	assert s.peek_back() == `v`
+	// advance, then peek_back again:
+	assert s.next() == `言`
+	assert s.peek_back() == `语`
+	// peeking before the start:
+	s.reset()
+	assert s.peek_back() == -1
+	// peeking right at the end:
+	s.goto_end()
+	assert s.peek_back() == `语`
+}
+
 fn test_peek_back_n() {
 	mut s := textscanner.new('abc')
 	s.goto_end()
 	assert s.peek_back_n(0) == `c`
 	assert s.peek_back_n(1) == `b`
 	assert s.peek_back_n(2) == `a`
+	assert s.peek_back_n(3) == -1
+	assert s.peek_back_n(4) == -1
+}
+
+fn test_peek_back_n_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	s.goto_end()
+	assert s.peek_back_n(0) == `言`
+	assert s.peek_back_n(1) == `语`
+	assert s.peek_back_n(2) == `v`
 	assert s.peek_back_n(3) == -1
 	assert s.peek_back_n(4) == -1
 }
@@ -158,6 +308,16 @@ fn test_reset() {
 	assert s.next() == -1
 	s.reset()
 	assert s.next() == `a`
+}
+
+fn test_reset_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	assert s.next() == `v`
+	s.next()
+	s.next()
+	assert s.next() == -1
+	s.reset()
+	assert s.next() == `v`
 }
 
 fn test_current() {
@@ -183,10 +343,39 @@ fn test_current() {
 	assert s.current() == `a`
 }
 
+fn test_current_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	assert s.current() == -1
+	assert s.next() == `v`
+	assert s.current() == `v`
+	assert s.current() == `v`
+	assert s.peek_back() == -1
+	assert s.next() == `语`
+	assert s.current() == `语`
+	assert s.current() == `语`
+	assert s.peek_back() == `v`
+	assert s.next() == `言`
+	assert s.current() == `言`
+	assert s.next() == -1
+	assert s.current() == `言`
+	assert s.next() == -1
+	assert s.current() == `言`
+	s.reset()
+	assert s.current() == -1
+	assert s.next() == `v`
+	assert s.current() == `v`
+}
+
 fn test_goto_end() {
 	mut s := textscanner.new('abc')
 	s.goto_end()
 	assert s.current() == `c`
+}
+
+fn test_goto_end_rune() {
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	s.goto_end()
+	assert s.current() == `言`
 }
 
 fn test_skip_whitespace() {
@@ -203,6 +392,20 @@ fn test_skip_whitespace() {
 	assert s.next() == `z`
 }
 
+fn test_skip_whitespace_rune() {
+	mut s := textscanner.new('v语言   ♥  \n   大家好', force_rune_mode: true)
+	assert s.current() == -1
+	assert s.next() == `v`
+	assert s.next() == `语`
+	assert s.next() == `言`
+	s.skip_whitespace()
+	assert s.next() == `♥`
+	s.skip_whitespace()
+	assert s.next() == `大`
+	assert s.next() == `家`
+	assert s.next() == `好`
+}
+
 fn test_peek_u8() {
 	mut s := textscanner.new('abc')
 	assert s.peek_u8() == `a`
@@ -211,11 +414,30 @@ fn test_peek_u8() {
 	assert s.peek_u8() == `b`
 }
 
+fn test_peek_u8_rune() {
+	// maybe for rune mode, we should not use `peek_u8()`
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	assert s.peek_u8() == u8(`v`)
+	assert !s.peek_u8().is_digit()
+	assert s.next() == u8(`v`)
+	assert s.peek_u8() == u8(`语`)
+}
+
 fn test_peek_n_u8() {
 	mut s := textscanner.new('abc')
 	assert s.peek_n_u8(0) == `a`
 	assert s.peek_n_u8(1) == `b`
 	assert s.peek_n_u8(2) == `c`
+	assert s.peek_n_u8(3) == 0
+	assert s.peek_n_u8(4) == 0
+}
+
+fn test_peek_n_u8_rune() {
+	// maybe for rune mode, we should not use `peek_n_u8()`
+	mut s := textscanner.new('v语言', force_rune_mode: true)
+	assert s.peek_n_u8(0) == u8(`v`)
+	assert s.peek_n_u8(1) == u8(`语`)
+	assert s.peek_n_u8(2) == u8(`言`)
 	assert s.peek_n_u8(3) == 0
 	assert s.peek_n_u8(4) == 0
 }
@@ -243,28 +465,79 @@ fn test_next_line() {
 	assert end5 == false
 }
 
+fn test_next_line_rune() {
+	mut s := textscanner.new('v语言\r\n大家好\n\n♥', force_rune_mode: true)
+	line1, end1 := s.next_line()
+	assert line1 == 'v语言'
+	assert end1 == true
+
+	line2, end2 := s.next_line()
+	assert line2 == '大家好'
+	assert end2 == true
+
+	line3, end3 := s.next_line()
+	assert line3 == ''
+	assert end3 == true
+
+	line4, end4 := s.next_line()
+	assert line4 == '♥'
+	assert end4 == false
+
+	line5, end5 := s.next_line()
+	assert line5 == ''
+	assert end5 == false
+}
+
 fn test_read_until() {
 	mut s := textscanner.new('abc\r\n12|3#')
-	t1 := s.read_until([`|`]) or { panic(err) }
+	t1 := s.read_until('|') or { panic(err) }
 	assert t1 == 'abc\r\n12'
 
-	t2 := s.read_until([`#`]) or { panic(err) }
+	t2 := s.read_until('#') or { panic(err) }
 	assert t2 == '3'
-	t3 := s.read_until([`#`]) or {
+	t3 := s.read_until('#') or {
 		assert err.msg() == 'already at EOF'
 		'not exist'
 	}
 	assert t3 == 'not exist'
 
 	mut ss := textscanner.new('abc\r\n12|3#')
-	tt1 := ss.read_until([`|`, `#`]) or { panic(err) }
+	tt1 := ss.read_until('|#') or { panic(err) }
 	assert tt1 == 'abc\r\n12'
 
-	tt2 := ss.read_until([`|`, `#`]) or { panic(err) }
+	tt2 := ss.read_until('|#') or { panic(err) }
 	assert tt2 == '3'
-	tt3 := ss.read_until([`|`, `#`]) or {
+	tt3 := ss.read_until('|#') or {
 		assert err.msg() == 'already at EOF'
 		'not exist'
 	}
 	assert tt3 == 'not exist'
+}
+
+fn test_read_until_rune() {
+	mut s := textscanner.new('v语言♥\r\n大家好|♥3#', force_rune_mode: true)
+	t1 := s.read_until('♥') or { panic(err) }
+	assert t1 == 'v语言'
+
+	t2 := s.read_until('#') or { panic(err) }
+	assert t2 == '\r\n大家好|♥3'
+	t3 := s.read_until('#') or {
+		assert err.msg() == 'already at EOF'
+		'已经到结尾了'
+	}
+	assert t3 == '已经到结尾了'
+
+	mut ss := textscanner.new('v语言♥\r\n大家好|♥3#', force_rune_mode: true)
+	tt1 := ss.read_until('♥#') or { panic(err) }
+	assert tt1 == 'v语言'
+
+	tt2 := ss.read_until('♥#') or { panic(err) }
+	assert tt2 == '\r\n大家好|'
+	tt3 := ss.read_until('♥#') or { panic(err) }
+	assert tt3 == '3'
+	tt4 := ss.read_until('♥#') or {
+		assert err.msg() == 'already at EOF'
+		'已经到结尾了'
+	}
+	assert tt4 == '已经到结尾了'
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Introduce `force_rune_mode` params to the `new(input string, config TextScannerConfig)` and this will help scan runes instead of bytes of a `input` string.

```v

@[params]
pub struct TextScannerConfig {
pub mut:
	force_rune_mode bool
}

// new returns a stack allocated instance of TextScanner.
pub fn new(input string, config TextScannerConfig) TextScanner

// next_line advances the scanner’s position to the start of
// the next line, and return the line.
// Returns true if successful, or false if the end of the input
// is reached.

pub fn (mut ss TextScanner) next_line() (string, bool) 

// read_until reads characters from the current scanning position
// until a delimiter (from the provided string `delimiters`) is encountered.
// The returned string includes all characters from the starting
// position up to (but ​not​ including) the first encountered
// delimiter. The scanner's position is advanced to the character
// immediately after the delimiter (or to the end of the input if
// no delimiter is found).

pub fn (mut ss TextScanner) read_until(delimiters string) !string

// substr return a sub string of input string from start to end.
pub fn (mut ss TextScanner) substr(start int, end int) string 
```