### PR TITLE
ci: add -std=c99 to vtest-all.v to fix GCC 15 / C23 bool conflict

### DIFF
--- a/cmd/tools/vtest-all.v
+++ b/cmd/tools/vtest-all.v
@@ -389,7 +389,7 @@ fn get_all_commands() []Command {
 	}
 	$if macos || linux {
 		res << Command{
-			line:   '${vexe} -o v.c cmd/v && cc -Werror v.c -lpthread -lm && rm -rf a.out'
+			line:   '${vexe} -o v.c cmd/v && cc -Werror -std=c99 v.c -lpthread -lm && rm -rf a.out'
 			label:  'v.c should be buildable with no warnings...'
 			okmsg:  'v.c can be compiled without warnings. This is good :)'
 			rmfile: 'v.c'


### PR DESCRIPTION
GCC 15 defaults to C23, where `bool`, `true`, and `false` are keywords. This conflicts with V's `typedef u8 bool` in cheaders.v.

Adding `-std=c99` to the cc command ensures the generated v.c compiles without warnings on systems with GCC 15+.

ref #25805