### PR TITLE
math.unsigned: fix rsh() for Uint128, add tests

### DIFF
--- a/vlib/math/unsigned/uint128.v
+++ b/vlib/math/unsigned/uint128.v
@@ -323,9 +323,18 @@ pub fn (u Uint128) lsh(n u32) Uint128 {
 // rsh returns u >> n
 pub fn (u Uint128) rsh(n u32) Uint128 {
 	mut s := Uint128{}
-	if n > 64 {
+	if n == 0 {
+		s.lo = u.lo
+		s.hi = u.hi
+	} else if n >= 128 {
+		s.lo = 0
 		s.hi = 0
-		s.lo = u.hi << (n - 64)
+	} else if n == 64 {
+		s.hi = 0
+		s.lo = u.hi
+	} else if n > 64 {
+		s.hi = 0
+		s.lo = u.hi >> (n - 64)
 	} else {
 		s.lo = u.lo >> n | u.hi << (64 - n)
 		s.hi = u.hi >> n

--- a/vlib/math/unsigned/uint128_test.v
+++ b/vlib/math/unsigned/uint128_test.v
@@ -183,3 +183,13 @@ fn test_lsh() {
 	assert '302984417681386893975453667670529933312' == a.lsh(100).str()
 	assert unsigned.uint128_zero == a.lsh(200)
 }
+
+fn test_rsh() {
+	a := unsigned.uint128_from_dec_str('279625844435276397900870454226348864638')!
+	assert a.str() == a.rsh(0).str()
+	assert '139812922217638198950435227113174432319' == a.rsh(1).str()
+	assert '15158547400991018568' == a.rsh(64).str()
+	assert '220585896' == a.rsh(100).str()
+	assert '1' == a.rsh(127).str()
+	assert unsigned.uint128_zero == a.rsh(200)
+}


### PR DESCRIPTION
Lets fix rsh() for Uint128.
Multi-billion loop against `libgmp` passed.