### PR TITLE
math.unsigned: new uint256_new() function, add tests

### DIFF
--- a/vlib/math/unsigned/uint128_test.v
+++ b/vlib/math/unsigned/uint128_test.v
@@ -170,3 +170,7 @@ fn test_separators() {
 		assert with == without
 	}
 }
+
+fn test_new() {
+	assert unsigned.uint128_new(max_u64, max_u64) == unsigned.uint128_max
+}

--- a/vlib/math/unsigned/uint256.v
+++ b/vlib/math/unsigned/uint256.v
@@ -22,6 +22,11 @@ pub fn uint256_from_64(v u64) Uint256 {
 	return uint256_from_128(uint128_from_64(v))
 }
 
+// uint256_new creates new Uint256 with given `lo` and `hi`
+pub fn uint256_new(lo Uint128, hi Uint128) Uint256 {
+	return Uint256{lo, hi}
+}
+
 // is_zero checks if specified Uint256 is zero
 pub fn (u Uint256) is_zero() bool {
 	return u.lo.is_zero() && u.hi.is_zero()

--- a/vlib/math/unsigned/uint256_test.v
+++ b/vlib/math/unsigned/uint256_test.v
@@ -276,3 +276,7 @@ fn test_separators() {
 		assert with == without
 	}
 }
+
+fn test_new() {
+	assert unsigned.uint256_new(unsigned.uint128_max, unsigned.uint128_max) == unsigned.uint256_max
+}


### PR DESCRIPTION
While creating module testing, I discovered that this function is very much missing.
Lets create it.

`uint128_new()` already in the code base.