### PR TITLE
cgen: fix generic cast to sumtype of empty struct (fix #25263)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7574,8 +7574,9 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 			}
 		}
 		.struct {
-			mut has_none_zero := false
 			info := sym.info as ast.Struct
+			mut has_none_zero := info.fields.len == 0
+
 			mut init_str := if info.is_anon && !g.inside_global_decl {
 				'(${g.styp(typ)}){'
 			} else {

--- a/vlib/v/tests/sumtypes/sumtype_empty_struct_test.v
+++ b/vlib/v/tests/sumtypes/sumtype_empty_struct_test.v
@@ -1,0 +1,18 @@
+struct Empty {
+}
+
+type Sum = int | Empty
+
+fn do_generic[T](val T) T {
+	$for v in Sum.variants {
+		if val is v {
+			return T(v)
+		}
+	}
+	return T{}
+}
+
+fn test_empty_cast() {
+	assert do_generic(Sum(0)) == Sum(0)
+	assert do_generic(Sum(Empty{})) == Sum(Empty{})
+}

--- a/vlib/x/json2/types.v
+++ b/vlib/x/json2/types.v
@@ -24,9 +24,7 @@ pub type Any = []Any
 	| Null
 
 // Null is a simple representation of the `null` value in JSON.
-pub struct Null {
-	is_null bool = true
-}
+pub struct Null {}
 
 // null is an instance of the Null type, to ease comparisons with it.
 pub const null = Null{}


### PR DESCRIPTION
fix #25263

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
