### PR TITLE
eval:add more infix op support; fix early func return

### DIFF
--- a/vlib/v/eval/eval.v
+++ b/vlib/v/eval/eval.v
@@ -64,6 +64,7 @@ pub mut:
 	scope_idx              int      // this is increased when e.open_scope() is called, decreased when e.close_scope() (and all variables with that scope level deleted)
 	returning              bool
 	return_values          []Object
+	execute_return_stmt    bool // already execute a retrun stmt in func or not
 	cur_mod                string
 	cur_file               string
 
@@ -152,6 +153,7 @@ pub fn (mut e Eval) run_func(func ast.FnDecl, _args ...Object) {
 				scope_idx: e.scope_idx
 			}
 		}
+		e.execute_return_stmt = false
 		e.stmts(func.stmts)
 		e.returning = false
 		e.close_scope()
@@ -316,6 +318,11 @@ pub fn (mut e Eval) comptime_cond(cond ast.Expr) bool {
 					e.error('unsupported prefix expression')
 				}
 			}
+		}
+		ast.InfixExpr {
+			left := e.comptime_cond(cond.left)
+			right := e.comptime_cond(cond.right)
+			return e.infix_expr(left, right, cond.op, ast.bool_type) as bool
 		}
 		else {
 			e.error('unsupported expression')

--- a/vlib/v/eval/eval.v
+++ b/vlib/v/eval/eval.v
@@ -64,7 +64,7 @@ pub mut:
 	scope_idx              int      // this is increased when e.open_scope() is called, decreased when e.close_scope() (and all variables with that scope level deleted)
 	returning              bool
 	return_values          []Object
-	execute_return_stmt    bool // already execute a retrun stmt in func or not
+	executed_return_stmt   bool // already executed a return stmt in func
 	cur_mod                string
 	cur_file               string
 
@@ -153,7 +153,7 @@ pub fn (mut e Eval) run_func(func ast.FnDecl, _args ...Object) {
 				scope_idx: e.scope_idx
 			}
 		}
-		e.execute_return_stmt = false
+		e.executed_return_stmt = false
 		e.stmts(func.stmts)
 		e.returning = false
 		e.close_scope()

