### PR TITLE
tools: add check for Git repository in v doctor

### DIFF
--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -237,6 +237,11 @@ fn (mut a App) cpu_info(key string) string {
 }
 
 fn (mut a App) git_info() string {
+	// Check if in a Git repository
+	x := os.execute('git rev-parse --is-inside-work-tree')
+	if x.exit_code != 0 || x.output.trim_space() != 'true' {
+		return 'N/A'
+	}
 	mut out := a.cmd(command: 'git -C . describe --abbrev=8 --dirty --always --tags').trim_space()
 	os.execute('git -C . remote add V_REPO https://github.com/vlang/v') // ignore failure (i.e. remote exists)
 	if '-skip-github' !in os.args {


### PR DESCRIPTION
Fix #24419

---

**Tests OK** on Linux Debian with build from 0.4.10 sources + patch for `cmd/tools/vdoctor.v`

```sh
# Download packaged sources for V 0.4.10 and vc commit 66ea39be2275ac723225b9ca99d51ec1212c640d
$ wget https://github.com/vlang/v/archive/refs/tags/0.4.10.tar.gz -O v-0.4.10.tar.gz
$ wget https://github.com/vlang/vc/archive/66ea39be2275ac723225b9ca99d51ec1212c640d.tar.gz -O vc-66ea39be2275ac723225b9ca99d51ec1212c640d.tar.gz

# Extract sources for V 0.4.10
$ tar xzvf v-0.4.10.tar.gz
$ tar xzvf vc-66ea39be2275ac723225b9ca99d51ec1212c640d.tar.gz

$ cd v-0.4.10
$ mv ../vc-66ea39be2275ac723225b9ca99d51ec1212c640d ./vc

Apply patch for cmd/tools/vdoctor.v (function git_info)

# Build with local sources
$ make local=1 prod=1
Using local vc
Using local tcc
The executable './thirdparty/tcc/tcc.exe' does not work.
cc  -std=gnu99 -w -o v1 ./vc/v.c -lm -lpthread  || cmd/tools/cc_compilation_failed_non_windows.sh
./v1 -no-parallel -o v2 -prod cmd/v
./v2 -nocache -o ./v -prod cmd/v
rm -rf v1 v2
```

Output OK for `vdoctor` : V Git status = N/A

```sh
$  ./v doctor
|V full version      |V 0.4.10 9b1937a87166e3327497f332bf9584ff90592617.
|:-------------------|:-------------------
|OS                  |linux, Debian GNU/Linux trixie/sid
|Processor           |8 cpus, 64bit, little endian, Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz
|Memory              |2.5GB/15.5GB
|                    |
|V executable        |/tmp/v-0.4.10/v
|V last modified time|2025-05-05 15:58:57
|                    |
|V home dir          |OK, value: /tmp/v-0.4.10
|VMODULES            |OK, value: /home/fox/.vmodules
|VTMP                |OK, value: /tmp/v_1000
|Current working dir |OK, value: /tmp/v-0.4.10
|                    |
|Git version         |git version 2.47.2
|V git status        |N/A
|.git/config present |false
|                    |
|cc version          |cc (Debian 14.2.0-19) 14.2.0
|gcc version         |gcc (Debian 14.2.0-19) 14.2.0
|clang version       |Debian clang version 19.1.7 (3)
|tcc version         |N/A
|tcc git status      |N/A
|emcc version        |N/A
|glibc version       |ldd (Debian GLIBC 2.41-7) 2.41
```