### PR TITLE
x.crypto.mldsa: add ML-DSA signature algorithm

### DIFF
--- a/vlib/crypto/sha3/xof.v
+++ b/vlib/crypto/sha3/xof.v
@@ -16,18 +16,22 @@ mut:
 	squeeze_buf  []u8
 }
 
+// new_shake128 returns a new Shake instance for SHAKE-128 extended output function.
 pub fn new_shake128() &Shake {
 	return &Shake{
 		rate: xof_rate_128
 	}
 }
 
+// new_shake256 returns a new Shake instance for SHAKE-256 extended output function.
 pub fn new_shake256() &Shake {
 	return &Shake{
 		rate: xof_rate_256
 	}
 }
 
+// write absorbs more data into the sponge state.
+// Panics if called after `read`.
 @[direct_array_access]
 pub fn (mut s Shake) write(data []u8) {
 	if s.finalized {
@@ -94,6 +98,8 @@ fn (mut s Shake) finalize() {
 	s.input_buffer = []u8{}
 }
 
+// read squeezes `out_len` bytes from the sponge state.
+// Finalizes the sponge on first call; further calls to `write` will panic.
 @[direct_array_access]
 pub fn (mut s Shake) read(out_len int) []u8 {
 	if !s.finalized {
@@ -119,6 +125,7 @@ pub fn (mut s Shake) read(out_len int) []u8 {
 	return result
 }
 
+// reset clears the sponge state, allowing the Shake instance to be reused.
 pub fn (mut s Shake) reset() {
 	s.s = State{}
 	s.input_buffer = []u8{}


### PR DESCRIPTION
This adds the ML-DSA signature algorithm, as per [FIPS 204](https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.204.pdf). The code added was ported from [golang's own implementation](https://github.com/golang/go/tree/master/src/crypto/internal/fips140/mldsa) of the algorithm, thus why I added their BSD license to the code.

_They are also in the process of discussing whether to add this impl to the public go `crypto` API: https://github.com/golang/go/issues/77626_

ML-DSA is NIST's postquantum digital signature standard, which is believed to be resistant against quantum computers. It leverages the [shortest vector problem](https://en.wikipedia.org/wiki/Lattice_problem#Shortest_vector_problem_(SVP)) as the one-way function, more specifically the [short integer problem](https://en.wikipedia.org/wiki/Short_integer_solution_problem).

We implement the three parameters sets: `ML-DSA-44`, `ML-DSA-65` and `ML-DSA-87` (specified in FIPS 204, sec. 4).

Even though optional, Pre-Hash ML-DSA is also implemented in `prehash.v` (we basically sign the hash of the message instead of the message itself), and is disabled by default (configurable on `.sign(...)` via `prehash: <hash-alg>`).

The code lives at `vlib/x/crypto/mldsa`, and [XOF](https://en.wikipedia.org/wiki/Extendable-output_function) was added to the `vlib/crypto/sha3` module in `xof.v`. I can split this into a separate PR if you think this is too much.

```v
import crypto.sha3

// one-shot (existing)
digest := sha3.shake256(message, 32)

// streaming (new)
mut xof := sha3.new_shake256()
xof.write(rho)        
xof.write([u8(row)])   
xof.write([u8(col)])   
coefs := xof.read(256) // squeeze out 256 bytes

// we can read again from the same state
more := xof.read(64)

// reset and reuse
xof.reset()
xof.write(seed)
hash := xof.read(64)
```

XOF was needed because ML-DSA makes extensive use of it: we already exposed `sha3.shakeXXX()` oneshot functions, but here we need to stream input in multiple writes before reading output. See [FIPS 202](https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.202.pdf) if you're curious about it, I also have a short post with visual explainations of XOFs: https://blog.cstef.dev/posts/sponge

Code is mainly tested by using [NIST's ACVP test vectors](https://pages.nist.gov/ACVP/draft-celi-acvp-ml-dsa.html) (615 total):

- [ML-DSA-keyGen-FIPS204](https://github.com/usnistgov/ACVP-Server/tree/master/gen-val/json-files/ML-DSA-keyGen-FIPS204): `nist_keygen_test.v` (75 vecs)
- [ML-DSA-sigVer-FIPS204](https://github.com/usnistgov/ACVP-Server/tree/master/gen-val/json-files/ML-DSA-sigVer-FIPS204): `nist_sigver_test.v` (180 vecs)
- [ML-DSA-sigGen-FIPS204](https://github.com/usnistgov/ACVP-Server/tree/master/gen-val/json-files/ML-DSA-sigGen-FIPS204): `nist_siggen_test.v` (360 vecs)

## Example
```v
import x.crypto.mldsa

fn main() {
        // generate a new ML-DSA-65 key pair
        sk := mldsa.PrivateKey.generate(.ml_dsa_65)!
        pk := sk.public_key()

        // sign a message (with an optional context string)
        msg := 'Hello ML-DSA'.bytes()
        sig := sk.sign(msg, context: 'not-a-drill')!

        // verify the signature with the same context
        verified := pk.verify(msg, sig, context: 'not-a-drill')!
        assert verified // true

        // deterministic signing is also available
        sig2 := sk.sign(msg, context: 'not-a-drill', deterministic: true)!
        verified2 := pk.verify(msg, sig2, context: 'not-a-drill')!
        assert verified2 // true
}
```

<details>
  <summary>Benchmarks (Intel Core Ultra 5 135U)</summary>
<p></p>

`mldsa_bench_test.v` vs `BenchmarkMLDSA` @ [`crypto/internal/fips140test`](https://github.com/golang/go/tree/b7d1c5887561ee5502b6c04baaa27ead13b63971/src/crypto/internal/fips140test)

  | Operation | Param | Go | V | V/Go |
  |-----------|-------|----|---|---------|
  | **KeyGen** | ML-DSA-44 | 165 µs | 120 µs | **1.38** |
  | | ML-DSA-65 | 250 µs | 194 µs | **1.29** |
  | | ML-DSA-87 | 328 µs | 316 µs | **1.04** |
  | **Sign** | ML-DSA-44 | 275 µs | 261 µs | **1.06** |
  | | ML-DSA-65 | 453 µs | 434 µs | **1.04** |
  | | ML-DSA-87 | 498 µs | 469 µs | **1.06** |
  | **Verify** | ML-DSA-44 | 127 µs | 35 µs | **3.66** |
  | | ML-DSA-65 | 186 µs | 47 µs | **3.94** |
  | | ML-DSA-87 | 273 µs | 67 µs | **4.10** |



  </details>

Closes https://github.com/vlang/v/issues/26683