### PR TITLE
os: fix windows rmdir GetLastError()

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -480,8 +480,10 @@ pub fn rmdir(path string) ! {
 		rc := C.RemoveDirectory(path.to_wide())
 		if !rc {
 			// https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-removedirectorya - 0 == false, is failure
+			code := int(C.GetLastError())
 			return error_win32(
-				msg: 'Failed to remove "${path}": ' + get_error_msg(int(C.GetLastError()))
+				msg:  'Failed to remove "${path}": ' + get_error_msg(code)
+				code: code
 			)
 		}
 	} $else {

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -1107,20 +1107,20 @@ pub fn error_posix(e SystemError) IError {
 // error_win32 returns a Win32 API error:
 // example:
 // ```
-//   // save error code immediately, or it will be overwritten by other API
-//   // function calls, even by `str_intp`.
-//   code := int(C.GetLastError())
-//	 error_win32(
-//		msg : 'some error'
-//		code : code
-//	)
+//    // save error code immediately, or it will be overwritten by other API
+//    // function calls, even by `str_intp`.
+//    code := int(C.GetLastError())
+//    error_win32(
+//       msg : 'some error'
+//       code : code
+//    )
 // ```
 // wrong usage:
 // ```
-//	 error_win32(
-//		msg : 'some error ${path}'		// this will overwrite error code
-//		code : int(C.GetLastError())
-//	)
+//    error_win32(
+//        msg : 'some error ${path}'		// this will overwrite error code
+//        code : int(C.GetLastError())
+//    )
 // ```
 // Message defaults to Win 32 API error message for the error code
 @[inline; manualfree]


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix #24356

If not set `code`,  `error_win32()` will call `C.GetLastError()` again and get a zero value.