### PR TITLE
io.string_reader: fix fill_buffer_until(), add tests

### DIFF
--- a/vlib/io/string_reader/string_reader.v
+++ b/vlib/io/string_reader/string_reader.v
@@ -114,8 +114,12 @@ pub fn (mut r StringReader) fill_buffer_until(n int) !int {
 	}
 
 	mut end := start
+	defer {
+		// shrink the length of the buffer to the total of bytes read
+		r.builder.go_back(r.builder.len - end)
+	}
 	for {
-		read := reader.read(mut r.builder[start..]) or {
+		read := reader.read(mut r.builder[end..]) or {
 			r.end_of_stream = true
 			break
 		}
@@ -124,10 +128,11 @@ pub fn (mut r StringReader) fill_buffer_until(n int) !int {
 		if read == 0 || end - start == n {
 			break
 		} else if r.builder.len == end {
-			if n - end > io.read_all_grow_len {
+			remaining := n - (end - start)
+			if remaining > io.read_all_grow_len {
 				unsafe { r.builder.grow_len(io.read_all_grow_len) }
 			} else {
-				unsafe { r.builder.grow_len(n - end) }
+				unsafe { r.builder.grow_len(remaining) }
 			}
 		}
 	}

--- a/vlib/io/string_reader/string_reader_test.v
+++ b/vlib/io/string_reader/string_reader_test.v
@@ -28,7 +28,7 @@ fn (mut r TwoByteReader) read(mut buf []u8) !int {
 	if r.pos >= r.data.len {
 		return io.Eof{}
 	}
-	min := int_min(r.data.len - r.pos, 2)
+	min := int_min(int_min(r.data.len - r.pos, 2), buf.len)
 	for i in 0 .. min {
 		buf[i] = r.data[r.pos]
 		r.pos++
@@ -157,4 +157,50 @@ fn test_fill_buffer_false() {
 	mut reader := StringReader.new(reader: two)
 	assert reader.fill_buffer(false)! == 2
 	assert reader.get_string() == '12'
+}
+
+fn test_fill_buffer_until() {
+	mut two := TwoByteReader{
+		data: '12345'
+	}
+	mut reader := StringReader.new(reader: two)
+	assert reader.fill_buffer_until(1)! == 1
+	assert reader.builder.len == 1
+	assert reader.fill_buffer_until(2)! == 2
+	assert reader.builder.len == 3
+	assert reader.fill_buffer_until(2)! == 2
+	assert reader.builder.len == 5
+	assert reader.get_string() == '12345'
+}
+
+fn test_fill_buffer_until_one() {
+	mut two := TwoByteReader{
+		data: '12345'
+	}
+	mut reader := StringReader.new(reader: two)
+	assert reader.fill_buffer_until(1)! == 1
+	assert reader.builder.len == 1
+	assert reader.fill_buffer_until(1)! == 1
+	assert reader.builder.len == 2
+	assert reader.fill_buffer_until(1)! == 1
+	assert reader.builder.len == 3
+	assert reader.fill_buffer_until(1)! == 1
+	assert reader.builder.len == 4
+	assert reader.fill_buffer_until(1)! == 1
+	assert reader.builder.len == 5
+	assert reader.get_string() == '12345'
+}
+
+fn test_fill_buffer_until_many() {
+	mut two := TwoByteReader{
+		data: '12345'
+	}
+	mut reader := StringReader.new(reader: two)
+	assert reader.fill_buffer_until(1)! == 1
+	assert reader.builder.len == 1
+	assert reader.fill_buffer_until(12)! == 4
+	assert reader.builder.len == 5
+	assert reader.fill_buffer_until(123) or { -1 } == -1
+	assert reader.builder.len == 5
+	assert reader.get_string() == '12345'
 }


### PR DESCRIPTION
Saga continues.
The next function to fix is `fill_buffer_until()`.
Various tests were made on different combinations to verify the function's operation.
