### PR TITLE
json2: make examples/news_fetcher.v to work with decoder2

### DIFF
--- a/examples/news_fetcher.v
+++ b/examples/news_fetcher.v
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
 import net.http
-import x.json2
+import x.json2.decoder2
 import sync.pool
 
 struct Story {
@@ -16,9 +16,8 @@ fn worker_fetch(mut p pool.PoolProcessor, cursor int, worker_id int) voidptr {
 		println('failed to fetch data from /v0/item/${id}.json')
 		return pool.no_result
 	}
-	story := json2.decode[Story](resp.body) or {
+	story := decoder2.decode[Story](resp.body) or {
 		println('failed to decode a story')
-		// println(resp.body)
 		return pool.no_result
 	}
 	println('# ${cursor + 1}) ${story.title} | ${story.url}')
@@ -31,14 +30,12 @@ fn main() {
 		println('failed to fetch data from /v0/topstories.json')
 		return
 	}
-	// TODO bring back once json2 can decode []int
-	/*
-	ids := json2.decode[[]int](resp.body) or {
-		println('failed to decode topstories.json $err')
+
+	ids := decoder2.decode[[]int](resp.body) or {
+		println('failed to decode topstories.json ${err}')
 		return
-	}#[0..10]
-	*/
-	ids := resp.body.replace_once('[', '').replace_once(']', '').split(',').map(it.int())#[0..30]
+	}#[0..30]
+
 	mut fetcher_pool := pool.new_pool_processor(
 		callback: worker_fetch
 	)

--- a/vlib/x/json2/decoder2/decode.v
+++ b/vlib/x/json2/decoder2/decode.v
@@ -456,7 +456,7 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 				// field loop
 				for {
 					if current_field_info == unsafe { nil } {
-						decoder.current_node = decoder.current_node.next.next // skip value
+						decoder.current_node = decoder.current_node.next // skip value
 
 						break
 					}

--- a/vlib/x/json2/decoder2/tests/decode_struct_test.v
+++ b/vlib/x/json2/decoder2/tests/decode_struct_test.v
@@ -85,3 +85,12 @@ fn test_option_types() {
 		assert false, 'Should not return none'
 	}
 }
+
+struct Story {
+}
+
+fn test_issue_25347() {
+	t := '{"k":[1,2,3,4,5,6,7,8,9]}'
+	json.decode[Story](t) or { assert false }
+	assert true
+}


### PR DESCRIPTION
Fixes issue https://github.com/vlang/v/issues/25347
- `decode2.v` seems to had a typo I don't understand totally but seems fixes the issue.
- examples/news_fetcher.v working with decode2.
