### PR TITLE
vcomplete: add quest command

### DIFF
--- a/cmd/tools/vcomplete.v
+++ b/cmd/tools/vcomplete.v
@@ -97,6 +97,7 @@ const auto_complete_commands = [
 	'gret',
 	'git-fmt-hook',
 	'ls',
+	'quest',
 	'retry',
 	'reduce',
 	'repl',


### PR DESCRIPTION
Add `v quest` subcommand for shell completion via `vcomplete`.

Tested on Linux with `bash` shell