### PR TITLE
os,runtime: move some struct and fn def to builtin

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -528,3 +528,15 @@ fn C.WrappedNSLog(str &u8)
 fn C.abs(number int) int
 
 fn C.GetDiskFreeSpaceExA(const_path &char, free_bytes_available_to_caller &u64, total_number_of_bytes &u64, total_number_of_free_bytes &u64) bool
+
+// C.SYSTEM_INFO contains information about the current computer system. This includes the architecture and type of the processor, the number of processors in the system, the page size, and other such information.
+@[typedef]
+pub struct C.SYSTEM_INFO {
+	dwNumberOfProcessors u32
+	dwPageSize           u32
+}
+
+fn C.GetSystemInfo(&C.SYSTEM_INFO)
+
+@[typedef]
+pub struct C.SRWLOCK {}

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -585,15 +585,6 @@ fn get_long_path(path string) !string {
 	return long_path
 }
 
-// C.SYSTEM_INFO contains information about the current computer system. This includes the architecture and type of the processor, the number of processors in the system, the page size, and other such information.
-@[typedef]
-pub struct C.SYSTEM_INFO {
-	dwNumberOfProcessors u32
-	dwPageSize           u32
-}
-
-fn C.GetSystemInfo(&C.SYSTEM_INFO)
-
 // page_size returns the page size in bytes.
 pub fn page_size() int {
 	sinfo := C.SYSTEM_INFO{}

--- a/vlib/runtime/runtime_windows.c.v
+++ b/vlib/runtime/runtime_windows.c.v
@@ -8,7 +8,6 @@ pub struct C.MEMORYSTATUS {
 	dwAvailPhys usize
 }
 
-fn C.GetSystemInfo(&C.SYSTEM_INFO)
 fn C.GlobalMemoryStatus(&C.MEMORYSTATUS)
 
 // nr_cpus returns the number of virtual CPU cores found on the system.

--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -23,9 +23,6 @@ type MHANDLE = voidptr
 type SHANDLE = voidptr
 
 @[typedef]
-pub struct C.SRWLOCK {}
-
-@[typedef]
 pub struct C.CONDITION_VARIABLE {}
 
 //[init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

os,runtime: move some struct and fn def to `builtin` as they may needed by other modules ( e.g. `builtin.closure`).