### PR TITLE
gg: make draw_rect_empty/5 draw more exact borders, independent of the device, and fitting the draw_rect_filled/5 shapes

### DIFF
--- a/vlib/gg/draw.c.v
+++ b/vlib/gg/draw.c.v
@@ -190,13 +190,29 @@ pub fn (ctx &Context) draw_rect_empty(x f32, y f32, w f32, h f32, c gx.Color) {
 		sgl.load_pipeline(ctx.pipeline.alpha)
 	}
 	sgl.c4b(c.r, c.g, c.b, c.a)
-
-	sgl.begin_line_strip()
-	sgl.v2f(x * ctx.scale, y * ctx.scale)
-	sgl.v2f((x + w) * ctx.scale, y * ctx.scale)
-	sgl.v2f((x + w) * ctx.scale, (y + h) * ctx.scale)
-	sgl.v2f(x * ctx.scale, (y + h) * ctx.scale)
-	sgl.v2f(x * ctx.scale, (y - 1) * ctx.scale)
+	// The small offsets here, are to make sure, that the start and end points will be
+	// inside pixels, and not on their borders. That in turn, makes it much more likely
+	// that different OpenGL implementations will render them identically, for example
+	// Mesa, with `LIBGL_ALWAYS_SOFTWARE=1` renders the same as HD4000.
+	mut toffset := f32(0.1)
+	mut boffset := f32(-0.1)
+	tleft_x := toffset + x * ctx.scale
+	tleft_y := toffset + y * ctx.scale
+	bright_x := boffset + (x + w) * ctx.scale
+	bright_y := boffset + (y + h) * ctx.scale
+	sgl.begin_lines() // more predictable, compared to sgl.begin_line_strip, at the price of more vertexes send
+	// top:
+	sgl.v2f(tleft_x, tleft_y)
+	sgl.v2f(bright_x, tleft_y)
+	// left:
+	sgl.v2f(tleft_x, tleft_y)
+	sgl.v2f(tleft_x, bright_y)
+	// right:
+	sgl.v2f(bright_x, tleft_y)
+	sgl.v2f(bright_x, bright_y)
+	// bottom:
+	sgl.v2f(tleft_x, bright_y)
+	sgl.v2f(bright_x, bright_y)
 	sgl.end()
 }
 

--- a/vlib/gg/testdata/draw_rectangles.vv
+++ b/vlib/gg/testdata/draw_rectangles.vv
@@ -1,0 +1,24 @@
+module main
+
+import gg
+import gx
+
+gg.start(
+	bg_color:     gx.white
+	window_title: 'Rectangles'
+	width:        250
+	height:       100
+	frame_fn:     fn (ctx &gg.Context) {
+		ctx.begin()
+		ctx.draw_rect_filled(10, 10, 10, 10, gx.blue)
+		ctx.draw_rect_empty(30, 10, 10, 10, gx.red)
+		ctx.draw_rect_filled(50, 10, 30, 10, gx.green)
+		ctx.draw_rect_empty(100, 10, 30, 10, gx.black)
+
+		ctx.draw_rect_empty(10, 50, 10, 10, gx.blue)
+		ctx.draw_rect_filled(30, 50, 10, 10, gx.red)
+		ctx.draw_rect_empty(50, 50, 30, 10, gx.green)
+		ctx.draw_rect_filled(100, 50, 30, 10, gx.black)
+		ctx.end()
+	}
+)


### PR DESCRIPTION
The result of:
```v
module main

import gg
import gx

gg.start(
	bg_color:     gx.white
	window_title: 'Rectangles'
	width:        250
	height:       100
	frame_fn:     fn (ctx &gg.Context) {
		ctx.begin()
		ctx.draw_rect_filled(10, 10, 10, 10, gx.blue)
		ctx.draw_rect_empty(30, 10, 10, 10, gx.red)
		ctx.draw_rect_filled(50, 10, 30, 10, gx.green)
		ctx.draw_rect_empty(100, 10, 30, 10, gx.black)

		ctx.draw_rect_empty(10, 50, 10, 10, gx.blue)
		ctx.draw_rect_filled(30, 50, 10, 10, gx.red)
		ctx.draw_rect_empty(50, 50, 30, 10, gx.green)
		ctx.draw_rect_filled(100, 50, 30, 10, gx.black)
		ctx.end()
	}
)
```

with this PR on linux (with added guidelines) is:
![image](https://github.com/user-attachments/assets/c5ce8994-9b76-435d-a07a-d6dd9971fb71)
(the top image is from my GPU, the bottom one is from MESA, rendered with `LIBGL_ALWAYS_SOFTWARE=1`)

on macos, it is (with added guidelines):
![image](https://github.com/user-attachments/assets/ffa187dd-5b0e-46bd-82c3-cf7d57d2a340)

In both cases `draw_rect_empty` draws a rectangle, that exactly matches the shape and position of a filled rectangle, drawn with `draw_rect_filled`.