### PR TITLE
x.crypto.chacha20: makes 64-bit counter cipher works as an expected 

### DIFF
--- a/vlib/x/crypto/chacha20/bench/bench.v
+++ b/vlib/x/crypto/chacha20/bench/bench.v
@@ -19,6 +19,13 @@
 // -----------
 // Iterations:      10000          Total Duration:   48.242ms      ns/op:       4824       B/op:      3    allocs/op:      4
 //
+// Chacha20 old xor_key_stream_backup
+// -----------
+// Iterations:      10000          Total Duration:   53.430ms      ns/op:       5343       B/op:     11    allocs/op:     12
+// ChaCha20 new xor_key_stream
+// -----------
+// Iterations:      10000          Total Duration:   43.668ms      ns/op:       4366       B/op:      0    allocs/op:      1
+//
 import x.benchmark
 import encoding.hex
 import x.crypto.chacha20
@@ -40,6 +47,12 @@ fn bench_chacha20_decrypt() ! {
 	_ := chacha20.decrypt(key, nonce, ciphertext)!
 }
 
+fn bench_chacha20_xor_key_stream() ! {
+	mut dst := []u8{len: plaintext.len}
+	mut cs := chacha20.new_cipher(key, nonce)!
+	cs.xor_key_stream(mut dst, plaintext)
+}
+
 fn main() {
 	cf := benchmark.BenchmarkDefaults{
 		n: 10000
@@ -49,9 +62,13 @@ fn main() {
 	mut b0 := benchmark.setup(bench_chacha20_encrypt, cf)!
 	b0.run()
 
-	println('')
 	println('ChaCha20 Decryption')
 	println('-----------')
 	mut b1 := benchmark.setup(bench_chacha20_decrypt, cf)!
 	b1.run()
+
+	println('ChaCha20 new xor_key_stream')
+	println('-----------')
+	mut b3 := benchmark.setup(bench_chacha20_xor_key_stream, cf)!
+	b3.run()
 }

--- a/vlib/x/crypto/chacha20/stream_test.v
+++ b/vlib/x/crypto/chacha20/stream_test.v
@@ -22,13 +22,13 @@ fn test_stream_counter_handling() ! {
 	assert ctx.Stream.overflow == false
 	assert ctx.Stream.ctr() == max_64bit_counter
 
-	// after above process the counter should have at the maximum limit
-	// we use keystream_with_blocksize to test this counter handling, because
+	// after above process, the counter should reach the maximum limit
+	// we use keystream_full to test this counter handling, because
 	// xor_key_stream would panic on counter reset
 	msg1 := []u8{len: block_size}
-	ctx.Stream.keystream_with_blocksize(mut dst[..block_size], msg1) or {
+	ctx.Stream.keystream_full(mut dst[..block_size], msg1) or {
 		assert ctx.Stream.overflow == true
-		assert err == error('chacha20.check_ctr: internal counter overflow')
+		assert err == error('chacha20: internal counter overflow')
 		return
 	}
 }
@@ -58,7 +58,7 @@ fn test_state_of_chacha20_block_simple() ! {
 
 	mut block := []u8{len: block_size}
 	stream.set_ctr(1)
-	stream.keystream_with_blocksize(mut block, block)!
+	stream.keystream_full(mut block, block)!
 
 	expected_raw_bytes := '10f1e7e4d13b5915500fdd1fa32071c4c7d1f4c733c068030422aa9ac3d46c4ed2826446079faa0914c2d705d98b02a2b5129cd1de164eb9cbd083e8a2503c4e'
 	exp_bytes := hex.decode(expected_raw_bytes)!
@@ -66,7 +66,7 @@ fn test_state_of_chacha20_block_simple() ! {
 	assert block == exp_bytes
 }
 
-fn test_keystream_with_blocksize() ! {
+fn test_keystream_encryption() ! {
 	for val in blocks_testcases {
 		key := hex.decode(val.key)!
 		nonce := hex.decode(val.nonce)!
@@ -75,7 +75,7 @@ fn test_keystream_with_blocksize() ! {
 		stream.set_ctr(val.counter)
 
 		mut block := []u8{len: block_size}
-		stream.keystream_with_blocksize(mut block, block)!
+		stream.keystream_full(mut block, block)!
 		exp_bytes := hex.decode(val.output)!
 
 		assert block == exp_bytes


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR was motivated by discord disccussion [here](https://discord.com/channels/592103645835821068/592114487759470596/1417903638705082489), especially, for firebird client testing by @einar-hjortdal with 64-bit counter chacha20 cipher that does not works as an expected previously. This patch was inspired from [nakagami chacha20](https://github.com/nakagami/chacha20) used by golang firebird client in [golang firebirdsql](https://github.com/nakagami/firebirdsql). Its adapted into existing `x.crypto.chacha20` implementation.

This PR contains:

- Rewrites of `xor_key_stream` building block with the new one. Its splitted out keystream generation and xoring bytes into separated logic. Previously, its falls on the same `keystream_with_blocksize`  routine. With this patch, key stream generation separated into `Stream.keystream`, focussing on keystream generation and updating internal counter, where xor-ing messages happens on `xor_key_stream` and or `keystream_full` helper.
- After this applied, the benchmark for `xor_key_stream` show a nice improvement, from ±53.430ms down into ±43.668ms. The benchmark also added into `bench/bench.v` file. It also make it more simpler and readable.
- Some bits of clean up: split out increasing internal counter into own routine in `Stream.inc_ctr`
- Marked a `Cipher.reset` method for deprecation. It intended for internal use, See some possibles culprits of this misbehaved calls tested by @tankf33der at [here](https://github.com/vlang/v/pull/25334#issuecomment-3311553263). Thanks to @tankf33der 👍
- Removes unnecessary codes

After this patch applied, in my testing for [v firebird client](https://github.com/einar-hjortdal/firebird.git) with 64-bit counter activated, the tests was passed successfully. @einar-hjortdal: can you give it a try ?

Cheers,
thanks