### PR TITLE
jsgen: a pointer function cannot be called directly (fix #24417)

### DIFF
--- a/vlib/v/gen/js/fn.v
+++ b/vlib/v/gen/js/fn.v
@@ -437,7 +437,11 @@ fn (mut g JsGen) gen_call_expr(it ast.CallExpr) {
 	name = g.generic_fn_name(node.concrete_types, name)
 	g.expr(it.left)
 
-	g.write('${name}(')
+	g.write(name)
+	if it.fn_var_type.is_ptr() {
+		g.write('.val')
+	}
+	g.write('(')
 	for i, arg in it.args {
 		g.expr(arg.expr)
 		if i != it.args.len - 1 {

--- a/vlib/v/gen/js/tests/function.v
+++ b/vlib/v/gen/js/tests/function.v
@@ -1,0 +1,21 @@
+const hello = 'hello world!'
+
+fn main() {
+	// calls a function directly
+	cb1 := fn () string {
+		return hello
+	}
+	assert cb1() == hello
+
+	// calls a function indirectly
+	cb2 := cb1
+	assert cb2() == hello
+
+	// calls a pointer function
+	cb3 := &cb1
+	assert cb3() == hello
+
+	// calls a pointer function of a pointer function
+	cb4 := &cb3
+	assert cb4() == hello
+}


### PR DESCRIPTION
Fixes #24417 