### PR TITLE
cgen: fix array init with fixed array from return call

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -61,7 +61,7 @@ fn (mut g Gen) array_init(node ast.ArrayInit, var_name string) {
 				if node.elem_type.has_flag(.option) {
 					g.expr_with_opt(expr, expr_type, node.elem_type)
 				} else if elem_type.unaliased_sym.kind == .array_fixed
-					&& expr in [ast.Ident, ast.SelectorExpr] {
+					&& expr in [ast.Ident, ast.SelectorExpr, ast.CallExpr] {
 					info := elem_type.unaliased_sym.info as ast.ArrayFixed
 					g.fixed_array_var_init(g.expr_string(expr), expr.is_auto_deref_var(),
 						info.elem_type, info.size)

--- a/vlib/v/tests/builtin_arrays/array_init_fixed_array_ret_test.v
+++ b/vlib/v/tests/builtin_arrays/array_init_fixed_array_ret_test.v
@@ -1,0 +1,10 @@
+module main
+
+fn ret() [2]int {
+	return [3, 4]!
+}
+
+fn test_main() {
+	coords := [ret()]
+	assert coords[0] == [3, 4]!
+}


### PR DESCRIPTION
Fix #25954