### PR TITLE
thirdparty: update script to build tcc on OpenBSD

### DIFF
--- a/thirdparty/build_scripts/thirdparty-openbsd-amd64_tcc.sh
+++ b/thirdparty/build_scripts/thirdparty-openbsd-amd64_tcc.sh
@@ -67,7 +67,7 @@ popd
 rsync -a --delete tinycc/$TCC_FOLDER/                 $TCC_FOLDER/
 rsync -a          thirdparty/tcc.original/.git/       $TCC_FOLDER/.git/
 # rsync -a          thirdparty/tcc.original/lib/libgc*  $TCC_FOLDER/lib/
-rsync -a          thirdparty/tcc.original/lib/build*  $TCC_FOLDER/lib/
+# rsync -a          thirdparty/tcc.original/lib/build*  $TCC_FOLDER/lib/
 rsync -a          thirdparty/tcc.original/README.md   $TCC_FOLDER/README.md
 rsync -a          $CURRENT_SCRIPT_PATH                $TCC_FOLDER/build.sh
 mv                $TCC_FOLDER/tcc                     $TCC_FOLDER/tcc.exe


### PR DESCRIPTION
No lib/build* files in `thirdparty/tcc` directory on OpenBSD => skip copy in build script.

Script `thirdparty/build_scripts/thirdparty-openbsd-amd64_tcc.sh` used to update `tcc` build on OpenBSD 7.8 => see https://github.com/vlang/tccbin/pull/62