### PR TITLE
net.openssl: replace SSL_get1_peer_certificate by SSL_get_peer_certificate for OpenBSD

### DIFF
--- a/vlib/net/openssl/openssl_openbsd.c.v
+++ b/vlib/net/openssl/openssl_openbsd.c.v
@@ -1,0 +1,5 @@
+module openssl
+
+// SSL_get_peer1_certificate not defined in LibreSSL (OpenSSL fork) on OpenBSD,
+// use SSL_get_peer_certificate instead.
+fn C.SSL_get_peer_certificate(ssl &SSL) &C.X509

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -223,6 +223,7 @@ fn (mut s SSLConn) complete_connect() ! {
 	}
 
 	if s.config.validate {
+		mut pcert := &C.X509(unsafe { nil })
 		for {
 			mut res := C.SSL_do_handshake(voidptr(s.ssl))
 			if res == 1 {
@@ -239,7 +240,11 @@ fn (mut s SSLConn) complete_connect() ! {
 			}
 			return error('Could not validate SSL certificate. (${err_res}),err')
 		}
-		pcert := C.SSL_get1_peer_certificate(voidptr(s.ssl))
+		$if openbsd {
+			pcert = C.SSL_get_peer_certificate(voidptr(s.ssl))
+		} $else {
+			pcert = C.SSL_get1_peer_certificate(voidptr(s.ssl))
+		}
 		defer {
 			if pcert != 0 {
 				C.X509_free(pcert)


### PR DESCRIPTION
OpenBSD uses LibreSSL (OpenSSL fork) by default for libssl/libcrypto. `SSL_get1_peer_certificate` is not supported by LibreSSL, replace it by `SSL_get_peer_certificate`.

Fix #24547

---

**Tests OK** on OpenBSD current/amd64

```bash
$ ./v -stats -W -d use_openssl test vlib/net/http/http_test.v
---- Testing... ----
        V  source  code size:      42212 lines,     193393 tokens,    1164711 bytes,   474 types,    33 modules,   221 files
generated  target  code size:      21296 lines,     793237 bytes
compilation took: 1099.270 ms, compilation speed: 38400 vlines/s, cgen threads: 3
running tests in: /home/fox/dev/vlang.git/vlib/net/http/http_test.v
      OK    [1/4]     0.005 ms    NO asserts | main.test_http_get()
      OK    [2/4]     0.005 ms    NO asserts | main.test_http_get_from_vlang_utc_now()
      OK    [3/4]     0.005 ms    NO asserts | main.test_public_servers()
      OK    [4/4]     0.000 ms    NO asserts | main.test_relative_redirects()
     Summary for running V tests in "http_test.v": 0 total. Elapsed time: 0 ms.

 OK    1197.922 ms vlib/net/http/http_test.v
----
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 1201 ms, on 1 job. Comptime: 0 ms. Runtime: 1197 ms.
```