### PR TITLE
transformer: `-new-transformer` set generic flag for fixed array type if needed

### DIFF
--- a/vlib/v/transformer/array.v
+++ b/vlib/v/transformer/array.v
@@ -60,8 +60,13 @@ pub fn (mut t Transformer) array_init(mut node ast.ArrayInit) ast.Expr {
 		}
 		typ:  ast.int_type
 	}
-	fixed_array_typ := t.table.find_or_register_array_fixed(node.elem_type, len, ast.empty_expr,
+	fixed_array_idx := t.table.find_or_register_array_fixed(node.elem_type, len, ast.empty_expr,
 		false)
+	fixed_array_typ := if node.elem_type.has_flag(.generic) {
+		ast.new_type(fixed_array_idx).set_flag(.generic)
+	} else {
+		ast.new_type(fixed_array_idx)
+	}
 	fixed_array_arg := ast.CallArg{
 		expr: ast.CastExpr{
 			expr:      ast.ArrayInit{


### PR DESCRIPTION
Does not change the number of passing tests of `v -new-transformer self` followed by `v -new-transformer test-self`. (95 failing)
But the C compiler goes further in the code for `vlib/arrays/arrays_test.v` (before it was failing on `Array_fixed_T_1 undeclared` in `arrays__chunk_while_T_int` and now it fails on `Array_fixed_rune_1 undeclared` in `arrays__chunk_while_T_rune`).