### PR TITLE
checker: identify return on comptime generic match nested in if else

### DIFF
--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -445,11 +445,20 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 			}
 		}
 		first_iteration = false
-		if has_return := c.has_return(branch.stmts) {
-			if has_return {
+		if node.is_comptime {
+			// branches may not have been processed by c.stmts()
+			if has_top_return(branch.stmts) {
 				nbranches_with_return++
 			} else {
 				nbranches_without_return++
+			}
+		} else {
+			if has_return := c.has_return(branch.stmts) {
+				if has_return {
+					nbranches_with_return++
+				} else {
+					nbranches_without_return++
+				}
 			}
 		}
 	}

--- a/vlib/v/tests/comptime/comptime_match_generic_inside_if_test.v
+++ b/vlib/v/tests/comptime/comptime_match_generic_inside_if_test.v
@@ -1,0 +1,26 @@
+fn strange[T](a T, b T) T {
+	if a != 0 {
+		$match T {
+			u8 {
+				return a
+			}
+			i8 {
+				if a > 0 {
+					return a
+				} else {
+					return b
+				}
+			}
+			$else {
+				$compile_error('unknown')
+			}
+		}
+	} else {
+		return b
+	}
+}
+
+fn test_main() {
+	assert strange[u8](0, 1) == 1
+	assert strange[i8](0, 1) == 1
+}


### PR DESCRIPTION
Fixes #25461.

Checker was not correctly identifying returns being on all paths in the case where a comptime match was used on generics inside an if/else statement.

Included test used to output:

```v
code.v:1:1: error: missing return at end of function `strange`
    1 | fn strange[T](a T, b T) T {
      | ~~~~~~~~~~~~~~~~~~~~~~~~~
    2 |     if a != 0 {
    3 |         $match T {
```