### PR TITLE
v: cleanup, replace complex 64bit CPU comptime ident with `&& x64`

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -48,16 +48,8 @@ pub const max_i32 = i32(2147483647)
 pub const min_i64 = i64(-9223372036854775807 - 1)
 pub const max_i64 = i64(9223372036854775807)
 
-pub const min_int = $if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
-	int(min_i64)
-} $else {
-	int(min_i32)
-}
-pub const max_int = $if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
-	int(max_i64)
-} $else {
-	int(max_i32)
-}
+pub const min_int = $if new_int ? && x64 { int(min_i64) } $else { int(min_i32) }
+pub const max_int = $if new_int ? && x64 { int(max_i64) } $else { int(max_i32) }
 
 pub const min_u8 = u8(0)
 pub const max_u8 = u8(255)

--- a/vlib/builtin/js/int.js.v
+++ b/vlib/builtin/js/int.js.v
@@ -17,16 +17,8 @@ pub const max_i32 = i32(2147483647)
 pub const min_i64 = i64(-9223372036854775807 - 1)
 pub const max_i64 = i64(9223372036854775807)
 
-pub const min_int = $if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
-	int(min_i64)
-} $else {
-	int(min_i32)
-}
-pub const max_int = $if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
-	int(max_i64)
-} $else {
-	int(max_i32)
-}
+pub const min_int = $if new_int ? && x64 { int(min_i64) } $else { int(min_i32) }
+pub const max_int = $if new_int ? && x64 { int(max_i64) } $else { int(max_i32) }
 
 pub const min_u8 = u8(0)
 pub const max_u8 = u8(255)

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -24,12 +24,7 @@ pub const builtins = ['string', 'array', 'DenseArray', 'map', 'Error', 'IError',
 
 pub type TypeDecl = AliasTypeDecl | FnTypeDecl | SumTypeDecl
 
-pub const int_type_name = $if new_int ?
-	&& (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
-	'vint_t'
-} $else {
-	'int'
-}
+pub const int_type_name = $if new_int ? && x64 { 'vint_t' } $else { 'int' }
 
 pub type Expr = NodeError
 	| AnonFn

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -638,7 +638,7 @@ pub fn (typ Type) flip_signedness() Type {
 			u64_type
 		}
 		int_type {
-			$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+			$if new_int ? && x64 {
 				u64_type
 			} $else {
 				u32_type
@@ -1260,7 +1260,7 @@ pub fn (t &Table) type_size(typ Type) (int, int) {
 			align = 4
 		}
 		.int {
-			$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+			$if new_int ? && x64 {
 				size = 8
 				align = 8
 			} $else {

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -649,12 +649,7 @@ fn (mut c Checker) check_shift(mut node ast.InfixExpr, left_type_ ast.Type, righ
 							31
 						}
 						ast.int_type {
-							$if new_int ?
-								&& (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
-								63
-							} $else {
-								31
-							}
+							$if new_int ? && x64 { 63 } $else { 31 }
 						}
 						ast.i64_type {
 							63

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2075,7 +2075,7 @@ fn (mut c Checker) enum_decl(mut node ast.EnumDecl) {
 			signed, enum_imin, enum_imax = true, min_i32, max_i32
 		}
 		ast.int_type {
-			$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+			$if new_int ? && x64 {
 				signed, enum_imin, enum_imax = true, min_i32, max_i32
 			} $else {
 				signed, enum_imin, enum_imax = true, min_i64, max_i64
@@ -3835,7 +3835,7 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 					u64(0xffffffff)
 				}
 				ast.int_type_idx {
-					$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+					$if new_int ? && x64 {
 						u64(0xffffffffffffffff)
 					} $else {
 						u64(0xffffffff)

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -328,7 +328,7 @@ fn (mut c Checker) check_array_init_default_expr(mut node ast.ArrayInit) {
 
 fn (mut c Checker) check_array_init_para_type(para string, mut expr ast.Expr, pos token.Pos) {
 	sym := c.table.final_sym(c.unwrap_generic(c.expr(mut expr)))
-	$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+	$if new_int ? && x64 {
 		if sym.kind !in [.int, .int_literal, .i64, .i32, .i16, .i8] {
 			c.error('array ${para} needs to be an int/i64/i32/i16/i8', pos)
 		}

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -401,8 +401,7 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 										}
 									}
 									.int {
-										$if new_int ? && (arm64 || amd64 || rv64
-											|| s390x || ppc64le || loongarch64) {
+										$if new_int ? && x64 {
 											if !(num >= min_i64 && num <= max_i64) {
 												needs_explicit_cast = true
 											}

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -923,7 +923,7 @@ fn (g &Gen) type_to_fmt(typ ast.Type) StrIntpType {
 		}
 		return .si_g64
 	} else if sym.kind == .int {
-		$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+		$if new_int ? && x64 {
 			return .si_i64
 		} $else {
 			return .si_i32

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3579,7 +3579,7 @@ fn (mut g Gen) map_fn_ptrs(key_sym ast.TypeSymbol) (string, string, string, stri
 			clone_fn = 'builtin__map_enum_fn(3,sizeof(${key_sym.cname}))'
 		}
 		.int {
-			$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+			$if new_int ? && x64 {
 				hash_fn = '&builtin__map_hash_int_8'
 				key_eq_fn = '&builtin__map_eq_int_8'
 				clone_fn = '&builtin__map_clone_int_8'
@@ -8530,7 +8530,7 @@ fn (mut g Gen) check_noscan(elem_typ ast.Type) string {
 
 // vint2int rename `_vint_t` to `int`
 fn vint2int(name string) string {
-	$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+	$if new_int ? && x64 {
 		if name == ast.int_type_name {
 			return 'int'
 		}

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -144,7 +144,7 @@ fn (mut g Gen) str_format(node ast.StringInterLiteral, i int, fmts []u8) (u64, s
 					fmt_type = .si_u32
 				}
 				ast.int_type {
-					$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+					$if new_int ? && x64 {
 						fmt_type = .si_i64
 					} $else {
 						fmt_type = .si_i32
@@ -239,7 +239,7 @@ fn (mut g Gen) str_val(node ast.StringInterLiteral, i int, fmts []u8) {
 			} else if typ == ast.i32_type {
 				g.write('(u32)(')
 			} else if typ == ast.int_type {
-				$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+				$if new_int ? && x64 {
 					g.write('(u64)(')
 				} $else {
 					g.write('(u32)(')

--- a/vlib/v/gen/js/builtin_types.v
+++ b/vlib/v/gen/js/builtin_types.v
@@ -72,7 +72,7 @@ fn (mut g JsGen) sym_to_js_typ(sym ast.TypeSymbol) string {
 			styp = 'int'
 		}
 		.int {
-			$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+			$if new_int ? && x64 {
 				styp = 'i64'
 			} $else {
 				styp = 'int'

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -3249,7 +3249,7 @@ fn (mut g JsGen) greater_typ(left ast.Type, right ast.Type) ast.Type {
 			return ast.Type(ast.i32_type_idx)
 		}
 		if ast.int_type_idx in lr {
-			$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+			$if new_int ? && x64 {
 				return ast.Type(ast.i64_type_idx)
 			} $else {
 				return ast.Type(ast.i32_type_idx)

--- a/vlib/v/gen/native/amd64.v
+++ b/vlib/v/gen/native/amd64.v
@@ -506,7 +506,7 @@ fn (mut c Amd64) inc_var(var Var, config VarConfig) {
 					size_str = 'DWORD'
 				}
 				ast.int_type_idx {
-					$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+					$if new_int ? && x64 {
 						c.g.write16(0xFF48)
 						size_str = 'QWORD'
 					} $else {
@@ -781,7 +781,7 @@ fn (mut c Amd64) mov_reg_to_var(var Var, r Register, config VarConfig) {
 						size_str = 'DWORD'
 					}
 					ast.int_type_idx {
-						$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+						$if new_int ? && x64 {
 							c.g.write16(0x8948 + if is_extended_register { i32(4) } else { i32(0) })
 							size_str = 'QWORD'
 						} $else {
@@ -937,7 +937,7 @@ fn (mut c Amd64) mov_int_to_var(var Var, integer i32, config VarConfig) {
 					c.g.println('mov DWORD PTR[rbp-${int(offset).hex2()}], ${integer}')
 				}
 				ast.int_type_idx {
-					$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+					$if new_int ? && x64 {
 						c.g.write8(0x48)
 						c.g.write8(0xc7)
 						c.g.write8(if is_far_var { i32(0x85) } else { i32(0x45) })

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -842,7 +842,7 @@ fn (mut g Gen) get_type_size(raw_type ast.Type) i32 {
 				2
 			}
 			ast.int_type_idx {
-				$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+				$if new_int ? && x64 {
 					8
 				} $else {
 					4

--- a/vlib/v/gen/wasm/ops.v
+++ b/vlib/v/gen/wasm/ops.v
@@ -41,7 +41,7 @@ pub fn (mut g Gen) get_wasm_type(typ_ ast.Type) wasm.ValType {
 				wasm.ValType.i32_t
 			}
 			ast.int_type_idx {
-				$if new_int ? && (arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64) {
+				$if new_int ? && x64 {
 					wasm.ValType.i64_t
 				} $else {
 					wasm.ValType.i32_t


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Replace `(arm64 || amd64 || rv64 || s390x || ppc64le || loongarch64)` with `x64`.

In `cgen`, `x64` comptime ident will generate following code:
```c
#if INTPTR_MAX == INT32_MAX
        #define TARGET_IS_32BIT 1
#elif INTPTR_MAX == INT64_MAX
        #define TARGET_IS_64BIT 1
#else
        #error "The environment is not 32 or 64-bit."
#endif

...

        #if defined(TARGET_IS_64BIT)
        {
                println(_S("x64"));
        }
        #endif
```

This should be a better way detect the compile environment  is 64-bit or not.

And this will help compile 32bit `int` on an 64bit environment.

And also, it is much shorter. :)

