### PR TITLE
vcomplete: add git-fmt-hook command

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -95,6 +95,7 @@ const auto_complete_commands = [
 	'download',
 	'fmt',
 	'gret',
+	'git-fmt-hook',
 	'ls',
 	'retry',
 	'reduce',


### PR DESCRIPTION
Add shell completion to find `v git-fmt-hook` command.

**Tests OK with Bash shell** on OpenBSD and Linux.