### PR TITLE
checker: warn when a local variable shadows a function declaration (fixes #22685)

### DIFF
--- a/examples/c_interop_wkhtmltopdf.v
+++ b/examples/c_interop_wkhtmltopdf.v
@@ -75,13 +75,13 @@ fn main() {
 	if result {
 		pdata := &char(unsafe { nil })
 		ppdata := &pdata
-		size := C.wkhtmltopdf_get_output(converter, voidptr(ppdata))
-		println('wkhtmltopdf_get_output: ${size} bytes')
+		nbytes := C.wkhtmltopdf_get_output(converter, voidptr(ppdata))
+		println('wkhtmltopdf_get_output: ${nbytes} bytes')
 		mut file := os.open_file('./google.pdf', 'w+', 0o666) or {
 			println('ERR: ${err}')
 			return
 		}
-		wrote := unsafe { file.write_ptr(pdata, size) }
+		wrote := unsafe { file.write_ptr(pdata, nbytes) }
 		println('write_bytes: ${wrote} [./google.pdf]')
 		file.flush()
 		file.close()

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -1166,9 +1166,9 @@ pub fn (mut a array) push_many(val voidptr, size int) {
 	}
 	if is_self_append {
 		// handle `arr << arr`
-		copy := a.clone()
+		cloned := a.clone()
 		unsafe {
-			vmemcpy(&u8(a.data) + u64(a.element_size) * u64(a.len), copy.data,
+			vmemcpy(&u8(a.data) + u64(a.element_size) * u64(a.len), cloned.data,
 				u64(a.element_size) * u64(size))
 		}
 	} else {

--- a/vlib/builtin/array_d_gcboehm_opt.v
+++ b/vlib/builtin/array_d_gcboehm_opt.v
@@ -305,9 +305,9 @@ fn (mut a array) pop_noscan() voidptr {
 	new_len := a.len - 1
 	last_elem := unsafe { &u8(a.data) + u64(new_len) * u64(a.element_size) }
 	if a.needs_unique_shrink() {
-		copy := unsafe { memdup_noscan(last_elem, a.element_size) }
+		cloned := unsafe { memdup_noscan(last_elem, a.element_size) }
 		a.delete_many(new_len, 1)
-		return copy
+		return cloned
 	}
 	a.len = new_len
 	// Note: a.cap is not changed here *on purpose*, so that
@@ -393,12 +393,12 @@ fn (mut a array) push_many_noscan(val voidptr, size int) {
 	}
 	if a.data == val && a.data != 0 {
 		// handle `arr << arr`
-		copy := a.clone()
+		cloned := a.clone()
 		if int(new_len) > a.cap {
 			a.ensure_cap_noscan(int(new_len))
 		}
 		unsafe {
-			vmemcpy(a.get_unsafe(a.len), copy.data, u64(a.element_size) * u64(size))
+			vmemcpy(a.get_unsafe(a.len), cloned.data, u64(a.element_size) * u64(size))
 		}
 	} else {
 		if int(new_len) > a.cap {

--- a/vlib/cli/command.v
+++ b/vlib/cli/command.v
@@ -363,9 +363,9 @@ fn (mut cmd Command) handle_cb(cb FnCommandCallback, label string) {
 
 fn (cmd &Command) check_help_flag() {
 	if cmd.defaults.parsed.help.flag && cmd.flags.contains('help') {
-		help_flag :=
+		help_enabled :=
 			cmd.flags.get_bool('help') or { return } // ignore error and handle command normally
-		if help_flag {
+		if help_enabled {
 			cmd.execute_help()
 			exit(0)
 		}
@@ -374,9 +374,9 @@ fn (cmd &Command) check_help_flag() {
 
 fn (cmd &Command) check_man_flag() {
 	if cmd.defaults.parsed.man.flag && cmd.flags.contains('man') {
-		man_flag :=
+		man_enabled :=
 			cmd.flags.get_bool('man') or { return } // ignore error and handle command normally
-		if man_flag {
+		if man_enabled {
 			cmd.execute_man()
 			exit(0)
 		}
@@ -385,9 +385,9 @@ fn (cmd &Command) check_man_flag() {
 
 fn (cmd &Command) check_version_flag() {
 	if cmd.defaults.parsed.version.flag && cmd.version != '' && cmd.flags.contains('version') {
-		version_flag :=
+		version_enabled :=
 			cmd.flags.get_bool('version') or { return } // ignore error and handle command normally
-		if version_flag {
+		if version_enabled {
 			print_version_for_command(cmd) or { panic(err) }
 			exit(0)
 		}
@@ -406,10 +406,10 @@ fn (cmd &Command) check_required_flags() {
 // execute_help executes the callback registered for the `-h`/`--help` flag option.
 pub fn (cmd &Command) execute_help() {
 	if cmd.commands.contains('help') {
-		help_cmd :=
+		sub :=
 			cmd.commands.get('help') or { return } // ignore error and handle command normally
-		if !isnil(help_cmd.execute) {
-			help_cmd.execute(help_cmd) or { panic(err) }
+		if !isnil(sub.execute) {
+			sub.execute(sub) or { panic(err) }
 			return
 		}
 	}
@@ -419,8 +419,8 @@ pub fn (cmd &Command) execute_help() {
 // execute_man executes the callback registered for the `-man` flag option.
 pub fn (cmd &Command) execute_man() {
 	if cmd.commands.contains('man') {
-		man_cmd := cmd.commands.get('man') or { return }
-		man_cmd.execute(man_cmd) or { panic(err) }
+		sub := cmd.commands.get('man') or { return }
+		sub.execute(sub) or { panic(err) }
 	} else {
 		print(cmd.manpage())
 	}

--- a/vlib/cli/man.v
+++ b/vlib/cli/man.v
@@ -24,8 +24,8 @@ pub fn print_manpage_for_command(cmd Command) ! {
 	if cmd.args.len > 0 {
 		for sub_cmd in cmd.commands {
 			if sub_cmd.matches(cmd.args[0]) {
-				man_cmd := unsafe { &sub_cmd }
-				print(man_cmd.manpage())
+				target := unsafe { &sub_cmd }
+				print(target.manpage())
 				return
 			}
 		}

--- a/vlib/cli/version.v
+++ b/vlib/cli/version.v
@@ -22,8 +22,8 @@ fn print_version_for_command(cmd Command) ! {
 	if cmd.args.len > 0 {
 		for sub_cmd in cmd.commands {
 			if sub_cmd.name == cmd.args[0] {
-				version_cmd := unsafe { &sub_cmd }
-				print(version_cmd.version())
+				target := unsafe { &sub_cmd }
+				print(target.version())
 				return
 			}
 		}

--- a/vlib/crypto/rand/utils.v
+++ b/vlib/crypto/rand/utils.v
@@ -21,9 +21,9 @@ pub fn int_u64(max u64) !u64 {
 	}
 	mut n := u64(0)
 	for {
-		mut bytes := read(k)!
-		bytes[0] &= u8(int(u64(1) << b) - 1)
-		x := bytes_to_u64(bytes)
+		mut buf := read(k)!
+		buf[0] &= u8(int(u64(1) << b) - 1)
+		x := bytes_to_u64(buf)
 		n = x[0]
 		// NOTE: maybe until we have bigint could do it another way?
 		// if x.len > 1 {
@@ -81,12 +81,12 @@ pub fn int_big(n big.Integer) !big.Integer {
 
 	mut result := big.Integer{}
 	for {
-		mut bytes := read(k)!
+		mut buf := read(k)!
 
 		// Clear bits in the first byte to increase the probability that the result is < max
-		bytes[0] &= u8(int(1 << b) - 1)
+		buf[0] &= u8(int(1 << b) - 1)
 
-		result = big.integer_from_bytes(bytes)
+		result = big.integer_from_bytes(buf)
 		if result < max {
 			break
 		}

--- a/vlib/crypto/sha256/sha256.v
+++ b/vlib/crypto/sha256/sha256.v
@@ -214,10 +214,10 @@ pub fn sum256(data []u8) []u8 {
 pub fn sum224(data []u8) []u8 {
 	mut d := new224()
 	d.write(data) or { panic(err) }
-	sum := d.checksum()
-	mut sum224 := []u8{len: size224}
-	copy(mut sum224, sum[..size224])
-	return sum224
+	checksum := d.checksum()
+	mut result := []u8{len: size224}
+	copy(mut result, checksum[..size224])
+	return result
 }
 
 fn block(mut dig Digest, p []u8) {

--- a/vlib/math/big/integer.v
+++ b/vlib/math/big/integer.v
@@ -705,17 +705,17 @@ pub fn (mut a Integer) set_bit(i u32, value bool) {
 		return
 	}
 
-	mut copy := a.digits.clone()
+	mut cloned := a.digits.clone()
 
 	if value {
-		copy[target_index] |= u64(1) << offset
+		cloned[target_index] |= u64(1) << offset
 	} else {
-		copy[target_index] &= ~(u64(1) << offset)
+		cloned[target_index] &= ~(u64(1) << offset)
 	}
 
 	a = Integer{
 		signum: a.signum
-		digits: copy
+		digits: cloned
 	}
 }
 

--- a/vlib/math/cbrt.v
+++ b/vlib/math/cbrt.v
@@ -31,10 +31,10 @@ pub fn cbrt(a f64) f64 {
 	if x == 0.0 || is_nan(x) || is_inf(x, 0) {
 		return x
 	}
-	mut sign := false
+	mut neg := false
 	if x < 0 {
 		x = -x
-		sign = true
+		neg = true
 	}
 	// rough cbrt to 5 bits
 	mut t := f64_from_bits(f64_bits(x) / u64(3) + (u64(b1) << 32))
@@ -57,7 +57,7 @@ pub fn cbrt(a f64) f64 {
 	r = (r - t) / (w + r) // r-s is exact
 	t = t + t * r
 	// restore the sign bit
-	if sign {
+	if neg {
 		t = -t
 	}
 	return t

--- a/vlib/math/erf.v
+++ b/vlib/math/erf.v
@@ -227,10 +227,10 @@ pub fn erf(a f64) f64 {
 	if is_inf(x, -1) {
 		return f64(-1)
 	}
-	mut sign := false
+	mut neg := false
 	if x < 0 {
 		x = -x
-		sign = true
+		neg = true
 	}
 	if x < 0.84375 { // |x| < 0.84375
 		mut temp := 0.0
@@ -247,7 +247,7 @@ pub fn erf(a f64) f64 {
 			y := r / s_
 			temp = x + x * y
 		}
-		if sign {
+		if neg {
 			return -temp
 		}
 		return temp
@@ -256,13 +256,13 @@ pub fn erf(a f64) f64 {
 		s_ := x - 1
 		p := pa0 + s_ * (pa1 + s_ * (pa2 + s_ * (pa3 + s_ * (pa4 + s_ * (pa5 + s_ * pa6)))))
 		q := 1.0 + s_ * (qa1 + s_ * (qa2 + s_ * (qa3 + s_ * (qa4 + s_ * (qa5 + s_ * qa6)))))
-		if sign {
+		if neg {
 			return -erx - p / q
 		}
 		return erx + p / q
 	}
 	if x >= 6 { // inf > |x| >= 6
-		if sign {
+		if neg {
 			return -1
 		}
 		return 1.0
@@ -283,7 +283,7 @@ pub fn erf(a f64) f64 {
 	}
 	z := f64_from_bits(f64_bits(x) & 0xffffffff00000000) // pseudo-single (20-bit) precision x
 	r_ := exp(-z * z - 0.5625) * exp((z - x) * (z + x) + r / s)
-	if sign {
+	if neg {
 		return r_ / x - 1.0
 	}
 	return 1.0 - r_ / x
@@ -308,10 +308,10 @@ pub fn erfc(a f64) f64 {
 	if is_inf(x, -1) {
 		return 2.0
 	}
-	mut sign := false
+	mut neg := false
 	if x < 0 {
 		x = -x
-		sign = true
+		neg = true
 	}
 	if x < 0.84375 { // |x| < 0.84375
 		mut temp := 0.0
@@ -328,7 +328,7 @@ pub fn erfc(a f64) f64 {
 				temp = 0.5 + (x * y + (x - 0.5))
 			}
 		}
-		if sign {
+		if neg {
 			return 1.0 + temp
 		}
 		return 1.0 - temp
@@ -337,7 +337,7 @@ pub fn erfc(a f64) f64 {
 		s_ := x - 1
 		p := pa0 + s_ * (pa1 + s_ * (pa2 + s_ * (pa3 + s_ * (pa4 + s_ * (pa5 + s_ * pa6)))))
 		q := 1.0 + s_ * (qa1 + s_ * (qa2 + s_ * (qa3 + s_ * (qa4 + s_ * (qa5 + s_ * qa6)))))
-		if sign {
+		if neg {
 			return 1.0 + erx + p / q
 		}
 		return 1.0 - erx - p / q
@@ -352,7 +352,7 @@ pub fn erfc(a f64) f64 {
 			tmp282 := sa4 + s_ * (sa5 + s_ * (sa6 + s_ * (sa7 + s_ * sa8)))
 			s = 1.0 + s_ * (sa1 + s_ * (sa2 + s_ * (sa3 + s_ * tmp282)))
 		} else { // |x| >= 1 / 0.35 ~ 2.857143
-			if sign && x > 6 {
+			if neg && x > 6 {
 				return 2.0 // x < -6
 			}
 			tmp291 := rb3 + s_ * (rb4 + s_ * (rb5 + s_ * rb6))
@@ -362,12 +362,12 @@ pub fn erfc(a f64) f64 {
 		}
 		z := f64_from_bits(f64_bits(x) & 0xffffffff00000000) // pseudo-single (20-bit) precision x
 		r_ := exp(-z * z - 0.5625) * exp((z - x) * (z + x) + r / s)
-		if sign {
+		if neg {
 			return 2.0 - r_ / x
 		}
 		return r_ / x
 	}
-	if sign {
+	if neg {
 		return 2.0
 	}
 	return 0.0

--- a/vlib/math/factorial.v
+++ b/vlib/math/factorial.v
@@ -34,7 +34,7 @@ fn log_factorial_asymptotic_expansion(n int) f64 {
 	mut term := []f64{}
 	xx := f64((n + 1) * (n + 1))
 	mut xj := f64(n + 1)
-	log_factorial := log_sqrt_2pi - xj + (xj - 0.5) * log(xj)
+	log_fact := log_sqrt_2pi - xj + (xj - 0.5) * log(xj)
 	mut i := 0
 	for i = 0; i < m; i++ {
 		term << bernoulli[i] / xj
@@ -51,7 +51,7 @@ fn log_factorial_asymptotic_expansion(n int) f64 {
 		sum += term[i]
 		i--
 	}
-	return log_factorial + sum
+	return log_fact + sum
 }
 
 // factoriali returns 1 for n <= 0 and -1 if the result is too large for a 64 bit integer

--- a/vlib/math/gamma.v
+++ b/vlib/math/gamma.v
@@ -144,15 +144,15 @@ pub fn log_gamma(x f64) f64 {
 // log_gamma_sign returns the natural logarithm and sign (-1 or +1) of Gamma(x)
 pub fn log_gamma_sign(a f64) (f64, int) {
 	mut x := a
-	mut sign := 1
+	mut sgn := 1
 	if is_nan(x) {
-		return x, sign
+		return x, sgn
 	}
 	if is_inf(x, 1) {
-		return x, sign
+		return x, sgn
 	}
 	if x == 0.0 {
-		return inf(1), sign
+		return inf(1), sgn
 	}
 	mut neg := false
 	if x < 0 {
@@ -161,28 +161,28 @@ pub fn log_gamma_sign(a f64) (f64, int) {
 	}
 	if x < exp2(-70) { // if |x| < 2**-70, return -log(|x|)
 		if neg {
-			sign = -1
+			sgn = -1
 		}
-		return -log(x), sign
+		return -log(x), sgn
 	}
 	mut nadj := 0.0
 	if neg {
 		if x >= exp2(52) { // the constant is 0x4330000000000000 ~4.5036e+15
 			// x| >= 2**52, must be -integer
-			return inf(1), sign
+			return inf(1), sgn
 		}
 		t := sin_pi(x)
 		if t == 0 {
-			return inf(1), sign
+			return inf(1), sgn
 		}
 		nadj = log(pi / abs(t * x))
 		if t < 0 {
-			sign = -1
+			sgn = -1
 		}
 	}
 	mut lgamma := 0.0
 	if x == 1 || x == 2 { // purge off 1 and 2
-		return 0.0, sign
+		return 0.0, sgn
 	} else if x < 2 { // use lgamma(x) = lgamma(x+1) - log(x)
 		ymin := 1.461632144968362245
 		tc := 1.46163214496836224576e+00 // 0x3FF762D86356BE3F
@@ -292,7 +292,7 @@ pub fn log_gamma_sign(a f64) (f64, int) {
 	if neg {
 		lgamma = nadj - lgamma
 	}
-	return lgamma, sign
+	return lgamma, sgn
 }
 
 // sin_pi(x) is a helper function for negative x

--- a/vlib/math/invtrig.v
+++ b/vlib/math/invtrig.v
@@ -175,10 +175,10 @@ pub fn asin(x_ f64) f64 {
 	if x == 0.0 {
 		return x // special case
 	}
-	mut sign := false
+	mut neg := false
 	if x < 0.0 {
 		x = -x
-		sign = true
+		neg = true
 	}
 	if x > 1.0 {
 		return nan() // special case
@@ -189,7 +189,7 @@ pub fn asin(x_ f64) f64 {
 	} else {
 		temp = satan(x / temp)
 	}
-	if sign {
+	if neg {
 		temp = -temp
 	}
 	return temp

--- a/vlib/math/log.v
+++ b/vlib/math/log.v
@@ -56,13 +56,13 @@ pub fn log10(x f64) f64 {
 // log2 returns the binary logarithm of x.
 // The special cases are the same as for log.
 pub fn log2(x f64) f64 {
-	frac, exp := frexp(x)
+	frac, expn := frexp(x)
 	// Make sure exact powers of two give an exact answer.
-	// Don't depend on log(0.5)*(1/ln2)+exp being exactly exp-1.
+	// Don't depend on log(0.5)*(1/ln2)+expn being exactly expn-1.
 	if frac == 0.5 {
-		return f64(exp - 1)
+		return f64(expn - 1)
 	}
-	return log(frac) * (1.0 / ln2) + f64(exp)
+	return log(frac) * (1.0 / ln2) + f64(expn)
 }
 
 // log1p returns log(1+x)
@@ -113,8 +113,8 @@ pub fn ilog_b(x f64) int {
 // ilog_b returns the binary exponent of x. It assumes x is finite and
 // non-zero.
 fn ilog_b_(x_ f64) int {
-	x, exp := normalize(x_)
-	return int((f64_bits(x) >> shift) & mask) - bias + exp
+	x, expn := normalize(x_)
+	return int((f64_bits(x) >> shift) & mask) - bias + expn
 }
 
 // log returns the natural logarithm of x

--- a/vlib/math/math.v
+++ b/vlib/math/math.v
@@ -81,9 +81,9 @@ pub fn digits(num i64, params DigitParams) []int {
 		panic_n('digits: Cannot find digits of n with base:', b)
 	}
 	mut n := num
-	mut sign := 1
+	mut sgn := 1
 	if n < 0 {
-		sign = -1
+		sgn = -1
 		n = -n
 	}
 
@@ -99,8 +99,8 @@ pub fn digits(num i64, params DigitParams) []int {
 		n = next_n
 	}
 
-	if sign == -1 {
-		res[res.len - 1] *= sign
+	if sgn == -1 {
+		res[res.len - 1] *= sgn
 	}
 
 	if params.reverse {

--- a/vlib/math/sinh.v
+++ b/vlib/math/sinh.v
@@ -11,10 +11,10 @@ pub fn sinh(x_ f64) f64 {
 	q0 := -0.6307673640497716991212077277e+6
 	q1 := 0.1521517378790019070696485176e+5
 	q2 := -0.173678953558233699533450911e+3
-	mut sign := false
+	mut neg := false
 	if x < 0 {
 		x = -x
-		sign = true
+		neg = true
 	}
 	mut temp := 0.0
 	if x > 21 {
@@ -27,7 +27,7 @@ pub fn sinh(x_ f64) f64 {
 		temp = (((p3 * sq + p2) * sq + p1) * sq + p0) * x
 		temp = temp / (((sq + q2) * sq + q1) * sq + q0)
 	}
-	if sign {
+	if neg {
 		temp = -temp
 	}
 	return temp

--- a/vlib/math/tan.v
+++ b/vlib/math/tan.v
@@ -26,10 +26,10 @@ pub fn tan(a f64) f64 {
 	if is_inf(x, 0) {
 		return nan()
 	}
-	mut sign := 1 // make argument positive but save the sign
+	mut sgn := 1 // make argument positive but save the sign
 	if x < 0 {
 		x = -x
-		sign = -1
+		sgn = -1
 	}
 	if x > tan_lossth {
 		return 0.0
@@ -55,7 +55,7 @@ pub fn tan(a f64) f64 {
 	if (octant & 2) == 2 {
 		y = -1.0 / y
 	}
-	if sign < 0 {
+	if sgn < 0 {
 		y = -y
 	}
 	return y
@@ -73,10 +73,10 @@ pub fn cot(a f64) f64 {
 	if x == 0.0 {
 		return inf(1)
 	}
-	mut sign := 1 // make argument positive but save the sign
+	mut sgn := 1 // make argument positive but save the sign
 	if x < 0 {
 		x = -x
-		sign = -1
+		sgn = -1
 	}
 	if x > tan_lossth {
 		return 0.0
@@ -104,7 +104,7 @@ pub fn cot(a f64) f64 {
 	} else {
 		y = 1.0 / y
 	}
-	if sign < 0 {
+	if sgn < 0 {
 		y = -y
 	}
 	return y

--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -410,8 +410,8 @@ fn split_by_scheme(rawurl string) ![]string {
 }
 
 fn get_scheme(rawurl string) !string {
-	split := split_by_scheme(rawurl) or { return err.msg() }
-	return split[0]
+	parts := split_by_scheme(rawurl) or { return err.msg() }
+	return parts[0]
 }
 
 // split slices s into two substrings separated by the first occurrence of
@@ -713,13 +713,13 @@ pub fn (u URL) str() string {
 	if u.opaque != '' {
 		buf.write_string(u.opaque)
 	} else {
-		user := u.user or { Userinfo{} }
-		if u.scheme != '' || u.host != '' || !user.empty() {
-			if u.host != '' || u.path != '' || !user.empty() {
+		userinfo := u.user or { Userinfo{} }
+		if u.scheme != '' || u.host != '' || !userinfo.empty() {
+			if u.host != '' || u.path != '' || !userinfo.empty() {
 				buf.write_string('//')
 			}
-			if !user.empty() {
-				buf.write_string(user.str())
+			if !userinfo.empty() {
+				buf.write_string(userinfo.str())
 				buf.write_string('@')
 			}
 			if u.host != '' {

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -136,14 +136,14 @@ fn slurp_file_in_builder(fp &C.FILE) !strings.Builder {
 	buf := [buf_size]u8{}
 	mut sb := strings.new_builder(buf_size)
 	for {
-		mut read_bytes := fread(&buf[0], 1, buf_size, fp) or {
+		mut nbytes := fread(&buf[0], 1, buf_size, fp) or {
 			if err is Eof {
 				break
 			}
 			unsafe { sb.free() }
 			return err
 		}
-		unsafe { sb.write_ptr(&buf[0], read_bytes) }
+		unsafe { sb.write_ptr(&buf[0], nbytes) }
 	}
 	return sb
 }

--- a/vlib/os/os.v
+++ b/vlib/os/os.v
@@ -401,24 +401,24 @@ pub fn split_path(path string) (string, string, string) {
 	if path.ends_with(detected_path_separator) {
 		return path[..path.len - 1], '', ''
 	}
-	mut dir := '.'
+	mut dir_path := '.'
 	/*
 		TODO: JS backend does not support IfGuard yet.
 	*/
 	pos := path.last_index(detected_path_separator) or { -1 }
 	if pos == -1 {
-		dir = '.'
+		dir_path = '.'
 	} else if pos == 0 {
-		dir = detected_path_separator
+		dir_path = detected_path_separator
 	} else {
-		dir = path[..pos]
+		dir_path = path[..pos]
 	}
-	file_name := path.all_after_last(detected_path_separator)
-	pos_ext := file_name.last_index_u8(`.`)
-	if pos_ext == -1 || pos_ext == 0 || pos_ext + 1 >= file_name.len {
-		return dir, file_name, ''
+	fname := path.all_after_last(detected_path_separator)
+	pos_ext := fname.last_index_u8(`.`)
+	if pos_ext == -1 || pos_ext == 0 || pos_ext + 1 >= fname.len {
+		return dir_path, fname, ''
 	}
-	return dir, file_name[..pos_ext], file_name[pos_ext..]
+	return dir_path, fname[..pos_ext], fname[pos_ext..]
 }
 
 // input_opt returns a one-line string from stdin, after printing a prompt.
@@ -835,11 +835,11 @@ pub fn walk(path string, f fn (string)) {
 		return
 	}
 	mut remaining := []string{cap: 1000}
-	clean_path := path.trim_right(path_separator)
+	cleaned := path.trim_right(path_separator)
 	$if windows {
-		remaining << clean_path.replace('/', '\\')
+		remaining << cleaned.replace('/', '\\')
 	} $else {
-		remaining << clean_path
+		remaining << cleaned
 	}
 	for remaining.len > 0 {
 		cpath := remaining.pop()
@@ -873,11 +873,11 @@ pub fn walk_with_context(path string, context voidptr, fcb FnWalkContextCB) {
 		return
 	}
 	mut remaining := []string{cap: 1000}
-	clean_path := path.trim_right(path_separator)
+	cleaned := path.trim_right(path_separator)
 	$if windows {
-		remaining << clean_path.replace('/', '\\')
+		remaining << cleaned.replace('/', '\\')
 	} $else {
-		remaining << clean_path
+		remaining << cleaned
 	}
 	mut loops := 0
 	for remaining.len > 0 {
@@ -959,13 +959,13 @@ fn create_folder_when_it_does_not_exist(path string) {
 
 fn xdg_home_folder(ename string, lpath string) string {
 	xdg_folder := getenv(ename)
-	dir := if xdg_folder != '' {
+	xdg_dir := if xdg_folder != '' {
 		xdg_folder
 	} else {
 		join_path_single(home_dir(), lpath)
 	}
-	create_folder_when_it_does_not_exist(dir)
-	return dir
+	create_folder_when_it_does_not_exist(xdg_dir)
+	return xdg_dir
 }
 
 // cache_dir returns the path to a *writable* user-specific folder, suitable for writing non-essential data.

--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -293,13 +293,13 @@ pub fn ls(path string) ![]string {
 		return error('ls() expects a folder, not an empty string')
 	}
 	mut res := []string{cap: 50}
-	dir := unsafe { C.opendir(&char(path.str)) }
-	if isnil(dir) {
+	dir_ptr := unsafe { C.opendir(&char(path.str)) }
+	if isnil(dir_ptr) {
 		return error_posix(msg: 'ls() couldnt open dir "${path}"')
 	}
 	mut ent := &C.dirent(unsafe { nil })
 	for {
-		ent = C.readdir(dir)
+		ent = C.readdir(dir_ptr)
 		if isnil(ent) {
 			break
 		}
@@ -313,7 +313,7 @@ pub fn ls(path string) ![]string {
 			// vfmt on
 		}
 	}
-	C.closedir(dir)
+	C.closedir(dir_ptr)
 	return res
 }
 

--- a/vlib/time/time.v
+++ b/vlib/time/time.v
@@ -381,8 +381,8 @@ pub fn (t Time) week_of_year() int {
 	// 2. The ISO year is the calendar year of this Thursday.
 	// 3. Compute the week number as:
 	//    week_number = (thursday's day_of_year - 1) / 7 + 1
-	day_of_week := t.day_of_week()
-	days_to_thursday := 4 - day_of_week
+	dow := t.day_of_week()
+	days_to_thursday := 4 - dow
 	thursday_date := t.add_days(days_to_thursday)
 	thursday_day_of_year := thursday_date.year_day()
 	week_number := (thursday_day_of_year - 1) / 7 + 1

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -668,7 +668,7 @@ pub mut:
 }
 
 pub fn (f &FnDecl) new_method_with_receiver_type(new_type_ Type) FnDecl {
-	new_type := if f.params[0].typ.is_ptr() && !new_type_.is_ptr() {
+	recv_type := if f.params[0].typ.is_ptr() && !new_type_.is_ptr() {
 		new_type_.ref()
 	} else {
 		new_type_
@@ -678,10 +678,10 @@ pub fn (f &FnDecl) new_method_with_receiver_type(new_type_ Type) FnDecl {
 		new_method.params = f.params.clone()
 		for i in 1 .. new_method.params.len {
 			if new_method.params[i].typ == new_method.params[0].typ {
-				new_method.params[i].typ = new_type
+				new_method.params[i].typ = recv_type
 			}
 		}
-		new_method.params[0].typ = new_type
+		new_method.params[0].typ = recv_type
 		return *new_method
 	}
 }
@@ -776,7 +776,7 @@ pub fn (p &Param) specifier() string {
 }
 
 pub fn (f &Fn) new_method_with_receiver_type(new_type_ Type) Fn {
-	new_type := if f.params[0].typ.is_ptr() && !new_type_.is_ptr() {
+	recv_type := if f.params[0].typ.is_ptr() && !new_type_.is_ptr() {
 		new_type_.ref()
 	} else {
 		new_type_
@@ -786,7 +786,7 @@ pub fn (f &Fn) new_method_with_receiver_type(new_type_ Type) Fn {
 		new_method.params = f.params.clone()
 		for i in 1 .. new_method.params.len {
 			if new_method.params[i].typ == new_method.params[0].typ {
-				new_method.params[i].typ = new_type
+				new_method.params[i].typ = recv_type
 			}
 		}
 		new_method.from_embedded_type = if f.from_embedded_type != 0 {
@@ -794,7 +794,7 @@ pub fn (f &Fn) new_method_with_receiver_type(new_type_ Type) Fn {
 		} else {
 			f.params[0].typ
 		}
-		new_method.params[0].typ = new_type
+		new_method.params[0].typ = recv_type
 
 		return *new_method
 	}

--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -671,6 +671,12 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 							c.error('duplicate of an import symbol `${left.name}`', left.pos)
 						}
 						c.check_module_name_conflict(left.name, left.pos)
+						// Warn when a local variable shadows a function declaration (issue #22685)
+						mod_qualified := '${left.mod}.${left.name}'
+						if c.table.known_fn(mod_qualified) || c.table.known_fn(left.name) {
+							c.warn('variable `${left.name}` shadows a function declaration',
+								left.pos)
+						}
 					}
 					if node.op == .assign && left_type.has_flag(.option) && right is ast.UnsafeExpr
 						&& right.expr.is_nil() {

--- a/vlib/v/checker/tests/var_decl_shadows_fn.out
+++ b/vlib/v/checker/tests/var_decl_shadows_fn.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/var_decl_shadows_fn.vv:6:2: warning: variable `shadowed` shadows a function declaration
+    4 |
+    5 | fn main() {
+    6 |     shadowed := 5
+      |     ~~~~~~~~
+    7 |     println(shadowed)
+    8 |     _ = shadowed

--- a/vlib/v/checker/tests/var_decl_shadows_fn.vv
+++ b/vlib/v/checker/tests/var_decl_shadows_fn.vv
@@ -1,0 +1,9 @@
+pub fn shadowed() int {
+	return 42
+}
+
+fn main() {
+	shadowed := 5
+	println(shadowed)
+	_ = shadowed
+}

--- a/vlib/x/json2/decode.v
+++ b/vlib/x/json2/decode.v
@@ -84,15 +84,15 @@ mut:
 
 // push adds a new element to the linked list.
 fn (mut list LinkedList[T]) push(value T) {
-	new_node := &Node[T]{
+	node := &Node[T]{
 		value: value
 	}
 	if list.head == unsafe { nil } {
-		list.head = new_node
-		list.tail = new_node
+		list.head = node
+		list.tail = node
 	} else {
-		list.tail.next = new_node
-		list.tail = new_node
+		list.tail.next = node
+		list.tail = node
 	}
 	list.len++
 }


### PR DESCRIPTION
## Summary
- Emit a warning in `assign_stmt` when a newly declared local variable shares its name with an existing function (current module or builtin).
- Rename the few `vlib`/example sites that were silently shadowing functions so `-W` keeps passing.
- Add a checker test at `vlib/v/checker/tests/var_decl_shadows_fn.{vv,out}`.

Fixes #22685.

## Test plan
- [x] `./v vlib/v/checker/tests/var_decl_shadows_fn.vv` reproduces the expected warning.
- [ ] CI: full `v test-self` / `-W` builds green.