### PR TITLE
checker: add passes for top level decls

### DIFF
--- a/vlib/v/checker/tests/import_sym_builtin_override_err.out
+++ b/vlib/v/checker/tests/import_sym_builtin_override_err.out
@@ -1,11 +1,11 @@
-vlib/v/checker/tests/import_sym_builtin_override_err.vv:1:15: error: cannot import or override builtin type
-    1 | import rand { f64 }
-      |               ~~~
-    2 | 
-    3 | type Dot = [3]f64
 vlib/v/checker/tests/import_sym_builtin_override_err.vv:3:12: error: unknown type `rand.f64`.
 Did you mean `rand.PRNG`?
     1 | import rand { f64 }
-    2 | 
+    2 |
     3 | type Dot = [3]f64
       |            ~~~~~~
+vlib/v/checker/tests/import_sym_builtin_override_err.vv:1:15: error: cannot import or override builtin type
+    1 | import rand { f64 }
+      |               ~~~
+    2 |
+    3 | type Dot = [3]f64

--- a/vlib/v/tests/consts/const_fixed_array_return_unresolved_test_reordered.v
+++ b/vlib/v/tests/consts/const_fixed_array_return_unresolved_test_reordered.v
@@ -1,0 +1,15 @@
+fn get_chunkmap_at_coords(mapp []Chunk) [chunk_size][chunk_size]u64 {
+	return mapp[0].id_map
+}
+
+const chunk_size = 100
+
+struct Chunk {
+	id_map [chunk_size][chunk_size]u64
+}
+
+fn main() {
+	x := get_chunkmap_at_coords([]Chunk{len: 1})
+	assert x.len == 100
+	assert x[0].len == 100
+}


### PR DESCRIPTION
See #26306

~~Fixed arrays were getting a `_v_` prefix in `-no-skip-unused`. This patch makes only the outer dimension get this prefix.~~

~~This patch was a test of Claude on the V codebase; I made sure to clean up the code (as it touched cgen before, even though I told it not to).~~

~~Might also want to add `// vtest vflags: -no-skip-unused` to the related test.~~

See https://github.com/vlang/v/pull/26589#discussion_r2803535512.

