### PR TITLE
checker: add deprecate notice for `any` arg, prevent `any` from being used as map key,value or array type (currently crashing)

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -18,7 +18,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 		}
 		if node.elem_type != 0 {
 			elem_sym := c.table.sym(node.elem_type)
-
+			c.check_any_type(node.elem_type, elem_sym, node.pos)
 			if node.typ.has_flag(.option) && (node.has_cap || node.has_len) {
 				c.error('Option array `${elem_sym.name}` cannot have initializers', node.pos)
 			}
@@ -507,6 +507,7 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 				c.error('cannot use Result type as map value type', node.pos)
 			}
 			val_sym := c.table.sym(info.value_type)
+			c.check_any_type(info.value_type, val_sym, node.pos)
 			if val_sym.kind == .struct {
 				val_info := val_sym.info as ast.Struct
 				if val_info.generic_types.len > 0 && val_info.concrete_types.len == 0
@@ -531,6 +532,8 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 		c.ensure_type_exists(info.value_type, node.pos)
 		node.key_type = info.key_type
 		node.value_type = info.value_type
+		key_sym := c.table.sym(node.key_type)
+		c.check_any_type(info.value_type, key_sym, node.pos)
 		return node.typ
 	}
 

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -507,7 +507,6 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 				c.error('cannot use Result type as map value type', node.pos)
 			}
 			val_sym := c.table.sym(info.value_type)
-			c.check_any_type(info.value_type, val_sym, node.pos)
 			if val_sym.kind == .struct {
 				val_info := val_sym.info as ast.Struct
 				if val_info.generic_types.len > 0 && val_info.concrete_types.len == 0
@@ -532,8 +531,12 @@ fn (mut c Checker) map_init(mut node ast.MapInit) ast.Type {
 		c.ensure_type_exists(info.value_type, node.pos)
 		node.key_type = info.key_type
 		node.value_type = info.value_type
-		key_sym := c.table.sym(node.key_type)
-		c.check_any_type(info.value_type, key_sym, node.pos)
+		if (c.table.sym(info.key_type).language == .v && info.key_type == ast.any_type)
+			|| (c.table.sym(info.value_type).language == .v && info.value_type == ast.any_type) {
+			c.note('the `any` type is deprecated and will be removed soon - either use an empty interface, or a sum type',
+				node.pos)
+			c.error('cannot use type `any` here', node.pos)
+		}
 		return node.typ
 	}
 

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -280,7 +280,7 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				c.error('result type arguments are not supported', param.type_pos)
 			}
 			arg_typ_sym := c.table.sym(param.typ)
-			if param.typ == ast.any_type {
+			if node.language == .v && param.typ == ast.any_type {
 				c.note('the `any` type is deprecated and will be removed soon - either use an empty interface, or a sum type',
 					param.pos)
 			}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -280,7 +280,8 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				c.error('result type arguments are not supported', param.type_pos)
 			}
 			arg_typ_sym := c.table.sym(param.typ)
-			if node.language == .v && param.typ == ast.any_type {
+			if c.file.mod.name != 'builtin' && arg_typ_sym.language == .v
+				&& param.typ == ast.any_type {
 				c.note('the `any` type is deprecated and will be removed soon - either use an empty interface, or a sum type',
 					param.pos)
 			}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -280,8 +280,8 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				c.error('result type arguments are not supported', param.type_pos)
 			}
 			arg_typ_sym := c.table.sym(param.typ)
-			if c.file.mod.name != 'builtin' && arg_typ_sym.language == .v
-				&& param.typ == ast.any_type {
+			if arg_typ_sym.language == .v && param.typ == ast.any_type
+				&& c.file.mod.name != 'builtin' {
 				c.note('the `any` type is deprecated and will be removed soon - either use an empty interface, or a sum type',
 					param.pos)
 			}

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -280,6 +280,10 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 				c.error('result type arguments are not supported', param.type_pos)
 			}
 			arg_typ_sym := c.table.sym(param.typ)
+			if param.typ == ast.any_type {
+				c.note('the `any` type is deprecated and will be removed soon - either use an empty interface, or a sum type',
+					param.pos)
+			}
 			// resolve unresolved fixed array size e.g. [mod.const]array_type
 			if arg_typ_sym.info is ast.ArrayFixed
 				&& c.array_fixed_has_unresolved_size(arg_typ_sym.info) {

--- a/vlib/v/checker/tests/deprecate_any.out
+++ b/vlib/v/checker/tests/deprecate_any.out
@@ -3,6 +3,19 @@ vlib/v/checker/tests/deprecate_any.vv:1:8: notice: the `any` type is deprecated 
       |        ^
     2 | 
     3 | fn main() {
+vlib/v/checker/tests/deprecate_any.vv:5:7: notice: the `any` type is deprecated and will be removed soon - either use an empty interface, or a sum type
+    3 | fn main() {
+    4 |     _ := []any{}
+    5 |     _ := map[int]any{}
+      |          ~~~~~~~~~~~~~
+    6 |     _ := map[any]int{}
+    7 | }
+vlib/v/checker/tests/deprecate_any.vv:6:7: notice: the `any` type is deprecated and will be removed soon - either use an empty interface, or a sum type
+    4 |     _ := []any{}
+    5 |     _ := map[int]any{}
+    6 |     _ := map[any]int{}
+      |          ~~~~~~~~~~~~~
+    7 | }
 vlib/v/checker/tests/deprecate_any.vv:4:7: error: cannot use type `any` here
     2 | 
     3 | fn main() {

--- a/vlib/v/checker/tests/deprecate_any.out
+++ b/vlib/v/checker/tests/deprecate_any.out
@@ -1,0 +1,25 @@
+vlib/v/checker/tests/deprecate_any.vv:1:8: notice: the `any` type is deprecated and will be removed soon - either use an empty interface, or a sum type
+    1 | fn foo(a any) {}
+      |        ^
+    2 | 
+    3 | fn main() {
+vlib/v/checker/tests/deprecate_any.vv:4:7: error: cannot use type `any` here
+    2 | 
+    3 | fn main() {
+    4 |     _ := []any{}
+      |          ~~~~~~
+    5 |     _ := map[int]any{}
+    6 |     _ := map[any]int{}
+vlib/v/checker/tests/deprecate_any.vv:5:7: error: cannot use type `any` here
+    3 | fn main() {
+    4 |     _ := []any{}
+    5 |     _ := map[int]any{}
+      |          ~~~~~~~~~~~~~
+    6 |     _ := map[any]int{}
+    7 | }
+vlib/v/checker/tests/deprecate_any.vv:6:7: error: cannot use type `any` here
+    4 |     _ := []any{}
+    5 |     _ := map[int]any{}
+    6 |     _ := map[any]int{}
+      |          ~~~~~~~~~~~~~
+    7 | }

--- a/vlib/v/checker/tests/deprecate_any.vv
+++ b/vlib/v/checker/tests/deprecate_any.vv
@@ -1,0 +1,7 @@
+fn foo(a any) {}
+
+fn main() {
+	_ := []any{}
+	_ := map[int]any{}
+	_ := map[any]int{}
+}


### PR DESCRIPTION
Fix #24224