### PR TITLE
v.builder: add -stats for top level statements and non-vlib top level statements

### DIFF
--- a/vlib/v/builder/rebuilding.v
+++ b/vlib/v/builder/rebuilding.v
@@ -336,7 +336,8 @@ pub fn (mut b Builder) rebuild(backend_cb FnBackend) {
 	if b.pref.is_stats {
 		compilation_time_micros := 1 + sw.elapsed().microseconds()
 		scompilation_time_ms := util.bold('${f64(compilation_time_micros) / 1000.0:6.3f}')
-		mut all_v_source_lines, mut all_v_source_bytes, mut all_v_source_tokens, mut all_v_top_stmts, mut all_non_vlib_top_stmts := 0, 0, 0, 0, 0
+		mut all_v_source_lines, mut all_v_source_bytes, mut all_v_source_tokens := 0, 0, 0
+		mut all_v_top_stmts, mut all_non_vlib_top_stmts, mut all_main_top_stmts := 0, 0, 0
 		for pf in b.parsed_files {
 			all_v_source_lines += pf.nr_lines
 			all_v_source_bytes += pf.nr_bytes
@@ -345,9 +346,13 @@ pub fn (mut b Builder) rebuild(backend_cb FnBackend) {
 			if !pf.path.contains('vlib/') {
 				all_non_vlib_top_stmts += pf.stmts.len
 			}
+			if pf.mod.name == 'main' {
+				all_main_top_stmts += pf.stmts.len
+			}
 		}
 		mut sall_top_stmts := all_v_top_stmts.str()
 		mut sall_non_vlib_top_stmts := all_non_vlib_top_stmts.str()
+		mut sall_main_top_stmts := all_main_top_stmts.str()
 		mut sall_v_source_lines := all_v_source_lines.str()
 		mut sall_v_source_bytes := all_v_source_bytes.str()
 		mut sall_v_source_tokens := all_v_source_tokens.str()
@@ -362,7 +367,8 @@ pub fn (mut b Builder) rebuild(backend_cb FnBackend) {
 		sall_v_files = util.bold('${sall_v_files:5s}')
 		sall_top_stmts = util.bold('${sall_top_stmts:5s}')
 		sall_non_vlib_top_stmts = util.bold('${sall_non_vlib_top_stmts:5s}')
-		println('        V  source  code size: ${sall_v_source_lines} lines, ${sall_v_source_tokens} tokens, ${sall_v_source_bytes} bytes, ${sall_v_types} types, ${sall_v_modules} modules, ${sall_v_files} files, ${sall_top_stmts} tl_stmts, ${sall_non_vlib_top_stmts} non_vlib_tl_stmts')
+		sall_main_top_stmts = util.bold('${sall_main_top_stmts:5s}')
+		println('        V  source  code size: ${sall_v_source_lines} lines, ${sall_v_source_tokens} tokens, ${sall_v_source_bytes} bytes, ${sall_v_types} types, ${sall_v_modules} modules, ${sall_v_files} files, ${sall_top_stmts} tl_stmts, ${sall_non_vlib_top_stmts} non_vlib_tl_stmts, ${sall_main_top_stmts} main_tl_stmts')
 		//
 		mut slines := b.stats_lines.str()
 		mut sbytes := b.stats_bytes.str()


### PR DESCRIPTION
Some more stats for the examples and V itself (on macos):
<img width="1841" height="1570" alt="image" src="https://github.com/user-attachments/assets/667691d8-2fa5-496d-bda7-907831eaa24e" />
