### PR TITLE
runtime: add used_memory implementation for OpenBSD

### DIFF
--- a/vlib/runtime/used_memory_default.c.v
+++ b/vlib/runtime/used_memory_default.c.v
@@ -1,8 +1,8 @@
 module runtime
 
 // used_memory retrieves the current physical memory usage of the process.
-// Note: implementation available only on FreeBSD, macOS, Linux and Windows. Otherwise,
-// returns 'used_memory: not implemented'.
+// Note: implementation available only on FreeBSD, macOS, Linux, OpenBSD and
+// Windows. Otherwise, returns 'used_memory: not implemented'.
 pub fn used_memory() !u64 {
 	return error('used_memory: not implemented')
 }

--- a/vlib/runtime/used_memory_openbsd.c.v
+++ b/vlib/runtime/used_memory_openbsd.c.v
@@ -1,0 +1,26 @@
+module runtime
+
+#include <sys/resource.h>
+
+struct C.rusage {
+	ru_maxrss int
+}
+
+fn C.getrusage(who int, usage &C.rusage) int
+
+// used_memory retrieves the current physical memory usage of the process.
+pub fn used_memory() !u64 {
+	page_size := usize(C.sysconf(C._SC_PAGESIZE))
+	c_errno_1 := C.errno
+	if page_size == usize(-1) {
+		return error('used_memory: C.sysconf() return error code = ${c_errno_1}')
+	}
+
+	mut usage := C.rusage{}
+	ret := C.getrusage(C.RUSAGE_SELF, &usage)
+	if ret == -1 {
+		c_errno_2 := C.errno
+		return error('used_memory: C.getrusage() return error code = ${c_errno_2}')
+	}
+	return u64(int_max(1, usage.ru_maxrss)) * 1024
+}


### PR DESCRIPTION
**Tests OK** on OpenBSD current/amd64 with tcc, clang and gcc

```sh
$ ./v -stats -W test vlib/runtime/used_memory_test.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
        V  source  code size:      30279 lines,     139117 tokens,     818664 bytes,   292 types,    13 modules,   137 files
generated  target  code size:       9919 lines,     342127 bytes
compilation took: 623.194 ms, compilation speed: 48586 vlines/s, cgen threads: 3
running tests in: /home/fox/dev/vlang.git/vlib/runtime/used_memory_test.v
used memory 1 : 2293760
used memory 2 : 10731520
used memory 3 : 78139392
1
1
      OK      66.081 ms     3 asserts | main.test_used_memory()
     Summary for running V tests in "used_memory_test.v": 3 passed, 3 total. Elapsed time: 66 ms.

 OK     775.023 ms vlib/runtime/used_memory_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 780 ms, on 1 job. Comptime: 0 ms. Runtime: 775 ms.
```