### PR TITLE
checker: partial fix for generic type pollution bug

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -2952,3 +2952,14 @@ pub fn validate_type_string_is_pure_literal(typ Type, str string) ! {
 		return error('expected pure literal, found "${str}"')
 	}
 }
+
+// clone creates a shallow copy of the scope for generic function instantiation
+// Variables will be re-created during checking, so we just need a fresh container
+pub fn (s &Scope) clone_shallow() &Scope {
+	return &Scope{
+		parent:               s.parent
+		detached_from_parent: s.detached_from_parent // Keep same detachment as original
+		start_pos:            s.start_pos
+		end_pos:              s.end_pos
+	}
+}

--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -932,8 +932,13 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 		c.warn('`++` and `--` are statements, not expressions', node.pos)
 	}
 	*/
-	node.promoted_type = if node.op.is_relational() { ast.bool_type } else { return_type }
-	return node.promoted_type
+	promoted := if node.op.is_relational() { ast.bool_type } else { return_type }
+	node.promoted_type = promoted
+	// Also store in cache if in generic instantiation
+	if c.generic_instantiation_key != '' {
+		c.store_generic_type(voidptr(&node), promoted)
+	}
+	return promoted
 }
 
 fn (mut c Checker) check_div_mod_by_zero(expr ast.Expr, op_kind token.Kind) {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -238,7 +238,11 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 				continue
 			}
 			g.cur_concrete_types = concrete_types
+			// Set the instantiation key for cache lookups
+			g.generic_instantiation_key = g.table.make_generic_instantiation_key(concrete_types)
 			g.gen_fn_decl(node, skip)
+			// Clear the key after generation
+			g.generic_instantiation_key = ''
 		}
 		g.cur_concrete_types = []
 		return

--- a/vlib/v/tests/generics_type_inference_bug/unrelated.v
+++ b/vlib/v/tests/generics_type_inference_bug/unrelated.v
@@ -1,0 +1,8 @@
+module generics_type_inference_bug
+
+// This file contains an UNRELATED function with Vec3[f32]
+// The bug is that this affects type inference in unrelated code!
+
+fn unrelated_function_with_f32(a Vec3[f32]) bool {
+	return false
+}

--- a/vlib/v/tests/generics_type_inference_bug/vec.v
+++ b/vlib/v/tests/generics_type_inference_bug/vec.v
@@ -1,0 +1,28 @@
+module generics_type_inference_bug
+
+pub struct Vec3[T] {
+pub mut:
+	x T
+	y T
+	z T
+}
+
+pub fn vec3[T](x T, y T, z T) Vec3[T] {
+	return Vec3[T]{
+		x: x
+		y: y
+		z: z
+	}
+}
+
+pub fn (v Vec3[T]) dot(u Vec3[T]) T {
+	return T((v.x * u.x) + (v.y * u.y) + (v.z * u.z))
+}
+
+pub fn (v Vec3[T]) multiply_test(u Vec3[T]) T {
+	// This is the critical test: multiplying two T values should give T, not some other type
+	dot_result := v.dot(u)
+	norm := T(0.5)
+	result := dot_result * norm
+	return result
+}

--- a/vlib/v/tests/generics_type_inference_bug_test.v
+++ b/vlib/v/tests/generics_type_inference_bug_test.v
@@ -1,0 +1,21 @@
+import v.tests.generics_type_inference_bug
+
+fn test_f64_multiplication_should_return_f64() {
+	a1 := f64(10.0)
+	b1 := f64(20.0)
+	c1 := f64(30.0)
+	a2 := f64(1.0)
+	b2 := f64(2.0)
+	c2 := f64(3.0)
+
+	v := generics_type_inference_bug.vec3[f64](a1, b1, c1)
+	u := generics_type_inference_bug.vec3[f64](a2, b2, c2)
+
+	// Call the method that performs multiplication
+	result := v.multiply_test(u)
+
+	// The result should be f64, not f32!
+	// This test will help us verify the type
+	assert typeof(result).name == 'f64'
+	println('Result type: ${typeof(result).name}, value: ${result}')
+}


### PR DESCRIPTION
Potential fix for #25852

In generic functions with multiple type instantiations, typeof() expressions show incorrect types. Type information from one instantiation (e.g., f32) pollutes another instantiation (e.g., f64).

AST nodes are shared across all generic instantiations. When checking multiple instantiations, type information gets stored in shared AST nodes and pollutes subsequent instantiations.

Added infrastructure to cache types per instantiation:
- generic_type_cache map in Table
- Scope cloning for each instantiation
- Type caching during checking
- Type retrieval during generation

The fix works for the reported bug but ultimately seems to cause more harm than good.

At this point, I'm looking for guidance from maintainers who are more familiar with V's inner-workings than I am :)

Some possible paths forward:
1. Enhance type resolution map to handle all edge cases
2. Targeted typeof() fix only (wouldn't really address root cause)
3. Something else?
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
