### PR TITLE
v: add support for `alignof`.

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -190,7 +190,7 @@ by using any of the following commands in a terminal:
    		* [Trace](#trace)
     * [Memory-unsafe code](#memory-unsafe-code)
     * [Structs with reference fields](#structs-with-reference-fields)
-    * [sizeof and __offsetof](#sizeof-and-__offsetof)
+    * [sizeof, alignof and __offsetof](#sizeof-alignof-and-__offsetof)
     * [Limited operator overloading](#limited-operator-overloading)
     * [Performance tuning](#performance-tuning)
     * [Atomics](#atomics)
@@ -6909,9 +6909,10 @@ println(baz)
 println(qux)
 ```
 
-## sizeof and __offsetof
+## sizeof, alignof and __offsetof
 
 * `sizeof(Type)` gives the size of a type in bytes.
+* `alignof(Type)` gives the alignment of a type in bytes.
 * `__offsetof(Struct, field_name)` gives the offset in bytes of a struct field.
 
 ```v
@@ -6921,6 +6922,7 @@ struct Foo {
 }
 
 assert sizeof(Foo) == 8
+assert alignof[Foo]() == 4
 assert __offsetof(Foo, a) == 0
 assert __offsetof(Foo, b) == 4
 ```

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -413,6 +413,12 @@ pub fn (x &Expr) str() string {
 		stdatomic.sub_i64(&nested_expr_str_calls, 1)
 	}
 	match x {
+		AlignOf {
+			if x.is_type {
+				return 'alignof(${global_table.type_to_str(x.typ)})'
+			}
+			return 'alignof(${x.expr.str()})'
+		}
 		AnonFn {
 			return 'anon_fn'
 		}

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1303,6 +1303,13 @@ pub fn (t &Table) type_size(typ Type) (int, int) {
 	return size, align
 }
 
+// type_align returns the alignment (in bytes) of `typ`, just like C's alignof().
+pub fn (t &Table) type_align(typ Type) int {
+	// we only care about the second (alignment) return value
+	_, align := t.type_size(typ)
+	return align
+}
+
 // round_up rounds the number `n` up to the next multiple `multiple`.
 // Note: `multiple` must be a power of 2.
 @[inline]

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3239,7 +3239,7 @@ pub fn (mut c Checker) expr(mut node ast.Expr) ast.Type {
 			}
 			return ret_type
 		}
-		ast.SizeOf {
+		ast.AlignOf, ast.SizeOf {
 			if !node.is_type {
 				node.typ = c.expr(mut node.expr)
 			}

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -399,6 +399,10 @@ fn (mut c Checker) eval_comptime_const_expr(expr ast.Expr, nlevel int) ?ast.Comp
 				return val
 			}
 		}
+		ast.AlignOf {
+			a := c.table.type_align(expr.typ)
+			return i64(a)
+		}
 		ast.SizeOf {
 			s, _ := c.table.type_size(expr.typ)
 			return i64(s)

--- a/vlib/v/eval/expr.c.v
+++ b/vlib/v/eval/expr.c.v
@@ -513,6 +513,9 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 			// eprintln('unhandled struct init at line $expr.pos.line_nr')
 			return ''
 		}
+		ast.AlignOf {
+			return Uint{e.type_to_align(expr.typ), 64}
+		}
 		ast.SizeOf {
 			return Uint{e.type_to_size(expr.typ), 64}
 		}
@@ -620,6 +623,12 @@ fn (e &Eval) type_to_size(typ ast.Type) u64 {
 			return u64(-1)
 		}
 	}
+}
+
+// type_to_align returns the natural alignment (in bits) of `typ`.
+fn (e &Eval) type_to_align(typ ast.Type) u64 {
+	// on most ABIs the alignment of a type == its size
+	return e.type_to_size(typ)
 }
 
 fn (e &Eval) get_escape(r rune) rune {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -616,6 +616,9 @@ pub fn (mut f Fmt) expr(node_ ast.Expr) {
 	match mut node {
 		ast.NodeError {}
 		ast.EmptyExpr {}
+		ast.AlignOf {
+			f.align_of(node)
+		}
 		ast.AnonFn {
 			f.anon_fn(node)
 		}
@@ -3041,6 +3044,20 @@ pub fn (mut f Fmt) selector_expr(node ast.SelectorExpr) {
 	f.write('.')
 	f.write(node.field_name)
 	f.or_expr(node.or_block)
+}
+
+pub fn (mut f Fmt) align_of(node ast.AlignOf) {
+	f.write('alignof')
+	if node.is_type {
+		f.write('[')
+		f.write(f.table.type_to_str_using_aliases(node.typ, f.mod2alias))
+		f.write(']()')
+		return
+	} else {
+		f.write('(')
+		f.expr(node.expr)
+		f.write(')')
+	}
 }
 
 pub fn (mut f Fmt) size_of(node ast.SizeOf) {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3516,6 +3516,9 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 		ast.EmptyExpr {
 			g.error('g.expr(): unhandled EmptyExpr', token.Pos{})
 		}
+		ast.AlignOf {
+			g.align_of(node)
+		}
 		ast.AnonFn {
 			g.gen_anon_fn(mut node)
 		}
@@ -7419,6 +7422,17 @@ fn (g &Gen) get_all_test_function_names() []string {
 @[inline]
 fn (mut g Gen) get_type(typ ast.Type) ast.Type {
 	return if typ == g.field_data_type { g.comptime.comptime_for_field_value.typ } else { typ }
+}
+
+fn (mut g Gen) align_of(node ast.AlignOf) {
+	typ := g.type_resolver.typeof_type(node.expr, g.get_type(node.typ))
+	node_typ := g.unwrap_generic(typ)
+	sym := g.table.sym(node_typ)
+	if sym.language == .v && sym.kind in [.placeholder, .any] {
+		g.error('unknown type `${sym.name}`', node.pos)
+	}
+	styp := g.styp(node_typ)
+	g.write('alignof(${util.no_dots(styp)})')
 }
 
 fn (mut g Gen) size_of(node ast.SizeOf) {

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -595,6 +595,7 @@ typedef int (*qsort_callback_func)(const void*, const void*);
 #include <string.h>
 
 #include <stdarg.h> // for va_list
+#include <stdalign.h> // for alignof
 
 //================================== GLOBALS =================================*/
 int load_so(byteptr);

--- a/vlib/v/gen/golang/golang.v
+++ b/vlib/v/gen/golang/golang.v
@@ -633,6 +633,9 @@ pub fn (mut f Gen) expr(node_ ast.Expr) {
 		ast.SelectorExpr {
 			f.selector_expr(node)
 		}
+		ast.AlignOf {
+			f.align_of(node)
+		}
 		ast.SizeOf {
 			f.size_of(node)
 		}
@@ -2147,6 +2150,16 @@ pub fn (mut f Gen) selector_expr(node ast.SelectorExpr) {
 	f.expr(node.expr)
 	f.write('.')
 	f.write(node.field_name)
+}
+
+pub fn (mut f Gen) align_of(node ast.AlignOf) {
+	f.write('alignof(')
+	if node.is_type {
+		f.write(f.table.type_to_str_using_aliases(node.typ, f.mod2alias))
+	} else {
+		f.expr(node.expr)
+	}
+	f.write(')')
 }
 
 pub fn (mut f Gen) size_of(node ast.SizeOf) {

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -1035,7 +1035,7 @@ fn (mut g JsGen) expr(node_ ast.Expr) {
 		ast.SelectorExpr {
 			g.gen_selector_expr(node)
 		}
-		ast.SizeOf, ast.IsRefType {
+		ast.AlignOf, ast.SizeOf, ast.IsRefType {
 			// TODO
 		}
 		ast.OffsetOf {

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -506,7 +506,7 @@ fn (mut w Walker) expr(node_ ast.Expr) {
 				w.expr(node.high)
 			}
 		}
-		ast.SizeOf, ast.IsRefType {
+		ast.AlignOf, ast.SizeOf, ast.IsRefType {
 			w.expr(node.expr)
 		}
 		ast.StringInterLiteral {

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -326,8 +326,9 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 				}
 			}
 		}
-		.key_sizeof, .key_isreftype {
+		.key_alignof, .key_sizeof, .key_isreftype {
 			is_reftype := p.tok.kind == .key_isreftype
+			is_alignof := p.tok.kind == .key_alignof
 			p.next() // sizeof
 
 			if p.tok.kind == .lsbr {
@@ -341,6 +342,12 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 				p.check(.rpar)
 				if is_reftype {
 					node = ast.IsRefType{
+						is_type: true
+						typ:     typ
+						pos:     type_pos
+					}
+				} else if is_alignof {
+					node = ast.AlignOf{
 						is_type: true
 						typ:     typ
 						pos:     type_pos
@@ -375,6 +382,12 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 							expr:    expr
 							pos:     pos
 						}
+					} else if is_alignof {
+						node = ast.AlignOf{
+							is_type: false
+							expr:    expr
+							pos:     pos
+						}
 					} else {
 						node = ast.SizeOf{
 							is_type: false
@@ -392,6 +405,13 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 					p.expr_mod = save_expr_mod
 					if is_reftype {
 						node = ast.IsRefType{
+							guessed_type: true
+							is_type:      true
+							typ:          arg_type
+							pos:          pos
+						}
+					} else if is_alignof {
+						node = ast.AlignOf{
 							guessed_type: true
 							is_type:      true
 							typ:          arg_type

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4127,7 +4127,7 @@ fn (mut p Parser) global_decl() ast.GlobalDecl {
 				ast.FloatLiteral {
 					typ = ast.f64_type
 				}
-				ast.IntegerLiteral, ast.SizeOf {
+				ast.AlignOf, ast.IntegerLiteral, ast.SizeOf {
 					typ = ast.int_type
 				}
 				ast.StringLiteral, ast.StringInterLiteral {

--- a/vlib/v/tests/alignof_test.v
+++ b/vlib/v/tests/alignof_test.v
@@ -1,0 +1,23 @@
+struct S1 {
+	p voidptr
+}
+
+struct S2 {
+	i int
+}
+
+fn test_alignof() {
+	assert alignof[rune]() == 4
+	assert alignof[[44]u8]() == 1
+	assert alignof(`€`) == 4
+	// depends on -m32/64
+	assert alignof[S1]() in [u32(4), 8]
+	s := S2{}
+	assert alignof(s.i) == 4
+
+	assert alignof('hello') == $if x64 {
+		8
+	} $else {
+		4
+	}
+}

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -121,6 +121,7 @@ pub enum Kind {
 	key_select
 	key_like
 	key_ilike
+	key_alignof
 	key_sizeof
 	key_isreftype
 	key_likely
@@ -299,6 +300,7 @@ fn build_token_str() []string {
 	s[Kind.key_asm] = 'asm'
 	s[Kind.key_return] = 'return'
 	s[Kind.key_module] = 'module'
+	s[Kind.key_alignof] = 'alignof'
 	s[Kind.key_sizeof] = 'sizeof'
 	s[Kind.key_isreftype] = 'isreftype'
 	s[Kind.key_likely] = '_likely_'
@@ -647,6 +649,7 @@ pub fn kind_to_string(k Kind) string {
 		.key_select { 'key_select' }
 		.key_like { 'key_like' }
 		.key_ilike { 'key_ilike' }
+		.key_alignof { 'key_alignof' }
 		.key_sizeof { 'key_sizeof' }
 		.key_isreftype { 'key_isreftype' }
 		.key_likely { 'key_likely' }


### PR DESCRIPTION
### Summary

This PR adds support for the `alignof` builtin, allowing users to get the memory alignment (in bytes) of a type or expression.

### Highlights

* New AST node: `AlignOf`
    
* Supports both `alignof(expr)` and `alignof[Type]()`
    
* Integrated into:
    
    * Parser, checker, formatter (`v fmt`)
        
    * C codegen (via `alignof(...)` + `<stdalign.h>`)
        
    * JS backend (placeholder for now)
        
* Updated `docs.md` and changelog
    
This improves low-level memory control and brings `alignof` in line with `sizeof`.

I know this is missing tests, just want to make sure this is acceptable to add before I put more time into it.
