### PR TITLE
builder: prevent coroutines_runtime_test on FreeBSD

### DIFF
--- a/vlib/v/builder/coroutines_runtime_test.v
+++ b/vlib/v/builder/coroutines_runtime_test.v
@@ -5,7 +5,8 @@ import v.ast
 import v.pref
 
 fn test_ensure_imported_coroutines_runtime_downloads_photonwrapper() {
-	$if windows {
+	$if !macos && !linux {
+		// coroutines are only supported on macOS & Linux — see pref.ensure_coroutines_runtime
 		return
 	}
 	test_root := os.join_path(os.vtmp_dir(), 'v_builder_coroutines_runtime')


### PR DESCRIPTION
Coroutines rely on PhotonLibOS which only runs on macOS and Linux. 

This fixes the runtime guard to accurately reflect that.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
