### PR TITLE
cgen: enable vgc for tests too

### DIFF
--- a/vlib/builtin/vgc_d_vgc.c.v
+++ b/vlib/builtin/vgc_d_vgc.c.v
@@ -46,7 +46,7 @@ fn C.vgc_addr_to_arena(addr usize) int
 // ============================================================
 
 const vgc_page_shift = 13
-const vgc_page_size = usize(1) << vgc_page_shift // 8192 bytes
+const vgc_page_size = 8192
 const vgc_max_small_size = u32(32768) // objects > this are "large"
 const vgc_num_classes = 68
 const vgc_num_span_classes = 136 // 68 * 2 (scan + noscan variants)

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -315,10 +315,10 @@ pub fn (mut g Gen) gen_c_main_for_tests() {
 	if g.pref.gc_mode == .vgc {
 		g.writeln('\tbuiltin__vgc_init();')
 	}
+	g.writeln('\tmain__vtest_init();')
 	if !g.pref.no_builtin {
 		g.writeln('\t_vinit(___argc, (voidptr)___argv);')
 	}
-	g.writeln('\tmain__vtest_init();')
 	g.gen_c_main_profile_hook()
 
 	mut all_tfuncs := g.get_all_test_function_names()


### PR DESCRIPTION
As you probably already know, master contains a new garbage collector — VGC. This patch makes it possible to run tests in `-gc vgc` mode.

Now this will work:
```
$ v -cc gcc -gc vgc test vlib/builtin/int_test.v
```
Note: I'm spending a criminally large amount of time on vgc and will let you know when you can start playing around with it — for now it's just a non-working prototype.
