### PR TITLE
builtin: call the C function wrappers instead of the C functions directly

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -980,7 +980,7 @@ pub fn (mut a array) sort_with_compare(callback fn (voidptr, voidptr) int) {
 // See also .sort_with_compare()
 pub fn (a &array) sorted_with_compare(callback fn (voidptr, voidptr) int) array {
 	mut r := a.clone()
-	unsafe { C.qsort(r.data, usize(r.len), usize(r.element_size), voidptr(callback)) }
+	unsafe { vqsort(r.data, usize(r.len), usize(r.element_size), callback) }
 	return r
 }
 

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -228,7 +228,7 @@ fn map_map_eq(a map, b map) bool {
 		}
 		va := a.key_values.value(i)
 		vb := b.get(k, va)
-		if unsafe { C.memcmp(va, vb, a.value_bytes) } != 0 {
+		if unsafe { vmemcmp(va, vb, a.value_bytes) } != 0 {
 			return false
 		}
 	}
@@ -242,7 +242,7 @@ fn map_clone_string(dest voidptr, pkey voidptr) {
 		cloned := s.clone()
 		// Use memcpy for native backend compatibility
 		// (*&string(dest)) = cloned doesn't reliably store full struct
-		C.memcpy(dest, voidptr(&cloned), sizeof(string))
+		vmemcpy(dest, voidptr(&cloned), sizeof(string))
 	}
 }
 


### PR DESCRIPTION
builtin/array.v and builtin/map.v were calling C functions directly from a .v file which is now not allowed.

This converts those calls to using the wrapper functions in builtin/cfns_wrapper.c.v.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
