### PR TITLE
checker: maintain correct ref level in generic fn

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1067,7 +1067,13 @@ fn (mut c Checker) infer_fn_generic_types(func &ast.Fn, mut node ast.CallExpr) {
 				}
 				// resolve &T &&T ...
 				if param.typ.nr_muls() > 0 && typ.nr_muls() > 0 {
-					typ = typ.set_nr_muls(0)
+					param_muls := param.typ.nr_muls()
+					arg_muls := typ.nr_muls()
+					typ = if arg_muls >= param_muls {
+						typ.set_nr_muls(arg_muls - param_muls)
+					} else {
+						typ.set_nr_muls(0)
+					}
 				}
 			} else if param.typ.has_flag(.generic) {
 				arg_typ := if c.table.sym(arg.typ).kind == .any {

--- a/vlib/v/tests/generics/generic_fn_ref_level_test.v
+++ b/vlib/v/tests/generics/generic_fn_ref_level_test.v
@@ -1,0 +1,11 @@
+fn foo[T](v &T) string {
+	return typeof(v).name
+}
+
+fn test_main() {
+	i := i8(0)
+	ip := &i
+	ipp := &ip
+	assert foo(ip) == '&i8'
+	assert foo(ipp) == '&&i8'
+}


### PR DESCRIPTION
Fixes #25676.

`set_nr_muls` should only be called with 0 if `param.typ.nr_muls()` is smaller than `typ.nr_muls()`, otherwise it should be the difference so the correct ref level is maintained.