### PR TITLE
parser,checker: add top level comptime match support

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -20,11 +20,15 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 	}
 	mut cond_type := ast.void_type
 	if node.is_comptime {
-		// for field.name and generic type `T`
-		if node.cond is ast.SelectorExpr {
-			c.expr(mut node.cond)
+		if node.cond is ast.AtExpr {
+			cond_type = c.expr(mut node.cond)
+		} else {
+			// for field.name and generic type `T`
+			if node.cond is ast.SelectorExpr {
+				c.expr(mut node.cond)
+			}
+			cond_type = c.get_expr_type(node.cond)
 		}
-		cond_type = c.get_expr_type(node.cond)
 	} else {
 		cond_type = c.expr(mut node.cond)
 	}
@@ -69,7 +73,7 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 			c.expr(mut node.cond)
 			if !c.type_resolver.is_generic_param_var(node.cond) {
 				match mut node.cond {
-					ast.StringLiteral {
+					ast.StringLiteral, ast.AtExpr {
 						comptime_match_cond_value = node.cond.val
 					}
 					ast.IntegerLiteral {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -53,6 +53,9 @@ mut:
 	inside_select            bool // to allow `ch <- Struct{} {` inside `select`
 	inside_match_case        bool // to separate `match_expr { }` from `Struct{}`
 	inside_match_body        bool // to fix eval not used TODO
+	inside_ct_match          bool
+	inside_ct_match_case     bool
+	inside_ct_match_body     bool
 	inside_unsafe            bool
 	inside_sum_type          bool // to prevent parsing inline sum type again
 	inside_asm_template      bool
@@ -455,8 +458,9 @@ fn (mut p Parser) parse_block() []ast.Stmt {
 
 fn (mut p Parser) is_in_top_level_comptime(inside_assign_rhs bool) bool {
 	// TODO: find out a better way detect we are in top level.
-	return p.cur_fn_name.len == 0 && p.inside_ct_if_expr && !inside_assign_rhs && !p.script_mode
-		&& p.tok.kind != .name
+	return p.cur_fn_name.len == 0
+		&& (p.inside_ct_if_expr || p.inside_ct_match || p.inside_ct_match_body)
+		&& !inside_assign_rhs && !p.script_mode && p.tok.kind != .name
 }
 
 fn (mut p Parser) parse_block_no_scope(is_top_level bool) []ast.Stmt {

--- a/vlib/v/tests/comptime/comptime_if_at_expr_test.v
+++ b/vlib/v/tests/comptime/comptime_if_at_expr_test.v
@@ -1,0 +1,34 @@
+module main
+
+$if @MOD == 'main' {
+	const c1 = 'main'
+} $else {
+	const c1 = 'other'
+}
+
+$if @OS == 'linux' {
+	const os = 'linux'
+} $else $if @OS == 'windows' {
+	const os = 'windows'
+} $else {
+	const os = 'other'
+}
+
+fn test_comptime_if_at_expr() {
+	assert c1 == 'main'
+
+	$if linux {
+		assert os == 'linux'
+	} $else $if windows {
+		assert os == 'windows'
+	} $else {
+		assert os == 'other'
+	}
+
+	dump(@FN)
+	$if @FN == 'test_comptime_if_at_expr' {
+		assert true
+	} $else {
+		assert false
+	}
+}

--- a/vlib/v/tests/comptime/comptime_match_at_expr_test.v
+++ b/vlib/v/tests/comptime/comptime_match_at_expr_test.v
@@ -1,0 +1,44 @@
+module main
+
+$match @MOD {
+	'main' {
+		const c1 = 'main'
+	}
+	$else {
+		const c1 = 'other'
+	}
+}
+
+$match @OS {
+	'linux' {
+		const os = 'linux'
+	}
+	'windows' {
+		const os = 'windows'
+	}
+	$else {
+		const os = 'other'
+	}
+}
+
+fn test_comptime_match_at_expr() {
+	assert c1 == 'main'
+
+	dump(@FN)
+	$match @FN {
+		'test_comptime_match_at_expr' {
+			assert true
+		}
+		$else {
+			assert false
+		}
+	}
+
+	$if linux {
+		assert os == 'linux'
+	} $else $if windows {
+		assert os == 'windows'
+	} $else {
+		assert os == 'other'
+	}
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR enable top level `$match`.

Add @token support in `$if` and `$match`.
So we can write code such as :
```v
$match $OS {
    'linux' {
        import mymodule_linux
    }
    'windows' {
        import mymodule_windows
    }
    'macos' {
        import mymodule_macos
    }
    $else {
        import mymodule_default
    }
}
```

Top level comptime `$if` or `$match` only support @token `@MOD` `@OS` `@CCOMPILER` `@BACKEND` or `@PLATFORM` right now.

I am not sure other @token is useful or not at top level: `@VROOT`, `@VMODROOT`, `@VEXEROOT`, `@FN`, `@METHOD`, `@STRUCT`,
	`@VEXE`, `@FILE`, `@DIR`, `@LINE`, `@COLUMN`, `@VHASH`, `@VCURRENTHASH`, `@VMOD_FILE`,
	`@VMODHASH`, `@FILE_LINE`, `@LOCATION`, `@BUILD_DATE`, `@BUILD_TIME`, `@BUILD_TIMESTAMP`
