### PR TITLE
checker: clear all ref from autostr receiver_type

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -446,6 +446,12 @@ pub fn (t Type) clear_flags(flags ...TypeFlag) Type {
 	}
 }
 
+// clear_ref clear refs of type
+@[inline]
+pub fn (t Type) clear_ref() Type {
+	return t & ~0x00FF_0000
+}
+
 // clear option and result flags
 @[inline]
 pub fn (t Type) clear_option_and_result() Type {

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2305,7 +2305,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr, mut continue_check &bool) 
 				c.error('interface `${iname}` does not have a .str() method. Use typeof() instead',
 					node.pos)
 			}
-			node.receiver_type = left_type
+			node.receiver_type = left_type.clear_ref()
 			node.return_type = ast.string_type
 			if node.args.len > 0 {
 				c.error('.str() method calls should have no arguments', node.pos)


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

This is a feature needed by PR #25857, which can make sure always generate auto str function like this:
```v
pub fn (it main.Example) str() string 
```
instead of something like this :
```v
pub fn (it &main.Example) str() string 
pub fn (it &&main.Example) str() string 
```

This should has no impact on current auto str mechanism.
