### PR TITLE
crypto.ecdsa: improves performances of `.public_key` call 

### DIFF
--- a/vlib/crypto/ecdsa/ecdsa.c.v
+++ b/vlib/crypto/ecdsa/ecdsa.c.v
@@ -44,6 +44,8 @@ fn C.EVP_PKEY_size(key &C.EVP_PKEY) int
 fn C.EVP_PKEY_eq(a &C.EVP_PKEY, b &C.EVP_PKEY) int
 fn C.EVP_PKEY_check(ctx &C.EVP_PKEY_CTX) int
 fn C.EVP_PKEY_public_check(ctx &C.EVP_PKEY_CTX) int
+fn C.EVP_PKEY_dup(key &C.EVP_PKEY) &C.EVP_PKEY
+fn C.EVP_PKEY_set_bn_param(pkey &C.EVP_PKEY, key_name &char, bn &C.BIGNUM) int
 
 fn C.EVP_PKEY_get_group_name(pkey &C.EVP_PKEY, gname &u8, gname_sz u32, gname_len &usize) int
 fn C.EVP_PKEY_get1_encoded_public_key(pkey &C.EVP_PKEY, ppub &&u8) int
@@ -101,6 +103,7 @@ fn C.BIO_s_mem() &C.BIO_METHOD
 fn C.BIO_write(b &C.BIO, buf &u8, length int) int
 fn C.PEM_read_bio_PrivateKey(bp &C.BIO, x &&C.EVP_PKEY, cb int, u &voidptr) &C.EVP_PKEY
 fn C.PEM_read_bio_PUBKEY(bp &C.BIO, x &&C.EVP_PKEY, cb int, u &voidptr) &C.EVP_PKEY
+fn C.PEM_write_bio_PUBKEY(bp &C.BIO, x &C.EVP_PKEY) int
 fn C.d2i_PUBKEY(k &&C.EVP_PKEY, pp &&u8, length u32) &C.EVP_PKEY
 fn C.i2d_PUBKEY_bio(bo &C.BIO, pkey &C.EVP_PKEY) int
 fn C.d2i_PUBKEY_bio(bo &C.BIO, key &&C.EVP_PKEY) &C.EVP_PKEY

--- a/vlib/crypto/ecdsa/ecdsa.v
+++ b/vlib/crypto/ecdsa/ecdsa.v
@@ -262,14 +262,13 @@ pub fn (pv PrivateKey) seed() ![]u8 {
 
 // public_key gets the PublicKey from private key.
 pub fn (pv PrivateKey) public_key() !PublicKey {
-	bo := C.BIO_new(C.BIO_s_mem())
-	n := C.i2d_PUBKEY_bio(bo, pv.evpkey)
-	assert n != 0
-	// stores this bio as another key
-	pbkey := C.d2i_PUBKEY_bio(bo, 0)
-
-	C.BIO_free_all(bo)
-
+	// Using duplicate key and removes (clears out) priv key
+	pbkey := C.EVP_PKEY_dup(pv.evpkey)
+	bn := C.BN_new()
+	n := C.EVP_PKEY_set_bn_param(pbkey, c'priv', bn)
+	assert n == 1
+	// cleansup
+	C.BN_free(bn)
 	return PublicKey{
 		evpkey: pbkey
 	}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Even after this [PR](https://github.com/vlang/v/pull/23899), `PrivateKey.new` has been improved, overall of `generate_key` routine still has an overhead. In my test, its overhead happens on `.public_key` call. The overhead is about $\pm$ 310  µs (variesly).
After some digs to search the alternative approachs, i test 3 of them, for optimizing `public_key` part

- With the current approach, serializing using `d2i` based function
- Serializing and unserializing with `pem` based approach
- With duplicating key and clears out private info from the key.

With these approach, this is my test number

```bash
Average time using public_key_using_d2i (current)       : 288 µs
Average time using public_key_using_pem                 : 435 µs
Average time using public_key_using_dup_n_set_null      : 5 µs
```

The last approach looks like promising to be implemented and replacing the current approach. The benchmark test
show up the result

```bash
Benchmarking PrivateKey.public_key() (after patch)...
Average PrivateKey.public_key() (after patch) time: 5 µs
```

Its not a bad result, from $\pm$ 310  µs  goes down into  $\pm$  5 µs
This PR contains the third approach to replace the current of `public_key` method and the test still pass. Third approach was done by duplicating current private key and stripout private bits by replacing it with new empty bignum.

Thx