### PR TITLE
orm: add or_where() method to the builder

### DIFF
--- a/vlib/orm/orm_func.v
+++ b/vlib/orm/orm_func.v
@@ -43,12 +43,28 @@ pub fn (qb_ &QueryBuilder[T]) reset() &QueryBuilder[T] {
 	return qb
 }
 
-// where create a `where` clause
+// where create a `where` clause, it will `AND` with previous `where` clause.
 // valid token in the `condition` include: `field's names`, `operator`, `(`, `)`, `?`, `AND`, `OR`, `||`, `&&`,
 // valid `operator` incldue: `=`, `!=`, `<>`, `>=`, `<=`, `>`, `<`, `LIKE`, `ILIKE`, `IS NULL`, `IS NOT NULL`
 // example: `where('(a > ? AND b <= ?) OR (c <> ? AND (x = ? OR y = ?))', a, b, c, x, y)`
 pub fn (qb_ &QueryBuilder[T]) where(condition string, params ...Primitive) !&QueryBuilder[T] {
 	mut qb := unsafe { qb_ }
+	if qb.where.fields.len > 0 {
+		// skip first field
+		qb.where.is_and << true // and
+	}
+	qb.parse_conditions(condition, params)!
+	qb.config.has_where = true
+	return qb
+}
+
+// or_where create a `where` clause, it will `OR` with previous `where` clause.
+pub fn (qb_ &QueryBuilder[T]) or_where(condition string, params ...Primitive) !&QueryBuilder[T] {
+	mut qb := unsafe { qb_ }
+	if qb.where.fields.len > 0 {
+		// skip first field
+		qb.where.is_and << false // or
+	}
 	qb.parse_conditions(condition, params)!
 	qb.config.has_where = true
 	return qb

--- a/vlib/orm/orm_func_test.v
+++ b/vlib/orm/orm_func_test.v
@@ -496,6 +496,12 @@ fn test_orm_func_stmts() {
 	assert selected_users[0].name == 'Silly'
 	assert selected_users.len == 1
 
+	// chain where
+	and_where := qb.where('salary > ?', 2000)!.where('age > ?', 40)!.query()!
+	assert and_where.len == 1
+	or_where := qb.where('salary > ?', 2000)!.or_where('age > ? OR score > ?', 40, 85)!.query()!
+	assert or_where.len == 9
+
 	// chain calls
 	final_users := qb
 		.drop()!


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

1. Fix issue #24244
2. Add `or_where()` help create an or where clause.