### PR TITLE
parser: ensure @[deprecated_after] works without @[deprecated]

### DIFF
--- a/test_deprecated_with_date.v
+++ b/test_deprecated_with_date.v
@@ -1,0 +1,30 @@
+@[deprecated: '2025-10-10 !! use new function instead']
+fn d0() {}
+
+@[deprecated: '1234567890']
+fn d1() {}
+
+@[deprecated: '']
+fn d2() {}
+
+@[deprecated: 'a']
+fn d3() {}
+
+@[deprecated: 'lorem ipsum dolor sit']
+fn d4() {}
+
+@[deprecated: '2025-10-10!!close']
+fn d5() {}
+
+@[deprecated: ' 2025-10-10']
+fn d6() {}
+
+fn main() {
+	d0()
+	d1()
+	d2()
+	d3()
+	d4()
+	d5()
+	d6()
+}

--- a/vlib/v/checker/errors.v
+++ b/vlib/v/checker/errors.v
@@ -202,10 +202,15 @@ fn (mut c Checker) deprecate(kind string, name string, attrs []ast.Attr, pos tok
 		}
 		if attr.name == 'deprecated' {
 			deprecation_message = attr.arg
-		} else if attr.name == 'deprecated_after' {
-			after_time = time.parse_iso8601(attr.arg) or {
-				c.error('invalid time format', attr.pos)
-				now
+			left_trimmed := attr.arg.trim_left(' ')
+			if left, right := left_trimmed.split_once('!!') {
+				if t := time.parse_iso8601(left.trim_right(' ')) {
+					after_time = t
+					deprecation_message = right.trim_left(' ')
+				}
+			} else if t := time.parse_iso8601(left_trimmed.trim_right(' ')) {
+				after_time = t
+				deprecation_message = ''
 			}
 		}
 	}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -227,7 +227,7 @@ fn (mut p Parser) fn_decl() ast.FnDecl {
 			'manualfree' {
 				is_manualfree = true
 			}
-			'deprecated' {
+			'deprecated', 'deprecated_after' {
 				is_deprecated = true
 			}
 			'direct_array_access' {


### PR DESCRIPTION
Fixes #25471.

```v
@[deprecated: 'use d() instead']
fn d1() {
}

@[deprecated_after: '2025-10-10']
fn d2() {
}

@[deprecated: 'use d() instead']
@[deprecated_after: '2025-10-10']
fn d3() {
}

fn main() {
	d1()
	d2()
	d3()
}
```

Used to print:

```
❯ v run test.v
test.v:15:2: warning: function `d1` has been deprecated; use d() instead
   13 |
   14 | fn main() {
   15 |     d1()
      |     ~~~~
   16 |     d2()
   17 |     d3()
test.v:17:2: warning: function `d3` has been deprecated since 2025-10-10, it will be an error after 2026-04-08; use d() instead
   15 |     d1()
   16 |     d2()
   17 |     d3()
      |     ~~~~
   18 | }
```

Didn't add a test as this would change depending on the date which would be tricky.