### PR TITLE
checker,cgen: add comptime match support

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1262,9 +1262,10 @@ pub mut:
 @[minify]
 pub struct MatchExpr {
 pub:
-	tok_kind token.Kind
-	pos      token.Pos
-	comments []Comment // comments before the first branch
+	is_comptime bool
+	tok_kind    token.Kind
+	pos         token.Pos
+	comments    []Comment // comments before the first branch
 pub mut:
 	cond          Expr
 	branches      []MatchBranch

--- a/vlib/v/checker/tests/comptime_match_cond_cannot_mut.out
+++ b/vlib/v/checker/tests/comptime_match_cond_cannot_mut.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/comptime_match_cond_cannot_mut.vv:3:9: error: `x` is mut and may have changed since its definition
+    1 | fn main() {
+    2 |     mut x := 1
+    3 |     $match x {
+      |            ^
+    4 |         1 {
+    5 |             println('1')
+vlib/v/checker/tests/comptime_match_cond_cannot_mut.vv:13:13: error: `$match` condition `y` can not be mutable
+   11 | 
+   12 |     y := 100
+   13 |     $match mut y {
+      |                ^
+   14 |         100 {
+   15 |             println('100')

--- a/vlib/v/checker/tests/comptime_match_cond_cannot_mut.vv
+++ b/vlib/v/checker/tests/comptime_match_cond_cannot_mut.vv
@@ -1,0 +1,18 @@
+fn main() {
+	mut x := 1
+	$match x {
+		1 {
+			println('1')
+		}
+		2 {
+			println('2')
+		}
+	}
+
+	y := 100
+	$match mut y {
+		100 {
+			println('100')
+		}
+	}
+}

--- a/vlib/v/checker/tests/comptime_match_value_different_type.out
+++ b/vlib/v/checker/tests/comptime_match_value_different_type.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/comptime_match_value_different_type.vv:7:3: error: can not matching a string value(`'100'`) in a non string type `$match`, `x` type is `int`
+    5 |             println('int 100')
+    6 |         }
+    7 |         '100' {
+      |         ~~~~~
+    8 |             println('string 100')
+    9 |         }
+vlib/v/checker/tests/comptime_match_value_different_type.vv:18:3: error: can not matching a string value(`'1'`) in a non string type `$match`, `$int` type is `int`
+   16 |             println('IntegerLiteral')
+   17 |         }
+   18 |         '1' {
+      |         ~~~
+   19 |             println('StringLiteral')
+   20 |         }

--- a/vlib/v/checker/tests/comptime_match_value_different_type.vv
+++ b/vlib/v/checker/tests/comptime_match_value_different_type.vv
@@ -1,0 +1,25 @@
+fn match_value_different_type() {
+	x := 100
+	$match x {
+		100 {
+			println('int 100')
+		}
+		'100' {
+			println('string 100')
+		}
+	}
+}
+
+fn match_type_different_literal() {
+	$match $int {
+		1 {
+			println('IntegerLiteral')
+		}
+		'1' {
+			println('StringLiteral')
+		}
+		true {
+			println('BoolLiteral')
+		}
+	}
+}

--- a/vlib/v/checker/tests/comptime_match_value_type_mix_check.out
+++ b/vlib/v/checker/tests/comptime_match_value_type_mix_check.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/comptime_match_value_type_mix_check.vv:9:3: error: can not matching a type in a value `$match`
+    7 |             println('value check')
+    8 |         }
+    9 |         int {
+      |         ~~~
+   10 |             println('type check')
+   11 |         }
+vlib/v/checker/tests/comptime_match_value_type_mix_check.vv:21:3: error: can not matching a value in a type `$match`
+   19 |             println('type check')
+   20 |         }
+   21 |         100 {
+      |         ~~~
+   22 |             println('value check')
+   23 |         }

--- a/vlib/v/checker/tests/comptime_match_value_type_mix_check.vv
+++ b/vlib/v/checker/tests/comptime_match_value_type_mix_check.vv
@@ -1,0 +1,25 @@
+module main
+
+fn type_check_in_a_value_match() {
+	x := 100
+	$match x {
+		100 {
+			println('value check')
+		}
+		int {
+			println('type check')
+		}
+	}
+}
+
+fn value_check_in_a_type_match() {
+	x := 100
+	$match x {
+		int {
+			println('type check')
+		}
+		100 {
+			println('value check')
+		}
+	}
+}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2842,7 +2842,7 @@ pub fn (mut f Fmt) map_init(node ast.MapInit) {
 	f.write('}')
 }
 
-fn (mut f Fmt) match_branch(branch ast.MatchBranch, single_line bool) {
+fn (mut f Fmt) match_branch(branch ast.MatchBranch, single_line bool, is_comptime bool) {
 	if !branch.is_else {
 		// normal branch
 		f.is_mbranch_expr = true
@@ -2864,7 +2864,11 @@ fn (mut f Fmt) match_branch(branch ast.MatchBranch, single_line bool) {
 		f.is_mbranch_expr = false
 	} else {
 		// else branch
-		f.write('else')
+		if is_comptime {
+			f.write('\$else')
+		} else {
+			f.write('else')
+		}
 	}
 	if branch.stmts.len == 0 {
 		f.writeln(' {}')
@@ -2888,7 +2892,8 @@ fn (mut f Fmt) match_branch(branch ast.MatchBranch, single_line bool) {
 }
 
 pub fn (mut f Fmt) match_expr(node ast.MatchExpr) {
-	f.write('match ')
+	dollar := if node.is_comptime { '$' } else { '' }
+	f.write('${dollar}match ')
 	f.expr(node.cond)
 	f.writeln(' {')
 	f.indent++
@@ -2913,10 +2918,10 @@ pub fn (mut f Fmt) match_expr(node ast.MatchExpr) {
 			else_idx = i
 			continue
 		}
-		f.match_branch(branch, single_line)
+		f.match_branch(branch, single_line, node.is_comptime)
 	}
 	if else_idx >= 0 {
-		f.match_branch(node.branches[else_idx], single_line)
+		f.match_branch(node.branches[else_idx], single_line, node.is_comptime)
 	}
 	f.indent--
 	f.write('}')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3823,7 +3823,11 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 			g.map_init(node)
 		}
 		ast.MatchExpr {
-			g.match_expr(node)
+			if node.is_comptime {
+				g.comptime_match(node)
+			} else {
+				g.match_expr(node)
+			}
 		}
 		ast.NodeError {}
 		ast.Nil {

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -128,6 +128,9 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 				.key_if {
 					return p.if_expr(true, false)
 				}
+				.key_match {
+					return p.match_expr(true)
+				}
 				else {
 					return p.unexpected_with_pos(p.peek_tok.pos(),
 						got: '`$`'
@@ -184,7 +187,7 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 			if p.peek_tok.kind in [.lpar, .lsbr] && p.peek_tok.is_next_to(p.tok) {
 				node = p.call_expr(p.language, p.mod)
 			} else {
-				node = p.match_expr()
+				node = p.match_expr(false)
 			}
 		}
 		.key_select {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -957,6 +957,15 @@ fn (mut p Parser) stmt(is_top_level bool) ast.Stmt {
 				.key_for {
 					return p.comptime_for()
 				}
+				.key_match {
+					mut pos := p.tok.pos()
+					expr := p.match_expr(true)
+					pos.update_last_line(p.prev_tok.line_nr)
+					return ast.ExprStmt{
+						expr: expr
+						pos:  pos
+					}
+				}
 				.name {
 					// handles $dbg directly without registering token
 					if p.peek_tok.lit == 'dbg' {

--- a/vlib/v/tests/comptime/comptime_match_assign_test.v
+++ b/vlib/v/tests/comptime/comptime_match_assign_test.v
@@ -1,0 +1,62 @@
+fn test_comptime_match_assign() {
+	os := 'windows'
+	x := $match os {
+		'linux' { 'linux' }
+		'windows' { 'windows' }
+		$else { 'unknown' }
+	}
+
+	assert x == 'windows'
+
+	i := 123
+	y := $match i {
+		1 { '1' }
+		2 { '2' }
+		123 { '123' }
+		$else { 'unknown' }
+	}
+	assert y == '123'
+
+	j := true
+	z := $match j {
+		true { 'T' }
+		false { 'F' }
+	}
+
+	assert z == 'T'
+}
+
+fn test_comptime_match_assign_reverse() {
+	os1 := 'windows'
+	os2 := 'linux'
+	os3 := 'macos'
+	x := $match 'windows' {
+		os1 { 'w' }
+		os2 { 'l' }
+		os3 { 'm' }
+		$else { 'unknown' }
+	}
+	assert x == 'w'
+
+	b1 := true
+	b2 := false
+	b3 := true
+	y := $match false {
+		b1 { 'b1' }
+		b2 { 'b2' }
+		b3 { 'b3' }
+		$else { 'unknown' }
+	}
+	assert y == 'b2'
+
+	i1 := 123
+	i2 := 245
+	i3 := 1023
+	z := $match 1024 {
+		i1 { '123' }
+		i2 { '245' }
+		i3 { '1023' }
+		$else { 'unknown' }
+	}
+	assert z == 'unknown'
+}

--- a/vlib/v/tests/comptime/comptime_match_for_field_type_test.v
+++ b/vlib/v/tests/comptime/comptime_match_for_field_type_test.v
@@ -1,0 +1,47 @@
+struct My {
+	a int
+	b f64
+	c string
+}
+
+fn test_comptime_match_for_field_type() {
+	x := My{}
+
+	mut result := ''
+
+	$for f in x.fields {
+		f_name := f.name
+		$match f.typ {
+			int {
+				result += '${f_name}=int,'
+			}
+			f64 {
+				result += '${f_name}=f64,'
+			}
+			string {
+				result += '${f_name}=string,'
+			}
+			$else {
+				result += '${f_name}=unknown,'
+			}
+		}
+	}
+	assert result == 'a=int,b=f64,c=string,'
+}
+
+fn test_comptime_match_for_field_type_reverse() {
+	x := My{}
+	a := 100
+
+	mut result := ''
+
+	$for f in x.fields {
+		f_name := f.name
+		$match $int {
+			f.typ {
+				result += '${f_name}=int,'
+			}
+		}
+	}
+	assert result == 'a=int,'
+}

--- a/vlib/v/tests/comptime/comptime_match_for_field_value_test.v
+++ b/vlib/v/tests/comptime/comptime_match_for_field_value_test.v
@@ -1,0 +1,27 @@
+struct My {
+	a int
+	b string
+	c f64
+}
+
+fn test_comptime_match_for_field_value() {
+	x := My{}
+	mut result := ''
+	$for f in x.fields {
+		$match f.name {
+			'a' {
+				result += 'a'
+			}
+			'b' {
+				result += 'b'
+			}
+			'c' {
+				result += 'c'
+			}
+			$else {
+				result += '0'
+			}
+		}
+	}
+	assert result == 'abc'
+}

--- a/vlib/v/tests/comptime/comptime_match_generic_type_test.v
+++ b/vlib/v/tests/comptime/comptime_match_generic_type_test.v
@@ -1,0 +1,40 @@
+fn func[T](val T) string {
+	mut result := ''
+	$match T {
+		int {
+			result += 'int'
+		}
+		f64 {
+			result += 'f64'
+		}
+		string {
+			result += 'string'
+		}
+		$else {
+			result += 'unknown'
+		}
+	}
+
+	$match val {
+		int {
+			result += ',int'
+		}
+		f64 {
+			result += ',f64'
+		}
+		string {
+			result += ',string'
+		}
+		$else {
+			result += ',unknown'
+		}
+	}
+	return result
+}
+
+fn test_comptime_match_generic_type() {
+	assert func(100) == 'int,int'
+	assert func(1.1) == 'f64,f64'
+	assert func('1') == 'string,string'
+	assert func(`a`) == 'unknown,unknown'
+}

--- a/vlib/v/tests/comptime/comptime_match_type_2_test.v
+++ b/vlib/v/tests/comptime/comptime_match_type_2_test.v
@@ -1,0 +1,22 @@
+// This is a duplicate test of `comptime_match_type_test.v`, but with `$match` instead of a `match`
+struct Test {
+	a int
+	b []int
+	c map[int]string
+	d []?int
+}
+
+fn test_main() {
+	mut i := 1
+	$for f in Test.fields {
+		type_name := typeof(f.$(f.name)).name
+		$match f.typ {
+			int { assert i == 1, '1. ${f.name} is ${type_name}' }
+			[]int { assert i == 2, '2. ${f.name} is ${type_name}' }
+			map[int]string { assert i == 3, '3. ${f.name} is ${type_name}' }
+			[]?int { assert i == 4, '4. ${f.name} is ${type_name}' }
+			$else {}
+		}
+		i++
+	}
+}

--- a/vlib/v/tests/comptime/comptime_match_type_check_test.v
+++ b/vlib/v/tests/comptime/comptime_match_type_check_test.v
@@ -1,0 +1,53 @@
+fn test_comptime_match_type_check() {
+	x := 100
+	mut result := ''
+	$match x {
+		f64 {
+			result += 'f64'
+		}
+		u32 {
+			result += 'u32'
+		}
+		$int {
+			result += '\$int'
+		}
+		int, i32 {
+			result += 'int'
+		}
+		$else {
+			result += 'unknown'
+		}
+	}
+
+	assert result == '\$int'
+}
+
+fn test_comptime_match_type_check_reverse() {
+	a := 100
+	b := 200
+	c := 300
+	x := '123'
+	y := u64(22)
+	z := 1.2
+
+	mut result := ''
+	$match $int {
+		a, b {
+			result += 'a|b'
+		}
+		c {
+			result += 'c'
+		}
+		x {
+			result += 'x'
+		}
+		y {
+			result += 'y'
+		}
+		z {
+			result += 'z'
+		}
+	}
+
+	assert result == 'a|b'
+}

--- a/vlib/v/tests/comptime/comptime_match_value_check_test.v
+++ b/vlib/v/tests/comptime/comptime_match_value_check_test.v
@@ -1,0 +1,114 @@
+const version = 123
+const other = 456
+
+fn test_comptime_match_value_check() {
+	x := version
+	mut result := ''
+
+	$match x {
+		1 {
+			result += 'v1'
+		}
+		2 {
+			result += 'v2'
+		}
+		3 {
+			result += 'v3'
+		}
+		123 {
+			result += 'v123'
+		}
+		$else {
+			result += 'unknown'
+		}
+	}
+	assert result == 'v123'
+
+	result = ''
+	y := true
+	$match y {
+		true {
+			result += 'true'
+		}
+		false {
+			result += 'false'
+		}
+	}
+	assert result == 'true'
+
+	result = ''
+	z := 'abc'
+	$match z {
+		'123' {
+			result += 'a'
+		}
+		'abc' {
+			result += 'b'
+		}
+		$else {
+			result += 'c'
+		}
+	}
+	assert result == 'b'
+}
+
+fn test_comptime_match_value_check_reverse() {
+	x := version
+	y := 124
+	z := 125
+
+	mut result := ''
+	$match 124 {
+		x {
+			result += 'x'
+		}
+		y {
+			result += 'y'
+		}
+		z {
+			result += 'z'
+		}
+	}
+
+	assert result == 'y'
+
+	result = ''
+	a := true
+	b := true
+	c := false
+	$match true {
+		a {
+			result += 'a'
+		}
+		b {
+			result += 'b'
+		}
+		c {
+			result += 'c'
+		}
+		$else {
+			result += 'else'
+		}
+	}
+	assert result == 'a'
+
+	result = ''
+	s1 := '123'
+	s2 := 'abc'
+	s3 := 'kml'
+	$match 'abc' {
+		s1 {
+			result += 'a'
+		}
+		s2 {
+			result += 'b'
+		}
+		s3 {
+			result += 'c'
+		}
+		$else {
+			result += 'else'
+		}
+	}
+	assert result == 'b'
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Feature require by #25100

This PR support two kinds of `$match`, a type `$match` and a value `$match`.

ex:

```v
$match T {
   int { }
   string {}
   $else{}    // `$else` is optional
}
```

```v
$match x {
   1 {}
   2 {}
   3 {}
}
```

also, support assignment :

```v
   x := $match val {
            1 { '1' }
            2 { '2' }
            $else { 'unknown' }
   }
```