### PR TITLE
vfmt: prioritize internal error exit code (5) over format-diff exit codes

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -145,19 +145,24 @@ fn main() {
 		}
 		errors++
 	}
-	ecode := if has_internal_error { 5 } else { 0 }
+	if has_internal_error {
+		// When some files could not be processed due to internal vfmt errors,
+		// exit with code 5 regardless of format-diff errors in other files.
+		// This prevents exit codes like 7 (2+5) that confuse downstream CI checks.
+		exit(5)
+	}
 	if errors > 0 {
 		if !foptions.is_diff {
 			eprintln('Encountered a total of: ${errors} formatting errors.')
 		}
 		match true {
-			foptions.is_noerror { exit(0 + ecode) }
-			foptions.is_verify { exit(1 + ecode) }
-			foptions.is_c { exit(2 + ecode) }
-			else { exit(1 + ecode) }
+			foptions.is_noerror { exit(0) }
+			foptions.is_verify { exit(1) }
+			foptions.is_c { exit(2) }
+			else { exit(1) }
 		}
 	}
-	exit(ecode)
+	exit(0)
 }
 
 fn (foptions &FormatOptions) verify_file(prefs &pref.Preferences, fpath string) bool {


### PR DESCRIPTION
## Summary

- When vfmt encounters **both** internal processing errors (e.g., TCC crash on one file) **and** format differences in other files, the old code combined exit codes: `2` (format diffs with `-c`) + `5` (internal error) = `7`
- Exit code `7` is not handled by CI scripts that explicitly tolerate `exit_code -ne 5`, causing false CI failures
- Fix: when `has_internal_error` is true, `exit(5)` immediately, before evaluating any format-diff errors — the internal error takes priority

## Motivation

The `Format vlang/v-analyzer` CI step in `v_apps_and_modules_compile_ci.yml` uses:
```yaml
exit_code=$?; if [ $exit_code -ne 0 ] && [ $exit_code -ne 5 ]; then exit $exit_code; fi
```
This correctly tolerates exit 5 (TCC crash on a complex file). But when vfmt also found format diffs in *other* files before crashing, the old logic added the codes together, producing 7, which fails the check.

## Test plan

- [ ] Confirm `vfmt -c` on a mix of "internal error" files and "needs formatting" files exits with `5`, not `7`
- [ ] Confirm `vfmt -c` on only "needs formatting" files still exits with `2`
- [ ] Confirm `vfmt -c` on correctly-formatted files still exits with `0`

Closes: #26853

🤖 Generated with [Claude Code](https://claude.ai/claude-code)