### PR TITLE
math: fix round_to_even(), add tests

### DIFF
--- a/vlib/math/floor.v
+++ b/vlib/math/floor.v
@@ -144,8 +144,7 @@ pub fn round_to_even(x f64) f64 {
 		half_minus_ulp := u64(u64(1) << (shift - 1)) - 1
 		e_ -= u64(bias)
 		bits += (half_minus_ulp + (bits >> (shift - e_)) & 1) >> e_
-		bits &= frac_mask >> e_
-		bits ^= frac_mask >> e_
+		bits &= ~(frac_mask >> e_)
 	} else if e_ == bias - 1 && bits & frac_mask != 0 {
 		// round 0.5 < abs(x) < 1.
 		bits = bits & sign_mask | uvone // +-1

--- a/vlib/math/floor_test.v
+++ b/vlib/math/floor_test.v
@@ -1,0 +1,6 @@
+import math
+
+fn test_round_to_even() {
+	assert math.round_to_even(0.123) == 0.0
+	assert math.round_to_even(123.12345) == 123.00
+}


### PR DESCRIPTION
Created tests for `vlib/math` vs. [mpfr](https://www.mpfr.org/) library. In total, there are 37 matching functions. ~9 functions don't pass the tests, with this PR I'm opening a series of fixes for the `math` module.

When porting from [golang](https://github.com/golang/go/blob/master/src/math/floor.go#L149), a complex sequence of actions was incorrectly implemented.
Now `100M+` loop passed.

Test can not pass on `master`.
