### PR TITLE
datatypes: add lockfree version of counter and ringbuffer

### DIFF
--- a/vlib/datatypes/lockfree/README.md
+++ b/vlib/datatypes/lockfree/README.md
@@ -1,0 +1,159 @@
+# Lockfree Library for V
+
+A high-performance, thread-safe collection of lock-free data structures for 
+the V programming language.Designed for concurrent applications requiring 
+low-latency and high-throughput data processing.
+
+## Features
+
+- **Truly Lock-Free**: No mutexes or spinlocks
+- **Cross-Platform**: Works on Windows, Linux, macOS
+- **Memory Safe**: Built-in hazard pointers and safe memory reclamation
+- **Configurable**: Tune parameters for specific workloads
+- **High Performance**: Optimized for modern multi-core processors
+
+## Data Structures
+
+### 1. Atomic Counter
+
+A thread-safe counter with atomic operations.
+
+```v
+import datatypes.lockfree
+
+mut counter := lockfree.new_counter[int](0)
+counter.increment()
+counter.increment_by(5)
+value := counter.get() // 6
+counter.decrement()
+counter.clear()
+```
+
+**Features**:
+- Atomic increment/decrement
+- Batch operations
+- Get current value
+- Reset functionality
+
+### 2. Lock-Free Stack (LIFO)(TBD)
+
+A Last-In-First-Out stack with push/pop operations.
+
+```v ignore
+import datatypes.lockfree
+
+mut stack := lockfree.new_stack[int]()
+stack.push(42)
+stack.push(100)
+top := stack.pop() // 100
+size := stack.size()
+```
+
+**Features**:
+- Push/pop operations
+- Batch push/pop
+- Size approximation
+- Empty check
+- Thread-safe iteration
+
+### 3. Ring Buffer
+
+A circular buffer for producer-consumer scenarios.
+
+```v
+import datatypes.lockfree
+
+mut rb := lockfree.new_ringbuffer[int](1024)
+rb.push(10)
+rb.push(20)
+item := rb.pop() // 10
+free := rb.remaining()
+```
+
+**Features**:
+- Single/Multi producer/consumer modes
+- Blocking/non-blocking operations
+- Batch operations
+- Configurable size
+- Memory efficient
+
+### 4. Double-Ended Queue (Deque)(TBD)
+
+A thread-safe double-ended queue.
+
+```v ignore
+import datatypes.lockfree
+
+mut deque := lockfree.new_deque[string]()
+deque.push_front("first")
+deque.push_back("last")
+front := deque.pop_front() // "first"
+back := deque.pop_back() // "last"
+```
+
+**Features**:
+- Push/pop from both ends
+- Size tracking
+- Empty check
+- Batch operations
+- Iterators
+
+### 5. Concurrent Map(TBD)
+
+A thread-safe key-value store.
+
+```v ignore
+import datatypes.lockfree
+
+mut cmap := lockfree.new_map[string, int]()
+cmap.set("answer", 42)
+value := cmap.get("answer") // 42
+exists := cmap.exists("answer")
+cmap.delete("answer")
+```
+
+**Features**:
+- Get/set/delete operations
+- Key existence check
+- Size approximation
+- Iterators
+- Atomic updates
+
+## Best Practices
+
+1. **Choose the right mode**:
+   - SPSC: Single Producer Single Consumer
+   - MPSC: Multiple Producer Single Consumer
+   - MPMC: Multiple Producer Multiple Consumer
+
+2. **Batch operations**:
+   ```v ignore
+   // More efficient than single pushes
+   stack.push_batch([1, 2, 3, 4, 5])
+   ```
+
+3. **Monitor contention**:
+   ```v ignore
+   stats := stack.stats()
+   if stats.avg_retries > 5.0 {
+       // Consider tuning configuration
+   }
+   ```
+
+4. **Use appropriate backoff**:
+   - Low contention: Minimal backoff
+   - High contention: Exponential backoff
+
+## Acknowledgements
+
+This library incorporates research and design principles from:
+- Intel Threading Building Blocks (TBB)
+- Facebook Folly
+- Java Concurrent Package
+- Dmitry Vyukov's lock-free algorithms
+- DPDK rte ring
+
+---
+
+**Lockfree Library** - Build high-performance concurrent applications with confidence.
+

--- a/vlib/datatypes/lockfree/README.md
+++ b/vlib/datatypes/lockfree/README.md
@@ -8,7 +8,6 @@ low-latency and high-throughput data processing.
 
 - **Truly Lock-Free**: No mutexes or spinlocks
 - **Cross-Platform**: Works on Windows, Linux, macOS
-- **Memory Safe**: Built-in hazard pointers and safe memory reclamation
 - **Configurable**: Tune parameters for specific workloads
 - **High Performance**: Optimized for modern multi-core processors
 
@@ -35,28 +34,7 @@ counter.clear()
 - Get current value
 - Reset functionality
 
-### 2. Lock-Free Stack (LIFO)(TBD)
-
-A Last-In-First-Out stack with push/pop operations.
-
-```v ignore
-import datatypes.lockfree
-
-mut stack := lockfree.new_stack[int]()
-stack.push(42)
-stack.push(100)
-top := stack.pop() // 100
-size := stack.size()
-```
-
-**Features**:
-- Push/pop operations
-- Batch push/pop
-- Size approximation
-- Empty check
-- Thread-safe iteration
-
-### 3. Ring Buffer
+### 2. Ring Buffer
 
 A circular buffer for producer-consumer scenarios.
 
@@ -77,73 +55,6 @@ free := rb.remaining()
 - Configurable size
 - Memory efficient
 
-### 4. Double-Ended Queue (Deque)(TBD)
-
-A thread-safe double-ended queue.
-
-```v ignore
-import datatypes.lockfree
-
-mut deque := lockfree.new_deque[string]()
-deque.push_front("first")
-deque.push_back("last")
-front := deque.pop_front() // "first"
-back := deque.pop_back() // "last"
-```
-
-**Features**:
-- Push/pop from both ends
-- Size tracking
-- Empty check
-- Batch operations
-- Iterators
-
-### 5. Concurrent Map(TBD)
-
-A thread-safe key-value store.
-
-```v ignore
-import datatypes.lockfree
-
-mut cmap := lockfree.new_map[string, int]()
-cmap.set("answer", 42)
-value := cmap.get("answer") // 42
-exists := cmap.exists("answer")
-cmap.delete("answer")
-```
-
-**Features**:
-- Get/set/delete operations
-- Key existence check
-- Size approximation
-- Iterators
-- Atomic updates
-
-## Best Practices
-
-1. **Choose the right mode**:
-   - SPSC: Single Producer Single Consumer
-   - MPSC: Multiple Producer Single Consumer
-   - MPMC: Multiple Producer Multiple Consumer
-
-2. **Batch operations**:
-   ```v ignore
-   // More efficient than single pushes
-   stack.push_batch([1, 2, 3, 4, 5])
-   ```
-
-3. **Monitor contention**:
-   ```v ignore
-   stats := stack.stats()
-   if stats.avg_retries > 5.0 {
-       // Consider tuning configuration
-   }
-   ```
-
-4. **Use appropriate backoff**:
-   - Low contention: Minimal backoff
-   - High contention: Exponential backoff
-
 ## Acknowledgements
 
 This library incorporates research and design principles from:
@@ -154,6 +65,3 @@ This library incorporates research and design principles from:
 - DPDK rte ring
 
 ---
-
-**Lockfree Library** - Build high-performance concurrent applications with confidence.
-

