### PR TITLE
ci: fix vtcc int(0x8000_0000) overflow; document discord.v disable

### DIFF
--- a/.github/workflows/compile_discordv.sh
+++ b/.github/workflows/compile_discordv.sh
@@ -6,20 +6,20 @@ function show() {
 	printf "\u001b[35m$1\u001b[0m\n"
 }
 
-## Disabled: discord.v uses x.json2.raw_decode which was deprecated-as-error in V on 2025-10-10.
+## NOTE: this step is disabled in v_apps_and_modules_compile_ci.yml via `${{ false && ... }}`.
+## Reason: discord.v uses x.json2.raw_decode which was deprecated-as-error in V on 2025-10-10.
 ## The upstream repo (vcv88/discord.v) has not been updated since Dec 2024.
-## Track: https://github.com/vlang/v/issues/26853 / https://github.com/vcv88/discord.v/issues/21
-echo "discord.v test is temporarily disabled pending upstream fix (see vlang/v#26853)"
-exit 0
+## Re-enable both the yml step and this script once vcv88/discord.v#21 is resolved.
+## Track: https://github.com/vlang/v/issues/26853
 
-## Original code below; re-enable once vcv88/discord.v#21 is resolved:
-# rm -rf discord/
-# show "Clone https://github.com/vcv88/discord.v"
-# v retry -- git clone --filter=blob:none --quiet https://github.com/vcv88/discord.v discord/
-# cd discord/
-# show "Checkout last known good commit"
-# git checkout ce9ff457fce92d5bb15df2974440cd8292457ee0
-# show "Execute Tests"
-# v test .
-# cd ..
-# rm -rf discord/
+rm -rf discord/
+
+show "Clone https://github.com/vcv88/discord.v"
+v retry -- git clone --filter=blob:none --quiet https://github.com/vcv88/discord.v discord/
+cd discord/
+show "Checkout last known good commit"
+git checkout ce9ff457fce92d5bb15df2974440cd8292457ee0
+show "Execute Tests"
+v test .
+cd ..
+rm -rf discord/

--- a/.github/workflows/compile_discordv.sh
+++ b/.github/workflows/compile_discordv.sh
@@ -6,14 +6,20 @@ function show() {
 	printf "\u001b[35m$1\u001b[0m\n"
 }
 
-rm -rf discord/
+## Disabled: discord.v uses x.json2.raw_decode which was deprecated-as-error in V on 2025-10-10.
+## The upstream repo (vcv88/discord.v) has not been updated since Dec 2024.
+## Track: https://github.com/vlang/v/issues/26853 / https://github.com/vcv88/discord.v/issues/21
+echo "discord.v test is temporarily disabled pending upstream fix (see vlang/v#26853)"
+exit 0
 
-show "Clone https://github.com/vcv88/discord.v"
-v retry -- git clone --filter=blob:none --quiet https://github.com/vcv88/discord.v discord/
-cd discord/
-show "Checkout last known good commit"
-git checkout ce9ff457fce92d5bb15df2974440cd8292457ee0
-show "Execute Tests"
-v test .
-cd ..
-rm -rf discord/
+## Original code below; re-enable once vcv88/discord.v#21 is resolved:
+# rm -rf discord/
+# show "Clone https://github.com/vcv88/discord.v"
+# v retry -- git clone --filter=blob:none --quiet https://github.com/vcv88/discord.v discord/
+# cd discord/
+# show "Checkout last known good commit"
+# git checkout ce9ff457fce92d5bb15df2974440cd8292457ee0
+# show "Execute Tests"
+# v test .
+# cd ..
+# rm -rf discord/

--- a/.github/workflows/compile_v_with_vtcc.sh
+++ b/.github/workflows/compile_v_with_vtcc.sh
@@ -13,6 +13,11 @@ show "Clone vtcc"
 .github/workflows/retry.sh git clone https://github.com/felipensp/vtcc --branch stable --quiet vtcc/
 du -s vtcc/
 ## TODO: just `./v vtcc`, later will cause V, to detect the compiler as tcc (which it is), and add `-fwrapv`, which causes the vtcc compiler to panic currently
+show "Patch vtcc: fix int(0x8000_0000) overflow (felipensp/vtcc#6 / vlang/v#26853)"
+## 0x8000_0000 = 2147483648 overflows V's int (max 2147483647).
+## This causes a V warning (soon: hard error) and TCC rejects the generated C.
+sed -i 's/const shf_private = int(0x8000_0000)/const shf_private = u32(0x8000_0000)/' vtcc/src/tccelf.v
+
 show "Compile vtcc"
 cd vtcc/
 v run make.vsh


### PR DESCRIPTION
## Summary

Two CI fixes for the `v-apps-compile` job (tracked in #26853):

### vtcc — `int(0x8000_0000)` integer overflow

`felipensp/vtcc` (stable branch, `src/tccelf.v`) declares:
```v
const shf_private = int(0x8000_0000)
```
`0x8000_0000 = 2147483648` overflows V's `int` (max 2147483647). V emits a warning today and will make this a hard error soon. TCC then rejects the generated C with:
```
error: invalid operand types for binary operation
```
causing the entire `Test vtcc` CI step to fail on ubuntu-latest.

**Fix:** patch the constant to `u32(0x8000_0000)` with `sed` before compiling vtcc. Upstream issue: felipensp/vtcc#6.

### discord.v — document the temporary disable

The `compile_discordv.sh` script still contained the original cloning/testing code even though the yml step has been guarded with `${{ false && ... }}`. Added an early `exit 0` with a comment explaining why (uses deprecated `json2.raw_decode`) and linking to the upstream issue (vcv88/discord.v#21) so it's easy to re-enable once fixed.

## Test plan

- [ ] `Test vtcc` step passes on ubuntu-latest (was failing with C compile error)
- [ ] `Test discord.v` step remains disabled without error
- [ ] No other CI steps regress

Closes: #26853 (partially — vtcc fix; ui and vfmt fixes in separate PRs)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)