### PR TITLE
cgen: heap-wrap interface-to-pointer-interface `as` casts (fixes #25785)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -12627,12 +12627,19 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			g.as_cast_type_names[idx] = variant_sym.name
 		}
 	} else if expr_type_sym.kind == .interface && sym.kind == .interface {
+		is_ptr_target := node.typ.is_ptr()
+		if is_ptr_target {
+			g.write('HEAP(${sym.cname}, ')
+		}
 		g.write('I_${expr_type_sym.cname}_as_I_${sym.cname}(')
 		if node.expr_type.is_ptr() {
 			g.write('*')
 		}
 		g.expr(node.expr)
 		g.write(')')
+		if is_ptr_target {
+			g.write(')')
+		}
 
 		mut info := expr_type_sym.info as ast.Interface
 		right_info := sym.info as ast.Interface

--- a/vlib/v/tests/interfaces/interface_to_ptr_interface_as_cast_test.v
+++ b/vlib/v/tests/interfaces/interface_to_ptr_interface_as_cast_test.v
@@ -1,0 +1,46 @@
+// regression test for https://github.com/vlang/v/issues/25785
+// `iface as &OtherIface` must produce a valid pointer to the converted interface.
+
+pub interface Poolable {
+mut:
+	validate() !bool
+	close() !
+	reset() !
+}
+
+pub interface DbConn {
+mut:
+	query(q string) ![]string
+	close() !
+}
+
+pub struct PgConn {
+pub mut:
+	tag string
+}
+
+pub fn (mut c PgConn) query(q string) ![]string {
+	return [c.tag, q]
+}
+
+pub fn (mut c PgConn) close() ! {}
+
+pub fn (mut c PgConn) validate() !bool {
+	return true
+}
+
+pub fn (mut c PgConn) reset() ! {}
+
+fn take_ptr(p &Poolable) string {
+	mut conn := unsafe { p }
+	return if conn.validate() or { false } { 'ok' } else { 'bad' }
+}
+
+fn iface_to_ptr_iface(c DbConn) string {
+	return take_ptr(c as &Poolable)
+}
+
+fn test_iface_as_ptr_iface() {
+	c := DbConn(PgConn{ tag: 'pg' })
+	assert iface_to_ptr_iface(c) == 'ok'
+}


### PR DESCRIPTION
## Summary

Fixes #25785. Casting one interface to a pointer of another (`iface_a as &IfaceB`) emitted the conversion-function call directly where a pointer was expected, producing a C type mismatch like:

```
error: cannot convert 'struct pool__ConnectionPoolable' to 'struct pool__ConnectionPoolable *'
```

The `I_X_as_I_Y` conversion function returns the converted interface by value, so when the cast target is a pointer interface, the result is now wrapped in `HEAP(...)` so the caller receives a valid pointer to a heap-allocated copy.

## Test plan

- [x] Added `vlib/v/tests/interfaces/interface_to_ptr_interface_as_cast_test.v`
- [x] All 95 existing `vlib/v/tests/interfaces/` tests pass
- [x] All 48 `vlib/v/tests/sumtypes/` tests pass
- [x] `vlib/pool/connection_test.v` passes