### PR TITLE
ci: use `cache-apt-packages-action` in more CI jobs

### DIFF
--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -18,6 +18,7 @@ runs:
         version: 1.0
         packages: expect binutils postgresql sqlite3 clang valgrind \
           imagemagick openimageio-tools xvfb xsel xclip \
+          liblapack3 libopenblas-base liblapacke-dev libopenblas-dev libopenmpi-dev \
           libsodium-dev libpq-dev libssl-dev libsqlite3-dev \
           libfreetype6-dev libxi-dev libxcursor-dev \
           libgl-dev libxrandr-dev libasound2-dev \

--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -19,7 +19,7 @@ runs:
       with:
         version: 1.0
         packages: expect binutils postgresql sqlite3 clang valgrind \
-          imagemagick openimageio-tools xvfb xsel xclip \
+          imagemagick graphicsmagick-imagemagick-compat openimageio-tools xvfb xsel xclip \
           liblapack3 libopenblas-base liblapacke-dev libopenblas-dev libopenmpi-dev \
           libsodium-dev libpq-dev libssl-dev libsqlite3-dev \
           libfreetype6-dev libxi-dev libxcursor-dev \

--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -12,6 +12,7 @@ description: 'Cache all commonly used apt packages to speed up CI jobs'
 
 runs:
   using: 'composite'
+  if: runner.os == 'Linux'
   steps:
     - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
       with:
@@ -27,11 +28,5 @@ runs:
           libpng-dev libsamplerate0-dev \
           xfonts-75dpi xfonts-base
     - name: Install common packages on Ubuntu
-      if: runner.os == 'Linux'
       shell: bash
       run: echo "done installing packages on Ubuntu"
-
-    - name: Install common packages on Non Linux
-      if: runner.os != 'Linux'
-      shell: bash
-      run: echo "done"

--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -15,6 +15,7 @@ runs:
   steps:
     - name: Install common packages on Ubuntu
       if: runner.os == 'Linux'
+      run: echo "Installing packages on Ubuntu"
       uses: awalsh128/cache-apt-pkgs-action@v1.5.3
       with:
         version: 1.0
@@ -28,5 +29,3 @@ runs:
           libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-net-dev \
           libpng-dev libsamplerate0-dev \
           xfonts-75dpi xfonts-base
-      shell: bash
-      run: echo "done installing packages on Ubuntu"

--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -10,11 +10,12 @@ description: 'Cache all commonly used apt packages to speed up CI jobs'
 # sdl2                     : needed for Puzzle Vibes & Chocolate Doom
 # libsodium-dev            : needed for Gitly and C2V
 
-if: runner.os == 'Linux'
 runs:
   using: 'composite'
   steps:
-    - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+    - name: Install common packages on Ubuntu
+      if: runner.os == 'Linux'
+      uses: awalsh128/cache-apt-pkgs-action@v1.5.3
       with:
         version: 1.0
         packages: expect binutils postgresql sqlite3 clang valgrind \
@@ -27,6 +28,5 @@ runs:
           libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-net-dev \
           libpng-dev libsamplerate0-dev \
           xfonts-75dpi xfonts-base
-    - name: Install common packages on Ubuntu
       shell: bash
       run: echo "done installing packages on Ubuntu"

--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Install common packages on Ubuntu
       if: runner.os == 'Linux'
       run: echo "Installing packages on Ubuntu"
-      uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+    - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
       with:
         version: 1.0
         packages: expect binutils postgresql sqlite3 clang valgrind \

--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -13,11 +13,9 @@ description: 'Cache all commonly used apt packages to speed up CI jobs'
 runs:
   using: 'composite'
   steps:
-    - name: Install common packages on Ubuntu
+    - id: check-for-linux
       if: runner.os == 'Linux'
-      run: echo "Installing packages on Ubuntu"
-      shell: bash
-    - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+      uses: awalsh128/cache-apt-pkgs-action@v1.5.3
       with:
         version: 1.0
         packages: expect binutils postgresql sqlite3 clang valgrind \

--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -13,6 +13,8 @@ description: 'Cache all commonly used apt packages to speed up CI jobs'
 runs:
   using: 'composite'
   steps:
+    - name: Install common packages on Ubuntu
+      if: runner.os == 'Linux'
     - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
       with:
         version: 1.0
@@ -25,6 +27,10 @@ runs:
           libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-net-dev \
           libpng-dev libsamplerate0-dev \
           xfonts-75dpi xfonts-base
-    - name: Install common packages
-      run: echo "done installing packages"
       shell: bash
+      run: echo "done installing packages on Ubuntu"
+
+    - name: Install common packages on Non Linux
+      if: runner.os != 'Linux'
+      shell: bash
+      run: echo "done"

--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -13,8 +13,6 @@ description: 'Cache all commonly used apt packages to speed up CI jobs'
 runs:
   using: 'composite'
   steps:
-    - name: Install common packages on Ubuntu
-      if: runner.os == 'Linux'
     - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
       with:
         version: 1.0
@@ -27,6 +25,8 @@ runs:
           libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-net-dev \
           libpng-dev libsamplerate0-dev \
           xfonts-75dpi xfonts-base
+    - name: Install common packages on Ubuntu
+      if: runner.os == 'Linux'
       shell: bash
       run: echo "done installing packages on Ubuntu"
 

