### PR TITLE
builtin: fix tests for map

### DIFF
--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -222,8 +222,8 @@ fn test_various_map_value() {
 	m17['test'] = u64(0)
 	assert m17['test'] == u64(0)
 	mut m18 := map[string]&int{}
-	m18['test'] = &int(0)
-	assert unsafe { m18['test'] } == &int(0)
+	m18['test'] = &int(unsafe { nil })
+	assert unsafe { m18['test'] } == &int(unsafe { nil })
 }
 
 fn test_string_arr() {


### PR DESCRIPTION
**Tests OK** on Linux (Debian/amd64)

- Before fix

```bash
$ ./v -W test /home/fox/dev/vlang.git/vlib/builtin/map_test.v                                                                                                                                                                                
---- Testing... ----------------------------------------------------------------------------------------------------------------------------                                                                                                                                      
 FAIL     0.000 ms vlib/builtin/map_test.v                                                                                                                                                                                                                                        
>> compilation failed:                                                                                                                                                                                                                                                            
vlib/builtin/map_test.v:225:16: error: cannot cast a number to a type reference, use `nil` or a voidptr cast first: `&Type(voidptr(123))`                                                                                                                                         
  223 |     assert m17['test'] == u64(0)                                                                                                                                                                                                                                          
  224 |     mut m18 := map[string]&int{}                                                                                                                                                                                                                                          
  225 |     m18['test'] = &int(0)                                                                                                                                                                                                                                                 
      |                   ~~~~~~~                                                                                                                                                                                                                                                 
  226 |     assert unsafe { m18['test'] } == &int(0)                                                                                                                                                                                                                              
  227 | }                                                                                                                                                                                                                                                                         
vlib/builtin/map_test.v:226:35: error: cannot cast a number to a type reference, use `nil` or a voidptr cast first: `&Type(voidptr(123))`                                                                                                                                         
  224 |     mut m18 := map[string]&int{}                                                                                                                                                                                                                                          
  225 |     m18['test'] = &int(0)                                                                                                                                                                                                                                                 
  226 |     assert unsafe { m18['test'] } == &int(0)                                                                                                                                                                                                                              
      |                                      ~~~~~~~                                                                                                                                                                                                                              
  227 | }                                                                                                                                                                                                                                                                         
  228 |                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                  
--------------------------------------------------------------------------------------------------------------------------------------------                                                                                                                                      
To reproduce just failure 1 run:    '/home/fox/dev/vlang.git/v' -W '/home/fox/dev/vlang.git/vlib/builtin/map_test.v'                                                                                                                                                              
Summary for all V _test.v files: 1 failed, 1 total. Elapsed time: 1094 ms, on 1 job. Comptime: 1039 ms. Runtime: 0 ms.
```

- After fix

```bash
$ ./v -W test /home/fox/dev/vlang.git/vlib/builtin/map_test.v                                       
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK     467.671 ms vlib/builtin/map_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 867 ms, on 1 job. Comptime: 397 ms. Runtime: 467 ms.
```