### PR TITLE
cgen: allow asserts inside fn calls on const/global initialization in test files

### DIFF
--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -301,10 +301,10 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 		}
 		g.writeln('#endif')
 	}
+	g.writeln('\tmain__vtest_init();')
 	if !g.pref.no_builtin {
 		g.writeln('\t_vinit(___argc, (voidptr)___argv);')
 	}
-	g.writeln('\tmain__vtest_init();')
 	g.gen_c_main_profile_hook()
 
 	mut all_tfuncs := g.get_all_test_function_names()

--- a/vlib/v/tests/test_global_init_test.v
+++ b/vlib/v/tests/test_global_init_test.v
@@ -1,0 +1,10 @@
+const x = my_init()
+
+fn my_init() int {
+	assert true
+	return 1
+}
+
+fn test_my_init() {
+	assert x == 1
+}


### PR DESCRIPTION
Fix #24029