### PR TITLE
orm: add IN and NOT IN

### DIFF
--- a/cmd/tools/vtest-self.v
+++ b/cmd/tools/vtest-self.v
@@ -248,6 +248,7 @@ const skip_on_ubuntu_musl = [
 	'vlib/orm/orm_serial_attribute_test.v',
 	'vlib/orm/orm_option_subselect_test.v',
 	'vlib/orm/orm_func_test.v',
+	'vlib/orm/orm_where_in_test.v',
 	'vlib/v/tests/orm_enum_test.v',
 	'vlib/v/tests/orm_sub_struct_test.v',
 	'vlib/v/tests/orm_sub_array_struct_test.v',

--- a/vlib/db/mysql/orm.c.v
+++ b/vlib/db/mysql/orm.c.v
@@ -249,7 +249,7 @@ fn stmt_bind_primitive(mut stmt Stmt, data orm.Primitive) {
 		}
 		[]orm.Primitive {
 			for element in data {
-				pg_stmt_match(mut stmt, element)
+				stmt_bind_primitive(mut stmt, element)
 			}
 		}
 	}

--- a/vlib/db/mysql/orm.c.v
+++ b/vlib/db/mysql/orm.c.v
@@ -247,6 +247,11 @@ fn stmt_bind_primitive(mut stmt Stmt, data orm.Primitive) {
 		orm.Null {
 			stmt.bind_null()
 		}
+		[]orm.Primitive {
+			for element in data {
+				pg_stmt_match(mut stmt, element)
+			}
+		}
 	}
 }
 

--- a/vlib/db/pg/orm.v
+++ b/vlib/db/pg/orm.v
@@ -180,6 +180,11 @@ fn pg_stmt_match(mut types []u32, mut vals []&char, mut lens []int, mut formats 
 			lens << int(0) // ignored
 			formats << 0 // ignored
 		}
+		[]orm.Primitive {
+			for element in data {
+				pg_stmt_match(mut types, mut vals, mut lens, mut formats, element)
+			}
+		}
 	}
 }
 

--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -407,9 +407,8 @@ fn gen_where_clause(where QueryData, q string, qm string, num bool, mut c &int) 
 		}
 		str += '${q}${field}${q} ${where.kinds[i].to_str()}'
 		if !where.kinds[i].is_unary() {
-			data := where.data[i]
-			if data is []Primitive {
-				len := data.len
+			if where.data.len > i && where.data[i] is []Primitive {
+				len := (where.data[i] as []Primitive).len
 				mut tmp := []string{len: len}
 				for j in 0 .. len {
 					tmp[j] = '${qm}'

--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -52,6 +52,7 @@ pub type Primitive = InfixType
 	| u32
 	| u64
 	| u8
+	| []Primitive
 
 pub struct Null {}
 
@@ -406,10 +407,24 @@ fn gen_where_clause(where QueryData, q string, qm string, num bool, mut c &int) 
 		}
 		str += '${q}${field}${q} ${where.kinds[i].to_str()}'
 		if !where.kinds[i].is_unary() {
-			str += ' ${qm}'
-			if num {
-				str += '${c}'
-				c++
+			data := where.data[i]
+			if data is []Primitive {
+				len := data.len
+				mut tmp := []string{len: len}
+				for j in 0 .. len {
+					tmp[j] = '${qm}'
+					if num {
+						tmp[j] += '${c}'
+						c++
+					}
+				}
+				str += ' (${tmp.join(', ')})'
+			} else {
+				str += ' ${qm}'
+				if num {
+					str += '${c}'
+					c++
+				}
 			}
 		}
 		if current_post_par > 0 {
@@ -633,12 +648,20 @@ fn option_bool_to_primitive(b ?bool) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
 }
 
+fn array_bool_to_primitive(b []bool) Primitive {
+	return Primitive(b.map(bool_to_primitive(it)))
+}
+
 fn f32_to_primitive(b f32) Primitive {
 	return Primitive(b)
 }
 
 fn option_f32_to_primitive(b ?f32) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
+}
+
+fn array_f32_to_primitive(b []f32) Primitive {
+	return Primitive(b.map(f32_to_primitive(it)))
 }
 
 fn f64_to_primitive(b f64) Primitive {
@@ -649,12 +672,20 @@ fn option_f64_to_primitive(b ?f64) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
 }
 
+fn array_f64_to_primitive(b []f64) Primitive {
+	return Primitive(b.map(f64_to_primitive(it)))
+}
+
 fn i8_to_primitive(b i8) Primitive {
 	return Primitive(b)
 }
 
 fn option_i8_to_primitive(b ?i8) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
+}
+
+fn array_i8_to_primitive(b []i8) Primitive {
+	return Primitive(b.map(i8_to_primitive(it)))
 }
 
 fn i16_to_primitive(b i16) Primitive {
@@ -665,12 +696,20 @@ fn option_i16_to_primitive(b ?i16) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
 }
 
+fn array_i16_to_primitive(b []i16) Primitive {
+	return Primitive(b.map(i16_to_primitive(it)))
+}
+
 fn int_to_primitive(b int) Primitive {
 	return Primitive(b)
 }
 
 fn option_int_to_primitive(b ?int) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
+}
+
+fn array_int_to_primitive(b []int) Primitive {
+	return Primitive(b.map(int_to_primitive(it)))
 }
 
 // int_literal_to_primitive handles int literal value
@@ -682,6 +721,10 @@ fn option_int_literal_to_primitive(b ?int) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
 }
 
