### PR TITLE
net.http: http keep-alive connections in server

### DIFF
--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -29,14 +29,15 @@ pub struct Server {
 mut:
 	state ServerStatus = .closed
 pub mut:
-	addr               string        = ':${default_server_port}'
-	handler            Handler       = DebugHandler{}
-	read_timeout       time.Duration = 30 * time.second
-	write_timeout      time.Duration = 30 * time.second
-	accept_timeout     time.Duration = 30 * time.second
-	pool_channel_slots int           = 1024
-	worker_num         int           = runtime.nr_jobs()
-	listener           net.TcpListener
+	addr                    string        = ':${default_server_port}'
+	handler                 Handler       = DebugHandler{}
+	read_timeout            time.Duration = 30 * time.second
+	write_timeout           time.Duration = 30 * time.second
+	accept_timeout          time.Duration = 30 * time.second
+	pool_channel_slots      int           = 1024
+	worker_num              int           = runtime.nr_jobs()
+	max_keep_alive_requests int           = 100 // max requests per keep-alive connection (0 = unlimited)
+	listener                net.TcpListener
 
 	on_running fn (mut s Server) = unsafe { nil } // Blocking cb. If set, ran by the web server on transitions to its .running state.
 	on_stopped fn (mut s Server) = unsafe { nil } // Blocking cb. If set, ran by the web server on transitions to its .stopped state.
@@ -77,7 +78,7 @@ pub fn (mut s Server) listen_and_serve() {
 	// Create workers
 	mut ws := []thread{cap: s.worker_num}
 	for wid in 0 .. s.worker_num {
-		ws << new_handler_worker(wid, ch, s.handler)
+		ws << new_handler_worker(wid, ch, s.handler, s.max_keep_alive_requests)
 	}
 
 	if s.show_startup_message {
@@ -159,17 +160,19 @@ pub fn (mut s Server) wait_till_running(params WaitTillRunningParams) !int {
 }
 
 struct HandlerWorker {
-	id int
-	ch chan &net.TcpConn
+	id                      int
+	ch                      chan &net.TcpConn
+	max_keep_alive_requests int
 pub mut:
 	handler Handler
 }
 
-fn new_handler_worker(wid int, ch chan &net.TcpConn, handler Handler) thread {
+fn new_handler_worker(wid int, ch chan &net.TcpConn, handler Handler, max_keep_alive_requests int) thread {
 	mut w := &HandlerWorker{
-		id:      wid
-		ch:      ch
-		handler: handler
+		id:                      wid
+		ch:                      ch
+		handler:                 handler
+		max_keep_alive_requests: max_keep_alive_requests
 	}
 	return spawn w.process_requests()
 }
@@ -193,6 +196,7 @@ fn (mut w HandlerWorker) handle_conn(mut conn net.TcpConn) {
 		}
 	}
 
+	mut request_count := 0
 	for {
 		mut req := parse_request(mut reader) or {
 			$if debug {
@@ -201,6 +205,7 @@ fn (mut w HandlerWorker) handle_conn(mut conn net.TcpConn) {
 			}
 			return
 		}
+		request_count++
 
 		remote_ip := conn.peer_ip() or { '0.0.0.0' }
 		req.header.add_custom('Remote-Addr', remote_ip) or {}
@@ -215,11 +220,16 @@ fn (mut w HandlerWorker) handle_conn(mut conn net.TcpConn) {
 			resp.header.set(.content_length, '${resp.body.len}')
 		}
 
+		// Check if max keep-alive requests limit reached
+		max_reached := w.max_keep_alive_requests > 0 && request_count >= w.max_keep_alive_requests
+
 		// Determine if connection should be kept alive
 		// HTTP/1.1 defaults to keep-alive, HTTP/1.0 defaults to close
 		req_conn := (req.header.get(.connection) or { '' }).to_lower()
 		resp_conn := (resp.header.get(.connection) or { '' }).to_lower()
-		keep_alive := if resp_conn == 'close' {
+		keep_alive := if max_reached {
+			false
+		} else if resp_conn == 'close' {
 			false
 		} else if resp_conn == 'keep-alive' {
 			true
@@ -232,8 +242,9 @@ fn (mut w HandlerWorker) handle_conn(mut conn net.TcpConn) {
 			req.version == .v1_1
 		}
 
-		// Set Connection header in response if not already set
-		if !resp.header.contains(.connection) {
+		// Set Connection header in response
+		// Always override if max requests reached, otherwise only set if not already present
+		if max_reached || !resp.header.contains(.connection) {
 			if keep_alive {
 				resp.header.set(.connection, 'keep-alive')
 			} else {


### PR DESCRIPTION
**Implementation**
  1. Added `max_keep_alive_requests` setting - Limits requests per connection to prevent resource exhaustion. Default: `100` (`0` = unlimited)
  2. Updated `handle_conn`
    - Added request loop to handle multiple requests per connection
    - Track request count per connection
    - Determine `keep-alive` based on:
        - Max requests limit reached
      - Response Connection header
      - Request Connection header
      - HTTP version default (`1.1` -> `keep-alive`, `1.0` -> `close`)
    - Automatically set `Connection` header in response
    - Close connection when `keep-alive` should end
  3. Updated HandlerWorker - Added `max_keep_alive_requests` field and propagated it through worker creation


**Test cases**

 `test_server_keep_alive` test case:
  - Creates a TCP connection to the server
  - Sends 3 requests over the same connection with `Connection: keep-alive`
  - Verifies the response counter increments (proving same server handled all requests)
  - Verifies the Connection header is correctly echoed in responses
  - Sends final request with `Connection: close` to terminate

`test_server_max_keep_alive_requests`
  - Tests that connection closes after limit is reached

Fixes #26136