### PR TITLE
docs: add doc comments for OneContext pub functions

### DIFF
--- a/vlib/context/onecontext/onecontext.v
+++ b/vlib/context/onecontext/onecontext.v
@@ -34,6 +34,8 @@ pub fn merge(ctx context.Context, ctxs ...context.Context) (context.Context, con
 	return context.Context(octx), context.CancelFn(cancel)
 }
 
+// deadline returns the earliest deadline among all merged contexts,
+// or none if no context has a deadline set.
 pub fn (octx OneContext) deadline() ?time.Time {
 	mut min := time.Time{}
 
@@ -56,10 +58,12 @@ pub fn (octx OneContext) deadline() ?time.Time {
 	return min
 }
 
+// done returns the done channel, which is closed when the merged context is canceled.
 pub fn (octx OneContext) done() chan int {
 	return octx.done
 }
 
+// err returns the error from the merged context, or `none` if not yet canceled.
 pub fn (mut octx OneContext) err() IError {
 	octx.err_mutex.lock()
 	defer {
@@ -68,6 +72,8 @@ pub fn (mut octx OneContext) err() IError {
 	return octx.err
 }
 
+// value looks up a value by key across all merged contexts, returning
+// the first match found or none if no context holds the key.
 pub fn (octx OneContext) value(key context.Key) ?context.Any {
 	if value := octx.ctx.value(key) {
 		return value
@@ -82,6 +88,7 @@ pub fn (octx OneContext) value(key context.Key) ?context.Any {
 	return none
 }
 
+// run starts listening for cancellation signals from all merged contexts.
 pub fn (mut octx OneContext) run() {
 	mut wrapped_ctx := &octx.ctx
 	if octx.ctxs.len == 1 {
@@ -96,10 +103,13 @@ pub fn (mut octx OneContext) run() {
 	}
 }
 
+// str returns a string representation of the OneContext.
 pub fn (octx OneContext) str() string {
 	return ''
 }
 
+// cancel cancels the merged context with the given error, closing
+// the done channel and propagating cancellation to the underlying context.
 pub fn (mut octx OneContext) cancel(err IError) {
 	octx.cancel_fn()
 	octx.err_mutex.lock()
@@ -111,6 +121,8 @@ pub fn (mut octx OneContext) cancel(err IError) {
 	}
 }
 
+// run_two_contexts spawns a listener that cancels the merged context
+// when either of the two given contexts is done.
 pub fn (mut octx OneContext) run_two_contexts(mut ctx1 context.Context, mut ctx2 context.Context) {
 	spawn fn (mut octx OneContext, mut ctx1 context.Context, mut ctx2 context.Context) {
 		octx_cancel_done := octx.cancel_ctx.done()
@@ -130,6 +142,8 @@ pub fn (mut octx OneContext) run_two_contexts(mut ctx1 context.Context, mut ctx2
 	}(mut &octx, mut &ctx1, mut &ctx2)
 }
 
+// run_multiple_contexts spawns a listener that cancels the merged context
+// when the given context is done.
 pub fn (mut octx OneContext) run_multiple_contexts(mut ctx context.Context) {
 	spawn fn (mut octx OneContext, mut ctx context.Context) {
 		octx_cancel_done := octx.cancel_ctx.done()


### PR DESCRIPTION
## Summary
- Add missing doc comments for all public methods on OneContext in vlib/context/onecontext/onecontext.v
- Documents deadline(), done(), err(), value(), run(), str(), cancel(), run_two_contexts(), and run_multiple_contexts() methods

## Test plan
- [x] Verified v doc -comments renders the new doc comments correctly
- [ ] CI passes