### PR TITLE
checker: Detection of circular type references

### DIFF
--- a/vlib/v/checker/tests/sumtype_circular_reference_err.out
+++ b/vlib/v/checker/tests/sumtype_circular_reference_err.out
@@ -1,0 +1,11 @@
+vlib/v/checker/tests/sumtype_circular_reference_err.vv:1:14: error: sum type `Type6` cannot be defined recursively
+    1 | type Type6 = Type7 | int
+      |              ~~~~~
+    2 | type Type7 = Type6 | string
+    3 |
+vlib/v/checker/tests/sumtype_circular_reference_err.vv:2:14: error: sum type `Type7` cannot be defined recursively
+    1 | type Type6 = Type7 | int
+    2 | type Type7 = Type6 | string
+      |              ~~~~~
+    3 | 
+    4 | struct Foo {

--- a/vlib/v/checker/tests/sumtype_circular_reference_err.vv
+++ b/vlib/v/checker/tests/sumtype_circular_reference_err.vv
@@ -1,0 +1,6 @@
+type Type6 = Type7 | int
+type Type7 = Type6 | string
+
+struct Foo {
+	name Type7
+}


### PR DESCRIPTION
**Issue:** V incorrectly permitted circular type references in sum types like:
  type Type6 = Type7 | int
  type Type7 = Type6 | string

**Root Cause:** The checker only detected direct self-references (type A = A | int) but not indirect cycles through other sum types.

**Fix:**

1. vlib/v/checker/checker.v

  Added cycle detection for sum types:
  - Added an else if branch to check when a variant is itself a sum type
  - Added a new helper function sumtype_has_circular_ref() that recursively traverses sum type variants to detect cycles
  - Uses a visited map to prevent infinite recursion during cycle detection

2. New test files:

  - vlib/v/checker/tests/sumtype_circular_reference_err.vv - Test case with circular reference
  - vlib/v/checker/tests/sumtype_circular_reference_err.out - Expected error output

**Verification:**

  The fix correctly detects:
  - 2-type cycles: Type6 → Type7 → Type6
  - 3-type cycles: TypeA → TypeB → TypeC → TypeA
  - Deeper indirect cycles

  Non-circular sum types that reference other sum types still work correctly.

Fixes #24511