### PR TITLE
tools: fix tests for vtest with musl

### DIFF
--- a/cmd/tools/vtest_test.v
+++ b/cmd/tools/vtest_test.v
@@ -116,7 +116,8 @@ fn test_wimpure_v_warnings_are_shown_for_test_files() {
 }
 
 fn test_js_runtime_errors_are_shown_for_js_tests() {
-	if @CCOMPILER.contains('musl') || os.getenv('VFLAGS').contains('musl') {
+	if @CCOMPILER.contains('musl') || os.getenv('VFLAGS').contains('musl')
+		|| os.getenv('V_CI_MUSL') == '1' {
 		return
 	}
 	if os.execute('node --version').exit_code != 0 {


### PR DESCRIPTION
In tests for `vtest`, `VFLAGS` is set to `''` and cannot be used to detect musl library.
To bypass test `test_js_runtime_errors_are_shown_for_js_tests` (`cmd/tools/vtest_test.v`) for musl, check `V_CI_MUSL` env used by "Tools CI" (`.github/workflows/tools_ci.yml`).

With this fix, all jobs are successful for "Tools CI" workflow => see this run in my personal repo https://github.com/lcheylus/v/actions/runs/25255467969