### PR TITLE
crypto.ecdsa: update to use OpenSSL 3.5 on OpenBSD

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -912,8 +912,8 @@ fn check_openssl_present() bool {
 		return false
 	}
 	$if openbsd {
-		return os.execute('eopenssl34 --version').exit_code == 0
-			&& os.execute('pkg-config eopenssl34 --libs').exit_code == 0
+		return os.execute('eopenssl35 --version').exit_code == 0
+			&& os.execute('pkg-config eopenssl35 --libs').exit_code == 0
 	} $else {
 		return os.execute('openssl --version').exit_code == 0
 			&& os.execute('pkg-config openssl --libs').exit_code == 0

--- a/vlib/crypto/ecdsa/ecdsa.c.v
+++ b/vlib/crypto/ecdsa/ecdsa.c.v
@@ -15,8 +15,8 @@ module ecdsa
 #flag linux -I/usr/local/include/openssl
 #flag linux -L/usr/local/lib64/
 
-#flag openbsd -I/usr/local/include/eopenssl34
-#flag openbsd -L/usr/local/lib/eopenssl34 -Wl,-rpath,/usr/local/lib/eopenssl34
+#flag openbsd -I/usr/local/include/eopenssl35
+#flag openbsd -L/usr/local/lib/eopenssl35 -Wl,-rpath,/usr/local/lib/eopenssl35
 
 // Installed through choco:
 #flag windows -IC:/Program Files/OpenSSL-Win64/include


### PR DESCRIPTION
Update to use OpenSSL 3.5 on OpenBSD 7.8 (current release) for `crypto.ecdsa`

**Tests OK on OpenBSD 7.8 with tcc / clang 19.1.7**
```sh
$  uname -mrs
OpenBSD 7.8 amd64

$ ./v -cc tcc -W test vlib/crypto/ecdsa
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK    [1/4] C:   900.7 ms, R:    23.550 ms vlib/crypto/ecdsa/ecdsa_test.v
 OK    [2/4] C:   911.6 ms, R:    41.714 ms vlib/crypto/ecdsa/example/ecdsa_seed_test.v
 OK    [3/4] C:  1025.5 ms, R:    15.583 ms vlib/crypto/ecdsa/example/ensure_compatibility_with_net_openssl_test.v
 OK    [4/4] C:   870.6 ms, R:    39.004 ms vlib/crypto/ecdsa/util_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 4 passed, 4 total. Elapsed time: 1882 ms, on 3 parallel jobs. Comptime: 3708 ms. Runtime: 119 ms.

$ clang -v
OpenBSD clang version 19.1.7
Target: amd64-unknown-openbsd7.8
Thread model: posix
InstalledDir: /usr/bin

$ ./v -cc clang -W test vlib/crypto/ecdsa
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK    [1/4] C:  1615.7 ms, R:    36.524 ms vlib/crypto/ecdsa/example/ecdsa_seed_test.v
 OK    [2/4] C:  1685.8 ms, R:    32.599 ms vlib/crypto/ecdsa/ecdsa_test.v
 OK    [3/4] C:  1833.3 ms, R:    20.208 ms vlib/crypto/ecdsa/example/ensure_compatibility_with_net_openssl_test.v
 OK    [4/4] C:  1679.1 ms, R:    40.374 ms vlib/crypto/ecdsa/util_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 4 passed, 4 total. Elapsed time: 3413 ms, on 3 parallel jobs. Comptime: 6813 ms. Runtime: 129 ms.

```