### PR TITLE
builtin,cgen: ensure array of string is not cloned with depth 0

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -724,6 +724,13 @@ pub fn (a &array) clone_to_depth(depth int) array {
 			unsafe { arr.set_unsafe(i, &ar_clone) }
 		}
 		return arr
+	} else if depth > 0 && a.element_size == sizeof(string) && a.len >= 0 && a.cap >= a.len {
+		for i in 0 .. a.len {
+			str_ptr := unsafe { &string(a.get_unsafe(i)) }
+			str_clone := (*str_ptr).clone()
+			unsafe { arr.set_unsafe(i, &str_clone) }
+		}
+		return arr
 	} else {
 		if a.data != 0 && source_capacity_in_bytes > 0 {
 			unsafe { vmemcpy(&u8(arr.data), a.data, source_capacity_in_bytes) }

--- a/vlib/os/os_args_autofree_test.v
+++ b/vlib/os/os_args_autofree_test.v
@@ -1,0 +1,14 @@
+// vtest build: !sanitize-memory-gcc && !sanitize-address-gcc && !sanitize-address-clang
+// vtest vflags: -autofree
+import os
+
+fn test_os_args_no_double_free() {
+	args := os.args
+	assert args.len > 0
+}
+
+fn test_os_args_clone() {
+	a1 := os.args
+	a2 := os.args
+	assert a1 == a2
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -8532,6 +8532,8 @@ pub fn (mut g Gen) get_array_depth(el_typ ast.Type) int {
 	if sym.kind == .array {
 		info := sym.info as ast.Array
 		return 1 + g.get_array_depth(info.elem_type)
+	} else if sym.kind in [.string, .map] {
+		return 1
 	} else {
 		return 0
 	}


### PR DESCRIPTION
Fixes #25783.

`os.args` would clone with depth 0 when assigning it, which would cause any variable set to it to free a pointer to it (double free). This solution just uses depth 1 instead which means it can free both pointers normally. I looked at having a `@[manualfree]` for constants but that doesn't work with more than one assignment of `os.args`.