### PR TITLE
Skip C error bug reports in GitHub CI

### DIFF
--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -39,6 +39,9 @@ pub:
 }
 
 fn (mut v Builder) submit_c_error_bug_report(ccompiler string, c_output string) {
+	if !should_submit_c_error_bug_report(v.pref.c_error_bug_report_url) {
+		return
+	}
 	raw_report := v.new_c_error_bug_report(ccompiler, c_output)
 	report := bounded_c_error_bug_report(raw_report, c_error_bug_report_max_body_bytes)
 	report_url := c_error_bug_report_url(v.pref.c_error_bug_report_url)
@@ -103,6 +106,17 @@ fn c_error_bug_report_url(flag_url string) string {
 		return env_url.trim_right('/')
 	}
 	return default_c_error_bug_report_url
+}
+
+fn should_submit_c_error_bug_report(flag_url string) bool {
+	if running_in_github_ci() {
+		return c_error_bug_report_url(flag_url) != default_c_error_bug_report_url
+	}
+	return true
+}
+
+fn running_in_github_ci() bool {
+	return os.getenv('GITHUB_ACTIONS') == 'true' || os.getenv('GITHUB_JOB') != ''
 }
 
 fn send_c_error_bug_report(report CErrorBugReport, report_url string) !string {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -2,12 +2,16 @@ module builder
 
 import os
 
-fn restore_c_error_bug_report_url_env(old_url ?string) {
-	if url := old_url {
-		os.setenv('V_C_ERROR_BUG_REPORT_URL', url, true)
+fn restore_env_var(name string, old_value ?string) {
+	if value := old_value {
+		os.setenv(name, value, true)
 	} else {
-		os.unsetenv('V_C_ERROR_BUG_REPORT_URL')
+		os.unsetenv(name)
 	}
+}
+
+fn restore_c_error_bug_report_url_env(old_url ?string) {
+	restore_env_var('V_C_ERROR_BUG_REPORT_URL', old_url)
 }
 
 fn test_c_error_location_for_generated_c_parses_gcc_output() {
@@ -102,6 +106,50 @@ fn test_c_error_bug_report_url_uses_bugs_domain_by_default() {
 		restore_c_error_bug_report_url_env(old_url)
 	}
 	assert c_error_bug_report_url('') == 'https://bugs.vlang.io/bug-report'
+}
+
+fn test_should_submit_c_error_bug_report_allows_default_outside_github_ci() {
+	old_github_actions := os.getenv_opt('GITHUB_ACTIONS')
+	old_github_job := os.getenv_opt('GITHUB_JOB')
+	os.unsetenv('GITHUB_ACTIONS')
+	os.unsetenv('GITHUB_JOB')
+	defer {
+		restore_env_var('GITHUB_ACTIONS', old_github_actions)
+		restore_env_var('GITHUB_JOB', old_github_job)
+	}
+	assert should_submit_c_error_bug_report('')
+}
+
+fn test_should_submit_c_error_bug_report_skips_bugs_domain_in_github_ci() {
+	old_github_actions := os.getenv_opt('GITHUB_ACTIONS')
+	old_github_job := os.getenv_opt('GITHUB_JOB')
+	old_url := os.getenv_opt('V_C_ERROR_BUG_REPORT_URL')
+	os.setenv('GITHUB_ACTIONS', 'true', true)
+	os.unsetenv('GITHUB_JOB')
+	os.unsetenv('V_C_ERROR_BUG_REPORT_URL')
+	defer {
+		restore_env_var('GITHUB_ACTIONS', old_github_actions)
+		restore_env_var('GITHUB_JOB', old_github_job)
+		restore_c_error_bug_report_url_env(old_url)
+	}
+	assert !should_submit_c_error_bug_report('')
+	assert !should_submit_c_error_bug_report(' https://bugs.vlang.io/bug-report/ ')
+}
+
+fn test_should_submit_c_error_bug_report_uses_custom_url_in_github_ci() {
+	old_github_actions := os.getenv_opt('GITHUB_ACTIONS')
+	old_github_job := os.getenv_opt('GITHUB_JOB')
+	old_url := os.getenv_opt('V_C_ERROR_BUG_REPORT_URL')
+	os.unsetenv('GITHUB_ACTIONS')
+	os.setenv('GITHUB_JOB', 'test', true)
+	os.setenv('V_C_ERROR_BUG_REPORT_URL', 'http://127.0.0.1:19090/bug-report', true)
+	defer {
+		restore_env_var('GITHUB_ACTIONS', old_github_actions)
+		restore_env_var('GITHUB_JOB', old_github_job)
+		restore_c_error_bug_report_url_env(old_url)
+	}
+	assert should_submit_c_error_bug_report('')
+	assert should_submit_c_error_bug_report('http://127.0.0.1:19091/bug-report')
 }
 
 fn test_bounded_c_error_bug_report_keeps_encoded_body_under_limit() {

--- a/vlib/v/help/build/build-c.txt
+++ b/vlib/v/help/build/build-c.txt
@@ -324,6 +324,7 @@ see also `v help build`.
    -bug-report-url url
       Override where automatic C compiler bug reports are submitted.
       Useful with `v bug-report --host localhost --port 8080` for local testing.
+      Automatic reports to bugs.vlang.io are skipped when running in GitHub CI.
 
    -dump-c-flags file.txt
       Write all C flags into `file.txt`, one flag per line.


### PR DESCRIPTION
## Summary

- Skip automatic C compiler bug report submissions to `bugs.vlang.io` when V is running in GitHub CI.
- Keep explicit `-bug-report-url` and `V_C_ERROR_BUG_REPORT_URL` destinations usable, including local receiver testing.
- Document the GitHub CI exception in `v help build` output.

## Why

C compiler failures in GitHub Actions currently try to submit automatic reports to the public default endpoint. CI failures are already reported by the workflow logs, so sending those reports creates noisy duplicate submissions.

## Validation

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w vlib/v/builder/c_error_report.v vlib/v/builder/c_error_report_test.v`
- `./vnew -silent test vlib/v/builder/c_error_report_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `VFLAGS='-cc cc' ./vnew -silent test vlib/v/builder/base_url_test.v vlib/v/builder/builder_test.v vlib/v/builder/c_error_report_test.v vlib/v/builder/cbuilder/parallel_cc_test.v vlib/v/builder/cc_tcc_retry_test.v vlib/v/builder/cc_test.v vlib/v/builder/coroutines_runtime_test.v vlib/v/builder/gc_flags_test.v vlib/v/builder/icon_test.v vlib/v/builder/msvc_windows_test.v vlib/v/builder/parallel_cc_failure_test.v`
- `git diff --check`

Note: `./vnew -silent test vlib/v/` was attempted locally, but the current worktree contains pre-existing untracked `vlib/v/eval/` and `vlib/v/builder/interpreterbuilder/` tests that caused unrelated failures, so validation used the tracked builder tests instead.