### PR TITLE
js: remove unused variables in prelude for tests runner

### DIFF
--- a/vlib/v/preludes_js/test_runner.v
+++ b/vlib/v/preludes_js/test_runner.v
@@ -70,10 +70,10 @@ fn cb_assertion_failed(i VAssertMetaInfo) {
 	myeprintln('')
 }
 
-fn cb_assertion_ok(i &VAssertMetaInfo) {
+fn cb_assertion_ok(_ &VAssertMetaInfo) {
 }
 
-fn cb_propagate_test_error(line_nr int, file string, mod string, fn_name string, errmsg string) {
+fn cb_propagate_test_error(line_nr int, file string, _ string, fn_name string, errmsg string) {
 	filepath := if use_relative_paths { file } else { os.real_path(file) }
 	mut final_filepath := filepath + ':${line_nr}:'
 	mut final_funcname := 'fn ' + fn_name.replace('main.', '').replace('__', '.')


### PR DESCRIPTION
Remove unused variables in `vlib/v/preludes_js/test_runner.v`

- Before this fix:
```sh
$ ./v test vlib/builtin/js/int_test.js.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
vlib/v/preludes_js/test_runner.v:73:20: notice: unused parameter: `i`
   71 | }
   72 |
   73 | fn cb_assertion_ok(i &VAssertMetaInfo) {
      |                    ^
   74 | }
   75 |
vlib/v/preludes_js/test_runner.v:76:54: notice: unused parameter: `mod`
   74 | }
   75 |
   76 | fn cb_propagate_test_error(line_nr int, file string, mod string, fn_name string, errmsg string) {
      |                                                      ~~~
   77 |     filepath := if use_relative_paths { file } else { os.real_path(file) }
   78 |     mut final_filepath := filepath + ':${line_nr}:'
 OK     167.199 ms vlib/builtin/js/int_test.js.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 296 ms, on 1 job. Comptime: 127 ms. Runtime: 167 ms.
```