### PR TITLE
parser: allow for `|mut x, y|expr`

### DIFF
--- a/vlib/v/checker/if.v
+++ b/vlib/v/checker/if.v
@@ -156,7 +156,7 @@ fn (mut c Checker) if_expr(mut node ast.IfExpr) ast.Type {
 					c.error('non-bool type `${c.table.type_to_str(cond_typ)}` used as if condition',
 						branch.cond.pos())
 				}
-				if !c.pref.translated && !c.file.is_translated {
+				if !c.pref.translated && !c.file.is_translated && !c.inside_unsafe {
 					mut check_expr := branch.cond
 					t_expr := c.checker_transformer.expr(mut check_expr)
 					if t_expr is ast.BoolLiteral {

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -1017,6 +1017,7 @@ fn (mut p Parser) lambda_expr() ?ast.LambdaExpr {
 	// a) `f(||expr)` for a callback lambda expression with 0 arguments
 	// b) `f(|a_1,...,a_n| expr_with_a_1_etc_till_a_n)` for a callback with several arguments
 	if !(p.tok.kind == .logical_or
+		|| (p.peek_token(1).kind == .key_mut && p.peek_token(2).kind == .name)
 		|| (p.peek_token(1).kind == .name && p.peek_token(2).kind == .pipe)
 		|| (p.peek_token(1).kind == .name && p.peek_token(2).kind == .comma)) {
 		return none

--- a/vlib/v/tests/fns/lambda_expr_with_mut_param_test.v
+++ b/vlib/v/tests/fns/lambda_expr_with_mut_param_test.v
@@ -1,0 +1,29 @@
+struct Window {
+mut:
+	calls   int
+	on_init fn (mut w Window)        = unsafe { nil }
+	cb      fn (mut w Window, x int) = unsafe { nil }
+}
+
+fn (mut w Window) run() {
+	w.on_init(mut w)
+	w.cb(mut w, w.calls)
+}
+
+fn (mut w Window) method_with_mut_receiver() {
+	w.calls++
+}
+
+fn test_mut_lambda_expr() {
+	mut window := Window{
+		on_init: |mut w| w.method_with_mut_receiver()
+		cb:      |mut w, mut y| unsafe {
+			if true {
+				assert y == 1
+				w.calls++
+			}
+		}
+	}
+	window.run()
+	assert window.calls == 2
+}


### PR DESCRIPTION
Fix #25734 .