### PR TITLE
x.crypto.chacha20: fix internal counter handling

### DIFF
--- a/vlib/x/crypto/chacha20/chacha.v
+++ b/vlib/x/crypto/chacha20/chacha.v
@@ -96,7 +96,6 @@ pub fn (mut c Cipher) xor_key_stream(mut dst []u8, src []u8) {
 	mut src_len := src.len
 
 	dst = unsafe { dst[..src_len] }
-
 	if subtle.inexact_overlap(dst, src) {
 		panic('chacha20: invalid buffer overlap')
 	}
@@ -162,10 +161,10 @@ pub fn (mut c Cipher) encrypt(mut dst []u8, src []u8) ! {
 		return
 	}
 	if dst.len < src.len {
-		panic('chacha20: dst buffer is to small')
+		return error('chacha20: dst buffer is to small')
 	}
 	if subtle.inexact_overlap(dst, src) {
-		panic('chacha20: invalid buffer overlap')
+		return error('chacha20: invalid buffer overlap')
 	}
 
 	c.Stream.keystream_full(mut dst, src)!

--- a/vlib/x/crypto/chacha20/chacha_64bitctr_test.v
+++ b/vlib/x/crypto/chacha20/chacha_64bitctr_test.v
@@ -97,13 +97,13 @@ fn test_chacha20_encrypt_with_64bit_counter() ! {
 
 		mut c := new_cipher(key, nonce)!
 		mut dst := []u8{len: plaintext.len}
-		c.encrypt(mut dst, plaintext)
+		c.encrypt(mut dst, plaintext)!
 		assert dst == ciphertext
 
 		// decrypts the ciphertext back
 		// we need rekey the ciphers, because internal states has changed from previous invocations.
 		c.rekey(key, nonce)!
-		c.encrypt(mut dst, ciphertext)
+		c.encrypt(mut dst, ciphertext)!
 		assert dst == plaintext
 	}
 }

