### PR TITLE
checker: add missing check for casting generic type to literal values

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3583,6 +3583,12 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		c.error('cannot cast type `${ft}` to `${tt}`', node.pos)
 	}
 
+	// T(0) where T is array or map
+	if node.typ.has_flag(.generic) && to_sym.kind in [.array, .map, .array_fixed]
+		&& node.expr.is_literal() {
+		c.error('cannot cast literal value to ${to_sym.name} type', node.pos)
+	}
+
 	if to_sym.kind == .enum && !(c.inside_unsafe || c.file.is_translated) && from_sym.is_int() {
 		c.error('casting numbers to enums, should be done inside `unsafe{}` blocks', node.pos)
 	}

--- a/vlib/v/checker/tests/cast_generic_err.out
+++ b/vlib/v/checker/tests/cast_generic_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/cast_generic_err.vv:2:7: error: cannot cast literal value to [2]u8 type
+    1 | fn decode[T]() {
+    2 |     _ := T(0)
+      |          ~~~~
+    3 | }
+    4 |

--- a/vlib/v/checker/tests/cast_generic_err.vv
+++ b/vlib/v/checker/tests/cast_generic_err.vv
@@ -1,0 +1,9 @@
+fn decode[T]() {
+	_ := T(0)
+}
+
+fn main() {
+	decode[[2]u8]()
+	decode[[]u8]()
+	decode[map[int]u8]()
+}


### PR DESCRIPTION
Fix bug mentioned by @kbkpbot 