### PR TITLE
thirdparty: add `thirdparty/build_scripts/` to prepare for prebuilt tcc upgrades

### DIFF
--- a/thirdparty/build_scripts/README.md
+++ b/thirdparty/build_scripts/README.md
@@ -1,0 +1,16 @@
+This folder, contains build scripts used by the CI, to generate prebuilt versions
+(or latest version by default) of:
+A) TCC from https://repo.or.cz/tinycc.git/
+B) libgc from https://github.com/ivmai/bdwgc/
+
+In time, if everything works fine, we can deprecate the older approach, keeping 2 *separate*
+binary repos, tccbin/ and libgcbin/, with just pointers back to the build scripts here.
+
+Note: the previous approach (before 2024/08), used in https://github.com/vlang/tccbin/,
+where that separate repo contained both prebuilt binaries for tcc AND libgc.a,
+AND the separate scripts to generate them, in *separate branches*.
+In contrast, this folder contains *all scripts in the same location, in the same branch*, just
+with different names, thus making editing them all at the same time and in atomic commits,
+that can be reviewed and tested separately in PRs on the CI *much easier*.
+
+WARNING: this is still experimental, and should not be used, except to ease testing on the CI.

--- a/thirdparty/build_scripts/thirdparty-linux-amd64_bdwgc.sh
+++ b/thirdparty/build_scripts/thirdparty-linux-amd64_bdwgc.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -e
+
+if ! test -f vlib/v/compiler_errors_test.v; then
+  echo "this script should be run in V's main repo folder!"
+  exit 1
+fi
+  
+export CURRENT_SCRIPT_PATH=$(realpath "$0")
+
+export CC="${CC:-gcc}"
+export TCC_FOLDER="${TCC_FOLDER:-thirdparty/tcc}"
+export LIBGC_COMMIT="${LIBGC_COMMIT:-master}"
+mkdir -p $TCC_FOLDER/lib/
+
+echo "          CC: $CC"
+echo "  TCC_FOLDER: $TCC_FOLDER"
+echo "LIBGC_COMMIT: $LIBGC_COMMIT"
+echo ===============================================================
+
+rm -rf bdwgc/
+
+pushd .
+git clone https://github.com/ivmai/bdwgc
+cd bdwgc/
+
+git checkout $LIBGC_COMMIT
+export LIBGC_COMMIT_FULL_HASH=$(git rev-parse HEAD)
+
+./autogen.sh
+
+CC=$CC CFLAGS='-Os -mtune=generic -fPIC' LDFLAGS='-Os -fPIC' ./configure \
+	--disable-dependency-tracking \
+	--disable-docs \
+	--enable-handle-fork=yes \
+	--enable-rwlock \
+	--enable-threads=pthreads \
+	--enable-static \
+	--enable-shared=no \
+	--enable-parallel-mark \
+	--enable-single-obj-compilation \
+	--enable-gc-debug \
+	--with-libatomic-ops=yes \
+	--enable-sigrt-signals
+
+make
+
+popd
+
+cp bdwgc/.libs/libgc.a         $TCC_FOLDER/lib/libgc.a
+
+date                         > $TCC_FOLDER/lib/libgc_build_on_date.txt
+echo $LIBGC_COMMIT_FULL_HASH > $TCC_FOLDER/lib/libgc_build_source_hash.txt
+uname -a                     > $TCC_FOLDER/lib/libgc_build_machine_uname.txt
+
+ls -la $TCC_FOLDER/lib/libgc.a
+echo "Done compiling libgc, at commit $LIBGC_COMMIT , full hash: $LIBGC_COMMIT_FULL_HASH . The static library is in $TCC_FOLDER/lib/libgc.a "

