### PR TITLE
crypto.ripemd160: improve block(), update tests

### DIFF
--- a/vlib/crypto/ripemd160/ripemd160.v
+++ b/vlib/crypto/ripemd160/ripemd160.v
@@ -33,7 +33,10 @@ pub fn (mut d Digest) free() {
 	$if prealloc {
 		return
 	}
-	unsafe { d.x.free() }
+	unsafe {
+		d.s.free()
+		d.x.free()
+	}
 }
 
 fn (mut d Digest) init() {
@@ -61,7 +64,7 @@ fn (d &Digest) clone() &Digest {
 	}
 }
 
-// new returns a new Digest (implementing hash.Hash) computing the MD5 checksum.
+// new returns a new Digest (implementing hash.Hash) computing the RIPEMD-160 checksum.
 pub fn new() &Digest {
 	mut d := &Digest{}
 	d.init()
@@ -81,7 +84,6 @@ pub fn (d &Digest) block_size() int {
 // hexhash returns a hexadecimal RIPEMD-160 hash sum `string` of `s`.
 pub fn hexhash(s string) string {
 	mut d := new()
-	d.init()
 	d.write(s.bytes()) or { panic(err) }
 	return d.sum([]).hex()
 }

--- a/vlib/crypto/ripemd160/ripemd160_test.v
+++ b/vlib/crypto/ripemd160/ripemd160_test.v
@@ -29,6 +29,7 @@ fn test_vectors() {
 				md.write(tv.i.bytes()[tv.i.len / 2..]) or { panic(err) }
 			}
 			assert md.sum([]).hex() == tv.o
+			assert ripemd160.hexhash(tv.i) == tv.o
 			md.reset()
 		}
 	}

