### PR TITLE
add shake128 and shake256 entries into `crypto.Hash` enum

### DIFF
--- a/vlib/crypto/crypto.v
+++ b/vlib/crypto/crypto.v
@@ -16,6 +16,8 @@ pub enum Hash {
 	sha3_512
 	sha512_224
 	sha512_256
+	shake128
+	shake256
 	blake2s_256
 	blake2b_256
 	blake2b_384


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
In the mean time of [`pslhdsa`](https://github.com/blackshirt/pslhdsa) development, i've found if `SHAKE`-hash based family was not explicitly availables on the current entries of `crypto.Hash` enum.
Writing code likes this one for current workaround with this unavailiblity was absolutely and semantically wrong
```v
... (skipped)
match name'SHAKE-128' {
            // not availables on crypto.Hash enum, map to md4
			return crypto.Hash.md4
		} 
		'SHAKE-256' {
            // its also not availables on crypto.Hash enum, map to md5
			return crypto.Hash.md5
		} 
		'SHA2-224' {
			return crypto.Hash.sha224
		} // 224/8-bytes
..... (skipped)
```

This PR add two entries for SHAKE-family hash into the `crypto.Hash` enum in the means of `shake128` and `shake256`  entry.

Thanks
