### PR TITLE
builtin: add declarations for C.memmem and C.mempcpy

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -14,7 +14,7 @@ fn C.memset(str voidptr, c int, n usize) voidptr
 
 fn C.memchr(str voidptr, c int, n usize) voidptr
 
-fn C.memmem(haystack &u8, h_len usize, needle &u8, n_len usize) &u8
+fn C.memmem(haystack voidptr, haystacklen usize, needle voidptr, needlelen usize) voidptr
 
 fn C.mempcpy(dest voidptr, src voidptr, n usize) voidptr
 


### PR DESCRIPTION
### Real-world usage
```v
fn C.memchr(buf &u8, char int, len usize) &u8
fn C.memmem(haystack &u8, h_len usize, needle &u8, n_len usize) &u8
fn C.mempcpy(dest &u8, src &u8, n usize) &u8

fn main() {
	// A raw HTTP request
	raw_request := 'POST /api/data HTTP/1.1\r\nHost: localhost\r\nContent-Length: 11\r\n\r\nhello world'

	println('--- Parsing Request ---')

	unsafe {
		// Looking for the sequence \r\n\r\n
		separator := '\r\n\r\n'
		body_ptr := C.memmem(raw_request.str, raw_request.len, separator.str, separator.len)

		if body_ptr != nil {
			body_offset := int(body_ptr - raw_request.str) + 4
			body_content := raw_request[body_offset..]
			println('Body found at offset ${body_offset}: "${body_content}"')
		}

		// methods ends at the first space
		space_ptr := C.memchr(raw_request.str, u8(` `), raw_request.len)
		if space_ptr != nil {
			method_len := int(space_ptr - raw_request.str)
			method := raw_request[..method_len]
			println('Method found: ${method}')
		}
	}
	println('\n--- Building Response with mempcpy ---')

	mut res_buf := []u8{len: 128}
	mut curr := res_buf.data

	line1 := 'HTTP/1.1 200 OK\r\n'
	line2 := 'Content-Type: text/plain\r\n'
	line3 := 'Content-Length: 2\r\n\r\n'
	body := 'OK'

	unsafe {
		// curr always moves to the end of the last write
		curr = C.mempcpy(curr, line1.str, line1.len)
		curr = C.mempcpy(curr, line2.str, line2.len)
		curr = C.mempcpy(curr, line3.str, line3.len)
		curr = C.mempcpy(curr, body.str, body.len)

		final_len := int(&u8(curr) - &res_buf[0])
		println('Constructed Response (${final_len} bytes):\n' + res_buf[..final_len].bytestr())
	}
}
```