### PR TITLE
Fix TCC compiler integration for parallel compilation

### DIFF
--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -77,24 +77,26 @@ fn parallel_cc(mut b builder.Builder, result c.GenOutput) ! {
 	}
 
 	cc := b.quote_compiler_name(parallel_cc_compiler_path(b))
-	compile_args := b.get_compile_args()
-	linker_args := b.get_linker_args()
+	mut compile_args := b.get_compile_args()
+	mut linker_args := b.get_linker_args()
+	if b.ccoptions.cc == .tcc {
+		// vlang/tcc has its system headers under `${vroot}/thirdparty/tcc/lib/tcc/include/`
+		// and its runtime objects (libtcc1.a, bt-*.o) under `${vroot}/thirdparty/tcc/lib/tcc/`.
+		// `-B` controls tcc's include search (`${B}/include`) and `-L` adds a library search path,
+		// so pass absolute paths for both. This lets tcc find them regardless of the cwd from
+		// which v was invoked, without affecting how user-supplied relative flags are resolved.
+		tcc_install_dir := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'lib', 'tcc')
+		if os.is_dir(tcc_install_dir) {
+			tcc_b_arg := '-B${b.tcc_quoted_path(tcc_install_dir)}'
+			tcc_l_arg := '-L${b.tcc_quoted_path(tcc_install_dir)}'
+			compile_args << tcc_b_arg
+			linker_args << tcc_b_arg
+			linker_args << tcc_l_arg
+		}
+	}
 	scompile_args := compile_args.join(' ')
 	slinker_args := linker_args.join(' ')
 	scompile_args_for_linker := compile_args.filter(it != '-x objective-c').join(' ')
-
-	// tcc resolves its include and library search paths relative to the
-	// directory it is invoked from, so commands must run from the V root for
-	// `thirdparty/tcc/lib/tcc/...` lookups (stddef.h, libtcc1.a, bt-*.o) to work.
-	prev_cwd := os.getwd()
-	if b.ccoptions.cc == .tcc {
-		os.chdir(b.pref.vroot) or {}
-	}
-	defer {
-		if b.ccoptions.cc == .tcc {
-			os.chdir(prev_cwd) or {}
-		}
-	}
 
 	mut o_postfixes := ['0', 'x']
 	mut cmds := []string{}

--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -77,19 +77,24 @@ fn parallel_cc(mut b builder.Builder, result c.GenOutput) ! {
 	}
 
 	cc := b.quote_compiler_name(parallel_cc_compiler_path(b))
-	mut compile_args := b.get_compile_args()
-	mut linker_args := b.get_linker_args()
-	if b.ccoptions.cc == .tcc {
-		tcc_root := os.join_path(@VEXEROOT, 'thirdparty', 'tcc')
-		if os.is_dir(tcc_root) {
-			tcc_base_arg := '-B${b.tcc_quoted_path(tcc_root)}'
-			compile_args << tcc_base_arg
-			linker_args << tcc_base_arg
-		}
-	}
+	compile_args := b.get_compile_args()
+	linker_args := b.get_linker_args()
 	scompile_args := compile_args.join(' ')
 	slinker_args := linker_args.join(' ')
 	scompile_args_for_linker := compile_args.filter(it != '-x objective-c').join(' ')
+
+	// tcc resolves its include and library search paths relative to the
+	// directory it is invoked from, so commands must run from the V root for
+	// `thirdparty/tcc/lib/tcc/...` lookups (stddef.h, libtcc1.a, bt-*.o) to work.
+	prev_cwd := os.getwd()
+	if b.ccoptions.cc == .tcc {
+		os.chdir(b.pref.vroot) or {}
+	}
+	defer {
+		if b.ccoptions.cc == .tcc {
+			os.chdir(prev_cwd) or {}
+		}
+	}
 
 	mut o_postfixes := ['0', 'x']
 	mut cmds := []string{}
@@ -138,7 +143,10 @@ fn parallel_cc(mut b builder.Builder, result c.GenOutput) ! {
 	sw_link := time.new_stopwatch()
 	link_res := os.execute(link_cmd)
 	eprint_result_time(sw_link, 'link_cmd', link_cmd, link_res)
-	if link_res.exit_code != 0 {
+	// tcc reports duplicate symbol errors via stderr and an executable still gets emitted with exit code 0,
+	// so detect that pattern and treat it as a link failure too.
+	link_failed_with_tcc_dup := b.ccoptions.cc == .tcc && link_res.output.contains('defined twice')
+	if link_res.exit_code != 0 || link_failed_with_tcc_dup {
 		return error_with_code('failed to link after parallel C compilation', 1)
 	}
 }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -13031,9 +13031,7 @@ fn (mut g Gen) panic_debug_info(pos token.Pos) (int, string, string, string) {
 // when available, or emits `imessage` through a C error otherwise.
 pub fn get_guarded_include_text(iname string, imessage string) string {
 	res := '
-	|#if defined(__TINYC__)
-	|#include ${iname}
-	|#elif defined(__has_include)
+	|#if defined(__has_include)
 	|#if __has_include(${iname})
 	|#include ${iname}
 	|#else
@@ -13050,9 +13048,7 @@ pub fn get_guarded_include_text(iname string, imessage string) string {
 // the best available integer types header, or emits `imessage` otherwise.
 pub fn get_inttypes_or_stdint_include_text(imessage string) string {
 	res := '
-	|#if defined(__TINYC__)
-	|#include <stdint.h>
-	|#elif defined(__has_include)
+	|#if defined(__has_include)
 	|#if __has_include(<inttypes.h>)
 	|#include <inttypes.h>
 	|#elif __has_include(<stdint.h>)

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -214,7 +214,11 @@ const c_common_macros = '
 		#endif
 	#else
 		#define VV_EXP extern
-		#define VV_LOC static
+		#ifdef _VPARALLELCC
+			#define VV_LOC
+		#else
+			#define VV_LOC static
+		#endif
 	#endif
 #endif
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
This PR fixes several issues with TCC (Tiny C Compiler) support, particularly in the context of parallel C compilation. The changes address path resolution problems, duplicate symbol detection, and header inclusion guards.

## Key Changes

- **Parallel CC working directory handling**: Changed TCC compilation to execute from the V root directory, since TCC resolves include and library search paths relative to the invocation directory. This ensures `thirdparty/tcc/lib/tcc/...` lookups work correctly for standard headers and runtime objects.

- **TCC duplicate symbol detection**: Added detection for TCC's specific behavior where duplicate symbol errors are reported via stderr but the linker still exits with code 0. The build now properly fails when `defined twice` appears in TCC's output.

- **Simplified header inclusion guards**: Removed TCC-specific `__TINYC__` preprocessor checks from `get_guarded_include_text()` and `get_inttypes_or_stdint_include_text()` functions, relying instead on the more portable `__has_include` feature that TCC supports.

- **Parallel compilation symbol visibility**: Modified the `VV_LOC` macro definition to be empty (instead of `static`) when `_VPARALLELCC` is defined, allowing proper symbol visibility across separately compiled object files in parallel compilation mode.

## Implementation Details

- Uses `os.getwd()` and `os.chdir()` with defer to safely manage working directory changes during TCC compilation
- Maintains backward compatibility by only applying TCC-specific behavior when `b.ccoptions.cc == .tcc`
- The `_VPARALLELCC` flag controls whether symbols should be static or globally visible across compilation units

https://claude.ai/code/session_012PDdNjq22fSCxGV3PiTBMT