### PR TITLE
math.unsigned: fix lsh() for uint256, add tests

### DIFF
--- a/vlib/math/unsigned/uint256.v
+++ b/vlib/math/unsigned/uint256.v
@@ -259,18 +259,32 @@ pub fn (u Uint256) rsh(n u32) Uint256 {
 }
 
 // lsh returns a new Uint256 that has been left bit shifted
-pub fn (u Uint256) lsh(n_ u32) Uint256 {
-	mut n := n_
-	if n > 128 {
-		return Uint256{u.lo.lsh(n - 128), uint128_zero}
+pub fn (u Uint256) lsh(n u32) Uint256 {
+	mut s := Uint256{}
+	if n == 0 {
+		s.lo = u.lo
+		s.hi = u.hi
+	} else if n >= 256 {
+		s.lo = uint128_zero
+		s.hi = uint128_zero
+	} else if n == 128 {
+		s.lo = uint128_zero
+		s.hi = u.lo
+	} else if n > 128 {
+		s.lo = uint128_zero
+		s.hi = u.lo.lsh(n - 128)
+	} else if n == 64 {
+		s.lo = Uint128{0, u.lo.lo}
+		s.hi = Uint128{u.lo.hi, u.hi.lo}
+	} else if n > 64 {
+		shift := n - 64
+		s.lo = Uint128{0, u.lo.lo << shift}
+		s.hi = Uint128{u.lo.lo >> (64 - shift) | u.lo.hi << shift, u.lo.hi >> (64 - shift) | u.hi.lo << shift}
+	} else {
+		s.lo = Uint128{u.lo.lo << n, u.lo.hi << n | u.lo.lo >> (64 - n)}
+		s.hi = Uint128{u.hi.lo << n | u.lo.hi >> (64 - n), u.hi.hi << n | u.hi.lo >> (64 - n)}
 	}
-
-	if n > 64 {
-		n -= 64
-		return Uint256{Uint128{u.lo.lo << n, 0}, Uint128{u.lo.hi << n | u.lo.lo >> (64 - n), u.hi.lo << n | u.lo.hi >> (64 - n)}}
-	}
-
-	return Uint256{Uint128{u.lo.lo << n, u.lo.hi << n | u.lo.lo >> (64 - n)}, Uint128{u.hi.lo << n | u.lo.hi >> (64 - n), u.hi.hi << n | u.hi.lo >> (64 - n)}}
+	return s
 }
 
 // div - untested

--- a/vlib/math/unsigned/uint256_test.v
+++ b/vlib/math/unsigned/uint256_test.v
@@ -291,3 +291,15 @@ fn test_rsh() {
 	assert '170141183460469231731687303715884105727' == a.rsh(129).str()
 	assert unsigned.uint256_zero == a.rsh(256)
 }
+
+fn test_lsh() {
+	a := unsigned.uint256_from_dec_str('123')!
+	assert a.lsh(0).str() == a.str()
+	assert a.lsh(1).str() == '246'
+	assert a.lsh(63).str() == '1134474760533137424384'
+	assert a.lsh(64).str() == '2268949521066274848768'
+	assert a.lsh(100).str() == '155921023828072216384094494261248'
+	assert a.lsh(128).str() == '41854731131275431005995076714107490009088'
+	assert a.lsh(200).str() == '197653379443855803891661337357963000110230968235283518742069248'
+	assert a.lsh(300) == unsigned.uint256_zero
+}


### PR DESCRIPTION
`lsh()` for uint256 is broken.
The same mechanism as used for uint128 is used for the fix.
Now passed big loop against gmplib.