### PR TITLE
cgen: fix map of fixed array value in if guard

### DIFF
--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -343,9 +343,16 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 					} else {
 						branch.cond.vars[0].name
 					}
-					g.write('\t${base_type} ${cond_var_name} = ')
-					g.expr(branch.cond.expr)
-					g.writeln(';')
+					if g.table.sym(branch.cond.expr_type).kind == .array_fixed {
+						g.writeln('\t${base_type} ${cond_var_name} = {0};')
+						g.write('\tmemcpy((${base_type}*)${cond_var_name}, &')
+						g.expr(branch.cond.expr)
+						g.writeln(', sizeof(${base_type}));')
+					} else {
+						g.write('\t${base_type} ${cond_var_name} = ')
+						g.expr(branch.cond.expr)
+						g.writeln(';')
+					}
 				} else {
 					mut is_auto_heap := false
 					if branch.stmts.len > 0 {

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -546,7 +546,11 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 			opt_val_type := g.styp(val_type.set_flag(.option))
 			g.writeln('${opt_val_type} ${tmp_opt} = {0};')
 			g.writeln('if (${tmp_opt_ptr}) {')
-			g.writeln('\t*((${val_type_str}*)&${tmp_opt}.data) = *((${val_type_str}*)${tmp_opt_ptr});')
+			if val_sym.kind == .array_fixed {
+				g.writeln('\tmemcpy((${val_type_str}*)${tmp_opt}.data, (${val_type_str}*)${tmp_opt_ptr}, sizeof(${val_type_str}));')
+			} else {
+				g.writeln('\t*((${val_type_str}*)&${tmp_opt}.data) = *((${val_type_str}*)${tmp_opt_ptr});')
+			}
 			g.writeln('} else {')
 			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = _v_error(_SLIT("map key does not exist"));')
 			g.writeln('}')

--- a/vlib/v/tests/builtin_maps/map_fixed_array_if_guard_test.v
+++ b/vlib/v/tests/builtin_maps/map_fixed_array_if_guard_test.v
@@ -1,0 +1,29 @@
+struct Serials {
+	a u8
+	b u8
+	c u8
+pub mut:
+	ids map[u8][3]u8
+}
+
+pub fn (mut s Serials) id(id u8) {
+	if _ := s.ids[id] {
+	} else {
+		s3 := u8(s.c + s.ids.len)
+		s.ids[id] = [s.a, s.a, s3]!
+	}
+}
+
+fn test_map_fixed_array_if_guard() {
+	mut s := Serials{
+		a: 1
+		b: 2
+	}
+	s.id(u8(3))
+	println(s)
+	assert s.ids[3] == [u8(1), 1, 0]!
+
+	s.id(u8(4))
+	println(s)
+	assert s.ids[4] == [u8(1), 1, 1]!
+}


### PR DESCRIPTION
This PR fix map of fixed array value in if guard. (fix #24488)

- Fix map of fixed array value in if guard.
- Add test.

```v
struct Serials {
	a u8
	b u8
	c u8
pub mut:
	ids map[u8][3]u8
}

pub fn (mut s Serials) id(id u8) {
	if _ := s.ids[id] {
	} else {
		s3 := u8(s.c + s.ids.len)
		s.ids[id] = [s.a, s.a, s3]!
	}
}

fn main() {
	mut s := Serials{
		a: 1
		b: 2
	}
	s.id(u8(3))
	println(s)
	assert s.ids[3] == [u8(1), 1, 0]!

	s.id(u8(4))
	println(s)
	assert s.ids[4] == [u8(1), 1, 1]!
}

PS D:\Test\v\tt1> v run .       
Serials{
    a: 1
    b: 2
    c: 0
    ids: {3: [1, 1, 0]}
}
Serials{
    a: 1
    b: 2
    c: 0
    ids: {3: [1, 1, 0], 4: [1, 1, 1]}
}
```