### PR TITLE
os: add note for the availability of the debugger_present implementation

### DIFF
--- a/vlib/os/debugger_default.c.v
+++ b/vlib/os/debugger_default.c.v
@@ -1,6 +1,8 @@
 module os
 
 // debugger_present returns a bool indicating if the process is being debugged
+// Note: implementation available only on Darwin, FreeBSD, Linux, OpenBSD and
+// Windows. Otherwise, returns false.
 @[inline]
 pub fn debugger_present() bool {
 	return false


### PR DESCRIPTION
`debugger_present` implementation only available on Darwin, FreeBSD, Linux, OpenBSD and Windows.