### PR TITLE
x.crypto.chacha20poly1305: make psiv aead on par with standard aead 

### DIFF
--- a/vlib/v/checker/tests/array_of_refs_insert_non_ref.out
+++ b/vlib/v/checker/tests/array_of_refs_insert_non_ref.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/array_of_refs_insert_non_ref.vv:16:12: error: cannot append `Dummy` to `[]&Dummy`
+   14 |         v: 1
+   15 |     }
+   16 |     c.vals << d
+      |               ^
+   17 |     c.vals.insert(0, d)
+   18 | }
+vlib/v/checker/tests/array_of_refs_insert_non_ref.vv:17:19: error: cannot insert `Dummy` to `[]&Dummy`
+   15 |     }
+   16 |     c.vals << d
+   17 |     c.vals.insert(0, d)
+      |                      ^
+   18 | }

--- a/vlib/v/checker/tests/array_of_refs_insert_non_ref.vv
+++ b/vlib/v/checker/tests/array_of_refs_insert_non_ref.vv
@@ -1,0 +1,18 @@
+struct Dummy {
+	v int
+}
+
+@[heap]
+struct Container {
+mut:
+	vals []&Dummy
+}
+
+fn main() {
+	mut c := &Container{}
+	d := Dummy{
+		v: 1
+	}
+	c.vals << d
+	c.vals.insert(0, d)
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This patch basically based on works of unsent patch from @tankf33der discussed [here](https://discord.com/channels/592103645835821068/592320321995014154/1426185247699107881) . I'm waiting it to happen, but i think it not ready yet, so, i'm sent this patch so it can be tested on the broader scope.
This PR does not change on the how the psiv works, but it fundamentally rewriting some of the core of building block, in the means of 
- removed out the `arrays.chunk[T]` machinery to split out the messages and working directly with bytes slicing
- removed out `.key` field from `Chacha20Poly1305RE` opaque, its really not used on other ways.
- removed out some unnecessary helpers, and working directly with bytes slicing or copying-machinery.
- use fixed arrays in several places of the helper routines to reduce heap alloc.
- reuse the tag buffer as a temporary output in generating temporary tag and output tag buffer in  `psiv_gen_tag`. Its reduces buffer allocation for tag.
- working directly with little-endian serialization with fixed-arrays.
- Some other of bits of cleanups.

On my test, the psiv encrypt (and decrypt) now on par with standard `chacha20poly1305` aead encrypt (and decrypt), even it out perform standard aead in some cases.
This is my output number on latest run of `vlib/x/crypto/chacha20poly1305/bench/bench.v` with patch applied: 
```bash
Standard ChaCha20Poly1305 AEAD and PSIV construct output performance comparison
===============================================================================
Iterations per test: 1000
------------------------------------------------------------------------------------------------------
   Data Size |        Std |       PSIV | Enc (std/psiv) ||        Std |         PSIV | Dec (std/psiv)|
------------------------------------------------------------------------------------------------------
         6 B |    11.00ms |    14.00ms |          0.80x ||    10.00ms |      13.00ms |         0.79x |
         8 B |    11.00ms |    13.00ms |          0.89x ||    11.00ms |      13.00ms |         0.87x |
        12 B |    12.00ms |    20.00ms |          0.64x ||    16.00ms |      20.00ms |         0.80x |
        16 B |    11.00ms |    12.00ms |          0.89x ||    10.00ms |      14.00ms |         0.73x |
        64 B |    14.00ms |    16.00ms |          0.91x ||    15.00ms |      18.00ms |         0.85x |
        75 B |    18.00ms |    22.00ms |          0.82x ||    19.00ms |      33.00ms |         0.60x |
       256 B |    39.00ms |    49.00ms |          0.81x ||    38.00ms |      41.00ms |         0.93x |
      1028 B |   136.00ms |   131.00ms |          1.04x ||   140.00ms |     140.00ms |         1.00x |
      2049 B |   342.00ms |   267.00ms |          1.28x ||   277.00ms |     262.00ms |         1.06x |
------------------------------------------------------------------------------------------------------
       Total |   600.00ms |   548.00ms |          1.10x ||   540.00ms |     556.00ms |          0.97x|
------------------------------------------------------------------------------------------------------

Per-operation averages:
  Standard ChaCha20Poly1305 encrypt:        66743 ns per hash
  ChaCha20Poly1305 PSIV encrypt:            60889 ns per hash

  Standard ChaCha20Poly1305 decrypt:        60028 ns per hash
  ChaCha20Poly1305 PSIV decrypt:            61841 ns per hash
```
@tankf33der , @spytheman : can you look into this ?

Thanks,
Cheers.
