### PR TITLE
v2: fix self-host chain

### DIFF
--- a/vlib/v2/ast/flat.v
+++ b/vlib/v2/ast/flat.v
@@ -2347,15 +2347,16 @@ fn (mut w LegacyAstWalker) add_variant_payload(size u32) {
 }
 
 fn (mut w LegacyAstWalker) walk_file(file File) {
-	w.scan_dynamic(file)
+	w.add_string(file.mod)
+	w.add_string(file.name)
+	w.walk_attribute_array(file.attributes)
+	w.walk_import_array(file.imports)
+	w.walk_stmt_array(file.stmts)
 }
 
 fn (mut w LegacyAstWalker) walk_stmt(stmt Stmt) {
 	if stmt is []Attribute {
-		w.add_array_storage(sizeof(Attribute), stmt.len)
-		for attr in stmt {
-			w.walk_attribute(attr)
-		}
+		w.walk_attribute_array(stmt)
 		return
 	}
 	w.stats.stmt_nodes++
@@ -2364,92 +2365,130 @@ fn (mut w LegacyAstWalker) walk_stmt(stmt Stmt) {
 	match stmt {
 		AssignStmt {
 			w.add_variant_payload(sizeof(AssignStmt))
-			w.scan_dynamic(stmt)
+			w.walk_expr_array(stmt.lhs)
+			w.walk_expr_array(stmt.rhs)
 		}
 		AssertStmt {
 			w.add_variant_payload(sizeof(AssertStmt))
-			w.scan_dynamic(stmt)
+			w.walk_expr(stmt.expr)
+			w.walk_expr(stmt.extra)
 		}
 		AsmStmt {
 			w.add_variant_payload(sizeof(AsmStmt))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.arch)
 		}
 		BlockStmt {
 			w.add_variant_payload(sizeof(BlockStmt))
-			w.scan_dynamic(stmt)
+			w.walk_stmt_array(stmt.stmts)
 		}
 		ComptimeStmt {
 			w.add_variant_payload(sizeof(ComptimeStmt))
-			w.scan_dynamic(stmt)
+			w.walk_stmt(stmt.stmt)
 		}
 		ConstDecl {
 			w.add_variant_payload(sizeof(ConstDecl))
-			w.scan_dynamic(stmt)
+			w.walk_field_init_array(stmt.fields)
 		}
 		DeferStmt {
 			w.add_variant_payload(sizeof(DeferStmt))
-			w.scan_dynamic(stmt)
+			w.walk_stmt_array(stmt.stmts)
 		}
 		Directive {
 			w.add_variant_payload(sizeof(Directive))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.name)
+			w.add_string(stmt.value)
+			w.add_string(stmt.ct_cond)
 		}
 		EmptyStmt {}
 		EnumDecl {
 			w.add_variant_payload(sizeof(EnumDecl))
-			w.scan_dynamic(stmt)
+			w.walk_attribute_array(stmt.attributes)
+			w.add_string(stmt.name)
+			w.walk_expr(stmt.as_type)
+			w.walk_field_decl_array(stmt.fields)
 		}
 		ExprStmt {
 			w.add_variant_payload(sizeof(ExprStmt))
-			w.scan_dynamic(stmt)
+			w.walk_expr(stmt.expr)
 		}
 		FlowControlStmt {
 			w.add_variant_payload(sizeof(FlowControlStmt))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.label)
 		}
 		FnDecl {
 			w.add_variant_payload(sizeof(FnDecl))
-			w.scan_dynamic(stmt)
+			w.walk_attribute_array(stmt.attributes)
+			if stmt.is_method {
+				w.walk_parameter(stmt.receiver)
+			} else {
+				w.walk_parameter(Parameter{
+					typ: empty_expr
+				})
+			}
+			w.add_string(stmt.name)
+			w.walk_type(Type(stmt.typ))
+			w.walk_stmt_array(stmt.stmts)
 		}
 		ForInStmt {
 			w.add_variant_payload(sizeof(ForInStmt))
-			w.scan_dynamic(stmt)
+			w.walk_expr(stmt.key)
+			w.walk_expr(stmt.value)
+			w.walk_expr(stmt.expr)
 		}
 		ForStmt {
 			w.add_variant_payload(sizeof(ForStmt))
-			w.scan_dynamic(stmt)
+			w.walk_stmt(stmt.init)
+			w.walk_expr(stmt.cond)
+			w.walk_stmt(stmt.post)
+			w.walk_stmt_array(stmt.stmts)
 		}
 		GlobalDecl {
 			w.add_variant_payload(sizeof(GlobalDecl))
-			w.scan_dynamic(stmt)
+			w.walk_attribute_array(stmt.attributes)
+			w.walk_field_decl_array(stmt.fields)
 		}
 		ImportStmt {
 			w.add_variant_payload(sizeof(ImportStmt))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.name)
