### PR TITLE
vvet/tests: refactor old string interpolation with new string interpolation for indent_with_space.vv

### DIFF
--- a/cmd/tools/vvet/tests/indent_with_space.vv
+++ b/cmd/tools/vvet/tests/indent_with_space.vv
@@ -19,6 +19,6 @@ fn space_inside_strings() {
   Here too."
   str2 := 'linebreak and space\n  inside'
 	// String interpolation
-  si1 := 'Error here $foo
+  si1 := 'Error here ${foo}
   and not here'
 }


### PR DESCRIPTION
Part of https://github.com/vlang/v/issues/26382

The regex I have used to search for strings is
```
(?<!\\)\$(?!if\b|for\b|else\b|match\b|pointer\b|voidptr\b|tmpl\b|array\b|array_dynamic\b|array_fixed\b|function\b|shared\b|interface\b|enum\b|int\b|string\b|struct\b|map\b|option\b|float\b|sumtype\b|alias\b|pointer\b|voidptr\b)(\w+\.?\w{0,})
```
(Dollar sign _not_ preceded by `\`, then _not_ succeeded by comptime keywords. Select any word character after the dollar sign)