### PR TITLE
crypto.ecdsa: improves internal `sign_digest` routine

### DIFF
--- a/vlib/crypto/ecdsa/ecdsa.v
+++ b/vlib/crypto/ecdsa/ecdsa.v
@@ -364,7 +364,7 @@ fn sign_digest(key &C.EVP_PKEY, digest []u8) ![]u8 {
 	// was called with NULL signature buffer, siglen will tell maximum size of signature.
 	siglen := usize(C.EVP_PKEY_size(key))
 	sig := []u8{len: int(siglen)}
-	
+
 	// calls directly with sign
 	do := C.EVP_PKEY_sign(ctx, sig.data, &siglen, digest.data, digest.len)
 	if do <= 0 {

--- a/vlib/crypto/ecdsa/ecdsa.v
+++ b/vlib/crypto/ecdsa/ecdsa.v
@@ -363,14 +363,12 @@ fn sign_digest(key &C.EVP_PKEY, digest []u8) ![]u8 {
 	// siglen was used to store the size of the signature output. When EVP_PKEY_sign
 	// was called with NULL signature buffer, siglen will tell maximum size of signature.
 	siglen := usize(C.EVP_PKEY_size(key))
-	st := C.EVP_PKEY_sign(ctx, 0, &siglen, digest.data, digest.len)
-	if st <= 0 {
-		C.EVP_PKEY_CTX_free(ctx)
-		return error('Get null buffer length on EVP_PKEY_sign')
-	}
 	sig := []u8{len: int(siglen)}
+	
+	// calls directly with sign
 	do := C.EVP_PKEY_sign(ctx, sig.data, &siglen, digest.data, digest.len)
 	if do <= 0 {
+		unsafe { sig.free() }
 		C.EVP_PKEY_CTX_free(ctx)
 		return error('EVP_PKEY_sign fails to sign message')
 	}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR improves `sign_digest`  internal routine used by `PrivateKey.sign` method. Its done by eleminating one step of `C.EVP_PKEY_sign` calls with null signature buffer to know the length (size) of required buffer. This maximal sizes of the buffer was already known by calling `C.EVP_PKEY_size`, so its not needed to call `C.EVP_PKEY_sign` just to know the size of required buffer and we can allocate the buffer instead and call `C.EVP_PKEY_sign` directly  with this allocated buffer.

In my benchmark test, there are small improvements on this part

```v
Benchmarking PrivateKey.sign() (before patch)...
Average PrivateKey.sign() (before patch) time: 37 µs
```

and after patch

```v
Benchmarking PrivateKey.sign() (after patch)...
Average PrivateKey.sign() (after patch) time: 27 µs
```

Thanks