### PR TITLE
runtime: fix cast for free_memory on OpenBSD

### DIFF
--- a/vlib/runtime/free_memory_impl_openbsd.c.v
+++ b/vlib/runtime/free_memory_impl_openbsd.c.v
@@ -16,7 +16,7 @@ fn free_memory_impl() !usize {
 		$if openbsd {
 			mib := [C.CTL_VM, C.VM_UVMEXP]!
 			mut uvm := C.uvmexp{0, 0}
-			mut len := sizeof(C.uvmexp)
+			mut len := usize(sizeof(C.uvmexp))
 			retval := unsafe { C.sysctl(&mib[0], mib.len, &uvm, &len, C.NULL, 0) }
 			c_errno := C.errno
 			if retval == -1 {


### PR DESCRIPTION
Cast `len` to `usize` type (aka unsigned long) for `sysctl` function on OpenBSD: get `pagesize` and `free` from C `uvmexp` struct.

Without this cast, errors with tcc, clang and GCC when checking C code with `-cstrict`:

```bash
================== C compilation error (from clang): ==============
cc: /tmp/v_1000/get_free_mem_openbsd.01JXF6BTF9DM869CQGFEHKTKZG.tmp.c:5718:41: error: incompatible pointer types passing 'u32 *' (aka 'unsigned int *') to parameter of type 'size_t *' (aka 'unsigned long *') [-Werror,-Wincompatible-pointer-types]
cc:                 int retval = sysctl(&mib[0], 2, &uvm, &len, NULL, 0);
cc:                                                       ^~~~
cc: /usr/include/sys/sysctl.h:1100:48: note: passing argument to parameter here
cc: int     sysctl(const int *, u_int, void *, size_t *, void *, size_t);
cc:                                                    ^
cc: 1 error generated.
===================================================================
(You can pass `-cg`, or `-show-c-output` as well, to print all the C error messages).
builder error: 
==================
C error found. It should never happen, when compiling pure V code.
```

**Tests OK** on OpenBSD/amd64 with tcc, clang and gcc

```bash
$ ./v -W test vlib/runtime/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK       6.643 ms vlib/runtime/runtime_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 770 ms, on 1 job. Comptime: 758 ms. Runtime: 6 ms.

$ ./v -cc clang -W test vlib/runtime/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK       6.865 ms vlib/runtime/runtime_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 1473 ms, on 1 job. Comptime: 1462 ms. Runtime: 6 ms.

$ ./v -cc egcc -W test vlib/runtime/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK       6.865 ms vlib/runtime/runtime_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 1473 ms, on 1 job. Comptime: 1462 ms. Runtime: 6 ms.
```