### PR TITLE
slow_tests: fix crash on clang for asm_test.amd64.v

### DIFF
--- a/vlib/v/slow_tests/assembly/asm_test.amd64.v
+++ b/vlib/v/slow_tests/assembly/asm_test.amd64.v
@@ -107,6 +107,7 @@ fn test_inline_asm() {
 		; =b (o.ebx) as ebx0
 		  =d (o.edx) as edx0
 		  =c (o.ecx) as ecx0
+		;; eax
 	}
 	assert o.str()[0].is_capital()
 }

--- a/vlib/v/slow_tests/assembly/asm_test.amd64.v
+++ b/vlib/v/slow_tests/assembly/asm_test.amd64.v
@@ -107,7 +107,7 @@ fn test_inline_asm() {
 		; =b (o.ebx) as ebx0
 		  =d (o.edx) as edx0
 		  =c (o.ecx) as ecx0
-		;; eax
+		; ; eax
 	}
 	assert o.str()[0].is_capital()
 }


### PR DESCRIPTION
Currently, this test crashes on `clang`.
This needs to be fixed by proactively specifying that the `eax` register is modified.
It worked on `gcc` as is, but clang requires an explicit specification.