### PR TITLE
pref: fall back to bundled tcc on Windows when gcc is not in PATH (fix #27119)

### DIFF
--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -468,6 +468,23 @@ pub fn default_tcc_compiler() string {
 	return usable_system_tcc_compiler()
 }
 
+// windows_default_c_compiler picks the host C compiler to default to on Windows.
+// `gcc` is the historical default, but plenty of Windows users only have the
+// bundled tcc that `makev.bat` provisions under `thirdparty/tcc/tcc.exe`.
+// Falling back to the bundled tcc when `gcc` isn't on PATH avoids confusing
+// "'gcc' is not recognized as an internal or external command" errors during
+// `v install`, `v outdated`, etc. (https://github.com/vlang/v/issues/27119).
+fn windows_default_c_compiler(vroot string) string {
+	if os.find_abs_path_of_executable('gcc') or { '' } != '' {
+		return 'gcc'
+	}
+	vtccexe := os.join_path(vroot, 'thirdparty', 'tcc', 'tcc.exe')
+	if os.is_file(vtccexe) && os.is_executable(vtccexe) {
+		return vtccexe
+	}
+	return 'gcc'
+}
+
 fn (mut p Preferences) clear_gc_options() {
 	p.compile_defines = p.compile_defines.filter(it !in windows_default_gc_defines)
 	p.compile_defines_all = p.compile_defines_all.filter(it !in windows_default_gc_defines)
@@ -503,7 +520,7 @@ fn (mut p Preferences) clear_gc_options() {
 pub fn (mut p Preferences) default_c_compiler() {
 	// TODO: fix $if after 'string'
 	$if windows {
-		p.ccompiler = 'gcc'
+		p.ccompiler = windows_default_c_compiler(os.dir(vexe_path()))
 		return
 	}
 	if p.os == .ios {

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -478,9 +478,9 @@ fn windows_default_c_compiler(vroot string) string {
 	if os.find_abs_path_of_executable('gcc') or { '' } != '' {
 		return 'gcc'
 	}
-	vtccexe := os.join_path(vroot, 'thirdparty', 'tcc', 'tcc.exe')
-	if os.is_file(vtccexe) && os.is_executable(vtccexe) {
-		return vtccexe
+	bundled_tcc := usable_bundled_tcc_compiler(vroot)
+	if bundled_tcc != '' {
+		return bundled_tcc
 	}
 	return 'gcc'
 }

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -520,6 +520,13 @@ fn (mut p Preferences) clear_gc_options() {
 pub fn (mut p Preferences) default_c_compiler() {
 	// TODO: fix $if after 'string'
 	$if windows {
+		// -prealloc and -prod intentionally avoid the bundled tcc (see
+		// try_to_use_tcc_by_default); preserve that here so the Windows fallback
+		// does not silently re-select an incompatible compiler.
+		if p.prealloc || p.is_prod {
+			p.ccompiler = 'gcc'
+			return
+		}
 		p.ccompiler = windows_default_c_compiler(os.dir(vexe_path()))
 		return
 	}

--- a/vlib/v/pref/default_tcc_compiler_test.v
+++ b/vlib/v/pref/default_tcc_compiler_test.v
@@ -220,6 +220,52 @@ fn test_try_to_use_tcc_by_default_resolves_explicit_tcc_to_system_tcc_on_termux(
 	assert prefs.ccompiler == system_tcc
 }
 
+fn test_windows_default_c_compiler_prefers_gcc_when_available() {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v_pref_default_c_compiler_test')
+	prepare_test_tcc_binary(test_root, 'exit 0')
+	fake_gcc := prepare_test_executable(test_root, 'bin/gcc', 'exit 0')
+	old_path := os.getenv('PATH')
+	os.setenv('PATH', os.dir(fake_gcc), true)
+	defer {
+		os.setenv('PATH', old_path, true)
+		os.rmdir_all(test_root) or {}
+	}
+	assert windows_default_c_compiler(test_root) == 'gcc'
+}
+
+fn test_windows_default_c_compiler_falls_back_to_bundled_tcc_when_no_gcc() {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v_pref_default_c_compiler_test')
+	tcc_path := prepare_test_tcc_binary(test_root, 'exit 0')
+	old_path := os.getenv('PATH')
+	os.setenv('PATH', os.join_path(test_root, 'no_such_path'), true)
+	defer {
+		os.setenv('PATH', old_path, true)
+		os.rmdir_all(test_root) or {}
+	}
+	assert windows_default_c_compiler(test_root) == tcc_path
+}
+
+fn test_windows_default_c_compiler_keeps_gcc_when_neither_is_available() {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v_pref_default_c_compiler_test')
+	os.rmdir_all(test_root) or {}
+	old_path := os.getenv('PATH')
+	os.setenv('PATH', os.join_path(test_root, 'no_such_path'), true)
+	defer {
+		os.setenv('PATH', old_path, true)
+		os.rmdir_all(test_root) or {}
+	}
+	assert windows_default_c_compiler(test_root) == 'gcc'
+}
+
 fn prepare_test_executable(test_root string, relative_path string, exit_line string) string {
 	path := os.join_path(test_root, relative_path)
 	os.mkdir_all(os.dir(path)) or { panic(err) }

--- a/vlib/v/pref/default_tcc_compiler_test.v
+++ b/vlib/v/pref/default_tcc_compiler_test.v
@@ -251,6 +251,21 @@ fn test_windows_default_c_compiler_falls_back_to_bundled_tcc_when_no_gcc() {
 	assert windows_default_c_compiler(test_root) == tcc_path
 }
 
+fn test_windows_default_c_compiler_keeps_gcc_when_bundled_tcc_is_broken() {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v_pref_default_c_compiler_test')
+	prepare_test_tcc_binary(test_root, 'exit 1')
+	old_path := os.getenv('PATH')
+	os.setenv('PATH', os.join_path(test_root, 'no_such_path'), true)
+	defer {
+		os.setenv('PATH', old_path, true)
+		os.rmdir_all(test_root) or {}
+	}
+	assert windows_default_c_compiler(test_root) == 'gcc'
+}
+
 fn test_windows_default_c_compiler_keeps_gcc_when_neither_is_available() {
 	$if windows {
 		return


### PR DESCRIPTION
## Summary
- Adds a `windows_default_c_compiler()` helper that prefers `gcc` when it is on PATH, falls back to the bundled `thirdparty/tcc/tcc.exe` otherwise, and only keeps `gcc` as a last resort.
- Wires it into `Preferences.default_c_compiler()` on Windows so users with only the bundled tcc no longer see `'gcc' is not recognized as an internal or external command` from `v install`, `v outdated`, etc.

Fixes #27119.

## Test plan
- [x] `vlib/v/pref/default_tcc_compiler_test.v` extended with three cases: gcc preferred when available, bundled tcc used as fallback, and gcc kept as last resort when neither exists.
- [ ] CI on Windows.