### PR TITLE
encoding.base58: fix encoding, add test

### DIFF
--- a/vlib/encoding/base58/base58.v
+++ b/vlib/encoding/base58/base58.v
@@ -50,6 +50,7 @@ pub fn encode_walpha(input string, alphabet Alphabet) string {
 }
 
 // encode_walpha encodes the input array to base58 with a custom aplhabet
+@[direct_array_access]
 pub fn encode_walpha_bytes(input []u8, alphabet Alphabet) []u8 {
 	if input.len == 0 {
 		return []
@@ -80,7 +81,7 @@ pub fn encode_walpha_bytes(input []u8, alphabet Alphabet) []u8 {
 			out[i] = u8(carry % 58)
 			carry /= 58
 		}
-		high = 1
+		high = i
 	}
 
 	// determine additional "zero-gap" in the buffer, aside from zcount

--- a/vlib/encoding/base58/base58_test.v
+++ b/vlib/encoding/base58/base58_test.v
@@ -36,6 +36,9 @@ fn test_encode_string() {
 	a := 'lorem ipsum'
 	assert encode(a) == 'TtaR6twpTGu8VpY'
 
+	aa := '0JHRktAz1yEtdGl6RnO'
+	assert encode(aa) == '9qkYDxBXPdc6nW825HkNx7oFMY'
+
 	abc := new_alphabet('abcdefghij\$lmnopqrstuvwxyz0123456789_ABCDEFGHIJLMNOPQRSTUV') or {
 		panic(@MOD + '.' + @FN + ': this should never happen')
 	}


### PR DESCRIPTION
I love one-line patches.
Due to this typo, `encoding.base58` couldn't pass testing against an external library.
Now everything is fine, passed `300+ M` loop on random input of random length.
I found copy-paste source library in Internet, [no typo here](https://github.com/mr-tron/base58/blob/master/base58.go#L54).
Now `2x` faster for performance.
I decided not to set `@[direct_array_access]` for `decode()`, tested it has no effect.
Now `master` can not pass test without patch.

These performances requires verification and further investigation.
Need to check if anything can be improved.
<img width="1024" height="768" src="https://github.com/user-attachments/assets/e81b4d15-86b2-420b-96df-4ed3f246192f" alt="base">
p.s. `base32` and `base64` are fine, tested too.