### PR TITLE
cgen,autofree: don't clone array fn args in struct field init, add test

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -781,8 +781,16 @@ fn (mut g Gen) struct_init_field(sfield ast.StructInitField, language ast.Langua
 	field_type_sym := g.table.sym(sfield.typ)
 	mut cloned := false
 	if g.is_autofree && !sfield.typ.is_ptr() && field_type_sym.kind in [.array, .string] {
-		if g.gen_clone_assignment(sfield.expected_type, sfield.expr, sfield.typ, false) {
-			cloned = true
+		// array fn args should not be cloned into struct fields: the caller owns and
+		// frees the underlying data, so cloning would break mutation aliasing
+		// (e.g. `for mut x in iter`) and leak the clone. strings are still cloned
+		// since they may be freed before the struct field is used.
+		is_fn_arg := field_type_sym.kind == .array && sfield.expr is ast.Ident
+			&& sfield.expr.obj is ast.Var && (sfield.expr.obj as ast.Var).is_arg
+		if !is_fn_arg {
+			if g.gen_clone_assignment(sfield.expected_type, sfield.expr, sfield.typ, false) {
+				cloned = true
+			}
 		}
 	}
 	if !cloned {

--- a/vlib/v/tests/autofree_arrays_reverse_iter_test.v
+++ b/vlib/v/tests/autofree_arrays_reverse_iter_test.v
@@ -1,0 +1,16 @@
+// vtest vflags: -autofree
+// vtest build: !sanitize-address-gcc && !sanitize-address-clang
+import arrays
+
+fn test_arrays_fns_arg() {
+	mut original := [10, 20]
+	for mut x in arrays.reverse_iterator(original) {
+		(*x)++
+	}
+	assert original == [11, 21]
+
+	for mut x in original {
+		(*x)++
+	}
+	assert original == [12, 22]
+}


### PR DESCRIPTION
Slightly changing the strategy — it will be more beneficial for everyone if `vlib/` works in `-autofree` mode, rather than `examples/`; examples/ will then work on its own if everything is done correctly and in full.

Right now all arrays in -autofree mode are cloned when placed into a `struct`; this is my attempt to implement an exception so that `arrays.reverse_iterator()` does not clone and it is possible to modify data in-place inside the loop.

`v -autofree test vlib/v/tests/structs/` tests continue to pass successfully, just as before the patch.

From now `v -autofree test vlib/arrays/reverse_iterator_test.v` will work in -autofree mode too.

