### PR TITLE
math.vec: second attempt to fix project() for vec2,3,4

### DIFF
--- a/vlib/math/vec/vec2.v
+++ b/vlib/math/vec/vec2.v
@@ -264,22 +264,22 @@ pub fn (v Vec2[T]) perpendicular(u Vec2[T]) Vec2[T] {
 }
 
 // project returns the projected vector.
-// The projection of vector `u` onto vector `v` is the orthogonal projection
-// of `u` onto a straight line parallel to `v` that passes through the origin.
-// This is equivalent to the vector projection of `u` onto the unit vector in the direction of `v`.
-// and is given by the formula: proj_v(u) = (u · v / |v|^2) * v
-// where "·" denotes the dot product and |v| is the magnitude of vector `v`.
-// If `u` is a zero vector, the result will also be a zero vector.
+// The projection of vector `v` onto vector `u` is the orthogonal projection
+// of `v` onto a straight line parallel to `u` that passes through the origin.
+// This is equivalent to the vector projection of `v` onto the unit vector in the direction of `u`.
+// and is given by the formula: proj_v(u) = (v · u / |u|^2) * u
+// where "·" denotes the dot product and |u| is the magnitude of vector `u`.
+// If `v` is a zero vector, the result will also be a zero vector.
 // example:
 // ```v
 // v := vec2[f32](3, 4)
 // u := vec2[f32](5, 6)
 // proj := v.project(u)
-// println(proj) // Output: vec2[f32](3.61, 4.81)
+// println(proj) // Output: vec2[f32](3.1967213, 3.8360658)
 // ```
 pub fn (v Vec2[T]) project(u Vec2[T]) Vec2[T] {
-	scale := u.dot(v) / v.dot(v)
-	return v.mul_scalar(scale)
+	scale := T(v.dot(u) / u.dot(u))
+	return u.mul_scalar(scale)
 }
 
 // rotate_around_cw returns the vector `v` rotated *clockwise* `radians` around an origin vector `o` in Cartesian space.

