### PR TITLE
cgen: fix user-defined print with -no-builtin

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2082,7 +2082,7 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			}
 		}
 	}
-	is_print := node.kind in [.print, .println, .eprint, .eprintln, .panic]
+	mut is_print := !is_selector_call && node.kind in [.print, .println, .eprint, .eprintln, .panic]
 	print_method := name
 	is_json_encode := node.kind == .json_encode
 	is_json_encode_pretty := node.kind == .json_encode_pretty
@@ -2186,6 +2186,9 @@ fn (mut g Gen) fn_call(node ast.CallExpr) {
 			if func.mod == 'builtin' && !name.starts_with('builtin__') && node.language != .c {
 				name = 'builtin__${name}'
 			}
+			is_print = is_print && func.mod == 'builtin'
+		} else {
+			is_print = false
 		}
 	}
 	if node.is_fn_a_const {

--- a/vlib/v/gen/c/testdata/no_builtin_print_name_clash.c.must_have
+++ b/vlib/v/gen/c/testdata/no_builtin_print_name_clash.c.must_have
@@ -1,0 +1,2 @@
+void main__print(voidptr fmt, ... );
+main__print("\n");

--- a/vlib/v/gen/c/testdata/no_builtin_print_name_clash.vv
+++ b/vlib/v/gen/c/testdata/no_builtin_print_name_clash.vv
@@ -1,0 +1,7 @@
+// vtest vflags: -no-builtin
+@[markused]
+pub fn error() {
+	print(c'\n')
+}
+
+pub fn print(fmt voidptr, ...) {}


### PR DESCRIPTION
Fixes #26216.

Do not apply builtin `print(x)` stringification to user-defined `print` functions.

Adds a regression test for `-no-builtin` with a variadic `print(voidptr, ...)`.