### PR TITLE
examples: remove unused variable in snek JS

### DIFF
--- a/examples/snek/snek.js.v
+++ b/examples/snek/snek.js.v
@@ -72,7 +72,7 @@ fn (mut app App) move_food() {
 }
 
 // events
-fn on_keydown(key gg.KeyCode, mod gg.Modifier, mut app App) {
+fn on_keydown(key gg.KeyCode, _ gg.Modifier, mut app App) {
 	match key {
 		.w, .up {
 			if app.last_dir != .down {


### PR DESCRIPTION
Fix warning for unused variable `mod` in `examples/snek/snek.js.v`

- Before this fix:
```sh
$ ./v -b js_browser examples/snek/snek.js.v
vlib/os/sleeping.js.v:4:13: notice: unused parameter: `dur`
    2 |
    3 | // sleep_ms suspends the execution for a given duration (in milliseconds), without having to `import time` for a single time.sleep/1 call.
    4 | fn sleep_ms(dur i64) {
      |             ~~~
    5 |     #let now = new Date().getTime()
    6 |     #let toWait = BigInt(dur)
examples/snek/snek.js.v:75:31: notice: unused parameter: `mod`
   73 |
   74 | // events
   75 | fn on_keydown(key gg.KeyCode, mod gg.Modifier, mut app App) {
      |                               ~~~
   76 |     match key {
   77 |         .w, .up {
```

Fix for unused variable `dur` in `vlib/os/sleeping.js.v` => see PR #27035 