### PR TITLE
v.pref: error with exit if coroutines not supported

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -1013,7 +1013,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 						}
 					}
 				} $else {
-					println('coroutines only work on macos & linux for now')
+					eprintln_exit('coroutines only work on macOS & Linux for now')
 				}
 			}
 			'-new-generic-solver' {


### PR DESCRIPTION
When building with `-use-coroutines`, immediate exit with error message if coroutines not supported (**OS != Linux/macOS**).

- Before this fix, build on OpenBSD/amd64: error message then build continues and fails.
```sh
$ ./v -use-coroutines examples/coroutines/simple_coroutines.v
coroutines only work on macos & linux for now
================== C compilation error (from tcc): ==============
cc: tcc: error: file '/home/fox/dev/vlang.git/thirdparty/photon/photonwrapper.so' not found
=================================================================
Try passing `-g` when compiling, to see a .v file:line information, that correlates more with the C error.
(Alternatively, pass `-show-c-output`, to print the full C error message).
builder error:
==================
C error found. It should never happen, when compiling pure V code.
This is a V compiler bug, please report it using `v bug file.v`,
or goto https://github.com/vlang/v/issues/new/choose .
You can also use #help on Discord: https://discord.gg/vlang .
```

- With this fix, immediate exit with error message:
```sh
$ ./v -use-coroutines examples/coroutines/simple_coroutines.v
coroutines only work on macOS & Linux for now
```