--- a/vlib/math/vec/vec2_test.v
+++ b/vlib/math/vec/vec2_test.v
@@ -232,14 +232,14 @@ fn test_vec2_rotate_around_ccw_2() {
 // Test for Vec2 projection
 //
 fn test_vec2_project_onto_basic() {
-	u := vec.vec2(3.0, 4.0) // magnitude 5 vector
 	v := vec.vec2(5.0, 6.0) // magnitude ~7.81 vector
+	u := vec.vec2(3.0, 4.0) // magnitude 5 vector
 	// hand-computed:
-	// u·v = 5*3 + 6*4 = 39
-	// |v|^2 = 3^2 + 4^2 = 25
+	// v·u = 5*3 + 6*4 = 39
+	// |u|^2 = 3^2 + 4^2 = 25
 	// scale = 39/25 = 1.56
-	// proj = scale * v = (1.56*3, 1.56*4) = (4.68, 6.24)
-	proj := u.project(v)
+	// proj = scale * u = (1.56*3, 1.56*4) = (4.68, 6.24)
+	proj := v.project(u)
 	assert tolerance(proj.x, 4.68, vec.vec_epsilon)
 	assert tolerance(proj.y, 6.24, vec.vec_epsilon)
 }
@@ -247,9 +247,9 @@ fn test_vec2_project_onto_basic() {
 // Test for Vec2 projection onto zero vector
 // project v into the null vector
 fn test_vec2_project_onto_zero() {
-	u := vec.vec2(0.0, 0.0)
 	v := vec.vec2(5.0, 6.0)
-	proj := u.project(v)
+	u := vec.vec2(0.0, 0.0)
+	proj := v.project(u)
 	// must be nan
 	assert is_nan(proj.x)
 	assert is_nan(proj.y)
@@ -258,9 +258,9 @@ fn test_vec2_project_onto_zero() {
 // Test for Vec2 projection of zero vector
 // project a null vector
 fn test_vec2_project_zero_vector() {
-	u := vec.vec2(3.0, 4.0)
 	v := vec.vec2(0.0, 0.0)
-	proj := u.project(v)
+	u := vec.vec2(3.0, 4.0)
+	proj := v.project(u)
 	assert proj.x == 0.0
 	assert proj.y == 0.0
 }
@@ -277,8 +277,8 @@ fn test_vec2_project_onto_self() {
 // Test for Vec2 projection onto orthogonal vector
 //
 fn test_vec2_project_onto_orthogonal() {
-	u := vec.vec2(1.0, 0.0)
 	v := vec.vec2(0.0, 1.0)
+	u := vec.vec2(1.0, 0.0)
 	proj := u.project(v)
 	// more sensitive to floating point errors so i think close is better here
 	assert close(proj.x, 0.0)
@@ -288,14 +288,14 @@ fn test_vec2_project_onto_orthogonal() {
 // Test for Vec2 projection with negative components
 //
 fn test_vec2_project_negative_components() {
-	u := vec.vec2(-3.0, 4.0)
 	v := vec.vec2(5.0, -6.0)
+	u := vec.vec2(-3.0, 4.0)
 	// hand-computed:
-	// u·v = 5*-3 + -6*4 = -15 - 24 = -39
-	// |v|^2 = -3^2 + 4^2 = 9 + 16 = 25
+	// v·u = 5*-3 + -6*4 = -15 - 24 = -39
+	// |u|^2 = -3^2 + 4^2 = 9 + 16 = 25
 	// scale = -39/25 = -1.56
-	// proj = scale * v = (-1.56*-3, -1.56*4) = (4.68, -6.24)
-	proj := u.project(v)
+	// proj = scale * u = (-1.56*-3, -1.56*4) = (4.68, -6.24)
+	proj := v.project(u)
 	assert tolerance(proj.x, 4.68, vec.vec_epsilon)
 	assert tolerance(proj.y, -6.24, vec.vec_epsilon)
 }

--- a/vlib/math/vec/vec3.v
+++ b/vlib/math/vec/vec3.v
@@ -260,18 +260,17 @@ pub fn (v Vec3[T]) perpendicular(u Vec3[T]) Vec3[T] {
 }
 
 // project returns the projected vector.
-// The projection of vector `u` onto vector `v` is the orthogonal projection
-// of `u` onto a straight line parallel to `v` that passes through the origin.
-// This is equivalent to the vector projection of `u` onto the unit vector in the direction of `v`.
-// and is given by the formula: proj_v(u) = (u · v / |v|^2) * v
-// where "·" denotes the dot product and |v| is the magnitude of vector `v`.
-// If `u` is a zero vector, the result will also be a zero vector.
+// The projection of vector `v` onto vector `u` is the orthogonal projection
+// of `v` onto a straight line parallel to `u` that passes through the origin.
+// This is equivalent to the vector projection of `v` onto the unit vector in the direction of `u`.
+// and is given by the formula: proj_v(u) = (v · u / |u|^2) * u
+// where "·" denotes the dot product and |u| is the magnitude of vector `u`.
+// If `v` is a zero vector, the result will also be a zero vector.
 // example:
 // TODO: add examples
-// ```
 pub fn (v Vec3[T]) project(u Vec3[T]) Vec3[T] {
-	scale := T(u.dot(v) / v.dot(v))
-	return v.mul_scalar(scale)
+	scale := T(v.dot(u) / u.dot(u))
+	return u.mul_scalar(scale)
 }
 
 // eq returns a bool indicating if the two vectors are equal.

--- a/vlib/math/vec/vec3_test.v
+++ b/vlib/math/vec/vec3_test.v
@@ -92,14 +92,14 @@ fn test_vec3_f64_utils_2() {
 
 // sample tests for vec3 projection
 fn test_vec3_project_onto_basic() {
-	u := vec.vec3(3.0, 4.0, 0.0) // magnitude 5 vector
 	v := vec.vec3(5.0, 6.0, 0.0) // magnitude ~7.81 vector
+	u := vec.vec3(3.0, 4.0, 0.0) // magnitude 5 vector
 	// hand-computed:
-	// u·v = 5*3 + 6*4 + 0*0 = 39
-	// |v|^2 = 3^2 + 4^2 +0^2 = 25
+	// v·u = 5*3 + 6*4 + 0*0 = 39
+	// |u|^2 = 3^2 + 4^2 +0^2 = 25
 	// scale = 39/25 = 1.56
-	// proj = scale * v = (1.56*3, 1.56*4, 1.56*0) = (4.68, 6.24, 0)
-	proj := u.project(v)
+	// proj = scale * u = (1.56*3, 1.56*4, 1.56*0) = (4.68, 6.24, 0)
+	proj := v.project(u)
 	assert veryclose(proj.x, 4.68)
 	assert veryclose(proj.y, 6.24)
 	assert veryclose(proj.z, 0.0)
@@ -108,9 +108,9 @@ fn test_vec3_project_onto_basic() {
 // Test for Vec3 projection onto zero vector
 //
 fn test_vec3_project_onto_zero() {
-	u := vec.vec3(3.0, 4.0, 0.0)
 	v := vec.vec3(0.0, 0.0, 0.0)
-	proj := u.project(v)
+	u := vec.vec3(3.0, 4.0, 0.0)
+	proj := v.project(u)
 	assert proj.x == 0.0
 	assert proj.y == 0.0
 	assert proj.z == 0.0
@@ -119,14 +119,14 @@ fn test_vec3_project_onto_zero() {
 // Test for vec3 projection at an angle
 //
 fn test_vec3_project_onto_angle() {
-	u := vec.vec3(1.0, 0.0, 0.0) // magnitude 1 vector
 	v := vec.vec3(1.0, 1.0, 0.0) // magnitude sqrt(2) vector
+	u := vec.vec3(1.0, 0.0, 0.0) // magnitude 1 vector
 	// hand-computed:
-	// u·v = 1*1 + 0*1 + 0*0 = 1
-	// |v|^2 = 1^2 + 0^2 +0^2 = 1
+	// v·u = 1*1 + 1*0 + 0*0 = 1
+	// |u|^2 = 1^2 + 0^2 +0^2 = 1
 	// scale = 1/1 = 1
-	// proj = scale * v = (1*1, 1*0, 1*0) = (1, 0, 0)
-	proj := u.project(v)
+	// proj = scale * u = (1*1, 1*0, 1*0) = (1, 0, 0)
+	proj := v.project(u)
 	assert veryclose(proj.x, 1.0)
 	assert veryclose(proj.y, 0.0)
 	assert veryclose(proj.z, 0.0)

--- a/vlib/math/vec/vec4.v
+++ b/vlib/math/vec/vec4.v
@@ -276,18 +276,17 @@ pub fn (v Vec4[T]) perpendicular(u Vec4[T]) Vec4[T] {
 }
 
 // project returns the projected vector.
-// The projection of vector `u` onto vector `v` is the orthogonal projection
-// of `u` onto a straight line parallel to `v` that passes through the origin.
-// This is equivalent to the vector projection of `u` onto the unit vector in the direction of `v`.
-// and is given by the formula: proj_v(u) = (u · v / |v|^2) * v
-// where "·" denotes the dot product and |v| is the magnitude of vector `v`.
-// If `u` is a zero vector, the result will also be a zero vector.
+// The projection of vector `v` onto vector `u` is the orthogonal projection
+// of `v` onto a straight line parallel to `u` that passes through the origin.
+// This is equivalent to the vector projection of `v` onto the unit vector in the direction of `u`.
+// and is given by the formula: proj_v(u) = (v · u / |u|^2) * u
+// where "·" denotes the dot product and |u| is the magnitude of vector `u`.
+// If `v` is a zero vector, the result will also be a zero vector.
 // example:
 // TODO: add examples
-// ```
 pub fn (v Vec4[T]) project(u Vec4[T]) Vec4[T] {
-	scale := u.dot(v) / v.dot(v)
-	return v.mul_scalar(scale)
+	scale := T(v.dot(u) / u.dot(u))
+	return u.mul_scalar(scale)
 }
 
 // eq returns a bool indicating if the two vectors are equal.

--- a/vlib/math/vec/vec4_test.v
+++ b/vlib/math/vec/vec4_test.v
@@ -100,14 +100,14 @@ fn test_vec4_f64_utils_2() {
 
 // sample tests for vec4 projection
 fn test_vec4_project_onto_basic() {
-	u := vec.vec4(3.0, 4.0, 0.0, 0.0) // magnitude 5 vector
 	v := vec.vec4(5.0, 6.0, 0.0, 0.0) // magnitude ~7.81 vector
+	u := vec.vec4(3.0, 4.0, 0.0, 0.0) // magnitude 5 vector
 	// hand-computed:
-	// u·v = 5*3 + 6*4 + 0*0 + 0*0 = 39
-	// |v|^2 = 3^2 + 4^2 +0^2 +0^2 = 25
-	proj := u.project(v)
-	assert proj.x == 3.0
-	assert proj.y == 4.0
+	// v·u = 5*3 + 6*4 + 0*0 + 0*0 = 39
+	// |u|^2 = 3^2 + 4^2 +0^2 +0^2 = 25
+	proj := v.project(u)
+	assert proj.x == 4.68
+	assert proj.y == 6.24
 	assert proj.z == 0.0
 	assert proj.w == 0.0
 }
@@ -115,9 +115,9 @@ fn test_vec4_project_onto_basic() {
 // Test for Vec4 projection onto zero vector
 //
 fn test_vec4_project_onto_zero() {
-	u := vec.vec4(3.0, 4.0, 0.0, 0.0)
 	v := vec.vec4(0.0, 0.0, 0.0, 0.0)
-	proj := u.project(v)
+	u := vec.vec4(3.0, 4.0, 0.0, 0.0)
+	proj := v.project(u)
 	assert proj.x == 0.0
 	assert proj.y == 0.0
 	assert proj.z == 0.0


### PR DESCRIPTION
The previous authors did a lot of work, but still got confused, sigh.
The changes turned out to be too large. The most frustrating thing is that I posted the correct solution to PR, but it was completely ignored. I decided to fix it with a single patch as well :). 

The function, comments, tests, line order, and the order of using variables `v` and `u` have been changed. The `vec3` version was tested against the `cglm` library, and then all the others were based on it.
