### PR TITLE
Fix v doctor output on FreeBSD, do not run ldd to get glibc version

### DIFF
--- a/cmd/tools/vdoctor.v
+++ b/cmd/tools/vdoctor.v
@@ -149,7 +149,7 @@ fn (mut a App) collect_info() {
 	}
 	a.report_tcc_version('thirdparty/tcc')
 	a.line('emcc version', a.cmd(command: 'emcc --version'))
-	if os_kind != 'openbsd' {
+	if os_kind != 'openbsd' && os_kind != 'freebsd' {
 		a.line('glibc version', a.cmd(command: 'ldd --version'))
 	} else {
 		a.line('glibc version', 'N/A')


### PR DESCRIPTION
glibc not available on FreeBSD

**Tests OK on FreeBSD 14.2**

```sh
$ ./v doctor
|V full version      |V 0.4.10 dd859eae55cf4e69346851fe285b9af104c8ffb7.bab0441
|:-------------------|:-------------------
|OS                  |freebsd, 14.2-RELEASE-p1, FreeBSD 14.2-RELEASE-p1 GENERIC
|Processor           |4 cpus, 64bit, little endian
|Memory              |0.62GB/0.97GB
|                    |
|V executable        |/home/fox/dev/vlang.git/v
|V last modified time|2025-05-06 13:32:11
|                    |
|V home dir          |OK, value: /home/fox/dev/vlang.git
|VMODULES            |OK, value: /home/fox/.vmodules
|VTMP                |OK, value: /tmp/v_1000
|Current working dir |OK, value: /home/fox/dev/vlang.git
|                    |
|Git version         |git version 2.48.1
|V git status        |weekly.2025.17-60-gbab04415
|.git/config present |true
|                    |
|cc version          |FreeBSD clang version 18.1.6 (https://github.com/llvm/llvm-project.git llvmorg-18.1.6-0-g1118c2e05e67)
|gcc version         |N/A
|clang version       |FreeBSD clang version 18.1.6 (https://github.com/llvm/llvm-project.git llvmorg-18.1.6-0-g1118c2e05e67)
|tcc version         |tcc version 0.9.28rc 2025-02-13 HEAD@f8bd136d (x86_64 FreeBSD)
|tcc git status      |thirdparty-freebsd-amd64 2f0f0f13
|emcc version        |N/A
|glibc version       |N/A
```

**Tests OK on Linux Debian/testing**

```sh
$ ./v doctor
|V full version      |V 0.4.10 dd859eae55cf4e69346851fe285b9af104c8ffb7.bab0441
|:-------------------|:-------------------
|OS                  |linux, Debian GNU/Linux trixie/sid
|Processor           |8 cpus, 64bit, little endian, Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz
|Memory              |0.91GB/15.5GB
|                    |
|V executable        |/home/fox/dev/vlang.git/v
|V last modified time|2025-05-06 13:39:59
|                    |
|V home dir          |OK, value: /home/fox/dev/vlang.git
|VMODULES            |OK, value: /home/fox/.vmodules
|VTMP                |OK, value: /tmp/v_1000
|Current working dir |OK, value: /home/fox/dev/vlang.git
|                    |
|Git version         |git version 2.47.2
|V git status        |weekly.2025.17-60-gbab04415
|.git/config present |true
|                    |
|cc version          |cc (Debian 14.2.0-19) 14.2.0
|gcc version         |gcc (Debian 14.2.0-19) 14.2.0
|clang version       |Debian clang version 19.1.7 (3)
|tcc version         |tcc version 0.9.28rc 2025-02-13 HEAD@f8bd136d (x86_64 Linux)
|tcc git status      |thirdparty-linux-amd64 696c1d84
|emcc version        |N/A
|glibc version       |ldd (Debian GLIBC 2.41-7) 2.41
```