### PR TITLE
math: fix smootherstep(), add tests

### DIFF
--- a/vlib/math/interpolation.v
+++ b/vlib/math/interpolation.v
@@ -67,5 +67,5 @@ pub fn smoothstep[T](edge0 T, edge1 T, x T) T {
 @[inline]
 pub fn smootherstep[T](edge0 T, edge1 T, x T) T {
 	v := clip((x - edge0) / (edge1 - edge0), 0, 1)
-	return v * v * v * (x * (6 * x - 15) + 10)
+	return v * v * v * (v * (6 * v - 15) + 10)
 }

--- a/vlib/math/interpolation_test.v
+++ b/vlib/math/interpolation_test.v
@@ -117,4 +117,6 @@ fn test_smootherstep() {
 	assert math.close(math.smootherstep(0.0, 1, 0.9), 0.99144)
 	assert math.close(math.smootherstep(0.0, 1, 0.95), 0.998841875)
 	assert math.smootherstep(0.0, 1, 1) == 1
+	assert math.close(math.smootherstep(0.0, 1, 0.12345), 0.01550187121622219)
+	assert math.close(math.smootherstep(0.0, 1, 12345.12345), 1.0)
 }


### PR DESCRIPTION
Now `math.smootherstep()` have a multi-variable typo-like bug.
Check [wikipedia](https://en.wikipedia.org/wiki/Smoothstep#Variations) for correct variables or you could use [Tensorflow](https://www.tensorflow.org/probability/api_docs/python/tfp/math/smootherstep) if you like too:
```python
import tensorflow as tf
import tensorflow_probability as tfp

x = tf.constant(0.12345, dtype=tf.float64)
y = tfp.math.smootherstep(x)
print(y)
x = tf.constant(12345.12345, dtype=tf.float64)
y = tfp.math.smootherstep(x)
print(y)
```

The main point in these two lines is this - you calculated the value into a new variable - so use it!
