### PR TITLE
docs: typo fix

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6277,6 +6277,7 @@ that are substituted at compile time:
 - `@CCOMPILER` => replaced with the C compiler type, for example 'gcc' .
 - `@BACKEND` => replaced with current language backend, for example 'c' or 'golang' .
 - `@PLATFORM` => replaced with the platform type, for example 'amd64' .
+
 Note: `@BUILD_DATE`, `@BUILD_TIME`, `@BUILD_TIMESTAMP` represent times in the UTC timezone.
 By default, they are based on the current time of the compilation/build. They can be overridden
 by setting the environment variable `SOURCE_DATE_EPOCH`. That is also useful while making


### PR DESCRIPTION
The tiniest typo fix :))

Insufficient linebreaks left a note paragraph hiding on the end of a bullet list item about a specific variable that they weren't actually relevant to.
