### PR TITLE
cgen: fix interface `unsafe {nil}` comparison and initialization

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -258,7 +258,13 @@ fn (mut g Gen) gen_struct_equality_fn(left_type ast.Type) string {
 				&& (!field.typ.has_flag(.option) || !field.typ.is_ptr()) {
 				ptr := if field.typ.is_ptr() { '*'.repeat(field.typ.nr_muls()) } else { '' }
 				eq_fn := g.gen_interface_equality_fn(field.typ)
+				if ptr != '' {
+					fn_builder.write_string('((${left_arg} == (void*)0 && ${right_arg} == (void*)0) || (${left_arg} != (void*)0 && ${right_arg} != (void*)0 && ')
+				}
 				fn_builder.write_string('${eq_fn}_interface_eq(${ptr}${left_arg}, ${ptr}${right_arg})')
+				if ptr != '' {
+					fn_builder.write_string('))')
+				}
 			} else if field.typ.has_flag(.option) {
 				fn_builder.write_string('!memcmp(&${left_arg}.data, &${right_arg}.data, sizeof(${g.base_type(field.typ)}))')
 			} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2781,6 +2781,9 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp ast.Ty
 			g.write('&(${exp_styp.trim_right('*')}){._${got_styp.trim_right('*')}=')
 			rparen_n = 0
 			mutable_idx = got.idx()
+		} else if expr is ast.UnsafeExpr && expr.expr is ast.Nil {
+			g.write('(void*)0')
+			return
 		} else {
 			g.write('HEAP(${exp_styp}, ${fname}(')
 			rparen_n++

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -1217,6 +1217,8 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 	}
 	is_ctemp_fixed_ret := node.op in [.eq, .ne] && node.left is ast.CTempVar
 		&& node.left.is_fixed_ret
+	is_nil_cmp := node.right is ast.UnsafeExpr && node.right.expr is ast.Nil
+		&& g.table.final_sym(node.left_type).kind == .interface
 	if is_ctemp_fixed_ret {
 		if node.op == .eq {
 			g.write('!')
@@ -1224,9 +1226,9 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 		g.write('memcmp(')
 	}
 	g.expr(node.left)
-	if !is_ctemp_fixed_ret {
+	if !is_ctemp_fixed_ret && !is_nil_cmp {
 		g.write(' ${node.op.str()} ')
-	} else {
+	} else if !is_nil_cmp {
 		g.write(', ')
 	}
 
@@ -1237,7 +1239,12 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 		g.write('*')
 		g.expr(node.right)
 	} else {
-		g.expr_with_cast(node.right, node.right_type, node.left_type)
+		if is_nil_cmp {
+			sym := g.table.final_sym(node.left_type)
+			g.write('->_typ == _${sym.cname}_voidptr_index')
+		} else {
+			g.expr_with_cast(node.right, node.right_type, node.left_type)
+		}
 	}
 	if is_ctemp_fixed_ret {
 		g.write(', sizeof(${g.styp(node.right_type)}))')

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -1217,8 +1217,6 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 	}
 	is_ctemp_fixed_ret := node.op in [.eq, .ne] && node.left is ast.CTempVar
 		&& node.left.is_fixed_ret
-	is_nil_cmp := node.right is ast.UnsafeExpr && node.right.expr is ast.Nil
-		&& g.table.final_sym(node.left_type).kind == .interface
 	if is_ctemp_fixed_ret {
 		if node.op == .eq {
 			g.write('!')
@@ -1226,9 +1224,9 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 		g.write('memcmp(')
 	}
 	g.expr(node.left)
-	if !is_ctemp_fixed_ret && !is_nil_cmp {
+	if !is_ctemp_fixed_ret {
 		g.write(' ${node.op.str()} ')
-	} else if !is_nil_cmp {
+	} else {
 		g.write(', ')
 	}
 
@@ -1239,12 +1237,7 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 		g.write('*')
 		g.expr(node.right)
 	} else {
-		if is_nil_cmp {
-			sym := g.table.final_sym(node.left_type)
-			g.write('->_typ == _${sym.cname}_voidptr_index')
-		} else {
-			g.expr_with_cast(node.right, node.right_type, node.left_type)
-		}
+		g.expr_with_cast(node.right, node.right_type, node.left_type)
 	}
 	if is_ctemp_fixed_ret {
 		g.write(', sizeof(${g.styp(node.right_type)}))')

--- a/vlib/v/tests/interfaces/interface_edge_cases/fn_returning_voidptr_casted_as_interface_test.v
+++ b/vlib/v/tests/interfaces/interface_edge_cases/fn_returning_voidptr_casted_as_interface_test.v
@@ -23,5 +23,5 @@ fn test_fn_returning_voidptr_casted_as_interface_works() {
 	// TODO: understand the root reason why msvc and
 	// `-cc clang-11 -cflags -fsanitize=memory` produce
 	// something like `&IAbc(e42aff650)` here
-	assert f(pi).contains('&IAbc(')
+	assert f(pi) == '&nil'
 }

--- a/vlib/v/tests/interfaces/interface_nil_cmp_test.v
+++ b/vlib/v/tests/interfaces/interface_nil_cmp_test.v
@@ -1,0 +1,12 @@
+interface Cfg {
+	id string
+}
+
+struct XX {
+	cfg &Cfg = unsafe { nil }
+}
+
+fn test_main() {
+	xx := XX{}
+	assert xx.cfg == unsafe { nil }
+}

--- a/vlib/v/tests/interfaces/interface_nil_cmp_test.v
+++ b/vlib/v/tests/interfaces/interface_nil_cmp_test.v
@@ -9,4 +9,5 @@ struct XX {
 fn test_main() {
 	xx := XX{}
 	assert xx.cfg == unsafe { nil }
+	assert unsafe { nil } == xx.cfg
 }

--- a/vlib/v/tests/structs/struct_init_with_interface_pointer_and_embed_test.v
+++ b/vlib/v/tests/structs/struct_init_with_interface_pointer_and_embed_test.v
@@ -24,6 +24,6 @@ fn test_struct_with_both_an_embed_and_a_pointer_to_interface_value_fields__initi
 	assert si.contains('Embed: Embed{')
 	assert si.contains('foo: 0')
 	assert si.contains('id: 0')
-	assert si.contains('parent: &Node(0x0)')
+	assert si.contains('parent: &nil')
 	assert si.contains('}')
 }


### PR DESCRIPTION
Fix #24374