### PR TITLE
GNUmakefile: Fix building problems with legacy software on Mac OS X

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -42,10 +42,10 @@ TCCOS := macos
 ifeq ($(shell expr $(shell uname -r | cut -d. -f1) \<= 15), 1)
 LEGACY := 1
 CFLAGS += -I$(LEGACYLIBS)/include/LegacySupport
-LDFLAGS = -L$(LEGACYLIBS)/lib
+LDFLAGS += -L$(LEGACYLIBS)/lib
 LDFLAGS += -lMacportsLegacySupport
 VFLAGS += -cc $(CC)
-VFLAGS += -cflags $(CFLAGS)
+VFLAGS += -cflags "$(CFLAGS)"
 VFLAGS += -ldflags -L$(LEGACYLIBS)/lib
 VFLAGS += -ldflags -lMacportsLegacySupport
 endif


### PR DESCRIPTION
Building V on versions of Mac OS X that require the Macport legacy software currently fails. This is because the v1 compiler does not receive information about Macport legacy software. This patch fixes this problem by including the information in the VFLAGS variable.