### PR TITLE
thirdparty add macos arm64 bdwgc script

### DIFF
--- a/thirdparty/build_scripts/thirdparty-macos-arm64_bdwgc.sh
+++ b/thirdparty/build_scripts/thirdparty-macos-arm64_bdwgc.sh
@@ -39,14 +39,12 @@ echo "AOPS_LFLAGS=${AOPS_LFLAGS}"
 CC=$CC CFLAGS="-Os -mtune=generic -fPIC ${AOPS_CFLAGS}" LDFLAGS="-Os -fPIC ${AOPS_LFLAGS}" ./configure \
 	--disable-dependency-tracking \
 	--disable-docs \
-	--enable-handle-fork=yes \
-	--enable-rwlock \
-	--enable-threads=pthreads \
 	--enable-static \
 	--enable-shared=no \
-	--enable-parallel-mark \
 	--enable-single-obj-compilation \
 	--enable-gc-debug \
+	--enable-large-config \
+	--enable-cplusplus \
 	--with-libatomic-ops=yes \
 	--enable-sigrt-signals
 


### PR DESCRIPTION
- **thirdparty: add thirdparty-macos-arm64_bdwgc.sh (based on thirdparty-linux-amd64_bdwgc.sh)**
- **use /opt/homebrew/lib**
- **add pkg-config calls to retrieve the compilation options for libatomic_ops**
- **use the new AOPS env variables in the configure step**
- **change macos options, based on /opt/homebrew/Cellar/bdw-gc/8.2.8/.brew/bdw-gc.rb**