### PR TITLE
rand: use the OS CSPRNG for `uuid_v4`, `uuid_v7`, `UUIDSession` and `ulid`

### DIFF
--- a/vlib/crypto/rand/bigint/bigint.v
+++ b/vlib/crypto/rand/bigint/bigint.v
@@ -1,0 +1,51 @@
+// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module bigint
+
+import crypto.rand
+import math.big
+
+// int_big creates a random `big.Integer` with range `[0, n)`.
+// Returns an error if `n` is 0 or negative.
+// This function used to live in `crypto.rand`; it moved here so that
+// `crypto.rand` itself does not depend on `math.big`, which keeps
+// `crypto.rand` usable from lower-level modules without introducing
+// import cycles.
+pub fn int_big(n big.Integer) !big.Integer {
+	if n.signum < 1 {
+		return error('`n` cannot be 0 or negative.')
+	}
+
+	max := n - big.integer_from_int(1)
+	len := max.bit_len()
+
+	if len == 0 {
+		// max = n - 1, if max = 0 then return max, as it is the only valid integer in [0, 1)
+		return max
+	}
+
+	// k is the maximum byte length needed to encode a value < n
+	k := (len + 7) / 8
+
+	// b is the number of bits in the most significant byte of n-1
+	mut b := u8(len % 8)
+	if b == 0 {
+		b = 8
+	}
+
+	mut result := big.Integer{}
+	for {
+		mut bytes := rand.read(k)!
+
+		// Clear bits in the first byte to increase the probability that the result is < max
+		bytes[0] &= u8(int(1 << b) - 1)
+
+		result = big.integer_from_bytes(bytes)
+		if result < max {
+			break
+		}
+	}
+	return result
+}

--- a/vlib/crypto/rand/bigint/bigint_test.v
+++ b/vlib/crypto/rand/bigint/bigint_test.v
@@ -1,23 +1,23 @@
 import math.big