--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -10,9 +10,9 @@ description: 'Cache all commonly used apt packages to speed up CI jobs'
 # sdl2                     : needed for Puzzle Vibes & Chocolate Doom
 # libsodium-dev            : needed for Gitly and C2V
 
+if: runner.os == 'Linux'
 runs:
   using: 'composite'
-  if: runner.os == 'Linux'
   steps:
     - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
       with:

--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -16,6 +16,7 @@ runs:
     - name: Install common packages on Ubuntu
       if: runner.os == 'Linux'
       run: echo "Installing packages on Ubuntu"
+      shell: bash
     - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
       with:
         version: 1.0

--- a/.github/workflows/add-voting-info.yml
+++ b/.github/workflows/add-voting-info.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   add-voting-info:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     steps:

--- a/.github/workflows/alpine.build.sh
+++ b/.github/workflows/alpine.build.sh
@@ -6,7 +6,7 @@ pwd
 
 uname -a
 
-make -j4
+make
 
 ./v version
 

--- a/.github/workflows/benchmark_footprint_json_decode.yml
+++ b/.github/workflows/benchmark_footprint_json_decode.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   json-encode-benchmark:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/benchmark_footprint_json_decode.yml
+++ b/.github/workflows/benchmark_footprint_json_decode.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
 
       - name: Run V benchmark and save output
         run: (echo '```sh'; v -prod crun vlib/x/json2/decoder2/tests/bench.v; echo '```') > vlib/x/json2/decoder2/tests/bench_out.md

--- a/.github/workflows/benchmark_footprint_json_encode.yml
+++ b/.github/workflows/benchmark_footprint_json_encode.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   json-encode-benchmark:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/benchmark_footprint_json_encode.yml
+++ b/.github/workflows/benchmark_footprint_json_encode.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
 
       - name: Run V benchmark and save output
         run: (echo '```sh'; v -prod crun vlib/v/tests/bench/bench_json_vs_json2.v; echo '```') > vlib/v/tests/bench/bench_json_vs_json2_out.md

--- a/.github/workflows/bootstrapping_ci.yml
+++ b/.github/workflows/bootstrapping_ci.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build V
-        run: make -j4
+        run: make
       - name: Test bootstrapping (v.c can be compiled and run with -os cross)
         run: |
           ls -la v vc/v.c

--- a/.github/workflows/bootstrapping_ci.yml
+++ b/.github/workflows/bootstrapping_ci.yml
@@ -31,7 +31,7 @@ jobs:
   bootstrap-v:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-24.04, macos-14]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15

--- a/.github/workflows/build_on_ubuntu_25_ci.yml
+++ b/.github/workflows/build_on_ubuntu_25_ci.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   ubuntu-25-gcc-14-2-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/c2v_ci.yml
+++ b/.github/workflows/c2v_ci.yml
@@ -94,7 +94,7 @@ jobs:
           v -g ~/.vmodules/c2v/ || true
       - name: Install dependencies
         run: |
-          .github/workflows/disable_azure_mirror.sh		  
+          .github/workflows/disable_azure_mirror.sh
           v retry -- sudo apt update -y -qq
           v retry -- sudo apt install libsdl2-dev libsdl2-mixer-dev libsdl2-net-dev libpng-dev libsamplerate0-dev
           # c2v / DOOM dependencies

--- a/.github/workflows/c2v_ci.yml
+++ b/.github/workflows/c2v_ci.yml
@@ -32,6 +32,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
         run: make && ./v symlink
 
@@ -47,15 +48,6 @@ jobs:
         run: |
           v retry -- v install --git https://github.com/vlang/c2v
           v -g ~/.vmodules/c2v/ || true
-      - name: Install dependencies
-        run: |
-          if [ "${{ runner.os }}" == "Linux" ]; then
-            .github/workflows/disable_azure_mirror.sh
-            v retry -- sudo apt update -y -qq
-            v retry -- sudo apt install libsdl2-dev libsdl2-mixer-dev libsdl2-net-dev libpng-dev libsamplerate0-dev
-          else
-            v retry -- brew install sdl2 sdl2_mixer sdl2_net libpng libsamplerate
-          fi
       - name: Build original Chocolate Doom
         run: |
           v retry -- git clone --quiet --depth 1 https://github.com/vlang/doom ~/code/doom
@@ -77,6 +69,7 @@ jobs:
       VTMP: /tmp
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
         run: make && ./v symlink
 
@@ -92,19 +85,6 @@ jobs:
         run: |
           v retry -- v install --git https://github.com/vlang/c2v
           v -g ~/.vmodules/c2v/ || true
-      - name: Install dependencies
-        run: |
-          .github/workflows/disable_azure_mirror.sh
-          v retry -- sudo apt update -y -qq
-          v retry -- sudo apt install libsdl2-dev libsdl2-mixer-dev libsdl2-net-dev libpng-dev libsamplerate0-dev
-          # c2v / DOOM dependencies
-          # vgret dependencies
-          # imagemagick              : convert, mogrify, import
-          # xvfb                     : For starting X11 Virtual FrameBuffers
-          # openimageio-tools        : idiff
-          # libgl1-mesa-dri          : For headless rendering / software DRI driver (LIBGL_ALWAYS_SOFTWARE=true)
-          # freeglut3-dev            : Fixes graphic apps compilation with tcc
-          v retry -- sudo apt install imagemagick openimageio-tools freeglut3-dev libgl1-mesa-dri xvfb xsel xclip
       - name: Setup test tools
         run: |
           # Fetch the free ~4MB DOOM1.WAD from the link at https://doomwiki.org/wiki/DOOM1.WAD

