### PR TITLE
parser: fix duplicate mod imports

### DIFF
--- a/vlib/sync/chan_mod_sync_test.v
+++ b/vlib/sync/chan_mod_sync_test.v
@@ -1,0 +1,6 @@
+module sync
+
+fn test_chan_mod_sync() {
+	_ := chan bool{cap: 1}
+	assert true
+}

--- a/vlib/sync/chan_mod_sync_test.v
+++ b/vlib/sync/chan_mod_sync_test.v
@@ -1,5 +1,9 @@
 module sync
 
+struct ChanStruct {
+	workers []chan bool
+}
+
 fn test_chan_mod_sync() {
 	_ := chan bool{cap: 1}
 	assert true

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -219,12 +219,12 @@ pub fn (mut c Checker) check(mut ast_file ast.File) {
 	c.change_current_file(ast_file)
 	for i, ast_import in ast_file.imports {
 		// Imports with the same path and name (self-imports and module name conflicts with builtin module imports)
-		if c.mod == ast_import.mod {
+		if c.mod == ast_import.mod && c.mod !in ast_file.auto_imports {
 			c.error('cannot import `${ast_import.mod}` into a module with the same name',
 				ast_import.mod_pos)
 		}
 		// Duplicates of regular imports with the default alias (modname) and `as` imports with a custom alias
-		if c.mod == ast_import.alias {
+		if c.mod == ast_import.alias && c.mod !in ast_file.auto_imports {
 			if c.mod == ast_import.mod.all_after_last('.') {
 				c.error('cannot import `${ast_import.mod}` into a module with the same name',
 					ast_import.mod_pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -219,12 +219,12 @@ pub fn (mut c Checker) check(mut ast_file ast.File) {
 	c.change_current_file(ast_file)
 	for i, ast_import in ast_file.imports {
 		// Imports with the same path and name (self-imports and module name conflicts with builtin module imports)
-		if c.mod == ast_import.mod && c.mod !in ast_file.auto_imports {
+		if c.mod == ast_import.mod {
 			c.error('cannot import `${ast_import.mod}` into a module with the same name',
 				ast_import.mod_pos)
 		}
 		// Duplicates of regular imports with the default alias (modname) and `as` imports with a custom alias
-		if c.mod == ast_import.alias && c.mod !in ast_file.auto_imports {
+		if c.mod == ast_import.alias {
 			if c.mod == ast_import.mod.all_after_last('.') {
 				c.error('cannot import `${ast_import.mod}` into a module with the same name',
 					ast_import.mod_pos)

--- a/vlib/v/parser/module.v
+++ b/vlib/v/parser/module.v
@@ -43,6 +43,9 @@ fn (mut p Parser) register_used_import_for_symbol_name(sym_name string) {
 }
 
 fn (mut p Parser) register_auto_import(alias string) {
+	if p.mod == alias {
+		return
+	}
 	if alias !in p.imports {
 		p.imports[alias] = alias
 		p.table.imports << alias


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #24552

This bug is because when code has `chan` in it, `parser` will `register_auto_import('sync')`, and then `checker` will fail with error.