### PR TITLE
db.mysql: use mysql datatype for alloc string_binds_map, not orm's

### DIFF
--- a/vlib/db/mysql/mysql_orm_test.v
+++ b/vlib/db/mysql/mysql_orm_test.v
@@ -203,10 +203,9 @@ fn test_mysql_orm() {
 	}!
 
 	assert results[0].created_at == model.created_at
-	// TODO: investigate why these fail with V 0.4.0 11a8a46 , and fix them:
-	//	assert results[0].username == model.username
-	//	assert results[0].updated_at == model.updated_at
-	//	assert results[0].deleted_at == model.deleted_at
+	assert results[0].username == model.username
+	assert results[0].updated_at == model.updated_at
+	assert results[0].deleted_at == model.deleted_at
 
 	/** test default attribute
 	*/


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix the issue in `mysql_orm_test.v`.

for example:

```v
struct TestTimeType {
mut:
	id         int @[primary; sql: serial]
	username   string
	created_at time.Time @[sql_type: 'DATETIME']
	updated_at string    @[sql_type: 'DATETIME']
	deleted_at time.Time
}
```

The field `updated_at` has a orm type of `string`, but in mysql db, it is a `DATETIME`, and it should not use dynamically allocation.