### PR TITLE
cgen: fix generic key's type with `in` operation(fix #24983)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -614,7 +614,15 @@ fn (mut g Gen) infix_expr_in_op(node ast.InfixExpr) {
 	} else if right.unaliased_sym.kind == .map {
 		g.write('_IN_MAP(')
 		if !left.typ.is_ptr() {
-			styp := g.styp(node.left_type)
+			mut sym_map := g.table.sym(node.right_type)
+			if sym_map.info is ast.Alias {
+				sym_map = g.table.sym((sym_map.info as ast.Alias).parent_type)
+			}
+			styp := g.styp(if sym_map.info is ast.Map {
+				(sym_map.info as ast.Map).key_type
+			} else {
+				node.left_type
+			})
 			g.write('ADDR(${styp}, ')
 			g.expr(node.left)
 			g.write(')')

--- a/vlib/v/tests/builtin_maps/map_generic_keys_with_in_op_test.v
+++ b/vlib/v/tests/builtin_maps/map_generic_keys_with_in_op_test.v
@@ -1,0 +1,18 @@
+import datatypes
+
+fn x() {
+	mut set1 := datatypes.Set[string]{}
+	set1.add('')
+	assert set1.exists('')
+}
+
+fn y() {
+	mut set2 := datatypes.Set[int]{}
+	set2.add(1)
+	assert set2.exists(1)
+}
+
+fn test_main() {
+	x()
+	y()
+}


### PR DESCRIPTION
Fix #24983 .