### PR TITLE
checker: add missing `any` type validation on assignment

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -329,6 +329,11 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		}
 		node.left_types << left_type
 
+		if right is ast.StructInit {
+			right_sym := c.table.sym(right_type)
+			c.check_any_type(right_type, right_sym, right.pos())
+		}
+
 		if left is ast.ParExpr && is_decl {
 			c.error('parentheses are not supported on the left side of `:=`', left.pos())
 		}

--- a/vlib/v/checker/tests/assign_any_err.out
+++ b/vlib/v/checker/tests/assign_any_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/assign_any_err.vv:3:22: error: cannot use type `any` here
+    1 | fn g[T](x T) {
+    2 |         for _ in 0 .. 10 {
+    3 |                 _ := any{}
+      |                      ~~~~~
+    4 |         }
+    5 | }

--- a/vlib/v/checker/tests/assign_any_err.out
+++ b/vlib/v/checker/tests/assign_any_err.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/assign_any_err.vv:3:22: error: cannot use type `any` here
+vlib/v/checker/tests/assign_any_err.vv:3:8: error: cannot use type `any` here
     1 | fn g[T](x T) {
-    2 |         for _ in 0 .. 10 {
-    3 |                 _ := any{}
-      |                      ~~~~~
-    4 |         }
+    2 |     for _ in 0 .. 10 {
+    3 |         _ := any{}
+      |              ~~~~~
+    4 |     }
     5 | }

--- a/vlib/v/checker/tests/assign_any_err.vv
+++ b/vlib/v/checker/tests/assign_any_err.vv
@@ -1,0 +1,9 @@
+fn g[T](x T) {
+	for _ in 0 .. 10 {
+		_ := any{}
+	}
+}
+
+fn main() {
+	g[int](1)
+}


### PR DESCRIPTION
Fix #23905