### PR TITLE
v.pref: fix termux detection

### DIFF
--- a/vlib/v/pref/os.v
+++ b/vlib/v/pref/os.v
@@ -205,7 +205,7 @@ pub fn (o OS) str() string {
 }
 
 pub fn get_host_os() OS {
-	if os.getenv('TERMUX_VERSION') != '' {
+	$if termux {
 		return .termux
 	}
 	$if android {


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Issue found by PR #25122
https://github.com/vlang/v/actions/runs/17017667938/job/48242410975?pr=25122

When cross compile to `termux`, we have no env define for `TERMUX_VERSION`, so the original `termux` detection, by `os.getenv('TERMUX_VERSION') != ''` is not working.


BTW: does V has separate OS definition, that is, `host_os` and `target_os` ?
 