### PR TITLE
math.complex: replace == with eq_epsilon() in equals()

### DIFF
--- a/vlib/math/complex/complex.v
+++ b/vlib/math/complex/complex.v
@@ -372,5 +372,5 @@ pub fn (c Complex) acsch() Complex {
 
 // Complex Equals
 pub fn (c1 Complex) equals(c2 Complex) bool {
-	return c1.re == c2.re && c1.im == c2.im
+	return c1.re.eq_epsilon(c2.re) && c1.im.eq_epsilon(c2.im)
 }


### PR DESCRIPTION
Lets use `eq_epsilon()` for f64 comparison.
More robust and correct between systems.