### PR TITLE
tools: add note for vrun on OpenBSD (env -S not supported)

### DIFF
--- a/cmd/tools/vrun
+++ b/cmd/tools/vrun
@@ -5,8 +5,9 @@ v run $@
 ## the `/usr/bin/env` implementation, does not yet support a `-S` option.
 ## Notes: FreeBSD's env supports it since 2006.
 ##        GNU's coreutils env supports it since 2018.
-##        However, for example BusyBox's env still does not (2025/02/04), and there may
-##        be others like it too :-| .
+##        BusyBox's env does not support it (2025/02/04).
+##        OpenBSD's env does not support it (2026/01/14).
+##        And there may be others like it too :-| .
 
 ## On such systems, you can copy this script, or symlink it, somewhere in your PATH,
 ## and then start your .vsh scripts with: `#!/usr/bin/env vrun`.

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -8421,7 +8421,7 @@ exists the file will be overridden. If you want to rebuild each time and not kee
 instead use `#!/usr/bin/env -S v -raw-vsh-tmp-prefix tmp run`.
 
 Note: there is a small shell script `cmd/tools/vrun`, that can be useful for systems, that have an
-env program (`/usr/bin/env`), that still does not support an `-S` option (like BusyBox).
+env program (`/usr/bin/env`), that still does not support an `-S` option (like BusyBox and OpenBSD).
 See https://github.com/vlang/v/blob/master/cmd/tools/vrun for more details.
 
 # Appendices


### PR DESCRIPTION
Add note/doc for `cmd/tools/vrun` tool/script on OpenBSD => `env -S` not supported on this OS :(

See issue #26344 
