### PR TITLE
bench: refactor old string interpolation to new string interpolation for bench_euclid.v

### DIFF
--- a/vlib/v/tests/bench/math_big_gcd/bench_euclid.v
+++ b/vlib/v/tests/bench/math_big_gcd/bench_euclid.v
@@ -93,7 +93,7 @@ fn main() {
 		bench_euclid_vs_binary(prime_cfg, false, predicate_fn, mut clocks)
 
 		// just-to-be-sure, but makes no difference in this test.
-		// println('\n#-${i + 1}(Heap) "$prime_cfg"')
+		// println('\n#-${i + 1}(Heap) "${prime_cfg}"')
 		// bench_euclid_vs_binary(prime_cfg, true,  predicate_fn, mut clocks)
 	}
 	println('')


### PR DESCRIPTION
Part of https://github.com/vlang/v/issues/26382

The regex I have used to search for strings is
```
(?<!\\)\$(?!if\b|for\b|else\b|match\b|pointer\b|voidptr\b|tmpl\b|array\b|array_dynamic\b|array_fixed\b|function\b|shared\b|interface\b|enum\b|int\b|string\b|struct\b|map\b|option\b|float\b|sumtype\b|alias\b|pointer\b|voidptr\b)(\w+\.?\w{0,})
```
(Dollar sign _not_ preceded by `\`, then _not_ succeeded by comptime keywords. Select any word character after the dollar sign)