### PR TITLE
sync: remove pthread_rwlockattr_setpshared

### DIFF
--- a/vlib/sync/sync_darwin.c.v
+++ b/vlib/sync/sync_darwin.c.v
@@ -17,7 +17,6 @@ fn C.pthread_mutex_unlock(voidptr) int
 fn C.pthread_mutex_destroy(voidptr) int
 fn C.pthread_rwlockattr_init(voidptr) int
 fn C.pthread_rwlockattr_setkind_np(voidptr, int) int
-fn C.pthread_rwlockattr_setpshared(voidptr, int) int
 fn C.pthread_rwlock_init(voidptr, voidptr) int
 fn C.pthread_rwlock_rdlock(voidptr) int
 fn C.pthread_rwlock_wrlock(voidptr) int
@@ -110,7 +109,6 @@ pub fn (mut m RwMutex) init() {
 	should_be_zero(C.pthread_rwlockattr_init(&a.attr))
 	// Give writer priority over readers
 	C.pthread_rwlockattr_setkind_np(&a.attr, C.PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP)
-	C.pthread_rwlockattr_setpshared(&a.attr, C.PTHREAD_PROCESS_PRIVATE)
 	should_be_zero(C.pthread_rwlock_init(&m.mutex, &a.attr))
 }
 

--- a/vlib/sync/sync_default.c.v
+++ b/vlib/sync/sync_default.c.v
@@ -21,7 +21,6 @@ fn C.pthread_mutex_unlock(voidptr) int
 fn C.pthread_mutex_destroy(voidptr) int
 fn C.pthread_rwlockattr_init(voidptr) int
 fn C.pthread_rwlockattr_setkind_np(voidptr, int) int
-fn C.pthread_rwlockattr_setpshared(voidptr, int) int
 fn C.pthread_rwlockattr_destroy(voidptr) int
 fn C.pthread_rwlock_init(voidptr, voidptr) int
 fn C.pthread_rwlock_rdlock(voidptr) int
@@ -97,7 +96,6 @@ pub fn (mut m RwMutex) init() {
 	C.pthread_rwlockattr_init(&a.attr)
 	// Give writer priority over readers
 	C.pthread_rwlockattr_setkind_np(&a.attr, C.PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP)
-	C.pthread_rwlockattr_setpshared(&a.attr, C.PTHREAD_PROCESS_PRIVATE)
 	C.pthread_rwlock_init(&m.mutex, &a.attr)
 	C.pthread_rwlockattr_destroy(&a.attr) // destroy the attr when done
 }

--- a/vlib/sync/sync_freebsd.c.v
+++ b/vlib/sync/sync_freebsd.c.v
@@ -21,7 +21,6 @@ fn C.pthread_mutex_unlock(voidptr) int
 fn C.pthread_mutex_destroy(voidptr) int
 fn C.pthread_rwlockattr_init(voidptr) int
 fn C.pthread_rwlockattr_setkind_np(voidptr, int) int
-fn C.pthread_rwlockattr_setpshared(voidptr, int) int
 fn C.pthread_rwlockattr_destroy(voidptr) int
 fn C.pthread_rwlock_init(voidptr, voidptr) int
 fn C.pthread_rwlock_rdlock(voidptr) int
@@ -95,7 +94,6 @@ pub fn (mut m RwMutex) init() {
 	C.pthread_rwlockattr_init(&a.attr)
 	// Give writer priority over readers
 	C.pthread_rwlockattr_setkind_np(&a.attr, C.PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP)
-	C.pthread_rwlockattr_setpshared(&a.attr, C.PTHREAD_PROCESS_PRIVATE)
 	C.pthread_rwlock_init(&m.mutex, &a.attr)
 	C.pthread_rwlockattr_destroy(&a.attr) // destroy the attr when done
 }


### PR DESCRIPTION
During the porting of `vlang` to `NetBSD`, it was discovered that `pthread_rwlockattr_setpshared()` is hidden, and `PTHREAD_PROCESS_PRIVATE` is actually the default value in all systems.
Let's remove it completely and save `NetBSD`.

[FreeBSD 14](https://man.freebsd.org/cgi/man.cgi?query=pthread_rwlockattr_setpshared&apropos=0&sektion=3&manpath=FreeBSD+14.2-RELEASE&arch=default&format=ascii)
[MacOS 15](https://man.freebsd.org/cgi/man.cgi?query=pthread_rwlockattr_setpshared&apropos=0&sektion=3&manpath=macOS+15.0&arch=default&format=ascii)
[POSIX](https://linux.die.net/man/3/pthread_rwlockattr_setpshared)
[GNU Lib](https://www.gnu.org/software/gnulib/manual/html_node/pthread_005frwlockattr_005fsetpshared.html)