### PR TITLE
fix 24974

### DIFF
--- a/vlib/net/http/build_request_headers_test.v
+++ b/vlib/net/http/build_request_headers_test.v
@@ -1,0 +1,11 @@
+module http
+
+fn test_build_request_headers_with_empty_body_adds_content_length_zero() {
+	// Create a request with no data.
+	mut req := Request{}
+	// Build the headers for it. Ensure that Content-Length: 0 is added
+	// for requests without a body, which is required by some servers.
+	// We use a POST request, as it is most likely to be affected by this.
+	headers := req.build_request_headers(.post, 'localhost', 80, '/')
+	assert headers.contains('Content-Length: 0\r\n')
+}

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -566,9 +566,10 @@ pub fn parse_multipart_form(body string, boundary string) (map[string]string, ma
 	mut files := map[string][]FileData{}
 	// TODO: do not use split, but only indexes, to reduce copying of potentially large data
 	sections := body.split(boundary)
-	fields := sections[1..sections.len - 1]
+	fields := sections#[1..sections.len - 1]
+	mut line_segments := []LineSegmentIndexes{cap: 100}
 	for field in fields {
-		mut line_segments := []LineSegmentIndexes{cap: 100}
+		line_segments.clear()
 		mut line_idx, mut line_start := 0, 0
 		for cidx, c in field {
 			if line_idx >= 6 {
@@ -582,6 +583,9 @@ pub fn parse_multipart_form(body string, boundary string) (map[string]string, ma
 			}
 		}
 		line_segments << LineSegmentIndexes{line_start, field.len}
+		if line_segments.len < 2 {
+			continue
+		}
 		line1 := field[line_segments[1].start..line_segments[1].end]
 		line2 := field[line_segments[2].start..line_segments[2].end]
 		disposition := parse_disposition(line1.trim_space())


### PR DESCRIPTION
- **tests: bump timeouts in cmd/tools/vtimeout_test.v to reduce false positives when the CI runners are slow**
- **net.http: fix panic in parse_multipart_form for invalid boundary (fix #24974)**
