### PR TITLE
checker: add comptime support for s390x, ppc64le and loongarch64 platforms

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -1012,6 +1012,9 @@ fn (mut c Checker) comptime_if_cond(mut cond ast.Expr, pos token.Pos) ComptimeBr
 					'arm32' { return if c.pref.arch == .arm32 { .eval } else { .skip } }
 					'rv64' { return if c.pref.arch == .rv64 { .eval } else { .skip } }
 					'rv32' { return if c.pref.arch == .rv32 { .eval } else { .skip } }
+					's390x' { return if c.pref.arch == .s390x { .eval } else { .skip } }
+					'ppc64le' { return if c.pref.arch == .ppc64le { .eval } else { .skip } }
+					'loongarch64' { return if c.pref.arch == .loongarch64 { .eval } else { .skip } }
 					else { return .unknown }
 				}
 			} else if cname in ast.valid_comptime_if_cpu_features {


### PR DESCRIPTION
A trivial patch fixes two problems:

1. Currently C code `always` contains closure assembler code for these three platforms.
```
#if defined(__V_amd64)
#elif defined(__V_x86)
#elif defined(__V_arm64)
#elif defined(__V_arm32)
#elif defined(__V_rv64)
#elif defined(__V_rv32)
#elif defined(__V_s390x)
        _t2 = new_array_from_c_array_noscan(6, 6, sizeof(u8), _MOV((u8[6]){((u8)(0xB3)), 0xCD, 0x00, 0x2F, 0x07, 0xFE}));
        ;
#elif defined(__V_ppc64le)
        _t2 = new_array_from_c_array_noscan(8, 8, sizeof(u8), _MOV((u8[8]){((u8)(0x66)), 0x00, 0xc3, 0x7d, 0x20, 0x00, 0x80, 0x4e}));
        ;
#elif defined(__V_loongarch64)
        _t2 = new_array_from_c_array_noscan(8, 8, sizeof(u8), _MOV((u8[8]){((u8)(0x04)), 0xB9, 0x14, 0x01, 0x20, 0x00, 0x00, 0x4C}));
        ;
#else
        _t2 = __new_array_with_default_noscan(0, 0, sizeof(u8), 0);
        ;
#endif
        _const_builtin__closure__closure_get_data_bytes = _t2;
```

2. Fix the existing test [comptime_arch_test.v](https://github.com/vlang/v/blob/master/vlib/v/tests/comptime/comptime_arch_test.v)