### PR TITLE
cgen: fix match option with case non option

### DIFF
--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -217,6 +217,11 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 			}
 			g.inside_if_result = true
 			styp = styp.replace('*', '_ptr')
+		} else {
+			g.last_if_option_type = node.typ
+			defer {
+				g.last_if_option_type = tmp_if_option_type
+			}
 		}
 		cur_line = g.go_before_last_stmt()
 		g.empty_line = true

--- a/vlib/v/tests/options/option_match_case_test.v
+++ b/vlib/v/tests/options/option_match_case_test.v
@@ -1,0 +1,17 @@
+fn test_main() {
+	v := match 12 {
+		12 {
+			x := if true { 'b' } else { some_func()? }
+			assert x == 'b'
+			x
+		}
+		else {
+			none
+		}
+	}
+	assert v? == 'b'
+}
+
+fn some_func() ?string {
+	return 'a'
+}


### PR DESCRIPTION
Fix #24048
Fix #24047