### PR TITLE
cgen:enable windows tcc_backtrace() support

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -424,9 +424,7 @@ const c_common_macros = '
 	#undef TCCSKIP
 	#define TCCSKIP(x)
 	// #include <byteswap.h>
-	#ifndef _WIN32
-		int tcc_backtrace(const char *fmt, ...);
-	#endif
+	int tcc_backtrace(const char *fmt, ...);
 #endif
 
 // Use __offsetof_ptr instead of __offset_of, when you *do* have a valid pointer, to avoid UB:


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR will enable `tcc_backtrace()` compile support for custom `tcc` under Windows.

```
D://v//v//v//vlib//builtin//backtraces.c.v:16: error: implicit declaration of function 'tcc_backtrace'
builder error:
==================
C error found. It should never happen, when compiling pure V code.
This is a V compiler bug, please report it using `v bug file.v`,
or goto https://github.com/vlang/v/issues/new/choose .
You can also use #help on Discord: https://discord.gg/vlang .
```