### PR TITLE
slow_tests: fix good broken test

### DIFF
--- a/vlib/v/slow_tests/assembly/asm_test.amd64.v
+++ b/vlib/v/slow_tests/assembly/asm_test.amd64.v
@@ -100,7 +100,7 @@ fn test_inline_asm() {
 
 	assert util.add(8, 9, 34, 7) == 58 // test .amd64.v imported files
 
-	mut o := Manu{}
+	mut o := &Manu{}
 	asm amd64 {
 		mov eax, 0
 		cpuid
@@ -108,7 +108,7 @@ fn test_inline_asm() {
 		  =d (o.edx) as edx0
 		  =c (o.ecx) as ecx0
 	}
-	o.str()
+	assert o.str()[0].is_capital()
 }
 
 @[packed]
@@ -120,11 +120,11 @@ mut:
 	zero u8 // for string
 }
 
-fn (m Manu) str() string {
+fn (m &Manu) str() string {
 	return unsafe {
 		string{
-			str:    &u8(&m)
-			len:    24
+			str:    m
+			len:    12
 			is_lit: 1
 		}
 	}


### PR DESCRIPTION
A good and important test that didn't work at all and returned garbage.
I decided to fix it in this batch while minimally touching everything else.

Now everything is ok and the result will always start with a capital letter.