### PR TITLE
fmt: keep enum name when stringifying fixed-array size expressions

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1700,11 +1700,9 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 			elem_str := t.type_to_str_using_aliases(info.elem_type, import_aliases)
 			if info.size_expr is EmptyExpr {
 				res = '[${info.size}]${elem_str}'
-			} else if info.size_expr is Ident {
-				size_str := t.shorten_user_defined_typenames(info.size_expr.name, import_aliases)
-				res = '[${size_str}]${elem_str}'
 			} else {
-				res = '[${info.size_expr}]${elem_str}'
+				size_str := t.fixed_array_size_expr_to_str(info.size_expr, import_aliases)
+				res = '[${size_str}]${elem_str}'
 			}
 		}
 		.chan {
@@ -1856,6 +1854,34 @@ pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]
 		res = '!${res}'
 	}
 	return res
+}
+
+// fixed_array_size_expr_to_str renders a fixed-array size expression preserving
+// fully-qualified enum names. The default `Expr.str()` drops the enum name on
+// `EnumVal` (returning `.value`), which produces invalid output when the size
+// is something like `int(TestEnum._max)` because the enum type cannot be
+// inferred from context inside the array brackets.
+fn (t &Table) fixed_array_size_expr_to_str(expr Expr, import_aliases map[string]string) string {
+	match expr {
+		CastExpr {
+			type_name := t.shorten_user_defined_typenames(t.type_to_str_using_aliases(expr.typ,
+				import_aliases), import_aliases)
+			return '${type_name}(${t.fixed_array_size_expr_to_str(expr.expr, import_aliases)})'
+		}
+		EnumVal {
+			if expr.enum_name != '' {
+				name := t.shorten_user_defined_typenames(expr.enum_name, import_aliases)
+				return '${name}.${expr.val}'
+			}
+			return '.${expr.val}'
+		}
+		Ident {
+			return t.shorten_user_defined_typenames(expr.name, import_aliases)
+		}
+		else {
+			return expr.str()
+		}
+	}
 }
 
 fn (t &Table) shorten_user_defined_typenames(original_name string, import_aliases map[string]string) string {

--- a/vlib/v/fmt/tests/struct_fixed_array_enum_cast_keep.vv
+++ b/vlib/v/fmt/tests/struct_fixed_array_enum_cast_keep.vv
@@ -1,0 +1,16 @@
+module main
+
+enum TestEnum {
+	one
+	two
+	_max
+}
+
+struct Test1 {
+	list [int(TestEnum._max)]int
+}
+
+fn main() {
+	t := Test1{}
+	assert t.list.len == int(TestEnum._max)
+}


### PR DESCRIPTION
As mentioned in issue #27100, `v fmt` rewrites `[int(TestEnum._max)]int` as `[int(._max)]int`, dropping the enum name and producing a file that no longer compiles.

In `Table.type_to_str_using_aliases` (`vlib/v/ast/types.v`), the `array_fixed` branch rendered the size expression with `'${info.size_expr}'`, which dispatches to the sum-type `Expr.str()`. For `EnumVal`, that method returns only `.${val}` — the short form is fine where the enum type is inferable, but invalid inside `int(...)` since the parser has no context to resolve `.foo` against.

The fix adds a small helper `fixed_array_size_expr_to_str` used by the `array_fixed` branch. It recurses through `CastExpr`, handles `Ident` via `shorten_user_defined_typenames`, and for `EnumVal` emits the qualified `EnumName.value` form whenever `enum_name` is set (falling back to `.value` for the bare-form case where the parser left it empty). Anything else falls back to `Expr.str()`. The previous inline `Ident` branch is folded into the helper so all size-expr rendering lives in one place.

A `_keep.vv` regression test covers the issue's reproducer. `vlib/v/fmt/` and `vlib/v/tests/enums/` suites pass.

Fixes #27100