### PR TITLE
json2/scanner: fix "\\" parsing bug, disallow (ch < 0x20) unescaped control characters

### DIFF
--- a/vlib/x/json2/scanner_test.v
+++ b/vlib/x/json2/scanner_test.v
@@ -46,7 +46,21 @@ fn test_str_invalid_must_be_escape() {
 		}
 		tok := sc.scan()
 		assert tok.kind == .error
-		assert tok.lit.bytestr() == 'character must be escaped with a backslash'
+		assert tok.lit.bytestr() == 'character must be escaped with a backslash, replace with: \\${valid_unicode_escapes[important_escapable_chars.index(ch)]}'
+	}
+}
+
+fn test_str_control_must_be_escape() {
+	for ch := u8(0); ch < 0x20; ch++ {
+		if ch in important_escapable_chars {
+			continue
+		}
+		mut sc := Scanner{
+			text: [u8(`"`), `t`, ch, `"`]
+		}
+		tok := sc.scan()
+		assert tok.kind == .error
+		assert tok.lit.bytestr() == 'character must be escaped with a unicode escape, replace with: \\u${ch:04x}'
 	}
 }
 

--- a/vlib/x/json2/tests/decoder_test.v
+++ b/vlib/x/json2/tests/decoder_test.v
@@ -6,7 +6,7 @@ fn test_raw_decode_string() {
 }
 
 fn test_raw_decode_string_escape() {
-	jstr := json.raw_decode('"\u001b"')!
+	jstr := json.raw_decode('"\\u001b"')!
 	str := jstr.str()
 	assert str.len == 1
 	assert str[0] == 27


### PR DESCRIPTION
- Fix bug where `"\\"` is parsed incorrectly due to closing `` `"` `` requiring no preceding backslash
- Improve error messages for text_scan()
- Make unescaped control characters (ch < 0x20) an error, as per JSON spec.
- Fix decoder_test, '"\u001b"' should be an error, '"\\u001b"' is fine

standalone test:
```v
import x.json2

json2.decode[json2.Any](r'"\\"')!
```
`message: [x.json2] missing double quotes in string closing (0:44)`
from current https://play.vlang.io/

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
