### PR TITLE
ci: update cross-platform-actions/action to v1.1.0 for BSD CI

### DIFF
--- a/.github/workflows/freebsd_ci.yml
+++ b/.github/workflows/freebsd_ci.yml
@@ -28,105 +28,120 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - name: Tests on FreeBSD with tcc
-        id: tests-freebsd-tcc
-        uses: cross-platform-actions/action@v1.0.0
+
+      - name: Start FreeBSD VM for tcc
+        id: vm-freebsd-tcc
+        uses: cross-platform-actions/action@v1.1.0
         with:
           operating_system: freebsd
           version: '15.0'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
-          run: |
-            sudo pkg install -y git sqlite3 gmake boehm-gc-threaded libiconv
-            # Install DB packages needed to build examples
-            sudo pkg install -y mariadb118-client postgresql18-client
-            # Install packages needed by Sokol to build examples
-            sudo pkg install -y alsa-lib libglvnd libXi libXcursor
-            # Mandatory: hostname not set in VM => some tests fail
-            sudo hostname -s freebsd-ci
-            echo "::group::OS infos"
-            uname -a
-            echo "::endgroup::"
-            echo "::group::Build V"
-            git config --global --add safe.directory .
-            gmake
-            sudo ./v symlink
-            export VTEST_SHOW_LONGEST_BY_RUNTIME=3
-            export VTEST_SHOW_LONGEST_BY_COMPTIME=3
-            export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
-            export VFLAGS='-cc tcc -no-retry-compilation'
-            echo "::endgroup::"
-            ./v run ci/freebsd_ci.vsh all
+
+      - name: Tests on FreeBSD with tcc
+        id: tests-freebsd-tcc
+        shell: cpa.sh {0}
+        run: |
+          sudo pkg install -y git sqlite3 gmake boehm-gc-threaded libiconv
+          # Install DB packages needed to build examples
+          sudo pkg install -y mariadb118-client postgresql18-client
+          # Install packages needed by Sokol to build examples
+          sudo pkg install -y alsa-lib libglvnd libXi libXcursor
+          # Mandatory: hostname not set in VM => some tests fail
+          sudo hostname -s freebsd-ci
+          echo "::group::OS infos"
+          uname -a
+          echo "::endgroup::"
+          echo "::group::Build V"
+          git config --global --add safe.directory .
+          gmake
+          sudo ./v symlink
+          export VTEST_SHOW_LONGEST_BY_RUNTIME=3
+          export VTEST_SHOW_LONGEST_BY_COMPTIME=3
+          export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
+          export VFLAGS='-cc tcc -no-retry-compilation'
+          echo "::endgroup::"
+          ./v run ci/freebsd_ci.vsh all
 
   clang-freebsd:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - name: Tests on FreeBSD with clang
-        id: tests-freebsd-clang
-        uses: cross-platform-actions/action@v1.0.0
+
+      - name: Start FreeBSD VM for clang
+        id: vm-freebsd-clang
+        uses: cross-platform-actions/action@v1.1.0
         with:
           operating_system: freebsd
           version: '15.0'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
