### PR TITLE
vast: add --check flag

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -100,9 +100,9 @@ fn (ctx Context) skip_empty(child &Node) bool {
 
 fn (ctx Context) write_file_or_print(file string) {
 	if ctx.is_print {
-		println(ctx.json(file))
+		println(json(file))
 	} else {
-		println('${time.now()}: AST written to: ' + ctx.json_file(file))
+		println('${time.now()}: AST written to: ' + json_file(file))
 	}
 }
 
@@ -148,8 +148,8 @@ fn check_file(file string) {
 }
 
 // generate json file with the same file name
-fn (ctx Context) json_file(file string) string {
-	ast_json := ctx.json(file)
+fn json_file(file string) string {
+	ast_json := json(file)
 	// support .v and .vsh file
 	file_name := file[0..(file.len - os.file_ext(file).len)]
 	json_file := file_name + '.json'
@@ -158,7 +158,7 @@ fn (ctx Context) json_file(file string) string {
 }
 
 // generate json string
-fn (ctx Context) json(file string) string {
+fn json(file string) string {
 	// use as permissive preferences as possible, so that `v ast`
 	// can print the AST of arbitrary V files, even .vsh or ones
 	// that require globals:
@@ -175,7 +175,7 @@ fn (ctx Context) json(file string) string {
 	// parse file with comment
 	mut ast_file := parser.parse_file(file, mut t.table, .parse_comments, t.pref)
 
-	if !ctx.is_skip_checker {
+	if !context.is_skip_checker {
 		mut the_checker := checker.new_checker(t.table, pref_)
 		the_checker.check(mut ast_file)
 	}

--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -18,7 +18,7 @@ mut:
 	is_print         bool
 	is_terse         bool
 	is_skip_defaults bool
-	is_skip_checker  bool
+	check            bool
 	hide_names       map[string]bool
 }
 
@@ -45,7 +45,7 @@ fn main() {
 	ctx.is_compile = fp.bool('compile', `c`, false, 'watch the .v file for changes, rewrite the .json file, *AND* generate a .c file too on any change')
 	ctx.is_terse = fp.bool('terse', `t`, false, 'terse output, only with tree node names (AST structure), no details')
 	ctx.is_skip_defaults = fp.bool('skip-defaults', `s`, false, 'skip properties that have default values like false, 0, "", etc')
-	ctx.is_skip_checker = fp.bool('skip-checker', `t`, false, 'skip v.checker, as it will modify the AST tree')
+	ctx.check = fp.bool('check', `k`, false, 'run v.checker as well (it may modify the AST)')
 	hfields := fp.string_multi('hide', 0, 'hide the specified fields. You can give several, by separating them with `,`').join(',')
 	for hf in hfields.split(',') {
 		ctx.hide_names[hf] = true
@@ -175,7 +175,7 @@ fn json(file string) string {
 	// parse file with comment
 	mut ast_file := parser.parse_file(file, mut t.table, .parse_comments, t.pref)
 
-	if !context.is_skip_checker {
+	if context.check {
 		mut the_checker := checker.new_checker(t.table, pref_)
 		the_checker.check(mut ast_file)
 	}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

As `v.checker` may modify the AST tree, so introduce a new flag `--check` flag, which default is `false`. If set to `true`, then `vast` will product a checker-modified AST tree.