### PR TITLE
ast: optmize ast.call_kind() impl

### DIFF
--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -166,6 +166,9 @@ fn (mut p Parser) call_kind(fn_name string) ast.CallKind {
 				'sort' {
 					.sort
 				}
+				'trim' {
+					.trim
+				}
 				'last' {
 					.last
 				}
@@ -187,6 +190,12 @@ fn (mut p Parser) call_kind(fn_name string) ast.CallKind {
 			return match fn_name {
 				'count' {
 					.count
+				}
+				'print' {
+					.print
+				}
+				'close' {
+					.close
 				}
 				'slice' {
 					.slice
@@ -219,6 +228,9 @@ fn (mut p Parser) call_kind(fn_name string) ast.CallKind {
 				'values' {
 					.values
 				}
+				'eprint' {
+					.eprint
+				}
 				'sorted' {
 					.sorted
 				}
@@ -237,6 +249,9 @@ fn (mut p Parser) call_kind(fn_name string) ast.CallKind {
 				'__addr' {
 					.addr
 				}
+				'malloc' {
+					.malloc
+				}
 				else {
 					.unknown
 				}
@@ -246,6 +261,12 @@ fn (mut p Parser) call_kind(fn_name string) ast.CallKind {
 			return match fn_name {
 				'prepend' {
 					.prepend
+				}
+				'writeln' {
+					.writeln
+				}
+				'println' {
+					.println
 				}
 				'try_pop' {
 					.try_pop
@@ -265,6 +286,12 @@ fn (mut p Parser) call_kind(fn_name string) ast.CallKind {
 			return match fn_name {
 				'try_push' {
 					.try_push
+				}
+				'eprintln' {
+					.eprintln
+				}
+				'pointers' {
+					.pointers
 				}
 				'contains' {
 					.contains
@@ -300,6 +327,9 @@ fn (mut p Parser) call_kind(fn_name string) ast.CallKind {
 				'main.main' {
 					.main_main
 				}
+				'push_many' {
+					.push_many
+				}
 				else {
 					.unknown
 				}
@@ -334,6 +364,12 @@ fn (mut p Parser) call_kind(fn_name string) ast.CallKind {
 				}
 				'reverse_in_place' {
 					.reverse_in_place
+				}
+				'json.encode_pretty' {
+					.json_encode_pretty
+				}
+				'clone_to_depth' {
+					.clone_to_depth
 				}
 				else {
 					.unknown


### PR DESCRIPTION
```
==================================================================================================
Current git branch: opt_map_get, commit: e63fbf9
    Compiling new V executables from PR branch: opt_map_get, commit: e63fbf9 ...
CPU: 2.60s      Real: 2.70s     Elapsed: 0:02.70        RAM: 459248KB   ./v -o vnew1 cmd/v
CPU: 2.78s      Real: 2.72s     Elapsed: 0:02.72        RAM: 458864KB   ./vnew1 -o vnew2 cmd/v
CPU: 2.45s      Real: 3.30s     Elapsed: 0:03.30        RAM: 439600KB   ./vnew2 -no-parallel -o vnew cmd/v
CPU: 0.17s      Real: 0.21s     Elapsed: 0:00.21        RAM: 47132KB    ./vnew -no-parallel -o nhw_current.c examples/hello_world.v
CPU: 0.16s      Real: 0.20s     Elapsed: 0:00.20        RAM: 47664KB    ./vnew -no-parallel -o nhw_current_gcc.c -cc gcc examples/hello_world.v
CPU: 2.11s      Real: 2.64s     Elapsed: 0:02.64        RAM: 439788KB   ./vnew -no-parallel -o nv_current.c cmd/v
>Size of        nhw_current.c:      28170
>Size of    nhw_current_gcc.c:      41256
>Size of         nv_current.c:    6931095
>Size of                 vnew:   10475356
Switched to branch 'v_repo_master'
Your branch is up to date with 'V_REPO/master'.
==================================================================================================
    Compiling old V executables from branch: v_repo_master, commit: 12f04b5 ...
CPU: 3.26s      Real: 3.45s     Elapsed: 0:03.45        RAM: 458876KB   ./v -o vold1 cmd/v
CPU: 2.89s      Real: 2.89s     Elapsed: 0:02.89        RAM: 458672KB   ./vold1 -o vold2 cmd/v
CPU: 2.66s      Real: 3.47s     Elapsed: 0:03.47        RAM: 439652KB   ./vold2 -no-parallel -o vold cmd/v
CPU: 0.15s      Real: 0.21s     Elapsed: 0:00.21        RAM: 47248KB    ./vold -no-parallel -o ohw_master.c examples/hello_world.v
CPU: 0.16s      Real: 0.20s     Elapsed: 0:00.20        RAM: 47648KB    ./vold -no-parallel -o ohw_master_gcc.c -cc gcc examples/hello_world.v
CPU: 2.22s      Real: 2.84s     Elapsed: 0:02.84        RAM: 439652KB   ./vold -no-parallel -o ov_master.c cmd/v
>Size of         ohw_master.c:      28170
>Size of     ohw_master_gcc.c:      41256
>Size of          ov_master.c:    6930360
>Size of                 vold:   10474652
==================================================================================================
File sizes so far ...
>>>>>> size("    nhw_current.c") - size("     ohw_master.c") =      28170 -      28170 =          0
>>>>>> size("nhw_current_gcc.c") - size(" ohw_master_gcc.c") =      41256 -      41256 =          0
>>>>>> size("     nv_current.c") - size("      ov_master.c") =    6931095 -    6930360 =        735
>>>>>> size("             vnew") - size("             vold") =   10475356 -   10474652 =        704
Switched to branch 'opt_map_get'
==================================================================================================
    Measuring at PR branch: opt_map_get, commit: e63fbf9 ...
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 1/3, took: 3750.425 ms                                                                                                    
    1    -22.0%   1.28x faster  121.4ms ± σ:    1.2ms,  120.2ms… 123.1ms `./vnew -check-syntax           examples/hello_world.v`
 >  2           base            155.7ms ± σ:    1.2ms,  154.4ms… 157.3ms `./vold -check-syntax           examples/hello_world.v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 2/3, took: 3235.592 ms                                                                                                    
    1    -10.5%   1.12x faster  118.8ms ± σ:    1.5ms,  116.7ms… 120.2ms `./vnew -check-syntax           examples/hello_world.v`
 >  2           base            132.8ms ± σ:    3.2ms,  129.4ms… 137.0ms `./vold -check-syntax           examples/hello_world.v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 3/3, took: 3179.924 ms                                                                                                    
 >  1           base            118.9ms ± σ:    2.3ms,  115.8ms… 121.4ms `./vold -check-syntax           examples/hello_world.v`
    2     +2.4%   1.02x slower  121.7ms ± σ:    1.5ms,  119.8ms… 123.6ms `./vnew -check-syntax           examples/hello_world.v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 1/3, took: 4608.903 ms                                                                                                    
    1     -4.9%   1.05x faster  171.9ms ± σ:    0.8ms,  170.9ms… 172.9ms `./vnew -check                  examples/hello_world.v`
 >  2           base            180.8ms ± σ:    0.7ms,  179.9ms… 181.7ms `./vold -check                  examples/hello_world.v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 2/3, took: 4256.721 ms                                                                                                    
    1     -2.1%   1.02x faster  168.4ms ± σ:    1.4ms,  166.4ms… 169.8ms `./vnew -check                  examples/hello_world.v`
 >  2           base            171.9ms ± σ:    3.9ms,  166.5ms… 175.3ms `./vold -check                  examples/hello_world.v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 3/3, took: 4168.355 ms                                                                                                    
 >  1           base            166.3ms ± σ:    2.0ms,  163.6ms… 167.9ms `./vold -check                  examples/hello_world.v`
    2     +2.5%   1.02x slower  170.4ms ± σ:    2.1ms,  167.5ms… 172.4ms `./vnew -check                  examples/hello_world.v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 1/3, took: 5132.606 ms                                                                                                    
 >  1           base            205.0ms ± σ:    3.2ms,  201.9ms… 209.4ms `./vold -no-parallel -o ohw.c   examples/hello_world.v`
    2     +2.3%   1.02x slower  209.8ms ± σ:    1.5ms,  208.6ms… 211.9ms `./vnew -no-parallel -o nhw.c   examples/hello_world.v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 2/3, took: 5345.255 ms                                                                                                    
    1     -0.8%   1.01x faster  206.3ms ± σ:    2.6ms,  202.6ms… 208.5ms `./vnew -no-parallel -o nhw.c   examples/hello_world.v`
 >  2           base            208.0ms ± σ:    2.3ms,  205.6ms… 211.2ms `./vold -no-parallel -o ohw.c   examples/hello_world.v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 3/3, took: 5250.553 ms                                                                                                    
 >  1           base            206.7ms ± σ:    2.3ms,  203.9ms… 209.5ms `./vold -no-parallel -o ohw.c   examples/hello_world.v`
    2     +1.3%   1.01x slower  209.3ms ± σ:    2.4ms,  205.9ms… 211.5ms `./vnew -no-parallel -o nhw.c   examples/hello_world.v`
>>>>>> size("            nhw.c") - size("            ohw.c") =      28170 -      28170 =          0
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 1/3, took: 5621.663 ms                                                                                                    
    1     -0.9%   1.01x faster  221.0ms ± σ:    3.7ms,  215.8ms… 224.5ms `./vnew -no-parallel -o nhw.exe examples/hello_world.v`
 >  2           base            223.1ms ± σ:    3.5ms,  218.1ms… 225.7ms `./vold -no-parallel -o ohw.exe examples/hello_world.v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 2/3, took: 5476.432 ms                                                                                                    
    1     -5.1%   1.05x faster  206.8ms ± σ:    0.4ms,  206.3ms… 207.3ms `./vnew -no-parallel -o nhw.exe examples/hello_world.v`
 >  2           base            217.9ms ± σ:    3.3ms,  215.3ms… 222.6ms `./vold -no-parallel -o ohw.exe examples/hello_world.v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 3/3, took: 5156.658 ms                                                                                                    
 >  1           base            205.8ms ± σ:    5.2ms,  200.0ms… 212.7ms `./vold -no-parallel -o ohw.exe examples/hello_world.v`
    2     +1.4%   1.01x slower  208.6ms ± σ:    0.2ms,  208.4ms… 208.8ms `./vnew -no-parallel -o nhw.exe examples/hello_world.v`
>>>>>> size("          nhw.exe") - size("          ohw.exe") =     241848 -     241848 =          0
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 1/3, took: 21939.342 ms                                                                                                   
 >  1           base            871.0ms ± σ:   14.7ms,  856.1ms… 891.0ms `./vold -check-syntax           cmd/v`
    2     +0.7%   1.01x slower  877.1ms ± σ:   11.0ms,  861.6ms… 885.8ms `./vnew -check-syntax           cmd/v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 2/3, took: 21538.383 ms                                                                                                   
    1     -0.2%   1.00x faster  864.2ms ± σ:    4.5ms,  858.1ms… 868.7ms `./vnew -check-syntax           cmd/v`
 >  2           base            866.3ms ± σ:   13.2ms,  847.8ms… 878.1ms `./vold -check-syntax           cmd/v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 3/3, took: 21813.657 ms                                                                                                   
    1     -0.5%   1.01x faster  861.6ms ± σ:    2.8ms,  857.8ms… 864.1ms `./vnew -check-syntax           cmd/v`
 >  2           base            866.3ms ± σ:    3.1ms,  864.0ms… 870.7ms `./vold -check-syntax           cmd/v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 1/3, took: 38593.923 ms                                                                                                   
    1     -1.7%   1.02x faster 1516.0ms ± σ:    1.5ms, 1513.9ms…1517.5ms `./vnew -check                  cmd/v`
 >  2           base           1541.5ms ± σ:   35.2ms, 1491.9ms…1570.1ms `./vold -check                  cmd/v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 2/3, took: 37876.556 ms                                                                                                   
 >  1           base           1505.4ms ± σ:   37.3ms, 1477.1ms…1558.1ms `./vold -check                  cmd/v`
    2     +0.4%   1.00x slower 1512.1ms ± σ:   27.6ms, 1475.1ms…1541.2ms `./vnew -check                  cmd/v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 3/3, took: 38096.283 ms                                                                                                   
    1     -0.3%   1.00x faster 1525.3ms ± σ:   27.9ms, 1502.2ms…1564.6ms `./vnew -check                  cmd/v`
 >  2           base           1530.0ms ± σ:    8.6ms, 1523.2ms…1542.1ms `./vold -check                  cmd/v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 1/3, took: 75102.528 ms                                                                                                   
    1     -1.3%   1.01x faster 2815.4ms ± σ:   54.5ms, 2776.3ms…2892.5ms `./vnew -no-parallel -o nv.c    cmd/v`
 >  2           base           2851.8ms ± σ:   15.7ms, 2833.0ms…2871.4ms `./vold -no-parallel -o ov.c    cmd/v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 2/3, took: 76416.532 ms                                                                                                   
 >  1           base           2961.4ms ± σ:   17.1ms, 2942.0ms…2983.5ms `./vold -no-parallel -o ov.c    cmd/v`
    2     +0.3%   1.00x slower 2968.9ms ± σ:   65.8ms, 2903.7ms…3059.1ms `./vnew -no-parallel -o nv.c    cmd/v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 3/3, took: 71476.851 ms                                                                                                   
    1     -2.8%   1.03x faster 2743.9ms ± σ:   46.6ms, 2703.2ms…2809.1ms `./vnew -no-parallel -o nv.c    cmd/v`
 >  2           base           2821.6ms ± σ:   49.2ms, 2753.2ms…2866.4ms `./vold -no-parallel -o ov.c    cmd/v`
>>>>>> size("             nv.c") - size("             ov.c") =    6931095 -    6931095 =          0
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 1/3, took: 80030.447 ms                                                                                                   
    1     -2.3%   1.02x faster 3176.8ms ± σ:   20.5ms, 3147.9ms…3191.9ms `./vnew -no-parallel -o nv.exe  cmd/v`
 >  2           base           3251.7ms ± σ:   41.1ms, 3194.5ms…3289.0ms `./vold -no-parallel -o ov.exe  cmd/v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 2/3, took: 80565.214 ms                                                                                                   
    1     -1.6%   1.02x faster 3147.6ms ± σ:   37.2ms, 3095.7ms…3180.9ms `./vnew -no-parallel -o nv.exe  cmd/v`
 >  2           base           3198.6ms ± σ:   53.5ms, 3151.3ms…3273.4ms `./vold -no-parallel -o ov.exe  cmd/v`
Summary after 1 series x 10 runs (%s are relative to first command, or `base`), discard maxs:  7, repeat: 3/3, took: 81339.138 ms                                                                                                   
 >  1           base           3148.6ms ± σ:   39.0ms, 3115.3ms…3203.3ms `./vold -no-parallel -o ov.exe  cmd/v`
    2     +3.4%   1.03x slower 3255.6ms ± σ:   16.3ms, 3236.7ms…3276.5ms `./vnew -no-parallel -o nv.exe  cmd/v`
>>>>>> size("           nv.exe") - size("           ov.exe") =   10475358 -   10475358 =          0
Done. Total time: 675.116216967 s.
==================================================================================================
Final summary for file diff sizes on their own branches:
>>>>>> size("    nhw_current.c") - size("     ohw_master.c") =      28170 -      28170 =          0
>>>>>> size("nhw_current_gcc.c") - size(" ohw_master_gcc.c") =      41256 -      41256 =          0
>>>>>> size("     nv_current.c") - size("      ov_master.c") =    6931095 -    6930360 =        735
>>>>>> size("             vnew") - size("             vold") =   10475356 -   10474652 =        704
==================================================================================================
Final summary for file diff sizes for generated files on the *current* branch:
>>>>>> size("            nhw.c") - size("            ohw.c") =      28170 -      28170 =          0
>>>>>> size("             nv.c") - size("             ov.c") =    6931095 -    6931095 =          0
>>>>>> size("          nhw.exe") - size("          ohw.exe") =     241848 -     241848 =          0
>>>>>> size("           nv.exe") - size("           ov.exe") =   10475358 -   10475358 =          0
```