### PR TITLE
term.ui: use CSI ?2026 h/l for synchronized updates (fix #27136)

### DIFF
--- a/vlib/term/ui/ui.c.v
+++ b/vlib/term/ui/ui.c.v
@@ -19,9 +19,11 @@ pub fn (c Color) hex() string {
 
 // Synchronized Updates spec, designed to avoid tearing during renders
 // https://gitlab.com/gnachman/iterm2/-/wikis/synchronized-updates-spec
-const bsu = '\x1bP=1s\x1b\\'
+// The alternate `CSI ? 2026 h/l` sequences are preferred when no parameters
+// are passed, since they are correctly interpreted by terminals like screen.
+const bsu = '\x1b[?2026h'
 
-const esu = '\x1bP=2s\x1b\\'
+const esu = '\x1b[?2026l'
 
 // write puts the string `s` into the print buffer.
 @[inline]


### PR DESCRIPTION
## Summary

- `vlib/term/ui/ui.c.v` uses DCS-based BSU/ESU sequences (`\x1bP=1s\x1b\\` / `\x1bP=2s\x1b\\`) for synchronized updates.
- GNU `screen` does not recognise these and leaves stray `=1` / `=2` characters on the display (see #27136).
- Switched to the DECSET/DECRST forms `\x1b[?2026h` / `\x1b[?2026l`, which the [synchronized updates spec](https://gitlab.com/gnachman/iterm2/-/wikis/synchronized-updates-spec) recommends when no parameters are passed and which `screen` interprets correctly.

## Test plan

- [x] `v -o /tmp/vyper examples/term.ui/vyper.v` builds cleanly.
- [ ] Run `examples/term.ui/vyper` inside a `screen` window and confirm no stray `=1`/`=2` characters appear.
- [ ] Confirm behaviour is unchanged in terminals that already supported the prior DCS sequences (the feature-detection in `termios_nix.c.v` still passes since DECSET/DECRST produce no cursor movement when unsupported).