### PR TITLE
x.crypto.chacha20poly1305: move up responsibility for allocs into higher caller

### DIFF
--- a/vlib/x/crypto/chacha20poly1305/psiv_test.v
+++ b/vlib/x/crypto/chacha20poly1305/psiv_test.v
@@ -139,11 +139,14 @@ fn test_psiv_insternal_encryption_of_encrypted_text_is_plaintext() ! {
 		tag := rand.bytes(16)!
 		nonce := rand.bytes(12)!
 
-		out := psiv_encrypt_internal(input, key, tag, nonce)!
+		mut out := []u8{len: input.len}
+		psiv_encrypt_internal(mut out, input, key, tag, nonce)!
 
 		// encrypting this output with the same params was result in original input
-		awal := psiv_encrypt_internal(out, key, tag, nonce)!
-		assert awal == input
+		// make a clone of ciphertext output as an input into internal encrypt routine
+		text := out.clone()
+		psiv_encrypt_internal(mut out, text, key, tag, nonce)!
+		assert out == input
 	}
 }
 


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This patch was related with previous merged PR in [#25569](https://github.com/vlang/v/pull/25569). This PR fundamentally does not changes the core functionality. The reason for this changes was to move up buffer allocation in `psiv_encrypt_internal` and `psiv_gen_tag` into the caller responsible to do that allocs, especially in `.encrypt` and `.decrypt`. It also acts as preliminary step to move into fixed arrays.

This patch contains changes in the means of :
- The main one was a changed in the signature of `psiv_encrypt_internal` and `psiv_gen_tag` to accept output buffer as the first params and adapts in another places that call both of them.
- Updates comments on the code
- Removes out left unused remaining bits, ie `split_tag` helper
- Adjust the tests

Thanks, 
Cheers
