### PR TITLE
x.crypto.chacha20poly1305: changes artifacts to use fixed-array one

### DIFF
--- a/vlib/x/crypto/chacha20poly1305/psiv_test.v
+++ b/vlib/x/crypto/chacha20poly1305/psiv_test.v
@@ -136,16 +136,18 @@ fn test_psiv_insternal_encryption_of_encrypted_text_is_plaintext() ! {
 	for i := 0; i < 1024; i++ {
 		input := rand.bytes(i)!
 		key := rand.bytes(36)!
+		mut dkey := [36]u8{}
+		unsafe { vmemcpy(dkey, key.data, key.len) }
 		tag := rand.bytes(16)!
 		nonce := rand.bytes(12)!
 
 		mut out := []u8{len: input.len}
-		psiv_encrypt_internal(mut out, input, key, tag, nonce)!
+		psiv_encrypt_internal(mut out, input, dkey, tag, nonce)!
 
 		// encrypting this output with the same params was result in original input
 		// make a clone of ciphertext output as an input into internal encrypt routine
 		text := out.clone()
-		psiv_encrypt_internal(mut out, text, key, tag, nonce)!
+		psiv_encrypt_internal(mut out, text, dkey, tag, nonce)!
 		assert out == input
 	}
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This main focus of this patch was the change on the main psiv derivation routines to use fixed-sized array and adapt the artifacts to use this one. 
On the time of this changes, there are bug on the c-gen issue i've found. Its already issued at [bug#25626](https://github.com/vlang/v/issues/25626) so, i move up `psiv_init` into `new_psiv` directly.

In my last run of `vlib/x/crypto/chacha20poly1305/bench/bench.v`, its now on par with standard aead encrypt (decrypt) even outperform it on some cases.
```bash
....(skipped output)
Per-operation averages:
  Standard ChaCha20Poly1305 encrypt:        79450 ns per hash
  ChaCha20Poly1305 PSIV encrypt:            78893 ns per hash

  Standard ChaCha20Poly1305 decrypt:        79237 ns per hash
  ChaCha20Poly1305 PSIV decrypt:            79599 ns per hash
```

There are small areas can be cleaned up, but i think its can fall on the next iteration.

Thanks
Cheers.