--- a/.github/workflows/cross_ci.yml
+++ b/.github/workflows/cross_ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 10
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
 
       - name: Install dependencies
         run: |
@@ -60,14 +60,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 10
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build v
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
 
       - name: Install dependencies
         run: |
           .github/workflows/disable_azure_mirror.sh
           ./v retry -- sudo apt update -y -qq
-          ./v retry -- sudo apt install --quiet -y mingw-w64 wine wine64 winetricks libssl-dev sqlite3 libsqlite3-dev
+          ./v retry -- sudo apt install --quiet -y mingw-w64 wine wine64 winetricks
 
       - name: Show diagnostics for wine
         run: |

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Build V
-        run: echo "$VFLAGS" && make -j4 && ./v -cg -o v cmd/v
+        run: echo "$VFLAGS" && make && ./v -cg -o v cmd/v
       - name: Verify `v test` works
         run: |
           echo "$VFLAGS"

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -26,10 +26,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
         run: make
-      - name: Install dependencies (some examples show how to use sqlite and the x11 clipboard)
-        run: ./v retry -- sudo apt install --quiet -y libx11-dev libssl-dev sqlite3 libsqlite3-dev
       - name: Check markdown line length & code examples
         run: ./v check-md -hide-warnings .
         ## NB: -hide-warnings is used here, so that the output is less noisy,

--- a/.github/workflows/freebsd_ci.yml
+++ b/.github/workflows/freebsd_ci.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   tcc-freebsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
@@ -50,7 +50,7 @@ jobs:
             ./v run ci/freebsd_ci.vsh all
 
   clang-freebsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
@@ -76,7 +76,7 @@ jobs:
             ./v run ci/freebsd_ci.vsh all
 
   gcc-freebsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/gen_vc_ci.yml
+++ b/.github/workflows/gen_vc_ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Build V
-        run: make -j4
+        run: make
       - name: Regenerate v.c and v_win.c
         run: |
           git config --global user.email "vlang-bot@users.noreply.github.com"

--- a/.github/workflows/gen_vc_ci.yml
+++ b/.github/workflows/gen_vc_ci.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   build-vc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/gg_regressions_ci.yml
+++ b/.github/workflows/gg_regressions_ci.yml
@@ -32,21 +32,13 @@ jobs:
     steps:
       - name: Checkout V
         uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
 
       - name: Build local v
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
 
       - name: Setup dependencies
         run: |
-          # imagemagick              : convert, mogrify
-          # xvfb                     : xvfb
-          # openimageio-tools        : idiff
-          # libxcursor-dev libxi-dev : V gfx deps
-          # libgl1-mesa-dri          : For headless rendering / software DRI driver (LIBGL_ALWAYS_SOFTWARE=true)
-          # freeglut3-dev            : Fixes graphic apps compilation with tcc
-          .github/workflows/disable_azure_mirror.sh
-          ./v retry -- sudo apt update
-          ./v retry -- sudo apt install imagemagick openimageio-tools libgl1-mesa-dri xvfb libxcursor-dev libxi-dev libxrandr-dev freeglut3-dev xsel xclip
           ./v retry -- ./v download https://raw.githubusercontent.com/tremby/imgur.sh/c98345d/imgur.sh
           ./v retry -- git clone https://github.com/Larpon/gg-regression-images gg-regression-images
           chmod +x ./imgur.sh

--- a/.github/workflows/hub_docker_ci.yml
+++ b/.github/workflows/hub_docker_ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [debian, alpine]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -29,6 +29,10 @@ jobs:
       VFLAGS: -cc tcc -no-retry-compilation
     steps:
       - uses: actions/checkout@v5
+      - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        with:
+          packages: expect valgrind postgresql sqlite3 libpq-dev libssl-dev libsqlite3-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev xfonts-75dpi xfonts-base clang
+          version: 1.0
       - name: Build v
         run: make -j4 && ./v symlink
       - name: Build v with -prealloc
@@ -83,6 +87,10 @@ jobs:
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v5
+      - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        with:
+          packages: expect valgrind postgresql sqlite3 libpq-dev libssl-dev libsqlite3-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev xfonts-75dpi xfonts-base clang
+          version: 1.0
       - name: Build V
         run: make -j4 && ./v symlink
       - name: All code is formatted
@@ -137,6 +145,10 @@ jobs:
       VFLAGS: -cc clang
     steps:
       - uses: actions/checkout@v5
+      - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        with:
+          packages: expect valgrind postgresql sqlite3 libpq-dev libssl-dev libsqlite3-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev xfonts-75dpi xfonts-base clang
+          version: 1.0
       - name: Build V
         run: make -j4 && ./v symlink
       - name: All code is formatted

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/cache-apt-packages-action
       - name: Build v
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: Build v with -prealloc
         run: v run ci/linux_ci.vsh build_v_with_prealloc
       - name: All code is formatted
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: All code is formatted
         run: v run ci/linux_ci.vsh all_code_is_formatted_gcc
       - name: Install dependencies for examples and tools
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: All code is formatted
         run: v run ci/linux_ci.vsh all_code_is_formatted_clang
       - name: Install dependencies for examples and tools

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -29,10 +29,7 @@ jobs:
       VFLAGS: -cc tcc -no-retry-compilation
     steps:
       - uses: actions/checkout@v5
