### PR TITLE
Disable C error reports during tests

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -77,6 +77,8 @@ pub const separator = '-'.repeat(max_header_len) + '\n'
 
 pub const max_compilation_retries = get_max_compilation_retries()
 
+const c_error_bug_report_disabled_env = 'V_C_ERROR_BUG_REPORT_DISABLED'
+
 fn get_max_compilation_retries() int {
 	return os.getenv_opt('VTEST_MAX_COMPILATION_RETRIES') or { '3' }.int()
 }
@@ -301,6 +303,7 @@ pub fn (mut ts TestSession) system(cmd string, mtc MessageThreadContext) int {
 }
 
 pub fn new_test_session(_vargs string, will_compile bool) TestSession {
+	os.setenv(c_error_bug_report_disabled_env, '1', true)
 	mut skip_files := []string{}
 	vexe := pref.vexe_path()
 	vroot := os.dir(vexe)

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -6,6 +6,7 @@ import v.pref
 import v.util.version
 
 const default_c_error_bug_report_url = 'https://bugs.vlang.io/bug-report'
+const c_error_bug_report_disabled_env = 'V_C_ERROR_BUG_REPORT_DISABLED'
 const c_error_context_radius = 5
 const c_error_bug_report_max_body_bytes = 256 * 1024
 const c_error_bug_report_truncation_notice = '\n... report truncated before upload ...\n'
@@ -109,10 +110,22 @@ fn c_error_bug_report_url(flag_url string) string {
 }
 
 fn should_submit_c_error_bug_report(flag_url string) bool {
+	if c_error_bug_reports_disabled() {
+		return false
+	}
 	if running_in_github_ci() {
 		return c_error_bug_report_url(flag_url) != default_c_error_bug_report_url
 	}
 	return true
+}
+
+fn c_error_bug_reports_disabled() bool {
+	return os.getenv(c_error_bug_report_disabled_env).trim_space().to_lower() in ['1', 'true',
+		'yes', 'on']
+}
+
+fn disable_c_error_bug_reports() {
+	os.setenv(c_error_bug_report_disabled_env, '1', true)
 }
 
 fn running_in_github_ci() bool {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -14,6 +14,10 @@ fn restore_c_error_bug_report_url_env(old_url ?string) {
 	restore_env_var('V_C_ERROR_BUG_REPORT_URL', old_url)
 }
 
+fn restore_c_error_bug_report_disabled_env(old_value ?string) {
+	restore_env_var(c_error_bug_report_disabled_env, old_value)
+}
+
 fn test_c_error_location_for_generated_c_parses_gcc_output() {
 	loc := c_error_location_for_generated_c('/tmp/program.tmp.c:42:7: error: unknown type name',
 		'/tmp/program.tmp.c') or {
@@ -111,11 +115,14 @@ fn test_c_error_bug_report_url_uses_bugs_domain_by_default() {
 fn test_should_submit_c_error_bug_report_allows_default_outside_github_ci() {
 	old_github_actions := os.getenv_opt('GITHUB_ACTIONS')
 	old_github_job := os.getenv_opt('GITHUB_JOB')
+	old_disabled := os.getenv_opt(c_error_bug_report_disabled_env)
 	os.unsetenv('GITHUB_ACTIONS')
 	os.unsetenv('GITHUB_JOB')
+	os.unsetenv(c_error_bug_report_disabled_env)
 	defer {
 		restore_env_var('GITHUB_ACTIONS', old_github_actions)
 		restore_env_var('GITHUB_JOB', old_github_job)
+		restore_c_error_bug_report_disabled_env(old_disabled)
 	}
 	assert should_submit_c_error_bug_report('')
 }
@@ -124,13 +131,16 @@ fn test_should_submit_c_error_bug_report_skips_bugs_domain_in_github_ci() {
 	old_github_actions := os.getenv_opt('GITHUB_ACTIONS')
 	old_github_job := os.getenv_opt('GITHUB_JOB')
 	old_url := os.getenv_opt('V_C_ERROR_BUG_REPORT_URL')
+	old_disabled := os.getenv_opt(c_error_bug_report_disabled_env)
 	os.setenv('GITHUB_ACTIONS', 'true', true)
 	os.unsetenv('GITHUB_JOB')
 	os.unsetenv('V_C_ERROR_BUG_REPORT_URL')
+	os.unsetenv(c_error_bug_report_disabled_env)
 	defer {
 		restore_env_var('GITHUB_ACTIONS', old_github_actions)
 		restore_env_var('GITHUB_JOB', old_github_job)
 		restore_c_error_bug_report_url_env(old_url)
+		restore_c_error_bug_report_disabled_env(old_disabled)
 	}
 	assert !should_submit_c_error_bug_report('')
 	assert !should_submit_c_error_bug_report(' https://bugs.vlang.io/bug-report/ ')
@@ -140,16 +150,41 @@ fn test_should_submit_c_error_bug_report_uses_custom_url_in_github_ci() {
 	old_github_actions := os.getenv_opt('GITHUB_ACTIONS')
 	old_github_job := os.getenv_opt('GITHUB_JOB')
 	old_url := os.getenv_opt('V_C_ERROR_BUG_REPORT_URL')
+	old_disabled := os.getenv_opt(c_error_bug_report_disabled_env)
 	os.unsetenv('GITHUB_ACTIONS')
 	os.setenv('GITHUB_JOB', 'test', true)
 	os.setenv('V_C_ERROR_BUG_REPORT_URL', 'http://127.0.0.1:19090/bug-report', true)
+	os.unsetenv(c_error_bug_report_disabled_env)
 	defer {
 		restore_env_var('GITHUB_ACTIONS', old_github_actions)
 		restore_env_var('GITHUB_JOB', old_github_job)
 		restore_c_error_bug_report_url_env(old_url)
+		restore_c_error_bug_report_disabled_env(old_disabled)
 	}
 	assert should_submit_c_error_bug_report('')
 	assert should_submit_c_error_bug_report('http://127.0.0.1:19091/bug-report')
+}
+
+fn test_should_submit_c_error_bug_report_can_be_disabled_by_env() {
+	old_github_actions := os.getenv_opt('GITHUB_ACTIONS')
+	old_github_job := os.getenv_opt('GITHUB_JOB')
+	old_disabled := os.getenv_opt(c_error_bug_report_disabled_env)
+	os.unsetenv('GITHUB_ACTIONS')
+	os.unsetenv('GITHUB_JOB')
+	defer {
+		restore_env_var('GITHUB_ACTIONS', old_github_actions)
+		restore_env_var('GITHUB_JOB', old_github_job)
+		restore_c_error_bug_report_disabled_env(old_disabled)
+	}
+	for value in ['1', 'true', 'yes', 'on'] {
+		os.setenv(c_error_bug_report_disabled_env, value, true)
+		assert !should_submit_c_error_bug_report('')
+		assert !should_submit_c_error_bug_report('http://127.0.0.1:19090/bug-report')
+	}
+	os.setenv(c_error_bug_report_disabled_env, '0', true)
+	assert should_submit_c_error_bug_report('')
+	disable_c_error_bug_reports()
+	assert !should_submit_c_error_bug_report('')
 }
 
 fn test_bounded_c_error_bug_report_keeps_encoded_body_under_limit() {

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -16,6 +16,9 @@ pub fn should_find_windows_host_c_compiler(pref_ &pref.Preferences) bool {
 }
 
 pub fn compile(command string, pref_ &pref.Preferences, backend_cb FnBackend) {
+	if pref_.is_test {
+		disable_c_error_bug_reports()
+	}
 	check_if_input_file_exists(pref_)
 	check_if_output_folder_is_writable(pref_)
 	$if windows {

--- a/vlib/v/help/build/build-c.txt
+++ b/vlib/v/help/build/build-c.txt
@@ -325,6 +325,7 @@ see also `v help build`.
       Override where automatic C compiler bug reports are submitted.
       Useful with `v bug-report --host localhost --port 8080` for local testing.
       Automatic reports to bugs.vlang.io are skipped when running in GitHub CI.
+      Set V_C_ERROR_BUG_REPORT_DISABLED=1 to disable automatic report submission.
 
    -dump-c-flags file.txt
       Write all C flags into `file.txt`, one flag per line.


### PR DESCRIPTION
Fixes #27307.

## Summary
- Add `V_C_ERROR_BUG_REPORT_DISABLED=1` as an explicit guard for automatic C compiler report submission.
- Set the guard for direct `_test.v` compiles and for `v test` sessions so nested compiler invocations inherit it.
- Cover the disabled-report path in builder tests and document the env override in build help.

## Testing
- `make`
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w vlib/v/builder/c_error_report.v vlib/v/builder/compile.v vlib/v/builder/c_error_report_test.v cmd/tools/modules/testing/common.v`
- `./vnew -silent test vlib/v/builder/c_error_report_test.v`
- `./vnew -silent test cmd/tools/vtest_test.v`
- `V_C_ERROR_BUG_REPORT_URL=http://127.0.0.1:1/bug-report ./vnew -silent test vlib/v/tests/known_errors/known_errors_test.v`
- `V_C_ERROR_BUG_REPORT_URL=http://127.0.0.1:1/bug-report ./vnew vlib/v/tests/known_errors/known_errors_test.v`
- `V_C_ERROR_BUG_REPORT_URL=http://127.0.0.1:1/bug-report ./vnew -silent test vlib/v/generics/new_generics_regression_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `VFLAGS='-cc clang' ./vnew -silent test vlib/v/builder/builder_test.v`
- `./vnew -silent test vlib/v/` failed only in `vlib/v/builder/builder_test.v` because default tcc fallback warning text was included in exact stdout assertions; the same file passed with `VFLAGS='-cc clang'`.