### PR TITLE
cgen: fix the saving of g.skip_stmt_pos and g.stmt_path_pos when generating anonymous fns (fix #26498)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -754,9 +754,15 @@ fn (mut g Gen) gen_anon_fn_decl(mut node ast.AnonFn) {
 	}
 	pos := g.out.len
 	was_anon_fn := g.anon_fn
+	prev_stmt_path_pos := g.stmt_path_pos.clone()
+	prev_skip_stmt_pos := g.skip_stmt_pos
+	g.stmt_path_pos = []
+	g.skip_stmt_pos = false
 	g.anon_fn = node
 	g.fn_decl(node.decl)
 	g.anon_fn = was_anon_fn
+	g.skip_stmt_pos = prev_skip_stmt_pos
+	g.stmt_path_pos = prev_stmt_path_pos
 	builder.write_string(g.out.cut_to(pos))
 	out := builder.str()
 	g.anon_fn_definitions << out

--- a/vlib/v/tests/fns/anon_fn_in_generic_call_with_match_and_inner_generic_call_test.v
+++ b/vlib/v/tests/fns/anon_fn_in_generic_call_with_match_and_inner_generic_call_test.v
@@ -1,0 +1,41 @@
+module main
+
+import arrays
+import x.json2
+
+enum EventType {
+	message
+	reaction
+	unknown
+}
+
+struct ResponseStub {
+	etyp EventType @[json: 'type']
+}
+
+fn count_messages(events []json2.Any) !int {
+	return if events.len > 0 {
+		arrays.fold(events, 0, fn (acc int, a json2.Any) int {
+			typ := json2.decode[ResponseStub](a.str()) or { ResponseStub{.unknown} }.etyp
+			res := match typ {
+				.message { 1 }
+				.reaction { 2 }
+				else { none }
+			}
+			if r := res {
+				return acc + r
+			}
+			return acc
+		})
+	} else {
+		error('empty')
+	}
+}
+
+fn test_fix_issue_26498() {
+	events := [
+		json2.Any('{"type":"message"}'),
+		json2.Any('{"type":"reaction"}'),
+	]
+	assert count_messages(events)! == 3
+}


### PR DESCRIPTION
Fix #26498 .

Note: I used codex to fix the issue and to make the minimal reproduction.

The prompts I used with gpt-5.2-codex:
* `fix `v echobot.v` . Do not change the file, change /opt/v/vlib/v/gen/c/ . Read the /opt/v/AGENTS.md file .`
* `add a fix_issue_26498_test.v for that change too in /opt/v/vlib/v/tests/`
* `The fix is correct, but the test passes with `./v vlib/v/tests/fix_issue_26498_test.v` . It should fail with the unmodified compiler. It should work with the new one, when run like this: `./vnew vlib/v/tests/
  fix_issue_26498_test.v` . Ajdust the test, until it exhibits the same symptoms as the original code.`