### PR TITLE
v2: parser: allow programs without `fn main` (script mode)

### DIFF
--- a/vlib/v2/parser/parser.v
+++ b/vlib/v2/parser/parser.v
@@ -234,8 +234,24 @@ pub fn (mut p Parser) parse_file(filename string, mut file_set token.FileSet) as
 	mut script_stmts := []ast.Stmt{}
 	mut main_already_defined := false
 	for p.tok != .eof {
+		// Late `import` statements (after the initial import section, or
+		// after any top-level decl): keep recording them in `file.imports`
+		// so module-qualified references resolve, instead of silently
+		// routing into the synthesized main body.
+		if p.tok == .key_import {
+			import_stmt := p.import_stmt()
+			p.expect(.semicolon)
+			imports << import_stmt
+			top_stmts << import_stmt
+			continue
+		}
 		if mod == 'main' && !p.is_top_stmt_start() {
+			// Script-mode statements parse as if inside a function body
+			// (no top-level decl dispatch), since they will be wrapped
+			// into the synthesized `fn main()`.
+			p.in_top_level = false
 			stmt := p.stmt()
+			p.in_top_level = true
 			script_stmts << stmt
 			continue
 		}

--- a/vlib/v2/parser/parser.v
+++ b/vlib/v2/parser/parser.v
@@ -234,16 +234,12 @@ pub fn (mut p Parser) parse_file(filename string, mut file_set token.FileSet) as
 	mut script_stmts := []ast.Stmt{}
 	mut main_already_defined := false
 	for p.tok != .eof {
-		// Late `import` statements (after the initial import section, or
-		// after any top-level decl): keep recording them in `file.imports`
-		// so module-qualified references resolve, instead of silently
-		// routing into the synthesized main body.
+		// `import` is only allowed in the initial import section at the
+		// top of the file. A late `import` would otherwise (in script mode)
+		// be routed through `p.stmt()` into the synthesized `fn main()` —
+		// reject it with a clear error matching v1's behavior.
 		if p.tok == .key_import {
-			import_stmt := p.import_stmt()
-			p.expect(.semicolon)
-			imports << import_stmt
-			top_stmts << import_stmt
-			continue
+			p.error('`import x` can only be declared at the beginning of the file')
 		}
 		if mod == 'main' && !p.is_top_stmt_start() {
 			// Script-mode statements parse as if inside a function body
@@ -333,9 +329,12 @@ fn comptime_if_expr_contains_top_stmt(if_expr ast.IfExpr) bool {
 			}
 		} else if stmt is ast.AssignStmt {
 			return false
-		} else if stmt is ast.Directive {
-			return true
 		}
+		// `ast.Directive` (e.g. `#flag`, `#include`) is only valid at file
+		// scope — it does not by itself prove the branch is declaration-only,
+		// so we keep scanning the remaining stmts (and the `$else` chain
+		// below) instead of short-circuiting. A runtime stmt found later
+		// still disqualifies the branch and forces script-main wrapping.
 	}
 	if if_expr.else_expr is ast.IfExpr {
 		else_ie := if_expr.else_expr as ast.IfExpr

--- a/vlib/v2/parser/parser.v
+++ b/vlib/v2/parser/parser.v
@@ -233,6 +233,12 @@ pub fn (mut p Parser) parse_file(filename string, mut file_set token.FileSet) as
 	// programs without an explicit `fn main` (matching v1 behavior).
 	mut script_stmts := []ast.Stmt{}
 	mut main_already_defined := false
+	// Once the first script statement is seen, the rest of the file is
+	// parsed in function-body context (in_top_level=false). This matches
+	// v1's "all definitions must occur before code in script mode" — a
+	// `const`/`fn`/etc. that appears after a script stmt then surfaces as
+	// a parse error rather than being silently kept as a file-scope decl.
+	mut script_started := false
 	for p.tok != .eof {
 		// `import` is only allowed in the initial import section at the
 		// top of the file. A late `import` would otherwise (in script mode)
@@ -241,7 +247,7 @@ pub fn (mut p Parser) parse_file(filename string, mut file_set token.FileSet) as
 		if p.tok == .key_import {
 			p.error('`import x` can only be declared at the beginning of the file')
 		}
-		if mod == 'main' && !p.is_top_stmt_start() {
+		if mod == 'main' && (script_started || !p.is_top_stmt_start()) {
 			// Script-mode statements parse as if inside a function body
 			// (no top-level decl dispatch), since they will be wrapped
 			// into the synthesized `fn main()`.
@@ -249,6 +255,7 @@ pub fn (mut p Parser) parse_file(filename string, mut file_set token.FileSet) as
 			stmt := p.stmt()
 			p.in_top_level = true
 			script_stmts << stmt
+			script_started = true
 			continue
 		}
 		top_stmt := p.top_stmt()

--- a/vlib/v2/parser/parser.v
+++ b/vlib/v2/parser/parser.v
@@ -271,12 +271,17 @@ pub fn (mut p Parser) parse_file(filename string, mut file_set token.FileSet) as
 		// runtime statements (e.g. `println(...)`) needs to be wrapped into
 		// the synthesized `fn main()` so it actually executes. Comptime $if
 		// blocks containing only declarations (e.g. `$if !macos { fn C.x() }`)
-		// stay at file scope.
+		// stay at file scope. A `fn main` nested inside any branch counts
+		// as user-defined main and suppresses script-main synthesis.
 		if mod == 'main' && top_stmt is ast.ExprStmt {
 			inner := unwrap_comptime_expr(top_stmt.expr)
 			if inner is ast.IfExpr {
+				if comptime_if_expr_contains_fn_main(inner) {
+					main_already_defined = true
+				}
 				if !comptime_if_expr_contains_top_stmt(inner) {
 					script_stmts << top_stmt
+					script_started = true
 					continue
 				}
 			}
@@ -350,6 +355,34 @@ fn comptime_if_expr_contains_top_stmt(if_expr ast.IfExpr) bool {
 		}
 	}
 	return true
+}
+
+// comptime_if_expr_contains_fn_main reports whether any branch of a
+// comptime `$if` chain declares `fn main`. Used to suppress synthesis
+// of a script `main` when a user-defined `main` is hidden behind a
+// platform-conditional block (e.g. `$if windows { fn main() {} }`).
+fn comptime_if_expr_contains_fn_main(if_expr ast.IfExpr) bool {
+	for stmt in if_expr.stmts {
+		if stmt is ast.FnDecl {
+			if !stmt.is_method && stmt.name == 'main' {
+				return true
+			}
+		} else if stmt is ast.ExprStmt {
+			inner := unwrap_comptime_expr(stmt.expr)
+			if inner is ast.IfExpr {
+				if comptime_if_expr_contains_fn_main(inner) {
+					return true
+				}
+			}
+		}
+	}
+	if if_expr.else_expr is ast.IfExpr {
+		else_ie := if_expr.else_expr as ast.IfExpr
+		if comptime_if_expr_contains_fn_main(else_ie) {
+			return true
+		}
+	}
+	return false
 }
 
 // is_top_stmt_start reports whether the current token can start a top-level

--- a/vlib/v2/parser/parser.v
+++ b/vlib/v2/parser/parser.v
@@ -248,6 +248,20 @@ pub fn (mut p Parser) parse_file(filename string, mut file_set token.FileSet) as
 				main_already_defined = true
 			}
 		}
+		// Script-mode: a top-level `$if cond { ... }` whose body contains
+		// runtime statements (e.g. `println(...)`) needs to be wrapped into
+		// the synthesized `fn main()` so it actually executes. Comptime $if
+		// blocks containing only declarations (e.g. `$if !macos { fn C.x() }`)
+		// stay at file scope.
+		if mod == 'main' && top_stmt is ast.ExprStmt {
+			inner := unwrap_comptime_expr(top_stmt.expr)
+			if inner is ast.IfExpr {
+				if !comptime_if_expr_contains_top_stmt(inner) {
+					script_stmts << top_stmt
+					continue
+				}
+			}
+		}
 		top_stmts << top_stmt
 	}
 	p.in_top_level = false
