### PR TITLE
builtin: fix int.str_l() integer overflow

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -74,6 +74,14 @@ fn (nn int) str_l(max int) string {
 			return '0'
 		}
 
+		if n == min_i32 {
+			return '-2147483648'
+		}
+
+		if n == min_i64 {
+			return '-9223372036854775808'
+		}
+
 		mut is_neg := false
 		if n < 0 {
 			n = -n

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -74,12 +74,14 @@ fn (nn int) str_l(max int) string {
 			return '0'
 		}
 
-		if n == min_i32 {
-			return '-2147483648'
-		}
-
-		if n == min_i64 {
-			return '-9223372036854775808'
+		$if new_int ? && x64 {
+			if n == min_i64 {
+				return '-9223372036854775808'
+			}
+		} $else {
+			if n == min_i32 {
+				return '-2147483648'
+			}
 		}
 
 		mut is_neg := false

--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -74,6 +74,7 @@ fn (nn int) str_l(max int) string {
 			return '0'
 		}
 
+		// overflow protect
 		$if new_int ? && x64 {
 			if n == min_i64 {
 				return '-9223372036854775808'


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #25457 

test will be integrated in PR #25442 