### PR TITLE
cgen: fix `IError` assignment to `?IError` field (fix #26973)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3367,7 +3367,8 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 		g.write('${tmp_styp} ${tmp_var} = ')
 		g.gen_option_error(error_target_type, expr)
 		g.writeln(';')
-	} else if expr is ast.Ident && expr_typ == ast.error_type {
+	} else if expr is ast.Ident && expr_typ == ast.error_type
+		&& !(unwrapped_ret_typ.has_flag(.option) && unwrapped_ret_typ.idx() == ast.error_type_idx) {
 		g.writeln('${g.styp(unwrapped_ret_typ)} ${tmp_var} = {.state=2, .err=${expr.name}};')
 	} else {
 		mut simple_assign := false

--- a/vlib/v/tests/options/option_ierror_field_test.v
+++ b/vlib/v/tests/options/option_ierror_field_test.v
@@ -1,0 +1,23 @@
+struct Holder {
+mut:
+	err ?IError
+}
+
+fn (mut h Holder) set_err(e IError) {
+	h.err = e
+}
+
+fn test_direct_assignment() {
+	mut h := Holder{}
+	assert h.err == none
+	h.err = error('boom')
+	got := h.err or { panic('expected Some, got none') }
+	assert got.msg() == 'boom'
+}
+
+fn test_method_assignment() {
+	mut h := Holder{}
+	h.set_err(error('method boom'))
+	got := h.err or { panic('expected Some, got none') }
+	assert got.msg() == 'method boom'
+}


### PR DESCRIPTION
## Summary

Fixes #26973 — assigning an `IError` value to a `?IError` struct field silently failed (the field stayed `none`).

`expr_with_tmp_var` had a fast-path for an `IError` ident expression that unconditionally emitted `{.state=2, .err=<ident>}`. That layout is correct when the target is a Result (`!T`), but wrong when the target is `?IError`: it produced an Option with `state=2` (the none state) instead of a Some value, so the assignment looked like it took but the option still read as `none`.

This fix skips the fast-path when the target is `?IError`, so the value flows through the normal Some-wrapping path and ends up at `state=0` with `.data` set to the IError.

## Test plan

- [x] Issue repro now prints `Option(some error)` after `c.error = err` and `if e := c.error { ... }` correctly unwraps it.
- [x] Added regression test `vlib/v/tests/options/option_ierror_field_test.v` covering direct and method-receiver assignment.
- [x] All 208 `vlib/v/tests/options/` tests pass (including `option_with_error_test.v` from the prior #23085 fix that introduced the fast-path).
- [x] All 12 `vlib/v/gen/c/` codegen tests pass (including `coutput_test.v` golden tests).
- [x] All `vlib/v/checker/tests/` fixtures pass.