### PR TITLE
util: qualify modules relative to compilation project root (fix #27138)

### DIFF
--- a/vlib/v/tests/projects_that_should_compile_test.v
+++ b/vlib/v/tests/projects_that_should_compile_test.v
@@ -183,6 +183,23 @@ fn test_module_resolution_is_independent_of_working_directory() {
 	assert res_app.trim_space() == 'Hello 16!'
 }
 
+fn test_importing_submodule_through_nested_vmod_works_issue_27138() {
+	root := os.join_path(os.vtmp_dir(), 'v_issue_27138_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.mkdir_all(os.join_path(root, 'dep', 'mymod'))!
+	os.write_file(os.join_path(root, 'v.mod'), "Module {\n\tname: 'bug_project'\n}\n")!
+	os.write_file(os.join_path(root, 'dep', 'v.mod'), "Module {\n\tname: 'dep'\n}\n")!
+	os.write_file(os.join_path(root, 'dep', 'mymod', 'types.v'),
+		'module mymod\n\npub enum Color {\n\tred\n\tgreen\n}\n\npub fn color_name(c Color) string {\n\treturn match c {\n\t\t.red { \'red\' }\n\t\t.green { \'green\' }\n\t}\n}\n')!
+	os.write_file(os.join_path(root, 'main.v'),
+		"module main\n\nimport dep.mymod\n\nfn main() {\n\tprintln(mymod.color_name(mymod.Color.red))\n}\n")!
+	res := vrun_ok_in_dir(root, 'run', '.')
+	assert res.trim_space() == 'red'
+}
+
 fn test_running_project_from_its_own_vmod_with_parent_vmod_works_issue_26828() {
 	root := os.join_path(os.vtmp_dir(), 'v_issue_26828_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -133,6 +133,13 @@ fn mod_path_to_full_name(pref_ &pref.Preferences, mod string, path string) !stri
 			break
 		}
 	}
+	// Anchor the module-name boundary to the v.mod that contains the
+	// current compilation (`pref_.path`). Without this, a nested v.mod
+	// inside the project (e.g. a vendored sub-project at `dep/v.mod`)
+	// would shrink the qualified name: files at `dep/mymod` would become
+	// `mymod` instead of `dep.mymod`, breaking `import dep.mymod` from
+	// the outer project. See issue #27138.
+	pref_project_root := if in_vmod_path { '' } else { project_root_vmod_folder(pref_) }
 	path_parts := path.split(os.path_separator)
 	mod_path := mod.replace('.', os.path_separator)
 	// go back through each parent in path_parts and join with `mod_path` to see the dir exists
@@ -155,6 +162,16 @@ fn mod_path_to_full_name(pref_ &pref.Preferences, mod string, path string) !stri
 				// not in one of the `vmod_folders` so work backwards through each parent
 				// looking for for a `v.mod` file and break at the first path without it
 			} else {
+				if pref_project_root != '' {
+					real_try_path := os.real_path(try_path)
+					prefix := pref_project_root + os.path_separator
+					if real_try_path.starts_with(prefix) {
+						relative_parts := real_try_path.all_after(prefix).split(os.path_separator)
+						mod_full_name := normalize_base_url_mod_name(relative_parts.join('.'),
+							try_path)
+						return if mod_full_name.len < mod.len { mod } else { mod_full_name }
+					}
+				}
 				mut try_path_parts := try_path.split(os.path_separator)
 				// last index in try_path_parts that contains a `v.mod`
 				mut last_v_mod := -1
@@ -193,6 +210,37 @@ fn mod_path_to_full_name(pref_ &pref.Preferences, mod string, path string) !stri
 		}
 	}
 	return error('module not found')
+}
+
+// project_root_vmod_folder returns the absolute folder of the closest
+// enclosing v.mod for the current compilation (`pref_.path`). Module-name
+// qualification uses this as the boundary so a nested v.mod inside the
+// project does not silently rename its sub-modules.
+fn project_root_vmod_folder(pref_ &pref.Preferences) string {
+	if pref_.path == '' {
+		return ''
+	}
+	abs_pref_path := if os.is_abs_path(pref_.path) {
+		pref_.path
+	} else {
+		os.join_path_single(os.getwd(), pref_.path)
+	}
+	start := if os.is_dir(abs_pref_path) { abs_pref_path } else { os.dir(abs_pref_path) }
+	if start == '' {
+		return ''
+	}
+	mut cfolder := os.real_path(start)
+	for {
+		if os.is_file(os.join_path(cfolder, 'v.mod')) {
+			return cfolder
+		}
+		parent := os.dir(cfolder)
+		if parent == cfolder || parent == '' {
+			return ''
+		}
+		cfolder = parent
+	}
+	return ''
 }
 
 // normalize_base_url_mod_name strips the `base_url` prefix from `mod_full_name`


### PR DESCRIPTION
## Summary

Fixes #27138: when a project contains a subdirectory with its own `v.mod`, importing a submodule like `import dep.mymod` from the outer project failed with `unknown enum dep.mymod.Color (type_idx=0)` and `unknown function: dep.mymod.color_name`. The dependency's `.v` files were parsed but registered under the wrong qualified name (`mymod` instead of `dep.mymod`), because the inner `v.mod` was treated as the naming boundary in `util.qualify_module`.

The fix anchors `mod_path_to_full_name` to the v.mod that contains the current compilation (`pref.path`). When the resolved module directory lies inside that project root, the module name is computed relative to it, so a nested v.mod no longer shrinks names of its sub-modules. The existing standalone case (\`cd dep && v .\`) is preserved — it's covered by `test_running_project_from_its_own_vmod_with_parent_vmod_works_issue_26828`, which still passes.

## Test plan

- [x] Reproduction from the issue now prints `red / mymod.Point{...} / ok`, with `dep/v.mod` present.
- [x] Same reproduction still works after deleting `dep/v.mod` (no regression in the workaround path).
- [x] Self-host: `./v -o v cmd/v` runs cleanly for two iterations.
- [x] `vlib/v/tests/modules/` — 19/19 pass (includes `sub/sub_test.v` which uses a nested `v.mod` inside a submodule).
- [x] `vlib/v/tests/project_with_modules_having_submodules/` — 2/2 pass.
- [x] `vlib/v/tests/projects_that_should_compile_test.v` — all pass, including new `test_importing_submodule_through_nested_vmod_works_issue_27138` regression test.
- [x] `cmd/tools/vpm/` — 13/13 pass.