### PR TITLE
cgen: prefix builtin methods with builtin__

### DIFF
--- a/vlib/builtin/linux_bare/libc_impl.v
+++ b/vlib/builtin/linux_bare/libc_impl.v
@@ -4,6 +4,7 @@ import dlmalloc
 
 __global global_allocator dlmalloc.Dlmalloc
 
+@[export: 'memcpy']
 @[unsafe]
 pub fn memcpy(dest voidptr, src voidptr, n usize) voidptr {
 	dest_ := unsafe { &u8(dest) }
@@ -22,6 +23,7 @@ fn __malloc(n usize) voidptr {
 	return unsafe { global_allocator.malloc(n) }
 }
 
+@[export: 'strlen']
 @[unsafe]
 fn strlen(_s voidptr) usize {
 	s := unsafe { &u8(_s) }
@@ -30,6 +32,7 @@ fn strlen(_s voidptr) usize {
 	return usize(i)
 }
 
+@[export: 'realloc']
 @[unsafe]
 fn realloc(old_area voidptr, new_size usize) voidptr {
 	if old_area == 0 {
@@ -50,6 +53,7 @@ fn realloc(old_area voidptr, new_size usize) voidptr {
 	}
 }
 
+@[export: 'memset']
 @[unsafe]
 fn memset(s voidptr, c int, n usize) voidptr {
 	mut s_ := unsafe { &char(s) }
@@ -61,6 +65,7 @@ fn memset(s voidptr, c int, n usize) voidptr {
 	return unsafe { s }
 }
 
+@[export: 'memmove']
 @[unsafe]
 fn memmove(dest voidptr, src voidptr, n usize) voidptr {
 	dest_ := unsafe { &u8(dest) }
@@ -95,6 +100,7 @@ fn getchar() int {
 	return int(x)
 }
 
+@[export: 'memcmp']
 fn memcmp(a voidptr, b voidptr, n usize) int {
 	a_ := unsafe { &u8(a) }
 	b_ := unsafe { &u8(b) }

--- a/vlib/builtin/string_interpolation.v
+++ b/vlib/builtin/string_interpolation.v
@@ -721,22 +721,22 @@ pub const si_g64_code = '0xfe0f'
 
 @[inline]
 pub fn str_intp_sq(in_str string) string {
-	return 'str_intp(2, _MOV((StrIntpData[]){{_S("\'"), ${si_s_code}, {.d_s = ${in_str}}},{_S("\'"), 0, {.d_c = 0 }}}))'
+	return 'builtin__str_intp(2, _MOV((StrIntpData[]){{_S("\'"), ${si_s_code}, {.d_s = ${in_str}}},{_S("\'"), 0, {.d_c = 0 }}}))'
 }
 
 @[inline]
 pub fn str_intp_rune(in_str string) string {
-	return 'str_intp(2, _MOV((StrIntpData[]){{_S("\`"), ${si_s_code}, {.d_s = ${in_str}}},{_S("\`"), 0, {.d_c = 0 }}}))'
+	return 'builtin__str_intp(2, _MOV((StrIntpData[]){{_S("\`"), ${si_s_code}, {.d_s = ${in_str}}},{_S("\`"), 0, {.d_c = 0 }}}))'
 }
 
 @[inline]
 pub fn str_intp_g32(in_str string) string {
-	return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${si_g32_code}, {.d_f32 = ${in_str} }}}))'
+	return 'builtin__str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${si_g32_code}, {.d_f32 = ${in_str} }}}))'
 }
 
 @[inline]
 pub fn str_intp_g64(in_str string) string {
-	return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${si_g64_code}, {.d_f64 = ${in_str} }}}))'
+	return 'builtin__str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${si_g64_code}, {.d_f64 = ${in_str} }}}))'
 }
 
 // replace %% with the in_str
