### PR TITLE
Add Macports legacy software options to builder

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -203,8 +203,8 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		// Mac OS 10.4 and older requires Macports legacy software to build programs
 		if user_darwin_version <= 8 {
 			vexe_path := v.pref.vroot
-			ccoptions.args << '-I' + vexe_path + '/thirdparty/legacy/include/LegacySupport/'
-			ccoptions.args << vexe_path + '/thirdparty/legacy/lib/libMacportsLegacySupport.a'
+			ccoptions.args << '-I'+@VEXEROOT+'/thirdparty/legacy/include/LegacySupport/'
+			ccoptions.args << @VEXEROOT+'/thirdparty/legacy/lib/libMacportsLegacySupport.a'
 		}
 	}
 	ccoptions.debug_mode = v.pref.is_debug

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -202,8 +202,8 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 
 		// Mac OS 10.4 and older requires Macports legacy software to build programs
 		if user_darwin_version <= 8 {
-			ccoptions.args << '-I'+@VEXEROOT+'/thirdparty/legacy/include/LegacySupport/'
-			ccoptions.args << @VEXEROOT+'/thirdparty/legacy/lib/libMacportsLegacySupport.a'
+			ccoptions.args << '-I' + @VEXEROOT + '/thirdparty/legacy/include/LegacySupport/'
+			ccoptions.args << @VEXEROOT + '/thirdparty/legacy/lib/libMacportsLegacySupport.a'
 		}
 	}
 	ccoptions.debug_mode = v.pref.is_debug

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -202,7 +202,6 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 
 		// Mac OS 10.4 and older requires Macports legacy software to build programs
 		if user_darwin_version <= 8 {
-			vexe_path := v.pref.vroot
 			ccoptions.args << '-I'+@VEXEROOT+'/thirdparty/legacy/include/LegacySupport/'
 			ccoptions.args << @VEXEROOT+'/thirdparty/legacy/lib/libMacportsLegacySupport.a'
 		}

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -202,8 +202,8 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 
 		// Mac OS 10.4 and older requires Macports legacy software to build programs
 		if user_darwin_version <= 8 {
-		  ccoptions.args << "-I./thirdparty/legacy/include/LegacySupport/"
-		  ccoptions.args << "./thirdparty/legacy/lib/libMacportsLegacySupport.a"
+			ccoptions.args << '-I./thirdparty/legacy/include/LegacySupport/'
+			ccoptions.args << './thirdparty/legacy/lib/libMacportsLegacySupport.a'
 		}
 	}
 	ccoptions.debug_mode = v.pref.is_debug

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -202,8 +202,9 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 
 		// Mac OS 10.4 and older requires Macports legacy software to build programs
 		if user_darwin_version <= 8 {
-			ccoptions.args << '-I./thirdparty/legacy/include/LegacySupport/'
-			ccoptions.args << './thirdparty/legacy/lib/libMacportsLegacySupport.a'
+			vexe_path := v.pref.vroot
+			ccoptions.args << '-I' + vexe_path + '/thirdparty/legacy/include/LegacySupport/'
+			ccoptions.args << vexe_path + '/thirdparty/legacy/lib/libMacportsLegacySupport.a'
 		}
 	}
 	ccoptions.debug_mode = v.pref.is_debug

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -199,6 +199,12 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		if os.uname().machine == 'Power Macintosh' {
 			user_darwin_ppc = true
 		}
+
+		// Mac OS 10.4 and older requires Macports legacy software to build programs
+		if user_darwin_version <= 8 {
+		  ccoptions.args << "-I./thirdparty/legacy/include/LegacySupport/"
+		  ccoptions.args << "./thirdparty/legacy/lib/libMacportsLegacySupport.a"
+		}
 	}
 	ccoptions.debug_mode = v.pref.is_debug
 	ccoptions.guessed_compiler = v.pref.ccompiler


### PR DESCRIPTION
V on Mac OS 10.4 and older requires the MacPorts legacy software in order to build a program. If it is not included then error messages about missing functions like backtrace() are displayed. To fix this problem, this patch has the MacPorts legacy' include folder and library path sent to the C compiler.