### PR TITLE
math.big: new function com() + tests

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -813,6 +813,12 @@ fn test_bitwise_ops() {
 	assert b.bitwise_or(b) == b
 	assert b.bitwise_and(b) == b
 	assert b.bitwise_not() == big.zero_int
+	assert big.three_int.neg().bitwise_com() == big.two_int
+	assert big.two_int.neg().bitwise_com() == big.one_int
+	assert big.one_int.neg().bitwise_com() == big.zero_int
+	assert big.zero_int.bitwise_com() == big.one_int.neg()
+	assert big.one_int.bitwise_com() == big.two_int.neg()
+	assert big.two_int.bitwise_com() == big.three_int.neg()
 }
 
 fn test_get_bit() {

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -743,6 +743,17 @@ pub fn (a Integer) bitwise_not() Integer {
 	}
 }
 
+// bitwise_com returns "bitwise complement" of integer `a`.
+//
+// Note: this function consider the sign of the input.
+pub fn (a Integer) bitwise_com() Integer {
+	return if a.signum == -1 {
+		a.abs() - one_int
+	} else {
+		(a + one_int).neg()
+	}
+}
+
 // bitwise_xor returns the "bitwise exclusive or" of the integers `|a|` and `|b|`.
 //
 // Note: both operands are treated as absolute values.


### PR DESCRIPTION
"Bitwise complement" is like `~` but for math.big.
Complete test coverage of edge cases + tested against `mpz_com()` from `libgmp` on 1B loop.