### PR TITLE
cgen: fix auto-deref var in autofree string re-assignment

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -265,6 +265,9 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				g.write('${type_to_free} ${sref_name} = (') // TODO: we are copying the entire string here, optimize
 				// we can't just do `.str` since we need the extra data from the string struct
 				// doing `&string` is also not an option since the stack memory with the data will be overwritten
+				if left0.is_auto_deref_var() {
+					g.write('*')
+				}
 				g.expr(left0) // node.left[0])
 				if first_left_type.has_flag(.shared_f) {
 					g.write('->val')


### PR DESCRIPTION
One of the old issue contains an interesting idea to test `-autofree` mode on `examples/*.v` files. It contains a list of files that do not compile; currently the list is longer.

This is the first test PR from a series for fixing `-autofree` mode for `examples/*.v` files.
This patch fixes two files: `rule110.v` and `vpwgen.v`.

Current error message is:
```
lambda:~/v$ v -autofree -g run examples/rule110.v 
/tmp/v_1000//home/mpech/v/examples/rule110.v:99: error: '{' expected (got ";")
...
```
Now will work.

Patch passed all `vlib/` tests on my farm.