### PR TITLE
scanner: fix raw string ending withs backslash

### DIFF
--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1347,7 +1347,7 @@ pub fn (mut s Scanner) ident_string() string {
 		if n_cr_chars > 0 {
 			string_so_far = string_so_far.replace('\r', '')
 		}
-		if string_so_far.contains('\\\n') {
+		if !is_raw && string_so_far.contains('\\\n') {
 			lit = trim_slash_line_break(string_so_far)
 		} else {
 			lit = string_so_far

--- a/vlib/v/tests/raw_string_ending_withs_backslash_test.v
+++ b/vlib/v/tests/raw_string_ending_withs_backslash_test.v
@@ -1,0 +1,11 @@
+fn test_raw_string_ending_withs_backslack() {
+	str := r'line1 \
+	line2 \
+        line3\'
+
+	lines := str.split_into_lines()
+	assert lines.len == 3
+	assert lines[0] == 'line1 \\'
+	assert lines[1] == '\tline2 \\'
+	assert lines[2] == '        line3\\'
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #25455 

In raw string, should not remove the endings backslash.
