### PR TITLE
db.mysql: add null result support

### DIFF
--- a/vlib/db/mysql/mysql.c.v
+++ b/vlib/db/mysql/mysql.c.v
@@ -448,6 +448,7 @@ pub fn (stmt &StmtHandle) execute(params []string) ![]Row {
 			buffer:        param.str
 			buffer_length: u32(param.len)
 			length:        0
+			is_null:       0
 		}
 		bind_params << bind
 	}
@@ -470,6 +471,7 @@ pub fn (stmt &StmtHandle) execute(params []string) ![]Row {
 	}
 	num_cols := C.mysql_num_fields(query_metadata)
 	mut length := []u32{len: num_cols}
+	mut is_null := []bool{len: num_cols}
 
 	mut binds := []C.MYSQL_BIND{}
 	for i in 0 .. num_cols {
@@ -478,6 +480,7 @@ pub fn (stmt &StmtHandle) execute(params []string) ![]Row {
 			buffer:        0
 			buffer_length: 0
 			length:        unsafe { &length[i] }
+			is_null:       unsafe { &is_null[i] }
 		}
 		binds << bind
 	}

--- a/vlib/db/mysql/stmt.c.v
+++ b/vlib/db/mysql/stmt.c.v
@@ -13,6 +13,7 @@ mut:
 	buffer        voidptr
 	buffer_length u32
 	length        &u32
+	is_null       &bool
 }
 
 const mysql_type_decimal = C.MYSQL_TYPE_DECIMAL
@@ -250,6 +251,7 @@ pub fn (mut stmt Stmt) bind_null() {
 	stmt.binds << C.MYSQL_BIND{
 		buffer_type: mysql_type_null
 		length:      0
+		is_null:     0
 	}
 }
 
@@ -261,16 +263,18 @@ pub fn (mut stmt Stmt) bind(typ int, buffer voidptr, buf_len u32) {
 		buffer:        buffer
 		buffer_length: buf_len
 		length:        0
+		is_null:       0
 	}
 }
 
 // bind_res will store one result in the statement `stmt`
-pub fn (mut stmt Stmt) bind_res(fields &C.MYSQL_FIELD, dataptr []&u8, lengths []u32, num_fields int) {
+pub fn (mut stmt Stmt) bind_res(fields &C.MYSQL_FIELD, dataptr []&u8, lengths []u32, is_null []bool, num_fields int) {
 	for i in 0 .. num_fields {
 		stmt.res << C.MYSQL_BIND{
 			buffer_type: unsafe { fields[i].type }
 			buffer:      dataptr[i]
 			length:      &lengths[i]
+			is_null:     &is_null[i]
 		}
 	}
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #24130

This PR will check fetched field is `NULL` or not.
If the field is `NULL`, it will return `orm.Null{}` to `orm`, avoid use the old value stored in field.