### PR TITLE
cgen: use variadic_count == 1 when passing variadic to call of same a…

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2612,7 +2612,7 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 					}
 				} else {
 					// passing variadic arg to another call which expects same array type
-					if args.len == 1
+					if variadic_count == 1
 						&& ((args[arg_nr].typ.has_flag(.variadic) && args[arg_nr].typ == varg_type)
 						|| (varg_type.has_flag(.variadic)
 						&& args[arg_nr].typ == varg_type.clear_flag(.variadic))) {

--- a/vlib/v/tests/fns/variadic_fn_chain_test.v
+++ b/vlib/v/tests/fns/variadic_fn_chain_test.v
@@ -1,0 +1,9 @@
+fn called(s string, l ...string) {}
+
+fn caller(s string, l ...string) {
+	called(s, l)
+}
+
+fn test_main() {
+	caller('')
+}


### PR DESCRIPTION
Fixes #25827.

Does not fix the weird behavior that @jorgeluismireles observed with variadics passed to a function that takes a string parameter (here https://github.com/vlang/v/issues/25827#issuecomment-3576696815), I suspect it's partially intended behavior that is too broad.