### PR TITLE
ci: add task to build examples on OpenBSD

### DIFF
--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -39,6 +39,8 @@ jobs:
           sync_files: runner-to-vm
           run: |
             sudo pkg_add git sqlite3 gmake boehm-gc libiconv
+            # Install packages needed to build examples
+            sudo pkg_add mariadb-client postgresql-client
             # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s openbsd-ci
             echo "### OS infos"
@@ -68,6 +70,8 @@ jobs:
           sync_files: runner-to-vm
           run: |
             sudo pkg_add git sqlite3 gmake boehm-gc libiconv
+            # Install packages needed to build examples
+            sudo pkg_add mariadb-client postgresql-client
             # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s openbsd-ci
             echo "### OS infos"

--- a/ci/openbsd_ci.vsh
+++ b/ci/openbsd_ci.vsh
@@ -47,6 +47,14 @@ fn run_essential_tests() {
 	}
 }
 
+fn build_examples() {
+	if common.is_github_job {
+		exec('v -W build-examples')
+	} else {
+		exec('v -progress build-examples')
+	}
+}
+
 const all_tasks = {
 	'v_doctor':            Task{v_doctor, 'Run v doctor'}
 	'verify_v_test_works': Task{verify_v_test_works, 'Verify that v test works'}
@@ -54,6 +62,7 @@ const all_tasks = {
 	'check_math':          Task{check_math, 'Check the `math` module works'}
 	'check_compress':      Task{check_compress, 'Check the `compress` module works'}
 	'run_essential_tests': Task{run_essential_tests, 'Run only the essential tests'}
+	'build_examples':      Task{build_examples, 'Build examples'}
 }
 
 common.run(all_tasks)


### PR DESCRIPTION
In "OpenBSD CI", add a task to build examples with `tcc` and `clang`

- `.github/workflows/openbsd_ci.yml`: install packages needed for DB MySQL/PostgreSQL to build examples
- `ci/openbsd_ci.vsh`: add task to build examples in CI with `tcc` and `clang`

See this successful run with this new task in my personal repo => https://github.com/lcheylus/v/actions/runs/20893949417