### PR TITLE
checker: fix `sizeof(T)` usage on generic struct

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -402,7 +402,7 @@ fn (mut c Checker) eval_comptime_const_expr(expr ast.Expr, nlevel int) ?ast.Comp
 			}
 		}
 		ast.SizeOf {
-			s, _ := c.table.type_size(expr.typ)
+			s, _ := c.table.type_size(c.unwrap_generic(expr.typ))
 			return i64(s)
 		}
 		ast.FloatLiteral {

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -939,6 +939,16 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 		} else if struct_sym.info.generic_types.len == struct_sym.info.concrete_types.len {
 			parent_type := struct_sym.info.parent_type
 			parent_sym := c.table.sym(parent_type)
+			if c.inside_generic_struct_init {
+				mut st := unsafe { struct_sym.info }
+				for mut field in st.fields {
+					sym := c.table.sym(field.typ)
+					if sym.info is ast.ArrayFixed && c.array_fixed_has_unresolved_size(sym.info) {
+						mut size_expr := unsafe { sym.info.size_expr }
+						field.typ = c.eval_array_fixed_sizes(mut size_expr, 0, sym.info.elem_type)
+					}
+				}
+			}
 			for method in parent_sym.methods {
 				generic_names := struct_sym.info.generic_types.map(c.table.sym(it).name)
 				for i, param in method.params {

--- a/vlib/v/tests/structs/struct_generic_sizeof_test.v
+++ b/vlib/v/tests/structs/struct_generic_sizeof_test.v
@@ -1,0 +1,20 @@
+const cache_line_size = 32
+
+struct PaddedSlot[T] {
+mut:
+	data T
+	pad  [cache_line_size - sizeof(T)]u8
+}
+
+fn test_main() {
+	x := PaddedSlot[int]{}
+	assert '${x}' == 'PaddedSlot[int]{
+    data: 0
+    pad: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+}'
+	x2 := PaddedSlot[u8]{}
+	assert '${x2}' == 'PaddedSlot[u8]{
+    data: 0
+    pad: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+}'
+}


### PR DESCRIPTION
Fix #24806 