@@ -752,12 +752,12 @@ pub fn str_intp_sub(base_str string, in_str string) string {
 		st_str := base_str[..index]
 		if index + 2 < base_str.len {
 			en_str := base_str[index + 2..]
-			res_str := 'str_intp(2, _MOV((StrIntpData[]){{_S("${st_str}"), ${si_s_code}, {.d_s = ${in_str} }},{_S("${en_str}"), 0, {.d_c = 0}}}))'
+			res_str := 'builtin__str_intp(2, _MOV((StrIntpData[]){{_S("${st_str}"), ${si_s_code}, {.d_s = ${in_str} }},{_S("${en_str}"), 0, {.d_c = 0}}}))'
 			st_str.free()
 			en_str.free()
 			return res_str
 		}
-		res2_str := 'str_intp(1, _MOV((StrIntpData[]){{_S("${st_str}"), ${si_s_code}, {.d_s = ${in_str} }}}))'
+		res2_str := 'builtin__str_intp(1, _MOV((StrIntpData[]){{_S("${st_str}"), ${si_s_code}, {.d_s = ${in_str} }}}))'
 		st_str.free()
 		return res2_str
 	}

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -37,9 +37,9 @@ fn (mut g Gen) array_init(node ast.ArrayInit, var_name string) {
 		elem_styp := g.styp(elem_type.typ)
 		noscan := g.check_noscan(elem_type.typ)
 		if elem_type.unaliased_sym.kind == .function {
-			g.write('new_array_from_c_array(${len}, ${len}, sizeof(voidptr), _MOV((voidptr[${len}]){')
+			g.write('builtin__new_array_from_c_array(${len}, ${len}, sizeof(voidptr), _MOV((voidptr[${len}]){')
 		} else {
-			g.write('new_array_from_c_array${noscan}(${len}, ${len}, sizeof(${elem_styp}), _MOV((${elem_styp}[${len}]){')
+			g.write('builtin__new_array_from_c_array${noscan}(${len}, ${len}, sizeof(${elem_styp}), _MOV((${elem_styp}[${len}]){')
 		}
 		if len > 8 {
 			g.writeln('')
@@ -53,7 +53,7 @@ fn (mut g Gen) array_init(node ast.ArrayInit, var_name string) {
 				if is_iface_or_sumtype {
 					g.expr_with_cast(expr, expr_type, node.elem_type)
 				} else {
-					g.write('string_clone(')
+					g.write('builtin__string_clone(')
 					g.expr(expr)
 					g.write(')')
 				}
@@ -305,11 +305,11 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 			g.write('${ret_typ} ${past.tmp_var} =')
 		}
 		if is_default_array {
-			g.write('__new_array_with_array_default${noscan}(')
+			g.write('builtin____new_array_with_array_default${noscan}(')
 		} else if is_default_map {
-			g.write('__new_array_with_map_default${noscan}(')
+			g.write('builtin____new_array_with_map_default${noscan}(')
 		} else {
-			g.write('__new_array_with_default${noscan}(')
+			g.write('builtin____new_array_with_default${noscan}(')
 		}
 		if node.has_len {
 			g.expr(node.len_expr)
@@ -375,13 +375,13 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		return
 	}
 	if is_default_array {
-		g.write('__new_array_with_array_default${noscan}(')
+		g.write('builtin____new_array_with_array_default${noscan}(')
 	} else if is_default_map {
-		g.write('__new_array_with_map_default${noscan}(')
+		g.write('builtin____new_array_with_map_default${noscan}(')
 	} else if needs_more_defaults {
-		g.write('__new_array_with_multi_default${noscan}(')
+		g.write('builtin____new_array_with_multi_default${noscan}(')
 	} else {
-		g.write('__new_array_with_default${noscan}(')
+		g.write('builtin____new_array_with_default${noscan}(')
 	}
 	if node.has_len {
 		g.expr(node.len_expr)
@@ -419,7 +419,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		line := g.go_before_last_stmt().trim_space()
 		g.empty_line = true
 
-		g.write('${elem_styp}* ${tmp} = (${elem_styp}*) _v_malloc((')
+		g.write('${elem_styp}* ${tmp} = (${elem_styp}*) builtin___v_malloc((')
 		g.expr(node.len_expr)
 		g.writeln(') * sizeof(${elem_styp}));')
 		ind := g.new_tmp_var()
@@ -553,7 +553,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 	has_infix_left_var_name := g.write_prepared_tmp_value(past.tmp_var, node, ret_styp,
 		'{0}')
 	if left_is_array {
-		g.writeln('${past.tmp_var} = __new_array${noscan}(0, ${past.tmp_var}_len, sizeof(${ret_elem_styp}));\n')
+		g.writeln('${past.tmp_var} = builtin____new_array${noscan}(0, ${past.tmp_var}_len, sizeof(${ret_elem_styp}));\n')
 	}
 
 	mut closure_var := ''
@@ -667,7 +667,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 		}
 	}
 	if left_is_array {
-		g.writeln2(';', 'array_push${noscan}((array*)&${past.tmp_var}, &${tmp_map_expr_result_name});')
+		g.writeln2(';', 'builtin__array_push${noscan}((array*)&${past.tmp_var}, &${tmp_map_expr_result_name});')
 	} else {
 		g.writeln2(';', '${past.tmp_var}[${i}] = ${tmp_map_expr_result_name};')
 	}
@@ -706,11 +706,11 @@ fn (mut g Gen) gen_array_sorted(node ast.CallExpr) {
 			false
 		}
 		if !deref_field {
-			g.write('${atype} ${past.tmp_var} = array_clone_to_depth(ADDR(${atype},')
+			g.write('${atype} ${past.tmp_var} = builtin__array_clone_to_depth(ADDR(${atype},')
 			g.expr(node.left)
 			g.writeln('), ${depth});')
 		} else {
-			g.write('${atype} ${past.tmp_var} = array_clone_to_depth(')
+			g.write('${atype} ${past.tmp_var} = builtin__array_clone_to_depth(')
 			g.expr(node.left)
 			g.writeln(', ${depth});')
 		}
@@ -827,9 +827,19 @@ fn (mut g Gen) gen_array_sort(node ast.CallExpr) {
 	stype_arg := g.styp(elem_type)
 	g.sort_fn_definitions.writeln('VV_LOC ${g.static_modifier} int ${compare_fn}(${stype_arg}* a, ${stype_arg}* b) {')
 	c_condition := if comparison_type.sym.has_method('<') {
-		'${g.styp(comparison_type.typ)}__lt(${left_expr}, ${right_expr})'
+		method_name := if comparison_type.sym.is_builtin() {
+			'builtin__${g.styp(comparison_type.typ)}__lt'
+		} else {
+			'${g.styp(comparison_type.typ)}__lt'
+		}
+		'${method_name}(${left_expr}, ${right_expr})'
 	} else if comparison_type.unaliased_sym.has_method('<') {
-		'${g.styp(comparison_type.unaliased)}__lt(${left_expr}, ${right_expr})'
+		method_name := if comparison_type.unaliased_sym.is_builtin() {
+			'builtin__${g.styp(comparison_type.unaliased)}__lt'
+		} else {
+			'${g.styp(comparison_type.unaliased)}__lt'
+		}
+		'${method_name}(${left_expr}, ${right_expr})'
 	} else if use_lambda {
 		'${lambda_fn_name}(a, b)'
 	} else {
@@ -971,7 +981,7 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 	elem_type_str := g.styp(info.elem_type)
 	noscan := g.check_noscan(info.elem_type)
 	has_infix_left_var_name := g.write_prepared_tmp_value(past.tmp_var, node, styp, '{0}')
-	g.writeln('${past.tmp_var} = __new_array${noscan}(0, ${past.tmp_var}_len, sizeof(${elem_type_str}));\n')
+	g.writeln('${past.tmp_var} = builtin____new_array${noscan}(0, ${past.tmp_var}_len, sizeof(${elem_type_str}));\n')
 
 	mut expr := node.args[0].expr
 	var_name := g.get_array_expr_param_name(mut expr)
@@ -1034,7 +1044,7 @@ fn (mut g Gen) gen_array_filter(node ast.CallExpr) {
 			g.expr(expr)
 		}
 	}
-	g.writeln2(') {', '\tarray_push${noscan}((array*)&${past.tmp_var}, &${var_name});')
+	g.writeln2(') {', '\tbuiltin__array_push${noscan}((array*)&${past.tmp_var}, &${var_name});')
 	g.writeln('}')
 	g.indent--
 	g.writeln('}')
@@ -1058,9 +1068,9 @@ fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
 	noscan := g.check_noscan(left_info.elem_type)
 	addr := if node.left_type.is_ptr() { '' } else { '&' }
 	if is_arg2_array {
-		g.write('array_insert_many${noscan}(${addr}')
+		g.write('builtin__array_insert_many${noscan}(${addr}')
 	} else {
-		g.write('array_insert${noscan}(${addr}')
+		g.write('builtin__array_insert${noscan}(${addr}')
 	}
 	g.expr(node.left)
 	g.write(', ')
@@ -1076,7 +1086,7 @@ fn (mut g Gen) gen_array_insert(node ast.CallExpr) {
 			&& node.args[1].expr !in [ast.IndexExpr, ast.CallExpr, ast.StringLiteral, ast.StringInterLiteral, ast.InfixExpr]
 		g.write(', &(${elem_type_str}[]){')
 		if needs_clone {
-			g.write('string_clone(')
+			g.write('builtin__string_clone(')
 		}
 		g.expr_with_cast(node.args[1].expr, node.args[1].typ, left_info.elem_type)
 		if needs_clone {
@@ -1097,9 +1107,9 @@ fn (mut g Gen) gen_array_prepend(node ast.CallExpr) {
 	noscan := g.check_noscan(left_info.elem_type)
 	addr := if node.left_type.is_ptr() { '' } else { '&' }
 	if is_arg_array {
-		g.write('array_prepend_many${noscan}(${addr}')
+		g.write('builtin__array_prepend_many${noscan}(${addr}')
 	} else {
-		g.write('array_prepend${noscan}(${addr}')
+		g.write('builtin__array_prepend${noscan}(${addr}')
 	}
 	g.expr(node.left)
 	if is_arg_array {
@@ -1164,7 +1174,7 @@ fn (mut g Gen) gen_array_contains_methods() {
 			fn_builder.writeln('${g.static_non_parallel}bool ${fn_name}(${left_type_str} a, ${elem_type_str} v) {')
 			fn_builder.writeln('\tfor (int i = 0; i < a.len; ++i) {')
 			if elem_kind == .string {
-				fn_builder.writeln('\t\tif (fast_string_eq(((string*)a.data)[i], v)) {')
+				fn_builder.writeln('\t\tif (builtin__fast_string_eq(((string*)a.data)[i], v)) {')
 			} else if elem_kind in [.array, .array_fixed] && elem_is_not_ptr {
 				ptr_typ := g.equality_fn(elem_type)
 				fn_builder.writeln('\t\tif (${ptr_typ}_arr_eq(((${elem_type_str}*)a.data)[i], v)) {')
@@ -1206,7 +1216,7 @@ fn (mut g Gen) gen_array_contains_methods() {
 			fn_builder.writeln('${g.static_non_parallel}bool ${fn_name}(${left_type_str} a, ${elem_type_str} v) {')
 			fn_builder.writeln('\tfor (int i = 0; i < ${size}; ++i) {')
 			if elem_kind == .string {
-				fn_builder.writeln('\t\tif (fast_string_eq(a[i], v)) {')
+				fn_builder.writeln('\t\tif (builtin__fast_string_eq(a[i], v)) {')
 			} else if elem_kind in [.array, .array_fixed] && elem_is_not_ptr {
 				ptr_typ := g.equality_fn(left_info.elem_type)
 				fn_builder.writeln('\t\tif (${ptr_typ}_arr_eq(a[i], v)) {')
@@ -1313,7 +1323,7 @@ fn (mut g Gen) gen_array_index_methods() {
 			fn_builder.writeln('\t${elem_type_str}* pelem = a.data;')
 			fn_builder.writeln('\tfor (int i = 0; i < a.len; ++i, ++pelem) {')
 			if elem_sym.kind == .string {
-				fn_builder.writeln('\t\tif (fast_string_eq(*pelem, v)) {')
+				fn_builder.writeln('\t\tif (builtin__fast_string_eq(*pelem, v)) {')
 			} else if elem_sym.kind in [.array, .array_fixed] && !info.elem_type.is_ptr() {
 				ptr_typ := g.equality_fn(info.elem_type)
 				fn_builder.writeln('\t\tif (${ptr_typ}_arr_eq(*pelem, v)) {')
@@ -1356,7 +1366,7 @@ fn (mut g Gen) gen_array_index_methods() {
 			fn_builder.writeln('${g.static_non_parallel}int ${fn_name}(${left_type_str} a, ${elem_type_str} v) {')
 			fn_builder.writeln('\tfor (int i = 0; i < ${info.size}; ++i) {')
 			if elem_sym.kind == .string {
-				fn_builder.writeln('\t\tif (fast_string_eq(a[i], v)) {')
+				fn_builder.writeln('\t\tif (builtin__fast_string_eq(a[i], v)) {')
 			} else if elem_sym.kind in [.array, .array_fixed] && !info.elem_type.is_ptr() {
 				ptr_typ := g.equality_fn(info.elem_type)
 				fn_builder.writeln('\t\tif (${ptr_typ}_arr_eq(a[i], v)) {')

--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -58,7 +58,7 @@ fn (mut g Gen) assert_stmt(original_assert_statement ast.AssertStmt) {
 		g.decrement_inside_ternary()
 		g.writeln(' {')
 		metaname_panic := g.gen_assert_metainfo(node, .panic)
-		g.writeln('\t__print_assert_failure(&${metaname_panic});')
+		g.writeln('\tbuiltin____print_assert_failure(&${metaname_panic});')
 		g.gen_assert_postfailure_mode(node)
 		g.writeln('}')
 	}
@@ -125,7 +125,7 @@ fn (mut g Gen) gen_assert_postfailure_mode(node ast.AssertStmt) {
 	}
 	g.writeln2('\t// TODO', '\t// Maybe print all vars in a test function if it fails?')
 	if g.pref.assert_failure_mode != .continues {
-		g.writeln('\t_v_panic(_S("Assertion failed..."));')
+		g.writeln('\tbuiltin___v_panic(_S("Assertion failed..."));')
 	}
 }
 
@@ -241,7 +241,7 @@ fn (mut g Gen) gen_assert_single_expr(expr ast.Expr, typ ast.Type) {
 				}
 			}
 			if should_clone {
-				g.write('string_clone(')
+				g.write('builtin__string_clone(')
 			}
 			g.gen_expr_to_string(expr, typ)
 			if should_clone {

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -80,7 +80,7 @@ fn (mut g Gen) gen_sumtype_equality_fn(left_type ast.Type) string {
 		if variant.typ.has_flag(.option) {
 			fn_builder.writeln('\t\treturn ((*${left_arg}).state == 2 && (*${right_arg}).state == 2) || !memcmp(&(*${left_arg}).data, &(*${right_arg}).data, sizeof(${g.base_type(variant.typ)}));')
 		} else if variant.sym.kind == .string {
-			fn_builder.writeln('\t\treturn string__eq(*${left_arg}, *${right_arg});')
+			fn_builder.writeln('\t\treturn builtin__string__eq(*${left_arg}, *${right_arg});')
 		} else if variant.sym.kind == .sum_type && !typ.is_ptr() {
 			eq_fn := g.gen_sumtype_equality_fn(typ)
 			fn_builder.writeln('\t\treturn ${eq_fn}_sumtype_eq(*${left_arg}, *${right_arg});')
@@ -227,9 +227,9 @@ fn (mut g Gen) gen_struct_equality_fn(left_type ast.Type) string {
 				}
 
 				if field.typ.is_ptr() {
-					fn_builder.write_string('(${left_arg} == ${right_arg} || (${left_arg} != 0 &&  ${right_arg} != 0 && ((${left_arg})->len == (${right_arg})->len && (${left_arg})->len == 0) || fast_string_eq(*(${left_arg}), *(${right_arg}))))')
+					fn_builder.write_string('(${left_arg} == ${right_arg} || (${left_arg} != 0 &&  ${right_arg} != 0 && ((${left_arg})->len == (${right_arg})->len && (${left_arg})->len == 0) || builtin__fast_string_eq(*(${left_arg}), *(${right_arg}))))')
 				} else {
-					fn_builder.write_string('(((${left_arg}).len == (${right_arg}).len && (${left_arg}).len == 0) || fast_string_eq(${left_arg}, ${right_arg}))')
+					fn_builder.write_string('(((${left_arg}).len == (${right_arg}).len && (${left_arg}).len == 0) || builtin__fast_string_eq(${left_arg}, ${right_arg}))')
 				}
 			} else if field_type.sym.kind == .sum_type && !field.typ.is_ptr() {
 				eq_fn := g.gen_sumtype_equality_fn(field.typ)
@@ -316,9 +316,9 @@ fn (mut g Gen) gen_alias_equality_fn(left_type ast.Type) string {
 		if info.parent_type.has_flag(.option) {
 			left_var = '*' + g.read_opt(info.parent_type, 'a')
 			right_var = '*' + g.read_opt(info.parent_type, 'b')
-			fn_builder.writeln('\treturn ((${left_var}).len == (${right_var}).len && (${left_var}).len == 0) || fast_string_eq(${left_var}, ${right_var});')
+			fn_builder.writeln('\treturn ((${left_var}).len == (${right_var}).len && (${left_var}).len == 0) || builtin__fast_string_eq(${left_var}, ${right_var});')
 		} else {
-			fn_builder.writeln('\treturn string__eq(a, b);')
+			fn_builder.writeln('\treturn builtin__string__eq(a, b);')
 		}
 	} else if sym.kind == .sum_type && !left.typ.is_ptr() {
 		eq_fn := g.gen_sumtype_equality_fn(info.parent_type)
@@ -387,7 +387,7 @@ fn (mut g Gen) gen_array_equality_fn(left_type ast.Type) string {
 	fn_builder.writeln('\tfor (int i = 0; i < ${left_len}; ++i) {')
 	// compare every pair of elements of the two arrays
 	if elem.sym.kind == .string {
-		fn_builder.writeln('\t\tif (!string__eq(*((${ptr_elem_styp}*)((byte*)${left_data}+(i*${left_elem}))), *((${ptr_elem_styp}*)((byte*)${right_data}+(i*${right_elem}))))) {')
+		fn_builder.writeln('\t\tif (!builtin__string__eq(*((${ptr_elem_styp}*)((byte*)${left_data}+(i*${left_elem}))), *((${ptr_elem_styp}*)((byte*)${right_data}+(i*${right_elem}))))) {')
 	} else if elem.sym.kind == .sum_type && !elem.typ.is_ptr() {
 		eq_fn := g.gen_sumtype_equality_fn(elem.typ)
 		fn_builder.writeln('\t\tif (!${eq_fn}_sumtype_eq(((${ptr_elem_styp}*)${left_data})[i], ((${ptr_elem_styp}*)${right_data})[i])) {')
@@ -476,7 +476,7 @@ fn (mut g Gen) gen_fixed_array_equality_fn(left_type ast.Type) string {
 	fn_builder.writeln('\tfor (int i = 0; i < ${size}; ++i) {')
 	// compare every pair of elements of the two fixed arrays
 	if elem.sym.kind == .string {
-		fn_builder.writeln('\t\tif (!string__eq(((string*)${left})[i], ((string*)${right})[i])) {')
+		fn_builder.writeln('\t\tif (!builtin__string__eq(((string*)${left})[i], ((string*)${right})[i])) {')
 	} else if elem.sym.kind == .sum_type && !elem.typ.is_ptr() {
 		eq_fn := g.gen_sumtype_equality_fn(elem.typ)
 		fn_builder.writeln('\t\tif (!${eq_fn}_sumtype_eq(${left}[i], ${right}[i])) {')
@@ -539,58 +539,58 @@ fn (mut g Gen) gen_map_equality_fn(left_type ast.Type) string {
 	fn_builder.writeln('\t\treturn false;')
 	fn_builder.writeln('\t}')
 	fn_builder.writeln('\tfor (int i = 0; i < ${key_values}.len; ++i) {')
-	fn_builder.writeln('\t\tif (!DenseArray_has_index(&${key_values}, i)) continue;')
-	fn_builder.writeln('\t\tvoidptr k = DenseArray_key(&${key_values}, i);')
-	fn_builder.writeln('\t\tif (!map_exists(${b}, k)) return false;')
+	fn_builder.writeln('\t\tif (!builtin__DenseArray_has_index(&${key_values}, i)) continue;')
+	fn_builder.writeln('\t\tvoidptr k = builtin__DenseArray_key(&${key_values}, i);')
+	fn_builder.writeln('\t\tif (!builtin__map_exists(${b}, k)) return false;')
 	kind := g.table.type_kind(value.typ)
 	if kind == .function {
 		info := value.sym.info as ast.FnType
 		sig := g.fn_var_signature(info.func.return_type, info.func.params.map(it.typ),
 			'v')
-		fn_builder.writeln('\t\t${sig} = *(voidptr*)map_get(${a}, k, &(voidptr[]){ 0 });')
+		fn_builder.writeln('\t\t${sig} = *(voidptr*)builtin__map_get(${a}, k, &(voidptr[]){ 0 });')
 	} else {
-		fn_builder.writeln('\t\t${ptr_value_styp} v = *(${ptr_value_styp}*)map_get(${a}, k, &(${ptr_value_styp}[]){ 0 });')
+		fn_builder.writeln('\t\t${ptr_value_styp} v = *(${ptr_value_styp}*)builtin__map_get(${a}, k, &(${ptr_value_styp}[]){ 0 });')
 	}
 	match kind {
 		.string {
-			fn_builder.writeln('\t\tif (!fast_string_eq(*(string*)map_get(${b}, k, &(string[]){_S("")}), v)) {')
+			fn_builder.writeln('\t\tif (!builtin__fast_string_eq(*(string*)builtin__map_get(${b}, k, &(string[]){_S("")}), v)) {')
 		}
 		.sum_type {
 			eq_fn := g.gen_sumtype_equality_fn(value.typ)
-			fn_builder.writeln('\t\tif (!${eq_fn}_sumtype_eq(*(${ptr_value_styp}*)map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
+			fn_builder.writeln('\t\tif (!${eq_fn}_sumtype_eq(*(${ptr_value_styp}*)builtin__map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
 		}
 		.struct {
 			eq_fn := g.gen_struct_equality_fn(value.typ)
-			fn_builder.writeln('\t\tif (!${eq_fn}_struct_eq(*(${ptr_value_styp}*)map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
+			fn_builder.writeln('\t\tif (!${eq_fn}_struct_eq(*(${ptr_value_styp}*)builtin__map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
 		}
 		.interface {
 			eq_fn := g.gen_interface_equality_fn(value.typ)
-			fn_builder.writeln('\t\tif (!${eq_fn}_interface_eq(*(${ptr_value_styp}*)map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
+			fn_builder.writeln('\t\tif (!${eq_fn}_interface_eq(*(${ptr_value_styp}*)builtin__map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
 		}
 		.array {
 			eq_fn := g.gen_array_equality_fn(value.typ)
-			fn_builder.writeln('\t\tif (!${eq_fn}_arr_eq(*(${ptr_value_styp}*)map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
+			fn_builder.writeln('\t\tif (!${eq_fn}_arr_eq(*(${ptr_value_styp}*)builtin__map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
 		}
 		.array_fixed {
 			eq_fn := g.gen_fixed_array_equality_fn(value.typ)
-			fn_builder.writeln('\t\tif (!${eq_fn}_arr_eq(*(${ptr_value_styp}*)map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
+			fn_builder.writeln('\t\tif (!${eq_fn}_arr_eq(*(${ptr_value_styp}*)builtin__map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
 		}
 		.map {
 			eq_fn := g.gen_map_equality_fn(value.typ)
-			fn_builder.writeln('\t\tif (!${eq_fn}_map_eq(*(${ptr_value_styp}*)map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
+			fn_builder.writeln('\t\tif (!${eq_fn}_map_eq(*(${ptr_value_styp}*)builtin__map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
 		}
 		.alias {
 			eq_fn := g.gen_alias_equality_fn(value.typ)
-			fn_builder.writeln('\t\tif (!${eq_fn}_alias_eq(*(${ptr_value_styp}*)map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
+			fn_builder.writeln('\t\tif (!${eq_fn}_alias_eq(*(${ptr_value_styp}*)builtin__map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }), v)) {')
 		}
 		.function {
-			fn_builder.writeln('\t\tif (*(voidptr*)map_get(${b}, k, &(voidptr[]){ 0 }) != v) {')
+			fn_builder.writeln('\t\tif (*(voidptr*)builtin__map_get(${b}, k, &(voidptr[]){ 0 }) != v) {')
 		}
 		else {
 			if value.typ.has_flag(.option) {
-				fn_builder.writeln('\t\tif (memcmp(v.data, ((${ptr_value_styp}*)map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }))->data, sizeof(${g.base_type(value.typ)})) != 0) {')
+				fn_builder.writeln('\t\tif (memcmp(v.data, ((${ptr_value_styp}*)builtin__map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }))->data, sizeof(${g.base_type(value.typ)})) != 0) {')
 			} else {
-				fn_builder.writeln('\t\tif (*(${ptr_value_styp}*)map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }) != v) {')
+				fn_builder.writeln('\t\tif (*(${ptr_value_styp}*)builtin__map_get(${b}, k, &(${ptr_value_styp}[]){ 0 }) != v) {')
 			}
 		}
 	}
@@ -647,7 +647,7 @@ fn (mut g Gen) gen_interface_equality_fn(left_type ast.Type) string {
 				.string {
 					l_str := g.read_field(left_type, '_string', 'a')
 					r_str := g.read_field(left_type, '_string', 'b')
-					fn_builder.write_string('string__eq(*(${l_str}), *(${r_str}))')
+					fn_builder.write_string('builtin__string__eq(*(${l_str}), *(${r_str}))')
 				}
 				.sum_type {
 					eq_fn := g.gen_sumtype_equality_fn(typ)

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -48,12 +48,12 @@ fn (mut g Gen) gen_str_default(sym ast.TypeSymbol, styp string, str_fn_name stri
 	g.definitions.writeln('string ${str_fn_name}(${styp} it);')
 	g.auto_str_funcs.writeln('string ${str_fn_name}(${styp} it) {')
 	if convertor == 'bool' {
-		g.auto_str_funcs.writeln('\tstring tmp1 = string__plus(_S("${styp}("), (${convertor})it ? _S("true") : _S("false"));')
+		g.auto_str_funcs.writeln('\tstring tmp1 = builtin__string__plus(_S("${styp}("), (${convertor})it ? _S("true") : _S("false"));')
 	} else {
-		g.auto_str_funcs.writeln('\tstring tmp1 = string__plus(_S("${styp}("), tos3(${typename_}_str((${convertor})it).str));')
+		g.auto_str_funcs.writeln('\tstring tmp1 = builtin__string__plus(_S("${styp}("), builtin__tos3(_string__plus(_S("${typename_}("), _string__plus(_S(")"), _S(")"))).str));')
 	}
-	g.auto_str_funcs.writeln('\tstring tmp2 = string__plus(tmp1, _S(")"));')
-	g.auto_str_funcs.writeln('\tstring_free(&tmp1);')
+	g.auto_str_funcs.writeln('\tstring tmp2 = builtin__string__plus(tmp1, _S(")"));')
+	g.auto_str_funcs.writeln('\tbuiltin__string_free(&tmp1);')
 	g.auto_str_funcs.writeln('\treturn tmp2;')
 	g.auto_str_funcs.writeln('}')
 }
@@ -89,6 +89,9 @@ fn (mut g Gen) get_str_fn(typ ast.Type) string {
 			str_fn_name = styp_to_str_fn_name(sym.name)
 		}
 	}
+	if sym.is_builtin() && !str_fn_name.starts_with('builtin__') {
+		str_fn_name = 'builtin__${str_fn_name}'
+	}
 	if sym.has_method_with_generic_parent('str') {
 		match mut sym.info {
 			ast.Struct, ast.SumType, ast.Interface {
@@ -121,7 +124,7 @@ fn (mut g Gen) final_gen_str(typ StrType) {
 		return
 	}
 	styp := typ.styp
-	str_fn_name := styp_to_str_fn_name(styp)
+	str_fn_name := g.get_str_fn(typ.typ)
 	if str_fn_name in g.str_fn_names {
 		return
 	}
@@ -219,7 +222,7 @@ fn (mut g Gen) gen_str_for_option(typ ast.Type, styp string, str_fn_name string)
 	}
 	if sym.kind == .string {
 		if typ.nr_muls() > 1 {
-			g.auto_str_funcs.writeln('\t\tres = ptr_str(*(${sym.cname}**)&it.data);')
+			g.auto_str_funcs.writeln('\t\tres = builtin__ptr_str(*(${sym.cname}**)&it.data);')
 		} else {
 			tmp_res := '${parent_str_fn_name}(${deref}it.data)'
 			g.auto_str_funcs.writeln('\t\tres = ${str_intp_sq(tmp_res)};')
@@ -230,7 +233,7 @@ fn (mut g Gen) gen_str_for_option(typ ast.Type, styp string, str_fn_name string)
 		g.auto_str_funcs.writeln('\t\tres = ${parent_str_fn_name}();')
 	} else {
 		if typ.nr_muls() > 1 {
-			g.auto_str_funcs.writeln('\t\tres = ptr_str(*(${sym.cname}**)&it.data);')
+			g.auto_str_funcs.writeln('\t\tres = builtin__ptr_str(*(${sym.cname}**)&it.data);')
 		} else {
 			g.auto_str_funcs.writeln('\t\tres = ${parent_str_fn_name}(${deref}it.data);')
 		}
@@ -293,7 +296,7 @@ fn (mut g Gen) gen_str_for_alias(info ast.Alias, styp string, str_fn_name string
 	g.auto_str_funcs.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${arg_def}, int indent_count) {')
 	old := g.reset_tmp_count()
 	defer { g.tmp_count = old }
-	g.auto_str_funcs.writeln('\tstring indents = string_repeat(_S("    "), indent_count);')
+	g.auto_str_funcs.writeln('\tstring indents = builtin__string_repeat(_S("    "), indent_count);')
 	if str_method_expects_ptr {
 		it_arg := if is_c_struct { 'it' } else { '&it' }
 		g.auto_str_funcs.writeln('\tstring tmp_ds = ${parent_str_fn_name}(${it_arg});')
@@ -301,13 +304,13 @@ fn (mut g Gen) gen_str_for_alias(info ast.Alias, styp string, str_fn_name string
 		deref, _ := deref_kind(str_method_expects_ptr, info.parent_type.is_ptr(), info.parent_type)
 		g.auto_str_funcs.writeln('\tstring tmp_ds = ${parent_str_fn_name}(${deref}it);')
 	}
-	g.auto_str_funcs.writeln('\tstring res = str_intp(3, _MOV((StrIntpData[]){
+	g.auto_str_funcs.writeln('\tstring res = builtin__str_intp(3, _MOV((StrIntpData[]){
 		{_SLIT0, ${si_s_code}, {.d_s = indents }},
 		{_S("${clean_type_v_type_name}("), ${si_s_code}, {.d_s = tmp_ds }},
 		{_S(")"), 0, {.d_c = 0 }}
 	}));')
-	g.auto_str_funcs.writeln('\tstring_free(&indents);')
-	g.auto_str_funcs.writeln('\tstring_free(&tmp_ds);')
+	g.auto_str_funcs.writeln('\tbuiltin__string_free(&indents);')
+	g.auto_str_funcs.writeln('\tbuiltin__string_free(&tmp_ds);')
 	g.auto_str_funcs.writeln('\treturn res;')
 	g.auto_str_funcs.writeln('}')
 }
@@ -374,9 +377,9 @@ fn (mut g Gen) gen_str_for_enum(info ast.Enum, styp string, str_fn_name string) 
 		g.auto_str_funcs.writeln('\tu64 zit = (u64)it;')
 		for i, val in info.vals {
 			mask := u64(1) << i
-			g.auto_str_funcs.writeln('\tif (zit & 0x${mask:016x}U) {if (!first) {ret = string__plus(ret, _S(" | "));} ret = string__plus(ret, _S(".${val}")); first = 0;}')
+			g.auto_str_funcs.writeln('\tif (zit & 0x${mask:016x}U) {if (!first) {ret = builtin__string__plus(ret, _S(" | "));} ret = builtin__string__plus(ret, _S(".${val}")); first = 0;}')
 		}
-		g.auto_str_funcs.writeln('\tret = string__plus(ret, _S("}"));')
+		g.auto_str_funcs.writeln('\tret = builtin__string__plus(ret, _S("}"));')
 		g.auto_str_funcs.writeln('\treturn ret;')
 	} else if info.uses_exprs {
 		// The enum values could be C macros, expanded later to duplicate values, and we do not know if that is the case, so we can not use a switch here.
@@ -433,7 +436,7 @@ fn (mut g Gen) gen_str_for_interface(info ast.Interface, styp string, typ_str st
 				val += ', indent_count'
 			}
 			val += ')'
-			res := 'str_intp(2, _MOV((StrIntpData[]){
+			res := 'builtin__str_intp(2, _MOV((StrIntpData[]){
 				{_S("${clean_interface_v_type_name}(\'"), ${si_s_code}, {.d_s = ${val}}},
 				{_S("\')"), 0, {.d_c = 0 }}
 			}))'
@@ -446,7 +449,7 @@ fn (mut g Gen) gen_str_for_interface(info ast.Interface, styp string, typ_str st
 					val += ', indent_count'
 				}
 				val += ')'
-				res := 'str_intp(2, _MOV((StrIntpData[]){
+				res := 'builtin__str_intp(2, _MOV((StrIntpData[]){
 					{_S("${clean_interface_v_type_name}("), ${si_s_code}, {.d_s = ${val}}},
 					{_S(")"), 0, {.d_c = 0 }}
 				}))'
@@ -508,7 +511,7 @@ fn (mut g Gen) gen_str_for_union_sum_type(info ast.SumType, styp string, typ_str
 				val += ', indent_count'
 			}
 			val += ')'
-			res := 'str_intp(2, _MOV((StrIntpData[]){
+			res := 'builtin__str_intp(2, _MOV((StrIntpData[]){
 				{_S("${clean_sum_type_v_type_name}(\'"), ${si_s_code}, {.d_s = ${val}}},
 				{_S("\')"), 0, {.d_c = 0 }}
 			}))'
@@ -520,7 +523,7 @@ fn (mut g Gen) gen_str_for_union_sum_type(info ast.SumType, styp string, typ_str
 				val += ', indent_count'
 			}
 			val += ')'
-			res := 'str_intp(2, _MOV((StrIntpData[]){
+			res := 'builtin__str_intp(2, _MOV((StrIntpData[]){
 				{_S("${clean_sum_type_v_type_name}("), ${si_s_code}, {.d_s = ${val}}},
 				{_S(")"), 0, {.d_c = 0 }}
 			}))'
@@ -639,9 +642,9 @@ fn (mut g Gen) gen_str_for_array(info ast.Array, styp string, str_fn_name string
 	} else {
 		if !typ.has_flag(.option) && sym.kind == .array_fixed {
 			g.auto_str_funcs.writeln('\t\t${field_styp} it;')
-			g.auto_str_funcs.writeln('\t\tmemcpy(*(${field_styp}*)it, (byte*)array_get(a, i), sizeof(${field_styp}));')
+			g.auto_str_funcs.writeln('\t\tmemcpy(*(${field_styp}*)it, (byte*)builtin__array_get(a, i), sizeof(${field_styp}));')
 		} else {
-			g.auto_str_funcs.writeln('\t\t${field_styp} it = *(${field_styp}*)array_get(a, i);')
+			g.auto_str_funcs.writeln('\t\t${field_styp} it = *(${field_styp}*)builtin__array_get(a, i);')
 		}
 		if should_use_indent_func(sym.kind) && !sym_has_str_method {
 			if is_elem_ptr {
@@ -672,15 +675,15 @@ fn (mut g Gen) gen_str_for_array(info ast.Array, styp string, str_fn_name string
 			}
 		} else if sym.kind == .rune {
 			// Rune are managed at this level as strings
-			g.auto_str_funcs.writeln('\t\tstring x = str_intp(2, _MOV((StrIntpData[]){{_S("\`"), ${si_s_code}, {.d_s = ${elem_str_fn_name}(it) }}, {_S("\`"), 0, {.d_c = 0 }}}));\n')
+			g.auto_str_funcs.writeln('\t\tstring x = builtin__str_intp(2, _MOV((StrIntpData[]){{_S("\`"), ${si_s_code}, {.d_s = ${elem_str_fn_name}(it) }}, {_S("\`"), 0, {.d_c = 0 }}}));\n')
 		} else if sym.kind == .string {
 			if typ.has_flag(.option) {
 				func := g.get_str_fn(typ)
 				g.auto_str_funcs.writeln('\t\tstring x = ${func}(it);\n')
 			} else if is_elem_ptr {
-				g.auto_str_funcs.writeln('\t\tstring x = str_intp(2, _MOV((StrIntpData[]){{_S("&\'"), ${si_s_code}, {.d_s = *it }}, {_S("\'"), 0, {.d_c = 0 }}}));\n')
+				g.auto_str_funcs.writeln('\t\tstring x = builtin__str_intp(2, _MOV((StrIntpData[]){{_S("&\'"), ${si_s_code}, {.d_s = *it }}, {_S("\'"), 0, {.d_c = 0 }}}));\n')
 			} else {
-				g.auto_str_funcs.writeln('\t\tstring x = str_intp(2, _MOV((StrIntpData[]){{_S("\'"), ${si_s_code}, {.d_s = it }}, {_S("\'"), 0, {.d_c = 0 }}}));\n')
+				g.auto_str_funcs.writeln('\t\tstring x = builtin__str_intp(2, _MOV((StrIntpData[]){{_S("\'"), ${si_s_code}, {.d_s = it }}, {_S("\'"), 0, {.d_c = 0 }}}));\n')
 			}
 		} else {
 			// There is a custom .str() method, so use it.
@@ -706,7 +709,7 @@ fn (mut g Gen) gen_str_for_array(info ast.Array, styp string, str_fn_name string
 	g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, x);')
 	if g.is_autofree && typ != ast.bool_type {
 		// no need to free "true"/"false" literals
-		g.auto_str_funcs.writeln('\t\tstring_free(&x);')
+		g.auto_str_funcs.writeln('\t\tbuiltin__string_free(&x);')
 	}
 	g.auto_str_funcs.writeln('\t\tif (i < a.len-1) {')
 	g.auto_str_funcs.writeln('\t\t\tstrings__Builder_write_string(&sb, _S(", "));')
@@ -797,7 +800,7 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 		key_sym = g.table.sym(key_typ)
 	}
 	key_styp := g.styp(key_typ)
-	key_str_fn_name := styp_to_str_fn_name(key_styp)
+	key_str_fn_name := g.get_str_fn(key_typ)
 	if !key_sym.has_method('str') {
 		g.get_str_fn(key_typ)
 	}
@@ -810,22 +813,13 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 		val_sym = g.table.sym(val_typ)
 	}
 	val_styp := g.styp(val_typ)
-	mut elem_str_fn_name := styp_to_str_fn_name(val_styp)
+	mut elem_str_fn_name := g.get_str_fn(val_typ)
 
 	mut receiver_is_ptr := false
 	fn_str := val_sym.find_method_with_generic_parent('str') or { ast.Fn{} }
 
 	if fn_str.name == 'str' {
 		receiver_is_ptr = fn_str.receiver_type.is_ptr()
-		match mut val_sym.info {
-			ast.Struct, ast.Interface, ast.SumType {
-				if val_sym.info.generic_types.len > 0 {
-					elem_str_fn_name = g.generic_fn_name(val_sym.info.concrete_types,
-						elem_str_fn_name)
-				}
-			}
-			else {}
-		}
 	} else {
 		g.get_str_fn(val_typ)
 	}
@@ -838,13 +832,13 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _S("{"));')
 	g.auto_str_funcs.writeln('\tbool is_first = true;')
 	g.auto_str_funcs.writeln('\tfor (int i = 0; i < m.key_values.len; ++i) {')
-	g.auto_str_funcs.writeln('\t\tif (!DenseArray_has_index(&m.key_values, i)) { continue; }')
+	g.auto_str_funcs.writeln('\t\tif (!builtin__DenseArray_has_index(&m.key_values, i)) { continue; }')
 	g.auto_str_funcs.writeln('\t\telse if (!is_first) { strings__Builder_write_string(&sb, _S(", ")); }')
 
 	if key_sym.kind == .string {
-		g.auto_str_funcs.writeln('\t\tstring key = *(string*)DenseArray_key(&m.key_values, i);')
+		g.auto_str_funcs.writeln('\t\tstring key = *(string*)builtin__DenseArray_key(&m.key_values, i);')
 	} else {
-		g.auto_str_funcs.writeln('\t\t${key_styp} key = *(${key_styp}*)DenseArray_key(&m.key_values, i);')
+		g.auto_str_funcs.writeln('\t\t${key_styp} key = *(${key_styp}*)builtin__DenseArray_key(&m.key_values, i);')
 	}
 	if key_sym.kind == .string {
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${str_intp_sq('key')});')
@@ -865,9 +859,9 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 	} else if val_sym.kind == .string {
 		if val_typ.has_flag(.option) {
 			func := g.get_str_fn(val_typ)
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${func}(*(${val_styp}*)DenseArray_value(&m.key_values, i)));')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${func}(*(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)));')
 		} else {
-			tmp_str := str_intp_sq('*(${val_styp}*)DenseArray_value(&m.key_values, i)')
+			tmp_str := str_intp_sq('*(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)')
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${tmp_str});')
 		}
 	} else if should_use_indent_func(val_sym.kind) && fn_str.name != 'str' {
@@ -876,11 +870,11 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 		} else {
 			'*'.repeat(val_typ.nr_muls() + 1)
 		}
-		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, indent_${elem_str_fn_name}(${ptr_str}(${val_styp}*)DenseArray_value(&m.key_values, i), indent_count));')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, indent_${elem_str_fn_name}(${ptr_str}(${val_styp}*)builtin__DenseArray_value(&m.key_values, i), indent_count));')
 	} else if val_sym.kind in [.f32, .f64] {
-		tmp_val := '*(${val_styp}*)DenseArray_value(&m.key_values, i)'
+		tmp_val := '*(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)'
 		if val_typ.has_flag(.option) {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${g.get_str_fn(val_typ)}(*(${val_styp}*)DenseArray_value(&m.key_values, i)));')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${g.get_str_fn(val_typ)}(*(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)));')
 		} else {
 			if val_sym.kind == .f32 {
 				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${str_intp_g32(tmp_val)});')
@@ -889,16 +883,16 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 			}
 		}
 	} else if val_sym.kind == .rune {
-		tmp_str := str_intp_rune('${elem_str_fn_name}(*(${val_styp}*)DenseArray_value(&m.key_values, i))')
+		tmp_str := str_intp_rune('${elem_str_fn_name}(*(${val_styp}*)builtin__DenseArray_value(&m.key_values, i))')
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${tmp_str});')
 	} else {
 		ptr_str := '*'.repeat(val_typ.nr_muls())
 		if val_typ.has_flag(.option) {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${g.get_str_fn(val_typ)}(*${ptr_str}(${val_styp}*)DenseArray_value(&m.key_values, i)));')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${g.get_str_fn(val_typ)}(*${ptr_str}(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)));')
 		} else if receiver_is_ptr {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(${ptr_str}(${val_styp}*)DenseArray_value(&m.key_values, i)));')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(${ptr_str}(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)));')
 		} else {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(*${ptr_str}(${val_styp}*)DenseArray_value(&m.key_values, i)));')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(*${ptr_str}(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)));')
 		}
 	}
 	g.auto_str_funcs.writeln('\t\tis_first = false;')
@@ -983,7 +977,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 		return
 	}
 
-	fn_builder.writeln('\tstring indents = string_repeat(_S("    "), indent_count);')
+	fn_builder.writeln('\tstring indents = builtin__string_repeat(_S("    "), indent_count);')
 
 	mut fn_body_surrounder := util.new_surrounder(info.fields.len)
 	mut fn_body := strings.new_builder(info.fields.len * 256)
@@ -991,7 +985,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 		fn_body_surrounder.builder_write_befores(mut fn_builder)
 		fn_builder << fn_body
 		fn_body_surrounder.builder_write_afters(mut fn_builder)
-		fn_builder.writeln('\tstring_free(&indents);')
+		fn_builder.writeln('\tbuiltin__string_free(&indents);')
 		fn_builder.writeln('\treturn res;')
 		fn_builder.writeln('}')
 	}
@@ -1009,7 +1003,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 		fn_body.writeln('\tstring res = { .str ="str() used with -hide-auto-str", .len=30 }; return res;')
 		return
 	}
-	fn_body.writeln('\tstring res = str_intp( ${(info.fields.len - field_skips.len) * 4 + 3}, _MOV((StrIntpData[]){')
+	fn_body.writeln('\tstring res = builtin__str_intp( ${(info.fields.len - field_skips.len) * 4 + 3}, _MOV((StrIntpData[]){')
 	fn_body.writeln('\t\t{_S("${clean_struct_v_type_name}{\\n"), 0, {.d_c=0}},')
 
 	allow_circular := info.attrs.any(it.name == 'autostr' && it.arg == 'allowrecurse')
@@ -1102,9 +1096,9 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 		} else if ftyp_noshared.is_ptr() {
 			// reference types can be "nil"
 			if ftyp_noshared.has_flag(.option) {
-				funcprefix += 'isnil(&${it_field_name}) || isnil(&${it_field_name}.data)'
+				funcprefix += 'builtin__isnil(&${it_field_name}) || builtin__isnil(&${it_field_name}.data)'
 			} else {
-				funcprefix += 'isnil(${it_field_name})'
+				funcprefix += 'builtin__isnil(${it_field_name})'
 			}
 			funcprefix += ' ? _S("nil") : '
 			// struct, floats and ints have a special case through the _str function
@@ -1137,7 +1131,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 		} else {
 			// manage C charptr
 			if field.typ in ast.charptr_types {
-				fn_body.write_string('tos4((byteptr)${func})')
+				fn_body.write_string('builtin__tos4((byteptr)${func})')
 			} else {
 				if field.typ.is_ptr() && sym.kind in [.struct, .interface] {
 					funcprefix += '(indent_count > 25)? _S("<probably circular>") : '
@@ -1146,7 +1140,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 				if caller_should_free {
 					tmpvar := g.new_tmp_var()
 					fn_body_surrounder.add('\tstring ${tmpvar} = ${funcprefix}${func};',
-						'\tstring_free(&${tmpvar});')
+						'\tbuiltin__string_free(&${tmpvar});')
 					fn_body.write_string(tmpvar)
 				} else {
 					fn_body.write_string2(funcprefix, func)
@@ -1233,22 +1227,22 @@ fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.
 		} else if (field_type.is_int_valptr() || field_type.is_float_valptr()) && !expects_ptr {
 			// ptr int can be "nil", so this needs to be casted to a string
 			if sym.kind == .f32 {
-				return 'str_intp(1, _MOV((StrIntpData[]){
+				return 'builtin__str_intp(1, _MOV((StrIntpData[]){
 					{_SLIT0, ${si_g32_code}, {.d_f32 = *${method_str} }}
 				}))', true
 			} else if sym.kind == .f64 {
-				return 'str_intp(1, _MOV((StrIntpData[]){
+				return 'builtin__str_intp(1, _MOV((StrIntpData[]){
 					{_SLIT0, ${si_g64_code}, {.d_f64 = *${method_str} }}
 				}))', true
 			} else if sym.kind in [.u64, .usize] {
 				fmt_type := StrIntpType.si_u64
-				return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_u64 = *${method_str} }}}))', true
+				return 'builtin__str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_u64 = *${method_str} }}}))', true
 			} else if sym.kind in [.i64, .isize] {
 				fmt_type := StrIntpType.si_i64
-				return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_i64 = *${method_str} }}}))', true
+				return 'builtin__str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_i64 = *${method_str} }}}))', true
 			}
 			fmt_type := StrIntpType.si_i32
