### PR TITLE
msvc: split multi-token -I/-L values from pkg-config

### DIFF
--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -672,13 +672,21 @@ pub fn (mut v Builder) msvc_string_flags(cflags []cflag.CFlag) MsvcStringFlags {
 				}
 			}
 		} else if flag.name == '-I' {
-			parts := split_quoted_flags(flag.value)
-			if parts.len == 0 {
-				continue
-			}
-			if parts.len == 1 && !parts[0].starts_with('-') {
-				inc_paths << '/I"${os.real_path(parts[0])}"'
+			should_split := flag.value.contains(' -I') || flag.value.contains(' -L')
+				|| flag.value.contains(' -l') || flag.value.contains(' -Wl,')
+				|| flag.value.contains(' "-I') || flag.value.contains(' "-L')
+				|| flag.value.contains(' "-l') || flag.value.contains(' "-Wl,')
+				|| flag.value.contains('\t-I') || flag.value.contains('\t-L')
+				|| flag.value.contains('\t-l') || flag.value.contains('\t-Wl,')
+				|| flag.value.contains('\t"-I') || flag.value.contains('\t"-L')
+				|| flag.value.contains('\t"-l') || flag.value.contains('\t"-Wl,')
+			if !should_split {
+				inc_paths << '/I"${os.real_path(flag.value)}"'
 			} else {
+				parts := split_quoted_flags(flag.value)
+				if parts.len == 0 {
+					continue
+				}
 				for part in parts {
 					if part == '' {
 						continue
@@ -698,14 +706,22 @@ pub fn (mut v Builder) msvc_string_flags(cflags []cflag.CFlag) MsvcStringFlags {
 		} else if flag.name == '-D' {
 			defines << '/D${flag.value}'
 		} else if flag.name == '-L' {
-			parts := split_quoted_flags(flag.value)
-			if parts.len == 0 {
-				continue
-			}
-			if parts.len == 1 && !parts[0].starts_with('-') {
-				lib_paths << parts[0]
-				lib_paths << parts[0] + os.path_separator + 'msvc'
+			should_split := flag.value.contains(' -I') || flag.value.contains(' -L')
+				|| flag.value.contains(' -l') || flag.value.contains(' -Wl,')
+				|| flag.value.contains(' "-I') || flag.value.contains(' "-L')
+				|| flag.value.contains(' "-l') || flag.value.contains(' "-Wl,')
+				|| flag.value.contains('\t-I') || flag.value.contains('\t-L')
+				|| flag.value.contains('\t-l') || flag.value.contains('\t-Wl,')
+				|| flag.value.contains('\t"-I') || flag.value.contains('\t"-L')
+				|| flag.value.contains('\t"-l') || flag.value.contains('\t"-Wl,')
+			if !should_split {
+				lib_paths << flag.value
+				lib_paths << flag.value + os.path_separator + 'msvc'
 			} else {
+				parts := split_quoted_flags(flag.value)
+				if parts.len == 0 {
+					continue
+				}
 				for part in parts {
 					if part == '' {
 						continue


### PR DESCRIPTION
 ## Summary
  Fix MSVC handling of pkg-config output where `-I`/`-L` values contain multiple tokens
  (e.g. `-Ifoo -Ibar -Lbaz`) by splitting and applying them individually.

  ## What was wrong
  pkg-config sometimes returns multiple `-I/-L` tokens inside a single flag value.
  The MSVC builder previously wrapped the *entire* value into one `/I"..."` or `/LIBPATH:"..."`
  argument, so embedded `-I/-L` tokens were passed verbatim inside the string.
  MSVC ignored/misparsed those, causing missing include paths (e.g. `glibconfig.h`).

  ## What changed
  The `-I` and `-L` branches now split multi-token values and apply each part separately.
  This prevents embedded GNU-style tokens from being smuggled inside a single MSVC argument.

  ## Repro
  Build a GUI example on Windows with MSVC and vcpkg glib/pango installed; previously
  `glibconfig.h` was missing even though include paths were present.

  ## Tests
  Not run (local build of `arrows.v` succeeded).

  Changed files

  - vlib/v/builder/msvc_windows.v