### PR TITLE
net.http: enable test for relative redirects

### DIFF
--- a/vlib/net/http/http_test.v
+++ b/vlib/net/http/http_test.v
@@ -71,9 +71,7 @@ fn test_https_public_servers() {
 fn test_relative_redirects() {
 	$if !network ? {
 		return
-	} $else {
-		return
-	} // tempfix periodic: httpbin relative redirects are broken
+	}
 	res := http.get('https://httpbin.org/relative-redirect/3?abc=xyz') or { panic(err) }
 	assert res.status() == .ok
 	assert res.body != ''


### PR DESCRIPTION
Test for HTTP "relative redirects" via request to https://httpbin.org/relative-redirect/ works as expected.

- Minimal V code to test HTTP "relative redirects":
```v
import net.http

fn main() {
        res := http.get('https://httpbin.org/relative-redirect/3?abc=xyz') or { panic(err) }
        println(res.body)
}
```
- Run:
```sh
$ ./v run ~/tmp/http_redirect.v
{
  "args": {
    "abc": "xyz"
  },
  "headers": {
    "Content-Length": "0",
    "Host": "httpbin.org",
    "User-Agent": "v.http",
    "X-Amzn-Trace-Id": "Root=1-6981d4f3-025b139259ab9f4c3257e883"
  },
  "origin": REDACTED,
  "url": "https://httpbin.org/get?abc=xyz"
}
```

---

**Tests OK** on Linux/amd64 for `vlib/net/http/http_test.v`
```sh
$ ./v -d network -stats test vlib/net/http/http_test.v
---- Testing... ----
        V  source  code size:      45393 lines,     208298 tokens,    1266936 bytes,   528 types,    33 modules,   242 files,  3761 tl_stmts,     0 non_vlib_tl_stmts,    48 main_tl_stmts
generated  target  code size:      18990 lines,     730065 bytes
compilation took: 1768.007 ms, compilation speed: 25674 vlines/s, cgen threads: 7
running tests in: /home/fox/dev/Perso/vlang.git/vlib/net/http/http_test.v
https ok
      OK    [1/6]   313.475 ms     1 assert  | main.test_https_get()
Test getting current time from HTTP http://vlang.io/utc_now by http.get
Current time is: 1770115925
      OK    [2/6]   395.550 ms     3 asserts | main.test_http_get_from_vlang_utc_now()
Test getting current time from HTTPS https://vlang.io/utc_now by http.get
Current time is: 1770115925
      OK    [3/6]   309.873 ms     3 asserts | main.test_https_get_from_vlang_utc_now()
Testing http.get on public HTTP url: http://github.com/robots.txt
Testing http.get on public HTTP url: http://google.com/robots.txt
      OK    [4/6]   693.962 ms     4 asserts | main.test_http_public_servers()
Testing http.get on public HTTPS url: https://github.com/robots.txt
Testing http.get on public HTTPS url: https://google.com/robots.txt
      OK    [5/6]   720.670 ms     4 asserts | main.test_https_public_servers()
      OK    [6/6]  3580.680 ms     3 asserts | main.test_relative_redirects()
     Summary for running V tests in "http_test.v": 18 passed, 18 total. Elapsed time: 6014 ms.

 OK    7807.075 ms vlib/net/http/http_test.v
----
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 7808 ms, on 1 job. Comptime: 0 ms. Runtime: 7807 ms.
```
