### PR TITLE
checker: fix module var set at change_current_file()

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -338,6 +338,8 @@ pub fn (mut c Checker) change_current_file(file &ast.File) {
 	c.file = unsafe { file }
 	c.vmod_file_content = ''
 	c.mod = file.mod.name
+	c.is_just_builtin_mod = c.mod in ['builtin', 'builtin.closure']
+	c.is_builtin_mod = c.is_just_builtin_mod || c.mod in ['os', 'strconv']
 	c.is_generated = file.is_generated
 	c.short_module_names = ['builtin']
 	for import_sym in c.file.imports {
@@ -2407,9 +2409,6 @@ fn (mut c Checker) stmt(mut node ast.Stmt) {
 			c.interface_decl(mut node)
 		}
 		ast.Module {
-			c.mod = node.name
-			c.is_just_builtin_mod = node.name in ['builtin', 'builtin.closure']
-			c.is_builtin_mod = c.is_just_builtin_mod || node.name in ['os', 'strconv']
 			c.check_valid_snake_case(node.name, 'module name', node.pos)
 		}
 		ast.Return {


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Fix issue #25845 

This PR will help v set the module related vars in `change_current_file()`, not by processing the `module` statement.
As before processing `module` statement, `checker` will first check top-level exprs.

https://github.com/vlang/v/blob/b052af81c3969f173facffd5174177c4628ac187/vlib/v/checker/checker.v#L269-L278