### PR TITLE
cgen: fix fn_var_signature() support nr_muls

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -471,7 +471,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 
 fn (mut g Gen) declare_closure_fn(mut expr ast.AnonFn, var_name string) {
 	decl_var := g.fn_var_signature(expr.decl.return_type, expr.decl.params.map(it.typ),
-		var_name)
+		var_name, 0)
 	g.write('${decl_var} = ')
 	g.gen_anon_fn(mut expr)
 	g.writeln(';')
@@ -553,7 +553,7 @@ fn (mut g Gen) gen_array_map(node ast.CallExpr) {
 			if var_sym.info is ast.FnType {
 				ret_elem_styp = 'voidptr'
 				closure_var_decl = g.fn_var_signature(var_sym.info.func.return_type, var_sym.info.func.params.map(it.typ),
-					tmp_map_expr_result_name)
+					tmp_map_expr_result_name, 0)
 			}
 		}
 	}

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -507,7 +507,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 					// if it's a decl assign (`:=`) or a blank assignment `_ =`/`_ :=` then generate `void (*ident) (args) =`
 					if (is_decl || blank_assign) && left is ast.Ident {
 						sig := g.fn_var_signature(val.decl.return_type, val.decl.params.map(it.typ),
-							ident.name)
+							ident.name, 0)
 						g.write(sig + ' = ')
 					} else {
 						g.is_assign_lhs = true

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -548,7 +548,7 @@ fn (mut g Gen) gen_map_equality_fn(left_type ast.Type) string {
 	if kind == .function {
 		info := value.sym.info as ast.FnType
 		sig := g.fn_var_signature(info.func.return_type, info.func.params.map(it.typ),
-			'v')
+			'v', 0)
 		fn_builder.writeln('\t\t${sig} = *(voidptr*)builtin__map_get(${a}, k, &(voidptr[]){ 0 });')
 	} else {
 		fn_builder.writeln('\t\t${ptr_value_styp} v = *(${ptr_value_styp}*)builtin__map_get(${a}, k, &(${ptr_value_styp}[]){ ${initializer} });')

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -350,7 +350,7 @@ fn (mut g Gen) const_decl_init_later(mod string, name string, cname string, expr
 	if expr_sym.kind == .function {
 		// allow for: `const xyz = abc`, where `abc` is `fn abc() {}`
 		func := (expr_sym.info as ast.FnType).func
-		def = g.fn_var_signature(func.return_type, func.params.map(it.typ), cname)
+		def = g.fn_var_signature(func.return_type, func.params.map(it.typ), cname, 0)
 	}
 	init_str := init.str().trim_right('\n')
 	g.global_const_defs[util.no_dots(name)] = GlobalConstDef{

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -309,7 +309,7 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 
 			if call_fn.is_fn_var {
 				sig := g.fn_var_signature(call_fn.func.return_type, call_fn.func.params.map(it.typ),
-					call_fn.name)
+					call_fn.name, 0)
 				g.write(sig)
 				g.definitions.write_string(sig)
 			} else {
@@ -741,8 +741,8 @@ fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {
 			for var in node.inherited_vars {
 				var_sym := g.table.sym(var.typ)
 				if var_sym.info is ast.FnType {
-					sig := g.fn_var_signature(var_sym.info.func.return_type, var_sym.info.func.params.map(it.typ),
-						c_name(var.name))
+					mut sig := g.fn_var_signature(var_sym.info.func.return_type, var_sym.info.func.params.map(it.typ),
+						c_name(var.name), var.typ.nr_muls())
 					g.definitions.writeln('\t' + sig + ';')
 				} else {
 					styp := g.styp(var.typ)
@@ -881,7 +881,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 		if node.left.inherited_vars.len > 0 {
 			tmp_anon_fn_var = g.new_tmp_var()
 			fn_type := g.fn_var_signature(node.left.decl.return_type, node.left.decl.params.map(it.typ),
-				tmp_anon_fn_var)
+				tmp_anon_fn_var, 0)
 			line := g.go_before_last_stmt().trim_space()
 			g.empty_line = true
 			g.write('${fn_type} = ')
@@ -914,7 +914,7 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			tmp_res := g.new_tmp_var()
 			fn_sym := g.table.sym(left_typ).info as ast.FnType
 			fn_type := g.fn_var_signature(fn_sym.func.return_type, fn_sym.func.params.map(it.typ),
-				tmp_res)
+				tmp_res, 0)
 
 			old_is_fn_index_call := g.is_fn_index_call
 			g.is_fn_index_call = true

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -103,7 +103,7 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 		if !node.return_type.has_option_or_result() && ret_final_sym.kind == .function {
 			if ret_final_sym.info is ast.FnType {
 				def := g.fn_var_signature(ret_final_sym.info.func.return_type, ret_final_sym.info.func.params.map(it.typ),
-					tmp_var)
+					tmp_var, 0)
 				func_decl = '${def} = &${g.styp(node.return_type)};'
 			}
 		}

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -51,7 +51,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	} else if mut expr.left is ast.AnonFn {
 		if expr.left.inherited_vars.len > 0 {
 			fn_var := g.fn_var_signature(expr.left.decl.return_type, expr.left.decl.params.map(it.typ),
-				tmp_fn)
+				tmp_fn, 0)
 			g.write('\t${fn_var} = ')
 			g.gen_anon_fn(mut expr.left)
 			g.writeln(';')
@@ -65,7 +65,8 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 		if expr.is_fn_var {
 			fn_sym := g.table.sym(expr.fn_var_type)
 			func := (fn_sym.info as ast.FnType).func
-			fn_var := g.fn_var_signature(func.return_type, func.params.map(it.typ), tmp_fn)
+			fn_var := g.fn_var_signature(func.return_type, func.params.map(it.typ), tmp_fn,
+				0)
 			g.write('\t${fn_var} = ')
 			g.expr(expr.left)
 			g.writeln(';')
@@ -185,10 +186,10 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 			fn_sym := g.table.sym(node.call_expr.fn_var_type)
 			info := fn_sym.info as ast.FnType
 			fn_var = g.fn_var_signature(info.func.return_type, info.func.params.map(it.typ),
-				'fn')
+				'fn', 0)
 		} else if node.call_expr.left is ast.AnonFn {
 			f := node.call_expr.left.decl
-			fn_var = g.fn_var_signature(f.return_type, f.params.map(it.typ), 'fn')
+			fn_var = g.fn_var_signature(f.return_type, f.params.map(it.typ), 'fn', 0)
 		} else {
 			if node.call_expr.is_method {
 				rec_sym := g.table.sym(g.unwrap_generic(node.call_expr.receiver_type))
@@ -199,7 +200,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 					mut arg_types := f.params.map(it.typ)
 					arg_types = arg_types.map(muttable.convert_generic_type(it, f.generic_names,
 						node.call_expr.concrete_types) or { it })
-					fn_var = g.fn_var_signature(return_type, arg_types, 'fn')
+					fn_var = g.fn_var_signature(return_type, arg_types, 'fn', 0)
 				}
 			} else {
 				if f := g.table.find_fn(node.call_expr.name) {
@@ -222,7 +223,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 							}
 						}
 					}
-					fn_var = g.fn_var_signature(return_type, arg_types, 'fn')
+					fn_var = g.fn_var_signature(return_type, arg_types, 'fn', 0)
 				}
 			}
 		}
