### PR TITLE
db.sqlite: fix ADDR macro conflict on Windows by using #flag instead of #include

### DIFF
--- a/vlib/db/sqlite/sqlite.c.v
+++ b/vlib/db/sqlite/sqlite.c.v
@@ -12,8 +12,8 @@ $if $pkgconfig('sqlite3') {
 	#include "sqlite3.h" # The SQLite header file is missing. Please install the corresponding development package.
 } $else $if windows {
 	#flag -I@VEXEROOT/thirdparty/sqlite
+	#flag @VEXEROOT/thirdparty/sqlite/sqlite3.c
 	#include "sqlite3.h" # The SQLite header file is missing. Please run vlib/db/sqlite/install_thirdparty_sqlite.vsh to download an SQLite amalgamation.
-	#include "sqlite3.c" # The SQLite amalgamation source file is missing. Please run vlib/db/sqlite/install_thirdparty_sqlite.vsh to download an SQLite amalgamation.
 } $else $if darwin {
 	// macOS ships libsqlite3, so do not require a separately downloaded amalgamation.
 	#flag darwin -lsqlite3


### PR DESCRIPTION
On Windows, `sqlite.c.v` was using `#include "sqlite3.c"` which pulls the SQLite amalgamation directly into the same translation unit as V's generated C code. This caused a macro name collision:

- V defines `ADDR(type, expr)` (2 params) in its C header preamble
- SQLite's amalgamation defines `ADDR(X)` (1 param) internally in its VDBE engine (~line 17238 of sqlite3.c)

TCC then errors: `macro 'ADDR' used with too many args`

**Fix:** replace `#include "sqlite3.c"` with `#flag @VEXEROOT/thirdparty/sqlite/sqlite3.c` on Windows, matching the approach already used on Linux/BSD. This compiles sqlite3.c as a separate translation unit so its internal macros never conflict with V's headers.
