### PR TITLE
checker: correctly detect type when prepending to generic array

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -3335,7 +3335,8 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 								arg.expr.pos())
 							continue
 						}
-					} else if !c.check_types(base_arg_type, c.unwrap_generic(left_type)) {
+					} else if !c.check_types(base_arg_type, unwrapped_left_type)
+						&& !c.check_types(elem_typ, base_arg_type) {
 						c.error('cannot ${method_name} `${arg_sym.name}` to `${left_sym.name}`',
 							arg.expr.pos())
 						continue

--- a/vlib/v/tests/builtin_arrays/array_prepend_generic_test.v
+++ b/vlib/v/tests/builtin_arrays/array_prepend_generic_test.v
@@ -1,0 +1,22 @@
+struct Buffer[T] {
+	size int
+mut:
+	content []T
+}
+
+pub fn create_buffer[T](size int) Buffer[T] {
+	return Buffer[T]{
+		size:    size
+		content: []T{}
+	}
+}
+
+pub fn (mut b Buffer[T]) write(value T) {
+	b.content.prepend(value)
+}
+
+fn test_main() {
+	mut buffer := create_buffer[int](3)
+	buffer.write(1)
+	assert buffer.content[0] == 1
+}


### PR DESCRIPTION
Fixes #25585.

Also changed `c.unwrap_generic(left_type)` to `unwrapped_left_type` to remove unnecessary call.