### PR TITLE
Add generic function support and improve test infrastructure

### DIFF
--- a/cmd/v2/test_v2_self.sh
+++ b/cmd/v2/test_v2_self.sh
@@ -4,7 +4,7 @@ set -e
 # Build v2 with v1
 rm v2 || true
 V=${V:-$HOME/code/v/v}
-$V v2.v
+$V -gc none v2.v
 
 rm v3 || true
 rm v3.c || true

--- a/vlib/v2/builder/builder.v
+++ b/vlib/v2/builder/builder.v
@@ -150,7 +150,7 @@ fn (mut b Builder) gen_cleanc() {
 		if version_res.exit_code == 0 && version_res.output.contains('clang') {
 			error_limit_flag = ' -ferror-limit=0'
 		}
-		cc_cmd := '${cc} ${cc_flags} -w ${c_file} -o ${output_name}${error_limit_flag}'
+		cc_cmd := '${cc} ${cc_flags} -w ${c_file} -o ${output_name}${error_limit_flag} -lm'
 		if os.getenv('V2VERBOSE') != '' {
 			dump(cc_cmd)
 		}

--- a/vlib/v2/transformer/transformer.v
+++ b/vlib/v2/transformer/transformer.v
@@ -11883,6 +11883,16 @@ fn (t &Transformer) type_to_c_name(typ types.Type) string {
 			if typ.props.has(.boolean) {
 				return 'bool'
 			}
+			if typ.props.has(.untyped) {
+				if typ.props.has(.integer) {
+					return 'int_literal'
+				} else if typ.props.has(.float) {
+					return 'float_literal'
+				}
+			}
+			if typ.props.has(.float) {
+				return 'f${typ.size}'
+			}
 			if typ.props.has(.unsigned) {
 				match typ.size {
 					8 { return 'u8' }

--- a/vlib/v2/types/checker.v
+++ b/vlib/v2/types/checker.v
@@ -1390,6 +1390,16 @@ fn (mut c Checker) process_pending_interface_decls() {
 fn (mut c Checker) process_pending_struct_decls() {
 	for pending in c.pending_struct_decls {
 		c.scope = pending.scope
+		// Extract generic parameter names from the struct declaration
+		mut generic_params := []string{}
+		for generic_param in pending.decl.generic_params {
+			if generic_param is ast.Ident {
+				generic_params << generic_param.name
+			}
+		}
+		if generic_params.len > 0 {
+			c.generic_params = generic_params
+		}
 		mut fields := []Field{}
 		for field in pending.decl.fields {
 			fields << Field{
@@ -1397,6 +1407,9 @@ fn (mut c Checker) process_pending_struct_decls() {
 				typ:          c.expr(field.typ)
 				default_expr: field.value
 			}
+		}
+		if generic_params.len > 0 {
+			c.generic_params = []
 		}
 		mut embedded := []Struct{}
 		for embedded_expr in pending.decl.embedded {
@@ -1414,6 +1427,7 @@ fn (mut c Checker) process_pending_struct_decls() {
 				if mut sd is Struct {
 					sd.fields = fields
 					sd.embedded = embedded
+					sd.generic_params = generic_params
 				}
 			}
 		}

--- a/vlib/v2/types/types.v
+++ b/vlib/v2/types/types.v
@@ -205,10 +205,10 @@ pub:
 
 pub struct Struct {
 pub:
-	name           string
-	generic_params []string
+	name string
 pub mut:
-	embedded []Struct
+	generic_params []string
+	embedded       []Struct
 	// embedded       []Type
 	fields []Field
 	// fields	 map[string]Type


### PR DESCRIPTION
## Summary
This PR adds support for generic functions in V2's C code generator, improves the test infrastructure to handle internal module tests, and fixes several related issues with type inference and constant handling.

## Key Changes

### Generic Function Support
- Added infrastructure to track and instantiate generic functions with concrete types
- Implemented `GenericFnDeclInfo` struct to store generic function declarations and their type parameters
- Added prescan phase (`prescan_generic_fn_calls`) to detect calls to generic functions and determine concrete type instantiations
- Emit forward declarations for generic function instances before function bodies
- Generate concrete function instantiations with type parameter mapping via `generic_type_map`
- Skip uninstantiated generic structs and functions during code generation

### Test Infrastructure Improvements
- Added `expand_test_files()` function to detect internal module tests (`_test.v` files with non-main module declarations)
- Automatically include all non-test `.v` files from the same module directory for internal module tests, matching V1 behavior
- Implemented `emit_test_runner_main()` to generate a test runner main function when test files are detected
- Modified build script to use `-gc none` flag when compiling V2

### Type Inference and Generic Type Handling
- Added `is_generic_placeholder_type_name()` checks throughout type inference to handle unresolved generic types
- Improved type inference for generic function calls by inferring concrete types from first argument
- Enhanced `generic_type_map` resolution in `types_type_to_c()` and `expr_type_to_c()`
- Fixed type resolution for generic return types in assignment statements

### Constant and Initialization Improvements
- Changed integer constant generation from `#define` macros to anonymous enums to avoid name collisions
- Added check for function calls in array initializers (not allowed in C static initializers)
- Improved handling of const arrays with function calls via runtime initialization

### Code Generation Fixes
- Added `-lm` flag to C compiler command for math library linking
- Fixed function literal and lambda expression code generation (use stub function instead of NULL)
- Added `__fn_literal_stub()` no-op function for unimplemented function literals
- Improved struct field resolution checks for array and map types
- Enhanced `contains_call_expr()` to handle array initialization expressions

### Type System Updates
- Added `generic_params` field to `Struct` type in types system
- Improved type checker to extract and track generic parameter names during struct processing
- Enhanced `type_to_c_name()` to handle untyped and float type properties

## Implementation Details
- Generic functions are stored separately and only instantiated when called with concrete types
- Type parameter mapping is maintained in `generic_type_map` during code generation of instantiated functions
- Forward declarations for generic instances are emitted before all function bodies to ensure proper C compilation order
- Test detection and runner generation happens automatically during code generation

https://claude.ai/code/session_0158sG3xf2HH2bHPzcPVMAc4