### PR TITLE
gg: fix compiler error of ved on windows (adjust declaration of `struct C.RECT` from windef.h)

### DIFF
--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -57,6 +57,7 @@ $if macos {
 }
 
 $if windows {
+	@[typedef]
 	struct C.RECT {
 		left   i32
 		top    i32


### PR DESCRIPTION
compilation of ved on win64 fails with current (4ba2b1c8d70b0d9cd2cd80cf6dadd8dfb62d3009) master:

error:
```
cc: C://Users//jensj//AppData//Local//Temp//v_0//VED01K~1.C:21952: error: '{' expected (got "(")
```

code in transpiled C:
```
	#elif 1
	{
		voidptr hwnd = sokol__sapp__win32_get_hwnd();
		if (hwnd == ((void*)0)) {
			return;
		}
21949:		f32 scale = gg__dpi_scale();
21950:		int client_width = ((int)(((f32)(width)) * scale + ((f32)(0.5))));
21951:		int client_height = ((int)(((f32)(height)) * scale + ((f32)(0.5))));
21952:  	struct RECT _t2 = ((struct RECT){.left = 0,.top = 0,.right = ((i32)(client_width)),.bottom = ((i32)(client_height)),});
21953:		struct RECT rect = _t2;
```

the corresponding v code in [gg.c.v](https://github.com/vlang/v/blob/master/vlib/gg/gg.c.v#L681):

```
	} $else $if windows {
		hwnd := sapp.win32_get_hwnd()
		if hwnd == unsafe { nil } {
			return
		}
		scale := dpi_scale()
		client_width := int(f32(width) * scale + 0.5)
		client_height := int(f32(height) * scale + 0.5)
		mut rect := C.RECT{
			right:  i32(client_width)
			bottom: i32(client_height)
		}
```

**Analysis**: the RECT in windows is a typedef, but is used like a tag here, hence the compilation failure.

**Solution**: add `@[typedef]` to the v declaration

<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
