### PR TITLE
builtin: guard array push len panics

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -1129,11 +1129,13 @@ fn (mut a array) set_ni(i int, val voidptr) {
 }
 
 fn (mut a array) push(val voidptr) {
-	if a.len < 0 {
-		panic('array.push: negative len')
-	}
-	if a.len >= max_int {
-		panic('array.push: len bigger than max_int')
+	$if !no_bounds_checking {
+		if a.len < 0 {
+			panic('array.push: negative len')
+		}
+		if a.len >= max_int {
+			panic('array.push: len bigger than max_int')
+		}
 	}
 	required := a.len + 1
 	if a.needs_unique_append(required) {

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -1133,9 +1133,9 @@ fn (mut a array) push(val voidptr) {
 		if a.len < 0 {
 			panic('array.push: negative len')
 		}
-		if a.len >= max_int {
-			panic('array.push: len bigger than max_int')
-		}
+	}
+	if a.len >= max_int {
+		panic('array.push: len bigger than max_int')
 	}
 	required := a.len + 1
 	if a.needs_unique_append(required) {

--- a/vlib/builtin/array_d_gcboehm_opt.v
+++ b/vlib/builtin/array_d_gcboehm_opt.v
@@ -360,11 +360,13 @@ fn (a &array) clone_to_depth_noscan(depth int) array {
 }
 
 fn (mut a array) push_noscan(val voidptr) {
-	if a.len < 0 {
-		panic('array.push_noscan: negative len')
-	}
-	if a.len >= max_int {
-		panic('array.push_noscan: len bigger than max_int')
+	$if !no_bounds_checking {
+		if a.len < 0 {
+			panic('array.push_noscan: negative len')
+		}
+		if a.len >= max_int {
+			panic('array.push_noscan: len bigger than max_int')
+		}
 	}
 	required := a.len + 1
 	if a.needs_unique_append(required) {

--- a/vlib/builtin/array_d_gcboehm_opt.v
+++ b/vlib/builtin/array_d_gcboehm_opt.v
@@ -364,9 +364,9 @@ fn (mut a array) push_noscan(val voidptr) {
 		if a.len < 0 {
 			panic('array.push_noscan: negative len')
 		}
-		if a.len >= max_int {
-			panic('array.push_noscan: len bigger than max_int')
-		}
+	}
+	if a.len >= max_int {
+		panic('array.push_noscan: len bigger than max_int')
 	}
 	required := a.len + 1
 	if a.needs_unique_append(required) {

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -259,7 +259,7 @@ fn test_comptime_for_empty_attrs_does_not_emit_new_array_calls() {
 	assert !compilation.output.contains('.args = builtin____new_array_with_default(0, 0, sizeof(FunctionParam), 0)')
 }
 
-fn test_array_push_no_bounds_checking_does_not_emit_len_panics() {
+fn test_array_push_no_bounds_checking_keeps_max_len_panics() {
 	os.chdir(vroot) or {}
 	test_source := os.join_path(os.vtmp_dir(), 'coutput_array_push_no_bounds_checking.vv')
 	source_lines := [
@@ -283,9 +283,9 @@ fn test_array_push_no_bounds_checking_does_not_emit_len_panics() {
 	assert compilation.output.contains('VV_LOC void builtin__array_push(array* a, voidptr val) {')
 	assert compilation.output.contains('VV_LOC void builtin__array_push_noscan(array* a, voidptr val) {')
 	assert !compilation.output.contains('array.push: negative len')
-	assert !compilation.output.contains('array.push: len bigger than max_int')
+	assert compilation.output.contains('array.push: len bigger than max_int')
 	assert !compilation.output.contains('array.push_noscan: negative len')
-	assert !compilation.output.contains('array.push_noscan: len bigger than max_int')
+	assert compilation.output.contains('array.push_noscan: len bigger than max_int')
 }
 
 fn test_windows_sharedlive_string_interpolation_in_ternary_does_not_emit_inline_tmp_decl() {

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -259,6 +259,35 @@ fn test_comptime_for_empty_attrs_does_not_emit_new_array_calls() {
 	assert !compilation.output.contains('.args = builtin____new_array_with_default(0, 0, sizeof(FunctionParam), 0)')
 }
 
+fn test_array_push_no_bounds_checking_does_not_emit_len_panics() {
+	os.chdir(vroot) or {}
+	test_source := os.join_path(os.vtmp_dir(), 'coutput_array_push_no_bounds_checking.vv')
+	source_lines := [
+		'module main',
+		'',
+		'fn main() {',
+		'\tmut names := []string{}',
+		"\tnames << 'alpha'",
+		'\tmut scores := []int{}',
+		'\tscores << 1',
+		'\tprintln(names.len + scores.len)',
+		'}',
+	]
+	os.write_file(test_source, source_lines.join('\n') + '\n')!
+	defer {
+		os.rm(test_source) or {}
+	}
+	cmd := '${os.quoted_path(vexe)} -prod -no-bounds-checking -o - ${os.quoted_path(test_source)}'
+	compilation := os.execute(cmd)
+	ensure_compilation_succeeded(compilation, cmd)
+	assert compilation.output.contains('VV_LOC void builtin__array_push(array* a, voidptr val) {')
+	assert compilation.output.contains('VV_LOC void builtin__array_push_noscan(array* a, voidptr val) {')
+	assert !compilation.output.contains('array.push: negative len')
+	assert !compilation.output.contains('array.push: len bigger than max_int')
+	assert !compilation.output.contains('array.push_noscan: negative len')
+	assert !compilation.output.contains('array.push_noscan: len bigger than max_int')
+}
+
 fn test_windows_sharedlive_string_interpolation_in_ternary_does_not_emit_inline_tmp_decl() {
 	os.chdir(vroot) or {}
 	test_source := os.join_path(os.vtmp_dir(), 'coutput_live_windows_ternary_str_intp.vv')


### PR DESCRIPTION
Fixes #27334.

## What changed
- Guard the `array.push` and `array.push_noscan` negative-length sanity checks with `$if !no_bounds_checking`.
- Keep the `max_int` length guards unconditional so `required := a.len + 1` cannot overflow when bounds checking is disabled.
- Add a C-output regression that verifies `-prod -no-bounds-checking` generated C omits the negative-length panic paths while retaining the max-length overflow guards for both regular and noscan array pushes.

## Why
The negative-length checks are bounds-checking sanity paths and can be compiled out consistently with existing array access checks. The `max_int` checks are capacity-overflow guards, so they remain active even with `-no-bounds-checking`.

## Validation
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew test vlib/builtin/array_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`