### PR TITLE
toml: remove special cases for `jq` normalization

### DIFF
--- a/vlib/toml/tests/toml_lang_test.v
+++ b/vlib/toml/tests/toml_lang_test.v
@@ -29,12 +29,6 @@ const valid_exceptions = [
 ]
 const jq_not_equal = [
 	'do_not_remove',
-	'datetime/milliseconds.toml',
-	'float/zero.toml',
-	'inline-table/spaces.toml',
-	'spec/array-of-tables-1.toml',
-	'spec/float-0.toml',
-	'spec/float-2.toml',
 ]
 const invalid_exceptions = [
 	'do_not_remove',


### PR DESCRIPTION
Not sure if these will trigger the CI anymore (they do not trigger anything locally with `jq` v1.8.1), let's see 🤷🏻 