### PR TITLE
decoder2: rework decoding of sumtypes

### DIFF
--- a/vlib/x/json2/decoder2/decode.v
+++ b/vlib/x/json2/decoder2/decode.v
@@ -3,6 +3,7 @@ module decoder2
 import strconv
 import time
 import strings
+import x.json2
 
 const null_in_string = 'null'
 
@@ -628,6 +629,14 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 
 			val = time.parse_rfc3339(string_time) or { time.Time{} }
 		}
+	} $else $if T.unaliased_typ is json2.Null {
+		value_info := decoder.current_node.value
+
+		if value_info.value_kind != .null {
+			return error('Expected null, but got ${value_info.value_kind}')
+		}
+
+		val = json2.null
 	} $else $if T.unaliased_typ is $map {
 		decoder.decode_map(mut val)!
 		return

--- a/vlib/x/json2/decoder2/decode_sumtype.v
+++ b/vlib/x/json2/decoder2/decode_sumtype.v
@@ -1,22 +1,20 @@
 module decoder2
 
 import time
+import x.json2
+
+fn copy_type[T](t T) T {
+	return T{}
+}
 
 fn (mut decoder Decoder) get_decoded_sumtype_workaround[T](initialized_sumtype T) !T {
 	$if initialized_sumtype is $sumtype {
 		$for v in initialized_sumtype.variants {
 			if initialized_sumtype is v {
-				// workaround for auto generated function considering sumtype as array
-				unsafe {
-					$if initialized_sumtype is $map {
-						mut val := initialized_sumtype.clone()
-						decoder.decode_value(mut val)!
-						return T(val)
-					} $else {
-						mut val := initialized_sumtype
-						decoder.decode_value(mut val)!
-						return T(val)
-					}
+				$if initialized_sumtype !is $option { // only to avoid compiler errors, options wont get here
+					mut val := copy_type(initialized_sumtype)
+					decoder.decode_value(mut val)!
+					return T(val)
 				}
 			}
 		}
@@ -24,103 +22,281 @@ fn (mut decoder Decoder) get_decoded_sumtype_workaround[T](initialized_sumtype T
 	return initialized_sumtype
 }
 
-fn (mut decoder Decoder) init_sumtype_by_value_kind[T](mut val T, value_info ValueInfo) ! {
-	$for v in val.variants {
-		if value_info.value_kind == .string_ {
-			$if v.typ is string {
-				val = T(v)
-				return
-			} $else $if v.typ is time.Time {
-				val = T(v)
-				return
+fn (mut decoder Decoder) check_element_type_valid[T](element T, current_node Node[ValueInfo]) bool {
+	$if T.unaliased_typ is json2.Any {
+		return true
+	}
+
+	match current_node.value.value_kind {
+		.string_ {
+			$if element is string {
+				return true
+			} $else $if element is time.Time {
+				return true
 			}
-		} else if value_info.value_kind == .number {
-			$if v.typ is $float {
-				val = T(v)
-				return
-			} $else $if v.typ is $int {
-				val = T(v)
-				return
-			} $else $if v.typ is $enum {
-				val = T(v)
-				return
+		}
+		.number {
+			$if element is $float {
+				return true
+			} $else $if element is $int {
+				return true
+			} $else $if element is $enum {
+				return true
 			}
-		} else if value_info.value_kind == .boolean {
-			$if v.typ is bool {
-				val = T(v)
-				return
+		}
+		.boolean {
+			$if element is bool {
+				return true
 			}
-		} else if value_info.value_kind == .object {
-			$if v.typ is $map {
-				val = T(v)
-				return
-			} $else $if v.typ is $struct {
-				// find "_type" field in json object
-				mut type_field_node := decoder.current_node.next
-				map_position := value_info.position
-				map_end := map_position + value_info.length
+		}
+		.null {
+			$if element is json2.Null {
+				return true
+			}
+		}
+		.array {
+			$if element is $array {
+				if current_node.next != unsafe { nil } {
+					return decoder.check_array_type_valid(element, current_node.next)
+				} else {
+					return false
+				}
+			}
+		}
+		.object {
+			$if element is $map {
+				if current_node.next != unsafe { nil } && current_node.next.next != unsafe { nil } {
+					return decoder.check_map_type_valid(element, current_node.next.next)
+				} else {
+					return false
+				}
+			} $else $if element is $struct {
+				return decoder.check_struct_type_valid(element, current_node)
+			}
+		}
+		else {}
+	}
 
-				type_field := '"_type"'
+	return false
+}
 
-				for {
-					if type_field_node == unsafe { nil } {
-						break
-					}
+fn get_array_element_type[T](arr []T) T {
+	return T{}
+}
 
-					key_info := type_field_node.value
+fn (mut decoder Decoder) check_array_type_valid[T](arr []T, current_node Node[ValueInfo]) bool {
+	return decoder.check_element_type_valid(get_array_element_type(arr), current_node)
+}
 
-					if key_info.position >= map_end {
-						type_field_node = unsafe { nil }
-						break
-					}
-
-					if unsafe {
-						vmemcmp(decoder.json.str + key_info.position, type_field.str,
-							type_field.len) == 0
-					} {
-						// find type field
-						type_field_node = type_field_node.next
-
-						break
+fn (mut decoder Decoder) get_array_type_workaround[T](initialized_sumtype T) bool {
+	$if initialized_sumtype is $sumtype {
+		$for v in initialized_sumtype.variants {
+			if initialized_sumtype is v {
+				$if initialized_sumtype is $array {
+					val := copy_type(initialized_sumtype)
+					if decoder.current_node.next != unsafe { nil } {
+						return decoder.check_array_type_valid(val, decoder.current_node.next)
 					} else {
-						type_field_node = type_field_node.next
-					}
-				}
-
-				if type_field_node != unsafe { nil } {
-					$for v in val.variants {
-						variant_name := typeof(v.typ).name
-						if type_field_node.value.length - 2 == variant_name.len {
-							unsafe {
-							}
-							if unsafe {
-								vmemcmp(decoder.json.str + type_field_node.value.position + 1,
-									variant_name.str, variant_name.len) == 0
-							} {
-								val = T(v)
-							}
+						$if initialized_sumtype is []json2.Any {
+							return true
 						}
+						return false
 					}
 				}
-
-				return
-			}
-		} else if value_info.value_kind == .array {
-			$if v.typ is $array {
-				val = T(v)
-				return
 			}
 		}
 	}
+	return false
+}
+
+fn get_map_element_type[U, V](m map[U]V) V {
+	return V{}
+}
+
+fn (mut decoder Decoder) check_map_type_valid[T](m T, current_node Node[ValueInfo]) bool {
+	element := get_map_element_type(m)
+	return decoder.check_element_type_valid(element, current_node)
+}
+
+fn (mut decoder Decoder) get_map_type_workaround[T](initialized_sumtype T) bool {
+	$if initialized_sumtype is $sumtype {
+		$for v in initialized_sumtype.variants {
+			if initialized_sumtype is v {
+				$if initialized_sumtype is $map {
+					val := copy_type(initialized_sumtype)
+					if decoder.current_node.next != unsafe { nil }
+						&& decoder.current_node.next.next != unsafe { nil } {
+						return decoder.check_map_type_valid(val, decoder.current_node.next.next)
+					} else {
+						$if initialized_sumtype is map[string]json2.Any { // fix for aliased types
+							return true
+						}
+						return false
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+fn (mut decoder Decoder) check_struct_type_valid[T](s T, current_node Node[ValueInfo]) bool {
+	// find "_type" field in json object
+	mut type_field_node := decoder.current_node.next
+	map_position := current_node.value.position
+	map_end := map_position + current_node.value.length
+
+	type_field := '"_type"'
+
+	for {
+		if type_field_node == unsafe { nil } {
+			break
+		}
+
+		key_info := type_field_node.value
+
+		if key_info.position >= map_end {
+			type_field_node = unsafe { nil }
+			break
+		}
+
+		if unsafe {
+			vmemcmp(decoder.json.str + key_info.position, type_field.str, type_field.len) == 0
+		} {
+			// find type field
+			type_field_node = type_field_node.next
+
+			break
+		} else {
+			type_field_node = type_field_node.next
+		}
+	}
+
+	if type_field_node == unsafe { nil } {
+		return false
+	}
+
+	variant_name := typeof(s).name
+	if type_field_node.value.length - 2 == variant_name.len {
+		unsafe {
+		}
+		if unsafe {
+			vmemcmp(decoder.json.str + type_field_node.value.position + 1, variant_name.str,
+				variant_name.len) == 0
+		} {
+			return true
+		}
+	}
+
+	return false
+}
+
+fn (mut decoder Decoder) get_struct_type_workaround[T](initialized_sumtype T) bool {
+	$if initialized_sumtype is $sumtype {
+		$for v in initialized_sumtype.variants {
+			if initialized_sumtype is v {
+				$if initialized_sumtype is $struct {
+					val := copy_type(initialized_sumtype)
+					return decoder.check_struct_type_valid(val, decoder.current_node)
+				}
+			}
+		}
+	}
+	return false
+}
+
+fn (mut decoder Decoder) init_sumtype_by_value_kind[T](mut val T, value_info ValueInfo) ! {
+	mut failed_struct := false
+
+	match value_info.value_kind {
+		.string_ {
+			$for v in val.variants {
+				$if v.typ is string {
+					val = T(v)
+					return
+				} $else $if v.typ is time.Time {
+					val = T(v)
+					return
+				}
+			}
+		}
+		.number {
+			$for v in val.variants {
+				$if v.typ is $float {
+					val = T(v)
+					return
+				} $else $if v.typ is $int {
+					val = T(v)
+					return
+				} $else $if v.typ is $enum {
+					val = T(v)
+					return
+				}
+			}
+		}
+		.boolean {
+			$for v in val.variants {
+				$if v.typ is bool {
+					val = T(v)
+					return
+				}
+			}
+		}
+		.null {
+			$for v in val.variants {
+				$if v.typ is json2.Null {
+					val = T(v)
+					return
+				}
+			}
+		}
+		.array {
+			$for v in val.variants {
+				$if v.typ is $array {
+					val = T(v)
+
+					if decoder.get_array_type_workaround(val) {
+						return
+					}
+				}
+			}
+		}
+		.object {
+			$for v in val.variants {
+				$if v.typ is $map {
+					val = T(v)
+
+					if decoder.get_map_type_workaround(val) {
+						return
+					}
+				} $else $if v.typ is $struct {
+					val = T(v)
+
+					if decoder.get_struct_type_workaround(val) {
+						return
+					}
+
+					failed_struct = true
+				}
+			}
+		}
+		else {}
+	}
+
+	if failed_struct {
+		decoder.error('could not resolve sumtype `${T.name}`, missing "_type" field?')!
+	}
+
+	decoder.error('could not resolve sumtype `${T.name}`, got ${value_info.value_kind}.')!
 }
 
 fn (mut decoder Decoder) decode_sumtype[T](mut val T) ! {
+	$if T is $alias {
+		decoder.error('Type aliased sumtypes not supported.')!
+	}
 	value_info := decoder.current_node.value
 
 	decoder.init_sumtype_by_value_kind(mut val, value_info)!
 
-	decoded_sumtype := decoder.get_decoded_sumtype_workaround(val)!
-	unsafe {
-		*val = decoded_sumtype
-	}
+	val = decoder.get_decoded_sumtype_workaround(val)!
 }

--- a/vlib/x/json2/decoder2/decode_sumtype.v
+++ b/vlib/x/json2/decoder2/decode_sumtype.v
@@ -293,10 +293,11 @@ fn (mut decoder Decoder) init_sumtype_by_value_kind[T](mut val T, value_info Val
 fn (mut decoder Decoder) decode_sumtype[T](mut val T) ! {
 	$if T is $alias {
 		decoder.error('Type aliased sumtypes not supported.')!
+	} $else {
+		value_info := decoder.current_node.value
+
+		decoder.init_sumtype_by_value_kind(mut val, value_info)!
+
+		val = decoder.get_decoded_sumtype_workaround(val)!
 	}
-	value_info := decoder.current_node.value
-
-	decoder.init_sumtype_by_value_kind(mut val, value_info)!
-
-	val = decoder.get_decoded_sumtype_workaround(val)!
 }

--- a/vlib/x/json2/decoder2/tests/json_sumtype_test.v
+++ b/vlib/x/json2/decoder2/tests/json_sumtype_test.v
@@ -29,6 +29,21 @@ type Sum = int | string | bool | []string
 
 type StructSumTypes = Stru | Stru2
 
+type Mixed = Cat | int | map[string]int
+
+type Maybes = ?int | ?string
+
+type MultiArray = []int
+	| []bool
+	| [][]string
+	| []map[string]map[string][]int
+	| map[string]json2.Any
+	| string
+
+type StructLists = Cat | []Cat | map[string]Dog
+
+type SumAlias = Sum
+
 pub struct Stru {
 	val  int
 	val2 string
@@ -86,13 +101,61 @@ fn test_any_sum_type() {
 			'hello2': json2.Any('world')
 		})
 	})
+
+	assert json.decode[json2.Any]('{"name": null, "value": "hi"}')! == json2.Any({
+		'name':  json2.Any(json2.null)
+		'value': json2.Any('hi')
+	})
+
+	assert json.decode[json2.Any]('[]')! == json2.Any([]json2.Any{})
+	assert json.decode[json2.Any]('{}')! == json2.Any(map[string]json2.Any{})
 }
 
 fn test_sum_type_struct() {
-	assert json.decode[Animal]('{"cat_name": "Tom"}')! == Animal(Cat{'Tom'})
-	assert json.decode[Animal]('{"dog_name": "Rex"}')! == Animal(Cat{''})
+	if x := json.decode[Animal]('{"cat_name": "Tom"}') {
+		assert false
+	}
+	if x := json.decode[Animal]('{"dog_name": "Rex"}') {
+		assert false
+	}
 	assert json.decode[Animal]('{"dog_name": "Rex", "_type": "Dog"}')! == Animal(Dog{'Rex'})
 
 	// struct sumtype in random order
 	assert json.decode[StructSumTypes]('{"_type": "Stru", "val": 1, "val2": "lala", "val3": {"a": 2, "steak": "leleu"}, "val4": 2147483000, "val5": 2147483000}')! == StructSumTypes(Stru{1, 'lala', Stru2{2, 'leleu'}, 2147483000, 2147483000})
+}
+
+fn test_sum_type_mixed() {
+	assert json.decode[Mixed]('{"key":0}')! == Mixed({
+		'key': 0
+	})
+	assert json.decode[Mixed]('10')! == Mixed(10)
+}
+
+// to be implemented
+fn test_sum_type_options_fail() {
+	if x := json.decode[Maybes]('99') {
+		assert false
+	}
+	if x := json.decode[Maybes]('hi') {
+		assert false
+	}
+	if x := json.decode[Maybes]('true') {
+		assert false
+	}
+}
+
+// to be implemented
+fn test_sum_type_alias_fail() {
+	if x := json.decode[SumAlias]('99') {
+		assert false
+	}
+	if x := json.decode[SumAlias]('true') {
+		assert false
+	}
+	if x := json.decode[SumAlias]('["hi", "bye"]') {
+		assert false
+	}
+	if x := json.decode[SumAlias]('[0, 1]') {
+		assert false
+	}
 }

--- a/vlib/x/json2/decoder2/tests/json_sumtype_test.v
+++ b/vlib/x/json2/decoder2/tests/json_sumtype_test.v
@@ -57,6 +57,8 @@ pub struct Stru2 {
 	steak string
 }
 
+type NewAny = int | string | bool | []NewAny | map[string]NewAny | ?int
+
 fn test_simple_sum_type() {
 	assert json.decode[Sum]('1')! == Sum(1)
 
@@ -102,9 +104,9 @@ fn test_any_sum_type() {
 		})
 	})
 
-	assert json.decode[json2.Any]('{"name": null, "value": "hi"}')! == json2.Any({
-		'name':  json2.Any(json2.null)
-		'value': json2.Any('hi')
+	assert json.decode[NewAny]('{"name": null, "value": "hi"}')! == NewAny({
+		'name':  NewAny(?int(none))
+		'value': NewAny('hi')
 	})
 
 	assert json.decode[json2.Any]('[]')! == json2.Any([]json2.Any{})
@@ -133,6 +135,7 @@ fn test_sum_type_mixed() {
 
 // to be implemented
 fn test_sum_type_options_fail() {
+	assert json.decode[Maybes]('null')! == Maybes(?int(none))
 	if x := json.decode[Maybes]('99') {
 		assert false
 	}


### PR DESCRIPTION
Reworks the sumtype decoder to allow for more complex sumtypes and better error handling.

### New Features

- Adds Decoding for json2.Null, so that json2.Any is fully supported
- Sumtype that cant be resolved now gives a clearer error e.g. `could not resolve sumtype Sum, got string_` instead of `Expected number, but got string_`
- map & array now only get resolved if the entire type matches (instead of just using the first array / map). This allows for sumtypes with multiple different array types like `type MultiArray = []int | []bool`. This also enhances error messages.
- Options & Type aliases are still not support, but now give runtime errors instead of cryptic compiler errors
- Fix random compiler error when having multiple sumtypes with maps in the code

### BREAKS

Because the decoder now gives errors, instead of resolving bogus sumtypes, sumtypes with structs behave differently from json and json2. e.g.

```v
pub type Animal = Cat | Dog

pub struct Cat {
	cat_name string
}

pub struct Dog {
	dog_name string
}

// before
decoder2.decode[Animal]('{"cat_name": "Tom"}') // Animal(Cat{'Tom'})
decoder2.decode[Animal]('{"dog_name": "Tom"}') // Animal(Cat{})
decoder2.decode[Animal]('{"dog_name": "Rex", "_type": "Dog"}') // Animal(Dog{'Rex'})


// after
decoder2.decode[Animal]('{"cat_name": "Tom"}') // will now throw error, missing field _type
decoder2.decode[Animal]('{"dog_name": "Tom"}') // will now throw error, missing field _type
decoder2.decode[Animal]('{"dog_name": "Rex", "_type": "Dog"}') // Animal(Dog{'Rex'})
```