### PR TITLE
v2: fix native runtime C symbol lowering

### DIFF
--- a/vlib/v2/pref/comptime.v
+++ b/vlib/v2/pref/comptime.v
@@ -90,6 +90,10 @@ pub fn comptime_flag_value(pref &Preferences, name string) bool {
 			// guards select the software fallback path instead of inline asm.
 			return pref != unsafe { nil } && (pref.backend == .arm64 || pref.backend == .x64)
 		}
+		'no_backtrace' {
+			return pref != unsafe { nil } && ((pref.backend == .arm64 || pref.backend == .x64)
+				|| name in pref.user_defines)
+		}
 		'prealloc' {
 			return pref != unsafe { nil } && pref.prealloc
 		}

--- a/vlib/v2/pref/comptime_test.v
+++ b/vlib/v2/pref/comptime_test.v
@@ -20,6 +20,25 @@ fn test_comptime_flag_value_allows_nil_preferences() {
 	assert !comptime_flag_value(prefs, 'definitely_missing_flag')
 }
 
+fn test_comptime_flag_value_native_backend_backtrace_guards() {
+	mut prefs := new_preferences()
+	prefs.backend = .x64
+	assert comptime_flag_value(&prefs, 'no_backtrace')
+	assert comptime_flag_value(&prefs, 'tinyc')
+
+	prefs.backend = .arm64
+	assert comptime_flag_value(&prefs, 'no_backtrace')
+	assert comptime_flag_value(&prefs, 'tinyc')
+
+	prefs.backend = .cleanc
+	assert !comptime_flag_value(&prefs, 'no_backtrace')
+	assert !comptime_flag_value(&prefs, 'tinyc')
+
+	prefs.user_defines = ['no_backtrace']
+	assert comptime_flag_value(&prefs, 'no_backtrace')
+	assert !comptime_flag_value(&prefs, 'tinyc')
+}
+
 fn test_effective_arch_uses_target_os_preference() {
 	mut prefs := new_preferences()
 	prefs.arch = .auto

--- a/vlib/v2/ssa/builder.v
+++ b/vlib/v2/ssa/builder.v
@@ -6442,6 +6442,14 @@ fn (mut b Builder) build_selector(expr ast.SelectorExpr) ValueID {
 		if c_const_val.len > 0 {
 			return b.mod.get_or_add_const(b.mod.type_store.get_int(32), c_const_val)
 		}
+		// float.h exposes these as preprocessor macros, not linkable data symbols.
+		// Lower them directly so native backends do not emit _FLT_EPSILON/_DBL_EPSILON.
+		if c_name == 'FLT_EPSILON' {
+			return b.mod.get_or_add_const(b.mod.type_store.get_float(32), '1.19209290e-07')
+		}
+		if c_name == 'DBL_EPSILON' {
+			return b.mod.get_or_add_const(b.mod.type_store.get_float(64), '2.2204460492503131e-16')
+		}
 		// _wyp: wyhash secret array from wyhash.h. Our wyhash stub uses
 		// hardcoded constants, so this just needs to be a valid pointer.
 		if c_name == '_wyp' {
@@ -6472,11 +6480,11 @@ fn (mut b Builder) build_selector(expr ast.SelectorExpr) ValueID {
 
 		i8_t := b.mod.type_store.get_int(8)
 		ptr_t := b.mod.type_store.get_ptr(i8_t)
-		if b.is_macos_target() && c_name in ['stdout', 'stderr', 'stdin'] {
-			// `__stdoutp` / `__stdinp` / `__stderrp` are libSystem `FILE*` variables.
-			// Reading the V expression `C.stdout` must yield the FILE* value, not the
-			// address of the variable. The external global is pre-registered on the
-			// main module (build_all) so worker modules see it via seeded values.
+		if c_name in ['stdout', 'stderr', 'stdin'] {
+			// These are C `FILE*` variables. macOS exposes them as libSystem
+			// `__stdoutp` / `__stdinp` / `__stderrp`; other targets use the
+			// standard names. Reading the V expression `C.stdout` must yield the
+			// FILE* value, not the address of the variable.
 			glob := b.mod.add_external_global(target_name, ptr_t)
 			b.global_refs[target_name] = glob
 			return b.mod.add_instr(.load, b.cur_block, ptr_t, [glob])

--- a/vlib/v2/ssa/runtime_symbols_test.v
+++ b/vlib/v2/ssa/runtime_symbols_test.v
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module ssa
+
+import os
+import v2.parser
+import v2.pref as vpref
+import v2.token
+import v2.transformer
+import v2.types
+
+fn build_ssa_for_runtime_symbol_test(code string) &Module {
+	return build_ssa_for_runtime_symbol_target_test(code, 'linux')
+}
+
+fn build_ssa_for_runtime_symbol_target_test(code string, target_os string) &Module {
+	tmp_file := os.join_path(os.vtmp_dir(), 'v2_ssa_runtime_symbols_${os.getpid()}.v')
+	os.write_file(tmp_file, code) or { panic('failed to write temp file') }
+	defer {
+		os.rm(tmp_file) or {}
+	}
+	mut prefs := &vpref.Preferences{
+		backend:     .x64
+		no_parallel: true
+	}
+	prefs.target_os = target_os
+	mut file_set := token.FileSet.new()
+	mut par := parser.Parser.new(prefs)
+	files := par.parse_files([tmp_file], mut file_set)
+	mut env := types.Environment.new()
+	mut checker := types.Checker.new(prefs, file_set, env)
+	checker.check_files(files)
+	mut trans := transformer.Transformer.new_with_pref(files, env, prefs)
+	transformed := trans.transform_files(files)
+	mut ssa_mod := Module.new('runtime_symbols')
+	mut b := Builder.new_with_env(ssa_mod, env)
+	b.target_os = target_os
+	b.build_all(transformed)
+	return ssa_mod
+}
+
+fn stdio_loaded_external_symbol_names(m &Module) []string {
+	mut names := []string{}
+	for val in m.values {
+		if val.kind != .instruction {
+			continue
+		}
+		instr := m.instrs[val.index]
+		if instr.op != .load || instr.operands.len != 1 {
+			continue
+		}
+		operand := instr.operands[0]
+		if operand <= 0 || operand >= m.values.len {
+			continue
+		}
+		global := m.values[operand]
+		if global.kind == .global
+			&& global.name in ['stdout', 'stderr', 'stdin', '__stdoutp', '__stderrp', '__stdinp'] {
+			assert global.index >= 0 && global.index < m.globals.len
+			assert m.globals[global.index].linkage == .external
+			names << global.name
+		}
+	}
+	return names
+}
+
+fn test_c_float_epsilon_macros_are_ssa_constants_not_external_globals() {
+	m := build_ssa_for_runtime_symbol_test('
+module main
+
+fn seek_set() int {
+	return C.SEEK_SET
+}
+
+fn flt_epsilon() f32 {
+	return C.FLT_EPSILON
+}
+
+fn dbl_epsilon() f64 {
+	return C.DBL_EPSILON
+}
+
+fn main() {
+	_ := seek_set()
+	_ := flt_epsilon()
+	_ := dbl_epsilon()
+}
+')
+	mut has_seek_set_const := false
+	mut has_flt_epsilon_const := false
+	mut has_dbl_epsilon_const := false
+	for val in m.values {
+		if val.kind == .global {
+			assert val.name != 'SEEK_SET'
+			assert val.name != 'FLT_EPSILON'
+			assert val.name != 'DBL_EPSILON'
+		}
+		if val.kind != .constant {
+			continue
+		}
+		if val.name == '1.19209290e-07' {
+			typ := m.type_store.types[val.typ]
+			assert typ.kind == .float_t
+			assert typ.width == 32
+			has_flt_epsilon_const = true
+		}
+		if val.name == '2.2204460492503131e-16' {
+			typ := m.type_store.types[val.typ]
+			assert typ.kind == .float_t
+			assert typ.width == 64
+			has_dbl_epsilon_const = true
+		}
+		if val.name == '0' {
+			typ := m.type_store.types[val.typ]
+			if typ.kind == .int_t && typ.width == 32 {
+				has_seek_set_const = true
+			}
+		}
+	}
+	assert has_seek_set_const
+	assert has_flt_epsilon_const
+	assert has_dbl_epsilon_const
+}
+
+fn test_c_stdio_globals_are_loaded_on_non_macos_targets() {
+	m := build_ssa_for_runtime_symbol_target_test('
+module main
+
+fn main() {
+	_ := C.stdout
+	_ := C.stderr
+	_ := C.stdin
+}
+',
+		'linux')
+	load_names := stdio_loaded_external_symbol_names(m)
+
+	assert 'stdout' in load_names
+	assert 'stderr' in load_names
+	assert 'stdin' in load_names
+	assert '__stdoutp' !in load_names
+	assert '__stderrp' !in load_names
+	assert '__stdinp' !in load_names
+}
+
+fn test_c_stdio_globals_are_loaded_on_windows_targets() {
+	m := build_ssa_for_runtime_symbol_target_test('
+module main
+
+fn main() {
+	_ := C.stdout
+	_ := C.stderr
+	_ := C.stdin
+}
+',
+		'windows')
+	load_names := stdio_loaded_external_symbol_names(m)
+
+	assert 'stdout' in load_names
+	assert 'stderr' in load_names
+	assert 'stdin' in load_names
+	assert '__stdoutp' !in load_names
+	assert '__stderrp' !in load_names
+	assert '__stdinp' !in load_names
+}
+
+fn test_c_stdio_globals_are_loaded_from_macos_symbols_on_macos_targets() {
+	m := build_ssa_for_runtime_symbol_target_test('
+module main
+
+fn main() {
+	_ := C.stdout
+	_ := C.stderr
+	_ := C.stdin
+}
+',
+		'macos')
+	load_names := stdio_loaded_external_symbol_names(m)
+
+	assert '__stdoutp' in load_names
+	assert '__stderrp' in load_names
+	assert '__stdinp' in load_names
+	assert 'stdout' !in load_names
+	assert 'stderr' !in load_names
+	assert 'stdin' !in load_names
+}

--- a/vlib/v2/transformer/transformer_test.v
+++ b/vlib/v2/transformer/transformer_test.v
@@ -6694,9 +6694,8 @@ $else {
 	assert struct_field_names(files[0], 'Container') == ['tag']
 }
 
-// `tinyc` and `builtin_write_buf_to_fd_should_use_c_write` are recognized by
-// the shared `pref.comptime_flag_value` and evaluate true on the native
-// backends. Confirms the parser sees the same flag set the transformer does.
+// Native backend flags are recognized by the shared `pref.comptime_flag_value`.
+// Confirms the parser sees the same flag set the transformer does.
 fn test_struct_comptime_native_backend_flags() {
 	files := parse_code_with_prefs_for_test('
 module main
@@ -6704,6 +6703,9 @@ module main
 struct Container {
 $if tinyc ? {
 	tinyc_field string
+}
+$if no_backtrace ? {
+	no_backtrace_field string
 }
 $if builtin_write_buf_to_fd_should_use_c_write ? {
 	write_field string
@@ -6716,5 +6718,6 @@ $if new_int ? {
 ',
 		.x64, [])
 	assert files.len == 1
-	assert struct_field_names(files[0], 'Container') == ['tinyc_field', 'write_field', 'always']
+	assert struct_field_names(files[0], 'Container') == ['tinyc_field', 'no_backtrace_field',
+		'write_field', 'always']
 }

--- a/vlib/v2/types/comptime_test.v
+++ b/vlib/v2/types/comptime_test.v
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module types
+
+import v2.pref
+import v2.token
+
+fn test_checker_comptime_flags_match_pref_for_native_backends() {
+	x64_prefs := &pref.Preferences{
+		backend: .x64
+	}
+	arm64_prefs := &pref.Preferences{
+		backend: .arm64
+	}
+	mut file_set := token.FileSet.new()
+	env := Environment.new()
+	x64_checker := Checker.new(x64_prefs, file_set, env)
+	arm64_checker := Checker.new(arm64_prefs, file_set, env)
+
+	assert x64_checker.eval_comptime_flag('no_backtrace')
+	assert x64_checker.eval_comptime_flag('tinyc')
+	assert arm64_checker.eval_comptime_flag('no_backtrace')
+	assert arm64_checker.eval_comptime_flag('tinyc')
+}
+
+fn test_checker_comptime_flags_match_pref_for_non_native_backend() {
+	cleanc_prefs := &pref.Preferences{
+		backend: .cleanc
+	}
+	mut file_set := token.FileSet.new()
+	env := Environment.new()
+	cleanc_checker := Checker.new(cleanc_prefs, file_set, env)
+
+	assert !cleanc_checker.eval_comptime_flag('no_backtrace')
+	assert !cleanc_checker.eval_comptime_flag('tinyc')
+}
+
+fn test_checker_comptime_flags_honor_no_backtrace_user_define_for_non_native_backend() {
+	cleanc_prefs := &pref.Preferences{
+		backend:      .cleanc
+		user_defines: ['no_backtrace']
+	}
+	mut file_set := token.FileSet.new()
+	env := Environment.new()
+	cleanc_checker := Checker.new(cleanc_prefs, file_set, env)
+
+	assert cleanc_checker.eval_comptime_flag('no_backtrace')
+	assert !cleanc_checker.eval_comptime_flag('tinyc')
+}
+
+fn test_checker_comptime_flags_follow_pref_target_os_and_native_windows_pe() {
+	mut prefs := pref.new_preferences()
+	prefs.backend = .x64
+	prefs.arch = .x64
+	prefs.target_os = 'windows'
+	mut file_set := token.FileSet.new()
+	env := Environment.new()
+	checker := Checker.new(&prefs, file_set, env)
+
+	assert checker.eval_comptime_flag('windows')
+	assert !checker.eval_comptime_flag('linux')
+	assert !checker.eval_comptime_flag('macos')
+	assert checker.eval_comptime_flag('v2_native_windows_pe_minimal')
+
+	prefs.target_os = 'linux'
+	assert !checker.eval_comptime_flag('windows')
+	assert checker.eval_comptime_flag('linux')
+	assert !checker.eval_comptime_flag('v2_native_windows_pe_minimal')
+
+	prefs.target_os = 'windows'
+	prefs.backend = .arm64
+	assert checker.eval_comptime_flag('windows')
+	assert !checker.eval_comptime_flag('v2_native_windows_pe_minimal')
+}


### PR DESCRIPTION
## Summary

This PR fixes the remaining native V2 x64 runtime symbol issues around the Mach-O backend path.

Fix #27131 

It addresses two separate but related problems:

- C floating-point macros such as `C.FLT_EPSILON` and `C.DBL_EPSILON` were treated as external globals, which could produce missing runtime symbols such as `_FLT_EPSILON` / `_DBL_EPSILON`.
- Native V2 backends could still select runtime/backtrace paths that pull `_tcc_backtrace`, which is not available in the native backend runtime.

The patch keeps the fix in the V2 pipeline and avoids linker-only workarounds.

## What Changed

- `C.FLT_EPSILON` is lowered directly to an SSA `f32` constant.
- `C.DBL_EPSILON` is lowered directly to an SSA `f64` constant.
- The `no_backtrace` comptime flag is enabled for native `.x64` / `.arm64` backends, while still honoring explicit user defines.
- The checker now uses the shared `pref.comptime_flag_value(...)` logic, avoiding duplicated comptime-flag behavior.
- Native backend comptime tests now cover `tinyc`, `no_backtrace`, and recent target-specific flags such as `windows` and `v2_native_windows_pe_minimal`.
- `C.stdin`, `C.stdout`, and `C.stderr` are now loaded as `FILE*` values for all targets, not only macOS:
  - macOS keeps the existing `__stdinp` / `__stdoutp` / `__stderrp` remapping;
  - Linux/Windows keep the raw `stdin` / `stdout` / `stderr` symbols;
  - the SSA lowering now loads the value from the external global instead of passing the address of the global slot.

## Scope

This does not add a broad native runtime implementation and does not change V1.

It also does not add CRT support to the minimal Windows PE path. Explicit `C.stdout` usage remains a normal external C/CRT symbol reference; the minimal `println` path remains separate.

## Tests

Added/updated coverage for:

- `C.FLT_EPSILON` / `C.DBL_EPSILON` lowering as SSA constants;
- absence of runtime globals for those C macros;
- checker/pref comptime flag consistency;
- native `.x64` / `.arm64` `no_backtrace` behavior;
- target OS flags including `windows`;
- `v2_native_windows_pe_minimal`;
- `C.stdin` / `C.stdout` / `C.stderr` lowering through external globals plus `load`;
- Linux/Windows raw stdio symbol names;
- macOS stdio remapping to `__stdinp` / `__stdoutp` / `__stderrp`.

Validation run locally on Linux:

- `./v test vlib/v2/ssa/runtime_symbols_test.v`
- `./v test vlib/v2/pref/comptime_test.v`
- `./v test vlib/v2/types/comptime_test.v`
- `./v test vlib/v2/gen/x64`
- `./v test vlib/v2/ssa`
- `./v test vlib/v2/builder/native_test.v vlib/v2/builder/target_os_test.v`
- `./v fmt -verify ...`
- `git diff --check`

A real macOS native x64 smoke test should still be validated by CI or a macOS runner.