### PR TITLE
x.crypto.chacha20: mark `State` as public to make it a reusable thing

### DIFF
--- a/vlib/x/crypto/chacha20/chacha_test.v
+++ b/vlib/x/crypto/chacha20/chacha_test.v
@@ -2,6 +2,39 @@ import rand
 import encoding.hex
 import x.crypto.chacha20
 
+// test for chacha20.State exposed api. The test material was taken from
+// Test Vector for the ChaCha20 Block Function ch 2.3.2. from RFC 8439 doc.
+// See https://datatracker.ietf.org/doc/html/rfc8439#section-2.3.2
+fn test_chacha20_state() ! {
+	// ChaCha state with the key setup.
+	s := chacha20.State([u32(0x61707865), 0x3320646e, 0x79622d32, 0x6b206574, 0x03020100, 0x07060504,
+		0x0b0a0908, 0x0f0e0d0c, 0x13121110, 0x17161514, 0x1b1a1918, 0x1f1e1d1c, 0x00000001,
+		0x09000000, 0x4a000000, 0x00000000]!)
+
+	// test for .clone
+	mut ws := s.clone()
+	for i := 0; i < 16; i++ {
+		assert s[i] == ws[i]
+	}
+	// After running 20 rounds (10 column rounds interleaved with 10 "diagonal rounds"),
+	// the ChaCha state looks like this:
+	expected := chacha20.State([u32(0x837778ab), 0xe238d763, 0xa67ae21e, 0x5950bb2f, 0xc4f2d0c7,
+		0xfc62bb2f, 0x8fa018fc, 0x3f5ec7b7, 0x335271c2, 0xf29489f3, 0xeabda8fc, 0x82e46ebd,
+		0xd19c12b4, 0xb04e16de, 0x9e83d0cb, 0x4e3c50a2]!)
+
+	// test .qround call
+	ws.qround(10)
+	for i := 0; i < 16; i++ {
+		assert ws[i] == expected[i]
+	}
+
+	// test for .reset call
+	ws.reset()
+	for i := 0; i < 16; i++ {
+		assert ws[i] == 0
+	}
+}
+
 // test for extended chacha20 construct with 64-bit counter support
 fn test_xchacha20_cipher_with_64_counter() ! {
 	key := rand.bytes(32)!

--- a/vlib/x/crypto/chacha20/stream.v
+++ b/vlib/x/crypto/chacha20/stream.v
@@ -217,9 +217,12 @@ fn (mut s Stream) keystream() ![]u8 {
 
 	// The remaining quarter rounds
 	//
-	// For standard and original variant, the first column-round was already precomputed,
-	// so, quarter-round number reduced by one, becomes 9
-	ws.qround(9)
+	// For standard variant, the first column-round was already precomputed,
+	// For original variant, its use full quarter round number.
+	//
+	// perform chacha20 quarter round n-times
+	n := if s.mode == .standard { 9 } else { default_qround_nr }
+	ws.qround(n)
 
 	// Adding the working state values with inital state values.
 	// We dont performs xor-ing here, its done on xor_key_stream and or keystream_full.

--- a/vlib/x/crypto/chacha20/xchacha.v
+++ b/vlib/x/crypto/chacha20/xchacha.v
@@ -52,23 +52,7 @@ fn hchacha20(key []u8, nonce []u8) ![]u8 {
 	x[15] = binary.little_endian_u32(nonce[12..16])
 
 	// After initialization, proceed through the ChaCha20 rounds as usual.
-	for i := 0; i < 10; i++ {
-		// Column round.
-		qround_on_state(mut x, 0, 4, 8, 12) // 0
-		qround_on_state(mut x, 1, 5, 9, 13) // 1
-		qround_on_state(mut x, 2, 6, 10, 14) // 2
-		qround_on_state(mut x, 3, 7, 11, 15) // 3
-
-		// Diagonal round.
-		//   0 \  1 \  2 \  3
-		//   5 \  6 \  7 \  4
-		//  10 \ 11 \  8 \  9
-		//  15 \ 12 \ 13 \ 14
-		qround_on_state(mut x, 0, 5, 10, 15)
-		qround_on_state(mut x, 1, 6, 11, 12)
-		qround_on_state(mut x, 2, 7, 8, 13)
-		qround_on_state(mut x, 3, 4, 9, 14)
-	}
+	x.qround(10)
 
 	// Once the 20 ChaCh20 rounds have been completed, the first 128 bits (16 bytes) and
 	// last 128 bits (16 bytes) of the ChaCha state (both little-endian) are

--- a/vlib/x/crypto/poly1305/poly1305.v
+++ b/vlib/x/crypto/poly1305/poly1305.v
@@ -42,7 +42,8 @@ const p = Uint192{
 }
 
 // Poly1305 mac instance
-struct Poly1305 {
+@[noinit]
+pub struct Poly1305 {
 mut:
 	// Poly1305 mac accepts 32 bytes (256 bits) of key input.
 	// This key is partitioned into two's 128 bits parts, r and s
@@ -116,6 +117,19 @@ pub fn new(key []u8) !&Poly1305 {
 	return ctx
 }
 
+// clone returns the clone of the current Poly1305 state
+pub fn (po &Poly1305) clone() &Poly1305 {
+	poc := &Poly1305{
+		r:        po.r
+		s:        po.s
+		h:        po.h
+		buffer:   po.buffer
+		leftover: po.leftover
+		done:     po.done
+	}
+	return poc
+}
+
 // update updates internal of Poly1305 state by message.
 pub fn (mut po Poly1305) update(msg []u8) {
 	poly1305_update_block(mut po, msg)
@@ -170,7 +184,7 @@ pub fn (mut po Poly1305) reinit(key []u8) {
 	po.done = false
 }
 
-// poly1305_update_block updates the internals of Poly105 state instance by block of message.
+// poly1305_update_block updates the internals of Poly1305 state instance by block of message.
 fn poly1305_update_block(mut po Poly1305, msg []u8) {
 	if msg.len == 0 {
 		return

--- a/vlib/x/crypto/poly1305/poly1305.v
+++ b/vlib/x/crypto/poly1305/poly1305.v
@@ -42,8 +42,7 @@ const p = Uint192{
 }
 
 // Poly1305 mac instance
-@[noinit]
-pub struct Poly1305 {
+struct Poly1305 {
 mut:
 	// Poly1305 mac accepts 32 bytes (256 bits) of key input.
 	// This key is partitioned into two's 128 bits parts, r and s
@@ -117,19 +116,6 @@ pub fn new(key []u8) !&Poly1305 {
 	return ctx
 }
 
-// clone returns the clone of the current Poly1305 state
-pub fn (po &Poly1305) clone() &Poly1305 {
-	poc := &Poly1305{
-		r:        po.r
-		s:        po.s
-		h:        po.h
-		buffer:   po.buffer
-		leftover: po.leftover
-		done:     po.done
-	}
-	return poc
-}
-
 // update updates internal of Poly1305 state by message.
 pub fn (mut po Poly1305) update(msg []u8) {
 	poly1305_update_block(mut po, msg)
@@ -184,7 +170,7 @@ pub fn (mut po Poly1305) reinit(key []u8) {
 	po.done = false
 }
 
-// poly1305_update_block updates the internals of Poly1305 state instance by block of message.
+// poly1305_update_block updates the internals of Poly105 state instance by block of message.
 fn poly1305_update_block(mut po Poly1305, msg []u8) {
 	if msg.len == 0 {
 		return


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

While have a working prototype implementation of `ChaCha20-Poly1305-PSIV` construct, its used an internal of `chacha20` by rewriting it as a new routine, makes it a duplicated in a lot places. I think its should be a public to make it reusable thing. See the working implementation of this construct at [here](https://github.com/blackshirt/v/blob/psiv/vlib/x/crypto/chacha20poly1305/psiv.v).
By making it accessible outside the module, its make possible to expand by new construction based on this state, like above psiv construct or possibility of [this](https://arxiv.org/pdf/2507.18157v11). This also mean reduces code duplication.

This patch was related to previously merged PR [#25438](https://github.com/vlang/v/pull/25438), but comes with the changes on the `chacha20` sides..
Its exposes some cores of the `chacha20` as public in the means of :

- exposes a `chacha20.State` into user, mainly as a new building-block tool
- exposes minimal api for this state, currently only `.clone`, `.reset` and fundamental quarter round `.qround`  routines.
- adjustment on the State-related thing.

There are construct availables outside that relies on `hchacha20`, but its not the concerns of this PR.

Thanks
Cheers