### PR TITLE
checker, cgen: fix `$for method in field.methods` dispatch (fix #27076)

### DIFF
--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -777,6 +777,13 @@ fn (mut c Checker) comptime_for(mut node ast.ComptimeFor) {
 			typ = c.unwrap_generic(node.typ)
 		}
 	}
+	// When the resolved type is FieldData, the expression refers to a comptime
+	// field variable (e.g. `$for method in field.methods` where `field` comes
+	// from an outer `$for field in T.fields`). In that case use the actual field
+	// type from the outer comptime loop instead of the FieldData descriptor type.
+	if node.typ == c.field_data_type {
+		typ = c.comptime.comptime_for_field_type
+	}
 	sym := if node.typ != c.field_data_type {
 		c.table.final_sym(typ)
 	} else {

--- a/vlib/v/checker/used_features.v
+++ b/vlib/v/checker/used_features.v
@@ -186,6 +186,15 @@ fn (mut c Checker) markused_method_call(mut node ast.CallExpr, mut left_expr ast
 				c.table.used_features.comptime_calls['${int(left_type.ref())}.${node.name}'] = true
 			}
 		}
+	} else if !left_type.has_flag(.generic) && left_expr is ast.ComptimeSelector {
+		// `x.$(field.name).method()` — the concrete receiver type varies per
+		// outer `$for f in T.fields` iteration, and skip-unused has no way to
+		// see the runtime dispatch. Mark the per-iteration receiver type so
+		// the method survives -skip-unused.
+		c.table.used_features.comptime_calls['${int(left_type)}.${node.name}'] = true
+		if !left_type.is_ptr() {
+			c.table.used_features.comptime_calls['${int(left_type.ref())}.${node.name}'] = true
+		}
 	} else if left_type.has_flag(.generic) {
 		unwrapped_left := c.unwrap_generic(left_type)
 		c.table.used_features.comptime_calls['${int(unwrapped_left)}.${node.name}'] = true

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -329,9 +329,13 @@ fn (mut g Gen) resolve_comptime_selector_field(node ast.ComptimeSelector, left_t
 		g.comptime.comptime_for_field_value.name
 	}
 	if node.field_expr is ast.SelectorExpr && g.comptime.comptime_for_field_var != ''
-		&& g.comptime.comptime_for_method_var == '' && node.field_expr.field_name == 'name' {
+		&& node.field_expr.field_name == 'name' {
 		if node.field_expr.expr is ast.Ident
 			&& node.field_expr.expr.name == g.comptime.comptime_for_field_var {
+			// The checker stores typ_key per AST node, so the cached field name
+			// in `typ_key` is stale after iteration; always prefer the current
+			// outer-loop field value here (also necessary when this `$(field.name)`
+			// is used inside a nested `$for method in field.methods`).
 			field_name = g.comptime.comptime_for_field_value.name
 		}
 	}

--- a/vlib/v/tests/comptime/comptime_for_field_methods_test.v
+++ b/vlib/v/tests/comptime/comptime_for_field_methods_test.v
@@ -1,0 +1,66 @@
+// Regression test for https://github.com/vlang/v/issues/27076 —
+// `$for method in field.methods` inside `$for field in T.fields` evaluated
+// `$if method.name == ...` against an empty method name and dropped the body.
+
+struct Comp1 {
+mut:
+	a int
+}
+
+fn (mut c Comp1) on_init() {
+	c.a = 42
+}
+
+struct Comp2 {
+mut:
+	b int
+}
+
+fn (mut c Comp2) on_init() {
+	c.b = 42
+}
+
+struct Comp3 {
+mut:
+	c int
+}
+
+fn (mut c Comp3) on_init() {
+	c.c = 42
+}
+
+struct Container {
+mut:
+	id   string
+	cmp1 Comp1
+	cmp2 Comp2
+	cmp3 Comp3
+	cmp4 Comp1
+	cmp5 Comp2
+	cmp6 Comp3
+	cmp7 Comp1
+	cmp8 Comp2
+	cmp9 Comp3
+}
+
+fn test_comptime_method_dispatch_on_struct_fields() {
+	mut app := Container{}
+	$for field in Container.fields {
+		$if field.is_struct {
+			$for method in field.methods {
+				$if method.name == 'on_init' {
+					app.$(field.name).on_init()
+				}
+			}
+		}
+	}
+	assert app.cmp1.a == 42
+	assert app.cmp2.b == 42
+	assert app.cmp3.c == 42
+	assert app.cmp4.a == 42
+	assert app.cmp5.b == 42
+	assert app.cmp6.c == 42
+	assert app.cmp7.a == 42
+	assert app.cmp8.b == 42
+	assert app.cmp9.c == 42
+}


### PR DESCRIPTION
## Summary

Fixes #27076. The nested comptime pattern

```v
$for field in T.fields {
    $if field.is_struct {
        $for method in field.methods {
            $if method.name == 'on_init' {
                app.$(field.name).on_init()
            }
        }
    }
}
```

silently dropped every call. Three coordinated fixes were needed:

- **checker/comptime.v** — when the resolved expr type is `FieldData` (because `$for method in field.methods` uses the field-descriptor type), use the outer `$for field in T.fields` field type instead. Otherwise `get_type_methods()` returns an empty list, `$if method.name == 'X'` evaluates against an empty method name, and the body is dropped.
- **gen/c/comptime.v** — drop the `comptime_for_method_var == ''` guard in `resolve_comptime_selector_field` so `$(field.name)` resolves to the current outer-loop field value when used inside a nested `$for method in field.methods`. Previously the stale `node.typ_key` (overwritten each iteration) was used, so every call dispatched to the last field.
- **checker/used_features.v** — `markused_method_call` now tracks `ComptimeSelector` receivers, so `-skip-unused` (default in `-prod`) does not drop the per-field methods.

## Test plan

- [x] New regression test `vlib/v/tests/comptime/comptime_for_field_methods_test.v` exercises the exact pattern from the issue with 9 fields across 3 struct types.
- [x] `vlib/v/tests/comptime` — 167/167 pass.
- [x] `vlib/v/tests/generics` — 296/296 pass.
- [x] Full `vlib/v/tests` — 2115 passed, 5 skipped, 0 failures.
- [x] Original repro returns `126` under default, `-prod`, and `-no-skip-unused`.