### PR TITLE
flag: add DocOptions/Show to FlagParser

### DIFF
--- a/vlib/flag/flag.v
+++ b/vlib/flag/flag.v
@@ -145,6 +145,9 @@ pub fn new_flag_parser(args []string) &FlagParser {
 		all_after_dashdash: all_after_dashdash
 		args:               all_before_dashdash
 		max_free_args:      max_args_number
+		options:            DocOptions{
+			show: ~Show.zero() ^ .name
+		}
 	}
 }
 

--- a/vlib/flag/flag_test.v
+++ b/vlib/flag/flag_test.v
@@ -179,17 +179,17 @@ fn test_allow_to_build_usage_message() {
 	assert all_strings_found
 }
 
-fn test_if_app_name_given_but_no_show_usage_message_does_not_contain_app_name() {
+fn test_if_app_name_given_but_no_show_usage_message_still_contain_version() {
 	mut fp := flag.new_flag_parser([])
 	fp.application('flag_tool')
 	fp.version('v0.0.0')
 	fp.description('a description')
 	fp.bool('a_bool', 0, false, '')
 	fp.options.show.clear(.name)
-	assert !fp.usage().contains('flag_tool v0.0.0\n---')
+	assert fp.usage().contains('v0.0.0\n---')
 }
 
-fn test_if_version_given_but_no_show_usage_message_does_not_contain_version() {
+fn test_if_version_given_but_no_show_usage_message_does_not_contain_banner() {
 	mut fp := flag.new_flag_parser([])
 	fp.application('flag_tool')
 	fp.version('v0.0.0')

--- a/vlib/flag/flag_to.v
+++ b/vlib/flag/flag_to.v
@@ -617,30 +617,29 @@ pub fn (mut fm FlagMapper) parse[T]() ! {
 	}
 }
 
-// add app and/or version to doc. Returns true if version has been added.
+// add name and/or version to doc. Returns true if name or version has been added.
 fn doc_add_name_and_version(app_name string, app_version string, options DocOptions, mut docs []string) bool {
 	mut name_and_version := ''
-	mut version_added := false
 
-	if options.show.has(.name) {
+	if options.show.has(.name) && app_name != '' {
 		name_and_version = app_name
 	}
 
 	if options.show.has(.version) && app_version != '' {
-		if name_and_version != '' {
-			name_and_version = '${app_name} ${app_version}'
+		if app_name != '' {
+			name_and_version = '${app_name} ${app_version}' // Version string is always name + version
 		} else {
-			name_and_version = '${app_version}'
+			name_and_version = app_version
 		}
-
-		version_added = true
 	}
 
 	if name_and_version != '' {
 		docs << '${name_and_version}'
+
+		return true
 	}
 
-	return version_added
+	return false
 }
 
 // to_doc returns a "usage" style documentation `string` generated from the internal data structures generated via the `parse()` function.
@@ -673,7 +672,8 @@ pub fn (fm FlagMapper) to_doc(dc DocConfig) !string {
 		}
 	}
 
-	version := doc_add_name_and_version(app_name, app_version, dc.options, mut docs)
+	name_and_version := doc_add_name_and_version(app_name, app_version, dc.options, mut
+		docs)
 
 	// Resolve the description if visible
 	if dc.options.show.has(.description) {
@@ -716,7 +716,7 @@ pub fn (fm FlagMapper) to_doc(dc DocConfig) !string {
 		}
 	}
 
-	if version {
+	if name_and_version {
 		mut longest_line := 0
 		for doc_line in docs {
 			lines := doc_line.split('\n')


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This PR aims at enhancing the control of `FlagParser`.`usage()` output by adding `DocOptions` to the `FlagParser` struct.

Reason: I want to use `FlagParser` and leverage the implicit support for `--help` & `--version` flags but don't want to show version in usage.

For this I have currently to clear the app name & version information but then the support of the `--version` flag becomes moot as there's no version to display.

This PR also start to centralize common logic between `FlagParser`.`usage()` and `to_doc[T]()`.