### PR TITLE
add s390x assembly support + test

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -2640,7 +2640,7 @@ pub fn all_registers(mut t Table, arch pref.Arch) map[string]ScopeObject {
 		}
 		.s390x {
 			s390x := gen_all_registers(mut t, s390x_no_number_register_list, s390x_with_number_register_list,
-				 64)
+				64)
 			for k, v in s390x {
 				res[k] = v
 			}

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1826,6 +1826,13 @@ pub const riscv_with_number_register_list = {
 	'a#': 8
 }
 
+pub const s390x_no_number_register_list = []string{}
+pub const s390x_with_number_register_list = {
+	'f#': 16
+	'r#': 16
+	'v#': 32
+}
+
 pub struct DebuggerStmt {
 pub:
 	pos token.Pos
@@ -2628,6 +2635,13 @@ pub fn all_registers(mut t Table, arch pref.Arch) map[string]ScopeObject {
 			rv64 := gen_all_registers(mut t, riscv_no_number_register_list, riscv_with_number_register_list,
 				64)
 			for k, v in rv64 {
+				res[k] = v
+			}
+		}
+		.s390x {
+			s390x := gen_all_registers(mut t, s390x_no_number_register_list, s390x_with_number_register_list,
+				 64)
+			for k, v in s390x {
 				res[k] = v
 			}
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3166,7 +3166,8 @@ fn (mut g Gen) asm_stmt(stmt ast.AsmStmt) {
 			g.write(' ')
 		}
 		// swap destination and operands for att syntax, not for arm64
-		if template.args.len != 0 && !template.is_directive && stmt.arch != .arm64 {
+		if template.args.len != 0 && !template.is_directive && stmt.arch != .arm64
+			&& stmt.arch != .s390x {
 			template.args.prepend(template.args.last())
 			template.args.delete(template.args.len - 1)
 		}
@@ -3243,6 +3244,8 @@ fn (mut g Gen) asm_arg(arg ast.AsmArg, stmt ast.AsmStmt) {
 		ast.IntegerLiteral {
 			if stmt.arch == .arm64 {
 				g.write('#${arg.val}')
+			} else if stmt.arch == .s390x {
+				g.write('${arg.val}')
 			} else {
 				g.write('\$${arg.val}')
 			}

--- a/vlib/v/slow_tests/assembly/asm_test.s390x.v
+++ b/vlib/v/slow_tests/assembly/asm_test.s390x.v
@@ -1,0 +1,32 @@
+// vtest build: gcc
+fn test_inline_asm() {
+	a, mut b := 10, 0
+	asm s390x {
+		lgr r2, a
+		lgr b, r2
+		; +r (b)
+		; r (a)
+		; r2
+	}
+	assert a == b
+
+	mut c := 0
+	asm s390x {
+		lgfi c, 5
+		; +r (c)
+	}
+	assert c == 5
+
+	d, e, mut f := 10, 2, 0
+	asm s390x {
+		lgr f, d
+		ar f, e
+		ahi f, 5
+		; +r (f)
+		; r (d)
+		  r (e)
+	}
+	assert d == 10
+	assert e == 2
+	assert f == 17
+}


### PR DESCRIPTION
My attempt to add s390x assembly.

Highlights:

- Intel syntax
- I tried creating asm in C code and gcc only accepted integer literals as naked 5
- The test file is copied from a neighboring file. Not bad for a start