### PR TITLE
ast: refer to Table.type_symbols instead of Table.types in comment

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -104,7 +104,7 @@ pub fn pref_arch_to_table_language(pref_arch pref.Arch) Language {
 // Note: For a Type, use:
 // * Table.type_to_str(typ) not TypeSymbol.name.
 // * Table.type_kind(typ) not TypeSymbol.kind.
-// Each TypeSymbol is entered into `Table.types`.
+// Each TypeSymbol is entered into `Table.type_symbols`.
 // See also: Table.sym.
 @[minify]
 pub struct TypeSymbol {


### PR DESCRIPTION
A comment above `struct TypeSymbol` refers to a field `Table.types` that doesn't exist. It should refer to `Table.type_symbols`