### PR TITLE
builtin: fix tests for isnil

### DIFF
--- a/vlib/builtin/isnil_test.v
+++ b/vlib/builtin/isnil_test.v
@@ -14,6 +14,6 @@ fn test_isnil_charptr() {
 }
 
 fn test_isnil_intptr() {
-	pi := &int(0)
+	pi := &int(unsafe { nil })
 	assert isnil(pi)
 }


### PR DESCRIPTION
**Tests OK** on Linux (Debian/testing amd64)

- Before fix

```bash
$ ./v -W test /home/fox/dev/vlang.git/vlib/builtin/isnil_test.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 FAIL     0.000 ms vlib/builtin/isnil_test.v
>> compilation failed:
vlib/builtin/isnil_test.v:17:8: error: cannot cast a number to a type reference, use `nil` or a voidptr cast first: `&Type(voidptr(123))`
   15 | 
   16 | fn test_isnil_intptr() {
   17 |     pi := &int(0)
      |           ~~~~~~~
   18 |     assert isnil(pi)
   19 | }

--------------------------------------------------------------------------------------------------------------------------------------------
To reproduce just failure 1 run:    '/home/fox/dev/vlang.git/v' -W '/home/fox/dev/vlang.git/vlib/builtin/isnil_test.v'
Summary for all V _test.v files: 1 failed, 1 total. Elapsed time: 1023 ms, on 1 job. Comptime: 939 ms. Runtime: 0 ms.
```

- After fix

```bash
$ ./v -stats -W test /home/fox/dev/vlang.git/vlib/builtin/isnil_test.v
---- Testing... ----
        V  source  code size:      29869 lines,     137476 tokens,     802249 bytes,   285 types,    12 modules,   133 files
generated  target  code size:       9895 lines,     346743 bytes
compilation took: 466.271 ms, compilation speed: 64059 vlines/s, cgen threads: 7
running tests in: /home/fox/dev/vlang.git/vlib/builtin/isnil_test.v
      OK    [1/4]     0.001 ms     1 assert  | main.test_isnil_byteptr()
      OK    [2/4]     0.000 ms     1 assert  | main.test_isnil_voidptr()
      OK    [3/4]     0.000 ms     1 assert  | main.test_isnil_charptr()
      OK    [4/4]     0.000 ms     1 assert  | main.test_isnil_intptr()
     Summary for running V tests in "isnil_test.v": 4 passed, 4 total. Elapsed time: 0 ms.

 OK     482.842 ms vlib/builtin/isnil_test.v
----
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 483 ms, on 1 job. Comptime: 0 ms. Runtime: 482 ms.
```