### PR TITLE
cgen: correct T{} init for []Type aliases

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -52,7 +52,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 			g.write(g.type_default_sumtype(unwrapped_typ, sym))
 		}
 		return
-	} else if sym.kind == .map {
+	} else if sym.kind == .map || (sym.kind == .array && node.init_fields.len == 0) {
 		g.write(g.type_default(unwrapped_typ))
 		return
 	}

--- a/vlib/v/tests/aliases/modules/value/value.v
+++ b/vlib/v/tests/aliases/modules/value/value.v
@@ -1,0 +1,11 @@
+module value
+
+pub interface Value {
+	str() string
+}
+
+pub type List = []Value
+
+pub fn (x List) str() string {
+	return x.str()
+}

--- a/vlib/v/tests/aliases/modules/value/value_test.v
+++ b/vlib/v/tests/aliases/modules/value/value_test.v
@@ -1,0 +1,11 @@
+module value
+
+fn test_list() {
+	mut list := make_list()!
+	assert (list as List).len == 0
+}
+
+fn make_list() !Value {
+	mut list := List{}
+	return list
+}


### PR DESCRIPTION
Fixes #25962.

This fixes the cgen portion of this. The test kind of confuses me though, `make_list` should return `List` or `[]Value` but right now it returns `!Value` without issue. Secondly the `str()` method here calls itself, although that is less of a problem.