### PR TITLE
docs: add doc comments for ValueContext pub functions

### DIFF
--- a/vlib/context/value.v
+++ b/vlib/context/value.v
@@ -33,18 +33,24 @@ pub fn with_value(parent Context, key Key, value Any) Context {
 	}
 }
 
+// deadline returns the deadline from the parent context.
 pub fn (ctx &ValueContext) deadline() ?time.Time {
 	return ctx.context.deadline()
 }
 
+// done returns the done channel from the parent context.
 pub fn (mut ctx ValueContext) done() chan int {
 	return ctx.context.done()
 }
 
+// err returns the error from the parent context.
 pub fn (mut ctx ValueContext) err() IError {
 	return ctx.context.err()
 }
 
+// value returns the value associated with this context for the given key.
+// If the key matches the one stored in this ValueContext, its value is returned.
+// Otherwise, the lookup is delegated to the parent context.
 pub fn (ctx &ValueContext) value(key Key) ?Any {
 	if ctx.key == key {
 		return ctx.value
@@ -52,6 +58,8 @@ pub fn (ctx &ValueContext) value(key Key) ?Any {
 	return ctx.context.value(key)
 }
 
+// str returns a string representation of the ValueContext,
+// showing the parent context name suffixed with '.with_value'.
 pub fn (ctx &ValueContext) str() string {
 	return context_name(ctx.context) + '.with_value'
 }


### PR DESCRIPTION
## Summary
- Add missing doc comments for all public methods on  in 
- Documents , , , , and  methods

## Test plan
- [x] Verified module context

fn background() Context
    background returns an empty Context. It is never canceled, has no values, and has no deadline. It is typically used by the main function, initialization, and tests, and as the top-level Context for incoming requests.
fn todo() Context
    Todo: returns an empty Context. Code should use todo whenit's unclear which Context to use or it is not yet available (because the surrounding function has not yet been extended to accept a Context parameter).
fn with_cancel(mut parent Context) (Context, CancelFn)
    with_cancel returns a copy of parent with a new done channel. The returned context's done channel is closed when the returned cancel function is called or when the parent context's done channel is closed, whichever happens first.
    
    Canceling this context releases resources associated with it, so code should call cancel as soon as the operations running in this Context complete.
fn with_deadline(mut parent Context, d time.Time) (Context, CancelFn)
    with_deadline returns a copy of the parent context with the deadline adjusted to be no later than d. If the parent's deadline is already earlier than d, with_deadline(parent, d) is semantically equivalent to parent. The returned context's Done channel is closed when the deadline expires, when the returned cancel function is called, or when the parent context's Done channel is closed, whichever happens first.
    
    Canceling this context releases resources associated with it, so code should call cancel as soon as the operations running in this Context complete.
fn with_timeout(mut parent Context, timeout time.Duration) (Context, CancelFn)
    with_timeout returns with_deadline(parent, time.now().add(timeout)).
    
    Canceling this context releases resources associated with it, so code should call cancel as soon as the operations running in this Context complete
fn with_value(parent Context, key Key, value Any) Context
    with_value returns a copy of parent in which the value associated with key is val.
    
    Use context Values only for request-scoped data that transits processes and APIs, not for passing optional parameters to functions.
    
    The provided key must be comparable and should not be of type string or any other built-in type to avoid collisions between packages using context. Users of with_value should define their own types for keys
interface Any {}
    Any represents a generic type for the ValueContext
interface Canceler {
	id string
mut:
	cancel(remove_from_parent bool, err IError)
	done() chan int
}
interface Context {
	deadline() ?time.Time
	value(key Key) ?Any
mut:
	done() chan int
	err() IError
}
    `Context` is an interface that defined the minimum required functionality for a Context.
    
    `deadline()` returns the time when work done on behalf of this context should be canceled. deadline returns none when no deadline is set. Successive calls to deadline return the same results.
    
    `value(key)` returns an Optional that wraps the value associated with this context for key. It returns none if no value is associated with key. Successive calls to Value with the same key returns the same result.
    
    Use context values only for request-scoped data that transits processes and API boundaries, not for passing optional parameters to functions.
    
    A key identifies a specific value in a Context. Functions that wish to store values in Context typically allocate a key in a global variable then use that key as the argument to context.with_value and Context.value. A key can be any type that supports equality; modules should define keys as an unexported type to avoid collisions.
    
    `done()` returns a channel that's closed when work done on behalf of this context should be canceled. done may return a closed channel if this context can never be canceled. Successive calls to done return the same value. The close of the done channel may happen asynchronously, after the cancel function returns.
    
    with_cancel arranges for done to be closed when cancel is called; with_deadline arranges for done to be closed when the deadline expires; with_timeout arranges for done to be closed when the timeout elapses.
    
    `err()` returns an IError based on some conditions If done is not yet closed, err returns none. If done is closed, err returns a non-none error explaining why: canceled if the context was canceled or deadline_exceeded if the context's deadline passed. After err returns a non-none error, successive calls to err return the same error.
fn (ctx &Context) str() string
    str returns the `str` method of the corresponding Context struct
fn (ctx &BackgroundContext) str() string
    str returns a string describing the Context.
type CancelFn = fn ()
type Key = bool | f32 | f64 | i16 | i64 | i8 | int | string | u16 | u32 | u64 | u8 | voidptr
    Key represents the type for the ValueContext key
fn (ctx &TodoContext) str() string
    str returns a string describing the Context.
struct CancelContext {
	id string
mut:
	context  Context
	mutex    &sync.Mutex = sync.new_mutex()
	done     chan int
	children map[string]Canceler
	err      IError = none
}
    A CancelContext can be canceled. When canceled, it also cancels any children that implement Canceler.
fn (ctx &CancelContext) deadline() ?time.Time
fn (mut ctx CancelContext) done() chan int
fn (mut ctx CancelContext) err() IError
fn (ctx &CancelContext) value(key Key) ?Any
fn (ctx &CancelContext) str() string
struct EmptyContext {}
    An EmptyContext is never canceled, has no values.
fn (ctx &EmptyContext) deadline() ?time.Time
fn (ctx &EmptyContext) done() chan int
    done returns a closed channel, since an EmptyContext can never be canceled.
fn (ctx &EmptyContext) err() IError
fn (ctx &EmptyContext) value(key Key) ?Any
fn (ctx &EmptyContext) str() string
struct TimerContext {
	id string
mut:
	cancel_ctx CancelContext
	deadline   time.Time
}
    A TimerContext carries a timer and a deadline. It embeds a CancelContext to implement done and err. It implements cancel by stopping its timer then delegating to CancelContext.cancel
fn (ctx &TimerContext) deadline() ?time.Time
fn (mut ctx TimerContext) done() chan int
fn (mut ctx TimerContext) err() IError
fn (ctx &TimerContext) value(key Key) ?Any
fn (mut ctx TimerContext) cancel(remove_from_parent bool, err IError)
fn (ctx &TimerContext) str() string
struct ValueContext {
	key   Key
	value Any
mut:
	context Context
}
    A ValueContext carries a key-value pair. It implements Value for that key and delegates all other calls to the embedded Context.
fn (ctx &ValueContext) deadline() ?time.Time
    deadline returns the deadline from the parent context.
fn (mut ctx ValueContext) done() chan int
    done returns the done channel from the parent context.
fn (mut ctx ValueContext) err() IError
    err returns the error from the parent context.
fn (ctx &ValueContext) value(key Key) ?Any
    value returns the value associated with this context for the given key. If the key matches the one stored in this ValueContext, its value is returned. Otherwise, the lookup is delegated to the parent context.
fn (ctx &ValueContext) str() string
    str returns a string representation of the ValueContext, showing the parent context name suffixed with '.with_value'. renders the new doc comments correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)