### PR TITLE
stdatomic: Remove unused aarch64_cas functions

### DIFF
--- a/thirdparty/stdatomic/nix/atomic.h
+++ b/thirdparty/stdatomic/nix/atomic.h
@@ -508,14 +508,6 @@ extern inline unsigned long long __aarch64_ldeor8_acq_rel(unsigned long long*ptr
     );
 }
 
-#define aarch64_cas_acq_rel(ptr, expected, desired)      \
-    _Generic((ptr),                                      \
-        char*:         __aarch64_cas1_acq_rel,  \
-        short*:        __aarch64_cas2_acq_rel,  \
-        int*:          __aarch64_cas4_acq_rel,  \
-        long long*:    __aarch64_cas8_acq_rel   \
-    )(ptr, expected, desired)
-
 // relax version
 extern inline _Bool __aarch64_cas1_relax(unsigned char*ptr, unsigned char*expected, unsigned char desired) {
     return __atomic_compare_exchange_1(
@@ -716,14 +708,6 @@ extern inline unsigned long long __aarch64_ldeor8_relax(unsigned long long*ptr, 
         memory_order_relaxed
     );
 }
-
-#define aarch64_cas_relax(ptr, expected, desired)      \
-    _Generic((ptr),                                      \
-        char*:         __aarch64_cas1_relax,  \
-        short*:        __aarch64_cas2_relax,  \
-        int*:          __aarch64_cas4_relax,  \
-        long long*:    __aarch64_cas8_relax   \
-    )(ptr, expected, desired)
 
 #endif // __aarch64__
 


### PR DESCRIPTION
Remove macros aarch64_cas_acq_rel() and aarch64_cas_relax(). These macros should be removed because there is no code that actually calls them. They also depend on the c11 feature "_Generic" which prevents v from being compiled using a c99 compiler. 