### PR TITLE
checker: match type when auto deref occurs

### DIFF
--- a/vlib/v/checker/tests/for_mut_compare_rune_string_err.out
+++ b/vlib/v/checker/tests/for_mut_compare_rune_string_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/for_mut_compare_rune_string_err.vv:4:6: error: infix expr: cannot use `string` (right expression) as `rune`
+    2 |     s := 'Hello, World!'
+    3 |     for mut c in s.runes() {
+    4 |         if c == ' ' {
+      |            ~~~~~~~~
+    5 |             c = `x`
+    6 |         }

--- a/vlib/v/checker/tests/for_mut_compare_rune_string_err.vv
+++ b/vlib/v/checker/tests/for_mut_compare_rune_string_err.vv
@@ -1,0 +1,8 @@
+fn main() {
+	s := 'Hello, World!'
+	for mut c in s.runes() {
+		if c == ' ' {
+			c = `x`
+		}
+	}
+}


### PR DESCRIPTION
Fixes #25913.

There is an auto deref that happens in the check against the string but the compared types do not match.