### PR TITLE
ci: fix dependencies for modules with examples (libasound2-dev is needed for sokol.audio on Ubuntu)

### DIFF
--- a/.github/workflows/module_docs_ci.yml
+++ b/.github/workflows/module_docs_ci.yml
@@ -35,6 +35,8 @@ jobs:
       - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
+      - name: Update packages, before running apt install
+        run: v retry -- sudo apt update -y -qq
       - name: Install dependencies (some modules wrap C libs)
         run: v retry -- sudo apt install --quiet -y libpq-dev
           libsodium-dev libasound2-dev libssl-dev \

--- a/.github/workflows/module_docs_ci.yml
+++ b/.github/workflows/module_docs_ci.yml
@@ -35,6 +35,12 @@ jobs:
       - uses: actions/checkout@v5
       - name: Build V
         run: make -j4 && ./v symlink
+      - name: Install dependencies (some modules wrap C libs)
+        run: v retry -- sudo apt install --quiet -y libpq-dev
+          libsodium-dev libasound2-dev libssl-dev \
+          sqlite3 libsqlite3-dev libfreetype6-dev \
+          libx11-dev libxi-dev freeglut3-dev \
+          libgl1-mesa-dri libxcursor-dev libgl-dev libxrandr-dev
       - name: Install markdown from vpm
         run: v retry -- v install markdown
       - name: Test v doc


### PR DESCRIPTION
- **vdoc: enable example lines that have explicit imports too, fixup the remaining vlib examples, so `v doc -v -unsafe-run-examples -f none vlib/` could be added to the CI**
- **ci: use `./v doc -m -f html -unsafe-run-examples -time vlib/` for module doc generation**
- **ci: fix dependencies for modules with examples (libasound2-dev is needed for sokol.audio on Ubuntu)**