### PR TITLE
cgen: fix const declaration dependant mapping when using update_expr

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2601,6 +2601,9 @@ pub fn (t &Table) dependent_names_in_expr(expr Expr) []string {
 			names << t.dependent_names_in_expr(expr.expr)
 		}
 		StructInit {
+			if expr.has_update_expr {
+				names << t.dependent_names_in_expr(expr.update_expr)
+			}
 			for field in expr.init_fields {
 				names << t.dependent_names_in_expr(field.expr)
 			}

--- a/vlib/v/tests/consts/const_depend_update_expr_test.v
+++ b/vlib/v/tests/consts/const_depend_update_expr_test.v
@@ -1,0 +1,17 @@
+struct Cfg {
+	id   string
+	name string
+}
+
+pub const cfg1 = Cfg{
+	...cfg0
+	name: 'name1'
+}
+pub const cfg0 = Cfg{
+	id:   'cfg0'
+	name: 'name'
+}
+
+fn test_main() {
+	assert cfg1.id == 'cfg0'
+}


### PR DESCRIPTION
Fix #24437