### PR TITLE
wasm: fix export pub fns in main module when targeting wasi

### DIFF
--- a/vlib/v/gen/wasm/gen.v
+++ b/vlib/v/gen/wasm/gen.v
@@ -286,7 +286,7 @@ pub fn (mut g Gen) fn_decl(node ast.FnDecl) {
 	g.fn_local_idx_end = (g.local_vars.len + g.ret_rvars.len)
 	g.fn_name = name
 
-	mut should_export := g.pref.os == .browser && node.is_pub && node.mod == 'main'
+	mut should_export := g.pref.os in [.browser, .wasi] && node.is_pub && node.mod == 'main'
 
 	g.func = g.mod.new_debug_function(name, wasm.FuncType{paraml, retl, none}, paramdbg)
 	func_start := g.func.patch_pos()


### PR DESCRIPTION
Fixes: #25630

The WASM backend was only exporting pub functions when the target OS was `.browser`. When compiling with -b wasm (which defaults to .wasi target), pub functions were not exported. This prevented tools like wasmer from invoking the functions.

I've updated the logic to determine public exports in the main module to also include the `.wasi` target. Not entirely sure what a test for this would look like without adding a dependency on something like wasmer (or parsing the generated output file, maybe?)
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
