### PR TITLE
x.json2: fix decode_number for u8

### DIFF
--- a/vlib/x/json2/decode.v
+++ b/vlib/x/json2/decode.v
@@ -930,95 +930,19 @@ fn (mut decoder Decoder) decode_number[T](val &T) ! {
 	$if T.unaliased_typ is $float {
 		*val = T(strconv.atof_quick(decoder.json[number_info.position..number_info.position +
 			number_info.length]))
-	} $else { // this part is a minefield
-		mut is_negative := false
-		mut index := 0
-
-		if decoder.json[number_info.position] == `-` {
-			$if T.unaliased_typ is u8 || T.unaliased_typ is u16 || T.unaliased_typ is u32
-				|| T.unaliased_typ is u64 || T.unaliased_typ is $enum {
-				decoder.decode_error('expected positive integer for ${typeof(val).name} but got ${decoder.json[number_info.position..
-					number_info.position + number_info.length]}')!
-			}
-
-			is_negative = true
-			index++
-		}
-
-		// doing it like this means the minimum of signed numbers does not overflow before being inverted
-		*val = 0 // initialize to zero before accumulating digits
-		if !is_negative {
-			digit_amount := get_number_digits(*val)
-
-			if number_info.length > digit_amount {
-				decoder.decode_error('overflows ${typeof(val).name}')!
-			}
-
-			for index < int_min(number_info.length, digit_amount - 1) {
-				digit := T(decoder.json[number_info.position + index] - `0`)
-
-				if digit > 9 { // comma, e and E are all smaller 0 in ASCII so they underflow
-					decoder.decode_error('expected integer but got real number')!
-				}
-
-				*val = *val * 10 + digit
-
-				index++
-			}
-
-			if index == digit_amount - 1 {
-				digit := T(decoder.json[number_info.position + index] - `0`)
-
-				if digit > 9 { // comma, e and E are all smaller 0 in ASCII so they underflow
-					decoder.decode_error('expected integer but got real number')!
-				}
-
-				type_max := get_number_max(*val)
-				max_digits := type_max / 10
-				last_digit := type_max % 10
-
-				if *val > max_digits || (*val == max_digits && digit > last_digit) {
-					decoder.decode_error('overflows ${typeof(val).name}s')!
-				}
-
-				*val = *val * 10 + digit
-			}
-		} else {
-			digit_amount := get_number_digits(*val) + 1
-
-			if number_info.length > digit_amount {
-				decoder.decode_error('underflows ${typeof(val).name}')!
-			}
-
-			for index < int_min(number_info.length, digit_amount - 1) {
-				digit := T(decoder.json[number_info.position + index] - `0`)
-
-				if digit > 9 { // comma, e and E are all smaller 0 in ASCII so they underflow
-					decoder.decode_error('expected integer but got real number')!
-				}
-
-				*val = *val * 10 - digit
-
-				index++
-			}
-
-			if index == digit_amount - 1 {
-				digit := T(decoder.json[number_info.position + index] - `0`)
-
-				if digit > 9 { // comma, e and E are all smaller 0 in ASCII so they underflow
-					decoder.decode_error('expected integer but got real number')!
-				}
-
-				type_min := get_number_min(*val)
-				min_digits := type_min / 10
-				last_digit := type_min % 10
-
-				if *val < min_digits || (*val == min_digits && -digit < last_digit) {
-					decoder.decode_error('underflows ${typeof(val).name}')!
-				}
-
-				*val = *val * 10 - digit
-			}
+	} $else {
+		str := decoder.json[number_info.position..number_info.position + number_info.length]
+		$match T.unaliased_typ {
+			i8 { *val = strconv.atoi8(str)! }
+			i16 { *val = strconv.atoi16(str)! }
+			i32 { *val = strconv.atoi32(str)! }
+			i64 { *val = strconv.atoi64(str)! }
+			u8 { *val = strconv.atou8(str)! }
+			u16 { *val = strconv.atou16(str)! }
+			u32 { *val = strconv.atou32(str)! }
+			u64 { *val = strconv.atou64(str)! }
+			int { *val = strconv.atoi(str)! }
+			$else { return error('`decode_number` can not decode ${T.name} type') }
 		}
 	}
 }

--- a/vlib/x/json2/tests/decode_struct_test.v
+++ b/vlib/x/json2/tests/decode_struct_test.v
@@ -73,3 +73,20 @@ fn test_option_types() {
 		assert false, 'Should not return none'
 	}
 }
+
+struct JsonU8 {
+	val1 u8
+	val2 u8
+}
+
+fn test_u8_vals() {
+	x := JsonU8{
+		val1: 58
+		val2: 58
+	}
+
+	str := json.encode(x)
+
+	y := json.decode[JsonU8](str) or { panic(err) }
+	assert x == y
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #26027 

two digits u8 decode may fail with origin code.
Use `strconv.atoxx` instead.