### PR TITLE
v2: implement native x64 backend, part 2

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -100,7 +100,8 @@ jobs:
         run: |
           set -e
 
-          ./v test vlib/v2/abi vlib/v2/gen/x64
+          VJOBS=1 ./v test vlib/v2/abi vlib/v2/gen/x64
+          ./v test vlib/v2/builder/native_test.v vlib/v2/builder/target_os_test.v
           ./v test vlib/v2/ssa/optimize
           V2_VERIFY_STRICT=1 ./v test vlib/v2/ssa/optimize
 
@@ -131,6 +132,26 @@ jobs:
             fi
           }
 
+          run_native_x64_example() {
+            source="$1"
+            name="$2"
+            expected="$3"
+            shift 3
+
+            ./v -v2 -no-parallel -b x64 "$source" -o "$tmp/$name"
+            "$tmp/$name" "$@" > "$tmp/$name.out" 2> "$tmp/$name.err"
+            check_empty_stderr "$name" "$tmp/$name.err"
+            check_stdout "$name" "$expected" "$tmp/$name.out"
+          }
+
+          write_v_run_expected() {
+            source="$1"
+            expected="$2"
+            stderr="$tmp/$(basename "$expected").stderr"
+            ./v run "$source" > "$expected" 2> "$stderr"
+            check_empty_stderr "v run $source" "$stderr"
+          }
+
           write_fizz_buzz_expected() {
             i=1
             while [ "$i" -le 100 ]; do
@@ -147,17 +168,174 @@ jobs:
             done
           }
 
-          ./v -v2 -b x64 examples/hello_world.v -o "$tmp/hello_world"
-          "$tmp/hello_world" > "$tmp/hello_world.out" 2> "$tmp/hello_world.err"
-          printf 'Hello, World!\n' > "$tmp/hello_world.expected"
-          check_empty_stderr hello_world "$tmp/hello_world.err"
-          check_stdout hello_world "$tmp/hello_world.expected" "$tmp/hello_world.out"
+          write_hanoi_expected() {
+            python3 - <<'PY'
+          def hanoi(n, a, b, c):
+              if n == 1:
+                  print(f"Disc 1 from {a} to {c}...")
+              else:
+                  hanoi(n - 1, a, c, b)
+                  print(f"Disc {n} from {a} to {c}...")
+                  hanoi(n - 1, b, a, c)
 
-          ./v -v2 -b x64 examples/fizz_buzz.v -o "$tmp/fizz_buzz"
-          "$tmp/fizz_buzz" > "$tmp/fizz_buzz.out" 2> "$tmp/fizz_buzz.err"
+          hanoi(7, "A", "B", "C")
+          PY
+          }
+
+          write_sudoku_expected() {
+            python3 - <<'PY'
+          import sys
+
+          puzzle = [
+              [0, 3, 0, 0, 7, 0, 0, 0, 0],
+              [0, 0, 0, 1, 3, 5, 0, 0, 0],
+              [0, 0, 1, 0, 0, 0, 0, 5, 0],
+              [1, 0, 0, 0, 6, 0, 0, 0, 3],
+              [4, 0, 0, 8, 0, 3, 0, 0, 1],
+              [7, 0, 0, 0, 2, 0, 0, 0, 6],
+              [0, 0, 0, 0, 0, 0, 2, 1, 0],
+              [0, 0, 0, 4, 1, 2, 0, 0, 5],
+              [0, 0, 0, 0, 0, 0, 0, 7, 4],
+          ]
+          solution = [
+              [2, 3, 5, 6, 7, 8, 1, 4, 9],
+              [9, 4, 7, 1, 3, 5, 8, 6, 2],
+              [6, 8, 1, 2, 4, 9, 3, 5, 7],
+              [1, 2, 8, 7, 6, 4, 5, 9, 3],
+              [4, 5, 6, 8, 9, 3, 7, 2, 1],
+              [7, 9, 3, 5, 2, 1, 4, 8, 6],
+              [3, 6, 4, 9, 5, 7, 2, 1, 8],
+              [8, 7, 9, 4, 1, 2, 6, 3, 5],
+              [5, 1, 2, 3, 8, 6, 9, 7, 4],
+          ]
+
+          def append_grid(lines, label, grid):
+              lines.append(label)
+              for i, row in enumerate(grid):
+                  if i % 3 == 0 and i != 0:
+                      lines.append("- - - - - - - - - - - -")
+                  line = ""
+                  for j, value in enumerate(row):
+                      if j % 3 == 0 and j != 0:
+                          line += " | "
+                      line += f"{value} "
+                  lines.append(line)
+
+          lines = []
+          append_grid(lines, "Sudoku Puzzle:", puzzle)
+          lines.append("Solving...")
+          append_grid(lines, "Solution:", solution)
+          out = ("\n".join(lines) + "\n").encode()
+          if len(out) != 582:
+              raise SystemExit(f"sudoku stdout oracle shape changed: {len(out)} bytes")
+          sys.stdout.buffer.write(out)
+          PY
+          }
+
+          write_tree_of_nodes_expected() {
+            cat <<'EOF'
+          tree structure:
+           Node{
+              value: 10
+              left: Tree(Node{
+                  value: 30
+                  left: Tree(Empty{})
+                  right: Tree(Empty{})
+              })
+              right: Tree(Node{
+                  value: 20
+                  left: Tree(Empty{})
+                  right: Tree(Empty{})
+              })
+          }
+          tree size: 3
+          EOF
+          }
+
+          write_js_hello_world_expected() {
+            printf 'Hello from V.js (0)\nHello from V.js (1)\nHello from V.js (2)\n'
+          }
+
+          write_vascii_expected() {
+            python3 - <<'PY'
+          from pathlib import Path
+          import sys
+
+          source = Path("examples/vascii.v").read_text(encoding="utf-8")
+          start_marker = "println('"
+          end_marker = "')"
+          if source.count(start_marker) != 1:
+              raise SystemExit("vascii stdout oracle expects one single-quoted println literal")
+          start = source.index(start_marker) + len(start_marker)
+          end = source.rindex(end_marker)
+          if source[end + len(end_marker):].strip() != "}":
+              raise SystemExit("vascii stdout oracle expects the println literal to be the final main statement")
+
+          out = bytearray()
+          literal = source[start:end]
+          i = 0
+          while i < len(literal):
+              ch = literal[i]
+              if ch == "\\":
+                  i += 1
+                  if i >= len(literal):
+                      raise SystemExit("unterminated escape in vascii literal")
+                  escaped = literal[i]
+                  if escaped == "n":
+                      out.append(10)
+                  elif escaped == "t":
+                      out.append(9)
+                  elif escaped == "r":
+                      out.append(13)
+                  elif escaped == "\\":
+                      out.append(92)
+                  elif escaped == "'":
+                      out.append(39)
+                  elif escaped == '"':
+                      out.append(34)
+                  else:
+                      out.extend(escaped.encode("utf-8"))
+              else:
+                  out.extend(ch.encode("utf-8"))
+              i += 1
+          out.append(10)
+          sys.stdout.buffer.write(out)
+          PY
+          }
+
+          write_rune_expected() {
+            printf '\360\237\230\200\n@\n'
+          }
+
+          printf 'Hello, World!\n' > "$tmp/hello_world.expected"
           write_fizz_buzz_expected > "$tmp/fizz_buzz.expected"
-          check_empty_stderr fizz_buzz "$tmp/fizz_buzz.err"
-          check_stdout fizz_buzz "$tmp/fizz_buzz.expected" "$tmp/fizz_buzz.out"
+          write_hanoi_expected > "$tmp/hanoi.expected"
+          write_sudoku_expected > "$tmp/sudoku.expected"
+          printf 'HELLO WORLD\nHELLO WORLD\nHELLO WORLD\n' > "$tmp/function_types.expected"
+          printf '5\n3\n' > "$tmp/submodule.expected"
+          printf '1\n1\n2\n3\n5\n8\n13\n21\n34\n55\n89\n' > "$tmp/fibonacci_10.expected"
+          write_tree_of_nodes_expected > "$tmp/tree_of_nodes.expected"
+          write_js_hello_world_expected > "$tmp/js_hello_world.expected"
+          write_vascii_expected > "$tmp/vascii.expected"
+          write_rune_expected > "$tmp/rune.expected"
+          write_v_run_expected examples/graphs/bfs.v "$tmp/bfs.expected"
+          write_v_run_expected examples/graphs/dfs.v "$tmp/dfs.expected"
+          write_v_run_expected examples/graphs/dijkstra.v "$tmp/dijkstra.expected"
+
+          run_native_x64_example examples/hello_world.v hello_world "$tmp/hello_world.expected"
+          run_native_x64_example examples/fizz_buzz.v fizz_buzz "$tmp/fizz_buzz.expected"
+          run_native_x64_example examples/hanoi.v hanoi "$tmp/hanoi.expected"
+          run_native_x64_example examples/sudoku.v sudoku "$tmp/sudoku.expected"
+          run_native_x64_example examples/function_types.v function_types "$tmp/function_types.expected"
+          run_native_x64_example examples/submodule/main.v submodule "$tmp/submodule.expected"
+          run_native_x64_example examples/fibonacci.v fibonacci "$tmp/fibonacci_10.expected" 10
+          run_native_x64_example examples/tree_of_nodes.v tree_of_nodes "$tmp/tree_of_nodes.expected"
+          run_native_x64_example examples/js_hello_world.v js_hello_world "$tmp/js_hello_world.expected"
+          run_native_x64_example examples/vascii.v vascii "$tmp/vascii.expected"
+          run_native_x64_example examples/rune.v rune "$tmp/rune.expected"
+          run_native_x64_example examples/graphs/bfs.v bfs "$tmp/bfs.expected"
+          run_native_x64_example examples/graphs/dfs.v dfs "$tmp/dfs.expected"
+          run_native_x64_example examples/graphs/dijkstra.v dijkstra "$tmp/dijkstra.expected"
       - name: All code is formatted
         run: v run ci/linux_ci.vsh all_code_is_formatted_gcc
       - name: Install dependencies for examples and tools

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -105,7 +105,8 @@ jobs:
         run: |
           set -e
 
-          ./v test vlib/v2/abi vlib/v2/gen/x64
+          VJOBS=1 ./v test vlib/v2/abi vlib/v2/gen/x64
+          ./v test vlib/v2/builder/native_test.v vlib/v2/builder/target_os_test.v
           ./v test vlib/v2/ssa/optimize
           V2_VERIFY_STRICT=1 ./v test vlib/v2/ssa/optimize
 
@@ -122,6 +123,29 @@ jobs:
             fi
           }
 
+          check_v_run_stderr() {
+            label="$1"
+            stderr="$2"
+            if [ ! -s "$stderr" ]; then
+              return 0
+            fi
+            if python3 - "$stderr" <<'PY'
+          import re
+          import sys
+
+          text = open(sys.argv[1], "rb").read().decode("utf-8", "replace")
+          text = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", text).strip()
+          expected = "warning: tcc compilation failed, falling back to cc (this is much slower)"
+          raise SystemExit(0 if text == expected else 1)
+          PY
+            then
+              return 0
+            fi
+            echo "::error::$label wrote unexpected stderr"
+            cat "$stderr"
+            return 1
+          }
+
           check_stdout() {
             label="$1"
             expected="$2"
@@ -134,6 +158,26 @@ jobs:
               cat "$actual"
               return 1
             fi
+          }
+
+          run_native_x64_example() {
+            source="$1"
+            name="$2"
+            expected="$3"
+            shift 3
+
+            ./v -v2 -no-parallel -b x64 "$source" -o "$tmp/$name"
+            "$tmp/$name" "$@" > "$tmp/$name.out" 2> "$tmp/$name.err"
+            check_empty_stderr "$name" "$tmp/$name.err"
+            check_stdout "$name" "$expected" "$tmp/$name.out"
+          }
+
+          write_v_run_expected() {
+            source="$1"
+            expected="$2"
+            stderr="$tmp/$(basename "$expected").stderr"
+            ./v run "$source" > "$expected" 2> "$stderr"
+            check_v_run_stderr "v run $source" "$stderr"
           }
 
           write_fizz_buzz_expected() {
@@ -152,14 +196,171 @@ jobs:
             done
           }
 
-          ./v -v2 -b x64 examples/hello_world.v -o "$tmp/hello_world"
-          "$tmp/hello_world" > "$tmp/hello_world.out" 2> "$tmp/hello_world.err"
-          printf 'Hello, World!\n' > "$tmp/hello_world.expected"
-          check_empty_stderr hello_world "$tmp/hello_world.err"
-          check_stdout hello_world "$tmp/hello_world.expected" "$tmp/hello_world.out"
+          write_hanoi_expected() {
+            python3 - <<'PY'
+          def hanoi(n, a, b, c):
+              if n == 1:
+                  print(f"Disc 1 from {a} to {c}...")
+              else:
+                  hanoi(n - 1, a, c, b)
+                  print(f"Disc {n} from {a} to {c}...")
+                  hanoi(n - 1, b, a, c)
 
-          ./v -v2 -b x64 examples/fizz_buzz.v -o "$tmp/fizz_buzz"
-          "$tmp/fizz_buzz" > "$tmp/fizz_buzz.out" 2> "$tmp/fizz_buzz.err"
+          hanoi(7, "A", "B", "C")
+          PY
+          }
+
+          write_sudoku_expected() {
+            python3 - <<'PY'
+          import sys
+
+          puzzle = [
+              [0, 3, 0, 0, 7, 0, 0, 0, 0],
+              [0, 0, 0, 1, 3, 5, 0, 0, 0],
+              [0, 0, 1, 0, 0, 0, 0, 5, 0],
+              [1, 0, 0, 0, 6, 0, 0, 0, 3],
+              [4, 0, 0, 8, 0, 3, 0, 0, 1],
+              [7, 0, 0, 0, 2, 0, 0, 0, 6],
+              [0, 0, 0, 0, 0, 0, 2, 1, 0],
+              [0, 0, 0, 4, 1, 2, 0, 0, 5],
+              [0, 0, 0, 0, 0, 0, 0, 7, 4],
+          ]
+          solution = [
+              [2, 3, 5, 6, 7, 8, 1, 4, 9],
+              [9, 4, 7, 1, 3, 5, 8, 6, 2],
+              [6, 8, 1, 2, 4, 9, 3, 5, 7],
+              [1, 2, 8, 7, 6, 4, 5, 9, 3],
+              [4, 5, 6, 8, 9, 3, 7, 2, 1],
+              [7, 9, 3, 5, 2, 1, 4, 8, 6],
+              [3, 6, 4, 9, 5, 7, 2, 1, 8],
+              [8, 7, 9, 4, 1, 2, 6, 3, 5],
+              [5, 1, 2, 3, 8, 6, 9, 7, 4],
+          ]
+
+          def append_grid(lines, label, grid):
+              lines.append(label)
+              for i, row in enumerate(grid):
+                  if i % 3 == 0 and i != 0:
+                      lines.append("- - - - - - - - - - - -")
+                  line = ""
+                  for j, value in enumerate(row):
+                      if j % 3 == 0 and j != 0:
+                          line += " | "
+                      line += f"{value} "
+                  lines.append(line)
+
+          lines = []
+          append_grid(lines, "Sudoku Puzzle:", puzzle)
+          lines.append("Solving...")
+          append_grid(lines, "Solution:", solution)
+          out = ("\n".join(lines) + "\n").encode()
+          if len(out) != 582:
+              raise SystemExit(f"sudoku stdout oracle shape changed: {len(out)} bytes")
+          sys.stdout.buffer.write(out)
+          PY
+          }
+
+          write_tree_of_nodes_expected() {
+            cat <<'EOF'
+          tree structure:
+           Node{
+              value: 10
+              left: Tree(Node{
+                  value: 30
+                  left: Tree(Empty{})
+                  right: Tree(Empty{})
+              })
+              right: Tree(Node{
+                  value: 20
+                  left: Tree(Empty{})
+                  right: Tree(Empty{})
+              })
+          }
+          tree size: 3
+          EOF
+          }
+
+          write_js_hello_world_expected() {
+            printf 'Hello from V.js (0)\nHello from V.js (1)\nHello from V.js (2)\n'
+          }
+
+          write_vascii_expected() {
+            python3 - <<'PY'
+          from pathlib import Path
+          import sys
+
+          source = Path("examples/vascii.v").read_text(encoding="utf-8")
+          start_marker = "println('"
+          end_marker = "')"
+          if source.count(start_marker) != 1:
+              raise SystemExit("vascii stdout oracle expects one single-quoted println literal")
+          start = source.index(start_marker) + len(start_marker)
+          end = source.rindex(end_marker)
+          if source[end + len(end_marker):].strip() != "}":
+              raise SystemExit("vascii stdout oracle expects the println literal to be the final main statement")
+
+          out = bytearray()
+          literal = source[start:end]
+          i = 0
+          while i < len(literal):
+              ch = literal[i]
+              if ch == "\\":
+                  i += 1
+                  if i >= len(literal):
+                      raise SystemExit("unterminated escape in vascii literal")
+                  escaped = literal[i]
+                  if escaped == "n":
+                      out.append(10)
+                  elif escaped == "t":
+                      out.append(9)
+                  elif escaped == "r":
+                      out.append(13)
+                  elif escaped == "\\":
+                      out.append(92)
+                  elif escaped == "'":
+                      out.append(39)
+                  elif escaped == '"':
+                      out.append(34)
+                  else:
+                      out.extend(escaped.encode("utf-8"))
+              else:
+                  out.extend(ch.encode("utf-8"))
+              i += 1
+          out.append(10)
+          sys.stdout.buffer.write(out)
+          PY
+          }
+
+          write_rune_expected() {
+            printf '\360\237\230\200\n@\n'
+          }
+
+          printf 'Hello, World!\n' > "$tmp/hello_world.expected"
           write_fizz_buzz_expected > "$tmp/fizz_buzz.expected"
-          check_empty_stderr fizz_buzz "$tmp/fizz_buzz.err"
-          check_stdout fizz_buzz "$tmp/fizz_buzz.expected" "$tmp/fizz_buzz.out"
+          write_hanoi_expected > "$tmp/hanoi.expected"
+          write_sudoku_expected > "$tmp/sudoku.expected"
+          printf 'HELLO WORLD\nHELLO WORLD\nHELLO WORLD\n' > "$tmp/function_types.expected"
+          printf '5\n3\n' > "$tmp/submodule.expected"
+          printf '1\n1\n2\n3\n5\n8\n13\n21\n34\n55\n89\n' > "$tmp/fibonacci_10.expected"
+          write_tree_of_nodes_expected > "$tmp/tree_of_nodes.expected"
+          write_js_hello_world_expected > "$tmp/js_hello_world.expected"
+          write_vascii_expected > "$tmp/vascii.expected"
+          write_rune_expected > "$tmp/rune.expected"
+          write_v_run_expected examples/graphs/bfs.v "$tmp/bfs.expected"
+          write_v_run_expected examples/graphs/dfs.v "$tmp/dfs.expected"
+          write_v_run_expected examples/graphs/dijkstra.v "$tmp/dijkstra.expected"
+
+          run_native_x64_example examples/hello_world.v hello_world "$tmp/hello_world.expected"
+          run_native_x64_example examples/fizz_buzz.v fizz_buzz "$tmp/fizz_buzz.expected"
+          run_native_x64_example examples/hanoi.v hanoi "$tmp/hanoi.expected"
+          run_native_x64_example examples/sudoku.v sudoku "$tmp/sudoku.expected"
+          run_native_x64_example examples/function_types.v function_types "$tmp/function_types.expected"
+          run_native_x64_example examples/submodule/main.v submodule "$tmp/submodule.expected"
+          run_native_x64_example examples/fibonacci.v fibonacci "$tmp/fibonacci_10.expected" 10
+          run_native_x64_example examples/tree_of_nodes.v tree_of_nodes "$tmp/tree_of_nodes.expected"
+          run_native_x64_example examples/js_hello_world.v js_hello_world "$tmp/js_hello_world.expected"
+          run_native_x64_example examples/vascii.v vascii "$tmp/vascii.expected"
+          run_native_x64_example examples/rune.v rune "$tmp/rune.expected"
+          run_native_x64_example examples/graphs/bfs.v bfs "$tmp/bfs.expected"
+          run_native_x64_example examples/graphs/dfs.v dfs "$tmp/dfs.expected"
+          run_native_x64_example examples/graphs/dijkstra.v dijkstra "$tmp/dijkstra.expected"

--- a/.github/workflows/windows_ci_msvc.yml
+++ b/.github/workflows/windows_ci_msvc.yml
@@ -65,16 +65,20 @@ jobs:
             }
           }
 
-          function Invoke-NativeX64Example([string] $source, [string] $name, [byte[]] $expected_stdout) {
+          function Invoke-NativeX64Example([string] $source, [string] $name, [byte[]] $expected_stdout, [string[]] $program_args = @()) {
             $exe = Join-Path $tmp "$name.exe"
             $stdout_path = Join-Path $tmp "$name.out"
             $stderr_path = Join-Path $tmp "$name.err"
 
-            .\v.exe -v2 -b x64 $source -o $exe
+            .\v.exe -v2 -no-parallel -b x64 $source -o $exe
             Assert-LastExit "compile $source"
 
             Remove-Item -LiteralPath $stdout_path, $stderr_path -Force -ErrorAction SilentlyContinue
-            $process = Start-Process -FilePath $exe -NoNewWindow -Wait -PassThru -RedirectStandardOutput $stdout_path -RedirectStandardError $stderr_path
+            if ($program_args.Count -gt 0) {
+              $process = Start-Process -FilePath $exe -ArgumentList $program_args -NoNewWindow -Wait -PassThru -RedirectStandardOutput $stdout_path -RedirectStandardError $stderr_path
+            } else {
+              $process = Start-Process -FilePath $exe -NoNewWindow -Wait -PassThru -RedirectStandardOutput $stdout_path -RedirectStandardError $stderr_path
+            }
             if ($process.ExitCode -ne 0) {
               if (Test-Path -LiteralPath $stderr_path) {
                 Get-Content -LiteralPath $stderr_path
@@ -89,8 +93,12 @@ jobs:
             Assert-ByteArrayEqual $stderr $empty "$source stderr"
           }
 
+          $env:VJOBS = '1'
           .\v.exe test vlib/v2/abi vlib/v2/gen/x64
           Assert-LastExit 'vlib/v2/abi vlib/v2/gen/x64'
+          Remove-Item Env:\VJOBS -ErrorAction SilentlyContinue
+          .\v.exe test vlib/v2/builder/native_test.v vlib/v2/builder/target_os_test.v
+          Assert-LastExit 'vlib/v2/builder/native_test.v vlib/v2/builder/target_os_test.v'
           .\v.exe test vlib/v2/ssa/optimize
           Assert-LastExit 'vlib/v2/ssa/optimize'
           $env:V2_VERIFY_STRICT = '1'
@@ -100,6 +108,25 @@ jobs:
 
           $tmp = Join-Path $env:RUNNER_TEMP 'v2_x64_native'
           New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+
+          function Get-VRunExpectedBytes([string] $source, [string] $name) {
+            $stdout_path = Join-Path $tmp "$name.vrun.out"
+            $stderr_path = Join-Path $tmp "$name.vrun.err"
+            Remove-Item -LiteralPath $stdout_path, $stderr_path -Force -ErrorAction SilentlyContinue
+
+            $process = Start-Process -FilePath '.\v.exe' -ArgumentList @('run', $source) -NoNewWindow -Wait -PassThru -RedirectStandardOutput $stdout_path -RedirectStandardError $stderr_path
+            if ($process.ExitCode -ne 0) {
+              if (Test-Path -LiteralPath $stderr_path) {
+                Get-Content -LiteralPath $stderr_path
+              }
+              throw "v run $source failed with code $($process.ExitCode)"
+            }
+
+            [byte[]] $stderr = if (Test-Path -LiteralPath $stderr_path) { [System.IO.File]::ReadAllBytes($stderr_path) } else { New-Object byte[] 0 }
+            $empty = New-Object byte[] 0
+            Assert-ByteArrayEqual $stderr $empty "v run $source stderr"
+            return [System.IO.File]::ReadAllBytes($stdout_path)
+          }
 
           $hello_expected = [System.Text.Encoding]::UTF8.GetBytes("Hello, World!`n")
           Invoke-NativeX64Example 'examples/hello_world.v' 'hello_world' $hello_expected
@@ -117,6 +144,185 @@ jobs:
           }
           $fizz_expected = [System.Text.Encoding]::UTF8.GetBytes(($fizz_lines -join "`n") + "`n")
           Invoke-NativeX64Example 'examples/fizz_buzz.v' 'fizz_buzz' $fizz_expected
+
+          $fibonacci_expected = [System.Text.Encoding]::UTF8.GetBytes("1`n1`n2`n3`n5`n8`n13`n21`n34`n55`n89`n")
+          Invoke-NativeX64Example 'examples/fibonacci.v' 'fibonacci' $fibonacci_expected @('10')
+
+          function Get-HanoiExpectedLines([int] $n, [string] $a, [string] $b, [string] $c) {
+            if ($n -eq 1) {
+              "Disc 1 from $a to $c..."
+              return
+            }
+            Get-HanoiExpectedLines ($n - 1) $a $c $b
+            "Disc $n from $a to $c..."
+            Get-HanoiExpectedLines ($n - 1) $b $a $c
+          }
+
+          $hanoi_lines = @(Get-HanoiExpectedLines 7 'A' 'B' 'C')
+          $hanoi_expected = [System.Text.Encoding]::UTF8.GetBytes(($hanoi_lines -join "`n") + "`n")
+          Invoke-NativeX64Example 'examples/hanoi.v' 'hanoi' $hanoi_expected
+
+          function Get-SudokuExpectedLines {
+            $puzzle = @(
+              ,@(0, 3, 0, 0, 7, 0, 0, 0, 0)
+              ,@(0, 0, 0, 1, 3, 5, 0, 0, 0)
+              ,@(0, 0, 1, 0, 0, 0, 0, 5, 0)
+              ,@(1, 0, 0, 0, 6, 0, 0, 0, 3)
+              ,@(4, 0, 0, 8, 0, 3, 0, 0, 1)
+              ,@(7, 0, 0, 0, 2, 0, 0, 0, 6)
+              ,@(0, 0, 0, 0, 0, 0, 2, 1, 0)
+              ,@(0, 0, 0, 4, 1, 2, 0, 0, 5)
+              ,@(0, 0, 0, 0, 0, 0, 0, 7, 4)
+            )
+            $solution = @(
+              ,@(2, 3, 5, 6, 7, 8, 1, 4, 9)
+              ,@(9, 4, 7, 1, 3, 5, 8, 6, 2)
+              ,@(6, 8, 1, 2, 4, 9, 3, 5, 7)
+              ,@(1, 2, 8, 7, 6, 4, 5, 9, 3)
+              ,@(4, 5, 6, 8, 9, 3, 7, 2, 1)
+              ,@(7, 9, 3, 5, 2, 1, 4, 8, 6)
+              ,@(3, 6, 4, 9, 5, 7, 2, 1, 8)
+              ,@(8, 7, 9, 4, 1, 2, 6, 3, 5)
+              ,@(5, 1, 2, 3, 8, 6, 9, 7, 4)
+            )
+            $lines = [System.Collections.Generic.List[string]]::new()
+
+            function Add-SudokuGrid([string] $label, [object[]] $grid) {
+              $lines.Add($label)
+              for ($i = 0; $i -lt $grid.Count; $i++) {
+                if ($i % 3 -eq 0 -and $i -ne 0) {
+                  $lines.Add('- - - - - - - - - - - -')
+                }
+                $line = ''
+                for ($j = 0; $j -lt $grid[$i].Count; $j++) {
+                  if ($j % 3 -eq 0 -and $j -ne 0) {
+                    $line += ' | '
+                  }
+                  $line += "$($grid[$i][$j]) "
+                }
+                $lines.Add($line)
+              }
+            }
+
+            Add-SudokuGrid 'Sudoku Puzzle:' $puzzle
+            $lines.Add('Solving...')
+            Add-SudokuGrid 'Solution:' $solution
+            return $lines.ToArray()
+          }
+
+          $sudoku_lines = @(Get-SudokuExpectedLines)
+          $sudoku_expected = [System.Text.Encoding]::UTF8.GetBytes(($sudoku_lines -join "`n") + "`n")
+          if ($sudoku_expected.Length -ne 582) {
+            throw "sudoku stdout oracle shape changed: $($sudoku_expected.Length) bytes"
+          }
+          Invoke-NativeX64Example 'examples/sudoku.v' 'sudoku' $sudoku_expected
+
+          $function_types_expected = [System.Text.Encoding]::UTF8.GetBytes("HELLO WORLD`nHELLO WORLD`nHELLO WORLD`n")
+          Invoke-NativeX64Example 'examples/function_types.v' 'function_types' $function_types_expected
+
+          $submodule_expected = [System.Text.Encoding]::UTF8.GetBytes("5`n3`n")
+          Invoke-NativeX64Example 'examples/submodule/main.v' 'submodule' $submodule_expected
+
+          function Get-TreeOfNodesExpectedLines {
+            @(
+              'tree structure:'
+              ' Node{'
+              '    value: 10'
+              '    left: Tree(Node{'
+              '        value: 30'
+              '        left: Tree(Empty{})'
+              '        right: Tree(Empty{})'
+              '    })'
+              '    right: Tree(Node{'
+              '        value: 20'
+              '        left: Tree(Empty{})'
+              '        right: Tree(Empty{})'
+              '    })'
+              '}'
+              'tree size: 3'
+            )
+          }
+
+          $tree_of_nodes_lines = @(Get-TreeOfNodesExpectedLines)
+          $tree_of_nodes_expected = [System.Text.Encoding]::UTF8.GetBytes(($tree_of_nodes_lines -join "`n") + "`n")
+          if ($tree_of_nodes_expected.Length -ne 259) {
+            throw "tree_of_nodes stdout oracle shape changed: $($tree_of_nodes_expected.Length) bytes"
+          }
+          Invoke-NativeX64Example 'examples/tree_of_nodes.v' 'tree_of_nodes' $tree_of_nodes_expected
+
+          $js_hello_world_expected = [System.Text.Encoding]::UTF8.GetBytes("Hello from V.js (0)`nHello from V.js (1)`nHello from V.js (2)`n")
+          Invoke-NativeX64Example 'examples/js_hello_world.v' 'js_hello_world' $js_hello_world_expected
+
+          function Get-VSingleQuotedLiteralBytes([string] $literal) {
+            $bytes = [System.Collections.Generic.List[byte]]::new()
+            for ($i = 0; $i -lt $literal.Length; $i++) {
+              $ch = $literal[$i]
+              if ($ch -eq '\') {
+                $i++
+                if ($i -ge $literal.Length) {
+                  throw 'unterminated escape in V single-quoted literal'
+                }
+                $escaped = $literal[$i]
+                switch ([int][char] $escaped) {
+                  110 { [void] $bytes.Add(10) }
+                  116 { [void] $bytes.Add(9) }
+                  114 { [void] $bytes.Add(13) }
+                  92 { [void] $bytes.Add(92) }
+                  39 { [void] $bytes.Add(39) }
+                  34 { [void] $bytes.Add(34) }
+                  default {
+                    foreach ($byte in [System.Text.Encoding]::UTF8.GetBytes([string] $escaped)) {
+                      [void] $bytes.Add($byte)
+                    }
+                  }
+                }
+              } else {
+                foreach ($byte in [System.Text.Encoding]::UTF8.GetBytes([string] $ch)) {
+                  [void] $bytes.Add($byte)
+                }
+              }
+            }
+            return $bytes.ToArray()
+          }
+
+          function Get-VasciiExpectedBytes() {
+            $source = [System.IO.File]::ReadAllText((Join-Path (Get-Location) 'examples/vascii.v'), [System.Text.Encoding]::UTF8)
+            $start_marker = "println('"
+            $end_marker = "')"
+            $first = $source.IndexOf($start_marker, [System.StringComparison]::Ordinal)
+            if ($first -lt 0) {
+              throw 'missing vascii println literal start'
+            }
+            $second = $source.IndexOf($start_marker, $first + $start_marker.Length, [System.StringComparison]::Ordinal)
+            if ($second -ne -1) {
+              throw 'vascii stdout oracle expects one single-quoted println literal'
+            }
+            $start = $first + $start_marker.Length
+            $end = $source.LastIndexOf($end_marker, [System.StringComparison]::Ordinal)
+            if ($end -lt $start) {
+              throw 'missing vascii println literal end'
+            }
+            if ($source.Substring($end + $end_marker.Length).Trim() -ne '}') {
+              throw 'vascii stdout oracle expects the println literal to be the final main statement'
+            }
+            [byte[]] $bytes = Get-VSingleQuotedLiteralBytes ($source.Substring($start, $end - $start))
+            return $bytes + [byte] 10
+          }
+
+          [byte[]] $vascii_expected = Get-VasciiExpectedBytes
+          Invoke-NativeX64Example 'examples/vascii.v' 'vascii' $vascii_expected
+
+          [byte[]] $rune_expected = 0xF0, 0x9F, 0x98, 0x80, 0x0A, 0x40, 0x0A
+          Invoke-NativeX64Example 'examples/rune.v' 'rune' $rune_expected
+
+          [byte[]] $bfs_expected = Get-VRunExpectedBytes 'examples/graphs/bfs.v' 'bfs'
+          Invoke-NativeX64Example 'examples/graphs/bfs.v' 'bfs' $bfs_expected
+
+          [byte[]] $dfs_expected = Get-VRunExpectedBytes 'examples/graphs/dfs.v' 'dfs'
+          Invoke-NativeX64Example 'examples/graphs/dfs.v' 'dfs' $dfs_expected
+
+          [byte[]] $dijkstra_expected = Get-VRunExpectedBytes 'examples/graphs/dijkstra.v' 'dijkstra'
+          Invoke-NativeX64Example 'examples/graphs/dijkstra.v' 'dijkstra' $dijkstra_expected
       - name: Build V with WX
         run: v -cflags /WX self
       - name: All code is formatted

--- a/vlib/v2/builder/builder.v
+++ b/vlib/v2/builder/builder.v
@@ -1597,6 +1597,7 @@ fn is_macos_x64_native_target(arch pref.Arch, target_os string) bool {
 fn eprint_native_x64_link_error(message string) {
 	if message.starts_with('x64: unsupported backend feature: ') {
 		eprintln(message)
+		eprintln(x64.x64_backend_limitation_hint)
 		return
 	}
 	eprintln('Link failed:')
@@ -1635,11 +1636,28 @@ fn (b &Builder) uses_macos_x64_tiny_object(arch pref.Arch) bool {
 }
 
 fn macos_native_link_command(output_binary string, obj_file string, sdk_path string, arch_flag string, tiny_object bool) string {
-	normal_link_cmd := 'ld -o ${output_binary} ${obj_file} -lSystem -syslibroot "${sdk_path}" -e _main -arch ${arch_flag} -platform_version macos 11.0.0 11.0.0'
+	normal_link_cmd := 'ld -o ${os.quoted_path(output_binary)} ${os.quoted_path(obj_file)} -lSystem -syslibroot ${os.quoted_path(sdk_path)} -e _main -arch ${arch_flag} -platform_version macos 11.0.0 11.0.0'
 	if tiny_object {
 		return '${normal_link_cmd} -dead_strip -x -S'
 	}
 	return normal_link_cmd
+}
+
+fn native_external_object_file(output_binary string, target_os string) string {
+	if !is_macos_native_target(target_os) {
+		return 'main.o'
+	}
+	output_path := if os.is_abs_path(output_binary) {
+		output_binary
+	} else {
+		os.abs_path(output_binary)
+	}
+	output_dir := os.dir(output_path)
+	output_name := os.file_name(output_path)
+	if output_name == '' {
+		return os.join_path(output_dir, '.v_native_${os.getpid()}.o')
+	}
+	return os.join_path(output_dir, '.${output_name}.${os.getpid()}.o')
 }
 
 fn (mut b Builder) prepare_macos_tiny_candidate_source_files() {
@@ -1678,6 +1696,20 @@ fn native_x64_lowering_abi_for_os(target_os string) abi.X64Abi {
 		'windows' { abi.X64Abi.windows }
 		else { abi.X64Abi.sysv }
 	}
+}
+
+fn native_x64_mir_unsupported_external_symbol_message(mir_mod &mir.Module, obj_format x64.ObjectFormat) ?string {
+	for val in mir_mod.values {
+		if val.kind != .func_ref {
+			continue
+		}
+		if msg := x64.unsupported_external_symbol_message_for_name(obj_format, val.name,
+			'needed while preparing native x64 output')
+		{
+			return msg
+		}
+	}
+	return none
 }
 
 fn (b &Builder) native_backend_requires_ssa_optimization(arch pref.Arch) bool {
@@ -2676,7 +2708,7 @@ fn (mut b Builder) gen_native(backend_arch pref.Arch) {
 		}
 	} else {
 		// Generate object file and use external linker
-		obj_file := 'main.o'
+		obj_file := native_external_object_file(output_binary, target_os)
 		mut used_macos_tiny_object := false
 
 		if arch == .arm64 {
@@ -2690,6 +2722,10 @@ fn (mut b Builder) gen_native(backend_arch pref.Arch) {
 		} else {
 			obj_format := native_x64_object_format_for_os(target_os)
 			codegen_abi := native_x64_codegen_abi_for_os(target_os)
+			if msg := native_x64_mir_unsupported_external_symbol_message(&mir_mod, obj_format) {
+				eprint_native_x64_link_error(msg)
+				exit(1)
+			}
 			if is_windows_x64_native_target(arch, target_os) {
 				mut windows_gen := x64.Gen.new_with_format_and_abi(&mir_mod, obj_format,
 					codegen_abi)
@@ -2785,6 +2821,16 @@ fn (mut b Builder) gen_native(backend_arch pref.Arch) {
 			if link_result.exit_code != 0 && used_macos_tiny_object {
 				if b.pref.verbose {
 					println('[*] macOS tiny object link failed; retrying with normal Mach-O object')
+					println('[*] macOS tiny object link exit code: ${link_result.exit_code}')
+					println('[*] macOS tiny object link output:')
+					if link_result.output.len > 0 {
+						print(link_result.output)
+						if !link_result.output.ends_with('\n') {
+							println('')
+						}
+					} else {
+						println('<empty>')
+					}
 				}
 				if os.exists(output_binary) {
 					os.rm(output_binary) or {}

--- a/vlib/v2/builder/native_test.v
+++ b/vlib/v2/builder/native_test.v
@@ -187,7 +187,7 @@ fn test_macos_tiny_link_command_adds_hygiene_only_for_tiny_object() {
 	normal := macos_native_link_command('/tmp/out', 'main.o', '/SDK Path', 'x86_64', false)
 	tiny := macos_native_link_command('/tmp/out', 'main.o', '/SDK Path', 'x86_64', true)
 
-	assert normal == 'ld -o /tmp/out main.o -lSystem -syslibroot "/SDK Path" -e _main -arch x86_64 -platform_version macos 11.0.0 11.0.0'
+	assert normal == 'ld -o ${os.quoted_path('/tmp/out')} ${os.quoted_path('main.o')} -lSystem -syslibroot ${os.quoted_path('/SDK Path')} -e _main -arch x86_64 -platform_version macos 11.0.0 11.0.0'
 	assert tiny == '${normal} -dead_strip -x -S'
 	assert !normal.contains('-dead_strip')
 	assert !normal.contains(' -x')

--- a/vlib/v2/builder/ssa_build_parallel.v
+++ b/vlib/v2/builder/ssa_build_parallel.v
@@ -9,9 +9,10 @@ import v2.ssa
 
 // FnDeclRef references a function declaration within the files array.
 struct FnDeclRef {
-	file_idx int
-	stmt_idx int
-	mod_name string
+	file_idx                  int
+	stmt_idx                  int
+	mod_name                  string
+	selective_import_fn_names map[string]string
 }
 
 $if !windows {
@@ -42,6 +43,7 @@ $if !windows {
 		for fi := a.start_idx; fi < a.end_idx; fi++ {
 			ref := unsafe { fn_refs[fi] }
 			worker_b.cur_module = ref.mod_name
+			worker_b.set_selective_import_fn_names(ref.selective_import_fn_names)
 			file := unsafe { (*files)[ref.file_idx] }
 			stmt := file.stmts[ref.stmt_idx]
 			decl := stmt as ast.FnDecl
@@ -62,6 +64,7 @@ fn (mut b Builder) ssa_build_parallel(mut ssa_builder ssa.Builder, files []ast.F
 	for fi in 0 .. files.len {
 		file := files[fi]
 		mod_name := ssa.file_module_name(file)
+		selective_import_fn_names := ssa.selective_import_fn_names_from_imports(file.imports)
 		nstmts := file.stmts.len
 		for si in 0 .. nstmts {
 			stmt := file.stmts[si]
@@ -81,9 +84,10 @@ fn (mut b Builder) ssa_build_parallel(mut ssa_builder ssa.Builder, files []ast.F
 					}
 				}
 				fn_refs << FnDeclRef{
-					file_idx: fi
-					stmt_idx: si
-					mod_name: mod_name
+					file_idx:                  fi
+					stmt_idx:                  si
+					mod_name:                  mod_name
+					selective_import_fn_names: selective_import_fn_names.clone()
 				}
 			}
 		}
@@ -92,11 +96,13 @@ fn (mut b Builder) ssa_build_parallel(mut ssa_builder ssa.Builder, files []ast.F
 	n_fns := fn_refs.len
 	$if windows {
 		ssa_builder.build_all_fn_bodies(files)
+		ssa_builder.generate_referenced_synthetic_runtime_stubs()
 		return
 	} $else {
 		if n_fns <= 1 || n_jobs <= 1 {
 			// Fallback to sequential
 			ssa_builder.build_all_fn_bodies(files)
+			ssa_builder.generate_referenced_synthetic_runtime_stubs()
 			return
 		}
 
@@ -184,5 +190,6 @@ fn (mut b Builder) ssa_build_parallel(mut ssa_builder ssa.Builder, files []ast.F
 			mod.merge_worker_module(w_mod, func_data, seed_values, seed_instrs, seed_blocks,
 				seed_types, seed_funcs)
 		}
+		ssa_builder.generate_referenced_synthetic_runtime_stubs()
 	}
 }

--- a/vlib/v2/builder/target_os_test.v
+++ b/vlib/v2/builder/target_os_test.v
@@ -505,6 +505,26 @@ struct WindowsX64BuildResult {
 	image             []u8
 }
 
+fn windows_x64_map_string_wyhash_source() string {
+	return "module main
+
+fn sink_map(_ map[string]int) {}
+
+fn main() {
+	graph := {
+		'A': 1
+		'B': 2
+	}
+	sink_map(graph)
+}
+"
+}
+
+fn assert_windows_x64_map_string_wyhash_resolved(res WindowsX64BuildResult) {
+	assert 'wyhash' in res.built_functions, res.built_functions.str()
+	assert 'wyhash' !in res.undefined_symbols, res.undefined_symbols.str()
+}
+
 fn test_windows_x64_empty_main_links_without_crt_or_darwin_symbols() {
 	res := build_windows_x64_sample('module main\nfn main() {}\n', false, true)
 
@@ -567,6 +587,23 @@ fn test_windows_x64_minimal_runtime_builds_markused_core_functions() {
 	assert 'builtin__println' in res.built_functions, res.built_functions.str()
 	assert 'stderr' !in res.undefined_symbols, res.undefined_symbols.str()
 	assert_no_windows_minimal_runtime_retention(res.built_functions)
+}
+
+fn test_windows_x64_minimal_runtime_map_string_generates_referenced_wyhash_stub_sequential() {
+	res := build_windows_x64_sample(windows_x64_map_string_wyhash_source(), false, true)
+	assert_windows_x64_map_string_wyhash_resolved(res)
+}
+
+fn test_windows_x64_minimal_runtime_map_string_generates_referenced_wyhash_stub_flat() {
+	res := build_windows_x64_sample_configured(windows_x64_map_string_wyhash_source(), false, true,
+		true, true)
+	assert_windows_x64_map_string_wyhash_resolved(res)
+}
+
+fn test_windows_x64_minimal_runtime_map_string_generates_referenced_wyhash_stub_native_builder_path() {
+	res := build_windows_x64_sample_configured(windows_x64_map_string_wyhash_source(), false, true,
+		false, false)
+	assert_windows_x64_map_string_wyhash_resolved(res)
 }
 
 fn test_windows_x64_minimal_runtime_os_getwd_markused_does_not_retain_stdio_file_helpers() {
@@ -976,9 +1013,13 @@ fn assert_no_windows_large_runtime_module_retention(built_functions []string) {
 }
 
 fn build_windows_x64_sample(source string, link bool, optimize bool) WindowsX64BuildResult {
-	return build_windows_x64_sample_with_files({
+	return build_windows_x64_sample_configured(source, link, optimize, true, false)
+}
+
+fn build_windows_x64_sample_configured(source string, link bool, optimize bool, no_parallel bool, use_flat bool) WindowsX64BuildResult {
+	return build_windows_x64_sample_with_files_configured({
 		'main.v': source
-	}, link, optimize)
+	}, link, optimize, no_parallel, use_flat)
 }
 
 fn build_windows_x64_markused_sample(source string) map[string]bool {
@@ -1073,8 +1114,12 @@ fn windows_x64_markused_key_contains(used map[string]bool, needle string) bool {
 }
 
 fn build_windows_x64_sample_with_files(sources map[string]string, link bool, optimize bool) WindowsX64BuildResult {
+	return build_windows_x64_sample_with_files_configured(sources, link, optimize, true, false)
+}
+
+fn build_windows_x64_sample_with_files_configured(sources map[string]string, link bool, optimize bool, no_parallel bool, use_flat bool) WindowsX64BuildResult {
 	tmp_dir := os.join_path(os.temp_dir(),
-		'v2_builder_windows_x64_sample_${os.getpid()}_${sources.len}_${link}_${optimize}')
+		'v2_builder_windows_x64_sample_${os.getpid()}_${sources.len}_${link}_${optimize}_${no_parallel}_${use_flat}')
 	os.rmdir_all(tmp_dir) or {}
 	os.mkdir_all(tmp_dir) or { panic(err) }
 	defer {
@@ -1095,11 +1140,13 @@ fn build_windows_x64_sample_with_files(sources map[string]string, link bool, opt
 	prefs.arch = .x64
 	prefs.target_os = 'windows'
 	prefs.skip_type_check = true
-	prefs.no_parallel = true
+	prefs.no_parallel = no_parallel
 	prefs.no_parallel_transform = true
 	prefs.no_cache = true
+	prefs.no_optimize = !optimize
 
 	mut b := new_builder(&prefs)
+	b.flat_check_enabled = use_flat
 	b.user_files = [main_path]
 	parse_test_builder_files(mut b, [main_path])
 	b.env = types.Environment.new()
@@ -1117,15 +1164,22 @@ fn build_windows_x64_sample_with_files(sources map[string]string, link bool, opt
 	ssa_builder.minimal_runtime_roots = true
 	ssa_builder.native_backend_bulk_zero_alloca = true
 	ssa_builder.used_fn_keys = b.used_fn_keys.clone()
-	build_test_ssa(mut b, mut ssa_builder)
-	if optimize {
-		ssa_optimize.optimize(mut ssa_mod)
+	mut mir_mod := mir.Module{}
+	mut built_functions := []string{}
+	if no_parallel {
+		build_test_ssa(mut b, mut ssa_builder)
+		if optimize {
+			ssa_optimize.optimize(mut ssa_mod)
+		}
+		built_functions = ssa_mod.funcs.filter(it.blocks.len > 0).map(it.name)
+		mir_mod = mir.lower_from_ssa(ssa_mod)
+		abi.lower_with_x64_abi(mut mir_mod, .x64, .windows)
+		insel.select(mut mir_mod, .x64)
+	} else {
+		mir_mod = b.build_native_mir_from_files(b.files, .x64, 'windows', true, b.used_fn_keys,
+			'Windows x64 sample')
+		built_functions = mir_mod.funcs.filter(it.blocks.len > 0).map(it.name)
 	}
-	built_functions := ssa_mod.funcs.filter(it.blocks.len > 0).map(it.name)
-
-	mut mir_mod := mir.lower_from_ssa(ssa_mod)
-	abi.lower_with_x64_abi(mut mir_mod, .x64, .windows)
-	insel.select(mut mir_mod, .x64)
 
 	mut gen := x64.Gen.new_with_format_and_abi(&mir_mod, .coff, .windows)
 	gen.gen()

--- a/vlib/v2/builder/transform_parallel.v
+++ b/vlib/v2/builder/transform_parallel.v
@@ -486,32 +486,34 @@ fn stmt_can_split_top_level(stmt ast.Stmt) bool {
 	}
 }
 
-fn lpt_stmt_buckets(jobs []TransformStmtJob, n_jobs int) [][]TransformStmtJob {
-	mut order := []int{len: jobs.len, init: index}
-	for i in 1 .. order.len {
-		key := order[i]
-		kc := jobs[key].cost
-		mut j := i - 1
-		for j >= 0 && jobs[order[j]].cost < kc {
-			order[j + 1] = order[j]
-			j--
-		}
-		order[j + 1] = key
-	}
-	mut buckets := [][]TransformStmtJob{len: n_jobs}
-	mut load := []i64{len: n_jobs}
-	for job_idx in order {
-		mut mw := 0
-		for w in 1 .. n_jobs {
-			if load[w] < load[mw] {
-				mw = w
+$if !windows {
+	fn lpt_stmt_buckets(jobs []TransformStmtJob, n_jobs int) [][]TransformStmtJob {
+		mut order := []int{len: jobs.len, init: index}
+		for i in 1 .. order.len {
+			key := order[i]
+			kc := jobs[key].cost
+			mut j := i - 1
+			for j >= 0 && jobs[order[j]].cost < kc {
+				order[j + 1] = order[j]
+				j--
 			}
+			order[j + 1] = key
 		}
-		job := jobs[job_idx]
-		buckets[mw] << job
-		load[mw] += i64(job.cost)
+		mut buckets := [][]TransformStmtJob{len: n_jobs}
+		mut load := []i64{len: n_jobs}
+		for job_idx in order {
+			mut mw := 0
+			for w in 1 .. n_jobs {
+				if load[w] < load[mw] {
+					mw = w
+				}
+			}
+			job := jobs[job_idx]
+			buckets[mw] << job
+			load[mw] += i64(job.cost)
+		}
+		return buckets
 	}
-	return buckets
 }
 
 fn top_level_transform_stmt_cost(stmt ast.Stmt) int {

--- a/vlib/v2/gen/x64/diagnostics.v
+++ b/vlib/v2/gen/x64/diagnostics.v
@@ -5,7 +5,7 @@
 module x64
 
 const x64_backend_feature_prefix = 'backend feature: '
-const x64_backend_limitation_hint = 'x64: native backend limitation: retry with the C backend or reduce the source to supported x64 features'
+pub const x64_backend_limitation_hint = 'x64: native backend limitation: retry with the C backend or reduce the source to supported x64 features'
 
 const x64_minimal_unsupported_crt_stdio_symbols = ['stdin', 'stdout', 'stderr', 'printf', 'fprintf',
 	'dprintf', 'sprintf', 'snprintf', 'wprintf', 'puts', 'fputs', 'setvbuf', 'fflush', 'fopen',
@@ -13,6 +13,7 @@ const x64_minimal_unsupported_crt_stdio_symbols = ['stdin', 'stdout', 'stderr', 
 	'fgets', 'getc', 'feof', 'ferror', 'fseek', 'ftell', 'rewind', 'fileno', '_fileno',
 	'_get_osfhandle', '_open_osfhandle', 'fgetpos']
 
+const x64_unsupported_captured_fn_literal_symbol = 'v2_unsupported_captured_fn_literal'
 const x64_missing_v_runtime_helpers = ['builtin__Map_string_int__keys']
 
 fn x64_normalize_backend_feature(feature string) string {
@@ -49,10 +50,21 @@ fn x64_unresolved_external_symbol_message(format ObjectFormat, name string, cont
 	if format == .coff && name in x64_minimal_unsupported_crt_stdio_symbols {
 		return x64_unsupported_backend_feature_message('${linker_name} cannot resolve C stdio/file-descriptor symbol `${name}`: Windows x64 native backend uses Kernel32 handles, not C FILE/stdio calls; ${context}')
 	}
+	if name == x64_unsupported_captured_fn_literal_symbol {
+		return x64_unsupported_backend_feature_message('native x64 cannot lower captured function literal: closure environments are not implemented yet; ${context}')
+	}
 	if name in x64_missing_v_runtime_helpers {
 		return x64_unsupported_backend_feature_message('${linker_name} cannot resolve V runtime helper `${name}`: native x64 backend does not implement this feature for this target yet; ${context}')
 	}
 	return x64_unsupported_backend_feature_message('${linker_name} cannot resolve external symbol `${name}` yet; ${context}')
+}
+
+pub fn unsupported_external_symbol_message_for_name(format ObjectFormat, raw_name string, context string) ?string {
+	name := x64_normalize_external_symbol_name(format, raw_name)
+	if x64_symbol_needs_backend_runtime_support(name) {
+		return x64_unresolved_external_symbol_message(format, name, context)
+	}
+	return none
 }
 
 fn x64_normalize_external_symbol_name(format ObjectFormat, name string) string {
@@ -63,5 +75,6 @@ fn x64_normalize_external_symbol_name(format ObjectFormat, name string) string {
 }
 
 fn x64_symbol_needs_backend_runtime_support(name string) bool {
-	return name in x64_missing_v_runtime_helpers
+	return name == x64_unsupported_captured_fn_literal_symbol
+		|| name in x64_missing_v_runtime_helpers
 }

--- a/vlib/v2/gen/x64/elf_tiny.v
+++ b/vlib/v2/gen/x64/elf_tiny.v
@@ -17,6 +17,11 @@ const linux_mmap_private_anonymous = u32(0x22)
 const linux_tiny_int_str_arena_bytes = u32(4096)
 const linux_tiny_int_str_slot_bytes = 32
 const linux_tiny_int_str_arena_metadata_bytes = 16
+const linux_tiny_rune_str_arena_bytes = u32(4096)
+const linux_tiny_rune_str_slot_bytes = 8
+const linux_tiny_rune_str_arena_metadata_bytes = 16
+const linux_tiny_string_plus_arena_bytes = u32(4096)
+const linux_tiny_string_plus_arena_metadata_bytes = 16
 
 pub const linux_tiny_not_eligible_prefix = 'Linux tiny executable is not eligible: '
 
@@ -34,9 +39,11 @@ struct ElfDataRange {
 
 struct ElfTinyRuntime {
 mut:
-	text                  []u8
-	symbols               map[string]u64
-	int_str_arena_patches []int
+	text                      []u8
+	symbols                   map[string]u64
+	int_str_arena_patches     []int
+	rune_str_arena_patches    []int
+	string_plus_arena_patches []int
 }
 
 struct ElfTinyReachable {
@@ -87,10 +94,17 @@ fn (mut l ElfTinyLinker) write(path string) ! {
 	mut data_offsets := map[string]u64{}
 	l.copy_data_ranges(selected_data, .rodata, mut rodata, mut data_offsets)!
 	l.copy_data_ranges(selected_data, .data, mut data, mut data_offsets)!
-	bss_bytes := if 'builtin__int__str' in reachable.runtime_symbols {
-		linux_tiny_int_str_arena_metadata_bytes
-	} else {
-		0
+	int_str_runtime_needed := 'builtin__int__str' in reachable.runtime_symbols
+		|| 'builtin__i64__str' in reachable.runtime_symbols
+	mut bss_bytes := 0
+	if int_str_runtime_needed {
+		bss_bytes += linux_tiny_int_str_arena_metadata_bytes
+	}
+	if 'builtin__rune__str' in reachable.runtime_symbols {
+		bss_bytes += linux_tiny_rune_str_arena_metadata_bytes
+	}
+	if 'builtin__string__+' in reachable.runtime_symbols {
+		bss_bytes += linux_tiny_string_plus_arena_metadata_bytes
 	}
 	if rodata.len > 0 {
 		for text.len % int(l.data_section_alignment(.rodata)) != 0 {
@@ -106,8 +120,29 @@ fn (mut l ElfTinyLinker) write(path string) ! {
 	data_vaddr := linux_tiny_base_vaddr + u64(data_off)
 	bss_vaddr := if data.len > 0 { data_vaddr + u64(data.len) } else { data_vaddr }
 	if bss_bytes > 0 {
-		for field_off in runtime.int_str_arena_patches {
-			elf_tiny_patch_rel32(mut text, int(runtime_base) + field_off, text_vaddr, 0, bss_vaddr)
+		mut bss_offset := u64(0)
+		if int_str_runtime_needed {
+			int_str_arena_vaddr := bss_vaddr + bss_offset
+			for field_off in runtime.int_str_arena_patches {
+				elf_tiny_patch_rel32(mut text, int(runtime_base) + field_off, text_vaddr, 0,
+					int_str_arena_vaddr)
+			}
+			bss_offset += u64(linux_tiny_int_str_arena_metadata_bytes)
+		}
+		if 'builtin__rune__str' in reachable.runtime_symbols {
+			rune_str_arena_vaddr := bss_vaddr + bss_offset
+			for field_off in runtime.rune_str_arena_patches {
+				elf_tiny_patch_rel32(mut text, int(runtime_base) + field_off, text_vaddr, 0,
+					rune_str_arena_vaddr)
+			}
+			bss_offset += u64(linux_tiny_rune_str_arena_metadata_bytes)
+		}
+		if 'builtin__string__+' in reachable.runtime_symbols {
+			string_plus_arena_vaddr := bss_vaddr + bss_offset
+			for field_off in runtime.string_plus_arena_patches {
+				elf_tiny_patch_rel32(mut text, int(runtime_base) + field_off, text_vaddr, 0,
+					string_plus_arena_vaddr)
+			}
 		}
 	}
 	mut symbols := map[string]u64{}
@@ -337,6 +372,9 @@ fn (mut l ElfTinyLinker) collect_reachable() !ElfTinyReachable {
 			} else if sym.shndx == u16(l.elf_section_index(.rodata)) {
 				l.add_data_range(mut selected_data, .rodata, sym.value)!
 			} else if sym.shndx == u16(l.elf_section_index(.data)) {
+				if x64_main_argc_global_name(sym.name) || x64_main_argv_global_name(sym.name) {
+					return linux_tiny_not_eligible('arguments() requires hosted argc/argv; Linux tiny _start argv is not implemented yet')
+				}
 				l.add_data_range(mut selected_data, .data, sym.value)!
 			} else if sym.shndx == 0 {
 				if !l.tiny_runtime_symbol_name(sym.name) {
@@ -401,6 +439,18 @@ fn (mut l ElfTinyLinker) build_runtime(runtime_symbols map[string]bool) ElfTinyR
 	if 'builtin__int__str' in runtime_symbols {
 		rt.symbols['builtin__int__str'] = u64(rt.text.len)
 		elf_tiny_emit_int_str(mut rt)
+	}
+	if 'builtin__i64__str' in runtime_symbols {
+		rt.symbols['builtin__i64__str'] = u64(rt.text.len)
+		elf_tiny_emit_i64_str(mut rt)
+	}
+	if 'builtin__rune__str' in runtime_symbols {
+		rt.symbols['builtin__rune__str'] = u64(rt.text.len)
+		elf_tiny_emit_rune_str(mut rt)
+	}
+	if 'builtin__string__+' in runtime_symbols {
+		rt.symbols['builtin__string__+'] = u64(rt.text.len)
+		elf_tiny_emit_string_plus(mut rt)
 	}
 	return rt
 }
@@ -487,6 +537,14 @@ fn elf_tiny_emit_ultra_stdout(mut text []u8, stdout_len int) int {
 }
 
 fn elf_tiny_emit_int_str(mut rt ElfTinyRuntime) {
+	elf_tiny_emit_signed_decimal_str(mut rt, false)
+}
+
+fn elf_tiny_emit_i64_str(mut rt ElfTinyRuntime) {
+	elf_tiny_emit_signed_decimal_str(mut rt, true)
+}
+
+fn elf_tiny_emit_signed_decimal_str(mut rt ElfTinyRuntime, is_i64 bool) {
 	rt.text << u8(0x57) // push rdi
 	rt.text << [u8(0x4c), 0x8d, 0x1d] // lea r11, [arena]
 	rt.int_str_arena_patches << rt.text.len
@@ -535,15 +593,31 @@ fn elf_tiny_emit_int_str(mut rt ElfTinyRuntime) {
 	rt.text << [u8(0x49), 0x89, 0xc0] // mov r8, rax
 	allocated_off := rt.text.len
 	rt.text << u8(0x5f) // pop rdi
-	rt.text << [u8(0x89), 0xf8] // mov eax, edi
+	if is_i64 {
+		rt.text << [u8(0x48), 0x89, 0xf8] // mov rax, rdi
+	} else {
+		rt.text << [u8(0x89), 0xf8] // mov eax, edi
+	}
 	rt.text << [u8(0x45), 0x31, 0xc9] // xor r9d, r9d
 	rt.text << [u8(0x45), 0x31, 0xd2] // xor r10d, r10d
-	rt.text << [u8(0x85), 0xc0] // test eax, eax
+	if is_i64 {
+		rt.text << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	} else {
+		rt.text << [u8(0x85), 0xc0] // test eax, eax
+	}
 	non_negative_field := elf_tiny_emit_rel8_placeholder(mut rt.text, 0x79) // jns non_negative
 	rt.text << [u8(0x41), 0xb2, 0x01] // mov r10b, 1
-	rt.text << [u8(0xf7), 0xd8] // neg eax
+	if is_i64 {
+		rt.text << [u8(0x48), 0xf7, 0xd8] // neg rax
+	} else {
+		rt.text << [u8(0xf7), 0xd8] // neg eax
+	}
 	non_negative_off := rt.text.len
-	rt.text << [u8(0x85), 0xc0] // test eax, eax
+	if is_i64 {
+		rt.text << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	} else {
+		rt.text << [u8(0x85), 0xc0] // test eax, eax
+	}
 	non_zero_field := elf_tiny_emit_rel8_placeholder(mut rt.text, 0x75) // jne loop
 	rt.text << [u8(0x49), 0xff, 0xc8] // dec r8
 	rt.text << [u8(0x41), 0xc6, 0x00, 0x30] // mov byte ptr [r8], '0'
@@ -552,12 +626,20 @@ fn elf_tiny_emit_int_str(mut rt ElfTinyRuntime) {
 	loop_start := rt.text.len
 	rt.text << [u8(0x31), 0xd2] // xor edx, edx
 	rt.text << [u8(0xb9), 0x0a, 0, 0, 0] // mov ecx, 10
-	rt.text << [u8(0xf7), 0xf1] // div ecx
+	if is_i64 {
+		rt.text << [u8(0x48), 0xf7, 0xf1] // div rcx
+	} else {
+		rt.text << [u8(0xf7), 0xf1] // div ecx
+	}
 	rt.text << [u8(0x80), 0xc2, 0x30] // add dl, '0'
 	rt.text << [u8(0x49), 0xff, 0xc8] // dec r8
 	rt.text << [u8(0x41), 0x88, 0x10] // mov [r8], dl
 	rt.text << [u8(0x49), 0xff, 0xc1] // inc r9
-	rt.text << [u8(0x85), 0xc0] // test eax, eax
+	if is_i64 {
+		rt.text << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	} else {
+		rt.text << [u8(0x85), 0xc0] // test eax, eax
+	}
 	loop_field := elf_tiny_emit_rel8_placeholder(mut rt.text, 0x75) // jne loop
 	maybe_sign_off := rt.text.len
 	rt.text << [u8(0x45), 0x84, 0xd2] // test r10b, r10b
@@ -578,6 +660,278 @@ fn elf_tiny_emit_int_str(mut rt ElfTinyRuntime) {
 	elf_tiny_patch_rel8(mut rt.text, need_mmap_field, need_mmap_off)
 	elf_tiny_patch_rel8(mut rt.text, have_block_field, have_block_off)
 	elf_tiny_patch_rel8(mut rt.text, allocated_field, allocated_off)
+}
+
+fn elf_tiny_emit_rune_str(mut rt ElfTinyRuntime) {
+	rt.text << u8(0x57) // push rdi
+	rt.text << [u8(0x4c), 0x8d, 0x1d] // lea r11, [arena]
+	rt.rune_str_arena_patches << rt.text.len
+	rt.text << [u8(0), 0, 0, 0]
+	rt.text << [u8(0x4d), 0x8b, 0x03] // mov r8, [r11]
+	rt.text << [u8(0x4d), 0x8b, 0x4b, 0x08] // mov r9, [r11+8]
+	rt.text << [u8(0x4d), 0x85, 0xc0] // test r8, r8
+	need_mmap_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x84]) // je need_mmap
+	rt.text << [u8(0x49), 0x8d, 0x40, u8(linux_tiny_rune_str_slot_bytes)] // lea rax, [r8+8]
+	rt.text << [u8(0x4c), 0x39, 0xc8] // cmp rax, r9
+	have_block_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x86]) // jbe have_block
+	need_mmap_off := rt.text.len
+	rt.text << [u8(0x31), 0xff] // xor edi, edi
+	rt.text << u8(0xbe)
+	write_u32_le(mut rt.text, linux_tiny_rune_str_arena_bytes)
+	rt.text << u8(0xba)
+	write_u32_le(mut rt.text, linux_mmap_prot_read_write)
+	rt.text << [u8(0x41), 0xba]
+	write_u32_le(mut rt.text, linux_mmap_private_anonymous)
+	rt.text << [u8(0x49), 0xc7, 0xc0]
+	write_u32_le(mut rt.text, u32(0xffff_ffff))
+	rt.text << [u8(0x45), 0x31, 0xc9] // xor r9d, r9d
+	rt.text << u8(0xb8)
+	write_u32_le(mut rt.text, linux_sys_mmap)
+	rt.text << [u8(0x0f), 0x05] // syscall
+	rt.text << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	mmap_ok_field := elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x89]) // jns mmap_ok
+	rt.text << u8(0xbf)
+	write_u32_le(mut rt.text, 1)
+	rt.text << u8(0xb8)
+	write_u32_le(mut rt.text, linux_sys_exit_group)
+	rt.text << [u8(0x0f), 0x05, 0x0f, 0x0b] // syscall; ud2
+	mmap_ok_off := rt.text.len
+	rt.text << [u8(0x49), 0x89, 0xc0] // mov r8, rax
+	rt.text << [u8(0x4c), 0x8d, 0x50, u8(linux_tiny_rune_str_slot_bytes)] // lea r10, [rax+8]
+	rt.text << [u8(0x4c), 0x8d, 0x88]
+	write_u32_le(mut rt.text, linux_tiny_rune_str_arena_bytes) // lea r9, [rax+4096]
+	rt.text << [u8(0x4c), 0x8d, 0x1d] // lea r11, [arena]
+	rt.rune_str_arena_patches << rt.text.len
+	rt.text << [u8(0), 0, 0, 0]
+	rt.text << [u8(0x4d), 0x89, 0x13] // mov [r11], r10
+	rt.text << [u8(0x4d), 0x89, 0x4b, 0x08] // mov [r11+8], r9
+	allocated_field := elf_tiny_emit_jmp32_placeholder(mut rt.text)
+	have_block_off := rt.text.len
+	rt.text << [u8(0x49), 0x89, 0x03] // mov [r11], rax
+	allocated_off := rt.text.len
+	rt.text << u8(0x5f) // pop rdi
+	rt.text << [u8(0x89), 0xf8] // mov eax, edi
+	rt.text << [u8(0x83), 0xf8, 0x7f] // cmp eax, 0x7f
+	two_byte_field := elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x87]) // ja two_byte
+	rt.text << [u8(0x41), 0x88, 0x00] // mov [r8], al
+	rt.text << [u8(0x41), 0xc6, 0x40, 0x01, 0x00] // mov byte ptr [r8+1], 0
+	rt.text << [u8(0xba)]
+	write_u32_le(mut rt.text, 1)
+	one_byte_done_field := elf_tiny_emit_jmp32_placeholder(mut rt.text)
+	two_byte_off := rt.text.len
+	rt.text << u8(0x3d)
+	write_u32_le(mut rt.text, 0x7ff) // cmp eax, 0x7ff
+	three_byte_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x87]) // ja three_byte
+	rt.text << [u8(0x89), 0xc1] // mov ecx, eax
+	rt.text << [u8(0xc1), 0xe9, 0x06] // shr ecx, 6
+	rt.text << [u8(0x80), 0xc9, 0xc0] // or cl, 0xc0
+	rt.text << [u8(0x41), 0x88, 0x08] // mov [r8], cl
+	rt.text << [u8(0x89), 0xc1] // mov ecx, eax
+	rt.text << [u8(0x80), 0xe1, 0x3f] // and cl, 0x3f
+	rt.text << [u8(0x80), 0xc9, 0x80] // or cl, 0x80
+	rt.text << [u8(0x41), 0x88, 0x48, 0x01] // mov [r8+1], cl
+	rt.text << [u8(0x41), 0xc6, 0x40, 0x02, 0x00] // mov byte ptr [r8+2], 0
+	rt.text << [u8(0xba)]
+	write_u32_le(mut rt.text, 2)
+	two_byte_done_field := elf_tiny_emit_jmp32_placeholder(mut rt.text)
+	three_byte_off := rt.text.len
+	rt.text << u8(0x3d)
+	write_u32_le(mut rt.text, 0xffff) // cmp eax, 0xffff
+	four_byte_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x87]) // ja four_byte
+	rt.text << [u8(0x89), 0xc1] // mov ecx, eax
+	rt.text << [u8(0xc1), 0xe9, 0x0c] // shr ecx, 12
+	rt.text << [u8(0x80), 0xc9, 0xe0] // or cl, 0xe0
+	rt.text << [u8(0x41), 0x88, 0x08] // mov [r8], cl
+	rt.text << [u8(0x89), 0xc1] // mov ecx, eax
+	rt.text << [u8(0xc1), 0xe9, 0x06] // shr ecx, 6
+	rt.text << [u8(0x80), 0xe1, 0x3f] // and cl, 0x3f
+	rt.text << [u8(0x80), 0xc9, 0x80] // or cl, 0x80
+	rt.text << [u8(0x41), 0x88, 0x48, 0x01] // mov [r8+1], cl
+	rt.text << [u8(0x89), 0xc1] // mov ecx, eax
+	rt.text << [u8(0x80), 0xe1, 0x3f] // and cl, 0x3f
+	rt.text << [u8(0x80), 0xc9, 0x80] // or cl, 0x80
+	rt.text << [u8(0x41), 0x88, 0x48, 0x02] // mov [r8+2], cl
+	rt.text << [u8(0x41), 0xc6, 0x40, 0x03, 0x00] // mov byte ptr [r8+3], 0
+	rt.text << [u8(0xba)]
+	write_u32_le(mut rt.text, 3)
+	three_byte_done_field := elf_tiny_emit_jmp32_placeholder(mut rt.text)
+	four_byte_off := rt.text.len
+	rt.text << u8(0x3d)
+	write_u32_le(mut rt.text, 0x10ffff) // cmp eax, 0x10ffff
+	invalid_large_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x87]) // ja invalid
+	rt.text << [u8(0x89), 0xc1] // mov ecx, eax
+	rt.text << [u8(0xc1), 0xe9, 0x12] // shr ecx, 18
+	rt.text << [u8(0x80), 0xc9, 0xf0] // or cl, 0xf0
+	rt.text << [u8(0x41), 0x88, 0x08] // mov [r8], cl
+	rt.text << [u8(0x89), 0xc1] // mov ecx, eax
+	rt.text << [u8(0xc1), 0xe9, 0x0c] // shr ecx, 12
+	rt.text << [u8(0x80), 0xe1, 0x3f] // and cl, 0x3f
+	rt.text << [u8(0x80), 0xc9, 0x80] // or cl, 0x80
+	rt.text << [u8(0x41), 0x88, 0x48, 0x01] // mov [r8+1], cl
+	rt.text << [u8(0x89), 0xc1] // mov ecx, eax
+	rt.text << [u8(0xc1), 0xe9, 0x06] // shr ecx, 6
+	rt.text << [u8(0x80), 0xe1, 0x3f] // and cl, 0x3f
+	rt.text << [u8(0x80), 0xc9, 0x80] // or cl, 0x80
+	rt.text << [u8(0x41), 0x88, 0x48, 0x02] // mov [r8+2], cl
+	rt.text << [u8(0x89), 0xc1] // mov ecx, eax
+	rt.text << [u8(0x80), 0xe1, 0x3f] // and cl, 0x3f
+	rt.text << [u8(0x80), 0xc9, 0x80] // or cl, 0x80
+	rt.text << [u8(0x41), 0x88, 0x48, 0x03] // mov [r8+3], cl
+	rt.text << [u8(0x41), 0xc6, 0x40, 0x04, 0x00] // mov byte ptr [r8+4], 0
+	rt.text << [u8(0xba)]
+	write_u32_le(mut rt.text, 4)
+	four_byte_done_field := elf_tiny_emit_jmp32_placeholder(mut rt.text)
+	invalid_off := rt.text.len
+	rt.text << [u8(0x41), 0xc6, 0x00, 0x00] // mov byte ptr [r8], 0
+	rt.text << [u8(0x31), 0xd2] // xor edx, edx
+	done_off := rt.text.len
+	rt.text << [u8(0x4c), 0x89, 0xc0] // mov rax, r8
+	rt.text << u8(0xc3)
+	elf_tiny_patch_rel32_local(mut rt.text, need_mmap_field, need_mmap_off)
+	elf_tiny_patch_rel32_local(mut rt.text, have_block_field, have_block_off)
+	elf_tiny_patch_rel32_local(mut rt.text, mmap_ok_field, mmap_ok_off)
+	elf_tiny_patch_rel32_local(mut rt.text, allocated_field, allocated_off)
+	elf_tiny_patch_rel32_local(mut rt.text, two_byte_field, two_byte_off)
+	elf_tiny_patch_rel32_local(mut rt.text, one_byte_done_field, done_off)
+	elf_tiny_patch_rel32_local(mut rt.text, three_byte_field, three_byte_off)
+	elf_tiny_patch_rel32_local(mut rt.text, two_byte_done_field, done_off)
+	elf_tiny_patch_rel32_local(mut rt.text, four_byte_field, four_byte_off)
+	elf_tiny_patch_rel32_local(mut rt.text, three_byte_done_field, done_off)
+	elf_tiny_patch_rel32_local(mut rt.text, invalid_large_field, invalid_off)
+	elf_tiny_patch_rel32_local(mut rt.text, four_byte_done_field, done_off)
+}
+
+fn elf_tiny_emit_string_plus(mut rt ElfTinyRuntime) {
+	// SysV ABI: first string in rdi/rsi, second string in rdx/rcx, return in rax/rdx.
+	rt.text << [u8(0x57), 0x56, 0x52, 0x51] // push rdi; push rsi; push rdx; push rcx
+	rt.text << [u8(0x4c), 0x8d, 0x1d] // lea r11, [arena]
+	rt.string_plus_arena_patches << rt.text.len
+	rt.text << [u8(0), 0, 0, 0]
+	rt.text << [u8(0x4d), 0x8b, 0x13] // mov r10, [r11]
+	rt.text << [u8(0x49), 0x8b, 0x43, 0x08] // mov rax, [r11+8]
+	rt.text << [u8(0x4d), 0x85, 0xd2] // test r10, r10
+	need_mmap_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x84]) // je need_mmap
+	rt.text << [u8(0x44), 0x8b, 0x44, 0x24, 0x10] // mov r8d, [rsp+16]
+	rt.text << [u8(0x44), 0x03, 0x04, 0x24] // add r8d, [rsp]
+	rt.text << [u8(0x4d), 0x89, 0xc1] // mov r9, r8
+	rt.text << [u8(0x49), 0xff, 0xc1] // inc r9
+	rt.text << [u8(0x4c), 0x89, 0xd2] // mov rdx, r10
+	rt.text << [u8(0x4c), 0x01, 0xca] // add rdx, r9
+	rt.text << [u8(0x48), 0x39, 0xc2] // cmp rdx, rax
+	have_block_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x86]) // jbe have_block
+	need_mmap_off := rt.text.len
+	rt.text << [u8(0x44), 0x8b, 0x44, 0x24, 0x10] // mov r8d, [rsp+16]
+	rt.text << [u8(0x44), 0x03, 0x04, 0x24] // add r8d, [rsp]
+	rt.text << [u8(0x4d), 0x89, 0xc1] // mov r9, r8
+	rt.text << [u8(0x49), 0xff, 0xc1] // inc r9
+	rt.text << [u8(0x31), 0xff] // xor edi, edi
+	rt.text << [u8(0x4c), 0x89, 0xce] // mov rsi, r9
+	rt.text << [u8(0x48), 0x81, 0xfe]
+	write_u32_le(mut rt.text, linux_tiny_string_plus_arena_bytes) // cmp rsi, 4096
+	large_alloc_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x83]) // jae large_alloc
+	rt.text << u8(0xbe)
+	write_u32_le(mut rt.text, linux_tiny_string_plus_arena_bytes) // mov esi, 4096
+	large_alloc_off := rt.text.len
+	rt.text << u8(0xba)
+	write_u32_le(mut rt.text, linux_mmap_prot_read_write)
+	rt.text << [u8(0x41), 0xba]
+	write_u32_le(mut rt.text, linux_mmap_private_anonymous)
+	rt.text << [u8(0x49), 0xc7, 0xc0]
+	write_u32_le(mut rt.text, u32(0xffff_ffff))
+	rt.text << [u8(0x45), 0x31, 0xc9] // xor r9d, r9d
+	rt.text << u8(0xb8)
+	write_u32_le(mut rt.text, linux_sys_mmap)
+	rt.text << [u8(0x0f), 0x05] // syscall
+	rt.text << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	mmap_ok_field := elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x89]) // jns mmap_ok
+	rt.text << u8(0xbf)
+	write_u32_le(mut rt.text, 1)
+	rt.text << u8(0xb8)
+	write_u32_le(mut rt.text, linux_sys_exit_group)
+	rt.text << [u8(0x0f), 0x05, 0x0f, 0x0b] // syscall; ud2
+	mmap_ok_off := rt.text.len
+	rt.text << [u8(0x49), 0x89, 0xc2] // mov r10, rax
+	rt.text << [u8(0x44), 0x8b, 0x44, 0x24, 0x10] // mov r8d, [rsp+16]
+	rt.text << [u8(0x44), 0x03, 0x04, 0x24] // add r8d, [rsp]
+	rt.text << [u8(0x4d), 0x89, 0xc1] // mov r9, r8
+	rt.text << [u8(0x49), 0xff, 0xc1] // inc r9
+	rt.text << [u8(0x48), 0x89, 0xc2] // mov rdx, rax
+	rt.text << [u8(0x4c), 0x01, 0xca] // add rdx, r9
+	rt.text << [u8(0x4d), 0x89, 0xcb] // mov r11, r9
+	rt.text << [u8(0x49), 0x81, 0xfb]
+	write_u32_le(mut rt.text, linux_tiny_string_plus_arena_bytes) // cmp r11, 4096
+	large_end_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x83]) // jae large_end
+	rt.text << [u8(0x41), 0xbb]
+	write_u32_le(mut rt.text, linux_tiny_string_plus_arena_bytes) // mov r11d, 4096
+	large_end_off := rt.text.len
+	rt.text << [u8(0x4c), 0x89, 0xd0] // mov rax, r10
+	rt.text << [u8(0x4c), 0x01, 0xd8] // add rax, r11
+	rt.text << [u8(0x4c), 0x8d, 0x1d] // lea r11, [arena]
+	rt.string_plus_arena_patches << rt.text.len
+	rt.text << [u8(0), 0, 0, 0]
+	rt.text << [u8(0x49), 0x89, 0x13] // mov [r11], rdx
+	rt.text << [u8(0x49), 0x89, 0x43, 0x08] // mov [r11+8], rax
+	allocated_field := elf_tiny_emit_jmp32_placeholder(mut rt.text)
+	have_block_off := rt.text.len
+	rt.text << [u8(0x4c), 0x8d, 0x1d] // lea r11, [arena]
+	rt.string_plus_arena_patches << rt.text.len
+	rt.text << [u8(0), 0, 0, 0]
+	rt.text << [u8(0x49), 0x89, 0x13] // mov [r11], rdx
+	allocated_off := rt.text.len
+	rt.text << [u8(0x4c), 0x89, 0xd0] // mov rax, r10
+	rt.text << [u8(0x4d), 0x89, 0xd0] // mov r8, r10
+	rt.text << [u8(0x48), 0x8b, 0x74, 0x24, 0x18] // mov rsi, [rsp+24]
+	rt.text << [u8(0x8b), 0x4c, 0x24, 0x10] // mov ecx, [rsp+16]
+	rt.text << [u8(0x48), 0x85, 0xc9] // test rcx, rcx
+	copy_a_done_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x84]) // je copy_a_done
+	copy_a_loop := rt.text.len
+	rt.text << [u8(0x8a), 0x16] // mov dl, [rsi]
+	rt.text << [u8(0x41), 0x88, 0x10] // mov [r8], dl
+	rt.text << [u8(0x48), 0xff, 0xc6] // inc rsi
+	rt.text << [u8(0x49), 0xff, 0xc0] // inc r8
+	rt.text << [u8(0x48), 0xff, 0xc9] // dec rcx
+	copy_a_loop_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x85]) // jne copy_a_loop
+	copy_a_done_off := rt.text.len
+	rt.text << [u8(0x48), 0x8b, 0x74, 0x24, 0x08] // mov rsi, [rsp+8]
+	rt.text << [u8(0x8b), 0x0c, 0x24] // mov ecx, [rsp]
+	rt.text << [u8(0x48), 0x85, 0xc9] // test rcx, rcx
+	copy_b_done_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x84]) // je copy_b_done
+	copy_b_loop := rt.text.len
+	rt.text << [u8(0x8a), 0x16] // mov dl, [rsi]
+	rt.text << [u8(0x41), 0x88, 0x10] // mov [r8], dl
+	rt.text << [u8(0x48), 0xff, 0xc6] // inc rsi
+	rt.text << [u8(0x49), 0xff, 0xc0] // inc r8
+	rt.text << [u8(0x48), 0xff, 0xc9] // dec rcx
+	copy_b_loop_field :=
+		elf_tiny_emit_rel32_placeholder(mut rt.text, [u8(0x0f), 0x85]) // jne copy_b_loop
+	copy_b_done_off := rt.text.len
+	rt.text << [u8(0x41), 0xc6, 0x00, 0x00] // mov byte ptr [r8], 0
+	rt.text << [u8(0x8b), 0x54, 0x24, 0x10] // mov edx, [rsp+16]
+	rt.text << [u8(0x03), 0x14, 0x24] // add edx, [rsp]
+	rt.text << [u8(0x48), 0x83, 0xc4, 0x20] // add rsp, 32
+	rt.text << u8(0xc3)
+	elf_tiny_patch_rel32_local(mut rt.text, need_mmap_field, need_mmap_off)
+	elf_tiny_patch_rel32_local(mut rt.text, have_block_field, have_block_off)
+	elf_tiny_patch_rel32_local(mut rt.text, large_alloc_field, large_alloc_off)
+	elf_tiny_patch_rel32_local(mut rt.text, mmap_ok_field, mmap_ok_off)
+	elf_tiny_patch_rel32_local(mut rt.text, large_end_field, large_end_off)
+	elf_tiny_patch_rel32_local(mut rt.text, allocated_field, allocated_off)
+	elf_tiny_patch_rel32_local(mut rt.text, copy_a_done_field, copy_a_done_off)
+	elf_tiny_patch_rel32_local(mut rt.text, copy_a_loop_field, copy_a_loop)
+	elf_tiny_patch_rel32_local(mut rt.text, copy_b_done_field, copy_b_done_off)
+	elf_tiny_patch_rel32_local(mut rt.text, copy_b_loop_field, copy_b_loop)
 }
 
 fn (mut l ElfTinyLinker) write_executable(path string, text []u8, rodata []u8, data []u8, bss_bytes int, phnum int, text_off int, data_off int) ! {
@@ -644,12 +998,34 @@ fn elf_tiny_emit_rel8_placeholder(mut text []u8, opcode u8) int {
 	return field_off
 }
 
+fn elf_tiny_emit_rel32_placeholder(mut text []u8, opcode []u8) int {
+	text << opcode
+	field_off := text.len
+	text << [u8(0), 0, 0, 0]
+	return field_off
+}
+
+fn elf_tiny_emit_jmp32_placeholder(mut text []u8) int {
+	text << u8(0xe9)
+	field_off := text.len
+	text << [u8(0), 0, 0, 0]
+	return field_off
+}
+
 fn elf_tiny_patch_rel8(mut text []u8, field_off int, target_off int) {
 	disp := target_off - (field_off + 1)
 	if disp < -128 || disp > 127 {
 		panic('Linux tiny executable short branch is out of range')
 	}
 	text[field_off] = if disp < 0 { u8(256 + disp) } else { u8(disp) }
+}
+
+fn elf_tiny_patch_rel32_local(mut text []u8, field_off int, target_off int) {
+	disp := target_off - (field_off + 4)
+	if disp < -2147483648 || disp > 2147483647 {
+		panic('Linux tiny executable near branch is out of range')
+	}
+	binary.little_endian_put_u32(mut text[field_off..field_off + 4], u32(i32(disp)))
 }
 
 fn elf_tiny_write_phdr(mut b []u8, type_ u32, flags u32, off u64, vaddr u64, filesz u64, memsz u64, align u64) {
@@ -718,7 +1094,8 @@ fn (l ElfTinyLinker) elf_section_index(section ObjectSection) int {
 }
 
 fn (l ElfTinyLinker) tiny_runtime_symbol_name(name string) bool {
-	return name in ['write', 'exit', 'fflush', 'builtin__int__str']
+	return name in ['write', 'exit', 'fflush', 'builtin__int__str', 'builtin__i64__str',
+		'builtin__rune__str', 'builtin__string__+']
 }
 
 fn (l ElfTinyLinker) tiny_unsupported_defined_symbol_name(name string) bool {

--- a/vlib/v2/gen/x64/macho_tiny.v
+++ b/vlib/v2/gen/x64/macho_tiny.v
@@ -4,7 +4,14 @@
 
 module x64
 
+import encoding.binary
+
 pub const macos_tiny_not_eligible_prefix = 'macOS tiny object is not eligible: '
+
+const macos_tiny_builtin_string_plus_symbol = '_builtin__string__+'
+const macos_tiny_builtin_i64_str_symbol = '_builtin__i64__str'
+const macos_tiny_malloc_symbol = '_malloc'
+const macos_tiny_exit_symbol = '_exit'
 
 struct MachOTextRange {
 	name  string
@@ -19,6 +26,7 @@ struct MachODataRange {
 }
 
 struct MachOTinyReachable {
+mut:
 	names     []string
 	data      []MachODataRange
 	undefined map[string]bool
@@ -26,6 +34,11 @@ struct MachOTinyReachable {
 
 struct MachOTinyObjectWriter {
 	macho &MachOObject
+}
+
+struct MachOTinyRuntimeReloc {
+	addr   int
+	symbol string
 }
 
 pub fn (mut g Gen) write_macos_tiny_object(path string) ! {
@@ -42,22 +55,30 @@ pub fn (mut g Gen) write_macos_tiny_object(path string) ! {
 }
 
 fn (mut w MachOTinyObjectWriter) write(path string) ! {
-	reachable := w.collect_reachable()!
+	mut reachable := w.collect_reachable()!
 	mut out := MachOObject.new()
 	mut symbol_indices := map[string]int{}
 	mut func_offsets := map[string]u64{}
+	mut runtime_symbols := []string{}
+	mut runtime_relocs := []MachOTinyRuntimeReloc{}
 
 	for name in reachable.names {
 		range := w.text_range(name)!
 		func_offsets[name] = u64(out.text_data.len)
 		out.text_data << w.macho.text_data[int(range.start)..int(range.end)]
 	}
+	macho_tiny_add_runtime_helpers(mut out, mut reachable, mut func_offsets, mut runtime_symbols, mut
+		runtime_relocs)
 
 	mut data_offsets := map[string]u64{}
 	w.copy_data_ranges(reachable.data, .rodata, mut out.rodata, mut data_offsets)!
 	w.copy_data_ranges(reachable.data, .data, mut out.data_data, mut data_offsets)!
 
 	for name in reachable.names {
+		symbol_indices[name] = out.add_symbol(name, func_offsets[name],
+			macho_tiny_defined_symbol_is_external(name), ObjectFormat.macho.section_index(.text))
+	}
+	for name in runtime_symbols {
 		symbol_indices[name] = out.add_symbol(name, func_offsets[name],
 			macho_tiny_defined_symbol_is_external(name), ObjectFormat.macho.section_index(.text))
 	}
@@ -74,7 +95,6 @@ fn (mut w MachOTinyObjectWriter) write(path string) ! {
 	for name in undefined_names {
 		symbol_indices[name] = out.add_undefined(name)
 	}
-
 	for name in reachable.names {
 		range := w.text_range(name)!
 		new_base := func_offsets[name]
@@ -86,9 +106,20 @@ fn (mut w MachOTinyObjectWriter) write(path string) ! {
 			sym_idx := symbol_indices[sym.name] or {
 				return macos_tiny_not_eligible('symbol `${sym.name}` is not resolved by the tiny object')
 			}
-			out.add_reloc(int(new_base + u64(reloc.addr - int(range.start))), sym_idx, reloc.type_,
-				reloc.pcrel, reloc.length)
+			out_reloc_addr := int(new_base + u64(reloc.addr - int(range.start)))
+			if macho_tiny_resolve_relocation_locally(sym.name, reloc) {
+				macho_tiny_patch_rel32_local(mut out.text_data, out_reloc_addr,
+					int(func_offsets[sym.name]))
+				continue
+			}
+			out.add_reloc(out_reloc_addr, sym_idx, reloc.type_, reloc.pcrel, reloc.length)
 		}
+	}
+	for reloc in runtime_relocs {
+		sym_idx := symbol_indices[reloc.symbol] or {
+			return macos_tiny_not_eligible('runtime helper symbol `${reloc.symbol}` is not resolved by the tiny object')
+		}
+		out.add_reloc(reloc.addr, sym_idx, x86_64_reloc_branch, true, 2)
 	}
 
 	out.write(path)
@@ -126,6 +157,9 @@ fn (mut w MachOTinyObjectWriter) collect_reachable() !MachOTinyReachable {
 			} else if sym.sect == ObjectFormat.macho.section_index(.rodata) {
 				w.add_data_range(mut selected_data, .rodata, sym.value)!
 			} else if sym.sect == ObjectFormat.macho.section_index(.data) {
+				if x64_main_argc_global_name(sym.name) || x64_main_argv_global_name(sym.name) {
+					return macos_tiny_not_eligible('arguments() requires hosted argc/argv; macOS tiny _main argv is not implemented yet')
+				}
 				w.add_data_range(mut selected_data, .data, sym.value)!
 			} else if sym.sect == 0 && sym.type_ == 0x01 {
 				undefined[sym.name] = true
@@ -291,6 +325,373 @@ fn (w MachOTinyObjectWriter) data_section_alignment(section ObjectSection) u64 {
 
 fn macho_tiny_defined_symbol_is_external(name string) bool {
 	return name == '_main'
+}
+
+fn macho_tiny_resolve_relocation_locally(name string, reloc MachORelocationInfo) bool {
+	return name in [macos_tiny_builtin_string_plus_symbol, macos_tiny_builtin_i64_str_symbol]
+		&& reloc.type_ == x86_64_reloc_branch && reloc.pcrel && reloc.length == 2
+}
+
+fn macho_tiny_add_runtime_helpers(mut out MachOObject, mut reachable MachOTinyReachable, mut func_offsets map[string]u64, mut runtime_symbols []string, mut runtime_relocs []MachOTinyRuntimeReloc) {
+	if reachable.undefined[macos_tiny_builtin_i64_str_symbol] {
+		reachable.undefined.delete(macos_tiny_builtin_i64_str_symbol)
+		reachable.undefined[macos_tiny_malloc_symbol] = true
+		reachable.undefined[macos_tiny_exit_symbol] = true
+		func_offsets[macos_tiny_builtin_i64_str_symbol] = u64(out.text_data.len)
+		runtime_symbols << macos_tiny_builtin_i64_str_symbol
+		macho_tiny_emit_i64_str(mut out.text_data, mut runtime_relocs)
+	}
+	if reachable.undefined[macos_tiny_builtin_string_plus_symbol] {
+		reachable.undefined.delete(macos_tiny_builtin_string_plus_symbol)
+		reachable.undefined[macos_tiny_malloc_symbol] = true
+		reachable.undefined[macos_tiny_exit_symbol] = true
+		func_offsets[macos_tiny_builtin_string_plus_symbol] = u64(out.text_data.len)
+		runtime_symbols << macos_tiny_builtin_string_plus_symbol
+		macho_tiny_emit_string_plus(mut out.text_data, mut runtime_relocs)
+	}
+}
+
+fn macho_tiny_emit_i64_str(mut text []u8, mut runtime_relocs []MachOTinyRuntimeReloc) {
+	text << [
+		u8(0x57), // push rdi, input value
+		0xbf,
+		0x20,
+		0x00,
+		0x00,
+		0x00, // mov edi, 32
+	]
+	macho_tiny_emit_call_reloc(mut text, mut runtime_relocs, macos_tiny_malloc_symbol)
+	text << [
+		u8(0x48),
+		0x85,
+		0xc0, // test rax, rax
+	]
+	malloc_ok := macho_tiny_emit_jcc32(mut text, 0x85) // jne ok
+	text << [
+		u8(0xbf),
+		0x01,
+		0x00,
+		0x00,
+		0x00, // mov edi, 1
+	]
+	macho_tiny_emit_call_reloc(mut text, mut runtime_relocs, macos_tiny_exit_symbol)
+	text << [u8(0x0f), 0x0b] // ud2
+	ok_start := text.len
+	macho_tiny_patch_rel32_local(mut text, malloc_ok, ok_start)
+
+	text << [
+		u8(0x5f), // pop rdi
+		0x4c,
+		0x8d,
+		0x40,
+		0x1f, // lea r8, [rax+31]
+		0x41,
+		0xc6,
+		0x00,
+		0x00, // mov byte ptr [r8], 0
+		0x48,
+		0x89,
+		0xf8, // mov rax, rdi
+		0x45,
+		0x31,
+		0xc9, // xor r9d, r9d
+		0x45,
+		0x31,
+		0xd2, // xor r10d, r10d
+		0x48,
+		0x85,
+		0xc0, // test rax, rax
+	]
+	non_negative := macho_tiny_emit_jcc32(mut text, 0x89) // jns non_negative
+	text << [
+		u8(0x41),
+		0xb2,
+		0x01, // mov r10b, 1
+		0x48,
+		0xf7,
+		0xd8, // neg rax
+	]
+	non_negative_target := text.len
+	text << [
+		u8(0x48),
+		0x85,
+		0xc0, // test rax, rax
+	]
+	non_zero := macho_tiny_emit_jcc32(mut text, 0x85) // jne loop
+	text << [
+		u8(0x49),
+		0xff,
+		0xc8, // dec r8
+		0x41,
+		0xc6,
+		0x00,
+		0x30, // mov byte ptr [r8], '0'
+		0x41,
+		0xb9,
+		0x01,
+		0x00,
+		0x00,
+		0x00, // mov r9d, 1
+	]
+	maybe_sign_jump := macho_tiny_emit_jmp32(mut text)
+	loop_start := text.len
+	text << [
+		u8(0x31),
+		0xd2, // xor edx, edx
+		0xb9,
+		0x0a,
+		0x00,
+		0x00,
+		0x00, // mov ecx, 10
+		0x48,
+		0xf7,
+		0xf1, // div rcx
+		0x80,
+		0xc2,
+		0x30, // add dl, '0'
+		0x49,
+		0xff,
+		0xc8, // dec r8
+		0x41,
+		0x88,
+		0x10, // mov [r8], dl
+		0x49,
+		0xff,
+		0xc1, // inc r9
+		0x48,
+		0x85,
+		0xc0, // test rax, rax
+	]
+	loop_more := macho_tiny_emit_jcc32(mut text, 0x85) // jne loop
+	maybe_sign := text.len
+	text << [
+		u8(0x45),
+		0x84,
+		0xd2, // test r10b, r10b
+	]
+	done_digits := macho_tiny_emit_jcc32(mut text, 0x84) // je done
+	text << [
+		u8(0x49),
+		0xff,
+		0xc8, // dec r8
+		0x41,
+		0xc6,
+		0x00,
+		0x2d, // mov byte ptr [r8], '-'
+		0x49,
+		0xff,
+		0xc1, // inc r9
+	]
+	done_digits_target := text.len
+	text << [
+		u8(0x4c),
+		0x89,
+		0xc0, // mov rax, r8
+		0x4c,
+		0x89,
+		0xca, // mov rdx, r9
+		0xc3, // ret
+	]
+	macho_tiny_patch_rel32_local(mut text, non_negative, non_negative_target)
+	macho_tiny_patch_rel32_local(mut text, non_zero, loop_start)
+	macho_tiny_patch_rel32_local(mut text, maybe_sign_jump, maybe_sign)
+	macho_tiny_patch_rel32_local(mut text, loop_more, loop_start)
+	macho_tiny_patch_rel32_local(mut text, done_digits, done_digits_target)
+}
+
+fn macho_tiny_emit_string_plus(mut text []u8, mut runtime_relocs []MachOTinyRuntimeReloc) {
+	text << [
+		u8(0x57), // push rdi, first string ptr
+		0x56, // push rsi, first string len
+		0x52, // push rdx, second string ptr
+		0x51, // push rcx, second string len
+		0x48,
+		0x83,
+		0xec,
+		0x08, // sub rsp, 8, align before libSystem calls
+		0x44,
+		0x8b,
+		0x44,
+		0x24,
+		0x18, // mov r8d, [rsp+24]
+		0x44,
+		0x03,
+		0x44,
+		0x24,
+		0x08, // add r8d, [rsp+8]
+	]
+	len_overflow := macho_tiny_emit_jcc32(mut text, 0x82) // jc fail
+	text << [
+		u8(0x4d),
+		0x89,
+		0xc1, // mov r9, r8
+		0x49,
+		0x83,
+		0xc1,
+		0x01, // add r9, 1
+	]
+	alloc_overflow := macho_tiny_emit_jcc32(mut text, 0x82) // jc fail
+	text << [
+		u8(0x4c),
+		0x89,
+		0xcf, // mov rdi, r9
+	]
+	macho_tiny_emit_call_reloc(mut text, mut runtime_relocs, macos_tiny_malloc_symbol)
+	text << [
+		u8(0x48),
+		0x85,
+		0xc0, // test rax, rax
+	]
+	malloc_ok := macho_tiny_emit_jcc32(mut text, 0x85) // jne ok
+	fail_start := text.len
+	text << [
+		u8(0xbf),
+		0x01,
+		0x00,
+		0x00,
+		0x00, // mov edi, 1
+	]
+	macho_tiny_emit_call_reloc(mut text, mut runtime_relocs, macos_tiny_exit_symbol)
+	text << [u8(0x0f), 0x0b] // ud2
+	ok_start := text.len
+	macho_tiny_patch_rel32_local(mut text, len_overflow, fail_start)
+	macho_tiny_patch_rel32_local(mut text, alloc_overflow, fail_start)
+	macho_tiny_patch_rel32_local(mut text, malloc_ok, ok_start)
+
+	text << [
+		u8(0x49),
+		0x89,
+		0xc2, // mov r10, rax
+		0x49,
+		0x89,
+		0xc0, // mov r8, rax
+		0x48,
+		0x8b,
+		0x74,
+		0x24,
+		0x20, // mov rsi, [rsp+32]
+		0x8b,
+		0x4c,
+		0x24,
+		0x18, // mov ecx, [rsp+24]
+		0x48,
+		0x85,
+		0xc9, // test rcx, rcx
+	]
+	copy_a_done := macho_tiny_emit_jcc32(mut text, 0x84) // jz done
+	copy_a_loop := text.len
+	text << [
+		u8(0x8a),
+		0x16, // mov dl, [rsi]
+		0x41,
+		0x88,
+		0x10, // mov [r8], dl
+		0x48,
+		0xff,
+		0xc6, // inc rsi
+		0x49,
+		0xff,
+		0xc0, // inc r8
+		0x48,
+		0xff,
+		0xc9, // dec rcx
+	]
+	copy_a_continue := macho_tiny_emit_jcc32(mut text, 0x85) // jne loop
+	copy_a_done_target := text.len
+	macho_tiny_patch_rel32_local(mut text, copy_a_done, copy_a_done_target)
+	macho_tiny_patch_rel32_local(mut text, copy_a_continue, copy_a_loop)
+
+	text << [
+		u8(0x48),
+		0x8b,
+		0x74,
+		0x24,
+		0x10, // mov rsi, [rsp+16]
+		0x8b,
+		0x4c,
+		0x24,
+		0x08, // mov ecx, [rsp+8]
+		0x48,
+		0x85,
+		0xc9, // test rcx, rcx
+	]
+	copy_b_done := macho_tiny_emit_jcc32(mut text, 0x84) // jz done
+	copy_b_loop := text.len
+	text << [
+		u8(0x8a),
+		0x16, // mov dl, [rsi]
+		0x41,
+		0x88,
+		0x10, // mov [r8], dl
+		0x48,
+		0xff,
+		0xc6, // inc rsi
+		0x49,
+		0xff,
+		0xc0, // inc r8
+		0x48,
+		0xff,
+		0xc9, // dec rcx
+	]
+	copy_b_continue := macho_tiny_emit_jcc32(mut text, 0x85) // jne loop
+	copy_b_done_target := text.len
+	macho_tiny_patch_rel32_local(mut text, copy_b_done, copy_b_done_target)
+	macho_tiny_patch_rel32_local(mut text, copy_b_continue, copy_b_loop)
+
+	text << [
+		u8(0x41),
+		0xc6,
+		0x00,
+		0x00, // mov byte ptr [r8], 0
+		0x8b,
+		0x44,
+		0x24,
+		0x18, // mov eax, [rsp+24]
+		0x03,
+		0x44,
+		0x24,
+		0x08, // add eax, [rsp+8]
+		0x48,
+		0x89,
+		0xc2, // mov rdx, rax
+		0x4c,
+		0x89,
+		0xd0, // mov rax, r10
+		0x48,
+		0x83,
+		0xc4,
+		0x28, // add rsp, 40
+		0xc3, // ret
+	]
+}
+
+fn macho_tiny_emit_call_reloc(mut text []u8, mut runtime_relocs []MachOTinyRuntimeReloc, symbol string) {
+	text << u8(0xe8)
+	field_off := text.len
+	text << [u8(0), 0, 0, 0]
+	runtime_relocs << MachOTinyRuntimeReloc{
+		addr:   field_off
+		symbol: symbol
+	}
+}
+
+fn macho_tiny_emit_jcc32(mut text []u8, opcode u8) int {
+	text << [u8(0x0f), opcode]
+	field_off := text.len
+	text << [u8(0), 0, 0, 0]
+	return field_off
+}
+
+fn macho_tiny_emit_jmp32(mut text []u8) int {
+	text << u8(0xe9)
+	field_off := text.len
+	text << [u8(0), 0, 0, 0]
+	return field_off
+}
+
+fn macho_tiny_patch_rel32_local(mut text []u8, field_off int, target_off int) {
+	disp := i64(target_off) - i64(field_off + 4)
+	binary.little_endian_put_u32(mut text[field_off..field_off + 4], u32(i32(disp)))
 }
 
 fn macho_tiny_is_module_init_symbol(name string) bool {

--- a/vlib/v2/gen/x64/object.v
+++ b/vlib/v2/gen/x64/object.v
@@ -194,10 +194,10 @@ pub fn (mut g Gen) write_file(path string) {
 
 fn (g Gen) unsupported_external_symbol_message() ?string {
 	for raw_name in g.undefined_external_symbol_names() {
-		name := x64_normalize_external_symbol_name(g.obj_format, raw_name)
-		if x64_symbol_needs_backend_runtime_support(name) {
-			return x64_unresolved_external_symbol_message(g.obj_format, name,
-				'needed while preparing native x64 output')
+		if msg := unsupported_external_symbol_message_for_name(g.obj_format, raw_name,
+			'needed while preparing native x64 output')
+		{
+			return msg
 		}
 	}
 	return none

--- a/vlib/v2/gen/x64/pe.v
+++ b/vlib/v2/gen/x64/pe.v
@@ -48,9 +48,14 @@ const pe_runtime_data_alignment = 16
 const pe_wgetenv_buffer_wchars = 32768
 const pe_wgetenv_buffer_bytes = pe_wgetenv_buffer_wchars * 2
 
-const pe_kernel32_imports = ['ExitProcess', 'GetStdHandle', 'GetConsoleMode', 'MultiByteToWideChar',
-	'WideCharToMultiByte', 'GetCurrentDirectoryW', 'GetEnvironmentVariableW', 'WriteConsoleW',
-	'WriteFile', 'GetProcessHeap', 'HeapAlloc', 'HeapReAlloc', 'HeapFree', 'GetCurrentThreadId']
+const pe_kernel32_dll = 'kernel32.dll'
+const pe_shell32_dll = 'shell32.dll'
+const pe_kernel32_imports = ['ExitProcess', 'GetCommandLineW', 'GetStdHandle', 'GetConsoleMode',
+	'MultiByteToWideChar', 'WideCharToMultiByte', 'GetCurrentDirectoryW', 'GetEnvironmentVariableW',
+	'WriteConsoleW', 'WriteFile', 'GetProcessHeap', 'HeapAlloc', 'HeapReAlloc', 'HeapFree',
+	'GetCurrentThreadId', 'GetSystemTimeAsFileTime', 'FileTimeToSystemTime',
+	'SystemTimeToTzSpecificLocalTime']
+const pe_shell32_imports = ['CommandLineToArgvW']
 
 struct PeImport {
 	dll  string
@@ -58,8 +63,9 @@ struct PeImport {
 }
 
 struct PeRuntimeCallPatch {
-	field_off   int
-	import_name string
+	field_off int
+	dll       string
+	name      string
 }
 
 struct PeRuntimeDataPatch {
@@ -93,6 +99,20 @@ struct PeIdata {
 	import_size u32
 	iat_rva     u32
 	iat_size    u32
+	iat_rvas    map[string]u32
+}
+
+struct PeImportGroup {
+	dll   string
+	start int
+mut:
+	len int
+}
+
+struct PeTextBuild {
+	data                 []u8
+	argc_global_disp_off int
+	argv_global_disp_off int
 }
 
 pub struct PeLinker {
@@ -117,9 +137,10 @@ pub fn (mut l PeLinker) write(path string) ! {
 
 pub fn (mut l PeLinker) image() ![]u8 {
 	mut runtime_text := l.build_runtime_text()
-	l.imports = l.required_kernel32_imports(runtime_text)!
+	l.imports = l.required_pe_imports(runtime_text)!
 	l.patch_runtime_import_calls(mut runtime_text)!
-	mut text := l.build_text_section(runtime_text)!
+	text_build := l.build_text_section(runtime_text)!
+	mut text := text_build.data.clone()
 	mut data_data := l.coff.data_data.clone()
 	runtime_data_base := if runtime_text.data.len > 0 {
 		base := align_int(data_data.len, pe_runtime_data_alignment)
@@ -172,8 +193,10 @@ pub fn (mut l PeLinker) image() ![]u8 {
 	sections << idata_section
 
 	import_thunks := l.import_thunk_rvas(text_section.virtual_address, runtime_text.bytes.len)
-	import_iats := l.import_iat_rvas(idata.iat_rva)
+	import_iats := idata.iat_rvas.clone()
 	runtime_thunks := runtime_text.symbol_rvas(text_section.virtual_address)
+	l.patch_entry_argv_bootstrap_data_refs(mut text, text_section.virtual_address, data_rva,
+		text_build)!
 	l.apply_text_relocations(mut text, text_section.virtual_address, rdata_rva, data_rva,
 		runtime_text.bytes.len, runtime_thunks, import_thunks, import_iats)!
 	l.apply_runtime_data_patches(mut text, text_section.virtual_address, data_rva, runtime_text,
@@ -232,13 +255,38 @@ pub fn (mut l PeLinker) image() ![]u8 {
 	return buf
 }
 
-fn (l PeLinker) build_text_section(runtime_text PeRuntimeText) ![]u8 {
+fn (l PeLinker) build_text_section(runtime_text PeRuntimeText) !PeTextBuild {
 	main_rva := l.defined_symbol_offset('main') or {
 		return error('PE linker requires a defined main symbol')
 	}
 	mut text := []u8{}
 	vinit_offset := l.defined_symbol_offset('_vinit') or { u32(0xffff_ffff) }
 	text << [u8(0x48), 0x83, 0xec, 0x28] // sub rsp, 40
+	mut get_command_line_field := -1
+	mut command_line_to_argv_field := -1
+	mut argv_failure_exit_field := -1
+	mut argc_global_disp_off := -1
+	mut argv_global_disp_off := -1
+	if l.needs_windows_argv_bootstrap() {
+		text << [u8(0xc7), 0x44, 0x24, 0x20, 0, 0, 0, 0] // mov dword ptr [rsp+32], 0
+		get_command_line_field = pe_emit_call_placeholder(mut text)
+		text << [u8(0x48), 0x89, 0xc1] // mov rcx, rax
+		text << [u8(0x48), 0x8d, 0x54, 0x24, 0x20] // lea rdx, [rsp+32]
+		command_line_to_argv_field = pe_emit_call_placeholder(mut text)
+		text << [u8(0x48), 0x85, 0xc0] // test rax, rax
+		text << [u8(0x75), 0x0a] // jne argv parsed
+		text << [u8(0xb9), 1, 0, 0, 0] // mov ecx, 1
+		argv_failure_exit_field = pe_emit_call_placeholder(mut text)
+		if l.has_main_argv_data_symbol() {
+			argv_global_disp_off = pe_emit_lea_r10_rip_placeholder(mut text)
+			text << [u8(0x49), 0x89, 0x02] // mov [r10], rax
+		}
+		if l.has_main_argc_data_symbol() {
+			argc_global_disp_off = pe_emit_lea_r10_rip_placeholder(mut text)
+			text << [u8(0x8b), 0x4c, 0x24, 0x20] // mov ecx, [rsp+32]
+			text << [u8(0x41), 0x89, 0x0a] // mov [r10], ecx
+		}
+	}
 	if vinit_offset != 0xffff_ffff {
 		pe_emit_call_placeholder(mut text)
 	}
@@ -248,13 +296,32 @@ fn (l PeLinker) build_text_section(runtime_text PeRuntimeText) ![]u8 {
 	text << 0xcc
 
 	entry_stub_len := text.len
+	if entry_stub_len != l.entry_stub_size() {
+		return error('PE linker internal error: entry stub size mismatch (${entry_stub_len} != ${l.entry_stub_size()})')
+	}
 	text << l.coff.text_data
 	text << runtime_text.bytes
 	for _ in l.imports {
 		text << [u8(0xff), 0x25, 0, 0, 0, 0] // jmp qword ptr [rip + disp32]
 	}
 
-	mut cursor := 4
+	import_offsets := l.import_thunk_offsets(runtime_text.bytes.len)
+	exit_thunk_off := import_offsets[pe_kernel32_import_key('ExitProcess')] or {
+		return error('PE linker internal error: missing ExitProcess import thunk')
+	}
+	if get_command_line_field >= 0 {
+		get_command_line_thunk_off := import_offsets[pe_kernel32_import_key('GetCommandLineW')] or {
+			return error('PE linker internal error: missing GetCommandLineW import thunk')
+		}
+		command_line_to_argv_thunk_off := import_offsets[pe_shell32_import_key('CommandLineToArgvW')] or {
+			return error('PE linker internal error: missing CommandLineToArgvW import thunk')
+		}
+		pe_patch_rel32(mut text, get_command_line_field, get_command_line_thunk_off, 0)
+		pe_patch_rel32(mut text, command_line_to_argv_field, command_line_to_argv_thunk_off, 0)
+		pe_patch_rel32(mut text, argv_failure_exit_field, exit_thunk_off, 0)
+	}
+
+	mut cursor := 4 + l.windows_argv_bootstrap_size()
 	if vinit_offset != 0xffff_ffff {
 		pe_patch_rel32(mut text, cursor + 1, u32(entry_stub_len) + vinit_offset, 0)
 		cursor += 5
@@ -262,13 +329,13 @@ fn (l PeLinker) build_text_section(runtime_text PeRuntimeText) ![]u8 {
 	pe_patch_rel32(mut text, cursor + 1, u32(entry_stub_len) + main_rva, 0)
 	cursor += 5
 	cursor += 2
-	import_offsets := l.import_thunk_offsets(runtime_text.bytes.len)
-	exit_thunk_off := import_offsets['ExitProcess'] or {
-		return error('PE linker internal error: missing ExitProcess import thunk')
-	}
 	pe_patch_rel32(mut text, cursor + 1, exit_thunk_off, 0)
 
-	return text
+	return PeTextBuild{
+		data:                 text
+		argc_global_disp_off: argc_global_disp_off
+		argv_global_disp_off: argv_global_disp_off
+	}
 }
 
 fn (l PeLinker) build_runtime_text() PeRuntimeText {
@@ -339,6 +406,14 @@ fn (l PeLinker) build_runtime_text() PeRuntimeText {
 		rt.symbols['exit'] = runtime_base + u32(rt.bytes.len)
 		pe_emit_runtime_exit(mut rt)
 	}
+	if l.uses_undefined_symbol('builtin__i64__str') {
+		rt.symbols['builtin__i64__str'] = runtime_base + u32(rt.bytes.len)
+		pe_emit_runtime_i64_str(mut rt)
+	}
+	if l.uses_undefined_symbol('builtin__string__+') {
+		rt.symbols['builtin__string__+'] = runtime_base + u32(rt.bytes.len)
+		pe_emit_runtime_string_plus(mut rt)
+	}
 	if l.uses_undefined_symbol('builtin__Array_rune__string') {
 		rt.symbols['builtin__Array_rune__string'] = runtime_base + u32(rt.bytes.len)
 		pe_emit_runtime_array_rune_string(mut rt)
@@ -347,14 +422,36 @@ fn (l PeLinker) build_runtime_text() PeRuntimeText {
 		rt.symbols['builtin__new_array_from_c_array_noscan'] = runtime_base + u32(rt.bytes.len)
 		pe_emit_runtime_new_array_from_c_array_noscan(mut rt)
 	}
+	if l.uses_undefined_symbol('builtin____new_array_noscan')
+		|| l.uses_undefined_symbol('__new_array_noscan') {
+		start := runtime_base + u32(rt.bytes.len)
+		if l.uses_undefined_symbol('builtin____new_array_noscan') {
+			rt.symbols['builtin____new_array_noscan'] = start
+		}
+		if l.uses_undefined_symbol('__new_array_noscan') {
+			rt.symbols['__new_array_noscan'] = start
+		}
+		pe_emit_runtime_new_array_noscan(mut rt)
+	}
 	return rt
 }
 
-fn (l PeLinker) required_kernel32_imports(runtime_text PeRuntimeText) ![]PeImport {
-	mut required := map[string]bool{}
-	pe_require_kernel32_import(mut required, 'ExitProcess')!
+fn (l PeLinker) required_pe_imports(runtime_text PeRuntimeText) ![]PeImport {
+	mut required_kernel32 := map[string]bool{}
+	mut required_shell32 := map[string]bool{}
+	pe_require_kernel32_import(mut required_kernel32, 'ExitProcess')!
+	if l.needs_windows_argv_bootstrap() {
+		pe_require_kernel32_import(mut required_kernel32, 'GetCommandLineW')!
+		pe_require_shell32_import(mut required_shell32, 'CommandLineToArgvW')!
+	}
 	for patch in runtime_text.import_patches {
-		pe_require_kernel32_import(mut required, patch.import_name)!
+		if patch.dll == pe_kernel32_dll {
+			pe_require_kernel32_import(mut required_kernel32, patch.name)!
+		} else if patch.dll == pe_shell32_dll {
+			pe_require_shell32_import(mut required_shell32, patch.name)!
+		} else {
+			return error('PE linker internal error: unknown import DLL `${patch.dll}` for `${patch.name}`')
+		}
 	}
 	for reloc in l.coff.text_relocs {
 		if reloc.sym_idx < 0 || reloc.sym_idx >= l.coff.symbols.len {
@@ -368,15 +465,25 @@ fn (l PeLinker) required_kernel32_imports(runtime_text PeRuntimeText) ![]PeImpor
 			continue
 		}
 		if pe_kernel32_import_is_known(sym.name) {
-			required[sym.name] = true
+			required_kernel32[sym.name] = true
+		} else if pe_shell32_import_is_known(sym.name) {
+			required_shell32[sym.name] = true
 		}
 	}
 
-	mut imports := []PeImport{cap: required.len}
+	mut imports := []PeImport{cap: required_kernel32.len + required_shell32.len}
 	for name in pe_kernel32_imports {
-		if required[name] {
+		if required_kernel32[name] {
 			imports << PeImport{
-				dll:  'kernel32.dll'
+				dll:  pe_kernel32_dll
+				name: name
+			}
+		}
+	}
+	for name in pe_shell32_imports {
+		if required_shell32[name] {
+			imports << PeImport{
+				dll:  pe_shell32_dll
 				name: name
 			}
 		}
@@ -388,11 +495,24 @@ fn (l PeLinker) patch_runtime_import_calls(mut rt PeRuntimeText) ! {
 	runtime_base := u32(l.entry_stub_size() + l.coff.text_data.len)
 	import_offsets := l.import_thunk_offsets(rt.bytes.len)
 	for patch in rt.import_patches {
-		target := import_offsets[patch.import_name] or {
-			return error('PE linker internal error: missing import thunk for `${patch.import_name}`')
+		key := pe_import_key(patch.dll, patch.name)
+		target := import_offsets[key] or {
+			return error('PE linker internal error: missing import thunk for `${key}`')
 		}
 		pe_patch_rel32(mut rt.bytes, patch.field_off, target, runtime_base)
 	}
+}
+
+fn pe_import_key(dll string, name string) string {
+	return '${dll}:${name}'
+}
+
+fn pe_kernel32_import_key(name string) string {
+	return pe_import_key(pe_kernel32_dll, name)
+}
+
+fn pe_shell32_import_key(name string) string {
+	return pe_import_key(pe_shell32_dll, name)
 }
 
 fn pe_require_kernel32_import(mut required map[string]bool, name string) ! {
@@ -411,6 +531,22 @@ fn pe_kernel32_import_is_known(name string) bool {
 	return false
 }
 
+fn pe_require_shell32_import(mut required map[string]bool, name string) ! {
+	if !pe_shell32_import_is_known(name) {
+		return error('PE linker internal error: unknown Shell32 import `${name}`')
+	}
+	required[name] = true
+}
+
+fn pe_shell32_import_is_known(name string) bool {
+	for known in pe_shell32_imports {
+		if known == name {
+			return true
+		}
+	}
+	return false
+}
+
 fn (rt PeRuntimeText) symbol_rvas(text_rva u32) map[string]u32 {
 	mut out := map[string]u32{}
 	for name, off in rt.symbols {
@@ -421,17 +557,25 @@ fn (rt PeRuntimeText) symbol_rvas(text_rva u32) map[string]u32 {
 
 fn (l PeLinker) build_idata(idata_rva u32) PeIdata {
 	descriptor_size := 20
-	descriptor_count := 2 // kernel32 + null terminator
-	ilt_off := descriptor_size * descriptor_count
-	ilt_size := (l.imports.len + 1) * 8
-	iat_off := ilt_off + ilt_size
-	iat_size := (l.imports.len + 1) * 8
-	hint_name_off := iat_off + iat_size
+	groups := pe_import_groups(l.imports)
+	descriptor_count := groups.len + 1
+	mut cursor := descriptor_size * descriptor_count
+	mut ilt_offsets := []int{cap: groups.len}
+	for group in groups {
+		ilt_offsets << cursor
+		cursor += (group.len + 1) * 8
+	}
+	mut iat_offsets := []int{cap: groups.len}
+	for group in groups {
+		iat_offsets << cursor
+		cursor += (group.len + 1) * 8
+	}
+	hint_name_off := cursor
 
 	mut data := []u8{len: hint_name_off}
-	mut hint_name_rvas := []u32{cap: l.imports.len}
-	for imp in l.imports {
-		hint_name_rvas << idata_rva + u32(data.len)
+	mut hint_name_rvas := []u32{len: l.imports.len}
+	for i, imp in l.imports {
+		hint_name_rvas[i] = idata_rva + u32(data.len)
 		write_u16_le(mut data, 0)
 		data << imp.name.bytes()
 		data << 0
@@ -439,25 +583,66 @@ fn (l PeLinker) build_idata(idata_rva u32) PeIdata {
 			data << 0
 		}
 	}
-	dll_name_rva := idata_rva + u32(data.len)
-	data << 'kernel32.dll'.bytes()
-	data << 0
+	mut dll_name_rvas := []u32{len: groups.len}
+	for i, group in groups {
+		dll_name_rvas[i] = idata_rva + u32(data.len)
+		data << group.dll.bytes()
+		data << 0
+		if data.len % 2 != 0 {
+			data << 0
+		}
+	}
 
-	pe_put_u32_le(mut data, 0, idata_rva + u32(ilt_off))
-	pe_put_u32_le(mut data, 12, dll_name_rva)
-	pe_put_u32_le(mut data, 16, idata_rva + u32(iat_off))
-	for i, rva in hint_name_rvas {
-		pe_put_u64_le(mut data, ilt_off + i * 8, u64(rva))
-		pe_put_u64_le(mut data, iat_off + i * 8, u64(rva))
+	mut iat_rvas := map[string]u32{}
+	for group_idx, group in groups {
+		descriptor_off := group_idx * descriptor_size
+		ilt_off := ilt_offsets[group_idx]
+		iat_off := iat_offsets[group_idx]
+		pe_put_u32_le(mut data, descriptor_off, idata_rva + u32(ilt_off))
+		pe_put_u32_le(mut data, descriptor_off + 12, dll_name_rvas[group_idx])
+		pe_put_u32_le(mut data, descriptor_off + 16, idata_rva + u32(iat_off))
+		for local_i in 0 .. group.len {
+			import_idx := group.start + local_i
+			rva := hint_name_rvas[import_idx]
+			pe_put_u64_le(mut data, ilt_off + local_i * 8, u64(rva))
+			pe_put_u64_le(mut data, iat_off + local_i * 8, u64(rva))
+			imp := l.imports[import_idx]
+			iat_rvas[pe_import_key(imp.dll, imp.name)] = idata_rva + u32(iat_off + local_i * 8)
+		}
+	}
+	iat_rva := if groups.len == 0 { idata_rva } else { idata_rva + u32(iat_offsets[0]) }
+	iat_size := if groups.len == 0 {
+		u32(0)
+	} else {
+		last_group := groups[groups.len - 1]
+		last_iat_off := iat_offsets[iat_offsets.len - 1]
+		u32(last_iat_off + (last_group.len + 1) * 8 - iat_offsets[0])
 	}
 
 	return PeIdata{
 		data:        data
 		import_rva:  idata_rva
 		import_size: u32(descriptor_size * descriptor_count)
-		iat_rva:     idata_rva + u32(iat_off)
-		iat_size:    u32(iat_size)
+		iat_rva:     iat_rva
+		iat_size:    iat_size
+		iat_rvas:    iat_rvas
 	}
+}
+
+fn pe_import_groups(imports []PeImport) []PeImportGroup {
+	mut groups := []PeImportGroup{}
+	for i, imp in imports {
+		if groups.len == 0 || groups[groups.len - 1].dll != imp.dll {
+			groups << PeImportGroup{
+				dll:   imp.dll
+				start: i
+				len:   1
+			}
+		} else {
+			groups[groups.len - 1].len++
+		}
+	}
+	return groups
 }
 
 fn (l PeLinker) apply_text_relocations(mut text []u8,
@@ -497,7 +682,10 @@ fn (l PeLinker) apply_text_relocations(mut text []u8,
 				if runtime_rva := runtime_thunks[sym.name] {
 					runtime_rva
 				} else {
-					import_thunks[sym.name] or {
+					import_key := l.import_key_for_external_symbol(sym.name) or {
+						return error(l.unresolved_external_symbol_message(sym.name, reloc))
+					}
+					import_thunks[import_key] or {
 						return error(l.unresolved_external_symbol_message(sym.name, reloc))
 					}
 				}
@@ -517,8 +705,9 @@ fn (l PeLinker) apply_text_relocations(mut text []u8,
 	thunk_base := l.import_thunk_base(runtime_text_size)
 	for i, imp in l.imports {
 		thunk_off := thunk_base + i * 6
-		iat_entry_rva := import_iats[imp.name] or {
-			return error('PE linker internal error: missing IAT entry for `${imp.name}`')
+		import_key := pe_import_key(imp.dll, imp.name)
+		iat_entry_rva := import_iats[import_key] or {
+			return error('PE linker internal error: missing IAT entry for `${import_key}`')
 		}
 		thunk_rva := text_rva + u32(thunk_off)
 		disp := i32(int(iat_entry_rva) - (int(thunk_rva) + 6))
@@ -579,7 +768,7 @@ fn (l PeLinker) import_thunk_offsets(runtime_text_size int) map[string]u32 {
 	thunk_base := l.import_thunk_base(runtime_text_size)
 	mut out := map[string]u32{}
 	for i, imp in l.imports {
-		out[imp.name] = u32(thunk_base + i * 6)
+		out[pe_import_key(imp.dll, imp.name)] = u32(thunk_base + i * 6)
 	}
 	return out
 }
@@ -593,17 +782,34 @@ fn (l PeLinker) import_thunk_rvas(text_rva u32, runtime_text_size int) map[strin
 	return out
 }
 
-fn (l PeLinker) import_iat_rvas(iat_rva u32) map[string]u32 {
-	mut out := map[string]u32{}
-	for i, imp in l.imports {
-		out[imp.name] = iat_rva + u32(i * 8)
+fn (l PeLinker) import_key_for_external_symbol(name string) ?string {
+	if pe_kernel32_import_is_known(name) {
+		return pe_kernel32_import_key(name)
 	}
-	return out
+	if pe_shell32_import_is_known(name) {
+		return pe_shell32_import_key(name)
+	}
+	return none
 }
 
 fn (l PeLinker) entry_stub_size() int {
 	vinit := l.defined_symbol_offset('_vinit') or { u32(0xffff_ffff) }
-	return if vinit == 0xffff_ffff { 17 } else { 22 }
+	base_size := if vinit == 0xffff_ffff { 17 } else { 22 }
+	return base_size + l.windows_argv_bootstrap_size()
+}
+
+fn (l PeLinker) windows_argv_bootstrap_size() int {
+	if !l.needs_windows_argv_bootstrap() {
+		return 0
+	}
+	mut size := 8 + 5 + 3 + 5 + 5 + 15 // zero argc, argv calls, null check, ExitProcess(1)
+	if l.has_main_argv_data_symbol() {
+		size += 7 + 3 // lea g_main_argv; mov [g_main_argv], rax
+	}
+	if l.has_main_argc_data_symbol() {
+		size += 7 + 4 + 3 // lea g_main_argc; load local argc; mov [g_main_argc], ecx
+	}
+	return size
 }
 
 fn (l PeLinker) defined_symbol_offset(name string) ?u32 {
@@ -626,6 +832,73 @@ fn (l PeLinker) uses_undefined_symbol(name string) bool {
 		}
 	}
 	return false
+}
+
+fn (l PeLinker) needs_windows_argv_bootstrap() bool {
+	for reloc in l.coff.text_relocs {
+		if reloc.sym_idx < 0 || reloc.sym_idx >= l.coff.symbols.len {
+			continue
+		}
+		sym := l.coff.symbols[reloc.sym_idx]
+		if sym.section == 3
+			&& (x64_main_argc_global_name(sym.name) || x64_main_argv_global_name(sym.name)) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (l PeLinker) has_main_argc_data_symbol() bool {
+	if _ := l.main_argc_data_offset() {
+		return true
+	}
+	return false
+}
+
+fn (l PeLinker) has_main_argv_data_symbol() bool {
+	if _ := l.main_argv_data_offset() {
+		return true
+	}
+	return false
+}
+
+fn (l PeLinker) main_argc_data_offset() ?u32 {
+	for sym in l.coff.symbols {
+		if sym.section == 3 && x64_main_argc_global_name(sym.name) {
+			return sym.value
+		}
+	}
+	return none
+}
+
+fn (l PeLinker) main_argv_data_offset() ?u32 {
+	for sym in l.coff.symbols {
+		if sym.section == 3 && x64_main_argv_global_name(sym.name) {
+			return sym.value
+		}
+	}
+	return none
+}
+
+fn (l PeLinker) patch_entry_argv_bootstrap_data_refs(mut text []u8, text_rva u32, data_rva u32, text_build PeTextBuild) ! {
+	if text_build.argc_global_disp_off < 0 && text_build.argv_global_disp_off < 0 {
+		return
+	}
+	if data_rva == 0 {
+		return error('PE linker Windows argv bootstrap requires a .data section for g_main_argc/g_main_argv')
+	}
+	if text_build.argc_global_disp_off >= 0 {
+		argc_off := l.main_argc_data_offset() or {
+			return error('PE linker Windows argv bootstrap requires g_main_argc data symbol')
+		}
+		pe_patch_rel32(mut text, text_build.argc_global_disp_off, data_rva + argc_off, text_rva)
+	}
+	if text_build.argv_global_disp_off >= 0 {
+		argv_off := l.main_argv_data_offset() or {
+			return error('PE linker Windows argv bootstrap requires g_main_argv data symbol')
+		}
+		pe_patch_rel32(mut text, text_build.argv_global_disp_off, data_rva + argv_off, text_rva)
+	}
 }
 
 fn (mut l PeLinker) write_optional_header(mut buf []u8, size_of_code u32, size_of_initialized_data u32, size_of_image u32, size_of_headers int, idata PeIdata, entry_rva u32) {
@@ -748,15 +1021,26 @@ fn pe_check_written_image(path string, expected_size int) ! {
 	}
 }
 
-fn pe_emit_call_placeholder(mut text []u8) {
-	text << [u8(0xe8), 0, 0, 0, 0]
+fn pe_emit_call_placeholder(mut text []u8) int {
+	text << u8(0xe8)
+	field_off := text.len
+	text << [u8(0), 0, 0, 0]
+	return field_off
+}
+
+fn pe_emit_lea_r10_rip_placeholder(mut text []u8) int {
+	text << [u8(0x4c), 0x8d, 0x15] // lea r10, [rip + disp32]
+	field_off := text.len
+	text << [u8(0), 0, 0, 0]
+	return field_off
 }
 
 fn pe_emit_runtime_call_import(mut rt PeRuntimeText, import_name string) {
 	rt.bytes << u8(0xe8)
 	rt.import_patches << PeRuntimeCallPatch{
-		field_off:   rt.bytes.len
-		import_name: import_name
+		field_off: rt.bytes.len
+		dll:       pe_kernel32_dll
+		name:      import_name
 	}
 	rt.bytes << [u8(0), 0, 0, 0]
 }
@@ -1177,6 +1461,149 @@ fn pe_emit_runtime_exit(mut rt PeRuntimeText) {
 	rt.bytes << u8(0xcc) // int3
 }
 
+fn pe_emit_runtime_exit_process_1(mut rt PeRuntimeText) {
+	rt.bytes << [u8(0xb9), 0x01, 0, 0, 0] // mov ecx, 1
+	pe_emit_runtime_call_import(mut rt, 'ExitProcess')
+	rt.bytes << u8(0xcc) // int3
+}
+
+fn pe_emit_runtime_i64_str(mut rt PeRuntimeText) {
+	rt.bytes << [u8(0x48), 0x83, 0xec, 0x58] // sub rsp, 88
+	rt.bytes << [u8(0x48), 0x89, 0x4c, 0x24, 0x20] // mov [rsp+32], rcx
+	rt.bytes << [u8(0x48), 0x89, 0x54, 0x24, 0x28] // mov [rsp+40], rdx
+	pe_emit_runtime_call_import(mut rt, 'GetProcessHeap')
+	rt.bytes << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	no_heap := pe_emit_jcc32(mut rt.bytes, 0x84) // je
+	rt.bytes << [u8(0x48), 0x89, 0xc1] // mov rcx, rax
+	rt.bytes << [u8(0xba), 0x08, 0, 0, 0] // mov edx, HEAP_ZERO_MEMORY
+	rt.bytes << [u8(0x41), 0xb8, 0x20, 0, 0, 0] // mov r8d, 32
+	pe_emit_runtime_call_import(mut rt, 'HeapAlloc')
+	rt.bytes << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	alloc_failed := pe_emit_jcc32(mut rt.bytes, 0x84) // je
+	rt.bytes << [u8(0x48), 0x89, 0x44, 0x24, 0x30] // mov [rsp+48], rax
+	rt.bytes << [u8(0x4c), 0x8d, 0x40, 0x1f] // lea r8, [rax+31]
+	rt.bytes << [u8(0x41), 0xc6, 0x00, 0x00] // mov byte ptr [r8], 0
+	rt.bytes << [u8(0x48), 0x8b, 0x44, 0x24, 0x28] // mov rax, [rsp+40]
+	rt.bytes << [u8(0x45), 0x31, 0xc9] // xor r9d, r9d
+	rt.bytes << [u8(0x45), 0x31, 0xd2] // xor r10d, r10d
+	rt.bytes << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	non_negative := pe_emit_jcc32(mut rt.bytes, 0x89) // jns
+	rt.bytes << [u8(0x41), 0xb2, 0x01] // mov r10b, 1
+	rt.bytes << [u8(0x48), 0xf7, 0xd8] // neg rax
+	non_negative_target := rt.bytes.len
+	rt.bytes << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	non_zero := pe_emit_jcc32(mut rt.bytes, 0x85) // jne
+	rt.bytes << [u8(0x49), 0xff, 0xc8] // dec r8
+	rt.bytes << [u8(0x41), 0xc6, 0x00, 0x30] // mov byte ptr [r8], '0'
+	rt.bytes << [u8(0x41), 0xb9, 0x01, 0, 0, 0] // mov r9d, 1
+	maybe_sign_jump := pe_emit_jmp32(mut rt.bytes)
+	loop_start := rt.bytes.len
+	rt.bytes << [u8(0x31), 0xd2] // xor edx, edx
+	rt.bytes << [u8(0xb9), 0x0a, 0, 0, 0] // mov ecx, 10
+	rt.bytes << [u8(0x48), 0xf7, 0xf1] // div rcx
+	rt.bytes << [u8(0x80), 0xc2, 0x30] // add dl, '0'
+	rt.bytes << [u8(0x49), 0xff, 0xc8] // dec r8
+	rt.bytes << [u8(0x41), 0x88, 0x10] // mov [r8], dl
+	rt.bytes << [u8(0x49), 0xff, 0xc1] // inc r9
+	rt.bytes << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	loop_more := pe_emit_jcc32(mut rt.bytes, 0x85) // jne
+	maybe_sign := rt.bytes.len
+	rt.bytes << [u8(0x45), 0x84, 0xd2] // test r10b, r10b
+	done_digits := pe_emit_jcc32(mut rt.bytes, 0x84) // je
+	rt.bytes << [u8(0x49), 0xff, 0xc8] // dec r8
+	rt.bytes << [u8(0x41), 0xc6, 0x00, 0x2d] // mov byte ptr [r8], '-'
+	rt.bytes << [u8(0x49), 0xff, 0xc1] // inc r9
+	done_digits_target := rt.bytes.len
+	rt.bytes << [u8(0x48), 0x8b, 0x54, 0x24, 0x20] // mov rdx, [rsp+32]
+	rt.bytes << [u8(0x4c), 0x89, 0x02] // mov [rdx], r8
+	rt.bytes << [u8(0x44), 0x89, 0x4a, 0x08] // mov [rdx+8], r9d
+	rt.bytes << [u8(0xc7), 0x42, 0x0c, 0, 0, 0, 0] // mov dword ptr [rdx+12], 0
+	rt.bytes << [u8(0x48), 0x89, 0xd0] // mov rax, rdx
+	rt.bytes << [u8(0x48), 0x83, 0xc4, 0x58] // add rsp, 88
+	rt.bytes << u8(0xc3) // ret
+	fail := rt.bytes.len
+	pe_emit_runtime_exit_process_1(mut rt)
+	pe_patch_rel32_local(mut rt.bytes, no_heap, fail)
+	pe_patch_rel32_local(mut rt.bytes, alloc_failed, fail)
+	pe_patch_rel32_local(mut rt.bytes, non_negative, non_negative_target)
+	pe_patch_rel32_local(mut rt.bytes, non_zero, loop_start)
+	pe_patch_rel32_local(mut rt.bytes, maybe_sign_jump, maybe_sign)
+	pe_patch_rel32_local(mut rt.bytes, loop_more, loop_start)
+	pe_patch_rel32_local(mut rt.bytes, done_digits, done_digits_target)
+}
+
+fn pe_emit_runtime_string_plus(mut rt PeRuntimeText) {
+	rt.bytes << [u8(0x48), 0x83, 0xec, 0x68] // sub rsp, 104
+	rt.bytes << [u8(0x48), 0x89, 0x4c, 0x24, 0x20] // mov [rsp+32], rcx
+	rt.bytes << [u8(0x48), 0x89, 0x54, 0x24, 0x28] // mov [rsp+40], rdx
+	rt.bytes << [u8(0x4c), 0x89, 0x44, 0x24, 0x30] // mov [rsp+48], r8
+	rt.bytes << [u8(0x44), 0x8b, 0x4a, 0x08] // mov r9d, [rdx+8]
+	rt.bytes << [u8(0x45), 0x03, 0x48, 0x08] // add r9d, [r8+8]
+	len_overflow := pe_emit_jcc32(mut rt.bytes, 0x82) // jc
+	rt.bytes << [u8(0x4c), 0x89, 0x4c, 0x24, 0x38] // mov [rsp+56], r9
+	rt.bytes << [u8(0x45), 0x89, 0xc8] // mov r8d, r9d
+	rt.bytes << [u8(0x49), 0x83, 0xc0, 0x01] // add r8, 1
+	alloc_overflow := pe_emit_jcc32(mut rt.bytes, 0x82) // jc
+	rt.bytes << [u8(0x4c), 0x89, 0x44, 0x24, 0x40] // mov [rsp+64], r8
+	pe_emit_runtime_call_import(mut rt, 'GetProcessHeap')
+	rt.bytes << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	no_heap := pe_emit_jcc32(mut rt.bytes, 0x84) // je
+	rt.bytes << [u8(0x48), 0x89, 0xc1] // mov rcx, rax
+	rt.bytes << [u8(0xba), 0x08, 0, 0, 0] // mov edx, HEAP_ZERO_MEMORY
+	rt.bytes << [u8(0x4c), 0x8b, 0x44, 0x24, 0x40] // mov r8, [rsp+64]
+	pe_emit_runtime_call_import(mut rt, 'HeapAlloc')
+	rt.bytes << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	alloc_failed := pe_emit_jcc32(mut rt.bytes, 0x84) // je
+	rt.bytes << [u8(0x48), 0x89, 0x44, 0x24, 0x48] // mov [rsp+72], rax
+	rt.bytes << [u8(0x48), 0x8b, 0x54, 0x24, 0x28] // mov rdx, [rsp+40]
+	rt.bytes << [u8(0x4c), 0x8b, 0x12] // mov r10, [rdx]
+	rt.bytes << [u8(0x44), 0x8b, 0x5a, 0x08] // mov r11d, [rdx+8]
+	rt.bytes << [u8(0x48), 0x89, 0xc1] // mov rcx, rax
+	rt.bytes << [u8(0x4d), 0x85, 0xdb] // test r11, r11
+	copy_a_done := pe_emit_jcc32(mut rt.bytes, 0x84) // je
+	copy_a_loop := rt.bytes.len
+	rt.bytes << [u8(0x45), 0x8a, 0x0a] // mov r9b, [r10]
+	rt.bytes << [u8(0x44), 0x88, 0x09] // mov [rcx], r9b
+	rt.bytes << [u8(0x49), 0xff, 0xc2] // inc r10
+	rt.bytes << [u8(0x48), 0xff, 0xc1] // inc rcx
+	rt.bytes << [u8(0x49), 0xff, 0xcb] // dec r11
+	copy_a_more := pe_emit_jcc32(mut rt.bytes, 0x85) // jne
+	copy_a_done_target := rt.bytes.len
+	rt.bytes << [u8(0x4c), 0x8b, 0x44, 0x24, 0x30] // mov r8, [rsp+48]
+	rt.bytes << [u8(0x4d), 0x8b, 0x10] // mov r10, [r8]
+	rt.bytes << [u8(0x45), 0x8b, 0x58, 0x08] // mov r11d, [r8+8]
+	rt.bytes << [u8(0x4d), 0x85, 0xdb] // test r11, r11
+	copy_b_done := pe_emit_jcc32(mut rt.bytes, 0x84) // je
+	copy_b_loop := rt.bytes.len
+	rt.bytes << [u8(0x45), 0x8a, 0x0a] // mov r9b, [r10]
+	rt.bytes << [u8(0x44), 0x88, 0x09] // mov [rcx], r9b
+	rt.bytes << [u8(0x49), 0xff, 0xc2] // inc r10
+	rt.bytes << [u8(0x48), 0xff, 0xc1] // inc rcx
+	rt.bytes << [u8(0x49), 0xff, 0xcb] // dec r11
+	copy_b_more := pe_emit_jcc32(mut rt.bytes, 0x85) // jne
+	copy_b_done_target := rt.bytes.len
+	rt.bytes << [u8(0xc6), 0x01, 0x00] // mov byte ptr [rcx], 0
+	rt.bytes << [u8(0x48), 0x8b, 0x54, 0x24, 0x20] // mov rdx, [rsp+32]
+	rt.bytes << [u8(0x48), 0x8b, 0x44, 0x24, 0x48] // mov rax, [rsp+72]
+	rt.bytes << [u8(0x48), 0x89, 0x02] // mov [rdx], rax
+	rt.bytes << [u8(0x8b), 0x44, 0x24, 0x38] // mov eax, [rsp+56]
+	rt.bytes << [u8(0x89), 0x42, 0x08] // mov [rdx+8], eax
+	rt.bytes << [u8(0xc7), 0x42, 0x0c, 0, 0, 0, 0] // mov dword ptr [rdx+12], 0
+	rt.bytes << [u8(0x48), 0x89, 0xd0] // mov rax, rdx
+	rt.bytes << [u8(0x48), 0x83, 0xc4, 0x68] // add rsp, 104
+	rt.bytes << u8(0xc3) // ret
+	fail := rt.bytes.len
+	pe_emit_runtime_exit_process_1(mut rt)
+	pe_patch_rel32_local(mut rt.bytes, len_overflow, fail)
+	pe_patch_rel32_local(mut rt.bytes, alloc_overflow, fail)
+	pe_patch_rel32_local(mut rt.bytes, no_heap, fail)
+	pe_patch_rel32_local(mut rt.bytes, alloc_failed, fail)
+	pe_patch_rel32_local(mut rt.bytes, copy_a_done, copy_a_done_target)
+	pe_patch_rel32_local(mut rt.bytes, copy_a_more, copy_a_loop)
+	pe_patch_rel32_local(mut rt.bytes, copy_b_done, copy_b_done_target)
+	pe_patch_rel32_local(mut rt.bytes, copy_b_more, copy_b_loop)
+}
+
 fn pe_emit_runtime_errno(mut rt PeRuntimeText) {
 	errno_off := pe_runtime_data_alloc(mut rt, 4, 4)
 	pe_emit_runtime_lea_rax_data(mut rt, errno_off)
@@ -1275,6 +1702,78 @@ fn pe_emit_runtime_new_array_from_c_array_noscan(mut rt PeRuntimeText) {
 	pe_patch_rel32_local(mut rt.bytes, no_copy, done)
 	pe_patch_rel32_local(mut rt.bytes, null_source, done)
 	pe_patch_rel8(mut rt.bytes, copy_more, copy_loop)
+}
+
+fn pe_emit_runtime_new_array_noscan(mut rt PeRuntimeText) {
+	rt.bytes << [u8(0x48), 0x83, 0xec, 0x58] // sub rsp, 88
+	rt.bytes << [u8(0x48), 0x89, 0x4c, 0x24, 0x20] // mov [rsp+32], rcx
+	rt.bytes << [u8(0x48), 0x89, 0x54, 0x24, 0x28] // mov [rsp+40], rdx
+	rt.bytes << [u8(0x4c), 0x89, 0x44, 0x24, 0x30] // mov [rsp+48], r8
+	rt.bytes << [u8(0x4c), 0x89, 0x4c, 0x24, 0x38] // mov [rsp+56], r9
+	rt.bytes << [u8(0x48), 0xc7, 0x01, 0, 0, 0, 0] // mov qword ptr [rcx], 0
+	rt.bytes << [u8(0x48), 0xc7, 0x41, 0x08, 0, 0, 0, 0] // mov qword ptr [rcx+8], 0
+	rt.bytes << [u8(0x48), 0xc7, 0x41, 0x10, 0, 0, 0, 0] // mov qword ptr [rcx+16], 0
+	rt.bytes << [u8(0x48), 0xc7, 0x41, 0x18, 0, 0, 0, 0] // mov qword ptr [rcx+24], 0
+	rt.bytes << [u8(0x83), 0xfa, 0x00] // cmp edx, 0
+	negative_len := pe_emit_jcc32(mut rt.bytes, 0x8c) // jl
+	rt.bytes << [u8(0x41), 0x83, 0xf8, 0x00] // cmp r8d, 0
+	negative_cap := pe_emit_jcc32(mut rt.bytes, 0x8c) // jl
+	rt.bytes << [u8(0x41), 0x83, 0xf9, 0x00] // cmp r9d, 0
+	negative_elem_size := pe_emit_jcc32(mut rt.bytes, 0x8c) // jl
+	rt.bytes << [u8(0x45), 0x89, 0xc2] // mov r10d, r8d
+	rt.bytes << [u8(0x41), 0x39, 0xd2] // cmp r10d, edx
+	cap_ready := pe_emit_jcc8(mut rt.bytes, 0x7d) // jge
+	rt.bytes << [u8(0x41), 0x89, 0xd2] // mov r10d, edx
+	cap_ready_target := rt.bytes.len
+	rt.bytes << [u8(0x4c), 0x89, 0x54, 0x24, 0x40] // mov [rsp+64], r10
+	rt.bytes << [u8(0x49), 0x63, 0xc2] // movsxd rax, r10d
+	rt.bytes << [u8(0x4d), 0x63, 0xd9] // movsxd r11, r9d
+	rt.bytes << [u8(0x49), 0x0f, 0xaf, 0xc3] // imul rax, r11
+	rt.bytes << [u8(0x49), 0x89, 0xc0] // mov r8, rax
+	rt.bytes << [u8(0x4d), 0x85, 0xc0] // test r8, r8
+	payload_nonzero := pe_emit_jcc8(mut rt.bytes, 0x75) // jne
+	rt.bytes << [u8(0x41), 0xb8, 0x01, 0, 0, 0] // mov r8d, 1
+	payload_nonzero_target := rt.bytes.len
+	rt.bytes << [u8(0x49), 0x83, 0xc0, 0x20] // add r8, 32
+	allocation_overflow := pe_emit_jcc32(mut rt.bytes, 0x82) // jc
+	rt.bytes << [u8(0x4c), 0x89, 0x44, 0x24, 0x48] // mov [rsp+72], r8
+	pe_emit_runtime_call_import(mut rt, 'GetProcessHeap')
+	rt.bytes << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	no_heap := pe_emit_jcc32(mut rt.bytes, 0x84) // je
+	rt.bytes << [u8(0x48), 0x89, 0xc1] // mov rcx, rax
+	rt.bytes << [u8(0xba), 0x08, 0, 0, 0] // mov edx, HEAP_ZERO_MEMORY
+	rt.bytes << [u8(0x4c), 0x8b, 0x44, 0x24, 0x48] // mov r8, [rsp+72]
+	pe_emit_runtime_call_import(mut rt, 'HeapAlloc')
+	rt.bytes << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	alloc_failed := pe_emit_jcc32(mut rt.bytes, 0x84) // je
+	pe_emit_runtime_align_heap_allocated_data(mut rt)
+	rt.bytes << [u8(0x41), 0xc6, 0x03, 0] // mov byte ptr [r11], 0 ; ArrayDataHeader.has_slices = false
+	rt.bytes << [u8(0x48), 0x8b, 0x4c, 0x24, 0x20] // mov rcx, [rsp+32]
+	rt.bytes << [u8(0x49), 0x8d, 0x43, 0x08] // lea rax, [r11+8]
+	rt.bytes << [u8(0x48), 0x89, 0x01] // mov [rcx], rax
+	rt.bytes << [u8(0xc7), 0x41, 0x08, 0, 0, 0, 0] // mov dword ptr [rcx+8], 0
+	rt.bytes << [u8(0x8b), 0x44, 0x24, 0x28] // mov eax, [rsp+40]
+	rt.bytes << [u8(0x89), 0x41, 0x0c] // mov [rcx+12], eax
+	rt.bytes << [u8(0x8b), 0x44, 0x24, 0x40] // mov eax, [rsp+64]
+	rt.bytes << [u8(0x89), 0x41, 0x10] // mov [rcx+16], eax
+	rt.bytes << [u8(0xc7), 0x41, 0x14, 0x30, 0, 0, 0] // mov dword ptr [rcx+20], 48
+	rt.bytes << [u8(0x8b), 0x44, 0x24, 0x38] // mov eax, [rsp+56]
+	rt.bytes << [u8(0x89), 0x41, 0x18] // mov [rcx+24], eax
+	rt.bytes << [u8(0x48), 0x8b, 0x44, 0x24, 0x20] // mov rax, [rsp+32]
+	rt.bytes << [u8(0x48), 0x83, 0xc4, 0x58] // add rsp, 88
+	rt.bytes << u8(0xc3) // ret
+	fail := rt.bytes.len
+	rt.bytes << [u8(0x48), 0x8b, 0x44, 0x24, 0x20] // mov rax, [rsp+32]
+	rt.bytes << [u8(0x48), 0x83, 0xc4, 0x58] // add rsp, 88
+	rt.bytes << u8(0xc3) // ret
+	pe_patch_rel32_local(mut rt.bytes, negative_len, fail)
+	pe_patch_rel32_local(mut rt.bytes, negative_cap, fail)
+	pe_patch_rel32_local(mut rt.bytes, negative_elem_size, fail)
+	pe_patch_rel8(mut rt.bytes, cap_ready, cap_ready_target)
+	pe_patch_rel8(mut rt.bytes, payload_nonzero, payload_nonzero_target)
+	pe_patch_rel32_local(mut rt.bytes, allocation_overflow, fail)
+	pe_patch_rel32_local(mut rt.bytes, no_heap, fail)
+	pe_patch_rel32_local(mut rt.bytes, alloc_failed, fail)
 }
 
 fn pe_emit_runtime_array_rune_string(mut rt PeRuntimeText) {

--- a/vlib/v2/gen/x64/x64.v
+++ b/vlib/v2/gen/x64/x64.v
@@ -51,6 +51,12 @@ struct ReferencedWindowsCoffGlobals {
 	indexes  map[int]bool
 }
 
+struct X64MainArgGlobals {
+mut:
+	argc []string
+	argv []string
+}
+
 pub fn Gen.new(mod &mir.Module) &Gen {
 	return &Gen{
 		mod:        mod
@@ -190,6 +196,170 @@ fn (g Gen) scalar_global_initial_value_supported(typ_id ssa.TypeID) bool {
 	return typ.kind in [.int_t, .ptr_t]
 }
 
+fn x64_object_symbol_bare_name(name string) string {
+	if name.starts_with('_') {
+		return name[1..]
+	}
+	return name
+}
+
+fn x64_main_argc_global_name(name string) bool {
+	bare_name := x64_object_symbol_bare_name(name)
+	return bare_name == 'g_main_argc' || bare_name == 'builtin__g_main_argc'
+}
+
+fn x64_main_argv_global_name(name string) bool {
+	bare_name := x64_object_symbol_bare_name(name)
+	return bare_name == 'g_main_argv' || bare_name == 'builtin__g_main_argv'
+}
+
+fn x64_add_unique_global_name(mut names []string, name string) {
+	if name !in names {
+		names << name
+	}
+}
+
+fn x64_enqueue_reachable_func(mut queue []string, reachable map[string]bool, name string) {
+	if name != '' && !reachable[name] && name !in queue {
+		queue << name
+	}
+}
+
+fn (g Gen) func_by_name(name string) ?mir.Function {
+	for func in g.mod.funcs {
+		if func.name == name {
+			return func
+		}
+	}
+	return none
+}
+
+fn (g Gen) reachable_funcs_from_main() map[string]bool {
+	mut reachable := map[string]bool{}
+	mut queue := ['main']
+	for queue.len > 0 {
+		name := queue[0]
+		queue.delete(0)
+		if reachable[name] {
+			continue
+		}
+		func := g.func_by_name(name) or { continue }
+		reachable[name] = true
+		for blk_id in func.blocks {
+			if blk_id < 0 || blk_id >= g.mod.blocks.len {
+				continue
+			}
+			blk := g.mod.blocks[blk_id]
+			for instr_id in blk.instrs {
+				if instr_id < 0 || instr_id >= g.mod.values.len {
+					continue
+				}
+				val := g.mod.values[instr_id]
+				if val.kind != .instruction || val.index < 0 || val.index >= g.mod.instrs.len {
+					continue
+				}
+				instr := g.mod.instrs[val.index]
+				for operand_id in instr.operands {
+					if operand_id < 0 || operand_id >= g.mod.values.len {
+						continue
+					}
+					operand := g.mod.values[operand_id]
+					if operand.kind == .func_ref {
+						x64_enqueue_reachable_func(mut queue, reachable, operand.name)
+					}
+				}
+				if instr.op !in [.call, .call_sret, .go_call, .spawn_call]
+					|| instr.operands.len == 0 {
+					continue
+				}
+				callee_id := instr.operands[0]
+				if callee_id >= 0 && callee_id < g.mod.values.len {
+					callee := g.mod.values[callee_id]
+					if callee.kind in [.func_ref, .unknown] {
+						x64_enqueue_reachable_func(mut queue, reachable, callee.name)
+					}
+				}
+			}
+		}
+	}
+	return reachable
+}
+
+fn (g Gen) referenced_main_arg_globals(reachable map[string]bool) X64MainArgGlobals {
+	mut refs := X64MainArgGlobals{}
+	for func in g.mod.funcs {
+		if !reachable[func.name] {
+			continue
+		}
+		for blk_id in func.blocks {
+			if blk_id < 0 || blk_id >= g.mod.blocks.len {
+				continue
+			}
+			blk := g.mod.blocks[blk_id]
+			for instr_id in blk.instrs {
+				if instr_id < 0 || instr_id >= g.mod.values.len {
+					continue
+				}
+				val := g.mod.values[instr_id]
+				if val.kind != .instruction || val.index < 0 || val.index >= g.mod.instrs.len {
+					continue
+				}
+				instr := g.mod.instrs[val.index]
+				for operand in instr.operands {
+					if operand < 0 || operand >= g.mod.values.len {
+						continue
+					}
+					operand_val := g.mod.values[operand]
+					if operand_val.kind != .global {
+						continue
+					}
+					if x64_main_argc_global_name(operand_val.name) {
+						x64_add_unique_global_name(mut refs.argc, operand_val.name)
+					} else if x64_main_argv_global_name(operand_val.name) {
+						x64_add_unique_global_name(mut refs.argv, operand_val.name)
+					}
+				}
+			}
+		}
+	}
+	return refs
+}
+
+fn (g Gen) has_defined_global(name string) bool {
+	for gvar in g.mod.globals {
+		if gvar.name == name && gvar.linkage != .external {
+			return true
+		}
+	}
+	return false
+}
+
+fn (mut g Gen) store_reg_to_global_symbol(reg Reg, name string, size int) {
+	sym_idx := g.add_undefined(name)
+	asm_lea_reg_rip(mut g, r10)
+	g.add_rip_reloc(sym_idx)
+	g.emit_u32(0)
+	asm_store_mem_base_disp_reg_size(mut g, r10, 0, reg, size)
+}
+
+fn (mut g Gen) maybe_store_sysv_hosted_main_args(func mir.Function) {
+	if func.name != 'main' || g.abi != .sysv || g.obj_format !in [.elf, .macho] {
+		return
+	}
+	reachable := g.reachable_funcs_from_main()
+	refs := g.referenced_main_arg_globals(reachable)
+	for name in refs.argc {
+		if g.has_defined_global(name) {
+			g.store_reg_to_global_symbol(rdi, name, 4)
+		}
+	}
+	for name in refs.argv {
+		if g.has_defined_global(name) {
+			g.store_reg_to_global_symbol(rsi, name, 8)
+		}
+	}
+}
+
 fn (mut g Gen) gen_func(func mir.Function) {
 	g.curr_offset = g.text_len()
 	g.stack_map = map[int]int{}
@@ -293,6 +463,7 @@ fn (mut g Gen) gen_func(func mir.Function) {
 	asm_endbr64(mut g)
 	asm_push_rbp(mut g)
 	asm_mov_rbp_rsp(mut g)
+	g.maybe_store_sysv_hosted_main_args(func)
 
 	// Push callee-saved regs
 	for r in g.used_regs {
@@ -642,7 +813,7 @@ fn (mut g Gen) gen_instr(val_id int) {
 		}
 		.get_element_ptr {
 			g.load_val_to_reg(0, instr.operands[0]) // Base -> RAX
-			offset := g.gep_const_offset(instr.operands[0], instr.operands[1])
+			offset := g.gep_const_offset(instr.operands[0], instr.operands[1], instr.typ)
 			if offset >= 0 {
 				if offset > 0 {
 					asm_mov_reg_imm64(mut g, rcx, u64(offset))
@@ -982,8 +1153,8 @@ fn (mut g Gen) gen_instr(val_id int) {
 		.inline_string_init {
 			g.zero_value_bytes(val_id, g.stack_storage_size(val_id))
 			for fi, field_id in instr.operands {
-				g.store_field_value(val_id, instr.typ, fi, field_id,
-					g.type_size(g.mod.values[field_id].typ))
+				field_typ := g.struct_field_type(instr.typ, fi, g.mod.values[field_id].typ)
+				g.store_field_value(val_id, instr.typ, fi, field_id, g.type_size(field_typ))
 			}
 		}
 		.struct_init {
@@ -1281,7 +1452,7 @@ fn (g Gen) alloc_size_from_uses(ptr_id int, min_size int) int {
 			|| use_instr.operands[0] != ptr_id {
 			continue
 		}
-		offset := g.gep_const_offset(ptr_id, use_instr.operands[1])
+		offset := g.gep_const_offset(ptr_id, use_instr.operands[1], use_instr.typ)
 		if offset < 0 {
 			continue
 		}
@@ -1358,7 +1529,7 @@ fn (g Gen) struct_field_offset_bytes(struct_typ_id int, field_idx int) int {
 	return field_idx * 8
 }
 
-fn (g Gen) gep_const_offset(base_id int, idx_id int) int {
+fn (g Gen) gep_const_offset(base_id int, idx_id int, result_typ_id ssa.TypeID) int {
 	if idx_id <= 0 || idx_id >= g.mod.values.len || g.mod.values[idx_id].kind != .constant {
 		return -1
 	}
@@ -1376,6 +1547,12 @@ fn (g Gen) gep_const_offset(base_id int, idx_id int) int {
 	}
 	elem_typ := g.mod.type_store.types[base_typ.elem_type]
 	if elem_typ.kind == .struct_t {
+		if result_typ_id > 0 && result_typ_id < g.mod.type_store.types.len {
+			result_typ := g.mod.type_store.types[result_typ_id]
+			if result_typ.kind == .ptr_t && result_typ.elem_type == base_typ.elem_type {
+				return idx * g.type_size(base_typ.elem_type)
+			}
+		}
 		return g.struct_field_offset_bytes(base_typ.elem_type, idx)
 	}
 	if elem_typ.kind == .array_t {
@@ -2490,6 +2667,11 @@ fn (mut g Gen) load_val_to_reg(reg int, val_id int) {
 				asm_mov_reg_imm64(mut g, Reg(reg), u64(int_val))
 			}
 		}
+	} else if val.kind == .func_ref {
+		sym_idx := g.add_undefined(val.name)
+		asm_lea_reg_rip(mut g, Reg(reg))
+		g.add_rip_reloc(sym_idx)
+		g.emit_u32(0)
 	} else if val.kind == .global {
 		sym_idx := g.add_undefined(val.name)
 		if g.obj_format == .macho && val.index >= 0 && val.index < g.mod.globals.len
@@ -2547,11 +2729,26 @@ fn (mut g Gen) materialize_string_literal(reg int, val_id int) {
 	asm_lea_reg_rip(mut g, rax)
 	g.add_rip_reloc(sym_idx)
 	g.emit_u32(0)
-	asm_store_rbp_disp_reg_size(mut g, slot_off + g.struct_field_offset_bytes(val.typ, 0), rax, 8)
+	mut str_field_size := g.type_size(g.struct_field_type(val.typ, 0, 0))
+	if str_field_size <= 0 {
+		str_field_size = 8
+	}
+	mut len_field_size := g.type_size(g.struct_field_type(val.typ, 1, 0))
+	if len_field_size <= 0 {
+		len_field_size = 8
+	}
+	mut is_lit_field_size := g.type_size(g.struct_field_type(val.typ, 2, 0))
+	if is_lit_field_size <= 0 {
+		is_lit_field_size = 8
+	}
+	asm_store_rbp_disp_reg_size(mut g, slot_off + g.struct_field_offset_bytes(val.typ, 0), rax,
+		str_field_size)
 	asm_mov_reg_imm32(mut g, rax, u32(val.index))
-	asm_store_rbp_disp_reg_size(mut g, slot_off + g.struct_field_offset_bytes(val.typ, 1), rax, 4)
+	asm_store_rbp_disp_reg_size(mut g, slot_off + g.struct_field_offset_bytes(val.typ, 1), rax,
+		len_field_size)
 	asm_mov_reg_imm32(mut g, rax, 1)
-	asm_store_rbp_disp_reg_size(mut g, slot_off + g.struct_field_offset_bytes(val.typ, 2), rax, 4)
+	asm_store_rbp_disp_reg_size(mut g, slot_off + g.struct_field_offset_bytes(val.typ, 2), rax,
+		is_lit_field_size)
 	if slot_off >= -128 && slot_off <= 127 {
 		asm_lea_rax_rbp_disp8(mut g, i8(slot_off))
 	} else {

--- a/vlib/v2/gen/x64/x64_backend_diagnostics_test.v
+++ b/vlib/v2/gen/x64/x64_backend_diagnostics_test.v
@@ -135,6 +135,28 @@ fn main() {
 	}
 }
 
+fn test_x64_user_visible_stderr_reports_captured_fn_literal_unsupported() {
+	$if x64 {
+		failure := run_x64_backend_compile_failure('captured_fn_literal_unsupported', 'module main
+
+fn make_delta(delta int) fn (int) int {
+	return fn [delta] (value int) int {
+		return value + delta
+	}
+}
+
+fn main() {
+	f := make_delta(10)
+	println(f(1))
+}
+')
+		assert_x64_user_visible_compile_failure(failure, 'x64: unsupported backend feature: ')
+		assert failure.stderr.contains('native x64 cannot lower captured function literal'), failure.stderr
+
+		assert failure.stderr.contains('closure environments are not implemented yet'), failure.stderr
+	}
+}
+
 fn test_x64_unsupported_backend_feature_message_is_normalized() {
 	assert x64_unsupported_backend_feature_message('stack-passed float parameter') == 'x64: unsupported backend feature: stack-passed float parameter'
 	assert x64_unsupported_backend_feature_message('backend feature: Windows argument lowering') == 'x64: unsupported backend feature: Windows argument lowering'

--- a/vlib/v2/gen/x64/x64_object_format_test.v
+++ b/vlib/v2/gen/x64/x64_object_format_test.v
@@ -59,6 +59,24 @@ fn new_macho_global_codegen_test_module(name string, linkage ssa.Linkage) mir.Mo
 	}
 }
 
+fn new_func_ref_codegen_test_module(name string) mir.Module {
+	mut ts := ssa.TypeStore.new()
+	i8_t := ts.get_int(8)
+	ptr_t := ts.get_ptr(i8_t)
+	return mir.Module{
+		type_store: unsafe { *ts }
+		values:     [
+			mir.Value{
+				id:    0
+				typ:   ptr_t
+				index: 0
+				kind:  .func_ref
+				name:  name
+			},
+		]
+	}
+}
+
 fn new_windows_coff_global_codegen_test_module() mir.Module {
 	mut ts := ssa.TypeStore.new()
 	i64_t := ts.get_int(64)
@@ -349,6 +367,38 @@ fn macho_test_text_relocations(data []u8) []MachOTestRelocation {
 		}
 	}
 	return relocs
+}
+
+fn macho_test_text_bytes(data []u8) []u8 {
+	load_cmds := macho_test_load_commands(data)
+	sections := macho_test_sections(data, load_cmds[0])
+	return data[int(sections[0].offset)..int(sections[0].offset + sections[0].size)]
+}
+
+fn macho_test_bytes_index(data []u8, needle []u8) int {
+	if needle.len == 0 {
+		return 0
+	}
+	if needle.len > data.len {
+		return -1
+	}
+	for i in 0 .. data.len - needle.len + 1 {
+		mut matches := true
+		for j in 0 .. needle.len {
+			if data[i + j] != needle[j] {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return i
+		}
+	}
+	return -1
+}
+
+fn assert_macho_test_bytes_contains(data []u8, needle []u8, label string) {
+	assert macho_test_bytes_index(data, needle) >= 0, label
 }
 
 struct CoffTestSection {
@@ -1244,6 +1294,47 @@ fn test_macho_codegen_keeps_private_global_references_signed() {
 	assert gen.macho.symbols[gen.macho.relocs[0].sym_idx].name == '_app_global'
 }
 
+fn test_elf_codegen_loads_func_ref_as_rip_relative_address() {
+	mut mod := new_func_ref_codegen_test_module('_anon_fn_0')
+	mut gen := Gen.new_with_format(&mod, .elf)
+	gen.load_val_to_reg(0, 0)
+
+	assert gen.elf.text_data == [u8(0x48), 0x8d, 0x05, 0, 0, 0, 0]
+	assert gen.elf.text_relocs.len == 1
+	assert gen.elf.text_relocs[0].offset == 3
+	assert gen.elf.text_relocs[0].info & u64(0xffff_ffff) == u64(r_x86_64_pc32)
+	sym_idx := int(gen.elf.text_relocs[0].info >> 32)
+	assert gen.elf.symbols[sym_idx].name == '_anon_fn_0'
+	assert gen.elf.text_relocs[0].addend == i64(-4)
+}
+
+fn test_macho_codegen_loads_func_ref_as_rip_relative_address() {
+	mut mod := new_func_ref_codegen_test_module('_anon_fn_0')
+	mut gen := Gen.new_with_format(&mod, .macho)
+	gen.load_val_to_reg(0, 0)
+
+	assert gen.macho.text_data == [u8(0x48), 0x8d, 0x05, 0, 0, 0, 0]
+	assert gen.macho.relocs.len == 1
+	assert gen.macho.relocs[0].addr == 3
+	assert gen.macho.relocs[0].type_ == x86_64_reloc_signed
+	assert gen.macho.relocs[0].pcrel
+	assert gen.macho.relocs[0].extern
+	assert gen.macho.relocs[0].length == 2
+	assert gen.macho.symbols[gen.macho.relocs[0].sym_idx].name == '__anon_fn_0'
+}
+
+fn test_coff_codegen_loads_func_ref_as_rip_relative_address() {
+	mut mod := new_func_ref_codegen_test_module('_anon_fn_0')
+	mut gen := Gen.new_with_format(&mod, .coff)
+	gen.load_val_to_reg(0, 0)
+
+	assert gen.coff.text_data == [u8(0x48), 0x8d, 0x05, 0, 0, 0, 0]
+	assert gen.coff.text_relocs.len == 1
+	assert gen.coff.text_relocs[0].offset == 3
+	assert gen.coff.text_relocs[0].type_ == coff_image_rel_amd64_rel32
+	assert gen.coff.symbols[gen.coff.text_relocs[0].sym_idx].name == '_anon_fn_0'
+}
+
 fn test_windows_coff_codegen_omits_unused_global_data() {
 	mut mod := new_windows_coff_global_codegen_test_module()
 	mut gen := Gen.new_with_format_and_abi(&mod, .coff, .windows)
@@ -1630,6 +1721,237 @@ fn test_macho_tiny_object_writer_preserves_undefined_externals_and_remaps_reloca
 		assert reloc.length == 2
 		assert reloc.extern
 	}
+}
+
+fn test_macho_tiny_object_writer_resolves_builtin_string_plus_with_libsystem_runtime() {
+	path := temp_object_path('macho_tiny_string_plus_runtime')
+	defer {
+		os.rm(path) or {}
+	}
+
+	mut obj := MachOObject.new()
+	obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0xc3]
+	string_plus_sym := obj.add_undefined('_builtin__string__+')
+	obj.add_symbol('_main', 0, true, 1)
+	obj.add_reloc(1, string_plus_sym, x86_64_reloc_branch, true, 2)
+
+	mut writer := MachOTinyObjectWriter{
+		macho: obj
+	}
+	writer.write(path) or { panic(err) }
+
+	data := os.read_bytes(path) or { panic(err) }
+	symbols := macho_test_symbols(data)
+	names := symbols.map(it.name)
+	assert '_main' in names
+	assert '_builtin__string__+' in names
+	assert '_malloc' in names
+	assert '_exit' in names
+
+	string_plus_out := macho_test_symbol_by_name(symbols, '_builtin__string__+') or {
+		assert false, 'missing _builtin__string__+ in Mach-O tiny output'
+		return
+	}
+	assert string_plus_out.type_ == 0x0e
+	assert string_plus_out.sect == 1
+	assert string_plus_out.value > 0
+	for name in ['_malloc', '_exit'] {
+		symbol := macho_test_symbol_by_name(symbols, name) or {
+			assert false, 'missing ${name} in Mach-O tiny output'
+			return
+		}
+		assert symbol.type_ == 0x01
+		assert symbol.sect == 0
+		assert symbol.value == 0
+	}
+
+	relocs := macho_test_text_relocations(data)
+	assert relocs.len == 2
+	assert relocs[0].addr > int(string_plus_out.value)
+	assert symbols[relocs[0].sym_idx].name == '_malloc'
+	assert relocs[1].addr > int(string_plus_out.value)
+	assert relocs[1].addr > relocs[0].addr
+	assert symbols[relocs[1].sym_idx].name == '_exit'
+	mut reloc_names := []string{}
+	for reloc in relocs {
+		reloc_names << symbols[reloc.sym_idx].name
+		assert reloc.pcrel
+		assert reloc.length == 2
+		assert reloc.extern
+		assert reloc.type_ == x86_64_reloc_branch
+	}
+	reloc_names.sort()
+	assert reloc_names == ['_exit', '_malloc']
+
+	text := macho_test_text_bytes(data)
+	expected_disp := i64(string_plus_out.value) - i64(1 + 4)
+	assert read_u32_le(text, 1) == u32(i32(expected_disp))
+}
+
+fn test_macho_tiny_object_writer_resolves_builtin_i64_str_with_libsystem_runtime() {
+	path := temp_object_path('macho_tiny_i64_str_runtime')
+	defer {
+		os.rm(path) or {}
+	}
+
+	mut obj := MachOObject.new()
+	obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0xc3]
+	i64_str_sym := obj.add_undefined('_builtin__i64__str')
+	obj.add_symbol('_main', 0, true, 1)
+	obj.add_reloc(1, i64_str_sym, x86_64_reloc_branch, true, 2)
+
+	mut writer := MachOTinyObjectWriter{
+		macho: obj
+	}
+	writer.write(path) or { panic(err) }
+
+	data := os.read_bytes(path) or { panic(err) }
+	symbols := macho_test_symbols(data)
+	i64_str_out := macho_test_symbol_by_name(symbols, '_builtin__i64__str') or {
+		assert false, 'missing _builtin__i64__str in Mach-O tiny output'
+		return
+	}
+	assert i64_str_out.type_ == 0x0e
+	assert i64_str_out.sect == 1
+	assert i64_str_out.value > 0
+
+	relocs := macho_test_text_relocations(data)
+	assert relocs.len == 2
+	mut reloc_names := []string{}
+	for reloc in relocs {
+		reloc_names << symbols[reloc.sym_idx].name
+		assert reloc.pcrel
+		assert reloc.length == 2
+		assert reloc.extern
+		assert reloc.type_ == x86_64_reloc_branch
+		assert reloc.addr > int(i64_str_out.value)
+	}
+	reloc_names.sort()
+	assert reloc_names == ['_exit', '_malloc']
+
+	text := macho_test_text_bytes(data)
+	expected_disp := i64(i64_str_out.value) - i64(1 + 4)
+	assert read_u32_le(text, 1) == u32(i32(expected_disp))
+}
+
+fn test_macho_tiny_i64_str_helper_uses_signed_64_bit_decimal_runtime() {
+	path := temp_object_path('macho_tiny_i64_str_runtime_bytes')
+	defer {
+		os.rm(path) or {}
+	}
+
+	mut obj := MachOObject.new()
+	obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0xc3]
+	i64_str_sym := obj.add_undefined('_builtin__i64__str')
+	obj.add_symbol('_main', 0, true, 1)
+	obj.add_reloc(1, i64_str_sym, x86_64_reloc_branch, true, 2)
+
+	mut writer := MachOTinyObjectWriter{
+		macho: obj
+	}
+	writer.write(path) or { panic(err) }
+
+	data := os.read_bytes(path) or { panic(err) }
+	symbols := macho_test_symbols(data)
+	i64_str_out := macho_test_symbol_by_name(symbols, '_builtin__i64__str') or {
+		assert false, 'missing _builtin__i64__str in Mach-O tiny output'
+		return
+	}
+	text := macho_test_text_bytes(data)
+	helper := text[int(i64_str_out.value)..]
+
+	assert helper[0..7] == [u8(0x57), 0xbf, 0x20, 0, 0, 0, 0xe8]
+	assert helper[32] == 0x5f
+	assert_macho_test_bytes_contains(helper, [u8(0x48), 0x89, 0xf8],
+		'i64 str helper must read the full i64 argument from rdi')
+	assert_macho_test_bytes_contains(helper, [u8(0x41), 0xb2, 0x01],
+		'i64 str helper must remember signed negative inputs')
+	assert_macho_test_bytes_contains(helper, [u8(0x48), 0xf7, 0xd8],
+		'i64 str helper must negate the full 64-bit value, preserving i64_min as unsigned magnitude')
+	assert_macho_test_bytes_contains(helper, [u8(0x48), 0xf7, 0xf1],
+		'i64 str helper must divide the full 64-bit magnitude by 10')
+	assert_macho_test_bytes_contains(helper, [u8(0x41), 0xc6, 0x00, 0x2d],
+		'i64 str helper must emit a minus sign for signed negative inputs')
+	assert_macho_test_bytes_contains(helper, [u8(0x4c), 0x89, 0xc0, 0x4c, 0x89, 0xca, 0xc3],
+		'i64 str helper must return ptr in rax and len in rdx')
+
+	relocs := macho_test_text_relocations(data)
+	mut malloc_relocs := 0
+	mut exit_relocs := 0
+	for reloc in relocs {
+		name := symbols[reloc.sym_idx].name
+		if name == '_malloc' {
+			malloc_relocs++
+			assert reloc.addr == u32(i64_str_out.value + 7)
+		} else if name == '_exit' {
+			exit_relocs++
+			assert reloc.addr == u32(i64_str_out.value + 26)
+		} else {
+			assert false, 'unexpected Mach-O tiny i64 str helper relocation to ${name}'
+		}
+		assert reloc.extern
+		assert reloc.pcrel
+		assert reloc.length == 2
+		assert reloc.type_ == x86_64_reloc_branch
+	}
+	assert malloc_relocs == 1
+	assert exit_relocs == 1
+}
+
+fn test_macho_tiny_object_writer_resolves_i64_str_and_string_plus_locally() {
+	path := temp_object_path('macho_tiny_i64_str_string_plus_runtime')
+	defer {
+		os.rm(path) or {}
+	}
+
+	mut obj := MachOObject.new()
+	obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0xe8, 0, 0, 0, 0, 0xc3]
+	i64_str_sym := obj.add_undefined('_builtin__i64__str')
+	string_plus_sym := obj.add_undefined('_builtin__string__+')
+	obj.add_symbol('_main', 0, true, 1)
+	obj.add_reloc(1, i64_str_sym, x86_64_reloc_branch, true, 2)
+	obj.add_reloc(6, string_plus_sym, x86_64_reloc_branch, true, 2)
+
+	mut writer := MachOTinyObjectWriter{
+		macho: obj
+	}
+	writer.write(path) or { panic(err) }
+
+	data := os.read_bytes(path) or { panic(err) }
+	symbols := macho_test_symbols(data)
+	i64_str_out := macho_test_symbol_by_name(symbols, '_builtin__i64__str') or {
+		assert false, 'missing _builtin__i64__str in Mach-O tiny output'
+		return
+	}
+	string_plus_out := macho_test_symbol_by_name(symbols, '_builtin__string__+') or {
+		assert false, 'missing _builtin__string__+ in Mach-O tiny output'
+		return
+	}
+	assert i64_str_out.type_ == 0x0e
+	assert i64_str_out.sect == 1
+	assert i64_str_out.value > 0
+	assert string_plus_out.type_ == 0x0e
+	assert string_plus_out.sect == 1
+	assert string_plus_out.value > i64_str_out.value
+
+	relocs := macho_test_text_relocations(data)
+	assert relocs.len == 4
+	mut reloc_names := []string{}
+	for reloc in relocs {
+		reloc_names << symbols[reloc.sym_idx].name
+		assert reloc.pcrel
+		assert reloc.length == 2
+		assert reloc.extern
+		assert reloc.type_ == x86_64_reloc_branch
+	}
+	reloc_names.sort()
+	assert reloc_names == ['_exit', '_exit', '_malloc', '_malloc']
+
+	text := macho_test_text_bytes(data)
+	expected_i64_disp := i64(i64_str_out.value) - i64(1 + 4)
+	expected_string_plus_disp := i64(string_plus_out.value) - i64(6 + 4)
+	assert read_u32_le(text, 1) == u32(i32(expected_i64_disp))
+	assert read_u32_le(text, 6) == u32(i32(expected_string_plus_disp))
 }
 
 fn test_macho_tiny_object_writer_keeps_referenced_rodata_and_data() {

--- a/vlib/v2/gen/x64/x64_pe_linker_test.v
+++ b/vlib/v2/gen/x64/x64_pe_linker_test.v
@@ -188,7 +188,7 @@ fn pe_test_rva_to_file_off(image []u8, rva u32) int {
 	return -1
 }
 
-fn pe_test_import_names(image []u8) []string {
+fn pe_test_import_descriptor_offsets(image []u8) []int {
 	pe_off := int(pe_test_u32(image, 0x3c))
 	opt_off := pe_off + 4 + 20
 	import_rva := pe_test_u32(image, opt_off + 112 + pe_import_directory_index * 8)
@@ -197,29 +197,66 @@ fn pe_test_import_names(image []u8) []string {
 	}
 	import_off := pe_test_rva_to_file_off(image, import_rva)
 	assert import_off > 0
-	ilt_rva := pe_test_u32(image, import_off)
-	ilt_off := pe_test_rva_to_file_off(image, ilt_rva)
-	assert ilt_off > 0
-	mut names := []string{}
-	for i := 0; i < 128; i++ {
-		hint_name_rva := u32(pe_test_u64(image, ilt_off + i * 8))
-		if hint_name_rva == 0 {
-			return names
+	mut offsets := []int{}
+	for i := 0; i < 32; i++ {
+		descriptor_off := import_off + i * 20
+		ilt_rva := pe_test_u32(image, descriptor_off)
+		dll_name_rva := pe_test_u32(image, descriptor_off + 12)
+		first_thunk_rva := pe_test_u32(image, descriptor_off + 16)
+		if ilt_rva == 0 && dll_name_rva == 0 && first_thunk_rva == 0 {
+			return offsets
 		}
-		hint_name_off := pe_test_rva_to_file_off(image, hint_name_rva)
-		assert hint_name_off > 0
-		assert pe_test_u16(image, hint_name_off) == 0
-		assert hint_name_off % 2 == 0
-		names << pe_test_string(image, hint_name_off + 2)
+		assert ilt_rva != 0
+		assert dll_name_rva != 0
+		assert first_thunk_rva != 0
+		offsets << descriptor_off
 	}
 	assert false
+	return offsets
+}
+
+fn pe_test_import_names(image []u8) []string {
+	mut names := []string{}
+	for descriptor_off in pe_test_import_descriptor_offsets(image) {
+		ilt_rva := pe_test_u32(image, descriptor_off)
+		ilt_off := pe_test_rva_to_file_off(image, ilt_rva)
+		assert ilt_off > 0
+		for i := 0; i < 128; i++ {
+			hint_name_rva := u32(pe_test_u64(image, ilt_off + i * 8))
+			if hint_name_rva == 0 {
+				break
+			}
+			hint_name_off := pe_test_rva_to_file_off(image, hint_name_rva)
+			assert hint_name_off > 0
+			assert pe_test_u16(image, hint_name_off) == 0
+			assert hint_name_off % 2 == 0
+			names << pe_test_string(image, hint_name_off + 2)
+		}
+	}
 	return names
+}
+
+fn pe_test_import_dll_names(image []u8) []string {
+	mut dlls := []string{}
+	for descriptor_off in pe_test_import_descriptor_offsets(image) {
+		dll_name_rva := pe_test_u32(image, descriptor_off + 12)
+		dll_name_off := pe_test_rva_to_file_off(image, dll_name_rva)
+		assert dll_name_off > 0
+		dlls << pe_test_string(image, dll_name_off)
+	}
+	return dlls
 }
 
 fn pe_test_iat_size(image []u8) u32 {
 	pe_off := int(pe_test_u32(image, 0x3c))
 	opt_off := pe_off + 4 + 20
 	return pe_test_u32(image, opt_off + 116 + pe_iat_directory_index * 8)
+}
+
+fn pe_test_text_rel32_target(image []u8, text_rva u32, text_raw int, field_off int) u32 {
+	field_rva := text_rva + u32(field_off)
+	disp := pe_test_i32(image, text_raw + field_off)
+	return u32(i32(field_rva + 4) + disp)
 }
 
 fn sample_pe_coff_object() &CoffObject {
@@ -230,6 +267,27 @@ fn sample_pe_coff_object() &CoffObject {
 	obj.data_data << [u8(1), 2, 3, 4]
 	obj.add_symbol('_vinit', 0, true, 1)
 	obj.add_symbol('main', 1, true, 1)
+	return obj
+}
+
+fn sample_pe_arguments_coff_object(with_vinit bool) &CoffObject {
+	mut obj := CoffObject.new()
+	mut main_off := 0
+	if with_vinit {
+		obj.text_data << u8(0xc3)
+		obj.add_symbol('_vinit', 0, true, 1)
+		main_off = obj.text_data.len
+	}
+	obj.text_data << [u8(0x8b), 0x05, 0, 0, 0, 0] // mov eax, [rip + g_main_argc]
+	obj.text_data << [u8(0x48), 0x8b, 0x15, 0, 0, 0, 0] // mov rdx, [rip + g_main_argv]
+	obj.text_data << u8(0xc3)
+	obj.add_symbol('main', u64(main_off), true, 1)
+	obj.data_data << [u8(0), 0, 0, 0, 0, 0, 0, 0]
+	obj.data_data << [u8(0), 0, 0, 0, 0, 0, 0, 0]
+	argc_sym := obj.add_symbol('g_main_argc', 0, false, 3)
+	argv_sym := obj.add_symbol('g_main_argv', 8, false, 3)
+	obj.add_text_reloc(main_off + 2, argc_sym, coff_image_rel_amd64_rel32)
+	obj.add_text_reloc(main_off + 9, argv_sym, coff_image_rel_amd64_rel32)
 	return obj
 }
 
@@ -389,9 +447,12 @@ fn test_pe_linker_emits_demand_driven_kernel32_import_table() {
 	assert pe_test_u64(image, iat_off + expected_imports.len * 8) == 0
 	assert names == expected_imports
 	assert names == pe_test_import_names(image)
+	assert pe_test_import_dll_names(image) == ['kernel32.dll']
 	assert pe_test_iat_size(image) == u32((expected_imports.len + 1) * 8)
 	assert 'HeapAlloc' !in names
 	assert 'WriteFile' !in names
+	assert 'GetCommandLineW' !in names
+	assert 'CommandLineToArgvW' !in names
 }
 
 fn test_pe_linker_adds_direct_kernel32_imports_in_stable_order() {
@@ -425,6 +486,78 @@ fn test_pe_linker_adds_runtime_kernel32_import_patches_only_when_needed() {
 	assert names == ['ExitProcess', 'GetProcessHeap', 'HeapAlloc']
 	assert pe_test_iat_size(image) == u32((names.len + 1) * 8)
 	assert 'HeapFree' !in names
+	assert 'WriteFile' !in names
+}
+
+fn test_pe_linker_adds_shell32_imports_only_for_windows_arguments_globals() {
+	obj := sample_pe_arguments_coff_object(false)
+	mut linker := PeLinker.new(obj)
+	image := linker.image() or { panic(err) }
+	names := pe_test_import_names(image)
+
+	assert names == ['ExitProcess', 'GetCommandLineW', 'CommandLineToArgvW']
+	assert pe_test_import_dll_names(image) == ['kernel32.dll', 'shell32.dll']
+	assert pe_test_iat_size(image) == u32((names.len + 2) * 8)
+}
+
+fn test_pe_linker_uses_qualified_import_keys_for_multi_dll_thunks_and_iat() {
+	obj := sample_pe_coff_object()
+	mut linker := PeLinker.new(obj)
+	linker.imports = [
+		PeImport{
+			dll:  pe_kernel32_dll
+			name: 'SharedExport'
+		},
+		PeImport{
+			dll:  pe_shell32_dll
+			name: 'SharedExport'
+		},
+	]
+
+	kernel_key := pe_import_key(pe_kernel32_dll, 'SharedExport')
+	shell_key := pe_import_key(pe_shell32_dll, 'SharedExport')
+	import_offsets := linker.import_thunk_offsets(0)
+	idata := linker.build_idata(0x3000)
+
+	assert 'SharedExport' !in import_offsets
+	assert kernel_key in import_offsets
+	assert shell_key in import_offsets
+	assert import_offsets[kernel_key] != import_offsets[shell_key]
+	assert 'SharedExport' !in idata.iat_rvas
+	assert kernel_key in idata.iat_rvas
+	assert shell_key in idata.iat_rvas
+	assert idata.iat_rvas[kernel_key] != idata.iat_rvas[shell_key]
+}
+
+fn test_pe_linker_resolves_windows_string_plus_runtime_with_heap_imports() {
+	mut obj := CoffObject.new()
+	obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0xc3]
+	obj.add_symbol('main', 5, true, 1)
+	string_plus_sym := obj.add_undefined('builtin__string__+')
+	obj.add_text_reloc(1, string_plus_sym, coff_image_rel_amd64_rel32)
+
+	mut linker := PeLinker.new(obj)
+	image := linker.image() or { panic(err) }
+	names := pe_test_import_names(image)
+
+	assert names == ['ExitProcess', 'GetProcessHeap', 'HeapAlloc']
+	assert pe_test_iat_size(image) == u32((names.len + 1) * 8)
+	assert 'WriteFile' !in names
+}
+
+fn test_pe_linker_resolves_windows_i64_str_runtime_with_heap_imports() {
+	mut obj := CoffObject.new()
+	obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0xc3]
+	obj.add_symbol('main', 5, true, 1)
+	i64_str_sym := obj.add_undefined('builtin__i64__str')
+	obj.add_text_reloc(1, i64_str_sym, coff_image_rel_amd64_rel32)
+
+	mut linker := PeLinker.new(obj)
+	image := linker.image() or { panic(err) }
+	names := pe_test_import_names(image)
+
+	assert names == ['ExitProcess', 'GetProcessHeap', 'HeapAlloc']
+	assert pe_test_iat_size(image) == u32((names.len + 1) * 8)
 	assert 'WriteFile' !in names
 }
 
@@ -519,6 +652,61 @@ fn test_pe_linker_entry_stub_targets_main_and_exitprocess_thunk() {
 	assert u32(i32(exit_thunk_rva + 6) + exit_disp) == iat_rva
 }
 
+fn test_pe_linker_bootstraps_windows_arguments_before_vinit() {
+	obj := sample_pe_arguments_coff_object(true)
+	mut linker := PeLinker.new(obj)
+	image := linker.image() or { panic(err) }
+
+	text_off := pe_test_section_header(image, '.text')
+	text_rva := pe_test_u32(image, text_off + 12)
+	text_raw := int(pe_test_u32(image, text_off + 20))
+	data_off := pe_test_section_header(image, '.data')
+	data_rva := pe_test_u32(image, data_off + 12)
+	entry_stub_len := linker.entry_stub_size()
+	bootstrap_len := linker.windows_argv_bootstrap_size()
+
+	assert bootstrap_len > 0
+	assert image[text_raw..text_raw + 4] == [u8(0x48), 0x83, 0xec, 0x28]
+	assert image[text_raw + 4..text_raw + 12] == [u8(0xc7), 0x44, 0x24, 0x20, 0, 0, 0, 0]
+	assert image[text_raw + 12] == 0xe8
+	assert image[text_raw + 17..text_raw + 20] == [u8(0x48), 0x89, 0xc1]
+	assert image[text_raw + 20..text_raw + 25] == [u8(0x48), 0x8d, 0x54, 0x24, 0x20]
+	assert image[text_raw + 25] == 0xe8
+	assert image[text_raw + 30..text_raw + 33] == [u8(0x48), 0x85, 0xc0]
+	assert image[text_raw + 33..text_raw + 35] == [u8(0x75), 0x0a]
+	assert image[text_raw + 35..text_raw + 40] == [u8(0xb9), 1, 0, 0, 0]
+	assert image[text_raw + 40] == 0xe8
+	assert image[text_raw + 45..text_raw + 48] == [u8(0x4c), 0x8d, 0x15]
+	assert image[text_raw + 52..text_raw + 55] == [u8(0x49), 0x89, 0x02]
+	assert image[text_raw + 55..text_raw + 58] == [u8(0x4c), 0x8d, 0x15]
+	assert image[text_raw + 62..text_raw + 66] == [u8(0x8b), 0x4c, 0x24, 0x20]
+	assert image[text_raw + 66..text_raw + 69] == [u8(0x41), 0x89, 0x0a]
+
+	import_offsets := linker.import_thunk_offsets(0)
+	get_command_line_thunk := import_offsets[pe_kernel32_import_key('GetCommandLineW')] or {
+		panic('missing GetCommandLineW import thunk')
+	}
+	command_line_to_argv_thunk := import_offsets[pe_shell32_import_key('CommandLineToArgvW')] or {
+		panic('missing CommandLineToArgvW import thunk')
+	}
+	exit_thunk := import_offsets[pe_kernel32_import_key('ExitProcess')] or {
+		panic('missing ExitProcess import thunk')
+	}
+	assert pe_test_text_rel32_target(image, text_rva, text_raw, 13) == text_rva +
+		get_command_line_thunk
+	assert pe_test_text_rel32_target(image, text_rva, text_raw, 26) == text_rva +
+		command_line_to_argv_thunk
+	assert pe_test_text_rel32_target(image, text_rva, text_raw, 41) == text_rva + exit_thunk
+	assert pe_test_text_rel32_target(image, text_rva, text_raw, 48) == data_rva + 8
+	assert pe_test_text_rel32_target(image, text_rva, text_raw, 58) == data_rva
+	vinit_call_field := 4 + bootstrap_len + 1
+	main_call_field := vinit_call_field + 5
+	assert pe_test_text_rel32_target(image, text_rva, text_raw, vinit_call_field) == text_rva +
+		u32(entry_stub_len)
+	assert pe_test_text_rel32_target(image, text_rva, text_raw, main_call_field) == text_rva +
+		u32(entry_stub_len + 1)
+}
+
 fn test_pe_linker_applies_internal_rel32_relocations() {
 	mut obj := CoffObject.new()
 	obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0xc3]
@@ -570,11 +758,37 @@ fn test_pe_linker_resolves_get_current_thread_id_as_kernel32_import() {
 	disp := pe_test_i32(image, field_off)
 	target := u32(i32(field_rva + 4) + disp)
 	import_offsets := linker.import_thunk_offsets(0)
-	get_tid_thunk := import_offsets['GetCurrentThreadId'] or {
+	get_tid_thunk := import_offsets[pe_kernel32_import_key('GetCurrentThreadId')] or {
 		panic('missing GetCurrentThreadId import thunk')
 	}
 
 	assert target == text_rva + get_tid_thunk
+}
+
+fn test_pe_linker_resolves_windows_system_time_imports() {
+	for name in ['GetSystemTimeAsFileTime', 'FileTimeToSystemTime', 'SystemTimeToTzSpecificLocalTime'] {
+		mut obj := CoffObject.new()
+		obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0xc3]
+		obj.add_symbol('main', 0, true, 1)
+		sym := obj.add_undefined(name)
+		obj.add_text_reloc(1, sym, coff_image_rel_amd64_rel32)
+
+		mut linker := PeLinker.new(obj)
+		image := linker.image() or { panic(err) }
+		text_off := pe_test_section_header(image, '.text')
+		text_rva := pe_test_u32(image, text_off + 12)
+		text_raw := int(pe_test_u32(image, text_off + 20))
+		field_off := text_raw + linker.entry_stub_size() + 1
+		field_rva := text_rva + u32(linker.entry_stub_size() + 1)
+		disp := pe_test_i32(image, field_off)
+		target := u32(i32(field_rva + 4) + disp)
+		import_offsets := linker.import_thunk_offsets(0)
+		thunk := import_offsets[pe_kernel32_import_key(name)] or {
+			panic('missing ${name} import thunk')
+		}
+
+		assert target == text_rva + thunk
+	}
 }
 
 fn test_pe_linker_resolves_memcmp_and_exit_with_internal_runtime_thunks() {
@@ -988,7 +1202,7 @@ fn test_pe_linker_resolves_wgetenv_with_kernel32_runtime_thunk() {
 	import_offsets := linker.import_thunk_offsets(runtime_text_size)
 	names := pe_test_import_names(image)
 	assert names == ['ExitProcess', 'GetEnvironmentVariableW']
-	getenv_thunk := import_offsets['GetEnvironmentVariableW'] or {
+	getenv_thunk := import_offsets[pe_kernel32_import_key('GetEnvironmentVariableW')] or {
 		panic('missing GetEnvironmentVariableW import thunk')
 	}
 	getenv_thunk_rva := text_rva + getenv_thunk
@@ -1375,6 +1589,46 @@ fn test_pe_linker_resolves_new_array_from_c_array_noscan_with_internal_heap_thun
 	assert has_noscan_flags_store
 	assert has_element_size_store
 	assert has_byte_copy_loop
+}
+
+fn test_pe_linker_resolves_new_array_noscan_with_internal_heap_thunk() {
+	mut obj := CoffObject.new()
+	obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0xc3]
+	obj.add_symbol('main', 5, true, 1)
+	new_array_sym := obj.add_undefined('builtin____new_array_noscan')
+	obj.add_text_reloc(1, new_array_sym, coff_image_rel_amd64_rel32)
+
+	mut linker := PeLinker.new(obj)
+	image := linker.image() or { panic(err) }
+	text_off := pe_test_section_header(image, '.text')
+	text_rva := pe_test_u32(image, text_off + 12)
+	text_raw := int(pe_test_u32(image, text_off + 20))
+	text_raw_size := int(pe_test_u32(image, text_off + 16))
+	entry_stub_len := linker.entry_stub_size()
+	runtime_start_rva := text_rva + u32(entry_stub_len + obj.text_data.len)
+
+	mut first_import_thunk_file_off := -1
+	for off in text_raw + entry_stub_len + obj.text_data.len .. text_raw + text_raw_size - 1 {
+		if image[off] == 0xff && image[off + 1] == 0x25 {
+			first_import_thunk_file_off = off
+			break
+		}
+	}
+	assert first_import_thunk_file_off > 0
+	first_import_thunk_rva := text_rva + u32(first_import_thunk_file_off - text_raw)
+
+	new_array_field_off := text_raw + entry_stub_len + 1
+	new_array_field_rva := text_rva + u32(entry_stub_len + 1)
+	new_array_target := u32(i32(new_array_field_rva + 4) + pe_test_i32(image, new_array_field_off))
+	assert new_array_target >= runtime_start_rva
+	assert new_array_target < first_import_thunk_rva
+
+	new_array_off := pe_test_rva_to_file_off(image, new_array_target)
+	assert new_array_off > 0
+	assert image[new_array_off..new_array_off + 4] == [u8(0x48), 0x83, 0xec, 0x58] // sub rsp, 88
+	names := pe_test_import_names(image)
+	assert 'GetProcessHeap' in names
+	assert 'HeapAlloc' in names
 }
 
 fn test_pe_linker_rejects_unsupported_external_symbols() {

--- a/vlib/v2/gen/x64/x64_runtime_smoke_test.v
+++ b/vlib/v2/gen/x64/x64_runtime_smoke_test.v
@@ -141,6 +141,7 @@ fn x64_build_file_from_dir(vexe string, source_dir string, source_file string, b
 		build.close()
 	}
 	build.set_work_folder(source_dir)
+	build.set_environment(x64_pinned_v2_build_environment(vexe, os.dir(bin_path)))
 	build.set_args(['-v2', '-no-parallel', '-b', 'x64', source_file, '-o', bin_path])
 	build.set_redirect_stdio()
 	build.run()
@@ -460,6 +461,100 @@ fn run_x64_host_program_redirected_auto(name string, source string) X64HostRunRe
 	}
 }
 
+fn run_x64_host_program_redirected_auto_with_args(name string, source string, args []string) X64HostRunResult {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v2_x64_runtime_${name}_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	source_path := os.join_path(tmp_dir, '${name}.v')
+	bin_path := x64_host_bin_path(tmp_dir, name)
+	os.write_file(source_path, source) or { panic(err) }
+	vexe := os.getenv_opt('VEXE') or { @VEXE }
+	mut build := os.new_process(vexe)
+	defer {
+		build.close()
+	}
+	build.set_environment(x64_pinned_v2_build_environment(vexe, tmp_dir))
+	build.set_args(['-v2', '-no-parallel', '-b', 'x64', source_path, '-o', bin_path])
+	build.set_redirect_stdio()
+	build.run()
+	build.wait()
+	build_output := 'stdout:\n${build.stdout_slurp()}\nstderr:\n${build.stderr_slurp()}'
+	if build.code != 0 {
+		assert false, x64_host_build_failure_message(name, tmp_dir, source_path, source, bin_path,
+			build.code, build_output)
+	}
+	mut run := os.new_process(bin_path)
+	defer {
+		run.close()
+	}
+	run.set_args(args)
+	run.set_redirect_stdio()
+	run.run()
+	run.wait()
+	stdout := run.stdout_slurp().bytes()
+	stderr := run.stderr_slurp().bytes()
+	if run.code != 0 {
+		assert false, x64_host_run_failure_message(name, tmp_dir, source_path, source, bin_path,
+			build_output, run.code, stdout, stderr)
+	}
+	return X64HostRunResult{
+		name:         name
+		tmp_dir:      tmp_dir
+		source_path:  source_path
+		source_text:  source
+		bin_path:     bin_path
+		build_output: build_output
+		stdout:       stdout
+		stderr:       stderr
+	}
+}
+
+fn run_x64_host_program_redirected_macos_auto_tiny_verbose_with_args(name string, source string, args []string) X64HostRunResult {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v2_x64_runtime_${name}_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	source_path := os.join_path(tmp_dir, '${name}.v')
+	bin_path := x64_host_bin_path(tmp_dir, name)
+	os.write_file(source_path, source) or { panic(err) }
+	vexe := os.getenv_opt('VEXE') or { @VEXE }
+	mut build := os.new_process(vexe)
+	defer {
+		build.close()
+	}
+	build.set_environment(x64_macos_auto_tiny_build_environment(vexe, tmp_dir))
+	build.set_args(['-v2', '-v', '-no-parallel', '-b', 'x64', source_path, '-o', bin_path])
+	build.set_redirect_stdio()
+	build.run()
+	build.wait()
+	build_output := 'stdout:\n${build.stdout_slurp()}\nstderr:\n${build.stderr_slurp()}'
+	if build.code != 0 {
+		assert false, x64_host_build_failure_message(name, tmp_dir, source_path, source, bin_path,
+			build.code, build_output)
+	}
+	mut run := os.new_process(bin_path)
+	defer {
+		run.close()
+	}
+	run.set_args(args)
+	run.set_redirect_stdio()
+	run.run()
+	run.wait()
+	stdout := run.stdout_slurp().bytes()
+	stderr := run.stderr_slurp().bytes()
+	if run.code != 0 {
+		assert false, x64_host_run_failure_message(name, tmp_dir, source_path, source, bin_path,
+			build_output, run.code, stdout, stderr)
+	}
+	return X64HostRunResult{
+		name:         name
+		tmp_dir:      tmp_dir
+		source_path:  source_path
+		source_text:  source
+		bin_path:     bin_path
+		build_output: build_output
+		stdout:       stdout
+		stderr:       stderr
+	}
+}
+
 fn run_x64_host_program_redirected_with_exit(name string, source string) X64HostRunExitResult {
 	tmp_dir := os.join_path(os.vtmp_dir(), 'v2_x64_runtime_${name}_${os.getpid()}')
 	os.mkdir_all(tmp_dir) or { panic(err) }
@@ -682,6 +777,86 @@ fn run_x64_host_file_redirected(name string, source_dir string, source_file stri
 	}
 }
 
+fn run_x64_host_file_redirected_tiny(name string, source_dir string, source_file string) X64HostRunResult {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v2_x64_runtime_${name}_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	source_path := os.join_path(source_dir, source_file)
+	source_text := 'source file: ${source_path}'
+	bin_path := x64_host_bin_path(tmp_dir, name)
+	vexe := x64_vexe_command_path()
+	mut build := os.new_process(vexe)
+	defer {
+		build.close()
+	}
+	build.set_environment(x64_strict_tiny_build_environment(vexe, tmp_dir))
+	build.set_work_folder(source_dir)
+	build.set_args(['-v2', '-b', 'x64', source_file, '-o', bin_path])
+	build.set_redirect_stdio()
+	build.run()
+	build.wait()
+	build_output := 'stdout:\n${build.stdout_slurp()}\nstderr:\n${build.stderr_slurp()}'
+	if build.code != 0 {
+		assert false, x64_host_build_failure_message(name, tmp_dir, source_path, source_text,
+			bin_path, build.code, build_output)
+	}
+	mut run := os.new_process(bin_path)
+	defer {
+		run.close()
+	}
+	run.set_redirect_stdio()
+	run.run()
+	run.wait()
+	stdout := run.stdout_slurp().bytes()
+	stderr := run.stderr_slurp().bytes()
+	if run.code != 0 {
+		assert false, x64_host_run_failure_message(name, tmp_dir, source_path, source_text,
+			bin_path, build_output, run.code, stdout, stderr)
+	}
+	return X64HostRunResult{
+		name:         name
+		tmp_dir:      tmp_dir
+		source_path:  source_path
+		source_text:  source_text
+		bin_path:     bin_path
+		build_output: build_output
+		stdout:       stdout
+		stderr:       stderr
+	}
+}
+
+fn assert_x64_linux_tiny_file_build_rejected(name string, source_dir string, source_file string, expected_message string) {
+	$if linux {
+		tmp_dir := os.join_path(os.vtmp_dir(), 'v2_x64_runtime_${name}_${os.getpid()}')
+		os.mkdir_all(tmp_dir) or { panic(err) }
+		defer {
+			os.rmdir_all(tmp_dir) or {}
+		}
+		source_path := os.join_path(source_dir, source_file)
+		source_text := 'source file: ${source_path}'
+		bin_path := x64_host_bin_path(tmp_dir, name)
+		vexe := x64_vexe_command_path()
+		mut build := os.new_process(vexe)
+		defer {
+			build.close()
+		}
+		build.set_environment(x64_strict_tiny_build_environment(vexe, tmp_dir))
+		build.set_work_folder(source_dir)
+		build.set_args(['-v2', '-b', 'x64', source_file, '-o', bin_path])
+		build.set_redirect_stdio()
+		build.run()
+		build.wait()
+		build_output := 'stdout:\n${build.stdout_slurp()}\nstderr:\n${build.stderr_slurp()}'
+		assert build.code != 0, '${name} unexpectedly built with Linux tiny:\n${build_output}'
+		assert build_output.contains(linux_tiny_not_eligible_prefix), '${x64_host_build_failure_message(name,
+			tmp_dir, source_path, source_text, bin_path, build.code, build_output)}\nexpected Linux tiny rejection prefix `${linux_tiny_not_eligible_prefix}`'
+
+		assert build_output.contains(expected_message), '${x64_host_build_failure_message(name,
+			tmp_dir, source_path, source_text, bin_path, build.code, build_output)}\nexpected rejection to contain `${expected_message}`'
+
+		assert !os.exists(bin_path), '${name} produced a binary despite Linux tiny rejection: ${bin_path}'
+	}
+}
+
 fn run_x64_host_file_redirected_auto(name string, source_dir string, source_file string) X64HostRunResult {
 	tmp_dir := os.join_path(os.vtmp_dir(), 'v2_x64_runtime_${name}_${os.getpid()}')
 	os.mkdir_all(tmp_dir) or { panic(err) }
@@ -708,6 +883,102 @@ fn run_x64_host_file_redirected_auto(name string, source_dir string, source_file
 	defer {
 		run.close()
 	}
+	run.set_redirect_stdio()
+	run.run()
+	run.wait()
+	stdout := run.stdout_slurp().bytes()
+	stderr := run.stderr_slurp().bytes()
+	if run.code != 0 {
+		assert false, x64_host_run_failure_message(name, tmp_dir, source_path, source_text,
+			bin_path, build_output, run.code, stdout, stderr)
+	}
+	return X64HostRunResult{
+		name:         name
+		tmp_dir:      tmp_dir
+		source_path:  source_path
+		source_text:  source_text
+		bin_path:     bin_path
+		build_output: build_output
+		stdout:       stdout
+		stderr:       stderr
+	}
+}
+
+fn run_x64_host_file_redirected_auto_with_args(name string, source_dir string, source_file string, args []string) X64HostRunResult {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v2_x64_runtime_${name}_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	source_path := os.join_path(source_dir, source_file)
+	source_text := 'source file: ${source_path}'
+	bin_path := x64_host_bin_path(tmp_dir, name)
+	vexe := x64_vexe_command_path()
+	mut build := os.new_process(vexe)
+	defer {
+		build.close()
+	}
+	build.set_environment(x64_pinned_v2_build_environment(vexe, tmp_dir))
+	build.set_work_folder(source_dir)
+	build.set_args(['-v2', '-no-parallel', '-b', 'x64', source_file, '-o', bin_path])
+	build.set_redirect_stdio()
+	build.run()
+	build.wait()
+	build_output := 'stdout:\n${build.stdout_slurp()}\nstderr:\n${build.stderr_slurp()}'
+	if build.code != 0 {
+		assert false, x64_host_build_failure_message(name, tmp_dir, source_path, source_text,
+			bin_path, build.code, build_output)
+	}
+	mut run := os.new_process(bin_path)
+	defer {
+		run.close()
+	}
+	run.set_args(args)
+	run.set_redirect_stdio()
+	run.run()
+	run.wait()
+	stdout := run.stdout_slurp().bytes()
+	stderr := run.stderr_slurp().bytes()
+	if run.code != 0 {
+		assert false, x64_host_run_failure_message(name, tmp_dir, source_path, source_text,
+			bin_path, build_output, run.code, stdout, stderr)
+	}
+	return X64HostRunResult{
+		name:         name
+		tmp_dir:      tmp_dir
+		source_path:  source_path
+		source_text:  source_text
+		bin_path:     bin_path
+		build_output: build_output
+		stdout:       stdout
+		stderr:       stderr
+	}
+}
+
+fn run_x64_host_file_redirected_macos_auto_tiny_verbose_with_args(name string, source_dir string, source_file string, args []string) X64HostRunResult {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v2_x64_runtime_${name}_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	source_path := os.join_path(source_dir, source_file)
+	source_text := 'source file: ${source_path}'
+	bin_path := x64_host_bin_path(tmp_dir, name)
+	vexe := x64_vexe_command_path()
+	mut build := os.new_process(vexe)
+	defer {
+		build.close()
+	}
+	build.set_environment(x64_macos_auto_tiny_build_environment(vexe, tmp_dir))
+	build.set_work_folder(source_dir)
+	build.set_args(['-v2', '-v', '-no-parallel', '-b', 'x64', source_file, '-o', bin_path])
+	build.set_redirect_stdio()
+	build.run()
+	build.wait()
+	build_output := 'stdout:\n${build.stdout_slurp()}\nstderr:\n${build.stderr_slurp()}'
+	if build.code != 0 {
+		assert false, x64_host_build_failure_message(name, tmp_dir, source_path, source_text,
+			bin_path, build.code, build_output)
+	}
+	mut run := os.new_process(bin_path)
+	defer {
+		run.close()
+	}
+	run.set_args(args)
 	run.set_redirect_stdio()
 	run.run()
 	run.wait()
@@ -836,6 +1107,73 @@ fn assert_x64_linux_file_stdout_bytes(name string, source_dir string, source_fil
 		result := run_x64_linux_file_redirected(name, source_dir, source_file)
 		assert result.stdout == expected_stdout, '${name} stdout mismatch: ${result.stdout}'
 		assert result.stderr == []u8{}, '${name} stderr mismatch: ${result.stderr}'
+	}
+}
+
+fn x64_v_run_file_stdout_bytes(source_dir string, source_file string) []u8 {
+	vexe := x64_vexe_command_path()
+	source_path := os.join_path(source_dir, source_file)
+	mut run := os.new_process(vexe)
+	defer {
+		run.close()
+	}
+	run.set_work_folder(source_dir)
+	run.set_args(['run', source_file])
+	run.set_redirect_stdio()
+	run.run()
+	run.wait()
+	stdout := run.stdout_slurp().bytes()
+	stderr := run.stderr_slurp()
+	assert run.code == 0, 'v run ${source_path} failed with code ${run.code}\nstdout:\n${stdout.bytestr()}\nstderr:\n${stderr}'
+	assert x64_v_run_oracle_stderr_is_allowed(stderr), 'v run ${source_path} wrote unexpected stderr:\n${stderr}'
+	return stdout
+}
+
+fn x64_v_run_oracle_stderr_is_allowed(stderr string) bool {
+	if stderr == '' {
+		return true
+	}
+	clean := x64_strip_ansi_csi(stderr).trim_space()
+	return clean == 'warning: tcc compilation failed, falling back to cc (this is much slower)'
+}
+
+fn x64_strip_ansi_csi(text string) string {
+	bytes := text.bytes()
+	mut out := []u8{cap: bytes.len}
+	mut i := 0
+	for i < bytes.len {
+		if bytes[i] == 0x1b && i + 1 < bytes.len && bytes[i + 1] == `[` {
+			i += 2
+			for i < bytes.len {
+				b := bytes[i]
+				i++
+				if b >= 0x40 && b <= 0x7e {
+					break
+				}
+			}
+			continue
+		}
+		out << bytes[i]
+		i++
+	}
+	return out.bytestr()
+}
+
+fn assert_x64_linux_file_stdout_matches_v_run(name string, source_dir string, source_file string) {
+	$if linux {
+		expected_stdout := x64_v_run_file_stdout_bytes(source_dir, source_file)
+		assert_x64_linux_file_stdout_bytes(name, source_dir, source_file, expected_stdout)
+	}
+}
+
+fn assert_x64_macos_windows_file_stdout_matches_v_run(name string, source_dir string, source_file string) {
+	$if macos {
+		expected_stdout := x64_v_run_file_stdout_bytes(source_dir, source_file)
+		assert_x64_macos_windows_file_stdout_bytes(name, source_dir, source_file, expected_stdout)
+	}
+	$if windows {
+		expected_stdout := x64_v_run_file_stdout_bytes(source_dir, source_file)
+		assert_x64_macos_windows_file_stdout_bytes(name, source_dir, source_file, expected_stdout)
 	}
 }
 
@@ -2110,6 +2448,73 @@ fn x64_dynamic_int_array_stdout() []u8 {
 '.bytes()
 }
 
+fn x64_dynamic_string_array_index_source() string {
+	return "module main
+
+fn main() {
+	mut values := []string{}
+	values << 'alpha'
+	values << 'beta'
+	println(values[1])
+}
+"
+}
+
+fn x64_dynamic_string_array_index_stdout() []u8 {
+	return 'beta
+'.bytes()
+}
+
+fn x64_dynamic_string_array_str_source() string {
+	return "module main
+
+fn main() {
+	path := ['A', 'C', 'F']
+	println(path)
+	println('path: \${path}')
+	mut values := []string{}
+	values << 'alpha'
+	values << 'beta'
+	println(values)
+	graph := {
+		'A': ['B', 'C']
+	}
+	println(graph)
+	fixed := ['L', 'R']!
+	println(fixed)
+}
+"
+}
+
+fn x64_dynamic_string_array_str_stdout() []u8 {
+	return "['A', 'C', 'F']
+path: ['A', 'C', 'F']
+['alpha', 'beta']
+{'A': ['B', 'C']}
+['L', 'R']
+".bytes()
+}
+
+fn x64_string_int_map_literal_lookup_source() string {
+	return "module main
+
+fn main() {
+	values := {
+		'A': 11
+		'B': 22
+	}
+	println(values['A'])
+	println(values['B'])
+}
+"
+}
+
+fn x64_string_int_map_literal_lookup_stdout() []u8 {
+	return '11
+22
+'.bytes()
+}
+
 fn x64_windows_noscan_array_grow_free_slice_source() string {
 	return "module main
 
@@ -2212,8 +2617,232 @@ FizzBuzz
 '.bytes()
 }
 
+fn x64_named_function_value_source() string {
+	return 'module main
+
+fn inc(value int) int {
+	return value + 1
+}
+
+fn apply(f fn (int) int, value int) int {
+	return f(value)
+}
+
+fn main() {
+	f := inc
+	println(f(10))
+	println(apply(inc, 20))
+}
+'
+}
+
+fn x64_named_function_value_stdout() []u8 {
+	return '11
+21
+'.bytes()
+}
+
+fn x64_selective_import_builtin_shadow_fn_value_sources() map[string]string {
+	return {
+		'main.v':                     'module main
+
+import mymodules { print }
+
+fn main() {
+	f := print
+	f("ok")
+}
+'
+		'mymodules/main_functions.v': 'module mymodules
+
+pub fn print(s string) {
+	println("module:" + s)
+}
+'
+	}
+}
+
+fn x64_selective_import_builtin_shadow_fn_value_stdout() []u8 {
+	return 'module:ok
+'.bytes()
+}
+
+fn x64_selective_import_bare_fallback_shadow_sources() map[string]string {
+	return {
+		'main.v':                     'module main
+
+import mymodules { malloc }
+
+fn main() {
+	f := malloc
+	println(f("fn-value"))
+	println(malloc("direct"))
+}
+'
+		'mymodules/main_functions.v': 'module mymodules
+
+pub fn malloc(s string) string {
+	return "module:" + s
+}
+'
+	}
+}
+
+fn x64_selective_import_bare_fallback_shadow_stdout() []u8 {
+	return 'module:fn-value
+module:direct
+'.bytes()
+}
+
+fn x64_selective_import_method_shadow_sources() map[string]string {
+	return {
+		'main.v':                     'module main
+
+import mymodules { ping }
+
+struct Foo {}
+
+fn (f Foo) ping() string {
+	return "method"
+}
+
+fn main() {
+	println(ping())
+}
+'
+		'mymodules/main_functions.v': 'module mymodules
+
+pub fn ping() string {
+	return "module"
+}
+'
+	}
+}
+
+fn x64_selective_import_method_shadow_stdout() []u8 {
+	return 'module
+'.bytes()
+}
+
+fn x64_non_capturing_fn_literal_value_source() string {
+	return 'module main
+
+fn apply(f fn (int) int, value int) int {
+	return f(value)
+}
+
+fn main() {
+	f := fn (value int) int {
+		return value + 7
+	}
+	println(f(7))
+	println(apply(fn (value int) int {
+		return value + 3
+	}, 8))
+}
+'
+}
+
+fn x64_non_capturing_fn_literal_value_stdout() []u8 {
+	return '14
+11
+'.bytes()
+}
+
+fn x64_returned_non_capturing_fn_literal_source() string {
+	return 'module main
+
+fn make_double() fn (int) int {
+	return fn (value int) int {
+		return value * 2
+	}
+}
+
+fn apply(f fn (int) int, value int) int {
+	return f(value)
+}
+
+fn main() {
+	f := make_double()
+	println(f(9))
+	println(apply(make_double(), 12))
+}
+'
+}
+
+fn x64_returned_non_capturing_fn_literal_stdout() []u8 {
+	return '18
+24
+'.bytes()
+}
+
 fn x64_examples_dir() string {
 	return os.join_path(@VMODROOT, 'examples')
+}
+
+fn x64_arguments_index_one_int_source() string {
+	return 'module main
+
+fn main() {
+	args := arguments()
+	println(args.len)
+	println(args[1].int() + 32)
+}
+'
+}
+
+fn x64_arguments_index_one_int_stdout() []u8 {
+	return '2
+42
+'.bytes()
+}
+
+fn x64_arguments_via_function_pointer_source() string {
+	return 'module main
+
+fn get_args_len() int {
+	return arguments().len
+}
+
+fn call_it(f fn () int) int {
+	return f()
+}
+
+fn main() {
+	f := get_args_len
+	println(call_it(f))
+}
+'
+}
+
+fn x64_arguments_via_function_pointer_stdout() []u8 {
+	return '2
+'.bytes()
+}
+
+fn x64_hello_world_example_stdout() []u8 {
+	return 'Hello, World!\n'.bytes()
+}
+
+fn x64_fibonacci_10_example_stdout() []u8 {
+	return '1
+1
+2
+3
+5
+8
+13
+21
+34
+55
+89
+'.bytes()
+}
+
+fn x64_submodule_example_stdout() []u8 {
+	return '5
+3
+'.bytes()
 }
 
 fn x64_fizz_buzz_example_stdout() []u8 {
@@ -2317,6 +2946,345 @@ Fizz
 98
 Fizz
 Buzz
+'.bytes()
+}
+
+fn x64_hanoi_example_stdout() []u8 {
+	mut out := []u8{}
+	x64_hanoi_example_append_expected(mut out, 7, 'A', 'B', 'C')
+	text := out.bytestr()
+	move_count := text.count('\n')
+	assert out.len == 2794, 'hanoi stdout oracle source shape changed: bytes=${out.len}'
+	assert move_count == 127, 'hanoi stdout oracle source shape changed: moves=${move_count}'
+	assert text.starts_with('Disc 1 from A to C...\nDisc 2 from A to B...\n'), 'hanoi stdout oracle first moves changed'
+	assert text.ends_with('Disc 2 from B to C...\nDisc 1 from A to C...\n'), 'hanoi stdout oracle final moves changed'
+	return out
+}
+
+fn x64_hanoi_example_append_expected(mut out []u8, n int, a string, b string, c string) {
+	if n == 1 {
+		out << 'Disc 1 from ${a} to ${c}...\n'.bytes()
+		return
+	}
+	x64_hanoi_example_append_expected(mut out, n - 1, a, c, b)
+	out << 'Disc ${n} from ${a} to ${c}...\n'.bytes()
+	x64_hanoi_example_append_expected(mut out, n - 1, b, a, c)
+}
+
+fn x64_sudoku_example_stdout() []u8 {
+	mut out := []u8{}
+	x64_sudoku_append_stdout_line(mut out, 'Sudoku Puzzle:', false)
+	x64_sudoku_append_stdout_line(mut out, '0 3 0  | 0 7 0  | 0 0 0', true)
+	x64_sudoku_append_stdout_line(mut out, '0 0 0  | 1 3 5  | 0 0 0', true)
+	x64_sudoku_append_stdout_line(mut out, '0 0 1  | 0 0 0  | 0 5 0', true)
+	x64_sudoku_append_stdout_line(mut out, '- - - - - - - - - - - -', false)
+	x64_sudoku_append_stdout_line(mut out, '1 0 0  | 0 6 0  | 0 0 3', true)
+	x64_sudoku_append_stdout_line(mut out, '4 0 0  | 8 0 3  | 0 0 1', true)
+	x64_sudoku_append_stdout_line(mut out, '7 0 0  | 0 2 0  | 0 0 6', true)
+	x64_sudoku_append_stdout_line(mut out, '- - - - - - - - - - - -', false)
+	x64_sudoku_append_stdout_line(mut out, '0 0 0  | 0 0 0  | 2 1 0', true)
+	x64_sudoku_append_stdout_line(mut out, '0 0 0  | 4 1 2  | 0 0 5', true)
+	x64_sudoku_append_stdout_line(mut out, '0 0 0  | 0 0 0  | 0 7 4', true)
+	x64_sudoku_append_stdout_line(mut out, 'Solving...', false)
+	x64_sudoku_append_stdout_line(mut out, 'Solution:', false)
+	x64_sudoku_append_stdout_line(mut out, '2 3 5  | 6 7 8  | 1 4 9', true)
+	x64_sudoku_append_stdout_line(mut out, '9 4 7  | 1 3 5  | 8 6 2', true)
+	x64_sudoku_append_stdout_line(mut out, '6 8 1  | 2 4 9  | 3 5 7', true)
+	x64_sudoku_append_stdout_line(mut out, '- - - - - - - - - - - -', false)
+	x64_sudoku_append_stdout_line(mut out, '1 2 8  | 7 6 4  | 5 9 3', true)
+	x64_sudoku_append_stdout_line(mut out, '4 5 6  | 8 9 3  | 7 2 1', true)
+	x64_sudoku_append_stdout_line(mut out, '7 9 3  | 5 2 1  | 4 8 6', true)
+	x64_sudoku_append_stdout_line(mut out, '- - - - - - - - - - - -', false)
+	x64_sudoku_append_stdout_line(mut out, '3 6 4  | 9 5 7  | 2 1 8', true)
+	x64_sudoku_append_stdout_line(mut out, '8 7 9  | 4 1 2  | 6 3 5', true)
+	x64_sudoku_append_stdout_line(mut out, '5 1 2  | 3 8 6  | 9 7 4', true)
+	return out
+}
+
+fn x64_sudoku_append_stdout_line(mut out []u8, line string, trailing_space bool) {
+	out << line.bytes()
+	if trailing_space {
+		out << u8(` `)
+	}
+	out << u8(`\n`)
+}
+
+fn x64_function_types_example_stdout() []u8 {
+	return 'HELLO WORLD
+HELLO WORLD
+HELLO WORLD
+'.bytes()
+}
+
+fn x64_struct_sumtype_field_init_source() string {
+	return '
+module main
+
+type Tree = Empty | Node
+
+struct Empty {}
+
+struct Node {
+	value int
+}
+
+struct Holder {
+	item Tree
+}
+
+fn value(tree Tree) int {
+	return match tree {
+		Empty { 0 }
+		Node { tree.value }
+	}
+}
+
+fn main() {
+	holder := Holder{Node{42}}
+	println(value(holder.item))
+}
+'
+}
+
+fn x64_struct_sumtype_field_init_stdout() []u8 {
+	return '42
+'.bytes()
+}
+
+fn x64_auto_str_recursive_sumtype_source() string {
+	return '
+module main
+
+type Tree = Empty | Node
+
+struct Empty {}
+
+struct Node {
+	value int
+	left  Tree
+	right Tree
+}
+
+fn main() {
+	leaf := Node{7, Empty{}, Empty{}}
+	root := Node{9, leaf, Empty{}}
+	print("\${root}")
+}
+'
+}
+
+fn x64_auto_str_recursive_sumtype_stdout() []u8 {
+	return 'Node{
+    value: 9
+    left: Tree(Node{
+        value: 7
+        left: Tree(Empty{})
+        right: Tree(Empty{})
+    })
+    right: Tree(Empty{})
+}'.bytes()
+}
+
+fn x64_tree_of_nodes_example_stdout() []u8 {
+	return 'tree structure:
+ Node{
+    value: 10
+    left: Tree(Node{
+        value: 30
+        left: Tree(Empty{})
+        right: Tree(Empty{})
+    })
+    right: Tree(Node{
+        value: 20
+        left: Tree(Empty{})
+        right: Tree(Empty{})
+    })
+}
+tree size: 3
+'.bytes()
+}
+
+fn x64_bfs_example_stdout() []u8 {
+	return "Graph: {'A': ['B', 'C'], 'B': ['A', 'D', 'E'], 'C': ['A', 'F'], 'D': ['B'], 'E': ['B', 'F'], 'F': ['C', 'E']}
+The shortest path from node A to node F is: ['A', 'C', 'F']
+".bytes()
+}
+
+fn x64_js_hello_world_example_stdout() []u8 {
+	return 'Hello from V.js (0)
+Hello from V.js (1)
+Hello from V.js (2)
+'.bytes()
+}
+
+fn x64_vascii_example_stdout() []u8 {
+	source := os.read_file(os.join_path(x64_examples_dir(), 'vascii.v')) or { panic(err) }
+	start_marker := "println('"
+	end_marker := "')"
+	assert source.count(start_marker) == 1, 'vascii stdout oracle expects one single-quoted println literal'
+	start := source.index(start_marker) or { panic('missing vascii println literal start') } +
+		start_marker.len
+	end := source.last_index(end_marker) or { panic('missing vascii println literal end') }
+	assert source[end + end_marker.len..].trim_space() == '}', 'vascii stdout oracle expects the println literal to be the final main statement'
+
+	mut out := x64_v_single_quoted_literal_bytes(source[start..end])
+	assert out.len == 8525, 'vascii stdout oracle source shape changed: literal bytes=${out.len}'
+	assert out.bytestr().contains('DEC  OCT   HEX  BIN        Sym'), 'vascii stdout oracle missing table header'
+
+	assert out.bytestr().contains('127  177   7F   01111111   DEL   &#127;            Delete'), 'vascii stdout oracle missing final ASCII row'
+
+	out << u8(`\n`)
+	return out
+}
+
+fn x64_v_single_quoted_literal_bytes(raw string) []u8 {
+	mut out := []u8{cap: raw.len}
+	mut i := 0
+	for i < raw.len {
+		if raw[i] == `\\` && i + 1 < raw.len {
+			match raw[i + 1] {
+				`n` { out << u8(`\n`) }
+				`t` { out << u8(`\t`) }
+				`r` { out << u8(`\r`) }
+				`\\` { out << u8(`\\`) }
+				`'` { out << u8(`'`) }
+				`"` { out << u8(`"`) }
+				else { out << raw[i + 1] }
+			}
+
+			i += 2
+			continue
+		}
+		out << raw[i]
+		i++
+	}
+	return out
+}
+
+fn x64_rune_example_stdout() []u8 {
+	return [u8(0xf0), 0x9f, 0x98, 0x80, u8(`\n`), u8(`@`), u8(`\n`)]
+}
+
+fn x64_rune_utf32_parity_stdout() []u8 {
+	return [
+		u8(0x7f),
+		u8(`\n`),
+		u8(0xc2),
+		0x80,
+		u8(`\n`),
+		u8(0xdf),
+		0xbf,
+		u8(`\n`),
+		u8(0xe0),
+		0xa0,
+		0x80,
+		u8(`\n`),
+		u8(0xed),
+		0x9f,
+		0xbf,
+		u8(`\n`),
+		u8(0xed),
+		0xa0,
+		0x80,
+		u8(`\n`),
+		u8(0xed),
+		0xbf,
+		0xbf,
+		u8(`\n`),
+		u8(0xee),
+		0x80,
+		0x80,
+		u8(`\n`),
+		u8(0xef),
+		0xbf,
+		0xbf,
+		u8(`\n`),
+		u8(0xf0),
+		0x90,
+		0x80,
+		0x80,
+		u8(`\n`),
+		u8(0xf4),
+		0x8f,
+		0xbf,
+		0xbf,
+		u8(`\n`),
+		u8(`\n`),
+	]
+}
+
+fn x64_long_ascii_literal_stdout() []u8 {
+	mut out := []u8{cap: 600}
+	for i in 0 .. 600 {
+		out << u8(`A` + i % 26)
+	}
+	return out
+}
+
+fn x64_repeated_ascii_literal(ch u8, count int) string {
+	mut out := []u8{cap: count}
+	for _ in 0 .. count {
+		out << ch
+	}
+	return out.bytestr()
+}
+
+fn x64_long_ascii_literal_source() string {
+	literal := x64_long_ascii_literal_stdout().bytestr()
+	return "module main
+
+fn emit(s string) {
+	print(s)
+}
+
+fn main() {
+	emit('${literal}')
+}
+	"
+}
+
+fn x64_string_literal_field_size_source() string {
+	literal := x64_long_ascii_literal_stdout().bytestr()
+	return "module main
+
+struct BoxedString {
+	before u8
+	value string
+	after u8
+}
+
+fn emit(s string) {
+	println(s.len)
+	println(s.is_lit)
+}
+
+fn main() {
+	s := '${literal}'
+	boxed := BoxedString{
+		before: 17
+		value: s
+		after: 23
+	}
+	println(s.len)
+	println(s.is_lit)
+	println(boxed.value.len)
+	println(boxed.value.is_lit)
+	println(int(boxed.before))
+	println(int(boxed.after))
+	emit('${literal}')
+}
+"
+}
+
+fn x64_string_literal_field_size_stdout() []u8 {
+	return '600
+1
+600
+1
+17
+23
+600
+1
 '.bytes()
 }
 
@@ -2743,6 +3711,49 @@ fn main() {
 	])
 }
 
+fn test_x64_linux_named_function_value_stdout_exact_bytes() {
+	assert_x64_linux_stdout_bytes('named_function_value_exact', x64_named_function_value_source(),
+		x64_named_function_value_stdout())
+}
+
+fn test_x64_linux_selective_import_builtin_shadow_fn_value_stdout_exact_bytes() {
+	assert_x64_linux_project_stdout_bytes('selective_import_builtin_shadow_fn_value_exact',
+		x64_selective_import_builtin_shadow_fn_value_sources(),
+		x64_selective_import_builtin_shadow_fn_value_stdout())
+}
+
+fn test_x64_linux_selective_import_bare_fallback_shadow_stdout_exact_bytes() {
+	assert_x64_linux_project_stdout_bytes('selective_import_bare_fallback_shadow_exact',
+		x64_selective_import_bare_fallback_shadow_sources(),
+		x64_selective_import_bare_fallback_shadow_stdout())
+}
+
+fn test_x64_linux_selective_import_method_shadow_stdout_exact_bytes() {
+	assert_x64_linux_project_stdout_bytes('selective_import_method_shadow_exact',
+		x64_selective_import_method_shadow_sources(), x64_selective_import_method_shadow_stdout())
+}
+
+fn test_x64_linux_non_capturing_fn_literal_value_stdout_exact_bytes() {
+	assert_x64_linux_stdout_bytes('non_capturing_fn_literal_value_exact',
+		x64_non_capturing_fn_literal_value_source(), x64_non_capturing_fn_literal_value_stdout())
+}
+
+fn test_x64_linux_returned_non_capturing_fn_literal_stdout_exact_bytes() {
+	assert_x64_linux_stdout_bytes('returned_non_capturing_fn_literal_exact',
+		x64_returned_non_capturing_fn_literal_source(),
+		x64_returned_non_capturing_fn_literal_stdout())
+}
+
+fn test_x64_linux_long_string_literal_len_stdout_exact_bytes() {
+	assert_x64_linux_stdout_bytes('long_string_literal_len_exact', x64_long_ascii_literal_source(),
+		x64_long_ascii_literal_stdout())
+}
+
+fn test_x64_linux_string_literal_field_size_stores_do_not_clobber_adjacent_fields() {
+	assert_x64_linux_stdout_bytes('string_literal_field_size_no_clobber',
+		x64_string_literal_field_size_source(), x64_string_literal_field_size_stdout())
+}
+
 fn test_x64_linux_i64_loop_carried_mutable_state_controls_branch() {
 	assert_x64_linux_stdout_bytes('i64_loop_carried_mutable_state_branch', "module main
 
@@ -2810,6 +3821,165 @@ fn test_x64_linux_fizz_buzz_example_top_level_stdout_exact_bytes() {
 		'fizz_buzz.v', x64_fizz_buzz_example_stdout())
 }
 
+fn test_x64_linux_hanoi_example_top_level_stdout_exact_bytes() {
+	assert_x64_linux_file_stdout_bytes('hanoi_example_top_level_exact', x64_examples_dir(),
+		'hanoi.v', x64_hanoi_example_stdout())
+}
+
+fn test_x64_linux_sudoku_example_top_level_stdout_exact_bytes() {
+	assert_x64_linux_file_stdout_bytes('sudoku_example_top_level_exact', x64_examples_dir(),
+		'sudoku.v', x64_sudoku_example_stdout())
+}
+
+fn test_x64_linux_function_types_example_top_level_stdout_exact_bytes() {
+	assert_x64_linux_file_stdout_bytes('function_types_example_top_level_exact',
+		x64_examples_dir(), 'function_types.v', x64_function_types_example_stdout())
+}
+
+fn test_x64_linux_submodule_example_top_level_stdout_exact_bytes() {
+	assert_x64_linux_file_stdout_bytes('submodule_example_top_level_exact', x64_examples_dir(),
+		'submodule/main.v', x64_submodule_example_stdout())
+}
+
+fn test_x64_linux_arguments_index_one_int_auto_tiny_falls_back_to_hosted() {
+	$if linux {
+		source := x64_arguments_index_one_int_source()
+		assert_x64_linux_tiny_build_rejected('tiny_arguments_index_one_int_rejected', source,
+			'arguments() requires hosted argc/argv')
+		result := run_x64_host_program_redirected_auto_with_args('arguments_index_one_int_hosted',
+			source, ['10'])
+		assert_x64_linux_hosted_libc_binary(result, x64_arguments_index_one_int_stdout())
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_arguments_via_function_pointer_auto_tiny_falls_back_to_hosted() {
+	$if linux {
+		source := x64_arguments_via_function_pointer_source()
+		assert_x64_linux_tiny_build_rejected('tiny_arguments_via_function_pointer_rejected',
+			source, 'arguments() requires hosted argc/argv')
+		result := run_x64_host_program_redirected_auto_with_args('arguments_via_function_pointer_hosted',
+			source, ['10'])
+		assert_x64_linux_hosted_libc_binary(result, x64_arguments_via_function_pointer_stdout())
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_fibonacci_example_arg_10_stdout_exact_bytes() {
+	$if linux {
+		result := run_x64_host_file_redirected_auto_with_args('fibonacci_example_arg_10_exact',
+			x64_examples_dir(), 'fibonacci.v', ['10'])
+		assert_x64_linux_hosted_libc_binary(result, x64_fibonacci_10_example_stdout())
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_fibonacci_example_strict_tiny_rejected() {
+	$if linux {
+		assert_x64_linux_tiny_file_build_rejected('fibonacci_example_strict_tiny_rejected',
+			x64_examples_dir(), 'fibonacci.v', 'arguments() requires hosted argc/argv')
+	}
+}
+
+fn test_x64_macos_arguments_index_one_int_auto_tiny_falls_back_to_hosted() {
+	$if macos {
+		result := run_x64_host_program_redirected_macos_auto_tiny_verbose_with_args('macos_arguments_index_one_int_hosted',
+			x64_arguments_index_one_int_source(), ['10'])
+		context := x64_host_result_context(result)
+		assert result.stdout == x64_arguments_index_one_int_stdout(), context
+		assert result.stderr == []u8{}, context
+		assert_x64_macos_tiny_object_rejected_for_arguments(result, context)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_macos_arguments_via_function_pointer_auto_tiny_falls_back_to_hosted() {
+	$if macos {
+		result := run_x64_host_program_redirected_macos_auto_tiny_verbose_with_args('macos_arguments_via_function_pointer_hosted',
+			x64_arguments_via_function_pointer_source(), ['10'])
+		context := x64_host_result_context(result)
+		assert result.stdout == x64_arguments_via_function_pointer_stdout(), context
+		assert result.stderr == []u8{}, context
+		assert_x64_macos_tiny_object_rejected_for_arguments(result, context)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_macos_fibonacci_example_arg_10_auto_tiny_falls_back_to_hosted() {
+	$if macos {
+		result := run_x64_host_file_redirected_macos_auto_tiny_verbose_with_args('macos_fibonacci_example_arg_10_exact',
+			x64_examples_dir(), 'fibonacci.v', ['10'])
+		context := x64_host_result_context(result)
+		assert result.stdout == x64_fibonacci_10_example_stdout(), context
+		assert result.stderr == []u8{}, context
+		assert_x64_macos_tiny_object_rejected_for_arguments(result, context)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_windows_arguments_index_one_int_stdout_exact_bytes() {
+	$if windows {
+		result := run_x64_host_program_redirected_auto_with_args('windows_arguments_index_one_int',
+			x64_arguments_index_one_int_source(), ['10'])
+		context := x64_host_result_context(result)
+		assert result.stdout == x64_arguments_index_one_int_stdout(), context
+		assert result.stderr == []u8{}, context
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_windows_arguments_via_function_pointer_stdout_exact_bytes() {
+	$if windows {
+		result := run_x64_host_program_redirected_auto_with_args('windows_arguments_via_function_pointer',
+			x64_arguments_via_function_pointer_source(), ['10'])
+		context := x64_host_result_context(result)
+		assert result.stdout == x64_arguments_via_function_pointer_stdout(), context
+		assert result.stderr == []u8{}, context
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_windows_fibonacci_example_arg_10_stdout_exact_bytes() {
+	$if windows {
+		result := run_x64_host_file_redirected_auto_with_args('windows_fibonacci_example_arg_10_exact',
+			x64_examples_dir(), 'fibonacci.v', ['10'])
+		context := x64_host_result_context(result)
+		assert result.stdout == x64_fibonacci_10_example_stdout(), context
+		assert result.stderr == []u8{}, context
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_struct_sumtype_field_init_stdout_exact_bytes() {
+	assert_x64_linux_stdout_bytes('struct_sumtype_field_init_exact',
+		x64_struct_sumtype_field_init_source(), x64_struct_sumtype_field_init_stdout())
+}
+
+fn test_x64_linux_auto_str_recursive_sumtype_stdout_exact_bytes() {
+	assert_x64_linux_stdout_bytes('auto_str_recursive_sumtype_exact',
+		x64_auto_str_recursive_sumtype_source(), x64_auto_str_recursive_sumtype_stdout())
+}
+
+fn test_x64_linux_tree_of_nodes_example_top_level_stdout_exact_bytes() {
+	assert_x64_linux_file_stdout_bytes('tree_of_nodes_example_top_level_exact', x64_examples_dir(),
+		'tree_of_nodes.v', x64_tree_of_nodes_example_stdout())
+}
+
+fn test_x64_linux_bfs_example_top_level_stdout_exact_bytes() {
+	assert_x64_linux_file_stdout_bytes('bfs_example_top_level_exact', os.join_path(x64_examples_dir(),
+		'graphs'), 'bfs.v', x64_bfs_example_stdout())
+}
+
+fn test_x64_linux_dfs_example_top_level_stdout_matches_v_run() {
+	assert_x64_linux_file_stdout_matches_v_run('dfs_example_top_level_v_run', os.join_path(x64_examples_dir(),
+		'graphs'), 'dfs.v')
+}
+
+fn test_x64_linux_dijkstra_example_top_level_stdout_matches_v_run() {
+	assert_x64_linux_file_stdout_matches_v_run('dijkstra_example_top_level_v_run', os.join_path(x64_examples_dir(),
+		'graphs'), 'dijkstra.v')
+}
+
 fn test_x64_linux_fizz_buzz_example_auto_tiny_no_libc() {
 	$if linux {
 		result := run_x64_host_file_redirected_auto('fizz_buzz_example_auto_tiny_no_libc',
@@ -2819,14 +3989,196 @@ fn test_x64_linux_fizz_buzz_example_auto_tiny_no_libc() {
 	}
 }
 
+fn test_x64_linux_hanoi_example_strict_tiny_no_libc() {
+	$if linux {
+		result := run_x64_host_file_redirected_tiny('hanoi_example_strict_tiny_no_libc',
+			x64_examples_dir(), 'hanoi.v')
+		assert_x64_linux_no_libc_binary(result, x64_hanoi_example_stdout())
+		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes +
+			linux_tiny_string_plus_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_hanoi_example_auto_tiny_no_libc() {
+	$if linux {
+		result := run_x64_host_file_redirected_auto('hanoi_example_auto_tiny_no_libc',
+			x64_examples_dir(), 'hanoi.v')
+		assert_x64_linux_no_libc_binary(result, x64_hanoi_example_stdout())
+		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes +
+			linux_tiny_string_plus_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
 fn test_x64_linux_hello_world_example_auto_tiny_no_libc() {
 	$if linux {
 		result := run_x64_host_file_redirected_auto('hello_world_example_auto_tiny_no_libc',
 			x64_examples_dir(), 'hello_world.v')
-		assert_x64_linux_no_libc_binary(result, 'Hello, World!\n'.bytes())
+		assert_x64_linux_no_libc_binary(result, x64_hello_world_example_stdout())
 		assert_x64_linux_tiny_load_segment_layout(result, 0)
 		context := x64_host_result_context(result)
 		assert os.file_size(result.bin_path) < 512, '${context}\nbinary is not ultra tiny: ${os.file_size(result.bin_path)} bytes'
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_js_hello_world_example_strict_tiny_no_libc() {
+	$if linux {
+		result := run_x64_host_file_redirected_tiny('js_hello_world_example_strict_tiny_no_libc',
+			x64_examples_dir(), 'js_hello_world.v')
+		assert_x64_linux_no_libc_binary(result, x64_js_hello_world_example_stdout())
+		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes +
+			linux_tiny_string_plus_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_js_hello_world_example_auto_tiny_no_libc() {
+	$if linux {
+		result := run_x64_host_file_redirected_auto('js_hello_world_example_auto_tiny_no_libc',
+			x64_examples_dir(), 'js_hello_world.v')
+		assert_x64_linux_no_libc_binary(result, x64_js_hello_world_example_stdout())
+		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes +
+			linux_tiny_string_plus_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_string_plus_runtime_strict_tiny_no_libc() {
+	$if linux {
+		result := run_x64_host_program_redirected_tiny('string_plus_runtime_strict_tiny_no_libc', "module main
+
+fn main() {
+	left := 'tiny '
+	right := 'concat'
+	println(left + right)
+}
+")
+		assert_x64_linux_no_libc_binary(result, 'tiny concat\n'.bytes())
+		assert_x64_linux_tiny_load_segment_layout(result,
+			linux_tiny_string_plus_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_string_plus_two_runtime_strict_tiny_no_libc() {
+	$if linux {
+		result := run_x64_host_program_redirected_tiny('string_plus_two_runtime_strict_tiny_no_libc', "module main
+
+fn main() {
+	a := 'one'
+	b := ' two'
+	c := ' three'
+	println(a + b + c)
+}
+")
+		assert_x64_linux_no_libc_binary(result, 'one two three\n'.bytes())
+		assert_x64_linux_tiny_load_segment_layout(result,
+			linux_tiny_string_plus_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_string_plus_chain_preserves_tmp_lifetime_strict_tiny_no_libc() {
+	$if linux {
+		result := run_x64_host_program_redirected_tiny('string_plus_chain_preserves_tmp_lifetime_strict_tiny_no_libc', "module main
+
+fn main() {
+	a := 'one'
+	b := ' two'
+	c := ' three'
+	tmp := a + b
+	println(tmp + c)
+	println(tmp)
+}
+")
+		assert_x64_linux_no_libc_binary(result, 'one two three\none two\n'.bytes())
+		assert_x64_linux_tiny_load_segment_layout(result,
+			linux_tiny_string_plus_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_string_plus_large_allocation_strict_tiny_no_libc() {
+	$if linux {
+		left := x64_repeated_ascii_literal(`A`, 4096)
+		right := x64_repeated_ascii_literal(`B`, 64)
+		result := run_x64_host_program_redirected_tiny('string_plus_large_allocation_strict_tiny_no_libc', "module main
+
+fn main() {
+	left := '${left}'
+	right := '${right}'
+	println(left + right)
+}
+")
+		assert_x64_linux_no_libc_binary(result, (left + right + '\n').bytes())
+		assert_x64_linux_tiny_load_segment_layout(result,
+			linux_tiny_string_plus_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_vascii_example_strict_tiny_no_libc() {
+	$if linux {
+		result := run_x64_host_file_redirected_tiny('vascii_example_strict_tiny_no_libc',
+			x64_examples_dir(), 'vascii.v')
+		assert_x64_linux_no_libc_binary(result, x64_vascii_example_stdout())
+		assert_x64_linux_tiny_load_segment_layout(result, 0)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_rune_example_strict_tiny_no_libc() {
+	$if linux {
+		result := run_x64_host_file_redirected_tiny('rune_example_strict_tiny_no_libc',
+			x64_examples_dir(), 'rune.v')
+		assert_x64_linux_no_libc_binary(result, x64_rune_example_stdout())
+		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_rune_str_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_rune_str_utf32_edge_bytes_strict_tiny_no_libc() {
+	$if linux {
+		result := run_x64_host_program_redirected_tiny('rune_str_utf32_edge_bytes_strict_tiny', 'module main
+
+fn main() {
+	println(rune(0x7f))
+	println(rune(0x80))
+	println(rune(0x7ff))
+	println(rune(0x800))
+	println(rune(0xd7ff))
+	println(rune(0xd800))
+	println(rune(0xdfff))
+	println(rune(0xe000))
+	println(rune(0xffff))
+	println(rune(0x10000))
+	println(rune(0x10ffff))
+	println(rune(0x110000))
+}
+')
+		assert_x64_linux_no_libc_binary(result, x64_rune_utf32_parity_stdout())
+		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_rune_str_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_int_i64_rune_strict_tiny_bss_metadata_sum() {
+	$if linux {
+		result := run_x64_host_program_redirected_tiny('int_i64_rune_strict_tiny_bss_sum', 'module main
+
+fn main() {
+	println(int(-23))
+	println(i64(4294967296))
+	println(rune(0x80))
+}
+')
+		mut expected_stdout := '-23\n4294967296\n'.bytes()
+		expected_stdout << [u8(0xc2), 0x80, u8(`\n`)]
+		assert_x64_linux_no_libc_binary(result, expected_stdout)
+		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes +
+			linux_tiny_rune_str_arena_metadata_bytes)
 		x64_host_cleanup_tmp(result.tmp_dir)
 	}
 }
@@ -2838,6 +4190,37 @@ fn assert_x64_macos_tiny_object_used(result X64HostRunResult, context string) {
 	assert !result.build_output.contains('retrying with normal Mach-O object'), context
 }
 
+fn assert_x64_macos_tiny_object_rejected_for_arguments(result X64HostRunResult, context string) {
+	assert result.build_output.contains('macOS tiny object candidate enabled'), context
+	assert result.build_output.contains('macOS tiny object not eligible; falling back to normal Mach-O object'), context
+
+	assert result.build_output.contains('arguments() requires hosted argc/argv'), context
+	assert !result.build_output.contains('built-in macOS tiny object'), context
+}
+
+fn test_x64_macos_i64_str_boundary_values_auto_tiny_uses_tiny_object() {
+	$if macos {
+		result := run_x64_host_project_redirected_macos_auto_tiny_verbose('macos_i64_str_boundary_values_auto_tiny', {
+			'main.v': 'module main
+
+fn main() {
+	println(i64(9223372036854775807))
+	println(-i64(9223372036854775807) - i64(1))
+	println(i64(4294967296))
+	println(i64(-4294967297))
+	println(i64(1234567890123456789))
+}
+'
+		})
+		context := x64_host_result_context(result)
+		assert result.stdout == '9223372036854775807\n-9223372036854775808\n4294967296\n-4294967297\n1234567890123456789\n'.bytes(), context
+
+		assert result.stderr == []u8{}, context
+		assert_x64_macos_tiny_object_used(result, context)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
 fn test_x64_macos_hello_world_example_auto_tiny_uses_tiny_object() {
 	$if macos {
 		tiny := run_x64_host_file_redirected_macos_auto_tiny('macos_hello_world_example_auto_tiny',
@@ -2845,7 +4228,7 @@ fn test_x64_macos_hello_world_example_auto_tiny_uses_tiny_object() {
 		normal := run_x64_host_file_redirected_no_tiny('macos_hello_world_example_normal',
 			x64_examples_dir(), 'hello_world.v')
 		context := '${x64_host_result_context(tiny)}\nnormal build:\n${x64_host_result_context(normal)}'
-		assert tiny.stdout == 'Hello, World!\n'.bytes(), context
+		assert tiny.stdout == x64_hello_world_example_stdout(), context
 		assert tiny.stderr == []u8{}, context
 		assert normal.stdout == tiny.stdout, context
 		assert normal.stderr == []u8{}, context
@@ -2877,6 +4260,94 @@ fn test_x64_macos_fizz_buzz_example_auto_tiny_uses_tiny_object() {
 		assert tiny_size > 0, '${context}\ntiny size: ${tiny_size}'
 		assert normal_size > 0, '${context}\nnormal size: ${normal_size}'
 		println('macOS x64 tiny fizz_buzz: tiny size=${tiny_size}; normal size=${normal_size}')
+		x64_host_cleanup_tmp(tiny.tmp_dir)
+		x64_host_cleanup_tmp(normal.tmp_dir)
+	}
+}
+
+fn test_x64_macos_hanoi_example_auto_tiny_uses_tiny_object() {
+	$if macos {
+		tiny := run_x64_host_file_redirected_macos_auto_tiny('macos_hanoi_example_auto_tiny',
+			x64_examples_dir(), 'hanoi.v')
+		normal := run_x64_host_file_redirected_no_tiny('macos_hanoi_example_normal',
+			x64_examples_dir(), 'hanoi.v')
+		context := '${x64_host_result_context(tiny)}\nnormal build:\n${x64_host_result_context(normal)}'
+		assert tiny.stdout == x64_hanoi_example_stdout(), context
+		assert tiny.stderr == []u8{}, context
+		assert normal.stdout == tiny.stdout, context
+		assert normal.stderr == []u8{}, context
+		assert_x64_macos_tiny_object_used(tiny, context)
+		tiny_size := os.file_size(tiny.bin_path)
+		normal_size := os.file_size(normal.bin_path)
+		assert tiny_size > 0, '${context}\ntiny size: ${tiny_size}'
+		assert normal_size > 0, '${context}\nnormal size: ${normal_size}'
+		println('macOS x64 tiny hanoi: tiny size=${tiny_size}; normal size=${normal_size}')
+		x64_host_cleanup_tmp(tiny.tmp_dir)
+		x64_host_cleanup_tmp(normal.tmp_dir)
+	}
+}
+
+fn test_x64_macos_js_hello_world_example_auto_tiny_uses_tiny_object() {
+	$if macos {
+		tiny := run_x64_host_file_redirected_macos_auto_tiny('macos_js_hello_world_example_auto_tiny',
+			x64_examples_dir(), 'js_hello_world.v')
+		normal := run_x64_host_file_redirected_no_tiny('macos_js_hello_world_example_normal',
+			x64_examples_dir(), 'js_hello_world.v')
+		context := '${x64_host_result_context(tiny)}\nnormal build:\n${x64_host_result_context(normal)}'
+		assert tiny.stdout == x64_js_hello_world_example_stdout(), context
+		assert tiny.stderr == []u8{}, context
+		assert normal.stdout == tiny.stdout, context
+		assert normal.stderr == []u8{}, context
+		assert_x64_macos_tiny_object_used(tiny, context)
+		tiny_size := os.file_size(tiny.bin_path)
+		normal_size := os.file_size(normal.bin_path)
+		assert tiny_size > 0, '${context}\ntiny size: ${tiny_size}'
+		assert normal_size > 0, '${context}\nnormal size: ${normal_size}'
+		println('macOS x64 tiny js_hello_world: tiny size=${tiny_size}; normal size=${normal_size}')
+		x64_host_cleanup_tmp(tiny.tmp_dir)
+		x64_host_cleanup_tmp(normal.tmp_dir)
+	}
+}
+
+fn test_x64_macos_vascii_example_auto_tiny_uses_tiny_object() {
+	$if macos {
+		tiny := run_x64_host_file_redirected_macos_auto_tiny('macos_vascii_example_auto_tiny',
+			x64_examples_dir(), 'vascii.v')
+		normal := run_x64_host_file_redirected_no_tiny('macos_vascii_example_normal',
+			x64_examples_dir(), 'vascii.v')
+		context := '${x64_host_result_context(tiny)}\nnormal build:\n${x64_host_result_context(normal)}'
+		assert tiny.stdout == x64_vascii_example_stdout(), context
+		assert tiny.stderr == []u8{}, context
+		assert normal.stdout == tiny.stdout, context
+		assert normal.stderr == []u8{}, context
+		assert_x64_macos_tiny_object_used(tiny, context)
+		tiny_size := os.file_size(tiny.bin_path)
+		normal_size := os.file_size(normal.bin_path)
+		assert tiny_size > 0, '${context}\ntiny size: ${tiny_size}'
+		assert normal_size > 0, '${context}\nnormal size: ${normal_size}'
+		println('macOS x64 tiny vascii: tiny size=${tiny_size}; normal size=${normal_size}')
+		x64_host_cleanup_tmp(tiny.tmp_dir)
+		x64_host_cleanup_tmp(normal.tmp_dir)
+	}
+}
+
+fn test_x64_macos_rune_example_auto_tiny_uses_tiny_object() {
+	$if macos {
+		tiny := run_x64_host_file_redirected_macos_auto_tiny('macos_rune_example_auto_tiny',
+			x64_examples_dir(), 'rune.v')
+		normal := run_x64_host_file_redirected_no_tiny('macos_rune_example_normal',
+			x64_examples_dir(), 'rune.v')
+		context := '${x64_host_result_context(tiny)}\nnormal build:\n${x64_host_result_context(normal)}'
+		assert tiny.stdout == x64_rune_example_stdout(), context
+		assert tiny.stderr == []u8{}, context
+		assert normal.stdout == tiny.stdout, context
+		assert normal.stderr == []u8{}, context
+		assert_x64_macos_tiny_object_used(tiny, context)
+		tiny_size := os.file_size(tiny.bin_path)
+		normal_size := os.file_size(normal.bin_path)
+		assert tiny_size > 0, '${context}\ntiny size: ${tiny_size}'
+		assert normal_size > 0, '${context}\nnormal size: ${normal_size}'
+		println('macOS x64 tiny rune: tiny size=${tiny_size}; normal size=${normal_size}')
 		x64_host_cleanup_tmp(tiny.tmp_dir)
 		x64_host_cleanup_tmp(normal.tmp_dir)
 	}
@@ -3007,9 +4478,9 @@ fn main() {
 	}
 }
 
-fn test_x64_linux_auto_tiny_stored_int_str_values_fall_back_to_hosted_libc() {
+fn test_x64_linux_auto_tiny_stored_int_str_values_use_tiny_runtime() {
 	$if linux {
-		result := run_x64_host_program_redirected_auto('auto_tiny_stored_int_str_values_hosted', 'module main
+		result := run_x64_host_program_redirected_auto('auto_tiny_stored_int_str_values_runtime', 'module main
 
 fn main() {
 	a := 12.str()
@@ -3019,14 +4490,15 @@ fn main() {
 	println(a)
 }
 ')
-		assert_x64_linux_hosted_libc_binary(result, '12\n34\n12\n'.bytes())
+		assert_x64_linux_no_libc_binary(result, '12\n34\n12\n'.bytes())
+		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes)
 		x64_host_cleanup_tmp(result.tmp_dir)
 	}
 }
 
-fn test_x64_linux_strict_tiny_stored_int_str_values_are_rejected() {
+fn test_x64_linux_strict_tiny_stored_int_str_values_use_tiny_runtime() {
 	$if linux {
-		assert_x64_linux_tiny_build_rejected('strict_tiny_stored_int_str_values_rejected', 'module main
+		result := run_x64_host_program_redirected_tiny('strict_tiny_stored_int_str_values_runtime', 'module main
 
 fn main() {
 	a := 12.str()
@@ -3035,14 +4507,16 @@ fn main() {
 	println(b)
 	println(a)
 }
-',
-			linux_tiny_not_eligible_prefix)
+')
+		assert_x64_linux_no_libc_binary(result, '12\n34\n12\n'.bytes())
+		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
 	}
 }
 
-fn test_x64_linux_auto_tiny_passed_int_str_value_falls_back_to_hosted_libc() {
+fn test_x64_linux_auto_tiny_passed_int_str_value_uses_tiny_runtime() {
 	$if linux {
-		result := run_x64_host_program_redirected_auto('auto_tiny_passed_int_str_value_hosted', 'module main
+		result := run_x64_host_program_redirected_auto('auto_tiny_passed_int_str_value_runtime', 'module main
 
 fn emit_twice(s string) {
 	println(s)
@@ -3053,14 +4527,15 @@ fn main() {
 	emit_twice(42.str())
 }
 ')
-		assert_x64_linux_hosted_libc_binary(result, '42\n42\n'.bytes())
+		assert_x64_linux_no_libc_binary(result, '42\n42\n'.bytes())
+		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes)
 		x64_host_cleanup_tmp(result.tmp_dir)
 	}
 }
 
-fn test_x64_linux_strict_tiny_passed_int_str_value_is_rejected() {
+fn test_x64_linux_strict_tiny_passed_int_str_value_uses_tiny_runtime() {
 	$if linux {
-		assert_x64_linux_tiny_build_rejected('strict_tiny_passed_int_str_value_rejected', 'module main
+		result := run_x64_host_program_redirected_tiny('strict_tiny_passed_int_str_value_runtime', 'module main
 
 fn emit_twice(s string) {
 	println(s)
@@ -3070,8 +4545,10 @@ fn emit_twice(s string) {
 fn main() {
 	emit_twice(42.str())
 }
-',
-			linux_tiny_not_eligible_prefix)
+')
+		assert_x64_linux_no_libc_binary(result, '42\n42\n'.bytes())
+		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
 	}
 }
 
@@ -3169,6 +4646,25 @@ fn main() {
 		}
 		expected_stdout << '2147483647\n'.bytes()
 		assert_x64_linux_no_libc_binary(result, expected_stdout)
+		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes)
+		x64_host_cleanup_tmp(result.tmp_dir)
+	}
+}
+
+fn test_x64_linux_tiny_i64_str_boundary_values_stdout_exact_bytes() {
+	$if linux {
+		result := run_x64_host_program_redirected_tiny('tiny_i64_str_boundary_values', 'module main
+
+fn main() {
+	println(i64(9223372036854775807))
+	println(-i64(9223372036854775807) - i64(1))
+	println(i64(4294967296))
+	println(i64(-4294967297))
+	println(i64(1234567890123456789))
+}
+')
+		assert_x64_linux_no_libc_binary(result,
+			'9223372036854775807\n-9223372036854775808\n4294967296\n-4294967297\n1234567890123456789\n'.bytes())
 		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes)
 		x64_host_cleanup_tmp(result.tmp_dir)
 	}
@@ -3341,9 +4837,55 @@ fn test_x64_macos_windows_println_string_parameter_stdout_exact_bytes() {
 		x64_println_string_parameter_stdout_source(), x64_println_string_parameter_stdout())
 }
 
+fn test_x64_macos_windows_named_function_value_stdout_exact_bytes() {
+	assert_x64_macos_windows_stdout_bytes('named_function_value_exact',
+		x64_named_function_value_source(), x64_named_function_value_stdout())
+}
+
+fn test_x64_macos_windows_selective_import_builtin_shadow_fn_value_stdout_exact_bytes() {
+	assert_x64_macos_windows_project_stdout_bytes('selective_import_builtin_shadow_fn_value_exact',
+		x64_selective_import_builtin_shadow_fn_value_sources(),
+		x64_selective_import_builtin_shadow_fn_value_stdout())
+}
+
+fn test_x64_macos_windows_selective_import_bare_fallback_shadow_stdout_exact_bytes() {
+	assert_x64_macos_windows_project_stdout_bytes('selective_import_bare_fallback_shadow_exact',
+		x64_selective_import_bare_fallback_shadow_sources(),
+		x64_selective_import_bare_fallback_shadow_stdout())
+}
+
+fn test_x64_macos_windows_selective_import_method_shadow_stdout_exact_bytes() {
+	assert_x64_macos_windows_project_stdout_bytes('selective_import_method_shadow_exact',
+		x64_selective_import_method_shadow_sources(), x64_selective_import_method_shadow_stdout())
+}
+
+fn test_x64_macos_windows_non_capturing_fn_literal_value_stdout_exact_bytes() {
+	assert_x64_macos_windows_stdout_bytes('non_capturing_fn_literal_value_exact',
+		x64_non_capturing_fn_literal_value_source(), x64_non_capturing_fn_literal_value_stdout())
+}
+
+fn test_x64_macos_windows_returned_non_capturing_fn_literal_stdout_exact_bytes() {
+	assert_x64_macos_windows_stdout_bytes('returned_non_capturing_fn_literal_exact',
+		x64_returned_non_capturing_fn_literal_source(),
+		x64_returned_non_capturing_fn_literal_stdout())
+}
+
 fn test_x64_macos_windows_i64_loop_carried_mutable_state_controls_branch() {
 	assert_x64_macos_windows_stdout_bytes('i64_loop_carried_mutable_state_branch',
 		x64_i64_loop_carried_mutable_state_source(), x64_i64_loop_carried_mutable_state_stdout())
+}
+
+fn test_x64_windows_i64_str_boundary_values_stdout_exact_bytes() {
+	assert_x64_windows_stdout_bytes('windows_i64_str_boundary_values', 'module main
+
+fn main() {
+	println(i64(9223372036854775807))
+	println(-i64(9223372036854775807) - i64(1))
+	println(i64(4294967296))
+	println(i64(-4294967297))
+}
+',
+		'9223372036854775807\n-9223372036854775808\n4294967296\n-4294967297\n'.bytes())
 }
 
 fn test_x64_macos_windows_print_integer_and_int_str_stdout_exact_bytes() {
@@ -3430,6 +4972,21 @@ fn test_x64_macos_windows_dynamic_int_array_stdout_exact_bytes() {
 		x64_dynamic_int_array_source(), x64_dynamic_int_array_stdout())
 }
 
+fn test_x64_macos_windows_dynamic_string_array_index_stdout_exact_bytes() {
+	assert_x64_macos_windows_stdout_bytes('dynamic_string_array_index_exact',
+		x64_dynamic_string_array_index_source(), x64_dynamic_string_array_index_stdout())
+}
+
+fn test_x64_macos_windows_dynamic_string_array_str_stdout_exact_bytes() {
+	assert_x64_macos_windows_stdout_bytes('dynamic_string_array_str_exact',
+		x64_dynamic_string_array_str_source(), x64_dynamic_string_array_str_stdout())
+}
+
+fn test_x64_macos_windows_string_int_map_literal_lookup_stdout_exact_bytes() {
+	assert_x64_macos_windows_stdout_bytes('string_int_map_literal_lookup_exact',
+		x64_string_int_map_literal_lookup_source(), x64_string_int_map_literal_lookup_stdout())
+}
+
 fn test_x64_windows_noscan_array_grow_free_slice_stdout_exact_bytes() {
 	assert_x64_windows_stdout_bytes('noscan_array_grow_free_slice_exact',
 		x64_windows_noscan_array_grow_free_slice_source(),
@@ -3486,9 +5043,84 @@ fn test_x64_macos_windows_fizz_buzz_core_for_range_match_true_stdout_exact_bytes
 		x64_fizz_buzz_core_source(), x64_fizz_buzz_core_stdout())
 }
 
+fn test_x64_macos_windows_string_literal_field_size_stores_do_not_clobber_adjacent_fields() {
+	assert_x64_macos_windows_stdout_bytes('string_literal_field_size_no_clobber',
+		x64_string_literal_field_size_source(), x64_string_literal_field_size_stdout())
+}
+
+fn test_x64_macos_windows_hello_world_example_top_level_stdout_exact_bytes() {
+	assert_x64_macos_windows_file_stdout_bytes('hello_world_example_top_level_exact',
+		x64_examples_dir(), 'hello_world.v', x64_hello_world_example_stdout())
+}
+
 fn test_x64_macos_windows_fizz_buzz_example_top_level_stdout_exact_bytes() {
 	assert_x64_macos_windows_file_stdout_bytes('fizz_buzz_example_top_level_exact',
 		x64_examples_dir(), 'fizz_buzz.v', x64_fizz_buzz_example_stdout())
+}
+
+fn test_x64_macos_windows_hanoi_example_top_level_stdout_exact_bytes() {
+	assert_x64_macos_windows_file_stdout_bytes('hanoi_example_top_level_exact', x64_examples_dir(),
+		'hanoi.v', x64_hanoi_example_stdout())
+}
+
+fn test_x64_macos_windows_sudoku_example_top_level_stdout_exact_bytes() {
+	assert_x64_macos_windows_file_stdout_bytes('sudoku_example_top_level_exact',
+		x64_examples_dir(), 'sudoku.v', x64_sudoku_example_stdout())
+}
+
+fn test_x64_macos_windows_function_types_example_top_level_stdout_exact_bytes() {
+	assert_x64_macos_windows_file_stdout_bytes('function_types_example_top_level_exact',
+		x64_examples_dir(), 'function_types.v', x64_function_types_example_stdout())
+}
+
+fn test_x64_macos_windows_submodule_example_top_level_stdout_exact_bytes() {
+	assert_x64_macos_windows_file_stdout_bytes('submodule_example_top_level_exact',
+		x64_examples_dir(), 'submodule/main.v', x64_submodule_example_stdout())
+}
+
+fn test_x64_macos_windows_struct_sumtype_field_init_stdout_exact_bytes() {
+	assert_x64_macos_windows_stdout_bytes('struct_sumtype_field_init_exact',
+		x64_struct_sumtype_field_init_source(), x64_struct_sumtype_field_init_stdout())
+}
+
+fn test_x64_macos_windows_auto_str_recursive_sumtype_stdout_exact_bytes() {
+	assert_x64_macos_windows_stdout_bytes('auto_str_recursive_sumtype_exact',
+		x64_auto_str_recursive_sumtype_source(), x64_auto_str_recursive_sumtype_stdout())
+}
+
+fn test_x64_macos_windows_tree_of_nodes_example_top_level_stdout_exact_bytes() {
+	assert_x64_macos_windows_file_stdout_bytes('tree_of_nodes_example_top_level_exact',
+		x64_examples_dir(), 'tree_of_nodes.v', x64_tree_of_nodes_example_stdout())
+}
+
+fn test_x64_macos_windows_bfs_example_top_level_stdout_exact_bytes() {
+	assert_x64_macos_windows_file_stdout_bytes('bfs_example_top_level_exact', os.join_path(x64_examples_dir(),
+		'graphs'), 'bfs.v', x64_bfs_example_stdout())
+}
+
+fn test_x64_macos_windows_dfs_example_top_level_stdout_matches_v_run() {
+	assert_x64_macos_windows_file_stdout_matches_v_run('dfs_example_top_level_v_run', os.join_path(x64_examples_dir(),
+		'graphs'), 'dfs.v')
+}
+
+fn test_x64_macos_windows_dijkstra_example_top_level_stdout_matches_v_run() {
+	assert_x64_macos_windows_file_stdout_matches_v_run('dijkstra_example_top_level_v_run', os.join_path(x64_examples_dir(),
+		'graphs'), 'dijkstra.v')
+}
+
+fn test_x64_macos_windows_js_hello_world_example_top_level_stdout_exact_bytes() {
+	assert_x64_macos_windows_file_stdout_bytes('js_hello_world_example_top_level_exact',
+		x64_examples_dir(), 'js_hello_world.v', x64_js_hello_world_example_stdout())
+}
+
+fn test_x64_macos_windows_vascii_example_top_level_stdout_exact_bytes() {
+	assert_x64_macos_windows_file_stdout_bytes('vascii_example_top_level_exact',
+		x64_examples_dir(), 'vascii.v', x64_vascii_example_stdout())
+}
+
+fn test_x64_macos_windows_rune_example_top_level_stdout_exact_bytes() {
+	assert_x64_macos_windows_file_stdout_bytes('rune_example_top_level_exact', x64_examples_dir(),
+		'rune.v', x64_rune_example_stdout())
 }
 
 fn test_x64_macos_windows_imported_module_init_runs_once_before_use_stdout_exact_bytes() {
@@ -3781,6 +5413,36 @@ fn main() {
 		u8(`S`),
 		u8(`\n`),
 	])
+}
+
+fn test_x64_linux_dynamic_array_literal_push_minimal_stdout_exact_bytes() {
+	assert_x64_linux_stdout_bytes('dynamic_array_literal_push_minimal_exact', 'module main
+
+fn main() {
+	mut a := [1, 2, 3]
+	a[1] = 7
+	a << 11
+	println(a.len)
+}
+', [
+		u8(`4`),
+		u8(`\n`),
+	])
+}
+
+fn test_x64_linux_dynamic_string_array_index_stdout_exact_bytes() {
+	assert_x64_linux_stdout_bytes('dynamic_string_array_index_exact',
+		x64_dynamic_string_array_index_source(), x64_dynamic_string_array_index_stdout())
+}
+
+fn test_x64_linux_dynamic_string_array_str_stdout_exact_bytes() {
+	assert_x64_linux_stdout_bytes('dynamic_string_array_str_exact',
+		x64_dynamic_string_array_str_source(), x64_dynamic_string_array_str_stdout())
+}
+
+fn test_x64_linux_string_int_map_literal_lookup_stdout_exact_bytes() {
+	assert_x64_linux_stdout_bytes('string_int_map_literal_lookup_exact',
+		x64_string_int_map_literal_lookup_source(), x64_string_int_map_literal_lookup_stdout())
 }
 
 fn test_x64_linux_imported_module_init_runs_once_before_use_stdout_exact_bytes() {

--- a/vlib/v2/markused/markused.v
+++ b/vlib/v2/markused/markused.v
@@ -17,7 +17,7 @@ fn sumtype_payload_word_is_valid(tag_word u64, data_word u64) bool {
 	// looks like a small tag, the payload must be a real pointer, not a leaked
 	// enum/default value like `3`.
 	if tag_word < 256 {
-		return data_word >= 0x100000000 && data_word < 0x0000800000000000
+		return data_word >= 0x10000 && data_word < 0x0000800000000000
 	}
 	return true
 }
@@ -30,7 +30,7 @@ fn string_ok(s string) bool {
 		return false
 	}
 	ptr := unsafe { u64(s.str) }
-	return ptr >= 0x100000000 && ptr < 0x0000800000000000
+	return ptr >= 0x10000 && ptr < 0x0000800000000000
 }
 
 fn expr_ok(expr ast.Expr) bool {
@@ -106,23 +106,25 @@ mut:
 
 	used_keys map[string]bool
 
-	module_names              map[string]bool
-	module_alias_to_real      map[string]string
-	type_names                map[string]bool
-	interface_type_names      map[string]bool
-	interface_method_names    map[string][]string
-	interface_embedded_names  map[string][]string
-	methods_by_receiver       map[string][]int
-	struct_field_receivers    map[string][]string
-	struct_embedded_receivers map[string][]string
-	struct_fn_fields          map[string]bool
-	global_interface_names    map[string]string
-	const_fn_value_aliases    map[string]string
+	module_names                map[string]bool
+	module_alias_to_real        map[string]string
+	type_names                  map[string]bool
+	interface_type_names        map[string]bool
+	interface_method_names      map[string][]string
+	interface_embedded_names    map[string][]string
+	methods_by_receiver         map[string][]int
+	struct_field_receivers      map[string][]string
+	struct_embedded_receivers   map[string][]string
+	struct_fn_fields            map[string]bool
+	global_interface_names      map[string]string
+	const_fn_value_aliases      map[string]string
+	selective_import_fn_targets map[string]string
 
 	lookup map[string][]int
 
 	cur_fn_scope &types.Scope = unsafe { nil }
 	cur_fn_decl  ast.FnDecl
+	cur_fn_file  string
 }
 
 pub struct MarkUsedOptions {
@@ -154,23 +156,24 @@ pub fn decl_key(module_name string, decl ast.FnDecl, env &types.Environment) str
 
 fn new_walker(files []ast.File, env &types.Environment, opts MarkUsedOptions) Walker {
 	return Walker{
-		files:                     files
-		env:                       unsafe { env }
-		opts:                      opts
-		used_keys:                 map[string]bool{}
-		queued_fn_indices:         map[int]bool{}
-		module_names:              map[string]bool{}
-		type_names:                map[string]bool{}
-		interface_type_names:      map[string]bool{}
-		interface_method_names:    map[string][]string{}
-		interface_embedded_names:  map[string][]string{}
-		methods_by_receiver:       map[string][]int{}
-		struct_field_receivers:    map[string][]string{}
-		struct_embedded_receivers: map[string][]string{}
-		struct_fn_fields:          map[string]bool{}
-		global_interface_names:    map[string]string{}
-		const_fn_value_aliases:    map[string]string{}
-		lookup:                    map[string][]int{}
+		files:                       files
+		env:                         unsafe { env }
+		opts:                        opts
+		used_keys:                   map[string]bool{}
+		queued_fn_indices:           map[int]bool{}
+		module_names:                map[string]bool{}
+		type_names:                  map[string]bool{}
+		interface_type_names:        map[string]bool{}
+		interface_method_names:      map[string][]string{}
+		interface_embedded_names:    map[string][]string{}
+		methods_by_receiver:         map[string][]int{}
+		struct_field_receivers:      map[string][]string{}
+		struct_embedded_receivers:   map[string][]string{}
+		struct_fn_fields:            map[string]bool{}
+		global_interface_names:      map[string]string{}
+		const_fn_value_aliases:      map[string]string{}
+		selective_import_fn_targets: map[string]string{}
+		lookup:                      map[string][]int{}
 	}
 }
 
@@ -200,8 +203,10 @@ fn (mut w Walker) walk_collected() map[string]bool {
 		info := w.fns[idx]
 		w.cur_fn_scope = w.lookup_fn_scope(info)
 		w.cur_fn_decl = info.decl
+		w.cur_fn_file = info.file
 		w.walk_stmts(info.decl.stmts, info.mod)
 		w.cur_fn_scope = unsafe { nil }
+		w.cur_fn_file = ''
 	}
 	return w.used_keys
 }
@@ -231,12 +236,14 @@ fn (mut w Walker) walk_collected_from_flat(flat &ast.FlatAst) map[string]bool {
 		info := w.fns[idx]
 		w.cur_fn_scope = w.lookup_fn_scope(info)
 		w.cur_fn_decl = info.decl
+		w.cur_fn_file = info.file
 		if info.decl_id >= 0 {
 			w.walk_fn_body_cursor(flat, info.decl_id, info.mod)
 		} else {
 			w.walk_stmts(info.decl.stmts, info.mod)
 		}
 		w.cur_fn_scope = unsafe { nil }
+		w.cur_fn_file = ''
 	}
 	return w.used_keys
 }
@@ -816,7 +823,7 @@ fn (mut w Walker) collect_defs() {
 	for file in w.files {
 		mod_name := normalize_module_name(file.mod)
 		w.add_module_name(mod_name)
-		w.collect_imports(file.imports)
+		w.collect_file_imports(file.name, file.imports)
 		for stmt in file.stmts {
 			w.collect_def_stmt(stmt, mod_name, file.name, ast.FlatNodeId(-1))
 		}
@@ -842,6 +849,18 @@ fn (mut w Walker) collect_defs_from_flat(flat &ast.FlatAst) {
 			name := imp_cur.name()
 			w.add_module_name(name)
 			alias := imp_cur.extra_str()
+			import_mod := if imp_cur.flag(ast.flag_is_aliased) {
+				name.all_after_last('.')
+			} else {
+				alias
+			}
+			for si in 0 .. imp_cur.edge_count() {
+				symbol := imp_cur.edge(si)
+				if symbol.is_valid() && symbol.kind() == .expr_ident {
+					w.selective_import_fn_targets['${fc.name()}:${symbol.name()}'] = markused_imported_symbol_fn_name(import_mod,
+						symbol.name())
+				}
+			}
 			if alias != '' {
 				w.add_module_name(alias)
 				// Map alias to real module name for correct symbol resolution.
@@ -899,6 +918,8 @@ fn const_fn_value_alias_key(mod_name string, name string) string {
 fn (mut w Walker) collect_const_fn_value_aliases() {
 	for file in w.files {
 		mod_name := normalize_module_name(file.mod)
+		prev_fn_file := w.cur_fn_file
+		w.cur_fn_file = file.name
 		for stmt in file.stmts {
 			if !stmt_ok(stmt) {
 				continue
@@ -920,6 +941,7 @@ fn (mut w Walker) collect_const_fn_value_aliases() {
 				}
 			}
 		}
+		w.cur_fn_file = prev_fn_file
 	}
 }
 
@@ -927,6 +949,8 @@ fn (mut w Walker) collect_const_fn_value_aliases_from_flat(flat &ast.FlatAst) {
 	for fi in 0 .. flat.files.len {
 		fc := flat.file_cursor(fi)
 		mod_name := normalize_module_name(fc.mod())
+		prev_fn_file := w.cur_fn_file
+		w.cur_fn_file = fc.name()
 		stmts_list := fc.stmts()
 		for i in 0 .. stmts_list.len() {
 			c := stmts_list.at(i)
@@ -956,6 +980,7 @@ fn (mut w Walker) collect_const_fn_value_aliases_from_flat(flat &ast.FlatAst) {
 				}
 			}
 		}
+		w.cur_fn_file = prev_fn_file
 	}
 }
 
@@ -972,6 +997,33 @@ fn (mut w Walker) collect_imports(imports []ast.ImportStmt) {
 				imp.name
 			}
 			w.module_alias_to_real[imp.alias] = real_name
+		}
+	}
+}
+
+fn markused_imported_symbol_fn_name(module_name string, name string) string {
+	if module_name == '' || module_name == 'main' {
+		return name
+	}
+	return '${module_name}__${name}'
+}
+
+fn selective_import_fn_key(file_name string, name string) string {
+	return '${file_name}:${name}'
+}
+
+fn (mut w Walker) collect_file_imports(file_name string, imports []ast.ImportStmt) {
+	w.collect_imports(imports)
+	for imp in imports {
+		if imp.symbols.len == 0 {
+			continue
+		}
+		import_mod := if imp.is_aliased { imp.name.all_after_last('.') } else { imp.alias }
+		for symbol in imp.symbols {
+			if symbol is ast.Ident {
+				w.selective_import_fn_targets[selective_import_fn_key(file_name, symbol.name)] = markused_imported_symbol_fn_name(import_mod,
+					symbol.name)
+			}
 		}
 	}
 }
@@ -2200,7 +2252,21 @@ fn (w &Walker) ident_resolves_to_fn_value(name string, mod_name string) bool {
 			return obj is types.Fn
 		}
 	}
-	for candidate in called_fn_name_candidates(name) {
+	candidates := called_fn_name_candidates(name)
+	if _ := w.exact_mangled_fn_lookup_key(name) {
+		return true
+	}
+	for candidate in candidates {
+		if _ := w.current_module_fn_lookup_key(candidate, mod_name) {
+			return true
+		}
+	}
+	for candidate in candidates {
+		if _ := w.selective_import_fn_lookup_key(candidate) {
+			return true
+		}
+	}
+	for candidate in candidates {
 		if w.lookup_count('mod:${mod_name}:${candidate}') > 0
 			|| w.lookup_count('fn:${candidate}') > 0 {
 			return true
@@ -2213,11 +2279,63 @@ fn (w &Walker) ident_resolves_to_fn_value(name string, mod_name string) bool {
 	return false
 }
 
+fn (w &Walker) current_module_fn_lookup_key(name string, mod_name string) ?string {
+	key := 'mod:${mod_name}:${name}'
+	if w.lookup_count(key) > 0 {
+		return key
+	}
+	return none
+}
+
+fn (w &Walker) exact_mangled_fn_lookup_key(name string) ?string {
+	if !name.contains('__') {
+		return none
+	}
+	key := 'fn:${name}'
+	if w.lookup_count(key) > 0 {
+		return key
+	}
+	return none
+}
+
+fn (w &Walker) selective_import_fn_lookup_key(name string) ?string {
+	if w.cur_fn_file == '' {
+		return none
+	}
+	if target := w.selective_import_fn_targets[selective_import_fn_key(w.cur_fn_file, name)] {
+		key := 'fn:${target}'
+		if w.lookup_count(key) > 0 {
+			return key
+		}
+	}
+	return none
+}
+
 fn (mut w Walker) mark_fn_name(name string, mod_name string) {
 	if name == '' || !string_ok(name) || !string_ok(mod_name) {
 		return
 	}
-	for candidate in called_fn_name_candidates(name) {
+	if w.opts.minimal_runtime_roots && name in ['array__eq', 'builtin__array__eq'] {
+		w.mark_fn_name('map_map_eq', 'builtin')
+	}
+	candidates := called_fn_name_candidates(name)
+	if key := w.exact_mangled_fn_lookup_key(name) {
+		w.mark_lookup(key)
+		return
+	}
+	for candidate in candidates {
+		if key := w.current_module_fn_lookup_key(candidate, mod_name) {
+			w.mark_lookup(key)
+			return
+		}
+	}
+	for candidate in candidates {
+		if key := w.selective_import_fn_lookup_key(candidate) {
+			w.mark_lookup(key)
+			return
+		}
+	}
+	for candidate in candidates {
 		w.mark_lookup('mod:${mod_name}:${candidate}')
 		w.mark_lookup('fn:${candidate}')
 		if !candidate.contains('__') && mod_name != '' && mod_name != 'main'
@@ -2798,7 +2916,24 @@ fn (w &Walker) add_fn_name_indices(name string, mod_name string, mut out []int) 
 	if name == '' || !string_ok(name) || !string_ok(mod_name) {
 		return
 	}
-	for candidate in called_fn_name_candidates(name) {
+	candidates := called_fn_name_candidates(name)
+	if key := w.exact_mangled_fn_lookup_key(name) {
+		w.add_lookup_indices(key, mut out)
+		return
+	}
+	for candidate in candidates {
+		if key := w.current_module_fn_lookup_key(candidate, mod_name) {
+			w.add_lookup_indices(key, mut out)
+			return
+		}
+	}
+	for candidate in candidates {
+		if key := w.selective_import_fn_lookup_key(candidate) {
+			w.add_lookup_indices(key, mut out)
+			return
+		}
+	}
+	for candidate in candidates {
 		w.add_lookup_indices('mod:${mod_name}:${candidate}', mut out)
 		w.add_lookup_indices('fn:${candidate}', mut out)
 		if !candidate.contains('__') && mod_name != '' && mod_name != 'main'

--- a/vlib/v2/markused/minimal_runtime_roots_test.v
+++ b/vlib/v2/markused/minimal_runtime_roots_test.v
@@ -45,6 +45,432 @@ fn mark_used_flat_minimal(files []ast.File, env &types.Environment) map[string]b
 	})
 }
 
+fn local_call_minimal_files() []ast.File {
+	return [
+		ast.File{
+			mod:   'main'
+			name:  'local_calls.v'
+			stmts: [
+				ast.Stmt(ast.FnDecl{
+					name:  'main'
+					typ:   ast.FnType{}
+					pos:   minimal_pos(10)
+					stmts: [
+						ast.Stmt(ast.ExprStmt{
+							expr: ast.CallExpr{
+								lhs: ast.Expr(minimal_ident('foo', 11))
+								pos: minimal_pos(11)
+							}
+						}),
+					]
+				}),
+				ast.Stmt(ast.FnDecl{
+					name:  'foo'
+					typ:   ast.FnType{}
+					pos:   minimal_pos(12)
+					stmts: [
+						ast.Stmt(ast.ExprStmt{
+							expr: ast.CallExpr{
+								lhs: ast.Expr(minimal_ident('status', 13))
+								pos: minimal_pos(13)
+							}
+						}),
+					]
+				}),
+				ast.Stmt(ast.FnDecl{
+					name: 'status'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(14)
+				}),
+				ast.Stmt(ast.FnDecl{
+					name: 'dead'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(15)
+				}),
+			]
+		},
+	]
+}
+
+fn assert_local_call_minimal_used(used map[string]bool, files []ast.File, env &types.Environment, label string) {
+	main_key := decl_key('main', files[0].stmts[0] as ast.FnDecl, env)
+	foo_key := decl_key('main', files[0].stmts[1] as ast.FnDecl, env)
+	status_key := decl_key('main', files[0].stmts[2] as ast.FnDecl, env)
+	dead_key := decl_key('main', files[0].stmts[3] as ast.FnDecl, env)
+
+	assert used[main_key], '${label}: main root was not kept'
+	assert used[foo_key], '${label}: local foo call was not marked'
+	assert used[status_key], '${label}: transitive local status call was not marked'
+	assert !used[dead_key], '${label}: unused local function should stay pruned'
+}
+
+fn test_minimal_runtime_roots_pointer_guards_accept_low_canonical_pointers() {
+	assert sumtype_payload_word_is_valid(1, 0x10000)
+	assert !sumtype_payload_word_is_valid(1, 0)
+	assert !sumtype_payload_word_is_valid(1, 3)
+	assert string_ok('foo')
+	assert string_ok('status')
+}
+
+fn test_minimal_runtime_roots_keep_local_calls_legacy() {
+	mut env := types.Environment.new()
+	files := local_call_minimal_files()
+	used := mark_used_with_options(files, env, MarkUsedOptions{
+		minimal_runtime_roots: true
+	})
+	assert_local_call_minimal_used(used, files, env, 'legacy')
+}
+
+fn test_minimal_runtime_roots_keep_local_calls_flat() {
+	mut env := types.Environment.new()
+	files := local_call_minimal_files()
+	used := mark_used_flat_minimal(files, env)
+	assert_local_call_minimal_used(used, files, env, 'flat')
+}
+
+fn selective_import_minimal_files() []ast.File {
+	return [
+		ast.File{
+			mod:     'main'
+			name:    'examples/submodule/main.v'
+			imports: [
+				ast.ImportStmt{
+					name:    'mymodules'
+					alias:   'mymodules'
+					symbols: [ast.Expr(minimal_ident('add_xy', 60))]
+				},
+				ast.ImportStmt{
+					name:    'mymodules.submodule'
+					alias:   'submodule'
+					symbols: [ast.Expr(minimal_ident('sub_xy', 61))]
+				},
+			]
+			stmts:   [
+				ast.Stmt(ast.FnDecl{
+					name:  'main'
+					typ:   ast.FnType{}
+					pos:   minimal_pos(62)
+					stmts: [
+						ast.Stmt(ast.ExprStmt{
+							expr: ast.CallExpr{
+								lhs: ast.Expr(minimal_ident('add_xy', 63))
+								pos: minimal_pos(63)
+							}
+						}),
+						ast.Stmt(ast.ExprStmt{
+							expr: ast.CallExpr{
+								lhs: ast.Expr(minimal_ident('sub_xy', 64))
+								pos: minimal_pos(64)
+							}
+						}),
+					]
+				}),
+			]
+		},
+		ast.File{
+			mod:   'mymodules'
+			name:  'examples/submodule/mymodules/main_functions.v'
+			stmts: [
+				ast.Stmt(ast.FnDecl{
+					name: 'add_xy'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(65)
+				}),
+				ast.Stmt(ast.FnDecl{
+					name: 'unused_add'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(66)
+				}),
+			]
+		},
+		ast.File{
+			mod:   'submodule'
+			name:  'examples/submodule/mymodules/submodule/sub_functions.v'
+			stmts: [
+				ast.Stmt(ast.FnDecl{
+					name: 'sub_xy'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(67)
+				}),
+				ast.Stmt(ast.FnDecl{
+					name: 'unused_sub'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(68)
+				}),
+			]
+		},
+	]
+}
+
+fn assert_selective_import_minimal_used(used map[string]bool, files []ast.File, env &types.Environment, label string) {
+	main_key := decl_key('main', files[0].stmts[0] as ast.FnDecl, env)
+	add_key := decl_key('mymodules', files[1].stmts[0] as ast.FnDecl, env)
+	unused_add_key := decl_key('mymodules', files[1].stmts[1] as ast.FnDecl, env)
+	sub_key := decl_key('submodule', files[2].stmts[0] as ast.FnDecl, env)
+	unused_sub_key := decl_key('submodule', files[2].stmts[1] as ast.FnDecl, env)
+
+	assert used[main_key], '${label}: main root was not kept'
+	assert used[add_key], '${label}: selective import add_xy was not resolved to mymodules__add_xy'
+	assert used[sub_key], '${label}: selective import sub_xy was not resolved to submodule__sub_xy'
+	assert !used[unused_add_key], '${label}: unused mymodules function should stay pruned'
+	assert !used[unused_sub_key], '${label}: unused submodule function should stay pruned'
+}
+
+fn test_minimal_runtime_roots_keep_selective_imported_function_calls_legacy() {
+	mut env := types.Environment.new()
+	files := selective_import_minimal_files()
+	used := mark_used_with_options(files, env, MarkUsedOptions{
+		minimal_runtime_roots: true
+	})
+	assert_selective_import_minimal_used(used, files, env, 'legacy')
+}
+
+fn test_minimal_runtime_roots_keep_selective_imported_function_calls_flat() {
+	mut env := types.Environment.new()
+	files := selective_import_minimal_files()
+	used := mark_used_flat_minimal(files, env)
+	assert_selective_import_minimal_used(used, files, env, 'flat')
+}
+
+fn selective_import_shadow_minimal_files(use_function_value bool) []ast.File {
+	mut main_body := []ast.Stmt{}
+	if use_function_value {
+		main_body << ast.Stmt(ast.AssignStmt{
+			op:  .decl_assign
+			lhs: [ast.Expr(minimal_ident('f', 150))]
+			rhs: [ast.Expr(minimal_ident('add_xy', 151))]
+			pos: minimal_pos(150)
+		})
+	} else {
+		main_body << ast.Stmt(ast.ExprStmt{
+			expr: ast.CallExpr{
+				lhs: ast.Expr(minimal_ident('add_xy', 152))
+				pos: minimal_pos(152)
+			}
+		})
+	}
+	return [
+		ast.File{
+			mod:     'main'
+			name:    'shadow/main.v'
+			imports: [
+				ast.ImportStmt{
+					name:    'mymodules'
+					alias:   'mymodules'
+					symbols: [ast.Expr(minimal_ident('add_xy', 153))]
+				},
+			]
+			stmts:   [
+				ast.Stmt(ast.FnDecl{
+					name:  'main'
+					typ:   ast.FnType{}
+					pos:   minimal_pos(154)
+					stmts: main_body
+				}),
+				ast.Stmt(ast.FnDecl{
+					name: 'add_xy'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(155)
+				}),
+			]
+		},
+		ast.File{
+			mod:   'mymodules'
+			name:  'shadow/mymodules/main_functions.v'
+			stmts: [
+				ast.Stmt(ast.FnDecl{
+					name: 'add_xy'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(156)
+				}),
+				ast.Stmt(ast.FnDecl{
+					name: 'unused_remote'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(157)
+				}),
+			]
+		},
+		ast.File{
+			mod:   'othermod'
+			name:  'shadow/othermod/main_functions.v'
+			stmts: [
+				ast.Stmt(ast.FnDecl{
+					name: 'add_xy'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(158)
+				}),
+			]
+		},
+	]
+}
+
+fn assert_selective_import_shadow_uses_local(used map[string]bool, files []ast.File, env &types.Environment, label string) {
+	main_key := decl_key('main', files[0].stmts[0] as ast.FnDecl, env)
+	local_add_key := decl_key('main', files[0].stmts[1] as ast.FnDecl, env)
+	imported_add_key := decl_key('mymodules', files[1].stmts[0] as ast.FnDecl, env)
+	unused_remote_key := decl_key('mymodules', files[1].stmts[1] as ast.FnDecl, env)
+	other_add_key := decl_key('othermod', files[2].stmts[0] as ast.FnDecl, env)
+
+	assert used[main_key], '${label}: main root was not kept'
+	assert used[local_add_key], '${label}: local add_xy should shadow the selective import'
+	assert !used[imported_add_key], '${label}: shadowed selective import should stay pruned'
+	assert !used[unused_remote_key], '${label}: unused imported-module function should stay pruned'
+	assert !used[other_add_key], '${label}: bare global add_xy fallback marked a colliding module function'
+}
+
+fn test_minimal_runtime_roots_selective_import_call_uses_local_shadow_legacy() {
+	mut env := types.Environment.new()
+	files := selective_import_shadow_minimal_files(false)
+	used := mark_used_with_options(files, env, MarkUsedOptions{
+		minimal_runtime_roots: true
+	})
+	assert_selective_import_shadow_uses_local(used, files, env, 'legacy call')
+}
+
+fn test_minimal_runtime_roots_selective_import_call_uses_local_shadow_flat() {
+	mut env := types.Environment.new()
+	files := selective_import_shadow_minimal_files(false)
+	used := mark_used_flat_minimal(files, env)
+	assert_selective_import_shadow_uses_local(used, files, env, 'flat call')
+}
+
+fn test_minimal_runtime_roots_selective_import_function_value_uses_local_shadow_legacy() {
+	mut env := types.Environment.new()
+	files := selective_import_shadow_minimal_files(true)
+	used := mark_used_with_options(files, env, MarkUsedOptions{
+		minimal_runtime_roots: true
+	})
+	assert_selective_import_shadow_uses_local(used, files, env, 'legacy function value')
+}
+
+fn test_minimal_runtime_roots_selective_import_function_value_uses_local_shadow_flat() {
+	mut env := types.Environment.new()
+	files := selective_import_shadow_minimal_files(true)
+	used := mark_used_flat_minimal(files, env)
+	assert_selective_import_shadow_uses_local(used, files, env, 'flat function value')
+}
+
+fn selective_import_function_value_minimal_files() []ast.File {
+	return [
+		ast.File{
+			mod:     'main'
+			name:    'fnvalue/main.v'
+			imports: [
+				ast.ImportStmt{
+					name:    'mymodules'
+					alias:   'mymodules'
+					symbols: [ast.Expr(minimal_ident('add_xy', 160))]
+				},
+			]
+			stmts:   [
+				ast.Stmt(ast.FnDecl{
+					name:  'main'
+					typ:   ast.FnType{}
+					pos:   minimal_pos(161)
+					stmts: [
+						ast.Stmt(ast.AssignStmt{
+							op:  .decl_assign
+							lhs: [ast.Expr(minimal_ident('f', 162))]
+							rhs: [ast.Expr(minimal_ident('add_xy', 163))]
+							pos: minimal_pos(162)
+						}),
+					]
+				}),
+			]
+		},
+		ast.File{
+			mod:   'mymodules'
+			name:  'fnvalue/mymodules/main_functions.v'
+			stmts: [
+				ast.Stmt(ast.FnDecl{
+					name: 'add_xy'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(164)
+				}),
+				ast.Stmt(ast.FnDecl{
+					name: 'unused_remote'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(165)
+				}),
+			]
+		},
+		ast.File{
+			mod:   'othermod'
+			name:  'fnvalue/othermod/main_functions.v'
+			stmts: [
+				ast.Stmt(ast.FnDecl{
+					name: 'add_xy'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(166)
+				}),
+			]
+		},
+	]
+}
+
+fn assert_selective_import_function_value_uses_imported_target(used map[string]bool, files []ast.File, env &types.Environment, label string) {
+	main_key := decl_key('main', files[0].stmts[0] as ast.FnDecl, env)
+	imported_add_key := decl_key('mymodules', files[1].stmts[0] as ast.FnDecl, env)
+	unused_remote_key := decl_key('mymodules', files[1].stmts[1] as ast.FnDecl, env)
+	other_add_key := decl_key('othermod', files[2].stmts[0] as ast.FnDecl, env)
+
+	assert used[main_key], '${label}: main root was not kept'
+	assert used[imported_add_key], '${label}: selective import function value did not resolve to mymodules__add_xy'
+	assert !used[unused_remote_key], '${label}: unused imported-module function should stay pruned'
+	assert !used[other_add_key], '${label}: bare global add_xy fallback marked a colliding module function'
+}
+
+fn test_minimal_runtime_roots_keep_selective_imported_function_values_legacy() {
+	mut env := types.Environment.new()
+	files := selective_import_function_value_minimal_files()
+	used := mark_used_with_options(files, env, MarkUsedOptions{
+		minimal_runtime_roots: true
+	})
+	assert_selective_import_function_value_uses_imported_target(used, files, env,
+		'legacy function value')
+}
+
+fn test_minimal_runtime_roots_keep_selective_imported_function_values_flat() {
+	mut env := types.Environment.new()
+	files := selective_import_function_value_minimal_files()
+	used := mark_used_flat_minimal(files, env)
+	assert_selective_import_function_value_uses_imported_target(used, files, env,
+		'flat function value')
+}
+
+fn test_minimal_runtime_roots_selective_import_add_fn_name_indices_legacy() {
+	mut env := types.Environment.new()
+	files := selective_import_function_value_minimal_files()
+	mut w := new_walker(files, env, MarkUsedOptions{
+		minimal_runtime_roots: true
+	})
+	w.collect_defs()
+	w.cur_fn_file = files[0].name
+	mut indices := []int{}
+	w.add_fn_name_indices('add_xy', 'main', mut indices)
+	target_key := decl_key('mymodules', files[1].stmts[0] as ast.FnDecl, env)
+
+	assert indices.len == 1
+	assert w.fns[indices[0]].key == target_key
+}
+
+fn test_minimal_runtime_roots_selective_import_add_fn_name_indices_flat() {
+	mut env := types.Environment.new()
+	files := selective_import_function_value_minimal_files()
+	flat := ast.flatten_files(files)
+	mut w := new_walker(files, env, MarkUsedOptions{
+		minimal_runtime_roots: true
+	})
+	w.collect_defs_from_flat(&flat)
+	w.cur_fn_file = files[0].name
+	mut indices := []int{}
+	w.add_fn_name_indices('add_xy', 'main', mut indices)
+	target_key := decl_key('mymodules', files[1].stmts[0] as ast.FnDecl, env)
+
+	assert indices.len == 1
+	assert w.fns[indices[0]].key == target_key
+}
+
 fn test_minimal_runtime_roots_keep_explicit_calls_only() {
 	mut env := types.Environment.new()
 	files := [
@@ -1034,6 +1460,78 @@ fn test_minimal_runtime_roots_keep_array_push_noscan_wrapper() {
 	assert used[push_key]
 }
 
+fn minimal_array_eq_runtime_dependency_files() []ast.File {
+	return [
+		ast.File{
+			mod:   'main'
+			name:  'array_eq_transformed.v'
+			stmts: [
+				ast.Stmt(ast.FnDecl{
+					name:  'main'
+					typ:   ast.FnType{}
+					pos:   minimal_pos(360)
+					stmts: [
+						ast.Stmt(ast.ExprStmt{
+							expr: ast.CallExpr{
+								lhs:  ast.Expr(minimal_ident('array__eq', 360))
+								args: [
+									ast.Expr(minimal_ident('path', 361)),
+									ast.Expr(minimal_ident('expected', 362)),
+								]
+								pos:  minimal_pos(363)
+							}
+						}),
+					]
+				}),
+			]
+		},
+		ast.File{
+			mod:   'builtin'
+			name:  'vlib/builtin/map.v'
+			stmts: [
+				ast.Stmt(ast.FnDecl{
+					name: 'map_map_eq'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(364)
+				}),
+				ast.Stmt(ast.FnDecl{
+					name: 'map_clone_string'
+					typ:  ast.FnType{}
+					pos:  minimal_pos(365)
+				}),
+			]
+		},
+	]
+}
+
+fn minimal_array_eq_runtime_dependency_env() &types.Environment {
+	return types.Environment.new()
+}
+
+fn test_minimal_runtime_roots_transformed_array_eq_keeps_map_map_eq_dependency_legacy() {
+	mut env := minimal_array_eq_runtime_dependency_env()
+	files := minimal_array_eq_runtime_dependency_files()
+	used := mark_used_with_options(files, env, MarkUsedOptions{
+		minimal_runtime_roots: true
+	})
+	map_map_eq_key := decl_key('builtin', files[1].stmts[0] as ast.FnDecl, env)
+	unused_key := decl_key('builtin', files[1].stmts[1] as ast.FnDecl, env)
+
+	assert used[map_map_eq_key]
+	assert !used[unused_key]
+}
+
+fn test_minimal_runtime_roots_transformed_array_eq_keeps_map_map_eq_dependency_flat() {
+	mut env := minimal_array_eq_runtime_dependency_env()
+	files := minimal_array_eq_runtime_dependency_files()
+	used := mark_used_flat_minimal(files, env)
+	map_map_eq_key := decl_key('builtin', files[1].stmts[0] as ast.FnDecl, env)
+	unused_key := decl_key('builtin', files[1].stmts[1] as ast.FnDecl, env)
+
+	assert used[map_map_eq_key]
+	assert !used[unused_key]
+}
+
 fn test_minimal_runtime_roots_do_not_seed_array_rune_string_helper_or_generic_array_methods() {
 	mut env := types.Environment.new()
 	array_rune_type := ast.Expr(ast.Type(ast.ArrayType{
@@ -1188,6 +1686,138 @@ fn test_minimal_runtime_roots_do_not_seed_array_rune_string_helper_or_generic_ar
 	assert !used[prepare_builder_key]
 	assert !used[unused_rune_helper_key]
 	assert !used[unused_builder_key]
+}
+
+fn array_rune_string_free_exact_target_files() []ast.File {
+	return [
+		ast.File{
+			mod:   'main'
+			name:  'main.v'
+			stmts: [
+				ast.Stmt(ast.FnDecl{
+					name:  'main'
+					typ:   ast.FnType{}
+					pos:   minimal_pos(500)
+					stmts: [
+						ast.Stmt(ast.ExprStmt{
+							expr: ast.CallExpr{
+								lhs: ast.Ident{
+									name: 'builtin__Array_rune__string'
+									pos:  minimal_pos(501)
+								}
+								pos: minimal_pos(501)
+							}
+						}),
+					]
+				}),
+			]
+		},
+		ast.File{
+			mod:   'builtin'
+			name:  'vlib/builtin/rune.v'
+			stmts: [
+				ast.Stmt(ast.FnDecl{
+					is_method: true
+					receiver:  ast.Parameter{
+						name: 'ra'
+						typ:  ast.Expr(ast.Type(ast.ArrayType{
+							elem_type: ast.Expr(ast.Ident{
+								name: 'rune'
+								pos:  minimal_pos(502)
+							})
+						}))
+						pos:  minimal_pos(503)
+					}
+					name:      'string'
+					typ:       ast.FnType{}
+					pos:       minimal_pos(504)
+					stmts:     [
+						ast.Stmt(ast.ExprStmt{
+							expr: ast.CallExpr{
+								lhs: ast.Ident{
+									name: 'strings__Builder__free'
+									pos:  minimal_pos(505)
+								}
+								pos: minimal_pos(505)
+							}
+						}),
+					]
+				}),
+				ast.Stmt(ast.FnDecl{
+					is_method: true
+					receiver:  ast.Parameter{
+						name: 'a'
+						typ:  ast.Expr(ast.Ident{
+							name: 'array'
+							pos:  minimal_pos(506)
+						})
+						pos:  minimal_pos(507)
+					}
+					name:      'free'
+					typ:       ast.FnType{}
+					pos:       minimal_pos(508)
+				}),
+			]
+		},
+		ast.File{
+			mod:   'strings'
+			name:  'vlib/strings/builder.v'
+			stmts: [
+				ast.Stmt(ast.StructDecl{
+					name: 'Builder'
+				}),
+				ast.Stmt(ast.FnDecl{
+					is_method: true
+					receiver:  ast.Parameter{
+						name: 'b'
+						typ:  ast.Expr(ast.SelectorExpr{
+							lhs: ast.Ident{
+								name: 'strings'
+								pos:  minimal_pos(509)
+							}
+							rhs: ast.Ident{
+								name: 'Builder'
+								pos:  minimal_pos(510)
+							}
+							pos: minimal_pos(509)
+						})
+						pos:  minimal_pos(511)
+					}
+					name:      'free'
+					typ:       ast.FnType{}
+					pos:       minimal_pos(512)
+				}),
+			]
+		},
+	]
+}
+
+fn assert_array_rune_string_marks_exact_builder_free(used map[string]bool, files []ast.File, env &types.Environment, label string) {
+	main_key := decl_key('main', files[0].stmts[0] as ast.FnDecl, env)
+	array_rune_string_key := decl_key('builtin', files[1].stmts[0] as ast.FnDecl, env)
+	array_free_key := decl_key('builtin', files[1].stmts[1] as ast.FnDecl, env)
+	builder_free_key := decl_key('strings', files[2].stmts[1] as ast.FnDecl, env)
+
+	assert used[main_key], '${label}: main root was not kept'
+	assert used[array_rune_string_key], '${label}: Array_rune.string was not reached'
+	assert used[builder_free_key], '${label}: exact strings__Builder__free target was pruned'
+	assert !used[array_free_key], '${label}: array__free alias replaced the exact Builder.free target'
+}
+
+fn test_minimal_runtime_roots_array_rune_string_keeps_exact_builder_free_legacy() {
+	mut env := types.Environment.new()
+	files := array_rune_string_free_exact_target_files()
+	used := mark_used_with_options(files, env, MarkUsedOptions{
+		minimal_runtime_roots: true
+	})
+	assert_array_rune_string_marks_exact_builder_free(used, files, env, 'legacy')
+}
+
+fn test_minimal_runtime_roots_array_rune_string_keeps_exact_builder_free_flat() {
+	mut env := types.Environment.new()
+	files := array_rune_string_free_exact_target_files()
+	used := mark_used_flat_minimal(files, env)
+	assert_array_rune_string_marks_exact_builder_free(used, files, env, 'flat')
 }
 
 fn test_minimal_runtime_roots_keep_synthesized_import_init_calls() {

--- a/vlib/v2/ssa/array_int_contract_test.v
+++ b/vlib/v2/ssa/array_int_contract_test.v
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module ssa
+
+import v2.ast
+import v2.types
+
+fn int_contract_num(value string) ast.Expr {
+	return ast.Expr(ast.BasicLiteral{
+		kind:  .number
+		value: value
+	})
+}
+
+fn int_contract_cast(type_name string, value string) ast.Expr {
+	return ast.Expr(ast.CallOrCastExpr{
+		lhs:  ast.Expr(ast.Ident{
+			name: type_name
+		})
+		expr: int_contract_num(value)
+	})
+}
+
+fn test_const_untyped_integer_array_serializes_as_dense_i32() {
+	mut mod := Module.new('array_int_contract')
+	env := types.Environment.new()
+	mut b := Builder.new_with_env(mod, env)
+	data := b.try_serialize_const_array(ast.ArrayInitExpr{
+		exprs: [int_contract_num('1'), int_contract_num('2'),
+			int_contract_num('3')]
+	})
+	assert data == [u8(1), 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]
+}
+
+fn test_const_explicit_i64_array_serializes_as_dense_i64() {
+	mut mod := Module.new('array_int_contract_i64')
+	env := types.Environment.new()
+	mut b := Builder.new_with_env(mod, env)
+	data := b.try_serialize_const_array(ast.ArrayInitExpr{
+		exprs: [int_contract_cast('i64', '1'), int_contract_cast('i64', '2')]
+	})
+	assert data == [u8(1), 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]
+}
+
+fn test_const_explicit_u8_array_serializes_as_dense_u8() {
+	mut mod := Module.new('array_int_contract_u8')
+	env := types.Environment.new()
+	mut b := Builder.new_with_env(mod, env)
+	data := b.try_serialize_const_array(ast.ArrayInitExpr{
+		exprs: [int_contract_cast('u8', '1'), int_contract_cast('u8', '2')]
+	})
+	assert data == [u8(1), 2]
+}
+
+fn test_const_explicit_rune_array_serializes_as_dense_i32() {
+	mut mod := Module.new('array_int_contract_rune')
+	env := types.Environment.new()
+	mut b := Builder.new_with_env(mod, env)
+	data := b.try_serialize_const_array(ast.ArrayInitExpr{
+		exprs: [int_contract_cast('rune', '65'), int_contract_cast('rune', '8364')]
+	})
+	assert data == [u8(65), 0, 0, 0, 172, 32, 0, 0]
+}

--- a/vlib/v2/ssa/build_array_init_from_flat_test.v
+++ b/vlib/v2/ssa/build_array_init_from_flat_test.v
@@ -12,10 +12,11 @@
 // using a `.typ_array` / `.typ_array_fixed` kind match (`edge(0)` / `edge(1)`
 // for elem_type) plus an `ast_type_to_ssa_from_flat` call; the fixed-array
 // marker check inspects `len_c.kind() == .expr_postfix` with `aux == .not`
-// (the `!` suffix) or `typ_c.kind() == .typ_array_fixed`. The `init`, `cap`,
-// and `update_expr` edges are never read — legacy `build_array_init_expr`
-// never consults them. Pin asserts module-count parity for the common literal
-// `[1, 2, 3]` path.
+// (the `!` suffix) or `typ_c.kind() == .typ_array_fixed`. Empty dynamic
+// arrays with explicit `len`/`cap` now read those edges and lower to the same
+// runtime allocation call as the legacy builder. Pin asserts module-count
+// parity for the common literal `[1, 2, 3]` path and the dynamic
+// `[]int{len: 3, cap: 5}` path.
 module ssa
 
 import v2.ast
@@ -32,6 +33,19 @@ fn ai_num(value string) ast.Expr {
 		kind:  .number
 		value: value
 	})
+}
+
+fn ai_array_type(elem ast.Expr) ast.Expr {
+	return ast.Expr(ast.Type(ast.ArrayType{
+		elem_type: elem
+	}))
+}
+
+fn ai_field(name string, typ string) ast.FieldDecl {
+	return ast.FieldDecl{
+		name: name
+		typ:  ai_ident(typ)
+	}
 }
 
 fn make_array_init_fixture() []ast.File {
@@ -58,6 +72,26 @@ fn make_array_init_fixture() []ast.File {
 			}),
 		]
 	})
+	// fn make_dynamic_arr() { a := []int{len: 3, cap: 5} _ = a }
+	stmts << ast.Stmt(ast.FnDecl{
+		name:  'make_dynamic_arr'
+		typ:   ast.FnType{
+			return_type: ast.empty_expr
+		}
+		stmts: [
+			ast.Stmt(ast.AssignStmt{
+				op:  .decl_assign
+				lhs: [ai_ident('a')]
+				rhs: [
+					ast.Expr(ast.ArrayInitExpr{
+						typ: ai_array_type(ai_ident('int'))
+						len: ai_num('3')
+						cap: ai_num('5')
+					}),
+				]
+			}),
+		]
+	})
 	return [
 		ast.File{
 			name:  'main.v'
@@ -65,6 +99,77 @@ fn make_array_init_fixture() []ast.File {
 			stmts: stmts
 		},
 	]
+}
+
+fn make_dynamic_array_init_fixture() []ast.File {
+	builtin_file := ast.File{
+		name:  'builtin.v'
+		mod:   'builtin'
+		stmts: [
+			ast.Stmt(ast.ModuleStmt{
+				name: 'builtin'
+			}),
+			ast.Stmt(ast.StructDecl{
+				name:   'array'
+				fields: [
+					ai_field('data', 'voidptr'),
+					ai_field('offset', 'int'),
+					ai_field('len', 'int'),
+					ai_field('cap', 'int'),
+					ai_field('flags', 'int'),
+					ai_field('element_size', 'int'),
+				]
+			}),
+			ast.Stmt(ast.FnDecl{
+				name:     'builtin____new_array_noscan'
+				language: .c
+				typ:      ast.FnType{
+					params:      [
+						ast.Parameter{
+							name: 'len'
+							typ:  ai_ident('int')
+						},
+						ast.Parameter{
+							name: 'cap'
+							typ:  ai_ident('int')
+						},
+						ast.Parameter{
+							name: 'elem_size'
+							typ:  ai_ident('int')
+						},
+					]
+					return_type: ai_ident('array')
+				}
+			}),
+		]
+	}
+	main_file := ast.File{
+		name:  'main.v'
+		mod:   'main'
+		stmts: [
+			ast.Stmt(ast.ModuleStmt{
+				name: 'main'
+			}),
+			ast.Stmt(ast.FnDecl{
+				name:  'make_dynamic'
+				typ:   ast.FnType{
+					return_type: ai_array_type(ai_ident('int'))
+				}
+				stmts: [
+					ast.Stmt(ast.ReturnStmt{
+						exprs: [
+							ast.Expr(ast.ArrayInitExpr{
+								typ: ai_array_type(ai_ident('int'))
+								len: ai_num('3')
+								cap: ai_num('5')
+							}),
+						]
+					}),
+				]
+			}),
+		]
+	}
+	return [builtin_file, main_file]
 }
 
 fn build_via_legacy_array_init(files []ast.File, env &types.Environment, name string) &Module {
@@ -84,6 +189,58 @@ fn build_via_flat_array_init(files []ast.File, env &types.Environment, name stri
 	return mod
 }
 
+fn build_all_via_legacy_array_init(files []ast.File, env &types.Environment, name string) &Module {
+	mut mod := Module.new(name)
+	mut b := Builder.new_with_env(mod, env)
+	b.minimal_runtime_roots = true
+	b.build_all(files)
+	return mod
+}
+
+fn build_all_via_flat_array_init(files []ast.File, env &types.Environment, name string) &Module {
+	flat := ast.flatten_files(files)
+	mut mod := Module.new(name)
+	mut b := Builder.new_with_env(mod, env)
+	b.minimal_runtime_roots = true
+	b.build_all_from_flat(&flat)
+	return mod
+}
+
+fn ai_call_operands(m &Module, func_name string, callee_name string) []ValueID {
+	for func in m.funcs {
+		if func.name != func_name {
+			continue
+		}
+		for block_id in func.blocks {
+			for value_id in m.blocks[block_id].instrs {
+				value := m.values[value_id]
+				if value.kind != .instruction {
+					continue
+				}
+				instr := m.instrs[value.index]
+				if instr.op != .call || instr.operands.len == 0 {
+					continue
+				}
+				callee_id := instr.operands[0]
+				if callee_id > 0 && callee_id < m.values.len
+					&& m.values[callee_id].name == callee_name {
+					return instr.operands
+				}
+			}
+		}
+	}
+	assert false, 'missing call to ${callee_name} in ${func_name}'
+	return []ValueID{}
+}
+
+fn ai_assert_dynamic_array_operands(m &Module) {
+	operands := ai_call_operands(m, 'make_dynamic', 'builtin____new_array_noscan')
+	assert operands.len == 4
+	assert m.values[operands[1]].name == '3'
+	assert m.values[operands[2]].name == '5'
+	assert m.values[operands[3]].name == '4'
+}
+
 fn test_build_array_init_from_flat_matches_legacy() {
 	files := make_array_init_fixture()
 	env := types.Environment.new()
@@ -94,4 +251,14 @@ fn test_build_array_init_from_flat_matches_legacy() {
 	assert mod_legacy.blocks.len == mod_flat.blocks.len
 	assert mod_legacy.instrs.len == mod_flat.instrs.len
 	assert mod_legacy.values.len == mod_flat.values.len
+}
+
+fn test_build_array_init_from_flat_dynamic_len_cap_operands_match_legacy() {
+	files := make_dynamic_array_init_fixture()
+	env := types.Environment.new()
+	mod_legacy := build_all_via_legacy_array_init(files, env, 'array_init_dynamic_legacy')
+	mod_flat := build_all_via_flat_array_init(files, env, 'array_init_dynamic_flat')
+
+	ai_assert_dynamic_array_operands(mod_legacy)
+	ai_assert_dynamic_array_operands(mod_flat)
 }

--- a/vlib/v2/ssa/builder.v
+++ b/vlib/v2/ssa/builder.v
@@ -136,6 +136,18 @@ struct SelectorAddr {
 	base_type TypeID
 }
 
+struct MatchExprIncoming {
+	value ValueID
+	block BlockID
+}
+
+struct MatchSumtypeBranchInfo {
+	tag          int
+	variant_type TypeID
+}
+
+const unsupported_captured_fn_literal_symbol = 'v2_unsupported_captured_fn_literal'
+
 pub struct Builder {
 pub mut:
 	mod        &Module
@@ -176,11 +188,14 @@ mut:
 	// Enum name -> field values
 	enum_values map[string]int
 	// Function name -> SSA function index
-	fn_index map[string]int
+	fn_index        map[string]int
+	module_fn_names map[string]string
 	// Function name -> dynamic array element type by argument index.
 	fn_param_array_elem_types map[string][]TypeID
 	// Function name -> SSA func_ref value
 	fn_refs map[string]ValueID
+	// Current file's selective imports: short symbol name -> mangled function name.
+	selective_import_fn_names map[string]string
 	// Global variable name -> SSA global value
 	global_refs map[string]ValueID
 	// Constant name -> evaluated integer value (for inlining)
@@ -222,6 +237,9 @@ mut:
 	struct_field_array_elem_types map[string]TypeID
 	// Expected element type for the array literal currently being built.
 	array_literal_elem_type_hint TypeID
+	// Current array literal is a temporary element buffer for a voidptr argument
+	// such as array.push_noscan, not a dynamic array value.
+	array_literal_as_element_buffer bool
 }
 
 struct LoopInfo {
@@ -242,8 +260,10 @@ pub fn Builder.new_with_env(mod &Module, env &types.Environment) &Builder {
 		type_aliases:                  map[string]TypeID{}
 		enum_values:                   map[string]int{}
 		fn_index:                      map[string]int{}
+		module_fn_names:               map[string]string{}
 		fn_param_array_elem_types:     map[string][]TypeID{}
 		fn_refs:                       map[string]ValueID{}
+		selective_import_fn_names:     map[string]string{}
 		global_refs:                   map[string]ValueID{}
 		option_wrapper_types:          map[string]TypeID{}
 		result_wrapper_types:          map[string]TypeID{}
@@ -277,6 +297,8 @@ pub fn (mut b Builder) new_worker_clone(worker_mod &Module, worker_idx int) &Bui
 		type_aliases:                    b.type_aliases.clone()
 		enum_values:                     b.enum_values.clone()
 		fn_index:                        b.fn_index.clone()
+		module_fn_names:                 b.module_fn_names.clone()
+		selective_import_fn_names:       b.selective_import_fn_names.clone()
 		fn_param_array_elem_types:       b.fn_param_array_elem_types.clone()
 		global_refs:                     b.global_refs.clone()
 		const_values:                    b.const_values.clone()
@@ -299,6 +321,62 @@ pub fn (mut b Builder) new_worker_clone(worker_mod &Module, worker_idx int) &Bui
 		mut_ptr_params:   map[string]bool{}
 		local_smartcasts: map[string]TypeID{}
 	}
+}
+
+pub fn imported_symbol_fn_name(module_name string, name string) string {
+	if module_name == '' || module_name == 'main' {
+		return name
+	}
+	return '${module_name}__${name}'
+}
+
+fn import_module_name(imp ast.ImportStmt) string {
+	return if imp.is_aliased { imp.name.all_after_last('.') } else { imp.alias }
+}
+
+pub fn selective_import_fn_names_from_imports(imports []ast.ImportStmt) map[string]string {
+	mut names := map[string]string{}
+	for imp in imports {
+		if imp.symbols.len == 0 {
+			continue
+		}
+		module_name := import_module_name(imp)
+		for symbol in imp.symbols {
+			if symbol is ast.Ident {
+				names[symbol.name] = imported_symbol_fn_name(module_name, symbol.name)
+			}
+		}
+	}
+	return names
+}
+
+fn (b &Builder) selective_import_fn_name(name string) ?string {
+	if imported := b.selective_import_fn_names[name] {
+		if imported in b.fn_index {
+			return imported
+		}
+	}
+	return none
+}
+
+fn module_fn_key(module_name string, name string) string {
+	return '${module_name}:${name}'
+}
+
+fn (b &Builder) current_module_fn_name(name string) ?string {
+	if name == '' {
+		return none
+	}
+	if target := b.module_fn_names[module_fn_key(b.cur_module, name)] {
+		if target in b.fn_index {
+			return target
+		}
+	}
+	return none
+}
+
+pub fn (mut b Builder) set_selective_import_fn_names(names map[string]string) {
+	b.selective_import_fn_names = names.clone()
 }
 
 pub fn (mut b Builder) build_all(files []ast.File) {
@@ -399,6 +477,7 @@ pub fn (mut b Builder) build_all(files []ast.File) {
 	if !b.skip_fn_bodies {
 		b.build_all_fn_bodies(files)
 	}
+	b.generate_referenced_synthetic_runtime_stubs()
 
 	// Phase 5: Generate _vinit for dynamic array constant initialization
 	// Always generate _vinit (even if empty) so the symbol is always resolvable
@@ -537,11 +616,65 @@ pub fn (mut b Builder) build_all_from_flat(flat &ast.FlatAst) {
 			b.build_fn_bodies_from_flat(fc)
 		}
 	}
+	b.generate_referenced_synthetic_runtime_stubs()
 
 	// Phase 5: Generate _vinit for dynamic array constant initialization
 	if b.hot_fn.len == 0 && !b.skip_fn_bodies {
 		b.generate_vinit()
 	}
+}
+
+// generate_referenced_synthetic_runtime_stubs materializes native-only helpers
+// that are referenced after transformation or minimal-runtime pruning.
+pub fn (mut b Builder) generate_referenced_synthetic_runtime_stubs() {
+	if b.hot_fn.len != 0 || b.skip_fn_bodies {
+		return
+	}
+	referenced := b.referenced_func_ref_names()
+	if referenced['builtin__string__plus_two'] {
+		b.generate_string_plus_two_stub()
+	}
+	if !b.minimal_runtime_roots {
+		return
+	}
+	if referenced['array__eq'] {
+		b.generate_array_eq_stub()
+	}
+	if referenced['_wymix'] {
+		b.generate_wymix_stub()
+	}
+	if referenced['wyhash64'] {
+		b.generate_wyhash64_stub()
+	}
+	if referenced['wyhash'] {
+		b.generate_wyhash_stub()
+	}
+	if referenced['IError__msg'] || referenced['IError__code'] || referenced['IError__type_name'] {
+		b.generate_ierror_stubs()
+	}
+	if referenced['FD_ZERO'] || referenced['FD_SET'] || referenced['FD_ISSET'] {
+		b.generate_fd_macro_stubs()
+	}
+}
+
+fn (b &Builder) referenced_func_ref_names() map[string]bool {
+	mut names := map[string]bool{}
+	for val in b.mod.values {
+		if val.kind != .instruction {
+			continue
+		}
+		instr := b.mod.instrs[val.index]
+		for operand in instr.operands {
+			if operand <= 0 || operand >= b.mod.values.len {
+				continue
+			}
+			ref := b.mod.values[operand]
+			if ref.kind == .func_ref && ref.name != '' {
+				names[ref.name] = true
+			}
+		}
+	}
+	return names
 }
 
 // build_all_fn_bodies builds SSA for all function bodies (Phase 4).
@@ -572,7 +705,7 @@ fn ssa_string_ok(s string) bool {
 		return false
 	}
 	ptr := unsafe { u64(s.str) }
-	return ptr >= 0x100000000 && ptr < 0x0000800000000000
+	return ptr >= 0x10000 && ptr < 0x0000800000000000
 }
 
 fn ssa_module_tail_name(name string) string {
@@ -586,6 +719,14 @@ fn ssa_module_tail_name(name string) string {
 		return name.all_after_last('_')
 	}
 	return name
+}
+
+fn ssa_is_string_struct_name(name string) bool {
+	return name == 'string' || name == 'builtin__string'
+}
+
+fn ssa_is_string_str_fn_name(name string) bool {
+	return name == 'string__str' || name == 'builtin__string__str'
 }
 
 fn (b &Builder) valid_value_id(val ValueID) bool {
@@ -2874,8 +3015,8 @@ fn (mut b Builder) try_serialize_const_array(arr ast.ArrayInitExpr) []u8 {
 	if arr.exprs.len == 0 {
 		return []u8{}
 	}
-	// Determine element size and whether it's a float array from the first element's type hint
-	mut elem_size := 8 // default to 8 bytes (u64/i64)
+	// Untyped integer literals default to V `int`, which is 32-bit.
+	mut elem_size := 4
 	mut is_float := false
 	// Check first element for type cast (e.g., u64(0x123), f64(0.5))
 	first := arr.exprs[0]
@@ -4174,6 +4315,9 @@ fn (mut b Builder) register_fn_sig(decl ast.FnDecl) {
 		}
 		return
 	}
+	if !decl.is_method && decl.language != .c && !is_generated_helper_fn_name(decl.name) {
+		b.module_fn_names[module_fn_key(b.cur_module, decl.name)] = fn_name
+	}
 
 	ret_type := b.ast_type_to_ssa(decl.typ.return_type)
 	idx := b.mod.new_function(fn_name, ret_type, []TypeID{})
@@ -4497,6 +4641,7 @@ fn (mut b Builder) receiver_type_name_from_flat(typ_c ast.Cursor) string {
 // --- Phase 3: Build function bodies ---
 
 pub fn (mut b Builder) build_fn_bodies(file ast.File) {
+	b.selective_import_fn_names = selective_import_fn_names_from_imports(file.imports)
 	nstmts := file.stmts.len
 	for si in 0 .. nstmts {
 		if file.stmts[si] is ast.FnDecl {
@@ -4531,6 +4676,8 @@ pub fn (mut b Builder) build_fn_bodies(file ast.File) {
 // this is the s185 wiring step that drops the last per-decl body decode.
 pub fn (mut b Builder) build_fn_bodies_from_flat(file_cursor ast.FileCursor) {
 	file_name := file_cursor.name()
+	b.selective_import_fn_names =
+		selective_import_fn_names_from_imports(file_cursor.flat.read_file_imports(file_cursor.flat_file()))
 	stmts := file_cursor.stmts()
 	for si in 0 .. stmts.len() {
 		c := stmts.at(si)
@@ -4711,6 +4858,9 @@ pub fn (mut b Builder) build_fn(decl ast.FnDecl) {
 			[]ValueID{})
 		b.mod.add_instr(.store, entry, 0, [param_val, alloca])
 		b.vars[param.name] = alloca
+		if param.is_mut && !is_already_ptr {
+			b.mut_ptr_params[param.name] = true
+		}
 
 		// Track array element types for transformer-generated functions (no checker info).
 		// E.g., param 'a' with type 'Array_int' → element type is 'int' → i32.
@@ -4847,6 +4997,9 @@ pub fn (mut b Builder) build_fn_from_flat(c ast.Cursor) {
 			[]ValueID{})
 		b.mod.add_instr(.store, entry, 0, [param_val, alloca])
 		b.vars[param_name] = alloca
+		if param_c.flag(ast.flag_is_mut) && !is_already_ptr {
+			b.mut_ptr_params[param_name] = true
+		}
 
 		if typ_c.kind() == .expr_ident {
 			param_type_name := typ_c.name()
@@ -5201,6 +5354,25 @@ fn (mut b Builder) unwrap_ident(expr ast.Expr) ?ast.Ident {
 	return none
 }
 
+fn (mut b Builder) assign_target_for_ident(name string) ValueID {
+	if p := b.vars[name] {
+		if name in b.mut_ptr_params {
+			ptr_typ := b.mod.values[p].typ
+			if b.valid_type_id(ptr_typ) {
+				elem_typ := b.mod.type_store.types[ptr_typ].elem_type
+				if elem_typ > 0 {
+					return b.mod.add_instr(.load, b.cur_block, elem_typ, [p])
+				}
+			}
+		}
+		return p
+	}
+	if glob_id := b.find_global_ident(name) {
+		return glob_id
+	}
+	return 0
+}
+
 fn (mut b Builder) build_assign(stmt ast.AssignStmt) {
 	// Multi-return decomposition: when LHS has more vars than RHS,
 	// the single RHS is a function call returning a tuple.
@@ -5246,12 +5418,7 @@ fn (mut b Builder) build_assign(stmt ast.AssignStmt) {
 				} else if ident.name == '_' {
 					continue
 				} else {
-					mut ptr := ValueID(0)
-					if p := b.vars[ident.name] {
-						ptr = p
-					} else if glob_id := b.find_global_ident(ident.name) {
-						ptr = glob_id
-					}
+					ptr := b.assign_target_for_ident(ident.name)
 					if ptr != 0 {
 						b.mod.add_instr(.store, b.cur_block, 0, [elem_val, ptr])
 					}
@@ -5276,12 +5443,7 @@ fn (mut b Builder) build_assign(stmt ast.AssignStmt) {
 				if ident.name == '_' {
 					continue
 				}
-				mut ptr := ValueID(0)
-				if p := b.vars[ident.name] {
-					ptr = p
-				} else if glob_id := b.find_global_ident(ident.name) {
-					ptr = glob_id
-				}
+				ptr := b.assign_target_for_ident(ident.name)
 				if ptr != 0 {
 					b.mod.add_instr(.store, b.cur_block, 0, [rhs_val, ptr])
 				}
@@ -5335,12 +5497,7 @@ fn (mut b Builder) build_assign(stmt ast.AssignStmt) {
 						continue
 					}
 				}
-				mut ptr := ValueID(0)
-				if p := b.vars[ident.name] {
-					ptr = p
-				} else if glob_id := b.find_global_ident(ident.name) {
-					ptr = glob_id
-				}
+				ptr := b.assign_target_for_ident(ident.name)
 				if ptr != 0 {
 					if stmt.op == .assign {
 						b.mod.add_instr(.store, b.cur_block, 0, [rhs_val, ptr])
@@ -5931,6 +6088,26 @@ fn (mut b Builder) smartcast_variant_type_ids_from_condition(cond ast.Expr) map[
 					smartcasts[expr_name] = tag_typ
 				}
 				return smartcasts
+			}
+			if cond.op == .eq {
+				if cond.rhs is ast.BasicLiteral && cond.rhs.kind == .number {
+					tag_typ2 := b.smartcast_variant_type_from_sumtype_tag(cond.lhs,
+						int(parse_const_int_literal(cond.rhs.value)))
+					expr_name := b.smartcast_expr_name(cond.lhs)
+					if tag_typ2 != 0 && expr_name != '' {
+						smartcasts[expr_name] = tag_typ2
+						return smartcasts
+					}
+				}
+				if cond.lhs is ast.BasicLiteral && cond.lhs.kind == .number {
+					tag_typ2 := b.smartcast_variant_type_from_sumtype_tag(cond.rhs,
+						int(parse_const_int_literal(cond.lhs.value)))
+					expr_name := b.smartcast_expr_name(cond.rhs)
+					if tag_typ2 != 0 && expr_name != '' {
+						smartcasts[expr_name] = tag_typ2
+						return smartcasts
+					}
+				}
 			}
 			if cond.op in [.key_is, .eq] {
 				expr_name := b.smartcast_expr_name(cond.lhs)
@@ -6533,7 +6710,114 @@ fn (mut b Builder) selector_module_name_from_flat(c ast.Cursor) ?string {
 		return none
 	}
 	mod_name := lhs_c.name()
-	return b.selector_module_name_for_ident(mod_name)
+	if resolved := b.selector_module_name_for_ident(mod_name) {
+		return resolved
+	}
+	rhs_c := c.edge(1)
+	if rhs_c.kind() == .expr_ident {
+		qualified := '${mod_name}__${rhs_c.name()}'
+		if qualified in b.fn_index {
+			return mod_name
+		}
+	}
+	return none
+}
+
+fn (mut b Builder) selector_type_name_to_ssa(mod_name string, type_name string) ?TypeID {
+	if mod_name == '' || type_name == '' || !ssa_string_ok(mod_name) || !ssa_string_ok(type_name) {
+		return none
+	}
+	normalized_mod := mod_name.replace('.', '_')
+	full_name := '${mod_name}.${type_name}'
+	if type_id := b.struct_types[full_name] {
+		return type_id
+	}
+	mod_qualified := '${normalized_mod}__${type_name}'
+	if type_id := b.struct_types[mod_qualified] {
+		return type_id
+	}
+	if alias_type := b.selector_type_alias_to_ssa(mod_name, type_name) {
+		return alias_type
+	}
+	if resolved_mod := b.selector_module_name_for_ident(mod_name) {
+		if alias_type := b.selector_type_alias_to_ssa(resolved_mod, type_name) {
+			return alias_type
+		}
+	}
+	if mod_name == 'C' {
+		cur_qualified := '${b.cur_module}__${type_name}'
+		if type_id := b.struct_types[cur_qualified] {
+			return type_id
+		}
+		for sname, sid in b.struct_types {
+			if sname.ends_with('__${type_name}') {
+				return sid
+			}
+		}
+	}
+	if b.is_enum_type(full_name) || b.is_enum_type(mod_qualified) {
+		return b.mod.type_store.get_int(32)
+	}
+	if b.env != unsafe { nil } {
+		if scope := b.env.get_scope(normalized_mod) {
+			if obj := scope.lookup_parent(type_name, 0) {
+				type_id := b.type_to_ssa(obj.typ())
+				if b.valid_type_id(type_id) {
+					return type_id
+				}
+			}
+		}
+	}
+	return none
+}
+
+fn (mut b Builder) call_or_cast_selector_should_remain_cast(sel ast.SelectorExpr, fn_name string) bool {
+	if sel.rhs.name == '' {
+		return false
+	}
+	if fn_name in b.fn_index {
+		if _ := b.selector_module_name(sel) {
+			return false
+		}
+	}
+	if target_type := b.call_lhs_type_to_ssa(sel) {
+		if b.valid_type_id(target_type) {
+			return true
+		}
+	}
+	if sel.lhs is ast.Ident {
+		if target_type := b.selector_type_name_to_ssa(sel.lhs.name, sel.rhs.name) {
+			if b.valid_type_id(target_type) {
+				return true
+			}
+		}
+	}
+	return looks_like_type_name(sel.rhs.name) && fn_name !in b.fn_index
+}
+
+fn (mut b Builder) call_or_cast_selector_should_remain_cast_from_flat(c ast.Cursor, fn_name string) bool {
+	if c.kind() != .expr_selector {
+		return false
+	}
+	if target_type := b.call_lhs_type_to_ssa_from_flat(c) {
+		if b.valid_type_id(target_type) {
+			return true
+		}
+	}
+	lhs_c := c.edge(0)
+	rhs_c := c.edge(1)
+	if rhs_c.kind() != .expr_ident {
+		return false
+	}
+	rhs_name := rhs_c.name()
+	if lhs_c.kind() == .expr_ident {
+		if target_type := b.selector_type_name_to_ssa(lhs_c.name(), rhs_name) {
+			if b.valid_type_id(target_type) {
+				return true
+			}
+		}
+	}
+	return looks_like_type_name(rhs_name) && fn_name !in b.fn_index
 }
 
 // static_receiver_type_name_from_flat (s219) cursor mirror of
@@ -7291,12 +7575,7 @@ fn (mut b Builder) build_assign_from_flat(c ast.Cursor) {
 				} else if ident_name == '_' {
 					continue
 				} else {
-					mut ptr := ValueID(0)
-					if p := b.vars[ident_name] {
-						ptr = p
-					} else if glob_id := b.find_global_ident(ident_name) {
-						ptr = glob_id
-					}
+					ptr := b.assign_target_for_ident(ident_name)
 					if ptr != 0 {
 						b.mod.add_instr(.store, b.cur_block, 0, [elem_val, ptr])
 					}
@@ -7321,12 +7600,7 @@ fn (mut b Builder) build_assign_from_flat(c ast.Cursor) {
 				if ident_name == '_' {
 					continue
 				}
-				mut ptr := ValueID(0)
-				if p := b.vars[ident_name] {
-					ptr = p
-				} else if glob_id := b.find_global_ident(ident_name) {
-					ptr = glob_id
-				}
+				ptr := b.assign_target_for_ident(ident_name)
 				if ptr != 0 {
 					b.mod.add_instr(.store, b.cur_block, 0, [rhs_val, ptr])
 				}
@@ -7367,12 +7641,7 @@ fn (mut b Builder) build_assign_from_flat(c ast.Cursor) {
 						continue
 					}
 				}
-				mut ptr := ValueID(0)
-				if p := b.vars[ident_name] {
-					ptr = p
-				} else if glob_id := b.find_global_ident(ident_name) {
-					ptr = glob_id
-				}
+				ptr := b.assign_target_for_ident(ident_name)
 				if ptr != 0 {
 					b.store_assign_to_ptr(ptr, rhs_val, op, true)
 				}
@@ -7629,8 +7898,7 @@ fn (mut b Builder) build_expr(expr ast.Expr) ValueID {
 			return b.build_string_inter_literal(expr)
 		}
 		ast.MatchExpr {
-			// Should be lowered by transformer
-			return b.mod.get_or_add_const(b.mod.type_store.get_int(32), '0')
+			return b.build_match_expr(expr)
 		}
 		ast.OrExpr {
 			return b.build_expr(expr.expr)
@@ -7722,6 +7990,13 @@ fn (mut b Builder) build_expr_from_flat(c ast.Cursor) ValueID {
 		.expr_string_inter {
 			return b.build_string_inter_from_flat(c)
 		}
+		.expr_match {
+			match_expr := c.flat.decode_expr(c.id)
+			if match_expr is ast.MatchExpr {
+				return b.build_match_expr(match_expr)
+			}
+			return b.mod.get_or_add_const(b.mod.type_store.get_int(32), '0')
+		}
 		.expr_or {
 			return b.build_or_from_flat(c)
 		}
@@ -7740,7 +8015,7 @@ fn (mut b Builder) build_expr_from_flat(c ast.Cursor) ValueID {
 		.expr_map_init, .expr_range, .expr_assoc {
 			return b.mod.get_or_add_const(b.mod.type_store.get_int(64), '0')
 		}
-		.expr_match, .expr_empty, .expr_if_guard, .expr_comptime, .expr_generic_arg_or_index,
+		.expr_empty, .expr_if_guard, .expr_comptime, .expr_generic_arg_or_index,
 		.expr_generic_args, .expr_lambda, .expr_lifetime, .expr_lock, .expr_select, .expr_sql {
 			return b.mod.get_or_add_const(b.mod.type_store.get_int(32), '0')
 		}
@@ -8502,6 +8777,71 @@ fn (mut b Builder) build_cast_from_flat(c ast.Cursor) ValueID {
 	return b.build_cast_value_to_type(val, target_type)
 }
 
+fn (b &Builder) const_int_value_id(val ValueID) ?i64 {
+	if val <= 0 || val >= b.mod.values.len {
+		return none
+	}
+	value := b.mod.values[val]
+	if value.kind != .constant || value.name == '' {
+		return none
+	}
+	first := value.name[0]
+	if first != `-` && (first < `0` || first > `9`) {
+		return none
+	}
+	return parse_const_int_literal(value.name)
+}
+
+fn (mut b Builder) build_sumtype_tag_compare(sum_val ValueID, tag_const_val ValueID, op token.Token) ?ValueID {
+	if op !in [.eq, .ne] || !b.valid_value_id(sum_val) || !b.valid_value_id(tag_const_val) {
+		return none
+	}
+	sum_type := b.mod.values[sum_val].typ
+	if !b.ssa_type_is_sumtype(sum_type) {
+		return none
+	}
+	tag := b.const_int_value_id(tag_const_val) or { return none }
+	sum_info := b.mod.type_store.types[sum_type]
+	i64_t := b.mod.type_store.get_int(64)
+	tag_type := if sum_info.fields.len > 0 { sum_info.fields[0] } else { i64_t }
+	tag_idx := b.mod.get_or_add_const(b.mod.type_store.get_int(32), '0')
+	tag_val := b.mod.add_instr(.extractvalue, b.cur_block, tag_type, [sum_val, tag_idx])
+	expected := b.mod.get_or_add_const(tag_type, tag.str())
+	bool_type := b.mod.type_store.get_int(1)
+	cmp_op := if op == .eq { OpCode.eq } else { OpCode.ne }
+	return b.mod.add_instr(cmp_op, b.cur_block, bool_type, [tag_val, expected])
+}
+
+fn (mut b Builder) build_sumtype_tag_compare_values(lhs ValueID, rhs ValueID, op token.Token) ?ValueID {
+	if cmp := b.build_sumtype_tag_compare(lhs, rhs, op) {
+		return cmp
+	}
+	if cmp := b.build_sumtype_tag_compare(rhs, lhs, op) {
+		return cmp
+	}
+	return none
+}
+
+fn (mut b Builder) build_sumtype_variant_compare_expr(sum_val ValueID, variant_expr ast.Expr, op token.Token) ?ValueID {
+	if op !in [.eq, .ne] || !b.valid_value_id(sum_val) {
+		return none
+	}
+	sum_type := b.mod.values[sum_val].typ
+	if !b.ssa_type_is_sumtype(sum_type) {
+		return none
+	}
+	info := b.match_sumtype_branch_info(sum_type, variant_expr) or { return none }
+	sum_info := b.mod.type_store.types[sum_type]
+	i64_t := b.mod.type_store.get_int(64)
+	tag_type := if sum_info.fields.len > 0 { sum_info.fields[0] } else { i64_t }
+	tag_idx := b.mod.get_or_add_const(b.mod.type_store.get_int(32), '0')
+	tag_val := b.mod.add_instr(.extractvalue, b.cur_block, tag_type, [sum_val, tag_idx])
+	expected := b.mod.get_or_add_const(tag_type, info.tag.str())
+	bool_type := b.mod.type_store.get_int(1)
+	cmp_op := if op == .eq { OpCode.eq } else { OpCode.ne }
+	return b.mod.add_instr(cmp_op, b.cur_block, bool_type, [tag_val, expected])
+}
+
 // build_infix_from_flat (s211) mirrors `build_infix` cursor-natively.
 // InfixExpr flat encoding (`flat.v:1956`) is
 // `(.expr_infix, pos, -1, -1, u16(op), 0, [edge0=lhs, edge1=rhs])`.
@@ -8570,8 +8910,19 @@ fn (mut b Builder) build_infix_from_flat(c ast.Cursor) ValueID {
 	}
 
 	lhs := b.build_expr_from_flat(lhs_c)
+	rhs_expr := rhs_c.flat.decode_expr(rhs_c.id)
+	if tag_cmp := b.build_sumtype_variant_compare_expr(lhs, rhs_expr, op) {
+		return tag_cmp
+	}
 	rhs := b.build_expr_from_flat(rhs_c)
+	lhs_expr := lhs_c.flat.decode_expr(lhs_c.id)
+	if tag_cmp := b.build_sumtype_variant_compare_expr(rhs, lhs_expr, op) {
+		return tag_cmp
+	}
 	result_type := b.expr_type_from_flat(c)
+	if tag_cmp := b.build_sumtype_tag_compare_values(lhs, rhs, op) {
+		return tag_cmp
+	}
 
 	// Option/Result comparison with none: x == none / x != none
 	if (op == .eq || op == .ne)
@@ -9362,9 +9713,127 @@ fn (mut b Builder) build_postfix_from_flat(c ast.Cursor) ValueID {
 	return b.build_expr_from_flat(inner_c)
 }
 
+fn (mut b Builder) array_bound_or_zero(val ValueID, int_type TypeID) ValueID {
+	zero := b.mod.get_or_add_const(int_type, '0')
+	if !b.valid_value_id(val) {
+		return zero
+	}
+	if b.mod.values[val].typ == int_type {
+		return val
+	}
+	return b.build_cast_value_to_type(val, int_type)
+}
+
+fn ssa_number_literal_is_float(value string) bool {
+	return value.contains('.')
+		|| (!value.starts_with('0x') && !value.starts_with('0X')
+		&& (value.contains('e') || value.contains('E')))
+}
+
+fn (b &Builder) array_literal_value_type_can_infer_elem(expr ast.Expr, val ValueID) bool {
+	if !b.valid_value_id(val) {
+		return false
+	}
+	if expr is ast.BasicLiteral && expr.kind == .number && !ssa_number_literal_is_float(expr.value) {
+		return false
+	}
+	return true
+}
+
+fn (b &Builder) array_literal_flat_value_type_can_infer_elem(c ast.Cursor, val ValueID) bool {
+	if !b.valid_value_id(val) {
+		return false
+	}
+	if c.kind() == .expr_basic_literal {
+		expr := c.flat.decode_expr(c.id)
+		if expr is ast.BasicLiteral && expr.kind == .number
+			&& !ssa_number_literal_is_float(expr.value) {
+			return false
+		}
+	}
+	return true
+}
+
+fn (mut b Builder) build_dynamic_array_from_element_buffer(elem_type TypeID, elem_vals []ValueID, buffer ValueID) ValueID {
+	arr_type := b.get_array_type()
+	if arr_type == 0 {
+		return b.mod.get_or_add_const(arr_type, '0')
+	}
+	i32_t := b.mod.type_store.get_int(32)
+	len_arg := b.mod.get_or_add_const(i32_t, elem_vals.len.str())
+	mut elem_size := b.type_byte_size(elem_type)
+	if elem_size <= 0 {
+		elem_size = 8
+	}
+	elem_size_arg := b.mod.get_or_add_const(i32_t, elem_size.str())
+	i8_t := b.mod.type_store.get_int(8)
+	voidptr_t := b.mod.type_store.get_ptr(i8_t)
+	buffer_arg := if b.valid_value_id(buffer) && b.mod.values[buffer].typ == voidptr_t {
+		buffer
+	} else {
+		b.mod.add_instr(.bitcast, b.cur_block, voidptr_t, [buffer])
+	}
+	fn_name := if 'builtin__new_array_from_c_array_noscan' in b.fn_index {
+		'builtin__new_array_from_c_array_noscan'
+	} else {
+		'new_array_from_c_array_noscan'
+	}
+	fn_ref := b.get_or_create_fn_ref(fn_name, arr_type)
+	call_val := b.mod.add_instr(.call, b.cur_block, arr_type, [
+		fn_ref,
+		len_arg,
+		len_arg,
+		elem_size_arg,
+		buffer_arg,
+	])
+	b.array_value_elem_types[call_val] = elem_type
+	return call_val
+}
+
+fn (mut b Builder) build_empty_dynamic_array(elem_type_in TypeID, len_val ValueID, cap_val ValueID) ValueID {
+	arr_type := b.get_array_type()
+	if arr_type == 0 {
+		return b.mod.get_or_add_const(arr_type, '0')
+	}
+	i32_t := b.mod.type_store.get_int(32)
+	elem_type := if b.valid_type_id(elem_type_in) {
+		elem_type_in
+	} else {
+		i32_t
+	}
+	len_arg := b.array_bound_or_zero(len_val, i32_t)
+	cap_arg := if b.valid_value_id(cap_val) {
+		b.array_bound_or_zero(cap_val, i32_t)
+	} else {
+		len_arg
+	}
+	mut elem_size := b.type_byte_size(elem_type)
+	if elem_size <= 0 {
+		elem_size = 8
+	}
+	elem_size_arg := b.mod.get_or_add_const(i32_t, elem_size.str())
+	fn_name := if 'builtin____new_array_noscan' in b.fn_index {
+		'builtin____new_array_noscan'
+	} else {
+		'__new_array_noscan'
+	}
+	fn_ref := b.get_or_create_fn_ref(fn_name, arr_type)
+	call_val := b.mod.add_instr(.call, b.cur_block, arr_type, [
+		fn_ref,
+		len_arg,
+		cap_arg,
+		elem_size_arg,
+	])
+	b.array_value_elem_types[call_val] = elem_type
+	return call_val
+}
+
 fn (mut b Builder) build_array_init_from_flat(c ast.Cursor) ValueID {
 	typ_c := c.edge(0)
+	init_c := c.edge(1)
+	cap_c := c.edge(2)
 	len_c := c.edge(3)
+	update_c := c.edge(4)
 	nedges := c.edge_count()
 	array_elem_hint := b.array_literal_elem_type_hint
 	b.array_literal_elem_type_hint = 0
@@ -9421,8 +9890,8 @@ fn (mut b Builder) build_array_init_from_flat(c ast.Cursor) ValueID {
 			}
 		}
 		if !has_declared_type && elem_vals.len > 0 {
-			for val in elem_vals {
-				if b.valid_value_id(val) {
+			for i, val in elem_vals {
+				if b.array_literal_flat_value_type_can_infer_elem(c.edge(i + 5), val) {
 					elem_type = b.mod.values[val].typ
 					break
 				}
@@ -9499,7 +9968,10 @@ fn (mut b Builder) build_array_init_from_flat(c ast.Cursor) ValueID {
 		if is_fixed {
 			return b.mod.add_instr(.load, b.cur_block, arr_fixed_type, [alloca])
 		}
-		return alloca
+		if b.array_literal_as_element_buffer {
+			return alloca
+		}
+		return b.build_dynamic_array_from_element_buffer(elem_type, elem_vals, alloca)
 	}
 
 	if typ_c.kind() == .typ_array_fixed {
@@ -9530,6 +10002,25 @@ fn (mut b Builder) build_array_init_from_flat(c ast.Cursor) ValueID {
 			}
 			return b.mod.add_instr(.load, b.cur_block, arr_fixed_type, [alloca])
 		}
+	}
+
+	if typ_c.kind() == .typ_array && init_c.kind() == .expr_empty && update_c.kind() == .expr_empty {
+		elem_type := if array_elem_hint != 0 {
+			array_elem_hint
+		} else {
+			b.array_init_elem_type_from_flat(c)
+		}
+		len_val := if len_c.kind() == .expr_empty {
+			ValueID(0)
+		} else {
+			b.build_expr_from_flat(len_c)
+		}
+		cap_val := if cap_c.kind() == .expr_empty {
+			ValueID(0)
+		} else {
+			b.build_expr_from_flat(cap_c)
+		}
+		return b.build_empty_dynamic_array(elem_type, len_val, cap_val)
 	}
 
 	arr_type := b.get_array_type()
@@ -9639,9 +10130,12 @@ fn (mut b Builder) build_fn_literal_from_flat(c ast.Cursor) ValueID {
 	return_type_c := typ_c.edge(2)
 	ncaptured := c.extra_int()
 
+	if ncaptured > 0 {
+		return b.get_or_create_fn_ref(unsupported_captured_fn_literal_symbol, 0)
+	}
+
 	anon_name := '_anon_fn_${b.anon_fn_counter}'
 	b.anon_fn_counter++
-
 	ret_type := b.ast_type_to_ssa_from_flat(return_type_c)
 
 	func_idx := b.mod.new_function(anon_name, ret_type, []TypeID{})
@@ -9680,6 +10174,10 @@ fn (mut b Builder) build_fn_literal_from_flat(c ast.Cursor) ValueID {
 			[]ValueID{})
 		b.mod.add_instr(.store, entry, 0, [param_val, alloca])
 		b.vars[param_name] = alloca
+		if param_is_mut && !(param_type < b.mod.type_store.types.len
+			&& b.mod.type_store.types[param_type].kind == .ptr_t) {
+			b.mut_ptr_params[param_name] = true
+		}
 	}
 
 	for i in (1 + ncaptured) .. c.edge_count() {
@@ -9714,6 +10212,59 @@ fn (mut b Builder) build_fn_literal_from_flat(c ast.Cursor) ValueID {
 fn (mut b Builder) build_call_or_cast_from_flat(c ast.Cursor) ValueID {
 	lhs_c := c.edge(0)
 	expr_c := c.edge(1)
+	if lhs_c.kind() == .expr_ident {
+		name := lhs_c.name()
+		fn_name := b.resolve_call_name_ident_from_flat(lhs_c)
+		if fn_name in b.fn_index && !is_builtin_cast_type_name(name) && !b.known_type_name(name) {
+			lhs_expr := ast.Expr(ast.Ident{
+				name: name
+				pos:  lhs_c.pos()
+			})
+			args := if expr_c.kind() == .expr_empty {
+				[]ast.Expr{}
+			} else {
+				[expr_c.flat.decode_expr(expr_c.id)]
+			}
+			return b.build_call_resolved(fn_name, ast.CallExpr{
+				lhs:  lhs_expr
+				args: args
+				pos:  c.pos()
+			})
+		}
+	}
+	if lhs_c.kind() == .expr_selector {
+		fn_name := b.resolve_call_name_from_flat(lhs_c)
+		if mod_name := b.selector_module_name_from_flat(lhs_c) {
+			if (mod_name == 'C' || fn_name in b.fn_index)
+				&& !b.call_or_cast_selector_should_remain_cast_from_flat(lhs_c, fn_name) {
+				lhs_expr := lhs_c.flat.decode_expr(lhs_c.id)
+				args := if expr_c.kind() == .expr_empty {
+					[]ast.Expr{}
+				} else {
+					[expr_c.flat.decode_expr(expr_c.id)]
+				}
+				return b.build_call_resolved(fn_name, ast.CallExpr{
+					lhs:  lhs_expr
+					args: args
+					pos:  c.pos()
+				})
+			}
+		}
+		if fn_name in b.fn_index
+			&& !b.call_or_cast_selector_should_remain_cast_from_flat(lhs_c, fn_name) {
+			lhs_expr := lhs_c.flat.decode_expr(lhs_c.id)
+			args := if expr_c.kind() == .expr_empty {
+				[]ast.Expr{}
+			} else {
+				[expr_c.flat.decode_expr(expr_c.id)]
+			}
+			return b.build_call_resolved(fn_name, ast.CallExpr{
+				lhs:  lhs_expr
+				args: args
+				pos:  c.pos()
+			})
+		}
+	}
 	target_type := b.ast_type_to_ssa_from_flat(lhs_c)
 	addr := b.build_addr_from_flat(expr_c)
 	if addr != 0 {
@@ -10152,20 +10703,12 @@ fn (mut b Builder) prepare_snprintf_arg(val ValueID, fmt string) ValueID {
 
 fn (mut b Builder) convert_to_string(val ValueID, typ TypeID) ValueID {
 	str_type := b.get_string_type()
-	// If already a string, return as-is
-	if str_type != 0 && typ == str_type {
+	// If already a string, return as-is.
+	if b.is_string_struct_type(typ) {
 		return val
 	}
 	if val <= 0 || val >= b.mod.values.len || typ <= 0 || int(typ) >= b.mod.type_store.types.len {
 		return b.mod.add_value_node(.string_literal, str_type, '', 0)
-	}
-	// Also check if the type is a struct named 'string' (may have different ID)
-	tinfo := b.mod.type_store.types[typ]
-	if tinfo.kind == .struct_t {
-		// Check if this is the string struct by field count (str, len, is_lit)
-		if tinfo.fields.len == 3 || typ == str_type {
-			return val
-		}
 	}
 	// Determine the conversion function based on the type
 	type_info := b.mod.type_store.types[typ]
@@ -10190,8 +10733,52 @@ fn (mut b Builder) convert_to_string(val ValueID, typ TypeID) ValueID {
 		fn_ref := b.get_or_create_fn_ref(fn_name, str_type)
 		return b.mod.add_instr(.call, b.cur_block, str_type, [fn_ref, val])
 	}
+	if str_fn_name := b.str_fn_name_for_ssa_type(typ) {
+		fn_ref := b.get_or_create_fn_ref(str_fn_name, str_type)
+		return b.mod.add_instr(.call, b.cur_block, str_type, [fn_ref, val])
+	}
 	// Fallback: return empty string
 	return b.mod.add_value_node(.string_literal, str_type, '', 0)
+}
+
+fn (b &Builder) str_fn_name_for_ssa_type(typ TypeID) ?string {
+	if typ <= 0 || int(typ) >= b.mod.type_store.types.len {
+		return none
+	}
+	type_name := b.mod.c_struct_names[int(typ)] or { return none }
+	if type_name == '' || ssa_is_string_struct_name(type_name) {
+		return none
+	}
+	fn_name := '${type_name}__str'
+	if fn_name in b.fn_index {
+		return fn_name
+	}
+	if type_name.contains('__') {
+		short_name := type_name.all_after_last('__')
+		short_fn_name := '${short_name}__str'
+		if short_fn_name in b.fn_index {
+			return short_fn_name
+		}
+	}
+	return none
+}
+
+fn (b &Builder) is_string_struct_type(typ TypeID) bool {
+	str_type := b.struct_types['string'] or { TypeID(0) }
+	if str_type != 0 && typ == str_type {
+		return true
+	}
+	if typ <= 0 || int(typ) >= b.mod.type_store.types.len {
+		return false
+	}
+	if name := b.mod.c_struct_names[int(typ)] {
+		if ssa_is_string_struct_name(name) {
+			return true
+		}
+	}
+	tinfo := b.mod.type_store.types[typ]
+	return tinfo.kind == .struct_t && tinfo.field_names.len == 3 && tinfo.field_names[0] == 'str'
+		&& tinfo.field_names[1] == 'len' && tinfo.field_names[2] == 'is_lit'
 }
 
 fn (mut b Builder) build_ident(ident ast.Ident) ValueID {
@@ -10234,17 +10821,23 @@ fn (mut b Builder) build_ident(ident ast.Ident) ValueID {
 		}
 	}
 	// Try as function reference
+	qualified_name := '${b.cur_module}__${ident.name}'
+	if local_fn := b.current_module_fn_name(ident.name) {
+		return b.get_or_create_fn_ref(local_fn, 0)
+	}
+	if imported := b.selective_import_fn_name(ident.name) {
+		return b.get_or_create_fn_ref(imported, 0)
+	}
 	if ident.name in b.fn_index {
 		return b.get_or_create_fn_ref(ident.name, 0)
+	}
+	if qualified_name in b.fn_index {
+		return b.get_or_create_fn_ref(qualified_name, 0)
 	}
 	// Try with module prefix (transformer strips module prefix for builtin functions)
 	builtin_name := 'builtin__${ident.name}'
 	if builtin_name in b.fn_index {
 		return b.get_or_create_fn_ref(builtin_name, 0)
-	}
-	qualified_name := '${b.cur_module}__${ident.name}'
-	if qualified_name in b.fn_index {
-		return b.get_or_create_fn_ref(qualified_name, 0)
 	}
 	// Try as float constant (inline as f64)
 	if fval := b.float_const_values[ident.name] {
@@ -10449,8 +11042,17 @@ fn (mut b Builder) build_infix(expr ast.InfixExpr) ValueID {
 	}
 
 	lhs := b.build_expr(expr.lhs)
+	if tag_cmp := b.build_sumtype_variant_compare_expr(lhs, expr.rhs, expr.op) {
+		return tag_cmp
+	}
 	rhs := b.build_expr(expr.rhs)
+	if tag_cmp := b.build_sumtype_variant_compare_expr(rhs, expr.lhs, expr.op) {
+		return tag_cmp
+	}
 	result_type := b.expr_type(ast.Expr(expr))
+	if tag_cmp := b.build_sumtype_tag_compare_values(lhs, rhs, expr.op) {
+		return tag_cmp
+	}
 	// Handle Option/Result comparison with none: x == none / x != none
 	// Compare the state field (field 0) with 0 (success state) instead of
 	// doing a whole-struct comparison with an integer.
@@ -11194,12 +11796,43 @@ fn (mut b Builder) array_elem_type_from_new_array_call_from_flat(fn_name string,
 
 fn (mut b Builder) build_call_arg(fn_name string, param_idx int, arg ast.Expr) ValueID {
 	old_hint := b.array_literal_elem_type_hint
+	old_as_element_buffer := b.array_literal_as_element_buffer
+	is_map_init_buffer_arg := param_idx in [7, 8]
+		&& fn_name in ['new_map_init_noscan_value', 'builtin__new_map_init_noscan_value']
 	if elem_type := b.call_param_array_elem_type(fn_name, param_idx) {
 		b.array_literal_elem_type_hint = elem_type
 	}
-	val := b.build_expr(arg)
+	if param_idx == 1
+		&& fn_name in ['array__push_noscan', 'builtin__array__push_noscan', 'builtin__array_push_noscan'] {
+		b.array_literal_as_element_buffer = true
+	}
+	if param_idx == 3
+		&& fn_name in ['new_array_from_c_array', 'builtin__new_array_from_c_array', 'new_array_from_c_array_noscan', 'builtin__new_array_from_c_array_noscan'] {
+		b.array_literal_as_element_buffer = true
+	}
+	if is_map_init_buffer_arg {
+		b.array_literal_as_element_buffer = true
+	}
+	mut val := b.build_expr(arg)
 	b.array_literal_elem_type_hint = old_hint
+	b.array_literal_as_element_buffer = old_as_element_buffer
+	if is_map_init_buffer_arg {
+		val = b.dynamic_array_data_pointer_if_value(val)
+	}
 	return val
+}
+
+fn (mut b Builder) dynamic_array_data_pointer_if_value(val ValueID) ValueID {
+	if !b.valid_value_id(val) || b.get_array_type() == 0 {
+		return val
+	}
+	if b.mod.values[val].typ != b.get_array_type() {
+		return val
+	}
+	i8_t := b.mod.type_store.get_int(8)
+	void_ptr := b.mod.type_store.get_ptr(i8_t)
+	idx0 := b.mod.get_or_add_const(b.mod.type_store.get_int(32), '0')
+	return b.mod.add_instr(.extractvalue, b.cur_block, void_ptr, [val, idx0])
 }
 
 // build_call_arg_from_flat (s225) is the cursor-native mirror of build_call_arg:
@@ -11209,11 +11842,29 @@ fn (mut b Builder) build_call_arg(fn_name string, param_idx int, arg ast.Expr) V
 // produces the same ValueID as build_expr(decode_expr(arg_c)) (the migration invariant).
 fn (mut b Builder) build_call_arg_from_flat(fn_name string, param_idx int, arg_c ast.Cursor) ValueID {
 	old_hint := b.array_literal_elem_type_hint
+	old_as_element_buffer := b.array_literal_as_element_buffer
+	is_map_init_buffer_arg := param_idx in [7, 8]
+		&& fn_name in ['new_map_init_noscan_value', 'builtin__new_map_init_noscan_value']
 	if elem_type := b.call_param_array_elem_type(fn_name, param_idx) {
 		b.array_literal_elem_type_hint = elem_type
 	}
-	val := b.build_expr_from_flat(arg_c)
+	if param_idx == 1
+		&& fn_name in ['array__push_noscan', 'builtin__array__push_noscan', 'builtin__array_push_noscan'] {
+		b.array_literal_as_element_buffer = true
+	}
+	if param_idx == 3
+		&& fn_name in ['new_array_from_c_array', 'builtin__new_array_from_c_array', 'new_array_from_c_array_noscan', 'builtin__new_array_from_c_array_noscan'] {
+		b.array_literal_as_element_buffer = true
+	}
+	if is_map_init_buffer_arg {
+		b.array_literal_as_element_buffer = true
+	}
+	mut val := b.build_expr_from_flat(arg_c)
 	b.array_literal_elem_type_hint = old_hint
+	b.array_literal_as_element_buffer = old_as_element_buffer
+	if is_map_init_buffer_arg {
+		val = b.dynamic_array_data_pointer_if_value(val)
+	}
 	return val
 }
 
@@ -11259,6 +11910,13 @@ fn (mut b Builder) build_call_resolved(fn_name_in string, expr ast.CallExpr) Val
 		}
 		if target_type := b.call_lhs_type_to_ssa(expr.lhs) {
 			return b.build_cast_expr_to_type_id(expr.args[0], target_type)
+		}
+	}
+
+	if ssa_is_string_str_fn_name(fn_name) && expr.args.len == 1 {
+		arg_type := b.expr_type(expr.args[0])
+		if b.is_string_struct_type(arg_type) {
+			return b.build_expr(expr.args[0])
 		}
 	}
 
@@ -11357,24 +12015,33 @@ fn (mut b Builder) build_call_resolved(fn_name_in string, expr ast.CallExpr) Val
 				}
 			}
 			mut receiver := if expects_ptr {
-				// Mut receiver: pass address (pointer to struct)
-				addr := b.build_addr(sel.lhs)
-				if addr != 0 {
-					// build_addr for an Ident returns the alloca.
-					// For a mut receiver variable, the alloca is ptr(ptr(Struct)),
-					// storing the struct pointer. We need to load from the alloca
-					// to get the actual struct pointer ptr(Struct).
-					addr_typ := b.mod.values[addr].typ
-					if addr_typ < b.mod.type_store.types.len
-						&& b.mod.type_store.types[addr_typ].kind == .ptr_t {
-						inner := b.mod.type_store.types[addr_typ].elem_type
-						if inner < b.mod.type_store.types.len
-							&& b.mod.type_store.types[inner].kind == .ptr_t {
-							pointee := b.mod.type_store.types[inner].elem_type
-							if pointee < b.mod.type_store.types.len
-								&& b.mod.type_store.types[pointee].kind == .struct_t {
-								// addr is ptr(ptr(Struct)) — load to get ptr(Struct)
-								b.mod.add_instr(.load, b.cur_block, inner, [addr])
+				receiver_val := b.build_expr(sel.lhs)
+				receiver_typ := b.mod.values[receiver_val].typ
+				expected_receiver_typ := b.call_param_type(fn_name, 0) or { TypeID(0) }
+				if expected_receiver_typ != 0 && receiver_typ == expected_receiver_typ {
+					receiver_val
+				} else {
+					// Mut receiver: pass address (pointer to struct/array).
+					addr := b.build_addr(sel.lhs)
+					if addr != 0 {
+						// build_addr for an Ident returns the alloca.
+						// For a mut receiver variable, the alloca is ptr(ptr(Struct)),
+						// storing the struct pointer. We need to load from the alloca
+						// to get the actual struct pointer ptr(Struct).
+						addr_typ := b.mod.values[addr].typ
+						if addr_typ < b.mod.type_store.types.len
+							&& b.mod.type_store.types[addr_typ].kind == .ptr_t {
+							inner := b.mod.type_store.types[addr_typ].elem_type
+							if inner < b.mod.type_store.types.len
+								&& b.mod.type_store.types[inner].kind == .ptr_t {
+								pointee := b.mod.type_store.types[inner].elem_type
+								if pointee < b.mod.type_store.types.len
+									&& b.mod.type_store.types[pointee].kind == .struct_t {
+									// addr is ptr(ptr(Struct)) — load to get ptr(Struct)
+									b.mod.add_instr(.load, b.cur_block, inner, [addr])
+								} else {
+									addr
+								}
 							} else {
 								addr
 							}
@@ -11382,10 +12049,8 @@ fn (mut b Builder) build_call_resolved(fn_name_in string, expr ast.CallExpr) Val
 							addr
 						}
 					} else {
-						addr
+						receiver_val
 					}
-				} else {
-					b.build_expr(sel.lhs)
 				}
 			} else {
 				b.build_expr(sel.lhs)
@@ -11544,10 +12209,20 @@ fn (mut b Builder) build_call_resolved(fn_name_in string, expr ast.CallExpr) Val
 	if fn_name in b.fn_index {
 		for ai := 0; ai < args.len; ai++ {
 			param_type := b.call_param_type(fn_name, ai) or { continue }
-			arg_type := b.mod.values[args[ai]].typ
+			mut arg_type := b.mod.values[args[ai]].typ
 			if arg_type < b.mod.type_store.types.len && param_type < b.mod.type_store.types.len {
-				arg_kind := b.mod.type_store.types[arg_type].kind
+				mut arg_kind := b.mod.type_store.types[arg_type].kind
 				param_kind := b.mod.type_store.types[param_type].kind
+				// Variant value passed to a sumtype parameter: materialize the canonical
+				// sumtype wrapper so callees can read _tag/_data reliably.
+				if arg_kind == .struct_t && param_kind == .struct_t && arg_type != param_type
+					&& b.ssa_type_is_sumtype(param_type) {
+					if wrapped := b.wrap_value_for_sumtype_target(args[ai], param_type) {
+						args[ai] = wrapped
+						arg_type = param_type
+						arg_kind = .struct_t
+					}
+				}
 				// Pointer arg but value param: auto-deref
 				// Only auto-deref when the pointee is a struct and the
 				// parameter expects that struct value. Do NOT deref raw
@@ -12683,15 +13358,19 @@ fn (mut b Builder) resolve_method_name_for_value(val ValueID, method_name string
 // `resolve_call_name_ident_from_flat` (s216) delegate here so they stay
 // bit-identical. No AST traversal; pure string + map lookups.
 fn (b &Builder) resolve_call_name_for_ident_name(name string) string {
-	// Try module-qualified FIRST to avoid shadowing by C functions.
-	// E.g., os.getenv() should resolve to os__getenv, not C.getenv.
-	qualified := '${b.cur_module}__${name}'
-	if qualified in b.fn_index {
-		return qualified
+	if local_fn := b.current_module_fn_name(name) {
+		return local_fn
+	}
+	if imported := b.selective_import_fn_name(name) {
+		return imported
 	}
 	// Check if it's a known function
 	if name in b.fn_index {
 		return name
+	}
+	qualified := '${b.cur_module}__${name}'
+	if qualified in b.fn_index {
+		return qualified
 	}
 	// Try builtin-qualified (transformer remaps builtin__X to X)
 	builtin_qualified := 'builtin__${name}'
@@ -14774,6 +15453,422 @@ fn (mut b Builder) build_if_expr(node ast.IfExpr) ValueID {
 	return b.mod.add_instr(.phi, merge_block, phi_type, phi_operands)
 }
 
+fn match_expr_bool_literal(expr ast.Expr) ?bool {
+	match expr {
+		ast.BasicLiteral {
+			if expr.kind == .key_true {
+				return true
+			}
+			if expr.kind == .key_false {
+				return false
+			}
+		}
+		ast.Keyword {
+			if expr.tok == .key_true {
+				return true
+			}
+			if expr.tok == .key_false {
+				return false
+			}
+		}
+		ast.ParenExpr {
+			return match_expr_bool_literal(expr.expr)
+		}
+		else {}
+	}
+
+	return none
+}
+
+fn match_bool_branch_cond_expr(conds []ast.Expr, match_value bool) ast.Expr {
+	mut branch_cond := ast.Expr(ast.empty_expr)
+	for cond in conds {
+		mut single_cond := cond
+		if !match_value {
+			single_cond = ast.Expr(ast.PrefixExpr{
+				op:   .not
+				expr: cond
+				pos:  cond.pos()
+			})
+		}
+		if branch_cond is ast.EmptyExpr {
+			branch_cond = single_cond
+		} else {
+			branch_cond = ast.Expr(ast.InfixExpr{
+				op:  .logical_or
+				lhs: branch_cond
+				rhs: single_cond
+				pos: cond.pos()
+			})
+		}
+	}
+	return branch_cond
+}
+
+fn (mut b Builder) build_match_branch_value(branch ast.MatchBranch) ValueID {
+	if branch.stmts.len == 0 {
+		return 0
+	}
+	for i := 0; i < branch.stmts.len - 1; i++ {
+		b.build_stmt(branch.stmts[i])
+	}
+	last := branch.stmts[branch.stmts.len - 1]
+	if last is ast.ExprStmt {
+		return b.build_expr(last.expr)
+	}
+	b.build_stmt(last)
+	return 0
+}
+
+fn (mut b Builder) match_expr_phi_type(incoming []MatchExprIncoming, fallback TypeID, i64_t TypeID) TypeID {
+	mut phi_type := fallback
+	if phi_type == 0 || phi_type == i64_t {
+		for item in incoming {
+			if item.value == 0 || item.value >= b.mod.values.len {
+				continue
+			}
+			value_type := b.mod.values[item.value].typ
+			if value_type != 0 {
+				phi_type = value_type
+				break
+			}
+		}
+	}
+	if phi_type == 0 {
+		phi_type = i64_t
+	}
+	return phi_type
+}
+
+fn (mut b Builder) build_bool_match_expr(expr ast.MatchExpr, match_value bool) ValueID {
+	if expr.branches.len == 0 {
+		return b.mod.get_or_add_const(b.mod.type_store.get_int(32), '0')
+	}
+
+	i64_t := b.mod.type_store.get_int(64)
+	result_type := b.expr_type(ast.Expr(expr))
+	merge_block := b.mod.add_block(b.cur_func, 'matchx_merge')
+	mut incoming := []MatchExprIncoming{}
+	saved_local_smartcasts := b.local_smartcasts.clone()
+	mut reached_else := false
+
+	for branch in expr.branches {
+		b.local_smartcasts = saved_local_smartcasts.clone()
+		if branch.cond.len == 0 {
+			value := b.build_match_branch_value(branch)
+			end_block := b.cur_block
+			if !b.block_has_terminator(b.cur_block) {
+				b.mod.add_instr(.jmp, b.cur_block, 0, [b.mod.blocks[merge_block].val_id])
+				b.add_edge(b.cur_block, merge_block)
+				incoming << MatchExprIncoming{
+					value: value
+					block: end_block
+				}
+			}
+			reached_else = true
+			break
+		}
+
+		cond_expr := match_bool_branch_cond_expr(branch.cond, match_value)
+		cond_val := b.build_expr(cond_expr)
+		then_block := b.mod.add_block(b.cur_func, 'matchx_branch')
+		next_block := b.mod.add_block(b.cur_func, 'matchx_next')
+		b.mod.add_instr(.br, b.cur_block, 0,
+			[cond_val, b.mod.blocks[then_block].val_id, b.mod.blocks[next_block].val_id])
+		b.add_edge(b.cur_block, then_block)
+		b.add_edge(b.cur_block, next_block)
+
+		b.cur_block = then_block
+		b.apply_local_smartcasts(b.smartcast_variant_type_ids_from_condition(cond_expr))
+		value := b.build_match_branch_value(branch)
+		end_block := b.cur_block
+		if !b.block_has_terminator(b.cur_block) {
+			b.mod.add_instr(.jmp, b.cur_block, 0, [b.mod.blocks[merge_block].val_id])
+			b.add_edge(b.cur_block, merge_block)
+			incoming << MatchExprIncoming{
+				value: value
+				block: end_block
+			}
+		}
+		b.cur_block = next_block
+	}
+
+	b.local_smartcasts = saved_local_smartcasts.clone()
+	if !reached_else && !b.block_has_terminator(b.cur_block) {
+		end_block := b.cur_block
+		b.mod.add_instr(.jmp, b.cur_block, 0, [b.mod.blocks[merge_block].val_id])
+		b.add_edge(b.cur_block, merge_block)
+		incoming << MatchExprIncoming{
+			value: 0
+			block: end_block
+		}
+	}
+
+	b.cur_block = merge_block
+	if b.mod.blocks[merge_block].preds.len == 0 {
+		b.mod.add_instr(.unreachable, b.cur_block, 0, []ValueID{})
+		return b.mod.get_or_add_const(result_type, '0')
+	}
+
+	phi_type := b.match_expr_phi_type(incoming, result_type, i64_t)
+	zero := b.mod.get_or_add_const(phi_type, '0')
+	mut phi_operands := []ValueID{cap: incoming.len * 2}
+	for item in incoming {
+		result := if item.value != 0 { item.value } else { zero }
+		phi_operands << result
+		phi_operands << b.mod.blocks[item.block].val_id
+	}
+	if phi_operands.len == 0 {
+		b.mod.add_instr(.unreachable, b.cur_block, 0, []ValueID{})
+		return zero
+	}
+	return b.mod.add_instr(.phi, merge_block, phi_type, phi_operands)
+}
+
+fn (mut b Builder) build_match_phi(merge_block BlockID, incoming []MatchExprIncoming, result_type TypeID, i64_t TypeID) ValueID {
+	b.cur_block = merge_block
+	if b.mod.blocks[merge_block].preds.len == 0 {
+		b.mod.add_instr(.unreachable, b.cur_block, 0, []ValueID{})
+		return b.mod.get_or_add_const(result_type, '0')
+	}
+
+	phi_type := b.match_expr_phi_type(incoming, result_type, i64_t)
+	zero := b.mod.get_or_add_const(phi_type, '0')
+	mut phi_operands := []ValueID{cap: incoming.len * 2}
+	for item in incoming {
+		result := if item.value != 0 { item.value } else { zero }
+		phi_operands << result
+		phi_operands << b.mod.blocks[item.block].val_id
+	}
+	if phi_operands.len == 0 {
+		b.mod.add_instr(.unreachable, b.cur_block, 0, []ValueID{})
+		return zero
+	}
+	return b.mod.add_instr(.phi, merge_block, phi_type, phi_operands)
+}
+
+fn sumtype_variant_candidate_names(expr ast.Expr) []string {
+	match expr {
+		ast.ParenExpr {
+			return sumtype_variant_candidate_names(expr.expr)
+		}
+		ast.Ident {
+			if expr.name == '' {
+				return []string{}
+			}
+			return [expr.name]
+		}
+		ast.SelectorExpr {
+			mut names := []string{}
+			if expr.rhs.name != '' {
+				if expr.lhs is ast.Ident {
+					lhs_name := (expr.lhs as ast.Ident).name
+					if lhs_name != '' {
+						names << '${lhs_name}__${expr.rhs.name}'
+						names << '${lhs_name}.${expr.rhs.name}'
+					}
+				}
+				names << expr.rhs.name
+			}
+			return names
+		}
+		ast.InitExpr {
+			return sumtype_variant_candidate_names(expr.typ)
+		}
+		ast.CallOrCastExpr {
+			return sumtype_variant_candidate_names(expr.lhs)
+		}
+		ast.CastExpr {
+			return sumtype_variant_candidate_names(expr.typ)
+		}
+		else {
+			return []string{}
+		}
+	}
+}
+
+fn (mut b Builder) sumtype_variant_type_for_name(sumtype_type TypeID, candidate string) ?TypeID {
+	if candidate == '' || b.env == unsafe { nil } {
+		return none
+	}
+	sumtype_name := b.mod.c_struct_names[sumtype_type] or { return none }
+	mut lookup_module := b.cur_module
+	mut lookup_name := sumtype_name
+	if dunder := sumtype_name.index('__') {
+		lookup_module = sumtype_name[..dunder]
+		last_dunder := sumtype_name.last_index('__') or { dunder }
+		lookup_name = sumtype_name[last_dunder + 2..]
+	}
+	scope := b.env.get_scope(lookup_module) or { return none }
+	obj := scope.lookup_parent(lookup_name, 0) or { return none }
+	obj_type := obj.typ()
+	if obj_type !is types.SumType {
+		return none
+	}
+	candidate_norm := candidate.replace('.', '__')
+	sumtype_info := obj_type as types.SumType
+	for variant in sumtype_info.get_variants() {
+		variant_name := variant.name()
+		variant_norm := variant_name.replace('.', '__')
+		if ssa_type_name_matches(variant_norm, candidate_norm) {
+			return b.type_to_ssa(variant)
+		}
+	}
+	return none
+}
+
+fn (mut b Builder) sumtype_variant_type_for_expr(sumtype_type TypeID, expr ast.Expr) ?TypeID {
+	for candidate in sumtype_variant_candidate_names(expr) {
+		if variant_type := b.sumtype_variant_type_for_name(sumtype_type, candidate) {
+			return variant_type
+		}
+	}
+	variant_type := b.smartcast_rhs_variant_type_id(expr, true)
+	if b.valid_type_id(variant_type) {
+		if _ := b.sumtype_variant_tag(sumtype_type, variant_type) {
+			return variant_type
+		}
+	}
+	return none
+}
+
+fn (mut b Builder) match_sumtype_branch_info(sumtype_type TypeID, cond ast.Expr) ?MatchSumtypeBranchInfo {
+	if cond is ast.ParenExpr {
+		return b.match_sumtype_branch_info(sumtype_type, cond.expr)
+	}
+	variant_type := b.sumtype_variant_type_for_expr(sumtype_type, cond) or { return none }
+	if !b.valid_type_id(variant_type) || variant_type == sumtype_type {
+		return none
+	}
+	tag := b.sumtype_variant_tag(sumtype_type, variant_type) or { return none }
+	return MatchSumtypeBranchInfo{
+		tag:          tag
+		variant_type: variant_type
+	}
+}
+
+fn (mut b Builder) match_sumtype_branch_infos(sumtype_type TypeID, conds []ast.Expr) []MatchSumtypeBranchInfo {
+	mut infos := []MatchSumtypeBranchInfo{}
+	for cond in conds {
+		info := b.match_sumtype_branch_info(sumtype_type, cond) or { continue }
+		infos << info
+	}
+	return infos
+}
+
+fn (mut b Builder) build_sumtype_match_condition(tag_val ValueID, infos []MatchSumtypeBranchInfo) ValueID {
+	bool_type := b.mod.type_store.get_int(1)
+	if !b.valid_value_id(tag_val) || infos.len == 0 {
+		return b.mod.get_or_add_const(bool_type, '0')
+	}
+	tag_type := b.mod.values[tag_val].typ
+	mut cond_val := ValueID(0)
+	for info in infos {
+		tag_const := b.mod.get_or_add_const(tag_type, info.tag.str())
+		eq_val := b.mod.add_instr(.eq, b.cur_block, bool_type, [tag_val, tag_const])
+		if cond_val == 0 {
+			cond_val = eq_val
+		} else {
+			cond_val = b.mod.add_instr(.or_, b.cur_block, bool_type, [cond_val, eq_val])
+		}
+	}
+	return cond_val
+}
+
+fn (mut b Builder) apply_sumtype_match_smartcast(subject ast.Expr, infos []MatchSumtypeBranchInfo) {
+	if infos.len != 1 {
+		return
+	}
+	expr_name := b.smartcast_expr_name(subject)
+	if expr_name != '' {
+		b.local_smartcasts[expr_name] = infos[0].variant_type
+	}
+}
+
+fn (mut b Builder) build_sumtype_match_expr(expr ast.MatchExpr, subject ValueID, subject_type TypeID) ValueID {
+	if expr.branches.len == 0 {
+		return b.mod.get_or_add_const(b.mod.type_store.get_int(32), '0')
+	}
+	i64_t := b.mod.type_store.get_int(64)
+	result_type := b.expr_type(ast.Expr(expr))
+	type_info := b.mod.type_store.types[subject_type]
+	tag_type := if type_info.fields.len > 0 { type_info.fields[0] } else { i64_t }
+	tag_idx := b.mod.get_or_add_const(b.mod.type_store.get_int(32), '0')
+	tag_val := b.mod.add_instr(.extractvalue, b.cur_block, tag_type, [subject, tag_idx])
+	merge_block := b.mod.add_block(b.cur_func, 'matchx_merge')
+	mut incoming := []MatchExprIncoming{}
+	saved_local_smartcasts := b.local_smartcasts.clone()
+	mut reached_else := false
+
+	for branch in expr.branches {
+		b.local_smartcasts = saved_local_smartcasts.clone()
+		if branch.cond.len == 0 {
+			value := b.build_match_branch_value(branch)
+			end_block := b.cur_block
+			if !b.block_has_terminator(b.cur_block) {
+				b.mod.add_instr(.jmp, b.cur_block, 0, [b.mod.blocks[merge_block].val_id])
+				b.add_edge(b.cur_block, merge_block)
+				incoming << MatchExprIncoming{
+					value: value
+					block: end_block
+				}
+			}
+			reached_else = true
+			break
+		}
+
+		infos := b.match_sumtype_branch_infos(subject_type, branch.cond)
+		cond_val := b.build_sumtype_match_condition(tag_val, infos)
+		then_block := b.mod.add_block(b.cur_func, 'matchx_branch')
+		next_block := b.mod.add_block(b.cur_func, 'matchx_next')
+		b.mod.add_instr(.br, b.cur_block, 0,
+			[cond_val, b.mod.blocks[then_block].val_id, b.mod.blocks[next_block].val_id])
+		b.add_edge(b.cur_block, then_block)
+		b.add_edge(b.cur_block, next_block)
+
+		b.cur_block = then_block
+		b.apply_sumtype_match_smartcast(expr.expr, infos)
+		value := b.build_match_branch_value(branch)
+		end_block := b.cur_block
+		if !b.block_has_terminator(b.cur_block) {
+			b.mod.add_instr(.jmp, b.cur_block, 0, [b.mod.blocks[merge_block].val_id])
+			b.add_edge(b.cur_block, merge_block)
+			incoming << MatchExprIncoming{
+				value: value
+				block: end_block
+			}
+		}
+		b.cur_block = next_block
+	}
+
+	b.local_smartcasts = saved_local_smartcasts.clone()
+	if !reached_else && !b.block_has_terminator(b.cur_block) {
+		end_block := b.cur_block
+		b.mod.add_instr(.jmp, b.cur_block, 0, [b.mod.blocks[merge_block].val_id])
+		b.add_edge(b.cur_block, merge_block)
+		incoming << MatchExprIncoming{
+			value: 0
+			block: end_block
+		}
+	}
+
+	return b.build_match_phi(merge_block, incoming, result_type, i64_t)
+}
+
+fn (mut b Builder) build_match_expr(expr ast.MatchExpr) ValueID {
+	if match_value := match_expr_bool_literal(expr.expr) {
+		return b.build_bool_match_expr(expr, match_value)
+	}
+	subject := b.build_expr(expr.expr)
+	if b.valid_value_id(subject) {
+		subject_type := b.mod.values[subject].typ
+		if b.ssa_type_is_sumtype(subject_type) {
+			return b.build_sumtype_match_expr(expr, subject, subject_type)
+		}
+	}
+	return b.mod.get_or_add_const(b.mod.type_store.get_int(32), '0')
+}
+
 // build_if_expr_from_flat (s231, s232) is the cursor-native port of
 // build_if_expr. IfExpr flat encoding: (.expr_if, [edge0=cond, edge1=else_expr,
 // edge2..n=stmts]). Cond/stmts/else-chain/phi are built from cursors via
@@ -14984,8 +16079,8 @@ fn (mut b Builder) build_array_init_expr(expr ast.ArrayInitExpr) ValueID {
 			}
 		}
 		if !has_declared_type && elem_vals.len > 0 {
-			for val in elem_vals {
-				if b.valid_value_id(val) {
+			for i, val in elem_vals {
+				if b.array_literal_value_type_can_infer_elem(expr.exprs[i], val) {
 					elem_type = b.mod.values[val].typ
 					break
 				}
@@ -15081,7 +16176,10 @@ fn (mut b Builder) build_array_init_expr(expr ast.ArrayInitExpr) ValueID {
 		if is_fixed {
 			return b.mod.add_instr(.load, b.cur_block, arr_fixed_type, [alloca])
 		}
-		return alloca
+		if b.array_literal_as_element_buffer {
+			return alloca
+		}
+		return b.build_dynamic_array_from_element_buffer(elem_type, elem_vals, alloca)
 	}
 
 	// Check if this is a fixed-size array type (e.g., [5]u8{}).
@@ -15122,6 +16220,29 @@ fn (mut b Builder) build_array_init_expr(expr ast.ArrayInitExpr) ValueID {
 				}
 			}
 			else {}
+		}
+	}
+
+	if builder_expr_ok(expr.typ) && expr.typ is ast.Type && expr.init is ast.EmptyExpr
+		&& expr.update_expr is ast.EmptyExpr {
+		expr_typ := expr.typ as ast.Type
+		if expr_typ is ast.ArrayType {
+			elem_type := if array_elem_hint != 0 {
+				array_elem_hint
+			} else {
+				b.ast_type_to_ssa(expr_typ.elem_type)
+			}
+			len_val := if expr.len is ast.EmptyExpr {
+				ValueID(0)
+			} else {
+				b.build_expr(expr.len)
+			}
+			cap_val := if expr.cap is ast.EmptyExpr {
+				ValueID(0)
+			} else {
+				b.build_expr(expr.cap)
+			}
+			return b.build_empty_dynamic_array(elem_type, len_val, cap_val)
 		}
 	}
 
@@ -15201,7 +16322,16 @@ fn (mut b Builder) collect_init_expr_values(expr ast.InitExpr) (TypeID, []ValueI
 				if is_sumtype_data {
 					b.in_sumtype_data = true
 				}
-				mut field_val := b.build_expr(expr.fields[idx].value)
+				mut field_val := ValueID(0)
+				if b.ssa_type_is_sumtype(field_type) {
+					addr := b.build_addr(expr.fields[idx].value)
+					if wrapped := b.wrap_address_for_sumtype_target(addr, field_type) {
+						field_val = wrapped
+					}
+				}
+				if field_val == 0 {
+					field_val = b.build_expr(expr.fields[idx].value)
+				}
 				if is_sumtype_data {
 					b.in_sumtype_data = false
 				}
@@ -15223,6 +16353,7 @@ fn (mut b Builder) collect_init_expr_values(expr ast.InitExpr) (TypeID, []ValueI
 						])
 					}
 				}
+				field_val = b.coerce_struct_sumtype_field_value(field_val, field_type)
 				field_vals << field_val
 			} else {
 				field_vals << b.mod.get_or_add_const(field_type, '0')
@@ -15310,7 +16441,16 @@ fn (mut b Builder) collect_init_expr_values_from_flat(c ast.Cursor) (TypeID, []V
 				}
 				field_c := c.edge(1 + idx)
 				value_c := field_c.edge(0)
-				mut field_val := b.build_expr_from_flat(value_c)
+				mut field_val := ValueID(0)
+				if b.ssa_type_is_sumtype(field_type) {
+					addr := b.build_addr_from_flat(value_c)
+					if wrapped := b.wrap_address_for_sumtype_target(addr, field_type) {
+						field_val = wrapped
+					}
+				}
+				if field_val == 0 {
+					field_val = b.build_expr_from_flat(value_c)
+				}
 				if is_sumtype_data {
 					b.in_sumtype_data = false
 				}
@@ -15328,6 +16468,7 @@ fn (mut b Builder) collect_init_expr_values_from_flat(c ast.Cursor) (TypeID, []V
 						])
 					}
 				}
+				field_val = b.coerce_struct_sumtype_field_value(field_val, field_type)
 				field_vals << field_val
 			} else {
 				field_vals << b.mod.get_or_add_const(field_type, '0')
@@ -15342,6 +16483,19 @@ fn (mut b Builder) collect_init_expr_values_from_flat(c ast.Cursor) (TypeID, []V
 	}
 
 	return struct_type, field_vals
+}
+
+fn (mut b Builder) coerce_struct_sumtype_field_value(field_val ValueID, field_type TypeID) ValueID {
+	if field_val <= 0 || field_val >= b.mod.values.len || !b.ssa_type_is_sumtype(field_type) {
+		return field_val
+	}
+	if b.mod.values[field_val].typ == field_type {
+		return field_val
+	}
+	if wrapped := b.wrap_value_for_sumtype_target(field_val, field_type) {
+		return wrapped
+	}
+	return field_val
 }
 
 // build_init_expr_ptr_from_flat is the cursor-native counterpart of
@@ -15647,6 +16801,37 @@ fn (mut b Builder) build_call_or_cast(expr ast.CallOrCastExpr) ValueID {
 	// between a function call and a type cast, e.g., int(x) or voidptr(p).
 	// After type checking, the transformer usually resolves these, but some
 	// may remain as casts. Treat as cast: convert expr to target type.
+	if expr.lhs is ast.Ident {
+		name := expr.lhs.name
+		fn_name := b.resolve_call_name_for_ident_name(name)
+		if fn_name in b.fn_index && !is_builtin_cast_type_name(name) && !b.known_type_name(name) {
+			args := if expr.expr is ast.EmptyExpr { []ast.Expr{} } else { [expr.expr] }
+			return b.build_call_resolved(fn_name, ast.CallExpr{
+				lhs:  expr.lhs
+				args: args
+				pos:  expr.pos
+			})
+		}
+	}
+	if expr.lhs is ast.SelectorExpr {
+		sel := expr.lhs as ast.SelectorExpr
+		args := if expr.expr is ast.EmptyExpr { []ast.Expr{} } else { [expr.expr] }
+		call_expr := ast.CallExpr{
+			lhs:  expr.lhs
+			args: args
+			pos:  expr.pos
+		}
+		fn_name := b.resolve_call_name(call_expr)
+		if mod_name := b.selector_module_name(sel) {
+			if (mod_name == 'C' || fn_name in b.fn_index)
+				&& !b.call_or_cast_selector_should_remain_cast(sel, fn_name) {
+				return b.build_call_resolved(fn_name, call_expr)
+			}
+		}
+		if fn_name in b.fn_index && !b.call_or_cast_selector_should_remain_cast(sel, fn_name) {
+			return b.build_call_resolved(fn_name, call_expr)
+		}
+	}
 	target_type := b.ast_type_to_ssa(expr.lhs)
 	addr := b.build_addr(expr.expr)
 	if addr != 0 {
@@ -16905,6 +18090,10 @@ fn (mut b Builder) get_or_create_fn_ref(name string, _typ TypeID) ValueID {
 }
 
 fn (mut b Builder) build_fn_literal(expr ast.FnLiteral) ValueID {
+	if expr.captured_vars.len > 0 {
+		return b.get_or_create_fn_ref(unsupported_captured_fn_literal_symbol, 0)
+	}
+
 	// Generate unique name for this anonymous function
 	anon_name := '_anon_fn_${b.anon_fn_counter}'
 	b.anon_fn_counter++
@@ -16951,6 +18140,10 @@ fn (mut b Builder) build_fn_literal(expr ast.FnLiteral) ValueID {
 			[]ValueID{})
 		b.mod.add_instr(.store, entry, 0, [param_val, alloca])
 		b.vars[param.name] = alloca
+		if param.is_mut && !(param_type < b.mod.type_store.types.len
+			&& b.mod.type_store.types[param_type].kind == .ptr_t) {
+			b.mut_ptr_params[param.name] = true
+		}
 	}
 
 	// Build body
@@ -17813,6 +19006,45 @@ fn (b &Builder) lookup_checked_struct_type_by_c_name(c_name string) ?types.Struc
 		}
 	}
 	return none
+}
+
+fn (mut b Builder) generate_string_plus_two_stub() {
+	fn_name := 'builtin__string__plus_two'
+	if fn_name in b.fn_index {
+		fn_idx := b.fn_index[fn_name]
+		b.mod.func_set_c_extern(fn_idx, false)
+		b.generate_string_plus_two_body(fn_idx)
+		return
+	}
+	string_t := b.get_string_type()
+	if string_t == 0 {
+		return
+	}
+	func_idx := b.mod.new_function(fn_name, string_t, []TypeID{})
+	b.fn_index[fn_name] = func_idx
+	b.generate_string_plus_two_body(func_idx)
+}
+
+fn (mut b Builder) generate_string_plus_two_body(func_idx int) {
+	string_t := b.get_string_type()
+	if string_t == 0 {
+		return
+	}
+	b.mod.func_clear_blocks(func_idx)
+	b.mod.func_clear_params(func_idx)
+
+	entry := b.mod.add_block(func_idx, 'entry')
+	param_a := b.mod.add_value_node(.argument, string_t, 'a', 0)
+	param_b := b.mod.add_value_node(.argument, string_t, 'b', 0)
+	param_c := b.mod.add_value_node(.argument, string_t, 'c', 0)
+	b.mod.func_add_param(func_idx, param_a)
+	b.mod.func_add_param(func_idx, param_b)
+	b.mod.func_add_param(func_idx, param_c)
+
+	plus_fn := b.get_or_create_fn_ref('builtin__string__+', string_t)
+	ab := b.mod.add_instr(.call, entry, string_t, [plus_fn, param_a, param_b])
+	abc := b.mod.add_instr(.call, entry, string_t, [plus_fn, ab, param_c])
+	b.mod.add_instr(.ret, entry, 0, [abc])
 }
 
 // generate_wymix_stub creates a synthetic `_wymix` function for the native backend.

--- a/vlib/v2/ssa/core_builtin_type_registration_test.v
+++ b/vlib/v2/ssa/core_builtin_type_registration_test.v
@@ -1,0 +1,902 @@
+module ssa
+
+import v2.ast
+import v2.token
+import v2.types
+
+fn core_reg_ident(name string) ast.Expr {
+	return ast.Expr(ast.Ident{
+		name: name
+	})
+}
+
+fn core_reg_field(name string, typ string) ast.FieldDecl {
+	return ast.FieldDecl{
+		name: name
+		typ:  core_reg_ident(typ)
+	}
+}
+
+fn core_reg_builtin_file() ast.File {
+	return ast.File{
+		name:  'builtin.v'
+		mod:   'builtin'
+		stmts: [
+			ast.Stmt(ast.ModuleStmt{
+				name: 'builtin'
+			}),
+			ast.Stmt(ast.StructDecl{
+				name:   'array'
+				fields: [
+					core_reg_field('data', 'voidptr'),
+					core_reg_field('offset', 'int'),
+					core_reg_field('len', 'int'),
+					core_reg_field('cap', 'int'),
+					core_reg_field('flags', 'int'),
+					core_reg_field('element_size', 'int'),
+				]
+			}),
+			ast.Stmt(ast.StructDecl{
+				name:   'string'
+				fields: [
+					core_reg_field('str', 'voidptr'),
+					core_reg_field('len', 'int'),
+					core_reg_field('is_lit', 'int'),
+				]
+			}),
+		]
+	}
+}
+
+fn core_reg_array_type(elem ast.Expr) ast.Expr {
+	return ast.Expr(ast.Type(ast.ArrayType{
+		elem_type: elem
+	}))
+}
+
+fn core_reg_selector(lhs ast.Expr, rhs string) ast.Expr {
+	return ast.Expr(ast.SelectorExpr{
+		lhs: lhs
+		rhs: ast.Ident{
+			name: rhs
+		}
+	})
+}
+
+fn core_reg_call(lhs ast.Expr, args []ast.Expr) ast.Expr {
+	return ast.Expr(ast.CallExpr{
+		lhs:  lhs
+		args: args
+	})
+}
+
+fn core_reg_num(value string) ast.Expr {
+	return ast.Expr(ast.BasicLiteral{
+		kind:  .number
+		value: value
+	})
+}
+
+fn core_reg_bool(value bool) ast.Expr {
+	return ast.Expr(ast.BasicLiteral{
+		kind: if value { token.Token.key_true } else { token.Token.key_false }
+	})
+}
+
+fn core_reg_string(value string) ast.Expr {
+	return ast.Expr(ast.StringLiteral{
+		kind:  .v
+		value: value
+	})
+}
+
+fn core_reg_infix(lhs ast.Expr, op token.Token, rhs ast.Expr) ast.Expr {
+	return ast.Expr(ast.InfixExpr{
+		op:  op
+		lhs: lhs
+		rhs: rhs
+	})
+}
+
+fn core_reg_decl(name string, rhs ast.Expr) ast.Stmt {
+	return ast.Stmt(ast.AssignStmt{
+		op:  .decl_assign
+		lhs: [core_reg_ident(name)]
+		rhs: [rhs]
+	})
+}
+
+fn core_reg_return(expr ast.Expr) ast.Stmt {
+	return ast.Stmt(ast.ReturnStmt{
+		exprs: [expr]
+	})
+}
+
+fn core_reg_expr_stmt(expr ast.Expr) ast.Stmt {
+	return ast.Stmt(ast.ExprStmt{
+		expr: expr
+	})
+}
+
+fn core_reg_empty_dynamic_array(elem string, cap ast.Expr) ast.Expr {
+	return ast.Expr(ast.ArrayInitExpr{
+		typ: core_reg_array_type(core_reg_ident(elem))
+		cap: cap
+	})
+}
+
+fn core_reg_pointer_type(name string) ast.Expr {
+	return ast.Expr(ast.PrefixExpr{
+		op:   .amp
+		expr: core_reg_ident(name)
+	})
+}
+
+fn core_reg_call_or_cast(lhs ast.Expr, expr ast.Expr) ast.Expr {
+	return ast.Expr(ast.CallOrCastExpr{
+		lhs:  lhs
+		expr: expr
+	})
+}
+
+fn core_reg_unsafe_expr(expr ast.Expr) ast.Expr {
+	return ast.Expr(ast.UnsafeExpr{
+		stmts: [
+			ast.Stmt(ast.ExprStmt{
+				expr: expr
+			}),
+		]
+	})
+}
+
+fn core_reg_string_runes_decl() ast.Stmt {
+	s_ident := core_reg_ident('s')
+	runes_ident := core_reg_ident('runes')
+	return ast.Stmt(ast.FnDecl{
+		is_method: true
+		receiver:  ast.Parameter{
+			name: 's'
+			typ:  core_reg_ident('string')
+		}
+		name:      'runes'
+		typ:       ast.FnType{
+			return_type: core_reg_array_type(core_reg_ident('rune'))
+		}
+		stmts:     [
+			core_reg_decl('runes', core_reg_empty_dynamic_array('rune', core_reg_selector(s_ident,
+				'len'))),
+			core_reg_return(runes_ident),
+		]
+	})
+}
+
+fn core_reg_string_graphemes_impl_decl() ast.Stmt {
+	s_ident := core_reg_ident('s')
+	runes_ident := core_reg_ident('runes')
+	res_ident := core_reg_ident('res')
+	return ast.Stmt(ast.FnDecl{
+		name:  'string_graphemes_impl'
+		typ:   ast.FnType{
+			params:      [
+				ast.Parameter{
+					name: 's'
+					typ:  core_reg_ident('string')
+				},
+			]
+			return_type: core_reg_array_type(core_reg_ident('string'))
+		}
+		stmts: [
+			core_reg_decl('runes', core_reg_call(core_reg_selector(s_ident, 'runes'), []ast.Expr{})),
+			core_reg_decl('res', core_reg_empty_dynamic_array('string', core_reg_selector(runes_ident,
+				'len'))),
+			core_reg_decl('cluster', core_reg_empty_dynamic_array('rune', ast.Expr(ast.BasicLiteral{
+				kind:  .number
+				value: '4'
+			}))),
+			core_reg_return(res_ident),
+		]
+	})
+}
+
+fn core_reg_tos2_decl() ast.Stmt {
+	return ast.Stmt(ast.FnDecl{
+		name: 'tos2'
+		typ:  ast.FnType{
+			params:      [
+				ast.Parameter{
+					name: 's'
+					typ:  core_reg_pointer_type('u8')
+				},
+			]
+			return_type: core_reg_ident('string')
+		}
+	})
+}
+
+fn core_reg_string_clone_decl() ast.Stmt {
+	return ast.Stmt(ast.FnDecl{
+		is_method: true
+		receiver:  ast.Parameter{
+			name: 's'
+			typ:  core_reg_ident('string')
+		}
+		name:      'clone'
+		typ:       ast.FnType{
+			return_type: core_reg_ident('string')
+		}
+	})
+}
+
+fn core_reg_array_clone_decl() ast.Stmt {
+	return ast.Stmt(ast.FnDecl{
+		is_method: true
+		receiver:  ast.Parameter{
+			name: 'a'
+			typ:  core_reg_ident('array')
+		}
+		name:      'clone'
+		typ:       ast.FnType{
+			return_type: core_reg_ident('array')
+		}
+	})
+}
+
+fn core_reg_array_alloc_like_decl() ast.Stmt {
+	return ast.Stmt(ast.FnDecl{
+		is_method: true
+		receiver:  ast.Parameter{
+			name: 'a'
+			typ:  core_reg_ident('array')
+		}
+		name:      'alloc_array_data_like_uninit'
+		typ:       ast.FnType{
+			params:      [
+				ast.Parameter{
+					name: 'new_size'
+					typ:  core_reg_ident('u64')
+				},
+			]
+			return_type: core_reg_ident('voidptr')
+		}
+	})
+}
+
+fn core_reg_int_str_decl() ast.Stmt {
+	return ast.Stmt(ast.FnDecl{
+		is_method: true
+		receiver:  ast.Parameter{
+			name: 'n'
+			typ:  core_reg_ident('int')
+		}
+		name:      'str'
+		typ:       ast.FnType{
+			return_type: core_reg_ident('string')
+		}
+	})
+}
+
+fn core_reg_tos_clone_decl() ast.Stmt {
+	const_s := core_reg_ident('const_s')
+	ptr_cast := ast.Expr(ast.PrefixExpr{
+		op:   .amp
+		expr: core_reg_call_or_cast(core_reg_ident('u8'), const_s)
+	})
+	tos2_call := core_reg_call_or_cast(core_reg_ident('tos2'), ptr_cast)
+	return ast.Stmt(ast.FnDecl{
+		name:  'tos_clone'
+		typ:   ast.FnType{
+			params:      [
+				ast.Parameter{
+					name: 'const_s'
+					typ:  core_reg_pointer_type('u8')
+				},
+			]
+			return_type: core_reg_ident('string')
+		}
+		stmts: [
+			core_reg_decl('s', core_reg_unsafe_expr(tos2_call)),
+			core_reg_return(core_reg_call(core_reg_selector(core_reg_ident('s'), 'clone'),
+				[]ast.Expr{})),
+		]
+	})
+}
+
+fn core_reg_param(name string, typ ast.Expr) ast.Parameter {
+	return ast.Parameter{
+		name: name
+		typ:  typ
+	}
+}
+
+fn core_reg_fn_decl(name string, params []ast.Parameter, return_type ast.Expr, stmts []ast.Stmt) ast.Stmt {
+	return ast.Stmt(ast.FnDecl{
+		name:  name
+		typ:   ast.FnType{
+			params:      params
+			return_type: return_type
+		}
+		stmts: stmts
+	})
+}
+
+fn core_reg_c_puts_decl() ast.Stmt {
+	return ast.Stmt(ast.FnDecl{
+		name:     'puts'
+		language: .c
+		typ:      ast.FnType{
+			params:      [
+				core_reg_param('s', core_reg_ident('voidptr')),
+			]
+			return_type: core_reg_ident('int')
+		}
+	})
+}
+
+fn core_reg_dep_file() ast.File {
+	x_ident := core_reg_ident('x')
+	return ast.File{
+		name:  'dep.v'
+		mod:   'dep'
+		stmts: [
+			ast.Stmt(ast.ModuleStmt{
+				name: 'dep'
+			}),
+			ast.Stmt(ast.StructDecl{
+				name:   'Type'
+				fields: [
+					core_reg_field('value', 'int'),
+				]
+			}),
+			core_reg_fn_decl('value', [
+				core_reg_param('x', core_reg_ident('int')),
+			], core_reg_ident('int'), [
+				core_reg_return(x_ident),
+			]),
+			core_reg_fn_decl('cast_c_type', [
+				core_reg_param('x', core_reg_ident('int')),
+			], core_reg_ident('Type'), [
+				core_reg_return(core_reg_call_or_cast(core_reg_selector(core_reg_ident('C'), 'Type'),
+					x_ident)),
+			]),
+		]
+	}
+}
+
+fn core_reg_call_or_cast_matrix_main_file() ast.File {
+	p_ident := core_reg_ident('p')
+	x_ident := core_reg_ident('x')
+	s_ident := core_reg_ident('s')
+	a_ident := core_reg_ident('a')
+	n_ident := core_reg_ident('n')
+	return ast.File{
+		name:  'main.v'
+		mod:   'main'
+		stmts: [
+			ast.Stmt(ast.ModuleStmt{
+				name: 'main'
+			}),
+			core_reg_c_puts_decl(),
+			core_reg_fn_decl('call_tos2', [
+				core_reg_param('p', core_reg_pointer_type('u8')),
+			], core_reg_ident('string'), [
+				core_reg_return(core_reg_call_or_cast(core_reg_ident('tos2'), p_ident)),
+			]),
+			core_reg_fn_decl('cast_int', [
+				core_reg_param('x', core_reg_ident('i64')),
+			], core_reg_ident('int'), [
+				core_reg_return(core_reg_call_or_cast(core_reg_ident('int'), x_ident)),
+			]),
+			core_reg_fn_decl('cast_voidptr', [
+				core_reg_param('x', core_reg_ident('i64')),
+			], core_reg_ident('voidptr'), [
+				core_reg_return(core_reg_call_or_cast(core_reg_ident('voidptr'), x_ident)),
+			]),
+			core_reg_fn_decl('cast_u8_ptr', [
+				core_reg_param('x', core_reg_ident('voidptr')),
+			], core_reg_pointer_type('u8'), [
+				core_reg_return(ast.Expr(ast.PrefixExpr{
+					op:   .amp
+					expr: core_reg_call_or_cast(core_reg_ident('u8'), x_ident)
+				})),
+			]),
+			core_reg_fn_decl('call_c_puts', [
+				core_reg_param('p', core_reg_ident('voidptr')),
+			], core_reg_ident('int'), [
+				core_reg_return(core_reg_call_or_cast(core_reg_selector(core_reg_ident('C'), 'puts'),
+					p_ident)),
+			]),
+			core_reg_fn_decl('call_dep_value', [
+				core_reg_param('x', core_reg_ident('int')),
+			], core_reg_ident('int'), [
+				core_reg_return(core_reg_call_or_cast(core_reg_selector(core_reg_ident('dep'),
+					'value'), x_ident)),
+			]),
+			core_reg_fn_decl('cast_dep_type', [
+				core_reg_param('x', core_reg_ident('int')),
+			], core_reg_selector(core_reg_ident('dep'), 'Type'), [
+				core_reg_return(core_reg_call_or_cast(core_reg_selector(core_reg_ident('dep'),
+					'Type'), x_ident)),
+			]),
+			core_reg_fn_decl('clone_string', [
+				core_reg_param('s', core_reg_ident('string')),
+			], core_reg_ident('string'), [
+				core_reg_return(core_reg_call(core_reg_selector(s_ident, 'clone'), []ast.Expr{})),
+			]),
+			core_reg_fn_decl('clone_array', [
+				core_reg_param('a', core_reg_ident('array')),
+			], core_reg_ident('array'), [
+				core_reg_return(core_reg_call(core_reg_selector(a_ident, 'clone'), []ast.Expr{})),
+			]),
+			core_reg_fn_decl('call_array_alloc_like', [
+				core_reg_param('a', core_reg_ident('array')),
+				core_reg_param('n', core_reg_ident('u64')),
+			], core_reg_ident('voidptr'), [
+				core_reg_return(core_reg_call_or_cast(core_reg_selector(a_ident,
+					'alloc_array_data_like_uninit'), n_ident)),
+			]),
+		]
+	}
+}
+
+fn core_reg_call_or_cast_matrix_files() []ast.File {
+	base_builtin := core_reg_builtin_file()
+	mut builtin_stmts := base_builtin.stmts.clone()
+	builtin_stmts << core_reg_tos2_decl()
+	builtin_stmts << core_reg_string_clone_decl()
+	builtin_stmts << core_reg_array_clone_decl()
+	builtin_stmts << core_reg_array_alloc_like_decl()
+	builtin := ast.File{
+		name:  base_builtin.name
+		mod:   base_builtin.mod
+		stmts: builtin_stmts
+	}
+	return [builtin, core_reg_dep_file(), core_reg_call_or_cast_matrix_main_file()]
+}
+
+fn core_reg_mod_eq_zero(lhs ast.Expr, divisor string) ast.Expr {
+	return core_reg_infix(core_reg_infix(lhs, .mod, core_reg_num(divisor)), .eq, core_reg_num('0'))
+}
+
+fn core_reg_match_branch(conds []ast.Expr, value ast.Expr) ast.MatchBranch {
+	return ast.MatchBranch{
+		cond:  conds
+		stmts: [
+			core_reg_expr_stmt(value),
+		]
+	}
+}
+
+fn core_reg_match_true_value_main_file() ast.File {
+	n_ident := core_reg_ident('n')
+	match_expr := ast.Expr(ast.MatchExpr{
+		expr:     core_reg_bool(true)
+		branches: [
+			core_reg_match_branch([core_reg_mod_eq_zero(n_ident, '15')],
+				core_reg_string("'FizzBuzz'")),
+			core_reg_match_branch([core_reg_mod_eq_zero(n_ident, '5')], core_reg_string("'Buzz'")),
+			core_reg_match_branch([core_reg_mod_eq_zero(n_ident, '3')], core_reg_string("'Fizz'")),
+			core_reg_match_branch([]ast.Expr{}, core_reg_call(core_reg_selector(n_ident, 'str'),
+				[]ast.Expr{})),
+		]
+	})
+	return ast.File{
+		name:  'main.v'
+		mod:   'main'
+		stmts: [
+			ast.Stmt(ast.ModuleStmt{
+				name: 'main'
+			}),
+			core_reg_fn_decl('fizz_value', [
+				core_reg_param('n', core_reg_ident('int')),
+			], core_reg_ident('string'), [
+				core_reg_decl('value', match_expr),
+				core_reg_return(core_reg_ident('value')),
+			]),
+		]
+	}
+}
+
+fn core_reg_match_true_value_files() []ast.File {
+	base_builtin := core_reg_builtin_file()
+	mut builtin_stmts := base_builtin.stmts.clone()
+	builtin_stmts << core_reg_int_str_decl()
+	builtin := ast.File{
+		name:  base_builtin.name
+		mod:   base_builtin.mod
+		stmts: builtin_stmts
+	}
+	return [builtin, core_reg_match_true_value_main_file()]
+}
+
+fn core_reg_literal_decl() ast.Stmt {
+	return ast.Stmt(ast.FnDecl{
+		name:  'literal_value'
+		typ:   ast.FnType{
+			return_type: core_reg_ident('string')
+		}
+		stmts: [
+			core_reg_return(ast.Expr(ast.StringLiteral{
+				kind:  .v
+				value: "'hi'"
+			})),
+		]
+	})
+}
+
+fn core_reg_call_runes_decl() ast.Stmt {
+	s_ident := core_reg_ident('s')
+	return ast.Stmt(ast.FnDecl{
+		name:  'call_runes'
+		typ:   ast.FnType{
+			params:      [
+				ast.Parameter{
+					name: 's'
+					typ:  core_reg_ident('string')
+				},
+			]
+			return_type: core_reg_array_type(core_reg_ident('rune'))
+		}
+		stmts: [
+			core_reg_return(core_reg_call(core_reg_selector(s_ident, 'runes'), []ast.Expr{})),
+		]
+	})
+}
+
+fn core_reg_contract_files() []ast.File {
+	base_builtin := core_reg_builtin_file()
+	mut builtin_stmts := base_builtin.stmts.clone()
+	builtin_stmts << core_reg_string_runes_decl()
+	builtin_stmts << core_reg_string_graphemes_impl_decl()
+	builtin := ast.File{
+		name:  base_builtin.name
+		mod:   base_builtin.mod
+		stmts: builtin_stmts
+	}
+	main_file := ast.File{
+		name:  'main.v'
+		mod:   'main'
+		stmts: [
+			ast.Stmt(ast.ModuleStmt{
+				name: 'main'
+			}),
+			core_reg_literal_decl(),
+			core_reg_call_runes_decl(),
+		]
+	}
+	return [builtin, main_file]
+}
+
+fn core_reg_build_contract() &Builder {
+	files := core_reg_contract_files()
+	env := types.Environment.new()
+	mut mod := Module.new('core_builtin_type_contract')
+	mut b := Builder.new_with_env(mod, env)
+	b.minimal_runtime_roots = true
+	b.build_all(files)
+	return b
+}
+
+fn core_reg_build_call_or_cast_matrix_legacy() &Builder {
+	files := core_reg_call_or_cast_matrix_files()
+	env := types.Environment.new()
+	mut mod := Module.new('call_or_cast_matrix_legacy')
+	mut b := Builder.new_with_env(mod, env)
+	b.minimal_runtime_roots = true
+	b.build_all(files)
+	return b
+}
+
+fn core_reg_build_call_or_cast_matrix_flat() &Builder {
+	files := core_reg_call_or_cast_matrix_files()
+	flat := ast.flatten_files(files)
+	env := types.Environment.new()
+	mut mod := Module.new('call_or_cast_matrix_flat')
+	mut b := Builder.new_with_env(mod, env)
+	b.minimal_runtime_roots = true
+	b.build_all_from_flat(&flat)
+	return b
+}
+
+fn core_reg_build_match_true_value_legacy() &Builder {
+	files := core_reg_match_true_value_files()
+	env := types.Environment.new()
+	mut mod := Module.new('match_true_value_legacy')
+	mut b := Builder.new_with_env(mod, env)
+	b.minimal_runtime_roots = true
+	b.build_all(files)
+	return b
+}
+
+fn core_reg_build_match_true_value_flat() &Builder {
+	files := core_reg_match_true_value_files()
+	flat := ast.flatten_files(files)
+	env := types.Environment.new()
+	mut mod := Module.new('match_true_value_flat')
+	mut b := Builder.new_with_env(mod, env)
+	b.minimal_runtime_roots = true
+	b.build_all_from_flat(&flat)
+	return b
+}
+
+fn core_reg_func_idx(b &Builder, name string) int {
+	return b.fn_index[name] or {
+		assert false, 'missing SSA function ${name}'
+		return -1
+	}
+}
+
+fn core_reg_func_value_ids(b &Builder, name string) []ValueID {
+	idx := core_reg_func_idx(b, name)
+	func := b.mod.funcs[idx]
+	mut ids := []ValueID{}
+	for block_id in func.blocks {
+		for value_id in b.mod.blocks[block_id].instrs {
+			ids << value_id
+		}
+	}
+	return ids
+}
+
+fn core_reg_call_callees(b &Builder, name string) []string {
+	mut callees := []string{}
+	for value_id in core_reg_func_value_ids(b, name) {
+		value := b.mod.values[value_id]
+		if value.kind != .instruction {
+			continue
+		}
+		instr := b.mod.instrs[value.index]
+		if instr.op != .call || instr.operands.len == 0 {
+			continue
+		}
+		callee_id := instr.operands[0]
+		if callee_id > 0 && callee_id < b.mod.values.len {
+			callees << b.mod.values[callee_id].name
+		}
+	}
+	return callees
+}
+
+fn core_reg_assert_callees(b &Builder, name string, expected []string) {
+	callees := core_reg_call_callees(b, name)
+	assert callees == expected, '${name} callees: ${callees}, expected ${expected}'
+}
+
+fn core_reg_assert_no_zero_loads(b &Builder, name string) {
+	for value_id in core_reg_func_value_ids(b, name) {
+		value := b.mod.values[value_id]
+		if value.kind != .instruction {
+			continue
+		}
+		instr := b.mod.instrs[value.index]
+		if instr.op == .load {
+			assert value.typ != 0, '${name} has load v${value_id} with type 0'
+		}
+	}
+}
+
+fn core_reg_find_call_type(b &Builder, func_name string, callee_name string) TypeID {
+	for value_id in core_reg_func_value_ids(b, func_name) {
+		value := b.mod.values[value_id]
+		if value.kind != .instruction {
+			continue
+		}
+		instr := b.mod.instrs[value.index]
+		if instr.op != .call || instr.operands.len == 0 {
+			continue
+		}
+		callee_id := instr.operands[0]
+		if callee_id > 0 && callee_id < b.mod.values.len
+			&& b.mod.values[callee_id].name == callee_name {
+			return value.typ
+		}
+	}
+	assert false, 'missing call to ${callee_name} in ${func_name}'
+	return 0
+}
+
+fn core_reg_assert_return_type(b &Builder, func_name string, expected TypeID) {
+	idx := core_reg_func_idx(b, func_name)
+	assert b.mod.funcs[idx].typ == expected
+}
+
+fn core_reg_has_phi_type(b &Builder, func_name string, expected TypeID) bool {
+	for value_id in core_reg_func_value_ids(b, func_name) {
+		value := b.mod.values[value_id]
+		if value.kind != .instruction {
+			continue
+		}
+		instr := b.mod.instrs[value.index]
+		if instr.op == .phi && value.typ == expected {
+			return true
+		}
+	}
+	return false
+}
+
+fn core_reg_assert_call_or_cast_matrix(mut b Builder) {
+	i8_t := b.mod.type_store.get_int(8)
+	u8_t := b.mod.type_store.get_uint(8)
+	i32_t := b.mod.type_store.get_int(32)
+	ptr_i8_t := b.mod.type_store.get_ptr(i8_t)
+	ptr_u8_t := b.mod.type_store.get_ptr(u8_t)
+	dep_type := b.struct_types['dep__Type'] or {
+		assert false, 'missing dep__Type'
+		return
+	}
+	assert 'dep__value' in b.fn_index
+	dep_value_selector := ast.SelectorExpr{
+		lhs: core_reg_ident('dep')
+		rhs: ast.Ident{
+			name: 'value'
+		}
+	}
+	assert b.selector_module_name(dep_value_selector) or { '' } == 'dep'
+	string_type := b.get_string_type()
+	array_type := b.get_array_type()
+
+	core_reg_assert_callees(b, 'call_tos2', ['builtin__tos2'])
+	assert core_reg_find_call_type(b, 'call_tos2', 'builtin__tos2') == string_type
+
+	core_reg_assert_callees(b, 'cast_int', [])
+	core_reg_assert_return_type(b, 'cast_int', i32_t)
+	core_reg_assert_callees(b, 'cast_voidptr', [])
+	core_reg_assert_return_type(b, 'cast_voidptr', ptr_i8_t)
+	core_reg_assert_callees(b, 'cast_u8_ptr', [])
+	core_reg_assert_return_type(b, 'cast_u8_ptr', ptr_u8_t)
+
+	core_reg_assert_callees(b, 'call_c_puts', ['puts'])
+	assert core_reg_find_call_type(b, 'call_c_puts', 'puts') == i32_t
+	core_reg_assert_callees(b, 'dep__cast_c_type', [])
+	core_reg_assert_return_type(b, 'dep__cast_c_type', dep_type)
+
+	core_reg_assert_callees(b, 'call_dep_value', ['dep__value'])
+	assert core_reg_find_call_type(b, 'call_dep_value', 'dep__value') == i32_t
+	core_reg_assert_callees(b, 'cast_dep_type', [])
+	core_reg_assert_return_type(b, 'cast_dep_type', dep_type)
+
+	core_reg_assert_callees(b, 'clone_string', ['builtin__string__clone'])
+	assert core_reg_find_call_type(b, 'clone_string', 'builtin__string__clone') == string_type
+	core_reg_assert_callees(b, 'clone_array', ['builtin__array__clone'])
+	assert core_reg_find_call_type(b, 'clone_array', 'builtin__array__clone') == array_type
+	core_reg_assert_callees(b, 'call_array_alloc_like', [
+		'builtin__array__alloc_array_data_like_uninit',
+	])
+	assert core_reg_find_call_type(b, 'call_array_alloc_like',
+		'builtin__array__alloc_array_data_like_uninit') == ptr_i8_t
+}
+
+fn core_reg_assert_match_true_value(mut b Builder) {
+	string_type := b.get_string_type()
+	assert string_type != 0
+	core_reg_assert_return_type(b, 'fizz_value', string_type)
+	core_reg_assert_callees(b, 'fizz_value', ['builtin__int__str'])
+	assert core_reg_find_call_type(b, 'fizz_value', 'builtin__int__str') == string_type
+	assert core_reg_has_phi_type(b, 'fizz_value', string_type)
+}
+
+fn assert_core_builtin_types_registered(mut b Builder) {
+	assert ssa_string_ok('array')
+	assert ssa_string_ok('string')
+	assert b.get_array_type() != 0
+	assert b.get_string_type() != 0
+	assert b.struct_types['array'] == b.get_array_type()
+	assert b.struct_types['string'] == b.get_string_type()
+}
+
+fn test_build_all_preregisters_core_builtin_types() {
+	files := [core_reg_builtin_file()]
+	env := types.Environment.new()
+	mut mod := Module.new('core_builtin_type_registration')
+	mut b := Builder.new_with_env(mod, env)
+	b.skip_fn_bodies = true
+	b.minimal_runtime_roots = true
+	b.build_all(files)
+	assert_core_builtin_types_registered(mut b)
+}
+
+fn test_build_all_from_flat_preregisters_core_builtin_types() {
+	files := [core_reg_builtin_file()]
+	flat := ast.flatten_files(files)
+	env := types.Environment.new()
+	mut mod := Module.new('core_builtin_type_registration_flat')
+	mut b := Builder.new_with_env(mod, env)
+	b.skip_fn_bodies = true
+	b.minimal_runtime_roots = true
+	b.build_all_from_flat(&flat)
+	assert_core_builtin_types_registered(mut b)
+}
+
+fn test_string_literal_uses_canonical_string_struct_type() {
+	mut b := core_reg_build_contract()
+	string_type := b.get_string_type()
+	assert string_type != 0
+	assert b.mod.type_store.types[string_type].kind == .struct_t
+
+	mut found := false
+	for value in b.mod.values {
+		if value.kind == .string_literal {
+			assert value.typ == string_type
+			found = true
+		}
+	}
+	assert found
+}
+
+fn test_builtin_string_runes_signature_and_call_return_canonical_array_type() {
+	mut b := core_reg_build_contract()
+	array_type := b.get_array_type()
+	assert array_type != 0
+	assert b.mod.type_store.types[array_type].kind == .struct_t
+
+	runes_idx := core_reg_func_idx(b, 'builtin__string__runes')
+	assert b.mod.funcs[runes_idx].typ == array_type
+	assert core_reg_find_call_type(b, 'call_runes', 'builtin__string__runes') == array_type
+}
+
+fn test_string_graphemes_impl_has_no_zero_typed_loads() {
+	b := core_reg_build_contract()
+	core_reg_assert_no_zero_loads(b, 'builtin__string_graphemes_impl')
+}
+
+fn test_empty_dynamic_rune_array_local_load_is_canonical_array_type() {
+	mut b := core_reg_build_contract()
+	array_type := b.get_array_type()
+	mut found_array_load := false
+	for value_id in core_reg_func_value_ids(b, 'builtin__string__runes') {
+		value := b.mod.values[value_id]
+		if value.kind != .instruction {
+			continue
+		}
+		instr := b.mod.instrs[value.index]
+		if instr.op == .load {
+			assert value.typ != 0, 'builtin__string__runes has load v${value_id} with type 0'
+			if value.typ == array_type {
+				found_array_load = true
+			}
+		}
+	}
+	assert found_array_load
+}
+
+fn test_call_or_cast_dispatch_matrix_matches_legacy_and_flat() {
+	mut legacy := core_reg_build_call_or_cast_matrix_legacy()
+	core_reg_assert_call_or_cast_matrix(mut legacy)
+	mut flat := core_reg_build_call_or_cast_matrix_flat()
+	core_reg_assert_call_or_cast_matrix(mut flat)
+}
+
+fn test_match_true_expression_lowers_to_string_value_legacy_and_flat() {
+	mut legacy := core_reg_build_match_true_value_legacy()
+	core_reg_assert_match_true_value(mut legacy)
+	mut flat := core_reg_build_match_true_value_flat()
+	core_reg_assert_match_true_value(mut flat)
+}
+
+fn test_call_or_cast_known_builtin_fn_stays_call_before_string_clone_resolution() {
+	base_builtin := core_reg_builtin_file()
+	mut builtin_stmts := base_builtin.stmts.clone()
+	builtin_stmts << core_reg_tos2_decl()
+	builtin_stmts << core_reg_string_clone_decl()
+	builtin_stmts << core_reg_array_clone_decl()
+	builtin_stmts << core_reg_tos_clone_decl()
+	files := [
+		ast.File{
+			name:  base_builtin.name
+			mod:   base_builtin.mod
+			stmts: builtin_stmts
+		},
+	]
+	flat := ast.flatten_files(files)
+	env := types.Environment.new()
+	mut mod := Module.new('core_builtin_call_or_cast_fn')
+	mut b := Builder.new_with_env(mod, env)
+	b.minimal_runtime_roots = true
+	b.build_all_from_flat(&flat)
+
+	callees := core_reg_call_callees(b, 'builtin__tos_clone')
+	assert 'builtin__tos2' in callees
+	assert 'builtin__string__clone' in callees
+	assert 'builtin__array__clone' !in callees
+	assert core_reg_find_call_type(b, 'builtin__tos_clone', 'builtin__tos2') == b.get_string_type()
+	assert core_reg_find_call_type(b, 'builtin__tos_clone', 'builtin__string__clone') == b.get_string_type()
+}

--- a/vlib/v2/ssa/dynamic_array_literal_storage_test.v
+++ b/vlib/v2/ssa/dynamic_array_literal_storage_test.v
@@ -1,0 +1,345 @@
+module ssa
+
+import v2.ast
+import v2.token
+import v2.types
+
+fn dal_ident(name string) ast.Expr {
+	return ast.Expr(ast.Ident{
+		name: name
+	})
+}
+
+fn dal_num(value string) ast.Expr {
+	return ast.Expr(ast.BasicLiteral{
+		kind:  .number
+		value: value
+	})
+}
+
+fn dal_array_type(elem ast.Expr) ast.Expr {
+	return ast.Expr(ast.Type(ast.ArrayType{
+		elem_type: elem
+	}))
+}
+
+fn dal_sizeof(expr ast.Expr) ast.Expr {
+	return ast.Expr(ast.KeywordOperator{
+		op:    token.Token.key_sizeof
+		exprs: [expr]
+	})
+}
+
+fn dal_field(name string, typ string) ast.FieldDecl {
+	return ast.FieldDecl{
+		name: name
+		typ:  dal_ident(typ)
+	}
+}
+
+fn dal_param(name string, typ ast.Expr) ast.Parameter {
+	return ast.Parameter{
+		name: name
+		typ:  typ
+	}
+}
+
+fn dal_builtin_file() ast.File {
+	return ast.File{
+		name:  'builtin.v'
+		mod:   'builtin'
+		stmts: [
+			ast.Stmt(ast.ModuleStmt{
+				name: 'builtin'
+			}),
+			ast.Stmt(ast.StructDecl{
+				name:   'array'
+				fields: [
+					dal_field('data', 'voidptr'),
+					dal_field('offset', 'int'),
+					dal_field('len', 'int'),
+					dal_field('cap', 'int'),
+					dal_field('flags', 'int'),
+					dal_field('element_size', 'int'),
+				]
+			}),
+			ast.Stmt(ast.FnDecl{
+				name: 'new_array_from_c_array_noscan'
+				typ:  ast.FnType{
+					params:      [
+						dal_param('len', dal_ident('int')),
+						dal_param('cap', dal_ident('int')),
+						dal_param('elem_size', dal_ident('int')),
+						dal_param('data', dal_ident('voidptr')),
+					]
+					return_type: dal_ident('array')
+				}
+			}),
+		]
+	}
+}
+
+fn dal_dynamic_literal_files() []ast.File {
+	return [
+		dal_builtin_file(),
+		ast.File{
+			name:  'main.v'
+			mod:   'main'
+			stmts: [
+				ast.Stmt(ast.ModuleStmt{
+					name: 'main'
+				}),
+				ast.Stmt(ast.FnDecl{
+					name:  'make_arr'
+					typ:   ast.FnType{
+						return_type: dal_array_type(dal_ident('int'))
+					}
+					stmts: [
+						ast.Stmt(ast.AssignStmt{
+							op:  .decl_assign
+							lhs: [dal_ident('a')]
+							rhs: [
+								ast.Expr(ast.ArrayInitExpr{
+									exprs: [dal_num('1'), dal_num('2'),
+										dal_num('3')]
+								}),
+							]
+						}),
+						ast.Stmt(ast.ReturnStmt{
+							exprs: [
+								dal_ident('a'),
+							]
+						}),
+					]
+				}),
+				ast.Stmt(ast.FnDecl{
+					name:  'make_arr_of_arrs'
+					typ:   ast.FnType{
+						params:      [
+							dal_param('a', dal_array_type(dal_ident('int'))),
+							dal_param('b', dal_array_type(dal_ident('int'))),
+							dal_param('c', dal_array_type(dal_ident('int'))),
+						]
+						return_type: dal_array_type(dal_array_type(dal_ident('int')))
+					}
+					stmts: [
+						ast.Stmt(ast.ReturnStmt{
+							exprs: [
+								ast.Expr(ast.CallExpr{
+									lhs:  dal_ident('new_array_from_c_array_noscan')
+									args: [dal_num('3'), dal_num('3'),
+										dal_sizeof(dal_array_type(dal_ident('int'))),
+										ast.Expr(ast.ArrayInitExpr{
+											exprs: [dal_ident('a'),
+												dal_ident('b'),
+												dal_ident('c')]
+										})]
+								}),
+							]
+						}),
+					]
+				}),
+			]
+		},
+	]
+}
+
+fn dal_build_legacy() &Builder {
+	files := dal_dynamic_literal_files()
+	env := types.Environment.new()
+	mut mod := Module.new('dynamic_array_literal_storage_legacy')
+	mut b := Builder.new_with_env(mod, env)
+	b.minimal_runtime_roots = true
+	b.build_all(files)
+	return b
+}
+
+fn dal_build_flat() &Builder {
+	files := dal_dynamic_literal_files()
+	flat := ast.flatten_files(files)
+	env := types.Environment.new()
+	mut mod := Module.new('dynamic_array_literal_storage_flat')
+	mut b := Builder.new_with_env(mod, env)
+	b.minimal_runtime_roots = true
+	b.build_all_from_flat(&flat)
+	return b
+}
+
+fn dal_func_value_ids(b &Builder, name string) []ValueID {
+	idx := b.fn_index[name] or {
+		assert false, 'missing SSA function ${name}'
+		return []ValueID{}
+	}
+	mut ids := []ValueID{}
+	for block_id in b.mod.funcs[idx].blocks {
+		for value_id in b.mod.blocks[block_id].instrs {
+			ids << value_id
+		}
+	}
+	return ids
+}
+
+fn dal_new_array_call_ids(b &Builder, fn_name string) []ValueID {
+	mut call_ids := []ValueID{}
+	for value_id in dal_func_value_ids(b, fn_name) {
+		value := b.mod.values[value_id]
+		if value.kind != .instruction {
+			continue
+		}
+		instr := b.mod.instrs[value.index]
+		if instr.op != .call || instr.operands.len == 0 {
+			continue
+		}
+		callee_id := instr.operands[0]
+		if callee_id > 0 && callee_id < b.mod.values.len
+			&& b.mod.values[callee_id].name == 'builtin__new_array_from_c_array_noscan' {
+			call_ids << value_id
+		}
+	}
+	return call_ids
+}
+
+fn dal_new_array_call_in_fn(b &Builder, fn_name string) (ValueID, []ValueID) {
+	call_ids := dal_new_array_call_ids(b, fn_name)
+	assert call_ids.len == 1
+	call_id := call_ids[0]
+	instr := b.mod.instrs[b.mod.values[call_id].index]
+	return call_id, instr.operands
+}
+
+fn dal_new_array_call(b &Builder) (ValueID, []ValueID) {
+	return dal_new_array_call_in_fn(b, 'make_arr')
+}
+
+fn dal_fixed_array_alloca_type_id(b &Builder, value_id ValueID) TypeID {
+	if value_id <= 0 || value_id >= b.mod.values.len {
+		return 0
+	}
+	value := b.mod.values[value_id]
+	if value.kind != .instruction {
+		return 0
+	}
+	instr := b.mod.instrs[value.index]
+	if instr.op != .alloca {
+		return 0
+	}
+	typ := b.mod.type_store.types[value.typ]
+	if typ.kind != .ptr_t || typ.elem_type <= 0 || typ.elem_type >= b.mod.type_store.types.len {
+		return 0
+	}
+	fixed_type := typ.elem_type
+	if b.mod.type_store.types[fixed_type].kind != .array_t {
+		return 0
+	}
+	return fixed_type
+}
+
+fn dal_new_array_data_buffer_alloca(b &Builder, fn_name string) ValueID {
+	_, operands := dal_new_array_call_in_fn(b, fn_name)
+	assert operands.len == 5
+	data_arg := operands[4]
+	assert data_arg > 0 && data_arg < b.mod.values.len
+	data_value := b.mod.values[data_arg]
+	assert data_value.kind == .instruction
+	data_instr := b.mod.instrs[data_value.index]
+	if data_instr.op == .bitcast {
+		assert data_instr.operands.len == 1
+		return data_instr.operands[0]
+	}
+	return data_arg
+}
+
+fn dal_assert_single_new_array_call_in_fn(b &Builder, fn_name string) {
+	call_ids := dal_new_array_call_ids(b, fn_name)
+	assert call_ids.len == 1
+}
+
+fn dal_assert_array_of_arrays_literal_is_raw_element_buffer(b &Builder) {
+	array_type := b.struct_types['array'] or { TypeID(0) }
+	assert array_type != 0
+	dal_assert_single_new_array_call_in_fn(b, 'make_arr_of_arrs')
+	buffer_alloca := dal_new_array_data_buffer_alloca(b, 'make_arr_of_arrs')
+	fixed_type := dal_fixed_array_alloca_type_id(b, buffer_alloca)
+	assert fixed_type != 0
+	fixed_info := b.mod.type_store.types[fixed_type]
+	assert fixed_info.len == 3
+	assert fixed_info.elem_type == array_type
+	_, operands := dal_new_array_call_in_fn(b, 'make_arr_of_arrs')
+	assert b.mod.values[operands[1]].name == '3'
+	assert b.mod.values[operands[2]].name == '3'
+	assert b.mod.values[operands[3]].name == '32'
+}
+
+fn dal_is_fixed_array_alloca_ptr(b &Builder, value_id ValueID) bool {
+	return dal_fixed_array_alloca_type_id(b, value_id) != 0
+}
+
+fn dal_assert_no_nested_dynamic_array_for_arg(b &Builder) {
+	dal_assert_single_new_array_call_in_fn(b, 'make_arr_of_arrs')
+}
+
+fn dal_assert_dijkstra_array_literal_regression(b &Builder) {
+	dal_assert_array_of_arrays_literal_is_raw_element_buffer(b)
+	dal_assert_no_nested_dynamic_array_for_arg(b)
+}
+
+fn dal_assert_no_raw_fixed_array_local_store(b &Builder) {
+	for value_id in dal_func_value_ids(b, 'make_arr') {
+		value := b.mod.values[value_id]
+		if value.kind != .instruction {
+			continue
+		}
+		instr := b.mod.instrs[value.index]
+		if instr.op != .store || instr.operands.len < 2 {
+			continue
+		}
+		assert !dal_is_fixed_array_alloca_ptr(b, instr.operands[0])
+	}
+}
+
+fn dal_assert_dynamic_literal_storage_invariant(b &Builder) {
+	array_type := b.struct_types['array'] or { TypeID(0) }
+	assert array_type != 0
+	call_id, operands := dal_new_array_call(b)
+	assert b.mod.values[call_id].typ == array_type
+	assert operands.len == 5
+	assert b.mod.values[operands[1]].name == '3'
+	assert b.mod.values[operands[2]].name == '3'
+	assert b.mod.values[operands[3]].name == '4'
+
+	data_arg := operands[4]
+	assert data_arg > 0 && data_arg < b.mod.values.len
+	data_value := b.mod.values[data_arg]
+	assert data_value.kind == .instruction
+	data_instr := b.mod.instrs[data_value.index]
+	assert data_instr.op == .bitcast
+	assert data_instr.operands.len == 1
+	assert dal_is_fixed_array_alloca_ptr(b, data_instr.operands[0])
+
+	mut stored_call_to_array_local := false
+	for value_id in dal_func_value_ids(b, 'make_arr') {
+		value := b.mod.values[value_id]
+		if value.kind != .instruction {
+			continue
+		}
+		instr := b.mod.instrs[value.index]
+		if instr.op != .store || instr.operands.len < 2 || instr.operands[0] != call_id {
+			continue
+		}
+		dst_type := b.mod.type_store.types[b.mod.values[instr.operands[1]].typ]
+		assert dst_type.kind == .ptr_t
+		assert dst_type.elem_type == array_type
+		stored_call_to_array_local = true
+	}
+	assert stored_call_to_array_local
+	dal_assert_no_raw_fixed_array_local_store(b)
+}
+
+fn test_dynamic_array_literal_storage_invariant_matches_legacy_and_flat() {
+	legacy := dal_build_legacy()
+	dal_assert_dynamic_literal_storage_invariant(legacy)
+	dal_assert_dijkstra_array_literal_regression(legacy)
+	flat := dal_build_flat()
+	dal_assert_dynamic_literal_storage_invariant(flat)
+	dal_assert_dijkstra_array_literal_regression(flat)
+}

--- a/vlib/v2/ssa/module_storage_test.v
+++ b/vlib/v2/ssa/module_storage_test.v
@@ -12,7 +12,7 @@ fn module_storage_ssa_tmp_dir(label string) string {
 	return os.join_path(os.temp_dir(), 'v2_module_storage_ssa_${label}_${os.getpid()}')
 }
 
-fn module_storage_ssa_for_test_sources(label string, sources map[string]string) &Module {
+fn module_storage_ssa_builder_for_test_sources(label string, sources map[string]string) &Builder {
 	tmp_dir := module_storage_ssa_tmp_dir(label)
 	os.mkdir_all(tmp_dir) or { panic('cannot create ${tmp_dir}') }
 	defer {
@@ -25,7 +25,10 @@ fn module_storage_ssa_for_test_sources(label string, sources map[string]string) 
 		os.write_file(path, code) or { panic('cannot write ${path}') }
 		paths << path
 	}
-	prefs := &pref.Preferences{}
+	prefs := &pref.Preferences{
+		backend: .x64
+		arch:    .x64
+	}
 	mut file_set := token.FileSet.new()
 	mut par := parser.Parser.new(prefs)
 	files := par.parse_files(paths, mut file_set)
@@ -38,7 +41,12 @@ fn module_storage_ssa_for_test_sources(label string, sources map[string]string) 
 	mut mod := Module.new('module_storage_test')
 	mut builder := Builder.new_with_env(mod, env)
 	builder.build_all(transformed_files)
-	return mod
+	return builder
+}
+
+fn module_storage_ssa_for_test_sources(label string, sources map[string]string) &Module {
+	builder := module_storage_ssa_builder_for_test_sources(label, sources)
+	return builder.mod
 }
 
 fn module_storage_ssa_for_test_sources_flat(label string, sources map[string]string) &Module {
@@ -134,6 +142,31 @@ fn module_storage_ssa_return_value_ids(m &Module, func Function) []ValueID {
 	return ret_vals
 }
 
+fn module_storage_ssa_call_callees(m &Module, func Function) []string {
+	mut callees := []string{}
+	for blk_id in func.blocks {
+		for val_id in m.blocks[blk_id].instrs {
+			value := m.values[val_id]
+			if value.kind != .instruction {
+				continue
+			}
+			instr := m.instrs[value.index]
+			if instr.op != .call || instr.operands.len == 0 {
+				continue
+			}
+			callee_id := instr.operands[0]
+			if callee_id <= 0 || callee_id >= m.values.len {
+				continue
+			}
+			callee := m.values[callee_id]
+			if callee.kind == .func_ref {
+				callees << callee.name
+			}
+		}
+	}
+	return callees
+}
+
 fn test_module_storage_import_alias_resolves_to_declaring_module_in_ssa() {
 	m := module_storage_ssa_for_test_sources('alias', {
 		'report/report.v': 'module report
@@ -153,6 +186,97 @@ fn main() {
 	assert 'report__errors' in names
 	assert 'r__errors' !in names
 	assert module_storage_ssa_has_store_to_global(m, 'report__errors')
+}
+
+fn test_module_storage_legacy_direct_import_module_selector_one_arg_stays_call() {
+	m := module_storage_ssa_for_test_sources('module_selector_one_arg_call', {
+		'main.v':          'module main
+
+import left as l
+import right
+import helper
+
+fn main() {
+	first := l.state == 10 && right.state == 200 && l.score() == 1001 && right.score() == 20005
+	direct := l.bump(3)
+	transitive := helper.bump_right(5)
+	second := direct == 132 && transitive == 2057 && l.state == 13 && right.state == 205
+	_ = first
+	_ = second
+}
+'
+		'left/left.v':     'module left
+
+pub __global mut state = 10
+__global mut private_hits = 1
+
+pub fn bump(delta int) int {
+	state += delta
+	private_hits += 1
+	return state * 10 + private_hits
+}
+
+pub fn score() int {
+	return state * 100 + private_hits
+}
+'
+		'right/right.v':   'module right
+
+pub __global mut state = 200
+__global mut private_hits = 5
+
+pub fn bump(delta int) int {
+	state += delta
+	private_hits += 2
+	return state * 10 + private_hits
+}
+
+pub fn score() int {
+	return state * 100 + private_hits
+}
+'
+		'helper/helper.v': 'module helper
+
+import right as r
+
+pub fn bump_right(delta int) int {
+	return r.bump(delta)
+}
+
+pub fn right_score() int {
+	return r.score()
+}
+'
+	})
+	main_func := module_storage_ssa_func(m, 'main') or { panic('missing main') }
+	callees := module_storage_ssa_call_callees(m, main_func)
+	assert 'helper__bump_right' in callees
+}
+
+fn test_module_storage_legacy_call_or_cast_module_selector_prefers_registered_call() {
+	mut builder := module_storage_ssa_builder_for_test_sources('module_selector_call_or_cast_decision', {
+		'helper/helper.v': 'module helper
+
+pub fn bump_right(delta int) int {
+	return delta + 1
+}
+'
+		'main.v':          'module main
+
+import helper
+
+fn main() {}
+'
+	})
+	sel := ast.SelectorExpr{
+		lhs: ast.Expr(ast.Ident{
+			name: 'helper'
+		})
+		rhs: ast.Ident{
+			name: 'bump_right'
+		}
+	}
+	assert !builder.call_or_cast_selector_should_remain_cast(sel, 'helper__bump_right')
 }
 
 fn test_module_qualified_alias_array_field_index_has_alias_element_type() {

--- a/vlib/v2/ssa/struct_sumtype_field_init_test.v
+++ b/vlib/v2/ssa/struct_sumtype_field_init_test.v
@@ -1,0 +1,130 @@
+module ssa
+
+import os
+import v2.ast
+import v2.parser
+import v2.pref as vpref
+import v2.token
+import v2.transformer
+import v2.types
+
+fn struct_sumtype_field_init_source() string {
+	return '
+module main
+
+type Tree = Empty | Node
+
+struct Empty {}
+
+struct Node {
+	value int
+}
+
+struct Holder {
+	item Tree
+}
+
+fn make_holder() Holder {
+	return Holder{Node{42}}
+}
+'
+}
+
+fn build_struct_sumtype_field_init_legacy(label string) &Module {
+	tmp_file := os.join_path(os.vtmp_dir(), 'v2_ssa_struct_sumtype_field_${label}_${os.getpid()}.v')
+	os.write_file(tmp_file, struct_sumtype_field_init_source()) or {
+		panic('failed to write temp file')
+	}
+	defer {
+		os.rm(tmp_file) or {}
+	}
+	mut prefs := &vpref.Preferences{
+		backend:     .x64
+		no_parallel: true
+	}
+	mut file_set := token.FileSet.new()
+	mut par := parser.Parser.new(prefs)
+	files := par.parse_files([tmp_file], mut file_set)
+	mut env := types.Environment.new()
+	mut checker := types.Checker.new(prefs, file_set, env)
+	checker.check_files(files)
+	mut trans := transformer.Transformer.new_with_pref(env, prefs)
+	transformed := trans.transform_files(files)
+	mut ssa_mod := Module.new('struct_sumtype_field_legacy')
+	mut b := Builder.new_with_env(ssa_mod, env)
+	b.build_all(transformed)
+	return ssa_mod
+}
+
+fn build_struct_sumtype_field_init_flat(label string) &Module {
+	tmp_file := os.join_path(os.vtmp_dir(),
+		'v2_ssa_struct_sumtype_field_flat_${label}_${os.getpid()}.v')
+	os.write_file(tmp_file, struct_sumtype_field_init_source()) or {
+		panic('failed to write temp file')
+	}
+	defer {
+		os.rm(tmp_file) or {}
+	}
+	mut prefs := &vpref.Preferences{
+		backend:     .x64
+		no_parallel: true
+	}
+	mut file_set := token.FileSet.new()
+	mut par := parser.Parser.new(prefs)
+	files := par.parse_files([tmp_file], mut file_set)
+	mut env := types.Environment.new()
+	mut checker := types.Checker.new(prefs, file_set, env)
+	checker.check_files(files)
+	mut trans := transformer.Transformer.new_with_pref(env, prefs)
+	flat := ast.flatten_files(files)
+	transformed_flat, _ := trans.transform_files_to_flat(&flat, files)
+	mut ssa_mod := Module.new('struct_sumtype_field_flat')
+	mut b := Builder.new_with_env(ssa_mod, env)
+	b.build_all_from_flat(&transformed_flat)
+	return ssa_mod
+}
+
+fn struct_sumtype_field_type_id(m &Module, short_name string) TypeID {
+	for type_id, name in m.c_struct_names {
+		if name == short_name || name.all_after_last('__') == short_name {
+			return TypeID(type_id)
+		}
+	}
+	return 0
+}
+
+fn assert_holder_field_value_is_wrapped_tree(m &Module) {
+	tree_type := struct_sumtype_field_type_id(m, 'Tree')
+	node_type := struct_sumtype_field_type_id(m, 'Node')
+	holder_type := struct_sumtype_field_type_id(m, 'Holder')
+	assert tree_type != 0, 'missing Tree SSA type'
+	assert node_type != 0, 'missing Node SSA type'
+	assert holder_type != 0, 'missing Holder SSA type'
+	mut found_holder_init := false
+	for value in m.values {
+		if value.kind != .instruction || value.typ != holder_type {
+			continue
+		}
+		instr := m.instrs[value.index]
+		if instr.op != .struct_init || instr.operands.len != 1 {
+			continue
+		}
+		found_holder_init = true
+		field_value := instr.operands[0]
+		assert field_value > 0 && field_value < m.values.len
+		field_type := m.values[field_value].typ
+		assert field_type == tree_type, 'Holder.item must be wrapped as Tree, got type ${field_type}'
+		assert field_type != node_type, 'Holder.item was stored as raw Node instead of Tree'
+	}
+	assert found_holder_init, 'missing Holder struct_init'
+}
+
+fn test_struct_sumtype_field_init_wraps_variant_on_legacy_ast() {
+	m := build_struct_sumtype_field_init_legacy('legacy')
+	assert_holder_field_value_is_wrapped_tree(m)
+}
+
+fn test_struct_sumtype_field_init_wraps_variant_on_flat_ast() {
+	m := build_struct_sumtype_field_init_flat('flat')
+	assert_holder_field_value_is_wrapped_tree(m)
+}

--- a/vlib/v2/ssa/tree_sumtype_lowering_test.v
+++ b/vlib/v2/ssa/tree_sumtype_lowering_test.v
@@ -1,0 +1,694 @@
+module ssa
+
+import os
+import v2.ast
+import v2.parser
+import v2.pref
+import v2.token
+import v2.transformer
+import v2.types
+
+fn tree_sumtype_source() string {
+	source := r'module main
+
+type Tree = Empty | Node
+
+struct Empty {}
+
+struct Node {
+	value int
+	left  Tree
+	right Tree
+}
+
+fn size(tree Tree) int {
+	return match tree {
+		Empty { int(0) }
+		Node { 1 + size(tree.left) + size(tree.right) }
+	}
+}
+
+fn println(s string) {
+	_ = s
+}
+
+fn main() {
+	node1 := Node{30, Empty{}, Empty{}}
+	node2 := Node{20, Empty{}, Empty{}}
+	tree := Node{10, node1, node2}
+	println(@tree_structure_inter@)
+	println(@tree_size_inter@)
+}
+'
+	return source.replace('@tree_structure_inter@', "'tree structure:\\n \${tree}'").replace('@tree_size_inter@',
+		"'tree size: \${size(tree)}'")
+}
+
+fn tree_sumtype_example_source() string {
+	source := r'type Tree = Empty | Node
+
+struct Empty {}
+
+struct Node {
+	value int
+	left  Tree
+	right Tree
+}
+
+fn size(tree Tree) int {
+	return match tree {
+		Empty { int(0) }
+		Node { 1 + size(tree.left) + size(tree.right) }
+	}
+}
+
+fn println(s string) {
+	_ = s
+}
+
+fn main() {
+	node1 := Node{30, Empty{}, Empty{}}
+	node2 := Node{20, Empty{}, Empty{}}
+	tree := Node{10, node1, node2}
+	println(@tree_structure_inter@)
+	println(@tree_size_inter@)
+}
+'
+	return source.replace('@tree_structure_inter@', "'tree structure:\\n \${tree}'").replace('@tree_size_inter@',
+		"'tree size: \${size(tree)}'")
+}
+
+fn string_param_interpolation_source() string {
+	source := r'module main
+
+fn render(n int, src string, dst string) string {
+	return @move_inter@
+}
+
+fn main() {
+	_ = render(1, @src_arg@, @dst_arg@)
+}
+'
+	return source.replace('@move_inter@', "'Disc \${n} from \${src} to \${dst}...'").replace('@src_arg@',
+		"'a'").replace('@dst_arg@', "'b'")
+}
+
+fn hanoi_string_param_interpolation_source() string {
+	source := r'module main
+
+fn println(s string) {
+	_ = s
+}
+
+fn move(n int, a string, b string) {
+	println(@move_inter@)
+}
+
+fn hanoi(n int, a string, b string, c string) {
+	if n == 1 {
+		move(n, a, c)
+	} else {
+		hanoi(n - 1, a, c, b)
+		move(n, a, c)
+		hanoi(n - 1, b, a, c)
+	}
+}
+
+fn main() {
+	hanoi(3, "A", "B", "C")
+}
+'
+	return source.replace('@move_inter@', "'Disc \${n} from \${a} to \${b}...'")
+}
+
+fn tree_ssa_module_for_source(label string, source string) &Module {
+	tmp_dir := os.join_path(os.temp_dir(), 'v2_tree_sumtype_${label}_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic('cannot create ${tmp_dir}') }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	binary_dir := os.join_path(tmp_dir, 'encoding', 'binary')
+	os.mkdir_all(binary_dir) or { panic('cannot create ${binary_dir}') }
+	binary_path := os.join_path(binary_dir, 'binary.v')
+	os.write_file(binary_path, 'module binary
+
+pub fn size[T](x T) int {
+	_ = x
+	return -1
+}
+') or {
+		panic('cannot write ${binary_path}')
+	}
+	path := os.join_path(tmp_dir, 'main.v')
+	os.write_file(path, source) or { panic('cannot write ${path}') }
+	prefs := &pref.Preferences{
+		backend: .x64
+		arch:    .x64
+	}
+	mut file_set := token.FileSet.new()
+	mut par := parser.Parser.new(prefs)
+	files := par.parse_files([binary_path, path], mut file_set)
+	env := types.Environment.new()
+	mut checker := types.Checker.new(prefs, file_set, env)
+	checker.check_files(files)
+	mut trans := transformer.Transformer.new_with_pref(env, prefs)
+	trans.set_file_set(file_set)
+	transformed_files := trans.transform_files(files)
+	mut mod := Module.new('tree_sumtype_${label}')
+	mut builder := Builder.new_with_env(mod, env)
+	builder.build_all(transformed_files)
+	return mod
+}
+
+fn tree_ssa_module_for_source_flat(label string, source string) &Module {
+	tmp_dir := os.join_path(os.temp_dir(), 'v2_tree_sumtype_flat_${label}_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic('cannot create ${tmp_dir}') }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	binary_dir := os.join_path(tmp_dir, 'encoding', 'binary')
+	os.mkdir_all(binary_dir) or { panic('cannot create ${binary_dir}') }
+	binary_path := os.join_path(binary_dir, 'binary.v')
+	os.write_file(binary_path, 'module binary
+
+pub fn size[T](x T) int {
+	_ = x
+	return -1
+}
+') or {
+		panic('cannot write ${binary_path}')
+	}
+	path := os.join_path(tmp_dir, 'main.v')
+	os.write_file(path, source) or { panic('cannot write ${path}') }
+	prefs := &pref.Preferences{
+		backend: .x64
+		arch:    .x64
+	}
+	mut file_set := token.FileSet.new()
+	mut par := parser.Parser.new(prefs)
+	files := par.parse_files([binary_path, path], mut file_set)
+	env := types.Environment.new()
+	mut checker := types.Checker.new(prefs, file_set, env)
+	checker.check_files(files)
+	mut trans := transformer.Transformer.new_with_pref(env, prefs)
+	trans.set_file_set(file_set)
+	flat := ast.flatten_files(files)
+	transformed_flat, _ := trans.transform_files_to_flat(&flat, files)
+	mut mod := Module.new('tree_sumtype_flat_${label}')
+	mut builder := Builder.new_with_env(mod, env)
+	builder.build_all_from_flat(&transformed_flat)
+	return mod
+}
+
+fn tree_ssa_func(m &Module, name string) ?Function {
+	for func in m.funcs {
+		if func.name == name {
+			return func
+		}
+	}
+	return none
+}
+
+fn tree_ssa_call_callees(m &Module, func Function) []string {
+	mut callees := []string{}
+	for blk_id in func.blocks {
+		for val_id in m.blocks[blk_id].instrs {
+			value := m.values[val_id]
+			if value.kind != .instruction {
+				continue
+			}
+			instr := m.instrs[value.index]
+			if instr.op != .call || instr.operands.len == 0 {
+				continue
+			}
+			callee_id := instr.operands[0]
+			if callee_id <= 0 || callee_id >= m.values.len {
+				continue
+			}
+			callee := m.values[callee_id]
+			if callee.kind == .func_ref {
+				callees << callee.name
+			}
+		}
+	}
+	return callees
+}
+
+fn tree_ssa_type_name(m &Module, typ TypeID) string {
+	if typ <= 0 || int(typ) >= m.type_store.types.len {
+		return ''
+	}
+	return m.c_struct_names[int(typ)] or { '' }
+}
+
+fn tree_ssa_type_id_by_name(m &Module, type_name string) ?TypeID {
+	for type_id, name in m.c_struct_names {
+		if ssa_type_name_matches(name, type_name) {
+			return TypeID(type_id)
+		}
+	}
+	return none
+}
+
+fn tree_ssa_is_const_zero(m &Module, val_id ValueID) bool {
+	if val_id <= 0 || val_id >= m.values.len {
+		return false
+	}
+	return m.values[val_id].kind == .constant && m.values[val_id].name == '0'
+}
+
+fn tree_ssa_const_name(m &Module, val_id ValueID) string {
+	if val_id <= 0 || val_id >= m.values.len || m.values[val_id].kind != .constant {
+		return ''
+	}
+	return m.values[val_id].name
+}
+
+fn tree_ssa_value_points_to_type(m &Module, val_id ValueID, type_name string) bool {
+	if val_id <= 0 || val_id >= m.values.len {
+		return false
+	}
+	typ := m.values[val_id].typ
+	if typ <= 0 || int(typ) >= m.type_store.types.len {
+		return false
+	}
+	info := m.type_store.types[typ]
+	if info.kind != .ptr_t {
+		return false
+	}
+	return ssa_type_name_matches(tree_ssa_type_name(m, info.elem_type), type_name)
+}
+
+fn tree_ssa_has_sumtype_tag_extract(m &Module, func Function, type_name string) bool {
+	return tree_ssa_sumtype_tag_value_ids(m, func, type_name).len > 0
+}
+
+fn tree_ssa_sumtype_tag_value_ids(m &Module, func Function, type_name string) []ValueID {
+	mut sumtype_storage := []ValueID{}
+	for blk_id in func.blocks {
+		for val_id in m.blocks[blk_id].instrs {
+			value := m.values[val_id]
+			if value.kind != .instruction {
+				continue
+			}
+			instr := m.instrs[value.index]
+			if instr.op != .store || instr.operands.len < 2 {
+				continue
+			}
+			src_id := instr.operands[0]
+			dst_id := instr.operands[1]
+			if src_id <= 0 || src_id >= m.values.len || dst_id <= 0 || dst_id >= m.values.len {
+				continue
+			}
+			src_type_name := tree_ssa_type_name(m, m.values[src_id].typ)
+			if ssa_type_name_matches(src_type_name, type_name) && dst_id !in sumtype_storage {
+				sumtype_storage << dst_id
+			}
+		}
+	}
+	mut tag_ptrs := []ValueID{}
+	mut tag_vals := []ValueID{}
+	for blk_id in func.blocks {
+		for val_id in m.blocks[blk_id].instrs {
+			value := m.values[val_id]
+			if value.kind != .instruction {
+				continue
+			}
+			instr := m.instrs[value.index]
+			if instr.op == .extractvalue && instr.operands.len >= 2 {
+				base_id := instr.operands[0]
+				index_id := instr.operands[1]
+				if base_id <= 0 || base_id >= m.values.len || !tree_ssa_is_const_zero(m, index_id) {
+					continue
+				}
+				base_type_name := tree_ssa_type_name(m, m.values[base_id].typ)
+				if ssa_type_name_matches(base_type_name, type_name) {
+					tag_vals << val_id
+				}
+			}
+			if instr.op == .get_element_ptr && instr.operands.len >= 2 {
+				base_id := instr.operands[0]
+				index_id := instr.operands[1]
+				if !tree_ssa_is_const_zero(m, index_id) {
+					continue
+				}
+				if base_id in sumtype_storage
+					|| tree_ssa_value_points_to_type(m, base_id, type_name) {
+					tag_ptrs << val_id
+				}
+			}
+			if instr.op == .load && instr.operands.len > 0 {
+				ptr_id := instr.operands[0]
+				if ptr_id in tag_ptrs {
+					tag_vals << val_id
+				}
+			}
+		}
+	}
+	return tag_vals
+}
+
+fn tree_ssa_sumtype_tag_compare_const_names(m &Module, func Function, type_name string) []string {
+	tag_vals := tree_ssa_sumtype_tag_value_ids(m, func, type_name)
+	mut names := []string{}
+	for blk_id in func.blocks {
+		for val_id in m.blocks[blk_id].instrs {
+			value := m.values[val_id]
+			if value.kind != .instruction {
+				continue
+			}
+			instr := m.instrs[value.index]
+			if instr.op !in [.eq, .ne] || instr.operands.len < 2 {
+				continue
+			}
+			lhs := instr.operands[0]
+			rhs := instr.operands[1]
+			if lhs in tag_vals && rhs > 0 && rhs < m.values.len && m.values[rhs].kind == .constant {
+				names << m.values[rhs].name
+			}
+			if rhs in tag_vals && lhs > 0 && lhs < m.values.len && m.values[lhs].kind == .constant {
+				names << m.values[lhs].name
+			}
+		}
+	}
+	return names
+}
+
+fn tree_ssa_has_eq_on_type(m &Module, func Function, type_name string) bool {
+	for blk_id in func.blocks {
+		for val_id in m.blocks[blk_id].instrs {
+			value := m.values[val_id]
+			if value.kind != .instruction {
+				continue
+			}
+			instr := m.instrs[value.index]
+			if instr.op != .eq {
+				continue
+			}
+			for operand in instr.operands {
+				if operand <= 0 || operand >= m.values.len {
+					continue
+				}
+				operand_type_name := tree_ssa_type_name(m, m.values[operand].typ)
+				if ssa_type_name_matches(operand_type_name, type_name) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+fn tree_ssa_assert_sumtype_match_uses_tag(m &Module, func Function, type_name string) {
+	assert tree_ssa_has_sumtype_tag_extract(m, func, type_name)
+	assert !tree_ssa_has_eq_on_type(m, func, type_name)
+	tag_consts := tree_ssa_sumtype_tag_compare_const_names(m, func, type_name)
+	assert '0' in tag_consts
+	assert '1' in tag_consts
+}
+
+fn tree_ssa_assert_no_raw_tree_string_concat_arg(m &Module, func Function) {
+	string_concat_callees := ['builtin__string__+', 'builtin__string__plus_two']
+	for blk_id in func.blocks {
+		for val_id in m.blocks[blk_id].instrs {
+			value := m.values[val_id]
+			if value.kind != .instruction {
+				continue
+			}
+			instr := m.instrs[value.index]
+			if instr.op != .call || instr.operands.len < 2 {
+				continue
+			}
+			callee_id := instr.operands[0]
+			if callee_id <= 0 || callee_id >= m.values.len {
+				continue
+			}
+			callee := m.values[callee_id]
+			if callee.kind != .func_ref || callee.name !in string_concat_callees {
+				continue
+			}
+			for operand in instr.operands[1..] {
+				if operand <= 0 || operand >= m.values.len {
+					continue
+				}
+				operand_type := m.values[operand].typ
+				operand_type_name := tree_ssa_type_name(m, operand_type)
+				assert !ssa_type_name_matches(operand_type_name, 'Node'), '${func.name} passes raw Node v${operand} to ${callee.name}'
+
+				assert !ssa_type_name_matches(operand_type_name, 'Tree'), '${func.name} passes raw Tree v${operand} to ${callee.name}'
+			}
+		}
+	}
+}
+
+fn tree_ssa_assert_string_param_interpolation_has_no_string_str(m &Module) {
+	tree_ssa_assert_func_has_no_string_str(m, 'render')
+}
+
+fn tree_ssa_assert_func_has_no_string_str(m &Module, name string) {
+	func := tree_ssa_func(m, name) or { panic('missing ${name}') }
+	callees := tree_ssa_call_callees(m, func)
+	assert 'builtin__string__str' !in callees
+	assert 'string__str' !in callees
+	assert 'builtin__string__+' in callees || 'builtin__string__plus_two' in callees
+}
+
+fn tree_ssa_call_arg_type_names(m &Module, func Function, callee_name string) []string {
+	mut names := []string{}
+	for blk_id in func.blocks {
+		for val_id in m.blocks[blk_id].instrs {
+			value := m.values[val_id]
+			if value.kind != .instruction {
+				continue
+			}
+			instr := m.instrs[value.index]
+			if instr.op != .call || instr.operands.len < 2 {
+				continue
+			}
+			callee_id := instr.operands[0]
+			if callee_id <= 0 || callee_id >= m.values.len {
+				continue
+			}
+			callee := m.values[callee_id]
+			if callee.kind != .func_ref || callee.name != callee_name {
+				continue
+			}
+			arg_id := instr.operands[1]
+			if arg_id <= 0 || arg_id >= m.values.len {
+				continue
+			}
+			names << tree_ssa_type_name(m, m.values[arg_id].typ)
+		}
+	}
+	return names
+}
+
+fn test_tree_sumtype_main_calls_local_size_not_generic_size() {
+	m := tree_ssa_module_for_source('local_size', tree_sumtype_source())
+	main_func := tree_ssa_func(m, 'main') or { panic('missing main') }
+	size_func := tree_ssa_func(m, 'size') or { panic('missing size') }
+	main_callees := tree_ssa_call_callees(m, main_func)
+	size_callees := tree_ssa_call_callees(m, size_func)
+	assert 'size' in main_callees
+	assert 'size_T_Type' !in main_callees
+	assert 'binary__size_value_T_Type' !in main_callees
+	assert 'size' in size_callees
+	assert 'size_T_Type' !in size_callees
+	tree_ssa_assert_sumtype_match_uses_tag(m, size_func, 'Tree')
+	size_arg_types := tree_ssa_call_arg_type_names(m, main_func, 'size')
+	assert 'Tree' in size_arg_types
+	assert 'Node' !in size_arg_types
+}
+
+fn test_tree_sumtype_variant_struct_fields_keep_sumtype_storage_type() {
+	m := tree_ssa_module_for_source('variant_field_storage', tree_sumtype_source())
+	node_type := tree_ssa_type_id_by_name(m, 'Node') or { panic('missing Node type') }
+	node_info := m.type_store.types[node_type]
+	left_idx := node_info.field_names.index('left')
+	right_idx := node_info.field_names.index('right')
+	assert left_idx >= 0
+	assert right_idx >= 0
+	assert ssa_type_name_matches(tree_ssa_type_name(m, node_info.fields[left_idx]), 'Tree')
+	assert ssa_type_name_matches(tree_ssa_type_name(m, node_info.fields[right_idx]), 'Tree')
+}
+
+fn tree_ssa_assert_variant_struct_init_wraps_sumtype_fields(m &Module) {
+	main_func := tree_ssa_func(m, 'main') or { panic('missing main') }
+	mut saw_root_node_init := false
+	for blk_id in main_func.blocks {
+		for val_id in m.blocks[blk_id].instrs {
+			value := m.values[val_id]
+			if value.kind != .instruction {
+				continue
+			}
+			instr := m.instrs[value.index]
+			if instr.op != .struct_init || instr.operands.len < 3 {
+				continue
+			}
+			if !ssa_type_name_matches(tree_ssa_type_name(m, value.typ), 'Node') {
+				continue
+			}
+			if tree_ssa_const_name(m, instr.operands[0]) != '10' {
+				continue
+			}
+			saw_root_node_init = true
+			assert ssa_type_name_matches(tree_ssa_type_name(m, m.values[instr.operands[1]].typ),
+				'Tree')
+			assert ssa_type_name_matches(tree_ssa_type_name(m, m.values[instr.operands[2]].typ),
+				'Tree')
+		}
+	}
+	assert saw_root_node_init
+}
+
+fn test_tree_sumtype_variant_struct_init_wraps_sumtype_fields() {
+	m := tree_ssa_module_for_source('variant_field_init', tree_sumtype_source())
+	tree_ssa_assert_variant_struct_init_wraps_sumtype_fields(m)
+}
+
+fn test_tree_sumtype_flat_variant_struct_init_wraps_sumtype_fields() {
+	m := tree_ssa_module_for_source_flat('flat_variant_field_init', tree_sumtype_source())
+	tree_ssa_assert_variant_struct_init_wraps_sumtype_fields(m)
+}
+
+fn test_tree_sumtype_interpolation_uses_autostr_not_raw_struct_string() {
+	m := tree_ssa_module_for_source('node_str', tree_sumtype_source())
+	main_func := tree_ssa_func(m, 'main') or { panic('missing main') }
+	main_callees := tree_ssa_call_callees(m, main_func)
+	main_uses_autostr := 'Tree__str' in main_callees || 'Node__str' in main_callees
+	assert main_uses_autostr
+	if 'Tree__str' in main_callees {
+		tree_str_callees := tree_ssa_call_callees(m, tree_ssa_func(m, 'Tree__str') or {
+			panic('missing Tree__str')
+		})
+		assert 'Empty__str' in tree_str_callees
+		assert 'Node__str' in tree_str_callees
+	}
+	assert 'Tree__str' in tree_ssa_call_callees(m, tree_ssa_func(m, 'Node__str') or {
+		panic('missing Node__str')
+	})
+	tree_ssa_assert_no_raw_tree_string_concat_arg(m, main_func)
+}
+
+fn test_tree_sumtype_example_interpolation_uses_node_str_and_tree_str_helpers() {
+	m := tree_ssa_module_for_source('example_node_str', tree_sumtype_example_source())
+	main_func := tree_ssa_func(m, 'main') or { panic('missing main') }
+	main_callees := tree_ssa_call_callees(m, main_func)
+	assert 'Node__str' in main_callees
+	node_str_callees := tree_ssa_call_callees(m, tree_ssa_func(m, 'Node__str') or {
+		panic('missing Node__str')
+	})
+	assert 'Tree__str' in node_str_callees
+	tree_str_callees := tree_ssa_call_callees(m, tree_ssa_func(m, 'Tree__str') or {
+		panic('missing Tree__str')
+	})
+	assert 'Empty__str' in tree_str_callees
+	assert 'Node__str' in tree_str_callees
+	tree_ssa_assert_no_raw_tree_string_concat_arg(m, main_func)
+}
+
+fn test_tree_sumtype_flat_match_uses_tag_and_autostr_helpers() {
+	m := tree_ssa_module_for_source_flat('tree_pipeline', tree_sumtype_source())
+	main_func := tree_ssa_func(m, 'main') or { panic('missing main') }
+	size_func := tree_ssa_func(m, 'size') or { panic('missing size') }
+	tree_ssa_assert_sumtype_match_uses_tag(m, size_func, 'Tree')
+	main_callees := tree_ssa_call_callees(m, main_func)
+	main_uses_autostr := 'Tree__str' in main_callees || 'Node__str' in main_callees
+	assert main_uses_autostr
+	assert 'Tree__str' in tree_ssa_call_callees(m, tree_ssa_func(m, 'Node__str') or {
+		panic('missing Node__str')
+	})
+	tree_ssa_assert_no_raw_tree_string_concat_arg(m, main_func)
+}
+
+fn test_string_parameter_interpolation_does_not_call_string_str() {
+	m := tree_ssa_module_for_source('string_param_interpolation',
+		string_param_interpolation_source())
+	tree_ssa_assert_string_param_interpolation_has_no_string_str(m)
+}
+
+fn test_flat_string_parameter_interpolation_does_not_call_string_str() {
+	m := tree_ssa_module_for_source_flat('flat_string_param_interpolation',
+		string_param_interpolation_source())
+	tree_ssa_assert_string_param_interpolation_has_no_string_str(m)
+}
+
+fn test_hanoi_string_parameter_interpolation_does_not_call_string_str() {
+	m := tree_ssa_module_for_source('hanoi_string_param_interpolation',
+		hanoi_string_param_interpolation_source())
+	tree_ssa_assert_func_has_no_string_str(m, 'move')
+}
+
+fn test_flat_hanoi_string_parameter_interpolation_does_not_call_string_str() {
+	m := tree_ssa_module_for_source_flat('flat_hanoi_string_param_interpolation',
+		hanoi_string_param_interpolation_source())
+	tree_ssa_assert_func_has_no_string_str(m, 'move')
+}
+
+fn test_tree_sumtype_convert_to_string_uses_registered_autostr_helper() {
+	mut mod := Module.new('tree_three_field_struct')
+	mut builder := Builder.new_with_env(mod, types.Environment.new())
+	i8_type := builder.mod.type_store.get_int(8)
+	ptr_i8_type := builder.mod.type_store.get_ptr(i8_type)
+	int_type := builder.mod.type_store.get_int(32)
+	string_type := builder.mod.type_store.register(Type{
+		kind:        .struct_t
+		fields:      [ptr_i8_type, int_type, int_type]
+		field_names: ['str', 'len', 'is_lit']
+	})
+	builder.struct_types['string'] = string_type
+	builder.mod.c_struct_names[int(string_type)] = 'string'
+	node_type := builder.mod.type_store.register(Type{
+		kind:        .struct_t
+		fields:      [int_type, string_type, string_type]
+		field_names: ['value', 'left', 'right']
+	})
+	builder.mod.c_struct_names[int(node_type)] = 'Node'
+	node_val := builder.mod.add_value_node(.argument, node_type, 'node', 0)
+	node_str_fn := builder.mod.new_function('Node__str', string_type, []TypeID{})
+	builder.fn_index['Node__str'] = node_str_fn
+	test_fn := builder.mod.new_function('test_convert_to_string', string_type, []TypeID{})
+	builder.cur_func = test_fn
+	builder.cur_block = builder.mod.add_block(test_fn, 'entry')
+	converted := builder.convert_to_string(node_val, node_type)
+	assert converted != node_val
+	assert builder.mod.values[converted].typ == string_type
+	assert builder.mod.values[converted].kind == .instruction
+	instr := builder.mod.instrs[builder.mod.values[converted].index]
+	assert instr.op == .call
+	assert instr.operands.len > 0
+	callee := builder.mod.values[instr.operands[0]]
+	assert callee.kind == .func_ref
+	assert callee.name == 'Node__str'
+}
+
+fn test_convert_to_string_treats_string_struct_names_as_already_string() {
+	for type_name in ['string', 'builtin__string'] {
+		mut mod := Module.new('string_alias_${type_name}')
+		mut builder := Builder.new_with_env(mod, types.Environment.new())
+		i8_type := builder.mod.type_store.get_int(8)
+		ptr_i8_type := builder.mod.type_store.get_ptr(i8_type)
+		int_type := builder.mod.type_store.get_int(32)
+		string_type := builder.mod.type_store.register(Type{
+			kind:        .struct_t
+			fields:      [ptr_i8_type, int_type, int_type]
+			field_names: ['str', 'len', 'is_lit']
+		})
+		builder.mod.c_struct_names[int(string_type)] = type_name
+		string_val := builder.mod.add_value_node(.argument, string_type, 's', 0)
+		str_fn := builder.mod.new_function('${type_name}__str', string_type, [
+			string_type,
+		])
+		builder.fn_index['${type_name}__str'] = str_fn
+		test_fn := builder.mod.new_function('test_convert_to_string_${type_name}', string_type,
+			[]TypeID{})
+		builder.cur_func = test_fn
+		builder.cur_block = builder.mod.add_block(test_fn, 'entry')
+
+		assert builder.is_string_struct_type(string_type)
+		str_fn_name := builder.str_fn_name_for_ssa_type(string_type) or { '' }
+		assert str_fn_name == ''
+		converted := builder.convert_to_string(string_val, string_type)
+		assert converted == string_val
+	}
+}

--- a/vlib/v2/transformer/auto_str_generation_test.v
+++ b/vlib/v2/transformer/auto_str_generation_test.v
@@ -1,0 +1,513 @@
+module transformer
+
+import os
+import v2.ast
+import v2.parser
+import v2.pref as vpref
+import v2.token
+import v2.types
+
+fn auto_str_parse_files_for_test(label string, source string) ([]ast.File, ast.FlatAst, &types.Environment, &vpref.Preferences) {
+	tmp_file := os.join_path(os.vtmp_dir(), 'v2_auto_str_generation_${label}_${os.getpid()}.v')
+	os.write_file(tmp_file, source) or { panic('failed to write temp file') }
+	defer {
+		os.rm(tmp_file) or {}
+	}
+	mut prefs := &vpref.Preferences{
+		backend:     .x64
+		no_parallel: true
+	}
+	mut file_set := token.FileSet.new()
+	mut par := parser.Parser.new(prefs)
+	files := par.parse_files([tmp_file], mut file_set)
+	mut env := types.Environment.new()
+	mut checker := types.Checker.new(prefs, file_set, env)
+	checker.check_files(files)
+	flat := ast.flatten_files(files)
+	return files, flat, env, prefs
+}
+
+fn auto_str_legacy_generated_files(label string, source string) []ast.File {
+	files, _, env, prefs := auto_str_parse_files_for_test(label, source)
+	mut trans := Transformer.new_with_pref(env, prefs)
+	return trans.transform_files(files)
+}
+
+fn auto_str_flat_generated_files(label string, source string) []ast.File {
+	files, flat, env, prefs := auto_str_parse_files_for_test(label, source)
+	mut trans := Transformer.new_with_pref(env, prefs)
+	transformed_flat, _ := trans.transform_files_to_flat_via_driver(&flat, files)
+	return transformed_flat.to_files()
+}
+
+fn auto_str_generated_fn_names(files []ast.File) []string {
+	mut names := []string{}
+	for file in files {
+		for stmt in file.stmts {
+			if stmt is ast.FnDecl && stmt.name.ends_with('__str') {
+				names << stmt.name
+			}
+		}
+	}
+	names.sort()
+	return names
+}
+
+fn assert_auto_str_names(files []ast.File, expected []string) {
+	names := auto_str_generated_fn_names(files)
+	for name in expected {
+		assert name in names, '${name} missing from generated names ${names}'
+	}
+}
+
+fn auto_str_generated_fn(files []ast.File, name string) ?ast.FnDecl {
+	for file in files {
+		for stmt in file.stmts {
+			if stmt is ast.FnDecl && stmt.name == name {
+				return stmt
+			}
+		}
+	}
+	return none
+}
+
+fn auto_str_collect_stmt_string_literals(stmt ast.Stmt, mut values []string) {
+	match stmt {
+		ast.AssignStmt {
+			for expr in stmt.lhs {
+				auto_str_collect_expr_string_literals(expr, mut values)
+			}
+			for expr in stmt.rhs {
+				auto_str_collect_expr_string_literals(expr, mut values)
+			}
+		}
+		ast.ExprStmt {
+			auto_str_collect_expr_string_literals(stmt.expr, mut values)
+		}
+		ast.ReturnStmt {
+			for expr in stmt.exprs {
+				auto_str_collect_expr_string_literals(expr, mut values)
+			}
+		}
+		else {}
+	}
+}
+
+fn auto_str_collect_expr_string_literals(expr ast.Expr, mut values []string) {
+	match expr {
+		ast.AsCastExpr {
+			auto_str_collect_expr_string_literals(expr.expr, mut values)
+			auto_str_collect_expr_string_literals(expr.typ, mut values)
+		}
+		ast.CallExpr {
+			for arg in expr.args {
+				auto_str_collect_expr_string_literals(arg, mut values)
+			}
+		}
+		ast.CastExpr {
+			auto_str_collect_expr_string_literals(expr.expr, mut values)
+			auto_str_collect_expr_string_literals(expr.typ, mut values)
+		}
+		ast.IfExpr {
+			auto_str_collect_expr_string_literals(expr.cond, mut values)
+			for nested in expr.stmts {
+				auto_str_collect_stmt_string_literals(nested, mut values)
+			}
+			auto_str_collect_expr_string_literals(expr.else_expr, mut values)
+		}
+		ast.InfixExpr {
+			auto_str_collect_expr_string_literals(expr.lhs, mut values)
+			auto_str_collect_expr_string_literals(expr.rhs, mut values)
+		}
+		ast.ModifierExpr {
+			auto_str_collect_expr_string_literals(expr.expr, mut values)
+		}
+		ast.ParenExpr {
+			auto_str_collect_expr_string_literals(expr.expr, mut values)
+		}
+		ast.PrefixExpr {
+			auto_str_collect_expr_string_literals(expr.expr, mut values)
+		}
+		ast.SelectorExpr {
+			auto_str_collect_expr_string_literals(expr.lhs, mut values)
+		}
+		ast.StringLiteral {
+			values << expr.value
+		}
+		else {}
+	}
+}
+
+fn auto_str_fn_string_literals(files []ast.File, fn_name string) []string {
+	fn_decl := auto_str_generated_fn(files, fn_name) or {
+		assert false, 'missing generated function ${fn_name}'
+		return []string{}
+	}
+	mut values := []string{}
+	for stmt in fn_decl.stmts {
+		auto_str_collect_stmt_string_literals(stmt, mut values)
+	}
+	return values
+}
+
+fn auto_str_has_literal_prefix(values []string, prefix string) bool {
+	for value in values {
+		if value.starts_with(prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+fn auto_str_collect_stmt_call_names(stmt ast.Stmt, mut names []string) {
+	match stmt {
+		ast.AssignStmt {
+			for expr in stmt.lhs {
+				auto_str_collect_expr_call_names(expr, mut names)
+			}
+			for expr in stmt.rhs {
+				auto_str_collect_expr_call_names(expr, mut names)
+			}
+		}
+		ast.ExprStmt {
+			auto_str_collect_expr_call_names(stmt.expr, mut names)
+		}
+		ast.ReturnStmt {
+			for expr in stmt.exprs {
+				auto_str_collect_expr_call_names(expr, mut names)
+			}
+		}
+		else {}
+	}
+}
+
+fn auto_str_collect_expr_call_names(expr ast.Expr, mut names []string) {
+	match expr {
+		ast.AsCastExpr {
+			auto_str_collect_expr_call_names(expr.expr, mut names)
+			auto_str_collect_expr_call_names(expr.typ, mut names)
+		}
+		ast.CallExpr {
+			if expr.lhs is ast.Ident {
+				lhs := expr.lhs as ast.Ident
+				names << lhs.name
+			}
+			for arg in expr.args {
+				auto_str_collect_expr_call_names(arg, mut names)
+			}
+		}
+		ast.CastExpr {
+			auto_str_collect_expr_call_names(expr.expr, mut names)
+			auto_str_collect_expr_call_names(expr.typ, mut names)
+		}
+		ast.IfExpr {
+			auto_str_collect_expr_call_names(expr.cond, mut names)
+			for nested in expr.stmts {
+				auto_str_collect_stmt_call_names(nested, mut names)
+			}
+			auto_str_collect_expr_call_names(expr.else_expr, mut names)
+		}
+		ast.InfixExpr {
+			auto_str_collect_expr_call_names(expr.lhs, mut names)
+			auto_str_collect_expr_call_names(expr.rhs, mut names)
+		}
+		ast.ModifierExpr {
+			auto_str_collect_expr_call_names(expr.expr, mut names)
+		}
+		ast.ParenExpr {
+			auto_str_collect_expr_call_names(expr.expr, mut names)
+		}
+		ast.PrefixExpr {
+			auto_str_collect_expr_call_names(expr.expr, mut names)
+		}
+		ast.SelectorExpr {
+			auto_str_collect_expr_call_names(expr.lhs, mut names)
+		}
+		ast.StringInterLiteral {
+			for inter in expr.inters {
+				auto_str_collect_expr_call_names(inter.expr, mut names)
+				auto_str_collect_expr_call_names(inter.format_expr, mut names)
+			}
+		}
+		else {}
+	}
+}
+
+fn auto_str_fn_call_names(files []ast.File, fn_name string) []string {
+	fn_decl := auto_str_generated_fn(files, fn_name) or {
+		assert false, 'missing generated function ${fn_name}'
+		return []string{}
+	}
+	mut names := []string{}
+	for stmt in fn_decl.stmts {
+		auto_str_collect_stmt_call_names(stmt, mut names)
+	}
+	return names
+}
+
+fn auto_str_collect_stmt_selector_names(stmt ast.Stmt, mut names []string) {
+	match stmt {
+		ast.AssignStmt {
+			for expr in stmt.lhs {
+				auto_str_collect_expr_selector_names(expr, mut names)
+			}
+			for expr in stmt.rhs {
+				auto_str_collect_expr_selector_names(expr, mut names)
+			}
+		}
+		ast.ExprStmt {
+			auto_str_collect_expr_selector_names(stmt.expr, mut names)
+		}
+		ast.ReturnStmt {
+			for expr in stmt.exprs {
+				auto_str_collect_expr_selector_names(expr, mut names)
+			}
+		}
+		else {}
+	}
+}
+
+fn auto_str_collect_expr_selector_names(expr ast.Expr, mut names []string) {
+	match expr {
+		ast.AsCastExpr {
+			auto_str_collect_expr_selector_names(expr.expr, mut names)
+			auto_str_collect_expr_selector_names(expr.typ, mut names)
+		}
+		ast.CallExpr {
+			for arg in expr.args {
+				auto_str_collect_expr_selector_names(arg, mut names)
+			}
+		}
+		ast.CastExpr {
+			auto_str_collect_expr_selector_names(expr.expr, mut names)
+			auto_str_collect_expr_selector_names(expr.typ, mut names)
+		}
+		ast.IfExpr {
+			auto_str_collect_expr_selector_names(expr.cond, mut names)
+			for nested in expr.stmts {
+				auto_str_collect_stmt_selector_names(nested, mut names)
+			}
+			auto_str_collect_expr_selector_names(expr.else_expr, mut names)
+		}
+		ast.InfixExpr {
+			auto_str_collect_expr_selector_names(expr.lhs, mut names)
+			auto_str_collect_expr_selector_names(expr.rhs, mut names)
+		}
+		ast.ModifierExpr {
+			auto_str_collect_expr_selector_names(expr.expr, mut names)
+		}
+		ast.ParenExpr {
+			auto_str_collect_expr_selector_names(expr.expr, mut names)
+		}
+		ast.PrefixExpr {
+			auto_str_collect_expr_selector_names(expr.expr, mut names)
+		}
+		ast.SelectorExpr {
+			names << expr.rhs.name
+			auto_str_collect_expr_selector_names(expr.lhs, mut names)
+		}
+		ast.StringInterLiteral {
+			for inter in expr.inters {
+				auto_str_collect_expr_selector_names(inter.expr, mut names)
+				auto_str_collect_expr_selector_names(inter.format_expr, mut names)
+			}
+		}
+		else {}
+	}
+}
+
+fn auto_str_fn_selector_names(files []ast.File, fn_name string) []string {
+	fn_decl := auto_str_generated_fn(files, fn_name) or {
+		assert false, 'missing generated function ${fn_name}'
+		return []string{}
+	}
+	mut names := []string{}
+	for stmt in fn_decl.stmts {
+		auto_str_collect_stmt_selector_names(stmt, mut names)
+	}
+	return names
+}
+
+fn assert_auto_str_simple_point_body(files []ast.File) {
+	literals := auto_str_fn_string_literals(files, 'Point__str')
+	calls := auto_str_fn_call_names(files, 'Point__str')
+	assert 'Point{}' !in literals
+	assert auto_str_has_literal_prefix(literals, 'Point{')
+	assert '    x: ' in literals
+	assert '    y: ' in literals
+	assert 'strings__Builder__write_string' in calls
+	assert 'strings__Builder__str' in calls
+}
+
+fn assert_auto_str_recursive_node_body(files []ast.File) {
+	literals := auto_str_fn_string_literals(files, 'Node__str')
+	calls := auto_str_fn_call_names(files, 'Node__str')
+	assert 'Node{}' !in literals
+	assert auto_str_has_literal_prefix(literals, 'Node{')
+	assert '    value: ' in literals
+	assert '    left: ' in literals
+	assert '    right: ' in literals
+	assert 'Tree__str' in calls
+	assert 'string__replace' in calls
+}
+
+fn assert_auto_str_tree_sumtype_body(files []ast.File) {
+	literals := auto_str_fn_string_literals(files, 'Tree__str')
+	calls := auto_str_fn_call_names(files, 'Tree__str')
+	selectors := auto_str_fn_selector_names(files, 'Tree__str')
+	assert 'Tree(' in literals
+	assert ')' in literals
+	assert 'Tree{}' in literals
+	assert 'Empty__str' in calls
+	assert 'Node__str' in calls
+	assert '_tag' in selectors
+}
+
+fn assert_auto_str_main_uses_node_str(files []ast.File) {
+	calls := auto_str_fn_call_names(files, 'main')
+	assert 'Node__str' in calls
+}
+
+fn test_auto_struct_str_generates_field_struct_helper_from_legacy_and_flat() {
+	source := '
+module main
+
+struct Point {
+	x int
+	y int
+}
+
+fn show(point Point) string {
+	return "\${point}"
+}
+'
+	legacy := auto_str_legacy_generated_files('simple_struct_legacy', source)
+	flat := auto_str_flat_generated_files('simple_struct_flat', source)
+	assert_auto_str_names(legacy, ['Point__str'])
+	assert_auto_str_names(flat, ['Point__str'])
+	assert_auto_str_simple_point_body(legacy)
+	assert_auto_str_simple_point_body(flat)
+}
+
+fn test_auto_sumtype_str_generates_wrapper_and_variant_helpers_from_legacy_and_flat() {
+	source := '
+module main
+
+type Tree = Empty | Node
+
+struct Empty {}
+
+struct Node {
+	value int
+}
+
+fn show(tree Tree) string {
+	return "\${tree}"
+}
+'
+	legacy := auto_str_legacy_generated_files('sumtype_legacy', source)
+	flat := auto_str_flat_generated_files('sumtype_flat', source)
+	assert_auto_str_names(legacy, ['Empty__str', 'Node__str', 'Tree__str'])
+	assert_auto_str_names(flat, ['Empty__str', 'Node__str', 'Tree__str'])
+	assert_auto_str_tree_sumtype_body(legacy)
+	assert_auto_str_tree_sumtype_body(flat)
+}
+
+fn test_auto_recursive_struct_sumtype_str_generates_helpers_from_legacy_and_flat() {
+	source := '
+module main
+
+type Tree = Empty | Node
+
+struct Empty {}
+
+struct Node {
+	value int
+	left  Tree
+	right Tree
+}
+
+fn show(node Node) string {
+	return "\${node}"
+}
+'
+	legacy := auto_str_legacy_generated_files('recursive_legacy', source)
+	flat := auto_str_flat_generated_files('recursive_flat', source)
+	assert_auto_str_names(legacy, ['Empty__str', 'Node__str', 'Tree__str'])
+	assert_auto_str_names(flat, ['Empty__str', 'Node__str', 'Tree__str'])
+	assert_auto_str_recursive_node_body(legacy)
+	assert_auto_str_recursive_node_body(flat)
+	assert_auto_str_tree_sumtype_body(legacy)
+	assert_auto_str_tree_sumtype_body(flat)
+}
+
+fn test_auto_recursive_struct_sumtype_str_from_call_arg_interpolation_legacy_and_flat() {
+	source := '
+module main
+
+type Tree = Empty | Node
+
+struct Empty {}
+
+struct Node {
+	value int
+	left  Tree
+	right Tree
+}
+
+fn sink(s string) {
+	_ = s
+}
+
+fn main() {
+	leaf := Node{7, Empty{}, Empty{}}
+	root := Node{9, leaf, Empty{}}
+	sink("\${root}")
+}
+'
+	legacy := auto_str_legacy_generated_files('recursive_call_arg_legacy', source)
+	flat := auto_str_flat_generated_files('recursive_call_arg_flat', source)
+	assert_auto_str_names(legacy, ['Empty__str', 'Node__str', 'Tree__str'])
+	assert_auto_str_names(flat, ['Empty__str', 'Node__str', 'Tree__str'])
+	assert_auto_str_main_uses_node_str(legacy)
+	assert_auto_str_main_uses_node_str(flat)
+	assert_auto_str_recursive_node_body(legacy)
+	assert_auto_str_recursive_node_body(flat)
+	assert_auto_str_tree_sumtype_body(legacy)
+	assert_auto_str_tree_sumtype_body(flat)
+}
+
+fn test_auto_recursive_struct_sumtype_str_from_implicit_main_call_arg_legacy_and_flat() {
+	source := '
+type Tree = Empty | Node
+
+struct Empty {}
+
+struct Node {
+	value int
+	left  Tree
+	right Tree
+}
+
+fn sink(s string) {
+	_ = s
+}
+
+fn main() {
+	node1 := Node{30, Empty{}, Empty{}}
+	node2 := Node{20, Empty{}, Empty{}}
+	tree := Node{10, node1, node2}
+	sink("\${tree}")
+}
+'
+	legacy := auto_str_legacy_generated_files('recursive_implicit_main_call_arg_legacy', source)
+	flat := auto_str_flat_generated_files('recursive_implicit_main_call_arg_flat', source)
+	assert_auto_str_names(legacy, ['Empty__str', 'Node__str', 'Tree__str'])
+	assert_auto_str_names(flat, ['Empty__str', 'Node__str', 'Tree__str'])
+	assert_auto_str_main_uses_node_str(legacy)
+	assert_auto_str_main_uses_node_str(flat)
+	assert_auto_str_recursive_node_body(legacy)
+	assert_auto_str_recursive_node_body(flat)
+	assert_auto_str_tree_sumtype_body(legacy)
+	assert_auto_str_tree_sumtype_body(flat)
+}

--- a/vlib/v2/transformer/fn.v
+++ b/vlib/v2/transformer/fn.v
@@ -49,6 +49,9 @@ fn (t &Transformer) type_from_param_type_expr(expr ast.Expr, generic_params []st
 	if generic_name != '' {
 		return types.Type(types.NamedType(generic_name))
 	}
+	if typ := t.generic_aware_type_from_param_type_expr(expr, generic_params) {
+		return typ
+	}
 	// Resolve from the AST directly so nested type shapes like `&map[K]V`
 	// don't lose structure round-tripping through C-style name strings
 	// (which are ambiguous for pointer-of-map vs. map-of-pointer).
@@ -66,6 +69,81 @@ fn (t &Transformer) type_from_param_type_expr(expr ast.Expr, generic_params []st
 	if c_name != '' && c_name != type_name {
 		if typ := t.c_name_to_type(c_name) {
 			return typ
+		}
+	}
+	return none
+}
+
+fn (t &Transformer) generic_aware_type_from_param_type_expr(expr ast.Expr, generic_params []string) ?types.Type {
+	if expr is ast.Ident {
+		if expr.name in generic_params {
+			return types.Type(types.NamedType(expr.name))
+		}
+		return none
+	}
+	if expr is ast.ModifierExpr {
+		return t.generic_aware_type_from_param_type_expr(expr.expr, generic_params)
+	}
+	if expr is ast.PrefixExpr && expr.op == .amp {
+		base := t.type_from_param_type_expr(expr.expr, generic_params) or { return none }
+		return types.Type(types.Pointer{
+			base_type: base
+		})
+	}
+	if expr is ast.Type {
+		match expr {
+			ast.ArrayType {
+				elem := t.type_from_param_type_expr(expr.elem_type, generic_params) or {
+					return none
+				}
+				return types.Type(types.Array{
+					elem_type: elem
+				})
+			}
+			ast.ArrayFixedType {
+				elem := t.type_from_param_type_expr(expr.elem_type, generic_params) or {
+					return none
+				}
+				return types.Type(types.ArrayFixed{
+					len:       expr.len.str().int()
+					elem_type: elem
+				})
+			}
+			ast.MapType {
+				key := t.type_from_param_type_expr(expr.key_type, generic_params) or { return none }
+				value := t.type_from_param_type_expr(expr.value_type, generic_params) or {
+					return none
+				}
+				return types.Type(types.Map{
+					key_type:   key
+					value_type: value
+				})
+			}
+			ast.PointerType {
+				base := t.type_from_param_type_expr(expr.base_type, generic_params) or {
+					return none
+				}
+				return types.Type(types.Pointer{
+					base_type: base
+				})
+			}
+			ast.OptionType {
+				base := t.type_from_param_type_expr(expr.base_type, generic_params) or {
+					return none
+				}
+				return types.Type(types.OptionType{
+					base_type: base
+				})
+			}
+			ast.ResultType {
+				base := t.type_from_param_type_expr(expr.base_type, generic_params) or {
+					return none
+				}
+				return types.Type(types.ResultType{
+					base_type: base
+				})
+			}
+			else {}
 		}
 	}
 	return none
@@ -1123,7 +1201,7 @@ fn transformer_string_has_valid_data(s string) bool {
 		return false
 	}
 	ptr := unsafe { u64(s.str) }
-	return ptr >= 0x100000000 && ptr < 0x0000800000000000
+	return transformer_data_ptr_has_valid_address(ptr)
 }
 
 fn (t &Transformer) method_key_matches_type_name(method_key string, type_name string) bool {
@@ -2763,6 +2841,13 @@ fn (mut t Transformer) transform_call_expr(expr ast.CallExpr) ast.Expr {
 		fn_name := expr.lhs.name
 		if fn_name in ['println', 'eprintln', 'print', 'eprint'] && expr.args.len == 1 {
 			arg := expr.args[0]
+			if arg is ast.StringInterLiteral {
+				return ast.CallExpr{
+					lhs:  ast.Expr(expr.lhs)
+					args: [t.transform_expr(arg)]
+					pos:  expr.pos
+				}
+			}
 			if !t.is_string_expr(arg) {
 				// Get the str function name and record it for generation
 				str_fn_info := t.get_str_fn_info_for_expr(arg)
@@ -3248,6 +3333,9 @@ mut:
 }
 
 fn (t &Transformer) call_fn_info_for_lhs(lhs ast.Expr) ?CallFnInfo {
+	if lhs is ast.Ident && t.has_current_module_concrete_fn(lhs.name) {
+		return t.lookup_call_fn_info(lhs)
+	}
 	if base_name := t.generic_call_base_name(lhs) {
 		return t.generic_aware_call_fn_info(lhs, base_name)
 	}
@@ -3261,6 +3349,8 @@ fn (t &Transformer) generic_aware_call_fn_info(lhs ast.Expr, base_name string) ?
 	}
 	if decl_info := t.generic_call_info_for_decl(base_name) {
 		decl_call_info := t.drop_method_receiver_from_call_info(lhs, decl_info)
+		needs_decl_generic_signature := info.generic_params.len == 0
+			&& decl_call_info.generic_params.len > 0
 		if info.generic_params.len == 0 {
 			info.generic_params = decl_call_info.generic_params.clone()
 		}
@@ -3274,7 +3364,7 @@ fn (t &Transformer) generic_aware_call_fn_info(lhs ast.Expr, base_name string) ?
 		if info.param_names.len == 0 {
 			info.param_names = decl_call_info.param_names.clone()
 		}
-		if info.param_types.len == 0 {
+		if info.param_types.len == 0 || needs_decl_generic_signature {
 			info.param_types = decl_call_info.param_types.clone()
 		}
 		if !info.is_variadic {
@@ -3612,9 +3702,10 @@ fn (t &Transformer) inferred_generic_call_name(base_name string, info CallFnInfo
 	if base_name == '' || base_name.contains('_T_') || info.generic_params.len == 0 {
 		return none
 	}
-	bindings := t.generic_bindings_from_call_args(info, call_args) or { return none }
-	mut parts := []string{cap: info.generic_params.len}
-	for param_name in info.generic_params {
+	infer_info := t.generic_inference_info_for_call(base_name, info, call_args.len)
+	bindings := t.generic_bindings_from_call_args(infer_info, call_args) or { return none }
+	mut parts := []string{cap: infer_info.generic_params.len}
+	for param_name in infer_info.generic_params {
 		concrete := bindings[param_name] or { return none }
 		parts << t.generic_specialization_token_from_type(concrete)
 	}
@@ -3631,6 +3722,14 @@ fn (t &Transformer) inferred_generic_call_name(base_name string, info CallFnInfo
 	return '${base}_T_${parts.join('_')}'
 }
 
+fn (t &Transformer) generic_inference_info_for_call(base_name string, info CallFnInfo, call_arg_count int) CallFnInfo {
+	decl_info := t.generic_call_info_for_decl(base_name) or { return info }
+	if decl_info.generic_params.len == 0 || decl_info.param_types.len != call_arg_count {
+		return info
+	}
+	return decl_info
+}
+
 fn (mut t Transformer) register_generic_call_return_type(base_name string, info CallFnInfo, call_args []ast.Expr, pos token.Pos) {
 	if !pos.is_valid() || base_name == '' {
 		return
@@ -3640,7 +3739,8 @@ fn (mut t Transformer) register_generic_call_return_type(base_name string, info 
 	if generic_params.len == 0 || decl.typ.return_type is ast.EmptyExpr {
 		return
 	}
-	bindings := t.generic_bindings_from_call_args(info, call_args) or { return }
+	infer_info := t.generic_inference_info_for_call(base_name, info, call_args.len)
+	bindings := t.generic_bindings_from_call_args(infer_info, call_args) or { return }
 	ret_type := t.type_from_param_type_expr(decl.typ.return_type, generic_params) or { return }
 	t.register_synth_type(pos, substitute_type(ret_type, bindings))
 }
@@ -3661,6 +3761,9 @@ fn (t &Transformer) generic_bindings_from_call_args(info CallFnInfo, call_args [
 		}
 		generic_name := info.generic_params[generic_idx]
 		if generic_name in bindings {
+			continue
+		}
+		if !t.call_info_param_is_direct_generic(info, param_idx, generic_name) {
 			continue
 		}
 		arg_type := t.call_arg_type_for_generic_infer(arg) or { continue }
@@ -3684,6 +3787,9 @@ fn (t &Transformer) generic_bindings_from_call_args(info CallFnInfo, call_args [
 			if generic_name in tail_bindings {
 				continue
 			}
+			if !t.call_info_param_is_direct_generic(info, param_idx, generic_name) {
+				continue
+			}
 			arg_type := t.call_arg_type_for_generic_infer(arg) or { continue }
 			tail_bindings[generic_name] = arg_type
 		}
@@ -3705,6 +3811,23 @@ fn (t &Transformer) generic_bindings_from_call_args(info CallFnInfo, call_args [
 		return none
 	}
 	return bindings
+}
+
+fn (t &Transformer) call_info_param_is_direct_generic(info CallFnInfo, param_idx int, generic_name string) bool {
+	if param_idx < 0 || generic_name == '' {
+		return false
+	}
+	if param_idx >= info.param_types.len {
+		return true
+	}
+	param_type := generic_infer_unwrap_alias(t, info.param_types[param_idx])
+	if param_type is types.Void {
+		return true
+	}
+	if param_type is types.NamedType {
+		return string(param_type) == generic_name
+	}
+	return false
 }
 
 fn (t &Transformer) infer_generic_bindings_from_call_args(param_types []types.Type, call_args []ast.Expr, generic_params []string, param_offset int, mut bindings map[string]types.Type) {
@@ -5528,6 +5651,13 @@ fn (mut t Transformer) transform_call_or_cast_expr(expr ast.CallOrCastExpr) ast.
 		fn_name := expr.lhs.name
 		if fn_name in ['println', 'eprintln', 'print', 'eprint'] {
 			arg := expr.expr
+			if arg is ast.StringInterLiteral {
+				return ast.CallExpr{
+					lhs:  ast.Expr(expr.lhs)
+					args: [t.transform_expr(arg)]
+					pos:  expr.pos
+				}
+			}
 			if !t.is_string_expr(arg) {
 				// Get the str function name and record it for generation
 				str_fn_info := t.get_str_fn_info_for_expr(arg)

--- a/vlib/v2/transformer/monomorphize.v
+++ b/vlib/v2/transformer/monomorphize.v
@@ -1882,31 +1882,53 @@ fn (t &Transformer) resolve_generic_decl_key_for_call(base_name string, decl_nod
 	if name == '' {
 		return none
 	}
-	if !name.contains('__') && !name.contains('.') && t.cur_module != '' && t.cur_module != 'main'
+	if !name.contains('__') && !name.contains('.') && t.cur_module != ''
 		&& t.cur_module != 'builtin' {
-		call_prefix := module_call_c_prefix(t.cur_module)
-		if call_prefix != '' {
-			candidate := '${call_prefix}__${name}'
+		if t.cur_module != 'main' {
+			call_prefix := module_call_c_prefix(t.cur_module)
+			if call_prefix != '' {
+				candidate := '${call_prefix}__${name}'
+				if candidate in decl_node {
+					return candidate
+				}
+			}
+			module_prefix := t.cur_module.replace('.', '__')
+			if module_prefix != '' {
+				candidate := '${module_prefix}__${name}'
+				if candidate in decl_node {
+					return candidate
+				}
+			}
+			candidate := '${t.cur_module}.${name}'
 			if candidate in decl_node {
 				return candidate
 			}
 		}
-		module_prefix := t.cur_module.replace('.', '__')
-		if module_prefix != '' {
-			candidate := '${module_prefix}__${name}'
-			if candidate in decl_node {
-				return candidate
-			}
-		}
-		candidate := '${t.cur_module}.${name}'
-		if candidate in decl_node {
-			return candidate
-		}
-		if _ := t.lookup_fn_cached(t.cur_module, name) {
+		if t.has_current_module_concrete_fn(name) {
 			return none
 		}
 	}
 	return t.resolve_monomorphize_decl_key(name, decl_node)
+}
+
+fn (t &Transformer) has_current_module_concrete_fn(name string) bool {
+	return t.has_concrete_fn_in_module(t.cur_module, name)
+		|| (t.cur_module == 'main' && t.has_concrete_fn_in_module('', name))
+}
+
+fn (t &Transformer) has_concrete_fn_in_module(module_name string, name string) bool {
+	if fn_type := t.lookup_fn_cached(module_name, name) {
+		return fn_type.get_generic_params().len == 0
+	}
+	scope := t.get_module_scope(module_name) or { return false }
+	obj := scope.objects[name] or { return false }
+	if obj is types.Fn {
+		typ := obj.get_typ()
+		if typ is types.FnType {
+			return typ.get_generic_params().len == 0
+		}
+	}
+	return false
 }
 
 fn (mut t Transformer) collect_generic_call_specs(files []ast.File) {
@@ -5645,11 +5667,12 @@ fn (mut t Transformer) clone_expr_with_bindings_and_fields(expr ast.Expr, bindin
 					return specialized
 				}
 			}
+			pos := t.clone_monomorphized_pos_with_type(expr.pos, bindings)
 			return ast.Expr(ast.IndexExpr{
 				lhs:      t.clone_expr_with_bindings_and_fields(expr.lhs, bindings, contexts)
 				expr:     t.clone_expr_with_bindings_and_fields(expr.expr, bindings, contexts)
 				is_gated: expr.is_gated
-				pos:      expr.pos
+				pos:      pos
 			})
 		}
 		ast.RangeExpr {
@@ -6269,11 +6292,12 @@ pub fn (mut t Transformer) clone_expr_with_bindings(expr ast.Expr, bindings map[
 					return specialized
 				}
 			}
+			pos := t.clone_monomorphized_pos_with_type(expr.pos, bindings)
 			return ast.Expr(ast.IndexExpr{
 				lhs:      t.clone_expr_with_bindings(expr.lhs, bindings)
 				expr:     t.clone_expr_with_bindings(expr.expr, bindings)
 				is_gated: expr.is_gated
-				pos:      expr.pos
+				pos:      pos
 			})
 		}
 		ast.InitExpr {

--- a/vlib/v2/transformer/monomorphize_test.v
+++ b/vlib/v2/transformer/monomorphize_test.v
@@ -4,10 +4,12 @@
 // vtest build: !windows
 module transformer
 
+import os
 import v2.ast
+import v2.parser
+import v2.pref as vpref
 import v2.token
 import v2.types
-import v2.pref as vpref
 
 fn mono_test_transformer() &Transformer {
 	env := &types.Environment{}
@@ -198,6 +200,357 @@ fn test_generic_call_info_bare_lookup_stays_in_current_module() {
 	decl := t.generic_fn_decl_for_call_info('encode') or { panic('missing current module decl') }
 	gp := decl.typ.generic_params[0] as ast.Ident
 	assert gp.name == 'CborT'
+}
+
+fn test_transformer_pointer_guards_accept_low_canonical_pointers() {
+	assert sumtype_payload_word_is_valid(1, 0x10000)
+	assert transformer_data_ptr_has_valid_address(0x10000)
+	assert !sumtype_payload_word_is_valid(1, 0)
+	assert !sumtype_payload_word_is_valid(1, 3)
+}
+
+fn mono_transform_dijkstra_shape_for_test() []ast.File {
+	source_path := os.join_path(os.temp_dir(), 'v2_mono_dijkstra_shape_${os.getpid()}.v')
+	os.write_file(source_path, '
+module main
+
+struct NODE {
+mut:
+	data int
+	priority int
+}
+
+fn push_pq[T](mut prior_queue []T, data int, priority int) {
+	_ = prior_queue
+	_ = data
+	_ = priority
+}
+
+fn updating_priority[T](mut prior_queue []T, search_data int, new_priority int) {
+	_ = prior_queue
+	_ = search_data
+	_ = new_priority
+}
+
+fn departure_priority[T](mut prior_queue []T) int {
+	_ = prior_queue
+	return 0
+}
+
+fn all_adjacents[T](g [][]T, v int) []int {
+	mut temp := []int{}
+	for i in 0 .. g.len {
+		if g[v][i] > 0 {
+			temp << i
+		}
+	}
+	return temp
+}
+
+fn print_solution[T](dist []T) {
+	_ = dist
+}
+
+fn print_paths_dist[T](path []T, dist []T) {
+	_ = path
+	_ = dist
+}
+
+fn dijkstra(g [][]int, s int) {
+	mut pq_queue := []NODE{}
+	push_pq(mut pq_queue, s, 0)
+	mut n := g.len
+	mut dist := []int{len: n, init: -1}
+	mut path := []int{len: n, init: -1}
+	dist[s] = 0
+	for pq_queue.len != 0 {
+		mut v := departure_priority(mut pq_queue)
+		mut adjs_of_v := all_adjacents(g, v)
+		mut new_dist := 0
+		for w in adjs_of_v {
+			new_dist = dist[v] + g[v][w]
+			if dist[w] == -1 {
+				dist[w] = new_dist
+				push_pq(mut pq_queue, w, dist[w])
+				path[w] = v
+			}
+			if dist[w] > new_dist {
+				dist[w] = new_dist
+				updating_priority(mut pq_queue, w, dist[w])
+				path[w] = v
+			}
+		}
+	}
+	print_solution(dist)
+	print_paths_dist(path, dist)
+}
+') or {
+		panic('failed to write temp source')
+	}
+	defer {
+		os.rm(source_path) or {}
+	}
+	prefs := &vpref.Preferences{
+		backend:     .x64
+		no_parallel: true
+	}
+	mut file_set := token.FileSet.new()
+	mut par := parser.Parser.new(prefs)
+	files := par.parse_files([source_path], mut file_set)
+	mut env := types.Environment.new()
+	mut checker := types.Checker.new(prefs, file_set, env)
+	checker.check_files(files)
+	mut trans := Transformer.new_with_pref(env, prefs)
+	return trans.transform_files(files)
+}
+
+fn mono_collect_call_names_from_expr(expr ast.Expr, mut names []string) {
+	match expr {
+		ast.ArrayInitExpr {
+			for nested in expr.exprs {
+				mono_collect_call_names_from_expr(nested, mut names)
+			}
+		}
+		ast.CallExpr {
+			if expr.lhs is ast.Ident {
+				names << expr.lhs.name
+			}
+			mono_collect_call_names_from_expr(expr.lhs, mut names)
+			for arg in expr.args {
+				mono_collect_call_names_from_expr(arg, mut names)
+			}
+		}
+		ast.IfExpr {
+			mono_collect_call_names_from_expr(expr.cond, mut names)
+			for stmt in expr.stmts {
+				mono_collect_call_names_from_stmt(stmt, mut names)
+			}
+			mono_collect_call_names_from_expr(expr.else_expr, mut names)
+		}
+		ast.InfixExpr {
+			mono_collect_call_names_from_expr(expr.lhs, mut names)
+			mono_collect_call_names_from_expr(expr.rhs, mut names)
+		}
+		ast.ModifierExpr {
+			mono_collect_call_names_from_expr(expr.expr, mut names)
+		}
+		ast.ParenExpr {
+			mono_collect_call_names_from_expr(expr.expr, mut names)
+		}
+		ast.PrefixExpr {
+			mono_collect_call_names_from_expr(expr.expr, mut names)
+		}
+		ast.SelectorExpr {
+			mono_collect_call_names_from_expr(expr.lhs, mut names)
+		}
+		else {}
+	}
+}
+
+fn mono_collect_call_names_from_stmt(stmt ast.Stmt, mut names []string) {
+	match stmt {
+		ast.AssignStmt {
+			for expr in stmt.rhs {
+				mono_collect_call_names_from_expr(expr, mut names)
+			}
+		}
+		ast.ExprStmt {
+			mono_collect_call_names_from_expr(stmt.expr, mut names)
+		}
+		ast.ForStmt {
+			mono_collect_call_names_from_expr(stmt.cond, mut names)
+			for nested in stmt.stmts {
+				mono_collect_call_names_from_stmt(nested, mut names)
+			}
+		}
+		ast.ReturnStmt {
+			for expr in stmt.exprs {
+				mono_collect_call_names_from_expr(expr, mut names)
+			}
+		}
+		else {}
+	}
+}
+
+fn mono_call_names_for_fn(files []ast.File, fn_name string) []string {
+	mut names := []string{}
+	for file in files {
+		for stmt in file.stmts {
+			if stmt is ast.FnDecl && stmt.name == fn_name {
+				for nested in stmt.stmts {
+					mono_collect_call_names_from_stmt(nested, mut names)
+				}
+			}
+		}
+	}
+	return names
+}
+
+fn mono_has_fn(files []ast.File, fn_name string) bool {
+	for file in files {
+		for stmt in file.stmts {
+			if stmt is ast.FnDecl && stmt.name == fn_name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+fn test_transform_dijkstra_shape_rewrites_inferred_generic_nested_array_call() {
+	files := mono_transform_dijkstra_shape_for_test()
+	call_names := mono_call_names_for_fn(files, 'dijkstra')
+	assert 'all_adjacents_T_int' in call_names
+	assert 'all_adjacents' !in call_names
+	assert mono_has_fn(files, 'all_adjacents_T_int')
+}
+
+fn test_inferred_generic_call_name_for_nested_array_param() {
+	mut t := mono_test_transformer()
+	t.cur_module = 'main'
+	t.generic_fn_decl_index['all_adjacents'] = ast.FnDecl{
+		name: 'all_adjacents'
+		typ:  ast.FnType{
+			generic_params: [
+				ast.Expr(ast.Ident{
+					name: 'T'
+				}),
+			]
+			params:         [
+				ast.Parameter{
+					name: 'g'
+					typ:  ast.Expr(ast.Type(ast.ArrayType{
+						elem_type: ast.Expr(ast.Type(ast.ArrayType{
+							elem_type: ast.Expr(ast.Ident{
+								name: 'T'
+							})
+						}))
+					}))
+				},
+				ast.Parameter{
+					name: 'v'
+					typ:  ast.Expr(ast.Ident{
+						name: 'int'
+					})
+				},
+			]
+		}
+	}
+	t.local_decl_types['g'] = types.Type(types.Array{
+		elem_type: types.Type(types.Array{
+			elem_type: types.Type(types.int_)
+		})
+	})
+	info := CallFnInfo{
+		param_types:                    [
+			types.Type(types.Array{
+				elem_type: types.Type(types.Array{
+					elem_type: types.Type(types.NamedType('T'))
+				})
+			}),
+			types.Type(types.int_),
+		]
+		generic_param_names_by_param:   ['T', '']
+		generic_param_indexes_by_param: [0, -1]
+		generic_params:                 ['T']
+	}
+	call_name := t.inferred_generic_call_name('all_adjacents', info, [
+		ast.Expr(ast.Ident{
+			name: 'g'
+		}),
+		ast.Expr(ast.Ident{
+			name: 'v'
+		}),
+	]) or { panic('missing inferred generic call name') }
+	assert call_name == 'all_adjacents_T_int'
+}
+
+fn test_generic_call_info_preserves_nested_array_generic_param() {
+	mut t := mono_test_transformer()
+	t.cur_module = 'main'
+	t.generic_fn_decl_index['all_adjacents'] = ast.FnDecl{
+		name: 'all_adjacents'
+		typ:  ast.FnType{
+			generic_params: [
+				ast.Expr(ast.Ident{
+					name: 'T'
+				}),
+			]
+			params:         [
+				ast.Parameter{
+					name: 'g'
+					typ:  ast.Expr(ast.Type(ast.ArrayType{
+						elem_type: ast.Expr(ast.Type(ast.ArrayType{
+							elem_type: ast.Expr(ast.Ident{
+								name: 'T'
+							})
+						}))
+					}))
+				},
+			]
+		}
+	}
+	info := t.generic_call_info_for_decl('all_adjacents') or { panic('missing generic call info') }
+	assert info.param_types.len == 1
+	outer := info.param_types[0] as types.Array
+	inner := outer.elem_type as types.Array
+	assert inner.elem_type.name() == 'T'
+}
+
+fn test_transform_rewrites_inferred_generic_call_for_nested_array_param() {
+	mut t := mono_test_transformer()
+	t.cur_module = 'main'
+	t.generic_fn_decl_index['all_adjacents'] = ast.FnDecl{
+		name: 'all_adjacents'
+		typ:  ast.FnType{
+			generic_params: [
+				ast.Expr(ast.Ident{
+					name: 'T'
+				}),
+			]
+			params:         [
+				ast.Parameter{
+					name: 'g'
+					typ:  ast.Expr(ast.Type(ast.ArrayType{
+						elem_type: ast.Expr(ast.Type(ast.ArrayType{
+							elem_type: ast.Expr(ast.Ident{
+								name: 'T'
+							})
+						}))
+					}))
+				},
+				ast.Parameter{
+					name: 'v'
+					typ:  ast.Expr(ast.Ident{
+						name: 'int'
+					})
+				},
+			]
+		}
+	}
+	t.local_decl_types['g'] = types.Type(types.Array{
+		elem_type: types.Type(types.Array{
+			elem_type: types.Type(types.int_)
+		})
+	})
+	t.local_decl_types['v'] = types.Type(types.int_)
+	out := t.transform_call_expr(ast.CallExpr{
+		lhs:  ast.Ident{
+			name: 'all_adjacents'
+		}
+		args: [
+			ast.Expr(ast.Ident{
+				name: 'g'
+			}),
+			ast.Expr(ast.Ident{
+				name: 'v'
+			}),
+		]
+	})
+	assert out is ast.CallExpr
+	call := out as ast.CallExpr
+	assert call.lhs is ast.Ident
+	assert (call.lhs as ast.Ident).name == 'all_adjacents_T_int'
 }
 
 fn test_clone_fn_decl_substitutes_fn_literal_signature() {

--- a/vlib/v2/transformer/struct.v
+++ b/vlib/v2/transformer/struct.v
@@ -1403,18 +1403,27 @@ fn (mut t Transformer) transform_init_expr(expr ast.InitExpr) ast.Expr {
 	// Note: ArrayInitExpr is NOT transformed here because cleanc uses field type info
 	// to determine if it's a fixed-size array (which transformer doesn't have access to)
 	mut fields := []ast.FieldInit{cap: expr.fields.len}
+	positional_field_names := t.struct_positional_field_names(struct_type_name)
+	mut positional_idx := 0
 	for field in expr.fields {
+		mut lookup_field_name := field.name
+		if lookup_field_name == '' {
+			if positional_idx < positional_field_names.len {
+				lookup_field_name = positional_field_names[positional_idx]
+			}
+			positional_idx++
+		}
 		// Check if this field is a sum type and needs wrapping
-		mut field_type_name := t.get_struct_field_type_name(struct_type_name, field.name)
+		mut field_type_name := t.get_struct_field_type_name(struct_type_name, lookup_field_name)
 		mut expected_field_type := types.Type(types.int_)
 		mut has_expected_field_type := false
 		mut pretransformed_value := ast.empty_expr
 		mut has_pretransformed_value := false
-		if direct_type := t.lookup_struct_field_type(struct_type_name, field.name) {
+		if direct_type := t.lookup_struct_field_type(struct_type_name, lookup_field_name) {
 			expected_field_type = direct_type
 			has_expected_field_type = true
 			field_type_name = t.type_to_c_name(direct_type)
-		} else if direct_type := t.get_init_expr_field_type(init_typ_expr, field.name) {
+		} else if direct_type := t.get_init_expr_field_type(init_typ_expr, lookup_field_name) {
 			expected_field_type = direct_type
 			has_expected_field_type = true
 			field_type_name = t.type_to_c_name(direct_type)
@@ -1425,7 +1434,7 @@ fn (mut t Transformer) transform_init_expr(expr ast.InitExpr) ast.Expr {
 			}
 		} else {
 			// Fallback to direct type lookup from the init expression type.
-			field_type_name = t.get_init_expr_field_type_name(expr.typ, field.name)
+			field_type_name = t.get_init_expr_field_type_name(expr.typ, lookup_field_name)
 			if field_type_name != '' {
 				if expected_typ := t.lookup_type(field_type_name) {
 					expected_field_type = expected_typ
@@ -1486,9 +1495,10 @@ fn (mut t Transformer) transform_init_expr(expr ast.InitExpr) ast.Expr {
 				t.transform_expr(field_value)
 			} else {
 				// Transform array elements with sumtype wrapping if needed.
-				elem_sumtype := t.get_field_array_elem_sumtype_name(struct_type_name, field.name)
+				elem_sumtype := t.get_field_array_elem_sumtype_name(struct_type_name,
+					lookup_field_name)
 				elem_interface_typ := t.get_field_array_elem_interface_type(struct_type_name,
-					field.name)
+					lookup_field_name)
 				mut new_exprs := []ast.Expr{cap: arr_value.exprs.len}
 				for e in arr_value.exprs {
 					mut transformed := t.transform_expr(e)
@@ -1513,7 +1523,7 @@ fn (mut t Transformer) transform_init_expr(expr ast.InitExpr) ast.Expr {
 				// This is critical when elements were wrapped in a sum type above,
 				// as the C array type must match the wrapped (sum type) elements.
 				mut arr_with_type := arr_value
-				elem_c_name := t.get_field_array_elem_c_name(struct_type_name, field.name)
+				elem_c_name := t.get_field_array_elem_c_name(struct_type_name, lookup_field_name)
 				if elem_c_name != '' {
 					arr_with_type = ast.ArrayInitExpr{
 						typ:   ast.Expr(ast.Type(ast.ArrayType{
@@ -1554,6 +1564,23 @@ fn (mut t Transformer) transform_init_expr(expr ast.InitExpr) ast.Expr {
 		fields: fields
 		pos:    expr.pos
 	}
+}
+
+fn (t &Transformer) struct_positional_field_names(struct_name string) []string {
+	if struct_name == '' {
+		return []string{}
+	}
+	struct_type := t.lookup_type(struct_name) or { return []string{} }
+	base_type := t.unwrap_alias_and_pointer_type(struct_type)
+	if base_type !is types.Struct {
+		return []string{}
+	}
+	info := base_type as types.Struct
+	mut names := []string{cap: info.fields.len}
+	for field in info.fields {
+		names << field.name
+	}
+	return names
 }
 
 fn (t &Transformer) type_resolves_to_pointer(typ types.Type) bool {

--- a/vlib/v2/transformer/transformer.v
+++ b/vlib/v2/transformer/transformer.v
@@ -5031,6 +5031,13 @@ fn (mut t Transformer) transform_assign_stmt_parts(stmt ast.AssignStmt) (token.T
 				}
 			}
 		}
+		if t.is_native_be && rhs_expr is ast.ArrayInitExpr {
+			arr := rhs_expr as ast.ArrayInitExpr
+			if arr.len is ast.EmptyExpr && arr.cap is ast.EmptyExpr && arr.init is ast.EmptyExpr {
+				rhs << rhs_expr
+				continue
+			}
+		}
 		rhs << t.transform_expr(rhs_expr)
 	}
 	t.skip_if_value_lowering = saved_skip
@@ -11869,17 +11876,11 @@ fn (mut t Transformer) transform_sprintf_arg(inter ast.StringInter) ast.Expr {
 		}
 		else {
 			// For custom types with str() method: Type__str(expr).str
-			str_fn_info := t.get_str_fn_info_for_expr(inter.expr)
-			if str_fn_info.str_fn_name != '' {
-				t.needed_str_fns[str_fn_info.str_fn_name] = str_fn_info.elem_type
-				if etyp := t.string_inter_arg_type(inter.expr) {
-					if etyp is types.Enum {
-						t.needed_enum_str_fns[str_fn_info.str_fn_name] = etyp
-					}
-				}
+			str_fn_name := t.register_auto_str_dependency(typ)
+			if str_fn_name != '' {
 				str_call := ast.Expr(ast.CallExpr{
 					lhs:  ast.Ident{
-						name: str_fn_info.str_fn_name
+						name: str_fn_name
 					}
 					args: [transformed]
 					pos:  inter.expr.pos()
@@ -14495,34 +14496,12 @@ fn (mut t Transformer) generate_str_functions_with_explicit(explicit_str_fns map
 				if enum_type := t.needed_enum_str_fns[fn_name] {
 					// Generate enum str function with if-else chain for each variant
 					result << t.generate_enum_str_fn(fn_name, struct_name, enum_type)
+				} else if sumtype_type := t.lookup_sumtype_type_any_module(struct_name) {
+					result << t.generate_sumtype_str_fn(fn_name, struct_name, sumtype_type)
+				} else if struct_type := t.lookup_struct_type_any_module(struct_name) {
+					result << t.generate_struct_str_fn(fn_name, struct_name, struct_type)
 				} else {
-					// Generate struct str function: fn StructName__str(s StructName) string { return "StructName{}" }
-					result << ast.Stmt(ast.FnDecl{
-						name:  fn_name
-						typ:   ast.FnType{
-							params:      [
-								ast.Parameter{
-									name: 's'
-									typ:  ast.Ident{
-										name: struct_name
-									}
-								},
-							]
-							return_type: ast.Ident{
-								name: 'string'
-							}
-						}
-						stmts: [
-							ast.Stmt(ast.ReturnStmt{
-								exprs: [
-									ast.Expr(ast.StringLiteral{
-										value: "'${struct_name}{}'"
-										kind:  .v
-									}),
-								]
-							}),
-						]
-					})
+					result << t.generate_empty_struct_str_fn(fn_name, struct_name)
 				}
 			}
 		}
@@ -14531,6 +14510,362 @@ fn (mut t Transformer) generate_str_functions_with_explicit(explicit_str_fns map
 		}
 	}
 	return result
+}
+
+fn auto_str_display_type_name(type_name string) string {
+	if type_name.contains('__') {
+		return type_name.all_after_last('__')
+	}
+	return type_name
+}
+
+fn (t &Transformer) lookup_sumtype_type_any_module(name string) ?types.SumType {
+	if typ := t.lookup_type(name) {
+		if typ is types.SumType {
+			return typ
+		}
+	}
+	for _, scope in t.cached_scopes {
+		if typ := scope.lookup_type(name) {
+			if typ is types.SumType {
+				return typ
+			}
+		}
+	}
+	return none
+}
+
+fn (mut t Transformer) auto_str_literal(value string) ast.Expr {
+	return ast.Expr(ast.StringLiteral{
+		kind:  .v
+		value: value
+	})
+}
+
+fn (mut t Transformer) auto_str_call_expr(fn_name string, args []ast.Expr) ast.Expr {
+	return ast.Expr(ast.CallExpr{
+		lhs:  ast.Ident{
+			name: fn_name
+		}
+		args: args
+	})
+}
+
+fn (mut t Transformer) auto_str_builder_decl(cap_hint int) ast.Stmt {
+	return ast.Stmt(ast.AssignStmt{
+		op:  .decl_assign
+		lhs: [
+			ast.Expr(ast.ModifierExpr{
+				kind: .key_mut
+				expr: ast.Ident{
+					name: 'sb'
+				}
+			}),
+		]
+		rhs: [
+			t.auto_str_call_expr('strings__new_builder', [
+				t.make_number_expr(cap_hint.str()),
+			]),
+		]
+	})
+}
+
+fn (mut t Transformer) auto_str_write_stmt(value ast.Expr) ast.Stmt {
+	return ast.Stmt(ast.ExprStmt{
+		expr: ast.CallExpr{
+			lhs:  ast.Ident{
+				name: 'strings__Builder__write_string'
+			}
+			args: [
+				ast.Expr(ast.PrefixExpr{
+					op:   .amp
+					expr: ast.Ident{
+						name: 'sb'
+					}
+				}),
+				value,
+			]
+		}
+	})
+}
+
+fn (mut t Transformer) auto_str_return_builder_stmt() ast.Stmt {
+	return ast.Stmt(ast.ReturnStmt{
+		exprs: [
+			t.auto_str_call_expr('strings__Builder__str', [
+				ast.Expr(ast.PrefixExpr{
+					op:   .amp
+					expr: ast.Ident{
+						name: 'sb'
+					}
+				}),
+			]),
+		]
+	})
+}
+
+fn (t &Transformer) auto_str_needed_elem_info(typ types.Type) string {
+	match typ {
+		types.Array {
+			return t.type_to_c_name(typ.elem_type)
+		}
+		types.ArrayFixed {
+			return t.type_to_c_name(typ.elem_type)
+		}
+		types.Map {
+			key_name := t.type_to_c_name(typ.key_type)
+			val_name := t.type_to_c_name(typ.value_type)
+			return '${key_name}|${val_name}'
+		}
+		types.Alias {
+			if base := t.live_alias_base_type(typ) {
+				return t.auto_str_needed_elem_info(base)
+			}
+			return t.type_to_c_name(typ)
+		}
+		else {
+			return t.type_to_c_name(typ)
+		}
+	}
+}
+
+fn (mut t Transformer) register_auto_str_dependency(typ types.Type) string {
+	str_fn_name := t.get_str_fn_name_for_type(typ) or { return '' }
+	if str_fn_name !in t.needed_str_fns {
+		t.needed_str_fns[str_fn_name] = t.auto_str_needed_elem_info(typ)
+	}
+	if typ is types.Enum {
+		t.needed_enum_str_fns[str_fn_name] = typ
+	}
+	return str_fn_name
+}
+
+fn (mut t Transformer) auto_str_value_expr(value ast.Expr, typ types.Type) ast.Expr {
+	match typ {
+		types.String {
+			return value
+		}
+		types.Alias {
+			if base := t.live_alias_base_type(typ) {
+				if base is types.String {
+					return value
+				}
+			}
+		}
+		else {}
+	}
+
+	str_fn_name := t.register_auto_str_dependency(typ)
+	if str_fn_name == '' {
+		return t.auto_str_literal('')
+	}
+	mut arg := value
+	if typ is types.Pointer && typ.base_type !is types.Void {
+		arg = ast.Expr(ast.PrefixExpr{
+			op:   .mul
+			expr: value
+		})
+	}
+	return t.auto_str_call_expr(str_fn_name, [arg])
+}
+
+fn (mut t Transformer) auto_str_indented_value_expr(value ast.Expr) ast.Expr {
+	return t.auto_str_call_expr('string__replace', [
+		value,
+		t.auto_str_literal('\\n'),
+		t.auto_str_literal('\\n    '),
+	])
+}
+
+fn (t &Transformer) auto_str_type_can_multiline(typ types.Type) bool {
+	match typ {
+		types.Struct, types.SumType, types.Array, types.ArrayFixed, types.Map {
+			return true
+		}
+		types.Alias {
+			if base := t.live_alias_base_type(typ) {
+				return t.auto_str_type_can_multiline(base)
+			}
+			return false
+		}
+		types.Pointer {
+			return t.auto_str_type_can_multiline(typ.base_type)
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn (mut t Transformer) generate_empty_struct_str_fn(fn_name string, struct_name string) ast.Stmt {
+	param_s := ast.Parameter{
+		name: 's'
+		typ:  ast.Ident{
+			name: struct_name
+		}
+	}
+	t.register_generated_fn_scope(fn_name, clone_generated_fn_scope_module(struct_name), [
+		param_s,
+	])
+	display_name := auto_str_display_type_name(struct_name)
+	return ast.Stmt(ast.FnDecl{
+		name:  fn_name
+		typ:   ast.FnType{
+			params:      [param_s]
+			return_type: ast.Ident{
+				name: 'string'
+			}
+		}
+		stmts: [
+			ast.Stmt(ast.ReturnStmt{
+				exprs: [
+					t.auto_str_literal('${display_name}{}'),
+				]
+			}),
+		]
+	})
+}
+
+fn (mut t Transformer) append_auto_str_struct_field(mut body_stmts []ast.Stmt, field_name string, field_value ast.Expr, field_type types.Type) {
+	if field_name == '' {
+		return
+	}
+	body_stmts << t.auto_str_write_stmt(t.auto_str_literal('    ${field_name}: '))
+	field_str := t.auto_str_value_expr(field_value, field_type)
+	field_out := if t.auto_str_type_can_multiline(field_type) {
+		t.auto_str_indented_value_expr(field_str)
+	} else {
+		field_str
+	}
+	body_stmts << t.auto_str_write_stmt(field_out)
+	body_stmts << t.auto_str_write_stmt(t.auto_str_literal('\\n'))
+}
+
+fn (mut t Transformer) generate_struct_str_fn(fn_name string, struct_name string, struct_type types.Struct) ast.Stmt {
+	param_s := ast.Parameter{
+		name: 's'
+		typ:  ast.Ident{
+			name: struct_name
+		}
+	}
+	t.register_generated_fn_scope(fn_name, clone_generated_fn_scope_module(struct_name), [
+		param_s,
+	])
+	display_name := auto_str_display_type_name(struct_name)
+	field_count := struct_type.embedded.len + struct_type.fields.len
+	if field_count == 0 {
+		return t.generate_empty_struct_str_fn(fn_name, struct_name)
+	}
+	mut body_stmts := []ast.Stmt{cap: 4 + field_count * 4}
+	body_stmts << t.auto_str_builder_decl(display_name.len + 8 + field_count * 32)
+	body_stmts << t.auto_str_write_stmt(t.auto_str_literal('${display_name}{\\n'))
+	for embedded in struct_type.embedded {
+		field_name := auto_str_display_type_name(embedded.name)
+		field_value := t.synth_selector(ast.Expr(ast.Ident{
+			name: 's'
+		}), field_name, types.Type(embedded))
+		t.append_auto_str_struct_field(mut body_stmts, field_name, field_value,
+			types.Type(embedded))
+	}
+	for field in struct_type.fields {
+		field_value := t.synth_selector_from_struct(ast.Expr(ast.Ident{
+			name: 's'
+		}), field.name, struct_name)
+		t.append_auto_str_struct_field(mut body_stmts, field.name, field_value, field.typ)
+	}
+	body_stmts << t.auto_str_write_stmt(t.auto_str_literal('}'))
+	body_stmts << t.auto_str_return_builder_stmt()
+	return ast.Stmt(ast.FnDecl{
+		name:       fn_name
+		is_public:  false
+		is_method:  false
+		is_static:  false
+		attributes: []ast.Attribute{}
+		typ:        ast.FnType{
+			params:      [param_s]
+			return_type: ast.Ident{
+				name: 'string'
+			}
+		}
+		stmts:      body_stmts
+	})
+}
+
+fn (mut t Transformer) sumtype_variant_as_expr(sumtype_value_name string, variant_type types.Type) ast.Expr {
+	pos := t.next_synth_pos()
+	t.register_synth_type(pos, variant_type)
+	return ast.Expr(ast.AsCastExpr{
+		expr: ast.Ident{
+			name: sumtype_value_name
+		}
+		typ:  ast.Ident{
+			name: t.type_to_c_name(variant_type)
+		}
+		pos:  pos
+	})
+}
+
+fn (mut t Transformer) generate_sumtype_str_branch_stmts(sumtype_name string, variant_type types.Type) []ast.Stmt {
+	display_name := auto_str_display_type_name(sumtype_name)
+	variant_value := t.sumtype_variant_as_expr('s', variant_type)
+	variant_str := t.auto_str_value_expr(variant_value, variant_type)
+	mut stmts := []ast.Stmt{cap: 5}
+	stmts << t.auto_str_builder_decl(display_name.len + 32)
+	stmts << t.auto_str_write_stmt(t.auto_str_literal('${display_name}('))
+	stmts << t.auto_str_write_stmt(variant_str)
+	stmts << t.auto_str_write_stmt(t.auto_str_literal(')'))
+	stmts << t.auto_str_return_builder_stmt()
+	return stmts
+}
+
+fn (mut t Transformer) generate_sumtype_str_fn(fn_name string, sumtype_name string, sumtype_type types.SumType) ast.Stmt {
+	param_s := ast.Parameter{
+		name: 's'
+		typ:  ast.Ident{
+			name: sumtype_name
+		}
+	}
+	t.register_generated_fn_scope(fn_name, clone_generated_fn_scope_module(sumtype_name), [
+		param_s,
+	])
+	mut else_body := ast.Expr(ast.empty_expr)
+	variants := sumtype_type.get_variants()
+	for i := variants.len - 1; i >= 0; i-- {
+		cond := t.make_infix_expr(.eq, t.synth_selector(ast.Expr(ast.Ident{
+			name: 's'
+		}), '_tag', types.Type(types.int_)), t.make_number_expr(i.str()))
+		else_body = ast.Expr(ast.IfExpr{
+			cond:      cond
+			stmts:     t.generate_sumtype_str_branch_stmts(sumtype_name, variants[i])
+			else_expr: else_body
+		})
+	}
+	mut stmts := []ast.Stmt{}
+	if else_body !is ast.EmptyExpr {
+		stmts << ast.Stmt(ast.ExprStmt{
+			expr: else_body
+		})
+	}
+	display_name := auto_str_display_type_name(sumtype_name)
+	stmts << ast.Stmt(ast.ReturnStmt{
+		exprs: [
+			t.auto_str_literal('${display_name}{}'),
+		]
+	})
+	return ast.Stmt(ast.FnDecl{
+		name:       fn_name
+		is_public:  false
+		is_method:  false
+		is_static:  false
+		attributes: []ast.Attribute{}
+		typ:        ast.FnType{
+			params:      [param_s]
+			return_type: ast.Ident{
+				name: 'string'
+			}
+		}
+		stmts:      stmts
+	})
 }
 
 fn (mut t Transformer) generate_enum_str_fn(fn_name string, enum_name string, enum_type types.Enum) ast.Stmt {
@@ -14966,31 +15301,30 @@ fn (mut t Transformer) generate_array_str_fn(fn_name string, elem_type string) a
 		elem_expr
 	}
 
-	// strings__Builder__write_string(&sb, a[i]) for strings, else use the element str helper
-	for_body << ast.ExprStmt{
-		expr: ast.CallExpr{
-			lhs:  ast.Ident{
-				name: 'strings__Builder__write_string'
-			}
-			args: [
-				ast.Expr(ast.PrefixExpr{
-					op:   .amp
-					expr: ast.Ident{
-						name: 'sb'
-					}
-				}),
-				if elem_type == 'string' {
-					elem_expr
-				} else {
-					ast.Expr(ast.CallExpr{
-						lhs:  ast.Ident{
-							name: elem_str_fn
-						}
-						args: [str_arg]
-					})
-				},
-			]
+	sb_ref := ast.Expr(ast.PrefixExpr{
+		op:   .amp
+		expr: ast.Ident{
+			name: 'sb'
 		}
+	})
+	if elem_type == 'string' {
+		for_body << builder_write_string_stmt(sb_ref, ast.Expr(ast.StringLiteral{
+			kind:  .v
+			value: "'"
+		}))
+		for_body << builder_write_string_stmt(sb_ref, elem_expr)
+		for_body << builder_write_string_stmt(sb_ref, ast.Expr(ast.StringLiteral{
+			kind:  .v
+			value: "'"
+		}))
+	} else {
+		// strings__Builder__write_string(&sb, elem_str_fn(a[i]))
+		for_body << builder_write_string_stmt(sb_ref, ast.Expr(ast.CallExpr{
+			lhs:  ast.Ident{
+				name: elem_str_fn
+			}
+			args: [str_arg]
+		}))
 	}
 
 	// for loop: for i := 0; i < a.len; i++ { ... }
@@ -15246,36 +15580,38 @@ fn (mut t Transformer) generate_fixed_array_str_fn(fn_name string) ast.Stmt {
 		}
 	}
 
-	// strings__Builder__write_string(&sb, elem_str_fn(a[i]))
-	for_body << ast.ExprStmt{
-		expr: ast.CallExpr{
-			lhs:  ast.Ident{
-				name: 'strings__Builder__write_string'
-			}
-			args: [
-				ast.Expr(ast.PrefixExpr{
-					op:   .amp
-					expr: ast.Ident{
-						name: 'sb'
-					}
-				}),
-				ast.Expr(ast.CallExpr{
-					lhs:  ast.Ident{
-						name: elem_str_fn
-					}
-					args: [
-						ast.Expr(ast.IndexExpr{
-							lhs:  ast.Ident{
-								name: 'a'
-							}
-							expr: ast.Ident{
-								name: 'i'
-							}
-						}),
-					]
-				}),
-			]
+	sb_ref := ast.Expr(ast.PrefixExpr{
+		op:   .amp
+		expr: ast.Ident{
+			name: 'sb'
 		}
+	})
+	elem_expr := ast.Expr(ast.IndexExpr{
+		lhs:  ast.Ident{
+			name: 'a'
+		}
+		expr: ast.Ident{
+			name: 'i'
+		}
+	})
+	if elem_type == 'string' {
+		for_body << builder_write_string_stmt(sb_ref, ast.Expr(ast.StringLiteral{
+			kind:  .v
+			value: "'"
+		}))
+		for_body << builder_write_string_stmt(sb_ref, elem_expr)
+		for_body << builder_write_string_stmt(sb_ref, ast.Expr(ast.StringLiteral{
+			kind:  .v
+			value: "'"
+		}))
+	} else {
+		// strings__Builder__write_string(&sb, elem_str_fn(a[i]))
+		for_body << builder_write_string_stmt(sb_ref, ast.Expr(ast.CallExpr{
+			lhs:  ast.Ident{
+				name: elem_str_fn
+			}
+			args: [elem_expr]
+		}))
 	}
 
 	// for i := 0; i < arr_size; i++ { ... }

--- a/vlib/v2/transformer/transformer_test.v
+++ b/vlib/v2/transformer/transformer_test.v
@@ -626,6 +626,56 @@ fn call_names_for_fn(files []ast.File, fn_name string) []string {
 	return names
 }
 
+fn test_println_rune_lowers_to_rune_str_call() {
+	mut t := create_transformer_with_vars({
+		'r': types.Type(types.rune_)
+	})
+	out := t.transform_call_expr(ast.CallExpr{
+		lhs:  ast.Ident{
+			name: 'println'
+		}
+		args: [ast.Expr(ast.Ident{
+			name: 'r'
+		})]
+	})
+	assert out is ast.CallExpr
+	call := out as ast.CallExpr
+	assert call.args.len == 1
+	assert call.args[0] is ast.CallExpr
+	str_call := call.args[0] as ast.CallExpr
+	assert str_call.lhs is ast.Ident
+	assert (str_call.lhs as ast.Ident).name == 'rune__str'
+	assert 'rune__str' in t.needed_str_fns
+}
+
+fn test_println_i64_call_or_cast_lowers_to_i64_str_call() {
+	mut t := create_test_transformer()
+	out := t.transform_call_expr(ast.CallExpr{
+		lhs:  ast.Ident{
+			name: 'println'
+		}
+		args: [
+			ast.Expr(ast.CallOrCastExpr{
+				lhs:  ast.Ident{
+					name: 'i64'
+				}
+				expr: ast.BasicLiteral{
+					kind:  .number
+					value: '4294967296'
+				}
+			}),
+		]
+	})
+	assert out is ast.CallExpr
+	call := out as ast.CallExpr
+	assert call.args.len == 1
+	assert call.args[0] is ast.CallExpr
+	str_call := call.args[0] as ast.CallExpr
+	assert str_call.lhs is ast.Ident
+	assert (str_call.lhs as ast.Ident).name == 'i64__str'
+	assert 'i64__str' in t.needed_str_fns
+}
+
 fn call_names_for_fn_suffix(files []ast.File, fn_suffix string) []string {
 	mut names := []string{}
 	for file in files {

--- a/vlib/v2/transformer/types.v
+++ b/vlib/v2/transformer/types.v
@@ -406,19 +406,31 @@ fn (t &Transformer) type_from_init_expr(expr ast.InitExpr) ?types.Type {
 		})
 	}
 	if typ := t.get_expr_type(expr.typ) {
-		return t.normalize_type(typ)
+		normalized := t.normalize_type(typ)
+		if t.type_to_c_name(normalized) != '' {
+			return normalized
+		}
 	}
 	type_name := t.expr_to_type_name(expr.typ)
 	if type_name == '' {
 		return none
 	}
 	if typ := t.c_name_to_type(type_name) {
-		return t.normalize_type(typ)
+		normalized := t.normalize_type(typ)
+		if t.type_to_c_name(normalized) != '' {
+			return normalized
+		}
 	}
 	if typ := t.lookup_type(type_name) {
-		return t.normalize_type(typ)
+		normalized := t.normalize_type(typ)
+		if t.type_to_c_name(normalized) != '' {
+			return normalized
+		}
 	}
-	return none
+	c_type_name := t.v_type_name_to_c_name(type_name)
+	return types.Type(types.Struct{
+		name: if c_type_name != '' { c_type_name } else { type_name }
+	})
 }
 
 fn (t &Transformer) generic_init_type_name(expr ast.Expr) ?string {
@@ -1055,7 +1067,10 @@ fn (t &Transformer) type_to_c_decl_name(typ types.Type) string {
 fn (t &Transformer) expr_to_type_name(expr ast.Expr) string {
 	if expr is ast.Ident {
 		if typ := t.get_synth_type(expr.pos) {
-			return t.type_to_c_name(typ)
+			c_name := t.type_to_c_name(typ)
+			if c_name != '' {
+				return c_name
+			}
 		}
 		name := expr.name
 		// Add module prefix for non-builtin types when inside a non-main/builtin module.
@@ -2723,9 +2738,13 @@ fn sumtype_payload_word_is_valid(tag_word u64, data_word u64) bool {
 	// looks like a small tag, the payload must be a real pointer, not a leaked
 	// enum/default value like `3`.
 	if tag_word < 256 {
-		return data_word >= 0x100000000 && data_word < 0x0000800000000000
+		return transformer_data_ptr_has_valid_address(data_word)
 	}
 	return true
+}
+
+fn transformer_data_ptr_has_valid_address(ptr u64) bool {
+	return ptr >= 0x10000 && ptr < 0x0000800000000000
 }
 
 fn stmt_has_valid_data(stmt ast.Stmt) bool {
@@ -2747,7 +2766,7 @@ fn stmt_array_has_valid_data(stmts []ast.Stmt) bool {
 		return false
 	}
 	data_word := u64(voidptr(stmts.data))
-	return data_word >= 0x100000000 && data_word < 0x0000800000000000
+	return transformer_data_ptr_has_valid_address(data_word)
 }
 
 fn expr_has_valid_data(expr ast.Expr) bool {
@@ -2777,7 +2796,7 @@ fn expr_array_has_valid_data(exprs []ast.Expr) bool {
 		return false
 	}
 	data_word := u64(voidptr(exprs.data))
-	return data_word >= 0x100000000 && data_word < 0x0000800000000000
+	return transformer_data_ptr_has_valid_address(data_word)
 }
 
 // get_expr_type returns the types.Type for an expression by looking it up in the environment
@@ -2860,6 +2879,11 @@ fn (t &Transformer) get_expr_type(expr ast.Expr) ?types.Type {
 		}
 		if pos.is_valid() {
 			if typ := t.env.get_expr_type(pos.id) {
+				return t.normalize_type(typ)
+			}
+		}
+		if t.call_or_cast_lhs_is_type(expr.lhs) {
+			if typ := t.type_from_param_type_expr(expr.lhs, []) {
 				return t.normalize_type(typ)
 			}
 		}
@@ -4379,11 +4403,17 @@ fn (t &Transformer) get_str_fn_name_for_type(typ types.Type) ?string {
 			}
 			return '${typ.name}__str'
 		}
+		types.SumType {
+			return '${t.type_to_c_name(typ)}__str'
+		}
 		types.Enum {
 			if !transformer_string_has_valid_data(typ.name) {
 				return none
 			}
 			return '${typ.name}__str'
+		}
+		types.Rune {
+			return 'rune__str'
 		}
 		types.Primitive {
 			if typ.props.has(types.Properties.boolean) {
@@ -4397,18 +4427,18 @@ fn (t &Transformer) get_str_fn_name_for_type(typ types.Type) ?string {
 			}
 			if typ.props.has(types.Properties.unsigned) {
 				match typ.size {
-					1 { return 'u8__str' }
-					2 { return 'u16__str' }
-					4 { return 'u32__str' }
-					8 { return 'u64__str' }
+					8 { return 'u8__str' }
+					16 { return 'u16__str' }
+					32 { return 'u32__str' }
+					64 { return 'u64__str' }
 					else { return 'int__str' }
 				}
 			}
 			match typ.size {
-				1 { return 'i8__str' }
-				2 { return 'i16__str' }
-				4 { return 'int__str' }
-				8 { return 'i64__str' }
+				8 { return 'i8__str' }
+				16 { return 'i16__str' }
+				32, 0 { return 'int__str' }
+				64 { return 'i64__str' }
 				else { return 'int__str' }
 			}
 		}


### PR DESCRIPTION
## Summary

This is part 2 of the V2 native x64 backend.

It extends the backend enough to compile and run more real V examples across Linux, macOS x64, and Windows x64, while keeping the tiny/native output path for small eligible programs and falling back to the normal path when needed.

## Added support

The x64 backend now covers the existing part 1 / part 1b examples, plus additional examples such as:

- `examples/hello_world.v`
- `examples/fizz_buzz.v`
- `examples/js_hello_world.v`
- `examples/vascii.v`
- `examples/rune.v`
- `examples/hanoi.v`
- `examples/fibonacci.v`
- `examples/function_types.v`
- `examples/submodule/main.v`
- `examples/sudoku.v`
- `examples/tree_of_nodes.v`
- `examples/graphs/bfs.v`
- `examples/graphs/dfs.v`
- `examples/graphs/dijkstra.v`

## Testing

Added/extended regression coverage for the new x64 backend behavior and wired the supported examples into the Linux, macOS x64, and Windows x64 CI checks.

Validated locally with:

- `./v fmt -verify vlib/v2/gen/x64/x64_runtime_smoke_test.v`
- `./v test vlib/v2/builder/native_test.v vlib/v2/builder/target_os_test.v`
- `./v test vlib/v2/ssa/optimize`
- `V2_VERIFY_STRICT=1 ./v test vlib/v2/ssa/optimize`
- `VJOBS=1 ./v test vlib/v2/abi vlib/v2/gen/x64`