### PR TITLE
net.http: add synchronous HTTP/2 client connection (H2Conn)

### DIFF
--- a/vlib/net/http/h2_conn.v
+++ b/vlib/net/http/h2_conn.v
@@ -66,16 +66,18 @@ pub mut:
 // H2Conn is a client-side HTTP/2 connection.
 pub struct H2Conn {
 mut:
-	transport      H2Transport
-	encoder        H2HpackEncoder
-	decoder        H2HpackDecoder
-	peer           H2PeerSettings
-	rbuf           []u8      // buffered bytes read from the transport, not yet consumed
-	pending        []H2Frame // stream frames read early (while sending), to replay
-	next_stream_id u32 = 1 // clients use odd stream ids
-	send_window    i64 = 65535
-	handshaked     bool
-	goaway         bool
+	transport          H2Transport
+	encoder            H2HpackEncoder
+	decoder            H2HpackDecoder
+	peer               H2PeerSettings
+	rbuf               []u8      // buffered bytes read from the transport, not yet consumed
+	pending            []H2Frame // stream frames read early (while sending), to replay
+	next_stream_id     u32 = 1 // clients use odd stream ids
+	cur_stream_id      u32 // the stream currently being driven by do()
+	send_window        i64 = 65535 // connection-level send flow-control window
+	stream_send_window i64 // send window for cur_stream_id
+	handshaked         bool
+	goaway             bool
 }
 
 // new_h2_conn creates a client connection over `transport`. The HTTP/2
@@ -94,6 +96,8 @@ pub fn (mut c H2Conn) do(req H2ClientRequest) !H2ClientResponse {
 	}
 	stream_id := c.next_stream_id
 	c.next_stream_id += 2
