### PR TITLE
cgen: fix eq for anon C structs

### DIFF
--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -235,7 +235,14 @@ fn (mut g Gen) gen_struct_equality_fn(left_type ast.Type) string {
 				fn_builder.write_string('${eq_fn}_sumtype_eq(${left_arg}, ${right_arg})')
 			} else if field_type.sym.kind == .struct && !field.typ.is_ptr() {
 				eq_fn := g.gen_struct_equality_fn(field.typ)
-				fn_builder.write_string('${eq_fn}_struct_eq(${left_arg}, ${right_arg})')
+				if field_type.sym.struct_info().is_anon && !field.typ.has_flag(.option)
+					&& !field.typ.has_flag(.shared_f) {
+					styp := g.styp(field.typ)
+					fn_name_ := styp.replace('struct ', '')
+					fn_builder.write_string('${eq_fn}_struct_eq(*(${fn_name_}*)&(${left_arg}), *(${fn_name_}*)&(${right_arg}))')
+				} else {
+					fn_builder.write_string('${eq_fn}_struct_eq(${left_arg}, ${right_arg})')
+				}
 			} else if field_type.sym.kind == .array && !field.typ.is_ptr() {
 				eq_fn := g.gen_array_equality_fn(field.typ)
 				fn_builder.write_string('${eq_fn}_arr_eq(${left_arg}, ${right_arg})')

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1194,6 +1194,13 @@ fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.
 			}
 			return '${fn_name}(${obj})', true
 		}
+		if sym.kind == .struct {
+			if sym.info is ast.Struct && sym.info.is_anon && !_field_type.has_flag(.option)
+				&& !_field_type.has_flag(.shared_f) {
+				typed_obj := '*(${sym.cname}*)&(${obj})'
+				return '${fn_name}(${typed_obj})', true
+			}
+		}
 		return 'indent_${fn_name}(${obj}, indent_count + 1)', true
 	} else if sym.kind in [.array, .array_fixed, .map, .sum_type] {
 		obj := '${prefix}it${op}${final_field_name}${sufix}'

--- a/vlib/v/tests/c_structs/cstruct_anon_eq_test.c.v
+++ b/vlib/v/tests/c_structs/cstruct_anon_eq_test.c.v
@@ -1,0 +1,14 @@
+#insert "@VMODROOT/anon.h"
+
+@[typedef]
+struct C.outer {
+	inner struct {
+		x int
+	}
+}
+
+fn test_main() {
+	a := C.outer{}
+	b := C.outer{}
+	assert a == b
+}


### PR DESCRIPTION
Given the below C struct (typedef is not required to repro):

```c
// anon.h

typedef struct {
      struct {
               int x;
       } inner;
} outer;
```

```v
// cstruct_anon_eq_test.c.v

#insert "@VMODROOT/anon.h"

@[typedef]
struct C.outer {
      inner struct {
            x int
      }
}

fn test_main() {
      a := C.outer{}
      b := C.outer{}
      assert a == b
}
```

Currently generates invalid eq functions:

```
======== Output of the C Compiler (/home/dylan/Downloads/v_linux/v/thirdparty/tcc/tcc.exe) ========
/tmp/v_1000/cstruct_anon_eq_test.01K37GBP8GYEP9GV6HW3RTH1D4.tmp.c:2416: error: cannot convert 'struct <anonymous>' to 'struct main___VAnonStruct1'
===================================================================================================
======== Output of the C Compiler (cc) ========
/tmp/v_1000/cstruct_anon_eq_test.01K37GBP8GYEP9GV6HW3RTH1D4.tmp.c: In function ‘indent_outer_str’:
/tmp/v_1000/cstruct_anon_eq_test.01K37GBP8GYEP9GV6HW3RTH1D4.tmp.c:2416:55: error: incompatible type for argument 1 of ‘indent_main___VAnonStruct1_str’
 2416 |         string _t1 = indent_main___VAnonStruct1_str(it->inner, indent_count + 1);
      |                                                     ~~^~~~~~~
      |                                                       |
      |                                                       struct <anonymous>
/tmp/v_1000/cstruct_anon_eq_test.01K37GBP8GYEP9GV6HW3RTH1D4.tmp.c:1886:66: note: expected ‘main___VAnonStruct1’ but argument is of type ‘struct <anonymous>’
 1886 | static string indent_main___VAnonStruct1_str(main___VAnonStruct1 it, int indent_count);
      |                                              ~~~~~~~~~~~~~~~~~~~~^~
/tmp/v_1000/cstruct_anon_eq_test.01K37GBP8GYEP9GV6HW3RTH1D4.tmp.c: In function ‘outer_struct_eq’:
/tmp/v_1000/cstruct_anon_eq_test.01K37GBP8GYEP9GV6HW3RTH1D4.tmp.c:2452:47: error: incompatible type for argument 1 of ‘main___VAnonStruct1_struct_eq’
 2452 |         return main___VAnonStruct1_struct_eq(a.inner, b.inner);
      |                                              ~^~~~~~
      |                                               |
      |                                               struct <anonymous>
/tmp/v_1000/cstruct_anon_eq_test.01K37GBP8GYEP9GV6HW3RTH1D4.tmp.c:2447:63: note: expected ‘main___VAnonStruct1’ but argument is of type ‘struct <anonymous>’
 2447 | inline bool main___VAnonStruct1_struct_eq(main___VAnonStruct1 a, main___VAnonStruct1 b) {
      |                                           ~~~~~~~~~~~~~~~~~~~~^
/tmp/v_1000/cstruct_anon_eq_test.01K37GBP8GYEP9GV6HW3RTH1D4.tmp.c:2452:56: error: incompatible type for argument 2 of ‘main___VAnonStruct1_struct_eq’
 2452 |         return main___VAnonStruct1_struct_eq(a.inner, b.inner);
      |                                                       ~^~~~~~
      |                                                        |
      |                                                        struct <anonymous>
/tmp/v_1000/cstruct_anon_eq_test.01K37GBP8GYEP9GV6HW3RTH1D4.tmp.c:2447:86: note: expected ‘main___VAnonStruct1’ but argument is of type ‘struct <anonymous>’
 2447 | inline bool main___VAnonStruct1_struct_eq(main___VAnonStruct1 a, main___VAnonStruct1 b) {
      |                                                                  ~~~~~~~~~~~~~~~~~~~~^
===============================================
```

`struct <anonymous>` and `struct main___VAnonStruct1` are the same struct so we can cast to `struct main___VAnonStruct1`, which makes:

```v
inline bool outer_struct_eq(outer a, outer b) {
	return main___VAnonStruct1_struct_eq(*(main___VAnonStruct1*)&(a.inner), *(main___VAnonStruct1*)&(b.inner));
}
```

I am unfamiliar with the codebase so let me know if something looks wrong.