@@ -273,6 +287,47 @@ pub fn (mut p Parser) parse_file(filename string, mut file_set token.FileSet) as
 		// decls: decls
 		stmts: top_stmts
 	}
+}
+
+// unwrap_comptime_expr returns the inner expression of a `$expr` wrapper,
+// or the expression itself when it is not a ComptimeExpr.
+fn unwrap_comptime_expr(expr ast.Expr) ast.Expr {
+	if expr is ast.ComptimeExpr {
+		return expr.expr
+	}
+	return expr
+}
+
+// comptime_if_expr_contains_top_stmt reports whether every branch of a
+// comptime `$if` chain contains only top-level statements (declarations,
+// directives, or nested top-level `$if`s). Returns false if any branch
+// contains a runtime CallExpr / CallOrCastExpr / AssignStmt — in script
+// mode such blocks are wrapped into the synthesized `fn main()`.
+// Ported from v1 `vlib/v/parser/parser.v::comptime_if_expr_contains_top_stmt`.
+fn comptime_if_expr_contains_top_stmt(if_expr ast.IfExpr) bool {
+	for stmt in if_expr.stmts {
+		if stmt is ast.ExprStmt {
+			inner := unwrap_comptime_expr(stmt.expr)
+			if inner is ast.IfExpr {
+				if !comptime_if_expr_contains_top_stmt(inner) {
+					return false
+				}
+			} else if inner is ast.CallExpr || inner is ast.CallOrCastExpr {
+				return false
+			}
+		} else if stmt is ast.AssignStmt {
+			return false
+		} else if stmt is ast.Directive {
+			return true
+		}
+	}
+	if if_expr.else_expr is ast.IfExpr {
+		else_ie := if_expr.else_expr as ast.IfExpr
+		if !comptime_if_expr_contains_top_stmt(else_ie) {
+			return false
+		}
+	}
+	return true
 }
 
 // is_top_stmt_start reports whether the current token can start a top-level

