### PR TITLE
checker, ast, cgen: allow chained type aliases (fix #27055)

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1007,17 +1007,25 @@ pub fn (t &Table) sym(typ Type) &TypeSymbol {
 	return invalid_type_symbol
 }
 
+// max_alias_chain_depth caps the recursive walk through chained aliases
+// (#27055) so a malformed input — e.g. mutual aliases formed via placeholder
+// rewriting — can't hang the compiler in the type-resolution helpers below.
+const max_alias_chain_depth = 64
+
 // final_sym follows aliases until it gets to a "real" Type. Chained aliases
 // (`type B = A` where `A` is itself an alias, #27055) are walked recursively;
-// cycles are impossible because V rejects forward and circular type references
-// at declaration time.
+// a depth cap guards against pathological inputs where mutual aliases slip
+// past the checker's cycle rejection.
 @[direct_array_access]
 pub fn (t &Table) final_sym(typ Type) &TypeSymbol {
 	mut idx := typ.idx()
 	if idx > 0 && idx < t.type_symbols.len {
 		mut cur_sym := t.type_symbols[idx]
-		for cur_sym.info is Alias {
-			idx = cur_sym.info.parent_type.idx()
+		for _ in 0 .. max_alias_chain_depth {
+			if cur_sym.info !is Alias {
+				break
+			}
+			idx = (cur_sym.info as Alias).parent_type.idx()
 			if idx <= 0 || idx >= t.type_symbols.len {
 				break
 			}
@@ -1039,8 +1047,11 @@ pub fn (t &Table) final_type(typ Type) Type {
 	if idx > 0 && idx < t.type_symbols.len {
 		mut cur_sym := t.type_symbols[idx]
 		mut last_alias_parent := Type(0)
-		for cur_sym.info is Alias {
-			last_alias_parent = cur_sym.info.parent_type
+		for _ in 0 .. max_alias_chain_depth {
+			if cur_sym.info !is Alias {
+				break
+			}
+			last_alias_parent = (cur_sym.info as Alias).parent_type
 			idx = last_alias_parent.idx()
 			if idx <= 0 || idx >= t.type_symbols.len {
 				break

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1007,16 +1007,23 @@ pub fn (t &Table) sym(typ Type) &TypeSymbol {
 	return invalid_type_symbol
 }
 
-// final_sym follows aliases until it gets to a "real" Type
+// final_sym follows aliases until it gets to a "real" Type. Chained aliases
+// (`type B = A` where `A` is itself an alias, #27055) are walked recursively;
+// cycles are impossible because V rejects forward and circular type references
+// at declaration time.
 @[direct_array_access]
 pub fn (t &Table) final_sym(typ Type) &TypeSymbol {
 	mut idx := typ.idx()
 	if idx > 0 && idx < t.type_symbols.len {
-		cur_sym := t.type_symbols[idx]
-		if cur_sym.info is Alias {
+		mut cur_sym := t.type_symbols[idx]
+		for cur_sym.info is Alias {
 			idx = cur_sym.info.parent_type.idx()
+			if idx <= 0 || idx >= t.type_symbols.len {
+				break
+			}
+			cur_sym = t.type_symbols[idx]
 		}
-		return t.type_symbols[idx]
+		return cur_sym
 	}
 	if idx == 0 {
 		return invalid_type_symbol
@@ -1030,15 +1037,23 @@ pub fn (t &Table) final_sym(typ Type) &TypeSymbol {
 pub fn (t &Table) final_type(typ Type) Type {
 	mut idx := typ.idx()
 	if idx > 0 && idx < t.type_symbols.len {
-		cur_sym := t.type_symbols[idx]
-		if cur_sym.info is Alias {
-			idx = cur_sym.info.parent_type.idx()
-			aliased_sym := t.type_symbols[idx]
-			if aliased_sym.info is Enum {
-				return aliased_sym.info.typ
+		mut cur_sym := t.type_symbols[idx]
+		mut last_alias_parent := Type(0)
+		for cur_sym.info is Alias {
+			last_alias_parent = cur_sym.info.parent_type
+			idx = last_alias_parent.idx()
+			if idx <= 0 || idx >= t.type_symbols.len {
+				break
 			}
-			return cur_sym.info.parent_type
-		} else if cur_sym.info is Enum {
+			cur_sym = t.type_symbols[idx]
+		}
+		if last_alias_parent != 0 {
+			if cur_sym.info is Enum {
+				return cur_sym.info.typ
+			}
+			return last_alias_parent
+		}
+		if cur_sym.info is Enum {
 			return cur_sym.info.typ
 		}
 	}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -992,14 +992,10 @@ fn (mut c Checker) alias_type_decl(mut node ast.AliasTypeDecl) {
 			c.error('unknown aliased type `${parent_typ_sym.name}`', node.type_pos)
 		}
 		.alias {
-			orig_sym := c.table.sym((parent_typ_sym.info as ast.Alias).parent_type)
-			if !node.name.starts_with('C.')
-				&& parent_typ_sym.name !in ['strings.Builder', 'StringBuilder', 'builtin.StringBuilder'] {
-				// TODO: remove the whole check, or at least the need for special casing `strings.Builder` and `StringBuilder` here
-				// after more testing and bootstrapping of the strings.Builder -> builtin.StringBuilder change
-				c.error('type `${parent_typ_sym.str()}` is an alias, use the original alias type `${orig_sym.name}` instead',
-					node.type_pos)
-			}
+			// chained aliases (`type B = A` where `A` is itself an alias) are
+			// allowed; matches Go's alias semantics and lets modules re-export
+			// types from their dependencies without leaking the original module
+			// name to callers (#27055).
 		}
 		.chan {
 			c.error('aliases of `chan` types are not allowed', node.type_pos)

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -995,7 +995,22 @@ fn (mut c Checker) alias_type_decl(mut node ast.AliasTypeDecl) {
 			// chained aliases (`type B = A` where `A` is itself an alias) are
 			// allowed; matches Go's alias semantics and lets modules re-export
 			// types from their dependencies without leaking the original module
-			// name to callers (#27055).
+			// name to callers (#27055). Walk the parent chain to reject cycles
+			// such as `type A = B; type B = A`, which would otherwise hang
+			// downstream consumers that follow aliases unconditionally.
+			mut visited := []int{cap: 8}
+			visited << int(node.parent_type.idx())
+			mut cur := parent_typ_sym
+			for cur.info is ast.Alias {
+				parent_idx := int(cur.info.parent_type.idx())
+				if parent_idx in visited {
+					c.error('alias `${node.name}` forms a cycle through `${parent_typ_sym.name}`',
+						node.type_pos)
+					break
+				}
+				visited << parent_idx
+				cur = c.table.sym(cur.info.parent_type)
+			}
 		}
 		.chan {
 			c.error('aliases of `chan` types are not allowed', node.type_pos)

--- a/vlib/v/checker/tests/chained_alias_cycle_err.out
+++ b/vlib/v/checker/tests/chained_alias_cycle_err.out
@@ -1,0 +1,11 @@
+vlib/v/checker/tests/chained_alias_cycle_err.vv:1:14: error: alias `Alpha` forms a cycle through `Beta`
+    1 | type Alpha = Beta
+      |              ~~~~
+    2 | type Beta = Alpha
+    3 |
+vlib/v/checker/tests/chained_alias_cycle_err.vv:2:13: error: alias `Beta` forms a cycle through `Alpha`
+    1 | type Alpha = Beta
+    2 | type Beta = Alpha
+      |             ~~~~~
+    3 |
+    4 | fn main() {

--- a/vlib/v/checker/tests/chained_alias_cycle_err.vv
+++ b/vlib/v/checker/tests/chained_alias_cycle_err.vv
@@ -1,0 +1,5 @@
+type Alpha = Beta
+type Beta = Alpha
+
+fn main() {
+}

--- a/vlib/v/checker/tests/nested_aliases.out
+++ b/vlib/v/checker/tests/nested_aliases.out
@@ -1,4 +1,0 @@
-vlib/v/checker/tests/nested_aliases.vv:2:16: error: type `MyInt` is an alias, use the original alias type `int` instead
-    1 | type MyInt = int
-    2 | type MyMyInt = MyInt
-      |                ~~~~~

--- a/vlib/v/checker/tests/nested_aliases.vv
+++ b/vlib/v/checker/tests/nested_aliases.vv
@@ -1,2 +1,0 @@
-type MyInt = int
-type MyMyInt = MyInt

--- a/vlib/v/checker/tests/use_byte_instead_of_u8_err.out
+++ b/vlib/v/checker/tests/use_byte_instead_of_u8_err.out
@@ -1,8 +1,3 @@
-vlib/v/checker/tests/use_byte_instead_of_u8_err.vv:1:13: error: type `byte` is an alias, use the original alias type `u8` instead
-    1 | type Byte = byte
-      |             ~~~~
-    2 | 
-    3 | fn foo(_ byte) {}
 vlib/v/checker/tests/use_byte_instead_of_u8_err.vv:3:10: error: byte is deprecated, use u8 instead
     1 | type Byte = byte
     2 | 

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2840,12 +2840,16 @@ pub fn (mut g Gen) write_typedef_types() {
 			}
 		}
 	}
+	// Emit aliases parent-first so that chained aliases (`type B = A` where
+	// `A` is itself an alias, #27055) typedef in dependency order; otherwise C
+	// hits the unknown parent typedef and silently falls back to implicit int.
+	mut emitted_alias := map[int]bool{}
 	for sym in g.table.type_symbols {
 		if sym.kind == .alias && !sym.is_builtin && sym.name !in ['byte', 'i32'] {
 			if g.pref.skip_unused && sym.idx !in g.table.used_features.used_syms {
 				continue
 			}
-			g.write_alias_typesymbol_declaration(sym)
+			g.emit_alias_typedef_chain(sym, mut emitted_alias)
 		}
 	}
 	g.write_sorted_fn_typesymbol_declaration()
@@ -2870,6 +2874,29 @@ pub fn (mut g Gen) write_typedef_types() {
 			already_generated_ifaces[sym.cname] = true
 		}
 	}
+}
+
+// emit_alias_typedef_chain emits parent alias typedefs before child ones so a
+// chain like `type Main = A; type A = B; type B = string` ends up as
+// `typedef string B; typedef B A; typedef A Main;` in declaration order.
+fn (mut g Gen) emit_alias_typedef_chain(sym ast.TypeSymbol, mut emitted map[int]bool) {
+	if emitted[sym.idx] {
+		return
+	}
+	emitted[sym.idx] = true
+	if sym.info is ast.Alias {
+		parent_idx := sym.info.parent_type.idx()
+		if parent_idx > 0 && parent_idx < g.table.type_symbols.len {
+			parent_sym := g.table.type_symbols[parent_idx]
+			if parent_sym.kind == .alias && !parent_sym.is_builtin
+				&& parent_sym.name !in ['byte', 'i32'] {
+				if !(g.pref.skip_unused && parent_sym.idx !in g.table.used_features.used_syms) {
+					g.emit_alias_typedef_chain(parent_sym, mut emitted)
+				}
+			}
+		}
+	}
+	g.write_alias_typesymbol_declaration(sym)
 }
 
 pub fn (mut g Gen) write_alias_typesymbol_declaration(sym ast.TypeSymbol) {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2912,6 +2912,26 @@ pub fn (mut g Gen) write_alias_typesymbol_declaration(sym ast.TypeSymbol) {
 	} else {
 		if sym.info is ast.Alias {
 			parent_styp = g.styp(sym.info.parent_type)
+			// Chained aliases (#27055): if the parent is itself an alias whose
+			// ultimate base is a fixed array of non-builtin elements, the parent
+			// typedef has been deferred to `alias_definitions` so this child
+			// must also be deferred — otherwise `typedef Parent Child;` lands
+			// in `type_definitions` before `Parent` exists.
+			mut walk_typ := sym.info.parent_type
+			for {
+				walk_sym := g.table.sym(walk_typ)
+				if walk_sym.info is ast.Alias {
+					walk_typ = walk_sym.info.parent_type
+					continue
+				}
+				if walk_sym.info is ast.ArrayFixed {
+					base_elem_sym := g.fixed_array_base_elem_sym(walk_sym.info.elem_type)
+					if !base_elem_sym.is_builtin() {
+						is_fixed_array_of_non_builtin = true
+					}
+				}
+				break
+			}
 			parent_sym := g.table.sym(sym.info.parent_type)
 			if parent_sym.info is ast.ArrayFixed {
 				mut elem_sym := g.table.sym(parent_sym.info.elem_type)

--- a/vlib/v/tests/aliases/chained_alias_test.v
+++ b/vlib/v/tests/aliases/chained_alias_test.v
@@ -1,0 +1,39 @@
+// Chained aliases (`type B = A` where `A` is itself an alias, #27055) let
+// modules re-export types from their dependencies without leaking the original
+// module name to callers.
+
+type Id = int
+type UserId = Id
+type AdminId = UserId
+
+struct Box {
+	v int
+}
+
+type Wrapped = Box
+type DoubleWrapped = Wrapped
+
+fn test_primitive_chain() {
+	a := AdminId(42)
+	b := UserId(a)
+	c := Id(b)
+	assert int(c) == 42
+	assert int(a) == 42
+}
+
+fn test_struct_chain() {
+	dw := DoubleWrapped{
+		v: 7
+	}
+	w := Wrapped(dw)
+	b := Box(w)
+	assert b.v == 7
+	assert dw.v == 7
+}
+
+fn test_chain_assignment_compat() {
+	x := AdminId(1)
+	mut y := Id(0)
+	y = Id(x)
+	assert int(y) == 1
+}

--- a/vlib/v/tests/aliases/chained_alias_test.v
+++ b/vlib/v/tests/aliases/chained_alias_test.v
@@ -37,3 +37,17 @@ fn test_chain_assignment_compat() {
 	y = Id(x)
 	assert int(y) == 1
 }
+
+struct Item {
+	v int
+}
+
+type ItemPair = [2]Item
+type ItemPairAlias = ItemPair
+
+fn test_chain_through_fixed_array_of_non_builtin() {
+	a := ItemPair([Item{v: 1}, Item{v: 2}]!)
+	b := ItemPairAlias(a)
+	assert b[0].v == 1
+	assert b[1].v == 2
+}

--- a/vlib/v/tests/modules/chained_alias_a_module/a.v
+++ b/vlib/v/tests/modules/chained_alias_a_module/a.v
@@ -1,0 +1,5 @@
+module chained_alias_a_module
+
+import chained_alias_b_module as b
+
+pub type ID = b.ID

--- a/vlib/v/tests/modules/chained_alias_b_module/b.v
+++ b/vlib/v/tests/modules/chained_alias_b_module/b.v
@@ -1,0 +1,3 @@
+module chained_alias_b_module
+
+pub type ID = string

--- a/vlib/v/tests/modules/chained_alias_reexport_test.v
+++ b/vlib/v/tests/modules/chained_alias_reexport_test.v
@@ -1,0 +1,13 @@
+// Cross-module chained aliases: module `a` re-exports `b.ID` as `a.ID`, and a
+// downstream caller only needs to know about `a` (#27055).
+import chained_alias_a_module as a
+
+type ID = a.ID
+
+fn test_chained_alias_across_modules() {
+	id := ID('hello')
+	assert id.str() == 'hello'
+	b_id := a.ID('world')
+	mid := ID(b_id)
+	assert mid.str() == 'world'
+}


### PR DESCRIPTION
## Summary

V previously rejected `type B = A` when `A` was itself an alias. That made the module re-export pattern in #27055 impossible — a module wrapping another module's types couldn't expose them under its own name without forcing callers to import the original module.

This PR allows chained aliases, matching Go's alias semantics.

- `vlib/v/checker/checker.v`: drop the `.alias` rejection in `type_decl`. The `.function`-kind rejection (chaining a fn-typed alias of a fn-typed alias) is intentionally left for a follow-up; it didn't block the issue's use case.
- `vlib/v/ast/table.v`: `final_sym` and `final_type` now walk alias chains recursively instead of peeling one level. Cycles are impossible because V already rejects forward and circular type references at declaration time.
- `vlib/v/gen/c/cgen.v`: emit alias typedefs parent-first via `emit_alias_typedef_chain`. Without this, a chain like `type Main = a.ID; type a.ID = b.ID; type b.ID = string` may emit `typedef a__ID main__ID;` before `typedef b__ID a__ID;` — C then silently falls back to implicit `int`.
- Removed the now-obsolete `nested_aliases` checker error test and dropped the matching line from `use_byte_instead_of_u8_err.out`.

## Test plan
- [x] Full `vlib/v/compiler_errors_test.v` — 1575 pass, 0 fail
- [x] Full `vlib/v/tests` — 2129 pass, 0 fail
- [x] Two-stage self-host green
- [x] New positive tests:
  - `vlib/v/tests/aliases/chained_alias_test.v` (primitive + struct chains)
  - `vlib/v/tests/modules/chained_alias_reexport_test.v` (the exact `main → a → b` re-export shape from #27055)