### PR TITLE
rand.pcg32: make incrementer be always odd in PCG32RNG

### DIFF
--- a/vlib/rand/pcg32/pcg32.v
+++ b/vlib/rand/pcg32/pcg32.v
@@ -15,7 +15,7 @@ pub struct PCG32RNG {
 	buffer.PRNGBuffer
 mut:
 	state u64 = u64(0x853c49e6748fea9b) ^ seed.time_seed_64()
-	inc   u64 = u64(0xda3e39cb94b95bdb) ^ seed.time_seed_64()
+	inc   u64 = (u64(0xda3e39cb94b95bdb) ^ seed.time_seed_64()) | u64(1)
 }
 
 // seed seeds the PCG32RNG with 4 `u32` values.


### PR DESCRIPTION
If the user uses `pcg32` without using a `seed()`, it is necessary to guarantee that `inc` will always be `odd` (!). This is required by `LCG` generators theory, of which `PCG` is a sub-type.
That's why the `seed()` function always makes `inc` `odd`. The value can be anything, but `odd`.

As soon as you use a random `even` number in pcg32, `TestU01` tool is immediately dissatisfied.
For example, in `crush` mode (-c):
```
========= Summary results of Crush =========

 Version:          TestU01 1.2.3
 Generator:        pcg32 lsb 32-bits
 Number of statistics:  144
 Total CPU time:   00:16:18.75
 The following tests gave p-values outside [0.001, 0.9990]:
 (eps  means a value < 1.0e-300):
 (eps1 means a value < 1.0e-15):

       Test                          p-value
 ----------------------------------------------
 72  LinearComp, r = 29              8.4e-4
 ----------------------------------------------
 All other tests were passed
```
Excellent audit finding.