### PR TITLE
x.crypto.poly1305: makes a Poly1305 as a public

### DIFF
--- a/vlib/x/crypto/poly1305/poly1305.v
+++ b/vlib/x/crypto/poly1305/poly1305.v
@@ -42,7 +42,8 @@ const p = Uint192{
 }
 
 // Poly1305 mac instance
-struct Poly1305 {
+@[noinit]
+pub struct Poly1305 {
 mut:
 	// Poly1305 mac accepts 32 bytes (256 bits) of key input.
 	// This key is partitioned into two's 128 bits parts, r and s
@@ -116,6 +117,19 @@ pub fn new(key []u8) !&Poly1305 {
 	return ctx
 }
 
+// clone returns the clone of the current Poly1305 state
+pub fn (po &Poly1305) clone() &Poly1305 {
+	poc := &Poly1305{
+		r:        po.r
+		s:        po.s
+		h:        po.h
+		buffer:   po.buffer
+		leftover: po.leftover
+		done:     po.done
+	}
+	return poc
+}
+
 // update updates internal of Poly1305 state by message.
 pub fn (mut po Poly1305) update(msg []u8) {
 	poly1305_update_block(mut po, msg)
@@ -170,7 +184,7 @@ pub fn (mut po Poly1305) reinit(key []u8) {
 	po.done = false
 }
 
-// poly1305_update_block updates the internals of Poly105 state instance by block of message.
+// poly1305_update_block updates the internals of Poly1305 state instance by block of message.
 fn poly1305_update_block(mut po Poly1305, msg []u8) {
 	if msg.len == 0 {
 		return


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

While working on a nonce-misuse resistent support for `x.crypto.chacha20poly1305`, we need `poly1305.Poly1305` accessible outside the module. There are several cases where its need publicly availables, one of them was several nonce-misuse and key-commiting aead construct. while at this time its a private opaque.
This small patch makes a `Poly1305` structure as a publicly availables to user while still tagged as `@[noinit]`, so you should make it  through the `new` constructor. and also adds a `clone` method to the opaque.

Thanks
cheers