### PR TITLE
math.bits: optimizations, tweaks to doc comments

### DIFF
--- a/vlib/math/bits/bits.arm64.v
+++ b/vlib/math/bits/bits.arm64.v
@@ -53,3 +53,158 @@ pub fn mul_add_64(x u64, y u64, z u64) (u64, u64) {
 	// cross compile
 	return mul_add_64_default(x, y, z)
 }
+
+// leading_zeros_8 returns the number of leading zero bits in x; the result is 8 for x == 0.
+@[inline]
+pub fn leading_zeros_8(x u8) int {
+	if x == 0 {
+		return 8
+	}
+	mut n := u32(x)
+	asm arm64 {
+		clz n, n
+		; +r (n)
+	}
+	return int(n) - 24
+}
+
+// leading_zeros_16 returns the number of leading zero bits in x; the result is 16 for x == 0.
+@[inline]
+pub fn leading_zeros_16(x u16) int {
+	if x == 0 {
+		return 16
+	}
+	mut n := u32(x)
+	asm arm64 {
+		clz n, n
+		; +r (n)
+	}
+	return int(n) - 16
+}
+
+// leading_zeros_32 returns the number of leading zero bits in x; the result is 32 for x == 0.
+@[inline]
+pub fn leading_zeros_32(x u32) int {
+	if x == 0 {
+		return 32
+	}
+	mut n := x
+	asm arm64 {
+		clz n, n
+		; +r (n)
+	}
+	return int(n)
+}
+
+// leading_zeros_64 returns the number of leading zero bits in x; the result is 64 for x == 0.
+@[inline]
+pub fn leading_zeros_64(x u64) int {
+	if x == 0 {
+		return 64
+	}
+	mut n := x
+	asm arm64 {
+		clz n, n
+		; +r (n)
+	}
+	return int(n)
+}
+
+// trailing_zeros_8 returns the number of trailing zero bits in x; the result is 8 for x == 0.
+@[inline]
+pub fn trailing_zeros_8(x u8) int {
+	if x == 0 {
+		return 8
+	}
+	mut n := u32(x)
+	asm arm64 {
+		rbit n, n
+		clz n, n
+		; +r (n)
+	}
+	return int(n)
+}
+
+// trailing_zeros_16 returns the number of trailing zero bits in x; the result is 16 for x == 0.
+@[inline]
+pub fn trailing_zeros_16(x u16) int {
+	if x == 0 {
+		return 16
+	}
+	mut n := u32(x)
+	asm arm64 {
+		rbit n, n
+		clz n, n
+		; +r (n)
+	}
+	return int(n)
+}
+
+// trailing_zeros_32 returns the number of trailing zero bits in x; the result is 32 for x == 0.
+@[inline]
+pub fn trailing_zeros_32(x u32) int {
+	if x == 0 {
+		return 32
+	}
+	mut n := x
+	asm arm64 {
+		rbit n, n
+		clz n, n
+		; +r (n)
+	}
+	return int(n)
+}
+
+// trailing_zeros_64 returns the number of trailing zero bits in x; the result is 64 for x == 0.
+@[inline]
+pub fn trailing_zeros_64(x u64) int {
+	if x == 0 {
+		return 64
+	}
+	mut n := x
+	asm arm64 {
+		rbit n, n
+		clz n, n
+		; +r (n)
+	}
+	return int(n)
+}
+
+// reverse_bytes_16 returns the value of x with its bytes in reversed order.
+//
+// This function's execution time does not depend on the inputs.
+@[inline]
+pub fn reverse_bytes_16(x u16) u16 {
+	mut n := u32(x)
+	asm arm64 {
+		rev16 n, n
+		; +r (n)
+	}
+	return u16(n)
+}
+
+// reverse_bytes_32 returns the value of x with its bytes in reversed order.
+//
+// This function's execution time does not depend on the inputs.
+@[inline]
+pub fn reverse_bytes_32(x u32) u32 {
+	mut n := x
+	asm arm64 {
+		rev n, n
+		; +r (n)
+	}
+	return n
+}
+
+// reverse_bytes_64 returns the value of x with its bytes in reversed order.
+//
+// This function's execution time does not depend on the inputs.
+@[inline]
+pub fn reverse_bytes_64(x u64) u64 {
+	mut n := x
+	asm arm64 {
+		rev n, n
+		; +r (n)
+	}
+	return n
+}

--- a/vlib/math/bits/bits.arm64.v
+++ b/vlib/math/bits/bits.arm64.v
@@ -61,11 +61,14 @@ pub fn leading_zeros_8(x u8) int {
 		return 8
 	}
 	mut n := u32(x)
-	asm arm64 {
-		clz n, n
-		; +r (n)
+	$if arm64 && !tinyc {
+		asm arm64 {
+			clz n, n
+			; +r (n)
+		}
+		return int(n) - 24
 	}
-	return int(n) - 24
+	return int(leading_zeros_8_default(x))
 }
 
 // leading_zeros_16 returns the number of leading zero bits in x; the result is 16 for x == 0.
@@ -75,11 +78,14 @@ pub fn leading_zeros_16(x u16) int {
 		return 16
 	}
 	mut n := u32(x)
-	asm arm64 {
-		clz n, n
-		; +r (n)
+	$if arm64 && !tinyc {
+		asm arm64 {
+			clz n, n
+			; +r (n)
+		}
+		return int(n) - 16
 	}
-	return int(n) - 16
+	return int(leading_zeros_16_default(x))
 }
 
 // leading_zeros_32 returns the number of leading zero bits in x; the result is 32 for x == 0.
@@ -89,11 +95,14 @@ pub fn leading_zeros_32(x u32) int {
 		return 32
 	}
 	mut n := x
-	asm arm64 {
-		clz n, n
-		; +r (n)
+	$if arm64 && !tinyc {
+		asm arm64 {
+			clz n, n
+			; +r (n)
+		}
+		return int(n)
 	}
-	return int(n)
+	return int(leading_zeros_32_default(x))
 }
 
 // leading_zeros_64 returns the number of leading zero bits in x; the result is 64 for x == 0.
@@ -103,11 +112,14 @@ pub fn leading_zeros_64(x u64) int {
 		return 64
 	}
 	mut n := x
