### PR TITLE
net.websocket: fix incorrect formatting for custom headers during handshake

### DIFF
--- a/vlib/net/websocket/handshake.v
+++ b/vlib/net/websocket/handshake.v
@@ -24,7 +24,7 @@ fn (mut ws Client) handshake() ! {
 	sb.write_string('\r\nSec-WebSocket-Version: 13')
 	for key in ws.header.keys() {
 		val := ws.header.custom_values(key).join(',')
-		sb.write_string('\r\n${key}:${val}')
+		sb.write_string('\r\n${key}: ${val}')
 	}
 	sb.write_string('\r\n\r\n')
 	handshake := sb.str()


### PR DESCRIPTION
fix that makes custom headers during ws client handshake actually valid

if for example a server requires the `Origin` header to be set, before this fix, said server would've denied the connection even if the value was correct and the header was there, just because the header isn't valid, but now since it's valid it no longer fails

i didn't make a specific test for this fix in particular because it just adds a space to a string and the only valid testing option i know of is a very specific domain (not local) and i wouldn't want to have an external connection in a test like that