### PR TITLE
crypto: remove unused os import for SHA512 tests

### DIFF
--- a/vlib/crypto/sha512/sha384_shavs_test.v
+++ b/vlib/crypto/sha512/sha384_shavs_test.v
@@ -6,7 +6,6 @@
 //     SHA384ShortMsg.rsp
 import crypto.sha512
 import encoding.hex
-import os
 
 // This structure deals with short message tests
 struct SHA384TestCase {

--- a/vlib/crypto/sha512/sha512_224_shavs_test.v
+++ b/vlib/crypto/sha512/sha512_224_shavs_test.v
@@ -6,7 +6,6 @@
 //     SHA512_224ShortMsg.rsp
 import crypto.sha512
 import encoding.hex
-import os
 
 // This structure deals with short message tests
 struct SHA512_224TestCase {

--- a/vlib/crypto/sha512/sha512_256_shavs_test.v
+++ b/vlib/crypto/sha512/sha512_256_shavs_test.v
@@ -6,7 +6,6 @@
 //     SHA512_256ShortMsg.rsp
 import crypto.sha512
 import encoding.hex
-import os
 
 // This structure deals with short message tests
 struct SHA512_256TestCase {

--- a/vlib/crypto/sha512/sha512_shavs_test.v
+++ b/vlib/crypto/sha512/sha512_shavs_test.v
@@ -6,7 +6,6 @@
 //     SHA512ShortMsg.rsp
 import crypto.sha512
 import encoding.hex
-import os
 
 // This structure deals with short message tests
 struct SHA512TestCase {


### PR DESCRIPTION
**All tests OK** for `vlib.crypto` with `-W` flag:

```bash
$ ./v -W test vlib/crypto/
(...)
Summary for all V _test.v files: 60 passed, 4 skipped, 64 total. Elapsed time: 29025 ms, on 3 parallel jobs. Comptime: 58158 ms. Runtime: 27687 ms.
```