### PR TITLE
fix orm dynamic query-data guard folding

### DIFF
--- a/vlib/orm/orm_dynamic_test.v
+++ b/vlib/orm/orm_dynamic_test.v
@@ -11,6 +11,10 @@ mut:
 	status string
 }
 
+struct DynamicMemberFilter {
+	name ?string
+}
+
 @[table: 'dynamic_cast_members']
 struct DynamicCastMember {
 mut:
@@ -76,6 +80,21 @@ fn test_dynamic_select_with_inline_where_block() {
 	assert rows[0].name == 'Alice'
 	assert rows[0].email == 'alice@example.com'
 	assert rows[0].age == 31
+
+	filter := DynamicMemberFilter{
+		name: 'Alice'
+	}
+	where_expr := {
+		if name := filter.name {
+			name == name
+		}
+	}
+
+	guard_rows := sql db {
+		dynamic select from DynamicMember where where_expr
+	}!
+
+	assert guard_rows.len == 2
 }
 
 fn test_dynamic_update_with_alias_set_block() {
@@ -149,8 +168,13 @@ fn test_dynamic_update_with_alias_set_block_cast_expr() {
 	id := db.last_id()
 	next_name := 'Alicia'
 	next_required := true
+	filter := DynamicMemberFilter{
+		name: next_name
+	}
 	update_expr := {
-		name == next_name,
+		if name := filter.name {
+			name == name
+		},
 		is_required == u8(if next_required { 1 } else { 0 })
 	}
 

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -808,7 +808,12 @@ fn (mut t Transformer) sql_query_data_items(items []ast.SqlQueryDataItem) []ast.
 fn (mut t Transformer) sql_query_data_item(mut item ast.SqlQueryDataItem) ast.SqlQueryDataItem {
 	match mut item {
 		ast.SqlQueryDataLeaf {
+			// The left side is an ORM field, but the right side can be a V variable
+			// with the same name, so `field == field` must not fold to `true`.
+			old_inside_sql := t.inside_sql
+			t.inside_sql = true
 			item.expr = t.expr(mut item.expr)
+			t.inside_sql = old_inside_sql
 		}
 		ast.SqlQueryDataIf {
 			for mut branch in item.branches {


### PR DESCRIPTION


Fixes #27112.

This prevents the transformer from folding dynamic ORM query-data leaf
expressions like `name == name` to `true` in `-prod` builds.

In dynamic ORM query-data blocks, the left side of a comparison is a table
field, while the right side can be a V variable with the same name. When the
query-data block is stored in an alias and then used by `dynamic select` or
`dynamic update`, `-prod` optimization could treat it as a normal self
comparison and fold it, causing cgen to fail with:

```text
cgen error: ORM: dynamic query-data leaf must be an infix expression
```

The fix reuses the existing SQL-context guard while transforming
`SqlQueryDataLeaf` expressions.

Tests added for:
- dynamic `where` query-data alias with an optional guard
- dynamic `set` query-data alias with an optional guard