### PR TITLE
net.smtp: strip display name from MAIL FROM / RCPT TO envelope addresses

### DIFF
--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -246,18 +246,30 @@ fn (mut c Client) send_auth() ! {
 // display name. The SMTP envelope (`MAIL FROM:` / `RCPT TO:`) only accepts a
 // bare mailbox (RFC 5321), while `Mail.from`/`Mail.to` may also be written in
 // the RFC 5322 `Display Name <addr@example.com>` form for the message header.
+//
+// Only strip an angle-addr wrapper when the input actually ends in `>`; bare
+// mailboxes are returned unchanged. When walking for the opening `<`, quoted
+// strings are skipped so a quoted local-part like `"a<b"@example.com` is
+// preserved intact.
 fn envelope_addr(s string) string {
 	trimmed := s.trim_space()
-	lt := trimmed.index_u8(`<`)
-	if lt < 0 {
+	if !trimmed.ends_with('>') {
 		return trimmed
 	}
-	rest := trimmed[lt + 1..]
-	gt := rest.index_u8(`>`)
-	if gt < 0 {
-		return rest
+	mut in_quote := false
+	mut i := 0
+	for i < trimmed.len - 1 {
+		c := trimmed[i]
+		if c == `"` {
+			in_quote = !in_quote
+		} else if in_quote && c == `\\` && i + 1 < trimmed.len {
+			i++
+		} else if c == `<` && !in_quote {
+			return trimmed[i + 1..trimmed.len - 1]
+		}
+		i++
 	}
-	return rest[..gt]
+	return trimmed
 }
 
 fn (mut c Client) send_mailfrom(from string) ! {

--- a/vlib/net/smtp/smtp.v
+++ b/vlib/net/smtp/smtp.v
@@ -242,14 +242,32 @@ fn (mut c Client) send_auth() ! {
 	c.expect_reply(.auth_ok)!
 }
 
+// envelope_addr extracts the bare mailbox from an address that may include a
+// display name. The SMTP envelope (`MAIL FROM:` / `RCPT TO:`) only accepts a
+// bare mailbox (RFC 5321), while `Mail.from`/`Mail.to` may also be written in
+// the RFC 5322 `Display Name <addr@example.com>` form for the message header.
+fn envelope_addr(s string) string {
+	trimmed := s.trim_space()
+	lt := trimmed.index_u8(`<`)
+	if lt < 0 {
+		return trimmed
+	}
+	rest := trimmed[lt + 1..]
+	gt := rest.index_u8(`>`)
+	if gt < 0 {
+		return rest
+	}
+	return rest[..gt]
+}
+
 fn (mut c Client) send_mailfrom(from string) ! {
-	c.send_str('MAIL FROM: <${from}>\r\n')!
+	c.send_str('MAIL FROM:<${envelope_addr(from)}>\r\n')!
 	c.expect_reply(.action_ok)!
 }
 
 fn (mut c Client) send_mailto(to string) ! {
 	for rcpt in to.split(';') {
-		c.send_str('RCPT TO: <${rcpt}>\r\n')!
+		c.send_str('RCPT TO:<${envelope_addr(rcpt)}>\r\n')!
 		c.expect_reply(.action_ok)!
 	}
 }

--- a/vlib/net/smtp/smtp_internal_test.v
+++ b/vlib/net/smtp/smtp_internal_test.v
@@ -85,3 +85,26 @@ fn test_fold_base64_wraps_long_lines() {
 	assert lines[0].len == 76
 	assert lines[1].len == 32
 }
+
+fn test_envelope_addr_strips_display_name() {
+	assert envelope_addr('ivan@example.com') == 'ivan@example.com'
+	assert envelope_addr('  ivan@example.com  ') == 'ivan@example.com'
+	assert envelope_addr('<ivan@example.com>') == 'ivan@example.com'
+	assert envelope_addr('Ivan Petrov <ivan@example.com>') == 'ivan@example.com'
+	assert envelope_addr('"Petrov, Ivan" <ivan@example.com>') == 'ivan@example.com'
+	// Tolerate a malformed input with no closing '>' rather than panicking.
+	assert envelope_addr('Ivan <ivan@example.com') == 'ivan@example.com'
+}
+
+fn test_mail_message_data_preserves_display_name_in_from_header() {
+	mail := Mail{
+		from:    'Ivan Petrov <ivan@example.com>'
+		to:      'recipient@example.com'
+		subject: 'Test'
+		body:    'hi'
+	}
+
+	message := mail.message_data()
+
+	assert message.contains('From: Ivan Petrov <ivan@example.com>\r\n')
+}

--- a/vlib/net/smtp/smtp_internal_test.v
+++ b/vlib/net/smtp/smtp_internal_test.v
@@ -92,8 +92,15 @@ fn test_envelope_addr_strips_display_name() {
 	assert envelope_addr('<ivan@example.com>') == 'ivan@example.com'
 	assert envelope_addr('Ivan Petrov <ivan@example.com>') == 'ivan@example.com'
 	assert envelope_addr('"Petrov, Ivan" <ivan@example.com>') == 'ivan@example.com'
-	// Tolerate a malformed input with no closing '>' rather than panicking.
-	assert envelope_addr('Ivan <ivan@example.com') == 'ivan@example.com'
+	// Quoted local-parts may legitimately contain '<'. Without a trailing '>',
+	// the input is not an angle-addr wrapper and must pass through unchanged.
+	assert envelope_addr('"a<b"@example.com') == '"a<b"@example.com'
+	// Quoted display name and quoted local-part both containing '<'/'>'.
+	assert envelope_addr('"a<b" <"a<b"@example.com>') == '"a<b"@example.com'
+	// Escaped quote inside a quoted display name must not end the quoted run.
+	assert envelope_addr('"a\\"<b" <ivan@example.com>') == 'ivan@example.com'
+	// Malformed input (no closing '>') passes through; the server can reject.
+	assert envelope_addr('Ivan <ivan@example.com') == 'Ivan <ivan@example.com'
 }
 
 fn test_mail_message_data_preserves_display_name_in_from_header() {


### PR DESCRIPTION
## Summary

`Mail.from` / `Mail.to` are reused for both the SMTP envelope commands and the message headers, but those have different syntax rules:

- **Envelope** (`MAIL FROM:` / `RCPT TO:`, RFC 5321) — bare mailbox only.
- **Message headers** (`From:` / `To:`, RFC 5322) — may include a display name.

Today, passing `from: 'Ivan Petrov <ivan@example.com>'` emits

```
MAIL FROM: <Ivan Petrov <ivan@example.com>>
```

which servers reject, leading to `V panic: Sending mailfrom failed`.

This PR adds a small `envelope_addr` helper that returns the angle-bracketed address when present, and routes `send_mailfrom` / `send_mailto` through it. The `message_data` path is unchanged, so the `From:` / `To:` headers still preserve the display name.

I also tightened `MAIL FROM:` / `RCPT TO:` to drop the space before the `<`, matching the form most servers expect (`MAIL FROM:<addr>`); both forms are accepted in practice but the no-space form is the canonical RFC 5321 syntax.

Reported in #26862.

## Test plan

- [x] `v test vlib/net/smtp/smtp_internal_test.v` — passes (4 existing + 2 new tests).
- [x] New `test_envelope_addr_strips_display_name` covers bare addr, whitespace, `<addr>`, `Display <addr>`, quoted display name, and an unterminated input.
- [x] New `test_mail_message_data_preserves_display_name_in_from_header` confirms the `From:` header still emits `Ivan Petrov <ivan@example.com>` verbatim.