### PR TITLE
cgen: fix hanging when printing to console in a `-subsystem windows` executable

### DIFF
--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -115,16 +115,16 @@ fn (mut g Gen) gen_c_main_function_only_header() {
 			} else {
 				g.writeln('\tcon_valid = AttachConsole(ATTACH_PARENT_PROCESS);')
 			}
-			g.writeln('\tFILE* res_fp = 0')
-			g.writeln('\terrno_t err')
+			g.writeln('\tFILE* res_fp = 0;')
+			g.writeln('\terrno_t err;')
 			g.writeln('\tif (con_valid) {')
-			g.writeln('\t\terr = freopen_s(&res_fp, "CON", "w", stdout)')
-			g.writeln('\t\terr = freopen_s(&res_fp, "CON", "w", stderr)')
+			g.writeln('\t\terr = freopen_s(&res_fp, "CON", "w", stdout);')
+			g.writeln('\t\terr = freopen_s(&res_fp, "CON", "w", stderr);')
 			g.writeln('\t} else {')
-			g.writeln('\t\terr = freopen_s(&res_fp, "NUL", "w", stdout)')
-			g.writeln('\t\terr = freopen_s(&res_fp, "NUL", "w", stderr)')
+			g.writeln('\t\terr = freopen_s(&res_fp, "NUL", "w", stdout);')
+			g.writeln('\t\terr = freopen_s(&res_fp, "NUL", "w", stderr);')
 			g.writeln('\t}')
-			g.writeln('\t(void)err')
+			g.writeln('\t(void)err;')
 
 			return
 		}


### PR DESCRIPTION
Resolves #26481

When you double click an executable from explorer, there is no parent console to attach to. So when trying to println("hello, world!") from an exe that is subsystem windows instead of subsystem console, it just hangs.

Ran this test program, and it successfully made a file `test` after the println
```
module main
import os

fn main() {
  println("hello, world!")
  os.create("test")!
  exit(0)
}
```