--- a/vlib/v2/parser/parser.v
+++ b/vlib/v2/parser/parser.v
@@ -228,14 +228,38 @@ pub fn (mut p Parser) parse_file(filename string, mut file_set token.FileSet) as
 		top_stmts << import_stmt
 	}
 	p.in_top_level = true
+	// Script-mode: when in `main` module, top-level statements that are not
+	// declarations are collected into a synthesized `fn main()`, allowing
+	// programs without an explicit `fn main` (matching v1 behavior).
+	mut script_stmts := []ast.Stmt{}
+	mut main_already_defined := false
 	for p.tok != .eof {
+		if mod == 'main' && !p.is_top_stmt_start() {
+			stmt := p.stmt()
+			script_stmts << stmt
+			continue
+		}
 		top_stmt := p.top_stmt()
 		// if top_stmt is ast.Decl {
 		// 	decls << top_stmt
 		// }
+		if top_stmt is ast.FnDecl {
+			if !top_stmt.is_method && top_stmt.name == 'main' {
+				main_already_defined = true
+			}
+		}
 		top_stmts << top_stmt
 	}
 	p.in_top_level = false
+	if script_stmts.len > 0 {
+		if main_already_defined {
+			p.error('function `main` is already defined, put your script statements inside it')
+		}
+		top_stmts << ast.FnDecl{
+			name:  'main'
+			stmts: script_stmts
+		}
+	}
 	if p.pref.verbose {
 		parse_time := sw.elapsed()
 		println('scan & parse ${filename} (${p.file.line_count()} LOC): ${parse_time.milliseconds()}ms (${parse_time.microseconds()}µs)')
@@ -248,6 +272,18 @@ pub fn (mut p Parser) parse_file(filename string, mut file_set token.FileSet) as
 		selector_names: p.selector_names.clone()
 		// decls: decls
 		stmts: top_stmts
+	}
+}
+
+// is_top_stmt_start reports whether the current token can start a top-level
+// declaration. Used to detect script-mode statements (e.g. bare `println(...)`
+// in `main` module) which are wrapped into a synthesized `fn main()`.
+fn (p &Parser) is_top_stmt_start() bool {
+	return match p.tok {
+		.dollar, .hash, .key_asm, .key_const, .key_enum, .key_fn, .key_global,
+		.key_interface, .key_pub, .key_struct, .key_union, .key_type, .attribute,
+		.lsbr { true }
+		else { false }
 	}
 }
 


### PR DESCRIPTION
## Summary
- Top-level statements in the `main` module are collected into a synthesized `fn main()`, matching v1 script-mode behavior.
- Fixes #27009 — `v -v2 main.v` on `println('Hello from v')` no longer errors with `unknown top stmt: name`.

## Implementation
In `vlib/v2/parser/parser.v` `parse_file`:
- When `mod == 'main'` and the current token doesn't start a top-level declaration, parse it as a regular statement and accumulate into `script_stmts`.
- After parsing the file, wrap accumulated `script_stmts` into a synthesized `ast.FnDecl{name: 'main', ...}` appended to top-level stmts.
- If the user also declared their own `fn main`, error with the same message v1 uses.
- New helper `is_top_stmt_start()` lists the tokens that legitimately start a top-level decl.

## Test plan
- [x] `println('Hello from v')` (no `fn main`) → compiles and prints `Hello from v`
- [x] Mixed: script statements + a helper `fn` at top level → compiles, expected output
- [x] Script stmts + explicit `fn main` → errors with the same message v1 uses
- [x] Existing programs with explicit `fn main` still compile
- [x] `cmd/v2/v2 test-self` — all 25 unit tests pass; the pre-existing `v3 -> v4` cleanc self-host failure is reproducible on master and unrelated to this change