### PR TITLE
tests: enable gcc and clang for closure

### DIFF
--- a/vlib/v/tests/fns/closure_generator_test.v
+++ b/vlib/v/tests/fns/closure_generator_test.v
@@ -200,9 +200,11 @@ fn test_closure_return_${styp}_${i}() ! {
 	full_path_to_target := os.join_path(wrkdir, 'closure_return_test.v')
 	os.write_file(full_path_to_target, code)!
 	vexe := os.getenv('VEXE')
-	cmd := '${os.quoted_path(vexe)} -keepc -cg -showcc ${full_path_to_target}'
+	mut cmd := '${os.quoted_path(vexe)} -cc gcc -keepc -cg -showcc ${full_path_to_target}'
 	res := os.execute(cmd)
-	if res.exit_code != 0 {
+	cmd = '${os.quoted_path(vexe)} -cc clang -keepc -cg -showcc ${full_path_to_target}'
+	res2 := os.execute(cmd)
+	if res.exit_code != 0 || res2.exit_code != 0 {
 		eprintln(res.output)
 		eprintln('> failed exit code: ${res.exit_code} | cmd:\n${cmd}')
 		assert false


### PR DESCRIPTION
The generated file with multiple closure variants must always be successful for all architectures under both gcc and clang.

Very important.

p.s. Made a PR and realized that I don't know if CI will break because `clang` is not installed :(