### PR TITLE
js: fix callback passed as params (fix #24260)

### DIFF
--- a/vlib/v/gen/js/fn.v
+++ b/vlib/v/gen/js/fn.v
@@ -391,7 +391,7 @@ fn (mut g JsGen) gen_call_expr(it ast.CallExpr) {
 	if it.should_be_skipped {
 		return
 	}
-	if it.is_method && g.table.sym(it.receiver_type).name.starts_with('JS.') {
+	if it.is_method && (it.is_field || g.table.sym(it.receiver_type).name.starts_with('JS.')) {
 		g.js_method_call(it)
 		return
 	} else if it.name.starts_with('JS.') {

--- a/vlib/v/gen/js/tests/callback.v
+++ b/vlib/v/gen/js/tests/callback.v
@@ -1,0 +1,38 @@
+struct FooParams {
+	name   string
+	update fn (name string) @[required]
+}
+
+fn foo(params FooParams) {
+	params.update(params.name)
+}
+
+fn main() {
+	// anonymous function callback
+	foo(
+		name:   'item 1'
+		update: fn (name string) {
+			println('update ${name}')
+		}
+	)
+
+	// lambda function callback
+	update := fn (name string) {
+		println('update ${name}')
+	}
+	foo(name: 'item 2', update: update)
+
+	// anonymous function field
+	item_3 := FooParams{
+		update: fn (name string) {
+			println('update ${name}')
+		}
+	}
+	item_3.update('item 3')
+
+	// lambda function field
+	item_4 := FooParams{
+		update: update
+	}
+	item_4.update('item 4')
+}


### PR DESCRIPTION
- Modified `fn.v` and check if the callback expression is a field
- Added `callback.v` test