### PR TITLE
fix: initialize error object in or_block (fix #24529)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7087,7 +7087,13 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			} else {
 				styp := g.styp(g.fn_decl.return_type)
 				err_obj := g.new_tmp_var()
-				g.writeln2('\t${styp} ${err_obj};', '\tmemcpy(&${err_obj}, &${cvar_name}, sizeof(${result_name}));')
+				g.writeln('\t${styp} ${err_obj} = {0};')
+				if g.fn_decl.return_type.has_flag(.result) {
+					g.writeln('\t${err_obj}.is_error = true;')
+				} else if g.fn_decl.return_type.has_flag(.option) {
+					g.writeln('\t${err_obj}.state = 2;')
+				}
+				g.writeln('\t${err_obj}.err = ${cvar_name}${tmp_op}err;')
 				g.writeln('\treturn ${err_obj};')
 			}
 		}


### PR DESCRIPTION
Fixes #24529

There's no guarantee that `memcpy` will work correctly, since `err_obj` and `cvar_name` can be of different types. Instead of using `memcpy`, we declare a fresh variable and initialize its values.

All tests passed on a MacBook Pro M1:
```bash
v self
v test-self
```