### PR TITLE
math.big: fix zero base in big_mod_pow(), add tests

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -399,6 +399,10 @@ struct PowTest {
 
 // vfmt off
 const pow_test_data = [
+	PowTest{ 0, 0, 1},
+	PowTest{ 0, 1, 0},
+	PowTest{ 1, 0, 1},
+	PowTest{ 1, 1, 1},
 	PowTest{ 2, 0, 1 },
 	PowTest{ 2, 1, 2 },
 	PowTest{ 2, 5, 32 },
@@ -422,6 +426,10 @@ struct ModPowTest {
 
 // vfmt off
 const mod_pow_test_data = [
+	ModPowTest{ 0, 0, 123, 1 },
+	ModPowTest{ 0, 1, 123, 0 },
+	ModPowTest{ 1, 0, 123, 1 },
+	ModPowTest{ 1, 1, 123, 1 },
 	ModPowTest{ 324, 315, 632, 512 },
 	ModPowTest{ 65, 17, 3233, 2790 },
 	ModPowTest{ 2790, 413, 3233, 65 },
@@ -437,6 +445,10 @@ struct BigModPowTest {
 
 // vfmt off
 const big_mod_pow_test_data = [
+	BigModPowTest{  0,  0, 4205,   1 },
+	BigModPowTest{  0,  1, 4205,   0 },
+	BigModPowTest{  1,  0, 4205,   1 },
+	BigModPowTest{  1,  1, 4205,   1 },
 	BigModPowTest{ 23, 35, 4205, 552 }, // passed to mod_pow
 	BigModPowTest{
 		'5155371529688',

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -632,7 +632,7 @@ pub fn (base Integer) big_mod_pow(exponent Integer, modulus Integer) !Integer {
 
 	// 0^x == 0 (x != 0 due to previous clause)
 	if base.signum == 0 {
-		return one_int
+		return zero_int
 	}
 
 	if exponent.bit_len() == 1 {


### PR DESCRIPTION
Fix `big_mod_pow()` if base is `zero`.
Tests were also added for all three functions where there are powers - `pow()`, `mod_pow()`, `big_mod_pow()`.
Found via my test-suite.