-      - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
-        with:
-          packages: expect valgrind postgresql sqlite3 libpq-dev libssl-dev libsqlite3-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev xfonts-75dpi xfonts-base clang
-          version: 1.0
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build v
         run: make -j4 && ./v symlink
       - name: Build v with -prealloc
@@ -87,10 +84,7 @@ jobs:
     timeout-minutes: 121
     steps:
       - uses: actions/checkout@v5
-      - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
-        with:
-          packages: expect valgrind postgresql sqlite3 libpq-dev libssl-dev libsqlite3-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev xfonts-75dpi xfonts-base clang
-          version: 1.0
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
         run: make -j4 && ./v symlink
       - name: All code is formatted
@@ -145,10 +139,7 @@ jobs:
       VFLAGS: -cc clang
     steps:
       - uses: actions/checkout@v5
-      - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
-        with:
-          packages: expect valgrind postgresql sqlite3 libpq-dev libssl-dev libsqlite3-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev xfonts-75dpi xfonts-base clang
-          version: 1.0
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
         run: make -j4 && ./v symlink
       - name: All code is formatted

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -9,7 +9,6 @@ on:
       - '!**/linux_ci.yml'
       - 'cmd/tools/**'
       - '!cmd/tools/builders/**.v'
-      - '.github/actions/cache-apt-packages-action/action.yml'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -17,7 +16,6 @@ on:
       - '!**/linux_ci.yml'
       - 'cmd/tools/**'
       - '!cmd/tools/builders/**.v'
-      - '.github/actions/cache-apt-packages-action/action.yml'
 
 concurrency:
   group: linux-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -9,7 +9,7 @@ on:
       - '!**/linux_ci.yml'
       - 'cmd/tools/**'
       - '!cmd/tools/builders/**.v'
-	  - '.github/actions/cache-apt-packages-action/action.yml'
+      - '.github/actions/cache-apt-packages-action/action.yml'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -17,7 +17,7 @@ on:
       - '!**/linux_ci.yml'
       - 'cmd/tools/**'
       - '!cmd/tools/builders/**.v'
-	  - '.github/actions/cache-apt-packages-action/action.yml'
+      - '.github/actions/cache-apt-packages-action/action.yml'
 
 concurrency:
   group: linux-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -9,6 +9,7 @@ on:
       - '!**/linux_ci.yml'
       - 'cmd/tools/**'
       - '!cmd/tools/builders/**.v'
+	  - '.github/actions/cache-apt-packages-action/action.yml'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -16,6 +17,7 @@ on:
       - '!**/linux_ci.yml'
       - 'cmd/tools/**'
       - '!cmd/tools/builders/**.v'
+	  - '.github/actions/cache-apt-packages-action/action.yml'
 
 concurrency:
   group: linux-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: Test symlink
         run: v run ci/macos_ci.vsh test_symlink
       - name: v doctor

--- a/.github/workflows/module_docs_ci.yml
+++ b/.github/workflows/module_docs_ci.yml
@@ -34,16 +34,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
-        run: make -j4 && ./v symlink
-      - name: Update packages, before running apt install
-        run: .github/workflows/disable_azure_mirror.sh && v retry -- sudo apt update -y -qq
-      - name: Install dependencies (some modules wrap C libs)
-        run: v retry -- sudo apt install --quiet -y libpq-dev
-          libsodium-dev libasound2-dev libssl-dev \
-          sqlite3 libsqlite3-dev libfreetype6-dev \
-          libx11-dev libxi-dev freeglut3-dev \
-          libgl1-mesa-dri libxcursor-dev libgl-dev libxrandr-dev
+        run: make && ./v symlink
       - name: Install markdown from vpm
         run: v retry -- v install markdown
       - name: Test v doc

--- a/.github/workflows/module_docs_lint.yml
+++ b/.github/workflows/module_docs_lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint-module-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - name: Check Formatting

--- a/.github/workflows/more_extensive_but_slower_tests_ci.yml
+++ b/.github/workflows/more_extensive_but_slower_tests_ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build V
         if: runner.os != 'Windows'
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: Build V (Windows)
         if: runner.os == 'Windows'
         run: ./make.bat && ./v symlink

--- a/.github/workflows/more_extensive_but_slower_tests_ci.yml
+++ b/.github/workflows/more_extensive_but_slower_tests_ci.yml
@@ -24,7 +24,7 @@ jobs:
   more-tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-24.04, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   tcc-openbsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
@@ -50,7 +50,7 @@ jobs:
             ./v run ci/openbsd_ci.vsh all
 
   clang-openbsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
@@ -76,7 +76,7 @@ jobs:
             ./v run ci/openbsd_ci.vsh all
 
   gcc-openbsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/other_ci.yml
+++ b/.github/workflows/other_ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Environment info
         run: echo "$VFLAGS $GITHUB_SHA $GITHUB_REF"
       - name: Build local v
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: v test-cleancode
         run: ./v -silent test-cleancode
       - name: v test-fmt
@@ -91,11 +91,11 @@ jobs:
       - name: Environment info
         run: echo "$VFLAGS $GITHUB_SHA $GITHUB_REF"
       - name: Build local v
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: Clone & Build previous vmaster/v
         run: |
           ./v retry -- git clone --depth=1 https://github.com/vlang/v vmaster/
