### PR TITLE
datatypes: fix insert() and delete() for items in second half of DoubleLinkedList[T]{}, add test

### DIFF
--- a/vlib/datatypes/doubly_linked_list.v
+++ b/vlib/datatypes/doubly_linked_list.v
@@ -165,7 +165,7 @@ pub fn (mut list DoublyLinkedList[T]) insert(idx int, item T) ! {
 // when idx > list.len/2. This helper function assumes idx bounds have
 // already been checked and idx is not at the edges.
 fn (mut list DoublyLinkedList[T]) insert_back(idx int, item T) {
-	mut node := list.node(idx + 1)
+	mut node := list.node(idx)
 	mut prev := node.prev
 	//   prev       node
 	//  ------     ------
@@ -226,7 +226,7 @@ fn (list &DoublyLinkedList[T]) node(idx int) &DoublyListNode[T] {
 		return node
 	}
 	mut node := list.tail
-	for t := list.len - 1; t >= idx; t -= 1 {
+	for t := list.len - 1; t > idx; t -= 1 {
 		node = node.prev
 	}
 	return node

--- a/vlib/datatypes/doubly_linked_list_test.v
+++ b/vlib/datatypes/doubly_linked_list_test.v
@@ -136,6 +136,21 @@ fn test_delete() {
 	assert list.len() == 0
 }
 
+fn test_insert_delete() {
+	mut list := DoublyLinkedList[int]{}
+	elem := [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+	list.push_many(elem, Direction.front)
+	for i in 0 .. 12 {
+		list.insert(i, 777)!
+		assert list.array() != elem
+		r := list.index(777)!
+		assert r == i
+		list.delete(r)
+		assert list.index(777) or { -7 } == -7
+		assert list.array() == elem
+	}
+}
+
 fn test_iter() {
 	mut list := DoublyLinkedList[int]{}
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
The created test for full coverage of insertion and deletion cannot pass the test on `master`.
The index calculation for where to insert and where to delete from is incorrect.
Lets try to fix this.
