### PR TITLE
v2: emit Mach-O objects for x64 on macOS

### DIFF
--- a/vlib/v2/builder/builder.v
+++ b/vlib/v2/builder/builder.v
@@ -2027,6 +2027,12 @@ fn (mut b Builder) gen_native(backend_arch pref.Arch) {
 		'out'
 	}
 
+	if arch == .x64 && os.user_os() == 'windows' {
+		eprintln('error: the v2 x64 native backend does not support Windows yet')
+		eprintln('hint: Windows x64 requires COFF object output and the Windows x64 calling convention')
+		exit(1)
+	}
+
 	if arch == .arm64 && os.user_os() == 'macos' {
 		// Use built-in linker for ARM64 macOS
 		stage_start = native_sw.elapsed()
@@ -2066,7 +2072,12 @@ fn (mut b Builder) gen_native(backend_arch pref.Arch) {
 			}
 			gen.write_file(obj_file)
 		} else {
-			mut gen := x64.Gen.new(&mir_mod)
+			obj_format := if os.user_os() == 'macos' {
+				x64.ObjectFormat.macho
+			} else {
+				x64.ObjectFormat.elf
+			}
+			mut gen := x64.Gen.new_with_format(&mir_mod, obj_format)
 			gen.gen()
 			gen.write_file(obj_file)
 		}