--- a/vlib/crypto/ripemd160/ripemd160block.v
+++ b/vlib/crypto/ripemd160/ripemd160block.v
@@ -7,7 +7,7 @@ import math.bits
 
 // vfmt off
 const n__ = [
-	u32(0), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+	u8(0), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
 	7, 4, 13, 1, 10, 6, 15, 3, 12, 0, 9, 5, 2, 14, 11, 8,
 	3, 10, 14, 4, 9, 15, 8, 1, 2, 7, 0, 6, 13, 11, 5, 12,
 	1, 9, 11, 10, 0, 8, 12, 4, 13, 3, 7, 15, 14, 5, 6, 2,
@@ -15,7 +15,7 @@ const n__ = [
 ]
 
 const r__ = [
-	u32(11), 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8,
+	u8(11), 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8,
 	7, 6, 8, 13, 11, 9, 7, 15, 7, 12, 15, 9, 11, 7, 13, 12,
 	11, 13, 6, 7, 14, 9, 13, 15, 14, 8, 13, 6, 5, 12, 7, 5,
 	11, 12, 14, 15, 14, 15, 9, 8, 9, 14, 5, 6, 8, 6, 5, 12,
@@ -23,7 +23,7 @@ const r__ = [
 ]
 
 const n_ = [
-	u32(5), 14, 7, 0, 9, 2, 11, 4, 13, 6, 15, 8, 1, 10, 3, 12,
+	u8(5), 14, 7, 0, 9, 2, 11, 4, 13, 6, 15, 8, 1, 10, 3, 12,
 	6, 11, 3, 7, 0, 13, 5, 10, 14, 15, 8, 12, 4, 9, 1, 2,
 	15, 5, 1, 3, 7, 14, 6, 9, 11, 8, 12, 2, 10, 0, 4, 13,
 	8, 6, 4, 1, 3, 11, 15, 0, 5, 12, 2, 13, 9, 7, 10, 14,
@@ -31,7 +31,7 @@ const n_ = [
 ]
 
 const r_ = [
-	u32(8), 9, 9, 11, 13, 15, 15, 5, 7, 7, 8, 11, 14, 14, 12, 6,
+	u8(8), 9, 9, 11, 13, 15, 15, 5, 7, 7, 8, 11, 14, 14, 12, 6,
 	9, 13, 15, 7, 12, 8, 9, 11, 7, 7, 12, 7, 6, 15, 13, 11,
 	9, 7, 15, 11, 8, 6, 6, 14, 12, 13, 5, 14, 13, 13, 7, 5,
 	15, 5, 8, 11, 14, 14, 6, 14, 6, 9, 12, 9, 12, 5, 15, 8,
@@ -39,34 +39,30 @@ const r_ = [
 ]
 // vfmt on
 @[direct_array_access]
-fn block(mut md Digest, p0 []u8) int {
-	mut p := p0.clone()
+fn block(mut md Digest, p []u8) int {
 	mut n := 0
 	mut x := []u32{len: 16}
 	mut alpha := u32(0)
 	mut beta := u32(0)
 
-	for p.len >= block_size {
+	for n + block_size <= p.len {
 		mut a, mut b, mut c, mut d, mut e := md.s[0], md.s[1], md.s[2], md.s[3], md.s[4]
 		mut aa, mut bb, mut cc, mut dd, mut ee := a, b, c, d, e
-		mut j := 0
 
 		for i := 0; i < 16; i++ {
+			j := n + i * 4
 			x[i] = u32(p[j]) | u32(p[j + 1]) << 8 | u32(p[j + 2]) << 16 | u32(p[j + 3]) << 24
-			j += 4
 		}
 
 		mut i := 0
 		for i < 16 {
 			alpha = a + (b ^ c ^ d) + x[n__[i]]
-			mut s := int(r__[i])
-			alpha = bits.rotate_left_32(alpha, s) + e
+			alpha = bits.rotate_left_32(alpha, r__[i]) + e
 			beta = bits.rotate_left_32(c, 10)
 			a, b, c, d, e = e, alpha, b, beta, d
 
 			alpha = aa + (bb ^ (cc | ~dd)) + x[n_[i]] + 0x50a28be6
-			s = int(r_[i])
-			alpha = bits.rotate_left_32(alpha, s) + ee
+			alpha = bits.rotate_left_32(alpha, r_[i]) + ee
 			beta = bits.rotate_left_32(cc, 10)
 			aa, bb, cc, dd, ee = ee, alpha, bb, beta, dd
 
@@ -75,15 +71,13 @@ fn block(mut md Digest, p0 []u8) int {
 
 		for i < 32 {
 			alpha = a + (b & c | ~b & d) + x[n__[i]] + 0x5a827999
-			mut s := int(r__[i])
-			alpha = bits.rotate_left_32(alpha, s) + e
+			alpha = bits.rotate_left_32(alpha, r__[i]) + e
 			beta = bits.rotate_left_32(c, 10)
 			a, b, c, d, e = e, alpha, b, beta, d
 
 			// parallel line
 			alpha = aa + (bb & dd | cc & ~dd) + x[n_[i]] + 0x5c4dd124
-			s = int(r_[i])
-			alpha = bits.rotate_left_32(alpha, s) + ee
+			alpha = bits.rotate_left_32(alpha, r_[i]) + ee
 			beta = bits.rotate_left_32(cc, 10)
 			aa, bb, cc, dd, ee = ee, alpha, bb, beta, dd
 
@@ -92,15 +86,13 @@ fn block(mut md Digest, p0 []u8) int {
 
 		for i < 48 {
 			alpha = a + (b | ~c ^ d) + x[n__[i]] + 0x6ed9eba1
-			mut s := int(r__[i])
-			alpha = bits.rotate_left_32(alpha, s) + e
+			alpha = bits.rotate_left_32(alpha, r__[i]) + e
 			beta = bits.rotate_left_32(c, 10)
 			a, b, c, d, e = e, alpha, b, beta, d
 
 			// parallel line
 			alpha = aa + (bb | ~cc ^ dd) + x[n_[i]] + 0x6d703ef3
-			s = int(r_[i])
-			alpha = bits.rotate_left_32(alpha, s) + ee
+			alpha = bits.rotate_left_32(alpha, r_[i]) + ee
 			beta = bits.rotate_left_32(cc, 10)
 			aa, bb, cc, dd, ee = ee, alpha, bb, beta, dd
 
@@ -109,15 +101,13 @@ fn block(mut md Digest, p0 []u8) int {
 
 		for i < 64 {
 			alpha = a + (b & d | c & ~d) + x[n__[i]] + 0x8f1bbcdc
-			mut s := int(r__[i])
-			alpha = bits.rotate_left_32(alpha, s) + e
+			alpha = bits.rotate_left_32(alpha, r__[i]) + e
 			beta = bits.rotate_left_32(c, 10)
 			a, b, c, d, e = e, alpha, b, beta, d
 
 			// parallel line
 			alpha = aa + (bb & cc | ~bb & dd) + x[n_[i]] + 0x7a6d76e9
-			s = int(r_[i])
-			alpha = bits.rotate_left_32(alpha, s) + ee
+			alpha = bits.rotate_left_32(alpha, r_[i]) + ee
 			beta = bits.rotate_left_32(cc, 10)
 			aa, bb, cc, dd, ee = ee, alpha, bb, beta, dd
 
@@ -126,15 +116,13 @@ fn block(mut md Digest, p0 []u8) int {
 
 		for i < 80 {
 			alpha = a + (b ^ (c | ~d)) + x[n__[i]] + 0xa953fd4e
-			mut s := int(r__[i])
-			alpha = bits.rotate_left_32(alpha, s) + e
+			alpha = bits.rotate_left_32(alpha, r__[i]) + e
 			beta = bits.rotate_left_32(c, 10)
 			a, b, c, d, e = e, alpha, b, beta, d
 
 			// parallel line
 			alpha = aa + (bb ^ cc ^ dd) + x[n_[i]]
-			s = int(r_[i])
-			alpha = bits.rotate_left_32(alpha, s) + ee
+			alpha = bits.rotate_left_32(alpha, r_[i]) + ee
 			beta = bits.rotate_left_32(cc, 10)
 			aa, bb, cc, dd, ee = ee, alpha, bb, beta, dd
 
@@ -148,7 +136,6 @@ fn block(mut md Digest, p0 []u8) int {
 		md.s[4] = md.s[0] + b + cc
 		md.s[0] = dd
 
-		p = p[block_size..].clone()
 		n += block_size
 	}
 	return n


### PR DESCRIPTION
Current `ripemd160` implementation translated from [Go](https://cs.opensource.google/go/x/crypto/+/refs/tags/v0.47.0:ripemd160/), but it's not that simple.
Let's go through the patch from top to bottom:
1. `free()` - added second array to free
2. typo
3. `hexhash()` - remove second init(), already done in `new()`
4. test file - lets test `hexhash()` too
5. switch arrays from u32 to u8, less memory
6. big boss `block()` - remove unnecessary `clone()` and rest trivial optimization(s).

My standard 10MB bench code and cheap laptop:
```
import crypto.ripemd160
import time

fn main() {
	a := []u8{len: 10_000_000}
	t1 := time.now()
	println(ripemd160.hexhash(a.bytestr()))
	println(time.since(t1))
}
```
`master`
```
$ v run ripem.v && v -prod ripem.v && xtime ./ripem
b52e79a8919bb82acb98ce46527f2b822fc9f3ee
2:47.822
b52e79a8919bb82acb98ce46527f2b822fc9f3ee
2:54.161
```

`patch`
```
$ v run ripem.v && v -prod ripem.v && xtime ./ripem
b52e79a8919bb82acb98ce46527f2b822fc9f3ee
217.005ms
b52e79a8919bb82acb98ce46527f2b822fc9f3ee
36.332ms
```

`tcc` will work `700+` times faster
`gcc` will work `4800+` times faster
