### PR TITLE
picoev: add implementation for OpenBSD using kqueue

### DIFF
--- a/vlib/picoev/loop_openbsd.c.v
+++ b/vlib/picoev/loop_openbsd.c.v
@@ -1,0 +1,205 @@
+module picoev
+
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/event.h>
+
+fn C.kevent(int, changelist voidptr, nchanges int, eventlist voidptr, nevents int, timeout &C.timespec) int
+fn C.kqueue() int
+fn C.EV_SET(kev voidptr, ident int, filter i16, flags u16, fflags u32, data voidptr, udata voidptr)
+
+pub struct C.kevent {
+pub mut:
+	ident int
+	// uintptr_t
+	filter i16
+	flags  u16
+	fflags u32
+	data   voidptr
+	// intptr_t
+	udata voidptr
+}
+
+@[heap]
+pub struct KqueueLoop {
+mut:
+	id    int
+	now   i64
+	kq_id int
+	// -1 if not changed
+	changed_fds int
+	events      [1024]C.kevent
+	changelist  [256]C.kevent
+}
+
+type LoopType = KqueueLoop
+
+// create_kqueue_loop creates a new kernel event queue with loop_id=`id`.
+pub fn create_kqueue_loop(id int) !&KqueueLoop {
+	mut loop := &KqueueLoop{
+		id: id
+	}
+
+	loop.kq_id = C.kqueue()
+	if loop.kq_id == -1 {
+		return error('could not create kqueue loop!')
+	}
+	loop.changed_fds = -1
+	return loop
+}
+
+// ev_set sets a new `kevent` with file descriptor `index`.
+@[inline]
+pub fn (mut pv Picoev) ev_set(index int, operation int, events int) {
+	mut filter := 0
+	if events & picoev_read != 0 {
+		filter |= C.EVFILT_READ
+	}
+	if events & picoev_write != 0 {
+		filter |= C.EVFILT_WRITE
+	}
+	filter = i16(filter)
+
+	C.EV_SET(&pv.loop.changelist[index], pv.loop.changed_fds, filter, operation, 0, 0,
+		0)
+}
+
+// backend_build uses the lower 8 bits to store the old events and the higher 8
+// bits to store the next file descriptor in `Target.backend`.
+@[inline]
+fn backend_build(next_fd int, events u32) int {
+	return int((u32(next_fd) << 8) | (events & 0xff))
+}
+
+// get the lower 8 bits.
+@[inline]
+fn backend_get_old_events(backend int) int {
+	return backend & 0xff
+}
+
+// get the higher 8 bits.
+@[inline]
+fn backend_get_next_fd(backend int) int {
+	return backend >> 8
+}
+
+// apply pending processes all changes for the file descriptors and updates `loop.changelist`
+// if `aplly_all` is `true` the changes are immediately applied.
+fn (mut pv Picoev) apply_pending_changes(apply_all bool) int {
+	mut total, mut nevents := 0, 0
+
+	for pv.loop.changed_fds != -1 {
+		mut target := pv.file_descriptors[pv.loop.changed_fds]
+		old_events := backend_get_old_events(target.backend)
+		if target.events != old_events {
+			// events have been changed
+			if old_events != 0 {
+				pv.ev_set(total, C.EV_DISABLE, old_events)
+				total++
+			}
+			if target.events != 0 {
+				pv.ev_set(total, C.EV_ADD | C.EV_ENABLE, int(target.events))
+				total++
+			}
+			// Apply the changes if the total changes exceed the changelist size
+			if total + 1 >= pv.loop.changelist.len {
+				nevents = C.kevent(pv.loop.kq_id, &pv.loop.changelist, total, C.NULL,
+					0, C.NULL)
+				assert nevents == 0
+				total = 0
+			}
+		}
+
+		pv.loop.changed_fds = backend_get_next_fd(target.backend)
+		target.backend = -1
+	}
+
+	if apply_all && total != 0 {
+		nevents = C.kevent(pv.loop.kq_id, &pv.loop.changelist, total, C.NULL, 0, C.NULL)
+		assert nevents == 0
+		total = 0
+	}
+
+	return total
+}
+
+@[direct_array_access]
+fn (mut pv Picoev) update_events(fd int, events int) int {
+	// check if fd is in range
+	assert fd < max_fds
+
+	mut target := pv.file_descriptors[fd]
+
+	// initialize if adding the fd
+	if events & picoev_add != 0 {
+		target.backend = -1
+	}
+
+	// return if nothing to do
+	if (events == picoev_del && target.backend == -1)
+		|| (events != picoev_del && events & picoev_readwrite == target.events) {
+		return 0
+	}
+
+	// add to changed list if not yet being done
+	if target.backend == -1 {
+		target.backend = backend_build(pv.loop.changed_fds, target.events)
+		pv.loop.changed_fds = fd
+	}
+
+	// update events
+	target.events = u32(events & picoev_readwrite)
+	// apply immediately if is a DELETE
+	if events & picoev_del != 0 {
+		pv.apply_pending_changes(true)
+	}
+
+	return 0
+}
+
+@[direct_array_access]
+fn (mut pv Picoev) poll_once(max_wait_in_sec int) int {
+	ts := C.timespec{
+		tv_sec:  max_wait_in_sec
+		tv_nsec: 0
+	}
+
+	mut total, mut nevents := 0, 0
+	// apply changes later when the callback is called.
+	total = pv.apply_pending_changes(false)
+
+	nevents = C.kevent(pv.loop.kq_id, &pv.loop.changelist, total, &pv.loop.events, pv.loop.events.len,
+		&ts)
+	if nevents == -1 {
+		// the errors we can only rescue
+		assert C.errno == C.EACCES || C.errno == C.EFAULT || C.errno == C.EINTR
+		return -1
+	}
+
+	for i := 0; i < nevents; i++ {
+		event := pv.loop.events[i]
+		target := pv.file_descriptors[event.ident]
+
+		// changelist errors are fatal
+		assert event.flags & C.EV_ERROR == 0
+
+		if pv.loop.id == target.loop_id && event.filter & (C.EVFILT_READ | C.EVFILT_WRITE) != 0 {
+			read_events := match int(event.filter) {
+				C.EVFILT_READ {
+					picoev_read
+				}
+				C.EVFILT_WRITE {
+					picoev_write
+				}
+				else {
+					0
+				}
+			}
+
+			// do callback!
+			unsafe { target.cb(target.fd, read_events, &pv) }
+		}
+	}
+
+	return 0
+}

