### PR TITLE
os: fix unused variable in sleeping JS implementation

### DIFF
--- a/vlib/os/sleeping.js.v
+++ b/vlib/os/sleeping.js.v
@@ -5,4 +5,6 @@ fn sleep_ms(dur i64) {
 	#let now = new Date().getTime()
 	#let toWait = BigInt(dur)
 	#while (new Date().getTime() < now + Number(toWait)) {}
+
+	_ = dur // unused
 }


### PR DESCRIPTION
Before this fix:
```sh
$ ./v -b js_browser examples/tetris/tetris.js.v
vlib/os/sleeping.js.v:4:13: notice: unused parameter: `dur`
    2 |
    3 | // sleep_ms suspends the execution for a given duration (in milliseconds), without having to `import time` for a single time.sleep/1 call.
    4 | fn sleep_ms(dur i64) {
      |             ~~~
    5 |     #let now = new Date().getTime()
    6 |     #let toWait = BigInt(dur)
```
