### PR TITLE
datatypes.fsm: remove unused variables

### DIFF
--- a/vlib/datatypes/fsm/fsm.v
+++ b/vlib/datatypes/fsm/fsm.v
@@ -4,10 +4,10 @@ pub type EventHandlerFn = fn (receiver voidptr, from string, to string)
 
 pub type ConditionFn = fn (receiver voidptr, from string, to string) bool
 
-fn dummy_event_handler_fn(receiver voidptr, from string, to string) {
+fn dummy_event_handler_fn(_ voidptr, _ string, _ string) {
 }
 
-fn dummy_condition_fn(receiver voidptr, from string, to string) bool {
+fn dummy_condition_fn(_ voidptr, _ string, _ string) bool {
 	return true
 }
 


### PR DESCRIPTION
Remove unused variables in `vlib/datatypes/fsm/fsm.v` (datatype for Finite State Machine)

- Before this fix:
```sh
$ ./v test vlib/datatypes/fsm/
---- Testing... ----
vlib/datatypes/fsm/fsm.v:7:27: notice: unused parameter: `receiver`
    5 | pub type ConditionFn = fn (receiver voidptr, from string, to string) bool
    6 |
    7 | fn dummy_event_handler_fn(receiver voidptr, from string, to string) {
      |                           ~~~~~~~~
    8 | }
    9 |
vlib/datatypes/fsm/fsm.v:7:45: notice: unused parameter: `from`
    5 | pub type ConditionFn = fn (receiver voidptr, from string, to string) bool
    6 |
    7 | fn dummy_event_handler_fn(receiver voidptr, from string, to string) {
      |                                             ~~~~
    8 | }
    9 |
vlib/datatypes/fsm/fsm.v:7:58: notice: unused parameter: `to`
    5 | pub type ConditionFn = fn (receiver voidptr, from string, to string) bool
    6 |
    7 | fn dummy_event_handler_fn(receiver voidptr, from string, to string) {
      |                                                          ~~
    8 | }
    9 |
vlib/datatypes/fsm/fsm.v:10:23: notice: unused parameter: `receiver`
    8 | }
    9 |
   10 | fn dummy_condition_fn(receiver voidptr, from string, to string) bool {
      |                       ~~~~~~~~
   11 |     return true
   12 | }
vlib/datatypes/fsm/fsm.v:10:41: notice: unused parameter: `from`
    8 | }
    9 |
   10 | fn dummy_condition_fn(receiver voidptr, from string, to string) bool {
      |                                         ~~~~
   11 |     return true
   12 | }
vlib/datatypes/fsm/fsm.v:10:54: notice: unused parameter: `to`
    8 | }
    9 |
   10 | fn dummy_condition_fn(receiver voidptr, from string, to string) bool {
      |                                                      ~~
   11 |     return true
   12 | }
 OK       1.729 ms vlib/datatypes/fsm/fsm_test.v
----
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 433 ms, on 1 job. Comptime: 429 ms. Runtime: 1 ms.
```