### PR TITLE
Makefile: fix compatibility with BSD make (or bmake on Linux)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,50 +2,21 @@ CC ?= cc
 VFLAGS ?=
 CFLAGS ?=
 LDFLAGS ?=
-BOOTSTRAP_CC_CFLAGS := $(strip $(CFLAGS))
-BOOTSTRAP_VC_CC_CFLAGS := $(BOOTSTRAP_CC_CFLAGS)
-BOOTSTRAP_VC_CFLAGS := $(BOOTSTRAP_CC_CFLAGS)
-BOOTSTRAP_CFLAGS := $(BOOTSTRAP_CC_CFLAGS)
-BOOTSTRAP_LDFLAGS := $(strip $(LDFLAGS))
-
-ifeq ($(shell uname -s 2>/dev/null),Linux)
-ifneq ($(filter arm%,$(shell uname -m 2>/dev/null)),)
-BOOTSTRAP_LDFLAGS := $(strip $(BOOTSTRAP_LDFLAGS) -latomic)
-endif
-ifneq ($(filter $(shell uname -m 2>/dev/null),arm64 aarch64),)
-BOOTSTRAP_VC_UNSAFE_OPTFLAGS := $(filter-out -O -O0 -O1,$(filter -O%,$(BOOTSTRAP_CC_CFLAGS)))
-ifneq ($(BOOTSTRAP_VC_UNSAFE_OPTFLAGS),)
-	# Some Linux ARM64 system compilers miscompile the external vc bootstrap
-	# snapshot at -O2/-O3, making `v1` segfault before it can build `v2`.
-	# Keep the bootstrap stages at -O1, but preserve the requested flags for
-	# the final `v` build.
-	BOOTSTRAP_VC_SAFE_CFLAGS := $(strip $(filter-out -O%,$(BOOTSTRAP_CC_CFLAGS)) -O1)
-	BOOTSTRAP_VC_CC_CFLAGS := $(BOOTSTRAP_VC_SAFE_CFLAGS)
-	BOOTSTRAP_VC_CFLAGS := $(BOOTSTRAP_VC_SAFE_CFLAGS)
-endif
-endif
-endif
-
-ifneq ($(filter $(shell uname -s 2>/dev/null),FreeBSD NetBSD OpenBSD),)
-BOOTSTRAP_LDFLAGS := $(strip $(BOOTSTRAP_LDFLAGS) -lexecinfo)
-endif
-
-BOOTSTRAP_VC_VFLAGS := $(if $(strip $(BOOTSTRAP_VC_CFLAGS)),-cflags "$(BOOTSTRAP_VC_CFLAGS)") $(if $(strip $(BOOTSTRAP_LDFLAGS)),-ldflags "$(BOOTSTRAP_LDFLAGS)")
-BOOTSTRAP_VFLAGS := $(if $(strip $(BOOTSTRAP_CFLAGS)),-cflags "$(BOOTSTRAP_CFLAGS)") $(if $(strip $(BOOTSTRAP_LDFLAGS)),-ldflags "$(BOOTSTRAP_LDFLAGS)")
-
-.PHONY: all check download_vc v
 
 all: download_vc v
 
+.PHONY: all check download_vc install v
+
 download_vc:
-	if [ -f vc/v.c ] ; then \
-		if command -v git >/dev/null 2>&1 ; then \
+	@set -e; \
+	if [ -f vc/v.c ]; then \
+		if command -v git >/dev/null 2>&1; then \
 			git -C vc/ pull --rebase; \
 		else \
 			echo "git not found; using existing vc/v.c"; \
 		fi; \
 	else \
-		if command -v git >/dev/null 2>&1 ; then \
+		if command -v git >/dev/null 2>&1; then \
 			git clone --filter=blob:none https://github.com/vlang/vc vc/; \
 		else \
 			echo "git is required to download vc/. Please install git or provide vc/v.c."; \
@@ -54,13 +25,73 @@ download_vc:
 	fi
 
 v:
