### PR TITLE
tools: remove specific case for FreeBSD in cmd/tools/vtest_test.v

### DIFF
--- a/cmd/tools/vtest_test.v
+++ b/cmd/tools/vtest_test.v
@@ -13,11 +13,7 @@ fn testsuite_end() {
 }
 
 fn testsuite_begin() {
-	$if freebsd {
-		os.setenv('VFLAGS', '-cc clang', true)
-	} $else {
-		os.setenv('VFLAGS', '', true)
-	}
+	os.setenv('VFLAGS', '', true)
 	os.setenv('VCOLORS', 'never', true)
 	os.setenv('VJOBS', '2', true)
 	os.rmdir_all(tpath) or {}


### PR DESCRIPTION
A specific case was added in `cmd/tools/vtest_test.v` for FreeBSD to bypass an issue with `tcc` => PR https://github.com/vlang/v/pull/21534

This issue (support of `.symver` for tcc on FreeBSD) is now fixed (see https://repo.or.cz/tinycc.git/commit/ea75d5cf390c095503544718a6c3099c4e3cdabb) and merged in our `tcc` binary for FreeBSD/amd64.

**Tests OK** on FreeBSD/amd64 with tcc, clang and gcc

```bash
$ ./v -stats -W test cmd/tools/vtest_test.v                                                                                                                                                                                                                
---- Testing... ----------------------------------------------------------------------------------------------------------------------------   
        V  source  code size:      30017 lines,     138470 tokens,     808795 bytes,   291 types,    13 modules,   133 files                                                                                                                                                      
generated  target  code size:      11490 lines,     405356 bytes                                                                                                                                                                                                                  
compilation took: 2867.759 ms, compilation speed: 10467 vlines/s, cgen threads: 3                                                                                                                                                                                                 
running tests in: /home/fox/dev/vlang.git/cmd/tools/vtest_test.v                                                                                                                                                                                                                  
      OK    [1/7]    23.943 ms     4 asserts | main.testsuite_begin()                                                                                                                                                                                                             
      OK    [2/7]  3796.201 ms     1 assert  | main.test_vtest_executable_compiles()                                                                                                                                                                                              
      OK    [3/7]  3184.043 ms     5 asserts | main.test_with_several_test_files()                                                                                                                                                                                                
      OK    [4/7]  3405.343 ms     4 asserts | main.test_with_stats_and_several_test_files()
      OK    [5/7]  3102.359 ms     4 asserts | main.test_partial_failure()
      OK    [6/7]  3517.202 ms     4 asserts | main.test_with_stats_and_partial_failure()
      OK    [7/7]     2.175 ms    NO asserts | main.testsuite_end()
     Summary for running V tests in "vtest_test.v": 22 passed, 22 total. Elapsed time: 17032 ms.

 OK   19991.265 ms cmd/tools/vtest_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 20006 ms, on 1 job. Comptime: 0 ms. Runtime: 19991 ms.
```