### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/benchmark_footprint_json_decode.yml
+++ b/.github/workflows/benchmark_footprint_json_decode.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build V
         run: make -j4 && ./v symlink

--- a/.github/workflows/benchmark_footprint_json_encode.yml
+++ b/.github/workflows/benchmark_footprint_json_encode.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build V
         run: make -j4 && ./v symlink

--- a/.github/workflows/bootstrapping_ci.yml
+++ b/.github/workflows/bootstrapping_ci.yml
@@ -39,7 +39,7 @@ jobs:
       VFLAGS: -no-parallel
       B_LFLAGS: -lm -lpthread
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Build V

--- a/.github/workflows/c2v_ci.yml
+++ b/.github/workflows/c2v_ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make && ./v symlink
 
@@ -75,7 +75,7 @@ jobs:
       LIBGL_ALWAYS_SOFTWARE: true
       VTMP: /tmp
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make && ./v symlink
 

--- a/.github/workflows/cross_ci.yml
+++ b/.github/workflows/cross_ci.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       VFLAGS: -cc clang
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 10
       - name: Build V
@@ -57,7 +57,7 @@ jobs:
     env:
       VFLAGS: -cc tcc -no-retry-compilation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 10
       - name: Build v
@@ -103,7 +103,7 @@ jobs:
     runs-on: windows-2025
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build
         run: |
           echo %VFLAGS%

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -9,7 +9,7 @@ jobs:
     env:
       VFLAGS: -cc msvc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build
         run: |
           echo %VFLAGS%

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -35,7 +35,7 @@ jobs:
         - ${{github.workspace}}:/opt/vlang
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Show Environment
         run: |
           echo "PWD:"
@@ -65,7 +65,7 @@ jobs:
         - ${{github.workspace}}:/opt/vlang
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Build V
         run: echo "$VFLAGS" && make -j4 && ./v -cg -o v cmd/v
       - name: Verify `v test` works

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make
       - name: Install dependencies (some examples show how to use sqlite and the x11 clipboard)
@@ -41,12 +41,12 @@ jobs:
     env:
       MOPTIONS: --diff --deprecated --relative-paths --exclude /vlib/v/ --exclude /builtin/linux_bare/ --exclude /testdata/ --exclude /tests/
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make
 
       - name: Checkout previous v
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: vlang/v
           ref: master # important
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make
       - name: Check doc comment dots for some key modules

--- a/.github/workflows/freebsd_ci.yml
+++ b/.github/workflows/freebsd_ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Tests on FreeBSD with tcc
         id: tests-freebsd-tcc
         uses: cross-platform-actions/action@v0.29.0
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Tests on FreeBSD with clang
         id: tests-freebsd-clang
         uses: cross-platform-actions/action@v0.29.0
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Tests on FreeBSD with gcc
         id: tests-freebsd-gcc
         uses: cross-platform-actions/action@v0.29.0

--- a/.github/workflows/gen_vc_ci.yml
+++ b/.github/workflows/gen_vc_ci.yml
@@ -31,7 +31,7 @@ jobs:
   build-vc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4
       - name: Regenerate v.c and v_win.c

--- a/.github/workflows/gg_regressions_ci.yml
+++ b/.github/workflows/gg_regressions_ci.yml
@@ -31,7 +31,7 @@ jobs:
       VTMP: /tmp
     steps:
       - name: Checkout V
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build local v
         run: make -j4 && ./v symlink

--- a/.github/workflows/hub_docker_ci.yml
+++ b/.github/workflows/hub_docker_ci.yml
@@ -23,7 +23,7 @@ jobs:
         os: [debian, alpine]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: 'vlang/docker'
 

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       VFLAGS: -cc tcc -no-retry-compilation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build v
         run: make -j4 && ./v symlink
       - name: Build v with -prealloc
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 121
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
       - name: All code is formatted
@@ -136,7 +136,7 @@ jobs:
     env:
       VFLAGS: -cc clang
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
       - name: All code is formatted

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       VFLAGS: -cc clang
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
       - name: Test symlink

--- a/.github/workflows/module_docs_ci.yml
+++ b/.github/workflows/module_docs_ci.yml
@@ -32,7 +32,7 @@ jobs:
   build-module-docs:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
       - name: Install markdown from vpm

--- a/.github/workflows/module_docs_lint.yml
+++ b/.github/workflows/module_docs_lint.yml
@@ -12,7 +12,7 @@ jobs:
   lint-module-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check Formatting
         uses: creyD/prettier_action@v4.6
         with:

--- a/.github/workflows/more_extensive_but_slower_tests_ci.yml
+++ b/.github/workflows/more_extensive_but_slower_tests_ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 121
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build V
         if: runner.os != 'Windows'

