### PR TITLE
transformer: disable generic str_intp opt

### DIFF
--- a/vlib/v/tests/generics/generics_str_intp_test.v
+++ b/vlib/v/tests/generics/generics_str_intp_test.v
@@ -1,0 +1,27 @@
+module main
+
+import strings
+
+pub struct MyStruct[T] {
+pub mut:
+	result T
+}
+
+pub fn (it MyStruct[T]) indent_str[T]() string {
+	mut res := strings.new_builder(32)
+	res.write_string('${it.result}')
+	return res.str()
+}
+
+fn test_generics_str_intp() {
+	x := MyStruct[int]{
+		result: 100
+	}
+
+	y := MyStruct[string]{
+		result: 'hello'
+	}
+
+	assert x.indent_str() == '100'
+	assert y.indent_str() == 'hello'
+}

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -1268,6 +1268,11 @@ pub fn (mut t Transformer) simplify_nested_interpolation_in_sb(mut onode ast.Stm
 		return false
 	}
 	original := nexpr.args[0].expr as ast.StringInterLiteral
+	if original.exprs.len != original.expr_types.len {
+		// This should be a generic type, e.g., `${it}` where `it` is type of T
+		// first time, `T` maybe `int`, but second time, `T` maybe `string`
+		return false
+	}
 	// only very simple string interpolations, without any formatting, like the following examples
 	// can be optimised to a list of simpler string builder calls, instead of using str_intp:
 	// >> sb.write_string('abc ${num}')


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #25896 

`transformer` can't handle generic string intp opt right now, so skip it.
