### PR TITLE
math.big: reminder must respect the sign of dividend in % operator, a…

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -639,6 +639,19 @@ fn test_mod() {
 	}
 }
 
+fn test_mod_sign() {
+	for a in -10 .. 10 {
+		for b in -10 .. 10 {
+			if b == 0 {
+				continue
+			}
+			big_a := big.integer_from_int(a)
+			big_b := big.integer_from_int(b)
+			assert (big_a % big_b).str() == (a % b).str()
+		}
+	}
+}
+
 fn test_div_mod() {
 	for t in div_mod_test_data {
 		a := t.dividend.parse()

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -472,6 +472,10 @@ pub fn (dividend Integer) / (divisor Integer) Integer {
 // returns a Result refer to `mod_checked`.
 @[inline]
 pub fn (dividend Integer) % (divisor Integer) Integer {
+	if dividend.signum == -1 {
+		_, r := dividend.neg().div_mod(divisor)
+		return r.neg()
+	}
 	_, r := dividend.div_mod(divisor)
 	return r
 }


### PR DESCRIPTION
`%` operator of `math.big` does not respect sign of `dividend`.

Just copy-paste from `/` operator for `sign` management.
Now it can pass new test and 1M loop against `libgmp`.
