### PR TITLE
tools: store C error reports as SQLite columns

### DIFF
--- a/cmd/tools/modules/vbugreport/c_error_storage.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage.v
@@ -1,0 +1,42 @@
+module vbugreport
+
+import os
+
+pub struct StoredCErrorReport {
+pub:
+	c_file_name  string
+	target_os    string
+	ccompiler    string
+	error_string string
+}
+
+// new_stored_c_error_report builds the fields stored by the C error report receiver.
+pub fn new_stored_c_error_report(c_file string, target_os string, ccompiler string, c_error string) StoredCErrorReport {
+	return StoredCErrorReport{
+		c_file_name:  normalized_file_name(c_file)
+		target_os:    target_os
+		ccompiler:    ccompiler
+		error_string: c_error_string(c_error)
+	}
+}
+
+fn normalized_file_name(path string) string {
+	return os.file_name(path.replace('\\', '/'))
+}
+
+fn c_error_string(c_output string) string {
+	for line in c_output.split_into_lines() {
+		trimmed := line.trim_space()
+		lower := trimmed.to_lower_ascii()
+		if lower.starts_with('warning:') {
+			continue
+		}
+		if lower.starts_with('error:') {
+			return trimmed
+		}
+		if idx := lower.index('error:') {
+			return trimmed[idx..]
+		}
+	}
+	return ''
+}

--- a/cmd/tools/modules/vbugreport/c_error_storage.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage.v
@@ -31,12 +31,33 @@ fn c_error_string(c_output string) string {
 		if lower.starts_with('warning:') {
 			continue
 		}
-		if lower.starts_with('error:') {
-			return trimmed
-		}
-		if idx := lower.index('error:') {
-			return trimmed[idx..]
+		if error_string := normalized_error_string(trimmed, lower) {
+			return error_string
 		}
 	}
 	return ''
+}
+
+fn normalized_error_string(trimmed string, lower string) ?string {
+	if lower.starts_with('fatal error:') || lower.starts_with('fatal error ') {
+		return 'error: ${trimmed}'
+	}
+	if lower.starts_with('error:') {
+		return trimmed
+	}
+	if lower.starts_with('error ') {
+		return 'error: ${trimmed['error '.len..]}'
+	}
+	for needle in [' fatal error:', ' fatal error '] {
+		if idx := lower.index(needle) {
+			return 'error: ${trimmed[idx + 1..]}'
+		}
+	}
+	if idx := lower.index(' error:') {
+		return trimmed[idx + 1..]
+	}
+	if idx := lower.index(' error ') {
+		return 'error: ${trimmed[idx + ' error '.len..]}'
+	}
+	return none
 }

--- a/cmd/tools/modules/vbugreport/c_error_storage_test.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage_test.v
@@ -1,0 +1,25 @@
+module vbugreport
+
+fn test_new_stored_c_error_report_extracts_sql_fields() {
+	report := new_stored_c_error_report('/tmp/v/program.tmp.c', 'linux', 'clang',
+		'/tmp/v/program.tmp.c:12:7: error: unknown type name "Foo"')
+	assert report.c_file_name == 'program.tmp.c'
+	assert report.target_os == 'linux'
+	assert report.ccompiler == 'clang'
+	assert report.error_string == 'error: unknown type name "Foo"'
+}
+
+fn test_new_stored_c_error_report_handles_windows_c_file_path() {
+	report := new_stored_c_error_report('C:\\tmp\\program.tmp.c', 'windows', 'msvc',
+		'error: syntax error')
+	assert report.c_file_name == 'program.tmp.c'
+}
+
+fn test_c_error_string_skips_warning_lines() {
+	c_output := 'warning: unused command line argument\n  warning: note before error\nerror: invalid conversion'
+	assert c_error_string(c_output) == 'error: invalid conversion'
+}
+
+fn test_c_error_string_returns_empty_without_error_line() {
+	assert c_error_string('warning: unused command line argument\nnote: build stopped') == ''
+}

