### PR TITLE
checker: preserve alias type in array_init for type aliases like strings.Builder

### DIFF
--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -120,6 +120,9 @@ fn (mut c Checker) array_init(mut node ast.ArrayInit) ast.Type {
 				node.expr_types << typ
 			}
 		}
+		if node.alias_type != ast.void_type {
+			return node.alias_type
+		}
 		return node.typ
 	}
 

--- a/vlib/v/tests/alias_array_init_method_test.v
+++ b/vlib/v/tests/alias_array_init_method_test.v
@@ -1,0 +1,16 @@
+// Test that array type aliases preserve their alias type when initialized with `{}`,
+// so that methods defined on the alias type are accessible.
+// See: https://github.com/vlang/v/issues/26767
+import strings
+
+fn test_builder_alias_preserves_type_on_init() {
+	mut builder := strings.Builder{}
+	builder.write_decimal(42)
+	assert builder.str() == '42'
+}
+
+fn test_builder_new_builder() {
+	mut builder := strings.new_builder(10)
+	builder.write_decimal(123)
+	assert builder.str() == '123'
+}


### PR DESCRIPTION
## Summary
- `strings.Builder{}` (and other array type aliases) initialized with `{}` syntax returned the underlying `[]u8` type instead of the alias type
- Root cause: `array_init()` checker returned `node.typ` (the underlying array type) without checking `node.alias_type` first
- Methods like `write_decimal` defined on `Builder` were inaccessible because the variable had type `[]u8`

Fixes #26767

## Test plan
- [x] Added regression test `alias_array_init_method_test.v`
- [x] V self-compiles successfully
- [x] All existing tests pass (20 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)