### PR TITLE
decoder2: Add support for surrogates

### DIFF
--- a/vlib/x/json2/decoder2/tests/decode_escaped_string_test.v
+++ b/vlib/x/json2/decoder2/tests/decode_escaped_string_test.v
@@ -10,3 +10,50 @@ fn test_decode_escaped_string() {
 
 	assert escaped_strings == decoded_strings
 }
+
+fn test_surrogate() {
+	assert decoder2.decode[string](r'"\ud83d\ude00"')! == '😀'
+	assert decoder2.decode[string](r'"\ud83d\ude00 text"')! == '😀 text'
+}
+
+fn test_invalid_surrogate() {
+	if x := decoder2.decode[string](r'"\ud83d"') {
+		assert false
+	} else {
+		if err is decoder2.JsonDecodeError {
+			assert err.line == 1
+			assert err.character == 1
+			assert err.message == 'Data: Expected a trail surrogate after a head surrogate, but got no valid escape sequence.'
+		}
+	}
+
+	if x := decoder2.decode[string](r'"\ud83d\n\n\n\n"') {
+		assert false
+	} else {
+		if err is decoder2.JsonDecodeError {
+			assert err.line == 1
+			assert err.character == 1
+			assert err.message == 'Data: Expected a trail surrogate after a head surrogate, but got no valid escape sequence.'
+		}
+	}
+
+	if x := decoder2.decode[string](r'"\ud83d\ud83d"') {
+		assert false
+	} else {
+		if err is decoder2.JsonDecodeError {
+			assert err.line == 1
+			assert err.character == 1
+			assert err.message == 'Data: Expected a trail surrogate after a head surrogate, but got D83D.'
+		}
+	}
+
+	if x := decoder2.decode[string](r'"\ude00\ud83d"') {
+		assert false
+	} else {
+		if err is decoder2.JsonDecodeError {
+			assert err.line == 1
+			assert err.character == 1
+			assert err.message == 'Data: Got trail surrogate: DE00 before head surrogate.'
+		}
+	}
+}


### PR DESCRIPTION
Will now decode utf-16 surrogates, used by some encoders for characters outside the bilingual plane.

`println(decoder2.decode[string](r'"\ud83d\ude00"')!) // '😀'`

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
