### PR TITLE
parser, fmt: keep trailing comment on array element when next line starts with `.enum_val` (fix #27074)

### DIFF
--- a/vlib/v/fmt/tests/array_init_enum_short_no_comma_expected.vv
+++ b/vlib/v/fmt/tests/array_init_enum_short_no_comma_expected.vv
@@ -1,0 +1,11 @@
+enum EE {
+	a
+	b
+	c
+}
+
+const xs = [
+	EE.a, // first
+	.b, // missing comma
+	.c, // third
+]

--- a/vlib/v/fmt/tests/array_init_enum_short_no_comma_input.vv
+++ b/vlib/v/fmt/tests/array_init_enum_short_no_comma_input.vv
@@ -1,0 +1,11 @@
+enum EE {
+	a
+	b
+	c
+}
+
+const xs = [
+	EE.a, // first
+	.b // missing comma
+	.c, // third
+]

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -500,7 +500,8 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 		p.if_cond_comments << p.eat_comments()
 	}
 	if p.pref.is_fmt && p.tok.kind == .comment && p.peek_tok.kind.is_infix() && !p.inside_map_init
-		&& !(p.peek_tok.kind == .mul && p.peek_tok.pos().line_nr != p.tok.pos().line_nr) {
+		&& !(p.peek_tok.kind == .mul && p.peek_tok.pos().line_nr != p.tok.pos().line_nr)
+		&& !(p.peek_tok.kind == .dot && p.inside_array_lit) {
 		p.left_comments = p.eat_comments()
 	}
 	return p.expr_with_left(node, precedence, is_stmt_ident)


### PR DESCRIPTION
## Summary

Fixes #27074. `v fmt` was relocating a trailing comment on an array element to an unrelated `InfixExpr` (e.g. inside an `if` condition) when the next array element started with `.enum_val` shorthand and the comma had been omitted.

### Root cause

In `check_expr` (`vlib/v/parser/expr.v`), fmt mode eagerly consumes a trailing comment into `p.left_comments` whenever the peek token is an infix operator, so the comment can later be reattached to the `InfixExpr`. Inside an array literal, `.dot` continuation is blocked when there is a space/newline before the dot (`expr_with_left` at expr.v:715-717), so the comment was orphaned in `p.left_comments` and picked up by the next unrelated `infix_expr` call — for the issue's program, `a.num_touches > 0` inside `main`.

### Fix

Skip the eager `left_comments` consumption when peek is `.dot` and we are `inside_array_lit`. The comment then falls through to `eat_comments()` in `array_init`, staying attached to the correct array element.

## Test plan

- [x] New regression test `vlib/v/fmt/tests/array_init_enum_short_no_comma_{input,expected}.vv` — verified to fail without the patch
- [x] `./v test vlib/v/fmt/` — all 5 suites pass
- [x] `./v test vlib/v/parser/` — all 9 suites pass
- [x] `./v self` succeeds
- [x] Original reproduction from the issue formats correctly (comma inserted, `// clipboard_pasted` comment stays with its element, `main` body untouched)