### PR TITLE
pool: fix initialization of WaitGroup in test_concurrent_access()

### DIFF
--- a/vlib/pool/connection_test.v
+++ b/vlib/pool/connection_test.v
@@ -195,7 +195,7 @@ fn test_concurrent_access() {
 	defer {
 		p.close()
 	}
-	mut wg := &sync.WaitGroup{}
+	mut wg := sync.new_waitgroup()
 
 	for _ in 0 .. 20 {
 		wg.add(1)


### PR DESCRIPTION
Creating a new empty WaitGroup structure does not initialize the semaphore structure member.  Calling sync.new_waitgroup() makes sure the proper initialization happens.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
