### PR TITLE
math.big: fix integer_from_int(min_int) edge case, add tests

### DIFF
--- a/vlib/math/big/big_test.v
+++ b/vlib/math/big/big_test.v
@@ -52,6 +52,8 @@ const integer_from_int_test_data = [
 	IntegerFromTest{ 127, '127' },
 	IntegerFromTest{ 1024, '1024' },
 	IntegerFromTest{ 2147483647, '0x7fffffff' },
+	IntegerFromTest{ -2147483647, '-2147483647' },
+	IntegerFromTest{ -2147483648, '-2147483648' },
 ]
 
 const integer_from_u64_test_data = [

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -51,9 +51,16 @@ pub fn integer_from_int(value int) Integer {
 	if value == 0 {
 		return zero_int
 	}
-	return Integer{
-		digits: [u64(iabs(value))]
-		signum: int_signum(value)
+	if value == min_int {
+		return Integer{
+			digits: [u64(0x80000000)]
+			signum: -1
+		}
+	} else {
+		return Integer{
+			digits: [u64(iabs(value))]
+			signum: int_signum(value)
+		}
 	}
 }
 


### PR DESCRIPTION
The current implementation of `integer_from_i64()` already has support for the minimum int value `min_i64`.

Currently this code returns wrong output:

```
pulsar:~# cat r.v 
import math.big

fn main() {
        println(big.integer_from_int(min_int))
}
pulsar:~# v run r.v 
-18446744071562067968
pulsar:~# 
```

Lets fix `integer_from_int()` too.