### PR TITLE
builtin: use local static libgc for FreeBSD with tcc

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -70,7 +70,7 @@ $if dynamic_boehm ? {
 		}
 		$if tinyc {
 			#flag -I/usr/local/include
-			#flag $first_existing("/usr/local/lib/libgc-threaded.a", "/usr/lib/libgc-threaded.a")
+			#flag $first_existing("@VEXEROOT/thirdparty/tcc/lib/libgc.a", "/usr/local/lib/libgc-threaded.a", "/usr/lib/libgc-threaded.a")
 			#flag -lgc-threaded
 		}
 		#flag -lpthread


### PR DESCRIPTION
On FreeBSD, when building with tcc compiler, use local static lib `thirdparty/tcc/lib/libgc.a` if exists.

This modification allows to solve issue #24710 and issue ##24683.

---

**Tests OK** on FreeBSD/amd64 with tcc
- Test-self
```bash
$ VTEST_JUST_ESSENTIAL=1 VTEST_SANDBOXED_PACKAGING=1 ./v -cc tcc -W test-self
(...)
Summary for testing: cmd, vlib: 65 passed, 4 skipped, 69 total. Elapsed time: 146675 ms, on 3 parallel jobs. Comptime: 359143 ms. Runtime: 68918 ms.
```
- Test with `os.fork` (see code in issue #24710)
```bash
$ ./v -cc tcc -showcc run /tmp/test_fork.v
> C compiler cmd: '/home/fox/dev/vlang.git/thirdparty/tcc/tcc.exe' '@/tmp/v_1000/test_fork.01JXQ7C0XKR5XJWX0ACJ50P4Z9.tmp.c.rsp'
> C compiler response file "/tmp/v_1000/test_fork.01JXQ7C0XKR5XJWX0ACJ50P4Z9.tmp.c.rsp":
  -D__RUNETYPE_INTERNAL -o "/tmp/test_fork" -D GC_THREADS=1 -D GC_BUILTIN_ATOMIC=1 -D BUS_PAGE_FAULT=T_PAGEFLT -I "/usr/local/include" "/tmp/v_1000/test_fork.01JXQ7C0XKR5XJWX0ACJ50P4Z9.tmp.c" -std=c99 -D_DEFAULT_SOURCE -bt25 "/home/fox/dev/vlang.git/thirdparty/tcc/lib/libgc.a" -lgc-threaded -lpthread -lexecinfo -lelf  
Parent [Process id: 47707]
Child [Process id: 47726]
Child - parent process id: 47707
```
- Test with `vlib/os/process_test.v`
```bash
$ ./v -cc tcc -stats test vlib/os/process_test.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
        V  source  code size:      29926 lines,     137967 tokens,     804450 bytes,   288 types,    12 modules,   131 files
generated  target  code size:      12343 lines,     433835 bytes
compilation took: 2886.075 ms, compilation speed: 10369 vlines/s, cgen threads: 3
running tests in: /home/fox/dev/vlang.git/vlib/os/process_test.v
      OK    [1/8]  2534.086 ms     1 assert  | main.testsuite_begin()
test_getpid
current pid: 56195
      OK    [2/8]     0.084 ms     1 assert  | main.test_getpid()
test_set_work_folder
[/home/fox/dev/vlang.git/vlib/os/process_test.v:40] new_work_folder: /tmp
[/home/fox/dev/vlang.git/vlib/os/process_test.v:41] parent_working_folder: /home/fox/dev/vlang.git
[/home/fox/dev/vlang.git/vlib/os/process_test.v:58] child_work_folder: /tmp
[/home/fox/dev/vlang.git/vlib/os/process_test.v:61] new_parent_work_folder: /home/fox/dev/vlang.git
      OK    [3/8]   233.769 ms     4 asserts | main.test_set_work_folder()
test_set_environment
      OK    [4/8]   230.825 ms     2 asserts | main.test_set_environment()
test_run
stdout, start
stderr, start
stdout, 1
stderr, 1
stdout, 2
stderr, 2
stdout, 3
stderr, 3
polling iterations: 4
      OK    [5/8]   218.120 ms     6 asserts | main.test_run()
test_wait
stdout, start
stderr, start
stdout, 1
stderr, 1
stdout, 2
stderr, 2
stdout, 3
stderr, 3
stdout, 4
stderr, 4
      OK    [6/8]   232.795 ms     4 asserts | main.test_wait()
test_slurping_output
      OK    [7/8]   662.557 ms    11 asserts | main.test_slurping_output()
      OK    [8/8]     1.272 ms    NO asserts | main.testsuite_end()
     Summary for running V tests in "process_test.v": 29 passed, 29 total. Elapsed time: 4115 ms.

 OK    7094.891 ms vlib/os/process_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 7111 ms, on 1 job. Comptime: 0 ms. Runtime: 7094 ms.
```
