### PR TITLE
db.sqlite: fix get_text to trim data after (including) first 0 character

### DIFF
--- a/vlib/db/sqlite/sqlite.c.v
+++ b/vlib/db/sqlite/sqlite.c.v
@@ -122,6 +122,8 @@ fn C.sqlite3_column_count(&C.sqlite3_stmt) int
 
 fn C.sqlite3_column_type(&C.sqlite3_stmt, int) int
 
+fn C.sqlite3_column_bytes(&C.sqlite3_stmt, int) int
+
 //
 fn C.sqlite3_errstr(int) &char
 

--- a/vlib/db/sqlite/stmt.c.v
+++ b/vlib/db/sqlite/stmt.c.v
@@ -74,7 +74,8 @@ fn (stmt &Stmt) get_text(idx int) ?string {
 		if b == &char(unsafe { nil }) {
 			return ''
 		}
-		return unsafe { b.vstring() }
+		l := C.sqlite3_column_bytes(stmt.stmt, idx)
+		return unsafe { b.vstring_with_len(l) }
 	}
 }
 


### PR DESCRIPTION
When using SQLite and selecting a text column, C.strlen is used to calculate the string's length. Due to C.strlen stopping at the first 0 character, data can get cut off. This PR modifies the get_text function to use C.sqlite3_column_bytes instead of C.strlen to calculate the strings length, preserving the entire data.