### PR TITLE
docs: combine IDE plugins into one list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,12 +226,14 @@ make
 
 ## Editor/IDE Plugins
 
-- [VS Code](https://marketplace.visualstudio.com/items?itemName=VOSCA.vscode-v-analyzer)
-- [Vim](https://github.com/vlang/awesome-v#vim)
-- [Emacs](https://github.com/vlang/awesome-v#emacs)
-- [Sublime Text 3](https://github.com/vlang/awesome-v#sublime-text-3)
 - [Atom](https://github.com/vlang/awesome-v#atom)
+- [Emacs](https://github.com/vlang/awesome-v#emacs)
 - [JetBrains](https://plugins.jetbrains.com/plugin/20287-vlang/docs/syntax-highlighting.html)
+- [Sublime Text 3](https://github.com/vlang/awesome-v#sublime-text-3)
+- [Vim](https://github.com/vlang/awesome-v#vim)
+- [VS Code](https://marketplace.visualstudio.com/items?itemName=VOSCA.vscode-v-analyzer)
+- [zed](https://github.com/lv37/zed-v)
+
 
 To bring IDE functions for the V programming languages to your editor, check out
 [v-analyzer](https://github.com/vlang/v-analyzer). It provides language server capabilities.

--- a/README.md
+++ b/README.md
@@ -226,20 +226,15 @@ make
 
 ## Editor/IDE Plugins
 
+- [VS Code](https://marketplace.visualstudio.com/items?itemName=VOSCA.vscode-v-analyzer)
+- [Vim](https://github.com/vlang/awesome-v#vim)
+- [Emacs](https://github.com/vlang/awesome-v#emacs)
+- [Sublime Text 3](https://github.com/vlang/awesome-v#sublime-text-3)
+- [Atom](https://github.com/vlang/awesome-v#atom)
+- [JetBrains](https://plugins.jetbrains.com/plugin/20287-vlang/docs/syntax-highlighting.html)
+
 To bring IDE functions for the V programming languages to your editor, check out
-[v-analyzer](https://github.com/vlang/v-analyzer). It provides a
-[VS Code extension](https://marketplace.visualstudio.com/items?itemName=VOSCA.vscode-v-analyzer)
-and language server capabilities for other editors.
-
-The plugin for JetBrains IDEs (IntelliJ, CLion, GoLand, etc.) also offers a great development
-experience with V. You can find all features in [its documentation](https://plugins.jetbrains.com/plugin/20287-vlang/docs/syntax-highlighting.html).
-
-Other Plugins:
-
-- [Vim plugins](https://github.com/vlang/awesome-v#vim)
-- [Emacs plugins](https://github.com/vlang/awesome-v#emacs)
-- [Sublime Text 3 plugins](https://github.com/vlang/awesome-v#sublime-text-3)
-- [Atom plugins](https://github.com/vlang/awesome-v#atom)
+[v-analyzer](https://github.com/vlang/v-analyzer). It provides language server capabilities.
 
 ## Testing and running the examples
 


### PR DESCRIPTION
I didn't see an IDE plugin I needed because the links were split between the list and the paragraph. So I put them all in the list.

> As always, you are welcome to close this or make any edits on top -- no need to ask me.