### PR TITLE
builder: error on implicit function declaration

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -511,6 +511,14 @@ fn (v &Builder) only_compile_args(ccoptions CcompilerOptions) []string {
 				all << '-Werror=implicit-function-declaration'
 			}
 		}
+	} $else {
+		// On non-Windows platforms, always add -Werror=implicit-function-declaration
+		// to catch implicit function declarations at compile time
+		if ccoptions.cc != .msvc {
+			if !v.pref.is_cstrict {
+				all << '-Werror=implicit-function-declaration'
+			}
+		}
 	}
 	all << ccoptions.pre_args
 	all << ccoptions.source_args

--- a/vlib/v/tests/implicit_function_declaration_test.v
+++ b/vlib/v/tests/implicit_function_declaration_test.v
@@ -1,0 +1,38 @@
+// Test for implicit C function declaration detection
+// This test verifies that V correctly catches implicit C function declarations
+
+module main
+
+import os
+
+// `test_imp_c_function.v` filename can't contains `implicit`
+const test_file = os.join_path(os.vtmp_dir(), 'test_imp_c_function.v')
+
+fn testsuite_begin() {
+	os.rm(test_file) or {}
+	// Test code that should fail due to implicit C function declaration
+	test_code := 'module main
+fn C.custom_undeclared_function()
+fn main() {
+        C.custom_undeclared_function()
+}
+'
+	// Write the test code to the temporary file
+	os.write_file(test_file, test_code) or {
+		eprintln('FAIL: Unable to write test file')
+		exit(1)
+	}
+}
+
+fn testsuite_end() {
+	os.rm(test_file) or { eprintln('Warning: Unable to delete temporary file') }
+}
+
+fn test_implicit_c_function_declaration() {
+	result := os.execute('v ${test_file}')
+	assert result.exit_code != 0
+	println(result.output)
+	assert result.output.contains('custom_undeclared_function')
+	// C4013 is for msvc
+	assert result.output.contains('implicit') || result.output.contains('C4013')
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

Turn `implicit function declaration` from warning to error.
This help fix issue such as #14783
