### PR TITLE
vwatch: fix process handle leak in `kill_pgroup()`

### DIFF
--- a/cmd/tools/vwatch.v
+++ b/cmd/tools/vwatch.v
@@ -282,6 +282,7 @@ fn (mut context Context) kill_pgroup() {
 		context.child_process.signal_pgkill()
 	}
 	context.child_process.wait()
+	context.child_process.close()
 }
 
 fn (mut context Context) run_before_cmd() {


### PR DESCRIPTION
**Problem**
Process handles not being released when `vwatch` kills and restarts child processes.

**Change**
Add missing `close()` call after `wait()` to properly release OS resources.
Without this, each restart cycle leaks file descriptors and process
handles, causing resource exhaustion during long watch sessions
(e.g., veb livereload development).

**Why**
`wait()` only waits for the process to exit and retrieves its `status. close()` is required to actually free the OS resources (file descriptors, process table entries). Without it, resources accumulate with each restart cycle.
