### PR TITLE
toml, tests: update `burntsushi` -> `toml-lang` and `alexcrichton` ->`toml-rs`

### DIFF
--- a/.github/workflows/download_full_toml_test_suites.sh
+++ b/.github/workflows/download_full_toml_test_suites.sh
@@ -2,15 +2,15 @@
 
 set -ex
 
-rm -rf vlib/toml/tests/testdata/burntsushi  vlib/toml/tests/testdata/iarna  vlib/toml/tests/testdata/alexcrichton  vlib/toml/tests/testdata/large_toml_file_test.toml
+rm -rf vlib/toml/tests/testdata/iarna vlib/toml/tests/testdata/toml_rs vlib/toml/tests/testdata/toml_lang vlib/toml/tests/testdata/large_toml_file_test.toml
 
 ./v retry -- ./v download -o vlib/toml/tests/testdata/large_toml_file_test.toml https://gist.githubusercontent.com/Larpon/89b0e3d94c6903851ff15559e5df7a05/raw/62a1f87a4e37bf157f2e0bfb32d85d840c98e422/large_toml_file_test.toml
 
 ./v retry -- git clone -n https://github.com/iarna/toml-spec-tests.git vlib/toml/tests/testdata/iarna
 git -C vlib/toml/tests/testdata/iarna checkout 1880b1a
 
-./v retry -- git clone -n https://github.com/toml-lang/toml-test.git vlib/toml/tests/testdata/burntsushi
-git -C vlib/toml/tests/testdata/burntsushi checkout f30c716
+./v retry -- git clone -n https://github.com/toml-lang/toml-test.git vlib/toml/tests/testdata/toml_lang
+git -C vlib/toml/tests/testdata/toml_lang checkout f30c716
 
-./v retry -- git clone -n https://github.com/toml-rs/toml.git vlib/toml/tests/testdata/alexcrichton
-git -C vlib/toml/tests/testdata/alexcrichton reset --hard 499e8c4
+./v retry -- git clone -n https://github.com/toml-rs/toml.git vlib/toml/tests/testdata/toml_rs
+git -C vlib/toml/tests/testdata/toml_rs reset --hard 499e8c4

