### PR TITLE
move up AEAD interface from experimental namespace to `cipher.AEAD`

### DIFF
--- a/vlib/crypto/cipher/cipher.v
+++ b/vlib/crypto/cipher/cipher.v
@@ -47,6 +47,26 @@ pub interface BlockMode {
 	// maintains state and does not reset at each crypt_blocks call.
 }
 
+// AEAD provides an authenticated encryption with associated data for encryption (decryption).
+pub interface AEAD {
+	// nonce_size returns the size of nonce (in bytes) used by this AEAD that must be
+	// passed to `.encrypt` or `.decrypt`.
+	nonce_size() int
+	// overhead returns the maximum difference between the lengths of a plaintext and its ciphertext.
+	overhead() int
+	// encrypt encrypts and authenticates the provided plaintext along with the nonce and
+	// additional data in `ad`. The nonce must be `nonce_size()` bytes long and unique
+	// for all time, for a given key. It returns encrypted (and authenticated) ciphertext bytes
+	// where its encoded form is up to implementation and not dictated by the interfaces.
+	// Commonly, its contains encrypted text plus some authentication tag, and maybe some other bytes.
+	encrypt(plaintext []u8, nonce []u8, ad []u8) ![]u8
+	// decrypt decrypts and authenticates (verifies) the provided ciphertext along with a nonce, and
+	// additional data. The nonce must be `nonce_size()` bytes long and both it and the additional data
+	// must match the value passed to `encrypt`.
+	// Its returns the verified plaintext on success, or errors on fails.
+	decrypt(ciphertext []u8, nonce []u8, ad []u8) ![]u8
+}
+
 // Utility routines
 
 // fn dup(p []u8) []u8 {

--- a/vlib/x/crypto/chacha20poly1305/chacha20poly1305.v
+++ b/vlib/x/crypto/chacha20poly1305/chacha20poly1305.v
@@ -10,34 +10,11 @@
 //   Arbitrary length additional authenticated data (AAD)
 module chacha20poly1305
 
+import crypto.cipher
 import encoding.binary
 import crypto.internal.subtle
 import x.crypto.chacha20
 import x.crypto.poly1305
-
-// This interface was a proposed draft for Authenticated Encryption with Additional Data (AEAD)
-// interface `AEAD` likes discussion at discord channel.
-// see https://discord.com/channels/592103645835821068/592320321995014154/1206029352412778577
-// But its little modified to be more v-idiomatic.
-// Note: This interface should be more appropriately located in `crypto.cipher`, we can move
-// it into `crypto.cipher` later.
-// Authenticated Encryption with Additional Data (AEAD) interface
-pub interface AEAD {
-	// nonce_size return the nonce size (in bytes) used by this AEAD algorithm that should be
-	// passed to `.encrypt` or `.decrypt`.
-	nonce_size() int
-	// overhead returns the maximum difference between the lengths of a plaintext and its ciphertext.
-	overhead() int
-	// encrypt encrypts and authenticates the provided plaintext along with a nonce, and
-	// to be authenticated additional data in `ad`.
-	// It returns ciphertext bytes where its encoded form is up to implementation and
-	// not dictated by the interfaces.
-	// Usually its contains encrypted text plus some authentication tag, and maybe some other bytes.
-	encrypt(plaintext []u8, nonce []u8, ad []u8) ![]u8
-	// decrypt decrypts and authenticates (verifies) the provided ciphertext along with a nonce, and
-	// additional data. If verified successfully, it returns the plaintext and error otherwise.
-	decrypt(ciphertext []u8, nonce []u8, ad []u8) ![]u8
-}
 
 // key_size is the size of key (in bytes) which the Chacha20Poly1305 AEAD accepts.
 pub const key_size = 32
@@ -79,7 +56,7 @@ mut:
 
 // new creates a new Chacha20Poly1305 AEAD instance with given 32 bytes of key
 // and the nonce size in nsize. The nsize should be 8, 12 or 24 length, otherwise it would return error.
-pub fn new(key []u8, nsize int, opt chacha20.Options) !&AEAD {
+pub fn new(key []u8, nsize int, opt chacha20.Options) !&cipher.AEAD {
 	if key.len != key_size {
 		return error('chacha20poly1305: bad key size')
 	}

--- a/vlib/x/crypto/chacha20poly1305/psiv.v
+++ b/vlib/x/crypto/chacha20poly1305/psiv.v
@@ -9,6 +9,7 @@
 // See the detail on the [A Robust Variant of ChaCha20-Poly1305](https://eprint.iacr.org/2025/222).
 module chacha20poly1305
 
+import crypto.cipher
 import encoding.binary
 import crypto.internal.subtle
 import x.crypto.chacha20
@@ -70,7 +71,7 @@ pub fn psiv_decrypt(ciphertext []u8, key []u8, nonce []u8, ad []u8) ![]u8 {
 // Chacha20Poly1305RE is a Chacha20Poly1305 opaque with nonce-misuse resistent
 // and key-commiting AEAD scheme with PSIV construct.
 @[noinit]
-pub struct Chacha20Poly1305RE implements AEAD {
+pub struct Chacha20Poly1305RE implements cipher.AEAD {
 mut:
 	// flag that marked this instance should not be used again, set on .free call
 	done bool


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
This PR moves up `interface AEAD` from `vlib/x/crypto/chacha20poly1305.AEAD` space into `cipher.AEAD` space.
I think its should live at that correct space instead the current one. It also follow the `go` version of the same interface.
Its previously has been discussed at [here](https://discord.com/channels/592103645835821068/592320321995014154/1206029352412778577) lengthy.

Cheers.
