### PR TITLE
term: fix misleading example in README (fix #27120)

### DIFF
--- a/vlib/term/README.md
+++ b/vlib/term/README.md
@@ -41,42 +41,80 @@ This simple program covers many of the principal aspects of the `term ` module.
 
 ## API
 
-Here are some of the main functions of the `term `module:
+Here are some of the main functions of the `term` module. Note that the
+coloring/styling functions like `ok_message`, `yellow`, `bold`, etc., do
+*not* print anything by themselves — they return a new string with ANSI
+escape codes embedded, which you can then pass to `println` (or similar)
+to actually display the styled text on stdout.
 
 ```v
 import term
+import os
 
 // returns the height and the width of the terminal
 width, height := term.get_terminal_size()
-println('width: ${width}, height: ${height}')
-// returns the string as green text to be printed on stdout
-term.ok_message('cool')
-// returns the string as red text to be printed on stdout
-term.fail_message('oh, no')
-// returns the string as yellow text to be printed on stdout
-term.warn_message('be warned')
-// clears the entire terminal and leaves a blank one
+println('terminal dimensions: width: ${width} height: ${height}')
+
+mut output := ''
+
+// returns the string as green text
+output = 'ok_message() text ' + term.ok_message('is green')
+println(output)
+
+// returns the string as red text
+output = 'fail_message() text ' + term.fail_message('is red')
+println(output)
+
+// returns the string as yellow text
+output = 'warn_message() text ' + term.warn_message('is yellow')
+println(output)
+
+os.input('hit Enter to clear the console and continue')
+
+// clears the entire terminal
 term.clear()
 
-// Set the color output of the output.
+// Set the color output of the text.
 // The available colors are:
 // black, white, blue, yellow,
 // green, red, cyan, magenta,
 // bright_black, bright_white, bright_blue, bright_yellow,
 // bright_green, bright_red, bright_cyan, bright_magenta,
-term.yellow('submarine')
+output = 'yellow() - ' + term.yellow('text')
+println(output)
 
 // transforms the given string into bold text
-term.bold('and beautiful')
+output = 'bold() - ' + term.bold('text')
+println(output)
+
 // puts a strikethrough into the given string
-term.strikethrough('the core of the problem')
+output = 'strikethrough() - ' + term.strikethrough('text')
+println(output)
+
 // underlines the given string
-term.underline('important')
+output = 'underline() - ' + term.underline('text')
+println(output)
+
 // colors the background of the output following the given color
 // the available colors are: black, blue, yellow, green, cyan, gray
-term.bg_green('field')
-// sets the position of the cursor at a given place in the terminal
+output = 'bg_green() - ' + term.bg_green('text')
+println(output)
+
+// sets the position of the cursor
 term.set_cursor_position(x: 5, y: 10)
+println('Cursor at (5,10)')
+
+// flashes (blinks) the text
+output = term.slow_blink('done')
+println(output)
+```
+
+The `term` module also provides several lower-level cursor-control
+helpers, which write directly to stdout:
+
+```v
+import term
+
 // moves the cursor up
 term.cursor_up(1)
 // moves the cursor down


### PR DESCRIPTION
## Summary

- The API example in `vlib/term/README.md` had comments saying functions like `term.ok_message('cool')` are "printed on stdout", which is wrong — those helpers only return a styled string. Reported in #27120.
- Rewrote the example so each styling call is captured into `output` and `println`'d, making it actually runnable and demonstrating the colors/styles.
- Added a short note explaining that the coloring/styling helpers return a string with embedded ANSI escape codes and do not print on their own.
- Split the lower-level cursor controls (`cursor_up/down/forward/back`, `hide_cursor`, `show_cursor`) into a separate block, since those *do* write directly to stdout.

The example follows the wording the issue reporter and a maintainer agreed on in the thread.

## Test plan

- [x] `v -check` passes on both example code blocks