### PR TITLE
ci: remove the `// vtest flaky: true` tags from the remaining tests

### DIFF
--- a/examples/dynamic_library_loading/use_library_test.v
+++ b/examples/dynamic_library_loading/use_library_test.v
@@ -1,6 +1,5 @@
 module main
 
-// vtest flaky: true
 // vtest retry: 3
 import os
 import dl

--- a/vlib/builtin/js/array_test.js.v
+++ b/vlib/builtin/js/array_test.js.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 // vtest build: present_node?
 

--- a/vlib/builtin/js/int_test.js.v
+++ b/vlib/builtin/js/int_test.js.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 // vtest build: present_node?
 

--- a/vlib/builtin/js/map_test.js.v
+++ b/vlib/builtin/js/map_test.js.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 // vtest build: present_node?
 import rand

--- a/vlib/builtin/js/string_test.js.v
+++ b/vlib/builtin/js/string_test.js.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 // vtest build: present_node?
 

--- a/vlib/context/cancel_test.v
+++ b/vlib/context/cancel_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 // vtest build: amd64 || arm64
 import context

--- a/vlib/net/tcp_test.v
+++ b/vlib/net/tcp_test.v
@@ -1,5 +1,4 @@
 // vtest retry: 5
-// vtest flaky: true
 import net
 
 const test_port = 45123

--- a/vlib/orm/orm_create_and_drop_test.v
+++ b/vlib/orm/orm_create_and_drop_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 

--- a/vlib/orm/orm_custom_operators_test.v
+++ b/vlib/orm/orm_custom_operators_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 

--- a/vlib/orm/orm_fk_test.v
+++ b/vlib/orm/orm_fk_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 

--- a/vlib/orm/orm_fn_calls_test.v
+++ b/vlib/orm/orm_fn_calls_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 

--- a/vlib/orm/orm_fn_test.v
+++ b/vlib/orm/orm_fn_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import orm
 

--- a/vlib/orm/orm_insert_reserved_name_test.v
+++ b/vlib/orm/orm_insert_reserved_name_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 

--- a/vlib/orm/orm_insert_test.v
+++ b/vlib/orm/orm_insert_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 import rand

--- a/vlib/orm/orm_interface_test.v
+++ b/vlib/orm/orm_interface_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 import orm

--- a/vlib/orm/orm_last_id_test.v
+++ b/vlib/orm/orm_last_id_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 

--- a/vlib/orm/orm_mut_connection_test.v
+++ b/vlib/orm/orm_mut_connection_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import orm
 

--- a/vlib/orm/orm_mut_db_test.v
+++ b/vlib/orm/orm_mut_db_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 

--- a/vlib/orm/orm_nested_struct_test.v
+++ b/vlib/orm/orm_nested_struct_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 

--- a/vlib/orm/orm_null_test.v
+++ b/vlib/orm/orm_null_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import orm
 import db.sqlite

--- a/vlib/orm/orm_option_array_test.v
+++ b/vlib/orm/orm_option_array_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 

--- a/vlib/orm/orm_option_time_test.v
+++ b/vlib/orm/orm_option_time_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 import time

--- a/vlib/orm/orm_references_test.v
+++ b/vlib/orm/orm_references_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 

--- a/vlib/orm/orm_result_test.v
+++ b/vlib/orm/orm_result_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 

--- a/vlib/orm/orm_sql_or_blocks_test.v
+++ b/vlib/orm/orm_sql_or_blocks_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import os
 import db.sqlite

--- a/vlib/orm/orm_string_interpolation_in_where_test.v
+++ b/vlib/orm/orm_string_interpolation_in_where_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 

--- a/vlib/orm/orm_test.v
+++ b/vlib/orm/orm_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 // vtest build: !windows
 // import db.mysql

--- a/vlib/os/notify/notify_test.c.v
+++ b/vlib/os/notify/notify_test.c.v
@@ -1,3 +1,4 @@
+// vtest flaky: true
 // vtest retry: 3
 import os
 import os.notify

--- a/vlib/os/notify/notify_test.c.v
+++ b/vlib/os/notify/notify_test.c.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import os
 import os.notify

