### PR TITLE
pref: Add arm64 and x64 to backend message

### DIFF
--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -1095,7 +1095,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					continue
 				}
 				b := backend_from_string(sbackend) or {
-					eprintln_exit('Unknown V backend: ${sbackend}\nValid -backend choices are: c, js, js_node, js_browser, js_freestanding, wasm')
+					eprintln_exit('Unknown V backend: ${sbackend}\nValid -backend choices are: c, js, js_node, js_browser, js_freestanding, wasm, arm64, x64')
 				}
 				if b == .wasm {
 					res.compile_defines << 'wasm'


### PR DESCRIPTION
Add 'arm64' and 'x64' to the message printed when 'v -backend ?' is invoked.

This is the new message that is printed:
```
Unknown V backend: v
Valid -backend choices are: c, js, js_node, js_browser, js_freestanding, wasm, arm64, x64
```