### PR TITLE
bitfield: fix pop_count(), add test

### DIFF
--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -428,18 +428,12 @@ pub fn (a BitField) == (b BitField) bool {
 pub fn (instance BitField) pop_count() int {
 	size := instance.size
 	bitnslots := zbitnslots(size)
-	tail := size % slot_size
 	mut count := 0
-	for i in 0 .. bitnslots - 1 {
+	for i in 0 .. bitnslots {
 		for j in 0 .. slot_size {
 			if u32(instance.field[i] >> u32(j)) & u32(1) == u32(1) {
 				count++
 			}
-		}
-	}
-	for j in 0 .. tail {
-		if u32(instance.field[bitnslots - 1] >> u32(j)) & u32(1) == u32(1) {
-			count++
 		}
 	}
 	return count

--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -134,6 +134,11 @@ fn test_pop_count() {
 	assert count0 == count1
 }
 
+fn test_pop_count2() {
+	b := bitfield.from_str('011000110110110000010001000011010011011111011110101001010011011010001100001001101111111011010011')
+	assert b.pop_count() == 50
+}
+
 fn test_hamming() {
 	len := 80
 	mut count := 0


### PR DESCRIPTION
I have created a new testsuite, now for `bitfield` module vs. some random github [repo](https://github.com/ciubotaru/bitfield), 20 tests.

The `pop_count()` function and indirectly `hamming()` work incorrectly. If the number of bits is a multiple of 32, then the last word is not processed at all.

I propose a naive patch. Passed 1+M tests for bit sequences of random length.
