### PR TITLE
doc: remove only reference to `any`  from docs

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -531,8 +531,6 @@ f32 f64
 isize, usize // platform-dependent, the size is how many bytes it takes to reference any location in memory
 
 voidptr // this one is mostly used for [C interoperability](#v-and-c)
-
-any // similar to C's void* and Go's interface{}
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Step 1 for removing `any` from V.