### PR TITLE
checker: Allow explicit sumtype to option casts

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3547,10 +3547,14 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 	if from_type == ast.void_type {
 		c.error('expression does not return a value so it cannot be cast', node.expr.pos())
 	}
-	inner_to_type := if to_type.has_flag(.option) { to_type.clear_flag(.option) } else { ast.void_type }
+	inner_to_type := if to_type.has_flag(.option) {
+		to_type.clear_flag(.option)
+	} else {
+		ast.void_type
+	}
 	if to_type.has_flag(.option) && from_type == ast.none_type {
 		// allow conversion from none to every option type
-	} else if to_type.has_flag(.option) && from_type  == inner_to_type {
+	} else if to_type.has_flag(.option) && from_type == inner_to_type {
 		return to_type
 	} else if to_sym.kind == .sum_type {
 		to_sym_info := to_sym.info as ast.SumType

--- a/vlib/v/tests/options/option_sumtype_explicit_cast_test.v
+++ b/vlib/v/tests/options/option_sumtype_explicit_cast_test.v
@@ -9,7 +9,7 @@ fn test_sumtype_explicit_to_option_sumtype() {
 	a := ?SumType(value)
 	assert a != none
 	assert a? == SumType(u16(0))
-} 
+}
 
 fn test_sumtype_explicit_to_option_sumtype_generic() {
 	value := SumType(u16(1))


### PR DESCRIPTION
This fixes #25796 by allowing explicit casts from a sum type `T` to its option type `?T`, just like with non-sum types. 
Before this, code like `?SumType(SumType(u16(0)))` failed because `SumType -> ?SumType` wasn’t allowed.

The fix adds a check that lets you cast to `?T` when the value is exactly type `T`, even if `T` is a sum type.