### PR TITLE
json: remove unnecessary default value for string in tests

### DIFF
--- a/vlib/json/tests/json_encode_default_option_none_test.v
+++ b/vlib/json/tests/json_encode_default_option_none_test.v
@@ -3,7 +3,7 @@ module main
 import json
 
 struct Test {
-	id ?string = none
+	id ?string
 }
 
 fn test_main() {


### PR DESCRIPTION
Tests OK for `vlib/json` with `-W` flag
```bash
$ ./v -W test vlib/json/tests/
(...)
Summary for all V _test.v files: 43 passed, 43 total. Elapsed time: 5457 ms, on 7 parallel jobs. Comptime: 35674 ms. Runtime: 368 ms.
```