### PR TITLE
Update checker fixture outputs

### DIFF
--- a/vlib/v/checker/tests/assign_immutable_reference_call_result_err.out
+++ b/vlib/v/checker/tests/assign_immutable_reference_call_result_err.out
@@ -1,13 +1,13 @@
-vlib/v/checker/tests/assign_immutable_reference_call_result_err.vv:15:16: notice: `ja` is immutable, cannot have a mutable reference to an immutable object
-   13 | fn main() {
-   14 |     ja := User{name: 'foo'}
-   15 |     mut x := rere(ja)
+vlib/v/checker/tests/assign_immutable_reference_call_result_err.vv:17:16: notice: `ja` is immutable, cannot have a mutable reference to an immutable object
+   15 |         name: 'foo'
+   16 |     }
+   17 |     mut x := rere(ja)
       |                   ~~
-   16 |     x.name = 'bar'
-   17 | }
-vlib/v/checker/tests/assign_immutable_reference_call_result_err.vv:16:4: error: `x.name` aliases mutable data from an immutable value
-   14 |     ja := User{name: 'foo'}
-   15 |     mut x := rere(ja)
-   16 |     x.name = 'bar'
+   18 |     x.name = 'bar'
+   19 | }
+vlib/v/checker/tests/assign_immutable_reference_call_result_err.vv:18:4: error: `x.name` aliases mutable data from an immutable value
+   16 |     }
+   17 |     mut x := rere(ja)
+   18 |     x.name = 'bar'
       |       ~~~~
-   17 | }
+   19 | }

--- a/vlib/v/checker/tests/fixed_array_new_syntax_size_mismatch_err.out
+++ b/vlib/v/checker/tests/fixed_array_new_syntax_size_mismatch_err.out
@@ -1,5 +1,5 @@
 vlib/v/checker/tests/fixed_array_new_syntax_size_mismatch_err.vv:2:13: error: fixed array expects 2 value(s), but got 3
     1 | fn main() {
-    2 |     _ := [2]int[1 2 3]
-      |                ~~~~~~~
+    2 |     _ := [2]int[1, 2, 3]
+      |                ~~~~~~~~~
     3 | }

--- a/vlib/v/checker/tests/if_smartcast_mutation_err.out
+++ b/vlib/v/checker/tests/if_smartcast_mutation_err.out
@@ -1,7 +1,7 @@
-vlib/v/checker/tests/if_smartcast_mutation_err.vv:5:3: error: cannot mutate `a` in a non-mut smartcast, use `if mut a ...`
-    3 |     a := SmartcastValue(1)
-    4 |     if a is int {
-    5 |         a = 3
+vlib/v/checker/tests/if_smartcast_mutation_err.vv:6:3: error: cannot mutate `a` in a non-mut smartcast, use `if mut a ...`
+    4 |     a := SmartcastValue(1)
+    5 |     if a is int {
+    6 |         a = 3
       |         ^
-    6 |     }
-    7 | }
+    7 |     }
+    8 | }

--- a/vlib/v/checker/tests/orm_dynamic_unknown_field_err.out
+++ b/vlib/v/checker/tests/orm_dynamic_unknown_field_err.out
@@ -2,7 +2,7 @@ vlib/v/checker/tests/orm_dynamic_unknown_field_err.vv:11:13: error: ORM: `User` 
 2 possibilities: `id`, `name`.
     9 |     db := sqlite.connect(':memory:') or { panic(err) }
    10 |     where_expr := {
-   11 |         if true { zzz == 'Alice' },
+   11 |         if true { zzz == 'Alice' }
       |                   ~~~
    12 |     }
    13 |     _ := sql db {

--- a/vlib/v/checker/tests/pool_processor_callback_array_return_err.out
+++ b/vlib/v/checker/tests/pool_processor_callback_array_return_err.out
@@ -1,7 +1,7 @@
 vlib/v/checker/tests/pool_processor_callback_array_return_err.vv:9:3: error: cannot assign to field `callback`: expected `fn (mut pool.PoolProcessor, int, int) voidptr`, not `fn (mut pool.PoolProcessor, int, int) []Foo`
     7 | fn main() {
     8 |     _ := pool.new_pool_processor(
-    9 |         callback: fn (mut pp pool.PoolProcessor, idx int, wid int) []Foo {
-      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    9 |         callback: fn (mut pp pool.PoolProcessor, idx int, wid int) []main.Foo {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    10 |             _ = wid
    11 |             return [Foo{


### PR DESCRIPTION
## Summary
- Regenerate checker `.out` expectations after the formatted error fixtures from #26859
- Keep this as an output-only follow-up because #26859 was merged before the review fix landed

## Tests
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `git diff --check HEAD~1..HEAD`