### PR TITLE
toml, tests: support v2.0.0 of the test-suite at toml-lang/toml-test@229ce2e

### DIFF
--- a/.github/workflows/download_full_toml_test_suites.sh
+++ b/.github/workflows/download_full_toml_test_suites.sh
@@ -10,7 +10,7 @@ rm -rf vlib/toml/tests/testdata/iarna vlib/toml/tests/testdata/toml_rs vlib/toml
 git -C vlib/toml/tests/testdata/iarna checkout 1880b1a
 
 ./v retry -- git clone -n https://github.com/toml-lang/toml-test.git vlib/toml/tests/testdata/toml_lang
-git -C vlib/toml/tests/testdata/toml_lang checkout 8bb8d9c
+git -C vlib/toml/tests/testdata/toml_lang checkout 229ce2e
 
 # A few history notes of toml-rs (previously alexcrichton):
 #  commit 7f5472c the test-suite dir moves to the crates/ sub-directory

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -1541,7 +1541,7 @@ pub fn (mut p Parser) time() !ast.Time {
 	lit += p.tok.lit
 	p.check(.number)!
 	lit += p.tok.lit
-	// TODO: does TOML even have optional seconds?
+	// NOTE: TOML v1.1.0 have optional seconds
 	// if p.peek_tok.kind == .colon {
 	p.check(.colon)!
 	lit += p.tok.lit
@@ -1555,6 +1555,11 @@ pub fn (mut p Parser) time() !ast.Time {
 		p.check(.period)!
 		lit += p.tok.lit
 		p.expect(.number)!
+	}
+
+	if !lit[lit.len - 1].is_digit() {
+		return error(@MOD + '.' + @STRUCT + '.' + @FN +
+			' expected a number as last occurrence in "${lit}" got "${lit[lit.len - 1].ascii_str()}"')
 	}
 
 	// Parse offset

--- a/vlib/toml/tests/toml_lang_test.v
+++ b/vlib/toml/tests/toml_lang_test.v
@@ -1,7 +1,7 @@
 // Instructions for developers:
 // The actual tests and data can be obtained by doing:
 // `git clone -n https://github.com/toml-lang/toml-test.git vlib/toml/tests/testdata/toml_lang`
-// `git -C vlib/toml/tests/testdata/toml_lang reset --hard 8bb8d9c
+// `git -C vlib/toml/tests/testdata/toml_lang reset --hard 229ce2e
 // See also the CI toml tests
 import os
 import toml
@@ -14,7 +14,8 @@ const test_files_file = os.join_path(test_root, 'files-toml-1.0.0')
 const hide_oks = os.getenv('VTEST_HIDE_OK') == '1'
 const no_jq = os.getenv('VNO_JQ') == '1'
 
-// Kept for easier handling of future updates to the tests
+// Kept for easier lookup and handling of future updates to the tests.
+// NOTE: entries in this list are valid TOML that the parser should work with, but currently does not.
 const valid_exceptions = [
 	'do_not_remove',
 	'array/open-parent-table.toml',
@@ -26,17 +27,23 @@ const valid_exceptions = [
 	'table/array-implicit-and-explicit-after.toml',
 	'table/array-within-dotted.toml',
 ]
-const jq_not_equal = [
-	'do_not_remove',
-]
+// NOTE: entries in this list are tests of invalid TOML that should have the parser fail, but currently does not.
 const invalid_exceptions = [
 	'do_not_remove',
-	'inline-table/duplicate-key-2.toml',
-	'string/multiline-escape-space-2.toml',
+	'key/duplicate-keys-06.toml',
+	'inline-table/duplicate-key-02.toml',
+	'string/multiline-escape-space-02.toml',
+	'string/missing-quotes-array.toml',
 	'table/duplicate-key-dotted-array.toml',
-	'table/redefine-2.toml',
+	'table/append-with-dotted-keys-05.toml',
+	'table/duplicate-key-03.toml',
+	'table/duplicate-key-10.toml',
+	'table/redefine-02.toml',
 ]
 const valid_value_exceptions = [
+	'do_not_remove',
+]
+const jq_not_equal = [
 	'do_not_remove',
 ]
 


### PR DESCRIPTION
This PR "fast forwards" to handle toml-lang/toml-test@229ce2e which is the latest commit as of today.

A version 2.0 of the suite was released last week so hopefully the setup should hold up for a while.

This comes at the small "expense" of having to add a few new entries to the `invalid_exceptions` list (I need more time/motivation before fixing those) where a few entries was also renamed to use `0` (zero) prefixes for numbers in the file names.

I've also included a small fix for detecting invalid parsed time, because... well... it's Christmas time and I felt joy doing it 🙂🎄🎅🏻 (fixes concrete test: `vlib/toml/tests/testdata/toml_lang/tests/invalid/datetime/second-trailing-dot.toml`)

Merry Christmas to everyone on the V team, that celebrates Christmas.