### PR TITLE
transformer: early return to avoid transform getting applied twice

### DIFF
--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -500,6 +500,7 @@ pub fn (mut t Transformer) for_stmt(mut node ast.ForStmt) ast.Stmt {
 					stmt = t.stmt(mut stmt)
 				}
 				t.index.unindent()
+				return node
 			}
 		}
 	}


### PR DESCRIPTION
Without the return, the tranform gets applied twice.