### PR TITLE
vtest: remove ts.vroot only from beginning of the path (fix #24363)

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -417,7 +417,7 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 		cmd_options << ' -enable-globals'
 	}
 	if ts.root_relative {
-		relative_file = relative_file.replace(ts.vroot + os.path_separator, '')
+		relative_file = relative_file.replace_once(ts.vroot + os.path_separator, '')
 	}
 	file := os.real_path(relative_file)
 	mtc := MessageThreadContext{


### PR DESCRIPTION
To transform an absolute path into a relative one, you need to remove the `root` only at the beginning of the path, not everywhere.
I'm curious how this will work in `CI`.