### PR TITLE
parser: fix last stmt is fn call in or_expr

### DIFF
--- a/vlib/v/tests/last_stmt_fn_call_or_expr_test.v
+++ b/vlib/v/tests/last_stmt_fn_call_or_expr_test.v
@@ -1,0 +1,22 @@
+module main
+
+fn x1() ?int {
+	return none
+}
+
+fn x2() ?int {
+	return none
+}
+
+fn x3() ?int {
+	return none
+}
+
+fn def() int {
+	return 123
+}
+
+fn test_last_stmt_fn_call_or_expr() {
+	y := x1() or { x2() or { x3() or { def() } } }
+	assert y == 123
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #25732

In `mark_last_call_return_as_used()`, if the expr has a `or_expr`, we need to check and set the last expr in the `or_expr` as used.
