### PR TITLE
ast: proposed fix for list of generic bug

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -3775,7 +3775,14 @@ fn (mut t Table) unwrap_generic_type_ex_with_depth(typ Type, generic_names []str
 			// If concrete types still contain generic parameters (e.g. Vec3[U] where U
 			// is unresolved), don't create a partially-resolved struct entry. The struct
 			// will be properly instantiated when all type parameters are known.
-			if final_concrete_types.any(it.has_flag(.generic)) {
+			//
+			// Structural check via generic_type_names catches entries like `[]T`
+			// whose `.generic` Type-flag has been cleared but whose type structure
+			// still references an unresolved generic parameter. Without this check,
+			// such entries reach register_sym below and leak into codegen as
+			// `Array_T` / placeholder-typed struct fields.
+			if final_concrete_types.any(it.has_flag(.generic))
+				|| final_concrete_types.any(t.generic_type_names(it).len > 0) {
 				return typ
 			}
 		}

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -4532,7 +4532,8 @@ pub fn (mut t Table) generic_insts_to_concrete() {
 		}
 		if sym.info is Struct {
 			if sym.info.concrete_types.len > 0 && sym.info.parent_type.has_flag(.generic)
-				&& !sym.info.concrete_types.any(it.has_flag(.generic)) {
+				&& !sym.info.concrete_types.any(it.has_flag(.generic))
+				&& !sym.info.concrete_types.any(t.generic_type_names(it).len > 0) {
 				parent_sym := t.sym(sym.info.parent_type)
 				for method in parent_sym.methods {
 					if method.generic_names.len == sym.info.concrete_types.len

--- a/vlib/v/tests/generics/generic_method_slice_two_param_sibling_test.v
+++ b/vlib/v/tests/generics/generic_method_slice_two_param_sibling_test.v
@@ -1,0 +1,71 @@
+module main
+
+struct Pair[A, B] {
+	a A
+	b B
+}
+
+struct Container[T] {
+	value T
+}
+
+pub fn (c Container[T]) get() !T {
+	return c.value
+}
+
+fn make_pair[A, B](a A, b B) Container[Pair[A, B]] {
+	return Container[Pair[A, B]]{
+		value: Pair[A, B]{
+			a: a
+			b: b
+		}
+	}
+}
+
+fn make_list[T](items []T) Container[[]T] {
+	return Container[[]T]{
+		value: items
+	}
+}
+
+fn test_pair_container_get_returns_pair() {
+	c := make_pair[int, int](7, 11)
+	p := c.get() or {
+		assert false, 'get() on Container[Pair[int, int]] errored: ${err}'
+		return
+	}
+	assert p.a == 7, 'expected p.a == 7, got ${p.a}'
+	assert p.b == 11, 'expected p.b == 11, got ${p.b}'
+}
+
+fn test_list_container_get_returns_slice() {
+	c := make_list[int]([1, 2, 3])
+	lst := c.get() or {
+		assert false, 'get() on Container[[]int] errored: ${err}'
+		return
+	}
+	assert lst.len == 3, 'expected length 3, got ${lst.len}'
+	assert lst[0] == 1
+	assert lst[1] == 2
+	assert lst[2] == 3
+}
+
+fn test_sibling_factories_return_independent_shapes() {
+	pc := make_pair[string, int]('hello', 42)
+	lc := make_list[string](['a', 'b'])
+
+	p := pc.get() or {
+		assert false, 'pair get failed: ${err}'
+		return
+	}
+	assert p.a == 'hello'
+	assert p.b == 42
+
+	lst := lc.get() or {
+		assert false, 'list get failed: ${err}'
+		return
+	}
+	assert lst.len == 2
+	assert lst[0] == 'a'
+	assert lst[1] == 'b'
+}


### PR DESCRIPTION
I ran in to another code generation bug while I was playing around with generics.

The following code shows the problem:
```
module main

struct Container[T] {}

pub fn (c Container[T]) get() !T {
	return T{}
}

fn make_list[T]() Container[[]T] {
	return Container[[]T]{}
}

fn test_make_list() {
	_ := make_list[int]()
	assert true
}
```

Prior to making the change, I would see the following error:
```
$ v test /private/tmp/generic_method_slice_test.v
---- Testing... ------------------------------------------------------------------------------------
/private/tmp/generic_method_slice_test.v:6:9: error: cannot use `[][][]T` as type `![][]T` in return argument
    4 | 
    5 | pub fn (c Container[T]) get() !T {
    6 |     return T{}
      |            ~~~
    7 | }
    8 |
 FAIL     0.000 ms /private/tmp/generic_method_slice_test.v
>> compilation failed:
/private/tmp/generic_method_slice_test.v:6:9: error: cannot use `[][][]T` as type `![][]T` in return argument
    4 | 
    5 | pub fn (c Container[T]) get() !T {
    6 |     return T{}
      |            ~~~
    7 | }
    8 |

----------------------------------------------------------------------------------------------------
To reproduce just failure 1 run:    '/Users/kim/Projects/v/from_github/v/v'  '/private/tmp/generic_method_slice_test.v'
Summary for all V _test.v files: 1 failed, 1 total. Elapsed time: 846 ms, on 1 job. Comptime: 792 ms. Runtime: 0 ms.
```

After applying the change, the error goes away:
```
$ v test /private/tmp/generic_method_slice_test.v
---- Testing... ------------------------------------------------------------------------------------
 OK     406.864 ms /private/tmp/generic_method_slice_test.v
----------------------------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total. Elapsed time: 713 ms, on 1 job. Comptime: 305 ms. Runtime: 406 ms.
```

```
$ v doctor
|V full version      |V 0.5.1 ed5fc1638abe439f5b4d5d31e0c91a81af065b94
|:-------------------|:-------------------
|OS                  |macos, macOS, 26.4.1, 25E253
|Processor           |10 cpus, 64bit, little endian, Apple M1 Max
|Memory              |1.3GB/64GB
|                    |
|V executable        |/Users/kim/Projects/v/from_github/v/v
|V last modified time|2026-05-10 21:34:03
|                    |
|V home dir          |OK, value: /Users/kim/Projects/v/from_github/v
|VMODULES            |OK, value: /Users/kim/.vmodules
|VTMP                |OK, value: /tmp/v_1002
|Current working dir |OK, value: /Users/kim/Projects/Github/v
|                    |
|env LDFLAGS         |"-L/opt/homebrew/opt/postgresql@15/lib"
|Git version         |git version 2.50.1 (Apple Git-155)
|V git status        |0.5.1-1536-ged5fc163-dirty
|.git/config present |true
|                    |
|cc version          |Apple clang version 21.0.0 (clang-2100.0.123.102)
|gcc version         |Apple clang version 21.0.0 (clang-2100.0.123.102)
|clang version       |Apple clang version 21.0.0 (clang-2100.0.123.102)
|tcc version         |tcc version 0.9.28rc 2026-01-10 HEAD@5ec0e6f8 (AArch64 Darwin)
|tcc git status      |thirdparty-macos-arm64 f995efa3
|emcc version        |N/A
|glibc version       |N/A
```

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
