### PR TITLE
rand: fix warnings for unused variables in JS implementation

### DIFF
--- a/vlib/rand/rand.js.v
+++ b/vlib/rand/rand.js.v
@@ -5,17 +5,21 @@ fn init() {
 	default_rng = new_default()
 }
 
-fn internal_fill_buffer_from_set(mut rng PRNG, charset string, mut buf []u8) {
+fn internal_fill_buffer_from_set(mut _ PRNG, _ string, mut _ []u8) {
 	panic('todo')
 }
 
-fn internal_string_from_set(mut rng PRNG, charset string, len int) string {
+// fn internal_string_from_set(mut rng PRNG, charset string, len int) string {
+fn internal_string_from_set(mut _ PRNG, charset string, len int) string {
 	result := ''
 	#
 	#const characters = charset.str;
 	#const charactersLength = characters.length;
 	#for (let i = 0;i < len.val;i++)
 	#result.str += characters.charAt(Math.random() * charactersLength);
+
+	_ = charset
+	_ = len
 
 	return result
 }


### PR DESCRIPTION
Remove unused variables in `rand` Javascript implementation => `vlib/rand/rand.js.v`

- Before this fix:
```sh
$ ./v -b js_browser examples/tetris/tetris.js.v
vlib/os/os_js.js.v:37:26: notice: unused parameter: `path`
   35 | }
   36 |
   37 | fn kind_of_existing_path(path string) PathKind {
      |                          ~~~~
   38 |     is_link := false
   39 |     is_dir := false
vlib/os/sleeping.js.v:4:13: notice: unused parameter: `dur`
    2 |
    3 | // sleep_ms suspends the execution for a given duration (in milliseconds), without having to `import time` for a single time.sleep/1 call.
    4 | fn sleep_ms(dur i64) {
      |             ~~~
    5 |     #let now = new Date().getTime()
    6 |     #let toWait = BigInt(dur)
vlib/rand/rand.js.v:8:38: notice: unused parameter: `rng`
    6 | }
    7 |
    8 | fn internal_fill_buffer_from_set(mut rng PRNG, charset string, mut buf []u8) {
      |                                      ~~~
    9 |     panic('todo')
   10 | }
vlib/rand/rand.js.v:8:48: notice: unused parameter: `charset`
    6 | }
    7 |
    8 | fn internal_fill_buffer_from_set(mut rng PRNG, charset string, mut buf []u8) {
      |                                                ~~~~~~~
    9 |     panic('todo')
   10 | }
vlib/rand/rand.js.v:8:68: notice: unused parameter: `buf`
    6 | }
    7 |
    8 | fn internal_fill_buffer_from_set(mut rng PRNG, charset string, mut buf []u8) {
      |                                                                    ~~~
    9 |     panic('todo')
   10 | }
vlib/rand/rand.js.v:12:33: notice: unused parameter: `rng`
   10 | }
   11 |
   12 | fn internal_string_from_set(mut rng PRNG, charset string, len int) string {
      |                                 ~~~
   13 |     result := ''
   14 |     #
vlib/rand/rand.js.v:12:43: notice: unused parameter: `charset`
   10 | }
   11 |
   12 | fn internal_string_from_set(mut rng PRNG, charset string, len int) string {
      |                                           ~~~~~~~
   13 |     result := ''
   14 |     #
vlib/rand/rand.js.v:12:59: notice: unused parameter: `len`
   10 | }
   11 |
   12 | fn internal_string_from_set(mut rng PRNG, charset string, len int) string {
      |                                                           ~~~
   13 |     result := ''
   14 |     #
```
- After this fix => no more warning for unused variables in `vlib/rand/rand.js.v`
```sh
$ ./v -b js_browser examples/tetris/tetris.js.v
vlib/os/os_js.js.v:37:26: notice: unused parameter: `path`
   35 | }
   36 |
   37 | fn kind_of_existing_path(path string) PathKind {
      |                          ~~~~
   38 |     is_link := false
   39 |     is_dir := false
vlib/os/sleeping.js.v:4:13: notice: unused parameter: `dur`
    2 |
    3 | // sleep_ms suspends the execution for a given duration (in milliseconds), without having to `import time` for a single time.sleep/1 call.
    4 | fn sleep_ms(dur i64) {
      |             ~~~
    5 |     #let now = new Date().getTime()
    6 |     #let toWait = BigInt(dur)
```