### PR TITLE
gen: avoid heap allocation for empty .attrs/.attributes/.args in $for (fix #27274)

### DIFF
--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -1293,8 +1293,8 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 			mlocation := util.cescaped_path(util.path_styled_for_error_messages(method.file))
 			g.writeln('\t${node.val_var}.location = _S("${mlocation}:${method.name_pos.line_nr + 1}:${method.name_pos.col}");')
 			if method.attrs.len == 0 {
-				g.writeln('\t${node.val_var}.attrs = builtin____new_array_with_default(0, 0, sizeof(string), 0);')
-				g.writeln('\t${node.val_var}.attributes = builtin____new_array_with_default(0, 0, sizeof(VAttribute), 0);')
+				g.writeln('\t${node.val_var}.attrs = ((array){.data = 0, .offset = 0, .len = 0, .cap = 0, .flags = 0, .element_size = sizeof(string)});')
+				g.writeln('\t${node.val_var}.attributes = ((array){.data = 0, .offset = 0, .len = 0, .cap = 0, .flags = 0, .element_size = sizeof(VAttribute)});')
 			} else {
 				attrs := cgen_attrs(method.attrs)
 				vattrs := cgen_vattrs(method.attrs)
@@ -1307,7 +1307,7 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 			}
 			if method.params.len < 2 {
 				// 0 or 1 (the receiver) args
-				g.writeln('\t${node.val_var}.args = builtin____new_array_with_default(0, 0, sizeof(FunctionParam), 0);')
+				g.writeln('\t${node.val_var}.args = ((array){.data = 0, .offset = 0, .len = 0, .cap = 0, .flags = 0, .element_size = sizeof(FunctionParam)});')
 			} else {
 				len := method.params.len - 1
 				g.write('\t${node.val_var}.args = builtin__new_array_from_c_array(${len}, ${len}, sizeof(FunctionParam), _MOV((FunctionParam[${len}]){')
@@ -1382,7 +1382,7 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 				g.writeln('/* field ${i} : ${field.name} */ {')
 				g.writeln('\t${node.val_var}.name = _S("${field.name}");')
 				if field.attrs.len == 0 {
-					g.writeln('\t${node.val_var}.attrs = builtin____new_array_with_default(0, 0, sizeof(string), 0);')
+					g.writeln('\t${node.val_var}.attrs = ((array){.data = 0, .offset = 0, .len = 0, .cap = 0, .flags = 0, .element_size = sizeof(string)});')
 				} else {
 					attrs := cgen_attrs(field.attrs)
 					g.writeln(
@@ -1449,7 +1449,7 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 					}
 					enum_attrs := sym.info.attrs[val]
 					if enum_attrs.len == 0 {
-						g.writeln('\t${node.val_var}.attrs = builtin____new_array_with_default(0, 0, sizeof(string), 0);')
+						g.writeln('\t${node.val_var}.attrs = ((array){.data = 0, .offset = 0, .len = 0, .cap = 0, .flags = 0, .element_size = sizeof(string)});')
 					} else {
 						attrs := cgen_attrs(enum_attrs)
 						g.writeln(


### PR DESCRIPTION
## Summary

Fixes #27274.

`$for field in T.fields` (and `$for method in T.methods`, `$for val in T.variants`) emitted `builtin____new_array_with_default(0, 0, sizeof(X), 0)` per field per iteration for empty `.attrs`/`.attributes`/`.args`. Each such call does a `calloc(0)`, runs 2 panic checks, and blocks the C compiler from eliminating the dead store.

Replaced the 5 call sites in `vlib/v/gen/c/comptime.v` with inline `array` C struct literals — no function call, no allocation, fully eliminable.

## Benchmark

Using the program in the issue (20-field struct, 5M iterations, no `-prod`):

| build  | ns/call | total   |
|--------|---------|---------|
| before | 614 ns  | 3071 ms |
| after  |  94 ns  |  473 ms |

~6.5x speedup on the loop body.

## Test plan

- [x] `v test vlib/v/tests/comptime/` — all 168 tests pass
- [x] Self-host: `v -o v_self cmd/v` succeeds
- [x] Verified generated C now emits `((array){.data = 0, .offset = 0, .len = 0, .cap = 0, .flags = 0, .element_size = sizeof(X)})` for the 5 sites