### PR TITLE
checker: ensure fn pointer cannot be used as non-fn argument

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -1900,8 +1900,10 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 	if mut method := c.table.sym(c.unwrap_generic(typ)).find_method_with_generic_parent(field_name) {
 		c.markused_comptime_call(typ.has_flag(.generic), '${int(method.params[0].typ)}.${field_name}')
 		if c.expected_type != 0 && c.expected_type != ast.none_type {
-			fn_type := ast.new_type(c.table.find_or_register_fn_type(method, false, true))
-			// if the expected type includes the receiver, don't hide it behind a closure
+			mut method_copy := method
+			method_copy.name = ''
+			fn_type := ast.new_type(c.table.find_or_register_fn_type(method_copy, false,
+				true))
 			if c.check_types(fn_type, c.expected_type) {
 				c.table.used_features.anon_fn = true
 				return fn_type

--- a/vlib/v/checker/tests/method_ptr_used_as_argument_err.out
+++ b/vlib/v/checker/tests/method_ptr_used_as_argument_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/method_ptr_used_as_argument_err.vv:8:16: error: cannot use `fn () int` as `int` in argument 1 to `add`
+    6 |     arg1 := '10'
+    7 |     arg2 := '20'
+    8 |     result := add(arg1.int, arg2.int)
+      |                   ~~~~~~~~
+    9 |     println(result)
+   10 | }
+vlib/v/checker/tests/method_ptr_used_as_argument_err.vv:8:26: error: cannot use `fn () int` as `int` in argument 2 to `add`
+    6 |     arg1 := '10'
+    7 |     arg2 := '20'
+    8 |     result := add(arg1.int, arg2.int)
+      |                             ~~~~~~~~
+    9 |     println(result)
+   10 | }

--- a/vlib/v/checker/tests/method_ptr_used_as_argument_err.vv
+++ b/vlib/v/checker/tests/method_ptr_used_as_argument_err.vv
@@ -1,0 +1,10 @@
+fn add(x int, y int) int {
+	return x + y
+}
+
+fn main() {
+	arg1 := '10'
+	arg2 := '20'
+	result := add(arg1.int, arg2.int)
+	println(result)
+}


### PR DESCRIPTION
Fixes #26017.

Test is simplified from the original issue.