### PR TITLE
parser: fix vfmt comment in struct init after the update expr

### DIFF
--- a/vlib/v/fmt/tests/struct_init_with_update_expr_comment_keep.vv
+++ b/vlib/v/fmt/tests/struct_init_with_update_expr_comment_keep.vv
@@ -1,0 +1,20 @@
+module main
+
+struct MyStruct {
+	a int
+	b int
+}
+
+fn x() {
+	k := MyStruct{}
+	_ := MyStruct{
+		...k // same line comment
+		// keep comment here
+	}
+
+	_ := MyStruct{
+		...k // same line comment
+		// keep comment here
+		b: 100
+	}
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -582,7 +582,7 @@ fn (mut p Parser) struct_init(typ_str string, kind ast.StructInitKind, is_option
 			update_expr_pos = p.tok.pos()
 			p.check(.ellipsis)
 			update_expr = p.expr(0)
-			update_expr_comments << p.eat_comments(same_line: true)
+			update_expr_comments << p.eat_comments()
 			has_update_expr = true
 		} else {
 			prev_comments = p.eat_comments()


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #24361