### PR TITLE
parser: fix eval fixed array size

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -388,6 +388,9 @@ fn (mut c Checker) eval_array_fixed_sizes(mut size_expr ast.Expr, size int, elem
 					ast.IntegerLiteral {
 						fixed_size = size_expr.expr.val.int()
 					}
+					ast.FloatLiteral {
+						fixed_size = int(size_expr.expr.val.f64())
+					}
 					ast.EnumVal {
 						if val := c.table.find_enum_field_val(size_expr.expr.enum_name,
 							size_expr.expr.val)

--- a/vlib/v/tests/complex_dim_fixed_array_test.v
+++ b/vlib/v/tests/complex_dim_fixed_array_test.v
@@ -1,0 +1,10 @@
+const k = 2
+
+fn test_complex_dim_fixed_array() {
+	result := [[0, 0]!, [0, 0]!]!
+
+	assert result == [2][k]int{}
+	assert result == [2][k + 1 - 1]int{}
+	assert result == [k][(k + 1) * 2 - 4]int{}
+	assert result == [k][int(k)]int{}
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #25404

BTW, I think we should remove `eval_array_fixed_sizes()` from `parser`. Because in `parser`, it has no full information, for example, `[2][const_a - sizeof(T)]int{}`, `sizeof(T)` is ready in `checker`. And `checker` also has it's own `eval_array_fixed_sizes()`.