### PR TITLE
doc: fix link in "Passing C compilation flags" section

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -7967,7 +7967,7 @@ C compilation line, before other libs), use:
 ```
 
 You can (optionally) use different flags for different targets.
-Every OS listed in [Compile time code](#if-condition) is supported as flags.
+Every OS listed in [Compile time code](#compile-time-code) is supported as flags.
 
 > [!NOTE]
 > Each flag must go on its own line (for now)


### PR DESCRIPTION
Fix link after commit d89bb65d7e69cc6289f1b407fc0c6d8228074b8a