### PR TITLE
checker: always use ... prefix when passing array to vararg

### DIFF
--- a/vlib/v/checker/tests/sumtype_array_to_variadic.out
+++ b/vlib/v/checker/tests/sumtype_array_to_variadic.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/sumtype_array_to_variadic.vv:32:9: error: to pass `kv_pairs` ([]Value) to `Map__static__create` (which accepts type `...Value`), use `...kv_pairs`
+   30 |     }
+   31 |     assert kv_pairs.len % 2 == 0
+   32 |     return Map.create(kv_pairs)
+      |            ~~~~~~~~~~~~~~~~~~~~
+   33 | }
+   34 |

--- a/vlib/v/checker/tests/sumtype_array_to_variadic.vv
+++ b/vlib/v/checker/tests/sumtype_array_to_variadic.vv
@@ -1,0 +1,38 @@
+type Nil = u8
+
+const c_nil = Nil(`\0`)
+
+pub type Value = Nil | int | string | []Value | Map
+
+pub fn (v Value) string() string {
+	return '${v.str()}'
+}
+
+pub struct Map {
+mut:
+	m map[string]Value
+}
+
+pub fn Map.create(values ...Value) Map {
+	assert values.len > 1
+	assert values.len % 2 == 0
+	mut m := Map{}
+	for i := 0; i < values.len; i += 2 {
+		m.m[values[i].string()] = values[i + 1]
+	}
+	return m
+}
+
+pub fn build_map(index_from int, index_to int) Map {
+	mut kv_pairs := []Value{len: index_to - index_from, init: Value(c_nil)}
+	for i := index_from; i < index_to; i++ {
+		kv_pairs[i - index_from] = Value(i)
+	}
+	assert kv_pairs.len % 2 == 0
+	return Map.create(kv_pairs)
+}
+
+fn main() {
+	m := build_map(2, 4)
+	_ = m
+}

--- a/vlib/v/tests/fns/call_args_variadic_sumtype_test.v
+++ b/vlib/v/tests/fns/call_args_variadic_sumtype_test.v
@@ -20,5 +20,5 @@ fn test_main() {
 	}
 	mut animals := []Animal{}
 	animals << cat
-	print_names(animals)
+	print_names(...animals)
 }

--- a/vlib/v/tests/fns/variadic_sumtype_test.v
+++ b/vlib/v/tests/fns/variadic_sumtype_test.v
@@ -14,6 +14,11 @@ fn div(params ...Either) int {
 	return tag(params)
 }
 
+fn div2(params ...Either) int {
+	return tag(...params)
+}
+
 fn test_main() {
 	assert dump(div('foo', 1, 2)) == 3
+	assert dump(div2(6, -2, 'hello', 10)) == 14
 }


### PR DESCRIPTION
Fixes #25424.

When passing an array of sumtype to a function taking a vararg, the `...` prefix was not required which caused a cgen error. 
This makes sure the `...` prefix is required for arrays.

The check is a bit long so let me know if there's a simpler way. 