### PR TITLE
checker: fix option in struct member infix expr and swapped none comp…

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -798,12 +798,12 @@ fn (mut c Checker) check_append(mut node ast.InfixExpr, left_type ast.Type, righ
 	if !node.is_stmt {
 		c.error('array append cannot be used in an expression', node.pos)
 	}
-	if left_type.has_flag(.option) && node.left is ast.Ident && node.left.or_expr.kind == .absent {
-		c.error('unwrapped Option cannot be used in an infix expression', node.pos)
-	}
-	right_pos := node.right.pos()
 	mut right_sym := c.table.sym(right_type)
 	mut left_sym := c.table.sym(left_type)
+	if left_type.has_flag(.option) && node.left is ast.Ident && node.left.or_expr.kind == .absent {
+		c.check_option_infix_expr(node, left_type, right_type, left_sym, right_sym)
+	}
+	right_pos := node.right.pos()
 	// `array << elm`
 	c.check_expr_option_or_result_call(node.right, right_type)
 	node.auto_locked, _ = c.fail_if_immutable(mut node.left)

--- a/vlib/v/checker/tests/infix_compare_option_err.out
+++ b/vlib/v/checker/tests/infix_compare_option_err.out
@@ -1,12 +1,5 @@
-vlib/v/checker/tests/infix_compare_option_err.vv:6:5: error: unwrapped Option cannot be compared in an infix expression
-    4 | 
-    5 | fn main() {
-    6 |     if foo() > foo() {
-      |        ~~~~~
-    7 |     }
-    8 | }
-vlib/v/checker/tests/infix_compare_option_err.vv:6:5: error: unwrapped Option cannot be used in an infix expression
-    4 | 
+vlib/v/checker/tests/infix_compare_option_err.vv:6:5: error: `?int` cannot be used as `int`, unwrap the option first
+    4 |
     5 | fn main() {
     6 |     if foo() > foo() {
       |        ~~~~~

--- a/vlib/v/checker/tests/infix_err.out
+++ b/vlib/v/checker/tests/infix_err.out
@@ -1,137 +1,168 @@
-vlib/v/checker/tests/infix_err.vv:9:5: error: mismatched types `string` and `?string`
-    7 | }
-    8 | 
-    9 | _ = '' + f()
+vlib/v/checker/tests/infix_err.vv:13:5: error: mismatched types `string` and `?string`
+   11 | }
+   12 |
+   13 | _ = '' + f()
       |     ~~~~~~~~
-   10 | _ = f() + ''
-   11 | _ = f() + f()
-vlib/v/checker/tests/infix_err.vv:9:10: error: unwrapped Option cannot be used in an infix expression
-    7 | }
-    8 | 
-    9 | _ = '' + f()
+   14 | _ = f() + ''
+   15 | _ = f() + f()
+vlib/v/checker/tests/infix_err.vv:13:10: error: `?string` cannot be used as `string`, unwrap the option first
+   11 | }
+   12 |
+   13 | _ = '' + f()
       |          ~~~
-   10 | _ = f() + ''
-   11 | _ = f() + f()
-vlib/v/checker/tests/infix_err.vv:10:5: error: mismatched types `?string` and `string`
-    8 | 
-    9 | _ = '' + f()
-   10 | _ = f() + ''
+   14 | _ = f() + ''
+   15 | _ = f() + f()
+vlib/v/checker/tests/infix_err.vv:14:5: error: mismatched types `?string` and `string`
+   12 |
+   13 | _ = '' + f()
+   14 | _ = f() + ''
       |     ~~~~~~~~
-   11 | _ = f() + f()
+   15 | _ = f() + f()
+   16 |
+vlib/v/checker/tests/infix_err.vv:14:5: error: `?string` cannot be used as `string`, unwrap the option first
    12 |
-vlib/v/checker/tests/infix_err.vv:10:5: error: unwrapped Option cannot be used in an infix expression
-    8 | 
-    9 | _ = '' + f()
-   10 | _ = f() + ''
+   13 | _ = '' + f()
+   14 | _ = f() + ''
       |     ~~~
