### PR TITLE
now musl have gettid()

### DIFF
--- a/vlib/v/tests/trace_calls_test.v
+++ b/vlib/v/tests/trace_calls_test.v
@@ -1,3 +1,4 @@
+// vtest build: !(os_id_ubuntu? && musl?)
 import os
 
 const vexe = @VEXE

--- a/vlib/v/trace_calls/tracing_calls_d_musl.v
+++ b/vlib/v/trace_calls/tracing_calls_d_musl.v
@@ -1,8 +1,0 @@
-module trace_calls
-
-// gettid is missing on musl/alpine, but present on most everything else
-@[export: 'gettid']
-@[weak]
-fn vgettid() &u32 {
-	return 0
-}


### PR DESCRIPTION
Latest supported `Alpine Linux` version is 3.18.12, it have `gettid()` in manual pages.
Now test is broken, lets make it work. Tested on latest 3.21.3

```
94cc75377785:~/v/vlib# ../v test v/tests/trace_calls_test.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 FAIL  5033.210 ms /root/v/vlib/v/tests/trace_calls_test.v
> trace_fns_only_println compilation output:
================== C compilation error (from cc): ==============
cc: /tmp/v_0/tsession_4002904cc0_01JRYX8ABNH5HRE009SG5GQZVM/single_println.01JRYX8FW0CN09699MYB2GPFW8.tmp.c:2120:31: error: conflicting types for 'gettid'; have 'u32 *(void)' {aka 'unsigned int *(void)'}
cc:  2120 | VV_EXPORTED_SYMBOL VWEAK u32* gettid(void); // exported fn v.trace_calls.vgettid
cc:       |                               ^~~~~~
cc: In file included from /usr/include/fortify/unistd.h:23,
cc:                  from /tmp/v_0/tsession_4002904cc0_01JRYX8ABNH5HRE009SG5GQZVM/single_println.01JRYX8FW0CN09699MYB2GPFW8.tmp.c:507:
cc: /usr/include/unistd.h:198:7: note: previous declaration of 'gettid' with type 'pid_t(void)' {aka 'int(void)'}
cc:   198 | pid_t gettid(void);
cc:       |       ^~~~~~
cc: /tmp/v_0/tsession_4002904cc0_01JRYX8ABNH5HRE009SG5GQZVM/single_println.01JRYX8FW0CN09699MYB2GPFW8.tmp.c: In function 'v__trace_calls__on_call':
cc: /tmp/v_0/tsession_4002904cc0_01JRYX8ABNH5HRE009SG5GQZVM/single_println.01JRYX8FW0CN09699MYB2GPFW8.tmp.c:14527:29: warning: assignment to 'u32' {aka 'unsigned int'} from 'u32 *' {aka 'unsigned int *'} makes integer from pointer without a cast [-Wint-conversion]
cc: 14527 |                         tid = gettid();
cc:       |                             ^
...
cc:       |       ^~~~~~
(note: the original output was 19 lines long; it was truncated to its first 12 lines + the last line)
================================================================
(You can pass `-cg`, or `-show-c-output` as well, to print all the C error messages).
builder error:
==================
C error found. It should never happen, when compiling pure V code.
This is a V compiler bug, please report it using `v bug file.v`,
or goto https://github.com/vlang/v/issues/new/choose .
You can also use #help on Discord: https://discord.gg/vlang .

/root/v/vlib/v/tests/trace_calls_test.v:55: fn run
   > assert res.exit_code == 0, 'compilation of $fpath failed'
     Left value (len: 1): `1`
    Right value (len: 1): `0`
        Message: compilation of vlib/v/tests/testdata/trace_calls/single_println.vv failed

> 64bit compilation output:
================== C compilation error (from cc): ==============
cc: /tmp/v_0/tsession_4002904cc0_01JRYX8ABNH5HRE009SG5GQZVM/single_println.01JRYX8JEMC71Y50G8HM1EHM6M.tmp.c:2120:31: error: conflicting types for 'gettid'; have 'u32 *(void)' {aka 'unsigned int *(void)'}
cc:  2120 | VV_EXPORTED_SYMBOL VWEAK u32* gettid(void); // exported fn v.trace_calls.vgettid
cc:       |                               ^~~~~~
cc: In file included from /usr/include/fortify/unistd.h:23,
cc:                  from /tmp/v_0/tsession_4002904cc0_01JRYX8ABNH5HRE009SG5GQZVM/single_println.01JRYX8JEMC71Y50G8HM1EHM6M.tmp.c:507:
cc: /usr/include/unistd.h:198:7: note: previous declaration of 'gettid' with type 'pid_t(void)' {aka 'int(void)'}
cc:   198 | pid_t gettid(void);
cc:       |       ^~~~~~
cc: /tmp/v_0/tsession_4002904cc0_01JRYX8ABNH5HRE009SG5GQZVM/single_println.01JRYX8JEMC71Y50G8HM1EHM6M.tmp.c: In function 'v__trace_calls__on_call':
cc: /tmp/v_0/tsession_4002904cc0_01JRYX8ABNH5HRE009SG5GQZVM/single_println.01JRYX8JEMC71Y50G8HM1EHM6M.tmp.c:15212:29: warning: assignment to 'u32' {aka 'unsigned int'} from 'u32 *' {aka 'unsigned int *'} makes integer from pointer without a cast [-Wint-conversion]
cc: 15212 |                         tid = gettid();
cc:       |                             ^
...
cc:       |       ^~~~~~
(note: the original output was 19 lines long; it was truncated to its first 12 lines + the last line)
================================================================
(You can pass `-cg`, or `-show-c-output` as well, to print all the C error messages).
builder error:
==================
C error found. It should never happen, when compiling pure V code.
This is a V compiler bug, please report it using `v bug file.v`,
or goto https://github.com/vlang/v/issues/new/choose .
You can also use #help on Discord: https://discord.gg/vlang .

/root/v/vlib/v/tests/trace_calls_test.v:55: fn run
   > assert res.exit_code == 0, 'compilation of $fpath failed'
     Left value (len: 1): `1`
    Right value (len: 1): `0`
        Message: compilation of vlib/v/tests/testdata/trace_calls/single_println.vv failed
--------------------------------------------------------------------------------------------------------------------------------------------
To reproduce just failure 1 run:    '/root/v/v'  '/root/v/vlib/v/tests/trace_calls_test.v'
Summary for all V _test.v files: 1 failed, 1 total. Elapsed time: 10533 ms, on 1 job. Comptime: 5474 ms. Runtime: 5031 ms.
```