### PR TITLE
markused: add new auto_str() used funcs for bootstrap

### DIFF
--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -1442,6 +1442,10 @@ fn (mut w Walker) mark_resource_dependencies() {
 	if w.features.auto_str || w.uses_dump {
 		w.fn_by_name(ast.string_type_idx.str() + '.repeat')
 		w.fn_by_name('tos3')
+		builderptr_idx := int(w.table.find_type('strings.Builder').ref()).str()
+		w.fn_by_name(builderptr_idx + '.write_string')
+		w.fn_by_name(builderptr_idx + '.writeln')
+		w.fn_by_name(builderptr_idx + '.indent')
 	}
 	if w.uses_index || w.pref.is_shared {
 		w.fn_by_name(array_idx_str + '.slice')


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

As PR #25857, new `auto_str()` used some functions in `strings`, so add them to make bootstrap working.
