### PR TITLE
docs, cmd: fix broken docs source links regression in `vdoc`

### DIFF
--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -314,7 +314,7 @@ fn (mut vd VDoc) generate_docs_from_file() {
 			vd.manifest = manifest
 		}
 	} else if cfg.is_vlib {
-		assert false, 'vdoc: manifest does not exists for vlib'
+		assert false, 'vdoc: manifest does not exist for vlib'
 	}
 	if cfg.include_readme || cfg.is_vlib {
 		mut readme_name := 'README'

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -303,7 +303,11 @@ fn (mut vd VDoc) generate_docs_from_file() {
 	} else {
 		os.dir(cfg.input_path)
 	}
-	manifest_path := os.join_path(dir_path, 'v.mod')
+	manifest_path := if cfg.is_vlib {
+		os.join_path(vroot, 'v.mod')
+	} else {
+		os.join_path(dir_path, 'v.mod')
+	}
 	if os.exists(manifest_path) {
 		vd.vprintln('Reading v.mod info from ${manifest_path}')
 		if manifest := vmod.from_file(manifest_path) {

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -313,6 +313,8 @@ fn (mut vd VDoc) generate_docs_from_file() {
 		if manifest := vmod.from_file(manifest_path) {
 			vd.manifest = manifest
 		}
+	} else if cfg.is_vlib {
+		assert false, 'vdoc: manifest does not exists for vlib'
 	}
 	if cfg.include_readme || cfg.is_vlib {
 		mut readme_name := 'README'


### PR DESCRIPTION
Locally running `v doc -m -f html -o ./tmpdocs vlib/ && firefox tmpdocs/builtin.html` now results in source links showed:
![image](https://github.com/user-attachments/assets/98bc2e48-3b1a-4678-9c24-4ef34dbc8cc6)

I'm unsure about how to add a regression test :thinking: 
Maybe we could do an `assert` somewhere if `cfg.is_vlib == true`  :shrug: 