### PR TITLE
net.http: set IP address for HTTP server during tests

### DIFF
--- a/vlib/net/http/server_test.v
+++ b/vlib/net/http/server_test.v
@@ -121,7 +121,7 @@ fn test_server_custom_handler() {
 	mut server := &http.Server{
 		accept_timeout: atimeout
 		handler:        handler
-		addr:           ':18197'
+		addr:           '127.0.0.1:18197'
 	}
 	t := spawn server.listen_and_serve()
 	server.wait_till_running()!
@@ -261,12 +261,13 @@ fn (mut handler MyCustomHttpHostHandler) handle(req http.Request) http.Response 
 }
 
 fn test_host_header_sent_to_server() {
+	ip := '127.0.0.1'
 	port := 54671
 	log.warn('${@FN} started')
 	defer { log.warn('${@FN} finished') }
 	mut server := &http.Server{
 		handler: MyCustomHttpHostHandler{}
-		addr:    ':${port}'
+		addr:    '${ip}:${port}'
 	}
 	t := spawn server.listen_and_serve()
 	server.wait_till_running()!
@@ -274,5 +275,5 @@ fn test_host_header_sent_to_server() {
 	dump(server.addr)
 	x := http.get('http://${server.addr}/')!
 	dump(x)
-	assert x.body.ends_with(':${port}')
+	assert x.body.ends_with('${ip}:${port}')
 }


### PR DESCRIPTION
On OpenBSD, TCP connect fails (return EINVAL) if attempted with 0.0.0.0 address.

In `vlib/net/http/server_test.v`, for tests `test_server_custom_handler` and `test_host_header_sent_to_server`, use 127.0.0.1 as IP addr for the HTTP server.

Fix https://github.com/vlang/v/issues/22126

**Tests OK** on OpenBSD/amd64 and Linux/amd64 with tcc, clang and gcc

```bash
$ ./v test vlib/net/http/server_test.v 
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK    1996.242 ms vlib/net/http/server_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 3590 ms, on 1 job. Comptime: 1585 ms. Runtime: 1996 ms.

$ ./v -cc clang test vlib/net/http/server_test.v 
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK    2112.866 ms vlib/net/http/server_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 5325 ms, on 1 job. Comptime: 3206 ms. Runtime: 2112 ms.

$ ./v -cc egcc test vlib/net/http/server_test.v 
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK    2044.330 ms vlib/net/http/server_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 6186 ms, on 1 job. Comptime: 4136 ms. Runtime: 2044 ms.
```