### PR TITLE
ci use cache apt pkgs action

### DIFF
--- a/.github/workflows/puzzle_vibes_ci.yml
+++ b/.github/workflows/puzzle_vibes_ci.yml
@@ -29,8 +29,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
-
-      - name: Install SDL2 dependencies
       - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
         with:
           packages: libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev

--- a/.github/workflows/puzzle_vibes_ci.yml
+++ b/.github/workflows/puzzle_vibes_ci.yml
@@ -4,19 +4,23 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - 'vlib/**'
+      - 'vlib/v/checker/**.v'
+      - 'vlib/v/gen/c/**.v'
       - 'thirdparty/**'
       - 'cmd/tools/builders/**.v'
       - 'cmd/tools/vshader.v'
       - '**/puzzle_vibes_ci.yml'
+      - '!**_test.v'
       - '!**.md'
   pull_request:
     paths:
-      - 'vlib/**'
+      - 'vlib/v/checker/**'
+      - 'vlib/v/gen/c/**'
       - 'thirdparty/**'
       - 'cmd/tools/builders/**.v'
       - 'cmd/tools/vshader.v'
       - '**/puzzle_vibes_ci.yml'
+      - '!**_test.v'
       - '!**.md'
 
 concurrency:

--- a/.github/workflows/puzzle_vibes_ci.yml
+++ b/.github/workflows/puzzle_vibes_ci.yml
@@ -29,15 +29,14 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
+      - name: Install SDL2 dependencies
+      - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        with:
+          packages: libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev
+          version: 1.0
+
       - name: Build V
         run: make && ./v symlink
-
-      - name: Install dependencies
-        run: |
-          .github/workflows/disable_azure_mirror.sh
-          v retry 'sudo apt update'
-          v retry 'sudo apt install -y libsdl2-dev libsdl2-ttf-dev'
-          v retry 'sudo apt install -y libsdl2-mixer-dev libsdl2-image-dev'
 
       - name: Install & Setup SDL
         run: v retry -- v install sdl && v ~/.vmodules/sdl/setup.vsh

--- a/.github/workflows/puzzle_vibes_ci.yml
+++ b/.github/workflows/puzzle_vibes_ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: cd puzzle_vibes && v -g .
 
       - name: Check PV compiles with -prod
-        run: cd puzzle_vibes && v -prod .
+        run: cd puzzle_vibes && v -prod    -no-prod-options .
 
       - name: Check PV compiles with -prod and -g
-        run: cd puzzle_vibes && v -prod -g .
+        run: cd puzzle_vibes && v -prod -g -no-prod-options .

--- a/.github/workflows/puzzle_vibes_ci.yml
+++ b/.github/workflows/puzzle_vibes_ci.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
+
       - name: Install SDL2 dependencies
       - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
         with:


### PR DESCRIPTION
- **ci: change url to http://archive.ubuntu.com in .github/workflows/disable_azure_mirror.sh**
- **ci: change the azure mirror URL in /etc/apt/sources.list too**
- **ci: use awalsh128/cache-apt-pkgs-action@v1.5.3 instead of a manual apt update/apt install step, to leverage caching more**
- **fix syntax**
- **fix syntax**
- **test PV only when the V compiler itself changes**
- **use -no-prod-options to speed up steps, without affecting the output that V produces**
