### PR TITLE
v2: fix x64 hello world on linux

### DIFF
--- a/vlib/v2/builder/builder.v
+++ b/vlib/v2/builder/builder.v
@@ -1324,8 +1324,8 @@ fn ast_file_module_name(file ast.File) string {
 	return 'main'
 }
 
-fn flag_os_matches(cond string) bool {
-	current := os.user_os().to_lower()
+fn flag_os_matches(cond string, target_os string) bool {
+	current := pref.normalize_os_name(target_os)
 	return match cond.to_lower() {
 		'darwin', 'macos', 'mac' { current == 'macos' || current == 'darwin' }
 		'linux' { current == 'linux' }
@@ -1406,7 +1406,7 @@ fn normalize_flag_value_for_file(flag_value string, file_path string) string {
 	return out.join(' ')
 }
 
-fn parse_flag_directive_line(line string, file_path string) ?string {
+fn parse_flag_directive_line(line string, file_path string, target_os string) ?string {
 	trimmed := line.trim_space()
 	if !trimmed.starts_with('#flag') {
 		return none
@@ -1426,7 +1426,7 @@ fn parse_flag_directive_line(line string, file_path string) ?string {
 		return none
 	}
 	if !parts[0].starts_with('-') && !parts[0].starts_with('@') && parts.len > 1 {
-		if !flag_os_matches(parts[0]) {
+		if !flag_os_matches(parts[0], target_os) {
 			return none
 		}
 		rest = rest[parts[0].len..].trim_space()
@@ -1484,7 +1484,8 @@ fn (b &Builder) collect_cflags_from_sources() string {
 	if !b.pref.skip_builtin {
 		for module_path in core_cached_module_paths {
 			vlib_path := b.pref.get_vlib_module_path(module_path)
-			module_files := get_v_files_from_dir(vlib_path, b.pref.user_defines)
+			module_files := get_v_files_from_dir(vlib_path, b.pref.user_defines,
+				b.pref.get_effective_os())
 			for mf in module_files {
 				if mf !in scanned_files {
 					scan_paths << mf
@@ -1508,7 +1509,7 @@ fn (b &Builder) collect_cflags_from_sources() string {
 				cond := trimmed[4..].trim_right('?{ ').trim_space()
 				if skip_depth > 0 {
 					skip_depth++
-				} else if !comptime_cond_matches(cond) {
+				} else if !comptime_cond_matches(cond, b.pref.get_effective_os()) {
 					skip_depth = 1
 				}
 				continue
@@ -1531,7 +1532,8 @@ fn (b &Builder) collect_cflags_from_sources() string {
 			// Replace @VEXEROOT before parsing so path normalization sees absolute paths
 			resolved_line := line.replace('@VEXEROOT', b.pref.vroot).replace('VEXEROOT',
 				b.pref.vroot)
-			mut flag := parse_flag_directive_line(resolved_line, scan_path) or { continue }
+			mut flag := parse_flag_directive_line(resolved_line, scan_path,
+				b.pref.get_effective_os()) or { continue }
 			// Build include flags from already-collected flags for compiling missing .o files
 			mut inc_flags := []string{}
 			for f in flags {
@@ -1592,18 +1594,18 @@ fn split_compile_and_link_flags(flags string) (string, string) {
 	return compile.join(' '), link.join(' ')
 }
 
-fn comptime_cond_matches(cond string) bool {
+fn comptime_cond_matches(cond string, target_os string) bool {
 	// Handle negation: $if !platform
 	if cond.starts_with('!') {
-		return !comptime_cond_matches(cond[1..])
+		return !comptime_cond_matches(cond[1..], target_os)
 	}
 	// Handle && conjunction
 	if and_idx := cond.index('&&') {
 		left := cond[..and_idx].trim_space()
 		right := cond[and_idx + 2..].trim_space()
-		return comptime_cond_matches(left) && comptime_cond_matches(right)
+		return comptime_cond_matches(left, target_os) && comptime_cond_matches(right, target_os)
 	}
-	current := os.user_os().to_lower()
+	current := pref.normalize_os_name(target_os)
 	return match cond.to_lower() {
 		'macos', 'darwin', 'mac' { current == 'macos' || current == 'darwin' }
 		'linux' { current == 'linux' }
@@ -1733,7 +1735,7 @@ fn (mut b Builder) gen_native(backend_arch pref.Arch) {
 	mod.target = ssa.TargetData{
 		ptr_size:      8
 		endian_little: true
-		os:            os.user_os().to_lower()
+		os:            b.pref.get_effective_os()
 	}
 	mut ssa_builder := ssa.Builder.new_with_env(mod, b.env)
 	mut native_sw := time.new_stopwatch()

--- a/vlib/v2/builder/builder.v
+++ b/vlib/v2/builder/builder.v
@@ -1730,6 +1730,11 @@ fn (mut b Builder) gen_native(backend_arch pref.Arch) {
 		eprintln('hint: use v2 compiled with v1 for native code generation')
 		return
 	}
+	mod.target = ssa.TargetData{
+		ptr_size:      8
+		endian_little: true
+		os:            os.user_os().to_lower()
+	}
 	mut ssa_builder := ssa.Builder.new_with_env(mod, b.env)
 	mut native_sw := time.new_stopwatch()
 

--- a/vlib/v2/builder/cache_headers.v
+++ b/vlib/v2/builder/cache_headers.v
@@ -231,7 +231,8 @@ fn (b &Builder) module_source_files(modules []string) []string {
 	mut files_set := map[string]bool{}
 	for module_name in modules {
 		module_path := b.pref.get_vlib_module_path(module_name)
-		module_files := get_v_files_from_dir(module_path, b.pref.user_defines)
+		module_files := get_v_files_from_dir(module_path, b.pref.user_defines,
+			b.pref.get_effective_os())
 		for file in module_files {
 			files_set[file] = true
 		}
@@ -249,7 +250,7 @@ fn (b &Builder) core_cache_compiler_dependency_files() []string {
 		if !os.is_dir(dir) {
 			continue
 		}
-		for file in get_v_files_from_dir(dir, b.pref.user_defines) {
+		for file in get_v_files_from_dir(dir, b.pref.user_defines, b.pref.get_effective_os()) {
 			files_set[os.norm_path(file)] = true
 		}
 	}
@@ -452,7 +453,7 @@ fn (b &Builder) source_fn_return_types(modules []string) map[string]string {
 	mut fn_returns := map[string]string{}
 	for module_name in modules {
 		module_dir := b.pref.get_vlib_module_path(module_name)
-		for file in get_v_files_from_dir(module_dir, b.pref.user_defines) {
+		for file in get_v_files_from_dir(module_dir, b.pref.user_defines, b.pref.get_effective_os()) {
 			lines := os.read_lines(file) or { continue }
 			for raw_line in lines {
 				line := raw_line.trim_space()
@@ -470,7 +471,7 @@ fn (b &Builder) source_fn_decls_for_module(module_name string) map[string]string
 	module_path := b.module_name_to_path(module_name)
 	module_dir := b.pref.get_vlib_module_path(module_path)
 	mut decls := map[string]string{}
-	for file in get_v_files_from_dir(module_dir, b.pref.user_defines) {
+	for file in get_v_files_from_dir(module_dir, b.pref.user_defines, b.pref.get_effective_os()) {
 		lines := os.read_lines(file) or { continue }
 		mut in_interface := false
 		mut interface_name := ''
@@ -545,7 +546,7 @@ fn (b &Builder) source_struct_field_types_for_module(module_name string) map[str
 	module_path := b.module_name_to_path(module_name)
 	module_dir := b.pref.get_vlib_module_path(module_path)
 	mut field_types := map[string]string{}
-	for file in get_v_files_from_dir(module_dir, b.pref.user_defines) {
+	for file in get_v_files_from_dir(module_dir, b.pref.user_defines, b.pref.get_effective_os()) {
 		lines := os.read_lines(file) or { continue }
 		mut in_struct := false
 		mut struct_name := ''
@@ -594,7 +595,7 @@ fn (mut b Builder) parse_module_source_files_for_headers(modules []string) []ast
 	mut source_paths := []string{}
 	for module_name in modules {
 		source_paths << get_v_files_from_dir(b.pref.get_vlib_module_path(module_name),
-			b.pref.user_defines)
+			b.pref.user_defines, b.pref.get_effective_os())
 	}
 	return parser_reused.parse_files(source_paths, mut b.file_set)
 }
@@ -795,7 +796,7 @@ fn (b &Builder) resolved_header_interface_decl(module_name string, stmt ast.Inte
 fn (b &Builder) append_source_type_alias_decls(module_name string, mut type_decl_stmts []ast.Stmt, mut type_decl_seen map[string]bool) {
 	module_path := b.module_name_to_path(module_name)
 	module_dir := b.pref.get_vlib_module_path(module_path)
-	for file in get_v_files_from_dir(module_dir, b.pref.user_defines) {
+	for file in get_v_files_from_dir(module_dir, b.pref.user_defines, b.pref.get_effective_os()) {
 		lines := os.read_lines(file) or { continue }
 		for raw_line in lines {
 			line := raw_line.trim_space()
@@ -1024,7 +1025,7 @@ fn (b &Builder) module_name_to_path(module_name string) string {
 fn (b &Builder) lookup_alias_source_type_expr(module_name string, type_name string) ?ast.Expr {
 	module_path := b.module_name_to_path(module_name)
 	module_dir := b.pref.get_vlib_module_path(module_path)
-	for file in get_v_files_from_dir(module_dir, b.pref.user_defines) {
+	for file in get_v_files_from_dir(module_dir, b.pref.user_defines, b.pref.get_effective_os()) {
 		lines := os.read_lines(file) or { continue }
 		for raw_line in lines {
 			line := raw_line.trim_space()
@@ -1149,7 +1150,7 @@ fn (b &Builder) module_defines_c_type(module_name string, type_name string) bool
 		'type C.${type_name}',
 		'pub type C.${type_name}',
 	]
-	for file in get_v_files_from_dir(module_dir, b.pref.user_defines) {
+	for file in get_v_files_from_dir(module_dir, b.pref.user_defines, b.pref.get_effective_os()) {
 		content := os.read_file(file) or { continue }
 		for pattern in patterns {
 			idx := content.index(pattern) or { continue }

--- a/vlib/v2/builder/parse.v
+++ b/vlib/v2/builder/parse.v
@@ -50,7 +50,8 @@ fn (mut b Builder) parse_files(files []string) []ast.File {
 		} else {
 			for module_path in core_cached_module_paths {
 				vlib_path := b.pref.get_vlib_module_path(module_path)
-				module_files := get_v_files_from_dir(vlib_path, b.pref.user_defines)
+				module_files := get_v_files_from_dir(vlib_path, b.pref.user_defines,
+					b.pref.get_effective_os())
 				parsed_module_files := parser_reused.parse_files(module_files, mut b.file_set)
 				ast_files << parsed_module_files
 			}
@@ -64,7 +65,7 @@ fn (mut b Builder) parse_files(files []string) []ast.File {
 			continue
 		}
 		if os.is_dir(input) {
-			dir_files := get_v_files_from_dir(input, b.pref.user_defines)
+			dir_files := get_v_files_from_dir(input, b.pref.user_defines, b.pref.get_effective_os())
 			for dir_file in dir_files {
 				if dir_file != '' && dir_file !in seen_user_files {
 					expanded_user_files << dir_file
@@ -78,7 +79,8 @@ fn (mut b Builder) parse_files(files []string) []ast.File {
 				expanded_user_files << input
 				seen_user_files[input] = true
 			}
-			dir_files := get_v_files_from_dir(os.dir(input), b.pref.user_defines)
+			dir_files := get_v_files_from_dir(os.dir(input), b.pref.user_defines,
+				b.pref.get_effective_os())
 			for dir_file in dir_files {
 				if dir_file != '' && dir_file !in seen_user_files {
 					expanded_user_files << dir_file
@@ -113,7 +115,8 @@ fn (mut b Builder) parse_files(files []string) []ast.File {
 				continue
 			}
 			mod_path := b.pref.get_module_path(mod.name, ast_file.name)
-			module_files := get_v_files_from_dir(mod_path, b.pref.user_defines)
+			module_files := get_v_files_from_dir(mod_path, b.pref.user_defines,
+				b.pref.get_effective_os())
 			if module_files.len == 0 {
 				continue
 			}

--- a/vlib/v2/builder/parse_d_parallel.v
+++ b/vlib/v2/builder/parse_d_parallel.v
@@ -45,7 +45,8 @@ fn worker(mut wp util.WorkerPool[string, ast.File], mut pstate ParsingSharedStat
 				}
 				pstate.mark_module_as_parsed(mod.name)
 				mod_path := prefs.get_module_path(mod.name, ast_file.name)
-				wp.queue_jobs(get_v_files_from_dir(mod_path, prefs.user_defines))
+				wp.queue_jobs(get_v_files_from_dir(mod_path, prefs.user_defines,
+					prefs.get_effective_os()))
 			}
 		}
 		wp.push_result(ast_file)
@@ -78,7 +79,7 @@ fn (mut b Builder) parse_files_parallel(files []string) []ast.File {
 		} else {
 			for module_path in core_cached_module_paths {
 				worker_pool.queue_jobs(get_v_files_from_dir(b.pref.get_vlib_module_path(module_path),
-					b.pref.user_defines))
+					b.pref.user_defines, b.pref.get_effective_os()))
 			}
 		}
 	}

--- a/vlib/v2/builder/util.v
+++ b/vlib/v2/builder/util.v
@@ -10,7 +10,7 @@ fn list_dir_entries(path string) []string {
 	return os.ls(path) or { []string{} }
 }
 
-pub fn get_v_files_from_dir(dir string, user_defines []string) []string {
+pub fn get_v_files_from_dir(dir string, user_defines []string, target_os string) []string {
 	if dir == '' {
 		return []string{}
 	}
@@ -30,7 +30,7 @@ pub fn get_v_files_from_dir(dir string, user_defines []string) []string {
 			continue
 		}
 		// Skip files specialized for a different target OS before parsing/type checking.
-		if pref.file_has_incompatible_os_suffix(file, os.user_os()) {
+		if pref.file_has_incompatible_os_suffix(file, target_os) {
 			continue
 		}
 		// Conditional compilation files: _d_<feature> included when -d <feature> is set,

--- a/vlib/v2/builder/util_test.v
+++ b/vlib/v2/builder/util_test.v
@@ -1,0 +1,40 @@
+module builder
+
+import os
+
+fn test_get_v_files_from_dir_uses_target_os() {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v2_builder_target_os_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	os.write_file(os.join_path(tmp_dir, 'common.v'), 'module test') or { panic(err) }
+	os.write_file(os.join_path(tmp_dir, 'platform_linux.v'), 'module test') or { panic(err) }
+	os.write_file(os.join_path(tmp_dir, 'platform_macos.v'), 'module test') or { panic(err) }
+
+	macos_files := get_v_files_from_dir(tmp_dir, []string{}, 'mac')
+	macos_names := macos_files.map(os.file_name(it))
+	assert 'common.v' in macos_names
+	assert 'platform_macos.v' in macos_names
+	assert 'platform_linux.v' !in macos_names
+
+	linux_files := get_v_files_from_dir(tmp_dir, []string{}, 'linux')
+	linux_names := linux_files.map(os.file_name(it))
+	assert 'common.v' in linux_names
+	assert 'platform_linux.v' in linux_names
+	assert 'platform_macos.v' !in linux_names
+}
+
+fn test_flag_helpers_use_target_os() {
+	assert flag_os_matches('macos', 'mac')
+	assert !flag_os_matches('linux', 'mac')
+	assert comptime_cond_matches('macos', 'mac')
+	assert !comptime_cond_matches('linux', 'mac')
+	assert comptime_cond_matches('macos && !linux', 'mac')
+	macos_flag := parse_flag_directive_line('#flag macos -framework Cocoa', '/tmp/source.v', 'mac') or {
+		''
+	}
+	linux_flag := parse_flag_directive_line('#flag linux -lm', '/tmp/source.v', 'mac') or { '' }
+	assert macos_flag == '-framework Cocoa'
+	assert linux_flag == ''
+}

--- a/vlib/v2/gen/x64/asm.v
+++ b/vlib/v2/gen/x64/asm.v
@@ -217,6 +217,14 @@ fn asm_xor_reg_reg(mut g Gen, reg Reg) {
 	}
 }
 
+// and rcx, imm8
+fn asm_and_rcx_imm8(mut g Gen, imm u8) {
+	g.emit(0x48)
+	g.emit(0x83)
+	g.emit(0xE1)
+	g.emit(imm)
+}
+
 // === Shifts ===
 
 // shl rax, cl
@@ -237,6 +245,13 @@ fn asm_sar_rax_cl(mut g Gen) {
 fn asm_shr_rax_cl(mut g Gen) {
 	g.emit(0x48)
 	g.emit(0xD3)
+	g.emit(0xE8)
+}
+
+// shr rax, 1
+fn asm_shr_rax_1(mut g Gen) {
+	g.emit(0x48)
+	g.emit(0xD1)
 	g.emit(0xE8)
 }
 
@@ -308,6 +323,15 @@ fn asm_setcc_al_movzx(mut g Gen, cc u8) {
 	g.emit(0x0F)
 	g.emit(0xB6)
 	g.emit(0xC0) // movzx rax, al
+}
+
+fn asm_ucomis_xmm0_xmm1(mut g Gen, size int) {
+	if size == 8 {
+		g.emit(0x66)
+	}
+	g.emit(0x0F)
+	g.emit(0x2E)
+	g.emit(0xC1)
 }
 
 // === Memory ===
@@ -680,6 +704,64 @@ fn asm_load_xmm_rbp_disp(mut g Gen, xmm int, disp int, size int) {
 	}
 }
 
+fn asm_load_xmm_mem_base_disp_size(mut g Gen, xmm int, base Reg, disp int, size int) {
+	base_hw := g.map_reg(int(base))
+	if size == 4 {
+		g.emit(0xF3)
+	} else {
+		g.emit(0xF2)
+	}
+	mut rex := u8(0)
+	if xmm >= 8 {
+		rex |= 4
+	}
+	if base_hw >= 8 {
+		rex |= 1
+	}
+	if rex != 0 {
+		g.emit(0x40 | rex)
+	}
+	g.emit(0x0F)
+	g.emit(0x10)
+	asm_emit_modrm_base_disp(mut g, u8(xmm & 7), base_hw, disp)
+}
+
+fn asm_cvtss2sd_xmm0_xmm0(mut g Gen) {
+	g.emit(0xF3)
+	g.emit(0x0F)
+	g.emit(0x5A)
+	g.emit(0xC0)
+}
+
+fn asm_cvtsd2ss_xmm0_xmm0(mut g Gen) {
+	g.emit(0xF2)
+	g.emit(0x0F)
+	g.emit(0x5A)
+	g.emit(0xC0)
+}
+
+fn asm_add_float_xmm0_xmm0(mut g Gen, size int) {
+	if size == 4 {
+		g.emit(0xF3)
+	} else {
+		g.emit(0xF2)
+	}
+	g.emit(0x0F)
+	g.emit(0x58)
+	g.emit(0xC0)
+}
+
+fn asm_sub_float_xmm0_xmm1(mut g Gen, size int) {
+	if size == 4 {
+		g.emit(0xF3)
+	} else {
+		g.emit(0xF2)
+	}
+	g.emit(0x0F)
+	g.emit(0x5C)
+	g.emit(0xC1)
+}
+
 fn asm_float_binop_xmm0_xmm1(mut g Gen, op u8, size int) {
 	if size == 4 {
 		g.emit(0xF3)
@@ -728,6 +810,16 @@ fn asm_je_rel32(mut g Gen) {
 fn asm_jne_rel32(mut g Gen) {
 	g.emit(0x0F)
 	g.emit(0x85)
+}
+
+fn asm_jns_rel32(mut g Gen) {
+	g.emit(0x0F)
+	g.emit(0x89)
+}
+
+fn asm_jae_rel32(mut g Gen) {
+	g.emit(0x0F)
+	g.emit(0x83)
 }
 
 // === Call ===

--- a/vlib/v2/gen/x64/asm.v
+++ b/vlib/v2/gen/x64/asm.v
@@ -155,6 +155,13 @@ fn asm_idiv_rcx(mut g Gen) {
 	g.emit(0xF9)
 }
 
+// div rcx (unsigned rdx:rax / rcx -> quotient in rax, remainder in rdx)
+fn asm_div_rcx(mut g Gen) {
+	g.emit(0x48)
+	g.emit(0xF7)
+	g.emit(0xF1)
+}
+
 // mov rax, rdx (for getting remainder after idiv)
 fn asm_mov_rax_rdx(mut g Gen) {
 	g.emit(0x48)
@@ -189,6 +196,12 @@ fn asm_xor_rax_rcx(mut g Gen) {
 fn asm_xor_eax_eax(mut g Gen) {
 	g.emit(0x31)
 	g.emit(0xC0)
+}
+
+// xor edx, edx (clear rdx before unsigned division)
+fn asm_xor_edx_edx(mut g Gen) {
+	g.emit(0x31)
+	g.emit(0xD2)
 }
 
 // xor reg, reg (clear register - handles r8-r15)
@@ -278,6 +291,14 @@ const cc_le = u8(0x9E) // less or equal (signed)
 
 const cc_ge = u8(0x9D) // greater or equal (signed)
 
+const cc_b = u8(0x92) // below (unsigned less)
+
+const cc_a = u8(0x97) // above (unsigned greater)
+
+const cc_be = u8(0x96) // below or equal (unsigned)
+
+const cc_ae = u8(0x93) // above or equal (unsigned)
+
 // setcc al + movzx rax, al
 fn asm_setcc_al_movzx(mut g Gen, cc u8) {
 	g.emit(0x0F)
@@ -303,6 +324,29 @@ fn asm_mov_rax_mem_rcx(mut g Gen) {
 	g.emit(0x48)
 	g.emit(0x8B)
 	g.emit(0x01)
+}
+
+fn asm_emit_modrm_base_disp(mut g Gen, reg_bits u8, base_hw u8, disp int) {
+	rm := base_hw & 7
+	needs_sib := rm == 4 // rsp/r12
+	if disp == 0 && rm != 5 {
+		g.emit((reg_bits << 3) | rm)
+		if needs_sib {
+			g.emit(0x24)
+		}
+	} else if disp >= -128 && disp <= 127 {
+		g.emit(0x40 | (reg_bits << 3) | rm)
+		if needs_sib {
+			g.emit(0x24)
+		}
+		g.emit(u8(disp))
+	} else {
+		g.emit(0x80 | (reg_bits << 3) | rm)
+		if needs_sib {
+			g.emit(0x24)
+		}
+		g.emit_u32(u32(disp))
+	}
 }
 
 // mov rax, [base + disp]
@@ -338,6 +382,56 @@ fn asm_mov_rax_mem_base_disp(mut g Gen, base Reg, disp int) {
 	}
 }
 
+fn asm_load_reg_mem_base_disp_size(mut g Gen, reg Reg, base Reg, disp int, size int) {
+	reg_hw := g.map_reg(int(reg))
+	base_hw := g.map_reg(int(base))
+	if size == 8 {
+		mut rex := u8(0x48)
+		if reg_hw >= 8 {
+			rex |= 4 // REX.R
+		}
+		if base_hw >= 8 {
+			rex |= 1 // REX.B
+		}
+		g.emit(rex)
+		g.emit(0x8B)
+		asm_emit_modrm_base_disp(mut g, reg_hw & 7, base_hw, disp)
+		return
+	}
+	if size == 4 {
+		mut rex := u8(0)
+		if reg_hw >= 8 {
+			rex |= 4
+		}
+		if base_hw >= 8 {
+			rex |= 1
+		}
+		if rex != 0 {
+			g.emit(0x40 | rex)
+		}
+		g.emit(0x8B)
+		asm_emit_modrm_base_disp(mut g, reg_hw & 7, base_hw, disp)
+		return
+	}
+	if size == 2 || size == 1 {
+		mut rex := u8(0)
+		if reg_hw >= 8 {
+			rex |= 4
+		}
+		if base_hw >= 8 {
+			rex |= 1
+		}
+		if rex != 0 {
+			g.emit(0x40 | rex)
+		}
+		g.emit(0x0F)
+		g.emit(if size == 2 { u8(0xB7) } else { u8(0xB6) })
+		asm_emit_modrm_base_disp(mut g, reg_hw & 7, base_hw, disp)
+		return
+	}
+	asm_load_reg_mem_base_disp_size(mut g, reg, base, disp, 8)
+}
+
 // mov [base + disp], rax
 fn asm_mov_mem_base_disp_rax(mut g Gen, base Reg, disp int) {
 	base_hw := g.map_reg(int(base))
@@ -369,6 +463,43 @@ fn asm_mov_mem_base_disp_rax(mut g Gen, base Reg, disp int) {
 		}
 		g.emit_u32(u32(disp))
 	}
+}
+
+fn asm_store_mem_base_disp_reg_size(mut g Gen, base Reg, disp int, reg Reg, size int) {
+	reg_hw := g.map_reg(int(reg))
+	base_hw := g.map_reg(int(base))
+	if size == 8 {
+		mut rex := u8(0x48)
+		if reg_hw >= 8 {
+			rex |= 4 // REX.R
+		}
+		if base_hw >= 8 {
+			rex |= 1 // REX.B
+		}
+		g.emit(rex)
+		g.emit(0x89)
+		asm_emit_modrm_base_disp(mut g, reg_hw & 7, base_hw, disp)
+		return
+	}
+	if size == 4 || size == 2 || size == 1 {
+		if size == 2 {
+			g.emit(0x66)
+		}
+		mut rex := u8(0)
+		if reg_hw >= 8 {
+			rex |= 4
+		}
+		if base_hw >= 8 {
+			rex |= 1
+		}
+		if rex != 0 {
+			g.emit(0x40 | rex)
+		}
+		g.emit(if size == 1 { u8(0x88) } else { u8(0x89) })
+		asm_emit_modrm_base_disp(mut g, reg_hw & 7, base_hw, disp)
+		return
+	}
+	asm_store_mem_base_disp_reg_size(mut g, base, disp, reg, 8)
 }
 
 // lea rax, [rbp + disp8]
@@ -477,6 +608,107 @@ fn asm_store_rbp_disp_reg(mut g Gen, disp int, reg Reg) {
 		g.emit(0x85 | ((hw_reg & 7) << 3)) // ModRM 10 = disp32
 		g.emit_u32(u32(disp))
 	}
+}
+
+fn asm_store_rbp_disp_reg_size(mut g Gen, disp int, reg Reg, size int) {
+	asm_store_mem_base_disp_reg_size(mut g, rbp, disp, reg, size)
+}
+
+fn asm_cvtsi2ss_xmm0_rax(mut g Gen) {
+	g.emit(0xF3)
+	g.emit(0x48)
+	g.emit(0x0F)
+	g.emit(0x2A)
+	g.emit(0xC0)
+}
+
+fn asm_cvtsi2sd_xmm0_rax(mut g Gen) {
+	g.emit(0xF2)
+	g.emit(0x48)
+	g.emit(0x0F)
+	g.emit(0x2A)
+	g.emit(0xC0)
+}
+
+fn asm_cvttss2si_rax_xmm0(mut g Gen) {
+	g.emit(0xF3)
+	g.emit(0x48)
+	g.emit(0x0F)
+	g.emit(0x2C)
+	g.emit(0xC0)
+}
+
+fn asm_cvttsd2si_rax_xmm0(mut g Gen) {
+	g.emit(0xF2)
+	g.emit(0x48)
+	g.emit(0x0F)
+	g.emit(0x2C)
+	g.emit(0xC0)
+}
+
+fn asm_store_xmm0_rbp_disp(mut g Gen, disp int, size int) {
+	if size == 4 {
+		g.emit(0xF3)
+	} else {
+		g.emit(0xF2)
+	}
+	g.emit(0x0F)
+	g.emit(0x11)
+	if disp >= -128 && disp <= 127 {
+		g.emit(0x45)
+		g.emit(u8(disp))
+	} else {
+		g.emit(0x85)
+		g.emit_u32(u32(disp))
+	}
+}
+
+fn asm_load_xmm_rbp_disp(mut g Gen, xmm int, disp int, size int) {
+	if size == 4 {
+		g.emit(0xF3)
+	} else {
+		g.emit(0xF2)
+	}
+	g.emit(0x0F)
+	g.emit(0x10)
+	if disp >= -128 && disp <= 127 {
+		g.emit(0x45 | (u8(xmm & 7) << 3))
+		g.emit(u8(disp))
+	} else {
+		g.emit(0x85 | (u8(xmm & 7) << 3))
+		g.emit_u32(u32(disp))
+	}
+}
+
+fn asm_float_binop_xmm0_xmm1(mut g Gen, op u8, size int) {
+	if size == 4 {
+		g.emit(0xF3)
+	} else {
+		g.emit(0xF2)
+	}
+	g.emit(0x0F)
+	g.emit(op)
+	g.emit(0xC1)
+}
+
+fn asm_movsxd_rax_eax(mut g Gen) {
+	g.emit(0x48)
+	g.emit(0x63)
+	g.emit(0xC0)
+}
+
+fn asm_movsx_rax_ax(mut g Gen) {
+	g.emit(0x48)
+	g.emit(0x0F)
+	g.emit(0xBF)
+	g.emit(0xC0)
+}
+
+fn asm_movsx_rax_al(mut g Gen) {
+	g.emit(0x48)
+	g.emit(0x0F)
+	g.emit(0xBE)
+	g.emit(0xC0)
 }
 
 // === Branches ===

--- a/vlib/v2/gen/x64/asm.v
+++ b/vlib/v2/gen/x64/asm.v
@@ -185,6 +185,12 @@ fn asm_or_rax_rcx(mut g Gen) {
 	g.emit(0xC8)
 }
 
+fn asm_or_rax_r11(mut g Gen) {
+	g.emit(0x4C)
+	g.emit(0x09)
+	g.emit(0xD8)
+}
+
 // xor rax, rcx
 fn asm_xor_rax_rcx(mut g Gen) {
 	g.emit(0x48)
@@ -255,12 +261,26 @@ fn asm_shr_rax_1(mut g Gen) {
 	g.emit(0xE8)
 }
 
+fn asm_shr_rax_imm8(mut g Gen, imm u8) {
+	g.emit(0x48)
+	g.emit(0xC1)
+	g.emit(0xE8)
+	g.emit(imm)
+}
+
 // shl rcx, 3 (for GEP: index * 8)
 fn asm_shl_rcx_3(mut g Gen) {
 	g.emit(0x48)
 	g.emit(0xC1)
 	g.emit(0xE1)
 	g.emit(0x03)
+}
+
+fn asm_shl_r11_imm8(mut g Gen, imm u8) {
+	g.emit(0x49)
+	g.emit(0xC1)
+	g.emit(0xE3)
+	g.emit(imm)
 }
 
 // === Compare ===
@@ -314,6 +334,10 @@ const cc_be = u8(0x96) // below or equal (unsigned)
 
 const cc_ae = u8(0x93) // above or equal (unsigned)
 
+const cc_p = u8(0x9A) // parity (unordered for ucomis)
+
+const cc_np = u8(0x9B) // not parity (ordered for ucomis)
+
 // setcc al + movzx rax, al
 fn asm_setcc_al_movzx(mut g Gen, cc u8) {
 	g.emit(0x0F)
@@ -323,6 +347,16 @@ fn asm_setcc_al_movzx(mut g Gen, cc u8) {
 	g.emit(0x0F)
 	g.emit(0xB6)
 	g.emit(0xC0) // movzx rax, al
+}
+
+fn asm_setcc_cl_movzx(mut g Gen, cc u8) {
+	g.emit(0x0F)
+	g.emit(cc)
+	g.emit(0xC1) // setcc cl
+	g.emit(0x48)
+	g.emit(0x0F)
+	g.emit(0xB6)
+	g.emit(0xC9) // movzx rcx, cl
 }
 
 fn asm_ucomis_xmm0_xmm1(mut g Gen, size int) {
@@ -453,7 +487,36 @@ fn asm_load_reg_mem_base_disp_size(mut g Gen, reg Reg, base Reg, disp int, size 
 		asm_emit_modrm_base_disp(mut g, reg_hw & 7, base_hw, disp)
 		return
 	}
-	asm_load_reg_mem_base_disp_size(mut g, reg, base, disp, 8)
+	asm_unsupported_memory_size('load', size)
+}
+
+fn asm_load_reg_mem_base_disp_size_signed(mut g Gen, reg Reg, base Reg, disp int, size int) {
+	reg_hw := g.map_reg(int(reg))
+	base_hw := g.map_reg(int(base))
+	if size == 8 {
+		asm_load_reg_mem_base_disp_size(mut g, reg, base, disp, size)
+		return
+	}
+	mut rex := u8(0x48)
+	if reg_hw >= 8 {
+		rex |= 4
+	}
+	if base_hw >= 8 {
+		rex |= 1
+	}
+	g.emit(rex)
+	if size == 4 {
+		g.emit(0x63)
+		asm_emit_modrm_base_disp(mut g, reg_hw & 7, base_hw, disp)
+		return
+	}
+	if size == 2 || size == 1 {
+		g.emit(0x0F)
+		g.emit(if size == 2 { u8(0xBF) } else { u8(0xBE) })
+		asm_emit_modrm_base_disp(mut g, reg_hw & 7, base_hw, disp)
+		return
+	}
+	asm_unsupported_memory_size('signed load', size)
 }
 
 // mov [base + disp], rax
@@ -523,7 +586,12 @@ fn asm_store_mem_base_disp_reg_size(mut g Gen, base Reg, disp int, reg Reg, size
 		asm_emit_modrm_base_disp(mut g, reg_hw & 7, base_hw, disp)
 		return
 	}
-	asm_store_mem_base_disp_reg_size(mut g, base, disp, reg, 8)
+	asm_unsupported_memory_size('store', size)
+}
+
+fn asm_unsupported_memory_size(op string, size int) {
+	eprintln('x64: unsupported ${op} memory size ${size}')
+	exit(1)
 }
 
 // lea rax, [rbp + disp8]
@@ -671,18 +739,25 @@ fn asm_cvttsd2si_rax_xmm0(mut g Gen) {
 }
 
 fn asm_store_xmm0_rbp_disp(mut g Gen, disp int, size int) {
+	asm_store_xmm_rbp_disp(mut g, 0, disp, size)
+}
+
+fn asm_store_xmm_rbp_disp(mut g Gen, xmm int, disp int, size int) {
 	if size == 4 {
 		g.emit(0xF3)
 	} else {
 		g.emit(0xF2)
 	}
+	if xmm >= 8 {
+		g.emit(0x44)
+	}
 	g.emit(0x0F)
 	g.emit(0x11)
 	if disp >= -128 && disp <= 127 {
-		g.emit(0x45)
+		g.emit(0x45 | (u8(xmm & 7) << 3))
 		g.emit(u8(disp))
 	} else {
-		g.emit(0x85)
+		g.emit(0x85 | (u8(xmm & 7) << 3))
 		g.emit_u32(u32(disp))
 	}
 }
@@ -731,6 +806,13 @@ fn asm_cvtss2sd_xmm0_xmm0(mut g Gen) {
 	g.emit(0x0F)
 	g.emit(0x5A)
 	g.emit(0xC0)
+}
+
+fn asm_cvtss2sd_xmm1_xmm1(mut g Gen) {
+	g.emit(0xF3)
+	g.emit(0x0F)
+	g.emit(0x5A)
+	g.emit(0xC9)
 }
 
 fn asm_cvtsd2ss_xmm0_xmm0(mut g Gen) {

--- a/vlib/v2/gen/x64/x64.v
+++ b/vlib/v2/gen/x64/x64.v
@@ -208,6 +208,7 @@ fn (mut g Gen) gen_func(func mir.Function) {
 	abi_regs := [7, 6, 2, 1, 8, 9]
 	arg_reg_base := if func.abi_ret_indirect { 1 } else { 0 }
 	mut reg_arg_idx := arg_reg_base
+	mut sse_arg_idx := 0
 	if func.abi_ret_indirect && g.sret_save_offset != 0 {
 		asm_store_rbp_disp_reg(mut g, g.sret_save_offset, rdi)
 	}
@@ -215,6 +216,15 @@ fn (mut g Gen) gen_func(func mir.Function) {
 	for i, pid in func.params {
 		is_indirect_param := i < func.abi_param_class.len && func.abi_param_class[i] == .indirect
 		param_size := g.type_size(g.mod.values[pid].typ)
+		if g.value_is_float_type(pid) {
+			g.ensure_float_abi_scalar(pid, 'parameter')
+			if sse_arg_idx >= 8 {
+				g.unsupported_float_abi('stack parameter', pid)
+			}
+			asm_store_xmm_rbp_disp(mut g, sse_arg_idx, g.stack_map[pid], param_size)
+			sse_arg_idx++
+			continue
+		}
 		param_chunks := if !is_indirect_param && g.value_is_aggregate(pid) && param_size > 8
 			&& param_size <= 16 {
 			(param_size + 7) / 8
@@ -228,13 +238,16 @@ fn (mut g Gen) gen_func(func mir.Function) {
 			} else if param_chunks > 1 {
 				offset := g.stack_map[pid]
 				for chunk := 0; chunk < param_chunks; chunk++ {
-					asm_store_rbp_disp_reg_size(mut g, offset + chunk * 8, Reg(abi_regs[
-						reg_arg_idx + chunk]), if chunk == param_chunks - 1 {
+					chunk_size := if chunk == param_chunks - 1 {
 						param_size - chunk * 8
 					} else {
 						8
-					})
+					}
+					g.store_reg_to_rbp_exact(Reg(abi_regs[reg_arg_idx + chunk]),
+						offset + chunk * 8, chunk_size)
 				}
+			} else if g.value_needs_raw_abi_reg_bytes(pid, param_size) {
+				g.store_reg_to_rbp_exact(Reg(src), g.stack_map[pid], param_size)
 			} else if reg := g.reg_map[pid] {
 				asm_mov_reg_reg(mut g, Reg(reg), Reg(src))
 			} else {
@@ -250,6 +263,9 @@ fn (mut g Gen) gen_func(func mir.Function) {
 				g.copy_indirect_param_from_reg(pid, int(rax))
 			} else if param_chunks > 1 {
 				g.copy_memory(int(rbp), g.stack_map[pid], int(rbp), stack_param_offset, param_size)
+			} else if g.value_needs_raw_abi_reg_bytes(pid, param_size) {
+				asm_load_reg_rbp_disp(mut g, rax, stack_param_offset)
+				g.store_reg_to_rbp_exact(rax, g.stack_map[pid], param_size)
 			} else if reg := g.reg_map[pid] {
 				asm_load_reg_rbp_disp(mut g, rax, stack_param_offset)
 				asm_mov_reg_reg(mut g, Reg(reg), rax)
@@ -301,6 +317,10 @@ fn (mut g Gen) gen_instr(val_id int) {
 	match op {
 		.add, .sub, .mul, .sdiv, .udiv, .srem, .urem, .and_, .or_, .xor, .shl, .ashr, .lshr, .eq,
 		.ne, .lt, .gt, .le, .ge, .ult, .ugt, .ule, .uge {
+			if op in [.eq, .ne, .lt, .gt, .le, .ge] && g.value_is_float_type(instr.operands[0]) {
+				g.emit_float_compare(op, instr.operands[0], instr.operands[1], val_id)
+				return
+			}
 			g.load_val_to_reg(0, instr.operands[0]) // RAX
 			g.load_val_to_reg(1, instr.operands[1]) // RCX
 
@@ -378,7 +398,7 @@ fn (mut g Gen) gen_instr(val_id int) {
 			src_typ := g.mod.values[src_id].typ
 			src_type_info := g.mod.type_store.types[src_typ]
 			src_size := g.type_size(src_typ)
-			if src_type_info.kind == .struct_t || src_size > 8 {
+			if src_type_info.kind in [.struct_t, .array_t] || src_size > 8 {
 				g.load_struct_src_address_to_reg(int(r10), src_id, src_typ)
 				g.load_val_to_reg(int(r11), instr.operands[1])
 				g.copy_memory(int(r11), 0, int(r10), 0, src_size)
@@ -391,8 +411,13 @@ fn (mut g Gen) gen_instr(val_id int) {
 		.load {
 			g.load_val_to_reg(1, instr.operands[0]) // Ptr -> RCX
 			load_size := g.type_size(instr.typ)
-			asm_load_reg_mem_base_disp_size(mut g, rax, rcx, 0, load_size)
-			g.store_reg_to_val(0, val_id)
+			load_type_info := g.mod.type_store.types[instr.typ]
+			if load_type_info.kind in [.struct_t, .array_t] || load_size > 8 {
+				g.copy_memory(int(rbp), g.stack_map[val_id], int(rcx), 0, load_size)
+			} else {
+				g.load_typed_mem_to_reg(rax, rcx, 0, instr.typ, load_size)
+				g.store_reg_to_val(0, val_id)
+			}
 		}
 		.alloca {
 			off := g.alloca_offsets[val_id]
@@ -457,28 +482,11 @@ fn (mut g Gen) gen_instr(val_id int) {
 			}
 
 			// Stack arguments were pushed above; this pass only loads register arguments.
-			mut reg_arg_idx := 0
-			for i in 1 .. instr.operands.len {
-				arg_idx := i - 1
-				arg_id := instr.operands[i]
-				if stack_args[arg_idx] {
-					continue
-				}
-				arg_chunks := g.call_arg_reg_chunks(arg_id, arg_idx, instr)
-				if reg_arg_idx + arg_chunks <= 6 {
-					if arg_chunks > 1 {
-						g.load_aggregate_arg_to_regs(arg_id, abi_regs[reg_arg_idx..reg_arg_idx +
-							arg_chunks], g.type_size(g.mod.values[arg_id].typ))
-					} else {
-						g.load_call_arg_to_reg(abi_regs[reg_arg_idx], arg_id, arg_idx, instr)
-					}
-					reg_arg_idx += arg_chunks
-				}
-			}
+			sse_arg_idx := g.load_call_register_args(instr, abi_regs, stack_args)
 			fn_val := g.mod.values[instr.operands[0]]
 
-			// xor eax, eax (Clear AL for variadic function calls)
-			asm_xor_eax_eax(mut g)
+			// AL carries the number of SSE argument registers for variadic calls.
+			g.emit_sse_arg_count(sse_arg_idx)
 
 			if fn_val.name != '' && fn_val.kind in [.unknown, .func_ref] {
 				asm_call_rel32(mut g)
@@ -502,7 +510,7 @@ fn (mut g Gen) gen_instr(val_id int) {
 			}
 
 			if g.mod.type_store.types[g.mod.values[val_id].typ].kind != .void_t {
-				g.store_reg_to_val(0, val_id)
+				g.store_call_result(val_id)
 			}
 		}
 		.call_sret {
@@ -527,29 +535,12 @@ fn (mut g Gen) gen_instr(val_id int) {
 			}
 
 			// Stack arguments were pushed above; this pass only loads register arguments.
-			mut reg_arg_idx := 0
-			for i := 1; i <= num_args; i++ {
-				arg_idx := i - 1
-				arg_id := instr.operands[i]
-				if stack_args[arg_idx] {
-					continue
-				}
-				arg_chunks := g.call_arg_reg_chunks(arg_id, arg_idx, instr)
-				if reg_arg_idx + arg_chunks <= abi_regs.len {
-					if arg_chunks > 1 {
-						g.load_aggregate_arg_to_regs(arg_id, abi_regs[reg_arg_idx..reg_arg_idx +
-							arg_chunks], g.type_size(g.mod.values[arg_id].typ))
-					} else {
-						g.load_call_arg_to_reg(abi_regs[reg_arg_idx], arg_id, arg_idx, instr)
-					}
-					reg_arg_idx += arg_chunks
-				}
-			}
+			sse_arg_idx := g.load_call_register_args(instr, abi_regs, stack_args)
 
 			fn_val := g.mod.values[instr.operands[0]]
 
-			// xor eax, eax (Clear AL for variadic function calls)
-			asm_xor_eax_eax(mut g)
+			// AL carries the number of SSE argument registers for variadic calls.
+			g.emit_sse_arg_count(sse_arg_idx)
 
 			if fn_val.name != '' && fn_val.kind in [.unknown, .func_ref] {
 				asm_call_rel32(mut g)
@@ -591,30 +582,13 @@ fn (mut g Gen) gen_instr(val_id int) {
 			}
 
 			// Stack arguments were pushed above; this pass only loads register arguments.
-			mut reg_arg_idx := 0
-			for i in 1 .. instr.operands.len {
-				arg_idx := i - 1
-				arg_id := instr.operands[i]
-				if stack_args[arg_idx] {
-					continue
-				}
-				arg_chunks := g.call_arg_reg_chunks(arg_id, arg_idx, instr)
-				if reg_arg_idx + arg_chunks <= abi_regs.len {
-					if arg_chunks > 1 {
-						g.load_aggregate_arg_to_regs(arg_id, abi_regs[reg_arg_idx..reg_arg_idx +
-							arg_chunks], g.type_size(g.mod.values[arg_id].typ))
-					} else {
-						g.load_call_arg_to_reg(abi_regs[reg_arg_idx], arg_id, arg_idx, instr)
-					}
-					reg_arg_idx += arg_chunks
-				}
-			}
+			sse_arg_idx := g.load_call_register_args(instr, abi_regs, stack_args)
 
 			// Load function pointer to r10 (caller-saved, not used for args)
 			g.load_val_to_reg(10, instr.operands[0])
 
-			// xor eax, eax (Clear AL for variadic function calls)
-			asm_xor_eax_eax(mut g)
+			// AL carries the number of SSE argument registers for variadic calls.
+			g.emit_sse_arg_count(sse_arg_idx)
 
 			// call *r10
 			asm_call_r10(mut g)
@@ -630,7 +604,7 @@ fn (mut g Gen) gen_instr(val_id int) {
 			}
 
 			if g.mod.type_store.types[g.mod.values[val_id].typ].kind != .void_t {
-				g.store_reg_to_val(0, val_id)
+				g.store_call_result(val_id)
 			}
 		}
 		.ret {
@@ -643,18 +617,20 @@ fn (mut g Gen) gen_instr(val_id int) {
 					ret_size := g.type_size(g.cur_func_ret_type)
 					if ret_size > 0 {
 						g.load_struct_src_address_to_reg(int(r10), ret_val_id, g.cur_func_ret_type)
-						num_chunks := (ret_size + 7) / 8
-						for i := 0; i < num_chunks; i++ {
-							disp := i * 8
-							asm_mov_rax_mem_base_disp(mut g, r10, disp)
-							asm_mov_mem_base_disp_rax(mut g, rdi, disp)
-						}
+						g.copy_memory(int(rdi), 0, int(r10), 0, ret_size)
 					}
 				}
 				// SysV returns sret pointer in RAX.
 				asm_mov_reg_reg(mut g, rax, rdi)
 			} else if instr.operands.len > 0 {
-				g.load_val_to_reg(0, instr.operands[0])
+				ret_val_id := instr.operands[0]
+				if g.value_is_float_type(ret_val_id) {
+					g.ensure_float_abi_scalar(ret_val_id, 'return')
+					g.load_float_val_to_xmm(0, ret_val_id,
+						g.type_size(g.mod.values[ret_val_id].typ))
+				} else {
+					g.load_val_to_reg(0, ret_val_id)
+				}
 			}
 			g.emit_epilogue()
 		}
@@ -832,7 +808,7 @@ fn (mut g Gen) gen_instr(val_id int) {
 			if result_size > 8 || g.value_is_aggregate(val_id) {
 				g.copy_memory(int(rbp), g.stack_map[val_id], int(r10), field_off, result_size)
 			} else {
-				asm_load_reg_mem_base_disp_size(mut g, rax, r10, field_off, result_size)
+				g.load_typed_mem_to_reg(rax, r10, field_off, instr.typ, result_size)
 				g.store_reg_to_val(0, val_id)
 			}
 		}
@@ -870,6 +846,57 @@ fn (mut g Gen) mask_rax_to_size(size int, op ssa.OpCode, val_id int) {
 			g.unsupported_numeric_conversion(op, size, size, val_id)
 		}
 	}
+}
+
+fn (mut g Gen) emit_float_compare(op ssa.OpCode, lhs int, rhs int, val_id int) {
+	lhs_size := g.type_size(g.mod.values[lhs].typ)
+	rhs_size := g.type_size(g.mod.values[rhs].typ)
+	if lhs_size !in [4, 8] || rhs_size !in [4, 8] || !g.value_is_float_type(rhs) {
+		g.unsupported_numeric_conversion(op, lhs_size, rhs_size, val_id)
+	}
+	g.load_float_val_to_xmm(0, lhs, lhs_size)
+	g.load_float_val_to_xmm(1, rhs, rhs_size)
+	size := if lhs_size == 8 || rhs_size == 8 { 8 } else { 4 }
+	if lhs_size == 4 && size == 8 {
+		asm_cvtss2sd_xmm0_xmm0(mut g)
+	}
+	if rhs_size == 4 && size == 8 {
+		asm_cvtss2sd_xmm1_xmm1(mut g)
+	}
+	asm_ucomis_xmm0_xmm1(mut g, size)
+	match op {
+		.eq {
+			asm_setcc_al_movzx(mut g, cc_e)
+			asm_setcc_cl_movzx(mut g, cc_np)
+			asm_and_rax_rcx(mut g)
+		}
+		.ne {
+			asm_setcc_al_movzx(mut g, cc_ne)
+			asm_setcc_cl_movzx(mut g, cc_p)
+			asm_or_rax_rcx(mut g)
+		}
+		.lt {
+			asm_setcc_al_movzx(mut g, cc_b)
+			asm_setcc_cl_movzx(mut g, cc_np)
+			asm_and_rax_rcx(mut g)
+		}
+		.gt {
+			asm_setcc_al_movzx(mut g, cc_a)
+		}
+		.le {
+			asm_setcc_al_movzx(mut g, cc_be)
+			asm_setcc_cl_movzx(mut g, cc_np)
+			asm_and_rax_rcx(mut g)
+		}
+		.ge {
+			asm_setcc_al_movzx(mut g, cc_ae)
+		}
+		else {
+			g.unsupported_numeric_conversion(op, size, size, val_id)
+		}
+	}
+
+	g.store_reg_to_val(0, val_id)
 }
 
 fn (mut g Gen) emit_signed_int_to_float(result_size int, op ssa.OpCode, val_id int) {
@@ -1141,9 +1168,10 @@ fn (mut g Gen) store_repeated_zero(base int, off int, size int) {
 		asm_store_mem_base_disp_reg_size(mut g, Reg(base), off + done, rax, 8)
 		done += 8
 	}
-	if done < size {
-		tail := size - done
-		asm_store_mem_base_disp_reg_size(mut g, Reg(base), off + done, rax, tail)
+	for done < size {
+		chunk := raw_memory_chunk_size(size - done)
+		asm_store_mem_base_disp_reg_size(mut g, Reg(base), off + done, rax, chunk)
+		done += chunk
 	}
 }
 
@@ -1162,10 +1190,82 @@ fn (mut g Gen) copy_memory(dst_base int, dst_off int, src_base int, src_off int,
 		asm_store_mem_base_disp_reg_size(mut g, Reg(dst_base), dst_off + done, rax, 8)
 		done += 8
 	}
-	if done < size {
-		tail := size - done
-		asm_load_reg_mem_base_disp_size(mut g, rax, Reg(src_base), src_off + done, tail)
-		asm_store_mem_base_disp_reg_size(mut g, Reg(dst_base), dst_off + done, rax, tail)
+	for done < size {
+		chunk := raw_memory_chunk_size(size - done)
+		asm_load_reg_mem_base_disp_size(mut g, rax, Reg(src_base), src_off + done, chunk)
+		asm_store_mem_base_disp_reg_size(mut g, Reg(dst_base), dst_off + done, rax, chunk)
+		done += chunk
+	}
+}
+
+fn raw_memory_chunk_size(size int) int {
+	if size >= 4 {
+		return 4
+	}
+	if size >= 2 {
+		return 2
+	}
+	return 1
+}
+
+fn is_raw_abi_reg_size(size int) bool {
+	return size !in [1, 2, 4, 8]
+}
+
+fn (mut g Gen) load_typed_mem_to_reg(reg Reg, base Reg, disp int, typ_id int, size int) {
+	typ := g.mod.type_store.types[typ_id]
+	if typ.kind == .int_t && !typ.is_unsigned {
+		asm_load_reg_mem_base_disp_size_signed(mut g, reg, base, disp, size)
+		return
+	}
+	asm_load_reg_mem_base_disp_size(mut g, reg, base, disp, size)
+}
+
+fn (mut g Gen) load_raw_mem_to_reg(reg Reg, base Reg, disp int, size int) {
+	if size in [1, 2, 4, 8] {
+		asm_load_reg_mem_base_disp_size(mut g, reg, base, disp, size)
+		return
+	}
+	if size <= 0 || size > 8 {
+		eprintln('x64: unsupported raw memory size ${size}')
+		exit(1)
+	}
+	asm_xor_reg_reg(mut g, rax)
+	mut done := 0
+	for done < size {
+		chunk := raw_memory_chunk_size(size - done)
+		asm_load_reg_mem_base_disp_size(mut g, r11, base, disp + done, chunk)
+		if done > 0 {
+			asm_shl_r11_imm8(mut g, u8(done * 8))
+		}
+		asm_or_rax_r11(mut g)
+		done += chunk
+	}
+	if reg != rax {
+		asm_mov_reg_reg(mut g, reg, rax)
+	}
+}
+
+fn (mut g Gen) store_reg_to_rbp_exact(reg Reg, off int, size int) {
+	if size in [1, 2, 4, 8] {
+		asm_store_rbp_disp_reg_size(mut g, off, reg, size)
+		return
+	}
+	if size <= 0 || size > 8 {
+		eprintln('x64: unsupported raw register spill size ${size}')
+		exit(1)
+	}
+	if reg != rax {
+		asm_mov_reg_reg(mut g, rax, reg)
+	}
+	mut done := 0
+	for done < size {
+		chunk := raw_memory_chunk_size(size - done)
+		asm_store_rbp_disp_reg_size(mut g, off + done, rax, chunk)
+		done += chunk
+		if done < size {
+			asm_shr_rax_imm8(mut g, u8(chunk * 8))
+		}
 	}
 }
 
@@ -1173,6 +1273,11 @@ fn (mut g Gen) store_field_value(dst_id int, dst_typ int, field_idx int, src_id 
 	field_off := g.struct_field_offset_bytes(dst_typ, field_idx)
 	dst_off := g.stack_map[dst_id] + field_off
 	if size > 8 || g.value_is_aggregate(src_id) {
+		if g.value_is_zero_constant(src_id) {
+			asm_xor_reg_reg(mut g, rax)
+			g.store_repeated_zero(int(rbp), dst_off, size)
+			return
+		}
 		g.load_struct_src_address_to_reg(int(r10), src_id, g.mod.values[src_id].typ)
 		g.copy_memory(int(rbp), dst_off, int(r10), 0, size)
 		return
@@ -1245,7 +1350,71 @@ fn (mut g Gen) load_call_arg_to_reg(reg int, val_id int, arg_idx int, instr mir.
 		g.load_address_of_val_to_reg(reg, val_id)
 		return
 	}
+	size := g.type_size(g.mod.values[val_id].typ)
+	if g.value_needs_raw_abi_reg_bytes(val_id, size) {
+		if g.value_is_zero_constant(val_id) {
+			asm_xor_reg_reg(mut g, Reg(reg))
+			return
+		}
+		g.load_struct_src_address_to_reg(int(r10), val_id, g.mod.values[val_id].typ)
+		g.load_raw_mem_to_reg(Reg(reg), r10, 0, size)
+		return
+	}
 	g.load_val_to_reg(reg, val_id)
+}
+
+fn (mut g Gen) load_call_register_args(instr mir.Instruction, abi_regs []int, stack_args []bool) int {
+	mut reg_arg_idx := 0
+	mut sse_arg_idx := 0
+	for i in 1 .. instr.operands.len {
+		arg_idx := i - 1
+		arg_id := instr.operands[i]
+		if g.value_is_float_type(arg_id) {
+			g.load_float_call_arg_to_xmm(sse_arg_idx, arg_id)
+			sse_arg_idx++
+			continue
+		}
+		if stack_args[arg_idx] {
+			continue
+		}
+		arg_chunks := g.call_arg_reg_chunks(arg_id, arg_idx, instr)
+		if reg_arg_idx + arg_chunks <= abi_regs.len {
+			if arg_chunks > 1 {
+				g.load_aggregate_arg_to_regs(arg_id,
+					abi_regs[reg_arg_idx..reg_arg_idx + arg_chunks],
+					g.type_size(g.mod.values[arg_id].typ))
+			} else {
+				g.load_call_arg_to_reg(abi_regs[reg_arg_idx], arg_id, arg_idx, instr)
+			}
+			reg_arg_idx += arg_chunks
+		}
+	}
+	return sse_arg_idx
+}
+
+fn (mut g Gen) load_float_call_arg_to_xmm(xmm int, val_id int) {
+	g.ensure_float_abi_scalar(val_id, 'argument')
+	if xmm >= 8 {
+		g.unsupported_float_abi('stack argument', val_id)
+	}
+	g.load_float_val_to_xmm(xmm, val_id, g.type_size(g.mod.values[val_id].typ))
+}
+
+fn (mut g Gen) store_call_result(val_id int) {
+	if g.value_is_float_type(val_id) {
+		g.ensure_float_abi_scalar(val_id, 'call result')
+		asm_store_xmm0_rbp_disp(mut g, g.stack_map[val_id], g.type_size(g.mod.values[val_id].typ))
+		return
+	}
+	g.store_reg_to_val(0, val_id)
+}
+
+fn (mut g Gen) emit_sse_arg_count(count int) {
+	if count == 0 {
+		asm_xor_eax_eax(mut g)
+	} else {
+		asm_mov_reg_imm32(mut g, rax, u32(count))
+	}
 }
 
 fn (g Gen) param_stack_slots(is_indirect bool, reg_chunks int, size int) int {
@@ -1291,8 +1460,17 @@ fn (g Gen) call_stack_arg_mask(instr mir.Instruction, abi_reg_count int) []bool 
 	num_args := instr.operands.len - 1
 	mut stack_args := []bool{len: num_args}
 	mut reg_arg_idx := 0
+	mut sse_arg_idx := 0
 	for arg_idx := 0; arg_idx < num_args; arg_idx++ {
 		arg_id := instr.operands[arg_idx + 1]
+		if g.value_is_float_type(arg_id) {
+			g.ensure_float_abi_scalar(arg_id, 'argument')
+			if sse_arg_idx >= 8 {
+				g.unsupported_float_abi('stack argument', arg_id)
+			}
+			sse_arg_idx++
+			continue
+		}
 		arg_chunks := g.call_arg_reg_chunks(arg_id, arg_idx, instr)
 		if reg_arg_idx + arg_chunks <= abi_reg_count {
 			reg_arg_idx += arg_chunks
@@ -1322,7 +1500,7 @@ fn (mut g Gen) push_call_stack_arg(val_id int, arg_idx int, instr mir.Instructio
 		g.load_struct_src_address_to_reg(int(r10), val_id, g.mod.values[val_id].typ)
 		for chunk := slots - 1; chunk >= 0; chunk-- {
 			chunk_size := if chunk == slots - 1 { size - chunk * 8 } else { 8 }
-			asm_load_reg_mem_base_disp_size(mut g, rax, r10, chunk * 8, chunk_size)
+			g.load_raw_mem_to_reg(rax, r10, chunk * 8, chunk_size)
 			asm_push(mut g, rax)
 		}
 		return
@@ -1335,7 +1513,7 @@ fn (mut g Gen) load_aggregate_arg_to_regs(val_id int, regs []int, size int) {
 	g.load_struct_src_address_to_reg(int(r10), val_id, g.mod.values[val_id].typ)
 	for chunk, reg in regs {
 		chunk_size := if chunk == regs.len - 1 { size - chunk * 8 } else { 8 }
-		asm_load_reg_mem_base_disp_size(mut g, Reg(reg), r10, chunk * 8, chunk_size)
+		g.load_raw_mem_to_reg(Reg(reg), r10, chunk * 8, chunk_size)
 	}
 }
 
@@ -1367,12 +1545,7 @@ fn (mut g Gen) copy_indirect_param_from_reg(param_id int, src_reg int) {
 		asm_mov_reg_reg(mut g, r10, Reg(src_reg))
 	}
 	g.load_address_of_val_to_reg(int(r11), param_id)
-	num_chunks := (param_size + 7) / 8
-	for i := 0; i < num_chunks; i++ {
-		disp := i * 8
-		asm_mov_rax_mem_base_disp(mut g, r10, disp)
-		asm_mov_mem_base_disp_rax(mut g, r11, disp)
-	}
+	g.copy_memory(int(r11), 0, int(r10), 0, param_size)
 }
 
 fn (mut g Gen) load_val_to_reg(reg int, val_id int) {
@@ -1633,6 +1806,10 @@ fn (mut g Gen) allocate_registers(func mir.Function) {
 			alloca_vals[pid] = true
 			continue
 		}
+		if g.value_is_float_type(pid) {
+			alloca_vals[pid] = true
+			continue
+		}
 		intervals[pid] = &Interval{
 			val_id: pid
 			start:  0
@@ -1728,6 +1905,43 @@ fn (g Gen) value_is_aggregate(val_id int) bool {
 	}
 	typ := g.mod.type_store.types[typ_id]
 	return typ.kind in [.struct_t, .array_t]
+}
+
+fn (g Gen) value_is_float_type(val_id int) bool {
+	if val_id <= 0 || val_id >= g.mod.values.len {
+		return false
+	}
+	typ_id := g.mod.values[val_id].typ
+	if typ_id <= 0 || typ_id >= g.mod.type_store.types.len {
+		return false
+	}
+	return g.mod.type_store.types[typ_id].kind == .float_t
+}
+
+fn (g Gen) ensure_float_abi_scalar(val_id int, context string) {
+	size := g.type_size(g.mod.values[val_id].typ)
+	if size == 4 || size == 8 {
+		return
+	}
+	g.unsupported_float_abi(context, val_id)
+}
+
+fn (g Gen) unsupported_float_abi(context string, val_id int) {
+	size := g.type_size(g.mod.values[val_id].typ)
+	eprintln('x64: unsupported float ABI ${context} with ${size * 8}-bit type in value ${val_id}')
+	exit(1)
+}
+
+fn (g Gen) value_is_zero_constant(val_id int) bool {
+	if val_id <= 0 || val_id >= g.mod.values.len {
+		return false
+	}
+	val := g.mod.values[val_id]
+	return val.kind == .constant && val.name == '0'
+}
+
+fn (g Gen) value_needs_raw_abi_reg_bytes(val_id int, size int) bool {
+	return size > 0 && size <= 8 && (g.value_is_aggregate(val_id) || is_raw_abi_reg_size(size))
 }
 
 fn (g Gen) stack_storage_size(val_id int) int {

--- a/vlib/v2/gen/x64/x64.v
+++ b/vlib/v2/gen/x64/x64.v
@@ -456,7 +456,7 @@ fn (mut g Gen) gen_instr(val_id int) {
 				}
 			}
 
-			// Load register arguments
+			// Stack arguments were pushed above; this pass only loads register arguments.
 			mut reg_arg_idx := 0
 			for i in 1 .. instr.operands.len {
 				arg_idx := i - 1
@@ -526,7 +526,7 @@ fn (mut g Gen) gen_instr(val_id int) {
 				}
 			}
 
-			// Load register arguments.
+			// Stack arguments were pushed above; this pass only loads register arguments.
 			mut reg_arg_idx := 0
 			for i := 1; i <= num_args; i++ {
 				arg_idx := i - 1
@@ -590,7 +590,7 @@ fn (mut g Gen) gen_instr(val_id int) {
 				}
 			}
 
-			// Load register arguments
+			// Stack arguments were pushed above; this pass only loads register arguments.
 			mut reg_arg_idx := 0
 			for i in 1 .. instr.operands.len {
 				arg_idx := i - 1
@@ -713,40 +713,70 @@ fn (mut g Gen) gen_instr(val_id int) {
 		}
 		.bitcast, .trunc, .zext, .sext {
 			if instr.operands.len > 0 {
-				g.load_val_to_reg(0, instr.operands[0])
-				if op == .sext {
-					src_size := g.type_size(g.mod.values[instr.operands[0]].typ)
-					if src_size == 1 {
-						asm_movsx_rax_al(mut g)
-					} else if src_size == 2 {
-						asm_movsx_rax_ax(mut g)
-					} else if src_size == 4 {
-						asm_movsxd_rax_eax(mut g)
+				src_typ := g.mod.values[instr.operands[0]].typ
+				dst_typ := instr.typ
+				src_info := g.mod.type_store.types[src_typ]
+				dst_info := g.mod.type_store.types[dst_typ]
+				src_size := g.type_size(src_typ)
+				dst_size := g.type_size(dst_typ)
+				if op in [.trunc, .zext] && src_info.kind == .float_t && dst_info.kind == .float_t {
+					g.load_float_val_to_xmm(0, instr.operands[0], src_size)
+					if op == .trunc && src_size == 8 && dst_size == 4 {
+						asm_cvtsd2ss_xmm0_xmm0(mut g)
+					} else if op == .zext && src_size == 4 && dst_size == 8 {
+						asm_cvtss2sd_xmm0_xmm0(mut g)
+					} else {
+						g.unsupported_numeric_conversion(op, src_size, dst_size, val_id)
 					}
+					asm_store_xmm0_rbp_disp(mut g, g.stack_map[val_id], dst_size)
+				} else if op in [.trunc, .zext, .sext] && src_info.kind == .int_t
+					&& dst_info.kind == .int_t {
+					g.load_val_to_reg(0, instr.operands[0])
+					if op == .trunc {
+						g.mask_rax_to_size(dst_size, op, val_id)
+					} else if op == .zext {
+						g.mask_rax_to_size(src_size, op, val_id)
+					} else if op == .sext {
+						if src_size == 1 {
+							asm_movsx_rax_al(mut g)
+						} else if src_size == 2 {
+							asm_movsx_rax_ax(mut g)
+						} else if src_size == 4 {
+							asm_movsxd_rax_eax(mut g)
+						} else if src_size != 8 {
+							g.unsupported_numeric_conversion(op, src_size, dst_size, val_id)
+						}
+					}
+					g.store_reg_to_val(0, val_id)
+				} else if op == .bitcast {
+					g.load_val_to_reg(0, instr.operands[0])
+					g.store_reg_to_val(0, val_id)
+				} else {
+					g.unsupported_numeric_conversion(op, src_size, dst_size, val_id)
 				}
-				g.store_reg_to_val(0, val_id)
 			}
 		}
 		.sitofp, .uitofp {
 			if instr.operands.len > 0 {
 				g.load_val_to_reg(0, instr.operands[0])
-				result_size := g.type_size(instr.typ)
-				if result_size == 4 {
-					asm_cvtsi2ss_xmm0_rax(mut g)
+				src_size := g.type_size(g.mod.values[instr.operands[0]].typ)
+				if op == .uitofp {
+					g.emit_unsigned_int_to_float(src_size, g.type_size(instr.typ), val_id)
 				} else {
-					asm_cvtsi2sd_xmm0_rax(mut g)
+					g.emit_signed_int_to_float(g.type_size(instr.typ), op, val_id)
 				}
-				asm_store_xmm0_rbp_disp(mut g, g.stack_map[val_id], result_size)
+				asm_store_xmm0_rbp_disp(mut g, g.stack_map[val_id], g.type_size(instr.typ))
 			}
 		}
 		.fptosi, .fptoui {
 			if instr.operands.len > 0 {
 				src_size := g.type_size(g.mod.values[instr.operands[0]].typ)
+				dst_size := g.type_size(instr.typ)
 				g.load_float_val_to_xmm(0, instr.operands[0], src_size)
-				if src_size == 4 {
-					asm_cvttss2si_rax_xmm0(mut g)
+				if op == .fptoui {
+					g.emit_float_to_unsigned_int(src_size, dst_size, val_id)
 				} else {
-					asm_cvttsd2si_rax_xmm0(mut g)
+					g.emit_float_to_signed_int(src_size, op, val_id)
 				}
 				g.store_reg_to_val(0, val_id)
 			}
@@ -819,6 +849,127 @@ fn (mut g Gen) gen_instr(val_id int) {
 			exit(1)
 		}
 	}
+}
+
+fn (mut g Gen) mask_rax_to_size(size int, op ssa.OpCode, val_id int) {
+	match size {
+		1 {
+			asm_mov_reg_imm64(mut g, rcx, 0xff)
+			asm_and_rax_rcx(mut g)
+		}
+		2 {
+			asm_mov_reg_imm64(mut g, rcx, 0xffff)
+			asm_and_rax_rcx(mut g)
+		}
+		4 {
+			asm_mov_reg_imm64(mut g, rcx, 0xffffffff)
+			asm_and_rax_rcx(mut g)
+		}
+		8 {}
+		else {
+			g.unsupported_numeric_conversion(op, size, size, val_id)
+		}
+	}
+}
+
+fn (mut g Gen) emit_signed_int_to_float(result_size int, op ssa.OpCode, val_id int) {
+	if result_size == 4 {
+		asm_cvtsi2ss_xmm0_rax(mut g)
+	} else if result_size == 8 {
+		asm_cvtsi2sd_xmm0_rax(mut g)
+	} else {
+		g.unsupported_numeric_conversion(op, 8, result_size, val_id)
+	}
+}
+
+fn (mut g Gen) emit_unsigned_int_to_float(src_size int, result_size int, val_id int) {
+	if src_size < 8 {
+		g.mask_rax_to_size(src_size, .uitofp, val_id)
+		g.emit_signed_int_to_float(result_size, .uitofp, val_id)
+		return
+	}
+	if src_size != 8 {
+		g.unsupported_numeric_conversion(.uitofp, src_size, result_size, val_id)
+	}
+	asm_test_rax_rax(mut g)
+	asm_jns_rel32(mut g)
+	normal_patch := g.elf.text_data.len
+	g.emit_u32(0)
+	asm_mov_reg_reg(mut g, rcx, rax)
+	asm_and_rcx_imm8(mut g, 1)
+	asm_shr_rax_1(mut g)
+	asm_or_rax_rcx(mut g)
+	g.emit_signed_int_to_float(result_size, .uitofp, val_id)
+	asm_add_float_xmm0_xmm0(mut g, result_size)
+	asm_jmp_rel32(mut g)
+	end_patch := g.elf.text_data.len
+	g.emit_u32(0)
+	g.patch_rel32(normal_patch)
+	g.emit_signed_int_to_float(result_size, .uitofp, val_id)
+	g.patch_rel32(end_patch)
+}
+
+fn (mut g Gen) emit_float_to_signed_int(src_size int, op ssa.OpCode, val_id int) {
+	if src_size == 4 {
+		asm_cvttss2si_rax_xmm0(mut g)
+	} else if src_size == 8 {
+		asm_cvttsd2si_rax_xmm0(mut g)
+	} else {
+		g.unsupported_numeric_conversion(op, src_size, 8, val_id)
+	}
+}
+
+fn (mut g Gen) emit_float_to_unsigned_int(src_size int, dst_size int, val_id int) {
+	if dst_size != 8 {
+		g.emit_float_to_signed_int(src_size, .fptoui, val_id)
+		g.mask_rax_to_size(dst_size, .fptoui, val_id)
+		return
+	}
+	g.load_fp_2p63_to_xmm1(src_size, val_id)
+	asm_ucomis_xmm0_xmm1(mut g, src_size)
+	asm_jae_rel32(mut g)
+	big_patch := g.elf.text_data.len
+	g.emit_u32(0)
+	g.emit_float_to_signed_int(src_size, .fptoui, val_id)
+	asm_jmp_rel32(mut g)
+	end_patch := g.elf.text_data.len
+	g.emit_u32(0)
+	g.patch_rel32(big_patch)
+	asm_sub_float_xmm0_xmm1(mut g, src_size)
+	g.emit_float_to_signed_int(src_size, .fptoui, val_id)
+	asm_mov_reg_imm64(mut g, rcx, 0x8000000000000000)
+	asm_or_rax_rcx(mut g)
+	g.patch_rel32(end_patch)
+}
+
+fn (mut g Gen) load_fp_2p63_to_xmm1(size int, val_id int) {
+	mut bytes := []u8{len: size}
+	if size == 4 {
+		binary.little_endian_put_u32(mut bytes, 0x5f000000)
+	} else if size == 8 {
+		binary.little_endian_put_u64(mut bytes, 0x43e0000000000000)
+	} else {
+		g.unsupported_numeric_conversion(.fptoui, size, 8, val_id)
+	}
+	str_offset := g.elf.rodata.len
+	g.elf.rodata << bytes
+	sym_name := 'L_fp_${g.curr_offset}_${str_offset}'
+	sym_idx := g.elf.add_symbol(sym_name, u64(str_offset), false, 3)
+	asm_lea_reg_rip(mut g, r10)
+	g.elf.add_text_reloc(u64(g.elf.text_data.len), sym_idx, 2, -4)
+	g.emit_u32(0)
+	asm_load_xmm_mem_base_disp_size(mut g, 1, r10, 0, size)
+}
+
+fn (mut g Gen) patch_rel32(patch_pos int) {
+	target := g.elf.text_data.len
+	rel := target - (patch_pos + 4)
+	g.write_u32(patch_pos, u32(rel))
+}
+
+fn (g Gen) unsupported_numeric_conversion(op ssa.OpCode, src_size int, dst_size int, val_id int) {
+	eprintln('x64: unsupported numeric conversion ${op} from ${src_size * 8}-bit to ${dst_size * 8}-bit in value ${val_id}')
+	exit(1)
 }
 
 fn (g Gen) const_int_operand(val_id int) int {

--- a/vlib/v2/gen/x64/x64.v
+++ b/vlib/v2/gen/x64/x64.v
@@ -105,13 +105,14 @@ fn (mut g Gen) gen_func(func mir.Function) {
 
 	g.allocate_registers(func)
 
-	// Calculate Stack Frame
-	mut slot_offset := 8
+	// Start after callee-saved pushes so locals do not overlap their rbp slots.
+	mut slot_offset := g.used_regs.len * 8
 
 	// Hidden sret pointer slot (SysV: incoming in RDI)
 	if func.abi_ret_indirect {
-		g.sret_save_offset = -slot_offset
-		slot_offset += 8
+		off, next_offset := reserve_stack_bytes(slot_offset, 8, 1)
+		g.sret_save_offset = off
+		slot_offset = next_offset
 	}
 
 	for pi, pid in func.params {
@@ -119,12 +120,13 @@ fn (mut g Gen) gen_func(func mir.Function) {
 		param_size := g.type_size(param_typ)
 		is_indirect_param := pi < func.abi_param_class.len && func.abi_param_class[pi] == .indirect
 		if (is_indirect_param || g.value_is_aggregate(pid) || param_size > 8) && param_size > 0 {
-			slot_offset = (slot_offset + 15) & ~0xF
-			slot_offset += param_size
-			g.stack_map[pid] = -slot_offset
+			off, next_offset := reserve_stack_bytes(slot_offset, param_size, 16)
+			g.stack_map[pid] = off
+			slot_offset = next_offset
 		} else {
-			g.stack_map[pid] = -slot_offset
-			slot_offset += 8
+			off, next_offset := reserve_stack_bytes(slot_offset, 8, 1)
+			g.stack_map[pid] = off
+			slot_offset = next_offset
 		}
 	}
 
@@ -143,18 +145,16 @@ fn (mut g Gen) gen_func(func mir.Function) {
 				ptr_type := g.mod.type_store.types[val.typ]
 				alloc_size := g.alloc_size_from_uses(val_id, g.type_size(ptr_type.elem_type))
 
-				// Align to 16 bytes
-				slot_offset = (slot_offset + 15) & ~0xF
-				slot_offset += if alloc_size > 0 { alloc_size } else { 8 }
-				g.alloca_offsets[val_id] = -slot_offset
-				slot_offset += 8 // Slot for the pointer
+				off, next_offset := reserve_stack_bytes(slot_offset, alloc_size, 16)
+				g.alloca_offsets[val_id] = off
+				slot_offset = next_offset
 			}
 
 			if g.value_needs_stack_storage(val_id) {
 				result_size := g.stack_storage_size(val_id)
-				slot_offset = (slot_offset + 15) & ~0xF
-				slot_offset += if result_size > 0 { result_size } else { 8 }
-				g.stack_map[val_id] = -slot_offset
+				off, next_offset := reserve_stack_bytes(slot_offset, result_size, 16)
+				g.stack_map[val_id] = off
+				slot_offset = next_offset
 				continue
 			}
 
@@ -162,17 +162,18 @@ fn (mut g Gen) gen_func(func mir.Function) {
 				if operand > 0 && operand < g.mod.values.len && g.value_needs_stack_storage(operand)
 					&& operand !in g.stack_map {
 					lit_size := g.stack_storage_size(operand)
-					slot_offset = (slot_offset + 15) & ~0xF
-					slot_offset += if lit_size > 0 { lit_size } else { 24 }
-					g.stack_map[operand] = -slot_offset
+					off, next_offset := reserve_stack_bytes(slot_offset, lit_size, 16)
+					g.stack_map[operand] = off
+					slot_offset = next_offset
 				}
 			}
 
 			if val_id in g.reg_map {
 				continue
 			}
-			g.stack_map[val_id] = -slot_offset
-			slot_offset += 8
+			off, next_offset := reserve_stack_bytes(slot_offset, 8, 1)
+			g.stack_map[val_id] = off
+			slot_offset = next_offset
 		}
 	}
 
@@ -210,6 +211,7 @@ fn (mut g Gen) gen_func(func mir.Function) {
 	if func.abi_ret_indirect && g.sret_save_offset != 0 {
 		asm_store_rbp_disp_reg(mut g, g.sret_save_offset, rdi)
 	}
+	mut stack_param_offset := 16
 	for i, pid in func.params {
 		is_indirect_param := i < func.abi_param_class.len && func.abi_param_class[i] == .indirect
 		param_size := g.type_size(g.mod.values[pid].typ)
@@ -242,17 +244,21 @@ fn (mut g Gen) gen_func(func mir.Function) {
 			reg_arg_idx += param_chunks
 		} else {
 			// Stack parameters start at [rbp+16].
-			stack_param_offset := 16 + (i - reg_arg_idx) * 8
-			// Load from stack into RAX, then store to our slot
-			asm_load_reg_rbp_disp(mut g, rax, stack_param_offset)
 			if is_indirect_param {
+				// Load pointer from stack into RAX, then copy through it.
+				asm_load_reg_rbp_disp(mut g, rax, stack_param_offset)
 				g.copy_indirect_param_from_reg(pid, int(rax))
+			} else if param_chunks > 1 {
+				g.copy_memory(int(rbp), g.stack_map[pid], int(rbp), stack_param_offset, param_size)
 			} else if reg := g.reg_map[pid] {
+				asm_load_reg_rbp_disp(mut g, rax, stack_param_offset)
 				asm_mov_reg_reg(mut g, Reg(reg), rax)
 			} else {
+				asm_load_reg_rbp_disp(mut g, rax, stack_param_offset)
 				offset := g.stack_map[pid]
 				asm_store_rbp_disp_reg(mut g, offset, rax)
 			}
+			stack_param_offset += g.param_stack_slots(is_indirect_param, param_chunks, param_size) * 8
 		}
 	}
 
@@ -273,6 +279,17 @@ fn (mut g Gen) gen_func(func mir.Function) {
 			g.gen_instr(val_id)
 		}
 	}
+}
+
+// slot_offset is the number of bytes already reserved below rbp.
+fn reserve_stack_bytes(slot_offset int, size int, align int) (int, int) {
+	mut next_offset := slot_offset
+	if align > 1 && slot_offset % align != 0 {
+		next_offset = ((slot_offset + align - 1) / align) * align
+	}
+	alloc_size := if size > 0 { size } else { 8 }
+	next_offset += alloc_size
+	return -next_offset, next_offset
 }
 
 fn (mut g Gen) gen_instr(val_id int) {
@@ -425,19 +442,17 @@ fn (mut g Gen) gen_instr(val_id int) {
 		.call {
 			abi_regs := [7, 6, 2, 1, 8, 9]
 			num_args := instr.operands.len - 1
+			stack_args := g.call_stack_arg_mask(instr, abi_regs.len)
+			stack_slots := g.call_stack_slots(instr, stack_args)
 
-			// Push stack arguments in reverse order (args 7+)
-			mut stack_args := 0
-			if num_args > 6 {
-				stack_args = num_args - 6
-				// Align stack to 16 bytes if odd number of stack args
-				if stack_args % 2 == 1 {
+			if stack_slots > 0 {
+				if stack_slots % 2 == 1 {
 					asm_push(mut g, rax)
 				}
-				// Push in reverse order
-				for i := num_args; i > 6; i-- {
-					g.load_call_arg_to_reg(0, instr.operands[i], i - 1, instr) // RAX
-					asm_push(mut g, rax)
+				for arg_idx := num_args - 1; arg_idx >= 0; arg_idx-- {
+					if stack_args[arg_idx] {
+						g.push_call_stack_arg(instr.operands[arg_idx + 1], arg_idx, instr)
+					}
 				}
 			}
 
@@ -446,6 +461,9 @@ fn (mut g Gen) gen_instr(val_id int) {
 			for i in 1 .. instr.operands.len {
 				arg_idx := i - 1
 				arg_id := instr.operands[i]
+				if stack_args[arg_idx] {
+					continue
+				}
 				arg_chunks := g.call_arg_reg_chunks(arg_id, arg_idx, instr)
 				if reg_arg_idx + arg_chunks <= 6 {
 					if arg_chunks > 1 {
@@ -474,8 +492,8 @@ fn (mut g Gen) gen_instr(val_id int) {
 			}
 
 			// Clean up stack arguments
-			if stack_args > 0 {
-				cleanup := (stack_args + (stack_args % 2)) * 8
+			if stack_slots > 0 {
+				cleanup := (stack_slots + (stack_slots % 2)) * 8
 				if cleanup <= 127 {
 					asm_add_rsp_imm8(mut g, u8(cleanup))
 				} else {
@@ -491,20 +509,20 @@ fn (mut g Gen) gen_instr(val_id int) {
 			// SysV x86_64: hidden sret pointer in RDI, then user args in RSI,RDX,RCX,R8,R9.
 			abi_regs := [6, 2, 1, 8, 9]
 			num_args := instr.operands.len - 1
+			stack_args := g.call_stack_arg_mask(instr, abi_regs.len)
+			stack_slots := g.call_stack_slots(instr, stack_args)
 
 			// Load destination pointer to RDI.
 			g.load_address_of_val_to_reg(7, val_id)
 
-			// Push stack arguments in reverse order (args 6+ after hidden sret ptr).
-			mut stack_args := 0
-			if num_args > 5 {
-				stack_args = num_args - 5
-				if stack_args % 2 == 1 {
+			if stack_slots > 0 {
+				if stack_slots % 2 == 1 {
 					asm_push(mut g, rax)
 				}
-				for i := num_args; i > 5; i-- {
-					g.load_call_arg_to_reg(0, instr.operands[i], i - 1, instr) // RAX
-					asm_push(mut g, rax)
+				for arg_idx := num_args - 1; arg_idx >= 0; arg_idx-- {
+					if stack_args[arg_idx] {
+						g.push_call_stack_arg(instr.operands[arg_idx + 1], arg_idx, instr)
+					}
 				}
 			}
 
@@ -513,6 +531,9 @@ fn (mut g Gen) gen_instr(val_id int) {
 			for i := 1; i <= num_args; i++ {
 				arg_idx := i - 1
 				arg_id := instr.operands[i]
+				if stack_args[arg_idx] {
+					continue
+				}
 				arg_chunks := g.call_arg_reg_chunks(arg_id, arg_idx, instr)
 				if reg_arg_idx + arg_chunks <= abi_regs.len {
 					if arg_chunks > 1 {
@@ -541,8 +562,8 @@ fn (mut g Gen) gen_instr(val_id int) {
 			}
 
 			// Clean up stack arguments
-			if stack_args > 0 {
-				cleanup := (stack_args + (stack_args % 2)) * 8
+			if stack_slots > 0 {
+				cleanup := (stack_slots + (stack_slots % 2)) * 8
 				if cleanup <= 127 {
 					asm_add_rsp_imm8(mut g, u8(cleanup))
 				} else {
@@ -555,25 +576,37 @@ fn (mut g Gen) gen_instr(val_id int) {
 			// operands[0] is the function pointer, rest are arguments
 			abi_regs := [7, 6, 2, 1, 8, 9]
 			num_args := instr.operands.len - 1
+			stack_args := g.call_stack_arg_mask(instr, abi_regs.len)
+			stack_slots := g.call_stack_slots(instr, stack_args)
 
-			// Push stack arguments in reverse order (args 7+)
-			mut stack_args := 0
-			if num_args > 6 {
-				stack_args = num_args - 6
-				// Align stack to 16 bytes if odd number of stack args
-				if stack_args % 2 == 1 {
+			if stack_slots > 0 {
+				if stack_slots % 2 == 1 {
 					asm_push(mut g, rax)
 				}
-				for i := num_args; i > 6; i-- {
-					g.load_call_arg_to_reg(0, instr.operands[i], i - 1, instr)
-					asm_push(mut g, rax)
+				for arg_idx := num_args - 1; arg_idx >= 0; arg_idx-- {
+					if stack_args[arg_idx] {
+						g.push_call_stack_arg(instr.operands[arg_idx + 1], arg_idx, instr)
+					}
 				}
 			}
 
 			// Load register arguments
+			mut reg_arg_idx := 0
 			for i in 1 .. instr.operands.len {
-				if i - 1 < 6 {
-					g.load_call_arg_to_reg(abi_regs[i - 1], instr.operands[i], i - 1, instr)
+				arg_idx := i - 1
+				arg_id := instr.operands[i]
+				if stack_args[arg_idx] {
+					continue
+				}
+				arg_chunks := g.call_arg_reg_chunks(arg_id, arg_idx, instr)
+				if reg_arg_idx + arg_chunks <= abi_regs.len {
+					if arg_chunks > 1 {
+						g.load_aggregate_arg_to_regs(arg_id, abi_regs[reg_arg_idx..reg_arg_idx +
+							arg_chunks], g.type_size(g.mod.values[arg_id].typ))
+					} else {
+						g.load_call_arg_to_reg(abi_regs[reg_arg_idx], arg_id, arg_idx, instr)
+					}
+					reg_arg_idx += arg_chunks
 				}
 			}
 
@@ -587,8 +620,8 @@ fn (mut g Gen) gen_instr(val_id int) {
 			asm_call_r10(mut g)
 
 			// Clean up stack arguments
-			if stack_args > 0 {
-				cleanup := (stack_args + (stack_args % 2)) * 8
+			if stack_slots > 0 {
+				cleanup := (stack_slots + (stack_slots % 2)) * 8
 				if cleanup <= 127 {
 					asm_add_rsp_imm8(mut g, u8(cleanup))
 				} else {
@@ -1064,6 +1097,19 @@ fn (mut g Gen) load_call_arg_to_reg(reg int, val_id int, arg_idx int, instr mir.
 	g.load_val_to_reg(reg, val_id)
 }
 
+fn (g Gen) param_stack_slots(is_indirect bool, reg_chunks int, size int) int {
+	if is_indirect {
+		return 1
+	}
+	if reg_chunks > 1 {
+		return reg_chunks
+	}
+	if size > 8 {
+		return (size + 7) / 8
+	}
+	return 1
+}
+
 fn (g Gen) call_arg_reg_chunks(val_id int, arg_idx int, instr mir.Instruction) int {
 	is_indirect := arg_idx >= 0 && arg_idx < instr.abi_arg_class.len
 		&& instr.abi_arg_class[arg_idx] == .indirect
@@ -1075,6 +1121,63 @@ fn (g Gen) call_arg_reg_chunks(val_id int, arg_idx int, instr mir.Instruction) i
 		return (size + 7) / 8
 	}
 	return 1
+}
+
+fn (g Gen) call_arg_stack_slots(val_id int, arg_idx int, instr mir.Instruction) int {
+	is_indirect := arg_idx >= 0 && arg_idx < instr.abi_arg_class.len
+		&& instr.abi_arg_class[arg_idx] == .indirect
+	if is_indirect {
+		return 1
+	}
+	size := g.type_size(g.mod.values[val_id].typ)
+	if g.value_is_aggregate(val_id) || size > 8 {
+		return (size + 7) / 8
+	}
+	return 1
+}
+
+fn (g Gen) call_stack_arg_mask(instr mir.Instruction, abi_reg_count int) []bool {
+	num_args := instr.operands.len - 1
+	mut stack_args := []bool{len: num_args}
+	mut reg_arg_idx := 0
+	for arg_idx := 0; arg_idx < num_args; arg_idx++ {
+		arg_id := instr.operands[arg_idx + 1]
+		arg_chunks := g.call_arg_reg_chunks(arg_id, arg_idx, instr)
+		if reg_arg_idx + arg_chunks <= abi_reg_count {
+			reg_arg_idx += arg_chunks
+		} else {
+			stack_args[arg_idx] = true
+		}
+	}
+	return stack_args
+}
+
+fn (g Gen) call_stack_slots(instr mir.Instruction, stack_args []bool) int {
+	mut slots := 0
+	for arg_idx, is_stack in stack_args {
+		if is_stack {
+			slots += g.call_arg_stack_slots(instr.operands[arg_idx + 1], arg_idx, instr)
+		}
+	}
+	return slots
+}
+
+fn (mut g Gen) push_call_stack_arg(val_id int, arg_idx int, instr mir.Instruction) {
+	is_indirect := arg_idx >= 0 && arg_idx < instr.abi_arg_class.len
+		&& instr.abi_arg_class[arg_idx] == .indirect
+	size := g.type_size(g.mod.values[val_id].typ)
+	slots := g.call_arg_stack_slots(val_id, arg_idx, instr)
+	if !is_indirect && slots > 1 {
+		g.load_struct_src_address_to_reg(int(r10), val_id, g.mod.values[val_id].typ)
+		for chunk := slots - 1; chunk >= 0; chunk-- {
+			chunk_size := if chunk == slots - 1 { size - chunk * 8 } else { 8 }
+			asm_load_reg_mem_base_disp_size(mut g, rax, r10, chunk * 8, chunk_size)
+			asm_push(mut g, rax)
+		}
+		return
+	}
+	g.load_call_arg_to_reg(0, val_id, arg_idx, instr)
+	asm_push(mut g, rax)
 }
 
 fn (mut g Gen) load_aggregate_arg_to_regs(val_id int, regs []int, size int) {

--- a/vlib/v2/gen/x64/x64.v
+++ b/vlib/v2/gen/x64/x64.v
@@ -7,6 +7,7 @@ module x64
 import v2.mir
 import v2.ssa
 import encoding.binary
+import math.bits
 
 pub struct Gen {
 	mod &mir.Module
@@ -47,26 +48,43 @@ pub fn Gen.new(mod &mir.Module) &Gen {
 
 pub fn (mut g Gen) gen() {
 	for func in g.mod.funcs {
+		if func.is_c_extern {
+			continue
+		}
+		if func.blocks.len == 0 {
+			continue
+		}
 		g.gen_func(func)
 	}
 
 	// Generate Globals in .data
 	for gvar in g.mod.globals {
+		if gvar.linkage == .external {
+			continue
+		}
 		for g.elf.data_data.len % 8 != 0 {
 			g.elf.data_data << 0
 		}
 		addr := u64(g.elf.data_data.len)
 		g.elf.add_symbol(gvar.name, addr, false, 2)
-		if gvar.is_constant {
-			// For constants, write the initial value
-			mut bytes := []u8{len: 8}
-			binary.little_endian_put_u64(mut bytes, u64(gvar.initial_value))
-			for b in bytes {
-				g.elf.data_data << b
+		if gvar.initial_data.len > 0 {
+			g.elf.data_data << gvar.initial_data
+		} else if gvar.is_constant {
+			size := g.type_size(gvar.typ)
+			mut bytes := []u8{len: if size > 0 { size } else { 8 }}
+			if bytes.len >= 8 {
+				binary.little_endian_put_u64(mut bytes, u64(gvar.initial_value))
+			} else {
+				for i := 0; i < bytes.len; i++ {
+					bytes[i] = u8(u64(gvar.initial_value) >> (i * 8))
+				}
 			}
+			g.elf.data_data << bytes
 		} else {
 			// For regular globals, initialize with zeros
-			for _ in 0 .. 8 {
+			size := g.type_size(gvar.typ)
+			data_size := if size > 0 { size } else { 8 }
+			for _ in 0 .. data_size {
 				g.elf.data_data << 0
 			}
 		}
@@ -100,7 +118,7 @@ fn (mut g Gen) gen_func(func mir.Function) {
 		param_typ := g.mod.values[pid].typ
 		param_size := g.type_size(param_typ)
 		is_indirect_param := pi < func.abi_param_class.len && func.abi_param_class[pi] == .indirect
-		if is_indirect_param && param_size > 0 {
+		if (is_indirect_param || g.value_is_aggregate(pid) || param_size > 8) && param_size > 0 {
 			slot_offset = (slot_offset + 15) & ~0xF
 			slot_offset += param_size
 			g.stack_map[pid] = -slot_offset
@@ -123,36 +141,30 @@ fn (mut g Gen) gen_func(func mir.Function) {
 				// Calculate allocation size based on the type
 				// The alloca result type is ptr(T), so get the element type
 				ptr_type := g.mod.type_store.types[val.typ]
-				elem_type := g.mod.type_store.types[ptr_type.elem_type]
-
-				// Calculate size based on element type
-				mut alloc_size := 64 // Default for non-array types
-				if elem_type.kind == .array_t {
-					// Get the array element type to determine element size
-					arr_elem_type := g.mod.type_store.types[elem_type.elem_type]
-					elem_size := if arr_elem_type.width > 0 {
-						(arr_elem_type.width + 7) / 8 // bits to bytes, rounded up
-					} else {
-						8 // default to 64-bit
-					}
-					alloc_size = elem_type.len * elem_size
-				}
+				alloc_size := g.alloc_size_from_uses(val_id, g.type_size(ptr_type.elem_type))
 
 				// Align to 16 bytes
 				slot_offset = (slot_offset + 15) & ~0xF
-				slot_offset += alloc_size
+				slot_offset += if alloc_size > 0 { alloc_size } else { 8 }
 				g.alloca_offsets[val_id] = -slot_offset
 				slot_offset += 8 // Slot for the pointer
 			}
 
-			if instr.op == .call_sret {
-				result_typ := g.mod.type_store.types[val.typ]
-				if result_typ.kind == .struct_t {
-					result_size := g.type_size(val.typ)
+			if g.value_needs_stack_storage(val_id) {
+				result_size := g.stack_storage_size(val_id)
+				slot_offset = (slot_offset + 15) & ~0xF
+				slot_offset += if result_size > 0 { result_size } else { 8 }
+				g.stack_map[val_id] = -slot_offset
+				continue
+			}
+
+			for operand in instr.operands {
+				if operand > 0 && operand < g.mod.values.len && g.value_needs_stack_storage(operand)
+					&& operand !in g.stack_map {
+					lit_size := g.stack_storage_size(operand)
 					slot_offset = (slot_offset + 15) & ~0xF
-					slot_offset += result_size
-					g.stack_map[val_id] = -slot_offset
-					continue
+					slot_offset += if lit_size > 0 { lit_size } else { 24 }
+					g.stack_map[operand] = -slot_offset
 				}
 			}
 
@@ -165,6 +177,9 @@ fn (mut g Gen) gen_func(func mir.Function) {
 	}
 
 	g.stack_size = (slot_offset + 16) & ~0xF
+	if g.used_regs.len % 2 == 1 {
+		g.stack_size += 8
+	}
 
 	g.elf.add_symbol(func.name, u64(g.curr_offset), true, 1)
 
@@ -191,25 +206,43 @@ fn (mut g Gen) gen_func(func mir.Function) {
 	// For sret functions, hidden pointer consumes RDI.
 	abi_regs := [7, 6, 2, 1, 8, 9]
 	arg_reg_base := if func.abi_ret_indirect { 1 } else { 0 }
-	num_reg_args := 6 - arg_reg_base
+	mut reg_arg_idx := arg_reg_base
 	if func.abi_ret_indirect && g.sret_save_offset != 0 {
 		asm_store_rbp_disp_reg(mut g, g.sret_save_offset, rdi)
 	}
 	for i, pid in func.params {
 		is_indirect_param := i < func.abi_param_class.len && func.abi_param_class[i] == .indirect
-		if i < num_reg_args {
-			src := abi_regs[i + arg_reg_base]
+		param_size := g.type_size(g.mod.values[pid].typ)
+		param_chunks := if !is_indirect_param && g.value_is_aggregate(pid) && param_size > 8
+			&& param_size <= 16 {
+			(param_size + 7) / 8
+		} else {
+			1
+		}
+		if reg_arg_idx + param_chunks <= 6 {
+			src := abi_regs[reg_arg_idx]
 			if is_indirect_param {
 				g.copy_indirect_param_from_reg(pid, src)
+			} else if param_chunks > 1 {
+				offset := g.stack_map[pid]
+				for chunk := 0; chunk < param_chunks; chunk++ {
+					asm_store_rbp_disp_reg_size(mut g, offset + chunk * 8, Reg(abi_regs[
+						reg_arg_idx + chunk]), if chunk == param_chunks - 1 {
+						param_size - chunk * 8
+					} else {
+						8
+					})
+				}
 			} else if reg := g.reg_map[pid] {
 				asm_mov_reg_reg(mut g, Reg(reg), Reg(src))
 			} else {
 				offset := g.stack_map[pid]
 				asm_store_rbp_disp_reg(mut g, offset, Reg(src))
 			}
+			reg_arg_idx += param_chunks
 		} else {
 			// Stack parameters start at [rbp+16].
-			stack_param_offset := 16 + (i - num_reg_args) * 8
+			stack_param_offset := 16 + (i - reg_arg_idx) * 8
 			// Load from stack into RAX, then store to our slot
 			asm_load_reg_rbp_disp(mut g, rax, stack_param_offset)
 			if is_indirect_param {
@@ -249,8 +282,8 @@ fn (mut g Gen) gen_instr(val_id int) {
 	// Temps: 0=RAX, 1=RCX
 
 	match op {
-		.add, .sub, .mul, .sdiv, .srem, .and_, .or_, .xor, .shl, .ashr, .lshr, .eq, .ne, .lt, .gt,
-		.le, .ge {
+		.add, .sub, .mul, .sdiv, .udiv, .srem, .urem, .and_, .or_, .xor, .shl, .ashr, .lshr, .eq,
+		.ne, .lt, .gt, .le, .ge, .ult, .ugt, .ule, .uge {
 			g.load_val_to_reg(0, instr.operands[0]) // RAX
 			g.load_val_to_reg(1, instr.operands[1]) // RCX
 
@@ -268,9 +301,18 @@ fn (mut g Gen) gen_instr(val_id int) {
 					asm_cqo(mut g)
 					asm_idiv_rcx(mut g)
 				}
+				.udiv {
+					asm_xor_edx_edx(mut g)
+					asm_div_rcx(mut g)
+				}
 				.srem {
 					asm_cqo(mut g)
 					asm_idiv_rcx(mut g)
+					asm_mov_rax_rdx(mut g)
+				}
+				.urem {
+					asm_xor_edx_edx(mut g)
+					asm_div_rcx(mut g)
 					asm_mov_rax_rdx(mut g)
 				}
 				.and_ {
@@ -291,7 +333,7 @@ fn (mut g Gen) gen_instr(val_id int) {
 				.lshr {
 					asm_shr_rax_cl(mut g)
 				}
-				.eq, .ne, .lt, .gt, .le, .ge {
+				.eq, .ne, .lt, .gt, .le, .ge, .ult, .ugt, .ule, .uge {
 					asm_cmp_rax_rcx(mut g)
 					cc := match op {
 						.eq { cc_e }
@@ -300,6 +342,10 @@ fn (mut g Gen) gen_instr(val_id int) {
 						.gt { cc_g }
 						.le { cc_le }
 						.ge { cc_ge }
+						.ult { cc_b }
+						.ugt { cc_a }
+						.ule { cc_be }
+						.uge { cc_ae }
 						else { cc_e }
 					}
 
@@ -315,24 +361,20 @@ fn (mut g Gen) gen_instr(val_id int) {
 			src_typ := g.mod.values[src_id].typ
 			src_type_info := g.mod.type_store.types[src_typ]
 			src_size := g.type_size(src_typ)
-			if src_type_info.kind == .struct_t && src_size > 16 {
+			if src_type_info.kind == .struct_t || src_size > 8 {
 				g.load_struct_src_address_to_reg(int(r10), src_id, src_typ)
 				g.load_val_to_reg(int(r11), instr.operands[1])
-				num_chunks := (src_size + 7) / 8
-				for i := 0; i < num_chunks; i++ {
-					disp := i * 8
-					asm_mov_rax_mem_base_disp(mut g, r10, disp)
-					asm_mov_mem_base_disp_rax(mut g, r11, disp)
-				}
+				g.copy_memory(int(r11), 0, int(r10), 0, src_size)
 			} else {
 				g.load_val_to_reg(0, src_id) // Val -> RAX
 				g.load_val_to_reg(1, instr.operands[1]) // Ptr -> RCX
-				asm_mov_mem_rcx_rax(mut g)
+				asm_store_mem_base_disp_reg_size(mut g, rcx, 0, rax, src_size)
 			}
 		}
 		.load {
 			g.load_val_to_reg(1, instr.operands[0]) // Ptr -> RCX
-			asm_mov_rax_mem_rcx(mut g)
+			load_size := g.type_size(instr.typ)
+			asm_load_reg_mem_base_disp_size(mut g, rax, rcx, 0, load_size)
 			g.store_reg_to_val(0, val_id)
 		}
 		.alloca {
@@ -345,12 +387,39 @@ fn (mut g Gen) gen_instr(val_id int) {
 			}
 			g.store_reg_to_val(0, val_id)
 		}
+		.heap_alloc {
+			alloc_size := g.heap_alloc_size(val_id)
+			asm_mov_reg_imm32(mut g, rdi, 1)
+			asm_mov_reg_imm64(mut g, rsi, u64(alloc_size))
+			asm_xor_eax_eax(mut g)
+			asm_call_rel32(mut g)
+			sym_idx := g.elf.add_undefined('calloc')
+			g.elf.add_text_reloc(u64(g.elf.text_data.len), sym_idx, 4, -4)
+			g.emit_u32(0)
+			g.store_reg_to_val(0, val_id)
+		}
 		.get_element_ptr {
 			g.load_val_to_reg(0, instr.operands[0]) // Base -> RAX
-			g.load_val_to_reg(1, instr.operands[1]) // Index -> RCX
-			// add rax, (rcx << 3)
-			asm_shl_rcx_3(mut g)
-			asm_add_rax_rcx(mut g)
+			offset := g.gep_const_offset(instr.operands[0], instr.operands[1])
+			if offset >= 0 {
+				if offset > 0 {
+					asm_mov_reg_imm64(mut g, rcx, u64(offset))
+					asm_add_rax_rcx(mut g)
+				}
+			} else {
+				g.load_val_to_reg(1, instr.operands[1]) // Index -> RCX
+				elem_size := g.gep_elem_size(instr.operands[0])
+				if elem_size == 8 {
+					asm_shl_rcx_3(mut g)
+				} else if elem_size > 1 {
+					asm_mov_reg_reg(mut g, rax, rcx)
+					asm_mov_reg_imm64(mut g, rcx, u64(elem_size))
+					asm_imul_rax_rcx(mut g)
+					asm_mov_reg_reg(mut g, rcx, rax)
+					g.load_val_to_reg(0, instr.operands[0])
+				}
+				asm_add_rax_rcx(mut g)
+			}
 			g.store_reg_to_val(0, val_id)
 		}
 		.call {
@@ -373,9 +442,19 @@ fn (mut g Gen) gen_instr(val_id int) {
 			}
 
 			// Load register arguments
+			mut reg_arg_idx := 0
 			for i in 1 .. instr.operands.len {
-				if i - 1 < 6 {
-					g.load_call_arg_to_reg(abi_regs[i - 1], instr.operands[i], i - 1, instr)
+				arg_idx := i - 1
+				arg_id := instr.operands[i]
+				arg_chunks := g.call_arg_reg_chunks(arg_id, arg_idx, instr)
+				if reg_arg_idx + arg_chunks <= 6 {
+					if arg_chunks > 1 {
+						g.load_aggregate_arg_to_regs(arg_id, abi_regs[reg_arg_idx..reg_arg_idx +
+							arg_chunks], g.type_size(g.mod.values[arg_id].typ))
+					} else {
+						g.load_call_arg_to_reg(abi_regs[reg_arg_idx], arg_id, arg_idx, instr)
+					}
+					reg_arg_idx += arg_chunks
 				}
 			}
 			fn_val := g.mod.values[instr.operands[0]]
@@ -430,8 +509,20 @@ fn (mut g Gen) gen_instr(val_id int) {
 			}
 
 			// Load register arguments.
-			for i := 1; i <= num_args && i <= 5; i++ {
-				g.load_call_arg_to_reg(abi_regs[i - 1], instr.operands[i], i - 1, instr)
+			mut reg_arg_idx := 0
+			for i := 1; i <= num_args; i++ {
+				arg_idx := i - 1
+				arg_id := instr.operands[i]
+				arg_chunks := g.call_arg_reg_chunks(arg_id, arg_idx, instr)
+				if reg_arg_idx + arg_chunks <= abi_regs.len {
+					if arg_chunks > 1 {
+						g.load_aggregate_arg_to_regs(arg_id, abi_regs[reg_arg_idx..reg_arg_idx +
+							arg_chunks], g.type_size(g.mod.values[arg_id].typ))
+					} else {
+						g.load_call_arg_to_reg(abi_regs[reg_arg_idx], arg_id, arg_idx, instr)
+					}
+					reg_arg_idx += arg_chunks
+				}
 			}
 
 			fn_val := g.mod.values[instr.operands[0]]
@@ -532,20 +623,7 @@ fn (mut g Gen) gen_instr(val_id int) {
 			} else if instr.operands.len > 0 {
 				g.load_val_to_reg(0, instr.operands[0])
 			}
-			// Cleanup Stack
-			if g.stack_size > 0 {
-				if g.stack_size <= 127 {
-					asm_add_rsp_imm8(mut g, u8(g.stack_size))
-				} else {
-					asm_add_rsp_imm32(mut g, u32(g.stack_size))
-				}
-			}
-			// Pop callee-saved regs (reverse order)
-			for i := g.used_regs.len - 1; i >= 0; i-- {
-				asm_pop(mut g, Reg(g.used_regs[i]))
-			}
-			asm_pop_rbp(mut g)
-			asm_ret(mut g)
+			g.emit_epilogue()
 		}
 		.jmp {
 			target_idx := g.mod.values[instr.operands[0]].index
@@ -592,12 +670,106 @@ fn (mut g Gen) gen_instr(val_id int) {
 		.assign {
 			dest_id := instr.operands[0]
 			src_id := instr.operands[1]
-			g.load_val_to_reg(0, src_id)
-			g.store_reg_to_val(0, dest_id)
+			dest_size := g.type_size(g.mod.values[dest_id].typ)
+			if g.value_is_aggregate(dest_id) || dest_size > 8 {
+				g.copy_value_bytes(dest_id, src_id, dest_size)
+			} else {
+				g.load_val_to_reg(0, src_id)
+				g.store_reg_to_val(0, dest_id)
+			}
 		}
-		.bitcast {
+		.bitcast, .trunc, .zext, .sext {
 			if instr.operands.len > 0 {
 				g.load_val_to_reg(0, instr.operands[0])
+				if op == .sext {
+					src_size := g.type_size(g.mod.values[instr.operands[0]].typ)
+					if src_size == 1 {
+						asm_movsx_rax_al(mut g)
+					} else if src_size == 2 {
+						asm_movsx_rax_ax(mut g)
+					} else if src_size == 4 {
+						asm_movsxd_rax_eax(mut g)
+					}
+				}
+				g.store_reg_to_val(0, val_id)
+			}
+		}
+		.sitofp, .uitofp {
+			if instr.operands.len > 0 {
+				g.load_val_to_reg(0, instr.operands[0])
+				result_size := g.type_size(instr.typ)
+				if result_size == 4 {
+					asm_cvtsi2ss_xmm0_rax(mut g)
+				} else {
+					asm_cvtsi2sd_xmm0_rax(mut g)
+				}
+				asm_store_xmm0_rbp_disp(mut g, g.stack_map[val_id], result_size)
+			}
+		}
+		.fptosi, .fptoui {
+			if instr.operands.len > 0 {
+				src_size := g.type_size(g.mod.values[instr.operands[0]].typ)
+				g.load_float_val_to_xmm(0, instr.operands[0], src_size)
+				if src_size == 4 {
+					asm_cvttss2si_rax_xmm0(mut g)
+				} else {
+					asm_cvttsd2si_rax_xmm0(mut g)
+				}
+				g.store_reg_to_val(0, val_id)
+			}
+		}
+		.fadd, .fsub, .fmul, .fdiv {
+			result_size := g.type_size(instr.typ)
+			g.load_float_val_to_xmm(0, instr.operands[0], result_size)
+			g.load_float_val_to_xmm(1, instr.operands[1], result_size)
+			opcode := match op {
+				.fadd { u8(0x58) }
+				.fsub { u8(0x5C) }
+				.fmul { u8(0x59) }
+				.fdiv { u8(0x5E) }
+				else { u8(0x58) }
+			}
+
+			asm_float_binop_xmm0_xmm1(mut g, opcode, result_size)
+			asm_store_xmm0_rbp_disp(mut g, g.stack_map[val_id], result_size)
+		}
+		.inline_string_init {
+			g.zero_value_bytes(val_id, g.stack_storage_size(val_id))
+			for fi, field_id in instr.operands {
+				g.store_field_value(val_id, instr.typ, fi, field_id,
+					g.type_size(g.mod.values[field_id].typ))
+			}
+		}
+		.struct_init {
+			g.zero_value_bytes(val_id, g.type_size(instr.typ))
+			for fi, field_id in instr.operands {
+				field_typ := g.struct_field_type(instr.typ, fi, g.mod.values[field_id].typ)
+				g.store_field_value(val_id, instr.typ, fi, field_id, g.type_size(field_typ))
+			}
+		}
+		.insertvalue {
+			tuple_id := instr.operands[0]
+			elem_id := instr.operands[1]
+			idx := g.const_int_operand(instr.operands[2])
+			total_size := g.type_size(instr.typ)
+			if !(g.mod.values[tuple_id].kind == .constant && g.mod.values[tuple_id].name == 'undef') {
+				g.copy_value_bytes(val_id, tuple_id, total_size)
+			} else {
+				g.zero_value_bytes(val_id, total_size)
+			}
+			elem_typ := g.struct_field_type(instr.typ, idx, g.mod.values[elem_id].typ)
+			g.store_field_value(val_id, instr.typ, idx, elem_id, g.type_size(elem_typ))
+		}
+		.extractvalue {
+			tuple_id := instr.operands[0]
+			idx := g.const_int_operand(instr.operands[1])
+			field_off := g.struct_field_offset_bytes(g.mod.values[tuple_id].typ, idx)
+			result_size := g.type_size(instr.typ)
+			g.load_struct_src_address_to_reg(int(r10), tuple_id, g.mod.values[tuple_id].typ)
+			if result_size > 8 || g.value_is_aggregate(val_id) {
+				g.copy_memory(int(rbp), g.stack_map[val_id], int(r10), field_off, result_size)
+			} else {
+				asm_load_reg_mem_base_disp_size(mut g, rax, r10, field_off, result_size)
 				g.store_reg_to_val(0, val_id)
 			}
 		}
@@ -610,9 +782,234 @@ fn (mut g Gen) gen_instr(val_id int) {
 			asm_ud2(mut g)
 		}
 		else {
-			eprintln('x64: unknown op ${op} (${instr.selected_op})')
+			eprintln('x64: unsupported op ${op} (${instr.selected_op}) in value ${val_id}')
+			exit(1)
 		}
 	}
+}
+
+fn (g Gen) const_int_operand(val_id int) int {
+	if val_id > 0 && val_id < g.mod.values.len {
+		return int(g.mod.values[val_id].name.i64())
+	}
+	return 0
+}
+
+fn (g Gen) heap_alloc_size(val_id int) int {
+	val := g.mod.values[val_id]
+	mut min_size := 8
+	if val.typ > 0 && val.typ < g.mod.type_store.types.len {
+		ptr_typ := g.mod.type_store.types[val.typ]
+		if ptr_typ.kind == .ptr_t && ptr_typ.elem_type > 0 {
+			size := g.type_size(ptr_typ.elem_type)
+			min_size = if size > 0 { size } else { 8 }
+		}
+	}
+	return g.alloc_size_from_uses(val_id, min_size)
+}
+
+fn (g Gen) alloc_size_from_uses(ptr_id int, min_size int) int {
+	mut size := if min_size > 0 { min_size } else { 8 }
+	if ptr_id <= 0 || ptr_id >= g.mod.values.len {
+		return size
+	}
+	for use_id in g.mod.values[ptr_id].uses {
+		if use_id <= 0 || use_id >= g.mod.values.len || g.mod.values[use_id].kind != .instruction {
+			continue
+		}
+		use_instr := g.mod.instrs[g.mod.values[use_id].index]
+		if use_instr.op == .store && use_instr.operands.len >= 2 && use_instr.operands[1] == ptr_id {
+			src_size := g.type_size(g.mod.values[use_instr.operands[0]].typ)
+			if src_size > size {
+				size = src_size
+			}
+		}
+		if use_instr.op != .get_element_ptr || use_instr.operands.len < 2
+			|| use_instr.operands[0] != ptr_id {
+			continue
+		}
+		offset := g.gep_const_offset(ptr_id, use_instr.operands[1])
+		if offset < 0 {
+			continue
+		}
+		access_size := g.pointer_access_size(use_id)
+		end := offset + if access_size > 0 { access_size } else { g.gep_elem_size(ptr_id) }
+		if end > size {
+			size = end
+		}
+	}
+	return size
+}
+
+fn (g Gen) pointer_access_size(ptr_id int) int {
+	if ptr_id <= 0 || ptr_id >= g.mod.values.len {
+		return 0
+	}
+	mut size := 0
+	for use_id in g.mod.values[ptr_id].uses {
+		if use_id <= 0 || use_id >= g.mod.values.len || g.mod.values[use_id].kind != .instruction {
+			continue
+		}
+		use_instr := g.mod.instrs[g.mod.values[use_id].index]
+		if use_instr.op == .store && use_instr.operands.len >= 2 && use_instr.operands[1] == ptr_id {
+			src_size := g.type_size(g.mod.values[use_instr.operands[0]].typ)
+			if src_size > size {
+				size = src_size
+			}
+		} else if use_instr.op == .load && use_instr.operands.len >= 1
+			&& use_instr.operands[0] == ptr_id {
+			load_size := g.type_size(use_instr.typ)
+			if load_size > size {
+				size = load_size
+			}
+		}
+	}
+	return size
+}
+
+fn (g Gen) struct_field_type(struct_typ_id int, field_idx int, fallback int) int {
+	if struct_typ_id > 0 && struct_typ_id < g.mod.type_store.types.len {
+		typ := g.mod.type_store.types[struct_typ_id]
+		if typ.kind == .struct_t && field_idx >= 0 && field_idx < typ.fields.len {
+			return typ.fields[field_idx]
+		}
+		if typ.kind == .array_t {
+			return typ.elem_type
+		}
+	}
+	return fallback
+}
+
+fn (g Gen) struct_field_offset_bytes(struct_typ_id int, field_idx int) int {
+	if struct_typ_id <= 0 || struct_typ_id >= g.mod.type_store.types.len {
+		return field_idx * 8
+	}
+	typ := g.mod.type_store.types[struct_typ_id]
+	if typ.kind == .array_t {
+		return field_idx * g.type_size(typ.elem_type)
+	}
+	if typ.kind != .struct_t {
+		return field_idx * 8
+	}
+	mut off := 0
+	for i, field_typ in typ.fields {
+		align := g.type_align(field_typ)
+		if align > 1 && off % align != 0 {
+			off = (off + align - 1) & ~(align - 1)
+		}
+		if i == field_idx {
+			return off
+		}
+		off += g.type_size(field_typ)
+	}
+	return field_idx * 8
+}
+
+fn (g Gen) gep_const_offset(base_id int, idx_id int) int {
+	if idx_id <= 0 || idx_id >= g.mod.values.len || g.mod.values[idx_id].kind != .constant {
+		return -1
+	}
+	idx := g.const_int_operand(idx_id)
+	if base_id <= 0 || base_id >= g.mod.values.len {
+		return idx * 8
+	}
+	base_typ_id := g.mod.values[base_id].typ
+	if base_typ_id <= 0 || base_typ_id >= g.mod.type_store.types.len {
+		return idx * 8
+	}
+	base_typ := g.mod.type_store.types[base_typ_id]
+	if base_typ.kind != .ptr_t {
+		return idx * 8
+	}
+	elem_typ := g.mod.type_store.types[base_typ.elem_type]
+	if elem_typ.kind == .struct_t {
+		return g.struct_field_offset_bytes(base_typ.elem_type, idx)
+	}
+	return idx * g.type_size(base_typ.elem_type)
+}
+
+fn (g Gen) gep_elem_size(base_id int) int {
+	if base_id > 0 && base_id < g.mod.values.len {
+		base_typ_id := g.mod.values[base_id].typ
+		if base_typ_id > 0 && base_typ_id < g.mod.type_store.types.len {
+			base_typ := g.mod.type_store.types[base_typ_id]
+			if base_typ.kind == .ptr_t {
+				size := g.type_size(base_typ.elem_type)
+				return if size > 0 { size } else { 8 }
+			}
+		}
+	}
+	return 8
+}
+
+fn (mut g Gen) zero_value_bytes(val_id int, size int) {
+	if size <= 0 {
+		return
+	}
+	dst_off := g.stack_map[val_id]
+	asm_xor_reg_reg(mut g, rax)
+	g.store_repeated_zero(int(rbp), dst_off, size)
+}
+
+fn (mut g Gen) store_repeated_zero(base int, off int, size int) {
+	mut done := 0
+	for done + 8 <= size {
+		asm_store_mem_base_disp_reg_size(mut g, Reg(base), off + done, rax, 8)
+		done += 8
+	}
+	if done < size {
+		tail := size - done
+		asm_store_mem_base_disp_reg_size(mut g, Reg(base), off + done, rax, tail)
+	}
+}
+
+fn (mut g Gen) copy_value_bytes(dst_id int, src_id int, size int) {
+	if size <= 0 {
+		return
+	}
+	g.load_struct_src_address_to_reg(int(r10), src_id, g.mod.values[src_id].typ)
+	g.copy_memory(int(rbp), g.stack_map[dst_id], int(r10), 0, size)
+}
+
+fn (mut g Gen) copy_memory(dst_base int, dst_off int, src_base int, src_off int, size int) {
+	mut done := 0
+	for done + 8 <= size {
+		asm_load_reg_mem_base_disp_size(mut g, rax, Reg(src_base), src_off + done, 8)
+		asm_store_mem_base_disp_reg_size(mut g, Reg(dst_base), dst_off + done, rax, 8)
+		done += 8
+	}
+	if done < size {
+		tail := size - done
+		asm_load_reg_mem_base_disp_size(mut g, rax, Reg(src_base), src_off + done, tail)
+		asm_store_mem_base_disp_reg_size(mut g, Reg(dst_base), dst_off + done, rax, tail)
+	}
+}
+
+fn (mut g Gen) store_field_value(dst_id int, dst_typ int, field_idx int, src_id int, size int) {
+	field_off := g.struct_field_offset_bytes(dst_typ, field_idx)
+	dst_off := g.stack_map[dst_id] + field_off
+	if size > 8 || g.value_is_aggregate(src_id) {
+		g.load_struct_src_address_to_reg(int(r10), src_id, g.mod.values[src_id].typ)
+		g.copy_memory(int(rbp), dst_off, int(r10), 0, size)
+		return
+	}
+	g.load_val_to_reg(0, src_id)
+	asm_store_rbp_disp_reg_size(mut g, dst_off, rax, size)
+}
+
+fn (mut g Gen) emit_epilogue() {
+	if g.stack_size > 0 {
+		if g.stack_size <= 127 {
+			asm_add_rsp_imm8(mut g, u8(g.stack_size))
+		} else {
+			asm_add_rsp_imm32(mut g, u32(g.stack_size))
+		}
+	}
+	for i := g.used_regs.len - 1; i >= 0; i-- {
+		asm_pop(mut g, Reg(g.used_regs[i]))
+	}
+	asm_pop_rbp(mut g)
+	asm_ret(mut g)
 }
 
 fn (g Gen) selected_opcode(instr mir.Instruction) ssa.OpCode {
@@ -667,8 +1064,33 @@ fn (mut g Gen) load_call_arg_to_reg(reg int, val_id int, arg_idx int, instr mir.
 	g.load_val_to_reg(reg, val_id)
 }
 
+fn (g Gen) call_arg_reg_chunks(val_id int, arg_idx int, instr mir.Instruction) int {
+	is_indirect := arg_idx >= 0 && arg_idx < instr.abi_arg_class.len
+		&& instr.abi_arg_class[arg_idx] == .indirect
+	if is_indirect || !g.value_is_aggregate(val_id) {
+		return 1
+	}
+	size := g.type_size(g.mod.values[val_id].typ)
+	if size > 8 && size <= 16 {
+		return (size + 7) / 8
+	}
+	return 1
+}
+
+fn (mut g Gen) load_aggregate_arg_to_regs(val_id int, regs []int, size int) {
+	g.load_struct_src_address_to_reg(int(r10), val_id, g.mod.values[val_id].typ)
+	for chunk, reg in regs {
+		chunk_size := if chunk == regs.len - 1 { size - chunk * 8 } else { 8 }
+		asm_load_reg_mem_base_disp_size(mut g, Reg(reg), r10, chunk * 8, chunk_size)
+	}
+}
+
 fn (mut g Gen) load_struct_src_address_to_reg(reg int, val_id int, expected_struct_typ int) {
 	val := g.mod.values[val_id]
+	if val.kind == .string_literal {
+		g.materialize_string_literal(reg, val_id)
+		return
+	}
 	if val.typ > 0 && val.typ < g.mod.type_store.types.len {
 		val_typ := g.mod.type_store.types[val.typ]
 		if val_typ.kind == .ptr_t && val_typ.elem_type == expected_struct_typ {
@@ -751,6 +1173,8 @@ fn (mut g Gen) load_val_to_reg(reg int, val_id int) {
 		sym_idx := g.elf.add_undefined(val.name)
 		g.elf.add_text_reloc(u64(g.elf.text_data.len), sym_idx, 2, -4)
 		g.emit_u32(0)
+	} else if val.kind == .string_literal {
+		g.materialize_string_literal(reg, val_id)
 	} else {
 		if reg_idx := g.reg_map[val_id] {
 			if reg_idx != reg {
@@ -772,6 +1196,46 @@ fn (mut g Gen) store_reg_to_val(reg int, val_id int) {
 		offset := g.stack_map[val_id]
 		asm_store_rbp_disp_reg(mut g, offset, Reg(reg))
 	}
+}
+
+fn (mut g Gen) materialize_string_literal(reg int, val_id int) {
+	val := g.mod.values[val_id]
+	str_offset := g.elf.rodata.len
+	g.elf.rodata << val.name.bytes()
+	g.elf.rodata << 0
+	sym_name := 'L_str_${g.curr_offset}_${str_offset}'
+	sym_idx := g.elf.add_symbol(sym_name, u64(str_offset), false, 3)
+
+	slot_off := g.stack_map[val_id]
+	asm_lea_reg_rip(mut g, rax)
+	g.elf.add_text_reloc(u64(g.elf.text_data.len), sym_idx, 2, -4)
+	g.emit_u32(0)
+	asm_store_rbp_disp_reg_size(mut g, slot_off + g.struct_field_offset_bytes(val.typ, 0), rax, 8)
+	asm_mov_reg_imm32(mut g, rax, u32(val.index))
+	asm_store_rbp_disp_reg_size(mut g, slot_off + g.struct_field_offset_bytes(val.typ, 1), rax, 4)
+	asm_mov_reg_imm32(mut g, rax, 1)
+	asm_store_rbp_disp_reg_size(mut g, slot_off + g.struct_field_offset_bytes(val.typ, 2), rax, 4)
+	if slot_off >= -128 && slot_off <= 127 {
+		asm_lea_rax_rbp_disp8(mut g, i8(slot_off))
+	} else {
+		asm_lea_rax_rbp_disp32(mut g, slot_off)
+	}
+	if reg != 0 {
+		asm_mov_reg_reg(mut g, Reg(reg), rax)
+	}
+}
+
+fn (mut g Gen) load_float_val_to_xmm(xmm int, val_id int, size int) {
+	val := g.mod.values[val_id]
+	if val.kind == .constant {
+		if size == 4 {
+			asm_mov_reg_imm32(mut g, rax, bits.f32_bits(val.name.f32()))
+		} else {
+			asm_mov_reg_imm64(mut g, rax, bits.f64_bits(val.name.f64()))
+		}
+		asm_store_rbp_disp_reg_size(mut g, g.stack_map[val_id], rax, size)
+	}
+	asm_load_xmm_rbp_disp(mut g, xmm, g.stack_map[val_id], size)
 }
 
 fn (g Gen) type_size(typ_id ssa.TypeID) int {
@@ -800,14 +1264,19 @@ fn (g Gen) type_size(typ_id ssa.TypeID) int {
 		}
 		.struct_t {
 			mut total := 0
+			mut max_align := 1
 			for field_typ in typ.fields {
-				if total % 8 != 0 {
-					total = (total + 7) & ~7
+				align := g.type_align(field_typ)
+				if align > max_align {
+					max_align = align
+				}
+				if align > 1 && total % align != 0 {
+					total = (total + align - 1) & ~(align - 1)
 				}
 				total += g.type_size(field_typ)
 			}
-			if total % 8 != 0 {
-				total = (total + 7) & ~7
+			if max_align > 1 && total % max_align != 0 {
+				total = (total + max_align - 1) & ~(max_align - 1)
 			}
 			return if total > 0 { total } else { 8 }
 		}
@@ -818,6 +1287,26 @@ fn (g Gen) type_size(typ_id ssa.TypeID) int {
 			return 0
 		}
 	}
+}
+
+fn (g Gen) type_align(typ_id ssa.TypeID) int {
+	if typ_id > 0 && typ_id < g.mod.type_store.types.len {
+		typ := g.mod.type_store.types[typ_id]
+		if typ.kind == .array_t {
+			return g.type_align(typ.elem_type)
+		}
+	}
+	size := g.type_size(typ_id)
+	if size >= 8 {
+		return 8
+	}
+	if size >= 4 {
+		return 4
+	}
+	if size >= 2 {
+		return 2
+	}
+	return 1
 }
 
 fn (mut g Gen) load_address_of_val_to_reg(reg int, val_id int) {
@@ -875,6 +1364,11 @@ pub fn (mut g Gen) write_file(path string) {
 fn (mut g Gen) allocate_registers(func mir.Function) {
 	mut intervals := map[int]&Interval{}
 	mut instr_idx := 0
+	mut total_instrs := 0
+
+	for blk_id in func.blocks {
+		total_instrs += g.mod.blocks[blk_id].instrs.len
+	}
 
 	// Track which values are alloca results - don't register allocate these
 	// as they hold addresses that may be needed across the function
@@ -888,7 +1382,10 @@ fn (mut g Gen) allocate_registers(func mir.Function) {
 		intervals[pid] = &Interval{
 			val_id: pid
 			start:  0
-			end:    0
+			// ABI lowering can hide original parameter uses inside selected call sequences.
+			// Keep incoming parameters live across the function to avoid reusing their
+			// callee-saved register while later calls still need the parameter value.
+			end: total_instrs
 		}
 	}
 
@@ -898,6 +1395,9 @@ fn (mut g Gen) allocate_registers(func mir.Function) {
 			val := g.mod.values[val_id]
 			if val.kind == .instruction || val.kind == .argument {
 				if unsafe { intervals[val_id] == nil } {
+					if val.kind == .instruction && g.value_needs_stack_storage(val_id) {
+						continue
+					}
 					intervals[val_id] = &Interval{
 						val_id: val_id
 						start:  instr_idx
@@ -907,7 +1407,7 @@ fn (mut g Gen) allocate_registers(func mir.Function) {
 			}
 			instr := g.mod.instrs[val.index]
 			// Mark alloca results as non-register-allocatable
-			if instr.op in [.alloca, .call_sret] {
+			if instr.op in [.alloca, .call_sret] || g.value_needs_stack_storage(val_id) {
 				alloca_vals[val_id] = true
 			}
 			for op in instr.operands {
@@ -962,4 +1462,53 @@ fn (mut g Gen) allocate_registers(func mir.Function) {
 		}
 	}
 	g.used_regs.sort()
+}
+
+fn (g Gen) value_is_aggregate(val_id int) bool {
+	if val_id <= 0 || val_id >= g.mod.values.len {
+		return false
+	}
+	typ_id := g.mod.values[val_id].typ
+	if typ_id <= 0 || typ_id >= g.mod.type_store.types.len {
+		return false
+	}
+	typ := g.mod.type_store.types[typ_id]
+	return typ.kind in [.struct_t, .array_t]
+}
+
+fn (g Gen) stack_storage_size(val_id int) int {
+	if val_id <= 0 || val_id >= g.mod.values.len {
+		return 8
+	}
+	val := g.mod.values[val_id]
+	size := g.type_size(val.typ)
+	if val.kind == .string_literal && size < 16 {
+		return 16
+	}
+	return if size > 0 { size } else { 8 }
+}
+
+fn (g Gen) value_needs_stack_storage(val_id int) bool {
+	if val_id <= 0 || val_id >= g.mod.values.len {
+		return false
+	}
+	val := g.mod.values[val_id]
+	if val.kind == .string_literal {
+		return true
+	}
+	if val.typ <= 0 || val.typ >= g.mod.type_store.types.len {
+		return false
+	}
+	typ := g.mod.type_store.types[val.typ]
+	if typ.kind == .float_t {
+		return true
+	}
+	if typ.kind in [.struct_t, .array_t] || g.type_size(val.typ) > 8 {
+		return true
+	}
+	if val.kind != .instruction {
+		return false
+	}
+	instr := g.mod.instrs[val.index]
+	return instr.op in [.call_sret, .inline_string_init, .struct_init, .insertvalue, .extractvalue]
 }

--- a/vlib/v2/gen/x64/x64_issue_27039_test.v
+++ b/vlib/v2/gen/x64/x64_issue_27039_test.v
@@ -81,3 +81,72 @@ fn main() {
 ")
 	assert output == 'Const hello'
 }
+
+fn test_issue_27039_x64_aggregate_arg_spills_to_stack() {
+	output := run_issue_27039_x64_program('aggregate_arg_spill', "module main
+
+struct Pair {
+	a i64
+	b i64
+}
+
+fn sum_after_five(a i64, b i64, c i64, d i64, e i64, p Pair) i64 {
+	return a + b + c + d + e + p.a + p.b
+}
+
+fn main() {
+	if sum_after_five(1, 2, 3, 4, 5, Pair{6, 7}) == 28 {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_stack_arg_after_two_chunk_aggregate() {
+	output := run_issue_27039_x64_program('stack_arg_after_pair', "module main
+
+struct Pair {
+	a i64
+	b i64
+}
+
+fn sum_pair_then_scalars(p Pair, a i64, b i64, c i64, d i64, e i64) i64 {
+	return p.a + p.b + a + b + c + d + e
+}
+
+fn main() {
+	if sum_pair_then_scalars(Pair{10, 20}, 1, 2, 3, 4, 5) == 45 {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_spilled_aggregate_does_not_consume_remaining_register() {
+	output := run_issue_27039_x64_program('aggregate_spill_then_reg', "module main
+
+struct Pair {
+	a i64
+	b i64
+}
+
+fn sum_spill_then_reg(a i64, b i64, c i64, d i64, e i64, p Pair, z i64) i64 {
+	return p.a + p.b + z
+}
+
+fn main() {
+	if sum_spill_then_reg(1, 2, 3, 4, 5, Pair{10, 20}, 6) == 36 {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}

--- a/vlib/v2/gen/x64/x64_issue_27039_test.v
+++ b/vlib/v2/gen/x64/x64_issue_27039_test.v
@@ -19,11 +19,27 @@ fn run_issue_27039_x64_program(name string, source string) string {
 	assert build.exit_code == 0, build.output
 	run :=
 		os.execute('out=$(${os.quoted_path(bin_path)} 2>&1); code=$?; printf "%s\\n%s" "$code" "$out"')
-	assert run.exit_code == 0, run.output
+	assert run.exit_code == 0, '${name}: ${run.output}'
 	lines := run.output.split_into_lines()
-	assert lines.len >= 1, run.output
-	assert lines[0] == '0', run.output
+	assert lines.len >= 1, '${name}: ${run.output}'
+	assert lines[0] == '0', '${name}: ${run.output}'
 	return lines[1..].join('\n')
+}
+
+fn run_issue_27039_x64_compile_error(name string, source string) string {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_issue_27039_x64_fail_${name}_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(tmp_dir, '${name}.v')
+	bin_path := os.join_path(tmp_dir, name)
+	os.write_file(source_path, source) or { panic(err) }
+	vexe := os.getenv_opt('VEXE') or { @VEXE }
+	build :=
+		os.execute('${os.quoted_path(vexe)} -v2 -b x64 ${os.quoted_path(source_path)} -o ${os.quoted_path(bin_path)}')
+	assert build.exit_code != 0, build.output
+	return build.output
 }
 
 fn run_issue_27039_x64_program_redirected(name string, source string) (string, string) {
@@ -123,6 +139,416 @@ fn main() {
 	assert output == 'ok'
 }
 
+fn test_issue_27039_x64_signed_memory_loads_extend_values() {
+	output := run_issue_27039_x64_program('signed_memory_loads', "module main
+
+fn load_i8_from_ptr(p &i8) i64 {
+	return i64(*p)
+}
+
+fn load_i16_from_ptr(p &i16) i64 {
+	return i64(*p)
+}
+
+fn main() {
+	mut a := i8(-42)
+	mut b := i16(-12345)
+	if load_i8_from_ptr(&a) == -42 && load_i16_from_ptr(&b) == -12345 {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_raw_copy_tails_do_not_overwrite_sentinel() {
+	output := run_issue_27039_x64_program('raw_copy_tails', "module main
+
+struct Tiny3 {
+mut:
+	a u8
+	b u8
+	c u8
+}
+
+struct Wrap3 {
+mut:
+	data Tiny3
+	sentinel u8
+}
+
+struct Tiny5 {
+mut:
+	a u8
+	b u8
+	c u8
+	d u8
+	e u8
+}
+
+struct Wrap5 {
+mut:
+	data Tiny5
+	sentinel u8
+}
+
+struct Tiny6 {
+mut:
+	a u8
+	b u8
+	c u8
+	d u8
+	e u8
+	f u8
+}
+
+struct Wrap6 {
+mut:
+	data Tiny6
+	sentinel u8
+}
+
+struct Tiny7 {
+mut:
+	a u8
+	b u8
+	c u8
+	d u8
+	e u8
+	f u8
+	g u8
+}
+
+struct Wrap7 {
+mut:
+	data Tiny7
+	sentinel u8
+}
+
+fn check3() bool {
+	src := Tiny3{
+		a: 1
+		b: 2
+		c: 3
+	}
+	mut w := Wrap3{
+		sentinel: 0x5A
+	}
+	w.data = src
+	return w.sentinel == 0x5A && w.data.a == 1 && w.data.b == 2 && w.data.c == 3
+}
+
+fn check5() bool {
+	src := Tiny5{
+		a: 1
+		b: 2
+		c: 3
+		d: 4
+		e: 5
+	}
+	mut w := Wrap5{
+		sentinel: 0x5A
+	}
+	w.data = src
+	return w.sentinel == 0x5A && w.data.a == 1 && w.data.b == 2 && w.data.c == 3
+		&& w.data.d == 4 && w.data.e == 5
+}
+
+fn check6() bool {
+	src := Tiny6{
+		a: 1
+		b: 2
+		c: 3
+		d: 4
+		e: 5
+		f: 6
+	}
+	mut w := Wrap6{
+		sentinel: 0x5A
+	}
+	w.data = src
+	return w.sentinel == 0x5A && w.data.a == 1 && w.data.b == 2 && w.data.c == 3
+		&& w.data.d == 4 && w.data.e == 5 && w.data.f == 6
+}
+
+fn check7() bool {
+	src := Tiny7{
+		a: 1
+		b: 2
+		c: 3
+		d: 4
+		e: 5
+		f: 6
+		g: 7
+	}
+	mut w := Wrap7{
+		sentinel: 0x5A
+	}
+	w.data = src
+	return w.sentinel == 0x5A && w.data.a == 1 && w.data.b == 2 && w.data.c == 3
+		&& w.data.d == 4 && w.data.e == 5 && w.data.f == 6 && w.data.g == 7
+}
+
+fn main() {
+	if check3() && check5() && check6() && check7() {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_small_aggregates_pass_by_value_in_registers() {
+	output := run_issue_27039_x64_program('small_aggregate_reg_args', "module main
+
+struct Tiny3 {
+	a u8
+	b u8
+	c u8
+}
+
+struct Tiny5 {
+	a u8
+	b u8
+	c u8
+	d u8
+	e u8
+}
+
+struct Tiny6 {
+	a u8
+	b u8
+	c u8
+	d u8
+	e u8
+	f u8
+}
+
+struct Tiny7 {
+	a u8
+	b u8
+	c u8
+	d u8
+	e u8
+	f u8
+	g u8
+}
+
+fn sum3(t Tiny3) int {
+	return int(t.a) + int(t.b) + int(t.c)
+}
+
+fn sum5(t Tiny5) int {
+	return int(t.a) + int(t.b) + int(t.c) + int(t.d) + int(t.e)
+}
+
+fn sum6(t Tiny6) int {
+	return int(t.a) + int(t.b) + int(t.c) + int(t.d) + int(t.e) + int(t.f)
+}
+
+fn sum7(t Tiny7) int {
+	return int(t.a) + int(t.b) + int(t.c) + int(t.d) + int(t.e) + int(t.f) + int(t.g)
+}
+
+fn main() {
+	a := Tiny3{
+		a: 1
+		b: 2
+		c: 3
+	}
+	b := Tiny5{
+		a: 1
+		b: 2
+		c: 3
+		d: 4
+		e: 5
+	}
+	c := Tiny6{
+		a: 1
+		b: 2
+		c: 3
+		d: 4
+		e: 5
+		f: 6
+	}
+	d := Tiny7{
+		a: 1
+		b: 2
+		c: 3
+		d: 4
+		e: 5
+		f: 6
+		g: 7
+	}
+	if sum3(a) == 6 && sum5(b) == 15 && sum6(c) == 21 && sum7(d) == 28 {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_raw_aggregate_arg_does_not_clobber_rcx_arg() {
+	output := run_issue_27039_x64_program('small_aggregate_after_rcx_arg', "module main
+
+struct Tiny3 {
+	a u8
+	b u8
+	c u8
+}
+
+fn check(a i64, b i64, c i64, marker i64, t Tiny3) i64 {
+	return marker + i64(t.a) + i64(t.b) + i64(t.c)
+}
+
+fn main() {
+	t := Tiny3{
+		a: 1
+		b: 2
+		c: 3
+	}
+	if check(10, 20, 30, 1000, t) == 1006 {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_big17_sret_and_indirect_param_copy_exact_bytes() {
+	output := run_issue_27039_x64_program('big17_exact_copies', "module main
+
+struct Big17 {
+mut:
+	a u8
+	b u8
+	c u8
+	d u8
+	e u8
+	f u8
+	g u8
+	h u8
+	i u8
+	j u8
+	k u8
+	l u8
+	m u8
+	n u8
+	o u8
+	p u8
+	q u8
+}
+
+fn make_big() Big17 {
+	return Big17{
+		a: 1
+		b: 2
+		c: 3
+		d: 4
+		e: 5
+		f: 6
+		g: 7
+		h: 8
+		i: 9
+		j: 10
+		k: 11
+		l: 12
+		m: 13
+		n: 14
+		o: 15
+		p: 16
+		q: 17
+	}
+}
+
+fn id_big(x Big17) Big17 {
+	return x
+}
+
+fn sum_big(x Big17) int {
+	return int(x.a) + int(x.b) + int(x.c) + int(x.d) + int(x.e) + int(x.f) + int(x.g)
+		+ int(x.h) + int(x.i) + int(x.j) + int(x.k) + int(x.l) + int(x.m) + int(x.n)
+		+ int(x.o) + int(x.p) + int(x.q)
+}
+
+fn main() {
+	x := make_big()
+	y := id_big(x)
+	if sum_big(y) == 153 {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_fixed_array_store_uses_raw_copy() {
+	output := run_issue_27039_x64_program('fixed_array_store', "module main
+
+fn main() {
+	mut src := [3]u8{}
+	src[0] = 1
+	src[1] = 2
+	src[2] = 3
+	mut dst := [3]u8{}
+	dst = src
+	if dst[0] == 1 && dst[1] == 2 && dst[2] == 3 {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_heap_sizing_allows_struct_access_past_eight_bytes() {
+	output := run_issue_27039_x64_program('heap_struct_size', "module main
+
+struct Heap17 {
+mut:
+	a u8
+	b u8
+	c u8
+	d u8
+	e u8
+	f u8
+	g u8
+	h u8
+	i u8
+	j u8
+	k u8
+	l u8
+	m u8
+	n u8
+	o u8
+	p u8
+	q u8
+}
+
+fn main() {
+	mut p := &Heap17{}
+	p.q = 17
+	if p.q == 17 {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
 fn test_issue_27039_x64_float_width_casts_convert_values() {
 	output := run_issue_27039_x64_program('float_width_casts', "module main
 
@@ -138,6 +564,139 @@ fn main() {
 	a := widen(f32(1.5))
 	b := narrow(a + 0.25)
 	if a > 1.49 && a < 1.51 && b > f32(1.74) && b < f32(1.76) {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_scalar_float_abi_uses_xmm_registers() {
+	output := run_issue_27039_x64_program('scalar_float_abi', "module main
+
+fn from_f64_u32(x f64) u32 {
+	return u32(x)
+}
+
+fn id_f64(x f64) f64 {
+	return x
+}
+
+fn id_f32(x f32) f32 {
+	return x
+}
+
+fn mixed(a i64, x f64, b i64, y f32, c i64) i64 {
+	if x > 1.24 && x < 1.26 && y > f32(2.49) && y < f32(2.51) {
+		return a + b + c
+	}
+	return -1
+}
+
+fn main() {
+	x := 4000000000.0
+	local := u32(x) == u32(4000000000)
+	low := from_f64_u32(42.0) == u32(42)
+	high := from_f64_u32(4000000000.0) == u32(4000000000)
+	ret64 := id_f64(1.25) > 1.24 && id_f64(1.25) < 1.26
+	ret32 := id_f32(f32(2.5)) > f32(2.49) && id_f32(f32(2.5)) < f32(2.51)
+	mixed_ok := mixed(10, 1.25, 20, f32(2.5), 30) == 60
+	if local && low && high && ret64 && ret32 && mixed_ok {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_scalar_float_stack_args_fail_explicitly() {
+	output := run_issue_27039_x64_compile_error('float_stack_arg_unsupported', 'module main
+
+fn many(a f64, b f64, c f64, d f64, e f64, f f64, g f64, h f64, i f64) f64 {
+	return a + b + c + d + e + f + g + h + i
+}
+
+fn main() {
+	println(many(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0))
+}
+')
+	assert output.contains('x64: unsupported float ABI stack parameter')
+}
+
+fn test_issue_27039_x64_float_comparisons_use_numeric_semantics() {
+	output := run_issue_27039_x64_program('float_comparisons', "module main
+
+import os
+
+fn eq_f64(a f64, b f64) bool {
+	return a == b
+}
+
+fn ne_f64(a f64, b f64) bool {
+	return a != b
+}
+
+fn lt_f64(a f64, b f64) bool {
+	return a < b
+}
+
+fn gt_f64(a f64, b f64) bool {
+	return a > b
+}
+
+fn le_f64(a f64, b f64) bool {
+	return a <= b
+}
+
+fn ge_f64(a f64, b f64) bool {
+	return a >= b
+}
+
+fn le_f32(a f32, b f32) bool {
+	return a <= b
+}
+
+fn gt_f32(a f32, b f32) bool {
+	return a > b
+}
+
+fn ge_f32(a f32, b f32) bool {
+	return a >= b
+}
+
+fn eq_f32(a f32, b f32) bool {
+	return a == b
+}
+
+fn ne_f32(a f32, b f32) bool {
+	return a != b
+}
+
+fn lt_f32(a f32, b f32) bool {
+	return a < b
+}
+
+fn main() {
+	argc := os.args.len
+	z := f64(argc - argc)
+	one := f64(argc)
+	two := one + one
+	neg_zero := -z
+	nan := z / z
+	ok64 := eq_f64(z, neg_zero) && ne_f64(nan, nan) && lt_f64(-two, -one)
+		&& gt_f64(-one, -two) && le_f64(z, neg_zero) && ge_f64(z, neg_zero)
+	nan64 := !eq_f64(nan, nan) && ne_f64(nan, nan) && !lt_f64(nan, one)
+		&& !le_f64(nan, one) && !gt_f64(nan, one) && !ge_f64(nan, one)
+	nanf := f32(nan)
+	onef := f32(one)
+	ok32 := eq_f32(f32(z), f32(neg_zero)) && lt_f32(f32(-two), f32(-one))
+	nan32 := !eq_f32(nanf, nanf) && ne_f32(nanf, nanf) && !lt_f32(nanf, onef)
+		&& !le_f32(nanf, onef) && !gt_f32(nanf, onef) && !ge_f32(nanf, onef)
+	if ok64 && nan64 && ok32 && nan32 {
 		println('ok')
 	} else {
 		println('bad')

--- a/vlib/v2/gen/x64/x64_issue_27039_test.v
+++ b/vlib/v2/gen/x64/x64_issue_27039_test.v
@@ -82,6 +82,122 @@ fn main() {
 	assert output == 'Const hello'
 }
 
+fn test_issue_27039_x64_trunc_and_zext_mask_integer_values() {
+	output := run_issue_27039_x64_program('int_cast_masks', "module main
+
+fn narrow_and_widen(x u16) u64 {
+	y := u8(x)
+	return u64(y)
+}
+
+fn narrow_u32_to_u16(x u32) u64 {
+	y := u16(x)
+	return u64(y)
+}
+
+fn narrow_u64_to_u8(x u64) u64 {
+	y := u8(x)
+	return u64(y)
+}
+
+fn sign_extend_i8(x i8) i64 {
+	return i64(x)
+}
+
+fn sign_extend_i16(x i16) i64 {
+	return i64(x)
+}
+
+fn main() {
+	if narrow_and_widen(u16(0x1234)) == 0x34
+		&& narrow_u32_to_u16(u32(0x12345678)) == 0x5678
+		&& narrow_u64_to_u8(u64(0x123456789ABCDEFF)) == 0xFF
+		&& sign_extend_i8(i8(-42)) == -42
+		&& sign_extend_i16(i16(-12345)) == -12345 {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_float_width_casts_convert_values() {
+	output := run_issue_27039_x64_program('float_width_casts', "module main
+
+fn widen(x f32) f64 {
+	return f64(x)
+}
+
+fn narrow(x f64) f32 {
+	return f32(x)
+}
+
+fn main() {
+	a := widen(f32(1.5))
+	b := narrow(a + 0.25)
+	if a > 1.49 && a < 1.51 && b > f32(1.74) && b < f32(1.76) {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_unsigned_64_to_float_handles_high_bit() {
+	output := run_issue_27039_x64_program('u64_to_float_high_bit', "module main
+
+fn to_f64(x u64) f64 {
+	return f64(x)
+}
+
+fn to_f32(x u64) f32 {
+	return f32(x)
+}
+
+fn main() {
+	a := to_f64(u64(9223372036854775808))
+	b := to_f64(u64(18446744073709551615))
+	c := to_f32(u64(9223372036854775808))
+	if a == 9223372036854775808.0 && b > 18446744073709550000.0 && c > f32(9223371000000000000.0) {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
+fn test_issue_27039_x64_float_to_unsigned_64_handles_high_bit() {
+	output := run_issue_27039_x64_program('float_to_u64_high_bit', "module main
+
+fn from_f64(x f64) u64 {
+	return u64(x)
+}
+
+fn from_f32(x f32) u64 {
+	return u64(x)
+}
+
+fn main() {
+	a := from_f64(9223372036854775808.0)
+	b := from_f64(9223372036854777856.0)
+	c := from_f32(f32(9223372036854775808.0))
+	if a == u64(9223372036854775808) && b == u64(9223372036854777856)
+		&& c == u64(9223372036854775808) {
+		println('ok')
+	} else {
+		println('bad')
+	}
+}
+")
+	assert output == 'ok'
+}
+
 fn test_issue_27039_x64_aggregate_arg_spills_to_stack() {
 	output := run_issue_27039_x64_program('aggregate_arg_spill', "module main
 

--- a/vlib/v2/gen/x64/x64_issue_27039_test.v
+++ b/vlib/v2/gen/x64/x64_issue_27039_test.v
@@ -1,0 +1,83 @@
+// vtest build: linux && amd64
+
+module x64
+
+import os
+
+fn run_issue_27039_x64_program(name string, source string) string {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_issue_27039_x64_${name}_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(tmp_dir, '${name}.v')
+	bin_path := os.join_path(tmp_dir, name)
+	os.write_file(source_path, source) or { panic(err) }
+	vexe := os.getenv_opt('VEXE') or { @VEXE }
+	build :=
+		os.execute('${os.quoted_path(vexe)} -v2 -b x64 ${os.quoted_path(source_path)} -o ${os.quoted_path(bin_path)}')
+	assert build.exit_code == 0, build.output
+	run :=
+		os.execute('out=$(${os.quoted_path(bin_path)} 2>&1); code=$?; printf "%s\\n%s" "$code" "$out"')
+	assert run.exit_code == 0, run.output
+	lines := run.output.split_into_lines()
+	assert lines.len >= 1, run.output
+	assert lines[0] == '0', run.output
+	return lines[1..].join('\n')
+}
+
+fn run_issue_27039_x64_program_redirected(name string, source string) (string, string) {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_issue_27039_x64_redir_${name}_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(tmp_dir, '${name}.v')
+	bin_path := os.join_path(tmp_dir, name)
+	stdout_path := os.join_path(tmp_dir, '${name}.out')
+	stderr_path := os.join_path(tmp_dir, '${name}.err')
+	os.write_file(source_path, source) or { panic(err) }
+	vexe := os.getenv_opt('VEXE') or { @VEXE }
+	build :=
+		os.execute('${os.quoted_path(vexe)} -v2 -b x64 ${os.quoted_path(source_path)} -o ${os.quoted_path(bin_path)}')
+	assert build.exit_code == 0, build.output
+	run :=
+		os.execute('${os.quoted_path(bin_path)} > ${os.quoted_path(stdout_path)} 2> ${os.quoted_path(stderr_path)}')
+	assert run.exit_code == 0, run.output
+	stdout := os.read_file(stdout_path) or { panic(err) }
+	stderr := os.read_file(stderr_path) or { panic(err) }
+	return stdout, stderr
+}
+
+fn test_issue_27039_x64_hello_world_runs() {
+	output := run_issue_27039_x64_program('hello_world', "module main
+
+fn main() {
+	println('Hello World!')
+}
+")
+	assert output == 'Hello World!'
+}
+
+fn test_issue_27039_x64_hello_world_runs_with_stdout_redirected() {
+	stdout, stderr := run_issue_27039_x64_program_redirected('hello_world_redir', "module main
+
+fn main() {
+	println('Hello World!')
+}
+")
+	assert stdout == 'Hello World!\n'
+	assert stderr == ''
+}
+
+fn test_issue_27039_x64_const_init_is_not_skipped() {
+	output := run_issue_27039_x64_program('const_string', "module main
+
+const greeting = 'Const hello'
+
+fn main() {
+	println(greeting)
+}
+")
+	assert output == 'Const hello'
+}

--- a/vlib/v2/pref/pref.v
+++ b/vlib/v2/pref/pref.v
@@ -55,6 +55,7 @@ pub mut:
 	gc_mode               GarbageCollectionMode // Garbage collection mode (-gc flag)
 	backend               Backend
 	arch                  Arch = .auto
+	target_os             string
 	output_file           string
 	printfn_list          []string // List of function names whose generated C source should be printed
 	user_defines          []string // User-defined comptime flags via -d <name>
@@ -238,6 +239,7 @@ pub fn new_preferences_from_args(args []string) Preferences {
 
 	output_file := cmdline.option(args, '-o', cmdline.option(args, '-output', ''))
 	ccompiler := cmdline.option(args, '-cc', '')
+	target_os := normalize_os_name(cmdline.option(args, '-os', ''))
 
 	// Parse -printfn option (comma-separated list of function names to print)
 	mut printfn_str := cmdline.option(args, '-printfn', '')
@@ -297,8 +299,8 @@ pub fn new_preferences_from_args(args []string) Preferences {
 	}
 
 	// Validate flags: error on unknown options
-	known_flags_with_values := ['-backend', '-b', '-o', '-output', '-arch', '-printfn', '-gc',
-		'-d', '-hot-fn', '-cc']
+	known_flags_with_values := ['-backend', '-b', '-o', '-output', '-arch', '-os', '-printfn',
+		'-gc', '-d', '-hot-fn', '-cc']
 	mut known_boolean_flags := ['--debug', '--verbose', '-v', '--skip-genv', '--skip-builtin',
 		'--skip-imports', '--skip-type-check', '--no-parallel', '-nocache', '--nocache',
 		'-nomarkused', '--nomarkused', '-showcc', '--showcc', '-stats', '--stats',
@@ -320,6 +322,7 @@ pub fn new_preferences_from_args(args []string) Preferences {
 			eprintln('  -b <name>              Short for -backend')
 			eprintln('  -eval                  Short for -backend eval')
 			eprintln('  -arch <name>           Architecture: auto, x64, arm64 (default: auto)')
+			eprintln('  -os <name>             Target OS (default: host OS)')
 			eprintln('  -printfn <names>       Print generated C for functions (comma-separated)')
 			eprintln('  -stats, --stats        Print compilation statistics')
 			eprintln('  -nocache, --nocache    Disable build cache')
@@ -366,6 +369,7 @@ pub fn new_preferences_from_args(args []string) Preferences {
 		gc_mode:               gc_mode
 		backend:               backend
 		arch:                  arch
+		target_os:             target_os
 		output_file:           output_file
 		printfn_list:          printfn_list
 		user_defines:          all_defines
@@ -433,4 +437,12 @@ pub fn (p &Preferences) get_effective_arch() Arch {
 	}
 	// Auto-detect: macOS defaults to arm64, others to x64
 	return if os.user_os() == 'macos' { Arch.arm64 } else { Arch.x64 }
+}
+
+// get_effective_os returns the explicitly requested target OS, or the host OS.
+pub fn (p &Preferences) get_effective_os() string {
+	if p.target_os.len > 0 {
+		return p.target_os
+	}
+	return normalize_os_name(os.user_os())
 }

--- a/vlib/v2/pref/pref_test.v
+++ b/vlib/v2/pref/pref_test.v
@@ -1,0 +1,15 @@
+module pref
+
+import os
+
+fn test_target_os_flag_is_parsed() {
+	prefs := new_preferences_from_args(['v2', '-b', 'x64', '-os', 'mac', 'main.v'])
+	assert prefs.target_os == 'macos'
+	assert prefs.get_effective_os() == 'macos'
+}
+
+fn test_effective_os_defaults_to_host_os() {
+	prefs := new_preferences_from_args(['v2', '-b', 'x64', 'main.v'])
+	assert prefs.target_os == ''
+	assert prefs.get_effective_os() == normalize_os_name(os.user_os())
+}

--- a/vlib/v2/pref/source_filter.v
+++ b/vlib/v2/pref/source_filter.v
@@ -1,15 +1,15 @@
 module pref
 
-fn normalize_current_os_name(current_os string) string {
-	return match current_os.to_lower() {
+pub fn normalize_os_name(os_name string) string {
+	return match os_name.to_lower() {
 		'darwin', 'mac' { 'macos' }
-		else { current_os.to_lower() }
+		else { os_name.to_lower() }
 	}
 }
 
 // file_has_incompatible_os_suffix reports whether file is specialized for a different OS.
 pub fn file_has_incompatible_os_suffix(file string, current_os string) bool {
-	os_name := normalize_current_os_name(current_os)
+	os_name := normalize_os_name(current_os)
 	if os_name == 'windows' && file.contains('_nix.') {
 		return true
 	}

--- a/vlib/v2/ssa/builder.v
+++ b/vlib/v2/ssa/builder.v
@@ -7,6 +7,7 @@ module ssa
 import v2.ast
 import v2.markused
 import v2.types
+import os
 
 struct DynConstArray {
 	arr_global_name  string // V array struct global name
@@ -127,7 +128,7 @@ fn (b &Builder) c_stdio_target_os() string {
 	if b.mod.target.os.len > 0 {
 		return b.mod.target.os
 	}
-	return 'linux'
+	return os.user_os().to_lower()
 }
 
 pub fn Builder.new(mod &Module) &Builder {

--- a/vlib/v2/ssa/builder.v
+++ b/vlib/v2/ssa/builder.v
@@ -82,6 +82,54 @@ struct LoopInfo {
 	exit_block BlockID
 }
 
+fn c_stdio_symbol_for_os(c_name string, user_os string) string {
+	match c_name {
+		'stdin' {
+			return match user_os {
+				'macos', 'freebsd', 'netbsd', 'dragonfly' { '__stdinp' }
+				'openbsd' { '__stdin' }
+				else { 'stdin' }
+			}
+		}
+		'stdout' {
+			return match user_os {
+				'macos', 'freebsd', 'netbsd', 'dragonfly' { '__stdoutp' }
+				'openbsd' { '__stdout' }
+				else { 'stdout' }
+			}
+		}
+		'stderr' {
+			return match user_os {
+				'macos', 'freebsd', 'netbsd', 'dragonfly' { '__stderrp' }
+				'openbsd' { '__stderr' }
+				else { 'stderr' }
+			}
+		}
+		else {
+			return c_name
+		}
+	}
+}
+
+fn c_stdio_symbol_needs_load(user_os string) bool {
+	return user_os != 'openbsd'
+}
+
+fn c_float_macro_const(c_name string) (int, string) {
+	return match c_name {
+		'FLT_EPSILON' { 32, '1.19209290e-07' }
+		'DBL_EPSILON' { 64, '2.2204460492503131e-16' }
+		else { 0, '' }
+	}
+}
+
+fn (b &Builder) c_stdio_target_os() string {
+	if b.mod.target.os.len > 0 {
+		return b.mod.target.os
+	}
+	return 'linux'
+}
+
 pub fn Builder.new(mod &Module) &Builder {
 	return Builder.new_with_env(mod, unsafe { nil })
 }
@@ -221,6 +269,7 @@ pub fn (mut b Builder) build_all(files []ast.File) {
 		b.generate_wyhash_stub()
 		b.generate_ierror_stubs()
 		b.generate_fd_macro_stubs()
+		b.generate_tcc_backtrace_stub()
 	}
 
 	// Phase 4: Build function bodies
@@ -2350,6 +2399,9 @@ pub fn (mut b Builder) should_build_fn(file_name string, decl ast.FnDecl) bool {
 	}
 	// Always build functions from core modules that the runtime needs
 	if b.cur_module in ['builtin', 'strings', 'strconv', 'bits', 'sha256', 'binary'] {
+		return true
+	}
+	if b.cur_module == 'os' && decl.name == 'getenv_opt' {
 		return true
 	}
 	// Always build .vh header declarations
@@ -5614,6 +5666,10 @@ fn (mut b Builder) build_selector(expr ast.SelectorExpr) ValueID {
 		if c_const_val.len > 0 {
 			return b.mod.get_or_add_const(b.mod.type_store.get_int(32), c_const_val)
 		}
+		float_width, float_value := c_float_macro_const(c_name)
+		if float_width > 0 {
+			return b.mod.get_or_add_const(b.mod.type_store.get_float(float_width), float_value)
+		}
 		// _wyp: wyhash secret array from wyhash.h. Our wyhash stub uses
 		// hardcoded constants, so this just needs to be a valid pointer.
 		if c_name == '_wyp' {
@@ -5628,19 +5684,25 @@ fn (mut b Builder) build_selector(expr ast.SelectorExpr) ValueID {
 			call_val := b.mod.add_instr(.call, b.cur_block, ptr_i32, [err_fn])
 			return b.mod.add_instr(.load, b.cur_block, i32_t, [call_val])
 		}
-		// Map C standard I/O streams to macOS-specific symbol names
-		macos_name := match c_name {
-			'stdout' { '__stdoutp' }
-			'stderr' { '__stderrp' }
-			'stdin' { '__stdinp' }
-			else { c_name }
-		}
-
-		// Not a known constant — emit as a global reference (e.g. C.stdout, C.stderr)
 		i8_t := b.mod.type_store.get_int(8)
 		ptr_t := b.mod.type_store.get_ptr(i8_t)
-		glob := b.mod.add_value_node(.global, ptr_t, macos_name, 0)
-		b.global_refs[macos_name] = glob
+		if c_name in ['stdin', 'stdout', 'stderr'] {
+			target_os := b.c_stdio_target_os()
+			symbol_name := c_stdio_symbol_for_os(c_name, target_os)
+			if c_stdio_symbol_needs_load(target_os) {
+				glob := b.mod.add_external_global(symbol_name, ptr_t)
+				b.global_refs[symbol_name] = glob
+				return b.mod.add_instr(.load, b.cur_block, ptr_t, [glob])
+			}
+			glob := b.mod.add_value_node(.global, ptr_t, symbol_name, 0)
+			b.global_refs[symbol_name] = glob
+			return glob
+		}
+
+		// Not a known constant — emit as a global reference.
+		symbol_name := c_name
+		glob := b.mod.add_value_node(.global, ptr_t, symbol_name, 0)
+		b.global_refs[symbol_name] = glob
 		return glob
 	}
 
@@ -8952,6 +9014,21 @@ fn (mut b Builder) generate_fd_macro_stubs() {
 		result := b.mod.add_instr(.and_, entry, i32_t, [shifted, c1])
 		b.mod.add_instr(.ret, entry, 0, [result])
 	}
+}
+
+fn (mut b Builder) generate_tcc_backtrace_stub() {
+	if 'tcc_backtrace' !in b.fn_index {
+		return
+	}
+	func_idx := b.fn_index['tcc_backtrace']
+	if b.mod.funcs[func_idx].blocks.len > 0 {
+		return
+	}
+	b.mod.func_set_c_extern(func_idx, false)
+	entry := b.mod.add_block(func_idx, 'entry')
+	i32_t := b.mod.type_store.get_int(32)
+	zero := b.mod.get_or_add_const(i32_t, '0')
+	b.mod.add_instr(.ret, entry, 0, [zero])
 }
 
 fn (b &Builder) find_fd_fn(name string) ?string {

--- a/vlib/v2/ssa/builder_issue_27039_test.v
+++ b/vlib/v2/ssa/builder_issue_27039_test.v
@@ -22,3 +22,35 @@ fn test_c_float_epsilon_macros_are_inline_constants() {
 	assert unknown_width == 0
 	assert unknown_value == ''
 }
+
+fn test_worker_module_preserves_target_os_for_stdio_symbols() {
+	mut m := Module.new('main')
+	m.target = TargetData{
+		ptr_size:      8
+		endian_little: true
+		os:            'macos'
+	}
+	worker := m.new_worker_module()
+	assert worker.target.os == 'macos'
+	b := Builder.new(worker)
+	assert c_stdio_symbol_for_os('stdout', b.c_stdio_target_os()) == '__stdoutp'
+}
+
+fn test_merge_worker_module_preserves_external_function_metadata() {
+	mut m := Module.new('main')
+	mut worker := Module.new('worker')
+	func_idx := worker.new_function('C.external_fn', 0, []TypeID{})
+	mut f := worker.funcs[func_idx]
+	f.is_c_extern = true
+	f.linkage = .external
+	f.call_conv = .fast_call
+	worker.funcs[func_idx] = f
+
+	m.merge_worker_module(worker, []FuncSSAData{}, 1, 0, 0, 0, 0)
+
+	assert m.funcs.len == 1
+	assert m.funcs[0].name == 'C.external_fn'
+	assert m.funcs[0].is_c_extern
+	assert m.funcs[0].linkage == .external
+	assert m.funcs[0].call_conv == .fast_call
+}

--- a/vlib/v2/ssa/builder_issue_27039_test.v
+++ b/vlib/v2/ssa/builder_issue_27039_test.v
@@ -1,0 +1,24 @@
+module ssa
+
+fn test_c_stdio_symbols_are_platform_specific() {
+	assert c_stdio_symbol_for_os('stderr', 'linux') == 'stderr'
+	assert c_stdio_symbol_for_os('stdout', 'linux') == 'stdout'
+	assert c_stdio_symbol_for_os('stdin', 'linux') == 'stdin'
+	assert c_stdio_symbol_for_os('stderr', 'macos') == '__stderrp'
+	assert c_stdio_symbol_for_os('stdout', 'freebsd') == '__stdoutp'
+	assert c_stdio_symbol_for_os('stdin', 'openbsd') == '__stdin'
+	assert c_stdio_symbol_needs_load('linux')
+	assert !c_stdio_symbol_needs_load('openbsd')
+}
+
+fn test_c_float_epsilon_macros_are_inline_constants() {
+	flt_width, flt_value := c_float_macro_const('FLT_EPSILON')
+	assert flt_width == 32
+	assert flt_value == '1.19209290e-07'
+	dbl_width, dbl_value := c_float_macro_const('DBL_EPSILON')
+	assert dbl_width == 64
+	assert dbl_value == '2.2204460492503131e-16'
+	unknown_width, unknown_value := c_float_macro_const('OTHER')
+	assert unknown_width == 0
+	assert unknown_value == ''
+}

--- a/vlib/v2/ssa/module.v
+++ b/vlib/v2/ssa/module.v
@@ -10,6 +10,7 @@ pub struct TargetData {
 pub:
 	ptr_size      int
 	endian_little bool
+	os            string
 }
 
 @[heap]
@@ -668,11 +669,14 @@ pub fn (mut m Module) merge_worker_module(w &Module, func_data []FuncSSAData, se
 			wfunc.typ
 		}
 		m.funcs << Function{
-			id:     m.funcs.len
-			name:   wfunc.name
-			typ:    new_typ
-			blocks: new_blocks
-			params: new_params
+			id:          m.funcs.len
+			name:        wfunc.name
+			typ:         new_typ
+			blocks:      new_blocks
+			params:      new_params
+			is_c_extern: wfunc.is_c_extern
+			linkage:     wfunc.linkage
+			call_conv:   wfunc.call_conv
 		}
 	}
 }

--- a/vlib/v2/ssa/module.v
+++ b/vlib/v2/ssa/module.v
@@ -387,6 +387,7 @@ pub fn (mut m Module) new_worker_module() &Module {
 
 	mut w := &Module{
 		name:              m.name
+		target:            m.target
 		shared_type_store: unsafe { nil }
 		type_store:        wts
 		env:               m.env


### PR DESCRIPTION
fix #27039 

## Diagnostic

Short version: this is a compiler/backend bug, but it also comes from the fact that the `v2 x64` backend is not complete yet. A simple `hello_world.v` does not look complex, but it already exercises a significant part of the V runtime: `println`, strings, const initialization, C stdio, C float constants, aggregates, and x64 ABI handling.

## Why the First Small Fix Was Not Enough

At first, it looked possible to make a small patch of roughly 100 lines that fixed the visible linker errors or avoided some crashes. But that approach would have been misleading.

It only fixed symptoms:

- replacing `__stderrp` with `stderr` on Linux;
- avoiding some C extern emission issues;
- making `Hello World!` appear to work by bypassing parts of the runtime.

The real problems were still there:

- `__v_init_consts_*` functions are required and must not be skipped;
- skipping them may make the small example appear to work, but the runtime is not correctly initialized;
- when they are not skipped, the previous backend generated bad code: `heap_alloc` could allocate too little memory, then generated code would write past it;
- several SSA/MIR operations were not supported by the x64 backend yet, including `insertvalue`, `extractvalue`, `trunc`, `sext`, aggregates, and strings;
- so the small patch would have hidden the failure instead of fixing the actual codegen path.

In other words: the small patch removed the smoke, not the fire.

## What the Current Fix Does

The current fix addresses the underlying causes:

- portable `stdin/stdout/stderr` mapping depending on the target OS;
- `FLT_EPSILON` and `DBL_EPSILON` emitted as inline constants instead of unresolved external symbols;
- preservation of `is_c_extern`, `linkage`, and `call_conv` during SSA module merge;
- x64 codegen no longer emits local bodies/data for external functions/globals;
- x64 support for aggregates, strings, `insertvalue`, `extractvalue`, casts, sized loads/stores;
- heap allocation sizing based on SSA usage instead of blindly allocating too little;
- conservative parameter liveness handling to avoid register clobbering;
- explicit failure on unsupported x64 operations instead of silently continuing after printing an error.
- additional target OS propagation through the v2 preferences and native target metadata;
- target-OS-aware source filtering, `$if <os>` handling, and `#flag <os>` handling;
- x64 ABI planning for aggregate arguments that must spill from registers to the stack;
- callee-side stack parameter decoding through an explicit stack cursor;
- shared stack/register argument planning for normal, sret, and indirect calls;
- explicit stack frame reservation for wide values to avoid overlapping local storage.


## Tests Added

Two regression test files were added:

- `builder_issue_27039_test.v`
  Checks target-specific `stdin/stdout/stderr` symbol mapping and inline handling of `FLT_EPSILON` / `DBL_EPSILON`.

- `x64_issue_27039_test.v`
  Checks that:
  - `hello_world.v` compiles with `-v2 -b x64`;
  - the produced binary prints exactly `Hello World!`;
  - stdout also works when redirected;
  - const initialization is not skipped.

I also confirmed with `nm` / `objdump` that `main` still calls the `__v_init_consts_*` functions.

## Validation

Validated locally:

- `make -j4` passes;
- v2 SSA/x64 tests pass;
- direct repro with `-v2 -b x64` passes;
- redirected stdout contains exactly `Hello World!\n`;
- stderr is empty.

## Additional Note

My personal feeling is that this looks more like work that is still actively in progress and simply has not had time to be completed yet, rather than a small isolated regression. That is why I am not fully sure how useful it is to treat this as a regular runtime regression issue ( the #27039 ) at this stage, but I may be missing some context.

Since this patch touches important parts of the V v2 engine and x64 code generation, I would really appreciate a full review from @medvednikov or someone deeply familiar with the v2 backend architecture before considering it ready.

@medvednikov One question: is the small `tcc_backtrace` native-backend stub acceptable here, or would you prefer this to be fixed higher up in the TinyC/backtrace compile-time selection instead?

Let's first see what the GitHub Codex review reports....
