### PR TITLE
C builtin function: memchr

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -12,7 +12,7 @@ fn C.memmove(dest voidptr, const_src voidptr, n usize) voidptr
 
 fn C.memset(str voidptr, c int, n usize) voidptr
 
-fn C.memchr(buf &u8, char int, len usize) &u8
+fn C.memchr(str voidptr, c int, n usize) voidptr
 
 @[trusted]
 fn C.calloc(int, int) &u8


### PR DESCRIPTION
libc memchr is vector-accelerated via glibc IFUNC

use case example
```v
fn find_byte(buf &u8, len int, c u8) int {
	unsafe {
		p := C.memchr(buf, c, len)
		if p == voidptr(nil) {
			return -1
		}
		return int(p - buf)
	}
}
```