### PR TITLE
veb, vweb: update unit tests for FreeBSD

### DIFF
--- a/vlib/veb/tests/veb_should_listen_on_both_ipv4_and_ipv6_by_default_test.v
+++ b/vlib/veb/tests/veb_should_listen_on_both_ipv4_and_ipv6_by_default_test.v
@@ -82,6 +82,16 @@ fn test_net_http_connecting_through_ipv6_works() {
 		log.warn('skipping test ${@FN} on windows for now')
 		return
 	}
+	$if freebsd {
+		// if the sysctl net.inet.ip.connect_inaddr_wild doesn't exist or
+		// if it axists and is non-zero, we should expect the IPv6 socket to be open.
+		result := os.execute('sysctl net.inet.ip.connect_inaddr_wild')
+		if result.exit_code == 0
+			&& result.output.trim_space() == 'net.inet.ip.connect_inaddr_wild: 0' {
+			log.warn('skipping test ${@FN} on FreeBSD because sysctl setting net.inet.ip.connect_inaddr_wild=0')
+			return
+		}
+	}
 	res := http.get('http://[::1]:${port}/')!
 	assert res.status_code == 200, res.str()
 	assert res.status_msg == 'OK', res.str()

--- a/vlib/vweb/tests/vweb_should_listen_on_both_ipv4_and_ipv6_by_default_test.v
+++ b/vlib/vweb/tests/vweb_should_listen_on_both_ipv4_and_ipv6_by_default_test.v
@@ -81,6 +81,16 @@ fn test_net_http_connecting_through_ipv6_works() {
 		log.warn('skipping test ${@FN} on windows for now')
 		return
 	}
+	$if freebsd {
+		// if the sysctl net.inet.ip.connect_inaddr_wild doesn't exist or
+		// if it axists and is non-zero, we should expect the IPv6 socket to be open.
+		result := os.execute('sysctl net.inet.ip.connect_inaddr_wild')
+		if result.exit_code == 0
+			&& result.output.trim_space() == 'net.inet.ip.connect_inaddr_wild: 0' {
+			log.warn('skipping test ${@FN} on FreeBSD because sysctl setting net.inet.ip.connect_inaddr_wild=0')
+			return
+		}
+	}
 	res := http.get('http://[::1]:${port}/')!
 	assert res.status_code == 200, res.str()
 	assert res.status_msg == 'OK', res.str()


### PR DESCRIPTION
update unit tests to deal with net.inet.ip.connect_inaddr_wild on FreeBSD

This is a potential fix for issue [25935](https://github.com/vlang/v/issues/25935).

It checks for the existence of the net.inet.ip.connect_inaddr_wild sysctl and if it exists and if it is zero, it skips checking for the IPv6 socket listening for connections.

Prior to FreeBSD 14, there was no sysctl named net.inet.ip.connect_inaddr_wild and opening a socket on localhost would open both an IPv4 and IPv6 socket.  In FreeBSD 14, this sysctl was introduced with a default value or 1.  This retained the behavior of FreeBSD 13 and earlier.  With the release of FreeBSD 15, this value now defaults to 0 which means that opening a socket on localhost only opens the IPv4 socket.  There are more details in the related issue.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
