### PR TITLE
builtin: fix track_heap cross C generation

### DIFF
--- a/vlib/builtin/allocation.c.v
+++ b/vlib/builtin/allocation.c.v
@@ -38,30 +38,15 @@ __global total_m = i64(0)
 // track_heap models *manual* memory management (`-gc none`): the free hook only
 // fires on the manual-free path, so under a GC the collector reclaims blocks with
 // no matching hook and they would be reported as permanently live. Reject that
-// combination at compile time rather than emit misleading stats. The guard lives
-// in `_ht_alloc`, whose body is only compiled under `-d track_heap`.
+// combination at C compile time rather than emit misleading stats. The guard is
+// emitted as C preprocessor code so `-cross` can still preserve conditional C.
+#insert "@VEXEROOT/vlib/builtin/track_heap_checks.h"
+
 fn C.vheap_alloc(p voidptr, n u64)
 fn C.vheap_free(p voidptr)
 
 @[if track_heap ?]
 fn _ht_alloc(p &u8, n isize) {
-	// `$if track_heap ?` (not just the `@[if track_heap ?]` attribute) is required:
-	// the attribute only elides the call, while the comptime `$compile_error` below
-	// is still evaluated by the checker/`v fmt` under the default flags. Gating on
-	// track_heap keeps it compiled out unless the flag is actually set.
-	$if track_heap ? {
-		$if gcboehm ? {
-			$compile_error('-d track_heap requires manual memory management; rebuild with `-gc none`')
-		}
-		$if vgc ? {
-			$compile_error('-d track_heap requires manual memory management; rebuild with `-gc none`')
-		}
-		$if prealloc {
-			// -prealloc bumps from an arena and never frees individually, so the
-			// hooks would see no frees (every alloc shows live forever) — useless.
-			$compile_error('-d track_heap requires manual memory management; rebuild with `-gc none` (not -prealloc)')
-		}
-	}
 	C.vheap_alloc(p, u64(n))
 }
 

--- a/vlib/builtin/track_heap_checks.h
+++ b/vlib/builtin/track_heap_checks.h
@@ -1,0 +1,16 @@
+#ifndef V_TRACK_HEAP_CHECKS_H
+#define V_TRACK_HEAP_CHECKS_H
+
+#if defined(CUSTOM_DEFINE_track_heap) && (defined(_VGCBOEHM) || defined(CUSTOM_DEFINE_gcboehm))
+#error "-d track_heap requires manual memory management; rebuild with -gc none"
+#endif
+
+#if defined(CUSTOM_DEFINE_track_heap) && defined(CUSTOM_DEFINE_vgc)
+#error "-d track_heap requires manual memory management; rebuild with -gc none"
+#endif
+
+#if defined(CUSTOM_DEFINE_track_heap) && defined(_VPREALLOC)
+#error "-d track_heap requires manual memory management; rebuild with -gc none (not -prealloc)"
+#endif
+
+#endif


### PR DESCRIPTION
## What changed

Move the `track_heap` incompatible-GC guard from V `$compile_error` branches into an inserted C preprocessor guard.

## Why

`VC gen` failed while regenerating `vc/v.c` because `-cross` type-checks disabled `$if` branch bodies so conditional C can be preserved. The new `$compile_error` statements in `allocation.c.v` therefore fired during cross-C generation instead of only for real incompatible `-d track_heap` builds.

The C guard keeps the invalid combinations rejected for Boehm, VGC, and `-prealloc`, while allowing `-cross` to emit the conditional generated C.

## Checks

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -o /tmp/vci_v.c -cross cmd/v`
- `./vnew -o /tmp/vci_v_win.c -os windows -cc msvc cmd/v`
- `./vnew -silent test vlib/builtin/`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`