### PR TITLE
generics: new WIP generic solver stage behind `-new-generic-solver`

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -10,6 +10,7 @@ import v.vmod
 import v.checker
 import v.transformer
 import v.comptime
+import v.generics
 import v.parser
 import v.markused
 import v.depgraph
@@ -25,6 +26,7 @@ pub mut:
 	checker             &checker.Checker         = unsafe { nil }
 	transformer         &transformer.Transformer = unsafe { nil }
 	comptime            &comptime.Comptime       = unsafe { nil }
+	generics            &generics.Generics       = unsafe { nil }
 	out_name_c          string
 	out_name_js         string
 	stats_lines         int // size of backend generated source code in lines
@@ -85,6 +87,7 @@ pub fn new_builder(pref_ &pref.Preferences) Builder {
 		checker:           checker.new_checker(table, pref_)
 		transformer:       transformer.new_transformer_with_table(table, pref_)
 		comptime:          comptime.new_comptime_with_table(table, pref_)
+		generics:          generics.new_generics_with_table(table, pref_)
 		compiled_dir:      compiled_dir
 		cached_msvc:       msvc
 		executable_exists: os.is_file(executable_name)
@@ -138,6 +141,12 @@ pub fn (mut b Builder) middle_stages() ! {
 		for t, s in b.table.type_symbols {
 			println('> t: ${t:10} | s.mod: ${s.mod:-40} | s.name: ${'${s.name#[..30]}':-30} | s.is_builtin: ${s.is_builtin:6} | s.is_pub: ${s.is_pub}')
 		}
+	}
+
+	if b.pref.new_generic_solver {
+		util.timing_start('GENERICS')
+		b.generics.solve_files(b.parsed_files)
+		util.timing_measure('GENERICS')
 	}
 
 	util.timing_start('COMPTIME')

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -3579,13 +3579,21 @@ fn (mut c Checker) array_builtin_method_call(mut node ast.CallExpr, left_type as
 				arg_type
 			}
 		}
-		node.return_type = c.table.find_or_register_array(c.unwrap_generic(ret_type))
+		if c.pref.new_generic_solver {
+			node.return_type = c.table.find_or_register_array(ret_type)
+		} else {
+			node.return_type = c.table.find_or_register_array(c.unwrap_generic(ret_type))
+		}
 		if node.return_type.has_flag(.shared_f) {
 			node.return_type = node.return_type.clear_flag(.shared_f).deref()
 		}
 		ret_sym := c.table.sym(ret_type)
 		if ret_sym.kind == .multi_return {
 			c.error('returning multiple values is not supported in .map() calls', node.pos)
+		}
+
+		if c.pref.new_generic_solver && ret_type.has_flag(.generic) {
+			node.return_type = node.return_type.set_flag(.generic)
 		}
 	} else if node.kind == .filter {
 		// check fn

--- a/vlib/v/generics/generics.v
+++ b/vlib/v/generics/generics.v
@@ -1,0 +1,1017 @@
+module generics
+
+// TODO do scopes need to be cloned?
+import v.pref
+import v.ast
+import arrays
+import strings
+
+// Stage for solving generics
+
+pub struct Generics {
+	pref &pref.Preferences
+pub mut:
+	table               &ast.Table = unsafe { nil }
+	file                &ast.File  = unsafe { nil }
+	styp_cache          map[ast.Type]string
+	cur_fn              &ast.FnDecl = unsafe { nil }
+	cur_concrete_types  []ast.Type
+	inside_struct_init  bool
+	cur_struct_init_typ ast.Type
+}
+
+pub fn new_generics(pref_ &pref.Preferences) &Generics {
+	return &Generics{
+		pref: pref_
+	}
+}
+
+pub fn new_generics_with_table(table &ast.Table, pref_ &pref.Preferences) &Generics {
+	mut g := new_generics(pref_)
+	g.table = table
+	return g
+}
+
+pub fn (mut g Generics) solve_files(ast_files []&ast.File) {
+	for i in 0 .. ast_files.len {
+		mut file := unsafe { ast_files[i] }
+		g.solve(mut file)
+	}
+}
+
+pub fn (mut g Generics) solve(mut ast_file ast.File) {
+	g.file = ast_file
+	ast_file.stmts = g.stmts(mut ast_file.stmts)
+}
+
+pub fn (mut g Generics) stmts(mut nodes []ast.Stmt) []ast.Stmt {
+	mut solved_indexes := []int{}
+	mut solved_generic_fns := []ast.Stmt{}
+	for i, mut stmt in nodes {
+		match mut stmt {
+			ast.FnDecl {
+				old_cur_fn := g.cur_fn
+				g.cur_fn = unsafe { &stmt }
+				if stmt.generic_names.len > 0 {
+					solved_generic_fns << g.generic_fn_decl(mut stmt)
+					solved_indexes << i
+				} else {
+					nodes[i] = g.stmt(mut stmt)
+				}
+				g.cur_fn = old_cur_fn
+			}
+			else {
+				stmt = g.stmt(mut stmt)
+			}
+		}
+	}
+	for i in arrays.reverse_iterator(solved_indexes) {
+		nodes.delete(*i)
+	}
+	nodes << solved_generic_fns
+	return nodes
+}
+
+pub fn (mut g Generics) stmt(mut node ast.Stmt) ast.Stmt {
+	match mut node {
+		ast.EmptyStmt {}
+		ast.NodeError {}
+		ast.AsmStmt {}
+		ast.DebuggerStmt {}
+		ast.AssertStmt {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Stmt(ast.AssertStmt{
+					...node
+					expr: g.expr(mut node.expr)
+				})
+			}
+			node.expr = g.expr(mut node.expr)
+		}
+		ast.AssignStmt {
+			if g.cur_concrete_types.len > 0 {
+				mut right := node.right.clone()
+				mut left := node.left.clone()
+				return ast.Stmt(ast.AssignStmt{
+					...node
+					right:       g.exprs(mut right)
+					left:        g.exprs(mut left)
+					left_types:  node.left_types.map(g.unwrap_generic(it))
+					right_types: node.right_types.map(g.unwrap_generic(it))
+				})
+			}
+			node.right = g.exprs(mut node.right)
+			node.left = g.exprs(mut node.left)
+		}
+		ast.Block {
+			if g.cur_concrete_types.len > 0 {
+				mut stmts := node.stmts.clone()
+				return ast.Stmt(ast.Block{
+					...node
+					stmts: g.stmts(mut stmts)
+				})
+			}
+			node.stmts = g.stmts(mut node.stmts)
+		}
+		ast.BranchStmt {}
+		ast.ComptimeFor {
+			if g.cur_concrete_types.len > 0 {
+				mut stmts := node.stmts.clone()
+				return ast.Stmt(ast.ComptimeFor{
+					...node
+					typ:   g.unwrap_generic(node.typ)
+					stmts: g.stmts(mut stmts)
+				})
+			}
+			node.stmts = g.stmts(mut node.stmts)
+		}
+		ast.ConstDecl {
+			if g.cur_concrete_types.len > 0 {
+				mut fields := node.fields.clone()
+				for mut field in fields {
+					field.typ = g.unwrap_generic(field.typ)
+					field.expr = g.expr(mut field.expr)
+				}
+				return ast.Stmt(ast.ConstDecl{
+					...node
+					fields: fields
+				})
+			}
+			for mut field in node.fields {
+				field.expr = g.expr(mut field.expr)
+			}
+		}
+		ast.DeferStmt {
+			if g.cur_concrete_types.len > 0 {
+				mut stmts := node.stmts.clone()
+				return ast.Stmt(ast.DeferStmt{
+					...node
+					stmts: g.stmts(mut stmts)
+				})
+			}
+			node.stmts = g.stmts(mut node.stmts)
+		}
+		ast.EnumDecl {}
+		ast.ExprStmt {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Stmt(ast.ExprStmt{
+					...node
+					expr: g.expr(mut node.expr)
+					typ:  g.unwrap_generic(node.typ)
+				})
+			}
+			node.expr = g.expr(mut node.expr)
+		}
+		ast.FnDecl {
+			if g.cur_concrete_types.len > 0 {
+				old_cur_fn := g.cur_fn
+				g.cur_fn = unsafe { &node }
+				mut params := node.params.clone()
+				for mut param in params {
+					param.typ = g.unwrap_generic(param.typ)
+				}
+				mut stmts := node.stmts.clone()
+				stmts = g.stmts(mut stmts)
+				mut defer_stmts := node.defer_stmts.clone()
+				for mut defer_stmt in defer_stmts {
+					defer_stmt = g.stmt(mut defer_stmt) as ast.DeferStmt
+				}
+				g.cur_fn = old_cur_fn
+				return ast.Stmt(ast.FnDecl{
+					...node
+					return_type: g.unwrap_generic(node.return_type)
+					params:      params
+					stmts:       stmts
+					defer_stmts: defer_stmts
+				})
+			}
+			old_cur_fn := g.cur_fn
+			g.cur_fn = unsafe { &node }
+			node.stmts = g.stmts(mut node.stmts)
+			g.cur_fn = old_cur_fn
+		}
+		ast.ForCStmt {
+			if g.cur_concrete_types.len > 0 {
+				mut stmts := node.stmts.clone()
+				return ast.Stmt(ast.ForCStmt{
+					...node
+					cond:  g.expr(mut node.cond)
+					init:  g.stmt(mut node.init)
+					inc:   g.stmt(mut node.inc)
+					stmts: g.stmts(mut stmts)
+				})
+			}
+			if node.has_init && !node.is_multi {
+				node.init = g.stmt(mut node.init)
+			}
+
+			if node.has_cond {
+				node.cond = g.expr(mut node.cond)
+			}
+
+			node.stmts = g.stmts(mut node.stmts)
+
+			if node.has_inc && !node.is_multi {
+				node.inc = g.stmt(mut node.inc)
+			}
+		}
+		ast.ForInStmt {
+			if g.cur_concrete_types.len > 0 {
+				mut stmts := node.stmts.clone()
+				return ast.Stmt(ast.ForInStmt{
+					...node
+					cond:      g.expr(mut node.cond)
+					high:      g.expr(mut node.high)
+					key_type:  g.unwrap_generic(node.key_type)
+					val_type:  g.unwrap_generic(node.val_type)
+					cond_type: g.unwrap_generic(node.cond_type)
+					high_type: g.unwrap_generic(node.high_type)
+					stmts:     g.stmts(mut stmts)
+				})
+			}
+			node.stmts = g.stmts(mut node.stmts)
+		}
+		ast.ForStmt {
+			if g.cur_concrete_types.len > 0 {
+				mut stmts := node.stmts.clone()
+				return ast.Stmt(ast.ForStmt{
+					...node
+					cond:  g.expr(mut node.cond)
+					stmts: g.stmts(mut stmts)
+				})
+			}
+			node.cond = g.expr(mut node.cond)
+			node.stmts = g.stmts(mut node.stmts)
+		}
+		ast.GlobalDecl {
+			if g.cur_concrete_types.len > 0 {
+				mut fields := node.fields.clone()
+				for mut field in fields {
+					field.typ = g.unwrap_generic(field.typ)
+					field.expr = g.expr(mut field.expr)
+				}
+				return ast.Stmt(ast.GlobalDecl{
+					...node
+					fields: fields
+				})
+			}
+			for mut field in node.fields {
+				field.expr = g.expr(mut field.expr)
+			}
+		}
+		ast.GotoLabel {}
+		ast.GotoStmt {}
+		ast.HashStmt {
+			if g.cur_concrete_types.len > 0 {
+				mut ct_conds := node.ct_conds.clone()
+				return ast.Stmt(ast.HashStmt{
+					...node
+					ct_conds: g.exprs(mut ct_conds)
+				})
+			}
+			node.ct_conds = g.exprs(mut node.ct_conds)
+		}
+		ast.Import {}
+		ast.InterfaceDecl {}
+		ast.Module {}
+		ast.Return {
+			if g.cur_concrete_types.len > 0 {
+				mut exprs := node.exprs.clone()
+				return ast.Stmt(ast.Return{
+					...node
+					exprs: g.exprs(mut exprs)
+					types: node.types.map(g.unwrap_generic(it))
+				})
+			}
+			node.exprs = g.exprs(mut node.exprs)
+		}
+		ast.SemicolonStmt {}
+		ast.SqlStmt {}
+		ast.StructDecl {
+			if g.cur_concrete_types.len > 0 {
+				mut fields := node.fields.clone()
+				for mut field in fields {
+					field.container_typ = g.unwrap_generic(field.container_typ)
+					field.default_expr_typ = g.unwrap_generic(field.default_expr_typ)
+					field.typ = g.unwrap_generic(field.typ)
+					field.unaliased_typ = g.unwrap_generic(field.unaliased_typ)
+					field.default_expr = g.expr(mut field.default_expr)
+				}
+				return ast.Stmt(ast.StructDecl{
+					...node
+					fields: fields
+				})
+			}
+			for mut field in node.fields {
+				field.default_expr = g.expr(mut field.default_expr)
+			}
+		}
+		ast.TypeDecl {}
+	}
+	return node
+}
+
+// incomplete implementation: TODO
+pub fn (mut g Generics) styp(_t ast.Type) string {
+	t := g.unwrap_generic(_t)
+	if styp := g.styp_cache[t] {
+		return styp
+	}
+	if g.pref.nofloat {
+		if t == ast.f32_type {
+			return 'u32'
+		} else if t == ast.f64_type {
+			return 'u64'
+		}
+	}
+	share := t.share()
+	mut styp := if share == .atomic_t { t.atomic_typename() } else { g.cc_type(t, true) }
+	nr_muls := t.nr_muls()
+	if nr_muls > 0 {
+		styp += strings.repeat(`*`, nr_muls)
+	}
+	g.styp_cache[t] = styp
+	return styp
+}
+
+// cc_type whether to prefix 'struct' or not (C__Foo -> struct Foo)
+fn (mut g Generics) cc_type(typ ast.Type, is_prefix_struct bool) string {
+	sym := g.table.sym(g.unwrap_generic(typ))
+	mut styp := sym.scoped_cname()
+	match sym.info {
+		ast.Struct, ast.Interface, ast.SumType {
+			if sym.info.is_generic && sym.generic_types.len == 0 {
+				mut sgtyps := '_T'
+				for gt in sym.info.generic_types {
+					gts := g.table.sym(g.unwrap_generic(gt))
+					sgtyps += '_${gts.cname}'
+				}
+				styp += sgtyps
+			}
+		}
+		else {}
+	}
+	if is_prefix_struct && sym.language == .c {
+		styp = styp[3..]
+		if sym.kind == .struct {
+			info := sym.info as ast.Struct
+			if info.is_anon {
+				styp = 'C__' + styp
+			} else if !info.is_typedef {
+				styp = 'struct ${styp}'
+			}
+		}
+	}
+	return styp
+}
+
+pub fn (mut g Generics) concrete_name(old_name string, concrete_types []ast.Type) string {
+	mut name := old_name
+	if concrete_types.len > 0 {
+		name += '_T'
+	}
+	for typ in concrete_types {
+		name += '_' + strings.repeat_string('__ptr__', typ.nr_muls()) + g.styp(typ.set_nr_muls(0))
+	}
+	return name
+}
+
+pub fn (mut g Generics) generic_fn_decl(mut node ast.FnDecl) []ast.Stmt {
+	mut solved_fns := []ast.Stmt{}
+	nkey := node.fkey()
+	generic_types_by_fn := g.table.fn_generic_types[nkey]
+	for concrete_types in generic_types_by_fn {
+		if g.pref.is_verbose {
+			syms := concrete_types.map(g.table.sym(it))
+			the_type := syms.map(it.name).join(', ')
+			println('solve generic fn `${node.name}` for type `${the_type}`')
+		}
+		g.cur_concrete_types = concrete_types
+
+		mut new_node := ast.FnDecl{
+			...node
+		}
+		new_node = g.stmt(mut new_node) as ast.FnDecl
+		solved_fns << ast.FnDecl{
+			...new_node
+			name:          g.concrete_name(new_node.name, concrete_types)
+			generic_names: []
+		}
+	}
+	g.cur_concrete_types = []
+	return solved_fns
+}
+
+pub fn (mut g Generics) exprs(mut nodes []ast.Expr) []ast.Expr {
+	for mut e in nodes {
+		e = g.expr(mut e)
+	}
+	return nodes
+}
+
+pub fn (mut g Generics) expr(mut node ast.Expr) ast.Expr {
+	match mut node {
+		ast.AnonFn {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.AnonFn{
+					...node
+					typ:  g.unwrap_generic(node.typ)
+					decl: g.stmt(mut node.decl) as ast.FnDecl
+				})
+			}
+			node.decl = g.stmt(mut node.decl) as ast.FnDecl
+		}
+		ast.ArrayDecompose {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.ArrayDecompose{
+					...node
+					expr_type: g.unwrap_generic(node.expr_type)
+					arg_type:  g.unwrap_generic(node.arg_type)
+					expr:      g.expr(mut node.expr)
+				})
+			}
+			node.expr = g.expr(mut node.expr)
+		}
+		ast.ArrayInit {
+			if g.cur_concrete_types.len > 0 {
+				mut exprs := node.exprs.clone()
+				return ast.Expr(ast.ArrayInit{
+					...node
+					exprs:      g.exprs(mut exprs)
+					expr_types: node.expr_types.map(g.unwrap_generic(it))
+					typ:        g.unwrap_generic(node.typ)
+					elem_type:  g.unwrap_generic(node.elem_type)
+					alias_type: g.unwrap_generic(node.alias_type)
+					len_expr:   g.expr(mut node.len_expr)
+					cap_expr:   g.expr(mut node.cap_expr)
+					init_type:  g.unwrap_generic(node.init_type)
+					init_expr:  g.expr(mut node.init_expr)
+				})
+			}
+			node.exprs = g.exprs(mut node.exprs)
+			if node.has_len {
+				node.len_expr = g.expr(mut node.len_expr)
+			}
+			if node.has_cap {
+				node.cap_expr = g.expr(mut node.cap_expr)
+			}
+			if node.has_init {
+				node.init_expr = g.expr(mut node.init_expr)
+			}
+		}
+		ast.AsCast {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.AsCast{
+					...node
+					typ:       g.unwrap_generic(node.typ)
+					expr_type: g.unwrap_generic(node.expr_type)
+					expr:      g.expr(mut node.expr)
+				})
+			} else {
+				node.expr = g.expr(mut node.expr)
+			}
+		}
+		ast.CallExpr {
+			if g.cur_concrete_types.len > 0 {
+				mut args := node.args.clone()
+				for mut arg in args {
+					arg.typ = g.unwrap_generic(arg.typ)
+					arg.expr = g.expr(mut arg.expr)
+				}
+				mut all_concrete_types := node.concrete_types.clone()
+				for mut ct in all_concrete_types {
+					idx := g.cur_fn.generic_names.index(g.table.type_str(ct))
+					if idx != -1 {
+						ct = g.cur_concrete_types[idx]
+					}
+				}
+				return ast.Expr(ast.CallExpr{
+					...node
+					name:                g.concrete_name(node.name, all_concrete_types)
+					left_type:           g.unwrap_generic(node.left_type)
+					receiver_type:       g.unwrap_generic(node.receiver_type)
+					return_type:         g.unwrap_generic(node.return_type)
+					return_type_generic: ast.no_type
+					fn_var_type:         g.unwrap_generic(node.fn_var_type)
+					left:                g.expr(mut node.left)
+					expected_arg_types:  node.expected_arg_types.map(g.unwrap_generic(it))
+					args:                args
+					concrete_types:      []
+					raw_concrete_types:  node.raw_concrete_types.clone()
+					from_embed_types:    node.from_embed_types.clone()
+					or_block:            g.expr(mut node.or_block) as ast.OrExpr
+				})
+			}
+			node.left = g.expr(mut node.left)
+			for mut arg in node.args {
+				arg.expr = g.expr(mut arg.expr)
+			}
+			node.or_block = g.expr(mut node.or_block) as ast.OrExpr
+			if node.concrete_types.len > 0 {
+				if func := g.table.find_fn(node.name) {
+					node.expected_arg_types = node.expected_arg_types.map(g.table.convert_generic_type(it,
+						func.generic_names, node.concrete_types) or { it })
+				}
+			}
+			node.name = g.concrete_name(node.name, node.concrete_types)
+			return ast.Expr(ast.CallExpr{
+				...node
+				concrete_types:     []
+				raw_concrete_types: []
+			})
+		}
+		ast.CastExpr {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.CastExpr{
+					...node
+					typ:  g.unwrap_generic(node.typ)
+					arg:  g.expr(mut node.arg)
+					expr: g.expr(mut node.expr)
+				})
+			}
+			node.arg = g.expr(mut node.arg)
+			node.expr = g.expr(mut node.expr)
+		}
+		ast.ChanInit {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.ChanInit{
+					...node
+					typ:       g.unwrap_generic(node.typ)
+					elem_type: g.unwrap_generic(node.typ)
+					cap_expr:  g.expr(mut node.cap_expr)
+				})
+			}
+			node.cap_expr = g.expr(mut node.cap_expr)
+		}
+		ast.ComptimeCall {
+			if g.cur_concrete_types.len > 0 {
+				mut args := node.args.clone()
+				for mut arg in args {
+					arg.expr = g.expr(mut arg.expr)
+				}
+				return ast.Expr(ast.ComptimeCall{
+					...node
+					left_type:   g.unwrap_generic(node.left_type)
+					result_type: g.unwrap_generic(node.result_type)
+					args:        args
+				})
+			}
+			for mut arg in node.args {
+				arg.expr = g.expr(mut arg.expr)
+			}
+		}
+		ast.ComptimeSelector {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.ComptimeSelector{
+					...node
+					left_type:  g.unwrap_generic(node.left_type)
+					typ:        g.unwrap_generic(node.typ)
+					left:       g.expr(mut node.left)
+					field_expr: g.expr(mut node.field_expr)
+				})
+			}
+			node.left = g.expr(mut node.left)
+			node.field_expr = g.expr(mut node.field_expr)
+		}
+		ast.ConcatExpr {
+			if g.cur_concrete_types.len > 0 {
+				mut vals := node.vals.clone()
+				for mut val in vals {
+					val = g.expr(mut val)
+				}
+				return ast.Expr(ast.ConcatExpr{
+					...node
+					return_type: g.unwrap_generic(node.return_type)
+					vals:        vals
+				})
+			}
+			for mut val in node.vals {
+				val = g.expr(mut val)
+			}
+		}
+		ast.DumpExpr {
+			if g.cur_concrete_types.len > 0 {
+				name := if mut node.expr is ast.Ident {
+					// var
+					if node.expr.info is ast.IdentVar && node.expr.language == .v {
+						g.styp(g.unwrap_generic(node.expr.info.typ.clear_flags(.shared_f,
+							.result))).replace('*', '')
+					} else {
+						node.cname
+					}
+				} else if mut node.expr is ast.CallExpr {
+					g.styp(g.unwrap_generic(node.expr_type.clear_flags(.shared_f, .result))).replace('*',
+						'').replace('.', '__')
+				} else {
+					node.cname
+				}
+				return ast.Expr(ast.DumpExpr{
+					...node
+					cname:     name
+					expr_type: g.unwrap_generic(node.expr_type)
+					expr:      g.expr(mut node.expr)
+				})
+			}
+			node.expr = g.expr(mut node.expr)
+		}
+		ast.Ident {
+			match mut node.obj {
+				ast.Var {
+					if g.cur_concrete_types.len > 0 {
+						is_ct_type_generic := node.obj.ct_type_var == .generic_param
+							|| node.obj.ct_type_var == .generic_var
+						unwrapped_typ := g.unwrap_generic(node.obj.typ)
+						return ast.Expr(ast.Ident{
+							...node
+							obj: ast.Var{
+								...node.obj
+								typ:           unwrapped_typ
+								smartcasts:    node.obj.smartcasts.map(g.unwrap_generic(it))
+								is_auto_deref: node.obj.is_auto_deref
+									|| (node.obj.typ.has_flag(.generic)
+									&& g.table.sym(unwrapped_typ).kind in [.sum_type, .interface])
+								// node.obj.orig_type = g.unwrap_generic(node.obj.orig_type)
+								ct_type_unwrapped: is_ct_type_generic || node.obj.ct_type_unwrapped
+								ct_type_var:       if is_ct_type_generic {
+									.no_comptime
+								} else {
+									node.obj.ct_type_var
+								}
+							}
+						})
+					}
+				}
+				else {}
+			}
+		}
+		ast.IfExpr {
+			if g.cur_concrete_types.len > 0 {
+				mut branches := node.branches.clone()
+				for mut branch in branches {
+					branch.stmts = branch.stmts.clone()
+					branch.cond = g.expr(mut branch.cond)
+					branch.stmts = g.stmts(mut branch.stmts)
+				}
+				return ast.Expr(ast.IfExpr{
+					...node
+					typ:      g.unwrap_generic(node.typ)
+					branches: branches
+					left:     g.expr(mut node.left)
+				})
+			}
+			for mut branch in node.branches {
+				branch.cond = g.expr(mut branch.cond)
+				branch.stmts = g.stmts(mut branch.stmts)
+			}
+			node.left = g.expr(mut node.left)
+		}
+		ast.IfGuardExpr {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.IfGuardExpr{
+					...node
+					expr_type: g.unwrap_generic(node.expr_type)
+					expr:      g.expr(mut node.expr)
+				})
+			}
+			node.expr = g.expr(mut node.expr)
+		}
+		ast.IndexExpr {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.IndexExpr{
+					...node
+					left_type: g.unwrap_generic(node.left_type)
+					typ:       g.unwrap_generic(node.typ)
+					left:      g.expr(mut node.left)
+					index:     g.expr(mut node.index)
+					or_expr:   g.expr(mut node.or_expr) as ast.OrExpr
+				})
+			}
+			node.left = g.expr(mut node.left)
+			node.index = g.expr(mut node.index)
+			node.or_expr = g.expr(mut node.or_expr) as ast.OrExpr
+		}
+		ast.InfixExpr {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.InfixExpr{
+					...node
+					left_type:     g.unwrap_generic(node.left_type)
+					right_type:    g.unwrap_generic(node.right_type)
+					promoted_type: g.unwrap_generic(node.promoted_type)
+					left:          g.expr(mut node.left)
+					right:         g.expr(mut node.right)
+				})
+			}
+			node.left = g.expr(mut node.left)
+			node.right = g.expr(mut node.right)
+		}
+		ast.IsRefType {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.IsRefType{
+					...node
+					typ:  g.unwrap_generic(node.typ)
+					expr: g.expr(mut node.expr)
+				})
+			}
+			node.expr = g.expr(mut node.expr)
+		}
+		ast.Likely {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.Likely{
+					...node
+					expr: g.expr(mut node.expr)
+				})
+			}
+			node.expr = g.expr(mut node.expr)
+		}
+		ast.LockExpr {
+			if g.cur_concrete_types.len > 0 {
+				mut stmts := node.stmts.clone()
+				mut lockeds := node.lockeds.clone()
+				return ast.Expr(ast.LockExpr{
+					...node
+					typ:     g.unwrap_generic(node.typ)
+					stmts:   g.stmts(mut stmts)
+					lockeds: g.exprs(mut lockeds)
+				})
+			}
+			node.stmts = g.stmts(mut node.stmts)
+			node.lockeds = g.exprs(mut node.lockeds)
+		}
+		ast.MapInit {
+			if g.cur_concrete_types.len > 0 {
+				mut keys := node.keys.clone()
+				mut vals := node.vals.clone()
+				return ast.Expr(ast.MapInit{
+					typ:        g.unwrap_generic(node.typ)
+					key_type:   g.unwrap_generic(node.key_type)
+					value_type: g.unwrap_generic(node.value_type)
+					val_types:  node.val_types.map(g.unwrap_generic(it))
+					keys:       g.exprs(mut keys)
+					vals:       g.exprs(mut vals)
+				})
+			}
+			node.keys = g.exprs(mut node.keys)
+			node.vals = g.exprs(mut node.vals)
+		}
+		ast.MatchExpr {
+			if g.cur_concrete_types.len > 0 {
+				mut branches := node.branches.clone()
+				for mut branch in node.branches {
+					branch.stmts = branch.stmts.clone()
+					branch.exprs = branch.exprs.clone()
+					branch.exprs = g.exprs(mut branch.exprs)
+					branch.stmts = g.stmts(mut branch.stmts)
+				}
+				return ast.Expr(ast.MatchExpr{
+					...node
+					branches:      branches
+					return_type:   g.unwrap_generic(node.return_type)
+					cond_type:     g.unwrap_generic(node.cond_type)
+					cond:          g.expr(mut node.cond)
+					expected_type: g.unwrap_generic(node.expected_type)
+				})
+			}
+			node.cond = g.expr(mut node.cond)
+			for mut branch in node.branches {
+				branch.exprs = g.exprs(mut branch.exprs)
+				branch.stmts = g.stmts(mut branch.stmts)
+			}
+		}
+		ast.OrExpr {
+			if g.cur_concrete_types.len > 0 {
+				mut stmts := node.stmts.clone()
+				return ast.Expr(ast.OrExpr{
+					...node
+					stmts: g.stmts(mut stmts)
+				})
+			}
+			node.stmts = g.stmts(mut node.stmts)
+		}
+		ast.ParExpr {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.ParExpr{
+					...node
+					expr: g.expr(mut node.expr)
+				})
+			}
+			node.expr = g.expr(mut node.expr)
+		}
+		ast.PostfixExpr {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.PostfixExpr{
+					...node
+					expr: g.expr(mut node.expr)
+					typ:  g.unwrap_generic(node.typ)
+				})
+			}
+			node.expr = g.expr(mut node.expr)
+		}
+		ast.PrefixExpr {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.PrefixExpr{
+					...node
+					right_type: g.unwrap_generic(node.right_type)
+					right:      g.expr(mut node.right)
+					or_block:   g.expr(mut node.or_block) as ast.OrExpr
+				})
+			}
+			node.right = g.expr(mut node.right)
+			node.or_block = g.expr(mut node.or_block) as ast.OrExpr
+		}
+		ast.RangeExpr {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.RangeExpr{
+					...node
+					typ:  g.unwrap_generic(node.typ)
+					low:  g.expr(mut node.low)
+					high: g.expr(mut node.high)
+				})
+			}
+			node.low = g.expr(mut node.low)
+			node.high = g.expr(mut node.high)
+		}
+		ast.SelectExpr {
+			if g.cur_concrete_types.len > 0 {
+				mut branches := node.branches.clone()
+				for mut branch in node.branches {
+					branch.stmt = g.stmt(mut branch.stmt)
+					branch.stmts = branch.stmts.clone()
+					branch.stmts = g.stmts(mut branch.stmts)
+				}
+				return ast.Expr(ast.SelectExpr{
+					...node
+					expected_type: g.unwrap_generic(node.expected_type)
+					branches:      branches
+				})
+			}
+			for mut branch in node.branches {
+				branch.stmt = g.stmt(mut branch.stmt)
+				branch.stmts = g.stmts(mut branch.stmts)
+			}
+		}
+		ast.SelectorExpr {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.SelectorExpr{
+					...node
+					expr:             g.expr(mut node.expr)
+					expr_type:        g.unwrap_generic(node.expr_type)
+					typ:              g.unwrap_generic(node.typ)
+					name_type:        g.unwrap_generic(node.name_type)
+					from_embed_types: node.from_embed_types.map(g.unwrap_generic(it))
+				})
+			}
+			node.expr = g.expr(mut node.expr)
+		}
+		ast.SizeOf {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.SizeOf{
+					...node
+					expr: g.expr(mut node.expr)
+					typ:  g.unwrap_generic(node.typ)
+				})
+			}
+			node.expr = g.expr(mut node.expr)
+		}
+		ast.SqlExpr {
+			if g.cur_concrete_types.len > 0 {
+				mut fields := node.fields.clone()
+				for mut field in fields {
+					field.default_expr = g.expr(mut field.default_expr)
+				}
+				mut sub_structs := node.sub_structs.clone()
+				for _, mut sub_struct in sub_structs {
+					sub_struct = g.expr(mut sub_struct) as ast.SqlExpr
+				}
+				return ast.Expr(ast.SqlExpr{
+					...node
+					typ:         g.unwrap_generic(node.typ)
+					db_expr:     g.expr(mut node.db_expr)
+					where_expr:  g.expr(mut node.where_expr)
+					order_expr:  g.expr(mut node.order_expr)
+					limit_expr:  g.expr(mut node.limit_expr)
+					offset_expr: g.expr(mut node.offset_expr)
+					fields:      fields
+					sub_structs: sub_structs
+				})
+			}
+			node.db_expr = g.expr(mut node.db_expr)
+			if node.has_where {
+				node.where_expr = g.expr(mut node.where_expr)
+			}
+			if node.has_order {
+				node.order_expr = g.expr(mut node.order_expr)
+			}
+			if node.has_limit {
+				node.limit_expr = g.expr(mut node.limit_expr)
+			}
+			if node.has_offset {
+				node.offset_expr = g.expr(mut node.offset_expr)
+			}
+			for mut field in node.fields {
+				field.default_expr = g.expr(mut field.default_expr)
+			}
+			for _, mut sub_struct in node.sub_structs {
+				sub_struct = g.expr(mut sub_struct) as ast.SqlExpr
+			}
+		}
+		ast.StringInterLiteral {
+			if g.cur_concrete_types.len > 0 {
+				mut exprs := node.exprs.clone()
+				return ast.Expr(ast.StringInterLiteral{
+					...node
+					exprs:      g.exprs(mut exprs)
+					expr_types: node.expr_types.map(g.unwrap_generic(it))
+				})
+			}
+			node.exprs = g.exprs(mut node.exprs)
+		}
+		ast.StructInit {
+			if g.cur_concrete_types.len > 0 {
+				g.inside_struct_init = true
+				g.cur_struct_init_typ = node.typ
+				mut init_fields := node.init_fields.clone()
+				for mut init_field in init_fields {
+					init_field.expr = g.expr(mut init_field.expr)
+				}
+				out := ast.Expr(ast.StructInit{
+					...node
+					typ:              g.unwrap_generic(node.typ)
+					typ_str:          g.table.type_str(g.unwrap_generic(node.typ))
+					generic_types:    node.generic_types.map(g.unwrap_generic(it))
+					update_expr:      g.expr(mut node.update_expr)
+					update_expr_type: g.unwrap_generic(node.update_expr_type)
+					init_fields:      init_fields
+				})
+				g.cur_struct_init_typ = 0
+				g.inside_struct_init = false
+				return out
+			}
+			g.inside_struct_init = true
+			g.cur_struct_init_typ = node.typ
+			node.update_expr = g.expr(mut node.update_expr)
+			for mut init_field in node.init_fields {
+				init_field.expr = g.expr(mut init_field.expr)
+			}
+			g.cur_struct_init_typ = 0
+			g.inside_struct_init = false
+		}
+		ast.TypeNode {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.TypeNode{
+					...node
+					typ:  g.unwrap_generic(node.typ)
+					stmt: g.stmt(mut node.stmt)
+				})
+			}
+			node.stmt = g.stmt(mut node.stmt)
+		}
+		ast.UnsafeExpr {
+			if g.cur_concrete_types.len > 0 {
+				return ast.Expr(ast.UnsafeExpr{
+					...node
+					expr: g.expr(mut node.expr)
+				})
+			}
+			node.expr = g.expr(mut node.expr)
+		}
+		else {}
+	}
+	return node
+}
+
+fn (mut g Generics) unwrap_generic(typ ast.Type) ast.Type {
+	if typ.has_flag(.generic) {
+		if g.cur_fn != unsafe { nil } && g.cur_fn.generic_names.len > 0 {
+			if t_typ := g.table.convert_generic_type(typ, g.cur_fn.generic_names, g.cur_concrete_types) {
+				return t_typ
+			}
+		} else if g.inside_struct_init {
+			if g.cur_struct_init_typ != 0 {
+				sym := g.table.sym(g.cur_struct_init_typ)
+				if sym.info is ast.Struct {
+					if sym.info.generic_types.len > 0 {
+						generic_names := sym.info.generic_types.map(g.table.sym(it).name)
+						if t_typ := g.table.convert_generic_type(typ, generic_names, sym.info.concrete_types) {
+							return t_typ
+						}
+					}
+				}
+			}
+		} else if g.table.sym(typ).kind == .struct {
+			// resolve selector `a.foo` where `a` is struct[T] on non generic function
+			sym := g.table.sym(typ)
+			if sym.info is ast.Struct {
+				if sym.info.generic_types.len > 0 {
+					generic_names := sym.info.generic_types.map(g.table.sym(it).name)
+					if t_typ := g.table.convert_generic_type(typ, generic_names, sym.info.concrete_types) {
+						return t_typ
+					}
+
+					if t_typ := g.table.convert_generic_type(typ, generic_names, g.cur_concrete_types) {
+						return t_typ
+					}
+				}
+			}
+		}
+	}
+	return typ
+}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -258,10 +258,11 @@ pub mut:
 	// forwards compatibility settings:
 	relaxed_gcc14 bool = true // turn on the generated pragmas, that make gcc versions > 14 a lot less pedantic. The default is to have those pragmas in the generated C output, so that gcc-14 can be used on Arch etc.
 	//
-	subsystem     Subsystem // the type of the window app, that is going to be generated; has no effect on !windows
-	is_vls        bool
-	json_errors   bool // -json-errors, for VLS and other tools
-	new_transform bool // temporary for the new transformer
+	subsystem          Subsystem // the type of the window app, that is going to be generated; has no effect on !windows
+	is_vls             bool
+	json_errors        bool // -json-errors, for VLS and other tools
+	new_transform      bool // temporary for the new transformer
+	new_generic_solver bool
 }
 
 pub fn parse_args(known_external_commands []string, args []string) (&Preferences, string) {
@@ -1014,6 +1015,9 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 				} $else {
 					println('coroutines only work on macos & linux for now')
 				}
+			}
+			'-new-generic-solver' {
+				res.new_generic_solver = true
 			}
 			else {
 				if command == 'build' && is_source_file(arg) {


### PR DESCRIPTION
Introduces a new WIP stage for solving generics.
Half of the tests from `v -new-generic-solver test vlib/v/tests/generics/`  are passing: `128 failed, 131 passed, 259 total`

The styp and cc_type implementations (and some other code snippets related to solving generics) are taken from cgen but are incomplete for the moment.

The current logic for `generics` is: when encoutering a FnDecl statement, clone the AST for each concrete type.