### PR TITLE
builder: skip foreign v.mod project dirs when resolving imports (fix #27151)

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -820,6 +820,31 @@ fn (b &Builder) module_path_has_v_files(path string) bool {
 	return b.v_files_from_dir(path).len > 0
 }
 
+// candidate_belongs_to_foreign_project returns true when `candidate_path` lives
+// inside a different `v.mod`-rooted project than the importer, and is not a
+// vlib/vmodules lookup entry. Such candidates are someone else's source tree:
+// e.g. when a `vlib/*` file imports `sync`, a sibling `coreutils/src/sync`
+// directory is not a real `sync` module and should be skipped (see #27151).
+fn (b &Builder) candidate_belongs_to_foreign_project(candidate_path string, importer_vmod_folder string) bool {
+	if importer_vmod_folder == '' {
+		return false
+	}
+	abs_candidate := os.real_path(candidate_path)
+	for lookup in b.pref.lookup_path {
+		abs_lookup := os.real_path(lookup)
+		if abs_candidate == abs_lookup
+			|| abs_candidate.starts_with(abs_lookup + os.path_separator) {
+			return false
+		}
+	}
+	mut mcache := vmod.get_cache()
+	candidate_vmod_folder := mcache.get_by_folder(candidate_path).vmod_folder
+	if candidate_vmod_folder == '' || candidate_vmod_folder == importer_vmod_folder {
+		return false
+	}
+	return os.real_path(candidate_vmod_folder) != os.real_path(importer_vmod_folder)
+}
+
 // TODO: try to merge this & util.module functions to create a
 // reliable multi use function. see comments in util/module.v
 pub fn (b &Builder) find_module_path(mod string, fpath string) !string {
@@ -827,6 +852,11 @@ pub fn (b &Builder) find_module_path(mod string, fpath string) !string {
 	mut mcache := vmod.get_cache()
 	resolved_fpath := os.real_path(fpath)
 	vmod_file_location := mcache.get_by_file(resolved_fpath)
+	importer_vmod_folder := if vmod_file_location.vmod_file.len != 0 {
+		vmod_file_location.vmod_folder
+	} else {
+		''
+	}
 	mod_path := module_path(mod)
 	mut module_lookup_paths := []string{}
 	if vmod_file_location.vmod_file.len != 0
@@ -852,6 +882,12 @@ pub fn (b &Builder) find_module_path(mod string, fpath string) !string {
 			println('  >> trying to find ${mod} in ${try_path} ..')
 		}
 		if found_path := find_module_path_from_search_root(search_path, mod) {
+			if b.candidate_belongs_to_foreign_project(found_path, importer_vmod_folder) {
+				if b.pref.is_verbose {
+					println('  << skipped ${found_path} (belongs to a different v.mod project) .')
+				}
+				continue
+			}
 			if b.module_path_has_v_files(found_path) {
 				if b.pref.is_verbose {
 					println('  << found ${found_path} .')
@@ -874,17 +910,22 @@ pub fn (b &Builder) find_module_path(mod string, fpath string) !string {
 			println('  >> trying to find ${mod} in ${try_path} ..')
 		}
 		if found_path := find_module_path_from_search_root(current_dir, mod) {
-			if b.module_path_has_v_files(found_path) {
+			if b.candidate_belongs_to_foreign_project(found_path, importer_vmod_folder) {
+				if b.pref.is_verbose {
+					println('  << skipped ${found_path} (belongs to a different v.mod project) .')
+				}
+			} else if b.module_path_has_v_files(found_path) {
 				if b.pref.is_verbose {
 					println('  << found ${found_path} .')
 				}
 				return found_path
-			}
-			if empty_module_path == '' {
-				empty_module_path = found_path
-			}
-			if b.pref.is_verbose {
-				println('  << skipped ${found_path} (no .v files) .')
+			} else {
+				if empty_module_path == '' {
+					empty_module_path = found_path
+				}
+				if b.pref.is_verbose {
+					println('  << skipped ${found_path} (no .v files) .')
+				}
 			}
 		}
 		parent_dir := os.dir(current_dir)

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -856,10 +856,25 @@ pub fn (b &Builder) find_module_path(mod string, fpath string) !string {
 	mut mcache := vmod.get_cache()
 	resolved_fpath := os.real_path(fpath)
 	vmod_file_location := mcache.get_by_file(resolved_fpath)
-	importer_vmod_folder := if vmod_file_location.vmod_file.len != 0 {
-		vmod_file_location.vmod_folder
-	} else {
-		''
+	// Anchor the importer to the OUTERMOST enclosing `v.mod`, not the nearest
+	// one. A file at `<project>/modules/<name>/file.v` carries the vendored
+	// package's `v.mod` as its nearest root, but logically belongs to
+	// `<project>` — and must be able to see sibling vendored deps under
+	// `<project>/modules/`.
+	mut importer_vmod_folder := ''
+	if vmod_file_location.vmod_file.len != 0 {
+		importer_vmod_folder = vmod_file_location.vmod_folder
+		for {
+			parent := os.dir(importer_vmod_folder)
+			if parent == importer_vmod_folder {
+				break
+			}
+			parent_loc := mcache.get_by_folder(parent)
+			if parent_loc.vmod_file == '' {
+				break
+			}
+			importer_vmod_folder = parent_loc.vmod_folder
+		}
 	}
 	mod_path := module_path(mod)
 	mut module_lookup_paths := []string{}

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -820,16 +820,25 @@ fn (b &Builder) module_path_has_v_files(path string) bool {
 	return b.v_files_from_dir(path).len > 0
 }
 
-// candidate_belongs_to_foreign_project returns true when `candidate_path` lives
-// inside a different `v.mod`-rooted project than the importer, and is not a
-// vlib/vmodules lookup entry. Such candidates are someone else's source tree:
-// e.g. when a `vlib/*` file imports `sync`, a sibling `coreutils/src/sync`
-// directory is not a real `sync` module and should be skipped (see #27151).
+// candidate_belongs_to_foreign_project returns true when `candidate_path` is
+// neither inside the importer's `v.mod` tree nor inside a configured
+// `lookup_path` entry (vlib / vmodules). Such candidates are someone else's
+// source tree: e.g. when a `vlib/*` file imports `sync`, a sibling
+// `coreutils/src/sync` directory is not a real `sync` module and should be
+// skipped (see #27151). Comparing by path containment (rather than by the
+// nearest enclosing `v.mod`) keeps vendored dependencies like
+// `<project>/modules/<name>/` — which carry their own `v.mod` — resolvable
+// from `<project>`'s own code.
 fn (b &Builder) candidate_belongs_to_foreign_project(candidate_path string, importer_vmod_folder string) bool {
 	if importer_vmod_folder == '' {
 		return false
 	}
 	abs_candidate := os.real_path(candidate_path)
+	abs_importer_vmod := os.real_path(importer_vmod_folder)
+	if abs_candidate == abs_importer_vmod
+		|| abs_candidate.starts_with(abs_importer_vmod + os.path_separator) {
+		return false
+	}
 	for lookup in b.pref.lookup_path {
 		abs_lookup := os.real_path(lookup)
 		if abs_candidate == abs_lookup
@@ -837,12 +846,7 @@ fn (b &Builder) candidate_belongs_to_foreign_project(candidate_path string, impo
 			return false
 		}
 	}
-	mut mcache := vmod.get_cache()
-	candidate_vmod_folder := mcache.get_by_folder(candidate_path).vmod_folder
-	if candidate_vmod_folder == '' || candidate_vmod_folder == importer_vmod_folder {
-		return false
-	}
-	return os.real_path(candidate_vmod_folder) != os.real_path(importer_vmod_folder)
+	return true
 }
 
 // TODO: try to merge this & util.module functions to create a

--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -401,6 +401,39 @@ fn test_vlib_import_does_not_match_user_project_dir() {
 	assert !res.output.contains('bad module definition'), res.output
 }
 
+fn test_vendored_sibling_modules_with_own_vmod_resolve_each_other() {
+	// Regression guard for the #27151 fix: when both the importer and the
+	// imported module live as siblings under `<project>/modules/` and each
+	// carry their own `v.mod`, the foreign-project check must still let them
+	// see one another. The importer's `v.mod` anchor needs to climb to the
+	// outermost project root, not stop at its own vendored package.
+	project_dir := os.join_path(test_path, 'vendored_sibling_27151')
+	os.rmdir_all(project_dir) or {}
+	os.mkdir_all(os.join_path(project_dir, 'modules', 'foo'))!
+	os.mkdir_all(os.join_path(project_dir, 'modules', 'bar'))!
+	defer {
+		os.chdir(test_path) or {}
+		os.rmdir_all(project_dir) or {}
+	}
+	os.write_file(os.join_path(project_dir, 'v.mod'),
+		"Module {\n\tname: 'vendored_sibling_27151'\n\tversion: '0.0.1'\n\tdescription: ''\n\tlicense: 'MIT'\n\tdependencies: []\n}\n")!
+	os.write_file(os.join_path(project_dir, 'modules', 'foo', 'v.mod'),
+		"Module {\n\tname: 'foo'\n\tversion: '0.0.1'\n\tdescription: ''\n\tlicense: 'MIT'\n\tdependencies: []\n}\n")!
+	os.write_file(os.join_path(project_dir, 'modules', 'bar', 'v.mod'),
+		"Module {\n\tname: 'bar'\n\tversion: '0.0.1'\n\tdescription: ''\n\tlicense: 'MIT'\n\tdependencies: []\n}\n")!
+	os.write_file(os.join_path(project_dir, 'modules', 'bar', 'bar.v'),
+		'module bar\n\npub fn name() string {\n\treturn "bar"\n}\n')!
+	os.write_file(os.join_path(project_dir, 'modules', 'foo', 'foo.v'),
+		'module foo\n\nimport bar\n\npub fn hello() string {\n\treturn bar.name()\n}\n')!
+	os.write_file(os.join_path(project_dir, 'main.v'),
+		'module main\n\nimport foo\n\nfn main() {\n\tprintln(foo.hello())\n}\n')!
+	os.chdir(project_dir)!
+
+	res := os.execute('${os.quoted_path(vexe)} -check .')
+	assert res.exit_code == 0, res.output
+	assert !res.output.contains('not found'), res.output
+}
+
 fn test_vendored_modules_dir_with_own_vmod_still_resolves() {
 	// Regression guard for the #27151 fix: a vendored dependency at
 	// `<project>/modules/<name>/` that carries its own `v.mod` must still

--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -371,6 +371,36 @@ fn test_macos_2048_build_does_not_force_deployment_target() {
 	assert !flags_output.contains('-mmacosx-version-min=')
 }
 
+fn test_vlib_import_does_not_match_user_project_dir() {
+	// Regression for vlang/v#27151: when V is invoked from inside another
+	// project that happens to have a `src/sync/` directory (e.g. coreutils),
+	// a vlib file that imports `sync` (via the `shared` keyword in
+	// `v.ast.Table`) must still resolve to vlib's sync module, not to the
+	// user's foreign `main` files.
+	project_dir := os.join_path(test_path, 'foreign_sync_27151')
+	os.rmdir_all(project_dir) or {}
+	os.mkdir_all(os.join_path(project_dir, 'src', 'sync'))!
+	os.mkdir_all(os.join_path(project_dir, 'src', 'app'))!
+	defer {
+		os.chdir(test_path) or {}
+		os.rmdir_all(project_dir) or {}
+	}
+	os.write_file(os.join_path(project_dir, 'v.mod'),
+		"Module {\n\tname: 'foreign_sync_27151'\n\tversion: '0.0.1'\n\tdescription: ''\n\tlicense: 'MIT'\n\tdependencies: []\n}\n")!
+	// `src/sync/sync.v` has no `module` declaration, so V defaults it to
+	// `module main`. It must not be picked up as the `sync` module when
+	// a vlib file (here, `v.ast`, which uses `shared`) imports `sync`.
+	os.write_file(os.join_path(project_dir, 'src', 'sync', 'sync.v'),
+		'import os\n\nfn run() {\n\tprintln(os.args)\n}\n')!
+	os.write_file(os.join_path(project_dir, 'src', 'app', 'app_test.v'),
+		'import v.ast\n\nfn test_vast_table_loads() {\n\t_ := ast.new_table()\n}\n')!
+	os.chdir(project_dir)!
+
+	res := os.execute('${os.quoted_path(vexe)} -check src/app/app_test.v')
+	assert res.exit_code == 0, res.output
+	assert !res.output.contains('bad module definition'), res.output
+}
+
 fn test_macos_arch_flag_is_forwarded_to_c_compiler() {
 	$if !macos {
 		return

--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -401,6 +401,34 @@ fn test_vlib_import_does_not_match_user_project_dir() {
 	assert !res.output.contains('bad module definition'), res.output
 }
 
+fn test_vendored_modules_dir_with_own_vmod_still_resolves() {
+	// Regression guard for the #27151 fix: a vendored dependency at
+	// `<project>/modules/<name>/` that carries its own `v.mod` must still
+	// resolve when imported from `<project>`'s own code. The foreign-project
+	// skip is path-based, so anything inside the importer's `v.mod` tree —
+	// including nested `v.mod`s under `modules/` — must remain visible.
+	project_dir := os.join_path(test_path, 'vendored_modules_27151')
+	os.rmdir_all(project_dir) or {}
+	os.mkdir_all(os.join_path(project_dir, 'modules', 'vendored'))!
+	defer {
+		os.chdir(test_path) or {}
+		os.rmdir_all(project_dir) or {}
+	}
+	os.write_file(os.join_path(project_dir, 'v.mod'),
+		"Module {\n\tname: 'vendored_modules_27151'\n\tversion: '0.0.1'\n\tdescription: ''\n\tlicense: 'MIT'\n\tdependencies: []\n}\n")!
+	os.write_file(os.join_path(project_dir, 'modules', 'vendored', 'v.mod'),
+		"Module {\n\tname: 'vendored'\n\tversion: '0.0.1'\n\tdescription: ''\n\tlicense: 'MIT'\n\tdependencies: []\n}\n")!
+	os.write_file(os.join_path(project_dir, 'modules', 'vendored', 'vendored.v'),
+		'module vendored\n\npub fn hello() string {\n\treturn "hi from vendored"\n}\n')!
+	os.write_file(os.join_path(project_dir, 'main.v'),
+		'module main\n\nimport vendored\n\nfn main() {\n\tprintln(vendored.hello())\n}\n')!
+	os.chdir(project_dir)!
+
+	res := os.execute('${os.quoted_path(vexe)} -check .')
+	assert res.exit_code == 0, res.output
+	assert !res.output.contains('not found'), res.output
+}
+
 fn test_macos_arch_flag_is_forwarded_to_c_compiler() {
 	$if !macos {
 		return


### PR DESCRIPTION
## Summary
- When V is invoked from inside another project (e.g. `vlang/coreutils`) that contains a sibling directory whose name matches a vlib module (like `src/sync/`), `find_module_path` would pick that user directory before trying vlib, and parsing then failed with `bad module definition: ... imports module "sync" but ...src/sync/sync.v is defined as module ` + "`main`" + `.
- Added `Builder.candidate_belongs_to_foreign_project` and use it in both lookup loops of `find_module_path` to skip candidates whose enclosing `v.mod` belongs to a different project than the importer, unless the candidate sits inside a configured `lookup_path` entry (vlib / vmodules).
- Added a regression test in `vlib/v/builder/builder_test.v` that constructs a fake user project with a `src/sync/` of `module main` files and `-check`s a file that imports `v.ast` (which transitively imports `sync` via `shared`).

## Test plan
- [x] Reproduces the original failure with the unfixed binary: `v -d trace_same_results -stats src/uptime/uptime_nix_test.v` inside a fresh `vlang/coreutils` clone.
- [x] Fixed binary no longer emits any `bad module definition` error for that command.
- [x] `./v self` succeeds and a second self-host pass succeeds.
- [x] New `test_vlib_import_does_not_match_user_project_dir` test in `vlib/v/builder/builder_test.v` fails on master and passes with this change.
- [x] Existing `vlib/v/builder/base_url_test.v` still passes; the `vlib/v/checker/tests/modules/` checker fixtures still resolve their imports.