### PR TITLE
transformer: eval par expr for literal and ident

### DIFF
--- a/vlib/v/transformer/tests/const_infix_expr_test.v
+++ b/vlib/v/transformer/tests/const_infix_expr_test.v
@@ -4,12 +4,12 @@ import v.parser
 import v.checker
 import v.transformer
 
-fn test_const_infix_expr() {
+fn test_const_par_expr_and_infix_expr() {
 	println(@LOCATION)
 	source_text := '
 const k = 2
 fn main() {
-	x := [(k-1)*2]int{}
+	x := [(k+1)-2+(2*(k))]int{}
 }
 '
 	mut table := ast.new_table()
@@ -19,15 +19,15 @@ fn main() {
 	checker_.check(mut prog)
 	mut t := transformer.new_transformer_with_table(table, vpref)
 
-	// get the `InfixExpr`(`(k-1)*2`) from table
-	main_fn := unsafe { table.cur_fn[0] }
+	// get the `InfixExpr`(`(k+1)-2+(2*(k))`) from table
+	main_fn := table.cur_fn
 	assign_stmt := main_fn.stmts[0] as ast.AssignStmt
 	array_init_expr := assign_stmt.right[0] as ast.ArrayInit
 	mut dim_expr := array_init_expr.exprs[0] as ast.InfixExpr
 	dump(dim_expr)
 
-	// verify `infix_expr` work as expected
+	// verify `infix_expr` and `par_expr` work as expected
 	folded_expr := t.infix_expr(mut dim_expr)
 	dump(folded_expr)
-	assert '${folded_expr}' == '(1) * 2'
+	assert '${folded_expr}' == '5'
 }

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -650,7 +650,18 @@ pub fn (mut t Transformer) expr(mut node ast.Expr) ast.Expr {
 			}
 		}
 		ast.ParExpr {
-			node.expr = t.expr(mut node.expr)
+			mut inner_expr := t.expr(mut node.expr)
+			if inner_expr in [
+				ast.IntegerLiteral,
+				ast.FloatLiteral,
+				ast.BoolLiteral,
+				ast.StringLiteral,
+				ast.StringInterLiteral,
+				ast.CharLiteral,
+				ast.Ident,
+			] {
+				return inner_expr
+			}
 		}
 		ast.PostfixExpr {
 			node.expr = t.expr(mut node.expr)


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Remove par when the inner expr is literal or ident.
This will folder const expr as expected.

I'm not sure if doing this has side effects? For example, in terms of syntax, parentheses might have new uses, such as `(k)` representing some special meaning. If we remove the parentheses, it might change the semantics.