### PR TITLE
cgen: fix codegen for passing int from selector to voidptr expect arg

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2707,6 +2707,8 @@ fn (mut g Gen) ref_or_deref_arg(arg ast.CallArg, expected_type ast.Type, lang as
 						}
 						if arg.expr.is_as_cast() {
 							g.inside_smartcast = true
+						} else if arg_typ_sym.is_int() {
+							g.write('(voidptr)&')
 						} else {
 							g.write('ADDR(${g.styp(atype)}, ')
 							needs_closing = true

--- a/vlib/v/tests/concurrency/chan_try_push_int_test.v
+++ b/vlib/v/tests/concurrency/chan_try_push_int_test.v
@@ -1,0 +1,15 @@
+struct Foo {
+mut:
+	value int = 123
+}
+
+fn test_main() {
+	shared m := Foo{}
+	ch := chan int{cap: 1}
+	ch.try_push(rlock m {
+		m.value
+	})
+	mut tmp := int(0)
+	ch.try_pop(mut tmp)
+	assert tmp == 123
+}


### PR DESCRIPTION
Fix #25081