### PR TITLE
cgen: fix codegen for multi return with aliased fixed array

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5930,7 +5930,9 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				line := g.go_before_last_stmt().trim_space()
 				expr_styp := g.styp(node.types[i])
 				g.write('memcpy(&${tmpvar}.arg${arg_idx}, ')
-				g.write('(${expr_styp})')
+				if expr is ast.StructInit {
+					g.write('(${expr_styp})')
+				}
 				g.expr(expr)
 				g.writeln(', sizeof(${expr_styp}));')
 				final_assignments += g.go_before_last_stmt() + '\t'

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5930,6 +5930,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				line := g.go_before_last_stmt().trim_space()
 				expr_styp := g.styp(node.types[i])
 				g.write('memcpy(&${tmpvar}.arg${arg_idx}, ')
+				g.write('(${expr_styp})')
 				g.expr(expr)
 				g.writeln(', sizeof(${expr_styp}));')
 				final_assignments += g.go_before_last_stmt() + '\t'

--- a/vlib/v/tests/fns/return_multi_aliased_fixed_array_test.v
+++ b/vlib/v/tests/fns/return_multi_aliased_fixed_array_test.v
@@ -1,0 +1,24 @@
+type Bytes32 = [32]u8
+
+pub fn a(x1 Bytes32, y1 Bytes32, z1 Bytes32, x2 Bytes32, y2 Bytes32, z2 Bytes32) (Bytes32, Bytes32, Bytes32) {
+	return Bytes32{}, Bytes32{}, Bytes32{}
+}
+
+pub fn b(x Bytes32, y Bytes32, z Bytes32) (Bytes32, Bytes32) {
+	return Bytes32{}, Bytes32{}
+}
+
+fn test_main() {
+	x1 := Bytes32{}
+	y1 := Bytes32{}
+	z1 := Bytes32{}
+	x2 := Bytes32{}
+	y2 := Bytes32{}
+	z2 := Bytes32{}
+
+	x3, y3, z3 := a(x1, y1, z1, x2, y2, z2)
+
+	xx, yy := b(x3, y3, z3)
+
+	assert xx == yy
+}


### PR DESCRIPTION
Fix second bug case posted at #24280