### PR TITLE
cgen: fix codegen for option return unwrapping on last statement

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -601,6 +601,20 @@ fn (mut p Parser) mark_last_call_return_as_used(mut last_stmt ast.Stmt) {
 						}
 					}
 				}
+				ast.InfixExpr {
+					// last stmt has infix expr with CallExpr: foo()? + 'a'
+					mut left_expr := last_stmt.expr.left
+					for {
+						if mut left_expr is ast.InfixExpr {
+							left_expr = left_expr.left
+							continue
+						}
+						if mut left_expr is ast.CallExpr {
+							left_expr.is_return_used = true
+						}
+						break
+					}
+				}
 				else {}
 			}
 		}

--- a/vlib/v/tests/options/option_last_call_test.v
+++ b/vlib/v/tests/options/option_last_call_test.v
@@ -1,0 +1,16 @@
+fn test_main() {
+	assert some_func2(14)? + 'c' == 'aabcac'
+}
+
+fn some_func(i int) ?string {
+	return 'a'
+}
+
+fn some_func2(i int) ?string {
+	return match i {
+		12 { some_func(1)? + 'b' }
+		13 { some_func(1)? + 'b' + 'c' }
+		14 { 'a' + some_func(1)? + 'b' + 'c' + some_func(1)? }
+		else { none }
+	}
+}


### PR DESCRIPTION
Fix #24026