### PR TITLE
math.unsigned: fix put_bytes()

### DIFF
--- a/vlib/math/unsigned/uint128.v
+++ b/vlib/math/unsigned/uint128.v
@@ -413,8 +413,8 @@ pub fn (u_ Uint128) str() string {
 
 // put_bytes stores u in b in little-endian order
 pub fn (u Uint128) put_bytes(mut b []u8) {
-	binary.little_endian_put_u64(mut b, u.lo)
-	binary.little_endian_put_u64(mut b, u.hi)
+	binary.little_endian_put_u64(mut b[..8], u.lo)
+	binary.little_endian_put_u64(mut b[8..], u.hi)
 }
 
 // uint128_from_64 converts v to a Uint128 value

--- a/vlib/math/unsigned/uint128_test.v
+++ b/vlib/math/unsigned/uint128_test.v
@@ -1,5 +1,6 @@
 import math.big
 import math.unsigned
+import rand
 
 fn test_str() {
 	x := unsigned.uint128_from_dec_str('170141183460469231713240559642174554112') or { panic('') }
@@ -240,4 +241,14 @@ fn test_div_128() {
 			}
 		}
 	}
+}
+
+fn test_put_bytes() {
+	a := unsigned.uint128_new(rand.u64(), rand.u64())
+	b := a.reverse_bytes()
+	mut buf_a := []u8{len: 16}
+	mut buf_b := []u8{len: 16}
+	a.put_bytes(mut buf_a)
+	b.put_bytes(mut buf_b)
+	assert buf_a == buf_b.reverse()
 }


### PR DESCRIPTION
The two-line patch speaks for itself and test can not pass on `master`.

p.s. I'm not sure if I have the right(s) to include and rely on the `rand` module for random numbers, but it can always be redone.