### PR TITLE
builtin: add diff_array() functions

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -1082,11 +1082,11 @@ fn panic_on_negative_cap(cap int) {
 
 // diff_string returns the difference of two strings.
 pub fn diff_string(a string, b string) []DiffChange {
-	return diff(a.runes(), b.runes())
+	return diff_array(a.runes(), b.runes())
 }
 
-// diff returns the difference of two arrays.
-pub fn diff[T](a []T, b []T) []DiffChange {
+// diff_array returns the difference of two arrays.
+pub fn diff_array[T](a []T, b []T) []DiffChange {
 	mut c := DiffContext[T]{
 		a: a
 		b: b
@@ -1102,7 +1102,7 @@ pub fn diff[T](a []T, b []T) []DiffChange {
 // print_diff prints colorful diff of two arrays.
 @[direct_array_access]
 pub fn print_diff[T](src []T, dst []T) {
-	mut entries := diff[T](src, dst)
+	mut entries := diff_array[T](src, dst)
 	mut prev_a := 0
 	for _, v in entries {
 		if prev_a < v.a {

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -1177,7 +1177,7 @@ fn (mut c DiffContext[T]) compare(mut_aoffset int, mut_boffset int, mut_alimit i
 		}
 		return
 	}
-	mut x, y := c.find_middle_snake(aoffset, boffset, alimit, blimit)
+	x, y := c.find_middle_snake(aoffset, boffset, alimit, blimit)
 	c.compare(aoffset, boffset, x, y)
 	c.compare(x, y, alimit, blimit)
 }

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1778,14 +1778,14 @@ fn test_sorted_with_compare() {
 	assert bb == ['1', '3', '5', 'hi'], 'bb should be sorted, according to the custom comparison callback fn'
 }
 
-fn test_diff() {
+fn test_diff_array() {
 	mut aa := ['hi', '1', '5', '3']
 	mut bb := aa.clone()
-	assert diff(aa, bb) == []
+	assert diff_array(aa, bb) == []
 	bb.insert(2, 'max')
 	// aa := ['hi', '1', '5', '3']
 	// bb := ['hi', '1', 'max', '5', '3']
-	assert diff(aa, bb) == [DiffChange{
+	assert diff_array(aa, bb) == [DiffChange{
 		a:   2
 		b:   2
 		del: 0
@@ -1795,7 +1795,7 @@ fn test_diff() {
 	bb.delete(4)
 	// aa := ['hi', '1', '5', '3']
 	// bb := ['hi', '1', 'max', '5']
-	assert diff(aa, bb) == [DiffChange{
+	assert diff_array(aa, bb) == [DiffChange{
 		a:   2
 		b:   2
 		del: 0

--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -1777,3 +1777,65 @@ fn test_sorted_with_compare() {
 	assert aa == ['hi', '1', '5', '3'], 'aa should stay unmodified'
 	assert bb == ['1', '3', '5', 'hi'], 'bb should be sorted, according to the custom comparison callback fn'
 }
+
+fn test_diff() {
+	mut aa := ['hi', '1', '5', '3']
+	mut bb := aa.clone()
+	assert diff(aa, bb) == []
+	bb.insert(2, 'max')
+	// aa := ['hi', '1', '5', '3']
+	// bb := ['hi', '1', 'max', '5', '3']
+	assert diff(aa, bb) == [DiffChange{
+		a:   2
+		b:   2
+		del: 0
+		ins: 1
+	}]
+
+	bb.delete(4)
+	// aa := ['hi', '1', '5', '3']
+	// bb := ['hi', '1', 'max', '5']
+	assert diff(aa, bb) == [DiffChange{
+		a:   2
+		b:   2
+		del: 0
+		ins: 1
+	}, DiffChange{
+		a:   3
+		b:   4
+		del: 1
+		ins: 0
+	}]
+
+	print_diff(aa, bb)
+	/*
+['hi', '1']
++ ['max']
+  ['5']
+- ['3']
+	*/
+
+	a_str := '1234567890abcdef'
+	b_str := 'x1234567890acdef'
+	assert diff_string(a_str, b_str) == [
+		DiffChange{
+			a:   0
+			b:   0
+			del: 0
+			ins: 1
+		},
+		DiffChange{
+			a:   11
+			b:   12
+			del: 1
+			ins: 0
+		},
+	]
+	print_diff(a_str.runes(), b_str.runes())
+	/*
++ [`x`]
+  [`1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `0`, `a`]
+- [`b`]
+  [`c`, `d`, `e`, `f`]
+	*/
+}

--- a/vlib/v/checker/tests/globals/assign_global_to_shared_err.out
+++ b/vlib/v/checker/tests/globals/assign_global_to_shared_err.out
@@ -1,18 +1,18 @@
 vlib/v/checker/tests/globals/assign_global_to_shared_err.vv:5:9: warning: unused variable: `b`
     3 | 
     4 | fn main() {
-    5 |     shared b := a
+    5 |     shared b := global_a
       |            ^
     6 | }
 vlib/v/checker/tests/globals/assign_global_to_shared_err.vv:5:14: error: cannot assign global variable to shared variable
     3 | 
     4 | fn main() {
-    5 |     shared b := a
-      |                 ^
+    5 |     shared b := global_a
+      |                 ~~~~~~~~
     6 | }
 vlib/v/checker/tests/globals/assign_global_to_shared_err.vv:5:14: error: cannot copy map: call `move` or `clone` method (or use a reference)
     3 | 
     4 | fn main() {
-    5 |     shared b := a
-      |                 ^
+    5 |     shared b := global_a
+      |                 ~~~~~~~~
     6 | }

--- a/vlib/v/checker/tests/globals/assign_global_to_shared_err.vv
+++ b/vlib/v/checker/tests/globals/assign_global_to_shared_err.vv
@@ -1,6 +1,6 @@
 @[has_globals]
-__global a = {1: 'one', 2: 'two'}
+__global global_a = {1: 'one', 2: 'two'}
 
 fn main() {
-	shared b := a
+	shared b := global_a
 }

--- a/vlib/v/checker/tests/globals/unknown_typ.out
+++ b/vlib/v/checker/tests/globals/unknown_typ.out
@@ -1,11 +1,11 @@
-vlib/v/checker/tests/globals/unknown_typ.vv:1:12: error: unknown type `foo`
-    1 | __global x foo
-      |            ~~~
+vlib/v/checker/tests/globals/unknown_typ.vv:1:19: error: unknown type `foo`
+    1 | __global global_x foo
+      |                   ~~~
     2 | __global (
-    3 |     y = float(5.0)
-vlib/v/checker/tests/globals/unknown_typ.vv:3:6: error: unknown function: float
-    1 | __global x foo
+    3 |     global_y = float(5.0)
+vlib/v/checker/tests/globals/unknown_typ.vv:3:13: error: unknown function: float
+    1 | __global global_x foo
     2 | __global (
-    3 |     y = float(5.0)
-      |         ~~~~~~~~~~
+    3 |     global_y = float(5.0)
+      |                ~~~~~~~~~~
     4 | )

--- a/vlib/v/checker/tests/globals/unknown_typ.vv
+++ b/vlib/v/checker/tests/globals/unknown_typ.vv
@@ -1,4 +1,4 @@
-__global x foo
+__global global_x foo
 __global (
-	y = float(5.0)
+	global_y = float(5.0)
 )


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR add `diff_array[T]()` functions. This will help build portable `diff` utility.

A directly conversion from https://github.com/covrom/diff
Fast diff library for Myers algorithm.
The algorithm is described in "An O(ND) Difference Algorithm and its Variations", Eugene Myers, Algorithmica Vol. 1 No. 2, 1986, pp. 251-266