### PR TITLE
cgen: workaround tcc aarch64 spawn call bug

### DIFF
--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -336,10 +336,8 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 			}
 		}
 		g.gowrappers.writeln(');')
-		if call_ret_type != ast.void_type {
-			if g.pref.os != .windows {
-				g.gowrappers.write_string('\t*ret_ptr = ${tcc_bug_tmp_var};\n')
-			}
+		if g.pref.os != .windows && call_ret_type != ast.void_type {
+			g.gowrappers.writeln('\t*ret_ptr = ${tcc_bug_tmp_var};')
 		}
 		if is_spawn {
 			g.gowrappers.writeln('\t_v_free(arg);')

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -241,12 +241,13 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 		thread_ret_type := if g.pref.os == .windows { 'u32' } else { 'void*' }
 		g.waiter_fn_definitions.writeln('${g.static_non_parallel}${thread_ret_type} ${wrapper_fn_name}(${wrapper_struct_name} *arg);')
 		g.gowrappers.writeln('${thread_ret_type} ${wrapper_fn_name}(${wrapper_struct_name} *arg) {')
+		tcc_bug_tmp_var := g.new_tmp_var()
 		if call_ret_type != ast.void_type {
 			if g.pref.os == .windows {
 				g.gowrappers.write_string('\t*((${s_ret_typ}*)(arg->ret_ptr)) = ')
 			} else {
 				g.gowrappers.writeln('\t${s_ret_typ}* ret_ptr = (${s_ret_typ}*) _v_malloc(sizeof(${s_ret_typ}));')
-				g.gowrappers.write_string('\t*ret_ptr = ')
+				g.gowrappers.write_string('\t${s_ret_typ} ${tcc_bug_tmp_var} = ')
 			}
 		} else {
 			g.gowrappers.write_string('\t')
@@ -335,6 +336,11 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 			}
 		}
 		g.gowrappers.writeln(');')
+		if call_ret_type != ast.void_type {
+			if g.pref.os != .windows {
+				g.gowrappers.write_string('\t*ret_ptr = ${tcc_bug_tmp_var};\n')
+			}
+		}
 		if is_spawn {
 			g.gowrappers.writeln('\t_v_free(arg);')
 		}

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -241,13 +241,16 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 		thread_ret_type := if g.pref.os == .windows { 'u32' } else { 'void*' }
 		g.waiter_fn_definitions.writeln('${g.static_non_parallel}${thread_ret_type} ${wrapper_fn_name}(${wrapper_struct_name} *arg);')
 		g.gowrappers.writeln('${thread_ret_type} ${wrapper_fn_name}(${wrapper_struct_name} *arg) {')
-		tcc_bug_tmp_var := g.new_tmp_var()
 		if call_ret_type != ast.void_type {
 			if g.pref.os == .windows {
 				g.gowrappers.write_string('\t*((${s_ret_typ}*)(arg->ret_ptr)) = ')
 			} else {
 				g.gowrappers.writeln('\t${s_ret_typ}* ret_ptr = (${s_ret_typ}*) _v_malloc(sizeof(${s_ret_typ}));')
-				g.gowrappers.write_string('\t${s_ret_typ} ${tcc_bug_tmp_var} = ')
+				$if tinyc && arm64 {
+					g.gowrappers.write_string('\t${s_ret_typ} tcc_bug_tmp_var = ')
+				} $else {
+					g.gowrappers.write_string('\t*ret_ptr = ')
+				}
 			}
 		} else {
 			g.gowrappers.write_string('\t')
@@ -336,8 +339,10 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 			}
 		}
 		g.gowrappers.writeln(');')
-		if g.pref.os != .windows && call_ret_type != ast.void_type {
-			g.gowrappers.writeln('\t*ret_ptr = ${tcc_bug_tmp_var};')
+		$if tinyc && arm64 {
+			if g.pref.os != .windows && call_ret_type != ast.void_type {
+				g.gowrappers.writeln('\t*ret_ptr = tcc_bug_tmp_var;')
+			}
 		}
 		if is_spawn {
 			g.gowrappers.writeln('\t_v_free(arg);')


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #24482

This PR introduce a tmp var, a workaround for the `tcc/aarch64` bug.

before :

```c
void* string_hex_thread_wrapper(thread_arg_string_hex *arg) {
	string* ret_ptr = (string*) _v_malloc(sizeof(string));
	*ret_ptr = arg->fn(arg->arg0); 
	_v_free(arg);
	return ret_ptr;
}
```

after:

```c
void* string_hex_thread_wrapper(thread_arg_string_hex *arg) {
        string* ret_ptr = (string*) _v_malloc(sizeof(string));
        string _t3 = arg->fn(arg->arg0);
        *ret_ptr = _t3;
        _v_free(arg);
        return ret_ptr;
}
```