### PR TITLE
GNUmakefile: switch to ldd --version for musl check

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,7 +31,7 @@ endif
 ifeq ($(_SYS),Linux)
 LINUX := 1
 TCCOS := linux
-ifneq ($(shell ldd /bin/ls | grep musl),)
+ifneq ($(shell ldd --version 2>&1 | grep -i musl),)
 TCCOS := linuxmusl
 endif
 endif


### PR DESCRIPTION
I encountered this issue when trying to install V on my NixOS machine using make:
```
ldd: /bin/ls: No such file or directory
```

I realized the problem stemmed from the `GNUmakefile`. On NixOS, some utilities like `cd` and `ls` aren't located in `/bin` as they typically are on other systems.

My initial solution was to use this somewhat hacky script instead:
```sh
ldd "$(shell command which ls)" | grep musl
```

However, this still seemed like an odd way to check for `musl`. That’s why I decided to use `ldd --version` instead, since it produces the following output on Alpine Linux:
```
# ldd --version
musl libc (x86_64)
Version 1.2.5
```
