### PR TITLE
cgen: fix asm stmt separators

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3255,7 +3255,7 @@ fn (mut g Gen) asm_stmt(stmt ast.AsmStmt) {
 		}
 
 		if !template.is_label {
-			g.write(';')
+			g.write('\\n\\t')
 		}
 		g.writeln('"')
 	}

--- a/vlib/v/slow_tests/assembly/stmt_separator_test.amd64.v
+++ b/vlib/v/slow_tests/assembly/stmt_separator_test.amd64.v
@@ -1,0 +1,48 @@
+import os
+import time
+
+const asm_file_content = '
+fn asm_fn() {
+	mut x := u64(0)
+	mut y := u64(0)
+	mut z := u64(0)
+	mut hi := u64(0)
+	mut lo := u64(0)
+	asm amd64 {
+		mulq rdx
+		addq rax, z
+		adcq rdx, 0
+		; =a (lo)
+		=d (hi)
+		; a (x)
+		  d (y)
+		  r (z)
+		; cc
+	}
+}
+
+fn main() {
+	asm_fn()
+}
+'
+
+const vexe = os.getenv('VEXE')
+const v_file = os.join_path(os.vtmp_dir(), 'generated_stmt_separator.amd64.v')
+const genexe_file = os.join_path(os.vtmp_dir(), 'generated_stmt_separator.exe')
+const c_file = os.join_path(os.vtmp_dir(), 'generated_stmt_separator.exe.tmp.c')
+
+fn test_stmt_separator() {
+	os.write_file(v_file, asm_file_content)!
+	eprintln('Compiling...')
+	compile_cmd := '${os.quoted_path(vexe)} -cg -skip-running -no-rsp -keepc -o ${os.quoted_path(genexe_file)} ${os.quoted_path(v_file)}'
+	eprintln('> compile_cmd: ${compile_cmd}')
+	time.sleep(1000 * time.millisecond) // improve chances of working on windows
+	compile_res := os.system(compile_cmd)
+	assert compile_res == 0
+
+	content := os.read_file(c_file)!
+	os.rm(v_file)!
+	os.rm(genexe_file)!
+	os.rm(c_file)!
+	assert content.contains('addq %[z], %%rax\\n\\t')
+}

--- a/vlib/v/slow_tests/assembly/stmt_separator_test.amd64.v
+++ b/vlib/v/slow_tests/assembly/stmt_separator_test.amd64.v
@@ -44,5 +44,5 @@ fn test_stmt_separator() {
 	os.rm(v_file)!
 	os.rm(genexe_file)!
 	os.rm(c_file)!
-	assert content.contains('addq %[z], %%rax\\n\\t')
+	assert content.contains(r'addq %[z], %%rax\n\t')
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

```
"mul %[lo], %[x], %[y];"
"umulh %[hi], %[x], %[y];"
```

This violates GCC/Clang's inline assembly syntax requirements. And this PR replaced semicolons with proper `\n\t` separators.

```
"mul %[lo], %[x], %[y]\n\t"
"umulh %[hi], %[x], %[y]\n\t"
```