### PR TITLE
wasm: add run support with wasm-micro-runtime/iwasm

### DIFF
--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -95,7 +95,7 @@ fn (mut b Builder) run_compiled_executable_and_exit() {
 			panic('Could not find `${node_basename}` in system path. Do you have Node.js installed?')
 		}
 	} else if b.pref.backend == .wasm {
-		mut actual_run := ['wasmer', 'wasmtime', 'wavm', 'wasm3']
+		mut actual_run := ['wasmer', 'wasmtime', 'wavm', 'wasm3', 'iwasm']
 		mut actual_rf := ''
 
 		// -autofree bug
@@ -115,7 +115,7 @@ fn (mut b Builder) run_compiled_executable_and_exit() {
 		}
 
 		if actual_rf == '' {
-			panic('Could not find `wasmer`, `wasmtime`, `wavm`, or `wasm3` in system path. Do you have any installed?')
+			panic('Could not find `wasmer`, `wasmtime`, `wavm`, `wasm3` or `ìwasm` in system path. Do you have any installed?')
 		}
 
 		actual_rf

--- a/vlib/v/gen/wasm/tests/wasm_test.v
+++ b/vlib/v/gen/wasm/tests/wasm_test.v
@@ -6,7 +6,7 @@ const is_verbose = os.getenv('VTEST_SHOW_CMD') != ''
 
 // TODO: some logic copy pasted from valgrind_test.v and compiler_test.v, move to a module
 fn test_wasm() {
-	mut runtimes := ['wasmer', 'wasmtime', 'wavm', 'wasm3']
+	mut runtimes := ['wasmer', 'wasmtime', 'wavm', 'wasm3', 'iwasm']
 	mut runtime_found := false
 
 	for runtime in runtimes {


### PR DESCRIPTION
`v -b wasm run x.v` now works with iwasm from the wasm-micro-runtime.
