### PR TITLE
checker: fix panic on cross-file fixed-array indexed by enum-cast const (fix #27078)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -121,11 +121,22 @@ fn (mut c Checker) struct_decl(mut node ast.StructDecl) {
 			sym := c.table.sym(field.typ)
 			if sym.info is ast.ArrayFixed && c.array_fixed_has_unresolved_size(sym.info) {
 				mut size_expr := unsafe { sym.info.size_expr }
+				old_typ := field.typ
 				field.typ = c.eval_array_fixed_sizes(mut size_expr, 0, sym.info.elem_type)
 				for mut symfield in struct_sym.info.fields {
 					if symfield.name == field.name {
 						symfield.typ = field.typ
 					}
+				}
+				// Overwrite the previously unresolved type symbol so that earlier
+				// expressions which captured its idx (e.g. IndexExpr.left_type from
+				// another file checked first) observe the resolved size. See #27078.
+				if old_typ.idx() != field.typ.idx() {
+					new_sym := c.table.sym(field.typ)
+					mut old_sym := c.table.type_symbols[old_typ.idx()]
+					old_sym.name = new_sym.name
+					old_sym.cname = new_sym.cname
+					old_sym.info = new_sym.info
 				}
 			}
 		}

--- a/vlib/v/tests/project_issue_27078/main.v
+++ b/vlib/v/tests/project_issue_27078/main.v
@@ -1,0 +1,7 @@
+module main
+
+fn main() {
+	mut t := TestStruct{}
+	t.list[TestEnum.one] = 1
+	assert t.list[TestEnum.one] == 1
+}

--- a/vlib/v/tests/project_issue_27078/misc.v
+++ b/vlib/v/tests/project_issue_27078/misc.v
@@ -1,0 +1,14 @@
+module main
+
+enum TestEnum {
+	one
+	two
+	_max
+}
+
+const te_max = int(TestEnum._max)
+
+struct TestStruct {
+mut:
+	list [te_max]int
+}

--- a/vlib/v/tests/project_issue_27078/v.mod
+++ b/vlib/v/tests/project_issue_27078/v.mod
@@ -1,0 +1,3 @@
+Module {
+	name: 'project_issue_27078'
+}

--- a/vlib/v/tests/project_issue_27078_run_test.v
+++ b/vlib/v/tests/project_issue_27078_run_test.v
@@ -1,0 +1,9 @@
+import os
+
+const vexe = os.quoted_path(@VEXE)
+const issue_27078_project = os.join_path(os.dir(@FILE), 'project_issue_27078')
+
+fn test_fixed_array_with_int_cast_enum_const_in_separate_file_runs() {
+	res := os.execute('${vexe} run ${os.quoted_path(issue_27078_project)}')
+	assert res.exit_code == 0, res.output
+}


### PR DESCRIPTION
Fixes #27078.

When a struct field uses a fixed-array sized by a constant whose initializer is `int(EnumVal)` (e.g. `const te_max = int(TestEnum._max)`) and the struct lives in a different `.v` file from where it is indexed, the parser cannot evaluate the size, so the field is registered with size `0`. Later, `checker.struct_decl` resolves the size by registering a new `ArrayFixed` type idx with the correct size and updates `field.typ` and `struct_sym.info.fields[i].typ`. However, any `IndexExpr.left_type` already cached on a previously-checked file still points to the original (size `0`) idx, so codegen emits `builtin__v_fixed_index(idx, 0)` and panics at runtime.

This mirrors what `Checker.update_unresolved_fixed_sizes` already does for fn return types and aliases: after registering the resolved idx, overwrite the original `TypeSymbol` in-place so any stale references see the correct size.