### PR TITLE
cgen: fix extra dereference when indexing array of fns passed by pointer (fix #26556)

### DIFF
--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -301,7 +301,7 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 						g.write(')(*(${elem_type_str}*)builtin__array_get(')
 					}
 				}
-				if left_is_ptr && !left_is_shared {
+				if left_is_ptr && !left_is_shared && !is_direct_array_access {
 					g.write('*')
 				}
 			} else if is_direct_array_access {


### PR DESCRIPTION
…ter (fix #26556)


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
   When an array of functions is passed as a mutable pointer argument and
   indexed with a direct array access, the generated C code incorrectly
   added an extra `*` dereference before `->data`.

   Before: `((voidptr*)*a->data)[0]`
   After:  `((voidptr*)a->data)[0]`

   The `->` operator already handles the pointer dereference, so the
   explicit `*` was redundant and caused a compilation error.
