### PR TITLE
cgen: fix showing the expression as literal value in case of `assert s[x..y] == "literal"` (fix #24103)

### DIFF
--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -207,11 +207,7 @@ fn (mut g Gen) gen_assert_single_expr(expr ast.Expr, typ ast.Type) {
 			g.write(ctoslit(expr_str))
 		}
 		ast.IndexExpr {
-			if expr.index is ast.RangeExpr {
-				g.write(ctoslit(expr_str))
-			} else {
-				g.gen_expr_to_string(expr, typ)
-			}
+			g.gen_expr_to_string(expr, typ)
 		}
 		ast.PrefixExpr {
 			if expr.right is ast.CastExpr {

--- a/vlib/v/tests/skip_unused/assert_works_test.run.out
+++ b/vlib/v/tests/skip_unused/assert_works_test.run.out
@@ -3,3 +3,8 @@ vlib/v/tests/skip_unused/assert_works_test.vv:2: fn test_abc
      Left value (len: 3): `abc`
     Right value (len: 3): `xyz`
 
+vlib/v/tests/skip_unused/assert_works_test.vv:7: fn test_index_expr
+   > assert example_string[1 .. 4] == 'abcdef'
+     Left value (len: 3): `his`
+    Right value (len: 6): `abcdef`
+

--- a/vlib/v/tests/skip_unused/assert_works_test.skip_unused.run.out
+++ b/vlib/v/tests/skip_unused/assert_works_test.skip_unused.run.out
@@ -3,3 +3,8 @@ vlib/v/tests/skip_unused/assert_works_test.vv:2: fn test_abc
      Left value (len: 3): `abc`
     Right value (len: 3): `xyz`
 
+vlib/v/tests/skip_unused/assert_works_test.vv:7: fn test_index_expr
+   > assert example_string[1 .. 4] == 'abcdef'
+     Left value (len: 3): `his`
+    Right value (len: 6): `abcdef`
+

--- a/vlib/v/tests/skip_unused/assert_works_test.vv
+++ b/vlib/v/tests/skip_unused/assert_works_test.vv
@@ -1,3 +1,8 @@
 fn test_abc() {
 	assert 'abc' == 'xyz'
 }
+
+fn test_index_expr() {
+	example_string := 'This is an example string'
+	assert example_string[1..4] == 'abcdef'
+}


### PR DESCRIPTION
Fix #24103 .