### PR TITLE
ci: add CI for OpenBSD

### DIFF
--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -98,5 +98,5 @@ jobs:
             git config --global --add safe.directory .
             gmake
             sudo ./v symlink
-            export VFLAGS='-cc gcc'
+            export VFLAGS='-cc egcc'
             ./v run ci/openbsd_ci.vsh all

--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -1,0 +1,102 @@
+name: CI OpenBSD
+
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.yml'
+      - 'cmd/tools/**'
+      - '!**/openbsd_ci.yml'
+      - '!ci/openbsd_ci.vsh'
+      - '!cmd/tools/builders/**.v'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.yml'
+      - 'cmd/tools/**'
+      - '!**/openbsd_ci.yml'
+      - '!ci/openbsd_ci.vsh'
+      - '!cmd/tools/builders/**.v'
+
+### See https://github.com/cross-platform-actions/action
+### for a description of the used fields here
+
+jobs:
+  tcc-openbsd:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tests on OpenBSD with tcc
+        id: tests-openbsd-tcc
+        uses: cross-platform-actions/action@v0.28.0
+        with:
+          operating_system: openbsd
+          version: '7.7'
+          memory: 4G
+          shell: sh
+          sync_files: runner-to-vm
+          run: |
+            sudo pkg_add install -y git sqlite3 gmake boehm-gc libiconv
+            # Mandatory: hostname not set in VM => some tests fail
+            sudo hostname -s openbsd-ci
+            echo "### OS infos"
+            uname -a
+            git config --global --add safe.directory .
+            gmake
+            sudo ./v symlink
+            export VFLAGS='-cc tcc -no-retry-compilation'
+            ./v run ci/openbsd_ci.vsh all
+
+  clang-openbsd:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tests on OpenBSD with clang
+        id: tests-openbsd-clang
+        uses: cross-platform-actions/action@v0.28.0
+        with:
+          operating_system: openbsd
+          version: '7.7'
+          memory: 4G
+          shell: sh
+          sync_files: runner-to-vm
+          run: |
+            sudo pkg_add install -y git sqlite3 gmake boehm-gc libiconv
+            # Mandatory: hostname not set in VM => some tests fail
+            sudo hostname -s openbsd-ci
+            echo "### OS infos"
+            uname -a
+            git config --global --add safe.directory .
+            gmake
+            sudo ./v symlink
+            export VFLAGS='-cc clang'
+            ./v run ci/openbsd_ci.vsh all
+
+  gcc-openbsd:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tests on OpenBSD with gcc
+        id: tests-openbsd-gcc
+        uses: cross-platform-actions/action@v0.28.0
+        with:
+          operating_system: openbsd
+          version: '7.7'
+          memory: 4G
+          shell: sh
+          sync_files: runner-to-vm
+          run: |
+            sudo pkg_add install -y git sqlite3 gmake boehm-gc libiconv gcc
+            # Mandatory: hostname not set in VM => some tests fail
+            sudo hostname -s openbsd-ci
+            echo "### OS infos"
+            uname -a
+            git config --global --add safe.directory .
+            gmake
+            sudo ./v symlink
+            export VFLAGS='-cc gcc'
+            ./v run ci/openbsd_ci.vsh all

--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   tcc-openbsd:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Tests on OpenBSD with tcc
@@ -51,7 +51,7 @@ jobs:
 
   clang-openbsd:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Tests on OpenBSD with clang
@@ -77,7 +77,7 @@ jobs:
 
   gcc-openbsd:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Tests on OpenBSD with gcc

--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -90,7 +90,7 @@ jobs:
           shell: sh
           sync_files: runner-to-vm
           run: |
-            sudo pkg_add git sqlite3 gmake boehm-gc libiconv gcc
+            sudo pkg_add git sqlite3 gmake boehm-gc libiconv gcc-11.2.0p15
             # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s openbsd-ci
             echo "### OS infos"

--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -38,7 +38,7 @@ jobs:
           shell: sh
           sync_files: runner-to-vm
           run: |
-            sudo pkg_add install -y git sqlite3 gmake boehm-gc libiconv
+            sudo pkg_add git sqlite3 gmake boehm-gc libiconv
             # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s openbsd-ci
             echo "### OS infos"
