### PR TITLE
tests: enable closure_test.v for every CPU arch

### DIFF
--- a/vlib/v/tests/fns/closure_test.v
+++ b/vlib/v/tests/fns/closure_test.v
@@ -1,4 +1,3 @@
-// vtest build: amd64 || arm64 // closures aren't implemented yet
 fn test_decl_assignment() {
 	my_var := 12
 	c1 := fn [my_var] () int {


### PR DESCRIPTION
Every CPU arch have `closure` implemented.
Enable good tests. 