### PR TITLE
strings, builtin: remove `strings.Builder.clear()`, fix `array.clear()` not working in the JS backend

### DIFF
--- a/vlib/builtin/js/array.js.v
+++ b/vlib/builtin/js/array.js.v
@@ -317,7 +317,7 @@ pub fn (mut a array) reverse_in_place() {
 
 pub fn (mut a array) clear() {
 	#a.val.arr.make_copy()
-	#a.val.arr.arr.clear()
+	#a.val.arr.arr.length = 0
 }
 
 // reduce executes a given reducer function on each element of the array,

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -59,11 +59,6 @@ pub fn (mut b Builder) write_runes(runes []rune) {
 	}
 }
 
-// clear clears the buffer contents
-pub fn (mut b Builder) clear() {
-	b = []u8{cap: b.cap}
-}
-
 // write_u8 appends a single `data` byte to the accumulated buffer
 @[inline]
 pub fn (mut b Builder) write_u8(data u8) {
@@ -246,7 +241,7 @@ pub fn (mut b Builder) str() string {
 	b << u8(0)
 	bcopy := unsafe { &u8(memdup_noscan(b.data, b.len)) }
 	s := unsafe { bcopy.vstring_with_len(b.len - 1) }
-	b.trim(0)
+	b.clear()
 	return s
 }
 

--- a/vlib/strings/builder.js.v
+++ b/vlib/strings/builder.js.v
@@ -22,10 +22,6 @@ pub fn (mut b Builder) write_byte(data u8) {
 	b << data
 }
 
-pub fn (mut b Builder) clear() {
-	b = []u8{cap: b.cap}
-}
-
 pub fn (mut b Builder) write_u8(data u8) {
 	b << data
 }
@@ -67,7 +63,7 @@ pub fn (mut b Builder) str() string {
 
 	#for (const c of b.val.arr.arr)
 	#s.str += String.fromCharCode(+c)
-	b.trim(0)
+	b.clear()
 	return s
 }
 


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Currently, `strings.Builder` has a function named `clear()` which clears the content by reallocating the backing array.

However, there is no need to reallocate the array. For example, in `str()` function, the backing array is simply trimmed to zero length.

Also, the array type itself has a `clear()` function which does the same as `trim(0)`. This PR reuses the `clear()` function in the `array` by simply removing the `clear()` function in `strings.Builder` and replacing `trim(0)` with `clear()` which does the same thing.

This PR shouldn't break existing code