### PR TITLE
ast: fix parse_cflag() support other flags between allowed_flags

### DIFF
--- a/vlib/v/ast/cflags.v
+++ b/vlib/v/ast/cflags.v
@@ -49,26 +49,15 @@ pub fn (mut t Table) parse_cflag(cflg string, mod string, ctimedefines []string)
 				}
 			}
 		}
-		mut index := flag.index(' -') or { -1 }
-		for index > -1 {
-			mut has_next := false
-			for f in allowed_flags {
-				i := index + 2 + f.len
-				if i <= flag.len && f == flag[index + 2..i] {
-					value = flag[..index + 1].trim_space()
-					flag = flag[index + 1..].trim_space()
-					has_next = true
-					break
-				}
-			}
-			if has_next {
-				break
-			}
-			index = flag.index_after(' -', index + 1) or { -1 }
+		// -I/usr/local/include -m64 -I/usr/include
+		index := flag.index(' ') or { -1 }
+		if index > -1 {
+			value = flag[..index].trim_space()
+			flag = flag[index..].trim_space()
+		} else {
+			value = flag
 		}
-		if index == -1 {
-			value = flag.trim_space()
-		}
+
 		if name in ['-I', '-l', '-L'] && value == '' {
 			hint := if name == '-l' { 'library name' } else { 'path' }
 			return error('bad #flag `${flag_orig}`: missing ${hint} after `${name}`')

--- a/vlib/v/ast/cflags.v
+++ b/vlib/v/ast/cflags.v
@@ -49,8 +49,8 @@ pub fn (mut t Table) parse_cflag(cflg string, mod string, ctimedefines []string)
 				}
 			}
 		}
-		// -I/usr/local/include -m64 -I/usr/include
-		index := flag.index(' ') or { -1 }
+		// -I/usr/local/a b c/include -m64 -I/usr/include
+		index := flag.index(' -') or { -1 }
 		if index > -1 {
 			value = flag[..index].trim_space()
 			flag = flag[index..].trim_space()

--- a/vlib/v/ast/cflags_test.v
+++ b/vlib/v/ast/cflags_test.v
@@ -26,6 +26,7 @@ fn test_parse_valid_cflags() {
 		make_flag(no_os, no_name, '-m64'),
 		make_flag(no_os, '-I', '/usr/include'),
 		make_flag(no_os, no_name, '/v/thirdparty/tcc/lib/libgc.a'),
+		make_flag(no_os, '-I', '/usr/include/你好 my , @с интервали'),
 	]
 	parse_valid_flag(mut t, '-lmysqlclient')
 	parse_valid_flag(mut t, '-test')
@@ -38,6 +39,7 @@ fn test_parse_valid_cflags() {
 	parse_valid_flag(mut t, 'linux -I/usr/include/SDL2 -D_REENTRANT -L/usr/lib/x86_64-linux-gnu -lSDL2')
 	parse_valid_flag(mut t, '-I/usr/include/mysql -m64 -I/usr/include')
 	parse_valid_flag(mut t, '/v/thirdparty/tcc/lib/libgc.a')
+	parse_valid_flag(mut t, '-I/usr/include/你好 my , @с интервали')
 	assert t.cflags.len == expected_flags.len
 	for f in expected_flags {
 		assert t.has_cflag(f)

--- a/vlib/v/ast/cflags_test.v
+++ b/vlib/v/ast/cflags_test.v
@@ -22,6 +22,10 @@ fn test_parse_valid_cflags() {
 		make_flag('linux', '-D', '_REENTRANT'),
 		make_flag('linux', '-L', '/usr/lib/x86_64-linux-gnu'),
 		make_flag('linux', '-l', 'SDL2'),
+		make_flag(no_os, '-I', '/usr/include/mysql'),
+		make_flag(no_os, no_name, '-m64'),
+		make_flag(no_os, '-I', '/usr/include'),
+		make_flag(no_os, no_name, '/v/thirdparty/tcc/lib/libgc.a'),
 	]
 	parse_valid_flag(mut t, '-lmysqlclient')
 	parse_valid_flag(mut t, '-test')
@@ -32,6 +36,8 @@ fn test_parse_valid_cflags() {
 	parse_valid_flag(mut t, 'solaris -L/opt/local/lib')
 	parse_valid_flag(mut t, 'windows -lgdi32')
 	parse_valid_flag(mut t, 'linux -I/usr/include/SDL2 -D_REENTRANT -L/usr/lib/x86_64-linux-gnu -lSDL2')
+	parse_valid_flag(mut t, '-I/usr/include/mysql -m64 -I/usr/include')
+	parse_valid_flag(mut t, '/v/thirdparty/tcc/lib/libgc.a')
 	assert t.cflags.len == expected_flags.len
 	for f in expected_flags {
 		assert t.has_cflag(f)


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #24121
Parse cflags like '-I/usr/include/mysql -m64 -I/usr/include', if the first flag is in `allowed_flags`, it will treat all before next `allowed_flags` as a value, which is not correct. The old code will create `name=-I`, `value=/usr/include/mysql -m64`.