### PR TITLE
gg: optimise the ``draw_rounded_rect_filled`` function

### DIFF
--- a/vlib/gg/draw.c.v
+++ b/vlib/gg/draw.c.v
@@ -435,7 +435,7 @@ pub fn (ctx &Context) draw_rounded_rect_empty(x f32, y f32, w f32, h f32, radius
 // `w` is the width, `h` is the height .
 // `radius` is the radius of the corner-rounding in pixels.
 // `c` is the color of the filled.
-// it dive the rounded rectangle into 3 shapes, the top part, the midle and the bottom part.
+// it divides the rounded rectangle into 3 shapes, the top part, the midle and the bottom part.
 pub fn (ctx &Context) draw_rounded_rect_filled(x f32, y f32, w f32, h f32, radius f32, c Color) {
 	if w <= 0 || h <= 0 || radius < 0 {
 		return


### PR DESCRIPTION
This PR aims to optimise the ``draw_rounded_rect_filled`` function by changing how it works:
Now instead of drawing four corner and 3 rectangle, it draw the top part, the middle part using a rectangle and the bottom part

The top and bottom part are drawn as follow:
For each angle, you place a new point on each side, right and left using the ``sgl.begin_triangle_strip()`` primitive