### PR TITLE
term/ui: fix fatal from missing cursor pos resp

### DIFF
--- a/vlib/term/ui/termios_nix.c.v
+++ b/vlib/term/ui/termios_nix.c.v
@@ -168,6 +168,9 @@ fn get_cursor_position() (int, int) {
 		buf[len] = 0
 		s = tos(buf, len)
 	}
+	if s.len == 0 {
+		return -1, -1
+	}
 	a := s[2..].split(';')
 	if a.len != 2 {
 		return -1, -1

--- a/vlib/term/ui/termios_nix_test.v
+++ b/vlib/term/ui/termios_nix_test.v
@@ -1,0 +1,65 @@
+module ui
+
+fn test_get_cursor_position_reads_valid_row_column_data() ! {
+	mut pipeset := [0, 0]
+	mut original_stdin_fd := -1
+	unsafe {
+		if C.pipe(&pipeset[0]) == -1 {
+			return error("unable to create pipe: ${C.strerror(C.errno)}")
+		}
+
+		fake_cursor_pos_data := '\033[45;70R'
+		written_bytes := C.write(pipeset[1], fake_cursor_pos_data.str, fake_cursor_pos_data.len)
+		if written_bytes == -1 {
+			C.close(pipeset[0])
+			C.close(pipeset[1])
+			return error("error writing into pipe: ${C.strerror(C.errno)}")
+		}
+
+		C.close(pipeset[1])
+
+		if C.dup2(pipeset[0], C.STDIN_FILENO) == -1 {
+			C.close(pipeset[0])
+			return error("error redirecting stdin with dup2: ${C.strerror(C.errno)}")
+		}
+
+		C.close(pipeset[0])
+
+		cursor_pos_x, cursor_pos_y := get_cursor_position()
+		assert cursor_pos_x == 45
+		assert cursor_pos_y == 70
+	}
+}
+
+fn test_get_cursor_position_reads_empty_position_data() ! {
+	mut pipeset := [0, 0]
+	mut original_stdin_fd := -1
+	unsafe {
+		if C.pipe(&pipeset[0]) == -1 {
+			return error("unable to create pipe: ${C.strerror(C.errno)}")
+		}
+
+		fake_cursor_pos_data := ''
+		written_bytes := C.write(pipeset[1], fake_cursor_pos_data.str, fake_cursor_pos_data.len)
+		if written_bytes == -1 {
+			C.close(pipeset[0])
+			C.close(pipeset[1])
+			return error("error writing into pipe: ${C.strerror(C.errno)}")
+		}
+
+		C.close(pipeset[1])
+
+		if C.dup2(pipeset[0], C.STDIN_FILENO) == -1 {
+			C.close(pipeset[0])
+			return error("error redirecting stdin with dup2: ${C.strerror(C.errno)}")
+		}
+
+		C.close(pipeset[0])
+
+		cursor_pos_x, cursor_pos_y := get_cursor_position()
+		assert cursor_pos_x == -1
+		assert cursor_pos_y == -1
+	}
+}
+
+

--- a/vlib/term/ui/termios_nix_test.v
+++ b/vlib/term/ui/termios_nix_test.v
@@ -5,7 +5,7 @@ fn test_get_cursor_position_reads_valid_row_column_data() ! {
 	mut original_stdin_fd := -1
 	unsafe {
 		if C.pipe(&pipeset[0]) == -1 {
-			return error("unable to create pipe: ${C.strerror(C.errno)}")
+			return error('unable to create pipe: ${C.strerror(C.errno)}')
 		}
 
 		fake_cursor_pos_data := '\033[45;70R'
@@ -13,14 +13,14 @@ fn test_get_cursor_position_reads_valid_row_column_data() ! {
 		if written_bytes == -1 {
 			C.close(pipeset[0])
 			C.close(pipeset[1])
-			return error("error writing into pipe: ${C.strerror(C.errno)}")
+			return error('error writing into pipe: ${C.strerror(C.errno)}')
 		}
 
 		C.close(pipeset[1])
 
 		if C.dup2(pipeset[0], C.STDIN_FILENO) == -1 {
 			C.close(pipeset[0])
-			return error("error redirecting stdin with dup2: ${C.strerror(C.errno)}")
+			return error('error redirecting stdin with dup2: ${C.strerror(C.errno)}')
 		}
 
 		C.close(pipeset[0])
@@ -36,7 +36,7 @@ fn test_get_cursor_position_reads_empty_position_data() ! {
 	mut original_stdin_fd := -1
 	unsafe {
 		if C.pipe(&pipeset[0]) == -1 {
-			return error("unable to create pipe: ${C.strerror(C.errno)}")
+			return error('unable to create pipe: ${C.strerror(C.errno)}')
 		}
 
 		fake_cursor_pos_data := ''
@@ -44,14 +44,14 @@ fn test_get_cursor_position_reads_empty_position_data() ! {
 		if written_bytes == -1 {
 			C.close(pipeset[0])
 			C.close(pipeset[1])
-			return error("error writing into pipe: ${C.strerror(C.errno)}")
+			return error('error writing into pipe: ${C.strerror(C.errno)}')
 		}
 
 		C.close(pipeset[1])
 
 		if C.dup2(pipeset[0], C.STDIN_FILENO) == -1 {
 			C.close(pipeset[0])
-			return error("error redirecting stdin with dup2: ${C.strerror(C.errno)}")
+			return error('error redirecting stdin with dup2: ${C.strerror(C.errno)}')
 		}
 
 		C.close(pipeset[0])
@@ -61,5 +61,3 @@ fn test_get_cursor_position_reads_empty_position_data() ! {
 		assert cursor_pos_y == -1
 	}
 }
-
-


### PR DESCRIPTION
There are some cases I've encountered when running a V terminal/TUI application where the host does not respond with actual cursor position data when requested. If this occurs we get an OOB panic, even if the TUI application doesn't need or care what the current cursor position is.

This very simple PR just adds an additional check to prevent an OOB based panic/fatal crash and also includes a test to demonstrate that this is working as expected.