+			w.add_string(stmt.alias)
+			w.walk_expr_array(stmt.symbols)
 		}
 		InterfaceDecl {
 			w.add_variant_payload(sizeof(InterfaceDecl))
-			w.scan_dynamic(stmt)
+			w.walk_attribute_array(stmt.attributes)
+			w.add_string(stmt.name)
+			w.walk_expr_array(stmt.generic_params)
+			w.walk_expr_array(stmt.embedded)
+			w.walk_field_decl_array(stmt.fields)
 		}
 		LabelStmt {
 			w.add_variant_payload(sizeof(LabelStmt))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.name)
+			w.walk_stmt(stmt.stmt)
 		}
 		ModuleStmt {
 			w.add_variant_payload(sizeof(ModuleStmt))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.name)
 		}
 		ReturnStmt {
 			w.add_variant_payload(sizeof(ReturnStmt))
-			w.scan_dynamic(stmt)
+			w.walk_expr_array(stmt.exprs)
 		}
 		StructDecl {
 			w.add_variant_payload(sizeof(StructDecl))
-			w.scan_dynamic(stmt)
+			w.walk_attribute_array(stmt.attributes)
+			w.add_string(stmt.name)
+			w.walk_expr_array(stmt.implements)
+			w.walk_expr_array(stmt.embedded)
+			w.walk_expr_array(stmt.generic_params)
+			w.walk_field_decl_array(stmt.fields)
 		}
 		TypeDecl {
 			w.add_variant_payload(sizeof(TypeDecl))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.name)
+			w.walk_expr(stmt.base_type)
+			w.walk_expr_array(stmt.generic_params)
+			w.walk_expr_array(stmt.variants)
 		}
 		[]Attribute {}
 	}
