### PR TITLE
cgen: fix builtin__closure__closure_init() before vinit() in -shared

### DIFF
--- a/vlib/v/checker/tests/wrong_struct_declare1_err.out
+++ b/vlib/v/checker/tests/wrong_struct_declare1_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/wrong_struct_declare1_err.vv:5:13: error: unexpected name `foos`, expecting `:`
+    3 | 
+    4 | struct Bar {
+    5 |         mut foos []Foo
+      |             ~~~~
+    6 | }

--- a/vlib/v/checker/tests/wrong_struct_declare1_err.vv
+++ b/vlib/v/checker/tests/wrong_struct_declare1_err.vv
@@ -1,0 +1,6 @@
+struct Foo {
+}
+
+struct Bar {
+        mut foos []Foo
+}

--- a/vlib/v/checker/tests/wrong_struct_declare2_err.out
+++ b/vlib/v/checker/tests/wrong_struct_declare2_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/wrong_struct_declare2_err.vv:5:16: error: unexpected name `foos`, expecting `:`
+    3 | 
+    4 | struct Bar {
+    5 |         module foos []Foo
+      |                ~~~~
+    6 | }

--- a/vlib/v/checker/tests/wrong_struct_declare2_err.vv
+++ b/vlib/v/checker/tests/wrong_struct_declare2_err.vv
@@ -1,0 +1,6 @@
+struct Foo {
+}
+
+struct Bar {
+        module foos []Foo
+}

--- a/vlib/v/checker/tests/wrong_struct_declare3_err.out
+++ b/vlib/v/checker/tests/wrong_struct_declare3_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/wrong_struct_declare3_err.vv:5:18: error: unexpected name `foos`, expecting `:`
+    3 | 
+    4 | struct Bar {
+    5 |         __global foos []Foo
+      |                  ~~~~
+    6 | }

--- a/vlib/v/checker/tests/wrong_struct_declare3_err.vv
+++ b/vlib/v/checker/tests/wrong_struct_declare3_err.vv
@@ -1,0 +1,6 @@
+struct Foo {
+}
+
+struct Bar {
+        __global foos []Foo
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6798,9 +6798,6 @@ fn (mut g Gen) write_init_function() {
 		g.export_funcs << '_vinit_caller'
 		g.writeln('void _vinit_caller() {')
 		g.writeln('\tstatic bool once = false; if (once) {return;} once = true;')
-		if g.nr_closures > 0 {
-			g.writeln('\tbuiltin__closure__closure_init(); // vinit_caller()')
-		}
 		g.writeln('\t_vinit(0,0);')
 		g.writeln('}')
 

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -166,7 +166,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 					is_field_global = false
 				}
 				p.check(.colon)
-			} else if p.tok.kind == .key_mut && p.peek_tok.kind == .colon {
+			} else if p.tok.kind == .key_mut {
 				if mut_pos != -1 {
 					p.error('redefinition of `mut` section')
 					return ast.StructDecl{}
@@ -177,7 +177,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				is_field_pub = false
 				is_field_mut = true
 				is_field_global = false
-			} else if p.tok.kind == .key_global && p.peek_tok.kind == .colon {
+			} else if p.tok.kind == .key_global {
 				if global_pos != -1 {
 					p.error('redefinition of `global` section')
 					return ast.StructDecl{}
@@ -188,7 +188,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				is_field_pub = true
 				is_field_mut = true
 				is_field_global = true
-			} else if p.tok.kind == .key_module && p.peek_tok.kind == .colon {
+			} else if p.tok.kind == .key_module {
 				if module_pos != -1 {
 					p.error('redefinition of `module` section')
 					return ast.StructDecl{}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #25417

Remove `builtin__closure__closure_init()` from `-shared` before `vinit()`, as it is called inside `vinit()`.