-	asm arm64 {
-		clz n, n
-		; +r (n)
+	$if arm64 && !tinyc {
+		asm arm64 {
+			clz n, n
+			; +r (n)
+		}
+		return int(n)
 	}
-	return int(n)
+	return int(leading_zeros_64_default(x))
 }
 
 // trailing_zeros_8 returns the number of trailing zero bits in x; the result is 8 for x == 0.
@@ -117,12 +129,15 @@ pub fn trailing_zeros_8(x u8) int {
 		return 8
 	}
 	mut n := u32(x)
-	asm arm64 {
-		rbit n, n
-		clz n, n
-		; +r (n)
+	$if arm64 && !tinyc {
+		asm arm64 {
+			rbit n, n
+			clz n, n
+			; +r (n)
+		}
+		return int(n)
 	}
-	return int(n)
+	return int(trailing_zeros_8_default(x))
 }
 
 // trailing_zeros_16 returns the number of trailing zero bits in x; the result is 16 for x == 0.
@@ -132,12 +147,15 @@ pub fn trailing_zeros_16(x u16) int {
 		return 16
 	}
 	mut n := u32(x)
-	asm arm64 {
-		rbit n, n
-		clz n, n
-		; +r (n)
+	$if arm64 && !tinyc {
+		asm arm64 {
+			rbit n, n
+			clz n, n
+			; +r (n)
+		}
+		return int(n)
 	}
-	return int(n)
+	return int(trailing_zeros_16_default(x))
 }
 
 // trailing_zeros_32 returns the number of trailing zero bits in x; the result is 32 for x == 0.
@@ -147,12 +165,15 @@ pub fn trailing_zeros_32(x u32) int {
 		return 32
 	}
 	mut n := x
-	asm arm64 {
-		rbit n, n
-		clz n, n
-		; +r (n)
+	$if arm64 && !tinyc {
+		asm arm64 {
+			rbit n, n
+			clz n, n
+			; +r (n)
+		}
+		return int(n)
 	}
-	return int(n)
+	return int(trailing_zeros_32_default(x))
 }
 
 // trailing_zeros_64 returns the number of trailing zero bits in x; the result is 64 for x == 0.
@@ -162,12 +183,15 @@ pub fn trailing_zeros_64(x u64) int {
 		return 64
 	}
 	mut n := x
-	asm arm64 {
-		rbit n, n
-		clz n, n
-		; +r (n)
+	$if arm64 && !tinyc {
+		asm arm64 {
+			rbit n, n
+			clz n, n
+			; +r (n)
+		}
+		return int(n)
 	}
-	return int(n)
+	return int(trailing_zeros_64_default(x))
 }
 
 // reverse_bytes_16 returns the value of x with its bytes in reversed order.
