### PR TITLE
checker: explain smartcast narrowing in or {} / ? error on unwrapped option (fix #27130)

### DIFF
--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -6403,10 +6403,12 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 		// Got a var with type T, return current generic type
 		if node.or_expr.kind != .absent {
 			if !info.typ.has_flag(.option) {
+				hint := c.smartcast_unwrap_hint(node.scope.find_var(node.name) or { unsafe { nil } })
 				if node.or_expr.kind == .propagate_option {
-					c.error('cannot use `?` on non-option variable', node.pos)
+					c.error('cannot use `?` on non-option variable${hint}', node.pos)
 				} else if node.or_expr.kind == .block {
-					c.error('cannot use `or {}` block on non-option variable', node.pos)
+					c.error('cannot use `or {}` block on non-option variable${hint}',
+						node.pos)
 				}
 			}
 			unwrapped_typ := typ.clear_option_and_result()
@@ -6552,10 +6554,13 @@ fn (mut c Checker) ident(mut node ast.Ident) ast.Type {
 							return typ.clear_flag(.result)
 						}
 						if !typ.has_flag(.option) {
+							hint := c.smartcast_unwrap_hint(&obj)
 							if node.or_expr.kind == .propagate_option {
-								c.error('cannot use `?` on non-option variable', node.pos)
+								c.error('cannot use `?` on non-option variable${hint}',
+									node.pos)
 							} else if node.or_expr.kind == .block {
-								c.error('cannot use `or {}` block on non-option variable', node.pos)
+								c.error('cannot use `or {}` block on non-option variable${hint}',
+									node.pos)
 							}
 						}
 						unwrapped_typ := typ.clear_option_and_result()
@@ -7312,6 +7317,17 @@ fn (mut c Checker) visible_var_type_for_read(v ast.Var) ast.Type {
 		return v.orig_type
 	}
 	return c.exposed_smartcast_type(v.orig_type, v.smartcasts.last(), v.is_mut)
+}
+
+fn (mut c Checker) smartcast_unwrap_hint(v &ast.Var) string {
+	if v == unsafe { nil } {
+		return ''
+	}
+	if v.smartcasts.len == 0 || !v.typ.has_flag(.option) {
+		return ''
+	}
+	narrowed := c.table.type_to_str(v.smartcasts.last())
+	return ' `${v.name}` (it was already unwrapped to `${narrowed}` by an earlier none check; use `${v.name}` directly)'
 }
 
 @[inline]

--- a/vlib/v/checker/tests/or_block_smartcast_unwrapped_err.out
+++ b/vlib/v/checker/tests/or_block_smartcast_unwrapped_err.out
@@ -1,0 +1,19 @@
+vlib/v/checker/tests/or_block_smartcast_unwrapped_err.vv:13:2: warning: unwrapping option is redundant as the function returns option
+   11 |         return none
+   12 |     }
+   13 |     return name?
+      |     ~~~~~~~~~~~
+   14 | }
+vlib/v/checker/tests/or_block_smartcast_unwrapped_err.vv:5:11: error: cannot use `or {}` block on non-option variable `name` (it was already unwrapped to `string` by an earlier none check; use `name` directly)
+    3 |         return
+    4 |     }
+    5 |     name_ := name or { '' }.trim_space()
+      |              ~~~~
+    6 |     println(name_)
+    7 | }
+vlib/v/checker/tests/or_block_smartcast_unwrapped_err.vv:13:9: error: cannot use `?` on non-option variable `name` (it was already unwrapped to `string` by an earlier none check; use `name` directly)
+   11 |         return none
+   12 |     }
+   13 |     return name?
+      |            ~~~~
+   14 | }

--- a/vlib/v/checker/tests/or_block_smartcast_unwrapped_err.vv
+++ b/vlib/v/checker/tests/or_block_smartcast_unwrapped_err.vv
@@ -1,0 +1,14 @@
+fn valid_name(name ?string) ! {
+	if name == none {
+		return
+	}
+	name_ := name or { '' }.trim_space()
+	println(name_)
+}
+
+fn propagate_name(name ?string) ?string {
+	if name == none {
+		return none
+	}
+	return name?
+}


### PR DESCRIPTION
## Summary

Improves the error message for `or {}` / `?` used on an option variable that has already been smartcast-narrowed to its unwrapped type by an earlier `if x == none { return }` (or `!= none`) check.

Before: ``cannot use `or {}` block on non-option variable`` — misleading, since the variable's declared type is `?string`.

After: ``cannot use `or {}` block on non-option variable `name` (it was already unwrapped to `string` by an earlier none check; use `name` directly)``.

The new wording matches the "Alternative" suggested in the issue: it tells the user the variable was narrowed and what to do instead, instead of pretending the variable was never an option.

Fixes #27130.

## Test plan

- [x] New regression test `vlib/v/checker/tests/or_block_smartcast_unwrapped_err.vv` covers both `or {}` and `?` on a smartcast-narrowed option variable
- [x] `./v -silent test vlib/v/compiler_errors_test.v` passes the new case
- [x] `./v self` rebuilds cleanly with the patched checker