--- a/vlib/picoev/loop_openbsd.c.v
+++ b/vlib/picoev/loop_openbsd.c.v
@@ -34,7 +34,7 @@ mut:
 
 type LoopType = KqueueLoop
 
-// create_kqueue_loop creates a new kernel event queue with loop_id=`id`.
+// create_kqueue_loop creates a new kernel event queue with loop_id=`id`
 pub fn create_kqueue_loop(id int) !&KqueueLoop {
 	mut loop := &KqueueLoop{
 		id: id
@@ -48,7 +48,7 @@ pub fn create_kqueue_loop(id int) !&KqueueLoop {
 	return loop
 }
 
-// ev_set sets a new `kevent` with file descriptor `index`.
+// ev_set sets a new `kevent` with file descriptor `index`
 @[inline]
 pub fn (mut pv Picoev) ev_set(index int, operation int, events int) {
 	mut filter := 0
@@ -65,26 +65,26 @@ pub fn (mut pv Picoev) ev_set(index int, operation int, events int) {
 }
 
 // backend_build uses the lower 8 bits to store the old events and the higher 8
-// bits to store the next file descriptor in `Target.backend`.
+// bits to store the next file descriptor in `Target.backend`
 @[inline]
 fn backend_build(next_fd int, events u32) int {
 	return int((u32(next_fd) << 8) | (events & 0xff))
 }
 
-// get the lower 8 bits.
+// get the lower 8 bits
 @[inline]
 fn backend_get_old_events(backend int) int {
 	return backend & 0xff
 }
 
-// get the higher 8 bits.
+// get the higher 8 bits
 @[inline]
 fn backend_get_next_fd(backend int) int {
 	return backend >> 8
 }
 
 // apply pending processes all changes for the file descriptors and updates `loop.changelist`
-// if `aplly_all` is `true` the changes are immediately applied.
+// if `aplly_all` is `true` the changes are immediately applied
 fn (mut pv Picoev) apply_pending_changes(apply_all bool) int {
 	mut total, mut nevents := 0, 0
 

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -325,7 +325,7 @@ pub fn new(config Config) !&Picoev {
 	// select on windows and others
 	$if linux || termux {
 		pv.loop = create_epoll_loop(0) or { panic(err) }
-	} $else $if freebsd || macos {
+	} $else $if freebsd || macos || openbsd {
 		pv.loop = create_kqueue_loop(0) or { panic(err) }
 	} $else {
 		pv.loop = create_select_loop(0) or { panic(err) }


### PR DESCRIPTION
- `vlib/picoev/picoev.v`: add case for openbsd to use kqueue loop
- `vlib/picoev/loop_openbsd.c.v`: implementation for OpenBSD using kqueue (same as FreeBSD implementation).

---

**Tests OK** on OpenBSD/amd64 with tcc, clang and gcc for `vlib/picoev` tests and tests with `veb` (implementation uses picoev).

```bash
$ ./v  -W test vlib/picoev/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK       9.768 ms vlib/picoev/picoev_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 947 ms, on 1 job. Comptime: 933 ms. Runtime: 9 ms.

$ ./v -stats -W test vlib/veb/tests/veb_test.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
        V  source  code size:      50087 lines,     230184 tokens,    1370664 bytes,   597 types,    36 modules,   273 files
generated  target  code size:      30201 lines,    1116181 bytes
compilation took: 1635.293 ms, compilation speed: 30628 vlines/s, cgen threads: 3
>> webserver: pid: 97802, started on http://localhost:13005/ , with maximum runtime of 12000 milliseconds.
running tests in: /home/fox/dev/vlang.git/vlib/veb/tests/veb_test.v
      OK    [ 1/23]     2.123 ms    NO asserts | main.testsuite_begin()
      OK    [ 2/23]  1570.440 ms     2 asserts | main.test_simple_veb_app_can_be_compiled()
      OK    [ 3/23]   112.370 ms     1 assert  | main.test_a_simple_veb_app_runs_in_the_background()
> client retries: 1
      OK    [ 4/23]     1.153 ms     7 asserts | main.test_a_simple_tcp_client_can_connect_to_the_veb_server()
> client retries: 1
      OK    [ 5/23]     0.373 ms     7 asserts | main.test_a_simple_tcp_client_simple_route()
> client retries: 1
      OK    [ 6/23]     0.375 ms     1 assert  | main.test_a_simple_tcp_client_zero_content_length()
> client retries: 1
      OK    [ 7/23]  2018.785 ms     1 assert  | main.test_timeout_after_delayed_body()
> client retries: 1
      OK    [ 8/23]     1.757 ms     6 asserts | main.test_a_simple_tcp_client_html_page()
      OK    [ 9/23]     3.087 ms     6 asserts | main.test_http_client_index()
      OK    [10/23]     1.814 ms     6 asserts | main.test_http_client_404()
      OK    [11/23]     0.457 ms     5 asserts | main.test_http_client_simple()
      OK    [12/23]     0.427 ms     5 asserts | main.test_http_client_html_page()
      OK    [13/23]     0.913 ms     8 asserts | main.test_http_client_settings_page()
      OK    [14/23]    41.715 ms     9 asserts | main.test_http_client_user_repo_settings_page()
      OK    [15/23]     1.173 ms     6 asserts | main.test_http_client_json_post()


      OK    [16/23]     1.693 ms     2 asserts | main.test_http_client_multipart_form_data()

      OK    [17/23]     0.931 ms     3 asserts | main.test_login_with_multipart_form_data_send_by_fetch()
      OK    [18/23]     0.721 ms     2 asserts | main.test_query_params_are_passed_as_arguments()
      OK    [19/23]     0.763 ms     2 asserts | main.test_host()
      OK    [20/23]     0.357 ms     1 assert  | main.test_http_client_shutdown_does_not_work_without_a_cookie()
      OK    [21/23]     1.461 ms     4 asserts | main.test_empty_querypath()
> client retries: 1
>> webserver: exit_gracefully
      OK    [22/23]    85.958 ms     6 asserts | main.test_large_response()
      OK    [23/23]     0.730 ms     2 asserts | main.testsuite_end()
     Summary for running V tests in "veb_test.v": 92 passed, 92 total. Elapsed time: 3851 ms.

 OK    5663.612 ms vlib/veb/tests/veb_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 5666 ms, on 1 job. Comptime: 0 ms. Runtime: 5663 ms.

$ ./v -stats -W test vlib/veb/tests/large_payload_test.v 
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
        V  source  code size:      49980 lines,     226965 tokens,    1423180 bytes,   579 types,    42 modules,   250 files
generated  target  code size:      27548 lines,    1130419 bytes
compilation took: 1666.623 ms, compilation speed: 29988 vlines/s, cgen threads: 3
running tests in: /home/fox/dev/vlang.git/vlib/veb/tests/large_payload_test.v
[veb] Running app on http://localhost:13002/
      OK    [1/7]    43.617 ms     2 asserts | main.testsuite_begin()
      OK    [2/7]    44.270 ms   110 asserts | main.test_large_request_body()
[veb] error parsing request: too large
      OK    [3/7]     0.791 ms     8 asserts | main.test_large_request_header()
      OK    [4/7]  2019.755 ms     9 asserts | main.test_bigger_content_length()
      OK    [5/7]     0.482 ms     9 asserts | main.test_smaller_content_length()
      OK    [6/7]     1.749 ms    32 asserts | main.test_sendfile()
      OK    [7/7]     0.324 ms    NO asserts | main.testsuite_end()
     Summary for running V tests in "large_payload_test.v": 170 passed, 170 total. Elapsed time: 2111 ms.

 OK    3903.684 ms vlib/veb/tests/large_payload_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 3909 ms, on 1 job. Comptime: 0 ms. Runtime: 3903 ms.
```