### PR TITLE
all: `defer` is now scoped by default

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2656,7 +2656,7 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 		ast.DeferStmt {
 			mut defer_stmt := node
 			defer_stmt.ifdef = g.defer_ifdef
-			if defer_stmt.mode == .function || !g.pref.scoped_defer {
+			if defer_stmt.mode == .function {
 				g.writeln('${g.defer_flag_var(defer_stmt)} = true;')
 			}
 			g.defer_stmts << defer_stmt

--- a/vlib/v/gen/c/defer.v
+++ b/vlib/v/gen/c/defer.v
@@ -26,8 +26,7 @@ fn (mut g Gen) write_defer_stmts(scope &ast.Scope, lookup bool, pos token.Pos) {
 			g.error('Gen.write_defer_stmts(): defer_stmt.scope is nil', pos)
 		}
 
-		is_scoped := g.pref.scoped_defer && defer_stmt.mode == .scoped
-		if is_scoped {
+		if defer_stmt.mode == .scoped {
 			if !((lookup && defer_stmt.scope.start_pos < scope.start_pos
 				&& defer_stmt.scope.end_pos > scope.end_pos)
 				|| defer_stmt.scope == scope) {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -454,7 +454,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 	}
 	g.indent++
 	for defer_stmt in node.defer_stmts {
-		if defer_stmt.mode != .function && g.pref.scoped_defer {
+		if defer_stmt.mode != .function {
 			continue
 		}
 		g.writeln('bool ${g.defer_flag_var(defer_stmt)} = false;')

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -260,8 +260,6 @@ pub mut:
 	subsystem   Subsystem // the type of the window app, that is going to be generated; has no effect on !windows
 	is_vls      bool
 	json_errors bool // -json-errors, for VLS and other tools
-
-	scoped_defer bool = true // experimental support, is activated with `-scoped-defer`
 }
 
 pub fn parse_args(known_external_commands []string, args []string) (&Preferences, string) {
@@ -763,10 +761,6 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			}
 			'-experimental' {
 				res.experimental = true
-			}
-			'-scoped-defer' {
-				// experimental, remove once defer is scoped by default
-				res.scoped_defer = true
 			}
 			'-usecache' {
 				res.use_cache = true

--- a/vlib/v/tests/defer/defer_fixed_array_test.v
+++ b/vlib/v/tests/defer/defer_fixed_array_test.v
@@ -1,5 +1,3 @@
-// vtest vflags: -scoped-defer
-
 fn foo() {
 	a := [u8(1), 2, 3]!
 	defer {

--- a/vlib/v/tests/defer/defer_if_comptime_test.v
+++ b/vlib/v/tests/defer/defer_if_comptime_test.v
@@ -1,5 +1,3 @@
-// vtest vflags: -scoped-defer
-
 fn test_main() {
 	defer {
 		$if foo ? {

--- a/vlib/v/tests/defer/defer_return_test.v
+++ b/vlib/v/tests/defer/defer_return_test.v
@@ -1,5 +1,3 @@
-// vtest vflags: -scoped-defer
-
 @[heap]
 struct Hwe {
 mut:

--- a/vlib/v/tests/defer/defer_static_test.v
+++ b/vlib/v/tests/defer/defer_static_test.v
@@ -1,5 +1,3 @@
-// vtest vflags: -scoped-defer
-
 @[unsafe]
 fn g() {
 	mut static levels := 0

--- a/vlib/v/tests/defer/defer_test.v
+++ b/vlib/v/tests/defer/defer_test.v
@@ -1,5 +1,3 @@
-// vtest vflags: -scoped-defer
-
 fn foo() string {
 	println('foo()')
 	return 'foo'

--- a/vlib/v/tests/defer/defer_use_returned_value_test.v
+++ b/vlib/v/tests/defer/defer_use_returned_value_test.v
@@ -1,5 +1,3 @@
-// vtest vflags: -scoped-defer
-
 struct Test {
 mut:
 	a int

--- a/vlib/v/tests/defer/defer_with_fn_var_test.v
+++ b/vlib/v/tests/defer/defer_with_fn_var_test.v
@@ -1,5 +1,3 @@
-// vtest vflags: -scoped-defer
-
 @[has_globals]
 module main
 

--- a/vlib/v/tests/defer/scoped_defer_test.v
+++ b/vlib/v/tests/defer/scoped_defer_test.v
@@ -1,5 +1,3 @@
-// vtest vflags: -scoped-defer
-
 struct Data {
 mut:
 	counter int


### PR DESCRIPTION
Continuation of PR #25639. Final part of the scoped `defer` implementation.

* Remove `-scoped-defer` flag, now `defer` is scoped by default.