### PR TITLE
cgen: fix generic function error propagation type mismatch

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7500,13 +7500,22 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			if g.fn_decl == unsafe { nil } || g.fn_decl.return_type == ast.void_type {
 				g.writeln('\treturn;')
 			} else {
-				styp := g.styp(g.fn_decl.return_type)
+				mut fn_return_type := g.fn_decl.return_type
+				if g.cur_fn != unsafe { nil } && g.cur_fn.generic_names.len > 0
+					&& g.cur_concrete_types.len > 0 {
+					if converted_type := g.table.convert_generic_type(g.fn_decl.return_type,
+						g.cur_fn.generic_names, g.cur_concrete_types)
+					{
+						fn_return_type = converted_type
+					}
+				}
+				styp := g.styp(fn_return_type)
 				err_obj := g.new_tmp_var()
 				g.writeln('\t${styp} ${err_obj} = {0};')
-				if g.fn_decl.return_type.has_flag(.result) {
+				if fn_return_type.has_flag(.result) {
 					g.writeln('\t${err_obj}.is_error = true;')
 					g.writeln('\t${err_obj}.err = ${cvar_name}${tmp_op}err;')
-				} else if g.fn_decl.return_type.has_flag(.option) {
+				} else if fn_return_type.has_flag(.option) {
 					g.writeln('\t${err_obj}.state = 2;')
 				}
 				g.writeln('\treturn ${err_obj};')

--- a/vlib/v/tests/generics/generic_function_error_propagation_test.v
+++ b/vlib/v/tests/generics/generic_function_error_propagation_test.v
@@ -1,0 +1,12 @@
+import rand
+
+type Condition = fn () bool
+
+fn test_generic_function_error_propagation() {
+	mut list := []Condition{}
+	list = [fn () bool {
+		return true
+	}]
+	println(rand.element[Condition](list) or { panic('Err') })
+	println(list)
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Closes #26263 

When generating error propagation code for generic functions, the code used `g.fn_decl.return_type` directly without considering that this type might still be a generic type (e.g., !T) rather than the instantiated concrete type (e.g., Result[Condition]).

During generic function instantiation, `g.fn_decl` points to the original generic function declaration, not the instantiated version. Therefore, `g.fn_decl.return_type` contains the generic type, which leads to incorrect C code generation when creating error objects.