### PR TITLE
x.crypto.ascon: small bits of cleansup and optimization

### DIFF
--- a/vlib/x/crypto/ascon/ascon.v
+++ b/vlib/x/crypto/ascon/ascon.v
@@ -41,6 +41,9 @@ fn ascon_pnr(mut s State, nr int) {
 	if nr < 1 || nr > 16 {
 		panic('Invalid round number')
 	}
+	// Allocate temporary vars to reduce allocation within loop
+	mut x0 := u64(0)
+	mut y0 := u64(0)
 	// Ascon permutation routine
 	for i := max_nr_perm - nr; i < max_nr_perm; i++ {
 		// 3.2 Constant-Addition Layer step
@@ -56,18 +59,22 @@ fn ascon_pnr(mut s State, nr int) {
 		s.e0 ^= s.e4
 		s.e4 ^= s.e3
 		s.e2 ^= s.e1
-
+		// Set temp vars to values
+		x0 = s.e0
+		y0 = s.e4 ^ (~s.e0 & s.e1)
+		/*
 		t0 := s.e4 ^ (~s.e0 & s.e1)
 		t1 := s.e0 ^ (~s.e1 & s.e2)
 		t2 := s.e1 ^ (~s.e2 & s.e3)
 		t3 := s.e2 ^ (~s.e3 & s.e4)
 		t4 := s.e3 ^ (~s.e4 & s.e0)
+		*/
 
-		s.e0 = t1
-		s.e1 = t2
-		s.e2 = t3
-		s.e3 = t4
-		s.e4 = t0
+		s.e0 = s.e0 ^ (~s.e1 & s.e2) // t1
+		s.e1 = s.e1 ^ (~s.e2 & s.e3) // t2
+		s.e2 = s.e2 ^ (~s.e3 & s.e4) // t3
+		s.e3 = s.e3 ^ (~s.e4 & x0) // t4, change s.e0 to x0
+		s.e4 = y0
 
 		s.e1 ^= s.e0
 		s.e0 ^= s.e4

--- a/vlib/x/crypto/ascon/util.v
+++ b/vlib/x/crypto/ascon/util.v
@@ -83,13 +83,23 @@ fn set_byte(b u8, i int) u64 {
 fn load_bytes(bytes []u8, n int) u64 {
 	mut x := u64(0)
 	for i := 0; i < n; i++ {
-		x |= set_byte(bytes[i], i)
+		// This is the same way to store bytes in little-endian way
+		//		x |= u64(bytes[0]) << 8*0  // LSB at lowest index
+		//		x |= u64(bytes[1]) << 8*1
+		// 		x |= u64(bytes[2]) << 8*2
+		//		x |= u64(bytes[3]) << 8*3
+		//		...etc
+		// 		x |= u64(bytes[7]) << 8*7  // MSB at highest index
+		x |= u64(bytes[i]) << (8 * i)
 	}
-	return u64le(x)
+	// No need to cast with u64le, its alread le
+	return x
 }
 
+@[direct_array_access]
 fn store_bytes(mut out []u8, x u64, n int) {
 	for i := 0; i < n; i++ {
-		out[i] = get_byte(x, i)
+		// use underlying get_byte directly
+		out[i] = u8(x >> (8 * i))
 	}
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Just small bits of cleans up, reorganizing and small optimization, ie:

- Reduce allocation on internal  `ascon_pnr`
- Rewrite internal of `ascon_generic_hash` to be more improved
- Small direct-embedding on utility function
- Others bits of changes

Here my profiling number before and after

```c
Before
          1000          0.037ms          0.037ms             37ns x__crypto__ascon__pad 
          1000          0.038ms          0.038ms             38ns x__crypto__ascon__store_bytes 
          1000          0.045ms          0.045ms             45ns x__crypto__ascon__load_bytes 
         17000          9.822ms          9.822ms            578ns x__crypto__ascon__ascon_pnr 
          1000         16.185ms          3.255ms          16185ns x__crypto__ascon__ascon_generic_hash 
          1000         16.282ms          0.097ms          16282ns x__crypto__ascon__sum256 
After

          1000          0.038ms          0.038ms             38ns x__crypto__ascon__store_bytes 
          1000          0.049ms          0.049ms             49ns x__crypto__ascon__load_bytes 
         17000          8.057ms          8.057ms            474ns x__crypto__ascon__ascon_pnr 
          1000         12.789ms          2.679ms          12789ns x__crypto__ascon__ascon_generic_hash 
          1000         12.899ms          0.110ms          12899ns x__crypto__ascon__sum256 
```

This patch focus on improving `ascon_pnr` and `ascon_generic_hash` used accross the module.
Even it has been improved a lot, its still most time-consuming on average. that's of course understandable, since this routine is heavily used accross the phase.