### PR TITLE
cgen: fix generic_fn_name generating incorrect names for C structs

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1271,7 +1271,8 @@ fn (mut g Gen) generic_fn_name(types []ast.Type, before string) string {
 	// `foo[int]()` => `foo_T_int()`
 	mut name := before + '_T'
 	for typ in types {
-		name += '_' + strings.repeat_string('__ptr__', typ.nr_muls()) + g.styp(typ.set_nr_muls(0))
+		name += '_' + strings.repeat_string('__ptr__', typ.nr_muls()) +
+			g.styp(typ.set_nr_muls(0)).replace(' ', '_')
 	}
 	return name
 }

--- a/vlib/v/tests/generics/foo.h
+++ b/vlib/v/tests/generics/foo.h
@@ -1,0 +1,9 @@
+// foo.h
+#ifndef TEST_H
+#define TEST_H
+
+struct foo {
+  int a;
+};
+
+#endif

--- a/vlib/v/tests/generics/generic_struct_cstruct_test.v
+++ b/vlib/v/tests/generics/generic_struct_cstruct_test.v
@@ -1,0 +1,14 @@
+#insert "@VMODROOT/foo.h"
+
+struct C.foo {
+	a int
+}
+
+fn ref[T](x T) &T {
+	return &x
+}
+
+fn test_main() {
+	a := C.foo{}
+	b := ref(a)
+}


### PR DESCRIPTION
Currently using C structs in generics does not work. Given the below files:

```c
// foo.h
#ifndef TEST_H
#define TEST_H

struct foo {
  int a;
};

#endif
```

```v
// generic_struct_cstruct_test.v
#insert "@VMODROOT/foo.h"

struct C.foo {
	a int
}

fn ref[T](x T) &T {
	return &x
}

fn test_main() {
	a := C.foo{}
	b := ref(a)
}
```

Currently outputs this C code:

```c
VV_LOC struct foo* main__ref_T_struct foo(struct foo _v_toheap_x) {
struct foo* x = HEAP(struct foo, _v_toheap_x);
	return &(*(x));
}
VV_LOC void main__test_main(void) {
	struct foo a = ((struct foo){.a = 0,});
	struct foo* b = main__ref_T_struct foo(a);
}
```

Notice the space between `main__ref_T_struct` and `foo` on the first line.

This fails to compile:
```c
/tmp/v_1000/generic_struct_cstruct_test.01K3EZ101KHRXGH9XKC03Q2DEW.tmp.c:1872:39: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘foo’
 1872 | VV_LOC struct foo* main__ref_T_struct foo(struct foo _v_toheap_x);
      |                                       ^~~
/tmp/v_1000/generic_struct_cstruct_test.01K3EZ101KHRXGH9XKC03Q2DEW.tmp.c:8195:39: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘foo’
 8195 | VV_LOC struct foo* main__ref_T_struct foo(struct foo _v_toheap_x) {
      |                                       ^~~
/tmp/v_1000/generic_struct_cstruct_test.01K3EZ101KHRXGH9XKC03Q2DEW.tmp.c: In function ‘main__test_main’:
/tmp/v_1000/generic_struct_cstruct_test.01K3EZ101KHRXGH9XKC03Q2DEW.tmp.c:8201:25: error: ‘main__ref_T_struct’ undeclared (first use in this function)
 8201 |         struct foo* b = main__ref_T_struct foo(a);
      |                         ^~~~~~~~~~~~~~~~~~
/tmp/v_1000/generic_struct_cstruct_test.01K3EZ101KHRXGH9XKC03Q2DEW.tmp.c:8201:25: note: each undeclared identifier is reported only once for each function it appears in
/tmp/v_1000/generic_struct_cstruct_test.01K3EZ101KHRXGH9XKC03Q2DEW.tmp.c:8201:44: error: expected ‘,’ or ‘;’ before ‘foo’
 8201 |         struct foo* b = main__ref_T_struct foo(a);
      |                                            ^~~
```

Wasn't sure if I should put the test under `tests/generics` or `tests/c_structs`. Let me know if I should change it.