### PR TITLE
vlib,tests: fix int i32 for 64bit int

### DIFF
--- a/vlib/builtin/utf8.c.v
+++ b/vlib/builtin/utf8.c.v
@@ -97,7 +97,7 @@ pub fn string_from_wide2(_wstr &u16, len int) string {
 // NOTE: It return a vstring(encoded in UTF-8) []u8 under Linux.
 pub fn wide_to_ansi(_wstr &u16) []u8 {
 	$if windows {
-		num_bytes := C.WideCharToMultiByte(cp_acp, 0, _wstr, -1, 0, 0, 0, 0)
+		num_bytes := int(C.WideCharToMultiByte(cp_acp, 0, _wstr, -1, 0, 0, 0, 0))
 		if num_bytes != 0 {
 			mut str_to := []u8{len: num_bytes}
 			C.WideCharToMultiByte(cp_acp, 0, _wstr, -1, &char(str_to.data), str_to.len,

--- a/vlib/db/mysql/mysql.c.v
+++ b/vlib/db/mysql/mysql.c.v
@@ -545,7 +545,7 @@ pub fn (stmt &StmtHandle) execute(params []string) ![]Row {
 	if query_metadata == unsafe { nil } {
 		return []Row{}
 	}
-	num_cols := C.mysql_num_fields(query_metadata)
+	num_cols := int(C.mysql_num_fields(query_metadata))
 	mut length := []u32{len: num_cols}
 	mut is_null := []bool{len: num_cols}
 

--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -400,7 +400,7 @@ pub fn (db &DB) copy_expert(query string, mut file io.ReaderWriter) !int {
 	} else if status == .copy_out {
 		for {
 			address := &char(unsafe { nil })
-			n_bytes := C.PQgetCopyData(db.conn, &address, 0)
+			n_bytes := int(C.PQgetCopyData(db.conn, &address, 0))
 			if n_bytes > 0 {
 				mut local_buf := []u8{len: n_bytes}
 				unsafe { C.memcpy(&u8(local_buf.data), address, n_bytes) }

--- a/vlib/os/notify/backend_linux.c.v
+++ b/vlib/os/notify/backend_linux.c.v
@@ -104,7 +104,7 @@ fn (mut en EpollNotifier) wait(timeout time.Duration) []FdEvent {
 	events := [512]C.epoll_event{}
 	// populate events with the new events
 	to := timeout.sys_milliseconds()
-	count := C.epoll_wait(en.epoll_fd, &events[0], events.len, to)
+	count := int(C.epoll_wait(en.epoll_fd, &events[0], events.len, to))
 
 	if count > 0 {
 		mut arr := []FdEvent{cap: count}

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -636,7 +636,7 @@ pub fn get_raw_stdin() []u8 {
 	} $else {
 		max := usize(0)
 		buf := &u8(unsafe { nil })
-		nr_chars := unsafe { C.getline(voidptr(&buf), &max, C.stdin) }
+		nr_chars := unsafe { int(C.getline(voidptr(&buf), &max, C.stdin)) }
 		return array{
 			element_size: 1
 			data:         voidptr(buf)

--- a/vlib/v/gen/c/testdata/translated/sym.c
+++ b/vlib/v/gen/c/testdata/translated/sym.c
@@ -2,6 +2,6 @@ struct my_struct {
        bool active;
 } my_instance = { true };
 
-int ExternalSymbol(char *hello) {
+i32 ExternalSymbol(char *hello) {
 	return *hello;
 }

--- a/vlib/v/gen/c/testdata/translated/translated_module_actual.v
+++ b/vlib/v/gen/c/testdata/translated/translated_module_actual.v
@@ -4,7 +4,7 @@ module translated
 #include "@VMODROOT/sym.c"
 
 @[c: 'ExternalSymbol']
-pub fn external_symbol(&char) int
+pub fn external_symbol(&char) i32
 
 struct C.my_struct {
 	active bool

--- a/vlib/v/gen/c/testdata/translated_module.c.must_have
+++ b/vlib/v/gen/c/testdata/translated_module.c.must_have
@@ -1,3 +1,3 @@
-int ExternalSymbol(char* );
-int a = ExternalSymbol("hello");
+i32 ExternalSymbol(char* );
+i32 a = ExternalSymbol("hello");
 extern struct my_struct my_instance;


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR fix `vlib` for future apply 64bit int.
As `C.func` will only return `i32` not `int` any more, to avoid the error message:
```
error: array len needs to be an int
```
And also fix `vlib/v/gen/c/testdata/translated/` files to workaround `int` in source code and generated code.