### PR TITLE
cast C.AF_INET to u16 to avoid type error in c_const_u8_test

### DIFF
--- a/vlib/v/tests/c_const_u8_test.v
+++ b/vlib/v/tests/c_const_u8_test.v
@@ -13,5 +13,5 @@ fn xint(n int) bool {
 fn test_const() {
 	assert xint(C.EOF) == true // a random libc const is int by default
 
-	assert x16(C.AF_INET) == true // defined in V's net module
+	assert x16(u16(C.AF_INET)) == true // defined in V's net module
 }


### PR DESCRIPTION
I get a compile error that prevents this test from succeeding.  Since the enumeration value C.AF_INET defaults to int, it needs to be converted to u16.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
