### PR TITLE
ci: add closure tests for riscv64

### DIFF
--- a/.github/workflows/riscv64_linux_ci.yml
+++ b/.github/workflows/riscv64_linux_ci.yml
@@ -49,3 +49,4 @@ jobs:
             file ./v
             ls -la ./v
             ./v test vlib/builtin vlib/os vlib/encoding/binary
+            VTEST_ONLY=closure ./v test vlib/v/tests


### PR DESCRIPTION
- add `closure` tests. Useful and important.
- s390x CI will be the same after #24383.
