### PR TITLE
checker: ignore type compatibility check for ComptimeSelector in infix expr

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -886,8 +886,10 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 			if node.right is ast.None && left_is_option {
 				return ast.bool_type
 			}
-			c.error('infix expr: cannot use `${right_sym.name}` (right expression) as `${left_sym.name}`',
-				left_right_pos)
+			if node.left !is ast.ComptimeSelector {
+				c.error('infix expr: cannot use `${right_sym.name}` (right expression) as `${left_sym.name}`',
+					left_right_pos)
+			}
 		} else if left_type.is_ptr() {
 			for_ptr_op := c.table.type_is_for_pointer_arithmetic(left_type)
 			if left_sym.language == .v && !c.pref.translated && !c.inside_unsafe && !for_ptr_op

--- a/vlib/v/tests/comptime/comptime_selector_field_compare_test.v
+++ b/vlib/v/tests/comptime/comptime_selector_field_compare_test.v
@@ -1,0 +1,22 @@
+struct Struct {
+	s string
+	i int
+}
+
+fn test_comptime_selector_field_compare() {
+	tst := Struct{
+		s: 'tst-s'
+		i: 42
+	}
+
+	mut result := false
+
+	$for field in Struct.fields {
+		$if field.typ !is int && field.typ is string {
+			if tst.$(field.name) == 'tst-s' {
+				result = true
+			}
+		}
+	}
+	assert result
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #24938

```v
struct Struct {
	s string
	i int
}

fn test_comptime_selector_field_compare() {
	tst := Struct{
		s: 'tst-s'
		i: 42
	}

	mut result := false

	$for field in Struct.fields {
		$if field.typ !is int && field.typ is string {
			if tst.$(field.name) == 'tst-s' {
				result = true
			}
		}
	}
	assert result
}
```

For checker, the first time `tst.$(field.name)` is a `string` type, and the second time `tst.$(field.name)` is a `int` type, so I think skip the compatibility check for `ComptimeSelector` is a workaround for right now.

A fully fix for this involve in evaluating comptime conditions in checker, then for `false` branch, just not execute the stmts in it.