### PR TITLE
feat(db.sqlite): add Row.names, get_string/get_int, and improve exec_map

### DIFF
--- a/vlib/db/sqlite/sqlite.c.v
+++ b/vlib/db/sqlite/sqlite.c.v
@@ -88,7 +88,27 @@ pub fn (db &DB) str() string {
 
 pub struct Row {
 pub mut:
-	vals []string
+	vals  []string
+	names []string
+}
+
+// get_string returns the value for the given column name, or '' if the column is not found
+// or if the corresponding value index is out of range.
+pub fn (r &Row) get_string(col_name string) string {
+	for i, name in r.names {
+		if name == col_name {
+			if i < r.vals.len {
+				return r.vals[i]
+			}
+			return ''
+		}
+	}
+	return ''
+}
+
+// get_int returns the integer value for the given column name, or 0 if the column is not found.
+pub fn (r &Row) get_int(col_name string) int {
+	return r.get_string(col_name).int()
 }
 
 pub type Params = []string | [][]string
@@ -246,6 +266,11 @@ pub fn (db &DB) exec_map(query string) ![]map[string]string {
 		C.sqlite3_finalize(stmt)
 	}
 	nr_cols := C.sqlite3_column_count(stmt)
+	mut col_names := []string{cap: nr_cols}
+	for i in 0 .. nr_cols {
+		col_char := unsafe { &u8(C.sqlite3_column_name(stmt, i)) }
+		col_names << if col_char != unsafe { nil } { unsafe { tos_clone(col_char) } } else { '' }
+	}
 	mut res := 0
 	mut rows := []map[string]string{}
 	for {
@@ -256,13 +281,7 @@ pub fn (db &DB) exec_map(query string) ![]map[string]string {
 		mut row := map[string]string{}
 		for i in 0 .. nr_cols {
 			val := unsafe { &u8(C.sqlite3_column_text(stmt, i)) }
-			col_char := unsafe { &u8(C.sqlite3_column_name(stmt, i)) }
-			col := unsafe { tos_clone(col_char) }
-			if val == &u8(unsafe { nil }) {
-				row[col] = ''
-			} else {
-				row[col] = unsafe { tos_clone(val) }
-			}
+			row[col_names[i]] = if val != unsafe { nil } { unsafe { tos_clone(val) } } else { '' }
 		}
 		rows << row
 	}
@@ -285,6 +304,11 @@ pub fn (db &DB) exec(query string) ![]Row {
 		C.sqlite3_finalize(stmt)
 	}
 	nr_cols := C.sqlite3_column_count(stmt)
+	mut col_names := []string{cap: nr_cols}
+	for i in 0 .. nr_cols {
+		col_char := unsafe { &u8(C.sqlite3_column_name(stmt, i)) }
+		col_names << if col_char != unsafe { nil } { unsafe { tos_clone(col_char) } } else { '' }
+	}
 	mut res := 0
 	mut rows := []Row{}
 	for {
@@ -292,7 +316,9 @@ pub fn (db &DB) exec(query string) ![]Row {
 		if res != sqlite_row {
 			break
 		}
-		mut row := Row{}
+		mut row := Row{
+			names: col_names
+		}
 		for i in 0 .. nr_cols {
 			val := unsafe { &u8(C.sqlite3_column_text(stmt, i)) }
 			if val == &u8(unsafe { nil }) {
@@ -372,6 +398,11 @@ pub fn (db &DB) exec_param_many(query string, params Params) ![]Row {
 
 	mut rows := []Row{}
 	nr_cols := C.sqlite3_column_count(stmt)
+	mut col_names := []string{cap: nr_cols}
+	for i in 0 .. nr_cols {
+		col_char := unsafe { &u8(C.sqlite3_column_name(stmt, i)) }
+		col_names << if col_char != unsafe { nil } { unsafe { tos_clone(col_char) } } else { '' }
+	}
 
 	if params is []string {
 		for i, param in params {
@@ -381,7 +412,9 @@ pub fn (db &DB) exec_param_many(query string, params Params) ![]Row {
 			}
 		}
 		for {
-			mut row := Row{}
+			mut row := Row{
+				names: col_names
+			}
 			code = C.sqlite3_step(stmt)
 			if is_error(code) {
 				return db.error_message(code, query)
@@ -402,7 +435,9 @@ pub fn (db &DB) exec_param_many(query string, params Params) ![]Row {
 	} else if params is [][]string {
 		// Rows to process
 		for params_row in params {
-			mut row := Row{}
+			mut row := Row{
+				names: col_names
+			}
 			// Param values to bind
 			for i, param in params_row {
 				code = C.sqlite3_bind_text(stmt, i + 1, voidptr(param.str), param.len,


### PR DESCRIPTION
## Summary

- Add `names []string` to `Row` — populated by `exec` and `exec_param_many` after `sqlite3_prepare_v2`, shared across all rows in a result set
- Add `get_string(col_name string) string` and `get_int(col_name string) int` accessor methods on `Row`
- Improve `exec_map` to capture column names once before the row loop instead of on every row iteration

## Motivation

`Row` previously only exposed `vals []string`, requiring callers to hardcode column positions from the originating `SELECT`. Any reordering of columns would silently break lookups. `exec_map` provided name-based access but at the cost of a map allocation per row and redundant `sqlite3_column_name` calls on every row.

## Design

Column names are available from `sqlite3_column_name` immediately after `sqlite3_prepare_v2` — before any `sqlite3_step` call. Names are captured into a single `[]string` slice and the same slice is assigned to every `Row` in the result set. V slices share the backing array, so there is no per-row name allocation overhead.

`get_string` and `get_int` perform a linear scan of `r.names`, which is acceptable for typical SQL result sets (small number of columns). Both return zero values gracefully when `names` is empty (manually constructed `Row` instances).

## Impact on existing callers

- **Zero breaking changes.** `Row{vals: [...]}` and `Row{}` constructions are unaffected; `names` defaults to `[]string{}` and all existing `row.vals[i]` access is unchanged.
- `exec_map` callers see no API change — same return type and values, fewer `sqlite3_column_name` calls.

## Test plan

- [x] All existing `vlib/db/sqlite/` tests pass (6 passed, 1 skipped — skip is pre-existing and unrelated)

Closes #26701
