### PR TITLE
os: use XDG tmpdir before the POSIX env if defined

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -943,7 +943,10 @@ pub fn local_bin_dir() string {
 
 // temp_dir returns the path to a folder, that is suitable for storing temporary files.
 pub fn temp_dir() string {
-	mut path := getenv('TMPDIR')
+	mut path := getenv('XDG_RUNTIME_DIR')
+	if path == '' {
+		path = getenv('TMPDIR')
+	}
 	$if windows {
 		if path == '' {
 			// TODO: see Qt's implementation?


### PR DESCRIPTION
some tests fail because make wrong assumptions like considering the temporary directories are one path above the root.

```
   > assert document.get_parent_mod(os.temp_dir())? == ''
     Left value (len: 4): `user`
    Right value (len: 0): ``
```