### PR TITLE
vfmt: fix conditional selective imports

### DIFF
--- a/vlib/v/fmt/tests/conditional_import_expected.vv
+++ b/vlib/v/fmt/tests/conditional_import_expected.vv
@@ -1,0 +1,7 @@
+module main
+
+$if linux {
+	import math { max }
+} $else $if windows {
+	import arrays { max }
+}

--- a/vlib/v/fmt/tests/conditional_import_input.vv
+++ b/vlib/v/fmt/tests/conditional_import_input.vv
@@ -1,0 +1,8 @@
+module main
+
+$if linux {
+import math { max }
+} $else $if windows
+{
+import arrays { max }
+}

--- a/vlib/v/parser/module.v
+++ b/vlib/v/parser/module.v
@@ -323,7 +323,7 @@ fn (mut p Parser) import_syms(mut parent ast.Import) {
 	for p.tok.kind == .name {
 		pos := p.tok.pos()
 		alias := p.check_name()
-		if p.is_imported_symbol(alias) {
+		if p.is_imported_symbol(alias) && !(p.pref.is_fmt && p.inside_ct_if_expr) {
 			p.error_with_pos('cannot register symbol `${alias}`, it was already imported',
 				pos)
 			return


### PR DESCRIPTION
Allow vfmt to handle selective imports inside `$if/$else` branches.