### PR TITLE
crypto: fix ambiguous expressions in DES implementation

### DIFF
--- a/vlib/crypto/des/block.v
+++ b/vlib/crypto/des/block.v
@@ -80,7 +80,7 @@ fn permute_initial_block(b u64) u64 {
 	block ^= b1 ^ b2 ^ b1 << 48 ^ b2 >> 48
 
 	// block = b1 b0 b5 b4 b3 b2 b7 b6
-	b1 = block >> 32 & 0xff00ff
+	b1 = (block >> 32) & 0xff00ff
 	b2 = (block & 0xff00ff00)
 	block ^= b1 << 32 ^ b2 ^ b1 << 8 ^ b2 << 24 // exchange b0 b4 with b3 b7
 
@@ -156,7 +156,7 @@ fn permute_final_block(b u64) u64 {
 	b2 = block & 0x0000f0f00000f0f0
 	block ^= b1 ^ b2 ^ b1 >> 12 ^ b2 << 12
 
-	b1 = block >> 32 & 0xff00ff
+	b1 = (block >> 32) & 0xff00ff
 	b2 = (block & 0xff00ff00)
 	block ^= b1 << 32 ^ b2 ^ b1 << 8 ^ b2 << 24
 


### PR DESCRIPTION
Fix ambiguous expressions in `vlib/crypto/des/block.v` for `& << >>`.

Without this fix, warnings (notice) with `crypto/des` tests:

```bash
$ ./v -stats -W test vlib/crypto/des/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
vlib/crypto/des/block.v:83:19: notice: ambiguous expression. use `()` to ensure correct order of operations
   81 | 
   82 |     // block = b1 b0 b5 b4 b3 b2 b7 b6
   83 |     b1 = block >> 32 & 0xff00ff
      |                      ^
   84 |     b2 = (block & 0xff00ff00)
   85 |     block ^= b1 << 32 ^ b2 ^ b1 << 8 ^ b2 << 24 // exchange b0 b4 with b3 b7
vlib/crypto/des/block.v:159:19: notice: ambiguous expression. use `()` to ensure correct order of operations
  157 |     block ^= b1 ^ b2 ^ b1 >> 12 ^ b2 << 12
  158 | 
  159 |     b1 = block >> 32 & 0xff00ff
      |                      ^
  160 |     b2 = (block & 0xff00ff00)
  161 |     block ^= b1 << 32 ^ b2 ^ b1 << 8 ^ b2 << 24
checker summary: 0 V errors, 0 V warnings, 2 V notices
        V  source  code size:      32148 lines,     151554 tokens,     874194 bytes,   314 types,    16 modules,   151 files
generated  target  code size:      10892 lines,     385648 bytes
compilation took: 354.297 ms, compilation speed: 90737 vlines/s, cgen threads: 7
running tests in: /home/fox/dev/Perso/vlang.git/vlib/crypto/des/des_test.v
test_triple_des ok
      OK    [1/2]     0.054 ms     2 asserts | main.test_triple_des()
test_des ok
      OK    [2/2]     0.024 ms     2 asserts | main.test_des()
     Summary for running V tests in "des_test.v": 4 passed, 4 total. Elapsed time: 0 ms.

 OK     369.242 ms vlib/crypto/des/des_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 372 ms, on 1 job. Comptime: 0 ms. Runtime: 369 ms.
```

No more warnings after fix:

```bash
$ ./v -stats -W test vlib/crypto/des/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
        V  source  code size:      32148 lines,     151558 tokens,     874198 bytes,   314 types,    16 modules,   151 files
generated  target  code size:      10892 lines,     385652 bytes
compilation took: 347.592 ms, compilation speed: 92487 vlines/s, cgen threads: 7
running tests in: /home/fox/dev/Perso/vlang.git/vlib/crypto/des/des_test.v
test_triple_des ok
      OK    [1/2]     0.100 ms     2 asserts | main.test_triple_des()
test_des ok
      OK    [2/2]     0.038 ms     2 asserts | main.test_des()
     Summary for running V tests in "des_test.v": 4 passed, 4 total. Elapsed time: 0 ms.

 OK     361.368 ms vlib/crypto/des/des_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 362 ms, on 1 job. Comptime: 0 ms. Runtime: 361 ms.
```