### PR TITLE
toml: fix unicode decoding panic on invalid TOML `key/duplicate-keys-06.toml`

### DIFF
--- a/vlib/toml/decoder/decoder.v
+++ b/vlib/toml/decoder/decoder.v
@@ -156,7 +156,7 @@ pub fn decode_quoted_escapes(mut q ast.Quoted) ! {
 					mut slen := if is_valid_long { 10 } else { 6 }
 					if slen <= s.remaining() {
 						pos := s.state().pos
-						sequence := s.text[pos..pos + slen + 1]
+						sequence := s.text#[pos..pos + slen + 1]
 						decoded, unicode_val, sequence_length = decode_unicode_escape(sequence) or {
 							decoded_s += escape
 							continue

--- a/vlib/toml/tests/toml_lang_test.v
+++ b/vlib/toml/tests/toml_lang_test.v
@@ -28,7 +28,6 @@ const valid_exceptions = [
 // NOTE: entries in this list are tests of invalid TOML that should have the parser fail, but currently does not.
 const invalid_exceptions = [
 	'do_not_remove',
-	'key/duplicate-keys-06.toml',
 	'inline-table/duplicate-key-02.toml',
 	'string/multiline-escape-space-02.toml',
 	'string/missing-quotes-array.toml',


### PR DESCRIPTION
Before this PR, a `panic` like the following would occur on the specific test `invalid/key/duplicate-keys-06.toml`:
```
V panic: substr(2, 9) out of bounds (len=8) s=a\u0027b
 v hash: d058404
    pid: 0x8c41
    tid: 0x8c41
/dev/shm/tsession_7ae1a0b21740_01KDD5EKG37KTF2H4RQQ321YK9/toml_lang_test.01KDD5EKG883JGWN3AY535BVYG:9128: at builtin___v_panic: Backtrace
/dev/shm/tsession_7ae1a0b21740_01KDD5EKG37KTF2H4RQQ321YK9/toml_lang_test.01KDD5EKG883JGWN3AY535BVYG:9653: by builtin__string_substr
/dev/shm/tsession_7ae1a0b21740_01KDD5EKG37KTF2H4RQQ321YK9/toml_lang_test.01KDD5EKG883JGWN3AY535BVYG:16493: by toml__decoder__decode_quoted_escapes
/dev/shm/tsession_7ae1a0b21740_01KDD5EKG37KTF2H4RQQ321YK9/toml_lang_test.01KDD5EKG883JGWN3AY535BVYG:18659: by toml__parser__Parser_key
/dev/shm/tsession_7ae1a0b21740_01KDD5EKG37KTF2H4RQQ321YK9/toml_lang_test.01KDD5EKG883JGWN3AY535BVYG:18678: by toml__parser__Parser_key_value
/dev/shm/tsession_7ae1a0b21740_01KDD5EKG37KTF2H4RQQ321YK9/toml_lang_test.01KDD5EKG883JGWN3AY535BVYG:17244: by toml__parser__Parser_root_table
/dev/shm/tsession_7ae1a0b21740_01KDD5EKG37KTF2H4RQQ321YK9/toml_lang_test.01KDD5EKG883JGWN3AY535BVYG:16689: by toml__parser__Parser_parse
/dev/shm/tsession_7ae1a0b21740_01KDD5EKG37KTF2H4RQQ321YK9/toml_lang_test.01KDD5EKG883JGWN3AY535BVYG:19270: by toml__parse_file
/dev/shm/tsession_7ae1a0b21740_01KDD5EKG37KTF2H4RQQ321YK9/toml_lang_test.01KDD5EKG883JGWN3AY535BVYG:19808: by main__test_toml_lang_tomltest
/dev/shm/tsession_7ae1a0b21740_01KDD5EKG37KTF2H4RQQ321YK9/toml_lang_test.01KDD5EKG883JGWN3AY535BVYG:20049: by main
```