### PR TITLE
fix wide tests for big_endian

### DIFF
--- a/vlib/builtin/utf8_test.v
+++ b/vlib/builtin/utf8_test.v
@@ -55,19 +55,31 @@ fn test_to_wide_cyrillic() {
 	}
 }
 
-const wide_serial_number = [u8(67), 0, 76, 0, 52, 0, 54, 0, 73, 0, 49, 0, 65, 0, 48, 0, 48, 0,
+const little_serial_number = [u8(67), 0, 76, 0, 52, 0, 54, 0, 73, 0, 49, 0, 65, 0, 48, 0, 48, 0,
+	54, 0, 52, 0, 57, 0, 0, 0, 0]
+const big_serial_number = [u8(0), 67, 0, 76, 0, 52, 0, 54, 0, 73, 0, 49, 0, 65, 0, 48, 0, 48, 0,
 	54, 0, 52, 0, 57, 0, 0, 0, 0]
 
 const swide_serial_number = 'CL46I1A00649'
 
 fn test_string_from_wide() {
-	z := unsafe { string_from_wide(wide_serial_number.data) }
-	assert z == swide_serial_number
+	$if little_endian {
+		z := unsafe { string_from_wide(little_serial_number.data) }
+		assert z == swide_serial_number
+	} $else {
+		z := unsafe { string_from_wide(big_serial_number.data) }
+		assert z == swide_serial_number
+	}
 }
 
 fn test_string_from_wide2() {
-	z := unsafe { string_from_wide2(wide_serial_number.data, 12) }
-	assert z == swide_serial_number
+	$if little_endian {
+		z := unsafe { string_from_wide2(little_serial_number.data, 12) }
+		assert z == swide_serial_number
+	} $else {
+		z := unsafe { string_from_wide2(big_serial_number.data, 12) }
+		assert z == swide_serial_number
+	}
 }
 
 fn test_reverse_cyrillic_with_string_from_wide() {

--- a/vlib/builtin/wchar/wchar_test.v
+++ b/vlib/builtin/wchar/wchar_test.v
@@ -1,9 +1,11 @@
 import builtin.wchar
 
-const wide_serial_number_unix = [u16(67), 0, 76, 0, 52, 0, 54, 0, 73, 0, 49, 0, 65, 0, 48, 0, 48,
+const little_serial_number = [u16(67), 0, 76, 0, 52, 0, 54, 0, 73, 0, 49, 0, 65, 0, 48, 0, 48,
+	0, 54, 0, 52, 0, 57, 0, 0, 0, 0]
+const big_serial_number = [u16(0), 67, 0, 76, 0, 52, 0, 54, 0, 73, 0, 49, 0, 65, 0, 48, 0, 48,
 	0, 54, 0, 52, 0, 57, 0, 0, 0, 0]
 
-const wide_serial_number_windows = wide_serial_number_unix.map(u8(it))
+const wide_serial_number_windows = little_serial_number.map(u8(it))
 
 const swide_serial_number = 'CL46I1A00649'
 
@@ -16,14 +18,20 @@ fn test_from_to_rune() {
 }
 
 fn test_to_string() {
-	mut p := voidptr(wide_serial_number_unix.data)
+	$if little_endian {
+		mut p := voidptr(little_serial_number.data)
+		assert unsafe { wchar.length_in_characters(p) } == swide_serial_number.len
+		s := unsafe { wchar.to_string(p) }
+		assert s == swide_serial_number
+	} $else {
+		mut p := voidptr(big_serial_number.data)
+		assert unsafe { wchar.length_in_characters(p) } == swide_serial_number.len
+		s := unsafe { wchar.to_string(p) }
+		assert s == swide_serial_number
+	}
 	$if windows {
 		p = wide_serial_number_windows.data
 	}
-	assert unsafe { wchar.length_in_characters(p) } == swide_serial_number.len
-	s := unsafe { wchar.to_string(p) }
-	dump(s)
-	assert s == swide_serial_number
 }
 
 fn test_from_string() {


### PR DESCRIPTION
My attempt fix tests for UTF16 in `vlib/builtin/` for big_endian system(s).
