### PR TITLE
x.crypto.chacha20: fix issue on consecutive calls of `xor_key_stream`

### DIFF
--- a/vlib/x/crypto/chacha20/chacha_test.v
+++ b/vlib/x/crypto/chacha20/chacha_test.v
@@ -4,6 +4,35 @@ import crypto.cipher
 import rand
 import encoding.hex
 
+fn test_xor_key_stream_consecutive() {
+	// See https://github.com/vlang/v/issues/23977
+	key := [u8(64), 116, 63, 11, 221, 199, 187, 110, 217, 68, 0, 50, 65, 79, 24, 10, 124, 174,
+		66, 2, 172, 153, 237, 145, 244, 41, 131, 84, 247, 42, 73, 131]
+	nonce := [u8(86), 124, 222, 94, 253, 187, 151, 219, 17, 83, 118, 255]
+	encoded_data_one := [u8(201), 199, 66, 226]
+	decoded_data_one := [u8(0), 0, 0, 9]
+	encoded_data_two := [u8(82), 189, 125, 3, 24, 185, 183, 240, 29, 223, 17, 241, 103, 69, 45,
+		101]
+	decoded_data_two := [u8(0), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+	mut c := new_cipher(key, nonce)!
+	mut dst := []u8{len: encoded_data_one.len}
+	c.xor_key_stream(mut dst, encoded_data_one)
+	assert dst == decoded_data_one
+
+	// consecutive call
+	dst = []u8{len: encoded_data_two.len}
+	c.xor_key_stream(mut dst, encoded_data_two)
+	assert dst == decoded_data_two
+
+	// additional data
+	msg := 'billy the kid'.bytes()
+	mut dst2 := []u8{len: msg.len}
+	c.xor_key_stream(mut dst2, msg)
+	// the go version produces: [40 17 78 116 255 224 2 52 92 151 103 107 138]
+	assert dst2 == [u8(40), 17, 78, 116, 255, 224, 2, 52, 92, 151, 103, 107, 138]
+}
+
 struct StreamCipher {
 mut:
 	cipher &cipher.Stream
@@ -72,10 +101,11 @@ fn test_chacha20_block_function() ! {
 		nonce_bytes := hex.decode(val.nonce)!
 		mut cs := new_cipher(key_bytes, nonce_bytes)!
 		cs.set_counter(val.counter)
-		cs.chacha20_block()
+		mut block := []u8{len: block_size}
+		cs.chacha20_block_generic(mut block, block)
 		exp_bytes := hex.decode(val.output)!
 
-		assert cs.block == exp_bytes
+		assert block == exp_bytes
 	}
 }
 
@@ -89,12 +119,12 @@ fn test_chacha20_simple_block_function() ! {
 	mut block := []u8{len: block_size}
 	mut cs := new_cipher(key_bytes, nonce_bytes)!
 	cs.set_counter(u32(1))
-	cs.chacha20_block()
+	cs.chacha20_block_generic(mut block, block)
 
 	expected_raw_bytes := '10f1e7e4d13b5915500fdd1fa32071c4c7d1f4c733c068030422aa9ac3d46c4ed2826446079faa0914c2d705d98b02a2b5129cd1de164eb9cbd083e8a2503c4e'
 	exp_bytes := hex.decode(expected_raw_bytes)!
 
-	assert cs.block == exp_bytes
+	assert block == exp_bytes
 }
 
 fn test_chacha20_quarter_round() {

--- a/vlib/x/crypto/chacha20poly1305/chacha20poly1305.v
+++ b/vlib/x/crypto/chacha20poly1305/chacha20poly1305.v
@@ -127,13 +127,13 @@ fn (c Chacha20Poly1305) encrypt_generic(plaintext []u8, nonce []u8, ad []u8) ![]
 	// see https://datatracker.ietf.org/doc/html/rfc8439#section-2.6
 	mut polykey := []u8{len: key_size}
 	mut s := chacha20.new_cipher(c.key, nonce)!
-	s.xor_key_stream(mut polykey, polykey)
+	s.encrypt(mut polykey, polykey)
 
 	// Next, the ChaCha20 encryption function is called to encrypt the plaintext,
 	// using the same key and nonce, and with the initial ChaCha20 counter set to 1.
 	mut ciphertext := []u8{len: plaintext.len}
 	s.set_counter(1)
-	s.xor_key_stream(mut ciphertext, plaintext)
+	s.encrypt(mut ciphertext, plaintext)
 
 	// Finally, the Poly1305 function is called with the generated Poly1305 one-time key
 	// calculated above, and a message constructed as described in
@@ -177,7 +177,7 @@ fn (c Chacha20Poly1305) decrypt_generic(ciphertext []u8, nonce []u8, ad []u8) ![
 	// generates poly1305 one-time key for later calculation
 	mut polykey := []u8{len: key_size}
 	mut s := chacha20.new_cipher(c.key, nonce)!
-	s.xor_key_stream(mut polykey, polykey)
+	s.encrypt(mut polykey, polykey)
 
 	// Remember, ciphertext is concatenation of associated cipher output plus tag (mac) bytes
 	encrypted := ciphertext[0..ciphertext.len - c.overhead()]
@@ -186,7 +186,7 @@ fn (c Chacha20Poly1305) decrypt_generic(ciphertext []u8, nonce []u8, ad []u8) ![
 	mut plaintext := []u8{len: encrypted.len}
 	s.set_counter(1)
 	// doing reverse encrypt on cipher output part produces plaintext
-	s.xor_key_stream(mut plaintext, encrypted)
+	s.encrypt(mut plaintext, encrypted)
 
 	// authenticated messages part
 	mut constructed_msg := []u8{}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR fixs the issue related consecutive calls of `xor_key_stream` thats not handled correctly after the first calls. Its issue was reported by @einar-hjortdal . See the issue at [23977](https://github.com/vlang/v/issues/23977). Thank for report the issue.

In this PR, we follow and adapt the go version and also unifies between `chach20_block` and `generic_key_stream` method to single one in the form of `chacha20_block_generic`. Its also adds a test for this consecutive calls issue.

Thanks