### PR TITLE
cgen: stop treating every `.m` as an Objective-C import

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6157,10 +6157,11 @@ fn (mut g Gen) hash_stmt(node ast.HashStmt) {
 	} else {
 		&ast.HashStmtNode(&node)
 	}
+	is_objc_target := is_objc_hash_target(node.kind, node.main)
 
 	match node.kind {
 		'include', 'insert', 'define' {
-			if node.main.contains('.m') {
+			if is_objc_target {
 				// Objective C code import, include it after V types, so that e.g. `string` is
 				// available there
 				if the_node !in g.definition_nodes {
@@ -6173,7 +6174,7 @@ fn (mut g Gen) hash_stmt(node ast.HashStmt) {
 			}
 		}
 		'preinclude' {
-			if node.main.contains('.m') {
+			if is_objc_target {
 				// Objective C code import, include it after V types, so that e.g. `string` is
 				// available there
 				if the_node !in g.definition_nodes {
@@ -6192,6 +6193,18 @@ fn (mut g Gen) hash_stmt(node ast.HashStmt) {
 		}
 		else {}
 	}
+}
+
+fn is_objc_hash_target(kind string, raw_target string) bool {
+	if kind !in ['include', 'preinclude'] {
+		return false
+	}
+	mut target := raw_target.trim_space()
+	if target.len >= 2 && ((target.starts_with('"') && target.ends_with('"'))
+		|| (target.starts_with('<') && target.ends_with('>'))) {
+		target = target[1..target.len - 1]
+	}
+	return os.file_name(target).ends_with('.m')
 }
 
 fn (mut g Gen) gen_hash_stmts(mut sb strings.Builder, node &ast.HashStmtNode, section string) {
@@ -6250,12 +6263,13 @@ fn (mut g Gen) gen_hash_stmts(mut sb strings.Builder, node &ast.HashStmtNode, se
 			// #inlude,#define,#insert          => `includes` section
 			// #postinclude                     => `postincludes` section
 			// '*.m' in #include or #preinclude => `definitions` section
+			is_objc_target := is_objc_hash_target(node.kind, node.main)
 			need_gen_stmt := match section {
 				'preincludes' {
-					if node.kind == 'preinclude' && !node.main.contains('.m') { true } else { false }
+					if node.kind == 'preinclude' && !is_objc_target { true } else { false }
 				}
 				'includes' {
-					if node.kind in ['include', 'define', 'insert'] && !node.main.contains('.m') {
+					if node.kind in ['include', 'define', 'insert'] && !is_objc_target {
 						true
 					} else {
 						false
@@ -6264,7 +6278,7 @@ fn (mut g Gen) gen_hash_stmts(mut sb strings.Builder, node &ast.HashStmtNode, se
 				'definitions' {
 					// Objective C code import, include it after V types, so that e.g. `string` is
 					// available there
-					if node.kind in ['include', 'preinclude'] && node.main.contains('.m') {
+					if node.kind in ['include', 'preinclude'] && is_objc_target {
 						true
 					} else {
 						false

--- a/vlib/v/gen/c/testdata/hash_stmt_dot_m_false_positive.c.must_have
+++ b/vlib/v/gen/c/testdata/hash_stmt_dot_m_false_positive.c.must_have
@@ -1,0 +1,2 @@
+#define DOT_M_INSERT_OK 1
+#define DOT_M_DEFINE_OK "tmp/project.m/value.h"

--- a/vlib/v/gen/c/testdata/hash_stmt_dot_m_false_positive.m.h
+++ b/vlib/v/gen/c/testdata/hash_stmt_dot_m_false_positive.m.h
@@ -1,0 +1,1 @@
+#define DOT_M_INSERT_OK 1

--- a/vlib/v/gen/c/testdata/hash_stmt_dot_m_false_positive.vv
+++ b/vlib/v/gen/c/testdata/hash_stmt_dot_m_false_positive.vv
@@ -1,0 +1,6 @@
+// This reproduces a false positive in the old `.contains('.m')` check:
+// neither the inserted header nor the define value is an Objective-C `.m` import.
+#insert "@DIR/hash_stmt_dot_m_false_positive.m.h"
+#define DOT_M_DEFINE_OK "tmp/project.m/value.h"
+
+fn main() {}


### PR DESCRIPTION
This fixes a cgen bug where C hash directives could disappear from the generated C output if their text happened to contain `.m` in the wrong place.

The old logic used a plain `contains('.m')` check to decide whether a directive should be treated as an Objective-C include and deferred until after V type definitions. That was too broad. It could misclassify things like:
- `#insert` with a path that contains `.m`
- `#define` with a value that contains `.m`

When that happened, the directive was moved out of the normal include flow and never emitted.

This change tightens the check so the Objective-C path only applies to `#include` and `#preinclude` directives whose target file actually ends with `.m`.