### PR TITLE
cgen: fix codegen for assigning `nil` or `0` to option ptr field

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2333,7 +2333,8 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 						}
 					}
 				}
-				if expr_typ != ast.nil_type && ret_typ.nr_muls() > expr_typ.nr_muls() {
+				if !expr.is_literal() && expr_typ != ast.nil_type
+					&& ret_typ.nr_muls() > expr_typ.nr_muls() {
 					g.write('&'.repeat(ret_typ.nr_muls() - expr_typ.nr_muls()))
 				}
 			}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2333,7 +2333,7 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 						}
 					}
 				}
-				if ret_typ.nr_muls() > expr_typ.nr_muls() {
+				if expr_typ != ast.nil_type && ret_typ.nr_muls() > expr_typ.nr_muls() {
 					g.write('&'.repeat(ret_typ.nr_muls() - expr_typ.nr_muls()))
 				}
 			}

--- a/vlib/v/tests/options/option_ptr_nil_test.v
+++ b/vlib/v/tests/options/option_ptr_nil_test.v
@@ -1,0 +1,21 @@
+struct Foo {
+	name ?&string
+}
+
+struct Foo2 {
+mut:
+	name ?&string
+}
+
+fn test_1() {
+	_ := Foo{
+		name: unsafe { nil }
+	}
+}
+
+fn test_2() {
+	mut foo := Foo2{}
+	unsafe {
+		foo.name = nil
+	}
+}

--- a/vlib/v/tests/options/option_ptr_zero_test.v
+++ b/vlib/v/tests/options/option_ptr_zero_test.v
@@ -1,0 +1,28 @@
+// Simple arena allocator
+struct ArenaChunk {
+mut:
+	next ?&ArenaChunk
+	used int
+	cap  int
+	data byteptr
+}
+
+struct Arena {
+mut:
+	head ?&ArenaChunk
+}
+
+fn arena_init(mut arena Arena, first_capacity int) {
+	chunk := &ArenaChunk{
+		next: 0
+		used: 0
+		cap:  first_capacity
+		data: unsafe { malloc(first_capacity) }
+	}
+	arena.head = chunk
+}
+
+fn test_main() {
+	mut green_arena := Arena{}
+	arena_init(mut green_arena, 64 * 1024)
+}


### PR DESCRIPTION
Fix #24447
Fix #24500