### PR TITLE
arrays: add subtract/2

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -782,14 +782,14 @@ pub fn each_indexed[T](a []T, cb fn (i int, e T)) {
 	}
 }
 
-// substract returns a new array consisting of the elements of array `a` that are not
+// subtract returns a new array consisting of the elements of array `a` that are not
 // among the elements of array `b`. Performance of this implementation tends to O(n+m),
 // where n and m are the lengths of input arrays.
 //
 // Note: The array element type must be valid type for V `map` keys.
 //
-// Example: arrays.substract([1, 2, 3, 4, 5, 6, 7], [3, 5, 6]) // -> [1, 2, 4, 7]
-pub fn substract[T](a []T, b []T) []T {
+// Example: arrays.subtract([1, 2, 3, 4, 5, 6, 7], [3, 5, 6]) // -> [1, 2, 4, 7]
+pub fn subtract[T](a []T, b []T) []T {
 	mut result := []T{cap: a.len}
 	mut bset := map[T]u8{}
 	for elem in b {

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -605,9 +605,9 @@ fn test_each_indexed() {
 	assert control_sum == sum
 }
 
-fn test_substract() {
-	assert substract([1, 2, 3, 4, 5, 6, 7], [3, 5, 6]) == [1, 2, 4, 7]
-	assert substract([1, 2, 3], [1, 2, 3]) == []
-	assert substract([]int{}, [1, 2, 3]) == []
-	assert substract([]int{}, []int{}) == []
+fn test_subtract() {
+	assert subtract([1, 2, 3, 4, 5, 6, 7], [3, 5, 6]) == [1, 2, 4, 7]
+	assert subtract([1, 2, 3], [1, 2, 3]) == []
+	assert subtract([]int{}, [1, 2, 3]) == []
+	assert subtract([]int{}, []int{}) == []
 }


### PR DESCRIPTION
Added a generic function `subtract` for subtracting array elements and a test.

```v
assert arrays.subtract([1, 2, 3, 4, 5, 6, 7], [3, 5, 6]) == [1, 2, 4, 7]
```

This is a convenient way to solve quite often task to find the difference between sets of elements. `arrays.diff` module is not suitable for this.