### PR TITLE
cgen: fix generic name handling for struct generic

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -754,7 +754,10 @@ fn (mut g Gen) fn_decl_params(params []ast.Param, scope &ast.Scope, is_variadic 
 			typ = g.table.sym(typ).array_info().elem_type.set_flag(.variadic)
 		}
 		param_type_sym := g.table.sym(typ)
-		mut param_type_name := g.styp(typ).replace_each(c_fn_name_escape_seq)
+		mut param_type_name := g.styp(typ)
+		if param.typ.has_flag(.generic) {
+			param_type_name = param_type_name.replace_each(c_fn_name_escape_seq)
+		}
 		if param_type_sym.kind == .function && !typ.has_flag(.option) {
 			info := param_type_sym.info as ast.FnType
 			func := info.func
@@ -2013,7 +2016,9 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 					}
 				}
 				name = g.generic_fn_name(concrete_types, name)
-				name = name.replace_each(c_fn_name_escape_seq)
+				if concrete_types.len > 0 {
+					name = name.replace_each(c_fn_name_escape_seq)
+				}
 			}
 		}
 	}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -561,6 +561,7 @@ fn (mut g Gen) c_fn_name(node &ast.FnDecl) string {
 
 	if node.generic_names.len > 0 {
 		name = g.generic_fn_name(g.cur_concrete_types, name)
+		name = name.replace_each(c_fn_name_escape_seq)
 	}
 
 	if g.pref.translated || g.file.is_translated || node.is_file_translated {
@@ -2012,6 +2013,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 					}
 				}
 				name = g.generic_fn_name(concrete_types, name)
+				name = name.replace_each(c_fn_name_escape_seq)
 			}
 		}
 	}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2016,9 +2016,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 					}
 				}
 				name = g.generic_fn_name(concrete_types, name)
-				if concrete_types.len > 0 {
-					name = name.replace_each(c_fn_name_escape_seq)
-				}
+				name = name.replace_each(c_fn_name_escape_seq)
 			}
 		}
 	}

--- a/vlib/v/tests/generics/generic_fn_struct_test.v
+++ b/vlib/v/tests/generics/generic_fn_struct_test.v
@@ -1,0 +1,23 @@
+module main
+
+struct People[T] {
+	raw T
+}
+
+struct Man {
+	name string
+}
+
+fn test_main() {
+	m1 := Man{
+		name: 'Tom'
+	}
+	gen1(m1)
+}
+
+fn gen1[T](m T) {
+	gen2[People[T]]()
+}
+
+fn gen2[T]() {
+}


### PR DESCRIPTION
Fix #24530