### PR TITLE
tuto/C2V/README.md: Remove newline in compile example

### DIFF
--- a/tutorials/C2V_translating_simple_programs_and_DOOM/README.md
+++ b/tutorials/C2V_translating_simple_programs_and_DOOM/README.md
@@ -243,7 +243,6 @@ v -o doom_v/doom.o -w -translated doom_v
 
 cc -o doomv \
   $DOOM/src/doom/doom_v/doom.o \
-
   $DOOM/src/CMakeFiles/chocolate-doom.dir/*.o \
   $DOOM/textscreen/CMakeFiles/textscreen.dir/*.o \
   $DOOM/pcsound/CMakeFiles/pcsound.dir/*.o \


### PR DESCRIPTION
Removes newline in example compiling to doomv.
The tutorial example for C2V splits arguments to the cc command over multiple lines, including an empty line. This commit removes the newline from the example command, such that the example will use all provided arguments over the next lines.