### PR TITLE
builtin, checker, cgen: expose is_embed in FieldData

### DIFF
--- a/vlib/builtin/builtin.v
+++ b/vlib/builtin/builtin.v
@@ -124,9 +124,10 @@ pub:
 	typ           int    // the internal TypeID of the field f,
 	unaliased_typ int    // if f's type was an alias of int, this will be TypeID(int)
 
-	attrs  []string // the attributes of the field f
-	is_pub bool     // f is in a `pub:` section
-	is_mut bool     // f is in a `mut:` section
+	attrs    []string // the attributes of the field f
+	is_pub   bool     // f is in a `pub:` section
+	is_mut   bool     // f is in a `mut:` section
+	is_embed bool     // f is a embedded struct
 
 	is_shared bool // `f shared Abc`
 	is_atomic bool // `f atomic int` , TODO

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -1398,7 +1398,7 @@ fn (mut c Checker) comptime_if_cond(mut cond ast.Expr, mut sb strings.Builder) (
 		}
 		ast.SelectorExpr {
 			if c.comptime.comptime_for_field_var != '' && cond.expr is ast.Ident {
-				if (cond.expr as ast.Ident).name == c.comptime.comptime_for_field_var && cond.field_name in ['is_mut', 'is_pub', 'is_shared', 'is_atomic', 'is_option', 'is_array', 'is_map', 'is_chan', 'is_struct', 'is_alias', 'is_enum'] {
+				if (cond.expr as ast.Ident).name == c.comptime.comptime_for_field_var && cond.field_name in ['is_mut', 'is_pub', 'is_embed', 'is_shared', 'is_atomic', 'is_option', 'is_array', 'is_map', 'is_chan', 'is_struct', 'is_alias', 'is_enum'] {
 					is_true = c.type_resolver.get_comptime_selector_bool_field(cond.field_name)
 					sb.write_string('${is_true}')
 					return is_true, true

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -740,6 +740,7 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 				g.writeln('\t${node.val_var}.unaliased_typ = ${int(unaliased_styp.idx())};\t// ${g.table.type_to_str(unaliased_styp)}')
 				g.writeln('\t${node.val_var}.is_pub = ${field.is_pub};')
 				g.writeln('\t${node.val_var}.is_mut = ${field.is_mut};')
+				g.writeln('\t${node.val_var}.is_embed = ${field.is_embed};')
 
 				g.writeln('\t${node.val_var}.is_shared = ${field.typ.has_flag(.shared_f)};')
 				g.writeln('\t${node.val_var}.is_atomic = ${field.typ.has_flag(.atomic_f)};')

--- a/vlib/v/tests/comptime/comptime_for_test.v
+++ b/vlib/v/tests/comptime/comptime_for_test.v
@@ -1,4 +1,5 @@
 struct App {
+	Inner
 	a string
 	b string
 mut:
@@ -11,6 +12,8 @@ pub mut:
 	g string
 	h u8
 }
+
+struct Inner {}
 
 @['foo/bar/three']
 fn (mut app App) run() {
@@ -85,13 +88,16 @@ fn test_comptime_for_fields() {
 			assert field.name in ['d', 'e']
 		}
 		if field.is_mut {
-			assert field.name in ['c', 'd', 'g', 'h']
+			assert field.name in ['c', 'd', 'g', 'h', 'Inner']
 		}
 		if field.is_pub {
-			assert field.name in ['e', 'f', 'g', 'h']
+			assert field.name in ['e', 'f', 'g', 'h', 'Inner']
 		}
 		if field.is_pub && field.is_mut {
-			assert field.name in ['g', 'h']
+			assert field.name in ['g', 'h', 'Inner']
+		}
+		if field.is_embed {
+			assert field.name == 'Inner'
 		}
 		if field.name == 'f' {
 			assert sizeof(field) == 8

--- a/vlib/v/type_resolver/comptime_resolver.v
+++ b/vlib/v/type_resolver/comptime_resolver.v
@@ -224,6 +224,7 @@ pub fn (mut t TypeResolver) get_comptime_selector_bool_field(field_name string) 
 	match field_name {
 		'is_pub' { return field.is_pub }
 		'is_mut' { return field.is_mut }
+		'is_embed' { return field.is_embed }
 		'is_shared' { return field_typ.has_flag(.shared_f) }
 		'is_atomic' { return field_typ.has_flag(.atomic_f) }
 		'is_option' { return field.typ.has_flag(.option) }


### PR DESCRIPTION
Add is_embed to the FieldData struct accessed when iterating over the fields of a struct using comptime for. This is required to effectively en/decode embedded structs.

Example:

```v
struct Inner {
	a int
}

struct Outer {
	Inner 
	b int
}

fn main() {
	$for field in Outer.fields {
		if field.is_embed {
			println(field.name)
		}
	}
}

// output: Inner
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
