### PR TITLE
builtin: add a rune iterator method to strings, allowing `for for i, r in s.runes_iterator() {` without first allocating an array for all the runes

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -74,9 +74,9 @@ fn __print_assert_failure(i &VAssertMetaInfo) {
 	eprintln('${i.fpath}:${i.line_nr + 1}: FAIL: fn ${i.fn_name}: assert ${i.src}')
 	if i.op.len > 0 && i.op != 'call' {
 		if i.llabel == i.lvalue {
-			eprintln('  left value: ${i.llabel}')
+			eprintln('   left value: ${i.llabel}')
 		} else {
-			eprintln('  left value: ${i.llabel} = ${i.lvalue}')
+			eprintln('   left value: ${i.llabel} = ${i.lvalue}')
 		}
 		if i.rlabel == i.rvalue {
 			eprintln('  right value: ${i.rlabel}')

--- a/vlib/builtin/string_iterator_test.v
+++ b/vlib/builtin/string_iterator_test.v
@@ -1,0 +1,32 @@
+fn check(s string) {
+	srunes := s.runes()
+	println('')
+	println('>          s: ${s}')
+	println('>      s.len: ${s.len:-4}')
+	println('> srunes.len: ${srunes.len:-4}')
+	mut itera_ := []rune{}
+	for r in s.runes_iterator() {
+		itera_ << r
+	}
+	println('>   srunes: ${srunes}')
+	println('> iterated: ${itera_}')
+	assert srunes == itera_
+}
+
+fn test_ascii() {
+	check('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789')
+}
+
+fn test_mixed() {
+	check('abc,あいうえお,привет,❄☕❀💰')
+}
+
+fn test_emoji_and_for_i_r_in_iterator() {
+	s := '❄☕❀💰'
+	check(s)
+	srunes := s.runes()
+	for i, r in s.runes_iterator() {
+		eprintln('> i: ${i} | r: ${r}')
+		assert srunes[i] == r
+	}
+}

--- a/vlib/v/gen/c/testdata/if_else_return.c.must_have
+++ b/vlib/v/gen/c/testdata/if_else_return.c.must_have
@@ -5,5 +5,5 @@ _result_ok(&(string[]) { s }, (_result*)(&_t2), sizeof(string));
 } else {
 return (_result_string){ .is_error=true, .err=_v_error(_S("empty")), .data={E_STRUCT} };
 }
-return _t1;
+return _t2;
 }


### PR DESCRIPTION
- **builtin: add a s.runes_iterator() method, allowing for `for i, r in s.runes_iterator() {` with no allocations**
- **fix if_else_return.c.must_have**