### PR TITLE
db.mysql: improve documentation for support on FreeBSD

### DIFF
--- a/vlib/db/mysql/README.md
+++ b/vlib/db/mysql/README.md
@@ -24,6 +24,8 @@ Use `docker container rm some-mysql` to remove it completely, after it is stoppe
 
 For Linux, you need to install `MySQL development` package and `pkg-config`.
 
+For FreeBSD, you need to install the `mariadb118-client` package.
+
 For OpenBSD, you need to install the `mariadb-client` package.
 
 For Windows, install [the installer](https://dev.mysql.com/downloads/installer/) ,

--- a/vlib/db/mysql/_cdefs_nix.c.v
+++ b/vlib/db/mysql/_cdefs_nix.c.v
@@ -10,6 +10,8 @@ $if $pkgconfig('mysqlclient') {
 	#pkgconfig mariadb
 	$if openbsd {
 		#include <mysql.h> # Please install the mariadb-client package for development headers
+	} $else $if freebsd {
+		#include <mysql.h> # Please install the mariadb118-client package for development headers
 	} $else {
 		#include <mysql.h> # Please install the libmariadb-dev development headers
 	}


### PR DESCRIPTION
- `vlib/db/mysql/README.md`: add doc to install FreeBSD package needed for MariaDB/MySQL lib and includes
- `vlib/db/mysql/_cdefs_nix.c.v`: add FreeBSD case to display error message for include `mysql.h`