### PR TITLE
ci: update cross-platform-actions/action action for BSD workflows

### DIFF
--- a/.github/workflows/freebsd_ci.yml
+++ b/.github/workflows/freebsd_ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Tests on FreeBSD with tcc
         id: tests-freebsd-tcc
-        uses: cross-platform-actions/action@v0.32.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: freebsd
           version: '15.0'
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Tests on FreeBSD with clang
         id: tests-freebsd-clang
-        uses: cross-platform-actions/action@v0.32.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: freebsd
           version: '15.0'
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Tests on FreeBSD with gcc
         id: tests-freebsd-gcc
-        uses: cross-platform-actions/action@v0.32.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: freebsd
           version: '15.0'

--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Tests on OpenBSD with tcc
         id: tests-openbsd-tcc
-        uses: cross-platform-actions/action@v0.32.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: openbsd
           version: '7.8'
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Tests on OpenBSD with clang
         id: tests-openbsd-clang
-        uses: cross-platform-actions/action@v0.32.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: openbsd
           version: '7.8'

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -147,7 +147,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Tests tools on FreeBSD with ${{ matrix.cc }}
-        uses: cross-platform-actions/action@v0.32.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: freebsd
           version: '15.0'
@@ -196,7 +196,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Tests tools on OpenBSD with ${{ matrix.cc }}
-        uses: cross-platform-actions/action@v0.32.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: openbsd
           version: '7.8'


### PR DESCRIPTION
Update action `cross-platform-actions/action` to version 1.0.0 for FreeBSD/OpenBSD CI and Tools CI.

Cross Platform Action release 1.0.0: https://github.com/cross-platform-actions/action/releases/tag/v1.0.0