### PR TITLE
checker: fix vls autocomplete

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -448,7 +448,7 @@ pub fn (mut c Checker) check_files(ast_files []&ast.File) {
 			c.ident_gotodef()
 			exit(0)
 		}
-		if c.pref.linfo.expr.contains('()') {
+		if c.pref.linfo.expr.contains('()') || c.pref.linfo.expr.ends_with('(') {
 			c.autocomplete_for_fn_call_expr()
 			exit(0)
 		}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This PR enable `vls`(https://github.com/vlang/vls) autocomplete on modules pub funcs/enums/type alias/structs/consts.

And work with PR https://github.com/vlang/vls/pull/466

Make different kind of icon for different kind of objects:
<img width="551" height="291" src="https://github.com/user-attachments/assets/0495e4dd-fca2-47b7-91a3-7bb10a08708e" alt="image">

Also support module alias(`import time as t`)