### PR TITLE
net.http_proxy : Use a url when using a proxy instead of only the path

### DIFF
--- a/vlib/net/http/http_proxy.v
+++ b/vlib/net/http/http_proxy.v
@@ -94,7 +94,7 @@ fn (pr &HttpProxy) http_do(host urllib.URL, method Method, path string, req &Req
 		path
 	}
 
-	s := req.build_request_headers(req.method, host_name, port, path)
+	s := req.build_request_headers(req.method, host_name, port, full_url)
 	if host.scheme == 'https' {
 		mut client := pr.ssl_dial('${host.host}:443')!
 

--- a/vlib/net/http/http_proxy.v
+++ b/vlib/net/http/http_proxy.v
@@ -87,6 +87,13 @@ fn (pr &HttpProxy) build_proxy_headers(host string) string {
 fn (pr &HttpProxy) http_do(host urllib.URL, method Method, path string, req &Request) !Response {
 	host_name, port := net.split_address(host.hostname())!
 
+	full_url := if host.scheme == 'http' || host.scheme == 'https' {
+		port_part := if port == 80 || port == 0 { '' } else { ':${port}' }
+		'${host.scheme}://${host_name}${port_part}${path}'
+	} else {
+		path
+	}
+
 	s := req.build_request_headers(req.method, host_name, port, path)
 	if host.scheme == 'https' {
 		mut client := pr.ssl_dial('${host.host}:443')!


### PR DESCRIPTION
In the `net.http_proxy.http_do` method, have it construct a url for the request instead of just the path. It should only happen when using a proxy
```
fn (pr &HttpProxy) http_do(host urllib.URL, method Method, path string, req &Request) !Response {
	host_name, port := net.split_address(host.hostname())!

	full_url := if host.scheme == 'http' || host.scheme == 'https' {
		port_part := if port == 80 || port == 0 { '' } else { ':${port}' }
		'${host.scheme}://${host_name}${port_part}${path}'
	} else {
		path
	}

	s := req.build_request_headers(req.method, host_name, port, full_url)

```
This change fixed being able to use HTTP_PROXY and HTTPS_PROXY environment variables with the current DX. Will probably make sense to fill in more proxy handling in other modules, but this for now works with the current http_proxy API.

My reproducing cade: 
```
proxy := http.new_http_proxy(os.environ()['HTTP_PROXY']) or { panic('failed to create proxy') }
testrequest := http.prepare(http.FetchConfig{
  url:         'http://google.com'
  proxy:       proxy
  max_retries: 2
}) or { panic('failed') }

result := testrequest.do()!
println(result.body)
```
Will try to build the test (I'm not used to testing yet) in the next commit. 