### PR TITLE
cgen: fix function-like macro '_BIONIC_AVAILABILITY_GUARD' is not defined in termux

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -316,7 +316,7 @@ typedef int (*qsort_callback_func)(const void*, const void*);
 #endif
 #ifdef __TERMUX__
 #if !defined(__BIONIC_AVAILABILITY_GUARD)
-#define __BIONIC_AVAILABILITY_GUARD(api_level) 0
+	#define __BIONIC_AVAILABILITY_GUARD(api_level) 0
 #endif
 #if __BIONIC_AVAILABILITY_GUARD(28)
 #else


### PR DESCRIPTION
fix compiler error in termux(0.118.0)
<img width="838" height="221" alt="Snipaste_2026-01-13_22-48-08" src="https://github.com/user-attachments/assets/fdef9fa9-b651-40eb-a6c8-bca130dcc92d" />
<img width="880" height="666" alt="Snipaste_2026-01-13_22-50-07" src="https://github.com/user-attachments/assets/4c5ffd60-4955-490f-bf63-21c763446614" />