--- a/cmd/tools/modules/vbugreport/c_error_storage_test.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage_test.v
@@ -20,6 +20,16 @@ fn test_c_error_string_skips_warning_lines() {
 	assert c_error_string(c_output) == 'error: invalid conversion'
 }
 
+fn test_c_error_string_handles_msvc_error_codes() {
+	c_output := 'C:\\tmp\\program.tmp.c(19): error C2143: syntax error'
+	assert c_error_string(c_output) == 'error: C2143: syntax error'
+}
+
+fn test_c_error_string_preserves_fatal_error_diagnostics() {
+	c_output := '/tmp/program.tmp.c:7:1: fatal error: missing.h: No such file or directory'
+	assert c_error_string(c_output) == 'error: fatal error: missing.h: No such file or directory'
+}
+
 fn test_c_error_string_returns_empty_without_error_line() {
 	assert c_error_string('warning: unused command line argument\nnote: build stopped') == ''
 }

--- a/cmd/tools/vbug-report.v
+++ b/cmd/tools/vbug-report.v
@@ -6,6 +6,7 @@ import json
 import os
 import rand
 import time
+import vbugreport
 import veb
 
 const default_port = 8080
@@ -188,15 +189,18 @@ fn connect_db(db_path string) !sqlite.DB {
 
 fn init_db(db sqlite.DB) ! {
 	db.exec('create table if not exists bug_reports (
-		id text primary key,
-		delete_token text not null,
-		created_at text not null,
-		remote_ip text not null,
-		user_agent text not null,
-		report_json text not null
-	)')!
+			id text primary key,
+			delete_token text not null,
+			created_at text not null,
+			remote_ip text not null,
+			user_agent text not null,
+			c_file_name text not null,
+			target_os text not null,
+			ccompiler text not null,
+			error_string text not null
+		)')!
 	db.exec('create index if not exists idx_bug_reports_created_at
-		on bug_reports(created_at)')!
+			on bug_reports(created_at)')!
 }
 
 // create stores a compiler bug report and returns its deletion token.
@@ -215,17 +219,23 @@ pub fn (mut app App) create(mut ctx Context) veb.Result {
 	if report.kind != 'v-c-compiler-error' {
 		return ctx.request_error('unsupported report kind')
 	}
+	stored_report := vbugreport.new_stored_c_error_report(report.c_file, report.target_os,
+		report.ccompiler, report.c_error)
 	id := new_report_id()
 	delete_token := rand.uuid_v4()
 	app.db.exec_param_many('insert into bug_reports (
-			id, delete_token, created_at, remote_ip, user_agent, report_json
-		) values (?, ?, ?, ?, ?, ?)', [
+				id, delete_token, created_at, remote_ip, user_agent,
+				c_file_name, target_os, ccompiler, error_string
+			) values (?, ?, ?, ?, ?, ?, ?, ?, ?)', [
 		id,
 		delete_token,
 		time.utc().format_rfc3339(),
 		ctx.ip(),
 		ctx.user_agent(),
-		json.encode(report),
+		stored_report.c_file_name,
+		stored_report.target_os,
+		stored_report.ccompiler,
+		stored_report.error_string,
 	]) or { return ctx.server_error('could not store report') }
 	return ctx.json(CreateBugReportResponse{
 		id:           id


### PR DESCRIPTION
## Summary
- Store automatic C compiler bug reports in explicit SQLite columns instead of a `report_json` blob.
- Add a `vbugreport` helper for extracting `c_file_name`, `target_os`, `ccompiler`, and a canonical `error_string`.
- Skip diagnostic lines starting with `warning:` when selecting the stored error string.

## Testing
- `./vnew -silent test cmd/tools/modules/vbugreport/`
- `./vnew -o /tmp/vbug-report-test cmd/tools/vbug-report.v`
- Local receiver POST plus SQLite query confirmed the fresh DB schema and stored row values.