### PR TITLE
db.pg: improve doc for support on FreeBSD

### DIFF
--- a/vlib/db/pg/README.md
+++ b/vlib/db/pg/README.md
@@ -49,6 +49,8 @@ gem install pg -- --with-pg-config=/opt/local/lib/postgresql[version number]/bin
 
 **ArchLinux**: `pacman -S postgresql-libs`
 
+**FreeBSD**: `pkg install postgresql18-client`
+
 **OpenBSD**: `pkg_add postgresql-client`
 
 **Windows**:


### PR DESCRIPTION
Install `postgresql18-client` package on FreeBSD for `libpq` lib and includes.