--- a/vlib/datatypes/lockfree/README.md
+++ b/vlib/datatypes/lockfree/README.md
@@ -1,7 +1,7 @@
 # Lockfree Library for V
 
 A high-performance, thread-safe collection of lock-free data structures for 
-the V programming language.Designed for concurrent applications requiring 
+the V programming language. Designed for concurrent applications requiring 
 low-latency and high-throughput data processing.
 
 ## Features

--- a/vlib/datatypes/lockfree/bench/bench_channel.v
+++ b/vlib/datatypes/lockfree/bench/bench_channel.v
@@ -45,21 +45,21 @@ fn main() {
 	results << test_scenario('SPSC', 1, 1, debug)
 
 	// Multiple Producers Single Consumer
-	for i in [2, 4, 8] {
+	for i in [2, 4, 8, 16] {
 		if i <= max_threads {
 			results << test_scenario('MPSC (${i}P1C)', i, 1, debug)
 		}
 	}
 
 	// Single Producer Multiple Consumers
-	for i in [2, 4] {
+	for i in [2, 4, 8, 16] {
 		if i <= max_threads {
 			results << test_scenario('SPMC (1P${i}C)', 1, i, debug)
 		}
 	}
 
 	// Multiple Producers Multiple Consumers
-	for i in [2, 4, 8] {
+	for i in [2, 4, 8, 16] {
 		if i * 2 <= max_threads {
 			results << test_scenario('MPMC (${i}P${i}C)', i, i, debug)
 		}

--- a/vlib/datatypes/lockfree/bench/bench_channel.v
+++ b/vlib/datatypes/lockfree/bench/bench_channel.v
@@ -18,7 +18,7 @@ const test_runs = 5 // Number of test runs
 const max_threads = runtime.nr_cpus() // Maximum number of threads
 
 // Performance test results
-struct PerfResult {
+struct ChannelPerfResult {
 	scenario   string // Test scenario identifier
 	throughput f64    // Throughput in million operations per second
 	latency    f64    // Average latency in nanoseconds
@@ -39,7 +39,7 @@ fn main() {
 	}
 
 	// Test different scenarios
-	mut results := []PerfResult{}
+	mut results := []ChannelPerfResult{}
 
 	// Single Producer Single Consumer
 	results << test_scenario('SPSC', 1, 1, debug)
@@ -70,7 +70,7 @@ fn main() {
 }
 
 // Test specific scenario with given producers/consumers
-fn test_scenario(scenario string, producers int, consumers int, debug bool) PerfResult {
+fn test_scenario(scenario string, producers int, consumers int, debug bool) ChannelPerfResult {
 	println('\nTesting scenario: ${scenario}')
 
 	// Create channel
@@ -99,7 +99,7 @@ fn test_scenario(scenario string, producers int, consumers int, debug bool) Perf
 	throughput := f64(total_ops) / avg_time.seconds() / 1_000_000 // MOPS
 	latency := avg_time.nanoseconds() / f64(total_ops / test_runs) // ns/op
 
-	return PerfResult{
+	return ChannelPerfResult{
 		scenario:   scenario
 		throughput: throughput
 		latency:    latency
@@ -192,7 +192,7 @@ fn consumer_thread(ch chan int, id int, items_to_consume int, mut consumed_count
 }
 
 // Print formatted performance results
-fn print_results(results []PerfResult) {
+fn print_results(results []ChannelPerfResult) {
 	println('\nPerformance Results')
 	println('====================================================================')
 	println('Scenario\t\tThroughput (M ops/s)\tAvg Latency (ns)\tCPU Usage (%)')

--- a/vlib/datatypes/lockfree/bench/bench_channel.v
+++ b/vlib/datatypes/lockfree/bench/bench_channel.v
@@ -15,7 +15,7 @@ const warmup_runs = 3 // Number of warmup runs
 
 const test_runs = 5 // Number of test runs
 
-const max_threads = runtime.nr_cpus() // Maximum number of threads
+const max_threads = runtime.nr_jobs() // Maximum number of threads
 
 // Performance test results
 struct ChannelPerfResult {
@@ -28,7 +28,7 @@ struct ChannelPerfResult {
 fn main() {
 	println('Channel Performance Test')
 	println('======================================')
-	println('Maximum number of threads set to nr_cpus = ${max_threads}')
+	println('Maximum number of threads set to nr_jobs = ${max_threads}')
 	mut fp := flag.new_flag_parser(os.args.clone())
 	fp.skip_executable()
 	show_help := fp.bool('help', 0, false, 'Show this help screen\n')

--- a/vlib/datatypes/lockfree/bench/bench_ringbuffer.v
+++ b/vlib/datatypes/lockfree/bench/bench_ringbuffer.v
@@ -1,0 +1,251 @@
+module main
+
+import datatypes.lockfree
+import time
+import sync
+import math
+
+// Test configuration parameters
+const buffer_size = 1024 // Size of the ring buffer
+
+const items_per_thread = 1_000_000 // Items to produce per thread
+
+const warmup_runs = 3 // Number of warmup runs
+
+const test_runs = 5 // Number of test runs
+
+const max_threads = 8 // Maximum number of threads
+
+// Performance test results
+struct PerfResult {
+	scenario   string // Test scenario identifier
+	throughput f64    // Throughput in million operations per second
+	latency    f64    // Average latency in nanoseconds
+	cpu_usage  f64    // CPU usage percentage
+}
+
+fn main() {
+	println('Lock-Free Ring Buffer Performance Test')
+	println('======================================')
+
+	// Test different scenarios
+	mut results := []PerfResult{}
+
+	// Single Producer Single Consumer
+	results << test_scenario('SPSC', 1, 1)
+
+	// Multiple Producers Single Consumer
+	for i in [2, 4, 8] {
+		if i <= max_threads {
+			results << test_scenario('MPSC (${i}P1C)', i, 1)
+		}
+	}
+
+	// Single Producer Multiple Consumers
+	for i in [2, 4] {
+		if i <= max_threads {
+			results << test_scenario('SPMC (1P${i}C)', 1, i)
+		}
+	}
+
+	// Multiple Producers Multiple Consumers
+	for i in [2, 4, 8] {
+		if i * 2 <= max_threads {
+			results << test_scenario('MPMC (${i}P${i}C)', i, i)
+		}
+	}
+
+	// Print final results
+	print_results(results)
+}
+
+// Test specific scenario with given producers/consumers
+fn test_scenario(scenario string, producers int, consumers int) PerfResult {
+	println('\nTesting scenario: ${scenario}')
+
+	// Create ring buffer
+	mut rb := lockfree.new_ringbuffer[int](buffer_size)
+
+	// Warmup runs
+	for _ in 0 .. warmup_runs {
+		run_test(mut rb, producers, consumers, false)
+	}
+
+	// Actual test runs
+	mut total_time := time.Duration(0)
+	mut total_ops := 0
+
+	for _ in 0 .. test_runs {
+		duration, ops := run_test(mut rb, producers, consumers, true)
+		total_time += duration
+		total_ops += ops
+
+		// Reset buffer after each run
+		reset_buffer(mut rb)
+	}
+
+	// Calculate performance metrics
+	avg_time := total_time / test_runs
+	throughput := f64(total_ops) / avg_time.seconds() / 1_000_000 // MOPS
+	latency := avg_time.nanoseconds() / f64(total_ops / test_runs) // ns/op
+
+	return PerfResult{
+		scenario:   scenario
+		throughput: throughput
+		latency:    latency
+		cpu_usage:  0.0 // Actual value should be obtained from system
+	}
+}
+
+// Execute single test run
+fn run_test(mut rb lockfree.RingBuffer[int], producers int, consumers int, measure bool) (time.Duration, int) {
+	mut wg := sync.new_waitgroup()
+	total_items := producers * items_per_thread
+
+	// Key fix: Consumers should consume exact producer total
+	items_per_consumer := total_items / consumers
+	mut remaining := total_items % consumers
+
+	// Start producers
+	start_time := time.now()
+	for i in 0 .. producers {
+		wg.add(1)
+		spawn producer_thread(mut rb, i, mut wg)
+	}
+
+	// Start consumers
+	mut consumed_counts := []int{len: consumers, init: 0}
+	for i in 0 .. consumers {
+		wg.add(1)
+		// Distribute remaining items to first consumers
+		mut count := items_per_consumer
+		if remaining > 0 {
+			count += 1
+			remaining -= 1
+		}
+		spawn consumer_thread(mut rb, i, count, mut consumed_counts, mut wg)
+	}
+
+	// Wait for all threads to complete
+	wg.wait()
+	end_time := time.now()
+
+	// Validate results
+	mut total_consumed := 0
+	for count in consumed_counts {
+		total_consumed += count
+	}
+
+	if total_consumed != total_items {
+		eprintln('Error: Produced ${total_items} items but consumed ${total_consumed}')
+	}
+
+	duration := end_time - start_time
+	if measure {
+		println('Completed ${total_items} items in ${duration.milliseconds()}ms')
+	}
+
+	return duration, total_items
+}
+
+// Producer thread implementation
+fn producer_thread(mut rb lockfree.RingBuffer[int], id int, mut wg sync.WaitGroup) {
+	defer {
+		wg.done()
+	}
+
+	// Generate items in producer-specific range
+	start := id * items_per_thread
+	end := start + items_per_thread
+
+	// Use batch pushing for better performance
+	batch_size := 32
+	mut batch := []int{cap: batch_size}
+
+	for i in start .. end {
+		batch << i
+		if batch.len == batch_size {
+			rb.push_many(batch)
+			batch.clear()
+		}
+	}
+
+	// Push remaining items in final batch
+	if batch.len > 0 {
+		rb.push_many(batch)
+	}
+}
+
+// Consumer thread with fixed consumption target
+fn consumer_thread(mut rb lockfree.RingBuffer[int], id int, items_to_consume int, mut consumed_counts []int, mut wg sync.WaitGroup) {
+	defer {
+		wg.done()
+	}
+
+	// Use batch consumption for better performance
+	batch_size := 32
+	mut count := 0
+
+	for count < items_to_consume {
+		// Calculate current batch size
+		remaining := items_to_consume - count
+		current_batch := math.min(batch_size, remaining)
+
+		// Consume batch and update count
+		items := rb.pop_many(u32(current_batch))
+		count += items.len
+
+		// Validate sequence integrity
+		if items.len > 0 {
+			first := items[0]
+			last := items[items.len - 1]
+			if last - first != items.len - 1 {
+				eprintln('Thread ${id}: Sequence error! Expected ${first}..${first + items.len - 1}, got ${first}..${last}')
+			}
+		}
+	}
+
+	consumed_counts[id] = count
+}
+
+// Reset buffer to initial state
+fn reset_buffer(mut rb lockfree.RingBuffer[int]) {
+	// Clear all items from buffer
+	for {
+		rb.try_pop() or { break }
+	}
+
+	// Reset internal pointers
+	unsafe {
+		rb.prod_head = 0
+		rb.prod_tail = 0
+		rb.cons_head = 0
+		rb.cons_tail = 0
+	}
+}
+
+// Print formatted performance results
+fn print_results(results []PerfResult) {
+	println('\nPerformance Results')
+	println('====================================================================')
+	println('Scenario\t\tThroughput (M ops/s)\tAvg Latency (ns)\tCPU Usage (%)')
+	println('--------------------------------------------------------------------')
+
+	for res in results {
+		println('${res.scenario:20}\t${res.throughput:8.2f}\t\t\t${res.latency:8.2f}\t\t\t${res.cpu_usage:5.1f}')
+	}
+	println('====================================================================')
+
+	// Find best performing scenario
+	mut best_throughput := 0.0
+	mut best_scenario := ''
+
+	for res in results {
+		if res.throughput > best_throughput {
+			best_throughput = res.throughput
+			best_scenario = res.scenario
+		}
+	}
+
+	println('\nBest performance: ${best_scenario} with ${best_throughput:.2f} M ops/s')
+}

--- a/vlib/datatypes/lockfree/bench/bench_ringbuffer.v
+++ b/vlib/datatypes/lockfree/bench/bench_ringbuffer.v
@@ -47,21 +47,21 @@ fn main() {
 	results << test_scenario('SPSC', 1, 1, batch, debug)
 
 	// Multiple Producers Single Consumer
-	for i in [2, 4, 8] {
+	for i in [2, 4, 8, 16] {
 		if i <= max_threads {
 			results << test_scenario('MPSC (${i}P1C)', i, 1, batch, debug)
 		}
 	}
 
 	// Single Producer Multiple Consumers
-	for i in [2, 4] {
+	for i in [2, 4, 8, 16] {
 		if i <= max_threads {
 			results << test_scenario('SPMC (1P${i}C)', 1, i, batch, debug)
 		}
 	}
 
 	// Multiple Producers Multiple Consumers
-	for i in [2, 4, 8] {
+	for i in [2, 4, 8, 16] {
 		if i * 2 <= max_threads {
 			results << test_scenario('MPMC (${i}P${i}C)', i, i, batch, debug)
 		}

--- a/vlib/datatypes/lockfree/bench/bench_ringbuffer.v
+++ b/vlib/datatypes/lockfree/bench/bench_ringbuffer.v
@@ -16,7 +16,7 @@ const warmup_runs = 3 // Number of warmup runs
 
 const test_runs = 5 // Number of test runs
 
-const max_threads = runtime.nr_cpus() // Maximum number of threads
+const max_threads = runtime.nr_jobs() // Maximum number of threads
 
 // Performance test results
 struct RingBufferPerfResult {
@@ -29,7 +29,7 @@ struct RingBufferPerfResult {
 fn main() {
 	println('Lock-Free Ring Buffer Performance Test')
 	println('======================================')
-	println('Maximum number of threads set to nr_cpus = ${max_threads}')
+	println('Maximum number of threads set to nr_jobs = ${max_threads}')
 	mut fp := flag.new_flag_parser(os.args.clone())
 	fp.skip_executable()
 	show_help := fp.bool('help', 0, false, 'Show this help screen\n')

--- a/vlib/datatypes/lockfree/bench/bench_ringbuffer.v
+++ b/vlib/datatypes/lockfree/bench/bench_ringbuffer.v
@@ -19,7 +19,7 @@ const test_runs = 5 // Number of test runs
 const max_threads = runtime.nr_cpus() // Maximum number of threads
 
 // Performance test results
-struct PerfResult {
+struct RingBufferPerfResult {
 	scenario   string // Test scenario identifier
 	throughput f64    // Throughput in million operations per second
 	latency    f64    // Average latency in nanoseconds
@@ -41,7 +41,7 @@ fn main() {
 	}
 
 	// Test different scenarios
-	mut results := []PerfResult{}
+	mut results := []RingBufferPerfResult{}
 
 	// Single Producer Single Consumer
 	results << test_scenario('SPSC', 1, 1, batch, debug)
@@ -72,7 +72,7 @@ fn main() {
 }
 
 // Test specific scenario with given producers/consumers
-fn test_scenario(scenario string, producers int, consumers int, batch bool, debug bool) PerfResult {
+fn test_scenario(scenario string, producers int, consumers int, batch bool, debug bool) RingBufferPerfResult {
 	println('\nTesting scenario: ${scenario}')
 
 	// Create ring buffer
@@ -102,7 +102,7 @@ fn test_scenario(scenario string, producers int, consumers int, batch bool, debu
 	throughput := f64(total_ops) / avg_time.seconds() / 1_000_000 // MOPS
 	latency := avg_time.nanoseconds() / f64(total_ops / test_runs) // ns/op
 
-	return PerfResult{
+	return RingBufferPerfResult{
 		scenario:   scenario
 		throughput: throughput
 		latency:    latency
@@ -266,7 +266,7 @@ fn validate_batch_detailed(id int, batch []int, prev_last int) bool {
 }
 
 // Print formatted performance results
-fn print_results(results []PerfResult) {
+fn print_results(results []RingBufferPerfResult) {
 	println('\nPerformance Results')
 	println('====================================================================')
 	println('Scenario\t\tThroughput (M ops/s)\tAvg Latency (ns)\tCPU Usage (%)')

--- a/vlib/datatypes/lockfree/counter.v
+++ b/vlib/datatypes/lockfree/counter.v
@@ -1,0 +1,63 @@
+module lockfree
+
+import sync.stdatomic
+
+// Counter is a thread-safe atomic counter supporting multiple integer types.
+// It provides atomic increment, decrement, and value retrieval operations.
+@[noinit]
+struct Counter[T] {
+mut:
+	value &stdatomic.AtomicVal[T]
+}
+
+// new_counter creates a new atomic counter with the specified initial value.
+// It only supports integer types (8-bit to 64-bit integers).
+pub fn new_counter[T](init T) &Counter[T] {
+	// Compile-time type check: only integers are supported
+	$if T !is $int {
+		$compile_error('new_counter(): only integers are supported.')
+	}
+	return &Counter[T]{
+		value: stdatomic.new_atomic[T](init)
+	}
+}
+
+// increment_by atomically adds a delta value to the counter and returns
+// the previous value before the operation (fetch-and-add).
+@[inline]
+pub fn (mut c Counter[T]) increment_by(delta T) T {
+	return c.value.add(delta)
+}
+
+// increment atomically increments the counter by 1 and returns
+// the previous value before the operation.
+@[inline]
+pub fn (mut c Counter[T]) increment() T {
+	return c.increment_by(T(1))
+}
+
+// decrement_by atomically subtracts a delta value from the counter and returns
+// the previous value before the operation (fetch-and-sub).
+@[inline]
+pub fn (mut c Counter[T]) decrement_by(delta T) T {
+	return c.value.sub(delta)
+}
+
+// decrement atomically decrements the counter by 1 and returns
+// the previous value before the operation.
+@[inline]
+pub fn (mut c Counter[T]) decrement() T {
+	return c.decrement_by(T(1))
+}
+
+// get atomically retrieves the current value of the counter.
+@[inline]
+pub fn (mut c Counter[T]) get() T {
+	return c.value.load()
+}
+
+// clear atomically resets the counter to zero.
+@[inline]
+pub fn (mut c Counter[T]) clear() {
+	c.value.store(0)
+}

--- a/vlib/datatypes/lockfree/counter_test.v
+++ b/vlib/datatypes/lockfree/counter_test.v
@@ -1,0 +1,42 @@
+import sync
+import datatypes.lockfree
+
+fn test_counter() {
+	number_threads := 10
+	mut counter := lockfree.new_counter(u64(0))
+	mut wg := sync.new_waitgroup()
+	for i in 0 .. number_threads {
+		wg.add(1)
+		spawn fn (mut c lockfree.Counter[u64], id int, mut wg sync.WaitGroup) {
+			for j in 0 .. 1000 {
+				c.increment()
+			}
+			wg.done()
+		}(mut counter, i, mut wg)
+	}
+
+	for i in 0 .. number_threads {
+		wg.add(1)
+		spawn fn (mut c lockfree.Counter[u64], id int, mut wg sync.WaitGroup) {
+			for j in 0 .. 1000 {
+				c.decrement()
+			}
+			wg.done()
+		}(mut counter, i, mut wg)
+	}
+
+	wg.wait()
+	assert counter.get() == u64(0)
+
+	counter.increment_by(100)
+	assert counter.get() == u64(100)
+	counter.decrement_by(100)
+	assert counter.get() == u64(0)
+
+	counter.increment_by(1024)
+	counter.clear()
+	assert counter.get() == u64(0)
+
+	mut counter_init := lockfree.new_counter(u64(100))
+	assert counter.get() == u64(100)
+}

--- a/vlib/datatypes/lockfree/counter_test.v
+++ b/vlib/datatypes/lockfree/counter_test.v
@@ -38,5 +38,5 @@ fn test_counter() {
 	assert counter.get() == u64(0)
 
 	mut counter_init := lockfree.new_counter(u64(100))
-	assert counter.get() == u64(100)
+	assert counter_init.get() == u64(100)
 }

--- a/vlib/datatypes/lockfree/lockfree.v
+++ b/vlib/datatypes/lockfree/lockfree.v
@@ -1,0 +1,38 @@
+module lockfree
+
+// copy from vlib/sync/stdatomic/1.declarations.c.v, as we don't import `sync`
+fn C.atomic_load_u32(voidptr) u32
+fn C.atomic_store_u32(voidptr, u32)
+fn C.atomic_compare_exchange_weak_u32(voidptr, voidptr, u32) bool
+fn C.atomic_thread_fence(int)
+fn C.cpu_relax()
+
+fn C.ANNOTATE_RWLOCK_CREATE(voidptr)
+fn C.ANNOTATE_RWLOCK_ACQUIRED(voidptr, int)
+fn C.ANNOTATE_RWLOCK_RELEASED(voidptr, int)
+fn C.ANNOTATE_RWLOCK_DESTROY(voidptr)
+
+$if valgrind ? {
+	#flag -I/usr/include/valgrind
+	#include <valgrind/helgrind.h>
+}
+
+// Define cache line size to prevent false sharing between CPU cores
+const cache_line_size = 64
+
+// next_power_of_two calculates the smallest power of two >= n
+@[inline]
+fn next_power_of_two(n u32) u32 {
+	if n == 0 {
+		return 1
+	}
+	mut x := n - 1
+
+	// Efficient bit manipulation to find next power of two
+	x |= x >> 1
+	x |= x >> 2
+	x |= x >> 4
+	x |= x >> 8
+	x |= x >> 16
+	return x + 1
+}

--- a/vlib/datatypes/lockfree/lockfree.v
+++ b/vlib/datatypes/lockfree/lockfree.v
@@ -1,21 +1,6 @@
 module lockfree
 
-// copy from vlib/sync/stdatomic/1.declarations.c.v, as we don't import `sync`
-fn C.atomic_load_u32(voidptr) u32
-fn C.atomic_store_u32(voidptr, u32)
-fn C.atomic_compare_exchange_weak_u32(voidptr, voidptr, u32) bool
-fn C.atomic_thread_fence(int)
-fn C.cpu_relax()
-
-fn C.ANNOTATE_RWLOCK_CREATE(voidptr)
-fn C.ANNOTATE_RWLOCK_ACQUIRED(voidptr, int)
-fn C.ANNOTATE_RWLOCK_RELEASED(voidptr, int)
-fn C.ANNOTATE_RWLOCK_DESTROY(voidptr)
-
-$if valgrind ? {
-	#flag -I/usr/include/valgrind
-	#include <valgrind/helgrind.h>
-}
+import sync.stdatomic as _
 
 // Define cache line size to prevent false sharing between CPU cores
 const cache_line_size = 64

--- a/vlib/datatypes/lockfree/ringbuffer.v
+++ b/vlib/datatypes/lockfree/ringbuffer.v
@@ -31,7 +31,7 @@ pub mut:
 pub struct RingBufferParam {
 pub:
 	mode                  RingBufferMode = .mpmc // Default to most concurrent mode
-	max_waiting_prod_cons int            = 2     // Max allowed waiting producers/consumers before rejecting operations
+	max_waiting_prod_cons int            = 1     // Max allowed waiting producers/consumers before rejecting operations
 }
 
 // RingBuffer Lock-free multiple producer/multiple consumer ring buffer.

--- a/vlib/datatypes/lockfree/ringbuffer.v
+++ b/vlib/datatypes/lockfree/ringbuffer.v
@@ -1,5 +1,8 @@
 module lockfree
 
+// This design is ported from the DPDK rte_ring library.
+// Source: https://doc.dpdk.org/guides/prog_guide/ring_lib.html
+
 // RingBufferMode Operation modes for the ring buffer
 pub enum RingBufferMode {
 	spsc = 0 // Single Producer, Single Consumer (optimized for single-threaded access)

--- a/vlib/datatypes/lockfree/ringbuffer.v
+++ b/vlib/datatypes/lockfree/ringbuffer.v
@@ -366,8 +366,11 @@ pub fn (mut rb RingBuffer[T]) push_many(items []T) {
 
 // pop_many blocking pop of multiple items.
 @[inline]
-pub fn (mut rb RingBuffer[T]) pop_many(n u32) []T {
-	mut result := []T{len: int(n)}
+pub fn (mut rb RingBuffer[T]) pop_many(mut result []T) {
+	n := result.len
+	if n == 0 {
+		return
+	}
 	mut backoff := 1
 	for {
 		ret := rb.try_pop_many(mut result)
@@ -381,7 +384,6 @@ pub fn (mut rb RingBuffer[T]) pop_many(n u32) []T {
 			backoff = int_min(backoff * 2, 1024)
 		}
 	}
-	return result
 }
 
 // is_empty checks if the buffer is empty.

--- a/vlib/datatypes/lockfree/ringbuffer.v
+++ b/vlib/datatypes/lockfree/ringbuffer.v
@@ -1,0 +1,478 @@
+module lockfree
+
+// copy from vlib/sync/stdatomic/1.declarations.c.v, as we don't import `sync`
+fn C.atomic_load_u32(voidptr) u32
+fn C.atomic_store_u32(voidptr, u32)
+fn C.atomic_compare_exchange_weak_u32(voidptr, voidptr, u32) bool
+fn C.atomic_thread_fence(int)
+fn C.cpu_relax()
+
+fn C.ANNOTATE_RWLOCK_CREATE(voidptr)
+fn C.ANNOTATE_RWLOCK_ACQUIRED(voidptr, int)
+fn C.ANNOTATE_RWLOCK_RELEASED(voidptr, int)
+fn C.ANNOTATE_RWLOCK_DESTROY(voidptr)
+
+$if valgrind ? {
+	#flag -I/usr/include/valgrind
+	#include <valgrind/helgrind.h>
+}
+
+// Define cache line size to prevent false sharing between CPU cores
+const cache_line_size = 64
+
+// RingBufferMode Operation modes for the ring buffer
+pub enum RingBufferMode {
+	spsc = 0 // Single Producer, Single Consumer (optimized for single-threaded access)
+	spmc = 1 // Single Producer, Multiple Consumers (one writer, multiple readers)
+	mpsc = 2 // Multiple Producers, Single Consumer (multiple writers, one reader)
+	mpmc = 3 // Multiple Producers, Multiple Consumers (default, fully concurrent)
+}
+
+// RingBufferParam Configuration parameters for ring buffer creation
+@[params]
+pub struct RingBufferParam {
+pub:
+	mode RingBufferMode = .mpmc // Default to most concurrent mode
+}
+
+// RingBuffer Lock-free multiple producer/multiple consumer ring buffer
+// Requires explicit initialization
+@[noinit]
+pub struct RingBuffer[T] {
+mut:
+	mode       u32                      // Current operation mode (from RingBufferMode)
+	capacity   u32                      // Total capacity (always power of two)
+	mask       u32                      // Bitmask for index calculation (capacity - 1)
+	clear_flag u32                      // Flag indicating clear operation in progress
+	pad0       [cache_line_size - 16]u8 // Padding to align to cache line boundary
+
+	// Producer state (isolated to prevent false sharing)
+	prod_head u32                     // Producer head (next write position)
+	pad1      [cache_line_size - 4]u8 // Cache line padding
+	prod_tail u32                     // Producer tail (last committed position)
+	pad2      [cache_line_size - 4]u8 // Cache line padding
+
+	// Consumer state (isolated to prevent false sharing)
+	cons_head u32                     // Consumer head (next read position)
+	pad3      [cache_line_size - 4]u8 // Cache line padding
+	cons_tail u32                     // Consumer tail (last committed position)
+	pad4      [cache_line_size - 4]u8 // Cache line padding
+
+	// Data storage area
+	slots []T // Array holding actual data elements
+}
+
+// new_ringbuffer creates a new lock-free ring buffer
+pub fn new_ringbuffer[T](size u32, param RingBufferParam) &RingBuffer[T] {
+	// Ensure capacity is power of two for efficient modulo operations
+	capacity := next_power_of_two(size)
+	mask := capacity - 1
+
+	// Initialize data storage array
+	mut slots := []T{len: int(capacity)}
+
+	rb := &RingBuffer[T]{
+		mode:     u32(param.mode)
+		capacity: capacity
+		mask:     mask
+		slots:    slots
+	}
+
+	// Disable Valgrind checking for performance
+	$if valgrind ? {
+		C.VALGRIND_HG_DISABLE_CHECKING(rb, sizeof(RingBuffer[T]))
+	}
+	return rb
+}
+
+// next_power_of_two calculates the smallest power of two >= n
+@[inline]
+fn next_power_of_two(n u32) u32 {
+	if n == 0 {
+		return 1
+	}
+	mut x := n - 1
+	// Efficient bit manipulation to find next power of two
+	x |= x >> 1
+	x |= x >> 2
+	x |= x >> 4
+	x |= x >> 8
+	x |= x >> 16
+	return x + 1
+}
+
+// is_single_producer checks if current mode is single producer
+@[inline]
+fn is_single_producer(mode u32) bool {
+	return mode & 0x02 == 0
+}
+
+// is_single_consumer checks if current mode is single consumer
+@[inline]
+fn is_single_consumer(mode u32) bool {
+	return mode & 0x01 == 0
+}
+
+// try_push tries to push a single item non-blocking.
+pub fn (mut rb RingBuffer[T]) try_push(item T) bool {
+	return rb.try_push_many([item]) == 1
+}
+
+// try_push_many tries to push multiple items non-blocking.
+pub fn (mut rb RingBuffer[T]) try_push_many(items []T) u32 {
+	n := u32(items.len)
+	if n == 0 {
+		return 0
+	}
+
+	// Check if clear operation is in progress
+	if C.atomic_load_u32(&rb.clear_flag) != 0 {
+		return 0
+	}
+
+	capacity := rb.capacity
+	mut success := false
+	mut attempts := 0
+	mut old_head := u32(0)
+	mut new_head := u32(0)
+
+	// Attempt to reserve space in the buffer
+	for !success && attempts < 10 {
+		old_head = rb.prod_head
+
+		// Memory barrier for weak memory models
+		$if !x64 && !x32 {
+			C.atomic_thread_fence(C.memory_order_acquire)
+		}
+
+		// Calculate available space using unsigned arithmetic
+		free_entries := capacity + rb.cons_tail - old_head
+
+		// Check if there's enough space
+		if n > free_entries {
+			return 0
+		}
+
+		// Calculate new head position after adding items
+		new_head = old_head + n
+		if is_single_producer(rb.mode) {
+			// Direct update for single producer
+			rb.prod_head = new_head
+			success = true
+		} else {
+			// Atomic compare-and-swap for multiple producers
+			$if valgrind ? {
+				C.ANNOTATE_HAPPENS_BEFORE(&rb.prod_head)
+			}
+			success = C.atomic_compare_exchange_weak_u32(&rb.prod_head, &old_head, new_head)
+			$if valgrind ? {
+				C.ANNOTATE_HAPPENS_AFTER(&rb.prod_head)
+			}
+		}
+		attempts++
+	}
+
+	// Exit if space reservation failed
+	if !success {
+		return 0
+	}
+
+	// Write data to the reserved slots
+	for i in 0 .. n {
+		index := (old_head + i) & rb.mask
+		$if valgrind ? {
+			C.VALGRIND_HG_DISABLE_CHECKING(&rb.slots[index], sizeof(T))
+			C.ANNOTATE_HAPPENS_BEFORE(&rb.slots[index])
+		}
+		rb.slots[index] = items[i]
+		$if valgrind ? {
+			C.ANNOTATE_HAPPENS_AFTER(&rb.slots[index])
+		}
+	}
+
+	// For multiple producers: wait for previous producers to complete
+	if !is_single_producer(rb.mode) {
+		mut attempts_wait := 1
+		for rb.prod_tail != old_head {
+			C.cpu_relax() // Low-latency pause instruction
+			attempts_wait++
+		}
+	}
+
+	// Make data visible to consumers
+	$if valgrind ? {
+		C.ANNOTATE_HAPPENS_BEFORE(&rb.prod_tail)
+	}
+	rb.prod_tail = new_head
+	$if valgrind ? {
+		C.ANNOTATE_HAPPENS_AFTER(&rb.prod_tail)
+	}
+	return n
+}
+
+// try_pop tries to pop a single item non-blocking.
+pub fn (mut rb RingBuffer[T]) try_pop() ?T {
+	mut items := []T{len: 1}
+	if rb.try_pop_many(mut items) == 1 {
+		return items[0]
+	}
+	return none // Buffer empty
+}
+
+// try_pop_many tries to pop multiple items non-blocking.
+pub fn (mut rb RingBuffer[T]) try_pop_many(mut items []T) u32 {
+	n := u32(items.len)
+	if n == 0 {
+		return 0
+	}
+
+	// Check if clear operation is in progress
+	if C.atomic_load_u32(&rb.clear_flag) != 0 {
+		return 0
+	}
+
+	mut success := false
+	mut attempts := 0
+	mut old_head := u32(0)
+	mut new_head := u32(0)
+
+	// Attempt to reserve data for reading
+	for !success && attempts < 10 {
+		old_head = rb.cons_head
+		// Memory barrier for weak memory models
+		$if !x64 && !x32 {
+			C.atomic_thread_fence(C.memory_order_acquire)
+		}
+
+		// Calculate available items to read
+		entries := rb.prod_tail - old_head
+
+		// Check if enough data is available
+		if n > entries {
+			return 0
+		}
+
+		// Calculate new head position after reading
+		new_head = old_head + n
+		if is_single_consumer(rb.mode) {
+			// Direct update for single consumer
+			rb.cons_head = new_head
+			success = true
+		} else {
+			// Atomic compare-and-swap for multiple consumers
+			$if valgrind ? {
+				C.ANNOTATE_HAPPENS_BEFORE(&rb.cons_head)
+			}
+			success = C.atomic_compare_exchange_weak_u32(&rb.cons_head, &old_head, new_head)
+			$if valgrind ? {
+				C.ANNOTATE_HAPPENS_AFTER(&rb.cons_head)
+			}
+		}
+		attempts++
+	}
+
+	// Exit if data reservation failed
+	if !success {
+		return 0
+	}
+
+	// Read data from reserved slots
+	for i in 0 .. n {
+		index := (old_head + i) & rb.mask
+		$if valgrind ? {
+			C.ANNOTATE_HAPPENS_BEFORE(&rb.slots[index])
+		}
+		items[i] = rb.slots[index]
+		$if valgrind ? {
+			C.ANNOTATE_HAPPENS_AFTER(&rb.slots[index])
+		}
+	}
+
+	// For multiple consumers: wait for previous consumers to complete
+	if !is_single_consumer(rb.mode) {
+		mut attempts_wait := 1
+		for rb.cons_tail != old_head {
+			C.cpu_relax() // Low-latency pause instruction
+			attempts_wait++
+		}
+	}
+
+	// Free up buffer space
+	$if valgrind ? {
+		C.ANNOTATE_HAPPENS_BEFORE(&rb.cons_tail)
+	}
+	rb.cons_tail = new_head
+	$if valgrind ? {
+		C.ANNOTATE_HAPPENS_AFTER(&rb.cons_tail)
+	}
+	return n
+}
+
+// push blocking push of a single item.
+pub fn (mut rb RingBuffer[T]) push(item T) {
+	// Retry until successful
+	for {
+		if rb.try_push(item) {
+			return
+		}
+		C.cpu_relax() // Pause before retry
+	}
+}
+
+// pop blocking pop of a single item.
+pub fn (mut rb RingBuffer[T]) pop() T {
+	// Retry until successful
+	for {
+		if item := rb.try_pop() {
+			return item
+		}
+		C.cpu_relax() // Pause before retry
+	}
+	return T(0) // Default value (should never be reached)
+}
+
+// push_many blocking push of multiple items.
+pub fn (mut rb RingBuffer[T]) push_many(items []T) {
+	for {
+		n := rb.try_push_many(items)
+		if n == items.len {
+			break
+		} else {
+			C.cpu_relax() // Pause when buffer is full
+		}
+	}
+}
+
+// pop_many blocking pop of multiple items.
+pub fn (mut rb RingBuffer[T]) pop_many(n u32) []T {
+	mut result := []T{len: int(n)}
+
+	for {
+		ret := rb.try_pop_many(mut result)
+		if ret == n {
+			break
+		} else {
+			C.cpu_relax() // Pause when buffer is empty
+		}
+	}
+	return result
+}
+
+// is_empty checks if the buffer is empty.
+pub fn (rb RingBuffer[T]) is_empty() bool {
+	return rb.occupied() == 0
+}
+
+// is_full checks if the buffer is full.
+pub fn (rb RingBuffer[T]) is_full() bool {
+	return rb.occupied() >= rb.capacity
+}
+
+// capacity returns the total capacity of the buffer.
+pub fn (rb RingBuffer[T]) capacity() u32 {
+	return rb.capacity
+}
+
+// occupied returns the number of occupied slots.
+@[inline]
+pub fn (rb RingBuffer[T]) occupied() u32 {
+	// Memory barrier for weak memory models
+	$if !x64 && !x32 {
+		C.atomic_thread_fence(C.memory_order_acquire)
+	}
+
+	prod_tail := C.atomic_load_u32(&rb.prod_tail)
+	cons_tail := C.atomic_load_u32(&rb.cons_tail)
+
+	// Handle potential overflow
+	used := if prod_tail >= cons_tail {
+		prod_tail - cons_tail
+	} else {
+		(max_u32 - cons_tail) + prod_tail + 1
+	}
+
+	return used
+}
+
+// remaining returns the number of free slots.
+pub fn (rb RingBuffer[T]) remaining() u32 {
+	return rb.capacity - rb.occupied()
+}
+
+// clear clears the ring buffer and resets all pointers.
+pub fn (mut rb RingBuffer[T]) clear() bool {
+	mut clear_flag := u32(0)
+	mut attempts := 0
+	max_attempts := 1000
+
+	// Acquire clear flag using atomic CAS
+	for {
+		if C.atomic_compare_exchange_weak_u32(&rb.clear_flag, &clear_flag, 1) {
+			break
+		}
+		clear_flag = u32(0)
+		C.cpu_relax()
+		attempts++
+		if attempts > max_attempts {
+			return false // Failed to acquire clear flag
+		}
+	}
+
+	// Wait for producers to finish with exponential backoff
+	mut backoff := 1
+	mut prod_wait := 0
+	for {
+		prod_head := C.atomic_load_u32(&rb.prod_head)
+		prod_tail := C.atomic_load_u32(&rb.prod_tail)
+		if prod_head == prod_tail {
+			break
+		}
+		// Exponential backoff wait
+		for _ in 0 .. backoff {
+			C.cpu_relax()
+		}
+		backoff = int_min(backoff * 2, 1024)
+
+		prod_wait++
+		if prod_wait > max_attempts {
+			// Force advance producer tail
+			C.atomic_store_u32(&rb.prod_tail, prod_head)
+			break
+		}
+	}
+
+	// Wait for consumers to finish with exponential backoff
+	backoff = 1
+	mut cons_wait := 0
+	for {
+		cons_head := C.atomic_load_u32(&rb.cons_head)
+		cons_tail := C.atomic_load_u32(&rb.cons_tail)
+
+		if cons_head == cons_tail {
+			break
+		}
+
+		// Exponential backoff wait
+		for _ in 0 .. backoff {
+			C.cpu_relax()
+		}
+		backoff = int_min(backoff * 2, 1024)
+
+		cons_wait++
+		if cons_wait > max_attempts {
+			// Force advance consumer tail
+			C.atomic_store_u32(&rb.cons_tail, cons_head)
+			break
+		}
+	}
+
+	// Reset all pointers to zero
+	C.atomic_store_u32(&rb.prod_head, 0)
+	C.atomic_store_u32(&rb.prod_tail, 0)
+	C.atomic_store_u32(&rb.cons_head, 0)
+	C.atomic_store_u32(&rb.cons_tail, 0)
+
+	// Release clear flag
+	C.atomic_store_u32(&rb.clear_flag, 0)
+	return true // Clear operation successful
+}

--- a/vlib/datatypes/lockfree/ringbuffer.v
+++ b/vlib/datatypes/lockfree/ringbuffer.v
@@ -73,6 +73,9 @@ mut:
 }
 
 // new_ringbuffer creates a new lock-free ring buffer.
+// Note: The buffer capacity will be expanded to the next power of two
+//       for efficient modulo operations using bitwise AND.
+//       The actual capacity may be larger than the requested `size`.
 pub fn new_ringbuffer[T](size u32, param RingBufferParam) &RingBuffer[T] {
 	// Ensure capacity is power of two for efficient modulo operations
 	capacity := next_power_of_two(size)

--- a/vlib/datatypes/lockfree/ringbuffer_test.v
+++ b/vlib/datatypes/lockfree/ringbuffer_test.v
@@ -1,0 +1,372 @@
+import datatypes.lockfree
+import time
+import sync
+
+// Test basic push and pop operations
+fn test_push_and_pop() {
+	mut r := lockfree.new_ringbuffer[int](2)
+
+	r.push(3)
+	r.push(4)
+
+	mut oldest_value := r.pop()
+
+	assert oldest_value == 3
+
+	r.push(5)
+
+	oldest_value = r.pop()
+
+	assert oldest_value == 4
+}
+
+// Test clear functionality and empty state
+fn test_clear_and_empty() {
+	mut r := lockfree.new_ringbuffer[int](4)
+	r.push(3)
+	r.push(4)
+
+	oldest_value := r.pop()
+	assert oldest_value == 3
+
+	r.clear()
+
+	assert r.is_empty() == true
+}
+
+// Test capacity tracking and full state detection
+fn test_capacity_and_is_full() {
+	mut r := lockfree.new_ringbuffer[int](4)
+
+	assert r.capacity() == 4
+
+	r.push(3)
+	r.push(4)
+	r.push(5)
+	r.push(6)
+
+	assert r.is_full() == true
+}
+
+// Test occupied slots vs remaining capacity
+fn test_occupied_and_remaining() {
+	mut r := lockfree.new_ringbuffer[int](4)
+
+	r.push(3)
+	r.push(4)
+
+	assert r.occupied() == r.remaining()
+}
+
+// Test batch push/pop operations
+fn test_push_and_pop_many() {
+	mut r := lockfree.new_ringbuffer[int](4)
+	a := [1, 2, 3, 4]
+	r.push_many(a)
+
+	assert r.is_full() == true
+
+	b := r.pop_many(4)
+
+	assert a == b
+}
+
+// Test single producer single consumer mode
+fn test_spsc_mode() {
+	println('===== Testing SPSC Mode =====')
+	mut rb := lockfree.new_ringbuffer[int](1024, mode: .spsc)
+
+	// Basic push/pop functionality
+	assert rb.try_push(42) == true
+	assert rb.try_push(100) == true
+	assert rb.occupied() == 2
+
+	item1 := rb.try_pop() or { panic('Expected value') }
+	assert item1 == 42
+	item2 := rb.try_pop() or { panic('Expected value') }
+	assert item2 == 100
+	assert rb.is_empty() == true
+
+	// Boundary capacity testing
+	for i in 0 .. 1024 {
+		assert rb.try_push(i) == true
+	}
+	assert rb.is_full() == true
+	assert rb.try_push(1024) == false
+
+	for i in 0 .. 1024 {
+		item := rb.try_pop() or { panic('Expected value') }
+		assert item == i
+	}
+	assert rb.is_empty() == true
+
+	println('SPSC basic tests passed')
+
+	// Performance measurement
+	start := time.now()
+	mut producer := spawn fn (mut rb lockfree.RingBuffer[int]) {
+		for i in 0 .. 100000 {
+			rb.push(i)
+		}
+	}(mut rb)
+
+	mut consumer := spawn fn (mut rb lockfree.RingBuffer[int]) {
+		for i in 0 .. 100000 {
+			item := rb.pop()
+			assert item == i
+		}
+	}(mut rb)
+
+	producer.wait()
+	consumer.wait()
+	duration := time.since(start)
+	println('SPSC performance: ${duration} for 100k items')
+}
+
+// Test single producer multiple consumers mode
+fn test_spmc_mode() {
+	println('===== Testing SPMC Mode =====')
+	mut rb := lockfree.new_ringbuffer[int](1024, mode: .spmc)
+	mut wg := sync.new_waitgroup()
+	consumers := 4
+	items_per_consumer := 25000
+	total_items := consumers * items_per_consumer
+
+	// Producer thread
+	spawn fn (mut rb lockfree.RingBuffer[int], total int) {
+		for i in 0 .. total {
+			rb.push(i)
+		}
+	}(mut rb, total_items)
+
+	// Consumer threads
+	shared results := []int{cap: total_items}
+
+	for i in 0 .. consumers {
+		wg.add(1)
+		spawn fn (id int, mut rb lockfree.RingBuffer[int], shared results []int, count int, mut wg sync.WaitGroup) {
+			for _ in 0 .. count {
+				item := rb.pop()
+				lock results {
+					results << item
+				}
+			}
+			wg.done()
+		}(i, mut rb, shared results, items_per_consumer, mut wg)
+	}
+
+	wg.wait()
+
+	// Result validation
+	lock results {
+		assert results.len == total_items
+		results.sort()
+		for i in 0 .. total_items {
+			assert results[i] == i
+		}
+	}
+	println('SPMC test passed with ${consumers} consumers')
+}
+
+// Test multiple producers single consumer mode
+fn test_mpsc_mode() {
+	println('===== Testing MPSC Mode =====')
+	mut rb := lockfree.new_ringbuffer[int](1024, mode: .mpsc)
+	mut wg := sync.new_waitgroup()
+	producers := 4
+	items_per_producer := 25000
+	total_items := producers * items_per_producer
+
+	// Consumer thread
+	wg.add(1)
+	shared results := []int{cap: total_items}
+	spawn fn (mut rb lockfree.RingBuffer[int], shared results []int, total int, mut wg sync.WaitGroup) {
+		for _ in 0 .. total {
+			item := rb.pop()
+			lock results {
+				results << item
+			}
+		}
+		wg.done()
+	}(mut rb, shared results, total_items, mut wg)
+
+	// Producer threads
+	for i in 0 .. producers {
+		wg.add(1)
+		spawn fn (mut rb lockfree.RingBuffer[int], start int, count int, mut wg sync.WaitGroup) {
+			for j in 0 .. count {
+				rb.push(start + j)
+			}
+			wg.done()
+		}(mut rb, i * items_per_producer, items_per_producer, mut wg)
+	}
+
+	wg.wait()
+
+	// Result validation
+	lock results {
+		assert results.len == total_items
+		results.sort()
+		for i in 0 .. total_items {
+			assert results[i] == i
+		}
+	}
+	println('MPSC test passed with ${producers} producers')
+}
+
+// Test multiple producers multiple consumers mode
+fn test_mpmc_mode() {
+	println('===== Testing MPMC Mode =====')
+	mut rb := lockfree.new_ringbuffer[int](1024, mode: .mpmc)
+	mut wg := sync.new_waitgroup()
+	producers := 4
+	consumers := 4
+	items_per_producer := 10000
+	total_items := producers * items_per_producer
+
+	// Result collection
+	shared results := []int{cap: total_items}
+
+	// Producer threads
+	for i in 0 .. producers {
+		wg.add(1)
+		spawn fn (mut rb lockfree.RingBuffer[int], start int, count int, mut wg sync.WaitGroup) {
+			for j in 0 .. count {
+				rb.push(start + j)
+			}
+			wg.done()
+		}(mut rb, i * items_per_producer, items_per_producer, mut wg)
+	}
+
+	// Consumer threads
+	for i in 0 .. consumers {
+		wg.add(1)
+		spawn fn (mut rb lockfree.RingBuffer[int], shared results []int, count int, mut wg sync.WaitGroup) {
+			for _ in 0 .. count {
+				item := rb.pop()
+				lock results {
+					results << item
+				}
+			}
+			wg.done()
+		}(mut rb, shared results, items_per_producer, mut wg)
+	}
+
+	wg.wait()
+
+	// Result validation
+	lock results {
+		assert results.len == total_items
+		results.sort()
+		for i in 0 .. total_items {
+			assert results[i] == i
+		}
+	}
+	println('MPMC test passed with ${producers} producers and ${consumers} consumers')
+}
+
+// Test buffer clear functionality
+fn test_clear_function() {
+	println('===== Testing Clear Function =====')
+	mut rb := lockfree.new_ringbuffer[int](1024, mode: .mpmc)
+
+	// Fill buffer partially
+	for i in 0 .. 512 {
+		rb.push(i)
+	}
+	assert rb.occupied() == 512
+
+	// Clear buffer verification
+	assert rb.clear() == true
+	assert rb.is_empty() == true
+	assert rb.try_pop() == none
+
+	// Concurrent clear test
+	mut wg := sync.new_waitgroup()
+	producers := 4
+	items_per_producer := 1000
+
+	// Producer threads
+	for i in 0 .. producers {
+		wg.add(1)
+		spawn fn (mut rb lockfree.RingBuffer[int], id int, count int, mut wg sync.WaitGroup) {
+			for j in 0 .. count {
+				rb.push(id * 1000 + j)
+			}
+			wg.done()
+		}(mut rb, i, items_per_producer, mut wg)
+	}
+
+	// Clear thread
+	spawn fn (mut rb lockfree.RingBuffer[int]) {
+		time.sleep(1 * time.millisecond) // Allow producers to start
+		for i in 0 .. 5 {
+			if rb.clear() {
+				println('Clear successful ${i}')
+				time.sleep(2 * time.millisecond)
+			} else {
+				println('Clear failed ${i}')
+			}
+		}
+	}(mut rb)
+
+	wg.wait()
+	println('Clear function test passed')
+}
+
+// Test edge case scenarios
+fn test_edge_cases() {
+	println('===== Testing Edge Cases =====')
+	mut rb := lockfree.new_ringbuffer[int](4, mode: .spsc)
+
+	// Empty buffer tests
+	assert rb.is_empty() == true
+	assert rb.try_pop() == none
+	assert rb.remaining() == 4
+
+	// Full buffer tests
+	assert rb.try_push(1) == true
+	assert rb.try_push(2) == true
+	assert rb.try_push(3) == true
+	assert rb.try_push(4) == true
+	assert rb.is_full() == true
+	assert rb.try_push(5) == false
+	assert rb.remaining() == 0
+
+	// Pop then push again
+	item := rb.try_pop() or { panic('Expected value') }
+	assert item == 1
+	assert rb.try_push(5) == true
+	assert rb.is_full() == true
+
+	// Clear and reuse
+	assert rb.clear() == true
+	assert rb.is_empty() == true
+	assert rb.try_push(10) == true
+	assert rb.try_pop() or { panic('Expected value') } == 10
+
+	println('Edge cases test passed')
+}
+
+// Test batch operations functionality
+fn test_batch_operations() {
+	println('===== Testing Batch Operations =====')
+	mut rb := lockfree.new_ringbuffer[int](1024, mode: .mpmc)
+
+	// Batch push operation
+	items := []int{len: 100, init: it}
+	pushed := rb.try_push_many(items)
+	assert pushed == 100
+	assert rb.occupied() == 100
+
+	// Batch pop operation
+	mut result := []int{len: 100}
+	popped := rb.try_pop_many(mut result)
+	assert popped == 100
+	for i in 0 .. 100 {
+		assert result[i] == i
+	}
+	assert rb.is_empty() == true
+
+	println('Batch operations test passed')
+}

--- a/vlib/datatypes/lockfree/ringbuffer_test.v
+++ b/vlib/datatypes/lockfree/ringbuffer_test.v
@@ -66,7 +66,8 @@ fn test_push_and_pop_many() {
 
 	assert r.is_full() == true
 
-	b := r.pop_many(4)
+	mut b := []int{len: 4}
+	r.pop_many(mut b)
 
 	assert a == b
 }
@@ -354,7 +355,7 @@ fn test_batch_operations() {
 	mut rb := lockfree.new_ringbuffer[int](1024, mode: .mpmc)
 
 	// Batch push operation
-	items := []int{len: 100, init: it}
+	items := []int{len: 100, init: index}
 	pushed := rb.try_push_many(items)
 	assert pushed == 100
 	assert rb.occupied() == 100


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Thread-safe high-performance datatypes implemented using atomic operations, currently supporting `counter` and `ringbuffer`.

TBD:

1. Stack
2. Double-Ended Queue (Deque)
3. Concurrent Map
4. ...