-	$(CC) $(BOOTSTRAP_VC_CC_CFLAGS) -std=gnu11 -w -o v1 vc/v.c -lm -lpthread $(BOOTSTRAP_LDFLAGS) || cmd/tools/cc_compilation_failed_non_windows.sh
-	./v1 -no-parallel -o v2 $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
-	./v2 -o v $(VFLAGS) $(BOOTSTRAP_VFLAGS) cmd/v
-	rm -rf v1 v2
-	./v run ./cmd/tools/detect_tcc.v
-	@echo "V has been successfully built"
-	./v version
+	@set -e; \
+	sys=`uname -s 2>/dev/null || echo Unknown`; \
+	arch=`uname -m 2>/dev/null || echo unknown`; \
+	set -- $(CFLAGS); \
+	ccflags=; \
+	unsafe_o=0; \
+	for arg do \
+		case "$$arg" in \
+			-O|-O0|-O1) \
+				ccflags="$$ccflags $$arg"; \
+				;; \
+			-O*) \
+				unsafe_o=1; \
+				;; \
+			*) \
+				ccflags="$$ccflags $$arg"; \
+				;; \
+		esac; \
+	done; \
+	ccflags=$${ccflags# }; \
+	if [ $$unsafe_o -eq 1 ]; then \
+		ccflags="$$ccflags -O1"; \
+		ccflags=$${ccflags# }; \
+	fi; \
+	set -- $(LDFLAGS); \
+	ldflags=; \
+	for arg do \
+		ldflags="$$ldflags $$arg"; \
+	done; \
+	ldflags=$${ldflags# }; \
+	case "$$sys" in \
+		Linux) \
+			case "$$arch" in \
+				arm*) \
+					ldflags="$$ldflags -latomic"; \
+					;; \
+			esac; \
+			;; \
+		FreeBSD|NetBSD|OpenBSD) \
+			ldflags="$$ldflags -lexecinfo"; \
+			;; \
+	esac; \
+	ccflags=$${ccflags# }; \
+	ldflags=$${ldflags# }; \
+	$(CC) $$ccflags -std=gnu11 -w -o v1 vc/v.c -lm -lpthread $$ldflags || cmd/tools/cc_compilation_failed_non_windows.sh; \
+	set -- ./v1 -no-parallel -o v2 $(VFLAGS); \
+	if [ -n "$$ccflags" ]; then \
+		set -- "$$@" -cflags "$$ccflags"; \
+	fi; \
+	if [ -n "$$ldflags" ]; then \
+		set -- "$$@" -ldflags "$$ldflags"; \
+	fi; \
+	set -- "$$@" cmd/v; \
+	"$$@"; \
+	set -- ./v2 -o v $(VFLAGS); \
+	if [ -n "$$ccflags" ]; then \
+		set -- "$$@" -cflags "$$ccflags"; \
+	fi; \
+	if [ -n "$$ldflags" ]; then \
+		set -- "$$@" -ldflags "$$ldflags"; \
+	fi; \
+	set -- "$$@" cmd/v; \
+	"$$@"; \
+	rm -rf v1 v2; \
+	./v run ./cmd/tools/detect_tcc.v; \
+	echo "V has been successfully built"; \
+	./v version; \
 	./v run .github/problem-matchers/register_all.vsh
 
 check:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ download_vc:
 
 v:
 	@set -e; \
-	sys=`uname -s 2>/dev/null || echo Unknown`; \
+	sys=`uname -s 2>/dev/null || echo unknown`; \
 	arch=`uname -m 2>/dev/null || echo unknown`; \
 	set -- $(CFLAGS); \
 	ccflags=; \

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ v:
 				ccflags="$$ccflags $$arg"; \
 				;; \
 			-O*) \
+				ccflags="$$ccflags $$arg"; \
 				unsafe_o=1; \
 				;; \
 			*) \
