### PR TITLE
cgen: fix fixed-array const initializer

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7591,7 +7591,7 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 					field_sym := g.table.sym(field.typ)
 					is_option := field.typ.has_flag(.option)
 					if is_option || field.has_default_expr
-						|| field_sym.kind in [.enum, .array_fixed, .array, .map, .string, .bool, .alias, .i8, .i16, .int, .i64, .u8, .u16, .u32, .u64, .f32, .f64, .char, .voidptr, .byteptr, .charptr, .struct, .chan, .sum_type] {
+						|| field_sym.kind in [.enum, .array_fixed, .array, .map, .string, .bool, .alias, .i8, .i16, .i32, .int, .i64, .u8, .u16, .u32, .u64, .f32, .f64, .char, .voidptr, .byteptr, .charptr, .struct, .chan, .sum_type] {
 						if sym.language == .c && !field.has_default_expr && !is_option {
 							continue
 						}
@@ -7668,7 +7668,7 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 			if has_none_zero {
 				init_str += '}'
 				if !typ_is_shared_f {
-					type_name := if info.is_anon || g.inside_global_decl {
+					type_name := if info.is_anon || g.inside_global_decl || g.inside_const {
 						// No name needed for anon structs, C figures it out on its own.
 						''
 					} else {

--- a/vlib/v/tests/modules/sub/global_fixed_array_test.v
+++ b/vlib/v/tests/modules/sub/global_fixed_array_test.v
@@ -20,3 +20,15 @@ fn test_main() {
 	assert dump(f) == [foo.num_elements]DummyStruct{}
 	assert dump(d) == [foo.num_elements]DummyStruct{}
 }
+
+struct DummyStruct2 {
+	dummy_item1 int
+	dummy_item2 i32
+	dummy_item3 u8
+}
+
+const m = [foo.num_elements]DummyStruct2{}
+
+fn test_many_dummy_fields_with_diff_types() {
+	assert dump(m) == [foo.num_elements]DummyStruct2{}
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #25291

In `msvc`,  initializer for the global array uses compound literals (which are not constant expressions in C) and also uses a cast-like syntax that is not allowed in constant expressions.

And this PR also enable `i32` in the check.

```c
Array_fixed_main__DummyStruct_2 _const_main__f = {(main__DummyStruct){.dummy_item = 0,}, (main__DummyStruct){.dummy_item = 0,}}; // fixed array const
```

=>

```c
Array_fixed_main__DummyStruct_2 _const_main__f = {{.dummy_item = 0,}, {.dummy_item = 0,}}; // fixed array const
```