-   11 | _ = f() + f()
-   12 |
-vlib/v/checker/tests/infix_err.vv:11:9: error: `+` cannot be used with `?string`
-    9 | _ = '' + f()
-   10 | _ = f() + ''
-   11 | _ = f() + f()
+   15 | _ = f() + f()
+   16 |
+vlib/v/checker/tests/infix_err.vv:15:9: error: `+` cannot be used with `?string`
+   13 | _ = '' + f()
+   14 | _ = f() + ''
+   15 | _ = f() + f()
       |         ^
-   12 | 
-   13 | _ = 4 + g()
-vlib/v/checker/tests/infix_err.vv:11:5: error: unwrapped Option cannot be used in an infix expression
-    9 | _ = '' + f()
-   10 | _ = f() + ''
-   11 | _ = f() + f()
+   16 |
+   17 | _ = 4 + g()
+vlib/v/checker/tests/infix_err.vv:15:5: error: `?string` cannot be used as `string`, unwrap the option first
+   13 | _ = '' + f()
+   14 | _ = f() + ''
+   15 | _ = f() + f()
       |     ~~~
-   12 | 
-   13 | _ = 4 + g()
-vlib/v/checker/tests/infix_err.vv:13:7: error: `+` cannot be used with `?int`
-   11 | _ = f() + f()
-   12 | 
-   13 | _ = 4 + g()
+   16 |
+   17 | _ = 4 + g()
+vlib/v/checker/tests/infix_err.vv:17:7: error: `+` cannot be used with `?int`
+   15 | _ = f() + f()
+   16 |
+   17 | _ = 4 + g()
       |       ^
-   14 | _ = int(0) + g()
-   15 | _ = g() + int(3)
-vlib/v/checker/tests/infix_err.vv:13:9: error: unwrapped Option cannot be used in an infix expression
-   11 | _ = f() + f()
-   12 | 
-   13 | _ = 4 + g()
+   18 | _ = int(0) + g()
+   19 | _ = g() + int(3)
+vlib/v/checker/tests/infix_err.vv:17:9: error: `?int` cannot be used as `int literal`, unwrap the option first
+   15 | _ = f() + f()
+   16 |
+   17 | _ = 4 + g()
       |         ~~~
-   14 | _ = int(0) + g()
-   15 | _ = g() + int(3)
-vlib/v/checker/tests/infix_err.vv:14:14: error: unwrapped Option cannot be used in an infix expression
-   12 | 
-   13 | _ = 4 + g()
-   14 | _ = int(0) + g()
+   18 | _ = int(0) + g()
+   19 | _ = g() + int(3)
+vlib/v/checker/tests/infix_err.vv:18:14: error: `?int` cannot be used as `int`, unwrap the option first
+   16 |
+   17 | _ = 4 + g()
+   18 | _ = int(0) + g()
       |              ~~~
-   15 | _ = g() + int(3)
-   16 | _ = g() + 3
-vlib/v/checker/tests/infix_err.vv:15:9: error: `+` cannot be used with `?int`
-   13 | _ = 4 + g()
-   14 | _ = int(0) + g()
-   15 | _ = g() + int(3)
+   19 | _ = g() + int(3)
+   20 | _ = g() + 3
+vlib/v/checker/tests/infix_err.vv:19:9: error: `+` cannot be used with `?int`
+   17 | _ = 4 + g()
+   18 | _ = int(0) + g()
+   19 | _ = g() + int(3)
       |         ^
-   16 | _ = g() + 3
-   17 |
-vlib/v/checker/tests/infix_err.vv:15:5: error: unwrapped Option cannot be used in an infix expression
-   13 | _ = 4 + g()
-   14 | _ = int(0) + g()
-   15 | _ = g() + int(3)
+   20 | _ = g() + 3
+   21 |
+vlib/v/checker/tests/infix_err.vv:19:5: error: `?int` cannot be used as `int`, unwrap the option first
+   17 | _ = 4 + g()
+   18 | _ = int(0) + g()
+   19 | _ = g() + int(3)
       |     ~~~
-   16 | _ = g() + 3
-   17 |
-vlib/v/checker/tests/infix_err.vv:16:9: error: `+` cannot be used with `?int`
-   14 | _ = int(0) + g()
-   15 | _ = g() + int(3)
-   16 | _ = g() + 3
+   20 | _ = g() + 3
+   21 |
+vlib/v/checker/tests/infix_err.vv:20:9: error: `+` cannot be used with `?int`
+   18 | _ = int(0) + g()
+   19 | _ = g() + int(3)
+   20 | _ = g() + 3
       |         ^
