### PR TITLE
crypto.rc4: new_cipher should return a reference to the Cipher for consistency with other ciphers

### DIFF
--- a/vlib/crypto/rc4/rc4.v
+++ b/vlib/crypto/rc4/rc4.v
@@ -31,11 +31,11 @@ pub fn (mut c Cipher) free() {
 
 // new_cipher creates and returns a new Cipher. The key argument should be the
 // RC4 key, at least 1 byte and at most 256 bytes.
-pub fn new_cipher(key []u8) !Cipher {
+pub fn new_cipher(key []u8) !&Cipher {
 	if key.len < 1 || key.len > 256 {
 		return error('crypto.rc4: invalid key size ' + key.len.str())
 	}
-	mut c := Cipher{
+	mut c := &Cipher{
 		s: []u32{len: (256)}
 	}
 	for i in 0 .. 256 {


### PR DESCRIPTION
if x.crypto.chacha20 new_cipher returns `!&Cipher`, then all new_cipher functions that return a cipher.Stream implementation should return a reference for consistency.

From [here](https://github.com/einar-hjortdal/firebird/blob/8420b91899fc21608c2a691a50c75ac185d03ecc/src/protocol_channel.v#L13)
```v
struct WireChannel {
mut:
	conn          &net.TcpConn
	reader        &io.BufferedReader
	writer        &io.BufferedWriter
	plugin        string
	crypto_reader &cipher.Stream
	crypto_writer &cipher.Stream
}

fn (mut c WireChannel) set_crypt_key(plugin string, session_key []u8, nonce []u8) ! {
	c.plugin = plugin
	match plugin {
		chacha20_64_plugin_name, chacha20_32_plugin_name {
			mut digest := sha256.new()
			digest.write(session_key)!
			key := digest.sum([]u8{})
			c.crypto_reader = chacha20.new_cipher(key, nonce)!
			c.crypto_writer = chacha20.new_cipher(key, nonce)!
		}
		rc4_plugin_name {
			// unlike assignment with chacha20.new_cipher, here the user needs 2 steps to assign a reference
			r := rc4.new_cipher(session_key)!
			w := rc4.new_cipher(session_key)!
			c.crypto_reader = &r
			c.crypto_writer = &w
		}
		else {
			return error(format_error_message('Unknown wire encryption plugin name: ${plugin}'))
		}
	}
}
```

With my proposed change, code looks cleaner and more consistent
```v
fn (mut c WireChannel) set_crypt_key(plugin string, session_key []u8, nonce []u8) ! {
	c.plugin = plugin
	match plugin {
		chacha20_64_plugin_name, chacha20_32_plugin_name {
			mut digest := sha256.new()
			digest.write(session_key)!
			key := digest.sum([]u8{})
			c.crypto_reader = chacha20.new_cipher(key, nonce)!
			c.crypto_writer = chacha20.new_cipher(key, nonce)!
		}
		rc4_plugin_name {
			c.crypto_reader =  rc4.new_cipher(session_key)!
			c.crypto_writer =  rc4.new_cipher(session_key)!
		}
		else {
			return error(format_error_message('Unknown wire encryption plugin name: ${plugin}'))
		}
	}
}
```