### PR TITLE
cgen: fix C error on `return $tmpl(...)` when fn returns Result/Option (fix #27094)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -10186,7 +10186,13 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			if !g.is_builtin_mod {
 				g.autofree_scope_vars(node.pos.pos - 1, node.pos.line_nr, true)
 			}
-			if fn_ret_type.has_option_or_result() {
+			// `$veb.html()` returns `veb.Result` and the template body
+			// already writes the rendered string to the response, so just
+			// return a zero-initialized Result here. Other tmpl kinds
+			// (`$tmpl(...)`) yield a string in `_tmpl_res_*`.
+			if expr0.kind == .html {
+				g.writeln('return (${ret_typ}){0};')
+			} else if fn_ret_type.has_option_or_result() {
 				tmp := g.new_tmp_var()
 				g.writeln('${ret_typ} ${tmp} = {0};')
 				if fn_ret_type.has_flag(.result) {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -10179,12 +10179,25 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			g.inside_return_tmpl = true
 			g.expr(expr0)
 			g.inside_return_tmpl = false
-			ret_typ := g.ret_styp(g.unwrap_generic(g.fn_decl.return_type))
+			fn_ret_type := g.fn_decl.return_type
+			ret_typ := g.ret_styp(g.unwrap_generic(fn_ret_type))
+			tmpl_fn_name := g.fn_decl.name.replace('.', '__').to_lower() + expr0.pos.pos.str()
 			g.write_defer_stmts_when_needed(node.scope, true, node.pos)
 			if !g.is_builtin_mod {
 				g.autofree_scope_vars(node.pos.pos - 1, node.pos.line_nr, true)
 			}
-			g.writeln('return (${ret_typ}){0};')
+			if fn_ret_type.has_option_or_result() {
+				tmp := g.new_tmp_var()
+				g.writeln('${ret_typ} ${tmp} = {0};')
+				if fn_ret_type.has_flag(.result) {
+					g.writeln('builtin___result_ok(&(string[]) { _tmpl_res_${tmpl_fn_name} }, (_result*)(&${tmp}), sizeof(string));')
+				} else {
+					g.writeln('builtin___option_ok(&(string[]) { _tmpl_res_${tmpl_fn_name} }, (_option*)(&${tmp}), sizeof(string));')
+				}
+				g.writeln('return ${tmp};')
+			} else {
+				g.writeln('return _tmpl_res_${tmpl_fn_name};')
+			}
 			return
 		}
 	}

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -434,7 +434,20 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 		} else {
 			// return $tmpl string
 			if g.inside_return_tmpl {
-				g.writeln('return _tmpl_res_${fn_name};')
+				fn_ret_type := g.fn_decl.return_type
+				if fn_ret_type.has_option_or_result() {
+					ret_styp := g.ret_styp(g.unwrap_generic(fn_ret_type))
+					tmp := g.new_tmp_var()
+					g.writeln('${ret_styp} ${tmp} = {0};')
+					if fn_ret_type.has_flag(.result) {
+						g.writeln('builtin___result_ok(&(string[]) { _tmpl_res_${fn_name} }, (_result*)(&${tmp}), sizeof(string));')
+					} else {
+						g.writeln('builtin___option_ok(&(string[]) { _tmpl_res_${fn_name} }, (_option*)(&${tmp}), sizeof(string));')
+					}
+					g.writeln('return ${tmp};')
+				} else {
+					g.writeln('return _tmpl_res_${fn_name};')
+				}
 			} else {
 				g.write(cur_line)
 				g.write('_tmpl_res_${fn_name}')

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -431,28 +431,13 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 			g.writeln('veb__Context_html(${g.veb_context_html_arg()}, _tmpl_res_${fn_name});')
 			g.writeln('strings__Builder_free(&sb_${fn_name});')
 			g.writeln('builtin__string_free(&_tmpl_res_${fn_name});')
-		} else {
-			// return $tmpl string
-			if g.inside_return_tmpl {
-				fn_ret_type := g.fn_decl.return_type
-				if fn_ret_type.has_option_or_result() {
-					ret_styp := g.ret_styp(g.unwrap_generic(fn_ret_type))
-					tmp := g.new_tmp_var()
-					g.writeln('${ret_styp} ${tmp} = {0};')
-					if fn_ret_type.has_flag(.result) {
-						g.writeln('builtin___result_ok(&(string[]) { _tmpl_res_${fn_name} }, (_result*)(&${tmp}), sizeof(string));')
-					} else {
-						g.writeln('builtin___option_ok(&(string[]) { _tmpl_res_${fn_name} }, (_option*)(&${tmp}), sizeof(string));')
-					}
-					g.writeln('return ${tmp};')
-				} else {
-					g.writeln('return _tmpl_res_${fn_name};')
-				}
-			} else {
-				g.write(cur_line)
-				g.write('_tmpl_res_${fn_name}')
-			}
+		} else if !g.inside_return_tmpl {
+			g.write(cur_line)
+			g.write('_tmpl_res_${fn_name}')
 		}
+		// when inside_return_tmpl, the cgen.v Return handler emits the
+		// return statement after defer/autofree so it can wrap the result
+		// for Option/Result return types (see issue #27094).
 		return
 	}
 	mut left_type := g.resolved_expr_type(node.left, node.left_type)

--- a/vlib/v/tests/tmpl_return_result_test.v
+++ b/vlib/v/tests/tmpl_return_result_test.v
@@ -1,0 +1,34 @@
+// Regression test for https://github.com/vlang/v/issues/27094
+// `return $tmpl(...)` from a function whose return type is a Result/Option
+// used to emit C code that returned the raw `string` without wrapping it in
+// the surrounding `_result_string` / `_option_string` struct.
+
+fn gen_result(flag int) !string {
+	if flag <= 0 {
+		return error('non-positive flag')
+	}
+	name := 'abc'
+	return $tmpl('tmpl/template.txt')
+}
+
+fn gen_option(flag int) ?string {
+	if flag <= 0 {
+		return none
+	}
+	name := 'abc'
+	return $tmpl('tmpl/template.txt')
+}
+
+fn test_tmpl_in_return_result() {
+	assert gen_result(1)! == 'abc\n'
+	if _ := gen_result(0) {
+		assert false
+	} else {
+		assert err.msg() == 'non-positive flag'
+	}
+}
+
+fn test_tmpl_in_return_option() {
+	assert gen_option(1)? == 'abc\n'
+	assert gen_option(0) or { 'none' } == 'none'
+}


### PR DESCRIPTION
## Summary

- `return $tmpl('...')` inside a fn returning `!T` or `?T` emitted a raw `return _tmpl_res_xxx;` (a plain `string`), causing C compilation to fail with `cannot convert 'struct string' to 'struct _result_string'`.
- When inside `return $tmpl` and the enclosing fn's return type carries the Option/Result flag, wrap the tmpl string via `builtin___result_ok` / `builtin___option_ok` into a tmp of the actual return type and return that.
- Plain `string` returns are unchanged.

## Test plan

- [x] Original repro from #27094 now compiles and prints `fooo`
- [x] New regression test `vlib/v/tests/tmpl_return_result_test.v` covers both `!string` and `?string` returns (success + error/none paths)
- [x] Existing `tmpl_*` tests still pass (`tmpl_test`, `tmpl_in_return_match_expr_test`, `multiple_comptime_tmpl_in_one_fn_test`, `tmpl_dot_var_test`, `tmpl_if_cond_test`, `for_brace_block_tmpl_test`)
- [x] `vlib/veb/tests/` all pass (22/22)
- [x] `v fmt -verify` clean