### PR TITLE
native: array with values

### DIFF
--- a/vlib/builtin/builtin.c.v
+++ b/vlib/builtin/builtin.c.v
@@ -682,6 +682,8 @@ pub fn vcalloc(n isize) &u8 {
 	}
 	$if prealloc {
 		return unsafe { prealloc_calloc(n) }
+	} $else $if native {
+		return unsafe { C.calloc(1, n) }
 	} $else $if gcboehm ? {
 		return unsafe { &u8(C.GC_MALLOC(n)) }
 	} $else {

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -809,8 +809,14 @@ fn (mut g Gen) get_var_offset(var_name string) i32 {
 fn (mut g Gen) get_field_offset(in_type ast.Type, name string) i32 {
 	typ := g.unwrap(in_type)
 	ts := g.table.sym(typ)
-	field := ts.find_field(name) or {
-		g.n_error('${@LOCATION} Could not find field `${name}` on init')
+	field := if ts.kind == .array {
+		g.table.sym(ast.array_type).find_field(name) or {
+			g.n_error('${@LOCATION} Could not find field `${name}` on init ${g.table.sym(ast.array_type)}')
+		}
+	} else {
+		ts.find_field(name) or {
+			g.n_error('${@LOCATION} Could not find field `${name}` on init')
+		}
 	}
 	return g.structs[typ.idx()].offsets[field.i]
 }

--- a/vlib/v/gen/native/gen.v
+++ b/vlib/v/gen/native/gen.v
@@ -814,9 +814,7 @@ fn (mut g Gen) get_field_offset(in_type ast.Type, name string) i32 {
 			g.n_error('${@LOCATION} Could not find field `${name}` on init ${g.table.sym(ast.array_type)}')
 		}
 	} else {
-		ts.find_field(name) or {
-			g.n_error('${@LOCATION} Could not find field `${name}` on init')
-		}
+		ts.find_field(name) or { g.n_error('${@LOCATION} Could not find field `${name}` on init') }
 	}
 	return g.structs[typ.idx()].offsets[field.i]
 }

--- a/vlib/v/gen/native/tests/arrays.vv
+++ b/vlib/v/gen/native/tests/arrays.vv
@@ -1,5 +1,10 @@
 fn main() {
 	assert [1, 2, 3] != []
+	array_with_len()
+	array_with_values()
+}
+
+fn array_with_len() {
 	len := 20
 	mut my_array := []int{len:20}
 	for i in 0 .. len {
@@ -24,4 +29,30 @@ fn main() {
 	}
 	assert my_array.len == len
 	assert my_array.cap == len
+}
+
+fn array_with_values() {
+	mut arr := [2, 4, 8, 16, 32, 64, 128]
+	assert arr[0] == 2
+	assert arr[1] == 4
+	assert arr[2] == 8
+	assert arr[3] == 16
+	assert arr[4] == 32
+	assert arr[5] == 64
+	assert arr[6] == 128
+	// below taken from builtin/array_test.v
+	arr[0] = 2
+	arr[1] &= 255
+	arr[2] |= 255
+	arr[3] <<= 4
+	arr[4] >>= 4
+	arr[5] %= 5
+	arr[6] ^= 3
+	assert arr[0] == 2
+	assert arr[1] == 4 & 255
+	assert arr[2] == 8 | 255
+	assert arr[3] == 16 << 4
+	assert arr[4] == 32 >> 4
+	assert arr[5] == 64 % 5
+	assert arr[6] == 128 ^ 3
 }

--- a/vlib/v/gen/native/tests/arrays.vv
+++ b/vlib/v/gen/native/tests/arrays.vv
@@ -1,6 +1,13 @@
 fn main() {
 	assert [1, 2, 3] != []
-	mut my_array := []int{len:3}
+	len := 20
+	mut my_array := []int{len:20}
+	for i in 0 .. len {
+		assert my_array[i] == 0	
+		unsafe {
+			assert &int(my_array.data)[i] == 0
+		}
+	}
 	my_array[0] = 4
 	my_array[1] = 5
 	my_array[2] = 6
@@ -10,4 +17,11 @@ fn main() {
 	assert my_array[0] == 4
 	assert my_array[1] == 5
 	assert my_array[2] == 6
+	unsafe {
+		assert &int(my_array.data)[0] == 4
+		assert &int(my_array.data)[1] == 5
+		assert &int(my_array.data)[2] == 6
+	}
+	assert my_array.len == len
+	assert my_array.cap == len
 }


### PR DESCRIPTION
- fix array behavior from previous pr and improve the tests
- add support for `a := [1, 2, 3, 4]`


for the change in `builtin/builtin.c.v` in `vcalloc` it is the same issue as last PR, the default compile time branch does not get generated