### PR TITLE
cgen: remove no longer required words from c_reserved

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -17,16 +17,14 @@ import v.type_resolver
 import sync.pool
 
 // Note: some of the words in c_reserved, are not reserved in C, but are
-// in C++, or have special meaning in V, thus need escaping too. `small`
-// should not be needed, but see:
-// https://stackoverflow.com/questions/5874215/what-is-rpcndr-h
+// in C++, or have special meaning in V
 const c_reserved = ['asm', 'array', 'auto', 'bool', 'break', 'calloc', 'case', 'char', 'class',
 	'complex', 'const', 'continue', 'default', 'delete', 'do', 'double', 'else', 'enum', 'error',
 	'exit', 'export', 'extern', 'false', 'float', 'for', 'free', 'goto', 'if', 'inline', 'int',
-	'link', 'long', 'malloc', 'namespace', 'new', 'nil', 'panic', 'register', 'restrict', 'return',
-	'short', 'signed', 'sizeof', 'static', 'string', 'struct', 'switch', 'typedef', 'typename',
-	'typeof', 'union', 'unix', 'unsigned', 'void', 'volatile', 'while', 'template', 'true', 'small',
-	'stdout', 'stdin', 'stderr', 'far', 'near', 'huge', 'requires']
+	'long', 'malloc', 'namespace', 'new', 'nil', 'panic', 'register', 'restrict', 'return', 'short',
+	'signed', 'sizeof', 'static', 'string', 'struct', 'switch', 'typedef', 'typename', 'typeof',
+	'union', 'unix', 'unsigned', 'void', 'volatile', 'while', 'template', 'true', 'stdout', 'stdin',
+	'stderr', 'requires']
 const c_reserved_chk = token.new_keywords_matcher_from_array_trie(c_reserved)
 // same order as in token.Kind
 const cmp_str = ['eq', 'ne', 'gt', 'lt', 'ge', 'le']


### PR DESCRIPTION
I am keeping `stdout`, `stdin` and `stderr` for now as they are file handles. The "keywords" in `rpcndr.h` which are simply defines should be safe to remove but I am not on windows so these might still fail. 
I am unsure why `link` is a keyword in here, as I haven't found anything that defines it. 
~~The `unix` word is a preprocessor define so it might be better to actually keep it? Not sure about this.~~
Edit: unix is still needed
