### PR TITLE
ci: add job to tests tools on OpenBSD

### DIFF
--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -181,3 +181,49 @@ jobs:
               echo "### Test tools (-cstrict)"
               ./v -silent -W -cstrict test-self cmd
             fi
+
+  tools-openbsd:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        cc: [tcc, clang]
+      fail-fast: false
+    env:
+      VFLAGS: -cc ${{ matrix.cc }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Tests tools on OpenBSD with ${{ matrix.cc }}
+        uses: cross-platform-actions/action@v0.32.0
+        with:
+          operating_system: openbsd
+          version: '7.8'
+          memory: 4G
+          shell: sh
+          sync_files: runner-to-vm
+          environment_variables: VFLAGS
+          run: |
+            sudo pkg_add git sqlite3 gmake boehm-gc libiconv
+            # Mandatory: hostname not set in VM => some tests fail
+            sudo hostname -s openbsd-ci
+            echo "### OS infos"
+            uname -a
+            git config --global --add safe.directory .
+            # Build V
+            echo "### Build V"
+            printf "VFLAGS = %s\n" "$VFLAGS"
+            gmake && ./v -showcc -o v cmd/v && sudo ./v symlink && ./v doctor
+            # Code in cmd/ is formatted
+            echo "### Check code in cmd/ is formatted"
+            ./v fmt -verify cmd/
+            # Check build-tools
+            echo "### Check build tools"
+            ./v -silent -N -W -check build-tools
+            # Test tools
+            echo "### Test tools"
+            ./v -silent test-self cmd
+            # Test tools (-cstrict)
+            if [ "$VFLAGS" != "-cc tcc" ]; then
+              echo "### Test tools (-cstrict)"
+              ./v -silent -W -cstrict test-self cmd
+            fi


### PR DESCRIPTION
- Use GitHub action [cross-platform-actions/action](https://github.com/cross-platform-actions/action) to run OpenBSD/amd64 7.8 VM
- Tests tools on OpenBSD with `tcc` and `clang`

**Tests OK on OpenBSD in "Tools CI" with tcc and clang** => see this run on my personal repository https://github.com/lcheylus/v/actions/runs/21129303987

