### PR TITLE
doc: clarify sum type smart cast vs static type

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1913,6 +1913,13 @@ println(u_name) // John
 
 You can check the current type of a sum type using `is` and its negated form `!is`.
 
+Note that the variable's declared type stays the sum type itself. In the example
+below, `x` has the static type `Alphabet`, even though the value it holds is an
+`Abc`. Inside an `is` check (or a `match` branch) the compiler automatically
+*smart casts* `x` to the matched variant, so within that block `x` has the static
+type `Abc` and you can access its fields directly and safely, without writing an
+explicit `as` cast.
+
 You can do it either in an `if`:
 
 ```v cgen


### PR DESCRIPTION
Closes #27364.

The issue reports that the "Type checks and casts" section's claim — *"x is automatically cast to Abc"* — is wrong, arguing that `x := Alphabet(Abc{'test'})` already declares `x` as `Abc`, so no cast is needed.

That reasoning conflates two different things:

- **Static type** of `x` → `Alphabet` (the sum type). This is what `typeof(x).name` reports.
- **Runtime variant** currently held → `Abc`. This is what `x.type_name()` reports.

The reporter's own "proof" (`typeof(x).name` = `Alphabet`, `x.type_name()` = `Abc`) actually demonstrates that `x` is *not* statically an `Abc` — so the smart cast inside `if x is Abc` / `match` is real and necessary. Inside the branch, `typeof(x).name` becomes `Abc`.

The existing wording is therefore correct, so this PR doesn't change the claims. It just adds a short clarifying paragraph distinguishing the variable's declared (sum) type from the smart cast that happens within an `is`/`match` block, to prevent this confusion.

`v check-md doc/docs.md` passes (0 warnings, 0 errors).