### PR TITLE
builtin: fix mix prod and debug ucrt lib

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -122,14 +122,6 @@ $if gcboehm_leak ? {
 	#flag -DGC_DEBUG=1
 }
 
-$if windows && msvc {
-	$if prod {
-		#flag ucrt.lib
-	} $else {
-		#flag ucrtd.lib
-	}
-}
-
 #include <gc.h>
 
 // #include <gc/gc_mark.h>

--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -123,7 +123,11 @@ $if gcboehm_leak ? {
 }
 
 $if windows && msvc {
-	#flag ucrtd.lib
+	$if prod {
+		#flag ucrt.lib
+	} $else {
+		#flag ucrtd.lib
+	}
 }
 
 #include <gc.h>


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR fix a Windows/msvc issue

```
v -prod vlib\v\gen\c\testdata\self_printer_with_prod.vv
```

When execute the generated `.exe`, it output nothing.

This is due to a mix using of debug/non-debug of `ucrt.lib/ucrtd.lib`. It will cause `os.c.v` `fdopen` crash.

It may also related to issue #20923