### PR TITLE
eval: reset return value after const eval

### DIFF
--- a/vlib/v/eval/eval.v
+++ b/vlib/v/eval/eval.v
@@ -179,7 +179,11 @@ pub fn (mut e Eval) register_symbols(mut files []&ast.File) {
 		for file, fields in const_files {
 			e.cur_file = file
 			for _, field in fields {
+				e.returning = true
+				e.return_values = []
 				e.mods[mod][field.name.all_after_last('.')] = e.expr(field.expr, field.typ)
+				e.returning = false
+				e.return_values = []
 				if mod == 'os' && field.name.all_after_last('.') == 'args' {
 					mut res := Array{}
 					res.val << e.pref.out_name.all_after_last('/')

--- a/vlib/v/eval/expr.c.v
+++ b/vlib/v/eval/expr.c.v
@@ -150,7 +150,12 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 						e.returning = true
 						e.return_values = []
 						e.stmts(branch.stmts)
-						return e.return_values[0]
+						val := if e.return_values.len > 0 {
+							e.return_values[e.return_values.len - 1]
+						} else {
+							empty
+						}
+						return val
 					}
 				}
 				return empty

--- a/vlib/v/eval/tests/comptime_if_test.v
+++ b/vlib/v/eval/tests/comptime_if_test.v
@@ -14,8 +14,14 @@ fn test_comptime_if() {
 	\$else \$if s390x       { "s390x" } 
 	\$else \$if ppc64le     { "ppc64le" } 
 	\$else \$if loongarch64 { "loongarch64" } 
-	\$else { "unknown" }')!
+	\$else { "unknown" }
+
+	const b = 1.5
+
+	fn display() (string,f64) { println(a) println(b) return a,b } display()')!
+
 	dump(ret)
 	assert ret[0].string().len != 0
 	assert ret[0].string() != 'unknown'
+	assert ret[1].float_val() == 1.5
 }

--- a/vlib/v/eval/tests/const_test.v
+++ b/vlib/v/eval/tests/const_test.v
@@ -1,0 +1,13 @@
+import v.eval
+
+fn test_const() {
+	mut e := eval.create()
+
+	ret := e.run('const a = 100
+	const b = "test"
+	fn display() (int,string) { println(a) println(b) return a,b } display()')!
+
+	dump(ret)
+	assert ret[0].int_val() == 100
+	assert ret[1].string() == 'test'
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
eval: reset return value after const eval.
This PR will reset the return values after eval a const statement.
