### PR TITLE
builder: skip bug reports for missing C libraries

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -277,6 +277,13 @@ fn c_error_missing_library_name(c_output string) string {
 	return ''
 }
 
+fn c_error_should_send_bug_report(c_output string) bool {
+	if c_error_missing_libatomic_marker(c_output) != '' {
+		return false
+	}
+	return c_error_missing_library_name(c_output) == ''
+}
+
 fn (mut v Builder) show_c_compiler_output(ccompiler string, res os.Result) {
 	header := '======== Output of the C Compiler (${ccompiler}) ========'
 	println(header)
@@ -388,7 +395,9 @@ fn (mut v Builder) post_process_c_compiler_output_with_report(ccompiler string, 
 			}
 		}
 	}
-	v.submit_c_error_bug_report(report_ccompiler, report_res.output)
+	if c_error_should_send_bug_report(report_res.output) {
+		v.submit_c_error_bug_report(report_ccompiler, report_res.output)
+	}
 	if v.pref.is_quiet {
 		exit(1)
 	}

--- a/vlib/v/builder/cc_test.v
+++ b/vlib/v/builder/cc_test.v
@@ -736,6 +736,21 @@ fn test_c_error_missing_library_name_with_regular_c_error() {
 	assert c_error_missing_library_name(c_output) == ''
 }
 
+fn test_c_error_should_send_bug_report_skips_libatomic() {
+	c_output := '/usr/bin/ld: cannot find -latomic\ncollect2: error: ld returned 1 exit status\n'
+	assert !c_error_should_send_bug_report(c_output)
+}
+
+fn test_c_error_should_send_bug_report_skips_missing_library() {
+	c_output := '/usr/bin/ld: cannot find -lllvm\ncollect2: error: ld returned 1 exit status\n'
+	assert !c_error_should_send_bug_report(c_output)
+}
+
+fn test_c_error_should_send_bug_report_for_regular_c_error() {
+	c_output := "error: unknown type name 'my_missing_type'"
+	assert c_error_should_send_bug_report(c_output)
+}
+
 fn prepare_test_ccompiler_alias(test_root string, compiler_name string, version_output string) string {
 	os.rmdir_all(test_root) or {}
 	os.mkdir_all(test_root) or { panic(err) }


### PR DESCRIPTION
## Summary
- skip automatic C compiler bug report submission when the final C compiler output is a known missing link library or libatomic failure
- keep the existing local missing-library diagnostics unchanged
- add builder coverage for `-lllvm`, libatomic, and regular C errors

## Testing
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent test vlib/v/builder/cc_test.v`
- `./vnew -silent test vlib/v/builder/c_error_report_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- Attempted `./vnew -silent test vlib/v/`, but this checkout has pre-existing untracked `vlib/v/eval/` and `vlib/v/builder/interpreterbuilder/` tests that are discovered by the runner and fail with `use v -v2 -eval file.v`; stopped after confirming those unrelated failures.