### PR TITLE
flag: better covering fix for #25166 tail/single bool flag error in `flag_to.v`

### DIFF
--- a/vlib/flag/flag_to.v
+++ b/vlib/flag/flag_to.v
@@ -934,9 +934,7 @@ pub fn (fm FlagMapper) to_struct[T](defaults ?T) !T {
 						.f64()
 				} $else $if field.typ is bool {
 					if arg := f.arg {
-						if arg != '' {
-							return error('can not assign `${arg}` to bool field `${field.name}`')
-						}
+						return error('can not assign `${arg}` to bool field `${field.name}`')
 					}
 					result.$(field.name) = !the_default.$(field.name)
 				} $else $if field.typ is string {
@@ -1037,7 +1035,7 @@ fn (mut fm FlagMapper) map_v(flag_ctx FlagContext, field StructField) !bool {
 	next := flag_ctx.next
 
 	if field.hints.has(.is_bool) {
-		if flag_name == field.match_name {
+		if flag_name == field.match_name || flag_name == field.short {
 			arg := if flag_raw.contains('=') { flag_raw.all_after('=') } else { '' }
 			if arg != '' {
 				return error('flag `${flag_raw}` can not be assigned to bool field "${field.name}"')

--- a/vlib/flag/flag_to_tail_bool_test.v
+++ b/vlib/flag/flag_to_tail_bool_test.v
@@ -1,14 +1,22 @@
 import flag
 
-const args_bool_short = ['some.exe', '-h']
-const args_bool_long = ['some.exe', '-help']
+const args_bool_short_tail = ['some.exe', '-h']
+const args_bool_long_tail = ['some.exe', '-help']
+
+const args_bool_short_mixed = ['some.exe', '-h', '-long', 'val']
+const args_bool_long_mixed = ['some.exe', '-help', '-long', 'val']
 
 struct CliOptions {
 	show_help bool @[long: 'help'; short: h]
 }
 
-fn test_short_tail_bool() {
-	cli_options, unmatched := flag.to_struct[CliOptions](args_bool_short,
+struct CliOptions2 {
+	show_help bool @[long: 'help'; short: h]
+	long      string
+}
+
+fn test_v_style_short_tail_bool() {
+	cli_options, unmatched := flag.to_struct[CliOptions](args_bool_short_tail,
 		skip:  1
 		style: .v
 		mode:  .relaxed
@@ -24,8 +32,8 @@ fn test_short_tail_bool() {
 	}
 }
 
-fn test_long_tail_bool() {
-	cli_options, unmatched := flag.to_struct[CliOptions](args_bool_long,
+fn test_v_style_long_tail_bool() {
+	cli_options, unmatched := flag.to_struct[CliOptions](args_bool_long_tail,
 		skip:  1
 		style: .v
 		mode:  .relaxed
@@ -39,4 +47,40 @@ fn test_long_tail_bool() {
 	} else {
 		assert false
 	}
+}
+
+fn test_v_style_short_bool() {
+	cli_options, unmatched := flag.to_struct[CliOptions2](args_bool_short_mixed,
+		skip:  1
+		style: .v
+		mode:  .relaxed
+	)!
+
+	if unmatched.len > 0 {
+		assert false
+	}
+	if cli_options.show_help {
+		assert true
+	} else {
+		assert false
+	}
+	assert cli_options.long == 'val'
+}
+
+fn test_v_style_long_bool() {
+	cli_options, unmatched := flag.to_struct[CliOptions2](args_bool_long_mixed,
+		skip:  1
+		style: .v
+		mode:  .relaxed
+	)!
+
+	if unmatched.len > 0 {
+		assert false
+	}
+	if cli_options.show_help {
+		assert true
+	} else {
+		assert false
+	}
+	assert cli_options.long == 'val'
 }


### PR DESCRIPTION
Turns out the previous fix did not cover cases where there were multiple flags involved. This improved fix should cover cases where the bool flag is not only the tail/last in the argument list. New tests included for the new case