### PR TITLE
ci: refactor $str to ${str} across entire repository

### DIFF
--- a/.github/workflows/android_cross_compile.vsh
+++ b/.github/workflows/android_cross_compile.vsh
@@ -24,8 +24,8 @@ fn main() {
 	include_path := os.join_path(sysroot_path, 'usr', 'include')
 	android_include_path := os.join_path(include_path, 'android')
 
-	//'-I"$include_path"'
-	cflags := ['-I"$android_include_path"', '-Wno-unused-value', '-Wno-implicit-function-declaration',
+	//'-I"${include_path}"'
+	cflags := ['-I"${android_include_path}"', '-Wno-unused-value', '-Wno-implicit-function-declaration',
 		'-Wno-int-conversion']
 	for arch in ndk.supported_archs {
 		for level in ['min', 'max'] {
@@ -46,22 +46,22 @@ fn main() {
 			o_file := os.join_path(work_dir, arch + '-' + level + '.o')
 
 			// x.v -> x.c
-			v_compile_cmd := '$vexe -o $c_file -os android -gc none $v_example'
+			v_compile_cmd := '${vexe} -o ${c_file} -os android -gc none ${v_example}'
 			vres := os.execute(v_compile_cmd)
 			if vres.exit_code != 0 {
-				panic('"$v_compile_cmd" failed: $vres.output')
+				panic('"${v_compile_cmd}" failed: ${vres.output}')
 			}
 			assert os.exists(c_file)
 
 			// x.c -> x.o
-			compile_cmd := '$compiler_api ${cflags.join(' ')} -c $c_file -o $o_file'
+			compile_cmd := '${compiler_api} ${cflags.join(' ')} -c ${c_file} -o ${o_file}'
 			cres := os.execute(compile_cmd)
 			if cres.exit_code != 0 {
-				panic('"$compile_cmd" failed: $cres.output')
+				panic('"${compile_cmd}" failed: ${cres.output}')
 			}
 			assert os.exists(o_file)
 			compiler_exe_name := os.file_name(compiler_api)
-			println('Compiled examples/toml.v successfully for ($level) $arch $compiler_exe_name')
+			println('Compiled examples/toml.v successfully for (${level}) ${arch} ${compiler_exe_name}')
 		}
 	}
 }


### PR DESCRIPTION
Part of https://github.com/vlang/v/issues/26382

The regex I have used to search for strings is
```
(?<!\\)\$(?!if\b|for\b|else\b|match\b|pointer\b|voidptr\b|tmpl\b|array\b|array_dynamic\b|array_fixed\b|function\b|shared\b|interface\b|enum\b|int\b|string\b|struct\b|map\b|option\b|float\b|sumtype\b|alias\b|pointer\b|voidptr\b)(\w+\.?\w{0,})
```
(Dollar sign _not_ preceded by `\`, then _not_ succeeded by comptime keywords. Select any word character after the dollar sign)