### PR TITLE
net.http.signature: add HTTP Message Signatures (RFC 9421) module

### DIFF
--- a/examples/http_signature.v
+++ b/examples/http_signature.v
@@ -1,0 +1,88 @@
+// HTTP Message Signatures example: signs an outbound request with
+// Ed25519 (using the RFC 9421 §B.1.4 test key in PEM form) and then
+// verifies the result with the matching public key.
+//
+// Run with:  v run examples/http_signature.v
+import net.http
+import net.http.signature
+
+const ed25519_private_pem = '-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF
+-----END PRIVATE KEY-----'
+
+const ed25519_public_pem = '-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAJrQLj5P/89iXES9+vFgrIy29clF9CC/oPPsw3c5D0bs=
+-----END PUBLIC KEY-----'
+
+fn main() {
+	demo_sign_and_verify_request()!
+	demo_two_signatures()!
+}
+
+// demo_sign_and_verify_request walks through the common path: the
+// client signs a request before sending; the server verifies before
+// processing.
+fn demo_sign_and_verify_request() ! {
+	priv := signature.Key.from_pem(ed25519_private_pem)!.with_keyid('test-key-ed25519')
+	pub_key := signature.Key.from_pem(ed25519_public_pem)!
+
+	mut req := http.Request{
+		method: .post
+		url:    'https://example.com/foo'
+	}
+	req.header.add_custom('Host', 'example.com')!
+	req.header.add_custom('Date', 'Tue, 20 Apr 2021 02:07:55 GMT')!
+	req.header.add_custom('Content-Type', 'application/json')!
+	req.header.add_custom('Content-Length', '18')!
+
+	signature.sign_request(mut req, priv,
+		components: ['date', '@method', '@path', '@authority', 'content-type', 'content-length']
+		created:    1618884473
+		label:      'sig-b26'
+	)!
+
+	si := req.header.get_custom('Signature-Input') or { '' }
+	sig := req.header.get_custom('Signature') or { '' }
+	println('Signature-Input: ${si}')
+	println('Signature:       ${sig}')
+
+	signature.verify_request(req, pub_key)!
+	println('  ✓ verified with the matching public key')
+}
+
+// demo_two_signatures shows a TLS-terminating proxy scenario: the
+// client signs the original request, the proxy adds its own signature
+// over the same message under a different label, and the backend
+// verifies both independently.
+fn demo_two_signatures() ! {
+	client_key := signature.Key.hmac_sha256('client-shared-secret'.bytes()).with_keyid('client')
+	proxy_key := signature.Key.hmac_sha256('proxy-shared-secret'.bytes()).with_keyid('proxy')
+
+	mut req := http.Request{
+		method: .get
+		url:    'https://api.example.com/orders/42'
+	}
+	req.header.add_custom('Host', 'api.example.com')!
+	req.header.add_custom('Date', 'Tue, 20 Apr 2021 02:07:55 GMT')!
+
+	// `created` defaults to `time.now().unix()` when not set —
+	// fine for a real client. Pinned here so the example output
+	// is reproducible across runs.
+	signature.sign_request(mut req, client_key,
+		components: ['@method', '@target-uri', 'date']
+		label:      'client-sig'
+		created:    1618884473
+	)!
+	signature.sign_request(mut req, proxy_key,
+		components: ['@method', '@authority', 'date']
+		label:      'proxy-sig'
+		created:    1618884480
+	)!
+
+	si := req.header.get_custom('Signature-Input') or { '' }
+	println('\nMerged Signature-Input: ${si}')
+
+	signature.verify_request(req, client_key, label: 'client-sig')!
+	signature.verify_request(req, proxy_key, label: 'proxy-sig')!
+	println('  ✓ both labelled signatures verified')
+}

--- a/examples/http_signature.v
+++ b/examples/http_signature.v
@@ -1,0 +1,89 @@
+// vtest build: present_openssl? && !(openbsd && gcc) && !(sanitize-memory-clang || docker-ubuntu-musl)
+// HTTP Message Signatures example: signs an outbound request with
+// Ed25519 (using the RFC 9421 §B.1.4 test key in PEM form) and then
+// verifies the result with the matching public key.
+//
+// Run with:  v run examples/http_signature.v
+import net.http
+import net.http.signature
+
+const ed25519_private_pem = '-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF
+-----END PRIVATE KEY-----'
+
+const ed25519_public_pem = '-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAJrQLj5P/89iXES9+vFgrIy29clF9CC/oPPsw3c5D0bs=
+-----END PUBLIC KEY-----'
+
+fn main() {
+	demo_sign_and_verify_request()!
+	demo_two_signatures()!
+}
+
+// demo_sign_and_verify_request walks through the common path: the
+// client signs a request before sending; the server verifies before
+// processing.
+fn demo_sign_and_verify_request() ! {
+	priv := signature.Key.from_pem(ed25519_private_pem)!.with_keyid('test-key-ed25519')
+	pub_key := signature.Key.from_pem(ed25519_public_pem)!
+
+	mut req := http.Request{
+		method: .post
+		url:    'https://example.com/foo'
+	}
+	req.header.add_custom('Host', 'example.com')!
+	req.header.add_custom('Date', 'Tue, 20 Apr 2021 02:07:55 GMT')!
+	req.header.add_custom('Content-Type', 'application/json')!
+	req.header.add_custom('Content-Length', '18')!
+
+	signature.sign_request(mut req, priv,
+		components: ['date', '@method', '@path', '@authority', 'content-type', 'content-length']
+		created:    1618884473
+		label:      'sig-b26'
+	)!
+
+	si := req.header.get_custom('Signature-Input') or { '' }
+	sig := req.header.get_custom('Signature') or { '' }
+	println('Signature-Input: ${si}')
+	println('Signature:       ${sig}')
+
+	signature.verify_request(req, pub_key)!
+	println('  ✓ verified with the matching public key')
+}
+
+// demo_two_signatures shows a TLS-terminating proxy scenario: the
+// client signs the original request, the proxy adds its own signature
+// over the same message under a different label, and the backend
+// verifies both independently.
+fn demo_two_signatures() ! {
+	client_key := signature.Key.hmac_sha256('client-shared-secret'.bytes()).with_keyid('client')
+	proxy_key := signature.Key.hmac_sha256('proxy-shared-secret'.bytes()).with_keyid('proxy')
+
+	mut req := http.Request{
+		method: .get
+		url:    'https://api.example.com/orders/42'
+	}
+	req.header.add_custom('Host', 'api.example.com')!
+	req.header.add_custom('Date', 'Tue, 20 Apr 2021 02:07:55 GMT')!
+
+	// `created` defaults to `time.now().unix()` when not set —
+	// fine for a real client. Pinned here so the example output
+	// is reproducible across runs.
+	signature.sign_request(mut req, client_key,
+		components: ['@method', '@target-uri', 'date']
+		label:      'client-sig'
+		created:    1618884473
+	)!
+	signature.sign_request(mut req, proxy_key,
+		components: ['@method', '@authority', 'date']
+		label:      'proxy-sig'
+		created:    1618884480
+	)!
+
+	si := req.header.get_custom('Signature-Input') or { '' }
+	println('\nMerged Signature-Input: ${si}')
+
+	signature.verify_request(req, client_key, label: 'client-sig')!
+	signature.verify_request(req, proxy_key, label: 'proxy-sig')!
+	println('  ✓ both labelled signatures verified')
+}

--- a/examples/http_signature.v
+++ b/examples/http_signature.v
@@ -56,8 +56,8 @@ fn demo_sign_and_verify_request() ! {
 // over the same message under a different label, and the backend
 // verifies both independently.
 fn demo_two_signatures() ! {
-	client_key := signature.Key.hmac_sha256('client-shared-secret'.bytes()).with_keyid('client')
-	proxy_key := signature.Key.hmac_sha256('proxy-shared-secret'.bytes()).with_keyid('proxy')
+	client_key := signature.Key.hmac_sha256('client-shared-secret'.bytes())!.with_keyid('client')
+	proxy_key := signature.Key.hmac_sha256('proxy-shared-secret'.bytes())!.with_keyid('proxy')
 
 	mut req := http.Request{
 		method: .get

--- a/examples/http_signature.v
+++ b/examples/http_signature.v
@@ -47,7 +47,10 @@ fn demo_sign_and_verify_request() ! {
 	println('Signature-Input: ${si}')
 	println('Signature:       ${sig}')
 
-	signature.verify_request(req, pub_key)!
+	signature.verify_request(req, pub_key,
+		required_components: ['date', '@method', '@path', '@authority', 'content-type',
+			'content-length']
+	)!
 	println('  ✓ verified with the matching public key')
 }
 
@@ -83,7 +86,13 @@ fn demo_two_signatures() ! {
 	si := req.header.get_custom('Signature-Input') or { '' }
 	println('\nMerged Signature-Input: ${si}')
 
-	signature.verify_request(req, client_key, label: 'client-sig')!
-	signature.verify_request(req, proxy_key, label: 'proxy-sig')!
+	signature.verify_request(req, client_key,
+		label:               'client-sig'
+		required_components: ['@method', '@target-uri', 'date']
+	)!
+	signature.verify_request(req, proxy_key,
+		label:               'proxy-sig'
+		required_components: ['@method', '@authority', 'date']
+	)!
 	println('  ✓ both labelled signatures verified')
 }

--- a/vlib/net/http/backend.c.v
+++ b/vlib/net/http/backend.c.v
@@ -15,7 +15,7 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string,
 
 fn net_ssl_do(req &Request, port int, method Method, host_name string, path string, data string, header Header) !Response {
 	mut retries := 0
-	req_headers := req.build_request_headers_with(method, host_name, port, path, data, header)
+	req_headers := req.build_request_headers_with(method, host_name, port, 443, path, data, header)
 	$if trace_http_request ? {
 		eprint('> ')
 		eprint(req_headers)

--- a/vlib/net/http/backend.c.v
+++ b/vlib/net/http/backend.c.v
@@ -15,7 +15,7 @@ fn (req &Request) ssl_do(port int, method Method, host_name string, path string,
 
 fn net_ssl_do(req &Request, port int, method Method, host_name string, path string, data string, header Header) !Response {
 	mut retries := 0
-	req_headers := req.build_request_headers_with(method, host_name, port, 443, path, data, header)
+	req_headers := req.build_request_headers_with(method, host_name, port, 443, path, data, header)!
 	$if trace_http_request ? {
 		eprint('> ')
 		eprint(req_headers)

--- a/vlib/net/http/backend_vschannel_windows.c.v
+++ b/vlib/net/http/backend_vschannel_windows.c.v
@@ -45,7 +45,7 @@ fn vschannel_h1_do(req &Request, port int, method Method, host_name string, path
 	C.vschannel_init(&ctx, C.BOOL(if req.validate { 1 } else { 0 }))
 	mut buff := unsafe { malloc_noscan(C.vsc_init_resp_buff_size) }
 	addr := host_name
-	sdata := req.build_request_headers_with(method, host_name, port, path, data, header)
+	sdata := req.build_request_headers_with(method, host_name, port, 443, path, data, header)
 	$if trace_http_request ? {
 		eprintln('> ${sdata}')
 	}
@@ -60,7 +60,7 @@ fn vschannel_h1_do(req &Request, port int, method Method, host_name string, path
 // did not negotiate `h2`. It consumes (and cleans up) `ctx`.
 fn (req &Request) vschannel_h1_on_open(ctx &C.TlsContext, method Method, host_name string, port int, path string, data string, header Header) !Response {
 	mut buff := unsafe { malloc_noscan(C.vsc_init_resp_buff_size) }
-	sdata := req.build_request_headers_with(method, host_name, port, path, data, header)
+	sdata := req.build_request_headers_with(method, host_name, port, 443, path, data, header)
 	$if trace_http_request ? {
 		eprintln('> ${sdata}')
 	}

--- a/vlib/net/http/backend_vschannel_windows.c.v
+++ b/vlib/net/http/backend_vschannel_windows.c.v
@@ -45,7 +45,7 @@ fn vschannel_h1_do(req &Request, port int, method Method, host_name string, path
 	C.vschannel_init(&ctx, C.BOOL(if req.validate { 1 } else { 0 }))
 	mut buff := unsafe { malloc_noscan(C.vsc_init_resp_buff_size) }
 	addr := host_name
-	sdata := req.build_request_headers_with(method, host_name, port, 443, path, data, header)
+	sdata := req.build_request_headers_with(method, host_name, port, 443, path, data, header)!
 	$if trace_http_request ? {
 		eprintln('> ${sdata}')
 	}
@@ -60,7 +60,7 @@ fn vschannel_h1_do(req &Request, port int, method Method, host_name string, path
 // did not negotiate `h2`. It consumes (and cleans up) `ctx`.
 fn (req &Request) vschannel_h1_on_open(ctx &C.TlsContext, method Method, host_name string, port int, path string, data string, header Header) !Response {
 	mut buff := unsafe { malloc_noscan(C.vsc_init_resp_buff_size) }
-	sdata := req.build_request_headers_with(method, host_name, port, 443, path, data, header)
+	sdata := req.build_request_headers_with(method, host_name, port, 443, path, data, header)!
 	$if trace_http_request ? {
 		eprintln('> ${sdata}')
 	}

--- a/vlib/net/http/build_request_headers_test.v
+++ b/vlib/net/http/build_request_headers_test.v
@@ -35,6 +35,13 @@ fn test_build_request_headers_semicolon_combines_case_insensitive_cookie_fields(
 	assert headers.contains('Cookie: a=1; b=2\r\n')
 }
 
+fn test_build_request_headers_preserves_present_empty_cookie_field() {
+	mut req := Request{}
+	req.header.add_custom('Cookie', '')!
+	headers := req.build_request_headers(.get, 'localhost', 80, '/')
+	assert headers.contains('Cookie: \r\n')
+}
+
 fn test_build_request_headers_deduplicates_header_name_casing() {
 	mut req := Request{}
 	req.header.add_custom('X-Foo', 'a')!

--- a/vlib/net/http/build_request_headers_test.v
+++ b/vlib/net/http/build_request_headers_test.v
@@ -26,6 +26,22 @@ fn test_build_request_headers_trims_repeated_fields_before_combining() {
 	assert headers.contains('X-Foo: a, b\r\n')
 }
 
+fn test_build_request_headers_preserves_trailing_empty_repeated_field() {
+	mut req := Request{}
+	req.header.add_custom('X-Foo', 'a')!
+	req.header.add_custom('X-Foo', '')!
+	headers := req.build_request_headers(.get, 'localhost', 80, '/')
+	assert headers.count('X-Foo:') == 2
+	parsed := parse_request_str(headers)!
+	assert parsed.header.custom_values('X-Foo') == ['a', '']
+}
+
+fn test_build_request_headers_does_not_add_content_length_to_trace() {
+	req := Request{}
+	headers := req.build_request_headers(.trace, 'localhost', 80, '/')
+	assert !headers.contains('Content-Length:')
+}
+
 fn test_build_request_headers_semicolon_combines_case_insensitive_cookie_fields() {
 	mut req := Request{}
 	req.header.add_custom('cookie', 'a=1')!

--- a/vlib/net/http/build_request_headers_test.v
+++ b/vlib/net/http/build_request_headers_test.v
@@ -9,3 +9,11 @@ fn test_build_request_headers_with_empty_body_adds_content_length_zero() {
 	headers := req.build_request_headers(.post, 'localhost', 80, '/')
 	assert headers.contains('Content-Length: 0\r\n')
 }
+
+fn test_build_request_headers_comma_combines_repeated_fields() {
+	mut req := Request{}
+	req.header.add_custom('Accept', 'text/html')!
+	req.header.add_custom('Accept', 'application/json')!
+	headers := req.build_request_headers(.get, 'localhost', 80, '/')
+	assert headers.contains('Accept: text/html, application/json\r\n')
+}

--- a/vlib/net/http/build_request_headers_test.v
+++ b/vlib/net/http/build_request_headers_test.v
@@ -26,3 +26,12 @@ fn test_build_request_headers_semicolon_combines_case_insensitive_cookie_fields(
 	assert headers.count('Cookie:') == 1
 	assert headers.contains('Cookie: a=1; b=2\r\n')
 }
+
+fn test_build_request_headers_deduplicates_header_name_casing() {
+	mut req := Request{}
+	req.header.add_custom('X-Foo', 'a')!
+	req.header.add_custom('x-foo', 'b')!
+	headers := req.build_request_headers(.get, 'localhost', 80, '/')
+	assert headers.count('X-Foo:') == 1
+	assert headers.contains('X-Foo: a, b\r\n')
+}

--- a/vlib/net/http/build_request_headers_test.v
+++ b/vlib/net/http/build_request_headers_test.v
@@ -18,6 +18,14 @@ fn test_build_request_headers_comma_combines_repeated_fields() {
 	assert headers.contains('Accept: text/html, application/json\r\n')
 }
 
+fn test_build_request_headers_trims_repeated_fields_before_combining() {
+	mut req := Request{}
+	req.header.add_custom('X-Foo', ' a ')!
+	req.header.add_custom('X-Foo', ' b ')!
+	headers := req.build_request_headers(.get, 'localhost', 80, '/')
+	assert headers.contains('X-Foo: a, b\r\n')
+}
+
 fn test_build_request_headers_semicolon_combines_case_insensitive_cookie_fields() {
 	mut req := Request{}
 	req.header.add_custom('cookie', 'a=1')!

--- a/vlib/net/http/build_request_headers_test.v
+++ b/vlib/net/http/build_request_headers_test.v
@@ -50,3 +50,19 @@ fn test_build_request_headers_deduplicates_header_name_casing() {
 	assert headers.count('X-Foo:') == 1
 	assert headers.contains('X-Foo: a, b\r\n')
 }
+
+fn test_build_request_headers_preserves_nondefault_port_for_scheme() {
+	req := Request{}
+	http_headers := req.build_request_headers_with(.get, 'example.com', 443, 80, '/', '',
+		new_header())
+	assert http_headers.contains('Host: example.com:443\r\n')
+	https_headers := req.build_request_headers_with(.get, 'example.com', 80, 443, '/', '',
+		new_header())
+	assert https_headers.contains('Host: example.com:80\r\n')
+}
+
+fn test_build_request_headers_brackets_ipv6_authority() {
+	req := Request{}
+	headers := req.build_request_headers_with(.get, '2001:db8::1', 443, 443, '/', '', new_header())
+	assert headers.contains('Host: [2001:db8::1]\r\n')
+}

--- a/vlib/net/http/build_request_headers_test.v
+++ b/vlib/net/http/build_request_headers_test.v
@@ -17,3 +17,12 @@ fn test_build_request_headers_comma_combines_repeated_fields() {
 	headers := req.build_request_headers(.get, 'localhost', 80, '/')
 	assert headers.contains('Accept: text/html, application/json\r\n')
 }
+
+fn test_build_request_headers_semicolon_combines_case_insensitive_cookie_fields() {
+	mut req := Request{}
+	req.header.add_custom('cookie', 'a=1')!
+	req.header.add_custom('cookie', 'b=2')!
+	headers := req.build_request_headers(.get, 'localhost', 80, '/')
+	assert headers.count('Cookie:') == 1
+	assert headers.contains('Cookie: a=1; b=2\r\n')
+}

--- a/vlib/net/http/build_request_headers_test.v
+++ b/vlib/net/http/build_request_headers_test.v
@@ -6,7 +6,7 @@ fn test_build_request_headers_with_empty_body_adds_content_length_zero() {
 	// Build the headers for it. Ensure that Content-Length: 0 is added
 	// for requests without a body, which is required by some servers.
 	// We use a POST request, as it is most likely to be affected by this.
-	headers := req.build_request_headers(.post, 'localhost', 80, '/')
+	headers := req.build_request_headers(.post, 'localhost', 80, '/')!
 	assert headers.contains('Content-Length: 0\r\n')
 }
 
@@ -14,7 +14,7 @@ fn test_build_request_headers_comma_combines_repeated_fields() {
 	mut req := Request{}
 	req.header.add_custom('Accept', 'text/html')!
 	req.header.add_custom('Accept', 'application/json')!
-	headers := req.build_request_headers(.get, 'localhost', 80, '/')
+	headers := req.build_request_headers(.get, 'localhost', 80, '/')!
 	assert headers.contains('Accept: text/html, application/json\r\n')
 }
 
@@ -22,7 +22,7 @@ fn test_build_request_headers_trims_repeated_fields_before_combining() {
 	mut req := Request{}
 	req.header.add_custom('X-Foo', ' a ')!
 	req.header.add_custom('X-Foo', ' b ')!
-	headers := req.build_request_headers(.get, 'localhost', 80, '/')
+	headers := req.build_request_headers(.get, 'localhost', 80, '/')!
 	assert headers.contains('X-Foo: a, b\r\n')
 }
 
@@ -30,7 +30,7 @@ fn test_build_request_headers_preserves_trailing_empty_repeated_field() {
 	mut req := Request{}
 	req.header.add_custom('X-Foo', 'a')!
 	req.header.add_custom('X-Foo', '')!
-	headers := req.build_request_headers(.get, 'localhost', 80, '/')
+	headers := req.build_request_headers(.get, 'localhost', 80, '/')!
 	assert headers.count('X-Foo:') == 2
 	parsed := parse_request_str(headers)!
 	assert parsed.header.custom_values('X-Foo') == ['a', '']
@@ -38,15 +38,25 @@ fn test_build_request_headers_preserves_trailing_empty_repeated_field() {
 
 fn test_build_request_headers_does_not_add_content_length_to_trace() {
 	req := Request{}
-	headers := req.build_request_headers(.trace, 'localhost', 80, '/')
+	headers := req.build_request_headers(.trace, 'localhost', 80, '/')!
 	assert !headers.contains('Content-Length:')
+}
+
+fn test_build_request_headers_rejects_trace_body() {
+	req := Request{
+		method: .trace
+		data:   'body'
+	}
+	if _ := req.build_request_headers(.trace, 'localhost', 80, '/') {
+		assert false, 'TRACE request bodies must not be serialized without framing'
+	}
 }
 
 fn test_build_request_headers_semicolon_combines_case_insensitive_cookie_fields() {
 	mut req := Request{}
 	req.header.add_custom('cookie', 'a=1')!
 	req.header.add_custom('cookie', 'b=2')!
-	headers := req.build_request_headers(.get, 'localhost', 80, '/')
+	headers := req.build_request_headers(.get, 'localhost', 80, '/')!
 	assert headers.count('Cookie:') == 1
 	assert headers.contains('Cookie: a=1; b=2\r\n')
 }
@@ -54,7 +64,7 @@ fn test_build_request_headers_semicolon_combines_case_insensitive_cookie_fields(
 fn test_build_request_headers_preserves_present_empty_cookie_field() {
 	mut req := Request{}
 	req.header.add_custom('Cookie', '')!
-	headers := req.build_request_headers(.get, 'localhost', 80, '/')
+	headers := req.build_request_headers(.get, 'localhost', 80, '/')!
 	assert headers.contains('Cookie: \r\n')
 }
 
@@ -62,7 +72,7 @@ fn test_build_request_headers_deduplicates_header_name_casing() {
 	mut req := Request{}
 	req.header.add_custom('X-Foo', 'a')!
 	req.header.add_custom('x-foo', 'b')!
-	headers := req.build_request_headers(.get, 'localhost', 80, '/')
+	headers := req.build_request_headers(.get, 'localhost', 80, '/')!
 	assert headers.count('X-Foo:') == 1
 	assert headers.contains('X-Foo: a, b\r\n')
 }
@@ -70,15 +80,15 @@ fn test_build_request_headers_deduplicates_header_name_casing() {
 fn test_build_request_headers_preserves_nondefault_port_for_scheme() {
 	req := Request{}
 	http_headers := req.build_request_headers_with(.get, 'example.com', 443, 80, '/', '',
-		new_header())
+		new_header())!
 	assert http_headers.contains('Host: example.com:443\r\n')
 	https_headers := req.build_request_headers_with(.get, 'example.com', 80, 443, '/', '',
-		new_header())
+		new_header())!
 	assert https_headers.contains('Host: example.com:80\r\n')
 }
 
 fn test_build_request_headers_brackets_ipv6_authority() {
 	req := Request{}
-	headers := req.build_request_headers_with(.get, '2001:db8::1', 443, 443, '/', '', new_header())
+	headers := req.build_request_headers_with(.get, '2001:db8::1', 443, 443, '/', '', new_header())!
 	assert headers.contains('Host: [2001:db8::1]\r\n')
 }

--- a/vlib/net/http/h2_client.v
+++ b/vlib/net/http/h2_client.v
@@ -36,10 +36,10 @@ fn (req &Request) to_h2_request(method Method, authority string, path string, da
 		}
 	}
 	mut extra := []H2HeaderField{}
-	if !header.contains(.user_agent) && req.user_agent != '' {
+	if !header.contains(.user_agent) {
 		extra << H2HeaderField{'user-agent', req.user_agent}
 	}
-	if data.len > 0 && !header.contains(.content_length) {
+	if !header.contains(.content_length) {
 		extra << H2HeaderField{'content-length', data.len.str()}
 	}
 	for key in header.keys() {
@@ -59,15 +59,9 @@ fn (req &Request) to_h2_request(method Method, authority string, path string, da
 	}
 	// Cookies: the request's own cookie map plus any Cookie header values,
 	// joined into one field (RFC 7540 Section 8.1.2.5 also allows splitting).
-	mut cookie_parts := []string{}
-	for k, v in req.cookies {
-		cookie_parts << '${k}=${v}'
-	}
-	for cv in header.values(.cookie) {
-		cookie_parts << cv
-	}
-	if cookie_parts.len > 0 {
-		extra << H2HeaderField{'cookie', cookie_parts.join('; ')}
+	cookie_value := req.cookie_header_value_with_header(header)
+	if cookie_value != '' {
+		extra << H2HeaderField{'cookie', cookie_value}
 	}
 	return H2ClientRequest{
 		method:    method.str()

--- a/vlib/net/http/h2_client.v
+++ b/vlib/net/http/h2_client.v
@@ -42,7 +42,7 @@ fn (req &Request) to_h2_request(method Method, authority string, path string, da
 	if !header.contains(.content_length) {
 		extra << H2HeaderField{'content-length', data.len.str()}
 	}
-	for key in header.keys() {
+	for key in header.unique_keys() {
 		lkey := key.to_lower()
 		if lkey in h2_hop_by_hop {
 			continue

--- a/vlib/net/http/h2_client.v
+++ b/vlib/net/http/h2_client.v
@@ -17,10 +17,18 @@ const h2_hop_by_hop = ['connection', 'keep-alive', 'proxy-connection', 'transfer
 // h2_authority returns the :authority value for a host and port, omitting the
 // port for the default HTTPS port.
 fn h2_authority(host string, port int) string {
+	wire_host := authority_host(host)
 	if port == 443 || port == 0 {
-		return host
+		return wire_host
 	}
-	return '${host}:${port}'
+	return '${wire_host}:${port}'
+}
+
+fn authority_host(host string) string {
+	if host.contains(':') && !(host.starts_with('[') && host.ends_with(']')) {
+		return '[${host}]'
+	}
+	return host
 }
 
 // to_h2_request builds an HTTP/2 request from this request. Header names are

--- a/vlib/net/http/h2_client.v
+++ b/vlib/net/http/h2_client.v
@@ -47,7 +47,7 @@ fn (req &Request) to_h2_request(method Method, authority string, path string, da
 	if !header.contains(.user_agent) {
 		extra << H2HeaderField{'user-agent', req.user_agent}
 	}
-	if !header.contains(.content_length) {
+	if method != .trace && !header.contains(.content_length) {
 		extra << H2HeaderField{'content-length', data.len.str()}
 	}
 	for key in header.unique_keys() {

--- a/vlib/net/http/h2_client.v
+++ b/vlib/net/http/h2_client.v
@@ -39,8 +39,9 @@ fn (req &Request) to_h2_request(method Method, authority string, path string, da
 	// path (used for virtual-host / host-override requests).
 	mut auth := authority
 	if host := header.get(.host) {
-		if host != '' {
-			auth = host
+		trimmed_host := host.trim_space()
+		if trimmed_host != '' {
+			auth = trimmed_host
 		}
 	}
 	mut extra := []H2HeaderField{}

--- a/vlib/net/http/h2_client.v
+++ b/vlib/net/http/h2_client.v
@@ -60,7 +60,7 @@ fn (req &Request) to_h2_request(method Method, authority string, path string, da
 	// Cookies: the request's own cookie map plus any Cookie header values,
 	// joined into one field (RFC 7540 Section 8.1.2.5 also allows splitting).
 	cookie_value := req.cookie_header_value_with_header(header)
-	if cookie_value != '' {
+	if cookie_value != '' || header.contains(.cookie) {
 		extra << H2HeaderField{'cookie', cookie_value}
 	}
 	return H2ClientRequest{

--- a/vlib/net/http/h2_client_test.v
+++ b/vlib/net/http/h2_client_test.v
@@ -86,6 +86,16 @@ fn test_to_h2_request_collapses_cookies() {
 	assert cookie[0].value.contains('a=1')
 }
 
+fn test_to_h2_request_preserves_present_empty_cookie_field() {
+	mut h := new_header()
+	h.add(.cookie, '')
+	req := Request{}
+	h2req := req.to_h2_request(.get, 'h.example', '/', '', h)
+	cookie := h2req.headers.filter(it.name == 'cookie')
+	assert cookie.len == 1
+	assert cookie[0].value == ''
+}
+
 fn test_h2_response_to_http() {
 	h2resp := H2ClientResponse{
 		status:  200

--- a/vlib/net/http/h2_client_test.v
+++ b/vlib/net/http/h2_client_test.v
@@ -116,6 +116,8 @@ fn test_h2_authority_omits_default_port() {
 	assert h2_authority('example.com', 443) == 'example.com'
 	assert h2_authority('example.com', 0) == 'example.com'
 	assert h2_authority('example.com', 8443) == 'example.com:8443'
+	assert h2_authority('2001:db8::1', 443) == '[2001:db8::1]'
+	assert h2_authority('2001:db8::1', 8443) == '[2001:db8::1]:8443'
 }
 
 // End-to-end test against a real HTTP/2 server. Run with `-d network`,

--- a/vlib/net/http/h2_client_test.v
+++ b/vlib/net/http/h2_client_test.v
@@ -30,6 +30,12 @@ fn test_to_h2_request_lowercases_and_keeps_custom_headers() {
 	assert h2req.headers.any(it.name == 'content-length' && it.value == '0')
 }
 
+fn test_to_h2_request_does_not_add_content_length_to_trace() {
+	req := Request{}
+	h2req := req.to_h2_request(.trace, 'h.example', '/', '', new_header())
+	assert !h2req.headers.any(it.name == 'content-length')
+}
+
 fn test_to_h2_request_deduplicates_header_name_casing() {
 	mut h := new_header()
 	h.add_custom('X-Foo', 'a')!

--- a/vlib/net/http/h2_client_test.v
+++ b/vlib/net/http/h2_client_test.v
@@ -152,3 +152,11 @@ fn test_to_h2_request_authority_from_host_header() {
 	assert h2req.authority == 'override.example:8443'
 	assert !h2req.headers.any(it.name == 'host')
 }
+
+fn test_to_h2_request_trims_authority_from_host_header() {
+	mut h := new_header()
+	h.add(.host, ' override.example:8443 ')
+	req := Request{}
+	h2req := req.to_h2_request(.get, 'origin.example', '/', '', h)
+	assert h2req.authority == 'override.example:8443'
+}

--- a/vlib/net/http/h2_client_test.v
+++ b/vlib/net/http/h2_client_test.v
@@ -27,6 +27,7 @@ fn test_to_h2_request_lowercases_and_keeps_custom_headers() {
 	h2req := req.to_h2_request(.get, 'h.example', '/', '', h)
 	assert h2req.headers.any(it.name == 'accept' && it.value == 'application/json')
 	assert h2req.headers.any(it.name == 'content-type' && it.value == 'text/plain')
+	assert h2req.headers.any(it.name == 'content-length' && it.value == '0')
 }
 
 fn test_to_h2_request_strips_hop_by_hop_and_host() {

--- a/vlib/net/http/h2_client_test.v
+++ b/vlib/net/http/h2_client_test.v
@@ -30,6 +30,18 @@ fn test_to_h2_request_lowercases_and_keeps_custom_headers() {
 	assert h2req.headers.any(it.name == 'content-length' && it.value == '0')
 }
 
+fn test_to_h2_request_deduplicates_header_name_casing() {
+	mut h := new_header()
+	h.add_custom('X-Foo', 'a')!
+	h.add_custom('x-foo', 'b')!
+	req := Request{}
+	h2req := req.to_h2_request(.get, 'h.example', '/', '', h)
+	values := h2req.headers.filter(it.name == 'x-foo')
+	assert values.len == 2
+	assert values[0].value == 'a'
+	assert values[1].value == 'b'
+}
+
 fn test_to_h2_request_strips_hop_by_hop_and_host() {
 	mut h := new_header()
 	h.add(.connection, 'keep-alive')

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -924,7 +924,7 @@ fn (mut c H2ServerConn) build_request(s &H2ServerStream) !Request {
 fn (mut c H2ServerConn) send_response(stream_id u32, resp Response, mut handler Handler) ! {
 	status := if resp.status_code == 0 { 200 } else { resp.status_code }
 	mut fields := [H2HeaderField{':status', status.str()}]
-	for key in resp.header.keys() {
+	for key in resp.header.unique_keys() {
 		lkey := key.to_lower()
 		// Drop hop-by-hop headers; HTTP/2 forbids them (RFC 9113 §8.2.2).
 		if lkey in h2_conn_specific_headers {

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -841,6 +841,37 @@ fn test_h2_server_trailers_only_response_is_single_frame() {
 	assert fields.any(it.name == 'grpc-message' && it.value == 'not found')
 }
 
+struct MixedCaseResponseHeaderHandler {}
+
+fn (mut h MixedCaseResponseHeaderHandler) handle(req Request) Response {
+	mut headers := new_header()
+	headers.add_custom('X-Foo', 'a') or {}
+	headers.add_custom('x-foo', 'b') or {}
+	return Response{
+		status_code: 200
+		header:      headers
+	}
+}
+
+fn test_h2_server_deduplicates_response_header_name_casing() {
+	mut client_end, mut server_end := new_pipe()
+	mut handler_iface := Handler(MixedCaseResponseHeaderHandler{})
+	spawn fn [mut server_end, mut handler_iface] () {
+		mut transport := H2Transport(server_end)
+		serve_h2_conn(mut transport, mut handler_iface) or {}
+	}()
+
+	mut conn := new_h2_conn(client_end)
+	resp := conn.do(H2ClientRequest{ authority: 'h.example' }) or {
+		assert false, 'client do() failed: ${err}'
+		return
+	}
+	values := resp.headers.filter(it.name == 'x-foo')
+	assert values.len == 2
+	assert values[0].value == 'a'
+	assert values[1].value == 'b'
+}
+
 struct FilteredTrailerHandler {}
 
 fn (mut h FilteredTrailerHandler) handle(req Request) Response {

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -683,6 +683,9 @@ pub fn (h Header) render_into_sb(mut sb strings.Builder, flags HeaderRenderConfi
 	// for _, kv in h.data {
 	for i := 0; i < h.cur_pos; i++ {
 		kv := h.data[i]
+		if kv.value == '' { // empty value marks a deleted header
+			continue
+		}
 		key := if flags.version == .v2_0 {
 			kv.key.to_lower()
 		} else if flags.canonicalize {

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -467,7 +467,7 @@ pub fn (mut h Header) set_custom(key string, value string) ! {
 	mut set := false
 	mut i := 0
 	for i < h.cur_pos {
-		if h.data[i].key == key {
+		if header_key_eq(h.data[i].key, key) {
 			if !set {
 				h.data[i] = HeaderKV{key, value}
 				set = true
@@ -498,7 +498,7 @@ pub fn (mut h Header) delete(key CommonHeader) {
 pub fn (mut h Header) delete_custom(key string) {
 	mut i := 0
 	for i < h.cur_pos {
-		if h.data[i].key == key {
+		if header_key_eq(h.data[i].key, key) {
 			h.delete_at(i)
 		} else {
 			i++
@@ -642,8 +642,23 @@ pub fn (h Header) keys() []string {
 	for i := 0; i < h.cur_pos; i++ {
 		res << h.data[i].key
 	}
-	// Make sure keys are lower case and unique
 	return arrays.uniq(res)
+}
+
+// unique_keys gets header names deduplicated case-insensitively, retaining the
+// first spelling. Use this when serializing HTTP fields.
+pub fn (h Header) unique_keys() []string {
+	mut res := []string{cap: h.cur_pos}
+	mut seen := map[string]bool{}
+	for i := 0; i < h.cur_pos; i++ {
+		lower := h.data[i].key.to_lower()
+		if lower in seen {
+			continue
+		}
+		seen[lower] = true
+		res << h.data[i].key
+	}
+	return res
 }
 
 @[params]

--- a/vlib/net/http/header.v
+++ b/vlib/net/http/header.v
@@ -465,16 +465,18 @@ pub fn (mut h Header) set(key CommonHeader, value string) {
 pub fn (mut h Header) set_custom(key string, value string) ! {
 	is_valid(key)!
 	mut set := false
-	for i, kv in h.data {
-		if kv.key == key {
+	mut i := 0
+	for i < h.cur_pos {
+		if h.data[i].key == key {
 			if !set {
 				h.data[i] = HeaderKV{key, value}
 				set = true
+				i++
 			} else {
-				// Remove old duplicates
-				h.data[i] = HeaderKV{key, ''}
+				h.delete_at(i)
 			}
-			// return
+		} else {
+			i++
 		}
 	}
 	if set {
@@ -494,9 +496,12 @@ pub fn (mut h Header) delete(key CommonHeader) {
 
 // delete_custom deletes all values for a custom header key.
 pub fn (mut h Header) delete_custom(key string) {
-	for i := 0; i < h.cur_pos; i++ {
+	mut i := 0
+	for i < h.cur_pos {
 		if h.data[i].key == key {
-			h.data[i] = HeaderKV{key, ''}
+			h.delete_at(i)
+		} else {
+			i++
 		}
 	}
 	// h.data.delete(key)
@@ -508,6 +513,14 @@ pub fn (mut h Header) delete_custom(key string) {
 		h.keys[kl] = h.keys[kl].filter(it != key)
 	}
 	*/
+}
+
+fn (mut h Header) delete_at(index int) {
+	for i := index; i < h.cur_pos - 1; i++ {
+		h.data[i] = h.data[i + 1]
+	}
+	h.cur_pos--
+	h.data[h.cur_pos] = HeaderKV{}
 }
 
 // contains returns whether the header key exists in the map.
@@ -607,7 +620,7 @@ pub fn (h Header) custom_values(key string, flags HeaderQueryConfig) []string {
 	if flags.exact {
 		for i := 0; i < h.cur_pos; i++ {
 			kv := h.data[i]
-			if kv.key == key && kv.value != '' { // empty value means a deleted header
+			if kv.key == key {
 				res << kv.value
 			}
 		}
@@ -615,7 +628,7 @@ pub fn (h Header) custom_values(key string, flags HeaderQueryConfig) []string {
 	} else {
 		for i := 0; i < h.cur_pos; i++ {
 			kv := h.data[i]
-			if header_key_eq(kv.key, key) && kv.value != '' { // empty value means a deleted header
+			if header_key_eq(kv.key, key) {
 				res << kv.value
 			}
 		}
@@ -627,9 +640,6 @@ pub fn (h Header) custom_values(key string, flags HeaderQueryConfig) []string {
 pub fn (h Header) keys() []string {
 	mut res := []string{cap: h.cur_pos}
 	for i := 0; i < h.cur_pos; i++ {
-		if h.data[i].value == '' {
-			continue
-		}
 		res << h.data[i].key
 	}
 	// Make sure keys are lower case and unique
@@ -683,9 +693,6 @@ pub fn (h Header) render_into_sb(mut sb strings.Builder, flags HeaderRenderConfi
 	// for _, kv in h.data {
 	for i := 0; i < h.cur_pos; i++ {
 		kv := h.data[i]
-		if kv.value == '' { // empty value marks a deleted header
-			continue
-		}
 		key := if flags.version == .v2_0 {
 			kv.key.to_lower()
 		} else if flags.canonicalize {

--- a/vlib/net/http/header_test.v
+++ b/vlib/net/http/header_test.v
@@ -86,6 +86,14 @@ fn test_delete_header() {
 	assert r.header.get(.authorization)? == ''
 }
 
+fn test_render_omits_deleted_header_slots() {
+	mut h := new_header()
+	h.add_custom('X-Test', 'first')!
+	h.add_custom('X-Test', 'second')!
+	h.delete_custom('X-Test')
+	assert h.render(HeaderRenderConfig{}) == ''
+}
+
 fn test_custom_header() {
 	mut h := new_header()
 	h.add_custom('AbC', 'dEf')!

--- a/vlib/net/http/header_test.v
+++ b/vlib/net/http/header_test.v
@@ -107,6 +107,7 @@ fn test_custom_header() {
 	assert h.custom_values('ABC') == ['dEf', 'GhI']
 	assert h.custom_values('abc') == ['dEf', 'GhI']
 	assert h.keys() == ['AbC', 'aBc']
+	assert h.unique_keys() == ['AbC']
 	h.delete_custom('AbC')
 	h.delete_custom('aBc')
 

--- a/vlib/net/http/header_test.v
+++ b/vlib/net/http/header_test.v
@@ -83,7 +83,9 @@ fn test_delete_header() {
 	mut r := new_request(.get, '', '')
 	r.header.set(.authorization, 'foo')
 	r.header.delete(.authorization)
-	assert r.header.get(.authorization)? == ''
+	if _ := r.header.get(.authorization) {
+		assert false, 'a deleted header must be absent'
+	}
 }
 
 fn test_render_omits_deleted_header_slots() {
@@ -92,6 +94,8 @@ fn test_render_omits_deleted_header_slots() {
 	h.add_custom('X-Test', 'second')!
 	h.delete_custom('X-Test')
 	assert h.render(HeaderRenderConfig{}) == ''
+	h.add_custom('X-Empty', '')!
+	assert h.render(HeaderRenderConfig{}) == 'X-Empty: \r\n'
 }
 
 fn test_custom_header() {

--- a/vlib/net/http/http_proxy.v
+++ b/vlib/net/http/http_proxy.v
@@ -153,15 +153,9 @@ fn (pr &HttpProxy) http_do(host urllib.URL, method Method, path string, req &Req
 	if port == 0 {
 		port = if host.scheme == 'https' { 443 } else { 80 }
 	}
-	port_part := if (host.scheme == 'http' && port == 80) || (host.scheme == 'https' && port == 443) {
-		''
-	} else {
-		':${port}'
-	}
-
 	default_port := if host.scheme == 'https' { 443 } else { 80 }
-	s := req.build_request_headers_with(method, host_name, port, default_port,
-		'${host.scheme}://${host_name}${port_part}${path}', data, header)
+	s := req.build_request_headers_with(method, host_name, port, default_port, proxy_request_target(host,
+		port, path), data, header)
 	if host.scheme == 'https' {
 		mut client := pr.ssl_dial('${host_name}:${port}')!
 
@@ -195,6 +189,15 @@ fn (pr &HttpProxy) http_do(host urllib.URL, method Method, path string, req &Req
 		return parse_received_response(response_text, response_data.info)
 	}
 	return error('Invalid Scheme')
+}
+
+fn proxy_request_target(host urllib.URL, port int, path string) string {
+	port_part := if (host.scheme == 'http' && port == 80) || (host.scheme == 'https' && port == 443) {
+		''
+	} else {
+		':${port}'
+	}
+	return '${host.scheme}://${authority_host(host.hostname())}${port_part}${path}'
 }
 
 fn (pr &HttpProxy) dial(host string) !&net.TcpConn {

--- a/vlib/net/http/http_proxy.v
+++ b/vlib/net/http/http_proxy.v
@@ -159,7 +159,8 @@ fn (pr &HttpProxy) http_do(host urllib.URL, method Method, path string, req &Req
 		':${port}'
 	}
 
-	s := req.build_request_headers_with(method, host_name, port,
+	default_port := if host.scheme == 'https' { 443 } else { 80 }
+	s := req.build_request_headers_with(method, host_name, port, default_port,
 		'${host.scheme}://${host_name}${port_part}${path}', data, header)
 	if host.scheme == 'https' {
 		mut client := pr.ssl_dial('${host_name}:${port}')!
@@ -171,8 +172,8 @@ fn (pr &HttpProxy) http_do(host urllib.URL, method Method, path string, req &Req
 			// client.shutdown()!
 			// return response_text
 		} $else {
-			return req.do_request(req.build_request_headers_with(method, host_name, port, path,
-				data, header), mut client)!
+			return req.do_request(req.build_request_headers_with(method, host_name, port,
+				default_port, path, data, header), mut client)!
 		}
 	} else if host.scheme == 'http' {
 		mut client := pr.dial('${host_name}:${port}')!

--- a/vlib/net/http/http_proxy.v
+++ b/vlib/net/http/http_proxy.v
@@ -155,7 +155,7 @@ fn (pr &HttpProxy) http_do(host urllib.URL, method Method, path string, req &Req
 	}
 	default_port := if host.scheme == 'https' { 443 } else { 80 }
 	s := req.build_request_headers_with(method, host_name, port, default_port, proxy_request_target(host,
-		port, path), data, header)
+		port, path), data, header)!
 	if host.scheme == 'https' {
 		mut client := pr.ssl_dial('${host_name}:${port}')!
 
@@ -167,7 +167,7 @@ fn (pr &HttpProxy) http_do(host urllib.URL, method Method, path string, req &Req
 			// return response_text
 		} $else {
 			return req.do_request(req.build_request_headers_with(method, host_name, port,
-				default_port, path, data, header), mut client)!
+				default_port, path, data, header)!, mut client)!
 		}
 	} else if host.scheme == 'http' {
 		mut client := pr.dial('${host_name}:${port}')!

--- a/vlib/net/http/http_proxy_test.v
+++ b/vlib/net/http/http_proxy_test.v
@@ -60,6 +60,12 @@ fn test_proxy_headers_authenticated() ? {
 		'Proxy-Connection: Keep-Alive\r\nProxy-Authorization: Basic ${auth_token}\r\n\r\n'
 }
 
+fn test_proxy_request_target_preserves_ipv6_brackets() {
+	host := urllib.parse('http://[2001:db8::1]/')!
+	assert proxy_request_target(host, 80, '/path') == 'http://[2001:db8::1]/path'
+	assert proxy_request_target(host, 8080, '/path') == 'http://[2001:db8::1]:8080/path'
+}
+
 enum ProxyTunnelCopyResult {
 	data
 	timeout

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -367,7 +367,7 @@ fn (req &Request) build_request_headers_opts(method Method, host_name string, po
 		sb.write_string('\r\n')
 	}
 	chkey := CommonHeader.cookie.str()
-	for key in header.keys() {
+	for key in header.unique_keys() {
 		if header_key_eq(key, chkey) {
 			continue
 		}

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -161,6 +161,21 @@ pub fn (req &Request) cookie(name string) ?Cookie {
 	return none
 }
 
+// cookie_header_value returns the value net.http sends in the Cookie header,
+// combining request cookies and explicit Cookie field values.
+pub fn (req &Request) cookie_header_value() string {
+	return req.cookie_header_value_with_header(req.header)
+}
+
+fn (req &Request) cookie_header_value_with_header(header Header) string {
+	mut parts := []string{cap: req.cookies.len + header.values(.cookie).len}
+	for key, value in req.cookies {
+		parts << '${key}=${value}'
+	}
+	parts << header.values(.cookie)
+	return parts.join('; ')
+}
+
 // do will send the HTTP request and returns `http.Response` as soon as the response is received
 pub fn (req &Request) do() !Response {
 	mut rurl := urllib.parse(req.url) or { return error('http.Request.do: invalid url ${req.url}') }
@@ -353,7 +368,7 @@ fn (req &Request) build_request_headers_opts(method Method, host_name string, po
 	}
 	chkey := CommonHeader.cookie.str()
 	for key in header.keys() {
-		if key == chkey {
+		if header_key_eq(key, chkey) {
 			continue
 		}
 		// RFC 9110 §5.2 combines repeated field lines with a comma. This also
@@ -378,32 +393,11 @@ fn (req &Request) build_request_cookies_header() string {
 }
 
 fn (req &Request) build_request_cookies_header_with_header(header Header) string {
-	if req.cookies.len < 1 {
+	value := req.cookie_header_value_with_header(header)
+	if value == '' {
 		return ''
 	}
-	mut sb_cookie := strings.new_builder(1024)
-	hvcookies := header.values(.cookie)
-	total_cookies := req.cookies.len + hvcookies.len
-	sb_cookie.write_string('Cookie: ')
-	mut idx := 0
-	for key, val in req.cookies {
-		sb_cookie.write_string(key)
-		sb_cookie.write_string('=')
-		sb_cookie.write_string(val)
-		if idx < total_cookies - 1 {
-			sb_cookie.write_string('; ')
-		}
-		idx++
-	}
-	for c in hvcookies {
-		sb_cookie.write_string(c)
-		if idx < total_cookies - 1 {
-			sb_cookie.write_string('; ')
-		}
-		idx++
-	}
-	sb_cookie.write_string('\r\n')
-	return sb_cookie.str()
+	return 'Cookie: ${value}\r\n'
 }
 
 fn (req &Request) http_do(host string, method Method, path string, data string, header Header) !Response {

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -363,7 +363,7 @@ fn (req &Request) build_request_headers_opts(method Method, host_name string, po
 		sb.write_string(ua)
 		sb.write_string('\r\n')
 	}
-	if !header.contains(.content_length) {
+	if method != .trace && !header.contains(.content_length) {
 		// Write Content-Length: 0 even if there's no content, since some APIs
 		// stop working without this header.
 		sb.write_string('Content-Length: ')
@@ -375,13 +375,23 @@ fn (req &Request) build_request_headers_opts(method Method, host_name string, po
 		if header_key_eq(key, chkey) {
 			continue
 		}
-		// RFC 9110 §5.2 combines repeated field lines with a comma. This also
-		// keeps HTTP/1.x serialization consistent with the HTTP/2 path.
-		val := header.custom_values(key).map(it.trim_space()).join(', ')
-		sb.write_string(key)
-		sb.write_string(': ')
-		sb.write_string(val)
-		sb.write_string('\r\n')
+		values := header.custom_values(key).map(it.trim_space())
+		if values.len > 1 && values.last() == '' {
+			// A combined trailing empty member would end in OWS, which parsers
+			// remove. Separate lines preserve the empty value for signatures.
+			for value in values {
+				sb.write_string(key)
+				sb.write_string(': ')
+				sb.write_string(value)
+				sb.write_string('\r\n')
+			}
+		} else {
+			// RFC 9110 §5.2 permits combining repeated field lines with a comma.
+			sb.write_string(key)
+			sb.write_string(': ')
+			sb.write_string(values.join(', '))
+			sb.write_string('\r\n')
+		}
 	}
 	sb.write_string(req.build_request_cookies_header_with_header(header))
 	if connection_close {

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -373,7 +373,7 @@ fn (req &Request) build_request_headers_opts(method Method, host_name string, po
 		}
 		// RFC 9110 §5.2 combines repeated field lines with a comma. This also
 		// keeps HTTP/1.x serialization consistent with the HTTP/2 path.
-		val := header.custom_values(key).join(', ')
+		val := header.custom_values(key).map(it.trim_space()).join(', ')
 		sb.write_string(key)
 		sb.write_string(': ')
 		sb.write_string(val)

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -356,7 +356,9 @@ fn (req &Request) build_request_headers_opts(method Method, host_name string, po
 		if key == chkey {
 			continue
 		}
-		val := header.custom_values(key).join('; ')
+		// RFC 9110 §5.2 combines repeated field lines with a comma. This also
+		// keeps HTTP/1.x serialization consistent with the HTTP/2 path.
+		val := header.custom_values(key).join(', ')
 		sb.write_string(key)
 		sb.write_string(': ')
 		sb.write_string(val)

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -394,7 +394,7 @@ fn (req &Request) build_request_cookies_header() string {
 
 fn (req &Request) build_request_cookies_header_with_header(header Header) string {
 	value := req.cookie_header_value_with_header(header)
-	if value == '' {
+	if value == '' && !header.contains(.cookie) {
 		return ''
 	}
 	return 'Cookie: ${value}\r\n'

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -323,11 +323,14 @@ fn (req &Request) method_and_url_to_response(method Method, url urllib.URL, data
 }
 
 fn (req &Request) build_request_headers(method Method, host_name string, port int, path string) string {
-	return req.build_request_headers_with(method, host_name, port, path, req.data, req.header)
+	default_port := if port == 443 { 443 } else { 80 }
+	return req.build_request_headers_with(method, host_name, port, default_port, path, req.data,
+		req.header)
 }
 
-fn (req &Request) build_request_headers_with(method Method, host_name string, port int, path string, data string, header Header) string {
-	return req.build_request_headers_opts(method, host_name, port, path, data, header, true)
+fn (req &Request) build_request_headers_with(method Method, host_name string, port int, default_port int, path string, data string, header Header) string {
+	return req.build_request_headers_opts(method, host_name, port, default_port, path, data,
+		header, true)
 }
 
 // build_request_headers_opts builds the raw HTTP/1.x request. With
@@ -335,7 +338,7 @@ fn (req &Request) build_request_headers_with(method Method, host_name string, po
 // one-shot behavior); the pooled keep-alive path passes false and emits no
 // Connection header, leaving the HTTP/1.1 default (keep-alive) in effect and
 // respecting any Connection header the caller set themselves.
-fn (req &Request) build_request_headers_opts(method Method, host_name string, port int, path string, data string, header Header, connection_close bool) string {
+fn (req &Request) build_request_headers_opts(method Method, host_name string, port int, default_port int, path string, data string, header Header, connection_close bool) string {
 	mut sb := strings.new_builder(4096)
 	version := if req.version == .unknown { Version.v1_1 } else { req.version }
 	sb.write_string(method.str())
@@ -346,10 +349,11 @@ fn (req &Request) build_request_headers_opts(method Method, host_name string, po
 	sb.write_string('\r\n')
 	if !header.contains(.host) {
 		sb.write_string('Host: ')
-		if port != 80 && port != 443 && port != 0 {
-			sb.write_string('${host_name}:${port}')
+		wire_host := authority_host(host_name)
+		if port != default_port && port != 0 {
+			sb.write_string('${wire_host}:${port}')
 		} else {
-			sb.write_string(host_name)
+			sb.write_string(wire_host)
 		}
 		sb.write_string('\r\n')
 	}
@@ -402,7 +406,7 @@ fn (req &Request) build_request_cookies_header_with_header(header Header) string
 
 fn (req &Request) http_do(host string, method Method, path string, data string, header Header) !Response {
 	host_name, port := net.split_address(host)!
-	s := req.build_request_headers_with(method, host_name, port, path, data, header)
+	s := req.build_request_headers_with(method, host_name, port, 80, path, data, header)
 	mut client := net.dial_tcp(host)!
 	client.set_read_timeout(req.read_timeout)
 	client.set_write_timeout(req.write_timeout)

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -853,12 +853,10 @@ pub fn parse_request_head(mut reader io.BufferedReader) !Request {
 			// Skip space or tab in value name
 			pos++
 		}
-		if pos + 1 < line.len {
-			value := line[pos + 1..]
-			_, _ = key, value
-			// println('key,value=${key},${value}')
-			header.add_custom(key, value)!
-		}
+		value := if pos + 1 < line.len { line[pos + 1..] } else { '' }
+		// Preserve present empty fields; signature verification distinguishes
+		// an empty field value from a missing field.
+		header.add_custom(key, value)!
 		line = reader.read_line()!
 	}
 	// header.coerce(canonicalize: true)
@@ -916,10 +914,8 @@ pub fn parse_request_head_str(s string) !Request {
 			val_start++
 		}
 
-		if val_start < line.len {
-			value := line[val_start..]
-			header.add_custom(key, value)!
-		}
+		value := if val_start < line.len { line[val_start..] } else { '' }
+		header.add_custom(key, value)!
 		line_start = line_end + 1
 	}
 

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -322,13 +322,13 @@ fn (req &Request) method_and_url_to_response(method Method, url urllib.URL, data
 	return error('http.request.method_and_url_to_response: unsupported scheme: "${scheme}"')
 }
 
-fn (req &Request) build_request_headers(method Method, host_name string, port int, path string) string {
+fn (req &Request) build_request_headers(method Method, host_name string, port int, path string) !string {
 	default_port := if port == 443 { 443 } else { 80 }
 	return req.build_request_headers_with(method, host_name, port, default_port, path, req.data,
 		req.header)
 }
 
-fn (req &Request) build_request_headers_with(method Method, host_name string, port int, default_port int, path string, data string, header Header) string {
+fn (req &Request) build_request_headers_with(method Method, host_name string, port int, default_port int, path string, data string, header Header) !string {
 	return req.build_request_headers_opts(method, host_name, port, default_port, path, data,
 		header, true)
 }
@@ -338,7 +338,10 @@ fn (req &Request) build_request_headers_with(method Method, host_name string, po
 // one-shot behavior); the pooled keep-alive path passes false and emits no
 // Connection header, leaving the HTTP/1.1 default (keep-alive) in effect and
 // respecting any Connection header the caller set themselves.
-fn (req &Request) build_request_headers_opts(method Method, host_name string, port int, default_port int, path string, data string, header Header, connection_close bool) string {
+fn (req &Request) build_request_headers_opts(method Method, host_name string, port int, default_port int, path string, data string, header Header, connection_close bool) !string {
+	if method == .trace && data != '' {
+		return error('net.http: TRACE requests must not carry a body')
+	}
 	mut sb := strings.new_builder(4096)
 	version := if req.version == .unknown { Version.v1_1 } else { req.version }
 	sb.write_string(method.str())
@@ -416,7 +419,7 @@ fn (req &Request) build_request_cookies_header_with_header(header Header) string
 
 fn (req &Request) http_do(host string, method Method, path string, data string, header Header) !Response {
 	host_name, port := net.split_address(host)!
-	s := req.build_request_headers_with(method, host_name, port, 80, path, data, header)
+	s := req.build_request_headers_with(method, host_name, port, 80, path, data, header)!
 	mut client := net.dial_tcp(host)!
 	client.set_read_timeout(req.read_timeout)
 	client.set_write_timeout(req.write_timeout)

--- a/vlib/net/http/request_test.v
+++ b/vlib/net/http/request_test.v
@@ -51,6 +51,12 @@ fn test_parse_request_two_headers() {
 	assert req.header.custom_values('Test2') == ['B']
 }
 
+fn test_parse_request_preserves_present_empty_header() {
+	mut reader_ := reader('GET / HTTP/1.1\r\nHost: example.com\r\nX-Empty:\r\n\r\n')
+	req := http.parse_request(mut reader_) or { panic('did not parse: ${err}') }
+	assert req.header.custom_values('X-Empty') == ['']
+}
+
 fn test_parse_request_two_header_values() {
 	mut reader_ := reader('GET / HTTP/1.1\r\nTest1: a; b\r\nTest2: c\r\nTest2: d\r\n\r\n')
 	req := http.parse_request(mut reader_) or { panic('did not parse: ${err}') }
@@ -285,6 +291,11 @@ fn test_parse_request_head_str_post_with_headers() {
 	assert req.version == .v1_1
 	assert req.host == 'test.com'
 	assert req.header.custom_values('Content-Type') == ['application/json']
+}
+
+fn test_parse_request_head_str_preserves_present_empty_header() {
+	req := http.parse_request_head_str('GET / HTTP/1.1\r\nHost: example.com\r\nX-Empty:\r\n\r\n')!
+	assert req.header.custom_values('X-Empty') == ['']
 }
 
 fn test_parse_request_head_str_post_with_headers_and_body() {

--- a/vlib/net/http/response_test.v
+++ b/vlib/net/http/response_test.v
@@ -13,6 +13,15 @@ fn test_normalize_server_response_preserves_unassigned_three_digit_status() {
 	assert resp.status_msg == 'Unassigned'
 }
 
+fn test_normalize_server_response_defaults_zero_status_despite_reason_phrase() {
+	mut resp := Response{
+		status_msg: 'custom reason without a status'
+	}
+	normalize_server_response(mut resp, Request{})
+	assert resp.status_code == 200
+	assert resp.status_msg == 'OK'
+}
+
 fn test_response_bytestr_1() {
 	resp := new_response(
 		status: .ok

--- a/vlib/net/http/response_test.v
+++ b/vlib/net/http/response_test.v
@@ -4,6 +4,15 @@ import compress.brotli
 import compress.gzip
 import compress.zlib
 
+fn test_normalize_server_response_preserves_unassigned_three_digit_status() {
+	mut resp := Response{
+		status_code: 299
+	}
+	normalize_server_response(mut resp, Request{})
+	assert resp.status_code == 299
+	assert resp.status_msg == 'Unassigned'
+}
+
 fn test_response_bytestr_1() {
 	resp := new_response(
 		status: .ok

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -312,7 +312,7 @@ fn normalize_server_response(mut resp Response, req Request) {
 		if resp.status_msg == '' {
 			resp.status_msg = status.str()
 		}
-	} else if resp.status_code == 0 && resp.status_msg == '' {
+	} else if resp.status_code == 0 {
 		resp.set_status(.ok)
 	} else {
 		resp.set_status(.internal_server_error)

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -308,7 +308,7 @@ fn normalize_server_response(mut resp Response, req Request) {
 	}
 
 	status := status_from_int(resp.status_code)
-	if status.is_valid() {
+	if resp.status_code >= 100 && resp.status_code <= 599 {
 		if resp.status_msg == '' {
 			resp.status_msg = status.str()
 		}

--- a/vlib/net/http/signature/README.md
+++ b/vlib/net/http/signature/README.md
@@ -1,0 +1,124 @@
+# `net.http.signature` — HTTP Message Signatures (RFC 9421)
+
+Sign and verify HTTP requests and responses per [RFC 9421][rfc9421] —
+the standard that replaces the long-running `Signature` /
+`Signature-Input` drafts and underpins production deployments at major
+CDNs, mTLS proxies, mutual API authentication, and the upcoming
+[Web Bot Auth][web-bot-auth] work.
+
+[rfc9421]: https://www.rfc-editor.org/rfc/rfc9421.html
+[web-bot-auth]: https://datatracker.ietf.org/doc/draft-meunier-web-bot-auth-architecture/
+
+## Quick start
+
+```v ignore
+import net.http
+import net.http.signature
+
+// Sign an outbound request. `created` defaults to time.now().unix().
+mut req := http.new_request(.post, 'https://example.com/items', '{}')!
+req.header.add_custom('Date', 'Tue, 20 Apr 2021 02:07:55 GMT')!
+req.header.add_custom('Content-Type', 'application/json')!
+
+priv := signature.Key.from_pem(alice_private_pem)!.with_keyid('alice')
+signature.sign_request(mut req, priv,
+    components: ['@method', '@target-uri', '@authority', 'date', 'content-type']
+)!
+// req now carries Signature-Input and Signature header fields.
+
+// On the receiving side, verify with the public key resolved from `keyid`:
+pub_key := signature.Key.from_pem(alice_public_pem)!
+signature.verify_request(req, pub_key, now_unix: time.now().unix())!
+```
+
+`Key.from_pem` accepts the canonical PKCS#8 / SPKI / SEC1 PEM blocks
+that `openssl genpkey` and friends produce. The raw-coordinate
+constructors (`Key.ed25519_private(seed)`, `Key.ecdsa_p256_public(x,
+y)`, …) are still available when you have JWK-style key material.
+
+The `now_unix` option enforces the optional `expires` parameter; pass
+`0` (the default) to skip the expiry check.
+
+## Algorithms
+
+| IANA name           | Status | Backed by |
+| ------------------- | ------ | --------- |
+| `hmac-sha256`       | ✅ | `crypto.hmac` + `crypto.sha256` |
+| `ecdsa-p256-sha256` | ✅ | `crypto.ecdsa` (P-256) |
+| `ecdsa-p384-sha384` | ✅ | `crypto.ecdsa` (P-384) |
+| `ed25519`           | ✅ | `crypto.ed25519` |
+
+`rsa-pss-sha512` and `rsa-v1_5-sha256` are intentionally out of scope —
+`vlib/crypto` does not yet ship an RSA implementation. Adding them is
+mechanical once it does.
+
+## Covered components
+
+All derived components from RFC 9421 §2.2 are implemented:
+
+`@method`, `@target-uri`, `@authority`, `@scheme`, `@request-target`,
+`@path`, `@query`, `@status`.
+
+Plain HTTP fields are matched by *lowercased* field name, with
+multi-value fields joined by `", "` and OWS trimmed at the boundaries
+(RFC 9421 §2.1).
+
+`@query-param` (RFC 9421 §2.2.8), structured-field re-serialisation
+(`sf`, `key`, `bs` parameters from §2.1.x), and binary-wrapped fields
+are deferred to a follow-up PR.
+
+## Two API layers
+
+```v ignore
+// Components-level - works on any HTTP-shaped data, no http.Request
+// dependency. Use this offline (signing fixtures, building tests).
+base := signature.signature_base_string(components, params)!
+out  := signature.sign(components, params, key, 'sig1')!
+signature.verify(components, sig_input, sig_value, 'sig1', key)!
+
+// http.Request / http.Response wrappers - sugar over the above.
+signature.sign_request(mut req, key, components: [...], created: now)!
+signature.verify_request(req, key, now_unix: now)!
+```
+
+## Design notes
+
+* **No silent algorithm fallbacks.** If you set the `alg` parameter
+  and it doesn't match the key's algorithm, `sign` errors out with
+  `MalformedMessage`. `verify` does the same on the inbound side.
+  RFC 9421 §3.1 step 3 makes this a correctness requirement.
+
+* **Empty `keyid` is allowed.** RFC 9421 doesn't make `keyid`
+  mandatory; some out-of-band channel (mTLS cert, JWT bearer)
+  identifies the signer instead. `sign` still emits a usable
+  signature; the verifier picks the key by other means.
+
+* **Multiple signatures coexist.** Calling `sign_request` twice with
+  different labels merges the labelled entries into a single
+  `Signature-Input` / `Signature` field per RFC 8941 §3.2 (comma-
+  separated dictionary) — TLS-terminating proxies and federated
+  signing scenarios both rely on this layout.
+
+* **No clock dependency.** Both `created` and the expiry check are
+  driven by the caller (`opts.created`, `opts.now_unix`). Signing in
+  bulk over historical data, deterministic test runs, and replay
+  protection are all the caller's concern.
+
+## Test vectors
+
+RFC 9421 Appendix B vectors are vendored under
+`tests/rfc9421/` and exercised by `rfc9421_test.v`:
+
+| Section | Algorithm | Mode |
+| --- | --- | --- |
+| B.2.5 | `hmac-sha256` | **bytes-exact** |
+| B.2.6 | `ed25519` | **bytes-exact** |
+| B.2.4 | `ecdsa-p256-sha256` | verify (ECDSA non-deterministic) |
+
+`http_message_test.v` covers sign/verify roundtrips across all four
+supported algorithms (including a freshly-generated P-384 key),
+tampered URL rejection, missing-header rejection, expiry enforcement,
+multi-signature coexistence, and `alg` / label validation.
+`structured_field_test.v` pins the Inner List + parameter
+serialisation, multi-value field joining, OWS trimming, and the
+`@query` empty-vs-present semantics.

--- a/vlib/net/http/signature/README.md
+++ b/vlib/net/http/signature/README.md
@@ -40,13 +40,15 @@ The `now_unix` option rejects signatures created after the supplied time and
 enforces the optional `expires` parameter; pass `0` (the default) to skip time
 validation.
 
-`verify_request` requires `@method`, `@target-uri`, and `@authority` by default.
-For responses, the default is `@status`; a body also requires `content-digest`.
-Likewise, default `sign_response` calls require an existing `Content-Digest`
-field for a body and cover it. Applications must also validate that digest
-against the received body. A different authorization profile can be selected
-explicitly with `required_components`. The lower-level `verify` API performs
-cryptographic verification only unless its `required_components` option is set.
+`verify_request` requires `@method`, `@target-uri`, and `@authority` by default;
+a body also requires `content-digest`. For responses, the default is `@status`,
+again with `content-digest` for a body. Default `sign_request` and
+`sign_response` calls require an existing `Content-Digest` field for a body and
+cover it. Applications must also validate that digest against the received
+body. A different authorization profile can be selected explicitly with
+`components` when signing and `required_components` when verifying. The
+lower-level `verify` API performs cryptographic verification only unless its
+`required_components` option is set.
 
 ## Algorithms
 

--- a/vlib/net/http/signature/README.md
+++ b/vlib/net/http/signature/README.md
@@ -40,11 +40,13 @@ The `now_unix` option rejects signatures created after the supplied time and
 enforces the optional `expires` parameter; pass `0` (the default) to skip time
 validation.
 
-`verify_request` requires `@method`, `@target-uri`, and `@authority` by
-default, while `verify_response` requires `@status`. Applications using a
-different authorization profile must pass its component set explicitly with
-`required_components`. The lower-level `verify` API performs cryptographic
-verification only unless its `required_components` option is set.
+`verify_request` requires `@method`, `@target-uri`, and `@authority` by default.
+For responses, the default is `@status`; a body also requires `content-digest`.
+Likewise, default `sign_response` calls require an existing `Content-Digest`
+field for a body and cover it. Applications must also validate that digest
+against the received body. A different authorization profile can be selected
+explicitly with `required_components`. The lower-level `verify` API performs
+cryptographic verification only unless its `required_components` option is set.
 
 ## Algorithms
 

--- a/vlib/net/http/signature/README.md
+++ b/vlib/net/http/signature/README.md
@@ -36,8 +36,9 @@ that `openssl genpkey` and friends produce. The raw-coordinate
 constructors (`Key.ed25519_private(seed)`, `Key.ecdsa_p256_public(x,
 y)`, …) are still available when you have JWK-style key material.
 
-The `now_unix` option enforces the optional `expires` parameter; pass
-`0` (the default) to skip the expiry check.
+The `now_unix` option rejects signatures created after the supplied time and
+enforces the optional `expires` parameter; pass `0` (the default) to skip time
+validation.
 
 `verify_request` requires `@method`, `@target-uri`, and `@authority` by
 default, while `verify_response` requires `@status`. Applications using a

--- a/vlib/net/http/signature/README.md
+++ b/vlib/net/http/signature/README.md
@@ -39,6 +39,12 @@ y)`, …) are still available when you have JWK-style key material.
 The `now_unix` option enforces the optional `expires` parameter; pass
 `0` (the default) to skip the expiry check.
 
+`verify_request` requires `@method`, `@target-uri`, and `@authority` by
+default, while `verify_response` requires `@status`. Applications using a
+different authorization profile must pass its component set explicitly with
+`required_components`. The lower-level `verify` API performs cryptographic
+verification only unless its `required_components` option is set.
+
 ## Algorithms
 
 | IANA name           | Status | Backed by |

--- a/vlib/net/http/signature/README.md
+++ b/vlib/net/http/signature/README.md
@@ -99,6 +99,11 @@ signature.verify_request(req, key, now_unix: now)!
   separated dictionary) — TLS-terminating proxies and federated
   signing scenarios both rely on this layout.
 
+* **Extension parameters stay covered.** Unknown signature parameters
+  with token, decimal, or byte-sequence values are preserved as
+  `ExtensionParamValue` entries while verification replays their exact
+  wire representation in the signature base.
+
 * **No clock dependency.** Both `created` and the expiry check are
   driven by the caller (`opts.created`, `opts.now_unix`). Signing in
   bulk over historical data, deterministic test runs, and replay

--- a/vlib/net/http/signature/algorithms.v
+++ b/vlib/net/http/signature/algorithms.v
@@ -1,0 +1,44 @@
+// Algorithm identifiers from the IANA "HTTP Signature Algorithms" registry
+// (RFC 9421 §6.2.2). Only those backed by `vlib/crypto` primitives are
+// modelled here; RSA-based algorithms are deliberately omitted because
+// `vlib/crypto` does not yet ship an RSA implementation.
+module signature
+
+// Algorithm names the signing or verification routine selected for a
+// signature. The string form returned by `name()` is the exact token
+// emitted on the wire as the value of the `alg` signature parameter.
+pub enum Algorithm {
+	hmac_sha256       // hmac-sha256       — RFC 9421 §3.3.3
+	ecdsa_p256_sha256 // ecdsa-p256-sha256 — RFC 9421 §3.3.4
+	ecdsa_p384_sha384 // ecdsa-p384-sha384 — RFC 9421 §3.3.5
+	ed25519           // ed25519           — RFC 9421 §3.3.6
+}
+
+// name returns the IANA token for the algorithm.
+pub fn (a Algorithm) name() string {
+	return match a {
+		.hmac_sha256 { 'hmac-sha256' }
+		.ecdsa_p256_sha256 { 'ecdsa-p256-sha256' }
+		.ecdsa_p384_sha384 { 'ecdsa-p384-sha384' }
+		.ed25519 { 'ed25519' }
+	}
+}
+
+// algorithm_from_name parses the IANA token. Returns `none` for
+// algorithms outside this module's supported set so the caller can
+// surface an `UnsupportedAlgorithm` error with the original token kept.
+pub fn algorithm_from_name(s string) ?Algorithm {
+	return match s {
+		'hmac-sha256' { Algorithm.hmac_sha256 }
+		'ecdsa-p256-sha256' { Algorithm.ecdsa_p256_sha256 }
+		'ecdsa-p384-sha384' { Algorithm.ecdsa_p384_sha384 }
+		'ed25519' { Algorithm.ed25519 }
+		else { none }
+	}
+}
+
+// is_mac reports whether the algorithm is symmetric (MAC) rather than
+// asymmetric (signature). MACs are signed and verified with the same key.
+pub fn (a Algorithm) is_mac() bool {
+	return a == .hmac_sha256
+}

--- a/vlib/net/http/signature/components.v
+++ b/vlib/net/http/signature/components.v
@@ -66,7 +66,7 @@ fn (c Components) derived_value(name string) !string {
 		}
 		'@authority' {
 			if a := c.authority {
-				a.to_lower()
+				normalize_authority(a, c.scheme)
 			} else {
 				return missing(name)
 			}
@@ -132,6 +132,38 @@ fn missing(name string) IError {
 	return MalformedMessage{
 		reason: 'covered component "${name}" is not present in the message'
 	}
+}
+
+// normalize_authority lowercases the authority and strips the port when
+// it equals the URI scheme's default (RFC 9421 §2.2.3 + RFC 9110 §4.2.3).
+// Without this, peers that emit `example.com` and peers that emit
+// `example.com:443` produce different signature bases for the same
+// resource and fail to interoperate.
+fn normalize_authority(authority string, scheme ?string) string {
+	lower := authority.to_lower()
+	port_colon := find_port_colon(lower) or { return lower }
+	port := lower[port_colon + 1..]
+	scheme_lower := if s := scheme { s.to_lower() } else { '' }
+	if (scheme_lower == 'https' && port == '443') || (scheme_lower == 'http' && port == '80') {
+		return lower[..port_colon]
+	}
+	return lower
+}
+
+// find_port_colon returns the index of the ':' that separates the port
+// in an authority, or `none` if no port is present. IPv6 literals embed
+// colons inside `[...]`; the port colon (if any) is the one immediately
+// following the closing bracket.
+fn find_port_colon(authority string) ?int {
+	if authority.starts_with('[') {
+		bracket := authority.index(']') or { return none }
+		if bracket + 1 < authority.len && authority[bracket + 1] == `:` {
+			return bracket + 1
+		}
+		return none
+	}
+	colon := authority.last_index(':') or { return none }
+	return colon
 }
 
 // trim_ows removes leading/trailing OWS (RFC 7230 §3.2.3 - SP and

--- a/vlib/net/http/signature/components.v
+++ b/vlib/net/http/signature/components.v
@@ -1,0 +1,149 @@
+// Components captures the inputs the signing/verifying side reads
+// when it builds the signature base. It is deliberately decoupled
+// from `http.Request` / `http.Response` so the same primitives work
+// for messages produced by any HTTP stack (or for offline signing).
+//
+// The `request_*` and `response_*` slots overlap on purpose - a
+// Components value typically describes either a request or a
+// response, and unused fields stay `none`.
+module signature
+
+// Components is the side-channel input for `signature_base_string`.
+// Empty / `none` fields mean "not available" - the signer / verifier
+// returns `MalformedMessage` if the covered-components list mentions
+// a derived component whose source is `none` here.
+pub struct Components {
+pub mut:
+	// Derived components covered by RFC 9421 §2.2.
+	method         ?string
+	target_uri     ?string // full request URI, used by @target-uri
+	authority      ?string // host[:port] of the request
+	scheme         ?string // "http" | "https"
+	request_target ?string // method-line target as-on-the-wire
+	path           ?string // path component of the URI
+	query          ?string // query component INCLUDING the leading "?"
+	// status applies to response signing/verification (@status, §2.2.9).
+	status ?int
+	// fields holds HTTP header field values keyed by *lowercased*
+	// field name, with the slice preserving the order multiple values
+	// arrive in. Values are joined with ", " on emission per
+	// RFC 9421 §2.1.
+	fields map[string][]string
+}
+
+// add_field is sugar for accumulating header values without juggling
+// the underlying map manually. Consecutive calls preserve insertion
+// order, which matters for fields that appear more than once.
+pub fn (mut c Components) add_field(name string, value string) {
+	lname := name.to_lower()
+	if lname in c.fields {
+		mut existing := c.fields[lname]
+		existing << value
+		c.fields[lname] = existing
+	} else {
+		c.fields[lname] = [value]
+	}
+}
+
+// component_value returns the canonical string the component
+// contributes to the signature base. Derived components start with
+// '@'; everything else is treated as an HTTP field name (lowercased
+// for lookup, RFC 9421 §2.1.3).
+fn (c Components) component_value(name string) !string {
+	if name != '' && name[0] == `@` {
+		return c.derived_value(name)!
+	}
+	return c.field_value(name)!
+}
+
+fn (c Components) derived_value(name string) !string {
+	return match name {
+		'@method' {
+			c.method or { return missing(name) }
+		}
+		'@target-uri' {
+			c.target_uri or { return missing(name) }
+		}
+		'@authority' {
+			if a := c.authority {
+				a.to_lower()
+			} else {
+				return missing(name)
+			}
+		}
+		'@scheme' {
+			if s := c.scheme {
+				s.to_lower()
+			} else {
+				return missing(name)
+			}
+		}
+		'@request-target' {
+			c.request_target or { return missing(name) }
+		}
+		'@path' {
+			c.path or { return missing(name) }
+		}
+		'@query' {
+			// RFC 9421 §2.2.7: the value MUST include the leading "?".
+			// If query is empty, the value is the single character "?".
+			if q := c.query {
+				if q.len == 0 || q[0] != `?` {
+					'?' + q
+				} else {
+					q
+				}
+			} else {
+				return missing(name)
+			}
+		}
+		'@status' {
+			if s := c.status {
+				s.str()
+			} else {
+				return missing(name)
+			}
+		}
+		else {
+			return MalformedMessage{
+				reason: 'unsupported derived component "${name}"'
+			}
+		}
+	}
+}
+
+fn (c Components) field_value(name string) !string {
+	lname := name.to_lower()
+	values := c.fields[lname] or { return missing(name) }
+	if values.len == 0 {
+		return missing(name)
+	}
+	if values.len == 1 {
+		return trim_ows(values[0])
+	}
+	mut trimmed := []string{cap: values.len}
+	for v in values {
+		trimmed << trim_ows(v)
+	}
+	return trimmed.join(', ')
+}
+
+fn missing(name string) IError {
+	return MalformedMessage{
+		reason: 'covered component "${name}" is not present in the message'
+	}
+}
+
+// trim_ows removes leading/trailing OWS (RFC 7230 §3.2.3 - SP and
+// HTAB). RFC 9421 §2.1 step 3 mandates this trim before signing.
+fn trim_ows(s string) string {
+	mut start := 0
+	mut end := s.len
+	for start < end && (s[start] == ` ` || s[start] == `\t`) {
+		start++
+	}
+	for end > start && (s[end - 1] == ` ` || s[end - 1] == `\t`) {
+		end--
+	}
+	return s[start..end]
+}

--- a/vlib/net/http/signature/components_test.v
+++ b/vlib/net/http/signature/components_test.v
@@ -1,0 +1,76 @@
+// Tests for derived component canonicalization rules from RFC 9421 §2.2.
+module signature
+
+fn test_authority_strips_default_https_port() {
+	c := Components{
+		authority: 'Example.com:443'
+		scheme:    'https'
+	}
+	assert c.derived_value('@authority')! == 'example.com'
+}
+
+fn test_authority_strips_default_http_port() {
+	c := Components{
+		authority: 'example.com:80'
+		scheme:    'http'
+	}
+	assert c.derived_value('@authority')! == 'example.com'
+}
+
+fn test_authority_keeps_non_default_port() {
+	c := Components{
+		authority: 'example.com:8443'
+		scheme:    'https'
+	}
+	assert c.derived_value('@authority')! == 'example.com:8443'
+}
+
+fn test_authority_does_not_strip_when_scheme_mismatched() {
+	// :80 with https scheme is *not* the default, so it must stay.
+	c := Components{
+		authority: 'example.com:80'
+		scheme:    'https'
+	}
+	assert c.derived_value('@authority')! == 'example.com:80'
+}
+
+fn test_authority_no_port_unchanged() {
+	c := Components{
+		authority: 'Example.COM'
+		scheme:    'https'
+	}
+	assert c.derived_value('@authority')! == 'example.com'
+}
+
+fn test_authority_ipv6_strips_default_port() {
+	c := Components{
+		authority: '[2001:db8::1]:443'
+		scheme:    'https'
+	}
+	assert c.derived_value('@authority')! == '[2001:db8::1]'
+}
+
+fn test_authority_ipv6_keeps_non_default_port() {
+	c := Components{
+		authority: '[2001:db8::1]:8443'
+		scheme:    'https'
+	}
+	assert c.derived_value('@authority')! == '[2001:db8::1]:8443'
+}
+
+fn test_authority_ipv6_no_port_unchanged() {
+	c := Components{
+		authority: '[2001:db8::1]'
+		scheme:    'https'
+	}
+	assert c.derived_value('@authority')! == '[2001:db8::1]'
+}
+
+fn test_authority_no_scheme_keeps_port() {
+	// Without a scheme we cannot know which port is the default, so
+	// the port is preserved.
+	c := Components{
+		authority: 'example.com:443'
+	}
+	assert c.derived_value('@authority')! == 'example.com:443'
+}

--- a/vlib/net/http/signature/components_test.v
+++ b/vlib/net/http/signature/components_test.v
@@ -1,3 +1,4 @@
+// vtest build: present_openssl? && !(openbsd && gcc) && !(sanitize-memory-clang || docker-ubuntu-musl)
 // Tests for derived component canonicalization rules from RFC 9421 §2.2.
 module signature
 

--- a/vlib/net/http/signature/errors.v
+++ b/vlib/net/http/signature/errors.v
@@ -1,0 +1,68 @@
+// Typed errors surfaced by the signature module. All concrete error
+// types embed `Error` so callers can pattern-match with `err is X` (V's
+// idiomatic typed-error matching).
+module signature
+
+// VerificationFailed is returned when a signature does not match the
+// recomputed signature base. Distinct from `MalformedMessage` so that
+// callers can tell "wire bytes are fine but signature is bad" apart
+// from "wire bytes are unparseable".
+pub struct VerificationFailed {
+	Error
+pub:
+	label string
+}
+
+// msg formats a VerificationFailed for `IError.msg()`.
+pub fn (e &VerificationFailed) msg() string {
+	if e.label != '' {
+		return 'http.signature: signature ${e.label} did not verify'
+	}
+	return 'http.signature: signature did not verify'
+}
+
+// MalformedMessage covers all syntactic and structural problems with
+// the inputs (missing covered components, malformed Signature-Input,
+// unknown derived component, etc.). The `reason` field carries the
+// short human-readable detail.
+pub struct MalformedMessage {
+	Error
+pub:
+	reason string
+}
+
+// msg formats a MalformedMessage for `IError.msg()`.
+pub fn (e &MalformedMessage) msg() string {
+	return 'http.signature: ${e.reason}'
+}
+
+// UnsupportedAlgorithm is returned when the `alg` parameter (or the
+// implied algorithm of the supplied key) is not one this module
+// implements. Carrying the offending token lets callers report it
+// clearly rather than echoing a generic "not supported".
+pub struct UnsupportedAlgorithm {
+	Error
+pub:
+	name string
+}
+
+// msg formats an UnsupportedAlgorithm for `IError.msg()`.
+pub fn (e &UnsupportedAlgorithm) msg() string {
+	return 'http.signature: algorithm ${e.name} is not supported'
+}
+
+// SignatureExpired is returned by verification helpers when the
+// signature's `expires` parameter is at or before the verification
+// time. Callers that don't want this check can pass their own time
+// reference (or use the lower-level `verify` that does no time check).
+pub struct SignatureExpired {
+	Error
+pub:
+	expires i64
+	now     i64
+}
+
+// msg formats a SignatureExpired for `IError.msg()`.
+pub fn (e &SignatureExpired) msg() string {
+	return 'http.signature: signature expired (expires=${e.expires}, now=${e.now})'
+}

--- a/vlib/net/http/signature/errors.v
+++ b/vlib/net/http/signature/errors.v
@@ -53,8 +53,7 @@ pub fn (e &UnsupportedAlgorithm) msg() string {
 
 // SignatureExpired is returned by verification helpers when the
 // signature's `expires` parameter is at or before the verification
-// time. Callers that don't want this check can pass their own time
-// reference (or use the lower-level `verify` that does no time check).
+// time. Callers that don't want this check can leave `now_unix` at zero.
 pub struct SignatureExpired {
 	Error
 pub:
@@ -65,4 +64,18 @@ pub:
 // msg formats a SignatureExpired for `IError.msg()`.
 pub fn (e &SignatureExpired) msg() string {
 	return 'http.signature: signature expired (expires=${e.expires}, now=${e.now})'
+}
+
+// SignatureNotYetValid is returned by verification helpers when the
+// signature's `created` parameter is later than the verification time.
+pub struct SignatureNotYetValid {
+	Error
+pub:
+	created i64
+	now     i64
+}
+
+// msg formats a SignatureNotYetValid for `IError.msg()`.
+pub fn (e &SignatureNotYetValid) msg() string {
+	return 'http.signature: signature is not yet valid (created=${e.created}, now=${e.now})'
 }

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -1,0 +1,248 @@
+// http.Request / http.Response integration. These helpers are thin
+// wrappers - they translate the message into a `Components` value and
+// delegate to `sign` / `verify`. Keeping the conversion isolated here
+// means the components-level API stays the canonical surface.
+module signature
+
+import net.http
+import net.urllib
+import time
+
+// SignRequestOptions parametrises `sign_request`. `components` is
+// optional - when omitted we sign the conservative default
+// (`@method`, `@target-uri`, `@authority`, plus the `Date` header if
+// present). RFC 9421 doesn't mandate a default; this one mirrors what
+// most production deployments use.
+@[params]
+pub struct SignRequestOptions {
+pub:
+	components []string
+	label      string = 'sig1'
+	keyid      ?string
+	created    ?i64
+	expires    ?i64
+	nonce      ?string
+	tag        ?string
+	// include_alg, when true, emits the `alg` signature parameter on
+	// the wire. Most signers leave it off (the verifier looks the alg
+	// up by `keyid`); set to true for explicit signalling.
+	include_alg bool
+}
+
+// sign_request signs an HTTP request in place by appending the
+// `Signature-Input` and `Signature` header fields. Existing values of
+// these headers are preserved (RFC 9421 §4.3 - multiple signatures
+// can coexist), so calling this twice with different labels yields
+// two co-existing signatures.
+//
+// `created` defaults to `time.now().unix()` when omitted, since
+// RFC 9421 §7.2.1 RECOMMENDS the parameter for replay protection.
+// Pass an explicit `created: 0` only if you know you don't want it.
+pub fn sign_request(mut req http.Request, key Key, opts SignRequestOptions) ! {
+	c := request_components(req)!
+	mut comps := opts.components.clone()
+	if comps.len == 0 {
+		comps = default_request_components(req)
+	}
+	mut alg := ?string(none)
+	if opts.include_alg {
+		alg = key.algorithm.name()
+	}
+	p := SignatureParams{
+		components: comps
+		keyid:      opts.keyid
+		alg:        alg
+		created:    opts.created or { time.now().unix() }
+		expires:    opts.expires
+		nonce:      opts.nonce
+		tag:        opts.tag
+	}
+	out := sign(c, p, key, opts.label)!
+	append_dict_header(mut req.header, 'Signature-Input', out.signature_input)!
+	append_dict_header(mut req.header, 'Signature', out.signature)!
+}
+
+// VerifyRequestOptions parametrises `verify_request`. `label` selects
+// which labelled signature to verify when several are present.
+@[params]
+pub struct VerifyRequestOptions {
+pub:
+	label    string
+	now_unix i64
+}
+
+// verify_request verifies a labelled signature on an HTTP request. If
+// `opts.label` is empty and exactly one signature is present, that
+// one is checked. If `opts.now_unix > 0`, the `expires` parameter is
+// also enforced.
+pub fn verify_request(req http.Request, key Key, opts VerifyRequestOptions) ! {
+	c := request_components(req)!
+	sig_input := merged_dict_field(req.header, 'Signature-Input') or {
+		return MalformedMessage{
+			reason: 'request has no Signature-Input header'
+		}
+	}
+	sig_value := merged_dict_field(req.header, 'Signature') or {
+		return MalformedMessage{
+			reason: 'request has no Signature header'
+		}
+	}
+	verify(c, sig_input, sig_value, opts.label, key, now_unix: opts.now_unix)!
+}
+
+// SignResponseOptions / VerifyResponseOptions mirror their request
+// counterparts. Defaults assume a status-code-and-content scenario.
+@[params]
+pub struct SignResponseOptions {
+pub:
+	components  []string
+	label       string = 'sig1'
+	keyid       ?string
+	created     ?i64
+	expires     ?i64
+	nonce       ?string
+	tag         ?string
+	include_alg bool
+}
+
+// sign_response signs an HTTP response in place. Like `sign_request`
+// it preserves any pre-existing Signature-Input / Signature values
+// and defaults `created` to the current time.
+pub fn sign_response(mut resp http.Response, key Key, opts SignResponseOptions) ! {
+	c := response_components(resp)
+	mut comps := opts.components.clone()
+	if comps.len == 0 {
+		comps = ['@status']
+	}
+	mut alg := ?string(none)
+	if opts.include_alg {
+		alg = key.algorithm.name()
+	}
+	p := SignatureParams{
+		components: comps
+		keyid:      opts.keyid
+		alg:        alg
+		created:    opts.created or { time.now().unix() }
+		expires:    opts.expires
+		nonce:      opts.nonce
+		tag:        opts.tag
+	}
+	out := sign(c, p, key, opts.label)!
+	append_dict_header(mut resp.header, 'Signature-Input', out.signature_input)!
+	append_dict_header(mut resp.header, 'Signature', out.signature)!
+}
+
+@[params]
+pub struct VerifyResponseOptions {
+pub:
+	label    string
+	now_unix i64
+}
+
+// verify_response verifies a labelled signature on an HTTP response.
+pub fn verify_response(resp http.Response, key Key, opts VerifyResponseOptions) ! {
+	c := response_components(resp)
+	sig_input := merged_dict_field(resp.header, 'Signature-Input') or {
+		return MalformedMessage{
+			reason: 'response has no Signature-Input header'
+		}
+	}
+	sig_value := merged_dict_field(resp.header, 'Signature') or {
+		return MalformedMessage{
+			reason: 'response has no Signature header'
+		}
+	}
+	verify(c, sig_input, sig_value, opts.label, key, now_unix: opts.now_unix)!
+}
+
+// append_dict_header merges `addition` into the existing dictionary
+// field `name`, separating with ", " per RFC 8941 §3.2 - this keeps
+// multiple labelled signatures in a single `Signature-Input` /
+// `Signature` field as the spec recommends, even when `add_custom`
+// would otherwise create separate field instances.
+fn append_dict_header(mut h http.Header, name string, addition string) ! {
+	existing := h.get_custom(name) or {
+		h.add_custom(name, addition)!
+		return
+	}
+	h.set_custom(name, existing + ', ' + addition)!
+}
+
+// merged_dict_field returns the concatenation of all values of `name`
+// joined with ", ". HTTP/1.1 §3.2.2 lets a Structured Field appear on
+// multiple field-lines; verifiers MUST reassemble them before parsing.
+fn merged_dict_field(h http.Header, name string) ?string {
+	values := h.custom_values(name)
+	if values.len == 0 {
+		return none
+	}
+	return values.join(', ')
+}
+
+// request_components extracts the derived-component values from an
+// http.Request. The url field is parsed once; if it is not a valid
+// URL we surface a typed error rather than silently dropping
+// components that depend on it (@scheme, @authority, @path, @query).
+fn request_components(req http.Request) !Components {
+	mut c := Components{
+		method:     req.method.str()
+		target_uri: req.url
+	}
+	parsed := urllib.parse(req.url) or {
+		return MalformedMessage{
+			reason: 'request url "${req.url}" is not a valid URL: ${err.msg()}'
+		}
+	}
+	authority := if parsed.host != '' {
+		parsed.host
+	} else {
+		req.host
+	}
+	if authority != '' {
+		c.authority = authority
+	}
+	if parsed.scheme != '' {
+		c.scheme = parsed.scheme
+	}
+	if parsed.path != '' {
+		c.path = parsed.path
+	} else {
+		c.path = '/'
+	}
+	c.query = if parsed.raw_query != '' { '?' + parsed.raw_query } else { '?' }
+	mut request_target := c.path or { '/' }
+	if rq := c.query {
+		if rq != '?' {
+			request_target += rq
+		}
+	}
+	c.request_target = request_target
+	for k in req.header.keys() {
+		values := req.header.custom_values(k)
+		if values.len > 0 {
+			c.fields[k.to_lower()] = values
+		}
+	}
+	return c
+}
+
+fn response_components(resp http.Response) Components {
+	mut c := Components{
+		status: resp.status_code
+	}
+	for k in resp.header.keys() {
+		values := resp.header.custom_values(k)
+		if values.len > 0 {
+			c.fields[k.to_lower()] = values
+		}
+	}
+	return c
+}
+
+fn default_request_components(req http.Request) []string {
+	mut comps := ['@method', '@target-uri', '@authority']
+	if req.header.contains_custom('Date') {
+		comps << 'date'
+	}
+	return comps
+}

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -27,6 +27,12 @@ pub:
 	// the wire. Most signers leave it off (the verifier looks the alg
 	// up by `keyid`); set to true for explicit signalling.
 	include_alg bool
+	// scheme is used to reconstruct `@target-uri` and `@scheme` when
+	// `req.url` is origin-form (e.g. `/foo`, as produced by
+	// `http.parse_request*`). The default matches the common signing
+	// scenario (TLS-protected APIs). Ignored when `req.url` already
+	// carries a scheme.
+	scheme string = 'https'
 }
 
 // sign_request signs an HTTP request in place by appending the
@@ -39,7 +45,7 @@ pub:
 // RFC 9421 §7.2.1 RECOMMENDS the parameter for replay protection.
 // Pass an explicit `created: 0` only if you know you don't want it.
 pub fn sign_request(mut req http.Request, key Key, opts SignRequestOptions) ! {
-	c := request_components(req)!
+	c := request_components(req, opts.scheme)!
 	mut comps := opts.components.clone()
 	if comps.len == 0 {
 		comps = default_request_components(req)
@@ -69,6 +75,10 @@ pub struct VerifyRequestOptions {
 pub:
 	label    string
 	now_unix i64
+	// scheme — see SignRequestOptions.scheme. Both ends of the
+	// signature must agree on the scheme used to reconstruct the
+	// target URI, otherwise the signature bases differ.
+	scheme string = 'https'
 }
 
 // verify_request verifies a labelled signature on an HTTP request. If
@@ -76,7 +86,7 @@ pub:
 // one is checked. If `opts.now_unix > 0`, the `expires` parameter is
 // also enforced.
 pub fn verify_request(req http.Request, key Key, opts VerifyRequestOptions) ! {
-	c := request_components(req)!
+	c := request_components(req, opts.scheme)!
 	sig_input := merged_dict_field(req.header, 'Signature-Input') or {
 		return MalformedMessage{
 			reason: 'request has no Signature-Input header'
@@ -180,14 +190,13 @@ fn merged_dict_field(h http.Header, name string) ?string {
 }
 
 // request_components extracts the derived-component values from an
-// http.Request. The url field is parsed once; if it is not a valid
-// URL we surface a typed error rather than silently dropping
-// components that depend on it (@scheme, @authority, @path, @query).
-fn request_components(req http.Request) !Components {
-	mut c := Components{
-		method:     req.method.str()
-		target_uri: req.url
-	}
+// http.Request. `default_scheme` is used when `req.url` is in
+// origin-form (e.g. `/foo?bar=1`, as produced by `http.parse_request*`
+// for inbound HTTP/1.1 messages); in that case `@target-uri` is
+// reconstructed as `<scheme>://<authority><url>` per RFC 9110 §7.1.
+// If `req.url` is not a valid URL we surface a typed error rather
+// than silently dropping components that depend on it.
+fn request_components(req http.Request, default_scheme string) !Components {
 	parsed := urllib.parse(req.url) or {
 		return MalformedMessage{
 			reason: 'request url "${req.url}" is not a valid URL: ${err.msg()}'
@@ -198,11 +207,21 @@ fn request_components(req http.Request) !Components {
 	} else {
 		req.host
 	}
+	scheme := if parsed.scheme != '' { parsed.scheme } else { default_scheme }
+	mut c := Components{
+		method: req.method.str()
+	}
+	is_origin_form := req.url.starts_with('/')
+	c.target_uri = if is_origin_form && authority != '' {
+		'${scheme}://${authority}${req.url}'
+	} else {
+		req.url
+	}
 	if authority != '' {
 		c.authority = authority
 	}
-	if parsed.scheme != '' {
-		c.scheme = parsed.scheme
+	if scheme != '' {
+		c.scheme = scheme
 	}
 	if parsed.path != '' {
 		c.path = parsed.path

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -130,6 +130,7 @@ pub fn sign_response(mut resp http.Response, key Key, opts SignResponseOptions) 
 		comps = ['@status']
 	}
 	validate_stable_signature_components(comps)!
+	validate_response_component_coverage(comps)!
 	if comps.any(it.to_lower() == 'content-length') && !resp.header.contains(.content_length) {
 		// Insert the field so both HTTP/1.x and HTTP/2 actually transmit the
 		// value covered by the signature.
@@ -275,6 +276,17 @@ fn validate_request_component_coverage(req http.Request, components []string, de
 	}
 }
 
+fn validate_response_component_coverage(components []string) ! {
+	for component in components {
+		name := component.to_lower()
+		if name in ['connection', 'keep-alive', 'proxy-connection', 'transfer-encoding', 'upgrade'] {
+			return MalformedMessage{
+				reason: 'covered response field "${name}" may be removed by HTTP/2 transport'
+			}
+		}
+	}
+}
+
 enum RequestComponentsMode {
 	outgoing
 	incoming
@@ -285,13 +297,18 @@ enum RequestComponentsMode {
 // serialization, while incoming values preserve the parsed request target.
 // `default_scheme` reconstructs `@target-uri` for origin-form input.
 fn request_components(req http.Request, default_scheme string, mode RequestComponentsMode) !Components {
-	parsed := urllib.parse(req.url) or {
+	is_authority_form := mode == .incoming && req.method == .connect
+	is_asterisk_form := mode == .incoming && req.method == .options && req.url == '*'
+	parse_target := if is_authority_form || is_asterisk_form { '/' } else { req.url }
+	parsed := urllib.parse(parse_target) or {
 		return MalformedMessage{
 			reason: 'request url "${req.url}" is not a valid URL: ${err.msg()}'
 		}
 	}
 	uses_absolute_form := mode == .outgoing && !isnil(req.proxy) && parsed.scheme == 'http'
-	mut authority := if parsed.host != '' {
+	mut authority := if is_authority_form {
+		req.url
+	} else if parsed.host != '' {
 		parsed.host
 	} else {
 		req.host
@@ -308,13 +325,23 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 			}
 		}
 	}
-	scheme := if parsed.scheme != '' { parsed.scheme } else { default_scheme }
+	scheme := if !is_authority_form && !is_asterisk_form && parsed.scheme != '' {
+		parsed.scheme
+	} else {
+		default_scheme
+	}
 	mut c := Components{
 		method: req.method.str()
 	}
 	is_origin_form := req.url.starts_with('/')
 	escaped_path := parsed.escaped_path()
-	incoming_path := if escaped_path != '' { escaped_path } else { '/' }
+	incoming_path := if is_authority_form || is_asterisk_form {
+		'/'
+	} else if escaped_path != '' {
+		escaped_path
+	} else {
+		'/'
+	}
 	// Keep this in sync with Request.method_and_url_to_response: it removes
 	// duplicate leading slashes and re-encodes query values before sending.
 	transport_path := '/' + escaped_path.trim_left('/')
@@ -335,6 +362,8 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 	}
 	c.target_uri = if mode == .outgoing && parsed.host != '' {
 		'${scheme}://${authority}${origin_target}'
+	} else if (is_authority_form || is_asterisk_form) && authority != '' && scheme != '' {
+		'${scheme}://${authority}'
 	} else if is_origin_form && authority != '' && scheme != '' {
 		'${scheme}://${authority}${req.url}'
 	} else {

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -45,7 +45,7 @@ pub:
 // RFC 9421 §7.2.1 RECOMMENDS the parameter for replay protection.
 // Pass an explicit `created: 0` only if you know you don't want it.
 pub fn sign_request(mut req http.Request, key Key, opts SignRequestOptions) ! {
-	c := request_components(req, opts.scheme)!
+	c := request_components(req, opts.scheme, .outgoing)!
 	mut comps := opts.components.clone()
 	if comps.len == 0 {
 		comps = default_request_components(req)
@@ -86,7 +86,7 @@ pub:
 // one is checked. If `opts.now_unix > 0`, the `expires` parameter is
 // also enforced.
 pub fn verify_request(req http.Request, key Key, opts VerifyRequestOptions) ! {
-	c := request_components(req, opts.scheme)!
+	c := request_components(req, opts.scheme, .incoming)!
 	sig_input := merged_dict_field(req.header, 'Signature-Input') or {
 		return MalformedMessage{
 			reason: 'request has no Signature-Input header'
@@ -203,14 +203,16 @@ fn merged_dict_field(h http.Header, name string) ?string {
 	return values.join(', ')
 }
 
+enum RequestComponentsMode {
+	outgoing
+	incoming
+}
+
 // request_components extracts the derived-component values from an
-// http.Request. `default_scheme` is used when `req.url` is in
-// origin-form (e.g. `/foo?bar=1`, as produced by `http.parse_request*`
-// for inbound HTTP/1.1 messages); in that case `@target-uri` is
-// reconstructed as `<scheme>://<authority><url>` per RFC 9110 §7.1.
-// If `req.url` is not a valid URL we surface a typed error rather
-// than silently dropping components that depend on it.
-fn request_components(req http.Request, default_scheme string) !Components {
+// http.Request. Outgoing values match net.http's request-line and header
+// serialization, while incoming values preserve the parsed request target.
+// `default_scheme` reconstructs `@target-uri` for origin-form input.
+fn request_components(req http.Request, default_scheme string, mode RequestComponentsMode) !Components {
 	parsed := urllib.parse(req.url) or {
 		return MalformedMessage{
 			reason: 'request url "${req.url}" is not a valid URL: ${err.msg()}'
@@ -226,9 +228,30 @@ fn request_components(req http.Request, default_scheme string) !Components {
 		method: req.method.str()
 	}
 	is_origin_form := req.url.starts_with('/')
-	request_target := parsed.request_uri()
-	c.target_uri = if authority != '' && scheme != '' && (is_origin_form || parsed.host != '') {
-		'${scheme}://${authority}${request_target}'
+	escaped_path := parsed.escaped_path()
+	incoming_path := if escaped_path != '' { escaped_path } else { '/' }
+	// Keep this in sync with Request.method_and_url_to_response: it removes
+	// duplicate leading slashes and re-encodes query values before sending.
+	transport_path := '/' + escaped_path.trim_left('/')
+	transport_query := parsed.query().encode()
+	origin_target := if transport_query != '' {
+		'${transport_path}?${transport_query}'
+	} else {
+		transport_path
+	}
+	request_target := if mode == .outgoing {
+		if !isnil(req.proxy) && parsed.scheme == 'http' {
+			'${scheme}://${transport_authority(parsed)}${origin_target}'
+		} else {
+			origin_target
+		}
+	} else {
+		req.url
+	}
+	c.target_uri = if mode == .outgoing && parsed.host != '' {
+		'${scheme}://${transport_authority(parsed)}${origin_target}'
+	} else if is_origin_form && authority != '' && scheme != '' {
+		'${scheme}://${authority}${req.url}'
 	} else {
 		req.url
 	}
@@ -238,21 +261,29 @@ fn request_components(req http.Request, default_scheme string) !Components {
 	if scheme != '' {
 		c.scheme = scheme
 	}
-	escaped_path := parsed.escaped_path()
-	if escaped_path != '' {
-		c.path = escaped_path
-	} else {
-		c.path = '/'
-	}
-	c.query = if parsed.raw_query != '' { '?' + parsed.raw_query } else { '?' }
+	c.path = if mode == .outgoing { transport_path } else { incoming_path }
+	query := if mode == .outgoing { transport_query } else { parsed.raw_query }
+	c.query = if query != '' { '?' + query } else { '?' }
 	c.request_target = request_target
 	for k in req.header.keys() {
 		values := req.header.custom_values(k)
 		if values.len > 0 {
-			c.fields[k.to_lower()] = values
+			// HTTP/1.x emits repeated custom header values on one field line,
+			// separated with `; `. Sign that exact serialized representation.
+			c.fields[k.to_lower()] = if mode == .outgoing { [
+					values.join('; ')] } else { values }
 		}
 	}
 	return c
+}
+
+fn transport_authority(url urllib.URL) string {
+	hostname := url.hostname()
+	port := url.port().int()
+	if port == 0 || (url.scheme == 'http' && port == 80) || (url.scheme == 'https' && port == 443) {
+		return hostname
+	}
+	return '${hostname}:${port}'
 }
 
 fn response_components(resp http.Response) Components {

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -46,11 +46,13 @@ pub:
 // RFC 9421 §7.2.1 RECOMMENDS the parameter for replay protection.
 // Pass an explicit `created: 0` only if you know you don't want it.
 pub fn sign_request(mut req http.Request, key Key, opts SignRequestOptions) ! {
+	ensure_signature_label_available(req.header, opts.label)!
 	c := request_components(req, opts.scheme, .outgoing)!
 	mut comps := opts.components.clone()
 	if comps.len == 0 {
 		comps = default_request_components(req)
 	}
+	validate_request_component_coverage(req, comps, opts.scheme)!
 	mut alg := ?string(none)
 	if opts.include_alg {
 		alg = key.algorithm.name()
@@ -121,6 +123,7 @@ pub:
 // it preserves any pre-existing Signature-Input / Signature values
 // and defaults `created` to the current time.
 pub fn sign_response(mut resp http.Response, key Key, opts SignResponseOptions) ! {
+	ensure_signature_label_available(resp.header, opts.label)!
 	mut comps := opts.components.clone()
 	if comps.len == 0 {
 		comps = ['@status']
@@ -208,6 +211,49 @@ fn merged_dict_field(h http.Header, name string) ?string {
 		return none
 	}
 	return values.join(', ')
+}
+
+fn ensure_signature_label_available(h http.Header, label string) ! {
+	check_label(label)!
+	if input := merged_dict_field(h, 'Signature-Input') {
+		entries := parse_signature_input(input)!
+		if entries.any(it.label == label) {
+			return MalformedMessage{
+				reason: 'signature label "${label}" already exists in Signature-Input'
+			}
+		}
+	}
+	if signatures := merged_dict_field(h, 'Signature') {
+		parsed := parse_signature(signatures)!
+		if label in parsed {
+			return MalformedMessage{
+				reason: 'signature label "${label}" already exists in Signature'
+			}
+		}
+	}
+}
+
+fn validate_request_component_coverage(req http.Request, components []string, default_scheme string) ! {
+	if !req.enable_http2 {
+		return
+	}
+	parsed := urllib.parse(req.url) or {
+		return MalformedMessage{
+			reason: 'request url "${req.url}" is not a valid URL: ${err.msg()}'
+		}
+	}
+	scheme := if parsed.scheme != '' { parsed.scheme } else { default_scheme }
+	if scheme != 'https' {
+		return
+	}
+	for component in components {
+		name := component.to_lower()
+		if name in ['connection', 'keep-alive', 'proxy-connection', 'transfer-encoding', 'upgrade'] {
+			return MalformedMessage{
+				reason: 'covered field "${name}" may be removed during HTTP/2 negotiation'
+			}
+		}
+	}
 }
 
 enum RequestComponentsMode {

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -218,10 +218,19 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 			reason: 'request url "${req.url}" is not a valid URL: ${err.msg()}'
 		}
 	}
-	authority := if parsed.host != '' {
+	mut authority := if parsed.host != '' {
 		parsed.host
 	} else {
 		req.host
+	}
+	if mode == .outgoing {
+		if host := req.header.get(.host) {
+			if host != '' {
+				authority = host
+			}
+		} else if parsed.host != '' {
+			authority = transport_authority(parsed)
+		}
 	}
 	scheme := if parsed.scheme != '' { parsed.scheme } else { default_scheme }
 	mut c := Components{
@@ -249,7 +258,7 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 		req.url
 	}
 	c.target_uri = if mode == .outgoing && parsed.host != '' {
-		'${scheme}://${transport_authority(parsed)}${origin_target}'
+		'${scheme}://${authority}${origin_target}'
 	} else if is_origin_form && authority != '' && scheme != '' {
 		'${scheme}://${authority}${req.url}'
 	} else {
@@ -268,10 +277,7 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 	for k in req.header.keys() {
 		values := req.header.custom_values(k)
 		if values.len > 0 {
-			// HTTP/1.x emits repeated custom header values on one field line,
-			// separated with `; `. Sign that exact serialized representation.
-			c.fields[k.to_lower()] = if mode == .outgoing { [
-					values.join('; ')] } else { values }
+			c.fields[k.to_lower()] = values
 		}
 	}
 	return c

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -440,6 +440,10 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 		}
 	}
 	if mode == .incoming && req.version == .v2_0 {
+		// net.http synthesizes Host from :authority for handler compatibility,
+		// without retaining its provenance. Conservatively disallow Host
+		// coverage for incoming HTTP/2; @authority remains available.
+		c.fields.delete('host')
 		cookie_values := req.header.custom_values('Cookie')
 		if cookie_values.len > 0 {
 			c.fields['cookie'] = [cookie_values.map(it.trim_space()).join('; ')]

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -351,7 +351,7 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 		if !uses_absolute_form {
 			if host := req.header.get(.host) {
 				if host != '' {
-					authority = host
+					authority = host.trim_space()
 				}
 			}
 		}

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -426,7 +426,7 @@ fn transport_authority(url urllib.URL) string {
 fn response_components(resp http.Response) Components {
 	wire_status := if resp.status_code >= 100 && resp.status_code <= 599 {
 		resp.status_code
-	} else if resp.status_code == 0 && resp.status_msg == '' {
+	} else if resp.status_code == 0 {
 		200
 	} else {
 		500

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -226,8 +226,9 @@ fn request_components(req http.Request, default_scheme string) !Components {
 		method: req.method.str()
 	}
 	is_origin_form := req.url.starts_with('/')
-	c.target_uri = if is_origin_form && authority != '' {
-		'${scheme}://${authority}${req.url}'
+	request_target := parsed.request_uri()
+	c.target_uri = if authority != '' && scheme != '' && (is_origin_form || parsed.host != '') {
+		'${scheme}://${authority}${request_target}'
 	} else {
 		req.url
 	}
@@ -244,12 +245,6 @@ fn request_components(req http.Request, default_scheme string) !Components {
 		c.path = '/'
 	}
 	c.query = if parsed.raw_query != '' { '?' + parsed.raw_query } else { '?' }
-	mut request_target := c.path or { '/' }
-	if rq := c.query {
-		if rq != '?' {
-			request_target += rq
-		}
-	}
 	c.request_target = request_target
 	for k in req.header.keys() {
 		values := req.header.custom_values(k)

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -54,6 +54,7 @@ pub fn sign_request(mut req http.Request, key Key, opts SignRequestOptions) ! {
 	}
 	validate_stable_signature_components(comps)!
 	validate_request_component_coverage(req, comps, opts.scheme)!
+	ensure_signature_header_capacity(req.header, 0)!
 	mut alg := ?string(none)
 	if opts.include_alg {
 		alg = key.algorithm.name()
@@ -131,7 +132,10 @@ pub fn sign_response(mut resp http.Response, key Key, opts SignResponseOptions) 
 	}
 	validate_stable_signature_components(comps)!
 	validate_response_component_coverage(comps)!
-	if comps.any(it.to_lower() == 'content-length') && !resp.header.contains(.content_length) {
+	adds_content_length := comps.any(it.to_lower() == 'content-length')
+		&& !resp.header.contains(.content_length)
+	ensure_signature_header_capacity(resp.header, if adds_content_length { 1 } else { 0 })!
+	if adds_content_length {
 		// Insert the field so both HTTP/1.x and HTTP/2 actually transmit the
 		// value covered by the signature.
 		resp.header.set(.content_length, resp.body.len.str())
@@ -236,6 +240,23 @@ fn ensure_signature_label_available(h http.Header, label string) ! {
 	}
 }
 
+fn ensure_signature_header_capacity(h http.Header, extra_slots int) ! {
+	input_count := h.custom_values('Signature-Input').len
+	signature_count := h.custom_values('Signature').len
+	mut current_slots := 0
+	for key in h.keys() {
+		current_slots += h.custom_values(key, exact: true).len
+	}
+	// Each signature field is collapsed to one slot when appending. Account for
+	// those replacements as well as any earlier mutation sign_response needs.
+	future_slots := current_slots - input_count - signature_count + 2 + extra_slots
+	if future_slots > http.max_headers {
+		return MalformedMessage{
+			reason: 'signing requires ${future_slots} header slots, but http.Header supports ${http.max_headers}'
+		}
+	}
+}
+
 fn validate_stable_signature_components(components []string) ! {
 	for component in components {
 		name := component.to_lower()
@@ -267,6 +288,11 @@ fn validate_request_component_coverage(req http.Request, components []string, de
 	}
 	for component in components {
 		name := component.to_lower()
+		if name == 'host' {
+			return MalformedMessage{
+				reason: 'covered field "host" is replaced by "@authority" during HTTP/2 negotiation'
+			}
+		}
 		if name in ['connection', 'keep-alive', 'proxy-connection', 'transfer-encoding', 'upgrade'] {
 			return MalformedMessage{
 				reason: 'covered field "${name}" may be removed during HTTP/2 negotiation'

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -39,7 +39,8 @@ pub:
 // `Signature-Input` and `Signature` header fields. Existing values of
 // these headers are preserved (RFC 9421 §4.3 - multiple signatures
 // can coexist), so calling this twice with different labels yields
-// two co-existing signatures.
+// two co-existing signatures. Automatic redirects are disabled because
+// the signature only covers this request target and method.
 //
 // `created` defaults to `time.now().unix()` when omitted, since
 // RFC 9421 §7.2.1 RECOMMENDS the parameter for replay protection.
@@ -66,6 +67,7 @@ pub fn sign_request(mut req http.Request, key Key, opts SignRequestOptions) ! {
 	out := sign(c, p, key, opts.label)!
 	append_dict_header(mut req.header, 'Signature-Input', out.signature_input)!
 	append_dict_header(mut req.header, 'Signature', out.signature)!
+	req.allow_redirect = false
 }
 
 // VerifyRequestOptions parametrises `verify_request`. `label` selects
@@ -278,7 +280,7 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 	query := if mode == .outgoing { transport_query } else { parsed.raw_query }
 	c.query = if query != '' { '?' + query } else { '?' }
 	c.request_target = request_target
-	for k in req.header.keys() {
+	for k in req.header.unique_keys() {
 		values := req.header.custom_values(k)
 		if values.len > 0 {
 			c.fields[k.to_lower()] = values
@@ -323,11 +325,14 @@ fn response_components(resp http.Response) Components {
 	mut c := Components{
 		status: wire_status
 	}
-	for k in resp.header.keys() {
+	for k in resp.header.unique_keys() {
 		values := resp.header.custom_values(k)
 		if values.len > 0 {
 			c.fields[k.to_lower()] = values
 		}
+	}
+	if !resp.header.contains(.content_length) {
+		c.fields['content-length'] = [resp.body.len.str()]
 	}
 	return c
 }

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -121,11 +121,16 @@ pub:
 // it preserves any pre-existing Signature-Input / Signature values
 // and defaults `created` to the current time.
 pub fn sign_response(mut resp http.Response, key Key, opts SignResponseOptions) ! {
-	c := response_components(resp)
 	mut comps := opts.components.clone()
 	if comps.len == 0 {
 		comps = ['@status']
 	}
+	if comps.any(it.to_lower() == 'content-length') && !resp.header.contains(.content_length) {
+		// Insert the field so both HTTP/1.x and HTTP/2 actually transmit the
+		// value covered by the signature.
+		resp.header.set(.content_length, resp.body.len.str())
+	}
+	c := response_components(resp)
 	mut alg := ?string(none)
 	if opts.include_alg {
 		alg = key.algorithm.name()
@@ -330,9 +335,6 @@ fn response_components(resp http.Response) Components {
 		if values.len > 0 {
 			c.fields[k.to_lower()] = values
 		}
-	}
-	if !resp.header.contains(.content_length) {
-		c.fields['content-length'] = [resp.body.len.str()]
 	}
 	return c
 }

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -44,12 +44,19 @@ pub:
 //
 // `created` defaults to `time.now().unix()` when omitted, since
 // RFC 9421 §7.2.1 RECOMMENDS the parameter for replay protection.
-// Pass an explicit `created: 0` only if you know you don't want it.
+// Pass an explicit `created: 0` only if you know you don't want it. The
+// default component profile additionally requires and covers Content-Digest
+// when the request has a body.
 pub fn sign_request(mut req http.Request, key Key, opts SignRequestOptions) ! {
 	ensure_signature_label_available(req.header, opts.label)!
 	c := request_components(req, opts.scheme, .outgoing)!
 	mut comps := opts.components.clone()
 	if comps.len == 0 {
+		if req.data != '' && !req.header.contains_custom('Content-Digest') {
+			return MalformedMessage{
+				reason: 'default signing of a request body requires a Content-Digest field'
+			}
+		}
 		comps = default_request_components(req)
 	}
 	validate_stable_signature_components(comps)!
@@ -81,7 +88,8 @@ pub struct VerifyRequestOptions {
 pub:
 	label    string
 	now_unix i64
-	// required_components defaults to @method, @target-uri, and @authority.
+	// required_components defaults to @method, @target-uri, and @authority,
+	// plus content-digest for a body.
 	required_components []string
 	// scheme — see SignRequestOptions.scheme. Both ends of the
 	// signature must agree on the scheme used to reconstruct the
@@ -91,10 +99,10 @@ pub:
 
 // verify_request verifies a labelled signature on an HTTP request. If
 // `opts.label` is empty and exactly one signature is present, that
-// one is checked. If `opts.now_unix > 0`, the `expires` parameter is
-// also enforced. By default, coverage of @method, @target-uri, and
-// @authority is required; pass an explicit application profile through
-// `required_components` to override that policy.
+// one is checked. If `opts.now_unix > 0`, the signature time bounds are
+// enforced. By default, coverage of @method, @target-uri, and
+// @authority is required, plus content-digest for a body; pass an explicit
+// application profile through `required_components` to override that policy.
 pub fn verify_request(req http.Request, key Key, opts VerifyRequestOptions) ! {
 	c := request_components(req, opts.scheme, .incoming)!
 	sig_input := merged_dict_field(req.header, 'Signature-Input') or {
@@ -109,6 +117,8 @@ pub fn verify_request(req http.Request, key Key, opts VerifyRequestOptions) ! {
 	}
 	required := if opts.required_components.len > 0 {
 		opts.required_components
+	} else if req.data != '' {
+		['@method', '@target-uri', '@authority', 'content-digest']
 	} else {
 		['@method', '@target-uri', '@authority']
 	}
@@ -531,6 +541,9 @@ fn default_request_components(req http.Request) []string {
 	mut comps := ['@method', '@target-uri', '@authority']
 	if req.header.contains_custom('Date') {
 		comps << 'date'
+	}
+	if req.data != '' {
+		comps << 'content-digest'
 	}
 	return comps
 }

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -390,6 +390,12 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 			c.fields[k.to_lower()] = values
 		}
 	}
+	if mode == .incoming && req.version == .v2_0 {
+		cookie_values := req.header.custom_values('Cookie')
+		if cookie_values.len > 0 {
+			c.fields['cookie'] = [cookie_values.map(it.trim_space()).join('; ')]
+		}
+	}
 	if mode == .outgoing {
 		if !req.header.contains(.host) {
 			c.fields['host'] = [transport_authority(parsed)]
@@ -418,8 +424,7 @@ fn transport_authority(url urllib.URL) string {
 }
 
 fn response_components(resp http.Response) Components {
-	status := http.status_from_int(resp.status_code)
-	wire_status := if status.is_valid() {
+	wire_status := if resp.status_code >= 100 && resp.status_code <= 599 {
 		resp.status_code
 	} else if resp.status_code == 0 && resp.status_msg == '' {
 		200

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -81,6 +81,8 @@ pub struct VerifyRequestOptions {
 pub:
 	label    string
 	now_unix i64
+	// required_components defaults to @method, @target-uri, and @authority.
+	required_components []string
 	// scheme — see SignRequestOptions.scheme. Both ends of the
 	// signature must agree on the scheme used to reconstruct the
 	// target URI, otherwise the signature bases differ.
@@ -90,7 +92,9 @@ pub:
 // verify_request verifies a labelled signature on an HTTP request. If
 // `opts.label` is empty and exactly one signature is present, that
 // one is checked. If `opts.now_unix > 0`, the `expires` parameter is
-// also enforced.
+// also enforced. By default, coverage of @method, @target-uri, and
+// @authority is required; pass an explicit application profile through
+// `required_components` to override that policy.
 pub fn verify_request(req http.Request, key Key, opts VerifyRequestOptions) ! {
 	c := request_components(req, opts.scheme, .incoming)!
 	sig_input := merged_dict_field(req.header, 'Signature-Input') or {
@@ -103,7 +107,15 @@ pub fn verify_request(req http.Request, key Key, opts VerifyRequestOptions) ! {
 			reason: 'request has no Signature header'
 		}
 	}
-	verify(c, sig_input, sig_value, opts.label, key, now_unix: opts.now_unix)!
+	required := if opts.required_components.len > 0 {
+		opts.required_components
+	} else {
+		['@method', '@target-uri', '@authority']
+	}
+	verify(c, sig_input, sig_value, opts.label, key,
+		now_unix:            opts.now_unix
+		required_components: required
+	)!
 }
 
 // SignResponseOptions / VerifyResponseOptions mirror their request
@@ -164,9 +176,12 @@ pub struct VerifyResponseOptions {
 pub:
 	label    string
 	now_unix i64
+	// required_components defaults to @status.
+	required_components []string
 }
 
-// verify_response verifies a labelled signature on an HTTP response.
+// verify_response verifies a labelled signature on an HTTP response and
+// requires @status coverage unless `required_components` is set explicitly.
 pub fn verify_response(resp http.Response, key Key, opts VerifyResponseOptions) ! {
 	c := response_components(resp)
 	sig_input := merged_dict_field(resp.header, 'Signature-Input') or {
@@ -179,7 +194,15 @@ pub fn verify_response(resp http.Response, key Key, opts VerifyResponseOptions) 
 			reason: 'response has no Signature header'
 		}
 	}
-	verify(c, sig_input, sig_value, opts.label, key, now_unix: opts.now_unix)!
+	required := if opts.required_components.len > 0 {
+		opts.required_components
+	} else {
+		['@status']
+	}
+	verify(c, sig_input, sig_value, opts.label, key,
+		now_unix:            opts.now_unix
+		required_components: required
+	)!
 }
 
 // append_dict_header merges `addition` into the existing dictionary
@@ -342,7 +365,7 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 	} else if parsed.host != '' {
 		parsed.host
 	} else {
-		req.host
+		req.host.trim_space()
 	}
 	if mode == .outgoing {
 		if parsed.host != '' {
@@ -442,11 +465,12 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 
 fn transport_authority(url urllib.URL) string {
 	hostname := url.hostname()
+	host := if hostname.contains(':') { '[${hostname}]' } else { hostname }
 	port := url.port().int()
 	if port == 0 || (url.scheme == 'http' && port == 80) || (url.scheme == 'https' && port == 443) {
-		return hostname
+		return host
 	}
-	return '${hostname}:${port}'
+	return '${host}:${port}'
 }
 
 fn response_components(resp http.Response) Components {

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -305,9 +305,10 @@ fn validate_stable_signature_components(components []string) ! {
 }
 
 fn validate_request_component_coverage(req http.Request, components []string, default_scheme string) ! {
-	if req.disable_connection_reuse && components.any(it.to_lower() == 'connection') {
+	if (req.disable_connection_reuse || req.proxy != unsafe { nil })
+		&& components.any(it.to_lower() == 'connection') {
 		return MalformedMessage{
-			reason: 'covered field "connection" changes when connection reuse is disabled'
+			reason: 'covered field "connection" changes on a connection-close transport'
 		}
 	}
 	if !req.enable_http2 {

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -249,6 +249,11 @@ fn merged_dict_field(h http.Header, name string) ?string {
 fn ensure_signature_label_available(h http.Header, label string) ! {
 	check_label(label)!
 	if input := merged_dict_field(h, 'Signature-Input') {
+		if input.trim_space() == '' {
+			return MalformedMessage{
+				reason: 'existing Signature-Input dictionary is empty'
+			}
+		}
 		entries := parse_signature_input(input)!
 		if entries.any(it.label == label) {
 			return MalformedMessage{
@@ -257,6 +262,11 @@ fn ensure_signature_label_available(h http.Header, label string) ! {
 		}
 	}
 	if signatures := merged_dict_field(h, 'Signature') {
+		if signatures.trim_space() == '' {
+			return MalformedMessage{
+				reason: 'existing Signature dictionary is empty'
+			}
+		}
 		parsed := parse_signature(signatures)!
 		if label in parsed {
 			return MalformedMessage{

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -135,12 +135,21 @@ pub:
 
 // sign_response signs an HTTP response in place. Like `sign_request`
 // it preserves any pre-existing Signature-Input / Signature values
-// and defaults `created` to the current time.
+// and defaults `created` to the current time. The default component profile
+// additionally requires and covers Content-Digest when the response has a body.
 pub fn sign_response(mut resp http.Response, key Key, opts SignResponseOptions) ! {
 	ensure_signature_label_available(resp.header, opts.label)!
 	mut comps := opts.components.clone()
 	if comps.len == 0 {
 		comps = ['@status']
+		if resp.body != '' {
+			if !resp.header.contains_custom('Content-Digest') {
+				return MalformedMessage{
+					reason: 'default signing of a response body requires a Content-Digest field'
+				}
+			}
+			comps << 'content-digest'
+		}
 	}
 	validate_stable_signature_components(comps)!
 	validate_response_component_coverage(comps)!
@@ -179,12 +188,13 @@ pub struct VerifyResponseOptions {
 pub:
 	label    string
 	now_unix i64
-	// required_components defaults to @status.
+	// required_components defaults to @status, plus content-digest for a body.
 	required_components []string
 }
 
 // verify_response verifies a labelled signature on an HTTP response and
-// requires @status coverage unless `required_components` is set explicitly.
+// requires @status coverage, plus content-digest for a body, unless
+// `required_components` is set explicitly.
 pub fn verify_response(resp http.Response, key Key, opts VerifyResponseOptions) ! {
 	c := response_components(resp)
 	sig_input := merged_dict_field(resp.header, 'Signature-Input') or {
@@ -199,6 +209,8 @@ pub fn verify_response(resp http.Response, key Key, opts VerifyResponseOptions) 
 	}
 	required := if opts.required_components.len > 0 {
 		opts.required_components
+	} else if resp.body != '' {
+		['@status', 'content-digest']
 	} else {
 		['@status']
 	}
@@ -386,10 +398,14 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 			authority = transport_authority(parsed)
 		}
 		if !uses_absolute_form {
-			if host := req.header.get(.host) {
-				if host != '' {
-					authority = host.trim_space()
+			if req.header.contains(.host) {
+				host := (req.header.get(.host) or { '' }).trim_space()
+				if host == '' {
+					return MalformedMessage{
+						reason: 'explicit Host field must not be empty'
+					}
 				}
+				authority = host
 			}
 		}
 	}

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -171,11 +171,25 @@ pub fn verify_response(resp http.Response, key Key, opts VerifyResponseOptions) 
 // `Signature` field as the spec recommends, even when `add_custom`
 // would otherwise create separate field instances.
 fn append_dict_header(mut h http.Header, name string, addition string) ! {
-	existing := h.get_custom(name) or {
+	existing_values := h.custom_values(name)
+	if existing_values.len == 0 {
 		h.add_custom(name, addition)!
 		return
 	}
-	h.set_custom(name, existing + ', ' + addition)!
+	// Collapse all case-insensitive field lines before appending. Keeping the
+	// first spelling lets Header.set_custom reuse that entry after duplicates
+	// have been cleared instead of consuming another fixed-capacity slot.
+	mut matching_keys := []string{}
+	for key in h.keys() {
+		if key.to_lower() == name.to_lower() {
+			matching_keys << key
+		}
+	}
+	for key in matching_keys {
+		h.delete_custom(key)
+	}
+	key := if matching_keys.len > 0 { matching_keys[0] } else { name }
+	h.set_custom(key, existing_values.join(', ') + ', ' + addition)!
 }
 
 // merged_dict_field returns the concatenation of all values of `name`
@@ -223,8 +237,9 @@ fn request_components(req http.Request, default_scheme string) !Components {
 	if scheme != '' {
 		c.scheme = scheme
 	}
-	if parsed.path != '' {
-		c.path = parsed.path
+	escaped_path := parsed.escaped_path()
+	if escaped_path != '' {
+		c.path = escaped_path
 	} else {
 		c.path = '/'
 	}

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -52,6 +52,7 @@ pub fn sign_request(mut req http.Request, key Key, opts SignRequestOptions) ! {
 	if comps.len == 0 {
 		comps = default_request_components(req)
 	}
+	validate_stable_signature_components(comps)!
 	validate_request_component_coverage(req, comps, opts.scheme)!
 	mut alg := ?string(none)
 	if opts.include_alg {
@@ -128,6 +129,7 @@ pub fn sign_response(mut resp http.Response, key Key, opts SignResponseOptions) 
 	if comps.len == 0 {
 		comps = ['@status']
 	}
+	validate_stable_signature_components(comps)!
 	if comps.any(it.to_lower() == 'content-length') && !resp.header.contains(.content_length) {
 		// Insert the field so both HTTP/1.x and HTTP/2 actually transmit the
 		// value covered by the signature.
@@ -233,6 +235,17 @@ fn ensure_signature_label_available(h http.Header, label string) ! {
 	}
 }
 
+fn validate_stable_signature_components(components []string) ! {
+	for component in components {
+		name := component.to_lower()
+		if name in ['signature-input', 'signature'] {
+			return MalformedMessage{
+				reason: 'covered field "${name}" changes when the signature fields are appended'
+			}
+		}
+	}
+}
+
 fn validate_request_component_coverage(req http.Request, components []string, default_scheme string) ! {
 	if !req.enable_http2 {
 		return
@@ -251,6 +264,12 @@ fn validate_request_component_coverage(req http.Request, components []string, de
 		if name in ['connection', 'keep-alive', 'proxy-connection', 'transfer-encoding', 'upgrade'] {
 			return MalformedMessage{
 				reason: 'covered field "${name}" may be removed during HTTP/2 negotiation'
+			}
+		}
+		if name == 'te'
+			&& req.header.custom_values('TE').any(it.trim_space().to_lower() != 'trailers') {
+			return MalformedMessage{
+				reason: 'covered field "te" contains a value that may be removed during HTTP/2 negotiation'
 			}
 		}
 	}

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -248,6 +248,11 @@ fn validate_stable_signature_components(components []string) ! {
 }
 
 fn validate_request_component_coverage(req http.Request, components []string, default_scheme string) ! {
+	if req.disable_connection_reuse && components.any(it.to_lower() == 'connection') {
+		return MalformedMessage{
+			reason: 'covered field "connection" changes when connection reuse is disabled'
+		}
+	}
 	if !req.enable_http2 {
 		return
 	}

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -218,18 +218,22 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 			reason: 'request url "${req.url}" is not a valid URL: ${err.msg()}'
 		}
 	}
+	uses_absolute_form := mode == .outgoing && !isnil(req.proxy) && parsed.scheme == 'http'
 	mut authority := if parsed.host != '' {
 		parsed.host
 	} else {
 		req.host
 	}
 	if mode == .outgoing {
-		if host := req.header.get(.host) {
-			if host != '' {
-				authority = host
-			}
-		} else if parsed.host != '' {
+		if parsed.host != '' {
 			authority = transport_authority(parsed)
+		}
+		if !uses_absolute_form {
+			if host := req.header.get(.host) {
+				if host != '' {
+					authority = host
+				}
+			}
 		}
 	}
 	scheme := if parsed.scheme != '' { parsed.scheme } else { default_scheme }
@@ -249,7 +253,7 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 		transport_path
 	}
 	request_target := if mode == .outgoing {
-		if !isnil(req.proxy) && parsed.scheme == 'http' {
+		if uses_absolute_form {
 			'${scheme}://${transport_authority(parsed)}${origin_target}'
 		} else {
 			origin_target
@@ -281,7 +285,9 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 		}
 	}
 	if mode == .outgoing {
-		c.fields['host'] = [authority]
+		if !req.header.contains(.host) {
+			c.fields['host'] = [transport_authority(parsed)]
+		}
 		if !req.header.contains(.user_agent) {
 			c.fields['user-agent'] = [req.user_agent]
 		}

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -147,12 +147,12 @@ pub fn sign_response(mut resp http.Response, key Key, opts SignResponseOptions) 
 	adds_content_length := comps.any(it.to_lower() == 'content-length')
 		&& !resp.header.contains(.content_length)
 	ensure_signature_header_capacity(resp.header, if adds_content_length { 1 } else { 0 })!
+	mut c := response_components(resp)
 	if adds_content_length {
-		// Insert the field so both HTTP/1.x and HTTP/2 actually transmit the
-		// value covered by the signature.
-		resp.header.set(.content_length, resp.body.len.str())
+		// Sign the value that will be inserted only after signing succeeds, so
+		// an error cannot leave the unsigned response mutated.
+		c.fields['content-length'] = [resp.body.len.str()]
 	}
-	c := response_components(resp)
 	mut alg := ?string(none)
 	if opts.include_alg {
 		alg = key.algorithm.name()
@@ -167,6 +167,9 @@ pub fn sign_response(mut resp http.Response, key Key, opts SignResponseOptions) 
 		tag:        opts.tag
 	}
 	out := sign(c, p, key, opts.label)!
+	if adds_content_length {
+		resp.header.set(.content_length, resp.body.len.str())
+	}
 	append_dict_header(mut resp.header, 'Signature-Input', out.signature_input)!
 	append_dict_header(mut resp.header, 'Signature', out.signature)!
 }
@@ -456,7 +459,7 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 		if !req.header.contains(.user_agent) {
 			c.fields['user-agent'] = [req.user_agent]
 		}
-		if !req.header.contains(.content_length) {
+		if req.method != .trace && !req.header.contains(.content_length) {
 			c.fields['content-length'] = [req.data.len.str()]
 		}
 		cookie_value := req.cookie_header_value()

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -280,6 +280,19 @@ fn request_components(req http.Request, default_scheme string, mode RequestCompo
 			c.fields[k.to_lower()] = values
 		}
 	}
+	if mode == .outgoing {
+		c.fields['host'] = [authority]
+		if !req.header.contains(.user_agent) {
+			c.fields['user-agent'] = [req.user_agent]
+		}
+		if !req.header.contains(.content_length) {
+			c.fields['content-length'] = [req.data.len.str()]
+		}
+		cookie_value := req.cookie_header_value()
+		if cookie_value != '' {
+			c.fields['cookie'] = [cookie_value]
+		}
+	}
 	return c
 }
 
@@ -293,8 +306,16 @@ fn transport_authority(url urllib.URL) string {
 }
 
 fn response_components(resp http.Response) Components {
+	status := http.status_from_int(resp.status_code)
+	wire_status := if status.is_valid() {
+		resp.status_code
+	} else if resp.status_code == 0 && resp.status_msg == '' {
+		200
+	} else {
+		500
+	}
 	mut c := Components{
-		status: resp.status_code
+		status: wire_status
 	}
 	for k in resp.header.keys() {
 		values := resp.header.custom_values(k)

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -147,6 +147,7 @@ pub:
 // it preserves any pre-existing Signature-Input / Signature values
 // and defaults `created` to the current time. The default component profile
 // additionally requires and covers Content-Digest when the response has a body.
+// Nonzero status codes outside the HTTP 100...599 range are rejected.
 pub fn sign_response(mut resp http.Response, key Key, opts SignResponseOptions) ! {
 	ensure_signature_label_available(resp.header, opts.label)!
 	mut comps := opts.components.clone()
@@ -166,7 +167,7 @@ pub fn sign_response(mut resp http.Response, key Key, opts SignResponseOptions) 
 	adds_content_length := comps.any(it.to_lower() == 'content-length')
 		&& !resp.header.contains(.content_length)
 	ensure_signature_header_capacity(resp.header, if adds_content_length { 1 } else { 0 })!
-	mut c := response_components(resp)
+	mut c := response_components(resp)!
 	if adds_content_length {
 		// Sign the value that will be inserted only after signing succeeds, so
 		// an error cannot leave the unsigned response mutated.
@@ -206,7 +207,7 @@ pub:
 // requires @status coverage, plus content-digest for a body, unless
 // `required_components` is set explicitly.
 pub fn verify_response(resp http.Response, key Key, opts VerifyResponseOptions) ! {
-	c := response_components(resp)
+	c := response_components(resp)!
 	sig_input := merged_dict_field(resp.header, 'Signature-Input') or {
 		return MalformedMessage{
 			reason: 'response has no Signature-Input header'
@@ -517,14 +518,13 @@ fn transport_authority(url urllib.URL) string {
 	return '${host}:${port}'
 }
 
-fn response_components(resp http.Response) Components {
-	wire_status := if resp.status_code >= 100 && resp.status_code <= 599 {
-		resp.status_code
-	} else if resp.status_code == 0 {
-		200
-	} else {
-		500
+fn response_components(resp http.Response) !Components {
+	if resp.status_code != 0 && (resp.status_code < 100 || resp.status_code > 599) {
+		return MalformedMessage{
+			reason: 'response status code ${resp.status_code} is outside 100...599'
+		}
 	}
+	wire_status := if resp.status_code == 0 { 200 } else { resp.status_code }
 	mut c := Components{
 		status: wire_status
 	}

--- a/vlib/net/http/signature/http_message.v
+++ b/vlib/net/http/signature/http_message.v
@@ -49,6 +49,11 @@ pub:
 // when the request has a body.
 pub fn sign_request(mut req http.Request, key Key, opts SignRequestOptions) ! {
 	ensure_signature_label_available(req.header, opts.label)!
+	if req.method == .trace && req.data != '' {
+		return MalformedMessage{
+			reason: 'TRACE requests must not carry a body'
+		}
+	}
 	c := request_components(req, opts.scheme, .outgoing)!
 	mut comps := opts.components.clone()
 	if comps.len == 0 {

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -140,6 +140,65 @@ fn test_verify_request_rejects_expired_signature() {
 	verify_request(req, key)!
 }
 
+fn test_origin_form_request_target_uri_reconstructed() {
+	// Inbound HTTP/1.1 requests parsed by `http.parse_request*` carry
+	// the request target verbatim (`/foo?bar=1`), not an absolute URI.
+	// `request_components` must rebuild `<scheme>://<authority><url>`
+	// so the verifier sees the same `@target-uri` as a peer that signs
+	// with an absolute URL.
+	mut signing_req := http.Request{
+		method: .post
+		url:    'https://example.com/foo?bar=1'
+	}
+	signing_req.header.add_custom('Host', 'example.com')!
+	key := Key.hmac_sha256(test_secret.bytes())
+	sign_request(mut signing_req, key,
+		components: ['@method', '@target-uri']
+		created:    1
+	)!
+
+	// Receiver side: same request as it would land after parsing.
+	mut received := http.Request{
+		method: .post
+		url:    '/foo?bar=1'
+		host:   'example.com'
+	}
+	for k in signing_req.header.keys() {
+		for v in signing_req.header.custom_values(k) {
+			received.header.add_custom(k, v)!
+		}
+	}
+	verify_request(received, key)!
+}
+
+fn test_origin_form_uses_explicit_scheme() {
+	// HTTP-only deployment: caller must pass `scheme: 'http'` so both
+	// sides agree on the reconstructed target URI.
+	mut signing_req := http.Request{
+		method: .get
+		url:    'http://api.example.com/v1/items'
+	}
+	signing_req.header.add_custom('Host', 'api.example.com')!
+	key := Key.hmac_sha256(test_secret.bytes())
+	sign_request(mut signing_req, key,
+		components: ['@method', '@target-uri']
+		created:    1
+		scheme:     'http'
+	)!
+
+	mut received := http.Request{
+		method: .get
+		url:    '/v1/items'
+		host:   'api.example.com'
+	}
+	for k in signing_req.header.keys() {
+		for v in signing_req.header.custom_values(k) {
+			received.header.add_custom(k, v)!
+		}
+	}
+	verify_request(received, key, scheme: 'http')!
+}
+
 fn test_sign_two_signatures_coexist() {
 	mut req := build_request('https://example.com/foo')
 	k1 := Key.hmac_sha256('one'.bytes())

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -1,0 +1,229 @@
+// Tests for the http.Request / http.Response wrappers. The
+// roundtrip cases exercise the full sign-then-verify pipeline through
+// the public API; the negative paths cover the rejection branches
+// callers depend on for security.
+module signature
+
+import crypto.ecdsa
+import crypto.ed25519
+import encoding.base64
+import net.http
+
+const test_secret = 'shh-this-is-a-secret-shared-with-the-server'
+
+fn build_request(url string) http.Request {
+	mut req := http.Request{
+		method: .post
+		url:    url
+	}
+	req.header.add_custom('Date', 'Tue, 20 Apr 2021 02:07:55 GMT') or {}
+	req.header.add_custom('Content-Type', 'application/json') or {}
+	req.header.add_custom('Host', 'example.com') or {}
+	return req
+}
+
+fn test_sign_and_verify_request_hmac_roundtrip() {
+	mut req := build_request('https://example.com/foo?bar=1')
+	key := Key.hmac_sha256(test_secret.bytes()).with_keyid('shared-key')
+	sign_request(mut req, key,
+		components: ['@method', '@target-uri', '@authority', 'date', 'content-type']
+		created:    1618884473
+	)!
+	verify_request(req, key)!
+}
+
+fn test_sign_and_verify_request_ed25519_roundtrip() {
+	seed := []u8{len: 32, init: u8(index)}
+	priv_obj := ed25519.new_key_from_seed(seed)
+	pub_bytes := []u8(priv_obj.public_key())
+
+	priv_key := Key.ed25519_private(seed).with_keyid('alice-ed25519')
+	pub_key := Key.ed25519_public(pub_bytes)
+
+	mut req := build_request('https://example.com/foo')
+	sign_request(mut req, priv_key,
+		components: ['@method', '@target-uri', 'date']
+		created:    1618884473
+	)!
+	verify_request(req, pub_key)!
+}
+
+fn test_sign_and_verify_request_ecdsa_p256_roundtrip() {
+	x, y, d := p256_test_key()
+	priv_key := Key.ecdsa_p256_private(x, y, d).with_keyid('p256-key')
+	pub_key := Key.ecdsa_p256_public(x, y)
+	mut req := build_request('https://example.com/api?id=42')
+	sign_request(mut req, priv_key,
+		components: ['@method', '@target-uri', '@path', '@query', 'content-type']
+		created:    1618884473
+	)!
+	verify_request(req, pub_key)!
+}
+
+fn test_sign_and_verify_request_ecdsa_p384_roundtrip() {
+	// P-384 has no RFC 9421 vector; generate a fresh keypair via the
+	// V ecdsa module so the test is self-contained.
+	pub_obj, priv_obj := ecdsa.generate_key(nid: .secp384r1)!
+	defer {
+		priv_obj.free()
+		pub_obj.free()
+	}
+	pub_bytes := pub_obj.bytes()!
+	// pub_bytes is the SEC1 uncompressed point: 0x04 || x || y. The
+	// public-key constructor wants raw (x, y) — strip the prefix.
+	x := pub_bytes[1..49]
+	y := pub_bytes[49..97]
+	d := priv_obj.bytes()!
+	priv_key := Key.ecdsa_p384_private(x, y, d).with_keyid('p384-key')
+	pub_key := Key.ecdsa_p384_public(x, y)
+	mut req := build_request('https://example.com/foo')
+	sign_request(mut req, priv_key,
+		components: ['@method', '@target-uri']
+		created:    1618884473
+	)!
+	verify_request(req, pub_key)!
+}
+
+fn test_verify_request_rejects_wrong_key() {
+	mut req := build_request('https://example.com/foo')
+	good := Key.hmac_sha256('secret-A'.bytes())
+	bad := Key.hmac_sha256('secret-B'.bytes())
+	sign_request(mut req, good, components: ['@method', '@target-uri'], created: 1)!
+	if _ := verify_request(req, bad) {
+		assert false, 'wrong key must not verify'
+	} else {
+		assert err is VerificationFailed
+	}
+}
+
+fn test_verify_request_rejects_tampered_target_uri() {
+	mut req := build_request('https://example.com/foo')
+	key := Key.hmac_sha256(test_secret.bytes())
+	sign_request(mut req, key, components: ['@method', '@target-uri'], created: 1)!
+	// Mutate the URL after signing - the verifier rebuilds the
+	// signature base from the (now-tampered) request and must fail.
+	req.url = 'https://example.com/bar'
+	if _ := verify_request(req, key) {
+		assert false, 'tampered @target-uri must not verify'
+	} else {
+		assert err is VerificationFailed
+	}
+}
+
+fn test_verify_request_rejects_missing_signature_header() {
+	mut req := build_request('https://example.com/foo')
+	key := Key.hmac_sha256(test_secret.bytes())
+	sign_request(mut req, key, components: ['@method'], created: 1)!
+	req.header.delete_custom('Signature')
+	if _ := verify_request(req, key) {
+		assert false, 'missing Signature header must error'
+	} else {
+		assert err is MalformedMessage
+		assert err.msg().contains('no Signature header')
+	}
+}
+
+fn test_verify_request_rejects_expired_signature() {
+	mut req := build_request('https://example.com/foo')
+	key := Key.hmac_sha256(test_secret.bytes())
+	sign_request(mut req, key,
+		components: ['@method']
+		created:    1000
+		expires:    2000
+	)!
+	if _ := verify_request(req, key, now_unix: 5000) {
+		assert false, 'expired signature must be rejected when now_unix > expires'
+	} else {
+		assert err is SignatureExpired
+	}
+	// Unchecked when now_unix is left at the default zero.
+	verify_request(req, key)!
+}
+
+fn test_sign_two_signatures_coexist() {
+	mut req := build_request('https://example.com/foo')
+	k1 := Key.hmac_sha256('one'.bytes())
+	k2 := Key.hmac_sha256('two'.bytes())
+	sign_request(mut req, k1, components: ['@method'], label: 'sig-a', created: 1)!
+	sign_request(mut req, k2, components: ['@target-uri'], label: 'sig-b', created: 2)!
+	verify_request(req, k1, label: 'sig-a')!
+	verify_request(req, k2, label: 'sig-b')!
+	if _ := verify_request(req, k1, label: 'sig-b') {
+		assert false, 'sig-b must not verify under k1'
+	} else {
+		assert err is VerificationFailed
+	}
+}
+
+fn test_sign_response_and_verify() {
+	mut resp := http.Response{
+		status_code: 200
+	}
+	resp.header.add_custom('Content-Type', 'application/json')!
+	resp.header.add_custom('Content-Length', '23')!
+	key := Key.hmac_sha256(test_secret.bytes())
+	sign_response(mut resp, key,
+		components: ['@status', 'content-type', 'content-length']
+		created:    1
+	)!
+	verify_response(resp, key)!
+}
+
+fn test_alg_param_must_match_key_algorithm() {
+	x, y, d := p256_test_key()
+	priv := Key.ecdsa_p256_private(x, y, d)
+	c := Components{
+		method:     'GET'
+		target_uri: 'https://example.com/'
+	}
+	p := SignatureParams{
+		components: ['@method']
+		alg:        'ed25519'
+	}
+	if _ := sign(c, p, priv, 'sig1') {
+		assert false, 'alg mismatch must fail'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
+fn test_label_validation_rejects_empty_and_uppercase() {
+	p := SignatureParams{
+		components: ['@method']
+	}
+	key := Key.hmac_sha256('k'.bytes())
+	c := Components{
+		method: 'GET'
+	}
+	if _ := sign(c, p, key, '') {
+		assert false, 'empty label must fail'
+	} else {
+		assert err is MalformedMessage
+	}
+	if _ := sign(c, p, key, 'Sig1') {
+		assert false, 'uppercase label must fail (Structured Field key grammar)'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
+// p256_test_key returns the (x, y, d) coordinates from RFC 9421
+// Appendix B.1.3.
+fn p256_test_key() ([]u8, []u8, []u8) {
+	x := pad_b64u('qIVYZVLCrPZHGHjP17CTW0_-D9Lfw0EkjqF7xB4FivA', 32)
+	y := pad_b64u('Mc4nN9LTDOBhfoUeg8Ye9WedFRhnZXZJA12Qp0zZ6F0', 32)
+	d := pad_b64u('UpuF81l-kOxbjf7T4mNSv0r5tN67Gim7rnf6EFpcYDs', 32)
+	return x, y, d
+}
+
+fn pad_b64u(s string, want int) []u8 {
+	mut padded := s
+	for padded.len % 4 != 0 {
+		padded += '='
+	}
+	mut b := base64.url_decode(padded)
+	for b.len < want {
+		b.prepend(u8(0))
+	}
+	return b
+}

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -1,3 +1,4 @@
+// vtest build: present_openssl? && !(openbsd && gcc) && !(sanitize-memory-clang || docker-ubuntu-musl)
 // Tests for the http.Request / http.Response wrappers. The
 // roundtrip cases exercise the full sign-then-verify pipeline through
 // the public API; the negative paths cover the rejection branches

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -25,7 +25,7 @@ fn build_request(url string) http.Request {
 
 fn test_sign_and_verify_request_hmac_roundtrip() {
 	mut req := build_request('https://example.com/foo?bar=1')
-	key := Key.hmac_sha256(test_secret.bytes()).with_keyid('shared-key')
+	key := Key.hmac_sha256(test_secret.bytes())!.with_keyid('shared-key')
 	sign_request(mut req, key,
 		components: ['@method', '@target-uri', '@authority', 'date', 'content-type']
 		created:    1618884473
@@ -87,8 +87,8 @@ fn test_sign_and_verify_request_ecdsa_p384_roundtrip() {
 
 fn test_verify_request_rejects_wrong_key() {
 	mut req := build_request('https://example.com/foo')
-	good := Key.hmac_sha256('secret-A'.bytes())
-	bad := Key.hmac_sha256('secret-B'.bytes())
+	good := Key.hmac_sha256('secret-A'.bytes())!
+	bad := Key.hmac_sha256('secret-B'.bytes())!
 	sign_request(mut req, good, components: ['@method', '@target-uri'], created: 1)!
 	if _ := verify_request(req, bad) {
 		assert false, 'wrong key must not verify'
@@ -99,7 +99,7 @@ fn test_verify_request_rejects_wrong_key() {
 
 fn test_verify_request_rejects_tampered_target_uri() {
 	mut req := build_request('https://example.com/foo')
-	key := Key.hmac_sha256(test_secret.bytes())
+	key := Key.hmac_sha256(test_secret.bytes())!
 	sign_request(mut req, key, components: ['@method', '@target-uri'], created: 1)!
 	// Mutate the URL after signing - the verifier rebuilds the
 	// signature base from the (now-tampered) request and must fail.
@@ -113,7 +113,7 @@ fn test_verify_request_rejects_tampered_target_uri() {
 
 fn test_verify_request_rejects_missing_signature_header() {
 	mut req := build_request('https://example.com/foo')
-	key := Key.hmac_sha256(test_secret.bytes())
+	key := Key.hmac_sha256(test_secret.bytes())!
 	sign_request(mut req, key, components: ['@method'], created: 1)!
 	req.header.delete_custom('Signature')
 	if _ := verify_request(req, key) {
@@ -126,7 +126,7 @@ fn test_verify_request_rejects_missing_signature_header() {
 
 fn test_verify_request_rejects_expired_signature() {
 	mut req := build_request('https://example.com/foo')
-	key := Key.hmac_sha256(test_secret.bytes())
+	key := Key.hmac_sha256(test_secret.bytes())!
 	sign_request(mut req, key,
 		components: ['@method']
 		created:    1000
@@ -152,7 +152,7 @@ fn test_origin_form_request_target_uri_reconstructed() {
 		url:    'https://example.com/foo?bar=1'
 	}
 	signing_req.header.add_custom('Host', 'example.com')!
-	key := Key.hmac_sha256(test_secret.bytes())
+	key := Key.hmac_sha256(test_secret.bytes())!
 	sign_request(mut signing_req, key,
 		components: ['@method', '@target-uri']
 		created:    1
@@ -180,7 +180,7 @@ fn test_origin_form_uses_explicit_scheme() {
 		url:    'http://api.example.com/v1/items'
 	}
 	signing_req.header.add_custom('Host', 'api.example.com')!
-	key := Key.hmac_sha256(test_secret.bytes())
+	key := Key.hmac_sha256(test_secret.bytes())!
 	sign_request(mut signing_req, key,
 		components: ['@method', '@target-uri']
 		created:    1
@@ -236,6 +236,18 @@ fn test_outgoing_proxy_request_components_use_absolute_form() {
 	assert c.component_value('@request-target')! == 'http://example.com/search?q=a+b'
 }
 
+fn test_outgoing_proxy_request_components_preserve_url_authority() {
+	proxy := http.new_http_proxy('http://localhost:8080')!
+	mut req := build_request('http://origin.example:80/search')
+	req.proxy = proxy
+	req.header.set(.host, 'virtual.example')
+	c := request_components(req, 'http', .outgoing)!
+	assert c.component_value('@authority')! == 'origin.example'
+	assert c.component_value('@target-uri')! == 'http://origin.example/search'
+	assert c.component_value('@request-target')! == 'http://origin.example/search'
+	assert c.component_value('host')! == 'virtual.example'
+}
+
 fn test_outgoing_request_components_use_host_override() {
 	mut req := build_request('https://origin.example/path')
 	req.header.set(.host, 'virtual.example')
@@ -273,7 +285,7 @@ fn test_outgoing_request_components_include_generated_fields() {
 
 fn test_sign_request_rejects_control_bytes_in_parameters() {
 	mut req := build_request('https://example.com/')
-	key := Key.hmac_sha256(test_secret.bytes())
+	key := Key.hmac_sha256(test_secret.bytes())!
 	if _ := sign_request(mut req, key,
 		components: ['@method']
 		keyid:      'safe\r\nInjected: true'
@@ -307,8 +319,8 @@ fn test_append_dict_header_preserves_all_existing_field_lines() {
 
 fn test_sign_two_signatures_coexist() {
 	mut req := build_request('https://example.com/foo')
-	k1 := Key.hmac_sha256('one'.bytes())
-	k2 := Key.hmac_sha256('two'.bytes())
+	k1 := Key.hmac_sha256('one'.bytes())!
+	k2 := Key.hmac_sha256('two'.bytes())!
 	sign_request(mut req, k1, components: ['@method'], label: 'sig-a', created: 1)!
 	sign_request(mut req, k2, components: ['@target-uri'], label: 'sig-b', created: 2)!
 	verify_request(req, k1, label: 'sig-a')!
@@ -326,7 +338,7 @@ fn test_sign_response_and_verify() {
 	}
 	resp.header.add_custom('Content-Type', 'application/json')!
 	resp.header.add_custom('Content-Length', '23')!
-	key := Key.hmac_sha256(test_secret.bytes())
+	key := Key.hmac_sha256(test_secret.bytes())!
 	sign_response(mut resp, key,
 		components: ['@status', 'content-type', 'content-length']
 		created:    1
@@ -336,7 +348,7 @@ fn test_sign_response_and_verify() {
 
 fn test_sign_response_normalizes_zero_status_to_wire_ok() {
 	mut resp := http.Response{}
-	key := Key.hmac_sha256(test_secret.bytes())
+	key := Key.hmac_sha256(test_secret.bytes())!
 	sign_response(mut resp, key, components: ['@status'], created: 1)!
 	received := http.Response{
 		...resp
@@ -367,7 +379,7 @@ fn test_label_validation_rejects_empty_and_uppercase() {
 	p := SignatureParams{
 		components: ['@method']
 	}
-	key := Key.hmac_sha256('k'.bytes())
+	key := Key.hmac_sha256('k'.bytes())!
 	c := Components{
 		method: 'GET'
 	}

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -378,6 +378,25 @@ fn test_incoming_http2_request_components_semicolon_combine_cookie_fields() {
 	assert c.component_value('cookie')! == 'a=1; b=2'
 }
 
+fn test_incoming_http2_request_components_exclude_synthesized_host() {
+	mut req := http.Request{
+		method:  .get
+		url:     '/'
+		host:    'example.com'
+		version: .v2_0
+	}
+	// H2ServerConn adds this compatibility field from :authority even though
+	// no Host field was present in the HTTP/2 message.
+	req.header.set(.host, 'example.com')
+	c := request_components(req, 'https', .incoming)!
+	assert c.component_value('@authority')! == 'example.com'
+	if _ := c.component_value('host') {
+		assert false, 'a synthesized HTTP/2 Host field must not be coverable'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_sign_request_rejects_control_bytes_in_parameters() {
 	mut req := build_request('https://example.com/')
 	key := Key.hmac_sha256(test_secret.bytes())!

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -34,6 +34,44 @@ fn test_sign_and_verify_request_hmac_roundtrip() {
 	verify_request(req, key)!
 }
 
+fn test_request_defaults_require_content_digest_for_body() {
+	mut missing_digest := build_request('https://example.com/upload')
+	missing_digest.data = 'hello'
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_request(mut missing_digest, key, created: 1) {
+		assert false, 'default request signing must require a digest for a body'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !missing_digest.header.contains_custom('Signature')
+
+	mut req := build_request('https://example.com/upload')
+	req.data = 'hello'
+	req.header.add_custom('Content-Digest', 'sha-256=:digest:')!
+	sign_request(mut req, key, created: 1)!
+	signature_input := req.header.get_custom('Signature-Input') or { '' }
+	assert signature_input.contains('"content-digest"')
+	verify_request(req, key)!
+}
+
+fn test_verify_request_requires_content_digest_coverage_for_body_by_default() {
+	mut req := build_request('https://example.com/upload')
+	req.data = 'hello'
+	key := Key.hmac_sha256(test_secret.bytes())!
+	sign_request(mut req, key,
+		components: ['@method', '@target-uri', '@authority']
+		created:    1
+	)!
+	if _ := verify_request(req, key) {
+		assert false, 'default request verification must require digest coverage for a body'
+	} else {
+		assert err is MalformedMessage
+	}
+	verify_request(req, key,
+		required_components: ['@method', '@target-uri', '@authority']
+	)!
+}
+
 fn test_sign_and_verify_request_ed25519_roundtrip() {
 	seed := []u8{len: 32, init: u8(index)}
 	priv_obj := ed25519.new_key_from_seed(seed)

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -51,8 +51,8 @@ fn test_sign_and_verify_request_ed25519_roundtrip() {
 
 fn test_sign_and_verify_request_ecdsa_p256_roundtrip() {
 	x, y, d := p256_test_key()
-	priv_key := Key.ecdsa_p256_private(x, y, d).with_keyid('p256-key')
-	pub_key := Key.ecdsa_p256_public(x, y)
+	priv_key := Key.ecdsa_p256_private(x, y, d)!.with_keyid('p256-key')
+	pub_key := Key.ecdsa_p256_public(x, y)!
 	mut req := build_request('https://example.com/api?id=42')
 	sign_request(mut req, priv_key,
 		components: ['@method', '@target-uri', '@path', '@query', 'content-type']
@@ -75,8 +75,8 @@ fn test_sign_and_verify_request_ecdsa_p384_roundtrip() {
 	x := pub_bytes[1..49]
 	y := pub_bytes[49..97]
 	d := priv_obj.bytes()!
-	priv_key := Key.ecdsa_p384_private(x, y, d).with_keyid('p384-key')
-	pub_key := Key.ecdsa_p384_public(x, y)
+	priv_key := Key.ecdsa_p384_private(x, y, d)!.with_keyid('p384-key')
+	pub_key := Key.ecdsa_p384_public(x, y)!
 	mut req := build_request('https://example.com/foo')
 	sign_request(mut req, priv_key,
 		components: ['@method', '@target-uri']
@@ -202,16 +202,46 @@ fn test_origin_form_uses_explicit_scheme() {
 
 fn test_request_components_preserve_escaped_path() {
 	req := build_request('https://example.com/files/a%2Fb?download=1')
-	c := request_components(req, 'https')!
+	c := request_components(req, 'https', .outgoing)!
 	assert c.component_value('@path')! == '/files/a%2Fb'
 	assert c.component_value('@request-target')! == '/files/a%2Fb?download=1'
 }
 
 fn test_request_components_normalize_empty_absolute_path() {
 	req := build_request('https://example.com')
-	c := request_components(req, 'https')!
+	c := request_components(req, 'https', .outgoing)!
 	assert c.component_value('@target-uri')! == 'https://example.com/'
 	assert c.component_value('@request-target')! == '/'
+}
+
+fn test_outgoing_request_components_match_transmitted_query() {
+	req := build_request('https://example.com/search?q=a%20b&flag=&bare')
+	c := request_components(req, 'https', .outgoing)!
+	assert c.component_value('@target-uri')! == 'https://example.com/search?q=a+b&flag&bare'
+	assert c.component_value('@request-target')! == '/search?q=a+b&flag&bare'
+	assert c.component_value('@query')! == '?q=a+b&flag&bare'
+}
+
+fn test_incoming_request_components_preserve_absolute_form() {
+	req := build_request('http://example.com/search?q=a+b')
+	c := request_components(req, 'http', .incoming)!
+	assert c.component_value('@request-target')! == 'http://example.com/search?q=a+b'
+}
+
+fn test_outgoing_proxy_request_components_use_absolute_form() {
+	proxy := http.new_http_proxy('http://localhost:8080')!
+	mut req := build_request('http://example.com/search?q=a%20b')
+	req.proxy = proxy
+	c := request_components(req, 'http', .outgoing)!
+	assert c.component_value('@request-target')! == 'http://example.com/search?q=a+b'
+}
+
+fn test_outgoing_request_components_match_repeated_header_serialization() {
+	mut req := build_request('https://example.com/')
+	req.header.add_custom('Accept', 'text/html')!
+	req.header.add_custom('Accept', 'application/json')!
+	c := request_components(req, 'https', .outgoing)!
+	assert c.component_value('accept')! == 'text/html; application/json'
 }
 
 fn test_sign_request_rejects_control_bytes_in_parameters() {
@@ -270,7 +300,7 @@ fn test_sign_response_and_verify() {
 
 fn test_alg_param_must_match_key_algorithm() {
 	x, y, d := p256_test_key()
-	priv := Key.ecdsa_p256_private(x, y, d)
+	priv := Key.ecdsa_p256_private(x, y, d)!
 	c := Components{
 		method:     'GET'
 		target_uri: 'https://example.com/'

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -400,6 +400,35 @@ fn test_sign_request_rejects_http2_removed_covered_field() {
 	assert !req.header.contains_custom('Signature')
 }
 
+fn test_sign_request_rejects_http2_replaced_host_field() {
+	mut req := build_request('https://example.com/foo')
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_request(mut req, key, components: ['host'], created: 1) {
+		assert false, 'Host is replaced by @authority during possible HTTP/2 negotiation'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !req.header.contains_custom('Signature')
+}
+
+fn test_sign_request_preflights_both_signature_header_slots() {
+	mut req := http.Request{
+		method: .get
+		url:    'https://example.com/'
+	}
+	for i in 0 .. http.max_headers - 1 {
+		req.header.add_custom('X-Fill-${i}', 'value')!
+	}
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_request(mut req, key, components: ['@method'], created: 1) {
+		assert false, 'signing must reject insufficient capacity before changing either header'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !req.header.contains_custom('Signature-Input')
+	assert !req.header.contains_custom('Signature')
+}
+
 fn test_sign_request_rejects_generated_connection_close_coverage() {
 	mut req := build_request('http://example.com/foo')
 	req.disable_connection_reuse = true
@@ -553,6 +582,23 @@ fn test_sign_response_rejects_http2_removed_covered_field() {
 	} else {
 		assert err is MalformedMessage
 	}
+	assert !resp.header.contains_custom('Signature')
+}
+
+fn test_sign_response_preflights_both_signature_header_slots() {
+	mut resp := http.Response{
+		status_code: 200
+	}
+	for i in 0 .. http.max_headers - 1 {
+		resp.header.add_custom('X-Fill-${i}', 'value')!
+	}
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_response(mut resp, key, components: ['@status'], created: 1) {
+		assert false, 'signing must reject insufficient capacity before changing either header'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !resp.header.contains_custom('Signature-Input')
 	assert !resp.header.contains_custom('Signature')
 }
 

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -387,6 +387,19 @@ fn test_sign_request_rejects_http2_removed_covered_field() {
 	assert !req.header.contains_custom('Signature')
 }
 
+fn test_sign_request_rejects_generated_connection_close_coverage() {
+	mut req := build_request('http://example.com/foo')
+	req.disable_connection_reuse = true
+	req.header.set(.connection, 'keep-alive')
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_request(mut req, key, components: ['connection'], created: 1) {
+		assert false, 'a transport-generated Connection: close value cannot be omitted from coverage'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !req.header.contains_custom('Signature')
+}
+
 fn test_sign_request_rejects_http2_filtered_te_value() {
 	mut req := build_request('https://example.com/foo')
 	req.header.add_custom('TE', 'gzip')!

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -372,10 +372,21 @@ fn test_sign_response_includes_generated_content_length() {
 	}
 	key := Key.hmac_sha256(test_secret.bytes())!
 	sign_response(mut resp, key, components: ['@status', 'content-length'], created: 1)!
+	assert (resp.header.get(.content_length) or { '' }) == '5'
 	mut received := resp
 	received.status_code = 200
-	received.header.set(.content_length, received.body.len.str())
 	verify_response(received, key)!
+}
+
+fn test_response_components_do_not_invent_content_length() {
+	c := response_components(http.Response{
+		body: 'hello'
+	})
+	if _ := c.component_value('content-length') {
+		assert false, 'an absent response Content-Length must remain absent'
+	} else {
+		assert err is MalformedMessage
+	}
 }
 
 fn test_alg_param_must_match_key_algorithm() {

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -632,6 +632,39 @@ fn test_sign_response_includes_generated_content_length() {
 	verify_response(received, key)!
 }
 
+fn test_sign_response_failure_does_not_add_generated_content_length() {
+	mut resp := http.Response{
+		body: 'hello'
+	}
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_response(mut resp, key,
+		components: ['@status', 'content-length']
+		created:    2
+		expires:    1
+	)
+	{
+		assert false, 'invalid signature parameters must fail'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !resp.header.contains(.content_length)
+	assert !resp.header.contains_custom('Signature-Input')
+	assert !resp.header.contains_custom('Signature')
+}
+
+fn test_outgoing_trace_components_do_not_synthesize_content_length() {
+	req := http.Request{
+		method: .trace
+		url:    'https://example.com/'
+	}
+	c := request_components(req, 'https', .outgoing)!
+	if _ := c.component_value('content-length') {
+		assert false, 'TRACE must not synthesize a Content-Length field'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_sign_response_rejects_existing_label() {
 	mut resp := http.Response{
 		status_code: 200

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -368,6 +368,44 @@ fn test_sign_request_rejects_http2_removed_covered_field() {
 	assert !req.header.contains_custom('Signature')
 }
 
+fn test_sign_request_rejects_http2_filtered_te_value() {
+	mut req := build_request('https://example.com/foo')
+	req.header.add_custom('TE', 'gzip')!
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_request(mut req, key, components: ['te'], created: 1) {
+		assert false, 'TE values filtered during possible HTTP/2 negotiation cannot be covered'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !req.header.contains_custom('Signature')
+}
+
+fn test_sign_request_allows_http2_te_trailers() {
+	mut req := build_request('https://example.com/foo')
+	req.header.add_custom('TE', 'trailers')!
+	key := Key.hmac_sha256(test_secret.bytes())!
+	sign_request(mut req, key, components: ['te'], created: 1)!
+	verify_request(req, key)!
+}
+
+fn test_sign_request_rejects_self_referential_signature_field() {
+	mut req := build_request('https://example.com/foo')
+	req.header.add_custom('Signature-Input', 'old=()')!
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_request(mut req, key,
+		components: ['signature-input']
+		label:      'new'
+		created:    1
+	)
+	{
+		assert false, 'a field changed by signing cannot be covered'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert req.header.custom_values('Signature-Input') == ['old=()']
+	assert !req.header.contains_custom('Signature')
+}
+
 fn test_sign_response_and_verify() {
 	mut resp := http.Response{
 		status_code: 200
@@ -416,6 +454,27 @@ fn test_sign_response_rejects_existing_label() {
 	} else {
 		assert err is MalformedMessage
 	}
+}
+
+fn test_sign_response_rejects_self_referential_signature_field_without_mutation() {
+	mut resp := http.Response{
+		status_code: 200
+		body:        'hello'
+	}
+	resp.header.add_custom('Signature', 'old=:b2xk:')!
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_response(mut resp, key,
+		components: ['signature', 'content-length']
+		label:      'new'
+		created:    1
+	)
+	{
+		assert false, 'a field changed by signing cannot be covered'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert resp.header.custom_values('Signature') == ['old=:b2xk:']
+	assert !resp.header.contains(.content_length)
 }
 
 fn test_response_components_do_not_invent_content_length() {

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -229,6 +229,25 @@ fn test_incoming_request_components_preserve_absolute_form() {
 	assert c.component_value('@request-target')! == 'http://example.com/search?q=a+b'
 }
 
+fn test_incoming_connect_reconstructs_target_uri_from_authority_form() {
+	req :=
+		http.parse_request_str('CONNECT tunnel.example:443 HTTP/1.1\r\nHost: ignored.example\r\n\r\n')!
+	c := request_components(req, 'https', .incoming)!
+	assert c.component_value('@target-uri')! == 'https://tunnel.example:443'
+	assert c.component_value('@authority')! == 'tunnel.example'
+	assert c.component_value('@path')! == '/'
+	assert c.component_value('@request-target')! == 'tunnel.example:443'
+}
+
+fn test_incoming_options_asterisk_reconstructs_target_uri_without_path() {
+	req := http.parse_request_str('OPTIONS * HTTP/1.1\r\nHost: example.com:8443\r\n\r\n')!
+	c := request_components(req, 'https', .incoming)!
+	assert c.component_value('@target-uri')! == 'https://example.com:8443'
+	assert c.component_value('@authority')! == 'example.com:8443'
+	assert c.component_value('@path')! == '/'
+	assert c.component_value('@request-target')! == '*'
+}
+
 fn test_outgoing_proxy_request_components_use_absolute_form() {
 	proxy := http.new_http_proxy('http://localhost:8080')!
 	mut req := build_request('http://example.com/search?q=a%20b')
@@ -475,6 +494,20 @@ fn test_sign_response_rejects_self_referential_signature_field_without_mutation(
 	}
 	assert resp.header.custom_values('Signature') == ['old=:b2xk:']
 	assert !resp.header.contains(.content_length)
+}
+
+fn test_sign_response_rejects_http2_removed_covered_field() {
+	mut resp := http.Response{
+		status_code: 200
+	}
+	resp.header.set(.connection, 'keep-alive')
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_response(mut resp, key, components: ['connection'], created: 1) {
+		assert false, 'fields removed by an HTTP/2 response transport cannot be covered'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !resp.header.contains_custom('Signature')
 }
 
 fn test_response_components_do_not_invent_content_length() {

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -252,6 +252,25 @@ fn test_outgoing_request_components_match_repeated_header_serialization() {
 	assert c.component_value('accept')! == 'text/html, application/json'
 }
 
+fn test_outgoing_request_components_include_generated_fields() {
+	mut req := http.Request{
+		method:     .post
+		url:        'https://example.com/upload'
+		data:       'body'
+		user_agent: 'signature-test'
+	}
+	req.add_cookie(http.Cookie{
+		name:  'sid'
+		value: 'abc'
+	})
+	req.header.add_custom('cookie', 'theme=dark')!
+	c := request_components(req, 'https', .outgoing)!
+	assert c.component_value('host')! == 'example.com'
+	assert c.component_value('user-agent')! == 'signature-test'
+	assert c.component_value('content-length')! == '4'
+	assert c.component_value('cookie')! == 'sid=abc; theme=dark'
+}
+
 fn test_sign_request_rejects_control_bytes_in_parameters() {
 	mut req := build_request('https://example.com/')
 	key := Key.hmac_sha256(test_secret.bytes())
@@ -313,6 +332,17 @@ fn test_sign_response_and_verify() {
 		created:    1
 	)!
 	verify_response(resp, key)!
+}
+
+fn test_sign_response_normalizes_zero_status_to_wire_ok() {
+	mut resp := http.Response{}
+	key := Key.hmac_sha256(test_secret.bytes())
+	sign_response(mut resp, key, components: ['@status'], created: 1)!
+	received := http.Response{
+		...resp
+		status_code: 200
+	}
+	verify_response(received, key)!
 }
 
 fn test_alg_param_must_match_key_algorithm() {

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -47,7 +47,7 @@ fn test_sign_and_verify_request_ed25519_roundtrip() {
 		components: ['@method', '@target-uri', 'date']
 		created:    1618884473
 	)!
-	verify_request(req, pub_key)!
+	verify_request(req, pub_key, required_components: ['@method', '@target-uri'])!
 }
 
 fn test_sign_and_verify_request_ecdsa_p256_roundtrip() {
@@ -59,7 +59,9 @@ fn test_sign_and_verify_request_ecdsa_p256_roundtrip() {
 		components: ['@method', '@target-uri', '@path', '@query', 'content-type']
 		created:    1618884473
 	)!
-	verify_request(req, pub_key)!
+	verify_request(req, pub_key,
+		required_components: ['@method', '@target-uri', '@path', '@query', 'content-type']
+	)!
 }
 
 fn test_sign_and_verify_request_ecdsa_p384_roundtrip() {
@@ -83,7 +85,7 @@ fn test_sign_and_verify_request_ecdsa_p384_roundtrip() {
 		components: ['@method', '@target-uri']
 		created:    1618884473
 	)!
-	verify_request(req, pub_key)!
+	verify_request(req, pub_key, required_components: ['@method', '@target-uri'])!
 }
 
 fn test_verify_request_rejects_wrong_key() {
@@ -91,7 +93,7 @@ fn test_verify_request_rejects_wrong_key() {
 	good := Key.hmac_sha256('secret-A'.bytes())!
 	bad := Key.hmac_sha256('secret-B'.bytes())!
 	sign_request(mut req, good, components: ['@method', '@target-uri'], created: 1)!
-	if _ := verify_request(req, bad) {
+	if _ := verify_request(req, bad, required_components: ['@method', '@target-uri']) {
 		assert false, 'wrong key must not verify'
 	} else {
 		assert err is VerificationFailed
@@ -105,7 +107,7 @@ fn test_verify_request_rejects_tampered_target_uri() {
 	// Mutate the URL after signing - the verifier rebuilds the
 	// signature base from the (now-tampered) request and must fail.
 	req.url = 'https://example.com/bar'
-	if _ := verify_request(req, key) {
+	if _ := verify_request(req, key, required_components: ['@method', '@target-uri']) {
 		assert false, 'tampered @target-uri must not verify'
 	} else {
 		assert err is VerificationFailed
@@ -133,13 +135,28 @@ fn test_verify_request_rejects_expired_signature() {
 		created:    1000
 		expires:    2000
 	)!
-	if _ := verify_request(req, key, now_unix: 5000) {
+	if _ := verify_request(req, key, now_unix: 5000, required_components: ['@method']) {
 		assert false, 'expired signature must be rejected when now_unix > expires'
 	} else {
 		assert err is SignatureExpired
 	}
 	// Unchecked when now_unix is left at the default zero.
-	verify_request(req, key)!
+	verify_request(req, key, required_components: ['@method'])!
+}
+
+fn test_verify_request_requires_safe_default_component_coverage() {
+	mut req := build_request('https://example.com/foo')
+	key := Key.hmac_sha256(test_secret.bytes())!
+	sign_request(mut req, key, components: ['date'], created: 1)!
+	if _ := verify_request(req, key) {
+		assert false, 'request verification must require method, target URI, and authority by default'
+	} else {
+		assert err is MalformedMessage
+		assert err.msg().contains('@method')
+	}
+	// Applications with a different authorization profile can opt into its
+	// required component set explicitly.
+	verify_request(req, key, required_components: ['date'])!
 }
 
 fn test_origin_form_request_target_uri_reconstructed() {
@@ -170,7 +187,7 @@ fn test_origin_form_request_target_uri_reconstructed() {
 			received.header.add_custom(k, v)!
 		}
 	}
-	verify_request(received, key)!
+	verify_request(received, key, required_components: ['@method', '@target-uri'])!
 }
 
 fn test_origin_form_uses_explicit_scheme() {
@@ -198,7 +215,10 @@ fn test_origin_form_uses_explicit_scheme() {
 			received.header.add_custom(k, v)!
 		}
 	}
-	verify_request(received, key, scheme: 'http')!
+	verify_request(received, key,
+		scheme:              'http'
+		required_components: ['@method', '@target-uri']
+	)!
 }
 
 fn test_request_components_preserve_escaped_path() {
@@ -230,6 +250,31 @@ fn test_outgoing_request_components_trim_explicit_host_for_derived_values() {
 	c := request_components(req, 'https', .outgoing)!
 	assert c.component_value('@authority')! == 'example.com'
 	assert c.component_value('@target-uri')! == 'https://example.com/path'
+}
+
+fn test_incoming_request_components_trim_host_for_derived_values() {
+	req := http.parse_request_str('GET /path HTTP/1.1\r\nHost: example.com \r\n\r\n')!
+	c := request_components(req, 'https', .incoming)!
+	assert c.component_value('@authority')! == 'example.com'
+	assert c.component_value('@target-uri')! == 'https://example.com/path'
+}
+
+fn test_outgoing_request_components_preserve_ipv6_authority_brackets() {
+	req := http.Request{
+		method: .get
+		url:    'https://[2001:db8::1]/path'
+	}
+	c := request_components(req, 'https', .outgoing)!
+	assert c.component_value('@authority')! == '[2001:db8::1]'
+	assert c.component_value('@target-uri')! == 'https://[2001:db8::1]/path'
+
+	req_nondefault := http.Request{
+		method: .get
+		url:    'https://[2001:db8::1]:8443/path'
+	}
+	c_nondefault := request_components(req_nondefault, 'https', .outgoing)!
+	assert c_nondefault.component_value('@authority')! == '[2001:db8::1]:8443'
+	assert c_nondefault.component_value('@target-uri')! == 'https://[2001:db8::1]:8443/path'
 }
 
 fn test_incoming_request_components_preserve_absolute_form() {
@@ -373,9 +418,15 @@ fn test_sign_two_signatures_coexist() {
 	k2 := Key.hmac_sha256('two'.bytes())!
 	sign_request(mut req, k1, components: ['@method'], label: 'sig-a', created: 1)!
 	sign_request(mut req, k2, components: ['@target-uri'], label: 'sig-b', created: 2)!
-	verify_request(req, k1, label: 'sig-a')!
-	verify_request(req, k2, label: 'sig-b')!
-	if _ := verify_request(req, k1, label: 'sig-b') {
+	verify_request(req, k1, label: 'sig-a', required_components: ['@method'])!
+	verify_request(req, k2, label: 'sig-b', required_components: ['@target-uri'])!
+	if _ := verify_request(req, k1,
+		label:               'sig-b'
+		required_components: [
+			'@target-uri',
+		]
+	)
+	{
 		assert false, 'sig-b must not verify under k1'
 	} else {
 		assert err is VerificationFailed
@@ -468,7 +519,7 @@ fn test_sign_request_allows_http2_te_trailers() {
 	req.header.add_custom('TE', 'trailers')!
 	key := Key.hmac_sha256(test_secret.bytes())!
 	sign_request(mut req, key, components: ['te'], created: 1)!
-	verify_request(req, key)!
+	verify_request(req, key, required_components: ['te'])!
 }
 
 fn test_sign_request_rejects_self_referential_signature_field() {
@@ -501,6 +552,22 @@ fn test_sign_response_and_verify() {
 		created:    1
 	)!
 	verify_response(resp, key)!
+}
+
+fn test_verify_response_requires_status_coverage_by_default() {
+	mut resp := http.Response{
+		status_code: 200
+	}
+	resp.header.add_custom('Content-Type', 'application/json')!
+	key := Key.hmac_sha256(test_secret.bytes())!
+	sign_response(mut resp, key, components: ['content-type'], created: 1)!
+	if _ := verify_response(resp, key) {
+		assert false, 'response verification must require status coverage by default'
+	} else {
+		assert err is MalformedMessage
+		assert err.msg().contains('@status')
+	}
+	verify_response(resp, key, required_components: ['content-type'])!
 }
 
 fn test_sign_response_normalizes_zero_status_to_wire_ok() {

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -207,6 +207,28 @@ fn test_request_components_preserve_escaped_path() {
 	assert c.component_value('@request-target')! == '/files/a%2Fb?download=1'
 }
 
+fn test_request_components_normalize_empty_absolute_path() {
+	req := build_request('https://example.com')
+	c := request_components(req, 'https')!
+	assert c.component_value('@target-uri')! == 'https://example.com/'
+	assert c.component_value('@request-target')! == '/'
+}
+
+fn test_sign_request_rejects_control_bytes_in_parameters() {
+	mut req := build_request('https://example.com/')
+	key := Key.hmac_sha256(test_secret.bytes())
+	if _ := sign_request(mut req, key,
+		components: ['@method']
+		keyid:      'safe\r\nInjected: true'
+	)
+	{
+		assert false, 'control bytes in signature parameters must be rejected'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !req.header.contains_custom('Signature-Input')
+}
+
 fn test_append_dict_header_preserves_all_existing_field_lines() {
 	mut header := http.Header{}
 	header.add_custom('Signature-Input', 'sig-a=("@method")')!

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -466,7 +466,9 @@ fn test_sign_response_and_verify() {
 }
 
 fn test_sign_response_normalizes_zero_status_to_wire_ok() {
-	mut resp := http.Response{}
+	mut resp := http.Response{
+		status_msg: 'custom reason without a status'
+	}
 	key := Key.hmac_sha256(test_secret.bytes())!
 	sign_response(mut resp, key, components: ['@status'], created: 1)!
 	received := http.Response{

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -311,6 +311,19 @@ fn test_outgoing_request_components_include_generated_fields() {
 	assert c.component_value('cookie')! == 'sid=abc; theme=dark'
 }
 
+fn test_incoming_http2_request_components_semicolon_combine_cookie_fields() {
+	mut req := http.Request{
+		method:  .get
+		url:     '/'
+		host:    'example.com'
+		version: .v2_0
+	}
+	req.header.add_custom('cookie', 'a=1')!
+	req.header.add_custom('cookie', 'b=2')!
+	c := request_components(req, 'https', .incoming)!
+	assert c.component_value('cookie')! == 'a=1; b=2'
+}
+
 fn test_sign_request_rejects_control_bytes_in_parameters() {
 	mut req := build_request('https://example.com/')
 	key := Key.hmac_sha256(test_secret.bytes())!
@@ -461,6 +474,24 @@ fn test_sign_response_normalizes_zero_status_to_wire_ok() {
 		status_code: 200
 	}
 	verify_response(received, key)!
+}
+
+fn test_sign_response_preserves_unassigned_three_digit_status() {
+	mut resp := http.Response{
+		status_code: 299
+	}
+	key := Key.hmac_sha256(test_secret.bytes())!
+	sign_response(mut resp, key, components: ['@status'], created: 1)!
+	verify_response(resp, key)!
+	tampered := http.Response{
+		...resp
+		status_code: 250
+	}
+	if _ := verify_response(tampered, key) {
+		assert false, 'the signature must bind the actual unassigned status code'
+	} else {
+		assert err is VerificationFailed
+	}
 }
 
 fn test_sign_response_includes_generated_content_length() {

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -265,6 +265,19 @@ fn test_outgoing_request_components_trim_explicit_host_for_derived_values() {
 	assert c.component_value('@target-uri')! == 'https://example.com/path'
 }
 
+fn test_sign_request_rejects_empty_explicit_host() {
+	mut req := build_request('https://example.com/path')
+	req.enable_http2 = false
+	req.header.set(.host, '   ')
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_request(mut req, key, created: 1) {
+		assert false, 'an empty Host field suppresses the wire authority'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !req.header.contains_custom('Signature')
+}
+
 fn test_incoming_request_components_trim_host_for_derived_values() {
 	req := http.parse_request_str('GET /path HTTP/1.1\r\nHost: example.com \r\n\r\n')!
 	c := request_components(req, 'https', .incoming)!
@@ -629,6 +642,45 @@ fn test_verify_response_requires_status_coverage_by_default() {
 	verify_response(resp, key, required_components: ['content-type'])!
 }
 
+fn test_response_defaults_require_content_digest_for_body() {
+	mut missing_digest := http.Response{
+		status_code: 200
+		body:        'hello'
+	}
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_response(mut missing_digest, key, created: 1) {
+		assert false, 'default response signing must require a digest for a body'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !missing_digest.header.contains_custom('Signature')
+
+	mut resp := http.Response{
+		status_code: 200
+		body:        'hello'
+	}
+	resp.header.add_custom('Content-Digest', 'sha-256=:digest:')!
+	sign_response(mut resp, key, created: 1)!
+	signature_input := resp.header.get_custom('Signature-Input') or { '' }
+	assert signature_input.contains('"content-digest"')
+	verify_response(resp, key)!
+}
+
+fn test_verify_response_requires_content_digest_coverage_for_body_by_default() {
+	mut resp := http.Response{
+		status_code: 200
+		body:        'hello'
+	}
+	key := Key.hmac_sha256(test_secret.bytes())!
+	sign_response(mut resp, key, components: ['@status'], created: 1)!
+	if _ := verify_response(resp, key) {
+		assert false, 'default response verification must require digest coverage for a body'
+	} else {
+		assert err is MalformedMessage
+	}
+	verify_response(resp, key, required_components: ['@status'])!
+}
+
 fn test_sign_response_normalizes_zero_status_to_wire_ok() {
 	mut resp := http.Response{
 		status_msg: 'custom reason without a status'
@@ -669,7 +721,7 @@ fn test_sign_response_includes_generated_content_length() {
 	assert (resp.header.get(.content_length) or { '' }) == '5'
 	mut received := resp
 	received.status_code = 200
-	verify_response(received, key)!
+	verify_response(received, key, required_components: ['@status', 'content-length'])!
 }
 
 fn test_sign_response_failure_does_not_add_generated_content_length() {

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -144,6 +144,19 @@ fn test_verify_request_rejects_expired_signature() {
 	verify_request(req, key, required_components: ['@method'])!
 }
 
+fn test_verify_request_rejects_signature_created_in_future() {
+	mut req := build_request('https://example.com/foo')
+	key := Key.hmac_sha256(test_secret.bytes())!
+	sign_request(mut req, key, components: ['@method'], created: 2000)!
+	if _ := verify_request(req, key, now_unix: 1000, required_components: ['@method']) {
+		assert false, 'a signature created after now_unix must be rejected'
+	} else {
+		assert err is SignatureNotYetValid
+	}
+	// Time validation remains opt-in.
+	verify_request(req, key, required_components: ['@method'])!
+}
+
 fn test_verify_request_requires_safe_default_component_coverage() {
 	mut req := build_request('https://example.com/foo')
 	key := Key.hmac_sha256(test_secret.bytes())!
@@ -467,6 +480,19 @@ fn test_sign_request_rejects_existing_label_without_mutation() {
 	assert req.header.custom_values('Signature') == signature_before
 }
 
+fn test_sign_request_rejects_empty_existing_signature_input() {
+	mut req := build_request('https://example.com/foo')
+	req.header.add_custom('Signature-Input', '')!
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_request(mut req, key, components: ['@method'], created: 1) {
+		assert false, 'an empty existing Signature-Input dictionary must be rejected'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert req.header.custom_values('Signature-Input') == ['']
+	assert !req.header.contains_custom('Signature')
+}
+
 fn test_sign_request_rejects_http2_removed_covered_field() {
 	mut req := build_request('https://example.com/foo')
 	req.header.set(.connection, 'keep-alive')
@@ -676,6 +702,21 @@ fn test_sign_response_rejects_existing_label() {
 	} else {
 		assert err is MalformedMessage
 	}
+}
+
+fn test_sign_response_rejects_empty_existing_signature() {
+	mut resp := http.Response{
+		status_code: 200
+	}
+	resp.header.add_custom('Signature', '')!
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_response(mut resp, key, created: 1) {
+		assert false, 'an empty existing Signature dictionary must be rejected'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert resp.header.custom_values('Signature') == ['']
+	assert !resp.header.contains_custom('Signature-Input')
 }
 
 fn test_sign_response_rejects_self_referential_signature_field_without_mutation() {

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -236,12 +236,20 @@ fn test_outgoing_proxy_request_components_use_absolute_form() {
 	assert c.component_value('@request-target')! == 'http://example.com/search?q=a+b'
 }
 
+fn test_outgoing_request_components_use_host_override() {
+	mut req := build_request('https://origin.example/path')
+	req.header.set(.host, 'virtual.example')
+	c := request_components(req, 'https', .outgoing)!
+	assert c.component_value('@authority')! == 'virtual.example'
+	assert c.component_value('@target-uri')! == 'https://virtual.example/path'
+}
+
 fn test_outgoing_request_components_match_repeated_header_serialization() {
 	mut req := build_request('https://example.com/')
 	req.header.add_custom('Accept', 'text/html')!
 	req.header.add_custom('Accept', 'application/json')!
 	c := request_components(req, 'https', .outgoing)!
-	assert c.component_value('accept')! == 'text/html; application/json'
+	assert c.component_value('accept')! == 'text/html, application/json'
 }
 
 fn test_sign_request_rejects_control_bytes_in_parameters() {
@@ -267,6 +275,15 @@ fn test_append_dict_header_preserves_all_existing_field_lines() {
 	assert header.custom_values('Signature-Input') == [
 		'sig-a=("@method"), sig-b=("@path"), sig-c=("@authority")',
 	]
+	response := http.Response{
+		status_code:  200
+		status_msg:   'OK'
+		http_version: '1.1'
+		header:       header
+	}
+	wire := response.bytestr()
+	assert wire.count('Signature-Input:') == 1
+	assert !wire.contains('Signature-Input: \r\n')
 }
 
 fn test_sign_two_signatures_coexist() {

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -323,6 +323,20 @@ fn test_outgoing_proxy_request_components_use_absolute_form() {
 	assert c.component_value('@request-target')! == 'http://example.com/search?q=a+b'
 }
 
+fn test_sign_proxy_request_rejects_covered_connection_field() {
+	proxy := http.new_http_proxy('http://localhost:8080')!
+	mut req := build_request('http://example.com/')
+	req.proxy = proxy
+	req.header.set(.connection, 'keep-alive')
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_request(mut req, key, components: ['connection'], created: 1) {
+		assert false, 'proxy serialization appends Connection: close'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !req.header.contains_custom('Signature')
+}
+
 fn test_outgoing_proxy_request_components_preserve_url_authority() {
 	proxy := http.new_http_proxy('http://localhost:8080')!
 	mut req := build_request('http://origin.example:80/search')

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -223,6 +223,15 @@ fn test_outgoing_request_components_match_transmitted_query() {
 	assert c.component_value('@query')! == '?q=a+b&flag&bare'
 }
 
+fn test_outgoing_request_components_trim_explicit_host_for_derived_values() {
+	mut req := build_request('https://url.example/path')
+	req.enable_http2 = false
+	req.header.set(.host, ' example.com ')
+	c := request_components(req, 'https', .outgoing)!
+	assert c.component_value('@authority')! == 'example.com'
+	assert c.component_value('@target-uri')! == 'https://example.com/path'
+}
+
 fn test_incoming_request_components_preserve_absolute_form() {
 	req := build_request('http://example.com/search?q=a+b')
 	c := request_components(req, 'http', .incoming)!

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -341,6 +341,33 @@ fn test_sign_two_signatures_coexist() {
 	}
 }
 
+fn test_sign_request_rejects_existing_label_without_mutation() {
+	mut req := build_request('https://example.com/foo')
+	key := Key.hmac_sha256(test_secret.bytes())!
+	sign_request(mut req, key, components: ['@method'], created: 1)!
+	input_before := req.header.custom_values('Signature-Input')
+	signature_before := req.header.custom_values('Signature')
+	if _ := sign_request(mut req, key, components: ['@path'], created: 2) {
+		assert false, 'an existing signature label must not be appended again'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert req.header.custom_values('Signature-Input') == input_before
+	assert req.header.custom_values('Signature') == signature_before
+}
+
+fn test_sign_request_rejects_http2_removed_covered_field() {
+	mut req := build_request('https://example.com/foo')
+	req.header.set(.connection, 'keep-alive')
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_request(mut req, key, components: ['connection'], created: 1) {
+		assert false, 'fields removed by possible HTTP/2 negotiation cannot be covered'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !req.header.contains_custom('Signature')
+}
+
 fn test_sign_response_and_verify() {
 	mut resp := http.Response{
 		status_code: 200
@@ -376,6 +403,19 @@ fn test_sign_response_includes_generated_content_length() {
 	mut received := resp
 	received.status_code = 200
 	verify_response(received, key)!
+}
+
+fn test_sign_response_rejects_existing_label() {
+	mut resp := http.Response{
+		status_code: 200
+	}
+	key := Key.hmac_sha256(test_secret.bytes())!
+	sign_response(mut resp, key, created: 1)!
+	if _ := sign_response(mut resp, key, created: 2) {
+		assert false, 'an existing response signature label must not be appended again'
+	} else {
+		assert err is MalformedMessage
+	}
 }
 
 fn test_response_components_do_not_invent_content_length() {

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -200,6 +200,23 @@ fn test_origin_form_uses_explicit_scheme() {
 	verify_request(received, key, scheme: 'http')!
 }
 
+fn test_request_components_preserve_escaped_path() {
+	req := build_request('https://example.com/files/a%2Fb?download=1')
+	c := request_components(req, 'https')!
+	assert c.component_value('@path')! == '/files/a%2Fb'
+	assert c.component_value('@request-target')! == '/files/a%2Fb?download=1'
+}
+
+fn test_append_dict_header_preserves_all_existing_field_lines() {
+	mut header := http.Header{}
+	header.add_custom('Signature-Input', 'sig-a=("@method")')!
+	header.add_custom('Signature-Input', 'sig-b=("@path")')!
+	append_dict_header(mut header, 'Signature-Input', 'sig-c=("@authority")')!
+	assert header.custom_values('Signature-Input') == [
+		'sig-a=("@method"), sig-b=("@path"), sig-c=("@authority")',
+	]
+}
+
 fn test_sign_two_signatures_coexist() {
 	mut req := build_request('https://example.com/foo')
 	k1 := Key.hmac_sha256('one'.bytes())

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -30,6 +30,7 @@ fn test_sign_and_verify_request_hmac_roundtrip() {
 		components: ['@method', '@target-uri', '@authority', 'date', 'content-type']
 		created:    1618884473
 	)!
+	assert !req.allow_redirect
 	verify_request(req, key)!
 }
 
@@ -264,6 +265,14 @@ fn test_outgoing_request_components_match_repeated_header_serialization() {
 	assert c.component_value('accept')! == 'text/html, application/json'
 }
 
+fn test_outgoing_request_components_deduplicate_header_name_casing() {
+	mut req := build_request('https://example.com/')
+	req.header.add_custom('X-Foo', 'a')!
+	req.header.add_custom('x-foo', 'b')!
+	c := request_components(req, 'https', .outgoing)!
+	assert c.component_value('x-foo')! == 'a, b'
+}
+
 fn test_outgoing_request_components_include_generated_fields() {
 	mut req := http.Request{
 		method:     .post
@@ -354,6 +363,18 @@ fn test_sign_response_normalizes_zero_status_to_wire_ok() {
 		...resp
 		status_code: 200
 	}
+	verify_response(received, key)!
+}
+
+fn test_sign_response_includes_generated_content_length() {
+	mut resp := http.Response{
+		body: 'hello'
+	}
+	key := Key.hmac_sha256(test_secret.bytes())!
+	sign_response(mut resp, key, components: ['@status', 'content-length'], created: 1)!
+	mut received := resp
+	received.status_code = 200
+	received.header.set(.content_length, received.body.len.str())
 	verify_response(received, key)!
 }
 

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -750,6 +750,21 @@ fn test_sign_response_preserves_unassigned_three_digit_status() {
 	}
 }
 
+fn test_sign_response_rejects_out_of_range_status_without_mutation() {
+	mut resp := http.Response{
+		status_code: 700
+	}
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_response(mut resp, key, components: ['@status'], created: 1) {
+		assert false, 'an out-of-range wire status must not be signed as a different code'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert resp.status_code == 700
+	assert !resp.header.contains_custom('Signature-Input')
+	assert !resp.header.contains_custom('Signature')
+}
+
 fn test_sign_response_includes_generated_content_length() {
 	mut resp := http.Response{
 		body: 'hello'
@@ -878,7 +893,7 @@ fn test_sign_response_preflights_both_signature_header_slots() {
 fn test_response_components_do_not_invent_content_length() {
 	c := response_components(http.Response{
 		body: 'hello'
-	})
+	})!
 	if _ := c.component_value('content-length') {
 		assert false, 'an absent response Content-Length must remain absent'
 	} else {

--- a/vlib/net/http/signature/http_message_test.v
+++ b/vlib/net/http/signature/http_message_test.v
@@ -810,6 +810,21 @@ fn test_outgoing_trace_components_do_not_synthesize_content_length() {
 	}
 }
 
+fn test_sign_request_rejects_trace_body() {
+	mut req := http.Request{
+		method: .trace
+		url:    'https://example.com/'
+		data:   'body'
+	}
+	key := Key.hmac_sha256(test_secret.bytes())!
+	if _ := sign_request(mut req, key, components: ['@method'], created: 1) {
+		assert false, 'TRACE request bodies cannot be sent safely'
+	} else {
+		assert err is MalformedMessage
+	}
+	assert !req.header.contains_custom('Signature')
+}
+
 fn test_sign_response_rejects_existing_label() {
 	mut resp := http.Response{
 		status_code: 200

--- a/vlib/net/http/signature/key.v
+++ b/vlib/net/http/signature/key.v
@@ -261,17 +261,21 @@ fn ecdsa_key_from_xy_d(xy []u8, d []u8, is_priv bool) !Key {
 	coord := (xy.len - 1) / 2
 	x := xy[1..1 + coord]
 	y := xy[1 + coord..1 + coord * 2]
+	// `ecdsa.PrivateKey.bytes()` returns the scalar in minimal-length form
+	// (no leading zeros), so we pad it to the curve byte size; the wire
+	// layout that `ecdsa_sign` expects is fixed-width.
+	priv_d := if is_priv { pad_left(d, coord)! } else { d }
 	return match coord {
 		32 {
 			if is_priv {
-				Key.ecdsa_p256_private(x, y, d)
+				Key.ecdsa_p256_private(x, y, priv_d)
 			} else {
 				Key.ecdsa_p256_public(x, y)
 			}
 		}
 		48 {
 			if is_priv {
-				Key.ecdsa_p384_private(x, y, d)
+				Key.ecdsa_p384_private(x, y, priv_d)
 			} else {
 				Key.ecdsa_p384_public(x, y)
 			}
@@ -282,4 +286,20 @@ fn ecdsa_key_from_xy_d(xy []u8, d []u8, is_priv bool) !Key {
 			}
 		}
 	}
+}
+
+fn pad_left(b []u8, width int) ![]u8 {
+	if b.len == width {
+		return b
+	}
+	if b.len > width {
+		return MalformedMessage{
+			reason: 'ECDSA scalar wider (${b.len}) than curve coordinate size (${width})'
+		}
+	}
+	mut out := []u8{len: width}
+	for i, v in b {
+		out[width - b.len + i] = v
+	}
+	return out
 }

--- a/vlib/net/http/signature/key.v
+++ b/vlib/net/http/signature/key.v
@@ -1,0 +1,285 @@
+// Key material used by `sign` and `verify`. The struct is intentionally
+// algorithm-tagged - one Key value carries both its algorithm and the
+// raw octets, so the high-level helpers can pick the right primitive
+// without the caller having to repeat themselves.
+//
+// Use the typed constructors (Key.hmac_sha256, Key.ed25519_private,
+// Key.ecdsa_p256_public, etc.) - never build a Key by struct literal.
+module signature
+
+import crypto.ecdsa
+import crypto.pem
+
+// Key is a tagged blob of key material. Public/private distinction is
+// in `is_private`; the on-the-wire layout of `bytes` depends on
+// `algorithm` and is documented per constructor below.
+pub struct Key {
+pub:
+	algorithm  Algorithm
+	is_private bool
+	// bytes layout per algorithm:
+	//   .hmac_sha256       → the symmetric secret
+	//   .ed25519, private  → 32-byte seed (RFC 8032 §5.1.5)
+	//   .ed25519, public   → 32-byte x coordinate
+	//   .ecdsa_*, private  → x || y || d (each at curve byte size)
+	//   .ecdsa_*, public   → x || y       (each at curve byte size)
+	bytes []u8
+	// keyid, if set, is what the high-level helpers will emit as the
+	// `keyid` signature parameter when no explicit keyid is passed.
+	// Not part of the cryptographic identity - just routing metadata.
+	keyid ?string
+}
+
+// Key.hmac_sha256 builds a symmetric key for the hmac-sha256 algorithm.
+// `secret` must not be empty. RFC 9421 §3.3.3 recommends at least
+// 256 bits of entropy.
+pub fn Key.hmac_sha256(secret []u8) Key {
+	return Key{
+		algorithm: .hmac_sha256
+		bytes:     secret
+	}
+}
+
+// Key.ed25519_private wraps a 32-byte Ed25519 seed (RFC 8032 §5.1.5).
+// The corresponding public key can be derived on demand by the signer.
+pub fn Key.ed25519_private(seed []u8) Key {
+	return Key{
+		algorithm:  .ed25519
+		is_private: true
+		bytes:      seed
+	}
+}
+
+// Key.ed25519_public wraps the 32-byte Ed25519 public x-coordinate.
+pub fn Key.ed25519_public(x []u8) Key {
+	return Key{
+		algorithm: .ed25519
+		bytes:     x
+	}
+}
+
+// Key.ecdsa_p256_private wraps an ECDSA P-256 private key as raw
+// (x, y, d) coordinates. Each coordinate is zero-padded to 32 bytes
+// (the curve byte size).
+pub fn Key.ecdsa_p256_private(x []u8, y []u8, d []u8) Key {
+	return Key{
+		algorithm:  .ecdsa_p256_sha256
+		is_private: true
+		bytes:      concat3(x, y, d)
+	}
+}
+
+// Key.ecdsa_p256_public wraps an ECDSA P-256 public key as raw (x, y).
+pub fn Key.ecdsa_p256_public(x []u8, y []u8) Key {
+	return Key{
+		algorithm: .ecdsa_p256_sha256
+		bytes:     concat3(x, y, []u8{})
+	}
+}
+
+// Key.ecdsa_p384_private wraps an ECDSA P-384 private key as raw
+// (x, y, d) coordinates. Each coordinate is zero-padded to 48 bytes.
+pub fn Key.ecdsa_p384_private(x []u8, y []u8, d []u8) Key {
+	return Key{
+		algorithm:  .ecdsa_p384_sha384
+		is_private: true
+		bytes:      concat3(x, y, d)
+	}
+}
+
+// Key.ecdsa_p384_public wraps an ECDSA P-384 public key as raw (x, y).
+pub fn Key.ecdsa_p384_public(x []u8, y []u8) Key {
+	return Key{
+		algorithm: .ecdsa_p384_sha384
+		bytes:     concat3(x, y, []u8{})
+	}
+}
+
+// with_keyid returns a copy of the Key with `keyid` set. Convenience
+// for fluent construction at call sites.
+pub fn (k Key) with_keyid(keyid string) Key {
+	return Key{
+		algorithm:  k.algorithm
+		is_private: k.is_private
+		bytes:      k.bytes
+		keyid:      keyid
+	}
+}
+
+fn concat3(a []u8, b []u8, c []u8) []u8 {
+	mut out := []u8{cap: a.len + b.len + c.len}
+	out << a
+	out << b
+	out << c
+	return out
+}
+
+// Key.from_pem decodes a PEM-encoded key and returns a Key tagged with
+// the algorithm inferred from the embedded OID. Supports the four
+// PEM shapes commonly emitted by `openssl genpkey` / `openssl ec`:
+//
+//   * `-----BEGIN PRIVATE KEY-----`     (PKCS#8 — Ed25519 or ECDSA)
+//   * `-----BEGIN EC PRIVATE KEY-----`  (SEC1 — ECDSA)
+//   * `-----BEGIN PUBLIC KEY-----`      (SPKI — Ed25519 or ECDSA)
+//
+// HMAC keys never come as PEM (they're raw shared secrets) — call
+// `Key.hmac_sha256` directly with the bytes for those.
+pub fn Key.from_pem(pem_text string) !Key {
+	block := pem.decode_only(pem_text) or {
+		return MalformedMessage{
+			reason: 'PEM decode failed (missing or malformed BEGIN/END markers)'
+		}
+	}
+	der := block.data
+	if contains_oid_ed25519(der) {
+		return match block.block_type {
+			'PRIVATE KEY' {
+				parse_ed25519_pkcs8(der)!
+			}
+			'PUBLIC KEY' {
+				parse_ed25519_spki(der)!
+			}
+			else {
+				return MalformedMessage{
+					reason: 'unexpected PEM block "${block.block_type}" for an Ed25519 key'
+				}
+			}
+		}
+	}
+	// ECDSA path - delegate parsing to vlib/crypto/ecdsa, then extract
+	// raw coordinates so the Key struct stays algorithm-tagged.
+	return match block.block_type {
+		'PUBLIC KEY' {
+			ecdsa_key_from_pem_public(pem_text)!
+		}
+		'EC PRIVATE KEY', 'PRIVATE KEY' {
+			ecdsa_key_from_pem_private(pem_text)!
+		}
+		else {
+			return MalformedMessage{
+				reason: 'unsupported PEM block "${block.block_type}" - expected PRIVATE KEY, EC PRIVATE KEY, or PUBLIC KEY'
+			}
+		}
+	}
+}
+
+// OID 1.3.101.112 (id-Ed25519, RFC 8410 §3) - the byte sequence
+// `06 03 2B 65 70` is unambiguous in any PKCS#8 / SPKI Ed25519 blob.
+fn contains_oid_ed25519(b []u8) bool {
+	needle := [u8(0x06), 0x03, 0x2B, 0x65, 0x70]
+	if b.len < needle.len {
+		return false
+	}
+	for i in 0 .. b.len - needle.len + 1 {
+		mut ok := true
+		for j in 0 .. needle.len {
+			if b[i + j] != needle[j] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+// parse_ed25519_pkcs8 extracts the 32-byte seed from the canonical
+// RFC 8410 §7 PrivateKeyInfo encoding. The DER is fully constrained
+// for Ed25519 keys (no optional fields), so we recognise the byte
+// pattern rather than running a general ASN.1 parser.
+fn parse_ed25519_pkcs8(der []u8) !Key {
+	prefix := [u8(0x30), 0x2E, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2B, 0x65, 0x70, 0x04,
+		0x22, 0x04, 0x20]
+	if der.len != 48 || !has_prefix(der, prefix) {
+		return MalformedMessage{
+			reason: 'Ed25519 PKCS#8 private key must follow the canonical RFC 8410 §7 encoding'
+		}
+	}
+	return Key.ed25519_private(der[16..48].clone())
+}
+
+// parse_ed25519_spki extracts the 32-byte x coordinate from the
+// canonical SubjectPublicKeyInfo encoding (RFC 8410 §4).
+fn parse_ed25519_spki(der []u8) !Key {
+	prefix := [u8(0x30), 0x2A, 0x30, 0x05, 0x06, 0x03, 0x2B, 0x65, 0x70, 0x03, 0x21, 0x00]
+	if der.len != 44 || !has_prefix(der, prefix) {
+		return MalformedMessage{
+			reason: 'Ed25519 SPKI public key must follow the canonical RFC 8410 §4 encoding'
+		}
+	}
+	return Key.ed25519_public(der[12..44].clone())
+}
+
+fn has_prefix(b []u8, prefix []u8) bool {
+	if b.len < prefix.len {
+		return false
+	}
+	for i in 0 .. prefix.len {
+		if b[i] != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
+
+fn ecdsa_key_from_pem_private(pem_text string) !Key {
+	priv_obj := ecdsa.privkey_from_string(pem_text) or {
+		return MalformedMessage{
+			reason: 'ECDSA PEM parse failed: ${err.msg()}'
+		}
+	}
+	d := priv_obj.bytes()!
+	pub_obj := priv_obj.public_key()!
+	priv_obj.free()
+	xy := pub_obj.bytes()!
+	pub_obj.free()
+	return ecdsa_key_from_xy_d(xy, d, true)!
+}
+
+fn ecdsa_key_from_pem_public(pem_text string) !Key {
+	pub_obj := ecdsa.pubkey_from_string(pem_text) or {
+		return MalformedMessage{
+			reason: 'ECDSA PEM parse failed: ${err.msg()}'
+		}
+	}
+	xy := pub_obj.bytes()!
+	pub_obj.free()
+	return ecdsa_key_from_xy_d(xy, []u8{}, false)!
+}
+
+// ecdsa_key_from_xy_d takes the SEC1 uncompressed point (`xy` =
+// `0x04 || x || y`) and an optional `d` and selects the matching
+// `Key.ecdsa_p256_*` / `Key.ecdsa_p384_*` constructor by point size.
+fn ecdsa_key_from_xy_d(xy []u8, d []u8, is_priv bool) !Key {
+	if xy.len < 1 || xy[0] != 0x04 {
+		return MalformedMessage{
+			reason: 'ECDSA public key must be SEC1 uncompressed (0x04 || x || y)'
+		}
+	}
+	coord := (xy.len - 1) / 2
+	x := xy[1..1 + coord]
+	y := xy[1 + coord..1 + coord * 2]
+	return match coord {
+		32 {
+			if is_priv {
+				Key.ecdsa_p256_private(x, y, d)
+			} else {
+				Key.ecdsa_p256_public(x, y)
+			}
+		}
+		48 {
+			if is_priv {
+				Key.ecdsa_p384_private(x, y, d)
+			} else {
+				Key.ecdsa_p384_public(x, y)
+			}
+		}
+		else {
+			return UnsupportedAlgorithm{
+				name: 'ECDSA curve with ${coord * 8}-bit coordinates'
+			}
+		}
+	}
+}

--- a/vlib/net/http/signature/key.v
+++ b/vlib/net/http/signature/key.v
@@ -60,38 +60,43 @@ pub fn Key.ed25519_public(x []u8) Key {
 
 // Key.ecdsa_p256_private wraps an ECDSA P-256 private key as raw
 // (x, y, d) coordinates. Each coordinate is zero-padded to 32 bytes
-// (the curve byte size).
-pub fn Key.ecdsa_p256_private(x []u8, y []u8, d []u8) Key {
+// (the curve byte size). Oversized coordinates return `MalformedMessage`.
+pub fn Key.ecdsa_p256_private(x []u8, y []u8, d []u8) !Key {
 	return Key{
 		algorithm:  .ecdsa_p256_sha256
 		is_private: true
-		bytes:      concat3(x, y, d)
+		bytes:      concat3(pad_left(x, 32)!, pad_left(y, 32)!, pad_left(d, 32)!)
 	}
 }
 
-// Key.ecdsa_p256_public wraps an ECDSA P-256 public key as raw (x, y).
-pub fn Key.ecdsa_p256_public(x []u8, y []u8) Key {
+// Key.ecdsa_p256_public wraps an ECDSA P-256 public key as raw (x, y),
+// zero-padding each coordinate to 32 bytes. Oversized coordinates return
+// `MalformedMessage`.
+pub fn Key.ecdsa_p256_public(x []u8, y []u8) !Key {
 	return Key{
 		algorithm: .ecdsa_p256_sha256
-		bytes:     concat3(x, y, []u8{})
+		bytes:     concat3(pad_left(x, 32)!, pad_left(y, 32)!, []u8{})
 	}
 }
 
 // Key.ecdsa_p384_private wraps an ECDSA P-384 private key as raw
 // (x, y, d) coordinates. Each coordinate is zero-padded to 48 bytes.
-pub fn Key.ecdsa_p384_private(x []u8, y []u8, d []u8) Key {
+// Oversized coordinates return `MalformedMessage`.
+pub fn Key.ecdsa_p384_private(x []u8, y []u8, d []u8) !Key {
 	return Key{
 		algorithm:  .ecdsa_p384_sha384
 		is_private: true
-		bytes:      concat3(x, y, d)
+		bytes:      concat3(pad_left(x, 48)!, pad_left(y, 48)!, pad_left(d, 48)!)
 	}
 }
 
-// Key.ecdsa_p384_public wraps an ECDSA P-384 public key as raw (x, y).
-pub fn Key.ecdsa_p384_public(x []u8, y []u8) Key {
+// Key.ecdsa_p384_public wraps an ECDSA P-384 public key as raw (x, y),
+// zero-padding each coordinate to 48 bytes. Oversized coordinates return
+// `MalformedMessage`.
+pub fn Key.ecdsa_p384_public(x []u8, y []u8) !Key {
 	return Key{
 		algorithm: .ecdsa_p384_sha384
-		bytes:     concat3(x, y, []u8{})
+		bytes:     concat3(pad_left(x, 48)!, pad_left(y, 48)!, []u8{})
 	}
 }
 
@@ -261,23 +266,19 @@ fn ecdsa_key_from_xy_d(xy []u8, d []u8, is_priv bool) !Key {
 	coord := (xy.len - 1) / 2
 	x := xy[1..1 + coord]
 	y := xy[1 + coord..1 + coord * 2]
-	// `ecdsa.PrivateKey.bytes()` returns the scalar in minimal-length form
-	// (no leading zeros), so we pad it to the curve byte size; the wire
-	// layout that `ecdsa_sign` expects is fixed-width.
-	priv_d := if is_priv { pad_left(d, coord)! } else { d }
 	return match coord {
 		32 {
 			if is_priv {
-				Key.ecdsa_p256_private(x, y, priv_d)
+				Key.ecdsa_p256_private(x, y, d)!
 			} else {
-				Key.ecdsa_p256_public(x, y)
+				Key.ecdsa_p256_public(x, y)!
 			}
 		}
 		48 {
 			if is_priv {
-				Key.ecdsa_p384_private(x, y, priv_d)
+				Key.ecdsa_p384_private(x, y, d)!
 			} else {
-				Key.ecdsa_p384_public(x, y)
+				Key.ecdsa_p384_public(x, y)!
 			}
 		}
 		else {
@@ -294,7 +295,7 @@ fn pad_left(b []u8, width int) ![]u8 {
 	}
 	if b.len > width {
 		return MalformedMessage{
-			reason: 'ECDSA scalar wider (${b.len}) than curve coordinate size (${width})'
+			reason: 'ECDSA value wider (${b.len}) than curve coordinate size (${width})'
 		}
 	}
 	mut out := []u8{len: width}

--- a/vlib/net/http/signature/key.v
+++ b/vlib/net/http/signature/key.v
@@ -151,14 +151,20 @@ pub fn Key.from_pem(pem_text string) !Key {
 			}
 		}
 	}
+	if block.block_type !in ['PUBLIC KEY', 'EC PRIVATE KEY', 'PRIVATE KEY'] {
+		return MalformedMessage{
+			reason: 'unsupported PEM block "${block.block_type}" - expected PRIVATE KEY, EC PRIVATE KEY, or PUBLIC KEY'
+		}
+	}
+	curve := ecdsa_curve_from_der(der)!
 	// ECDSA path - delegate parsing to vlib/crypto/ecdsa, then extract
 	// raw coordinates so the Key struct stays algorithm-tagged.
 	return match block.block_type {
 		'PUBLIC KEY' {
-			ecdsa_key_from_pem_public(pem_text)!
+			ecdsa_key_from_pem_public(pem_text, curve)!
 		}
 		'EC PRIVATE KEY', 'PRIVATE KEY' {
-			ecdsa_key_from_pem_private(pem_text)!
+			ecdsa_key_from_pem_private(pem_text, curve)!
 		}
 		else {
 			return MalformedMessage{
@@ -172,8 +178,43 @@ pub fn Key.from_pem(pem_text string) !Key {
 // `06 03 2B 65 70` is unambiguous in any PKCS#8 / SPKI Ed25519 blob.
 fn contains_oid_ed25519(b []u8) bool {
 	needle := [u8(0x06), 0x03, 0x2B, 0x65, 0x70]
+	return contains_bytes(b, needle)
+}
+
+enum EcdsaPemCurve {
+	p256
+	p384
+}
+
+fn ecdsa_curve_from_der(der []u8) !EcdsaPemCurve {
+	p256_pos := index_bytes(der, [u8(0x06), 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07])
+	p384_pos := index_bytes(der, [u8(0x06), 0x05, 0x2B, 0x81, 0x04, 0x00, 0x22])
+	k1_pos := index_bytes(der, [u8(0x06), 0x05, 0x2B, 0x81, 0x04, 0x00, 0x0A])
+	p521_pos := index_bytes(der, [u8(0x06), 0x05, 0x2B, 0x81, 0x04, 0x00, 0x23])
+	mut first_pos := der.len
+	for pos in [p256_pos, p384_pos, k1_pos, p521_pos] {
+		if pos >= 0 && pos < first_pos {
+			first_pos = pos
+		}
+	}
+	if p256_pos == first_pos {
+		return .p256
+	}
+	if p384_pos == first_pos {
+		return .p384
+	}
+	return UnsupportedAlgorithm{
+		name: 'ECDSA curve in PEM'
+	}
+}
+
+fn contains_bytes(b []u8, needle []u8) bool {
+	return index_bytes(b, needle) >= 0
+}
+
+fn index_bytes(b []u8, needle []u8) int {
 	if b.len < needle.len {
-		return false
+		return -1
 	}
 	for i in 0 .. b.len - needle.len + 1 {
 		mut ok := true
@@ -184,10 +225,10 @@ fn contains_oid_ed25519(b []u8) bool {
 			}
 		}
 		if ok {
-			return true
+			return i
 		}
 	}
-	return false
+	return -1
 }
 
 // parse_ed25519_pkcs8 extracts the 32-byte seed from the canonical
@@ -229,7 +270,7 @@ fn has_prefix(b []u8, prefix []u8) bool {
 	return true
 }
 
-fn ecdsa_key_from_pem_private(pem_text string) !Key {
+fn ecdsa_key_from_pem_private(pem_text string, curve EcdsaPemCurve) !Key {
 	priv_obj := ecdsa.privkey_from_string(pem_text) or {
 		return MalformedMessage{
 			reason: 'ECDSA PEM parse failed: ${err.msg()}'
@@ -240,10 +281,10 @@ fn ecdsa_key_from_pem_private(pem_text string) !Key {
 	priv_obj.free()
 	xy := pub_obj.bytes()!
 	pub_obj.free()
-	return ecdsa_key_from_xy_d(xy, d, true)!
+	return ecdsa_key_from_xy_d(xy, d, true, curve)!
 }
 
-fn ecdsa_key_from_pem_public(pem_text string) !Key {
+fn ecdsa_key_from_pem_public(pem_text string, curve EcdsaPemCurve) !Key {
 	pub_obj := ecdsa.pubkey_from_string(pem_text) or {
 		return MalformedMessage{
 			reason: 'ECDSA PEM parse failed: ${err.msg()}'
@@ -251,13 +292,13 @@ fn ecdsa_key_from_pem_public(pem_text string) !Key {
 	}
 	xy := pub_obj.bytes()!
 	pub_obj.free()
-	return ecdsa_key_from_xy_d(xy, []u8{}, false)!
+	return ecdsa_key_from_xy_d(xy, []u8{}, false, curve)!
 }
 
 // ecdsa_key_from_xy_d takes the SEC1 uncompressed point (`xy` =
-// `0x04 || x || y`) and an optional `d` and selects the matching
-// `Key.ecdsa_p256_*` / `Key.ecdsa_p384_*` constructor by point size.
-fn ecdsa_key_from_xy_d(xy []u8, d []u8, is_priv bool) !Key {
+// `0x04 || x || y`) and an optional `d` and selects the constructor
+// matching the named-curve OID parsed from the PEM.
+fn ecdsa_key_from_xy_d(xy []u8, d []u8, is_priv bool, curve EcdsaPemCurve) !Key {
 	if xy.len < 1 || xy[0] != 0x04 {
 		return MalformedMessage{
 			reason: 'ECDSA public key must be SEC1 uncompressed (0x04 || x || y)'
@@ -266,24 +307,29 @@ fn ecdsa_key_from_xy_d(xy []u8, d []u8, is_priv bool) !Key {
 	coord := (xy.len - 1) / 2
 	x := xy[1..1 + coord]
 	y := xy[1 + coord..1 + coord * 2]
-	return match coord {
-		32 {
+	return match curve {
+		.p256 {
+			if coord != 32 {
+				return MalformedMessage{
+					reason: 'P-256 key must have 32-byte coordinates'
+				}
+			}
 			if is_priv {
 				Key.ecdsa_p256_private(x, y, d)!
 			} else {
 				Key.ecdsa_p256_public(x, y)!
 			}
 		}
-		48 {
+		.p384 {
+			if coord != 48 {
+				return MalformedMessage{
+					reason: 'P-384 key must have 48-byte coordinates'
+				}
+			}
 			if is_priv {
 				Key.ecdsa_p384_private(x, y, d)!
 			} else {
 				Key.ecdsa_p384_public(x, y)!
-			}
-		}
-		else {
-			return UnsupportedAlgorithm{
-				name: 'ECDSA curve with ${coord * 8}-bit coordinates'
 			}
 		}
 	}

--- a/vlib/net/http/signature/key.v
+++ b/vlib/net/http/signature/key.v
@@ -33,7 +33,12 @@ pub:
 // Key.hmac_sha256 builds a symmetric key for the hmac-sha256 algorithm.
 // `secret` must not be empty. RFC 9421 §3.3.3 recommends at least
 // 256 bits of entropy.
-pub fn Key.hmac_sha256(secret []u8) Key {
+pub fn Key.hmac_sha256(secret []u8) !Key {
+	if secret.len == 0 {
+		return MalformedMessage{
+			reason: 'HMAC secret cannot be empty'
+		}
+	}
 	return Key{
 		algorithm: .hmac_sha256
 		bytes:     secret

--- a/vlib/net/http/signature/key_test.v
+++ b/vlib/net/http/signature/key_test.v
@@ -23,6 +23,15 @@ AwEHoUQDQgAEqIVYZVLCrPZHGHjP17CTW0/+D9Lfw0EkjqF7xB4FivAxzic30tMM
 4GF+hR6Dxh71Z50VGGdldkkDXZCnTNnoXQ==
 -----END EC PRIVATE KEY-----'
 
+// P-256 key whose private scalar starts with 0x00, so OpenSSL's
+// `BN_bn2binpad(num_bytes)` returns 31 bytes instead of 32. This
+// exercises the leading-zero padding in `ecdsa_key_from_xy_d`.
+const short_d_p256_private_pem = '-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIACZmEw0q8iipb0amaNiobX/wwn6PoIKUatErMY2Dd4+oAoGCCqGSM49
+AwEHoUQDQgAE/z/OBheMT6mCKDapfETr56tkYLOrnQh+ZL293+IqXsJ+iMZgYe0/
+WHaZhZfCu1OKUWayaVEkvb7j0o3uUfw+OQ==
+-----END EC PRIVATE KEY-----'
+
 fn key_test_b26_components() Components {
 	return Components{
 		method:    'POST'
@@ -101,6 +110,35 @@ fn test_from_pem_ecdsa_p256_public_verifies_rfc_b24_reference() {
 		'sig-b24=("@status" "content-type" "content-digest" "content-length");created=1618884473;keyid="test-key-ecc-p256"',
 		'sig-b24=:wNmSUAhwb5LxtOtOpNa6W5xj067m5hFrj0XQ4fvpaCLx0NKocgPquLgyahnzDnDAUy5eCdlYUEkLIj+32oiasw==:',
 		'sig-b24', pub_key)!
+}
+
+fn test_from_pem_ecdsa_p256_pads_short_private_scalar() {
+	// Regression: a P-256 PEM whose `d` has a leading zero byte must
+	// still produce a 96-byte (x||y||d) key and sign successfully.
+	priv := Key.from_pem(short_d_p256_private_pem)!
+	assert priv.algorithm == .ecdsa_p256_sha256
+	assert priv.is_private
+	assert priv.bytes.len == 96
+	c := Components{
+		method:     'POST'
+		target_uri: 'https://example.com/'
+	}
+	p := SignatureParams{
+		components: ['@method', '@target-uri']
+		created:    1
+	}
+	out := sign(c, p, priv, 'sig1')!
+	verify(c, out.signature_input, out.signature, 'sig1', priv)!
+}
+
+fn test_pad_left_pads_to_width_and_rejects_overflow() {
+	assert pad_left([u8(0x01)], 4)! == [u8(0x00), 0x00, 0x00, 0x01]
+	assert pad_left([u8(0x01), 0x02, 0x03, 0x04], 4)! == [u8(0x01), 0x02, 0x03, 0x04]
+	if _ := pad_left([u8(0x01), 0x02, 0x03, 0x04, 0x05], 4) {
+		assert false, 'must reject scalars wider than the curve'
+	} else {
+		assert err is MalformedMessage
+	}
 }
 
 fn test_from_pem_rejects_garbage() {

--- a/vlib/net/http/signature/key_test.v
+++ b/vlib/net/http/signature/key_test.v
@@ -1,0 +1,121 @@
+// Tests for Key.from_pem - the PEM blocks come from RFC 9421
+// Appendix B.1.3 (ECDSA P-256) and B.1.4 (Ed25519). The verification
+// roundtrip checks that the parsed key behaves identically to one
+// built from raw coordinates.
+module signature
+
+const rfc_ed25519_public_pem = '-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAJrQLj5P/89iXES9+vFgrIy29clF9CC/oPPsw3c5D0bs=
+-----END PUBLIC KEY-----'
+
+const rfc_ed25519_private_pem = '-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF
+-----END PRIVATE KEY-----'
+
+const rfc_ec_p256_public_pem = '-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqIVYZVLCrPZHGHjP17CTW0/+D9Lf
+w0EkjqF7xB4FivAxzic30tMM4GF+hR6Dxh71Z50VGGdldkkDXZCnTNnoXQ==
+-----END PUBLIC KEY-----'
+
+const rfc_ec_p256_private_pem = '-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIFKbhfNZfpDsW43+0+JjUr9K+bTeuxopu653+hBaXGA7oAoGCCqGSM49
+AwEHoUQDQgAEqIVYZVLCrPZHGHjP17CTW0/+D9Lfw0EkjqF7xB4FivAxzic30tMM
+4GF+hR6Dxh71Z50VGGdldkkDXZCnTNnoXQ==
+-----END EC PRIVATE KEY-----'
+
+fn key_test_b26_components() Components {
+	return Components{
+		method:    'POST'
+		path:      '/foo'
+		authority: 'example.com'
+		fields:    {
+			'date':           ['Tue, 20 Apr 2021 02:07:55 GMT']
+			'content-type':   ['application/json']
+			'content-length': ['18']
+		}
+	}
+}
+
+fn key_test_b26_params() SignatureParams {
+	return SignatureParams{
+		components: ['date', '@method', '@path', '@authority', 'content-type', 'content-length']
+		created:    1618884473
+		keyid:      'test-key-ed25519'
+	}
+}
+
+fn key_test_b24_components() Components {
+	return Components{
+		status: 200
+		fields: {
+			'content-type':   ['application/json']
+			'content-digest': [
+				'sha-512=:mEWXIS7MaLRuGgxOBdODa3xqM1XdEvxoYhvlCFJ41QJgJc4GTsPp29l5oGX69wWdXymyU0rjJuahq4l5aGgfLQ==:',
+			]
+			'content-length': ['23']
+		}
+	}
+}
+
+fn test_from_pem_ed25519_private_reproduces_rfc_signature() {
+	priv := Key.from_pem(rfc_ed25519_private_pem)!
+	assert priv.algorithm == .ed25519
+	assert priv.is_private
+	c := key_test_b26_components()
+	out := sign(c, key_test_b26_params(), priv, 'sig-b26')!
+	// RFC 9421 §B.2.6 reference value, byte-exact.
+	assert out.signature == 'sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==:'
+}
+
+fn test_from_pem_ed25519_public_verifies_rfc_signature() {
+	pub_key := Key.from_pem(rfc_ed25519_public_pem)!
+	assert pub_key.algorithm == .ed25519
+	assert !pub_key.is_private
+	verify(key_test_b26_components(),
+		'sig-b26=("date" "@method" "@path" "@authority" "content-type" "content-length");created=1618884473;keyid="test-key-ed25519"',
+		'sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==:',
+		'sig-b26', pub_key)!
+}
+
+fn test_from_pem_ecdsa_p256_private_signs_and_verifies() {
+	priv := Key.from_pem(rfc_ec_p256_private_pem)!
+	pub_key := Key.from_pem(rfc_ec_p256_public_pem)!
+	assert priv.algorithm == .ecdsa_p256_sha256
+	assert pub_key.algorithm == .ecdsa_p256_sha256
+	assert priv.is_private
+	c := Components{
+		method:     'POST'
+		target_uri: 'https://example.com/'
+	}
+	p := SignatureParams{
+		components: ['@method', '@target-uri']
+		created:    1
+	}
+	out := sign(c, p, priv, 'sig1')!
+	verify(c, out.signature_input, out.signature, 'sig1', pub_key)!
+}
+
+fn test_from_pem_ecdsa_p256_public_verifies_rfc_b24_reference() {
+	pub_key := Key.from_pem(rfc_ec_p256_public_pem)!
+	verify(key_test_b24_components(),
+		'sig-b24=("@status" "content-type" "content-digest" "content-length");created=1618884473;keyid="test-key-ecc-p256"',
+		'sig-b24=:wNmSUAhwb5LxtOtOpNa6W5xj067m5hFrj0XQ4fvpaCLx0NKocgPquLgyahnzDnDAUy5eCdlYUEkLIj+32oiasw==:',
+		'sig-b24', pub_key)!
+}
+
+fn test_from_pem_rejects_garbage() {
+	if _ := Key.from_pem('not a PEM block') {
+		assert false, 'must reject non-PEM input'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
+fn test_from_pem_rejects_unsupported_block_type() {
+	src := '-----BEGIN RSA PRIVATE KEY-----\nMIIEvg==\n-----END RSA PRIVATE KEY-----'
+	if _ := Key.from_pem(src) {
+		assert false, 'must reject RSA PEM (no RSA support in this module)'
+	} else {
+		assert err is MalformedMessage
+	}
+}

--- a/vlib/net/http/signature/key_test.v
+++ b/vlib/net/http/signature/key_test.v
@@ -1,3 +1,4 @@
+// vtest build: present_openssl? && !(openbsd && gcc) && !(sanitize-memory-clang || docker-ubuntu-musl)
 // Tests for Key.from_pem - the PEM blocks come from RFC 9421
 // Appendix B.1.3 (ECDSA P-256) and B.1.4 (Ed25519). The verification
 // roundtrip checks that the parsed key behaves identically to one

--- a/vlib/net/http/signature/key_test.v
+++ b/vlib/net/http/signature/key_test.v
@@ -33,6 +33,12 @@ AwEHoUQDQgAE/z/OBheMT6mCKDapfETr56tkYLOrnQh+ZL293+IqXsJ+iMZgYe0/
 WHaZhZfCu1OKUWayaVEkvb7j0o3uUfw+OQ==
 -----END EC PRIVATE KEY-----'
 
+const secp256k1_private_pem = '-----BEGIN EC PRIVATE KEY-----
+MHQCAQEEIOPU7WKsHTyVIXG8dgC7rRnWHs5aB4Ltm4evimpk/i3woAcGBSuBBAAK
+oUQDQgAECSuyyabDUU2w1p22h1AGyfD7At+Cvb63E//kTmcXA55d1xZZH3WX6msE
+9u0eNEe/4nVyHbTKoW+DKBFEGtHNpw==
+-----END EC PRIVATE KEY-----'
+
 fn key_test_b26_components() Components {
 	return Components{
 		method:    'POST'
@@ -130,6 +136,14 @@ fn test_from_pem_ecdsa_p256_pads_short_private_scalar() {
 	}
 	out := sign(c, p, priv, 'sig1')!
 	verify(c, out.signature_input, out.signature, 'sig1', priv)!
+}
+
+fn test_from_pem_rejects_unsupported_same_width_curve() {
+	if _ := Key.from_pem(secp256k1_private_pem) {
+		assert false, 'secp256k1 must not be interpreted as NIST P-256'
+	} else {
+		assert err is UnsupportedAlgorithm
+	}
 }
 
 fn test_pad_left_pads_to_width_and_rejects_overflow() {

--- a/vlib/net/http/signature/key_test.v
+++ b/vlib/net/http/signature/key_test.v
@@ -5,6 +5,8 @@
 // built from raw coordinates.
 module signature
 
+import crypto.ed25519
+
 const rfc_ed25519_public_pem = '-----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEAJrQLj5P/89iXES9+vFgrIy29clF9CC/oPPsw3c5D0bs=
 -----END PUBLIC KEY-----'
@@ -195,6 +197,15 @@ fn test_verify_rejects_invalid_ed25519_private_seed_length() {
 		assert false, 'verification must reject an invalid private seed without panicking'
 	} else {
 		assert err is MalformedMessage
+	}
+}
+
+fn test_verify_rejects_invalid_ed25519_signature_length() {
+	key := Key.ed25519_public([]u8{len: ed25519.public_key_size})
+	if _ := verify_base('base'.bytes(), []u8{}, key, 'sig1') {
+		assert false, 'verification must reject an invalid Ed25519 signature length without panicking'
+	} else {
+		assert err is VerificationFailed
 	}
 }
 

--- a/vlib/net/http/signature/key_test.v
+++ b/vlib/net/http/signature/key_test.v
@@ -142,6 +142,23 @@ fn test_pad_left_pads_to_width_and_rejects_overflow() {
 	}
 }
 
+fn test_raw_ecdsa_constructors_pad_coordinates() {
+	p256 := Key.ecdsa_p256_private([u8(1)], [u8(2)], [u8(3)])!
+	assert p256.bytes.len == 96
+	assert p256.bytes[31] == 1
+	assert p256.bytes[63] == 2
+	assert p256.bytes[95] == 3
+	p384 := Key.ecdsa_p384_public([u8(1)], [u8(2)])!
+	assert p384.bytes.len == 96
+	assert p384.bytes[47] == 1
+	assert p384.bytes[95] == 2
+	if _ := Key.ecdsa_p256_public([]u8{len: 33}, [u8(1)]) {
+		assert false, 'raw constructors must reject oversized coordinates'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_from_pem_rejects_garbage() {
 	if _ := Key.from_pem('not a PEM block') {
 		assert false, 'must reject non-PEM input'

--- a/vlib/net/http/signature/key_test.v
+++ b/vlib/net/http/signature/key_test.v
@@ -189,6 +189,15 @@ fn test_hmac_rejects_empty_secret() {
 	}
 }
 
+fn test_verify_rejects_invalid_ed25519_private_seed_length() {
+	key := Key.ed25519_private([u8(1)])
+	if _ := verify_base('base'.bytes(), []u8{len: 64}, key, 'sig1') {
+		assert false, 'verification must reject an invalid private seed without panicking'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_from_pem_rejects_garbage() {
 	if _ := Key.from_pem('not a PEM block') {
 		assert false, 'must reject non-PEM input'

--- a/vlib/net/http/signature/key_test.v
+++ b/vlib/net/http/signature/key_test.v
@@ -173,6 +173,22 @@ fn test_raw_ecdsa_constructors_pad_coordinates() {
 	}
 }
 
+fn test_hmac_rejects_empty_secret() {
+	if _ := Key.hmac_sha256([]u8{}) {
+		assert false, 'empty HMAC secrets must be rejected'
+	} else {
+		assert err is MalformedMessage
+	}
+	key := Key{
+		algorithm: .hmac_sha256
+	}
+	if _ := sign_base('base'.bytes(), key) {
+		assert false, 'directly constructed empty HMAC keys must not sign'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_from_pem_rejects_garbage() {
 	if _ := Key.from_pem('not a PEM block') {
 		assert false, 'must reject non-PEM input'

--- a/vlib/net/http/signature/rfc9421_test.v
+++ b/vlib/net/http/signature/rfc9421_test.v
@@ -1,0 +1,164 @@
+// Byte-exact test cases from RFC 9421 Appendix B. Deterministic
+// algorithms (Ed25519, HMAC) reproduce the reference signature
+// exactly; ECDSA can only verify the reference (RFC 9421 §B.2.4
+// notes its non-determinism).
+module signature
+
+import encoding.base64
+import encoding.hex
+
+const sample_request_date = 'Tue, 20 Apr 2021 02:07:55 GMT'
+
+// b64u_decode is base64.url_decode with manual padding restoration —
+// JWK encodes raw key coordinates without trailing '=' padding.
+fn b64u_decode(s string) []u8 {
+	mut padded := s
+	for padded.len % 4 != 0 {
+		padded += '='
+	}
+	return base64.url_decode(padded)
+}
+
+// RFC 9421 §B.2.6: Ed25519 over the standard test request, byte-exact
+// reproduction of the reference signature.
+fn test_b26_ed25519_signature_base_matches_rfc() {
+	c := Components{
+		method:    'POST'
+		path:      '/foo'
+		authority: 'example.com'
+		fields:    {
+			'date':           ['Tue, 20 Apr 2021 02:07:55 GMT']
+			'content-type':   ['application/json']
+			'content-length': ['18']
+		}
+	}
+	p := SignatureParams{
+		components: ['date', '@method', '@path', '@authority', 'content-type', 'content-length']
+		created:    1618884473
+		keyid:      'test-key-ed25519'
+	}
+	got := signature_base_string(c, p)!
+	want := '"date": Tue, 20 Apr 2021 02:07:55 GMT\n' + '"@method": POST\n' + '"@path": /foo\n' +
+		'"@authority": example.com\n' + '"content-type": application/json\n' +
+		'"content-length": 18\n' +
+		'"@signature-params": ("date" "@method" "@path" "@authority" "content-type" "content-length");created=1618884473;keyid="test-key-ed25519"'
+	assert got == want
+}
+
+fn test_b26_ed25519_signature_matches_rfc() {
+	seed := b64u_decode('n4Ni-HpISpVObnQMW0wOhCKROaIKqKtW_2ZYb2p9KcU')
+	priv := Key.ed25519_private(seed)
+	c := b26_components()
+	p := b26_params()
+	out := sign(c, p, priv, 'sig-b26')!
+	want_input := 'sig-b26=("date" "@method" "@path" "@authority" "content-type" "content-length");created=1618884473;keyid="test-key-ed25519"'
+	want_signature := 'sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==:'
+	assert out.signature_input == want_input
+	assert out.signature == want_signature
+}
+
+fn test_b26_ed25519_verify_roundtrip() {
+	x := b64u_decode('JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs')
+	pub_key := Key.ed25519_public(x)
+	verify(b26_components(),
+		'sig-b26=("date" "@method" "@path" "@authority" "content-type" "content-length");created=1618884473;keyid="test-key-ed25519"',
+		'sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==:',
+		'sig-b26', pub_key)!
+}
+
+fn b26_components() Components {
+	return Components{
+		method:    'POST'
+		path:      '/foo'
+		authority: 'example.com'
+		fields:    {
+			'date':           [sample_request_date]
+			'content-type':   ['application/json']
+			'content-length': ['18']
+		}
+	}
+}
+
+fn b26_params() SignatureParams {
+	return SignatureParams{
+		components: ['date', '@method', '@path', '@authority', 'content-type', 'content-length']
+		created:    1618884473
+		keyid:      'test-key-ed25519'
+	}
+}
+
+// RFC 9421 §B.2.5: HMAC-SHA256 — deterministic, byte-exact.
+fn test_b25_hmac_sha256_matches_rfc() {
+	secret :=
+		base64.decode('uzvJfB4u3N0Jy4T7NZ75MDVcr8zSTInedJtkgcu46YW4XByzNJjxBdtjUkdJPBtbmHhIDi6pcl8jsasjlTMtDQ==')
+	key := Key.hmac_sha256(secret)
+	c := Components{
+		authority: 'example.com'
+		fields:    {
+			'date':         [sample_request_date]
+			'content-type': ['application/json']
+		}
+	}
+	p := SignatureParams{
+		components: ['date', '@authority', 'content-type']
+		created:    1618884473
+		keyid:      'test-shared-secret'
+	}
+	out := sign(c, p, key, 'sig-b25')!
+	assert out.signature_input == 'sig-b25=("date" "@authority" "content-type");created=1618884473;keyid="test-shared-secret"'
+	assert out.signature == 'sig-b25=:pxcQw6G3AjtMBQjwo8XzkZf/bws5LelbaMk5rGIGtE8=:'
+	verify(c, out.signature_input, out.signature, 'sig-b25', key)!
+}
+
+// RFC 9421 §B.2.4: ECDSA P-256 / SHA-256 over the test response.
+// ECDSA is non-deterministic — only verification of the reference
+// signature is checked here. A separate test does sign+verify roundtrip.
+fn test_b24_ecdsa_p256_verify_rfc_signature() {
+	x := b64u_decode('qIVYZVLCrPZHGHjP17CTW0_-D9Lfw0EkjqF7xB4FivA')
+	y := b64u_decode('Mc4nN9LTDOBhfoUeg8Ye9WedFRhnZXZJA12Qp0zZ6F0')
+	pub_key := Key.ecdsa_p256_public(x, y)
+	c := b24_components()
+	verify(c,
+		'sig-b24=("@status" "content-type" "content-digest" "content-length");created=1618884473;keyid="test-key-ecc-p256"',
+		'sig-b24=:wNmSUAhwb5LxtOtOpNa6W5xj067m5hFrj0XQ4fvpaCLx0NKocgPquLgyahnzDnDAUy5eCdlYUEkLIj+32oiasw==:',
+		'sig-b24', pub_key)!
+}
+
+fn test_b24_ecdsa_p256_sign_verify_roundtrip() {
+	x := b64u_decode('qIVYZVLCrPZHGHjP17CTW0_-D9Lfw0EkjqF7xB4FivA')
+	y := b64u_decode('Mc4nN9LTDOBhfoUeg8Ye9WedFRhnZXZJA12Qp0zZ6F0')
+	d := b64u_decode('UpuF81l-kOxbjf7T4mNSv0r5tN67Gim7rnf6EFpcYDs')
+	priv := Key.ecdsa_p256_private(x, y, d)
+	pub_key := Key.ecdsa_p256_public(x, y)
+	c := b24_components()
+	p := SignatureParams{
+		components: ['@status', 'content-type', 'content-digest', 'content-length']
+		created:    1618884473
+		keyid:      'test-key-ecc-p256'
+	}
+	out := sign(c, p, priv, 'sig-b24')!
+	verify(c, out.signature_input, out.signature, 'sig-b24', pub_key)!
+}
+
+fn b24_components() Components {
+	return Components{
+		status: 200
+		fields: {
+			'content-type':   ['application/json']
+			'content-digest': [
+				'sha-512=:mEWXIS7MaLRuGgxOBdODa3xqM1XdEvxoYhvlCFJ41QJgJc4GTsPp29l5oGX69wWdXymyU0rjJuahq4l5aGgfLQ==:',
+			]
+			'content-length': ['23']
+		}
+	}
+}
+
+// Sanity check: the raw Ed25519 signature is exactly 64 bytes (RFC 8032).
+fn test_ed25519_signature_is_64_bytes() {
+	seed := b64u_decode('n4Ni-HpISpVObnQMW0wOhCKROaIKqKtW_2ZYb2p9KcU')
+	priv := Key.ed25519_private(seed)
+	base := signature_base_string(b26_components(), b26_params())!
+	raw := sign_base(base.bytes(), priv)!
+	assert raw.len == 64
+	_ = hex.encode(raw)
+}

--- a/vlib/net/http/signature/rfc9421_test.v
+++ b/vlib/net/http/signature/rfc9421_test.v
@@ -1,3 +1,4 @@
+// vtest build: present_openssl? && !(openbsd && gcc) && !(sanitize-memory-clang || docker-ubuntu-musl)
 // Byte-exact test cases from RFC 9421 Appendix B. Deterministic
 // algorithms (Ed25519, HMAC) reproduce the reference signature
 // exactly; ECDSA can only verify the reference (RFC 9421 §B.2.4

--- a/vlib/net/http/signature/rfc9421_test.v
+++ b/vlib/net/http/signature/rfc9421_test.v
@@ -117,7 +117,7 @@ fn test_b25_hmac_sha256_matches_rfc() {
 fn test_b24_ecdsa_p256_verify_rfc_signature() {
 	x := b64u_decode('qIVYZVLCrPZHGHjP17CTW0_-D9Lfw0EkjqF7xB4FivA')
 	y := b64u_decode('Mc4nN9LTDOBhfoUeg8Ye9WedFRhnZXZJA12Qp0zZ6F0')
-	pub_key := Key.ecdsa_p256_public(x, y)
+	pub_key := Key.ecdsa_p256_public(x, y)!
 	c := b24_components()
 	verify(c,
 		'sig-b24=("@status" "content-type" "content-digest" "content-length");created=1618884473;keyid="test-key-ecc-p256"',
@@ -129,8 +129,8 @@ fn test_b24_ecdsa_p256_sign_verify_roundtrip() {
 	x := b64u_decode('qIVYZVLCrPZHGHjP17CTW0_-D9Lfw0EkjqF7xB4FivA')
 	y := b64u_decode('Mc4nN9LTDOBhfoUeg8Ye9WedFRhnZXZJA12Qp0zZ6F0')
 	d := b64u_decode('UpuF81l-kOxbjf7T4mNSv0r5tN67Gim7rnf6EFpcYDs')
-	priv := Key.ecdsa_p256_private(x, y, d)
-	pub_key := Key.ecdsa_p256_public(x, y)
+	priv := Key.ecdsa_p256_private(x, y, d)!
+	pub_key := Key.ecdsa_p256_public(x, y)!
 	c := b24_components()
 	p := SignatureParams{
 		components: ['@status', 'content-type', 'content-digest', 'content-length']

--- a/vlib/net/http/signature/rfc9421_test.v
+++ b/vlib/net/http/signature/rfc9421_test.v
@@ -92,7 +92,7 @@ fn b26_params() SignatureParams {
 fn test_b25_hmac_sha256_matches_rfc() {
 	secret :=
 		base64.decode('uzvJfB4u3N0Jy4T7NZ75MDVcr8zSTInedJtkgcu46YW4XByzNJjxBdtjUkdJPBtbmHhIDi6pcl8jsasjlTMtDQ==')
-	key := Key.hmac_sha256(secret)
+	key := Key.hmac_sha256(secret)!
 	c := Components{
 		authority: 'example.com'
 		fields:    {

--- a/vlib/net/http/signature/signature.v
+++ b/vlib/net/http/signature/signature.v
@@ -1,0 +1,190 @@
+// HTTP Message Signatures (RFC 9421) - module entry point.
+//
+// Two API layers:
+//
+//   * **Components-based** - `signature_base_string`, `sign`, `verify`
+//     work over a generic `Components` value. Use this when you have
+//     parsed the HTTP message yourself or when signing offline.
+//
+//   * **`http.Request` / `http.Response` integration** - the
+//     `sign_request`, `verify_request`, `sign_response`,
+//     `verify_response` helpers wrap the components layer for code
+//     that already speaks `vlib/net/http`.
+//
+// The output of `sign` is the literal pair of header values you set
+// on the message - one for `Signature-Input`, one for `Signature` -
+// not a higher-level "signed message" object. Symmetry is the goal -
+// the verifier reparses the same headers and recomputes the base.
+module signature
+
+// SignedHeaders bundles the two HTTP header values produced by
+// `sign`. The signer attaches these as `Signature-Input` and
+// `Signature` respectively.
+pub struct SignedHeaders {
+pub:
+	signature_input string
+	signature       string
+}
+
+// sign computes the signature base, signs it with `key`, and returns
+// the two header values to attach to the message under `label`.
+//
+// Required parameters in `p`:
+//   * `components` - the ordered covered-components list
+//   * either `keyid` (commonly required for routing) or none (rare)
+//
+// `key.algorithm` selects the signing routine; if `p.alg` is also set
+// it MUST match the algorithm of `key` (RFC 9421 §3.1 step 3).
+pub fn sign(c Components, p SignatureParams, key Key, label string) !SignedHeaders {
+	check_label(label)!
+	check_alg_consistency(p, key)!
+	mut p2 := SignatureParams{
+		components: p.components.clone()
+		keyid:      p.keyid
+		alg:        p.alg
+		created:    p.created
+		expires:    p.expires
+		nonce:      p.nonce
+		tag:        p.tag
+	}
+	if p2.keyid == none {
+		if kid := key.keyid {
+			p2.keyid = kid
+		}
+	}
+	base := signature_base_string(c, p2)!
+	sig := sign_base(base.bytes(), key)!
+	return SignedHeaders{
+		signature_input: signature_input_value(label, p2)
+		signature:       signature_header_value(label, sig)
+	}
+}
+
+// VerifyOptions tweaks `verify`. `now_unix` enables the optional
+// `expires` parameter check (any value > 0 turns it on); leave it at
+// the default to skip the expiry check entirely. Kept as a single
+// option struct so future toggles (clock skew tolerance, allowed
+// algorithm list…) land here without breaking signatures.
+@[params]
+pub struct VerifyOptions {
+pub:
+	now_unix i64
+}
+
+// verify checks the signature for `label` against `c` using `key`.
+// Both header values are taken as-they-appear-on-the-wire (i.e. the
+// raw `Signature-Input` and `Signature` field values).
+//
+// `label` selects which signature to check when several are present.
+// Pass an empty string to verify the only signature - the call fails
+// with `MalformedMessage` if zero or more than one is found. When
+// `opts.now_unix > 0` the `expires` parameter is also enforced.
+pub fn verify(c Components, sig_input_header string, signature_header string, label string, key Key, opts VerifyOptions) ! {
+	entries := parse_signature_input(sig_input_header)!
+	signatures := parse_signature(signature_header)!
+	wanted := pick_label(entries, signatures, label)!
+	entry := find_entry(entries, wanted) or {
+		return MalformedMessage{
+			reason: 'Signature-Input has no entry for label "${wanted}"'
+		}
+	}
+	sig := signatures[wanted] or {
+		return MalformedMessage{
+			reason: 'Signature header has no entry for label "${wanted}"'
+		}
+	}
+	check_alg_param(entry, key)!
+	base := signature_base_from_entry(c, entry)!
+	verify_base(base.bytes(), sig, key, wanted)!
+	if opts.now_unix > 0 {
+		if exp_v := entry.params['expires'] {
+			if exp_v is i64 {
+				if opts.now_unix >= exp_v {
+					return SignatureExpired{
+						expires: exp_v
+						now:     opts.now_unix
+					}
+				}
+			}
+		}
+	}
+}
+
+fn pick_label(entries []SignatureEntry, signatures map[string][]u8, requested string) !string {
+	if requested != '' {
+		return requested
+	}
+	if entries.len == 1 && signatures.len == 1 {
+		return entries[0].label
+	}
+	if entries.len == 0 {
+		return MalformedMessage{
+			reason: 'Signature-Input is empty'
+		}
+	}
+	return MalformedMessage{
+		reason: 'multiple signatures present; pass a label to choose one'
+	}
+}
+
+fn find_entry(entries []SignatureEntry, label string) ?SignatureEntry {
+	for e in entries {
+		if e.label == label {
+			return e
+		}
+	}
+	return none
+}
+
+fn check_label(label string) ! {
+	if label == '' {
+		return MalformedMessage{
+			reason: 'signature label cannot be empty'
+		}
+	}
+	for c in label {
+		if !((c >= `a` && c <= `z`) || (c >= `0` && c <= `9`) || c == `-` || c == `_` || c == `*`) {
+			return MalformedMessage{
+				reason: 'signature label "${label}" must match the Structured Field key grammar (lowercase + digits + - _ *)'
+			}
+		}
+	}
+	first := label[0]
+	if !((first >= `a` && first <= `z`) || first == `*`) {
+		return MalformedMessage{
+			reason: 'signature label "${label}" must start with a lowercase letter or "*"'
+		}
+	}
+}
+
+fn check_alg_consistency(p SignatureParams, key Key) ! {
+	if alg_str := p.alg {
+		want := algorithm_from_name(alg_str) or {
+			return UnsupportedAlgorithm{
+				name: alg_str
+			}
+		}
+		if want != key.algorithm {
+			return MalformedMessage{
+				reason: 'alg parameter "${alg_str}" does not match key algorithm "${key.algorithm.name()}"'
+			}
+		}
+	}
+}
+
+fn check_alg_param(entry SignatureEntry, key Key) ! {
+	if alg_v := entry.params['alg'] {
+		if alg_v is string {
+			want := algorithm_from_name(alg_v) or {
+				return UnsupportedAlgorithm{
+					name: alg_v
+				}
+			}
+			if want != key.algorithm {
+				return MalformedMessage{
+					reason: 'signature alg "${alg_v}" does not match key algorithm "${key.algorithm.name()}"'
+				}
+			}
+		}
+	}
+}

--- a/vlib/net/http/signature/signature.v
+++ b/vlib/net/http/signature/signature.v
@@ -93,17 +93,37 @@ pub fn verify(c Components, sig_input_header string, signature_header string, la
 			reason: 'Signature header has no entry for label "${wanted}"'
 		}
 	}
+	check_registered_param_types(entry)!
 	check_alg_param(entry, key)!
 	base := signature_base_from_entry(c, entry)!
 	verify_base(base.bytes(), sig, key, wanted)!
 	if opts.now_unix > 0 {
 		if exp_v := entry.params['expires'] {
-			if exp_v is i64 {
-				if opts.now_unix >= exp_v {
-					return SignatureExpired{
-						expires: exp_v
-						now:     opts.now_unix
-					}
+			if exp_v is i64 && opts.now_unix >= exp_v {
+				return SignatureExpired{
+					expires: exp_v
+					now:     opts.now_unix
+				}
+			}
+		}
+	}
+}
+
+fn check_registered_param_types(entry SignatureEntry) ! {
+	for name in ['created', 'expires'] {
+		if value := entry.params[name] {
+			if value !is i64 {
+				return MalformedMessage{
+					reason: 'signature parameter "${name}" must be an Integer'
+				}
+			}
+		}
+	}
+	for name in ['nonce', 'alg', 'keyid', 'tag'] {
+		if value := entry.params[name] {
+			if value !is string {
+				return MalformedMessage{
+					reason: 'signature parameter "${name}" must be a String'
 				}
 			}
 		}

--- a/vlib/net/http/signature/signature.v
+++ b/vlib/net/http/signature/signature.v
@@ -137,22 +137,27 @@ fn find_entry(entries []SignatureEntry, label string) ?SignatureEntry {
 }
 
 fn check_label(label string) ! {
-	if label == '' {
+	check_sf_key(label, 'signature label')!
+}
+
+fn check_sf_key(key string, description string) ! {
+	if key == '' {
 		return MalformedMessage{
-			reason: 'signature label cannot be empty'
+			reason: '${description} cannot be empty'
 		}
 	}
-	for c in label {
-		if !((c >= `a` && c <= `z`) || (c >= `0` && c <= `9`) || c == `-` || c == `_` || c == `*`) {
+	for c in key {
+		if !((c >= `a` && c <= `z`) || (c >= `0` && c <= `9`) || c == `-` || c == `_`
+			|| c == `.` || c == `*`) {
 			return MalformedMessage{
-				reason: 'signature label "${label}" must match the Structured Field key grammar (lowercase + digits + - _ *)'
+				reason: '${description} "${key}" must match the Structured Field key grammar'
 			}
 		}
 	}
-	first := label[0]
+	first := key[0]
 	if !((first >= `a` && first <= `z`) || first == `*`) {
 		return MalformedMessage{
-			reason: 'signature label "${label}" must start with a lowercase letter or "*"'
+			reason: '${description} "${key}" must start with a lowercase letter or "*"'
 		}
 	}
 }

--- a/vlib/net/http/signature/signature.v
+++ b/vlib/net/http/signature/signature.v
@@ -55,7 +55,7 @@ pub fn sign(c Components, p SignatureParams, key Key, label string) !SignedHeade
 	base := signature_base_string(c, p2)!
 	sig := sign_base(base.bytes(), key)!
 	return SignedHeaders{
-		signature_input: signature_input_value(label, p2)
+		signature_input: signature_input_value(label, p2)!
 		signature:       signature_header_value(label, sig)
 	}
 }

--- a/vlib/net/http/signature/signature.v
+++ b/vlib/net/http/signature/signature.v
@@ -56,7 +56,7 @@ pub fn sign(c Components, p SignatureParams, key Key, label string) !SignedHeade
 	sig := sign_base(base.bytes(), key)!
 	return SignedHeaders{
 		signature_input: signature_input_value(label, p2)!
-		signature:       signature_header_value(label, sig)
+		signature:       signature_header_value(label, sig)!
 	}
 }
 

--- a/vlib/net/http/signature/signature.v
+++ b/vlib/net/http/signature/signature.v
@@ -66,14 +66,13 @@ pub fn sign(c Components, p SignatureParams, key Key, label string) !SignedHeade
 }
 
 // VerifyOptions tweaks `verify`. `now_unix` enables the optional
-// `expires` parameter check (any value > 0 turns it on); leave it at
-// the default to skip the expiry check entirely. Kept as a single
-// option struct so future toggles (clock skew tolerance, allowed
-// algorithm list…) land here without breaking signatures.
+// `expires` parameter check (any value > 0 turns it on), and
+// `required_components` enforces an application coverage policy.
 @[params]
 pub struct VerifyOptions {
 pub:
-	now_unix i64
+	now_unix            i64
+	required_components []string
 }
 
 // verify checks the signature for `label` against `c` using `key`.
@@ -83,7 +82,9 @@ pub:
 // `label` selects which signature to check when several are present.
 // Pass an empty string to verify the only signature - the call fails
 // with `MalformedMessage` if zero or more than one is found. When
-// `opts.now_unix > 0` the `expires` parameter is also enforced.
+// `opts.now_unix > 0` the `expires` parameter is also enforced. The
+// low-level API requires callers to set `required_components` when the
+// result is used for authorization; the HTTP wrappers provide safe defaults.
 pub fn verify(c Components, sig_input_header string, signature_header string, label string, key Key, opts VerifyOptions) ! {
 	entries := parse_signature_input(sig_input_header)!
 	signatures := parse_signature(signature_header)!
@@ -99,6 +100,7 @@ pub fn verify(c Components, sig_input_header string, signature_header string, la
 		}
 	}
 	check_registered_param_types(entry)!
+	check_required_components(entry, opts.required_components)!
 	if created := entry.params['created'] {
 		if created is i64 {
 			if expires := entry.params['expires'] {
@@ -118,6 +120,16 @@ pub fn verify(c Components, sig_input_header string, signature_header string, la
 					expires: exp_v
 					now:     opts.now_unix
 				}
+			}
+		}
+	}
+}
+
+fn check_required_components(entry SignatureEntry, required []string) ! {
+	for component in normalize_component_names(required) {
+		if component !in entry.components {
+			return MalformedMessage{
+				reason: 'signature does not cover required component "${component}"'
 			}
 		}
 	}

--- a/vlib/net/http/signature/signature.v
+++ b/vlib/net/http/signature/signature.v
@@ -38,6 +38,11 @@ pub:
 pub fn sign(c Components, p SignatureParams, key Key, label string) !SignedHeaders {
 	check_label(label)!
 	check_alg_consistency(p, key)!
+	if created := p.created {
+		if expires := p.expires {
+			check_signature_time_order(created, expires)!
+		}
+	}
 	mut p2 := SignatureParams{
 		components: p.components.clone()
 		keyid:      p.keyid
@@ -94,6 +99,15 @@ pub fn verify(c Components, sig_input_header string, signature_header string, la
 		}
 	}
 	check_registered_param_types(entry)!
+	if created := entry.params['created'] {
+		if created is i64 {
+			if expires := entry.params['expires'] {
+				if expires is i64 {
+					check_signature_time_order(created, expires)!
+				}
+			}
+		}
+	}
 	check_alg_param(entry, key)!
 	base := signature_base_from_entry(c, entry)!
 	verify_base(base.bytes(), sig, key, wanted)!
@@ -105,6 +119,14 @@ pub fn verify(c Components, sig_input_header string, signature_header string, la
 					now:     opts.now_unix
 				}
 			}
+		}
+	}
+}
+
+fn check_signature_time_order(created i64, expires i64) ! {
+	if expires <= created {
+		return MalformedMessage{
+			reason: 'signature parameter "expires" must be later than "created"'
 		}
 	}
 }

--- a/vlib/net/http/signature/signature.v
+++ b/vlib/net/http/signature/signature.v
@@ -65,8 +65,8 @@ pub fn sign(c Components, p SignatureParams, key Key, label string) !SignedHeade
 	}
 }
 
-// VerifyOptions tweaks `verify`. `now_unix` enables the optional
-// `expires` parameter check (any value > 0 turns it on), and
+// VerifyOptions tweaks `verify`. `now_unix` enables `created` and optional
+// `expires` time checks (any value > 0 turns them on), and
 // `required_components` enforces an application coverage policy.
 @[params]
 pub struct VerifyOptions {
@@ -82,9 +82,10 @@ pub:
 // `label` selects which signature to check when several are present.
 // Pass an empty string to verify the only signature - the call fails
 // with `MalformedMessage` if zero or more than one is found. When
-// `opts.now_unix > 0` the `expires` parameter is also enforced. The
-// low-level API requires callers to set `required_components` when the
-// result is used for authorization; the HTTP wrappers provide safe defaults.
+// `opts.now_unix > 0`, `created` and the optional `expires` parameter are
+// also enforced. The low-level API requires callers to set
+// `required_components` when the result is used for authorization; the HTTP
+// wrappers provide safe defaults.
 pub fn verify(c Components, sig_input_header string, signature_header string, label string, key Key, opts VerifyOptions) ! {
 	entries := parse_signature_input(sig_input_header)!
 	signatures := parse_signature(signature_header)!
@@ -114,6 +115,14 @@ pub fn verify(c Components, sig_input_header string, signature_header string, la
 	base := signature_base_from_entry(c, entry)!
 	verify_base(base.bytes(), sig, key, wanted)!
 	if opts.now_unix > 0 {
+		if created_v := entry.params['created'] {
+			if created_v is i64 && created_v > opts.now_unix {
+				return SignatureNotYetValid{
+					created: created_v
+					now:     opts.now_unix
+				}
+			}
+		}
 		if exp_v := entry.params['expires'] {
 			if exp_v is i64 && opts.now_unix >= exp_v {
 				return SignatureExpired{

--- a/vlib/net/http/signature/signature_base.v
+++ b/vlib/net/http/signature/signature_base.v
@@ -1,0 +1,124 @@
+// Construction of the canonical signature base string per
+// RFC 9421 §2.5. The signature base is the data passed to the
+// signing primitive; both signer and verifier MUST produce identical
+// bytes here for verification to succeed.
+//
+// Format (one line per covered component, separated by LF):
+//
+//   "<component>": <component-value>
+//   …
+//   "@signature-params": <inner-list>;<params>
+//
+// The final line is the only one without a trailing newline.
+module signature
+
+// SignatureParams holds the parameters that go after the inner-list
+// in the @signature-params line and on the Signature-Input header.
+// `components` is the *ordered* list the verifier walks; mutating
+// the order changes the wire bytes and breaks verification.
+@[params]
+pub struct SignatureParams {
+pub mut:
+	components []string
+	keyid      ?string
+	alg        ?string
+	created    ?i64
+	expires    ?i64
+	nonce      ?string
+	tag        ?string
+}
+
+// signature_base_string returns the bytes that go into the signing
+// primitive. RFC 9421 §2.5 step 7 forbids duplicate covered components
+// (the verifier rejects them), so we enforce that here too.
+pub fn signature_base_string(c Components, p SignatureParams) !string {
+	return build_signature_base(c, p.components, serialize_signature_params(p))!
+}
+
+// build_signature_base is the shared core. Both `signature_base_string`
+// (signer side - canonical params from the struct) and the verify
+// path (verifier side - params replayed verbatim from the wire) drive
+// it; only the way they obtain `signature_params_value` differs.
+fn build_signature_base(c Components, components []string, signature_params_value string) !string {
+	mut seen := map[string]bool{}
+	mut lines := []string{cap: components.len + 1}
+	for name in components {
+		if name in seen {
+			return MalformedMessage{
+				reason: 'covered components list contains duplicate "${name}"'
+			}
+		}
+		seen[name] = true
+		value := c.component_value(name)!
+		lines << '"' + name + '": ' + value
+	}
+	lines << '"@signature-params": ' + signature_params_value
+	return lines.join('\n')
+}
+
+// serialize_signature_params formats the inner-list-with-parameters
+// segment that goes both into the @signature-params line and into
+// the Signature-Input header value. Parameter order is fixed
+// (created, expires, nonce, alg, keyid, tag) for diff-stability;
+// RFC 9421 doesn't constrain order and verifiers reparse anyway.
+pub fn serialize_signature_params(p SignatureParams) string {
+	mut pairs := []ParamPair{cap: 6}
+	if v := p.created {
+		pairs << ParamPair{
+			name:  'created'
+			value: v
+		}
+	}
+	if v := p.expires {
+		pairs << ParamPair{
+			name:  'expires'
+			value: v
+		}
+	}
+	if v := p.nonce {
+		pairs << ParamPair{
+			name:  'nonce'
+			value: v
+		}
+	}
+	if v := p.alg {
+		pairs << ParamPair{
+			name:  'alg'
+			value: v
+		}
+	}
+	if v := p.keyid {
+		pairs << ParamPair{
+			name:  'keyid'
+			value: v
+		}
+	}
+	if v := p.tag {
+		pairs << ParamPair{
+			name:  'tag'
+			value: v
+		}
+	}
+	return serialize_inner_list(p.components) + serialize_params(pairs)
+}
+
+// signature_input_value returns the full Signature-Input value for
+// `label`, ready to be put into the header `Signature-Input: <…>`.
+pub fn signature_input_value(label string, p SignatureParams) string {
+	return label + '=' + serialize_signature_params(p)
+}
+
+// signature_header_value returns the full Signature value for `label`,
+// ready to be put into the header `Signature: <…>`.
+pub fn signature_header_value(label string, sig []u8) string {
+	return label + '=' + encode_byte_sequence(sig)
+}
+
+// signature_base_from_entry replays the signature base for a parsed
+// SignatureEntry. The `@signature-params` line uses the entry's raw
+// wire bytes verbatim so verification matches exactly what the signer
+// signed, regardless of the order in which the signer emitted its
+// parameters.
+fn signature_base_from_entry(c Components, entry SignatureEntry) !string {
+	return build_signature_base(c, entry.components, entry.signature_params_value)!
+}

--- a/vlib/net/http/signature/signature_base.v
+++ b/vlib/net/http/signature/signature_base.v
@@ -32,7 +32,7 @@ pub mut:
 // primitive. RFC 9421 §2.5 step 7 forbids duplicate covered components
 // (the verifier rejects them), so we enforce that here too.
 pub fn signature_base_string(c Components, p SignatureParams) !string {
-	return build_signature_base(c, p.components, serialize_signature_params(p))!
+	return build_signature_base(c, p.components, serialize_signature_params(p)!)!
 }
 
 // build_signature_base is the shared core. Both `signature_base_string`
@@ -61,7 +61,8 @@ fn build_signature_base(c Components, components []string, signature_params_valu
 // the Signature-Input header value. Parameter order is fixed
 // (created, expires, nonce, alg, keyid, tag) for diff-stability;
 // RFC 9421 doesn't constrain order and verifiers reparse anyway.
-pub fn serialize_signature_params(p SignatureParams) string {
+// Invalid Structured Field string bytes return `MalformedMessage`.
+pub fn serialize_signature_params(p SignatureParams) !string {
 	mut pairs := []ParamPair{cap: 6}
 	if v := p.created {
 		pairs << ParamPair{
@@ -99,13 +100,14 @@ pub fn serialize_signature_params(p SignatureParams) string {
 			value: v
 		}
 	}
-	return serialize_inner_list(p.components) + serialize_params(pairs)
+	return serialize_inner_list(p.components)! + serialize_params(pairs)!
 }
 
 // signature_input_value returns the full Signature-Input value for
 // `label`, ready to be put into the header `Signature-Input: <…>`.
-pub fn signature_input_value(label string, p SignatureParams) string {
-	return label + '=' + serialize_signature_params(p)
+// Invalid Structured Field string bytes return `MalformedMessage`.
+pub fn signature_input_value(label string, p SignatureParams) !string {
+	return label + '=' + serialize_signature_params(p)!
 }
 
 // signature_header_value returns the full Signature value for `label`,

--- a/vlib/net/http/signature/signature_base.v
+++ b/vlib/net/http/signature/signature_base.v
@@ -105,14 +105,17 @@ pub fn serialize_signature_params(p SignatureParams) !string {
 
 // signature_input_value returns the full Signature-Input value for
 // `label`, ready to be put into the header `Signature-Input: <…>`.
-// Invalid Structured Field string bytes return `MalformedMessage`.
+// Invalid labels or Structured Field string bytes return `MalformedMessage`.
 pub fn signature_input_value(label string, p SignatureParams) !string {
+	check_label(label)!
 	return label + '=' + serialize_signature_params(p)!
 }
 
 // signature_header_value returns the full Signature value for `label`,
-// ready to be put into the header `Signature: <…>`.
-pub fn signature_header_value(label string, sig []u8) string {
+// ready to be put into the header `Signature: <…>`. Invalid labels return
+// `MalformedMessage`.
+pub fn signature_header_value(label string, sig []u8) !string {
+	check_label(label)!
 	return label + '=' + encode_byte_sequence(sig)
 }
 

--- a/vlib/net/http/signature/signature_base.v
+++ b/vlib/net/http/signature/signature_base.v
@@ -32,7 +32,9 @@ pub mut:
 // primitive. RFC 9421 §2.5 step 7 forbids duplicate covered components
 // (the verifier rejects them), so we enforce that here too.
 pub fn signature_base_string(c Components, p SignatureParams) !string {
-	return build_signature_base(c, p.components, serialize_signature_params(p)!)!
+	mut normalized := p
+	normalized.components = normalize_component_names(p.components)
+	return build_signature_base(c, normalized.components, serialize_signature_params(normalized)!)!
 }
 
 // build_signature_base is the shared core. Both `signature_base_string`
@@ -100,7 +102,11 @@ pub fn serialize_signature_params(p SignatureParams) !string {
 			value: v
 		}
 	}
-	return serialize_inner_list(p.components)! + serialize_params(pairs)!
+	return serialize_inner_list(normalize_component_names(p.components))! + serialize_params(pairs)!
+}
+
+fn normalize_component_names(components []string) []string {
+	return components.map(if it.starts_with('@') { it } else { it.to_lower() })
 }
 
 // signature_input_value returns the full Signature-Input value for

--- a/vlib/net/http/signature/signing.v
+++ b/vlib/net/http/signature/signing.v
@@ -1,0 +1,331 @@
+// Sign / verify primitives - the part that actually consumes the
+// signature base. Each branch wraps the corresponding `vlib/crypto`
+// routine (ed25519, ecdsa, hmac) and converts between RFC 9421's
+// preferred formats and what the V crypto modules expose:
+//
+//   * Ed25519: raw 32-byte seed in / out (matches RFC 8032).
+//   * ECDSA:   raw R‖S concatenation (RFC 9421 §3.3.4); V's `ecdsa`
+//              module talks DER, so we convert at the boundary.
+//   * HMAC:    raw bytes out (RFC 9421 §3.3.3).
+module signature
+
+import crypto.ecdsa
+import crypto.ed25519
+import crypto.hmac
+import crypto.sha256
+
+const ec_p256_size = 32
+const ec_p384_size = 48
+
+// sign_base computes the signature of `base` using `key`.
+// Returns the raw signature bytes (not yet base64-encoded).
+fn sign_base(base []u8, key Key) ![]u8 {
+	if !key.is_private && !key.algorithm.is_mac() {
+		return MalformedMessage{
+			reason: 'sign requires a private key for ${key.algorithm.name()}'
+		}
+	}
+	return match key.algorithm {
+		.hmac_sha256 { hmac.new(key.bytes, base, sha256.sum, sha256.block_size) }
+		.ed25519 { ed25519_sign(base, key.bytes)! }
+		.ecdsa_p256_sha256 { ecdsa_sign(base, key, ec_p256_size, .prime256v1)! }
+		.ecdsa_p384_sha384 { ecdsa_sign(base, key, ec_p384_size, .secp384r1)! }
+	}
+}
+
+// verify_base checks that `signature` is valid over `base` under `key`.
+// Returns a typed `VerificationFailed` rather than `false`+nil so
+// callers can distinguish "signature invalid" from "verification
+// machinery itself failed".
+fn verify_base(base []u8, signature []u8, key Key, label string) ! {
+	ok := match key.algorithm {
+		.hmac_sha256 {
+			expected := hmac.new(key.bytes, base, sha256.sum, sha256.block_size)
+			hmac.equal(signature, expected)
+		}
+		.ed25519 {
+			ed25519_verify(base, signature, key)!
+		}
+		.ecdsa_p256_sha256 {
+			ecdsa_verify(base, signature, key, ec_p256_size, .prime256v1)!
+		}
+		.ecdsa_p384_sha384 {
+			ecdsa_verify(base, signature, key, ec_p384_size, .secp384r1)!
+		}
+	}
+
+	if !ok {
+		return VerificationFailed{
+			label: label
+		}
+	}
+}
+
+fn ed25519_sign(base []u8, seed []u8) ![]u8 {
+	if seed.len != ed25519.seed_size {
+		return MalformedMessage{
+			reason: 'Ed25519 seed must be ${ed25519.seed_size} bytes, got ${seed.len}'
+		}
+	}
+	priv := ed25519.new_key_from_seed(seed)
+	return priv.sign(base)
+}
+
+fn ed25519_verify(base []u8, sig []u8, key Key) !bool {
+	pub_key := if key.is_private {
+		ed25519.new_key_from_seed(key.bytes).public_key()
+	} else {
+		ed25519.PublicKey(key.bytes.clone())
+	}
+	return ed25519.verify(pub_key, base, sig)
+}
+
+fn ecdsa_sign(base []u8, key Key, coord_size int, curve ecdsa.Nid) ![]u8 {
+	// Raw layout for an ECDSA private Key is x || y || d (each
+	// `coord_size` bytes). V's ecdsa module derives x and y from d
+	// alone, so we only need d to build the EVP key.
+	if key.bytes.len != coord_size * 3 {
+		return MalformedMessage{
+			reason: 'ECDSA private key must be ${coord_size * 3} bytes (x||y||d), got ${key.bytes.len}'
+		}
+	}
+	d := key.bytes[coord_size * 2..coord_size * 3]
+	priv := ecdsa.new_key_from_seed(d, nid: curve, fixed_size: true) or {
+		return MalformedMessage{
+			reason: 'ECDSA new_key_from_seed failed: ${err.msg()}'
+		}
+	}
+	defer {
+		priv.free()
+	}
+	der := priv.sign(base) or {
+		return MalformedMessage{
+			reason: 'ECDSA sign failed: ${err.msg()}'
+		}
+	}
+	return der_to_raw(der, coord_size)
+}
+
+fn ecdsa_verify(base []u8, sig []u8, key Key, coord_size int, curve ecdsa.Nid) !bool {
+	if sig.len != coord_size * 2 {
+		return VerificationFailed{}
+	}
+	pub_key := build_ecdsa_public(key, coord_size, curve)!
+	defer {
+		pub_key.free()
+	}
+	der := raw_to_der(sig, coord_size)
+	return pub_key.verify(base, der) or {
+		// V's ecdsa.verify returns an error for malformed DER but
+		// success/false for "signature does not match". We mapped
+		// both to VerificationFailed at the call site, so swallow
+		// the error here and return false.
+		false
+	}
+}
+
+fn build_ecdsa_public(key Key, coord_size int, curve ecdsa.Nid) !ecdsa.PublicKey {
+	// For a private Key we build via the seed path (V's ecdsa derives
+	// x, y from d). For a public Key we hand-craft a SubjectPublicKeyInfo
+	// DER from the supplied (x, y) - this is the only place where this
+	// module talks raw ASN.1 DER.
+	if key.is_private {
+		if key.bytes.len != coord_size * 3 {
+			return MalformedMessage{
+				reason: 'ECDSA private key must be ${coord_size * 3} bytes'
+			}
+		}
+		d := key.bytes[coord_size * 2..coord_size * 3]
+		priv := ecdsa.new_key_from_seed(d, nid: curve, fixed_size: true)!
+		pub_key := priv.public_key()!
+		priv.free()
+		return pub_key
+	}
+	if key.bytes.len != coord_size * 2 {
+		return MalformedMessage{
+			reason: 'ECDSA public key must be ${coord_size * 2} bytes (x||y)'
+		}
+	}
+	x := key.bytes[..coord_size]
+	y := key.bytes[coord_size..coord_size * 2]
+	spki := build_ec_spki(x, y, curve)
+	return ecdsa.pubkey_from_bytes(spki)!
+}
+
+// der_to_raw extracts (R, S) from a DER-encoded ECDSA signature and
+// returns R‖S left-padded to `coord_size` bytes each. RFC 3279 §2.2.3
+// shape is: SEQUENCE { INTEGER R, INTEGER S }.
+fn der_to_raw(der []u8, coord_size int) ![]u8 {
+	if der.len < 8 || der[0] != 0x30 {
+		return MalformedMessage{
+			reason: 'ECDSA signature: malformed DER (no SEQUENCE)'
+		}
+	}
+	mut idx, _ := read_der_length(der, 1)!
+	r, idx2 := read_der_integer(der, idx)!
+	s, _ := read_der_integer(der, idx2)!
+	mut out := []u8{len: coord_size * 2}
+	pad_into(mut out, 0, r, coord_size)
+	pad_into(mut out, coord_size, s, coord_size)
+	return out
+}
+
+// raw_to_der packs R‖S back into the SEQUENCE form `ecdsa.verify`
+// expects. Both halves are sign-extended (a 0x00 prefix is added when
+// the high bit is set) so they remain non-negative INTEGERs.
+fn raw_to_der(raw []u8, coord_size int) []u8 {
+	r := strip_zeros(raw[..coord_size])
+	s := strip_zeros(raw[coord_size..coord_size * 2])
+	r_int := encode_der_integer(r)
+	s_int := encode_der_integer(s)
+	body_len := r_int.len + s_int.len
+	mut out := []u8{cap: body_len + 8}
+	out << 0x30
+	out << encode_der_length(body_len)
+	out << r_int
+	out << s_int
+	return out
+}
+
+fn read_der_length(buf []u8, start int) !(int, int) {
+	if start >= buf.len {
+		return MalformedMessage{
+			reason: 'truncated DER length'
+		}
+	}
+	first := buf[start]
+	if first < 0x80 {
+		return start + 1, int(first)
+	}
+	n := int(first & 0x7f)
+	if n == 0 || n > 4 || start + 1 + n > buf.len {
+		return MalformedMessage{
+			reason: 'unsupported DER long-form length (${n} bytes)'
+		}
+	}
+	mut len := u32(0)
+	for i in 0 .. n {
+		len = (len << 8) | u32(buf[start + 1 + i])
+	}
+	return start + 1 + n, int(len)
+}
+
+fn read_der_integer(buf []u8, start int) !([]u8, int) {
+	if start + 2 > buf.len || buf[start] != 0x02 {
+		return MalformedMessage{
+			reason: 'expected INTEGER tag 0x02 at offset ${start}'
+		}
+	}
+	idx, len := read_der_length(buf, start + 1)!
+	if idx + len > buf.len {
+		return MalformedMessage{
+			reason: 'INTEGER content runs past buffer'
+		}
+	}
+	mut content_start := idx
+	end := idx + len
+	// DER INTEGERs are sign-extended; strip the 0x00 padding byte.
+	for end > content_start + 1 && buf[content_start] == 0x00 {
+		content_start++
+	}
+	return buf[content_start..end].clone(), idx + len
+}
+
+fn encode_der_length(n int) []u8 {
+	if n < 0x80 {
+		return [u8(n)]
+	}
+	mut bytes := []u8{cap: 4}
+	mut x := n
+	for x > 0 {
+		bytes.prepend(u8(x & 0xff))
+		x >>= 8
+	}
+	mut out := []u8{cap: bytes.len + 1}
+	out << u8(0x80 | bytes.len)
+	out << bytes
+	return out
+}
+
+fn encode_der_integer(content []u8) []u8 {
+	// Pad with 0x00 if the high bit is set, otherwise the value would
+	// be interpreted as a negative integer.
+	mut body := content.clone()
+	if body.len == 0 {
+		body = [u8(0x00)]
+	} else if body[0] & 0x80 != 0 {
+		body.prepend(u8(0x00))
+	}
+	mut out := []u8{cap: body.len + 4}
+	out << 0x02
+	out << encode_der_length(body.len)
+	out << body
+	return out
+}
+
+fn strip_zeros(b []u8) []u8 {
+	mut i := 0
+	for i < b.len - 1 && b[i] == 0 {
+		i++
+	}
+	return b[i..]
+}
+
+fn pad_into(mut dst []u8, dst_off int, src []u8, target int) {
+	if src.len >= target {
+		// Source is already at or above the curve byte size; copy the
+		// rightmost `target` bytes (drops the sign-extension 0x00).
+		off := src.len - target
+		for i in 0 .. target {
+			dst[dst_off + i] = src[off + i]
+		}
+		return
+	}
+	pad := target - src.len
+	for i in 0 .. pad {
+		dst[dst_off + i] = 0
+	}
+	for i in 0 .. src.len {
+		dst[dst_off + pad + i] = src[i]
+	}
+}
+
+// build_ec_spki constructs a SubjectPublicKeyInfo DER for an EC public
+// key with the given (x, y) coordinates. RFC 5280 §4.1.2.7 + RFC 5480
+// shape:
+//
+//   SEQUENCE {
+//     SEQUENCE { OID ecPublicKey, OID <curve> },
+//     BIT STRING (0x00 || 0x04 || x || y)
+//   }
+fn build_ec_spki(x []u8, y []u8, curve ecdsa.Nid) []u8 {
+	curve_oid := match curve {
+		.prime256v1 { [u8(0x06), 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07] } // 1.2.840.10045.3.1.7
+		.secp384r1 { [u8(0x06), 0x05, 0x2B, 0x81, 0x04, 0x00, 0x22] } // 1.3.132.0.34
+		else { []u8{} }
+	}
+
+	ec_pub_oid := [u8(0x06), 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01] // 1.2.840.10045.2.1
+	mut alg := []u8{}
+	alg << ec_pub_oid
+	alg << curve_oid
+	mut alg_seq := []u8{cap: alg.len + 4}
+	alg_seq << 0x30
+	alg_seq << encode_der_length(alg.len)
+	alg_seq << alg
+	mut point := []u8{cap: 1 + x.len + y.len}
+	point << 0x04 // uncompressed point header (RFC 5480 §2.2)
+	point << x
+	point << y
+	mut bit_string := []u8{cap: point.len + 4}
+	bit_string << 0x03
+	bit_string << encode_der_length(point.len + 1)
+	bit_string << 0x00 // unused-bits indicator
+	bit_string << point
+	mut spki := []u8{cap: alg_seq.len + bit_string.len + 4}
+	spki << 0x30
+	spki << encode_der_length(alg_seq.len + bit_string.len)
+	spki << alg_seq
+	spki << bit_string
+	return spki
+}

--- a/vlib/net/http/signature/signing.v
+++ b/vlib/net/http/signature/signing.v
@@ -82,6 +82,13 @@ fn ed25519_sign(base []u8, seed []u8) ![]u8 {
 }
 
 fn ed25519_verify(base []u8, sig []u8, key Key) !bool {
+	expected_size := if key.is_private { ed25519.seed_size } else { ed25519.public_key_size }
+	if key.bytes.len != expected_size {
+		kind := if key.is_private { 'seed' } else { 'public key' }
+		return MalformedMessage{
+			reason: 'Ed25519 ${kind} must be ${expected_size} bytes, got ${key.bytes.len}'
+		}
+	}
 	pub_key := if key.is_private {
 		ed25519.new_key_from_seed(key.bytes).public_key()
 	} else {

--- a/vlib/net/http/signature/signing.v
+++ b/vlib/net/http/signature/signing.v
@@ -82,6 +82,9 @@ fn ed25519_sign(base []u8, seed []u8) ![]u8 {
 }
 
 fn ed25519_verify(base []u8, sig []u8, key Key) !bool {
+	if sig.len != ed25519.signature_size {
+		return false
+	}
 	expected_size := if key.is_private { ed25519.seed_size } else { ed25519.public_key_size }
 	if key.bytes.len != expected_size {
 		kind := if key.is_private { 'seed' } else { 'public key' }

--- a/vlib/net/http/signature/signing.v
+++ b/vlib/net/http/signature/signing.v
@@ -20,6 +20,7 @@ const ec_p384_size = 48
 // sign_base computes the signature of `base` using `key`.
 // Returns the raw signature bytes (not yet base64-encoded).
 fn sign_base(base []u8, key Key) ![]u8 {
+	validate_hmac_key(key)!
 	if !key.is_private && !key.algorithm.is_mac() {
 		return MalformedMessage{
 			reason: 'sign requires a private key for ${key.algorithm.name()}'
@@ -38,6 +39,7 @@ fn sign_base(base []u8, key Key) ![]u8 {
 // callers can distinguish "signature invalid" from "verification
 // machinery itself failed".
 fn verify_base(base []u8, signature []u8, key Key, label string) ! {
+	validate_hmac_key(key)!
 	ok := match key.algorithm {
 		.hmac_sha256 {
 			expected := hmac.new(key.bytes, base, sha256.sum, sha256.block_size)
@@ -57,6 +59,14 @@ fn verify_base(base []u8, signature []u8, key Key, label string) ! {
 	if !ok {
 		return VerificationFailed{
 			label: label
+		}
+	}
+}
+
+fn validate_hmac_key(key Key) ! {
+	if key.algorithm == .hmac_sha256 && key.bytes.len == 0 {
+		return MalformedMessage{
+			reason: 'HMAC secret cannot be empty'
 		}
 	}
 }

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -1,0 +1,396 @@
+// Minimal Structured Field Values (RFC 8941) helpers, scoped to what
+// the Signature-Input and Signature header fields actually use:
+//
+//   Signature-Input: <label>=(<inner-list>);<params>, <label2>=...
+//   Signature:       <label>=:<base64-bytes>:, <label2>=...
+//
+// We deliberately avoid a full RFC 8941 implementation — every
+// production-quality SF parser is a few hundred lines of dispatch and
+// edge-case handling, and 95% of that surface is unused here. If we
+// later need general SF support, factor this into a sibling module.
+module signature
+
+import encoding.base64
+
+// ParamValue is the typed value of a signature parameter. RFC 9421 §2.3
+// defines the registered parameters as either Integer (`created`,
+// `expires`) or String (`keyid`, `nonce`, `tag`, `alg`). Boolean is
+// included for future-proofing per RFC 8941 §3.1.2.
+pub type ParamValue = i64 | string | bool
+
+// SignatureEntry is one (label, covered-components, parameters) tuple
+// parsed out of a Signature-Input header. The raw
+// `signature_params_value` is preserved verbatim - the verifier
+// re-emits these exact bytes into the signature base, which is what
+// the signer signed. Re-serialising from the parsed params would
+// introduce ordering ambiguity (RFC 8941 doesn't pin a canonical map
+// order) and break verification of signatures produced by other
+// stacks.
+pub struct SignatureEntry {
+pub:
+	label                  string
+	components             []string
+	params                 map[string]ParamValue
+	signature_params_value string
+}
+
+// serialize_params formats the named parameters in RFC 8941 §3.1.2 form,
+// in the order they were inserted into the map. RFC 9421 does not
+// constrain the order of parameters, but our output mirrors `pairs` so
+// callers control the wire layout.
+pub fn serialize_params(pairs []ParamPair) string {
+	mut sb := []string{cap: pairs.len * 2}
+	for pair in pairs {
+		sb << ';'
+		sb << pair.name
+		sb << '='
+		match pair.value {
+			i64 { sb << pair.value.str() }
+			string { sb << '"' + escape_string(pair.value) + '"' }
+			bool { sb << if pair.value { '?1' } else { '?0' } }
+		}
+	}
+	return sb.join('')
+}
+
+// ParamPair is one parameter for `serialize_params`. We use a slice of
+// these instead of a map because parameter order matters on the wire
+// (it doesn't change verification - the verifier reparses - but it
+// makes generated headers deterministic and diff-friendly).
+pub struct ParamPair {
+pub:
+	name  string
+	value ParamValue
+}
+
+// serialize_inner_list returns the canonical Inner List form (parens
+// around space-separated quoted-string items) for the covered
+// components list. Each component name is emitted as a quoted string.
+pub fn serialize_inner_list(items []string) string {
+	mut parts := []string{cap: items.len}
+	for it in items {
+		parts << '"' + escape_string(it) + '"'
+	}
+	return '(' + parts.join(' ') + ')'
+}
+
+// escape_string applies the RFC 8941 §3.3.3 quoted-string escape rules
+// (backslash and double-quote are the only escape-required characters).
+fn escape_string(s string) string {
+	if !s.contains('\\') && !s.contains('"') {
+		return s
+	}
+	mut out := []u8{cap: s.len + 4}
+	for c in s {
+		if c == `\\` || c == `"` {
+			out << `\\`
+		}
+		out << c
+	}
+	return out.bytestr()
+}
+
+// parse_signature_input parses one Signature-Input header value into a
+// list of entries (one per labelled signature). The grammar follows
+// RFC 9421 §4.1 / §4.2 and RFC 8941 §3.2.
+pub fn parse_signature_input(input string) ![]SignatureEntry {
+	mut p := SfParser{
+		src: input
+		pos: 0
+	}
+	mut entries := []SignatureEntry{}
+	for {
+		p.skip_sp()
+		if p.done() {
+			break
+		}
+		label := p.parse_key()!
+		p.expect(`=`) or {
+			return MalformedMessage{
+				reason: 'Signature-Input: expected "=" after label "${label}"'
+			}
+		}
+		value_start := p.pos
+		components := p.parse_inner_list()!
+		params := p.parse_params()!
+		value_end := p.pos
+		entries << SignatureEntry{
+			label:                  label
+			components:             components
+			params:                 params
+			signature_params_value: p.src[value_start..value_end]
+		}
+		p.skip_sp()
+		if p.done() {
+			break
+		}
+		p.expect(`,`) or {
+			return MalformedMessage{
+				reason: 'Signature-Input: expected "," between entries near offset ${p.pos}'
+			}
+		}
+	}
+	return entries
+}
+
+// parse_signature parses a Signature header value into a label →
+// signature-bytes map. Each value in the source is a `:base64:` byte
+// sequence per RFC 8941 §3.3.5.
+pub fn parse_signature(input string) !map[string][]u8 {
+	mut p := SfParser{
+		src: input
+		pos: 0
+	}
+	mut out := map[string][]u8{}
+	for {
+		p.skip_sp()
+		if p.done() {
+			break
+		}
+		label := p.parse_key()!
+		p.expect(`=`) or {
+			return MalformedMessage{
+				reason: 'Signature: expected "=" after label "${label}"'
+			}
+		}
+		bytes := p.parse_byte_sequence()!
+		out[label] = bytes
+		p.skip_sp()
+		if p.done() {
+			break
+		}
+		p.expect(`,`) or {
+			return MalformedMessage{
+				reason: 'Signature: expected "," between entries near offset ${p.pos}'
+			}
+		}
+	}
+	return out
+}
+
+// SfParser is a tiny hand-written cursor over a Structured Field byte
+// string. Dedicated to the small subset of RFC 8941 we use - keeping
+// the state on the struct lets us return precise positions in errors.
+struct SfParser {
+	src string
+mut:
+	pos int
+}
+
+fn (mut p SfParser) done() bool {
+	return p.pos >= p.src.len
+}
+
+fn (mut p SfParser) peek() u8 {
+	return if p.pos < p.src.len { p.src[p.pos] } else { 0 }
+}
+
+fn (mut p SfParser) skip_sp() {
+	for p.pos < p.src.len && (p.src[p.pos] == ` ` || p.src[p.pos] == `\t`) {
+		p.pos++
+	}
+}
+
+fn (mut p SfParser) expect(c u8) ! {
+	if p.pos >= p.src.len || p.src[p.pos] != c {
+		return error('expected "${rune(c)}"')
+	}
+	p.pos++
+}
+
+// parse_key parses a Dictionary key (RFC 8941 §3.2 + §3.1.2). Per
+// RFC 9421 §2.3, signature labels are the same lexical form.
+fn (mut p SfParser) parse_key() !string {
+	if p.done() {
+		return MalformedMessage{
+			reason: 'unexpected end of input expecting key'
+		}
+	}
+	c := p.peek()
+	if !(c == `*` || (c >= `a` && c <= `z`)) {
+		return MalformedMessage{
+			reason: 'invalid key start byte 0x${c.hex()} at offset ${p.pos}'
+		}
+	}
+	start := p.pos
+	for p.pos < p.src.len {
+		ch := p.src[p.pos]
+		if (ch >= `a` && ch <= `z`) || (ch >= `0` && ch <= `9`) || ch == `_`
+			|| ch == `-` || ch == `.` || ch == `*` {
+			p.pos++
+		} else {
+			break
+		}
+	}
+	return p.src[start..p.pos]
+}
+
+fn (mut p SfParser) parse_inner_list() ![]string {
+	p.expect(`(`) or {
+		return MalformedMessage{
+			reason: 'expected "(" starting inner list at offset ${p.pos}'
+		}
+	}
+	mut items := []string{}
+	for {
+		p.skip_sp()
+		if p.done() {
+			return MalformedMessage{
+				reason: 'unterminated inner list'
+			}
+		}
+		if p.peek() == `)` {
+			p.pos++
+			return items
+		}
+		items << p.parse_string()!
+		// A list item may itself carry parameters (`;k=v`); RFC 9421's
+		// covered-components list never sets these, but RFC 8941 allows
+		// them so we silently skip them to stay forward-compatible.
+		for p.pos < p.src.len && p.src[p.pos] == `;` {
+			p.pos++
+			p.parse_key()!
+			if p.pos < p.src.len && p.src[p.pos] == `=` {
+				p.pos++
+				p.parse_bare_item()!
+			}
+		}
+	}
+	return items
+}
+
+// parse_params consumes `;name=value` pairs starting at the current
+// position and returns them as a name-keyed map. Callers that need
+// the original wire-ordered serialisation must work from the raw
+// substring rather than this map (RFC 8941 doesn't pin a canonical
+// re-emission order).
+fn (mut p SfParser) parse_params() !map[string]ParamValue {
+	mut m := map[string]ParamValue{}
+	for p.pos < p.src.len && p.src[p.pos] == `;` {
+		p.pos++
+		p.skip_sp()
+		name := p.parse_key()!
+		mut value := ParamValue(true)
+		if p.pos < p.src.len && p.src[p.pos] == `=` {
+			p.pos++
+			value = p.parse_bare_item()!
+		}
+		m[name] = value
+	}
+	return m
+}
+
+fn (mut p SfParser) parse_bare_item() !ParamValue {
+	if p.done() {
+		return MalformedMessage{
+			reason: 'unexpected end of input'
+		}
+	}
+	c := p.peek()
+	if c == `"` {
+		return ParamValue(p.parse_string()!)
+	}
+	if c == `?` {
+		p.pos++
+		if p.pos >= p.src.len {
+			return MalformedMessage{
+				reason: 'truncated boolean literal'
+			}
+		}
+		b := p.src[p.pos]
+		if b != `0` && b != `1` {
+			return MalformedMessage{
+				reason: 'invalid boolean literal "?${rune(b)}"'
+			}
+		}
+		p.pos++
+		return ParamValue(b == `1`)
+	}
+	if c == `-` || (c >= `0` && c <= `9`) {
+		return ParamValue(p.parse_integer()!)
+	}
+	return MalformedMessage{
+		reason: 'unsupported bare item byte 0x${c.hex()} at offset ${p.pos} (this module models only string/integer/boolean parameter values)'
+	}
+}
+
+fn (mut p SfParser) parse_string() !string {
+	p.expect(`"`) or {
+		return MalformedMessage{
+			reason: 'expected quoted string at offset ${p.pos}'
+		}
+	}
+	mut out := []u8{}
+	for p.pos < p.src.len {
+		c := p.src[p.pos]
+		if c == `"` {
+			p.pos++
+			return out.bytestr()
+		}
+		if c == `\\` {
+			p.pos++
+			if p.pos >= p.src.len {
+				return MalformedMessage{
+					reason: 'truncated escape sequence in string'
+				}
+			}
+			n := p.src[p.pos]
+			if n != `\\` && n != `"` {
+				return MalformedMessage{
+					reason: 'invalid escape "\\${rune(n)}" in string'
+				}
+			}
+			out << n
+			p.pos++
+			continue
+		}
+		out << c
+		p.pos++
+	}
+	return MalformedMessage{
+		reason: 'unterminated string'
+	}
+}
+
+fn (mut p SfParser) parse_integer() !i64 {
+	start := p.pos
+	if p.pos < p.src.len && p.src[p.pos] == `-` {
+		p.pos++
+	}
+	digits_start := p.pos
+	for p.pos < p.src.len && p.src[p.pos] >= `0` && p.src[p.pos] <= `9` {
+		p.pos++
+	}
+	if p.pos == digits_start {
+		return MalformedMessage{
+			reason: 'integer literal with no digits at offset ${start}'
+		}
+	}
+	return p.src[start..p.pos].i64()
+}
+
+fn (mut p SfParser) parse_byte_sequence() ![]u8 {
+	p.expect(`:`) or {
+		return MalformedMessage{
+			reason: 'expected ":" starting byte sequence at offset ${p.pos}'
+		}
+	}
+	start := p.pos
+	for p.pos < p.src.len && p.src[p.pos] != `:` {
+		p.pos++
+	}
+	if p.pos >= p.src.len {
+		return MalformedMessage{
+			reason: 'unterminated byte sequence'
+		}
+	}
+	encoded := p.src[start..p.pos]
+	p.pos++ // closing ':'
+	return base64.decode(encoded)
+}
+
+// encode_byte_sequence produces the wire form `:base64:` used inside
+// the Signature header.
+pub fn encode_byte_sequence(bytes []u8) string {
+	return ':' + base64.encode(bytes) + ':'
+}

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -38,10 +38,11 @@ pub:
 // in the order they were inserted into the map. RFC 9421 does not
 // constrain the order of parameters, but our output mirrors `pairs` so
 // callers control the wire layout. It returns `MalformedMessage` when a
-// string value contains bytes outside the RFC 8941 visible ASCII range.
+// parameter name or string value violates the RFC 8941 grammar.
 pub fn serialize_params(pairs []ParamPair) !string {
 	mut sb := []string{cap: pairs.len * 2}
 	for pair in pairs {
+		check_sf_key(pair.name, 'parameter name')!
 		sb << ';'
 		sb << pair.name
 		sb << '='

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -331,7 +331,13 @@ fn (mut p SfParser) parse_inner_list() ![]string {
 			p.pos++
 			return items
 		}
-		items << p.parse_string()!
+		item := p.parse_string()!
+		if !item.starts_with('@') && item != item.to_lower() {
+			return MalformedMessage{
+				reason: 'HTTP field component identifier "${item}" must be lowercase'
+			}
+		}
+		items << item
 		if p.pos < p.src.len && p.src[p.pos] == `;` {
 			return MalformedMessage{
 				reason: 'covered-component parameters are not supported at offset ${p.pos}'

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -14,11 +14,18 @@ import encoding.base64
 
 const sf_integer_max = i64(999_999_999_999_999)
 
+// ExtensionParamValue preserves a valid RFC 8941 bare item whose type is not
+// used by a registered RFC 9421 signature parameter.
+pub struct ExtensionParamValue {
+pub:
+	raw string
+}
+
 // ParamValue is the typed value of a signature parameter. RFC 9421 §2.3
 // defines the registered parameters as either Integer (`created`,
-// `expires`) or String (`keyid`, `nonce`, `tag`, `alg`). Boolean is
-// included for future-proofing per RFC 8941 §3.1.2.
-pub type ParamValue = i64 | string | bool
+// `expires`) or String (`keyid`, `nonce`, `tag`, `alg`). Boolean and valid
+// extension bare items are retained for application-defined parameters.
+pub type ParamValue = ExtensionParamValue | bool | i64 | string
 
 // SignatureEntry is one (label, covered-components, parameters) tuple
 // parsed out of a Signature-Input header. The raw
@@ -58,6 +65,10 @@ pub fn serialize_params(pairs []ParamPair) !string {
 			}
 			bool {
 				sb << if pair.value { '?1' } else { '?0' }
+			}
+			ExtensionParamValue {
+				validate_extension_param_value(pair.value.raw)!
+				sb << pair.value.raw
 			}
 		}
 	}
@@ -113,6 +124,18 @@ fn validate_sf_integer(value i64) ! {
 	if value < -sf_integer_max || value > sf_integer_max {
 		return MalformedMessage{
 			reason: 'Structured Field integer ${value} exceeds the 15-digit range'
+		}
+	}
+}
+
+fn validate_extension_param_value(raw string) ! {
+	mut p := SfParser{
+		src: raw
+	}
+	p.parse_bare_item()!
+	if !p.done() {
+		return MalformedMessage{
+			reason: 'extension parameter is not a single Structured Field bare item'
 		}
 	}
 }
@@ -369,12 +392,39 @@ fn (mut p SfParser) parse_bare_item() !ParamValue {
 		p.pos++
 		return ParamValue(b == `1`)
 	}
+	if c == `:` {
+		start := p.pos
+		p.parse_byte_sequence()!
+		return ParamValue(ExtensionParamValue{
+			raw: p.src[start..p.pos]
+		})
+	}
 	if c == `-` || (c >= `0` && c <= `9`) {
-		return ParamValue(p.parse_integer()!)
+		return p.parse_number()!
+	}
+	if (c >= `A` && c <= `Z`) || (c >= `a` && c <= `z`) || c == `*` {
+		return ParamValue(ExtensionParamValue{
+			raw: p.parse_token()!
+		})
 	}
 	return MalformedMessage{
-		reason: 'unsupported bare item byte 0x${c.hex()} at offset ${p.pos} (this module models only string/integer/boolean parameter values)'
+		reason: 'invalid bare item byte 0x${c.hex()} at offset ${p.pos}'
 	}
+}
+
+fn (mut p SfParser) parse_token() !string {
+	start := p.pos
+	for p.pos < p.src.len {
+		c := p.src[p.pos]
+		if (c >= `A` && c <= `Z`) || (c >= `a` && c <= `z`) || (c >= `0` && c <= `9`)
+			|| c == 0x60
+			|| c in [`!`, `#`, `$`, `%`, `&`, `'`, `*`, `+`, `-`, `.`, `^`, `_`, `|`, `~`, `:`, `/`] {
+			p.pos++
+		} else {
+			break
+		}
+	}
+	return p.src[start..p.pos]
 }
 
 fn (mut p SfParser) parse_string() !string {
@@ -420,7 +470,7 @@ fn (mut p SfParser) parse_string() !string {
 	}
 }
 
-fn (mut p SfParser) parse_integer() !i64 {
+fn (mut p SfParser) parse_number() !ParamValue {
 	start := p.pos
 	if p.pos < p.src.len && p.src[p.pos] == `-` {
 		p.pos++
@@ -434,6 +484,26 @@ fn (mut p SfParser) parse_integer() !i64 {
 			reason: 'integer literal with no digits at offset ${start}'
 		}
 	}
+	if p.pos < p.src.len && p.src[p.pos] == `.` {
+		if p.pos - digits_start > 12 {
+			return MalformedMessage{
+				reason: 'Structured Field decimal exceeds the 12-digit integer range at offset ${start}'
+			}
+		}
+		p.pos++
+		fraction_start := p.pos
+		for p.pos < p.src.len && p.src[p.pos] >= `0` && p.src[p.pos] <= `9` {
+			p.pos++
+		}
+		if p.pos == fraction_start || p.pos - fraction_start > 3 {
+			return MalformedMessage{
+				reason: 'Structured Field decimal must have one to three fractional digits at offset ${start}'
+			}
+		}
+		return ParamValue(ExtensionParamValue{
+			raw: p.src[start..p.pos]
+		})
+	}
 	if p.pos - digits_start > 15 {
 		return MalformedMessage{
 			reason: 'Structured Field integer exceeds the 15-digit range at offset ${start}'
@@ -441,7 +511,7 @@ fn (mut p SfParser) parse_integer() !i64 {
 	}
 	value := p.src[start..p.pos].i64()
 	validate_sf_integer(value)!
-	return value
+	return ParamValue(value)
 }
 
 fn (mut p SfParser) parse_byte_sequence() ![]u8 {

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -88,13 +88,45 @@ pub:
 // serialize_inner_list returns the canonical Inner List form (parens
 // around space-separated quoted-string items) for the covered
 // components list. Each component name is emitted as a quoted string;
-// invalid Structured Field string bytes return `MalformedMessage`.
+// invalid HTTP field names or Structured Field string bytes return
+// `MalformedMessage`.
 pub fn serialize_inner_list(items []string) !string {
 	mut parts := []string{cap: items.len}
 	for it in items {
+		check_component_identifier(it)!
 		parts << '"' + escape_string(it)! + '"'
 	}
 	return '(' + parts.join(' ') + ')'
+}
+
+fn check_component_identifier(name string) ! {
+	if name.starts_with('@') {
+		return
+	}
+	if name == '' {
+		return MalformedMessage{
+			reason: 'HTTP field component identifier must not be empty'
+		}
+	}
+	if name != name.to_lower() {
+		return MalformedMessage{
+			reason: 'HTTP field component identifier "${name}" must be lowercase'
+		}
+	}
+	for c in name {
+		if int(c) >= 128 || !is_http_token(c) {
+			return MalformedMessage{
+				reason: 'HTTP field component identifier "${name}" is not a valid field name'
+			}
+		}
+	}
+}
+
+fn is_http_token(c u8) bool {
+	return match c {
+		33, 35...39, 42, 43, 45, 46, 48...57, 65...90, 94...122, 124, 126 { true }
+		else { false }
+	}
 }
 
 // escape_string applies the RFC 8941 §3.3.3 quoted-string escape rules
@@ -332,11 +364,7 @@ fn (mut p SfParser) parse_inner_list() ![]string {
 			return items
 		}
 		item := p.parse_string()!
-		if !item.starts_with('@') && item != item.to_lower() {
-			return MalformedMessage{
-				reason: 'HTTP field component identifier "${item}" must be lowercase'
-			}
-		}
+		check_component_identifier(item)!
 		items << item
 		if p.pos < p.src.len && p.src[p.pos] == `;` {
 			return MalformedMessage{

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -253,6 +253,16 @@ fn (mut p SfParser) parse_inner_list() ![]string {
 	}
 	mut items := []string{}
 	for {
+		if p.done() {
+			return MalformedMessage{
+				reason: 'unterminated inner list'
+			}
+		}
+		if items.len > 0 && p.peek() != `)` && p.peek() != ` ` {
+			return MalformedMessage{
+				reason: 'inner-list items must be separated by a space at offset ${p.pos}'
+			}
+		}
 		p.skip_sp()
 		if p.done() {
 			return MalformedMessage{

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -12,6 +12,8 @@ module signature
 
 import encoding.base64
 
+const sf_integer_max = i64(999_999_999_999_999)
+
 // ParamValue is the typed value of a signature parameter. RFC 9421 §2.3
 // defines the registered parameters as either Integer (`created`,
 // `expires`) or String (`keyid`, `nonce`, `tag`, `alg`). Boolean is
@@ -47,9 +49,16 @@ pub fn serialize_params(pairs []ParamPair) !string {
 		sb << pair.name
 		sb << '='
 		match pair.value {
-			i64 { sb << pair.value.str() }
-			string { sb << '"' + escape_string(pair.value)! + '"' }
-			bool { sb << if pair.value { '?1' } else { '?0' } }
+			i64 {
+				validate_sf_integer(pair.value)!
+				sb << pair.value.str()
+			}
+			string {
+				sb << '"' + escape_string(pair.value)! + '"'
+			}
+			bool {
+				sb << if pair.value { '?1' } else { '?0' }
+			}
 		}
 	}
 	return sb.join('')
@@ -98,6 +107,14 @@ fn escape_string(s string) !string {
 		out << c
 	}
 	return out.bytestr()
+}
+
+fn validate_sf_integer(value i64) ! {
+	if value < -sf_integer_max || value > sf_integer_max {
+		return MalformedMessage{
+			reason: 'Structured Field integer ${value} exceeds the 15-digit range'
+		}
+	}
 }
 
 // parse_signature_input parses one Signature-Input header value into a
@@ -364,6 +381,11 @@ fn (mut p SfParser) parse_string() !string {
 	mut out := []u8{}
 	for p.pos < p.src.len {
 		c := p.src[p.pos]
+		if c < 0x20 || c > 0x7e {
+			return MalformedMessage{
+				reason: 'Structured Field string contains invalid byte ${c} at offset ${p.pos}'
+			}
+		}
 		if c == `"` {
 			p.pos++
 			return out.bytestr()
@@ -407,7 +429,14 @@ fn (mut p SfParser) parse_integer() !i64 {
 			reason: 'integer literal with no digits at offset ${start}'
 		}
 	}
-	return p.src[start..p.pos].i64()
+	if p.pos - digits_start > 15 {
+		return MalformedMessage{
+			reason: 'Structured Field integer exceeds the 15-digit range at offset ${start}'
+		}
+	}
+	value := p.src[start..p.pos].i64()
+	validate_sf_integer(value)!
+	return value
 }
 
 fn (mut p SfParser) parse_byte_sequence() ![]u8 {

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -240,6 +240,12 @@ fn (mut p SfParser) skip_sp() {
 	}
 }
 
+fn (mut p SfParser) skip_inner_list_sp() {
+	for p.pos < p.src.len && p.src[p.pos] == ` ` {
+		p.pos++
+	}
+}
+
 fn (mut p SfParser) expect(c u8) ! {
 	if p.pos >= p.src.len || p.src[p.pos] != c {
 		return error('expected "${rune(c)}"')
@@ -292,7 +298,7 @@ fn (mut p SfParser) parse_inner_list() ![]string {
 				reason: 'inner-list items must be separated by a space at offset ${p.pos}'
 			}
 		}
-		p.skip_sp()
+		p.skip_inner_list_sp()
 		if p.done() {
 			return MalformedMessage{
 				reason: 'unterminated inner list'

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -144,6 +144,12 @@ pub fn parse_signature_input(input string) ![]SignatureEntry {
 				reason: 'Signature-Input: expected "," between entries near offset ${p.pos}'
 			}
 		}
+		p.skip_sp()
+		if p.done() {
+			return MalformedMessage{
+				reason: 'Signature-Input: expected an entry after ","'
+			}
+		}
 	}
 	return entries
 }
@@ -182,6 +188,12 @@ pub fn parse_signature(input string) !map[string][]u8 {
 		p.expect(`,`) or {
 			return MalformedMessage{
 				reason: 'Signature: expected "," between entries near offset ${p.pos}'
+			}
+		}
+		p.skip_sp()
+		if p.done() {
+			return MalformedMessage{
+				reason: 'Signature: expected an entry after ","'
 			}
 		}
 	}
@@ -416,7 +428,32 @@ fn (mut p SfParser) parse_byte_sequence() ![]u8 {
 	}
 	encoded := p.src[start..p.pos]
 	p.pos++ // closing ':'
-	return base64.decode(encoded)
+	if encoded.len % 4 != 0 {
+		return MalformedMessage{
+			reason: 'byte sequence is not canonically padded base64'
+		}
+	}
+	for i, c in encoded {
+		is_base64 := (c >= `A` && c <= `Z`) || (c >= `a` && c <= `z`)
+			|| (c >= `0` && c <= `9`) || c == `+` || c == `/`
+		if !is_base64 && c != `=` {
+			return MalformedMessage{
+				reason: 'invalid base64 character at offset ${start + i}'
+			}
+		}
+		if c == `=` && (i < encoded.len - 2 || (i == encoded.len - 2 && encoded[i + 1] != `=`)) {
+			return MalformedMessage{
+				reason: 'invalid base64 padding in byte sequence'
+			}
+		}
+	}
+	decoded := base64.decode(encoded)
+	if base64.encode(decoded) != encoded {
+		return MalformedMessage{
+			reason: 'byte sequence is not canonical base64'
+		}
+	}
+	return decoded
 }
 
 // encode_byte_sequence produces the wire form `:base64:` used inside

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -286,15 +286,9 @@ fn (mut p SfParser) parse_inner_list() ![]string {
 			return items
 		}
 		items << p.parse_string()!
-		// A list item may itself carry parameters (`;k=v`); RFC 9421's
-		// covered-components list never sets these, but RFC 8941 allows
-		// them so we silently skip them to stay forward-compatible.
-		for p.pos < p.src.len && p.src[p.pos] == `;` {
-			p.pos++
-			p.parse_key()!
-			if p.pos < p.src.len && p.src[p.pos] == `=` {
-				p.pos++
-				p.parse_bare_item()!
+		if p.pos < p.src.len && p.src[p.pos] == `;` {
+			return MalformedMessage{
+				reason: 'covered-component parameters are not supported at offset ${p.pos}'
 			}
 		}
 	}

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -327,7 +327,6 @@ fn (mut p SfParser) parse_params() !map[string]ParamValue {
 	mut m := map[string]ParamValue{}
 	for p.pos < p.src.len && p.src[p.pos] == `;` {
 		p.pos++
-		p.skip_sp()
 		name := p.parse_key()!
 		if name in m {
 			return MalformedMessage{

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -37,8 +37,9 @@ pub:
 // serialize_params formats the named parameters in RFC 8941 §3.1.2 form,
 // in the order they were inserted into the map. RFC 9421 does not
 // constrain the order of parameters, but our output mirrors `pairs` so
-// callers control the wire layout.
-pub fn serialize_params(pairs []ParamPair) string {
+// callers control the wire layout. It returns `MalformedMessage` when a
+// string value contains bytes outside the RFC 8941 visible ASCII range.
+pub fn serialize_params(pairs []ParamPair) !string {
 	mut sb := []string{cap: pairs.len * 2}
 	for pair in pairs {
 		sb << ';'
@@ -46,7 +47,7 @@ pub fn serialize_params(pairs []ParamPair) string {
 		sb << '='
 		match pair.value {
 			i64 { sb << pair.value.str() }
-			string { sb << '"' + escape_string(pair.value) + '"' }
+			string { sb << '"' + escape_string(pair.value)! + '"' }
 			bool { sb << if pair.value { '?1' } else { '?0' } }
 		}
 	}
@@ -65,18 +66,26 @@ pub:
 
 // serialize_inner_list returns the canonical Inner List form (parens
 // around space-separated quoted-string items) for the covered
-// components list. Each component name is emitted as a quoted string.
-pub fn serialize_inner_list(items []string) string {
+// components list. Each component name is emitted as a quoted string;
+// invalid Structured Field string bytes return `MalformedMessage`.
+pub fn serialize_inner_list(items []string) !string {
 	mut parts := []string{cap: items.len}
 	for it in items {
-		parts << '"' + escape_string(it) + '"'
+		parts << '"' + escape_string(it)! + '"'
 	}
 	return '(' + parts.join(' ') + ')'
 }
 
 // escape_string applies the RFC 8941 §3.3.3 quoted-string escape rules
 // (backslash and double-quote are the only escape-required characters).
-fn escape_string(s string) string {
+fn escape_string(s string) !string {
+	for c in s {
+		if c < 0x20 || c > 0x7e {
+			return MalformedMessage{
+				reason: 'Structured Field string contains invalid byte ${c}'
+			}
+		}
+	}
 	if !s.contains('\\') && !s.contains('"') {
 		return s
 	}

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -306,6 +306,11 @@ fn (mut p SfParser) parse_params() !map[string]ParamValue {
 		p.pos++
 		p.skip_sp()
 		name := p.parse_key()!
+		if name in m {
+			return MalformedMessage{
+				reason: 'duplicate signature parameter "${name}"'
+			}
+		}
 		mut value := ParamValue(true)
 		if p.pos < p.src.len && p.src[p.pos] == `=` {
 			p.pos++

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -115,6 +115,11 @@ pub fn parse_signature_input(input string) ![]SignatureEntry {
 			break
 		}
 		label := p.parse_key()!
+		if entries.any(it.label == label) {
+			return MalformedMessage{
+				reason: 'Signature-Input contains duplicate label "${label}"'
+			}
+		}
 		p.expect(`=`) or {
 			return MalformedMessage{
 				reason: 'Signature-Input: expected "=" after label "${label}"'
@@ -158,6 +163,11 @@ pub fn parse_signature(input string) !map[string][]u8 {
 			break
 		}
 		label := p.parse_key()!
+		if label in out {
+			return MalformedMessage{
+				reason: 'Signature contains duplicate label "${label}"'
+			}
+		}
 		p.expect(`=`) or {
 			return MalformedMessage{
 				reason: 'Signature: expected "=" after label "${label}"'

--- a/vlib/net/http/signature/structured_field.v
+++ b/vlib/net/http/signature/structured_field.v
@@ -290,7 +290,7 @@ fn (mut p SfParser) peek() u8 {
 }
 
 fn (mut p SfParser) skip_sp() {
-	for p.pos < p.src.len && (p.src[p.pos] == ` ` || p.src[p.pos] == `\t`) {
+	for p.pos < p.src.len && p.src[p.pos] == ` ` {
 		p.pos++
 	}
 }

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -1,0 +1,219 @@
+// Tests for the small RFC 8941 subset implemented in
+// `structured_field.v`. We don't test general SF parsing - only what
+// HTTP signatures actually use - and pin the output bytes that
+// matter for interop.
+module signature
+
+fn test_serialize_inner_list_quotes_each_item() {
+	got := serialize_inner_list(['@method', 'date', '@path'])
+	assert got == '("@method" "date" "@path")'
+}
+
+fn test_serialize_inner_list_handles_empty() {
+	assert serialize_inner_list([]string{}) == '()'
+}
+
+fn test_serialize_params_keeps_input_order() {
+	pairs := [
+		ParamPair{
+			name:  'created'
+			value: i64(1)
+		},
+		ParamPair{
+			name:  'keyid'
+			value: 'k1'
+		},
+	]
+	got := serialize_params(pairs)
+	assert got == ';created=1;keyid="k1"'
+}
+
+fn test_serialize_params_escapes_quotes_in_strings() {
+	pairs := [
+		ParamPair{
+			name:  'tag'
+			value: 'has"quote'
+		},
+	]
+	assert serialize_params(pairs) == ';tag="has\\"quote"'
+}
+
+fn test_serialize_params_emits_boolean_short_form() {
+	pairs := [
+		ParamPair{
+			name:  'flag'
+			value: true
+		},
+		ParamPair{
+			name:  'other'
+			value: false
+		},
+	]
+	assert serialize_params(pairs) == ';flag=?1;other=?0'
+}
+
+fn test_parse_signature_input_single_entry() {
+	src := 'sig1=("@method" "host");created=1618884473;keyid="my-key"'
+	entries := parse_signature_input(src)!
+	assert entries.len == 1
+	e := entries[0]
+	assert e.label == 'sig1'
+	assert e.components == ['@method', 'host']
+	assert e.params['created'] or { ParamValue(i64(0)) } == ParamValue(i64(1618884473))
+	assert e.params['keyid'] or { ParamValue('') } == ParamValue('my-key')
+}
+
+fn test_parse_signature_input_multiple_entries() {
+	src := 'sig-a=("@method");created=1, sig-b=("date" "@authority");keyid="k"'
+	entries := parse_signature_input(src)!
+	assert entries.len == 2
+	assert entries[0].label == 'sig-a'
+	assert entries[0].components == ['@method']
+	assert entries[1].label == 'sig-b'
+	assert entries[1].components == ['date', '@authority']
+}
+
+fn test_parse_signature_returns_decoded_bytes() {
+	src := 'sig1=:cGF5bG9hZA==:'
+	parsed := parse_signature(src)!
+	assert parsed.len == 1
+	bytes := parsed['sig1'] or { []u8{} }
+	assert bytes.bytestr() == 'payload'
+}
+
+fn test_parse_signature_input_rejects_uppercase_label() {
+	if _ := parse_signature_input('Sig1=()') {
+		assert false, 'uppercase label must be rejected by SF parser'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
+fn test_parse_signature_input_preserves_signature_params_value() {
+	src := 'sig1=("@method");created=1618884473;keyid="my-key"'
+	entries := parse_signature_input(src)!
+	// The verifier replays this verbatim into the signature base so
+	// it MUST equal the input substring (including the inner list).
+	assert entries[0].signature_params_value == '("@method");created=1618884473;keyid="my-key"'
+}
+
+fn test_verify_accepts_non_canonical_param_order() {
+	// External signers might emit `;keyid=...;created=...` (keyid
+	// before created). Our re-canonicalised order is the opposite, so
+	// without the verbatim replay the bases would differ. Use HMAC so
+	// we can synthesise a wire signature ourselves.
+	c := Components{
+		method: 'POST'
+	}
+	key := Key.hmac_sha256('shared-secret'.bytes())
+	// Hand-build the base with keyid first, sign it, then verify
+	// using the same wire order.
+	base := '"@method": POST\n"@signature-params": ("@method");keyid="k1";created=42'
+	sig := sign_base(base.bytes(), key)!
+	sig_input := 'sig1=("@method");keyid="k1";created=42'
+	sig_header := signature_header_value('sig1', sig)
+	verify(c, sig_input, sig_header, 'sig1', key)!
+}
+
+fn test_signature_base_string_rejects_duplicate_components() {
+	c := Components{
+		method: 'GET'
+		fields: {
+			'host': ['example.com']
+		}
+	}
+	p := SignatureParams{
+		components: ['@method', '@method']
+	}
+	if _ := signature_base_string(c, p) {
+		assert false, 'duplicate components must error'
+	} else {
+		assert err is MalformedMessage
+		assert err.msg().contains('duplicate')
+	}
+}
+
+fn test_signature_base_string_errors_on_missing_field() {
+	c := Components{
+		method: 'GET'
+	}
+	p := SignatureParams{
+		components: ['@method', 'date']
+	}
+	if _ := signature_base_string(c, p) {
+		assert false, 'missing component must error'
+	} else {
+		assert err is MalformedMessage
+		assert err.msg().contains('"date"')
+	}
+}
+
+fn test_components_lowercases_field_names_and_adds_in_order() {
+	mut c := Components{}
+	c.add_field('Accept', 'text/html')
+	c.add_field('accept', 'application/json')
+	values := c.fields['accept']
+	assert values.len == 2
+	assert values[0] == 'text/html'
+	assert values[1] == 'application/json'
+}
+
+fn test_field_value_joins_multi_value_with_comma_space() {
+	c := Components{
+		fields: {
+			'accept': ['text/html', 'application/json']
+		}
+	}
+	p := SignatureParams{
+		components: ['accept']
+	}
+	got := signature_base_string(c, p)!
+	assert got.starts_with('"accept": text/html, application/json\n')
+}
+
+fn test_field_value_trims_ows() {
+	c := Components{
+		fields: {
+			'foo': ['  hello   ', '\tworld\t']
+		}
+	}
+	p := SignatureParams{
+		components: ['foo']
+	}
+	got := signature_base_string(c, p)!
+	assert got.starts_with('"foo": hello, world\n')
+}
+
+fn test_query_with_leading_question_mark_is_preserved() {
+	c := Components{
+		query: '?a=1'
+	}
+	p := SignatureParams{
+		components: ['@query']
+	}
+	got := signature_base_string(c, p)!
+	assert got.starts_with('"@query": ?a=1\n')
+}
+
+fn test_empty_query_emits_single_question_mark() {
+	c := Components{
+		query: ''
+	}
+	p := SignatureParams{
+		components: ['@query']
+	}
+	got := signature_base_string(c, p)!
+	// RFC 9421 §2.2.7: empty query is the single character "?".
+	assert got.starts_with('"@query": ?\n')
+}
+
+fn test_authority_is_lowercased() {
+	c := Components{
+		authority: 'EXAMPLE.com'
+	}
+	p := SignatureParams{
+		components: ['@authority']
+	}
+	got := signature_base_string(c, p)!
+	assert got.starts_with('"@authority": example.com\n')
+}

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -1,3 +1,4 @@
+// vtest build: present_openssl? && !(openbsd && gcc) && !(sanitize-memory-clang || docker-ubuntu-musl)
 // Tests for the small RFC 8941 subset implemented in
 // `structured_field.v`. We don't test general SF parsing - only what
 // HTTP signatures actually use - and pin the output bytes that

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -126,8 +126,24 @@ fn test_verify_accepts_non_canonical_param_order() {
 	base := '"@method": POST\n"@signature-params": ("@method");keyid="k1";created=42'
 	sig := sign_base(base.bytes(), key)!
 	sig_input := 'sig1=("@method");keyid="k1";created=42'
-	sig_header := signature_header_value('sig1', sig)
+	sig_header := signature_header_value('sig1', sig)!
 	verify(c, sig_input, sig_header, 'sig1', key)!
+}
+
+fn test_public_header_serializers_reject_invalid_labels() {
+	p := SignatureParams{
+		components: ['@method']
+	}
+	if _ := signature_input_value('safe\r\nInjected', p) {
+		assert false, 'Signature-Input labels must use the Structured Field key grammar'
+	} else {
+		assert err is MalformedMessage
+	}
+	if _ := signature_header_value('safe\r\nInjected', 'signature'.bytes()) {
+		assert false, 'Signature labels must use the Structured Field key grammar'
+	} else {
+		assert err is MalformedMessage
+	}
 }
 
 fn test_signature_base_string_rejects_duplicate_components() {

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -108,6 +108,14 @@ fn test_parse_signature_input_rejects_unsupported_component_parameters() {
 	}
 }
 
+fn test_parse_signature_input_rejects_duplicate_signature_parameters() {
+	if _ := parse_signature_input('sig1=("@method");expires=1;expires=9999999999') {
+		assert false, 'duplicate signature parameters must be rejected'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_parse_signature_input_multiple_entries() {
 	src := 'sig-a=("@method");created=1, sig-b=("date" "@authority");keyid="k"'
 	entries := parse_signature_input(src)!

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -296,6 +296,26 @@ fn test_parse_signature_input_rejects_uppercase_http_field_component() {
 	}
 }
 
+fn test_parse_signature_input_rejects_invalid_http_field_components() {
+	for component in ['', 'x y', 'x:y'] {
+		if _ := parse_signature_input('sig1=("${component}")') {
+			assert false, 'invalid HTTP field component identifier "${component}" must be rejected'
+		} else {
+			assert err is MalformedMessage
+		}
+	}
+}
+
+fn test_serialize_inner_list_rejects_invalid_http_field_components() {
+	for component in ['', 'x y', 'x:y'] {
+		if _ := serialize_inner_list([component]) {
+			assert false, 'invalid HTTP field component identifier "${component}" must not be serialized'
+		} else {
+			assert err is MalformedMessage
+		}
+	}
+}
+
 fn test_parse_signature_input_preserves_signature_params_value() {
 	src := 'sig1=("@method");created=1618884473;keyid="my-key"'
 	entries := parse_signature_input(src)!

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -140,6 +140,16 @@ fn test_parse_signature_input_rejects_duplicate_signature_parameters() {
 	}
 }
 
+fn test_parse_signature_input_rejects_whitespace_after_parameter_delimiter() {
+	for value in ['sig1=("@method"); created=1', 'sig1=("@method");\tcreated=1'] {
+		if _ := parse_signature_input(value) {
+			assert false, 'a parameter key must immediately follow its semicolon'
+		} else {
+			assert err is MalformedMessage
+		}
+	}
+}
+
 fn test_parse_signature_input_rejects_out_of_range_integers() {
 	for value in ['1000000000000000', '-1000000000000000'] {
 		if _ := parse_signature_input('sig1=("@method");created=${value}') {

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -147,7 +147,7 @@ fn test_verify_accepts_non_canonical_param_order() {
 	c := Components{
 		method: 'POST'
 	}
-	key := Key.hmac_sha256('shared-secret'.bytes())
+	key := Key.hmac_sha256('shared-secret'.bytes())!
 	// Hand-build the base with keyid first, sign it, then verify
 	// using the same wire order.
 	base := '"@method": POST\n"@signature-params": ("@method");keyid="k1";created=42'
@@ -196,6 +196,30 @@ fn test_signature_base_string_rejects_duplicate_components() {
 	} else {
 		assert err is MalformedMessage
 		assert err.msg().contains('duplicate')
+	}
+}
+
+fn test_signature_base_string_normalizes_field_component_names() {
+	c := Components{
+		fields: {
+			'content-type': ['application/json']
+		}
+	}
+	p := SignatureParams{
+		components: ['Content-Type']
+	}
+	base := signature_base_string(c, p)!
+	assert base.starts_with('"content-type": application/json\n')
+	assert base.ends_with('"@signature-params": ("content-type")')
+	assert serialize_signature_params(p)! == '("content-type")'
+
+	duplicate := SignatureParams{
+		components: ['Content-Type', 'content-type']
+	}
+	if _ := signature_base_string(c, duplicate) {
+		assert false, 'component names that collide after normalization must be rejected'
+	} else {
+		assert err is MalformedMessage
 	}
 }
 

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -53,6 +53,22 @@ fn test_serialize_params_emits_boolean_short_form() {
 	assert serialize_params(pairs)! == ';flag=?1;other=?0'
 }
 
+fn test_serialize_params_rejects_out_of_range_integers() {
+	for value in [i64(1_000_000_000_000_000), i64(-1_000_000_000_000_000)] {
+		if _ := serialize_params([
+			ParamPair{
+				name:  'created'
+				value: value
+			},
+		])
+		{
+			assert false, 'Structured Field integers are limited to 15 digits'
+		} else {
+			assert err is MalformedMessage
+		}
+	}
+}
+
 fn test_serialize_params_rejects_control_bytes() {
 	pairs := [
 		ParamPair{
@@ -111,6 +127,48 @@ fn test_parse_signature_input_rejects_unsupported_component_parameters() {
 fn test_parse_signature_input_rejects_duplicate_signature_parameters() {
 	if _ := parse_signature_input('sig1=("@method");expires=1;expires=9999999999') {
 		assert false, 'duplicate signature parameters must be rejected'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
+fn test_parse_signature_input_rejects_out_of_range_integers() {
+	for value in ['1000000000000000', '-1000000000000000'] {
+		if _ := parse_signature_input('sig1=("@method");created=${value}') {
+			assert false, 'parsed Structured Field integers are limited to 15 digits'
+		} else {
+			assert err is MalformedMessage
+		}
+	}
+}
+
+fn test_parse_signature_input_rejects_invalid_string_bytes() {
+	for value in ['bad\rvalue', 'bad\x7fvalue', 'café'] {
+		if _ := parse_signature_input('sig1=("@method");keyid="${value}"') {
+			assert false, 'Structured Field strings must contain only SP and visible ASCII bytes'
+		} else {
+			assert err is MalformedMessage
+		}
+	}
+}
+
+fn test_sign_and_verify_reject_invalid_signature_time_order() {
+	c := Components{
+		method: 'GET'
+	}
+	key := Key.hmac_sha256('shared-secret'.bytes())!
+	p := SignatureParams{
+		components: ['@method']
+		created:    2
+		expires:    2
+	}
+	if _ := sign(c, p, key, 'sig1') {
+		assert false, 'expires must be later than created when signing'
+	} else {
+		assert err is MalformedMessage
+	}
+	if _ := verify(c, 'sig1=("@method");created=2;expires=1', 'sig1=:AA==:', 'sig1', key) {
+		assert false, 'expires must be later than created when verifying'
 	} else {
 		assert err is MalformedMessage
 	}

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -116,6 +116,14 @@ fn test_parse_signature_input_requires_inner_list_whitespace() {
 	}
 }
 
+fn test_parse_signature_input_rejects_inner_list_tab_padding() {
+	if _ := parse_signature_input('sig1=(\t"@method")') {
+		assert false, 'inner-list padding must use SP, not HTAB'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_parse_signature_input_rejects_unsupported_component_parameters() {
 	if _ := parse_signature_input('sig1=("example-dict";key="a")') {
 		assert false, 'unsupported covered-component parameters must not be discarded'

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -67,6 +67,20 @@ fn test_serialize_params_rejects_control_bytes() {
 	}
 }
 
+fn test_serialize_params_rejects_invalid_names() {
+	pairs := [
+		ParamPair{
+			name:  'safe\r\nInjected'
+			value: true
+		},
+	]
+	if _ := serialize_params(pairs) {
+		assert false, 'parameter names must use the Structured Field key grammar'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_parse_signature_input_single_entry() {
 	src := 'sig1=("@method" "host");created=1618884473;keyid="my-key"'
 	entries := parse_signature_input(src)!
@@ -144,6 +158,14 @@ fn test_public_header_serializers_reject_invalid_labels() {
 	} else {
 		assert err is MalformedMessage
 	}
+}
+
+fn test_public_header_serializers_accept_dotted_labels() {
+	p := SignatureParams{
+		components: ['@method']
+	}
+	assert signature_input_value('sig.v1', p)! == 'sig.v1=("@method")'
+	assert signature_header_value('sig.v1', 'signature'.bytes())!.starts_with('sig.v1=:')
 }
 
 fn test_signature_base_string_rejects_duplicate_components() {

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -181,6 +181,21 @@ fn test_public_header_serializers_accept_dotted_labels() {
 	assert signature_header_value('sig.v1', 'signature'.bytes())!.starts_with('sig.v1=:')
 }
 
+fn test_verify_rejects_non_integer_expires() {
+	c := Components{
+		method: 'GET'
+	}
+	key := Key.hmac_sha256('shared-secret'.bytes())!
+	if _ := verify(c, 'sig1=("@method");expires="1"', 'sig1=:AA==:', 'sig1', key,
+		now_unix: 2
+	)
+	{
+		assert false, 'expires must be an Integer'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_signature_base_string_rejects_duplicate_components() {
 	c := Components{
 		method: 'GET'

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -102,6 +102,19 @@ fn test_parse_signature_input_multiple_entries() {
 	assert entries[1].components == ['date', '@authority']
 }
 
+fn test_parsers_reject_duplicate_labels() {
+	if _ := parse_signature_input('sig1=("@method"), sig1=("@path")') {
+		assert false, 'Signature-Input must reject duplicate dictionary labels'
+	} else {
+		assert err is MalformedMessage
+	}
+	if _ := parse_signature('sig1=:YQ==:, sig1=:Yg==:') {
+		assert false, 'Signature must reject duplicate dictionary labels'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_parse_signature_returns_decoded_bytes() {
 	src := 'sig1=:cGF5bG9hZA==:'
 	parsed := parse_signature(src)!

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -6,12 +6,12 @@
 module signature
 
 fn test_serialize_inner_list_quotes_each_item() {
-	got := serialize_inner_list(['@method', 'date', '@path'])
+	got := serialize_inner_list(['@method', 'date', '@path'])!
 	assert got == '("@method" "date" "@path")'
 }
 
 fn test_serialize_inner_list_handles_empty() {
-	assert serialize_inner_list([]string{}) == '()'
+	assert serialize_inner_list([]string{})! == '()'
 }
 
 fn test_serialize_params_keeps_input_order() {
@@ -25,7 +25,7 @@ fn test_serialize_params_keeps_input_order() {
 			value: 'k1'
 		},
 	]
-	got := serialize_params(pairs)
+	got := serialize_params(pairs)!
 	assert got == ';created=1;keyid="k1"'
 }
 
@@ -36,7 +36,7 @@ fn test_serialize_params_escapes_quotes_in_strings() {
 			value: 'has"quote'
 		},
 	]
-	assert serialize_params(pairs) == ';tag="has\\"quote"'
+	assert serialize_params(pairs)! == ';tag="has\\"quote"'
 }
 
 fn test_serialize_params_emits_boolean_short_form() {
@@ -50,7 +50,21 @@ fn test_serialize_params_emits_boolean_short_form() {
 			value: false
 		},
 	]
-	assert serialize_params(pairs) == ';flag=?1;other=?0'
+	assert serialize_params(pairs)! == ';flag=?1;other=?0'
+}
+
+fn test_serialize_params_rejects_control_bytes() {
+	pairs := [
+		ParamPair{
+			name:  'keyid'
+			value: 'safe\r\nInjected: true'
+		},
+	]
+	if _ := serialize_params(pairs) {
+		assert false, 'control bytes must not be serialized into a Structured Field string'
+	} else {
+		assert err is MalformedMessage
+	}
 }
 
 fn test_parse_signature_input_single_entry() {

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -288,6 +288,14 @@ fn test_parse_signature_input_rejects_uppercase_label() {
 	}
 }
 
+fn test_parse_signature_input_rejects_uppercase_http_field_component() {
+	if _ := parse_signature_input('sig1=("Content-Type")') {
+		assert false, 'HTTP field component identifiers must be lowercase'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_parse_signature_input_preserves_signature_params_value() {
 	src := 'sig1=("@method");created=1618884473;keyid="my-key"'
 	entries := parse_signature_input(src)!

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -150,6 +150,40 @@ fn test_parse_signature_input_rejects_whitespace_after_parameter_delimiter() {
 	}
 }
 
+fn test_parse_signature_input_accepts_extension_bare_item_types() {
+	src := 'sig1=("@method");token=alpha/one;bytes=:YQ==:;decimal=1.25'
+	entries := parse_signature_input(src)!
+	assert entries.len == 1
+	for name in ['token', 'bytes', 'decimal'] {
+		value := entries[0].params[name] or { panic('missing extension parameter ${name}') }
+		assert value is ExtensionParamValue
+	}
+	assert entries[0].signature_params_value == '("@method");token=alpha/one;bytes=:YQ==:;decimal=1.25'
+}
+
+fn test_verify_accepts_extension_signature_parameters() {
+	c := Components{
+		method: 'GET'
+	}
+	key := Key.hmac_sha256('shared-secret'.bytes())!
+	params := '("@method");token=alpha/one;bytes=:YQ==:;decimal=1.25'
+	base := '"@method": GET\n"@signature-params": ${params}'
+	sig := sign_base(base.bytes(), key)!
+	verify(c, 'sig1=${params}', signature_header_value('sig1', sig)!, 'sig1', key)!
+}
+
+fn test_serialize_extension_signature_parameter() {
+	got := serialize_params([
+		ParamPair{
+			name:  'ext'
+			value: ExtensionParamValue{
+				raw: 'alpha/one'
+			}
+		},
+	])!
+	assert got == ';ext=alpha/one'
+}
+
 fn test_parse_signature_input_rejects_out_of_range_integers() {
 	for value in ['1000000000000000', '-1000000000000000'] {
 		if _ := parse_signature_input('sig1=("@method");created=${value}') {

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -92,6 +92,14 @@ fn test_parse_signature_input_single_entry() {
 	assert e.params['keyid'] or { ParamValue('') } == ParamValue('my-key')
 }
 
+fn test_parse_signature_input_requires_inner_list_whitespace() {
+	if _ := parse_signature_input('sig1=("@method""host")') {
+		assert false, 'inner-list items must be separated by SP'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_parse_signature_input_multiple_entries() {
 	src := 'sig-a=("@method");created=1, sig-b=("date" "@authority");keyid="k"'
 	entries := parse_signature_input(src)!

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -100,6 +100,14 @@ fn test_parse_signature_input_requires_inner_list_whitespace() {
 	}
 }
 
+fn test_parse_signature_input_rejects_unsupported_component_parameters() {
+	if _ := parse_signature_input('sig1=("example-dict";key="a")') {
+		assert false, 'unsupported covered-component parameters must not be discarded'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
 fn test_parse_signature_input_multiple_entries() {
 	src := 'sig-a=("@method");created=1, sig-b=("date" "@authority");keyid="k"'
 	entries := parse_signature_input(src)!

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -131,6 +131,29 @@ fn test_parse_signature_returns_decoded_bytes() {
 	assert bytes.bytestr() == 'payload'
 }
 
+fn test_dictionary_parsers_reject_trailing_commas() {
+	if _ := parse_signature_input('sig1=("@method"), ') {
+		assert false, 'Signature-Input must reject a trailing dictionary comma'
+	} else {
+		assert err is MalformedMessage
+	}
+	if _ := parse_signature('sig1=:YQ==:, ') {
+		assert false, 'Signature must reject a trailing dictionary comma'
+	} else {
+		assert err is MalformedMessage
+	}
+}
+
+fn test_parse_signature_rejects_invalid_base64() {
+	for value in ['!', 'YQ=', 'YQ===', 'Y=Q=', 'Zh=='] {
+		if _ := parse_signature('sig1=:${value}:') {
+			assert false, 'Signature must reject invalid or non-canonical base64 "${value}"'
+		} else {
+			assert err is MalformedMessage
+		}
+	}
+}
+
 fn test_parse_signature_input_rejects_uppercase_label() {
 	if _ := parse_signature_input('Sig1=()') {
 		assert false, 'uppercase label must be rejected by SF parser'

--- a/vlib/net/http/signature/structured_field_test.v
+++ b/vlib/net/http/signature/structured_field_test.v
@@ -270,6 +270,23 @@ fn test_dictionary_parsers_reject_trailing_commas() {
 	}
 }
 
+fn test_dictionary_parsers_reject_htab_at_member_boundaries() {
+	for input in ['\tsig1=("@method")', 'sig1=("@method"),\tsig2=("@path")', 'sig1=("@method")\t'] {
+		if _ := parse_signature_input(input) {
+			assert false, 'Signature-Input dictionary whitespace must be SP only'
+		} else {
+			assert err is MalformedMessage
+		}
+	}
+	for input in ['\tsig1=:YQ==:', 'sig1=:YQ==:,\tsig2=:Yg==:', 'sig1=:YQ==:\t'] {
+		if _ := parse_signature(input) {
+			assert false, 'Signature dictionary whitespace must be SP only'
+		} else {
+			assert err is MalformedMessage
+		}
+	}
+}
+
 fn test_parse_signature_rejects_invalid_base64() {
 	for value in ['!', 'YQ=', 'YQ===', 'Y=Q=', 'Zh=='] {
 		if _ := parse_signature('sig1=:${value}:') {

--- a/vlib/net/http/signature/tests/rfc9421/B_2_4_ecdsa.json
+++ b/vlib/net/http/signature/tests/rfc9421/B_2_4_ecdsa.json
@@ -1,0 +1,31 @@
+{
+   "title": "RFC 9421 §B.2.4 — Signing a Response Using ecdsa-p256-sha256",
+   "input": {
+      "status": 200,
+      "fields": {
+         "content-type": "application/json",
+         "content-digest": "sha-512=:mEWXIS7MaLRuGgxOBdODa3xqM1XdEvxoYhvlCFJ41QJgJc4GTsPp29l5oGX69wWdXymyU0rjJuahq4l5aGgfLQ==:",
+         "content-length": "23"
+      },
+      "components": ["@status", "content-type", "content-digest", "content-length"],
+      "params": {
+         "created": 1618884473,
+         "keyid": "test-key-ecc-p256"
+      },
+      "label": "sig-b24",
+      "key": {
+         "alg": "ecdsa-p256-sha256",
+         "x_b64u": "qIVYZVLCrPZHGHjP17CTW0_-D9Lfw0EkjqF7xB4FivA",
+         "y_b64u": "Mc4nN9LTDOBhfoUeg8Ye9WedFRhnZXZJA12Qp0zZ6F0",
+         "d_b64u": "UpuF81l-kOxbjf7T4mNSv0r5tN67Gim7rnf6EFpcYDs"
+      }
+   },
+   "intermediates": {
+      "signature_base": "\"@status\": 200\n\"content-type\": application/json\n\"content-digest\": sha-512=:mEWXIS7MaLRuGgxOBdODa3xqM1XdEvxoYhvlCFJ41QJgJc4GTsPp29l5oGX69wWdXymyU0rjJuahq4l5aGgfLQ==:\n\"content-length\": 23\n\"@signature-params\": (\"@status\" \"content-type\" \"content-digest\" \"content-length\");created=1618884473;keyid=\"test-key-ecc-p256\""
+   },
+   "output": {
+      "signature_input": "sig-b24=(\"@status\" \"content-type\" \"content-digest\" \"content-length\");created=1618884473;keyid=\"test-key-ecc-p256\"",
+      "signature": "sig-b24=:wNmSUAhwb5LxtOtOpNa6W5xj067m5hFrj0XQ4fvpaCLx0NKocgPquLgyahnzDnDAUy5eCdlYUEkLIj+32oiasw==:",
+      "note": "ECDSA is non-deterministic — the signature value above is verifiable but cannot be reproduced byte-for-byte."
+   }
+}

--- a/vlib/net/http/signature/tests/rfc9421/B_2_5_hmac.json
+++ b/vlib/net/http/signature/tests/rfc9421/B_2_5_hmac.json
@@ -1,0 +1,28 @@
+{
+   "title": "RFC 9421 §B.2.5 — Signing a Request Using hmac-sha256",
+   "input": {
+      "method": "POST",
+      "authority": "example.com",
+      "fields": {
+         "date": "Tue, 20 Apr 2021 02:07:55 GMT",
+         "content-type": "application/json"
+      },
+      "components": ["date", "@authority", "content-type"],
+      "params": {
+         "created": 1618884473,
+         "keyid": "test-shared-secret"
+      },
+      "label": "sig-b25",
+      "key": {
+         "alg": "hmac-sha256",
+         "k_b64": "uzvJfB4u3N0Jy4T7NZ75MDVcr8zSTInedJtkgcu46YW4XByzNJjxBdtjUkdJPBtbmHhIDi6pcl8jsasjlTMtDQ=="
+      }
+   },
+   "intermediates": {
+      "signature_base": "\"date\": Tue, 20 Apr 2021 02:07:55 GMT\n\"@authority\": example.com\n\"content-type\": application/json\n\"@signature-params\": (\"date\" \"@authority\" \"content-type\");created=1618884473;keyid=\"test-shared-secret\""
+   },
+   "output": {
+      "signature_input": "sig-b25=(\"date\" \"@authority\" \"content-type\");created=1618884473;keyid=\"test-shared-secret\"",
+      "signature": "sig-b25=:pxcQw6G3AjtMBQjwo8XzkZf/bws5LelbaMk5rGIGtE8=:"
+   }
+}

--- a/vlib/net/http/signature/tests/rfc9421/B_2_6_ed25519.json
+++ b/vlib/net/http/signature/tests/rfc9421/B_2_6_ed25519.json
@@ -1,0 +1,31 @@
+{
+   "title": "RFC 9421 §B.2.6 — Signing a Request Using ed25519",
+   "input": {
+      "method": "POST",
+      "path": "/foo",
+      "authority": "example.com",
+      "fields": {
+         "date": "Tue, 20 Apr 2021 02:07:55 GMT",
+         "content-type": "application/json",
+         "content-length": "18"
+      },
+      "components": ["date", "@method", "@path", "@authority", "content-type", "content-length"],
+      "params": {
+         "created": 1618884473,
+         "keyid": "test-key-ed25519"
+      },
+      "label": "sig-b26",
+      "key": {
+         "alg": "ed25519",
+         "d_b64u": "n4Ni-HpISpVObnQMW0wOhCKROaIKqKtW_2ZYb2p9KcU",
+         "x_b64u": "JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs"
+      }
+   },
+   "intermediates": {
+      "signature_base": "\"date\": Tue, 20 Apr 2021 02:07:55 GMT\n\"@method\": POST\n\"@path\": /foo\n\"@authority\": example.com\n\"content-type\": application/json\n\"content-length\": 18\n\"@signature-params\": (\"date\" \"@method\" \"@path\" \"@authority\" \"content-type\" \"content-length\");created=1618884473;keyid=\"test-key-ed25519\""
+   },
+   "output": {
+      "signature_input": "sig-b26=(\"date\" \"@method\" \"@path\" \"@authority\" \"content-type\" \"content-length\");created=1618884473;keyid=\"test-key-ed25519\"",
+      "signature": "sig-b26=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==:"
+   }
+}

--- a/vlib/net/http/transport.v
+++ b/vlib/net/http/transport.v
@@ -527,7 +527,9 @@ fn (mut t Transport) maybe_checkin(mut conn H1PooledConn, header Header, reusabl
 // retrying once on a connection that turned out to be stale), dials otherwise,
 // and returns healthy connections to the pool afterwards.
 fn (mut t Transport) round_trip(req &Request, method Method, scheme string, host string, port int, path string, data string, header Header) !Response {
-	raw := req.build_request_headers_opts(method, host, port, path, data, header, false)
+	default_port := if scheme == 'https' { 443 } else { 80 }
+	raw := req.build_request_headers_opts(method, host, port, default_port, path, data, header,
+		false)
 	$if trace_http_request ? {
 		eprint('> ')
 		eprint(raw)

--- a/vlib/net/http/transport.v
+++ b/vlib/net/http/transport.v
@@ -529,7 +529,7 @@ fn (mut t Transport) maybe_checkin(mut conn H1PooledConn, header Header, reusabl
 fn (mut t Transport) round_trip(req &Request, method Method, scheme string, host string, port int, path string, data string, header Header) !Response {
 	default_port := if scheme == 'https' { 443 } else { 80 }
 	raw := req.build_request_headers_opts(method, host, port, default_port, path, data, header,
-		false)
+		false)!
 	$if trace_http_request ? {
 		eprint('> ')
 		eprint(raw)


### PR DESCRIPTION
This PR adds `vlib/net/http/signature` — a pure-V implementation of [RFC 9421][rfc9421] (HTTP Message Signatures). Sign and verify HTTP requests and responses with the four algorithms backed by `vlib/crypto`: `hmac-sha256`, `ecdsa-p256-sha256`, `ecdsa-p384-sha384`, `ed25519`.

No new C code, no new third-party crypto: everything sits on `vlib/crypto` (`ecdsa`, `ed25519`, `hmac`, `sha256`) and `vlib/crypto/pem` for `Key.from_pem`.

[rfc9421]: https://www.rfc-editor.org/rfc/rfc9421.html

## Why

RFC 9421 was published in February 2024. It supersedes the long-running Cavage drafts (`draft-cavage-http-signatures-*`) that ActivityPub / Mastodon-style federation has been using in non-interoperable variants for years, and gives the ecosystem a single normative spec with stable header names and a stable signature-base format. The signed-request model authenticates HTTP messages end-to-end across TLS terminators and lets multiple per-hop signatures (client → proxy → backend) coexist on the same request. The new IETF [Web Bot Auth][wba] draft is built directly on top of it. With `vlib/net/http` already in the stdlib, V apps could not produce or verify RFC 9421 signatures until now.

[wba]: https://datatracker.ietf.org/doc/draft-meunier-web-bot-auth-architecture/

## What's covered

| Algorithm name (IANA HTTP Signature Algorithms registry) | Reference | Status |
| --- | --- | --- |
| `hmac-sha256` | RFC 9421 §3.3.3 | ✅ |
| `ecdsa-p256-sha256` | RFC 9421 §3.3.4 | ✅ |
| `ecdsa-p384-sha384` | RFC 9421 §3.3.5 | ✅ |
| `ed25519` | RFC 9421 §3.3.6 | ✅ |

The RFC 9421 §2.2 derived components implemented are `@method`, `@target-uri`, `@authority`, `@scheme`, `@request-target`, `@path`, `@query`, `@status` — the `@query-param` selector (§2.2.8) is the only one missing and is called out below as deferred. Plain HTTP fields are matched by lowercased name, multi-value joined as `", "`, OWS trimmed (RFC 9421 §2.1). Optional outer behaviours: multiple co-existing signatures merged into a single Structured Field per RFC 8941 §3.2; `expires` enforced when the caller passes `now_unix > 0`.

`rsa-pss-sha512` and `rsa-v1_5-sha256` are intentionally out of scope — `vlib/crypto` does not yet ship an RSA implementation. Adding them is mechanical once it does. `@query-param`, `sf` / `key` / `bs` parameter handling are deferred to a follow-up PR.

## Module surface

```v ignore
import net.http
import net.http.signature
import time
// Sign an outbound request (Ed25519 + PEM-encoded private key).
priv := signature.Key.from_pem(alice_private_pem)!.with_keyid('alice')
signature.sign_request(mut req, priv,
    components: ['@method', '@target-uri', '@authority', 'date'])!
// Verify on the server side.
pub_key := signature.Key.from_pem(alice_public_pem)!
signature.verify_request(req, pub_key, now_unix: time.now().unix())!
```

`Key.from_pem` accepts the canonical PKCS#8 / SPKI / SEC1 PEM blocks `openssl genpkey` and friends produce; the raw-coordinate constructors (`Key.ed25519_private(seed)`, `Key.ecdsa_p256_public(x, y)`, …) remain for callers that have JWK-shaped material. `created` defaults to `time.now().unix()` when omitted, since RFC 9421 §7.2.1 RECOMMENDS it for replay protection.

A complete example program lives at `examples/http_signature.v`.

## Conformance / test vectors

RFC 9421 Appendix B vectors are vendored under `vlib/net/http/signature/tests/rfc9421/` and exercised by `rfc9421_test.v`:

| Vector | Algorithm | Mode |
| --- | --- | --- |
| §B.2.5 | `hmac-sha256` | **bytes-exact** |
| §B.2.6 | `ed25519` | **bytes-exact** |
| §B.2.4 | `ecdsa-p256-sha256` | verify (ECDSA non-deterministic) |

Both byte-exact tests reproduce the RFC reference signature down to the last base64 character; the ECDSA case verifies the reference signature and adds an independent sign-then-verify roundtrip.

In addition to the public corpus:

* `http_message_test.v` — sign/verify roundtrips for HMAC, Ed25519, ECDSA P-256 (RFC key) and ECDSA P-384 (fresh keypair via `ecdsa.generate_key`); tampered-URL rejection; missing-header rejection; `expires` enforcement; two-signature coexistence; `alg` mismatch rejection; label grammar (Structured Field key form).
* `structured_field_test.v` — Inner List + parameter serialisation pinned (`("@method" "host");created=N;keyid="…"` byte-for-byte), escape rules for quoted strings, multi-entry / single-entry parsing, raw `signature_params_value` preservation, and **non-canonical wire-order verification** — proves the verifier replays the wire param substring verbatim instead of re-serialising in a fixed canonical order, which is what makes interop with stacks that emit `;keyid=…;created=…` (instead of the inverse) work.
* `key_test.v` — `Key.from_pem` round-trip with the RFC §B.1.3 P-256 PEM and §B.1.4 Ed25519 PEM, byte-exact RFC §B.2.6 signature reproduction *via* `Key.from_pem`, and rejection of unsupported PEM block types (`RSA PRIVATE KEY` etc).

I've also tested these modules against lib in other languages to check interop.

## Out of scope (deliberate)

* **RSA signatures** — `rsa-pss-sha512` and `rsa-v1_5-sha256` need an RSA-PSS implementation in `vlib/crypto`, which is a separate effort. Adding them is purely additive once it lands.
* **`@query-param` derived component** (RFC 9421 §2.2.8) — defers per-parameter selection rules; rare in practice and easy to add later.
* **Structured-field re-serialisation parameters** (`sf`, `key`, `bs` from §2.1.x) — used when signing structured-field values themselves; out of v1 to keep the parser narrow.
* **Body covered components beyond what `Components.fields` already supports** — `Content-Digest` is signed as a regular header field; computing the digest itself stays the caller's concern (matches what every other RFC 9421 stack does).