### PR TITLE
builtin: fix warnings in array JS tests

### DIFF
--- a/vlib/builtin/js/array_test.js.v
+++ b/vlib/builtin/js/array_test.js.v
@@ -78,12 +78,12 @@ fn test_deleting() {
 
 fn test_slice_delete() {
 	mut a := [1.5, 2.5, 3.25, 4.5, 5.75]
-	b := a[2..4]
+	b := a[2..4].clone()
 	a.delete(0)
 	assert a == [2.5, 3.25, 4.5, 5.75]
 	assert b == [3.25, 4.5]
 	a = [3.75, 4.25, -1.5, 2.25, 6.0]
-	c := a[..3]
+	c := a[..3].clone()
 	a.delete(2)
 	assert a == [3.75, 4.25, 2.25, 6.0]
 	assert c == [3.75, 4.25, -1.5]
@@ -91,11 +91,11 @@ fn test_slice_delete() {
 
 fn test_delete_many() {
 	mut a := [1, 2, 3, 4, 5, 6, 7, 8, 9]
-	b := a[2..6]
+	b := a[2..6].clone()
 	a.delete_many(4, 3)
 	assert a == [1, 2, 3, 4, 8, 9]
 	assert b == [3, 4, 5, 6]
-	c := a[..a.len]
+	c := a[..a.len].clone()
 	a.delete_many(2, 0) // this should just clone
 	a[1] = 17
 	assert a == [1, 17, 3, 4, 8, 9]


### PR DESCRIPTION
Remove notice/warning for array clone in array JS tests `vlib/builtin/js/array_test.js.v`

- Before this fix:
```sh
$ ./v test vlib/builtin/js/array_test.js.v
---- Testing... ----------------------------------------------------------------------------------------------------------------------------
vlib/builtin/js/array_test.js.v:81:8: notice: an implicit clone of the slice was done here
   79 | fn test_slice_delete() {
   80 |     mut a := [1.5, 2.5, 3.25, 4.5, 5.75]
   81 |     b := a[2..4]
      |           ~~~~~~
   82 |     a.delete(0)
   83 |     assert a == [2.5, 3.25, 4.5, 5.75]
Details: vlib/builtin/js/array_test.js.v:81:8: details: To silence this notice, use either an explicit `a[..].clone()`,
or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.
   79 | fn test_slice_delete() {
   80 |     mut a := [1.5, 2.5, 3.25, 4.5, 5.75]
   81 |     b := a[2..4]
      |           ~~~~~~
   82 |     a.delete(0)
   83 |     assert a == [2.5, 3.25, 4.5, 5.75]
vlib/builtin/js/array_test.js.v:86:8: notice: an implicit clone of the slice was done here
   84 |     assert b == [3.25, 4.5]
   85 |     a = [3.75, 4.25, -1.5, 2.25, 6.0]
   86 |     c := a[..3]
      |           ~~~~~
   87 |     a.delete(2)
   88 |     assert a == [3.75, 4.25, 2.25, 6.0]
Details: vlib/builtin/js/array_test.js.v:86:8: details: To silence this notice, use either an explicit `a[..].clone()`,
or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.
   84 |     assert b == [3.25, 4.5]
   85 |     a = [3.75, 4.25, -1.5, 2.25, 6.0]
   86 |     c := a[..3]
      |           ~~~~~
   87 |     a.delete(2)
   88 |     assert a == [3.75, 4.25, 2.25, 6.0]
vlib/builtin/js/array_test.js.v:94:8: notice: an implicit clone of the slice was done here
   92 | fn test_delete_many() {
   93 |     mut a := [1, 2, 3, 4, 5, 6, 7, 8, 9]
   94 |     b := a[2..6]
      |           ~~~~~~
   95 |     a.delete_many(4, 3)
   96 |     assert a == [1, 2, 3, 4, 8, 9]
Details: vlib/builtin/js/array_test.js.v:94:8: details: To silence this notice, use either an explicit `a[..].clone()`,
or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.
   92 | fn test_delete_many() {
   93 |     mut a := [1, 2, 3, 4, 5, 6, 7, 8, 9]
   94 |     b := a[2..6]
      |           ~~~~~~
   95 |     a.delete_many(4, 3)
   96 |     assert a == [1, 2, 3, 4, 8, 9]
vlib/builtin/js/array_test.js.v:98:8: notice: an implicit clone of the slice was done here
   96 |     assert a == [1, 2, 3, 4, 8, 9]
   97 |     assert b == [3, 4, 5, 6]
   98 |     c := a[..a.len]
      |           ~~~~~~~~~
   99 |     a.delete_many(2, 0) // this should just clone
  100 |     a[1] = 17
Details: vlib/builtin/js/array_test.js.v:98:8: details: To silence this notice, use either an explicit `a[..].clone()`,
or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.
   96 |     assert a == [1, 2, 3, 4, 8, 9]
   97 |     assert b == [3, 4, 5, 6]
   98 |     c := a[..a.len]
      |           ~~~~~~~~~
   99 |     a.delete_many(2, 0) // this should just clone
  100 |     a[1] = 17
 OK     267.541 ms vlib/builtin/js/array_test.js.v
--------------------------------------------------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 432 ms, on 1 job. Comptime: 162 ms. Runtime: 267 ms.

```