-   17 | 
-   18 | // binary operands
-vlib/v/checker/tests/infix_err.vv:16:5: error: unwrapped Option cannot be used in an infix expression
-   14 | _ = int(0) + g()
-   15 | _ = g() + int(3)
-   16 | _ = g() + 3
+   21 |
+   22 | // binary operands
+vlib/v/checker/tests/infix_err.vv:20:5: error: `?int` cannot be used as `int literal`, unwrap the option first
+   18 | _ = int(0) + g()
+   19 | _ = g() + int(3)
+   20 | _ = g() + 3
       |     ~~~
-   17 | 
-   18 | // binary operands
-vlib/v/checker/tests/infix_err.vv:19:5: error: left operand for `&&` is not a boolean
-   17 | 
-   18 | // binary operands
-   19 | _ = 1 && 2
+   21 |
+   22 | // binary operands
+vlib/v/checker/tests/infix_err.vv:23:5: error: left operand for `&&` is not a boolean
+   21 |
+   22 | // binary operands
+   23 | _ = 1 && 2
       |     ^
-   20 | _ = true || 2
+   24 | _ = true || 2
+   25 |
+vlib/v/checker/tests/infix_err.vv:23:10: error: right operand for `&&` is not a boolean
    21 |
-vlib/v/checker/tests/infix_err.vv:19:10: error: right operand for `&&` is not a boolean
-   17 | 
-   18 | // binary operands
-   19 | _ = 1 && 2
+   22 | // binary operands
+   23 | _ = 1 && 2
       |          ^
-   20 | _ = true || 2
-   21 |
-vlib/v/checker/tests/infix_err.vv:20:13: error: right operand for `||` is not a boolean
-   18 | // binary operands
-   19 | _ = 1 && 2
-   20 | _ = true || 2
+   24 | _ = true || 2
+   25 |
+vlib/v/checker/tests/infix_err.vv:24:13: error: right operand for `||` is not a boolean
+   22 | // binary operands
+   23 | _ = 1 && 2
+   24 | _ = true || 2
       |             ^
-   21 | 
-   22 | // boolean expressions
-vlib/v/checker/tests/infix_err.vv:20:5: error: infix expr: cannot use `int literal` (right expression) as `bool`
-   18 | // binary operands
-   19 | _ = 1 && 2
-   20 | _ = true || 2
+   25 |
+   26 | // boolean expressions
+vlib/v/checker/tests/infix_err.vv:24:5: error: infix expr: cannot use `int literal` (right expression) as `bool`
+   22 | // binary operands
+   23 | _ = 1 && 2
+   24 | _ = true || 2
       |     ~~~~~~~~~
-   21 | 
-   22 | // boolean expressions
-vlib/v/checker/tests/infix_err.vv:23:22: error: ambiguous boolean expression. use `()` to ensure correct order of operations
-   21 | 
-   22 | // boolean expressions
-   23 | _ = 1 == 1 && 2 == 2 || 3 == 3
+   25 |
+   26 | // boolean expressions
+vlib/v/checker/tests/infix_err.vv:27:22: error: ambiguous boolean expression. use `()` to ensure correct order of operations
+   25 |
+   26 | // boolean expressions
+   27 | _ = 1 == 1 && 2 == 2 || 3 == 3
       |                      ~~
-   24 | _ = 1 == 1 && 2 == 2 || 3 == 3 && 4 == 4
-   25 | _ = 1 + println('')
-vlib/v/checker/tests/infix_err.vv:24:22: error: ambiguous boolean expression. use `()` to ensure correct order of operations
-   22 | // boolean expressions
-   23 | _ = 1 == 1 && 2 == 2 || 3 == 3
-   24 | _ = 1 == 1 && 2 == 2 || 3 == 3 && 4 == 4
+   28 | _ = 1 == 1 && 2 == 2 || 3 == 3 && 4 == 4
+   29 | _ = 1 + println('')
+vlib/v/checker/tests/infix_err.vv:28:22: error: ambiguous boolean expression. use `()` to ensure correct order of operations
+   26 | // boolean expressions
+   27 | _ = 1 == 1 && 2 == 2 || 3 == 3
+   28 | _ = 1 == 1 && 2 == 2 || 3 == 3 && 4 == 4
       |                      ~~
