### PR TITLE
builder: use bugs.vlang.io for C error reports

### DIFF
--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -5,7 +5,7 @@ import strings
 import v.pref
 import v.util.version
 
-const default_c_error_bug_report_url = 'https://vlang.io/bug-report'
+const default_c_error_bug_report_url = 'https://bugs.vlang.io/bug-report'
 const c_error_context_radius = 5
 const c_error_bug_report_max_body_bytes = 256 * 1024
 const c_error_bug_report_truncation_notice = '\n... report truncated before upload ...\n'

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -1,5 +1,15 @@
 module builder
 
+import os
+
+fn restore_c_error_bug_report_url_env(old_url ?string) {
+	if url := old_url {
+		os.setenv('V_C_ERROR_BUG_REPORT_URL', url, true)
+	} else {
+		os.unsetenv('V_C_ERROR_BUG_REPORT_URL')
+	}
+}
+
 fn test_c_error_location_for_generated_c_parses_gcc_output() {
 	loc := c_error_location_for_generated_c('/tmp/program.tmp.c:42:7: error: unknown type name',
 		'/tmp/program.tmp.c') or {
@@ -83,6 +93,15 @@ fn test_generated_c_line_for_source_location_prefers_non_empty_line() {
 
 fn test_c_error_bug_report_url_uses_override_without_trailing_slash() {
 	assert c_error_bug_report_url(' http://127.0.0.1:19090/bug-report/ ') == 'http://127.0.0.1:19090/bug-report'
+}
+
+fn test_c_error_bug_report_url_uses_bugs_domain_by_default() {
+	old_url := os.getenv_opt('V_C_ERROR_BUG_REPORT_URL')
+	os.unsetenv('V_C_ERROR_BUG_REPORT_URL')
+	defer {
+		restore_c_error_bug_report_url_env(old_url)
+	}
+	assert c_error_bug_report_url('') == 'https://bugs.vlang.io/bug-report'
 }
 
 fn test_bounded_c_error_bug_report_keeps_encoded_body_under_limit() {


### PR DESCRIPTION
## What changed

- Change the default automatic C compiler error report endpoint from `https://vlang.io/bug-report` to `https://bugs.vlang.io/bug-report`.
- Add a regression test for the default URL while preserving `-bug-report-url` / `V_C_ERROR_BUG_REPORT_URL` override behavior.

## Why

The bug report receiver has moved to `bugs.vlang.io`, so compiler-side automatic C error reports should use the new public endpoint by default.

## Validation

- `make`
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w vlib/v/builder/c_error_report.v vlib/v/builder/c_error_report_test.v`
- `./vnew test vlib/v/builder/c_error_report_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/` completed with 1 unrelated failure in `vlib/v/builder/builder_test.v`, where local tcc fallback warning text polluted exact stdout assertions.
- `VFLAGS='-cc clang' ./vnew -silent vlib/v/builder/builder_test.v` passed.