### PR TITLE
builtin: correct max size of strings for integers

### DIFF
--- a/vlib/builtin/int.v
+++ b/vlib/builtin/int.v
@@ -125,23 +125,23 @@ fn (nn int) str_l(max int) string {
 // str returns the value of the `i8` as a `string`.
 // Example: assert i8(-2).str() == '-2'
 pub fn (n i8) str() string {
-	return int(n).str_l(5)
+	return int(n).str_l(4)
 }
 
 // str returns the value of the `i16` as a `string`.
 // Example: assert i16(-20).str() == '-20'
 pub fn (n i16) str() string {
-	return int(n).str_l(7)
+	return int(n).str_l(6)
 }
 
 // str returns the value of the `u16` as a `string`.
 // Example: assert u16(20).str() == '20'
 pub fn (n u16) str() string {
-	return int(n).str_l(7)
+	return int(n).str_l(6)
 }
 
 pub fn (n i32) str() string {
-	return int(n).str_l(12)
+	return int(n).str_l(11)
 }
 
 pub fn (nn int) hex_full() string {
@@ -151,7 +151,11 @@ pub fn (nn int) hex_full() string {
 // str returns the value of the `int` as a `string`.
 // Example: assert int(-2020).str() == '-2020'
 pub fn (n int) str() string {
-	return n.str_l(12)
+	$if new_int ? {
+		return impl_i64_to_string(n)
+	} $else {
+		return n.str_l(11)
+	}
 }
 
 // str returns the value of the `u32` as a `string`.
@@ -164,7 +168,7 @@ pub fn (nn u32) str() string {
 		if n == 0 {
 			return '0'
 		}
-		max := 12
+		max := 10
 		mut buf := malloc_noscan(max + 1)
 		mut index := max
 		buf[index] = 0
@@ -501,7 +505,7 @@ pub fn (nn u64) hex_full() string {
 // See also: [`byte.ascii_str`](#byte.ascii_str)
 // Example: assert u8(111).str() == '111'
 pub fn (b u8) str() string {
-	return int(b).str_l(7)
+	return int(b).str_l(4)
 }
 
 // ascii_str returns the contents of `byte` as a zero terminated ASCII `string` character.

--- a/vlib/builtin/int_test.v
+++ b/vlib/builtin/int_test.v
@@ -41,6 +41,18 @@ fn test_str_methods() {
 	assert charptr(1).str() == '0x1'
 }
 
+fn test_str_length() {
+	assert i8(-125).str() == '-125'
+	assert i16(-32760).str() == '-32760'
+	assert i32(-2147483610).str() == '-2147483610'
+	assert int(-2147483620).str() == '-2147483620'
+	assert i64(-9223372036854775801).str() == '-9223372036854775801'
+	assert u8(250).str() == '250'
+	assert u16(65530).str() == '65530'
+	assert u32(4294967250).str() == '4294967250'
+	assert u64(18446744073709551611).str() == '18446744073709551611'
+}
+
 fn test_and_precedence() {
 	assert (2 & 0 == 0) == ((2 & 0) == 0)
 	assert (2 & 0 != 0) == ((2 & 0) != 0)


### PR DESCRIPTION
Short version first:
the input number is divided into **pairs** of numbers and is written backwards with or without a minus sign, and then is moved to the beginning of the buffer by the `vmemmove()` function. Only i64-u64 have correct size.


I'm showing the division into pairs for each number type, and you can see that the number of bytes is always `even`, except for one type:
```
Unsigned:                               Signed:

(V)2_55 = 4 							(0)1_28 = 4
(V)6_55_35 = 6							(0)3_27_68 = 6
42_94_96_72_95 = 10						-21_47_48_36_48 = 11
18_44_67_44_07_37_09_55_16_15 = 20		(0)9_22_33_72_03_68_54_77_58_08 = 20
===================
Legend for above:
 (V) - zero and will be overwritten by vmemmove()
 (0) - this zero could be overwritten or replaced with a minus sign
```

Example 1:
```
Lets convert 65535 step by step, malloc(6+1)
 .  .  .  .  .  . [0]
 .  .  .  . [3][5][0]
 .  . [5][5][3][5][0]
[0][6][5][5][3][5][0]
[6][5][5][3][5][0] .    <- vmemmove() shift
 ^
 |
 +-- beginning of buffer
```

Example 2:
```
Lets convert -22768 step by step, malloc(6+1)
 .  .  .  .  .  . [0]
 .  .  .  . [6][8][0]
 .  . [2][7][6][8][0]
[0][2][2][7][6][8][0]
[-][2][2][7][6][8][0]
 ^
 |
 +-- beginning of buffer
```

I manually verified for each type that these are the minimum number of bytes required, otherwise `ASAN` and `Fil-C` get triggered. (It's good that `ASAN` with `-gc none` is already protecting `vlang` in `CI` jobs and therefore I feel more confident, let's see how the check of the entire `vlib` works out.)

I added tests for all types of possible maximum length.