### PR TITLE
cli: account for initial indent on subcommands

### DIFF
--- a/vlib/cli/help.v
+++ b/vlib/cli/help.v
@@ -114,7 +114,7 @@ pub fn (cmd &Command) help_message() string {
 			base_indent := ' '.repeat(base_indent_len)
 			description_indent := ' '.repeat(name_len - command.name.len)
 			help += '${base_indent}${command.name}${description_indent}' +
-				pretty_description(command.description, name_len) + '\n'
+				pretty_description(command.description, base_indent_len + name_len) + '\n'
 		}
 	}
 	return help


### PR DESCRIPTION
We need to account for the initial indent on a subcommand, just like was done for flags.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
