### PR TITLE
fasthttp: improve minimal server example

### DIFF
--- a/vlib/fasthttp/README.md
+++ b/vlib/fasthttp/README.md
@@ -29,11 +29,26 @@ import fasthttp
 fn handle_request(req fasthttp.HttpRequest) ![]u8 {
 	path := req.buffer[req.path.start..req.path.start + req.path.len].bytestr()
 
+	mut body := ''
+	mut status_line := ''
+
 	if path == '/' {
-		return 'Hello, World!'.bytes()
+		body = 'Hello, World!\n'
+		status_line = 'HTTP/1.1 200 OK'
+	} else {
+		body = '${path} not found\n'
+		status_line = 'HTTP/1.1 404 Not Found'
 	}
 
-	return '404 Not Found'.bytes()
+	headers := [
+		status_line,
+		'Content-Type: text/plain',
+		'Content-Length: ${body.len}',
+		'Connection: close',
+	]
+	header_string := headers.join('\r\n')
+
+	return '${header_string}\r\n\r\n${body}'.bytes()
 }
 
 fn main() {


### PR DESCRIPTION
While experimenting with fasthttp on darwin and FreeBSD, the minimal server example, which does function, does not comply with the HTTP protocol exactly.  When using curl to hit the server, it complains about a response using HTTP 0.9.  Adding a status header to the response gets past that hurdle.  However, it then complains about other missing headers and no reply content.

The changes I am proposing make the response compatible with HTTP/1.1 and has enough headers and content to keep curl happy.  This might make it more obvious to people using this module that they are responsible for crafting legitimate responses which includes the headers.  I tried to keep the code minimal while satisfying the protocol constraints.

I do have another question.

I was able to copy fasthttp_darwin.v to fasthttp_freebsd.v and everything works with no changes.  I suspect that the same would work for OpenBSD, NetBSD, and DragonflyBSD.  However, I think having 5 identical copies of the kqueue implementation under os specific file names would not be ideal.

Unfortunately, I have to work with many different languages in my day job and I don't have the proper mindset to really write v code in proper idiomatic v.  I only get to write v code in my spare time which is quite scarce at the moment.

My first idea is to create a fasthttp_default.v file with the kqueue implementation enclosed in:
```
$if darwin || freebsd || openbsd || netbsd || dragonflybsd {
...
}
```
and remove the fasthttp_darwin.v file.  Somehow, that doesn't feel right.

I am open to any suggestions.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
