### PR TITLE
x.json2: fix memory access error when decoding string enum values

### DIFF
--- a/vlib/x/json2/decode.v
+++ b/vlib/x/json2/decode.v
@@ -839,7 +839,7 @@ fn (mut decoder Decoder) decode_enum[T](mut val T) ! {
 		decoder.decode_error('Number value: `${result}` does not match any field in enum: ${typeof(val).name}')!
 	} else if enum_info.value_kind == .string {
 		mut result := ''
-		unsafe { decoder.decode_value(mut result)! }
+		decoder.decode_string(mut result)!
 
 		$for value in T.values {
 			if value.name == result {

--- a/vlib/x/json2/tests/decode_enum_test.v
+++ b/vlib/x/json2/tests/decode_enum_test.v
@@ -93,3 +93,15 @@ fn test_invalid_decode_fails() {
 		}
 	}
 }
+
+fn test_map_string_enum_decode() {
+	m := json.decode[map[string]Bar]('{"foo": "a", "bar": "b", "baz": "c"}')!
+	assert m['foo'] == .a
+	assert m['bar'] == .b
+	assert m['baz'] == .c
+
+	m2 := json.decode[map[string]Bar]('{"x": 0, "y": 1, "z": 10}')!
+	assert m2['x'] == .a
+	assert m2['y'] == .b
+	assert m2['z'] == .c
+}


### PR DESCRIPTION
`json.decode[map[string]Enum]()` caused a memory access error.

Fixes #26176 and #26179