@@ -2473,149 +2512,182 @@ fn (mut w LegacyAstWalker) walk_expr(expr Expr) {
 	match expr {
 		ArrayInitExpr {
 			w.add_variant_payload(sizeof(ArrayInitExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.typ)
+			w.walk_expr_array(expr.exprs)
+			w.walk_expr(expr.init)
+			w.walk_expr(expr.cap)
+			w.walk_expr(expr.len)
+			w.walk_expr(expr.update_expr)
 		}
 		AsCastExpr {
 			w.add_variant_payload(sizeof(AsCastExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
+			w.walk_expr(expr.typ)
 		}
 		AssocExpr {
 			w.add_variant_payload(sizeof(AssocExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.typ)
+			w.walk_expr(expr.expr)
+			w.walk_field_init_array(expr.fields)
 		}
 		BasicLiteral {
 			w.add_variant_payload(sizeof(BasicLiteral))
-			w.scan_dynamic(expr)
+			w.add_string(expr.value)
 		}
 		CallExpr {
 			w.add_variant_payload(sizeof(CallExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_expr_array(expr.args)
 		}
 		CallOrCastExpr {
 			w.add_variant_payload(sizeof(CallOrCastExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_expr(expr.expr)
 		}
 		CastExpr {
 			w.add_variant_payload(sizeof(CastExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.typ)
+			w.walk_expr(expr.expr)
 		}
 		ComptimeExpr {
 			w.add_variant_payload(sizeof(ComptimeExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
 		}
 		EmptyExpr {}
 		FnLiteral {
 			w.add_variant_payload(sizeof(FnLiteral))
-			w.scan_dynamic(expr)
+			w.walk_type(Type(expr.typ))
+			w.walk_expr_array(expr.captured_vars)
+			w.walk_stmt_array(expr.stmts)
 		}
 		GenericArgOrIndexExpr {
 			w.add_variant_payload(sizeof(GenericArgOrIndexExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_expr(expr.expr)
 		}
 		GenericArgs {
 			w.add_variant_payload(sizeof(GenericArgs))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_expr_array(expr.args)
 		}
 		Ident {
 			w.add_variant_payload(sizeof(Ident))
-			w.scan_dynamic(expr)
+			w.add_string(expr.name)
 		}
 		IfExpr {
 			w.add_variant_payload(sizeof(IfExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.cond)
+			w.walk_expr(expr.else_expr)
+			w.walk_stmt_array(expr.stmts)
 		}
 		IfGuardExpr {
 			w.add_variant_payload(sizeof(IfGuardExpr))
-			w.scan_dynamic(expr)
+			w.walk_stmt(Stmt(expr.stmt))
 		}
 		IndexExpr {
 			w.add_variant_payload(sizeof(IndexExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_expr(expr.expr)
 		}
 		InfixExpr {
 			w.add_variant_payload(sizeof(InfixExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_expr(expr.rhs)
 		}
 		InitExpr {
 			w.add_variant_payload(sizeof(InitExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.typ)
+			w.walk_field_init_array(expr.fields)
 		}
 		Keyword {}
 		KeywordOperator {
 			w.add_variant_payload(sizeof(KeywordOperator))
-			w.scan_dynamic(expr)
+			w.walk_expr_array(expr.exprs)
 		}
 		LambdaExpr {
 			w.add_variant_payload(sizeof(LambdaExpr))
-			w.scan_dynamic(expr)
+			w.walk_ident_array(expr.args)
+			w.walk_expr(expr.expr)
 		}
 		LifetimeExpr {
 			w.add_variant_payload(sizeof(LifetimeExpr))
-			w.scan_dynamic(expr)
+			w.add_string(expr.name)
 		}
 		LockExpr {
 			w.add_variant_payload(sizeof(LockExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr_array(expr.lock_exprs)
+			w.walk_expr_array(expr.rlock_exprs)
+			w.walk_stmt_array(expr.stmts)
 		}
 		MapInitExpr {
 			w.add_variant_payload(sizeof(MapInitExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.typ)
+			w.walk_expr_array(expr.keys)
+			w.walk_expr_array(expr.vals)
 		}
 		MatchExpr {
 			w.add_variant_payload(sizeof(MatchExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
+			w.walk_match_branch_array(expr.branches)
 		}
 		ModifierExpr {
 			w.add_variant_payload(sizeof(ModifierExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
 		}
 		OrExpr {
 			w.add_variant_payload(sizeof(OrExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
+			w.walk_stmt_array(expr.stmts)
 		}
 		ParenExpr {
 			w.add_variant_payload(sizeof(ParenExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
 		}
 		PostfixExpr {
 			w.add_variant_payload(sizeof(PostfixExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
 		}
 		PrefixExpr {
 			w.add_variant_payload(sizeof(PrefixExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
 		}
 		RangeExpr {
 			w.add_variant_payload(sizeof(RangeExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.start)
+			w.walk_expr(expr.end)
 		}
 		SelectExpr {
 			w.add_variant_payload(sizeof(SelectExpr))
-			w.scan_dynamic(expr)
+			w.walk_stmt(expr.stmt)
+			w.walk_stmt_array(expr.stmts)
+			w.walk_expr(expr.next)
 		}
 		SelectorExpr {
 			w.add_variant_payload(sizeof(SelectorExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_ident(expr.rhs)
 		}
 		SqlExpr {
 			w.add_variant_payload(sizeof(SqlExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
+			w.add_string(expr.table_name)
 		}
 		StringInterLiteral {
 			w.add_variant_payload(sizeof(StringInterLiteral))
-			w.scan_dynamic(expr)
+			w.walk_string_array(expr.values)
+			w.walk_string_inter_array(expr.inters)
 		}
 		StringLiteral {
 			w.add_variant_payload(sizeof(StringLiteral))
-			w.scan_dynamic(expr)
+			w.add_string(expr.value)
 		}
 		Tuple {
 			w.add_variant_payload(sizeof(Tuple))
-			w.scan_dynamic(expr)
+			w.walk_expr_array(expr.exprs)
 		}
 		UnsafeExpr {
 			w.add_variant_payload(sizeof(UnsafeExpr))
-			w.scan_dynamic(expr)
+			w.walk_stmt_array(expr.stmts)
 		}
 		FieldInit, Type {}
 	}
@@ -2627,53 +2699,62 @@ fn (mut w LegacyAstWalker) walk_type(typ Type) {
 	match typ {
 		AnonStructType {
 			w.add_variant_payload(sizeof(AnonStructType))
-			w.scan_dynamic(typ)
+			w.walk_expr_array(typ.generic_params)
+			w.walk_expr_array(typ.embedded)
+			w.walk_field_decl_array(typ.fields)
 		}
 		ArrayFixedType {
 			w.add_variant_payload(sizeof(ArrayFixedType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.len)
+			w.walk_expr(typ.elem_type)
 		}
 		ArrayType {
 			w.add_variant_payload(sizeof(ArrayType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.elem_type)
 		}
 		ChannelType {
 			w.add_variant_payload(sizeof(ChannelType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.cap)
+			w.walk_expr(typ.elem_type)
 		}
 		FnType {
 			w.add_variant_payload(sizeof(FnType))
-			w.scan_dynamic(typ)
+			w.walk_expr_array(typ.generic_params)
+			w.walk_parameter_array(typ.params)
+			w.walk_expr(typ.return_type)
 		}
 		GenericType {
 			w.add_variant_payload(sizeof(GenericType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.name)
+			w.walk_expr_array(typ.params)
 		}
 		MapType {
 			w.add_variant_payload(sizeof(MapType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.key_type)
+			w.walk_expr(typ.value_type)
 		}
 		NilType {}
 		NoneType {}
 		OptionType {
 			w.add_variant_payload(sizeof(OptionType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.base_type)
 		}
 		PointerType {
 			w.add_variant_payload(sizeof(PointerType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.base_type)
+			w.add_string(typ.lifetime)
 		}
 		ResultType {
 			w.add_variant_payload(sizeof(ResultType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.base_type)
 		}
 		ThreadType {
 			w.add_variant_payload(sizeof(ThreadType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.elem_type)
 		}
 		TupleType {
 			w.add_variant_payload(sizeof(TupleType))
-			w.scan_dynamic(typ)
+			w.walk_expr_array(typ.types)
 		}
 	}
 }
@@ -2683,132 +2764,121 @@ fn (mut w LegacyAstWalker) walk_type(typ Type) {
 
 fn (mut w LegacyAstWalker) walk_attribute(attr Attribute) {
 	w.stats.aux_nodes++
-	w.scan_dynamic(attr)
+	w.add_string(attr.name)
+	w.walk_expr(attr.value)
+	w.walk_expr(attr.comptime_cond)
 }
 
 fn (mut w LegacyAstWalker) walk_field_init(field FieldInit) {
 	w.stats.aux_nodes++
-	w.scan_dynamic(field)
+	w.add_string(field.name)
+	w.walk_expr(field.value)
 }
 
 fn (mut w LegacyAstWalker) walk_field_decl(field FieldDecl) {
 	w.stats.aux_nodes++
-	w.scan_dynamic(field)
+	w.add_string(field.name)
+	w.walk_expr(field.typ)
+	w.walk_expr(field.value)
+	w.walk_attribute_array(field.attributes)
 }
 
 fn (mut w LegacyAstWalker) walk_parameter(param Parameter) {
 	w.stats.aux_nodes++
-	w.scan_dynamic(param)
+	w.add_string(param.name)
+	w.walk_expr(param.typ)
 }
 
 fn (mut w LegacyAstWalker) walk_match_branch(branch MatchBranch) {
 	w.stats.aux_nodes++
-	w.scan_dynamic(branch)
+	w.walk_expr_array(branch.cond)
+	w.walk_stmt_array(branch.stmts)
 }
 
 fn (mut w LegacyAstWalker) walk_string_inter(inter StringInter) {
 	w.stats.aux_nodes++
-	w.scan_dynamic(inter)
+	w.walk_expr(inter.expr)
+	w.walk_expr(inter.format_expr)
+	w.add_string(inter.resolved_fmt)
 }
 
-fn (mut w LegacyAstWalker) scan_dynamic[T](node T) {
-	$for field in T.fields {
-		$if field.typ is string {
-			w.add_string(node.$(field.name))
-		} $else $if field.typ is []string {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(string), arr.len)
-			for v in arr {
-				w.add_string(v)
-			}
-		} $else $if field.typ is Expr {
-			w.walk_expr(node.$(field.name))
-		} $else $if field.typ is []Expr {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(Expr), arr.len)
-			for v in arr {
-				w.walk_expr(v)
-			}
-		} $else $if field.typ is Stmt {
-			w.walk_stmt(node.$(field.name))
-		} $else $if field.typ is []Stmt {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(Stmt), arr.len)
-			for v in arr {
-				w.walk_stmt(v)
-			}
-		} $else $if field.typ is Type {
-			w.walk_type(node.$(field.name))
-		} $else $if field.typ is []Type {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(Type), arr.len)
-			for v in arr {
-				w.walk_type(v)
-			}
-		} $else $if field.typ is Attribute {
-			w.walk_attribute(node.$(field.name))
-		} $else $if field.typ is []Attribute {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(Attribute), arr.len)
-			for v in arr {
-				w.walk_attribute(v)
-			}
-		} $else $if field.typ is FieldInit {
-			w.walk_field_init(node.$(field.name))
-		} $else $if field.typ is []FieldInit {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(FieldInit), arr.len)
-			for v in arr {
-				w.walk_field_init(v)
-			}
-		} $else $if field.typ is FieldDecl {
-			w.walk_field_decl(node.$(field.name))
-		} $else $if field.typ is []FieldDecl {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(FieldDecl), arr.len)
-			for v in arr {
-				w.walk_field_decl(v)
-			}
-		} $else $if field.typ is Parameter {
-			w.walk_parameter(node.$(field.name))
-		} $else $if field.typ is []Parameter {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(Parameter), arr.len)
-			for v in arr {
-				w.walk_parameter(v)
-			}
-		} $else $if field.typ is MatchBranch {
-			w.walk_match_branch(node.$(field.name))
-		} $else $if field.typ is []MatchBranch {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(MatchBranch), arr.len)
-			for v in arr {
-				w.walk_match_branch(v)
-			}
-		} $else $if field.typ is StringInter {
-			w.walk_string_inter(node.$(field.name))
-		} $else $if field.typ is []StringInter {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(StringInter), arr.len)
-			for v in arr {
-				w.walk_string_inter(v)
-			}
-		} $else $if field.typ is Ident {
-			w.walk_expr(Expr(node.$(field.name)))
-		} $else $if field.typ is []Ident {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(Ident), arr.len)
-			for v in arr {
-				w.walk_expr(Expr(v))
-			}
-		} $else $if field.typ is ImportStmt {
-			w.walk_stmt(Stmt(node.$(field.name)))
-		} $else $if field.typ is []ImportStmt {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(ImportStmt), arr.len)
-			for v in arr {
-				w.walk_stmt(Stmt(v))
-			}
-		}
+fn (mut w LegacyAstWalker) walk_ident(ident Ident) {
+	w.walk_expr(Expr(ident))
+}
+
+fn (mut w LegacyAstWalker) walk_expr_array(items []Expr) {
+	w.add_array_storage(sizeof(Expr), items.len)
+	for item in items {
+		w.walk_expr(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_stmt_array(items []Stmt) {
+	w.add_array_storage(sizeof(Stmt), items.len)
+	for item in items {
+		w.walk_stmt(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_attribute_array(items []Attribute) {
+	w.add_array_storage(sizeof(Attribute), items.len)
+	for item in items {
+		w.walk_attribute(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_field_init_array(items []FieldInit) {
+	w.add_array_storage(sizeof(FieldInit), items.len)
+	for item in items {
+		w.walk_field_init(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_field_decl_array(items []FieldDecl) {
+	w.add_array_storage(sizeof(FieldDecl), items.len)
+	for item in items {
+		w.walk_field_decl(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_parameter_array(items []Parameter) {
+	w.add_array_storage(sizeof(Parameter), items.len)
+	for item in items {
+		w.walk_parameter(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_match_branch_array(items []MatchBranch) {
+	w.add_array_storage(sizeof(MatchBranch), items.len)
+	for item in items {
+		w.walk_match_branch(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_string_inter_array(items []StringInter) {
+	w.add_array_storage(sizeof(StringInter), items.len)
+	for item in items {
+		w.walk_string_inter(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_ident_array(items []Ident) {
+	w.add_array_storage(sizeof(Ident), items.len)
+	for item in items {
+		w.walk_ident(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_import_array(items []ImportStmt) {
+	w.add_array_storage(sizeof(ImportStmt), items.len)
+	for item in items {
+		w.walk_stmt(Stmt(item))
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_string_array(items []string) {
+	w.add_array_storage(sizeof(string), items.len)
+	for item in items {
+		w.add_string(item)
 	}
 }

--- a/vlib/v2/ast/flat_reader.v
+++ b/vlib/v2/ast/flat_reader.v
@@ -88,11 +88,13 @@ fn (r &FlatReader) read_file(ff FlatFile) File {
 	imports_id := r.edge(n, 1)
 	stmts_id := r.edge(n, 2)
 	mut attrs := []Attribute{}
-	for cid in r.list_children(attrs_id) {
+	attr_children := r.list_children(attrs_id)
+	for cid in attr_children {
 		attrs << r.read_attribute(cid)
 	}
 	mut imports := []ImportStmt{}
-	for cid in r.list_children(imports_id) {
+	import_children := r.list_children(imports_id)
+	for cid in import_children {
 		c := Cursor{
 			flat: r.flat
 			id:   cid
@@ -102,7 +104,8 @@ fn (r &FlatReader) read_file(ff FlatFile) File {
 		}
 	}
 	mut stmts := []Stmt{}
-	for cid in r.list_children(stmts_id) {
+	stmt_children := r.list_children(stmts_id)
+	for cid in stmt_children {
 		stmts << r.read_stmt(cid)
 	}
 	return File{
@@ -125,7 +128,8 @@ pub fn (flat &FlatAst) read_file_imports(ff FlatFile) []ImportStmt {
 	n := r.node(ff.file_id)
 	imports_id := r.edge(n, 1)
 	mut imports := []ImportStmt{}
-	for cid in r.list_children(imports_id) {
+	import_children := r.list_children(imports_id)
+	for cid in import_children {
 		c := Cursor{
 			flat: r.flat
 			id:   cid
@@ -147,7 +151,8 @@ pub fn (flat &FlatAst) read_file_stmts(ff FlatFile) []Stmt {
 	n := r.node(ff.file_id)
 	stmts_id := r.edge(n, 2)
 	mut stmts := []Stmt{}
-	for cid in r.list_children(stmts_id) {
+	stmt_children := r.list_children(stmts_id)
+	for cid in stmt_children {
 		stmts << r.read_stmt(cid)
 	}
 	return stmts
@@ -244,7 +249,8 @@ fn (r &FlatReader) read_field_decl(id FlatNodeId) FieldDecl {
 	n := r.node(id)
 	attrs_id := r.edge(n, 2)
 	mut attrs := []Attribute{}
-	for cid in r.list_children(attrs_id) {
+	attr_children := r.list_children(attrs_id)
+	for cid in attr_children {
 		attrs << r.read_attribute(cid)
 	}
 	return FieldDecl{
@@ -274,11 +280,13 @@ fn (r &FlatReader) read_match_branch(id FlatNodeId) MatchBranch {
 	cond_id := r.edge(n, 0)
 	stmts_id := r.edge(n, 1)
 	mut cond := []Expr{}
-	for cid in r.list_children(cond_id) {
+	cond_children := r.list_children(cond_id)
+	for cid in cond_children {
 		cond << r.read_expr(cid)
 	}
 	mut stmts := []Stmt{}
-	for cid in r.list_children(stmts_id) {
+	stmt_children := r.list_children(stmts_id)
+	for cid in stmt_children {
 		stmts << r.read_stmt(cid)
 	}
 	return MatchBranch{
@@ -324,7 +332,8 @@ fn (r &FlatReader) read_int(id FlatNodeId) int {
 
 fn (r &FlatReader) read_expr_list(id FlatNodeId) []Expr {
 	mut out := []Expr{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_expr(cid)
 	}
 	return out
@@ -332,7 +341,8 @@ fn (r &FlatReader) read_expr_list(id FlatNodeId) []Expr {
 
 fn (r &FlatReader) read_stmt_list(id FlatNodeId) []Stmt {
 	mut out := []Stmt{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_stmt(cid)
 	}
 	return out
@@ -340,7 +350,8 @@ fn (r &FlatReader) read_stmt_list(id FlatNodeId) []Stmt {
 
 fn (r &FlatReader) read_attr_list(id FlatNodeId) []Attribute {
 	mut out := []Attribute{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_attribute(cid)
 	}
 	return out
@@ -348,7 +359,8 @@ fn (r &FlatReader) read_attr_list(id FlatNodeId) []Attribute {
 
 fn (r &FlatReader) read_field_decl_list(id FlatNodeId) []FieldDecl {
 	mut out := []FieldDecl{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_field_decl(cid)
 	}
 	return out
@@ -356,7 +368,8 @@ fn (r &FlatReader) read_field_decl_list(id FlatNodeId) []FieldDecl {
 
 fn (r &FlatReader) read_field_init_list(id FlatNodeId) []FieldInit {
 	mut out := []FieldInit{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_field_init(cid)
 	}
 	return out
@@ -364,7 +377,8 @@ fn (r &FlatReader) read_field_init_list(id FlatNodeId) []FieldInit {
 
 fn (r &FlatReader) read_parameter_list(id FlatNodeId) []Parameter {
 	mut out := []Parameter{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_parameter(cid)
 	}
 	return out
@@ -456,7 +470,8 @@ fn (r &FlatReader) read_string_list(id FlatNodeId) []string {
 
 fn (r &FlatReader) read_string_inter_list(id FlatNodeId) []StringInter {
 	mut out := []StringInter{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_string_inter(cid)
 	}
 	return out

--- a/vlib/v2/builder/builder.v
+++ b/vlib/v2/builder/builder.v
@@ -845,10 +845,19 @@ fn (mut b Builder) gen_cleanc_source_with_options(modules []string, emit_files [
 		gen_files << file
 	}
 	if cached_init_calls.len > 0 && b.used_vh_for_parse {
-		mut p := parser.Parser.new(b.pref)
-		header_files := p.parse_files(b.core_cached_parse_paths(), mut b.file_set)
-		for header_file in header_files {
-			gen_files << header_file
+		mut has_vh_files := false
+		for file in gen_files {
+			if file.name.ends_with('.vh') {
+				has_vh_files = true
+				break
+			}
+		}
+		if !has_vh_files {
+			mut p := parser.Parser.new(b.pref)
+			header_files := p.parse_files(b.core_cached_parse_paths(), mut b.file_set)
+			for header_file in header_files {
+				gen_files << header_file
+			}
 		}
 	}
 	mut gen := cleanc.Gen.new_with_env_and_pref(gen_files, b.env, b.pref)

--- a/vlib/v2/gen/cleanc/types.v
+++ b/vlib/v2/gen/cleanc/types.v
@@ -831,7 +831,7 @@ fn (mut g Gen) collect_runtime_aliases() {
 	}
 	// Also use type-checker output so aliases used only in expressions are captured.
 	if g.env != unsafe { nil } {
-		for typ in g.env.all_expr_types() {
+		for _, typ in g.env.expr_types {
 			if !type_has_valid_data(typ) || typ is types.Void {
 				continue
 			}

--- a/vlib/v2/transformer/transformer.v
+++ b/vlib/v2/transformer/transformer.v
@@ -14781,10 +14781,13 @@ fn (mut t Transformer) generate_str_functions_with_explicit(explicit_str_fns map
 	mut generated := map[string]bool{}
 	for {
 		mut found_new := false
-		for fn_name, elem_type in t.needed_str_fns {
+		mut fn_names := t.needed_str_fns.keys()
+		fn_names.sort()
+		for fn_name in fn_names {
 			if fn_name in generated {
 				continue
 			}
+			elem_type := t.needed_str_fns[fn_name] or { continue }
 			if fn_name.starts_with('Array_fixed_') {
 				// Generate fixed array str function
 				generated[fn_name] = true

--- a/vlib/v2/types/checker.v
+++ b/vlib/v2/types/checker.v
@@ -589,6 +589,8 @@ struct PendingFnBody {
 	typ           FnType
 	scope_fn_name string
 	module_name   string
+	flat          &ast.FlatAst   = unsafe { nil }
+	flat_decl_id  ast.FlatNodeId = -1
 }
 
 struct Checker {
@@ -609,6 +611,8 @@ mut:
 	fallback_vars map[string]Type
 	// when true, function declarations only register signatures and queue body checking
 	collect_fn_signatures_only bool
+	pending_fn_body_flat       &ast.FlatAst   = unsafe { nil }
+	pending_fn_body_flat_id    ast.FlatNodeId = -1
 	pending_const_fields       []PendingConstField
 	pending_interface_decls    []PendingInterfaceDecl
 	pending_struct_decls       []PendingStructDecl
@@ -1933,8 +1937,26 @@ fn (mut c Checker) preregister_fn_signatures_from_flat(flat &ast.FlatAst, ff ast
 	c.scope = mod_scope
 	prev_collect := c.collect_fn_signatures_only
 	c.collect_fn_signatures_only = true
-	for stmt in flat.read_file_stmts(ff) {
-		c.preregister_fn_signature_stmt(stmt)
+	decls := ast.Cursor{
+		flat: unsafe { flat }
+		id:   ff.file_id
+	}.list_at(2)
+	for di in 0 .. decls.len() {
+		dc := decls.at(di)
+		if dc.kind() == .stmt_fn_decl {
+			decl := flat.decode_fn_decl_signature(dc.id)
+			prev_flat := c.pending_fn_body_flat
+			prev_flat_id := c.pending_fn_body_flat_id
+			c.pending_fn_body_flat = unsafe { flat }
+			c.pending_fn_body_flat_id = dc.id
+			c.preregister_fn_signature_stmt(ast.Stmt(decl))
+			c.pending_fn_body_flat = prev_flat
+			c.pending_fn_body_flat_id = prev_flat_id
+			continue
+		}
+		if dc.kind() == .stmt_expr {
+			c.preregister_fn_signature_stmt(flat.decode_stmt(dc.id))
+		}
 	}
 	c.collect_fn_signatures_only = prev_collect
 }
@@ -5003,8 +5025,9 @@ fn (mut c Checker) process_pending_fn_bodies() {
 }
 
 fn (mut c Checker) check_pending_fn_body(pending PendingFnBody) bool {
-	decl_generic_params := collect_fn_generic_params(pending.decl)
-	has_decl_generic_params := pending.decl.typ.generic_params.len > 0
+	signature_decl := pending.decl
+	decl_generic_params := collect_fn_generic_params(signature_decl)
+	has_decl_generic_params := signature_decl.typ.generic_params.len > 0
 	has_generic_params := decl_generic_params.len > 0
 	if has_decl_generic_params {
 		mut generic_types := []map[string]Type{}
@@ -5023,7 +5046,7 @@ fn (mut c Checker) check_pending_fn_body(pending PendingFnBody) bool {
 			} else {
 				base_name
 			}
-			if base_name == pending.decl.name || short_name == pending.decl.name {
+			if base_name == signature_decl.name || short_name == signature_decl.name {
 				generic_types = inferred.clone()
 				has_generic_types = true
 				break
@@ -5036,6 +5059,13 @@ fn (mut c Checker) check_pending_fn_body(pending PendingFnBody) bool {
 		c.env.cur_generic_types << generic_types
 	}
 	if !has_decl_generic_params || c.env.cur_generic_types.len > 0 {
+		mut decl := signature_decl
+		if pending.flat != unsafe { nil } && pending.flat_decl_id >= 0 {
+			stmt := pending.flat.decode_stmt(pending.flat_decl_id)
+			if stmt is ast.FnDecl {
+				decl = stmt
+			}
+		}
 		prev_scope := c.scope
 		prev_module := c.cur_file_module
 		prev_fn_root_scope := c.fn_root_scope
@@ -5050,14 +5080,14 @@ fn (mut c Checker) check_pending_fn_body(pending PendingFnBody) bool {
 				c.fallback_vars[param.name] = param.typ
 			}
 		}
-		if pending.decl.is_method {
-			mut receiver_type := c.type_expr(pending.decl.receiver.typ)
-			if pending.decl.receiver.is_mut && receiver_type !is Pointer {
+		if decl.is_method {
+			mut receiver_type := c.type_expr(decl.receiver.typ)
+			if decl.receiver.is_mut && receiver_type !is Pointer {
 				receiver_type = Type(Pointer{
 					base_type: receiver_type
 				})
 			}
-			c.fallback_vars[pending.decl.receiver.name] = receiver_type
+			c.fallback_vars[decl.receiver.name] = receiver_type
 		}
 		if has_generic_params {
 			c.generic_params = decl_generic_params
@@ -5079,12 +5109,12 @@ fn (mut c Checker) check_pending_fn_body(pending PendingFnBody) bool {
 			prev_owned_types = c.owned_var_types.clone()
 			prev_moved = c.moved_vars.clone()
 			prev_borrowed = c.borrowed_vars.clone()
-			c.ownership_enter_fn(pending.decl.name, pending.decl)
+			c.ownership_enter_fn(decl.name, decl)
 		}
-		c.stmt_list(pending.decl.stmts)
+		c.stmt_list(decl.stmts)
 		$if ownership ? {
-			publish_keys := ownership_publish_keys_for(pending.module_name, pending.decl)
-			c.ownership_snapshot_drops_at_fn_exit(pending.decl.name, publish_keys)
+			publish_keys := ownership_publish_keys_for(pending.module_name, decl)
+			c.ownership_snapshot_drops_at_fn_exit(decl.name, publish_keys)
 			c.ownership_publish_pending_return_drops(publish_keys)
 			c.ownership_leave_fn(prev_ownership_fn, prev_owned, prev_owned_types, prev_moved,
 				prev_borrowed)
@@ -5859,6 +5889,8 @@ fn (mut c Checker) fn_decl(decl ast.FnDecl) {
 		typ:           fn_typ
 		scope_fn_name: scope_fn_name
 		module_name:   module_name
+		flat:          c.pending_fn_body_flat
+		flat_decl_id:  c.pending_fn_body_flat_id
 	}
 	if c.collect_fn_signatures_only {
 		c.pending_fn_bodies << pending


### PR DESCRIPTION
## Summary

Fix the V2 self-host chain so `v -o v2 v2.v && ./v2 -o v3 v2.v && ./v3 -o v4 v2.v` completes reliably from `cmd/v2`.

The fix keeps flat-mode preregistration from decoding every function body up front, avoids unsafe mutation during generated `str()` function worklist iteration, avoids materializing the full expression-type list during cleanc alias collection, and prevents duplicate `.vh` inputs when cached headers are already present.

## Root Cause

The second-generation V2 compiler could corrupt or exhaust runtime state while rebuilding itself:

- flat preregistration decoded full function bodies when only signatures were needed
- generated `str()` function discovery iterated a map that can be extended by recursive generation
- cleanc alias collection allocated a large temporary array of expression types
- cached `.vh` files could be appended twice in the flat/cached path

## Validation

- `../../v -o v2 v2.v && ./v2 -o v3 v2.v && ./v3 -o v4 v2.v` from `cmd/v2`
- isolated detached worktree at the PR commit with freshly built `./v`, same self-host chain
- `./vnew -silent test vlib/v2/ast/ vlib/v2/types/checker_flat_test.v vlib/v2/builder/target_os_test.v vlib/v2/transformer/generated_fns_parts_from_flat_test.v`
- `git diff --check`