-          (cd vmaster; make -j4)
+          (cd vmaster; make)
       - name: V versions
         run: ./v version && ./vmaster/v version
       - name: Build the repeat tool
@@ -114,15 +114,14 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 10
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build v
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
 
       - name: Install dependencies
         run: |
           .github/workflows/disable_azure_mirror.sh
           ./v retry -- sudo apt update
-          ./v retry -- sudo apt install --quiet -y libsodium-dev libssl-dev sqlite3 libsqlite3-dev postgresql libpq-dev valgrind
-          ./v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev xfonts-75dpi xfonts-base
           ./v retry -- sudo apt install --quiet -y g++-9 g++-10
 
       - name: g++-9 version
@@ -151,7 +150,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Build local v
         run: |
-          make -j4 && ./v symlink
+          make && ./v symlink
           ./v -g -d trace_parse_stmt cmd/tools/vtest-parser.v
       - name: Install zzuf
         run: ./v retry -- sudo apt install -qq zzuf

--- a/.github/workflows/periodic_ci.yml
+++ b/.github/workflows/periodic_ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Build
         if: runner.os != 'Windows'
-        run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
+        run: make && ./v -showcc -o v cmd/v && ./v doctor
       - name: Build V (Windows)
         if: runner.os == 'Windows'
         run: ./make.bat -msvc && ./v -o v2.exe cmd/v && ./v2 -showcc -o v.exe cmd/v && ./v doctor

--- a/.github/workflows/periodic_ci.yml
+++ b/.github/workflows/periodic_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             cc: tcc
           - os: windows-latest
             cc: msvc

--- a/.github/workflows/puzzle_vibes_ci.yml
+++ b/.github/workflows/puzzle_vibes_ci.yml
@@ -12,6 +12,7 @@ on:
       - '**/puzzle_vibes_ci.yml'
       - '!**_test.v'
       - '!**.md'
+      - '.github/actions/cache-apt-packages-action/action.yml'
   pull_request:
     paths:
       - 'vlib/v/checker/**'
@@ -22,6 +23,7 @@ on:
       - '**/puzzle_vibes_ci.yml'
       - '!**_test.v'
       - '!**.md'
+      - '.github/actions/cache-apt-packages-action/action.yml'
 
 concurrency:
   group: puzzle_vibes-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}

--- a/.github/workflows/puzzle_vibes_ci.yml
+++ b/.github/workflows/puzzle_vibes_ci.yml
@@ -43,7 +43,11 @@ jobs:
       - name: Build V
         run: make && ./v symlink
 
-      - name: Install & Setup SDL
+      - name: Install SDL2 on macOS
+        if: runner.os == 'macOS'
+        run: v retry -- brew install sdl2
+
+      - name: Install & Setup the V SDL wrapper
         run: v retry -- v install sdl && v ~/.vmodules/sdl/setup.vsh
 
       - name: Install Shy

--- a/.github/workflows/puzzle_vibes_ci.yml
+++ b/.github/workflows/puzzle_vibes_ci.yml
@@ -29,7 +29,10 @@ concurrency:
 
 jobs:
   v-compiles-puzzle-vibes:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-13]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -109,7 +109,7 @@ jobs:
   release-publish:
     if: github.ref_type == 'tag'
     needs: release-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/download-artifact@v5
       - name: Create release

--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -89,17 +89,11 @@ jobs:
       VNATIVE_SKIP_LIBC_VV: 1
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: Ensure code is well formatted
         run: ./v -silent test-cleancode
-      - name: Install dependencies
-        run: |
-          .github/workflows/disable_azure_mirror.sh
-          ./v retry -- sudo apt update
-          ./v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          ./v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev
-          ./v retry -- sudo apt install clang
       - name: Recompile V with -cstrict
         run: ./v -cg -cstrict -o v cmd/v
       - name: Self tests (-fsanitize=undefined)
@@ -119,16 +113,11 @@ jobs:
       VNATIVE_SKIP_LIBC_VV: 1
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: Ensure code is well formatted
         run: ./v -silent test-cleancode
-      - name: Install dependencies
-        run: |
-          .github/workflows/disable_azure_mirror.sh
-          ./v retry -- sudo apt update
-          ./v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          ./v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev
       - name: Recompile V with -cstrict
         run: ./v -cg -cstrict -o v cmd/v
       - name: Self tests (-fsanitize=undefined)
@@ -149,17 +138,11 @@ jobs:
       VNATIVE_SKIP_LIBC_VV: 1
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: Ensure code is well formatted
         run: ./v -silent test-cleancode
-      - name: Install dependencies
-        run: |
-          .github/workflows/disable_azure_mirror.sh
-          ./v retry -- sudo apt update
-          ./v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          ./v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev
-          ./v retry -- sudo apt install clang
       - name: Recompile V with -cstrict
         run: ./v -cg -cstrict -o v cmd/v
       - name: Self tests (-fsanitize=address)
@@ -206,17 +189,11 @@ jobs:
       VNATIVE_SKIP_LIBC_VV: 1
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: Ensure code is well formatted
         run: ./v -silent test-cleancode
-      - name: Install dependencies
-        run: |
-          .github/workflows/disable_azure_mirror.sh
-          ./v retry -- sudo apt update
-          ./v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          ./v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev
-          ./v retry -- sudo apt install clang
       - name: Recompile V with -cstrict
         run: ./v -cg -cstrict -o v cmd/v
       - name: Self tests (-fsanitize=address)
