### PR TITLE
net.websocket: treat zero-byte frame-header reads as peer close

### DIFF
--- a/vlib/net/websocket/message.v
+++ b/vlib/net/websocket/message.v
@@ -216,8 +216,7 @@ pub fn (mut ws Client) parse_frame_header() !Frame {
 	for ws.get_state() == .open {
 		read_bytes := ws.socket_read_ptr(&rbuff[0], 1)!
 		if read_bytes == 0 {
-			// this is probably a timeout or close
-			continue
+			return error('websocket peer closed connection')
 		}
 		buffer[bytes_read] = rbuff[0]
 		bytes_read++


### PR DESCRIPTION
## Summary

Treat a zero-byte read in `parse_frame_header()` as a peer-close condition
instead of continuing the read loop.

## Why

A `read_bytes == 0` result indicates EOF or peer closure. Continuing the loop
can delay close propagation and leave websocket state waiting unnecessarily.

Returning an error here makes connection shutdown behavior more explicit and
better aligned with socket EOF semantics.
