### PR TITLE
math.big: is_power_of_2() is false for negatives too, add test

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -110,6 +110,7 @@ struct IsXTest {
 
 // vfmt off
 const is_power_of_2_test_data = [
+	IsXTest{ "-4", false },
 	IsXTest{ u32(0b110000000000), false },
 	IsXTest{ "537502395172353242345", false },
 	IsXTest{ "590295810358705700000", false },

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -1214,7 +1214,7 @@ pub fn (x Integer) is_odd() bool {
 // is_power_of_2 returns true when the integer `x` satisfies `2^n`, where `n >= 0`
 @[direct_array_access; inline]
 pub fn (x Integer) is_power_of_2() bool {
-	if x.signum == 0 {
+	if x.signum <= 0 {
 		return false
 	}
 


### PR DESCRIPTION
is_power_of_2() must be `false` for negatives.
Lets fix it.
Prove from [julia-lang.](https://github.com/JuliaLang/julia/blob/master/base/intfuncs.jl#L537)