### PR TITLE
crypto.ecdsa: add support for OpenSSL on OpenBSD

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -54,9 +54,6 @@ pub const is_python_present = os.execute('python --version').exit_code == 0
 pub const is_sqlite3_present = os.execute('sqlite3 --version').exit_code == 0
 	&& os.execute('pkg-config sqlite3 --libs').exit_code == 0
 
-pub const is_openssl_present = os.execute('openssl --version').exit_code == 0
-	&& os.execute('pkg-config openssl --libs').exit_code == 0
-
 pub const all_processes = get_all_processes()
 
 pub const header_bytes_to_search_for_module_main = 500
@@ -880,6 +877,18 @@ fn get_max_header_len() int {
 	}
 	return cols
 }
+
+fn check_openssl_present() bool {
+	$if openbsd {
+		return os.execute('eopenssl34 --version').exit_code == 0
+			&& os.execute('pkg-config eopenssl34 --libs').exit_code == 0
+	} $else {
+		return os.execute('openssl --version').exit_code == 0
+			&& os.execute('pkg-config openssl --libs').exit_code == 0
+	}
+}
+
+pub const is_openssl_present = check_openssl_present()
 
 // is_started_mysqld is true, when the test runner determines that there is a running mysql server
 pub const is_started_mysqld = find_started_process('mysqld') or { '' }

--- a/vlib/crypto/ecdsa/ecdsa.c.v
+++ b/vlib/crypto/ecdsa/ecdsa.c.v
@@ -15,6 +15,9 @@ module ecdsa
 #flag linux -I/usr/local/include/openssl
 #flag linux -L/usr/local/lib64/
 
+#flag openbsd -I/usr/local/include/eopenssl34
+#flag openbsd -L/usr/local/lib/eopenssl34 -Wl,-rpath,/usr/local/lib/eopenssl34
+
 // Installed through choco:
 #flag windows -IC:/Program Files/OpenSSL-Win64/include
 #flag windows -LC:/Program Files/OpenSSL-Win64/lib/VC/x64/MD

--- a/vlib/crypto/ecdsa/ecdsa_test.v
+++ b/vlib/crypto/ecdsa/ecdsa_test.v
@@ -1,4 +1,4 @@
-// vtest build: present_openssl? && !(sanitize-memory-clang || docker-ubuntu-musl)
+// vtest build: present_openssl? && !(openbsd && gcc) && !(sanitize-memory-clang || docker-ubuntu-musl)
 module ecdsa
 
 fn test_ecdsa() {

--- a/vlib/crypto/ecdsa/example/ecdsa_seed_test.v
+++ b/vlib/crypto/ecdsa/example/ecdsa_seed_test.v
@@ -1,4 +1,4 @@
-// vtest build: present_openssl? && !(sanitize-memory-clang || docker-ubuntu-musl)
+// vtest build: present_openssl? && !(openbsd && gcc) && !(sanitize-memory-clang || docker-ubuntu-musl)
 import rand
 import crypto.ecdsa
 import encoding.hex

--- a/vlib/crypto/ecdsa/example/ensure_compatibility_with_net_openssl_test.v
+++ b/vlib/crypto/ecdsa/example/ensure_compatibility_with_net_openssl_test.v
@@ -1,4 +1,4 @@
-// vtest build: present_openssl? && !(sanitize-memory-clang || docker-ubuntu-musl)
+// vtest build: present_openssl? && !(openbsd && gcc) && !(sanitize-memory-clang || docker-ubuntu-musl)
 import net.openssl
 import crypto.ecdsa
 

--- a/vlib/crypto/ecdsa/util_test.v
+++ b/vlib/crypto/ecdsa/util_test.v
@@ -1,4 +1,4 @@
-// vtest build: present_openssl? && !(sanitize-memory-clang || docker-ubuntu-musl)
+// vtest build: present_openssl? && !(openbsd && gcc) && !(sanitize-memory-clang || docker-ubuntu-musl)
 module ecdsa
 
 import encoding.hex
@@ -90,7 +90,7 @@ fn test_load_privkey_from_string_sign_and_verify() ! {
 	expected_pvkey_bytes := '30ce3da288965ac6093f0ba9a9a15b2476bea3eda925e1b3c1f094674f52795cd6cb3cafe235dfc15bec542448ffa715'
 	assert pvkey.bytes()!.hex() == expected_pvkey_bytes
 
-	// public key part	
+	// public key part
 	pbkey := pvkey.public_key()!
 	pbkey_bytes := pbkey.bytes()!
 	expected_pubkey_bytes := '04f8fdeb845913d5f5c761b6370a9701761eb14c2ef831017171fb4d543df310f573a3ffce6a52156ad635eb692c83cb9158176f145b8767d38c55791b8f05b085c5cfeea988f6b3922d1dc019495dcbe6c1a55da74f7d3aa8223081400c78e24f'
@@ -133,7 +133,7 @@ UHhnmmVRraSwrVkPdYIeXhH/Ob4+8OLcwrQBMv4RXsD1GVFsgkvEYDTEb/vnMA==
 fn test_key_signing_verifying_with_custom_hash() ! {
 	// privatekey_sample was P-384 key
 	pvkey := privkey_from_string(privatekey_sample)!
-	// public key part	
+	// public key part
 	pbkey := pvkey.public_key()!
 	pbk := pubkey_from_string(public_key_sample)!
 


### PR DESCRIPTION
On OpenBSD, LibreSSL (https://www.libressl.org/) is used by default as TLS/crypto stack. This library is not fully compatible with OpenSSL v3.

OpenSSL v3.4 could be installed on OpenBSD via `eopenssl34` package available in official ports tree.

This PR adds support for OpenSSL version 3.4 (more recent version available for 7.7 release) on OpenBSD :

- `cmd/tools/modules/testing/common.v`: add special case for OpenBSD to check if OpenSSL is present
- `vlib/crypto/ecdsa/ecdsa.c.v`: add flags for OpenSSL to find OpenSSL v3.4 includes/libs
- disable tests for OpenBSD with gcc in `crypto/ecdsa`: issues to find OpenSSL symbols during link (unable to fix theses errors for now).

---

**Tests OK** on OpenBSD/amd64 with tcc, clang and gcc for `vlib/crypto`, `vlib/net/ssl/` and `vlib/net/openssl/`

```bash
$ ./v -cc tcc -W test vlib/crypto/
(...)
Summary for all V _test.v files: 64 passed, 64 total. Elapsed time: 31790 ms, on 3 parallel jobs. Comptime: 65572 ms. Runtime: 28527 ms.

$ ./v -cc tcc -W test vlib/net/ssl/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK       9.164 ms vlib/net/ssl/ssl_compiles_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 1221 ms, on 1 job. Comptime: 1206 ms. Runtime: 9 ms.

$ ./v -cc tcc -W test vlib/net/openssl/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK       8.713 ms vlib/net/openssl/openssl_compiles_test.c.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 948 ms, on 1 job. Comptime: 935 ms. Runtime: 8 ms.
```