### PR TITLE
builder: fix cached vsh run on windows

### DIFF
--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -78,7 +78,7 @@ fn test_run_from_workdir_with_spaces() {
 	assert run_dir_res.output.trim_space() == 'Hello from a spaced path'
 }
 
-fn test_existing_vsh_executable_runs_on_second_invocation() {
+fn test_existing_vsh_executable_uses_cache_until_source_is_newer() {
 	project_dir := os.join_path(test_path, 'existing vsh executable')
 	os.rmdir_all(project_dir) or {}
 	os.mkdir_all(project_dir)!
@@ -86,7 +86,8 @@ fn test_existing_vsh_executable_runs_on_second_invocation() {
 		os.chdir(test_path) or {}
 		os.rmdir_all(project_dir) or {}
 	}
-	os.write_file(os.join_path(project_dir, 'script.vsh'), "println('Hello from cached vsh')\n")!
+	script_path := os.join_path(project_dir, 'script.vsh')
+	os.write_file(script_path, "println('Hello from cached vsh')\n")!
 	os.chdir(project_dir)!
 
 	cmd := '${os.quoted_path(vexe)} script.vsh'
@@ -100,9 +101,27 @@ fn test_existing_vsh_executable_runs_on_second_invocation() {
 	}
 	assert os.is_file(executable)
 
-	second_res := os.execute(cmd)
-	assert second_res.exit_code == 0, second_res.output
-	assert second_res.output.trim_space() == 'Hello from cached vsh'
+	warm_cache_res := os.execute(cmd)
+	assert warm_cache_res.exit_code == 0, warm_cache_res.output
+	assert warm_cache_res.output.trim_space() == 'Hello from cached vsh'
+
+	cache_stamp := os.file_last_mod_unix(executable) + 3600
+	os.utime(executable, cache_stamp, cache_stamp)!
+
+	os.write_file(script_path, "println('Hello from rebuilt vsh')\n")!
+	os.utime(script_path, cache_stamp - 1, cache_stamp - 1)!
+	assert os.file_last_mod_unix(script_path) < cache_stamp
+
+	cached_res := os.execute(cmd)
+	assert cached_res.exit_code == 0, cached_res.output
+	assert cached_res.output.trim_space() == 'Hello from cached vsh'
+
+	os.utime(script_path, cache_stamp + 60, cache_stamp + 60)!
+	assert os.file_last_mod_unix(script_path) > cache_stamp
+
+	rebuilt_res := os.execute(cmd)
+	assert rebuilt_res.exit_code == 0, rebuilt_res.output
+	assert rebuilt_res.output.trim_space() == 'Hello from rebuilt vsh'
 }
 
 fn test_file_list() {

--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -78,6 +78,33 @@ fn test_run_from_workdir_with_spaces() {
 	assert run_dir_res.output.trim_space() == 'Hello from a spaced path'
 }
 
+fn test_existing_vsh_executable_runs_on_second_invocation() {
+	project_dir := os.join_path(test_path, 'existing vsh executable')
+	os.rmdir_all(project_dir) or {}
+	os.mkdir_all(project_dir)!
+	defer {
+		os.chdir(test_path) or {}
+		os.rmdir_all(project_dir) or {}
+	}
+	os.write_file(os.join_path(project_dir, 'script.vsh'), "println('Hello from cached vsh')\n")!
+	os.chdir(project_dir)!
+
+	cmd := '${os.quoted_path(vexe)} script.vsh'
+	first_res := os.execute(cmd)
+	assert first_res.exit_code == 0, first_res.output
+	assert first_res.output.trim_space() == 'Hello from cached vsh'
+
+	mut executable := os.join_path(project_dir, 'script')
+	$if windows {
+		executable += '.exe'
+	}
+	assert os.is_file(executable)
+
+	second_res := os.execute(cmd)
+	assert second_res.exit_code == 0, second_res.output
+	assert second_res.output.trim_space() == 'Hello from cached vsh'
+}
+
 fn test_file_list() {
 	os.chdir(test_path)!
 	os.mkdir_all('filelist')!

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -119,6 +119,9 @@ fn (mut b Builder) run_compiled_executable_and_exit() {
 	if b.pref.backend == .wasm && !compiled_file.ends_with('.wasm') {
 		compiled_file += '.wasm'
 	}
+	if b.pref.backend == .c && b.pref.os == .windows && !compiled_file.ends_with('.exe') {
+		compiled_file += '.exe'
+	}
 	compiled_file = os.real_path(compiled_file)
 
 	mut run_args := []string{cap: b.pref.run_args.len + 1}


### PR DESCRIPTION
Fixes Windows `.vsh` execution when a previously built script executable already exists.

On the second invocation, V skipped rebuilding and tried to run the extensionless path via `os.new_process`, which fails on Windows after exact `CreateProcessW` binding. The run path is now normalized to `.exe` for Windows C backend executables.

Test added for running the same `.vsh` script twice.