### PR TITLE
checker, cgen: allow consts referencing each other inside anon fn bodies (fix #27087)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -84,6 +84,7 @@ pub mut:
 	strict_map_index_in_module  bool     // true if the current module has @[strict_map_index] attribute
 	const_var                   &ast.ConstField = unsafe { nil } // the current constant, when checking const declarations
 	const_deps                  []string
+	const_eval_stack            []string // names of constants currently being recursively resolved (to break cycles via anon fn bodies)
 	const_names                 []string
 	global_names                []string
 	locked_names                []string // vars that are currently locked
@@ -3439,6 +3440,7 @@ fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 	}
 	for i, mut field in node.fields {
 		c.const_deps << field.name
+		c.const_eval_stack << field.name
 		prev_const_var := c.const_var
 		c.const_var = unsafe { field }
 		mut typ := c.check_expr_option_or_result_call(field.expr, c.expr(mut field.expr))
@@ -3476,6 +3478,7 @@ fn (mut c Checker) const_decl(mut node ast.ConstDecl) {
 			}
 		}
 		c.const_deps = []
+		c.const_eval_stack.pop()
 		c.const_var = prev_const_var
 	}
 }
@@ -6350,7 +6353,9 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 		// detect cycles, while allowing for references to the same constant,
 		// used inside its initialisation like: `struct Abc { x &Abc } ... const a = [ Abc{0}, Abc{unsafe{&a[0]}} ]!`
 		// see vlib/v/tests/const_fixed_array_containing_references_to_itself_test.v
-		if unsafe { c.const_var != 0 } && name == c.const_var.name {
+		// references inside anonymous function bodies are runtime-only, so they
+		// cannot create an initialisation-time cycle (fix #27087)
+		if unsafe { c.const_var != 0 } && name == c.const_var.name && !c.inside_anon_fn {
 			if mut c.const_var.expr is ast.ArrayInit && c.const_var.expr.is_fixed
 				&& c.expected_type.nr_muls() > 0 {
 				elem_typ := c.expected_type.deref()
@@ -6366,7 +6371,9 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 			c.error('cycle in constant `${c.const_var.name}`', node.pos)
 			return ast.void_type
 		}
-		c.const_deps << name
+		if !c.inside_anon_fn {
+			c.const_deps << name
+		}
 	}
 	if node.kind == .blank_ident {
 		if node.tok_kind !in [.assign, .decl_assign] {
@@ -6606,11 +6613,44 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 					}
 					mut typ := obj.typ
 					if typ == 0 {
+						// a constant currently being recursively resolved is
+						// referenced again. Inside an anonymous function body the
+						// reference is runtime-only (fix #27087), so fall back to
+						// the expected type without caching it; otherwise this is
+						// a real multi-step initialisation cycle (e.g. a -> b -> a).
+						if obj.name in c.const_eval_stack {
+							if !c.inside_anon_fn {
+								c.error('cycle in constant `${obj.name}`', node.pos)
+								return ast.void_type
+							}
+							fallback_typ := if c.expected_type != ast.void_type {
+								c.expected_type
+							} else {
+								ast.void_type
+							}
+							node.name = name
+							node.kind = .constant
+							node.info = ast.IdentVar{
+								typ: fallback_typ
+							}
+							node.obj = obj
+							c.mark_const_decl_as_referenced(obj.name)
+							return fallback_typ
+						}
 						old_c_mod := c.mod
 						c.mod = obj.mod
 						inside_const := c.inside_const
 						c.inside_const = true
+						// the constant's own initializer is evaluated at
+						// init-time, even if the caller is checking an
+						// anon function body; clear inside_anon_fn so a
+						// cycle hit during this recursion is reported.
+						inside_anon_fn := c.inside_anon_fn
+						c.inside_anon_fn = false
+						c.const_eval_stack << obj.name
 						typ = c.expr(mut obj.expr)
+						c.const_eval_stack.pop()
+						c.inside_anon_fn = inside_anon_fn
 						c.inside_const = inside_const
 						c.mod = old_c_mod
 

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -2133,10 +2133,12 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 							g.inside_assign_fn_var = val is ast.PrefixExpr && val.op == .amp
 								&& is_fn_var
 							mut nval := val
+							mut nval_handled := false
 							if val is ast.PrefixExpr && val.right is ast.CallExpr {
 								call_expr := val.right as ast.CallExpr
 								if call_expr.name == 'new_array_from_c_array' {
 									nval = call_expr
+									nval_handled = true
 									if !var_type.has_flag(.shared_f) {
 										g.write('HEAP(${g.styp(var_type.clear_ref())}, ')
 									}
@@ -2146,7 +2148,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 									}
 								}
 							}
-							if nval == val {
+							if !nval_handled {
 								if auto_heap_uses_existing_storage {
 									g.write_auto_heap_assignment_expr(nval, val_type)
 								} else {

--- a/vlib/v/tests/consts/const_referencing_each_other_inside_anon_fns_test.v
+++ b/vlib/v/tests/consts/const_referencing_each_other_inside_anon_fns_test.v
@@ -1,0 +1,38 @@
+// Regression test for https://github.com/vlang/v/issues/27087
+// Constants that reference each other only inside anonymous function bodies
+// are not a real initialisation-time cycle (the bodies run at runtime).
+
+type FnPtr = fn (voidptr)
+
+fn FnPtr.nop(_ voidptr) {}
+
+struct AppViewFn {
+mut:
+	on_event  FnPtr = FnPtr.nop
+	on_update FnPtr = FnPtr.nop
+	on_draw   FnPtr = FnPtr.nop
+}
+
+struct AppView {
+mut:
+	on_fn AppViewFn
+}
+
+const fn_idle = AppViewFn{
+	on_event: fn (mut view AppView) {
+		view.on_fn = fn_track
+	}
+}
+
+const fn_track = AppViewFn{
+	on_event: fn (mut view AppView) {
+		view.on_fn = fn_idle
+	}
+}
+
+fn test_mutual_const_references_inside_anon_fn_bodies_compile() {
+	v := AppView{
+		on_fn: fn_idle
+	}
+	assert voidptr(v.on_fn.on_event) != unsafe { nil }
+}


### PR DESCRIPTION
## Summary

Fixes #27087.

V incorrectly reported a `cycle in constant` error when two constants referenced each other only inside anonymous function bodies. Those references are runtime-only (the bodies run at call time), so they cannot create an initialisation-time cycle.

- **`vlib/v/checker/checker.v`** — added a `const_eval_stack` to track which constants are currently being recursively resolved. The cycle error / const-dep edge is now skipped when the reference appears inside an anon fn body, and `ident_const`'s recursive `c.expr(obj.expr)` falls back to the expected type when the target is already on the stack (instead of recursing infinitely).
- **`vlib/v/gen/c/assign.v`** — the resulting AST contains a real cycle through `Ident.obj -> ConstField -> expr -> AnonFn body -> Ident.obj`, which tripped an unsafe `nval == val` deep struct equality in `assign_stmt`. Replaced with an explicit `nval_handled` boolean to keep cgen cycle-safe.
- **`vlib/v/tests/consts/const_referencing_each_other_inside_anon_fns_test.v`** — regression test.

## Test plan

- [x] Original repro from #27087 compiles cleanly
- [x] New regression test passes
- [x] All 46 tests in `vlib/v/tests/consts/` pass
- [x] Existing `const a = a + 0` direct-cycle test still errors with the same output
- [x] Double self-host succeeds
- [x] All 78 `cmd/tools` build clean