### PR TITLE
live: add ext(.dll/.so) to output name of -live

### DIFF
--- a/vlib/v/live/executable/reloader.c.v
+++ b/vlib/v/live/executable/reloader.c.v
@@ -78,8 +78,8 @@ fn compile_and_reload_shared_lib(mut r live.LiveReloadInfo) !bool {
 }
 
 fn compile_lib(mut r live.LiveReloadInfo) ?string {
-	new_lib_path, new_lib_path_with_extension := current_shared_library_path(mut r)
-	cmd := '${os.quoted_path(r.vexe)} ${r.vopts} -o ${os.quoted_path(new_lib_path)} ${os.quoted_path(r.original)}'
+	_, new_lib_path_with_extension := current_shared_library_path(mut r)
+	cmd := '${os.quoted_path(r.vexe)} ${r.vopts} -o ${os.quoted_path(new_lib_path_with_extension)} ${os.quoted_path(r.original)}'
 	elog(r, '>       compilation cmd: ${cmd}')
 	cwatch := time.new_stopwatch()
 	recompilation_result := os.execute(cmd)


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #6936

Now, `-live` work both under Windows and Linux:

```
D:\v\v\v>v -live run examples\hot_reload\message.v
OK reloads:    1 | Total reloads:    1 | Hello! Modify this message while the program is running. app: 48e0fd0 | app.x:      0 | app.counter:      0
OK reloads:    1 | Total reloads:    1 | Hello! Modify this message while the program is running. app: 48e0fd0 | app.x:      0 | app.counter:      1
OK reloads:    1 | Total reloads:    1 | Hello! Modify this message while the program is running. app: 48e0fd0 | app.x:      0 | app.counter:      2
```

```
D:\v\v\v>v -live run examples\hot_reload\message.v -cc msvc
OK reloads:    1 | Total reloads:    1 | Hello! Modify this message while the program is running. app: 1550fd0 | app.x:      0 | app.counter:      0
OK reloads:    1 | Total reloads:    1 | Hello! Modify this message while the program is running. app: 1550fd0 | app.x:      0 | app.counter:      1
OK reloads:    1 | Total reloads:    1 | Hello! Modify this message while the program is running. app: 1550fd0 | app.x:      0 | app.counter:      2
OK reloads:    1 | Total reloads:    1 | Hello! Modify this message while the program is running. app: 1550fd0 | app.x:      0 | app.counter:      3
```

```
$ v -live run examples/hot_reload/message.v
OK reloads:    1 | Total reloads:    1 | Hello! Modify this message while the program is running. app: 755911d62fe0 | app.x:      0 | app.counter:      0
OK reloads:    1 | Total reloads:    1 | Hello! Modify this message while the program is running. app: 755911d62fe0 | app.x:      0 | app.counter:      1
OK reloads:    1 | Total reloads:    1 | Hello! Modify this message while the program is running. app: 755911d62fe0 | app.x:      0 | app.counter:      2
```