### PR TITLE
cgen: fix C codegen for generic chan pop via if-guard bound var (#27205)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -8873,7 +8873,14 @@ fn (mut g Gen) select_expr(node ast.SelectExpr) {
 						|| branch.stmt.right_types[0] != branch.stmt.left_types[0] {
 						tmp_obj := g.new_tmp_var()
 						tmp_objs << tmp_obj
-						el_stype := g.styp(branch.stmt.right_types[0])
+						// Re-resolve the channel element type through the current generic
+						// instantiation; `right_types[0]` may be a stale concrete type baked
+						// from a different instantiation of the same generic body (issue #27205).
+						mut elem_type := g.resolved_expr_type(rec_expr, branch.stmt.right_types[0])
+						if elem_type == 0 {
+							elem_type = branch.stmt.right_types[0]
+						}
+						el_stype := g.styp(elem_type)
 						elem_types << if branch.stmt.op == .decl_assign {
 							el_stype + ' '
 						} else {

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -1476,6 +1476,23 @@ fn (mut g Gen) resolved_expr_type(expr ast.Expr, default_typ ast.Type) ast.Type 
 				return g.unwrap_generic(left_type)
 			}
 		}
+		ast.IfGuardExpr {
+			// A variable bound by an `if x := opt() {` guard stores the whole
+			// `IfGuardExpr` as its init expression. Resolve from the guard's source
+			// expression so the variable's type follows the current generic
+			// instantiation, instead of a stale type baked from a different one
+			// (see issue #27205). Only single-var guards map to one value type.
+			if expr.vars.len == 1 {
+				resolved := g.resolved_expr_type(expr.expr, if expr.expr_type != 0 {
+					expr.expr_type
+				} else {
+					default_typ
+				})
+				if resolved != 0 {
+					return g.unwrap_generic(g.recheck_concrete_type(resolved)).clear_option_and_result()
+				}
+			}
+		}
 		ast.IfExpr {
 			inferred_typ := g.infer_if_expr_type(expr)
 			if inferred_typ != 0 && inferred_typ != ast.void_type {

--- a/vlib/v/tests/generics/generic_chan_pop_via_if_guard_test.v
+++ b/vlib/v/tests/generics/generic_chan_pop_via_if_guard_test.v
@@ -1,0 +1,100 @@
+// Regression test for https://github.com/vlang/v/issues/27205
+//
+// A generic struct with a `chan T` field, popped through a variable that is
+// bound by a map-index `if`-guard (`if w := c.waiters[id] { ... <-w.c.c ... }`).
+// The body of such a generic method is generated once per concrete type. The
+// channel element type must follow the current instantiation; previously it
+// leaked the concrete type of a *different* instantiation, producing invalid C.
+module main
+
+import time
+
+struct Inner[T] {
+	c chan T
+}
+
+struct Waiter[T] {
+	c Inner[T]
+}
+
+struct Controller[T] {
+mut:
+	waiters map[int]Waiter[T]
+}
+
+fn (mut c Controller[T]) add(id int) {
+	c.waiters[id] = Waiter[T]{
+		c: Inner[T]{
+			c: chan T{cap: 1}
+		}
+	}
+}
+
+fn (mut c Controller[T]) emit(id int, e T) {
+	if w := c.waiters[id] {
+		w.c.c <- e
+	}
+}
+
+// bare channel pop through an `if`-guard bound variable
+fn (mut c Controller[T]) recv(id int) ?T {
+	if w := c.waiters[id] {
+		return <-w.c.c
+	}
+	return none
+}
+
+// `select`-based channel pop through an `if`-guard bound variable
+fn (mut c Controller[T]) recv_select(id int) ?T {
+	if w := c.waiters[id] {
+		select {
+			r := <-w.c.c {
+				return r
+			}
+			500 * time.millisecond {
+				return none
+			}
+		}
+	}
+	return none
+}
+
+struct EvA {
+	a int
+}
+
+struct EvB {
+	b string
+}
+
+fn test_generic_chan_pop_via_if_guard() {
+	mut ca := Controller[EvA]{}
+	ca.add(0)
+	mut cb := Controller[EvB]{}
+	cb.add(0)
+
+	ca.emit(0, EvA{ a: 42 })
+	cb.emit(0, EvB{ b: 'hello' })
+
+	ra := ca.recv(0) or { EvA{} }
+	assert ra.a == 42
+
+	rb := cb.recv(0) or { EvB{} }
+	assert rb.b == 'hello'
+}
+
+fn test_generic_chan_select_via_if_guard() {
+	mut ca := Controller[EvA]{}
+	ca.add(0)
+	mut cb := Controller[EvB]{}
+	cb.add(0)
+
+	ca.emit(0, EvA{ a: 7 })
+	cb.emit(0, EvB{ b: 'world' })
+
+	ra := ca.recv_select(0) or { EvA{} }
+	assert ra.a == 7
+
+	rb := cb.recv_select(0) or { EvB{} }
+	assert rb.b == 'world'
+}


### PR DESCRIPTION
## Fixes #27205

C compilation error when compiling generic event waiters (reported against the `discord.v` library's `EventController[T]`).

### Root cause

When a generic struct has a `chan T` field that is popped through a variable bound by a map-index `if`-guard:

```v
if w := a.controller.wait_fors[a.id] {
    return <-w.c.c          // and: select { r := <-w.c.c { ... } }
}
```

the body of the generic method is generated once per concrete type, but the channel element type leaked from a *different* instantiation. For `EventController[ReadyEvent]` the generated `receive()` emitted `__chan_main__MessageCreateEvent_popval(...)` and declared a temp of the wrong type, producing invalid C — `cannot convert 'struct main__MessageCreateEvent' to 'int'` (tcc reports it as `'{' expected (got ";")`).

The bound variable's init expression is an `ast.IfGuardExpr`, and `resolved_expr_type()` (the generic-aware type resolver in cgen) had **no case for it**, so it returned `0` and codegen fell back to a stale type baked from the last checked instantiation.

### Fix

- **`vlib/v/gen/c/utils.v`** — add an `ast.IfGuardExpr` arm to `resolved_expr_type()` that resolves an `if`-guard-bound variable's type from the guard's source expression through the current generic instantiation. Fixes the bare `<-w.c.c` pop.
- **`vlib/v/gen/c/cgen.v`** — in `select_expr()`, re-resolve the channel element type instead of using the stale `branch.stmt.right_types[0]`. Fixes the `select { r := <-w.c.c }` pop.

### Tests

- New regression test `vlib/v/tests/generics/generic_chan_pop_via_if_guard_test.v` covering both the bare `<-` pop and the `select` pop across two instantiations. Confirmed it **fails** (C error) on the unpatched compiler and **passes** with the fix.
- No regressions: `vlib/v/tests/generics/` (298), `vlib/v/tests/concurrency/` (68 + 1 skipped), and option/if-guard/or-block tests all pass; V self-compiles cleanly.