### PR TITLE
parser: fix panic for `struct Abc { pub mut: }`

### DIFF
--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -213,7 +213,9 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 			mut option_pos := token.Pos{}
 
 			if p.tok.kind == .rcbr {
-				ast_fields.last().next_comments << pre_field_comments
+				if ast_fields.len > 0 {
+					ast_fields.last().next_comments << pre_field_comments
+				}
 				break
 			}
 

--- a/vlib/v/parser/tests/struct_with_empty_pub_mut_section.vv
+++ b/vlib/v/parser/tests/struct_with_empty_pub_mut_section.vv
@@ -1,0 +1,2 @@
+pub struct Foo {
+}


### PR DESCRIPTION
Fix #24404 .
- **ci: reduce false positives for init_global_test.v on windows (retry it 2 times)**
- **ci: reduce false positives for orm_func_test.v on windows (retry it 2 times)**
- **parser: fix panic for `struct Abc { pub mut: }`**