### PR TITLE
checker: fix multi return var passing to fn arg

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1685,6 +1685,16 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 						return ast.void_type
 					}
 				}
+				if !func.is_variadic && func.params.len < (param_i + arg_typ_sym.info.types.len) {
+					c.fn_call_error_have_want(
+						nr_params: func.params.len
+						nr_args:   param_i + arg_typ_sym.info.types.len
+						params:    func.params
+						args:      node.args
+						pos:       node.pos
+					)
+					return ast.void_type
+				}
 				out: for n in 0 .. arg_typ_sym.info.types.len {
 					curr_arg := arg_typs[n]
 					multi_param := if func.is_variadic && i >= func.params.len - 1 {

--- a/vlib/v/checker/tests/fn_call_arg_multi_err.out
+++ b/vlib/v/checker/tests/fn_call_arg_multi_err.out
@@ -1,0 +1,15 @@
+vlib/v/checker/tests/fn_call_arg_multi_err.vv:9:7: error: assignment mismatch: 1 variable but `a()` returns 2 values
+    7 | 
+    8 | fn main() {
+    9 |     rets := a()
+      |          ~~
+   10 |     b(1, rets)
+   11 | }
+vlib/v/checker/tests/fn_call_arg_multi_err.vv:10:2: error: expected 2 arguments, but got 3
+    8 | fn main() {
+    9 |     rets := a()
+   10 |     b(1, rets)
+      |     ~~~~~~~~~~
+   11 | }
+Details: have (int literal, (int, int))
+         want (int, []int)

--- a/vlib/v/checker/tests/fn_call_arg_multi_err.vv
+++ b/vlib/v/checker/tests/fn_call_arg_multi_err.vv
@@ -1,0 +1,11 @@
+fn a() (int, int) {
+	return 1, 1
+}
+
+fn b(w int, arg []int) {
+}
+
+fn main() {
+	rets := a()
+	b(1, rets)
+}


### PR DESCRIPTION
Fix #24870