### PR TITLE
cgen: fix cast() generic type bug

### DIFF
--- a/vlib/v/tests/bool_cast_int_test.v
+++ b/vlib/v/tests/bool_cast_int_test.v
@@ -1,5 +1,10 @@
 module main
 
+fn generic_asm[T](var &T) T {
+	ret := unsafe { T(14) }
+	return ret
+}
+
 fn test_main() {
 	v1 := unsafe { bool(1) }
 	v10 := unsafe { bool(10) }
@@ -11,4 +16,6 @@ fn test_main() {
 	assert int(v2) == 0
 	v3 := true
 	assert int(v3) == 1
+
+	assert generic_asm[bool](v1) == true
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #26065 

This is because a mix use of `node.typ` and `node_typ`:
```v
node_typ := g.unwrap_generic(node.typ)
```

I think we should use `node_typ` in `cast_expr()`, as `node.typ` sometimes is `T`.
