### PR TITLE
veb: handle sendfile errors

### DIFF
--- a/vlib/veb/veb.v
+++ b/vlib/veb/veb.v
@@ -254,7 +254,11 @@ fn handle_write_file(mut pv picoev.Picoev, mut params RequestParams, fd int) {
 
 	$if linux || freebsd {
 		bytes_written := sendfile(fd, params.file_responses[fd].file.fd, bytes_to_write)
-		params.file_responses[fd].pos += bytes_written
+		if bytes_written < 0 {
+			params.file_responses[fd].pos += bytes_to_write
+		} else {
+			params.file_responses[fd].pos += bytes_written
+		}
 	} $else {
 		if bytes_to_write > max_write {
 			bytes_to_write = max_write


### PR DESCRIPTION
fix [the issue in the discord server help channel](https://discord.com/channels/592103645835821068/592294828432424960/1348248565646102569) where cancelling a download prompted by `return ctx.file("filename")` occasionally crashed the program due to a SIGPIPE signal being caught (no github issue for this exists as far as i'm aware)

no test comes with this PR due to the issue being seemingly random(?) and most likely impossible to automate. if needed, create a simple server in veb that serves a file, then repeat the download request, cancelling it each time until the program crashes (which shouldn't happen with this fix)