### PR TITLE
x.json2.decoder2: fix array decoding in struct is field, when array is initialized

### DIFF
--- a/vlib/x/json2/decoder2/decode.v
+++ b/vlib/x/json2/decoder2/decode.v
@@ -618,7 +618,9 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 		decoder.decode_map(mut val)!
 		return
 	} $else $if T.unaliased_typ is $array {
-		unsafe { val.len = 0 }
+		unsafe {
+			val.len = 0
+		}
 		decoder.decode_array(mut val)!
 		// return to avoid the next increment of the current node
 		// this is because the current node is already incremented in the decode_array function

--- a/vlib/x/json2/decoder2/decode.v
+++ b/vlib/x/json2/decoder2/decode.v
@@ -618,6 +618,7 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 		decoder.decode_map(mut val)!
 		return
 	} $else $if T.unaliased_typ is $array {
+		unsafe { val.len = 0 }
 		decoder.decode_array(mut val)!
 		// return to avoid the next increment of the current node
 		// this is because the current node is already incremented in the decode_array function

--- a/vlib/x/json2/decoder2/tests/old_json_compatibility/json_decode_struct_default_test.v
+++ b/vlib/x/json2/decoder2/tests/old_json_compatibility/json_decode_struct_default_test.v
@@ -1,0 +1,21 @@
+import x.json2 as json
+import x.json2.decoder2
+
+struct Bar {
+	b []int = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+}
+
+struct Foo {
+	Bar
+	a []int = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+}
+
+fn test_main() {
+	str := json.encode(Foo{})
+	assert decoder2.decode[Foo](str)!.str() == 'Foo{
+    Bar: Bar{
+        b: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    }
+    a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+}'
+}


### PR DESCRIPTION
```v
import x.json2 as json
import x.json2.decoder2

struct Bar {
	b []int = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
}

struct Foo {
	Bar
	a []int = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
}

fn test_main() {
	str := json.encode(Foo{})
	assert decoder2.decode[Foo](str)!.str() == 'Foo{
    Bar: Bar{
        b: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
    }
    a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
}'
}
```