### PR TITLE
x.json2: fix tests for deprecated function fast_raw_decode

### DIFF
--- a/vlib/x/json2/decoder2/tests/json2_tests/decode_struct_test.v
+++ b/vlib/x/json2/decoder2/tests/json2_tests/decode_struct_test.v
@@ -1,5 +1,4 @@
 import x.json2.decoder2 as json
-import x.json2
 import time
 
 const fixed_time = time.new(

--- a/vlib/x/json2/decoder2/tests/json2_tests/json2_test.v
+++ b/vlib/x/json2/decoder2/tests/json2_tests/json2_test.v
@@ -17,12 +17,12 @@ pub mut:
 
 fn test_fast_raw_decode() {
 	s := '{"name":"Peter","age":28,"salary":95000.5,"title":2}'
-	o := json2.fast_raw_decode(s) or {
+	o := json2.decode[json2.Any](s) or {
 		assert false
 		json2.Any('')
 	}
 	str := o.str()
-	assert str == '{"name":"Peter","age":"28","salary":"95000.5","title":"2"}'
+	assert str == '{"name":"Peter","age":28,"salary":95000.5,"title":2}'
 }
 
 struct StructType[T] {

--- a/vlib/x/json2/tests/json2_test.v
+++ b/vlib/x/json2/tests/json2_test.v
@@ -16,12 +16,12 @@ pub mut:
 
 fn test_fast_raw_decode() {
 	s := '{"name":"Peter","age":28,"salary":95000.5,"title":2}'
-	o := json.fast_raw_decode(s) or {
+	o := json.decode[json.Any](s) or {
 		assert false
 		json.Any('')
 	}
 	str := o.str()
-	assert str == '{"name":"Peter","age":"28","salary":"95000.5","title":"2"}'
+	assert str == '{"name":"Peter","age":28,"salary":95000.5,"title":2}'
 }
 
 fn test_character_unescape() {


### PR DESCRIPTION
`x.json2`: `fast_raw_decode` deprecated after 2025-03-18 => needs to be replaced by `decode[json.Any]` instead

Fix tests in `vlib/x/json2/tests/json2_test.v` and `vlib/x/json2/decoder2/tests/json2_tests/json2_test.v`

**Tests OK** on Linux Debian/testing (amd64) with `prod` mode

- Before this fix

```bash
$ ./v -prod test vlib/x/json2/tests/json2_test.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 FAIL     0.000 ms vlib/x/json2/tests/json2_test.v
>> compilation failed:
vlib/x/json2/tests/json2_test.v:19:12: error: function `x.json2.fast_raw_decode` has been deprecated since 2025-03-18, it will be an error after 2025-09-14; use `decode[json.Any]` instead
   17 | fn test_fast_raw_decode() {
   18 |     s := '{"name":"Peter","age":28,"salary":95000.5,"title":2}'
   19 |     o := json.fast_raw_decode(s) or {
      |               ~~~~~~~~~~~~~~~~~~
   20 |         assert false
   21 |         json.Any('')

--------------------------------------------------------------------------------------------------------------------------------------------
To reproduce just failure 1 run:    '/home/fox/dev/vlang.git/v' -prod '/home/fox/dev/vlang.git/vlib/x/json2/tests/json2_test.v'
Summary for all V _test.v files: 1 failed, 1 total. Elapsed time: 1067 ms, on 1 job. Comptime: 979 ms. Runtime: 0 ms.
```

- After fix

```bash
$ ./v -prod test vlib/x/json2/tests/json2_test.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK       1.709 ms vlib/x/json2/tests/json2_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 7063 ms, on 1 job. Comptime: 7060 ms. Runtime: 1 ms.
```