### PR TITLE
native: use builtin exit function

### DIFF
--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -1758,7 +1758,7 @@ pub fn (mut c Amd64) call_fn(node ast.CallExpr) {
 	name := node.name
 	mut n := name
 	if !n.contains('.') && n !in c.g.fn_addr.keys() { // if the name is in keys, it is a function from builtin
-		n = 'main.${n}' 
+		n = 'main.${n}'
 	}
 	if node.is_method {
 		n = '${c.g.table.get_type_name(node.receiver_type)}.${node.name}'

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -1757,8 +1757,8 @@ fn (mut c Amd64) sar8(r Amd64Register, val u8) {
 pub fn (mut c Amd64) call_fn(node ast.CallExpr) {
 	name := node.name
 	mut n := name
-	if !n.contains('.') {
-		n = 'main.${n}'
+	if !n.contains('.') && n !in c.g.fn_addr.keys() { // if the name is in keys, it is a function from builtin
+		n = 'main.${n}' 
 	}
 	if node.is_method {
 		n = '${c.g.table.get_type_name(node.receiver_type)}.${node.name}'

--- a/vlib/v/gen/native/blacklist.v
+++ b/vlib/v/gen/native/blacklist.v
@@ -30,6 +30,7 @@ already compiling functions:
 // true: blacklist function
 const whitelist = {
 	'main.main': false
+	'exit': false
 }
 
 fn (g &Gen) is_blacklisted(name string, is_builtin bool) bool {

--- a/vlib/v/gen/native/blacklist.v
+++ b/vlib/v/gen/native/blacklist.v
@@ -30,7 +30,7 @@ already compiling functions:
 // true: blacklist function
 const whitelist = {
 	'main.main': false
-	'exit': false
+	'exit':      false
 }
 
 fn (g &Gen) is_blacklisted(name string, is_builtin bool) bool {

--- a/vlib/v/gen/native/builtins.v
+++ b/vlib/v/gen/native/builtins.v
@@ -19,7 +19,7 @@ mut:
 	calls []i64 // call addresses
 }
 
-pub const inline_builtins = ['assert', 'print', 'eprint', 'println', 'eprintln', 'C.syscall'] // classic V builtin functions accessible to the user get inlined
+pub const inline_builtins = ['print', 'eprint', 'println', 'eprintln', 'C.syscall'] // classic V builtin functions accessible to the user get inlined
 
 pub fn (mut g Gen) init_builtins() {
 	g.builtins = {

--- a/vlib/v/gen/native/builtins.v
+++ b/vlib/v/gen/native/builtins.v
@@ -19,7 +19,7 @@ mut:
 	calls []i64 // call addresses
 }
 
-pub const inline_builtins = ['assert', 'print', 'eprint', 'println', 'eprintln', 'exit', 'C.syscall'] // classic V builtin functions accessible to the user get inlined
+pub const inline_builtins = ['assert', 'print', 'eprint', 'println', 'eprintln', 'C.syscall'] // classic V builtin functions accessible to the user get inlined
 
 pub fn (mut g Gen) init_builtins() {
 	g.builtins = {

--- a/vlib/v/gen/native/expr.v
+++ b/vlib/v/gen/native/expr.v
@@ -27,9 +27,6 @@ fn (mut g Gen) expr(node ast.Expr) {
 				'C.syscall' {
 					g.code_gen.gen_syscall(node)
 				}
-				'exit' {
-					g.code_gen.gen_exit(node.args[0].expr)
-				}
 				'println', 'print', 'eprintln', 'eprint' {
 					expr := node.args[0].expr
 					typ := node.args[0].typ

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -1174,6 +1174,7 @@ fn (mut g Gen) println(comment string) {
 
 @[noreturn]
 pub fn (mut g Gen) n_error(s string) {
+	print_backtrace()
 	util.verror('native error', s)
 }
 


### PR DESCRIPTION
- allow the exit function from builtin (instead of using the native one)


changes need to be made to issues:
#24172 cross out exit() from the list
    and assert() as it is not longer a function from builtin (now specific to each backend)
