### PR TITLE
checker: revise logic for reporting import conflicts with module names

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -239,16 +239,22 @@ pub fn (mut c Checker) check(mut ast_file ast.File) {
 					sym.pos)
 			}
 		}
+
+		cmp_mod_name := if ast_import.mod != ast_import.alias && ast_import.alias != '_' {
+			ast_import.alias
+		} else {
+			ast_import.mod
+		}
 		for j in 0 .. i {
-			if ast_import.mod == ast_file.imports[j].mod {
-				c.error('`${ast_import.mod}` was already imported on line ${
-					ast_file.imports[j].mod_pos.line_nr + 1}', ast_import.mod_pos)
-			} else if ast_import.mod == ast_file.imports[j].alias {
-				c.error('`${ast_file.imports[j].mod}` was already imported as `${ast_import.alias}` on line ${
-					ast_file.imports[j].mod_pos.line_nr + 1}', ast_import.mod_pos)
-			} else if ast_import.alias != '_' && ast_import.alias == ast_file.imports[j].alias {
-				c.error('`${ast_file.imports[j].mod}` was already imported on line ${
-					ast_file.imports[j].alias_pos.line_nr + 1}', ast_import.alias_pos)
+			eprintln('import[${j}] ${ast_file.imports[j].mod} ("${ast_file.imports[j].alias}")')
+			if cmp_mod_name == if ast_file.imports[j].mod != ast_file.imports[j].alias
+				&& ast_file.imports[j].alias != '_' {
+				ast_file.imports[j].alias
+			} else {
+				ast_file.imports[j].mod
+			} {
+				c.error('2 A module `${cmp_mod_name}` was already imported on line ${
+					ast_file.imports[j].mod_pos.line_nr + 1}`.', ast_import.mod_pos)
 			}
 		}
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -252,7 +252,7 @@ pub fn (mut c Checker) check(mut ast_file ast.File) {
 			} else {
 				ast_file.imports[j].mod
 			} {
-				c.error('2 A module `${cmp_mod_name}` was already imported on line ${
+				c.error('A module `${cmp_mod_name}` was already imported on line ${
 					ast_file.imports[j].mod_pos.line_nr + 1}`.', ast_import.mod_pos)
 			}
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -246,7 +246,6 @@ pub fn (mut c Checker) check(mut ast_file ast.File) {
 			ast_import.mod
 		}
 		for j in 0 .. i {
-			eprintln('import[${j}] ${ast_file.imports[j].mod} ("${ast_file.imports[j].alias}")')
 			if cmp_mod_name == if ast_file.imports[j].mod != ast_file.imports[j].alias
 				&& ast_file.imports[j].alias != '_' {
 				ast_file.imports[j].alias

--- a/vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.out
+++ b/vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.out
@@ -1,6 +1,6 @@
-vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.vv:2:19: error: `json` was already imported on line 1
+vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.vv:2:8: error: A module `json` was already imported on line 1`.
     1 | import json
     2 | import x.json2 as json
-      |                   ~~~~
+      |        ~~~~~~~
     3 | 
     4 | numbers := {

--- a/vlib/v/checker/tests/import_mod_as_import_duplicate_err.out
+++ b/vlib/v/checker/tests/import_mod_as_import_duplicate_err.out
@@ -1,4 +1,4 @@
-vlib/v/checker/tests/import_mod_as_import_duplicate_err.vv:2:8: error: `x.json2` was already imported as `json` on line 1
+vlib/v/checker/tests/import_mod_as_import_duplicate_err.vv:2:8: error: A module `json` was already imported on line 1`.
     1 | import x.json2 as json
     2 | import json
       |        ~~~~

--- a/vlib/v/tests/import_order_1_test.v
+++ b/vlib/v/tests/import_order_1_test.v
@@ -1,0 +1,13 @@
+// NOTE: the order of these import statements is the opposite of the one in import_order_2_test.v,
+// but *both* should compile and work:
+import x.benchmark
+import benchmark as jj
+
+fn test_runs() {
+	mut b := jj.start()
+	mut action := benchmark.setup(fn () ! {
+		return error('no')
+	})!
+	action.run()
+	b.measure('nothing')
+}

--- a/vlib/v/tests/import_order_2_test.v
+++ b/vlib/v/tests/import_order_2_test.v
@@ -1,0 +1,13 @@
+// NOTE: the order of these import statements is the opposite of the one in import_order_1_test.v,
+// but *both* should compile and work:
+import benchmark as jj
+import x.benchmark
+
+fn test_runs() {
+	mut b := jj.start()
+	mut action := benchmark.setup(fn () ! {
+		return error('no')
+	})!
+	action.run()
+	b.measure('nothing')
+}


### PR DESCRIPTION
# Issues with checker validations of import names

**Assumption** The V syntax `import <name> as <alias>` allows for:

- shortening a modules name
- resolve name conflicts

## Scenario

Scenario we have two distinct modules that happen to have the same name. The user correctly uses the `import <name> as <alias>` in one of the imports to correct the name collision.

## Issue

> Project replicating error [prj_module_alias_error.zip](https://github.com/user-attachments/files/20361788/prj_module_alias_error.zip).

Depending on the order of the import there is an edge case where the checker will report a module as already imported although it has an alias.  The following import triggers an error:

```v
import utilities.validations
import validations as vals //<-- triggers error
```

While this one is accepted:

```v
import validations as vals
import utilities.validations
```

## Cause

The elseif at checker.v on line 246 does not consider if the imported module has an alias causing it to report an error.

```v
for j in 0 .. i {
	if ast_import.mod == ast_file.imports[j].mod {
		c.error('`${ast_import.mod}` was already imported on line ${
			ast_file.imports[j].mod_pos.line_nr + 1}', ast_import.mod_pos)
	} else if ast_import.mod == ast_file.imports[j].alias {
		c.error('`${ast_file.imports[j].mod}` was already imported as `${ast_import.alias}` on line ${
			ast_file.imports[j].mod_pos.line_nr + 1}', ast_import.mod_pos)
	} else if ast_import.alias != '_' && ast_import.alias == ast_file.imports[j].alias {
		c.error('`${ast_file.imports[j].mod}` was already imported on line ${
			ast_file.imports[j].alias_pos.line_nr + 1}', ast_import.alias_pos)
	}
}
```

# The suggested fix is as follows:

```v
cmp_mod_name := if ast_import.mod != ast_import.alias && ast_import.alias != '_' {
	ast_import.alias
} else {
	ast_import.mod
}
for j in 0 .. i {
	if cmp_mod_name == if ast_file.imports[j].mod != ast_file.imports[j].alias
		&& ast_file.imports[j].alias != '_' {
		ast_file.imports[j].alias
	} else {
		ast_file.imports[j].mod
	} {
		c.error('A module `${cmp_mod_name}` was already imported on line ${
			ast_file.imports[j].mod_pos.line_nr + 1}`.', ast_import.mod_pos)
	}
}
```

- Prioritize using the alias since the alias is the scope name that will be used in code and things like `mod.sub_mod.member` are not a valid in code.
- The error message is generic since we can not make the distinction of whether the user is actually using the `as` syntax, we could compare to see if the module name contains submodule and see if the alias is the same as the las segment of the module name, but IMHO the current error should be enough for people to be able to identify and fix the error.

# Tests

## Valid imports

```v
import google.validations
import validations as vals
```

```v
import google.validations as vals
import validations
```

## Invalid imports

```sh
test_module_alias/main.v:3:8: error: A module `validations` was already imported on line 2`.
1 |
2 | import google.validations
3 | import validations
  |        ~~~~~~~~~~~

test_module_alias/main.v:3:8: error: A module `vals` was already imported on line 2`.
  1 |
  2 | import google.validations as vals
  3 | import validations as vals
	|        ~~~~~~~~~~~

test_module_alias/main.v:3:8: error: A module `validations` was already imported on line 2`.
	1 |
	2 | import validations
	3 | import google.validations
	  |        ~~~~~~~~~~~~~~~~~~
```