### PR TITLE
pref: fix photonwrapper download by using GitHub Raw URL

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -993,7 +993,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					vexe := vexe_path()
 					vroot := os.dir(vexe)
 					so_path := os.join_path(vroot, 'thirdparty', 'photon', 'photonwrapper.so')
-					so_url := 'https://github.com/vlang/photonbin/raw/master/photonwrapper_${os.user_os()}_${arch}.so'
+					so_url := 'https://raw.githubusercontent.com/vlang/photonbin/master/photonwrapper_${os.user_os()}_${arch}.so'
 					if !os.exists(so_path) {
 						println('coroutines .so not found, downloading...')
 						os.execute_opt('wget -O "${so_path}" "${so_url}"') or {


### PR DESCRIPTION
This change fixes #25708. To summarize, when compiling with `-use-coroutines` `v` fails to download the correct photonwrapper.so library via `cUrl`. I opted to just use a raw github url vs adding `-L` option to `cURL`.

Tested by compiling and running coroutine examples in https://github.com/rrpolanco/v/tree/fix-photonwrapper-download-for-macos/examples/coroutines.