### PR TITLE
examples: get_weather use json2 and add translation

### DIFF
--- a/examples/get_weather/README.md
+++ b/examples/get_weather/README.md
@@ -1,23 +1,31 @@
 # get_weather
-get_weather is a very simple web crawler.
-Its goal is to get a weather forecast from caiyunapp.com.  
 
-# Compile and Run
+get_weather is a web crawler. Its goal is to get a weather forecast from
+`https://api.caiyunapp.com` in chinese and translated to another selected language.
 
-Use this to generate an executable and then launch the web crawler.
+We use `http.fetch()` to get a forecast `http.Response`, with a custom user-agent
+and then we decode the json into a struct with only relevant fields `lang`,
+`result` and `forecast_keypoint`.
+
+The chinese texts are translated with another `http.fetch()` to
+`https://translate.googleapis.com` and then decoding the `http.Response` as `json2.Any` arrays.
+
+## running
+
+By default texts are translated to English. Another language can be indicated
+with first argument as an [ISO 639](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) code:
+
 ```bash
-v get_weather.v
-./get_weather
+$ v run examples/get_weather/get_weather.v
+   zh_CN: 未来两小时天气
+      en: Weather in the next two hours
+   zh_CN: 最近的降雨带在西北66公里外呢
+      en: The nearest rainfall zone is 66 kilometers northwest
+$
+$ v run examples/get_weather/get_weather.v es
+   zh_CN: 未来两小时天气
+      es: Clima en las próximas dos horas
+   zh_CN: 最近的降雨带在西北66公里外呢
+      es: La zona de lluvia más cercana está a 66 kilómetros al noroeste
 ```
 
-As a convenience, you can also compile and launch the web crawler directly.
-```bash
-v run get_weather.v
-```
-
-In this project we use http.fetch() to get a http.Response, with a
-custom user-agent and then we use json.decode() to decode the json 
-response to struct.
-We also use a `[skip]` attribute to skip certain fields in the response,
-that we don't need and use a `[json: result]` attribute to specify that
-our struct field is named differently from the incoming json response.

--- a/examples/get_weather/get_weather.v
+++ b/examples/get_weather/get_weather.v
@@ -1,55 +1,69 @@
-import json
-import rand
 import net.http
+import os
+import rand
+import x.json2
+import x.json2.decoder2 as json
 
 struct Weather {
-	status      string @[skip] // drop this field
-	api_version string @[skip]
-	api_status  string @[skip]
-	lang        string @[skip]
-	unit        string @[skip]
-	tzshift     int    @[skip]
-	timezone    string @[skip]
-	server_time u32    @[skip]
-	location    []f32  @[skip]
-	result      Result //@[json: result] if the field name is different in JSON, it can be specified
+	lang   string
+	result Result
 }
 
 struct Result {
-	realtime          Realtime @[skip]
-	minutely          Minutely @[skip]
-	hourly            Hourly   @[skip]
-	daily             Daily    @[skip]
-	primary           int      @[skip]
 	forecast_keypoint string
 }
 
-struct Realtime {}
-
-struct Minutely {}
-
-struct Hourly {}
-
-struct Daily {}
+const config = http.FetchConfig{
+	user_agent: 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:88.0) Gecko/20100101 Firefox/88.0'
+}
 
 fn main() {
-	config := http.FetchConfig{
-		user_agent: 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:88.0) Gecko/20100101 Firefox/88.0'
-	}
-
+	dest_lang := if os.args.len > 1 { os.args[1] } else { 'en' }
 	rnd := rand.f32()
 	url := 'https://api.caiyunapp.com/v2.5/96Ly7wgKGq6FhllM/116.391912,40.010711/weather.jsonp?hourlysteps=120&random=${rnd}'
-	// println(url)
 
 	resp := http.fetch(http.FetchConfig{ ...config, url: url }) or {
 		println('failed to fetch data from the server')
 		return
 	}
 
-	weather := json.decode(Weather, resp.body) or {
+	weather := json.decode[Weather](resp.body) or {
 		println('failed to decode weather json')
 		return
 	}
 
-	println('未来两小时天气:\n${weather.result.forecast_keypoint}.')
+	for ch in ['未来两小时天气', weather.result.forecast_keypoint] {
+		println('${weather.lang:8}: ${ch}')
+		t := translate(ch, weather.lang, dest_lang) or {
+			println('failed to translate ${ch}: ${err}')
+			continue
+		}
+		println('${dest_lang:8}: ${t}')
+	}
+}
+
+// translate fetch google to print translate text `q` in languate `sl` into language `tl`.
+// A translation typical response json is like: `[[["Weather in the next two hours",
+// "未来两小时天气",null,null,3,null,null,[[null,"offline"]],
+// [[["61549914d65604307a34fd1855292577","offline_launch_doc.md"],null,null,null,null,
+// [[[6,8,0]]]]]]],null,"zh-CN",null,null,null,null,[]]`
+// where translated text is located at position `json_resp[0][0][0]`.
+fn translate(q string, sl string, tl string) !string {
+	url := 'https://translate.googleapis.com/translate_a/single?client=gtx&sl=${sl}&tl=${tl}&dt=t&q=${q}'
+
+	resp := http.fetch(http.FetchConfig{ ...config, url: url })!
+
+	json_resp := json.decode[json2.Any](resp.body)!
+
+	a := json_resp.arr()
+	if a.len > 0 {
+		a0 := a[0].arr()
+		if a0.len > 0 {
+			a00 := a0[0].arr()
+			if a00.len > 0 {
+				return a00[0].str()
+			}
+		}
+	}
+	return error('invalid translation response')
 }


### PR DESCRIPTION
- Use json2 to parse weather data. Leave in struct only relevant fields.
- I took the liberty adding translation for the original texts. Parse translation response with `json2.Any` arrays.