### PR TITLE
cgen: cast member variables to correct types in comptime $for

### DIFF
--- a/vlib/v/tests/comptime/comptime_for_in_options_struct_test.v
+++ b/vlib/v/tests/comptime/comptime_for_in_options_struct_test.v
@@ -10,7 +10,7 @@ fn unwrap_not_none_field_types[T](t T) []string {
 		v := t.$(f.name)
 		$if f is $option {
 			if v != none {
-				arr << typeof(v).name
+				arr << '${typeof(v).name}:${f.name}=`${v}`'
 			}
 		}
 	}
@@ -23,5 +23,5 @@ fn test_main() {
 		b: 1
 		c: 2.3
 	})
-	assert arr.join(' ') == 'string int f64'
+	assert arr.join(' ') == 'string:a=`x` int:b=`1` f64:c=`2.3`'
 }

--- a/vlib/v/tests/comptime/comptime_var_assignment_test.v
+++ b/vlib/v/tests/comptime/comptime_var_assignment_test.v
@@ -26,6 +26,6 @@ fn test_main() {
 	out := encode_struct(FixedStruct1{1, 'foo', 4, 'bar'})
 	assert out[0] == '1'
 	assert out[1] == 'foo'
-	assert out[2] == 'Option(4)'
-	assert out[3] == "Option('bar')"
+	assert out[2] == '4'
+	assert out[3] == 'bar'
 }


### PR DESCRIPTION
Fixes #25771.

Updated the test to include the value checking from the issue.
This affected `vlib/v/tests/comptime/comptime_var_assignment_test.v` and it seems more correct now? Let me know if it looks incorrect but I think the updated behavior is more correct.