### PR TITLE
toml: add compile error when passing `encode/1` types of T != struct

### DIFF
--- a/vlib/toml/toml.v
+++ b/vlib/toml/toml.v
@@ -167,13 +167,18 @@ fn decode_struct[T](doc Any, mut typ T) {
 // encode encodes the type `T` into a TOML string.
 // If `T` has a custom `.to_toml()` method, it will be used instead of the default.
 pub fn encode[T](typ T) string {
-	$for method in T.methods {
-		$if method.name == 'to_toml' {
-			return typ.$method()
+	$if T is $struct {
+		$for method in T.methods {
+			$if method.name == 'to_toml' {
+				return typ.$method()
+			}
 		}
+		mp := encode_struct[T](typ)
+		return mp.to_toml()
+	} $else {
+		$compile_error('Currently only type `struct` is supported for `T` to encode as TOML')
 	}
-	mp := encode_struct[T](typ)
-	return mp.to_toml()
+	return ''
 }
 
 fn encode_struct[T](typ T) map[string]Any {


### PR DESCRIPTION
fixes #24435 ... kind of. The C error should still be fixed somehow IMO and maybe the MRE in #24435 is actually valuable. I can reproduce something similar with e.g. (without importing `toml`):

```v
module main

type Any = string | int

fn (a Any) to_toml() string {
	return match a {
		string {
			'TOML string'
		}
		int {
			'TOML int'
		}
	}
}

fn (m map[string]Any) to_toml() string {
	mut t := ''
	for _, v in m {
		t += v.to_toml() + ','
	}
	return t
}

fn main() {
	mut doc := map[string]Any{}
	doc['key'] = Any('value')

	// Try to encode it - this is where the bug occurs
	toml_content := encode(doc)

	println(toml_content)
}

fn encode[T](typ T) string {
	$for method in T.methods {
		$if method.name == 'to_toml' {
			return typ.$method()
		}
	}
	mp := encode_struct[T](typ)
	return mp.to_toml()
}

fn encode_struct[T](typ T) map[string]Any {
	mut mp := map[string]Any{}
	$for field in T.fields {
		mut skip := false
		mut field_name := field.name
		for attr in field.attrs {
			if attr == 'skip' {
				skip = true
				break
			}
			if attr.starts_with('toml:') {
				field_name = attr.all_after(':').trim_space()
			}
		}
		if !skip {
			mp[field_name] = to_any(typ.$(field.name))
		}
	}
	return mp
}
```