### PR TITLE
ci: fix vtcc sed patch — use int(-2147483648) not u32 for shf_private

### DIFF
--- a/.github/workflows/compile_v_with_vtcc.sh
+++ b/.github/workflows/compile_v_with_vtcc.sh
@@ -13,10 +13,13 @@ show "Clone vtcc"
 .github/workflows/retry.sh git clone https://github.com/felipensp/vtcc --branch stable --quiet vtcc/
 du -s vtcc/
 ## TODO: just `./v vtcc`, later will cause V, to detect the compiler as tcc (which it is), and add `-fwrapv`, which causes the vtcc compiler to panic currently
-show "Patch vtcc: fix int(0x8000_0000) overflow (felipensp/vtcc#6 / vlang/v#26853)"
+show "Patch vtcc: fix int(0x8000_0000) overflow (felipensp/vtcc#7 / vlang/v#26853)"
 ## 0x8000_0000 = 2147483648 overflows V's int (max 2147483647).
-## This causes a V warning (soon: hard error) and TCC rejects the generated C.
-sed -i 's/const shf_private = int(0x8000_0000)/const shf_private = u32(0x8000_0000)/' vtcc/src/tccelf.v
+## V warns now and will make this a hard error soon; TCC then rejects the generated C.
+## Use -2147483648 (INT_MIN) — same bit pattern in two's complement, keeps type as int,
+## so no cascading type changes needed in new_section/new_symtab/struct Section.
+## Remove this patch once felipensp/vtcc#7 is merged into the stable branch.
+sed -i 's/const shf_private = int(0x8000_0000)/const shf_private = -2147483648/' vtcc/src/tccelf.v
 
 show "Compile vtcc"
 cd vtcc/


### PR DESCRIPTION
## Follow-up to #26858

The vtcc workaround in #26858 patched `const shf_private = int(0x8000_0000)` → `u32(0x8000_0000)`. This fixed the overflow warning but introduced a new error visible in the `c80a8a8` CI run:

```
failed src/tccelf.v:49:65: error: `(shf_private | shf_dynsym)` (no value) used as value in argument 4 to `new_symtab`
   49 |     s.dynsymtab_section = new_symtab(s, c'.dynsymtab', sht_symtab, (shf_private | shf_dynsym),
```

**Root cause:** `shf_dynsym` is still `int` and `new_symtab` takes `sh_flags int`. V cannot OR `u32 | int` and pass the result as `int`. Fixing by cascading `u32` through `struct Section.sh_flags`, `new_section`, and `new_symtab` would touch 20+ bitwise-op sites.

**Fix:** use `-2147483648` (INT_MIN) — the **same bit pattern** as `0x8000_0000` in two's complement signed arithmetic. Type stays `int`, no cascading changes needed.

A proper upstream fix has been filed at **felipensp/vtcc#7**. This sed patch is a temporary workaround until that merges into the stable branch.

## Test plan
- [ ] `Test vtcc` passes on ubuntu-latest without overflow warning or type error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)