### PR TITLE
checker,cgen,type_resolver: prevent stale type cast on comptime for, …

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3179,6 +3179,18 @@ pub fn (mut c Checker) expr(mut node ast.Expr) ast.Type {
 				} else if (node.expr as ast.Ident).name in c.type_resolver.type_map {
 					node.expr_type = c.type_resolver.get_ct_type_or_default((node.expr as ast.Ident).name,
 						node.expr_type)
+				} else if node.expr.obj is ast.Var {
+					var_obj := node.expr.obj as ast.Var
+					if var_obj.smartcasts.len > 0 {
+						node.expr_type = c.unwrap_generic(var_obj.smartcasts.last())
+					}
+				}
+			} else if mut node.expr is ast.Ident {
+				if node.expr.obj is ast.Var {
+					var_obj := node.expr.obj as ast.Var
+					if var_obj.smartcasts.len > 0 {
+						node.expr_type = c.unwrap_generic(var_obj.smartcasts.last())
+					}
 				}
 			}
 			c.check_expr_option_or_result_call(node.expr, node.expr_type)

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -137,7 +137,10 @@ fn (mut c Checker) match_expr(mut node ast.MatchExpr) ast.Type {
 				c.cur_ct_id++
 				branch.id = c.cur_ct_id
 			}
-			idx_str := comptime_branch_context_str + '|id=${branch.id}|'
+			mut idx_str := comptime_branch_context_str + '|id=${branch.id}|'
+			if c.comptime.inside_comptime_for && c.comptime.comptime_for_field_var != '' {
+				idx_str += '|field_type=${c.comptime.comptime_for_field_type}|'
+			}
 			mut c_str := ''
 			if !branch.is_else {
 				if c.inside_x_matches_type {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -423,7 +423,10 @@ fn (mut g Gen) comptime_if(node ast.IfExpr) {
 		// The first part represents the current context of the branch statement, `comptime_branch_context_str`, formatted like `T=int,X=string,method.name=json`
 		// The second part is the branch's id.
 		// This format must match what is in `checker`.
-		idx_str := comptime_branch_context_str + '|id=${branch.id}|'
+		mut idx_str := comptime_branch_context_str + '|id=${branch.id}|'
+		if g.comptime.inside_comptime_for && g.comptime.comptime_for_field_var != '' {
+			idx_str += '|field_type=${g.comptime.comptime_for_field_type}|'
+		}
 		if comptime_is_true := g.table.comptime_is_true[idx_str] {
 			// `g.table.comptime_is_true` are the branch condition results set by `checker`
 			is_true = comptime_is_true
@@ -1013,7 +1016,10 @@ fn (mut g Gen) comptime_match(node ast.MatchExpr) {
 		// The first part represents the current context of the branch statement, `comptime_branch_context_str`, formatted like `T=int,X=string,method.name=json`
 		// The second part is the branch's id.
 		// This format must match what is in `checker`.
-		idx_str := comptime_branch_context_str + '|id=${branch.id}|'
+		mut idx_str := comptime_branch_context_str + '|id=${branch.id}|'
+		if g.comptime.inside_comptime_for && g.comptime.comptime_for_field_var != '' {
+			idx_str += '|field_type=${g.comptime.comptime_for_field_type}|'
+		}
 		if comptime_is_true := g.table.comptime_is_true[idx_str] {
 			// `g.table.comptime_is_true` are the branch condition results set by `checker`
 			is_true = comptime_is_true

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -42,7 +42,21 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 			}
 		}
 	} else if node.expr is ast.Ident && node.expr.ct_expr {
-		expr_type = g.type_resolver.get_type(node.expr)
+		for {
+			if node.expr.obj is ast.Var {
+				if node.expr.obj.ct_type_var == .field_var && g.comptime.inside_comptime_for
+					&& g.comptime.comptime_for_field_var != '' {
+					expr_type = if node.expr.obj.ct_type_unwrapped || node.expr.obj.is_unwrapped {
+						g.comptime.comptime_for_field_type.clear_flag(.option)
+					} else {
+						g.comptime.comptime_for_field_type
+					}
+					break
+				}
+			}
+			expr_type = g.type_resolver.get_type(node.expr)
+			break
+		}
 		name = g.styp(g.unwrap_generic(expr_type.clear_flags(.shared_f, .result))).replace('*',
 			'')
 	} else if node.expr is ast.SelectorExpr && node.expr.expr is ast.Ident
@@ -83,7 +97,25 @@ fn (mut g Gen) dump_expr(node ast.DumpExpr) {
 		if expr_type.has_flag(.option_mut_param_t) {
 			g.write('*')
 		}
-		g.expr(node.expr)
+		for {
+			if node.expr is ast.Ident {
+				if node.expr.obj is ast.Var {
+					if node.expr.obj.ct_type_var == .field_var && g.comptime.inside_comptime_for
+						&& (node.expr.obj.ct_type_unwrapped || node.expr.obj.is_unwrapped) {
+						field_type := g.comptime.comptime_for_field_type
+						if field_type.has_flag(.option) {
+							styp := g.base_type(field_type.clear_flag(.option))
+							is_auto_heap := node.expr.is_auto_heap()
+							ptr := if is_auto_heap { '->' } else { '.' }
+							g.write('(*(${styp}*)${c_name(node.expr.name)}${ptr}data)')
+							break
+						}
+					}
+				}
+			}
+			g.expr(node.expr)
+			break
+		}
 		g.inside_opt_or_res = old_inside_opt_or_res
 	}
 	g.write(')')

--- a/vlib/v/tests/comptime/comptime_for_in_options_struct_test.v
+++ b/vlib/v/tests/comptime/comptime_for_in_options_struct_test.v
@@ -11,10 +11,38 @@ fn unwrap_not_none_field_types[T](t T) []string {
 		$if f is $option {
 			if v != none {
 				arr << '${typeof(v).name}:${f.name}=`${v}`'
+
+				w := v // assign
+
+				$if w is string {
+					t_string(w) // fn call with string value
+				}
+
+				t_generic(w) // fn call with generic value
 			}
 		}
 	}
 	return arr
+}
+
+fn t_string(s string) {
+	assert s == 'x'
+}
+
+fn t_generic[T](t T) {
+	$if t is int {
+		assert t == 1
+		return
+	}
+	$if t is f64 {
+		assert t == 2.3
+		return
+	}
+	$if t is string {
+		t_string(t)
+		return
+	}
+	assert false
 }
 
 fn test_main() {

--- a/vlib/v/type_resolver/type_resolver.v
+++ b/vlib/v/type_resolver/type_resolver.v
@@ -207,8 +207,13 @@ pub fn (mut t TypeResolver) get_type(node ast.Expr) ast.Type {
 				}
 				.field_var {
 					// field var from $for loop
-					if node.obj.ct_type_unwrapped {
-						t.info.comptime_for_field_type.clear_flag(.option)
+					unwrapped_field_type := t.info.comptime_for_field_type.clear_flag(.option)
+					if t.info.comptime_for_field_type.has_flag(.option)
+						&& node.obj.typ != ast.void_type && !node.obj.typ.has_flag(.option)
+						&& node.obj.typ == unwrapped_field_type {
+						node.obj.typ
+					} else if node.obj.ct_type_unwrapped {
+						unwrapped_field_type
 					} else {
 						t.info.comptime_for_field_type
 					}


### PR DESCRIPTION
Fixes #25781.

I really hope I fixed all the issues with comptime for at this point. There was some issues with stale type references being used in assignment inside comptime for, `value != none` was also not casting `value`  to a some type and `$if v is string` would evaluate to true on all iterations inside the loop in the test (due to the stale reference).

I added multiple cases of the below code snippet:
```
mut idx_str := comptime_branch_context_str + '|id=${branch.id}|'
if c.comptime.inside_comptime_for && c.comptime.comptime_for_field_var != '' {
	idx_str += '|field_type=${c.comptime.comptime_for_field_type}|'
}
```
Maybe might want to make it into a function.