### PR TITLE
cgen: fix codegen for generating operator overload method_name on alias to builtin types

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -164,7 +164,8 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 			g.styp(left.unaliased.set_nr_muls(0))
 		}
 		mut is_builtin_or_alias_to_builtin := left.sym.is_builtin()
-		if !is_builtin_or_alias_to_builtin && left.sym.info is ast.Alias {
+		if !has_alias_eq_op_overload && !is_builtin_or_alias_to_builtin
+			&& left.sym.info is ast.Alias {
 			alias_info := left.sym.info as ast.Alias
 			parent_sym := g.table.sym(alias_info.parent_type)
 			is_builtin_or_alias_to_builtin = parent_sym.is_builtin()

--- a/vlib/v/tests/aliases/alias_eq_op_test.v
+++ b/vlib/v/tests/aliases/alias_eq_op_test.v
@@ -1,0 +1,10 @@
+type MyInt = int
+
+fn (i1 MyInt) == (i2 MyInt) bool {
+	return int(i1) == int(i2)
+}
+
+fn test_main() {
+	c := MyInt(3) == MyInt(1)
+	assert c == false
+}


### PR DESCRIPTION
Fix #25709