### PR TITLE
parser: detect wrong multi-dim arr declare

### DIFF
--- a/vlib/v/checker/tests/wrong_muti_dim_arr_declare_err.out
+++ b/vlib/v/checker/tests/wrong_muti_dim_arr_declare_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/wrong_muti_dim_arr_declare_err.vv:4:15: warning: use `x := []Type{}` instead of `x := []Type`
+    2 | 
+    3 | fn main() {
+    4 |         a2 := [][][]f32[][]{}
+      |               ~~~~~~~~~~
+    5 |         dump(typeof(a2).name)
+    6 |
+vlib/v/checker/tests/wrong_muti_dim_arr_declare_err.vv:4:25: error: invalid expression: unexpected token `]`
+    2 | 
+    3 | fn main() {
+    4 |         a2 := [][][]f32[][]{}
+      |                         ^
+    5 |         dump(typeof(a2).name)
+    6 |

--- a/vlib/v/checker/tests/wrong_muti_dim_arr_declare_err.vv
+++ b/vlib/v/checker/tests/wrong_muti_dim_arr_declare_err.vv
@@ -1,0 +1,9 @@
+module main
+
+fn main() {
+        a2 := [][][]f32[][]{}
+        dump(typeof(a2).name)
+
+	assert typeof(a2).name == '[][][]f32'
+}
+

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -111,15 +111,7 @@ fn (mut p Parser) parse_array_type(expecting token.Kind, is_option bool) ast.Typ
 	if elem_type.idx() == ast.thread_type_idx {
 		p.register_auto_import('sync.threads')
 	}
-	mut nr_dims := 1
-	// detect attr
-	not_attr := p.peek_tok.kind != .name && p.peek_token(2).kind !in [.semicolon, .rsbr]
-	for p.tok.kind == expecting && not_attr {
-		p.next()
-		p.check(.rsbr)
-		nr_dims++
-	}
-	idx := p.table.find_or_register_array_with_dims(elem_type, nr_dims)
+	idx := p.table.find_or_register_array_with_dims(elem_type, 1)
 	if elem_type.has_flag(.generic) {
 		return ast.new_type(idx).set_flag(.generic)
 	}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #25333
Terminate the array type scan after parser got an element type, do not scan further `[]` pairs.

I think this is a code snippet left behind from the early stages for detecting multidimensional arrays with legacy syntax.