### PR TITLE
docs: add section in README for compilation on OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ cd v
 make
 ```
 
+### OpenBSD
+
+On OpenBSD (release 7.7), V needs `boehm-gc` and `openssl-3.4.1p0v0` packages preinstalled. After
+installing them, use GNU `make` (installed with `gmake` package), to build V.
+
+```bash
+pkg_add boehm-gc openssl-3.4.1p0v0 gmake
+git clone --depth=1 https://github.com/vlang/v
+cd v
+gmake
+```
+
 ### Termux/Android
 
 On Termux, V needs some packages preinstalled - a working C compiler, also `libexecinfo`,


### PR DESCRIPTION
Improve documentation with a dedicated section to build V on OpenBSD: 3 packages needed to build it.