@@ -237,17 +214,11 @@ jobs:
       VNATIVE_SKIP_LIBC_VV: 1
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: Ensure code is well formatted
         run: ./v -silent test-cleancode
-      - name: Install dependencies
-        run: |
-          .github/workflows/disable_azure_mirror.sh
-          ./v retry -- sudo apt update
-          ./v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
-          ./v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev
-          ./v retry -- sudo apt install clang
       - name: Recompile V with clang and -cstrict
         run: ./v -cc clang -cg -cstrict -o v cmd/v
       - name: Self tests (-fsanitize=memory)

--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -95,7 +95,7 @@ jobs:
         run: ./v -silent test-cleancode
       - name: Install dependencies
         run: |
-          .github/workflows/disable_azure_mirror.sh		
+          .github/workflows/disable_azure_mirror.sh
           ./v retry -- sudo apt update
           ./v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
           ./v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev
@@ -125,7 +125,7 @@ jobs:
         run: ./v -silent test-cleancode
       - name: Install dependencies
         run: |
-          .github/workflows/disable_azure_mirror.sh		
+          .github/workflows/disable_azure_mirror.sh
           ./v retry -- sudo apt update
           ./v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
           ./v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev
@@ -155,7 +155,7 @@ jobs:
         run: ./v -silent test-cleancode
       - name: Install dependencies
         run: |
-          .github/workflows/disable_azure_mirror.sh		
+          .github/workflows/disable_azure_mirror.sh
           ./v retry -- sudo apt update
           ./v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
           ./v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev
@@ -212,7 +212,7 @@ jobs:
         run: ./v -silent test-cleancode
       - name: Install dependencies
         run: |
-          .github/workflows/disable_azure_mirror.sh		
+          .github/workflows/disable_azure_mirror.sh
           ./v retry -- sudo apt update
           ./v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
           ./v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev
@@ -243,7 +243,7 @@ jobs:
         run: ./v -silent test-cleancode
       - name: Install dependencies
         run: |
-          .github/workflows/disable_azure_mirror.sh		
+          .github/workflows/disable_azure_mirror.sh
           ./v retry -- sudo apt update
           ./v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
           ./v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev

--- a/.github/workflows/sdl_ci.yml
+++ b/.github/workflows/sdl_ci.yml
@@ -31,15 +31,9 @@ jobs:
       VFLAGS: -cc tcc
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
         run: make && sudo ./v symlink
-
-      - name: Install dependencies
-        run: |
-          .github/workflows/disable_azure_mirror.sh
-          v retry 'sudo apt update'
-          v retry 'sudo apt install -y libsdl2-dev libsdl2-ttf-dev'
-          v retry 'sudo apt install -y libsdl2-mixer-dev libsdl2-image-dev'
 
       - name: Clone sdl into .vmodules
         run: |

--- a/.github/workflows/sdl_ci.yml
+++ b/.github/workflows/sdl_ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          .github/workflows/disable_azure_mirror.sh		
+          .github/workflows/disable_azure_mirror.sh
           v retry 'sudo apt update'
           v retry 'sudo apt install -y libsdl2-dev libsdl2-ttf-dev'
           v retry 'sudo apt install -y libsdl2-mixer-dev libsdl2-image-dev'

--- a/.github/workflows/symlink_ci.yml
+++ b/.github/workflows/symlink_ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Build V
-        run: make -j4
+        run: make
       - name: Symlink
         run: |
           ./v symlink

--- a/.github/workflows/termux_ci.yml
+++ b/.github/workflows/termux_ci.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   termux-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/time_ci.yml
+++ b/.github/workflows/time_ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   time-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - name: Build V

--- a/.github/workflows/toml_ci.yml
+++ b/.github/workflows/toml_ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
       - name: Install dependencies
         run: |
           v retry -- v download https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64

--- a/.github/workflows/toml_ci.yml
+++ b/.github/workflows/toml_ci.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   toml-module-pass-external-test-suites:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Build V
-        run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
+        run: make && ./v -showcc -o v cmd/v && ./v doctor
       - name: Code in cmd/ is formatted
         run: ./v fmt -verify cmd/
       - name: Check build-tools
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Build V
-        run: make -j4 && ./v -showcc -o v cmd/v && ./v doctor
+        run: make && ./v -showcc -o v cmd/v && ./v doctor
       - name: Check build-tools
         run: ./v -silent -N -W -check build-tools
       - name: Test tools
@@ -119,7 +119,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Build V
-        run: make -j4 && ./v -cg -o v cmd/v
+        run: make && ./v -cg -o v cmd/v
       - name: Ensure git commands can be used with no prompts on modern Git versions
         run: git config --global --add safe.directory /__w/v/v
       - name: Verify `v test` works

--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -24,7 +24,7 @@ jobs:
   v-apps-compile:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-24.04, macos-14]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "$RUNNER_OS" == 'Linux' ]; then
-            .github/workflows/disable_azure_mirror.sh		  
+            .github/workflows/disable_azure_mirror.sh
             v retry -- sudo apt -qq update
             v retry -- sudo apt -qq install libgc-dev libsodium-dev libssl-dev sqlite3 libsqlite3-dev
             v retry -- sudo apt -qq install libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev xfonts-75dpi xfonts-base

