### PR TITLE
cgen: properly define stdin, stdout, and stderr for FreeBSD

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -376,7 +376,7 @@ FILE* __cdecl __acrt_iob_func(unsigned index);
 #define stdout (__acrt_iob_func(1))
 #define stderr (__acrt_iob_func(2))
 #else
-	#if defined(__APPLE__)
+	#if defined(__APPLE__) || defined(__FreeBSD__)
 typedef struct __sFILE FILE;
 extern FILE* __stdinp;
 extern FILE* __stdoutp;
@@ -384,7 +384,7 @@ extern FILE* __stderrp;
 #define stdin __stdinp
 #define stdout __stdoutp
 #define stderr __stderrp
-	#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+	#elif defined(__NetBSD__) || defined(__DragonFly__)
 typedef struct __sFILE FILE;
 extern FILE* stdin;
 extern FILE* stdout;


### PR DESCRIPTION
I noticed that I was unable to build the v compiler on FreeBSD because of improper definitions of `stdin`, `stdout`, and `strerr`.  The `vc/v.c` file doesn't compile anymore without this fix and subsequent build steps (building v2 from v1, and so on) fail for the same reason.

```
$ v doctor
|V full version      |V 0.5.1 364cf7c47c6883c4f591c56cc56e7360a4cfed23
|:-------------------|:-------------------
|OS                  |freebsd, 15.0-RELEASE-p5, FreeBSD 15.0-RELEASE-p5 releng/15.0-n281018-0730d5233286 GENERIC
|Processor           |2 cpus, 64bit, little endian
|Memory              |1.38GB/3.97GB
|                    |
|V executable        |/var/home/kim/Projects/v/from_github/v/v
|V last modified time|2026-04-18 17:33:10
|                    |
|V home dir          |OK, value: /var/home/kim/Projects/v/from_github/v
|VMODULES            |OK, value: /home/kim/.vmodules
|VTMP                |OK, value: /tmp/v_1002
|Current working dir |OK, value: /var/home/kim/Projects/v/from_github/v
|                    |
|Git version         |git version 2.53.0
|V git status        |0.5.1-1024-g56fbd068-dirty
|.git/config present |true
|                    |
|cc version          |FreeBSD clang version 19.1.7 (https://github.com/llvm/llvm-project.git llvmorg-19.1.7-0-gcd708029e0b2)
|gcc version         |N/A
|clang version       |FreeBSD clang version 19.1.7 (https://github.com/llvm/llvm-project.git llvmorg-19.1.7-0-gcd708029e0b2)
|tcc version         |tcc version 0.9.28rc 2025-02-13 HEAD@f8bd136d (x86_64 FreeBSD)
|tcc git status      |thirdparty-freebsd-amd64 204a2d97
|emcc version        |N/A
|glibc version       |N/A
```
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
