### PR TITLE
rand: fix randomness in shuffle()

### DIFF
--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -460,7 +460,7 @@ pub fn (mut rng PRNG) shuffle[T](mut a []T, config_ config.ShuffleConfigStruct) 
 	// We implement the Fisher-Yates shuffle:
 	// https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
 
-	for i in config_.start .. new_end - 2 {
+	for i in config_.start .. new_end - 1 {
 		x := rng.int_in_range(i, new_end) or { i }
 		// swap
 		a_i := a[i]


### PR DESCRIPTION
The current implementation incorrectly iterates through the array for shuffling and doesn't touch the `last two` elements, whereas it should only leave the `last one` untouched.

Due to this, some combinations don't occur at all, here's a histogram with 100k attempts.
<img width="800" height="600" alt="master" src="https://github.com/user-attachments/assets/c5fea3d0-d5d8-41e7-915b-6e7751df493a" />

My proposed patch increases randomness and in the future `all` combinations will occur.
<img width="800" height="600" alt="patch" src="https://github.com/user-attachments/assets/c171e06e-f8b4-46f8-a7dd-9b1f6018b524" />

Here is text data for histogram above:
```
4086 4113 4116 4134 4231 4305 4153 4178
4268 4163 4137 4129 4264 4179 4189 4197 
4157 4190 4150 4131 4173 4125 4122 4110
```
Now any combination will occur approximately equally.