### PR TITLE
vpm: refuse to overwrite an installed module with uncommitted or unpushed git changes

### DIFF
--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -105,6 +105,10 @@ fn (m Module) install() InstallResult {
 		os.rmdir_all(m.tmp_path) or {}
 	}
 	if m.is_installed {
+		if has_local_git_changes(m.install_path) {
+			vpm_error('refusing to install `${m.name}`: `${m.install_path_fmted}` has uncommitted or unpushed git changes. Commit and push your changes, or remove the directory manually before retrying.')
+			exit(1)
+		}
 		// Case: installed, but not an explicit version. Update instead of continuing the installation.
 		if m.version == '' && m.installed_version == '' {
 			if m.is_external && m.url.starts_with('http://') {
@@ -164,6 +168,24 @@ fn (m Module) confirm_install() bool {
 			}
 		}
 	}
+}
+
+// has_local_git_changes returns true if `path` is a git repository with
+// uncommitted changes (staged, unstaged, or untracked) or with local commits
+// that have not been pushed to any remote.
+fn has_local_git_changes(path string) bool {
+	if !os.exists(os.join_path(path, '.git')) {
+		return false
+	}
+	quoted := os.quoted_path(path)
+	status := os.execute_opt('git -C ${quoted} status --porcelain') or { return false }
+	if status.output.trim_space() != '' {
+		return true
+	}
+	unpushed := os.execute_opt('git -C ${quoted} rev-list --branches --not --remotes') or {
+		return false
+	}
+	return unpushed.output.trim_space() != ''
 }
 
 fn (m Module) remove() ! {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -182,7 +182,10 @@ fn has_local_git_changes(path string) bool {
 	if status.output.trim_space() != '' {
 		return true
 	}
-	unpushed := os.execute_opt('git -C ${quoted} rev-list --branches --not --remotes') or {
+	// Include `HEAD` so commits made on a detached HEAD (e.g. after
+	// `git clone -b <tag>`, the layout vpm uses for versioned installs) are
+	// also detected. `--branches` alone only walks local branch refs.
+	unpushed := os.execute_opt('git -C ${quoted} rev-list HEAD --branches --not --remotes') or {
 		return false
 	}
 	return unpushed.output.trim_space() != ''

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -104,11 +104,16 @@ fn (m Module) install() InstallResult {
 	defer {
 		os.rmdir_all(m.tmp_path) or {}
 	}
+	// Run this check unconditionally — `m.is_installed` is computed via
+	// `git ls-remote`, which itself fails when `.git` is corrupted or
+	// inaccessible, so relying on it here would skip the guard in exactly
+	// the cases we most need to fail closed.
+	reason := local_git_changes_reason(m.install_path)
+	if reason != '' {
+		vpm_error('refusing to install `${m.name}`: `${m.install_path_fmted}` has local git work that would be lost (${reason}). Commit and push your changes, or remove the directory manually before retrying.')
+		exit(1)
+	}
 	if m.is_installed {
-		if has_local_git_changes(m.install_path) {
-			vpm_error('refusing to install `${m.name}`: `${m.install_path_fmted}` has uncommitted or unpushed git changes. Commit and push your changes, or remove the directory manually before retrying.')
-			exit(1)
-		}
 		// Case: installed, but not an explicit version. Update instead of continuing the installation.
 		if m.version == '' && m.installed_version == '' {
 			if m.is_external && m.url.starts_with('http://') {
@@ -170,25 +175,33 @@ fn (m Module) confirm_install() bool {
 	}
 }
 
-// has_local_git_changes returns true if `path` is a git repository with
-// uncommitted changes (staged, unstaged, or untracked) or with local commits
-// that have not been pushed to any remote.
-fn has_local_git_changes(path string) bool {
+// local_git_changes_reason returns a non-empty reason string if `path` is a
+// git repository whose contents should not be silently overwritten — either
+// because it has uncommitted/unpushed work, or because git could not be
+// queried at all (in which case we fail closed rather than risk data loss).
+// Returns '' when the path is safe to overwrite (not a git repo, or a clean
+// repo fully in sync with its remote).
+fn local_git_changes_reason(path string) string {
 	if !os.exists(os.join_path(path, '.git')) {
-		return false
+		return ''
 	}
 	quoted := os.quoted_path(path)
-	status := os.execute_opt('git -C ${quoted} status --porcelain') or { return false }
+	status := os.execute_opt('git -C ${quoted} status --porcelain') or {
+		return 'failed to run `git status`: ${err.msg()}'
+	}
 	if status.output.trim_space() != '' {
-		return true
+		return 'uncommitted changes detected'
 	}
 	// Include `HEAD` so commits made on a detached HEAD (e.g. after
 	// `git clone -b <tag>`, the layout vpm uses for versioned installs) are
 	// also detected. `--branches` alone only walks local branch refs.
 	unpushed := os.execute_opt('git -C ${quoted} rev-list HEAD --branches --not --remotes') or {
-		return false
+		return 'failed to run `git rev-list`: ${err.msg()}'
 	}
-	return unpushed.output.trim_space() != ''
+	if unpushed.output.trim_space() != '' {
+		return 'unpushed local commits detected'
+	}
+	return ''
 }
 
 fn (m Module) remove() ! {


### PR DESCRIPTION
## Summary
- `v install foo` now exits with an error if the existing module directory is a git repository that has uncommitted changes (staged, unstaged, or untracked) or local commits not pushed to any remote.
- Prevents accidental loss of local work when reinstalling or updating a module that the user has been hacking on.

## Test plan
- [x] Manually verified with a local `file://` remote:
  - dirty working tree → exits 1 with a clear error
  - clean tree → install/update proceeds as before
  - local commit not pushed to remote → exits 1 with a clear error