@@ -45,10 +46,7 @@ v:
 		esac; \
 	done; \
 	ccflags=$${ccflags# }; \
-	if [ $$unsafe_o -eq 1 ]; then \
-		ccflags="$$ccflags -O1"; \
-		ccflags=$${ccflags# }; \
-	fi; \
+	bootstrap_ccflags=$$ccflags; \
 	set -- $(LDFLAGS); \
 	ldflags=; \
 	for arg do \
@@ -69,10 +67,34 @@ v:
 	esac; \
 	ccflags=$${ccflags# }; \
 	ldflags=$${ldflags# }; \
-	$(CC) $$ccflags -std=gnu11 -w -o v1 vc/v.c -lm -lpthread $$ldflags || cmd/tools/cc_compilation_failed_non_windows.sh; \
+	if [ "$$sys" = Linux ]; then \
+		case "$$arch" in \
+			arm64|aarch64) \
+				if [ $$unsafe_o -eq 1 ]; then \
+					set -- $$ccflags; \
+					bootstrap_ccflags=; \
+					for arg do \
+						case "$$arg" in \
+							-O|-O0|-O1) \
+								bootstrap_ccflags="$$bootstrap_ccflags $$arg"; \
+								;; \
+							-O*) \
+								bootstrap_ccflags="$$bootstrap_ccflags -O1"; \
+								;; \
+							*) \
+								bootstrap_ccflags="$$bootstrap_ccflags $$arg"; \
+								;; \
+						esac; \
+					done; \
+					bootstrap_ccflags=$${bootstrap_ccflags# }; \
+				fi; \
+				;; \
+		esac; \
+	fi; \
+	$(CC) $$bootstrap_ccflags -std=gnu11 -w -o v1 vc/v.c -lm -lpthread $$ldflags || cmd/tools/cc_compilation_failed_non_windows.sh; \
 	set -- ./v1 -no-parallel -o v2 $(VFLAGS); \
-	if [ -n "$$ccflags" ]; then \
-		set -- "$$@" -cflags "$$ccflags"; \
+	if [ -n "$$bootstrap_ccflags" ]; then \
+		set -- "$$@" -cflags "$$bootstrap_ccflags"; \
 	fi; \
 	if [ -n "$$ldflags" ]; then \
 		set -- "$$@" -ldflags "$$ldflags"; \

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -255,7 +255,7 @@ fn get_make_cmd_name() string {
 	if os.user_os() == 'windows' {
 		return 'makev.bat'
 	}
-	if gmake := os.find_abs_path_of_executable('gmake') {
+	if _ := os.find_abs_path_of_executable('gmake') {
 		return 'gmake'
 	}
 	cmd := 'make'

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -255,6 +255,9 @@ fn get_make_cmd_name() string {
 	if os.user_os() == 'windows' {
 		return 'makev.bat'
 	}
+	if gmake := os.find_abs_path_of_executable('gmake') {
+		return 'gmake'
+	}
 	cmd := 'make'
 	make_sure_cmd_is_available(cmd)
 	cc := os.getenv_opt('CC') or { 'cc' }

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -255,9 +255,6 @@ fn get_make_cmd_name() string {
 	if os.user_os() == 'windows' {
 		return 'makev.bat'
 	}
-	if _ := os.find_abs_path_of_executable('gmake') {
-		return 'gmake'
-	}
 	cmd := 'make'
 	make_sure_cmd_is_available(cmd)
 	cc := os.getenv_opt('CC') or { 'cc' }


### PR DESCRIPTION
Previously:
```
0[12:12:03]vfast@freebsd: (master) /usr/home/vfast/code/v $ make
make: "/usr/home/vfast/code/v/Makefile" line 11: Invalid line type
make: "/usr/home/vfast/code/v/Makefile" line 12: Invalid line type
make: "/usr/home/vfast/code/v/Makefile" line 14: Invalid line type
make: "/usr/home/vfast/code/v/Makefile" line 15: Invalid line type
make: "/usr/home/vfast/code/v/Makefile" line 17: Invalid line type
make: "/usr/home/vfast/code/v/Makefile" line 25: Invalid line type
make: "/usr/home/vfast/code/v/Makefile" line 26: Invalid line type
make: "/usr/home/vfast/code/v/Makefile" line 27: Invalid line type
make: "/usr/home/vfast/code/v/Makefile" line 29: Invalid line type
make: "/usr/home/vfast/code/v/Makefile" line 31: Invalid line type
make: Fatal errors encountered -- cannot continue
make: stopped in /usr/home/vfast/code/v
1[12:12:05]vfast@freebsd: (master) /usr/home/vfast/code/v $
```
After (edited to show the final version, after the additional commits/cleanups):
```
0[13:08:34]vfast@freebsd: (master) /usr/home/vfast/code/v $ make
Already up to date.
Your `tcc` is working. Good - it is much faster at compiling C source code.
V has been successfully built
V 0.5.1 88fbefb
0[13:12:42]vfast@freebsd: (master) /usr/home/vfast/code/v $
```