### PR TITLE
x.crypto.slhdsa: add support on OpenBSD using OpenSSL 3.5

### DIFF
--- a/vlib/x/crypto/slhdsa/slhdsa.c.v
+++ b/vlib/x/crypto/slhdsa/slhdsa.c.v
@@ -22,6 +22,9 @@ module slhdsa
 #flag darwin -I/usr/local/opt/openssl/include
 #flag darwin -L/usr/local/opt/openssl/lib
 
+#flag openbsd -I/usr/local/include/eopenssl35
+#flag openbsd -L/usr/local/lib/eopenssl35 -Wl,-rpath,/usr/local/lib/eopenssl35
+
 #include <openssl/obj_mac.h>
 #include <openssl/evp.h>
 #include <openssl/bio.h>


### PR DESCRIPTION
OpenSSL version 3.5 available on OpenBSD 7.8 (current release) via ports => add flags in `vlib/x/crypto/slhdsa/slhdsa.c.v` to use it for `openbsd`.

**Tests OK with tcc / clang 19**
```sh
$ uname -mrs
OpenBSD 7.8 amd64
$ eopenssl35 version
OpenSSL 3.5.4 30 Sep 2025 (Library: OpenSSL 3.5.4 30 Sep 2025)

$ ./v -d has_modern_openssl -cc tcc test vlib/x/crypto/slhdsa/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK    [1/4] C:   797.8 ms, R:    41.026 ms vlib/x/crypto/slhdsa/slhdsa_sigver_test.v
 OK    [2/4] C:   792.5 ms, R:  1525.497 ms vlib/x/crypto/slhdsa/usage_test.v
 OK    [3/4] C:   922.6 ms, R:  5246.069 ms vlib/x/crypto/slhdsa/base_test.v
 OK    [4/4] C:   842.5 ms, R:  9869.963 ms vlib/x/crypto/slhdsa/slhdsa_siggen_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 4 passed, 4 total. Elapsed time: 10756 ms, on 3 parallel jobs. Comptime: 3355 ms. Runtime: 16682 ms.

$ ./v -d has_modern_openssl -cc clang test vlib/x/crypto/slhdsa/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK    [1/4] C:  1583.2 ms, R:    41.451 ms vlib/x/crypto/slhdsa/slhdsa_sigver_test.v
 OK    [2/4] C:  1475.7 ms, R:  1404.662 ms vlib/x/crypto/slhdsa/usage_test.v
 OK    [3/4] C:  1654.8 ms, R:  5548.034 ms vlib/x/crypto/slhdsa/base_test.v
 OK    [4/4] C:  1586.4 ms, R: 11003.026 ms vlib/x/crypto/slhdsa/slhdsa_siggen_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 4 passed, 4 total. Elapsed time: 12635 ms, on 3 parallel jobs. Comptime: 6300 ms. Runtime: 17997 ms.
```