### PR TITLE
repl: mkdir temp folder before chdir to avoid startup failure

### DIFF
--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -458,6 +458,7 @@ fn remove_comment(oline string) string {
 }
 
 fn run_repl(workdir string, vrepl_prefix string) int {
+	os.mkdir_all(workdir) or {}
 	os.chdir(workdir) or {
 		rerror('Could not change the REPL working folder to `${workdir}`: ${err}')
 		return 1

--- a/cmd/tools/vrepl.v
+++ b/cmd/tools/vrepl.v
@@ -458,7 +458,10 @@ fn remove_comment(oline string) string {
 }
 
 fn run_repl(workdir string, vrepl_prefix string) int {
-	os.mkdir_all(workdir) or {}
+	os.mkdir_all(workdir) or {
+		rerror('Could not create the REPL working folder `${workdir}`: ${err}')
+		return 1
+	}
 	os.chdir(workdir) or {
 		rerror('Could not change the REPL working folder to `${workdir}`: ${err}')
 		return 1


### PR DESCRIPTION
## Summary

- `run_repl` called `os.chdir(workdir)` before `new_repl(workdir)`, so the `os.mkdir_all` inside `new_repl` was never reached when the temp directory did not exist
- Fix: add `os.mkdir_all(workdir) or {}` before `os.chdir` in `run_repl`
- Reproduces whenever `$TEMP/v_0/repl` does not exist (e.g. freshly cleared temp folder)

Fixes #26804

## Test plan

- [ ] Run `v` with a cleared temp folder — REPL starts without error
- [ ] `./vnew -silent vlib/v/slow_tests/repl/repl_test.v`
