### PR TITLE
json2: add support for encoding embedded structs

### DIFF
--- a/vlib/x/json2/encode.v
+++ b/vlib/x/json2/encode.v
@@ -389,86 +389,110 @@ fn (mut encoder Encoder) cached_field_infos[T]() []EncoderFieldInfo {
 @[unsafe]
 fn (mut encoder Encoder) encode_struct[T](val T) {
 	encoder.output << `{`
-	field_infos := encoder.cached_field_infos[T]()
-	mut i := 0
-	mut is_first := true
-	$for field in T.fields {
-		field_info := field_infos[i]
-		i++
 
-		mut write_field := true
+	is_first := encoder.encode_struct_fields(val, true, [], '')
 
-		if field_info.is_skip {
-			write_field = false
-		} else {
-			value := val.$(field.name)
-
-			if field_info.is_omitempty {
-				$if value is $option {
-					write_field = check_not_empty(value) or { false }
-				} $else {
-					write_field = check_not_empty(value) or { false }
-				}
-			}
-
-			if !field_info.is_required {
-				$if value is $option {
-					if value == none {
-						write_field = false
-					}
-				}
-			}
-		}
-
-		$if field.indirections != 0 {
-			if val.$(field.name) == unsafe { nil } {
-				write_field = false
-			}
-		}
-
-		if write_field {
-			if is_first {
-				if encoder.prettify {
-					encoder.increment_level()
-				}
-				is_first = false
-			} else {
-				encoder.output << `,`
-			}
-			if encoder.prettify {
-				encoder.add_indent()
-			}
-
-			encoder.encode_string(field_info.key_name)
-
-			encoder.output << `:`
-			if encoder.prettify {
-				encoder.output << ` `
-			}
-
-			$if field is $option {
-				if val.$(field.name) == none {
-					unsafe { encoder.output.push_many(null_string.str, null_string.len) }
-				} else {
-					encoder.encode_value(val.$(field.name))
-				}
-			} $else $if field.indirections == 1 {
-				encoder.encode_value(*val.$(field.name))
-			} $else $if field.indirections == 2 {
-				encoder.encode_value(**val.$(field.name))
-			} $else $if field.indirections == 3 {
-				encoder.encode_value(***val.$(field.name))
-			} $else {
-				encoder.encode_value(val.$(field.name))
-			}
-		}
-	}
 	if encoder.prettify && !is_first {
 		encoder.decrement_level()
 		encoder.add_indent()
 	}
 
 	encoder.output << `}`
+}
+
+@[unsafe]
+fn (mut encoder Encoder) encode_struct_fields[T](val T, was_first bool, old_used_keys []string, prefix string) bool {
+	field_infos := encoder.cached_field_infos[T]()
+	mut i := 0
+	mut is_first := was_first
+	mut used_keys := old_used_keys
+
+	$for field in T.fields {
+		$if !field.is_embed {
+			field_info := field_infos[i]
+
+			mut write_field := true
+
+			if field_info.is_skip {
+				write_field = false
+			} else {
+				value := val.$(field.name)
+
+				if field_info.is_omitempty {
+					$if value is $option {
+						write_field = check_not_empty(value) or { false }
+					} $else {
+						write_field = check_not_empty(value) or { false }
+					}
+				}
+
+				if !field_info.is_required {
+					$if value is $option {
+						if value == none {
+							write_field = false
+						}
+					}
+				}
+			}
+
+			$if field.indirections != 0 {
+				if val.$(field.name) == unsafe { nil } {
+					write_field = false
+				}
+			}
+
+			if write_field {
+				if is_first {
+					if encoder.prettify {
+						encoder.increment_level()
+					}
+					is_first = false
+				} else {
+					encoder.output << `,`
+				}
+				if encoder.prettify {
+					encoder.add_indent()
+				}
+
+				if field_info.key_name in old_used_keys {
+					encoder.encode_string(prefix + field_info.key_name)
+				} else {
+					encoder.encode_string(field_info.key_name)
+					used_keys << field_info.key_name
+				}
+
+				encoder.output << `:`
+				if encoder.prettify {
+					encoder.output << ` `
+				}
+
+				$if field is $option {
+					if val.$(field.name) == none {
+						unsafe { encoder.output.push_many(null_string.str, null_string.len) }
+					} else {
+						encoder.encode_value(val.$(field.name))
+					}
+				} $else $if field.indirections == 1 {
+					encoder.encode_value(*val.$(field.name))
+				} $else $if field.indirections == 2 {
+					encoder.encode_value(**val.$(field.name))
+				} $else $if field.indirections == 3 {
+					encoder.encode_value(***val.$(field.name))
+				} $else {
+					encoder.encode_value(val.$(field.name))
+				}
+			}
+		}
+		i++
+	}
+	$for field in T.fields {
+		$if field.is_embed {
+			new_prefix := prefix + field.name + '.'
+			is_first = encoder.encode_struct_fields(val.$(field.name), is_first, used_keys,
+				new_prefix)
+		}
+	}
+	return is_first
 }
 
 fn (mut encoder Encoder) encode_custom[T](val T) {

--- a/vlib/x/json2/tests/encode_embedded_structs_test.v
+++ b/vlib/x/json2/tests/encode_embedded_structs_test.v
@@ -1,0 +1,28 @@
+import x.json2 as json
+
+struct Baz {
+	c bool = true
+}
+
+struct Foo {
+	Baz
+	a int = 1
+	b int = 2
+}
+
+struct Bar {
+	Foo
+	a string = '1'
+	c string = '3'
+}
+
+fn test_embed() {
+	assert json.encode(Bar{}) == '{"a":"1","c":"3","Foo.a":1,"b":2,"Foo.Baz.c":true}'
+	assert json.encode(Bar{}, prettify: true) == '{
+    "a": "1",
+    "c": "3",
+    "Foo.a": 1,
+    "b": 2,
+    "Foo.Baz.c": true
+}'
+}


### PR DESCRIPTION
fix: #24994

```v
import x.json2 as json

struct Baz {
	c bool = true
}

struct Foo {
	Baz
	a int = 1
	b int = 2
}

struct Bar {
	Foo
	a string = '1'
	c string = '3'
}

fn main() {
	println(json.encode(Bar{})) // {"a":"1","c":"3","Foo.a":1,"b":2,"Foo.Baz.c":true}
}
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
