### PR TITLE
cgen: fix if codegen when func parameter is option type

### DIFF
--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -76,6 +76,7 @@ fn (mut g Gen) need_tmp_var_in_expr(expr ast.Expr) bool {
 					return true
 				}
 			}
+			return expr.expected_arg_types.any(it.has_flag(.option))
 		}
 		ast.CastExpr {
 			return g.need_tmp_var_in_expr(expr.expr)

--- a/vlib/v/tests/fns/call_option_param_test.v
+++ b/vlib/v/tests/fns/call_option_param_test.v
@@ -1,0 +1,15 @@
+pub fn new_group(t ?Texts) Group {
+	return Group{}
+}
+
+struct Group {
+}
+
+struct Texts {
+}
+
+fn test_main() {
+	a := 0
+	_ := if a != 0 { new_group(Texts{}) } else { Group{} }
+	_ := if a != 0 { new_group(none) } else { Group{} }
+}


### PR DESCRIPTION
Fix  #24813