### PR TITLE
strings: fix write_decimal() for min_i64, add test

### DIFF
--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -81,7 +81,7 @@ pub fn (mut b Builder) write_decimal(n i64) {
 		return
 	}
 	mut buf := [25]u8{}
-	mut x := if n < 0 { -n } else { n }
+	mut x := if n < 0 { u64(-n) } else { u64(n) }
 	mut i := 24
 	for x != 0 {
 		nextx := x / 10

--- a/vlib/strings/builder_test.v
+++ b/vlib/strings/builder_test.v
@@ -165,6 +165,7 @@ fn test_write_decimal() {
 	assert sb_i64_str(-1234567890) == '-1234567890'
 	assert sb_i64_str(9223372036854775807) == '9223372036854775807'
 	assert sb_i64_str(-9223372036854775807) == '-9223372036854775807'
+	assert sb_i64_str(min_i64) == '-9223372036854775808'
 }
 
 fn test_grow_len() {


### PR DESCRIPTION
Currently this code now prints garbage:
```v
import strings

fn main() {
        mut bs := strings.new_builder(32)
        bs.write_decimal(min_i64)
        println(bs)
}
```

Lets fix this. Test was added too.