### PR TITLE
cgen: fix unused functions returning fixed arrays of custom structs

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2029,6 +2029,13 @@ pub fn (mut g Gen) write_array_fixed_return_types() {
 			// unresolved sizes e.g. [unknown_const]int
 			continue
 		}
+		// Skip if element type is a non-builtin struct that isn't marked as used
+		// This prevents generating wrapper structs that reference undefined types
+		elem_sym := g.table.sym(info.elem_type)
+		if g.pref.skip_unused && elem_sym.kind == .struct && !elem_sym.is_builtin()
+			&& elem_sym.idx !in g.table.used_features.used_syms {
+			continue
+		}
 		mut fixed_elem_name := g.styp(info.elem_type.set_nr_muls(0))
 		if info.elem_type.is_ptr() {
 			fixed_elem_name += '*'.repeat(info.elem_type.nr_muls())

--- a/vlib/v/tests/fns/unused_fn_fixed_array_ret_test.v
+++ b/vlib/v/tests/fns/unused_fn_fixed_array_ret_test.v
@@ -1,0 +1,37 @@
+// Test that unused functions returning fixed arrays of custom structs
+// don't cause C compilation errors when skip_unused is enabled.
+// Related to: functions returning [N]CustomStruct where the function is never called.
+
+struct QuadVertex {
+	pos [2]f32
+	uv  [2]f32
+}
+
+// This function is intentionally never called - it tests that skip_unused
+// correctly handles fn_ret ArrayFixed types with custom struct elements.
+pub fn make_quad_vertices(x f32, y f32, w f32, h f32) [4]QuadVertex {
+	return [
+		QuadVertex{
+			pos: [x, y]!
+			uv:  [f32(0), 0]!
+		},
+		QuadVertex{
+			pos: [x + w, y]!
+			uv:  [f32(1), 0]!
+		},
+		QuadVertex{
+			pos: [x + w, y + h]!
+			uv:  [f32(1), 1]!
+		},
+		QuadVertex{
+			pos: [x, y + h]!
+			uv:  [f32(0), 1]!
+		},
+	]!
+}
+
+fn test_unused_fn_fixed_array_ret() {
+	// The test passes if compilation succeeds.
+	// make_quad_vertices is intentionally not called.
+	assert true
+}


### PR DESCRIPTION
## Summary

Fix C compilation error when unused functions return fixed arrays of custom structs.

Fixes #26439

## Changes

- Skip generating fn_ret wrapper structs when the element type is a non-builtin struct that isn't marked as used
- Add test case for the fix

## Problem

When `skip_unused` is enabled, functions returning `[N]CustomStruct` that are never called cause C compilation errors:

```
error: ';' expected (got "main__QuadVertex")
```

The wrapper struct (`_v_Array_fixed_main__QuadVertex_4`) was generated, but the element type (`main__QuadVertex`) was not, because `skip_unused` determined it was unused.

## Solution

In `write_array_fixed_return_types()`, skip generating the wrapper struct if its element type is an unused custom struct:

```v
elem_sym := g.table.sym(info.elem_type)
if g.pref.skip_unused && elem_sym.kind == .struct && !elem_sym.is_builtin()
    && elem_sym.idx !in g.table.used_features.used_syms {
    continue
}
```

## Test plan

- [x] Added `vlib/v/tests/fns/unused_fn_fixed_array_ret_test.v`
- [x] Verified test fails without fix, passes with fix
- [x] `v test vlib/v/tests/fns/` passes (146/146)
