### PR TITLE
v.ast: add Table.update_sym_by_idx/2

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -840,6 +840,7 @@ fn (mut t Table) rewrite_already_registered_symbol(typ TypeSymbol, existing_idx 
 	$if trace_rewrite_already_registered_symbol ? {
 		eprintln('>> rewrite_already_registered_symbol sym: ${typ.name} | existing_idx: ${existing_idx} | existing_symbol: ${existing_symbol.name}')
 	}
+	t.delete_cached_type_to_str(idx_to_type(existing_idx), map[string]string{})
 	if existing_symbol.kind == .placeholder {
 		// override placeholder
 		t.type_symbols[existing_idx] = &TypeSymbol{

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -840,7 +840,7 @@ fn (mut t Table) rewrite_already_registered_symbol(typ TypeSymbol, existing_idx 
 	$if trace_rewrite_already_registered_symbol ? {
 		eprintln('>> rewrite_already_registered_symbol sym: ${typ.name} | existing_idx: ${existing_idx} | existing_symbol: ${existing_symbol.name}')
 	}
-	t.delete_cached_type_to_str(idx_to_type(existing_idx), map[string]string{})
+	t.delete_cached_type_to_str(idx_to_type(existing_idx), 0)
 	if existing_symbol.kind == .placeholder {
 		// override placeholder
 		t.type_symbols[existing_idx] = &TypeSymbol{
@@ -874,7 +874,13 @@ fn (mut t Table) rewrite_already_registered_symbol(typ TypeSymbol, existing_idx 
 		}
 		return existing_idx
 	}
-	return invalid_type_idx
+
+	// allow override other already registered types
+	t.type_symbols[existing_idx] = &TypeSymbol{
+		...typ
+		idx: existing_idx
+	}
+	return existing_idx
 }
 
 @[inline]

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -835,12 +835,20 @@ pub fn (t &Table) unaliased_type(typ Type) Type {
 	return typ
 }
 
+// update_sym updates the `existing_idx` sym with new `typ`
+pub fn (mut t Table) update_sym(typ TypeSymbol, existing_idx int) {
+	t.delete_cached_type_to_str(idx_to_type(existing_idx), 0)
+	t.type_symbols[existing_idx] = &TypeSymbol{
+		...typ
+		idx: existing_idx
+	}
+}
+
 fn (mut t Table) rewrite_already_registered_symbol(typ TypeSymbol, existing_idx int) int {
 	existing_symbol := t.type_symbols[existing_idx]
 	$if trace_rewrite_already_registered_symbol ? {
 		eprintln('>> rewrite_already_registered_symbol sym: ${typ.name} | existing_idx: ${existing_idx} | existing_symbol: ${existing_symbol.name}')
 	}
-	t.delete_cached_type_to_str(idx_to_type(existing_idx), 0)
 	if existing_symbol.kind == .placeholder {
 		// override placeholder
 		t.type_symbols[existing_idx] = &TypeSymbol{
@@ -874,13 +882,7 @@ fn (mut t Table) rewrite_already_registered_symbol(typ TypeSymbol, existing_idx 
 		}
 		return existing_idx
 	}
-
-	// allow override other already registered types
-	t.type_symbols[existing_idx] = &TypeSymbol{
-		...typ
-		idx: existing_idx
-	}
-	return existing_idx
+	return invalid_type_idx
 }
 
 @[inline]

--- a/vlib/v/ast/table_test.v
+++ b/vlib/v/ast/table_test.v
@@ -5,7 +5,7 @@ import v.ast
 
 type T001 = [47]int
 
-fn test_rewrite_already_registered_symbol() {
+fn test_update_sym() {
 	// we will update the `size` & `size_expr` in sym.info for `T001`
 	mut pref_ := pref.new_preferences()
 	$if x64 {
@@ -29,7 +29,7 @@ fn test_rewrite_already_registered_symbol() {
 	old_info := old_sym.info as ast.ArrayFixed
 	dump(old_info)
 
-	// update the existing sym by calling `register_sym()` again
+	// update the existing sym
 	new_info := ast.ArrayFixed{
 		...old_info
 		size:      100
@@ -40,7 +40,7 @@ fn test_rewrite_already_registered_symbol() {
 		...old_sym
 		info: new_info
 	}
-	t.register_sym(new_sym) // call `rewrite_already_registered_symbol()` internally
+	t.update_sym(new_sym, typ)
 	new_str := t.type_to_str(typ)
 	dump(new_str)
 	assert new_str == '[100]int'

--- a/vlib/v/ast/table_test.v
+++ b/vlib/v/ast/table_test.v
@@ -1,47 +1,52 @@
-import v.builder
-import v.parser
-import v.pref
 import v.ast
+import v.pref
+import v.parser
 
-type T001 = [47]int
-
-fn test_update_sym() {
+fn test_update_sym_by_idx() {
+	old_size := 47
+	new_size := 100
+	b_old_size := 4 * old_size
+	b_new_size := 4 * new_size
+	source := 'type T001 = [${old_size}]u32' // u32 is an element type, with a known size, that is not going to change in the future, unlike int
 	// we will update the `size` & `size_expr` in sym.info for `T001`
-	mut pref_ := pref.new_preferences()
-	$if x64 {
-		pref_.m64 = true
-	}
-	mut b := builder.new_builder(pref_)
-	mut files := b.get_builtin_files()
-	b.set_module_lookup_paths()
-	parser.parse_files(files, mut b.table, b.pref)
-	b.parse_imports()
-	parser.parse_file(@FILE, mut b.table, .parse_comments, b.pref)
+	mut t := ast.new_table()
+	parser.parse_text(source, '', mut t, .parse_comments, pref.new_preferences())
 
-	mut t := b.table
-
-	// retrieve old sym first
-	typ := t.type_idxs['[47]int']!
+	// retrieve old sym first:
+	typ := t.type_idxs['[${old_size}]u32']!
 	old_str := t.type_to_str(typ)
-	dump(old_str)
-	assert old_str == '[47]int'
+	assert old_str == '[${old_size}]u32'
 	old_sym := t.sym(typ)
 	old_info := old_sym.info as ast.ArrayFixed
-	dump(old_info)
+
+	alias_typ := t.type_idxs['main.T001']!
+	alias_str := t.type_to_str(alias_typ)
+	assert alias_str == 'main.T001'
+	// make sure that the alias type had the correct size before the change (the size is stored in the alias type symbol)
+	alias_size, _ := t.type_size(alias_typ)
+	assert alias_size == b_old_size
+	alias_sym := t.sym(alias_typ)
+	assert (alias_sym.info as ast.Alias).parent_type == typ
+	assert alias_sym.size == b_old_size
 
 	// update the existing sym
 	new_info := ast.ArrayFixed{
 		...old_info
-		size:      100
+		size:      new_size
 		size_expr: ast.empty_expr
 	}
-	dump(new_info)
 	new_sym := ast.TypeSymbol{
 		...old_sym
 		info: new_info
 	}
-	t.update_sym(new_sym, typ)
+	t.update_sym_by_idx(typ, new_sym)
 	new_str := t.type_to_str(typ)
-	dump(new_str)
-	assert new_str == '[100]int'
+	assert new_str == '[${new_size}]u32'
+
+	// check again the alias size (it should be indirectly changed as well):
+	new_alias_sym := t.sym(alias_typ)
+	assert new_alias_sym.size == -1
+	new_alias_size, _ := t.type_size(alias_typ)
+	assert new_alias_size == b_new_size
+	assert new_alias_sym.size == b_new_size // make sure that `new_alias_sym` is now updated too (since it is a pointer to a symbol value stored in the table)
 }

--- a/vlib/v/ast/table_test.v
+++ b/vlib/v/ast/table_test.v
@@ -1,0 +1,47 @@
+import v.builder
+import v.parser
+import v.pref
+import v.ast
+
+type T001 = [47]int
+
+fn test_rewrite_already_registered_symbol() {
+	// we will update the `size` & `size_expr` in sym.info for `T001`
+	mut pref_ := pref.new_preferences()
+	$if x64 {
+		pref_.m64 = true
+	}
+	mut b := builder.new_builder(pref_)
+	mut files := b.get_builtin_files()
+	b.set_module_lookup_paths()
+	parser.parse_files(files, mut b.table, b.pref)
+	b.parse_imports()
+	parser.parse_file(@FILE, mut b.table, .parse_comments, b.pref)
+
+	mut t := b.table
+
+	// retrieve old sym first
+	typ := t.type_idxs['[47]int']!
+	old_str := t.type_to_str(typ)
+	dump(old_str)
+	assert old_str == '[47]int'
+	old_sym := t.sym(typ)
+	old_info := old_sym.info as ast.ArrayFixed
+	dump(old_info)
+
+	// update the existing sym by calling `register_sym()` again
+	new_info := ast.ArrayFixed{
+		...old_info
+		size:      100
+		size_expr: ast.empty_expr
+	}
+	dump(new_info)
+	new_sym := ast.TypeSymbol{
+		...old_sym
+		info: new_info
+	}
+	t.register_sym(new_sym) // call `rewrite_already_registered_symbol()` internally
+	new_str := t.type_to_str(typ)
+	dump(new_str)
+	assert new_str == '[100]int'
+}

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1460,8 +1460,8 @@ fn strip_extra_struct_types(name string) string {
 }
 
 // delete_cached_type_to_str remove a `type_to_str` from the cache
-pub fn (t &Table) delete_cached_type_to_str(typ Type, import_aliases map[string]string) {
-	cache_key := (u64(import_aliases.len) << 32) | u64(typ)
+pub fn (t &Table) delete_cached_type_to_str(typ Type, import_aliases_len int) {
+	cache_key := (u64(import_aliases_len) << 32) | u64(typ)
 	mut mt := unsafe { &Table(t) }
 	lock mt.cached_type_to_str {
 		mt.cached_type_to_str.delete(cache_key)

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1459,6 +1459,15 @@ fn strip_extra_struct_types(name string) string {
 	}
 }
 
+// delete_cached_type_to_str remove a `type_to_str` from the cache
+pub fn (t &Table) delete_cached_type_to_str(typ Type, import_aliases map[string]string) {
+	cache_key := (u64(import_aliases.len) << 32) | u64(typ)
+	mut mt := unsafe { &Table(t) }
+	lock mt.cached_type_to_str {
+		mt.cached_type_to_str.delete(cache_key)
+	}
+}
+
 // import_aliases is a map of imported symbol aliases 'module.Type' => 'Type'
 pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]string) string {
 	cache_key := (u64(import_aliases.len) << 32) | u64(typ)


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Allow update existing symbol via call `update_sym()`.


a use case:
To support the new array syntax, we need to update the fixed-arrays size after scan the array lit. For example, 
```v
[..][..]int[[1 2][3 4]]
```
When parse this, we don't known the size of the fixed-array first, but register a `[-1][-1]int` symbol in the system.
 And then after scan the array lit, `[[1 2][3 4]]`, we can update the existing `[-1][-1]int` symbol to `[2][2]int`.
