### PR TITLE
cgen: keep interface typeof independent of builtin string

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1388,11 +1388,11 @@ pub fn (mut g Gen) write_typeof_functions() {
 			}
 			already_generated_ifaces[sym.cname] = true
 			impl_types := inter_info.implementor_types(true)
-			g.definitions.writeln('${g.static_non_parallel}string v_typeof_interface_${sym.cname}(u32 sidx);')
+			g.definitions.writeln('${g.static_non_parallel}char * v_typeof_interface_${sym.cname}(u32 sidx);')
 			if g.pref.parallel_cc {
-				g.extern_out.writeln('extern string v_typeof_interface_${sym.cname}(u32 sidx);')
+				g.extern_out.writeln('extern char * v_typeof_interface_${sym.cname}(u32 sidx);')
 			}
-			g.writeln('${g.static_non_parallel}string v_typeof_interface_${sym.cname}(u32 sidx) {')
+			g.writeln('${g.static_non_parallel}char * v_typeof_interface_${sym.cname}(u32 sidx) {')
 			for t in impl_types {
 				sub_sym := g.table.sym(ast.mktyp(t))
 				if sub_sym.kind == .interface {
@@ -1405,9 +1405,9 @@ pub fn (mut g Gen) write_typeof_functions() {
 					&& sub_sym.idx !in g.table.used_features.used_syms {
 					continue
 				}
-				g.writeln('\tif (sidx == _${sym.cname}_${sub_sym.cname}_index) return _S("${util.strip_main_name(sub_sym.name)}");')
+				g.writeln('\tif (sidx == _${sym.cname}_${sub_sym.cname}_index) return "${util.strip_main_name(sub_sym.name)}";')
 			}
-			g.writeln2('\treturn _S("unknown ${util.strip_main_name(sym.name)}");', '}')
+			g.writeln2('\treturn "unknown ${util.strip_main_name(sym.name)}";', '}')
 			// Avoid duplicate symbol '_v_typeof_interface_idx_IError' when using -usecache
 			if g.pref.build_mode != .build_module {
 				interface_idx_static_prefix := if g.pref.is_o { 'static ' } else { '' }
@@ -11664,7 +11664,7 @@ return ${cast_shared_struct_str};
 					conversion_functions.writeln('\tif (x._typ == _${interface_name}_${variant_sym.cname}_index) return I_${variant_sym.cname}_to_Interface_${vsym.cname}(x._${variant_sym.cname});')
 				}
 			}
-			pmessage := 'builtin__string__plus(builtin__string__plus(_S("`as_cast`: cannot convert "), v_typeof_interface_${interface_name}(x._typ)), _S(" to ${util.strip_main_name(vsym.name)}"))'
+			pmessage := 'builtin__string__plus(builtin__string__plus(_S("`as_cast`: cannot convert "), builtin__tos3(v_typeof_interface_${interface_name}(x._typ))), _S(" to ${util.strip_main_name(vsym.name)}"))'
 			if g.pref.is_debug {
 				// TODO: actually return a valid position here
 				conversion_functions.write_string2('\tbuiltin__panic_debug(1, builtin__tos3("builtin.v"), builtin__tos3("builtin"), builtin__tos3("__as_cast"), ',

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -4194,7 +4194,8 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 						')', node)
 					return
 				} else if left_sym.kind == .interface {
-					g.conversion_function_call('v_typeof_interface_${typ_sym.cname}', '', node)
+					g.conversion_function_call('builtin__charptr_vstring_literal(v_typeof_interface_${typ_sym.cname}',
+						')', node)
 					return
 				}
 			}

--- a/vlib/v/gen/c/testdata/interface_type_name.c.must_have
+++ b/vlib/v/gen/c/testdata/interface_type_name.c.must_have
@@ -1,0 +1,1 @@
+builtin__charptr_vstring_literal(v_typeof_interface_main__Thing(

--- a/vlib/v/gen/c/testdata/interface_type_name.vv
+++ b/vlib/v/gen/c/testdata/interface_type_name.vv
@@ -1,0 +1,8 @@
+interface Thing {}
+
+struct Item {}
+
+fn main() {
+	t := Thing(Item{})
+	println(t.type_name())
+}

--- a/vlib/v/gen/c/testdata/no_builtin_interface_typeof.c.must_have
+++ b/vlib/v/gen/c/testdata/no_builtin_interface_typeof.c.must_have
@@ -1,0 +1,3 @@
+static char * v_typeof_interface_main__Thing(u32 sidx) {
+if (sidx == _main__Thing_main__Item_index) return "Item";
+return "unknown Thing";

--- a/vlib/v/gen/c/testdata/no_builtin_interface_typeof.vv
+++ b/vlib/v/gen/c/testdata/no_builtin_interface_typeof.vv
@@ -1,0 +1,9 @@
+// vtest vflags: -no-builtin
+interface Thing {}
+
+struct Item {}
+
+fn main() {
+	h := Thing(Item{})
+	_ = h
+}


### PR DESCRIPTION
This regressed in #26772, which changed `v_typeof_interface_*` helpers from `char *` to `string` and introduced an unnecessary builtin string dependency into interface runtime support.

These helpers are part of runtime interface support and should not depend on builtin string machinery by default.

This PR restores `v_typeof_interface_*` to `char *`. Call sites that really need a V `string` now convert locally instead of pushing builtin string semantics into the helper itself.
