### PR TITLE
db.mysql: add Config.ssl_mode to control MYSQL_OPT_SSL_MODE (fix #27139)

### DIFF
--- a/vlib/db/mysql/enums.v
+++ b/vlib/db/mysql/enums.v
@@ -1,5 +1,17 @@
 module mysql
 
+// SslMode mirrors the values of the C `enum mysql_ssl_mode`, used with
+// `MYSQL_OPT_SSL_MODE`. Use `.unset` to leave the option untouched, in which
+// case the underlying libmysqlclient default applies (typically `.preferred`).
+pub enum SslMode {
+	unset           = 0
+	disabled        = 1
+	preferred       = 2
+	required        = 3
+	verify_ca       = 4
+	verify_identity = 5
+}
+
 // FieldType is a list of all supported MYSQL field types.
 pub enum FieldType {
 	type_decimal

--- a/vlib/db/mysql/mysql.c.v
+++ b/vlib/db/mysql/mysql.c.v
@@ -89,6 +89,13 @@ pub mut:
 	dbname   string
 	flag     ConnectionFlag
 
+	// ssl_mode controls the SSL/TLS negotiation policy via `MYSQL_OPT_SSL_MODE`.
+	// Set it to `.disabled` to connect to servers without TLS support
+	// (libmysqlclient 8.x otherwise tries `.preferred`/`.required`, which can
+	// fail against servers built without SSL). When left as `.unset`, no
+	// `MYSQL_OPT_SSL_MODE` call is made and the libmysqlclient default applies.
+	ssl_mode SslMode
+
 	// SSL params, only valid when set .client_ssl
 	ssl_key    string
 	ssl_cert   string
@@ -124,6 +131,11 @@ pub fn connect(config Config) !DB {
 		conn: C.mysql_init(0)
 	}
 	username := config.connection_user()!
+
+	if config.ssl_mode != .unset {
+		ssl_mode := int(config.ssl_mode)
+		db.set_option(C.MYSQL_OPT_SSL_MODE, &ssl_mode)
+	}
 
 	if config.flag.has(.client_ssl) {
 		if config.ssl_key.len > 0 {


### PR DESCRIPTION
## Summary

Fixes #27139.

libmysqlclient 8.x defaults `MYSQL_OPT_SSL_MODE` to `PREFERRED` (and to `REQUIRED` in some builds, e.g. Alpine/musl), so `mysql.connect()` against a server without TLS support fails with:

```
TLS/SSL error: SSL is required, but the server does not support it
```

even though the user never set `ConnectionFlag.client_ssl`. There was no way to override this from `db.mysql`.

This PR adds:

- `SslMode` enum in `vlib/db/mysql/enums.v` mirroring the C `mysql_ssl_mode` values (`unset`, `disabled`, `preferred`, `required`, `verify_ca`, `verify_identity`).
- `ssl_mode SslMode` field on `mysql.Config`. Default is `.unset`, which preserves the previous behavior (no `MYSQL_OPT_SSL_MODE` call; libmysqlclient default applies).
- In `connect()`, when `ssl_mode != .unset`, call `set_option(C.MYSQL_OPT_SSL_MODE, &ssl_mode)` before `mysql_real_connect`.

Usage for the reporter's case:

```v
cfg := mysql.Config{
    host:     'mysql'
    port:     3306
    username: 'root'
    password: 'root'
    dbname:   'omega'
    ssl_mode: .disabled
}
mut db := mysql.connect(cfg)!
```

## Test plan
- [ ] Connect to a MySQL 8.x server started with `--require_secure_transport=OFF` using `ssl_mode: .disabled` and confirm the connection succeeds.
- [ ] Existing `db.mysql` tests still pass (no behavior change when `ssl_mode` is left at the default `.unset`).