### PR TITLE
cgen: fix codegen for option void fn return block unwrap

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7106,7 +7106,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 								g.writeln(' }, (${option_name}*)&${cvar_name}, sizeof(${cast_typ}));')
 								g.indent--
 								return
-							} else {
+							} else if return_type.clear_option_and_result() != ast.void_type {
 								g.write('*(${cast_typ}*) ${cvar_name}${tmp_op}data = ')
 							}
 						}

--- a/vlib/v/tests/options/option_or_expr_dump_test.v
+++ b/vlib/v/tests/options/option_or_expr_dump_test.v
@@ -1,0 +1,8 @@
+fn f() ? {
+	println('hello')
+	return none
+}
+
+fn test_main() {
+	f() or { dump(err) }
+}


### PR DESCRIPTION
Fix #25074