-			return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_i32 = *${method_str} }}}))', true
+			return 'builtin__str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_i32 = *${method_str} }}}))', true
 		}
 		return method_str, false
 	}
@@ -1319,23 +1313,23 @@ fn (mut g Gen) gen_enum_static_from_string(fn_name string, mod_enum_name string,
 	fn_builder.writeln('\t${option_enum_styp} t1;')
 	fn_builder.writeln('\tbool exists = false;')
 	fn_builder.writeln('\tint inx = 0;')
-	fn_builder.writeln('\tarray field_names = __new_array_with_default(0, 0, sizeof(string), 0);')
+	fn_builder.writeln('\tarray field_names = builtin____new_array_with_default(0, 0, sizeof(string), 0);')
 	for field_name in enum_field_names {
-		fn_builder.writeln('\tarray_push((array*)&field_names, _MOV((string[]){ _S("${field_name}") }));')
+		fn_builder.writeln('\tbuiltin__array_push((array*)&field_names, _MOV((string[]){ _S("${field_name}") }));')
 	}
-	fn_builder.writeln('\tarray field_vals = __new_array_with_default(0, 0, sizeof(i64), 0);')
+	fn_builder.writeln('\tarray field_vals = builtin____new_array_with_default(0, 0, sizeof(i64), 0);')
 	for field_val in enum_field_vals {
-		fn_builder.writeln('\tarray_push((array*)&field_vals, _MOV((i64[]){ ${field_val} }));')
+		fn_builder.writeln('\tbuiltin__array_push((array*)&field_vals, _MOV((i64[]){ ${field_val} }));')
 	}
 	fn_builder.writeln('\tfor (int i = 0; i < ${enum_field_names.len}; ++i) {')
-	fn_builder.writeln('\t\tif (fast_string_eq(name, (*(string*)array_get(field_names, i)))) {')
+	fn_builder.writeln('\t\tif (builtin__fast_string_eq(name, (*(string*)builtin__array_get(field_names, i)))) {')
 	fn_builder.writeln('\t\t\texists = true;')
 	fn_builder.writeln('\t\t\tinx = i;')
 	fn_builder.writeln('\t\t\tbreak;')
 	fn_builder.writeln('\t\t}')
 	fn_builder.writeln('\t}')
 	fn_builder.writeln('\tif (exists) {')
-	fn_builder.writeln('\t\t_option_ok(&(${enum_styp}[]){ (*(i64*)array_get(field_vals, inx)) }, (_option*)&t1, sizeof(${enum_styp}));')
+	fn_builder.writeln('\t\tbuiltin___option_ok(&(${enum_styp}[]){ (*(i64*)builtin__array_get(field_vals, inx)) }, (_option*)&t1, sizeof(${enum_styp}));')
 	fn_builder.writeln('\t\treturn t1;')
 	fn_builder.writeln('\t} else {')
 	fn_builder.writeln('\t\treturn (${option_enum_styp}){ .state=2, .err=_const_none__, .data={E_STRUCT} };')

--- a/vlib/v/gen/c/autofree.v
+++ b/vlib/v/gen/c/autofree.v
@@ -148,13 +148,13 @@ fn (mut g Gen) autofree_variable(v ast.Var) {
 		// eprintln('   > var name: ${v.name:-20s} | is_arg: ${v.is_arg.str():6} | var type: ${int(v.typ):8} | type_name: ${sym.name:-33s}')
 	}
 	// }
-	free_fn := g.styp(v.typ.set_nr_muls(0).clear_option_and_result()) + '_free'
+	mut free_fn := g.styp(v.typ.set_nr_muls(0).clear_option_and_result()) + '_free'
 	if sym.kind == .array {
 		if sym.has_method('free') {
 			g.autofree_var_call(free_fn, v)
 			return
 		}
-		g.autofree_var_call('array_free', v)
+		g.autofree_var_call('builtin__array_free', v)
 		return
 	}
 	if sym.kind == .string {
@@ -179,8 +179,11 @@ fn (mut g Gen) autofree_variable(v ast.Var) {
 				*/
 			}
 		}
-		g.autofree_var_call('string_free', v)
+		g.autofree_var_call('builtin__string_free', v)
 		return
+	}
+	if sym.is_builtin() {
+		free_fn = 'builtin__${free_fn}'
 	}
 	// Free user reference types
 	is_user_ref := v.typ.is_ptr() && sym.name.after('.')[0].is_capital()

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1505,7 +1505,7 @@ fn (mut g Gen) write_shareds() {
 		g.shared_types.writeln('\t${base} val;')
 		g.shared_types.writeln('};')
 		g.shared_functions.writeln('static inline voidptr __dup${sh_typ}(voidptr src, int sz) {')
-		g.shared_functions.writeln('\t${sh_typ}* dest = memdup(src, sz);')
+		g.shared_functions.writeln('\t${sh_typ}* dest = builtin__memdup(src, sz);')
 		g.shared_functions.writeln('\tsync__RwMutex_init(&dest->mtx);')
 		g.shared_functions.writeln('\treturn dest;')
 		g.shared_functions.writeln('}')
@@ -1527,7 +1527,7 @@ fn (mut g Gen) register_thread_void_wait_call() {
 	} else {
 		g.gowrappers.writeln('\tint stat = pthread_join(thread, (void **)NULL);')
 	}
-	g.gowrappers.writeln('\tif (stat != 0) { _v_panic(_S("unable to join thread")); }')
+	g.gowrappers.writeln('\tif (stat != 0) { builtin___v_panic(_S("unable to join thread")); }')
 	if g.pref.os == .windows {
 		g.gowrappers.writeln('\tCloseHandle(thread);')
 	}
@@ -1563,7 +1563,7 @@ void ${fn_name}(${thread_arr_typ} a) {
 			g.waiter_fn_definitions.writeln('${ret_typ} ${fn_name}(${thread_arr_typ} a);')
 			g.gowrappers.writeln('
 ${ret_typ} ${fn_name}(${thread_arr_typ} a) {
-	${ret_typ} res = __new_array_with_default(a.len, a.len, sizeof(${eltyp}), 0);
+	${ret_typ} res = builtin____new_array_with_default(a.len, a.len, sizeof(${eltyp}), 0);
 	for (int i = 0; i < a.len; ++i) {
 		${thread_typ} t = ((${thread_typ}*)a.data)[i];')
 			if g.pref.os == .windows {
@@ -1611,7 +1611,7 @@ void ${fn_name}(${thread_arr_typ} a) {
 			g.waiter_fn_definitions.writeln('${ret_typ} ${fn_name}(${thread_arr_typ} a);')
 			g.gowrappers.writeln('
 ${ret_typ} ${fn_name}(${thread_arr_typ} a) {
-	${ret_typ} res = __new_array_with_default(${len}, ${len}, sizeof(${eltyp}), 0);
+	${ret_typ} res = builtin____new_array_with_default(${len}, ${len}, sizeof(${eltyp}), 0);
 	for (int i = 0; i < ${len}; ++i) {
 		${thread_typ} t = ((${thread_typ}*)a)[i];')
 			if g.pref.os == .windows {
@@ -1650,7 +1650,7 @@ fn (mut g Gen) write_chan_pop_option_fns() {
 static inline ${opt_el_type} __Option_${styp}_popval(${styp} ch) {
 	${opt_el_type} _tmp = {0};
 	if (sync__Channel_try_pop_priv(ch, _tmp.data, false)) {
-		return (${opt_el_type}){ .state = 2, .err = _v_error(_S("channel closed")), .data = {E_STRUCT} };
+		return (${opt_el_type}){ .state = 2, .err = builtin___v_error(_S("channel closed")), .data = {E_STRUCT} };
 	}
 	return _tmp;
 }')
@@ -1679,7 +1679,7 @@ fn (mut g Gen) write_chan_push_option_fns() {
 		g.channel_definitions.writeln('
 static inline ${option_name}_void __Option_${styp}_pushval(${styp} ch, ${el_type} e) {
 	if (sync__Channel_try_push_priv(ch, &e, false)) {
-		return (${option_name}_void){ .state = 2, .err = _v_error(_S("channel closed")), .data = {E_STRUCT} };
+		return (${option_name}_void){ .state = 2, .err = builtin___v_error(_S("channel closed")), .data = {E_STRUCT} };
 	}
 	return (${option_name}_void){0};
 }')
@@ -2188,7 +2188,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 								g.expr_with_cast(stmt.expr, stmt.typ, ret_typ)
 								g.writeln(';')
 							} else {
-								g.write('_option_ok(&(${styp}[]) { ')
+								g.write('builtin___option_ok(&(${styp}[]) { ')
 								g.expr_with_cast(stmt.expr, stmt.typ, ret_typ)
 								g.writeln(' }, (${option_name}*)(&${tmp_var}), sizeof(${styp}));')
 							}
@@ -2227,7 +2227,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 								g.expr(stmt.expr)
 								g.writeln(';')
 							} else {
-								g.write('_result_ok(&(${styp}[]) { ')
+								g.write('builtin___result_ok(&(${styp}[]) { ')
 								g.expr_with_cast(stmt.expr, stmt.typ, ret_typ)
 								g.writeln(' }, (${result_name}*)(&${tmp_var}), sizeof(${styp}));')
 							}
@@ -2383,7 +2383,7 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 				if simple_assign {
 					g.write('${tmp_var} = ')
 				} else {
-					g.write('_option_none(&(${styp}[]) { ')
+					g.write('builtin___option_none(&(${styp}[]) { ')
 				}
 			} else {
 				simple_assign =
@@ -2397,13 +2397,13 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 				} else if expr_typ_is_option && expr is ast.PrefixExpr
 					&& expr.right is ast.StructInit
 					&& (expr.right as ast.StructInit).init_fields.len == 0 {
-					g.write('_option_none(&(${styp}[]) { ')
+					g.write('builtin___option_none(&(${styp}[]) { ')
 				} else if expr in [ast.Ident, ast.SelectorExpr]
 					&& final_expr_sym.kind == .array_fixed {
 					expr_is_fixed_array_var = true
-					g.write('_option_ok(&')
+					g.write('builtin___option_ok(&')
 				} else {
-					g.write('_option_ok(&(${styp}[]) { ')
+					g.write('builtin___option_ok(&(${styp}[]) { ')
 					if final_expr_sym.info is ast.FnType {
 						final_ret_sym := g.table.final_sym(ret_typ)
 						if final_ret_sym.info is ast.FnType {
@@ -2433,7 +2433,7 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 				}
 			}
 		} else {
-			g.write('_result_ok(&(${styp}[]) { ')
+			g.write('builtin___result_ok(&(${styp}[]) { ')
 		}
 		g.expr_with_cast(expr, expr_typ, ret_typ)
 		if fn_option_clone {
@@ -2839,7 +2839,7 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 		g.definitions.writeln('${exp_cname} ${fun.fn_name}(${got_cname}* x, bool is_mut);')
 		sb.writeln('${exp_cname} ${fun.fn_name}(${got_cname}* x, bool is_mut) {')
 		sb.writeln('\t${got_cname}* ptr = x;')
-		sb.writeln('\tif (!is_mut) { ptr = memdup(x, sizeof(${got_cname})); }')
+		sb.writeln('\tif (!is_mut) { ptr = builtin__memdup(x, sizeof(${got_cname})); }')
 	}
 	for embed_hierarchy in g.table.get_embeds(got_sym) {
 		// last embed in the hierarchy
@@ -2856,7 +2856,7 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 			accessor += embed_name
 		}
 		// if the variable is not used, the C compiler will optimize it away
-		sb.writeln('\t${embed_cname}* ${embed_name}_ptr = memdup(${accessor}, sizeof(${embed_cname}));')
+		sb.writeln('\t${embed_cname}* ${embed_name}_ptr = builtin__memdup(${accessor}, sizeof(${embed_cname}));')
 	}
 	sb.write_string('\treturn (${exp_cname}){ ._${variant_name} = ptr, ._typ = ${type_idx}')
 	for field in (exp_sym.info as ast.SumType).fields {
@@ -3519,12 +3519,12 @@ fn (mut g Gen) gen_clone_assignment(var_type ast.Type, val ast.Expr, typ ast.Typ
 			if is_sumtype {
 				variant_typ := g.styp(typ).replace('*', '')
 				fn_name := g.get_sumtype_casting_fn(typ, var_type)
-				g.write('${fn_name}(ADDR(${variant_typ}, array_clone_static_to_depth(')
+				g.write('${fn_name}(ADDR(${variant_typ}, builtin__array_clone_static_to_depth(')
 				if typ.is_ptr() {
 					g.write('*')
 				}
 			} else {
-				g.write(' array_clone_static_to_depth(')
+				g.write(' builtin__array_clone_static_to_depth(')
 			}
 			g.expr(val)
 			if typ.share() == .shared_t {
@@ -3542,9 +3542,9 @@ fn (mut g Gen) gen_clone_assignment(var_type ast.Type, val ast.Expr, typ ast.Typ
 		} else if right_sym.kind == .string {
 			// `str1 = str2` => `str1 = str2.clone()`
 			if var_type.has_flag(.option) {
-				g.write(' string_option_clone_static(')
+				g.write(' builtin__string_option_clone_static(')
 			} else {
-				g.write(' string_clone_static(')
+				g.write(' builtin__string_clone_static(')
 			}
 			g.expr(val)
 			g.write(')')
@@ -3557,21 +3557,21 @@ fn (mut g Gen) map_fn_ptrs(key_sym ast.TypeSymbol) (string, string, string, stri
 	mut hash_fn := ''
 	mut key_eq_fn := ''
 	mut clone_fn := ''
-	mut free_fn := '&map_free_nop'
+	mut free_fn := '&builtin__map_free_nop'
 	match key_sym.kind {
 		.alias {
 			alias_key_type := (key_sym.info as ast.Alias).parent_type
 			return g.map_fn_ptrs(g.table.sym(alias_key_type))
 		}
 		.u8, .i8, .char {
-			hash_fn = '&map_hash_int_1'
-			key_eq_fn = '&map_eq_int_1'
-			clone_fn = '&map_clone_int_1'
+			hash_fn = '&builtin__map_hash_int_1'
+			key_eq_fn = '&builtin__map_eq_int_1'
+			clone_fn = '&builtin__map_clone_int_1'
 		}
 		.i16, .u16 {
-			hash_fn = '&map_hash_int_2'
-			key_eq_fn = '&map_eq_int_2'
-			clone_fn = '&map_clone_int_2'
+			hash_fn = '&builtin__map_hash_int_2'
+			key_eq_fn = '&builtin__map_eq_int_2'
+			clone_fn = '&builtin__map_clone_int_2'
 		}
 		.enum {
 			einfo := (key_sym.info) as ast.Enum
@@ -3583,9 +3583,9 @@ fn (mut g Gen) map_fn_ptrs(key_sym ast.TypeSymbol) (string, string, string, stri
 			return g.map_fn_ptrs(g.table.sym(einfo.typ))
 		}
 		.int, .i32, .u32, .rune, .f32 {
-			hash_fn = '&map_hash_int_4'
-			key_eq_fn = '&map_eq_int_4'
-			clone_fn = '&map_clone_int_4'
+			hash_fn = '&builtin__map_hash_int_4'
+			key_eq_fn = '&builtin__map_eq_int_4'
+			clone_fn = '&builtin__map_clone_int_4'
 		}
 		.voidptr {
 			ts := if g.pref.m64 {
@@ -3596,15 +3596,15 @@ fn (mut g Gen) map_fn_ptrs(key_sym ast.TypeSymbol) (string, string, string, stri
 			return g.map_fn_ptrs(ts)
 		}
 		.u64, .i64, .f64 {
-			hash_fn = '&map_hash_int_8'
-			key_eq_fn = '&map_eq_int_8'
-			clone_fn = '&map_clone_int_8'
+			hash_fn = '&builtin__map_hash_int_8'
+			key_eq_fn = '&builtin__map_eq_int_8'
+			clone_fn = '&builtin__map_clone_int_8'
 		}
 		.string {
-			hash_fn = '&map_hash_string'
-			key_eq_fn = '&map_eq_string'
-			clone_fn = '&map_clone_string'
-			free_fn = '&map_free_string'
+			hash_fn = '&builtin__map_hash_string'
+			key_eq_fn = '&builtin__map_eq_string'
+			clone_fn = '&builtin__map_clone_string'
+			free_fn = '&builtin__map_free_string'
 		}
 		else {
 			verror('map key type `${key_sym.name}` not supported')
@@ -3909,7 +3909,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 					}
 				}
 				g.writeln('if (${expr_str}${dot_or_ptr}state != 0) {')
-				g.writeln2('\tpanic_option_not_set(_S("none"));', '}')
+				g.writeln2('\tbuiltin__panic_option_not_set(_S("none"));', '}')
 				g.write(cur_line)
 				if is_unwrapped {
 					typ := g.type_resolver.typeof_type(node.expr, node.typ)
@@ -4118,7 +4118,7 @@ fn (mut g Gen) typeof_expr(node ast.TypeOf) {
 	if sym.kind == .sum_type {
 		// When encountering a .sum_type, typeof() should be done at runtime,
 		// because the subtype of the expression may change:
-		g.write('charptr_vstring_literal(v_typeof_sumtype_${sym.cname}( (')
+		g.write('builtin__charptr_vstring_literal(v_typeof_sumtype_${sym.cname}( (')
 		if typ.nr_muls() > 0 {
 			g.write('*'.repeat(typ.nr_muls()))
 		}
@@ -4414,7 +4414,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			}
 			g.write('builtin__closure__closure_create(${name}, ')
 			if !receiver.typ.is_ptr() {
-				g.write('memdup_uncollectable(')
+				g.write('builtin__memdup_uncollectable(')
 			}
 			mut has_addr := false
 			if !node.expr_type.is_ptr() {
@@ -4586,7 +4586,17 @@ fn (mut g Gen) gen_closure_fn(expr_styp string, m ast.Fn, name string) {
 		left_type_name := util.no_dots(left_cc_type)
 		sb.write_string('${c_name(left_type_name)}_name_table[a0->_typ]._method_${method_name}(')
 	} else {
-		sb.write_string('${expr_styp}_${method_name}(')
+		mut full_method_name := '${expr_styp}_${method_name}'
+		if !expr_styp.starts_with('builtin__') {
+			if resolved_sym := g.table.find_sym(expr_styp) {
+				if resolved_sym.is_builtin() {
+					full_method_name = 'builtin__${full_method_name}'
+				}
+			} else if expr_styp in ['int_literal', 'float_literal'] {
+				full_method_name = 'builtin__${full_method_name}'
+			}
+		}
+		sb.write_string('${full_method_name}(')
 		if !receiver.typ.is_ptr() {
 			sb.write_string('*')
 		}
@@ -4792,7 +4802,7 @@ fn (mut g Gen) debugger_stmt(node ast.DebuggerStmt) {
 		count += 1
 	}
 	g.writeln('{')
-	g.writeln('\tMap_string_string _scope = new_map_init(&map_hash_string, &map_eq_string, &map_clone_string, &map_free_string, ${vars.len}, sizeof(string), sizeof(v__debug__DebugContextVar),')
+	g.writeln('\tMap_string_string _scope = builtin__new_map_init(&builtin__map_hash_string, &builtin__map_eq_string, &builtin__map_clone_string, &builtin__map_free_string, ${vars.len}, sizeof(string), sizeof(v__debug__DebugContextVar),')
 	g.write2('\t\t_MOV((string[${vars.len}]){', keys.str())
 	g.writeln('}),')
 	g.write2('\t\t_MOV((v__debug__DebugContextVar[${vars.len}]){', values.str())
@@ -5015,7 +5025,7 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 		g.writeln('(${shared_styp}*)__dup_shared_map(&(${shared_styp}){.mtx = {0}, .val =')
 	} else if is_amp {
 		styp = g.styp(node.typ)
-		g.write('(${styp}*)memdup(ADDR(${styp}, ')
+		g.write('(${styp}*)builtin__memdup(ADDR(${styp}, ')
 	}
 	noscan_key := g.check_noscan(node.key_type)
 	noscan_value := g.check_noscan(node.value_type)
@@ -5031,12 +5041,12 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 	if size > 0 {
 		effective_typ_str := if value_sym.kind == .function { 'voidptr' } else { value_typ_str }
 		if node.has_update_expr {
-			g.writeln('new_map_update_init(')
+			g.writeln('builtin__new_map_update_init(')
 			g.write('\t&(')
 			g.expr(node.update_expr)
 			g.writeln('), ${size}, sizeof(${key_typ_str}), sizeof(${effective_typ_str}),')
 		} else {
-			g.writeln('new_map_init${noscan}(${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn}, ${size}, sizeof(${key_typ_str}), sizeof(${effective_typ_str}),')
+			g.writeln('builtin__new_map_init${noscan}(${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn}, ${size}, sizeof(${key_typ_str}), sizeof(${effective_typ_str}),')
 		}
 		g.writeln('\t_MOV((${key_typ_str}[${size}]){')
 		for expr in node.keys {
@@ -5061,11 +5071,11 @@ fn (mut g Gen) map_init(node ast.MapInit) {
 		}
 		g.writeln2('\t})', ')')
 	} else if node.has_update_expr {
-		g.write('map_clone(&(')
+		g.write('builtin__map_clone(&(')
 		g.expr(node.update_expr)
 		g.writeln('))')
 	} else {
-		g.writeln('new_map${noscan}(sizeof(${key_typ_str}), sizeof(${value_typ_str}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn})')
+		g.writeln('builtin__new_map${noscan}(sizeof(${key_typ_str}), sizeof(${value_typ_str}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn})')
 	}
 	if g.is_shared {
 		g.write('}, sizeof(${shared_styp}))')
@@ -5149,9 +5159,9 @@ fn (mut g Gen) select_expr(node ast.SelectExpr) {
 	}
 	chan_array := g.new_tmp_var()
 	if n_channels == 0 {
-		g.writeln('Array_sync__Channel_ptr ${chan_array} = __new_array_with_default(0, 0, sizeof(sync__Channel*), 0);')
+		g.writeln('Array_sync__Channel_ptr ${chan_array} = builtin____new_array_with_default(0, 0, sizeof(sync__Channel*), 0);')
 	} else {
-		g.write('Array_sync__Channel_ptr ${chan_array} = new_array_from_c_array(${n_channels}, ${n_channels}, sizeof(sync__Channel*), _MOV((sync__Channel*[${n_channels}]){')
+		g.write('Array_sync__Channel_ptr ${chan_array} = builtin__new_array_from_c_array(${n_channels}, ${n_channels}, sizeof(sync__Channel*), _MOV((sync__Channel*[${n_channels}]){')
 		for i in 0 .. n_channels {
 			if i > 0 {
 				g.write(', ')
@@ -5164,9 +5174,9 @@ fn (mut g Gen) select_expr(node ast.SelectExpr) {
 	}
 	directions_array := g.new_tmp_var()
 	if n_channels == 0 {
-		g.writeln('Array_sync__Direction ${directions_array} = __new_array_with_default(0, 0, sizeof(sync__Direction), 0);')
+		g.writeln('Array_sync__Direction ${directions_array} = builtin____new_array_with_default(0, 0, sizeof(sync__Direction), 0);')
 	} else {
-		g.write('Array_sync__Direction ${directions_array} = new_array_from_c_array(${n_channels}, ${n_channels}, sizeof(sync__Direction), _MOV((sync__Direction[${n_channels}]){')
+		g.write('Array_sync__Direction ${directions_array} = builtin__new_array_from_c_array(${n_channels}, ${n_channels}, sizeof(sync__Direction), _MOV((sync__Direction[${n_channels}]){')
 		for i in 0 .. n_channels {
 			if i > 0 {
 				g.write(', ')
@@ -5181,9 +5191,9 @@ fn (mut g Gen) select_expr(node ast.SelectExpr) {
 	}
 	objs_array := g.new_tmp_var()
 	if n_channels == 0 {
-		g.writeln('Array_voidptr ${objs_array} = __new_array_with_default(0, 0, sizeof(voidptr), 0);')
+		g.writeln('Array_voidptr ${objs_array} = builtin____new_array_with_default(0, 0, sizeof(voidptr), 0);')
 	} else {
-		g.write('Array_voidptr ${objs_array} = new_array_from_c_array(${n_channels}, ${n_channels}, sizeof(voidptr), _MOV((voidptr[${n_channels}]){')
+		g.write('Array_voidptr ${objs_array} = builtin__new_array_from_c_array(${n_channels}, ${n_channels}, sizeof(voidptr), _MOV((voidptr[${n_channels}]){')
 		for i in 0 .. n_channels {
 			if i > 0 {
 				g.write(', &')
@@ -5209,8 +5219,8 @@ fn (mut g Gen) select_expr(node ast.SelectExpr) {
 	}
 	g.writeln(');')
 	// free the temps that were created
-	g.writeln2('array_free(&${objs_array});', 'array_free(&${directions_array});')
-	g.writeln('array_free(&${chan_array});')
+	g.writeln2('builtin__array_free(&${objs_array});', 'builtin__array_free(&${directions_array});')
+	g.writeln('builtin__array_free(&${chan_array});')
 	mut i := 0
 	for j in 0 .. node.branches.len {
 		if j > 0 {
@@ -5261,6 +5271,15 @@ fn (mut g Gen) ident(node ast.Ident) {
 		return
 	}
 	mut name := if node.kind == .function { c_fn_name(node.name) } else { c_name(node.name) }
+	if node.kind == .function {
+		if func := g.table.find_fn(node.name) {
+			if func.mod == 'builtin' && !name.starts_with('builtin__') && func.language != .c {
+				name = 'builtin__${name}'
+			}
+		} else if node.name == 'print' {
+			name = 'builtin__print'
+		}
+	}
 	if node.kind == .constant {
 		if g.pref.translated && !g.is_builtin_mod
 			&& !util.module_is_builtin(node.name.all_before_last('.')) {
@@ -5630,10 +5649,10 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 					tmp_var := g.new_tmp_var()
 					tmp_var2 := g.new_tmp_var()
 					g.writeln2('${styp} ${tmp_var};', '${g.styp(parent_type)} ${tmp_var2};')
-					g.write('_option_ok(&(${g.base_type(parent_type)}[]) { ')
+					g.write('builtin___option_ok(&(${g.base_type(parent_type)}[]) { ')
 					g.expr(node.expr)
 					g.writeln(' }, (${option_name}*)(&${tmp_var2}), sizeof(${g.base_type(parent_type)}));')
-					g.writeln('_option_ok(&(${g.styp(parent_type)}[]) { ${tmp_var2} }, (${option_name}*)&${tmp_var}, sizeof(${g.styp(parent_type)}));')
+					g.writeln('builtin___option_ok(&(${g.styp(parent_type)}[]) { ${tmp_var2} }, (${option_name}*)&${tmp_var}, sizeof(${g.styp(parent_type)}));')
 					g.write2(cur_stmt, tmp_var)
 				} else if node.expr_type.has_flag(.option) {
 					g.expr_opt_with_alias(node.expr, expr_type, node.typ)
@@ -5652,7 +5671,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 				&& g.table.sumtype_has_variant(sym.info.parent_type, expr_typ, false)
 			if alias_to_sumtype {
 				expr_styp := g.styp(expr_typ)
-				g.write('{._${g.table.sym(expr_typ).cname}=memdup(ADDR(${expr_styp}, ')
+				g.write('{._${g.table.sym(expr_typ).cname}=builtin__memdup(ADDR(${expr_styp}, ')
 				g.expr(node.expr)
 				g.write('), sizeof(${expr_styp})),._typ=${int(expr_typ)}})')
 			} else {
@@ -6162,11 +6181,11 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 		if fn_return_is_option {
 			g.writeln('${ret_typ} ${tmpvar};')
 			styp = g.base_type(ret_type)
-			g.write('_option_ok(&(${styp}[]) { ')
+			g.write('builtin___option_ok(&(${styp}[]) { ')
 		} else if fn_return_is_result {
 			g.writeln('${ret_typ} ${tmpvar};')
 			styp = g.base_type(ret_type)
-			g.write('_result_ok(&(${styp}[]) { ')
+			g.write('builtin___result_ok(&(${styp}[]) { ')
 		} else {
 			if use_tmp_var {
 				g.write('${ret_typ} ${tmpvar} = ')
@@ -6310,7 +6329,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			} else {
 				g.writeln('${ret_typ} ${tmpvar};')
 				styp := g.base_type(fn_ret_type)
-				g.write('_option_ok(&(${styp}[]) { ')
+				g.write('builtin___option_ok(&(${styp}[]) { ')
 				if !fn_ret_type.is_ptr() && type0.is_ptr() {
 					if !(expr0 is ast.Ident && !g.is_amp) {
 						g.write('*')
@@ -6356,7 +6375,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				g.writeln(', sizeof(${styp}));')
 			} else {
 				styp := g.base_type(fn_ret_type)
-				g.write('_result_ok(&(${styp}[]) { ')
+				g.write('builtin___result_ok(&(${styp}[]) { ')
 				if !fn_ret_type.is_ptr() && type0.is_ptr() {
 					if !((expr0 is ast.Ident && !g.is_amp) || sym.kind == .interface) {
 						g.write('*')
@@ -6644,19 +6663,19 @@ fn (mut g Gen) write_init_function() {
 		if _ := g.table.fns['v_segmentation_fault_handler'] {
 			// 11 is SIGSEGV. It is hardcoded here, to avoid FreeBSD compilation errors for trivial examples.
 			// shared object does not need this
-			g.writeln('#if __STDC_HOSTED__ == 1\n\tsignal(11, v_segmentation_fault_handler);\n#endif')
+			g.writeln('#if __STDC_HOSTED__ == 1\n\tsignal(11, builtin__v_segmentation_fault_handler);\n#endif')
 		}
 	}
 
 	if g.pref.is_bare {
 		if _ := g.table.fns['init_global_allocator'] {
-			g.writeln('init_global_allocator();')
+			g.writeln('builtin__init_global_allocator();')
 		}
 	}
 
 	if g.pref.prealloc {
 		if _ := g.table.fns['prealloc_vinit'] {
-			g.writeln('prealloc_vinit();')
+			g.writeln('builtin__prealloc_vinit();')
 		}
 	}
 
@@ -6669,7 +6688,7 @@ fn (mut g Gen) write_init_function() {
 	}
 	if !g.pref.is_shared && (!g.pref.skip_unused || g.table.used_features.used_fns['builtin_init']) {
 		// shared object does not need this
-		g.writeln('\tbuiltin_init();')
+		g.writeln('\tbuiltin__builtin_init();')
 	}
 
 	// reflection bootstrapping
@@ -6751,7 +6770,7 @@ fn (mut g Gen) write_init_function() {
 			g.writeln2('\t// Cleanups for module ${mod_name} :', g.cleanups[mod_name].str())
 		}
 		if g.as_cast_type_names.len > 0 {
-			g.writeln('\tarray_free(&as_cast_type_indexes);')
+			g.writeln('\tbuiltin__array_free(&as_cast_type_indexes);')
 		}
 	}
 	for x in cleaning_up_array.reverse() {
@@ -7252,7 +7271,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 									g.write('*(${cast_typ}*) ${cvar_name}${tmp_op}data = ')
 								}
 							} else if g.inside_opt_or_res && return_is_option && g.inside_assign {
-								g.write('_option_ok(&(${cast_typ}[]) { ')
+								g.write('builtin___option_ok(&(${cast_typ}[]) { ')
 								g.expr_with_cast(expr_stmt.expr, expr_stmt.typ, return_type.clear_option_and_result())
 								g.writeln(' }, (${option_name}*)&${cvar_name}, sizeof(${cast_typ}));')
 								g.indent--
@@ -7354,9 +7373,9 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			err_msg := 'IError_name_table[${cvar_name}${tmp_op}err._typ]._method_msg(${cvar_name}${tmp_op}err._object)'
 			if g.pref.is_debug {
 				paline, pafile, pamod, pafn := g.panic_debug_info(or_block.pos)
-				g.writeln('panic_debug(${paline}, tos3("${pafile}"), tos3("${pamod}"), tos3("${pafn}"), ${err_msg});')
+				g.writeln('builtin__panic_debug(${paline}, builtin__tos3("${pafile}"), builtin__tos3("${pamod}"), builtin__tos3("${pafn}"), ${err_msg});')
 			} else {
-				g.writeln('\tpanic_result_not_set(${err_msg});')
+				g.writeln('\tbuiltin__panic_result_not_set(${err_msg});')
 			}
 		} else if g.fn_decl != unsafe { nil } && g.fn_decl.is_test {
 			g.gen_failing_error_propagation_for_test_fn(or_block, cvar_name)
@@ -7388,9 +7407,9 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			err_msg := 'IError_name_table[${cvar_name}${tmp_op}err._typ]._method_msg(${cvar_name}${tmp_op}err._object)'
 			if g.pref.is_debug {
 				paline, pafile, pamod, pafn := g.panic_debug_info(or_block.pos)
-				g.writeln('panic_debug(${paline}, tos3("${pafile}"), tos3("${pamod}"), tos3("${pafn}"), ${err_msg}.len == 0 ? _S("option not set ()") : ${err_msg});')
+				g.writeln('builtin__panic_debug(${paline}, builtin__tos3("${pafile}"), builtin__tos3("${pamod}"), builtin__tos3("${pafn}"), ${err_msg}.len == 0 ? _S("option not set ()") : ${err_msg});')
 			} else {
-				g.writeln('\tpanic_option_not_set( ${err_msg} );')
+				g.writeln('\tbuiltin__panic_option_not_set( ${err_msg} );')
 			}
 		} else if g.fn_decl != unsafe { nil } && g.fn_decl.is_test {
 			g.gen_failing_error_propagation_for_test_fn(or_block, cvar_name)
@@ -7529,7 +7548,7 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 				elem_type_str = elem_type_str[3..]
 			}
 			noscan := g.check_noscan(elem_typ)
-			init_str := '__new_array${noscan}(0, 0, sizeof(${elem_type_str}))'
+			init_str := 'builtin____new_array${noscan}(0, 0, sizeof(${elem_type_str}))'
 			if typ.has_flag(.shared_f) {
 				atyp := '__shared__${sym.cname}'
 				return '(${atyp}*)__dup_shared_array(&(${atyp}){.mtx = {0}, .val =${init_str}}, sizeof(${atyp}))'
@@ -7552,7 +7571,7 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 					noscan += '_value'
 				}
 			}
-			init_str := 'new_map${noscan}(sizeof(${g.styp(info.key_type)}), sizeof(${g.styp(info.value_type)}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn})'
+			init_str := 'builtin__new_map${noscan}(sizeof(${g.styp(info.key_type)}), sizeof(${g.styp(info.value_type)}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn})'
 			if typ.has_flag(.shared_f) {
 				mtyp := '__shared__Map_${key_typ.cname}_${g.styp(info.value_type).replace('*',
 					'_ptr')}'
@@ -7774,11 +7793,11 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			g.expr(node.expr)
 			g.write('; ')
 			if sym.info is ast.FnType {
-				g.write('(${styp})__as_cast(')
+				g.write('(${styp})builtin____as_cast(')
 			} else if g.inside_smartcast {
-				g.write('(${styp}*)__as_cast(')
+				g.write('(${styp}*)builtin____as_cast(')
 			} else {
-				g.write('*(${styp}*)__as_cast(')
+				g.write('*(${styp}*)builtin____as_cast(')
 			}
 			g.write2(tmp_var, dot)
 			g.write2('_${sym.cname},', tmp_var)
@@ -7787,11 +7806,11 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			g.write('_typ, ${sidx}); })')
 		} else {
 			if sym.info is ast.FnType {
-				g.write('(${styp})__as_cast(')
+				g.write('(${styp})builtin____as_cast(')
 			} else if g.inside_smartcast {
-				g.write('(${styp}*)__as_cast(')
+				g.write('(${styp}*)builtin____as_cast(')
 			} else {
-				g.write('*(${styp}*)__as_cast(')
+				g.write('*(${styp}*)builtin____as_cast(')
 			}
 			g.write('(')
 			g.expr(node.expr)
@@ -7838,11 +7857,11 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			g.expr(node.expr)
 			g.write('; ')
 			if sym.info is ast.FnType {
-				g.write('(${styp})__as_cast(')
+				g.write('(${styp})builtin____as_cast(')
 			} else if g.inside_smartcast {
-				g.write('(${styp}*)__as_cast(')
+				g.write('(${styp}*)builtin____as_cast(')
 			} else {
-				g.write('*(${styp}*)__as_cast(')
+				g.write('*(${styp}*)builtin____as_cast(')
 			}
 			g.write2(tmp_var, dot)
 			g.write('_${sym.cname},v_typeof_interface_idx_${expr_type_sym.cname}(')
@@ -7851,11 +7870,11 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			g.write('_typ), ${sidx}); })')
 		} else {
 			if sym.info is ast.FnType {
-				g.write('(${styp})__as_cast(')
+				g.write('(${styp})builtin____as_cast(')
 			} else if g.inside_smartcast {
-				g.write('(${styp}*)__as_cast(')
+				g.write('(${styp}*)builtin____as_cast(')
 			} else {
-				g.write('*(${styp}*)__as_cast(')
+				g.write('*(${styp}*)builtin____as_cast(')
 			}
 			g.write('(')
 			g.expr(node.expr)
@@ -7909,11 +7928,11 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 
 fn (g &Gen) as_cast_name_table() string {
 	if g.as_cast_type_names.len == 0 {
-		return 'new_array_from_c_array(1, 1, sizeof(VCastTypeIndexName), _MOV((VCastTypeIndexName[1]){(VCastTypeIndexName){.tindex = 0,.tname = _S("unknown")}}));\n'
+		return 'builtin__new_array_from_c_array(1, 1, sizeof(VCastTypeIndexName), _MOV((VCastTypeIndexName[1]){(VCastTypeIndexName){.tindex = 0,.tname = _S("unknown")}}));\n'
 	}
 	mut name_ast := strings.new_builder(1024)
 	casts_len := g.as_cast_type_names.len + 1
-	name_ast.writeln('new_array_from_c_array(${casts_len}, ${casts_len}, sizeof(VCastTypeIndexName), _MOV((VCastTypeIndexName[${casts_len}]){')
+	name_ast.writeln('builtin__new_array_from_c_array(${casts_len}, ${casts_len}, sizeof(VCastTypeIndexName), _MOV((VCastTypeIndexName[${casts_len}]){')
 	name_ast.writeln('\t\t  (VCastTypeIndexName){.tindex = 0, .tname = _S("unknown")}')
 	for key, value in g.as_cast_type_names {
 		name_ast.writeln('\t\t, (VCastTypeIndexName){.tindex = ${key}, .tname = _S("${value}")}')
@@ -8219,7 +8238,13 @@ return ${cast_shared_struct_str};
 					}
 					// inline void Cat_speak_Interface_Animal_method_wrapper(Cat c) { return Cat_speak(*c); }
 					iwpostfix := '_Interface_${interface_name}_method_wrapper'
-					methods_wrapper.write_string('static inline ${g.ret_styp(method.return_type)} ${cctype}_${name}${iwpostfix}(')
+					mut wrapper_method_name := '${cctype}_${name}${iwpostfix}'
+					method_sym := g.table.sym(method.params[0].typ)
+					if method_sym.is_builtin() {
+						wrapper_method_name = 'builtin__${wrapper_method_name}'
+						method_call = 'builtin__${method_call}'
+					}
+					methods_wrapper.write_string('static inline ${g.ret_styp(method.return_type)} ${wrapper_method_name}(')
 					params_start_pos := g.out.len
 					mut params := method.params.clone()
 					// hack to mutate typ
@@ -8245,7 +8270,10 @@ return ${cast_shared_struct_str};
 					}
 					if embed_types.len > 0 && method.name !in method_names {
 						embed_sym := g.table.sym(embed_types.last())
-						method_name := '${embed_sym.cname}_${method.name}'
+						mut method_name := '${embed_sym.cname}_${method.name}'
+						if embed_sym.is_builtin() {
+							method_name = 'builtin__${method_name}'
+						}
 						methods_wrapper.write_string('${method_name}(${fargs[0]}')
 						for idx_embed, embed in embed_types {
 							esym := g.table.sym(embed)
@@ -8269,7 +8297,7 @@ return ${cast_shared_struct_str};
 					}
 					methods_wrapper.writeln('}')
 					// .speak = Cat_speak_Interface_Animal_method_wrapper
-					method_call += iwpostfix
+					method_call = wrapper_method_name
 				}
 				if g.pref.build_mode != .build_module && st != ast.voidptr_type
 					&& st != ast.nil_type {
@@ -8311,14 +8339,14 @@ return ${cast_shared_struct_str};
 				variant_sym := g.table.sym(variant)
 				conversion_functions.writeln('\tif (x._typ == _${interface_name}_${variant_sym.cname}_index) return I_${variant_sym.cname}_to_Interface_${vsym.cname}(x._${variant_sym.cname});')
 			}
-			pmessage := 'string__plus(string__plus(tos3("`as_cast`: cannot convert "), tos3(v_typeof_interface_${interface_name}(x._typ))), tos3(" to ${util.strip_main_name(vsym.name)}"))'
+			pmessage := 'builtin__string__plus(builtin__string__plus(builtin__tos3("`as_cast`: cannot convert "), builtin__tos3(v_typeof_interface_${interface_name}(x._typ))), builtin__tos3(" to ${util.strip_main_name(vsym.name)}"))'
 			if g.pref.is_debug {
 				// TODO: actually return a valid position here
-				conversion_functions.write_string2('\tpanic_debug(1, tos3("builtin.v"), tos3("builtin"), tos3("__as_cast"), ',
+				conversion_functions.write_string2('\tbuiltin__panic_debug(1, builtin__tos3("builtin.v"), builtin__tos3("builtin"), builtin__tos3("__as_cast"), ',
 					pmessage)
 				conversion_functions.writeln(');')
 			} else {
-				conversion_functions.write_string2('\t_v_panic(', pmessage)
+				conversion_functions.write_string2('\tbuiltin___v_panic(', pmessage)
 				conversion_functions.writeln(');')
 			}
 			conversion_functions.writeln2('\treturn (${vsym.cname}){0};', '}')

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -18,7 +18,7 @@ struct __shared_map {
 	map val;
 };
 static inline voidptr __dup_shared_map(voidptr src, int sz) {
-	__shared_map* dest = memdup(src, sz);
+	__shared_map* dest = builtin__memdup(src, sz);
 	sync__RwMutex_init(&dest->mtx);
 	return dest;
 }
@@ -28,7 +28,7 @@ struct __shared_array {
 	array val;
 };
 static inline voidptr __dup_shared_array(voidptr src, int sz) {
-	__shared_array* dest = memdup(src, sz);
+	__shared_array* dest = builtin__memdup(src, sz);
 	sync__RwMutex_init(&dest->mtx);
 	return dest;
 }
@@ -315,19 +315,19 @@ const c_helper_macros = '//============================== HELPER C MACROS ======
 #define _S(s) ((string){.str=(byteptr)("" s), .len=(sizeof(s)-1), .is_lit=1})
 #define _SLEN(s, n) ((string){.str=(byteptr)("" s), .len=n, .is_lit=1})
 // optimized way to compare literal strings
-#define _SLIT_EQ(sptr, slen, lit) (slen == sizeof("" lit)-1 && !vmemcmp(sptr, "" lit, slen))
-#define _SLIT_NE(sptr, slen, lit) (slen != sizeof("" lit)-1 || vmemcmp(sptr, "" lit, slen))
+#define _SLIT_EQ(sptr, slen, lit) (slen == sizeof("" lit)-1 && !builtin__vmemcmp(sptr, "" lit, slen))
+#define _SLIT_NE(sptr, slen, lit) (slen != sizeof("" lit)-1 || builtin__vmemcmp(sptr, "" lit, slen))
 
 // take the address of an rvalue
 #define ADDR(type, expr) (&((type[]){expr}[0]))
 
 // copy something to the heap
-#define HEAP(type, expr) ((type*)memdup((void*)&((type[]){expr}[0]), sizeof(type)))
-#define HEAP_noscan(type, expr) ((type*)memdup_noscan((void*)&((type[]){expr}[0]), sizeof(type)))
-#define HEAP_align(type, expr, align) ((type*)memdup_align((void*)&((type[]){expr}[0]), sizeof(type), align))
+#define HEAP(type, expr) ((type*)builtin__memdup((void*)&((type[]){expr}[0]), sizeof(type)))
+#define HEAP_noscan(type, expr) ((type*)builtin__memdup_noscan((void*)&((type[]){expr}[0]), sizeof(type)))
+#define HEAP_align(type, expr, align) ((type*)builtin__memdup_align((void*)&((type[]){expr}[0]), sizeof(type), align))
 
-#define _PUSH_MANY(arr, val, tmp, tmp_typ) {tmp_typ tmp = (val); array_push_many(arr, tmp.data, tmp.len);}
-#define _PUSH_MANY_noscan(arr, val, tmp, tmp_typ) {tmp_typ tmp = (val); array_push_many_noscan(arr, tmp.data, tmp.len);}
+#define _PUSH_MANY(arr, val, tmp, tmp_typ) {tmp_typ tmp = (val); builtin__array_push_many(arr, tmp.data, tmp.len);}
+#define _PUSH_MANY_noscan(arr, val, tmp, tmp_typ) {tmp_typ tmp = (val); builtin__array_push_many_noscan(arr, tmp.data, tmp.len);}
 '
 
 const c_headers = c_helper_macros + c_unsigned_comparison_functions + c_common_macros +
@@ -563,7 +563,7 @@ void _vcleanup();
 #define _ARR_LEN(a) ( (sizeof(a)) / (sizeof(a[0])) )
 
 void v_free(voidptr ptr);
-voidptr memdup(voidptr src, isize size);
+voidptr builtin__memdup(voidptr src, isize size);
 
 '
 
@@ -709,5 +709,5 @@ static inline uint64_t wy2u0k(uint64_t r, uint64_t k){ _wymum(&r,&k); return k; 
 #endif
 #endif
 
-#define _IN_MAP(val, m) map_exists(m, val)
+#define _IN_MAP(val, m) builtin__map_exists(m, val)
 '

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -248,7 +248,7 @@ pub fn (mut g Gen) gen_failing_error_propagation_for_test_fn(or_block ast.OrExpr
 	paline, pafile, pamod, pafn := g.panic_debug_info(or_block.pos)
 	dot_or_ptr := if cvar_name in g.tmp_var_ptr { '->' } else { '.' }
 	err_msg := 'IError_name_table[${cvar_name}${dot_or_ptr}err._typ]._method_msg(${cvar_name}${dot_or_ptr}err._object)'
-	g.writeln('\tmain__TestRunner_name_table[test_runner._typ]._method_fn_error(test_runner._object, ${paline}, tos3("${pafile}"), tos3("${pamod}"), tos3("${pafn}"), ${err_msg} );')
+	g.writeln('\tmain__TestRunner_name_table[test_runner._typ]._method_fn_error(test_runner._object, ${paline}, builtin__tos3("${pafile}"), builtin__tos3("${pamod}"), builtin__tos3("${pafn}"), ${err_msg} );')
 	g.writeln('\tlongjmp(g_jump_buffer, 1);')
 }
 
@@ -259,7 +259,7 @@ pub fn (mut g Gen) gen_failing_return_error_for_test_fn(return_stmt ast.Return, 
 	paline, pafile, pamod, pafn := g.panic_debug_info(return_stmt.pos)
 	dot_or_ptr := if cvar_name in g.tmp_var_ptr { '->' } else { '.' }
 	err_msg := 'IError_name_table[${cvar_name}${dot_or_ptr}err._typ]._method_msg(${cvar_name}${dot_or_ptr}err._object)'
-	g.writeln('\tmain__TestRunner_name_table[test_runner._typ]._method_fn_error(test_runner._object, ${paline}, tos3("${pafile}"), tos3("${pamod}"), tos3("${pafn}"), ${err_msg} );')
+	g.writeln('\tmain__TestRunner_name_table[test_runner._typ]._method_fn_error(test_runner._object, ${paline}, builtin__tos3("${pafile}"), builtin__tos3("${pamod}"), builtin__tos3("${pafn}"), ${err_msg} );')
 	g.writeln('\tlongjmp(g_jump_buffer, 1);')
 }
 

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -129,7 +129,7 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 				g.writeln('vweb__Context_html(&${app_name}->Context, _tmpl_res_${fn_name});')
 			}
 			g.writeln('strings__Builder_free(&sb_${fn_name});')
-			g.writeln('string_free(&_tmpl_res_${fn_name});')
+			g.writeln('builtin__string_free(&_tmpl_res_${fn_name});')
 		} else {
 			// return $tmpl string
 			g.write(cur_line)
@@ -213,7 +213,7 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 				&& node.args[i - 1].expr is ast.ArrayDecompose {
 				mut d_count := 0
 				for d_i in i .. m.params.len {
-					g.write('*(${g.styp(m.params[i].typ)}*)array_get(')
+					g.write('*(${g.styp(m.params[i].typ)}*)builtin__array_get(')
 					g.expr(node.args[i - 1].expr)
 					g.write(', ${d_count})')
 
@@ -238,7 +238,7 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 				if m.params[i].typ.is_int() || m.params[i].typ.idx() == ast.bool_type_idx {
 					// Gets the type name and cast the string to the type with the string_<type> function
 					type_name := g.table.type_symbols[int(m.params[i].typ)].str()
-					g.write('string_${type_name}(((string*)${last_arg}.data) [${idx}])')
+					g.write('builtin__string_${type_name}(((string*)${last_arg}.data) [${idx}])')
 				} else {
 					g.write('((string*)${last_arg}.data) [${idx}] ')
 				}
@@ -279,7 +279,7 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 			if j > 0 {
 				g.write(' else ')
 			}
-			g.write('if (string__eq(${node.method_name}, _S("${method.name}"))) ')
+			g.write('if (builtin__string__eq(${node.method_name}, _S("${method.name}"))) ')
 		}
 		g.write('${g.cc_type(left_type, false)}_${method.name}(${amp} ')
 		g.expr(node.left)
@@ -470,7 +470,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 						tmp_var2 := g.new_tmp_var()
 						g.write('{ ${g.base_type(node.typ)} ${tmp_var2} = ')
 						g.stmt(last)
-						g.writeln('_result_ok(&(${g.base_type(node.typ)}[]) { ${tmp_var2} }, (_result*)(&${tmp_var}), sizeof(${g.base_type(node.typ)}));')
+						g.writeln('builtin___result_ok(&(${g.base_type(node.typ)}[]) { ${tmp_var2} }, (_result*)(&${tmp_var}), sizeof(${g.base_type(node.typ)}));')
 						g.writeln('}')
 					} else {
 						g.write('\t${tmp_var} = ')
@@ -488,7 +488,7 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 						tmp_var2 := g.new_tmp_var()
 						g.write('{ ${g.base_type(node.typ)} ${tmp_var2} = ')
 						g.stmt(last)
-						g.writeln('_result_ok(&(${g.base_type(node.typ)}[]) { ${tmp_var2} }, (_result*)(&${tmp_var}), sizeof(${g.base_type(node.typ)}));')
+						g.writeln('builtin___result_ok(&(${g.base_type(node.typ)}[]) { ${tmp_var2} }, (_result*)(&${tmp_var}), sizeof(${g.base_type(node.typ)}));')
 						g.writeln('}')
 					} else {
 						g.write('${tmp_var} = ')
@@ -645,19 +645,19 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 			g.writeln('/* method ${i} : ${method.name} */ {')
 			g.writeln('\t${node.val_var}.name = _S("${method.name}");')
 			if method.attrs.len == 0 {
-				g.writeln('\t${node.val_var}.attrs = __new_array_with_default(0, 0, sizeof(string), 0);')
+				g.writeln('\t${node.val_var}.attrs = builtin____new_array_with_default(0, 0, sizeof(string), 0);')
 			} else {
 				attrs := cgen_attrs(method.attrs)
 				g.writeln(
-					'\t${node.val_var}.attrs = new_array_from_c_array(${attrs.len}, ${attrs.len}, sizeof(string), _MOV((string[${attrs.len}]){' +
+					'\t${node.val_var}.attrs = builtin__new_array_from_c_array(${attrs.len}, ${attrs.len}, sizeof(string), _MOV((string[${attrs.len}]){' +
 					attrs.join(', ') + '}));\n')
 			}
 			if method.params.len < 2 {
 				// 0 or 1 (the receiver) args
-				g.writeln('\t${node.val_var}.args = __new_array_with_default(0, 0, sizeof(MethodParam), 0);')
+				g.writeln('\t${node.val_var}.args = builtin____new_array_with_default(0, 0, sizeof(MethodParam), 0);')
 			} else {
 				len := method.params.len - 1
-				g.write('\t${node.val_var}.args = new_array_from_c_array(${len}, ${len}, sizeof(MethodParam), _MOV((MethodParam[${len}]){')
+				g.write('\t${node.val_var}.args = builtin__new_array_from_c_array(${len}, ${len}, sizeof(MethodParam), _MOV((MethodParam[${len}]){')
 				// Skip receiver arg
 				for j, arg in method.params[1..] {
 					typ := arg.typ.idx()
@@ -725,11 +725,11 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 				g.writeln('/* field ${i} : ${field.name} */ {')
 				g.writeln('\t${node.val_var}.name = _S("${field.name}");')
 				if field.attrs.len == 0 {
-					g.writeln('\t${node.val_var}.attrs = __new_array_with_default(0, 0, sizeof(string), 0);')
+					g.writeln('\t${node.val_var}.attrs = builtin____new_array_with_default(0, 0, sizeof(string), 0);')
 				} else {
 					attrs := cgen_attrs(field.attrs)
 					g.writeln(
-						'\t${node.val_var}.attrs = new_array_from_c_array(${attrs.len}, ${attrs.len}, sizeof(string), _MOV((string[${attrs.len}]){' +
+						'\t${node.val_var}.attrs = builtin__new_array_from_c_array(${attrs.len}, ${attrs.len}, sizeof(string), _MOV((string[${attrs.len}]){' +
 						attrs.join(', ') + '}));\n')
 				}
 				field_sym := g.table.sym(field.typ)
@@ -790,11 +790,11 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 					}
 					enum_attrs := sym.info.attrs[val]
 					if enum_attrs.len == 0 {
-						g.writeln('\t${node.val_var}.attrs = __new_array_with_default(0, 0, sizeof(string), 0);')
+						g.writeln('\t${node.val_var}.attrs = builtin____new_array_with_default(0, 0, sizeof(string), 0);')
 					} else {
 						attrs := cgen_attrs(enum_attrs)
 						g.writeln(
-							'\t${node.val_var}.attrs = new_array_from_c_array(${attrs.len}, ${attrs.len}, sizeof(string), _MOV((string[${attrs.len}]){' +
+							'\t${node.val_var}.attrs = builtin__new_array_from_c_array(${attrs.len}, ${attrs.len}, sizeof(string), _MOV((string[${attrs.len}]){' +
 							attrs.join(', ') + '}));\n')
 					}
 					g.stmts(node.stmts)
@@ -1025,7 +1025,7 @@ fn (mut g Gen) comptime_match(node ast.MatchExpr) {
 						tmp_var2 := g.new_tmp_var()
 						g.write('{ ${g.base_type(node.return_type)} ${tmp_var2} = ')
 						g.stmt(last)
-						g.writeln('_result_ok(&(${g.base_type(node.return_type)}[]) { ${tmp_var2} }, (_result*)(&${tmp_var}), sizeof(${g.base_type(node.return_type)}));')
+						g.writeln('builtin___result_ok(&(${g.base_type(node.return_type)}[]) { ${tmp_var2} }, (_result*)(&${tmp_var}), sizeof(${g.base_type(node.return_type)}));')
 						g.writeln('}')
 					} else {
 						g.write('\t${tmp_var} = ')
@@ -1043,7 +1043,7 @@ fn (mut g Gen) comptime_match(node ast.MatchExpr) {
 						tmp_var2 := g.new_tmp_var()
 						g.write('{ ${g.base_type(node.return_type)} ${tmp_var2} = ')
 						g.stmt(last)
-						g.writeln('_result_ok(&(${g.base_type(node.return_type)}[]) { ${tmp_var2} }, (_result*)(&${tmp_var}), sizeof(${g.base_type(node.return_type)}));')
+						g.writeln('builtin___result_ok(&(${g.base_type(node.return_type)}[]) { ${tmp_var2} }, (_result*)(&${tmp_var}), sizeof(${g.base_type(node.return_type)}));')
 						g.writeln('}')
 					} else {
 						g.write('${tmp_var} = ')

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -241,7 +241,7 @@ fn (mut g Gen) const_decl_precomputed(mod string, name string, field_name string
 				order: -1
 			}
 			if g.is_autofree {
-				g.cleanups[mod].writeln('\tstring_free(&${cname});')
+				g.cleanups[mod].writeln('\tbuiltin__string_free(&${cname});')
 			}
 		}
 		voidptr {
@@ -360,14 +360,14 @@ fn (mut g Gen) const_decl_init_later(mod string, name string, expr ast.Expr, typ
 			if sym.has_method_with_generic_parent('free') {
 				g.cleanup.writeln('\t${styp}_free(&${cname});')
 			} else {
-				g.cleanup.writeln('\tarray_free(&${cname});')
+				g.cleanup.writeln('\tbuiltin__array_free(&${cname});')
 			}
 		} else if styp == 'string' {
-			g.cleanup.writeln('\tstring_free(&${cname});')
+			g.cleanup.writeln('\tbuiltin__string_free(&${cname});')
 		} else if sym.kind == .map {
-			g.cleanup.writeln('\tmap_free(&${cname});')
+			g.cleanup.writeln('\tbuiltin__map_free(&${cname});')
 		} else if styp == 'IError' {
-			g.cleanup.writeln('\tIError_free(&${cname});')
+			g.cleanup.writeln('\tbuiltin__IError_free(&${cname});')
 		}
 	}
 }
@@ -406,9 +406,13 @@ fn (mut g Gen) const_decl_init_later_msvc_string_fixed_array(mod string, name st
 	if g.is_autofree {
 		sym := g.table.sym(typ)
 		if sym.has_method_with_generic_parent('free') {
-			g.cleanup.writeln('\t${styp}_free(&${cname});')
+			if sym.is_builtin() {
+				g.cleanup.writeln('\tbuiltin__${styp}_free(&${cname});')
+			} else {
+				g.cleanup.writeln('\t${styp}_free(&${cname});')
+			}
 		} else {
-			g.cleanup.writeln('\tarray_free(&${cname});')
+			g.cleanup.writeln('\tbuiltin__array_free(&${cname});')
 		}
 	}
 }

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -184,15 +184,15 @@ fn (mut g Gen) dump_expr_definitions() {
 			continue
 		}
 		mut surrounder := util.new_surrounder(3)
-		surrounder.add('\tstring sline = int_str(line);', '\tstring_free(&sline);')
+		surrounder.add('\tstring sline = builtin__int_str(line);', '\tbuiltin__string_free(&sline);')
 		if dump_sym.kind == .function && !is_option {
-			surrounder.add('\tstring value = ${to_string_fn_name}();', '\tstring_free(&value);')
+			surrounder.add('\tstring value = ${to_string_fn_name}();', '\tbuiltin__string_free(&value);')
 		} else if dump_sym.kind == .none {
-			surrounder.add('\tstring value = _S("none");', '\tstring_free(&value);')
+			surrounder.add('\tstring value = _S("none");', '\tbuiltin__string_free(&value);')
 		} else if is_ptr {
 			if typ.has_flag(.option) {
-				surrounder.add('\tstring value = isnil(&dump_arg.data) ? _S("nil") : ${to_string_fn_name}(${deref}dump_arg);',
-					'\tstring_free(&value);')
+				surrounder.add('\tstring value = builtin__isnil(&dump_arg.data) ? _S("nil") : ${to_string_fn_name}(${deref}dump_arg);',
+					'\tbuiltin__string_free(&value);')
 			} else {
 				prefix := if dump_sym.is_c_struct() {
 					c_struct_ptr(dump_sym, typ, str_method_expects_ptr)
@@ -200,7 +200,7 @@ fn (mut g Gen) dump_expr_definitions() {
 					deref
 				}
 				surrounder.add('\tstring value = (dump_arg == NULL) ? _S("nil") : ${to_string_fn_name}(${prefix}dump_arg);',
-					'\tstring_free(&value);')
+					'\tbuiltin__string_free(&value);')
 			}
 		} else {
 			prefix := if dump_sym.is_c_struct() {
@@ -209,15 +209,15 @@ fn (mut g Gen) dump_expr_definitions() {
 				deref
 			}
 			surrounder.add('\tstring value = ${to_string_fn_name}(${prefix}dump_arg);',
-				'\tstring_free(&value);')
+				'\tbuiltin__string_free(&value);')
 		}
 		surrounder.add('
 	strings__Builder sb = strings__new_builder(64);
 ', '
 	string res;
 	res = strings__Builder_str(&sb);
-	eprint(res);
-	string_free(&res);
+	builtin__eprint(res);
+	builtin__string_free(&res);
 	strings__Builder_free(&sb);
 ')
 		surrounder.builder_write_befores(mut dump_fns)

--- a/vlib/v/gen/c/embed.v
+++ b/vlib/v/gen/c/embed.v
@@ -128,7 +128,7 @@ fn (mut g Gen) gen_embedded_metadata() {
 		g.embedded_data.writeln('\t\t\tbreak;')
 		g.embedded_data.writeln('\t\t} // case ${ef_idx}')
 	}
-	g.embedded_data.writeln('\t\tdefault: _v_panic(_S("unknown embed file"));')
+	g.embedded_data.writeln('\t\tdefault: builtin___v_panic(_S("unknown embed file"));')
 	g.embedded_data.writeln('\t} // switch')
 	g.embedded_data.writeln('\treturn res;')
 	g.embedded_data.writeln('}')

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -25,7 +25,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 				cur_line := g.go_before_last_stmt()
 				g.out.write_string(util.tabs(g.indent))
 				opt_elem_type := g.styp(ast.u8_type.set_flag(.option))
-				g.write('${opt_elem_type} ${tmp_opt} = string_at_with_check(')
+				g.write('${opt_elem_type} ${tmp_opt} = builtin__string_at_with_check(')
 				g.expr(node.left)
 				g.write(', ')
 				g.expr(node.index)
@@ -42,7 +42,7 @@ fn (mut g Gen) index_expr(node ast.IndexExpr) {
 					g.expr(node.index)
 					g.write(']')
 				} else {
-					g.write('string_at(')
+					g.write('builtin__string_at(')
 					g.expr(node.left)
 					g.write(', ')
 					g.expr(node.index)
@@ -72,16 +72,16 @@ fn (mut g Gen) index_range_expr(node ast.IndexExpr, range ast.RangeExpr) {
 	left_is_shared := unwrapped_left_type.has_flag(.shared_f)
 	if sym.kind == .string {
 		if node.is_gated {
-			g.write('string_substr_ni(')
+			g.write('builtin__string_substr_ni(')
 		} else {
 			if gen_or {
 				tmp_opt = g.new_tmp_var()
 				cur_line = g.go_before_last_stmt()
 				g.out.write_string(util.tabs(g.indent))
 				opt_elem_type := g.styp(ast.string_type.set_flag(.result))
-				g.write('${opt_elem_type} ${tmp_opt} = string_substr_with_check(')
+				g.write('${opt_elem_type} ${tmp_opt} = builtin__string_substr_with_check(')
 			} else {
-				g.write('string_substr(')
+				g.write('builtin__string_substr(')
 			}
 		}
 		if node.left_type.is_ptr() {
@@ -90,9 +90,9 @@ fn (mut g Gen) index_range_expr(node ast.IndexExpr, range ast.RangeExpr) {
 		g.expr(node.left)
 	} else if sym.kind == .array {
 		if node.is_gated {
-			g.write('array_slice_ni(')
+			g.write('builtin__array_slice_ni(')
 		} else {
-			g.write('array_slice(')
+			g.write('builtin__array_slice(')
 		}
 		if left_is_shared {
 			g.write('(')
@@ -108,11 +108,11 @@ fn (mut g Gen) index_range_expr(node ast.IndexExpr, range ast.RangeExpr) {
 		// Convert a fixed array to V array when doing `fixed_arr[start..end]`
 		noscan := g.check_noscan(sym.info.elem_type)
 		if node.is_gated {
-			g.write('array_slice_ni(')
+			g.write('builtin__array_slice_ni(')
 		} else {
-			g.write('array_slice(')
+			g.write('builtin__array_slice(')
 		}
-		g.write('new_array_from_c_array${noscan}(')
+		g.write('builtin__new_array_from_c_array${noscan}(')
 		ctype := g.styp(sym.info.elem_type)
 		g.write('${sym.info.size}, ${sym.info.size}, sizeof(${ctype}), ')
 		if left_is_shared {
@@ -185,14 +185,14 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 		if is_direct_array_access {
 			g.write('((${elem_type_str}*)')
 		} else if is_op_assign {
-			g.write('(*(${elem_type_str}*)array_get(')
+			g.write('(*(${elem_type_str}*)builtin__array_get(')
 			if left_is_ptr && !left_is_shared {
 				g.write('*')
 			}
 		} else {
 			g.cur_indexexpr << node.pos.pos
 			g.is_arraymap_set = true // special handling of assign_op and closing with '})'
-			g.write('array_set(')
+			g.write('builtin__array_set(')
 			if !left_is_ptr || left_is_shared {
 				g.write('&')
 			}
@@ -266,13 +266,13 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 		tmp_opt := if gen_or { g.new_tmp_var() } else { '' }
 		tmp_opt_ptr := if gen_or { g.new_tmp_var() } else { '' }
 		if gen_or {
-			g.write('${elem_type_str}* ${tmp_opt_ptr} = (${elem_type_str}*)(array_get_with_check(')
+			g.write('${elem_type_str}* ${tmp_opt_ptr} = (${elem_type_str}*)(builtin__array_get_with_check(')
 			if left_is_ptr && !left_is_shared {
 				g.write('*')
 			}
 		} else {
 			if needs_clone {
-				g.write('string_clone(')
+				g.write('builtin__string_clone(')
 			}
 			if is_fn_index_call {
 				if elem_sym.info is ast.FnType {
@@ -281,7 +281,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 					if is_direct_array_access {
 						g.write(')((${elem_type_str}*)')
 					} else {
-						g.write(')(*(${elem_type_str}*)array_get(')
+						g.write(')(*(${elem_type_str}*)builtin__array_get(')
 					}
 				}
 				if left_is_ptr && !left_is_shared {
@@ -290,7 +290,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 			} else if is_direct_array_access {
 				g.write('((${elem_type_str}*)')
 			} else {
-				g.write('(*(${elem_type_str}*)array_get(')
+				g.write('(*(${elem_type_str}*)builtin__array_get(')
 				if left_is_ptr && !left_is_shared {
 					g.write('*')
 				}
@@ -336,7 +336,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 			g.writeln('if (${tmp_opt_ptr}) {')
 			g.writeln('\t*((${elem_type_str}*)&${tmp_opt}.data) = *((${elem_type_str}*)${tmp_opt_ptr});')
 			g.writeln('} else {')
-			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = _v_error(_S("array index out of range"));')
+			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = builtin___v_error(_S("array index out of range"));')
 			g.writeln('}')
 			if !node.is_option {
 				g.or_block(tmp_opt, node.or_expr, elem_type)
@@ -399,7 +399,7 @@ fn (mut g Gen) index_of_fixed_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 		g.expr(node.index)
 	} else {
 		// bounds check
-		g.write('v_fixed_index(')
+		g.write('builtin__v_fixed_index(')
 		g.expr(node.index)
 		g.write(', ${info.size})')
 	}
@@ -431,12 +431,12 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 		if g.assign_op == .assign || info.value_type == ast.string_type {
 			g.cur_indexexpr << node.pos.pos
 			g.is_arraymap_set = true
-			g.write('map_set(')
+			g.write('builtin__map_set(')
 		} else {
 			if node.is_setter {
-				g.write('(*((${val_type_str}*)map_get_and_set((map*)')
+				g.write('(*((${val_type_str}*)builtin__map_get_and_set((map*)')
 			} else {
-				g.write('(*((${val_type_str}*)map_get((map*)')
+				g.write('(*((${val_type_str}*)builtin__map_get((map*)')
 			}
 		}
 		if !left_is_ptr || left_is_shared {
@@ -472,9 +472,9 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 		&& get_and_set_types)) {
 		zero := g.type_default(info.value_type)
 		if node.is_setter {
-			g.write('(*(${val_type_str}*)map_get_and_set((map*)')
+			g.write('(*(${val_type_str}*)builtin__map_get_and_set((map*)')
 		} else {
-			g.write('(*(${val_type_str}*)map_get((map*)')
+			g.write('(*(${val_type_str}*)builtin__map_get((map*)')
 		}
 		if !left_is_ptr || left_is_shared {
 			g.write('&')
@@ -503,18 +503,18 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 		tmp_opt_ptr := if gen_or { g.new_tmp_var() } else { '' }
 		mut is_fn_last_index_call := false
 		if gen_or {
-			g.write('${val_type_str}* ${tmp_opt_ptr} = (${val_type_str}*)(map_get_check(')
+			g.write('${val_type_str}* ${tmp_opt_ptr} = (${val_type_str}*)(builtin__map_get_check(')
 		} else {
 			if g.is_fn_index_call {
 				if val_sym.info is ast.FnType {
 					g.write('((')
 					g.write_fn_ptr_decl(&val_sym.info, '')
-					g.write(')(*(voidptr*)map_get(')
+					g.write(')(*(voidptr*)builtin__map_get(')
 					is_fn_last_index_call = true
 					g.is_fn_index_call = false
 				}
 			} else {
-				g.write('(*(${val_type_str}*)map_get(')
+				g.write('(*(${val_type_str}*)builtin__map_get(')
 			}
 		}
 		if !left_is_ptr || left_is_shared {
@@ -552,7 +552,7 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 				g.writeln('\t*((${val_type_str}*)&${tmp_opt}.data) = *((${val_type_str}*)${tmp_opt_ptr});')
 			}
 			g.writeln('} else {')
-			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = _v_error(_S("map key does not exist"));')
+			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = builtin___v_error(_S("map key does not exist"));')
 			g.writeln('}')
 			if !node.is_option {
 				g.or_block(tmp_opt, node.or_expr, val_type)

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -89,7 +89,7 @@ ${dec_fn_dec} {
 		if (error_ptr != NULL) {
 			const int error_pos = (int)cJSON_GetErrorPos();
 			int maxcontext_chars = 30;
-			byte *buf = vcalloc_noscan(maxcontext_chars + 10);
+			byte *buf = builtin__vcalloc_noscan(maxcontext_chars + 10);
 			if (error_pos > 0) {
 				int backlines = 1;
 				int backchars = error_pos < maxcontext_chars-7 ? (int)error_pos : maxcontext_chars-7 ;
@@ -107,15 +107,15 @@ ${dec_fn_dec} {
 						break; // stop at `{` too
 					}
 				}
-				int maxchars = vstrlen_char(prevline_ptr);
-				vmemcpy(buf, prevline_ptr, (maxchars < maxcontext_chars ? maxchars : maxcontext_chars));
+				int maxchars = builtin__vstrlen_char(prevline_ptr);
+				builtin__vmemcpy(buf, prevline_ptr, (maxchars < maxcontext_chars ? maxchars : maxcontext_chars));
 			}
 			string msg;
 			msg = _S("failed to decode JSON string");
 			if (buf[0] != \'\\0\') {
-				msg = string__plus(msg, _S(": "));
+				msg = builtin__string__plus(msg, _S(": "));
 			}
-			return (${result_name}_${ret_styp}){.is_error = true,.err = _v_error(string__plus(msg, tos2(buf))),.data = {0}};
+			return (${result_name}_${ret_styp}){.is_error = true,.err = builtin___v_error(builtin__string__plus(msg, builtin__tos2(buf))),.data = {0}};
 		}
 	}
 ')
@@ -123,13 +123,13 @@ ${dec_fn_dec} {
 		if utyp.has_flag(.option) {
 			dec.writeln('\tif (cJSON_IsNull(root)) {')
 			dec.writeln('\t${result_name}_${ret_styp} ret;')
-			dec.writeln('\t_result_ok(&res, (${result_name}*)&ret, sizeof(res));')
+			dec.writeln('\tbuiltin___result_ok(&res, (${result_name}*)&ret, sizeof(res));')
 			dec.writeln('\treturn ret;')
 			dec.writeln('\t}')
 
 			base_type := utyp.clear_flag(.option)
 			base_type_str := g.styp(base_type)
-			dec.writeln('\t_option_ok(&(${base_type_str}[]){ ${g.type_default(base_type)} }, (${styp}*)&res, sizeof(${base_type_str}));\n')
+			dec.writeln('\tbuiltin___option_ok(&(${base_type_str}[]){ ${g.type_default(base_type)} }, (${styp}*)&res, sizeof(${base_type_str}));\n')
 		}
 
 		extern_str := if g.pref.parallel_cc { 'extern ' } else { '' }
@@ -215,7 +215,7 @@ ${enc_fn_dec} {
 		}
 		// cJSON_delete
 		dec.writeln('\t${result_name}_${ret_styp} ret;')
-		dec.writeln('\t_result_ok(&res, (${result_name}*)&ret, sizeof(res));')
+		dec.writeln('\tbuiltin___result_ok(&res, (${result_name}*)&ret, sizeof(res));')
 		dec.writeln('\treturn ret;\n}')
 		enc.writeln('\treturn o;\n}')
 		g.gowrappers.writeln(dec.str())
@@ -254,17 +254,17 @@ fn (mut g Gen) gen_str_to_enum(utyp ast.Type, sym ast.TypeSymbol, val_var string
 			ast.Attr{}
 		}
 		if k == 0 {
-			dec.write_string('${ident}if (string__eq(_S("${val}"), ${val_var})')
+			dec.write_string('${ident}if (builtin__string__eq(_S("${val}"), ${val_var})')
 		} else {
-			dec.write_string('${ident}else if (string__eq(_S("${val}"), ${val_var})')
+			dec.write_string('${ident}else if (builtin__string__eq(_S("${val}"), ${val_var})')
 		}
 		if attr.has_arg {
-			dec.write_string(' || string__eq(_S("${attr.arg}"), ${val_var})')
+			dec.write_string(' || builtin__string__eq(_S("${attr.arg}"), ${val_var})')
 		}
 		dec.write_string(')\t')
 		if is_option {
 			base_typ := g.base_type(utyp)
-			dec.writeln('_option_ok(&(${base_typ}[]){ ${enum_prefix}${val} }, (${option_name}*)${result_var}, sizeof(${base_typ}));')
+			dec.writeln('builtin___option_ok(&(${base_typ}[]){ ${enum_prefix}${val} }, (${option_name}*)${result_var}, sizeof(${base_typ}));')
 		} else {
 			dec.writeln('${result_var} = ${enum_prefix}${val};')
 		}
@@ -289,7 +289,7 @@ fn (mut g Gen) gen_enum_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc strin
 		if is_option {
 			base_typ := g.styp(utyp.clear_flag(.option))
 			enc.writeln('\to = ${js_enc_name('u64')}(*val.data);')
-			dec.writeln('\t_option_ok(&(${base_typ}[]){ ${js_dec_name('u64')}(root) }, (${option_name}*)&res, sizeof(${base_typ}));')
+			dec.writeln('\tbuiltin___option_ok(&(${base_typ}[]){ ${js_dec_name('u64')}(root) }, (${option_name}*)&res, sizeof(${base_typ}));')
 		} else {
 			dec.writeln('\tres = ${js_dec_name('u64')}(root);')
 			enc.writeln('\to = ${js_enc_name('u64')}(val);')
@@ -326,7 +326,7 @@ fn (mut g Gen) gen_prim_enc_dec(typ ast.Type, mut enc strings.Builder, mut dec s
 			if typ.has_flag(.option) {
 				tmp_var := g.new_tmp_var()
 				dec.writeln('${type_str}* ${tmp_var} = HEAP(${type_str}, *(${type_str}*) ${dec_name}(root).data);')
-				dec.writeln('\t_option_ok(&(${type_str}*[]) { &(*(${tmp_var})) }, (${option_name}*)&res, sizeof(${type_str}*));')
+				dec.writeln('\tbuiltin___option_ok(&(${type_str}*[]) { &(*(${tmp_var})) }, (${option_name}*)&res, sizeof(${type_str}*));')
 			} else {
 				dec.writeln('\tres = HEAP(${type_str}, *(${type_str}*) ${dec_name}(root).data);')
 			}
@@ -334,7 +334,7 @@ fn (mut g Gen) gen_prim_enc_dec(typ ast.Type, mut enc strings.Builder, mut dec s
 			if typ.has_flag(.option) {
 				tmp_var := g.new_tmp_var()
 				dec.writeln('${type_str}* ${tmp_var} = HEAP(${type_str}, ${dec_name}(root));')
-				dec.writeln('\t_option_ok(&(${type_str}*[]) { &(*(${tmp_var})) }, (${option_name}*)&res, sizeof(${type_str}*));')
+				dec.writeln('\tbuiltin___option_ok(&(${type_str}*[]) { &(*(${tmp_var})) }, (${option_name}*)&res, sizeof(${type_str}*));')
 			} else {
 				dec.writeln('\tres = HEAP(${type_str}, ${dec_name}(root));')
 			}
@@ -359,10 +359,10 @@ fn (mut g Gen) gen_option_enc_dec(typ ast.Type, mut enc strings.Builder, mut dec
 
 	dec_name := js_dec_name(type_str)
 	dec.writeln('\tif (!cJSON_IsNull(root)) {')
-	dec.writeln('\t\t_option_ok(&(${type_str}[]){ ${dec_name}(root) }, (${option_name}*)&res, sizeof(${type_str}));')
+	dec.writeln('\t\tbuiltin___option_ok(&(${type_str}[]){ ${dec_name}(root) }, (${option_name}*)&res, sizeof(${type_str}));')
 	dec.writeln('\t} else {')
 	default_init := if typ.is_int() || typ.is_float() || typ.is_bool() { '0' } else { '{0}' }
-	dec.writeln('\t\t_option_none(&(${type_str}[]){ ${default_init} }, (${option_name}*)&res, sizeof(${type_str}));')
+	dec.writeln('\t\tbuiltin___option_none(&(${type_str}[]){ ${default_init} }, (${option_name}*)&res, sizeof(${type_str}));')
 	dec.writeln('\t}')
 }
 
@@ -498,7 +498,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 				dec.writeln('\t\t${variant_typ} value = *(${variant_typ}*)(${tmp}.data);')
 			}
 			if is_option {
-				dec.writeln('\t\t\t_option_ok(&(${sym.cname}[]){ ${variant_typ}_to_sumtype_${sym.cname}(&value, false) }, (${option_name}*)&res, sizeof(${sym.cname}));')
+				dec.writeln('\t\t\tbuiltin___option_ok(&(${sym.cname}[]){ ${variant_typ}_to_sumtype_${sym.cname}(&value, false) }, (${option_name}*)&res, sizeof(${sym.cname}));')
 			} else {
 				dec.writeln('\t\tres = ${variant_typ}_to_sumtype_${ret_styp}(&value, false);')
 			}
@@ -512,7 +512,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 					dec.writeln('\t\t\t\t${prefix}res.state = 0;')
 					tmp_time_var := g.new_tmp_var()
 					dec.writeln('\t\t\t\t${g.base_type(utyp)} ${tmp_time_var} = ${variant_typ}_to_sumtype_${sym.cname}(&${tmp}, false);')
-					dec.writeln('\t\t\t\tvmemcpy(&${prefix}res.data, ${tmp_time_var}._time__Time, sizeof(${variant_typ}));')
+					dec.writeln('\t\t\t\tbuiltin__vmemcpy(&${prefix}res.data, ${tmp_time_var}._time__Time, sizeof(${variant_typ}));')
 				} else {
 					dec.writeln('\t\t\t\t${prefix}res = ${variant_typ}_to_sumtype_${sym.cname}(&${tmp}, false);')
 				}
@@ -525,7 +525,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 				dec.writeln('\t\t\t\t\treturn (${result_name}_${ret_styp}){ .is_error = true, .err = ${tmp}.err, .data = {0} };')
 				dec.writeln('\t\t\t\t}')
 				if is_option {
-					dec.writeln('\t\t\t\t_option_ok(&(${sym.cname}[]){ ${variant_typ}_to_sumtype_${sym.cname}((${variant_typ}*)${tmp}.data, false) }, (${option_name}*)&res, sizeof(${sym.cname}));')
+					dec.writeln('\t\t\t\tbuiltin___option_ok(&(${sym.cname}[]){ ${variant_typ}_to_sumtype_${sym.cname}((${variant_typ}*)${tmp}.data, false) }, (${option_name}*)&res, sizeof(${sym.cname}));')
 				} else {
 					dec.writeln('\t\t\t\t${prefix}res = ${variant_typ}_to_sumtype_${sym.cname}((${variant_typ}*)${tmp}.data, false);')
 				}
@@ -565,7 +565,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 					dec.writeln('\t\tif (cJSON_IsNumber(root)) {')
 					dec.writeln('\t\t\t${var_t} value = ${js_dec_name('u64')}(root);')
 					if utyp.has_flag(.option) {
-						dec.writeln('\t\t\t_option_ok(&(${sym.cname}[]){ ${var_t}_to_sumtype_${sym.cname}(&value, false) }, (${option_name}*)&${prefix}res, sizeof(${sym.cname}));')
+						dec.writeln('\t\t\tbuiltin___option_ok(&(${sym.cname}[]){ ${var_t}_to_sumtype_${sym.cname}(&value, false) }, (${option_name}*)&${prefix}res, sizeof(${sym.cname}));')
 					} else {
 						dec.writeln('\t\t\t${prefix}res = ${var_t}_to_sumtype_${sym.cname}(&value, false);')
 					}
@@ -581,7 +581,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 					dec.writeln('\t\tif (cJSON_IsString(root)) {')
 					dec.writeln('\t\t\t${var_t} value = ${js_dec_name(var_t)}(root);')
 					if utyp.has_flag(.option) {
-						dec.writeln('\t\t\t_option_ok(&(${sym.cname}[]){ ${var_t}_to_sumtype_${sym.cname}(&value, false) }, (${option_name}*)&${prefix}res, sizeof(${sym.cname}));')
+						dec.writeln('\t\t\tbuiltin___option_ok(&(${sym.cname}[]){ ${var_t}_to_sumtype_${sym.cname}(&value, false) }, (${option_name}*)&${prefix}res, sizeof(${sym.cname}));')
 					} else {
 						dec.writeln('\t\t\t${prefix}res = ${var_t}_to_sumtype_${sym.cname}(&value, false);')
 					}
@@ -605,7 +605,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 					dec.writeln('\t\t\t\treturn (${result_name}_${ret_styp}){ .is_error = true, .err = ${tmp}.err, .data = {0} };')
 					dec.writeln('\t\t\t}')
 					if utyp.has_flag(.option) {
-						dec.writeln('\t\t\t_option_ok(&(${sym.cname}[]){ ${var_t}_to_sumtype_${sym.cname}((${var_t}*)${tmp}.data, false) }, (${option_name}*)&${prefix}res, sizeof(${sym.cname}));')
+						dec.writeln('\t\t\tbuiltin___option_ok(&(${sym.cname}[]){ ${var_t}_to_sumtype_${sym.cname}((${var_t}*)${tmp}.data, false) }, (${option_name}*)&${prefix}res, sizeof(${sym.cname}));')
 					} else {
 						dec.writeln('\t\t\t${prefix}res = ${var_t}_to_sumtype_${sym.cname}((${var_t}*)${tmp}.data, false);')
 					}
@@ -624,7 +624,7 @@ fn (mut g Gen) gen_sumtype_enc_dec(utyp ast.Type, sym ast.TypeSymbol, mut enc st
 					dec.writeln('\t\tif (cJSON_IsNumber(root)) {')
 					dec.writeln('\t\t\t${var_t} value = ${js_dec_name(var_t)}(root);')
 					if utyp.has_flag(.option) {
-						dec.writeln('\t\t\t_option_ok(&(${sym.cname}[]){ ${var_t}_to_sumtype_${sym.cname}(&value, false) }, (${option_name}*)&${prefix}res, sizeof(${sym.cname}));')
+						dec.writeln('\t\t\tbuiltin___option_ok(&(${sym.cname}[]){ ${var_t}_to_sumtype_${sym.cname}(&value, false) }, (${option_name}*)&${prefix}res, sizeof(${sym.cname}));')
 					} else {
 						dec.writeln('\t\t\t${prefix}res = ${var_t}_to_sumtype_${sym.cname}(&value, false);')
 					}
@@ -655,7 +655,7 @@ fn (mut g Gen) gen_prim_type_validation(name string, typ ast.Type, tmp string, i
 		return
 	}
 	dec.writeln('\t\tif (!(${type_check})) {')
-	dec.writeln('\t\t\treturn (${ret_styp}){ .is_error = true, .err = _v_error(string__plus(_S("type mismatch for field \'${name}\', expecting `${g.table.type_to_str(typ)}` type, got: "), json__json_print(jsonroot_${tmp}))), .data = {0} };')
+	dec.writeln('\t\t\treturn (${ret_styp}){ .is_error = true, .err = builtin___v_error(builtin__string__plus(_S("type mismatch for field \'${name}\', expecting `${g.table.type_to_str(typ)}` type, got: "), json__json_print(jsonroot_${tmp}))), .data = {0} };')
 	dec.writeln('\t\t}')
 }
 
@@ -723,9 +723,9 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				} else {
 					'{0}'
 				}
-				dec.writeln('\t\t_option_none(&(${base_typ}[]) { ${default_init} }, (${option_name}*)&${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
+				dec.writeln('\t\tbuiltin___option_none(&(${base_typ}[]) { ${default_init} }, (${option_name}*)&${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
 				dec.writeln('\telse')
-				dec.writeln('\t\t_option_ok(&(${base_typ}[]) {  json__json_print(js_get(root, "${name}")) }, (${option_name}*)&${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
+				dec.writeln('\t\tbuiltin___option_ok(&(${base_typ}[]) {  json__json_print(js_get(root, "${name}")) }, (${option_name}*)&${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
 			} else {
 				dec.writeln('\t${prefix}${op}${c_name(field.name)} = json__json_print(js_get(root, "${name}"));')
 			}
@@ -764,14 +764,14 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				if g.is_enum_as_int(field_sym) {
 					if is_option_field {
 						base_typ := g.base_type(field.typ)
-						dec.writeln('\t\t_option_ok(&(${base_typ}[]) { ${js_dec_name('u64')}(jsonroot_${tmp}) }, (${option_name}*)&${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
+						dec.writeln('\t\tbuiltin___option_ok(&(${base_typ}[]) { ${js_dec_name('u64')}(jsonroot_${tmp}) }, (${option_name}*)&${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
 					} else {
 						dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = ${js_dec_name('u64')}(jsonroot_${tmp});')
 					}
 				} else {
 					if is_option_field {
 						base_typ := g.base_type(field.typ)
-						dec.writeln('\t\t_option_ok(&(${base_typ}[]) { *(${base_typ}*)((${g.styp(field.typ)}*)${tmp}.data)->data }, (${option_name}*)&${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
+						dec.writeln('\t\tbuiltin___option_ok(&(${base_typ}[]) { *(${base_typ}*)((${g.styp(field.typ)}*)${tmp}.data)->data }, (${option_name}*)&${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
 					} else {
 						tmp2 := g.new_tmp_var()
 						dec.writeln('\t\tstring ${tmp2} = json__decode_string(jsonroot_${tmp});')
@@ -796,7 +796,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 					dec.writeln('\t\t\t${prefix}${op}${c_name(field.name)}.state = 0;\n')
 					tmp_time_var := g.new_tmp_var()
 					dec.writeln('\t\t\t${g.base_type(field.typ)} ${tmp_time_var} = time__unix(json__decode_u64(jsonroot_${tmp}));\n')
-					dec.writeln('\t\t\tvmemcpy(&${prefix}${op}${c_name(field.name)}.data, &${tmp_time_var}, sizeof(${g.base_type(field.typ)}));')
+					dec.writeln('\t\t\tbuiltin__vmemcpy(&${prefix}${op}${c_name(field.name)}.data, &${tmp_time_var}, sizeof(${g.base_type(field.typ)}));')
 					dec.writeln('\t\t}\n')
 				} else {
 					dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = time__unix(json__decode_u64(jsonroot_${tmp}));')
@@ -867,10 +867,10 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 						'${result_name}_${styp}', mut dec)
 				}
 				if field.typ.has_flag(.option) {
-					dec.writeln('\t\tvmemcpy(&${prefix}${op}${c_name(field.name)}, (${field_type}*)${tmp}.data, sizeof(${field_type}));')
+					dec.writeln('\t\tbuiltin__vmemcpy(&${prefix}${op}${c_name(field.name)}, (${field_type}*)${tmp}.data, sizeof(${field_type}));')
 				} else {
 					if field_sym.kind == .array_fixed {
-						dec.writeln('\t\tvmemcpy(${prefix}${op}${c_name(field.name)},*(${field_type}*)${tmp}.data,sizeof(${field_type}));')
+						dec.writeln('\t\tbuiltin__vmemcpy(${prefix}${op}${c_name(field.name)},*(${field_type}*)${tmp}.data,sizeof(${field_type}));')
 					} else {
 						dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = *(${field_type}*) ${tmp}.data;')
 					}
@@ -1007,7 +1007,7 @@ fn gen_js_get(styp string, tmp string, name string, mut dec strings.Builder, is_
 	dec.writeln('\tcJSON *jsonroot_${tmp} = js_get(root, "${name}");')
 	if is_required {
 		dec.writeln('\tif (jsonroot_${tmp} == 0) {')
-		dec.writeln('\t\treturn (${result_name}_${styp}){ .is_error = true, .err = _v_error(_S("expected field \'${name}\' is missing")), .data = {0} };')
+		dec.writeln('\t\treturn (${result_name}_${styp}){ .is_error = true, .err = builtin___v_error(_S("expected field \'${name}\' is missing")), .data = {0} };')
 		dec.writeln('\t}')
 	}
 }
@@ -1066,9 +1066,9 @@ fn (mut g Gen) decode_array(utyp ast.Type, value_type ast.Type, fixed_array_size
 			array_element_assign += '((${styp}*)res.data)[fixed_array_idx] = val;'
 			fixed_array_idx_increment += 'fixed_array_idx++; res.state = 0;'
 		} else {
-			array_element_assign += 'array_push${noscan}((array*)&res.data, &val);'
-			res_str += '_option_ok(&(${g.base_type(utyp)}[]) { __new_array${noscan}(0, 0, sizeof(${styp})) }, (${option_name}*)&res, sizeof(${g.base_type(utyp)}));'
-			array_free_str += 'array_free(&res.data);'
+			array_element_assign += 'builtin__array_push${noscan}((array*)&res.data, &val);'
+			res_str += 'builtin___option_ok(&(${g.base_type(utyp)}[]) { builtin____new_array${noscan}(0, 0, sizeof(${styp})) }, (${option_name}*)&res, sizeof(${g.base_type(utyp)}));'
+			array_free_str += 'builtin__array_free(&res.data);'
 		}
 	} else {
 		if is_array_fixed_val {
@@ -1080,9 +1080,9 @@ fn (mut g Gen) decode_array(utyp ast.Type, value_type ast.Type, fixed_array_size
 			array_element_assign += 'res[fixed_array_idx] = val;'
 			fixed_array_idx_increment += 'fixed_array_idx++;'
 		} else {
-			array_element_assign += 'array_push${noscan}((array*)&res, &val);'
-			res_str += 'res = __new_array${noscan}(0, 0, sizeof(${styp}));'
-			array_free_str += 'array_free(&res);'
+			array_element_assign += 'builtin__array_push${noscan}((array*)&res, &val);'
+			res_str += 'res = builtin____new_array${noscan}(0, 0, sizeof(${styp}));'
+			array_free_str += 'builtin__array_free(&res);'
 		}
 	}
 
@@ -1111,7 +1111,7 @@ fn (mut g Gen) decode_array(utyp ast.Type, value_type ast.Type, fixed_array_size
 
 	return '
 	if(root && !cJSON_IsArray(root) && !cJSON_IsNull(root)) {
-		return (${result_name}_${ret_styp}){.is_error = true, .err = _v_error(string__plus(_S("Json element is not an array: "), json__json_print(root))), .data = {0}};
+		return (${result_name}_${ret_styp}){.is_error = true, .err = builtin___v_error(builtin__string__plus(_S("Json element is not an array: "), json__json_print(root))), .data = {0}};
 	}
 	${res_str}
 	const cJSON *jsval = NULL;
@@ -1170,7 +1170,7 @@ fn (mut g Gen) decode_map(utyp ast.Type, key_type ast.Type, value_type ast.Type,
 		s = '
 		${result_name}_${ret_styp} val2 = ${fn_name_v} (js_get(root, jsval->string));
 		if(val2.is_error) {
-			map_free(&res);
+			builtin__map_free(&res);
 			return *(${result_name}_${ustyp}*)&val2;
 		}
 		${styp_v} val = *(${styp_v}*)val2.data;
@@ -1180,29 +1180,29 @@ fn (mut g Gen) decode_map(utyp ast.Type, key_type ast.Type, value_type ast.Type,
 	if utyp.has_flag(.option) {
 		return '
 		if(!cJSON_IsObject(root) && !cJSON_IsNull(root)) {
-			return (${result_name}_${ustyp}){ .is_error = true, .err = _v_error(string__plus(_S("Json element is not an object: "), json__json_print(root))), .data = {0}};
+			return (${result_name}_${ustyp}){ .is_error = true, .err = builtin___v_error(builtin__string__plus(_S("Json element is not an object: "), json__json_print(root))), .data = {0}};
 		}
-		_option_ok(&(${g.base_type(utyp)}[]) { new_map(sizeof(${styp}), sizeof(${styp_v}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn}) }, (${option_name}*)&res, sizeof(${g.base_type(utyp)}));
+		builtin___option_ok(&(${g.base_type(utyp)}[]) { builtin__new_map(sizeof(${styp}), sizeof(${styp_v}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn}) }, (${option_name}*)&res, sizeof(${g.base_type(utyp)}));
 		cJSON *jsval = NULL;
 		cJSON_ArrayForEach(jsval, root)
 		{
 			${s}
-			string key = tos2((byteptr)jsval->string);
-			map_set((map*)res.data, &key, &val);
+			string key = builtin__tos2((byteptr)jsval->string);
+			builtin__map_set((map*)res.data, &key, &val);
 		}
 '
 	} else {
 		return '
 		if(!cJSON_IsObject(root) && !cJSON_IsNull(root)) {
-			return (${result_name}_${ustyp}){ .is_error = true, .err = _v_error(string__plus(_S("Json element is not an object: "), json__json_print(root))), .data = {0}};
+			return (${result_name}_${ustyp}){ .is_error = true, .err = builtin___v_error(builtin__string__plus(_S("Json element is not an object: "), json__json_print(root))), .data = {0}};
 		}
-		res = new_map(sizeof(${styp}), sizeof(${styp_v}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn});
+		res = builtin__new_map(sizeof(${styp}), sizeof(${styp_v}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn});
 		cJSON *jsval = NULL;
 		cJSON_ArrayForEach(jsval, root)
 		{
 			${s}
-			string key = tos2((byteptr)jsval->string);
-			map_set(&res, &key, &val);
+			string key = builtin__tos2((byteptr)jsval->string);
+			builtin__map_set(&res, &key, &val);
 		}
 '
 	}
@@ -1224,22 +1224,22 @@ fn (mut g Gen) encode_map(utyp ast.Type, key_type ast.Type, value_type ast.Type)
 	if utyp.has_flag(.option) {
 		return '
 		o = cJSON_CreateObject();
-		Array_${styp} ${keys_tmp} = map_keys((map*)val.data);
+		Array_${styp} ${keys_tmp} = builtin__map_keys((map*)val.data);
 		for (int i = 0; i < ${keys_tmp}.len; ++i) {
 			${key}
-			cJSON_AddItemToObject(o, (char*) key.str, ${fn_name_v} ( *(${styp_v}*) map_get((map*)val.data, &key, &(${styp_v}[]) { ${zero} } ) ) );
+			cJSON_AddItemToObject(o, (char*) key.str, ${fn_name_v} ( *(${styp_v}*) builtin__map_get((map*)val.data, &key, &(${styp_v}[]) { ${zero} } ) ) );
 		}
-		array_free(&${keys_tmp});
+		builtin__array_free(&${keys_tmp});
 '
 	} else {
 		return '
 		o = cJSON_CreateObject();
-		Array_${styp} ${keys_tmp} = map_keys(&val);
+		Array_${styp} ${keys_tmp} = builtin__map_keys(&val);
 		for (int i = 0; i < ${keys_tmp}.len; ++i) {
 			${key}
-			cJSON_AddItemToObject(o, (char*) key.str, ${fn_name_v} ( *(${styp_v}*) map_get(&val, &key, &(${styp_v}[]) { ${zero} } ) ) );
+			cJSON_AddItemToObject(o, (char*) key.str, ${fn_name_v} ( *(${styp_v}*) builtin__map_get(&val, &key, &(${styp_v}[]) { ${zero} } ) ) );
 		}
-		array_free(&${keys_tmp});
+		builtin__array_free(&${keys_tmp});
 '
 	}
 }

--- a/vlib/v/gen/c/live.v
+++ b/vlib/v/gen/c/live.v
@@ -95,9 +95,9 @@ fn (mut g Gen) generate_hotcode_reloading_main_caller() {
 		g.writeln('\t\tlive_fn_mutex = CreateMutexA(0, 0, 0);')
 	}
 	g.writeln('\t\tv__live__LiveReloadInfo* live_info = v__live__executable__new_live_reload_info(')
-	g.writeln('\t\t\t\t\t tos2("${file}"),')
-	g.writeln('\t\t\t\t\t tos2("${vexe}"),')
-	g.writeln('\t\t\t\t\t tos2("${vopts}"),')
+	g.writeln('\t\t\t\t\t builtin__tos2("${file}"),')
+	g.writeln('\t\t\t\t\t builtin__tos2("${vexe}"),')
+	g.writeln('\t\t\t\t\t builtin__tos2("${vopts}"),')
 	g.writeln('\t\t\t\t\t &live_fn_mutex,')
 	g.writeln('\t\t\t\t\t v_bind_live_symbols')
 	g.writeln('\t\t);')

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -514,7 +514,7 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 							}
 						} else {
 							ptr_str := if node.cond_type.is_ptr() { '*' } else { '' }
-							g.write('fast_string_eq(${ptr_str}${cond_var}, ')
+							g.write('builtin__fast_string_eq(${ptr_str}${cond_var}, ')
 							g.expr(expr)
 							g.write(')')
 						}

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -152,7 +152,7 @@ fn (mut g Gen) write_orm_table_struct(typ ast.Type) {
 	g.writeln('((orm__Table){')
 	g.indent++
 	g.writeln('.name = _S("${table_name}"),')
-	g.writeln('.attrs = new_array_from_c_array(${table_attrs.len}, ${table_attrs.len}, sizeof(VAttribute),')
+	g.writeln('.attrs = builtin__new_array_from_c_array(${table_attrs.len}, ${table_attrs.len}, sizeof(VAttribute),')
 	g.indent++
 
 	if table_attrs.len > 0 {
@@ -192,7 +192,7 @@ fn (mut g Gen) write_orm_create_table(node ast.SqlStmtLine, table_name string, c
 	g.writeln('${connection_var_name}._object, // Connection object')
 	g.write_orm_table_struct(node.table_expr.typ)
 	g.writeln(',')
-	g.writeln('new_array_from_c_array(${node.fields.len}, ${node.fields.len}, sizeof(orm__TableField),')
+	g.writeln('builtin__new_array_from_c_array(${node.fields.len}, ${node.fields.len}, sizeof(orm__TableField),')
 	g.indent++
 
 	if node.fields.len > 0 {
@@ -215,7 +215,7 @@ fn (mut g Gen) write_orm_create_table(node ast.SqlStmtLine, table_name string, c
 			g.writeln('.is_arr = ${sym.kind == .array}, ')
 			g.writeln('.nullable = ${final_field_typ.has_flag(.option)},')
 			g.writeln('.default_val = (string){ .str = (byteptr) "${field.default_val}", .is_lit = 1 },')
-			g.writeln('.attrs = new_array_from_c_array(${field.attrs.len}, ${field.attrs.len}, sizeof(VAttribute),')
+			g.writeln('.attrs = builtin__new_array_from_c_array(${field.attrs.len}, ${field.attrs.len}, sizeof(VAttribute),')
 			g.indent++
 
 			if field.attrs.len > 0 {
@@ -274,7 +274,7 @@ fn (mut g Gen) write_orm_insert(node &ast.SqlStmtLine, table_name string, connec
 	or_expr &ast.OrExpr, table_attrs []ast.Attr) {
 	last_ids_variable_name := g.new_tmp_var()
 
-	g.writeln('Array_orm__Primitive ${last_ids_variable_name} = __new_array_with_default_noscan(0, 0, sizeof(orm__Primitive), 0);')
+	g.writeln('Array_orm__Primitive ${last_ids_variable_name} = builtin____new_array_with_default_noscan(0, 0, sizeof(orm__Primitive), 0);')
 	g.write_orm_insert_with_last_ids(node, connection_var_name, table_name, last_ids_variable_name,
 		result_var_name, '', '', or_expr)
 }
@@ -289,13 +289,13 @@ fn (mut g Gen) write_orm_update(node &ast.SqlStmtLine, table_name string, connec
 	g.writeln(',')
 	g.writeln('(orm__QueryData){')
 	g.indent++
-	g.writeln('.kinds = __new_array_with_default_noscan(0, 0, sizeof(orm__OperationKind), 0),')
-	g.writeln('.is_and = __new_array_with_default_noscan(0, 0, sizeof(bool), 0),')
-	g.writeln('.types = __new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
-	g.writeln('.parentheses = __new_array_with_default_noscan(0, 0, sizeof(Array_int), 0),')
+	g.writeln('.kinds = builtin____new_array_with_default_noscan(0, 0, sizeof(orm__OperationKind), 0),')
+	g.writeln('.is_and = builtin____new_array_with_default_noscan(0, 0, sizeof(bool), 0),')
+	g.writeln('.types = builtin____new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
+	g.writeln('.parentheses = builtin____new_array_with_default_noscan(0, 0, sizeof(Array_int), 0),')
 
 	if node.updated_columns.len > 0 {
-		g.writeln('.fields = new_array_from_c_array(${node.updated_columns.len}, ${node.updated_columns.len}, sizeof(string),')
+		g.writeln('.fields = builtin__new_array_from_c_array(${node.updated_columns.len}, ${node.updated_columns.len}, sizeof(string),')
 		g.indent++
 		g.writeln('_MOV((string[${node.updated_columns.len}]){')
 		g.indent++
@@ -306,10 +306,10 @@ fn (mut g Gen) write_orm_update(node &ast.SqlStmtLine, table_name string, connec
 		g.writeln('})')
 		g.indent--
 	} else {
-		g.writeln('.fields = __new_array_with_default_noscan(${node.updated_columns.len}, ${node.updated_columns.len}, sizeof(string), 0')
+		g.writeln('.fields = builtin____new_array_with_default_noscan(${node.updated_columns.len}, ${node.updated_columns.len}, sizeof(string), 0')
 	}
 
-	g.writeln2('),', '.data = new_array_from_c_array(${node.update_exprs.len}, ${node.update_exprs.len}, sizeof(orm__Primitive),')
+	g.writeln2('),', '.data = builtin__new_array_from_c_array(${node.update_exprs.len}, ${node.update_exprs.len}, sizeof(orm__Primitive),')
 
 	if node.update_exprs.len > 0 {
 		g.indent++
@@ -418,12 +418,12 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 			sub.object_var = '${node.object_var}${member_access_type}${sub.object_var}'
 		}
 		g.sql_stmt_line(sub, connection_var_name, or_expr)
-		g.writeln('array_push(&${last_ids_arr}, _MOV((orm__Primitive[1]){')
+		g.writeln('builtin__array_push(&${last_ids_arr}, _MOV((orm__Primitive[1]){')
 		g.writeln('\torm__int_to_primitive(orm__Connection_name_table[${connection_var_name}._typ]._method_last_id(${connection_var_name}._object))}));')
 		if subs_unwrapped_c_typ[i].len > 0 {
 			g.indent--
 			g.writeln('} else {')
-			g.writeln('\tarray_push(&${last_ids_arr}, _MOV((orm__Primitive[1]){ _const_orm__null_primitive }));')
+			g.writeln('\tbuiltin__array_push(&${last_ids_arr}, _MOV((orm__Primitive[1]){ _const_orm__null_primitive }));')
 			g.writeln('}')
 		}
 	}
@@ -436,7 +436,7 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 	g.writeln(',')
 	g.writeln('(orm__QueryData){')
 	g.indent++
-	g.writeln('.fields = new_array_from_c_array(${fields.len}, ${fields.len}, sizeof(string),')
+	g.writeln('.fields = builtin__new_array_from_c_array(${fields.len}, ${fields.len}, sizeof(string),')
 	g.indent++
 
 	if fields.len > 0 {
@@ -453,7 +453,7 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 	g.indent--
 	g.writeln('),')
 
-	g.writeln('.data = new_array_from_c_array(${fields.len}, ${fields.len}, sizeof(orm__Primitive),')
+	g.writeln('.data = builtin__new_array_from_c_array(${fields.len}, ${fields.len}, sizeof(orm__Primitive),')
 	g.indent++
 
 	if fields.len > 0 {
@@ -470,7 +470,7 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 			mut typ := sym.cname
 			mut ctyp := sym.cname
 			if sym.kind == .struct && typ != 'time__Time' {
-				g.writeln('(*(orm__Primitive*) array_get(${last_ids_arr}, ${structs})),')
+				g.writeln('(*(orm__Primitive*) builtin__array_get(${last_ids_arr}, ${structs})),')
 				structs++
 				continue
 			}
@@ -499,9 +499,9 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 	}
 	g.indent--
 	g.writeln('),')
-	g.writeln('.types = __new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
+	g.writeln('.types = builtin____new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
 	if auto_fields.len > 0 {
-		g.writeln('.auto_fields = new_array_from_c_array(${auto_fields.len}, ${auto_fields.len}, sizeof(${ast.int_type_name}),')
+		g.writeln('.auto_fields = builtin__new_array_from_c_array(${auto_fields.len}, ${auto_fields.len}, sizeof(${ast.int_type_name}),')
 		g.indent++
 		g.write('_MOV((int[${auto_fields.len}]){')
 		for i in auto_fields {
@@ -510,10 +510,10 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 		g.writeln(' })),')
 		g.indent--
 	} else {
-		g.writeln('.auto_fields = __new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
+		g.writeln('.auto_fields = builtin____new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
 	}
-	g.writeln('.kinds = __new_array_with_default_noscan(0, 0, sizeof(orm__OperationKind), 0),')
-	g.writeln('.is_and = __new_array_with_default_noscan(0, 0, sizeof(bool), 0),')
+	g.writeln('.kinds = builtin____new_array_with_default_noscan(0, 0, sizeof(orm__OperationKind), 0),')
+	g.writeln('.is_and = builtin____new_array_with_default_noscan(0, 0, sizeof(bool), 0),')
 	g.indent--
 	g.writeln('}')
 	g.indent--
@@ -549,9 +549,9 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 			res_ := g.new_tmp_var()
 			tmp_var := g.new_tmp_var()
 			if is_option {
-				g.writeln('${ctyp} ${tmp_var} = (*(${ctyp}*)array_get(*(Array_${ctyp}*)${node.object_var}${member_access_type}${arr.object_var}.data, ${idx}));')
+				g.writeln('${ctyp} ${tmp_var} = (*(${ctyp}*)builtin__array_get(*(Array_${ctyp}*)${node.object_var}${member_access_type}${arr.object_var}.data, ${idx}));')
 			} else {
-				g.writeln('${ctyp} ${tmp_var} = (*(${ctyp}*)array_get(${node.object_var}${member_access_type}${arr.object_var}, ${idx}));')
+				g.writeln('${ctyp} ${tmp_var} = (*(${ctyp}*)builtin__array_get(${node.object_var}${member_access_type}${arr.object_var}, ${idx}));')
 			}
 			arr.object_var = tmp_var
 			mut fff := []ast.StructField{}
@@ -706,9 +706,9 @@ fn (mut g Gen) write_orm_where(where_expr ast.Expr) {
 	g.indent++
 	g.write_orm_where_expr(where_expr, mut fields, mut parentheses, mut kinds, mut data, mut
 		is_ands)
-	g.writeln('.types = __new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
+	g.writeln('.types = builtin____new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
 	if fields.len > 0 {
-		g.writeln('.fields = new_array_from_c_array(${fields.len}, ${fields.len}, sizeof(string),')
+		g.writeln('.fields = builtin__new_array_from_c_array(${fields.len}, ${fields.len}, sizeof(string),')
 		g.indent++
 		g.writeln('_MOV((string[${fields.len}]){')
 		g.indent++
@@ -719,11 +719,11 @@ fn (mut g Gen) write_orm_where(where_expr ast.Expr) {
 		g.writeln('})')
 		g.indent--
 	} else {
-		g.writeln('.fields = __new_array_with_default_noscan(${fields.len}, ${fields.len}, sizeof(string), 0')
+		g.writeln('.fields = builtin____new_array_with_default_noscan(${fields.len}, ${fields.len}, sizeof(string), 0')
 	}
 	g.writeln('),')
 
-	g.writeln('.data = new_array_from_c_array(${data.len}, ${data.len}, sizeof(orm__Primitive),')
+	g.writeln('.data = builtin__new_array_from_c_array(${data.len}, ${data.len}, sizeof(orm__Primitive),')
 	g.indent++
 	if data.len > 0 {
 		g.writeln('_MOV((orm__Primitive[${data.len}]){')
@@ -741,26 +741,26 @@ fn (mut g Gen) write_orm_where(where_expr ast.Expr) {
 
 	g.write('.parentheses = ')
 	if parentheses.len > 0 {
-		g.write('new_array_from_c_array(${parentheses.len}, ${parentheses.len}, sizeof(Array_int), _MOV((Array_int[${parentheses.len}]){')
+		g.write('builtin__new_array_from_c_array(${parentheses.len}, ${parentheses.len}, sizeof(Array_int), _MOV((Array_int[${parentheses.len}]){')
 		for par in parentheses {
 			if par.len > 0 {
-				g.write('new_array_from_c_array(${par.len}, ${par.len}, sizeof(${ast.int_type_name}), _MOV((int[${par.len}]){')
+				g.write('builtin__new_array_from_c_array(${par.len}, ${par.len}, sizeof(${ast.int_type_name}), _MOV((int[${par.len}]){')
 				for val in par {
 					g.write('${val},')
 				}
 				g.write('})),')
 			} else {
-				g.write('__new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
+				g.write('builtin____new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
 			}
 		}
 		g.write('}))')
 	} else {
-		g.write('__new_array_with_default_noscan(0, 0, sizeof(Array_int), 0)')
+		g.write('builtin____new_array_with_default_noscan(0, 0, sizeof(Array_int), 0)')
 	}
 	g.writeln(',')
 
 	if kinds.len > 0 {
-		g.writeln('.kinds = new_array_from_c_array(${kinds.len}, ${kinds.len}, sizeof(orm__OperationKind),')
+		g.writeln('.kinds = builtin__new_array_from_c_array(${kinds.len}, ${kinds.len}, sizeof(orm__OperationKind),')
 		g.indent++
 		g.writeln('_MOV((orm__OperationKind[${kinds.len}]){')
 		g.indent++
@@ -771,12 +771,12 @@ fn (mut g Gen) write_orm_where(where_expr ast.Expr) {
 		g.writeln('})')
 		g.indent--
 	} else {
-		g.write('.kinds = __new_array_with_default_noscan(${kinds.len}, ${kinds.len}, sizeof(orm__OperationKind), 0')
+		g.write('.kinds = builtin____new_array_with_default_noscan(${kinds.len}, ${kinds.len}, sizeof(orm__OperationKind), 0')
 	}
 	g.writeln('),')
 
 	if is_ands.len > 0 {
-		g.write('.is_and = new_array_from_c_array(${is_ands.len}, ${is_ands.len}, sizeof(bool),')
+		g.write('.is_and = builtin__new_array_from_c_array(${is_ands.len}, ${is_ands.len}, sizeof(bool),')
 		g.indent++
 		g.writeln('_MOV((bool[${is_ands.len}]){')
 		g.indent++
@@ -787,7 +787,7 @@ fn (mut g Gen) write_orm_where(where_expr ast.Expr) {
 		g.write('})')
 		g.indent--
 	} else {
-		g.write('.is_and = __new_array_with_default_noscan(${is_ands.len}, ${is_ands.len}, sizeof(bool), 0')
+		g.write('.is_and = builtin____new_array_with_default_noscan(${is_ands.len}, ${is_ands.len}, sizeof(bool), 0')
 	}
 	g.indent--
 	g.writeln2('),', '}')
@@ -973,7 +973,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 	}
 
 	select_fields := fields.filter(g.table.sym(it.typ).kind != .array)
-	g.writeln('.fields = new_array_from_c_array(${select_fields.len}, ${select_fields.len}, sizeof(string),')
+	g.writeln('.fields = builtin__new_array_from_c_array(${select_fields.len}, ${select_fields.len}, sizeof(string),')
 	g.indent++
 	mut types := []string{}
 	if select_fields.len > 0 {
@@ -1002,7 +1002,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 		g.writeln('NULL')
 	}
 	g.indent--
-	g.writeln2('),', '.types = new_array_from_c_array(${types.len}, ${types.len}, sizeof(${ast.int_type_name}),')
+	g.writeln2('),', '.types = builtin__new_array_from_c_array(${types.len}, ${types.len}, sizeof(${ast.int_type_name}),')
 	g.indent++
 
 	if types.len > 0 {
@@ -1029,19 +1029,19 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 
 	g.writeln('(orm__QueryData) {')
 	g.indent++
-	g.writeln('.types = __new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
-	g.writeln('.kinds = __new_array_with_default_noscan(0, 0, sizeof(orm__OperationKind), 0),')
-	g.writeln('.is_and = __new_array_with_default_noscan(0, 0, sizeof(bool), 0),')
-	g.writeln('.parentheses = __new_array_with_default_noscan(0, 0, sizeof(Array_int), 0),')
+	g.writeln('.types = builtin____new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
+	g.writeln('.kinds = builtin____new_array_with_default_noscan(0, 0, sizeof(orm__OperationKind), 0),')
+	g.writeln('.is_and = builtin____new_array_with_default_noscan(0, 0, sizeof(bool), 0),')
+	g.writeln('.parentheses = builtin____new_array_with_default_noscan(0, 0, sizeof(Array_int), 0),')
 	if exprs.len > 0 {
-		g.write('.data = new_array_from_c_array(${exprs.len}, ${exprs.len}, sizeof(orm__Primitive),')
+		g.write('.data = builtin__new_array_from_c_array(${exprs.len}, ${exprs.len}, sizeof(orm__Primitive),')
 		g.write(' _MOV((orm__Primitive[${exprs.len}]){')
 		for e in exprs {
 			g.write_orm_expr_to_primitive(e)
 		}
 		g.writeln('})')
 	} else {
-		g.writeln('.data = __new_array_with_default_noscan(${exprs.len}, ${exprs.len}, sizeof(orm__Primitive), 0')
+		g.writeln('.data = builtin____new_array_with_default_noscan(${exprs.len}, ${exprs.len}, sizeof(orm__Primitive), 0')
 	}
 	g.indent--
 	g.writeln(')},')
@@ -1051,11 +1051,11 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 	} else {
 		g.writeln('(orm__QueryData) {')
 		g.indent++
-		g.writeln('.types = __new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
-		g.writeln('.kinds = __new_array_with_default_noscan(0, 0, sizeof(orm__OperationKind), 0),')
-		g.writeln('.is_and = __new_array_with_default_noscan(0, 0, sizeof(bool), 0),')
-		g.writeln('.parentheses = __new_array_with_default_noscan(0, 0, sizeof(Array_int), 0),')
-		g.writeln('.data = __new_array_with_default_noscan(0, 0, sizeof(orm__Primitive), 0)')
+		g.writeln('.types = builtin____new_array_with_default_noscan(0, 0, sizeof(${ast.int_type_name}), 0),')
+		g.writeln('.kinds = builtin____new_array_with_default_noscan(0, 0, sizeof(orm__OperationKind), 0),')
+		g.writeln('.is_and = builtin____new_array_with_default_noscan(0, 0, sizeof(bool), 0),')
+		g.writeln('.parentheses = builtin____new_array_with_default_noscan(0, 0, sizeof(Array_int), 0),')
+		g.writeln('.data = builtin____new_array_with_default_noscan(0, 0, sizeof(orm__Primitive), 0)')
 		g.indent--
 		g.writeln('}')
 	}
@@ -1077,7 +1077,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 	g.writeln('Array_Array_orm__Primitive ${select_unwrapped_result_var_name} = (*(Array_Array_orm__Primitive*)${select_result_var_name}.data);')
 
 	if node.is_count {
-		g.writeln('*(${unwrapped_c_typ}*) ${result_var}.data = *((*(orm__Primitive*) array_get((*(Array_orm__Primitive*)array_get(${select_unwrapped_result_var_name}, 0)), 0))._int);')
+		g.writeln('*(${unwrapped_c_typ}*) ${result_var}.data = *((*(orm__Primitive*) builtin__array_get((*(Array_orm__Primitive*) builtin__array_get(${select_unwrapped_result_var_name}, 0)), 0))._int);')
 	} else {
 		tmp := g.new_tmp_var()
 		idx := g.new_tmp_var()
@@ -1089,9 +1089,9 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 			base_typ := g.base_type(node.typ)
 			if node.typ.has_flag(.option) {
 				g.writeln('${unwrapped_c_typ} ${tmp}_array = { .state = 2, .err = _const_none__, .data = {E_STRUCT} };')
-				g.writeln('_option_ok(&(${base_typ}[]) { __new_array(0, ${select_unwrapped_result_var_name}.len, sizeof(${typ_str})) }, (_option *)&${tmp}_array, sizeof(${base_typ}));')
+				g.writeln('builtin___option_ok(&(${base_typ}[]) { builtin____new_array(0, ${select_unwrapped_result_var_name}.len, sizeof(${typ_str})) }, (_option *)&${tmp}_array, sizeof(${base_typ}));')
 			} else {
-				g.writeln('${unwrapped_c_typ} ${tmp}_array = __new_array(0, ${select_unwrapped_result_var_name}.len, sizeof(${typ_str}));')
+				g.writeln('${unwrapped_c_typ} ${tmp}_array = builtin____new_array(0, ${select_unwrapped_result_var_name}.len, sizeof(${typ_str}));')
 			}
 			g.writeln('for (; ${idx} < ${select_unwrapped_result_var_name}.len; ${idx}++) {')
 			g.indent++
@@ -1121,7 +1121,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 
 		mut fields_idx := 0
 		for field in fields {
-			array_get_call_code := '(*(orm__Primitive*) array_get((*(Array_orm__Primitive*) array_get(${select_unwrapped_result_var_name}, ${idx})), ${fields_idx}))'
+			array_get_call_code := '(*(orm__Primitive*) builtin__array_get((*(Array_orm__Primitive*) builtin__array_get(${select_unwrapped_result_var_name}, ${idx})), ${fields_idx}))'
 			final_field_typ := g.table.final_type(field.typ)
 			sym := g.table.sym(final_field_typ)
 			field_var := '${tmp}.${c_name(field.name)}'
@@ -1149,7 +1149,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 				if final_field_typ.has_flag(.option) {
 					unwrapped_field_c_typ := g.styp(final_field_typ.clear_flag(.option))
 					g.writeln('if (!${sub_result_var}.is_error)')
-					g.writeln('\t_option_ok(${sub_result_var}.data, (_option *)&${field_var}, sizeof(${unwrapped_field_c_typ}));')
+					g.writeln('\tbuiltin___option_ok(${sub_result_var}.data, (_option *)&${field_var}, sizeof(${unwrapped_field_c_typ}));')
 					g.writeln('else')
 					g.writeln('\t${field_var} = (${field_c_typ}){ .state = 2, .err = _const_none__, .data = {E_STRUCT} };')
 				} else {
@@ -1222,7 +1222,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 				g.writeln('\t${field_var} = (${field_c_typ}){ .state = 2, .err = _const_none__, .data = {E_STRUCT} };')
 
 				g.writeln('else')
-				g.writeln('\t_option_ok(${prim_var}->_${sym.cname}, (_option *)&${field_var}, sizeof(${sym.cname}));')
+				g.writeln('\tbuiltin___option_ok(${prim_var}->_${sym.cname}, (_option *)&${field_var}, sizeof(${sym.cname}));')
 				fields_idx++
 			} else if sym.kind == .enum {
 				mut typ := sym.cname
@@ -1237,9 +1237,9 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 		if node.is_array {
 			if node.typ.has_flag(.option) {
 				g.writeln('${tmp}_array.state = 0;')
-				g.writeln('array_push((${g.base_type(node.typ)}*)&${tmp}_array.data, _MOV((${typ_str}[]){ ${tmp} }));')
+				g.writeln('builtin__array_push((${g.base_type(node.typ)}*)&${tmp}_array.data, _MOV((${typ_str}[]){ ${tmp} }));')
 			} else {
-				g.writeln('array_push(&${tmp}_array, _MOV((${typ_str}[]){ ${tmp} }));')
+				g.writeln('builtin__array_push(&${tmp}_array, _MOV((${typ_str}[]){ ${tmp} }));')
 			}
 			g.indent--
 			g.writeln('}')

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -136,7 +136,7 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		}
 		if is_ptr && !is_var_mut {
 			ref_str := '&'.repeat(typ.nr_muls())
-			g.write('str_intp(1, _MOV((StrIntpData[]){{_S("${ref_str}"), ${si_s_code} ,{.d_s = isnil(')
+			g.write('builtin__str_intp(1, _MOV((StrIntpData[]){{_S("${ref_str}"), ${si_s_code} ,{.d_s = builtin__isnil(')
 			if typ.has_flag(.option) {
 				g.write('*(${g.base_type(exp_typ)}*)&')
 				if temp_var_needed {

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -255,7 +255,7 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 			}
 		}
 	}
-	g.write2('str_intp(', node.vals.len.str())
+	g.write2('builtin__str_intp(', node.vals.len.str())
 	g.write(', _MOV((StrIntpData[]){')
 	for i, val in node.vals {
 		mut escaped_val := cescape_nonascii(util.smart_quote(val, false))

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -97,15 +97,15 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		if node.typ.has_flag(.option) {
 			basetyp := g.base_type(node.typ)
 			if aligned != 0 {
-				g.write('(${basetyp}*)memdup_align(&(${basetyp}){')
+				g.write('(${basetyp}*)builtin__memdup_align(&(${basetyp}){')
 			} else {
-				g.write('(${basetyp}*)memdup(&(${basetyp}){')
+				g.write('(${basetyp}*)builtin__memdup(&(${basetyp}){')
 			}
 		} else {
 			if aligned != 0 {
-				g.write('(${styp}*)memdup_align(&(${styp}){')
+				g.write('(${styp}*)builtin__memdup_align(&(${styp}){')
 			} else {
-				g.write('(${styp}*)memdup(&(${styp}){')
+				g.write('(${styp}*)builtin__memdup(&(${styp}){')
 			}
 		}
 	} else if node.typ.is_ptr() {
@@ -124,9 +124,9 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 		g.writeln('${styp} ${tmp_var} = {0};')
 
 		if node.init_fields.len > 0 {
-			g.write('_option_ok(&(${base_styp}[]) { ')
+			g.write('builtin___option_ok(&(${base_styp}[]) { ')
 		} else {
-			g.write('_option_none(&(${base_styp}[]) { ')
+			g.write('builtin___option_none(&(${base_styp}[]) { ')
 		}
 		g.struct_init(ast.StructInit{
 			...node

--- a/vlib/v/gen/c/testdata/addr_from_range.c.must_have
+++ b/vlib/v/gen/c/testdata/addr_from_range.c.must_have
@@ -1,1 +1,1 @@
-Array_int* pointer_to_slice = ADDR(Array_int, array_slice((*(new_data)), 1, 2));
+Array_int* pointer_to_slice = ADDR(Array_int, builtin__array_slice((*(new_data)), 1, 2));

--- a/vlib/v/gen/c/testdata/alias_char_ptr_to_ptr.c.must_have
+++ b/vlib/v/gen/c/testdata/alias_char_ptr_to_ptr.c.must_have
@@ -1,8 +1,8 @@
 VV_LOC string main__get_two(void) {
 char* s = main__return_text_two();
-return cstring_to_vstring(s);
+return builtin__cstring_to_vstring(s);
 }
 VV_LOC string main__get_one(void) {
 main__ALcharptr s = main__return_text_one();
-return cstring_to_vstring(s);
+return builtin__cstring_to_vstring(s);
 }

--- a/vlib/v/gen/c/testdata/autofree_json_decode.c.must_have
+++ b/vlib/v/gen/c/testdata/autofree_json_decode.c.must_have
@@ -1,2 +1,2 @@
-string _arg_expr_json_decode_2_271 = string_str(msg);
+string _arg_expr_json_decode_2_271 = builtin__string_str(msg);
 cJSON* _t2 = json__json_parse(/*af arg2*/_arg_expr_json_decode_2_271);

--- a/vlib/v/gen/c/testdata/autofree_reused.c.must_have
+++ b/vlib/v/gen/c/testdata/autofree_reused.c.must_have
@@ -1,10 +1,9 @@
 VV_LOC void main__main(void) {
 	byteptr b = ((byteptr)("a"));
-	Array_u8 s = byteptr_vbytes(b, 1);
-	string _t1 = Array_u8_str(s); println(_t1); string_free(&_t1);
+	Array_u8 s = builtin__byteptr_vbytes(b, 1);
+	string _t1 = Array_u8_str(s); builtin__println(_t1); builtin__string_free(&_t1);
 	;
 	byteptr bb = ((byteptr)("a"));
-	string ss = byteptr_vstring(bb);
-	println(ss);
+	string ss = builtin__byteptr_vstring(bb);
+	builtin__println(ss);
 }
-

--- a/vlib/v/gen/c/testdata/autofree_toml.c.must_have
+++ b/vlib/v/gen/c/testdata/autofree_toml.c.must_have
@@ -1,9 +1,9 @@
 _result_toml__scanner__Scanner_ptr toml__scanner__new_scanner(toml__scanner__Config config) {
 	_result_toml__scanner__Scanner_ptr _t3 = {0};
-	_result_ok(&(toml__scanner__Scanner*[]) { s }, (_result*)(&_t3), sizeof(toml__scanner__Scanner*));
+	builtin___result_ok(&(toml__scanner__Scanner*[]) { s }, (_result*)(&_t3), sizeof(toml__scanner__Scanner*));
 	return _t3;
 }
 toml__ast__Quoted toml__parser__Parser_quoted(toml__parser__Parser* p) {
-	return ((toml__ast__Quoted){.text =  string_clone_static(lit),.pos = toml__token__Token_pos(&p->tok),.is_multiline = is_multiline,.quote = quote,});
+	return ((toml__ast__Quoted){.text =  builtin__string_clone_static(lit),.pos = toml__token__Token_pos(&p->tok),.is_multiline = is_multiline,.quote = quote,});
 }
 

--- a/vlib/v/gen/c/testdata/const_init_or_block.c.must_have
+++ b/vlib/v/gen/c/testdata/const_init_or_block.c.must_have
@@ -2,7 +2,7 @@
 _option_bool _t2 = main__t1();
 if (_t2.state != 0) {
 IError err = _t2.err;
-_v_panic(IError_str(err));
+builtin___v_panic(builtin__IError_str(err));
 VUNREACHABLE();
 ;
 }

--- a/vlib/v/gen/c/testdata/const_init_or_block_no_parallel.c.must_have
+++ b/vlib/v/gen/c/testdata/const_init_or_block_no_parallel.c.must_have
@@ -2,7 +2,7 @@
 _option_bool _t2 = main__t1();
 if (_t2.state != 0) {
 IError err = _t2.err;
-_v_panic(IError_str(err));
+builtin___v_panic(builtin__IError_str(err));
 VUNREACHABLE();
 ;
 }

--- a/vlib/v/gen/c/testdata/cross_printfn_v_malloc.c.must_have
+++ b/vlib/v/gen/c/testdata/cross_printfn_v_malloc.c.must_have
@@ -1,6 +1,6 @@
 total_m += n;
 fprintf(stderr, "_v_malloc %6d total %10d\n", n, total_m);
-return prealloc_malloc(n);
+return builtin__prealloc_malloc(n);
 res = GC_MALLOC(n);
 res = _aligned_malloc(n, 1);
 res = malloc(n);

--- a/vlib/v/gen/c/testdata/export_and_weak.c.must_have
+++ b/vlib/v/gen/c/testdata/export_and_weak.c.must_have
@@ -8,6 +8,6 @@ VV_EXP int abcd(void); // exported fn main.my_fn
 int abcd(void) {
 VV_LOC int main__my_fn(void) {
 
-	println(int_str(main__my_fn()));
-	println(int_str(main__my_other_fn()));
+	builtin__println(builtin__int_str(main__my_fn()));
+	builtin__println(builtin__int_str(main__my_other_fn()));
 

--- a/vlib/v/gen/c/testdata/free_array_of_strings.c.must_have
+++ b/vlib/v/gen/c/testdata/free_array_of_strings.c.must_have
@@ -1,2 +1,2 @@
-Array_string my_array_of_strings = __new_array_with_default(0, 10, sizeof(string), 0);
+Array_string my_array_of_strings = builtin____new_array_with_default(0, 10, sizeof(string), 0);
 Array_string_free(&my_array_of_strings);

--- a/vlib/v/gen/c/testdata/hw.c.must_have
+++ b/vlib/v/gen/c/testdata/hw.c.must_have
@@ -1,1 +1,1 @@
-VV_LOC void builtin_init(void) {
+VV_LOC void builtin__builtin_init(void) {

--- a/vlib/v/gen/c/testdata/if_else_return.c.must_have
+++ b/vlib/v/gen/c/testdata/if_else_return.c.must_have
@@ -3,7 +3,7 @@ _result_string _t2; /* if prepend */
 if ((s).len != 0) {
 _result_ok(&(string[]) { s }, (_result*)(&_t2), sizeof(string));
 } else {
-return (_result_string){ .is_error=true, .err=_v_error(_S("empty")), .data={E_STRUCT} };
+return (_result_string){ .is_error=true, .err=builtin___v_error(_S("empty")), .data={E_STRUCT} };
 }
 return _t2;
 }

--- a/vlib/v/gen/js/auto_str_methods.v
+++ b/vlib/v/gen/js/auto_str_methods.v
@@ -497,10 +497,10 @@ fn (mut g JsGen) gen_str_for_array(info ast.Array, styp string, str_fn_name stri
 		} else if sym.kind == .rune {
 			g.definitions.writeln('\t\tlet x = new string("\`" + String.fromCharCode(it.val) + "\`");')
 			// Rune are managed at this level as strings
-			// g.definitions.writeln('\t\tstring x = str_intp(2, _MOV((StrIntpData[]){{new string("\`"), $c.si_s_code, {.d_s = ${elem_str_fn_name}(it) }}, {new string("\`"), 0, {.d_c = 0 }}}));\n')
+			// g.definitions.writeln('\t\tstring x = builtin__str_intp(2, _MOV((StrIntpData[]){{new string("\`"), $c.si_s_code, {.d_s = ${elem_str_fn_name}(it) }}, {new string("\`"), 0, {.d_c = 0 }}}));\n')
 		} else if sym.kind == .string {
 			g.definitions.writeln('\t\tlet x = new string(it);')
-			// g.definitions.writeln('\t\tstring x = str_intp(2, _MOV((StrIntpData[]){{new string("\'"), $c.si_s_code, {.d_s = it }}, {new string("\'"), 0, {.d_c = 0 }}}));\n')
+			// g.definitions.writeln('\t\tstring x = builtin__str_intp(2, _MOV((StrIntpData[]){{new string("\'"), $c.si_s_code, {.d_s = it }}, {new string("\'"), 0, {.d_c = 0 }}}));\n')
 		} else {
 			// There is a custom .str() method, so use it.
 			// Note: we need to take account of whether the user has defined
@@ -759,7 +759,7 @@ fn (mut g JsGen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name st
 			func = '(voidptr) it.${field.name}'
 		} else if field.typ.is_ptr() {
 			// reference types can be "nil"
-			fn_builder.write_string('isnil(it.${g.js_name(field.name)})')
+			fn_builder.write_string('builtin__isnil(it.${g.js_name(field.name)})')
 			fn_builder.write_string(' ? new string("nil") : ')
 			// struct, floats and ints have a special case through the _str function
 			if sym.kind != .struct && !field.typ.is_int_valptr() && !field.typ.is_float_valptr() {
@@ -772,7 +772,7 @@ fn (mut g JsGen) gen_str_for_struct(info ast.Struct, styp string, str_fn_name st
 		} else {
 			// manage C charptr
 			if field.typ in ast.charptr_types {
-				fn_builder.write_string('tos4((byteptr)${func})')
+				fn_builder.write_string('builtin__tos4((byteptr)${func})')
 			} else {
 				if field.typ.is_ptr() && sym.kind == .struct {
 					fn_builder.write_string('(indent_count > 25)? new string("<probably circular>") : ')
@@ -819,22 +819,22 @@ fn struct_auto_str_func(mut g JsGen, sym &ast.TypeSymbol, field_type ast.Type, f
 		} else if (field_type.is_int_valptr() || field_type.is_float_valptr()) && !expects_ptr {
 			// ptr int can be "nil", so this needs to be casted to a string
 			if sym.kind == .f32 {
-				return 'str_intp(1, _MOV((StrIntpData[]){
+				return 'builtin__str_intp(1, _MOV((StrIntpData[]){
 					{_SLIT0, ${si_g32_code}, {.d_f32 = *${method_str} }}
 				}))'
 			} else if sym.kind == .f64 {
-				return 'str_intp(1, _MOV((StrIntpData[]){
+				return 'builtin__str_intp(1, _MOV((StrIntpData[]){
 					{_SLIT0, ${si_g64_code}, {.d_f64 = *${method_str} }}
 				}))'
 			} else if sym.kind in [.u64, .usize] {
 				fmt_type := StrIntpType.si_u64
-				return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_u64 = *${method_str} }}}))'
+				return 'builtin__str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_u64 = *${method_str} }}}))'
 			} else if sym.kind in [.i64, .isize] {
 				fmt_type := StrIntpType.si_u64
-				return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_i64 = *${method_str} }}}))'
+				return 'builtin__str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_i64 = *${method_str} }}}))'
 			}
 			fmt_type := StrIntpType.si_i32
-			return 'str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_i32 = *${method_str} }}}))'
+			return 'builtin__str_intp(1, _MOV((StrIntpData[]){{_SLIT0, ${u32(fmt_type) | 0xfe00}, {.d_i32 = *${method_str} }}}))'
 		}
 		return method_str
 	}

--- a/vlib/v/slow_tests/profile/profile_test.v
+++ b/vlib/v/slow_tests/profile/profile_test.v
@@ -68,10 +68,10 @@ fn test_v_profile_works() {
 	println(@FN)
 	sfile := 'vlib/v/slow_tests/profile/profile_test_1.v'
 	validate_output(@FN, '', sfile, {
-		'arguments':     1
-		'main__main':    1
-		'println':       1
-		'strconv__atoi': 1
+		'builtin__arguments': 1
+		'main__main':         1
+		'builtin__println':   1
+		'strconv__atoi':      1
 	})
 }
 
@@ -79,15 +79,15 @@ fn test_v_profile_on_off_api_works() {
 	println(@FN)
 	sfile := 'vlib/v/slow_tests/profile/profile_test_2.v'
 	res_lines := validate_output(@FN, '', sfile, {
-		'builtin_init': 1
-		'main__main':   1
-		'main__abc':    1
+		'builtin__builtin_init': 1
+		'main__main':            1
+		'main__abc':             1
 	})
 	// test that `-d no_profile_startup` *also* works:
 	res2_lines := validate_output(@FN, '-d no_profile_startup', sfile, {
-		'builtin_init': -1
-		'main__main':   1
-		'main__abc':    1
+		'builtin__builtin_init': -1
+		'main__main':            1
+		'main__abc':             1
 	})
 	assert res_lines.len > res2_lines.len
 	// dump(res2_lines)
@@ -96,23 +96,23 @@ fn test_v_profile_on_off_api_works() {
 fn test_v_profile_fns_option_works() {
 	println(@FN)
 	sfile := 'vlib/v/slow_tests/profile/profile_test_3.v'
-	validate_output(@FN, '-profile-fns println', sfile, {
-		'main__main': -1
-		'main__abc':  -1
-		'main__xyz':  -1
-		'println':    10
+	validate_output(@FN, '-profile-fns builtin__println', sfile, {
+		'main__main':       -1
+		'main__abc':        -1
+		'main__xyz':        -1
+		'builtin__println': 10
 	})
 	validate_output(@FN, '-profile-fns main__abc', sfile, {
-		'main__main': -1
-		'main__abc':  1
-		'main__xyz':  2
-		'println':    10
+		'main__main':       -1
+		'main__abc':        1
+		'main__xyz':        2
+		'builtin__println': 10
 	})
 	validate_output(@FN, '-profile-fns main__xyz', sfile, {
-		'main__main': -1
-		'main__abc':  -1
-		'main__xyz':  2
-		'println':    10
+		'main__main':       -1
+		'main__abc':        -1
+		'main__xyz':        2
+		'builtin__println': 10
 	})
 }
 

--- a/vlib/v/tests/clash_var_fn_name_test.v
+++ b/vlib/v/tests/clash_var_fn_name_test.v
@@ -1,0 +1,289 @@
+fn func(rune_bytes []byte) string {
+	return rune_bytes.str()
+}
+
+fn test_assign() {
+	r := rune(0)
+	mut rune_bytes := r.bytes()
+	rb := rune_bytes
+	_ = rune_bytes
+	rc := func(rb)
+}
+
+fn test_bool() {
+	b := bool(false)
+	bool_str := b.str()
+}
+
+fn test_byteptr() {
+	b0 := byteptr(c'a')
+	b1 := byteptr(c'b')
+	b2 := byteptr(c'c')
+	b3 := byteptr(c'd')
+	b4 := byteptr(c'e')
+	byteptr_str := b0.str()
+	byteptr_vbytes := unsafe { b0.vbytes(1) }
+	byteptr_vstring := unsafe { b1.vstring() }
+	byteptr_vstring_literal := unsafe { b2.vstring_literal() }
+	byteptr_vstring_literal_with_len := unsafe { b3.vstring_literal_with_len(1) }
+	byteptr_vstring_with_len := unsafe { b4.vstring_with_len(1) }
+}
+
+fn test_string() {
+	s := 'vstring'
+	s1 := ' other'
+	string_after := s.after('v')
+	string_after_char := s.after_char(`v`)
+	string_all_after := s.all_after('v')
+	string_all_after_first := s.all_after_first('v')
+	string_all_after_last := s.all_after_last('v')
+	string_all_before := s.all_before('v')
+	string_all_before_last := s.all_before_last('v')
+	string_before := s.before('v')
+	string_bool := s.bool()
+	string_bytes := s.bytes()
+	string_camel_to_snake := s.camel_to_snake()
+	string_capitalize := s.capitalize()
+	string_clone := s.clone()
+	string_compare := s.compare(s1)
+	string_contains := s.contains('v')
+	string_contains_any := s.contains_any('vs')
+	string_contains_any_substr := s.contains_any_substr(['v', 'ing'])
+	string_contains_only := s.contains_only('s')
+	string_contains_u8 := s.contains_u8(`g`)
+	string_count := s.count('i')
+	string_ends_with := s.ends_with('ing')
+	string_expand_tabs := s.expand_tabs(4)
+	string_f32 := s.f32()
+	string_f64 := s.f64()
+	string_fields := s.fields()
+	string_find_between := s.find_between('v', 'g')
+	string_hash := s.hash()
+	string_i16 := s.i16()
+	string_i32 := s.i32()
+	string_i64 := s.i64()
+	string_i8 := s.i8()
+	string_indent_width := s.indent_width()
+	string_index := s.index('g')
+	string_index_after_ := s.index_after_('n', 3)
+	string_index_any := s.index_any('g')
+	string_index_u8 := s.index_u8(`g`)
+	string_int := s.int()
+	string_is_ascii := s.is_ascii()
+	string_is_bin := s.is_bin()
+	string_is_blank := s.is_blank()
+	string_is_capital := s.is_capital()
+	string_is_hex := s.is_hex()
+	string_is_identifier := s.is_identifier()
+	string_is_int := s.is_int()
+	string_is_lower := s.is_lower()
+	string_is_oct := s.is_oct()
+	string_is_pure_ascii := s.is_pure_ascii()
+	string_is_title := s.is_title()
+	string_is_upper := s.is_upper()
+	string_last_index := s.last_index('g')
+	string_last_index_u8 := s.last_index_u8(`g`)
+	string_len_utf8 := s.len_utf8()
+	string_limit := s.limit(5)
+	string_match_glob := s.match_glob('*')
+	string_normalize_tabs := s.normalize_tabs(2)
+	string_parse_int := s.parse_int(10, 32) or { 0 }
+	string_parse_uint := s.parse_uint(10, 32) or { 0 }
+	string_repeat := s.repeat(2)
+	string_replace := s.replace('v', 'V')
+	string_replace_char := s.replace_char(`v`, `V`, 1)
+	string_replace_each := s.replace_each(['v', 'V'])
+	string_replace_once := s.replace_once('v', 'V')
+	string_reverse := s.reverse()
+	string_rsplit := s.rsplit('g')
+	string_rsplit_any := s.rsplit_any('g')
+	string_rsplit_nth := s.rsplit_nth('g', 1)
+	string_rsplit_once, tmp := s.rsplit_once('g') or { '', '' }
+	string_runes := s.runes()
+	string_runes_iterator := s.runes_iterator()
+	string_snake_to_camel := s.snake_to_camel()
+	string_split := s.split('r')
+	string_split_any := s.split_any('r')
+	string_split_by_space := s.split_by_space()
+	string_split_into_lines := s.split_into_lines()
+	string_split_n := s.split_n('g', 2)
+	string_split_nth := s.split_nth('ri', 2)
+	string_split_once, tmp1 := s.split_once('g') or { '', '' }
+	string_starts_with := s.starts_with('v')
+	string_starts_with_captial := s.starts_with_capital()
+	string_str := s.str()
+	string_strip_margin := s.strip_margin()
+	string_strip_margin_custom := s.strip_margin_custom(`v`)
+	string_substr := s.substr(1, 3)
+	string_substr_ni := s.substr_ni(0, 1)
+	string_substr_unsafe := unsafe { s[0..2] }
+	string_substr_with_check := s.substr_with_check(0, 1) or { '' }
+	string_title := s.title()
+	string_to_lower := s.to_lower()
+	string_to_lower_ascii := s.to_lower_ascii()
+	string_to_upper := s.to_upper()
+	string_to_upper_ascii := s.to_upper_ascii()
+	string_to_wide := s.to_wide()
+	string_trim_chars := s.trim('string')
+	string_trim_indent := s.trim_indent()
+	string_trim_indexes, tmp3 := s.trim_indexes('in')
+	string_trim_left := s.trim_left('g')
+	string_trim_right := s.trim_right('g')
+	string_trim_space := s.trim_space()
+	string_trim_space_left := s.trim_space_left()
+	string_trim_space_right := s.trim_space_right()
+	string_trim_string_left := s.trim_string_left('v')
+	string_trim_string_right := s.trim_string_right('g')
+	string_u16 := s.u16()
+	string_u32 := s.u32()
+	string_u64 := s.u64()
+	string_u8 := s.u8()
+	string_u8_array := s.u8_array()
+	string_uncapitalize := s.uncapitalize()
+	string_utf32_code := s.utf32_code()
+	string_wrap := s.wrap(width: 20)
+	string__eq := s == s1
+	string__lt := s < s1
+	string__plus := s + s1
+	string_at := s[3]
+}
+
+fn test_i8() {
+	i8_ := i8(0)
+	i8_str := i8_.str()
+}
+
+fn test_i16() {
+	i16_ := i16(0)
+	i16_str := i16_.str()
+}
+
+fn test_i32() {
+	i32_ := i32(0)
+	i32_str := i32_.str()
+}
+
+fn test_int() {
+	int_ := int(0)
+	int_str := int_.str()
+	int_literal_str := 0.str()
+}
+
+fn test_i64() {
+	i64_ := i64(0)
+	i64_str := i64_.str()
+}
+
+fn test_u8() {
+	u8_ := u8(0)
+	u8_str := u8_.str()
+	u8_ascii_str := u8_.ascii_str()
+}
+
+fn test_u16() {
+	u16_ := u16(0)
+	u16_str := u16_.str()
+}
+
+fn test_u32() {
+	u32_ := u32(0)
+	u32_str := u32_.str()
+}
+
+fn test_u64() {
+	u64_ := u64(0)
+	u64_str := u64_.str()
+	u64_hex := u64_.hex()
+}
+
+fn test_isize() {
+	isize_ := isize(0)
+	isize_str := isize_.str()
+}
+
+fn test_usize() {
+	usize_ := usize(0)
+	usize_str := usize_.str()
+}
+
+fn test_f32() {
+	f32_ := f32(0)
+	f32_str := f32_.str()
+	f32_strg := f32_.strg()
+	f32_strsci := f32_.strsci(2)
+	f32_strlong := f32_.strlong()
+	f32_eq_epsilon := f32_.eq_epsilon(0.000001)
+}
+
+fn test_f64() {
+	f64_ := f64(0)
+	f64_str := f64_.str()
+	f64_strg := f64_.strg()
+	f64_strsci := f64_.strsci(2)
+	f64_strlong := f64_.strlong()
+	f64_eq_epsilon := f64_.eq_epsilon(0.000001)
+}
+
+fn test_float() {
+	float_literal_str := 0.1.str()
+}
+
+fn test_rune() {
+	r := rune(0)
+	rune_bytes := r.bytes()
+	rune_str := r.str()
+	rune_to_upper := r.to_upper()
+}
+
+fn test_ptr() {
+	ptr := unsafe { voidptr(nil) }
+	voidptr_hex_full := ptr.hex_full()
+	voidptr_str := ptr.str()
+	voidptr_vbytes := unsafe { ptr.vbytes(1) }
+}
+
+fn test_char() {
+	char_ := unsafe { &char(c'a') }
+	char_str := char_.str()
+	char_vstring := unsafe { char_.vstring() }
+	char_vstring_literal_with_len := unsafe { char_.vstring_with_len(1) }
+	char_vstring_with_len := unsafe { char_.vstring_with_len(1) }
+}
+
+fn test_cstring() {
+	cstring := c'cstring'
+	u8_vstring := unsafe { cstring.vstring() }
+}
+
+fn test_array() {
+	// new_array_from_c_array_noscan := [1, 2, 3]
+	mut a := [1, 2, 3]
+	array_repeat_to_depth := a.repeat(2)
+	array_first := a.first()
+	array_last := a.last()
+	array_pop_left_noscan := a.pop_left()
+	array_pop_noscan := a.pop()
+	array_get := a[0]
+	array_clone_to_depth := a.clone()
+	array_reverse := a.reverse()
+	array_filter := a.filter(it < 2)
+	array_any := a.any(it % 2 == 1)
+	array_count := a.count(it > 1)
+	array_all := a.all(it > 0)
+	array_slice := unsafe { a[0..1] }
+}
+
+fn test_map() {
+	// new_map_noscan_key_value := map[int]int{}
+	// new_map_init_noscan_value := {
+	//	'test': 10
+	//}
+	mut m := {
+		'test': 10
+	}
+	map_clone := m.clone()
+	map_keys := m.keys()
+	map_values := m.values()
+	map_get := m['test']
+	map_move := m.move()
+}


### PR DESCRIPTION
We would like to prevent user-defined variable names from being able to conflict with c functions generated by the compiler. 

Most simple thing in most cases is prefixing with _ but we need to specifically check for builtin types in some places as we don't want to add this to user-defined functions which will then reintroduce the issue (maybe we want a separate prefix for user-defined variables as well so they don't conflict with c functions?).

I have some commented out lines in the test at the moment for array and map initialization. Wasn't sure how to handle this.

I handle `int_literal` and `float_literal` separately but there might be a more elegant way to do this?

There are some places where I only prefix an underscore and was wondering if it's more efficient to use the string plus operator or string formatting, I currently mostly use string formatting but it can be changed.

This does not handle name collisions with included c functions like `printf`. Maybe have a per-module c_reserved array with the included function names? Not sure about the best solution for this.

Since this adds quite a few `is_builtin()` checks it likely will have some performance impact. It didn't seem too bad but I didn't do any extensive tests.