### PR TITLE
checker: redefine export const global func names

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -99,8 +99,10 @@ pub mut:
 	anon_union_names    map[string]int // anon union name -> union sym idx
 	anon_union_counter  int
 	comptime_is_true    map[string]ComptTimeCondResult // The evaluate cond results for different generic types combination, such as `comptime_is_true['T=int,X=string|main.v|pos ...'] = {true, '!DEFINED(WINDOWS)'}`
-	new_int             bool // use 64bit/32bit platform dependent `int`
-	new_int_fmt_fix     bool // vfmt will fix `int` to `i32`
+	new_int             bool              // use 64bit/32bit platform dependent `int`
+	new_int_fmt_fix     bool              // vfmt will fix `int` to `i32`
+	export_const        map[string]string // @[export] const name
+	export_fn           map[string]string // @[export] func name
 }
 
 pub struct ComptTimeCondResult {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -115,6 +115,13 @@ fn (mut c Checker) fn_decl(mut node ast.FnDecl) {
 			if attr := node.attrs.find_first(attr_name) {
 				if attr.arg == '' {
 					c.error('missing argument for @[${attr_name}] attribute', attr.pos)
+				} else if attr_name == 'export' {
+					// export fn name
+					if attr.arg in c.table.export_fn.values() {
+						c.error('redefine export function `${attr.arg}`', node.pos)
+					} else {
+						c.table.export_fn[node.name] = attr.arg
+					}
 				}
 			}
 		}

--- a/vlib/v/checker/tests/redfine_global_const_fn_names.out
+++ b/vlib/v/checker/tests/redfine_global_const_fn_names.out
@@ -1,0 +1,21 @@
+vlib/v/checker/tests/redfine_global_const_fn_names.vv:10:7: error: duplicate export const `abc`
+    8 | 
+    9 | @[export: abc]
+   10 | const abc2 = 3
+      |       ~~~~
+   11 | 
+   12 | @[export: fn1]
+vlib/v/checker/tests/redfine_global_const_fn_names.vv:4:10: error: duplicate global and export const `abc`
+    2 | module main
+    3 | 
+    4 | __global abc = 1
+      |          ~~~
+    5 | 
+    6 | @[export: abc]
+vlib/v/checker/tests/redfine_global_const_fn_names.vv:17:1: error: redefine export function `fn1`
+   15 | 
+   16 | @[export: fn1]
+   17 | fn fn_abc2() {
+      | ~~~~~~~~~~~~
+   18 | }
+   19 |

--- a/vlib/v/checker/tests/redfine_global_const_fn_names.vv
+++ b/vlib/v/checker/tests/redfine_global_const_fn_names.vv
@@ -1,0 +1,19 @@
+@[has_globals]
+module main
+
+__global abc = 1
+
+@[export: abc]
+const abc1 = 2
+
+@[export: abc]
+const abc2 = 3
+
+@[export: fn1]
+fn fn_abc1() {
+}
+
+@[export: fn1]
+fn fn_abc2() {
+}
+


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #25301

1. disallow export same const name twice;
2. disallow export const name which has been defined as a global name, `__global`;
3. disallow export same function name twice.
