### PR TITLE
runtime: add used_memory() implementation for FreeBSD

### DIFF
--- a/vlib/runtime/used_memory_default.c.v
+++ b/vlib/runtime/used_memory_default.c.v
@@ -1,6 +1,8 @@
 module runtime
 
 // used_memory retrieves the current physical memory usage of the process.
+// Note: implementation available only on FreeBSD, macOS, Linux and Windows. Otherwise,
+// returns 'used_memory: not implemented'.
 pub fn used_memory() !u64 {
-	return error('`used_memory()` not implemented')
+	return error('used_memory: not implemented')
 }

--- a/vlib/runtime/used_memory_freebsd.c.v
+++ b/vlib/runtime/used_memory_freebsd.c.v
@@ -1,0 +1,37 @@
+module runtime
+
+import os
+
+#flag -lprocstat
+
+#include <sys/user.h>
+#include <libprocstat.h>
+
+struct C.procstat {}
+
+struct C.kinfo_proc {
+	ki_rssize u64
+}
+
+fn C.procstat_open_sysctl() &C.procstat
+fn C.procstat_close(&C.procstat)
+fn C.procstat_getprocs(&C.procstat, int, int, &u32) &C.kinfo_proc
+
+// used_memory retrieves the current physical memory usage of the process.
+pub fn used_memory() !u64 {
+	mut proc_status := C.procstat_open_sysctl()
+	defer {
+		C.procstat_close(proc_status)
+	}
+
+	mut count := u32(0)
+
+	kip := C.procstat_getprocs(proc_status, C.KERN_PROC_PID | C.KERN_PROC_INC_THREAD,
+		os.getpid(), &count)
+
+	if kip != 0 {
+		return u64(kip.ki_rssize)
+	}
+
+	return 0
+}

--- a/vlib/runtime/used_memory_freebsd.c.v
+++ b/vlib/runtime/used_memory_freebsd.c.v
@@ -7,7 +7,7 @@ $if tinyc {
 }
 struct C.rusage {
 	ru_maxrss int
-	ru_idrss int
+	ru_idrss  int
 }
 
 fn C.getrusage(who int, usage &C.rusage) int

--- a/vlib/runtime/used_memory_freebsd.c.v
+++ b/vlib/runtime/used_memory_freebsd.c.v
@@ -2,11 +2,22 @@ module runtime
 
 import os
 
-#flag -lprocstat
+$if tinyc {
+	#include <sys/resource.h>
+}
+struct C.rusage {
+	ru_maxrss int
+	ru_idrss int
+}
 
-#include <sys/user.h>
-#include <libprocstat.h>
+fn C.getrusage(who int, usage &C.rusage) int
 
+$if !tinyc {
+	#flag -lprocstat
+
+	#include <sys/user.h>
+	#include <libprocstat.h>
+}
 struct C.procstat {}
 
 struct C.kinfo_proc {
@@ -19,19 +30,33 @@ fn C.procstat_getprocs(&C.procstat, int, int, &u32) &C.kinfo_proc
 
 // used_memory retrieves the current physical memory usage of the process.
 pub fn used_memory() !u64 {
-	mut proc_status := C.procstat_open_sysctl()
-	defer {
-		C.procstat_close(proc_status)
+	page_size := usize(C.sysconf(C._SC_PAGESIZE))
+	c_errno_1 := C.errno
+	if page_size == usize(-1) {
+		return error('used_memory: C.sysconf() return error code = ${c_errno_1}')
 	}
+	$if tinyc {
+		mut usage := C.rusage{}
+		x := C.getrusage(0, &usage)
+		if x == -1 {
+			c_errno_2 := C.errno
+			return error('used_memory: C.getrusage() return error code = ${c_errno_2}')
+		}
+		return u64(int_max(1, usage.ru_maxrss)) * 1024
+	} $else {
+		mut proc_status := C.procstat_open_sysctl()
+		defer {
+			C.procstat_close(proc_status)
+		}
 
-	mut count := u32(0)
+		mut count := u32(0)
 
-	kip := C.procstat_getprocs(proc_status, C.KERN_PROC_PID | C.KERN_PROC_INC_THREAD,
-		os.getpid(), &count)
+		kip := C.procstat_getprocs(proc_status, C.KERN_PROC_PID | C.KERN_PROC_INC_THREAD,
+			os.getpid(), &count)
 
-	if kip != 0 {
-		return u64(kip.ki_rssize)
+		if kip != 0 {
+			return u64(kip.ki_rssize * page_size)
+		}
 	}
-
 	return 0
 }

--- a/vlib/runtime/used_memory_test.v
+++ b/vlib/runtime/used_memory_test.v
@@ -17,8 +17,8 @@ fn test_used_memory() {
 	assert used1 > 0
 	assert used2 >= used1
 	assert used3 > used2
-	unsafe { 
-		println(*&u8(mem1+1024))
-		println(*&u8(mem2+1024))
+	unsafe {
+		println(*&u8(mem1 + 1024))
+		println(*&u8(mem2 + 1024))
 	}
 }

--- a/vlib/runtime/used_memory_test.v
+++ b/vlib/runtime/used_memory_test.v
@@ -4,18 +4,21 @@ fn test_used_memory() {
 	used1 := runtime.used_memory()!
 	println('used memory 1 : ${used1}')
 
-	mut mem1 := unsafe { malloc(4096 * 1024) }
-	unsafe { vmemset(mem1, 1, 4096 * 1024) }
-
+	mut mem1 := unsafe { malloc(8 * 1024 * 1024) }
+	unsafe { vmemset(mem1, 1, 8 * 1024 * 1024) }
 	used2 := runtime.used_memory()!
 	println('used memory 2 : ${used2}')
 
-	mut mem2 := unsafe { malloc(8192 * 1024) }
-	unsafe { vmemset(mem2, 1, 8192 * 1024) }
-
+	mut mem2 := unsafe { malloc(64 * 1024 * 1024) }
+	unsafe { vmemset(mem2, 1, 64 * 1024 * 1024) }
 	used3 := runtime.used_memory()!
 	println('used memory 3 : ${used3}')
+
 	assert used1 > 0
-	assert used2 > used1
+	assert used2 >= used1
 	assert used3 > used2
+	unsafe { 
+		println(*&u8(mem1+1024))
+		println(*&u8(mem2+1024))
+	}
 }


### PR DESCRIPTION
Adding a FreeBSD implementation of used_memory() so that the vlib/runtime/used_memory_test.v passes.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
