### PR TITLE
toml: switch to test against entries in `files-toml-1.0.0` for `toml-lang` tests

### DIFF
--- a/vlib/toml/tests/toml_lang_test.v
+++ b/vlib/toml/tests/toml_lang_test.v
@@ -8,8 +8,7 @@ import toml
 import toml.ast
 import x.json2
 
-const test_root = os.join_path(@VROOT, 'vlib', 'toml', 'tests', 'testdata', 'toml_lang',
-	'tests')
+const test_root = os.join_path(@VROOT, 'vlib/toml/tests/testdata/toml_lang/tests')
 const test_files_file = os.join_path(test_root, 'files-toml-1.0.0')
 
 const hide_oks = os.getenv('VTEST_HIDE_OK') == '1'


### PR DESCRIPTION
This PR change the `toml_lang_test.v` to use the official test file list described here: https://github.com/toml-lang/toml-test/tree/main?tab=readme-ov-file#usage-without-toml-test-binary

This reliefs us from making distinctions between TOML v1.0.0 and v1.1.0 tests when testing our parser.