### PR TITLE
toml: allow `true` and `false` as keys when parsing root table

### DIFF
--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -486,7 +486,7 @@ pub fn (mut p Parser) root_table() ! {
 				util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'skipping formatting "${p.tok.kind}" "${p.tok.lit}"')
 				continue
 			}
-			.bare, .quoted, .number, .minus, .underscore {
+			.bare, .boolean, .quoted, .number, .minus, .underscore {
 				// Peek forward as far as we can skipping over space formatting tokens.
 				peek_tok, _ := p.peek_over(1, keys_and_space_formatting)!
 

--- a/vlib/toml/tests/toml_lang_test.v
+++ b/vlib/toml/tests/toml_lang_test.v
@@ -18,7 +18,6 @@ const no_jq = os.getenv('VNO_JQ') == '1'
 // NOTE: entries in this list are valid TOML that the parser should work with, but currently does not.
 const valid_exceptions = [
 	'do_not_remove',
-	'comment/after-literal-no-ws.toml',
 	'string/escapes.toml',
 	'string/multiline-quotes.toml',
 	'table/array-implicit-and-explicit-after.toml',


### PR DESCRIPTION
... which also happens to fix `valid/comment/after-literal-no-ws.toml` 🙂 