+fn array_int_literal_to_primitive(b []int) Primitive {
+	return Primitive(b.map(int_literal_to_primitive(it)))
+}
+
 // float_literal_to_primitive handles float literal value
 fn float_literal_to_primitive(b f64) Primitive {
 	return Primitive(b)
@@ -689,6 +732,10 @@ fn float_literal_to_primitive(b f64) Primitive {
 
 fn option_float_literal_to_primitive(b ?f64) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
+}
+
+fn array_float_literal_to_primitive(b []f64) Primitive {
+	return Primitive(b.map(float_literal_to_primitive(it)))
 }
 
 fn i64_to_primitive(b i64) Primitive {
@@ -699,12 +746,20 @@ fn option_i64_to_primitive(b ?i64) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
 }
 
+fn array_i64_to_primitive(b []i64) Primitive {
+	return Primitive(b.map(i64_to_primitive(it)))
+}
+
 fn u8_to_primitive(b u8) Primitive {
 	return Primitive(b)
 }
 
 fn option_u8_to_primitive(b ?u8) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
+}
+
+fn array_u8_to_primitive(b []u8) Primitive {
+	return Primitive(b.map(u8_to_primitive(it)))
 }
 
 fn u16_to_primitive(b u16) Primitive {
@@ -715,12 +770,20 @@ fn option_u16_to_primitive(b ?u16) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
 }
 
+fn array_u16_to_primitive(b []u16) Primitive {
+	return Primitive(b.map(u16_to_primitive(it)))
+}
+
 fn u32_to_primitive(b u32) Primitive {
 	return Primitive(b)
 }
 
 fn option_u32_to_primitive(b ?u32) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
+}
+
+fn array_u32_to_primitive(b []u32) Primitive {
+	return Primitive(b.map(u32_to_primitive(it)))
 }
 
 fn u64_to_primitive(b u64) Primitive {
@@ -731,6 +794,10 @@ fn option_u64_to_primitive(b ?u64) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
 }
 
+fn array_u64_to_primitive(b []u64) Primitive {
+	return Primitive(b.map(u64_to_primitive(it)))
+}
+
 fn string_to_primitive(b string) Primitive {
 	return Primitive(b)
 }
@@ -739,12 +806,20 @@ fn option_string_to_primitive(b ?string) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
 }
 
