### PR TITLE
veb: Unnecessary information is printed by `send_file` during user access.

### DIFF
--- a/vlib/veb/context.v
+++ b/vlib/veb/context.v
@@ -192,7 +192,6 @@ pub fn (mut ctx Context) file(file_path string) Result {
 }
 
 fn (mut ctx Context) send_file(content_type string, file_path string) Result {
-	// println('send_file ct=${content_type} path=${file_path}')
 	mut file := os.open(file_path) or {
 		eprint('[veb] error while trying to open file: ${err.msg()}')
 		ctx.res.set_status(.not_found)


### PR DESCRIPTION
Every time a user visits, the console prints a large amount of information about send_file, which severely interferes with log storage. The situation is similar to the following:

```
send_file ct=text/css path=static/css/style.css
send_file ct=text/javascript path=static/js/tools.js
send_file ct=text/javascript path=static/js/script.js
send_file ct=text/javascript path=static/js/node_modules/chart.js/dist/chart.umd.js
send_file ct=text/javascript path=static/js/node_modules/ionicons/dist/ionicons/ionicons.esm.js
send_file ct=image/png path=static/image/logo.png
send_file ct=text/javascript path=static/js/node_modules/ionicons/dist/ionicons/p-e26ac56f.js
send_file ct=text/javascript path=static/js/node_modules/ionicons/dist/ionicons/p-5c60b45e.entry.js
send_file ct=text/javascript path=static/js/node_modules/ionicons/dist/ionicons/p-3f680f7e.js
send_file ct=image/svg+xml path=static/js/node_modules/ionicons/dist/ionicons/svg/close-outline.svg
send_file ct=image/svg+xml path=static/js/node_modules/ionicons/dist/ionicons/svg/menu-outline.svg
```

After auditing the code, it was found that this issue is unrelated to the debug or production environment. Whenever the `send_file()` function is called, logs are printed. The printed content is mainly useful for checking Veb availability, such as when I set the following status:

```v
app.handle_static('static', true) or {
        panic(err)
}
```

The file location on the website should be `ip:port/js/tools.js`, but the output address is `path=static/js/tools.js`. I believe this is not helpful for actual work. After tracing the source of this code, it was discovered that it was added during a major update of Veb. I suspect this is a result of forgetting to remove the print statements during the debugging process. Therefore, I am submitting this PR to comment out this print statement.