### PR TITLE
make.bat: bootstrap from v_win.c only

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -15,8 +15,7 @@ set V_EXE=./v.exe
 set V_BOOTSTRAP=./v_win_bootstrap.exe
 set V_OLD=./v_old.exe
 set V_UPDATED=./v_up.exe
-set V_C_FILE=./vc/v.c
-if not exist "%V_C_FILE%" set V_C_FILE=./vc/v_win.c
+set V_C_FILE=./vc/v_win.c
 
 REM TCC variables
 set tcc_url=https://github.com/vlang/tccbin


### PR DESCRIPTION
Fixes #26756 

Windows systems cannot bootstrap from a `vc/v.c` file at all — that file is completely foreign to it, so a reference to it is not needed in `make.bat` whatsoever. 
Now `vc/v_win.c` will always be used unconditionally.

Tested all targets in different order + `v up`.
