### PR TITLE
misc: add micro editor syntax link for V

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ shell/editor after that, so that it can pick up the new PATH variable.
 - [Vim](https://github.com/vlang/awesome-v#vim)
 - [VS Code](https://marketplace.visualstudio.com/items?itemName=VOSCA.vscode-v-analyzer)
 - [zed](https://github.com/lv37/zed-v)
-
+- [micro](https://github.com/marc-dantas/micro-v)
 
 To bring IDE functions for the V programming languages to your editor, check out
 [v-analyzer](https://github.com/vlang/v-analyzer). It provides language server capabilities.


### PR DESCRIPTION
I appreciate this language a lot but I use [Micro](https://micro-editor.github.io/) as my main editor for a lot of my stuff.

So I decided to make my own syntax file for Micro. I did my best to search the docs and find everything that could be highlighted properly. Also searched in other syntax plugins/files for other editors and it seems like mine is proper.