### PR TITLE
orm: fix option field with default null value

### DIFF
--- a/vlib/orm/orm_func.v
+++ b/vlib/orm/orm_func.v
@@ -434,8 +434,7 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 
 				$if field.typ is $option {
 					if value == Primitive(Null{}) {
-						// ?? we can set any type of option field = ?i16(none)???
-						instance.$(field.name) = ?i16(none)
+						instance.$(field.name) = none
 					}
 				}
 				if value != Primitive(Null{}) {

--- a/vlib/orm/orm_func.v
+++ b/vlib/orm/orm_func.v
@@ -432,9 +432,13 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 			if index >= 0 {
 				value := row[index]
 
-				if value == Primitive(Null{}) {
-					// set to none by default
-				} else {
+				$if field.typ is $option {
+					if value == Primitive(Null{}) {
+						// ?? we can set any type of option field = ?i16(none)???
+						instance.$(field.name) = ?i16(none)
+					}
+				}
+				if value != Primitive(Null{}) {
 					$if field.typ is i8 || field.typ is ?i8 {
 						instance.$(field.name) = match value {
 							i8 { i8(value) }

--- a/vlib/orm/orm_func_test.v
+++ b/vlib/orm/orm_func_test.v
@@ -45,10 +45,12 @@ struct User {
 // a `null` value in database, will map to default value of the require field in struct
 @[table: 'sys_users']
 struct UserPart {
-	id         int @[primary; serial]
-	name       string
-	created_at time.Time @[sql_type: 'TIMESTAMP']
-	updated_at time.Time @[sql_type: 'TIMESTAMP']
+	id            int @[primary; serial]
+	name          string
+	created_at    time.Time @[sql_type: 'TIMESTAMP']
+	updated_at    time.Time @[sql_type: 'TIMESTAMP']
+	option_i8     ?i8     = 13 // option with default test
+	option_string ?string = 'this is not none'
 }
 
 fn test_orm_func_where() {
@@ -232,38 +234,38 @@ fn test_orm_func_stmts() {
 			option_string: 'hello'
 		},
 		User{
-			name:          'Silly'
-			age:           27
-			role:          'employer'
-			status:        5
-			salary:        2500
-			title:         'doctor'
-			score:         81
-			updated_at:    time.now()
-			type_i8:       1
-			type_i16:      2
-			type_int:      3
-			type_i64:      4
-			type_u8:       5
-			type_u16:      6
-			type_u32:      7
-			type_u64:      8
-			type_f32:      1.1
-			type_f64:      2.2
-			type_bool:     true
-			type_string:   'hello'
-			option_i8:     1
-			option_i16:    2
-			option_int:    3
-			option_i64:    4
-			option_u8:     5
-			option_u16:    6
-			option_u32:    7
-			option_u64:    8
-			option_f32:    1.1
-			option_f64:    2.2
-			option_bool:   true
-			option_string: 'hello'
+			name:        'Silly'
+			age:         27
+			role:        'employer'
+			status:      5
+			salary:      2500
+			title:       'doctor'
+			score:       81
+			updated_at:  time.now()
+			type_i8:     1
+			type_i16:    2
+			type_int:    3
+			type_i64:    4
+			type_u8:     5
+			type_u16:    6
+			type_u32:    7
+			type_u64:    8
+			type_f32:    1.1
+			type_f64:    2.2
+			type_bool:   true
+			type_string: 'hello'
+			option_i8:   1
+			option_i16:  2
+			option_int:  3
+			option_i64:  4
+			option_u8:   5
+			option_u16:  6
+			option_u32:  7
+			option_u64:  8
+			option_f32:  1.1
+			option_f64:  2.2
+			option_bool: true
+			// option_string: 'hello'	// option with default test
 		},
 		User{
 			name:          'Smith'
@@ -336,28 +338,28 @@ fn test_orm_func_stmts() {
 			option_string: 'hello'
 		},
 		User{
-			name:          'Peter'
-			age:           29
-			role:          'employer'
-			status:        1
-			salary:        3500
-			title:         'doctor'
-			score:         80
-			created_at:    time.now()
-			updated_at:    time.now()
-			type_i8:       1
-			type_i16:      2
-			type_int:      3
-			type_i64:      4
-			type_u8:       5
-			type_u16:      6
-			type_u32:      7
-			type_u64:      8
-			type_f32:      1.1
-			type_f64:      2.2
-			type_bool:     true
-			type_string:   'hello'
-			option_i8:     1
+			name:        'Peter'
+			age:         29
+			role:        'employer'
+			status:      1
+			salary:      3500
+			title:       'doctor'
+			score:       80
+			created_at:  time.now()
+			updated_at:  time.now()
+			type_i8:     1
+			type_i16:    2
+			type_int:    3
+			type_i64:    4
+			type_u8:     5
+			type_u16:    6
+			type_u32:    7
+			type_u64:    8
+			type_f32:    1.1
+			type_f64:    2.2
+			type_bool:   true
+			type_string: 'hello'
+			// option_i8:     1	// option with default test
 			option_i16:    2
 			option_int:    3
 			option_i64:    4


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR fix PR #24222

For struct option fields with default values, a `null` in database field should update the struct's field to `none`, not it's default value.

```v
@[table: 'sys_users']
struct UserPart {
	id         int @[primary; serial]
	name       string
	created_at time.Time @[sql_type: 'TIMESTAMP']
	updated_at time.Time @[sql_type: 'TIMESTAMP']
	option_i8	?i8 = 13		// option with default test
	option_string ?string = 'this is not none'
}
```

for example, if database field `option_i8`, `option_string` are `null`, then these fields should set to `none`, not their default values.