### PR TITLE
ci: add task to test inline Assembly on FreeBSD and OpenBSD

### DIFF
--- a/ci/freebsd_ci.vsh
+++ b/ci/freebsd_ci.vsh
@@ -49,6 +49,11 @@ fn check_math() {
 	exec('v -silent -exclude @vlib/math/*.c.v test vlib/math')
 }
 
+fn test_inline_assembly() {
+	println('### Test inline Assembly')
+	exec('v test vlib/v/slow_tests/assembly')
+}
+
 fn check_compress() {
 	println('### Test vlib/compress')
 	exec('v -silent test vlib/compress')
@@ -79,6 +84,7 @@ const all_tasks = {
 	'build_fast_script':     Task{build_fast_script, 'Check that building fast.v works'}
 	'check_math':            Task{check_math, 'Check the `math` module works'}
 	'check_compress':        Task{check_compress, 'Check the `compress` module works'}
+	'test_inline_assembly':  Task{test_inline_assembly, 'Test inline Assembly'}
 	'run_essential_tests':   Task{run_essential_tests, 'Run only the essential tests'}
 	'build_examples':        Task{build_examples, 'Build examples'}
 }

--- a/ci/openbsd_ci.vsh
+++ b/ci/openbsd_ci.vsh
@@ -54,6 +54,11 @@ fn check_compress() {
 	exec('v -silent test vlib/compress')
 }
 
+fn test_inline_assembly() {
+	println('### Test inline Assembly')
+	exec('v test vlib/v/slow_tests/assembly')
+}
+
 fn run_essential_tests() {
 	if common.is_github_job {
 		println('### Run essential tests')
@@ -79,6 +84,7 @@ const all_tasks = {
 	'build_fast_script':     Task{build_fast_script, 'Check that building fast.v works'}
 	'check_math':            Task{check_math, 'Check the `math` module works'}
 	'check_compress':        Task{check_compress, 'Check the `compress` module works'}
+	'test_inline_assembly':  Task{test_inline_assembly, 'Test inline Assembly'}
 	'run_essential_tests':   Task{run_essential_tests, 'Run only the essential tests'}
 	'build_examples':        Task{build_examples, 'Build examples'}
 }


### PR DESCRIPTION
Following commit 8cc9433f9f478b4665b5e86fd31d6b72ef535ee3, add also a task in CI to test inline Assembly on FreeBSD/amd64 and OpenBSD/amd64 with `v test vlib/v/slow_tests/assembly` command.

✅ Run on FreeBSD 15 (amd64) with `tcc`, `clang` and `gcc` compiler => all tests for inline Assembly are OK
https://github.com/lcheylus/v/actions/runs/21388773145

⚠️ For now, "FreeBSD CI" fails with `clang` compiler since commit f665055f41169c8523aa258923ca9154b25d146e (ongoing work for SSA) => same errors with "FreeBSD CI" on master. **Not related to this PR**.

✅ Run on OpenBSD 7.8 (amd64) with `tcc` and `clang` compiler => all tests for inline Assembly are OK
https://github.com/lcheylus/v/actions/runs/21388880906
