### PR TITLE
autofree: disable leak detection in some tests for now

### DIFF
--- a/vlib/time/parse_autofree_test.v
+++ b/vlib/time/parse_autofree_test.v
@@ -1,4 +1,4 @@
-// vtest build: !msvc-windows
+// vtest build: !msvc-windows && !sanitize-address-gcc && !sanitize-address-clang
 // vtest vflags: -autofree
 module time
 

--- a/vlib/v/tests/autofree_discarded_call_return_value_test.v
+++ b/vlib/v/tests/autofree_discarded_call_return_value_test.v
@@ -1,3 +1,4 @@
+// vtest build: !sanitize-address-gcc && !sanitize-address-clang
 // vtest vflags: -autofree
 @[has_globals]
 module main

--- a/vlib/v/tests/autofree_if_expr_call_arg_with_struct_init_test.v
+++ b/vlib/v/tests/autofree_if_expr_call_arg_with_struct_init_test.v
@@ -1,3 +1,4 @@
+// vtest build: !sanitize-address-gcc && !sanitize-address-clang
 // vtest vflags: -autofree
 module main
 

--- a/vlib/v/tests/autofree_net_addr_len_test.v
+++ b/vlib/v/tests/autofree_net_addr_len_test.v
@@ -1,3 +1,4 @@
+// vtest build: !sanitize-address-gcc && !sanitize-address-clang
 // vtest vflags: -autofree -cg
 module main
 


### PR DESCRIPTION
In the current codebase, not disabling memory leak detection for `-autofree` tests is too optimistic for CI. 

@JalonSolov - Now CI should turn full green, let's see how long that lasts.
