### PR TITLE
markused: improve the tracking of used closures

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -605,6 +605,7 @@ fn (t Tree) fn_decl(node ast.FnDecl) &Node {
 	obj.add_terse('is_unsafe', t.bool_node(node.is_unsafe))
 	obj.add_terse('is_markused', t.bool_node(node.is_markused))
 	obj.add_terse('is_file_translated', t.bool_node(node.is_file_translated))
+	obj.add_terse('is_closure', t.bool_node(node.is_closure))
 	obj.add_terse('receiver', t.struct_field(node.receiver))
 	obj.add('receiver_pos', t.pos(node.receiver_pos))
 	obj.add_terse('is_method', t.bool_node(node.is_method))

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -573,7 +573,7 @@ pub:
 pub struct AnonFn {
 pub mut:
 	decl           FnDecl
-	inherited_vars []Param
+	inherited_vars []Param         // note: closures have inherited_vars.len > 0
 	typ            Type            // the type of anonymous fn. Both .typ and .decl.name are auto generated
 	has_gen        map[string]bool // a map of the names of all generic anon functions, generated from it
 }
@@ -602,6 +602,7 @@ pub:
 	is_must_use           bool        // true, when @[must_use] is used on a fn. Calls to such functions, that ignore the return value, will cause warnings.
 	is_markused           bool        // true, when an explicit `@[markused]` tag was put on a fn; `-skip-unused` will not remove that fn
 	is_file_translated    bool        // true, when the file it resides in is `@[translated]`
+	is_closure            bool        // true, for actual closures like `fn [inherited] () {}` . It is false for normal anonymous functions, and for named functions/methods too.
 	receiver              StructField // TODO: this is not a struct field
 	receiver_pos          token.Pos   // `(u User)` in `fn (u User) name()` position
 	is_method             bool

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -35,6 +35,7 @@ pub mut:
 	used_veb_types []Type          // veb context types, filled in by checker
 	used_maps      int             // how many times maps were used, filled in by markused
 	used_none      int             // how many times `none` was used, filled in by markused
+	used_closures  int             // number of used closures, either directly with `fn [state] () {}`, or indirectly (though `instance.method` promotions)
 	// json             bool            // json is imported
 	comptime_calls map[string]bool // resolved name to call on comptime
 	comptime_syms  map[Type]bool   // resolved syms (generic)

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -372,7 +372,6 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 		eprintln('>> t.used_syms: ${table.used_features.used_syms.keys()}')
 		eprintln('>> t.used_maps: ${table.used_features.used_maps}')
 		eprintln('>> t.used_closures: ${table.used_features.used_closures}')
-		eprintln('>> t.imports: ${table.imports}')
 	}
 	if trace_skip_unused_just_unused_fns {
 		all_fns_keys := all_fns.keys()

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -363,13 +363,16 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 	table.used_features.used_consts = walker.used_consts.move()
 	table.used_features.used_globals = walker.used_globals.move()
 	table.used_features.used_syms = walker.used_syms.move()
+	table.used_features.used_closures = walker.used_closures
 
 	if trace_skip_unused {
 		eprintln('>> t.used_fns: ${table.used_features.used_fns.keys()}')
 		eprintln('>> t.used_consts: ${table.used_features.used_consts.keys()}')
 		eprintln('>> t.used_globals: ${table.used_features.used_globals.keys()}')
 		eprintln('>> t.used_syms: ${table.used_features.used_syms.keys()}')
-		eprintln('>> walker.table.used_features.used_maps: ${walker.table.used_features.used_maps}')
+		eprintln('>> t.used_maps: ${table.used_features.used_maps}')
+		eprintln('>> t.used_closures: ${table.used_features.used_closures}')
+		eprintln('>> t.imports: ${table.imports}')
 	}
 	if trace_skip_unused_just_unused_fns {
 		all_fns_keys := all_fns.keys()

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -914,6 +914,7 @@ fn (mut p Parser) anon_fn() ast.AnonFn {
 			return_type_pos: return_type_pos
 			params:          params
 			is_variadic:     is_variadic
+			is_closure:      inherited_vars.len > 0
 			is_method:       false
 			generic_names:   generic_names
 			is_anon:         true

--- a/vlib/v/parser/module.v
+++ b/vlib/v/parser/module.v
@@ -50,9 +50,7 @@ fn (mut p Parser) register_auto_import(alias string) {
 	}
 	if alias !in p.imports {
 		p.imports[alias] = alias
-		if alias !in p.table.imports {
-			p.table.imports << alias
-		}
+		p.table.imports << alias
 		node := ast.Import{
 			source_name: alias
 			pos:         p.tok.pos()
@@ -289,10 +287,10 @@ fn (mut p Parser) import_stmt() ast.Import {
 	if p.tok.kind == .semicolon {
 		p.check(.semicolon)
 	}
-	if mod_name !in p.table.imports {
-		p.table.imports << mod_name
-	}
+	// if mod_name !in p.table.imports {
+	p.table.imports << mod_name
 	p.ast_imports << import_node
+	// }
 	return import_node
 }
 

--- a/vlib/v/parser/module.v
+++ b/vlib/v/parser/module.v
@@ -50,7 +50,9 @@ fn (mut p Parser) register_auto_import(alias string) {
 	}
 	if alias !in p.imports {
 		p.imports[alias] = alias
-		p.table.imports << alias
+		if alias !in p.table.imports {
+			p.table.imports << alias
+		}
 		node := ast.Import{
 			source_name: alias
 			pos:         p.tok.pos()
@@ -287,10 +289,10 @@ fn (mut p Parser) import_stmt() ast.Import {
 	if p.tok.kind == .semicolon {
 		p.check(.semicolon)
 	}
-	// if mod_name !in p.table.imports {
-	p.table.imports << mod_name
+	if mod_name !in p.table.imports {
+		p.table.imports << mod_name
+	}
 	p.ast_imports << import_node
-	// }
 	return import_node
 }
 


### PR DESCRIPTION
- **ci,tools: implement support for VREPEAT_SILENT=1 and `v repeat -S`, to only show the summary of the runs, without the progress lines**
- **markused,ast: improve the tracking of closure usages (including instance.method that uses an implicit closure)**