### PR TITLE
Void Linux with musl error cc: tcc: error: undefined symbol '__atomic_thread_fence' #26449

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -273,13 +273,8 @@ pub fn parse_args(known_external_commands []string, args []string) (&Preferences
 fn detect_musl(mut res Preferences) {
 	res.is_glibc = true
 	res.is_musl = false
-	if os.exists('/etc/alpine-release') {
-		res.is_musl = true
-		res.is_glibc = false
-		return
-	}
-	my_libs := os.walk_ext('/proc/self/map_files/', '').map(os.real_path(it))
-	if my_libs.any(it.contains('musl')) {
+	musl := os.execute('ldd --version').contains('musl') or { false }
+	if musl {
 		res.is_musl = true
 		res.is_glibc = false
 	}


### PR DESCRIPTION

Detect musl on any nix system, not just alpine

https://github.com/vlang/v/issues/26449