+fn array_string_to_primitive(b []string) Primitive {
+	return Primitive(b.map(string_to_primitive(it)))
+}
+
 fn time_to_primitive(b time.Time) Primitive {
 	return Primitive(b)
 }
 
 fn option_time_to_primitive(b ?time.Time) Primitive {
 	return if b_ := b { Primitive(b_) } else { null_primitive }
+}
+
+fn array_time_to_primitive(b []time.Time) Primitive {
+	return Primitive(b.map(time_to_primitive(it)))
 }
 
 fn infix_to_primitive(b InfixType) Primitive {

--- a/vlib/orm/orm.v
+++ b/vlib/orm/orm.v
@@ -66,6 +66,8 @@ pub enum OperationKind {
 	orm_ilike   // ILIKE
 	is_null     // IS NULL
 	is_not_null // IS NOT NULL
+	in          // IN
+	not_in      // NOT IN
 }
 
 pub enum MathOperationKind {
@@ -105,6 +107,8 @@ fn (kind OperationKind) to_str() string {
 		.orm_ilike { 'ILIKE' }
 		.is_null { 'IS NULL' }
 		.is_not_null { 'IS NOT NULL' }
+		.in { 'IN' }
+		.not_in { 'NOT IN' }
 	}
 	return str
 }

--- a/vlib/orm/orm_where_in_test.v
+++ b/vlib/orm/orm_where_in_test.v
@@ -1,0 +1,48 @@
+// vtest flaky: true
+// vtest retry: 3
+import db.sqlite
+
+struct User {
+	id   int @[primary; sql: serial]
+	name string
+}
+
+fn get_users_in(mut db sqlite.DB, names []string) ![]User {
+	return sql db {
+		select from User where name in names
+	}!
+}
+
+fn get_users_not_in(mut db sqlite.DB, names []string) ![]User {
+	return sql db {
+		select from User where name !in names
+	}!
+}
+
+fn test_orm_mut_db() {
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+
+	sql db {
+		create table User
+	}!
+
+	first_user := User{
+		name: 'first'
+	}
+	second_user := User{
+		name: 'second'
+	}
+
+	sql db {
+		insert first_user into User
+		insert second_user into User
+	}!
+
+	in_users := get_users_in(mut db, ['first'])!
+
+	assert in_users.len == 1
+
+	not_in_users := get_users_not_in(mut db, ['second'])!
+
+	assert not_in_users.len == 1
+}

--- a/vlib/orm/orm_where_in_test.v
+++ b/vlib/orm/orm_where_in_test.v
@@ -45,4 +45,7 @@ fn test_orm_mut_db() {
 	not_in_users := get_users_not_in(mut db, ['second'])!
 
 	assert not_in_users.len == 1
+
+	all_users := get_users_in(mut db, ['first', 'second'])!
+	assert all_users.len == 2
 }

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -625,6 +625,8 @@ fn (mut g Gen) write_orm_primitive(t ast.Type, expr ast.Expr) {
 			typ = 'option_${typ}'
 		} else if g.table.final_sym(t).kind == .enum {
 			typ = g.table.sym(g.table.final_type(t)).cname
+		} else if g.table.final_sym(t).kind == .array {
+			typ = g.table.sym(g.table.final_type(t)).cname.to_lower()
 		}
 		g.write('orm__${typ}_to_primitive(')
 		if expr is ast.CallExpr {
@@ -777,6 +779,12 @@ fn (mut g Gen) write_orm_where_expr(expr ast.Expr, mut fields []string, mut pare
 				}
 				.not_is {
 					'orm__OperationKind__is_not_null'
+				}
+				.key_in {
+					'orm__OperationKind__in'
+				}
+				.not_in {
+					'orm__OperationKind__not_in'
 				}
 				else {
 					''


### PR DESCRIPTION
This PR add support for IN and NOT IN comparisions in the orm.

Usage is simply:

```v
return sql db {
	select from User where name in names
}!
```

or

```v
return sql db {
	select from User where name !in names
}!
```

Closes #24347