### PR TITLE
profile: new column for time of the function without the time of its children functions

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -574,6 +574,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 	b.write_string2('\n // V preincludes:\n', g.preincludes.str())
 	b.write_string2('\n// V cheaders:\n', g.cheaders.str())
 	if g.pcs_declarations.len > 0 {
+		g.pcs_declarations.writeln('double prof_measured_time = 0.0;') // does not work for multithreaded
 		b.write_string2('\n// V profile counters:\n', g.pcs_declarations.str())
 	}
 	b.write_string2('\n// V includes:\n', g.includes.str())


### PR DESCRIPTION
Adds a new column to the profiler output: time spent in the current function without the time spent in its children
Known problem: for multithreaded programs the time calculations are wrong and might show negative times.

Sample profiling output:

```
             1          0.034ms          0.007ms          34003ns rand__init
          1560          2.501ms          0.959ms           1603ns rand__PRNG_u32n
          1560          3.264ms          0.443ms           2092ns rand__PRNG_intn
          1560          4.015ms          0.432ms           2574ns rand__PRNG_int_in_range
          3120          1.064ms          0.419ms            341ns rand__PRNG_f64
          3120          2.355ms          0.678ms            755ns rand__PRNG_f64n
          3120          3.686ms          0.697ms           1181ns rand__PRNG_f64_in_range
             1          0.014ms          0.001ms          14173ns rand__new_default
          1560          0.137ms          0.137ms             88ns rand__int_in_range
          3120          0.186ms          0.186ms             60ns rand__f64_in_range
       7309361        605.565ms        605.565ms             83ns main__sqrt
       2015520        120.669ms        120.669ms             60ns main__Particle_update_pos
      11340456        647.577ms        647.577ms             57ns main__Particle_correct_constraints_square
       2015520         99.668ms         99.668ms             49ns main__Particle_accelerate
           312        107.600ms         49.533ms         344871ns main__App_init_opti_list
             1      10359.919ms          0.003ms    10359918908ns main__main
             2          0.000ms          0.000ms             86ns main__ceil
          3224       4097.998ms       2954.570ms        1271091ns main__App_solve_collisions
           403       4940.062ms        378.137ms       12258219ns main__App_compute_step
           403      10075.576ms         31.644ms       25001429ns main__on_frame
            83          0.015ms          0.014ms            177ns main__on_event
           312         10.171ms          1.276ms          32600ns main__App_spawn_parti
           312          0.082ms          0.082ms            264ns main__App_check_buttons
```

The effect is clearly seen on functions like `main__main` where no time is spent as it calls other functions.
It is useful when sorting on the 3rd column as functions that do not need to be optimized directly do not show:

```
          5642         96.640ms         96.640ms          17129ns fontstash__Context_draw_text
       2015520         99.668ms         99.668ms             49ns main__Particle_accelerate
       2015520        120.669ms        120.669ms             60ns main__Particle_update_pos
       2965680        203.247ms        203.247ms             69ns math__sinf
       2965680        210.164ms        210.164ms             71ns math__cosf
             1      10359.505ms        223.352ms    10359504750ns sokol__sapp__run
       5931360        270.991ms        270.991ms             46ns math__radians
           403       4940.062ms        378.137ms       12258219ns main__App_compute_step
       5965212        435.274ms        435.274ms             73ns sokol__sgl__v2f
           403        447.311ms        447.311ms        1109952ns sokol__sgl__draw
       7309361        605.565ms        605.565ms             83ns main__sqrt
      11340456        647.577ms        647.577ms             57ns main__Particle_correct_constraints_square
        250380       2232.434ms       1056.884ms           8916ns gg__Context_draw_polygon_filled
           403       2058.627ms       2058.627ms        5108255ns sokol__gfx__begin_pass
          3224       4097.998ms       2954.570ms        1271091ns main__App_solve_collisions
```