### PR TITLE
parser: fix interface method declaration with fixed array return type

### DIFF
--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -799,7 +799,10 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			}
 			if p.tok.kind.is_start_of_type() && p.tok.line_nr == line_nr {
 				method.return_type_pos = p.tok.pos()
+				last_inside_return := p.inside_fn_return
+				p.inside_fn_return = true
 				method.return_type = p.parse_type()
+				p.inside_fn_return = last_inside_return
 				method.return_type_pos = method.return_type_pos.extend(p.tok.pos())
 				method.pos = method.pos.extend(method.return_type_pos)
 			}

--- a/vlib/v/tests/interfaces/interface_fixed_array_ret_test.v
+++ b/vlib/v/tests/interfaces/interface_fixed_array_ret_test.v
@@ -1,0 +1,20 @@
+interface IValue {
+	value() [2]int
+}
+
+struct Speed {
+	data [2]int
+}
+
+fn (s Speed) value() [2]int {
+	return s.data
+}
+
+fn get_value(v IValue) [2]int {
+	return v.value()
+}
+
+fn test_main() {
+	s := Speed{[35, 36]!}
+	assert get_value(s) == [35, 36]!
+}


### PR DESCRIPTION
Fix #25137