### PR TITLE
builder,cgen: fix msvc build filename, remove temp files

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -726,10 +726,17 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 
 	if g.pref.is_shared && g.pref.os == .windows && g.export_funcs.len > 0 {
 		// generate a .def for export function names, avoid function name mangle
-		def_name := g.pref.out_name[0..g.pref.out_name.len - 4]
-		dll_name := g.pref.out_name.all_after_last('\\')
-		file_content := 'LIBRARY ${dll_name}.dll\n\nEXPORTS\n' + g.export_funcs.join('\n')
-		os.write_file('${def_name}.def', file_content) or { panic(err) }
+		mut def_name := ''
+		mut dll_name := ''
+		if g.pref.out_name.ends_with('.dll') {
+			def_name = g.pref.out_name[0..g.pref.out_name.len - 4] + '.def'
+			dll_name = g.pref.out_name.all_after_last('\\')
+		} else {
+			def_name = g.pref.out_name + '.def'
+			dll_name = g.pref.out_name.all_after_last('\\') + '.dll'
+		}
+		file_content := 'LIBRARY ${dll_name}\n\nEXPORTS\n' + g.export_funcs.join('\n')
+		os.write_file('${def_name}', file_content) or { panic(err) }
 	}
 
 	// End of out_0.c


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

1. Partially fix issue #23888 . If user specify a output name other than `.exe` or `.dll`, the output name will be appended with `.exe` or `.dll`;
2. Remove `msvc` generate temp files.