### PR TITLE
sqlite: use bundled amalgamation on Linux/macOS when pkg-config is unavailable

### DIFF
--- a/vlib/db/sqlite/sqlite.c.v
+++ b/vlib/db/sqlite/sqlite.c.v
@@ -11,7 +11,7 @@ $if $pkgconfig('sqlite3') {
 	#flag windows -L@VEXEROOT/thirdparty/sqlite
 	#flag windows @VEXEROOT/thirdparty/sqlite/sqlite3.o
 } $else {
-	#flag -lsqlite3
+	#flag @VEXEROOT/thirdparty/sqlite/sqlite3.c
 }
 #include "sqlite3.h" # The SQLite header file is missing. Please run vlib/db/sqlite/install_thirdparty_sqlite.vsh to download an SQLite amalgamation, or install its development package.
 


### PR DESCRIPTION
## Summary

- When `pkg-config sqlite3` fails on Linux/macOS, the module previously fell back to `-lsqlite3`, which requires a system development package to be installed
- This PR replaces that fallback with `#flag @VEXEROOT/thirdparty/sqlite/sqlite3.c`, compiling the bundled amalgamation directly — consistent with what already works on Windows
- Users without a system SQLite package can run `vlib/db/sqlite/install_thirdparty_sqlite.vsh` to obtain the amalgamation

## Test plan

- [ ] Run `vlib/db/sqlite/install_thirdparty_sqlite.vsh` on a Linux system without `libsqlite3-dev` installed
- [ ] Verify `v run vlib/db/sqlite/sqlite_test.v` passes

Fixes #26830 