### PR TITLE
cgen: fix codegen inconsistency handling `nil` param to arg expecting ptr

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2776,14 +2776,13 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp ast.Ty
 	is_sumtype_cast := !got_is_fn && fname.contains('_to_sumtype_')
 	is_comptime_variant := is_not_ptr_and_fn && expr is ast.Ident
 		&& g.comptime.is_comptime_variant_var(expr)
-
 	if exp.is_ptr() {
 		if $d('mutable_sumtype', false) && is_sumtype_cast && g.expected_arg_mut
 			&& expr is ast.Ident {
 			g.write('&(${exp_styp.trim_right('*')}){._${got_styp.trim_right('*')}=')
 			rparen_n = 0
 			mutable_idx = got.idx()
-		} else if expr is ast.UnsafeExpr && expr.expr is ast.Nil {
+		} else if (expr is ast.UnsafeExpr && expr.expr is ast.Nil) || got == ast.nil_type {
 			g.write('(void*)0')
 			return
 		} else {

--- a/vlib/v/tests/fns/call_with_nil_test.v
+++ b/vlib/v/tests/fns/call_with_nil_test.v
@@ -1,0 +1,24 @@
+module main
+
+interface ISomeStruct {
+	something string
+}
+
+struct SomeStruct {
+	something string
+}
+
+fn test(s &ISomeStruct) {
+	assert '${s}' == '&nil'
+	if s == unsafe { nil } {
+		assert true
+	} else {
+		assert false
+	}
+}
+
+fn test_main() {
+	y := unsafe { nil }
+	test(y)
+	test(unsafe { nil })
+}


### PR DESCRIPTION
Fix #24491