### PR TITLE
checker: allow cast from voidptr to sumtype in unsafe block

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3511,9 +3511,15 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 			from_type = node.expr_type
 		}
 		if !c.table.sumtype_has_variant(to_type, from_type, false) {
-			ft := c.table.type_to_str(from_type)
 			tt := c.table.type_to_str(to_type)
-			c.error('cannot cast `${ft}` to `${tt}`', node.pos)
+			if from_type == ast.voidptr_type_idx && to_type.is_ptr() {
+				if !c.inside_unsafe {
+					c.error('cannot cast voidptr to `${tt}` outside `unsafe`', node.pos)
+				}
+			} else {
+				ft := c.table.type_to_str(from_type)
+				c.error('cannot cast `${ft}` to `${tt}`', node.pos)
+			}
 		}
 	} else if mut to_sym.info is ast.Alias && !(final_to_sym.kind == .struct && final_to_is_ptr) {
 		if (!c.check_types(from_type, to_sym.info.parent_type) && !(final_to_sym.is_int()

--- a/vlib/v/checker/tests/sumtype_from_voidptr_err.out
+++ b/vlib/v/checker/tests/sumtype_from_voidptr_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/sumtype_from_voidptr_err.vv:13:11: error: cannot cast voidptr to `&Event` outside `unsafe`
+   11 | fn main() {
+   12 |     some_ptr := voidptr(1234)
+   13 |     event := &Event(some_ptr)
+      |              ~~~~~~~~~~~~~~~~
+   14 |     _ = event
+   15 | }

--- a/vlib/v/checker/tests/sumtype_from_voidptr_err.vv
+++ b/vlib/v/checker/tests/sumtype_from_voidptr_err.vv
@@ -1,0 +1,15 @@
+struct EventA {
+	a u32
+}
+
+struct EventB {
+	b u32
+}
+
+type Event = EventA | EventB
+
+fn main() {
+	some_ptr := voidptr(1234)
+	event := &Event(some_ptr)
+	_ = event
+}

--- a/vlib/v/tests/sumtypes/sumtype_cast_from_voidptr_test.v
+++ b/vlib/v/tests/sumtypes/sumtype_cast_from_voidptr_test.v
@@ -1,0 +1,22 @@
+struct EventA {
+	a u32
+}
+
+struct EventB {
+	b u32
+}
+
+type Event = EventA | EventB
+
+fn test_main() {
+	some_ptr := voidptr(&EventA{
+		a: 1234
+	})
+	event := unsafe { &Event(some_ptr) }
+
+	d1 := &EventA(event)
+	assert d1.a == 1234
+
+	d2 := &EventB(event)
+	assert d2.b == 1234
+}


### PR DESCRIPTION
Fixes #25652.

Not allowed outside of `unsafe` of course, as it has the same issues as with structs.

Added both a checker test to ensure it's in an `unsafe` block and a standard test for a functional version.

Interestingly you could implement a sort of "reinterpret cast" using this functionality to some extent. 