--- a/thirdparty/build_scripts/thirdparty-linux-amd64_tcc.sh
+++ b/thirdparty/build_scripts/thirdparty-linux-amd64_tcc.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+## should be run in V's main repo folder!
+
+export CURRENT_SCRIPT_PATH=$(realpath "$0")
+
+export TCC_COMMIT="${TCC_COMMIT:-mob}"
+export TCC_FOLDER="${TCC_FOLDER:-thirdparty/tcc.$TCC_COMMIT}"
+
+echo "TCC_COMMIT: $TCC_COMMIT"
+echo "TCC_FOLDER: $TCC_FOLDER"
+echo ===============================================================
+
+rm -rf tinycc/
+rm -rf thirdparty/tcc.original/
+rsync -a thirdparty/tcc/ thirdparty/tcc.original/
+## rm -rf $TCC_FOLDER
+
+pushd .
+
+git clone git://repo.or.cz/tinycc.git
+
+cd tinycc
+
+git checkout $TCC_COMMIT
+export TCC_COMMIT_FULL_HASH=$(git rev-parse HEAD)
+
+## Note: crt1.o is located in:
+## /usr/lib/x86_64-linux-gnu on Debian/Ubuntu
+## /usr/lib64 on Redhat/CentOS
+## /usr/lib on ArchLinux
+
+./configure \
+            --prefix=$TCC_FOLDER \
+            --bindir=$TCC_FOLDER \
+            --crtprefix=$TCC_FOLDER/lib:/usr/lib/x86_64-linux-gnu:/usr/lib64:/usr/lib:/lib/x86_64-linux-gnu:/lib \
+            --libpaths=$TCC_FOLDER/lib/tcc:$TCC_FOLDER/lib:/usr/lib/x86_64-linux-gnu:/usr/lib64:/usr/lib:/lib/x86_64-linux-gnu:/lib:/usr/local/lib/x86_64-linux-gnu:/usr/local/lib \
+            --cc=gcc-11 \
+            --extra-cflags=-O3 \
+            --config-bcheck=yes \
+            --config-backtrace=yes \
+            --debug
+
+make
+make install
+
+popd
+
+rsync -a --delete tinycc/$TCC_FOLDER/                 $TCC_FOLDER/
+rsync -a          thirdparty/tcc.original/.git/       $TCC_FOLDER/.git/
+rsync -a          thirdparty/tcc.original/lib/libgc*  $TCC_FOLDER/lib/
+rsync -a          thirdparty/tcc.original/lib/build*  $TCC_FOLDER/lib/
+rsync -a          thirdparty/tcc.original/README.md   $TCC_FOLDER/README.md
+rsync -a          $CURRENT_SCRIPT_PATH                $TCC_FOLDER/build.sh
+mv                $TCC_FOLDER/tcc                     $TCC_FOLDER/tcc.exe
+
+date                                                > $TCC_FOLDER/build_on_date.txt
+echo $TCC_COMMIT_FULL_HASH                          > $TCC_FOLDER/build_source_hash.txt
+$TCC_FOLDER/tcc.exe --version                       > $TCC_FOLDER/build_version.txt
+
+## show the builtin search paths for sanity checking:
+$TCC_FOLDER/tcc.exe -v -v
+
+echo "tcc commit: $TCC_COMMIT , full hash: $TCC_COMMIT_FULL_HASH . The tcc executable is ready in $TCC_FOLDER/tcc.exe "

--- a/thirdparty/build_scripts/thirdparty-linux-amd64_tcc.sh
+++ b/thirdparty/build_scripts/thirdparty-linux-amd64_tcc.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 
-## should be run in V's main repo folder!
+set -e
+
+if ! test -f vlib/v/compiler_errors_test.v; then
+  echo "this script should be run in V's main repo folder!"
+  exit 1
+fi
 
 export CURRENT_SCRIPT_PATH=$(realpath "$0")
 
 export TCC_COMMIT="${TCC_COMMIT:-mob}"
 export TCC_FOLDER="${TCC_FOLDER:-thirdparty/tcc.$TCC_COMMIT}"
+export CC="${CC:-gcc}"
 
+echo "        CC: $CC"
 echo "TCC_COMMIT: $TCC_COMMIT"
 echo "TCC_FOLDER: $TCC_FOLDER"
 echo ===============================================================
@@ -35,7 +42,7 @@ export TCC_COMMIT_FULL_HASH=$(git rev-parse HEAD)
             --bindir=$TCC_FOLDER \
             --crtprefix=$TCC_FOLDER/lib:/usr/lib/x86_64-linux-gnu:/usr/lib64:/usr/lib:/lib/x86_64-linux-gnu:/lib \
             --libpaths=$TCC_FOLDER/lib/tcc:$TCC_FOLDER/lib:/usr/lib/x86_64-linux-gnu:/usr/lib64:/usr/lib:/lib/x86_64-linux-gnu:/lib:/usr/local/lib/x86_64-linux-gnu:/usr/local/lib \
-            --cc=gcc-11 \
+            --cc=$CC \
             --extra-cflags=-O3 \
             --config-bcheck=yes \
             --config-backtrace=yes \
@@ -57,6 +64,7 @@ mv                $TCC_FOLDER/tcc                     $TCC_FOLDER/tcc.exe
 date                                                > $TCC_FOLDER/build_on_date.txt
 echo $TCC_COMMIT_FULL_HASH                          > $TCC_FOLDER/build_source_hash.txt
 $TCC_FOLDER/tcc.exe --version                       > $TCC_FOLDER/build_version.txt
+uname -a                                            > $TCC_FOLDER/build_machine_uname.txt
 
 ## show the builtin search paths for sanity checking:
 $TCC_FOLDER/tcc.exe -v -v


### PR DESCRIPTION
- **thirdparty: add thirdparty/build_scripts/ folder, to streamline CI testing of different versions of tcc and bdwgc**
- **add thirdparty/build_scripts/thirdparty-linux-amd64_bdwgc.sh ; make thirdparty-linux-amd64_tcc.sh stricter**