### PR TITLE
os: propagate POSIX error code from os.ls/1 and os.rmdir_all/1 on UNIX-like systems

### DIFF
--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -226,19 +226,29 @@ pub fn sigint_to_signal_name(si int) string {
 
 // rmdir_all recursively removes the specified directory.
 pub fn rmdir_all(path string) ! {
-	mut ret_err := ''
+	mut err_msg := ''
+	mut err_code := -1
 	items := ls(path)!
 	for item in items {
 		fullpath := join_path_single(path, item)
 		if is_dir(fullpath) && !is_link(fullpath) {
-			rmdir_all(fullpath) or { ret_err = err.msg() }
+			rmdir_all(fullpath) or {
+				err_msg = err.msg()
+				err_code = err.code()
+			}
 		} else {
-			rm(fullpath) or { ret_err = err.msg() }
+			rm(fullpath) or {
+				err_msg = err.msg()
+				err_code = err.code()
+			}
 		}
 	}
-	rmdir(path) or { ret_err = err.msg() }
-	if ret_err.len > 0 {
-		return error(ret_err)
+	rmdir(path) or {
+		err_msg = err.msg()
+		err_code = err.code()
+	}
+	if err_msg != '' {
+		return error_with_code(err_msg, err_code)
 	}
 }
 

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -282,11 +282,9 @@ pub fn ls(path string) ![]string {
 	mut res := []string{cap: 50}
 	dir := unsafe { C.opendir(&char(path.str)) }
 	if isnil(dir) {
-		// return error_with_code('ls() couldnt open dir "${path}"', C.errno)
 		return error_posix(msg: 'ls() couldnt open dir "${path}"')
 	}
 	mut ent := &C.dirent(unsafe { nil })
-	// mut ent := &C.dirent{!}
 	for {
 		ent = C.readdir(dir)
 		if isnil(ent) {

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -282,7 +282,8 @@ pub fn ls(path string) ![]string {
 	mut res := []string{cap: 50}
 	dir := unsafe { C.opendir(&char(path.str)) }
 	if isnil(dir) {
-		return error('ls() couldnt open dir "${path}"')
+		// return error_with_code('ls() couldnt open dir "${path}"', C.errno)
+		return error_posix(msg: 'ls() couldnt open dir "${path}"')
 	}
 	mut ent := &C.dirent(unsafe { nil })
 	// mut ent := &C.dirent{!}


### PR DESCRIPTION
Return the error code from `os.ls/1` and `os.mkdir_all/1` to enable detailed error handling e.g. you can now differ ENOENT (no such file or directory) and other possible I/O errors:

```
>>> os.ls('/nonexistent') or { println(err.code()) }
2
>>> os.rmdir_all('/nonexistent') or { println(err.code()) }
2
```