### PR TITLE
json2: make decoder2 fns public

### DIFF
--- a/vlib/x/json2/decoder2/stub.v
+++ b/vlib/x/json2/decoder2/stub.v
@@ -2,14 +2,16 @@ module decoder2
 
 import x.json2
 
+// decode decodes a JSON string into a specified type.
 @[deprecated: '`decode` has been moved to `x.json2`, use `decode` from `x.json2` instead']
 @[deprecated_after: '2025-10-12']
 pub fn decode[T](val string) !T {
-	return json2.decode[T](val)
+	return json2.decode[T](val)!
 }
 
-@[deprecated: '`decode` has been moved to `x.json2`, use `decode` from `x.json2` instead']
+// decode_array decodes a JSON string into a specified type. This is the same as decode.
+@[deprecated: '`decode_array` has been moved to `x.json2`, use `decode` from `x.json2` instead']
 @[deprecated_after: '2025-03-18']
 pub fn decode_array[T](src string) !T {
-	return json2.decode[T](src)
+	return json2.decode[T](src)!
 }


### PR DESCRIPTION
https://github.com/vlang/v/commit/2d33a7f2819dd5fc1f4aa3b3ca0bcc660810d7af breaks programs that already uses `x.json2.decoder2` module. This PR fixes it.

```
main.v:173:15: warning: function `x.json2.decoder2.decode` has been deprecated since 2025-10-12, it will be an error after 2026-04-10; `decode` has been moved to `x.json2`, use `decode` from `x.json2` instead
  171 |     j := json.encode[item.Item](i, prettify: true, indent_string: '  ')
  172 |     println(j)
  173 |     d := decoder.decode[item.Item](j)!
      |                  ~~~~~~~~~~~~~~~~~~~~
  174 |     assert i == d
  175 | }
main.v:173:15: error: function `x.json2.decoder2.decode` is private
  171 |     j := json.encode[item.Item](i, prettify: true, indent_string: '  ')
  172 |     println(j)
  173 |     d := decoder.decode[item.Item](j)!
      |                  ~~~~~~~~~~~~~~~~~~~~
  174 |     assert i == d
  175 | }
```