### PR TITLE
builtin:  make string end with null in repeat()

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -588,7 +588,7 @@ pub fn (b u8) repeat(count int) string {
 	mut bytes := unsafe { malloc_noscan(count + 1) }
 	unsafe {
 		vmemset(bytes, b, count)
-		bytes[count] = `0`
+		bytes[count] = 0
 	}
 	return unsafe { bytes.vstring_with_len(count) }
 }


### PR DESCRIPTION
Now `repeat()` generate 0 as last byte of string not null.
Lets fix this too.

Demo:
```v
fn main() {
        s := u8(57).repeat(3)
        for i in 0 .. 10 {
                unsafe { C.printf(c'%d\n', s.str[i]) }
        }
}
```