-          run: |
-            sudo pkg install -y git sqlite3 gmake boehm-gc-threaded libiconv
-            # Install DB packages needed to build examples
-            sudo pkg install -y mariadb118-client postgresql18-client
-            # Install packages needed by Sokol to build examples
-            sudo pkg install -y alsa-lib libglvnd libXi libXcursor
-            # Mandatory: hostname not set in VM => some tests fail
-            sudo hostname -s freebsd-ci
-            echo "::group::OS infos"
-            uname -a
-            echo "::endgroup::"
-            echo "::group::Build V"
-            git config --global --add safe.directory .
-            gmake
-            sudo ./v symlink
-            export VTEST_SHOW_LONGEST_BY_RUNTIME=3
-            export VTEST_SHOW_LONGEST_BY_COMPTIME=3
-            export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
-            export VFLAGS='-cc clang'
-            echo "::endgroup::"
-            ./v run ci/freebsd_ci.vsh all
+
+      - name: Tests on FreeBSD with clang
+        id: tests-freebsd-clang
+        shell: cpa.sh {0}
+        run: |
+          sudo pkg install -y git sqlite3 gmake boehm-gc-threaded libiconv
+          # Install DB packages needed to build examples
+          sudo pkg install -y mariadb118-client postgresql18-client
+          # Install packages needed by Sokol to build examples
+          sudo pkg install -y alsa-lib libglvnd libXi libXcursor
+          # Mandatory: hostname not set in VM => some tests fail
+          sudo hostname -s freebsd-ci
+          echo "::group::OS infos"
+          uname -a
+          echo "::endgroup::"
+          echo "::group::Build V"
+          git config --global --add safe.directory .
+          gmake
+          sudo ./v symlink
+          export VTEST_SHOW_LONGEST_BY_RUNTIME=3
+          export VTEST_SHOW_LONGEST_BY_COMPTIME=3
+          export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
+          export VFLAGS='-cc clang'
+          echo "::endgroup::"
+          ./v run ci/freebsd_ci.vsh all
 
   gcc-freebsd:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - name: Tests on FreeBSD with gcc
-        id: tests-freebsd-gcc
-        uses: cross-platform-actions/action@v1.0.0
+
+      - name: Start FreeBSD VM for gcc
+        id: vm-freebsd-gcc
+        uses: cross-platform-actions/action@v1.1.0
         with:
           operating_system: freebsd
           version: '15.0'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
-          run: |
-            sudo pkg install -y git sqlite3 gmake boehm-gc-threaded libiconv gcc
-            # Install DB packages needed to build examples
-            sudo pkg install -y mariadb118-client postgresql18-client
-            # Install packages needed by Sokol to build examples
-            sudo pkg install -y alsa-lib libglvnd libXi libXcursor
-            # Mandatory: hostname not set in VM => some tests fail
-            sudo hostname -s freebsd-ci
-            echo "::group::OS infos"
-            uname -a
-            echo "::endgroup::"
-            echo "::group::Build V"
-            git config --global --add safe.directory .
-            gmake
-            sudo ./v symlink
-            export VTEST_SHOW_LONGEST_BY_RUNTIME=3
-            export VTEST_SHOW_LONGEST_BY_COMPTIME=3
-            export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
-            export VFLAGS='-cc gcc'
-            echo "::endgroup::"
-            ./v run ci/freebsd_ci.vsh all
+
+      - name: Tests on FreeBSD with gcc
+        id: tests-freebsd-gcc
+        shell: cpa.sh {0}
+        run: |
+          sudo pkg install -y git sqlite3 gmake boehm-gc-threaded libiconv gcc
+          # Install DB packages needed to build examples
+          sudo pkg install -y mariadb118-client postgresql18-client
+          # Install packages needed by Sokol to build examples
+          sudo pkg install -y alsa-lib libglvnd libXi libXcursor
+          # Mandatory: hostname not set in VM => some tests fail
+          sudo hostname -s freebsd-ci
+          echo "::group::OS infos"
+          uname -a
+          echo "::endgroup::"
+          echo "::group::Build V"
+          git config --global --add safe.directory .
+          gmake
+          sudo ./v symlink
+          export VTEST_SHOW_LONGEST_BY_RUNTIME=3
+          export VTEST_SHOW_LONGEST_BY_COMPTIME=3
+          export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
+          export VFLAGS='-cc gcc'
+          echo "::endgroup::"
+          ./v run ci/freebsd_ci.vsh all

--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -28,66 +28,74 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - name: Tests on OpenBSD with tcc
-        id: tests-openbsd-tcc
-        uses: cross-platform-actions/action@v1.0.0
+
+      - name: Start OpenBSD VM for tcc
+        id: vm-openbsd-tcc
+        uses: cross-platform-actions/action@v1.1.0
         with:
           operating_system: openbsd
           version: '7.8'
           memory: 4G
-          shell: sh
           sync_files: runner-to-vm
