### PR TITLE
Support top-level declarations in comptime blocks and fix macOS executable()

### DIFF
--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -6,9 +6,7 @@ import strings
 #include <errno.h>
 
 $if macos {
-	#include <mach-o/dyld.h>
-	// needed for os.executable():
-	fn C._dyld_get_image_name(image u32) &char
+	#include <libproc.h>
 }
 
 $if freebsd || openbsd {
@@ -767,11 +765,14 @@ pub fn executable() string {
 		return res
 	}
 	$if macos {
-		self_path := &char(C._dyld_get_image_name(u32(0)))
-		if self_path == C.NULL {
+		pid := C.getpid()
+		ret := C.proc_pidpath(pid, &result[0], max_path_len)
+		if ret <= 0 {
+			eprintln('os.executable() failed at calling proc_pidpath with pid: ${pid} . proc_pidpath returned ${ret} ')
 			return executable_fallback()
 		}
-		return unsafe { cstring_to_vstring(self_path) }
+		res := unsafe { tos_clone(&result[0]) }
+		return res
 	}
 	$if freebsd {
 		bufsize := usize(max_path_buffer_size)


### PR DESCRIPTION
## Summary
This PR makes two key changes: (1) enables parsing of top-level declarations (const, enum, fn, struct, etc.) inside comptime `$if` blocks, and (2) fixes the `os.executable()` function on macOS to use the more reliable `proc_pidpath` API instead of the deprecated `_dyld_get_image_name`.

## Key Changes

**Parser improvements:**
- Added support for parsing top-level declarations within comptime conditional blocks
- Declarations now supported: `const`, `enum`, `fn`, `global`, `interface`, `struct`, `union`, `type`
- Added proper handling of `pub` keyword with these declarations
- Special handling for `fn` keyword to distinguish between function declarations and function literals

**macOS executable() fix:**
- Replaced deprecated `_dyld_get_image_name()` C function with `proc_pidpath()`
- Changed from including `<mach-o/dyld.h>` to `<libproc.h>`
- Updated implementation to use `C.getpid()` and `C.proc_pidpath()` for more reliable executable path resolution
- Added error handling and logging when `proc_pidpath` fails
- Uses `tos_clone()` instead of `cstring_to_vstring()` for proper string conversion

## Implementation Details
The parser changes allow comptime blocks to contain the same declarations that would normally appear at module level, enabling more flexible conditional compilation. The macOS fix addresses reliability issues with the previous implementation by using the standard process information API.

https://claude.ai/code/session_01WKy1isxRRBBJtZtTC382rL