### PR TITLE
encoding.iconv: add path for iconv library on FreeBSD

### DIFF
--- a/vlib/encoding/iconv/iconv_nix.c.v
+++ b/vlib/encoding/iconv/iconv_nix.c.v
@@ -7,6 +7,7 @@ module iconv
 #include <iconv.h>
 
 #flag darwin -liconv
+#flag freebsd -L/usr/local/lib -liconv
 #flag openbsd -L/usr/local/lib -liconv
 #flag termux -L/data/data/com.termux/files/usr/lib -liconv
 


### PR DESCRIPTION
On FreeBSD/amd64, it's necessary to add `/usr/local/lib` path to find `iconv` library to build `vlib/encoding/iconv`.

**Error not detected by "FreeBSD CI"** with `vlib/encoding/iconv` test because build in CI with default cc (clang 18 on FreeBSD 14.2) and not with tcc.

**Tests OK** on FreeBSD/amd64 14.2 with tcc

```bash
$ ./v -cc tcc test vlib/encoding/iconv/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK      44.535 ms vlib/encoding/iconv/iconv_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 2891 ms, on 1 job. Comptime: 2829 ms. Runtime: 44 ms.
fox@nas:~/dev/vlang.git$ ./v -stats test vlib/encoding/iconv/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
        V  source  code size:      30146 lines,     140102 tokens,     813840 bytes,   289 types,    13 modules,   133 files
generated  target  code size:      11645 lines,     435827 bytes
compilation took: 2892.782 ms, compilation speed: 10421 vlines/s, cgen threads: 3
running tests in: /home/fox/dev/vlang.git/vlib/encoding/iconv/iconv_test.v
      OK    [1/5]     8.315 ms     8 asserts | main.test_vstring_to_encoding()
      OK    [2/5]     5.819 ms     8 asserts | main.test_encoding_to_vstring()
      OK    [3/5]     0.034 ms     5 asserts | main.test_create_utf_string_with_bom()
      OK    [4/5]     0.029 ms     5 asserts | main.test_remove_utf_string_with_bom()
      OK    [5/5]    11.856 ms    30 asserts | main.test_read_file_encoding_write_file_encoding()
     Summary for running V tests in "iconv_test.v": 56 passed, 56 total. Elapsed time: 26 ms.

 OK    2997.690 ms vlib/encoding/iconv/iconv_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 3013 ms, on 1 job. Comptime: 0 ms. Runtime: 2997 ms.
```