### PR TITLE
markused: keep generic `next` for `for in` over instantiated iterators (fix #27147)

### DIFF
--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -802,9 +802,30 @@ pub fn (mut w Walker) stmt(node_ ast.Stmt) {
 					}
 				}
 				cond_type_sym := w.table.sym(resolved_cond_type)
-				if next_fn := cond_type_sym.find_method('next') {
+				mut next_method := cond_type_sym.find_method('next')
+				// Generic instantiated structs (e.g. `Range[big.Integer]`) have
+				// no methods of their own; the `next` method lives on the
+				// generic parent (`Range[T]`). The concrete types from the
+				// instantiation must be propagated to the walker, otherwise
+				// `remove_unused_fn_generic_types` may overwrite
+				// `fn_generic_types[next]` with the union derived from other
+				// callers (e.g. only `[int]` from a direct `iter.next()`),
+				// dropping the receiver type used here.
+				mut receiver_concrete_types := []ast.Type{}
+				if next_method == none && cond_type_sym.info is ast.Struct {
+					if cond_type_sym.info.concrete_types.len > 0
+						&& cond_type_sym.info.parent_type != 0 {
+						parent_sym := w.table.sym(cond_type_sym.info.parent_type)
+						if parent_next := parent_sym.find_method('next') {
+							next_method = parent_next
+							receiver_concrete_types = w.receiver_concrete_types(resolved_cond_type)
+						}
+					}
+				}
+				if next_fn := next_method {
 					unsafe {
-						w.fn_decl(mut &ast.FnDecl(next_fn.source_fn))
+						w.fn_decl_with_concrete_types(mut &ast.FnDecl(next_fn.source_fn),
+							receiver_concrete_types)
 					}
 				}
 			}

--- a/vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v
+++ b/vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v
@@ -175,3 +175,63 @@ fn test_skip_unused_marks_dependencies_inside_generic_anon_fns() {
 		panic(res.output)
 	}
 }
+
+fn test_skip_unused_keeps_generic_next_for_for_in_when_direct_calls_use_other_types() {
+	// Regression for https://github.com/vlang/v/issues/27147 .
+	// A `for in` over a generic iterator instantiation (e.g. `Range[big.Integer]`)
+	// must emit the matching `next` instantiation, even when other code calls
+	// methods on a different instantiation of the same generic struct directly
+	// (e.g. `iter.next()` on a `Range[int]`).
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_issue_27147')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(tmp_dir, 'issue_27147.v')
+	binary_path := os.join_path(tmp_dir, 'issue_27147')
+	source := [
+		'module main',
+		'',
+		'import math.big',
+		'',
+		'struct Range[T] {',
+		'\tstart T',
+		'\tend   T',
+		'\tstep  T',
+		'mut:',
+		'\tcur T',
+		'}',
+		'',
+		'pub fn (mut r Range[T]) next() ?T {',
+		'\tif r.cur > r.end {',
+		'\t\treturn none',
+		'\t}',
+		'\tdefer { r.cur += r.step }',
+		'\treturn r.cur',
+		'}',
+		'',
+		'pub fn (mut r Range[T]) reset() {',
+		'\tr.cur = r.start',
+		'}',
+		'',
+		'pub fn range[T](start T, end T, step T) Range[T] {',
+		'\treturn Range[T]{start: start, end: end, step: step, cur: start}',
+		'}',
+		'',
+		'fn main() {',
+		'\tmut iter := range(0, 5, 1)',
+		'\titer.reset()',
+		'\titer.next()',
+		'\tend := big.integer_from_int(3)',
+		'\tfor i in range[big.Integer](big.zero_int, end, big.one_int) {',
+		'\t\tprintln(i)',
+		'\t}',
+		'}',
+	].join('\n')
+	os.write_file(source_path, source) or { panic(err) }
+	res :=
+		os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(binary_path)} ${os.quoted_path(source_path)}')
+	if res.exit_code != 0 {
+		panic(res.output)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #27147.

When iterating a generic struct instantiation (e.g. `for i in range[big.Integer](...)`), the markused walker called `find_method('next')` on the instantiated symbol. Instantiated structs carry no methods of their own — they live on the generic parent — so the lookup returned `none` and the matching `next` instantiation was never recorded as used. When another call site used a different type parameter directly (e.g. `iter.next()` on a `Range[int]`), `remove_unused_fn_generic_types` Phase 2 overwrote `fn_generic_types[next]` with the union derived from the direct calls and dropped the type needed by the for-in.

The fix falls back to looking up `next` on the parent type when the instantiated symbol has no methods, and forwards the receiver's concrete types to `fn_decl_with_concrete_types` so the right instantiation survives the prune.

Minimal reproducer (previously failed with `implicit declaration of function 'ranges__Range_T_math__big__Integer_next_T_math__big__Integer'`):

```v
import math.big

struct Range[T] {
    start T
    end   T
    step  T
mut:
    cur T
}

pub fn (mut r Range[T]) next() ?T { /* ... */ }
pub fn (mut r Range[T]) reset()   { /* ... */ }
pub fn range[T](s T, e T, st T) Range[T] { /* ... */ }

fn main() {
    mut iter := range(0, 5, 1)
    iter.reset()
    iter.next()
    for i in range[big.Integer](big.zero_int, big.integer_from_int(3), big.one_int) {
        println(i)
    }
}
```

## Test plan

- [x] Added regression test `test_skip_unused_keeps_generic_next_for_for_in_when_direct_calls_use_other_types` in `vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v`.
- [x] `v test vlib/v/tests/` — 2114 passed, 5 skipped.
- [x] `v test vlib/v/tests/generics/` — 296 passed.
- [x] `v self` self-host succeeds.
- [x] Original reproducer from https://github.com/gechandesu/ranges/blob/a05536043672c1529a7723c01a67f2c96b4314b7/ranges_test.v passes with `v test .`.