### PR TITLE
v2: skip whole-program decode when transforming generic-free programs

### DIFF
--- a/vlib/v2/transformer/monomorphize.v
+++ b/vlib/v2/transformer/monomorphize.v
@@ -210,10 +210,18 @@ fn (t &Transformer) generic_types_spec_count() int {
 fn (mut t Transformer) collect_declared_method_fns(files []ast.File) {
 	t.declared_method_fns = map[string]bool{}
 	for file in files {
-		for stmt in file.stmts {
-			if stmt is ast.FnDecl && stmt.is_method {
-				t.register_declared_method_fn(stmt, file.mod)
-			}
+		t.collect_declared_method_fns_in_file(file)
+	}
+}
+
+// collect_declared_method_fns_in_file is the per-file body of
+// collect_declared_method_fns, factored out so the bounded (streaming)
+// transform path can accumulate the same whole-program map one decoded
+// file at a time without holding the full file set.
+fn (mut t Transformer) collect_declared_method_fns_in_file(file ast.File) {
+	for stmt in file.stmts {
+		if stmt is ast.FnDecl && stmt.is_method {
+			t.register_declared_method_fn(stmt, file.mod)
 		}
 	}
 }
@@ -306,23 +314,7 @@ fn (mut t Transformer) collect_concrete_embedded_owner_names(files []ast.File) {
 	old_import_aliases := t.cur_import_aliases.clone()
 	t.concrete_embedded_owner_names = map[string]map[string]string{}
 	for file in files {
-		t.cur_file_name = file.name
-		t.cur_module = file.mod
-		t.cur_import_aliases = import_aliases_for_generic_collect(file.imports)
-		if scope := t.get_module_scope(file.mod) {
-			t.scope = scope
-		} else {
-			t.scope = unsafe { nil }
-		}
-		for stmt in file.stmts {
-			if stmt is ast.StructDecl {
-				mut embedded := []ast.Expr{cap: stmt.embedded.len}
-				for item in stmt.embedded {
-					embedded << t.rewrite_concrete_generic_struct_type_expr(item)
-				}
-				t.register_concrete_embedded_owner_names(stmt, embedded)
-			}
-		}
+		t.collect_concrete_embedded_owner_names_in_file(file)
 	}
 	t.cur_module = old_module
 	t.cur_file_name = old_file
@@ -330,24 +322,88 @@ fn (mut t Transformer) collect_concrete_embedded_owner_names(files []ast.File) {
 	t.cur_import_aliases = old_import_aliases.clone()
 }
 
+// collect_concrete_embedded_owner_names_in_file is the per-file body of
+// collect_concrete_embedded_owner_names. It mutates the per-file cursor
+// state (cur_module / cur_file_name / cur_import_aliases / scope); callers
+// that stream files are responsible for saving and restoring that state
+// around the loop, exactly as the full-file collector above does.
+fn (mut t Transformer) collect_concrete_embedded_owner_names_in_file(file ast.File) {
+	t.cur_file_name = file.name
+	t.cur_module = file.mod
+	t.cur_import_aliases = import_aliases_for_generic_collect(file.imports)
+	if scope := t.get_module_scope(file.mod) {
+		t.scope = scope
+	} else {
+		t.scope = unsafe { nil }
+	}
+	for stmt in file.stmts {
+		if stmt is ast.StructDecl {
+			mut embedded := []ast.Expr{cap: stmt.embedded.len}
+			for item in stmt.embedded {
+				embedded << t.rewrite_concrete_generic_struct_type_expr(item)
+			}
+			t.register_concrete_embedded_owner_names(stmt, embedded)
+		}
+	}
+}
+
 fn (mut t Transformer) collect_struct_default_decl_infos(files []ast.File) {
 	t.struct_default_decl_infos = map[string]StructDefaultDeclInfo{}
 	for file in files {
-		for stmt in file.stmts {
-			if stmt is ast.StructDecl {
-				info := StructDefaultDeclInfo{
-					decl:        stmt
-					module_name: file.mod
-				}
-				c_name := generic_struct_decl_c_name(stmt, file.mod)
-				t.struct_default_decl_infos[c_name] = info
-				if c_name.contains('__') {
-					t.struct_default_decl_infos[c_name.all_after_last('__')] = info
-				}
-				t.struct_default_decl_infos[stmt.name] = info
+		t.collect_struct_default_decl_infos_in_file(file)
+	}
+}
+
+// collect_struct_default_decl_infos_in_file is the per-file body of
+// collect_struct_default_decl_infos, factored out for the streaming path.
+fn (mut t Transformer) collect_struct_default_decl_infos_in_file(file ast.File) {
+	for stmt in file.stmts {
+		if stmt is ast.StructDecl {
+			info := StructDefaultDeclInfo{
+				decl:        stmt
+				module_name: file.mod
 			}
+			c_name := generic_struct_decl_c_name(stmt, file.mod)
+			t.struct_default_decl_infos[c_name] = info
+			if c_name.contains('__') {
+				t.struct_default_decl_infos[c_name.all_after_last('__')] = info
+			}
+			t.struct_default_decl_infos[stmt.name] = info
 		}
 	}
+}
+
+// collect_non_generic_decl_infos_streaming populates the whole-program
+// decl-info maps that the per-file transform needs but that the bounded
+// dispatch path otherwise skips (it runs only when prepare_files_for_transform
+// is bypassed, i.e. a generic-free program). It streams one decoded file at a
+// time via to_files_range so peak memory stays bounded, and reuses the exact
+// per-file collectors so the maps are identical to the full-file path. The
+// generic-only collects (struct_field_generic_decl_types) and the monomorphize
+// fixpoint are correctly omitted: this path is taken only when there are no
+// generics, so they would be empty / no-ops anyway.
+fn (mut t Transformer) collect_non_generic_decl_infos_streaming(flat &ast.FlatAst) {
+	t.declared_method_fns = map[string]bool{}
+	t.struct_default_decl_infos = map[string]StructDefaultDeclInfo{}
+	t.concrete_embedded_owner_names = map[string]map[string]string{}
+	old_module := t.cur_module
+	old_file := t.cur_file_name
+	old_scope := t.scope
+	old_import_aliases := t.cur_import_aliases.clone()
+	for i in 0 .. flat.files.len {
+		one := flat.to_files_range(i, i + 1)
+		if one.len == 0 {
+			continue
+		}
+		file := one[0]
+		t.collect_declared_method_fns_in_file(file)
+		t.collect_struct_default_decl_infos_in_file(file)
+		t.collect_concrete_embedded_owner_names_in_file(file)
+	}
+	t.cur_module = old_module
+	t.cur_file_name = old_file
+	t.scope = old_scope
+	t.cur_import_aliases = old_import_aliases.clone()
 }
 
 fn generic_struct_runtime_args(args []ast.Expr) []ast.Expr {

--- a/vlib/v2/transformer/monomorphize.v
+++ b/vlib/v2/transformer/monomorphize.v
@@ -43,9 +43,44 @@ struct StructDefaultDeclInfo {
 }
 
 // needs_full_files_for_transform reports whether transform needs the whole
-// legacy file set before per-file workers can run.
+// legacy file set before per-file workers can run. It is true only when the
+// program actually contains generics: monomorphization (prepare_files_for_transform)
+// is the sole reason the per-file pipeline needs the full file set up front, and
+// it is a no-op when there are no generic decls. When false, the dispatch takes
+// the bounded-memory per-file path (one file decoded at a time via to_files_range)
+// instead of the whole-program flat.to_files() that OOMs the -gc none self-host.
 pub fn (t &Transformer) needs_full_files_for_transform() bool {
-	return true
+	return t.program_needs_generics
+}
+
+// program_needs_generics_from_flat reports whether the flat program contains any
+// generic function or struct declaration — i.e. whether the monomorphize fixpoint
+// (and the whole-program legacy decode it requires) is needed at all. Lifetime
+// params (`.expr_lifetime`) are not generics, mirroring has_non_lifetime_generic_params
+// (fn.v). Pure cursor scan, no decode. FnDecl edge 1 = FnType, FnType edge 0 =
+// generic_params; StructDecl edge 3 = generic_params (see flat_reader.v).
+fn program_needs_generics_from_flat(flat &ast.FlatAst) bool {
+	for i in 0 .. flat.files.len {
+		stmts := flat.file_cursor(i).stmts()
+		for j in 0 .. stmts.len() {
+			c := stmts.at(j)
+			kind := c.kind()
+			if kind != .stmt_fn_decl && kind != .stmt_struct_decl {
+				continue
+			}
+			gp := if kind == .stmt_fn_decl {
+				c.edge(1).list_at(0)
+			} else {
+				c.list_at(3)
+			}
+			for k in 0 .. gp.len() {
+				if gp.at(k).kind() != .expr_lifetime {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // prepare_files_for_transform performs whole-program preparation required

--- a/vlib/v2/transformer/program_needs_generics_test.v
+++ b/vlib/v2/transformer/program_needs_generics_test.v
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+// vtest build: macos
+//
+// Pins program_needs_generics_from_flat — the cursor-native predicate that
+// gates needs_full_files_for_transform. It must classify a program as needing
+// generics iff some FnDecl/StructDecl has a non-lifetime generic param, scanning
+// the flat AST directly (FnDecl edge 1 = FnType, FnType edge 0 = generic_params;
+// StructDecl edge 3 = generic_params). The edge offsets are the one real
+// correctness risk, so they get a dedicated test before the predicate is wired.
+module transformer
+
+import os
+import v2.ast
+import v2.parser
+import v2.pref as vpref
+import v2.token
+
+// png_of parses+flattens `src` and runs the predicate against the flat AST.
+// Self-contained (no checker needed: generic params are syntactic) so it
+// compiles standalone the way the V test runner builds each _test.v file.
+fn png_of(src string) bool {
+	tmp := '/tmp/v2_png_${os.getpid()}_${src.len}.v'
+	os.write_file(tmp, src) or { panic('write_file: ${err}') }
+	defer {
+		os.rm(tmp) or {}
+	}
+	prefs := &vpref.Preferences{
+		backend:     .cleanc
+		no_parallel: true
+	}
+	mut fs := token.FileSet.new()
+	mut par := parser.Parser.new(prefs)
+	files := par.parse_files([tmp], mut fs)
+	flat := ast.flatten_files(files)
+	return program_needs_generics_from_flat(&flat)
+}
+
+fn test_plain_fn_has_no_generics() {
+	assert !png_of('fn add(a int, b int) int { return a + b }\nfn main() { println(add(1, 2)) }')
+}
+
+fn test_plain_struct_has_no_generics() {
+	assert !png_of('struct Point { x int y int }\nfn main() { p := Point{1, 2} println(p.x) }')
+}
+
+fn test_generic_fn_is_detected() {
+	assert png_of('fn pick[T](a T, b T) T { return a }\nfn main() {}')
+}
+
+fn test_generic_struct_is_detected() {
+	assert png_of('struct Box[T] { val T }\nfn main() {}')
+}
+
+// A lifetime-only param (`^a`) is not a generic — mirror has_non_lifetime_generic_params.
+fn test_lifetime_only_fn_is_not_a_generic() {
+	assert !png_of('fn make[^a]() int { return 0 }\nfn main() {}')
+}
+
+fn test_lifetime_only_struct_is_not_a_generic() {
+	assert !png_of('struct Holder[^a] { x int }\nfn main() {}')
+}
+
+// A lifetime alongside a real generic param still needs monomorphization.
+fn test_lifetime_plus_generic_is_detected() {
+	assert png_of('struct Ref[^a, T] { val T }\nfn main() {}')
+}

--- a/vlib/v2/transformer/transformer.v
+++ b/vlib/v2/transformer/transformer.v
@@ -116,6 +116,12 @@ mut:
 	declared_method_fns           map[string]bool
 	monomorphized_fn_bindings     map[string]map[string]types.Type
 	cur_monomorphized_fn_bindings map[string]types.Type
+	// program_needs_generics gates needs_full_files_for_transform: when false
+	// (no generic decls in the program) the per-file transform takes the
+	// bounded-memory path instead of whole-program flat.to_files()+monomorphize.
+	// Set explicitly by both pre_pass (true) and pre_pass_from_flat (computed);
+	// defaults to true so any unset path stays on the safe full-files behavior.
+	program_needs_generics bool = true
 	// @[live] hot code reloading: function names and source file
 	live_fns         []LiveFn
 	live_source_file string
@@ -1521,6 +1527,10 @@ pub fn (mut t Transformer) pre_pass(files []ast.File) {
 	}
 	// Cache scope and method maps for lock-free access during transform.
 	t.cache_env_maps()
+	// Legacy []ast.File path: keep the full-files monomorphize behavior. The
+	// whole legacy AST is already resident, so the bounded path saves nothing
+	// here; always run prepare_files_for_transform (a no-op without generics).
+	t.program_needs_generics = true
 }
 
 // pre_pass_from_flat is the FlatAst-driven equivalent of pre_pass. Reads
@@ -1547,6 +1557,11 @@ pub fn (mut t Transformer) pre_pass_from_flat(flat &ast.FlatAst) {
 		t.collect_runtime_const_inits_from_flat(flat)
 	}
 	t.cache_env_maps()
+	// Flat path: monomorphization (and the whole-program flat.to_files() decode
+	// it requires) is only needed when the program actually has generics. When
+	// it doesn't, the dispatch takes the bounded per-file path and the -gc none
+	// self-host no longer OOMs decoding the whole program at once.
+	t.program_needs_generics = program_needs_generics_from_flat(flat)
 }
 
 // cache_env_maps snapshots the shared Environment maps into plain maps

--- a/vlib/v2/transformer/transformer.v
+++ b/vlib/v2/transformer/transformer.v
@@ -1539,6 +1539,12 @@ pub fn (mut t Transformer) pre_pass(files []ast.File) {
 // The per-stmt walks reuse the existing recursive visitors, which still
 // operate on legacy ast.Stmt/Expr — flat-native walks are a later step.
 pub fn (mut t Transformer) pre_pass_from_flat(flat &ast.FlatAst) {
+	// Flat path: monomorphization (and the whole-program flat.to_files() decode
+	// it requires) is only needed when the program actually has generics. When
+	// it doesn't, the dispatch takes the bounded per-file path and the -gc none
+	// self-host no longer OOMs decoding the whole program at once. Computed up
+	// front so the streaming decl-info collect below can be gated on it.
+	t.program_needs_generics = program_needs_generics_from_flat(flat)
 	t.collect_generic_fn_value_refs_from_flat(flat)
 	for ff in flat.files {
 		for stmt in flat.read_file_stmts(ff) {
@@ -1557,11 +1563,13 @@ pub fn (mut t Transformer) pre_pass_from_flat(flat &ast.FlatAst) {
 		t.collect_runtime_const_inits_from_flat(flat)
 	}
 	t.cache_env_maps()
-	// Flat path: monomorphization (and the whole-program flat.to_files() decode
-	// it requires) is only needed when the program actually has generics. When
-	// it doesn't, the dispatch takes the bounded per-file path and the -gc none
-	// self-host no longer OOMs decoding the whole program at once.
-	t.program_needs_generics = program_needs_generics_from_flat(flat)
+	if !t.program_needs_generics {
+		// The bounded transform path (taken for generic-free programs) skips
+		// prepare_files_for_transform, so populate the non-generic whole-program
+		// decl-info maps it still needs (declared_method_fns, struct default
+		// decl infos, concrete embedded owner names) by streaming each file once.
+		t.collect_non_generic_decl_infos_streaming(flat)
+	}
 }
 
 // cache_env_maps snapshots the shared Environment maps into plain maps

--- a/vlib/v2/transformer/transformer_flat_diff_test.v
+++ b/vlib/v2/transformer/transformer_flat_diff_test.v
@@ -1008,8 +1008,45 @@ fn run_parity(label string, src string) {
 	assert_transform_signatures_equal(label, leg, flt)
 }
 
+// fixture_methods_defaults_embed exercises the three whole-program decl-info
+// collects that the legacy path runs in prepare_files_for_transform and that the
+// bounded (generic-free) from-flat path now streams in pre_pass_from_flat:
+// declared_method_fns (the two methods), struct_default_decl_infos (the default
+// field values + the `Widget{}` literal that relies on them), and
+// concrete_embedded_owner_names (Widget embedding Base). If the streamed maps
+// diverge from the full-file maps, this parity check fails.
+const fixture_methods_defaults_embed = '
+struct Base {
+	id int = 7
+}
+
+fn (b Base) describe() int {
+	return b.id
+}
+
+struct Widget {
+	Base
+	tag int = 5
+	size int = 3
+}
+
+fn (w Widget) area() int {
+	return w.size * w.size
+}
+
+fn use_widget() int {
+	w := Widget{}
+	base := Base{}
+	return w.area() + base.describe() + w.id + w.tag
+}
+'
+
 fn test_flat_parity_plain_fn() {
 	run_parity('parity_plain_fn', fixture_plain_fn)
+}
+
+fn test_flat_parity_methods_defaults_embed() {
+	run_parity('parity_methods_defaults_embed', fixture_methods_defaults_embed)
 }
 
 fn test_flat_parity_infix_operator() {


### PR DESCRIPTION
> **Draft — does NOT fix the `-gc none` flat self-host OOM. See the correction below.** Kept open for a disposition decision (land as a minor improvement, or close in favor of flat-native transform).

## What this does

`needs_full_files_for_transform()` returned `true` unconditionally, so the flat transform pipeline always decoded the whole program to legacy `[]ast.File` (`flat.to_files()`) and ran the monomorphize fixpoint. This makes it return a new `program_needs_generics` field (computed by a pure cursor scan, `program_needs_generics_from_flat`); generic-free programs then take the existing bounded per-file dispatch (`to_files_range`, one file at a time). The bounded path also now streams the three non-generic whole-program collects it needs (`declared_method_fns`, `struct_default_decl_infos`, `concrete_embedded_owner_names`) via `collect_non_generic_decl_infos_streaming`, reusing the exact per-file collectors so the maps are identical to the full-file path.

## Honest result (corrected)

I initially reported an "8.5× memory win". That was **resident set size**, and against the *wrong baseline*. Measuring the real OOM trigger (`peak memory footprint`) on **merged master**, full `v3→v4` self-host, `-gc none`:

| | RSS | peak footprint | result |
|---|---|---|---|
| baseline (full path) | 7.9 GB | 97.4 GB | OOM-killed |
| this PR (bounded path) | 4.3 GB | 94.0 GB | OOM-killed |

- The `-gc none` flat self-host was **already** OOM-killed on master — this is **not a regression**, and this PR is marginally better on both metrics.
- But it **does not fix the OOM**: under `-gc none` the flat→legacy re-decode is never freed and accumulates regardless of all-at-once vs streamed. Streaming lowers RSS, not total footprint.
- The real fix is **flat-native transform** (transform reads the flat directly, never re-decoding to legacy → nothing to accumulate), which will supersede this bounded path entirely.

## Validation

- All 19 `vlib/v2/transformer/` tests green, including a new `transform_files`-vs-`transform_files_from_flat` parity fixture covering methods + struct defaults + an embedded struct (guards the streamed collects == full-file collects).
- `program_needs_generics_test.v` pins the predicate (edge offsets + lifetime filter).
- No regression vs merged-master baseline (table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)