### PR TITLE
runtime: fix cast error in free_memory implementation for OpenBSD

### DIFF
--- a/vlib/runtime/free_memory_impl_openbsd.c.v
+++ b/vlib/runtime/free_memory_impl_openbsd.c.v
@@ -18,7 +18,7 @@ fn free_memory_impl() usize {
 			mut uvm := C.uvmexp{0, 0}
 			mut len := sizeof(C.uvmexp)
 			unsafe { C.sysctl(&mib[0], mib.len, &uvm, &len, C.NULL, 0) }
-			return usize(uvm.pagesize * uvm.free)
+			return usize(uvm.pagesize) * usize(uvm.free)
 		}
 	}
 	return 1


### PR DESCRIPTION
In my previous commit https://github.com/vlang/v/commit/656afa9d1380abd037e00d6b9ce43726f7981de6, error in cast (usize) to get free memory on OpenBSD.

**Tests OK on OpenBSD current/amd64**

Code to illustrate this error with cast: `get_free_mem.c.v`

```go
#include <sys/sysctl.h>
#include <uvm/uvmexp.h>

struct C.uvmexp {
        pagesize int
        free int
}

fn main() {
        mib := [C.CTL_VM, C.VM_UVMEXP]!
        mut uvm := C.uvmexp{0, 0}
        mut len := sizeof(C.uvmexp)

        unsafe { C.sysctl(&mib[0], mib.len, &uvm, &len, C.NULL, 0) }
        println('uvm.pagesize = ${usize(uvm.pagesize)}')
        println('uvm.free = ${usize(uvm.free)}')

        free_mem := usize(uvm.pagesize) * usize(uvm.free)
        println('free mem = ${free_mem}')

        // Error with cast to usize (int * int)
        free_mem_1 := usize(uvm.pagesize * uvm.free)
        println('free mem_1 = ${free_mem_1}')
}
```

```sh
$ ./v run get_free_mem.c.v
uvm.pagesize = 4096
uvm.free = 679461
free mem = 2783072256   <-- GOOD (code for this commit)
free mem_1 = 18446744072197656576 <-- BAD (code from my previous commit)
```