@@ -238,7 +239,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 			arg_sym := g.table.sym(arg.typ)
 			if arg_sym.info is ast.FnType {
 				sig := g.fn_var_signature(arg_sym.info.func.return_type, arg_sym.info.func.params.map(it.typ),
-					'arg${i + 1}')
+					'arg${i + 1}', arg.typ.nr_muls())
 				g.type_definitions.writeln('\t' + sig + ';')
 			} else {
 				styp := g.styp(arg.typ)

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -84,14 +84,15 @@ fn (mut g Gen) unwrap(typ ast.Type) Type {
 }
 
 // generate function variable definition, e.g. `void (*var_name) (int, string)`
-fn (mut g Gen) fn_var_signature(return_type ast.Type, arg_types []ast.Type, var_name string) string {
+fn (mut g Gen) fn_var_signature(return_type ast.Type, arg_types []ast.Type, var_name string, nr_muls int) string {
 	ret_styp := g.styp(return_type)
-	mut sig := '${ret_styp} (*${c_name(var_name)}) ('
+	mut sig := '${ret_styp} (${'*'.repeat(nr_muls + 1)}${c_name(var_name)}) ('
 	for j, arg_typ in arg_types {
 		arg_sym := g.table.sym(arg_typ)
 		if arg_sym.info is ast.FnType {
 			func := arg_sym.info.func
-			arg_sig := g.fn_var_signature(func.return_type, func.params.map(it.typ), '')
+			arg_sig := g.fn_var_signature(func.return_type, func.params.map(it.typ), '',
+				arg_typ.nr_muls())
 			sig += arg_sig
 		} else {
 			arg_styp := g.styp(arg_typ)

--- a/vlib/v/tests/closure_with_fn_ref_var_test.v
+++ b/vlib/v/tests/closure_with_fn_ref_var_test.v
@@ -1,0 +1,25 @@
+module main
+
+fn f_a() int {
+	println('a')
+	return 1
+}
+
+fn test_closure_with_fn_ref_var() {
+	f := f_a
+	ref := &f
+	println('ref=0x${ptr_str(ref)}')
+
+	handler := fn [ref] () int { // ref_fn is captured as a direct function pointer (*fn) instead of a pointer to a function (**fn)
+		println('in closure: ref=0x${ptr_str(ref)}')
+		deref_fn := *ref
+		println('in closure: deref=0x${ptr_str(deref_fn)}')
+		return deref_fn()
+	}
+
+	f()
+	deref := *ref
+	println('deref=0x${ptr_str(deref)}')
+	assert deref() == 1
+	assert handler() == 1
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #26049

original code only support gen fn sig :
```c
void (*var_name) (int, string)
```
and now we can support fn sig such as :
```c
void (*****var_name) (int, string)
```