### PR TITLE
checker: fix chan elemen type validation with inexistent type

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1499,9 +1499,13 @@ pub fn (t &Table) known_type_names() []string {
 	for _, idx in t.type_idxs {
 		typ := idx_to_type(idx)
 		// Skip `int_literal_type_idx` and `float_literal_type_idx` because they shouldn't be visible to the User.
-		if idx !in [0, int_literal_type_idx, float_literal_type_idx] && t.known_type_idx(typ)
-			&& t.sym(typ).kind != .function {
-			res << t.type_to_str(typ)
+		if idx !in [0, int_literal_type_idx, float_literal_type_idx] && t.known_type_idx(typ) {
+			tsym := t.sym(typ)
+			if tsym.kind !in [.function, .chan] {
+				res << t.type_to_str(typ)
+			} else if tsym.info is Chan && t.sym(tsym.info.elem_type).kind != .placeholder {
+				res << t.type_to_str(tsym.info.elem_type)
+			}
 		}
 	}
 	return res

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5487,6 +5487,14 @@ fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Pos) bool {
 				}
 			}
 		}
+		.chan {
+			if sym.info is ast.Chan {
+				if !c.ensure_type_exists((sym.info as ast.Chan).elem_type, token.Pos{ ...pos, col:
+					pos.col + 5 }) {
+					return false
+				}
+			}
+		}
 		else {}
 	}
 	return true

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5489,8 +5489,10 @@ fn (mut c Checker) ensure_type_exists(typ ast.Type, pos token.Pos) bool {
 		}
 		.chan {
 			if sym.info is ast.Chan {
-				if !c.ensure_type_exists((sym.info as ast.Chan).elem_type, token.Pos{ ...pos, col:
-					pos.col + 5 }) {
+				if !c.ensure_type_exists((sym.info as ast.Chan).elem_type, token.Pos{
+					...pos
+					col: pos.col + 5
+				}) {
 					return false
 				}
 			}

--- a/vlib/v/checker/tests/chan_unknown_err.out
+++ b/vlib/v/checker/tests/chan_unknown_err.out
@@ -5,4 +5,3 @@ Did you mean `DoesNotExists`?
     7 |     bug chan DoesNotExist
       |              ~~~~~~~~~~~~
     8 | }
-    9 |

--- a/vlib/v/checker/tests/chan_unknown_err.out
+++ b/vlib/v/checker/tests/chan_unknown_err.out
@@ -1,0 +1,8 @@
+vlib/v/checker/tests/chan_unknown_err.vv:7:11: error: unknown type `DoesNotExist`.
+Did you mean `DoesNotExists`?
+    5 | struct ChanBug {
+    6 | pub mut:
+    7 |     bug chan DoesNotExist
+      |              ~~~~~~~~~~~~
+    8 | }
+    9 |

--- a/vlib/v/checker/tests/chan_unknown_err.vv
+++ b/vlib/v/checker/tests/chan_unknown_err.vv
@@ -1,0 +1,8 @@
+module main
+
+struct DoesNotExists {}
+
+struct ChanBug {
+pub mut:
+	bug chan DoesNotExist
+}


### PR DESCRIPTION
Fix #23978