### PR TITLE
cgen: fix fixed array expression field assignment

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -1441,7 +1441,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 		unaliased_right_sym := g.table.final_sym(unwrapped_val_type)
 		unaliased_left_sym := g.table.final_sym(g.unwrap_generic(var_type))
 		is_fixed_array_var := unaliased_right_sym.kind == .array_fixed && val !is ast.ArrayInit
-			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr, ast.ComptimeSelector, ast.DumpExpr, ast.InfixExpr]
+			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr, ast.ComptimeSelector, ast.DumpExpr, ast.InfixExpr, ast.IfExpr, ast.MatchExpr]
 			|| (val is ast.CastExpr && val.expr !is ast.ArrayInit)
 			|| (val is ast.PrefixExpr && val.op == .arrow)
 			|| (val is ast.UnsafeExpr && val.expr in [ast.SelectorExpr, ast.Ident, ast.CallExpr]))

--- a/vlib/v/tests/fixed_array_expr_field_assign_test.v
+++ b/vlib/v/tests/fixed_array_expr_field_assign_test.v
@@ -1,0 +1,38 @@
+const fixed_array_expr_hi = [u8(1), 2, 3, 4]!
+const fixed_array_expr_lo = [u8(5), 6, 7, 8]!
+
+struct FixedArrayExprMesh {
+mut:
+	highlight [4]u8
+}
+
+fn fixed_array_expr_set_if(mut mesh FixedArrayExprMesh, highlighted bool) {
+	mesh.highlight = if highlighted { fixed_array_expr_hi } else { fixed_array_expr_lo }
+}
+
+fn fixed_array_expr_set_match(mut mesh FixedArrayExprMesh, highlighted bool) {
+	mesh.highlight = match highlighted {
+		true { fixed_array_expr_hi }
+		false { fixed_array_expr_lo }
+	}
+}
+
+fn test_fixed_array_field_assign_from_if_expr() {
+	mut mesh := FixedArrayExprMesh{}
+
+	fixed_array_expr_set_if(mut mesh, true)
+	assert mesh.highlight == fixed_array_expr_hi
+
+	fixed_array_expr_set_if(mut mesh, false)
+	assert mesh.highlight == fixed_array_expr_lo
+}
+
+fn test_fixed_array_field_assign_from_match_expr() {
+	mut mesh := FixedArrayExprMesh{}
+
+	fixed_array_expr_set_match(mut mesh, true)
+	assert mesh.highlight == fixed_array_expr_hi
+
+	fixed_array_expr_set_match(mut mesh, false)
+	assert mesh.highlight == fixed_array_expr_lo
+}


### PR DESCRIPTION
## Summary
- Route fixed-array `if` and `match` expression RHS values through the fixed-array assignment path.
- Add regression coverage for assigning those expressions to fixed-array struct fields.

## Root Cause
Fixed-array RHS classification for normal assignments included identifiers, calls, selectors, and similar expressions, but not `IfExpr` or `MatchExpr`. That let struct field assignments like `mesh.highlight = if highlighted { hi } else { lo }` fall through to plain C array assignment instead of `memcpy`.

## Testing
- `./vnew fmt -w vlib/v/gen/c/assign.v vlib/v/tests/fixed_array_expr_field_assign_test.v`
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent test vlib/v/tests/fixed_array_expr_field_assign_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew -silent test vlib/v/` *(1 unrelated local failure in `vlib/v/builder/builder_test.v`: stdout was prefixed by `tcc compilation failed, falling back to cc`; the single test passed with `VFLAGS='-cc clang'`.)