### PR TITLE
cgen: fix missing braces for const init with castexpr from option unwrapping expr

### DIFF
--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -129,7 +129,9 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 							continue
 						}
 					}
-					g.const_decl_init_later(field.mod, name, field.expr, field.typ, false)
+					should_surround := field.expr.expr is ast.CallExpr
+						&& field.expr.expr.or_block.kind != .absent
+					g.const_decl_init_later(field.mod, name, field.expr, field.typ, should_surround)
 				} else if field.expr is ast.InfixExpr {
 					mut has_unwrap_opt_res := false
 					if field.expr.left is ast.CallExpr {

--- a/vlib/v/gen/c/testdata/const_init_or_block.c.must_have
+++ b/vlib/v/gen/c/testdata/const_init_or_block.c.must_have
@@ -1,0 +1,11 @@
+{
+_option_bool _t2 = main__t1();
+if (_t2.state != 0) {
+IError err = _t2.err;
+_v_panic(IError_str(err));
+VUNREACHABLE();
+;
+}
+
+_const_main__barz = (((*(bool*)_t2.data)));
+}

--- a/vlib/v/gen/c/testdata/const_init_or_block.vv
+++ b/vlib/v/gen/c/testdata/const_init_or_block.vv
@@ -1,0 +1,9 @@
+// vtest vflags: -no-skip-unused
+fn t1() ?bool {
+	return true
+}
+
+type FooBar = bool
+
+const bar = FooBar(t1() or { panic(err) })
+const barz = FooBar(t1() or { panic(err) })


### PR DESCRIPTION
Fix #24098