### PR TITLE
veb: fix readme typo

### DIFF
--- a/vlib/veb/README.md
+++ b/vlib/veb/README.md
@@ -175,7 +175,7 @@ pub fn (app &App) hello_user(mut ctx Context, user string) veb.Result {
               vv
 @['/document/:id']                              vv
 pub fn (app &App) get_document(mut ctx Context, id int) veb.Result {
-	return ctx.text('Hello ${id}')
+	return ctx.text('Document ${id}')
 }
 ```
 


### PR DESCRIPTION
Fix a typo is the ved readme.

The "user" variable does not exist, it should be "id".