### PR TITLE
os: fix windows get_error_msg() leak

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -367,7 +367,7 @@ fn C.GetFullPathName(voidptr, u32, voidptr, voidptr) u32
 @[trusted]
 fn C.GetCommandLine() voidptr
 
-fn C.LocalFree()
+fn C.LocalFree(voidptr)
 
 fn C.FindFirstFileW(lpFileName &u16, lpFindFileData voidptr) voidptr
 

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -272,7 +272,9 @@ pub fn get_error_msg(code int) string {
 	if ptr_text == 0 { // compare with null
 		return ''
 	}
-	return unsafe { string_from_wide(ptr_text) }
+	msg := unsafe { string_from_wide(ptr_text) }
+	C.LocalFree(ptr_text)
+	return msg
 }
 
 // execute starts the specified command, waits for it to complete, and returns its output.


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

```v
C.FormatMessageW(format_message_allocate_buffer,...)
```

The function allocates a buffer large enough to hold the formatted message, and it must be freed by `C.LocalFree()`.