### PR TITLE
jsgen: fix slightly incorrect JS (breaks esbuild) (fix #23711)

### DIFF
--- a/vlib/builtin/js/jsfns.js.v
+++ b/vlib/builtin/js/jsfns.js.v
@@ -122,7 +122,7 @@ fn (v JS.Map) toString() JS.String
 // Hack for "`[]JS.String` is not a struct" when returning arr.length or arr.len
 // TODO: Fix []JS.String not a struct error
 fn native_str_arr_len(arr []JS.String) int {
-	len := 0
+	mut len := 0
 	#len = arr.length
 
 	return len


### PR DESCRIPTION
Fixes #23711

How to test in Linux (macos):

```bash
# install esbuild (if not already installed)
npm -g install esbuild

# compile and minimize the code
cd examples
v -skip-unused -backend js_browser -prod ./js_hello_world.v -o hello.js
esbuild --minify --platform=browser --bundle hello.js --outfile=hello.min.js

# run it
node hello.min.js
```

Output:

```
Hello from V.js (0)
Hello from V.js (1)
Hello from V.js (2)
```