### PR TITLE
gg: make create_image* take a config...

### DIFF
--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -18,7 +18,7 @@ pub mut:
 	width          int
 	height         int
 	nr_channels    int
-  nr_mipmaps     int
+	nr_mipmaps     int
 	ok             bool
 	data           voidptr
 	ext            string
@@ -31,8 +31,8 @@ pub mut:
 
 @[params]
 pub struct ImageConfig {
-  nr_mipmaps int
-  texture_filter ?TextureFilter
+	nr_mipmaps     int
+	texture_filter ?TextureFilter
 }
 
 // destroy GPU resources associated with the image
@@ -49,8 +49,8 @@ fn (image &Image) destroy() {
 
 // create_image creates an `Image` from `file`.
 pub fn (mut ctx Context) create_image(file string, cfg ImageConfig) !Image {
-  $if android {
-    if !os.exists(file) {
+	$if android {
+		if !os.exists(file) {
 			image_data := os.read_apk_asset(file)!
 			mut image := ctx.create_image_from_byte_array(image_data, cfg)!
 
@@ -59,43 +59,42 @@ pub fn (mut ctx Context) create_image(file string, cfg ImageConfig) !Image {
 			return image
 		}
 	}
-  mut img := if ctx.native_rendering {
-			$if macos {
-        C.darwin_create_image(file)
-      } $else {
-        load_image(file)!
-      } 
-		} else { 
-      load_image(file)!
-    }
+	mut img := if ctx.native_rendering {
+		$if macos {
+			C.darwin_create_image(file)
+		} $else {
+			load_image(file)!
+		}
+	} else {
+		load_image(file)!
+	}
 	img.id = ctx.image_cache.len
 	img.texture_filter = cfg.texture_filter or { ctx.config.texture_filter }
-  img.nr_mipmaps = cfg.nr_mipmaps
-  img.ok = false
+	img.nr_mipmaps = cfg.nr_mipmaps
+	img.ok = false
 	unsafe {
 		ctx.image_cache << img
 	}
-  if gfx.is_valid() && !ctx.native_rendering {
-    img.init_sokol_image()
-  }
+	if gfx.is_valid() && !ctx.native_rendering {
+		img.init_sokol_image()
+	}
 	return img
-
 }
 
 // create_image_with_filter creates an `Image` from `file` with the requested texture filter.
 @[deprecated: 'use create_image instead']
 pub fn (mut ctx Context) create_image_with_filter(file string, texture_filter TextureFilter) !Image {
-  return ctx.create_image(file, texture_filter: texture_filter)
+	return ctx.create_image(file, texture_filter: texture_filter)
 }
 
 // init_sokol_image initializes this `Image` for use with the
 // sokol graphical backend system.
 pub fn (mut img Image) init_sokol_image() &Image {
-  nr_mipmaps := if img.nr_mipmaps >= 0 {
-    img.nr_mipmaps
-  } else {
-    (bits.len_32(u32(2*math.max(img.width, img.height) - 1))) / 2
-  }
+	nr_mipmaps := if img.nr_mipmaps >= 0 {
+		img.nr_mipmaps
+	} else {
+		(bits.len_32(u32(2 * math.max(img.width, img.height) - 1))) / 2
+	}
 	mut img_desc := gfx.ImageDesc{
 		width:       img.width
 		height:      img.height
@@ -215,8 +214,8 @@ pub fn (mut ctx Context) create_image_with_size(file string, width int, height i
 	if !gfx.is_valid() {
 		// Sokol is not initialized yet, add stbi object to a queue/cache
 		// ctx.image_queue << file
-		mut img := load_image(file) or { return Image{} }  
-    img.texture_filter = ctx.config.texture_filter
+		mut img := load_image(file) or { return Image{} }
+		img.texture_filter = ctx.config.texture_filter
 		img.width = width
 		img.height = height
 		img.ok = false
@@ -224,7 +223,9 @@ pub fn (mut ctx Context) create_image_with_size(file string, width int, height i
 		ctx.image_cache << img
 		return img
 	}
-	mut img := ctx.create_image(file, texture_filter: ctx.config.texture_filter) or { return Image{} }
+	mut img := ctx.create_image(file, texture_filter: ctx.config.texture_filter) or {
+		return Image{}
+	}
 	return img
 }
 
@@ -249,29 +250,29 @@ fn load_image(file string) !Image {
 //
 // See also: create_image_from_byte_array
 pub fn (mut ctx Context) create_image_from_memory(buf &u8, bufsize int, cfg ImageConfig) !Image {
-  stb_img := stbi.load_from_memory(buf, bufsize)!
-  mut img := Image{
-    width:          stb_img.width
+	stb_img := stbi.load_from_memory(buf, bufsize)!
+	mut img := Image{
+		width:          stb_img.width
 		height:         stb_img.height
 		nr_channels:    stb_img.nr_channels
-    nr_mipmaps:     cfg.nr_mipmaps
+		nr_mipmaps:     cfg.nr_mipmaps
 		ok:             stb_img.ok
 		data:           stb_img.data
 		ext:            stb_img.ext
 		id:             ctx.image_cache.len
 		texture_filter: cfg.texture_filter or { ctx.config.texture_filter }
-  }
-  if gfx.is_valid() && !ctx.native_rendering {
-    img.init_sokol_image() 
-  }
-  ctx.image_cache << img
-  return img
+	}
+	if gfx.is_valid() && !ctx.native_rendering {
+		img.init_sokol_image()
+	}
+	ctx.image_cache << img
+	return img
 }
 
 // create_image_from_memory_with_filter creates an `Image` from `buf` with the requested texture filter.
 @[deprecated: 'use create_image_from_memory instead']
 pub fn (mut ctx Context) create_image_from_memory_with_filter(buf &u8, bufsize int, texture_filter TextureFilter) !Image {
-  return ctx.create_image_from_memory(buf, bufsize, texture_filter: texture_filter)
+	return ctx.create_image_from_memory(buf, bufsize, texture_filter: texture_filter)
 }
 
 // create_image_from_byte_array creates an `Image` from the

--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -72,11 +72,11 @@ pub fn (mut ctx Context) create_image(file string, cfg ImageConfig) !Image {
 	img.texture_filter = cfg.texture_filter or { ctx.config.texture_filter }
 	img.nr_mipmaps = cfg.nr_mipmaps
 	img.ok = false
-	unsafe {
-		ctx.image_cache << img
-	}
 	if gfx.is_valid() && !ctx.native_rendering {
 		img.init_sokol_image()
+	}
+	unsafe {
+		ctx.image_cache << img
 	}
 	return img
 }
@@ -164,7 +164,7 @@ pub fn (mut ctx Context) new_streaming_image(w int, h int, channels int, sicfg S
 		height:       img.height
 		pixel_format: sicfg.pixel_format
 		num_slices:   1
-		num_mipmaps:  sicfg.num_mipmaps
+		num_mipmaps:  1
 		usage:        .stream
 		label:        &char(img.path.str)
 	}
@@ -296,7 +296,6 @@ pub:
 	wrap_v       gfx.Wrap        = .clamp_to_edge
 	min_filter   gfx.Filter      = .linear
 	mag_filter   gfx.Filter      = .linear
-	num_mipmaps  int             = 1
 }
 
 fn (filter TextureFilter) gfx_filter() gfx.Filter {

--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -2,6 +2,8 @@
 // Use of this source code is governed by an MIT license that can be found in the LICENSE file.
 module gg
 
+import math
+import math.bits
 import os
 import stbi
 import sokol.gfx
@@ -16,6 +18,7 @@ pub mut:
 	width          int
 	height         int
 	nr_channels    int
+  nr_mipmaps     int
 	ok             bool
 	data           voidptr
 	ext            string
@@ -24,6 +27,12 @@ pub mut:
 	ssmp           gfx.Sampler
 	path           string
 	texture_filter TextureFilter = .linear
+}
+
+@[params]
+pub struct ImageConfig {
+  nr_mipmaps int
+  texture_filter ?TextureFilter
 }
 
 // destroy GPU resources associated with the image
@@ -39,68 +48,58 @@ fn (image &Image) destroy() {
 }
 
 // create_image creates an `Image` from `file`.
-pub fn (mut ctx Context) create_image(file string) !Image {
-	return ctx.create_image_with_filter(file, ctx.config.texture_filter)
-}
-
-// create_image_with_filter creates an `Image` from `file` with the requested texture filter.
-pub fn (mut ctx Context) create_image_with_filter(file string, texture_filter TextureFilter) !Image {
-	if !os.exists(file) {
-		$if android {
+pub fn (mut ctx Context) create_image(file string, cfg ImageConfig) !Image {
+  $if android {
+    if !os.exists(file) {
 			image_data := os.read_apk_asset(file)!
-			mut image := ctx.create_image_from_byte_array_with_filter(image_data, texture_filter)!
+			mut image := ctx.create_image_from_byte_array(image_data, cfg)!
 
 			image.path = file
 
 			return image
-		} $else {
-			return error('image file "${file}" not found')
 		}
 	}
-
-	$if macos {
-		if ctx.native_rendering {
-			// return C.darwin_create_image(file)
-			mut img := C.darwin_create_image(file)
-			img.texture_filter = texture_filter
-
-			// println('created macos image: ${img.path} w=${img.width}')
-			// C.printf('p = %p\n', img.data)
-			img.id = ctx.image_cache.len
-			unsafe {
-				ctx.image_cache << img
-			}
-			return img
-		}
-	}
-
-	if !gfx.is_valid() {
-		// Sokol is not initialized yet, add stbi object to a queue/cache
-		// ctx.image_queue << file
-		mut img := load_image_with_filter(file, texture_filter)!
-		img.ok = false
-		img.id = ctx.image_cache.len
-		unsafe {
-			ctx.image_cache << img
-		}
-		return img
-	}
-	mut img := create_image(file, texture_filter)!
+  mut img := if ctx.native_rendering {
+			$if macos {
+        C.darwin_create_image(file)
+      } $else {
+        load_image(file)!
+      } 
+		} else { 
+      load_image(file)!
+    }
 	img.id = ctx.image_cache.len
+	img.texture_filter = cfg.texture_filter or { ctx.config.texture_filter }
+  img.nr_mipmaps = cfg.nr_mipmaps
+  img.ok = false
 	unsafe {
 		ctx.image_cache << img
 	}
+  if gfx.is_valid() && !ctx.native_rendering {
+    img.init_sokol_image()
+  }
 	return img
+
+}
+
+// create_image_with_filter creates an `Image` from `file` with the requested texture filter.
+@[deprecated: 'use create_image instead']
+pub fn (mut ctx Context) create_image_with_filter(file string, texture_filter TextureFilter) !Image {
+  return ctx.create_image(file, texture_filter: texture_filter)
 }
 
 // init_sokol_image initializes this `Image` for use with the
 // sokol graphical backend system.
 pub fn (mut img Image) init_sokol_image() &Image {
-	// println('\n init sokol image ${img.path} ok=${img.simg_ok}')
+  nr_mipmaps := if img.nr_mipmaps >= 0 {
+    img.nr_mipmaps
+  } else {
+    (bits.len_32(u32(2*math.max(img.width, img.height) - 1))) / 2
+  }
 	mut img_desc := gfx.ImageDesc{
 		width:       img.width
 		height:      img.height
-		num_mipmaps: 0
+		num_mipmaps: nr_mipmaps
 		// wrap_u: .clamp_to_edge // XTODO SAMPLER
 		// wrap_v: .clamp_to_edge
 		label:         &char(img.path.str)
@@ -166,7 +165,7 @@ pub fn (mut ctx Context) new_streaming_image(w int, h int, channels int, sicfg S
 		height:       img.height
 		pixel_format: sicfg.pixel_format
 		num_slices:   1
-		num_mipmaps:  1
+		num_mipmaps:  sicfg.num_mipmaps
 		usage:        .stream
 		label:        &char(img.path.str)
 	}
@@ -216,7 +215,8 @@ pub fn (mut ctx Context) create_image_with_size(file string, width int, height i
 	if !gfx.is_valid() {
 		// Sokol is not initialized yet, add stbi object to a queue/cache
 		// ctx.image_queue << file
-		mut img := load_image_with_filter(file, ctx.config.texture_filter) or { return Image{} }
+		mut img := load_image(file) or { return Image{} }  
+    img.texture_filter = ctx.config.texture_filter
 		img.width = width
 		img.height = height
 		img.ok = false
@@ -224,24 +224,7 @@ pub fn (mut ctx Context) create_image_with_size(file string, width int, height i
 		ctx.image_cache << img
 		return img
 	}
-	mut img := create_image(file, ctx.config.texture_filter) or { return Image{} }
-	img.id = ctx.image_cache.len
-	ctx.image_cache << img
-	return img
-}
-
-// create_image creates an `Image` from `file`.
-//
-// TODO: remove this
-fn create_image(file string, texture_filter TextureFilter) !Image {
-	mut img := load_image_with_filter(file, texture_filter)!
-	img.init_sokol_image()
-	return img
-}
-
-fn load_image_with_filter(file string, texture_filter TextureFilter) !Image {
-	mut img := load_image(file)!
-	img.texture_filter = texture_filter
+	mut img := ctx.create_image(file, texture_filter: ctx.config.texture_filter) or { return Image{} }
 	return img
 }
 
@@ -265,41 +248,44 @@ fn load_image(file string) !Image {
 // memory buffer `buf` of size `bufsize`.
 //
 // See also: create_image_from_byte_array
-pub fn (mut ctx Context) create_image_from_memory(buf &u8, bufsize int) !Image {
-	return ctx.create_image_from_memory_with_filter(buf, bufsize, ctx.config.texture_filter)
-}
-
-// create_image_from_memory_with_filter creates an `Image` from `buf` with the requested texture filter.
-pub fn (mut ctx Context) create_image_from_memory_with_filter(buf &u8, bufsize int, texture_filter TextureFilter) !Image {
-	stb_img := stbi.load_from_memory(buf, bufsize)!
-	mut img := Image{
-		width:          stb_img.width
+pub fn (mut ctx Context) create_image_from_memory(buf &u8, bufsize int, cfg ImageConfig) !Image {
+  stb_img := stbi.load_from_memory(buf, bufsize)!
+  mut img := Image{
+    width:          stb_img.width
 		height:         stb_img.height
 		nr_channels:    stb_img.nr_channels
+    nr_mipmaps:     cfg.nr_mipmaps
 		ok:             stb_img.ok
 		data:           stb_img.data
 		ext:            stb_img.ext
 		id:             ctx.image_cache.len
-		texture_filter: texture_filter
-	}
-	if gfx.is_valid() && !ctx.native_rendering {
-		img.init_sokol_image()
-	}
-	ctx.image_cache << img
-	return img
+		texture_filter: cfg.texture_filter or { ctx.config.texture_filter }
+  }
+  if gfx.is_valid() && !ctx.native_rendering {
+    img.init_sokol_image() 
+  }
+  ctx.image_cache << img
+  return img
+}
+
+// create_image_from_memory_with_filter creates an `Image` from `buf` with the requested texture filter.
+@[deprecated: 'use create_image_from_memory instead']
+pub fn (mut ctx Context) create_image_from_memory_with_filter(buf &u8, bufsize int, texture_filter TextureFilter) !Image {
+  return ctx.create_image_from_memory(buf, bufsize, texture_filter: texture_filter)
 }
 
 // create_image_from_byte_array creates an `Image` from the
 // byte array `b`.
 //
 // See also: create_image_from_memory
-pub fn (mut ctx Context) create_image_from_byte_array(b []u8) !Image {
-	return ctx.create_image_from_byte_array_with_filter(b, ctx.config.texture_filter)
+pub fn (mut ctx Context) create_image_from_byte_array(b []u8, cfg ImageConfig) !Image {
+	return ctx.create_image_from_memory(b.data, b.len, cfg)
 }
 
 // create_image_from_byte_array_with_filter creates an `Image` from `b` with the requested texture filter.
+@[deprecated: 'use create_image_from_byte_array instead']
 pub fn (mut ctx Context) create_image_from_byte_array_with_filter(b []u8, texture_filter TextureFilter) !Image {
-	return ctx.create_image_from_memory_with_filter(b.data, b.len, texture_filter)
+	return ctx.create_image_from_memory(b.data, b.len, texture_filter: texture_filter)
 }
 
 pub struct StreamingImageConfig {
@@ -310,7 +296,6 @@ pub:
 	min_filter   gfx.Filter      = .linear
 	mag_filter   gfx.Filter      = .linear
 	num_mipmaps  int             = 1
-	num_slices   int             = 1
 }
 
 fn (filter TextureFilter) gfx_filter() gfx.Filter {

--- a/vlib/gg/image.c.v
+++ b/vlib/gg/image.c.v
@@ -13,7 +13,7 @@ import sokol.sgl
 // represent a bitmap/pixel based image in memory.
 @[heap; markused]
 pub struct Image {
-pub mut:
+pub:
 	id             int
 	width          int
 	height         int
@@ -31,6 +31,7 @@ pub mut:
 
 @[params]
 pub struct ImageConfig {
+pub mut:
 	nr_mipmaps     int
 	texture_filter ?TextureFilter
 }

--- a/vlib/gg/image_test.v
+++ b/vlib/gg/image_test.v
@@ -79,7 +79,7 @@ fn test_create_image_from_byte_array_uses_context_texture_filter() {
 fn test_create_image_from_byte_array_with_filter_overrides_context_default() {
 	mut ctx := gg.new_context(width: 100)
 	background_bytes := os.read_bytes(background_path)!
-	img := ctx.create_image_from_byte_array_with_filter(background_bytes, .nearest)!
+	img := ctx.create_image_from_byte_array(background_bytes, texture_filter: .nearest)!
 	assert img.texture_filter == .nearest
 	assert ctx.get_cached_image_by_idx(img.id).texture_filter == .nearest
 }


### PR DESCRIPTION
...including options for texture_filter and nr_mipmaps

Configuring mipmaps is important depending on the use case and while at it I simplified the code and deprecated the `*_with_filter` functions. With increasing minification the texture quality degrades increasingly without mipmaps.

When the `nr_mipmaps` is set to a value below 0 the maximum number of mipmap levels is used. The default is still 0. This code is fully backwards compatible.

I also removed the `num_slices` option from the `StreamingImageConfig` as it is unused and the slice functionality of sokol is not exposed through any API on the V side.

P.S.: Also removed the `num_mipmaps` option from `StreamingImageConfig` as currently the current API provided by gg is not sufficient to make use of this.