### PR TITLE
ast: count duplicate sumtype fields once

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -872,7 +872,12 @@ pub fn (t &Table) resolve_common_sumtype_fields(mut sym TypeSymbol) {
 			}
 		}
 
+		mut counted_field_names := map[string]bool{}
 		for field in fields {
+			if field.name in counted_field_names {
+				continue
+			}
+			counted_field_names[field.name] = true
 			if field.name !in field_map {
 				field_map[field.name] = field
 				field_usages[field.name]++

--- a/vlib/v/tests/sumtype_common_fields_duplicate_embed_test.v
+++ b/vlib/v/tests/sumtype_common_fields_duplicate_embed_test.v
@@ -1,0 +1,41 @@
+struct CommonTrace {
+mut:
+	name   string
+	marker int
+}
+
+struct TraceWithDuplicateMarker {
+	CommonTrace
+mut:
+	marker int
+}
+
+struct TraceWithMarker {
+	CommonTrace
+}
+
+struct TraceWithoutMarker {
+mut:
+	name string
+}
+
+type Trace = TraceWithDuplicateMarker | TraceWithMarker | TraceWithoutMarker
+
+fn test_duplicate_embedded_fields_do_not_create_false_common_sumtype_field() {
+	traces := [
+		Trace(TraceWithDuplicateMarker{
+			name:   'duplicate'
+			marker: 1
+		}),
+		Trace(TraceWithMarker{
+			name: 'marker'
+		}),
+		Trace(TraceWithoutMarker{
+			name: 'plain'
+		}),
+	]
+
+	assert traces[0].name == 'duplicate'
+	assert traces[1].name == 'marker'
+	assert traces[2].name == 'plain'
+}


### PR DESCRIPTION
## Summary

Fixes false common-field detection for sum types whose variants expose the same field name more than once through direct and embedded fields.

VSL's `Trace` sum type hit this when some variants had `marker` both directly and through `CommonTrace`. The duplicate count made `marker` look common even though `ParallelCoordinatesTrace` and `SankeyTrace` do not define it, causing generated C to access missing fields in the VSL/VTL CI jobs.

## Changes

- Count each field name at most once per sum type variant while resolving common sum type fields.
- Add a regression test covering duplicate embedded fields that should not create a false common field.

## Validation

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -cc clang -silent test vlib/v/tests/sumtype_default_common_field_test.v vlib/v/tests/sumtype_common_fields_duplicate_embed_test.v`
- `./vnew -cc gcc -silent test vlib/v/tests/sumtype_common_fields_duplicate_embed_test.v`
- `/Users/alexander/code/v2/vnew -d vsl_vcl_dlopencl -cc gcc -d vsl_vulkan_dlopen -silent test plot/plot_test.v` in `/Users/alexander/code/vsl`
- `VMODULES=/Users/alexander/code /Users/alexander/code/v2/vnew -d vsl_vcl_dlopencl -cc gcc -d vsl_vulkan_dlopen examples/nn_training_metrics_plot/main.v` in `/Users/alexander/code/vtl`