### PR TITLE
pref: re-enable boehm GC by default for musl (fix #27090)

### DIFF
--- a/vlib/v/help/build/build-c.txt
+++ b/vlib/v/help/build/build-c.txt
@@ -218,11 +218,10 @@ see also `v help build`.
       more performant without autofree.
 
    -gc <mode>
-      On most supported C targets, V uses a garbage collector by default. Musl keeps the
-      historical default of `-gc none`. Only the Boehm–Demers–Weiser garbage collector is
-      supported currently with the following sub-options:
+      V uses a garbage collector by default. Only the Boehm–Demers–Weiser garbage collector
+      is supported currently with the following sub-options:
 
-      `-gc boehm` ........... use the default Boehm garbage collector mode
+      `-gc boehm` ........... use default garbage collector (same as not specifying option)
       `-gc boehm_full` ...... full garbage collection mode
       `-gc boehm_incr` ...... incremental/generational garbage collection mode
       `-gc boehm_full_opt` .. optimized full garbage collection mode

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -227,7 +227,7 @@ pub fn (mut p Preferences) fill_with_defaults() {
 		p.parse_define('cross') // TODO: remove when `$if cross {` works
 	}
 	if p.gc_mode == .unknown {
-		if p.backend != .c || p.building_v || p.is_bare || p.os == .windows || p.is_musl {
+		if p.backend != .c || p.building_v || p.is_bare || p.os == .windows {
 			p.gc_mode = .no_gc
 			p.build_options << ['-gc', 'none']
 		} else {

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -632,7 +632,7 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					}
 					else {
 						eprintln('unknown garbage collection mode `-gc ${gc_mode}`, supported modes are:`')
-						eprintln('  `-gc boehm` ............ select default Boehm mode (currently `boehm_full_opt`)')
+						eprintln('  `-gc boehm` ............ default GC-mode (currently `boehm_full_opt`)')
 						eprintln('  `-gc boehm_full` ....... classic full collection')
 						eprintln('  `-gc boehm_incr` ....... incremental collection')
 						eprintln('  `-gc boehm_full_opt` ... optimized classic full collection')

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -304,16 +304,12 @@ fn test_cross_compile_infers_android_arch_from_vcross_compiler_name() {
 	}
 }
 
-fn test_musl_defaults_to_no_gc() {
+fn test_musl_still_defaults_to_boehm_gc() {
+	// Regression test for https://github.com/vlang/v/issues/27090 .
+	// Alpine/musl programs must keep the boehm GC by default; otherwise
+	// long-running allocations grow without bound (see the issue's repro).
 	target := os.join_path(vroot, 'examples', 'hello_world.v')
 	prefs, _ := pref.parse_args_and_show_errors([], ['', '-musl', target], false)
-	assert prefs.is_musl
-	assert prefs.gc_mode == .no_gc
-}
-
-fn test_musl_keeps_explicit_gc_selection() {
-	target := os.join_path(vroot, 'examples', 'hello_world.v')
-	prefs, _ := pref.parse_args_and_show_errors([], ['', '-musl', '-gc', 'boehm', target], false)
 	assert prefs.is_musl
 	assert prefs.gc_mode == .boehm_full_opt
 }


### PR DESCRIPTION
## Summary
- Reverts the `|| p.is_musl` clause in `vlib/v/pref/default.v` introduced by 6978ca90b, which was disabling the GC for all Alpine/musl builds in an attempt to work around the old #14737 segfault (V 0.2.4).
- That change caused the regression reported in #27090: the issue's repro grows to 5 GB+ of RAM on Alpine with the default flags, but stays at ~4 KB with `-gc boehm`.
- Restores the pre-regression help text in `build-c.txt` and the unknown-`-gc` error message in `pref.v` to their original wording.
- Replaces `test_musl_defaults_to_no_gc` / `test_musl_keeps_explicit_gc_selection` with a single regression test `test_musl_still_defaults_to_boehm_gc` referencing #27090.

Boehm GC works on current musl/Alpine; anyone who specifically wants `-gc none` can still pass it explicitly.

## Test plan
- [x] `./v -o vfix cmd/v` builds cleanly in the worktree.
- [x] `VFLAGS="-gc none" ./vfix test vlib/v/pref/pref_test.v` passes (including the new regression test).
- [x] `./vfix -musl examples/hello_world.v` builds and runs.
- [ ] CI on Alpine / docker-ubuntu-musl jobs.