### PR TITLE
pref: Give user the ability to specify the default c compiler to use

### DIFF
--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -284,7 +284,7 @@ pub fn default_tcc_compiler() string {
 pub fn (mut p Preferences) default_c_compiler() {
 	// TODO: fix $if after 'string'
 	$if windows {
-		p.ccompiler = 'gcc'
+		p.ccompiler = $d('use_c_compiler', 'gcc')
 		return
 	}
 	if p.os == .ios {
@@ -299,12 +299,12 @@ pub fn (mut p Preferences) default_c_compiler() {
 			}
 			// On macOS, /usr/bin/cc is a hardlink/wrapper for xcrun. clang on darwin hosts
 			// will automatically change the build target based off of the selected sdk, making xcrun -sdk iphoneos pointless
-			p.ccompiler = '/usr/bin/cc'
+			p.ccompiler = $d('use_c_compiler', '/usr/bin/cc')
 			p.cflags = '-isysroot ${isysroot} ${arch}' + p.cflags
 			return
 		}
 	}
-	p.ccompiler = 'cc'
+	p.ccompiler = $d('use_c_compiler', 'cc')
 	return
 }
 


### PR DESCRIPTION
Currently v picks the default compiler to use. For Mac OS it uses /usr/bin/cc. This compiler might be good. Then again it could be old and not meeting v's requirements. The user might also want to compare performance differences between different c compilers. To be able to do this the user needs to be able to specify the default c compiler used by v. This pull request gives the user to do this by setting the use_c_compiler flag to the name of the desired compiler. Then add that flag to the VFLAGS variable.

Here is an example of how to build v using this flag: 
VFLAGS="-d use_c_compiler=clang-mp-3.8" make