### PR TITLE
cgen: fix assign from mut `for` variable to pointer

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -969,6 +969,11 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 					defer {
 						g.is_option_auto_heap = old_is_auto_heap
 					}
+					if val is ast.Ident && val.is_mut() && var_type.is_ptr() {
+						if var_type.nr_muls() < val_type.nr_muls() {
+							g.write('*'.repeat(var_type.nr_muls()))
+						}
+					}
 					g.is_option_auto_heap = val_type.has_flag(.option) && val is ast.PrefixExpr
 						&& val.right is ast.Ident && (val.right as ast.Ident).is_auto_heap()
 					if var_type.has_flag(.option) || gen_or {

--- a/vlib/v/tests/assign/assign_mut_for_var_test.v
+++ b/vlib/v/tests/assign/assign_mut_for_var_test.v
@@ -1,0 +1,24 @@
+@[heap]
+struct Demo {
+	a string
+}
+
+fn test_main() {
+	mut rl := [&Demo{'A'}]
+
+	assert rl[0].a == 'A'
+
+	mut p := &Demo{}
+	for mut e in rl {
+		p = e
+	}
+
+	assert p.a == 'A'
+
+	for i in 0 .. rl.len {
+		mut e := rl[i]
+		p = e
+	}
+
+	assert p.a == 'A'
+}


### PR DESCRIPTION
Fix #24432