### PR TITLE
ci: add linux_arm64 to release_ci.yml

### DIFF
--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -24,13 +24,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14, windows-latest]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-13, macos-14, windows-latest]
         include:
           - os: ubuntu-22.04
             cc: gcc
           - os: ubuntu-22.04
             target: linux
             artifact: v_linux.zip
+          - os: ubuntu-22.04-arm
+            cc: gcc
+          - os: ubuntu-22.04-arm
+            target: linux_arm64
+            artifact: v_linux_arm64.zip
           - os: macos-13
             cc: clang
           - os: macos-13
@@ -113,6 +118,7 @@ jobs:
           artifacts: |
             ~/work/v/v/windows/v_windows.zip
             ~/work/v/v/linux/v_linux.zip
+            ~/work/v/v/linux_arm64/v_linux_arm64.zip
             ~/work/v/v/macos_arm64/v_macos_arm64.zip
             ~/work/v/v/macos_x86_64/v_macos_x86_64.zip
           tag: ${{ github.ref_name }}


### PR DESCRIPTION
Add release build for Linux on `aarch64`.