### PR TITLE
tools: store C error report context lines

### DIFF
--- a/cmd/tools/modules/vbugreport/c_error_storage.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage.v
@@ -8,15 +8,17 @@ pub:
 	target_os    string
 	ccompiler    string
 	error_string string
+	lines        string
 }
 
 // new_stored_c_error_report builds the fields stored by the C error report receiver.
-pub fn new_stored_c_error_report(c_file string, target_os string, ccompiler string, c_error string) StoredCErrorReport {
+pub fn new_stored_c_error_report(c_file string, target_os string, ccompiler string, c_error string, c_lines []string, v_lines []string) StoredCErrorReport {
 	return StoredCErrorReport{
 		c_file_name:  normalized_file_name(c_file)
 		target_os:    target_os
 		ccompiler:    ccompiler
 		error_string: c_error_string(c_error)
+		lines:        c_error_report_lines(c_lines, v_lines)
 	}
 }
 
@@ -36,6 +38,17 @@ fn c_error_string(c_output string) string {
 		}
 	}
 	return ''
+}
+
+fn c_error_report_lines(c_lines []string, v_lines []string) string {
+	mut lines := []string{cap: c_lines.len + v_lines.len}
+	for line in c_lines {
+		lines << line
+	}
+	for line in v_lines {
+		lines << line
+	}
+	return lines.join('\n')
 }
 
 fn normalized_error_string(trimmed string, lower string) ?string {

--- a/cmd/tools/modules/vbugreport/c_error_storage_test.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage_test.v
@@ -2,16 +2,22 @@ module vbugreport
 
 fn test_new_stored_c_error_report_extracts_sql_fields() {
 	report := new_stored_c_error_report('/tmp/v/program.tmp.c', 'linux', 'clang',
-		'/tmp/v/program.tmp.c:12:7: error: unknown type name "Foo"')
+		'/tmp/v/program.tmp.c:12:7: error: unknown type name "Foo"', [
+		'void main__main(void) {',
+		'\tFoo x;',
+	], [
+		'foo := Foo{}',
+	])
 	assert report.c_file_name == 'program.tmp.c'
 	assert report.target_os == 'linux'
 	assert report.ccompiler == 'clang'
 	assert report.error_string == 'error: unknown type name "Foo"'
+	assert report.lines == 'void main__main(void) {\n\tFoo x;\nfoo := Foo{}'
 }
 
 fn test_new_stored_c_error_report_handles_windows_c_file_path() {
 	report := new_stored_c_error_report('C:\\tmp\\program.tmp.c', 'windows', 'msvc',
-		'error: syntax error')
+		'error: syntax error', []string{}, []string{})
 	assert report.c_file_name == 'program.tmp.c'
 }
 

--- a/cmd/tools/vbug-report.v
+++ b/cmd/tools/vbug-report.v
@@ -193,12 +193,13 @@ fn init_db(db sqlite.DB) ! {
 			delete_token text not null,
 			created_at text not null,
 			remote_ip text not null,
-			user_agent text not null,
-			c_file_name text not null,
-			target_os text not null,
-			ccompiler text not null,
-			error_string text not null
-		)')!
+				user_agent text not null,
+				c_file_name text not null,
+				target_os text not null,
+				ccompiler text not null,
+				error_string text not null,
+				lines text not null
+			)')!
 	db.exec('create index if not exists idx_bug_reports_created_at
 			on bug_reports(created_at)')!
 }
@@ -220,13 +221,14 @@ pub fn (mut app App) create(mut ctx Context) veb.Result {
 		return ctx.request_error('unsupported report kind')
 	}
 	stored_report := vbugreport.new_stored_c_error_report(report.c_file, report.target_os,
-		report.ccompiler, report.c_error)
+		report.ccompiler, report.c_error, report.c_context.map(it.text),
+		report.v_context.map(it.text))
 	id := new_report_id()
 	delete_token := rand.uuid_v4()
 	app.db.exec_param_many('insert into bug_reports (
 				id, delete_token, created_at, remote_ip, user_agent,
-				c_file_name, target_os, ccompiler, error_string
-			) values (?, ?, ?, ?, ?, ?, ?, ?, ?)', [
+				c_file_name, target_os, ccompiler, error_string, lines
+			) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', [
 		id,
 		delete_token,
 		time.utc().format_rfc3339(),
@@ -236,6 +238,7 @@ pub fn (mut app App) create(mut ctx Context) veb.Result {
 		stored_report.target_os,
 		stored_report.ccompiler,
 		stored_report.error_string,
+		stored_report.lines,
 	]) or { return ctx.server_error('could not store report') }
 	return ctx.json(CreateBugReportResponse{
 		id:           id


### PR DESCRIPTION
## Summary
- Add a `lines` SQLite column to the C compiler bug report receiver.
- Populate `lines` from uploaded generated C context lines followed by V source context lines, joined with `\n`.
- Keep `error_string` unchanged so it remains a compact diagnostic summary.

Follow-up to #27322 after the original PR was merged.

## Testing
- `./vnew -silent test cmd/tools/modules/vbugreport/`
- `./vnew -o /tmp/vbug-report-test cmd/tools/vbug-report.v`
- Local receiver POST plus SQLite query confirmed the fresh DB has `lines` and stores C/V context lines separated by newlines.