--- a/vlib/sync/channel_select_6_test.v
+++ b/vlib/sync/channel_select_6_test.v
@@ -1,5 +1,4 @@
-// vtest flaky: true
-// vtest retry: 15
+// vtest retry: 5
 
 // This test case runs concurrent 3 instances of `do_select` that
 // communicate with 6 other threads doing send and receive operations.

--- a/vlib/sync/channel_select_test.v
+++ b/vlib/sync/channel_select_test.v
@@ -1,7 +1,6 @@
 module sync
 
-// vtest flaky: true
-// vtest retry: 6
+// vtest retry: 3
 
 // ATTENTION! Do not use this file as an example!
 // For that, please look at `channel_select_2_test.v` or `channel_select_3_test.v`

--- a/vlib/toml/tests/burntsushi_toml_test.v
+++ b/vlib/toml/tests/burntsushi_toml_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 
 // Instructions for developers:

--- a/vlib/toml/tests/burntsushi_toml_test.v
+++ b/vlib/toml/tests/burntsushi_toml_test.v
@@ -1,3 +1,4 @@
+// vtest flaky: true
 // vtest retry: 3
 
 // Instructions for developers:

--- a/vlib/toml/tests/quoted_keys_test.v
+++ b/vlib/toml/tests/quoted_keys_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import toml
 

--- a/vlib/v/live/live_test.v
+++ b/vlib/v/live/live_test.v
@@ -1,7 +1,6 @@
 import os
 import time
 
-// vtest flaky: true
 // vtest retry: 4
 
 /*

--- a/vlib/v/pref/options_test.v
+++ b/vlib/v/pref/options_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import os
 import time

--- a/vlib/v/slow_tests/crun_mode/crun_test.v
+++ b/vlib/v/slow_tests/crun_mode/crun_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import os
 import time

--- a/vlib/v/slow_tests/keep_args_alive_test.c.v
+++ b/vlib/v/slow_tests/keep_args_alive_test.c.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 4
 /*
 * To verify the effect of "[keep_args_alive]", this attribute may be commented out.

--- a/vlib/v/tests/builtin_arrays/array_access_optimisation_test.v
+++ b/vlib/v/tests/builtin_arrays/array_access_optimisation_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import os
 

--- a/vlib/v/tests/concurrency/atomic_test.v
+++ b/vlib/v/tests/concurrency/atomic_test.v
@@ -1,6 +1,5 @@
 import time
 
-// vtest flaky: true
 // vtest retry: 3
 
 struct App {

--- a/vlib/v/tests/concurrency/semaphore_timed_test.v
+++ b/vlib/v/tests/concurrency/semaphore_timed_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import sync
 import time

--- a/vlib/v/tests/fns/go_anon_fn_variable_call_test.v
+++ b/vlib/v/tests/fns/go_anon_fn_variable_call_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 
 fn sum1(a int, b int) int {

--- a/vlib/v/tests/fns/go_array_wait_test.v
+++ b/vlib/v/tests/fns/go_array_wait_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 
 fn f(x f64) f64 {

--- a/vlib/v/tests/fns/go_wait_option_test.v
+++ b/vlib/v/tests/fns/go_wait_option_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 
 fn f(n int) ?f64 {

--- a/vlib/v/tests/project_with_c_code/main1_test.v
+++ b/vlib/v/tests/project_with_c_code/main1_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import v.tests.project_with_c_code.mod1
 

--- a/vlib/v/tests/project_with_c_code_2/main2_test.v
+++ b/vlib/v/tests/project_with_c_code_2/main2_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import v.tests.project_with_c_code_2.modc
 

--- a/vlib/v/tests/project_with_c_code_3/main3_test.v
+++ b/vlib/v/tests/project_with_c_code_3/main3_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import v.tests.project_with_c_code_3.mod1
 

--- a/vlib/veb/tests/large_payload_test.v
+++ b/vlib/veb/tests/large_payload_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import veb
 import net.http

--- a/vlib/x/sessions/tests/db_store_test.v
+++ b/vlib/x/sessions/tests/db_store_test.v
@@ -1,4 +1,3 @@
-// vtest flaky: true
 // vtest retry: 3
 import db.sqlite
 import x.json2 as json


### PR DESCRIPTION
Given the enhancements to the compiler and vlib, this PR removes the remaining flaky tags, to see what tests are still failing/unreliable, in order to improve them later.