### PR TITLE
builder: default to hidden symbol visibility for -shared (fix #27167)

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -776,6 +776,15 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		$if !windows {
 			ccoptions.args << '-fPIC' // -Wl,-z,defs'
 		}
+		// Default to hidden symbol visibility for shared libraries, so only
+		// functions/globals tagged with `@[export: '…']` (which emit `VV_EXP`
+		// = `__attribute__((visibility("default")))`) end up in the ABI.
+		// Without this, every C symbol from the V runtime + stdlib is exported.
+		// Windows uses `__declspec(dllexport)` and the linker only exports
+		// tagged symbols, so the flag is unnecessary there.
+		if v.pref.os !in [.windows, .wasm32] && ccoptions.cc != .msvc {
+			ccoptions.args << '-fvisibility=hidden'
+		}
 		if v.pref.os == .linux && 'gcboehm' in v.pref.compile_defines_all {
 			// Keep shared-library GC symbols bound to the shared object itself.
 			// This avoids cross-DSO symbol interposition between multiple V binaries

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -782,7 +782,11 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		// Without this, every C symbol from the V runtime + stdlib is exported.
 		// Windows uses `__declspec(dllexport)` and the linker only exports
 		// tagged symbols, so the flag is unnecessary there.
-		if v.pref.os !in [.windows, .wasm32] && ccoptions.cc != .msvc {
+		// `-sharedlive` is skipped: live reload resolves `impl_live_*` symbols
+		// via `dlsym` from the host process, and those are emitted without
+		// `VV_EXP` on non-Windows (see vlib/v/gen/c/fn.v).
+		if !v.pref.is_liveshared && v.pref.os !in [.windows, .wasm32]
+			&& ccoptions.cc != .msvc {
 			ccoptions.args << '-fvisibility=hidden'
 		}
 		if v.pref.os == .linux && 'gcboehm' in v.pref.compile_defines_all {

--- a/vlib/v/tests/shared_library_system_link_test.v
+++ b/vlib/v/tests/shared_library_system_link_test.v
@@ -20,6 +20,7 @@ fn test_shared_library_links_with_system_cc() {
 	os.write_file(lib_src, [
 		'module libfoo',
 		'',
+		"@[export: 'libfoo_square']",
 		'pub fn square(x int) int {',
 		'\treturn x * x',
 		'}',
@@ -27,10 +28,10 @@ fn test_shared_library_links_with_system_cc() {
 	os.write_file(host_src, [
 		'#include <stdio.h>',
 		'',
-		'int libfoo__square(int);',
+		'int libfoo_square(int);',
 		'',
 		'int main(void) {',
-		'\tprintf("%d\\n", libfoo__square(2));',
+		'\tprintf("%d\\n", libfoo_square(2));',
 		'\treturn 0;',
 		'}',
 	].join('\n')) or { panic(err) }
@@ -45,6 +46,57 @@ fn test_shared_library_links_with_system_cc() {
 		panic(err)
 	}
 	assert res.output.trim_space() == '4'
+}
+
+fn test_shared_library_only_exports_tagged_symbols() {
+	// Regression test for vlang/v#27167: `v -shared` used to export every
+	// V runtime/stdlib symbol, not just functions tagged with `@[export: '…']`.
+	uos := os.user_os()
+	if uos !in ['linux', 'macos'] {
+		return
+	}
+	// tcc on macOS does not honor `-fvisibility=hidden`, so the symbol-set check
+	// would be noisy there; rely on Linux + a `-cc clang` path on macOS.
+	cc_flag := if uos == 'macos' { '-cc clang' } else { '' }
+	workdir := os.join_path(os.vtmp_dir(), 'v_shared_visibility_${rand.ulid()}')
+	os.mkdir_all(workdir) or { panic(err) }
+	defer {
+		os.rmdir_all(workdir) or {}
+	}
+	lib_src := os.join_path(workdir, 'lib.v')
+	lib_out := os.join_path(workdir, 'liblib')
+	lib_so := if uos == 'macos' { '${lib_out}.dylib' } else { '${lib_out}.so' }
+	os.write_file(lib_src, [
+		'module main',
+		'',
+		"@[export: 'my_add']",
+		'fn my_add(a int, b int) int {',
+		'\treturn a + b',
+		'}',
+	].join('\n')) or { panic(err) }
+	run_cmd('${os.quoted_path(vexe)} ${cc_flag} -shared -o ${os.quoted_path(lib_out)} ${os.quoted_path(lib_src)}') or {
+		panic(err)
+	}
+	assert os.exists(lib_so)
+	nm_flag := if uos == 'macos' { '-gU' } else { '-D --defined-only' }
+	res := run_cmd('nm ${nm_flag} ${os.quoted_path(lib_so)}') or { panic(err) }
+	symbol_token := if uos == 'macos' { ' _my_add' } else { ' my_add' }
+	assert res.output.contains(symbol_token), 'expected exported `my_add` in:\n${res.output}'
+	// None of the V runtime/stdlib helpers should leak into the exported ABI.
+	leaky_prefixes := ['Array_string_', 'main__', 'builtin__', 'GC_', '_vinit', '_vcleanup',
+		'_const_']
+	for line in res.output.split('\n') {
+		for prefix in leaky_prefixes {
+			needles := if uos == 'macos' { [' _${prefix}', ' T _${prefix}', ' D _${prefix}'] } else { [
+					' ${prefix}',
+					' T ${prefix}',
+					' D ${prefix}',
+				] }
+			for needle in needles {
+				assert !line.contains(needle), 'unexpected exported symbol on line: ${line}'
+			}
+		}
+	}
 }
 
 fn run_cmd(cmd string) !os.Result {


### PR DESCRIPTION
## Summary

`v -shared` currently exports the entire V runtime + stdlib instead of just functions tagged with `@[export: '…']`. In the issue's minimal reproducer that is 855 of 856 symbols unintentionally exported; for a real library (CX's `libcx.dylib`) it is ~1770 of 2260.

This locks downstream consumers into accidental ABI on V internals (`Array_string_join`, `GC_get_stack_base`, …), bloats binary size, and slows `dlopen` symbol resolution.

## Fix

In `vlib/v/builder/cc.v`, when `is_shared` and the target is non-Windows / non-wasm with a non-MSVC `cc`, pass `-fvisibility=hidden`. Functions and globals tagged with `@[export: '…']` are already emitted with `VV_EXP` (= `__attribute__((visibility("default")))`), so they stay exported; everything else becomes hidden. Constructor/destructor attributes (`_vinit_caller`, `_vcleanup_caller`) keep working — they are dispatched through `.init_array` / `.fini_array`, not via symbol visibility.

Windows is unchanged: `__declspec(dllexport)` already enforces tagged-only export.

Matches Rust cdylib (`-C default-symbol-visibility=hidden`), Go (`//export` only), and the standard C `-fvisibility=hidden` + `__attribute__((visibility("default")))` pattern.

## Verification (issue reproducer, macOS arm64, `-cc clang`)

```
$ v -shared -o liblib.dylib lib.v
$ nm -gU liblib.dylib | wc -l
# before: 856
# after:  1
$ nm -gU liblib.dylib | grep ' _my_add'
0000000000031dd8 T _my_add
```

## Tests

- Updated `vlib/v/tests/shared_library_system_link_test.v` to tag its V function with `@[export: 'libfoo_square']` instead of relying on the implicit "every `pub fn` is exported" behavior that this PR removes.
- Added `test_shared_library_only_exports_tagged_symbols` regression test that builds the issue's reproducer and asserts no `GC_*`, `Array_string_*`, `builtin__*`, `main__*`, `_vinit`, `_vcleanup`, or `_const_*` symbols leak into the ABI.

## Compatibility note

V users who were inadvertently relying on stdlib internals being externally callable from `-shared` builds will need to add `@[export: '…']` to the functions they want exposed. The implicit behavior was never documented and the proper interface (`@[export]`) has always existed.

## Test plan

- [x] `v -shared` on the issue reproducer exports only `my_add`
- [x] `v -shared` on `examples/hello_world.v` exports 0 symbols
- [x] `vlib/v/tests/shared_library_system_link_test.v` passes
- [x] `vlib/v/tests/plugin_interface_shared_library_test.v` passes
- [ ] CI: Linux + macOS shared library tests
- [ ] CI: Windows DLL test (`vlib/v/tests/create_dll/`)