### PR TITLE
Update demo link in README to current dynamic_template_manager_test_server location

### DIFF
--- a/vlib/x/templating/dtm/README.md
+++ b/vlib/x/templating/dtm/README.md
@@ -125,7 +125,7 @@ pub fn (mut app App) index(mut ctx Context) veb.Result {
 ```
 
 You have a ready-to-view demonstration available
-[here](https://github.com/vlang/v/tree/master/vlib/veb/tests/dynamic_template_manager_test_server).
+[here](https://github.com/vlang/v/tree/master/vlib/vweb/tests/dynamic_template_manager_test_server).
 
 ## Available Options
 


### PR DESCRIPTION
The outdated link to the dynamic_template_manager_test_server demo in the README has been replaced with the correct, up-to-date path:
https://github.com/vlang/v/tree/master/vlib/vweb/tests/dynamic_template_manager_test_server
This ensures users can easily find and view the demonstration project.