### PR TITLE
fmt: keep single-line struct init inline inside single-line array literal

### DIFF
--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -2074,7 +2074,17 @@ pub fn (mut f Fmt) array_init(node ast.ArrayInit) {
 			if !is_new_line && i > 0 {
 				f.write(' ')
 			}
+			// When the array stays on a single source line, keep nested
+			// struct inits on a single line too (instead of expanding their
+			// named fields onto multiple lines).
+			keep_struct_inline := !line_break && expr is ast.StructInit
+				&& expr.pos.line_nr == expr.pos.last_line && expr.pre_comments.len == 0
+			old_single_line_fields := f.single_line_fields
+			if keep_struct_inline {
+				f.single_line_fields = true
+			}
 			f.expr(expr)
+			f.single_line_fields = old_single_line_fields
 		}
 		mut last_comment_was_inline := false
 		mut has_comments := node.ecmnts[i].len > 0

--- a/vlib/v/fmt/struct.v
+++ b/vlib/v/fmt/struct.v
@@ -367,7 +367,13 @@ pub fn (mut f Fmt) struct_init(node ast.StructInit) {
 				if !single_line_fields {
 					f.write(' '.repeat(value_align.max_len(init_field.pos.line_nr) - init_field.name.len))
 				}
+				if single_line_fields {
+					// Keep nested struct inits inline when the outer struct
+					// init is being formatted on a single line.
+					f.single_line_fields = true
+				}
 				f.expr(init_field.expr)
+				f.single_line_fields = false
 				if init_field.end_comments.len > 0 {
 					f.write(' '.repeat(comment_align.max_len(init_field.pos.line_nr) -
 						init_field.expr.str().len + 1))

--- a/vlib/v/fmt/tests/array_init_struct_inline_expected.vv
+++ b/vlib/v/fmt/tests/array_init_struct_inline_expected.vv
@@ -1,0 +1,11 @@
+struct Int {
+	val int
+}
+
+fn test() {
+	for x in [Int{}, Int{5}, Int{ val: 6 }] {
+		println(x.val)
+	}
+	a := [Int{ val: 1 }, Int{ val: 2 }]
+	println(a)
+}

--- a/vlib/v/fmt/tests/array_init_struct_inline_input.vv
+++ b/vlib/v/fmt/tests/array_init_struct_inline_input.vv
@@ -1,0 +1,11 @@
+struct Int {
+	val int
+}
+
+fn test() {
+	for x in [Int{}, Int{5}, Int{val: 6}] {
+		println(x.val)
+	}
+	a := [Int{val: 1}, Int{val: 2}]
+	println(a)
+}

--- a/vlib/v/tests/structs/struct_init_short_in_for_expr_test.v
+++ b/vlib/v/tests/structs/struct_init_short_in_for_expr_test.v
@@ -28,9 +28,7 @@ fn test_short_struct_init_multi_fields_in_for_in_array() {
 
 fn test_mixed_struct_init_styles_in_for_in_array() {
 	mut got := []int{}
-	for x in [Int{}, Int{5}, Int{
-		val: 6
-	}] {
+	for x in [Int{}, Int{5}, Int{ val: 6 }] {
 		got << x.val
 	}
 	assert got == [0, 5, 6]


### PR DESCRIPTION
## Summary

Previously, an array literal like `[Int{}, Int{5}, Int{val: 6}]` would
be reformatted with the last element broken across multiple lines, even
though the whole array fits on one source line:

```v
for x in [Int{}, Int{5}, Int{
    val: 6
}] {
```

`vfmt` now propagates the single-line context into nested struct inits
so they stay inline (e.g. `Int{ val: 6 }`), consistent with how struct
inits are already formatted as call args:

```v
for x in [Int{}, Int{5}, Int{ val: 6 }] {
```

## Changes

- `vlib/v/fmt/fmt.v` — in `array_init`, when an element is a single-line
  `StructInit` and the array itself is not line-broken, set
  `f.single_line_fields = true` before formatting that element.
- `vlib/v/fmt/struct.v` — in `struct_init`, when formatting a struct on
  a single line, propagate `single_line_fields` into the per-field
  `f.expr(init_field.expr)` call so nested struct inits also stay inline.
- `vlib/v/fmt/tests/array_init_struct_inline_{input,expected}.vv` —
  regression test for the new behavior.
- `vlib/v/tests/structs/struct_init_short_in_for_expr_test.v` — restored
  the test's intended single-line form, which is now preserved by vfmt.

## Test plan

- [x] `./v test vlib/v/fmt/` (all 5 fmt test suites pass, including the
  new `array_init_struct_inline` fixture and existing
  `fn_trailing_arg_syntax`).
- [x] `./v test vlib/v/tests/structs/struct_init_short_in_for_expr_test.v`
  (regression test for #27146 still passes).