### PR TITLE
compress: make vlib/compress/lz/interop/lz77_ref.py pass on older Python versions too (Python 3.8.10)

### DIFF
--- a/vlib/compress/lz/interop/lz77_ref.py
+++ b/vlib/compress/lz/interop/lz77_ref.py
@@ -18,7 +18,7 @@ def encode_uvarint(value: int) -> bytes:
     return bytes(out)
 
 
-def decode_uvarint(data: bytes, pos: int) -> tuple[int, int]:
+def decode_uvarint(data: bytes, pos: int):
     value = 0
     shift = 0
     i = pos


### PR DESCRIPTION
Before/After:
```
#127 12:16:00 ^ master ~/v>./v run vlib/compress/lz/interop/lz_interop.v   
LZ interop input: 524288 bytes
V roundtrip (lz77): OK
V roundtrip (lz78): OK
V roundtrip (lzw): OK
V roundtrip (lz4): OK
V roundtrip (lzss): OK
V roundtrip (lzma): OK
V roundtrip (lzjb): OK
Cross-validation: V<->C compress/decompress OK
Cross-validation V<->Python failed: Python decompress(V output) failed: Traceback (most recent call last):
  File "/home/delian/v/vlib/compress/lz/interop/lz77_ref.py", line 21, in <module>
    def decode_uvarint(data: bytes, pos: int) -> tuple[int, int]:
TypeError: 'type' object is not subscriptable
#1 12:16:06 ^ master ~/v>jed /home/delian/v/vlib/compress/lz/interop/lz77_ref.py
#0 12:16:21 ^ master ~/v>jed /home/delian/v/vlib/compress/lz/interop/lz77_ref.py:21
#0 12:16:31 ^ master ~/v>vjed /home/delian/v/vlib/compress/lz/interop/lz77_ref.py:21
#0 12:16:43 ^ master ~/v>./v run vlib/compress/lz/interop/lz_interop.v          
LZ interop input: 524288 bytes
V roundtrip (lz77): OK
V roundtrip (lz78): OK
V roundtrip (lzw): OK
V roundtrip (lz4): OK
V roundtrip (lzss): OK
V roundtrip (lzma): OK
V roundtrip (lzjb): OK
Cross-validation: V<->C compress/decompress OK
Cross-validation: V<->Python compress/decompress OK
```