### PR TITLE
checker: fix panic on wrong arg count with or-block containing if-expr

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1517,7 +1517,10 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				}
 			}
 		}
-		c.check_expected_arg_count(mut node, func) or { return func.return_type }
+		c.check_expected_arg_count(mut node, func) or {
+			node.return_type = func.return_type
+			return func.return_type
+		}
 	}
 	// println / eprintln / panic can print anything
 	if args_len > 0 && fn_name in print_everything_fns {

--- a/vlib/v/checker/tests/surplus_args_with_or_block_err.out
+++ b/vlib/v/checker/tests/surplus_args_with_or_block_err.out
@@ -1,0 +1,9 @@
+vlib/v/checker/tests/surplus_args_with_or_block_err.vv:31:47: error: expected 2 arguments, but got 3
+   29 |
+   30 |     if config.output_file != '' {
+   31 |         export_results(results, config.output_file, config) or {
+      |                                                     ~~~~~~
+   32 |             if config.use_color {
+   33 |                 eprintln('Error: export failed')
+Details: have ([]main.SimResult, string, main.Config)
+         want ([]main.SimResult, main.Config)

--- a/vlib/v/checker/tests/surplus_args_with_or_block_err.out
+++ b/vlib/v/checker/tests/surplus_args_with_or_block_err.out
@@ -1,9 +1,9 @@
-vlib/v/checker/tests/surplus_args_with_or_block_err.vv:31:47: error: expected 2 arguments, but got 3
-   29 |
-   30 |     if config.output_file != '' {
-   31 |         export_results(results, config.output_file, config) or {
+vlib/v/checker/tests/surplus_args_with_or_block_err.vv:34:47: error: expected 2 arguments, but got 3
+   32 |
+   33 |     if config.output_file != '' {
+   34 |         export_results(results, config.output_file, config) or {
       |                                                     ~~~~~~
-   32 |             if config.use_color {
-   33 |                 eprintln('Error: export failed')
+   35 |             if config.use_color {
+   36 |                 eprintln('Error: export failed')
 Details: have ([]main.SimResult, string, main.Config)
          want ([]main.SimResult, main.Config)

--- a/vlib/v/checker/tests/surplus_args_with_or_block_err.vv
+++ b/vlib/v/checker/tests/surplus_args_with_or_block_err.vv
@@ -1,0 +1,39 @@
+struct Config {
+	use_color   bool
+	output_file string
+}
+
+struct SimResult {
+	filename string
+	accuracy f64
+}
+
+fn export_results(results []SimResult, config Config) ! {
+	if config.output_file == '' {
+		return
+	}
+	println('Exporting to ${config.output_file}')
+}
+
+fn run_simulation(config Config) []SimResult {
+	return [SimResult{filename: 'test', accuracy: 0.9}]
+}
+
+fn main() {
+	mut config := Config{
+		use_color:   true
+		output_file: 'results.json'
+	}
+
+	results := run_simulation(config)
+
+	if config.output_file != '' {
+		export_results(results, config.output_file, config) or {
+			if config.use_color {
+				eprintln('Error: export failed')
+			} else {
+				eprintln('Error')
+			}
+		}
+	}
+}

--- a/vlib/v/checker/tests/surplus_args_with_or_block_err.vv
+++ b/vlib/v/checker/tests/surplus_args_with_or_block_err.vv
@@ -16,7 +16,10 @@ fn export_results(results []SimResult, config Config) ! {
 }
 
 fn run_simulation(config Config) []SimResult {
-	return [SimResult{filename: 'test', accuracy: 0.9}]
+	return [SimResult{
+		filename: 'test'
+		accuracy: 0.9
+	}]
 }
 
 fn main() {


### PR DESCRIPTION
When `check_expected_arg_count` detected wrong argument count and
returned early from `fn_call`, `node.return_type` was never set
(staying as 0). Back in `call_expr`, the or-block was still processed
using this zero type, and when `if_expr` inside the or-block called
`table.type_kind(0)` -> `table.sym(0)`, the compiler panicked with
"table.sym: invalid type (typ=ast.Type(0x0 = 0) idx=0)".

Fix: set `node.return_type = func.return_type` before the early return
so the or-block processes correctly even after an argument count error.

https://claude.ai/code/session_01RB9tJf3t9GEuuqcw1inq8k