### PR TITLE
runtime: improve free_memory implementation for OpenBSD

### DIFF
--- a/vlib/runtime/free_memory_impl_openbsd.c.v
+++ b/vlib/runtime/free_memory_impl_openbsd.c.v
@@ -1,14 +1,24 @@
 module runtime
 
+#include <sys/sysctl.h>
+#include <uvm/uvmexp.h>
+
+struct C.uvmexp {
+	pagesize int
+	free     int
+}
+
 fn free_memory_impl() usize {
 	$if cross ? {
 		return 1
 	}
 	$if !cross ? {
 		$if openbsd {
-			page_size := usize(C.sysconf(C._SC_PAGESIZE))
-			av_phys_pages := usize(C.sysconf(C._SC_AVPHYS_PAGES))
-			return page_size * av_phys_pages
+			mib := [C.CTL_VM, C.VM_UVMEXP]!
+			mut uvm := C.uvmexp{0, 0}
+			mut len := sizeof(C.uvmexp)
+			unsafe { C.sysctl(&mib[0], mib.len, &uvm, &len, C.NULL, 0) }
+			return usize(uvm.pagesize * uvm.free)
 		}
 	}
 	return 1


### PR DESCRIPTION
It's more accurate to use `sysctl` with `uvmexp` struct (statistics about the UVM memory management system) to get pagesize and free pages, than using calls to `C.sysconf`.

See [OpenBSD uvm/uvmexp.h](https://github.com/openbsd/src/blob/master/sys/uvm/uvmexp.h) include file for definition of `uvmexp` struct.

**Tests OK on OpenBSD current/amd64**

`get_free_memory.v`:

```v

// Get free memory (vlib/runtime/free_memory_impl*.c.v)

import os
import runtime

fn main() {
        println('OS: ${os.user_os()}')

        total := runtime.total_memory()
        free := runtime.free_memory()

        println('total memory: ${total}')
        println('free  memory: ${free}')
}
```

```sh
$ ./v run ~/tmp/get_free_memory.v 
OS: openbsd
total memory: 4278042624
free  memory: 1475702784
```