### PR TITLE
x.async: fix format for example in README

### DIFF
--- a/vlib/x/async/README.md
+++ b/vlib/x/async/README.md
@@ -79,9 +79,7 @@ fn main() {
 		return error('stop the group')
 	})!
 
-	group.wait() or {
-		eprintln('group failed: ${err.msg()}')
-	}
+	group.wait() or { eprintln('group failed: ${err.msg()}') }
 }
 ```
 


### PR DESCRIPTION
- Before this fix, `v fmt` error with example in `vlib/x/async/README.md` (added in PR #27029).
```sh
$ ./v check-md -hide-warnings vlib/x/async/
> Found: 13 .md files. Skipped by .vcheckignore: 0.
OK:   0, W:  0, E:  0, F:  0, ex.   1/12 , from line   54 to line 85   of 482 , command:      compile | File  13/13 : vlib/x/async/README.md
vlib/x/async/README.md:55:1: error: example is not formatted
import context
import time
import x.async

fn main() {
        parent := context.background()
        mut group := async.new_group(parent)

        group.go(fn (mut ctx context.Context) ! {
                // A long-running job should observe ctx.done().
                done := ctx.done()
                select {
                        _ := <-done {
                                return ctx.err()
                        }
                        50 * time.millisecond {
                                return
                        }
                }
        })!

        group.go(fn (mut ctx context.Context) ! {
                _ = ctx
                return error('stop the group')
        })!

        group.wait() or {
                eprintln('group failed: ${err.msg()}')
        }
}

Checked .md files: 13 | Ex.: 12 | Lines: 743 | OKs: 0 | Warnings: 0 | Errors: 1 | Fmt errors: 1
```

- `v fmt` diff for `vlib/x/async/README.md`:
```sh
$ ./v fmt -diff ~/tmp/x_async.v
@@ -24,9 +24,7 @@
                return error('stop the group')
        })!

-       group.wait() or {
-               eprintln('group failed: ${err.msg()}')
-       }
+       group.wait() or { eprintln('group failed: ${err.msg()}') }
}
```