### PR TITLE
cgen: fix fixed array return via local

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -10883,13 +10883,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 					if node.exprs[0] is ast.Ident {
 						g.writeln('{0};')
 						typ := if node.exprs[0].is_auto_deref_var() { type0.deref() } else { type0 }
-						typ_sym := g.table.final_sym(typ)
-						if typ_sym.kind == .array_fixed
-							&& (typ_sym.info as ast.ArrayFixed).is_fn_ret {
-							g.write('memcpy(${tmpvar}.ret_arr, ${g.expr_string(expr0)}.ret_arr, sizeof(${g.styp(typ)}))')
-						} else {
-							g.write('memcpy(${tmpvar}.ret_arr, ${g.expr_string(expr0)}, sizeof(${g.styp(typ)}))')
-						}
+						g.write('memcpy(${tmpvar}.ret_arr, ${g.expr_string(expr0)}, sizeof(${g.styp(typ)}))')
 					} else if expr0 in [ast.ArrayInit, ast.StructInit] {
 						if expr0 is ast.ArrayInit && expr0.is_fixed && expr0.has_init {
 							if expr0.init_expr.is_literal() {

--- a/vlib/v/tests/return_fixed_array_test.v
+++ b/vlib/v/tests/return_fixed_array_test.v
@@ -57,3 +57,16 @@ fn test_returns_option_and_result_fixed_array() {
 	}
 	assert res == [59, 101, 200]!
 }
+
+fn issue_27345_hud_rgba() [4]u8 {
+	return [u8(1), 2, 3, 4]!
+}
+
+fn issue_27345_shop_category_color() [4]u8 {
+	col := issue_27345_hud_rgba()
+	return col
+}
+
+fn test_fixed_array_return_via_local_from_call() {
+	assert issue_27345_shop_category_color() == [u8(1), 2, 3, 4]!
+}


### PR DESCRIPTION
## Summary

Fixes #27345.

- Copy fixed-array identifier returns from the raw local array instead of reading `.ret_arr` from it.
- Add a regression test for returning a fixed array through an intermediate local initialized from another fixed-array-returning function.

## Root Cause

Fixed-array function returns use a wrapper struct with a `.ret_arr` field in generated C, but ordinary local fixed-array variables are raw C arrays. The return path was using the fixed-array return-wrapper type metadata to decide that an identifier return should read `local.ret_arr`, which is invalid for raw local arrays.

## Validation

- `./v -g -keepc -o ./vnew cmd/v`
- issue repro with `./vnew run /tmp/.../repro.v`
- `./vnew -silent test vlib/v/tests/return_fixed_array_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
