### PR TITLE
cgen: fix generic result return

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -971,6 +971,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 				ret_typ = unaliased_type
 			}
 		} else if node.return_type_generic != 0 && node.raw_concrete_types.len == 0 {
+			ret_typ = g.fn_decl.return_type
 			unwrapped_ret_typ := g.unwrap_generic(node.return_type_generic)
 			if !unwrapped_ret_typ.has_flag(.generic) {
 				ret_sym := g.table.sym(unwrapped_ret_typ)

--- a/vlib/v/tests/generics/generics_return_result_maps.v
+++ b/vlib/v/tests/generics/generics_return_result_maps.v
@@ -1,0 +1,15 @@
+fn decode_map[K, V](a map[K]V) !map[K]V {
+	return a
+}
+
+fn decode[T]() !T {
+	return decode_map(T{})!
+}
+
+fn test_main() {
+	x_str_str := decode[map[string]string]()!
+	x_str_int := decode[map[string]int]()!
+
+	assert typeof(x_str_str).name == 'map[string]string'
+	assert typeof(x_str_int).name == 'map[string]int'
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Fix #24097

Maybe there is a better way to get the correct generic return type. This PR just set it to `g.fn_decl.return_type`.