-          run: |
-            sudo pkg_add git sqlite3 gmake boehm-gc libiconv
-            # Install packages needed to build examples
-            sudo pkg_add mariadb-client postgresql-client
-            # Mandatory: hostname not set in VM => some tests fail
-            sudo hostname -s openbsd-ci
-            echo "::group::OS infos"
-            uname -a
-            echo "::endgroup::"
-            echo "::group::Build V"
-            git config --global --add safe.directory .
-            gmake
-            sudo ./v symlink
-            export VTEST_SHOW_LONGEST_BY_RUNTIME=3
-            export VTEST_SHOW_LONGEST_BY_COMPTIME=3
-            export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
-            export VFLAGS='-cc tcc -no-retry-compilation'
-            echo "::endgroup::"
-            ./v run ci/openbsd_ci.vsh all
+
+      - name: Tests on OpenBSD with tcc
+        id: tests-openbsd-tcc
+        shell: cpa.sh {0}
+        run: |
+          sudo pkg_add git sqlite3 gmake boehm-gc libiconv
+          # Install packages needed to build examples
+          sudo pkg_add mariadb-client postgresql-client
+          # Mandatory: hostname not set in VM => some tests fail
+          sudo hostname -s openbsd-ci
+          echo "::group::OS infos"
+          uname -a
+          echo "::endgroup::"
+          echo "::group::Build V"
+          git config --global --add safe.directory .
+          gmake
+          sudo ./v symlink
+          export VTEST_SHOW_LONGEST_BY_RUNTIME=3
+          export VTEST_SHOW_LONGEST_BY_COMPTIME=3
+          export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
+          export VFLAGS='-cc tcc -no-retry-compilation'
+          echo "::endgroup::"
+          ./v run ci/openbsd_ci.vsh all
 
   clang-openbsd:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - name: Tests on OpenBSD with clang
-        id: tests-openbsd-clang
-        uses: cross-platform-actions/action@v1.0.0
+
+      - name: Start OpenBSD VM for clang
+        id: vm-openbsd-clang
+        uses: cross-platform-actions/action@v1.1.0
         with:
           operating_system: openbsd
           version: '7.8'
           memory: 4G
-          shell: sh
           sync_files: runner-to-vm
-          run: |
-            sudo pkg_add git sqlite3 gmake boehm-gc libiconv
-            # Install packages needed to build examples
-            sudo pkg_add mariadb-client postgresql-client
-            # Mandatory: hostname not set in VM => some tests fail
-            sudo hostname -s openbsd-ci
-            echo "::group::OS infos"
-            uname -a
-            clang -v
-            echo "::endgroup::"
-            echo "::group::Build V"
-            git config --global --add safe.directory .
-            gmake
-            sudo ./v symlink
-            export VTEST_SHOW_LONGEST_BY_RUNTIME=3
-            export VTEST_SHOW_LONGEST_BY_COMPTIME=3
-            export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
-            export VFLAGS='-cc clang'
-            echo "::endgroup::"
-            ./v run ci/openbsd_ci.vsh all
+
+      - name: Tests on OpenBSD with clang
+        id: tests-openbsd-clang
+        shell: cpa.sh {0}
+        run: |
+          sudo pkg_add git sqlite3 gmake boehm-gc libiconv
+          # Install packages needed to build examples
+          sudo pkg_add mariadb-client postgresql-client
+          # Mandatory: hostname not set in VM => some tests fail
+          sudo hostname -s openbsd-ci
+          echo "::group::OS infos"
+          uname -a
+          clang -v
+          echo "::endgroup::"
+          echo "::group::Build V"
+          git config --global --add safe.directory .
+          gmake
+          sudo ./v symlink
+          export VTEST_SHOW_LONGEST_BY_RUNTIME=3
+          export VTEST_SHOW_LONGEST_BY_COMPTIME=3
+          export VTEST_SHOW_LONGEST_BY_TOTALTIME=3
+          export VFLAGS='-cc clang'
+          echo "::endgroup::"
+          ./v run ci/openbsd_ci.vsh all

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -146,8 +146,9 @@ jobs:
       VFLAGS: -cc ${{ matrix.cc }}
     steps:
       - uses: actions/checkout@v6
