### PR TITLE
checker: ensure type of global exists

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2604,10 +2604,7 @@ fn (mut c Checker) global_decl(mut node ast.GlobalDecl) {
 			// add global to exports for duplicate check
 			c.table.export_names[field.name] = field.name
 		}
-		sym := c.table.sym(field.typ)
-		if sym.kind == .placeholder {
-			c.error('unknown type `${sym.name}`', field.typ_pos)
-		}
+		c.ensure_type_exists(field.typ, field.typ_pos)
 		if field.has_expr {
 			if field.expr is ast.AnonFn && field.name == 'main' {
 				c.error('the `main` function is the program entry point, cannot redefine it',

--- a/vlib/v/checker/tests/globals/nested_unknown_typ.out
+++ b/vlib/v/checker/tests/globals/nested_unknown_typ.out
@@ -1,0 +1,5 @@
+vlib/v/checker/tests/globals/nested_unknown_typ.vv:5:13: error: unknown type `StructS`
+    3 |
+    4 | @[markused]
+    5 | __global ga []?StructS
+      |             ^

--- a/vlib/v/checker/tests/globals/nested_unknown_typ.vv
+++ b/vlib/v/checker/tests/globals/nested_unknown_typ.vv
@@ -1,0 +1,5 @@
+@[has_globals]
+module main
+
+@[markused]
+__global ga []?StructS


### PR DESCRIPTION
Fixes #25910.

Currently can be bypassed by prefixing the undefined type with `[]?`.