### PR TITLE
cgen: ensure option none/ok state is also compared

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -403,13 +403,25 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 		old_inside_opt_or_res := g.inside_opt_or_res
 		g.inside_opt_or_res = true
 		if node.op == .eq {
-			g.write('!')
+			g.write('(')
+		} else {
+			g.write('!(')
 		}
-		g.write('memcmp(')
+		g.write('(')
 		g.expr(node.left)
-		g.write('.data, ')
+		g.write('.state == 2 && ')
 		g.expr(node.right)
-		g.write('.data, sizeof(${g.base_type(left_type)}))')
+		g.write('.state == 2) || (')
+		g.expr(node.left)
+		g.write('.state == ')
+		g.expr(node.right)
+		g.write('.state && ')
+		g.expr(node.left)
+		g.write('.state != 2 && !memcmp(&')
+		g.expr(node.left)
+		g.write('.data, &')
+		g.expr(node.right)
+		g.write('.data, sizeof(${g.base_type(left_type)}))))')
 		g.inside_opt_or_res = old_inside_opt_or_res
 	} else {
 		g.gen_plain_infix_expr(node)

--- a/vlib/v/tests/options/option_enum_compare_none_test.v
+++ b/vlib/v/tests/options/option_enum_compare_none_test.v
@@ -1,0 +1,17 @@
+enum A_ {
+	b
+}
+
+fn test_main() {
+	mut a := ?A_(none)
+	a = .b
+	b := ?A_(none)
+	match true {
+		a == ?A_(.b) && a != b {
+			assert true
+		}
+		else {
+			assert false
+		}
+	}
+}


### PR DESCRIPTION
Fixes #25530.

When comparing options, we can't just compare data. State needs to be compared. When state is 2 for both left and right, data should not be compared, but if they have the same non-2 state then data should be compared.