@@ -64,7 +64,7 @@ jobs:
           shell: sh
           sync_files: runner-to-vm
           run: |
-            sudo pkg_add install -y git sqlite3 gmake boehm-gc libiconv
+            sudo pkg_add git sqlite3 gmake boehm-gc libiconv
             # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s openbsd-ci
             echo "### OS infos"
@@ -90,7 +90,7 @@ jobs:
           shell: sh
           sync_files: runner-to-vm
           run: |
-            sudo pkg_add install -y git sqlite3 gmake boehm-gc libiconv gcc
+            sudo pkg_add git sqlite3 gmake boehm-gc libiconv gcc
             # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s openbsd-ci
             echo "### OS infos"

--- a/ci/openbsd_ci.vsh
+++ b/ci/openbsd_ci.vsh
@@ -1,0 +1,59 @@
+import os
+import common { Task, exec }
+
+fn v_doctor() {
+	dump(os.getenv('PATH'))
+	exec('v doctor')
+	if common.is_github_job {
+		exec('uname -mrs')
+		exec('sysctl hw.model')
+		exec('sysctl hw.ncpu')
+		exec('sysctl hw.physmem')
+		exec('sysctl hw.usermem')
+		exec('whoami')
+		exec('pwd')
+		exec('ls -la')
+		exec('git log -n1')
+		exec('cc --version')
+	}
+}
+
+fn verify_v_test_works() {
+	exec('echo \$VFLAGS')
+	exec('v cmd/tools/test_if_v_test_system_works.v')
+	exec('./cmd/tools/test_if_v_test_system_works')
+}
+
+fn build_fast_script() {
+	exec('cd cmd/tools/fast && v fast.v')
+}
+
+fn check_math() {
+	exec('v -silent test vlib/math')
+	println('Test the math module, using only the pure V versions,')
+	println('                          without the .c.v overrides.')
+	exec('v -silent -exclude @vlib/math/*.c.v test vlib/math')
+}
+
+fn check_compress() {
+	exec('v -silent test vlib/compress')
+}
+
+fn run_essential_tests() {
+	if common.is_github_job {
+		exec('VTEST_JUST_ESSENTIAL=1 v -silent test-self')
+	} else {
+		exec('VTEST_JUST_ESSENTIAL=1 v -progress test-self')
+	}
+}
+
+const all_tasks = {
+	'v_doctor':            Task{v_doctor, 'Run v doctor'}
+	'verify_v_test_works': Task{verify_v_test_works, 'Verify that v test works'}
+	'build_fast_script':   Task{build_fast_script, 'Check that building fast.v works'}
+	'check_math':          Task{check_math, 'Check the `math` module works'}
+	'check_compress':      Task{check_compress, 'Check the `compress` module works'}
+	'run_essential_tests': Task{run_essential_tests, 'Run only the essential tests'}
+}
+
+common.run(all_tasks)


### PR DESCRIPTION
After fixes, all tests runs without failure on OpenBSD/amd64 with tcc, clang and gcc compiler.

I propose to add a new CI for OpenBSD/amd64 to run tests on this OS with the 3 compilers. This CI is based on "CI FreeBSD", recently updated and improved (see PR https://github.com/vlang/v/pull/24726).

- use [cross-platform-actions/action](https://github.com/cross-platform-actions/action) GH action to run an OpenBSD/amd64 VM with 7.7 version (latest official release).
- 3 jobs to build V and run tests with tcc, clang (version 19.1.7) and gcc (version 11.2.0).
- tests runs via `ci/openbsd_ci.vsh`: same as FreeBSD ones (`ci/freebsd_ci.vsh`)
  - `v doctor`
  - `cmd/tools/test_if_v_test_system_works.v`
  - run `cmd/tools/fast.v`
  - test `vlib/math`
  - test `vlib/compress`
  - run `VTEST_JUST_ESSENTIAL=1 v test-self`

✅ Example of this "OpenBSD CI" workflow in my own repository => https://github.com/lcheylus/v/actions/runs/15673768104