### PR TITLE
x.json2: reject string-to-number type casting during decoding

### DIFF
--- a/vlib/x/json2/check.v
+++ b/vlib/x/json2/check.v
@@ -2,7 +2,7 @@ module json2
 
 // increment checks eof and increments checker by one
 @[inline]
-fn (mut checker DecodeContext) increment(message string) ! {
+fn (mut checker Decoder) increment(message string) ! {
 	if checker.checker_idx + 1 == checker.json.len {
 		if message == '' {
 			return Error{}
@@ -14,14 +14,14 @@ fn (mut checker DecodeContext) increment(message string) ! {
 
 // skip_whitespace checks eof and increments checker until next non whitespace character
 @[inline]
-fn (mut checker DecodeContext) skip_whitespace(message string) ! {
+fn (mut checker Decoder) skip_whitespace(message string) ! {
 	for checker.json[checker.checker_idx] in whitespace_chars {
 		checker.increment(message)!
 	}
 }
 
 // check_json_format checks if the JSON string is valid and updates the decoder state.
-fn (mut checker DecodeContext) check_json_format() ! {
+fn (mut checker Decoder) check_json_format() ! {
 	checker.skip_whitespace('empty json')!
 
 	start_idx_position := checker.checker_idx
@@ -104,7 +104,7 @@ fn (mut checker DecodeContext) check_json_format() ! {
 	}
 }
 
-fn (mut checker DecodeContext) check_string() ! {
+fn (mut checker Decoder) check_string() ! {
 	checker.increment('string not closed')!
 
 	// check if the JSON string is a valid escape sequence
@@ -146,7 +146,7 @@ fn (mut checker DecodeContext) check_string() ! {
 	}
 }
 
-fn (mut checker DecodeContext) check_number() ! {
+fn (mut checker Decoder) check_number() ! {
 	// check if the JSON string is a valid float or integer
 	if checker.json[checker.checker_idx] == `-` {
 		checker.increment('expected digit')!
@@ -198,7 +198,7 @@ fn (mut checker DecodeContext) check_number() ! {
 	checker.checker_idx--
 }
 
-fn (mut checker DecodeContext) check_boolean() ! {
+fn (mut checker Decoder) check_boolean() ! {
 	// check if the JSON string is a valid boolean
 	match checker.json[checker.checker_idx] {
 		`t` {
@@ -238,7 +238,7 @@ fn (mut checker DecodeContext) check_boolean() ! {
 	}
 }
 
-fn (mut checker DecodeContext) check_null() ! {
+fn (mut checker Decoder) check_null() ! {
 	// check if the JSON string is a null value
 	if checker.json.len - checker.checker_idx <= 3 {
 		return checker.checker_error('EOF error: expecting `null`')
@@ -255,7 +255,7 @@ fn (mut checker DecodeContext) check_null() ! {
 	checker.checker_idx += 3
 }
 
-fn (mut checker DecodeContext) check_array() ! {
+fn (mut checker Decoder) check_array() ! {
 	checker.increment('expected array end')!
 
 	checker.skip_whitespace('expected array end')!
@@ -276,7 +276,7 @@ fn (mut checker DecodeContext) check_array() ! {
 	}
 }
 
-fn (mut checker DecodeContext) check_object() ! {
+fn (mut checker Decoder) check_object() ! {
 	checker.increment('expected object end')!
 
 	checker.skip_whitespace('expected object end')!

--- a/vlib/x/json2/decode_sumtype.v
+++ b/vlib/x/json2/decode_sumtype.v
@@ -6,7 +6,7 @@ fn copy_type[T](t T) T {
 	return T{}
 }
 
-fn (mut decoder DecodeContext) get_decoded_sumtype_workaround[T](initialized_sumtype T) !T {
+fn (mut decoder Decoder) get_decoded_sumtype_workaround[T](initialized_sumtype T) !T {
 	$if initialized_sumtype is $sumtype {
 		$for v in initialized_sumtype.variants {
 			if initialized_sumtype is v {
@@ -29,7 +29,7 @@ fn (mut decoder DecodeContext) get_decoded_sumtype_workaround[T](initialized_sum
 	return initialized_sumtype // suppress compiler error
 }
 
-fn (mut decoder DecodeContext) check_element_type_valid[T](element T, current_node &Node[ValueInfo]) bool {
+fn (mut decoder Decoder) check_element_type_valid[T](element T, current_node &Node[ValueInfo]) bool {
 	if current_node == unsafe { nil } {
 		$if element is $array || element is $map {
 			return false
@@ -101,11 +101,11 @@ fn get_array_element_type[T](arr []T) T {
 	return T{}
 }
 
-fn (mut decoder DecodeContext) check_array_type_valid[T](arr []T, current_node &Node[ValueInfo]) bool {
+fn (mut decoder Decoder) check_array_type_valid[T](arr []T, current_node &Node[ValueInfo]) bool {
 	return decoder.check_element_type_valid(get_array_element_type(arr), current_node)
 }
 
-fn (mut decoder DecodeContext) get_array_type_workaround[T](initialized_sumtype T) bool {
+fn (mut decoder Decoder) get_array_type_workaround[T](initialized_sumtype T) bool {
 	$if initialized_sumtype is $sumtype {
 		$for v in initialized_sumtype.variants {
 			if initialized_sumtype is v {
@@ -122,17 +122,17 @@ fn get_map_element_type[U, V](m map[U]V) V {
 	return V{}
 }
 
-fn (mut decoder DecodeContext) check_map_type_valid[T](m T, current_node &Node[ValueInfo]) bool {
+fn (mut decoder Decoder) check_map_type_valid[T](m T, current_node &Node[ValueInfo]) bool {
 	element := get_map_element_type(m)
 	return decoder.check_element_type_valid(element, current_node)
 }
 
-fn (mut decoder DecodeContext) check_map_empty_valid[T](m T) bool {
+fn (mut decoder Decoder) check_map_empty_valid[T](m T) bool {
 	element := get_map_element_type(m)
 	return decoder.check_element_type_valid(element, current_node)
 }
 
-fn (mut decoder DecodeContext) get_map_type_workaround[T](initialized_sumtype T) bool {
+fn (mut decoder Decoder) get_map_type_workaround[T](initialized_sumtype T) bool {
 	$if initialized_sumtype is $sumtype {
 		$for v in initialized_sumtype.variants {
 			if initialized_sumtype is v {
@@ -150,7 +150,7 @@ fn (mut decoder DecodeContext) get_map_type_workaround[T](initialized_sumtype T)
 	return false
 }
 
-fn (mut decoder DecodeContext) check_struct_type_valid[T](s T, current_node Node[ValueInfo]) bool {
+fn (mut decoder Decoder) check_struct_type_valid[T](s T, current_node Node[ValueInfo]) bool {
 	// find "_type" field in json object
 	mut type_field_node := decoder.current_node.next
 	map_position := current_node.value.position
@@ -202,7 +202,7 @@ fn (mut decoder DecodeContext) check_struct_type_valid[T](s T, current_node Node
 	return false
 }
 
-fn (mut decoder DecodeContext) get_struct_type_workaround[T](initialized_sumtype T) bool {
+fn (mut decoder Decoder) get_struct_type_workaround[T](initialized_sumtype T) bool {
 	$if initialized_sumtype is $sumtype {
 		$for v in initialized_sumtype.variants {
 			if initialized_sumtype is v {
@@ -216,7 +216,7 @@ fn (mut decoder DecodeContext) get_struct_type_workaround[T](initialized_sumtype
 	return false
 }
 
-fn (mut decoder DecodeContext) init_sumtype_by_value_kind[T](mut val T, value_info ValueInfo) ! {
+fn (mut decoder Decoder) init_sumtype_by_value_kind[T](mut val T, value_info ValueInfo) ! {
 	mut failed_struct := false
 
 	match value_info.value_kind {
@@ -312,7 +312,7 @@ fn (mut decoder DecodeContext) init_sumtype_by_value_kind[T](mut val T, value_in
 	decoder.decode_error('could not resolve sumtype `${T.name}`, got ${value_info.value_kind}.')!
 }
 
-fn (mut decoder DecodeContext) decode_sumtype[T](mut val T) ! {
+fn (mut decoder Decoder) decode_sumtype[T](mut val T) ! {
 	$if T is $alias {
 		decoder.decode_error('Type aliased sumtypes not supported.')!
 	} $else {


### PR DESCRIPTION
Honor the JSON specification which requires numeric values to be unquoted.

This fix lets `json.decode[int]('"100"')` correctly return a `JsonDecodeError` with message `"Expected number, but got string"`, while unquoted numbers like `json.decode[int]('100')` continue to work as expected.

Fixes #26082