### PR TITLE
examples: remove unused variables for veb middleware

### DIFF
--- a/examples/veb/middleware/using_middleware.v
+++ b/examples/veb/middleware/using_middleware.v
@@ -69,12 +69,12 @@ pub fn (app &App) early(mut ctx Context) veb.Result {
 	return ctx.html(base)
 }
 
-fn other_func1(mut ctx Context) bool {
+fn other_func1(mut _ Context) bool {
 	println('1')
 	return true
 }
 
-fn other_func2(mut ctx Context) bool {
+fn other_func2(mut _ Context) bool {
 	println('2')
 	return true
 }


### PR DESCRIPTION
Remove unused `ctx` variables in `examples/veb/middleware/using_middleware.v`

- Before this fix:
```sh
$ ./v run examples/veb/middleware/using_middleware.v
examples/veb/middleware/using_middleware.v:72:20: notice: unused parameter: `ctx`
   70 | }
   71 |
   72 | fn other_func1(mut ctx Context) bool {
      |                    ~~~
   73 |     println('1')
   74 |     return true
examples/veb/middleware/using_middleware.v:77:20: notice: unused parameter: `ctx`
   75 | }
   76 |
   77 | fn other_func2(mut ctx Context) bool {
      |                    ~~~
   78 |     println('2')
   79 |     return true
[veb] Running multi-threaded app on http://localhost:8080/
listening on http://0.0.0.0:8080/
```
- After this fix:
```sh
$ ./v run examples/veb/middleware/using_middleware.v
[veb] Running multi-threaded app on http://localhost:8080/
listening on http://0.0.0.0:8080/
```