### PR TITLE
cgen: emit GC_allow_register_threads() constructor for shared libs

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -9739,6 +9739,36 @@ fn (mut g Gen) write_init_function() {
 		// provide a constructor/destructor pair, ensuring that all constants
 		// are initialized just once, and that they will be freed too.
 		// Note: os.args in this case will be [].
+		//
+		// Fix for vlang/v#27178: when the GC mode is one of the Boehm
+		// variants, host-spawned threads (Rust cargo workers, C# tasks,
+		// JNI threads, etc.) that enter V code must be registered with
+		// libgc via GC_register_my_thread() to avoid the libgc
+		// "Collecting from unknown thread" abort. The per-thread step
+		// is inherently caller-side, but `GC_allow_register_threads()`
+		// is process-level and can be done by V itself at library load
+		// time. Emit a constructor for it so the caller doesn't have
+		// to remember.
+		if g.pref.os != .windows && g.pref.gc_mode in [.boehm_full, .boehm_incr,
+			.boehm_full_opt, .boehm_incr_opt, .boehm_leak] {
+			g.writeln('__attribute__ ((constructor))')
+			g.writeln('static void _v_shared_lib_gc_init(void) {')
+			// Fix for macOS hardened-runtime: libgc's trampoline allocator
+			// requests rwx pages via mprotect(PROT_EXEC), which macOS
+			// hardened runtime refuses by default. Disabling executable
+			// pages before GC_INIT() opts libgc out of trampolines (it
+			// falls back to a non-JIT mark stack). Required for V `-prod`
+			// + shared lib + macOS, and harmless on Linux.
+			g.writeln('\tGC_set_pages_executable(0);')
+			g.writeln('#if defined(GC_THREADS)')
+			// Fix for vlang/v#27178: per-process thread-registration enable.
+			g.writeln('\tGC_allow_register_threads();')
+			g.writeln('#endif')
+			// Force explicit GC_INIT() so libgc doesn't lazy-init AFTER
+			// the trampoline pref has been overridden by something else.
+			g.writeln('\tGC_INIT();')
+			g.writeln('}')
+		}
 		if g.pref.os != .windows {
 			g.writeln('__attribute__ ((constructor))')
 		}


### PR DESCRIPTION
Closes #27178.

When a V `-shared` library is dlopen'd by a host runtime that spawns
its own OS threads (Rust cargo workers, C# tasks, Java JNI threads,
etc.), the host threads that enter V code must be registered with
libgc — otherwise libgc aborts with `"Collecting from unknown thread"`
on the first collection triggered from an unregistered thread.

Per-thread registration via `GC_register_my_thread()` is inherently
caller-side, but the process-level enable `GC_allow_register_threads()`
can be done by V itself at library load time. This PR emits a
`__attribute__((constructor))` that calls it, so bindings no longer
have to remember.

The constructor also calls `GC_set_pages_executable(0)` before
`GC_INIT()` to disable libgc's trampoline allocator (which requests
rwx pages via mprotect — denied under macOS hardened runtime). The
explicit `GC_INIT()` makes the timing deterministic so subsequent
allocations don't lazy-init under different settings.

All three calls are:
- Gated on `gc_mode in [boehm_full, boehm_incr, boehm_full_opt, boehm_incr_opt, boehm_leak]`
- Skipped on Windows (which uses a different shared-lib init path via gen_windows_shared_library_boehm_init)
- Guarded by `#if defined(GC_THREADS)` for the thread-registration call

Tested locally on macOS 26.4 ARM64 against a real-world V `-shared`
consumer (the cx-home/cx project, a structured-data library with 5
host-language bindings). Before this PR, every Rust/Go/C#/Java/TS
binding had to hand-roll a `cx_init` wrapper that called
`GC_allow_register_threads()` at module load. After: bindings can
just dlopen the library and start using it.

V's own `make test vlib/builtin` passes 35/35 with this patch.