### PR TITLE
cgen: unwrap option smartcast for interface casts

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -9230,7 +9230,8 @@ fn (mut g Gen) ident(node ast.Ident) {
 				g.write('*(')
 			}
 			if !has_smartcast && !selector_uses_unwrapped_option_smartcast
-				&& (g.inside_opt_or_res || g.left_is_opt) && node.or_expr.kind == .absent {
+				&& (g.inside_opt_or_res || (g.left_is_opt && !g.inside_interface_cast))
+				&& node.or_expr.kind == .absent {
 				if !g.is_assign_lhs && is_auto_heap {
 					g.write('(*${name})')
 				} else {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -9104,6 +9104,11 @@ fn (mut g Gen) ident(node ast.Ident) {
 			}
 		}
 	}
+	ident_option_name := if has_resolved_var && resolved_var.is_inherited {
+		'${closure_ctx}->${name}'
+	} else {
+		name
+	}
 	if node.info is ast.IdentVar {
 		node_info_is_option = node.info.is_option
 		if node.or_expr.kind == .absent {
@@ -9154,7 +9159,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 				if orig_has_option && !comptime_type.has_flag(.option) {
 					styp := g.base_type(comptime_type)
 					ptr := if is_auto_heap { '->' } else { '.' }
-					g.write('(*(${styp}*)${name}${ptr}data)')
+					g.write('(*(${styp}*)${ident_option_name}${ptr}data)')
 				} else if comptime_type.has_flag(.option) {
 					if (g.inside_opt_or_res || g.left_is_opt) && node.or_expr.kind == .absent {
 						if !g.is_assign_lhs && is_auto_heap {
@@ -9165,7 +9170,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 					} else {
 						styp := g.base_type(comptime_type)
 						ptr := if is_auto_heap { '->' } else { '.' }
-						g.write('(*(${styp}*)${name}${ptr}data)')
+						g.write('(*(${styp}*)${ident_option_name}${ptr}data)')
 					}
 				} else {
 					emit_auto_heap_deref := is_auto_heap && !g.inside_assign_fn_var
@@ -9255,7 +9260,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 				} else {
 					g.get_comptime_for_var_type(node, node.info.typ)
 				}
-				g.unwrap_option_type(unwrap_typ, name, is_auto_heap)
+				g.unwrap_option_type(unwrap_typ, ident_option_name, is_auto_heap)
 			}
 			if node.or_expr.kind != .absent && !(g.inside_opt_or_res && g.inside_assign
 				&& !g.is_assign_lhs) {
@@ -9346,7 +9351,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 				&& resolved_var.smartcasts.len == 0 && resolved_var.ct_type_var != .smartcast
 				&& !g.inside_opt_or_res && !g.is_assign_lhs && !g.inside_selector_lhs
 				&& !g.right_is_opt && (!g.left_is_opt || g.inside_cast) {
-				g.unwrap_option_type(runtime_option_type, name, is_auto_heap)
+				g.unwrap_option_type(runtime_option_type, ident_option_name, is_auto_heap)
 				return
 			}
 			// When an auto-heap option variable is being smartcast-unwrapped
@@ -9607,13 +9612,13 @@ fn (mut g Gen) ident(node ast.Ident) {
 			if g.inside_selector_lhs && !node_info_is_option && has_resolved_var
 				&& !resolved_var.is_unwrapped && resolved_var.smartcasts.len == 0
 				&& resolved_var.typ.has_flag(.option) && !g.is_assign_lhs {
-				g.unwrap_option_type(resolved_var.typ, name, is_auto_heap)
+				g.unwrap_option_type(resolved_var.typ, ident_option_name, is_auto_heap)
 				return
 			}
 			if g.inside_selector_lhs && has_resolved_var && resolved_var.is_unwrapped
 				&& resolved_var.smartcasts.len == 0 && resolved_var.orig_type.has_flag(.option)
 				&& !g.is_assign_lhs {
-				g.unwrap_option_type(resolved_var.orig_type, name, is_auto_heap)
+				g.unwrap_option_type(resolved_var.orig_type, ident_option_name, is_auto_heap)
 				return
 			}
 			if has_resolved_var && resolved_var.is_inherited {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -9335,6 +9335,20 @@ fn (mut g Gen) ident(node ast.Ident) {
 				}
 			}
 			is_option = is_option || (has_resolved_var && resolved_var.orig_type.has_flag(.option))
+			runtime_option_type := if resolved_var.orig_type.has_flag(.option) {
+				resolved_var.orig_type
+			} else if resolved_var.typ.has_flag(.option) {
+				resolved_var.typ
+			} else {
+				ast.no_type
+			}
+			if has_resolved_var && runtime_option_type != ast.no_type && !node_info_is_option
+				&& resolved_var.smartcasts.len == 0 && resolved_var.ct_type_var != .smartcast
+				&& !g.inside_opt_or_res && !g.is_assign_lhs && !g.inside_selector_lhs
+				&& !g.right_is_opt && (!g.left_is_opt || g.inside_cast) {
+				g.unwrap_option_type(runtime_option_type, name, is_auto_heap)
+				return
+			}
 			// When an auto-heap option variable is being smartcast-unwrapped
 			// (e.g. `if svc != none { use(svc) }`), the option unwrap code
 			// at `->data` already handles the pointer indirection. Skip the

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -174,6 +174,7 @@ mut:
 	inside_for_c_stmt                    bool
 	inside_cast_in_heap                  int // inside cast to interface type in heap (resolve recursive calls)
 	inside_cast                          bool
+	inside_interface_cast                bool
 	inside_sumtype_cast                  bool
 	inside_selector                      bool
 	inside_selector_lhs                  bool
@@ -4509,6 +4510,8 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp ast.Ty
 	} else {
 		old_inside_sumtype_cast := g.inside_sumtype_cast
 		g.inside_sumtype_cast = true
+		old_inside_interface_cast := g.inside_interface_cast
+		g.inside_interface_cast = g.inside_interface_cast || is_interface_cast
 		old_left_is_opt := g.left_is_opt
 		g.left_is_opt = !exp.has_flag(.option)
 		old_inside_assign_fn_var := g.inside_assign_fn_var
@@ -4524,6 +4527,7 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp ast.Ty
 		}
 		g.inside_assign_fn_var = old_inside_assign_fn_var
 		g.left_is_opt = old_left_is_opt
+		g.inside_interface_cast = old_inside_interface_cast
 		g.inside_sumtype_cast = old_inside_sumtype_cast
 	}
 	if is_sumtype_cast {
@@ -9350,7 +9354,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 			if has_resolved_var && runtime_option_type != ast.no_type && !node_info_is_option
 				&& resolved_var.smartcasts.len == 0 && resolved_var.ct_type_var != .smartcast
 				&& !g.inside_opt_or_res && !g.is_assign_lhs && !g.inside_selector_lhs
-				&& !g.right_is_opt && (!g.left_is_opt || g.inside_cast) {
+				&& !g.right_is_opt && (!g.left_is_opt || g.inside_cast || g.inside_interface_cast) {
 				g.unwrap_option_type(runtime_option_type, ident_option_name, is_auto_heap)
 				return
 			}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -6408,7 +6408,7 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 					exp_sym := g.table.sym(expected_types[i])
 					orig_sym := g.table.sym(arg.expr.obj.orig_type)
 					if !expected_types[i].has_option_or_result() && orig_sym.kind != .interface
-						&& (exp_sym.kind != .sum_type
+						&& (exp_sym.kind !in [.sum_type, .interface]
 						&& expected_types[i] != arg.expr.obj.orig_type) {
 						expected_types[i] = g.unwrap_generic(arg.expr.obj.smartcasts.last())
 						cast_sym := g.table.sym(expected_types[i])

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -6940,7 +6940,14 @@ fn (mut g Gen) ref_or_deref_arg_ex(arg ast.CallArg, expected_type_ ast.Type, lan
 		if resolved_arg_typ != 0 && (arg_typ == 0 || g.type_needs_generic_resolution(arg_typ)
 			|| in_generic_context
 			|| g.unwrap_generic(resolved_arg_typ) != g.unwrap_generic(arg_typ)) {
-			arg_typ = g.unwrap_generic(g.recheck_concrete_type(resolved_arg_typ))
+			resolved_arg_type := g.unwrap_generic(g.recheck_concrete_type(resolved_arg_typ))
+			skip_inherited_option_storage_type := arg.expr is ast.Ident && arg.expr.obj is ast.Var
+				&& arg.expr.obj.is_inherited && !expected_type.has_option_or_result()
+				&& arg_typ != 0 && !arg_typ.has_option_or_result()
+				&& resolved_arg_type.has_option_or_result()
+			if !skip_inherited_option_storage_type {
+				arg_typ = resolved_arg_type
+			}
 		}
 	}
 	// Array slice expressions (e.g. b[..8]) always return a value in C (via builtin__array_slice),

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -6904,7 +6904,14 @@ fn (mut g Gen) ref_or_deref_arg_ex(arg ast.CallArg, expected_type_ ast.Type, lan
 		if needs_resolved_ident_type {
 			resolved_arg_typ := g.resolved_expr_type(ast.Expr(arg.expr), arg_typ)
 			if resolved_arg_typ != 0 {
-				arg_typ = g.unwrap_generic(g.recheck_concrete_type(resolved_arg_typ))
+				resolved_arg_type := g.unwrap_generic(g.recheck_concrete_type(resolved_arg_typ))
+				skip_inherited_option_storage_type := arg.expr.obj is ast.Var
+					&& arg.expr.obj.is_inherited && !expected_type.has_option_or_result()
+					&& arg_typ != 0 && !arg_typ.has_option_or_result()
+					&& resolved_arg_type.has_option_or_result()
+				if !skip_inherited_option_storage_type {
+					arg_typ = resolved_arg_type
+				}
 			}
 		}
 		if expected_type.has_option_or_result() && !arg_typ.has_option_or_result() {

--- a/vlib/v/tests/casts/cast_option_to_interface_test.v
+++ b/vlib/v/tests/casts/cast_option_to_interface_test.v
@@ -63,3 +63,29 @@ fn test_option_none_guard_interface_cast() {
 	cat := v as Issue27340Cat
 	assert cat.state == 1
 }
+
+fn issue_27340_value_state(v Issue27340Value) int {
+	assert v is Issue27340Cat
+	cat := v as Issue27340Cat
+	return cat.state
+}
+
+fn test_option_none_guard_implicit_interface_arg() {
+	x := maybe_issue_27340_cat()
+	if x == none {
+		assert false
+		return
+	}
+	assert issue_27340_value_state(x) == 1
+}
+
+fn test_option_none_guard_interface_array_append() {
+	x := maybe_issue_27340_cat()
+	if x == none {
+		assert false
+		return
+	}
+	mut values := []Issue27340Value{}
+	values << x
+	assert issue_27340_value_state(values[0]) == 1
+}

--- a/vlib/v/tests/casts/cast_option_to_interface_test.v
+++ b/vlib/v/tests/casts/cast_option_to_interface_test.v
@@ -89,3 +89,33 @@ fn test_option_none_guard_interface_array_append() {
 	values << x
 	assert issue_27340_value_state(values[0]) == 1
 }
+
+fn test_option_positive_none_guard_interface_cast() {
+	x := maybe_issue_27340_cat()
+	if x != none {
+		v := Issue27340Value(x)
+		assert issue_27340_value_state(v) == 1
+		return
+	}
+	assert false
+}
+
+fn test_option_positive_none_guard_implicit_interface_arg() {
+	x := maybe_issue_27340_cat()
+	if x != none {
+		assert issue_27340_value_state(x) == 1
+		return
+	}
+	assert false
+}
+
+fn test_option_positive_none_guard_interface_array_append() {
+	x := maybe_issue_27340_cat()
+	if x != none {
+		mut values := []Issue27340Value{}
+		values << x
+		assert issue_27340_value_state(values[0]) == 1
+		return
+	}
+	assert false
+}

--- a/vlib/v/tests/casts/cast_option_to_interface_test.v
+++ b/vlib/v/tests/casts/cast_option_to_interface_test.v
@@ -38,3 +38,28 @@ fn test_cast_option_to_interface() {
 	assert e.parser.main.str == 'test'
 	eprintln(voidptr(e.parser.main))
 }
+
+interface Issue27340Value {
+}
+
+struct Issue27340Cat {
+	state int
+}
+
+fn maybe_issue_27340_cat() ?Issue27340Cat {
+	return Issue27340Cat{
+		state: 1
+	}
+}
+
+fn test_option_none_guard_interface_cast() {
+	x := maybe_issue_27340_cat()
+	if x == none {
+		assert false
+		return
+	}
+	v := Issue27340Value(x)
+	assert v is Issue27340Cat
+	cat := v as Issue27340Cat
+	assert cat.state == 1
+}

--- a/vlib/v/tests/options/option_none_guard_return_unwrap_test.v
+++ b/vlib/v/tests/options/option_none_guard_return_unwrap_test.v
@@ -41,7 +41,19 @@ fn guarded_cat_cast_state() int {
 	return cat.state
 }
 
+fn guarded_cat_closure_arg_state() int {
+	x := maybe_none_guard_cat()
+	if x == none {
+		return 0
+	}
+	callback := fn [x] () int {
+		return none_guard_cat_state(x)
+	}
+	return callback()
+}
+
 fn test_option_none_guard_return_unwrap_for_args_and_casts() {
 	assert guarded_cat_arg_state() == 1
 	assert guarded_cat_cast_state() == 1
+	assert guarded_cat_closure_arg_state() == 1
 }

--- a/vlib/v/tests/options/option_none_guard_return_unwrap_test.v
+++ b/vlib/v/tests/options/option_none_guard_return_unwrap_test.v
@@ -9,3 +9,39 @@ fn test_option_none_guard_return_unwrap() {
 	assert guarded_name_len(none) == 0
 	assert guarded_name_len('guarded') == 7
 }
+
+struct NoneGuardCat {
+	state int
+}
+
+fn maybe_none_guard_cat() ?NoneGuardCat {
+	return NoneGuardCat{
+		state: 1
+	}
+}
+
+fn none_guard_cat_state(cat NoneGuardCat) int {
+	return cat.state
+}
+
+fn guarded_cat_arg_state() int {
+	x := maybe_none_guard_cat()
+	if x == none {
+		return 0
+	}
+	return none_guard_cat_state(x)
+}
+
+fn guarded_cat_cast_state() int {
+	x := maybe_none_guard_cat()
+	if x == none {
+		return 0
+	}
+	cat := NoneGuardCat(x)
+	return cat.state
+}
+
+fn test_option_none_guard_return_unwrap_for_args_and_casts() {
+	assert guarded_cat_arg_state() == 1
+	assert guarded_cat_cast_state() == 1
+}

--- a/vlib/v/tests/options/option_none_guard_return_unwrap_test.v
+++ b/vlib/v/tests/options/option_none_guard_return_unwrap_test.v
@@ -52,8 +52,28 @@ fn guarded_cat_closure_arg_state() int {
 	return callback()
 }
 
+fn generic_none_guard_identity[T](value T) T {
+	return value
+}
+
+fn guarded_generic_closure_unwrap[T](value ?T) ?T {
+	if value == none {
+		return none
+	}
+	callback := fn [value] [T]() T {
+		return generic_none_guard_identity[T](value)
+	}
+	return callback[T]()
+}
+
+fn guarded_cat_generic_closure_arg_state() int {
+	cat := guarded_generic_closure_unwrap[NoneGuardCat](maybe_none_guard_cat()) or { return 0 }
+	return cat.state
+}
+
 fn test_option_none_guard_return_unwrap_for_args_and_casts() {
 	assert guarded_cat_arg_state() == 1
 	assert guarded_cat_cast_state() == 1
 	assert guarded_cat_closure_arg_state() == 1
+	assert guarded_cat_generic_closure_arg_state() == 1
 }


### PR DESCRIPTION
Fixes #27340.

## Summary
- unwrap option storage in cgen when an identifier has been narrowed by a `none` guard and is used as the payload value
- keep existing smartcast handling for active sumtype/comptime smartcasts to avoid forcing already-narrowed variants through `.data`
- add regression coverage for interface casts and call/cast uses after a `none` guard

## Tests
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w vlib/v/gen/c/cgen.v vlib/v/tests/casts/cast_option_to_interface_test.v vlib/v/tests/options/option_none_guard_return_unwrap_test.v`
- `VFLAGS='-cc clang' ./vnew test vlib/v/tests/options/option_sumtype_test.v vlib/v/tests/options/option_sumtype_unwrap_test.v vlib/v/tests/options/option_sumtype_variant_test.v vlib/v/tests/options/option_unwrap_ifexpr_test.v`
- `VFLAGS='-cc clang' ./vnew test vlib/v/tests/casts/cast_option_to_interface_test.v vlib/v/tests/options/option_none_guard_return_unwrap_test.v vlib/v/tests/alias_cast_to_fixed_array_test.v vlib/v/tests/fns/fn_fixed_array_ret_test.v vlib/v/tests/comptime/comptime_match_assign_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- `VTEST_HIDE_OK=1 VFLAGS='-cc clang' ./vnew -silent test vlib/v/`