### PR TITLE
math.big: fix sign machinarium in .+/2 function, add test

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -598,6 +598,16 @@ fn test_addition() {
 	}
 }
 
+fn test_add_sign() {
+	for a in -10 .. 10 {
+		for b in -10 .. 10 {
+			big_a := big.integer_from_int(a)
+			big_b := big.integer_from_int(b)
+			assert (big_a + big_b).str() == (a + b).str()
+		}
+	}
+}
+
 fn test_subtraction() {
 	for t in sub_test_data {
 		assert t.minuend.parse() - t.subtrahend.parse() == t.difference.parse(), 't.minuend: ${t.minuend}  - t.subtrahend: ${t.subtrahend}'

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -316,18 +316,12 @@ pub fn (augend Integer) + (addend Integer) Integer {
 	if augend.signum == addend.signum {
 		return augend.add(addend)
 	}
-	// Unequal signs, left is negative:
-	if augend.signum == -1 {
-		// -1 + 5 == 5 - 1
-		return addend.subtract(augend)
+	// Unequal signs
+	if augend.abs_cmp(addend) < 0 {
+		return augend.subtract(addend).neg()
+	} else {
+		return augend.subtract(addend)
 	}
-	// Unequal signs, left is positive:
-	res := augend.subtract(addend)
-	cmp := augend.abs_cmp(addend)
-	if cmp < 0 {
-		return res.neg()
-	}
-	return res
 }
 
 // - returns the difference of the integers `minuend` and `subtrahend`


### PR DESCRIPTION
The `+` function has incorrect `sign` management and cannot pass the new test.
The new version also passes the 1M loop test against `libgmp`.