### PR TITLE
Fix master CI failures on OpenBSD and markdown

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -4737,10 +4737,14 @@ fn (e Expect[[]T]) first_or(value T) T {
 }
 
 fn main() {
-	a := Expect[[]int]{value: [1, 2, 3]}
+	a := Expect[[]int]{
+		value: [1, 2, 3]
+	}
 	println(a.first_or(0)) // 1, T is bound to int
 
-	b := Expect[[]string]{value: []string{}}
+	b := Expect[[]string]{
+		value: []string{}
+	}
 	println(b.first_or('none')) // none, T is bound to string
 }
 ```
@@ -4763,7 +4767,11 @@ fn (e Expect[map[K]V]) get_or(key K, value V) V {
 }
 
 fn main() {
-	m := Expect[map[string]int]{value: {'a': 1}}
+	m := Expect[map[string]int]{
+		value: {
+			'a': 1
+		}
+	}
 	println(m.get_or('a', 0)) // 1   (K = string, V = int)
 	println(m.get_or('b', -1)) // -1
 }

--- a/vlib/db/mysql/mysql_compat.h
+++ b/vlib/db/mysql/mysql_compat.h
@@ -1,11 +1,12 @@
-// MYSQL_OPT_SSL_MODE was added in MySQL 5.7 and in MariaDB Connector/C 3.4.
-// Older mariadb-connector-c releases (still shipped by some BSDs and Linux
-// distributions) declare it as an enum value that is missing entirely,
-// which would cause the generated C code to fail to compile. Because the
-// symbol is an enum constant rather than a preprocessor macro, a plain
-// `#ifndef MYSQL_OPT_SSL_MODE` cannot detect it. Instead, gate on the
-// library's published version macros and supply a sentinel that
-// mysql_options() will reject at runtime.
-#if defined(MARIADB_PACKAGE_VERSION_ID) && MARIADB_PACKAGE_VERSION_ID < 30400
+// MYSQL_OPT_SSL_MODE was added in MySQL 5.7. MariaDB's server and connector
+// headers expose their own TLS options instead, so the generated C code would
+// fail to compile when it references the MySQL-only enum value. Because enum
+// values are not preprocessor macros, `#ifndef MYSQL_OPT_SSL_MODE` alone
+// cannot distinguish a MySQL header that has the enum from a MariaDB header
+// that does not. Gate on MariaDB's published macros and supply a sentinel that
+// mysql_options() will reject at runtime if Config.ssl_mode is used there.
+#if !defined(MYSQL_OPT_SSL_MODE) && \
+	(defined(MARIADB_BASE_VERSION) || defined(MARIADB_VERSION_ID) || \
+		defined(MARIADB_PACKAGE_VERSION_ID) || defined(LIBMARIADB))
 #define MYSQL_OPT_SSL_MODE 9999
 #endif

--- a/vlib/v/gen/c/testdata/c_extern_macro_name_guard_nix.vv
+++ b/vlib/v/gen/c/testdata/c_extern_macro_name_guard_nix.vv
@@ -5,14 +5,16 @@
 // declaration without breaking C compilation. The declaration is guarded by
 // `#ifndef`, so the C preprocessor skips it whenever the symbol is a macro.
 
-#flag -lc
-
+@[c_extern]
 fn C.WIFSTOPPED(i32) bool
 
+@[c_extern]
 fn C.WCOREDUMP(i32) bool
 
+@[c_extern]
 fn C.WIFCONTINUED(i32) bool
 
+@[c_extern]
 fn C.WSTOPSIG(i32) int
 
 fn main() {


### PR DESCRIPTION
## Summary
- Format the structured generic receiver examples in `doc/docs.md` so `check-md` passes.
- Make the c extern macro guard fixture use explicit `@[c_extern]` declarations, avoiding platform-dependent implicit extern emission.
- Broaden the MariaDB header compatibility fallback for `MYSQL_OPT_SSL_MODE` so OpenBSD MariaDB headers compile the MySQL examples.

## Root Cause
The latest master checks exposed one markdown formatting issue and two OpenBSD-specific compile paths. The cgen fixture depended on implicit extern generation behavior that was not stable across OpenBSD, and MariaDB headers there do not expose the MySQL-only `MYSQL_OPT_SSL_MODE` enum value.

## Validation
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w vlib/v/gen/c/testdata/c_extern_macro_name_guard_nix.vv`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew check-md -hide-warnings doc/docs.md`
- `git diff --check`
- local C compile probes for the MariaDB fallback and MySQL enum case