### PR TITLE
math.unsigned: fix lsh() for Uint128, add tests

### DIFF
--- a/vlib/math/unsigned/uint128.v
+++ b/vlib/math/unsigned/uint128.v
@@ -300,7 +300,16 @@ pub fn (u Uint128) quo_rem(v Uint128) (Uint128, Uint128) {
 // lsh returns u << n
 pub fn (u Uint128) lsh(n u32) Uint128 {
 	mut s := Uint128{}
-	if n > 64 {
+	if n == 0 {
+		s.lo = u.lo
+		s.hi = u.hi
+	} else if n >= 128 {
+		s.lo = 0
+		s.hi = 0
+	} else if n == 64 {
+		s.lo = 0
+		s.hi = u.lo
+	} else if n > 64 {
 		s.lo = 0
 		s.hi = u.lo << (n - 64)
 	} else {

--- a/vlib/math/unsigned/uint128_test.v
+++ b/vlib/math/unsigned/uint128_test.v
@@ -174,3 +174,12 @@ fn test_separators() {
 fn test_new() {
 	assert unsigned.uint128_new(max_u64, max_u64) == unsigned.uint128_max
 }
+
+fn test_lsh() {
+	a := unsigned.uint128_from_dec_str('123456789012345678901234567890')!
+	assert a.str() == a.lsh(0).str()
+	assert '246913578024691357802469135780' == a.lsh(1).str()
+	assert '259801135457060040952792416454273138688' == a.lsh(64).str()
+	assert '302984417681386893975453667670529933312' == a.lsh(100).str()
+	assert unsigned.uint128_zero == a.lsh(200)
+}


### PR DESCRIPTION
The `math.unsigned` module is also raw, untested and therefore buggy.
This patch allowed me to pass a multi-billion test against `gmplib`.
This is the first fix from a future series of corrections.