--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -30,6 +30,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
 
       - name: Build V
         id: build
@@ -40,9 +41,7 @@ jobs:
           if [ "$RUNNER_OS" == 'Linux' ]; then
             .github/workflows/disable_azure_mirror.sh
             v retry -- sudo apt -qq update
-            v retry -- sudo apt -qq install libgc-dev libsodium-dev libssl-dev sqlite3 libsqlite3-dev
-            v retry -- sudo apt -qq install libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev xfonts-75dpi xfonts-base
-            v retry -- sudo apt -qq install sassc libgit2-dev # needed by gitly
+            v retry -- sudo apt -qq install libgc-dev sassc libgit2-dev # needed by gitly
           else
             v retry brew install sassc libgit2
           fi

--- a/.github/workflows/vab_ci.yml
+++ b/.github/workflows/vab_ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/checkout@v5
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
 
       - name: Install vab
         run: |
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Build V
-        run: make -j4 && ./v symlink
+        run: make && ./v symlink
 
       - name: Install vab
         run: |

--- a/.github/workflows/vinix_ci.yml
+++ b/.github/workflows/vinix_ci.yml
@@ -28,13 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Build V
-        run: make -j4 && ./v symlink
-
-      - name: Install dependencies
-        run: |
-          .github/workflows/disable_azure_mirror.sh
-          v retry -- sudo apt update
-          v retry -- sudo apt install build-essential -y
+        run: make && ./v symlink
 
       - name: Clone current Vinix
         run: v retry -- git clone --depth=1 https://github.com/vlang/vinix.git

--- a/.github/workflows/vpm_ci.yml
+++ b/.github/workflows/vpm_ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: git version
       - name: Build V
         if: runner.os != 'Windows'
-        run: cd vlang && make -j4 && ./v doctor
+        run: cd vlang && make && ./v doctor
       - name: Build V (Windows)
         if: runner.os == 'Windows'
         run: cd vlang && ./make.bat && ./v doctor

--- a/.github/workflows/vpm_ci.yml
+++ b/.github/workflows/vpm_ci.yml
@@ -18,7 +18,7 @@ jobs:
   setup-vpm:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-24.04, windows-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -44,11 +44,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             cc: tcc
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             cc: gcc
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             cc: clang
           - os: macos-latest
             cc: clang

--- a/.github/workflows/vsl_and_vtl_compile_ci.yml
+++ b/.github/workflows/vsl_and_vtl_compile_ci.yml
@@ -41,8 +41,7 @@ jobs:
           if [ "$RUNNER_OS" == 'Linux' ]; then
             .github/workflows/disable_azure_mirror.sh
             v retry -- sudo apt -qq update
-            v retry -- sudo apt -qq install liblapacke-dev libopenblas-dev libopenmpi-dev \
-              opencl-headers libhdf5-cpp-103-1t64 libhdf5-dev libhdf5-mpi-dev hdf5-tools
+            v retry -- sudo apt -qq install opencl-headers libhdf5-cpp-103-1t64 libhdf5-dev libhdf5-mpi-dev hdf5-tools
           else
             v retry brew install coreutils hdf5 open-mpi openblas lapack opencl-headers
           fi
@@ -74,9 +73,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "$RUNNER_OS" == 'Linux' ]; then
-            .github/workflows/disable_azure_mirror.sh
-            v retry -- sudo apt -qq update
-            v retry -- sudo apt -qq install liblapacke-dev libopenblas-dev libopenmpi-dev
+            echo "everything should be already installed"
           else
             v retry brew install coreutils hdf5 open-mpi openblas lapack opencl-headers
           fi

--- a/.github/workflows/vsl_and_vtl_compile_ci.yml
+++ b/.github/workflows/vsl_and_vtl_compile_ci.yml
@@ -32,17 +32,17 @@ jobs:
       VFLAGS: -no-parallel
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
         id: build
         run: make && sudo ./v symlink
       - name: Install dependencies
         run: |
           if [ "$RUNNER_OS" == 'Linux' ]; then
-          .github/workflows/disable_azure_mirror.sh
-          v retry -- sudo apt -qq update
-          v retry -- sudo apt -qq install \
-            libgc-dev libgl1-mesa-dev mesa-common-dev liblapacke-dev libopenblas-dev libopenmpi-dev \
-            opencl-headers libxcursor-dev libxi-dev libxrandr-dev libhdf5-cpp-103-1t64 libhdf5-dev libhdf5-mpi-dev hdf5-tools
+            .github/workflows/disable_azure_mirror.sh
+            v retry -- sudo apt -qq update
+            v retry -- sudo apt -qq install liblapacke-dev libopenblas-dev libopenmpi-dev \
+              opencl-headers libhdf5-cpp-103-1t64 libhdf5-dev libhdf5-mpi-dev hdf5-tools
           else
             v retry brew install coreutils hdf5 open-mpi openblas lapack opencl-headers
           fi
@@ -67,6 +67,7 @@ jobs:
       TERM: xterm
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
         id: build
         run: make && sudo ./v symlink
@@ -75,8 +76,7 @@ jobs:
           if [ "$RUNNER_OS" == 'Linux' ]; then
             .github/workflows/disable_azure_mirror.sh
             v retry -- sudo apt -qq update
