### PR TITLE
cgen,parser: fix arm64 asm operand position; fix arm64 asm imm; support arm64 dot instruction

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3130,8 +3130,8 @@ fn (mut g Gen) asm_stmt(stmt ast.AsmStmt) {
 		} else {
 			g.write(' ')
 		}
-		// swap destination and operands for att syntax only for amd64
-		if template.args.len != 0 && !template.is_directive && stmt.arch == .amd64 {
+		// swap destination and operands for att syntax, not for arm64
+		if template.args.len != 0 && !template.is_directive && stmt.arch != .arm64 {
 			template.args.prepend(template.args.last())
 			template.args.delete(template.args.len - 1)
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3130,8 +3130,8 @@ fn (mut g Gen) asm_stmt(stmt ast.AsmStmt) {
 		} else {
 			g.write(' ')
 		}
-		// swap destination and operands for att syntax
-		if template.args.len != 0 && !template.is_directive {
+		// swap destination and operands for att syntax only for amd64
+		if template.args.len != 0 && !template.is_directive && stmt.arch == .amd64 {
 			template.args.prepend(template.args.last())
 			template.args.delete(template.args.len - 1)
 		}
@@ -3206,7 +3206,11 @@ fn (mut g Gen) asm_arg(arg ast.AsmArg, stmt ast.AsmStmt) {
 			g.write("'${arg.val}'")
 		}
 		ast.IntegerLiteral {
-			g.write('\$${arg.val}')
+			if stmt.arch == .arm64 {
+				g.write('#${arg.val}')
+			} else {
+				g.write('\$${arg.val}')
+			}
 		}
 		ast.FloatLiteral {
 			if g.pref.nofloat {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1301,8 +1301,8 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 			name += p.tok.lit
 			p.check(.name)
 		}
-		// dots are part of instructions for some riscv extensions and webassembly
-		if arch in [.rv32, .rv64, .wasm32] {
+		// dots are part of instructions for some riscv extensions and webassembly, arm64
+		if arch in [.rv32, .rv64, .wasm32, .arm64] {
 			for p.tok.kind == .dot {
 				name += '.'
 				p.next()

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1266,6 +1266,7 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 	for p.tok.kind !in [.semicolon, .rcbr, .eof] {
 		template_pos := p.tok.pos()
 		mut name := ''
+		mut comments := []ast.Comment{}
 		if p.tok.kind == .name && arch == .amd64 && p.tok.lit in ['rex', 'vex', 'xop'] {
 			name += p.tok.lit
 			p.next()
@@ -1297,6 +1298,10 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 		} else if p.tok.kind == .number {
 			name += p.tok.lit
 			p.next()
+		} else if p.tok.kind == .comment {
+			for p.tok.kind == .comment {
+				comments << p.comment()
+			}
 		} else {
 			name += p.tok.lit
 			p.check(.name)
@@ -1405,7 +1410,6 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 			// 	break
 			// }
 		}
-		mut comments := []ast.Comment{}
 		for p.tok.kind == .comment {
 			comments << p.comment()
 		}

--- a/vlib/v/slow_tests/assembly/asm_test.arm64.v
+++ b/vlib/v/slow_tests/assembly/asm_test.arm64.v
@@ -1,0 +1,119 @@
+// vtest build: gcc
+fn test_inline_asm() {
+	a, mut b := 10, 0
+	asm arm64 {
+		mov x0, a
+		mov b, x0
+		; +r (b)
+		; r (a)
+		; x0
+	}
+	assert a == 10
+	assert b == 10
+
+	mut c := 0
+	asm arm64 {
+		mov x0, 5
+		mov c, x0
+		; +r (c)
+		; ; x0
+	}
+	assert c == 5
+
+	d, e, mut f := 10, 2, 0
+	asm arm64 {
+		mov x0, d
+		mov x1, e
+		add x0, x0, x1
+		add x0, x0, 5
+		mov f, x0
+		; +r (f) // output
+		; r (d)
+		  r (e) // input
+		; x0
+		  x1
+	}
+	assert d == 10
+	assert e == 2
+	assert f == 17
+	/*
+	mut j := 0
+	// do 5*3
+	// adding three, five times
+	asm arm64 {
+		mov x0, 5 // loop 5 times
+		mov x1, 0
+		loop_start:
+		add x1, x1, 3
+		cmp x0, 5
+		b.lt loop_start
+		mov j, x0
+		; +r (j)
+		; ; x0 x1
+	}
+	assert j == 5 * 3
+
+	// not marked as mut because we dereference m to change l
+	l := 5
+	m := &l
+	asm arm64 {
+		movd [m], 7 // have to specify size with q
+		; ; r (m)
+	}
+	assert l == 7
+
+	mut manu := Manu{}
+	asm arm64 {
+		mov x0, MIDR_EL1
+		mov x1, ID_AA64ISAR0_EL1
+		mov x2, ID_AA64MMFR0_EL1
+		; =r (manu.midr_el1) as x0
+		  =r (manu.id_aa64isar0_el1) as x1
+		  =r (manu.id_aa64mmfr0_el1) as x2
+	}
+	manu.str()
+	*/
+}
+
+/*
+@[packed]
+struct Manu {
+mut:
+	midr_el1  u64
+	id_aa64isar0_el1  u64
+	id_aa64mmfr0_el1  u64
+	zero u8 // for string
+}
+
+fn (m Manu) str() string {
+	return unsafe {
+		string{
+			str:    &u8(&m)
+			len:    24
+			is_lit: 1
+		}
+	}
+}
+
+fn test_asm_generic() {
+	u := u64(49)
+	b := unsafe { bool(123) }
+	assert generic_asm(u) == 14
+	assert u == 63
+	assert u64(generic_asm(b)) == 14
+	assert u64(b) == 137
+}
+
+fn generic_asm[T](var &T) T {
+	mut ret := T(14)
+	unsafe {
+		asm volatile arm64 {
+			add var, ret
+			; +m (var[0]) as var
+			  +r (ret)
+			; ; memory
+		}
+	}
+	return ret
+}
+*/

--- a/vlib/v/slow_tests/assembly/asm_test.arm64.v
+++ b/vlib/v/slow_tests/assembly/asm_test.arm64.v
@@ -16,7 +16,8 @@ fn test_inline_asm() {
 		mov x0, 5
 		mov c, x0
 		; +r (c)
-		; ; x0
+		;
+		; x0
 	}
 	assert c == 5
 
@@ -30,13 +31,12 @@ fn test_inline_asm() {
 		; +r (f) // output
 		; r (d)
 		  r (e) // input
-		; x0
-		  x1
+		; x0 x1
 	}
 	assert d == 10
 	assert e == 2
 	assert f == 17
-	/*
+
 	mut j := 0
 	// do 5*3
 	// adding three, five times
@@ -45,14 +45,15 @@ fn test_inline_asm() {
 		mov x1, 0
 		loop_start:
 		add x1, x1, 3
-		cmp x0, 5
-		b.lt loop_start
-		mov j, x0
+		sub x0, x0, 1
+		cmp x0, 0
+		b.gt loop_start
+		mov j, x1
 		; +r (j)
 		; ; x0 x1
 	}
 	assert j == 5 * 3
-
+/*
 	// not marked as mut because we dereference m to change l
 	l := 5
 	m := &l
@@ -72,9 +73,8 @@ fn test_inline_asm() {
 		  =r (manu.id_aa64mmfr0_el1) as x2
 	}
 	manu.str()
-	*/
+*/
 }
-
 /*
 @[packed]
 struct Manu {
@@ -108,10 +108,13 @@ fn generic_asm[T](var &T) T {
 	mut ret := T(14)
 	unsafe {
 		asm volatile arm64 {
-			add var, ret
+			mov x0, ret
+			mov x1, var
+			add x1, x0, 0
+			mov var, x1
 			; +m (var[0]) as var
 			  +r (ret)
-			; ; memory
+			; ; memory x0 x1
 		}
 	}
 	return ret

--- a/vlib/v/slow_tests/assembly/asm_test.arm64.v
+++ b/vlib/v/slow_tests/assembly/asm_test.arm64.v
@@ -16,8 +16,7 @@ fn test_inline_asm() {
 		mov x0, 5
 		mov c, x0
 		; +r (c)
-		;
-		; x0
+		; ; x0
 	}
 	assert c == 5
 
@@ -31,7 +30,8 @@ fn test_inline_asm() {
 		; +r (f) // output
 		; r (d)
 		  r (e) // input
-		; x0 x1
+		; x0
+		  x1
 	}
 	assert d == 10
 	assert e == 2
@@ -50,10 +50,11 @@ fn test_inline_asm() {
 		b.gt loop_start
 		mov j, x1
 		; +r (j)
-		; ; x0 x1
+		; ; x0
+		  x1
 	}
 	assert j == 5 * 3
-/*
+	/*
 	// not marked as mut because we dereference m to change l
 	l := 5
 	m := &l
@@ -73,8 +74,9 @@ fn test_inline_asm() {
 		  =r (manu.id_aa64mmfr0_el1) as x2
 	}
 	manu.str()
-*/
+	*/
 }
+
 /*
 @[packed]
 struct Manu {


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

1. fix issue #24014
2. fix imm in `arm64` as it starts with `#` not `$`
3. fix parser support `arm64` dot instructions, such as `b.le`
4. fix issue #24015