### PR TITLE
cgen: use union tag for C union keepalive helpers

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2624,7 +2624,8 @@ fn (mut g Gen) cc_type(typ ast.Type, is_prefix_struct bool) string {
 			if info.is_anon {
 				styp = 'C__' + styp
 			} else if !info.is_typedef {
-				styp = 'struct ${styp}'
+				tag := if info.is_union { 'union' } else { 'struct' }
+				styp = '${tag} ${styp}'
 			}
 		}
 	}

--- a/vlib/v/gen/c/testdata/boehm_keepalive_c_union_tag.c.must_have
+++ b/vlib/v/gen/c/testdata/boehm_keepalive_c_union_tag.c.must_have
@@ -1,0 +1,2 @@
+union my_data* it, voidptr* out, int idx)
+struct my_event* it, voidptr* out, int idx)

--- a/vlib/v/gen/c/testdata/boehm_keepalive_c_union_tag.h
+++ b/vlib/v/gen/c/testdata/boehm_keepalive_c_union_tag.h
@@ -1,0 +1,13 @@
+#include <stdint.h>
+
+typedef union my_data {
+	void *ptr;
+	int fd;
+	uint32_t u32;
+	uint64_t u64;
+} my_data_t;
+
+struct my_event {
+	uint32_t events;
+	union my_data data;
+};

--- a/vlib/v/gen/c/testdata/boehm_keepalive_c_union_tag.vv
+++ b/vlib/v/gen/c/testdata/boehm_keepalive_c_union_tag.vv
@@ -1,0 +1,25 @@
+// vtest vflags: -prod -gc boehm_full_opt
+#include "@VMODROOT/vlib/v/gen/c/testdata/boehm_keepalive_c_union_tag.h"
+
+union C.my_data {
+mut:
+	ptr voidptr
+	fd  int
+}
+
+struct C.my_event {
+mut:
+	events u32
+	data   C.my_data
+}
+
+fn consume(n int) {
+	_ = n
+}
+
+fn main() {
+	mut ev := C.my_event{}
+	ev.data.fd = 42
+	fd := unsafe { ev.data.fd }
+	consume(fd)
+}


### PR DESCRIPTION
## Summary
- Emit `union` instead of `struct` for non-typedef C unions when spelling prefixed C types in cgen.
- Add a Boehm keepalive coutput regression covering a header-backed C union field.

Fixes #27339

## Testing
- `make` (in clean PR worktree, to bootstrap `./v`)
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w vlib/v/gen/c/cgen.v vlib/v/gen/c/testdata/boehm_keepalive_c_union_tag.vv`
- `VTEST_ONLY=boehm_keepalive_c_union_tag.c.must_have ./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew -prod -gc boehm_full_opt -o /tmp/boehm_keepalive_c_union_tag vlib/v/gen/c/testdata/boehm_keepalive_c_union_tag.vv && /tmp/boehm_keepalive_c_union_tag`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `TMPDIR=/tmp/v-pr-27339-tmp ./vnew -silent vlib/v/gen/c/coutput_test.v` (passed on rerun; first run failed opening a temporary linker output path)
- `TMPDIR=/tmp/v-pr-27339-tmp ./vnew -silent test vlib/v/` (1 unrelated failure: `vlib/v/builder/builder_test.v` output included `tcc compilation failed, falling back to cc` before the expected text)