### PR TITLE
encoding.binary: switch away from cap arrays

### DIFF
--- a/vlib/encoding/binary/big_endian.v
+++ b/vlib/encoding/binary/big_endian.v
@@ -49,9 +49,9 @@ pub fn big_endian_put_u16_end(mut b []u8, v u16) {
 
 // big_endian_get_u16 creates u8 array from the unsigned 16-bit integer v in big endian order.
 pub fn big_endian_get_u16(v u16) []u8 {
-	mut b := []u8{cap: 2}
-	b << u8(v >> u16(8))
-	b << u8(v)
+	mut b := []u8{len: 2}
+	b[0] = u8(v >> u16(8))
+	b[1] = u8(v)
 	return b
 }
 
@@ -105,11 +105,11 @@ pub fn big_endian_put_u32_end(mut b []u8, v u32) {
 
 // big_endian_get_u32 creates u8 array from the unsigned 32-bit integer v in big endian order.
 pub fn big_endian_get_u32(v u32) []u8 {
-	mut b := []u8{cap: 4}
-	b << u8(v >> u32(24))
-	b << u8(v >> u32(16))
-	b << u8(v >> u32(8))
-	b << u8(v)
+	mut b := []u8{len: 4}
+	b[0] = u8(v >> u32(24))
+	b[1] = u8(v >> u32(16))
+	b[2] = u8(v >> u32(8))
+	b[3] = u8(v)
 	return b
 }
 
@@ -172,14 +172,14 @@ pub fn big_endian_put_u64_end(mut b []u8, v u64) {
 
 // big_endian_get_u64 creates u8 array from the unsigned 64-bit integer v in big endian order.
 pub fn big_endian_get_u64(v u64) []u8 {
-	mut b := []u8{cap: 8}
-	b << u8(v >> u64(56))
-	b << u8(v >> u64(48))
-	b << u8(v >> u64(40))
-	b << u8(v >> u64(32))
-	b << u8(v >> u64(24))
-	b << u8(v >> u64(16))
-	b << u8(v >> u64(8))
-	b << u8(v)
+	mut b := []u8{len: 8}
+	b[0] = u8(v >> u64(56))
+	b[1] = u8(v >> u64(48))
+	b[2] = u8(v >> u64(40))
+	b[3] = u8(v >> u64(32))
+	b[4] = u8(v >> u64(24))
+	b[5] = u8(v >> u64(16))
+	b[6] = u8(v >> u64(8))
+	b[7] = u8(v)
 	return b
 }

--- a/vlib/encoding/binary/little_endian.v
+++ b/vlib/encoding/binary/little_endian.v
@@ -49,9 +49,9 @@ pub fn little_endian_put_u16_end(mut b []u8, v u16) {
 
 // little_endian_get_u16 creates u8 array from the unsigned 16-bit integer v in little endian order.
 pub fn little_endian_get_u16(v u16) []u8 {
-	mut b := []u8{cap: 2}
-	b << u8(v)
-	b << u8(v >> u16(8))
+	mut b := []u8{len: 2}
+	b[0] = u8(v)
+	b[1] = u8(v >> u16(8))
 	return b
 }
 
@@ -105,11 +105,11 @@ pub fn little_endian_put_u32_end(mut b []u8, v u32) {
 
 // little_endian_get_u32 creates u8 array from the unsigned 32-bit integer v in little endian order.
 pub fn little_endian_get_u32(v u32) []u8 {
-	mut b := []u8{cap: 4}
-	b << u8(v)
-	b << u8(v >> u32(8))
-	b << u8(v >> u32(16))
-	b << u8(v >> u32(24))
+	mut b := []u8{len: 4}
+	b[0] = u8(v)
+	b[1] = u8(v >> u32(8))
+	b[2] = u8(v >> u32(16))
+	b[3] = u8(v >> u32(24))
 	return b
 }
 
@@ -182,14 +182,14 @@ pub fn little_endian_f32_at(b []u8, o int) f32 {
 
 // little_endian_get_u64 creates u8 array from the unsigned 64-bit integer v in little endian order.
 pub fn little_endian_get_u64(v u64) []u8 {
-	mut b := []u8{cap: 8}
-	b << u8(v)
-	b << u8(v >> u64(8))
-	b << u8(v >> u64(16))
-	b << u8(v >> u64(24))
-	b << u8(v >> u64(32))
-	b << u8(v >> u64(40))
-	b << u8(v >> u64(48))
-	b << u8(v >> u64(56))
+	mut b := []u8{len: 8}
+	b[0] = u8(v)
+	b[1] = u8(v >> u64(8))
+	b[2] = u8(v >> u64(16))
+	b[3] = u8(v >> u64(24))
+	b[4] = u8(v >> u64(32))
+	b[5] = u8(v >> u64(40))
+	b[6] = u8(v >> u64(48))
+	b[7] = u8(v >> u64(56))
 	return b
 }


### PR DESCRIPTION
Accidentally noticed `capped` arrays in the `encoding.binary` module. I have an allergy to capped arrays. Decided to play around with performance if switching to `len` and showing the numbers below:

`Reference code:`
```
import encoding.binary
import time

fn main() {
        t1 := time.now()
        for _ in 0..100_000 {
                _ = binary.little_endian_get_u64(max_u64)
        }
        println(time.since(t1))
}
```
`Machine 1: - 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz`
```
Alpine Linux 3.22

clang-22: 
   Master: 63.335ms
   Patch:   2.072ms

gcc-14:
   Master: 59.112ms
   Patch:   3.172ms
```
`Machine 2: - Intel(R) Core(TM) i7-4790K CPU @ 4.00GHz`
``` 
Debian 11

gcc-10:
   Master:  3.104ms 
   Patch: 779.034us
 ```

The numbers speak for themselves and I think this is a useful patch.
