### PR TITLE
math.big: add_digit_array() refactoring

### DIFF
--- a/vlib/math/big/array_ops.v
+++ b/vlib/math/big/array_ops.v
@@ -34,11 +34,15 @@ fn add_digit_array(operand_a []u64, operand_b []u64, mut sum []u64) {
 		for index in 0 .. operand_b.len {
 			sum[index] = operand_b[index]
 		}
+		shrink_tail_zeros(mut sum)
+		return
 	}
 	if operand_b.len == 0 {
 		for index in 0 .. operand_a.len {
 			sum[index] = operand_a[index]
 		}
+		shrink_tail_zeros(mut sum)
+		return
 	}
 
 	// First pass intersects with both operands
@@ -62,11 +66,8 @@ fn add_digit_array(operand_a []u64, operand_b []u64, mut sum []u64) {
 		carry = u64(partial >> digit_bits)
 	}
 
-	if carry == 0 {
-		sum.delete_last()
-	} else {
-		sum[larger_limit] = carry
-	}
+	sum[larger_limit] = carry
+	shrink_tail_zeros(mut sum)
 }
 
 // Subtracts operand_b from operand_a and stores the difference in storage.


### PR DESCRIPTION
The first of two patches for addition.

It all started when I found that there was no fast exit from the function when the input array was empty. Currently there are three places in the library that use this function - `subtract`, `addition` and `Karatsuba`.

Simple arithmetic has protection and doesn't let empty arrays pass through, but `Karatsuba` does.

The patch contains three blocks of changes:

1. just protection for the future if someone uses the function incorrectly
2. `Karatsuba` can pass an empty array, it is necessary to do `shrink`, without `shrink` tests will fail
3. Here the point is to remove the unnecessary `if` and `delete_last()`

Multi-million loop passed against 'gmplib`.