### PR TITLE
cli: drop trailing periods and use 'Print' in default help/version/man descriptions

### DIFF
--- a/vlib/cli/help.v
+++ b/vlib/cli/help.v
@@ -13,7 +13,7 @@ fn help_flag(with_abbrev bool) Flag {
 		flag:        .bool
 		name:        'help'
 		abbrev:      sabbrev
-		description: 'Prints help information.'
+		description: 'Print help information'
 	}
 }
 
@@ -21,7 +21,7 @@ fn help_cmd() Command {
 	return Command{
 		name:        'help'
 		usage:       '<command>'
-		description: 'Prints help information.'
+		description: 'Print help information'
 		execute:     print_help_for_command
 	}
 }

--- a/vlib/cli/man.v
+++ b/vlib/cli/man.v
@@ -6,7 +6,7 @@ fn man_flag() Flag {
 	return Flag{
 		flag:        .bool
 		name:        'man'
-		description: 'Prints the auto-generated manpage.'
+		description: 'Print the auto-generated manpage'
 	}
 }
 
@@ -14,7 +14,7 @@ fn man_cmd() Command {
 	return Command{
 		name:        'man'
 		usage:       '<subcommand>'
-		description: 'Prints the auto-generated manpage.'
+		description: 'Print the auto-generated manpage'
 		execute:     print_manpage_for_command
 	}
 }

--- a/vlib/cli/testdata/default_command_flag.out
+++ b/vlib/cli/testdata/default_command_flag.out
@@ -1,7 +1,7 @@
 Usage:  [flags] [commands]
 
 Flags:
-  -version            Prints version information.
+  -version            Print version information
 
 Commands:
-  help                Prints help information.
+  help                Print help information

--- a/vlib/cli/testdata/default_help.out
+++ b/vlib/cli/testdata/default_help.out
@@ -1,7 +1,7 @@
 Usage:  [flags] [commands]
 
 Flags:
-  -help               Prints help information.
+  -help               Print help information
 
 Commands:
-  help                Prints help information.
+  help                Print help information

--- a/vlib/cli/testdata/default_help_flag_no_command.out
+++ b/vlib/cli/testdata/default_help_flag_no_command.out
@@ -1,8 +1,8 @@
 Usage: foo [flags] [commands]
 
 Flags:
-  -help               Prints help information.
-  -man                Prints the auto-generated manpage.
+  -help               Print help information
+  -man                Print the auto-generated manpage
 
 Commands:
-  man                 Prints the auto-generated manpage.
+  man                 Print the auto-generated manpage

--- a/vlib/cli/testdata/long_description.out
+++ b/vlib/cli/testdata/long_description.out
@@ -6,5 +6,5 @@ Flags:
   -fun                '{"uri":"mqtt://broker.emqx.io:1883","topic":"test_emq/1
 '{"uri":"mqtt://broker.emqx.io:1883","topic":"test_emq/1","filters":[{"producer_id":0,"trace_group":2,"string_id
                       ":3001},{"string_id":3002}]}'
-  -help               Prints help information.
-  -man                Prints the auto-generated manpage.
+  -help               Print help information
+  -man                Print the auto-generated manpage

--- a/vlib/cli/version.v
+++ b/vlib/cli/version.v
@@ -6,14 +6,14 @@ fn version_flag(with_abbrev bool) Flag {
 		flag:        .bool
 		name:        'version'
 		abbrev:      sabbrev
-		description: 'Prints version information.'
+		description: 'Print version information'
 	}
 }
 
 fn version_cmd() Command {
 	return Command{
 		name:        'version'
-		description: 'Prints version information.'
+		description: 'Print version information'
 		execute:     print_version_for_command
 	}
 }


### PR DESCRIPTION
This PR rewords the library-provided descriptions for the auto-injected `--help`, `--version` and `--man` flags (and their command equivalents) as terse imperatives without trailing punctuation, matching the convention used by `cobra`, `gh` or `git` for example:

- `Prints help information.` → `Print help information`
- `Prints version information.` → `Print version information`
- `Prints the auto-generated manpage.` → `Print the auto-generated manpage`

No public API change; apps that override these descriptions are unaffected on the lines they override.