### PR TITLE
checker: fix unused var warning for mut var passed to closure

### DIFF
--- a/vlib/v/checker/tests/mut_var_in_closure.vv
+++ b/vlib/v/checker/tests/mut_var_in_closure.vv
@@ -1,0 +1,12 @@
+fn not_unused() int {
+	mut used := 0
+	update_used := fn [mut used] () {
+		used += 1
+	}
+	update_used()
+	return used
+}
+
+fn main() {
+	println(not_unused())
+}

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -296,6 +296,10 @@ fn (mut p Parser) partial_assign_stmt(left []ast.Expr) ast.Stmt {
 	}
 	pos.update_last_line(p.prev_tok.line_nr)
 	p.expr_mod = ''
+	if op != .decl_assign && left[0] is ast.Ident && left[0].is_mut() {
+		var := left[0] as ast.Ident
+		p.scope.mark_var_as_used(var.name)
+	}
 	return ast.AssignStmt{
 		op:            op
 		left:          left


### PR DESCRIPTION
Fix #24078