### PR TITLE
net.http: use error_with_code in download_file()

### DIFF
--- a/vlib/net/http/download.v
+++ b/vlib/net/http/download.v
@@ -13,7 +13,7 @@ pub fn download_file(url string, out_file_path string) ! {
 	}
 	s := get(url) or { return err }
 	if s.status() != .ok {
-		return error('received http code ${s.status_code}')
+		return error_with_code(s.body, s.status_code)
 	}
 	$if debug_http ? {
 		println('http.download_file saving ${s.body.len} bytes')


### PR DESCRIPTION
Fixes #26056.

Fix provided by @quaesitor-scientiam.