### PR TITLE
builtin,strconv: fix zero to string conversion for floats, add tests

### DIFF
--- a/vlib/builtin/float_test.v
+++ b/vlib/builtin/float_test.v
@@ -1,3 +1,5 @@
+import math
+
 fn test_float_decl() {
 	// z := 1f
 	// assert z > 0
@@ -235,4 +237,60 @@ fn test_float_zero_str() {
 	assert '${f1}' == '0.0'
 	assert f2.str() == '0.0'
 	assert '${f2}' == '0.0'
+}
+
+fn test_f32_zero_chars() {
+	bits := math.f32_bits('-0.0'.f32())
+	assert math.f32_bits('-0 ms'.f32()) == bits
+	assert math.f32_bits('-0.0 ms'.f32()) == bits
+	assert math.f32_bits('-0.000 ms'.f32()) == bits
+	assert math.f32_bits('0 ms'.f32()) == 0
+	assert math.f32_bits('0.0 ms'.f32()) == 0
+	assert math.f32_bits('0.000 ms'.f32()) == 0
+	assert math.f32_bits('-0'.f32()) == bits
+	assert math.f32_bits('-0.0'.f32()) == bits
+	assert math.f32_bits('-0.000'.f32()) == bits
+	assert math.f32_bits('0'.f32()) == 0
+	assert math.f32_bits('0.0'.f32()) == 0
+	assert math.f32_bits('0.000'.f32()) == 0
+	assert '-0 ms'.f32().str() == '-0.0'
+	assert '-0.0 ms'.f32().str() == '-0.0'
+	assert '-0.000 ms'.f32().str() == '-0.0'
+	assert '0 ms'.f32().str() == '0.0'
+	assert '0.0 ms'.f32().str() == '0.0'
+	assert '0.000 ms'.f32().str() == '0.0'
+	assert '-0'.f32().str() == '-0.0'
+	assert '-0.0'.f32().str() == '-0.0'
+	assert '-0.000'.f32().str() == '-0.0'
+	assert '0'.f32().str() == '0.0'
+	assert '0.0'.f32().str() == '0.0'
+	assert '0.00'.f32().str() == '0.0'
+}
+
+fn test_f64_zero_chars() {
+	bits := math.f64_bits('-0.0'.f64())
+	assert math.f64_bits('-0 ms'.f64()) == bits
+	assert math.f64_bits('-0.0 ms'.f64()) == bits
+	assert math.f64_bits('-0.000 ms'.f64()) == bits
+	assert math.f64_bits('0 ms'.f64()) == 0
+	assert math.f64_bits('0.0 ms'.f64()) == 0
+	assert math.f64_bits('0.000 ms'.f64()) == 0
+	assert math.f64_bits('-0'.f64()) == bits
+	assert math.f64_bits('-0.0'.f64()) == bits
+	assert math.f64_bits('-0.000'.f64()) == bits
+	assert math.f64_bits('0'.f64()) == 0
+	assert math.f64_bits('0.0'.f64()) == 0
+	assert math.f64_bits('0.000'.f64()) == 0
+	assert '-0 ms'.f64().str() == '-0.0'
+	assert '-0.0 ms'.f64().str() == '-0.0'
+	assert '-0.000 ms'.f64().str() == '-0.0'
+	assert '0 ms'.f64().str() == '0.0'
+	assert '0.0 ms'.f64().str() == '0.0'
+	assert '0.000 ms'.f64().str() == '0.0'
+	assert '-0'.f64().str() == '-0.0'
+	assert '-0.0'.f64().str() == '-0.0'
+	assert '-0.000'.f64().str() == '-0.0'
+	assert '0'.f64().str() == '0.0'
+	assert '0.0'.f64().str() == '0.0'
+	assert '0.00'.f64().str() == '0.0'
 }

--- a/vlib/strconv/atof.c.v
+++ b/vlib/strconv/atof.c.v
@@ -247,6 +247,9 @@ fn converter(mut pn PrepNumber) u64 {
 	s0 = u32(pn.mantissa & u64(0x00000000FFFFFFFF))
 	s1 = u32(pn.mantissa >> 32)
 	s2 = u32(0)
+	if pn.mantissa == 0 && pn.exponent <= 0 {
+		return if pn.negative { double_minus_zero } else { double_plus_zero }
+	}
 	// so we take the decimal exponent off
 	for pn.exponent > 0 {
 		q2, q1, q0 = lsl96(s2, s1, s0) // q = s * 2


### PR DESCRIPTION
This PR fixes two issues:
1. complete conversion freeze for zero(s) value with additional characters, fixes #26429
2. while testing first problem with zeros found another problem - `'-0'.f64() != '-0 ms'.f64()`

In addition to adding tests for complete coverage of all possible combinations with zeros, I generated `100M+` numbers through Python and checked the operation of different types of conversion to and from float and string.

I would be glad if someone joins the testing of this PR.
