### PR TITLE
math.big: optimize divide_array_by_digit()

### DIFF
--- a/vlib/math/big/array_ops.v
+++ b/vlib/math/big/array_ops.v
@@ -228,19 +228,18 @@ fn divide_array_by_digit(operand_a []u32, divisor u32, mut quotient []u32, mut r
 	}
 	// Dividend has more digits
 	mut rem := u64(0)
+	mut qtemp := []u32{len: quotient.cap}
 	divisor64 := u64(divisor)
-	// Pad quotient to contain sufficient space
-	for _ in 0 .. operand_a.len {
-		quotient << 0
-	}
+
 	// Perform division step by step
 	for index := operand_a.len - 1; index >= 0; index-- {
 		dividend := (rem << 32) + operand_a[index]
-		quotient[index] = u32(dividend / divisor64)
+		qtemp[index] = u32(dividend / divisor64)
 		rem = dividend % divisor64
 	}
 	// Remove leading zeros from quotient
-	shrink_tail_zeros(mut quotient)
+	shrink_tail_zeros(mut qtemp)
+	quotient << qtemp
 	remainder << u32(rem)
 	shrink_tail_zeros(mut remainder)
 }


### PR DESCRIPTION
Capacity for `quotient` array already defined in `integer.v` like this:

```
...
       // Division for positive integers
        mut q := []u32{cap: int_max(1, dividend.digits.len - divisor.digits.len + 1)}
        mut r := []u32{cap: dividend.digits.len}
        divide_digit_array(dividend.digits, divisor.digits, mut q, mut r)
...
```

so just use it instead of full `operand_a`.
One of the important clients of this function is `str()` function.
Everyone will feel the difference.

Performance improvements:

- `"./v test vlib/math/big/"` works `~3+` times faster
- `str()` on ~180k digits works `~6` times faster