### PR TITLE
ci: update to use FreeBSD version 15.0

### DIFF
--- a/.github/workflows/freebsd_ci.yml
+++ b/.github/workflows/freebsd_ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: cross-platform-actions/action@v0.31.0
         with:
           operating_system: freebsd
-          version: '14.3'
+          version: '15.0'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
@@ -62,7 +62,7 @@ jobs:
         uses: cross-platform-actions/action@v0.31.0
         with:
           operating_system: freebsd
-          version: '14.3'
+          version: '15.0'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
@@ -91,7 +91,7 @@ jobs:
         uses: cross-platform-actions/action@v0.31.0
         with:
           operating_system: freebsd
-          version: '14.3'
+          version: '15.0'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm


### PR DESCRIPTION
After commit 68393b629c90a3e744d1cde59ab1addec80eeb3f, FreeBSD CI can be updated to use 15.0 version: Cross Platform Action version 0.31.0 adds support for this version (release notes => https://github.com/cross-platform-actions/action/releases/tag/v0.31.0).

**Tests OK with tcc/clang/gcc on FreeBSD 15.0**: see this "CI FreeBSD" run in my personal repo https://github.com/lcheylus/v/actions/runs/20265947910