### PR TITLE
ci: add markers between each step in FreeBSD/OpenBSD workflow

### DIFF
--- a/.github/workflows/freebsd_ci.yml
+++ b/.github/workflows/freebsd_ci.yml
@@ -48,6 +48,7 @@ jobs:
             echo "### OS infos"
             uname -a
             git config --global --add safe.directory .
+            echo "### Build V"
             gmake
             sudo ./v symlink
             export VTEST_SHOW_LONGEST_BY_RUNTIME=3
@@ -81,6 +82,7 @@ jobs:
             echo "### OS infos"
             uname -a
             git config --global --add safe.directory .
+            echo "### Build V"
             gmake
             sudo ./v symlink
             export VTEST_SHOW_LONGEST_BY_RUNTIME=3
@@ -114,6 +116,7 @@ jobs:
             echo "### OS infos"
             uname -a
             git config --global --add safe.directory .
+            echo "### Build V"
             gmake
             sudo ./v symlink
             export VTEST_SHOW_LONGEST_BY_RUNTIME=3

--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -46,6 +46,7 @@ jobs:
             echo "### OS infos"
             uname -a
             git config --global --add safe.directory .
+            echo "### Build V"
             gmake
             sudo ./v symlink
             export VTEST_SHOW_LONGEST_BY_RUNTIME=3
@@ -77,6 +78,7 @@ jobs:
             echo "### OS infos"
             uname -a
             git config --global --add safe.directory .
+            echo "### Build V"
             gmake
             sudo ./v symlink
             export VTEST_SHOW_LONGEST_BY_RUNTIME=3

--- a/ci/freebsd_ci.vsh
+++ b/ci/freebsd_ci.vsh
@@ -2,6 +2,7 @@ import os
 import common { Task, exec }
 
 fn v_doctor() {
+	println('### vdoctor')
 	dump(os.getenv('PATH'))
 	exec('v doctor')
 	if common.is_github_job {
@@ -19,6 +20,7 @@ fn v_doctor() {
 }
 
 fn build_v_with_prealloc() {
+	println('### Build v with prealloc')
 	exec('v -cg -cstrict -o vstrict1 cmd/v')
 	exec('./vstrict1 -o vprealloc -prealloc cmd/v')
 	exec('./vprealloc run examples/hello_world.v')
@@ -28,16 +30,19 @@ fn build_v_with_prealloc() {
 }
 
 fn verify_v_test_works() {
+	println('### Verify v test')
 	exec('echo \$VFLAGS')
 	exec('v cmd/tools/test_if_v_test_system_works.v')
 	exec('./cmd/tools/test_if_v_test_system_works')
 }
 
 fn build_fast_script() {
+	println('### Build fast script')
 	exec('cd cmd/tools/fast && v fast.v')
 }
 
 fn check_math() {
+	println('### Test vlib/math')
 	exec('v -silent test vlib/math')
 	println('Test the math module, using only the pure V versions,')
 	println('                          without the .c.v overrides.')
@@ -45,11 +50,13 @@ fn check_math() {
 }
 
 fn check_compress() {
+	println('### Test vlib/compress')
 	exec('v -silent test vlib/compress')
 }
 
 fn run_essential_tests() {
 	if common.is_github_job {
+		println('### Run essential tests')
 		exec('VTEST_JUST_ESSENTIAL=1 v -silent test-self')
 	} else {
 		exec('VTEST_JUST_ESSENTIAL=1 v -progress test-self')
@@ -58,6 +65,7 @@ fn run_essential_tests() {
 
 fn build_examples() {
 	if common.is_github_job {
+		println('### Build examples')
 		exec('v -W build-examples')
 	} else {
 		exec('v -progress build-examples')
@@ -72,7 +80,7 @@ const all_tasks = {
 	'check_math':            Task{check_math, 'Check the `math` module works'}
 	'check_compress':        Task{check_compress, 'Check the `compress` module works'}
 	'run_essential_tests':   Task{run_essential_tests, 'Run only the essential tests'}
-	'build_examples':      Task{build_examples, 'Build examples'}
+	'build_examples':        Task{build_examples, 'Build examples'}
 }
 
 common.run(all_tasks)

--- a/ci/openbsd_ci.vsh
+++ b/ci/openbsd_ci.vsh
@@ -2,6 +2,7 @@ import os
 import common { Task, exec }
 
 fn v_doctor() {
+	println('### vdoctor')
 	dump(os.getenv('PATH'))
 	exec('v doctor')
 	if common.is_github_job {
@@ -19,16 +20,19 @@ fn v_doctor() {
 }
 
 fn verify_v_test_works() {
+	println('### Verify v test')
 	exec('echo \$VFLAGS')
 	exec('v cmd/tools/test_if_v_test_system_works.v')
 	exec('./cmd/tools/test_if_v_test_system_works')
 }
 
 fn build_fast_script() {
+	println('### Build fast script')
 	exec('cd cmd/tools/fast && v fast.v')
 }
 
 fn check_math() {
+	println('### Test vlib/math')
 	exec('v -silent test vlib/math')
 	println('Test the math module, using only the pure V versions,')
 	println('                          without the .c.v overrides.')
@@ -36,11 +40,13 @@ fn check_math() {
 }
 
 fn check_compress() {
+	println('### Test vlib/compress')
 	exec('v -silent test vlib/compress')
 }
 
 fn run_essential_tests() {
 	if common.is_github_job {
+		println('### Run essential tests')
 		exec('VTEST_JUST_ESSENTIAL=1 v -silent test-self')
 	} else {
 		exec('VTEST_JUST_ESSENTIAL=1 v -progress test-self')
@@ -49,6 +55,7 @@ fn run_essential_tests() {
 
 fn build_examples() {
 	if common.is_github_job {
+		println('### Build examples')
 		exec('v -W build-examples')
 	} else {
 		exec('v -progress build-examples')


### PR DESCRIPTION
FreeBSD/OpenBSD workflow uses [cross-platform-actions/action](https://github.com/cross-platform-actions/action) GH action to run VM then build V and run tests via VSH script.

Add markers in workflow/VSH scripts to separate each step => improve search in logs after run.

✅ Run of "CI FreeBSD" with markers https://github.com/lcheylus/v/actions/runs/21130379350
✅ Run of "CI OpenBSD" with markers https://github.com/lcheylus/v/actions/runs/21130379370

