### PR TITLE
os.notify: fix struct epoll_event alignment

### DIFF
--- a/vlib/os/notify/epoll.h
+++ b/vlib/os/notify/epoll.h
@@ -1,6 +1,12 @@
 // NOTE: tcc does not support yet __attribute__ ((__packed__)) properly, 
 // so the __EPOLL_PACKED macro that /usr/include/bits/epoll.h uses does not work :-| .
 // However, it *does support* the older `#pragma pack(push, 1)`
+#if defined(__TINYC__) && defined(__V_amd64)
 #pragma pack(push, 1)
+#endif
+
 #include <sys/epoll.h>
+
+#if defined(__TINYC__) && defined(__V_amd64)
 #pragma pack(pop)
+#endif


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Original code force  `struct epoll_event` size = 12 under ARM64/Linux, this is not true, as it's size = 16.
Fix issue #25778