### PR TITLE
checker: unset @VCURRENTHASH for build outside of a Git repository

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -167,7 +167,7 @@ pub fn new_checker(table &ast.Table, pref_ &pref.Preferences) &Checker {
 		timers_should_print = true
 	}
 	v_current_commit_hash := if pref_.building_v {
-		version.githash(pref_.vroot) or { vcurrent_hash() }
+		version.githash(pref_.vroot) or { '' }
 	} else {
 		vcurrent_hash()
 	}


### PR DESCRIPTION
When building V outside of a Git repository (e.g. from release sources), `@VCURRENTHASH` is not defined.

Fix vlang/v#26407