-   25 | _ = 1 + println('')
-vlib/v/checker/tests/infix_err.vv:25:5: error: mismatched types `int literal` and `void`
-   23 | _ = 1 == 1 && 2 == 2 || 3 == 3
-   24 | _ = 1 == 1 && 2 == 2 || 3 == 3 && 4 == 4
-   25 | _ = 1 + println('')
+   29 | _ = 1 + println('')
+   30 |
+vlib/v/checker/tests/infix_err.vv:29:5: error: mismatched types `int literal` and `void`
+   27 | _ = 1 == 1 && 2 == 2 || 3 == 3
+   28 | _ = 1 == 1 && 2 == 2 || 3 == 3 && 4 == 4
+   29 | _ = 1 + println('')
       |     ~~~~~~~~~~~~~~~
+   30 |
+   31 | // struct members
+vlib/v/checker/tests/infix_err.vv:36:11: error: `?string` cannot be used as `string`, unwrap the option first
+   34 | }
+   35 | name := 'a name'
+   36 | _ := data.name == 'a name'
+      |           ~~~~
+   37 | _ := 'a name' == data.name
+   38 | _ := data.name == name
+vlib/v/checker/tests/infix_err.vv:37:23: error: `?string` cannot be used as `string`, unwrap the option first
+   35 | name := 'a name'
+   36 | _ := data.name == 'a name'
+   37 | _ := 'a name' == data.name
+      |                       ~~~~
+   38 | _ := data.name == name
+   39 | _ := name == data.name
+vlib/v/checker/tests/infix_err.vv:38:11: error: `?string` cannot be used as `string`, unwrap the option first
+   36 | _ := data.name == 'a name'
+   37 | _ := 'a name' == data.name
+   38 | _ := data.name == name
+      |           ~~~~
+   39 | _ := name == data.name
+   40 |
+vlib/v/checker/tests/infix_err.vv:39:19: error: `?string` cannot be used as `string`, unwrap the option first
+   37 | _ := 'a name' == data.name
+   38 | _ := data.name == name
+   39 | _ := name == data.name
+      |                   ~~~~
+   40 |
+   41 | // these should not error

--- a/vlib/v/checker/tests/infix_err.vv
+++ b/vlib/v/checker/tests/infix_err.vv
@@ -1,3 +1,7 @@
+struct Data {
+	name ?string
+}
+
 fn f() ?string {
 	return none
 }
@@ -23,3 +27,17 @@ _ = true || 2
 _ = 1 == 1 && 2 == 2 || 3 == 3
 _ = 1 == 1 && 2 == 2 || 3 == 3 && 4 == 4
 _ = 1 + println('')
+
+// struct members
+data := Data {
+  'a name'
+}
+name := 'a name'
+_ := data.name == 'a name'
+_ := 'a name' == data.name
+_ := data.name == name
+_ := name == data.name
+
+// these should not error
+_ := data.name == none
+_ := none == data.name

--- a/vlib/v/checker/tests/option_ptr_err.out
+++ b/vlib/v/checker/tests/option_ptr_err.out
@@ -4,7 +4,7 @@ vlib/v/checker/tests/option_ptr_err.vv:3:10: error: type `?int` is an Option, it
     3 |     assert *var == 0
       |             ~~~
     4 | }
