### PR TITLE
math: fix asinh(), add tests

### DIFF
--- a/vlib/math/invhyp.v
+++ b/vlib/math/invhyp.v
@@ -25,7 +25,7 @@ pub fn asinh(x f64) f64 {
 	a := abs(x)
 	s := if x < 0 { -1.0 } else { 1.0 }
 	if a > 1.0 / internal.sqrt_f64_epsilon {
-		return s * (log(a) + pi * 2.0)
+		return s * (log(a) + ln2)
 	} else if a > 2.0 {
 		return s * log(2.0 * a + 1.0 / (a + sqrt(a * a + 1.0)))
 	} else if a > internal.sqrt_f64_epsilon {

--- a/vlib/math/invhyp_test.v
+++ b/vlib/math/invhyp_test.v
@@ -4,3 +4,8 @@ fn test_acosh() {
 	assert math.close(math.acosh(1234567890.12345), 21.627134039822003)
 	assert math.close(math.acosh(12.123456789), 3.1865840454481904)
 }
+
+fn test_asinh() {
+	assert math.close(math.asinh(1234567890.12345), 21.627134039822003)
+	assert math.close(math.asinh(12.123456789), 3.1899859431901603)
+}


### PR DESCRIPTION
The same type of pseudo typo as in #25923.
Only this patch allows running multi-million tests against `mpfr` and `mpmath` libraries.
Tests cannot pass on `master`.