### PR TITLE
cgen: create ctemp before lockexpr gen

### DIFF
--- a/vlib/v/gen/c/assert.v
+++ b/vlib/v/gen/c/assert.v
@@ -100,6 +100,9 @@ fn (mut g Gen) assert_subexpression_to_ctemp(expr ast.Expr, expr_type ast.Type) 
 				return g.new_ctemp_var_then_gen(expr, expr_type)
 			}
 		}
+		ast.LockExpr {
+			return g.new_ctemp_var_then_gen(expr, expr_type)
+		}
 		else {}
 	}
 	return unsupported_ctemp_assert_transform

--- a/vlib/v/tests/concurrency/shared_lock_expr_assert_test.v
+++ b/vlib/v/tests/concurrency/shared_lock_expr_assert_test.v
@@ -1,0 +1,38 @@
+struct Counter {
+mut:
+	value int
+}
+
+fn (shared c Counter) inc() {
+	lock c {
+		c.value += 1
+	}
+}
+
+fn (c Counter) val() int {
+	return c.value
+}
+
+fn test_main() {
+	shared c := Counter{1}
+
+	assert rlock c {
+		c.val()
+	} == 1
+	if rlock c {
+		c.val()
+	} == 1 {
+		assert true
+	}
+
+	c.inc()
+
+	assert rlock c {
+		c.val()
+	} == 2
+	if rlock c {
+		c.val()
+	} == 2 {
+		assert true
+	}
+}


### PR DESCRIPTION
Fixes #25576.

3-line fix but added test as well.