-vlib/v/checker/tests/option_ptr_err.vv:3:9: error: unwrapped Option cannot be used in an infix expression
+vlib/v/checker/tests/option_ptr_err.vv:3:9: error: `?int` cannot be used as `int literal`, unwrap the option first
     1 | fn main() {
     2 |     mut var := unsafe { ?&int(none) }
     3 |     assert *var == 0

--- a/vlib/v/checker/tests/option_wrapped_cmp_op_err.out
+++ b/vlib/v/checker/tests/option_wrapped_cmp_op_err.out
@@ -1,25 +1,25 @@
-vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:3:10: error: unwrapped Option cannot be used in an infix expression
+vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:3:10: error: `?string` cannot be used as `string`, unwrap the option first
     1 | fn main() {
     2 |     a := ?string('hi')
     3 |     println(a == 'hi')
       |             ^
     4 |     println('hi' == a)
     5 |     println(a != 'hi')
-vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:4:18: error: unwrapped Option cannot be used in an infix expression
+vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:4:18: error: `?string` cannot be used as `string`, unwrap the option first
     2 |     a := ?string('hi')
     3 |     println(a == 'hi')
     4 |     println('hi' == a)
       |                     ^
     5 |     println(a != 'hi')
     6 |     println('hi' != a)
-vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:5:10: error: unwrapped Option cannot be used in an infix expression
+vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:5:10: error: `?string` cannot be used as `string`, unwrap the option first
     3 |     println(a == 'hi')
     4 |     println('hi' == a)
     5 |     println(a != 'hi')
       |             ^
     6 |     println('hi' != a)
     7 | }
-vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:6:18: error: unwrapped Option cannot be used in an infix expression
+vlib/v/checker/tests/option_wrapped_cmp_op_err.vv:6:18: error: `?string` cannot be used as `string`, unwrap the option first
     4 |     println('hi' == a)
     5 |     println(a != 'hi')
     6 |     println('hi' != a)

--- a/vlib/v/checker/tests/unwrapped_option_infix.out
+++ b/vlib/v/checker/tests/unwrapped_option_infix.out
@@ -1,5 +1,5 @@
-vlib/v/checker/tests/unwrapped_option_infix.vv:5:9: error: unwrapped Option cannot be used in an infix expression
+vlib/v/checker/tests/unwrapped_option_infix.vv:5:9: error: `?string` cannot be used as `string`, unwrap the option first
     3 | }
-    4 | 
+    4 |
     5 | println(test() == '')
       |         ~~~~~~

--- a/vlib/v/checker/tests/wrong_shift_left_option_err.out
+++ b/vlib/v/checker/tests/wrong_shift_left_option_err.out
@@ -5,11 +5,11 @@ vlib/v/checker/tests/wrong_shift_left_option_err.vv:7:2: error: cannot push to O
       |     ^
     8 |     mut b := ?[]int([2, 8]) // primitive type
     9 |     b << [1, 3, 4]
-vlib/v/checker/tests/wrong_shift_left_option_err.vv:7:4: error: unwrapped Option cannot be used in an infix expression
+vlib/v/checker/tests/wrong_shift_left_option_err.vv:7:2: error: `?[]SomeStruct` cannot be used as `[]SomeStruct`, unwrap the option first
     5 | fn main() {
     6 |     mut a := ?[]SomeStruct([SomeStruct{}, SomeStruct{}]) // struct type
     7 |     a << []SomeStruct{len: 20}
-      |       ~~
+      |     ^
     8 |     mut b := ?[]int([2, 8]) // primitive type
     9 |     b << [1, 3, 4]
 vlib/v/checker/tests/wrong_shift_left_option_err.vv:9:2: error: cannot push to Option array that was not unwrapped first
@@ -19,10 +19,10 @@ vlib/v/checker/tests/wrong_shift_left_option_err.vv:9:2: error: cannot push to O
       |     ^
    10 |     dump(a?.len)
    11 |     dump(b)
-vlib/v/checker/tests/wrong_shift_left_option_err.vv:9:4: error: unwrapped Option cannot be used in an infix expression
+vlib/v/checker/tests/wrong_shift_left_option_err.vv:9:2: error: `?[]int` cannot be used as `[]int`, unwrap the option first
     7 |     a << []SomeStruct{len: 20}
     8 |     mut b := ?[]int([2, 8]) // primitive type
     9 |     b << [1, 3, 4]
-      |       ~~
+      |     ^
    10 |     dump(a?.len)
    11 |     dump(b)


### PR DESCRIPTION
Fixes #26351. 

While fixing it I noticed that currently the below code:
```v
a := ?int(0)
_ := none == a
```
Gives the following output:
```
code.v:2:14: error: unwrapped Option cannot be used in an infix expression
    1 | a := ?int(0)
    2 | _ := none == a
      |              ^
code.v:2:6: error: infix expr: cannot use `int` (right expression) as `none`
    1 | a := ?int(0)
    2 | _ := none == a
```
Only if `none` is on the left.  This is also fixed in this pr.

I added the test to `vlib/v/checker/tests/infix_err.vv`. The changes in the other tests are due to me moving the logic to a the function `check_option_infix_expr`, and calling it in multiple places including `containers.v` with a new error message.