### PR TITLE
crypto.rc4: add @[direct_array_access]

### DIFF
--- a/vlib/crypto/rc4/rc4.v
+++ b/vlib/crypto/rc4/rc4.v
@@ -31,6 +31,7 @@ pub fn (mut c Cipher) free() {
 
 // new_cipher creates and returns a new Cipher. The key argument should be the
 // RC4 key, at least 1 byte and at most 256 bytes.
+@[direct_array_access]
 pub fn new_cipher(key []u8) !&Cipher {
 	if key.len < 1 || key.len > 256 {
 		return error('crypto.rc4: invalid key size ' + key.len.str())
@@ -65,6 +66,7 @@ pub fn (mut c Cipher) reset() {
 
 // xor_key_stream sets dst to the result of XORing src with the key stream.
 // Dst and src must overlap entirely or not at all.
+@[direct_array_access]
 pub fn (mut c Cipher) xor_key_stream(mut dst []u8, src []u8) {
 	if src.len == 0 {
 		return


### PR DESCRIPTION
Helps a lot.
```v
import crypto.rc4
import rand
import time

fn main() {
	key := rand.bytes(32)!
	mut c := rc4.new_cipher(key)!
	mut out := []u8{len: 10_000_000}
	mut txt := []u8{len: 10_000_000, init: 255}

	t1 := time.now()
	c.xor_key_stream(mut out, txt)
	println(time.since(t1))
}
```

`master`:
```
$ v run rc4.v && v -prod rc4.v && ./rc4
656.013ms
116.518ms
```

`patch`:
```
$ v run rc4.v && v -prod rc4.v && ./rc4
54.620ms
19.244ms
```

Note: I want to add that I have my own test vector against another RC4 implementation with very wide coverage.
Everything is ok.
