### PR TITLE
os: use _dyld_get_image_name() to increase compatibility with older versions of Mac OS X

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -7,8 +7,8 @@ import strings
 
 $if macos {
 	#include <mach-o/dyld.h>
-
-	fn C._dyld_get_image_name(image u32) charptr
+	// needed for os.executable():
+	fn C._dyld_get_image_name(image u32) &char
 }
 
 $if freebsd || openbsd {


### PR DESCRIPTION
The libproc.h header is not available on Mac OS 10.4 and older. It prevents V from being built on these operating systems. The solution is to replace the functions from libproc.h with the function _dyld_get_image_name() to get the path of the program.