### PR TITLE
work around a problem when compiling vtest-all.v

### DIFF
--- a/cmd/tools/vtest-all.v
+++ b/cmd/tools/vtest-all.v
@@ -472,10 +472,10 @@ fn (mut cmd Command) run() ? {
 	if vtest_nocleanup {
 		return
 	}
-	if cmd.rmfile != none {
-		mut file_existed := rm_existing(cmd.rmfile)
+	if rmfile := cmd.rmfile {
+		mut file_existed := rm_existing(rmfile)
 		if !file_existed {
-			eprintln('Expected file did not exist: ${cmd.rmfile}')
+			eprintln('Expected file did not exist: ${rmfile}')
 			cmd.ecode = 999
 		}
 	}


### PR DESCRIPTION
I have been unable to compile `cmd/tools/vtest-all.v` lately.
I have a work-around in this pull request.

I also have an analysis of the problem generated with the assistance of 
Claude.  Let me know if this sort of thing is useful or if I should stick with
100% human generated content.

[vlang_option_sumtype_smartcast_arg_bug_report.md](https://github.com/user-attachments/files/27212016/vlang_option_sumtype_smartcast_arg_bug_report.md)


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
