### PR TITLE
builtin: fix flaky segfault with boehm gc on FreeBSD

### DIFF
--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -75,6 +75,7 @@ $if dynamic_boehm ? {
 		// Tested on FreeBSD 13.0-RELEASE-p3, with clang, gcc and tcc
 		#flag -DGC_BUILTIN_ATOMIC=1
 		#flag -DBUS_PAGE_FAULT=T_PAGEFLT
+		#flag -DALL_INTERIOR_POINTERS=1
 		$if !tinyc {
 			#flag -DUSE_MMAP
 			#flag -I @VEXEROOT/thirdparty/libgc/include


### PR DESCRIPTION
I believe I have identified a problem that caused some flaky behavior on FreeBSD, especially when `-cc clang` was being used.

With interrior-pointer scanning off, bdwgc treats objects as unreachable unless some live base pointer still points to them.  Clang is aggressive about dropping base pointers once code only touches interior pointers, so live objects got swept.  tcc's weaker optimization preserved enough base pointers to accidentally mask the bug.


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
