### PR TITLE
parser: fix `$dbg` on function that uses veb comptimecall

### DIFF
--- a/vlib/v/parser/comptime.v
+++ b/vlib/v/parser/comptime.v
@@ -331,6 +331,10 @@ fn (mut p Parser) comptime_call() ast.ComptimeCall {
 	// the tmpl inherits all parent scopes. previous functionality was just to
 	// inherit the scope from which the comptime call was made and no parents.
 	// this is much simpler and allows access to globals. can be changed if needed.
+	p.open_scope()
+	defer {
+		p.close_scope()
+	}
 	mut file := parse_comptime(tmpl_path, v_code, mut p.table, p.pref, mut p.scope)
 	file.path = tmpl_path
 	return ast.ComptimeCall{


### PR DESCRIPTION
Fix #23999