### PR TITLE
cgen: fix codegen for thread.call() on var auto heap

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -1441,6 +1441,9 @@ fn (mut g Gen) gen_array_wait(node ast.CallExpr) {
 	eltyp := g.table.sym(thread_ret_type).cname
 	fn_name := g.register_thread_array_wait_call(eltyp)
 	g.write('${fn_name}(')
+	if node.left_type.is_ptr() {
+		g.write('*')
+	}
 	g.expr(node.left)
 	g.write(')')
 }

--- a/vlib/v/tests/concurrency/thread_wait_ptr_test.v
+++ b/vlib/v/tests/concurrency/thread_wait_ptr_test.v
@@ -1,0 +1,18 @@
+import math { sqrt }
+import time
+
+fn get_hypot(a f64, b f64) f64 {
+	time.sleep(100 * time.millisecond)
+	c := sqrt(a * a + b * b)
+	return c
+}
+
+fn test_main() {
+	mut arr := &[]thread f64{}
+	for num in 1 .. 1000 {
+		g := go get_hypot(num, num)
+		arr << g
+	}
+	result := arr.wait()
+	assert result[0] == 1.4142135623730951
+}


### PR DESCRIPTION
Fix #24326