### PR TITLE
checker: resolve @VROOT in #flag pseudo-variable expansion

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3155,6 +3155,12 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 
 fn (mut c Checker) resolve_pseudo_variables(oflag string, pos token.Pos) ?string {
 	mut flag := oflag
+	if flag.contains('@VROOT') {
+		flag = util.resolve_vmodroot(flag.replace('@VROOT', '@VMODROOT'), c.file.path) or {
+			c.error(err.msg(), pos)
+			return none
+		}
+	}
 	if flag.contains('@VEXEROOT') {
 		// expand `@VEXEROOT` to its absolute path
 		flag = flag.replace('@VEXEROOT', c.pref.vroot)

--- a/vlib/v/tests/cflags/vmodroot_and_vroot_test.c.v
+++ b/vlib/v/tests/cflags/vmodroot_and_vroot_test.c.v
@@ -11,8 +11,20 @@ fn C.add(i32, i32) i32
 #flag -I @VEXEROOT/thirdparty/stb_image
 #include "stb_image.h"
 
+// Tests that deprecated @VROOT still resolves to the current module root for object-file flags
+#flag @VROOT/vroot_obj.o
+#include "@VMODROOT/vroot_obj.h"
+
+fn C.meaning_of_life() i32
+
 fn test_vroot_and_vmodroot() {
 	x := C.add(123, 456)
 	dump(x)
 	assert x == 579
+}
+
+fn test_vroot_object_flags_resolve_to_module_root() {
+	x := C.meaning_of_life()
+	dump(x)
+	assert x == 42
 }

--- a/vlib/v/tests/cflags/vroot_obj.c
+++ b/vlib/v/tests/cflags/vroot_obj.c
@@ -1,0 +1,3 @@
+int meaning_of_life(void) {
+	return 42;
+}

--- a/vlib/v/tests/cflags/vroot_obj.h
+++ b/vlib/v/tests/cflags/vroot_obj.h
@@ -1,0 +1,1 @@
+int meaning_of_life(void);

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -128,7 +128,9 @@ pub fn launch_tool(is_verbose bool, tool_name string, args []string) {
 	if should_compile {
 		emodules := external_module_dependencies_for_tool[tool_name]
 		for emodule in emodules {
-			check_module_is_installed(emodule, is_verbose, false) or { panic(err) }
+			// Refresh external tool modules during recompilation, so tools pick up upstream
+			// compatibility fixes even when an older checkout already exists locally.
+			check_module_is_installed(emodule, is_verbose, true) or { panic(err) }
 		}
 		mut compilation_command := '${os.quoted_path(vexe)} '
 		if tool_name in ['vself', 'vup', 'vdoctor', 'vsymlink'] {


### PR DESCRIPTION
Fix `v doc` failing against stale external tool dependencies.

The original failure came from `vdoc` recompiling against an outdated local
`markdown` module checkout that still used deprecated `@VROOT` paths for its
`md4c` third-party objects. The `markdown` module has already fixed that
upstream, so this patch does not restore `@VROOT` handling in the compiler.

Instead, it makes tool recompilation refresh external module dependencies before
building the tool binary. That allows `v doc` to pick up the current
`vlang/markdown` sources, which already use non-deprecated paths.

Fixes #26698.