### PR TITLE
cgen: fix or-block with fixed array constants with GCC 15.2

### DIFF
--- a/vlib/v/tests/options/option_fixed_arr_const_test.v
+++ b/vlib/v/tests/options/option_fixed_arr_const_test.v
@@ -1,0 +1,20 @@
+// Test for or-block returning a fixed array constant.
+// Regression test for issue where cgen generated invalid C cast to array type.
+const default_arr = [f32(1.0), 2.0, 3.0, 4.0]!
+
+fn get_arr(key string) ?[4]f32 {
+	if key == 'valid' {
+		return [f32(0.1), 0.2, 0.3, 0.4]!
+	}
+	return none
+}
+
+fn test_or_block_with_fixed_array_const() {
+	result := get_arr('invalid') or { default_arr }
+	assert result == default_arr
+}
+
+fn test_or_block_with_valid_key() {
+	result := get_arr('valid') or { default_arr }
+	assert result == [f32(0.1), 0.2, 0.3, 0.4]!
+}


### PR DESCRIPTION
  Fix invalid C cast when or-block returns a fixed array constant/variable with GCC 15.2.                                                                                                                                                                   
                                                                                                                                                                                                                                                
  Fixes #26442                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                
  Changes                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                
  - Only use compound literal cast for brace-enclosed initializers (ArrayInit, StructInit), not for constants/variables                                                                                                                         
  - Add test case for or-block with fixed array constant                                                                                                                                                                                        
                                                                                                                                                                                                                                                
  Test plan                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                
  - v -cc gcc vlib/v/tests/options/option_fixed_arr_const_test.v passes                                                                                                                                                                         
  - Verified test fails on master, passes with fix 