### PR TITLE
orm: fix type alias not supported in table columns

### DIFF
--- a/vlib/v/checker/orm.v
+++ b/vlib/v/checker/orm.v
@@ -406,7 +406,9 @@ fn (mut c Checker) fetch_and_check_orm_fields(info ast.Struct, pos token.Pos, ta
 			continue
 		}
 		field_sym := c.table.sym(field.typ)
-		is_primitive := field.typ.is_string() || field.typ.is_bool() || field.typ.is_number()
+		final_field_typ := c.table.final_type(field.typ)
+		is_primitive := final_field_typ.is_string() || final_field_typ.is_bool()
+			|| final_field_typ.is_number()
 		is_struct := field_sym.kind == .struct
 		is_array := field_sym.kind == .array
 		is_enum := field_sym.kind == .enum

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -155,18 +155,19 @@ fn (mut g Gen) write_orm_create_table(node ast.SqlStmtLine, table_name string, c
 
 		for field in node.fields {
 			g.writeln('// `${table_name}`.`${field.name}`')
-			sym := g.table.sym(field.typ)
+			final_field_typ := g.table.final_type(field.typ)
+			sym := g.table.sym(final_field_typ)
 			typ := match true {
 				sym.name == 'time.Time' { '_const_orm__time_' }
 				sym.kind == .enum { '_const_orm__enum_' }
-				else { field.typ.idx().str() }
+				else { final_field_typ.idx().str() }
 			}
 			g.writeln('(orm__TableField){')
 			g.indent++
 			g.writeln('.name = _SLIT("${field.name}"),')
 			g.writeln('.typ = ${typ}, // `${sym.name}`')
 			g.writeln('.is_arr = ${sym.kind == .array}, ')
-			g.writeln('.nullable = ${field.typ.has_flag(.option)},')
+			g.writeln('.nullable = ${final_field_typ.has_flag(.option)},')
 			g.writeln('.default_val = (string){ .str = (byteptr) "${field.default_val}", .is_lit = 1 },')
 			g.writeln('.attrs = new_array_from_c_array(${field.attrs.len}, ${field.attrs.len}, sizeof(VAttribute),')
 			g.indent++
@@ -304,11 +305,16 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 	mut opt_fields := []int{}
 
 	for field in node.fields {
-		sym := g.table.sym(field.typ)
+		final_field_typ := g.table.final_type(field.typ)
+		sym := g.table.sym(final_field_typ)
 		if sym.kind == .struct && sym.name != 'time.Time' {
-			subs << unsafe { node.sub_structs[int(field.typ)] }
-			unwrapped_c_typ := g.styp(field.typ.clear_flag(.option))
-			subs_unwrapped_c_typ << if field.typ.has_flag(.option) { unwrapped_c_typ } else { '' }
+			subs << unsafe { node.sub_structs[int(final_field_typ)] }
+			unwrapped_c_typ := g.styp(final_field_typ.clear_flag(.option))
+			subs_unwrapped_c_typ << if final_field_typ.has_flag(.option) {
+				unwrapped_c_typ
+			} else {
+				''
+			}
 		} else if sym.kind == .array {
 			// Handle foreign keys
 			if attr := field.attrs.find_first('fkey') {
@@ -316,11 +322,11 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 			} else {
 				verror('missing fkey attribute')
 			}
-			if field.typ.has_flag(.option) {
+			if final_field_typ.has_flag(.option) {
 				opt_fields << arrs.len
 			}
 			if node.sub_structs.len > 0 {
-				arrs << unsafe { node.sub_structs[int(field.typ)] }
+				arrs << unsafe { node.sub_structs[int(final_field_typ)] }
 			}
 			field_names << field.name
 		}
@@ -403,7 +409,8 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 				g.writeln('${pid}, ')
 				continue
 			}
-			mut sym := g.table.sym(field.typ)
+			final_field_typ := g.table.final_type(field.typ)
+			mut sym := g.table.sym(final_field_typ)
 			mut typ := sym.cname
 			mut ctyp := sym.cname
 			if sym.kind == .struct && typ != 'time__Time' {
@@ -416,10 +423,10 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 				ctyp = 'time__Time'
 				typ = 'time'
 			} else if sym.kind == .enum {
-				typ = g.table.sym(g.table.final_type(field.typ)).cname
+				typ = g.table.sym(final_field_typ).cname
 			}
 			var := '${node.object_var}${member_access_type}${c_name(field.name)}'
-			if field.typ.has_flag(.option) {
+			if final_field_typ.has_flag(.option) {
 				g.writeln('${var}.state == 2? _const_orm__null_primitive : orm__${typ}_to_primitive(*(${ctyp}*)(${var}.data)),')
 			} else if inserting_object_sym.kind == .sum_type {
 				table_sym := g.table.sym(node.table_expr.typ)
@@ -566,7 +573,8 @@ fn (mut g Gen) write_orm_primitive(t ast.Type, expr ast.Expr) {
 	if t == 0 {
 		verror('${g.file.path}:${expr.pos().line_nr + 1}: ORM: unknown type t == 0\nexpr: ${expr}\nlast SQL stmt:\n${g.out.after(g.sql_last_stmt_out_len)}')
 	}
-	mut sym := g.table.sym(t)
+	final_field_typ := g.table.final_type(t)
+	mut sym := g.table.sym(final_field_typ)
 	mut typ := sym.cname
 	if typ == 'orm__Primitive' {
 		g.expr(expr)
@@ -908,7 +916,8 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 		g.indent++
 		for field in select_fields {
 			g.writeln('_SLIT("${g.get_orm_column_name_from_struct_field(field)}"),')
-			sym := g.table.sym(field.typ)
+			final_field_typ := g.table.final_type(field.typ)
+			sym := g.table.sym(final_field_typ)
 			if sym.name == 'time.Time' {
 				types << '_const_orm__time_'
 				continue
@@ -920,7 +929,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 				types << '_const_orm__enum_'
 				continue
 			}
-			types << field.typ.idx().str()
+			types << final_field_typ.idx().str()
 		}
 		g.indent--
 		g.writeln('})')
@@ -1048,11 +1057,12 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 		mut fields_idx := 0
 		for field in fields {
 			array_get_call_code := '(*(orm__Primitive*) array_get((*(Array_orm__Primitive*) array_get(${select_unwrapped_result_var_name}, ${idx})), ${fields_idx}))'
-			sym := g.table.sym(field.typ)
+			final_field_typ := g.table.final_type(field.typ)
+			sym := g.table.sym(final_field_typ)
 			field_var := '${tmp}.${c_name(field.name)}'
-			field_c_typ := g.styp(field.typ)
+			field_c_typ := g.styp(final_field_typ)
 			if sym.kind == .struct && sym.name != 'time.Time' {
-				mut sub := node.sub_structs[int(field.typ)]
+				mut sub := node.sub_structs[int(final_field_typ)]
 				mut where_expr := sub.where_expr as ast.InfixExpr
 				mut ident := where_expr.right as ast.Ident
 				primitive_type_index := g.table.find_type('orm.Primitive')
@@ -1071,8 +1081,8 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 				sub_result_c_typ := g.styp(sub.typ)
 				g.writeln('${sub_result_c_typ} ${sub_result_var};')
 				g.write_orm_select(sub, connection_var_name, sub_result_var)
-				if field.typ.has_flag(.option) {
-					unwrapped_field_c_typ := g.styp(field.typ.clear_flag(.option))
+				if final_field_typ.has_flag(.option) {
+					unwrapped_field_c_typ := g.styp(final_field_typ.clear_flag(.option))
 					g.writeln('if (!${sub_result_var}.is_error)')
 					g.writeln('\t_option_ok(${sub_result_var}.data, (_option *)&${field_var}, sizeof(${unwrapped_field_c_typ}));')
 					g.writeln('else')
@@ -1089,7 +1099,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 				} else {
 					verror('missing fkey attribute')
 				}
-				sub := node.sub_structs[field.typ]
+				sub := node.sub_structs[final_field_typ]
 				if sub.has_where {
 					mut where_expr := sub.where_expr as ast.InfixExpr
 					mut left_where_expr := where_expr.left as ast.Ident
@@ -1108,7 +1118,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 					}
 
 					mut sql_expr_select_array := ast.SqlExpr{
-						typ:          field.typ.set_flag(.result)
+						typ:          final_field_typ.set_flag(.result)
 						is_count:     sub.is_count
 						db_expr:      sub.db_expr
 						has_where:    sub.has_where
@@ -1132,15 +1142,15 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 					g.writeln('${sub_result_c_typ} ${sub_result_var};')
 					g.write_orm_select(sql_expr_select_array, connection_var_name, sub_result_var)
 					g.writeln('if (!${sub_result_var}.is_error) {')
-					if field.typ.has_flag(.option) {
+					if final_field_typ.has_flag(.option) {
 						g.writeln('\t${field_var}.state = 0;')
-						g.writeln('\t*(${g.base_type(field.typ)}*)${field_var}.data = *(${g.base_type(field.typ)}*)${sub_result_var}.data;')
+						g.writeln('\t*(${g.base_type(final_field_typ)}*)${field_var}.data = *(${g.base_type(final_field_typ)}*)${sub_result_var}.data;')
 					} else {
 						g.writeln('\t${field_var} = *(${unwrapped_c_typ}*)${sub_result_var}.data;')
 					}
 					g.writeln('}')
 				}
-			} else if field.typ.has_flag(.option) {
+			} else if final_field_typ.has_flag(.option) {
 				prim_var := g.new_tmp_var()
 				g.writeln('orm__Primitive *${prim_var} = &${array_get_call_code};')
 				g.writeln('if (${prim_var}->_typ == ${g.table.find_type_idx('orm.Null')})')
@@ -1261,7 +1271,8 @@ fn (g &Gen) get_orm_column_name_from_struct_field(field ast.StructField) string 
 		}
 	}
 
-	sym := g.table.sym(field.typ)
+	final_field_typ := g.table.final_type(field.typ)
+	sym := g.table.sym(final_field_typ)
 	if sym.kind == .struct && sym.name != 'time.Time' {
 		name = '${name}_id'
 	}

--- a/vlib/v/tests/orm_type_alias_test.v
+++ b/vlib/v/tests/orm_type_alias_test.v
@@ -1,3 +1,4 @@
+// vtest build: present_sqlite3?
 module main
 
 import db.sqlite

--- a/vlib/v/tests/orm_type_alias_test.v
+++ b/vlib/v/tests/orm_type_alias_test.v
@@ -1,4 +1,4 @@
-// vtest build: present_sqlite3?
+// vtest build: present_sqlite3? && !sanitize-memory-clang?
 module main
 
 import db.sqlite

--- a/vlib/v/tests/orm_type_alias_test.v
+++ b/vlib/v/tests/orm_type_alias_test.v
@@ -1,4 +1,4 @@
-// vtest build: present_sqlite3? && !sanitize-memory-clang?
+// vtest build: present_sqlite3? && !sanitize-memory-clang
 module main
 
 import db.sqlite

--- a/vlib/v/tests/orm_type_alias_test.v
+++ b/vlib/v/tests/orm_type_alias_test.v
@@ -1,0 +1,45 @@
+module main
+
+import db.sqlite
+
+type CountryCode = string
+
+@[table: 'addresses']
+pub struct Address {
+	id      int @[primary; sql: serial]
+	name    string
+	address string
+	country CountryCode
+}
+
+fn test_main() {
+	mut db := sqlite.connect(':memory:')!
+
+	sql db {
+		create table Address
+	}!
+
+	new_address := Address{
+		name:    'Myself'
+		address: 'Here and there'
+		country: 'fr'
+	}
+
+	sql db {
+		insert new_address into Address
+	}!
+
+	rows := sql db {
+		select from Address where country == 'fr'
+	}!
+
+	assert rows.len == 1
+
+	assert typeof(rows.first().country).name == 'CountryCode'
+
+	db.close()!
+}
+
+fn main() {
+	assert true
+}


### PR DESCRIPTION
Corollary to #15478, which fixes the type alias support for db type, this commit allows the use of an alias to a supported type in a column.

The fix is mainly replacing `field.typ` occurrences with `table.final_type(field.typ)` or equivalent.

Example use:

```
type CountryCode = string

@[table: 'addresses']
pub struct Address {
	id      int @[primary; sql: serial]
	name    string
	address string
	country CountryCode
}

// …

sql db {
	create table Address
} or { panic("don't panic!") }
```

Created as a draft because all comments welcome and and tests / doc not yet written because of this.