### PR TITLE
builtin: remove useless test for array

### DIFF
--- a/vlib/builtin/array_test.v
+++ b/vlib/builtin/array_test.v
@@ -945,7 +945,6 @@ fn test_fixed_array_literal_eq() {
 	// assert [[1, 1]!, [2, 2]!] != [[1, 2]!, [2, 3]!]
 	// vfmt off
 	assert ([1, 2, 3]!) == [1, 2, 3]!
-	assert (([1, 2, 3]!)) == [1, 2, 3]!
 	// vfmt on
 }
 


### PR DESCRIPTION
The suppressed test had a wrong format with redundant parentheses: test `test_fixed_array_literal_eq` in `vlib/builtin/array_test.v`

- Before this fix:
```sh
$ ./v test vlib/builtin/array_test.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
vlib/builtin/array_test.v:948:9: notice: redundant parentheses are used
  946 |     // vfmt off
  947 |     assert ([1, 2, 3]!) == [1, 2, 3]!
  948 |     assert (([1, 2, 3]!)) == [1, 2, 3]!
      |            ~~~~~~~~~~~~~~
  949 |     // vfmt on
  950 | }
 OK       3.003 ms vlib/builtin/array_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 582 ms, on 1 job. Comptime: 576 ms. Runtime: 3 ms.
```
- After this fix:
```sh
$ ./v test vlib/builtin/array_test.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
 OK       3.551 ms vlib/builtin/array_test.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 568 ms, on 1 job. Comptime: 561 ms. Runtime: 3 ms.
```