### PR TITLE
cmd/tools/vsqlite: route dot commands from CLI args to dot_cmd

### DIFF
--- a/cmd/tools/vsqlite/main.v
+++ b/cmd/tools/vsqlite/main.v
@@ -122,7 +122,12 @@ fn main() {
 		}
 		app.exec_file(args[2])
 	} else {
-		app.run(args[1..].join(' '))
+		cmd := args[1..].join(' ')
+		if cmd.starts_with('.') {
+			app.dot_cmd(cmd)
+		} else {
+			app.run(cmd)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #26793.

When a dot command (e.g. `.tables`, `.schema foo`) was passed as a CLI argument:

```sh
v sqlite mydb.db .tables
```

it was routed to `app.run()` which only handles SQL, causing `exec_none` to return code -1 and print an error. Dot commands must go to `app.dot_cmd()` instead.

**Fix:** check whether the CLI argument starts with `.` and dispatch accordingly.

## Test

```sh
v sqlite mydb.db .tables          # now lists tables correctly
v sqlite mydb.db ".schema mytbl"  # now shows schema correctly
v sqlite mydb.db "SELECT 1"       # SQL still works as before
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)