### PR TITLE
all: fix master CI module and MSSQL failures

### DIFF
--- a/vlib/db/mssql/_cdefs.c.v
+++ b/vlib/db/mssql/_cdefs.c.v
@@ -1,5 +1,18 @@
 module mssql
 
+type C.SQLCHAR = u8
+type C.SQLHDBC = voidptr
+type C.SQLHENV = voidptr
+type C.SQLHANDLE = voidptr
+type C.SQLHSTMT = voidptr
+type C.SQLHWND = voidptr
+type C.SQLINTEGER = int
+type C.SQLLEN = isize
+type C.SQLPOINTER = voidptr
+type C.SQLRETURN = i16
+type C.SQLSMALLINT = i16
+type C.SQLUSMALLINT = u16
+
 fn C.SQLAllocHandle(handle_type C.SQLSMALLINT, input_handle C.SQLHANDLE, output_handle &C.SQLHANDLE) C.SQLRETURN
 
 fn C.SQLSetEnvAttr(environment_handle C.SQLHENV, attribute C.SQLINTEGER, value C.SQLPOINTER, string_length C.SQLINTEGER) C.SQLRETURN

--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -829,7 +829,7 @@ fn (b &Builder) module_path_has_v_files(path string) bool {
 // nearest enclosing `v.mod`) keeps vendored dependencies like
 // `<project>/modules/<name>/` — which carry their own `v.mod` — resolvable
 // from `<project>`'s own code.
-fn (b &Builder) candidate_belongs_to_foreign_project(candidate_path string, importer_vmod_folder string) bool {
+fn (b &Builder) candidate_belongs_to_foreign_project(candidate_path string, importer_vmod_folder string, mod string) bool {
 	if importer_vmod_folder == '' {
 		return false
 	}
@@ -839,6 +839,9 @@ fn (b &Builder) candidate_belongs_to_foreign_project(candidate_path string, impo
 		|| abs_candidate.starts_with(abs_importer_vmod + os.path_separator) {
 		return false
 	}
+	if candidate_vmod_matches_import(abs_candidate, mod) {
+		return false
+	}
 	for lookup in b.pref.lookup_path {
 		abs_lookup := os.real_path(lookup)
 		if abs_candidate == abs_lookup || abs_candidate.starts_with(abs_lookup + os.path_separator) {
@@ -846,6 +849,16 @@ fn (b &Builder) candidate_belongs_to_foreign_project(candidate_path string, impo
 		}
 	}
 	return true
+}
+
+fn candidate_vmod_matches_import(candidate_path string, mod string) bool {
+	mut mcache := vmod.get_cache()
+	vmod_file_location := mcache.get_by_folder(candidate_path)
+	if vmod_file_location.vmod_file == '' {
+		return false
+	}
+	manifest := vmod.from_file(vmod_file_location.vmod_file) or { return false }
+	return manifest.name == mod || mod.starts_with(manifest.name + '.')
 }
 
 // TODO: try to merge this & util.module functions to create a
@@ -900,7 +913,7 @@ pub fn (b &Builder) find_module_path(mod string, fpath string) !string {
 			println('  >> trying to find ${mod} in ${try_path} ..')
 		}
 		if found_path := find_module_path_from_search_root(search_path, mod) {
-			if b.candidate_belongs_to_foreign_project(found_path, importer_vmod_folder) {
+			if b.candidate_belongs_to_foreign_project(found_path, importer_vmod_folder, mod) {
 				if b.pref.is_verbose {
 					println('  << skipped ${found_path} (belongs to a different v.mod project) .')
 				}
@@ -928,7 +941,7 @@ pub fn (b &Builder) find_module_path(mod string, fpath string) !string {
 			println('  >> trying to find ${mod} in ${try_path} ..')
 		}
 		if found_path := find_module_path_from_search_root(current_dir, mod) {
-			if b.candidate_belongs_to_foreign_project(found_path, importer_vmod_folder) {
+			if b.candidate_belongs_to_foreign_project(found_path, importer_vmod_folder, mod) {
 				if b.pref.is_verbose {
 					println('  << skipped ${found_path} (belongs to a different v.mod project) .')
 				}

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -169,7 +169,12 @@ fn mod_path_to_full_name(pref_ &pref.Preferences, mod string, path string) !stri
 						relative_parts := real_try_path.all_after(prefix).split(os.path_separator)
 						mod_full_name := normalize_base_url_mod_name(relative_parts.join('.'),
 							try_path)
-						return if mod_full_name.len < mod.len { mod } else { mod_full_name }
+						if mod_full_name.len < mod.len {
+							return mod
+						}
+						if !module_name_has_empty_part(mod_full_name) {
+							return mod_full_name
+						}
 					}
 				}
 				mut try_path_parts := try_path.split(os.path_separator)
@@ -192,7 +197,12 @@ fn mod_path_to_full_name(pref_ &pref.Preferences, mod string, path string) !stri
 				if last_v_mod > -1 {
 					mod_full_name := normalize_base_url_mod_name(try_path_parts[last_v_mod..].join('.'),
 						try_path)
-					return if mod_full_name.len < mod.len { mod } else { mod_full_name }
+					if mod_full_name.len < mod.len {
+						return mod
+					}
+					if !module_name_has_empty_part(mod_full_name) {
+						return mod_full_name
+					}
 				}
 			}
 		}
@@ -210,6 +220,18 @@ fn mod_path_to_full_name(pref_ &pref.Preferences, mod string, path string) !stri
 		}
 	}
 	return error('module not found')
+}
+
+fn module_name_has_empty_part(name string) bool {
+	if name == '' {
+		return true
+	}
+	for part in name.split('.') {
+		if part == '' {
+			return true
+		}
+	}
+	return false
 }
 
 // project_root_vmod_folder returns the absolute folder of the closest


### PR DESCRIPTION
## Summary
- avoid qualifying modules with invalid hidden-directory prefixes when compiling relative paths under the repo root
- allow sibling packages to resolve when the candidate package's `v.mod` name matches the import
- declare MSSQL ODBC C typedefs for V's checker before using the ODBC C API

## Validation
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w vlib/v/util/module.v vlib/v/builder/builder.v vlib/db/mssql/_cdefs.c.v`
- `./vnew -silent vlib/v/tests/relative_nested_module_lookup_test.v`
- `./vnew -silent vlib/v/tests/projects_that_should_compile_test.v`
- `VFLAGS='-cc clang' ./vnew -silent vlib/v/builder/builder_test.v`
- `./vnew -silent vlib/v/util/util_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -d started_mssql -silent test vlib/db/mssql/` reached local header discovery (`sql.h` missing here) after the previous unknown `C.SQL*` type errors were gone

## Notes
- The latest master run still has separate V2 failures and external infrastructure failures (`termux-build` mirror/package issue and `vsl-compiles` timeout) that are not covered by this focused change.