### PR TITLE
decoder2: fix decoding of structs with option fields

### DIFF
--- a/vlib/x/json2/decoder2/decode.v
+++ b/vlib/x/json2/decoder2/decode.v
@@ -810,7 +810,9 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 													&& decoder.json[decoder.current_node.value.position..decoder.current_node.value.position + 4] == 'null' {
 													val.$(field.name) = none
 												} else {
-													mut unwrapped_val := create_value_from_optional(val.$(field.name))
+													mut unwrapped_val := create_value_from_optional(val.$(field.name)) or {
+														return
+													}
 													decoder.decode_value(mut unwrapped_val)!
 													val.$(field.name) = unwrapped_val
 												}
@@ -975,7 +977,7 @@ fn get_value_kind(value u8) ValueKind {
 	return .unknown
 }
 
-fn create_value_from_optional[T](val ?T) T {
+fn create_value_from_optional[T](val ?T) ?T {
 	return T{}
 }
 

--- a/vlib/x/json2/decoder2/decode.v
+++ b/vlib/x/json2/decoder2/decode.v
@@ -546,18 +546,7 @@ pub fn decode[T](val string) !T {
 // decode_value decodes a value from the JSON nodes.
 @[manualfree]
 fn (mut decoder Decoder) decode_value[T](mut val T) ! {
-	$if T is $option {
-		value_info := decoder.current_node.value
-
-		if value_info.value_kind == .null {
-			decoder.current_node = decoder.current_node.next
-			// val = none // Is this line needed?
-			return
-		}
-		mut unwrapped_val := create_value_from_optional(val.$(field.name))
-		decoder.decode_value(mut unwrapped_val)!
-		val.$(field.name) = unwrapped_val
-	} $else $if T.unaliased_typ is string {
+	$if T.unaliased_typ is string {
 		string_info := decoder.current_node.value
 
 		if string_info.value_kind == .string_ {
@@ -815,11 +804,16 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 											}
 										} else {
 											$if field.typ is $option {
-												mut unwrapped_val := create_value_from_optional(val.$(field.name)) or {
-													return
+												// it would be nicer to do this at the start of the function
+												// but options cant be passed to generic functions
+												if decoder.current_node.value.length == 4
+													&& decoder.json[decoder.current_node.value.position..decoder.current_node.value.position + 4] == 'null' {
+													val.$(field.name) = none
+												} else {
+													mut unwrapped_val := create_value_from_optional(val.$(field.name))
+													decoder.decode_value(mut unwrapped_val)!
+													val.$(field.name) = unwrapped_val
 												}
-												decoder.decode_value(mut unwrapped_val)!
-												val.$(field.name) = unwrapped_val
 											} $else {
 												decoder.decode_value(mut val.$(field.name))!
 											}
@@ -981,7 +975,7 @@ fn get_value_kind(value u8) ValueKind {
 	return .unknown
 }
 
-fn create_value_from_optional[T](val ?T) ?T {
+fn create_value_from_optional[T](val ?T) T {
 	return T{}
 }
 

--- a/vlib/x/json2/decoder2/tests/decode_option_field_test.v
+++ b/vlib/x/json2/decoder2/tests/decode_option_field_test.v
@@ -1,0 +1,23 @@
+import x.json2.decoder2
+import json
+
+struct Data {
+	name  ?string
+	value string
+}
+
+fn test_decode_option_field() {
+	assert decoder2.decode[Data]('{"name": "test", "value": "hi"}')! == Data{
+		name:  'test'
+		value: 'hi'
+	}
+	assert decoder2.decode[Data]('{"name": null, "value": "hi"}')! == Data{
+		name:  none
+		value: 'hi'
+	}
+	assert decoder2.decode[Data]('{"value": "hi"}')! == Data{
+		name:  none
+		value: 'hi'
+	}
+	assert decoder2.decode[Data]('{"name": null, "value": null}') or { return } == Data{}
+}


### PR DESCRIPTION
fix: #24409 

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
