### PR TITLE
crypto.cipher: fix xor_key_stream() for OFB mode, add test

### DIFF
--- a/vlib/crypto/cipher/ofb.v
+++ b/vlib/crypto/cipher/ofb.v
@@ -56,7 +56,7 @@ pub fn (mut x Ofb) xor_key_stream(mut dst []u8, src []u8) {
 
 			copy(mut x.next, x.out)
 
-			n := xor_bytes(mut local_dst, local_src, x.out)
+			n := xor_bytes(mut local_dst, local_src, x.out[x.out_used..])
 			local_dst = local_dst[n..]
 			local_src = local_src[n..]
 			x.out_used += n

--- a/vlib/crypto/cipher/ofb_test.v
+++ b/vlib/crypto/cipher/ofb_test.v
@@ -1,11 +1,12 @@
 import crypto.cipher
+import crypto.aes
 import crypto.des
 
 struct StreamCipher {
 	cipher cipher.Stream
 }
 
-fn test_ctr_stream_cipher() ! {
+fn test_ofb_stream_cipher() ! {
 	key := '123456789012345678901234'.bytes()
 	iv := 'abcdegfh'.bytes()
 
@@ -15,4 +16,18 @@ fn test_ctr_stream_cipher() ! {
 	s := StreamCipher{
 		cipher: c
 	}
+}
+
+fn test_ofb_byte_by_byte() {
+	key := []u8{len: 16, init: index}
+	iv := []u8{len: 16, init: index}
+	txt := []u8{len: 32, init: index}
+	mut out := []u8{len: 32}
+
+	mut ofb := cipher.new_ofb(aes.new_cipher(key), iv)
+	for i in 0 .. 32 {
+		ofb.xor_key_stream(mut out[i..i + 1], txt[i..i + 1])
+	}
+	assert out == [u8(10), 149, 9, 182, 69, 107, 246, 66, 249, 202, 158, 83, 202, 94, 228, 85,
+		190, 246, 12, 182, 85, 194, 184, 92, 243, 121, 164, 215, 69, 34, 168, 124]
 }


### PR DESCRIPTION
The tests showed that byte-by-byte operation does not work correctly, while block-by-block operation works properly in OFB mode.

Trivial typo in the code that was not tested, proof [#1](https://github.com/vlang/v/blob/master/vlib/crypto/cipher/ctr.v#L71) and [#2](https://github.com/vlang/v/blob/master/vlib/crypto/cipher/cfb.v#L89).

The test vector was created using `openssl`.