-      - name: Tests tools on FreeBSD with ${{ matrix.cc }}
-        uses: cross-platform-actions/action@v1.0.0
+
+      - name: Start FreeBSD VM with ${{ matrix.cc }}
+        uses: cross-platform-actions/action@v1.1.0
         with:
           operating_system: freebsd
           version: '15.0'
@@ -155,43 +156,46 @@ jobs:
           shell: sh
           sync_files: runner-to-vm
           environment_variables: VFLAGS
-          run: |
-            sudo pkg install -y git sqlite3 gmake boehm-gc-threaded libiconv
-            if [ "$VFLAGS" = "-cc gcc" ]; then
-              sudo pkg install -y gcc
-            fi
-            # Mandatory: hostname not set in VM => some tests fail
-            sudo hostname -s freebsd-ci
-            echo "::group::OS infos"
-            uname -a
+
+      - name: Tests tools on FreeBSD with ${{ matrix.cc }}
+        shell: cpa.sh {0}
+        run: |
+          sudo pkg install -y git sqlite3 gmake boehm-gc-threaded libiconv
+          if [ "$VFLAGS" = "-cc gcc" ]; then
+            sudo pkg install -y gcc
+          fi
+          # Mandatory: hostname not set in VM => some tests fail
+          sudo hostname -s freebsd-ci
+          echo "::group::OS infos"
+          uname -a
+          echo "::endgroup::"
+          # Build V
+          echo "::group::Build V"
+          git config --global --add safe.directory .
+          printf "VFLAGS = %s\n" "$VFLAGS"
+          gmake && ./v -showcc -o v cmd/v && sudo ./v symlink
+          echo "::endgroup::"
+          echo "::group::v doctor"
+          ./v doctor
+          echo "::endgroup::"
+          # Code in cmd/ is formatted
+          echo "::group::Check code in cmd/ is formatted"
+          ./v fmt -verify cmd/
+          echo "::endgroup::"
+          # Check build-tools
+          echo "::group::Check build tools"
+          ./v -silent -N -W -check build-tools
+          echo "::endgroup::"
+          # Test tools
+          echo "::group::Test tools"
+          ./v -silent test-self cmd
+          echo "::endgroup::"
+          # Test tools (-cstrict)
+          if [ "$VFLAGS" != "-cc tcc" ]; then
+            echo "::group::Test tools (-cstrict)"
+            ./v -silent -W -cstrict test-self cmd
             echo "::endgroup::"
-            # Build V
-            echo "::group::Build V"
-            git config --global --add safe.directory .
-            printf "VFLAGS = %s\n" "$VFLAGS"
-            gmake && ./v -showcc -o v cmd/v && sudo ./v symlink
-            echo "::endgroup::"
-            echo "::group::v doctor"
-            ./v doctor
-            echo "::endgroup::"
-            # Code in cmd/ is formatted
-            echo "::group::Check code in cmd/ is formatted"
-            ./v fmt -verify cmd/
-            echo "::endgroup::"
-            # Check build-tools
-            echo "::group::Check build tools"
-            ./v -silent -N -W -check build-tools
-            echo "::endgroup::"
-            # Test tools
-            echo "::group::Test tools"
-            ./v -silent test-self cmd
-            echo "::endgroup::"
-            # Test tools (-cstrict)
-            if [ "$VFLAGS" != "-cc tcc" ]; then
-              echo "::group::Test tools (-cstrict)"
-              ./v -silent -W -cstrict test-self cmd
-              echo "::endgroup::"
-            fi
+          fi
 
   tools-openbsd:
     runs-on: ubuntu-latest
@@ -204,46 +208,49 @@ jobs:
       VFLAGS: -cc ${{ matrix.cc }}
     steps:
       - uses: actions/checkout@v6
-      - name: Tests tools on OpenBSD with ${{ matrix.cc }}
-        uses: cross-platform-actions/action@v1.0.0
+
+      - name: Start OpenBSD VM with ${{ matrix.cc }}
+        uses: cross-platform-actions/action@v1.1.0
         with:
           operating_system: openbsd
           version: '7.8'
           memory: 4G
