### PR TITLE
all: ignore compiled cmd/tools binaries (follow-up to #27010)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,21 @@ a.out
 fns.txt
 .noprefix.vrepl_temp.v
 
+# ignore compiled cmd/tools binaries (extensionless on Unix)
+/cmd/tools/vcheck-md
+/cmd/tools/vdoctor
+/cmd/tools/vdoc/vdoc
+/cmd/tools/vfmt
+/cmd/tools/vgit-fmt-hook
+/cmd/tools/vpm/vpm
+/cmd/tools/vself
+/cmd/tools/vsymlink/vsymlink
+/cmd/tools/vtest
+/cmd/tools/vtimeout
+/cmd/tools/vup
+/cmd/tools/vvet/vvet
+/cmd/tools/vwipe-cache
+
 # ignore temp and cache directories
 temp/
 tmp/


### PR DESCRIPTION
Mitigate the extensionless tool-binary regression that surfaced after #27010 removed the root `*/**/*` ignore rule.

On Unix, common workflows such as `v up`, `v fmt`, and test-related commands can produce extensionless binaries under `cmd/tools/`. These were previously hidden by the broad ignore rule; after #27010 they can show up as untracked.

This PR adds explicit `.gitignore` entries for the known high-traffic `cmd/tools/` outputs.

#### Notes:
This is an explicit-ignore mitigation, not a structural solution. It keeps source files visible and avoids restoring `!*.*`, which caused the `.git/info/exclude` issue fixed by #24590.

The same class of issue can occur when examples are compiled in place, so broader alternatives may still be worth discussing separately: https://github.com/vlang/v/pull/27010