### PR TITLE
examples: remove unused variable/function in viewer

### DIFF
--- a/examples/viewer/view.v
+++ b/examples/viewer/view.v
@@ -40,7 +40,7 @@ const win_width = 800
 const win_height = 800
 const bg_color = gg.black
 const pi_2 = 3.14159265359 / 2.0
-const uv = [f32(0), 0, 1, 0, 1, 1, 0, 1]! // used for zoom icon during rotations
+// const uv = [f32(0), 0, 1, 0, 1, 1, 0, 1]! // used for zoom icon during rotations
 
 const text_drop_files = 'Drop here some images/folder/zip to navigate in the pics'
 const text_scanning = 'Scanning...'
@@ -142,17 +142,6 @@ fn create_texture(w int, h int, buf &u8) (gfx.Image, gfx.Sampler) {
 
 fn destroy_texture(sg_img gfx.Image) {
 	gfx.destroy_image(sg_img)
-}
-
-// Use only if: .dynamic is enabled
-fn update_text_texture(sg_img gfx.Image, w int, h int, buf &u8) {
-	sz := w * h * 4
-	mut tmp_sbc := gfx.ImageData{}
-	tmp_sbc.subimage[0][0] = gfx.Range{
-		ptr:  buf
-		size: usize(sz)
-	}
-	gfx.update_image(sg_img, &tmp_sbc)
 }
 
 /******************************************************************************


### PR DESCRIPTION
Remove unused variable/function in `examples/viewer/view.v`:
- comment unused `uv` variable
- remove unused `update_text_texture` function

Before this fix:
```sh
$ ./v run examples/viewer/
examples/viewer/view.v:43:7: notice: unused constant: `uv`
   41 | const bg_color = gg.black
   42 | const pi_2 = 3.14159265359 / 2.0
   43 | const uv = [f32(0), 0, 1, 0, 1, 1, 0, 1]! // used for zoom icon during rotations
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   44 |
   45 | const text_drop_files = 'Drop here some images/folder/zip to navigate in the pics'
examples/viewer/view.v:148:4: notice: unused function: `update_text_texture`
  146 |
  147 | // Use only if: .dynamic is enabled
  148 | fn update_text_texture(sg_img gfx.Image, w int, h int, buf &u8) {
      |    ~~~~~~~~~~~~~~~~~~~
  149 |     sz := w * h * 4
  150 |     mut tmp_sbc := gfx.ImageData{}
Temporary path for the font file: [/tmp/RobotoMono-Regular.ttf]
Write font [RobotoMono-Regular.ttf] in temp folder.
Temporary path for the logo: [/tmp/logo.png]
Write logo [logo.png] in temp folder.
(...)
```