### PR TITLE
docs: add doc comments for public functions in vlib/context/empty.v

### DIFF
--- a/vlib/context/empty.v
+++ b/vlib/context/empty.v
@@ -9,6 +9,7 @@ import time
 // An EmptyContext is never canceled, has no values.
 pub struct EmptyContext {}
 
+// deadline returns none, since an EmptyContext has no deadline.
 pub fn (ctx &EmptyContext) deadline() ?time.Time {
 	return none
 }
@@ -20,14 +21,17 @@ pub fn (ctx &EmptyContext) done() chan int {
 	return ch
 }
 
+// err returns none, since an EmptyContext is never canceled.
 pub fn (ctx &EmptyContext) err() IError {
 	return none
 }
 
+// value returns none, since an EmptyContext carries no values.
 pub fn (ctx &EmptyContext) value(key Key) ?Any {
 	return none
 }
 
+// str returns a string describing the Context.
 pub fn (ctx &EmptyContext) str() string {
 	return 'unknown empty Context'
 }


### PR DESCRIPTION
## Summary
- Added V-style doc comments for the four undocumented public functions on EmptyContext: deadline, err, value, str

## Test plan
- [x] v doc -comments context shows all doc comments correctly