### PR TITLE
checker: allow `C.S{}` zero-init for C structs with reference fields (fix #27170)

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -1495,7 +1495,8 @@ fn (mut c Checker) check_uninitialized_struct_fields_and_embeds(node ast.StructI
 		}
 		field_is_option := field.typ.has_flag(.option)
 		if field.typ.is_ptr() && !field.typ.has_flag(.shared_f) && !field_is_option
-			&& !node.has_update_expr && !c.pref.translated && !c.file.is_translated {
+			&& !node.has_update_expr && !c.pref.translated && !c.file.is_translated
+			&& type_sym.language != .c {
 			// Skip this check during generic recheck (concrete instantiation),
 			// because generic code like `T{}` or `Struct[V]{}` cannot provide
 			// initializers for reference fields that only appear after type substitution.

--- a/vlib/v/tests/c_structs/cstruct.h
+++ b/vlib/v/tests/c_structs/cstruct.h
@@ -33,3 +33,14 @@ typedef struct Bar {
 typedef struct TestAlias {
     int a;
 };
+
+///
+
+typedef struct MyRefStruct MyRefStruct;
+struct MyRefStruct {
+    char* format;
+    char* name;
+    void** children;
+    void (*release)(struct MyRefStruct*);
+    void* private_data;
+};

--- a/vlib/v/tests/c_structs/cstruct_ref_zero_init_test.c.v
+++ b/vlib/v/tests/c_structs/cstruct_ref_zero_init_test.c.v
@@ -1,0 +1,18 @@
+#include "@VMODROOT/cstruct.h"
+
+struct C.MyRefStruct {
+mut:
+	format       &char
+	name         &char
+	children     &voidptr
+	release      fn (&C.MyRefStruct)
+	private_data voidptr
+}
+
+fn test_c_struct_zero_init_with_ref_fields() {
+	s := C.MyRefStruct{}
+	assert s.format == unsafe { nil }
+	assert s.name == unsafe { nil }
+	assert s.children == unsafe { nil }
+	assert s.private_data == unsafe { nil }
+}


### PR DESCRIPTION
## Summary

Fix #27170. C-imported structs (`struct C.X { ... }`) commonly match real C ABI shapes where reference-typed fields are expected to start as `NULL` and be filled in by the caller (e.g. the Arrow C-Data interface). The current `reference field ... must be initialized` check is too strict for these — the user is opting into C ABI semantics and should be trusted.

This skips the check for the direct struct init when `type_sym.language == .c`. `check_ref_fields_initialized` already short-circuits on `.c` for nested cases, so the two now match.

Before:

```
error: reference field `C.MyStruct.format` must be initialized
error: reference field `C.MyStruct.name` must be initialized
error: reference field `C.MyStruct.children` must be initialized
```

After: `s := C.MyStruct{}` compiles and produces a zeroed struct, matching the manual `malloc` + `vmemset` workaround callers use today.

V-native struct checks are unchanged.

## Test plan

- [x] Reproducer from the issue compiles and runs
- [x] New regression test `vlib/v/tests/c_structs/cstruct_ref_zero_init_test.c.v` asserts all ref fields are nil after zero-init
- [x] V-native struct still errors when ref fields are uninitialized
- [x] `vlib/v/compiler_errors_test.v` (full checker test suite) passes
- [x] All 16 tests in `vlib/v/tests/c_structs/` pass
- [x] All 111 tests in `vlib/v/tests/structs/` pass