### PR TITLE
docs: document sqlite convenience methods and interactive CLI

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -5639,13 +5639,40 @@ instead:
 - Fedora/RHEL: `sudo dnf -y install sqlite-devel`
 - Arch: `sudo pacman -S sqlite`
 
+### Interactive SQLite CLI
+
+V includes a built-in SQLite CLI (`v sqlite`) as a V-native
+replacement for `sqlite3`:
+
+```sh
+v sqlite mydb.db
+```
+
+It provides a full readline REPL with history and tab completion,
+9 output modes, `.dump`, `.import`/`.export`, `.backup`, session
+control, and schema tools. Run `.help` inside the REPL for the
+full command list.
+
+### Convenience Methods
+
+The `db.sqlite` module includes helper methods for common queries:
+
+```v ignore
+db.tables()!         // list all user table names
+db.columns('users')! // column names for a table
+db.schema('users')!  // CREATE statement(s)
+db.db_size()!        // file size in bytes
+```
+
 ### Using the self contained SQLite module
-V also maintains a separate `sqlite` module, that wraps an SQLite amalgamation, but otherwise
-has the same API as the `db.sqlite` module. Its benefit, is that with it, you do not need to
-install a separate system level sqlite package/library on your system (which can be hard on
-some systems like windows, or systems with musl for example).
-Its negative is that it can make your compilations a bit slower (since it compiles SQLite
-from C, in addition to your own code).
+
+V also maintains a separate `sqlite` module, that wraps an SQLite
+amalgamation, but otherwise has the same API as the `db.sqlite`
+module. Its benefit is that you do not need to install a separate
+system-level sqlite package (which can be hard on some systems
+like Windows, or systems with musl for example). Its downside is
+that it can make compilations a bit slower since it compiles
+SQLite from C in addition to your own code.
 
 To use it, do:
 ```sh

--- a/vlib/db/sqlite/README.md
+++ b/vlib/db/sqlite/README.md
@@ -21,6 +21,43 @@ instead:
 - Fedora/RHEL: `sudo dnf -y install sqlite-devel`
 - Arch: `sudo pacman -S sqlite`
 
+# Convenience Methods
+
+The `DB` struct provides several helper methods for common
+introspection queries:
+
+```v
+import db.sqlite
+
+db := sqlite.connect('mydb.db') or { panic(err) }
+
+// List all user tables
+tables := db.tables()!
+
+// Get column names for a table
+cols := db.columns('users')!
+
+// Get CREATE statements (single table or all objects)
+s := db.schema('users')!
+
+// Database file size in bytes
+size := db.db_size()!
+```
+
+# Interactive CLI
+
+V includes a built-in SQLite CLI as a replacement for `sqlite3`:
+
+```sh
+v sqlite mydb.db
+```
+
+Features include a full readline REPL with history and tab
+completion, 9 output modes (`table`, `box`, `markdown`, `csv`,
+`json`, `line`, `html`, `insert`, `quote`), `.dump`,
+`.import`/`.export`, `.backup`, session control, and schema tools.
+Run `.help` inside the REPL for the full command list.
+
 # Performance Tips
 
 When performing a large amount of database calls (i.e. INSERTS), significant


### PR DESCRIPTION
## Summary
- Adds "Convenience Methods" and "Interactive CLI" sections to `vlib/db/sqlite/README.md`
  (rendered at https://modules.vlang.io/db.sqlite.html)
- Adds "Interactive SQLite CLI" and "Convenience Methods" sections to `doc/docs.md`
  (rendered at https://docs.vlang.io/orm.html#using-the-self-contained-sqlite-module)
- Cleans up the self-contained sqlite module section text

## Context
Follows #26791 which added `tables()`, `columns()`, `schema()`, and `db_size()` to `sqlite.DB`.
The interactive CLI (`v sqlite`) documentation is forward-looking for the upcoming CLI tool PR.

## Test plan
- [x] `./vnew check-md vlib/db/sqlite/README.md` — 0 errors, 0 warnings
- [x] `./vnew check-md doc/docs.md` — 0 errors, 0 warnings
- Docs-only change, no code tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)