### PR TITLE
doc: multithread compatible profiler, stib comp arg

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5490,7 +5490,7 @@ The generated profile.txt file will have lines with 4 columns:
 1. How many times a function was called.
 2. How much time in total a function took (in ms).
 3. How much time on average, a call to a function took (in ns).
-4. How much time in total a function took (in ms), more reliable for multithreaded programs than the other (use gcc or clang, tcc does not support it).
+4. Same as 2 but more reliable for multithreaded programs (tcc does not support it).
 5. The name of the v function.
 
 You can sort on column 3 (average time per function) using:

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5490,7 +5490,8 @@ The generated profile.txt file will have lines with 4 columns:
 1. How many times a function was called.
 2. How much time in total a function took (in ms).
 3. How much time on average, a call to a function took (in ns).
-4. The name of the v function.
+4. How much time in total a function took (in ms), more reliable for multithreaded programs than the other (use gcc or clang, tcc does not support it).
+5. The name of the v function.
 
 You can sort on column 3 (average time per function) using:
 `sort -n -k3 profile.txt|tail`

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5490,7 +5490,8 @@ The generated profile.txt file will have lines with 4 columns:
 1. How many times a function was called.
 2. How much time in total a function took (in ms).
 3. How much time on average, a call to a function took (in ns).
-4. Same as 2 but more reliable for multithreaded programs (tcc does not support it).
+4. How much time a function took (in ms), on its own, without the calls inside it.
+   It is reliable for multithreaded programs, when tcc is not used.
 5. The name of the v function.
 
 You can sort on column 3 (average time per function) using:

--- a/vlib/stbi/stbi.c.v
+++ b/vlib/stbi/stbi.c.v
@@ -210,6 +210,7 @@ fn C.stbi_write_jpg(filename &char, w int, h int, comp int, buffer &u8, quality 
 
 // stbi_write_png write on path a PNG file
 // row_stride_in_bytes is usually equal to: w * comp
+// comp is the number of channels
 pub fn stbi_write_png(path string, w int, h int, comp int, buf &u8, row_stride_in_bytes int) ! {
 	if 0 == C.stbi_write_png(&char(path.str), w, h, comp, buf, row_stride_in_bytes) {
 		return error('stbi_image failed to write png file to "${path}"')
@@ -217,6 +218,7 @@ pub fn stbi_write_png(path string, w int, h int, comp int, buf &u8, row_stride_i
 }
 
 // stbi_write_png write on path a BMP file
+// comp is the number of channels
 pub fn stbi_write_bmp(path string, w int, h int, comp int, buf &u8) ! {
 	if 0 == C.stbi_write_bmp(&char(path.str), w, h, comp, buf) {
 		return error('stbi_image failed to write bmp file to "${path}"')
@@ -224,6 +226,7 @@ pub fn stbi_write_bmp(path string, w int, h int, comp int, buf &u8) ! {
 }
 
 // stbi_write_png write on path a TGA file
+// comp is the number of channels
 pub fn stbi_write_tga(path string, w int, h int, comp int, buf &u8) ! {
 	if 0 == C.stbi_write_tga(&char(path.str), w, h, comp, buf) {
 		return error('stbi_image failed to write tga file to "${path}"')
@@ -233,6 +236,7 @@ pub fn stbi_write_tga(path string, w int, h int, comp int, buf &u8) ! {
 // stbi_write_png write on path a JPG file
 // quality select the compression quality of the JPG
 // quality is between 1 and 100. Higher quality looks better but results in a bigger image.
+// comp is the number of channels
 pub fn stbi_write_jpg(path string, w int, h int, comp int, buf &u8, quality int) ! {
 	if 0 == C.stbi_write_jpg(&char(path.str), w, h, comp, buf, quality) {
 		return error('stbi_image failed to write jpg file to "${path}"')


### PR DESCRIPTION
- updates profiler documentiation for the new fourth column
- adds a description to the unclear comp argument. It was described somewhere in the C library but not close to the C functions