### PR TITLE
runtime: add note for the availability of the used_memory implementation

### DIFF
--- a/vlib/runtime/used_memory_default.c.v
+++ b/vlib/runtime/used_memory_default.c.v
@@ -1,7 +1,7 @@
 module runtime
 
 // used_memory retrieves the current physical memory usage of the process.
-// Note: implementation available only on Darwin, Linux and Windows. Otherwise,
+// Note: implementation available only on macOS, Linux and Windows. Otherwise,
 // returns 'used_memory: not implemented'.
 pub fn used_memory() !u64 {
 	return error('used_memory: not implemented')


### PR DESCRIPTION
`used_memory` function available only on Darwin, Linux and Windows. Otherwise returns `used_memory: not implemented`.