### PR TITLE
strings: add `lorum` Markov chain text generator 

### DIFF
--- a/examples/lorem.v
+++ b/examples/lorem.v
@@ -14,7 +14,7 @@ Example:
 
     ./lorem -order 2 -words 12 -sentences 4 -paragraphs 3 -corpus poe
 */
-import strings
+import strings.lorem
 import flag
 import os
 import rand
@@ -45,7 +45,7 @@ fn main() {
 		rng_seed = rand.int()
 	}
 
-	cfg := strings.LoremCfg{
+	text := lorem.generate(
 		markov_order:            order
 		words_per_sentence:      words_per_sentence
 		sentences_per_paragraph: sentences_per_paragraph
@@ -53,8 +53,7 @@ fn main() {
 		corpus_name:             corpus_name
 		seed_text:               seed_text
 		rng_seed:                rng_seed
-	}
+	)
 
-	text := strings.lorum(cfg)
 	println(text)
 }

--- a/vlib/strings/lorem/lorem.v
+++ b/vlib/strings/lorem/lorem.v
@@ -1,4 +1,4 @@
-module strings
+module lorem
 
 const lorem_corpora = {
 	'lorem':  lorem_corpus
@@ -88,7 +88,7 @@ pub:
 // - Optional seed phrases and RNG seed
 // - Optional corpus selection
 //
-pub fn lorum(cfg LoremCfg) string {
+pub fn generate(cfg LoremCfg) string {
 	// Initialize LCG with provided seed or default
 	// If rng_seed is 0, we use a default seed (making it deterministic by default)
 	initial_seed := if cfg.rng_seed != 0 { u32(cfg.rng_seed) } else { u32(123456789) }

--- a/vlib/strings/lorem/lorem_test.v
+++ b/vlib/strings/lorem/lorem_test.v
@@ -1,7 +1,7 @@
-module strings
+module lorem
 
 fn test_lorem_generate_basic() {
-	output := lorum(LoremCfg{
+	output := generate(LoremCfg{
 		paragraphs:              2
 		sentences_per_paragraph: 3
 		words_per_sentence:      5
@@ -16,8 +16,8 @@ fn test_lorem_generate_deterministic() {
 		rng_seed:   12345
 		paragraphs: 1
 	}
-	out1 := lorum(cfg)
-	out2 := lorum(cfg)
+	out1 := generate(cfg)
+	out2 := generate(cfg)
 	assert out1 == out2
 }
 
@@ -25,7 +25,7 @@ fn test_lorem_generate_counts() {
 	cfg := LoremCfg{
 		paragraphs: 3
 	}
-	output := lorum(cfg)
+	output := generate(cfg)
 	// There should be 2 separators for 3 paragraphs
 	assert output.count('\n\n') == 2
 }
@@ -37,7 +37,7 @@ fn test_lorem_custom_corpus() {
 		rng_seed:    999
 		paragraphs:  1
 	}
-	output := lorum(cfg)
+	output := generate(cfg)
 	assert output.len > 0
 	// Hard to check exact content due to randomness, but it should not crash
 }


### PR DESCRIPTION
This PR integrates `lorum` into `vlib/strings`, refining the implementation to be suitable for the standard library.

**Changes:**
- **Removes `rand` dependency:** Implements a simple internal LCG (Linear Congruential Generator) to handle pseudo-randomness. This prevents circular dependencies (e.g., `strings` -> `rand` -> `time`), which is critical for `vlib` core modules.
- **Deterministic by default:** The generator now defaults to a fixed seed if none is provided, ensuring reproducible output for tests and simple calls.
- **Renames API:** Renames `lorem_generate()` to `lorum()` for consistency with the file name and conciseness.
- **Updates Example:** Refactors `examples/lorem.v` to use the new `strings.lorum()` API. The example now handles random seeding explicitly using `rand` and `time` to maintain the expected CLI behavior (random output by default).

**Verification:**
- `v test vlib/strings/lorum_test.v` passes.
- `v run examples/lorem.v` runs successfully and produces varied output.

