### PR TITLE
decoder2: fix checking and decoding of escape characters

### DIFF
--- a/vlib/x/json2/decoder2/tests/decode_escaped_string_test.v
+++ b/vlib/x/json2/decoder2/tests/decode_escaped_string_test.v
@@ -1,0 +1,12 @@
+import x.json2
+import x.json2.decoder2
+
+fn test_decode_escaped_string() {
+	escaped_strings := ['test', 'test\\sd', 'test\nsd', '\ntest', 'test\\"', 'test\\', 'test\u1234ps',
+		'test\u1234', '\u1234\\\t"', '']
+
+	json_string := json2.encode[[]string](escaped_strings)
+	decoded_strings := decoder2.decode[[]string](json_string)!
+
+	assert escaped_strings == decoded_strings
+}


### PR DESCRIPTION
fix #24834. Modified checker to correctly handle escaped ", also rewrote the string decoder in a correct and faster way.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
