### PR TITLE
veb:  fix veb silently fails to bind a handler when result type is not veb.Result

### DIFF
--- a/vlib/veb/parse.v
+++ b/vlib/veb/parse.v
@@ -95,3 +95,23 @@ fn parse_form_from_request(request http.Request) !(map[string]string, map[string
 	}
 	return http.parse_form(request.data), map[string][]http.FileData{}
 }
+
+// has_route_attributes checks if a method has attributes that indicate it should be a route handler
+fn has_route_attributes(attrs []string) bool {
+	if attrs.len == 0 {
+		return false
+	}
+	for attr in attrs {
+		attru := attr.to_upper()
+		if attru in ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] {
+			return true
+		}
+		if attr.starts_with('/') {
+			return true
+		}
+		if attr.starts_with('host:') {
+			return true
+		}
+	}
+	return false
+}

--- a/vlib/veb/tests/invalid_return_type_test.v
+++ b/vlib/veb/tests/invalid_return_type_test.v
@@ -1,0 +1,26 @@
+import veb
+
+pub struct App {}
+
+struct Context {
+	veb.Context
+}
+
+// Test that methods with route attributes but wrong return type are caught
+fn test_invalid_return_type_is_detected() {
+	mut app := &App{}
+
+	// This should fail because get_task has route attributes but returns !veb.Result
+	veb.generate_routes[App, Context](app) or {
+		assert err.msg().contains('invalid return type'), 'Expected error about invalid return type, got: ${err.msg()}'
+		assert err.msg().contains('get_task'), 'Expected error to mention method name, got: ${err.msg()}'
+		return
+	}
+
+	assert false, 'Expected generate_routes to return an error for invalid return type'
+}
+
+@['/test'; get]
+pub fn (app &App) get_task(mut ctx Context) !veb.Result {
+	return ctx.text('Hello')
+}

--- a/vlib/veb/veb.v
+++ b/vlib/veb/veb.v
@@ -53,6 +53,11 @@ fn generate_routes[A, X](app &A) !map[string]Route {
 			}
 
 			routes[method.name] = route
+		} $else {
+			// If we have route attributes, but the wrong return type, return an error
+			if has_route_attributes(method.attrs) {
+				return error('method `${method.name}` has route attributes but invalid return type. Handler methods must return `veb.Result`, not `!veb.Result` or other types')
+			}
 		}
 	}
 	return routes


### PR DESCRIPTION
Potential Fix for #25970.

Fixes an issue where Veb would silently fail to bind a handler when the return type of a handler function is not veb.Result (and is, for example, `!veb.Result`). I've also added tests to cover this. I'm happy to take a different approach if needed, too. This is my first contribution to V and am still learning the ropes.

Changes:
- Added a function to check for route attributes which is used in other items below
- When generating routes, adds a branch to handle the case where a method does not have a veb.Result return type, but does have route attributes, in which case, error to warn the user of unexpected behavior.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
