### PR TITLE
strconv: fix atou64 silently wrapping on overflow

### DIFF
--- a/vlib/strconv/atou.v
+++ b/vlib/strconv/atou.v
@@ -55,11 +55,14 @@ fn atou_common(s string, type_max u64) !u64 {
 			}
 			underscored = false
 
-			oldx := x
-			x = (x * 10) + u64(c)
-			if x > type_max || oldx > x {
+			if x > type_max / 10 {
 				return error('strconv.atou: parsing "${s}": integer overflow')
 			}
+			x *= 10
+			if x > type_max - u64(c) {
+				return error('strconv.atou: parsing "${s}": integer overflow')
+			}
+			x += u64(c)
 		}
 	}
 	return x

--- a/vlib/strconv/atou_test.v
+++ b/vlib/strconv/atou_test.v
@@ -281,6 +281,7 @@ fn test_atou64() {
 	ko := [
 		'18446744073709551616', // Overflow by one
 		'+184467440214748364773709551615', // Large overflow .
+		'430943843908439083411', // Overflow that wraps without falling under oldx (issue #27102).
 	]
 
 	for v in ko {


### PR DESCRIPTION
`strconv.atou64` should return an error for any input larger than `max_u64`. Issue #27102 shows it silently returns a wrong value: `atou64("430943843908439083411")!` yields `6668730213119396243` instead of failing.

The shared helper `atou_common` checks overflow *after* `x = x * 10 + c` with `x > type_max || oldx > x`. That works for `u8`/`u16`/`u32` (where `type_max < max_u64`), but for `u64` the first comparison is unreachable and the second misses overflows whose wrapped result lands above `oldx` — which is the case here.

The fix checks *before* each step:

```
if x > type_max / 10 { return error(...) }
x *= 10
if x > type_max - u64(c) { return error(...) }
x += u64(c)
```

This catches every overflow regardless of `type_max`, with no behaviour change for the smaller types.

A regression test for the issue's input is added to `test_atou64`. Full `vlib/strconv/` suite passes, downstream consumers too, `v fmt -verify` is clean.

Fixes #27102.