### PR TITLE
builtin: add opt-in heap allocation hooks (-d track_heap)

### DIFF
--- a/vlib/builtin/allocation.c.v
+++ b/vlib/builtin/allocation.c.v
@@ -577,6 +577,10 @@ pub fn memdup_align(src voidptr, sz isize, align isize) voidptr {
 		// when the calling code wrongly relies on it being zeroed.
 		unsafe { C.memset(res, 0x4D, n) }
 	}
+	// memdup_align allocates directly via aligned_alloc / _aligned_malloc, so
+	// report it like malloc does; otherwise the later free() of an aligned heap
+	// literal (HEAP_align) would emit vheap_free for an untracked pointer.
+	_ht_alloc(res, n)
 	return C.memcpy(res, src, sz)
 }
 

--- a/vlib/builtin/allocation.c.v
+++ b/vlib/builtin/allocation.c.v
@@ -56,6 +56,11 @@ fn _ht_alloc(p &u8, n isize) {
 		$if vgc ? {
 			$compile_error('-d track_heap requires manual memory management; rebuild with `-gc none`')
 		}
+		$if prealloc {
+			// -prealloc bumps from an arena and never frees individually, so the
+			// hooks would see no frees (every alloc shows live forever) — useless.
+			$compile_error('-d track_heap requires manual memory management; rebuild with `-gc none` (not -prealloc)')
+		}
 	}
 	C.vheap_alloc(p, u64(n))
 }

--- a/vlib/builtin/allocation.c.v
+++ b/vlib/builtin/allocation.c.v
@@ -271,7 +271,12 @@ pub fn v_realloc(b &u8, n isize) &u8 {
 	if new_ptr == 0 {
 		_memory_panic(@FN, n)
 	}
-	_ht_free(b)
+	// realloc(nil, …) means "allocate", not "free then allocate" (the stbi
+	// STBI_REALLOC path forwards null `b` here), so only report a free when there
+	// was a real prior block — mirrors the nil guard in free().
+	if b != unsafe { nil } {
+		_ht_free(b)
+	}
 	_ht_alloc(new_ptr, n)
 	return new_ptr
 }
@@ -329,7 +334,10 @@ pub fn realloc_data(old_data &u8, old_size int, new_size int) &u8 {
 	if nptr == 0 {
 		_memory_panic(@FN, isize(new_size))
 	}
-	_ht_free(old_data)
+	// realloc(nil, …) means "allocate"; don't report a free with no prior block.
+	if old_data != unsafe { nil } {
+		_ht_free(old_data)
+	}
 	_ht_alloc(nptr, isize(new_size))
 	return nptr
 }

--- a/vlib/builtin/allocation.c.v
+++ b/vlib/builtin/allocation.c.v
@@ -363,6 +363,7 @@ pub fn vcalloc(n isize) &u8 {
 			if ptr != &u8(unsafe { nil }) {
 				unsafe { C.memset(ptr, 0, n) }
 			}
+			_ht_alloc(ptr, n)
 			return ptr
 		} $else {
 			r := unsafe { C.calloc(1, n) }
@@ -411,7 +412,6 @@ pub fn free(ptr voidptr) {
 	$if trace_free ? {
 		C.fprintf(C.stderr, c'free ptr: %p\n', ptr)
 	}
-	_ht_free(ptr)
 	$if builtin_free_nop ? {
 		return
 	}
@@ -447,6 +447,10 @@ pub fn free(ptr voidptr) {
 			unsafe { C.GC_FREE(ptr) }
 		}
 	} $else {
+		// Manual memory management: this is the only path that actually returns
+		// the block to the C allocator, and it mirrors where _ht_alloc fires, so
+		// report the free here (after the nil / none__ / nop / GC guards above).
+		_ht_free(ptr)
 		$if windows {
 			// Warning! On windows, we always use _aligned_free to free memory.
 			unsafe { C._aligned_free(ptr) }

--- a/vlib/builtin/allocation.c.v
+++ b/vlib/builtin/allocation.c.v
@@ -34,11 +34,29 @@ __global total_m = i64(0)
 // `vheap_free(ptr)`; link an external profiler / leak tracker that implements
 // them to observe live allocations at runtime. The `@[if track_heap ?]` attribute
 // compiles the hooks to no-ops (zero cost) when the flag is off.
+//
+// track_heap models *manual* memory management (`-gc none`): the free hook only
+// fires on the manual-free path, so under a GC the collector reclaims blocks with
+// no matching hook and they would be reported as permanently live. Reject that
+// combination at compile time rather than emit misleading stats. The guard lives
+// in `_ht_alloc`, whose body is only compiled under `-d track_heap`.
 fn C.vheap_alloc(p voidptr, n u64)
 fn C.vheap_free(p voidptr)
 
 @[if track_heap ?]
 fn _ht_alloc(p &u8, n isize) {
+	// `$if track_heap ?` (not just the `@[if track_heap ?]` attribute) is required:
+	// the attribute only elides the call, while the comptime `$compile_error` below
+	// is still evaluated by the checker/`v fmt` under the default flags. Gating on
+	// track_heap keeps it compiled out unless the flag is actually set.
+	$if track_heap ? {
+		$if gcboehm ? {
+			$compile_error('-d track_heap requires manual memory management; rebuild with `-gc none`')
+		}
+		$if vgc ? {
+			$compile_error('-d track_heap requires manual memory management; rebuild with `-gc none`')
+		}
+	}
 	C.vheap_alloc(p, u64(n))
 }
 

--- a/vlib/builtin/allocation.c.v
+++ b/vlib/builtin/allocation.c.v
@@ -28,6 +28,25 @@ fn _memory_panic(fname string, size isize) {
 }
 
 __global total_m = i64(0)
+
+// Opt-in heap allocation hooks, enabled with `-d track_heap`. When the flag is
+// set, every heap allocation calls `vheap_alloc(ptr, size)` and every free calls
+// `vheap_free(ptr)`; link an external profiler / leak tracker that implements
+// them to observe live allocations at runtime. The `@[if track_heap ?]` attribute
+// compiles the hooks to no-ops (zero cost) when the flag is off.
+fn C.vheap_alloc(p voidptr, n u64)
+fn C.vheap_free(p voidptr)
+
+@[if track_heap ?]
+fn _ht_alloc(p &u8, n isize) {
+	C.vheap_alloc(p, u64(n))
+}
+
+@[if track_heap ?]
+fn _ht_free(p voidptr) {
+	C.vheap_free(p)
+}
+
 // malloc dynamically allocates a `n` bytes block of memory on the heap.
 // malloc returns a `byteptr` pointing to the memory address of the allocated space.
 // unlike the `calloc` family of functions - malloc will not zero the memory block.
@@ -77,6 +96,7 @@ pub fn malloc(n isize) &u8 {
 		// when the calling code wrongly relies on it being zeroed.
 		unsafe { C.memset(res, 0x4D, n) }
 	}
+	_ht_alloc(res, n)
 	return res
 }
 
@@ -128,6 +148,7 @@ pub fn malloc_noscan(n isize) &u8 {
 		// when the calling code wrongly relies on it being zeroed.
 		unsafe { C.memset(res, 0x4D, n) }
 	}
+	_ht_alloc(res, n)
 	return res
 }
 
@@ -212,6 +233,7 @@ pub fn malloc_uncollectable(n isize) &u8 {
 		// when the calling code wrongly relies on it being zeroed.
 		unsafe { C.memset(res, 0x4D, n) }
 	}
+	_ht_alloc(res, n)
 	return res
 }
 
