### PR TITLE
parser: fix range expr precedence on compound logical and operator

### DIFF
--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -804,7 +804,7 @@ fn (mut p Parser) infix_expr(left ast.Expr) ast.Expr {
 			right = ast.RangeExpr{
 				low:      right
 				has_low:  true
-				high:     p.expr(0)
+				high:     p.expr(int(token.Precedence.in_as))
 				has_high: true
 				pos:      pos_high
 				is_gated: false

--- a/vlib/v/tests/range_expr_logical_and_test.v
+++ b/vlib/v/tests/range_expr_logical_and_test.v
@@ -1,0 +1,14 @@
+module main
+
+fn bang(a int, b int) int {
+	if a in 0..9 && b in 0..9 {
+		return a + b
+	} else {
+		return 0
+	}
+}
+
+fn test_main() {
+	assert bang(1, 2) == 3
+	assert bang(10, 1) == 0
+}


### PR DESCRIPTION
Fix #24252