### PR TITLE
repl: fix `typeof(a)` with warning (fix #24499)

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -533,7 +533,7 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 			if s.output.len > r.last_output.len {
 				cur_line_output := s.output[r.last_output.len..]
 				print_output(cur_line_output)
-				if s.exit_code == 0 {
+				if s.exit_code == 0 && !cur_line_output.contains('warning:') {
 					r.last_output = s.output.clone()
 					r.lines << r.line
 				}
@@ -583,8 +583,10 @@ fn run_repl(workdir string, vrepl_prefix string) int {
 					if s.output.len > r.last_output.len {
 						cur_line_output := s.output[r.last_output.len..]
 						print_output(cur_line_output)
-						r.last_output = s.output.clone()
-						r.lines << print_line
+						if !cur_line_output.contains('warning:') {
+							r.last_output = s.output.clone()
+							r.lines << print_line
+						}
 					}
 					continue
 				} else {

--- a/vlib/v/slow_tests/repl/print_output_warning.repl
+++ b/vlib/v/slow_tests/repl/print_output_warning.repl
@@ -1,0 +1,44 @@
+a := error('hi')
+typeof(a)
+typeof(a)
+typeof(a)
+print(typeof(a))
+print(typeof(a))
+print(typeof(a))
+===output===
+warning: use e.g. `typeof(expr).name` or `sum_type_instance.type_name()` instead
+    6 | 
+    7 | a := error('hi')
+    8 | println(typeof(a))
+      |         ~~~~~~
+IError
+warning: use e.g. `typeof(expr).name` or `sum_type_instance.type_name()` instead
+    6 | 
+    7 | a := error('hi')
+    8 | println(typeof(a))
+      |         ~~~~~~
+IError
+warning: use e.g. `typeof(expr).name` or `sum_type_instance.type_name()` instead
+    6 | 
+    7 | a := error('hi')
+    8 | println(typeof(a))
+      |         ~~~~~~
+IError
+warning: use e.g. `typeof(expr).name` or `sum_type_instance.type_name()` instead
+    6 | 
+    7 | a := error('hi')
+    8 | print(typeof(a))
+      |       ~~~~~~
+IError
+warning: use e.g. `typeof(expr).name` or `sum_type_instance.type_name()` instead
+    6 | 
+    7 | a := error('hi')
+    8 | print(typeof(a))
+      |       ~~~~~~
+IError
+warning: use e.g. `typeof(expr).name` or `sum_type_instance.type_name()` instead
+    6 | 
+    7 | a := error('hi')
+    8 | print(typeof(a))
+      |       ~~~~~~
+IError


### PR DESCRIPTION
This PR fix `typeof(a)` with warning in repl (fix #24499).

- Fix `typeof(a)` with warning.
- Add test.

```v
PS D:\Dev\vlang\v> v
 ____    ____
 \   \  /   /  |  Welcome to the V REPL (for help with V itself, type  exit , then run  v help ).
  \   \/   /   |  Note: the REPL is highly experimental. For best V experience, use a text editor,
   \      /    |  save your code in a  main.v  file and execute:  v run main.v
    \    /     |  V 0.4.10 2c42574 . Use  list  to see the accumulated program so far.
     \__/      |  Use Ctrl-C or  exit  to exit, or  help  to see other available commands.

>>> a := error('hi')
>>> typeof(a)
warning: use e.g. `typeof(expr).name` or `sum_type_instance.type_name()` instead
    6 |
    7 | a := error('hi')
    8 | println(typeof(a))
      |         ~~~~~~
IError
>>> typeof(a)
warning: use e.g. `typeof(expr).name` or `sum_type_instance.type_name()` instead
    6 |
    7 | a := error('hi')
    8 | println(typeof(a))
      |         ~~~~~~
IError
>>> print(typeof(a))
warning: use e.g. `typeof(expr).name` or `sum_type_instance.type_name()` instead
    6 |
    7 | a := error('hi')
    8 | print(typeof(a))
      |       ~~~~~~
IError
```