### PR TITLE
sync: remove unused header files from sync_darwin.c.v

### DIFF
--- a/vlib/sync/sync_darwin.c.v
+++ b/vlib/sync/sync_darwin.c.v
@@ -6,8 +6,6 @@ module sync
 import time
 
 #flag -lpthread
-#include <semaphore.h>
-#include <sys/errno.h>
 
 @[trusted]
 fn C.pthread_mutex_init(voidptr, voidptr) i32


### PR DESCRIPTION
The file vlib/sync/sync_darwin.c.v includes headers it does not use. These headers prevent building of vlib on certain versions of Mac OS X. Remove these header files to fix building of v on Mac OS X.