### PR TITLE
`x.crypto.chacha20`: Small cleans up as preliminary works to support 64bit counter

### DIFF
--- a/vlib/x/crypto/chacha20/chacha_test.v
+++ b/vlib/x/crypto/chacha20/chacha_test.v
@@ -1,6 +1,5 @@
 module chacha20
 
-import crypto.cipher
 import rand
 import encoding.hex
 
@@ -31,24 +30,6 @@ fn test_xor_key_stream_consecutive() {
 	c.xor_key_stream(mut dst2, msg)
 	// the go version produces: [40 17 78 116 255 224 2 52 92 151 103 107 138]
 	assert dst2 == [u8(40), 17, 78, 116, 255, 224, 2, 52, 92, 151, 103, 107, 138]
-}
-
-struct StreamCipher {
-mut:
-	cipher &cipher.Stream
-}
-
-// Verify chahca20.Cipher implements chiper.Stream correctly.
-fn test_chacha20_stream_cipher() ! {
-	mut key := []u8{len: 32}
-	mut nonce := []u8{len: 12}
-	rand.read(mut key)
-	rand.read(mut nonce)
-
-	mut c := new_cipher(key, nonce)!
-	s := StreamCipher{
-		cipher: c
-	}
 }
 
 fn test_chacha20_cipher_reset() ! {

--- a/vlib/x/crypto/chacha20/xchacha.v
+++ b/vlib/x/crypto/chacha20/xchacha.v
@@ -74,22 +74,3 @@ fn xchacha20(key []u8, nonce []u8) ![]u8 {
 
 	return out
 }
-
-// eXtended ChaCha20 (XChaCha20) encrypt function
-// see https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha-03#section-2.3.1
-fn xchacha20_encrypt(key []u8, nonce []u8, plaintext []u8) ![]u8 {
-	return xchacha20_encrypt_with_counter(key, nonce, u32(0), plaintext)
-}
-
-fn xchacha20_encrypt_with_counter(key []u8, nonce []u8, ctr u32, plaintext []u8) ![]u8 {
-	// bound check elimination
-	_ = nonce[x_nonce_size - 1]
-	subkey := xchacha20(key, nonce[0..16])!
-	mut cnonce := nonce[16..24].clone()
-
-	cnonce.prepend([u8(0x00), 0x00, 0x00, 0x00])
-
-	ciphertext := chacha20_encrypt_with_counter(subkey, cnonce, ctr, plaintext)!
-
-	return ciphertext
-}

--- a/vlib/x/crypto/chacha20/xchacha_test.v
+++ b/vlib/x/crypto/chacha20/xchacha_test.v
@@ -38,8 +38,7 @@ fn test_xchacha20_encrypt_vector_test_a321() ! {
 	nonce_bytes := hex.decode(nonce)!
 	ciphertext_bytes := hex.decode(ciphertext)!
 
-	encrypted_message := xchacha20_encrypt_with_counter(key_bytes, nonce_bytes, counter,
-		plaintext_bytes) or { return }
+	encrypted_message := encrypt(key_bytes, nonce_bytes, plaintext_bytes) or { return }
 
 	assert encrypted_message == ciphertext_bytes
 }
@@ -60,8 +59,11 @@ fn test_xchach20_encrypt_vector_test_a322() ! {
 	nonce_bytes := hex.decode(nonce)!
 	ciphertext_bytes := hex.decode(ciphertext)!
 
-	encrypted_message := xchacha20_encrypt_with_counter(key_bytes, nonce_bytes, counter,
-		plaintext_bytes) or { return }
+	mut c := new_cipher(key_bytes, nonce_bytes)!
+	c.set_counter(counter)
+
+	mut encrypted_message := []u8{len: plaintext_bytes.len}
+	c.encrypt(mut encrypted_message, plaintext_bytes)
 
 	assert encrypted_message == ciphertext_bytes
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This small PR acts as a preliminary step  in trying to add support for 64-bit counters to the `x.crypto.chacha20` module.

Currently, the `x.crypto.chacha20` module only supports for standard IETF variant which only support for 32-bit counters, and does not yet support for 64-bit counters.

This PR only contains some small cleans up by cleaning out some wrappers to simplify future works.

Thanks