### PR TITLE
builtin: fix typo in range in utf8_str_visible_length()

### DIFF
--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -181,7 +181,7 @@ pub fn utf8_str_visible_length(s string) int {
 				// CJK Unified Ideographs Extension B-G
 				// TODO: remove this workaround for v2's parser
 				// vfmt off
-				if (r >= 0x0f9f8880 && r <= 0xf09f8a8f) || 
+				if (r >= 0xf09f8880 && r <= 0xf09f8a8f) ||
 					(r >= 0xf09f8c80 && r <= 0xf09f9c90) ||
 					(r >= 0xf09fa490 && r <= 0xf09fa7af) ||
 					(r >= 0xf0a08080 && r <= 0xf180807f) {

--- a/vlib/builtin/utf8_test.v
+++ b/vlib/builtin/utf8_test.v
@@ -97,3 +97,7 @@ fn test_wide_to_ansi() {
 fn test_string_to_ansi_not_null_terminated() {
 	assert string_to_ansi_not_null_terminated('abc') == [u8(97), 98, 99]
 }
+
+fn test_utf8_str_visible_length() {
+	assert utf8_str_visible_length('𝐀𝐁𝐂') == 3
+}


### PR DESCRIPTION
I would like to submit this fix for review.
There is a trivial typo at the start of the range boundary and therefore the character length is calculated incorrectly. I'm not even mentioning that `0x0f9f8880` is not a valid UTF-8 sequence at all.

Added a test that cannot pass on master.
