### PR TITLE
math.big: remove minus from zero result in right_shift(), add tests

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -528,6 +528,8 @@ const left_shift_test_data = [
 ]
 
 const right_shift_test_data = [
+	ShiftTest{ -8, 4, 0 },
+	ShiftTest{ -8, 40, 0 },
 	ShiftTest{ 45, 3, 5 },
 	ShiftTest{ 0x13374956, 16, 0x1337 },
 	ShiftTest{ [u8(1), 1, 1, 0, 0, 0, 0, 0, 0, 0], 56, [u8(1), 1, 1] },

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -855,7 +855,7 @@ pub fn (a Integer) right_shift(amount u32) Integer {
 	}
 	return Integer{
 		digits: new_array
-		signum: a.signum
+		signum: if new_array.len > 0 { a.signum } else { 0 }
 	}
 }
 


### PR DESCRIPTION
Current issues in `right_shift()` are:

- sometimes returns '0'
- sometimes returns '-0'
- thus cannot pass against `libgmp`.

This is the last problem preventing me from cleanly testing all of `math.big` against `libgmp`.