### PR TITLE
checker: add interface type handling and new testcase

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -323,6 +323,11 @@ fn (mut c Checker) check_array_init_default_expr(mut node ast.ArrayInit) {
 	if node.elem_type.is_number() && init_typ.is_number() {
 		return
 	}
+	if c.table.type_kind(node.elem_type) == .interface {
+		if c.type_implements(init_typ, node.elem_type, init_expr.pos()) {
+			return
+		}
+	}
 	c.check_expected(init_typ, node.elem_type) or { c.error(err.msg(), init_expr.pos()) }
 }
 

--- a/vlib/v/checker/tests/array_init_with_interface_test.v
+++ b/vlib/v/checker/tests/array_init_with_interface_test.v
@@ -1,0 +1,16 @@
+interface IValue {}
+
+struct Null {}
+
+struct MyInt {
+	val int
+}
+
+fn test_array_init_with_interface_implicit_cast() {
+	// Test that array init with interface element type allows implicit cast
+	a := []IValue{len: 3, init: Null{}}
+	assert a.len == 3
+
+	b := []IValue{len: 2, init: MyInt{42}}
+	assert b.len == 2
+}


### PR DESCRIPTION
This fix in checker adds interface type handling and makes this code work without any errors.
``` v
module main

struct Null {}

interface Values {}

fn main() {
	mut a := []Values{len: 10, init: Null{}}
	for i := 0; i < a.len; i++ {
		a[i] = 69
	}
}
```
Testcase is included. Fixes #24116