### PR TITLE
Un-private `datatypes.Set.elements`

### DIFF
--- a/vlib/datatypes/set.v
+++ b/vlib/datatypes/set.v
@@ -1,7 +1,7 @@
 module datatypes
 
 pub struct Set[T] {
-mut:
+pub mut:
 	elements map[T]u8
 }
 

--- a/vlib/v/tests/builtin_maps/datatypes_set_public_elements_test.v
+++ b/vlib/v/tests/builtin_maps/datatypes_set_public_elements_test.v
@@ -1,0 +1,7 @@
+import datatypes
+
+fn test_datatypes_set_elements_is_public() {
+	mut set := datatypes.Set[string]{}
+	set.add_all(['a', 'b', 'c'])
+	assert set.elements.len == 3
+}


### PR DESCRIPTION
A previous change I made caused `datatypes.Set.elements` to become private, making it so that anyone using `.elements.len` had to revert to using `.size` instead. Not a huge deal, but breaking and unnecessary nonetheless. This PR fixes that and re-exposes `.elements` publicly.