### PR TITLE
os: fix windows filelock

### DIFF
--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -1,6 +1,7 @@
 // Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
+@[has_globals]
 module main
 
 import os
@@ -59,6 +60,8 @@ const external_tools = [
 ]
 const list_of_flags_that_allow_duplicates = ['cc', 'd', 'define', 'cf', 'cflags']
 
+__global timers = &util.Timers(unsafe { nil })
+
 fn main() {
 	unbuffer_stdout()
 	mut timers_should_print := false
@@ -68,12 +71,12 @@ fn main() {
 	if '-show-timings' in os.args {
 		timers_should_print = true
 	}
-	mut timers := util.new_timers(should_print: timers_should_print, label: 'main')
+	timers = util.new_timers(should_print: timers_should_print, label: 'main')
 	timers.start('v start')
 	timers.show('v start')
 	timers.start('TOTAL')
 	// use at_exit here, instead of defer, since some code paths later do early exit(0) or exit(1), for showing errors, or after `v run`
-	at_exit(fn [mut timers] () {
+	at_exit(fn () {
 		timers.show('TOTAL')
 	})!
 	timers.start('v parsing CLI args')

--- a/vlib/os/filelock/lib.v
+++ b/vlib/os/filelock/lib.v
@@ -5,13 +5,15 @@ import time
 pub struct FileLock {
 	name string
 mut:
-	fd int
+	cfile voidptr // Using void* instead of FILE*
+	fd    int
 }
 
 pub fn new(fileName string) FileLock {
 	return FileLock{
-		name: fileName
-		fd:   -1
+		name:  fileName
+		fd:    -1
+		cfile: unsafe { nil }
 	}
 }
 
@@ -22,16 +24,6 @@ pub fn (mut l FileLock) wait_acquire(timeout time.Duration) bool {
 			return true
 		}
 		time.sleep(1 * time.millisecond)
-	}
-	return false
-}
-
-pub fn (mut l FileLock) release() bool {
-	if l.fd != -1 {
-		unsafe {
-			l.unlink()
-		}
-		return true
 	}
 	return false
 }

--- a/vlib/os/filelock/lib.v
+++ b/vlib/os/filelock/lib.v
@@ -9,6 +9,7 @@ mut:
 	fd    int
 }
 
+// new create a new lock file object, it will not create the lock file until `acquire` it.
 pub fn new(fileName string) FileLock {
 	return FileLock{
 		name:  fileName
@@ -17,6 +18,7 @@ pub fn new(fileName string) FileLock {
 	}
 }
 
+// wait_acquire try acquire the lock file within a `timeout`.
 pub fn (mut l FileLock) wait_acquire(timeout time.Duration) bool {
 	fin := time.now().add(timeout)
 	for time.now() < fin {

--- a/vlib/os/filelock/lib_nix.c.v
+++ b/vlib/os/filelock/lib_nix.c.v
@@ -55,3 +55,13 @@ pub fn (mut l FileLock) try_acquire() bool {
 	}
 	return false
 }
+
+pub fn (mut l FileLock) release() bool {
+	if l.fd != -1 {
+		unsafe {
+			l.unlink()
+		}
+		return true
+	}
+	return false
+}

--- a/vlib/os/filelock/lib_nix.c.v
+++ b/vlib/os/filelock/lib_nix.c.v
@@ -10,10 +10,10 @@ fn C.flock(int, int) int
 @[unsafe]
 pub fn (mut l FileLock) unlink() {
 	if l.fd != -1 {
-		C.close(l.fd)
+		_ := C.close(l.fd)
 		l.fd = -1
 	}
-	C.unlink(&char(l.name.str))
+	_ := C.unlink(&char(l.name.str))
 }
 
 // acquire acquire the lock file.
@@ -26,7 +26,7 @@ pub fn (mut l FileLock) acquire() ! {
 		return error_with_code('cannot create lock file ${l.name}', -1)
 	}
 	if C.flock(fd, C.LOCK_EX) == -1 {
-		C.close(fd)
+		_ := C.close(fd)
 		return error_with_code('cannot lock', -2)
 	}
 	l.fd = fd
@@ -50,7 +50,7 @@ pub fn (mut l FileLock) try_acquire() bool {
 	if fd != -1 {
 		err := C.flock(fd, C.LOCK_EX | C.LOCK_NB)
 		if err == -1 {
-			C.close(fd)
+			_ := C.close(fd)
 			return false
 		}
 		l.fd = fd

--- a/vlib/os/filelock/lib_nix.c.v
+++ b/vlib/os/filelock/lib_nix.c.v
@@ -6,6 +6,7 @@ fn C.unlink(&char) int
 fn C.open(&char, int, int) int
 fn C.flock(int, int) int
 
+// unlink unlink the lock file and release it.
 @[unsafe]
 pub fn (mut l FileLock) unlink() {
 	if l.fd != -1 {
@@ -15,6 +16,7 @@ pub fn (mut l FileLock) unlink() {
 	C.unlink(&char(l.name.str))
 }
 
+// acquire acquire the lock file.
 pub fn (mut l FileLock) acquire() ! {
 	if l.fd != -1 {
 		return error_with_code('lock already acquired by this instance', 1)
@@ -39,6 +41,7 @@ fn open_lockfile(f string) int {
 	return fd
 }
 
+// try_acquire try acquire the lock file, it will return `true` if success.
 pub fn (mut l FileLock) try_acquire() bool {
 	if l.fd != -1 {
 		return true
@@ -56,6 +59,7 @@ pub fn (mut l FileLock) try_acquire() bool {
 	return false
 }
 
+// release release the lock file and unlink it.
 pub fn (mut l FileLock) release() bool {
 	if l.fd != -1 {
 		unsafe {

--- a/vlib/os/filelock/lib_windows.c.v
+++ b/vlib/os/filelock/lib_windows.c.v
@@ -4,6 +4,7 @@ fn C.DeleteFileW(&u16) bool
 fn C.CreateFileW(&u16, u32, u32, voidptr, u32, u32, voidptr) voidptr
 fn C.CloseHandle(voidptr) bool
 
+// unlink unlink the lock file and release it.
 pub fn (mut l FileLock) unlink() {
 	if !isnil(l.cfile) {
 		C.CloseHandle(l.cfile)
@@ -13,6 +14,7 @@ pub fn (mut l FileLock) unlink() {
 	C.DeleteFileW(t_wide)
 }
 
+// acquire acquire the lock file.
 pub fn (mut l FileLock) acquire() ! {
 	if !isnil(l.cfile) {
 		return error_with_code('lock already acquired by this instance', 1)
@@ -32,6 +34,7 @@ fn open(f string) voidptr {
 	return cfile
 }
 
+// try_acquire try acquire the lock file, it will return true if success.
 pub fn (mut l FileLock) try_acquire() bool {
 	if !isnil(l.cfile) {
 		// lock already acquired by this instance
@@ -45,6 +48,7 @@ pub fn (mut l FileLock) try_acquire() bool {
 	return true
 }
 
+// release release the lock file and unlink it.
 pub fn (mut l FileLock) release() bool {
 	if !isnil(l.cfile) {
 		unsafe {

--- a/vlib/os/filelock/lib_windows.c.v
+++ b/vlib/os/filelock/lib_windows.c.v
@@ -5,42 +5,52 @@ fn C.CreateFileW(&u16, u32, u32, voidptr, u32, u32, voidptr) voidptr
 fn C.CloseHandle(voidptr) bool
 
 pub fn (mut l FileLock) unlink() {
-	if l.fd != -1 {
-		C.CloseHandle(voidptr(l.fd))
-		l.fd = -1
+	if !isnil(l.cfile) {
+		ret := C.CloseHandle(l.cfile)
+		l.cfile = unsafe { nil }
 	}
 	t_wide := l.name.to_wide()
-	C.DeleteFileW(t_wide)
+	ret := C.DeleteFileW(t_wide)
 }
 
 pub fn (mut l FileLock) acquire() ! {
-	if l.fd != -1 {
+	if !isnil(l.cfile) {
 		return error_with_code('lock already acquired by this instance', 1)
 	}
-	fd := open(l.name)
-	if fd == -1 {
+	cfile := open(l.name)
+	if isnil(cfile) {
 		return error_with_code('cannot create lock file ${l.name}', -1)
 	}
-	l.fd = int(fd)
+	l.cfile = cfile
 }
 
 fn open(f string) voidptr {
 	f_wide := f.to_wide()
 	// locking it
-	fd := C.CreateFileW(f_wide, C.GENERIC_READ | C.GENERIC_WRITE, 0, 0, C.OPEN_ALWAYS,
+	cfile := C.CreateFileW(f_wide, C.GENERIC_READ | C.GENERIC_WRITE, 0, 0, C.OPEN_ALWAYS,
 		C.FILE_ATTRIBUTE_NORMAL, 0)
-	return fd
+	return cfile
 }
 
 pub fn (mut l FileLock) try_acquire() bool {
-	if l.fd != -1 {
+	if !isnil(l.cfile) {
 		// lock already acquired by this instance
 		return false
 	}
-	fd := open(l.name)
-	if fd == -1 {
+	cfile := open(l.name)
+	if isnil(cfile) {
 		return false
 	}
-	l.fd = int(fd)
+	l.cfile = cfile
 	return true
+}
+
+pub fn (mut l FileLock) release() bool {
+	if !isnil(l.cfile) {
+		unsafe {
+			l.unlink()
+		}
+		return true
+	}
+	return false
 }

--- a/vlib/os/filelock/lib_windows.c.v
+++ b/vlib/os/filelock/lib_windows.c.v
@@ -6,11 +6,11 @@ fn C.CloseHandle(voidptr) bool
 
 pub fn (mut l FileLock) unlink() {
 	if !isnil(l.cfile) {
-		ret := C.CloseHandle(l.cfile)
+		C.CloseHandle(l.cfile)
 		l.cfile = unsafe { nil }
 	}
 	t_wide := l.name.to_wide()
-	ret := C.DeleteFileW(t_wide)
+	C.DeleteFileW(t_wide)
 }
 
 pub fn (mut l FileLock) acquire() ! {

--- a/vlib/os/filelock/lib_windows.c.v
+++ b/vlib/os/filelock/lib_windows.c.v
@@ -7,11 +7,11 @@ fn C.CloseHandle(voidptr) bool
 // unlink unlink the lock file and release it.
 pub fn (mut l FileLock) unlink() {
 	if !isnil(l.cfile) {
-		C.CloseHandle(l.cfile)
+		_ := C.CloseHandle(l.cfile)
 		l.cfile = unsafe { nil }
 	}
 	t_wide := l.name.to_wide()
-	C.DeleteFileW(t_wide)
+	_ := C.DeleteFileW(t_wide)
 }
 
 // acquire acquire the lock file.


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Use `cfile` instead of `fd` for windows.
Avoid compiler warnings:

```
Warning: C:\Users\runneradmin\AppData\Local\Temp\v_0\v_prod_cg.01JSFX343YW33PCJ7ETMJQF2CH.tmp.c:27250:16: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
   CloseHandle(((voidptr)(l->fd)));
                ^
C:\Users\runneradmin\AppData\Local\Temp\v_0\v_prod_cg.01JSFX343YW33PCJ7ETMJQF2CH.tmp.c: In function 'os__filelock__FileLock_try_acquire':
Warning: C:\Users\runneradmin\AppData\Local\Temp\v_0\v_prod_cg.01JSFX343YW33PCJ7ETMJQF2CH.tmp.c:27266:9: warning: comparison between pointer and integer
  if (fd == -1) {
         ^~
Warning: C:\Users\runneradmin\AppData\Local\Temp\v_0\v_prod_cg.01JSFX343YW33PCJ7ETMJQF2CH.tmp.c:27269:11: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  l->fd = ((int)(fd));
           ^
```