### PR TITLE
log: add local time / utc time selection support

### DIFF
--- a/vlib/log/log.v
+++ b/vlib/log/log.v
@@ -38,6 +38,7 @@ mut:
 	time_format        TimeFormat = .tf_rfc3339_micro
 	custom_time_format string     = 'MMMM Do YY N kk:mm:ss A' // timestamp with custom format
 	short_tag          bool
+	local_time         bool // use local time or utc time in log
 	always_flush       bool // flush after every single .fatal(), .error(), .warn(), .info(), .debug() call
 	output_stream      io.Writer = stderr
 pub mut:
@@ -119,7 +120,7 @@ pub fn (mut l Log) reopen() ! {
 
 // log_file writes log line `s` with `level` to the log file.
 fn (mut l Log) log_file(s string, level Level) {
-	timestamp := l.time_format(time.utc())
+	timestamp := l.time_format(if l.local_time { time.now() } else { time.utc() })
 	e := tag_to_file(level, l.short_tag)
 
 	unsafe {
@@ -142,7 +143,7 @@ fn (mut l Log) log_file(s string, level Level) {
 
 // log_stream writes log line `s` with `level` to stderr or stderr depending on set output stream.
 fn (mut l Log) log_stream(s string, level Level) {
-	timestamp := l.time_format(time.utc())
+	timestamp := l.time_format(if l.local_time { time.now() } else { time.utc() })
 	tag := tag_to_console(level, l.short_tag)
 	msg := '${timestamp} [${tag}] ${s}\n'
 	arr := msg.bytes()
@@ -311,6 +312,16 @@ pub fn (mut l Log) set_short_tag(enabled bool) {
 // get_short_tag will get the log short tag enable state
 pub fn (l Log) get_short_tag() bool {
 	return l.short_tag
+}
+
+// set_local_time will set the log using local time
+pub fn (mut l Log) set_local_time(enabled bool) {
+	l.local_time = enabled
+}
+
+// get_local_time will get the log using local time state
+pub fn (l Log) get_local_time() bool {
+	return l.local_time
 }
 
 // use_stdout will restore the old behaviour of logging to stdout, instead of stderr.

--- a/vlib/log/log_test.v
+++ b/vlib/log/log_test.v
@@ -141,7 +141,6 @@ fn test_log_time_format() {
 	l.set_local_time(false)
 	l.info('${@FN} time log in utc time')
 	assert !l.get_local_time()
-	assert false
 	println(@FN + ' end')
 }
 

--- a/vlib/log/log_test.v
+++ b/vlib/log/log_test.v
@@ -134,6 +134,14 @@ fn test_log_time_format() {
 	assert TimeFormat.tf_custom_format == l.get_time_format()
 	l.info('${@FN} custom like January 1st 22 AD 13:45:33 PM')
 	assert true
+	l.set_time_format(.tf_default)
+	l.set_local_time(true)
+	l.info('${@FN} time log in local time')
+	assert l.get_local_time()
+	l.set_local_time(false)
+	l.info('${@FN} time log in utc time')
+	assert !l.get_local_time()
+	assert false
 	println(@FN + ' end')
 }
 


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR enable `log` to set log time in local time or utc time(default).

ll.v

```v
module main

import log

fn main() {
        mut l := log.Log{}

        l.set_time_format(.tf_default)
        l.info('utc time')

        l.set_local_time(true)
        l.info('local time')
}
```

run :

```
$ ./ll
2025-04-19 06:47 [INFO ] utc time
2025-04-19 14:47 [INFO ] local time
```