### PR TITLE
os: add debugger_present implementation for OpenBSD

### DIFF
--- a/vlib/os/debugger_openbsd.c.v
+++ b/vlib/os/debugger_openbsd.c.v
@@ -1,0 +1,45 @@
+module os
+
+#include <sys/ptrace.h>
+
+fn C.ptrace(int, u32, voidptr, int) int
+
+// debugger_present returns a bool indicating if the process is being debugged
+pub fn debugger_present() bool {
+	$if openbsd {
+		// check if a child process could trace its parent process,
+		// if not a debugger must be present
+		pid := fork()
+		if pid == 0 {
+			ppid := getppid()
+			/*
+			 * On OpenBSD, impossible to trace a parent process from its child.
+			 * Possible errors:
+			 *   - EBUSY: process already traced
+			 *   - EPERM: process is not a child of tracer (sysctl kern.global_ptrace=0)
+			 *   - EINVAL: process is an ancestor of the current process and not init
+			 *     (sysctl kern.global_ptrace=1)
+			 */
+			if C.ptrace(C.PT_ATTACH, ppid, unsafe { nil }, 0) < 0 {
+				if C.errno == C.EBUSY {
+					// external debugger must be present
+					exit(1)
+				} else {
+					// no external debugger
+					exit(0)
+				}
+			}
+		} else {
+			mut status := 0
+			// wait until the child process dies
+			C.waitpid(pid, &status, 0)
+			// check the exit code of the child process check
+			if C.WEXITSTATUS(status) == 0 {
+				return false
+			} else {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Check if a child process could trace its parent process, if not a debugger must be present.

On OpenBSD, impossible to trace a parent process from its child. But with errors (errno), it's possible to determine if a debugger is present or not.
Possible errors for ptrace / PT_ATTACH in child process:
  - EBUSY: process already traced
  - EPERM: process is not a child of tracer (sysctl kern.global_ptrace=0)
  - EINVAL: process is an ancestor of the current process and not init (sysctl kern.global_ptrace=1)

Closes #23603 

---
**Tests OK** on OpenBSD current/adm64

Code `debugger_present.v` to test if debugger is present or not
```go
import os

fn main() {
        println('Call 1:')
        if os.debugger_present() {
                println('debugger here')
        } else {
                println('no debugger')
        }

        println('Call 2:')
        if os.debugger_present() {
                println('debugger here')
        } else {
                println('no debugger')
        }
}
```
- Tests WITHOUT debugger:
```sh
$ ~/tmp/debugger_present
Call 1:
no debugger
Call 2:
no debugger
```
- Test WITH debugger (gdb)
```sh
$ gdb ~/tmp/debugger_present
(...)
(gdb) run
Starting program: /home/fox/tmp/debugger_present 
Call 1:
[New process 84238]
debugger here
Call 2:
debugger here

Program exited normally.
(gdb) quit
```

