### PR TITLE
Replacing a panic with an error return

### DIFF
--- a/vlib/crypto/pbkdf2/pbkdf2.v
+++ b/vlib/crypto/pbkdf2/pbkdf2.v
@@ -34,7 +34,7 @@ pub fn key(password []u8, salt []u8, count int, key_length int, h hash.Hash) ![]
 			}
 		}
 		else {
-			panic('Unsupported hash')
+			return error('Unsupported hash')
 		}
 	}
 


### PR DESCRIPTION
To avoid crashing the program, it is better to return an error instead of panicking.