### PR TITLE
slow_tests: use strict pointer casting in asm_test.amd64.v

### DIFF
--- a/vlib/v/slow_tests/assembly/asm_test.amd64.v
+++ b/vlib/v/slow_tests/assembly/asm_test.amd64.v
@@ -123,7 +123,7 @@ mut:
 fn (m &Manu) str() string {
 	return unsafe {
 		string{
-			str:    m
+			str:    &u8(m)
 			len:    12
 			is_lit: 1
 		}


### PR DESCRIPTION
Lets fix this warning too.

```
cpuid.c: In function 'main__Manu_str':
cpuid.c:5941:33: warning: initialization of 'u8 *' {aka 'unsigned char *'} from incompatible pointer type 'main__Manu *' [-Wincompatible-pointer-types]
 5941 |         return ((string){.str = m, .len = 12, .is_lit = 1});
      |                                 ^
cpuid.c:5941:33: note: (near initialization for '(anonymous).str')
```