### PR TITLE
cgen, ci: fix closures on s390x, ppc64le and loongarch64 platforms, add test to s390x CI

### DIFF
--- a/.github/workflows/s390x_linux_ci.yml
+++ b/.github/workflows/s390x_linux_ci.yml
@@ -47,3 +47,4 @@ jobs:
             file ./v
             ls -la ./v
             ./v test vlib/builtin vlib/os vlib/encoding/binary
+            ./v test vlib/v/tests/fns/closure_test.v

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -1359,6 +1359,9 @@ fn (mut g Gen) comptime_if_to_ifdef(name string, is_comptime_option bool) !strin
 		'rv64', 'riscv64' {
 			return '__V_rv64'
 		}
+		'rv32', 'riscv32' {
+			return '__V_rv32'
+		}
 		's390x' {
 			return '__V_s390x'
 		}


### PR DESCRIPTION
Currently, C code is generated in such a way that all platforms after `riscv32` don't receive control, and as a result, closures crash.

```
#if defined(__V_amd64)
#elif defined(__V_x86)
#elif defined(__V_arm64)
#elif defined(__V_arm32)
#elif defined(__V_rv64)
#elif defined(true)
#elif defined(__V_s390x)
#elif defined(__V_ppc64le)
#elif defined(__V_loongarch64)
#else
#endif
```

The patch fixes this, and adding a existing test to s390x CI minimizes the consequences of similar situations in the future.