### PR TITLE
net.http: add tests to check default/custom User-Agent header

### DIFF
--- a/vlib/net/http/http_test.v
+++ b/vlib/net/http/http_test.v
@@ -79,3 +79,26 @@ fn test_relative_redirects() {
 	assert res.body != ''
 	assert res.body.contains('"abc": "xyz"')
 }
+
+fn test_default_user_agent() {
+	$if !network ? {
+		return
+	}
+	res := http.get('https://httpbin.org/user-agent') or { panic(err) }
+	assert res.status() == .ok
+	assert res.body != ''
+	assert res.body.contains('"user-agent": "v.http"')
+}
+
+fn test_custom_user_agent() {
+	$if !network ? {
+		return
+	}
+	ua := 'V http test for UA'
+	mut req := http.new_request(.get, 'https://httpbin.org/user-agent', '')
+	req.user_agent = ua
+	res := req.do() or { panic(err) }
+	assert res.status() == .ok
+	assert res.body != ''
+	assert res.body.contains('"user-agent": "${ua}"')
+}


### PR DESCRIPTION
Request to https://httpbin.org/user-agent with:
- default UA = 'v.http'
- custom UA

and checks results in response body.

---
**Tests OK with Network** for `vlib/net/http/http_test.v`
```sh
$ ./v -d network -stats test vlib/net/http/http_test.v
---- Testing... ----
        V  source  code size:      45415 lines,     208433 tokens,    1267500 bytes,   528 types,    33 modules,   242 files,  3763 tl_stmts,     0 non_vlib_tl_stmts,    50 main_tl_stmts
generated  target  code size:      19180 lines,     745649 bytes
compilation took: 569.567 ms, compilation speed: 79736 vlines/s, cgen threads: 7
running tests in: /home/fox/dev/Perso/vlang.git/vlib/net/http/http_test.v
https ok
      OK    [1/8]   311.109 ms     1 assert  | main.test_https_get()
Test getting current time from HTTP http://vlang.io/utc_now by http.get
Current time is: 1770118002
      OK    [2/8]   391.081 ms     3 asserts | main.test_http_get_from_vlang_utc_now()
Test getting current time from HTTPS https://vlang.io/utc_now by http.get
Current time is: 1770118003
      OK    [3/8]   282.892 ms     3 asserts | main.test_https_get_from_vlang_utc_now()
Testing http.get on public HTTP url: http://github.com/robots.txt
Testing http.get on public HTTP url: http://google.com/robots.txt
      OK    [4/8]   709.779 ms     4 asserts | main.test_http_public_servers()
Testing http.get on public HTTPS url: https://github.com/robots.txt
Testing http.get on public HTTPS url: https://google.com/robots.txt
      OK    [5/8]   733.110 ms     4 asserts | main.test_https_public_servers()
      OK    [6/8]     0.000 ms    NO asserts | main.test_relative_redirects()
      OK    [7/8]   608.477 ms     3 asserts | main.test_default_user_agent()
      OK    [8/8]   602.230 ms     3 asserts | main.test_custom_user_agent()
     Summary for running V tests in "http_test.v": 21 passed, 21 total. Elapsed time: 3638 ms.

 OK    4229.315 ms vlib/net/http/http_test.v
----
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 4230 ms, on 1 job. Comptime: 0 ms. Runtime: 4229 ms.
```

