### PR TITLE
archive.tar: fix typo in new_decompressor fn name

### DIFF
--- a/examples/archive/tar_gz_reader.v
+++ b/examples/archive/tar_gz_reader.v
@@ -149,7 +149,7 @@ fn main() {
 		ctx: ctx
 	}
 	mut untar := tar.new_untar(reader)
-	mut decompressor := tar.new_decompresor(untar)
+	mut decompressor := tar.new_decompressor(untar)
 	downloader := new_downloader(ctx.url)!
 	if ctx.chunks {
 		decompressor.read_chunks(downloader.data)!

--- a/vlib/archive/tar/reader.v
+++ b/vlib/archive/tar/reader.v
@@ -177,7 +177,7 @@ mut:
 
 // new_decompressor returns a Decompressor to decompress a tar.gz file
 // A given Untar with a registered Reader will read the blocks.
-pub fn new_decompresor(untar &Untar) &Decompressor {
+pub fn new_decompressor(untar &Untar) &Decompressor {
 	return &Decompressor{
 		untar: untar
 	}

--- a/vlib/archive/tar/reader_test.v
+++ b/vlib/archive/tar/reader_test.v
@@ -108,7 +108,7 @@ fn new_test_reader_gz(tar_gz_file string, debug bool) !&TestReader {
 	mut untar := Untar{
 		reader: reader
 	}
-	mut decompressor := new_decompresor(untar)
+	mut decompressor := new_decompressor(untar)
 	tar_gz := os.read_bytes('${testdata}/${tar_gz_file}')!
 	decompressor.read_all(tar_gz)!
 


### PR DESCRIPTION
This PR fixes typo in `archive.tar` `new_decompressor` fn name. It's unlikely that anyone has had time to use this module, so this shouldn't be a breaking change.