### PR TITLE
regex: remove deprecated const group in tests

### DIFF
--- a/vlib/regex/regex_test.v
+++ b/vlib/regex/regex_test.v
@@ -202,7 +202,7 @@ const match_test_suite = [
     TestItem{"abcAAxyz", r"^abc\X4141xyz$", 0,8},
     TestItem{"abcALxyz", r"^abc\X414cxyz$", 0,8},
     TestItem{"abcALxyz", r"^abc\X414Cxyz$", 0,8},
-    TestItem{"abcBxyz", r"^abc\x41+xyz$", -1,3},    
+    TestItem{"abcBxyz", r"^abc\x41+xyz$", -1,3},
 ]
 
 struct TestItemRe {
@@ -817,8 +817,7 @@ struct Test_find_groups {
 }
 
 // vfmt off
-const (
-find_groups_test_suite = [
+const find_groups_test_suite = [
 	Test_find_groups{
 		"aabbbccccdd",
 		r"(b+)(c+)",
@@ -841,7 +840,6 @@ find_groups_test_suite = [
 		[2, 9, 2, 5, 9, 11],
 	},
 ]
-)
 // vfmt on
 
 fn test_groups_in_find() {


### PR DESCRIPTION
Tests OK for `vlib/regex` with `-W` flag.
```bash
$ ./v -cc tcc -W test vlib/regex/regex_test.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK      79.869 ms vlib/regex/regex_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 512 ms, on 1 job. Comptime: 430 ms. Runtime: 79 ms.
```