### PR TITLE
net.ftp: fix get() command conversation, add test

### DIFF
--- a/vlib/net/ftp/ftp.v
+++ b/vlib/net/ftp/ftp.v
@@ -249,6 +249,10 @@ pub fn (mut zftp FTP) get(file string) ![]u8 {
 		return error('Data connection not ready')
 	}
 	blob := dtp.read()!
+	result, _ := zftp.read()!
+	if result != complete {
+		return error('`RETR` not ok')
+	}
 	dtp.close()
 	return blob
 }

--- a/vlib/net/ftp/ftp_test.v
+++ b/vlib/net/ftp/ftp_test.v
@@ -49,3 +49,26 @@ fn ftp_client_test_inside() ! {
 	}
 	assert blob.len > 0
 }
+
+fn test_ftp_get() ! {
+	$if !network ? {
+		return
+	}
+
+	mut zftp := ftp.new()
+	defer {
+		zftp.close() or { panic(err) }
+	}
+	connect_result := zftp.connect('ftp.sunet.se:21')!
+	assert connect_result
+	login_result := zftp.login('ftp', 'ftp')!
+	assert login_result
+	pwd := zftp.pwd()!
+	assert pwd.len > 0
+	mut txt := zftp.get('robots.txt')!
+	assert txt[0] == 35 // first byte is # char
+	zftp.pwd()!
+	zftp.cd('pub')!
+	zftp.cd('..')!
+	zftp.get('robots.txt')!
+}


### PR DESCRIPTION
Fixes the #18858 

Currently, after receiving bytes, the `FTP` module immediately closes the connection and does not read the `final operation status`. This is easy to fix.

Important note:
I formally added a test, but it still doesn't execute because it's logically disabled due to the fact that it connects to external resources over the network.

If enable and run test it failed on `master`.