### PR TITLE
ci: fix vfmt and http redirect failures

### DIFF
--- a/cmd/tools/vfmt.v
+++ b/cmd/tools/vfmt.v
@@ -81,6 +81,9 @@ fn main() {
 		eprintln('vfmt env_vflags_and_os_args: ' + args.str())
 		eprintln('vfmt possible_files: ' + possible_files.str())
 	}
+	if '-help' in args || '--help' in args {
+		help.print_and_exit('fmt')
+	}
 	files := util.find_all_v_files(possible_files) or {
 		verror(err.msg())
 		return
@@ -89,7 +92,7 @@ fn main() {
 		foptions.format_pipe()
 		exit(0)
 	}
-	if files.len == 0 || '-help' in args || '--help' in args {
+	if files.len == 0 {
 		help.print_and_exit('fmt')
 	}
 	mut cli_args_no_files := []string{}

--- a/vlib/net/http/http_test.v
+++ b/vlib/net/http/http_test.v
@@ -1,5 +1,6 @@
 import net
 import net.http
+import time
 
 fn test_https_get() {
 	$if !network ? {
@@ -69,11 +70,58 @@ fn test_https_public_servers() {
 	}
 }
 
+struct RelativeRedirectHandler {}
+
+fn (mut handler RelativeRedirectHandler) handle(req http.Request) http.Response {
+	mut res := http.Response{}
+	match req.url {
+		'/relative-redirect/3?abc=xyz' {
+			res.header = http.new_header(key: .location, value: '/relative-redirect/2?abc=xyz')
+			res.set_status(.found)
+		}
+		'/relative-redirect/2?abc=xyz' {
+			res.header = http.new_header(key: .location, value: '/relative-redirect/1?abc=xyz')
+			res.set_status(.found)
+		}
+		'/relative-redirect/1?abc=xyz' {
+			res.header = http.new_header(key: .location, value: '/get?abc=xyz')
+			res.set_status(.found)
+		}
+		'/get?abc=xyz' {
+			res.body = '{"args": {"abc": "xyz"}}'
+			res.set_status(.ok)
+		}
+		else {
+			res.body = req.url
+			res.set_status(.not_found)
+		}
+	}
+
+	res.set_version(req.version)
+	return res
+}
+
 fn test_relative_redirects() {
 	$if !network ? {
 		return
 	}
-	res := http.get('https://httpbin.org/relative-redirect/3?abc=xyz') or { panic(err) }
+	mut server := &http.Server{
+		accept_timeout:       100 * time.millisecond
+		handler:              RelativeRedirectHandler{}
+		addr:                 '127.0.0.1:0'
+		show_startup_message: false
+	}
+	t := spawn server.listen_and_serve()
+	server.wait_till_running() or {
+		server.stop()
+		t.wait()
+		panic(err)
+	}
+	defer {
+		server.stop()
+		t.wait()
+	}
+	res := http.get('http://${server.addr}/relative-redirect/3?abc=xyz') or { panic(err) }
 	assert res.status() == .ok
 	assert res.body != ''
 	assert res.body.contains('"abc": "xyz"')

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -161,8 +161,7 @@ pub fn (req &Request) cookie(name string) ?Cookie {
 
 // do will send the HTTP request and returns `http.Response` as soon as the response is received
 pub fn (req &Request) do() !Response {
-	mut url := urllib.parse(req.url) or { return error('http.Request.do: invalid url ${req.url}') }
-	mut rurl := url
+	mut rurl := urllib.parse(req.url) or { return error('http.Request.do: invalid url ${req.url}') }
 	mut resp := Response{}
 	mut method := req.method
 	mut data := req.data
@@ -184,17 +183,19 @@ pub fn (req &Request) do() !Response {
 		}
 		// follow any redirects
 		mut redirect_url := resp.header.get(.location) or { '' }
+		mut qrurl := urllib.URL{}
 		if redirect_url.len > 0 && redirect_url[0] == `/` {
-			url.set_path(redirect_url) or {
-				return error('http.request.do: invalid path in redirect: "${redirect_url}"')
+			qrurl = rurl.parse(redirect_url) or {
+				return error('http.request.do: invalid URL in redirect "${redirect_url}"')
 			}
-			redirect_url = url.str()
+			redirect_url = qrurl.str()
+		} else {
+			qrurl = urllib.parse(redirect_url) or {
+				return error('http.request.do: invalid URL in redirect "${redirect_url}"')
+			}
 		}
 		if req.on_redirect != unsafe { nil } {
 			req.on_redirect(req, nredirects, redirect_url)!
-		}
-		qrurl := urllib.parse(redirect_url) or {
-			return error('http.request.do: invalid URL in redirect "${redirect_url}"')
 		}
 		method, data, header = redirected_request_parts(method, status, data, header)
 		rurl = qrurl


### PR DESCRIPTION
## Summary
- make `v fmt -help` exit before stdin formatting so CI-provided stdin is not parsed as V source
- resolve slash-prefixed HTTP redirects through URL reference parsing so query strings are preserved
- replace the flaky external `httpbin.org` relative redirect test with a local fixture

## Testing
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w cmd/tools/vfmt.v vlib/net/http/http_test.v vlib/net/http/request.v`
- `./vnew -silent cmd/tools/vfmt_test.v`
- `./vnew -silent test vlib/net/http/`
- `./vnew -d network -silent vlib/net/http/http_test.v`
- `printf 'echo bad\n' | ./vnew fmt -help >/tmp/vfmt-help.out && head -n 3 /tmp/vfmt-help.out`