### PR TITLE
docs: add doc comment for EmptyContext.done()

### DIFF
--- a/vlib/context/empty.v
+++ b/vlib/context/empty.v
@@ -13,6 +13,7 @@ pub fn (ctx &EmptyContext) deadline() ?time.Time {
 	return none
 }
 
+// done returns a closed channel, since an EmptyContext can never be canceled.
 pub fn (ctx &EmptyContext) done() chan int {
 	ch := chan int{}
 	ch.close()


### PR DESCRIPTION
## Summary
 [ ] Verify doc comment renders correctly with v doc context