### PR TITLE
parser: allow short positional struct init in for-in array literal (fix #27146)

### DIFF
--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -84,10 +84,10 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 			} else if p.tok.kind == .question && p.peek_tok.kind == .amp {
 				node = p.prefix_expr()
 			} else if p.inside_for_expr && p.tok.kind == .name && ((p.tok.lit[0].is_capital()
-				&& p.peek_tok.kind == .lcbr && p.peek_token(2).kind in [.rcbr, .name])
+				&& p.peek_tok.kind == .lcbr
+				&& (p.peek_token(2).kind in [.rcbr, .name] || p.inside_array_lit))
 				|| (p.inside_array_lit && p.peek_tok.kind == .dot && p.peek_token(2).kind == .name
-				&& p.peek_token(2).lit[0].is_capital() && p.peek_token(3).kind == .lcbr
-				&& p.peek_token(4).kind in [.rcbr, .name])) {
+				&& p.peek_token(2).lit[0].is_capital() && p.peek_token(3).kind == .lcbr)) {
 				node = p.struct_init(p.mod + '.' + p.tok.lit, .normal, false)
 			} else if p.is_generic_name() && p.peek_tok.kind == .lcbr
 				&& p.peek_token(2).kind == .rcbr && p.peek_token(2).line_nr == p.tok.line_nr {

--- a/vlib/v/tests/structs/struct_init_short_in_for_expr_test.v
+++ b/vlib/v/tests/structs/struct_init_short_in_for_expr_test.v
@@ -1,0 +1,35 @@
+// Regression test for https://github.com/vlang/v/issues/27146
+// Short struct init syntax (positional) inside an array literal in a `for in` loop.
+struct Int {
+	val int
+}
+
+struct Pair {
+	a int
+	b int
+}
+
+fn test_short_struct_init_in_for_in_array() {
+	mut got := []int{}
+	for a in [Int{1}, Int{2}, Int{3}] {
+		got << a.val
+	}
+	assert got == [1, 2, 3]
+}
+
+fn test_short_struct_init_multi_fields_in_for_in_array() {
+	mut got := []int{}
+	for p in [Pair{1, 2}, Pair{3, 4}] {
+		got << p.a
+		got << p.b
+	}
+	assert got == [1, 2, 3, 4]
+}
+
+fn test_mixed_struct_init_styles_in_for_in_array() {
+	mut got := []int{}
+	for x in [Int{}, Int{5}, Int{val: 6}] {
+		got << x.val
+	}
+	assert got == [0, 5, 6]
+}


### PR DESCRIPTION
## Summary
- `for a in [Int{1}, Int{2}] {}` failed to parse with `unexpected token \`}\`, expecting \`:\``.
- The special-case in `vlib/v/parser/expr.v` that routes `Type{...}` to `struct_init()` inside a for-in expression only matched when `peek_token(2)` was `.rcbr` or `.name` — i.e. only empty `Type{}` and keyed `Type{f: v}` were recognized. Positional `Type{1}` left `peek_token(2)` as `.number`, so it fell through to `name_expr()` where struct init is gated off by `inside_for`.
- Fix: when `inside_array_lit` is true, accept any token after `Type{` — the `Capital + lcbr` shape inside `[...]` of a for-in cond is unambiguously a struct init. Same relaxation applied to the `pkg.Type{...}` branch.

## Test plan
- [x] Added `vlib/v/tests/structs/struct_init_short_in_for_expr_test.v` covering positional, multi-field positional, and mixed empty/positional/keyed cases.
- [x] Existing `vlib/v/tests/structs/struct_init_on_for_expr_test.v` still passes.
- [x] All 112 struct tests pass.
- [x] Parser, checker, and for-loop tests pass.

Fixes #27146.