### PR TITLE
os.c.v: remove duplicate unsafe block

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -531,7 +531,7 @@ pub fn get_raw_line() string {
 		unsafe {
 			initial_size := 256 * wide_char_size
 			mut buf := malloc_noscan(initial_size)
-			defer { unsafe { buf.free() } }
+			defer { buf.free() }
 			mut capacity := initial_size
 			mut offset := 0
 


### PR DESCRIPTION
Fixes the following compile error:

```v
+ ./vlang-stage0 -cc gcc -d dynamic_boehm -no-parallel -o vlang-stage1 cmd/v
vlib/os/os.c.v:534:12: error: already inside `unsafe` block
             initial_size := 256 * wide_char_size
             mut buf := malloc_noscan(initial_size)
             defer { unsafe { buf.free() } }
                     ~~~~~~
             mut capacity := initial_size
             mut offset := 0
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
