### PR TITLE
rand.xoroshiro128pp: prevent generation of extra zeros in u16()

### DIFF
--- a/vlib/rand/xoroshiro128pp/xoros128pp.v
+++ b/vlib/rand/xoroshiro128pp/xoros128pp.v
@@ -48,8 +48,7 @@ pub fn (mut rng XOROS128PPRNG) u8() u8 {
 	ans := rng.u64()
 	rng.buffer = ans >> 8
 	rng.bytes_left = 7
-	value := u8(ans)
-	return value
+	return u8(ans)
 }
 
 // u16 returns a pseudorandom 16-bit unsigned integer (`u16`).
@@ -62,7 +61,7 @@ pub fn (mut rng XOROS128PPRNG) u16() u16 {
 		return value
 	}
 	ans := rng.u64()
-	rng.buffer = u32(ans >> 16)
+	rng.buffer = ans >> 16
 	rng.bytes_left = 6
 	return u16(ans)
 }


### PR DESCRIPTION
Audit of `rand` module continues.

if you look at the patch from top to bottom, it consists of parts for `u8()` and for `u16()`.

u8:
just removed an extra variable `value` whose purpose was to be used as the function result.

u16:
and here it's more interesting - a logical error leads to generation of extra zeros every 4th call, breaks the work logic and statistics.

 demo code:
```v
import rand.xoroshiro128pp

fn main() {
	mut xo := xoroshiro128pp.XOROS128PPRNG{}
	for _ in 0 .. 32 {
		println(xo.u16())
	}
}
```