### PR TITLE
crypto: remove unused variable in ed25519 internal

### DIFF
--- a/vlib/crypto/ed25519/internal/edwards25519/scalar.v
+++ b/vlib/crypto/ed25519/internal/edwards25519/scalar.v
@@ -1068,7 +1068,8 @@ fn (mut s Scalar) signed_radix16() []i8 {
 // utility function
 // generate returns a valid (reduced modulo l) Scalar with a distribution
 // weighted towards high, low, and edge values.
-fn generate_scalar(size int) !Scalar {
+// fn generate_scalar(size int) !Scalar {
+fn generate_scalar(_ int) !Scalar {
 	/*
 	s := scZero
 	diceRoll := rand.Intn(100)


### PR DESCRIPTION
Remove unused variable `int` in `vlib/crypto/ed25519/internal/edwards25519/scalar.v`

- Before this fix:
```sh
$ ./v -W test vlib/crypto/ed25519/
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
vlib/crypto/ed25519/internal/edwards25519/scalar.v:1071:20: notice: unused parameter: `size`
 1069 | // generate returns a valid (reduced modulo l) Scalar with a distribution
 1070 | // weighted towards high, low, and edge values.
 1071 | fn generate_scalar(size int) !Scalar {
      |                    ~~~~
 1072 |     /*
 1073 |     s := scZero
vlib/crypto/ed25519/internal/edwards25519/scalar.v:1071:20: notice: unused parameter: `size`
 1069 | // generate returns a valid (reduced modulo l) Scalar with a distribution
 1070 | // weighted towards high, low, and edge values.
 1071 | fn generate_scalar(size int) !Scalar {
      |                    ~~~~
 1072 |     /*
 1073 |     s := scZero
vlib/crypto/ed25519/internal/edwards25519/scalar.v:1071:20: notice: unused parameter: `size`
 1069 | // generate returns a valid (reduced modulo l) Scalar with a distribution
 1070 | // weighted towards high, low, and edge values.
 1071 | fn generate_scalar(size int) !Scalar {
      |                    ~~~~
 1072 |     /*
 1073 |     s := scZero
vlib/crypto/ed25519/internal/edwards25519/scalar.v:1071:20: notice: unused parameter: `size`
 1069 | // generate returns a valid (reduced modulo l) Scalar with a distribution
 1070 | // weighted towards high, low, and edge values.
 1071 | fn generate_scalar(size int) !Scalar {
      |                    ~~~~
 1072 |     /*
 1073 |     s := scZero
vlib/crypto/ed25519/internal/edwards25519/scalar.v:1071:20: notice: unused parameter: `size`
 1069 | // generate returns a valid (reduced modulo l) Scalar with a distribution
 1070 | // weighted towards high, low, and edge values.
 1071 | fn generate_scalar(size int) !Scalar {
      |                    ~~~~
 1072 |     /*
 1073 |     s := scZero
vlib/crypto/ed25519/internal/edwards25519/scalar.v:1071:20: notice: unused parameter: `size`
 1069 | // generate returns a valid (reduced modulo l) Scalar with a distribution
 1070 | // weighted towards high, low, and edge values.
 1071 | fn generate_scalar(size int) !Scalar {
      |                    ~~~~
 1072 |     /*
 1073 |     s := scZero
vlib/crypto/ed25519/internal/edwards25519/scalar.v:1071:20: notice: unused parameter: `size`
 1069 | // generate returns a valid (reduced modulo l) Scalar with a distribution
 1070 | // weighted towards high, low, and edge values.
 1071 | fn generate_scalar(size int) !Scalar {
      |                    ~~~~
 1072 |     /*
 1073 |     s := scZero
vlib/crypto/ed25519/internal/edwards25519/scalar.v:1071:20: notice: unused parameter: `size`
 1069 | // generate returns a valid (reduced modulo l) Scalar with a distribution
 1070 | // weighted towards high, low, and edge values.
 1071 | fn generate_scalar(size int) !Scalar {
      |                    ~~~~
 1072 |     /*
 1073 |     s := scZero
 OK    [1/8] C:  1529.4 ms, R:     3.847 ms vlib/crypto/ed25519/internal/edwards25519/scalar_alias_test.v
(...)
```