--- a/vlib/v2/gen/x64/elf.v
+++ b/vlib/v2/gen/x64/elf.v
@@ -80,13 +80,24 @@ pub fn ElfObject.new() &ElfObject {
 }
 
 pub fn (mut e ElfObject) add_symbol(name string, value u64, is_func bool, shndx u16) int {
-	idx := e.symbols.len
-	name_off := e.add_string(name)
-
 	// STB_GLOBAL (1) << 4 | STT_FUNC (2) or STT_OBJECT (1) or STT_NOTYPE (0)
 	type_ := if is_func { u8(2) } else { u8(1) } // Func : Object
 	bind := u8(1) // Global
 	info := (bind << 4) | type_
+
+	for i := 1; i < e.symbols.len; i++ {
+		if e.symbols[i].name != name {
+			continue
+		}
+		mut s := &e.symbols[i]
+		s.info = info
+		s.shndx = shndx
+		s.value = value
+		return i
+	}
+
+	idx := e.symbols.len
+	name_off := e.add_string(name)
 
 	e.symbols << ElfSymbol{
 		name:     name
@@ -99,9 +110,8 @@ pub fn (mut e ElfObject) add_symbol(name string, value u64, is_func bool, shndx 
 }
 
 pub fn (mut e ElfObject) add_undefined(name string) int {
-	// Check existing
-	for i, s in e.symbols {
-		if s.name == name && s.shndx == 0 && i > 0 {
+	for i := 1; i < e.symbols.len; i++ {
+		if e.symbols[i].name == name {
 			return i
 		}
 	}

--- a/vlib/v2/gen/x64/macho.v
+++ b/vlib/v2/gen/x64/macho.v
@@ -1,0 +1,282 @@
+// Copyright (c) 2026 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module x64
+
+import os
+
+const macho_mh_magic_64 = u32(0xfeedfacf)
+const macho_cpu_type_x86_64 = 0x01000007
+const macho_cpu_subtype_x86_64_all = 3
+const macho_mh_object = 1
+const macho_lc_segment_64 = 0x19
+const macho_lc_symtab = 0x2
+
+const x86_64_reloc_signed = 1
+const x86_64_reloc_branch = 2
+
+pub struct MachOObject {
+pub mut:
+	text_data []u8
+	data_data []u8
+	rodata    []u8
+
+	relocs      []MachORelocationInfo
+	symbols     []MachOSymbol
+	str_table   []u8
+	sym_by_name map[string]int
+}
+
+struct MachORelocationInfo {
+	addr    int
+	sym_idx int
+	pcrel   bool
+	length  int
+	extern  bool
+	type_   int
+}
+
+struct MachOSymbol {
+mut:
+	name     string
+	type_    u8
+	sect     u8
+	desc     u16
+	value    u64
+	name_off int
+}
+
+pub fn MachOObject.new() &MachOObject {
+	return &MachOObject{
+		str_table: [u8(0)]
+	}
+}
+
+pub fn (mut m MachOObject) add_symbol(name string, value u64, is_ext bool, sect u8) int {
+	typ := if is_ext { u8(0x0f) } else { u8(0x0e) }
+	if i := m.sym_by_name[name] {
+		mut s := &m.symbols[i]
+		s.type_ = typ
+		s.sect = sect
+		s.value = value
+		return i
+	}
+
+	idx := m.symbols.len
+	name_off := m.add_string(name)
+	m.symbols << MachOSymbol{
+		name:     name
+		type_:    typ
+		sect:     sect
+		desc:     0
+		value:    value
+		name_off: name_off
+	}
+	m.sym_by_name[name] = idx
+	return idx
+}
+
+pub fn (mut m MachOObject) add_undefined(name string) int {
+	if i := m.sym_by_name[name] {
+		return i
+	}
+
+	idx := m.symbols.len
+	name_off := m.add_string(name)
+	m.symbols << MachOSymbol{
+		name:     name
+		type_:    0x01 // N_UNDF | N_EXT
+		sect:     0
+		desc:     0
+		value:    0
+		name_off: name_off
+	}
+	m.sym_by_name[name] = idx
+	return idx
+}
+
+pub fn (mut m MachOObject) add_reloc(addr int, sym_idx int, typ int, pcrel bool, length int) {
+	m.relocs << MachORelocationInfo{
+		addr:    addr
+		sym_idx: sym_idx
+		type_:   typ
+		pcrel:   pcrel
+		length:  length
+		extern:  true
+	}
+}
+
+fn (mut m MachOObject) add_string(s string) int {
+	off := m.str_table.len
+	m.str_table << s.bytes()
+	m.str_table << 0
+	return off
+}
+
+pub fn (mut m MachOObject) write(path string) {
+	mut buf := []u8{}
+
+	n_sects := 3
+	header_size := 32
+	seg_cmd_size := 72 + (80 * n_sects)
+	symtab_cmd_size := 24
+	load_cmds_size := seg_cmd_size + symtab_cmd_size
+
+	text_off := align_int(header_size + load_cmds_size, 16)
+	text_len := m.text_data.len
+	rodata_off := align_int(text_off + text_len, 8)
+	rodata_len := m.rodata.len
+	data_off := align_int(rodata_off + rodata_len, 8)
+	data_len := m.data_data.len
+
+	text_addr := 0
+	rodata_addr := align_int(text_addr + text_len, 8)
+	data_addr := align_int(rodata_addr + rodata_len, 8)
+	total_size := data_addr + data_len
+
+	reloc_off := align_int(data_off + data_len, 8)
+	sym_off := align_int(reloc_off + (m.relocs.len * 8), 8)
+	sym_len := m.symbols.len * 16
+	str_off := sym_off + sym_len
+	str_size := m.str_table.len
+
+	write_u32_le(mut buf, macho_mh_magic_64)
+	write_u32_le(mut buf, u32(macho_cpu_type_x86_64))
+	write_u32_le(mut buf, u32(macho_cpu_subtype_x86_64_all))
+	write_u32_le(mut buf, macho_mh_object)
+	write_u32_le(mut buf, 2)
+	write_u32_le(mut buf, u32(load_cmds_size))
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+
+	write_u32_le(mut buf, macho_lc_segment_64)
+	write_u32_le(mut buf, u32(seg_cmd_size))
+	write_fixed_string(mut buf, '', 16)
+	write_u64_le(mut buf, 0)
+	write_u64_le(mut buf, u64(total_size))
+	write_u64_le(mut buf, u64(text_off))
+	write_u64_le(mut buf, u64(data_off + data_len - text_off))
+	write_u32_le(mut buf, 7)
+	write_u32_le(mut buf, 7)
+	write_u32_le(mut buf, u32(n_sects))
+	write_u32_le(mut buf, 0)
+
+	write_fixed_string(mut buf, '__text', 16)
+	write_fixed_string(mut buf, '__TEXT', 16)
+	write_u64_le(mut buf, u64(text_addr))
+	write_u64_le(mut buf, u64(text_len))
+	write_u32_le(mut buf, u32(text_off))
+	write_u32_le(mut buf, 4)
+	write_u32_le(mut buf, u32(reloc_off))
+	write_u32_le(mut buf, u32(m.relocs.len))
+	write_u32_le(mut buf, u32(0x80000400))
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+
+	write_fixed_string(mut buf, '__const', 16)
+	write_fixed_string(mut buf, '__TEXT', 16)
+	write_u64_le(mut buf, u64(rodata_addr))
+	write_u64_le(mut buf, u64(rodata_len))
+	write_u32_le(mut buf, u32(rodata_off))
+	write_u32_le(mut buf, 3)
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+
+	write_fixed_string(mut buf, '__data', 16)
+	write_fixed_string(mut buf, '__DATA', 16)
+	write_u64_le(mut buf, u64(data_addr))
+	write_u64_le(mut buf, u64(data_len))
+	write_u32_le(mut buf, u32(data_off))
+	write_u32_le(mut buf, 3)
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+	write_u32_le(mut buf, 0)
+
+	write_u32_le(mut buf, macho_lc_symtab)
+	write_u32_le(mut buf, u32(symtab_cmd_size))
+	write_u32_le(mut buf, u32(sym_off))
+	write_u32_le(mut buf, u32(m.symbols.len))
+	write_u32_le(mut buf, u32(str_off))
+	write_u32_le(mut buf, u32(str_size))
+
+	for buf.len < text_off {
+		buf << 0
+	}
+	buf << m.text_data
+	for buf.len < rodata_off {
+		buf << 0
+	}
+	buf << m.rodata
+	for buf.len < data_off {
+		buf << 0
+	}
+	buf << m.data_data
+
+	for buf.len < reloc_off {
+		buf << 0
+	}
+	for r in m.relocs {
+		write_u32_le(mut buf, u32(r.addr))
+		mut info := u32(r.sym_idx)
+		if r.pcrel {
+			info |= 1 << 24
+		}
+		info |= u32(r.length) << 25
+		if r.extern {
+			info |= 1 << 27
+		}
+		info |= u32(r.type_) << 28
+		write_u32_le(mut buf, info)
+	}
+
+	for buf.len < sym_off {
+		buf << 0
+	}
+	for s in m.symbols {
+		write_u32_le(mut buf, u32(s.name_off))
+		buf << s.type_
+		buf << s.sect
+		write_u16_le(mut buf, s.desc)
+		write_u64_le(mut buf, m.symbol_value(s, rodata_addr, data_addr))
+	}
+
+	buf << m.str_table
+
+	os.write_file_array(path, buf) or { panic(err) }
+}
+
+fn (m MachOObject) symbol_value(s MachOSymbol, rodata_addr int, data_addr int) u64 {
+	return match s.sect {
+		1 { s.value }
+		2 { u64(rodata_addr) + s.value }
+		3 { u64(data_addr) + s.value }
+		else { s.value }
+	}
+}
+
+fn align_int(value int, alignment int) int {
+	if alignment <= 1 || value % alignment == 0 {
+		return value
+	}
+	return value + (alignment - (value % alignment))
+}
+
+fn write_fixed_string(mut b []u8, s string, len int) {
+	bytes := s.bytes()
+	for i in 0 .. len {
+		if i < bytes.len {
+			b << bytes[i]
+		} else {
+			b << 0
+		}
+	}
+}

--- a/vlib/v2/gen/x64/object.v
+++ b/vlib/v2/gen/x64/object.v
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+
+module x64
+
+import encoding.binary
+
+pub enum ObjectFormat {
+	elf
+	macho
+}
+
+enum ObjectSection {
+	text
+	data
+	rodata
+}
+
+fn (format ObjectFormat) section_index(section ObjectSection) u8 {
+	return match format {
+		.elf {
+			match section {
+				.text { 1 }
+				.data { 2 }
+				.rodata { 3 }
+			}
+		}
+		.macho {
+			match section {
+				.text { 1 }
+				.rodata { 2 }
+				.data { 3 }
+			}
+		}
+	}
+}
+
+fn (format ObjectFormat) symbol_name(name string) string {
+	if format == .macho && !name.starts_with('L_') {
+		return '_' + name
+	}
+	return name
+}
+
+fn (mut g Gen) text_len() int {
+	return match g.obj_format {
+		.elf { g.elf.text_data.len }
+		.macho { g.macho.text_data.len }
+	}
+}
+
+fn (mut g Gen) data_len() int {
+	return match g.obj_format {
+		.elf { g.elf.data_data.len }
+		.macho { g.macho.data_data.len }
+	}
+}
+
+fn (mut g Gen) rodata_len() int {
+	return match g.obj_format {
+		.elf { g.elf.rodata.len }
+		.macho { g.macho.rodata.len }
+	}
+}
+
+fn (mut g Gen) add_data_byte(b u8) {
+	match g.obj_format {
+		.elf { g.elf.data_data << b }
+		.macho { g.macho.data_data << b }
+	}
+}
+
+fn (mut g Gen) add_data(bytes []u8) {
+	match g.obj_format {
+		.elf { g.elf.data_data << bytes }
+		.macho { g.macho.data_data << bytes }
+	}
+}
+
+fn (mut g Gen) add_rodata_byte(b u8) {
+	match g.obj_format {
+		.elf { g.elf.rodata << b }
+		.macho { g.macho.rodata << b }
+	}
+}
+
+fn (mut g Gen) add_rodata(bytes []u8) {
+	match g.obj_format {
+		.elf { g.elf.rodata << bytes }
+		.macho { g.macho.rodata << bytes }
+	}
+}
+
+fn (mut g Gen) add_symbol(name string, value u64, is_func bool, section ObjectSection) int {
+	sym_name := g.obj_format.symbol_name(name)
+	sect := g.obj_format.section_index(section)
+	return match g.obj_format {
+		.elf { g.elf.add_symbol(sym_name, value, is_func, u16(sect)) }
+		.macho { g.macho.add_symbol(sym_name, value, !sym_name.starts_with('L_'), sect) }
+	}
+}
+
+fn (mut g Gen) add_undefined(name string) int {
+	sym_name := g.obj_format.symbol_name(name)
+	return match g.obj_format {
+		.elf { g.elf.add_undefined(sym_name) }
+		.macho { g.macho.add_undefined(sym_name) }
+	}
+}
+
+fn (mut g Gen) add_call_reloc(sym_idx int) {
+	offset := g.text_len()
+	match g.obj_format {
+		.elf { g.elf.add_text_reloc(u64(offset), sym_idx, r_x86_64_plt32, -4) }
+		.macho { g.macho.add_reloc(offset, sym_idx, x86_64_reloc_branch, true, 2) }
+	}
+}
+
+fn (mut g Gen) add_rip_reloc(sym_idx int) {
+	offset := g.text_len()
+	match g.obj_format {
+		.elf { g.elf.add_text_reloc(u64(offset), sym_idx, r_x86_64_pc32, -4) }
+		.macho { g.macho.add_reloc(offset, sym_idx, x86_64_reloc_signed, true, 2) }
+	}
+}
+
+fn (mut g Gen) emit(b u8) {
+	match g.obj_format {
+		.elf { g.elf.text_data << b }
+		.macho { g.macho.text_data << b }
+	}
+}
+
+fn (mut g Gen) emit_u32(v u32) {
+	g.emit(u8(v))
+	g.emit(u8(v >> 8))
+	g.emit(u8(v >> 16))
+	g.emit(u8(v >> 24))
+}
+
+fn (mut g Gen) emit_u64(v u64) {
+	g.emit_u32(u32(v))
+	g.emit_u32(u32(v >> 32))
+}
+
+fn (mut g Gen) write_u32(off int, v u32) {
+	match g.obj_format {
+		.elf { binary.little_endian_put_u32(mut g.elf.text_data[off..off + 4], v) }
+		.macho { binary.little_endian_put_u32(mut g.macho.text_data[off..off + 4], v) }
+	}
+}
+
+pub fn (mut g Gen) write_file(path string) {
+	match g.obj_format {
+		.elf { g.elf.write(path) }
+		.macho { g.macho.write(path) }
+	}
+}

--- a/vlib/v2/gen/x64/x64.v
+++ b/vlib/v2/gen/x64/x64.v
@@ -12,7 +12,9 @@ import math.bits
 pub struct Gen {
 	mod &mir.Module
 mut:
-	elf &ElfObject
+	elf        &ElfObject
+	macho      &MachOObject
+	obj_format ObjectFormat
 
 	stack_map      map[int]int
 	alloca_offsets map[int]int
@@ -41,8 +43,19 @@ mut:
 
 pub fn Gen.new(mod &mir.Module) &Gen {
 	return &Gen{
-		mod: mod
-		elf: ElfObject.new()
+		mod:        mod
+		elf:        ElfObject.new()
+		macho:      MachOObject.new()
+		obj_format: .elf
+	}
+}
+
+pub fn Gen.new_with_format(mod &mir.Module, obj_format ObjectFormat) &Gen {
+	return &Gen{
+		mod:        mod
+		elf:        ElfObject.new()
+		macho:      MachOObject.new()
+		obj_format: obj_format
 	}
 }
 
@@ -62,13 +75,13 @@ pub fn (mut g Gen) gen() {
 		if gvar.linkage == .external {
 			continue
 		}
-		for g.elf.data_data.len % 8 != 0 {
-			g.elf.data_data << 0
+		for g.data_len() % 8 != 0 {
+			g.add_data_byte(0)
 		}
-		addr := u64(g.elf.data_data.len)
-		g.elf.add_symbol(gvar.name, addr, false, 2)
+		addr := u64(g.data_len())
+		g.add_symbol(gvar.name, addr, false, .data)
 		if gvar.initial_data.len > 0 {
-			g.elf.data_data << gvar.initial_data
+			g.add_data(gvar.initial_data)
 		} else if gvar.is_constant {
 			size := g.type_size(gvar.typ)
 			mut bytes := []u8{len: if size > 0 { size } else { 8 }}
@@ -79,20 +92,20 @@ pub fn (mut g Gen) gen() {
 					bytes[i] = u8(u64(gvar.initial_value) >> (i * 8))
 				}
 			}
-			g.elf.data_data << bytes
+			g.add_data(bytes)
 		} else {
 			// For regular globals, initialize with zeros
 			size := g.type_size(gvar.typ)
 			data_size := if size > 0 { size } else { 8 }
 			for _ in 0 .. data_size {
-				g.elf.data_data << 0
+				g.add_data_byte(0)
 			}
 		}
 	}
 }
 
 fn (mut g Gen) gen_func(func mir.Function) {
-	g.curr_offset = g.elf.text_data.len
+	g.curr_offset = g.text_len()
 	g.stack_map = map[int]int{}
 	g.alloca_offsets = map[int]int{}
 	g.block_offsets = map[int]int{}
@@ -182,7 +195,7 @@ fn (mut g Gen) gen_func(func mir.Function) {
 		g.stack_size += 8
 	}
 
-	g.elf.add_symbol(func.name, u64(g.curr_offset), true, 1)
+	g.add_symbol(func.name, u64(g.curr_offset), true, .text)
 
 	// Prologue
 	asm_endbr64(mut g)
@@ -280,7 +293,7 @@ fn (mut g Gen) gen_func(func mir.Function) {
 
 	for blk_id in func.blocks {
 		blk := g.mod.blocks[blk_id]
-		g.block_offsets[blk_id] = g.elf.text_data.len - g.curr_offset
+		g.block_offsets[blk_id] = g.text_len() - g.curr_offset
 
 		if offsets := g.pending_labels[blk_id] {
 			for off in offsets {
@@ -435,8 +448,8 @@ fn (mut g Gen) gen_instr(val_id int) {
 			asm_mov_reg_imm64(mut g, rsi, u64(alloc_size))
 			asm_xor_eax_eax(mut g)
 			asm_call_rel32(mut g)
-			sym_idx := g.elf.add_undefined('calloc')
-			g.elf.add_text_reloc(u64(g.elf.text_data.len), sym_idx, 4, -4)
+			sym_idx := g.add_undefined('calloc')
+			g.add_call_reloc(sym_idx)
 			g.emit_u32(0)
 			g.store_reg_to_val(0, val_id)
 		}
@@ -490,9 +503,9 @@ fn (mut g Gen) gen_instr(val_id int) {
 
 			if fn_val.name != '' && fn_val.kind in [.unknown, .func_ref] {
 				asm_call_rel32(mut g)
-				sym_idx := g.elf.add_undefined(fn_val.name)
+				sym_idx := g.add_undefined(fn_val.name)
 				// Use R_X86_64_PLT32 (4) for function calls to support shared libraries (libc)
-				g.elf.add_text_reloc(u64(g.elf.text_data.len), sym_idx, 4, -4)
+				g.add_call_reloc(sym_idx)
 				g.emit_u32(0)
 			} else {
 				g.load_val_to_reg(int(r10), instr.operands[0])
@@ -544,8 +557,8 @@ fn (mut g Gen) gen_instr(val_id int) {
 
 			if fn_val.name != '' && fn_val.kind in [.unknown, .func_ref] {
 				asm_call_rel32(mut g)
-				sym_idx := g.elf.add_undefined(fn_val.name)
-				g.elf.add_text_reloc(u64(g.elf.text_data.len), sym_idx, 4, -4)
+				sym_idx := g.add_undefined(fn_val.name)
+				g.add_call_reloc(sym_idx)
 				g.emit_u32(0)
 			} else {
 				g.load_val_to_reg(int(r10), instr.operands[0])
@@ -666,7 +679,7 @@ fn (mut g Gen) gen_instr(val_id int) {
 				asm_je_rel32(mut g)
 				target_idx := g.mod.values[instr.operands[i + 1]].index
 				if off := g.block_offsets[target_idx] {
-					rel := off - (g.elf.text_data.len - g.curr_offset + 4)
+					rel := off - (g.text_len() - g.curr_offset + 4)
 					g.emit_u32(u32(rel))
 				} else {
 					g.record_pending_label(target_idx)
@@ -920,7 +933,7 @@ fn (mut g Gen) emit_unsigned_int_to_float(src_size int, result_size int, val_id 
 	}
 	asm_test_rax_rax(mut g)
 	asm_jns_rel32(mut g)
-	normal_patch := g.elf.text_data.len
+	normal_patch := g.text_len()
 	g.emit_u32(0)
 	asm_mov_reg_reg(mut g, rcx, rax)
 	asm_and_rcx_imm8(mut g, 1)
@@ -929,7 +942,7 @@ fn (mut g Gen) emit_unsigned_int_to_float(src_size int, result_size int, val_id 
 	g.emit_signed_int_to_float(result_size, .uitofp, val_id)
 	asm_add_float_xmm0_xmm0(mut g, result_size)
 	asm_jmp_rel32(mut g)
-	end_patch := g.elf.text_data.len
+	end_patch := g.text_len()
 	g.emit_u32(0)
 	g.patch_rel32(normal_patch)
 	g.emit_signed_int_to_float(result_size, .uitofp, val_id)
@@ -955,11 +968,11 @@ fn (mut g Gen) emit_float_to_unsigned_int(src_size int, dst_size int, val_id int
 	g.load_fp_2p63_to_xmm1(src_size, val_id)
 	asm_ucomis_xmm0_xmm1(mut g, src_size)
 	asm_jae_rel32(mut g)
-	big_patch := g.elf.text_data.len
+	big_patch := g.text_len()
 	g.emit_u32(0)
 	g.emit_float_to_signed_int(src_size, .fptoui, val_id)
 	asm_jmp_rel32(mut g)
-	end_patch := g.elf.text_data.len
+	end_patch := g.text_len()
 	g.emit_u32(0)
 	g.patch_rel32(big_patch)
 	asm_sub_float_xmm0_xmm1(mut g, src_size)
@@ -978,18 +991,18 @@ fn (mut g Gen) load_fp_2p63_to_xmm1(size int, val_id int) {
 	} else {
 		g.unsupported_numeric_conversion(.fptoui, size, 8, val_id)
 	}
-	str_offset := g.elf.rodata.len
-	g.elf.rodata << bytes
+	str_offset := g.rodata_len()
+	g.add_rodata(bytes)
 	sym_name := 'L_fp_${g.curr_offset}_${str_offset}'
-	sym_idx := g.elf.add_symbol(sym_name, u64(str_offset), false, 3)
+	sym_idx := g.add_symbol(sym_name, u64(str_offset), false, .rodata)
 	asm_lea_reg_rip(mut g, r10)
-	g.elf.add_text_reloc(u64(g.elf.text_data.len), sym_idx, 2, -4)
+	g.add_rip_reloc(sym_idx)
 	g.emit_u32(0)
 	asm_load_xmm_mem_base_disp_size(mut g, 1, r10, 0, size)
 }
 
 fn (mut g Gen) patch_rel32(patch_pos int) {
-	target := g.elf.text_data.len
+	target := g.text_len()
 	rel := target - (patch_pos + 4)
 	g.write_u32(patch_pos, u32(rel))
 }
@@ -1335,7 +1348,7 @@ fn (g Gen) selected_opcode(instr mir.Instruction) ssa.OpCode {
 fn (mut g Gen) emit_jmp(target_idx int) {
 	asm_jmp_rel32(mut g)
 	if off := g.block_offsets[target_idx] {
-		rel := off - (g.elf.text_data.len - g.curr_offset + 4)
+		rel := off - (g.text_len() - g.curr_offset + 4)
 		g.emit_u32(u32(rel))
 	} else {
 		g.record_pending_label(target_idx)
@@ -1575,15 +1588,15 @@ fn (mut g Gen) load_val_to_reg(reg int, val_id int) {
 				}
 			}
 
-			str_offset := g.elf.rodata.len
-			g.elf.rodata << raw_bytes
-			g.elf.rodata << 0
+			str_offset := g.rodata_len()
+			g.add_rodata(raw_bytes)
+			g.add_rodata_byte(0)
 			sym_name := 'L_str_${g.curr_offset}_${str_offset}'
-			sym_idx := g.elf.add_symbol(sym_name, u64(str_offset), false, 3)
+			sym_idx := g.add_symbol(sym_name, u64(str_offset), false, .rodata)
 
 			// lea reg, [rip + disp]
 			asm_lea_reg_rip(mut g, Reg(reg))
-			g.elf.add_text_reloc(u64(g.elf.text_data.len), sym_idx, 2, -4)
+			g.add_rip_reloc(sym_idx)
 			g.emit_u32(0)
 		} else {
 			int_val := val.name.i64()
@@ -1597,8 +1610,8 @@ fn (mut g Gen) load_val_to_reg(reg int, val_id int) {
 		}
 	} else if val.kind == .global {
 		asm_lea_reg_rip(mut g, Reg(reg))
-		sym_idx := g.elf.add_undefined(val.name)
-		g.elf.add_text_reloc(u64(g.elf.text_data.len), sym_idx, 2, -4)
+		sym_idx := g.add_undefined(val.name)
+		g.add_rip_reloc(sym_idx)
 		g.emit_u32(0)
 	} else if val.kind == .string_literal {
 		g.materialize_string_literal(reg, val_id)
@@ -1627,15 +1640,15 @@ fn (mut g Gen) store_reg_to_val(reg int, val_id int) {
 
 fn (mut g Gen) materialize_string_literal(reg int, val_id int) {
 	val := g.mod.values[val_id]
-	str_offset := g.elf.rodata.len
-	g.elf.rodata << val.name.bytes()
-	g.elf.rodata << 0
+	str_offset := g.rodata_len()
+	g.add_rodata(val.name.bytes())
+	g.add_rodata_byte(0)
 	sym_name := 'L_str_${g.curr_offset}_${str_offset}'
-	sym_idx := g.elf.add_symbol(sym_name, u64(str_offset), false, 3)
+	sym_idx := g.add_symbol(sym_name, u64(str_offset), false, .rodata)
 
 	slot_off := g.stack_map[val_id]
 	asm_lea_reg_rip(mut g, rax)
-	g.elf.add_text_reloc(u64(g.elf.text_data.len), sym_idx, 2, -4)
+	g.add_rip_reloc(sym_idx)
 	g.emit_u32(0)
 	asm_store_rbp_disp_reg_size(mut g, slot_off + g.struct_field_offset_bytes(val.typ, 0), rax, 8)
 	asm_mov_reg_imm32(mut g, rax, u32(val.index))
@@ -1757,33 +1770,9 @@ fn (g Gen) map_reg(r int) u8 {
 	return u8(r)
 }
 
-fn (mut g Gen) emit(b u8) {
-	g.elf.text_data << b
-}
-
-fn (mut g Gen) emit_u32(v u32) {
-	g.emit(u8(v))
-	g.emit(u8(v >> 8))
-	g.emit(u8(v >> 16))
-	g.emit(u8(v >> 24))
-}
-
-fn (mut g Gen) emit_u64(v u64) {
-	g.emit_u32(u32(v))
-	g.emit_u32(u32(v >> 32))
-}
-
 fn (mut g Gen) record_pending_label(blk int) {
-	off := g.elf.text_data.len - g.curr_offset
+	off := g.text_len() - g.curr_offset
 	g.pending_labels[blk] << off
-}
-
-fn (mut g Gen) write_u32(off int, v u32) {
-	binary.little_endian_put_u32(mut g.elf.text_data[off..off + 4], v)
-}
-
-pub fn (mut g Gen) write_file(path string) {
-	g.elf.write(path)
 }
 
 // Register Allocation Logic

--- a/vlib/v2/gen/x64/x64_object_format_test.v
+++ b/vlib/v2/gen/x64/x64_object_format_test.v
@@ -1,0 +1,200 @@
+module x64
+
+import os
+
+fn temp_object_path(name string) string {
+	return os.join_path(os.vtmp_dir(), 'v2_x64_${name}_${os.getpid()}.o')
+}
+
+fn read_u32_le(data []u8, off int) u32 {
+	return u32(data[off]) | (u32(data[off + 1]) << 8) | (u32(data[off + 2]) << 16) | (u32(data[
+		off + 3]) << 24)
+}
+
+fn read_string(data []u8, off int) string {
+	mut end := off
+	for end < data.len && data[end] != 0 {
+		end++
+	}
+	return data[off..end].bytestr()
+}
+
+fn test_elf_writer_emits_x64_relocatable_object() {
+	path := temp_object_path('elf')
+	defer {
+		os.rm(path) or {}
+	}
+
+	mut obj := ElfObject.new()
+	obj.text_data << u8(0xc3)
+	obj.add_symbol('main', 0, true, 1)
+	obj.write(path)
+
+	data := os.read_bytes(path) or { panic(err) }
+	assert data.len > 64
+	assert data[0] == 0x7f
+	assert data[1] == `E`
+	assert data[2] == `L`
+	assert data[3] == `F`
+	assert data[4] == elfclass64
+	assert data[16] == u8(et_rel)
+	assert data[18] == u8(em_x86_64)
+}
+
+fn test_macho_writer_emits_x64_relocatable_object() {
+	path := temp_object_path('macho')
+	defer {
+		os.rm(path) or {}
+	}
+
+	mut obj := MachOObject.new()
+	obj.text_data << u8(0xc3)
+	obj.add_symbol('_main', 0, true, 1)
+	obj.write(path)
+
+	data := os.read_bytes(path) or { panic(err) }
+	assert data.len > 64
+	assert data[0] == 0xcf
+	assert data[1] == 0xfa
+	assert data[2] == 0xed
+	assert data[3] == 0xfe
+	assert data[4] == 0x07
+	assert data[5] == 0x00
+	assert data[6] == 0x00
+	assert data[7] == 0x01
+	assert data[8] == 0x03
+	assert data[12] == u8(macho_mh_object)
+	assert data[16] == 2
+	assert data.bytestr().contains('__text')
+	assert data.bytestr().contains('__const')
+	assert data.bytestr().contains('__data')
+	assert data.bytestr().contains('_main')
+}
+
+fn test_macho_writer_records_x64_text_relocations() {
+	mut obj := MachOObject.new()
+	call_sym := obj.add_undefined('_calloc')
+	data_sym := obj.add_symbol('L_str_0', 0, false, 2)
+	obj.add_reloc(1, call_sym, x86_64_reloc_branch, true, 2)
+	obj.add_reloc(8, data_sym, x86_64_reloc_signed, true, 2)
+
+	assert obj.relocs.len == 2
+	assert obj.relocs[0].addr == 1
+	assert obj.relocs[0].sym_idx == call_sym
+	assert obj.relocs[0].type_ == x86_64_reloc_branch
+	assert obj.relocs[0].pcrel
+	assert obj.relocs[0].length == 2
+	assert obj.relocs[1].addr == 8
+	assert obj.relocs[1].sym_idx == data_sym
+	assert obj.relocs[1].type_ == x86_64_reloc_signed
+	assert obj.relocs[1].pcrel
+	assert obj.relocs[1].length == 2
+}
+
+fn test_macho_object_format_prefixes_external_symbols() {
+	assert ObjectFormat.macho.symbol_name('main') == '_main'
+	assert ObjectFormat.macho.symbol_name('calloc') == '_calloc'
+	assert ObjectFormat.macho.symbol_name('_main') == '__main'
+	assert ObjectFormat.macho.symbol_name('__stdoutp') == '___stdoutp'
+	assert ObjectFormat.macho.symbol_name('__stderrp') == '___stderrp'
+	assert ObjectFormat.macho.symbol_name('__stdinp') == '___stdinp'
+	assert ObjectFormat.macho.symbol_name('__error') == '___error'
+	assert ObjectFormat.macho.symbol_name('L_str_0') == 'L_str_0'
+	assert ObjectFormat.elf.symbol_name('main') == 'main'
+	assert ObjectFormat.elf.symbol_name('calloc') == 'calloc'
+	assert ObjectFormat.elf.symbol_name('__stdoutp') == '__stdoutp'
+}
+
+fn test_elf_writer_reuses_undefined_symbol_when_it_is_defined_later() {
+	mut obj := ElfObject.new()
+	undef_idx := obj.add_undefined('app_global')
+	def_idx := obj.add_symbol('app_global', 16, false, 2)
+
+	assert def_idx == undef_idx
+	assert obj.symbols[def_idx].name == 'app_global'
+	assert obj.symbols[def_idx].shndx == 2
+	assert obj.symbols[def_idx].value == 16
+}
+
+fn test_elf_writer_reuses_defined_symbol_when_it_is_referenced_later() {
+	mut obj := ElfObject.new()
+	def_idx := obj.add_symbol('app_global', 16, false, 2)
+	undef_idx := obj.add_undefined('app_global')
+
+	assert undef_idx == def_idx
+	assert obj.symbols[undef_idx].name == 'app_global'
+	assert obj.symbols[undef_idx].shndx == 2
+	assert obj.symbols[undef_idx].value == 16
+}
+
+fn test_macho_writer_reuses_undefined_symbol_when_it_is_defined_later() {
+	mut obj := MachOObject.new()
+	undef_idx := obj.add_undefined('_app_global')
+	def_idx := obj.add_symbol('_app_global', 24, true, 3)
+
+	assert def_idx == undef_idx
+	assert obj.symbols[def_idx].name == '_app_global'
+	assert obj.symbols[def_idx].sect == 3
+	assert obj.symbols[def_idx].value == 24
+}
+
+fn test_macho_writer_serializes_text_relocations_and_symbols() {
+	path := temp_object_path('macho_relocs')
+	defer {
+		os.rm(path) or {}
+	}
+
+	mut obj := MachOObject.new()
+	obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0x48, 0x8d, 0x05, 0, 0, 0, 0]
+	call_name := ObjectFormat.macho.symbol_name('__stdoutp')
+	local_name := ObjectFormat.macho.symbol_name('L_str_0')
+	call_sym := obj.add_undefined(call_name)
+	data_sym := obj.add_symbol(local_name, 0, false, 2)
+	obj.rodata << 'hello'.bytes()
+	obj.rodata << 0
+	obj.add_reloc(1, call_sym, x86_64_reloc_branch, true, 2)
+	obj.add_reloc(8, data_sym, x86_64_reloc_signed, true, 2)
+	obj.write(path)
+
+	data := os.read_bytes(path) or { panic(err) }
+	seg_cmd_off := 32
+	text_section_off := seg_cmd_off + 72
+	reloc_off := int(read_u32_le(data, text_section_off + 56))
+	nreloc := int(read_u32_le(data, text_section_off + 60))
+	assert nreloc == 2
+
+	reloc0_addr := read_u32_le(data, reloc_off)
+	reloc0_info := read_u32_le(data, reloc_off + 4)
+	reloc1_addr := read_u32_le(data, reloc_off + 8)
+	reloc1_info := read_u32_le(data, reloc_off + 12)
+	assert reloc0_addr == 1
+	assert reloc0_info & 0x00ff_ffff == u32(call_sym)
+	assert ((reloc0_info >> 24) & 1) == 1
+	assert ((reloc0_info >> 25) & 3) == 2
+	assert ((reloc0_info >> 27) & 1) == 1
+	assert (reloc0_info >> 28) == u32(x86_64_reloc_branch)
+	assert reloc1_addr == 8
+	assert reloc1_info & 0x00ff_ffff == u32(data_sym)
+	assert ((reloc1_info >> 24) & 1) == 1
+	assert ((reloc1_info >> 25) & 3) == 2
+	assert ((reloc1_info >> 27) & 1) == 1
+	assert (reloc1_info >> 28) == u32(x86_64_reloc_signed)
+
+	symtab_cmd_off := seg_cmd_off + 72 + (80 * 3)
+	assert read_u32_le(data, symtab_cmd_off) == u32(macho_lc_symtab)
+	sym_off := int(read_u32_le(data, symtab_cmd_off + 8))
+	nsyms := int(read_u32_le(data, symtab_cmd_off + 12))
+	str_off := int(read_u32_le(data, symtab_cmd_off + 16))
+	str_size := int(read_u32_le(data, symtab_cmd_off + 20))
+	assert nsyms == 2
+	assert str_size > 1
+
+	call_name_off := int(read_u32_le(data, sym_off))
+	local_name_off := int(read_u32_le(data, sym_off + 16))
+	assert read_string(data, str_off + call_name_off) == call_name
+	assert read_string(data, str_off + local_name_off) == local_name
+	assert data[sym_off + 4] == 0x01
+	assert data[sym_off + 5] == 0
+	assert data[sym_off + 16 + 4] == 0x0e
+	assert data[sym_off + 16 + 5] == 2
+}


### PR DESCRIPTION
## Summary

This PR adds Mach-O relocatable object output for the V2 native x64 backend on macOS.

Fix #27131 

The issue is that `v -v2 -b x64` currently emits an ELF object even when running on macOS, so the Darwin linker rejects `main.o` as an unsupported file format. This patch keeps the existing ELF path for non-macOS hosts and adds a separate Mach-O writer for x86_64 macOS objects.

## What Changed

- Added a minimal x64 object format layer for ELF vs Mach-O emission.
- Added a Mach-O x86_64 relocatable object writer.
- Routes V2 x64 native codegen to Mach-O when the host OS is macOS.
- Keeps Linux x64 on the existing ELF writer path.
- Preserves Darwin symbol naming rules by prefixing non-local Mach-O symbols with `_`.
- Keeps local `L_` labels unprefixed.
- Adds Mach-O relocation support for x64 call and RIP-relative references.
- Adds ELF symbol de-duplication in both `undefined -> defined` and `defined -> undefined` directions.

## Tests

Validated locally with a compiler rebuilt from this branch:

- `git diff --check`
- `v fmt -verify` on the touched files
- `v test vlib/v2/gen/x64/x64_object_format_test.v`
- `v test vlib/v2/gen/x64`

Added test coverage for:

- ELF relocatable object header emission;
- Mach-O x86_64 relocatable object header emission;
- Darwin symbol prefixing, including `__stdoutp`, `__stderrp`, `__stdinp`, and `__error`;
- local `L_` label handling;
- serialized Mach-O relocation records;
- Mach-O symbol/string table entries;
- ELF symbol reuse for both definition/reference orders.

## Validation Note

I could validate the object writer and Linux-side regression locally, but I cannot run the final Darwin `ld64` validation from this Linux environment.

The key remaining validation for this PR is on macOS:

```bash
./v -v2 -b x64 main.v
