### PR TITLE
parser: fix closure auto import for field names

### DIFF
--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -2240,15 +2240,7 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 	} else {
 		p.name_error = true
 	}
-	if ast.builtin_array_generic_methods_matcher.matches(field_name) {
-		if p.file_backend_mode == .v || p.file_backend_mode == .c {
-			p.register_auto_import('builtin.closure')
-		}
-		p.open_scope()
-		defer(fn) {
-			p.close_scope()
-		}
-	}
+	is_builtin_array_generic_method := ast.builtin_array_generic_methods_matcher.matches(field_name)
 	// ! in mutable methods
 	if p.tok.kind == .not && p.peek_tok.kind == .lpar {
 		p.next()
@@ -2270,6 +2262,15 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 		}
 	}
 	if p.tok.kind == .lpar {
+		if is_builtin_array_generic_method {
+			if p.file_backend_mode == .v || p.file_backend_mode == .c {
+				p.register_auto_import('builtin.closure')
+			}
+			p.open_scope()
+			defer(fn) {
+				p.close_scope()
+			}
+		}
 		p.next()
 		args := p.call_args()
 		p.check(.rpar)

--- a/vlib/v/parser/v_parser_test.v
+++ b/vlib/v/parser/v_parser_test.v
@@ -477,3 +477,22 @@ x end_comment'
 y comment line2
 y end_comment'
 }
+
+fn test_no_closure_auto_import_for_field_names() {
+	vpref := &pref.Preferences{}
+	for field_name in ast.builtin_array_generic_methods {
+		source := 'struct Sample {
+mut:
+	${field_name} u32
+}
+
+fn use_field(mut sample Sample) {
+	_ = sample.${field_name}
+	sample.${field_name}++
+}
+'
+		mut table := ast.new_table()
+		prog := parse_text(source, '', mut table, .skip_comments, vpref)
+		assert 'builtin.closure' !in prog.auto_imports
+	}
+}


### PR DESCRIPTION
Do not auto-import `builtin.closure` for field names that match builtin array method names.

This keeps names like `all`, `any`, `count`, `filter`, `map`, `sort`, and `sorted` usable as normal struct fields, including with `-no-builtin`.

```v
struct Semaphore {
mut:
	count   u32
}

fn (mut self Semaphore) acquire() {
	self.count++
}
```

This code cannot compile with `-no-builtin` before because the compiler will import `closure ` automatically.