### PR TITLE
math.big: fix the order of calculations in mod_pow()

### DIFF
--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -605,9 +605,9 @@ pub fn (base Integer) mod_pow(exponent u32, modulus Integer) Integer {
 	mut y := one_int
 	for n > 1 {
 		if n & 1 == 1 {
-			y *= x % modulus
+			y = (y * x) % modulus
 		}
-		x *= x % modulus
+		x = (x * x) % modulus
 		n >>= 1
 	}
 	return x * y % modulus


### PR DESCRIPTION
By changing the order of executing multiplication and taking modulo, the result is equally correct, but the numbers always remain within the modulus bounds.
As a result, the function works faster:
```
2.325ms -> 61.188us
```
Also function passed the tests against `gmplib`.