### PR TITLE
builtin,cgen: fix i64 enum as a map key, when the enum values are too small (fix #25294)

### DIFF
--- a/vlib/builtin/map.c.v
+++ b/vlib/builtin/map.c.v
@@ -39,6 +39,58 @@ fn map_hash_int_8(pkey voidptr) u64 {
 	return C.wyhash64(*unsafe { &u64(pkey) }, 0)
 }
 
+fn map_enum_fn(kind int, esize int) voidptr {
+	if kind !in [1, 2, 3] {
+		panic('map_enum_fn: invalid kind')
+	}
+	if esize > 8 || esize < 0 {
+		panic('map_enum_fn: invalid esize')
+	}
+	if kind == 1 {
+		if esize > 4 {
+			return voidptr(map_hash_int_8)
+		}
+		if esize > 2 {
+			return voidptr(map_hash_int_4)
+		}
+		if esize > 1 {
+			return voidptr(map_hash_int_2)
+		}
+		if esize > 0 {
+			return voidptr(map_hash_int_1)
+		}
+	}
+	if kind == 2 {
+		if esize > 4 {
+			return voidptr(map_eq_int_8)
+		}
+		if esize > 2 {
+			return voidptr(map_eq_int_4)
+		}
+		if esize > 1 {
+			return voidptr(map_eq_int_2)
+		}
+		if esize > 0 {
+			return voidptr(map_eq_int_1)
+		}
+	}
+	if kind == 3 {
+		if esize > 4 {
+			return voidptr(map_clone_int_8)
+		}
+		if esize > 2 {
+			return voidptr(map_clone_int_4)
+		}
+		if esize > 1 {
+			return voidptr(map_clone_int_2)
+		}
+		if esize > 0 {
+			return voidptr(map_clone_int_1)
+		}
+	}
+	return unsafe { nil }
+}
+
 // Move all zeros to the end of the array and resize array
 fn (mut d DenseArray) zeros_to_end() {
 	// TODO: alloca?

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3559,22 +3559,9 @@ fn (mut g Gen) map_fn_ptrs(key_sym ast.TypeSymbol) (string, string, string, stri
 			clone_fn = '&builtin__map_clone_int_2'
 		}
 		.enum {
-			einfo := (key_sym.info) as ast.Enum
-			if g.pref.ccompiler_type == .tinyc
-				&& einfo.typ in [ast.u8_type, ast.u16_type, ast.i8_type, ast.i16_type] {
-				// workaround for tcc, since we can not generate a packed Enum with size < 4 bytes
-				return g.map_fn_ptrs(g.table.sym(ast.i32_type))
-			}
-			$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
-				// enum type alway use 32bit `int`
-				if einfo.typ == ast.int_type {
-					return g.map_fn_ptrs(g.table.sym(ast.i32_type))
-				} else {
-					return g.map_fn_ptrs(g.table.sym(einfo.typ))
-				}
-			} $else {
-				return g.map_fn_ptrs(g.table.sym(einfo.typ))
-			}
+			hash_fn = 'builtin__map_enum_fn(1,sizeof(${key_sym.cname}))'
+			key_eq_fn = 'builtin__map_enum_fn(2,sizeof(${key_sym.cname}))'
+			clone_fn = 'builtin__map_enum_fn(3,sizeof(${key_sym.cname}))'
 		}
 		.int {
 			$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {

--- a/vlib/v/tests/enums/map_with_enum_keys_test.v
+++ b/vlib/v/tests/enums/map_with_enum_keys_test.v
@@ -1,0 +1,83 @@
+enum NonSpecificEnum {
+	a = 1
+	b
+}
+
+enum Enum8 as u8 {
+	a = 1
+	b
+}
+enum Enum16 as u16 {
+	a = 1
+	b
+}
+enum Enum32 as u32 {
+	a = 1
+	b
+}
+enum Enum64 as u64 {
+	a = 1
+	b
+}
+
+// TODO: make a generic version, and call it several times
+
+fn test_check_map_with_enum_key() {
+	dump(sizeof(NonSpecificEnum))
+	mut m := map[NonSpecificEnum]string{}
+	m[.a] = 'a'
+	m[.b] = 'b'
+	dump(m)
+	dump(m[.a])
+	dump(m[.b])
+	assert m[.a] == 'a'
+	assert m[.b] == 'b'
+}
+
+fn test_check_map_with_enum_key_8() {
+	dump(sizeof(Enum8))
+	mut m := map[Enum8]string{}
+	m[.a] = 'a'
+	m[.b] = 'b'
+	dump(m)
+	dump(m[.a])
+	dump(m[.b])
+	assert m[.a] == 'a'
+	assert m[.b] == 'b'
+}
+
+fn test_check_map_with_enum_key_16() {
+	dump(sizeof(Enum16))
+	mut m := map[Enum16]string{}
+	m[.a] = 'a'
+	m[.b] = 'b'
+	dump(m)
+	dump(m[.a])
+	dump(m[.b])
+	assert m[.a] == 'a'
+	assert m[.b] == 'b'
+}
+
+fn test_check_map_with_enum_key_32() {
+	dump(sizeof(Enum32))
+	mut m := map[Enum32]string{}
+	m[.a] = 'a'
+	m[.b] = 'b'
+	dump(m)
+	dump(m[.a])
+	dump(m[.b])
+	assert m[.a] == 'a'
+	assert m[.b] == 'b'
+}
+
+fn test_check_map_with_enum_key_64() {
+	dump(sizeof(Enum64))
+	mut m := map[Enum64]string{}
+	m[.a] = 'a'
+	m[.b] = 'b'
+	dump(m)
+	dump(m[.a])
+	dump(m[.b])
+	assert m[.a] == 'a'
+	assert m[.b] == 'b'
+}


### PR DESCRIPTION
Fix #25294 .