### PR TITLE
v.util.version: fix output for V full version

### DIFF
--- a/vlib/v/util/version/version.v
+++ b/vlib/v/util/version/version.v
@@ -6,7 +6,8 @@ pub const v_version = '0.4.10'
 
 pub fn full_hash() string {
 	build_hash := vhash()
-	if vcurrent_hash() == '' || build_hash == vcurrent_hash() {
+
+	if vcurrent_hash() == '' || build_hash[..7] == vcurrent_hash() {
 		return build_hash
 	}
 	return '${build_hash}.${vcurrent_hash()}'


### PR DESCRIPTION
- `vhash()` function returns full hash (`C.V_COMMIT_HASH`) ; length = 50, see `v/util/version/version.c.v`
- `vcurrent_hash() `returns short form (length = 7)

**Tests OK** on Linux Debian/testing

With a clean Git worktree (`C.V_COMMIT_HASH == vcurrent_hash()`)

```sh
$ ./v version
V 0.4.10 b9fe26c

$ ./v -v version
V 0.4.10 b9fe26cbf18c746256414ae7a6d09cd80b4fa61d
```

With a dirty Git worktree (`C.V_COMMIT_HASH != vcurrent_hash()`)

```sh
$ ./v version
V 0.4.10 8877fe2

$ ./v -v version
V 0.4.10 b9fe26cbf18c746256414ae7a6d09cd80b4fa61d.8877fe2
```