### PR TITLE
cgen: guard C extern fn decls with #ifndef to coexist with macros (fix #27098)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1312,7 +1312,11 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 			}
 		}
 	} else if g.inside_c_extern {
-		c_extern_fn_header := 'extern ${type_name} ${fn_attrs}${name.all_after_first('C__')}('
+		c_name := name.all_after_first('C__')
+		// Guard with #ifndef so the declaration is skipped when the C symbol
+		// is actually a preprocessor macro (e.g. WIFSTOPPED from <sys/wait.h>).
+		g.definitions.writeln('#ifndef ${c_name}')
+		c_extern_fn_header := 'extern ${type_name} ${fn_attrs}${c_name}('
 		g.definitions.write_string(c_extern_fn_header)
 	} else {
 		if !(node.is_pub || g.pref.is_debug) {
@@ -1360,7 +1364,9 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 		&& !g.pref.is_test) || skip {
 		// Just a function header. Builtin function bodies are defined in builtin.o
 		g.definitions.writeln(');') // NO BODY')
-		if !g.inside_c_extern {
+		if g.inside_c_extern {
+			g.definitions.writeln('#endif')
+		} else {
 			g.writeln(');')
 		}
 		return

--- a/vlib/v/gen/c/testdata/c_extern_macro_name_guard_nix.c.must_have
+++ b/vlib/v/gen/c/testdata/c_extern_macro_name_guard_nix.c.must_have
@@ -1,0 +1,8 @@
+#ifndef WIFSTOPPED
+extern bool WIFSTOPPED(i32 _d1);
+#ifndef WCOREDUMP
+extern bool WCOREDUMP(i32 _d1);
+#ifndef WIFCONTINUED
+extern bool WIFCONTINUED(i32 _d1);
+#ifndef WSTOPSIG
+extern int WSTOPSIG(i32 _d1);

--- a/vlib/v/gen/c/testdata/c_extern_macro_name_guard_nix.vv
+++ b/vlib/v/gen/c/testdata/c_extern_macro_name_guard_nix.vv
@@ -1,0 +1,24 @@
+// vtest vflags: -no-parallel
+// Regression test for https://github.com/vlang/v/issues/27098 .
+// When a C function name (e.g. `WIFSTOPPED` from <sys/wait.h>) is actually
+// a preprocessor macro, V should still be able to emit an `extern` forward
+// declaration without breaking C compilation. The declaration is guarded by
+// `#ifndef`, so the C preprocessor skips it whenever the symbol is a macro.
+
+#flag -lc
+
+fn C.WIFSTOPPED(i32) bool
+
+fn C.WCOREDUMP(i32) bool
+
+fn C.WIFCONTINUED(i32) bool
+
+fn C.WSTOPSIG(i32) int
+
+fn main() {
+	x := i32(0)
+	_ = C.WIFSTOPPED(x)
+	_ = C.WCOREDUMP(x)
+	_ = C.WIFCONTINUED(x)
+	_ = C.WSTOPSIG(x)
+}


### PR DESCRIPTION
## Summary

Fixes #27098.

Body-less `fn C.NAME(...)` declarations are emitted as `extern T NAME(...)` prototypes when the source file links a C library (`#flag -l...`) or links a `.c`/`.o` source. If `NAME` also happens to be a preprocessor macro (for example `WIFSTOPPED`, `WCOREDUMP`, `WIFCONTINUED`, `WSTOPSIG` from `<sys/wait.h>`), the C preprocessor expands the macro inside the prototype and the compilation fails:

```
cc: ...tmp.so.c:2782: error: ')' expected (got "_d1")
```

This PR wraps each emitted `extern` declaration in `#ifndef NAME` / `#endif`, so the declaration is skipped whenever the symbol is already a macro. Direct call sites continue to work because they pick up the macro's expansion.

## Test plan

- [x] Added regression test `vlib/v/gen/c/testdata/c_extern_macro_name_guard_nix.{vv,c.must_have}` exercising the four `<sys/wait.h>` macros from the issue.
- [x] Verified the issue reproducer (`v -shared wait.c.v`) builds cleanly with tcc, gcc, and clang.
- [x] Existing `c_extern_on_C_fn_declarations.vv` / `c_extern_on_C_global_declarations.vv` still match their `.c.must_have` expectations.
- [x] `./v self` succeeds.