### PR TITLE
x.crypto.chacha20: adds some missing bits into stream reset

### DIFF
--- a/vlib/x/crypto/chacha20/chacha.v
+++ b/vlib/x/crypto/chacha20/chacha.v
@@ -40,6 +40,7 @@ pub fn encrypt(key []u8, nonce []u8, plaintext []u8) ![]u8 {
 	mut stream := new_stream(key, nonce)!
 	mut dst := []u8{len: plaintext.len}
 	stream.keystream_full(mut dst, plaintext)
+	unsafe { stream.reset() }
 	return dst
 }
 
@@ -49,6 +50,7 @@ pub fn decrypt(key []u8, nonce []u8, ciphertext []u8) ![]u8 {
 	mut stream := new_stream(key, nonce)!
 	mut dst := []u8{len: ciphertext.len}
 	stream.keystream_full(mut dst, ciphertext)
+	unsafe { stream.reset() }
 	return dst
 }
 


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This patch some missing bits of resetting fields into Stream.reset