### PR TITLE
builtin: fixed the thread naming issue by using RaiseException (0x406D1388) on windows.

### DIFF
--- a/vlib/builtin/builtin_windows.c.v
+++ b/vlib/builtin/builtin_windows.c.v
@@ -125,7 +125,7 @@ fn unhandled_exception_handler(e &ExceptionPointers) int {
 	match e.exception_record.code {
 		// These are 'used' by the backtrace printer
 		// so we dont want to catch them...
-		0x4001000A, 0x40010006, 0xE06D7363 {
+		0x4001000A, 0x40010006, 0x406D1388, 0xE06D7363 {
 			return 0
 		}
 		else {


### PR DESCRIPTION
On Windows, SetThreadName traditionally raises exception 0x406D1388 to set a thread name in the debugger. This exception is harmless and serves only as a debugging aid.Certain libraries might raise this exception and crash the program; it should be ignored or filtered.