### PR TITLE
parser, checker: only collect inner vars when `defer` is function-scoped

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2435,24 +2435,24 @@ fn (mut c Checker) defer_stmt(mut node ast.DeferStmt) {
 		if c.locked_names.len != 0 || c.rlocked_names.len != 0 {
 			c.error('`defer(fn)`s are not allowed in lock statements', node.pos)
 		}
-	}
-	for i, ident in node.defer_vars {
-		mut id := ident
-		if mut id.info is ast.IdentVar {
-			if id.comptime
-				&& (id.tok_kind == .question || id.name in ast.valid_comptime_not_user_defined) {
-				node.defer_vars[i] = ast.Ident{
-					scope: unsafe { nil }
-					name:  ''
+		for i, ident in node.defer_vars {
+			mut id := ident
+			if mut id.info is ast.IdentVar {
+				if id.comptime
+					&& (id.tok_kind == .question || id.name in ast.valid_comptime_not_user_defined) {
+					node.defer_vars[i] = ast.Ident{
+						scope: unsafe { nil }
+						name:  ''
+					}
+					continue
 				}
-				continue
+				typ := c.ident(mut id)
+				if typ == ast.error_type_idx {
+					continue
+				}
+				id.info.typ = typ
+				node.defer_vars[i] = id
 			}
-			typ := c.ident(mut id)
-			if typ == ast.error_type_idx {
-				continue
-			}
-			id.info.typ = typ
-			node.defer_vars[i] = id
 		}
 	}
 	c.stmts(mut node.stmts)

--- a/vlib/v/parser/assign.v
+++ b/vlib/v/parser/assign.v
@@ -7,11 +7,11 @@ import v.ast
 
 fn (mut p Parser) assign_stmt() ast.Stmt {
 	mut defer_vars := p.defer_vars.clone()
-	p.defer_vars = []ast.Ident{}
+	p.defer_vars = []
 
 	exprs := p.expr_list(true)
 
-	if !(p.inside_defer && p.tok.kind == .decl_assign) {
+	if !(p.inside_defer && p.defer_mode == .function && p.tok.kind == .decl_assign) {
 		defer_vars << p.defer_vars
 	}
 	p.defer_vars = defer_vars

--- a/vlib/v/tests/defer/scoped_defer_test.v
+++ b/vlib/v/tests/defer/scoped_defer_test.v
@@ -117,3 +117,16 @@ fn test_defer_with_comptime_for() {
 	}
 	assert c == 3
 }
+
+fn test_defer_fn_with_inner_var() {
+	mut x := 0
+	defer {
+		assert x == 1
+	}
+	{
+		a := 1
+		defer(fn) {
+			x = a
+		}
+	}
+}


### PR DESCRIPTION
For this piece of code:

```v
fn main() {
	mut x := 0
	{
		a := 1
		defer(fn) {
			x = a
		}
	}
}
```

The compiler will extract the declaration of `a` and place it in the same scope as `x`, so that it is accessible from the function's scope.

Currently, the compiler does this regardless of whether the `defer` is block-scoped or function-scoped.
This PR ensures that this only happens when the `defer` is function-scoped.