### PR TITLE
cgen: fix string interpolation of `for mut item in []string` (fix #27122)

### DIFF
--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -726,6 +726,25 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 							fmts[i] = g.get_default_fmt(field_typ, field_typ)
 						}
 					}
+				} else if g.expr_is_auto_deref_var(expr_) && field_typ.is_ptr()
+					&& !field_typ.has_flag(.option) && !field_typ.has_flag(.shared_f) {
+					// `for mut x in arr` loop variables surface in C as pointers
+					// (e.g. `string*`), but `${x}` should interpolate the
+					// underlying value. Pick the format specifier from the
+					// dereferenced element type so it lands in the `%s` path
+					// instead of falling through to `%p`. The pointer type is
+					// preserved in expr_types so `str_val` still emits the
+					// required `*` when reading the value.
+					if !node_.need_fmts[i] {
+						deref_typ := field_typ.deref()
+						ftyp_sym := g.table.sym(deref_typ)
+						new_typ := if ftyp_sym.kind == .alias && !ftyp_sym.has_method('str') {
+							g.table.unalias_num_type(deref_typ)
+						} else {
+							deref_typ
+						}
+						fmts[i] = g.get_default_fmt(deref_typ, new_typ)
+					}
 				}
 			}
 			else {}

--- a/vlib/v/slow_tests/inout/printing_for_mut_string_27122.out
+++ b/vlib/v/slow_tests/inout/printing_for_mut_string_27122.out
@@ -1,0 +1,9 @@
+item value: alpha
+item after: CHANGED_alpha
+item value: beta
+item after: CHANGED_beta
+item value: gamma
+item after: CHANGED_gamma
+CHANGED_alpha
+CHANGED_beta
+CHANGED_gamma

--- a/vlib/v/slow_tests/inout/printing_for_mut_string_27122.vv
+++ b/vlib/v/slow_tests/inout/printing_for_mut_string_27122.vv
@@ -1,0 +1,11 @@
+fn main() {
+	mut items := ['alpha', 'beta', 'gamma']
+	for mut item in items {
+		println('item value: ${item}')
+		item = 'CHANGED_${item}'
+		println('item after: ${item}')
+	}
+	for item in items {
+		println(item)
+	}
+}


### PR DESCRIPTION
## Summary

- `for mut item in arr` loop variables surface in C as pointers (e.g. `string*`). The string interpolation auto-format selector saw the pointer type and fell through to `%p`, so `${item}` leaked the raw memory address instead of the underlying string value.
- Fix is in `vlib/v/gen/c/str_intp.v`: when the expression is an auto-deref ident with a pointer `field_typ`, pick the default format from the dereferenced element type so the `%s` path is chosen. The pointer type is kept in `expr_types`, so the existing `str_val` deref logic emits `*item` when reading the value.

## Test plan

- [x] Added `vlib/v/slow_tests/inout/printing_for_mut_string_27122.{vv,out}` covering the reproducer from #27122.
- [x] `v test vlib/v/tests/builtin_strings_and_interpolation/` — 49/49 pass.
- [x] `v test vlib/v/tests/loops/` — 39/39 pass.
- [x] `v test vlib/v/tests/builtin_arrays/` — 128/128 pass.
- [x] `v test vlib/v/gen/c/` — 12/12 pass.
- [x] `v test vlib/v/slow_tests/inout/` passes (including the new case).
- [x] Self-host (`v self`) succeeds.