### PR TITLE
parser: fix segfault in orm `where` expression check

### DIFF
--- a/vlib/v/parser/orm.v
+++ b/vlib/v/parser/orm.v
@@ -835,7 +835,7 @@ fn (mut p Parser) check_sql_where_expr_has_no_undefined_variables(expr &ast.Expr
 			return left_check_result
 		}
 
-		variable_names := if expr.left is ast.Ident { [expr.left.str()] } else { []string{} }
+		variable_names := if expr.left is ast.Ident { [expr.left.name] } else { []string{} }
 		right_check_result := p.check_sql_where_expr_has_no_undefined_variables(expr.right,
 			variable_names)
 


### PR DESCRIPTION
expr.left.str() dereferenced the Idents nil `scope` field causing a segfault.

Fixes segfault in `v test vlib/v/fmt/fmt_keep_test.v`.


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
