### PR TITLE
ci: group logs sections for FreeBSD and OpenBSD

### DIFF
--- a/.github/workflows/freebsd_ci.yml
+++ b/.github/workflows/freebsd_ci.yml
@@ -45,16 +45,18 @@ jobs:
             sudo pkg install -y alsa-lib libglvnd libXi libXcursor
             # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s freebsd-ci
-            echo "### OS infos"
+            echo "::group::OS infos"
             uname -a
+            echo "::endgroup::"
+            echo "::group::Build V"
             git config --global --add safe.directory .
-            echo "### Build V"
             gmake
             sudo ./v symlink
             export VTEST_SHOW_LONGEST_BY_RUNTIME=3
             export VTEST_SHOW_LONGEST_BY_COMPTIME=3
             export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
             export VFLAGS='-cc tcc -no-retry-compilation'
+            echo "::endgroup::"
             ./v run ci/freebsd_ci.vsh all
 
   clang-freebsd:
@@ -79,16 +81,18 @@ jobs:
             sudo pkg install -y alsa-lib libglvnd libXi libXcursor
             # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s freebsd-ci
-            echo "### OS infos"
+            echo "::group::OS infos"
             uname -a
+            echo "::endgroup::"
+            echo "::group::Build V"
             git config --global --add safe.directory .
-            echo "### Build V"
             gmake
             sudo ./v symlink
             export VTEST_SHOW_LONGEST_BY_RUNTIME=3
             export VTEST_SHOW_LONGEST_BY_COMPTIME=3
             export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
             export VFLAGS='-cc clang'
+            echo "::endgroup::"
             ./v run ci/freebsd_ci.vsh all
 
   gcc-freebsd:
@@ -113,14 +117,16 @@ jobs:
             sudo pkg install -y alsa-lib libglvnd libXi libXcursor
             # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s freebsd-ci
-            echo "### OS infos"
+            echo "::group::OS infos"
             uname -a
+            echo "::endgroup::"
+            echo "::group::Build V"
             git config --global --add safe.directory .
-            echo "### Build V"
             gmake
             sudo ./v symlink
             export VTEST_SHOW_LONGEST_BY_RUNTIME=3
             export VTEST_SHOW_LONGEST_BY_COMPTIME=3
             export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
             export VFLAGS='-cc gcc'
+            echo "::endgroup::"
             ./v run ci/freebsd_ci.vsh all

--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -43,16 +43,18 @@ jobs:
             sudo pkg_add mariadb-client postgresql-client
             # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s openbsd-ci
-            echo "### OS infos"
+            echo "::group::OS infos"
             uname -a
+            echo "::endgroup::"
+            echo "::group::Build V"
             git config --global --add safe.directory .
-            echo "### Build V"
             gmake
             sudo ./v symlink
             export VTEST_SHOW_LONGEST_BY_RUNTIME=3
             export VTEST_SHOW_LONGEST_BY_COMPTIME=3
             export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
             export VFLAGS='-cc tcc -no-retry-compilation'
+            echo "::endgroup::"
             ./v run ci/openbsd_ci.vsh all
 
   clang-openbsd:
@@ -75,14 +77,17 @@ jobs:
             sudo pkg_add mariadb-client postgresql-client
             # Mandatory: hostname not set in VM => some tests fail
             sudo hostname -s openbsd-ci
-            echo "### OS infos"
+            echo "::group::OS infos"
             uname -a
+            clang -v
+            echo "::endgroup::"
+            echo "::group::Build V"
             git config --global --add safe.directory .
-            echo "### Build V"
             gmake
             sudo ./v symlink
             export VTEST_SHOW_LONGEST_BY_RUNTIME=3
             export VTEST_SHOW_LONGEST_BY_COMPTIME=3
             export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
             export VFLAGS='-cc clang'
+            echo "::endgroup::"
             ./v run ci/openbsd_ci.vsh all