--- a/vlib/toml/input/input.v
+++ b/vlib/toml/input/input.v
@@ -21,7 +21,7 @@ pub fn (c Config) read_input() !string {
 			' ${typeof(c).name} should contain only one of the fields `file_path` OR `text` filled out')
 	}
 	if c.file_path == '' && c.text == '' {
-		// TODO: passing both empty is used *a lot* by `./v vlib/toml/tests/burntsushi_toml_test.v`; investigate why.
+		// TODO: passing both empty is used *a lot* by `./v vlib/toml/tests/toml_lang_test.v`; investigate why.
 		return ''
 	}
 	if c.text != '' {

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -499,8 +499,8 @@ pub fn (mut p Parser) root_table() ! {
 							continue
 						}
 						// Check for "table injection":
-						// https://github.com/BurntSushi/toml-test/blob/576db85/tests/invalid/table/injection-1.toml
-						// https://github.com/BurntSushi/toml-test/blob/576db85/tests/invalid/table/injection-2.toml
+						// https://github.com/toml-lang/toml-test/blob/576db85/tests/invalid/table/injection-1.toml
+						// https://github.com/toml-lang/toml-test/blob/576db85/tests/invalid/table/injection-2.toml
 						if p.build_abs_dotted_key(sub_table).starts_with(explicit_key) {
 							return error(@MOD + '.' + @STRUCT + '.' + @FN +
 								' key `${dotted_key}` has already been explicitly declared. Unexpected redeclaration at "${p.tok.kind}" "${p.tok.lit}" in this (excerpt): "...${p.excerpt()}..."')
@@ -933,7 +933,7 @@ pub fn (mut p Parser) double_array_of_tables(mut table map[string]ast.Value) ! {
 					nm = &map[string]ast.Value{}
 					// We register this implicit allocation as *explicit* to be able to catch
 					// special cases like:
-					// https://github.com/BurntSushi/toml-test/blob/576db852/tests/invalid/table/array-implicit.toml
+					// https://github.com/toml-lang/toml-test/blob/576db852/tests/invalid/table/array-implicit.toml
 					p.explicit_declared << first
 				}
 

--- a/vlib/toml/tests/iarna_toml_spec_test.v
+++ b/vlib/toml/tests/iarna_toml_spec_test.v
@@ -302,7 +302,7 @@ fn to_iarna(value ast.Value, skip_value_map bool) string {
 			}
 			// NOTE test suite inconsistency.
 			// It seems it's implementation specific how time and
-			// date-time values are represented in detail. For now we follow the BurntSushi format
+			// date-time values are represented in detail. For now we follow the toml-lang format
 			// that expands to 6 digits which is also a valid RFC 3339 representation.
 			json_text = to_iarna_time(json_text[1..json_text.len - 1])
 			if skip_value_map {

--- a/vlib/toml/tests/testdata/.gitignore
+++ b/vlib/toml/tests/testdata/.gitignore
@@ -1,4 +1,4 @@
 iarna/
-burntsushi/
-alexcrichton/
+toml_lang/
+toml_rs/
 large_toml_file_test.toml

--- a/vlib/toml/tests/toml_lang_test.v
+++ b/vlib/toml/tests/toml_lang_test.v
@@ -1,7 +1,7 @@
 // Instructions for developers:
 // The actual tests and data can be obtained by doing:
-// `git clone -n https://github.com/toml-lang/toml-test.git vlib/toml/tests/testdata/burntsushi`
-// `git -C vlib/toml/tests/testdata/burntsushi reset --hard f30c716
+// `git clone -n https://github.com/toml-lang/toml-test.git vlib/toml/tests/testdata/toml_lang`
+// `git -C vlib/toml/tests/testdata/toml_lang reset --hard f30c716
 // See also the CI toml tests
 import os
 import toml
@@ -79,7 +79,7 @@ const valid_value_exceptions = [
 //'integer/long.toml', // TODO: https://github.com/vlang/v/issues/9507
 
 const jq = os.find_abs_path_of_executable('jq') or { '' }
-const compare_work_dir_root = os.join_path(os.vtmp_dir(), 'toml_burntsushi')
+const compare_work_dir_root = os.join_path(os.vtmp_dir(), 'toml_toml_lang')
 // From: https://stackoverflow.com/a/38266731/1904615
 const jq_normalize = r'# Apply f to composite entities recursively using keys[], and to atoms
 def sorted_walk(f):
@@ -103,10 +103,10 @@ fn run(args []string) !string {
 	return res.output
 }
 
-// test_burnt_sushi_tomltest run though 'testdata/burntsushi/toml-test/*' if found.
-fn test_burnt_sushi_tomltest() {
+// test_toml_lang_tomltest run though 'testdata/toml_lang/toml-test/*' if found.
+fn test_toml_lang_tomltest() {
 	eprintln('> running ${@LOCATION}')
-	test_root := '${@VROOT}/vlib/toml/tests/testdata/burntsushi/tests'
+	test_root := '${@VROOT}/vlib/toml/tests/testdata/toml_lang/tests'
 	if !os.is_dir(test_root) {
 		println('No test data directory found in "${test_root}"')
 		assert true
@@ -186,7 +186,7 @@ fn test_burnt_sushi_tomltest() {
 			bs_toml_json_path := os.join_path(compare_work_dir_root,
 				os.file_name(valid_test_file).all_before_last('.') + '.json')
 
-			os.write_file(v_toml_json_path, to_burntsushi(toml_doc.ast.table))!
+			os.write_file(v_toml_json_path, to_toml_lang(toml_doc.ast.table))!
 
 			bs_json := os.read_file(valid_test_file.all_before_last('.') + '.json')!
 
@@ -256,8 +256,8 @@ fn test_burnt_sushi_tomltest() {
 	}
 }
 
-// to_burntsushi returns a BurntSushi compatible json string converted from the `value` ast.Value.
-fn to_burntsushi(value ast.Value) string {
+// to_toml_lang returns a toml-lang compatible json string converted from the `value` ast.Value.
+fn to_toml_lang(value ast.Value) string {
 	match value {
 		ast.Quoted {
 			json_text := json2.Any(value.text).json_str()
@@ -323,7 +323,7 @@ fn to_burntsushi(value ast.Value) string {
 			mut str := '{ '
 			for key, val in value {
 				json_key := json2.Any(key).json_str()
-				str += ' ${json_key}: ${to_burntsushi(val)},'
+				str += ' ${json_key}: ${to_toml_lang(val)},'
 			}
 			str = str.trim_right(',')
 			str += ' }'
@@ -332,7 +332,7 @@ fn to_burntsushi(value ast.Value) string {
 		[]ast.Value {
 			mut str := '[ '
 			for val in value {
-				str += ' ${to_burntsushi(val)},'
+				str += ' ${to_toml_lang(val)},'
 			}
 			str = str.trim_right(',')
 			str += ' ]\n'

--- a/vlib/toml/tests/toml_rs_test.v
+++ b/vlib/toml/tests/toml_rs_test.v
@@ -8,8 +8,8 @@ const no_jq = os.getenv('VNO_JQ') == '1'
 
 // Instructions for developers:
 // The actual tests and data can be obtained by doing:
-// `git clone -n https://github.com/toml-rs/toml.git vlib/toml/tests/testdata/alexcrichton`
-// `git -C vlib/toml/tests/testdata/alexcrichton reset --hard 499e8c4`
+// `git clone -n https://github.com/toml-rs/toml.git vlib/toml/tests/testdata/toml_rs`
+// `git -C vlib/toml/tests/testdata/toml_rs reset --hard 499e8c4`
 // See also the CI toml tests
 // Kept for easier handling of future updates to the tests
 const valid_exceptions = [
@@ -38,7 +38,7 @@ const use_type_2_arrays = [
 ]
 const tests_folder = os.join_path('test-suite', 'tests')
 const jq = os.find_abs_path_of_executable('jq') or { '' }
-const compare_work_dir_root = os.join_path(os.vtmp_dir(), 'toml_alexcrichton')
+const compare_work_dir_root = os.join_path(os.vtmp_dir(), 'toml_toml_rs')
 // From: https://stackoverflow.com/a/38266731/1904615
 const jq_normalize = r'# Apply f to composite entities recursively using keys[], and to atoms
 def sorted_walk(f):
@@ -62,10 +62,10 @@ fn run(args []string) !string {
 	return res.output
 }
 
-// test_alexcrichton_toml_rs run though 'testdata/alexcrichton/toml-test/test-suite/tests/*' if found.
-fn test_alexcrichton_toml_rs() {
+// test_toml_rs_toml_rs run though 'testdata/toml_rs/toml-test/test-suite/tests/*' if found.
+fn test_toml_rs_toml_rs() {
 	eprintln('> running ${@LOCATION}')
-	test_root := '${@VROOT}/vlib/toml/tests/testdata/alexcrichton/test-suite/tests'
+	test_root := '${@VROOT}/vlib/toml/tests/testdata/toml_rs/test-suite/tests'
 	if os.is_dir(test_root) {
 		valid_test_files := os.walk_ext(os.join_path(test_root, 'valid'), '.toml')
 		invalid_test_files := os.walk_ext(os.join_path(test_root, 'invalid'), '.toml')
@@ -139,7 +139,7 @@ fn test_alexcrichton_toml_rs() {
 
 				v_toml_json_path := os.join_path(compare_work_dir_root,
 					os.file_name(valid_test_file).all_before_last('.') + '.v.json')
-				alexcrichton_toml_json_path := os.join_path(compare_work_dir_root,
+				toml_rs_toml_json_path := os.join_path(compare_work_dir_root,
 					os.file_name(valid_test_file).all_before_last('.') + '.json')
 
 				mut array_type := 1
@@ -147,23 +147,23 @@ fn test_alexcrichton_toml_rs() {
 					array_type = 2
 				}
 
-				os.write_file(v_toml_json_path, to_alexcrichton(toml_doc.ast.table, array_type))!
+				os.write_file(v_toml_json_path, to_toml_rs(toml_doc.ast.table, array_type))!
 
-				alexcrichton_json := os.read_file(valid_test_file.all_before_last('.') + '.json')!
+				toml_rs_json := os.read_file(valid_test_file.all_before_last('.') + '.json')!
 
-				os.write_file(alexcrichton_toml_json_path, alexcrichton_json)!
+				os.write_file(toml_rs_toml_json_path, toml_rs_json)!
 
 				v_normalized_json := run([jq, '-S', '-f "${jq_normalize_path}"', v_toml_json_path]) or {
 					contents := os.read_file(v_toml_json_path)!
 					panic(err.msg() + '\n${contents}')
 				}
-				alexcrichton_normalized_json := run([jq, '-S', '-f "${jq_normalize_path}"',
-					alexcrichton_toml_json_path]) or {
+				toml_rs_normalized_json := run([jq, '-S', '-f "${jq_normalize_path}"',
+					toml_rs_toml_json_path]) or {
 					contents := os.read_file(v_toml_json_path)!
 					panic(err.msg() + '\n${contents}')
 				}
 
-				assert alexcrichton_normalized_json == v_normalized_json
+				assert toml_rs_normalized_json == v_normalized_json
 
 				valid++
 			}
@@ -213,8 +213,8 @@ fn test_alexcrichton_toml_rs() {
 	}
 }
 
-// to_alexcrichton_time
-fn to_alexcrichton_time(time_str string) string {
+// to_toml_rs_time
+fn to_toml_rs_time(time_str string) string {
 	if time_str.contains('.') {
 		date_and_time := time_str.all_before('.')
 		mut ms := time_str.all_after('.')
@@ -229,8 +229,8 @@ fn to_alexcrichton_time(time_str string) string {
 	}
 }
 
-// to_alexcrichton returns an alexcrichton compatible json string converted from the `value` ast.Value.
-fn to_alexcrichton(value ast.Value, array_type int) string {
+// to_toml_rs returns an toml_rs compatible json string converted from the `value` ast.Value.
+fn to_toml_rs(value ast.Value, array_type int) string {
 	match value {
 		ast.Quoted {
 			json_text := json2.Any(value.text).json_str()
@@ -248,9 +248,9 @@ fn to_alexcrichton(value ast.Value, array_type int) string {
 			}
 			// NOTE test suite inconsistency.
 			// It seems it's implementation specific how time and
-			// date-time values are represented in detail. For now we follow the BurntSushi format
+			// date-time values are represented in detail. For now we follow the toml-lang format
 			// that expands to 6 digits which is also a valid RFC 3339 representation.
-			json_text = to_alexcrichton_time(json_text[1..json_text.len - 1])
+			json_text = to_toml_rs_time(json_text[1..json_text.len - 1])
 			return '{ "type": "${typ}", "value": "${json_text}" }'
 		}
 		ast.Date {
@@ -259,7 +259,7 @@ fn to_alexcrichton(value ast.Value, array_type int) string {
 		}
 		ast.Time {
 			mut json_text := json2.Any(value.text).json_str()
-			json_text = to_alexcrichton_time(json_text[1..json_text.len - 1])
+			json_text = to_toml_rs_time(json_text[1..json_text.len - 1])
 			return '{ "type": "time", "value": "${json_text}" }'
 		}
 		ast.Bool {
@@ -295,7 +295,7 @@ fn to_alexcrichton(value ast.Value, array_type int) string {
 			mut str := '{ '
 			for key, val in value {
 				json_key := json2.Any(key).json_str()
-				str += ' ${json_key}: ${to_alexcrichton(val, array_type)},'
+				str += ' ${json_key}: ${to_toml_rs(val, array_type)},'
 			}
 			str = str.trim_right(',')
 			str += ' }'
@@ -309,7 +309,7 @@ fn to_alexcrichton(value ast.Value, array_type int) string {
 				str = '[ '
 			}
 			for val in value {
-				str += ' ${to_alexcrichton(val, array_type)},'
+				str += ' ${to_toml_rs(val, array_type)},'
 			}
 			str = str.trim_right(',')
 			if array_type == 1 {


### PR DESCRIPTION
Due to the new names/repositories using `-` I chose to keep things on the V side using `_` since it makes it easier to handle in regards to directory names and, more importantly, variable names. So e.g. `toml-lang` is `toml_lang` *except* in some special-cases like in some comment URLs (which I have checked is still valid).