### PR TITLE
sync: fix spin lock, add destroy() and try_lock()

### DIFF
--- a/vlib/sync/spinlock_test.v
+++ b/vlib/sync/spinlock_test.v
@@ -28,5 +28,6 @@ fn test_spinlock() {
 		}(mut wg, s, &counter, iterations)
 	}
 	wg.wait()
+	s.destroy()
 	assert counter == num_threads * iterations
 }

--- a/vlib/sync/spinlock_test.v
+++ b/vlib/sync/spinlock_test.v
@@ -1,22 +1,32 @@
 import sync
+import rand
+import time
 
 fn test_spinlock() {
 	mut counter := 0
 	mut s := sync.new_spin_lock()
 	num_threads := 10
+	iterations := 10
 	mut wg := sync.new_waitgroup()
 	wg.add(num_threads)
 
 	for _ in 0 .. num_threads {
-		spawn fn (mut wg sync.WaitGroup, s &sync.SpinLock, counter_ref &int) {
-			defer {
+		spawn fn (mut wg sync.WaitGroup, s &sync.SpinLock, counter_ref &int, iterations int) {
+			for _ in 0 .. iterations {
+				s.lock()
+
+				unsafe {
+					tmp := *counter_ref
+					randval := rand.intn(100) or { 1 }
+					time.sleep(randval * time.nanosecond)
+
+					(*counter_ref) = tmp + 1
+				}
 				s.unlock()
-				wg.done()
 			}
-			s.lock()
-			(*counter_ref)++
-		}(mut wg, s, &counter)
+			wg.done()
+		}(mut wg, s, &counter, iterations)
 	}
 	wg.wait()
-	assert counter == num_threads
+	assert counter == num_threads * iterations
 }

--- a/vlib/sync/spinlock_test.v
+++ b/vlib/sync/spinlock_test.v
@@ -5,6 +5,9 @@ import time
 fn test_spinlock() {
 	mut counter := 0
 	mut s := sync.new_spin_lock()
+	defer {
+		s.destroy()
+	}
 	num_threads := 10
 	iterations := 10
 	mut wg := sync.new_waitgroup()
@@ -28,6 +31,11 @@ fn test_spinlock() {
 		}(mut wg, s, &counter, iterations)
 	}
 	wg.wait()
-	s.destroy()
 	assert counter == num_threads * iterations
+
+	// test try_lock()
+	s.lock()
+	assert s.try_lock() == false
+	s.unlock()
+	assert s.try_lock() == true
 }

--- a/vlib/sync/spinlock_test.v
+++ b/vlib/sync/spinlock_test.v
@@ -38,4 +38,5 @@ fn test_spinlock() {
 	assert s.try_lock() == false
 	s.unlock()
 	assert s.try_lock() == true
+	assert s.try_lock() == false
 }

--- a/vlib/sync/stdatomic/1.declarations.c.v
+++ b/vlib/sync/stdatomic/1.declarations.c.v
@@ -109,3 +109,13 @@ fn C.atomic_fetch_sub_u64(voidptr, u64) u64
 
 fn C.atomic_thread_fence(int)
 fn C.cpu_relax()
+
+fn C.ANNOTATE_RWLOCK_CREATE(voidptr)
+fn C.ANNOTATE_RWLOCK_ACQUIRED(voidptr, int)
+fn C.ANNOTATE_RWLOCK_RELEASED(voidptr, int)
+fn C.ANNOTATE_RWLOCK_DESTROY(voidptr)
+
+$if valgrind ? {
+	#flag -I/usr/include/valgrind
+	#include <valgrind/helgrind.h>
+}

--- a/vlib/sync/sync.c.v
+++ b/vlib/sync/sync.c.v
@@ -18,16 +18,6 @@ fn should_be_zero(res int) {
 	}
 }
 
-fn C.ANNOTATE_RWLOCK_CREATE(voidptr)
-fn C.ANNOTATE_RWLOCK_ACQUIRED(voidptr, int)
-fn C.ANNOTATE_RWLOCK_RELEASED(voidptr, int)
-fn C.ANNOTATE_RWLOCK_DESTROY(voidptr)
-
-$if valgrind ? {
-	#flag -I/usr/include/valgrind
-	#include <valgrind/helgrind.h>
-}
-
 // SpinLock is a mutual exclusion lock that busy-waits (spins) when locked.
 // When one thread holds the lock, any other thread attempting to acquire it
 // will loop repeatedly until the lock becomes available.

--- a/vlib/sync/sync.c.v
+++ b/vlib/sync/sync.c.v
@@ -71,8 +71,7 @@ pub fn (s &SpinLock) lock() {
 			C.cpu_relax()
 		}
 
-		// Refresh lock state before next attempt
-		expected = C.atomic_load_byte(&s.locked)
+		expected = 0
 	}
 }
 

--- a/vlib/sync/sync.c.v
+++ b/vlib/sync/sync.c.v
@@ -100,16 +100,14 @@ pub fn (s &SpinLock) try_lock() bool {
 		return false
 	}
 	mut expected := u8(0)
-	success := C.atomic_compare_exchange_weak_byte(&s.locked, &expected, 1)
-	$if valgrind ? {
-		if success {
+	if C.atomic_compare_exchange_weak_byte(&s.locked, &expected, 1) {
+		$if valgrind ? {
 			C.ANNOTATE_RWLOCK_ACQUIRED(&s.locked, 1)
 		}
-	}
-	if success {
 		C.atomic_thread_fence(C.memory_order_acquire)
+		return true
 	}
-	return success
+	return false
 }
 
 // unlock releases the spin lock, making it available to other threads.


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

1. Bug fix for spin lock expected value reset to unlock before retry.
2. Update test.
3. Add `destroy()`.
4. Add `try_lock()`.
5. Add `valgrind` `ANNOTATE` support  to avoid false error report with spin lock detection. When using with `valgrind`, please add `-d valgrind` to enable this.

Original code(`expected = C.atomic_load_byte(&s.locked)`) will cause the updated test fail sometimes.