### PR TITLE
GNUmakefile: Include Macport legacy headers in include path

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,6 +41,7 @@ MAC := 1
 TCCOS := macos
 ifeq ($(shell expr $(shell uname -r | cut -d. -f1) \<= 15), 1)
 LEGACY := 1
+CFLAGS += "-I$(LEGACYLIBS)/include/LegacySupport"
 endif
 endif
 


### PR DESCRIPTION
The Macports header files include code that adds newer constants and functions to older versions of Mac OS X. A lot of the code in these header files are needed to build V on Mac OS 10.4. This patch adds the path of the Macport legacy headers to the CFLAGS variable in the GNUmakefile.

