### PR TITLE
term: remove extra spaces sent to methods in ok_message(), fail_message(), and warn_message()

### DIFF
--- a/vlib/term/term.v
+++ b/vlib/term/term.v
@@ -58,7 +58,7 @@ pub fn failed(s string) string {
 // If colors are not allowed, returns a given string.
 pub fn ok_message(s string) string {
 	if can_show_color_on_stdout() {
-		return green(' ${s} ')
+		return green('${s}')
 	}
 	return s
 }
@@ -66,14 +66,14 @@ pub fn ok_message(s string) string {
 // fail_message returns a colored string with red color.
 // If colors are not allowed, returns a given string.
 pub fn fail_message(s string) string {
-	return failed(' ${s} ')
+	return failed('${s}')
 }
 
 // warn_message returns a colored string with yellow color.
 // If colors are not allowed, returns a given string.
 pub fn warn_message(s string) string {
 	if can_show_color_on_stdout() {
-		return bright_yellow(' ${s} ')
+		return bright_yellow('${s}')
 	}
 	return s
 }


### PR DESCRIPTION
The term methods ok_message(), fail_message(), and warn_message() all send extra spaces to methods they call. This leads to text containing unexpected spaces padding the text. The fix to this issue is to simply remove the extra spaces.