### PR TITLE
tests: add union_implementing_interface_test.v

### DIFF
--- a/vlib/v/tests/unions/union_implementing_interface_test.v
+++ b/vlib/v/tests/unions/union_implementing_interface_test.v
@@ -1,0 +1,20 @@
+interface Speaker {
+	speak() string
+}
+
+union MyUnion implements Speaker {
+	vint    int
+	vu32    u32
+	vstring string
+}
+
+fn (u MyUnion) speak() string {
+	return 'hi, u.vint: ${unsafe { u.vint }}'
+}
+
+fn test_union_implementing_interface() {
+	s := Speaker(MyUnion{
+		vint: 123
+	})
+	assert s.speak() == 'hi, u.vint: 123'
+}


### PR DESCRIPTION
Prevent silent regression of currently not tested functionality discovered in https://discord.com/channels/592103645835821068/784039809459027979/1391493199402504293 , i.e.

Unions can have methods, and they can also use `implements` similar to structs.