### PR TITLE
parser: allow keyword as struct param key on fn call

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -141,7 +141,7 @@ fn (mut p Parser) call_args() []ast.CallArg {
 			array_decompose = true
 		}
 		mut expr := ast.empty_expr
-		if p.tok.kind in [.name, .key_type] && p.peek_tok.kind == .colon {
+		if p.peek_tok.kind == .colon {
 			// `foo(key:val, key2:val2)`
 			expr = p.struct_init('void_type', .short_syntax, false)
 		} else {

--- a/vlib/v/tests/fns/call_struct_params_with_keyword_test.v
+++ b/vlib/v/tests/fns/call_struct_params_with_keyword_test.v
@@ -1,0 +1,13 @@
+@[params]
+struct Config {
+	dump bool
+}
+
+fn test_main() {
+	opt := Config{}
+	run('x', dump: opt.dump)!
+}
+
+fn run(source string, config Config) ! {
+	dump(config)
+}


### PR DESCRIPTION
Fix #24957