### PR TITLE
orm: skip sanitize check of orm_transaction_test.v

### DIFF
--- a/vlib/orm/orm_transaction_test.v
+++ b/vlib/orm/orm_transaction_test.v
@@ -1,4 +1,4 @@
-// vtest build: present_sqlite3?
+// vtest build: present_sqlite3? && !sanitize-memory-clang
 import db.sqlite
 import orm
 


### PR DESCRIPTION
Running
```
v -cc clang -gc none -cflags -fno-omit-frame-pointer -cflags -fsanitize=memory -silent -g /home/jalon/git/v/vlib/orm/orm_transaction_test.v
```
Gives the following error:
```
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
        V  source  code size:      39237 lines,     183151 tokens,    1072598 bytes,   480 types,    23 modules,   191 files,  3140 tl_stmts,     0 non_vlib_tl_stmts,    61 main_tl_stmts
generated  target  code size:      33095 lines,    1135448 bytes
compilation took: 1069.752 ms, compilation speed: 36678 vlines/s, cgen threads: 31
Uninitialized bytes in strcmp at offset 8 inside [0x70200000008c, 9)
==191767==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7fe97175176e  (/usr/lib/libsqlite3.so.0+0x2476e) (BuildId: ce973d6f19c918a3244b6c7db797c3ac3f4f3fcf)
    #1 0x7fe9718192bd  (/usr/lib/libsqlite3.so.0+0xec2bd) (BuildId: ce973d6f19c918a3244b6c7db797c3ac3f4f3fcf)
    #2 0x55d2c0570342 in db__sqlite__connect /home/jalon/git/v/vlib/db/sqlite/sqlite.c.v:167:13
    #3 0x55d2c057730a in main__setup_tx_db /home/jalon/git/v/vlib/orm/orm_transaction_test.v:11:31
    #4 0x55d2c057ac47 in main__test_transaction_callback_commits_on_success /home/jalon/git/v/vlib/orm/orm_transaction_test.v:70:31
    #5 0x55d2c05a39a4 in main /home/jalon/git/v/vlib/builtin/closure/closure.c.v:227:3
    #6 0x7fe971227c0d  (/usr/lib/libc.so.6+0x27c0d) (BuildId: 45bece07c9d751c2251242b44c114e38d08c5eff)
    #7 0x7fe971227d4a in __libc_start_main (/usr/lib/libc.so.6+0x27d4a) (BuildId: 45bece07c9d751c2251242b44c114e38d08c5eff)
    #8 0x55d2c0391344 in _start (/tmp/v_1000/tsession_7faaf5cbc740_01KKC5DF6WEWYWZJAWHMNHDTFJ/0_0/orm_transaction_test+0x42344) (BuildId: 76ef5299396afdbb5dadffebef8c05ec4785f336)

SUMMARY: MemorySanitizer: use-of-uninitialized-value (/usr/lib/libsqlite3.so.0+0x2476e) (BuildId: ce973d6f19c918a3244b6c7db797c3ac3f4f3fcf) 
Exiting

--------------------------------------------------------------------------------------------------------------------------------------------
To reproduce just failure 1 run:    '/home/jalon/git/v/v' -cc clang -gc none -cflags -fno-omit-frame-pointer -cflags -fsanitize=memory -silent -stats -g '/home/jalon/git/v/vlib/orm/orm_transaction_test.v'
Summary for all V _test.v files: 1 failed, 1 total. Elapsed time: 11083 ms, on 1 job. Comptime: 0 ms. Runtime: 11083 ms.
$
```
Since this is a failure inside sqlite, skip the sanitize test for this file to avoid the error.  Can revisit once sqlite gets updated.