### PR TITLE
cgen: fix option array init with non option values

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -175,7 +175,11 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 				} else {
 					node.elem_type
 				}
-				g.expr_with_cast(expr, expr_type, node.elem_type)
+				if node.elem_type.has_flag(.option) {
+					g.expr_with_opt(expr, expr_type, node.elem_type)
+				} else {
+					g.expr_with_cast(expr, expr_type, node.elem_type)
+				}
 			}
 			g.add_commas_and_prevent_long_lines(i, nelen)
 		}

--- a/vlib/v/tests/options/option_array_init_mix_test.v
+++ b/vlib/v/tests/options/option_array_init_mix_test.v
@@ -1,0 +1,9 @@
+fn test_main() {
+	a := [?string('a'), 'b']!
+	println(a)
+	assert '${a}' == "[Option('a'), Option('b')]"
+
+	b := [?int(1), 7]!
+	println(b)
+	assert '${b}' == '[Option(1), Option(7)]'
+}


### PR DESCRIPTION
Fix #26148