### PR TITLE
math.big: new math modulo function mod_euclid(), add tests (fix #24756)

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -300,6 +300,21 @@ const div_test_data = [
 ]
 // vfmt on
 
+struct ModEuclidTest {
+	dividend TestInteger
+	divisor  TestInteger
+	modulus  TestInteger
+}
+
+// vfmt off
+const mod_euclid_test_data = [
+	ModEuclidTest{-7, 3, 2},
+	ModEuclidTest{7, 3, 1},
+	ModEuclidTest{7, -3, 1},
+	ModEuclidTest{-7, -3, 2},
+]
+// vfmt on
+
 enum Comparison {
 	less    = -1
 	equal   = 0
@@ -652,6 +667,12 @@ fn test_div() {
 fn test_mod() {
 	for t in div_mod_test_data {
 		assert t.dividend.parse() % t.divisor.parse() == t.remainder.parse()
+	}
+}
+
+fn test_mod_euclid() {
+	for t in mod_euclid_test_data {
+		assert t.dividend.parse().mod_euclid(t.divisor.parse()) == t.modulus.parse()
 	}
 }
 

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -513,6 +513,33 @@ pub fn (dividend Integer) mod_checked(divisor Integer) !Integer {
 	return r
 }
 
+// modulo_euclid returns the result of mathematical modulus.
+// The result is always non-negative for positive `divisor`.
+//
+// WARNING: this method will panic if `divisor == 0`.
+@[inline]
+pub fn (dividend Integer) mod_euclid(divisor Integer) Integer {
+	r := dividend % divisor
+	if r < zero_int {
+		return r + divisor.abs()
+	} else {
+		return r
+	}
+}
+
+// mod_euclid_checked returns the result of mathematical modulus.
+// The result is always non-negative for positive `divisor`
+// or an error if `divisor == 0`.
+@[inline]
+pub fn (dividend Integer) mod_euclid_checked(divisor Integer) !Integer {
+	r := dividend.mod_checked(divisor)!
+	if r < zero_int {
+		return r + divisor.abs()
+	} else {
+		return r
+	}
+}
+
 // mask_bits is the equivalent of `a % 2^n` (only when `a >= 0`), however doing a full division
 // run for this would be a lot of work when we can simply "cut off" all bits to the left of
 // the `n`th bit.


### PR DESCRIPTION
It's time to add mathematical modulo.

The old commit 6e271b2 fixed the behavior of div_mod() family with negative input data as `truncate` (equivalent to `gmplib's` `mpz_tdiv` function family).

Now the new functions `mod_euclid()` and `mod_euclid_checked()` will behave like libgmp's `mpz_mod()`.
Tested against `mpz_mod()` on 1M cycle.