### PR TITLE
cgen: fix invalid C for nested `or` block whose last expr is `!void` call (fix #27012)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -11922,6 +11922,15 @@ fn (mut g Gen) or_block_on_value(var_name string, or_block ast.OrExpr, return_ty
 				else {}
 			}
 		}
+		// `call() or { ... }` whose call returns `!void`/`?void` has already
+		// consumed the option/result via its own or-block; the effective
+		// value of the last expression is void, so do not try to write
+		// `*(T*) tmp.data = <void>` (see issue #27012).
+		if last_expr_stmt.expr is ast.CallExpr
+			&& last_expr_stmt.expr.or_block.kind != .absent
+			&& last_expr_typ.clear_option_and_result() == ast.void_type {
+			last_expr_typ = ast.void_type
+		}
 		last_expr_produces_value = last_expr_typ != ast.void_type
 	}
 	if last_expr_produces_value {
@@ -12030,6 +12039,15 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 					}
 					else {}
 				}
+			}
+			// `call() or { ... }` whose call returns `!void`/`?void` has already
+			// consumed the option/result via its own or-block; the effective
+			// value of the last expression is void, so do not try to write
+			// `*(T*) tmp.data = <void>` (see issue #27012).
+			if last_expr_stmt.expr is ast.CallExpr
+				&& last_expr_stmt.expr.or_block.kind != .absent
+				&& last_expr_typ.clear_option_and_result() == ast.void_type {
+				last_expr_typ = ast.void_type
 			}
 			last_expr_produces_value = last_expr_typ != ast.void_type
 		}

--- a/vlib/v/tests/options/nested_or_block_with_void_result_test.v
+++ b/vlib/v/tests/options/nested_or_block_with_void_result_test.v
@@ -1,0 +1,45 @@
+// Regression test for https://github.com/vlang/v/issues/27012
+// A nested `or { call_returning_result_void() or { ... } }` used as a
+// statement (outer call result discarded) used to emit invalid C of the
+// form `*(T*) _t.data = ;` and fail to compile.
+
+struct Item {
+	id int
+}
+
+fn get_item() !Item {
+	return Item{id: 1}
+}
+
+fn get_item_err() !Item {
+	return error('outer')
+}
+
+fn do_void() ! {
+	return error('inner')
+}
+
+fn test_nested_or_block_with_void_result_inner_succeeds() {
+	mut traces := []string{}
+	get_item() or {
+		traces << 'outer: ${err}'
+		do_void() or {
+			traces << 'inner: ${err}'
+		}
+	}
+	// Outer call succeeded -> or-block is never entered.
+	assert traces.len == 0
+}
+
+fn test_nested_or_block_with_void_result_outer_errors() {
+	mut traces := []string{}
+	get_item_err() or {
+		traces << 'outer: ${err}'
+		do_void() or {
+			traces << 'inner: ${err}'
+		}
+	}
+	assert traces.len == 2
+	assert traces[0] == 'outer: outer'
+	assert traces[1] == 'inner: inner'
+}


### PR DESCRIPTION
## Summary

Fixes #27012 — a nested `or { call_returning_result_void() or { ... } }` used as a statement crashed the C compiler with `error: expected expression before ';' token` (or MSVC `C2059`).

When the last expression of an outer `or { ... }` block was `do_void() or { ... }` (where `do_void` returns `!void`/`?void`) and the outer call's result was discarded, codegen emitted `*(T*) _t.data = ;` because the inner expression has no value.

## Root cause

`or_block` / `or_block_on_value` in `vlib/v/gen/c/cgen.v` decide whether to treat the last stmt as value-producing by comparing the resolved expression type against `ast.void_type`. For a `CallExpr` whose function returns `!void`, the resolved type is `!void` — different from raw `void_type` — so the code incorrectly classified it as value-producing and tried to write the value into the outer `_t.data` slot.

## Fix

Before the `last_expr_produces_value` decision, recognize the specific shape — `CallExpr` whose `or_block.kind != .absent` and whose return type clears to `void` — and normalize `last_expr_typ` back to `void_type`. The non-value-producing branch (`g.stmts(stmts)`) then emits the inner or-block correctly without the spurious assignment.

## Test plan

- [x] Repro from the issue compiles and runs cleanly.
- [x] New regression test `vlib/v/tests/options/nested_or_block_with_void_result_test.v` covers both `get_item()` succeeding (or-block skipped) and erroring (or-block + nested or-block both fire).
- [x] `./v test vlib/v/tests/` — 2123 passed, 5 skipped, 0 failed.
- [x] `./v self` rebuilds.