### PR TITLE
maths.bits: fix ambiguous expressions

### DIFF
--- a/vlib/math/bits/bits.v
+++ b/vlib/math/bits/bits.v
@@ -106,8 +106,7 @@ pub fn ones_count_16(x u16) int {
 // ones_count_32 returns the number of one bits ("population count") in x.
 @[direct_array_access]
 pub fn ones_count_32(x u32) int {
-	return int(pop_8_tab[x >> 24] + pop_8_tab[(x >> 16) & 0xff] +
-		pop_8_tab[(x >> 8) & 0xff] +
+	return int(pop_8_tab[x >> 24] + pop_8_tab[(x >> 16) & 0xff] + pop_8_tab[(x >> 8) & 0xff] +
 		pop_8_tab[x & u32(0xff)])
 }
 

--- a/vlib/math/bits/bits.v
+++ b/vlib/math/bits/bits.v
@@ -106,7 +106,8 @@ pub fn ones_count_16(x u16) int {
 // ones_count_32 returns the number of one bits ("population count") in x.
 @[direct_array_access]
 pub fn ones_count_32(x u32) int {
-	return int(pop_8_tab[x >> 24] + pop_8_tab[x >> 16 & 0xff] + pop_8_tab[x >> 8 & 0xff] +
+	return int(pop_8_tab[x >> 24] + pop_8_tab[(x >> 16) & 0xff] +
+		pop_8_tab[(x >> 8) & 0xff] +
 		pop_8_tab[x & u32(0xff)])
 }
 
@@ -131,8 +132,8 @@ pub fn ones_count_64(x u64) int {
 	// Per "Hacker's Delight", the first line can be simplified
 	// more, but it saves at best one instruction, so we leave
 	// it alone for clarity.
-	mut y := (x >> u64(1) & (m0 & max_u64)) + (x & (m0 & max_u64))
-	y = (y >> u64(2) & (m1 & max_u64)) + (y & (m1 & max_u64))
+	mut y := ((x >> u64(1)) & (m0 & max_u64)) + (x & (m0 & max_u64))
+	y = ((y >> u64(2)) & (m1 & max_u64)) + (y & (m1 & max_u64))
 	y = ((y >> 4) + y) & (m2 & max_u64)
 	y += y >> 8
 	y += y >> 16
@@ -202,18 +203,18 @@ pub fn reverse_16(x u16) u16 {
 // reverse_32 returns the value of x with its bits in reversed order.
 @[inline]
 pub fn reverse_32(x u32) u32 {
-	mut y := ((x >> u32(1) & (m0 & max_u32)) | ((x & (m0 & max_u32)) << 1))
-	y = ((y >> u32(2) & (m1 & max_u32)) | ((y & (m1 & max_u32)) << u32(2)))
-	y = ((y >> u32(4) & (m2 & max_u32)) | ((y & (m2 & max_u32)) << u32(4)))
+	mut y := (((x >> u32(1)) & (m0 & max_u32)) | ((x & (m0 & max_u32)) << 1))
+	y = (((y >> u32(2)) & (m1 & max_u32)) | ((y & (m1 & max_u32)) << u32(2)))
+	y = (((y >> u32(4)) & (m2 & max_u32)) | ((y & (m2 & max_u32)) << u32(4)))
 	return reverse_bytes_32(u32(y))
 }
 
 // reverse_64 returns the value of x with its bits in reversed order.
 @[inline]
 pub fn reverse_64(x u64) u64 {
-	mut y := ((x >> u64(1) & (m0 & max_u64)) | ((x & (m0 & max_u64)) << 1))
-	y = ((y >> u64(2) & (m1 & max_u64)) | ((y & (m1 & max_u64)) << 2))
-	y = ((y >> u64(4) & (m2 & max_u64)) | ((y & (m2 & max_u64)) << 4))
+	mut y := (((x >> u64(1)) & (m0 & max_u64)) | ((x & (m0 & max_u64)) << 1))
+	y = (((y >> u64(2)) & (m1 & max_u64)) | ((y & (m1 & max_u64)) << 2))
+	y = (((y >> u64(4)) & (m2 & max_u64)) | ((y & (m2 & max_u64)) << 4))
 	return reverse_bytes_64(y)
 }
 
@@ -231,7 +232,7 @@ pub fn reverse_bytes_16(x u16) u16 {
 // This function's execution time does not depend on the inputs.
 @[inline]
 pub fn reverse_bytes_32(x u32) u32 {
-	y := ((x >> u32(8) & (m3 & max_u32)) | ((x & (m3 & max_u32)) << u32(8)))
+	y := (((x >> u32(8)) & (m3 & max_u32)) | ((x & (m3 & max_u32)) << u32(8)))
 	return u32((y >> 16) | (y << 16))
 }
 
@@ -240,8 +241,8 @@ pub fn reverse_bytes_32(x u32) u32 {
 // This function's execution time does not depend on the inputs.
 @[inline]
 pub fn reverse_bytes_64(x u64) u64 {
-	mut y := ((x >> u64(8) & (m3 & max_u64)) | ((x & (m3 & max_u64)) << u64(8)))
-	y = ((y >> u64(16) & (m4 & max_u64)) | ((y & (m4 & max_u64)) << u64(16)))
+	mut y := (((x >> u64(8)) & (m3 & max_u64)) | ((x & (m3 & max_u64)) << u64(8)))
+	y = (((y >> u64(16)) & (m4 & max_u64)) | ((y & (m4 & max_u64)) << u64(16)))
 	return (y >> 32) | (y << 32)
 }
 

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -806,13 +806,11 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	}
 	// Do an ambiguous expression check for << >> and &, since they all have the same precedence (unlike in C)
 	if !c.is_builtin_mod && node.op in [.amp, .left_shift, .right_shift] {
-		if !c.mod.starts_with('math') { // TODO fix all warnings in math
-			if mut node.left is ast.InfixExpr {
-				if node.left.op != node.op && node.left.op in [.amp, .left_shift, .right_shift] {
-					// for example: `(a << b) & c` instead of `a << b & c`
-					c.note('ambiguous expression. use `()` to ensure correct order of operations',
-						node.pos)
-				}
+		if mut node.left is ast.InfixExpr {
+			if node.left.op != node.op && node.left.op in [.amp, .left_shift, .right_shift] {
+				// for example: `(a << b) & c` instead of `a << b & c`
+				c.note('ambiguous expression. use `()` to ensure correct order of operations',
+					node.pos)
 			}
 		}
 	}


### PR DESCRIPTION
Fix ambiguous expressions for `& << >>` in `vlib/math/bits/bits.v` + enable check for `math` module in `vlib/v/checker/infix.v`

Without fixes, warnings (notice) for ambiguous expressions in `vlib/math/bits` during tests:
```bash
$ ./v -stats -W test vlib/math/bits
(...)
vlib/math/bits/bits.v:109:52: notice: ambiguous expression. use `()` to ensure correct order of operations
  107 | @[direct_array_access]
  108 | pub fn ones_count_32(x u32) int {
  109 |     return int(pop_8_tab[x >> 24] + pop_8_tab[x >> 16 & 0xff] + pop_8_tab[x >> 8 & 0xff] +
      |                                                       ^
  110 |         pop_8_tab[x & u32(0xff)])
  111 | }
vlib/math/bits/bits.v:134:24: notice: ambiguous expression. use `()` to ensure correct order of operations
  132 |     // more, but it saves at best one instruction, so we leave
  133 |     // it alone for clarity.
  134 |     mut y := (x >> u64(1) & (m0 & max_u64)) + (x & (m0 & max_u64))
      |                           ^
  135 |     y = (y >> u64(2) & (m1 & max_u64)) + (y & (m1 & max_u64))
  136 |     y = ((y >> 4) + y) & (m2 & max_u64)
vlib/math/bits/bits.v:135:19: notice: ambiguous expression. use `()` to ensure correct order of operations
  133 |     // it alone for clarity.
  134 |     mut y := (x >> u64(1) & (m0 & max_u64)) + (x & (m0 & max_u64))
  135 |     y = (y >> u64(2) & (m1 & max_u64)) + (y & (m1 & max_u64))
      |                      ^
  136 |     y = ((y >> 4) + y) & (m2 & max_u64)
  137 |     y += y >> 8
(...)
```

With fix, no more warnings for ambiguous expression, only notice for "shifting a value from a signed type `int`" (no fix for theses warnings).
```bash
$ ./v -stats -W test vlib/math/bits
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
vlib/math/bits/bits_test.v:18:29: notice: shifting a value from a signed type `int` can change the sign
   16 |     for x in 0 .. 8 {
   17 |         // C.printf("x:%02x lz: %d cmp: %d\n", i << x, leading_zeros_8(i << x), 7-x)
   18 |         assert leading_zeros_8(u8(i << x)) == 7 - x
      |                                   ^
   19 |     }
   20 |
vlib/math/bits/bits_test.v:51:8: notice: shifting a value from a signed type `int` can change the sign
   49 |         // C.printf("x:%02x lz: %llu cmp: %d\n", u8(i), ones_count_8(u8(i)), x)
   50 |         assert ones_count_8(u8(i)) == x
   51 |         i = (i << 1) + 1
      |              ^
   52 |     }
   53 |
vlib/math/bits/bits_test.v:59:8: notice: shifting a value from a signed type `int` can change the sign
   57 |         // C.printf("x:%04x lz: %llu cmp: %d\n", u16(i), ones_count_16(u16(i)), x)
   58 |         assert ones_count_16(u16(i)) == x
   59 |         i = (i << 1) + 1
      |              ^
   60 |     }
   61 |
vlib/math/bits/bits_test.v:67:8: notice: shifting a value from a signed type `int` can change the sign
   65 |         // C.printf("x:%08x lz: %llu cmp: %d\n", u32(i), ones_count_32(u32(i)), x)
   66 |         assert ones_count_32(u32(i)) == x
   67 |         i = (i << 1) + 1
      |              ^
   68 |     }
   69 |
vlib/math/bits/bits_test.v:103:8: notice: shifting a value from a signed type `int` can change the sign
  101 |         // C.printf("x:%02x lz: %llu cmp: %d\n", u8(i), reverse_8(u8(i)), rv)
  102 |         assert reverse_8(u8(i)) == rv
  103 |         i = (i << 1) + 1
      |              ^
  104 |     }
  105 |
vlib/math/bits/bits_test.v:119:8: notice: shifting a value from a signed type `int` can change the sign
  117 |         // C.printf("x:%04x lz: %llu cmp: %d\n", u16(i), reverse_16(u16(i)), rv)
  118 |         assert reverse_16(u16(i)) == rv
  119 |         i = (i << 1) + 1
      |              ^
  120 |     }
  121 |
vlib/math/bits/bits_test.v:135:8: notice: shifting a value from a signed type `int` can change the sign
  133 |         // C.printf("x:%08x lz: %llu cmp: %d\n", u32(i), reverse_32(u32(i)), rv)
  134 |         assert reverse_32(u32(i)) == rv
  135 |         i = (i << 1) + 1
      |              ^
  136 |     }
  137 |
checker summary: 0 V errors, 0 V warnings, 7 V notices
        V  source  code size:      30340 lines,     139498 tokens,     816501 bytes,   288 types,    12 modules,   135 files
generated  target  code size:      11765 lines,     436028 bytes
compilation took: 314.856 ms, compilation speed: 96361 vlines/s, cgen threads: 7
running tests in: /home/fox/dev/Perso/vlang.git/vlib/math/bits/bits_test.v
      OK    [1/2]     0.162 ms  1289 asserts | math.bits.test_bits()
      OK    [2/2]     0.001 ms     4 asserts | math.bits.test_div_64_edge_cases()
     Summary for running V tests in "bits_test.v": 1293 passed, 1293 total. Elapsed time: 0 ms.

 OK     328.813 ms vlib/math/bits/bits_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 329 ms, on 1 job. Comptime: 0 ms. Runtime: 328 ms.
```