### PR TITLE
fast.v: refactor old string interpolation with new string interpolation

### DIFF
--- a/cmd/tools/fast/fast.v
+++ b/cmd/tools/fast/fast.v
@@ -123,7 +123,7 @@ fn main() {
 	// measure
 	diff1 := measure('${vdir}/vprod ${voptions} -o v.c cmd/v', 'v.c')
 	diff2 := measure('${vdir}/vprod ${voptions} -cc ${ccompiler_path} -o v2 cmd/v', 'v2')
-	diff3 := 0 // measure('$vdir/vprod -native $vdir/cmd/tools/1mil.v', 'native 1mil')
+	diff3 := 0 // measure('${vdir}/vprod -native ${vdir}/cmd/tools/1mil.v', 'native 1mil')
 	diff4 := measure('${vdir}/vprod ${voptions} -cc ${ccompiler_path} examples/hello_world.v',
 		'hello.v')
 	vc_size := os.file_size('v.c') / 1000


### PR DESCRIPTION
Part of https://github.com/vlang/v/issues/26382

The regex I have used to search for strings is
```
(?<!\\)\$(?!if\b|for\b|else\b|match\b|pointer\b|voidptr\b|tmpl\b|array\b|array_dynamic\b|array_fixed\b|function\b|shared\b|interface\b|enum\b|int\b|string\b|struct\b|map\b|option\b|float\b|sumtype\b|alias\b|pointer\b|voidptr\b)(\w+\.?\w{0,})
```
(Dollar sign _not_ preceded by `\`, then _not_ succeeded by comptime keywords. Select any word character after the dollar sign)