### PR TITLE
toml, tests: update `toml-rs` test suite to last available commit before files where removed

### DIFF
--- a/.github/workflows/download_full_toml_test_suites.sh
+++ b/.github/workflows/download_full_toml_test_suites.sh
@@ -12,5 +12,9 @@ git -C vlib/toml/tests/testdata/iarna checkout 1880b1a
 ./v retry -- git clone -n https://github.com/toml-lang/toml-test.git vlib/toml/tests/testdata/toml_lang
 git -C vlib/toml/tests/testdata/toml_lang checkout f30c716
 
+# A few history notes of toml-rs (previously alexcrichton):
+#  commit 7f5472c the test-suite dir moves to the crates/ sub-directory
+#  commit 8461f7c *a lot* of test files are removed in *hope* that they are covered by the compliance test suite (assumed to be BurntSushi/toml-test, later toml-lang/toml-test)
+#  commit 9bd454c the last known good commit we can test against
 ./v retry -- git clone -n https://github.com/toml-rs/toml.git vlib/toml/tests/testdata/toml_rs
-git -C vlib/toml/tests/testdata/toml_rs reset --hard 499e8c4
+git -C vlib/toml/tests/testdata/toml_rs reset --hard 9bd454c

--- a/vlib/toml/tests/toml_rs_test.v
+++ b/vlib/toml/tests/toml_rs_test.v
@@ -9,7 +9,7 @@ const no_jq = os.getenv('VNO_JQ') == '1'
 // Instructions for developers:
 // The actual tests and data can be obtained by doing:
 // `git clone -n https://github.com/toml-rs/toml.git vlib/toml/tests/testdata/toml_rs`
-// `git -C vlib/toml/tests/testdata/toml_rs reset --hard 499e8c4`
+// `git -C vlib/toml/tests/testdata/toml_rs reset --hard 9bd454c`
 // See also the CI toml tests
 // Kept for easier handling of future updates to the tests
 const valid_exceptions = [
@@ -36,7 +36,7 @@ const use_type_2_arrays = [
 	'valid/table-array-nest.toml',
 	'valid/table-array-nest-no-keys.toml',
 ]
-const tests_folder = os.join_path('test-suite', 'tests')
+const tests_folder = os.join_path('crates', 'test-suite', 'tests')
 const jq = os.find_abs_path_of_executable('jq') or { '' }
 const compare_work_dir_root = os.join_path(os.vtmp_dir(), 'toml_toml_rs')
 // From: https://stackoverflow.com/a/38266731/1904615
@@ -62,10 +62,10 @@ fn run(args []string) !string {
 	return res.output
 }
 
-// test_toml_rs_toml_rs run though 'testdata/toml_rs/toml-test/test-suite/tests/*' if found.
+// test_toml_rs_toml_rs run though 'testdata/toml_rs/crates/test-suite/tests/*' if found.
 fn test_toml_rs_toml_rs() {
 	eprintln('> running ${@LOCATION}')
-	test_root := '${@VROOT}/vlib/toml/tests/testdata/toml_rs/test-suite/tests'
+	test_root := '${@VROOT}/vlib/toml/tests/testdata/toml_rs/crates/test-suite/tests'
 	if os.is_dir(test_root) {
 		valid_test_files := os.walk_ext(os.join_path(test_root, 'valid'), '.toml')
 		invalid_test_files := os.walk_ext(os.join_path(test_root, 'invalid'), '.toml')


### PR DESCRIPTION
For the sake of traceability and brief digital archeology/history:

This PR accounts for a few changes to the `toml-rs` test suite we've tested V's `toml` module against;
* [7f5472c](https://github.com/toml-rs/toml/commit/7f5472c) the `test-suite` directory moves to the `crates/` sub-directory
* [8461f7c](https://github.com/toml-rs/toml/commit/8461f7cfd963f116eb66b6c1558faed0532e453d#diff-ab1b28a84f7396fedb32848a984de4e1197f7b7ea34b0dbc6c7c898b5f68d1f1) *a lot* of test files are removed (in *hope*?) that they are covered by the compliance test suite (that I assume to be BurntSushi/toml-test, later `toml-lang/toml-test`)

V is now tested against commit [9bd454c](https://github.com/toml-rs/toml/commit/9bd454c) which, my detective work tells me, is the last known good commit that contains the test data we've been using so far.

Commits after `9bd454c` does seem to contain some mostly invalid `.toml` files but they are scattered around the project so would require some work to write tests for.

I assume that `toml-rs` is also using the now official `toml-lang/toml-test` test suite (I haven't dug deep to try and figure it out though).
So... despite some confusion I think we can concentrate on testing against https://github.com/toml-lang/toml-test going forward. For now I do not think it hurts much to still test against the stale ones (iarna/toml-rs remains).