### PR TITLE
checker,cgen: add `T.key_type`, `typeof(expr).key_type`, `T.value_type`, `typeof(expr).value_type`, `T.element_type`, `typeof(expr).element_type` for getting `Map[K]V` and `[]T` types

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1641,7 +1641,8 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 			else {
 				if node.field_name == 'name' {
 					return ast.string_type
-				} else if node.field_name in ['idx', 'unaliased_typ'] {
+				} else if node.field_name in ['idx', 'unaliased_typ', 'key_type', 'value_type',
+					'element_type'] {
 					return ast.int_type
 				} else if node.field_name == 'indirections' {
 					return ast.int_type

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3971,7 +3971,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 					g.type_name(name_type)
 					return
 				} else if node.field_name in ['idx', 'unaliased_typ'] {
-					// `typeof(expr).idx`, // `typeof(expr).unalised_typ`
+					// `T.idx`, `T.unaliased_typ`, `typeof(expr).idx`, `typeof(expr).unalised_typ`
 					mut name_type := node.name_type
 					if node.expr is ast.TypeOf {
 						name_type = g.type_resolver.typeof_field_type(g.type_resolver.typeof_type(node.expr.expr,
@@ -3980,6 +3980,13 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 					} else {
 						g.write(int(g.unwrap_generic(name_type)).str())
 					}
+					return
+				} else if node.field_name in ['key_type', 'value_type', 'element_type'] {
+					// `T.<field_name>`, `typeof(expr).<field_name>`
+					mut name_type := node.name_type
+					name_type = g.type_resolver.typeof_field_type(g.type_resolver.typeof_type(node.expr,
+						name_type), node.field_name)
+					g.write(int(name_type).str())
 					return
 				} else if node.field_name == 'indirections' {
 					mut name_type := node.name_type

--- a/vlib/v/tests/comptime/comptime_typeof_value_test.v
+++ b/vlib/v/tests/comptime/comptime_typeof_value_test.v
@@ -13,6 +13,6 @@ fn t[T](a T) string {
 }
 
 fn test_main() {
-	assert t(map[u8]string{}) == 'map[u8]string\n11 | u8 | 11 | u8\n21 | string | 21 | string\n105 | int | 105 | int'
+	assert t(map[u8]string{}) == 'map[u8]string\n11 | u8 | 11 | u8\n21 | string | 21 | string\n111 | int | 111 | int'
 	assert t([]rune{}) == '[]rune >> 22 | rune | 22 | rune'
 }

--- a/vlib/v/tests/comptime/comptime_typeof_value_test.v
+++ b/vlib/v/tests/comptime/comptime_typeof_value_test.v
@@ -1,0 +1,18 @@
+fn t[T](a T) string {
+	$if a is $map {
+		mut s := ''
+		s += '${typeof[T]().name}\n'
+		s += '${T.key_type} | ${typeof(T.key_type).name} | ${typeof[T]().key_type} | ${typeof(typeof[T]().key_type).name}\n'
+		s += '${T.value_type} | ${typeof(T.value_type).name} | ${typeof[T]().value_type} | ${typeof(typeof[T]().value_type).name}\n'
+		s += '${T.idx} | ${typeof(T.idx).name} | ${typeof[T]().idx} | ${typeof(typeof[T]().idx).name}'
+		return s
+	} $else $if a is $array {
+		return '${typeof[T]().name} >> ${T.element_type} | ${typeof(T.element_type).name} | ${typeof[T]().element_type} | ${typeof(typeof[T]().element_type).name}'
+	}
+	return ''
+}
+
+fn test_main() {
+	assert t(map[u8]string{}) == 'map[u8]string\n11 | u8 | 11 | u8\n21 | string | 21 | string\n105 | int | 105 | int'
+	assert t([]rune{}) == '[]rune >> 22 | rune | 22 | rune'
+}

--- a/vlib/v/tests/comptime/comptime_typeof_value_test.v
+++ b/vlib/v/tests/comptime/comptime_typeof_value_test.v
@@ -2,17 +2,17 @@ fn t[T](a T) string {
 	$if a is $map {
 		mut s := ''
 		s += '${typeof[T]().name}\n'
-		s += '${T.key_type} | ${typeof(T.key_type).name} | ${typeof[T]().key_type} | ${typeof(typeof[T]().key_type).name}\n'
-		s += '${T.value_type} | ${typeof(T.value_type).name} | ${typeof[T]().value_type} | ${typeof(typeof[T]().value_type).name}\n'
-		s += '${T.idx} | ${typeof(T.idx).name} | ${typeof[T]().idx} | ${typeof(typeof[T]().idx).name}'
+		s += '${T.key_type == typeof[u8]().idx} | ${typeof(T.key_type).name} | ${typeof[T]().key_type == typeof[u8]().idx} | ${typeof(typeof[T]().key_type).name}\n'
+		s += '${T.value_type == typeof[string]().idx} | ${typeof(T.value_type).name} | ${typeof[T]().value_type == typeof[string]().idx} | ${typeof(typeof[T]().value_type).name}\n'
+		s += '${T.idx == typeof[T]().idx} | ${typeof(T.idx).name} | ${typeof(typeof[T]().idx).name}'
 		return s
 	} $else $if a is $array {
-		return '${typeof[T]().name} >> ${T.element_type} | ${typeof(T.element_type).name} | ${typeof[T]().element_type} | ${typeof(typeof[T]().element_type).name}'
+		return '${typeof[T]().name} >> ${T.element_type == typeof[rune]().idx} | ${typeof(T.element_type).name} | ${typeof[T]().element_type == typeof[rune]().idx} | ${typeof(typeof[T]().element_type).name}'
 	}
 	return ''
 }
 
 fn test_main() {
-	assert t(map[u8]string{}) == 'map[u8]string\n11 | u8 | 11 | u8\n21 | string | 21 | string\n111 | int | 111 | int'
-	assert t([]rune{}) == '[]rune >> 22 | rune | 22 | rune'
+	assert t(map[u8]string{}) == 'map[u8]string\ntrue | u8 | true | u8\ntrue | string | true | string\ntrue | int | int'
+	assert t([]rune{}) == '[]rune >> true | rune | true | rune'
 }


### PR DESCRIPTION
Fix #23914 