### PR TITLE
ci: use VTEST_SHOW_LONGEST_BY_* vars on OpenBSD

### DIFF
--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -46,6 +46,9 @@ jobs:
             git config --global --add safe.directory .
             gmake
             sudo ./v symlink
+            export VTEST_SHOW_LONGEST_BY_RUNTIME=10
+            export VTEST_SHOW_LONGEST_BY_COMPTIME=10
+            export VTEST_SHOW_LONGEST_BY_TOTALTIME=10
             export VFLAGS='-cc tcc -no-retry-compilation'
             ./v run ci/openbsd_ci.vsh all
 
@@ -72,5 +75,8 @@ jobs:
             git config --global --add safe.directory .
             gmake
             sudo ./v symlink
+            export VTEST_SHOW_LONGEST_BY_RUNTIME=10
+            export VTEST_SHOW_LONGEST_BY_COMPTIME=10
+            export VTEST_SHOW_LONGEST_BY_TOTALTIME=10
             export VFLAGS='-cc clang'
             ./v run ci/openbsd_ci.vsh all


### PR DESCRIPTION
`VTEST_SHOW_LONGEST_BY*` variables added for `v test` in commit vlang/v@2e6b7ef46a60375efc2210f57dcdce7ce37f9626

**Tests OK for OpenBSD CI** => longest runs sorted by runtime/comptime/total time displayed at the end of the tests, see this run in my personal repo https://github.com/lcheylus/v/actions/runs/20194566450
