### PR TITLE
fix bound interface method values

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7675,6 +7675,11 @@ fn (mut g Gen) gen_closure_fn(expr_styp string, m ast.Fn, name string) {
 	if rec_sym.info is ast.Interface && rec_sym.info.get_methods().contains(method_name) {
 		methods_struct_name := g.interface_methods_struct_name(receiver.typ)
 		sb.write_string('((${methods_struct_name}*)a0->_methods)->_method_${method_name}(')
+		sb.write_string('a0->_object')
+		for i in 1 .. m.params.len {
+			sb.write_string(', ')
+			sb.write_string('a${i}')
+		}
 	} else {
 		mut full_method_name := '${expr_styp}_${method_name}'
 		if !expr_styp.starts_with('builtin__') {
@@ -7690,12 +7695,12 @@ fn (mut g Gen) gen_closure_fn(expr_styp string, m ast.Fn, name string) {
 		if !receiver.typ.is_ptr() {
 			sb.write_string('*')
 		}
-	}
-	for i in 0 .. m.params.len {
-		if i != 0 {
-			sb.write_string(', ')
+		for i in 0 .. m.params.len {
+			if i != 0 {
+				sb.write_string(', ')
+			}
+			sb.write_string('a${i}')
 		}
-		sb.write_string('a${i}')
 	}
 	sb.writeln(');')
 	sb.writeln('}')

--- a/vlib/v/tests/interfaces/interface_bound_mut_method_value_issue_26986_test.v
+++ b/vlib/v/tests/interfaces/interface_bound_mut_method_value_issue_26986_test.v
@@ -1,0 +1,56 @@
+struct ProtoReader {
+	value string
+}
+
+fn (pr &ProtoReader) read() string {
+	return pr.value
+}
+
+struct Conn {
+	rd &ProtoReader
+}
+
+fn (c &Conn) with_proto_reader(f fn (rd &ProtoReader) !) ! {
+	f(c.rd)!
+}
+
+interface Cmder {
+mut:
+	read_reply(rd &ProtoReader) !
+}
+
+struct SomeCmd {
+mut:
+	value string
+}
+
+fn (mut sc SomeCmd) read_reply(rd &ProtoReader) ! {
+	sc.value = rd.read()
+}
+
+fn process_via_interface_pointer(mut cmd Cmder) ! {
+	c := &Conn{
+		rd: &ProtoReader{
+			value: 'from pointer'
+		}
+	}
+	mut cmd_ref := unsafe { &cmd }
+	c.with_proto_reader(cmd_ref.read_reply)!
+}
+
+fn process_via_interface_value(mut cmd Cmder) ! {
+	c := &Conn{
+		rd: &ProtoReader{
+			value: 'from value'
+		}
+	}
+	c.with_proto_reader(cmd.read_reply)!
+}
+
+fn test_bound_mut_interface_method_value_mutates_underlying_object() ! {
+	mut cmd := &SomeCmd{}
+	process_via_interface_pointer(mut cmd)!
+	assert cmd.value == 'from pointer'
+	process_via_interface_value(mut cmd)!
+	assert cmd.value == 'from value'
+}


### PR DESCRIPTION
## Summary
- Fix bound method values on interface receivers to dispatch with the wrapped object pointer instead of the interface wrapper.
- Add a regression test for #26986 covering both interface pointer and interface value method values mutating the underlying object.

Fixes #26986.

## Testing
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w vlib/v/gen/c/cgen.v vlib/v/tests/interfaces/interface_bound_mut_method_value_issue_26986_test.v`
- `./vnew -silent test vlib/v/tests/interfaces/interface_bound_mut_method_value_issue_26986_test.v`
- `./vnew -silent test vlib/v/tests/interfaces/`
- `./vnew -silent vlib/v/compiler_errors_test.v`

Also attempted:
- `./vnew -silent vlib/v/gen/c/coutput_test.v` - failed because this local worktree already has untracked `vlib/v/gen/c/testdata/comp_if_unknown.*` fixtures that are picked up by the test runner.
- `./vnew -silent test vlib/v/` - stopped after unrelated baseline/worktree failures in areas outside this change.