### PR TITLE
example/viewer: Handle window closure in event manager

### DIFF
--- a/examples/viewer/view.v
+++ b/examples/viewer/view.v
@@ -607,6 +607,11 @@ fn clear_modifier_params(mut app App) {
 }
 
 fn my_event_manager(mut ev gg.Event, mut app App) {
+	// Handle window closure
+	if ev.typ == .quit_requested {
+		cleanup(mut app)
+		exit(0)
+	}
 	// navigation using the mouse wheel
 	app.scroll_y = int(ev.scroll_y)
 	if app.scroll_y != 0 {


### PR DESCRIPTION
Add handling for window closure event in my_event_manager in order to close the program properly.

This pull request fixes https://github.com/vlang/v/issues/25521