### PR TITLE
crypto: Optimize the hmac

### DIFF
--- a/vlib/crypto/hmac/hmac.v
+++ b/vlib/crypto/hmac/hmac.v
@@ -6,32 +6,32 @@ import crypto.internal.subtle
 
 // new returns a HMAC byte array, depending on the hash algorithm used.
 pub fn new(key []u8, data []u8, hash_func fn ([]u8) []u8, blocksize int) []u8 {
-        mut inner := []u8{len: blocksize, init: 0x36}
-        mut outer := []u8{len: blocksize, init: 0x5C}
+	mut inner := []u8{len: blocksize, init: 0x36}
+	mut outer := []u8{len: blocksize, init: 0x5C}
 
-        mut b_key := []u8{}
-        if key.len <= blocksize {
-                b_key = key.clone() // TODO: remove .clone() once https://github.com/vlang/v/issues/6604 gets fixed
-        } else {
-                b_key = hash_func(key)
-        }
+	mut b_key := []u8{}
+	if key.len <= blocksize {
+		b_key = key.clone() // TODO: remove .clone() once https://github.com/vlang/v/issues/6604 gets fixed
+	} else {
+		b_key = hash_func(key)
+	}
 	if b_key.len > blocksize {
 		b_key = b_key[..blocksize].clone()
 	}
-        for i, b in b_key {
-                inner[i] = b ^ 0x36
-                outer[i] = b ^ 0x5c
-        }
-        inner << data
-        inner_hash := hash_func(inner)
-        outer << inner_hash
-        digest := hash_func(outer)
-        return digest
+	for i, b in b_key {
+		inner[i] = b ^ 0x36
+		outer[i] = b ^ 0x5c
+	}
+	inner << data
+	inner_hash := hash_func(inner)
+	outer << inner_hash
+	digest := hash_func(outer)
+	return digest
 }
 
 // equal compares 2 MACs for equality, without leaking timing info.
 // Note: if the lengths of the 2 MACs are different, probably a completely different
 // hash function was used to generate them => no useful timing information.
 pub fn equal(mac1 []u8, mac2 []u8) bool {
-        return subtle.constant_time_compare(mac1, mac2) == 1
+	return subtle.constant_time_compare(mac1, mac2) == 1
 }


### PR DESCRIPTION
Without altering the operational logic of HMAC, the computation speed has been optimized, and the block division range has been expanded. A 500,000-cycle test was conducted to compare the time taken by the user for the old HMAC and the new HMAC, as shown below:

|Type|Old HMAC|New HMAC|
|--|--|--|
|hmac-sha128-64|3.623s|2.255s|
|hmac-sha256-64|7.587s|6.257s|
|hmac-sha512-128|11.088s|8.294s|

The new HMAC function supports calculations with a `blocksize > 256`. Using the old HMAC would cause a V panic (although now, the significance of crypto is minor).