### PR TITLE
v.builder: enable fwrap for C compilation on OpenBSD

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -227,7 +227,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 	}
 
 	// Add -fwrapv to handle UB overflows
-	if ccoptions.cc in [.gcc, .clang, .tcc] && v.pref.os in [.macos, .linux, .windows] {
+	if ccoptions.cc in [.gcc, .clang, .tcc] && v.pref.os in [.macos, .linux, .openbsd, .windows] {
 		ccoptions.args << '-fwrapv'
 	}
 


### PR DESCRIPTION
`-fwrap` option for C compilation ("Treat signed integer overflow as two's complement") is supported by tcc, clang and gcc on OpenBSD => enable it in `vlib/v/builder/cc.v`

**Tests OK** on OpenBSD current/amd64 with tcc, clang and gcc

```bash
$ VTEST_JUST_ESSENTIAL=1 VTEST_SANDBOXED_PACKAGING=1 ./v -W test-self
```