### PR TITLE
sync.stdatomic: new_atomic[T]() turn panic into compile_error

### DIFF
--- a/vlib/sync/stdatomic/atomic.c.v
+++ b/vlib/sync/stdatomic/atomic.c.v
@@ -69,12 +69,18 @@ pub struct AtomicVal[T] {
 // new_atomic creates a new atomic value of `T` type
 @[inline]
 pub fn new_atomic[T](val T) &AtomicVal[T] {
-	$if T is $int || T is bool {
+	// can't use `$if T is $int || T is bool` with $compile_error() now
+	// see issue #24562
+	$if T is $int {
+		return &AtomicVal[T]{
+			val: val
+		}
+	} $else $if T is bool {
 		return &AtomicVal[T]{
 			val: val
 		}
 	} $else {
-		panic('atomic: only support number and bool types')
+		$compile_error('atomic: only support number and bool types')
 	}
 	return unsafe { nil }
 }

--- a/vlib/v/checker/tests/sync_stdatomic_compile_err.out
+++ b/vlib/v/checker/tests/sync_stdatomic_compile_err.out
@@ -1,0 +1,7 @@
+vlib/sync/stdatomic/atomic.c.v:83:3: error: atomic: only support number and bool types
+   81 |         }
+   82 |     } $else {
+   83 |         $compile_error('atomic: only support number and bool types')
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   84 |     }
+   85 |     return unsafe { nil }

--- a/vlib/v/checker/tests/sync_stdatomic_compile_err.vv
+++ b/vlib/v/checker/tests/sync_stdatomic_compile_err.vv
@@ -1,0 +1,3 @@
+import sync.stdatomic {new_atomic}
+
+_ := new_atomic(`1`)


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This PR help find out `new_atomic[T]()` type error at compile time, not in run time.
