### PR TITLE
cgen: fix chan autostr

### DIFF
--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -118,10 +118,6 @@ fn new_channel_st_noscan(n u32, st u32) &Channel {
 	}
 }
 
-pub fn (ch &Channel) auto_str(typename string) string {
-	return 'chan ${typename}{cap: ${ch.cap}, closed: ${ch.closed}}'
-}
-
 pub fn (mut ch Channel) close() {
 	open_val := u16(0)
 	if !C.atomic_compare_exchange_strong_u16(&ch.closed, &open_val, 1) {

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -568,7 +568,27 @@ fn (mut g Gen) gen_str_for_chan(info ast.Chan, styp string, str_fn_name string) 
 	}
 	elem_type_name := util.strip_main_name(g.table.get_type_name(g.unwrap_generic(info.elem_type)))
 	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} x);')
-	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} x) { return sync__Channel_auto_str(x, _S("${elem_type_name}")); }')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} x) { return indent_${str_fn_name}(x, 0);}')
+	g.definitions.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${styp} x, ${ast.int_type_name} indent_count);')
+	g.auto_str_funcs.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${styp} x, ${ast.int_type_name} indent_count) {')
+	g.auto_str_funcs.writeln('\tstring indents = builtin__string_repeat(_S("    "), indent_count);')
+	g.auto_str_funcs.writeln('\tstrings__Builder sb = strings__new_builder(64);')
+	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _S("chan "));')
+	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _S("${elem_type_name}"));')
+	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _S("{\\n"));')
+	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, indents);')
+	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _S("    cap: "));')
+	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, builtin__int_str(x->cap));')
+	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _S(", closed: "));')
+	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, x->closed != 0 ? _S("true") : _S("false"));')
+	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _S("\\n"));')
+	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, indents);')
+	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _S("}"));')
+	g.auto_str_funcs.writeln('\tstring res = strings__Builder_str(&sb);')
+	g.auto_str_funcs.writeln('\tstrings__Builder_free(&sb);')
+	g.auto_str_funcs.writeln('\tbuiltin__string_free(&indents);')
+	g.auto_str_funcs.writeln('\treturn res;')
+	g.auto_str_funcs.writeln('}')
 }
 
 fn (mut g Gen) gen_str_for_thread(info ast.Thread, styp string, str_fn_name string) {
@@ -1268,7 +1288,7 @@ fn data_str(x StrIntpType) string {
 }
 
 fn should_use_indent_func(kind ast.Kind) bool {
-	return kind in [.struct, .alias, .array, .array_fixed, .map, .sum_type, .interface]
+	return kind in [.struct, .alias, .array, .array_fixed, .map, .sum_type, .interface, .chan]
 }
 
 fn (mut g Gen) get_enum_type_idx_from_fn_name(fn_name string) (string, int) {

--- a/vlib/v/tests/concurrency/channels_test.v
+++ b/vlib/v/tests/concurrency/channels_test.v
@@ -21,11 +21,11 @@ fn test_printing_of_channels() {
 	res := (spawn fn1(ch)).wait()
 	println(res)
 	println(ch)
-	assert res.str().contains('another: chan f64{cap: 100, closed: 0}')
-	assert ch.str() == 'chan St1{cap: 10, closed: 0}'
-	assert fch.str() == 'chan f64{cap: 100, closed: 0}'
+	assert res.str().contains('another: chan f64{\n        cap: 100, closed: false\n    }')
+	assert ch.str() == 'chan St1{\n    cap: 10, closed: false\n}'
+	assert fch.str() == 'chan f64{\n    cap: 100, closed: false\n}'
 	fch.close()
-	assert fch.str() == 'chan f64{cap: 100, closed: 1}'
+	assert fch.str() == 'chan f64{\n    cap: 100, closed: true\n}'
 }
 
 struct Aa {}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

closes #26337 

1. remove `auto_str()` from `vlib/sync/channels.c.v`, as it can't handle multi line indent correctly.
2. use `autostr` in `cgen` generate correct indent's chan string.
3. use `true/false` for `closed` field.
4. fix tests