### PR TITLE
checker: rewrite comptime_if_cond() to support comptime if cond evaluate

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -100,8 +100,8 @@ pub mut:
 	smartcast_mut_pos           token.Pos // match mut foo, if mut foo is Foo
 	smartcast_cond_pos          token.Pos // match cond
 	ct_cond_stack               []ast.Expr
-	ct_user_defines             map[string]ComptimeBranchSkipState
-	ct_system_defines           map[string]ComptimeBranchSkipState
+	ct_user_defines             map[string]bool
+	ct_system_defines           map[string]bool
 mut:
 	stmt_level int // the nesting level inside each stmts list;
 	// .stmt_level is used to check for `evaluated but not used` ExprStmts like `1 << 1`

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -55,11 +55,10 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 				if comptime_if_multi_pass_branch {
 					comptime_if_has_multi_pass_branch = true
 				}
-				if !comptime_if_result && !comptime_if_has_multi_pass_branch
-					&& comptime_if_found_branch {
-					// when curr cond is false, single pass branchs, and already has a true branch:
-					// remove following branchs' stmts
-					comptime_if_multi_pass_branch = false
+				if !comptime_if_has_multi_pass_branch && comptime_if_found_branch {
+					// when all prev branchs are single pass branchs, and already has a true branch:
+					// remove following branchs' stmts by overwrite `comptime_if_result`
+					comptime_if_result = false
 				}
 			} else {
 				// check condition type is boolean

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -55,7 +55,8 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 				if comptime_if_multi_pass_branch {
 					comptime_if_has_multi_pass_branch = true
 				}
-				if !comptime_if_result && !comptime_if_has_multi_pass_branch && comptime_if_found_branch {
+				if !comptime_if_result && !comptime_if_has_multi_pass_branch
+					&& comptime_if_found_branch {
 					// when curr cond is false, single pass branchs, and already has a true branch:
 					// remove following branchs' stmts
 					comptime_if_multi_pass_branch = false

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -55,6 +55,11 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 				if comptime_if_multi_pass_branch {
 					comptime_if_has_multi_pass_branch = true
 				}
+				if !comptime_if_result && !comptime_if_has_multi_pass_branch && comptime_if_found_branch {
+					// when curr cond is false, single pass branchs, and already has a true branch:
+					// remove following branchs' stmts
+					comptime_if_multi_pass_branch = false
+				}
 			} else {
 				// check condition type is boolean
 				c.expected_type = ast.bool_type

--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -119,6 +119,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 			if c.fn_level == 0 && c.pref.output_cross_c {
 				// do not skip any of the branches for top level `$if OS {`
 				// statements, in `-cross` mode
+				comptime_if_multi_pass_branch = true
 				c.skip_flags = false
 				c.ct_cond_stack << branch.cond
 			}

--- a/vlib/v/checker/tests/comptime_field_name_not_exist.out
+++ b/vlib/v/checker/tests/comptime_field_name_not_exist.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/comptime_field_name_not_exist.vv:9:23: error: unknown field `has_xdargfdsafsdfx` from f
+    7 |         mut c := 0
+    8 |         $for f in abc.attributes {
+    9 |                 $if f.has_xdargfdsafsdfx {
+      |                       ~~~~~~~~~~~~~~~~~~
+   10 |                         c++
+   11 |                         println('has_arg')

--- a/vlib/v/checker/tests/comptime_field_name_not_exist.vv
+++ b/vlib/v/checker/tests/comptime_field_name_not_exist.vv
@@ -1,0 +1,16 @@
+@[foo: 123]
+@[bar]
+fn abc() {
+}
+
+fn main() {
+        mut c := 0
+        $for f in abc.attributes {
+                $if f.has_xdargfdsafsdfx {
+                        c++
+                        println('has_arg')
+                }
+        }
+        assert c == 0
+}
+

--- a/vlib/v/checker/tests/custom_comptime_define_error.out
+++ b/vlib/v/checker/tests/custom_comptime_define_error.out
@@ -5,10 +5,10 @@ vlib/v/checker/tests/custom_comptime_define_error.vv:6:6: error: undefined ident
       |         ~~~~~~~~
     7 |         // this will produce a checker error when `-d mysymbol` is not given on the CLI
     8 |         println('comptime non-option define works')
-vlib/v/checker/tests/custom_comptime_define_error.vv:6:2: error: unknown var: `mysymbol`
+vlib/v/checker/tests/custom_comptime_define_error.vv:6:6: error: unknown var: `mysymbol`
     4 |         println('comptime option define works')
     5 |     }
     6 |     $if mysymbol {
-      |     ~~~~~~~~~~~~
+      |         ~~~~~~~~
     7 |         // this will produce a checker error when `-d mysymbol` is not given on the CLI
     8 |         println('comptime non-option define works')

--- a/vlib/v/checker/tests/unknown_comptime_expr.out
+++ b/vlib/v/checker/tests/unknown_comptime_expr.out
@@ -33,7 +33,7 @@ vlib/v/checker/tests/unknown_comptime_expr.vv:17:17: error: unknown type `T`
       |                    ^
    18 |     }
    19 |     $if s is int {
-vlib/v/checker/tests/unknown_comptime_expr.vv:21:13: error: invalid `$if` condition: expected a type
+vlib/v/checker/tests/unknown_comptime_expr.vv:21:13: error: invalid $if right expr: expected a type
    19 |     $if s is int {
    20 |     }
    21 |     $if s.i is 5 {

--- a/vlib/v/gen/c/testdata/comp_if_unknown.c.must_have
+++ b/vlib/v/gen/c/testdata/comp_if_unknown.c.must_have
@@ -1,5 +1,4 @@
 #if defined(__GLIBC__)
 x = 2;
 #else
-x = 3;
 #endif

--- a/vlib/v/gen/c/testdata/comp_if_unknown.c.must_have
+++ b/vlib/v/gen/c/testdata/comp_if_unknown.c.must_have
@@ -1,4 +1,0 @@
-#if defined(__GLIBC__)
-x = 2;
-#else
-#endif

--- a/vlib/v/gen/c/testdata/comp_if_unknown.vv
+++ b/vlib/v/gen/c/testdata/comp_if_unknown.vv
@@ -1,9 +1,0 @@
-fn main() {
-	mut x := 1
-	$if glibc {
-		x = 2
-	} $else {
-		x = 3
-	}
-	println('done')
-}

--- a/vlib/v/tests/comptime/comptime_for_if_cond_check_test.v
+++ b/vlib/v/tests/comptime/comptime_for_if_cond_check_test.v
@@ -1,0 +1,30 @@
+struct Struct {
+	s string
+	i int
+	f f64
+}
+
+fn test_for_if_fields_check() {
+	tst := Struct{
+		s: 'tst-s'
+		i: 42
+	}
+
+	mut result := ''
+	$for field in Struct.fields {
+		$if field.typ is string || field.typ is string {
+			if tst.$(field.name) == 'tst-s' {
+				result += '|s'
+			}
+		} $else $if field.typ is int {
+			if tst.$(field.name) == 42 {
+				result += '|i'
+			}
+		} $else {
+			result += '|f'
+		}
+	}
+	println(result)
+
+	assert result == '|s|i|f'
+}

--- a/vlib/v/tests/comptime/comptime_if_glibc_test.v
+++ b/vlib/v/tests/comptime/comptime_if_glibc_test.v
@@ -1,0 +1,21 @@
+fn test_comptime_if_glibc() {
+	mut x := 1
+	mut result := ''
+	$if glibc {
+		result += ' glibc'
+		x = 2
+	} $else {
+		result += ' else glibc'
+		x = 3
+	}
+
+	$if !glibc {
+		result += ' !glibc'
+	} $else {
+		result += ' else !glibc'
+	}
+
+	println(result)
+	assert result == ' glibc else !glibc' || result == ' else glibc  !glibc'
+	println('done')
+}

--- a/vlib/v/tests/comptime/comptime_if_glibc_test.v
+++ b/vlib/v/tests/comptime/comptime_if_glibc_test.v
@@ -10,12 +10,12 @@ fn test_comptime_if_glibc() {
 	}
 
 	$if !glibc {
-		result += '!glibc'
+		result += '+!glibc'
 	} $else {
-		result += '!!glibc'
+		result += '-!glibc'
 	}
 
 	println(result)
-	assert result == '+glibc!!glibc' || result == '-glibc!glibc'
+	assert result == '+glibc-!glibc' || result == '-glibc+!glibc'
 	println('done')
 }

--- a/vlib/v/tests/comptime/comptime_if_glibc_test.v
+++ b/vlib/v/tests/comptime/comptime_if_glibc_test.v
@@ -2,20 +2,20 @@ fn test_comptime_if_glibc() {
 	mut x := 1
 	mut result := ''
 	$if glibc {
-		result += ' glibc'
+		result += '+glibc'
 		x = 2
 	} $else {
-		result += ' else glibc'
+		result += '-glibc'
 		x = 3
 	}
 
 	$if !glibc {
-		result += ' !glibc'
+		result += '!glibc'
 	} $else {
-		result += ' else !glibc'
+		result += '!!glibc'
 	}
 
 	println(result)
-	assert result == ' glibc else !glibc' || result == ' else glibc  !glibc'
+	assert result == '+glibc!!glibc' || result == '-glibc!glibc'
 	println('done')
 }

--- a/vlib/v/type_resolver/type_resolver.v
+++ b/vlib/v/type_resolver/type_resolver.v
@@ -27,7 +27,8 @@ pub mut:
 	// .values
 	comptime_for_enum_var string
 	// .attributes
-	comptime_for_attr_var string
+	comptime_for_attr_var   string
+	comptime_for_attr_value ast.Attr
 	// .methods
 	comptime_for_method_var      string
 	comptime_for_method          &ast.Fn = unsafe { nil }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR:

1. Rewrite `comptime_if_cond()` in `checker`, fully support comptime if conditon evaluate to `true`/`false`.
2. Add comptime iter $for support for enum/method/method params/sumtype variants/attribute.
3. Fix issue #25099, #24938.

for test `vlib/v/gen/c/testdata/comp_if_unknown.vv`

```v
fn main() {
        mut x := 1
        $if glibc {
                x = 2
        } $else {
                x = 3
        }
        println('done')
}
```

I think the output should contain :

```c
#if defined(__GLIBC__)
x = 2;
#else
#endif
```

instead of :

```c
#if defined(__GLIBC__)
x = 2;
#else
x = 3;
#endif
```