### PR TITLE
parser,checker: add new array syntax support

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1607,9 +1607,11 @@ pub:
 	has_cap       bool
 	has_init      bool
 	has_index     bool // true if temp variable index is used
+	auto_length   bool // [..]
+	is_deprecated bool // is deprecated syntax
 pub mut:
 	exprs        []Expr // `[expr, expr]` or `[expr]Type{}` for fixed array
-	len_expr     Expr   // len: expr
+	len_expr     Expr   // len: expr, NOTE: for fixed-array, we set the size in `len_expr`
 	cap_expr     Expr   // cap: expr
 	init_expr    Expr   // init: expr
 	expr_types   []Type // [Dog, Cat] // also used for interface_types

--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -450,13 +450,13 @@ pub fn (x Expr) str() string {
 			typ_str := global_table.type_to_str(x.elem_type)
 			if fields.len > 0 {
 				if x.is_fixed {
-					return '${x.exprs.str()}${typ_str}{${fields.join(', ')}}'
+					return '[${x.len_expr.str()}]${typ_str}{${fields.join(', ')}}'
 				} else {
 					return '[]${typ_str}{${fields.join(', ')}}'
 				}
 			} else {
 				if x.is_fixed {
-					return '${x.exprs.str()}${typ_str}{}'
+					return '[${x.len_expr.str()}]${typ_str}{}'
 				} else {
 					return x.exprs.str()
 				}

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -133,7 +133,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 		c.check_elements_ref_fields_initialized(unwrap_elem_type, node.pos)
 	}
 	// `a = []`
-	if node.exprs.len == 0 {
+	if node.exprs.len == 0 && !node.is_fixed {
 		// `a := fn_returning_opt_array() or { [] }`
 		if c.expected_type == ast.void_type {
 			if c.expected_or_type != ast.void_type {
@@ -293,12 +293,12 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 			}
 		}
 		node.elem_type = elem_type
-	} else if node.is_fixed && node.exprs.len == 1 && node.elem_type != ast.void_type {
+	} else if node.is_fixed && node.elem_type != ast.void_type {
 		// `[50]u8`
 		sym := c.table.sym(node.typ)
 		if sym.info !is ast.ArrayFixed
 			|| c.array_fixed_has_unresolved_size(sym.info as ast.ArrayFixed) {
-			mut size_expr := node.exprs[0]
+			mut size_expr := node.len_expr
 			node.typ = c.eval_array_fixed_sizes(mut size_expr, 0, node.elem_type)
 			if node.is_option {
 				node.typ = node.typ.set_flag(.option)

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -158,7 +158,7 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 		}.clear_option_and_result()
 	}
 	// `[1,2,3]`
-	if node.exprs.len > 0 && node.elem_type == ast.void_type {
+	if node.exprs.len > 0 { //&& node.elem_type == ast.void_type {
 		mut expected_value_type := ast.void_type
 		mut expecting_interface_array := false
 		mut expecting_sumtype_array := false

--- a/vlib/v/checker/tests/array_init_without_init_value_err.out
+++ b/vlib/v/checker/tests/array_init_without_init_value_err.out
@@ -9,7 +9,7 @@ vlib/v/checker/tests/array_init_without_init_value_err.vv:7:13: warning: fixed a
     5 |     a := []Foo{len: 10}
     6 |     println(a)
     7 |     fixed_a := [10]Foo{}
-      |                ~~~~~~~~~
+      |                ~~~~~~~~
     8 |     println(fixed_a)
     9 | }
 vlib/v/checker/tests/array_init_without_init_value_err.vv:20:11: warning: arrays of references need to be initialized right away, therefore `len:` cannot be used (unless inside `unsafe`, or if you also use `init:`)
@@ -23,7 +23,7 @@ vlib/v/checker/tests/array_init_without_init_value_err.vv:21:10: warning: fixed 
    19 | fn main_ref() {
    20 |     println(*[]&int{len: 1}[0])
    21 |     println([1]&int{})
-      |             ~~~~~~~~~
+      |             ~~~~~~~~
    22 |     _ = [][1]&int{len: 1}[0][0]
    23 |     _ = []map[int]&int{len: 1}
 vlib/v/checker/tests/array_init_without_init_value_err.vv:22:6: warning: arrays of references need to be initialized right away, therefore `len:` cannot be used (unless inside `unsafe`, or if you also use `init:`)
@@ -58,7 +58,7 @@ vlib/v/checker/tests/array_init_without_init_value_err.vv:14:13: warning: fixed 
    12 |     a := []T{len: 10}
    13 |     println(a)
    14 |     fixed_a := [10]T{}
-      |                ~~~~~~~
+      |                ~~~~~~
    15 |     println(fixed_a)
    16 | }
 vlib/v/checker/tests/array_init_without_init_value_err.vv:45:22: warning: arrays of interfaces need to be initialized right away, therefore `len:` cannot be used (unless inside `unsafe`, or if you also use `init:`)

--- a/vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.out
+++ b/vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.out
@@ -9,7 +9,7 @@ vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:9:6: not
     7 | fn main() {
     8 |     _ = []Foo{len: 1}
     9 |     _ = [1]Foo{}
-      |         ~~~~~~~~
+      |         ~~~~~~~
    10 |     _ = map[string]Foo{}
    11 |     _ = map[string][]Foo{}
 vlib/v/checker/tests/array_map_elements_ref_fields_uninitialized_err.vv:12:6: notice: reference field `Foo.n` must be initialized (part of struct `Foo`)

--- a/vlib/v/checker/tests/wrong_muti_dim_arr_declare_err.out
+++ b/vlib/v/checker/tests/wrong_muti_dim_arr_declare_err.out
@@ -1,14 +1,7 @@
-vlib/v/checker/tests/wrong_muti_dim_arr_declare_err.vv:4:15: warning: use `x := []Type{}` instead of `x := []Type`
+vlib/v/checker/tests/wrong_muti_dim_arr_declare_err.vv:4:27: error: invalid expression: unexpected token `]`
     2 | 
     3 | fn main() {
     4 |         a2 := [][][]f32[][]{}
-      |               ~~~~~~~~~~
-    5 |         dump(typeof(a2).name)
-    6 |
-vlib/v/checker/tests/wrong_muti_dim_arr_declare_err.vv:4:25: error: invalid expression: unexpected token `]`
-    2 | 
-    3 | fn main() {
-    4 |         a2 := [][][]f32[][]{}
-      |                         ^
+      |                           ^
     5 |         dump(typeof(a2).name)
     6 |

--- a/vlib/v/eval/expr.c.v
+++ b/vlib/v/eval/expr.c.v
@@ -458,7 +458,7 @@ pub fn (mut e Eval) expr(expr ast.Expr, expecting ast.Type) Object {
 					e.error('unknown array init combination; len: ${expr.has_len}, cap: ${expr.has_cap}, init: ${expr.has_init}')
 				}
 			}
-			if expr.is_fixed || expr.has_val {
+			if expr.is_fixed {
 				mut res := FixedArray{
 					val: []Object{cap: expr.exprs.len}
 				}

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1880,6 +1880,10 @@ pub fn (mut f Fmt) array_init(node ast.ArrayInit) {
 		last_line_nr = c.pos.last_line
 	}
 	mut set_comma := false
+	if node.is_fixed && node.exprs.len == 0 {
+		// [4]int{}
+		f.write('${node.len_expr}')
+	}
 	for i, expr in node.exprs {
 		pos := expr.pos()
 		if i == 0 {

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -1882,7 +1882,7 @@ pub fn (mut f Fmt) array_init(node ast.ArrayInit) {
 	mut set_comma := false
 	if node.is_fixed && node.exprs.len == 0 {
 		// [4]int{}
-		f.write('${node.len_expr}')
+		f.expr(node.len_expr)
 	}
 	for i, expr in node.exprs {
 		pos := expr.pos()

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -2082,7 +2082,7 @@ fn (mut g JsGen) gen_array_init_expr(it ast.ArrayInit) {
 		g.write(', cap: new int(')
 		g.expr(it.len_expr)
 		g.write(')')
-	} else if it.is_fixed && it.exprs.len == 1 {
+	} else if it.is_fixed && it.exprs.len == 0 {
 		// [100]u8 codegen
 		t1 := g.new_tmp_var()
 		t2 := g.new_tmp_var()
@@ -2090,7 +2090,7 @@ fn (mut g JsGen) gen_array_init_expr(it ast.ArrayInit) {
 		g.inc_indent()
 		g.writeln('const ${t1} = [];')
 		g.write('for (let ${t2} = 0; ${t2} < ')
-		g.expr(it.exprs[0])
+		g.expr(it.len_expr)
 		g.writeln('; ${t2}++) {')
 		g.inc_indent()
 		g.write('${t1}.push(')
@@ -2107,9 +2107,9 @@ fn (mut g JsGen) gen_array_init_expr(it ast.ArrayInit) {
 		g.writeln('return ${t1};')
 		g.dec_indent()
 		g.write('})(), len: new int(')
-		g.expr(it.exprs[0])
+		g.expr(it.len_expr)
 		g.write('), cap: new int(')
-		g.expr(it.exprs[0])
+		g.expr(it.len_expr)
 		g.write(')')
 	} else {
 		styp := g.styp(it.elem_type)

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -6,7 +6,58 @@ module parser
 import v.ast
 import v.token
 
+fn (mut p Parser) parse_array_elem_type(is_option bool, is_fixed bool) (ast.Type, ast.Type) {
+	mut elem_type := ast.no_type
+	mut array_type := ast.void_type
+
+	elem_type_pos := p.tok.pos()
+	elem_type = p.parse_type()
+	// this is set here because it's a known type, others could be the
+	// result of expr so we do those in checker
+	if elem_type != 0 && !is_fixed {
+		if elem_type.has_flag(.result) {
+			p.error_with_pos('arrays do not support storing Result values', elem_type_pos)
+		}
+		idx := p.table.find_or_register_array(elem_type)
+		if elem_type.has_flag(.generic) {
+			array_type = ast.new_type(idx).set_flag(.generic)
+		} else {
+			array_type = ast.new_type(idx)
+		}
+		if is_option {
+			array_type = array_type.set_flag(.option)
+		}
+	}
+	return elem_type, array_type
+}
+
+fn (mut p Parser) parse_array_lit(mut exprs []ast.Expr, mut pre_cmnts []ast.Comment, mut ecmnts [][]ast.Comment) (int, token.Pos) {
+	old_inside_array_lit := p.inside_array_lit
+	old_last_enum_name := p.last_enum_name
+	old_last_enum_mod := p.last_enum_mod
+	p.inside_array_lit = true
+	p.last_enum_name = ''
+	p.last_enum_mod = ''
+	pre_cmnts = p.eat_comments()
+	for i := 0; p.tok.kind !in [.rsbr, .eof]; i++ {
+		exprs << p.expr(0)
+		ecmnts << p.eat_comments()
+		if p.tok.kind == .comma {
+			p.next()
+		}
+		ecmnts.last() << p.eat_comments()
+	}
+	p.inside_array_lit = old_inside_array_lit
+	p.last_enum_name = old_last_enum_name
+	p.last_enum_mod = old_last_enum_mod
+	line_nr := p.tok.line_nr
+	last_pos := p.tok.pos()
+	p.check(.rsbr)
+	return line_nr, last_pos
+}
+
 fn (mut p Parser) array_init(is_option bool, alias_array_type ast.Type) ast.ArrayInit {
+	// NOTE: for fixed-array, we set the size in `len_expr`
 	first_pos := p.tok.pos()
 	mut last_pos := p.tok.pos()
 	mut array_type := ast.void_type
@@ -19,172 +70,154 @@ fn (mut p Parser) array_init(is_option bool, alias_array_type ast.Type) ast.Arra
 	mut has_val := false
 	mut has_type := false
 	mut has_init := false
+	mut has_len := false
+	mut has_cap := false
 	mut has_index := false
 	mut init_expr := ast.empty_expr
+	mut len_expr := ast.empty_expr
+	mut cap_expr := ast.empty_expr
+	mut auto_length := false
+	mut line_nr := p.tok.line_nr
+	mut is_deprecated := false // deprecated fixed-array syntax
 	if alias_array_type == ast.void_type {
 		p.check(.lsbr)
 		if p.tok.kind == .rsbr {
+			// empty array: []
 			last_pos = p.tok.pos()
-			// []typ => `[]` and `typ` must be on the same line
-			line_nr := p.tok.line_nr
 			p.next()
-			// []string
-			if p.tok.kind in [.name, .amp, .lsbr, .question, .key_shared, .not]
-				&& p.tok.line_nr == line_nr {
-				elem_type_pos = p.tok.pos()
-				elem_type = p.parse_type()
-				// this is set here because it's a known type, others could be the
-				// result of expr so we do those in checker
-				if elem_type != 0 {
-					if elem_type.has_flag(.result) {
-						p.error_with_pos('arrays do not support storing Result values',
-							elem_type_pos)
-					}
-					idx := p.table.find_or_register_array(elem_type)
-					if elem_type.has_flag(.generic) {
-						array_type = ast.new_type(idx).set_flag(.generic)
-					} else {
-						array_type = ast.new_type(idx)
-					}
-					if is_option {
-						array_type = array_type.set_flag(.option)
-					}
-					has_type = true
-				}
-			}
-			last_pos = p.tok.pos()
-		} else {
-			// [1,2,3] or [const]u8
-			old_inside_array_lit := p.inside_array_lit
-			old_last_enum_name := p.last_enum_name
-			old_last_enum_mod := p.last_enum_mod
-			p.inside_array_lit = true
-			p.last_enum_name = ''
-			p.last_enum_mod = ''
-			pre_cmnts = p.eat_comments()
-			for i := 0; p.tok.kind !in [.rsbr, .eof]; i++ {
-				exprs << p.expr(0)
-				ecmnts << p.eat_comments()
-				if p.tok.kind == .comma {
-					p.next()
-				}
-				ecmnts.last() << p.eat_comments()
-			}
-			p.inside_array_lit = old_inside_array_lit
-			p.last_enum_name = old_last_enum_name
-			p.last_enum_mod = old_last_enum_mod
-			line_nr := p.tok.line_nr
+		} else if p.tok.kind == .dotdot {
+			// auto length fixed array: [..]
+			is_fixed = true
+			auto_length = true
+			p.next()
 			last_pos = p.tok.pos()
 			p.check(.rsbr)
-			if exprs.len == 1 && p.tok.line_nr == line_nr
-				&& (p.tok.kind in [.name, .amp, .question, .key_shared]
-				|| (p.tok.kind == .lsbr && p.is_array_type())) {
-				// [100]u8
-				elem_type = p.parse_type()
-				if elem_type != 0 {
-					s := p.table.sym(elem_type)
-					if s.name == 'byte' {
-						p.error('`byte` has been deprecated in favor of `u8`: use `[10]u8{}` instead of `[10]byte{}`')
-					}
-				}
-				last_pos = p.tok.pos()
-				is_fixed = true
-				if p.tok.kind == .lcbr {
-					p.next()
-					if p.tok.kind != .rcbr {
-						pos := p.tok.pos()
-						n := p.check_name()
-						if n != 'init' {
-							if is_fixed {
-								p.error_with_pos('`len` and `cap` are invalid attributes for fixed array dimension',
-									pos)
-							} else {
-								p.error_with_pos('expected `init:`, not `${n}`', pos)
-							}
-							return ast.ArrayInit{}
-						}
-						p.check(.colon)
-						has_init = true
-						has_index = p.handle_index_variable(mut init_expr)
-					}
-					last_pos = p.tok.pos()
-					p.check(.rcbr)
-				} else {
-					modifier := if is_option { '?' } else { '' }
-					p.warn_with_pos('use e.g. `x := ${modifier}[1]Type{}` instead of `x := ${modifier}[1]Type`',
-						first_pos.extend(last_pos))
-				}
-			} else {
-				if p.tok.kind == .not {
-					last_pos = p.tok.pos()
-					is_fixed = true
-					has_val = true
-					p.next()
-				}
-				if p.tok.kind == .not && p.tok.line_nr == p.prev_tok.line_nr {
-					last_pos = p.tok.pos()
-					p.error_with_pos('use e.g. `[1, 2, 3]!` instead of `[1, 2, 3]!!`',
-						last_pos)
-					p.next()
-				}
-			}
+		} else {
+			// Parse length expression or first element
+			line_nr, last_pos = p.parse_array_lit(mut exprs, mut pre_cmnts, mut ecmnts)
+			has_val = true
 		}
-		if exprs.len == 0 && p.tok.kind != .lcbr && has_type {
-			if !p.pref.is_fmt {
-				modifier := if is_option { '?' } else { '' }
-				p.warn_with_pos('use `x := ${modifier}[]Type{}` instead of `x := ${modifier}[]Type`',
-					first_pos.extend(last_pos))
+
+		// Parse type declaration if present
+		// []typ => `[]` and `typ` must be on the same line
+		if exprs.len <= 1 && p.tok.line_nr == line_nr
+			&& (p.tok.kind in [.name, .amp, .question, .key_shared]
+			|| (p.tok.kind == .lsbr && p.is_array_type())
+			|| (p.tok.kind == .not && exprs.len == 0)) // only `[]` can has a `!` type: []!int
+		  {
+			if exprs.len == 1 {
+				// [100]u8
+				// fixed-array move `exprs[0]` to `len_expr`
+				len_expr = exprs[0]
+				exprs.clear()
+				ecmnts.clear()
+				is_fixed = true
+				has_val = false
 			}
+			elem_type_pos = p.tok.pos()
+			elem_type, array_type = p.parse_array_elem_type(is_option, is_fixed)
+			if elem_type != 0 {
+				has_type = true
+			}
+			last_pos = p.tok.pos()
 		}
 	} else {
 		array_type = (p.table.sym(alias_array_type).info as ast.Alias).parent_type
 		elem_type = p.table.sym(array_type).array_info().elem_type
+		last_pos = p.tok.pos()
 		p.next()
+		has_type = true
 	}
-	mut has_len := false
-	mut has_cap := false
-	mut len_expr := ast.empty_expr
-	mut cap_expr := ast.empty_expr
-	mut attr_pos := token.Pos{}
-	if p.tok.kind == .lcbr && exprs.len == 0 && array_type != ast.void_type {
-		// `[]int{ len: 10, cap: 100}` syntax
-		p.next()
-		for p.tok.kind != .rcbr {
-			attr_pos = p.tok.pos()
-			key := p.check_name()
-			p.check(.colon)
-			if is_option {
-				p.error('Option array cannot have initializers')
-			}
-			match key {
-				'len' {
-					has_len = true
-					len_expr = p.expr(0)
-				}
-				'cap' {
-					has_cap = true
-					cap_expr = p.expr(0)
-				}
-				'init' {
-					has_init = true
-					has_index = p.handle_index_variable(mut init_expr)
-				}
-				else {
-					p.error_with_pos('wrong field `${key}`, expecting `len`, `cap`, or `init`',
-						attr_pos)
-					return ast.ArrayInit{}
+
+	if has_type {
+		if p.tok.kind == .lsbr {
+			// Parse array lit if present
+			p.next()
+			line_nr, last_pos = p.parse_array_lit(mut exprs, mut pre_cmnts, mut ecmnts)
+			if auto_length {
+				// auto length fixed-array set `len_expr`
+				len_expr = ast.IntegerLiteral{
+					val: exprs.len.str()
 				}
 			}
-			if p.tok.kind != .rcbr {
-				p.check(.comma)
+			has_val = true
+		} else if p.tok.kind == .lcbr {
+			// Parse array attribute initialization if present
+			p.next()
+			mut attr_pos := token.Pos{}
+			for p.tok.kind != .rcbr {
+				attr_pos = p.tok.pos()
+				key := p.check_name()
+				p.check(.colon)
+				if is_option && !is_fixed {
+					p.error('Option array cannot have initializers')
+				}
+				match key {
+					'len' {
+						if is_fixed {
+							p.error_with_pos('`len` and `cap` are invalid attributes for fixed array dimension',
+								attr_pos)
+						}
+						has_len = true
+						len_expr = p.expr(0)
+					}
+					'cap' {
+						if is_fixed {
+							p.error_with_pos('`len` and `cap` are invalid attributes for fixed array dimension',
+								attr_pos)
+						}
+						has_cap = true
+						cap_expr = p.expr(0)
+					}
+					'init' {
+						has_init = true
+						has_index = p.handle_index_variable(mut init_expr)
+					}
+					else {
+						if is_fixed {
+							p.error_with_pos('wrong field `${key}`, expecting `init`',
+								attr_pos)
+						} else {
+							p.error_with_pos('wrong field `${key}`, expecting `len`, `cap`, or `init`',
+								attr_pos)
+						}
+						return ast.ArrayInit{}
+					}
+				}
+				if p.tok.kind != .rcbr {
+					p.check(.comma)
+				}
 			}
+			p.check(.rcbr)
+			if has_init && !has_len && !is_fixed {
+				p.error_with_pos('cannot use `init` attribute unless `len` attribute is also provided',
+					attr_pos)
+			}
+		} else if !p.pref.is_fmt {
+			modifier := if is_option { '?' } else { '' }
+			fixed_modifier := if is_fixed { '1' } else { '' }
+			p.warn_with_pos('use `x := ${modifier}[${fixed_modifier}]Type{}` instead of `x := ${modifier}[${fixed_modifier}]Type`',
+				first_pos.extend(last_pos))
 		}
-		p.check(.rcbr)
-		if has_init && !has_len {
-			p.error_with_pos('cannot use `init` attribute unless `len` attribute is also provided',
-				attr_pos)
+	} else {
+		if p.tok.kind == .not {
+			last_pos = p.tok.pos()
+			is_fixed = true
+			has_val = true
+			p.next()
+			// deprecated fixed-array set `len_expr`
+			len_expr = ast.IntegerLiteral{
+				val: exprs.len.str()
+			}
+			is_deprecated = true
+		}
+		if p.tok.kind == .not && p.tok.line_nr == p.prev_tok.line_nr {
+			last_pos = p.tok.pos()
+			p.error_with_pos('use e.g. `[1, 2, 3]!` instead of `[1, 2, 3]!!`', last_pos)
+			p.next()
 		}
 	}
+
 	pos := first_pos.extend_with_last_line(last_pos, p.prev_tok.line_nr)
 	return ast.ArrayInit{
 		is_fixed:      is_fixed
@@ -206,6 +239,8 @@ fn (mut p Parser) array_init(is_option bool, alias_array_type ast.Type) ast.Arra
 		cap_expr:      cap_expr
 		init_expr:     init_expr
 		is_option:     is_option
+		auto_length:   auto_length
+		is_deprecated: is_deprecated
 	}
 }
 

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -148,24 +148,21 @@ fn (mut p Parser) array_init(is_option bool, alias_array_type ast.Type) ast.Arra
 			for p.tok.kind != .rcbr {
 				attr_pos = p.tok.pos()
 				key := p.check_name()
-				p.check(.colon)
 				if is_option && !is_fixed {
 					p.error('Option array cannot have initializers')
 				}
+				if is_fixed && key in ['len', 'cap'] {
+					p.error_with_pos('`len` and `cap` are invalid attributes for fixed array dimension',
+						attr_pos)
+					return ast.ArrayInit{}
+				}
+				p.check(.colon)
 				match key {
 					'len' {
-						if is_fixed {
-							p.error_with_pos('`len` and `cap` are invalid attributes for fixed array dimension',
-								attr_pos)
-						}
 						has_len = true
 						len_expr = p.expr(0)
 					}
 					'cap' {
-						if is_fixed {
-							p.error_with_pos('`len` and `cap` are invalid attributes for fixed array dimension',
-								attr_pos)
-						}
 						has_cap = true
 						cap_expr = p.expr(0)
 					}

--- a/vlib/v/parser/containers.v
+++ b/vlib/v/parser/containers.v
@@ -38,7 +38,8 @@ fn (mut p Parser) parse_array_lit(mut exprs []ast.Expr, mut pre_cmnts []ast.Comm
 	p.inside_array_lit = true
 	p.last_enum_name = ''
 	p.last_enum_mod = ''
-	pre_cmnts = p.eat_comments()
+	pre_cmnts.clear()
+	pre_cmnts << p.eat_comments()
 	for i := 0; p.tok.kind !in [.rsbr, .eof]; i++ {
 		exprs << p.expr(0)
 		ecmnts << p.eat_comments()

--- a/vlib/v/parser/parse_type.v
+++ b/vlib/v/parser/parse_type.v
@@ -11,75 +11,79 @@ import v.token
 const maximum_inline_sum_type_variants = 3
 const generic_type_level_cutoff_limit = 10 // it is very rarely deeper than 4
 
+fn (mut p Parser) eval_fixed_array_size_expr() (ast.Expr, int, bool) {
+	mut fixed_size := 0
+	mut size_expr := p.expr(0)
+	mut size_unresolved := true
+	if p.pref.is_fmt {
+		fixed_size = 987654321
+	} else {
+		match mut size_expr {
+			ast.IntegerLiteral {
+				fixed_size = size_expr.val.int()
+				size_unresolved = false
+			}
+			ast.ComptimeCall {
+				if size_expr.kind == .d {
+					size_expr.resolve_compile_value(p.pref.compile_values) or {
+						p.error_with_pos(err.msg(), size_expr.pos)
+					}
+					if size_expr.result_type != ast.i64_type {
+						p.error_with_pos('value from \$d() can only be positive integers when used as fixed size',
+							size_expr.pos)
+					}
+					fixed_size = size_expr.compile_value.int()
+					size_unresolved = false
+				} else {
+					p.error_with_pos('only \$d() is supported as fixed array size quantifier at compile time',
+						size_expr.pos)
+				}
+			}
+			ast.Ident {
+				if mut const_field := p.table.global_scope.find_const(size_expr.full_name()) {
+					if mut const_field.expr is ast.IntegerLiteral {
+						fixed_size = const_field.expr.val.int()
+						size_unresolved = false
+					} else if mut const_field.expr is ast.InfixExpr {
+						mut t := transformer.new_transformer_with_table(p.table, p.pref)
+						folded_expr := t.infix_expr(mut const_field.expr)
+
+						if folded_expr is ast.IntegerLiteral {
+							fixed_size = folded_expr.val.int()
+							size_unresolved = false
+						}
+					}
+				} else {
+					if p.pref.is_fmt {
+						// for vfmt purposes, pretend the constant does exist
+						// it may have been defined in another .v file:
+						fixed_size = 1
+						size_unresolved = false
+					}
+				}
+			}
+			ast.InfixExpr {
+				mut t := transformer.new_transformer_with_table(p.table, p.pref)
+				folded_expr := t.infix_expr(mut size_expr)
+
+				if folded_expr is ast.IntegerLiteral {
+					fixed_size = folded_expr.val.int()
+					size_unresolved = false
+				}
+			}
+			else {
+				p.error_with_pos('fixed array size cannot use non-constant value', size_expr.pos())
+			}
+		}
+	}
+	return size_expr, fixed_size, size_unresolved
+}
+
 fn (mut p Parser) parse_array_type(expecting token.Kind, is_option bool) ast.Type {
 	p.check(expecting)
 	// fixed array
 	if p.tok.kind in [.number, .name, .dollar] {
-		mut fixed_size := 0
-		mut size_expr := p.expr(0)
-		mut size_unresolved := true
-		if p.pref.is_fmt {
-			fixed_size = 987654321
-		} else {
-			match mut size_expr {
-				ast.IntegerLiteral {
-					fixed_size = size_expr.val.int()
-					size_unresolved = false
-				}
-				ast.ComptimeCall {
-					if size_expr.kind == .d {
-						size_expr.resolve_compile_value(p.pref.compile_values) or {
-							p.error_with_pos(err.msg(), size_expr.pos)
-						}
-						if size_expr.result_type != ast.i64_type {
-							p.error_with_pos('value from \$d() can only be positive integers when used as fixed size',
-								size_expr.pos)
-						}
-						fixed_size = size_expr.compile_value.int()
-						size_unresolved = false
-					} else {
-						p.error_with_pos('only \$d() is supported as fixed array size quantifier at compile time',
-							size_expr.pos)
-					}
-				}
-				ast.Ident {
-					if mut const_field := p.table.global_scope.find_const(size_expr.full_name()) {
-						if mut const_field.expr is ast.IntegerLiteral {
-							fixed_size = const_field.expr.val.int()
-							size_unresolved = false
-						} else if mut const_field.expr is ast.InfixExpr {
-							mut t := transformer.new_transformer_with_table(p.table, p.pref)
-							folded_expr := t.infix_expr(mut const_field.expr)
-
-							if folded_expr is ast.IntegerLiteral {
-								fixed_size = folded_expr.val.int()
-								size_unresolved = false
-							}
-						}
-					} else {
-						if p.pref.is_fmt {
-							// for vfmt purposes, pretend the constant does exist
-							// it may have been defined in another .v file:
-							fixed_size = 1
-							size_unresolved = false
-						}
-					}
-				}
-				ast.InfixExpr {
-					mut t := transformer.new_transformer_with_table(p.table, p.pref)
-					folded_expr := t.infix_expr(mut size_expr)
-
-					if folded_expr is ast.IntegerLiteral {
-						fixed_size = folded_expr.val.int()
-						size_unresolved = false
-					}
-				}
-				else {
-					p.error_with_pos('fixed array size cannot use non-constant value',
-						size_expr.pos())
-				}
-			}
-		}
+		size_expr, fixed_size, size_unresolved := p.eval_fixed_array_size_expr()
 		p.check(.rsbr)
 		p.fixed_array_dim++
 		defer {

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -115,6 +115,7 @@ mut:
 	main_already_defined     bool // TODO move to checker
 	is_vls                   bool
 	inside_import_section    bool
+	cur_array_elem_type      ast.Type = ast.void_type
 pub mut:
 	scanner &scanner.Scanner = unsafe { nil }
 	table   &ast.Table       = unsafe { nil }

--- a/vlib/v/parser/tests/array_init.out
+++ b/vlib/v/parser/tests/array_init.out
@@ -4,7 +4,7 @@ vlib/v/parser/tests/array_init.vv:2:7: warning: use `x := []Type{}` instead of `
       |          ~~~~~
     3 |     _ := [1]int
     4 |     _ := []!int{}
-vlib/v/parser/tests/array_init.vv:3:7: warning: use e.g. `x := [1]Type{}` instead of `x := [1]Type`
+vlib/v/parser/tests/array_init.vv:3:7: warning: use `x := [1]Type{}` instead of `x := [1]Type`
     1 | fn main() {
     2 |     _ := []int
     3 |     _ := [1]int


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Feature requested by #25183

NOTE: `vfmt` need further fix to work with new array syntax, in anther PR.

new.v

```v
module main

const kkk = 20

fn main() {
        // old syntax
        o1 := []int{}
        dump(o1)
        o2 := [int(1),2,3,4]
        dump(o2)
        o3 := [kkk]int{}
        dump(o3)
        o4 := [int(1),2,3,4]!
        dump(o4)

        // new syntax
        n1 := []int[1 2 3 4]
        dump(n1)
        n2 := [4]int[1 2 3 4]
        dump(n2)
        n3 := [..]int[1 2 3 4]
        dump(n3)
        /*
        // not work yet
        n4 := [4][4]f32[
                 [1 2 3 4]
                 [5 5 4 2]
                 [0 1 3 0]
                 [0 1 4 1]
        ]
        dump(n4)
        n5 := [..][..]f32[
                 [1 2 3 4]
                 [5 5 4 2]
                 [0 1 3 0]
                 [0 1 4 1]
        ]
        dump(n5)
        */
}
```