### PR TITLE
log: level string shouldn't contain white space

### DIFF
--- a/vlib/log/common.v
+++ b/vlib/log/common.v
@@ -36,8 +36,8 @@ fn tag_to_console(l Level, short_tag bool) string {
 			.disabled { '' }
 			.fatal { term.red('FATAL') }
 			.error { term.red('ERROR') }
-			.warn { term.yellow('WARN ') }
-			.info { term.white('INFO ') }
+			.warn { term.yellow('WARN') }
+			.info { term.white('INFO') }
 			.debug { term.magenta('DEBUG') }
 		}
 	}
@@ -60,8 +60,8 @@ fn tag_to_file(l Level, short_tag bool) string {
 			.disabled { '     ' }
 			.fatal { 'FATAL' }
 			.error { 'ERROR' }
-			.warn { 'WARN ' }
-			.info { 'INFO ' }
+			.warn { 'WARN' }
+			.info { 'INFO' }
 			.debug { 'DEBUG' }
 		}
 	}


### PR DESCRIPTION
Minor adjustment to the logging module, the fixed width log level string is removed let 4 characters be themselves without any empty space suffix