### PR TITLE
thirdparty: fix zstd compilation on OpenBSD with tcc

### DIFF
--- a/thirdparty/zstd/fix.md
+++ b/thirdparty/zstd/fix.md
@@ -1,17 +1,19 @@
 1. replace all `abs64` with `zstd_abs64`.
 
 2. add following at header of the file:
-#if defined(__TINYC__)
-#if defined(_WIN32)
+```c
+#if defined(__TINYC__) && defined(_WIN32)
 #undef ZSTD_MULTITHREAD
 #define ZSTD_NO_INTRINSICS
 #endif
+
 #if defined(__arm__) || defined(__aarch64__)
 #define NO_PREFETCH
 #endif
-#endif
+```
 
-3. replace `qsort_r` with `qsort`, as there is no way detect __MUSL__ macro. add following at header of the file:
+3. replace `qsort_r` with `qsort`, as there is no way detect `__MUSL__` macro. add following at header of the file:
+```c
 #ifndef ZDICT_QSORT
 # if defined(__APPLE__)
 #   define ZDICT_QSORT ZDICT_QSORT_APPLE /* uses qsort_r() with a different order for parameters */
@@ -25,4 +27,4 @@
 #   define ZDICT_QSORT ZDICT_QSORT_C90 /* uses standard qsort() which is not re-entrant (requires global variable) */
 # endif
 #endif
-
+```

--- a/thirdparty/zstd/zstd.c
+++ b/thirdparty/zstd/zstd.c
@@ -50,14 +50,13 @@
 /* TODO: Can't amalgamate ASM function */
 #define ZSTD_DISABLE_ASM 1
 
-#if defined(__TINYC__) 
-#if defined(_WIN32)
+#if defined(__TINYC__) && defined(_WIN32)
 #undef ZSTD_MULTITHREAD
 #define ZSTD_NO_INTRINSICS
 #endif
+
 #if defined(__arm__) || defined(__aarch64__)
 #define NO_PREFETCH
-#endif
 #endif
 
 #ifndef ZDICT_QSORT

--- a/thirdparty/zstd/zstd.c
+++ b/thirdparty/zstd/zstd.c
@@ -73,6 +73,11 @@
 # endif
 #endif
 
+/* Disable prefetch on OpenBSD with tcc */
+#if defined(__OpenBSD__) && defined(__TINYC__)
+#define NO_PREFETCH
+#endif
+
 /* Include zstd_deps.h first with all the options we need enabled. */
 #define ZSTD_DEPS_NEED_MALLOC
 #define ZSTD_DEPS_NEED_MATH64
@@ -740,7 +745,7 @@ int g_debuglevel = DEBUGLEVEL;
 /* vectorization
  * older GCC (pre gcc-4.3 picked as the cutoff) uses a different syntax,
  * and some compilers, like Intel ICC and MCST LCC, do not support it at all. */
-#if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__) && !defined(__LCC__)
+#if !(defined(__OpenBSD__) && defined(__TINYC__)) && !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__) && !defined(__LCC__)
 #  if (__GNUC__ == 4 && __GNUC_MINOR__ > 3) || (__GNUC__ >= 5)
 #    define DONT_VECTORIZE __attribute__((optimize("no-tree-vectorize")))
 #  else
@@ -34343,7 +34348,7 @@ size_t ZSTD_compressBlock_lazy_generic(
     }
 
     /* Match Loop */
-#if defined(__GNUC__) && defined(__x86_64__)
+#if !(defined(__OpenBSD__) && defined(__TINYC__)) && defined(__GNUC__) && defined(__x86_64__)
     /* I've measured random a 5% speed loss on levels 5 & 6 (greedy) when the
      * code alignment is perturbed. To fix the instability align the loop on 32-bytes.
      */
@@ -45950,7 +45955,7 @@ ZSTD_decompressSequences_body(ZSTD_DCtx* dctx,
         ZSTD_initFseState(&seqState.stateML, &seqState.DStream, dctx->MLTptr);
         assert(dst != NULL);
 
-#if defined(__GNUC__) && defined(__x86_64__)
+#if !(defined(__OpenBSD__) && defined(__TINYC__)) && defined(__GNUC__) && defined(__x86_64__)
             __asm__(".p2align 6");
             __asm__("nop");
 #  if __GNUC__ >= 7


### PR DESCRIPTION
For OpenBSD && tcc case (with `#if defined`):

- disable prefetch (define `NO_PREFTECH`)
- fix for `DONT_VECTORIZE` define
- don't use ASM in `ZSTD_compressBlock_lazy_generic` and `ZSTD_decompressSequences_body` functions.

Fix in `zstd.c` file and description in `fix.md`

Fix #24594

---

**Tests OK** on OpenBSD/amd64 with tcc

```bash
$ thirdparty/tcc/tcc.exe -v
tcc version 0.9.28rc 2025-05-27 HEAD@cb39bc4c (x86_64 OpenBSD)

$ ./v test vlib/compress/zstd
---- Testing... ----
 OK    [1/2] C:   913.2 ms, R:    59.349 ms vlib/compress/zstd/read_zstd_files_test.v
 OK    [2/2] C:   935.4 ms, R:   143.238 ms vlib/compress/zstd/zstd_test.v
----
Summary for all V _test.v files: 2 passed, 2 total. Elapsed time: 1120 ms, on 2 parallel jobs. Comptime: 1848 ms. Runtime: 202 ms.
```