### PR TITLE
cgen,slow_tests: improove loongarch64 inline asm, add test

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3412,12 +3412,18 @@ fn (mut g Gen) asm_arg(arg ast.AsmArg, stmt ast.AsmStmt) {
 				.base {
 					if stmt.arch == .arm64 {
 						g.write('[')
+					}
+					if stmt.arch == .loongarch64 {
+						g.write('')
 					} else {
 						g.write('(')
 					}
 					g.asm_arg(base, stmt)
 					if stmt.arch == .arm64 {
 						g.write(']')
+					}
+					if stmt.arch == .loongarch64 {
+						g.write('')
 					} else {
 						g.write(')')
 					}

--- a/vlib/v/slow_tests/assembly/asm_test.loongarch64.v
+++ b/vlib/v/slow_tests/assembly/asm_test.loongarch64.v
@@ -34,4 +34,15 @@ fn test_inline_asm() {
 	assert d == 10
 	assert e == 2
 	assert f == 17
+
+	l := 5
+	m := &l
+	asm loongarch64 {
+		li.w r20, 7
+		st.w r20, [m], 0
+		; ; r (m)
+		; r20
+		  memory
+	}
+	assert l == 7
 }


### PR DESCRIPTION
This patch add support to work with variable by reference for `loongarch64` architecture.
Works under gcc and clang.
