### PR TITLE
rand.mt19937: relax data for -autofree, update test

### DIFF
--- a/vlib/rand/mt19937/mt19937.v
+++ b/vlib/rand/mt19937/mt19937.v
@@ -73,14 +73,13 @@ fn get_first_state(seed_data []u32) []u64 {
 
 // calculate_state returns a random state array calculated from the `seed_data`.
 @[ignore_overflow]
-fn calculate_state(seed_data []u32, mut state []u64) []u64 {
+fn calculate_state(seed_data []u32, mut state []u64) {
 	lo := u64(seed_data[0])
 	hi := u64(seed_data[1])
 	state[0] = u64((hi << 32) | lo)
 	for j := 1; j < nn; j++ {
 		state[j] = u64(6364136223846793005) * (state[j - 1] ^ (state[j - 1] >> 62)) + u64(j)
 	}
-	return *state
 }
 
 // seed sets the current random state based on `seed_data`.
@@ -90,7 +89,7 @@ pub fn (mut rng MT19937RNG) seed(seed_data []u32) {
 		eprintln('mt19937 needs only two 32bit integers as seed: [lower, higher]')
 		exit(1)
 	}
-	rng.state = calculate_state(seed_data, mut rng.state)
+	calculate_state(seed_data, mut rng.state)
 	rng.mti = nn
 	rng.bytes_left = 0
 	rng.buffer = 0

--- a/vlib/rand/mt19937/mt19937_test.v
+++ b/vlib/rand/mt19937/mt19937_test.v
@@ -24,8 +24,7 @@ fn mt19937_basic_test() {
 fn gen_randoms(seed_data []u32, bound int) []u64 {
 	bound_u64 := u64(bound)
 	mut randoms := []u64{len: (20)}
-	x := mt19937.MT19937RNG{}
-	mut rnd := rand.PRNG(x)
+	mut rnd := &rand.PRNG(&mt19937.MT19937RNG{})
 	rnd.seed(seed_data)
 	for i in 0 .. 20 {
 		randoms[i] = rnd.u64n(bound_u64) or { panic("Couldn't obtain random u64") }


### PR DESCRIPTION
Fixes #13398

When operating in `-autofree` mode, memory errors that should not occur are detected.
Other generators are not affected by this.

1. `rng.state = calculate_state(seed_data, mut rng.state)` - if one is already being modified, then there's no need to return it.
2. `mut rnd := &rand.PRNG(&mt19937.MT19937RNG{})` - the usage principle is copied from another generator's test