--- a/.github/workflows/native_backend_ci.yml
+++ b/.github/workflows/native_backend_ci.yml
@@ -54,7 +54,7 @@ jobs:
     env:
       VJOBS: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make && ./v symlink
       - name: Install linker
@@ -69,7 +69,7 @@ jobs:
     env:
       VJOBS: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V (Windows)
         run: ./make.bat && ./v symlink
       - name: Rebuild V with -g, for better stacktraces on compiler panics

--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Tests on OpenBSD with tcc
         id: tests-openbsd-tcc
         uses: cross-platform-actions/action@v0.29.0
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Tests on OpenBSD with clang
         id: tests-openbsd-clang
         uses: cross-platform-actions/action@v0.29.0
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Tests on OpenBSD with gcc
         id: tests-openbsd-gcc
         uses: cross-platform-actions/action@v0.29.0

--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Environment info
@@ -47,11 +47,11 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout V ${{ github.head_ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: v
       - name: Checkout V master
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: vlang/v
           path: vmaster
@@ -71,7 +71,7 @@ jobs:
     env:
       VFLAGS: -cc gcc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Environment info
         run: echo "$VFLAGS $GITHUB_SHA $GITHUB_REF"
       - name: Build local v
@@ -87,7 +87,7 @@ jobs:
     env:
       VFLAGS: -cc gcc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Environment info
         run: echo "$VFLAGS $GITHUB_SHA $GITHUB_REF"
       - name: Build local v
@@ -111,7 +111,7 @@ jobs:
     env:
       VFLAGS: -cc tcc -no-retry-compilation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 10
       - name: Build v
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 121
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build local v
         run: |
           make -j4 && ./v symlink

--- a/.github/workflows/paths_ci.yml
+++ b/.github/workflows/paths_ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           path: '你好 my $path, @с интервали'
@@ -54,7 +54,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: '你好 my $path, @с интервали'
           persist-credentials: false
@@ -94,7 +94,7 @@ jobs:
     ####### D:\a\v\v\你好 my $path, @с интервали: No such file or directory
     ## and that happens even for gcc builds, not just tcc ones
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: 'path with some $punctuation, and some spaces'
           persist-credentials: false

--- a/.github/workflows/periodic_ci.yml
+++ b/.github/workflows/periodic_ci.yml
@@ -29,7 +29,7 @@ jobs:
       VFLAGS: -cc ${{ matrix.cc }}
       V_CI_PERIODIC: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build
         if: runner.os != 'Windows'
         run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor

--- a/.github/workflows/puzzle_vibes_ci.yml
+++ b/.github/workflows/puzzle_vibes_ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make && ./v symlink
 

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -54,7 +54,7 @@ jobs:
             artifact: v_windows.zip
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Compile release binaries
         if: runner.os != 'Windows'
         run: |

--- a/.github/workflows/riscv64_linux_ci.yml
+++ b/.github/workflows/riscv64_linux_ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: Build on ubuntu-24.04 riscv64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: uraimo/run-on-arch-action@v3
         name: Run commands
         id: runcmd

--- a/.github/workflows/s390x_linux_ci.yml
+++ b/.github/workflows/s390x_linux_ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: Build on ubuntu-22.04 s390x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: uraimo/run-on-arch-action@v3
         name: Run commands
         id: runcmd

--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -88,7 +88,7 @@ jobs:
       UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1:print_suppressions=0:suppressions=/home/runner/work/v/v/.github/workflows/run_sanitizers_undefined.suppressions
       VNATIVE_SKIP_LIBC_VV: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
       - name: Ensure code is well formatted
@@ -117,7 +117,7 @@ jobs:
       UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1:print_suppressions=0:suppressions=/home/runner/work/v/v/.github/workflows/run_sanitizers_undefined.suppressions
       VNATIVE_SKIP_LIBC_VV: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
       - name: Ensure code is well formatted
@@ -146,7 +146,7 @@ jobs:
       LSAN_OPTIONS: max_leaks=1:print_suppressions=0:suppressions=/home/runner/work/v/v/.github/workflows/run_sanitizers_leak.suppressions
       VNATIVE_SKIP_LIBC_VV: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
       - name: Ensure code is well formatted
@@ -176,7 +176,7 @@ jobs:
       VJOBS: 1
       VNATIVE_SKIP_LIBC_VV: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build
         run: |
           echo %VFLAGS%
@@ -202,7 +202,7 @@ jobs:
       LSAN_OPTIONS: max_leaks=1:print_suppressions=0:suppressions=/home/runner/work/v/v/.github/workflows/run_sanitizers_leak.suppressions
       VNATIVE_SKIP_LIBC_VV: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
       - name: Ensure code is well formatted
@@ -232,7 +232,7 @@ jobs:
       VJOBS: 1
       VNATIVE_SKIP_LIBC_VV: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
       - name: Ensure code is well formatted

--- a/.github/workflows/sdl_ci.yml
+++ b/.github/workflows/sdl_ci.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       VFLAGS: -cc tcc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make && sudo ./v symlink
 

--- a/.github/workflows/symlink_ci.yml
+++ b/.github/workflows/symlink_ci.yml
@@ -23,7 +23,7 @@ jobs:
         os: [ubuntu-24.04, macos-13]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4
       - name: Symlink
@@ -64,7 +64,7 @@ jobs:
         flags: ['', '-githubci']
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: ./make.bat
       - name: Symlink

--- a/.github/workflows/termux_ci.yml
+++ b/.github/workflows/termux_ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build and test in Termux
         run: |
           set -o xtrace

--- a/.github/workflows/time_ci.yml
+++ b/.github/workflows/time_ci.yml
@@ -22,7 +22,7 @@ jobs:
   time-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make
       - name: Test time functions in a timezone UTC-12
@@ -39,7 +39,7 @@ jobs:
   time-macos:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make
       - name: Test time functions in a timezone UTC-12
@@ -56,7 +56,7 @@ jobs:
   time-windows:
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: .\make.bat
       - name: Test time functions in a timezone UTC-12

--- a/.github/workflows/toml_ci.yml
+++ b/.github/workflows/toml_ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
       - name: Install dependencies

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -32,7 +32,7 @@ jobs:
     env:
       VFLAGS: -cc ${{ matrix.cc }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
       - name: Code in cmd/ is formatted
@@ -71,7 +71,7 @@ jobs:
     env:
       VFLAGS: -cc ${{ matrix.cc }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
       - name: Check build-tools
@@ -90,7 +90,7 @@ jobs:
     env:
       VFLAGS: -cc ${{ matrix.cc }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: ./make.bat -${{ matrix.cc }} && ./v -o v2.exe cmd/v && ./v2 -showcc -o v.exe cmd/v && ./v doctor
       - name: Check build tools
@@ -114,7 +114,7 @@ jobs:
         - ${{github.workspace}}:/opt/vlang
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v -cg -o v cmd/v
       - name: Ensure git commands can be used with no prompts on modern Git versions

--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 121
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build V
         id: build
@@ -237,7 +237,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make && ./v symlink
       - name: Build vpm

--- a/.github/workflows/vab_ci.yml
+++ b/.github/workflows/vab_ci.yml
@@ -33,7 +33,7 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
 
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
 

--- a/.github/workflows/vinix_ci.yml
+++ b/.github/workflows/vinix_ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
 

--- a/.github/workflows/vpm_ci.yml
+++ b/.github/workflows/vpm_ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: vlang
       - name: Show git version

--- a/.github/workflows/vsl_and_vtl_compile_ci.yml
+++ b/.github/workflows/vsl_and_vtl_compile_ci.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       VFLAGS: -no-parallel
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         id: build
         run: make && sudo ./v symlink
@@ -65,7 +65,7 @@ jobs:
       # (a warning on Linux, but an error on macOS).
       TERM: xterm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         id: build
         run: make && sudo ./v symlink

--- a/.github/workflows/vup_works.yml
+++ b/.github/workflows/vup_works.yml
@@ -41,7 +41,7 @@ jobs:
     env:
       VDIR: /tmp/v_from_release_zip
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build v
         run: make && ./v symlink && ./v version
 

--- a/.github/workflows/wasm_backend_ci.yml
+++ b/.github/workflows/wasm_backend_ci.yml
@@ -53,7 +53,7 @@ jobs:
     env:
       VTEST_ONLY: wasm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build V
         if: runner.os != 'Windows'
         run: make -j4

--- a/.github/workflows/websockets_ci.yml
+++ b/.github/workflows/websockets_ci.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       VFLAGS: -cc tcc -no-retry-compilation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build v
         run: |
           echo "$VFLAGS"

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       VFLAGS: -cc gcc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Show tool versions
         run: |
           gcc --version
@@ -97,7 +97,7 @@ jobs:
     env:
       VFLAGS: -cc msvc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build
         run: |
           echo %VFLAGS%
@@ -143,7 +143,7 @@ jobs:
     env:
       VFLAGS: -cc tcc -no-retry-compilation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build with make.bat -tcc
         run: |
           .\make.bat -tcc

--- a/.github/workflows/workflow_lint.yml
+++ b/.github/workflows/workflow_lint.yml
@@ -18,7 +18,7 @@ jobs:
   lint-yml-workflows:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Verify formatting
         uses: creyD/prettier_action@v4.6
         with:


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0