### PR TITLE
sync: fix documentation for new_spin_lock function

### DIFF
--- a/vlib/sync/sync.c.v
+++ b/vlib/sync/sync.c.v
@@ -27,8 +27,7 @@ mut:
 	padding [63]u8 // Cache line padding (fills to 64 bytes total)
 }
 
-// new_spin_lock creates and returns a new SpinLock instance initialized to
-// unlocked state.
+// new_spin_lock creates and returns a new SpinLock instance initialized to unlocked state.
 pub fn new_spin_lock() &SpinLock {
 	mut the_lock := &SpinLock{
 		locked: 0


### PR DESCRIPTION
Add final dot in documentation for `new_spin_lock` function.

Reviewed in PR #24788 but not fixed before merge :(