--- a/vlib/x/crypto/chacha20/chacha_test.v
+++ b/vlib/x/crypto/chacha20/chacha_test.v
@@ -129,7 +129,7 @@ fn test_chacha20_cipher_encrypt_with_xor_keystream() ! {
 		cs.set_counter(c.counter)
 
 		mut output := []u8{len: plaintext_bytes.len}
-		cs.encrypt(mut output, plaintext_bytes)
+		cs.encrypt(mut output, plaintext_bytes)!
 
 		expected := hex.decode(c.output)!
 		assert output == expected
@@ -146,7 +146,7 @@ fn test_chacha20_cipher_decrypt_with_xor_keystream() ! {
 		cs.set_counter(c.counter)
 
 		mut output := []u8{len: ciphertext.len}
-		cs.encrypt(mut output, ciphertext)
+		cs.encrypt(mut output, ciphertext)!
 
 		expected_decrypted_message := hex.decode(c.plaintext)!
 		assert output == expected_decrypted_message

--- a/vlib/x/crypto/chacha20/stream.v
+++ b/vlib/x/crypto/chacha20/stream.v
@@ -330,11 +330,6 @@ fn (b Stream) ctr() u64 {
 // set_ctr sets Stream's counter
 @[direct_array_access; inline]
 fn (mut b Stream) set_ctr(ctr u64) {
-	// if this set counter would overflow internal counter
-	// we do panic instead
-	if b.check_ctr(ctr) {
-		panic('set_ctr: invalid check, maybe would overflow')
-	}
 	match b.mode {
 		.original {
 			b.nonce[0] = u32(ctr)
@@ -374,13 +369,6 @@ fn (b Stream) max_ctr() u64 {
 
 // State represents the running 64-bytes of chacha20 stream,
 type State = [16]u32
-
-@[direct_array_access; inline; unsafe]
-fn reset_state(mut s State) {
-	unsafe {
-		_ := vmemset(&s, 0, 64)
-	}
-}
 
 @[direct_array_access; inline]
 fn clone_state(s State) State {

--- a/vlib/x/crypto/chacha20/stream_test.v
+++ b/vlib/x/crypto/chacha20/stream_test.v
@@ -1,6 +1,37 @@
 module chacha20
 
+import rand
 import encoding.hex
+
+// Test for Stream counter handling.
+// See the discussion at [here](https://discord.com/channels/592103645835821068/592114487759470596/1417900997090607215)
+fn test_stream_counter_handling() ! {
+	// creates a original mode of the cipher with 64-bit counter
+	mut ctx := new_cipher(rand.bytes(32)!, rand.bytes(8)!)!
+	// set the cipher's counter near the maximum of 64-bit counter
+	ctr := max_u64 - 2
+	ctx.set_counter(ctr)
+
+	// by setting internal counter into near of max 64-bit counter,
+	// it need a message with minimum length of  2*block_size bytes to reach the limit.
+	// let's build this message with 2 * block_size bytes in size
+	msg0 := []u8{len: 2 * block_size}
+	mut dst := []u8{len: msg0.len}
+	ctx.xor_key_stream(mut dst, msg0)
+	// at this step, the counter has reached the maximum_64bit_counter, but still not overflow
+	assert ctx.Stream.overflow == false
+	assert ctx.Stream.ctr() == max_64bit_counter
+
+	// after above process the counter should have at the maximum limit
+	// we use keystream_with_blocksize to test this counter handling, because
+	// xor_key_stream would panic on counter reset
+	msg1 := []u8{len: block_size}
+	ctx.Stream.keystream_with_blocksize(mut dst[..block_size], msg1) or {
+		assert ctx.Stream.overflow == true
+		assert err == error('chacha20.check_ctr: internal counter overflow')
+		return
+	}
+}
 
 fn test_qround_on_state() {
 	mut s := State{}
@@ -27,7 +58,7 @@ fn test_state_of_chacha20_block_simple() ! {
 
 	mut block := []u8{len: block_size}
 	stream.set_ctr(1)
-	stream.keystream_with_blocksize(mut block, block)
+	stream.keystream_with_blocksize(mut block, block)!
 
 	expected_raw_bytes := '10f1e7e4d13b5915500fdd1fa32071c4c7d1f4c733c068030422aa9ac3d46c4ed2826446079faa0914c2d705d98b02a2b5129cd1de164eb9cbd083e8a2503c4e'
 	exp_bytes := hex.decode(expected_raw_bytes)!
@@ -44,7 +75,7 @@ fn test_keystream_with_blocksize() ! {
 		stream.set_ctr(val.counter)
 
 		mut block := []u8{len: block_size}
-		stream.keystream_with_blocksize(mut block, block)
+		stream.keystream_with_blocksize(mut block, block)!
 		exp_bytes := hex.decode(val.output)!
 
 		assert block == exp_bytes

--- a/vlib/x/crypto/chacha20/xchacha_test.v
+++ b/vlib/x/crypto/chacha20/xchacha_test.v
@@ -38,7 +38,7 @@ fn test_xchacha20_encrypt_vector_test_a321() ! {
 	nonce_bytes := hex.decode(nonce)!
 	ciphertext_bytes := hex.decode(ciphertext)!
 
-	encrypted_message := encrypt(key_bytes, nonce_bytes, plaintext_bytes) or { return }
+	encrypted_message := encrypt(key_bytes, nonce_bytes, plaintext_bytes)!
 
 	assert encrypted_message == ciphertext_bytes
 }
@@ -63,7 +63,7 @@ fn test_xchach20_encrypt_vector_test_a322() ! {
 	c.set_counter(counter)
 
 	mut encrypted_message := []u8{len: plaintext_bytes.len}
-	c.encrypt(mut encrypted_message, plaintext_bytes)
+	c.encrypt(mut encrypted_message, plaintext_bytes)!
 
 	assert encrypted_message == ciphertext_bytes
 }

--- a/vlib/x/crypto/chacha20poly1305/chacha20poly1305.v
+++ b/vlib/x/crypto/chacha20poly1305/chacha20poly1305.v
@@ -127,13 +127,13 @@ fn (c Chacha20Poly1305) encrypt_generic(plaintext []u8, nonce []u8, ad []u8) ![]
 	// see https://datatracker.ietf.org/doc/html/rfc8439#section-2.6
 	mut polykey := []u8{len: key_size}
 	mut s := chacha20.new_cipher(c.key, nonce)!
-	s.encrypt(mut polykey, polykey)
+	s.encrypt(mut polykey, polykey)!
 
 	// Next, the ChaCha20 encryption function is called to encrypt the plaintext,
 	// using the same key and nonce, and with the initial ChaCha20 counter set to 1.
 	mut ciphertext := []u8{len: plaintext.len}
 	s.set_counter(1)
-	s.encrypt(mut ciphertext, plaintext)
+	s.encrypt(mut ciphertext, plaintext)!
 
 	// Finally, the Poly1305 function is called with the generated Poly1305 one-time key
 	// calculated above, and a message constructed as described in
@@ -177,7 +177,7 @@ fn (c Chacha20Poly1305) decrypt_generic(ciphertext []u8, nonce []u8, ad []u8) ![
 	// generates poly1305 one-time key for later calculation
 	mut polykey := []u8{len: key_size}
 	mut s := chacha20.new_cipher(c.key, nonce)!
-	s.encrypt(mut polykey, polykey)
+	s.encrypt(mut polykey, polykey)!
 
 	// Remember, ciphertext is concatenation of associated cipher output plus tag (mac) bytes
 	encrypted := ciphertext[0..ciphertext.len - c.overhead()]
@@ -186,7 +186,7 @@ fn (c Chacha20Poly1305) decrypt_generic(ciphertext []u8, nonce []u8, ad []u8) ![
 	mut plaintext := []u8{len: encrypted.len}
 	s.set_counter(1)
 	// doing reverse encrypt on cipher output part produces plaintext
-	s.encrypt(mut plaintext, encrypted)
+	s.encrypt(mut plaintext, encrypted)!
 
 	// authenticated messages part
 	mut constructed_msg := []u8{}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This small patch fix internal counter handling after rewrites the internal of `x.crypto.chacha20`. The counter increments phase not be adjusted to align with the changes and leads to the bug in [25318](https://github.com/vlang/v/issues/25318).
In my test for `firebird` by @einar-hjortdal, it pass successfully,

```bash
---- Testing... ------------------------------------------------------------------------------------------------------
 OK    [1/5] C:   645.2 ms, R:     2.047 ms /workspaces/firebird/protocol_test.v
 OK    [2/5] C:   613.6 ms, R:     2.126 ms /workspaces/firebird/protocol_utils_test.v
 OK    [3/5] C:   606.7 ms, R:    69.396 ms /workspaces/firebird/secure_remote_password_test.v
 OK    [4/5] C:   746.3 ms, R:   603.540 ms /workspaces/firebird/statement_test.v
 OK    [5/5] C:   595.4 ms, R:     2.202 ms /workspaces/firebird/time_test.v
```

Besides of counter adjusment, this pr also contains some bits of clean up. It also maintain relatives stable performance with previous one, see the benchmark at [here](https://discord.com/channels/592103645835821068/592320321995014154/1417074261096661002)

cc @einar-hjortdal please give this pr a try, i hope this fix the bug