### PR TITLE
crypto.ecdsa: the last bits of migration steps

### DIFF
--- a/vlib/crypto/ecdsa/ecdsa.c.v
+++ b/vlib/crypto/ecdsa/ecdsa.c.v
@@ -44,6 +44,8 @@ fn C.EVP_PKEY_bits(pkey &C.EVP_PKEY) int
 fn C.EVP_PKEY_size(key &C.EVP_PKEY) int
 fn C.EVP_PKEY_eq(a &C.EVP_PKEY, b &C.EVP_PKEY) int
 
+fn C.EVP_PKEY_get1_encoded_public_key(pkey &C.EVP_PKEY, ppub &&u8) int
+fn C.EVP_PKEY_get_bn_param(pkey &C.EVP_PKEY, key_name &u8, bn &&C.BIGNUM) int
 fn C.EVP_PKEY_fromdata_init(ctx &C.EVP_PKEY_CTX) int
 fn C.EVP_PKEY_fromdata(ctx &C.EVP_PKEY_CTX, ppkey &&C.EVP_PKEY, selection int, params &C.OSSL_PARAM) int
 
@@ -143,6 +145,7 @@ fn C.EC_GROUP_new_by_curve_name(nid int) &C.EC_GROUP
 @[typedef]
 struct C.BIGNUM {}
 
+fn C.BN_new() &C.BIGNUM
 fn C.BN_num_bits(a &C.BIGNUM) int
 fn C.BN_bn2bin(a &C.BIGNUM, to &u8) int
 fn C.BN_bn2binpad(a &C.BIGNUM, to &u8, tolen int) int


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This follow-up PR from the last commited [pr](https://github.com/vlang/v/pull/23876). In this PR, its done by migrating the last bits required to be changed, ie `.bytes()` method on the `PrivateKey` and `PublicKey`.
Its was done by using high level function. All info's of `EVP_PKEY` opaque was already availables on both of them by previous migrations. This series contains the bits forms:

- The changes on `.bytes()` on the both of `PrivateKey` and `PublicKey`
- Adds required definitions
- Some fixs of private and public key loader

After this PR, we can start out to cleanup some deprecated code. Should be this cleanup phase done in gradually step ?