### PR TITLE
gg: add draw_text in gg/testdata

### DIFF
--- a/vlib/gg/testdata/draw_text.vv
+++ b/vlib/gg/testdata/draw_text.vv
@@ -3,7 +3,7 @@ module main
 import gg
 
 gg.start(
-	width:        300
+	width:        640
 	height:       300
 	window_title: 'Circles'
 	frame_fn:     fn (mut ctx gg.Context) {


### PR DESCRIPTION
This PR aims to add a new file in gg/testdata that draw text using ``draw_text`` and by variating some of the fields in the ``gg.TextCfg``

However, I am not sure if the ``bold`` and ``italic`` field have any effect or if I juste don't see it