### PR TITLE
math.big: replace division with Knuth

### DIFF
--- a/vlib/math/big/array_ops.v
+++ b/vlib/math/big/array_ops.v
@@ -181,10 +181,7 @@ fn divide_digit_array(operand_a []u64, operand_b []u64, mut quotient []u64, mut 
 	cmp_result := compare_digit_array(operand_a, operand_b)
 	// a == b => q, r = 1, 0
 	if cmp_result == 0 {
-		quotient << 1
-		for quotient.len > 1 {
-			quotient.delete_last()
-		}
+		quotient[0] = 1
 		remainder.clear()
 		return
 	}
@@ -192,7 +189,9 @@ fn divide_digit_array(operand_a []u64, operand_b []u64, mut quotient []u64, mut 
 	// a < b => q, r = 0, a
 	if cmp_result < 0 {
 		quotient.clear()
-		remainder << operand_a
+		for i in 0 .. operand_a.len {
+			remainder[i] = operand_a[i]
+		}
 		return
 	}
 	if operand_b.len == 1 {
@@ -210,38 +209,36 @@ fn divide_array_by_digit(operand_a []u64, divisor u64, mut quotient []u64, mut r
 		// 1 digit for both dividend and divisor
 		dividend := operand_a[0]
 		q := dividend / divisor
-		if q != 0 {
-			quotient << q
-		}
+		quotient[0] = q
+
 		rem := dividend % divisor
-		if rem != 0 {
-			remainder << rem
-		}
+		remainder[0] = rem
+
+		shrink_tail_zeros(mut quotient)
+		shrink_tail_zeros(mut remainder)
 		return
 	}
 	// Dividend has more digits
 	mut rem := u64(0)
 	mut quo := u64(0)
-	mut qtemp := []u64{len: quotient.cap}
-	divisor64 := u64(divisor)
 
 	// Perform division step by step
 	for index := operand_a.len - 1; index >= 0; index-- {
 		hi := rem >> (64 - digit_bits)
 		lo := rem << digit_bits | operand_a[index]
-		quo, rem = bits.div_64(hi, lo, divisor64)
-		qtemp[index] = quo & max_digit
+		quo, rem = bits.div_64(hi, lo, divisor)
+		quotient[index] = quo & max_digit
 	}
+
 	// Remove leading zeros from quotient
-	shrink_tail_zeros(mut qtemp)
-	quotient << qtemp
-	remainder << rem
+	shrink_tail_zeros(mut quotient)
+	remainder[0] = rem
 	shrink_tail_zeros(mut remainder)
 }
 
 @[inline]
 fn divide_array_by_array(operand_a []u64, operand_b []u64, mut quotient []u64, mut remainder []u64) {
-	binary_divide_array_by_array(operand_a, operand_b, mut quotient, mut remainder)
+	knuth_divide_array_by_array(operand_a, operand_b, mut quotient, mut remainder)
 }
 
 // Shifts the contents of the original array by the given amount of bits to the left.

--- a/vlib/math/big/array_ops_test.v
+++ b/vlib/math/big/array_ops_test.v
@@ -136,8 +136,8 @@ fn test_compare_digit_array_02() {
 fn test_divide_digit_array_01() {
 	a := [u64(14)]
 	b := [u64(2)]
-	mut q := []u64{cap: 1}
-	mut r := []u64{cap: 1}
+	mut q := []u64{len: 1}
+	mut r := []u64{len: 1}
 
 	divide_digit_array(a, b, mut q, mut r)
 	assert q == [u64(7)]
@@ -147,8 +147,8 @@ fn test_divide_digit_array_01() {
 fn test_divide_digit_array_02() {
 	a := [u64(14)]
 	b := [u64(15)]
-	mut q := []u64{cap: 1}
-	mut r := []u64{cap: 1}
+	mut q := []u64{len: 1}
+	mut r := []u64{len: 1}
 
 	divide_digit_array(a, b, mut q, mut r)
 	assert q == []u64{len: 0}
@@ -158,8 +158,8 @@ fn test_divide_digit_array_02() {
 fn test_divide_digit_array_03() {
 	a := [u64(0), 4]
 	b := [u64(0), 1]
-	mut q := []u64{cap: a.len - b.len + 1}
-	mut r := []u64{cap: a.len}
+	mut q := []u64{len: a.len - b.len + 1}
+	mut r := []u64{len: a.len}
 
 	divide_digit_array(a, b, mut q, mut r)
 	assert q == [u64(4)]
@@ -169,8 +169,8 @@ fn test_divide_digit_array_03() {
 fn test_divide_digit_array_04() {
 	a := [u64(2), 4]
 	b := [u64(0), 1]
-	mut q := []u64{cap: a.len - b.len + 1}
-	mut r := []u64{cap: a.len}
+	mut q := []u64{len: a.len - b.len + 1}
+	mut r := []u64{len: a.len}
 
 	divide_digit_array(a, b, mut q, mut r)
 	assert q == [u64(4)]
@@ -180,8 +180,8 @@ fn test_divide_digit_array_04() {
 fn test_divide_digit_array_05() {
 	a := [u64(3)]
 	b := [u64(2)]
-	mut q := []u64{cap: a.len - b.len + 1}
-	mut r := []u64{cap: a.len}
+	mut q := []u64{len: a.len - b.len + 1}
+	mut r := []u64{len: a.len}
 
 	divide_digit_array(a, b, mut q, mut r)
 	assert q == [u64(1)]

--- a/vlib/math/big/division_array_ops_test.v
+++ b/vlib/math/big/division_array_ops_test.v
@@ -2,92 +2,11 @@ module big
 
 import rand
 
-fn test_left_shift_in_place() {
-	mut a := [u64(1), 1, 1, 1, 1]
-	left_shift_in_place(mut a, 1)
-	assert a == [u64(2), 2, 2, 2, 2]
-	left_shift_in_place(mut a, 7)
-	assert a == [u64(256), 256, 256, 256, 256]
-	mut b := [u64(0x08000000_00000001), 0x0c000000_00000000, 0x08000000_00000000, 0x07ffffff_ffffffff]
-	left_shift_in_place(mut b, 1)
-	assert b == [u64(2), 0x08000000_00000001, 1, 0x0fffffff_ffffffff]
-	mut c := [u64(0x00ffffff_ffffffff), 0x00f0f0f0_f0f0f0f0, 1, 0x03ffffff_ffffffff, 1]
-	left_shift_in_place(mut c, 2)
-	assert c == [u64(0x03ffffff_fffffffc), 0x03c3c3c3_c3c3c3c0, 4, 0x0fffffff_fffffffc, 4]
-}
-
-fn test_right_shift_in_place() {
-	mut a := [u64(2), 2, 2, 2, 2]
-	right_shift_in_place(mut a, 1)
-	assert a == [u64(1), 1, 1, 1, 1]
-	a = [u64(256), 256, 256, 256, 256]
-	right_shift_in_place(mut a, 7)
-	assert a == [u64(2), 2, 2, 2, 2]
-	a = [u64(0), 0, 1]
-	right_shift_in_place(mut a, 1)
-	assert a == [u64(0), 0x08000000_00000000, 0]
-	mut b := [u64(3), 0x08000000_00000001, 1, 0x0fffffff_ffffffff]
-	right_shift_in_place(mut b, 1)
-	assert b == [u64(0x08000000_00000001), 0x0c000000_00000000, 0x08000000_00000000,
-		0x07ffffff_ffffffff]
-	mut c := [u64(0x03ffffff), 0x03c3c3c3_c3c3c3c0, 7, 0xfffffffc, 4]
-	right_shift_in_place(mut c, 2)
-	assert c == [u64(0x00ffffff), 0x0cf0f0f0_f0f0f0f0, 1, 0x3fffffff, 1]
-}
-
-fn test_subtract_align_last_byte_in_place() {
-	mut a := [u64(2), 2, 2, 2, 2]
-	mut b := [u64(1), 1, 2, 1, 1]
-	subtract_align_last_byte_in_place(mut a, b)
-	assert a == [u64(1), 1, 0, 1, 1]
-
-	a = [u64(0), 0, 0, 0, 1]
-	b = [u64(0), 0, 1]
-	subtract_align_last_byte_in_place(mut a, b)
-	assert a == [u64(0), 0, 0, 0, 0]
-
-	a = [u64(0), 0, 0, 0, 1, 13]
-	b = [u64(1), 0, 1]
-	mut c := []u64{len: a.len}
-	mut d := [u64(0), 0, 0]
-	d << b // to have same length
-	subtract_digit_array(a, d, mut c)
-	subtract_align_last_byte_in_place(mut a, b)
-	assert a == [u64(0), 0, 0, u64(-1) & max_digit, 0, 12]
-	assert c == a
-}
-
-fn test_greater_equal_from_end() {
-	mut a := [u64(1), 2, 3, 4, 5, 6]
-	mut b := [u64(3), 4, 5, 6]
-	assert greater_equal_from_end(a, b) == true
-
-	a = [u64(1), 2, 3, 4, 5, 6]
-	b = [u64(1), 2, 3, 4, 5, 6]
-	assert greater_equal_from_end(a, b) == true
-
-	a = [u64(1), 2, 3, 4, 5, 6]
-	b = [u64(2), 2, 3, 4, 5, 6]
-	assert greater_equal_from_end(a, b) == false
-
-	a = [u64(0), 0, 0, 4, 5, 6]
-	b = [u64(4), 5, 6]
-	assert greater_equal_from_end(a, b) == true
-
-	a = [u64(0), 0, 0, 4, 5, 6]
-	b = [u64(4), 6, 6]
-	assert greater_equal_from_end(a, b) == false
-
-	a = [u64(0), 0, 0, 4, 5, 5]
-	b = [u64(4), 5, 6]
-	assert greater_equal_from_end(a, b) == false
-}
-
 fn test_divide_digit_array_03() {
 	a := [u64(0), 4]
 	b := [u64(0), 1]
-	mut q := []u64{cap: a.len - b.len + 1}
-	mut r := []u64{cap: a.len}
+	mut q := []u64{len: a.len - b.len + 1}
+	mut r := []u64{len: a.len}
 
 	divide_digit_array(a, b, mut q, mut r)
 	assert q == [u64(4)]
@@ -97,8 +16,8 @@ fn test_divide_digit_array_03() {
 fn test_divide_digit_array_04() {
 	a := [u64(2), 4]
 	b := [u64(0), 1]
-	mut q := []u64{cap: a.len - b.len + 1}
-	mut r := []u64{cap: a.len}
+	mut q := []u64{len: a.len - b.len + 1}
+	mut r := []u64{len: a.len}
 
 	divide_digit_array(a, b, mut q, mut r)
 	assert q == [u64(4)]
@@ -108,8 +27,8 @@ fn test_divide_digit_array_04() {
 fn test_divide_digit_array_05() {
 	a := [u64(2), 4, 5]
 	b := [u64(0), 1]
-	mut q := []u64{cap: a.len - b.len + 1}
-	mut r := []u64{cap: a.len}
+	mut q := []u64{len: a.len - b.len + 1}
+	mut r := []u64{len: a.len}
 
 	divide_digit_array(a, b, mut q, mut r)
 	assert q == [u64(4), 5]
@@ -119,8 +38,8 @@ fn test_divide_digit_array_05() {
 fn test_divide_digit_array_06() {
 	a := [u64(2), 4, 5, 3]
 	b := [u64(0), 0x8000]
-	mut q := []u64{cap: a.len - b.len + 1}
-	mut r := []u64{cap: a.len}
+	mut q := []u64{len: a.len - b.len + 1}
+	mut r := []u64{len: a.len}
 
 	divide_digit_array(a, b, mut q, mut r)
 	assert q == [u64(0xa000_00000000), 0x6000_00000000]

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -393,8 +393,8 @@ pub fn (multiplicand Integer) * (multiplier Integer) Integer {
 //
 // DO NOT use this method if the divisor has any chance of being 0.
 fn (dividend Integer) div_mod_internal(divisor Integer) (Integer, Integer) {
-	mut q := []u64{cap: int_max(1, dividend.digits.len - divisor.digits.len + 1)}
-	mut r := []u64{cap: dividend.digits.len}
+	mut q := []u64{len: int_max(1, dividend.digits.len - divisor.digits.len + 1)}
+	mut r := []u64{len: dividend.digits.len}
 	mut q_signum := 0
 	mut r_signum := 0
 


### PR DESCRIPTION
I am pleased and relieved to present a patch for transitioning to `Knuth's` division.

The patch consists of two parts: the first is a reorganization of division processing to reduce memory reallocation, and the second is Knuth's division itself.

Testing of the new division was conducted on random numbers of random length with over 20 billion runs, and if to-from string conversion is included, the number is even higher. Even special edge-case tests were created for dividing numbers that are multiples of 60 bits.

Division performance will significantly improve. Now, dividing a number with 366k digits by one half its length is over 100+ times faster. 

The overall comparison chart of the two division methods is presented below:
<img width="2048" height="2048" alt="division" src="https://github.com/user-attachments/assets/feb62661-c752-498a-90a2-81b3ad227696" />

To followers: If you have code that uses the math.big module, you have a great opportunity to test it before the merge.