### PR TITLE
cgen: fix codegen for fixed array init with init using structinit

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -180,12 +180,19 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 				g.add_commas_and_prevent_long_lines(i, info.size)
 			}
 		} else {
-			before_expr_pos := g.out.len
-			{
-				g.expr_with_init(node)
+			if g.table.final_sym(info.elem_type).kind in [.struct, .interface] {
+				for i in 0 .. info.size {
+					g.expr_with_init(node)
+					g.add_commas_and_prevent_long_lines(i, info.size)
+				}
+			} else {
+				before_expr_pos := g.out.len
+				{
+					g.expr_with_init(node)
+				}
+				sexpr := g.out.cut_to(before_expr_pos)
+				g.write_c99_elements_for_array(info.size, sexpr)
 			}
-			sexpr := g.out.cut_to(before_expr_pos)
-			g.write_c99_elements_for_array(info.size, sexpr)
 		}
 	} else if is_amp {
 		g.write('0')

--- a/vlib/v/tests/fixed_array_init_with_init_test.v
+++ b/vlib/v/tests/fixed_array_init_with_init_test.v
@@ -1,0 +1,20 @@
+struct Structure1 {
+	world [2]Structure2
+}
+
+struct Structure2 {
+	liste []Structure3
+}
+
+struct Structure3 {
+	coo []int
+}
+
+fn test_main() {
+	app := Structure1{
+		world: [2]Structure2{init: Structure2{
+			liste: []Structure3{len: 1, init: Structure3{}}
+		}}
+	}
+	assert app.world.len == 2
+}


### PR DESCRIPTION
Fix #24253