### PR TITLE
net: stop using vlib-specific symbols in C. defenitions in `net` module

### DIFF
--- a/vlib/fasthttp/fasthttp.v
+++ b/vlib/fasthttp/fasthttp.v
@@ -23,7 +23,7 @@ const tiny_bad_request_response = 'HTTP/1.1 400 Bad Request\r\nContent-Length: 0
 const status_444_response = 'HTTP/1.1 444 No Response\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 const status_413_response = 'HTTP/1.1 413 Payload Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 
-fn C.socket(domain net.AddrFamily, typ net.SocketType, protocol i32) i32
+fn C.socket(domain i32, typ i32, protocol i32) i32
 
 fn C.bind(sockfd i32, addr &net.Addr, addrlen u32) i32
 

--- a/vlib/fasthttp/fasthttp_bsd.c.v
+++ b/vlib/fasthttp/fasthttp_bsd.c.v
@@ -537,7 +537,7 @@ pub fn (mut s Server) run() ! {
 	// TcpConn.write).
 	C.signal(C.SIGPIPE, C.SIG_IGN)
 
-	s.socket_fd = C.socket(s.family, net.SocketType.tcp, 0)
+	s.socket_fd = C.socket(i32(s.family), i32(net.SocketType.tcp), 0)
 	if s.socket_fd < 0 {
 		C.perror(c'socket')
 		return error('socket creation failed')

--- a/vlib/fasthttp/fasthttp_linux.v
+++ b/vlib/fasthttp/fasthttp_linux.v
@@ -113,7 +113,7 @@ fn close_socket(fd int) bool {
 
 fn create_server_socket(server Server) int {
 	// Create a socket with non-blocking mode
-	server_fd := C.socket(server.family, net.SocketType.tcp, 0)
+	server_fd := C.socket(i32(server.family), i32(net.SocketType.tcp), 0)
 	if server_fd < 0 {
 		eprintln(@LOCATION)
 		C.perror(c'Socket creation failed')

--- a/vlib/net/aasocket.c.v
+++ b/vlib/net/aasocket.c.v
@@ -42,7 +42,7 @@ pub enum AddrFamily {
 	unspec = C.AF_UNSPEC
 }
 
-fn C.socket(domain AddrFamily, typ SocketType, protocol i32) i32
+fn C.socket(domain i32, typ i32, protocol i32) i32
 
 // fn C.setsockopt(sockfd int, level int, optname int, optval voidptr, optlen C.socklen_t) int
 fn C.setsockopt(sockfd i32, level i32, optname i32, optval voidptr, optlen u32) i32
@@ -56,12 +56,12 @@ fn C.ntohs(net u16) u16
 // fn C.bind(sockfd int, addr &C.sockaddr, addrlen C.socklen_t) int
 // use voidptr for arg 2 because sockaddr is a generic descriptor for any kind of socket operation,
 // it can also take sockaddr_in depending on the type of socket used in arg 1
-fn C.bind(sockfd i32, addr &Addr, addrlen u32) i32
+fn C.bind(sockfd i32, addr voidptr, addrlen u32) i32
 
 fn C.listen(sockfd i32, backlog i32) i32
 
 // fn C.accept(sockfd int, addr &C.sockaddr, addrlen &C.socklen_t) int
-fn C.accept(sockfd i32, addr &Addr, addrlen &u32) i32
+fn C.accept(sockfd i32, addr voidptr, addrlen &u32) i32
 
 fn C.getaddrinfo(node &char, service &char, hints &C.addrinfo, res &&C.addrinfo) i32
 
@@ -72,28 +72,28 @@ $if !windows {
 }
 
 // fn C.connect(sockfd int, addr &C.sockaddr, addrlen C.socklen_t) int
-fn C.connect(sockfd i32, addr &Addr, addrlen u32) i32
+fn C.connect(sockfd i32, addr voidptr, addrlen u32) i32
 
 // fn C.send(sockfd int, buf voidptr, len usize, flags int) usize
 fn C.send(sockfd i32, buf voidptr, len usize, flags i32) i32
 
 // fn C.sendto(sockfd int, buf voidptr, len usize, flags int, dest_add &C.sockaddr, addrlen C.socklen_t) usize
-fn C.sendto(sockfd i32, buf voidptr, len usize, flags i32, dest_add &Addr, addrlen u32) i32
+fn C.sendto(sockfd i32, buf voidptr, len usize, flags i32, dest_add voidptr, addrlen u32) i32
 
 // fn C.recv(sockfd int, buf voidptr, len usize, flags int) usize
 fn C.recv(sockfd i32, buf voidptr, len usize, flags i32) i32
 
 // fn C.recvfrom(sockfd int, buf voidptr, len usize, flags int, src_addr &C.sockaddr, addrlen &C.socklen_t) usize
-fn C.recvfrom(sockfd i32, buf voidptr, len usize, flags i32, src_addr &Addr, addrlen &u32) i32
+fn C.recvfrom(sockfd i32, buf voidptr, len usize, flags i32, src_addr voidptr, addrlen &u32) i32
 
 fn C.shutdown(socket i32, how i32) i32
 
 // fn C.getpeername(sockfd int, addr &C.sockaddr, addlen &C.socklen_t) int
-fn C.getpeername(sockfd i32, addr &Addr, addlen &u32) i32
+fn C.getpeername(sockfd i32, addr voidptr, addlen &u32) i32
 
-fn C.inet_ntop(af AddrFamily, src voidptr, dst &char, dst_size i32) &char
+fn C.inet_ntop(af i32, src voidptr, dst &char, dst_size i32) &char
 
-fn C.WSAAddressToStringA(lpsaAddress &Addr, dwAddressLength u32, lpProtocolInfo voidptr, lpszAddressString &char,
+fn C.WSAAddressToStringA(lpsaAddress voidptr, dwAddressLength u32, lpProtocolInfo voidptr, lpszAddressString &char,
 	lpdwAddressStringLength &u32) i32
 
 // fn C.getsockname(sockfd int, addr &C.sockaddr, addrlen &C.socklen_t) int
@@ -117,10 +117,10 @@ fn C.FD_SET(fd i32, fdset &C.fd_set)
 
 fn C.FD_ISSET(fd i32, fdset &C.fd_set) i32
 
-fn C.inet_pton(family AddrFamily, saddr &char, addr voidptr) i32
+fn C.inet_pton(family i32, saddr &char, addr voidptr) i32
 
-fn C.photon_socket(domain AddrFamily, typ SocketType, protocol i32) i32
-fn C.photon_connect(i32, &Addr, u32, timeout u64) i32
+fn C.photon_socket(domain i32, typ i32, protocol i32) i32
+fn C.photon_connect(i32, voidptr, u32, timeout u64) i32
 fn C.photon_accept(i32, voidptr, i32, timeout u64) i32
 fn C.photon_send(i32, voidptr, i32, i32, timeout u64) i32
 fn C.photon_recv(i32, voidptr, i32, i32, timeout u64) i32

--- a/vlib/net/address.c.v
+++ b/vlib/net/address.c.v
@@ -117,7 +117,7 @@ const max_ip6_len = 46
 pub fn (a Ip) str() string {
 	buf := [max_ip_len]char{}
 
-	res := &char(C.inet_ntop(.ip, &a.addr, &buf[0], buf.len))
+	res := &char(C.inet_ntop(i32(AddrFamily.ip), &a.addr, &buf[0], buf.len))
 
 	if res == 0 {
 		return '<Unknown>'
@@ -132,7 +132,7 @@ pub fn (a Ip) str() string {
 pub fn (a Ip6) str() string {
 	buf := [max_ip6_len]char{}
 
-	res := &char(C.inet_ntop(.ip6, &a.addr, &buf[0], buf.len))
+	res := &char(C.inet_ntop(i32(AddrFamily.ip6), &a.addr, &buf[0], buf.len))
 
 	if res == 0 {
 		return '<Unknown>'

--- a/vlib/net/raw.c.v
+++ b/vlib/net/raw.c.v
@@ -38,7 +38,7 @@ pub:
 // new_raw_socket creates a new raw socket with the given configuration.
 // Raw sockets typically require elevated privileges (root/administrator).
 pub fn new_raw_socket(config RawSocketConfig) !&RawConn {
-	sockfd := socket_error(C.socket(config.family, SocketType.raw, int(config.protocol)))!
+	sockfd := socket_error(C.socket(i32(config.family), i32(SocketType.raw), i32(config.protocol)))!
 	mut s := &RawSocket{
 		handle:   sockfd
 		protocol: config.protocol

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -571,9 +571,9 @@ pub struct TcpSocket {
 @[noinline]
 pub fn new_tcp_socket(family AddrFamily) !TcpSocket {
 	handle := $if is_coroutine ? {
-		socket_error(C.photon_socket(family, SocketType.tcp, 0))!
+		socket_error(C.photon_socket(i32(family), i32(SocketType.tcp), 0))!
 	} $else {
-		socket_error(C.socket(family, SocketType.tcp, 0))!
+		socket_error(C.socket(i32(family), i32(SocketType.tcp), 0))!
 	}
 	mut s := TcpSocket{
 		handle: handle

--- a/vlib/net/udp.c.v
+++ b/vlib/net/udp.c.v
@@ -337,7 +337,7 @@ pub fn listen_udp(laddr string) !&UdpConn {
 fn new_udp_socket(local_addr Addr) !&UdpSocket {
 	family := local_addr.family()
 
-	sockfd := socket_error(C.socket(family, SocketType.udp, 0))!
+	sockfd := socket_error(C.socket(i32(family), i32(SocketType.udp), 0))!
 	mut s := &UdpSocket{
 		handle: sockfd
 		l:      local_addr
@@ -416,7 +416,7 @@ fn parse_ipv4_interface_addr(iface_addr string) ![4]u8 {
 	}
 	address := normalize_ip_literal(iface_addr)
 	mut parsed := [4]u8{}
-	if C.inet_pton(.ip, &char(address.str), &parsed[0]) != 1 {
+	if C.inet_pton(i32(AddrFamily.ip), &char(address.str), &parsed[0]) != 1 {
 		return error('net: ipv4 multicast interface must be an ipv4 address')
 	}
 	return parsed
@@ -425,7 +425,7 @@ fn parse_ipv4_interface_addr(iface_addr string) ![4]u8 {
 fn parse_ipv4_multicast_addr(multicast_addr string) ![4]u8 {
 	address := normalize_ip_literal(multicast_addr)
 	mut parsed := [4]u8{}
-	if C.inet_pton(.ip, &char(address.str), &parsed[0]) != 1 {
+	if C.inet_pton(i32(AddrFamily.ip), &char(address.str), &parsed[0]) != 1 {
 		return error('net: invalid ipv4 multicast address `${multicast_addr}`')
 	}
 	if parsed[0] < 224 || parsed[0] > 239 {
@@ -437,7 +437,7 @@ fn parse_ipv4_multicast_addr(multicast_addr string) ![4]u8 {
 fn parse_ipv6_multicast_addr(multicast_addr string) ![16]u8 {
 	address := normalize_ip_literal(multicast_addr)
 	mut parsed := [16]u8{}
-	if C.inet_pton(.ip6, &char(address.str), &parsed[0]) != 1 {
+	if C.inet_pton(i32(AddrFamily.ip6), &char(address.str), &parsed[0]) != 1 {
 		return error('net: invalid ipv6 multicast address `${multicast_addr}`')
 	}
 	if parsed[0] != 0xff {

--- a/vlib/net/unix/stream.c.v
+++ b/vlib/net/unix/stream.c.v
@@ -385,9 +385,9 @@ mut:
 
 fn new_stream_socket(socket_path string) !StreamSocket {
 	handle := $if is_coroutine ? {
-		net.socket_error(C.photon_socket(.unix, .tcp, 0))!
+		net.socket_error(C.photon_socket(i32(net.AddrFamily.unix), i32(net.SocketType.tcp), 0))!
 	} $else {
-		net.socket_error(C.socket(.unix, .tcp, 0))!
+		net.socket_error(C.socket(i32(net.AddrFamily.unix), i32(net.SocketType.tcp), 0))!
 	}
 	mut s := StreamSocket{
 		handle:      handle

--- a/vlib/picoev/socket_util.c.v
+++ b/vlib/picoev/socket_util.c.v
@@ -90,7 +90,7 @@ fn fatal_socket_error(fd int) bool {
 // listen creates a listening tcp socket and returns its file descriptor.
 fn listen(config Config) !int {
 	// not using the `net` modules sockets, because not all socket options are defined
-	fd := C.socket(config.family, net.SocketType.tcp, 0)
+	fd := C.socket(i32(config.family), i32(net.SocketType.tcp), 0)
 	if fd == -1 {
 		return error('Failed to create socket')
 	}


### PR DESCRIPTION
Fix https://github.com/vlang/v/issues/27051

This PR makes the declarations of some C functions more general and closer to C, allowing users to create their own wrappers around these functions without depending on `net` module.