### PR TITLE
toml: make whitespaces separating dates inside arrays not intended to be a time separator in all cases.

### DIFF
--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -1420,6 +1420,14 @@ pub fn (mut p Parser) date_time() !ast.DateTimeType {
 			if p.tok.lit.starts_with('T') || p.tok.lit.starts_with('t') {
 				lit += p.tok.lit[0].ascii_str() //'T' or 't'
 			} else {
+				peek := p.peek(0)!
+				if peek.kind != .number {
+					// return early as date for strings yyyy-mm-dd_X... (_ is space, X is not numeric)
+					return ast.Date{
+						text: lit
+						pos:  pos
+					}
+				}
 				lit += p.tok.lit
 				p.next()!
 			}

--- a/vlib/toml/tests/encode_and_decode_test.v
+++ b/vlib/toml/tests/encode_and_decode_test.v
@@ -326,3 +326,14 @@ fn test_unsupported_type() {
 		assert err.msg() == 'Doc.decode: expected struct, found string'
 	}
 }
+
+fn test_date_array_decode_with_spaces() {
+	// test space after yyyy-mm-dd is not date-time separator but white to consume. issue # 25279
+	s := '
+dates = [ 1979-05-27    , 2022-12-31    ]
+'
+	a := Arrs{
+		dates: [toml.Date{'1979-05-27'}, toml.Date{'2022-12-31'}]
+	}
+	assert toml.decode[Arrs](s)! == a
+}


### PR DESCRIPTION
This PR fixes issue https://github.com/vlang/v/issues/25279