### PR TITLE
ast:return cached_name.clone(), as auto_str_methods free it

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -525,8 +525,13 @@ pub fn (x Expr) str() string {
 			return 'spawn ${x.call_expr}'
 		}
 		Ident {
-			// `util.strip_main_name` will clone `x.name`
-			return util.strip_main_name(x.name)
+			if x.cached_name == '' {
+				unsafe {
+					x.cached_name = util.strip_main_name(x.name)
+				}
+			}
+			// This clone may freed by auto str()
+			return x.cached_name.clone()
 		}
 		IfExpr {
 			mut parts := []string{}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

`cached_name` try to maintain a one-time alloc string for `ast.Ident`, but as the `auto_str_methods` function will generate code free it, so this can't work.

for example:

```c
string indent_v__ast__IfBranch_str(v__ast__IfBranch it, int indent_count) {
        string indents = string_repeat(_S("    "), indent_count);
        string _t1 = indent_v__token__Pos_str(it.pos, indent_count + 1);
        string _t2 = indent_v__token__Pos_str(it.body_pos, indent_count + 1);
        string _t3 = indent_Array_v__ast__Comment_str(it.comments, indent_count + 1);
        string _t4 = v__ast__Expr_str(&it.cond);
        string _t5 = indent_Array_v__ast__Stmt_str(it.stmts, indent_count + 1);
        string _t6 = isnil(it.scope) ? _S("nil") : (indent_count > 25)? _S("<probably circular>") : v__ast__Scope_str(it.scope);
        string res = str_intp( 31, _MOV((StrIntpData[]){
                {_S("ast.IfBranch{\n"), 0, {.d_c=0}},
                {_SLIT0, 0xfe10, {.d_s=indents}}, {_S("    pos: "), 0, {.d_c=0}}, {_S(""), 16, {.d_s=_t1}}, {_S(""), 0, {.d_c=0}},
                {_S("\n"), 0xfe10, {.d_s=indents}}, {_S("    body_pos: "), 0, {.d_c=0}}, {_S(""), 16, {.d_s=_t2}}, {_S(""), 0, {.d_c=0}},
                {_S("\n"), 0xfe10, {.d_s=indents}}, {_S("    comments: "), 0, {.d_c=0}}, {_S(""), 16, {.d_s=_t3}}, {_S(""), 0, {.d_c=0}},
                {_S("\n"), 0xfe10, {.d_s=indents}}, {_S("    cond: "), 0, {.d_c=0}}, {_S(""), 16, {.d_s=_t4}}, {_S(""), 0, {.d_c=0}},
                {_S("\n"), 0xfe10, {.d_s=indents}}, {_S("    pkg_exist: "), 0, {.d_c=0}}, {_S(""), 16, {.d_s=it.pkg_exist ? _S("true") : _S("false")}}, {_S(""), 0, {.d_c=0}},
                {_S("\n"), 0xfe10, {.d_s=indents}}, {_S("    stmts: "), 0, {.d_c=0}}, {_S(""), 16, {.d_s=_t5}}, {_S(""), 0, {.d_c=0}},
                {_S("\n"), 0xfe10, {.d_s=indents}}, {_S("    scope: &"), 0, {.d_c=0}}, {_S(""), 16, {.d_s=_t6}}, {_S(""), 0, {.d_c=0}},
                {_S("\n"), 0xfe10, {.d_s=indents}}, {_S("}"), 0, {.d_c=0}},
        }));
        string_free(&_t6);
        string_free(&_t5);
        string_free(&_t4);
        string_free(&_t3);
        string_free(&_t2);
        string_free(&_t1);
        string_free(&indents);
        return res;
}
```

Note that `_t4 = v__ast__Expr_str(&it.cond)` will point to `cached_name`, and it is freed by this function, this will cause following use of `cached_name` fail.