### PR TITLE
markused: keep structs used by __offsetof

### DIFF
--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -1518,7 +1518,9 @@ fn (mut w Walker) expr(node_ ast.Expr) {
 			w.uses_lock = true
 			w.stmts(node.stmts)
 		}
-		ast.OffsetOf {}
+		ast.OffsetOf {
+			w.mark_by_type(w.resolve_current_specialized_type(node.struct_type))
+		}
 		ast.OrExpr {
 			w.or_block(node)
 		}

--- a/vlib/v/tests/pointers/offsetof_test.v
+++ b/vlib/v/tests/pointers/offsetof_test.v
@@ -6,7 +6,19 @@ struct Cat {
 	age   int
 }
 
+struct OffsetInlineOnly {
+	a int
+	b int
+}
+
+struct OffsetConstOnly {
+	a int
+	b int
+}
+
 type Feline = Cat
+
+const offset_const_only_b = __offsetof(OffsetConstOnly, b)
 
 fn test_offsetof() {
 	cat := Cat{
@@ -19,6 +31,14 @@ fn test_offsetof() {
 		assert *(&string(&u8(&cat) + __offsetof(Cat, breed))) == 'Great Old One'
 		assert *(&int(&u8(&cat) + __offsetof(Cat, age))) == 2147483647
 	}
+}
+
+fn test_offsetof_inline_only_marks_struct_as_used() {
+	assert __offsetof(OffsetInlineOnly, b) == 4
+}
+
+fn test_offsetof_const_marks_struct_as_used() {
+	assert offset_const_only_b == 4
 }
 
 fn test_offsetof_struct_from_another_module() {

--- a/vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v
+++ b/vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v
@@ -36,6 +36,39 @@ fn test_skip_unused_prunes_unused_generic_fn_instantiations() {
 	assert !res.output.contains('VV_LOC Map_u8_int main__new_T_int(void)')
 }
 
+fn test_skip_unused_keeps_generic_offsetof_struct_instantiations() {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_issue_27283_generic_offsetof')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(tmp_dir, 'issue_27283_generic_offsetof.v')
+	binary_path := os.join_path(tmp_dir, 'issue_27283_generic_offsetof')
+	source := [
+		'module main',
+		'',
+		'struct Box[T] {',
+		'\ta int',
+		'\tb T',
+		'}',
+		'',
+		'fn off[T]() u32 {',
+		'\treturn __offsetof(Box[T], b)',
+		'}',
+		'',
+		'fn main() {',
+		'\tprintln(off[int]())',
+		'\tprintln(off[string]())',
+		'}',
+	].join('\n')
+	os.write_file(source_path, source) or { panic(err) }
+	res :=
+		os.execute('${os.quoted_path(vexe)} -skip-unused -o ${os.quoted_path(binary_path)} ${os.quoted_path(source_path)}')
+	if res.exit_code != 0 {
+		panic(res.output)
+	}
+}
+
 fn test_skip_unused_does_not_emit_impl_methods_for_interface_extensions() {
 	tmp_dir := os.join_path(os.vtmp_dir(), 'v_skip_unused_interface_extension_collision')
 	os.mkdir_all(tmp_dir) or { panic(err) }


### PR DESCRIPTION
## Summary

Fixes #27283.

`__offsetof(T, field)` now marks `T` as used during markused traversal. Without that, structs referenced only through `__offsetof` could be stripped from generated C, leaving generated code that referenced an undeclared C type.

The markused path now also resolves generic `__offsetof` struct types through the current concrete generic context, so `Box[int]`/`Box[string]` instantiations are kept correctly under `-skip-unused`.

This adds regression coverage for inline `__offsetof`, `const` initializers, and generic `__offsetof` use under `-skip-unused`.

## Validation

- `./vnew run /tmp/v-issue-27283.IKkJKR/inline.v`
- `./vnew run /tmp/v-issue-27283.IKkJKR/const_init.v`
- `./vnew -skip-unused run /tmp/v-issue-27283.IKkJKR/generic_offsetof.v`
- `./vnew -cc clang -silent test vlib/v/tests/pointers/offsetof_test.v`
- `VFLAGS='-cc clang' ./vnew -silent test vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v`
- `VFLAGS='-cc clang' ./vnew -silent vlib/v/compiler_errors_test.v`