### PR TITLE
ci: fix v-analyzer build in "V Apps and Modules" workflow

### DIFF
--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -43,6 +43,7 @@ jobs:
             v retry -- sudo apt -qq install libgc-dev libsodium-dev libssl-dev sqlite3 libsqlite3-dev
             v retry -- sudo apt -qq install libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev xfonts-75dpi xfonts-base libegl-dev
             v retry -- sudo apt -qq install sassc libgit2-dev # needed by gitly
+            v retry -- sudo apt -qq install libunwind-18-dev # needed by v-analyzer for libbacktrace
           else
             v retry brew install sassc libgit2
           fi


### PR DESCRIPTION
In `v-apps-compile` job, install `libunwind-18-dev` depend to build `v-analyzer` with `libbacktrace` (include `unwind.h` needed)

Fix #26806 

---

**Successful run** of this workflow with fix to build `v-analyzer` => https://github.com/lcheylus/v/actions/runs/23901496224/job/69699032727