-          shell: sh
           sync_files: runner-to-vm
           environment_variables: VFLAGS
-          run: |
-            sudo pkg_add git sqlite3 gmake boehm-gc libiconv
-            # Mandatory: hostname not set in VM => some tests fail
-            sudo hostname -s openbsd-ci
-            echo "::group::OS infos"
-            uname -a
+
+      - name: Tests tools on OpenBSD with ${{ matrix.cc }}
+        shell: cpa.sh {0}
+        run: |
+          sudo pkg_add git sqlite3 gmake boehm-gc libiconv
+          # Mandatory: hostname not set in VM => some tests fail
+          sudo hostname -s openbsd-ci
+          echo "::group::OS infos"
+          uname -a
+          echo "::endgroup::"
+          # Build V
+          echo "::group::Build V"
+          git config --global --add safe.directory .
+          printf "VFLAGS = %s\n" "$VFLAGS"
+          gmake && ./v -showcc -o v cmd/v && sudo ./v symlink
+          echo "::endgroup::"
+          echo "::group::v doctor"
+          ./v doctor
+          echo "::endgroup::"
+          # Code in cmd/ is formatted
+          echo "::group::Check code in cmd/ is formatted"
+          ./v fmt -verify cmd/
+          echo "::endgroup::"
+          # Check build-tools
+          echo "::group::Check build tools"
+          ./v -silent -N -W -check build-tools
+          echo "::endgroup::"
+          # Test tools
+          echo "::group::Test tools"
+          ./v -silent test-self cmd
+          echo "::endgroup::"
+          # Test tools (-cstrict)
+          if [ "$VFLAGS" != "-cc tcc" ]; then
+            echo "::group::Test tools (-cstrict)"
+            ./v -silent -W -cstrict test-self cmd
             echo "::endgroup::"
-            # Build V
-            echo "::group::Build V"
-            git config --global --add safe.directory .
-            printf "VFLAGS = %s\n" "$VFLAGS"
-            gmake && ./v -showcc -o v cmd/v && sudo ./v symlink
-            echo "::endgroup::"
-            echo "::group::v doctor"
-            ./v doctor
-            echo "::endgroup::"
-            # Code in cmd/ is formatted
-            echo "::group::Check code in cmd/ is formatted"
-            ./v fmt -verify cmd/
-            echo "::endgroup::"
-            # Check build-tools
-            echo "::group::Check build tools"
-            ./v -silent -N -W -check build-tools
-            echo "::endgroup::"
-            # Test tools
-            echo "::group::Test tools"
-            ./v -silent test-self cmd
-            echo "::endgroup::"
-            # Test tools (-cstrict)
-            if [ "$VFLAGS" != "-cc tcc" ]; then
-              echo "::group::Test tools (-cstrict)"
-              ./v -silent -W -cstrict test-self cmd
-              echo "::endgroup::"
-            fi
+          fi


### PR DESCRIPTION
This PR updates [cross-platform-actions/action](https://github.com/cross-platform-actions/action) action to version v1.1.0 in CI for BSD OS (FreeBSD, OpenBSD and Tools CI) => https://github.com/cross-platform-actions/action/releases/tag/v1.1.0

**It replaces PR #27181 created by dependabot** => this PR is not sufficient to update the action, it needs some modifications in YAML workflows for BSD OS.

In each modified CI, the jobs to run build/tests on BSD OS are divided in 2 steps:
1/ run FreeBSD/OpenBSD VM with cross-platform-actions/action v1.1.0
2/ run script to run tests/build via a new `cpa.sh` shell script provided by the updated action.

---
Successful run of modified BSD CI after these commits:
- OpenBSD CI https://github.com/lcheylus/v/actions/runs/26090346709
- FreeBSD CI https://github.com/lcheylus/v/actions/runs/26090706715
- Tools CI (with tests on FreeBSD and OpenBSD) https://github.com/lcheylus/v/actions/runs/26091198124