--- a/vlib/v/eval/expr.c.v
+++ b/vlib/v/eval/expr.c.v
@@ -498,6 +498,9 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 		}
 		ast.PrefixExpr {
 			match expr.op {
+				.not {
+					return !(e.expr(expr.right, ast.bool_type) as bool)
+				}
 				.amp {
 					x := e.expr(expr.right, expr.right_type)
 					return Ptr{

--- a/vlib/v/eval/infix.v
+++ b/vlib/v/eval/infix.v
@@ -132,6 +132,120 @@ fn (e &Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.
 				}
 			}
 		}
+		.ge {
+			match left {
+				Int {
+					match right {
+						Int { return left.val >= right.val }
+						Uint { return left.val >= right.val }
+						Float { return left.val >= right.val }
+						i64 { return left.val >= right }
+						f64 { return left.val >= right }
+						else { e.error('invalid operands to >=: Int and ${right.type_name()}') }
+					}
+				}
+				Uint {
+					match right {
+						Int { return left.val >= right.val }
+						Uint { return left.val >= right.val }
+						Float { return left.val >= right.val }
+						i64 { return left.val >= right }
+						f64 { return left.val >= right }
+						else { e.error('invalid operands to >=: Uint and ${right.type_name()}') }
+					}
+				}
+				Float {
+					match right {
+						Int { return left.val >= right.val }
+						Uint { return left.val >= right.val }
+						Float { return left.val >= right.val }
+						i64 { return left.val >= right }
+						f64 { return left.val >= right }
+						else { e.error('invalid operands to >=: Float and ${right.type_name()}') }
+					}
+				}
+				i64 {
+					match right {
+						Int { return left >= right.val }
+						Uint { return left >= right.val }
+						Float { return left >= right.val }
+						i64 { return left >= right }
+						f64 { return left >= right }
+						else { e.error('invalid operands to >=: int literal and ${right.type_name()}') }
+					}
+				}
+				f64 {
+					match right {
+						Int { return left >= right.val }
+						Uint { return left >= right.val }
+						Float { return left >= right.val }
+						i64 { return left >= right }
+						f64 { return left >= right }
+						else { e.error('invalid operands to >=: float literal and ${right.type_name()}') }
+					}
+				}
+				else {
+					e.error('invalid operands to >=: ${left.type_name()} and ${right.type_name()}')
+				}
+			}
+		}
+		.le {
+			match left {
+				Int {
+					match right {
+						Int { return left.val <= right.val }
+						Uint { return left.val <= right.val }
+						Float { return left.val <= right.val }
+						i64 { return left.val <= right }
+						f64 { return left.val <= right }
+						else { e.error('invalid operands to <=: Int and ${right.type_name()}') }
+					}
+				}
+				Uint {
+					match right {
+						Int { return left.val <= right.val }
+						Uint { return left.val <= right.val }
+						Float { return left.val <= right.val }
+						i64 { return left.val <= right }
+						f64 { return left.val <= right }
+						else { e.error('invalid operands to <=: Uint and ${right.type_name()}') }
+					}
+				}
+				Float {
+					match right {
+						Int { return left.val <= right.val }
+						Uint { return left.val <= right.val }
+						Float { return left.val <= right.val }
+						i64 { return left.val <= right }
+						f64 { return left.val <= right }
+						else { e.error('invalid operands to <=: Float and ${right.type_name()}') }
+					}
+				}
+				i64 {
+					match right {
+						Int { return left <= right.val }
+						Uint { return left <= right.val }
+						Float { return left <= right.val }
+						i64 { return left <= right }
+						f64 { return left <= right }
+						else { e.error('invalid operands to <=: int literal and ${right.type_name()}') }
+					}
+				}
+				f64 {
+					match right {
+						Int { return left <= right.val }
+						Uint { return left <= right.val }
+						Float { return left <= right.val }
+						i64 { return left <= right }
+						f64 { return left <= right }
+						else { e.error('invalid operands to <=: float literal and ${right.type_name()}') }
+					}
+				}
+				else {
+					e.error('invalid operands to <=: ${left.type_name()} and ${right.type_name()}')
+				}
+			}
+		}
 		.eq {
 			match left {
 				Int {

--- a/vlib/v/eval/infix.v
+++ b/vlib/v/eval/infix.v
@@ -6,6 +6,18 @@ import v.ast
 
 fn (e &Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.Type) Object {
 	match op {
+		.and {
+			if left is bool && right is bool {
+				return left && right
+			}
+			e.error('invalid operands to &&: ${left.type_name()} and ${right.type_name()}')
+		}
+		.logical_or {
+			if left is bool && right is bool {
+				return left || right
+			}
+			e.error('invalid operands to ||: ${left.type_name()} and ${right.type_name()}')
+		}
 		.gt {
 			match left {
 				Int {

--- a/vlib/v/eval/stmt.v
+++ b/vlib/v/eval/stmt.v
@@ -4,16 +4,16 @@ import v.ast
 import v.token
 
 pub fn (mut e Eval) stmts(stmts []ast.Stmt) {
-	if e.execute_return_stmt {
+	if e.executed_return_stmt {
 		return
 	}
 	e.open_scope()
 	for stmt in stmts {
-		if !e.execute_return_stmt {
+		if !e.executed_return_stmt {
 			e.stmt(stmt)
 		}
 		if stmt is ast.Return {
-			e.execute_return_stmt = true
+			e.executed_return_stmt = true
 			break
 		}
 	}

--- a/vlib/v/eval/stmt.v
+++ b/vlib/v/eval/stmt.v
@@ -4,10 +4,16 @@ import v.ast
 import v.token
 
 pub fn (mut e Eval) stmts(stmts []ast.Stmt) {
+	if e.execute_return_stmt {
+		return
+	}
 	e.open_scope()
 	for stmt in stmts {
-		e.stmt(stmt)
-		if e.returning {
+		if !e.execute_return_stmt {
+			e.stmt(stmt)
+		}
+		if stmt is ast.Return {
+			e.execute_return_stmt = true
 			break
 		}
 	}

--- a/vlib/v/eval/tests/comptime_if_test.v
+++ b/vlib/v/eval/tests/comptime_if_test.v
@@ -47,3 +47,24 @@ fn test_comptime_if_without_func() {
 	dump(ret)
 	assert ret == []
 }
+
+fn test_comptime_if_infix() {
+	mut e := eval.create()
+
+	ret := e.run('const a =
+	\$if amd64 || aarch64 || arm64 || rv64 { "64bit" }
+	\$else \$if i386 || arm32 || rv32 { "32bit" }
+	\$else \$if s390x       { "s390x" }
+	\$else \$if ppc64le     { "ppc64le" }
+	\$else \$if loongarch64 { "loongarch64" }
+	\$else { "unknown" }
+
+	const b = 1.5
+
+	fn display() (string,f64) { println(a) println(b) return a,b } display()')!
+
+	dump(ret)
+	assert ret[0].string().len != 0
+	assert ret[0].string() != 'unknown'
+	assert ret[1].float_val() == 1.5
+}

--- a/vlib/v/eval/tests/if_test.v
+++ b/vlib/v/eval/tests/if_test.v
@@ -29,3 +29,33 @@ fn test_if_return() {
 	dump(ret1)
 	assert ret1[0].int_val() == 666
 }
+
+fn test_if_infix_return_early() {
+	mut e := eval.create()
+
+	ret := e.run('
+	fn display(a int, b int) int {
+		if a == 100 && b == 100 {
+			return 111
+		} else if a == 100 && b != 100 {
+			return 222
+		} else if a == 100 && b > 100 {
+			return 333
+		} else if a == 100 && b < 100 {
+			return 444
+		} else if a == 100 || b == 100 {
+			return 555
+		} else if a == 100 || b != 100 {
+			return 666
+		} else if a == 100 || b > 100 {
+			return 777
+		} else if a == 100 || b < 100 {
+			return 888
+		}
+		return 7171
+	}
+	display(200, 100)')!
+
+	dump(ret)
+	assert ret[0].int_val() == 555
+}

--- a/vlib/v/eval/tests/if_test.v
+++ b/vlib/v/eval/tests/if_test.v
@@ -35,6 +35,11 @@ fn test_if_infix_return_early() {
 
 	ret := e.run('
 	fn display(a int, b int) int {
+		mut k := false
+		if !k {
+			k = !k
+		}
+		println(k)
 		if a == 100 && b == 100 {
 			return 100
 		} else if a == 100 && b != 100 {

--- a/vlib/v/eval/tests/if_test.v
+++ b/vlib/v/eval/tests/if_test.v
@@ -36,26 +36,34 @@ fn test_if_infix_return_early() {
 	ret := e.run('
 	fn display(a int, b int) int {
 		if a == 100 && b == 100 {
-			return 111
+			return 100
 		} else if a == 100 && b != 100 {
-			return 222
+			return 101
 		} else if a == 100 && b > 100 {
-			return 333
+			return 102
 		} else if a == 100 && b < 100 {
-			return 444
+			return 103
+		} else if a == 100 && b >= 100 {
+			return 104
+		} else if a == 100 && b <= 100 {
+			return 105
 		} else if a == 100 || b == 100 {
-			return 555
+			return 106
 		} else if a == 100 || b != 100 {
-			return 666
+			return 107
 		} else if a == 100 || b > 100 {
-			return 777
+			return 108
 		} else if a == 100 || b < 100 {
-			return 888
+			return 109
+		} else if a == 100 || b >= 100 {
+			return 110
+		} else if a == 100 || b <= 100 {
+			return 111
 		}
 		return 7171
 	}
-	display(200, 100)')!
+	display(200, 101)')!
 
 	dump(ret)
-	assert ret[0].int_val() == 555
+	assert ret[0].int_val() == 107
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR:

1. add support for `&&`, `||`, `>=`, `<=`,`!`;
2. comptime infix expr support;
3. early function return.