+	c.cur_stream_id = stream_id
+	c.stream_send_window = i64(c.peer.initial_window_size)
 
 	mut fields := [
 		H2HeaderField{':method', req.method},
@@ -106,12 +110,7 @@ pub fn (mut c H2Conn) do(req H2ClientRequest) !H2ClientResponse {
 	}
 	block := c.encoder.encode(fields)
 	has_body := req.body.len > 0
-	c.send_frame(H2HeadersFrame{
-		stream_id:   stream_id
-		fragment:    block
-		end_headers: true
-		end_stream:  !has_body
-	})!
+	c.send_header_block(stream_id, block, !has_body)!
 	if has_body {
 		c.send_body(stream_id, req.body)!
 	}
@@ -240,10 +239,10 @@ fn (mut c H2Conn) handle_conn_frame(frame H2Frame) !bool {
 			return true
 		}
 		H2WindowUpdateFrame {
-			// Only the connection-level send window is tracked in this
-			// single-stream client; per-stream grants are not yet needed.
 			if frame.stream_id == 0 {
 				c.send_window += i64(frame.window_size_increment)
+			} else if frame.stream_id == c.cur_stream_id {
+				c.stream_send_window += i64(frame.window_size_increment)
 			}
 			return true
 		}
@@ -260,37 +259,95 @@ fn (mut c H2Conn) handle_conn_frame(frame H2Frame) !bool {
 fn (mut c H2Conn) apply_settings(settings []H2Setting) {
 	for s in settings {
 		match s.id {
-			h2_settings_header_table_size { c.peer.header_table_size = s.value }
-			h2_settings_enable_push { c.peer.enable_push = s.value != 0 }
-			h2_settings_max_concurrent_streams { c.peer.max_concurrent_streams = s.value }
-			h2_settings_initial_window_size { c.peer.initial_window_size = s.value }
-			h2_settings_max_frame_size { c.peer.max_frame_size = s.value }
-			h2_settings_max_header_list_size { c.peer.max_header_list_size = s.value }
+			h2_settings_header_table_size {
+				c.peer.header_table_size = s.value
+			}
+			h2_settings_enable_push {
+				c.peer.enable_push = s.value != 0
+			}
+			h2_settings_max_concurrent_streams {
+				c.peer.max_concurrent_streams = s.value
+			}
+			h2_settings_initial_window_size {
+				// RFC 7540 Section 6.9.2: a change to the initial window size
+				// retroactively adjusts the active stream's send window by the
+				// delta.
+				delta := i64(s.value) - i64(c.peer.initial_window_size)
+				c.peer.initial_window_size = s.value
+				c.stream_send_window += delta
+			}
+			h2_settings_max_frame_size {
+				c.peer.max_frame_size = s.value
+			}
+			h2_settings_max_header_list_size {
+				c.peer.max_header_list_size = s.value
+			}
 			else {} // unknown settings are ignored (RFC 7540 Section 6.5.2)
 		}
 	}
 }
 
-// send_body writes the request body as DATA frames, chunked to the peer's
-// max frame size and bounded by the connection-level flow-control window.
+// send_header_block sends an HPACK header block as a HEADERS frame, splitting
+// it across CONTINUATION frames when it exceeds the peer's max frame size
+// (RFC 7540 Section 4.3). END_STREAM, when set, goes on the HEADERS frame.
+fn (mut c H2Conn) send_header_block(stream_id u32, block []u8, end_stream bool) ! {
+	max := int(c.peer.max_frame_size)
+	if block.len <= max {
+		c.send_frame(H2HeadersFrame{
+			stream_id:   stream_id
+			fragment:    block
+			end_headers: true
+			end_stream:  end_stream
+		})!
+		return
+	}
+	c.send_frame(H2HeadersFrame{
+		stream_id:   stream_id
+		fragment:    block[..max]
+		end_headers: false
+		end_stream:  end_stream
+	})!
+	mut off := max
+	for off < block.len {
+		mut next := off + max
+		if next > block.len {
+			next = block.len
+		}
+		c.send_frame(H2ContinuationFrame{
+			stream_id:   stream_id
+			fragment:    block[off..next]
+			end_headers: next == block.len
+		})!
+		off = next
+	}
+}
+
+// send_body writes the request body as DATA frames, chunked to the peer's max
+// frame size and bounded by both the connection and the per-stream send
+// flow-control windows (RFC 7540 Section 6.9).
 fn (mut c H2Conn) send_body(stream_id u32, body []u8) ! {
 	max := int(c.peer.max_frame_size)
 	mut off := 0
 	for off < body.len {
-		for c.send_window <= 0 {
-			// Wait for the peer to grow the window. Connection-level frames are
+		for c.send_window <= 0 || c.stream_send_window <= 0 {
+			// Wait for the peer to grow a window. Connection-level frames are
 			// handled; any stream frames are stashed for read_response.
 			frame := c.next_frame()!
 			if !c.handle_conn_frame(frame)! {
 				c.pending << frame
 			}
 		}
+		avail := if c.send_window < c.stream_send_window {
+			c.send_window
+		} else {
+			c.stream_send_window
+		}
 		mut chunk := body.len - off
 		if chunk > max {
 			chunk = max
 		}
-		if i64(chunk) > c.send_window {
-			chunk = int(c.send_window)
+		if i64(chunk) > avail {
+			chunk = int(avail)
 		}
 		next := off + chunk
 		c.send_frame(H2DataFrame{
@@ -299,6 +356,7 @@ fn (mut c H2Conn) send_body(stream_id u32, body []u8) ! {
 			end_stream: next == body.len
 		})!
 		c.send_window -= i64(chunk)
+		c.stream_send_window -= i64(chunk)
 		off = next
 	}
 }

--- a/vlib/net/http/h2_conn.v
+++ b/vlib/net/http/h2_conn.v
@@ -1,0 +1,375 @@
+// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module http
+
+// This file implements a minimal HTTP/2 client connection (RFC 7540) on top of
+// the framing and HPACK layers. It is intentionally synchronous and handles a
+// single request at a time: it sends one request, then reads frames until that
+// stream completes, servicing connection-level frames (SETTINGS, PING,
+// WINDOW_UPDATE, GOAWAY) inline. Stream multiplexing and a background reader
+// are a follow-up; this is the smallest useful, testable client.
+
+// h2_client_preface is the fixed sequence a client sends to start an HTTP/2
+// connection, immediately followed by a SETTINGS frame (RFC 7540 Section 3.5).
+pub const h2_client_preface = 'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n'
+
+// h2_default_initial_window is the initial flow-control window for both the
+// connection and new streams (RFC 7540 Section 6.9.2).
+pub const h2_default_initial_window = u32(65535)
+
+// h2_conn_read_chunk is the size of each transport read.
+const h2_conn_read_chunk = 16 * 1024
+
+// H2Transport is the byte transport an H2Conn runs over: typically an
+// ALPN-negotiated `h2` TLS connection, but any reader/writer works (which makes
+// the connection testable without a socket). Its method signatures match
+// net.ssl.SSLConn, so an SSLConn satisfies it directly.
+pub interface H2Transport {
+mut:
+	read(mut buf []u8) !int
+	write(buf []u8) !int
+}
+
+// H2PeerSettings holds the peer's SETTINGS, with HTTP/2 defaults.
+struct H2PeerSettings {
+mut:
+	header_table_size      u32  = 4096
+	enable_push            bool = true
+	max_concurrent_streams u32  = max_u32
+	initial_window_size    u32  = 65535
+	max_frame_size         u32  = 16384
+	max_header_list_size   u32  = max_u32
+}
+
+// H2ClientRequest describes a single HTTP/2 request. Header names in `headers`
+// must be lowercase (RFC 7540 Section 8.1.2); the pseudo-headers are filled in
+// from the other fields.
+pub struct H2ClientRequest {
+pub:
+	method    string = 'GET'
+	scheme    string = 'https'
+	authority string
+	path      string = '/'
+	headers   []H2HeaderField
+	body      []u8
+}
+
+// H2ClientResponse is the result of an HTTP/2 request.
+pub struct H2ClientResponse {
+pub mut:
+	status  int
+	headers []H2HeaderField
+	body    []u8
+}
+
+// H2Conn is a client-side HTTP/2 connection.
+pub struct H2Conn {
+mut:
+	transport      H2Transport
+	encoder        H2HpackEncoder
+	decoder        H2HpackDecoder
+	peer           H2PeerSettings
+	rbuf           []u8      // buffered bytes read from the transport, not yet consumed
+	pending        []H2Frame // stream frames read early (while sending), to replay
+	next_stream_id u32 = 1 // clients use odd stream ids
+	send_window    i64 = 65535
+	handshaked     bool
+	goaway         bool
+}
+
+// new_h2_conn creates a client connection over `transport`. The HTTP/2
+// connection preface is sent lazily on the first request.
+pub fn new_h2_conn(transport H2Transport) &H2Conn {
+	return &H2Conn{
+		transport: transport
+	}
+}
+
+// do sends `req` and returns the response, after the request's stream closes.
+pub fn (mut c H2Conn) do(req H2ClientRequest) !H2ClientResponse {
+	c.handshake()!
+	if c.goaway {
+		return error('h2: connection is shutting down (GOAWAY)')
+	}
+	stream_id := c.next_stream_id
+	c.next_stream_id += 2
+
+	mut fields := [
+		H2HeaderField{':method', req.method},
+		H2HeaderField{':scheme', req.scheme},
+		H2HeaderField{':authority', req.authority},
+		H2HeaderField{':path', req.path},
+	]
+	for h in req.headers {
+		fields << h
+	}
+	block := c.encoder.encode(fields)
+	has_body := req.body.len > 0
+	c.send_frame(H2HeadersFrame{
+		stream_id:   stream_id
+		fragment:    block
+		end_headers: true
+		end_stream:  !has_body
+	})!
+	if has_body {
+		c.send_body(stream_id, req.body)!
+	}
+	return c.read_response(stream_id)!
+}
+
+fn (mut c H2Conn) handshake() ! {
+	if c.handshaked {
+		return
+	}
+	c.write_all(h2_client_preface.bytes())!
+	// Advertise our SETTINGS: refuse server push, and use the protocol defaults
+	// otherwise. (Our decoder uses the default 4096-byte HPACK table.)
+	c.send_frame(H2SettingsFrame{
+		settings: [
+			H2Setting{h2_settings_enable_push, 0},
+			H2Setting{h2_settings_initial_window_size, h2_default_initial_window},
+			H2Setting{h2_settings_max_frame_size, h2_default_max_frame_size},
+		]
+	})!
+	c.handshaked = true
+}
+
+// read_response reads frames until `stream_id` is closed, returning its
+// response and servicing connection-level frames along the way.
+fn (mut c H2Conn) read_response(stream_id u32) !H2ClientResponse {
+	mut resp := H2ClientResponse{}
+	mut got_headers := false
+	for {
+		frame := c.next_frame()!
+		if c.handle_conn_frame(frame)! {
+			continue
+		}
+		match frame {
+			H2HeadersFrame {
+				if frame.stream_id != stream_id {
+					continue
+				}
+				fragment := c.collect_header_block(frame.fragment, frame.end_headers, stream_id)!
+				for f in c.decoder.decode(fragment)! {
+					if f.name == ':status' {
+						resp.status = f.value.int()
+					} else if !f.name.starts_with(':') {
+						resp.headers << f
+					}
+				}
+				got_headers = true
+				if frame.end_stream {
+					break
+				}
+			}
+			H2DataFrame {
+				if frame.stream_id != stream_id {
+					continue
+				}
+				resp.body << frame.data
+				if frame.data.len > 0 {
+					// Replenish flow control so the peer keeps sending.
+					c.send_window_update(0, u32(frame.data.len))!
+					c.send_window_update(stream_id, u32(frame.data.len))!
+				}
+				if frame.end_stream {
+					break
+				}
+			}
+			H2RstStreamFrame {
+				if frame.stream_id == stream_id {
+					return error('h2: stream reset by peer (${h2_error_code_name(frame.error_code)})')
+				}
+			}
+			else {
+				// PRIORITY / PUSH_PROMISE / stray CONTINUATION / unknown: ignore.
+			}
+		}
+	}
+	if !got_headers {
+		return error('h2: stream closed without a response')
+	}
+	return resp
+}
+
+// collect_header_block returns the full HPACK block for a HEADERS frame,
+// reading and concatenating CONTINUATION frames until END_HEADERS.
+fn (mut c H2Conn) collect_header_block(first []u8, end_headers bool, stream_id u32) ![]u8 {
+	if end_headers {
+		return first
+	}
+	mut fragment := first.clone()
+	for {
+		frame := c.read_frame()!
+		if frame is H2ContinuationFrame {
+			if frame.stream_id != stream_id {
+				return error('h2: CONTINUATION on the wrong stream')
+			}
+			fragment << frame.fragment
+			if frame.end_headers {
+				break
+			}
+		} else {
+			return error('h2: expected a CONTINUATION frame')
+		}
+	}
+	return fragment
+}
+
+// handle_conn_frame services a connection-level frame, returning true if the
+// frame was fully handled here (so the caller should skip it).
+fn (mut c H2Conn) handle_conn_frame(frame H2Frame) !bool {
+	match frame {
+		H2SettingsFrame {
+			if !frame.ack {
+				c.apply_settings(frame.settings)
+				c.send_frame(H2SettingsFrame{
+					ack: true
+				})!
+			}
+			return true
+		}
+		H2PingFrame {
+			if !frame.ack {
+				c.send_frame(H2PingFrame{
+					ack:  true
+					data: frame.data
+				})!
+			}
+			return true
+		}
+		H2WindowUpdateFrame {
+			// Only the connection-level send window is tracked in this
+			// single-stream client; per-stream grants are not yet needed.
+			if frame.stream_id == 0 {
+				c.send_window += i64(frame.window_size_increment)
+			}
+			return true
+		}
+		H2GoawayFrame {
+			c.goaway = true
+			return error('h2: GOAWAY received (${h2_error_code_name(frame.error_code)})')
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn (mut c H2Conn) apply_settings(settings []H2Setting) {
+	for s in settings {
+		match s.id {
+			h2_settings_header_table_size { c.peer.header_table_size = s.value }
+			h2_settings_enable_push { c.peer.enable_push = s.value != 0 }
+			h2_settings_max_concurrent_streams { c.peer.max_concurrent_streams = s.value }
+			h2_settings_initial_window_size { c.peer.initial_window_size = s.value }
+			h2_settings_max_frame_size { c.peer.max_frame_size = s.value }
+			h2_settings_max_header_list_size { c.peer.max_header_list_size = s.value }
+			else {} // unknown settings are ignored (RFC 7540 Section 6.5.2)
+		}
+	}
+}
+
+// send_body writes the request body as DATA frames, chunked to the peer's
+// max frame size and bounded by the connection-level flow-control window.
+fn (mut c H2Conn) send_body(stream_id u32, body []u8) ! {
+	max := int(c.peer.max_frame_size)
+	mut off := 0
+	for off < body.len {
+		for c.send_window <= 0 {
+			// Wait for the peer to grow the window. Connection-level frames are
+			// handled; any stream frames are stashed for read_response.
+			frame := c.next_frame()!
+			if !c.handle_conn_frame(frame)! {
+				c.pending << frame
+			}
+		}
+		mut chunk := body.len - off
+		if chunk > max {
+			chunk = max
+		}
+		if i64(chunk) > c.send_window {
+			chunk = int(c.send_window)
+		}
+		next := off + chunk
+		c.send_frame(H2DataFrame{
+			stream_id:  stream_id
+			data:       body[off..next]
+			end_stream: next == body.len
+		})!
+		c.send_window -= i64(chunk)
+		off = next
+	}
+}
+
+fn (mut c H2Conn) send_window_update(stream_id u32, inc u32) ! {
+	if inc == 0 {
+		return
+	}
+	c.send_frame(H2WindowUpdateFrame{
+		stream_id:             stream_id
+		window_size_increment: inc
+	})!
+}
+
+// next_frame returns the next frame, replaying any stashed stream frames first.
+fn (mut c H2Conn) next_frame() !H2Frame {
+	if c.pending.len > 0 {
+		f := c.pending[0]
+		c.pending.delete(0)
+		return f
+	}
+	return c.read_frame()!
+}
+
+// read_frame reads and decodes one frame from the transport, enforcing our
+// advertised max frame size.
+fn (mut c H2Conn) read_frame() !H2Frame {
+	c.fill_at_least(h2_frame_header_len)!
+	header := h2_parse_frame_header(c.rbuf)!
+	if header.length > h2_default_max_frame_size {
+		return error('h2: frame larger than SETTINGS_MAX_FRAME_SIZE (${header.length})')
+	}
+	total := h2_frame_header_len + int(header.length)
+	c.fill_at_least(total)!
+	frame := h2_parse_frame(header, c.rbuf[h2_frame_header_len..total])!
+	c.rbuf = c.rbuf[total..].clone()
+	return frame
+}
+
+// fill_at_least reads from the transport until rbuf holds at least n bytes.
+fn (mut c H2Conn) fill_at_least(n int) ! {
+	for c.rbuf.len < n {
+		mut tmp := []u8{len: h2_conn_read_chunk}
+		got := c.transport.read(mut tmp)!
+		if got <= 0 {
+			return error('h2: connection closed by peer')
+		}
+		c.rbuf << tmp[..got]
+	}
+}
+
+fn (mut c H2Conn) send_frame(f H2Frame) ! {
+	c.write_all(f.encode())!
+}
+
+fn (mut c H2Conn) write_all(data []u8) ! {
+	mut sent := 0
+	for sent < data.len {
+		n := c.transport.write(data[sent..])!
+		if n <= 0 {
+			return error('h2: transport write returned ${n}')
+		}
+		sent += n
+	}
+}
+
+// h2_error_code_name renders an HTTP/2 error code, falling back to hex for
+// codes outside the defined range.
+fn h2_error_code_name(code u32) string {
+	if code <= u32(H2ErrorCode.http_1_1_required) {
+		return unsafe { H2ErrorCode(code) }.str()
+	}
+	return 'unknown(0x${code.hex()})'
+}

--- a/vlib/net/http/h2_conn_test.v
+++ b/vlib/net/http/h2_conn_test.v
@@ -272,3 +272,108 @@ fn test_h2_conn_ping_ack() {
 	}
 	assert saw_ping_ack
 }
+
+fn test_h2_conn_splits_large_request_headers() {
+	inbound := build_server_stream([H2HeaderField{':status', '200'}], [])
+	mut t := &MockTransport{
+		inbound: inbound
+	}
+	mut c := new_h2_conn(t)
+	// A header value larger than the default 16 KiB max frame size forces the
+	// request header block to be split across HEADERS + CONTINUATION frames.
+	big := 'x'.repeat(20000)
+	resp := c.do(H2ClientRequest{
+		authority: 'h.example'
+		headers:   [H2HeaderField{'x-big', big}]
+	})!
+	assert resp.status == 200
+
+	mut pos := h2_client_preface.len
+	mut headers_open := false
+	mut continuation_end := false
+	mut block := []u8{}
+	for pos < t.outbound.len {
+		frame, n := h2_read_frame(t.outbound[pos..])!
+		pos += n
+		match frame {
+			H2HeadersFrame {
+				if frame.stream_id == 1 {
+					assert !frame.end_headers // split, so END_HEADERS not on HEADERS
+					headers_open = true
+					block << frame.fragment
+				}
+			}
+			H2ContinuationFrame {
+				if frame.stream_id == 1 {
+					block << frame.fragment
+					if frame.end_headers {
+						continuation_end = true
+					}
+				}
+			}
+			else {}
+		}
+	}
+	assert headers_open
+	assert continuation_end
+	// The reassembled block must decode back to the original header.
+	mut dec := H2HpackDecoder{}
+	fields := dec.decode(block)!
+	assert fields.any(it.name == 'x-big' && it.value == big)
+}
+
+fn test_h2_conn_large_body_flow_control() {
+	// Body larger than the initial 64 KiB window: the client sends up to the
+	// window, waits, then resumes once the peer grows both the connection and
+	// stream windows.
+	body := 'a'.repeat(70000)
+	mut inbound := []u8{}
+	inbound << H2Frame(H2SettingsFrame{}).encode()
+	inbound << H2Frame(H2WindowUpdateFrame{
+		stream_id:             0
+		window_size_increment: 70000
+	}).encode()
+	inbound << H2Frame(H2WindowUpdateFrame{
+		stream_id:             1
+		window_size_increment: 70000
+	}).encode()
+	mut senc := H2HpackEncoder{}
+	inbound << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    senc.encode([H2HeaderField{':status', '200'}])
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	mut t := &MockTransport{
+		inbound: inbound
+	}
+	mut c := new_h2_conn(t)
+	resp := c.do(H2ClientRequest{
+		method:    'POST'
+		authority: 'h.example'
+		path:      '/upload'
+		body:      body.bytes()
+	})!
+	assert resp.status == 200
+
+	// The client must have sent the entire body, ending with END_STREAM, and no
+	// single DATA frame may exceed the max frame size.
+	mut pos := h2_client_preface.len
+	mut sent := 0
+	mut ended := false
+	for pos < t.outbound.len {
+		frame, n := h2_read_frame(t.outbound[pos..])!
+		pos += n
+		if frame is H2DataFrame {
+			if frame.stream_id == 1 {
+				assert frame.data.len <= int(h2_default_max_frame_size)
+				sent += frame.data.len
+				if frame.end_stream {
+					ended = true
+				}
+			}
+		}
+	}
+	assert sent == body.len
+	assert ended
+}

--- a/vlib/net/http/h2_conn_test.v
+++ b/vlib/net/http/h2_conn_test.v
@@ -1,0 +1,274 @@
+module http
+
+// Tests for the synchronous HTTP/2 client connection, driven over an in-memory
+// transport so no socket is required.
+
+// MockTransport plays a fixed script of server->client bytes and records what
+// the client writes.
+struct MockTransport {
+mut:
+	inbound  []u8 // server -> client; the client reads these
+	rpos     int
+	outbound []u8 // client -> server; what the client wrote
+}
+
+fn (mut m MockTransport) read(mut buf []u8) !int {
+	if m.rpos >= m.inbound.len {
+		return error('eof')
+	}
+	mut n := m.inbound.len - m.rpos
+	if n > buf.len {
+		n = buf.len
+	}
+	for i in 0 .. n {
+		buf[i] = m.inbound[m.rpos + i]
+	}
+	m.rpos += n
+	return n
+}
+
+fn (mut m MockTransport) write(buf []u8) !int {
+	m.outbound << buf
+	return buf.len
+}
+
+// build_server_stream encodes a server-side response on stream 1: SETTINGS, an
+// ACK of our SETTINGS, a HEADERS frame, and optional DATA frames.
+fn build_server_stream(resp_fields []H2HeaderField, body_chunks [][]u8) []u8 {
+	mut senc := H2HpackEncoder{}
+	hdr := senc.encode(resp_fields)
+	mut out := []u8{}
+	out << H2Frame(H2SettingsFrame{}).encode()
+	out << H2Frame(H2SettingsFrame{
+		ack: true
+	}).encode()
+	last_is_headers := body_chunks.len == 0
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    hdr
+		end_headers: true
+		end_stream:  last_is_headers
+	}).encode()
+	for i, chunk in body_chunks {
+		out << H2Frame(H2DataFrame{
+			stream_id:  1
+			data:       chunk
+			end_stream: i == body_chunks.len - 1
+		}).encode()
+	}
+	return out
+}
+
+fn test_h2_conn_basic_get() {
+	inbound := build_server_stream([
+		H2HeaderField{':status', '200'},
+		H2HeaderField{'content-type', 'text/plain'},
+	], [' hello'.bytes()])
+	mut t := &MockTransport{
+		inbound: inbound
+	}
+	mut c := new_h2_conn(t)
+	resp := c.do(H2ClientRequest{
+		method:    'GET'
+		authority: 'example.com'
+		path:      '/'
+	})!
+	assert resp.status == 200
+	assert resp.body.bytestr() == ' hello'
+	assert resp.headers.any(it.name == 'content-type' && it.value == 'text/plain')
+
+	// The client must open with the connection preface.
+	assert t.outbound.len > h2_client_preface.len
+	assert t.outbound[..h2_client_preface.len].bytestr() == h2_client_preface
+
+	// First client frame after the preface is its SETTINGS.
+	f1, n1 := h2_read_frame(t.outbound[h2_client_preface.len..])!
+	assert f1 is H2SettingsFrame
+
+	// Next is the request HEADERS on stream 1; decode and check pseudo-headers.
+	f2, _ := h2_read_frame(t.outbound[h2_client_preface.len + n1..])!
+	headers := f2 as H2HeadersFrame
+	assert headers.stream_id == 1
+	assert headers.end_stream // GET with no body
+	mut dec := H2HpackDecoder{}
+	req_fields := dec.decode(headers.fragment)!
+	assert req_fields.any(it.name == ':method' && it.value == 'GET')
+	assert req_fields.any(it.name == ':scheme' && it.value == 'https')
+	assert req_fields.any(it.name == ':authority' && it.value == 'example.com')
+	assert req_fields.any(it.name == ':path' && it.value == '/')
+}
+
+fn test_h2_conn_multi_data_frames() {
+	inbound := build_server_stream([H2HeaderField{':status', '200'}], [
+		'foo'.bytes(),
+		'bar'.bytes(),
+		'baz'.bytes(),
+	])
+	mut t := &MockTransport{
+		inbound: inbound
+	}
+	mut c := new_h2_conn(t)
+	resp := c.do(H2ClientRequest{ authority: 'h.example' })!
+	assert resp.status == 200
+	assert resp.body.bytestr() == 'foobarbaz'
+}
+
+fn test_h2_conn_post_body() {
+	inbound := build_server_stream([H2HeaderField{':status', '201'}], [])
+	mut t := &MockTransport{
+		inbound: inbound
+	}
+	mut c := new_h2_conn(t)
+	resp := c.do(H2ClientRequest{
+		method:    'POST'
+		authority: 'h.example'
+		path:      '/submit'
+		body:      'payload-data'.bytes()
+	})!
+	assert resp.status == 201
+
+	// Walk the client's frames and confirm a DATA frame carried the body with
+	// END_STREAM, after a HEADERS frame that did not end the stream.
+	mut pos := h2_client_preface.len
+	mut saw_headers_open := false
+	mut data_payload := []u8{}
+	mut data_end := false
+	for pos < t.outbound.len {
+		frame, n := h2_read_frame(t.outbound[pos..])!
+		pos += n
+		match frame {
+			H2HeadersFrame {
+				if frame.stream_id == 1 {
+					assert !frame.end_stream
+					saw_headers_open = true
+				}
+			}
+			H2DataFrame {
+				if frame.stream_id == 1 {
+					data_payload << frame.data
+					if frame.end_stream {
+						data_end = true
+					}
+				}
+			}
+			else {}
+		}
+	}
+	assert saw_headers_open
+	assert data_end
+	assert data_payload.bytestr() == 'payload-data'
+}
+
+fn test_h2_conn_goaway_errors() {
+	mut inbound := []u8{}
+	inbound << H2Frame(H2SettingsFrame{}).encode()
+	inbound << H2Frame(H2GoawayFrame{
+		last_stream_id: 0
+		error_code:     u32(H2ErrorCode.protocol_error)
+	}).encode()
+	mut t := &MockTransport{
+		inbound: inbound
+	}
+	mut c := new_h2_conn(t)
+	c.do(H2ClientRequest{ authority: 'h.example' }) or {
+		assert err.msg().contains('GOAWAY')
+		assert err.msg().contains('PROTOCOL_ERROR')
+		return
+	}
+	assert false, 'expected GOAWAY error'
+}
+
+fn test_h2_conn_rst_stream_errors() {
+	mut senc := H2HpackEncoder{}
+	mut inbound := []u8{}
+	inbound << H2Frame(H2SettingsFrame{}).encode()
+	inbound << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    senc.encode([H2HeaderField{':status', '200'}])
+		end_headers: true
+	}).encode()
+	inbound << H2Frame(H2RstStreamFrame{
+		stream_id:  1
+		error_code: u32(H2ErrorCode.internal_error)
+	}).encode()
+	mut t := &MockTransport{
+		inbound: inbound
+	}
+	mut c := new_h2_conn(t)
+	c.do(H2ClientRequest{ authority: 'h.example' }) or {
+		assert err.msg().contains('reset')
+		return
+	}
+	assert false, 'expected RST_STREAM error'
+}
+
+fn test_h2_conn_continuation() {
+	// Split the response header block across HEADERS + CONTINUATION.
+	mut senc := H2HpackEncoder{}
+	full := senc.encode([
+		H2HeaderField{':status', '200'},
+		H2HeaderField{'x-test', 'continued'},
+	])
+	split := full.len / 2
+	mut inbound := []u8{}
+	inbound << H2Frame(H2SettingsFrame{}).encode()
+	inbound << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    full[..split]
+		end_headers: false
+	}).encode()
+	inbound << H2Frame(H2ContinuationFrame{
+		stream_id:   1
+		fragment:    full[split..]
+		end_headers: true
+	}).encode()
+	inbound << H2Frame(H2DataFrame{
+		stream_id:  1
+		data:       'ok'.bytes()
+		end_stream: true
+	}).encode()
+	mut t := &MockTransport{
+		inbound: inbound
+	}
+	mut c := new_h2_conn(t)
+	resp := c.do(H2ClientRequest{ authority: 'h.example' })!
+	assert resp.status == 200
+	assert resp.body.bytestr() == 'ok'
+	assert resp.headers.any(it.name == 'x-test' && it.value == 'continued')
+}
+
+fn test_h2_conn_ping_ack() {
+	// A server PING before the response must be answered with a PING ACK.
+	mut senc := H2HpackEncoder{}
+	mut inbound := []u8{}
+	inbound << H2Frame(H2SettingsFrame{}).encode()
+	inbound << H2Frame(H2PingFrame{
+		data: [u8(1), 2, 3, 4, 5, 6, 7, 8]
+	}).encode()
+	inbound << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    senc.encode([H2HeaderField{':status', '204'}])
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	mut t := &MockTransport{
+		inbound: inbound
+	}
+	mut c := new_h2_conn(t)
+	resp := c.do(H2ClientRequest{ authority: 'h.example' })!
+	assert resp.status == 204
+
+	// Find a PING ACK in the client's output carrying the same opaque data.
+	mut pos := h2_client_preface.len
+	mut saw_ping_ack := false
+	for pos < t.outbound.len {
+		frame, n := h2_read_frame(t.outbound[pos..])!
+		pos += n
+		if frame is H2PingFrame {
+			if frame.ack && frame.data == [u8(1), 2, 3, 4, 5, 6, 7, 8] {
+				saw_ping_ack = true
+			}
+		}
+	}
+	assert saw_ping_ack
+}


### PR DESCRIPTION
## What

Adds a minimal, synchronous, single-stream **HTTP/2 client connection** to
`net.http`, building on the now-merged ALPN (#27343), HPACK (#27353), and
frame-codec (#27356) PRs.

**Purely additive** — new files in the `http` module, no change to any existing
code path. Nothing wires it into `http.fetch` yet (that ALPN shim is the next
PR), so there is no user-visible behaviour change.

## Files

| File | Contents |
|------|----------|
| `h2_conn.v` | `H2Transport` interface, `H2Conn`, `H2ClientRequest`/`H2ClientResponse`, the request/response state machine |
| `h2_conn_test.v` | Hermetic tests over an in-memory transport |

## Design

- **`H2Transport` interface** — the byte transport the connection runs over. Its
  `read`/`write` signatures match `net.ssl.SSLConn`, so an ALPN-negotiated `h2`
  TLS socket satisfies it directly; tests use an in-memory mock, so the
  connection logic is exercised **without a socket**.
- **Handshake** — connection preface + SETTINGS, sent lazily on the first
  request.
- **`H2Conn.do(req)`** — HPACK-encodes the request headers, sends HEADERS (plus
  DATA for a body, chunked to the peer's `SETTINGS_MAX_FRAME_SIZE` and bounded
  by the connection flow-control window), then reads frames until the stream
  closes.
- **Connection-frame servicing**, inline: SETTINGS (apply + ACK), PING (echo
  ACK), WINDOW_UPDATE (grow the send window), GOAWAY (fail). Receive-side flow
  control is replenished with a WINDOW_UPDATE per DATA frame.
- **CONTINUATION reassembly** for response header blocks; **RST_STREAM** on the
  request stream is surfaced as an error.

This is deliberately **synchronous and single-stream** — the smallest shape that
is genuinely useful and fully testable. Stream multiplexing (with a background
reader thread) is a clear follow-up.

## Tests

`h2_conn_test.v` (internal `module http` test) drives the client over a
`MockTransport` that plays a scripted server side and records what the client
writes. Coverage:

- basic GET (asserts the preface, the client SETTINGS, and the request
  pseudo-headers by HPACK-decoding the client's HEADERS frame),
- multi-DATA-frame response body,
- POST with a request body (verifies HEADERS-without-END_STREAM then a DATA
  frame with END_STREAM),
- GOAWAY and RST_STREAM surfaced as errors,
- CONTINUATION-split response headers,
- PING answered with a PING ACK.

```
./vnew test vlib/net/http/h2_conn_test.v                       # passes
./vnew -W -cstrict -cc clang test vlib/net/http/h2_conn_test.v # passes
./vnew -silent test vlib/net/http/                             # 17 passed, 1 skipped (Windows)
```

## Roadmap

Next steps, each its own PR:
1. Wire this into `http.fetch` via ALPN (`h2` negotiated → use `H2Conn`, else the
   existing HTTP/1.1 path) — the user-facing unification.
2. Stream multiplexing + connection pooling (the HTTP/2 performance win).
3. Server-side HTTP/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)