### PR TITLE
gzip: fix decompression of a zero length payload

### DIFF
--- a/vlib/compress/gzip/gzip.v
+++ b/vlib/compress/gzip/gzip.v
@@ -209,6 +209,22 @@ pub fn decompress(data []u8, params DecompressParams) ![]u8 {
 	gzip_header := validate(data, params)!
 	header_length := gzip_header.length
 
+	// An empty-payload gzip stream has a 2-byte empty stored deflate
+	// block (03 00). miniz's tinfl_decompress_mem_to_heap returns NULL
+	// for zero-length output, so short-circuit before calling it.
+	if data.len == header_length + 2 + 8 && data[header_length] == 0x03
+		&& data[header_length + 1] == 0x00 {
+		length_expected := (u32(data[data.len - 1]) << 24) | (u32(data[data.len - 2]) << 16) | (u32(data[data.len - 3]) << 8) | data[data.len - 4]
+		checksum_expected := (u32(data[data.len - 5]) << 24) | (u32(data[data.len - 6]) << 16) | (u32(data[data.len - 7]) << 8) | data[data.len - 8]
+		if params.verify_length && length_expected != 0 {
+			return error('length verification failed, got 0, expected ${length_expected}')
+		}
+		if params.verify_checksum && checksum_expected != 0 {
+			return error('checksum verification failed')
+		}
+		return []u8{}
+	}
+
 	decompressed := compr.decompress(data[header_length..data.len - 8], 0)!
 	length_expected := (u32(data[data.len - 1]) << 24) | (u32(data[data.len - 2]) << 16) | (u32(data[data.len - 3]) << 8) | data[data.len - 4]
 	if params.verify_length && decompressed.len != length_expected {

--- a/vlib/compress/gzip/gzip_test.v
+++ b/vlib/compress/gzip/gzip_test.v
@@ -133,6 +133,35 @@ fn test_gzip_with_invalid_flags() {
 	assert_decompress_error(compressed, 'reserved flags are set, unsupported field detected')!
 }
 
+fn test_empty_input_roundtrip() {
+	empty := []u8{}
+	compressed := compress(empty)!
+	// Sanity: compress still produces a well-formed stream.
+	assert compressed.len == 20
+	assert compressed[0] == 0x1f && compressed[1] == 0x8b
+	decompressed := decompress(compressed)!
+	assert decompressed.len == 0
+	assert decompressed == empty
+}
+
+fn test_empty_input_trailer_tampered_rejected() {
+	// Confirm the fix still verifies the trailer: flip one byte of
+	// the declared size and decompress must error out.
+	mut compressed := compress([]u8{})!
+	compressed[compressed.len - 4] = 0x01 // claim length = 1, not 0
+	if _ := decompress(compressed) {
+		assert false, 'expected length-verification failure'
+	}
+}
+
+fn test_empty_input_checksum_tampered_rejected() {
+	mut compressed := compress([]u8{})!
+	compressed[compressed.len - 8] = 0x01 // corrupt CRC
+	if _ := decompress(compressed) {
+		assert false, 'expected checksum-verification failure'
+	}
+}
+
 fn test_gzip_decompress_callback() {
 	uncompressed := '321323'.repeat(10_000)
 	gz := compress(uncompressed.bytes())!


### PR DESCRIPTION
I found an edge case where decompressing a 0 length payload did not
return a 0 length result.

I have added some additional test cases around this.

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
