### PR TITLE
checker: ensure the defer behavior matches that of cgen

### DIFF
--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -33,6 +33,12 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 	defer {
 		c.inside_return = prev_inside_return
 	}
+
+	// check `defer_stmts` in return, to ensure the same behavior with `cgen`
+	for i := c.table.cur_fn.defer_stmts.len - 1; i >= 0; i-- {
+		c.stmts(mut c.table.cur_fn.defer_stmts[i].stmts)
+	}
+
 	c.expected_type = c.table.cur_fn.return_type
 	mut expected_type := c.unwrap_generic(c.expected_type)
 	if expected_type != 0 && c.table.sym(expected_type).kind == .alias {

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -35,9 +35,12 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 	}
 
 	// check `defer_stmts` in return, to ensure the same behavior with `cgen`
+	old_inside_defer := c.inside_defer
+	c.inside_defer = true
 	for i := c.table.cur_fn.defer_stmts.len - 1; i >= 0; i-- {
 		c.stmts(mut c.table.cur_fn.defer_stmts[i].stmts)
 	}
+	c.inside_defer = old_inside_defer
 
 	c.expected_type = c.table.cur_fn.return_type
 	mut expected_type := c.unwrap_generic(c.expected_type)


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR is try to ensure the defer behavior matches that of `cgen`.

In `cgen`, defer stmts may be copied into a `$for` iteration. This is different with `checker`.
For example:
```v
module main

struct Defer {
        a int
        b int
}

fn main() {
        x := Defer{}
        mut inside_for_flag := false
        defer {
                // g.comptime.inside_comptime_for = true here
                // but c.comptime.inside_comptime_for = false here
                println('inside_for_flag = ${inside_for_flag}')
        }

        $for f in x.fields {
                // g.comptime.inside_comptime_for == true here
                return
        }
        inside_for_flag = false
}
```

Note that in the `defer` block, `inside_comptime_for` in `checker` and `cgen` is different.
I can't provide a test now, maybe in another PR.