### PR TITLE
db.sqlite: add tables, columns, schema, db_size methods

### DIFF
--- a/vlib/db/sqlite/sqlite.c.v
+++ b/vlib/db/sqlite/sqlite.c.v
@@ -582,6 +582,37 @@ pub fn (mut db DB) release_savepoint(savepoint string) ! {
 	db.exec('RELEASE SAVEPOINT ${savepoint};')!
 }
 
+// tables returns the names of all user tables in the database.
+pub fn (db &DB) tables() ![]string {
+	rows := db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name")!
+	return rows.map(it.vals[0])
+}
+
+// columns returns the column names for the given table.
+pub fn (db &DB) columns(table string) ![]string {
+	rows := db.exec('PRAGMA table_info(${table})')!
+	return rows.map(it.vals[1])
+}
+
+// schema returns the CREATE statement(s) for the given table, or for all
+// objects if table is empty.
+pub fn (db &DB) schema(table string) !string {
+	filter := if table != '' { "AND name='${table}'" } else { '' }
+	rows := db.exec("SELECT sql FROM sqlite_master WHERE type IN ('table','index','view','trigger') ${filter} AND sql IS NOT NULL ORDER BY type, name")!
+	return rows.map(it.vals[0]).join('\n\n')
+}
+
+// db_size returns the database file size in bytes, computed from page_count
+// and page_size.
+pub fn (db &DB) db_size() !i64 {
+	pc := db.exec('PRAGMA page_count')!
+	ps := db.exec('PRAGMA page_size')!
+	if pc.len == 0 || ps.len == 0 {
+		return 0
+	}
+	return pc[0].vals[0].i64() * ps[0].vals[0].i64()
+}
+
 // reset returns the connection to initial state for reuse
 pub fn (mut db DB) reset() ! {
 }

--- a/vlib/db/sqlite/sqlite.c.v
+++ b/vlib/db/sqlite/sqlite.c.v
@@ -590,14 +590,20 @@ pub fn (db &DB) tables() ![]string {
 
 // columns returns the column names for the given table.
 pub fn (db &DB) columns(table string) ![]string {
-	rows := db.exec('PRAGMA table_info(${table})')!
+	escaped := table.replace('"', '""')
+	rows := db.exec('PRAGMA table_info("${escaped}")')!
 	return rows.map(it.vals[1])
 }
 
 // schema returns the CREATE statement(s) for the given table, or for all
 // objects if table is empty.
 pub fn (db &DB) schema(table string) !string {
-	filter := if table != '' { "AND name='${table}'" } else { '' }
+	filter := if table != '' {
+		escaped := table.replace("'", "''")
+		"AND name='${escaped}'"
+	} else {
+		''
+	}
 	rows := db.exec("SELECT sql FROM sqlite_master WHERE type IN ('table','index','view','trigger') ${filter} AND sql IS NOT NULL ORDER BY type, name")!
 	return rows.map(it.vals[0]).join('\n\n')
 }

--- a/vlib/db/sqlite/sqlite_test.v
+++ b/vlib/db/sqlite/sqlite_test.v
@@ -1,6 +1,7 @@
 // vtest build: present_sqlite3?
 import db.sqlite
 import orm
+import os
 
 type Connection = sqlite.DB
 
@@ -145,6 +146,46 @@ fn test_exec_param_many2() {
 	count := db.q_int('select count(*) from users')!
 	assert count == 3
 
+	db.close()!
+}
+
+fn test_tables() {
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+	db.exec('create table alpha (id integer)')!
+	db.exec('create table beta (id integer)')!
+	tbl := db.tables()!
+	assert tbl == ['alpha', 'beta']
+	db.close()!
+}
+
+fn test_columns() {
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+	db.exec('create table items (id integer primary key, name text, price real)')!
+	cols := db.columns('items')!
+	assert cols == ['id', 'name', 'price']
+	db.close()!
+}
+
+fn test_schema() {
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+	db.exec('create table things (id integer primary key, label text)')!
+	s := db.schema('things')!
+	assert s.contains('CREATE TABLE things')
+	// empty table name returns all objects
+	all := db.schema('')!
+	assert all.contains('CREATE TABLE things')
+	db.close()!
+}
+
+fn test_db_size() {
+	tmp := os.join_path(os.temp_dir(), 'test_db_size.db')
+	defer {
+		os.rm(tmp) or {}
+	}
+	mut db := sqlite.connect(tmp) or { panic(err) }
+	db.exec('create table t (id integer)')!
+	sz := db.db_size()!
+	assert sz > 0
 	db.close()!
 }
 


### PR DESCRIPTION
## Summary
- Adds `tables()`, `columns(table)`, `schema(table)`, and `db_size()` convenience methods to `sqlite.DB`
- All use existing `exec()` internally — no new C bindings
- Common introspection queries that currently require raw SQL from every caller

## Methods
| Method | Returns | Query |
|--------|---------|-------|
| `tables()` | `![]string` | `SELECT name FROM sqlite_master WHERE type='table'` |
| `columns(table)` | `![]string` | `PRAGMA table_info(table)` |
| `schema(table)` | `!string` | `SELECT sql FROM sqlite_master` (filtered or all) |
| `db_size()` | `!i64` | `PRAGMA page_count * page_size` |

## Test plan
- [x] `test_tables` — creates two tables, verifies sorted names
- [x] `test_columns` — verifies column names from `PRAGMA table_info`
- [x] `test_schema` — verifies CREATE statement content, single and all
- [x] `test_db_size` — file-backed DB reports size > 0
- [x] All existing tests pass unchanged
- [x] `./vnew -d present_sqlite3 test vlib/db/sqlite/sqlite_test.v` — 1 passed, 0 failed
- [x] `./vnew fmt -verify` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)