### PR TITLE
transformer: Resolve wrong cast fixed ArrayInit to voidptr

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5857,9 +5857,12 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 				if node_typ == ast.voidptr_type && node.expr is ast.ArrayInit
 					&& (node.expr as ast.ArrayInit).is_fixed {
 					expr_styp := g.styp(node.expr_type)
-					g.write('(${expr_styp})')
+					g.write('_MOV((${expr_styp})')
+					g.expr(node.expr)
+					g.write(')')
+				} else {
+					g.expr(node.expr)
 				}
-				g.expr(node.expr)
 				g.inside_assign_fn_var = old_inside_assign_fn_var
 				g.write('))')
 			}

--- a/vlib/v/transformer/array.v
+++ b/vlib/v/transformer/array.v
@@ -53,10 +53,17 @@ pub fn (mut t Transformer) array_init(mut node ast.ArrayInit) ast.Expr {
 		}
 		typ:  ast.int_type
 	}
+	elem_sym := t.table.sym(t.table.unwrap(node.elem_type))
+	// For function types, use voidptr size instead of function type size
+	sizeof_type := if elem_sym.kind == .function {
+		ast.voidptr_type
+	} else {
+		node.elem_type
+	}
 	sizeof_arg := ast.CallArg{
 		expr: ast.SizeOf{
 			is_type: true
-			typ:     node.elem_type
+			typ:     sizeof_type
 		}
 		typ:  ast.int_type
 	}


### PR DESCRIPTION
This PR attempt to correct the wrong cast done in fixed Arrays using the newer "transformer". This fixes the tests in `vlib/crypto/ed25519/internal/`.