### PR TITLE
eval: add more complex comptime-cond support

### DIFF
--- a/vlib/v/eval/tests/comptime_if_test.v
+++ b/vlib/v/eval/tests/comptime_if_test.v
@@ -68,3 +68,22 @@ fn test_comptime_if_infix() {
 	assert ret[0].string() != 'unknown'
 	assert ret[1].float_val() == 1.5
 }
+
+fn test_comptime_if_infix_user_define() {
+	mut e := eval.create()
+
+	// NOTE: currently we don't known how to pass a user-define `new_int` to eval :)
+	// so this test will always return `old_int`
+	ret := e.run('const a =
+	\$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) { "new_int" }
+	\$else { "old_int" }
+
+	const b = 1.5
+
+	fn display() (string,f64) { println(a) println(b) return a,b } display()')!
+
+	dump(ret)
+	assert ret[0].string().len != 0
+	assert ret[0].string() == 'old_int'
+	assert ret[1].float_val() == 1.5
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

As the `eval` need to execute some `builtin`, that need to enhance the `eval` comptime-cond support.
