### PR TITLE
strings: fix edge case for 1 character strings for jaro similarity

### DIFF
--- a/vlib/strings/similarity.v
+++ b/vlib/strings/similarity.v
@@ -151,7 +151,7 @@ pub fn jaro_similarity(a string, b string) f64 {
 	}
 
 	// Maximum distance upto which matching is allowed
-	match_distance := max2(a_len, b_len) / 2 - 1
+	match_distance := max2(max2(a_len, b_len) / 2 - 1, 0)
 
 	mut a_matches := []bool{len: a_len}
 	mut b_matches := []bool{len: b_len}

--- a/vlib/strings/similarity_test.v
+++ b/vlib/strings/similarity_test.v
@@ -48,6 +48,8 @@ fn test_jaro_similarity() {
 	assert strings.jaro_similarity('MARTHA', 'MARHTA') == 0.9444444444444445
 	assert strings.jaro_similarity('DIXON', 'DICKSONX') == 0.7666666666666666
 	assert strings.jaro_similarity('JELLYFISH', 'SMELLYFISH') == 0.8962962962962964
+	assert strings.jaro_similarity('a', 'a') == 1
+	assert strings.jaro_similarity('a', 'b') == 0
 }
 
 fn test_jaro_winkler_similarity() {
@@ -60,4 +62,5 @@ fn test_jaro_winkler_similarity() {
 	assert strings.jaro_winkler_similarity('accomodate', 'accompanist') == 0.8672727272727273
 	assert strings.jaro_winkler_similarity('untill', 'huntsville') == 0.8666666666666667
 	assert strings.jaro_winkler_similarity('wich', 'wichita') == 0.9142857142857143
+	assert strings.jaro_winkler_similarity('a', 'a') == 1
 }


### PR DESCRIPTION
I noticed a problem with strings that only had 1 character in them when
calling `strings.jaro_similarity()`.  The fix prevents `match_distance` from
going negative on strings of length 1.

I have added some test cases to exercise the fix

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
