### PR TITLE
math.unsigned: fix div_128() for uint128, add tests

### DIFF
--- a/vlib/math/unsigned/uint128_test.v
+++ b/vlib/math/unsigned/uint128_test.v
@@ -213,3 +213,31 @@ fn test_quo_rem() {
 		}
 	}
 }
+
+fn test_div_128() {
+	for a_lo in 0 .. 4 {
+		for a_hi in 0 .. 4 {
+			for b_lo in 0 .. 4 {
+				for b_hi in 0 .. 4 {
+					for c_lo in 0 .. 4 {
+						for c_hi in 0 .. 4 {
+							a := unsigned.uint128_new(u64(1 << a_lo), u64(1 << a_hi))
+							b := unsigned.uint128_new(u64(1 << b_lo), u64(1 << b_hi))
+							c := unsigned.uint128_new(u64(1 << c_lo), u64(1 << c_hi))
+							if c.cmp(a) <= 0 {
+								continue
+							}
+							aa := unsigned.uint256_new(b, a)
+							big_a := big.integer_from_string(aa.str())!
+							big_b := big.integer_from_string(c.str())!
+							q, r := unsigned.div_128(a, b, c)
+							big_q, big_r := big_a.div_mod(big_b)
+							assert q.str() == big_q.str()
+							assert r.str() == big_r.str()
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Current `div_128()` is broken and cannot even pass this new minimal test.
Took the algorithm that is already added in `quo_rem()` and adapted and extended it for these needed types.
Now passed multi-`B` loop against `gmplib`.
New test run several seconds.
