### PR TITLE
cgen: fix -prod -shared dlopen abort on macOS hardened runtime (fix #27165)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -10935,9 +10935,7 @@ fn (mut g Gen) write_init_function() {
 		g.export_funcs << '_vinit_caller'
 		g.writeln('void _vinit_caller() {')
 		g.writeln('\tstatic bool once = false; if (once) {return;} once = true;')
-		if g.pref.os == .windows {
-			g.gen_windows_shared_library_boehm_init()
-		}
+		g.gen_shared_library_boehm_init()
 		g.writeln('\t_vinit(0,0);')
 		g.writeln('}')
 

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -180,11 +180,14 @@ fn (mut g Gen) gen_boehm_gc_init() {
 	g.writeln('#endif')
 }
 
-fn (mut g Gen) gen_windows_shared_library_boehm_init() {
+fn (mut g Gen) gen_shared_library_boehm_init() {
 	if g.pref.gc_mode !in [.boehm_full, .boehm_incr, .boehm_full_opt, .boehm_incr_opt, .boehm_leak] {
 		return
 	}
 	g.writeln('#if defined(_VGCBOEHM)')
+	// macOS hardened runtime denies PROT_READ|PROT_WRITE|PROT_EXEC mappings from
+	// non-codesigned dylibs, so libgc must not request executable pages. The
+	// equivalent restriction applies to Windows DLLs.
 	g.writeln('\tGC_set_pages_executable(0);')
 	if g.pref.gc_mode in [.boehm_full_opt, .boehm_incr_opt] {
 		g.writeln('\tGC_set_free_space_divisor(2);')


### PR DESCRIPTION
## Summary

- Fixes #27165: `v -prod -shared` aborts when the resulting dylib is `dlopen`'d under macOS hardened runtime with `ABORT("Cannot allocate executable pages")` from the bundled libgc.
- Root cause: on non-Windows shared libraries, `_vinit_caller()` never called `GC_set_pages_executable(0)` before `GC_INIT()`. The bundled libgc therefore requested `PROT_READ|PROT_WRITE|PROT_EXEC` mmap, which macOS denies for non-codesigned dylibs (and other recent OS hardening rejects similarly).
- Fix: rename `gen_windows_shared_library_boehm_init` → `gen_shared_library_boehm_init` and invoke it unconditionally in `_vinit_caller()`, so every shared library disables executable GC pages before the first allocation, matching the existing Windows DLL behaviour.

## Test plan

- [x] Reproducer from the issue (`v -prod -shared -o libhello.dylib hello.v` then `dlopen` from C) now prints `result=5` instead of aborting.
- [x] `-shared` (no `-prod`), `-prod -gc none -shared`, and `-prod` executable still work.
- [x] `vlib/v/gen/c/coutput_test.v` passes (covers the existing Windows DLL assertion that `GC_set_pages_executable(0)` is emitted).
- [x] `vlib/v/tests/plugin_interface_shared_library_test.v` and `vlib/v/tests/shared_library_system_link_test.v` pass.