### PR TITLE
thirdparty: add NDEBUG check before glGetErrorCode if-statement in sokol_gfx.h

### DIFF
--- a/thirdparty/sokol/sokol_gfx.h
+++ b/thirdparty/sokol/sokol_gfx.h
@@ -4878,7 +4878,11 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
     #endif
     #ifndef _SG_GL_CHECK_ERROR
 	// __v_ start
+	#ifdef NDEBUG
+    #define _SG_GL_CHECK_ERROR() (void)(0)
+    #else 
     #define _SG_GL_CHECK_ERROR() { int glerr = glGetError(); if(glerr){ fprintf(stderr, ">> glGetError: %d\n", glerr); }; SOKOL_ASSERT(glerr == GL_NO_ERROR); }
+    #endif
 	// __v_ end
     #endif
 #endif


### PR DESCRIPTION
Fixes a performance drop caused by https://github.com/vlang/v/commit/37e5ead75d18e0c4d1261b7858f3a6a63c642c9d

When built for release, assert(x) is no-op. Commit 37e5ead, had introduced an if-block & fprintf statement to print the glGetError() code to make diagnostic easier. However, this change will execute even when assert(x) is void.

This commit provides a fix by having an ifdef check for NDEBUG, and if NDEBUG is defined then _SG_GL_CHECK_ERROR will be defined as nothing, as the result of SOKOL_ASSERT/ASSERT, would also be nothing (glibc/assert.h).

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Edit:

Video of performance drop (left is after this pull, right is before):

https://github.com/user-attachments/assets/1b71a5d0-dd93-4df5-82ea-49480af40bb5