### PR TITLE
net.http: split tests for HTTP/HTTPS requests

### DIFF
--- a/vlib/net/http/http_test.v
+++ b/vlib/net/http/http_test.v
@@ -1,42 +1,67 @@
 import net.http
 
-fn test_http_get() {
+fn test_https_get() {
 	$if !network ? {
 		return
 	}
 	assert http.get_text('https://vlang.io/version') == '0.1.5'
-	println('http ok')
+	println('https ok')
 }
 
 fn test_http_get_from_vlang_utc_now() {
 	$if !network ? {
 		return
 	}
-	urls := ['http://vlang.io/utc_now', 'https://vlang.io/utc_now']
-	for url in urls {
-		println('Test getting current time from ${url} by http.get')
-		res := http.get(url) or { panic(err) }
-		assert res.status() == .ok
-		assert res.body != ''
-		assert res.body.int() > 1566403696
-		println('Current time is: ${res.body.int()}')
-	}
+	url := 'http://vlang.io/utc_now'
+	println('Test getting current time from HTTP ${url} by http.get')
+	res := http.get(url) or { panic(err) }
+	assert res.status() == .ok
+	assert res.body != ''
+	assert res.body.int() > 1566403696
+	println('Current time is: ${res.body.int()}')
 }
 
-fn test_public_servers() {
+fn test_https_get_from_vlang_utc_now() {
+	$if !network ? {
+		return
+	}
+	url := 'https://vlang.io/utc_now'
+	println('Test getting current time from HTTPS ${url} by http.get')
+	res := http.get(url) or { panic(err) }
+	assert res.status() == .ok
+	assert res.body != ''
+	assert res.body.int() > 1566403696
+	println('Current time is: ${res.body.int()}')
+}
+
+fn test_http_public_servers() {
 	$if !network ? {
 		return
 	}
 	urls := [
 		'http://github.com/robots.txt',
 		'http://google.com/robots.txt',
+		// 'http://yahoo.com/robots.txt',
+	]
+	for url in urls {
+		println('Testing http.get on public HTTP url: ${url} ')
+		res := http.get(url) or { panic(err) }
+		assert res.status() == .ok
+		assert res.body != ''
+	}
+}
+
+fn test_https_public_servers() {
+	$if !network ? {
+		return
+	}
+	urls := [
 		'https://github.com/robots.txt',
 		'https://google.com/robots.txt',
-		// 'http://yahoo.com/robots.txt',
 		// 'https://yahoo.com/robots.txt',
 	]
 	for url in urls {
-		println('Testing http.get on public url: ${url} ')
+		println('Testing http.get on public HTTPS url: ${url} ')
 		res := http.get(url) or { panic(err) }
 		assert res.status() == .ok
 		assert res.body != ''


### PR DESCRIPTION
During the analysis of the issue #26398, I wanted to run tests in `vlib/net/http/http_test.v` separately for HTTP and HTTPS requests => proposal to split those tests for HTTP/HTTPS requests.

**Tests OK** on Linux/amd64 with `tcc` and `clang` compiler
```sh
$ ./v -d network -stats test vlib/net/http/http_test.v
---- Testing... ----
        V  source  code size:      45392 lines,     208303 tokens,    1266906 bytes,   528 types,    33 modules,   242 files,  3761 tl_stmts,     0 non_vlib_tl_stmts,    48 main_tl_stmts
generated  target  code size:      18998 lines,     730139 bytes
compilation took: 568.096 ms, compilation speed: 79901 vlines/s, cgen threads: 7
running tests in: /home/fox/dev/Perso/vlang.git/vlib/net/http/http_test.v
https ok
      OK    [1/6]   317.992 ms     1 assert  | main.test_https_get()
Test getting current time from HTTP http://vlang.io/utc_now by http.get
Current time is: 1770051605
      OK    [2/6]   408.813 ms     3 asserts | main.test_http_get_from_vlang_utc_now()
Test getting current time from HTTPS https://vlang.io/utc_now by http.get
Current time is: 1770051605
      OK    [3/6]   278.662 ms     3 asserts | main.test_https_get_from_vlang_utc_now()
Testing http.get on public HTTP url: http://github.com/robots.txt
Testing http.get on public HTTP url: http://google.com/robots.txt
      OK    [4/6]   705.349 ms     4 asserts | main.test_http_public_servers()
Testing http.get on public HTTPS url: https://github.com/robots.txt
Testing http.get on public HTTPS url: https://google.com/robots.txt
      OK    [5/6]   750.595 ms     4 asserts | main.test_https_public_servers()
      OK    [6/6]     0.000 ms    NO asserts | main.test_relative_redirects()
     Summary for running V tests in "http_test.v": 15 passed, 15 total. Elapsed time: 2461 ms.

 OK    3049.127 ms vlib/net/http/http_test.v
----
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 3050 ms, on 1 job. Comptime: 0 ms. Runtime: 3049 ms.
```