### PR TITLE
toml: fix for single `\r` occurence in multi-line `"""` strings (`\r\n` is still allowed)

### DIFF
--- a/vlib/toml/scanner/scanner.v
+++ b/vlib/toml/scanner/scanner.v
@@ -486,7 +486,7 @@ fn (mut s Scanner) extract_multiline_string() !string {
 		c := u8(s.at())
 		util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'c: `${c.ascii_str()}` / ${c} (quote type: ${quote}/${quote.ascii_str()})')
 
-		if c == `\r` {
+		if c == `\r` && s.peek(1) == `\n` {
 			continue
 		}
 		if c == `\n` {

--- a/vlib/toml/tests/burntsushi_toml_test.v
+++ b/vlib/toml/tests/burntsushi_toml_test.v
@@ -1,6 +1,3 @@
-// vtest flaky: true
-// vtest retry: 3
-
 // Instructions for developers:
 // The actual tests and data can be obtained by doing:
 // `git clone -n https://github.com/toml-lang/toml-test.git vlib/toml/tests/testdata/burntsushi`


### PR DESCRIPTION
Related to https://github.com/vlang/v/pull/24322 and presumably flaky tests occurring in CI