### PR TITLE
checker: support comptime fn type signature checks

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -2557,6 +2557,12 @@ pub fn (mut t Table) convert_generic_type(generic_type Type, generic_names []str
 				rtyp = rtyp.set_flag(.option_mut_param_t)
 			}
 		}
+		if typ.has_flag(.shared_f) {
+			rtyp = rtyp.set_flag(.shared_f)
+		}
+		if typ.has_flag(.atomic_f) {
+			rtyp = rtyp.set_flag(.atomic_f)
+		}
 		return rtyp
 	}
 	match mut sym.info {

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -1631,12 +1631,32 @@ fn (mut c Checker) check_compatible_types(left_type ast.Type, left_name string, 
 			return resolved_left_type.has_flag(.option) == right_type.has_flag(.option)
 				&& c.table.does_type_implement_interface(resolved_left_type, right_type)
 		}
-		if right_sym.info is ast.FnType && c.comptime.comptime_for_method_var == left_name {
+		if right_sym.info is ast.FnType && c.comptime.comptime_for_method_var != ''
+			&& c.comptime.comptime_for_method != unsafe { nil }
+			&& c.comptime.comptime_for_method_var == left_name {
 			right_fn_type := right_sym.info as ast.FnType
 			return c.table.fn_signature(right_fn_type.func,
 				skip_receiver: true
 				type_only:     true
 			) == c.table.fn_signature(c.comptime.comptime_for_method,
+				skip_receiver: true
+				type_only:     true
+			)
+		}
+		left_unaliased_type := c.table.fully_unaliased_type(resolved_left_type)
+		right_unaliased_type := c.table.fully_unaliased_type(right_type)
+		left_unaliased_sym := c.table.sym(left_unaliased_type)
+		right_unaliased_sym := c.table.sym(right_unaliased_type)
+		if left_unaliased_sym.info is ast.FnType && right_unaliased_sym.info is ast.FnType {
+			same_flags := left_unaliased_type.nr_muls() == right_unaliased_type.nr_muls()
+				&& left_unaliased_type.has_flag(.option) == right_unaliased_type.has_flag(.option)
+				&& left_unaliased_type.has_flag(.result) == right_unaliased_type.has_flag(.result)
+				&& left_unaliased_type.has_flag(.shared_f) == right_unaliased_type.has_flag(.shared_f)
+				&& left_unaliased_type.has_flag(.atomic_f) == right_unaliased_type.has_flag(.atomic_f)
+			return same_flags && c.table.fn_signature(left_unaliased_sym.info.func,
+				skip_receiver: true
+				type_only:     true
+			) == c.table.fn_signature(right_unaliased_sym.info.func,
 				skip_receiver: true
 				type_only:     true
 			)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1587,7 +1587,12 @@ fn (mut g Gen) generic_fn_name(types []ast.Type, before string) string {
 		// E.g. `neg` (a specific fn) should produce the same name as `fn(int) int`.
 		sym := g.table.sym(normalized_typ)
 		if sym.info is ast.FnType && sym.kind == .function {
-			anon_cname := 'anon_fn_${g.table.fn_type_signature(sym.info.func)}'
+			mut anon_cname := 'anon_fn_${g.table.fn_type_signature(sym.info.func)}'
+			if normalized_typ.has_flag(.shared_f) {
+				anon_cname = '__shared__${anon_cname}'
+			} else if normalized_typ.has_flag(.atomic_f) {
+				anon_cname = 'atomic_${anon_cname}'
+			}
 			if anon_cname != typ_name {
 				typ_name = anon_cname
 			}

--- a/vlib/v/parser/checks.v
+++ b/vlib/v/parser/checks.v
@@ -222,6 +222,16 @@ fn (p &Parser) is_generic_call() bool {
 		tok5 = p.peek_token(6)
 		kind5 = tok5.kind
 	}
+	if kind2 in [.key_shared, .key_atomic] && kind3 == .key_fn {
+		tok2 = tok3
+		kind2 = kind3
+		tok3 = tok4
+		kind3 = kind4
+		tok4 = tok5
+		kind4 = kind5
+		tok5 = p.peek_token(6)
+		kind5 = tok5.kind
+	}
 
 	if kind2 == .lsbr {
 		// case 1 (array or fixed array type)
@@ -229,6 +239,27 @@ fn (p &Parser) is_generic_call() bool {
 	}
 	if kind2 == .key_struct {
 		return p.is_anon_struct_generic_arg(.lpar)
+	}
+	if kind2 == .key_fn {
+		mut i := 3
+		mut nested_sbr_count := 0
+		for {
+			cur_tok := p.peek_token(i)
+			if cur_tok.kind == .eof
+				|| cur_tok.kind !in [.amp, .dot, .comma, .ellipsis, .name, .number, .lpar, .rpar, .lsbr, .rsbr, .question, .not, .key_fn, .key_mut, .key_shared, .key_atomic] {
+				break
+			}
+			if cur_tok.kind == .lsbr {
+				nested_sbr_count++
+			} else if cur_tok.kind == .rsbr {
+				if nested_sbr_count > 0 {
+					nested_sbr_count--
+				} else {
+					return p.peek_token(i + 1).kind == .lpar
+				}
+			}
+			i++
+		}
 	}
 
 	if kind2 == .name {

--- a/vlib/v/tests/comptime/comptime_if_fn_type_signature_test.v
+++ b/vlib/v/tests/comptime/comptime_if_fn_type_signature_test.v
@@ -1,0 +1,41 @@
+type IntMapper = fn (int) int
+
+type StringMapper = fn (string) string
+
+fn is_int_mapper[T]() bool {
+	$if T is fn (int) int {
+		return true
+	} $else {
+		return false
+	}
+}
+
+fn is_ref_int_mapper[T]() bool {
+	$if T is &fn (int) int {
+		return true
+	} $else {
+		return false
+	}
+}
+
+fn accepts_fixed_array_param_mapper[T]() bool {
+	return true
+}
+
+fn test_comptime_if_fn_type_signature() {
+	assert is_int_mapper[IntMapper]()
+	assert !is_int_mapper[StringMapper]()
+	assert is_int_mapper[fn (int) int]()
+	assert !is_int_mapper[&fn (int) int]()
+	assert !is_int_mapper[fn (string) string]()
+}
+
+fn test_comptime_if_fn_type_signature_with_shared_modifier() {
+	assert is_ref_int_mapper[&fn (int) int]()
+	assert !is_ref_int_mapper[shared fn (int) int]()
+	assert !is_int_mapper[atomic fn (int) int]()
+}
+
+fn test_fn_type_generic_call_detection_with_fixed_array_param() {
+	assert accepts_fixed_array_param_mapper[fn ([4]int) bool]()
+}


### PR DESCRIPTION
## Summary

This PR teaches the parser and checker to handle anonymous function types in generic/comptime type contexts:

- recognizes generic calls like `foo[fn (int) int]()`
- makes `$if T is fn (int) int` compare function type signatures, including aliases and anonymous function types
- keeps pointer/function-type modifiers distinct, so `&fn (int) int` does not match `fn (int) int`

## Root Cause

`foo[fn (int) int]()` was parsed through the generic-call heuristic before `parse_type()` could see the anonymous function type. The heuristic did not recognize `fn` as a concrete type start in that position.

For `$if T is fn (...)`, the checker compared resolved type ids. That works for many named types, but not for equivalent function signatures where one side is an alias or an anonymous function type.

## Validation

- `vlib/v/tests/comptime/comptime_if_fn_type_signature_test.v`
- `vlib/v/tests/comptime`
- `vlib/v/parser vlib/v/checker`
- `vlib/v/tests/generics`
- `git diff --check`
