### PR TITLE
gg: opti draw_rounded_rect_filled

### DIFF
--- a/vlib/gg/draw.c.v
+++ b/vlib/gg/draw.c.v
@@ -435,7 +435,7 @@ pub fn (ctx &Context) draw_rounded_rect_empty(x f32, y f32, w f32, h f32, radius
 // `w` is the width, `h` is the height .
 // `radius` is the radius of the corner-rounding in pixels.
 // `c` is the color of the filled.
-// it divides the rounded rectangle into 3 shapes, the top part, the midle and the bottom part.
+// it divides the rounded rectangle into 2 shapes, the top rounded part and the bottom rounded part which are connected at both extremes.
 pub fn (ctx &Context) draw_rounded_rect_filled(x f32, y f32, w f32, h f32, radius f32, c Color) {
 	if w <= 0 || h <= 0 || radius < 0 {
 		return


### PR DESCRIPTION
Another opti for ``draw_rounded_rect_filled``

There is only 2 cases, either there is no radius then you only need to draw a rectangle
Or there is a radius and you can juste draw the to rounded part and then the bottom rounded part with an order that create the inner rectangle automaticaly

Now it only use one ``sgl.begin_`` in both cases