### PR TITLE
cgen: fix parallel `cached_type_to_str` access

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -94,7 +94,7 @@ pub mut:
 	builtin_pub_fns   map[string]bool
 	pointer_size      int
 	// cache for type_to_str_using_aliases
-	cached_type_to_str map[u64]string
+	cached_type_to_str shared map[u64]string
 	// counters and maps for anon structs and unions, to avoid name conflicts.
 	anon_struct_names   map[string]int // anon struct name -> struct sym idx
 	anon_struct_counter int

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1417,8 +1417,10 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 	mut res := sym.name
 	mut mt := unsafe { &Table(t) }
 	defer {
-		// Note, that this relies on `res = value return res` if you want to return early!
-		mt.cached_type_to_str[cache_key] = res
+		lock mt.cached_type_to_str {
+			// Note, that this relies on `res = value return res` if you want to return early!
+			mt.cached_type_to_str[cache_key] = res
+		}
 	}
 	// Note, that the duplication of code in some of the match branches here
 	// is VERY deliberate. DO NOT be tempted to use `else {}` instead, because


### PR DESCRIPTION
Fix #23980