### PR TITLE
builtin: add string.expand_tabs()

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -604,11 +604,11 @@ pub fn (s string) normalize_tabs(tab_len int) string {
 // Example: assert 'AB\tHello!'.expand_tabs(4) == 'AB  Hello!'
 pub fn (s string) expand_tabs(tab_len int) string {
 	if tab_len <= 0 {
-		return s // Handle invalid tab length
+		return s.clone() // Handle invalid tab length
 	}
 	mut output := strings.new_builder(s.len)
 	mut column := 0
-	for r in s.runes() {
+	for r in s.runes_iterator() {
 		match r {
 			`\t` {
 				spaces := tab_len - (column % tab_len)

--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -600,6 +600,34 @@ pub fn (s string) normalize_tabs(tab_len int) string {
 	return s.replace_char(`\t`, ` `, tab_len)
 }
 
+// expand_tabs replaces tab characters (\t) in the input string with spaces to achieve proper column alignment
+// Example: assert 'AB\tHello!'.expand_tabs(4) == 'AB  Hello!'
+pub fn (s string) expand_tabs(tab_len int) string {
+	if tab_len <= 0 {
+		return s // Handle invalid tab length
+	}
+	mut output := strings.new_builder(s.len)
+	mut column := 0
+	for r in s.runes() {
+		match r {
+			`\t` {
+				spaces := tab_len - (column % tab_len)
+				output.write_string(' '.repeat(spaces))
+				column += spaces
+			}
+			`\n`, `\r` {
+				output.write_rune(r)
+				column = 0 // Reset on any line break
+			}
+			else {
+				output.write_rune(r)
+				column++ // Valid for most chars; consider Unicode wide chars
+			}
+		}
+	}
+	return output.str()
+}
+
 // bool returns `true` if the string equals the word "true" it will return `false` otherwise.
 @[inline]
 pub fn (s string) bool() bool {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -622,7 +622,7 @@ fn test_trim_space() {
 	assert a.trim_space_right() == ' a'
 
 	code := '
-
+	
 fn main() {
         println(2)
 }
@@ -632,7 +632,7 @@ fn main() {
         println(2)
 }'
 	code_trim_right := '
-
+	
 fn main() {
         println(2)
 }'
@@ -744,6 +744,11 @@ fn test_replace_char() {
 fn test_normalize_tabs() {
 	assert '\t\tHello!'.normalize_tabs(4) == '        Hello!'
 	assert '\t\tHello!\t; greeting'.normalize_tabs(1) == '  Hello! ; greeting'
+}
+
+fn test_expand_tabs() {
+	assert 'AB\tHello!'.expand_tabs(4) == 'AB  Hello!'
+	assert 'AB\t\tHello!\t; greeting'.expand_tabs(4) == 'AB      Hello!  ; greeting'
 }
 
 fn test_itoa() {

--- a/vlib/builtin/string_test.v
+++ b/vlib/builtin/string_test.v
@@ -622,7 +622,7 @@ fn test_trim_space() {
 	assert a.trim_space_right() == ' a'
 
 	code := '
-	
+\t
 fn main() {
         println(2)
 }
@@ -632,7 +632,7 @@ fn main() {
         println(2)
 }'
 	code_trim_right := '
-	
+\t
 fn main() {
         println(2)
 }'


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Add string.expand_tabs() replaces tab characters (\t) in the input string with spaces to achieve proper column alignment.
Example: assert 'AB\tHello!'.expand_tabs(4) == 'AB  Hello!'