### PR TITLE
math.big: remove unnecessary casting from is_power_of_2()

### DIFF
--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -1224,7 +1224,7 @@ pub fn (x Integer) is_power_of_2() bool {
 			return false
 		}
 	}
-	n := u32(x.digits.last())
+	n := x.digits.last()
 	return n & (n - u32(1)) == 0
 }
 


### PR DESCRIPTION
Remove casting - limb(s) in digits array already u32.