### PR TITLE
ast: fix dump() free bug for v.ast.TypeSymbol

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -920,7 +920,7 @@ pub enum Kind {
 
 // str returns the internal & source name of the type
 pub fn (t &TypeSymbol) str() string {
-	return t.name
+	return t.name.clone()
 }
 
 // TODO why is this needed? str() returns incorrect amount of &

--- a/vlib/v/gen/c/dumpexpr.v
+++ b/vlib/v/gen/c/dumpexpr.v
@@ -236,7 +236,7 @@ fn (mut g Gen) dump_expr_definitions() {
 					deref
 				}
 				surrounder.add('\tstring value = (dump_arg == NULL) ? _S("nil") : ${to_string_fn_name}(${prefix}dump_arg);',
-					'')
+					'\tbuiltin__string_free(&value);')
 			}
 		} else {
 			prefix := if dump_sym.is_c_struct() {


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Fix issue #26282 

because `t.name` may freed by `dump()`, so return a `t.name.clone()`