### PR TITLE
builtin: set @markused for vgc_memdup_typed()

### DIFF
--- a/vlib/builtin/vgc_d_vgc.c.v
+++ b/vlib/builtin/vgc_d_vgc.c.v
@@ -853,6 +853,7 @@ fn vgc_calloc(n usize) voidptr {
 
 // Typed memdup: allocate with pointer map and copy source data.
 // Used by HEAP_vgc() macro for struct allocations with known layout.
+@[markused]
 fn vgc_memdup_typed(src voidptr, n isize, ptrmap u64, ptr_words u8) voidptr {
 	if src == unsafe { nil } || n <= 0 {
 		return unsafe { nil }


### PR DESCRIPTION
Make this code compile and work under vgc cover:
```v
import crypto.blake2s
import time

fn main() {
	a := []u8{len: 10_000_000, init: index}
	t1 := time.now()
	c := blake2s.sum256(a)
	println(time.since(t1))
	assert c.hex() == 'd3ebb0180aef5371235c43dd375466aaf5ec5b6f44c43dc8d2597e71c718f1fb'
}
```

```
v -cc gcc -gc vgc run blake2s.v
```