### PR TITLE
pref: use smaller stack size for 32bit systems by default

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -248,7 +248,7 @@ pub mut:
 	fast_math           bool // -fast-math will pass either -ffast-math or /fp:fast (for msvc) to the C backend
 	// checker settings:
 	checker_match_exhaustive_cutoff_limit int = 12
-	thread_stack_size                     int = 8388608 // Change with `-thread-stack-size 4194304`. Note: on macos it was 524288, which is too small for more complex programs with many nested callexprs.
+	thread_stack_size                     int = $if i386 || arm32 || rv32 { 2097152 } $else { 8388608 }
 	// wasm settings:
 	wasm_stack_top    int = 1024 + (16 * 1024) // stack size for webassembly backend
 	wasm_validate     bool // validate webassembly code, by calling `wasm-validate`


### PR DESCRIPTION
Fixes #24394

The default stack size is currently set to 8MB for both 32-bit and 64-bit systems. 
Due to this excessively large size, one of the tests fails on i386.
This PR makes 32-bit systems use a 2MB stack instead.
Now related test passed on i386.
