### PR TITLE
all: restore .gitignore rule for extensionless binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+# ignore sub-level extensionless build outputs
+*/**/*
+!*/
+!*.*
+
 # ignore generated binaries and object files
-# Do not add broad unignore rules like !*.*; they override local excludes.
 *.exe
 *.o
 *.so
@@ -35,6 +39,9 @@ a.out
 fns.txt
 .noprefix.vrepl_temp.v
 
+# Prefix local scratch/repro files with tmp. when they should stay untracked.
+tmp.*
+
 # ignore temp and cache directories
 temp/
 tmp/
@@ -67,7 +74,6 @@ cache/
 *~
 ~*
 .sesskey
-/tmp*
 *.db
 *.swp
 *.swo
@@ -124,7 +130,6 @@ vls.log
 *.tmperr
 
 .vtmp_cov_*/
-*/**/tmp.*
 
 # ignore Intellij files
 .idea/


### PR DESCRIPTION
Restores the `.gitignore` behavior that ignores extensionless files in subdirectories, so Unix-style generated binaries written next to source files do not show up as untracked files.

For local scratch/repro files like the ones discussed in #24590, use the `tmp.*` prefix when they should stay untracked.

#### Notes
Longer term, the cleaner fix is probably to change build/test workflows so generated executables go into a predictable ignored output directory instead of being written next to sources.