### PR TITLE
net.mbedtls: disable AES-NI on OpenBSD with tcc

### DIFF
--- a/thirdparty/mbedtls/include/mbedtls/mbedtls_config.h
+++ b/thirdparty/mbedtls/include/mbedtls/mbedtls_config.h
@@ -3820,3 +3820,9 @@
 #undef MBEDTLS_AESNI_C
 #undef MBEDTLS_PADLOCK_C
 #endif
+
+#if ( defined(__TINYC__) && defined(__OpenBSD__) )
+#undef MBEDTLS_HAVE_ASM
+#undef MBEDTLS_AESNI_C
+#undef MBEDTLS_PADLOCK_C
+#endif


### PR DESCRIPTION
Fix #22239

---

**Tests OK** on OpenBSD current/amd64 with tcc

- Before fix

```bash
$ ./v -W test vlib/net/mbedtls/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 FAIL  [1/2] C:  3117.7 ms, R:     0.000 ms vlib/net/mbedtls/mbedtls_compiles_test.v
>> compilation failed:
failed thirdparty object build cmd:
'/home/fox/dev/vlang.git/thirdparty/tcc/tcc.exe' -std=c99 -D_DEFAULT_SOURCE    -fPIC -I "/home/fox/dev/vlang.git/thirdparty/mbedtls/library" -I "/home/fox/dev/vlang.git/thirdparty/mbedtls/include" -I "/home/fox/dev/vlang.git/thirdparty/mbedtls/3rdparty/everest/include" -I "/home/fox/dev/vlang.git/thirdparty/mbedtls/3rdparty/everest/include/everest" -I "/home/fox/dev/vlang.git/thirdparty/mbedtls/3rdparty/everest/include/everest/kremlib" -o "/home/fox/.vmodules/.cache/25/2547d2ed0ebaaacbcc6a8a3f80176e27.module.net.mbedtls.o" -c "/home/fox/dev/vlang.git/thirdparty/mbedtls/library/aesni.c"
builder error: /home/fox/dev/vlang.git/thirdparty/mbedtls/library/aesni.c:131: error: invalid clobber register 'xmm0'


 FAIL  [2/2] C:  3277.9 ms, R:     0.000 ms vlib/net/mbedtls/mbedtls_sslconn_shutdown_does_not_panic_test.v
>> compilation failed:
failed thirdparty object build cmd:
'/home/fox/dev/vlang.git/thirdparty/tcc/tcc.exe' -std=c99 -D_DEFAULT_SOURCE    -fPIC -I "/home/fox/dev/vlang.git/thirdparty/mbedtls/library" -I "/home/fox/dev/vlang.git/thirdparty/mbedtls/include" -I "/home/fox/dev/vlang.git/thirdparty/mbedtls/3rdparty/everest/include" -I "/home/fox/dev/vlang.git/thirdparty/mbedtls/3rdparty/everest/include/everest" -I "/home/fox/dev/vlang.git/thirdparty/mbedtls/3rdparty/everest/include/everest/kremlib" -o "/home/fox/.vmodules/.cache/25/2547d2ed0ebaaacbcc6a8a3f80176e27.module.net.mbedtls.o" -c "/home/fox/dev/vlang.git/thirdparty/mbedtls/library/aesni.c"
builder error: /home/fox/dev/vlang.git/thirdparty/mbedtls/library/aesni.c:131: error: invalid clobber register 'xmm0'


--------------------------------------------------------------------------------------------------------------------------------------------
To reproduce just failure 1 run:    '/home/fox/dev/vlang.git/v' -W '/home/fox/dev/vlang.git/vlib/net/mbedtls/mbedtls_compiles_test.v'
To reproduce just failure 2 run:    '/home/fox/dev/vlang.git/v' -W '/home/fox/dev/vlang.git/vlib/net/mbedtls/mbedtls_sslconn_shutdown_does_not_panic_test.v'
Summary for all V _test.v files: 2 failed, 2 total. Elapsed time: 3359 ms, on 2 parallel jobs. Comptime: 6395 ms. Runtime: 0 ms.
```

- With fix to disable AES-NI on OpenBSD with tcc

```bash
$ ./v -W test vlib/net/mbedtls/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK    [1/2] C:  6009.2 ms, R:    67.343 ms vlib/net/mbedtls/mbedtls_compiles_test.v
 OK    [2/2] C:  6074.1 ms, R:    12.301 ms vlib/net/mbedtls/mbedtls_sslconn_shutdown_does_not_panic_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 2 passed, 2 total. Elapsed time: 6099 ms, on 2 parallel jobs. Comptime: 12083 ms. Runtime: 79 ms.
```