### PR TITLE
builder: fix compile error message for -m32

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -75,7 +75,7 @@ fn (mut v Builder) post_process_c_compiler_output(ccompiler string, res os.Resul
 			}
 			println('='.repeat(header.len))
 			// Check for TCC cross-compilation errors
-			if ccompiler == 'tcc' && res.output.contains('could not run') {
+			if ccompiler == 'tcc' && res.output.starts_with('tcc: error: could not run') {
 				println('${highlight_word('Suggestion')}: try using a different C compiler with `-cc gcc` or `-cc clang`.')
 				println('${highlight_word('Suggestion')}: or build TCC for the target architecture yourself.')
 				println('${highlight_word('Note')}: you should build an 32bit version of `${@VROOT}/thirdparty/tcc/lib/libgc.a` first or use `-gc none`.')


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->

closes #16639

this will cause output message:
```
$ v -m32 examples/hello_world.v
================== C compilation error (from tcc): ==============
cc: tcc: error: could not run '/media/HD/github/kbkpbot/v/thirdparty/tcc/i386-tcc'
=================================================================
Suggestion: try using a different C compiler with `-cc gcc` or `-cc clang`.
Suggestion: or build TCC for the target architecture yourself.
Note: you should build an 32bit version of `/media/HD/github/kbkpbot/v/thirdparty/tcc/lib/libgc.a` first or use `-gc none`.
```