### PR TITLE
cgen: fix autofree used vars on return

### DIFF
--- a/vlib/v/gen/c/autofree.v
+++ b/vlib/v/gen/c/autofree.v
@@ -62,7 +62,7 @@ fn (mut g Gen) autofree_scope_vars2(scope &ast.Scope, start_pos int, end_pos int
 		match obj {
 			ast.Var {
 				g.trace_autofree('// var "${obj.name}" var.pos=${obj.pos.pos} var.line_nr=${obj.pos.line_nr}')
-				if obj.name == g.returned_var_name {
+				if obj.name in g.returned_var_names {
 					g.print_autofree_var(obj, 'returned from function')
 					g.trace_autofree('// skipping returned var')
 					continue
@@ -246,4 +246,18 @@ fn (mut g Gen) autofree_var_call(free_fn_name string, v ast.Var) {
 		}
 	}
 	g.autofree_scope_stmts << af.str()
+}
+
+fn (mut g Gen) detect_used_var_on_return(expr ast.Expr) {
+	match expr {
+		ast.Ident {
+			g.returned_var_names[expr.name] = true
+		}
+		ast.StructInit {
+			for field_expr in expr.init_fields {
+				g.detect_used_var_on_return(field_expr.expr)
+			}
+		}
+		else {}
+	}
 }

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -196,7 +196,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 	}
 	*/
 
-	g.returned_var_name = ''
+	g.returned_var_names.clear()
 	old_g_autofree := g.is_autofree
 	if node.is_manualfree {
 		g.is_autofree = false

--- a/vlib/v/gen/c/testdata/autofree_toml.c.must_have
+++ b/vlib/v/gen/c/testdata/autofree_toml.c.must_have
@@ -1,0 +1,9 @@
+_result_toml__scanner__Scanner_ptr toml__scanner__new_scanner(toml__scanner__Config config) {
+	_result_toml__scanner__Scanner_ptr _t3 = {0};
+	_result_ok(&(toml__scanner__Scanner*[]) { s }, (_result*)(&_t3), sizeof(toml__scanner__Scanner*));
+	return _t3;
+}
+toml__ast__Quoted toml__parser__Parser_quoted(toml__parser__Parser* p) {
+	return ((toml__ast__Quoted){.text =  string_clone_static(lit),.pos = toml__token__Token_pos(&p->tok),.is_multiline = is_multiline,.quote = quote,});
+}
+

--- a/vlib/v/gen/c/testdata/autofree_toml.vv
+++ b/vlib/v/gen/c/testdata/autofree_toml.vv
@@ -1,0 +1,15 @@
+// vtest vflags: -autofree
+import toml
+import os
+
+fn main() {
+	config_fname := 'config.toml'
+	tab_title := 'test tab title'
+	if !os.exists(config_fname) {
+		mut f := os.create(config_fname) or { panic(err) }
+		f.writeln('tab_title = "${tab_title}"') or { panic(err) }
+		f.close()
+	}
+	doc := toml.parse_file(config_fname) or { panic(err) }
+	assert doc.value('tab_title').string() == tab_title
+}


### PR DESCRIPTION
Fix #25196