### PR TITLE
time: make parse_rfc3339 accept `t`, and space, in addition to `T`, reject incomplete date-times and such with no timezone

### DIFF
--- a/vlib/time/parse.c.v
+++ b/vlib/time/parse.c.v
@@ -160,7 +160,7 @@ pub fn parse_rfc3339(s string) !Time {
 		year, month, day = check_and_extract_date(s)!
 	}
 	if s.len <= date_format_buffer.len {
-		return error('date too short to parse')
+		return error('date-time too short to parse')
 	}
 	if s[10] !in [u8(`T`), `t`, ` `] {
 		return error('invalid date-time separator:${s[10].ascii_str()}')

--- a/vlib/time/parse.c.v
+++ b/vlib/time/parse.c.v
@@ -158,18 +158,16 @@ pub fn parse_rfc3339(s string) !Time {
 
 	if is_date {
 		year, month, day = check_and_extract_date(s)!
-		if s.len == date_format_buffer.len {
-			return new(Time{
-				year:     year
-				month:    month
-				day:      day
-				is_local: false
-			})
-		}
+	}
+	if s.len <= date_format_buffer.len {
+		return error('date too short to parse')
+	}
+	if s[10] !in [u8(`T`), `t`, ` `] {
+		return error('invalid date-time separator:${s[10].ascii_str()}')
 	}
 
 	is_datetime := if s.len >= date_format_buffer.len + 1 + time_format_buffer.len + 1 {
-		is_date && s[10] == u8(`T`)
+		is_date
 	} else {
 		false
 	}
@@ -189,7 +187,7 @@ pub fn parse_rfc3339(s string) !Time {
 				timezone_start_position++
 				if timezone_start_position == s.len {
 					return error('timezone error: expected "Z" or "z" or "+" or "-" in position ${timezone_start_position}, not "${[
-						s[timezone_start_position],
+						s[s.len - 1],
 					].bytestr()}"')
 				}
 			}

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -225,7 +225,7 @@ fn test_parse_rfc3339() {
 	assert invalid_rfc3339('2006-01-01T23:59:99Z') == 'invalid second: 99'
 	assert invalid_rfc3339('1979-05-27X07:32:00Z') == 'invalid date-time separator:X'
 	assert invalid_rfc3339('1979-05-27T07:32:00') == 'timezone error: datetime string is too short'
-	assert invalid_rfc3339('1979-05-27') == 'date too short to parse'
+	assert invalid_rfc3339('1979-05-27') == 'date-time too short to parse'
 	assert invalid_rfc3339('1979-05-27T00:32:00.999999') == 'timezone error: expected "Z" or "z" or "+" or "-" in position 26, not "9"'
 	assert invalid_rfc3339('1979-05-27T00:32:00.') == 'timezone error: expected "Z" or "z" at the end of the string'
 }

--- a/vlib/time/parse_test.v
+++ b/vlib/time/parse_test.v
@@ -196,6 +196,9 @@ fn test_parse_rfc3339() {
 		['2024-10-19T22:47:08.9+00:00', '2024-10-19 22:47:08.900000'],
 		['2024-10-20T01:47:08+03:00', '2024-10-19 22:47:08.000000'],
 		['2024-10-20T01:47:08.981+03:00', '2024-10-19 22:47:08.981000'],
+		['1979-05-27t07:32:00z', '1979-05-27 07:32:00.000000'],
+		['1979-05-27 07:32:00Z', '1979-05-27 07:32:00.000000'],
+		['1979-05-27T00:32:00.999999Z', '1979-05-27 00:32:00.999999'],
 	]
 	for pair in pairs {
 		input, expected := pair[0], pair[1]
@@ -208,18 +211,23 @@ fn test_parse_rfc3339() {
 	}
 	assert invalid_rfc3339('22:47:08Z') == 'missing date part of RFC 3339'
 	assert invalid_rfc3339('01:47:08.981+03:00') == 'missing date part of RFC 3339'
-	assert invalid_rfc3339('2006-01-00') == 'date error: invalid day 0'
-	assert invalid_rfc3339('2006-01-32') == 'date error: invalid day 32'
-	assert invalid_rfc3339('2006-01-88') == 'date error: invalid day 88'
-	assert invalid_rfc3339('2006-00-01') == 'date error: invalid month 0'
-	assert invalid_rfc3339('2006-13-01') == 'date error: invalid month 13'
-	assert invalid_rfc3339('2006-77-01') == 'date error: invalid month 77'
+	assert invalid_rfc3339('2006-01-00T00:00:00Z') == 'date error: invalid day 0'
+	assert invalid_rfc3339('2006-01-32T00:00:00Z') == 'date error: invalid day 32'
+	assert invalid_rfc3339('2006-01-88T00:00:00Z') == 'date error: invalid day 88'
+	assert invalid_rfc3339('2006-00-01T00:00:00Z') == 'date error: invalid month 0'
+	assert invalid_rfc3339('2006-13-01T00:00:00Z') == 'date error: invalid month 13'
+	assert invalid_rfc3339('2006-77-01T00:00:00Z') == 'date error: invalid month 77'
 	assert invalid_rfc3339('2006-01-01T24:47:08Z') == 'invalid hour: 24'
 	assert invalid_rfc3339('2006-01-01T99:47:08Z') == 'invalid hour: 99'
 	assert invalid_rfc3339('2006-01-01T23:60:08Z') == 'invalid minute: 60'
 	assert invalid_rfc3339('2006-01-01T23:99:08Z') == 'invalid minute: 99'
 	assert invalid_rfc3339('2006-01-01T23:59:60Z') == 'invalid second: 60'
 	assert invalid_rfc3339('2006-01-01T23:59:99Z') == 'invalid second: 99'
+	assert invalid_rfc3339('1979-05-27X07:32:00Z') == 'invalid date-time separator:X'
+	assert invalid_rfc3339('1979-05-27T07:32:00') == 'timezone error: datetime string is too short'
+	assert invalid_rfc3339('1979-05-27') == 'date too short to parse'
+	assert invalid_rfc3339('1979-05-27T00:32:00.999999') == 'timezone error: expected "Z" or "z" or "+" or "-" in position 26, not "9"'
+	assert invalid_rfc3339('1979-05-27T00:32:00.') == 'timezone error: expected "Z" or "z" at the end of the string'
 }
 
 fn test_ad_second_to_parse_result_in_2001() {

--- a/vlib/toml/checker/checker.v
+++ b/vlib/toml/checker/checker.v
@@ -22,6 +22,10 @@ fn toml_parse_time(s string) !time.Time {
 		// complete the partial time, with an arbitrary date:
 		return time.parse_rfc3339('0001-01-01T' + s)
 	}
+	if s.len == 10 {
+		// complete the partial date, with zero time and zero timezone
+		return time.parse_rfc3339(s + 'T00:00:00Z')
+	}
 	return time.parse_rfc3339(s)!
 }
 


### PR DESCRIPTION
Fixes issue https://github.com/vlang/v/issues/25272 for parsing dates in format rfc3339.

- Accepts `t` and ` ` (space) as alternatives to default date time separator `T`.
- Continue accepting `z` as alternative of default `Z` for timezone zero.
- Reject (as golang does) not complete date-time strings or without timezone.
- Fix panic in fractions of second without `Z`.

Revised function `time.parse_rfc3339(string) !time.Time` can be used as simple and unique format for `json2.Any.to_time()` of type `string`.