### PR TITLE
ci: fix vtcc shf_private patch — use int(-2147483648) not u32

### DIFF
--- a/.github/workflows/compile_v_with_vtcc.sh
+++ b/.github/workflows/compile_v_with_vtcc.sh
@@ -16,7 +16,10 @@ du -s vtcc/
 show "Patch vtcc: fix int(0x8000_0000) overflow (felipensp/vtcc#6 / vlang/v#26853)"
 ## 0x8000_0000 = 2147483648 overflows V's int (max 2147483647).
 ## This causes a V warning (soon: hard error) and TCC rejects the generated C.
-sed -i 's/const shf_private = int(0x8000_0000)/const shf_private = u32(0x8000_0000)/' vtcc/src/tccelf.v
+## Use int(-2147483648) = INT_MIN, same bit pattern as 0x8000_0000 in two's complement.
+## Changing to u32 causes a type mismatch when the flag is OR-ed with other int constants
+## and passed to new_symtab/new_section which take sh_flags int.
+sed -i 's/const shf_private = int(0x8000_0000)/const shf_private = int(-2147483648)/' vtcc/src/tccelf.v
 
 show "Compile vtcc"
 cd vtcc/


### PR DESCRIPTION
## Follow-up to #26858

The vtcc patch in #26858 changed `const shf_private = int(0x8000_0000)` → `u32(0x8000_0000)`, which fixed the overflow warning but introduced a new compile error:

```
failed src/tccelf.v:49:65: error: `(shf_private | shf_dynsym)` (no value) used as value in argument 4 to `new_symtab`
   49 |     s.dynsymtab_section = new_symtab(s, c'.dynsymtab', sht_symtab, (shf_private | shf_dynsym),
```

**Root cause:** `shf_dynsym` is still `int`, and V cannot OR `u32 | int` and pass the result to `new_symtab(sh_flags int)`. The OR would produce `u32(0xC000_0000)` = 3221225472 which overflows `int`, leaving "(no value)".

**Fix:** Replace with `int(-2147483648)` — INT_MIN, the same bit pattern as `0x8000_0000` in two's complement. All bitwise operations and C-level semantics are identical. The type stays `int`, so no mismatch with `shf_dynsym` or the `sh_flags int` parameters of `new_section`/`new_symtab`.

## Test plan

- [ ] `Test vtcc` step passes on ubuntu-latest (was failing with "no value" type error)
- [ ] `Test vtcc` step passes without the old overflow warning too

Upstream issue: felipensp/vtcc#6

🤖 Generated with [Claude Code](https://claude.ai/claude-code)