### PR TITLE
checker: replace warning by notice for UTF8 strings validation

### DIFF
--- a/vlib/v/checker/str.v
+++ b/vlib/v/checker/str.v
@@ -134,7 +134,7 @@ const unicode_lit_overflow_message = 'unicode character exceeds max allowed valu
 fn (mut c Checker) string_lit(mut node ast.StringLiteral) ast.Type {
 	valid_utf8 := validate.utf8_string(node.val)
 	if !valid_utf8 {
-		c.warn("invalid utf8 string, please check your file's encoding is utf8", node.pos)
+		c.note("invalid utf8 string, please check your file's encoding is utf8", node.pos)
 	}
 	mut idx := 0
 	for idx < node.val.len {

--- a/vlib/v/checker/tests/invalid_utf8_string.out
+++ b/vlib/v/checker/tests/invalid_utf8_string.out
@@ -1,3 +1,3 @@
-vlib/v/checker/tests/invalid_utf8_string.vv:1:6: warning: invalid utf8 string, please check your file's encoding is utf8
+vlib/v/checker/tests/invalid_utf8_string.vv:1:6: notice: invalid utf8 string, please check your file's encoding is utf8
     1 | _ := '≤‚ ‘txt'
       |      ~~~~~~~


### PR DESCRIPTION
Fix #24538

---

**Tests OK** on Linux (Debian/amd64)

```bash
$ ./v -stats -W test vlib/encoding/utf8/validate/encoding_utf8_test.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
vlib/encoding/utf8/validate/encoding_utf8_test.v:6:36: notice: invalid utf8 string, please check your file's encoding is utf8
    4 |     assert validate.utf8_string('añçá') == true
    5 |     assert validate.utf8_string('\x61\xC3\xB1\xC3\xA7\xC3\xA1') == true
    6 |     assert validate.utf8_string('\xC0\xC1') == false
      |                                       ~~~~
    7 |     assert validate.utf8_string('\xF5\xFF') == false
    8 |     assert validate.utf8_string('\xE0\xEF') == false
vlib/encoding/utf8/validate/encoding_utf8_test.v:7:36: notice: invalid utf8 string, please check your file's encoding is utf8
    5 |     assert validate.utf8_string('\x61\xC3\xB1\xC3\xA7\xC3\xA1') == true
    6 |     assert validate.utf8_string('\xC0\xC1') == false
    7 |     assert validate.utf8_string('\xF5\xFF') == false
      |                                       ~~~~
    8 |     assert validate.utf8_string('\xE0\xEF') == false
    9 | }
vlib/encoding/utf8/validate/encoding_utf8_test.v:8:36: notice: invalid utf8 string, please check your file's encoding is utf8
    6 |     assert validate.utf8_string('\xC0\xC1') == false
    7 |     assert validate.utf8_string('\xF5\xFF') == false
    8 |     assert validate.utf8_string('\xE0\xEF') == false
      |                                       ~~~~
    9 | }
checker summary: 0 V errors, 0 V warnings, 3 V notices
        V  source  code size:      29945 lines,     137986 tokens,     804318 bytes,   286 types,    13 modules,   134 files
generated  target  code size:       9980 lines,     352219 bytes
compilation took: 338.826 ms, compilation speed: 88378 vlines/s, cgen threads: 7
running tests in: /home/fox/dev/vlang.git/vlib/encoding/utf8/validate/encoding_utf8_test.v
      OK       0.005 ms     5 asserts | main.test_validate_str()
     Summary for running V tests in "encoding_utf8_test.v": 5 passed, 5 total. Elapsed time: 0 ms.

 OK     358.708 ms vlib/encoding/utf8/validate/encoding_utf8_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 360 ms, on 1 job. Comptime: 0 ms. Runtime: 358 ms.
```