### PR TITLE
vdoc: fix flaky location of output path in vdoc_file_test.v

### DIFF
--- a/cmd/tools/vdoc/vdoc_file_test.v
+++ b/cmd/tools/vdoc/vdoc_file_test.v
@@ -72,6 +72,9 @@ fn test_out_path() {
 	test_path := os.join_path(os.vtmp_dir(), 'vdoc_test_${rand.ulid()}')
 	test_mod_path := os.join_path(test_path, small_pure_v_vlib_module)
 	os.mkdir_all(test_path)!
+	// Sentinel v.mod so that vdoc's get_parent_mod() stops climbing here instead of
+	// picking up stray .v files in ancestor tmp dirs (e.g. /private/tmp on macOS).
+	os.write_file(os.join_path(test_path, 'v.mod'), "Module { name: 'vdoc_test' }\n")!
 	defer {
 		os.chdir(vroot) or {}
 		os.rmdir_all(test_path) or {}
@@ -82,7 +85,7 @@ fn test_out_path() {
 
 	// Relative input with default output path.
 	os.execute_opt('${vexe} doc -f html -m ${small_pure_v_vlib_module}')!
-	output_path := os.join_path(mod_path, '_docs', '${small_pure_v_vlib_module}.html')
+	output_path := os.join_path(test_mod_path, '_docs', '${small_pure_v_vlib_module}.html')
 	assert os.exists(output_path), output_path
 
 	// Custom out path (no `_docs` subdir).


### PR DESCRIPTION
I noticed that if I had other `.v` files in /private/tmp on macOS that it would confuse
this test.

`get_parent_mod()` climbs up from cwd and stops only at a `v.mod` file or a dir containing
compilable V files. On macOS, /tmp resolves to /private/tmp/ which had stray .v files —          
get_parent_mod treated them as signalling a parent module and prepended `vdoc_test_<ulid>` to the   
module name, so vdoc wrote `vdoc_test_X.bitfield.html` instead of `bitfield.html`.
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