-            v retry -- sudo apt -qq install \
-              libgc-dev libgl1-mesa-dev mesa-common-dev liblapacke-dev libopenblas-dev libopenmpi-dev
+            v retry -- sudo apt -qq install liblapacke-dev libopenblas-dev libopenmpi-dev
           else
             v retry brew install coreutils hdf5 open-mpi openblas lapack opencl-headers
           fi

--- a/.github/workflows/wasm_backend_ci.yml
+++ b/.github/workflows/wasm_backend_ci.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Build V
         if: runner.os != 'Windows'
-        run: make -j4
+        run: make
       - name: Build V (Windows)
         if: runner.os == 'Windows'
         run: ./make.bat

--- a/.github/workflows/websockets_ci.yml
+++ b/.github/workflows/websockets_ci.yml
@@ -28,14 +28,13 @@ jobs:
       VFLAGS: -cc tcc -no-retry-compilation
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/cache-apt-packages-action
       - name: Build v
         run: |
           echo "$VFLAGS"
           sudo ln -s "$PWD/thirdparty/tcc/tcc.exe" /usr/local/bin/tcc ## TODO: remove
-          make -j4 && ./v symlink
+          make && ./v symlink
           ./v -g -o v cmd/v
-      - name: Install dependencies
-        run: v retry -- sudo apt install --quiet -y libssl-dev
       - name: v doctor
         run: ./v doctor
       - name: Run websockets tests

--- a/.github/workflows/workflow_lint.yml
+++ b/.github/workflows/workflow_lint.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   lint-yml-workflows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - name: Verify formatting

--- a/ci/linux_ci.vsh
+++ b/ci/linux_ci.vsh
@@ -58,11 +58,11 @@ fn install_dependencies_for_examples_and_tools_tcc() {
 	if common.is_github_job {
 		exec('.github/workflows/disable_azure_mirror.sh')
 	}
-	exec('v retry -- sudo apt update')
-	exec('v retry -- sudo apt install --quiet -y libssl-dev sqlite3 libsqlite3-dev valgrind')
-	exec('v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev')
+	// exec('v retry -- sudo apt update')
+	// exec('v retry -- sudo apt install --quiet -y libssl-dev sqlite3 libsqlite3-dev valgrind')
+	// exec('v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev')
 	// The following is needed for examples/wkhtmltopdf.v
-	exec('v retry -- sudo apt install --quiet -y xfonts-75dpi xfonts-base expect')
+	// exec('v retry -- sudo apt install --quiet -y xfonts-75dpi xfonts-base expect')
 	exec('v retry -- wget --quiet https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb')
 	exec('v retry -- sudo dpkg -i wkhtmltox_0.12.6.1-2.jammy_amd64.deb')
 }
@@ -182,9 +182,9 @@ fn install_dependencies_for_examples_and_tools_gcc() {
 	if common.is_github_job {
 		exec('.github/workflows/disable_azure_mirror.sh')
 	}
-	exec('v retry -- sudo apt update')
-	exec('v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind')
-	exec('v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev')
+	// exec('v retry -- sudo apt update')
+	// exec('v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind')
+	// exec('v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev')
 }
 
 fn recompile_v_with_cstrict_gcc() {
@@ -305,10 +305,10 @@ fn install_dependencies_for_examples_and_tools_clang() {
 	if common.is_github_job {
 		exec('.github/workflows/disable_azure_mirror.sh')
 	}
-	exec('v retry -- sudo apt update')
-	exec('v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind')
-	exec('v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev')
-	exec('v retry -- sudo apt install --quiet -y clang')
+	// exec('v retry -- sudo apt update')
+	// exec('v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind')
+	// exec('v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev')
+	// exec('v retry -- sudo apt install --quiet -y clang')
 }
 
 fn recompile_v_with_cstrict_clang() {

--- a/cmd/tools/vgret.v
+++ b/cmd/tools/vgret.v
@@ -379,7 +379,12 @@ fn take_screenshots(opt Options, app AppConfig) ![]string {
 				// Use ImageMagick's `import` tool to take the screenshot
 				out_file := os.join_path(out_path, os.file_name(app.path) +
 					'_screenshot_${existing_screenshots.len:02}.png')
-				result := opt.verbose_execute('import -window root "${out_file}"')
+				screenshot_command := if opt.verbose_execute('import --version').exit_code != 0 {
+					'gm import -window root'
+				} else {
+					'import -window root'
+				}
+				result := opt.verbose_execute('${screenshot_command} ${os.quoted_path(out_file)}')
 				if result.exit_code != 0 {
 					p_app.signal_kill()
 					return error('Failed taking screenshot of `${app.abs_path}` to "${out_file}":\n${result.output}')


### PR DESCRIPTION
- **ci: use the concrete name `ubuntu-24.04` instead of `ubuntu-latest` in the yml files (the *-latest variants cause redirection/more waiting, and change)**
- **ci: use awalsh128/cache-apt-pkgs-action@v1.5.3 in linux_ci.yml too**
- **ci: extract .github/actions/cache-apt-packages-action/action.yml, and use it in linux_ci.yml**
- **remove inputs: and outputs: keys from .github/actions/cache-apt-packages-action/action.yml**
- **fix the freaking tabs in linux_ci.yml**
- **add the libsdl2 packages too; let puzzle_vibes_ci.yml reuse the common cache-apt-packages-action**
- **cleanup, use .github/actions/cache-apt-packages-action/action.yml in more places**
