### PR TITLE
crypto.blake3: add @[direct_array_access] and improve f() performance

### DIFF
--- a/vlib/crypto/blake3/blake3.v
+++ b/vlib/crypto/blake3/blake3.v
@@ -137,7 +137,7 @@ pub fn Digest.new_hash() !Digest {
 // Digest.new_keyed_hash initializes a Digest structure for a Blake3 keyed hash
 pub fn Digest.new_keyed_hash(key []u8) !Digest {
 	// treat the key bytes as little endian u32 values
-	mut key_words := []u32{len: 8, cap: 8}
+	mut key_words := []u32{len: 8}
 	for i in 0 .. 8 {
 		key_words[i] = binary.little_endian_u32_at(key, i * 4)
 	}
@@ -153,7 +153,7 @@ pub fn Digest.new_derive_key_hash(context []u8) !Digest {
 	context_key := context_digest.checksum_internal(key_length)
 
 	// treat the context key bytes as little endian u32 values
-	mut key_words := []u32{len: 8, cap: 8}
+	mut key_words := []u32{len: 8}
 	for i in 0 .. 8 {
 		key_words[i] = binary.little_endian_u32_at(context_key, i * 4)
 	}
@@ -309,6 +309,7 @@ fn root_output_bytes(state HashState, size u64) []u8 {
 	return output
 }
 
+@[direct_array_access]
 fn (mut d Digest) add_node(node Node, level u8) {
 	// if we are above the highst level,
 	// just add the node at the top

--- a/vlib/crypto/blake3/blake3_chunk.v
+++ b/vlib/crypto/blake3/blake3_chunk.v
@@ -50,6 +50,7 @@ fn (c Chunk) str() string {
 //
 // As a potential speed up, we could try spawning this function
 // in a concurrent task and see if it is worth the overhead.
+@[direct_array_access]
 fn (mut c Chunk) process_input(input []u8, key_words []u32, counter u64, flags u32, root bool) []u32 {
 	mut remaining_input := unsafe { input[..] }
 
@@ -63,7 +64,7 @@ fn (mut c Chunk) process_input(input []u8, key_words []u32, counter u64, flags u
 
 	c.chunk_number = counter
 	c.chaining_value = key_words.clone()
-	c.block_words = []u32{len: 16, cap: 16, init: 0}
+	c.block_words = []u32{len: 16}
 
 	for i in 0 .. 16 {
 		c.block_len = u32(block_size)


### PR DESCRIPTION
All this contributes to increased productivity:

1. added `@[direct_array_access]`
2. changed `v` initialization in `f()`
3. cleaned up arrays initialization

My test code:
```v
import crypto.blake3
import time

fn main() {
	a := []u8{len: 10_000_000}
	t1 := time.now()
	_ := blake3.sum256(a)
	println(time.since(t1))
}
```

`master`:
```
v run blake3.v && v -prod blake3.v && ./blake3 
2.560s
412.975ms
```
`patch`:
```
v run blake3.v && v -prod blake3.v && ./blake3 
364.457ms
26.691ms
```

On my cheap laptop:
```
tcc: ~6.9x
gcc: ~16x
```