### PR TITLE
net.http: negotiate HTTP/2 in fetch via ALPN (opt-in)

### DIFF
--- a/vlib/net/http/backend.c.v
+++ b/vlib/net/http/backend.c.v
@@ -21,6 +21,9 @@ fn net_ssl_do(req &Request, port int, method Method, host_name string, path stri
 		eprint(req_headers)
 		eprintln('')
 	}
+	// Advertise ALPN `h2` (with an `http/1.1` fallback) only when HTTP/2 is
+	// requested, so existing callers see no change on the wire.
+	alpn := if req.enable_http2 { ['h2', 'http/1.1'] } else { []string{} }
 	for {
 		mut ssl_conn := ssl.new_ssl_conn(
 			verify:                 req.verify
@@ -28,6 +31,7 @@ fn net_ssl_do(req &Request, port int, method Method, host_name string, path stri
 			cert_key:               req.cert_key
 			validate:               req.validate
 			in_memory_verification: req.in_memory_verification
+			alpn_protocols:         alpn
 		)!
 		ssl_conn.dial(host_name, port) or {
 			retries++
@@ -42,9 +46,30 @@ fn net_ssl_do(req &Request, port int, method Method, host_name string, path stri
 		if req.read_timeout > 0 {
 			ssl_conn.set_read_timeout(req.read_timeout)
 		}
+		// If the server negotiated HTTP/2 via ALPN, speak it; otherwise fall
+		// back to the existing HTTP/1.1 path unchanged.
+		if req.enable_http2 && ssl_conn.negotiated_alpn() == 'h2' {
+			return req.h2_do(mut ssl_conn, method, host_name, port, path, data, header)!
+		}
 		return req.do_request(req_headers, mut ssl_conn)!
 	}
 	return error('http.net_ssl_do: exhausted retries')
+}
+
+// h2_do runs a single request over an HTTP/2 connection on an already-dialled,
+// ALPN-negotiated `h2` TLS socket, and returns the response as a net.http
+// Response.
+fn (req &Request) h2_do(mut ssl_conn ssl.SSLConn, method Method, host_name string, port int, path string, data string, header Header) !Response {
+	defer {
+		ssl_conn.shutdown() or {}
+	}
+	h2req := req.to_h2_request(method, h2_authority(host_name, port), path, data, header)
+	mut conn := new_h2_conn(ssl_conn)
+	h2resp := conn.do(h2req)!
+	if req.on_finish != unsafe { nil } {
+		req.on_finish(req, u64(h2resp.body.len))!
+	}
+	return h2_response_to_http(h2resp)
 }
 
 fn read_from_ssl_connection_cb(con voidptr, buf &u8, bufsize int) !int {

--- a/vlib/net/http/backend.c.v
+++ b/vlib/net/http/backend.c.v
@@ -22,8 +22,13 @@ fn net_ssl_do(req &Request, port int, method Method, host_name string, path stri
 		eprintln('')
 	}
 	// Advertise ALPN `h2` (with an `http/1.1` fallback) only when HTTP/2 is
-	// requested, so existing callers see no change on the wire.
-	alpn := if req.enable_http2 { ['h2', 'http/1.1'] } else { []string{} }
+	// requested, so existing callers see no change on the wire. Requests that
+	// rely on streaming response callbacks or stop limits stay on HTTP/1.1,
+	// since the HTTP/2 path buffers the full response; the ALPN offer is gated
+	// here (before negotiation) because once a server selects `h2` we cannot
+	// fall back to HTTP/1.1 framing on the same connection.
+	use_h2 := req.enable_http2 && !req.uses_response_streaming()
+	alpn := if use_h2 { ['h2', 'http/1.1'] } else { []string{} }
 	for {
 		mut ssl_conn := ssl.new_ssl_conn(
 			verify:                 req.verify
@@ -48,7 +53,7 @@ fn net_ssl_do(req &Request, port int, method Method, host_name string, path stri
 		}
 		// If the server negotiated HTTP/2 via ALPN, speak it; otherwise fall
 		// back to the existing HTTP/1.1 path unchanged.
-		if req.enable_http2 && ssl_conn.negotiated_alpn() == 'h2' {
+		if use_h2 && ssl_conn.negotiated_alpn() == 'h2' {
 			return req.h2_do(mut ssl_conn, method, host_name, port, path, data, header)!
 		}
 		return req.do_request(req_headers, mut ssl_conn)!

--- a/vlib/net/http/h2_client.v
+++ b/vlib/net/http/h2_client.v
@@ -27,6 +27,14 @@ fn h2_authority(host string, port int) string {
 // lowercased, hop-by-hop headers are dropped, the Host header becomes the
 // :authority pseudo-header, and cookies are collapsed into a single field.
 fn (req &Request) to_h2_request(method Method, authority string, path string, data string, header Header) H2ClientRequest {
+	// An explicit Host header overrides the URL host, matching the HTTP/1.1
+	// path (used for virtual-host / host-override requests).
+	mut auth := authority
+	if host := header.get(.host) {
+		if host != '' {
+			auth = host
+		}
+	}
 	mut extra := []H2HeaderField{}
 	if !header.contains(.user_agent) && req.user_agent != '' {
 		extra << H2HeaderField{'user-agent', req.user_agent}
@@ -58,11 +66,20 @@ fn (req &Request) to_h2_request(method Method, authority string, path string, da
 	return H2ClientRequest{
 		method:    method.str()
 		scheme:    'https'
-		authority: authority
+		authority: auth
 		path:      path
 		headers:   extra
 		body:      data.bytes()
 	}
+}
+
+// uses_response_streaming reports whether the request relies on streaming
+// response callbacks or stop limits. The HTTP/2 path buffers the full response,
+// so such requests must not negotiate HTTP/2 and instead use the HTTP/1.1 path,
+// which honors these. (Streaming over HTTP/2 is a planned follow-up.)
+fn (req &Request) uses_response_streaming() bool {
+	return req.on_progress != unsafe { nil } || req.on_progress_body != unsafe { nil }
+		|| req.stop_copying_limit >= 0 || req.stop_receiving_limit >= 0
 }
 
 // h2_response_to_http converts an HTTP/2 response into a net.http Response,

--- a/vlib/net/http/h2_client.v
+++ b/vlib/net/http/h2_client.v
@@ -1,0 +1,84 @@
+// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module http
+
+// This file converts between net.http's Request/Response and the HTTP/2
+// client types in h2_conn.v. The actual transport wiring (ALPN negotiation on
+// the TLS socket) lives in backend.c.v; these helpers are pure and backend
+// agnostic, so they can be tested without a socket.
+
+// h2_hop_by_hop are header names that must not be forwarded on HTTP/2
+// (RFC 7540 Section 8.1.2.2), plus `host` (replaced by the :authority
+// pseudo-header) and `cookie` (handled specially below).
+const h2_hop_by_hop = ['connection', 'keep-alive', 'proxy-connection', 'transfer-encoding', 'upgrade',
+	'host', 'cookie']
+
+// h2_authority returns the :authority value for a host and port, omitting the
+// port for the default HTTPS port.
+fn h2_authority(host string, port int) string {
+	if port == 443 || port == 0 {
+		return host
+	}
+	return '${host}:${port}'
+}
+
+// to_h2_request builds an HTTP/2 request from this request. Header names are
+// lowercased, hop-by-hop headers are dropped, the Host header becomes the
+// :authority pseudo-header, and cookies are collapsed into a single field.
+fn (req &Request) to_h2_request(method Method, authority string, path string, data string, header Header) H2ClientRequest {
+	mut extra := []H2HeaderField{}
+	if !header.contains(.user_agent) && req.user_agent != '' {
+		extra << H2HeaderField{'user-agent', req.user_agent}
+	}
+	if data.len > 0 && !header.contains(.content_length) {
+		extra << H2HeaderField{'content-length', data.len.str()}
+	}
+	for key in header.keys() {
+		lkey := key.to_lower()
+		if lkey in h2_hop_by_hop {
+			continue
+		}
+		for val in header.custom_values(key) {
+			extra << H2HeaderField{lkey, val}
+		}
+	}
+	// Cookies: the request's own cookie map plus any Cookie header values,
+	// joined into one field (RFC 7540 Section 8.1.2.5 also allows splitting).
+	mut cookie_parts := []string{}
+	for k, v in req.cookies {
+		cookie_parts << '${k}=${v}'
+	}
+	for cv in header.values(.cookie) {
+		cookie_parts << cv
+	}
+	if cookie_parts.len > 0 {
+		extra << H2HeaderField{'cookie', cookie_parts.join('; ')}
+	}
+	return H2ClientRequest{
+		method:    method.str()
+		scheme:    'https'
+		authority: authority
+		path:      path
+		headers:   extra
+		body:      data.bytes()
+	}
+}
+
+// h2_response_to_http converts an HTTP/2 response into a net.http Response,
+// decoding any Content-Encoding the same way the HTTP/1.1 path does.
+fn h2_response_to_http(h2resp H2ClientResponse) Response {
+	mut h := new_header()
+	for f in h2resp.headers {
+		h.add_custom(f.name, f.value) or {}
+	}
+	body := decode_response_body(h2resp.body.bytestr(), h.get(.content_encoding) or { '' })
+	status := status_from_int(h2resp.status)
+	return Response{
+		http_version: '2.0'
+		status_code:  h2resp.status
+		status_msg:   status.str()
+		header:       h
+		body:         body
+	}
+}

--- a/vlib/net/http/h2_client_test.v
+++ b/vlib/net/http/h2_client_test.v
@@ -93,3 +93,36 @@ fn test_http2_fetch_real_server() {
 	plain := get('https://www.google.com/')!
 	assert plain.version() == .v1_1
 }
+
+fn test_to_h2_request_authority_from_host_header() {
+	mut h := new_header()
+	h.add(.host, 'override.example:8443')
+	req := Request{}
+	// The URL host is origin.example, but an explicit Host header must win.
+	h2req := req.to_h2_request(.get, 'origin.example', '/', '', h)
+	assert h2req.authority == 'override.example:8443'
+	assert !h2req.headers.any(it.name == 'host')
+}
+
+fn test_uses_response_streaming() {
+	assert !(Request{}).uses_response_streaming()
+	assert (Request{
+		stop_copying_limit: 0
+	}).uses_response_streaming()
+	assert (Request{
+		stop_receiving_limit: 100
+	}).uses_response_streaming()
+	progress := fn (request &Request, chunk []u8, read_so_far u64) ! {}
+	assert (Request{
+		on_progress: progress
+	}).uses_response_streaming()
+	body_progress := fn (request &Request, chunk []u8, body_read_so_far u64, body_expected_size u64, status_code int) ! {}
+	assert (Request{
+		on_progress_body: body_progress
+	}).uses_response_streaming()
+	// A non-streaming callback (on_finish) does not force HTTP/1.1.
+	finish := fn (request &Request, final_size u64) ! {}
+	assert !(Request{
+		on_finish: finish
+	}).uses_response_streaming()
+}

--- a/vlib/net/http/h2_client_test.v
+++ b/vlib/net/http/h2_client_test.v
@@ -1,0 +1,95 @@
+module http
+
+// Tests for the HTTP/2 <-> net.http conversion glue (h2_client.v). The
+// request/response conversions are pure and need no socket; the end-to-end
+// fetch test is opt-in and network-dependent.
+
+fn test_to_h2_request_pseudo_headers_and_body() {
+	req := Request{
+		user_agent: 'v.http'
+	}
+	h2req := req.to_h2_request(.post, 'example.com', '/p?q=1', 'hello', new_header())
+	assert h2req.method == 'POST'
+	assert h2req.scheme == 'https'
+	assert h2req.authority == 'example.com'
+	assert h2req.path == '/p?q=1'
+	assert h2req.body.bytestr() == 'hello'
+	// user-agent (from the request) and a synthesized content-length.
+	assert h2req.headers.any(it.name == 'user-agent' && it.value == 'v.http')
+	assert h2req.headers.any(it.name == 'content-length' && it.value == '5')
+}
+
+fn test_to_h2_request_lowercases_and_keeps_custom_headers() {
+	mut h := new_header()
+	h.add_custom('Accept', 'application/json') or {}
+	h.add(.content_type, 'text/plain')
+	req := Request{}
+	h2req := req.to_h2_request(.get, 'h.example', '/', '', h)
+	assert h2req.headers.any(it.name == 'accept' && it.value == 'application/json')
+	assert h2req.headers.any(it.name == 'content-type' && it.value == 'text/plain')
+}
+
+fn test_to_h2_request_strips_hop_by_hop_and_host() {
+	mut h := new_header()
+	h.add(.connection, 'keep-alive')
+	h.add(.host, 'example.com')
+	h.add_custom('Transfer-Encoding', 'chunked') or {}
+	req := Request{}
+	h2req := req.to_h2_request(.get, 'example.com', '/', '', h)
+	assert !h2req.headers.any(it.name == 'connection')
+	assert !h2req.headers.any(it.name == 'host')
+	assert !h2req.headers.any(it.name == 'transfer-encoding')
+}
+
+fn test_to_h2_request_collapses_cookies() {
+	mut h := new_header()
+	h.add(.cookie, 'a=1')
+	req := Request{
+		cookies: {
+			'sid': 'abc'
+		}
+	}
+	h2req := req.to_h2_request(.get, 'h.example', '/', '', h)
+	cookie := h2req.headers.filter(it.name == 'cookie')
+	assert cookie.len == 1
+	// Both the request cookie map and the Cookie header value are present.
+	assert cookie[0].value.contains('sid=abc')
+	assert cookie[0].value.contains('a=1')
+}
+
+fn test_h2_response_to_http() {
+	h2resp := H2ClientResponse{
+		status:  200
+		headers: [H2HeaderField{'content-type', 'text/plain'},
+			H2HeaderField{'x-foo', 'bar'}]
+		body:    'hi'.bytes()
+	}
+	resp := h2_response_to_http(h2resp)
+	assert resp.status_code == 200
+	assert resp.http_version == '2.0'
+	assert resp.version() == .v2_0
+	assert resp.body == 'hi'
+	assert (resp.header.get_custom('content-type') or { '' }) == 'text/plain'
+	assert (resp.header.get_custom('x-foo') or { '' }) == 'bar'
+}
+
+fn test_h2_authority_omits_default_port() {
+	assert h2_authority('example.com', 443) == 'example.com'
+	assert h2_authority('example.com', 0) == 'example.com'
+	assert h2_authority('example.com', 8443) == 'example.com:8443'
+}
+
+// Opt-in end-to-end test against a real HTTP/2 server. Run with `-d network`,
+// e.g. `v -d network test vlib/net/http/h2_client_test.v`.
+fn test_http2_fetch_real_server() {
+	$if !network ? {
+		return
+	}
+	resp := fetch(url: 'https://www.google.com/', enable_http2: true)!
+	assert resp.version() == .v2_0
+	assert resp.status_code == 200
+	assert resp.body.len > 0
+	// Without opting in, the same server is reached over HTTP/1.1.
+	plain := get('https://www.google.com/')!
+	assert plain.version() == .v1_1
+}

--- a/vlib/net/http/h2_conn_test.v
+++ b/vlib/net/http/h2_conn_test.v
@@ -377,3 +377,26 @@ fn test_h2_conn_large_body_flow_control() {
 	assert sent == body.len
 	assert ended
 }
+
+fn test_h2_fetch_glue_roundtrip() {
+	// Drive the full conversion glue (Request -> H2 -> Response) over the mock
+	// transport, without a socket.
+	inbound := build_server_stream([
+		H2HeaderField{':status', '200'},
+		H2HeaderField{'content-type', 'text/plain'},
+	], [' world'.bytes()])
+	mut t := &MockTransport{
+		inbound: inbound
+	}
+	req := Request{
+		user_agent: 'v.http'
+	}
+	h2req := req.to_h2_request(.get, 'example.com', '/', '', new_header())
+	mut c := new_h2_conn(t)
+	h2resp := c.do(h2req)!
+	resp := h2_response_to_http(h2resp)
+	assert resp.status_code == 200
+	assert resp.version() == .v2_0
+	assert resp.body == ' world'
+	assert (resp.header.get_custom('content-type') or { '' }) == 'text/plain'
+}

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -36,7 +36,7 @@ pub mut:
 	in_memory_verification bool   // if true, verify, cert, and cert_key are read from memory, not from a file
 	allow_redirect         bool = true // whether to allow redirect
 	max_retries            int  = 5    // maximum number of retries required when an underlying socket error occurs
-	enable_http2           bool // opt in to HTTP/2 over TLS: advertise ALPN `h2` and, if the server selects it, speak HTTP/2 instead of HTTP/1.1
+	enable_http2           bool // opt in to HTTP/2 over TLS: advertise ALPN `h2` and, if the server selects it, speak HTTP/2 instead of HTTP/1.1. Requests using streaming response callbacks (on_progress/on_progress_body) or stop limits stay on HTTP/1.1, since the HTTP/2 path buffers the full response.
 	// callbacks to allow custom reporting code to run, while the request is running, and to implement streaming
 	on_redirect      RequestRedirectFn     = unsafe { nil }
 	on_progress      RequestProgressFn     = unsafe { nil }

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -36,6 +36,7 @@ pub mut:
 	in_memory_verification bool   // if true, verify, cert, and cert_key are read from memory, not from a file
 	allow_redirect         bool = true // whether to allow redirect
 	max_retries            int  = 5    // maximum number of retries required when an underlying socket error occurs
+	enable_http2           bool // opt in to HTTP/2 over TLS: advertise ALPN `h2` and, if the server selects it, speak HTTP/2 instead of HTTP/1.1
 	// callbacks to allow custom reporting code to run, while the request is running, and to implement streaming
 	on_redirect      RequestRedirectFn     = unsafe { nil }
 	on_progress      RequestProgressFn     = unsafe { nil }
@@ -188,6 +189,7 @@ pub fn prepare(config FetchConfig) !Request {
 		in_memory_verification: config.in_memory_verification
 		allow_redirect:         config.allow_redirect
 		max_retries:            config.max_retries
+		enable_http2:           config.enable_http2
 		on_progress:            config.on_progress
 		on_progress_body:       config.on_progress_body
 		on_redirect:            config.on_redirect

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -46,7 +46,7 @@ pub mut:
 	in_memory_verification bool // if true, verify, cert, and cert_key are read from memory, not from a file
 	allow_redirect         bool = true // whether to allow redirect
 	max_retries            int  = 5    // maximum number of retries required when an underlying socket error occurs
-	enable_http2           bool // opt in to HTTP/2 over TLS: advertise ALPN `h2` and, if the server selects it, speak HTTP/2 instead of HTTP/1.1
+	enable_http2           bool // opt in to HTTP/2 over TLS: advertise ALPN `h2` and, if the server selects it, speak HTTP/2 instead of HTTP/1.1. Requests using streaming response callbacks (on_progress/on_progress_body) or stop limits stay on HTTP/1.1, since the HTTP/2 path buffers the full response.
 	// callbacks to allow custom reporting code to run, while the request is running, and to implement streaming
 	on_redirect      RequestRedirectFn     = unsafe { nil }
 	on_progress      RequestProgressFn     = unsafe { nil }

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -46,6 +46,7 @@ pub mut:
 	in_memory_verification bool // if true, verify, cert, and cert_key are read from memory, not from a file
 	allow_redirect         bool = true // whether to allow redirect
 	max_retries            int  = 5    // maximum number of retries required when an underlying socket error occurs
+	enable_http2           bool // opt in to HTTP/2 over TLS: advertise ALPN `h2` and, if the server selects it, speak HTTP/2 instead of HTTP/1.1
 	// callbacks to allow custom reporting code to run, while the request is running, and to implement streaming
 	on_redirect      RequestRedirectFn     = unsafe { nil }
 	on_progress      RequestProgressFn     = unsafe { nil }


### PR DESCRIPTION
## What

Wires the HTTP/2 client connection (#27361) into the existing fetch path so a
**single `http.fetch` call transparently speaks HTTP/2** when the server
supports it, and HTTP/1.1 otherwise. This is the user-facing unification of the
HTTP/2 work (ALPN #27343, HPACK #27353, frames #27356, client #27361), now that
all of its dependencies have merged.

```v
resp := http.fetch(url: 'https://example.com/', enable_http2: true)!
assert resp.version() == .v2_0 // when the server offers h2
```

## Changes

| File | Change |
|------|--------|
| `request.v`, `http.v` | add the opt-in `enable_http2` field to `Request` and `FetchConfig` (and copy it through `prepare`) |
| `backend.c.v` | advertise ALPN `h2, http/1.1` when enabled; if the server selects `h2`, run over `H2Conn` (`h2_do`), else the existing HTTP/1.1 path unchanged |
| `h2_client.v` | pure conversion glue: Request → H2 request and H2 response → Response |
| `h2_client_test.v`, `h2_conn_test.v` | tests |

## Design

- **Opt-in, default off.** `enable_http2` defaults to `false`, so existing
  callers are completely unaffected and no ALPN extension is sent. A follow-up
  can flip the default to "prefer h2" once this has proven out.
- **One ALPN branch, one conversion site.** The only entry point is
  `negotiated_alpn() == 'h2'` in `net_ssl_do`; the HTTP/1.1 path is untouched.
- **Conversion** lowercases header names, drops hop-by-hop headers
  (RFC 7540 §8.1.2.2), maps `Host` to the `:authority` pseudo-header, collapses
  cookies into one field, and decodes `Content-Encoding` on the response exactly
  like the HTTP/1.1 path. `resp.version()` reports `2.0`.
- No connection pooling or multiplexing yet (each fetch is one TLS connection +
  one H2 request); those are later follow-ups.

## Tests

- Pure unit tests for the request/response conversions (pseudo-headers, header
  lowercasing, hop-by-hop stripping, cookie collapsing, content-length,
  authority/port).
- A full glue round-trip: `Request` → `H2Conn` over an in-memory transport →
  `Response`, with no socket.
- An **opt-in** end-to-end test against a real h2 server, gated behind
  `-d network` so it does not add CI flakiness.

Verified end-to-end against `https://www.google.com/` (HTTP/2.0, 200), with the
default path still selecting HTTP/1.1. `-W -cstrict -cc clang` passes; the full
`vlib/net/http` suite is green (1 Windows-only skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)