### PR TITLE
checker: fix cgen 'pointer expected' for loop-local var passed to variadic interface arg

### DIFF
--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -112,6 +112,35 @@ pub fn (s &Scope) find_var(name string) ?&Var {
 	return none
 }
 
+// find_var_decl returns the nearest declaration variable named `name`, walking
+// the parent scope chain and skipping synthetic smartcast vars (introduced by
+// `if x is T`/`match` branches, which carry a non-empty `smartcasts` list and
+// are copies of the real declaration). Use this when a promotion such as
+// auto-heap must be recorded on the variable that codegen emits as the
+// declaration, not on a smartcast copy living in an inner branch scope.
+pub fn (s &Scope) find_var_decl(name string) ?&Var {
+	if _unlikely_(s == unsafe { nil }) {
+		return none
+	}
+	for sc := unsafe { s }; true; sc = sc.parent {
+		pobj := unsafe { &sc.objects[name] or { nil } }
+		if pobj != unsafe { nil } {
+			match pobj {
+				Var {
+					if pobj.smartcasts.len == 0 {
+						return &pobj
+					}
+				}
+				else {}
+			}
+		}
+		if sc.dont_lookup_parent() {
+			break
+		}
+	}
+	return none
+}
+
 pub fn (s &Scope) find_global(name string) ?&GlobalField {
 	obj := s.find_ptr(name)
 	if _likely_(obj != unsafe { nil }) {

--- a/vlib/v/ast/scope.v
+++ b/vlib/v/ast/scope.v
@@ -113,11 +113,17 @@ pub fn (s &Scope) find_var(name string) ?&Var {
 }
 
 // find_var_decl returns the nearest declaration variable named `name`, walking
-// the parent scope chain and skipping synthetic smartcast vars (introduced by
-// `if x is T`/`match` branches, which carry a non-empty `smartcasts` list and
-// are copies of the real declaration). Use this when a promotion such as
-// auto-heap must be recorded on the variable that codegen emits as the
-// declaration, not on a smartcast copy living in an inner branch scope.
+// the parent scope chain and skipping synthetic smartcast vars introduced by
+// `if x is T`/`match` branches. Use this when a promotion such as auto-heap must
+// be recorded on the variable that codegen emits as the declaration, not on a
+// smartcast copy living in an inner branch scope.
+//
+// Only true synthetic copies are skipped: those are registered as separate
+// scope objects carrying both a non-empty `smartcasts` list and a non-zero
+// `orig_type` (the pre-smartcast type). A real declaration that is smartcast in
+// place keeps `orig_type == 0` (e.g. an option var unwrapped by
+// `if x == none { continue }` via `update_smartcasts`), so it is returned
+// rather than skipped.
 pub fn (s &Scope) find_var_decl(name string) ?&Var {
 	if _unlikely_(s == unsafe { nil }) {
 		return none
@@ -127,7 +133,7 @@ pub fn (s &Scope) find_var_decl(name string) ?&Var {
 		if pobj != unsafe { nil } {
 			match pobj {
 				Var {
-					if pobj.smartcasts.len == 0 {
+					if pobj.smartcasts.len == 0 || pobj.orig_type == 0 {
 						return &pobj
 					}
 				}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7646,13 +7646,21 @@ fn (mut c Checker) mark_as_referenced(mut node ast.Expr, as_interface bool) {
 				// use-site scope chain, since `c.fn_scope.find_var` only locates
 				// variables declared at the function level and misses those
 				// declared in nested scopes (e.g. inside a `for` loop body).
-				obj = node.scope.find_var(node.obj.name) or {
-					if c.fn_scope != unsafe { nil } {
+				mut resolved := node.scope.find_var(node.obj.name) or { obj }
+				if resolved.smartcasts.len != 0 {
+					// `node.scope.find_var` resolved a synthetic smartcast var
+					// from an `if x is T`/`match` branch rather than the real
+					// declaration. Such vars have no declaration of their own, so
+					// promoting them would set `is_auto_heap` on the smartcast var
+					// while the actual declaration stays a plain value, desyncing
+					// the pointer indirection. Fall back to the function scope.
+					resolved = if c.fn_scope != unsafe { nil } {
 						c.fn_scope.find_var(node.obj.name) or { obj }
 					} else {
 						obj
 					}
 				}
+				obj = resolved
 				if obj.typ == 0 {
 					return
 				}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7695,6 +7695,21 @@ fn (mut c Checker) mark_as_referenced(mut node ast.Expr, as_interface bool) {
 						}
 					}
 
+					if obj.is_auto_heap {
+						// `obj` is the canonical declaration, which cgen emits as a
+						// heap pointer. When the value is read through a branch-local
+						// smartcast/option-unwrap copy (`if x is T`, `if x != none`),
+						// cgen resolves that use-site copy (see
+						// `resolved_ident_is_auto_heap`) when emitting the read, so it
+						// must carry the same `is_auto_heap`. Otherwise the read (e.g.
+						// an unwrapped option's `.data`) is emitted without the pointer
+						// indirection the declaration was given, producing invalid C.
+						node.obj.is_auto_heap = true
+						if mut use_site := node.scope.find_var(node.obj.name) {
+							use_site.is_auto_heap = true
+						}
+					}
+
 					if as_interface {
 						for method in type_sym.methods {
 							c.mark_fn_decl_as_referenced(method.fkey())

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7640,8 +7640,18 @@ fn (mut c Checker) mark_as_referenced(mut node ast.Expr, as_interface bool) {
 		ast.Ident {
 			if mut node.obj is ast.Var {
 				mut obj := unsafe { &node.obj }
-				if c.fn_scope != unsafe { nil } {
-					obj = c.fn_scope.find_var(node.obj.name) or { obj }
+				// Resolve the canonical declaration variable so that the
+				// `is_auto_heap` promotion below is recorded on the variable
+				// that cgen will see when emitting its declaration. Prefer the
+				// use-site scope chain, since `c.fn_scope.find_var` only locates
+				// variables declared at the function level and misses those
+				// declared in nested scopes (e.g. inside a `for` loop body).
+				obj = node.scope.find_var(node.obj.name) or {
+					if c.fn_scope != unsafe { nil } {
+						c.fn_scope.find_var(node.obj.name) or { obj }
+					} else {
+						obj
+					}
 				}
 				if obj.typ == 0 {
 					return

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -7642,25 +7642,21 @@ fn (mut c Checker) mark_as_referenced(mut node ast.Expr, as_interface bool) {
 				mut obj := unsafe { &node.obj }
 				// Resolve the canonical declaration variable so that the
 				// `is_auto_heap` promotion below is recorded on the variable
-				// that cgen will see when emitting its declaration. Prefer the
-				// use-site scope chain, since `c.fn_scope.find_var` only locates
-				// variables declared at the function level and misses those
-				// declared in nested scopes (e.g. inside a `for` loop body).
-				mut resolved := node.scope.find_var(node.obj.name) or { obj }
-				if resolved.smartcasts.len != 0 {
-					// `node.scope.find_var` resolved a synthetic smartcast var
-					// from an `if x is T`/`match` branch rather than the real
-					// declaration. Such vars have no declaration of their own, so
-					// promoting them would set `is_auto_heap` on the smartcast var
-					// while the actual declaration stays a plain value, desyncing
-					// the pointer indirection. Fall back to the function scope.
-					resolved = if c.fn_scope != unsafe { nil } {
+				// that cgen will see when emitting its declaration. Walk the
+				// use-site scope chain (so variables declared in nested scopes,
+				// e.g. inside a `for` loop body, are found, unlike
+				// `c.fn_scope.find_var` which only locates function-level vars),
+				// while skipping synthetic smartcast vars from `if x is T`/`match`
+				// branches: those are copies with no declaration of their own, so
+				// promoting them would leave the real declaration emitted as a
+				// plain value and desync the pointer indirection.
+				obj = node.scope.find_var_decl(node.obj.name) or {
+					if c.fn_scope != unsafe { nil } {
 						c.fn_scope.find_var(node.obj.name) or { obj }
 					} else {
 						obj
 					}
 				}
-				obj = resolved
 				if obj.typ == 0 {
 					return
 				}

--- a/vlib/v/tests/interfaces/interface_variadic_test.v
+++ b/vlib/v/tests/interfaces/interface_variadic_test.v
@@ -101,6 +101,33 @@ fn test_variadic_interface_arg_smartcast_in_loop() {
 	assert total == 5
 }
 
+fn maybe_value() ?Cat {
+	return Cat{}
+}
+
+// For issue 27326: an option value unwrapped via an if-guard or `if x != none`
+// and then passed to a variadic interface parameter is auto-heap promoted, so
+// its declaration is emitted as an option pointer. The unwrapped `.data` read
+// at the call site must use the matching pointer indirection (`->data`);
+// previously cgen emitted value-style access and failed C compilation.
+fn test_variadic_interface_arg_option_unwrap() {
+	mut total := 0
+	if x := maybe_value() {
+		total += collect(x)
+	}
+	x := maybe_value()
+	if x != none {
+		total += collect(x)
+	}
+	for _ in 0 .. 2 {
+		y := maybe_value()
+		if y != none {
+			total += collect(y)
+		}
+	}
+	assert total == 4
+}
+
 fn check_animals(animals ...Animal) {
 	assert animals[0] is Cat
 	assert animals[1] is Dog

--- a/vlib/v/tests/interfaces/interface_variadic_test.v
+++ b/vlib/v/tests/interfaces/interface_variadic_test.v
@@ -36,6 +36,26 @@ fn test_variadic_interface_fn_arg() {
 	check_animals(c, d)
 }
 
+// For issue 27326: passing a local variable declared inside a loop to a
+// variadic interface parameter caused a `pointer expected` C error, because
+// the value was promoted to auto-heap at the use site but not at its
+// declaration, producing inconsistent pointer indirection in the generated C.
+interface Value {}
+
+fn collect(params ...Value) int {
+	return params.len
+}
+
+fn test_variadic_interface_arg_declared_in_loop() {
+	mut total := 0
+	for i := 0; i < 3; i++ {
+		id := [u8(1), 2, 3]
+		code := 'hello ${i}'
+		total += collect(id, code)
+	}
+	assert total == 6
+}
+
 fn check_animals(animals ...Animal) {
 	assert animals[0] is Cat
 	assert animals[1] is Dog

--- a/vlib/v/tests/interfaces/interface_variadic_test.v
+++ b/vlib/v/tests/interfaces/interface_variadic_test.v
@@ -56,6 +56,30 @@ fn test_variadic_interface_arg_declared_in_loop() {
 	assert total == 6
 }
 
+type ValueSum = Cat | Dog
+
+// For issue 27326: a variable smartcast via `if x is T` / `match` resolves to a
+// synthetic smartcast scope var, not its real declaration. Promoting that
+// synthetic var to auto-heap instead of the declaration must not desync the
+// pointer indirection when the value is passed to a variadic interface param.
+fn test_variadic_interface_arg_smartcast() {
+	mut total := 0
+	s := ValueSum(Cat{})
+	if s is Cat {
+		total += collect(s)
+	}
+	v := Value(Cat{})
+	if v is Cat {
+		total += collect(v)
+	}
+	match v {
+		Cat { total += collect(v) }
+		else {}
+	}
+
+	assert total == 3
+}
+
 fn check_animals(animals ...Animal) {
 	assert animals[0] is Cat
 	assert animals[1] is Dog

--- a/vlib/v/tests/interfaces/interface_variadic_test.v
+++ b/vlib/v/tests/interfaces/interface_variadic_test.v
@@ -80,6 +80,27 @@ fn test_variadic_interface_arg_smartcast() {
 	assert total == 3
 }
 
+// For issue 27326: a variable that is both declared in a nested scope (a `for`
+// loop body) and smartcast via `if x is T` must still resolve to its real
+// nested declaration, not the synthetic smartcast var nor only the function
+// scope, otherwise the auto-heap promotion desyncs the pointer indirection.
+fn test_variadic_interface_arg_smartcast_in_loop() {
+	mut total := 0
+	for _ in 0 .. 3 {
+		s := ValueSum(Cat{})
+		if s is Cat {
+			total += collect(s)
+		}
+	}
+	for _ in 0 .. 2 {
+		v := Value(Cat{})
+		if v is Cat {
+			total += collect(v)
+		}
+	}
+	assert total == 5
+}
+
 fn check_animals(animals ...Animal) {
 	assert animals[0] is Cat
 	assert animals[1] is Dog


### PR DESCRIPTION
## Fixes #27326

### Problem

Passing a local variable that is **declared inside a nested scope** (such as a `for` loop body) to a **variadic interface parameter** produced a `pointer expected` C compilation error:

```v
interface Value {}

fn execute(params ...Value) { println(params.len) }

fn main() {
	for _ in 0 .. 2 {
		code := 'hello'
		execute(code) // cc: error: pointer expected
	}
}
```

### Root cause

When an argument is passed to a variadic interface parameter, the checker calls `mark_as_referenced`, which promotes the variable to auto-heap (`is_auto_heap = true`) so the boxed interface can safely outlive the current scope.

To locate the canonical declaration variable, `mark_as_referenced` used `c.fn_scope.find_var(...)`. That only finds variables declared at the **function** scope and misses variables declared in nested scopes (loops, `if` blocks). For those, it fell back to toggling `is_auto_heap` on the use-site `Ident`'s `obj` copy only.

The result was inconsistent indirection in the generated C:

- the **read** at the call site saw `obj.is_auto_heap == true` and emitted a dereference (`*code`),
- but the **declaration** was emitted as a plain value (`string code = ...`) instead of a heap pointer,

so the generated code dereferenced a non-pointer:

```c
string code = _S("hello");                       // not a pointer
... HEAP(string, ((*(code))))                     // pointer expected
```

(The same code compiled fine when the variable was declared at function scope, where it was correctly emitted as `string *code = HEAP(...)`.)

### Fix

Resolve the canonical declaration variable via the use-site scope chain (`node.scope.find_var`), which walks parent scopes and therefore finds variables declared in nested scopes, falling back to `c.fn_scope` and finally to the node's own `obj`. The auto-heap promotion is now recorded on the variable that cgen sees when it emits the declaration, so the declaration and all reads use consistent pointer indirection.

### Testing

- Added a regression test in `vlib/v/tests/interfaces/interface_variadic_test.v`.
- The original reproduction from the issue (the `firebird` `statement_test.v`) now compiles past C code generation.
- `vlib/v/tests/interfaces/`, `vlib/v/tests/generics/`, and `vlib/v/tests/sumtypes/` all pass.