### PR TITLE
fix 24908 vfmt of if return

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1613,7 +1613,9 @@ pub fn (mut f Fmt) return_stmt(node ast.Return) {
 			}
 		}
 	}
-	f.writeln('')
+	if !f.single_line_if {
+		f.writeln('')
+	}
 }
 
 pub fn (mut f Fmt) sql_stmt(node ast.SqlStmt) {

--- a/vlib/v/fmt/tests/if_ternary_return_keep.vv
+++ b/vlib/v/fmt/tests/if_ternary_return_keep.vv
@@ -1,0 +1,8 @@
+module main
+
+fn g() ?int {
+	return 123
+}
+
+x := if ff := g() { ff } else { return }
+println(x)

--- a/vlib/v/tests/fns/closure_test.v
+++ b/vlib/v/tests/fns/closure_test.v
@@ -155,9 +155,7 @@ fn test_go_call_closure() {
 fn test_closures_with_ifstmt() {
 	a := 1
 	f := fn [a] (x int) int {
-		if a > x { return 1
-		 } else { return -1
-		 }
+		if a > x { return 1 } else { return -1 }
 	}
 	g := fn [a] () int {
 		if true {


### PR DESCRIPTION
- **fmt: fix `if x := g() { x } else { return }` wrapping (fix #24908)**
- **reformat vlib/v/tests/fns/closure_test.v**
