### PR TITLE
cgen: fix codegen for array of anon struct 

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -852,11 +852,13 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 		.none {
 			// var := struct { name: "" }
 			mut init_fields := []ast.StructField{}
-			for init_field in node.init_fields {
+			for mut init_field in node.init_fields {
 				mut expr := unsafe { init_field }
+				init_field.typ = c.expr(mut expr.expr)
+				init_field.expected_type = init_field.typ
 				init_fields << ast.StructField{
 					name:   init_field.name
-					typ:    c.expr(mut expr.expr)
+					typ:    init_field.typ
 					is_mut: c.anon_struct_should_be_mut
 				}
 			}

--- a/vlib/v/tests/structs/anon_struct_array_test.v
+++ b/vlib/v/tests/structs/anon_struct_array_test.v
@@ -1,0 +1,16 @@
+module main
+
+fn test_main() {
+	tsts := [struct {
+		name: 'Vlang'
+		age:  20
+	}]
+	for tst in tsts {
+		assert '${tst}' == "struct {
+    name: 'Vlang'
+    age: 20
+}"
+		assert tst.age == 20
+		assert tst.name == 'Vlang'
+	}
+}


### PR DESCRIPTION
Fix #23896