### PR TITLE
string: rename b to buf in string.replace_each to avoid sort lambda shadowing

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -492,11 +492,11 @@ pub fn (s string) replace_each(vals []string) string {
 		return s.clone()
 	}
 	idxs.sort(a.idx < b.idx)
-	mut b := unsafe { malloc_noscan(new_len + 1) } // add space for 0 terminator
+	mut buf := unsafe { malloc_noscan(new_len + 1) } // add space for 0 terminator
 	// Fill the new string
 	mut idx_pos := 0
 	mut cur_idx := idxs[idx_pos]
-	mut b_i := 0
+	mut buf_i := 0
 	for i := 0; i < s.len; i++ {
 		if i == cur_idx.idx {
 			// Reached the location of rep, replace it with "with"
@@ -504,9 +504,9 @@ pub fn (s string) replace_each(vals []string) string {
 			with := vals[cur_idx.val_idx + 1]
 			for j in 0 .. with.len {
 				unsafe {
-					b[b_i] = with[j]
+					buf[buf_i] = with[j]
 				}
-				b_i++
+				buf_i++
 			}
 			// Skip the length of rep, since we just replaced it with "with"
 			i += rep.len - 1
@@ -518,14 +518,14 @@ pub fn (s string) replace_each(vals []string) string {
 		} else {
 			// Rep doesnt start here, just copy
 			unsafe {
-				b[b_i] = s.str[i]
+				buf[buf_i] = s.str[i]
 			}
-			b_i++
+			buf_i++
 		}
 	}
 	unsafe {
-		b[new_len] = 0
-		return tos(b, new_len)
+		buf[new_len] = 0
+		return tos(buf, new_len)
 	}
 }
 


### PR DESCRIPTION
## Summary
- In `replace_each()`, `idxs.sort(a.idx < b.idx)` uses `b` as the sort lambda parameter
- The `mut b` declaration on the next line shadows it, causing the compiler to resolve `b` in the sort expression to the wrong variable
- This results in an access violation crash (exit code -1073741819 / 0xC0000005) during code generation
- Rename `b`/`b_i` to `buf`/`buf_i` to eliminate the name conflict

## Test plan
- [x] `v test vlib/builtin/` — 32 passed, 1 skipped, 0 failed
- [x] Verified crash no longer occurs when compiling projects that trigger `replace_each`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)