### PR TITLE
builder, cgen: fix macOS tcc header lookup

### DIFF
--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -80,16 +80,32 @@ fn parallel_cc(mut b builder.Builder, result c.GenOutput) ! {
 	mut compile_args := b.get_compile_args()
 	mut linker_args := b.get_linker_args()
 	if b.ccoptions.cc == .tcc {
-		// vlang/tcc has its system headers under `${vroot}/thirdparty/tcc/lib/tcc/include/`
-		// and its runtime objects (libtcc1.a, bt-*.o) under `${vroot}/thirdparty/tcc/lib/tcc/`.
+		// vlang/tcc can have its runtime objects under `${vroot}/thirdparty/tcc/lib/tcc/`
+		// or directly under `${vroot}/thirdparty/tcc/lib/`, while its system headers
+		// can be under that install dir or `${vroot}/thirdparty/tcc/include/`.
 		// `-B` controls tcc's include search (`${B}/include`) and `-L` adds a library search path,
 		// so pass absolute paths for both. This lets tcc find them regardless of the cwd from
 		// which v was invoked, without affecting how user-supplied relative flags are resolved.
-		tcc_install_dir := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'lib', 'tcc')
+		tcc_root_dir := os.join_path(@VEXEROOT, 'thirdparty', 'tcc')
+		tcc_lib_dir := os.join_path(tcc_root_dir, 'lib')
+		tcc_nested_dir := os.join_path(tcc_lib_dir, 'tcc')
+		tcc_install_dir := if os.is_dir(tcc_nested_dir) { tcc_nested_dir } else { tcc_lib_dir }
 		if os.is_dir(tcc_install_dir) {
 			tcc_b_arg := '-B${b.tcc_quoted_path(tcc_install_dir)}'
 			tcc_l_arg := '-L${b.tcc_quoted_path(tcc_install_dir)}'
 			compile_args << tcc_b_arg
+			mut tcc_include_dirs := [
+				os.join_path(tcc_install_dir, 'include'),
+				os.join_path(tcc_root_dir, 'include'),
+			]
+			for tcc_include_dir in tcc_include_dirs {
+				if os.is_dir(tcc_include_dir) {
+					tcc_include_arg := '-I${b.tcc_quoted_path(tcc_include_dir)}'
+					if tcc_include_arg !in compile_args {
+						compile_args << tcc_include_arg
+					}
+				}
+			}
 			linker_args << tcc_b_arg
 			linker_args << tcc_l_arg
 		}

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -572,6 +572,7 @@ V_CRT_LINKAGE void * V_CRT_CALL malloc(size_t size);
 V_CRT_LINKAGE void * V_CRT_CALL calloc(size_t nitems, size_t size);
 V_CRT_LINKAGE void * V_CRT_CALL realloc(void *ptr, size_t size);
 V_CRT_LINKAGE void * V_CRT_CALL aligned_alloc(size_t alignment, size_t size);
+V_CRT_LINKAGE int V_CRT_CALL posix_memalign(void **memptr, size_t alignment, size_t size);
 V_CRT_LINKAGE void V_CRT_CALL free(void *ptr);
 V_CRT_LINKAGE int V_CRT_CALL rand(void);
 V_CRT_LINKAGE void V_CRT_CALL srand(unsigned int seed);


### PR DESCRIPTION
## Summary

- declare posix_memalign in generated C headers so macOS aligned_alloc fallback compiles cleanly under tcc -cstrict
- make parallel-cc locate bundled tcc headers/runtime from both lib/tcc and lib layouts
- add an absolute bundled tcc include path for parallel C compile shards that run from tmp dirs

## Root Cause

macOS fallback code for aligned_alloc calls posix_memalign, but the manual libc declarations did not include a posix_memalign prototype. In cstrict mode, tcc treats that implicit declaration as an error and V falls back to the system compiler.

parallel-cc also assumed the older bundled tcc lib/tcc layout. The current macOS arm64 tcc bundle has headers under thirdparty/tcc/lib/include, and tcc's -B path alone is cwd-sensitive there, so compile shards created in /tmp could fail to include stdbool.h through Apple SDK headers.

## Validation

- ./v -g -keepc -o ./vnew cmd/v
- VMODULES=/tmp/vmodules_codex ./vnew -cc tcc -cstrict -show-c-output run examples/hello_world.v
- VMODULES=/tmp/vmodules_codex ./vnew -silent vlib/v/builder/parallel_cc_failure_test.v
- VMODULES=/tmp/vmodules_codex ./vnew -silent vlib/v/compiler_errors_test.v
- VMODULES=/tmp/vmodules_codex ./vnew -silent vlib/v/gen/c/coutput_test.v