### PR TITLE
wasm: only compile .wasm.v, .v.v and .v files

### DIFF
--- a/vlib/v/pref/should_compile.v
+++ b/vlib/v/pref/should_compile.v
@@ -292,7 +292,7 @@ pub fn (prefs &Preferences) should_compile_js(file string) bool {
 
 pub fn (prefs &Preferences) should_compile_wasm(file string) bool {
 	if !file.ends_with('.wasm.v') && file.count('.') >= 2 {
-		// not .wasm.v not .v.v something else like .c.v
+		// not .wasm.v not just .v something else like .c.v
 		return false
 	}
 	return true


### PR DESCRIPTION
Compiling with '-b wasm' only compiles the aforementioned type of files with this pr. Previously .c.v or .js.v files were included in the compilation process.