### PR TITLE
fix: print block the program when no stdout attached.

### DIFF
--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -133,6 +133,12 @@ fn (mut g Gen) gen_c_main_function_only_header() {
 
 fn (mut g Gen) gen_c_main_function_header() {
 	g.gen_c_main_function_only_header()
+
+	g.writeln('\tif (fileno(stdout) < 0) {')
+	g.writeln('\t\tfreopen("NUL", "w", stdout);')
+	g.writeln('\t\tfreopen("NUL", "w", stderr);')
+	g.writeln('\t}')
+
 	g.gen_c_main_trace_calls_hook()
 	if !g.pref.no_builtin {
 		if _ := g.table.global_scope.find_global('g_main_argc') {


### PR DESCRIPTION
When compiled as a non-console program, such as a GUI application, using the print function will cause the program to hang because there is no stdout.

```v
// eg
#flag -mwindows

```