### PR TITLE
crypto.sha3: fix aliasing in write()

### DIFF
--- a/vlib/crypto/sha3/sha3.v
+++ b/vlib/crypto/sha3/sha3.v
@@ -273,7 +273,7 @@ pub fn (mut d Digest) write(data []u8) ! {
 	}
 
 	if bytes_remaining.len > 0 {
-		d.input_buffer = bytes_remaining
+		d.input_buffer = bytes_remaining.clone()
 	}
 }
 


### PR DESCRIPTION
Fixes #27040 

Real bug, mandatory commit.
This code best demonstrates the bug and that's why `write()` captures bytes that are no longer needed:
```v
fn main() {
	mut a := []u8{len: 8, init: index}
	mut b := []u8{}
	unsafe { b = a }
	a[5] = 255
	println(a)
	println(b)
}
```
I'm already testing this in my external tests, but haven't caught it.
In the future, the testing needs to be modified and improved.