### PR TITLE
strings: make strings end with zero in repeat() and repeat_string()

### DIFF
--- a/vlib/strings/strings.c.v
+++ b/vlib/strings/strings.c.v
@@ -9,7 +9,7 @@ pub fn repeat(c u8, n int) string {
 	mut bytes := unsafe { malloc_noscan(n + 1) }
 	unsafe {
 		C.memset(bytes, c, n)
-		bytes[n] = `0`
+		bytes[n] = 0
 	}
 	return unsafe { bytes.vstring_with_len(n) }
 }
@@ -34,7 +34,7 @@ pub fn repeat_string(s string, n int) string {
 		}
 	}
 	unsafe {
-		bytes[blen] = `0`
+		bytes[blen] = 0
 	}
 	return unsafe { bytes.vstring_with_len(blen) }
 }


### PR DESCRIPTION
In these two functions the created strings are end with zero and not with NULL.
Demo:
```v
import strings

fn main() {
        s := strings.repeat(48, 3)
        for i in 0 .. 10 {
                unsafe { C.printf(c'%d\n', s.str[i]) }
        }
}
```
p.s. for another module decided to create a separate PR for the sake of cleanliness