### PR TITLE
enum struct fields: token, ast: remove @[minify] from structs with enum fields

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -250,7 +250,6 @@ pub:
 	pos token.Pos
 }
 
-@[minify]
 pub struct StringLiteral {
 pub:
 	val      string
@@ -302,7 +301,6 @@ pub enum GenericKindField {
 }
 
 // `foo.bar`
-@[minify]
 pub struct SelectorExpr {
 pub:
 	pos        token.Pos
@@ -353,7 +351,6 @@ pub:
 	pos token.Pos
 }
 
-@[minify]
 pub struct StructField {
 pub:
 	pos              token.Pos
@@ -416,7 +413,6 @@ pub mut:
 }
 
 // const declaration
-@[minify]
 pub struct ConstDecl {
 pub:
 	is_pub bool
@@ -428,7 +424,6 @@ pub mut:
 	is_block     bool         // const() block
 }
 
-@[minify]
 pub struct StructDecl {
 pub:
 	pos           token.Pos
@@ -472,7 +467,6 @@ pub:
 	comments []Comment
 }
 
-@[minify]
 pub struct InterfaceDecl {
 pub:
 	name          string
@@ -516,7 +510,6 @@ pub mut:
 //    ...a
 //    field1: 'hello'
 // }`
-@[minify]
 pub struct StructInit {
 pub:
 	pos             token.Pos
@@ -581,7 +574,6 @@ pub mut:
 }
 
 // function or method declaration
-@[minify]
 pub struct FnDecl {
 pub:
 	name                  string // 'math.bits.normalize'
@@ -675,7 +667,6 @@ pub fn (f &FnDecl) new_method_with_receiver_type(new_type_ Type) FnDecl {
 	}
 }
 
-@[minify]
 pub struct FnTrace {
 pub mut:
 	name string
@@ -687,7 +678,6 @@ pub:
 	is_fn_var   bool
 }
 
-@[minify]
 pub struct Fn {
 pub:
 	is_variadic           bool
@@ -739,7 +729,6 @@ fn (f &Fn) method_equals(o &Fn) bool {
 		&& f.name == o.name
 }
 
-@[minify]
 pub struct Param {
 pub:
 	pos        token.Pos
@@ -805,7 +794,6 @@ fn (p []Param) equals(o []Param) bool {
 }
 
 // break, continue
-@[minify]
 pub struct BranchStmt {
 pub:
 	kind  token.Kind
@@ -881,7 +869,6 @@ pub enum CallKind {
 }
 
 // function or method call expr
-@[minify]
 pub struct CallExpr {
 pub:
 	pos      token.Pos
@@ -939,7 +926,6 @@ pub struct AutofreeArgVar {
 */
 
 // function call argument: `f(callarg)`
-@[minify]
 pub struct CallArg {
 pub:
 	is_mut   bool
@@ -977,7 +963,6 @@ pub enum ComptimeVarKind {
 	aggregate     // aggregate var
 }
 
-@[minify]
 pub struct Var {
 pub:
 	name            string
@@ -1016,7 +1001,6 @@ pub mut:
 
 // used for smartcasting only
 // struct fields change type in scopes
-@[minify]
 pub struct ScopeStructField {
 pub:
 	struct_type Type // type of struct
@@ -1031,7 +1015,6 @@ pub:
 	//        12 <- the current casted type (typ)
 }
 
-@[minify]
 pub struct GlobalField {
 pub:
 	name        string
@@ -1066,7 +1049,6 @@ pub mut:
 	end_comments []Comment
 }
 
-@[minify]
 pub struct EmbeddedFile {
 pub:
 	compression_type string
@@ -1154,7 +1136,6 @@ pub mut:
 
 // TODO: (joe) remove completely, use ident.obj
 // instead which points to the scope object
-@[minify]
 pub struct IdentVar {
 pub mut:
 	typ         Type
@@ -1177,7 +1158,6 @@ pub enum IdentKind {
 }
 
 // A single identifier
-@[minify]
 pub struct Ident {
 pub:
 	language Language
@@ -1239,7 +1219,6 @@ pub fn (i &Ident) var_info() IdentVar {
 
 // left op right
 // See: token.Kind.is_infix
-@[minify]
 pub struct InfixExpr {
 pub:
 	op      token.Kind
@@ -1278,7 +1257,6 @@ pub mut:
 }
 
 // See: token.Kind.is_prefix
-@[minify]
 pub struct PrefixExpr {
 pub:
 	op  token.Kind
@@ -1290,7 +1268,6 @@ pub mut:
 	is_option  bool // IfGuard
 }
 
-@[minify]
 pub struct IndexExpr {
 pub:
 	pos token.Pos
@@ -1309,7 +1286,6 @@ pub mut:
 	typ       Type
 }
 
-@[minify]
 pub struct IfExpr {
 pub:
 	is_comptime   bool
@@ -1357,7 +1333,6 @@ pub mut:
 	scope    &Scope = unsafe { nil }
 }
 
-@[minify]
 pub struct MatchExpr {
 pub:
 	is_comptime bool
@@ -1399,7 +1374,6 @@ pub mut:
 	expected_type Type // for debugging only
 }
 
-@[minify]
 pub struct SelectBranch {
 pub:
 	pos           token.Pos
@@ -1447,7 +1421,6 @@ pub mut:
 	scope &Scope = unsafe { nil }
 }
 
-@[minify]
 pub struct ForInStmt {
 pub:
 	key_var    string
@@ -1508,7 +1481,6 @@ pub mut:
 }
 
 // variable assign statement
-@[minify]
 pub struct AssignStmt {
 pub:
 	op           token.Kind // include: =,:=,+=,-=,*=,/= and so on; for a list of all the assign operators, see vlib/token/token.v
@@ -1565,7 +1537,6 @@ pub mut:
 }
 
 // enum declaration
-@[minify]
 pub struct EnumDecl {
 pub:
 	name             string
@@ -1635,7 +1606,6 @@ pub enum DeferMode {
 // TODO: handle this differently
 // v1 excludes non current os ifdefs so
 // the defer's never get added in the first place
-@[minify]
 pub struct DeferStmt {
 pub:
 	pos   token.Pos
@@ -1657,7 +1627,6 @@ pub mut:
 	comments []Comment
 }
 
-@[minify]
 pub struct GoExpr {
 pub:
 	pos token.Pos
@@ -1666,7 +1635,6 @@ pub mut:
 	is_expr   bool
 }
 
-@[minify]
 pub struct SpawnExpr {
 pub:
 	pos token.Pos
@@ -1689,7 +1657,6 @@ pub:
 	pos  token.Pos
 }
 
-@[minify]
 pub struct ArrayInit {
 pub:
 	pos           token.Pos   // `[]` in []Type{} position
@@ -1737,7 +1704,6 @@ pub mut:
 	elem_type Type
 }
 
-@[minify]
 pub struct MapInit {
 pub:
 	pos       token.Pos
@@ -1757,7 +1723,6 @@ pub mut:
 }
 
 // s[10..20]
-@[minify]
 pub struct RangeExpr {
 pub:
 	has_high bool
@@ -1770,7 +1735,6 @@ pub mut:
 	typ  Type // filled in by checker; the type of `0...1` is `int` for example, while `a`...`z` is `rune` etc
 }
 
-@[minify]
 pub struct CastExpr {
 pub mut:
 	arg       Expr   // `n` in `string(buf, n)`
@@ -1782,7 +1746,6 @@ pub mut:
 	pos       token.Pos
 }
 
-@[minify]
 pub struct AsmStmt {
 pub:
 	arch        pref.Arch
@@ -1800,7 +1763,6 @@ pub mut:
 	local_labels  []string // local to the assembly block
 }
 
-@[minify]
 pub struct AsmTemplate {
 pub mut:
 	name         string
@@ -1988,7 +1950,6 @@ pub:
 }
 
 // `assert a == 0, 'a is zero'`
-@[minify]
 pub struct AssertStmt {
 pub:
 	pos       token.Pos
@@ -2045,7 +2006,6 @@ pub:
 */
 
 // deprecated
-@[minify]
 pub struct Assoc {
 pub:
 	var_name string
@@ -2077,7 +2037,6 @@ pub mut:
 	typ  Type
 }
 
-@[minify]
 pub struct OffsetOf {
 pub:
 	struct_type Type
@@ -2108,7 +2067,6 @@ pub mut:
 	expr Expr
 }
 
-@[minify]
 pub struct TypeOf {
 pub:
 	is_type bool
@@ -2118,7 +2076,6 @@ pub mut:
 	typ  Type
 }
 
-@[minify]
 pub struct DumpExpr {
 pub:
 	pos token.Pos
@@ -2153,7 +2110,6 @@ pub mut:
 	val string
 }
 
-@[minify]
 pub struct ComptimeSelector {
 pub:
 	has_parens bool // if $() is used, for vfmt
@@ -2182,7 +2138,6 @@ pub enum ComptimeCallKind {
 	compile_error
 }
 
-@[minify]
 pub struct ComptimeCall {
 pub:
 	pos         token.Pos

--- a/vlib/v/ast/attr.v
+++ b/vlib/v/ast/attr.v
@@ -14,7 +14,6 @@ pub enum AttrKind {
 }
 
 // e.g. `@[unsafe]`
-@[minify]
 pub struct Attr {
 pub:
 	name    string // [name]

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -106,7 +106,6 @@ pub fn pref_arch_to_table_language(pref_arch pref.Arch) Language {
 // * Table.type_kind(typ) not TypeSymbol.kind.
 // Each TypeSymbol is entered into `Table.type_symbols`.
 // See also: Table.sym.
-@[minify]
 pub struct TypeSymbol {
 pub mut:
 	parent_idx    int
@@ -169,7 +168,6 @@ pub mut:
 	func     Fn
 }
 
-@[minify]
 pub struct Struct {
 pub:
 	attrs       []Attr
@@ -199,7 +197,6 @@ pub mut:
 	concrete_types []Type // concrete types, e.g. [int, string]
 }
 
-@[minify]
 pub struct Interface {
 pub mut:
 	types   []Type // all types that implement this interface
@@ -228,7 +225,6 @@ pub:
 	name_pos         token.Pos
 }
 
-@[minify]
 pub struct Alias {
 pub mut:
 	parent_type Type
@@ -253,7 +249,6 @@ pub mut:
 	elem_type Type
 }
 
-@[minify]
 pub struct ArrayFixed {
 pub:
 	size      int
@@ -281,7 +276,6 @@ pub mut:
 	name_pos   token.Pos
 }
 
-@[minify]
 pub struct SumType {
 pub mut:
 	fields       []StructField
@@ -1736,7 +1730,6 @@ fn (t &Table) shorten_user_defined_typenames(original_name string, import_aliase
 	return '${mod}.${typ}'
 }
 
-@[minify]
 pub struct FnSignatureOpts {
 pub:
 	skip_receiver bool

--- a/vlib/v/token/token.v
+++ b/vlib/v/token/token.v
@@ -5,7 +5,6 @@ module token
 
 const orm_custom_operators = ['like', 'ilike']
 
-@[minify]
 pub struct Token {
 pub:
 	kind     Kind   // the token number/enum; for quick comparisons


### PR DESCRIPTION
When V is built from source with Clang, @[minify] generates C bit fields for enum-typed struct fields without 'unsigned'. Clang's handling of enum bit field signedness causes keyword token values (key_module=91 etc.) to be stored as negative numbers, corrupting the AST and breaking v fmt on every file.

Fix: remove @[minify] from Token, TypeSymbol, CallExpr, InfixExpr, AssignStmt, and all other structs in token.v, ast/types.v, ast/ast.v, and ast/attr.v that contain enum-typed fields.

Fixes https://github.com/vlang/v/issues/26658


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
