### PR TITLE
thirdparty.zstd: update patch with commit 8aa0369

### DIFF
--- a/thirdparty/zstd/zstd_v.patch
+++ b/thirdparty/zstd/zstd_v.patch
@@ -1,5 +1,5 @@
---- zstd.c	2025-05-30 16:39:46.374765970 +0800
-+++ zstd.c	2025-05-30 21:02:30.710831777 +0800
+--- zstd.c	2026-01-10 14:25:18.651952689 +0100
++++ zstd.c	2026-01-09 17:55:20.698628329 +0100
 @@ -50,6 +50,27 @@
  /* TODO: Can't amalgamate ASM function */
  #define ZSTD_DISABLE_ASM 1
@@ -28,6 +28,15 @@
  /* Include zstd_deps.h first with all the options we need enabled. */
  #define ZSTD_DEPS_NEED_MALLOC
  #define ZSTD_DEPS_NEED_MATH64
+@@ -698,7 +719,7 @@
+ /* vectorization
+  * older GCC (pre gcc-4.3 picked as the cutoff) uses a different syntax,
+  * and some compilers, like Intel ICC and MCST LCC, do not support it at all. */
+-#if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__) && !defined(__LCC__)
++#if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__) && !defined(__LCC__) && !defined(__TINYC__)
+ #  if (__GNUC__ == 4 && __GNUC_MINOR__ > 3) || (__GNUC__ >= 5)
+ #    define DONT_VECTORIZE __attribute__((optimize("no-tree-vectorize")))
+ #  else
 @@ -22353,7 +22374,7 @@
  ZSTD_GEN_RECORD_FINGERPRINT(43, 8)
  


### PR DESCRIPTION
Update local patch for `thirdparty/zstd/zstd.c` after commit vlang/v@8aa0369b64e1e3a2ed73254a2f0492015af15a53 (zstd: make compilable with tcc)