-import crypto.rand
+import crypto.rand.bigint
 
 fn test_int_big() {
 	z := big.integer_from_int(0)
-	if _ := rand.int_big(z) {
+	if _ := bigint.int_big(z) {
 		assert false
 	} else {
 		assert true
 	}
 
 	n := big.integer_from_int(-1)
-	if _ := rand.int_big(n) {
+	if _ := bigint.int_big(n) {
 		assert false
 	} else {
 		assert true
 	}
 
 	m := big.integer_from_int(1).left_shift(128)
-	l := rand.int_big(m)! // actual large number
+	l := bigint.int_big(m)! // actual large number
 	assert l < m
 	assert l > n
 }

--- a/vlib/crypto/rand/utils.v
+++ b/vlib/crypto/rand/utils.v
@@ -5,8 +5,6 @@
 module rand
 
 import math.bits
-import math.big
-import encoding.binary
 
 // int_u64 returns a random unsigned 64-bit integer `u64` read from a real OS source of entropy.
 pub fn int_u64(max u64) !u64 {
@@ -41,7 +39,8 @@ fn bytes_to_u64(b []u8) []u64 {
 	mut z := []u64{len: ((b.len + ws - 1) / ws)}
 	mut i := b.len
 	for k := 0; i >= ws; k++ {
-		z[k] = binary.big_endian_u64(b[i - ws..i])
+		// Inlined big-endian u64 read (avoids depending on `encoding.binary`).
+		z[k] = u64(b[i - 8]) << 56 | u64(b[i - 7]) << 48 | u64(b[i - 6]) << 40 | u64(b[i - 5]) << 32 | u64(b[i - 4]) << 24 | u64(b[i - 3]) << 16 | u64(b[i - 2]) << 8 | u64(b[i - 1])
 		i -= ws
 	}
 	if i > 0 {
@@ -53,43 +52,4 @@ fn bytes_to_u64(b []u8) []u64 {
 		z[z.len - 1] = d
 	}
 	return z
-}
-
-// int_big creates a random `big.Integer` with range [0, n)
-// returns an error if `n` is 0 or negative.
-pub fn int_big(n big.Integer) !big.Integer {
-	if n.signum < 1 {
-		return error('`n` cannot be 0 or negative.')
-	}
-
-	max := n - big.integer_from_int(1)
-	len := max.bit_len()
-
-	if len == 0 {
-		// max = n - 1, if max = 0 then return max, as it is the only valid integer in [0, 1)
-		return max
-	}
-
-	// k is the maximum byte length needed to encode a value < n
-	k := (len + 7) / 8
-
-	// b is the number of bits in the most significant byte of n-1
-	mut b := u8(len % 8)
-	if b == 0 {
-		b = 8
-	}
-
-	mut result := big.Integer{}
-	for {
-		mut bytes := read(k)!
-
-		// Clear bits in the first byte to increase the probability that the result is < max
-		bytes[0] &= u8(int(1 << b) - 1)
-
-		result = big.integer_from_bytes(bytes)
-		if result < max {
-			break
-		}
-	}
-	return result
 }

--- a/vlib/crypto/rand/utils.v
+++ b/vlib/crypto/rand/utils.v
@@ -5,6 +5,8 @@
 module rand
 
 import math.bits
+import math.big
+import encoding.binary
 
 // int_u64 returns a random unsigned 64-bit integer `u64` read from a real OS source of entropy.
 pub fn int_u64(max u64) !u64 {
@@ -39,8 +41,7 @@ fn bytes_to_u64(b []u8) []u64 {
 	mut z := []u64{len: ((b.len + ws - 1) / ws)}
 	mut i := b.len
 	for k := 0; i >= ws; k++ {
-		// Inlined big-endian u64 read (avoids depending on `encoding.binary`).
-		z[k] = u64(b[i - 8]) << 56 | u64(b[i - 7]) << 48 | u64(b[i - 6]) << 40 | u64(b[i - 5]) << 32 | u64(b[i - 4]) << 24 | u64(b[i - 3]) << 16 | u64(b[i - 2]) << 8 | u64(b[i - 1])
+		z[k] = binary.big_endian_u64(b[i - ws..i])
 		i -= ws
 	}
 	if i > 0 {
@@ -52,4 +53,44 @@ fn bytes_to_u64(b []u8) []u64 {
 		z[z.len - 1] = d
 	}
 	return z
+}
+
+// int_big creates a random `big.Integer` with range [0, n)
+// returns an error if `n` is 0 or negative.
+@[deprecated: 'use crypto.rand.bigint.int_big() instead']
+pub fn int_big(n big.Integer) !big.Integer {
+	if n.signum < 1 {
+		return error('`n` cannot be 0 or negative.')
+	}
+
+	max := n - big.integer_from_int(1)
+	len := max.bit_len()
+
+	if len == 0 {
+		// max = n - 1, if max = 0 then return max, as it is the only valid integer in [0, 1)
+		return max
+	}
+
+	// k is the maximum byte length needed to encode a value < n
+	k := (len + 7) / 8
+
+	// b is the number of bits in the most significant byte of n-1
+	mut b := u8(len % 8)
+	if b == 0 {
+		b = 8
+	}
+
+	mut result := big.Integer{}
+	for {
+		mut bytes := read(k)!
+
+		// Clear bits in the first byte to increase the probability that the result is < max
+		bytes[0] &= u8(int(1 << b) - 1)
+
+		result = big.integer_from_bytes(bytes)
+		if result < max {
+			break
+		}
+	}
+	return result
 }

--- a/vlib/rand/rand.c.v
+++ b/vlib/rand/rand.c.v
@@ -1,13 +1,27 @@
 module rand
 
 import time
+import crypto.rand as crypto_rand
 
-// uuid_v4 generates a random (v4) UUID.
+// csprng_u64_pair reads 16 bytes from the OS CSPRNG and packs them into two
+// big-endian u64 values, suitable for feeding `internal_uuid`.
+fn csprng_u64_pair() (u64, u64) {
+	buf := crypto_rand.read(16) or { panic('rand: OS CSPRNG unavailable: ${err}') }
+	mut a := u64(0)
+	mut b := u64(0)
+	for i in 0 .. 8 {
+		a = (a << 8) | u64(buf[i])
+		b = (b << 8) | u64(buf[8 + i])
+	}
+	return a, b
+}
+
+// uuid_v4 generates a random (v4) UUID, sourcing its 122 random bits from the
+// OS CSPRNG (see `crypto.rand.read`).
 // See https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
 // See https://datatracker.ietf.org/doc/html/rfc9562#name-uuid-version-4
 pub fn uuid_v4() string {
-	rand_1 := default_rng.u64()
-	rand_2 := default_rng.u64()
+	rand_1, rand_2 := csprng_u64_pair()
 	return internal_uuid(4, rand_1, rand_2)
 }
 
@@ -59,12 +73,14 @@ fn internal_uuid(version u8, rand_1 u64, rand_2 u64) string {
 	}
 }
 
-// uuid_v7 generates a time-ordered (v7) UUID.
+// uuid_v7 generates a time-ordered (v7) UUID. The 48-bit Unix millisecond
+// timestamp is concatenated with random bits drawn from the OS CSPRNG.
 // See https://datatracker.ietf.org/doc/html/rfc9562#name-uuid-version-7
 pub fn uuid_v7() string {
 	timestamp_48 := u64(time.now().unix_milli()) << 16
-	rand_1 := timestamp_48 | default_rng.u16()
-	rand_2 := default_rng.u64()
+	r1, r2 := csprng_u64_pair()
+	rand_1 := timestamp_48 | (r1 & 0xFFFF)
+	rand_2 := r2
 	return internal_uuid(7, rand_1, rand_2)
 }
 
@@ -88,7 +104,7 @@ pub fn (mut u UUIDSession) next() string {
 	// make place for holding 4 bits `version`
 	timestamp_shift_4bits := (timestamp & 0xFFFF_FFFF_FFFF_0000) | ((timestamp & 0x0000_0000_0000_FFFF) >> 4)
 	rand_1 := (timestamp_shift_4bits & 0xFFFF_FFFF_FFFF_FFC0) | u64(u.counter & 0x3F) // 6 bits session counter
-	rand_2 := default_rng.u64()
+	_, rand_2 := csprng_u64_pair()
 
 	u.counter++
 

--- a/vlib/rand/rand.c.v
+++ b/vlib/rand/rand.c.v
@@ -113,8 +113,11 @@ pub fn (mut u UUIDSession) next() string {
 
 const ulid_encoding = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
 
+// internal_ulid_format encodes a 48-bit Unix millisecond timestamp and 128
+// bits of randomness (supplied as two u64s, of which only the low 45 + 35
+// bits are used) into a 26-character Crockford Base32 ULID.
 @[direct_array_access]
-fn internal_ulid_at_millisecond(mut rng PRNG, unix_time_milli u64) string {
+fn internal_ulid_format(unix_time_milli u64, rand_a u64, rand_b u64) string {
 	buflen := 26
 	mut buf := unsafe { malloc_noscan(27) }
 	mut t := unix_time_milli
@@ -126,8 +129,7 @@ fn internal_ulid_at_millisecond(mut rng PRNG, unix_time_milli u64) string {
 		t = t >> 5
 		i--
 	}
-	// first rand set
-	mut x := rng.u64()
+	mut x := rand_a
 	i = 10
 	for i < 19 {
 		unsafe {
@@ -136,8 +138,7 @@ fn internal_ulid_at_millisecond(mut rng PRNG, unix_time_milli u64) string {
 		x = x >> 5
 		i++
 	}
-	// second rand set
-	x = rng.u64()
+	x = rand_b
 	for i < 26 {
 		unsafe {
 			buf[i] = ulid_encoding[int(x & 0x1F)]
@@ -149,6 +150,28 @@ fn internal_ulid_at_millisecond(mut rng PRNG, unix_time_milli u64) string {
 		buf[26] = 0
 		return buf.vstring_with_len(buflen)
 	}
+}
+
+@[direct_array_access]
+fn internal_ulid_at_millisecond(mut rng PRNG, unix_time_milli u64) string {
+	return internal_ulid_format(unix_time_milli, rng.u64(), rng.u64())
+}
+
+// ulid generates a unique lexicographically sortable identifier whose
+// 80 random bits are sourced from the OS CSPRNG (see `crypto.rand.read`).
+// See https://github.com/ulid/spec .
+// Note: ULIDs can leak timing information, if you make them public, because
+// you can infer the rate at which some resource is being created, like
+// users or business transactions.
+// (https://news.ycombinator.com/item?id=14526173)
+pub fn ulid() string {
+	return ulid_at_millisecond(u64(time.utc().unix_milli()))
+}
+
+// ulid_at_millisecond does the same as `ulid` but takes a custom Unix millisecond timestamp via `unix_milli`.
+pub fn ulid_at_millisecond(unix_time_milli u64) string {
+	rand_a, rand_b := csprng_u64_pair()
+	return internal_ulid_format(unix_time_milli, rand_a, rand_b)
 }
 
 @[direct_array_access]

--- a/vlib/rand/rand.js.v
+++ b/vlib/rand/rand.js.v
@@ -64,3 +64,18 @@ fn read_internal(mut rng PRNG, mut buf []u8) {
 		buf[i] = rng.u8()
 	}
 }
+
+// ulid generates an unique lexicographically sortable identifier.
+// See https://github.com/ulid/spec .
+// Note: ULIDs can leak timing information, if you make them public, because
+// you can infer the rate at which some resource is being created, like
+// users or business transactions.
+// (https://news.ycombinator.com/item?id=14526173)
+pub fn ulid() string {
+	return default_rng.ulid()
+}
+
+// ulid_at_millisecond does the same as `ulid` but takes a custom Unix millisecond timestamp via `unix_milli`.
+pub fn ulid_at_millisecond(unix_time_milli u64) string {
+	return default_rng.ulid_at_millisecond(unix_time_milli)
+}

--- a/vlib/rand/rand.v
+++ b/vlib/rand/rand.v
@@ -710,21 +710,6 @@ const english_letters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 const hex_chars = '0123456789abcdef'
 const ascii_chars = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\^_`abcdefghijklmnopqrstuvwxyz{|}~'
 
-// ulid generates an unique lexicographically sortable identifier.
-// See https://github.com/ulid/spec .
-// Note: ULIDs can leak timing information, if you make them public, because
-// you can infer the rate at which some resource is being created, like
-// users or business transactions.
-// (https://news.ycombinator.com/item?id=14526173)
-pub fn ulid() string {
-	return default_rng.ulid()
-}
-
-// ulid_at_millisecond does the same as `ulid` but takes a custom Unix millisecond timestamp via `unix_milli`.
-pub fn ulid_at_millisecond(unix_time_milli u64) string {
-	return default_rng.ulid_at_millisecond(unix_time_milli)
-}
-
 // string_from_set returns a string of length `len` containing random characters sampled from the given `charset`.
 pub fn string_from_set(charset string, len int) string {
 	return default_rng.string_from_set(charset, len)

--- a/vlib/v/gen/c/testdata/struct_field_result_init.vv
+++ b/vlib/v/gen/c/testdata/struct_field_result_init.vv
@@ -1,6 +1,6 @@
 import math
 import math.big { Integer }
-import crypto.rand
+import crypto.rand.bigint
 
 struct SSS {
 mut:
@@ -11,7 +11,7 @@ mut:
 fn (s SSS) random() !Integer {
 	mut result := big.zero_int + s.prime
 	result = result - big.one_int
-	return rand.int_big(result)
+	return bigint.int_big(result)
 }
 
 // mod_inverse computes the multiplicative inverse of the number on the field


### PR DESCRIPTION
The high-level identifier generators in `vlib/rand/` (`uuid_v4`, `uuid_v7`, `UUIDSession.next`, `ulid` and `ulid_at_millisecond`) currently draw their random bits from `default_rng`, which is a `WyRandRNG` — a fast non-cryptographic PRNG seeded from the current time. This PR routes those bits through `crypto.rand.read` instead, i.e. through the OS CSPRNG (`getrandom` on Linux, `getentropy` on macOS/BSD, `BCryptGenRandom` on Windows), without changing the public API or the produced format.

Importing `crypto.rand` from `vlib/rand/` would normally introduce an import cycle (`crypto.rand` used to depend on `math.big` and `encoding.binary`, both of which transitively depend on `rand` via test files or `sync`). The first commit breaks that cycle by trimming `crypto.rand`'s own dependencies — see *Commits* below.

## Motivation

These identifiers are routinely used as session IDs, request IDs, file boundaries, primary keys and cache keys (see e.g. `vlib/veb/auth/auth.v`, `vlib/veb/request_id`, `vlib/net/websocket`, `vlib/net/http/request.v`, `vlib/v/pref/pref.v`). In those contexts, unpredictability matters: a non-CSPRNG default lets an attacker who observes a few IDs reconstruct the PRNG state and predict subsequent ones.

Each of the relevant specifications already points in this direction:

- **UUIDv4 — RFC 4122 (2005)** defines v4 in §4.4 and points to §4.5 for random-number sourcing, which recommends a *"cryptographic quality random number"* and cites RFC 1750 / **RFC 4086** (*"Randomness Requirements for Security"*) for the underlying guidance.
- **UUIDv7 — RFC 9562** (the RFC that defines v7) inherits the same guidance for the `rand_a` and `rand_b` fields.
- **ULID — `ulid/spec`** is the most explicit: *"If no cryptographically secure random number generator is available, ULIDs should not be generated."*

The major ecosystems all default to a CSPRNG.

## Commits

The PR is three commits, bisect-clean (each one builds and passes its relevant tests on its own):

1. **`crypto.rand: split int_big into crypto.rand.bigint sub-module`** — moves `int_big()` (the only function in `crypto.rand` that needs `math.big`) into a new `crypto.rand.bigint` sub-module, and inlines the single `encoding.binary.big_endian_u64` call so `crypto.rand` no longer depends on `encoding.binary` either. **Breaking change**: callers of `crypto.rand.int_big` need to switch to `crypto.rand.bigint.int_big`. Inside vlib that's a single testdata file (`vlib/v/gen/c/testdata/struct_field_result_init.vv`), updated in the same commit. `crypto.rand.int_u64` stays where it is.
2. **`rand: use OS CSPRNG for uuid_v4, uuid_v7 and UUIDSession`** — the actual switch for the three UUID-family functions.
3. **`rand: use OS CSPRNG for ulid and ulid_at_millisecond`** — same for `ulid`. On the C backend the convenience functions now go through the CSPRNG; on the JS backend they keep the previous behaviour byte-for-byte.

## Changes per file

### `vlib/crypto/rand/utils.v`

- Drop `import math.big` and `import encoding.binary`.
- Inline the one `binary.big_endian_u64` call (3 lines).
- Remove `int_big()` (moved to the new sub-module).

### `vlib/crypto/rand/bigint/bigint.v`

- New module `crypto.rand.bigint`. Contains `pub fn int_big(n big.Integer) !big.Integer`. Imports `crypto.rand` and `math.big`.

### `vlib/crypto/rand/bigint/bigint_test.v`

- The previous `utils_test.v` content, renamed and re-pointed to `bigint.int_big`.

### `vlib/v/gen/c/testdata/struct_field_result_init.vv`

- One-line update: `rand.int_big(result)` → `bigint.int_big(result)`.

### `vlib/rand/rand.c.v`

- Add a private helper `csprng_u64_pair()` returning 16 bytes of OS CSPRNG output as two big-endian `u64`s. If `crypto.rand.read` returns a `ReadError` (OS entropy source unavailable), the helper panics rather than falling back to a non-cryptographic generator, which would defeat the guarantee.
- Switch `uuid_v4`, `uuid_v7` and `UUIDSession.next` to consume that helper instead of `default_rng.u64()` / `default_rng.u16()`.
- Extract a pure formatter `internal_ulid_format(time, rand_a, rand_b)` from `internal_ulid_at_millisecond`. The PRNG-based method is unchanged (it's a one-line wrapper around the formatter), and the new module-level convenience `ulid()` / `ulid_at_millisecond()` reuse the same formatter with `csprng_u64_pair()` as the random source.

### `vlib/rand/rand.v`

- Remove the convenience `pub fn ulid()` and `pub fn ulid_at_millisecond()` that used to delegate to `default_rng`. They move to the backend-specific files so that each backend can pick its own entropy source. The method forms `(mut rng PRNG) ulid()` / `(mut rng PRNG) ulid_at_millisecond()` stay where they are — they are explicit opt-in and untouched.

### `vlib/rand/rand.js.v`

- Add `pub fn ulid()` and `pub fn ulid_at_millisecond()` that delegate to `default_rng`. This preserves the current JS-backend behaviour byte-for-byte. Bringing a CSPRNG to the JS backend (via `crypto.getRandomValues` or `crypto.randomBytes`) is a separate question and is intentionally out of scope.

## API and behaviour

- **Public API is unchanged.** All function signatures (`fn () string`) and produced formats (36-char dashed UUID, 26-char Crockford Base32 ULID) are identical.
- **JS backend behaviour is unchanged.** ULID on the JS backend continues to go through `default_rng` exactly as before.
- **Method APIs are unchanged.** `(mut rng PRNG) ulid()` still draws from the user-provided PRNG. The opt-in path is preserved.

A future optimisation would be to amortise the syscall via a userspace entropy buffer (as other implementations do — one syscall every 128 UUIDs). That is intentionally **not** part of this PR: it raises its own questions (thread-safety, zeroising consumed bytes, fork handling) and deserves a dedicated discussion. The current change is the smallest one that brings V in line with the spec recommendations.

## Additional notes

- **`panic` on CSPRNG failure.** Changing `uuid_v4` to return `!string` would break a lot of call sites, including code that uses it as a function pointer of type `fn () string` (e.g. `veb/request_id`). `crypto.rand.read` already exposes an unrecoverable `ReadError` when the OS entropy source fails; the UUID/ULID layer simply elevates that to a `panic` rather than silently degrading to a non-cryptographic source, which would defeat the whole point.
- **No drive-by changes.** The two pre-existing `v vet` warnings in `rand.v` (`i32_in_range`, `f64cp` doc comments) are left untouched.