### PR TITLE
builtin: fix some C fn signatures

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -15,20 +15,20 @@ fn C.memset(str voidptr, c int, n usize) voidptr
 fn C.memchr(str voidptr, c int, n usize) voidptr
 
 @[trusted]
-fn C.calloc(int, int) &u8
+fn C.calloc(usize, usize) voidptr
 
 fn C.atoi(&char) int
 
-fn C.malloc(int) &u8
+fn C.malloc(usize) voidptr
 
-fn C.realloc(a &u8, b int) &u8
+fn C.realloc(a voidptr, b usize) voidptr
 
 fn C.free(ptr voidptr)
 
-fn C.mmap(addr_length int, length isize, prot int, flags int, fd int, offset u64) voidptr
-fn C.mprotect(addr_length int, len isize, prot int) int
+fn C.mmap(addr_length voidptr, length usize, prot int, flags int, fd int, offset isize) voidptr
+fn C.mprotect(addr_length voidptr, len usize, prot int) int
 
-fn C.aligned_alloc(align isize, size isize) voidptr
+fn C.aligned_alloc(align usize, size usize) voidptr
 
 // windows aligned memory functions
 fn C._aligned_malloc(size isize, align isize) voidptr


### PR DESCRIPTION
This patch affects 6 functions - `calloc()`, `malloc()`, `realloc()`, `mmap()`, `mprotect()`, `aligned_alloc()`. 

I manually compared and verified the signatures of these functions.
I spent 90% of the time selecting the correct type for `offset` from the `mmap()` function.

Please check my PR.


p.s. 
```
$ cat vlib/builtin/allocation.c.v | grep "pub fn malloc" | head -1
pub fn malloc(n isize) &u8 {
```
to be honest, I don't fully understand how this affects this and how `cfns.c.v` and `allocation.c.v` work with each other.