### PR TITLE
builder: switch to c99 for linux

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -111,7 +111,7 @@ ifdef LEGACY
 	rm -rf $(TMPLEGACY)
 	$(eval override LDFLAGS+=-L$(realpath $(LEGACYLIBS))/lib -lMacportsLegacySupport)
 endif
-	$(CC) $(CFLAGS) -std=gnu99 -w -o v1$(EXE_EXT) $(VC)/$(VCFILE) -lm -lpthread $(LDFLAGS) || cmd/tools/cc_compilation_failed_non_windows.sh
+	$(CC) $(CFLAGS) -std=c99 -w -o v1$(EXE_EXT) $(VC)/$(VCFILE) -lm -lpthread $(LDFLAGS) || cmd/tools/cc_compilation_failed_non_windows.sh
 ifdef NETBSD
 	paxctl +m v1$(EXE_EXT)
 endif
@@ -229,4 +229,3 @@ etags:
 
 ctags:
 	./v$(EXE_EXT) -print-v-files cmd/v | grep -v :parse_text| ctags -L -
-

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -11,9 +11,7 @@ import v.vcache
 import term
 
 const c_std = 'c99'
-const c_std_gnu = 'gnu99'
 const cpp_std = 'c++17'
-const cpp_std_gnu = 'gnu++17'
 
 const c_verror_message_marker = 'VERROR_MESSAGE '
 
@@ -465,12 +463,7 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		}
 	}
 	if !v.pref.no_std {
-		if v.pref.os == .linux {
-			ccoptions.source_args << '-std=${c_std_gnu}'
-		} else {
-			ccoptions.source_args << '-std=${c_std}'
-		}
-		ccoptions.source_args << '-D_DEFAULT_SOURCE'
+		ccoptions.source_args << ['-std=${c_std}', '-D_DEFAULT_SOURCE']
 	}
 	$if trace_ccoptions ? {
 		println('>>> setup_ccompiler_options ccompiler: ${ccompiler}')
@@ -545,18 +538,10 @@ fn (mut v Builder) thirdparty_object_args(ccoptions CcompilerOptions, middle []s
 	mut all := []string{}
 
 	if !v.pref.no_std {
-		if v.pref.os == .linux {
-			if cpp_file {
-				all << '-std=${cpp_std_gnu}'
-			} else {
-				all << '-std=${c_std_gnu}'
-			}
+		if cpp_file {
+			all << '-std=${cpp_std}'
 		} else {
-			if cpp_file {
-				all << '-std=${cpp_std}'
-			} else {
-				all << '-std=${c_std}'
-			}
+			all << '-std=${c_std}'
 		}
 		all << '-D_DEFAULT_SOURCE'
 	}

--- a/vlib/v/help/build/build-c.txt
+++ b/vlib/v/help/build/build-c.txt
@@ -341,7 +341,7 @@ see also `v help build`.
       compiler, on the command line, without writing an .rsp file first.
 
    -no-std
-      By default, V passes -std=gnu99(linux)/-std=c99 to the C backend, but some compilers do
+      By default, V passes -std=c99 to the C backend, but some compilers do
       not support that, even though they may be able to compile the produced
       code, or have other options that can be tuned to allow it.
       Passing -no-std will remove that flag, and you can then use -cflags ''

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -227,7 +227,7 @@ pub mut:
 	fatal_errors     bool // unconditionally exit after the first error with exit(1)
 	reuse_tmpc       bool // do not use random names for .tmp.c and .tmp.c.rsp files, and do not remove them
 	no_rsp           bool // when true, pass C backend options directly on the CLI (do not use `.rsp` files for them, some older C compilers do not support them)
-	no_std           bool // when true, do not pass -std=gnu99(linux)/-std=c99 to the C backend
+	no_std           bool // when true, do not pass -std=c99 to the C backend
 
 	no_parallel       bool // do not use threads when compiling; slower, but more portable and sometimes less buggy
 	parallel_cc       bool // whether to split the resulting .c file into many .c files + a common .h file, that are then compiled in parallel, then linked together.


### PR DESCRIPTION
Fixes #25833.

`linux` gets defined by `#define linux 1` on gcc and clang for `-std=gnu99` if you are running on linux.