### PR TITLE
mbedtls: better ux around client timeout by mentioning the mbedtls_client_read_timeout_ms flag

### DIFF
--- a/vlib/net/mbedtls/ssl_connection.c.v
+++ b/vlib/net/mbedtls/ssl_connection.c.v
@@ -584,6 +584,13 @@ pub fn (mut s SSLConn) socket_read_into_ptr(buf_ptr &u8, len int) !int {
 					}
 					return 0
 				}
+				C.MBEDTLS_ERR_SSL_TIMEOUT {
+					$if trace_ssl ? {
+						eprintln('${@METHOD} ---> res: ${err} C.MBEDTLS_ERR_SSL_TIMEOUT')
+					}
+					return error_with_code('net.mbedtls SSLConn.socket_read_into_ptr, did not receive any data within ${mbedtls_client_read_timeout_ms}ms. compile with `-d mbedtls_client_read_timeout_ms=100000` to set a higher timeout',
+						res)
+				}
 				else {
 					$if trace_ssl ? {
 						eprintln('${@METHOD} ---> res: could not read using SSL')


### PR DESCRIPTION
It was not at all obvious in #24715 that the problem was related to the client timeout being 10 seconds. Added an explicit match for `C.MBEDTLS_ERR_SSL_TIMEOUT` to explain the `mbedtls_client_read_timeout_ms` compile time flag