### PR TITLE
os: fix real_path() and executable() for GetFinalPathNameByHandleW() return zero value

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -700,7 +700,7 @@ pub fn executable() string {
 				// https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfinalpathnamebyhandlew
 				final_len := C.GetFinalPathNameByHandleW(file, unsafe { &u16(&final_path[0]) },
 					max_path_buffer_size, 0)
-				if final_len < u32(max_path_buffer_size) {
+				if final_len < u32(max_path_buffer_size) && final_len != 0 {
 					sret := unsafe { string_from_wide2(&u16(&final_path[0]), int(final_len)) }
 					defer {
 						unsafe { sret.free() }
@@ -709,7 +709,7 @@ pub fn executable() string {
 					sret_slice := sret[4..]
 					res := sret_slice.clone()
 					return res
-				} else {
+				} else if final_len != 0 {
 					eprintln('os.executable() saw that the executable file path was too long')
 				}
 			}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #25482

When `GetFinalPathNameByHandleW()`return zero, it mean that the func can't get the real path. It need to fallback to default.
TODO: we only check `VOLUME_NAME_DOS(0)` flag, maybe also need to check `VOLUME_NAME_GUID(1)` flag too.