### PR TITLE
transformer: `-new-transformer` fix vlib/strconv/atoi_test.v

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7203,7 +7203,7 @@ fn (mut g Gen) sort_structs(typesa []&ast.TypeSymbol) []&ast.TypeSymbol {
 					}
 				}
 				if !skip {
-					dep := g.table.final_sym(sym.info.elem_type).name
+					dep := g.table.final_sym(sym.info.elem_type).scoped_name()
 					if dep in type_names {
 						field_deps << dep
 					}


### PR DESCRIPTION
fixes `v -new-transformer vlib/strconv/atoi_test.v`

replace `.name` with `.scoped_name()` as the name used for the dependancy graph and for `type_names` is `sym.scoped_name()`