@@ -176,11 +200,14 @@ pub fn trailing_zeros_64(x u64) int {
 @[inline]
 pub fn reverse_bytes_16(x u16) u16 {
 	mut n := u32(x)
-	asm arm64 {
-		rev16 n, n
-		; +r (n)
+	$if arm64 && !tinyc {
+		asm arm64 {
+			rev16 n, n
+			; +r (n)
+		}
+		return u16(n)
 	}
-	return u16(n)
+	return reverse_bytes_16_default(x)
 }
 
 // reverse_bytes_32 returns the value of x with its bytes in reversed order.
@@ -189,11 +216,14 @@ pub fn reverse_bytes_16(x u16) u16 {
 @[inline]
 pub fn reverse_bytes_32(x u32) u32 {
 	mut n := x
-	asm arm64 {
-		rev n, n
-		; +r (n)
+	$if arm64 && !tinyc {
+		asm arm64 {
+			rev n, n
+			; +r (n)
+		}
+		return n
 	}
-	return n
+	return reverse_bytes_32_default(x)
 }
 
 // reverse_bytes_64 returns the value of x with its bytes in reversed order.
@@ -202,9 +232,12 @@ pub fn reverse_bytes_32(x u32) u32 {
 @[inline]
 pub fn reverse_bytes_64(x u64) u64 {
 	mut n := x
-	asm arm64 {
-		rev n, n
-		; +r (n)
+	$if arm64 && !tinyc {
+		asm arm64 {
+			rev n, n
+			; +r (n)
+		}
+		return n
 	}
-	return n
+	return reverse_bytes_64_default(x)
 }

--- a/vlib/math/bits/bits.c.v
+++ b/vlib/math/bits/bits.c.v
@@ -9,6 +9,7 @@ fn C.__lzcnt(x u32) i32
 fn C.__lzcnt64(x u64) i32
 
 // --- LeadingZeros ---
+
 // leading_zeros_8 returns the number of leading zero bits in x; the result is 8 for x == 0.
 @[inline]
 pub fn leading_zeros_8(x u8) int {
@@ -71,6 +72,7 @@ fn C._BitScanForward(pos &int, x u32) u8
 fn C._BitScanForward64(pos &int, x u64) u8
 
 // --- TrailingZeros ---
+
 // trailing_zeros_8 returns the number of trailing zero bits in x; the result is 8 for x == 0.
 @[inline]
 pub fn trailing_zeros_8(x u8) int {
@@ -139,8 +141,15 @@ fn C.__builtin_popcount(x u32) i32
 fn C.__builtin_popcountll(x u64) i32
 fn C.__popcnt(x u32) i32
 fn C.__popcnt64(x u64) i32
+fn C.__builtin_bswap16(x u16) u16
+fn C.__builtin_bswap32(x u32) u32
+fn C.__builtin_bswap64(x u64) u64
+fn C._byteswap_ushort(x u16) u16
+fn C._byteswap_ulong(x u32) u32
+fn C._byteswap_uint64(x u64) u64
 
 // --- OnesCount ---
+
 // ones_count_8 returns the number of one bits ("population count") in x.
 @[inline]
 pub fn ones_count_8(x u8) int {
@@ -183,4 +192,43 @@ pub fn ones_count_64(x u64) int {
 		return C.__builtin_popcountll(x)
 	}
 	return ones_count_64_default(x)
+}
+
+// reverse_bytes_16 returns the value of x with its bytes in reversed order.
+//
+// This function's execution time does not depend on the inputs.
+@[inline]
+pub fn reverse_bytes_16(x u16) u16 {
+	$if msvc {
+		return C._byteswap_ushort(x)
+	} $else $if !tinyc {
+		return C.__builtin_bswap16(x)
+	}
+	return reverse_bytes_16_default(x)
+}
+
+// reverse_bytes_32 returns the value of x with its bytes in reversed order.
+//
+// This function's execution time does not depend on the inputs.
+@[inline]
+pub fn reverse_bytes_32(x u32) u32 {
+	$if msvc {
+		return C._byteswap_ulong(x)
+	} $else $if !tinyc {
+		return C.__builtin_bswap32(x)
+	}
+	return reverse_bytes_32_default(x)
+}
+
+// reverse_bytes_64 returns the value of x with its bytes in reversed order.
+//
+// This function's execution time does not depend on the inputs.
+@[inline]
+pub fn reverse_bytes_64(x u64) u64 {
+	$if msvc {
+		return C._byteswap_uint64(x)
+	} $else $if !tinyc {
+		return C.__builtin_bswap64(x)
+	}
+	return reverse_bytes_64_default(x)
 }

--- a/vlib/math/bits/bits.v
+++ b/vlib/math/bits/bits.v
@@ -3,26 +3,8 @@
 // that can be found in the LICENSE file.
 module bits
 
-// See http://supertech.csail.mit.edu/papers/debruijn.pdf
-const de_bruijn32 = u32(0x077CB531)
-const de_bruijn32tab = [u8(0), 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8, 31, 27, 13,
-	23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9]!
-const de_bruijn64 = u64(0x03f79d71b4ca8b09)
-const de_bruijn64tab = [u8(0), 1, 56, 2, 57, 49, 28, 3, 61, 58, 42, 50, 38, 29, 17, 4, 62, 47,
-	59, 36, 45, 43, 51, 22, 53, 39, 33, 30, 24, 18, 12, 5, 63, 55, 48, 27, 60, 41, 37, 16, 46,
-	35, 44, 21, 52, 32, 23, 11, 54, 26, 40, 15, 34, 20, 31, 10, 25, 14, 19, 9, 13, 8, 7, 6]!
-
-const m0 = u64(0x5555555555555555) // 01010101 ...
-
-const m1 = u64(0x3333333333333333) // 00110011 ...
-
-const m2 = u64(0x0f0f0f0f0f0f0f0f) // 00001111 ...
-
-const m3 = u64(0x00ff00ff00ff00ff) // etc.
-
-const m4 = u64(0x0000ffff0000ffff)
-
 // --- LeadingZeros ---
+
 // leading_zeros_8 returns the number of leading zero bits in x; the result is 8 for x == 0.
 @[inline]
 pub fn leading_zeros_8(x u8) int {
@@ -68,6 +50,7 @@ fn leading_zeros_64_default(x u64) int {
 }
 
 // --- TrailingZeros ---
+
 // trailing_zeros_8 returns the number of trailing zero bits in x; the result is 8 for x == 0.
 @[inline]
 pub fn trailing_zeros_8(x u8) int {
@@ -85,13 +68,15 @@ pub fn trailing_zeros_16(x u16) int {
 	return trailing_zeros_16_default(x)
 }
 
-@[direct_array_access; ignore_overflow; inline]
+@[direct_array_access; inline]
 fn trailing_zeros_16_default(x u16) int {
 	if x == 0 {
 		return 16
 	}
-	// see comment in trailing_zeros_64
-	return int(de_bruijn32tab[u32(x & -x) * de_bruijn32 >> (32 - 5)])
+	if (x & u16(0xff)) == 0 {
+		return 8 + int(ntz_8_tab[x >> 8])
+	}
+	return int(ntz_8_tab[x & u16(0xff)])
 }
 
 // trailing_zeros_32 returns the number of trailing zero bits in x; the result is 32 for x == 0.
@@ -100,13 +85,15 @@ pub fn trailing_zeros_32(x u32) int {
 	return trailing_zeros_32_default(x)
 }
 
-@[direct_array_access; ignore_overflow; inline]
+@[direct_array_access; inline]
 fn trailing_zeros_32_default(x u32) int {
 	if x == 0 {
 		return 32
 	}
-	// see comment in trailing_zeros_64
-	return int(de_bruijn32tab[(x & -x) * de_bruijn32 >> (32 - 5)])
+	if (x & u32(0xffff)) == 0 {
+		return 16 + trailing_zeros_16_default(u16(x >> 16))
+	}
+	return trailing_zeros_16_default(u16(x))
 }
 
 // trailing_zeros_64 returns the number of trailing zero bits in x; the result is 64 for x == 0.
@@ -115,26 +102,20 @@ pub fn trailing_zeros_64(x u64) int {
 	return trailing_zeros_64_default(x)
 }
 
-@[direct_array_access; ignore_overflow; inline]
+@[direct_array_access; inline]
 fn trailing_zeros_64_default(x u64) int {
 	if x == 0 {
 		return 64
 	}
-	// If popcount is fast, replace code below with return popcount(^x & (x - 1)).
-	//
-	// x & -x leaves only the right-most bit set in the word. Let k be the
-	// index of that bit. Since only a single bit is set, the value is two
-	// to the power of k. Multiplying by a power of two is equivalent to
-	// left shifting, in this case by k bits. The de Bruijn (64 bit) constant
-	// is such that all six bit, consecutive substrings are distinct.
-	// Therefore, if we have a left shifted version of this constant we can
-	// find by how many bits it was shifted by looking at which six bit
-	// substring ended up at the top of the word.
-	// (Knuth, volume 4, section 7.3.1)
-	return int(de_bruijn64tab[int((x & -x) * de_bruijn64 >> (64 - 6))])
+	low := u32(x)
+	if low == 0 {
+		return 32 + trailing_zeros_32_default(u32(x >> 32))
+	}
+	return trailing_zeros_32_default(low)
 }
 
 // --- OnesCount ---
+
 // ones_count_8 returns the number of one bits ("population count") in x.
 @[inline]
 pub fn ones_count_8(x u8) int {
@@ -176,32 +157,7 @@ pub fn ones_count_64(x u64) int {
 }
 
 fn ones_count_64_default(x u64) int {
-	// Implementation: Parallel summing of adjacent bits.
-	// See "Hacker's Delight", Chap. 5: Counting Bits.
-	// The following pattern shows the general approach:
-	//
-	// x = x>>1&(m0&m) + x&(m0&m)
-	// x = x>>2&(m1&m) + x&(m1&m)
-	// x = x>>4&(m2&m) + x&(m2&m)
-	// x = x>>8&(m3&m) + x&(m3&m)
-	// x = x>>16&(m4&m) + x&(m4&m)
-	// x = x>>32&(m5&m) + x&(m5&m)
-	// return int(x)
-	//
-	// Masking (& operations) can be left away when there's no
-	// danger that a field's sum will carry over into the next
-	// field: Since the result cannot be > 64, 8 bits is enough
-	// and we can ignore the masks for the shifts by 8 and up.
-	// Per "Hacker's Delight", the first line can be simplified
-	// more, but it saves at best one instruction, so we leave
-	// it alone for clarity.
-	mut y := ((x >> u64(1)) & (m0 & max_u64)) + (x & (m0 & max_u64))
-	y = ((y >> u64(2)) & (m1 & max_u64)) + (y & (m1 & max_u64))
-	y = ((y >> 4) + y) & (m2 & max_u64)
-	y += y >> 8
-	y += y >> 16
-	y += y >> 32
-	return int(y) & ((1 << 7) - 1)
+	return ones_count_32_default(u32(x)) + ones_count_32_default(u32(x >> 32))
 }
 
 const n8 = u8(8)
@@ -210,6 +166,7 @@ const n32 = u32(32)
 const n64 = u64(64)
 
 // --- RotateLeft ---
+
 // rotate_left_8 returns the value of x rotated left by (k mod 8) bits.
 // To rotate x right by k bits, call rotate_left_8(x, -k).
 //
@@ -251,6 +208,7 @@ pub fn rotate_left_64(x u64, k int) u64 {
 }
 
 // --- Reverse ---
+
 // reverse_8 returns the value of x with its bits in reversed order.
 @[direct_array_access; inline]
 pub fn reverse_8(x u8) u8 {
@@ -263,30 +221,43 @@ pub fn reverse_16(x u16) u16 {
 	return u16(rev_8_tab[x >> 8]) | (u16(rev_8_tab[x & u16(0xff)]) << 8)
 }
 
+// vfmt off
+
 // reverse_32 returns the value of x with its bits in reversed order.
-@[inline]
+@[direct_array_access; inline]
 pub fn reverse_32(x u32) u32 {
-	mut y := (((x >> u32(1)) & (m0 & max_u32)) | ((x & (m0 & max_u32)) << 1))
-	y = (((y >> u32(2)) & (m1 & max_u32)) | ((y & (m1 & max_u32)) << u32(2)))
-	y = (((y >> u32(4)) & (m2 & max_u32)) | ((y & (m2 & max_u32)) << u32(4)))
-	return reverse_bytes_32(u32(y))
+	return (u32(rev_8_tab[u8(x)]) << 24) |
+		   (u32(rev_8_tab[u8(x >>  8)]) << 16) |
+		   (u32(rev_8_tab[u8(x >> 16)]) <<  8) |
+		    u32(rev_8_tab[u8(x >> 24)])
 }
 
 // reverse_64 returns the value of x with its bits in reversed order.
-@[inline]
+@[direct_array_access; inline]
 pub fn reverse_64(x u64) u64 {
-	mut y := (((x >> u64(1)) & (m0 & max_u64)) | ((x & (m0 & max_u64)) << 1))
-	y = (((y >> u64(2)) & (m1 & max_u64)) | ((y & (m1 & max_u64)) << 2))
-	y = (((y >> u64(4)) & (m2 & max_u64)) | ((y & (m2 & max_u64)) << 4))
-	return reverse_bytes_64(y)
+	return (u64(rev_8_tab[u8(x)]) << 56) |
+		   (u64(rev_8_tab[u8(x >>  8)]) << 48) |
+		   (u64(rev_8_tab[u8(x >> 16)]) << 40) |
+		   (u64(rev_8_tab[u8(x >> 24)]) << 32) |
+		   (u64(rev_8_tab[u8(x >> 32)]) << 24) |
+		   (u64(rev_8_tab[u8(x >> 40)]) << 16) |
+		   (u64(rev_8_tab[u8(x >> 48)]) <<  8) |
+		    u64(rev_8_tab[u8(x >> 56)])
 }
+// vfmt on
 
 // --- ReverseBytes ---
+
 // reverse_bytes_16 returns the value of x with its bytes in reversed order.
 //
 // This function's execution time does not depend on the inputs.
 @[inline]
 pub fn reverse_bytes_16(x u16) u16 {
+	return reverse_bytes_16_default(x)
+}
+
+@[inline]
+fn reverse_bytes_16_default(x u16) u16 {
 	return (x >> 8) | (x << 8)
 }
 
@@ -295,8 +266,12 @@ pub fn reverse_bytes_16(x u16) u16 {
 // This function's execution time does not depend on the inputs.
 @[inline]
 pub fn reverse_bytes_32(x u32) u32 {
-	y := (((x >> u32(8)) & (m3 & max_u32)) | ((x & (m3 & max_u32)) << u32(8)))
-	return u32((y >> 16) | (y << 16))
+	return reverse_bytes_32_default(x)
+}
+
+@[inline]
+fn reverse_bytes_32_default(x u32) u32 {
+	return (x >> 24) | ((x >> 8) & u32(0x0000_ff00)) | ((x << 8) & u32(0x00ff_0000)) | (x << 24)
 }
 
 // reverse_bytes_64 returns the value of x with its bytes in reversed order.
@@ -304,12 +279,16 @@ pub fn reverse_bytes_32(x u32) u32 {
 // This function's execution time does not depend on the inputs.
 @[inline]
 pub fn reverse_bytes_64(x u64) u64 {
-	mut y := (((x >> u64(8)) & (m3 & max_u64)) | ((x & (m3 & max_u64)) << u64(8)))
-	y = (((y >> u64(16)) & (m4 & max_u64)) | ((y & (m4 & max_u64)) << u64(16)))
-	return (y >> 32) | (y << 32)
+	return reverse_bytes_64_default(x)
+}
+
+@[inline]
+fn reverse_bytes_64_default(x u64) u64 {
+	return (x >> 56) | ((x >> 40) & u64(0x0000_0000_0000_ff00)) | ((x >> 24) & u64(0x0000_0000_00ff_0000)) | ((x >> 8) & u64(0x0000_0000_ff00_0000)) | ((x << 8) & u64(0x0000_00ff_0000_0000)) | ((x << 24) & u64(0x0000_ff00_0000_0000)) | ((x << 40) & u64(0x00ff_0000_0000_0000)) | (x << 56)
 }
 
 // --- Len ---
+
 // len_8 returns the minimum number of bits required to represent x; the result is 0 for x == 0.
 @[direct_array_access]
 pub fn len_8(x u8) int {
@@ -365,9 +344,7 @@ pub fn len_64(x u64) int {
 }
 
 // --- Add with carry ---
-// Add returns the sum with carry of x, y and carry: sum = x + y + carry.
-// The carry input must be 0 or 1; otherwise the behavior is undefined.
-// The carryOut output is guaranteed to be 0 or 1.
+
 // add_32 returns the sum with carry of x, y and carry: sum = x + y + carry.
 // The carry input must be 0 or 1; otherwise the behavior is undefined.
 // The carryOut output is guaranteed to be 0 or 1.
@@ -395,9 +372,7 @@ pub fn add_64(x u64, y u64, carry u64) (u64, u64) {
 }
 
 // --- Subtract with borrow ---
-// Sub returns the difference of x, y and borrow: diff = x - y - borrow.
-// The borrow input must be 0 or 1; otherwise the behavior is undefined.
-// The borrowOut output is guaranteed to be 0 or 1.
+
 // sub_32 returns the difference of x, y and borrow, diff = x - y - borrow.
 // The borrow input must be 0 or 1; otherwise the behavior is undefined.
 // The borrowOut output is guaranteed to be 0 or 1.
@@ -431,7 +406,7 @@ pub fn sub_64(x u64, y u64, borrow u64) (u64, u64) {
 pub const two32 = u64(0x100000000)
 const mask32 = two32 - 1
 const overflow_error = 'Overflow Error'
-const divide_error = 'Divide Error'
+// const divide_error = 'Divide Error'
 
 // mul_32 returns the 64-bit product of x and y: (hi, lo) = x * y
 // with the product bits' upper half returned in hi and the lower
@@ -509,6 +484,7 @@ fn mul_add_64_default(x u64, y u64, z u64) (u64, u64) {
 }
 
 // --- Full-width divide ---
+
 // div_32 returns the quotient and remainder of (hi, lo) divided by y:
 // quo = (hi, lo)/y, rem = (hi, lo)%y with the dividend bits' upper
 // half in parameter hi and the lower half in parameter lo.
@@ -544,6 +520,9 @@ fn div_64_default(hi u64, lo u64, y1 u64) (u64, u64) {
 	}
 	if y <= hi {
 		panic(overflow_error)
+	}
+	if hi == 0 {
+		return lo / y, lo % y
 	}
 	s := u32(leading_zeros_64(y))
 	y <<= s

--- a/vlib/math/bits/bits_test.v
+++ b/vlib/math/bits/bits_test.v
@@ -1,13 +1,11 @@
 //
 // test suite for bits and bits math functions
 //
-module bits
+module main
 
-fn C.system(s &char) int
-fn C.fopen(path &char, mode &char) voidptr
-fn C.fputs(s &char, f voidptr) int
-fn C.fclose(f voidptr) int
-fn C.remove(path &char) int
+import math
+import math.bits
+import os
 
 fn test_bits() {
 	mut i := 0
@@ -21,33 +19,33 @@ fn test_bits() {
 	i = 1
 	for x in 0 .. 8 {
 		// C.printf("x:%02x lz: %d cmp: %d\n", i << x, leading_zeros_8(i << x), 7-x)
-		assert leading_zeros_8(u8(u8(i) << x)) == 7 - x
+		assert bits.leading_zeros_8(u8(u8(i) << x)) == 7 - x
 	}
-	assert leading_zeros_8(0) == 8
+	assert bits.leading_zeros_8(0) == 8
 
 	// 16 bit
 	i = 1
 	for x in 0 .. 16 {
 		// C.printf("x:%04x lz: %d cmp: %d\n", u16(i) << x, leading_zeros_16(u16(i) << x), 15-x)
-		assert leading_zeros_16(u16(i) << x) == 15 - x
+		assert bits.leading_zeros_16(u16(i) << x) == 15 - x
 	}
-	assert leading_zeros_16(0) == 16
+	assert bits.leading_zeros_16(0) == 16
 
 	// 32 bit
 	i = 1
 	for x in 0 .. 32 {
 		// C.printf("x:%08x lz: %d cmp: %d\n", u32(i) << x, leading_zeros_32(u32(i) << x), 31-x)
-		assert leading_zeros_32(u32(i) << x) == 31 - x
+		assert bits.leading_zeros_32(u32(i) << x) == 31 - x
 	}
-	assert leading_zeros_32(0) == 32
+	assert bits.leading_zeros_32(0) == 32
 
 	// 64 bit
 	i = 1
 	for x in 0 .. 64 {
 		// C.printf("x:%016llx lz: %llu cmp: %d\n", u64(i) << x, leading_zeros_64(u64(i) << x), 63-x)
-		assert leading_zeros_64(u64(i) << x) == 63 - x
+		assert bits.leading_zeros_64(u64(i) << x) == 63 - x
 	}
-	assert leading_zeros_64(0) == 64
+	assert bits.leading_zeros_64(0) == 64
 
 	//
 	// --- TrailingZeros ---
@@ -56,30 +54,30 @@ fn test_bits() {
 	// 8 bit
 	i = 1
 	for x in 0 .. 8 {
-		assert trailing_zeros_8(u8(u8(i) << x)) == x
+		assert bits.trailing_zeros_8(u8(u8(i) << x)) == x
 	}
-	assert trailing_zeros_8(0) == 8
+	assert bits.trailing_zeros_8(0) == 8
 
 	// 16 bit
 	i = 1
 	for x in 0 .. 16 {
-		assert trailing_zeros_16(u16(i) << x) == x
+		assert bits.trailing_zeros_16(u16(i) << x) == x
 	}
-	assert trailing_zeros_16(0) == 16
+	assert bits.trailing_zeros_16(0) == 16
 
 	// 32 bit
 	i = 1
 	for x in 0 .. 32 {
-		assert trailing_zeros_32(u32(i) << x) == x
+		assert bits.trailing_zeros_32(u32(i) << x) == x
 	}
-	assert trailing_zeros_32(0) == 32
+	assert bits.trailing_zeros_32(0) == 32
 
 	// 64 bit
 	i = 1
 	for x in 0 .. 64 {
-		assert trailing_zeros_64(u64(i) << x) == x
+		assert bits.trailing_zeros_64(u64(i) << x) == x
 	}
-	assert trailing_zeros_64(0) == 64
+	assert bits.trailing_zeros_64(0) == 64
 
 	//
 	// --- ones_count ---
@@ -89,49 +87,49 @@ fn test_bits() {
 	i = 0
 	for x in 0 .. 9 {
 		// C.printf("x:%02x lz: %llu cmp: %d\n", u8(i), ones_count_8(u8(i)), x)
-		assert ones_count_8(u8(i)) == x
+		assert bits.ones_count_8(u8(i)) == x
 		i = int(u32(i) << 1) + 1
 	}
-	assert ones_count_8(0) == 0
-	assert ones_count_8(0xFF) == 8
+	assert bits.ones_count_8(0) == 0
+	assert bits.ones_count_8(0xFF) == 8
 
 	// 16 bit
 	i = 0
 	for x in 0 .. 17 {
 		// C.printf("x:%04x lz: %llu cmp: %d\n", u16(i), ones_count_16(u16(i)), x)
-		assert ones_count_16(u16(i)) == x
+		assert bits.ones_count_16(u16(i)) == x
 		i = int(u32(i) << 1) + 1
 	}
-	assert ones_count_16(0) == 0
-	assert ones_count_16(0xFFFF) == 16
+	assert bits.ones_count_16(0) == 0
+	assert bits.ones_count_16(0xFFFF) == 16
 
 	// 32 bit
 	i = 0
 	for x in 0 .. 33 {
 		// C.printf("x:%08x lz: %llu cmp: %d\n", u32(i), ones_count_32(u32(i)), x)
-		assert ones_count_32(u32(i)) == x
+		assert bits.ones_count_32(u32(i)) == x
 		i = int(u32(i) << 1) + 1
 	}
-	assert ones_count_32(0) == 0
-	assert ones_count_32(0xFFFF_FFFF) == 32
+	assert bits.ones_count_32(0) == 0
+	assert bits.ones_count_32(0xFFFF_FFFF) == 32
 
 	// 64 bit
 	i1 = 0
 	for x in 0 .. 65 {
 		// C.printf("x:%016llx lz: %llu cmp: %d\n", u64(i1), ones_count_64(u64(i1)), x)
-		assert ones_count_64(i1) == x
+		assert bits.ones_count_64(i1) == x
 		i1 = (i1 << 1) + 1
 	}
-	assert ones_count_64(0) == 0
-	assert ones_count_64(0xFFFF_FFFF_FFFF_FFFF) == 64
+	assert bits.ones_count_64(0) == 0
+	assert bits.ones_count_64(0xFFFF_FFFF_FFFF_FFFF) == 64
 
 	//
 	// --- rotate_left/right ---
 	//
-	assert rotate_left_8(0x12, 4) == 0x21
-	assert rotate_left_16(0x1234, 8) == 0x3412
-	assert rotate_left_32(0x12345678, 16) == 0x56781234
-	assert rotate_left_64(0x1234567887654321, 32) == 0x8765432112345678
+	assert bits.rotate_left_8(0x12, 4) == 0x21
+	assert bits.rotate_left_16(0x1234, 8) == 0x3412
+	assert bits.rotate_left_32(0x12345678, 16) == 0x56781234
+	assert bits.rotate_left_64(0x1234567887654321, 32) == 0x8765432112345678
 
 	//
 	// --- reverse ---
@@ -148,8 +146,7 @@ fn test_bits() {
 			bc++
 			n = n >> 1
 		}
-		// C.printf("x:%02x lz: %llu cmp: %d\n", u8(i), reverse_8(u8(i)), rv)
-		assert reverse_8(u8(i)) == rv
+		assert bits.reverse_8(u8(i)) == rv
 		i = int(u32(i) << 1) + 1
 	}
 
@@ -164,8 +161,7 @@ fn test_bits() {
 			bc++
 			n = n >> 1
 		}
-		// C.printf("x:%04x lz: %llu cmp: %d\n", u16(i), reverse_16(u16(i)), rv)
-		assert reverse_16(u16(i)) == rv
+		assert bits.reverse_16(u16(i)) == rv
 		i = int(u32(i) << 1) + 1
 	}
 
@@ -180,8 +176,7 @@ fn test_bits() {
 			bc++
 			n = n >> 1
 		}
-		// C.printf("x:%08x lz: %llu cmp: %d\n", u32(i), reverse_32(u32(i)), rv)
-		assert reverse_32(u32(i)) == rv
+		assert bits.reverse_32(u32(i)) == rv
 		i = int(u32(i) << 1) + 1
 	}
 
@@ -196,8 +191,7 @@ fn test_bits() {
 			bc++
 			n = n >> 1
 		}
-		// C.printf("x:%016llx lz: %016llx cmp: %016llx\n", u64(i1), reverse_64(u64(i1)), rv)
-		assert reverse_64(i1) == rv
+		assert bits.reverse_64(i1) == rv
 		i1 = (i1 << 1) + 1
 	}
 
@@ -205,9 +199,9 @@ fn test_bits() {
 	// --- reverse_bytes ---
 	//
 
-	assert reverse_bytes_16(0x1234) == 0x3412
-	assert reverse_bytes_32(0x12345678) == 0x78563412
-	assert reverse_bytes_64(0x1234567887654321) == 0x2143658778563412
+	assert bits.reverse_bytes_16(0x1234) == 0x3412
+	assert bits.reverse_bytes_32(0x12345678) == 0x78563412
+	assert bits.reverse_bytes_64(0x1234567887654321) == 0x2143658778563412
 
 	//
 	// --- add ---
@@ -217,15 +211,14 @@ fn test_bits() {
 	i = 1
 	for x in 0 .. 32 {
 		v := u32(i) << x
-		sum, carry := add_32(v, v, u32(0))
-		// C.printf("x:%08x [%llu,%llu] %llu\n", u32(i) << x, sum, carry, u64(v) + u64(v))
+		sum, carry := bits.add_32(v, v, u32(0))
 		assert ((u64(carry) << 32) | u64(sum)) == u64(v) + u64(v)
 	}
-	mut sum_32t, mut carry_32t := add_32(0x8000_0000, 0x8000_0000, u32(0))
+	mut sum_32t, mut carry_32t := bits.add_32(0x8000_0000, 0x8000_0000, u32(0))
 	assert sum_32t == u32(0)
 	assert carry_32t == u32(1)
 
-	sum_32t, carry_32t = add_32(0xFFFF_FFFF, 0xFFFF_FFFF, u32(1))
+	sum_32t, carry_32t = bits.add_32(0xFFFF_FFFF, 0xFFFF_FFFF, u32(1))
 	assert sum_32t == 0xFFFF_FFFF
 	assert carry_32t == u32(1)
 
@@ -233,15 +226,14 @@ fn test_bits() {
 	i = 1
 	for x in 0 .. 63 {
 		v := u64(i) << x
-		sum, carry := add_64(v, v, u64(0))
-		// C.printf("x:%16x [%llu,%llu] %llu\n", u64(i) << x, sum, carry, u64(v >> 32) + u64(v >> 32))
+		sum, carry := bits.add_64(v, v, u64(0))
 		assert ((carry << 32) | sum) == v + v
 	}
-	mut sum_64t, mut carry_64t := add_64(0x8000_0000_0000_0000, 0x8000_0000_0000_0000, u64(0))
+	mut sum_64t, mut carry_64t := bits.add_64(0x8000_0000_0000_0000, 0x8000_0000_0000_0000, u64(0))
 	assert sum_64t == u64(0)
 	assert carry_64t == u64(1)
 
-	sum_64t, carry_64t = add_64(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF, u64(1))
+	sum_64t, carry_64t = bits.add_64(0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF, u64(1))
 	assert sum_64t == 0xFFFF_FFFF_FFFF_FFFF
 	assert carry_64t == u64(1)
 
@@ -254,17 +246,14 @@ fn test_bits() {
 	for x in 1 .. 32 {
 		v0 := u32(i) << x
 		v1 := v0 >> 1
-		mut diff, mut borrow_out := sub_32(v0, v1, u32(0))
-		// C.printf("x:%08x [%llu,%llu] %08x\n", u32(i) << x, diff, borrow_out, v0 - v1)
+		mut diff, mut borrow_out := bits.sub_32(v0, v1, u32(0))
 		assert diff == v1
 
-		diff, borrow_out = sub_32(v0, v1, u32(1))
-		// C.printf("x:%08x [%llu,%llu] %08x\n", u32(i) << x, diff, borrow_out, v0 - v1)
+		diff, borrow_out = bits.sub_32(v0, v1, u32(1))
 		assert diff == (v1 - 1)
 		assert borrow_out == u32(0)
 
-		diff, borrow_out = sub_32(v1, v0, u32(1))
-		// C.printf("x:%08x [%llu,%llu] %08x\n", u32(i) << x, diff, borrow_out, v1 - v0)
+		diff, borrow_out = bits.sub_32(v1, v0, u32(1))
 		assert borrow_out == u32(1)
 	}
 
@@ -273,17 +262,14 @@ fn test_bits() {
 	for x in 1 .. 64 {
 		v0 := u64(i) << x
 		v1 := v0 >> 1
-		mut diff, mut borrow_out := sub_64(v0, v1, u64(0))
-		// C.printf("x:%08x [%llu,%llu] %08x\n", u64(i) << x, diff, borrow_out, v0 - v1)
+		mut diff, mut borrow_out := bits.sub_64(v0, v1, u64(0))
 		assert diff == v1
 
-		diff, borrow_out = sub_64(v0, v1, u64(1))
-		// C.printf("x:%08x [%llu,%llu] %08x\n", u64(i) << x, diff, borrow_out, v0 - v1)
+		diff, borrow_out = bits.sub_64(v0, v1, u64(1))
 		assert diff == (v1 - 1)
 		assert borrow_out == u64(0)
 
-		diff, borrow_out = sub_64(v1, v0, u64(1))
-		// C.printf("x:%08x [%llu,%llu] %08x\n",u64(i) << x, diff, borrow_out, v1 - v0)
+		diff, borrow_out = bits.sub_64(v1, v0, u64(1))
 		assert borrow_out == u64(1)
 	}
 
@@ -296,10 +282,10 @@ fn test_bits() {
 	for x in 0 .. 32 {
 		v0 := u32(i) << x
 		v1 := v0 - 1
-		hi, lo := mul_32(v0, v1)
+		hi, lo := bits.mul_32(v0, v1)
 		assert (u64(hi) << 32) | (u64(lo)) == u64(v0) * u64(v1)
 		v2 := u32(x)
-		h, l := mul_add_32(v0, v1, v2)
+		h, l := bits.mul_add_32(v0, v1, v2)
 		assert (u64(h) << 32) | (u64(l)) == u64(v0) * u64(v1) + u64(v2)
 	}
 
@@ -308,12 +294,11 @@ fn test_bits() {
 	for x in 0 .. 64 {
 		v0 := u64(i) << x
 		v1 := v0 - 1
-		hi, lo := mul_64(v0, v1)
-		// C.printf("v0: %llu v1: %llu [%llu,%llu] tt: %llu\n", v0, v1, hi, lo, (v0 >> 32) * (v1 >> 32))
+		hi, lo := bits.mul_64(v0, v1)
 		assert (hi & 0xFFFF_FFFF_0000_0000) == (((v0 >> 32) * (v1 >> 32)) & 0xFFFF_FFFF_0000_0000)
 		assert (lo & 0x0000_0000_FFFF_FFFF) == (((v0 & 0x0000_0000_FFFF_FFFF) * (v1 & 0x0000_0000_FFFF_FFFF)) & 0x0000_0000_FFFF_FFFF)
 		v2 := u64(x)
-		h, l := mul_add_64(v0, v1, v2)
+		h, l := bits.mul_add_64(v0, v1, v2)
 		assert (h & 0xFFFF_FFFF_0000_0000) == (((v0 >> 32) * (v1 >> 32)) & 0xFFFF_FFFF_0000_0000)
 		assert (l & 0x0000_0000_FFFF_FFFF) == ((
 			(v0 & 0x0000_0000_FFFF_FFFF) * (v1 & 0x0000_0000_FFFF_FFFF) + v2) & 0x0000_0000_FFFF_FFFF)
@@ -329,12 +314,11 @@ fn test_bits() {
 		hi := u32(i) << x
 		lo := hi - 1
 		y := u32(3) << x
-		quo, rem := div_32(hi, lo, y)
-		// C.printf("[%08x_%08x] %08x (%08x,%08x)\n", hi, lo, y, quo, rem)
+		quo, rem := bits.div_32(hi, lo, y)
 		tst := ((u64(hi) << 32) | u64(lo))
 		assert quo == (tst / u64(y))
 		assert rem == (tst % u64(y))
-		assert rem == rem_32(hi, lo, y)
+		assert rem == bits.rem_32(hi, lo, y)
 	}
 
 	// 64 bit
@@ -343,31 +327,30 @@ fn test_bits() {
 		hi := u64(i) << x
 		lo := u64(2) // hi - 1
 		y := u64(0x4000_0000_0000_0000)
-		quo, rem := div_64(hi, lo, y)
-		// C.printf("[%016llx_%016llx] %016llx (%016llx,%016llx)\n", hi, lo, y, quo, rem)
+		quo, rem := bits.div_64(hi, lo, y)
 		assert quo == u64(2) << (x + 1)
-		_, rem1 := div_64(hi % y, lo, y)
+		_, rem1 := bits.div_64(hi % y, lo, y)
 		assert rem == rem1
-		assert rem == rem_64(hi, lo, y)
+		assert rem == bits.rem_64(hi, lo, y)
 	}
 }
 
 fn test_div_64_edge_cases() {
-	qq, rr := div_64(10, 12, 11)
-	assert qq == 16769767339735956015
-	assert rr == 7
-	q, r := div_64(0, 23, 10000000000000000000)
+	mut q, mut r := bits.div_64(10, 12, 11)
+	assert q == 16769767339735956015
+	assert r == 7
+	q, r = bits.div_64(0, 23, 10000000000000000000)
 	assert q == 0
 	assert r == 23
 }
 
 fn test_float_bits_roundtrip() {
-	for bits in [u32(0), 0x8000_0000, 0x3f80_0000, 0x7f80_0000, 0x7fc0_0001] {
-		assert f32_bits(f32_from_bits(bits)) == bits
+	for u32_bits in [u32(0), 0x8000_0000, 0x3f80_0000, 0x7f80_0000, 0x7fc0_0001] {
+		assert math.f32_bits(math.f32_from_bits(u32_bits)) == u32_bits
 	}
-	for bits in [u64(0), 0x8000_0000_0000_0000, 0x3ff0_0000_0000_0000, 0x7ff0_0000_0000_0000,
+	for u64_bits in [u64(0), 0x8000_0000_0000_0000, 0x3ff0_0000_0000_0000, 0x7ff0_0000_0000_0000,
 		0x7ff8_0000_0000_0001] {
-		assert f64_bits(f64_from_bits(bits)) == bits
+		assert math.f64_bits(math.f64_from_bits(u64_bits)) == u64_bits
 	}
 }
 
@@ -379,14 +362,12 @@ fn test_div_panics() {
 }
 
 fn assert_program_panics(src string) {
-	path := '/tmp/bits_panic_test.v'
+	path := os.join_path_single(os.temp_dir(), 'bits_panic_test.v')
 	f := C.fopen(path.str, c'w')
 	C.fputs(src.str, f)
 	C.fclose(f)
-	defer {
-		C.remove(path.str)
-	}
 	cmd := '${@VEXE} run ${path}'
-	res := C.system(cmd.str)
+	res := unsafe { C.system(cmd.str) }
+	C.remove(path.str)
 	assert res != 0
 }

--- a/vlib/math/bits/bits_test.v
+++ b/vlib/math/bits/bits_test.v
@@ -3,6 +3,12 @@
 //
 module bits
 
+fn C.system(s &char) int
+fn C.fopen(path &char, mode &char) voidptr
+fn C.fputs(s &char, f voidptr) int
+fn C.fclose(f voidptr) int
+fn C.remove(path &char) int
+
 fn test_bits() {
 	mut i := 0
 	mut i1 := u64(0)
@@ -196,6 +202,14 @@ fn test_bits() {
 	}
 
 	//
+	// --- reverse_bytes ---
+	//
+
+	assert reverse_bytes_16(0x1234) == 0x3412
+	assert reverse_bytes_32(0x12345678) == 0x78563412
+	assert reverse_bytes_64(0x1234567887654321) == 0x2143658778563412
+
+	//
 	// --- add ---
 	//
 
@@ -345,4 +359,34 @@ fn test_div_64_edge_cases() {
 	q, r := div_64(0, 23, 10000000000000000000)
 	assert q == 0
 	assert r == 23
+}
+
+fn test_float_bits_roundtrip() {
+	for bits in [u32(0), 0x8000_0000, 0x3f80_0000, 0x7f80_0000, 0x7fc0_0001] {
+		assert f32_bits(f32_from_bits(bits)) == bits
+	}
+	for bits in [u64(0), 0x8000_0000_0000_0000, 0x3ff0_0000_0000_0000, 0x7ff0_0000_0000_0000,
+		0x7ff8_0000_0000_0001] {
+		assert f64_bits(f64_from_bits(bits)) == bits
+	}
+}
+
+fn test_div_panics() {
+	assert_program_panics('module main\nimport math.bits\nfn main() {\n\t_, _ := bits.div_32(0, 0, 0)\n}\n')
+	assert_program_panics('module main\nimport math.bits\nfn main() {\n\t_, _ := bits.div_32(1, 0, 1)\n}\n')
+	assert_program_panics('module main\nimport math.bits\nfn main() {\n\t_, _ := bits.div_64(0, 0, 0)\n}\n')
+	assert_program_panics('module main\nimport math.bits\nfn main() {\n\t_, _ := bits.div_64(1, 0, 1)\n}\n')
+}
+
+fn assert_program_panics(src string) {
+	path := '/tmp/bits_panic_test.v'
+	f := C.fopen(path.str, c'w')
+	C.fputs(src.str, f)
+	C.fclose(f)
+	defer {
+		C.remove(path.str)
+	}
+	cmd := '${@VEXE} run ${path}'
+	res := C.system(cmd.str)
+	assert res != 0
 }


### PR DESCRIPTION
* optimized `trailing_zeros_*` routines to use existing `ntz_8_tab` table
* switched from parallel-bit-summing to calling `ones_count_default`
* switched to direct byte-lane swaps in `reverse_bytes_*` routines
* added a fast path to `div_64_default` if `hi == 0`
* removed need for de Bruijn/popcount mask constants at top
* added `direct_array_access` attribute where table paths used