@@ -249,6 +271,8 @@ pub fn v_realloc(b &u8, n isize) &u8 {
 	if new_ptr == 0 {
 		_memory_panic(@FN, n)
 	}
+	_ht_free(b)
+	_ht_alloc(new_ptr, n)
 	return new_ptr
 }
 
@@ -305,6 +329,8 @@ pub fn realloc_data(old_data &u8, old_size int, new_size int) &u8 {
 	if nptr == 0 {
 		_memory_panic(@FN, isize(new_size))
 	}
+	_ht_free(old_data)
+	_ht_alloc(nptr, isize(new_size))
 	return nptr
 }
 
@@ -339,7 +365,9 @@ pub fn vcalloc(n isize) &u8 {
 			}
 			return ptr
 		} $else {
-			return unsafe { C.calloc(1, n) }
+			r := unsafe { C.calloc(1, n) }
+			_ht_alloc(r, n)
+			return r
 		}
 	}
 	return &u8(unsafe { nil }) // not reached, TODO: remove when V's checker is improved
@@ -383,6 +411,7 @@ pub fn free(ptr voidptr) {
 	$if trace_free ? {
 		C.fprintf(C.stderr, c'free ptr: %p\n', ptr)
 	}
+	_ht_free(ptr)
 	$if builtin_free_nop ? {
 		return
 	}


### PR DESCRIPTION
## What

Adds two opt-in hooks to `vlib/builtin/allocation.c.v`, gated by `-d track_heap`:

- every heap allocation (`malloc`, `malloc_noscan`, `malloc_uncollectable`, `vcalloc`, `v_realloc`, `realloc_data`) calls `vheap_alloc(ptr, size)`
- every `free` (and the free side of the reallocs) calls `vheap_free(ptr)`

```v
fn C.vheap_alloc(p voidptr, n u64)
fn C.vheap_free(p voidptr)

@[if track_heap ?]
fn _ht_alloc(p &u8, n isize) {
	C.vheap_alloc(p, u64(n))
}

@[if track_heap ?]
fn _ht_free(p voidptr) {
	C.vheap_free(p)
}
```

## Why

Under `-gc none` (manual memory management) a per-frame allocation that is never freed or reused leaks forever, and there is currently no built-in way to attribute live allocations to their call sites. These hooks let an external profiler / leak tracker implement the two `vheap_*` symbols and observe live allocations at runtime (group by backtrace, show live/new/freed totals, etc.). They were used to chase a multi-GB leak in a `-gc none` app down to a single hot allocation site.

## Cost

The `@[if track_heap ?]` attribute compiles `_ht_alloc`/`_ht_free` to no-ops when the flag is off, so there is **zero runtime cost and no external symbol dependency** for normal builds — the `vheap_*` symbols only need to exist when you build with `-d track_heap`.