### PR TITLE
crypto.ecda: small bits improvement of the`PrivateKey.new` method

### DIFF
--- a/vlib/crypto/ecdsa/ecdsa.v
+++ b/vlib/crypto/ecdsa/ecdsa.v
@@ -166,21 +166,6 @@ mut:
 // PrivateKey.new creates a new key pair. By default, it would create a prime256v1 based key.
 // Dont forget to call `.free()` after finish with your key.
 pub fn PrivateKey.new(opt CurveOptions) !PrivateKey {
-	// Default to prime256v1 based key
-	mut group_nid := nid_prime256v1
-	match opt.nid {
-		.prime256v1 {}
-		.secp384r1 {
-			group_nid = nid_secp384r1
-		}
-		.secp521r1 {
-			group_nid = nid_secp521r1
-		}
-		.secp256k1 {
-			group_nid = nid_secp256k1
-		}
-	}
-	// New high level keypair generator
 	evpkey := C.EVP_PKEY_new()
 	pctx := C.EVP_PKEY_CTX_new_id(nid_evp_pkey_ec, 0)
 	if pctx == 0 {
@@ -195,7 +180,7 @@ pub fn PrivateKey.new(opt CurveOptions) !PrivateKey {
 		return error('EVP_PKEY_keygen_init failed')
 	}
 	// set the group (curve)
-	cn := C.EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx, group_nid)
+	cn := C.EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx, int(opt.nid))
 	if cn <= 0 {
 		C.EVP_PKEY_free(evpkey)
 		C.EVP_PKEY_CTX_free(pctx)


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

After [this PR](https://github.com/vlang/v/pull/23876), The values of `Nid` enum was changed directly into underlying C counterparts, so, technically, the info's about nid of the group passed in options was already availables to the key generator routine.

This PR changes the `PrivateKey.new` method to utilize this information directly in the C call and removes out the `match` branch block to get the nid of the group in the preliminary call.

On my simple benchmark on my test machine, before the patch `PrivateKey.new` gets averages time in 37-40  µs (variesly) in 10.000 iterations, and after the patch, its gets down into 31-34  µs (variesly) with the same number of iterations. Not too bad improvement in small changes

NB:
the benchmark code

```v
import time
import crypto.ecdsa

fn main() {
	iterations := 10000

	println('Benchmarking PrivateKey.new (before patch)...')
	mut total_gen_time := i64(0)
	for _ in 0 .. iterations {
		sw := time.new_stopwatch()
		_ := ecdsa.PrivateKey.new() or { panic(err) }
		elapsed := sw.elapsed().microseconds()
		total_gen_time += elapsed
	}
	avg_gen_time := total_gen_time / iterations
	println('Average PrivateKey.new (before patch) time: ${avg_gen_time} µs')
}
```