### PR TITLE
encoding.iconv: add path to libiconv on termux

### DIFF
--- a/vlib/encoding/iconv/iconv_nix.c.v
+++ b/vlib/encoding/iconv/iconv_nix.c.v
@@ -8,6 +8,7 @@ module iconv
 
 #flag darwin -liconv
 #flag openbsd -L/usr/local/lib -liconv
+#flag termux -L/data/data/com.termux/files/usr/lib -liconv
 
 fn C.iconv_open(tocode charptr, fromcode charptr) voidptr
 fn C.iconv_close(cd voidptr) int


### PR DESCRIPTION
This PR fixes `encoding.iconv` on termux.

Before:

```
$ v doctor
cannot compile `/data/data/com.termux/files/home/.vlang/cmd/tools/vdoctor.v`: 1
ld.lld: error: undefined symbol: libiconv_open
>>> referenced by iconv_nix.c.v:42 (vlib/encoding/iconv/iconv_nix.c.v:42)
>>>               /data/data/com.termux/files/usr/tmp/vdoctor-72962e.o:(encoding__iconv__conv)

ld.lld: error: undefined symbol: libiconv
>>> referenced by iconv_nix.c.v:54 (vlib/encoding/iconv/iconv_nix.c.v:54)
>>>               /data/data/com.termux/files/usr/tmp/vdoctor-72962e.o:(encoding__iconv__conv)

ld.lld: error: undefined symbol: libiconv_close
>>> referenced by iconv_nix.c.v:46 (vlib/encoding/iconv/iconv_nix.c.v:46)
>>>               /data/data/com.termux/files/usr/tmp/vdoctor-72962e.o:(encoding__iconv__conv)
>>> referenced by iconv_nix.c.v:46 (vlib/encoding/iconv/iconv_nix.c.v:46)
>>>               /data/data/com.termux/files/usr/tmp/vdoctor-72962e.o:(encoding__iconv__conv)
cc: error: linker command failed with exit code 1 (use -v to see invocation)
builder error:
==================
C error found. It should never happen, when compiling pure V code.
This is a V compiler bug, please report it using `v bug file.v`,
or goto https://github.com/vlang/v/issues/new/choose .
You can also use #help on Discord: https://discord.gg/vlang .
```

After:

```
$ v doctor
|V full version      |V 0.4.10 ea8ae7b.071ab6c
|:-------------------|:-------------------
|OS                  |termux, 5.4.86-qgki-g3f7d4a87bcc6-dirty, #1 SMP PREEMPT Thu Mar 13 19:42:31 CST 2025
|Processor           |8 cpus, 64bit, little endian
|Memory              |9.3e-10GB/7.48GB
|                    |
|V executable        |/data/data/com.termux/files/home/.vlang/v
|V last modified time|2025-04-06 14:52:41
|                    |
|V home dir          |OK, value: /data/data/com.termux/files/home/.vlang
|VMODULES            |OK, value: /data/data/com.termux/files/home/.vmodules
|VTMP                |OK, value: /data/data/com.termux/files/usr/tmp/v_10191
|Current working dir |OK, value: /data/data/com.termux/files/home/.vlang/cmd/tools
|                    |
|Git version         |git version 2.49.0
|V git status        |weekly.2025.14-16-g071ab6c3-dirty
|.git/config present |true
|                    |
|cc version          |clang version 20.1.2
|gcc version         |clang version 20.1.2
|clang version       |clang version 20.1.2
|tcc version         |N/A
|tcc git status      |thirdparty-unknown-unknown de82a130
|emcc version        |N/A
|glibc version       |readelf: Error: 'readlink (GNU coreutils) 9.6
```