### PR TITLE
fix: guard arrays chunk and window against invalid input

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -156,6 +156,9 @@ pub fn group[T](arrs ...[]T) [][]T {
 // chunk array into a single array of arrays where each element is the next `size` elements of the original.
 // Example: arrays.chunk([1, 2, 3, 4, 5, 6, 7, 8, 9], 2) // => [[1, 2], [3, 4], [5, 6], [7, 8], [9]]
 pub fn chunk[T](array []T, size int) [][]T {
+	if size <= 0 || array.len == 0 {
+		return [][]T{}
+	}
 	// allocate chunk array
 	mut chunks := [][]T{cap: array.len / size + if array.len % size == 0 { 0 } else { 1 }}
 
@@ -222,7 +225,7 @@ pub:
 // Example: arrays.window([1, 2, 3, 4], size: 2) // => [[1, 2], [2, 3], [3, 4]]
 // Example: arrays.window([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], size: 3, step: 2) // => [[1, 2, 3], [3, 4, 5], [5, 6, 7], [7, 8, 9]]
 pub fn window[T](array []T, attr WindowAttribute) [][]T {
-	if array.len == 0 {
+	if array.len == 0 || attr.size <= 0 || attr.step <= 0 {
 		return [][]T{}
 	}
 	// allocate snapshot array

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -145,6 +145,8 @@ fn test_chunk() {
 	z2 := chunk[string](y, 3)
 	assert z2 == [['a', 'b', 'c'], ['d', 'e', 'f']]
 	assert chunk[int]([]int{}, 2) == [][]int{}
+	assert chunk[int](x, 0) == [][]int{}
+	assert chunk[int](x, -2) == [][]int{}
 }
 
 fn test_chunk_while() {
@@ -170,6 +172,8 @@ fn test_window() {
 		[4, 5, 6]]
 	assert window[int](x, size: 3, step: 2) == [[1, 2, 3], [3, 4, 5]]
 	assert window[int]([]int{}, size: 2) == [][]int{}
+	assert window[int](x, size: 0) == [][]int{}
+	assert window[int](x, size: 2, step: 0) == [][]int{}
 }
 
 /////////////////////////////


### PR DESCRIPTION

**Repo:** vlang/v (⭐ 37000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +8/-1

## What
This change hardens `vlib/arrays` by making `arrays.chunk` return an empty result when called with a non-positive chunk size, and making `arrays.window` return an empty result when called with a non-positive window size or step. It also adds regression tests that cover these invalid-input cases.

## Why
Before this patch, `arrays.chunk` could divide by zero for `size == 0`, and `arrays.window` could behave incorrectly or fail to terminate for invalid parameters such as `step == 0`. Returning an empty result for invalid non-positive values is a low-risk way to avoid panics and hangs in these helper APIs while keeping the function signatures unchanged.

## Testing
Source-level diff review only in this environment. I could not run `v fmt` or the focused `vlib/arrays` tests locally because this clone does not include a built `v` executable (`./v` was absent). The added tests describe the expected behavior for `chunk(..., 0)`, `chunk(..., -2)`, `window(..., size: 0)`, and `window(..., step: 0)`.

## Risk
Low - the change only affects previously invalid parameter combinations and leaves existing valid call paths unchanged.
