### PR TITLE
cgen,checker: handle array decompose for dynamic arrays and array init

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1524,6 +1524,20 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 			}
 		}
 		has_decompose = call_arg.expr is ast.ArrayDecompose
+		if !func.is_variadic && call_arg.expr is ast.ArrayDecompose {
+			if mut call_arg.expr is ast.ArrayDecompose {
+				if call_arg.expr.expr is ast.ArrayInit {
+					extra_params := func.params.len - i
+					array_init := call_arg.expr.expr as ast.ArrayInit
+					if array_init.exprs.len < extra_params {
+						elem_word := if array_init.exprs.len == 1 { 'element' } else { 'elements' }
+						verb_word := if extra_params == 1 { 'is' } else { 'are' }
+						c.error('array decompose has ${array_init.exprs.len} ${elem_word} but ${extra_params} ${verb_word} needed for `${func.name}`',
+							call_arg.pos)
+					}
+				}
+			}
+		}
 		already_checked := node.language != .js && call_arg.expr is ast.CallExpr
 		if func.is_variadic && param_i >= func.params.len - 1 {
 			param_sym := c.table.sym(param.typ)

--- a/vlib/v/checker/tests/array_init_decompose_extra_params.out
+++ b/vlib/v/checker/tests/array_init_decompose_extra_params.out
@@ -1,0 +1,20 @@
+vlib/v/checker/tests/array_init_decompose_extra_params.vv:33:11: error: array decompose has 1 element but 2 are needed for `print_2`
+   31 |   print_3(...arr4)
+   32 |
+   33 |   print_2(...['1'])
+      |           ~~~~~~~~
+   34 |   print_3(...['1', '2'])
+   35 |   print_4(...['1', '2', '3'])
+vlib/v/checker/tests/array_init_decompose_extra_params.vv:34:11: error: array decompose has 2 elements but 3 are needed for `print_3`
+   32 |
+   33 |   print_2(...['1'])
+   34 |   print_3(...['1', '2'])
+      |           ~~~~~~~~~~~~~
+   35 |   print_4(...['1', '2', '3'])
+   36 | }
+vlib/v/checker/tests/array_init_decompose_extra_params.vv:35:11: error: array decompose has 3 elements but 4 are needed for `print_4`
+   33 |   print_2(...['1'])
+   34 |   print_3(...['1', '2'])
+   35 |   print_4(...['1', '2', '3'])
+      |           ~~~~~~~~~~~~~~~~~~
+   36 | }

--- a/vlib/v/checker/tests/array_init_decompose_extra_params.vv
+++ b/vlib/v/checker/tests/array_init_decompose_extra_params.vv
@@ -1,0 +1,36 @@
+fn print_1(s string) {
+	dump(s)
+}
+
+fn print_2(s string, t string) {
+	dump('${s} ${t}')
+}
+
+fn print_3(s string, t string, u string) {
+	dump('${s} ${t} ${u}')
+}
+
+fn print_4(s string, t string, u string, v string) {
+	dump('${s} ${t} ${u} ${v}')
+}
+
+fn main() {
+  arr4 := ['Hello', 'World', 'V', '!']
+
+  print_1(...['Hello'])
+  print_2(...['Hello', 'World'])
+  print_3(...['Hello', 'World', '!'])
+  print_4(...['Hello', 'World', 'V', '!'])
+  print_4(...arr4)
+
+  print_1(...['Hello', 'World', 'V', '!'])
+  print_1(...arr4)
+  print_2(...['Hello', 'World', 'V', '!'])
+  print_2(...arr4)
+  print_3(...['Hello', 'World', 'V', '!'])
+  print_3(...arr4)
+
+  print_2(...['1'])
+  print_3(...['1', '2'])
+  print_4(...['1', '2', '3'])
+}

--- a/vlib/v/slow_tests/inout/panic_array_decompose_extra_args.out
+++ b/vlib/v/slow_tests/inout/panic_array_decompose_extra_args.out
@@ -1,0 +1,8 @@
+[vlib/v/slow_tests/inout/panic_array_decompose_extra_args.vv:2] s: a
+[vlib/v/slow_tests/inout/panic_array_decompose_extra_args.vv:2] s: a
+[vlib/v/slow_tests/inout/panic_array_decompose_extra_args.vv:6] '$s $t': a b
+[vlib/v/slow_tests/inout/panic_array_decompose_extra_args.vv:10] '$s $t $u': a b c
+[vlib/v/slow_tests/inout/panic_array_decompose_extra_args.vv:2] s: b
+[vlib/v/slow_tests/inout/panic_array_decompose_extra_args.vv:6] '$s $t': b c
+================ V panic ================
+V panic: array decompose: array has 3 elements but 4 elements are needed

--- a/vlib/v/slow_tests/inout/panic_array_decompose_extra_args.vv
+++ b/vlib/v/slow_tests/inout/panic_array_decompose_extra_args.vv
@@ -1,0 +1,31 @@
+fn print_1(s string) {
+	dump(s)
+}
+
+fn print_2(s string, t string) {
+	dump('${s} ${t}')
+}
+
+fn print_3(s string, t string, u string) {
+	dump('${s} ${t} ${u}')
+}
+
+fn print_4(s string, t string, u string, v string) {
+	dump('${s} ${t} ${u} ${v}')
+}
+
+fn main() {
+  array := ['a', 'b', 'c']
+
+  print_1(array[0])
+
+  print_1(...array)
+  print_2(...array)
+  print_3(...array)
+
+  print_1(...array[1..2])
+  print_2(...array[1..])
+
+  println('================ V panic ================')
+  print_4(...array)
+}


### PR DESCRIPTION
Fixes #25838.

Doing an array decompose on an array init can be verified by the checker, but this is not the case for dynamic arrays. Here I instead am adding a panic message that should be more useful.

Fixed array decomposition isn't allowed so no handling is needed for that.