### PR TITLE
ci: increase timeout for gcc-freebsd job in FreeBSD workflow

### DIFF
--- a/.github/workflows/freebsd_ci.yml
+++ b/.github/workflows/freebsd_ci.yml
@@ -93,7 +93,7 @@ jobs:
 
   gcc-freebsd:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Tests on FreeBSD with gcc


### PR DESCRIPTION
In "CI FreeBSD" workflow, some runs of `gcc-freebsd job` fails due to time-out (defined to 20 minutes).
For example, this run for "CI FreeBSD" https://github.com/vlang/v/actions/runs/23909219966

Increase timeout to 30 minutes for `gcc-freebsd job`