### PR TITLE
cgen: fix codegen for indexexpr on for loop with branchstmt

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2200,8 +2200,9 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 				}
 			}
 			g.stmt(stmt)
-			if (g.inside_if_option || g.inside_if_result || g.inside_match_option
-				|| g.inside_match_result) && stmt is ast.ExprStmt {
+			if stmt is ast.ExprStmt && (g.inside_if_option || g.inside_if_result
+				|| g.inside_match_option || g.inside_match_result
+				|| (stmt.expr is ast.IndexExpr && stmt.expr.or_expr.kind != .absent)) {
 				g.writeln(';')
 			}
 		}

--- a/vlib/v/tests/index_on_loop_test.v
+++ b/vlib/v/tests/index_on_loop_test.v
@@ -1,0 +1,7 @@
+fn test_main() {
+	arr := ['hello', 'world']
+	for {
+		arr[69] or { break }
+	}
+	assert true
+}


### PR DESCRIPTION
Fix #22760