--- a/ci/freebsd_ci.vsh
+++ b/ci/freebsd_ci.vsh
@@ -2,7 +2,11 @@ import os
 import common { Task, exec }
 
 fn v_doctor() {
-	println('### vdoctor')
+	if common.is_github_job {
+		println('::group::vdoctor')
+	} else {
+		println('### vdoctor')
+	}
 	dump(os.getenv('PATH'))
 	exec('v doctor')
 	if common.is_github_job {
@@ -16,63 +20,110 @@ fn v_doctor() {
 		exec('ls -la')
 		exec('git log -n1')
 		exec('cc --version')
+		println('::endgroup::')
 	}
 }
 
 fn build_v_with_prealloc() {
-	println('### Build v with prealloc')
+	if common.is_github_job {
+		println('::group::Build v with prealloc')
+	} else {
+		println('### Build v with prealloc')
+	}
 	exec('v -cg -cstrict -o vstrict1 cmd/v')
 	exec('./vstrict1 -o vprealloc -prealloc cmd/v')
 	exec('./vprealloc run examples/hello_world.v')
 	exec('./vprealloc -o v3 cmd/v')
 	exec('./v3 -o v4 cmd/v')
 	exec('./v4 -d debug_malloc -d debug_realloc -o vdebug1 cmd/v')
+	if common.is_github_job {
+		println('::endgroup::')
+	}
 }
 
 fn verify_v_test_works() {
-	println('### Verify v test')
+	if common.is_github_job {
+		println('::group::Verify v test')
+	} else {
+		println('### Verify v test')
+	}
 	exec('echo \$VFLAGS')
 	exec('v cmd/tools/test_if_v_test_system_works.v')
 	exec('./cmd/tools/test_if_v_test_system_works')
+	if common.is_github_job {
+		println('::endgroup::')
+	}
 }
 
 fn build_fast_script() {
-	println('### Build fast script')
+	if common.is_github_job {
+		println('::group::Build fast script')
+	} else {
+		println('### Build fast script')
+	}
 	exec('cd cmd/tools/fast && v fast.v')
+	if common.is_github_job {
+		println('::endgroup::')
+	}
 }
 
 fn check_math() {
-	println('### Test vlib/math')
+	if common.is_github_job {
+		println('::group::Test vlib/math')
+	} else {
+		println('### Test vlib/math')
+	}
 	exec('v -silent test vlib/math')
 	println('Test the math module, using only the pure V versions,')
 	println('                          without the .c.v overrides.')
 	exec('v -silent -exclude @vlib/math/*.c.v test vlib/math')
+	if common.is_github_job {
+		println('::endgroup::')
+	}
 }
 
 fn test_inline_assembly() {
-	println('### Test inline Assembly')
+	if common.is_github_job {
+		println('::group::Test inline Assembly')
+	} else {
+		println('### Test inline Assembly')
+	}
 	exec('v test vlib/v/slow_tests/assembly')
+	if common.is_github_job {
+		println('::endgroup::')
+	}
 }
 
 fn check_compress() {
-	println('### Test vlib/compress')
+	if common.is_github_job {
+		println('::group::Test vlib/compress')
+	} else {
+		println('### Test vlib/compress')
+	}
 	exec('v -silent test vlib/compress')
+	if common.is_github_job {
+		println('::endgroup::')
+	}
 }
 
 fn run_essential_tests() {
 	if common.is_github_job {
-		println('### Run essential tests')
+		println('::group::Run essential tests')
 		exec('VTEST_JUST_ESSENTIAL=1 v -silent test-self')
+		println('::endgroup::')
 	} else {
+		println('### Run essential tests')
 		exec('VTEST_JUST_ESSENTIAL=1 v -progress test-self')
 	}
 }
 
 fn build_examples() {
 	if common.is_github_job {
-		println('### Build examples')
+		println('::group::Build examples')
 		exec('v -W build-examples')
+		println('::endgroup::')
 	} else {
+		println('### Build examples')
 		exec('v -progress build-examples')
 	}
 }

--- a/ci/openbsd_ci.vsh
+++ b/ci/openbsd_ci.vsh
@@ -2,7 +2,11 @@ import os
 import common { Task, exec }
 
 fn v_doctor() {
-	println('### vdoctor')
+	if common.is_github_job {
+		println('::group::vdoctor')
+	} else {
+		println('### vdoctor')
+	}
 	dump(os.getenv('PATH'))
 	exec('v doctor')
 	if common.is_github_job {
@@ -16,63 +20,110 @@ fn v_doctor() {
 		exec('ls -la')
 		exec('git log -n1')
 		exec('cc --version')
+		println('::endgroup::')
 	}
 }
 
 fn build_v_with_prealloc() {
-	println('### Build v with prealloc')
+	if common.is_github_job {
+		println('::group::Build v with prealloc')
+	} else {
+		println('### Build v with prealloc')
+	}
 	exec('v -cg -cstrict -o vstrict1 cmd/v')
 	exec('./vstrict1 -o vprealloc -prealloc cmd/v')
 	exec('./vprealloc run examples/hello_world.v')
 	exec('./vprealloc -o v3 cmd/v')
 	exec('./v3 -o v4 cmd/v')
 	exec('./v4 -d debug_malloc -d debug_realloc -o vdebug1 cmd/v')
+	if common.is_github_job {
+		println('::endgroup::')
+	}
 }
 
 fn verify_v_test_works() {
-	println('### Verify v test')
+	if common.is_github_job {
+		println('::group::Verify v test')
+	} else {
+		println('### Verify v test')
+	}
 	exec('echo \$VFLAGS')
 	exec('v cmd/tools/test_if_v_test_system_works.v')
 	exec('./cmd/tools/test_if_v_test_system_works')
+	if common.is_github_job {
+		println('::endgroup::')
+	}
 }
 
 fn build_fast_script() {
-	println('### Build fast script')
+	if common.is_github_job {
+		println('::group::Build fast script')
+	} else {
+		println('### Build fast script')
+	}
 	exec('cd cmd/tools/fast && v fast.v')
+	if common.is_github_job {
+		println('::endgroup::')
+	}
 }
 
 fn check_math() {
-	println('### Test vlib/math')
+	if common.is_github_job {
+		println('::group::Test vlib/math')
+	} else {
+		println('### Test vlib/math')
+	}
 	exec('v -silent test vlib/math')
 	println('Test the math module, using only the pure V versions,')
 	println('                          without the .c.v overrides.')
 	exec('v -silent -exclude @vlib/math/*.c.v test vlib/math')
+	if common.is_github_job {
+		println('::endgroup::')
+	}
 }
 
 fn check_compress() {
-	println('### Test vlib/compress')
+	if common.is_github_job {
+		println('::group::Test vlib/compress')
+	} else {
+		println('### Test vlib/compress')
+	}
 	exec('v -silent test vlib/compress')
+	if common.is_github_job {
+		println('::endgroup::')
+	}
 }
 
 fn test_inline_assembly() {
-	println('### Test inline Assembly')
+	if common.is_github_job {
+		println('::group::Test inline Assembly')
+	} else {
+		println('### Test inline Assembly')
+	}
 	exec('v test vlib/v/slow_tests/assembly')
+	if common.is_github_job {
+		println('::endgroup::')
+	}
 }
 
 fn run_essential_tests() {
 	if common.is_github_job {
-		println('### Run essential tests')
+		println('::group::Run essential tests')
 		exec('VTEST_JUST_ESSENTIAL=1 v -silent test-self')
+		println('::endgroup::')
 	} else {
+		println('### Run essential tests')
 		exec('VTEST_JUST_ESSENTIAL=1 v -progress test-self')
 	}
 }
 
 fn build_examples() {
 	if common.is_github_job {
-		println('### Build examples')
+		println('::group::Build examples')
 		exec('v -W build-examples')
+		println('::endgroup::')
 	} else {
+		println('### Build examples')
 		exec('v -progress build-examples')
 	}
 }


### PR DESCRIPTION
In FreeBSD/OpenBSD workflow, group logs sections for tests => easier triage if failure.

- Successful run of "CI FreeBSD" workflow with this change: https://github.com/lcheylus/v/actions/runs/25422517152
- Successful run of "CI OpenBSD" workflow with this change: https://github.com/lcheylus/v/actions/runs/25422503071