### PR TITLE
cgen: fix codegen for multi return assignment with option type

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -1083,8 +1083,11 @@ fn (mut g Gen) gen_multi_return_assign(node &ast.AssignStmt, return_type ast.Typ
 				'${mr_var_name}.arg${i}'
 			}
 			if mr_types[i].has_flag(.option) {
+				old_left_is_opt := g.left_is_opt
+				g.left_is_opt = true
 				g.expr(lx)
-				g.write(' = ${tmp_var};')
+				g.writeln(' = ${tmp_var};')
+				g.left_is_opt = old_left_is_opt
 			} else {
 				g.write('_option_ok(&(${base_typ}[]) { ${tmp_var} }, (${option_name}*)(&')
 				tmp_left_is_opt := g.left_is_opt

--- a/vlib/v/tests/options/option_fn_multi_ret_test.v
+++ b/vlib/v/tests/options/option_fn_multi_ret_test.v
@@ -1,0 +1,23 @@
+module main
+
+type Cmd = fn () string
+
+fn cplx() (bool, ?Cmd) {
+	return true, stringer
+}
+
+fn stringer() string {
+	return 'a string'
+}
+
+fn test_main() {
+	mut cmd := ?Cmd(none)
+	mut truth := false
+	truth, cmd = cplx()
+	if cmd != none {
+		println(cmd())
+		assert true
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
Fix #24812