### PR TITLE
db.sqlite: link libm on linux

### DIFF
--- a/vlib/db/sqlite/sqlite.c.v
+++ b/vlib/db/sqlite/sqlite.c.v
@@ -22,6 +22,9 @@ $if $pkgconfig('sqlite3') {
 	#include "sqlite3.h" # The SQLite header file is missing. Please run vlib/db/sqlite/install_thirdparty_sqlite.vsh to download an SQLite amalgamation.
 	#flag @VEXEROOT/thirdparty/sqlite/sqlite3.c
 }
+$if linux {
+	#flag -lm
+}
 
 // https://www.sqlite.org/rescode.html
 pub const sqlite_ok = 0


### PR DESCRIPTION
## Summary

Adds a Linux `-lm` link flag for `db.sqlite` so programs that link against a static `libsqlite3.a` can resolve sqlite's math function references.

The bug report for `blog.01KT2GPD16YKGET92W1B9ZVANX.tmp.c` failed at link time with undefined references from `libsqlite3.a` to `log`, `pow`, `sqrt`, and related libm symbols.

## Validation

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent test vlib/db/sqlite/`
- `V_C_ERROR_BUG_REPORT_DISABLED=1 ./vnew -o /tmp/v_blog_check tutorials/building_a_simple_web_blog_with_veb/code/blog`