### PR TITLE
builtin: fix compilation with tcc on OpenBSD using libgc

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -93,6 +93,7 @@ $if dynamic_boehm ? {
 			#flag @VEXEROOT/thirdparty/libgc/gc.o
 		}
 		$if tinyc {
+			#flag -L/usr/local/lib
 			#flag -I/usr/local/include
 			#flag $first_existing("/usr/local/lib/libgc.a", "/usr/lib/libgc.a")
 			#flag -lgc


### PR DESCRIPTION
Add `#flag` to find `libgc` in `/usr/local/lib/` on OpenBSD with `tcc` compiler.

Fix vlang/v#26447

---

**Tests OK** for `vlib/v/slow_tests/assembly/asm_test.amd64.v` on OpenBSD with tcc  compiler
```sh
$ ./v -stats test vlib/v/slow_tests/assembly/asm_test.amd64.v
---- Testing... ----
        V  source  code size:      31893 lines,     145791 tokens,     864019 bytes,   323 types,    14 modules,   151 files
generated  target  code size:       9700 lines,     360911 bytes
compilation took: 1411.998 ms, compilation speed: 22587 vlines/s, cgen threads: 3
running tests in: /home/fox/dev/vlang.git/vlib/v/slow_tests/assembly/asm_test.amd64.v
      OK    [1/6]     0.043 ms    13 asserts | main.test_inline_asm()
      OK    [2/6]     0.006 ms     1 assert  | main.test_rip_relative_label()
      OK    [3/6]     0.000 ms     1 assert  | main.test_rip_relative_label_u8()
      OK    [4/6]     0.001 ms     5 asserts | main.test_flag_output()
      OK    [5/6]     0.001 ms     4 asserts | main.test_asm_generic()
      OK    [6/6]     0.000 ms     2 asserts | main.test_lock_prefix()
     Summary for running V tests in "asm_test.amd64.v": 26 passed, 26 total. Elapsed time: 0 ms.

 OK    1472.203 ms vlib/v/slow_tests/assembly/asm_test.amd64.v
----
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 1475 ms, on 1 job. Comptime: 0 ms. Runtime: 1472 ms.
```

**All tests OK**  for `vlib/v/slow_tests/assembly/` on OpenBSD/amd64 with tcc  compiler
```sh
$ ./v test vlib/v/slow_tests/assembly/
---- Testing... ----
 SKIP  [ 1/11] C:     0.0 ms, R:     0.000 ms vlib/v/slow_tests/assembly/asm_test.arm64.v
 SKIP  [ 2/11] C:     0.0 ms, R:     0.000 ms vlib/v/slow_tests/assembly/asm_test.i386.v
 SKIP  [ 3/11] C:     0.0 ms, R:     0.000 ms vlib/v/slow_tests/assembly/asm_test.loongarch64.v
 SKIP  [ 4/11] C:     0.0 ms, R:     0.000 ms vlib/v/slow_tests/assembly/asm_test.ppc64le.v
 SKIP  [ 5/11] C:     0.0 ms, R:     0.000 ms vlib/v/slow_tests/assembly/asm_test.rv64.v
 SKIP  [ 6/11] C:     0.0 ms, R:     0.000 ms vlib/v/slow_tests/assembly/asm_test.s390x.v
 SKIP  [ 7/11] C:     0.0 ms, R:     0.000 ms vlib/v/slow_tests/assembly/naked_attr_test.amd64.v
 SKIP  [ 8/11] C:     0.0 ms, R:     0.000 ms vlib/v/slow_tests/assembly/naked_attr_test.i386.v
 OK    [ 9/11] C:   821.1 ms, R:    12.094 ms vlib/v/slow_tests/assembly/asm_empty_statement_test.v
 OK    [10/11] C:  1565.8 ms, R:     6.462 ms vlib/v/slow_tests/assembly/asm_test.amd64.v
 OK    [11/11] C:   864.2 ms, R:  1451.974 ms vlib/v/slow_tests/assembly/stmt_separator_test.amd64.v
----
Summary for all V _test.v files: 3 passed, 8 skipped, 11 total. Elapsed time: 2367 ms, on 3 parallel jobs. Comptime: 3251 ms. Runtime: 1470 ms.
```
