### PR TITLE
os: remove warnings for unused variable in JS implementation

### DIFF
--- a/vlib/os/os_js.js.v
+++ b/vlib/os/os_js.js.v
@@ -40,6 +40,8 @@ fn kind_of_existing_path(path string) PathKind {
 	$if js_node {
 		#is_link.val = $fs.existsSync(path.str) && $fs.lstatSync(path.str).isSymbolicLink()
 		#is_dir.val = $fs.existsSync(path,str) && $fs.lstatSync(path.str).isDirectory()
+	} $else {
+		_ = path
 	}
 	return PathKind{
 		is_dir:  is_dir


### PR DESCRIPTION
Remove warning/notice for unused variable `path` in Javascript implementation => function `kind_of_existing_path` in `vlib/os/os_js.js.v`

- Before this fix:
```sh
$ ./v -b js_browser examples/tetris/tetris.js.v
vlib/os/os_js.js.v:37:26: notice: unused parameter: `path`
   35 | }
   36 |
   37 | fn kind_of_existing_path(path string) PathKind {
      |                          ~~~~
   38 |     is_link := false
   39 |     is_dir := false
(...)
```
- After this fix => nor more notice/warning for unused variable in `vlib/os/os_js.js.v` when running `examples/tetris/tetris.js.v`