### PR TITLE
v.util.version: fix output when VCURRENTHASH not defined

### DIFF
--- a/vlib/v/util/version/version.v
+++ b/vlib/v/util/version/version.v
@@ -6,7 +6,7 @@ pub const v_version = '0.4.10'
 
 pub fn full_hash() string {
 	build_hash := vhash()
-	if build_hash == vcurrent_hash() {
+	if vcurrent_hash() == '' || build_hash == vcurrent_hash() {
 		return build_hash
 	}
 	return '${build_hash}.${vcurrent_hash()}'


### PR DESCRIPTION
Fix vlang/v#24263

**Tests OK on Linux Debian/testing**

- build from Git repository commit 11e25bc9ea30ffde14bcd51d79ced465e3dcb4e2 (`VCURRENTHASH` defined)

```sh
$ git clone https://github.com/vlang/v
$ cd v
$ make
(...)

$ ./v version
V 0.4.10 11e25bc
$ ./v -v version
V 0.4.10 11e25bc9ea30ffde14bcd51d79ced465e3dcb4e2.11e25bc
```

- build from 0.4.10 sources (`VCURRENTHASH` not defined)
```sh
# Download packaged sources for V 0.4.10 and vc commit 66ea39be2275ac723225b9ca99d51ec1212c640d
$ wget https://github.com/vlang/v/archive/refs/tags/0.4.10.tar.gz -O v-0.4.10.tar.gz
$ wget https://github.com/vlang/vc/archive/66ea39be2275ac723225b9ca99d51ec1212c640d.tar.gz -O vc-66ea39be2275ac723225b9ca99d51ec1212c640d.tar.gz

# Extract sources for V 0.4.10
$ tar xzvf v-0.4.10.tar.gz
$ tar xzvf vc-66ea39be2275ac723225b9ca99d51ec1212c640d.tar.gz

$ cd v-0.4.10
$ mv ../vc-66ea39be2275ac723225b9ca99d51ec1212c640d ./vc

# Build with local sources + patch from this PR
$ make local=1 prod=1
(...)

# Output for V version
$ ./v version
V 0.4.10
$ ./v -v version
V 0.4.10 9b1937a87166e3327497f332bf9584ff90592617
```

**Tests OK on OpenBSD current/amd64**

- build from Git repository commit 11e25bc9ea30ffde14bcd51d79ced465e3dcb4e2 (`VCURRENTHASH` defined)

```sh
$ ./v -v version
V 0.4.10 11e25bc9ea30ffde14bcd51d79ced465e3dcb4e2.11e25bc
```

- build from 0.4.10 sources (`VCURRENTHASH` not defined) to package V on OpenBSD

```sh
$ ./v -v version
V 0.4.10 9b1937a87166e3327497f332bf9584ff90592617
```