### PR TITLE
checker: gotodef for struct init and sumtype rhs

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -608,6 +608,17 @@ fn (mut c Checker) alias_type_decl(mut node ast.AliasTypeDecl) {
 	if c.file.mod.name != 'builtin' && !node.name.starts_with('C.') {
 		c.check_valid_pascal_case(node.name, 'type alias', node.pos)
 	}
+	if c.pref.is_vls && c.pref.linfo.method == .definition {
+		if c.vls_is_the_node(node.type_pos) {
+			typ_str := c.table.type_to_str(node.parent_type)
+			if np := c.name_pos_gotodef(typ_str) {
+				if np.file_idx != -1 {
+					println('${c.table.filelist[np.file_idx]}:${np.line_nr + 1}:${np.col}')
+					exit(0)
+				}
+			}
+		}
+	}
 	if !c.ensure_type_exists(node.parent_type, node.type_pos) {
 		return
 	}
@@ -773,6 +784,19 @@ fn (mut c Checker) fn_type_decl(mut node ast.FnTypeDecl) {
 
 fn (mut c Checker) sum_type_decl(mut node ast.SumTypeDecl) {
 	c.check_valid_pascal_case(node.name, 'sum type', node.pos)
+	if c.pref.is_vls && c.pref.linfo.method == .definition {
+		for variant in node.variants {
+			if c.vls_is_the_node(variant.pos) {
+				typ_str := c.table.type_to_str(variant.typ)
+				if np := c.name_pos_gotodef(typ_str) {
+					if np.file_idx != -1 {
+						println('${c.table.filelist[np.file_idx]}:${np.line_nr + 1}:${np.col}')
+						exit(0)
+					}
+				}
+			}
+		}
+	}
 	mut names_used := []string{}
 	for variant in node.variants {
 		c.ensure_type_exists(variant.typ, variant.pos)

--- a/vlib/v/tests/vls/goto_def_test.v
+++ b/vlib/v/tests/vls/goto_def_test.v
@@ -16,117 +16,187 @@ struct TestCase {
 }
 
 const test_cases = [
+	// test_local_struct() tests
 	TestCase{
-		name:        'method_definition'
-		line:        38
+		name:        'method_call'
+		line:        17
 		col:         13
-		expected:    '${test_file}:31:20'
+		expected:    '${test_file}:10:20'
 		description: 'Go to method definition from method call'
 	},
 	TestCase{
-		name:        'enum_value_qualified'
-		line:        41
-		col:         20
-		expected:    '${test_file}:22:1'
-		description: 'Go to enum value definition (qualified form: LocalEnum.first)'
-	},
-	TestCase{
-		name:        'enum_value_short_form'
-		line:        44
-		col:         3
-		expected:    '${test_file}:23:1'
-		description: 'Go to enum value definition (short form: .second in match)'
-	},
-	TestCase{
-		name:        'type_alias_cast'
-		line:        48
-		col:         15
-		expected:    '${test_file}:27:5'
-		description: 'Go to type alias definition in cast expression'
-	},
-	TestCase{
-		name:        'sum_type_cast'
-		line:        50
-		col:         13
-		expected:    '${test_file}:29:5'
-		description: 'Go to sum type definition in cast expression'
-	},
-	TestCase{
 		name:        'struct_init'
-		line:        53
+		line:        20
 		col:         13
 		expected:    '${test_file}:6:7'
 		description: 'Go to struct definition from StructInit'
 	},
 	TestCase{
-		name:        'variable_reference'
-		line:        56
-		col:         17
-		expected:    '${test_file}:36:5'
-		description: 'Go to variable definition from reference'
-	},
-	TestCase{
-		name:        'imported_enum_value'
-		line:        59
-		col:         25
-		expected:    '${mod1_text_file}:25:1'
-		description: 'Go to imported enum value definition'
+		name:        'struct_init_field_name'
+		line:        15
+		col:         28
+		expected:    '${test_file}:7:1'
+		description: 'Go to field definition from field name in struct initialization'
 	},
 	TestCase{
 		name:        'field_access'
-		line:        62
-		col:         16
+		line:        21
+		col:         21
 		expected:    '${test_file}:7:1'
 		description: 'Go to field definition from field access'
 	},
 	TestCase{
-		name:        'embedded_struct_field'
-		line:        69
-		col:         23
-		expected:    '${test_file}:11:1'
-		description: 'Go to embedded struct field declaration (deep.LocalStruct)'
+		name:        'variable_reference'
+		line:        23
+		col:         17
+		expected:    '${test_file}:15:6'
+		description: 'Go to variable definition from reference'
 	},
 	TestCase{
-		name:        'embedded_field_to_type'
-		line:        11
-		col:         2
-		expected:    '${test_file}:6:7'
-		description: 'Go to struct type definition from embedded field declaration'
-	},
-	TestCase{
-		name:        'nested_struct_st'
-		line:        66
-		col:         22
-		expected:    '${test_file}:12:1'
-		description: 'Go to nested anonymous struct field definition (deep.st)'
-	},
-	TestCase{
-		name:        'nested_struct_sstt'
-		line:        66
-		col:         25
-		expected:    '${test_file}:13:2'
-		description: 'Go to deeply nested anonymous struct field definition (deep.st.sstt)'
-	},
-	TestCase{
-		name:        'nested_struct_l2'
-		line:        66
-		col:         29
-		expected:    '${test_file}:14:3'
-		description: 'Go to deeply nested struct field definition (deep.st.sstt.l2)'
+		name:        'field_access_via_variable'
+		line:        26
+		col:         17
+		expected:    '${test_file}:7:1'
+		description: 'Go to field definition from obj.value'
 	},
 	TestCase{
 		name:        'method_receiver_type'
-		line:        31
+		line:        10
 		col:         8
 		expected:    '${test_file}:6:7'
 		description: 'Go to struct definition from method receiver type (LocalStruct)'
 	},
 	TestCase{
 		name:        'method_return_type_builtin'
-		line:        31
+		line:        10
 		col:         33
 		expected:    os.join_path(vroot, 'vlib', 'builtin', 'string.v') + ':45:11'
 		description: 'Builtin return type (string) jumps to builtin string definition'
+	},
+	// test_deep_struct() tests
+	TestCase{
+		name:        'nested_struct_st'
+		line:        49
+		col:         22
+		expected:    '${test_file}:38:1'
+		description: 'Go to nested anonymous struct field definition (deep.st)'
+	},
+	TestCase{
+		name:        'nested_struct_sstt'
+		line:        49
+		col:         25
+		expected:    '${test_file}:39:2'
+		description: 'Go to deeply nested anonymous struct field definition (deep.st.sstt)'
+	},
+	TestCase{
+		name:        'nested_struct_l2'
+		line:        49
+		col:         30
+		expected:    '${test_file}:40:3'
+		description: 'Go to deeply nested struct field definition (deep.st.sstt.l2)'
+	},
+	TestCase{
+		name:        'embedded_struct_field'
+		line:        52
+		col:         23
+		expected:    '${test_file}:37:1'
+		description: 'Go to embedded struct field declaration (deep.LocalStruct)'
+	},
+	TestCase{
+		name:        'embedded_field_to_type'
+		line:        37
+		col:         2
+		expected:    '${test_file}:6:7'
+		description: 'Go to struct type definition from embedded field declaration'
+	},
+	TestCase{
+		name:        'deep_2_nested_sstt_in_init'
+		line:        58
+		col:         21
+		expected:    '${test_file}:39:2'
+		description: 'Go to field definition from deep.st.sstt in struct init'
+	},
+	TestCase{
+		name:        'deep_2_nested_l1_in_init'
+		line:        60
+		col:         16
+		expected:    '${test_file}:42:2'
+		description: 'Go to field definition from deep.st.l1 in struct init'
+	},
+	// test_local_enum() tests
+	TestCase{
+		name:        'enum_value_qualified'
+		line:        72
+		col:         18
+		expected:    '${test_file}:66:1'
+		description: 'Go to enum value definition (qualified form: LocalEnum.first)'
+	},
+	TestCase{
+		name:        'enum_value_short_form'
+		line:        75
+		col:         3
+		expected:    '${test_file}:67:1'
+		description: 'Go to enum value definition (short form: .second in match)'
+	},
+	// test_local_alias() tests
+	TestCase{
+		name:        'type_alias_cast'
+		line:        83
+		col:         13
+		expected:    '${test_file}:80:5'
+		description: 'Go to type alias definition in cast expression'
+	},
+	TestCase{
+		name:        'type_alias_rhs_type'
+		line:        80
+		col:         19
+		expected:    os.join_path(vroot, 'vlib', 'builtin', 'string.v') + ':45:11'
+		description: 'Go to builtin type definition from type alias RHS'
+	},
+	// test_local_sum() tests
+	TestCase{
+		name:        'sum_type_cast'
+		line:        99
+		col:         13
+		expected:    '${test_file}:86:5'
+		description: 'Go to sum type definition in cast expression'
+	},
+	TestCase{
+		name:        'user_sum_type_rhs_type_a'
+		line:        96
+		col:         18
+		expected:    '${test_file}:88:7'
+		description: 'Go to TypeA definition from UserSum type RHS'
+	},
+	TestCase{
+		name:        'user_sum_type_rhs_type_b'
+		line:        96
+		col:         26
+		expected:    '${test_file}:92:7'
+		description: 'Go to TypeB definition from UserSum type RHS'
+	},
+	// test_match_enum() tests
+	TestCase{
+		name:        'match_enum_short_form'
+		line:        115
+		col:         3
+		expected:    '${test_file}:107:1'
+		description: 'Go to enum value definition in match expression (short form .completion)'
+	},
+	TestCase{
+		name:        'match_enum_variable'
+		line:        114
+		col:         22
+		expected:    '${test_file}:113:1'
+		description: 'Go to variable definition from match expression condition'
+	},
+	// test_imported_enum() tests
+	TestCase{
+		name:        'imported_enum_value'
+		line:        129
+		col:         25
+		expected:    '${mod1_text_file}:25:1'
+		description: 'Go to imported enum value definition'
 	},
 ]
 

--- a/vlib/v/tests/vls/goto_def_test_data.vv
+++ b/vlib/v/tests/vls/goto_def_test_data.vv
@@ -7,6 +7,32 @@ struct LocalStruct {
 	value int
 }
 
+fn (ls LocalStruct) my_method() string {
+	return 'method'
+}
+
+fn test_local_struct() {
+ 	mut obj := LocalStruct{value: 42}
+
+	msg := obj.my_method()
+	println(msg)
+
+	another := LocalStruct{}
+	println(another.value)
+
+	yet_another := obj
+	println(yet_another)
+
+	val := obj.value
+	println(val)
+
+	result := obj.my_method()
+	println(result)
+
+	ret_type := obj.my_method()
+	println(ret_type)
+}
+
 struct DeepStruct {
 	LocalStruct
 	st struct {
@@ -18,60 +44,88 @@ struct DeepStruct {
 	l0 int
 }
 
-enum LocalEnum {
-	first
-	second
-	third
-}
-
-type LocalAlias = string
-
-type LocalSum = int | string
-
-fn (ls LocalStruct) my_method() string {
-	return 'method'
-}
-
-fn main() {
-	mut obj := LocalStruct{value: 42}
-
-	msg := obj.my_method()
-	println(msg)
-
-	e1 := LocalEnum.first
-
-	match e1 {
-		.second { println('second') }
-		else {}
-	}
-
-	casted := LocalAlias('test')
-
-	sum_val := LocalSum(42)
-	println(sum_val)
-
-	another := LocalStruct{}
-	println(another.value)
-
-	yet_another := obj
-	println(yet_another)
-
-	imported_e := s.PublicEnum1.a
-	println(imported_e)
-
-	val := obj.value
-	println(val)
-
-	deep := DeepStruct{}
+fn test_deep_struct() {
+  deep := DeepStruct{}
 	nested_val := deep.st.sstt.l2
 	println(nested_val)
 
 	embedded_val := deep.LocalStruct
 	println(embedded_val)
 
-	result := obj.my_method()
-	println(result)
+	deep_2 := DeepStruct {
+	  st: struct {
+			sstt: struct {
+			  l2: deep.st.sstt.l2
+			}
+			l1: deep.st.l1
+		}
+	}
+}
 
-	ret_type := obj.my_method()
-	println(ret_type)
+enum LocalEnum {
+	first
+	second
+	third
+}
+
+fn test_local_enum() {
+  e1 := LocalEnum.first
+
+	match e1 {
+		.second { println('second') }
+		else {}
+	}
+}
+
+type LocalAlias = string
+
+fn test_local_alias() {
+  casted := LocalAlias('test')
+}
+
+type LocalSum = int | string
+
+struct TypeA {
+	a int
+}
+
+struct TypeB {
+	b string
+}
+
+type UserSum = TypeA | TypeB
+
+fn test_local_sum() {
+	sum_val := LocalSum(42)
+	println(sum_val)
+
+	user_sum := UserSum(TypeA{a: 10})
+	println(user_sum)
+}
+
+enum Method {
+	completion
+	signature_help
+	definition
+}
+
+fn test_match_enum() {
+	method := Method.completion
+	line_info := match method {
+		.completion {
+			'completion_info'
+		}
+		.signature_help {
+			'signature_info'
+		}
+		.definition {
+			'definition_info'
+		}
+	}
+	println(line_info)
+}
+
+fn test_imported_enum() {
+	imported_e := s.PublicEnum1.a
+	println(imported_e)
 }


### PR DESCRIPTION
I split up the test file into functions so hopefully less positions need to be updated on each gotodef init. There are probably a few more cases I am missing (haven't tested `interface` or channels for example). The things I use most should at least have a gotodef implementation.