### PR TITLE
db.sqlite: add cols field to Row for column name access

### DIFF
--- a/vlib/db/sqlite/sqlite.c.v
+++ b/vlib/db/sqlite/sqlite.c.v
@@ -88,6 +88,7 @@ pub fn (db &DB) str() string {
 
 pub struct Row {
 pub mut:
+	cols []string
 	vals []string
 }
 
@@ -287,6 +288,16 @@ pub fn (db &DB) exec(query string) ![]Row {
 		C.sqlite3_finalize(stmt)
 	}
 	nr_cols := C.sqlite3_column_count(stmt)
+	// Resolve column names once from the prepared statement.
+	mut col_names := []string{cap: nr_cols}
+	for i in 0 .. nr_cols {
+		col_char := unsafe { &u8(C.sqlite3_column_name(stmt, i)) }
+		col_names << if col_char != &u8(unsafe { nil }) {
+			unsafe { tos_clone(col_char) }
+		} else {
+			''
+		}
+	}
 	mut res := 0
 	mut rows := []Row{}
 	for {
@@ -296,7 +307,9 @@ pub fn (db &DB) exec(query string) ![]Row {
 			// C.puts(C.sqlite3_errstr(res))
 			break
 		}
-		mut row := Row{}
+		mut row := Row{
+			cols: col_names
+		}
 		for i in 0 .. nr_cols {
 			val := unsafe { &u8(C.sqlite3_column_text(stmt, i)) }
 			if val == &u8(unsafe { nil }) {
@@ -376,6 +389,16 @@ pub fn (db &DB) exec_param_many(query string, params Params) ![]Row {
 
 	mut rows := []Row{}
 	nr_cols := C.sqlite3_column_count(stmt)
+	// Resolve column names once from the prepared statement.
+	mut col_names := []string{cap: nr_cols}
+	for i in 0 .. nr_cols {
+		col_char := unsafe { &u8(C.sqlite3_column_name(stmt, i)) }
+		col_names << if col_char != &u8(unsafe { nil }) {
+			unsafe { tos_clone(col_char) }
+		} else {
+			''
+		}
+	}
 
 	if params is []string {
 		for i, param in params {
@@ -385,7 +408,9 @@ pub fn (db &DB) exec_param_many(query string, params Params) ![]Row {
 			}
 		}
 		for {
-			mut row := Row{}
+			mut row := Row{
+				cols: col_names
+			}
 			code = C.sqlite3_step(stmt)
 			if is_error(code) {
 				return db.error_message(code, query)
@@ -406,7 +431,9 @@ pub fn (db &DB) exec_param_many(query string, params Params) ![]Row {
 	} else if params is [][]string {
 		// Rows to process
 		for params_row in params {
-			mut row := Row{}
+			mut row := Row{
+				cols: col_names
+			}
 			// Param values to bind
 			for i, param in params_row {
 				code = C.sqlite3_bind_text(stmt, i + 1, voidptr(param.str), param.len,

--- a/vlib/db/sqlite/sqlite_test.v
+++ b/vlib/db/sqlite/sqlite_test.v
@@ -131,6 +131,31 @@ fn test_exec_param_many() {
 	assert false
 }
 
+fn test_exec_returns_column_names() {
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+	db.exec('create table items (id integer primary key, name text, price real)')!
+	db.exec("insert into items (name, price) values ('Widget', 9.99)")!
+
+	// exec should populate cols on each row
+	rows := db.exec('select id, name, price from items')!
+	assert rows.len == 1
+	assert rows[0].cols == ['id', 'name', 'price']
+	assert rows[0].vals[1] == 'Widget'
+
+	// exec_one should also have cols
+	row := db.exec_one('select name, price from items where id = 1')!
+	assert row.cols == ['name', 'price']
+	assert row.vals[0] == 'Widget'
+
+	// exec_param should also have cols
+	param_rows := db.exec_param('select id, name from items where id = ?', '1')!
+	assert param_rows.len == 1
+	assert param_rows[0].cols == ['id', 'name']
+	assert param_rows[0].vals[1] == 'Widget'
+
+	db.close()!
+}
+
 fn test_exec_param_many2() {
 	mut db := sqlite.connect(':memory:') or { panic(err) }
 	assert db.is_open


### PR DESCRIPTION
## Summary
- Adds `cols []string` to `pub struct Row` in `vlib/db/sqlite/sqlite.c.v`
- Populates `cols` via the already-bound `C.sqlite3_column_name` in `exec()` and `exec_param_many()`
- Backwards-compatible — existing code reading `.vals` is unaffected
- Enables callers to access column names alongside values without separate queries or SQL parsing

## Motivation
`Row` currently only exposes `vals []string`, so callers needing column names must parse SQL or run `PRAGMA table_info` separately. The C API already provides column names at the statement level via `sqlite3_column_name` (already declared in `sqlite.c.v` line 115 and used in `exec_map`). This change makes the same information available through the standard `exec()` path.

## Test plan
- [x] New `test_exec_returns_column_names` covers `exec`, `exec_one`, and `exec_param`
- [x] All existing `sqlite_test.v` tests pass unchanged
- [x] `./vnew -d present_sqlite3 test vlib/db/sqlite/sqlite_test.v` — 1 passed, 0 failed
- [x] `./vnew fmt -verify` clean on both touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)