### PR TITLE
sync: fix race on poolprocessor

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -234,6 +234,9 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				// we can't just do `.str` since we need the extra data from the string struct
 				// doing `&string` is also not an option since the stack memory with the data will be overwritten
 				g.expr(left0) // node.left[0])
+				if first_left_type.has_flag(.shared_f) {
+					g.write('->val')
+				}
 				g.writeln('); // free ${type_to_free} on re-assignment2')
 				defer {
 					if af {


### PR DESCRIPTION
This PR fixes a race spotted by *Helgrind* running on same repo used on issue #23980

```
==12656== Possible data race during read of size 8 at 0xAAC5A20 by thread #1
==12656== Locks held: none
==12656==    at 0x4D0DFB: sync__pool__PoolProcessor_get_results_ref_T_v__gen__c__Gen (pool.c.v:152)
==12656==    by 0x740243: v__gen__c__gen (cgen.v:388)
==12656==    by 0x8AC1BC: v__builder__cbuilder__gen_c (cbuilder.v:80)
==12656==    by 0x8ABD84: v__builder__cbuilder__build_c (cbuilder.v:60)
==12656==    by 0x8ABBDC: v__builder__cbuilder__compile_c (cbuilder.v:50)
==12656==    by 0x8AA3AD: v__builder__Builder_rebuild (rebuilding.v:325)
==12656==    by 0x8A1281: v__builder__compile (compile.v:17)
==12656==    by 0x8B14B2: main__rebuild (v.v:193)
==12656==    by 0x8B09FE: main__main (v.v:151)
==12656==    by 0x8BBA58: main (v2.01JQ20DDCQ9XRY2AECS26KTMJK.tmp.c:236859)
```