### PR TITLE
ci: update and improve FreeBSD CI

### DIFF
--- a/.github/workflows/freebsd_ci.yml
+++ b/.github/workflows/freebsd_ci.yml
@@ -39,6 +39,7 @@ jobs:
           sync_files: runner-to-vm
           run: |
             sudo pkg install -y git sqlite3 gmake boehm-gc-threaded libiconv
+            # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s freebsd-ci
             echo "### OS infos"
             uname -a
@@ -64,6 +65,7 @@ jobs:
           sync_files: runner-to-vm
           run: |
             sudo pkg install -y git sqlite3 gmake boehm-gc-threaded libiconv
+            # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s freebsd-ci
             echo "### OS infos"
             uname -a
@@ -89,6 +91,7 @@ jobs:
           sync_files: runner-to-vm
           run: |
             sudo pkg install -y git sqlite3 gmake boehm-gc-threaded libiconv gcc
+            # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s freebsd-ci
             echo "### OS infos"
             uname -a


### PR DESCRIPTION
Now that all the tests have been fixed for FreeBSD with tcc, I propose to update and improve "FreeBSD CI":

- use [cross-platform-actions/action](https://github.com/cross-platform-actions/action) GH action instead of [vmactions/freebsd-vm](https://github.com/vmactions/freebsd-vm) action. **This action is more reliable and runs faster on amd64 architecture**. (< 10 minutes to run all tests with gcc)
- use a FreeBSD VM on amd64 arch with 14.2 version (14.3 is not available for now, see https://github.com/cross-platform-actions/action/issues/106).
- install `libiconv` and `boehm-gc-threaded` packages for build/tests on FreeBSD
- use `gmake` (GNU make) instead of BSD `make` to build V => `tcc` is detected during build
- remove unset of `CFLAGS` for V build
- **split this workflow with 3 jobs** (using different value of `VFLAGS` for each):
  - one for tests with `tcc`
  - one for tests with `clang` (version 19.1.7)
  - one for tests with `gcc` (version 13.3.0)
- **All tests run with script `ci/freebsd_ci.vsh` (unmodified)**

✅ Example of this "FreeBSD CI" workflow in my own repository => https://github.com/lcheylus/v/actions/runs/15663998010