### PR TITLE
json: fix builtin___option_ok cast for option decoder (fixes #27103)

### DIFF
--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -162,7 +162,7 @@ ${dec_fn_dec} {
 			} else {
 				g.type_default(base_type)
 			}
-			dec.writeln('\tbuiltin___option_ok(&(${base_type_str}[]){ ${base_value} }, (${styp}*)&res, sizeof(${base_type_str}));\n')
+			dec.writeln('\tbuiltin___option_ok(&(${base_type_str}[]){ ${base_value} }, (${option_name}*)&res, sizeof(${base_type_str}));\n')
 		}
 
 		extern_str := if g.pref.parallel_cc { 'extern ' } else { '' }
@@ -1191,7 +1191,7 @@ fn (mut g Gen) decode_array(utyp ast.Type, value_type ast.Type, fixed_array_size
 		} else {
 			array_element_assign += 'builtin__array_push${noscan}((array*)&res.data, &val);'
 			res_str += 'builtin___option_ok(&(${g.base_type(utyp)}[]) { builtin____new_array${noscan}(0, 0, sizeof(${styp})) }, (${option_name}*)&res, sizeof(${g.base_type(utyp)}));'
-			array_free_str += 'builtin__array_free(&res.data);'
+			array_free_str += 'builtin__array_free((array*)&res.data);'
 		}
 	} else {
 		if is_array_fixed_val {

--- a/vlib/v/gen/c/testdata/json_option_decode_cast.c.must_have
+++ b/vlib/v/gen/c/testdata/json_option_decode_cast.c.must_have
@@ -1,0 +1,3 @@
+builtin___option_ok(&(int[]){ 0 }, (_option*)&res, sizeof(int));
+Array_main__Bar[]){ builtin____new_array(0, 0, sizeof(main__Bar)) }, (_option*)&res
+builtin__array_free((array*)&res.data);

--- a/vlib/v/gen/c/testdata/json_option_decode_cast.vv
+++ b/vlib/v/gen/c/testdata/json_option_decode_cast.vv
@@ -1,0 +1,23 @@
+module main
+
+import json
+
+struct Bar {
+	name string
+}
+
+struct Foo {
+	a ?int
+	b ?[]Bar
+}
+
+fn main() {
+	src := '{"a": 1, "b": [{"name": "x"}]}'
+	f := json.decode(Foo, src) or { return }
+	if v := f.a {
+		println(v)
+	}
+	if v := f.b {
+		println(v)
+	}
+}


### PR DESCRIPTION
## Summary
- `json.decode` on optional primitive/array types emitted a cast to the concrete option struct pointer (e.g. `(_option_string*)&res`) when calling `builtin___option_ok`, whose parameter is `_option*`.
- Similarly, `decode_array` passed `&res.data` (a fixed `byte[N]`) directly to `builtin__array_free`, which expects `array*`.
- Older clang/gcc accept these silently, but clang 22.1.3 now treats `-Wincompatible-pointer-types` as an error, causing vls and similar projects to fail with `-cc clang` or `-prod`.

Fix: cast to `_option*` and `array*` respectively — matching the function signatures and every other call site in the same file.

## Test plan
- [x] Build vls (https://github.com/vlang/vls) with `v -cc clang -cflags -Werror=incompatible-pointer-types .` — passes (previously 20 errors).
- [x] Build vls with `-prod -cc clang` — passes.
- [x] `v test vlib/json/tests` — 49/49 pass.