### PR TITLE
db.mssql: avoid .sort() in get_conn_str to unbreak tcc CI

### DIFF
--- a/vlib/db/mssql/config.v
+++ b/vlib/db/mssql/config.v
@@ -77,11 +77,9 @@ pub fn (cfg Config) get_conn_str() string {
 	}
 	if cfg.options.len > 0 {
 		mut option_keys := cfg.options.keys()
-		$if macos {
-			option_keys.sort()
-		} $else {
+		$if tinyc {
 			// Manual insertion sort avoids relying on the generic .sort() helper,
-			// which has tripped tcc bounds-check builds in CI on non-macOS.
+			// which has tripped tcc bounds-check builds in CI.
 			for i in 1 .. option_keys.len {
 				key := option_keys[i]
 				mut j := i
@@ -91,6 +89,8 @@ pub fn (cfg Config) get_conn_str() string {
 				}
 				option_keys[j] = key
 			}
+		} $else {
+			option_keys.sort()
 		}
 		for key in option_keys {
 			append_conn_part(mut parts, key, cfg.options[key])

--- a/vlib/db/mssql/config.v
+++ b/vlib/db/mssql/config.v
@@ -77,16 +77,20 @@ pub fn (cfg Config) get_conn_str() string {
 	}
 	if cfg.options.len > 0 {
 		mut option_keys := cfg.options.keys()
-		// Manual insertion sort avoids relying on the generic .sort() helper
-		// which has tripped tcc bounds-check builds in CI.
-		for i in 1 .. option_keys.len {
-			key := option_keys[i]
-			mut j := i
-			for j > 0 && option_keys[j - 1] > key {
-				option_keys[j] = option_keys[j - 1]
-				j--
+		$if macos {
+			option_keys.sort()
+		} $else {
+			// Manual insertion sort avoids relying on the generic .sort() helper,
+			// which has tripped tcc bounds-check builds in CI on non-macOS.
+			for i in 1 .. option_keys.len {
+				key := option_keys[i]
+				mut j := i
+				for j > 0 && option_keys[j - 1] > key {
+					option_keys[j] = option_keys[j - 1]
+					j--
+				}
+				option_keys[j] = key
 			}
-			option_keys[j] = key
 		}
 		for key in option_keys {
 			append_conn_part(mut parts, key, cfg.options[key])

--- a/vlib/db/mssql/config.v
+++ b/vlib/db/mssql/config.v
@@ -77,7 +77,17 @@ pub fn (cfg Config) get_conn_str() string {
 	}
 	if cfg.options.len > 0 {
 		mut option_keys := cfg.options.keys()
-		option_keys.sort()
+		// Manual insertion sort avoids relying on the generic .sort() helper
+		// which has tripped tcc bounds-check builds in CI.
+		for i in 1 .. option_keys.len {
+			key := option_keys[i]
+			mut j := i
+			for j > 0 && option_keys[j - 1] > key {
+				option_keys[j] = option_keys[j - 1]
+				j--
+			}
+			option_keys[j] = key
+		}
 		for key in option_keys {
 			append_conn_part(mut parts, key, cfg.options[key])
 		}


### PR DESCRIPTION
## Summary
- mssql CI on tcc/Linux fails inside `v_stable_sort` with `RUNTIME ERROR: invalid memory access` ([job 77666606522](https://github.com/vlang/v/actions/runs/26386173744/job/77666606522)).
- The crash is reached from `Config.get_conn_str()` via `option_keys.sort()`. The generated C function (`v_stable_sort` in `cheaders.v`) looks correct under ASAN/UBSAN and on macOS, but tcc bounds-check on Linux trips on it.
- Replace the single `.sort()` call in `vlib/db/mssql/config.v` with a manual insertion sort so the mssql driver tests stop being blocked while the underlying `v_stable_sort` / tcc interaction is investigated separately.

## Test plan
- [x] `v run` of a standalone sort harness (`['TDS_Version', 'ClientCharset']`, `['TrustServerCertificate', 'Encrypt']`, single-element, empty, reversed) returns the expected ordering.
- [ ] mssql driver tests on tcc Linux pass in CI.