### PR TITLE
sync.stdatomic: workaround libatomic.a indirect symbols tcc bug

### DIFF
--- a/vlib/sync/stdatomic/1.declarations.c.v
+++ b/vlib/sync/stdatomic/1.declarations.c.v
@@ -29,19 +29,40 @@ $if linux {
 				#flag $when_first_existing('/usr/lib/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/6/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/7/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/8/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/9/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/10/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/11/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/12/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/13/libatomic.a','/usr/lib/gcc/x86_64-pc-linux-musl/14/libatomic.a')
 			}
 		} $else $if arm64 {
+			// Note: Use `.so` instead of `.a`.
+			// This is because `libatomic.a` atomic symbols, such as `__atomic_fetch_add_4`, are indirect(IFUNC) symbols:
+			// This can not be handled correctly by `tcc` right now.
+
+			// Symbol table '.symtab' contains 14 entries:
+			//   Num:    Value          Size Type    Bind   Vis      Ndx Name
+			//     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
+			//     1: 0000000000000000     0 SECTION LOCAL  DEFAULT    1
+			//     2: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT    1 $x
+			//     3: 0000000000000030    12 FUNC    LOCAL  DEFAULT    1 select_fetch_add_4
+			//     4: 0000000000000040    12 FUNC    LOCAL  DEFAULT    1 select_add_fetch_4
+			//     5: 0000000000000014     0 NOTYPE  LOCAL  DEFAULT    6 $d
+			//     6: 0000000000000000     0 SECTION LOCAL  DEFAULT    3
+			//     7: 0000000000000000     0 SECTION LOCAL  DEFAULT    4
+			//     8: 0000000000000000     0 SECTION LOCAL  DEFAULT    5
+			//     9: 0000000000000000     0 SECTION LOCAL  DEFAULT    6
+			//    10: 0000000000000000    24 FUNC    GLOBAL HIDDEN     1 libat_fetch_add_4
+			//    11: 0000000000000018    24 FUNC    GLOBAL HIDDEN     1 libat_add_fetch_4
+			//    12: 0000000000000030    12 IFUNC   GLOBAL DEFAULT    1 __atomic_fetch_add_4
+			//    13: 0000000000000040    12 IFUNC   GLOBAL DEFAULT    1 __atomic_add_fetch_4
+
 			// Debian/Ubuntu:
-			#flag $when_first_existing('/usr/lib/gcc/aarch64-linux-gnu/6/libatomic.a','/usr/lib/gcc/aarch64-linux-gnu/7/libatomic.a','/usr/lib/gcc/aarch64-linux-gnu/8/libatomic.a','/usr/lib/gcc/aarch64-linux-gnu/9/libatomic.a','/usr/lib/gcc/aarch64-linux-gnu/10/libatomic.a','/usr/lib/gcc/aarch64-linux-gnu/11/libatomic.a','/usr/lib/gcc/aarch64-linux-gnu/12/libatomic.a','/usr/lib/gcc/aarch64-linux-gnu/13/libatomic.a','/usr/lib/gcc/aarch64-linux-gnu/14/libatomic.a')
+			#flag $when_first_existing('/usr/lib/gcc/aarch64-linux-gnu/6/libatomic.so','/usr/lib/gcc/aarch64-linux-gnu/7/libatomic.so','/usr/lib/gcc/aarch64-linux-gnu/8/libatomic.so','/usr/lib/gcc/aarch64-linux-gnu/9/libatomic.so','/usr/lib/gcc/aarch64-linux-gnu/10/libatomic.so','/usr/lib/gcc/aarch64-linux-gnu/11/libatomic.so','/usr/lib/gcc/aarch64-linux-gnu/12/libatomic.so','/usr/lib/gcc/aarch64-linux-gnu/13/libatomic.so','/usr/lib/gcc/aarch64-linux-gnu/14/libatomic.so')
 			// Redhat/CentOS:
-			#flag $when_first_existing('/usr/lib/gcc/aarch64-redhat-linux/6/libatomic.a','/usr/lib/gcc/aarch64-redhat-linux/7/libatomic.a','/usr/lib/gcc/aarch64-redhat-linux/8/libatomic.a','/usr/lib/gcc/aarch64-redhat-linux/9/libatomic.a','/usr/lib/gcc/aarch64-redhat-linux/10/libatomic.a','/usr/lib/gcc/aarch64-redhat-linux/11/libatomic.a','/usr/lib/gcc/aarch64-redhat-linux/12/libatomic.a','/usr/lib/gcc/aarch64-redhat-linux/13/libatomic.a','/usr/lib/gcc/aarch64-redhat-linux/14/libatomic.a')
+			#flag $when_first_existing('/usr/lib/gcc/aarch64-redhat-linux/6/libatomic.so','/usr/lib/gcc/aarch64-redhat-linux/7/libatomic.so','/usr/lib/gcc/aarch64-redhat-linux/8/libatomic.so','/usr/lib/gcc/aarch64-redhat-linux/9/libatomic.so','/usr/lib/gcc/aarch64-redhat-linux/10/libatomic.so','/usr/lib/gcc/aarch64-redhat-linux/11/libatomic.so','/usr/lib/gcc/aarch64-redhat-linux/12/libatomic.so','/usr/lib/gcc/aarch64-redhat-linux/13/libatomic.so','/usr/lib/gcc/aarch64-redhat-linux/14/libatomic.so')
 			// Gentoo:
-			#flag $when_first_existing('/usr/lib/gcc/aarch64-pc-linux-gnu/6/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-gnu/7/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-gnu/8/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-gnu/9/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-gnu/10/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-gnu/11/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-gnu/12/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-gnu/13/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-gnu/14/libatomic.a')
+			#flag $when_first_existing('/usr/lib/gcc/aarch64-pc-linux-gnu/6/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-gnu/7/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-gnu/8/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-gnu/9/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-gnu/10/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-gnu/11/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-gnu/12/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-gnu/13/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-gnu/14/libatomic.so')
 			// OpenSUSE:
-			#flag $when_first_existing('/usr/lib64/gcc/aarch64-suse-linux/6/libatomic.a','/usr/lib64/gcc/aarch64-suse-linux/7/libatomic.a','/usr/lib64/gcc/aarch64-suse-linux/8/libatomic.a','/usr/lib64/gcc/aarch64-suse-linux/9/libatomic.a','/usr/lib64/gcc/aarch64-suse-linux/10/libatomic.a','/usr/lib64/gcc/aarch64-suse-linux/11/libatomic.a','/usr/lib64/gcc/aarch64-suse-linux/12/libatomic.a','/usr/lib64/gcc/aarch64-suse-linux/13/libatomic.a','/usr/lib64/gcc/aarch64-suse-linux/14/libatomic.a')
+			#flag $when_first_existing('/usr/lib64/gcc/aarch64-suse-linux/6/libatomic.so','/usr/lib64/gcc/aarch64-suse-linux/7/libatomic.so','/usr/lib64/gcc/aarch64-suse-linux/8/libatomic.so','/usr/lib64/gcc/aarch64-suse-linux/9/libatomic.so','/usr/lib64/gcc/aarch64-suse-linux/10/libatomic.so','/usr/lib64/gcc/aarch64-suse-linux/11/libatomic.so','/usr/lib64/gcc/aarch64-suse-linux/12/libatomic.so','/usr/lib64/gcc/aarch64-suse-linux/13/libatomic.so','/usr/lib64/gcc/aarch64-suse-linux/14/libatomic.so')
 			// ALT Linux:
-			#flag $when_first_existing('/usr/lib64/gcc/aarch64-alt-linux/6/libatomic.a','/usr/lib64/gcc/aarch64-alt-linux/7/libatomic.a','/usr/lib64/gcc/aarch64-alt-linux/8/libatomic.a','/usr/lib64/gcc/aarch64-alt-linux/9/libatomic.a','/usr/lib64/gcc/aarch64-alt-linux/10/libatomic.a','/usr/lib64/gcc/aarch64-alt-linux/11/libatomic.a','/usr/lib64/gcc/aarch64-alt-linux/12/libatomic.a','/usr/lib64/gcc/aarch64-alt-linux/13/libatomic.a','/usr/lib64/gcc/aarch64-alt-linux/14/libatomic.a')
+			#flag $when_first_existing('/usr/lib64/gcc/aarch64-alt-linux/6/libatomic.so','/usr/lib64/gcc/aarch64-alt-linux/7/libatomic.so','/usr/lib64/gcc/aarch64-alt-linux/8/libatomic.so','/usr/lib64/gcc/aarch64-alt-linux/9/libatomic.so','/usr/lib64/gcc/aarch64-alt-linux/10/libatomic.so','/usr/lib64/gcc/aarch64-alt-linux/11/libatomic.so','/usr/lib64/gcc/aarch64-alt-linux/12/libatomic.so','/usr/lib64/gcc/aarch64-alt-linux/13/libatomic.so','/usr/lib64/gcc/aarch64-alt-linux/14/libatomic.so')
 			$if musl ? {
 				// Alpine:
-				#flag $when_first_existing('/usr/lib/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-musl/6/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-musl/7/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-musl/8/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-musl/9/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-musl/10/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-musl/11/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-musl/12/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-musl/13/libatomic.a','/usr/lib/gcc/aarch64-pc-linux-musl/14/libatomic.a')
+				#flag $when_first_existing('/usr/lib/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-musl/6/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-musl/7/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-musl/8/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-musl/9/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-musl/10/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-musl/11/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-musl/12/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-musl/13/libatomic.so','/usr/lib/gcc/aarch64-pc-linux-musl/14/libatomic.so')
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Fix issue #23924

This is due to a `tcc` bug handling indirect(IFUNC) symbols in `.a`.
I think it should generate a `GOT/PLT` in output elf file. 
It can't determine the symbol's address at compile time.
https://lists.nongnu.org/archive/html/tinycc-devel/2025-05/msg00010.html