### PR TITLE
x.json2: remove workaround_cast(), add isize usize decode support

### DIFF
--- a/vlib/x/json2/decode.v
+++ b/vlib/x/json2/decode.v
@@ -876,7 +876,10 @@ fn (mut decoder Decoder) decode_number[T](val &T) ! {
 		u32 { *val = strconv.atou32(str)! }
 		u64 { *val = strconv.atou64(str)! }
 		int { *val = strconv.atoi(str)! }
-		$float { *val = T(strconv.atof_quick(str)) }
+		isize { *val = isize(strconv.atoi64(str)!) }
+		usize { *val = usize(strconv.atou64(str)!) }
+		f32 { *val = f32(strconv.atof_quick(str)) }
+		f64 { *val = strconv.atof_quick(str) }
 		$else { return error('`decode_number` can not decode ${T.name} type') }
 	}
 }

--- a/vlib/x/json2/encode.v
+++ b/vlib/x/json2/encode.v
@@ -22,11 +22,6 @@ mut:
 	output []u8 = []u8{cap: 2048}
 }
 
-@[inline]
-fn workaround_cast[T](val voidptr) T {
-	return *(&T(val))
-}
-
 // encode is a generic function that encodes a type into a JSON string.
 pub fn encode[T](val T, config EncoderOptions) string {
 	mut encoder := Encoder{
@@ -40,33 +35,33 @@ pub fn encode[T](val T, config EncoderOptions) string {
 
 fn (mut encoder Encoder) encode_value[T](val T) {
 	$if T.unaliased_typ is string {
-		encoder.encode_string(workaround_cast[string](&val))
+		encoder.encode_string(string(val))
 	} $else $if T.unaliased_typ is bool {
-		encoder.encode_boolean(workaround_cast[bool](&val))
+		encoder.encode_boolean(bool(val))
 	} $else $if T.unaliased_typ is u8 {
-		encoder.encode_number(workaround_cast[u8](&val))
+		encoder.encode_number(u8(val))
 	} $else $if T.unaliased_typ is u16 {
-		encoder.encode_number(workaround_cast[u16](&val))
+		encoder.encode_number(u16(val))
 	} $else $if T.unaliased_typ is u32 {
-		encoder.encode_number(workaround_cast[u32](&val))
+		encoder.encode_number(u32(val))
 	} $else $if T.unaliased_typ is u64 {
-		encoder.encode_number(workaround_cast[u64](&val))
+		encoder.encode_number(u64(val))
 	} $else $if T.unaliased_typ is i8 {
-		encoder.encode_number(workaround_cast[i8](&val))
+		encoder.encode_number(i8(val))
 	} $else $if T.unaliased_typ is i16 {
-		encoder.encode_number(workaround_cast[i16](&val))
+		encoder.encode_number(i16(val))
 	} $else $if T.unaliased_typ is int || T.unaliased_typ is i32 {
-		encoder.encode_number(workaround_cast[int](&val))
+		encoder.encode_number(i32(val))
 	} $else $if T.unaliased_typ is i64 {
-		encoder.encode_number(workaround_cast[i64](&val))
+		encoder.encode_number(i64(val))
 	} $else $if T.unaliased_typ is usize {
-		encoder.encode_number(workaround_cast[usize](&val))
+		encoder.encode_number(usize(val))
 	} $else $if T.unaliased_typ is isize {
-		encoder.encode_number(workaround_cast[isize](&val))
+		encoder.encode_number(isize(val))
 	} $else $if T.unaliased_typ is f32 {
-		encoder.encode_number(workaround_cast[f32](&val))
+		encoder.encode_number(f32(val))
 	} $else $if T.unaliased_typ is f64 {
-		encoder.encode_number(workaround_cast[f64](&val))
+		encoder.encode_number(f64(val))
 	} $else $if T.unaliased_typ is $array {
 		encoder.encode_array(val)
 	} $else $if T.unaliased_typ is $map {
@@ -293,7 +288,7 @@ fn (mut encoder Encoder) encode_map[T](val map[string]T) {
 
 fn (mut encoder Encoder) encode_enum[T](val T) {
 	if encoder.enum_as_int {
-		encoder.encode_number(workaround_cast[int](&val))
+		encoder.encode_number(int(val))
 	} else {
 		mut enum_val := val.str()
 		$if val is $alias {

--- a/vlib/x/json2/tests/encode_struct_test.v
+++ b/vlib/x/json2/tests/encode_struct_test.v
@@ -12,7 +12,19 @@ const fixed_time = time.new(
 
 type StringAlias = string
 type BoolAlias = bool
+type U8Alias = u8
+type U16Alias = u16
+type U32Alias = u32
+type U64Alias = u64
+type I8Alias = i8
+type I16Alias = i16
+type I32Alias = i32
+type I64Alias = i64
 type IntAlias = int
+type UsizeAlias = usize
+type IsizeAlias = isize
+type F32Alias = f32
+type F64Alias = f64
 type TimeAlias = time.Time
 type StructAlias = StructType[int]
 type EnumAlias = Enumerates
@@ -315,4 +327,29 @@ fn test_maps() {
 			}
 		}
 	}) == '{"val":{"a":{"1":1}}}'
+}
+
+struct AliasStruct {
+	f_string StringAlias = 'hello'
+	f_bool   BoolAlias   = true
+	f_u8     U8Alias     = 123
+	f_u16    U16Alias    = 456
+	f_u32    U32Alias    = 789
+	f_u64    U64Alias    = 112233
+	f_i8     I8Alias     = -123
+	f_i16    I16Alias    = -456
+	f_i32    I32Alias    = -789
+	f_i64    I64Alias    = -112233
+	f_int    IntAlias    = 7788
+	f_usize  UsizeAlias  = 9900
+	f_isize  IsizeAlias  = -9900
+	f_f32    F32Alias    = -1.5
+	f_f64    F64Alias    = 7.25
+}
+
+fn test_struct_alias() {
+	s := AliasStruct{}
+	str := json.encode(s)
+	assert str == '{"f_string":"hello","f_bool":true,"f_u8":123,"f_u16":456,"f_u32":789,"f_u64":112233,"f_i8":-123,"f_i16":-456,"f_i32":-789,"f_i64":-112233,"f_int":7788,"f_usize":9900,"f_isize":-9900,"f_f32":-1.5,"f_f64":7.25}'
+	assert json.decode[AliasStruct](str)! == s
 }


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This PR remove the  `workaround_cast()`, as alias cast is supported in PR #26079.
Also add support to decode `isize` and `usize`.