### PR TITLE
eval: support string concatenation with the + operator

### DIFF
--- a/vlib/v/eval/infix.v
+++ b/vlib/v/eval/infix.v
@@ -1165,6 +1165,12 @@ fn (e &Eval) infix_expr(left Object, right Object, op token.Kind, expecting ast.
 						}
 					}
 				}
+				string {
+					match right {
+						string { return left + right }
+						else { e.error('invalid operands to +: string and ${right.type_name()}') }
+					}
+				}
 				else {
 					e.error('invalid operands to +: ${left.type_name()} and ${right.type_name()}')
 				}


### PR DESCRIPTION
This fix addresses `invalid operands to +: string and string` errors
that I see when running `v test-all`.

The real fix is to fix the generator for `vlib/v/eval/infix.v`.  If I understand
things right, I saw that fixes for `&&` and `||` had been applied after 
`vlib/v/eval/infix.v` had been generated.  This fix follows that pattern.

I will look at doing the generator fix.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
