### PR TITLE
x.crypto.chacha20: add a check counter overflow to set_counter

### DIFF
--- a/vlib/x/crypto/chacha20/chacha.v
+++ b/vlib/x/crypto/chacha20/chacha.v
@@ -425,6 +425,10 @@ pub fn (mut c Cipher) set_counter(ctr u64) {
 			c.nonce[1] = u32(ctr >> 32)
 		}
 		.standard {
+			// check for ctr value that may exceed the counter limit
+			if ctr > max_32bit_counter {
+				panic('set_counter: counter value exceed the limit ')
+			}
 			c.nonce[0] = u32(ctr)
 		}
 	}

--- a/vlib/x/crypto/chacha20/chacha_64bitctr_test.v
+++ b/vlib/x/crypto/chacha20/chacha_64bitctr_test.v
@@ -109,7 +109,7 @@ fn test_chacha20_encrypt_with_64bit_counter() ! {
 }
 
 struct Test64BitCounter {
-	count      int
+	count      u64
 	key        string
 	nonce      string
 	plaintext  string


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This small PR contains two small fix,

1. The first part was adding check into `.set_counter` routine, especially in standard variant where its only allowing 32bit counter values.
2. The second fixs the warning when run the test of `chacha_64bitctr_test` with `-cstrict` options, would lead into  `error: integer constant is so large that it is unsigned [-Werror]` because counter was defined as `int` before changes.

Thanks