### PR TITLE
crypto.cipher: copy to next only after encryption in OFB mode

### DIFF
--- a/vlib/crypto/cipher/ofb.v
+++ b/vlib/crypto/cipher/ofb.v
@@ -52,10 +52,8 @@ pub fn (mut x Ofb) xor_key_stream(mut dst []u8, src []u8) {
 			if x.out_used == x.out.len {
 				x.b.encrypt(mut x.out, x.next)
 				x.out_used = 0
+				copy(mut x.next, x.out)
 			}
-
-			copy(mut x.next, x.out)
-
 			n := xor_bytes(mut local_dst, local_src, x.out[x.out_used..])
 			local_dst = local_dst[n..]
 			local_src = local_src[n..]


### PR DESCRIPTION
in OFB mode copy to `next` only after encryption when ready not on every loop.
External test(s) vs. `OpenSSL` - ok.
