### PR TITLE
autofree,flag: fix double free in FlagParser free

### DIFF
--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -107,10 +107,6 @@ pub mut:
 @[unsafe]
 fn (mut f FlagParser) free() {
 	unsafe {
-		for a in f.args {
-			a.free()
-		}
-		f.args.free()
 		//
 		for flag in f.flags {
 			flag.free()
@@ -130,6 +126,7 @@ pub const underline = '-----------------------------------------------'
 pub const max_args_number = 4048
 
 // new_flag_parser - create a new flag parser for the given args.
+@[manualfree]
 pub fn new_flag_parser(args []string) &FlagParser {
 	original_args := args.clone()
 	idx_dashdash := args.index('--')

--- a/vlib/flag/flag_autofree_test.v
+++ b/vlib/flag/flag_autofree_test.v
@@ -1,0 +1,10 @@
+// vtest vflags: -autofree
+import flag
+import os
+
+fn test_main() {
+	mut fp := flag.new_flag_parser(os.args)
+	test := fp.string('test', 0, '', 'this is a test')
+	fp.finalize() or { return }
+	println(test)
+}


### PR DESCRIPTION
Fixes #9815.

It seems to me like calling these frees on `f.args` frees `os.args` only on `-autofree`? Not sure why that would happen since `os.args` is always cloned.

I set it to `@[manualfree]` here but it might actually end up leaking some memory since the `new_flag_parser` function creates some clones, but it was preferable to freeing the variables before (and after) returning them?

A few flag tests still fail with autofree but not in a way related to this issue.