### PR TITLE
cgen: preserve interface arrays as single varargs

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2844,8 +2844,8 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 						}
 					}
 				} else {
-					// passing variadic arg to another call which expects same array type
-					if variadic_count == 1
+					// passing the current variadic arg to another call which expects the same array type
+					if variadic_count == 1 && g.is_forwarded_variadic_arg(args[arg_nr])
 						&& ((args[arg_nr].typ.has_flag(.variadic) && args[arg_nr].typ == varg_type)
 						|| (varg_type.has_flag(.variadic)
 						&& args[arg_nr].typ == varg_type.clear_flag(.variadic)
@@ -2883,6 +2883,18 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 			}
 		}
 	}
+}
+
+fn (g &Gen) is_forwarded_variadic_arg(arg ast.CallArg) bool {
+	if arg.typ.has_flag(.variadic) {
+		return true
+	}
+	if arg.expr is ast.Ident && g.cur_fn != unsafe { nil } && g.cur_fn.is_variadic
+		&& g.cur_fn.params.len > 0 && arg.expr.obj is ast.Var {
+		var_obj := arg.expr.obj as ast.Var
+		return var_obj.is_arg && arg.expr.name == g.cur_fn.params.last().name
+	}
+	return false
 }
 
 // similar to `autofree_call_pregen()` but only to to handle [keep_args_alive] for C functions

--- a/vlib/v/tests/fns/variadic_interface_array_arg_test.v
+++ b/vlib/v/tests/fns/variadic_interface_array_arg_test.v
@@ -1,0 +1,24 @@
+interface VariadicValue {}
+
+fn variadic_capture(values ...VariadicValue) []VariadicValue {
+	return values
+}
+
+fn test_variadic_interface_array_variable_as_single_arg() {
+	nested := [VariadicValue('brother')]
+	got := variadic_capture(nested)
+	assert got.len == 1
+
+	inner := got[0] as []VariadicValue
+	assert inner.len == 1
+	assert (inner[0] as string) == 'brother'
+}
+
+fn test_variadic_interface_array_literal_as_single_arg() {
+	got := variadic_capture([VariadicValue('x')])
+	assert got.len == 1
+
+	inner := got[0] as []VariadicValue
+	assert inner.len == 1
+	assert (inner[0] as string) == 'x'
+}


### PR DESCRIPTION
## Summary
- fix cgen for single interface-array arguments passed to variadic interface params
- keep the existing fast path only for real variadic forwarding from the current call frame
- add a regression test for array variables and literals passed as single interface varargs

## Root cause
Cgen treated any single `[]T` argument whose storage type matched the callee's variadic array type as a forwarded variadic array. That is correct for `inner(v)` when `v` is the current variadic parameter, but wrong for `called(v)` when `v` is an ordinary `[]Value` being passed as one interface value.

## Verification
- `./vnew run /tmp/issue26761.v`
- `./vnew vlib/v/tests/fns/variadic_interface_array_arg_test.v`
- `./vnew vlib/v/tests/fns/variadic_fn_chain_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/tests/fns/`

Fixes #26761