### PR TITLE
Improve v2 cold cleanc code generation speed

### DIFF
--- a/vlib/v2/ast/flat.v
+++ b/vlib/v2/ast/flat.v
@@ -2347,15 +2347,16 @@ fn (mut w LegacyAstWalker) add_variant_payload(size u32) {
 }
 
 fn (mut w LegacyAstWalker) walk_file(file File) {
-	w.scan_dynamic(file)
+	w.add_string(file.mod)
+	w.add_string(file.name)
+	w.walk_attribute_array(file.attributes)
+	w.walk_import_array(file.imports)
+	w.walk_stmt_array(file.stmts)
 }
 
 fn (mut w LegacyAstWalker) walk_stmt(stmt Stmt) {
 	if stmt is []Attribute {
-		w.add_array_storage(sizeof(Attribute), stmt.len)
-		for attr in stmt {
-			w.walk_attribute(attr)
-		}
+		w.walk_attribute_array(stmt)
 		return
 	}
 	w.stats.stmt_nodes++
@@ -2364,92 +2365,130 @@ fn (mut w LegacyAstWalker) walk_stmt(stmt Stmt) {
 	match stmt {
 		AssignStmt {
 			w.add_variant_payload(sizeof(AssignStmt))
-			w.scan_dynamic(stmt)
+			w.walk_expr_array(stmt.lhs)
+			w.walk_expr_array(stmt.rhs)
 		}
 		AssertStmt {
 			w.add_variant_payload(sizeof(AssertStmt))
-			w.scan_dynamic(stmt)
+			w.walk_expr(stmt.expr)
+			w.walk_expr(stmt.extra)
 		}
 		AsmStmt {
 			w.add_variant_payload(sizeof(AsmStmt))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.arch)
 		}
 		BlockStmt {
 			w.add_variant_payload(sizeof(BlockStmt))
-			w.scan_dynamic(stmt)
+			w.walk_stmt_array(stmt.stmts)
 		}
 		ComptimeStmt {
 			w.add_variant_payload(sizeof(ComptimeStmt))
-			w.scan_dynamic(stmt)
+			w.walk_stmt(stmt.stmt)
 		}
 		ConstDecl {
 			w.add_variant_payload(sizeof(ConstDecl))
-			w.scan_dynamic(stmt)
+			w.walk_field_init_array(stmt.fields)
 		}
 		DeferStmt {
 			w.add_variant_payload(sizeof(DeferStmt))
-			w.scan_dynamic(stmt)
+			w.walk_stmt_array(stmt.stmts)
 		}
 		Directive {
 			w.add_variant_payload(sizeof(Directive))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.name)
+			w.add_string(stmt.value)
+			w.add_string(stmt.ct_cond)
 		}
 		EmptyStmt {}
 		EnumDecl {
 			w.add_variant_payload(sizeof(EnumDecl))
-			w.scan_dynamic(stmt)
+			w.walk_attribute_array(stmt.attributes)
+			w.add_string(stmt.name)
+			w.walk_expr(stmt.as_type)
+			w.walk_field_decl_array(stmt.fields)
 		}
 		ExprStmt {
 			w.add_variant_payload(sizeof(ExprStmt))
-			w.scan_dynamic(stmt)
+			w.walk_expr(stmt.expr)
 		}
 		FlowControlStmt {
 			w.add_variant_payload(sizeof(FlowControlStmt))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.label)
 		}
 		FnDecl {
 			w.add_variant_payload(sizeof(FnDecl))
-			w.scan_dynamic(stmt)
+			w.walk_attribute_array(stmt.attributes)
+			if stmt.is_method {
+				w.walk_parameter(stmt.receiver)
+			} else {
+				w.walk_parameter(Parameter{
+					typ: empty_expr
+				})
+			}
+			w.add_string(stmt.name)
+			w.walk_type(Type(stmt.typ))
+			w.walk_stmt_array(stmt.stmts)
 		}
 		ForInStmt {
 			w.add_variant_payload(sizeof(ForInStmt))
-			w.scan_dynamic(stmt)
+			w.walk_expr(stmt.key)
+			w.walk_expr(stmt.value)
+			w.walk_expr(stmt.expr)
 		}
 		ForStmt {
 			w.add_variant_payload(sizeof(ForStmt))
-			w.scan_dynamic(stmt)
+			w.walk_stmt(stmt.init)
+			w.walk_expr(stmt.cond)
+			w.walk_stmt(stmt.post)
+			w.walk_stmt_array(stmt.stmts)
 		}
 		GlobalDecl {
 			w.add_variant_payload(sizeof(GlobalDecl))
-			w.scan_dynamic(stmt)
+			w.walk_attribute_array(stmt.attributes)
+			w.walk_field_decl_array(stmt.fields)
 		}
 		ImportStmt {
 			w.add_variant_payload(sizeof(ImportStmt))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.name)
+			w.add_string(stmt.alias)
+			w.walk_expr_array(stmt.symbols)
 		}
 		InterfaceDecl {
 			w.add_variant_payload(sizeof(InterfaceDecl))
-			w.scan_dynamic(stmt)
+			w.walk_attribute_array(stmt.attributes)
+			w.add_string(stmt.name)
+			w.walk_expr_array(stmt.generic_params)
+			w.walk_expr_array(stmt.embedded)
+			w.walk_field_decl_array(stmt.fields)
 		}
 		LabelStmt {
 			w.add_variant_payload(sizeof(LabelStmt))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.name)
+			w.walk_stmt(stmt.stmt)
 		}
 		ModuleStmt {
 			w.add_variant_payload(sizeof(ModuleStmt))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.name)
 		}
 		ReturnStmt {
 			w.add_variant_payload(sizeof(ReturnStmt))
-			w.scan_dynamic(stmt)
+			w.walk_expr_array(stmt.exprs)
 		}
 		StructDecl {
 			w.add_variant_payload(sizeof(StructDecl))
-			w.scan_dynamic(stmt)
+			w.walk_attribute_array(stmt.attributes)
+			w.add_string(stmt.name)
+			w.walk_expr_array(stmt.implements)
+			w.walk_expr_array(stmt.embedded)
+			w.walk_expr_array(stmt.generic_params)
+			w.walk_field_decl_array(stmt.fields)
 		}
 		TypeDecl {
 			w.add_variant_payload(sizeof(TypeDecl))
-			w.scan_dynamic(stmt)
+			w.add_string(stmt.name)
+			w.walk_expr(stmt.base_type)
+			w.walk_expr_array(stmt.generic_params)
+			w.walk_expr_array(stmt.variants)
 		}
 		[]Attribute {}
 	}
@@ -2473,149 +2512,182 @@ fn (mut w LegacyAstWalker) walk_expr(expr Expr) {
 	match expr {
 		ArrayInitExpr {
 			w.add_variant_payload(sizeof(ArrayInitExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.typ)
+			w.walk_expr_array(expr.exprs)
+			w.walk_expr(expr.init)
+			w.walk_expr(expr.cap)
+			w.walk_expr(expr.len)
+			w.walk_expr(expr.update_expr)
 		}
 		AsCastExpr {
 			w.add_variant_payload(sizeof(AsCastExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
+			w.walk_expr(expr.typ)
 		}
 		AssocExpr {
 			w.add_variant_payload(sizeof(AssocExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.typ)
+			w.walk_expr(expr.expr)
+			w.walk_field_init_array(expr.fields)
 		}
 		BasicLiteral {
 			w.add_variant_payload(sizeof(BasicLiteral))
-			w.scan_dynamic(expr)
+			w.add_string(expr.value)
 		}
 		CallExpr {
 			w.add_variant_payload(sizeof(CallExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_expr_array(expr.args)
 		}
 		CallOrCastExpr {
 			w.add_variant_payload(sizeof(CallOrCastExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_expr(expr.expr)
 		}
 		CastExpr {
 			w.add_variant_payload(sizeof(CastExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.typ)
+			w.walk_expr(expr.expr)
 		}
 		ComptimeExpr {
 			w.add_variant_payload(sizeof(ComptimeExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
 		}
 		EmptyExpr {}
 		FnLiteral {
 			w.add_variant_payload(sizeof(FnLiteral))
-			w.scan_dynamic(expr)
+			w.walk_type(Type(expr.typ))
+			w.walk_expr_array(expr.captured_vars)
+			w.walk_stmt_array(expr.stmts)
 		}
 		GenericArgOrIndexExpr {
 			w.add_variant_payload(sizeof(GenericArgOrIndexExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_expr(expr.expr)
 		}
 		GenericArgs {
 			w.add_variant_payload(sizeof(GenericArgs))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_expr_array(expr.args)
 		}
 		Ident {
 			w.add_variant_payload(sizeof(Ident))
-			w.scan_dynamic(expr)
+			w.add_string(expr.name)
 		}
 		IfExpr {
 			w.add_variant_payload(sizeof(IfExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.cond)
+			w.walk_expr(expr.else_expr)
+			w.walk_stmt_array(expr.stmts)
 		}
 		IfGuardExpr {
 			w.add_variant_payload(sizeof(IfGuardExpr))
-			w.scan_dynamic(expr)
+			w.walk_stmt(Stmt(expr.stmt))
 		}
 		IndexExpr {
 			w.add_variant_payload(sizeof(IndexExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_expr(expr.expr)
 		}
 		InfixExpr {
 			w.add_variant_payload(sizeof(InfixExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_expr(expr.rhs)
 		}
 		InitExpr {
 			w.add_variant_payload(sizeof(InitExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.typ)
+			w.walk_field_init_array(expr.fields)
 		}
 		Keyword {}
 		KeywordOperator {
 			w.add_variant_payload(sizeof(KeywordOperator))
-			w.scan_dynamic(expr)
+			w.walk_expr_array(expr.exprs)
 		}
 		LambdaExpr {
 			w.add_variant_payload(sizeof(LambdaExpr))
-			w.scan_dynamic(expr)
+			w.walk_ident_array(expr.args)
+			w.walk_expr(expr.expr)
 		}
 		LifetimeExpr {
 			w.add_variant_payload(sizeof(LifetimeExpr))
-			w.scan_dynamic(expr)
+			w.add_string(expr.name)
 		}
 		LockExpr {
 			w.add_variant_payload(sizeof(LockExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr_array(expr.lock_exprs)
+			w.walk_expr_array(expr.rlock_exprs)
+			w.walk_stmt_array(expr.stmts)
 		}
 		MapInitExpr {
 			w.add_variant_payload(sizeof(MapInitExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.typ)
+			w.walk_expr_array(expr.keys)
+			w.walk_expr_array(expr.vals)
 		}
 		MatchExpr {
 			w.add_variant_payload(sizeof(MatchExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
+			w.walk_match_branch_array(expr.branches)
 		}
 		ModifierExpr {
 			w.add_variant_payload(sizeof(ModifierExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
 		}
 		OrExpr {
 			w.add_variant_payload(sizeof(OrExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
+			w.walk_stmt_array(expr.stmts)
 		}
 		ParenExpr {
 			w.add_variant_payload(sizeof(ParenExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
 		}
 		PostfixExpr {
 			w.add_variant_payload(sizeof(PostfixExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
 		}
 		PrefixExpr {
 			w.add_variant_payload(sizeof(PrefixExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
 		}
 		RangeExpr {
 			w.add_variant_payload(sizeof(RangeExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.start)
+			w.walk_expr(expr.end)
 		}
 		SelectExpr {
 			w.add_variant_payload(sizeof(SelectExpr))
-			w.scan_dynamic(expr)
+			w.walk_stmt(expr.stmt)
+			w.walk_stmt_array(expr.stmts)
+			w.walk_expr(expr.next)
 		}
 		SelectorExpr {
 			w.add_variant_payload(sizeof(SelectorExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.lhs)
+			w.walk_ident(expr.rhs)
 		}
 		SqlExpr {
 			w.add_variant_payload(sizeof(SqlExpr))
-			w.scan_dynamic(expr)
+			w.walk_expr(expr.expr)
+			w.add_string(expr.table_name)
 		}
 		StringInterLiteral {
 			w.add_variant_payload(sizeof(StringInterLiteral))
-			w.scan_dynamic(expr)
+			w.walk_string_array(expr.values)
+			w.walk_string_inter_array(expr.inters)
 		}
 		StringLiteral {
 			w.add_variant_payload(sizeof(StringLiteral))
-			w.scan_dynamic(expr)
+			w.add_string(expr.value)
 		}
 		Tuple {
 			w.add_variant_payload(sizeof(Tuple))
-			w.scan_dynamic(expr)
+			w.walk_expr_array(expr.exprs)
 		}
 		UnsafeExpr {
 			w.add_variant_payload(sizeof(UnsafeExpr))
-			w.scan_dynamic(expr)
+			w.walk_stmt_array(expr.stmts)
 		}
 		FieldInit, Type {}
 	}
@@ -2627,53 +2699,62 @@ fn (mut w LegacyAstWalker) walk_type(typ Type) {
 	match typ {
 		AnonStructType {
 			w.add_variant_payload(sizeof(AnonStructType))
-			w.scan_dynamic(typ)
+			w.walk_expr_array(typ.generic_params)
+			w.walk_expr_array(typ.embedded)
+			w.walk_field_decl_array(typ.fields)
 		}
 		ArrayFixedType {
 			w.add_variant_payload(sizeof(ArrayFixedType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.len)
+			w.walk_expr(typ.elem_type)
 		}
 		ArrayType {
 			w.add_variant_payload(sizeof(ArrayType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.elem_type)
 		}
 		ChannelType {
 			w.add_variant_payload(sizeof(ChannelType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.cap)
+			w.walk_expr(typ.elem_type)
 		}
 		FnType {
 			w.add_variant_payload(sizeof(FnType))
-			w.scan_dynamic(typ)
+			w.walk_expr_array(typ.generic_params)
+			w.walk_parameter_array(typ.params)
+			w.walk_expr(typ.return_type)
 		}
 		GenericType {
 			w.add_variant_payload(sizeof(GenericType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.name)
+			w.walk_expr_array(typ.params)
 		}
 		MapType {
 			w.add_variant_payload(sizeof(MapType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.key_type)
+			w.walk_expr(typ.value_type)
 		}
 		NilType {}
 		NoneType {}
 		OptionType {
 			w.add_variant_payload(sizeof(OptionType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.base_type)
 		}
 		PointerType {
 			w.add_variant_payload(sizeof(PointerType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.base_type)
+			w.add_string(typ.lifetime)
 		}
 		ResultType {
 			w.add_variant_payload(sizeof(ResultType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.base_type)
 		}
 		ThreadType {
 			w.add_variant_payload(sizeof(ThreadType))
-			w.scan_dynamic(typ)
+			w.walk_expr(typ.elem_type)
 		}
 		TupleType {
 			w.add_variant_payload(sizeof(TupleType))
-			w.scan_dynamic(typ)
+			w.walk_expr_array(typ.types)
 		}
 	}
 }
@@ -2683,132 +2764,121 @@ fn (mut w LegacyAstWalker) walk_type(typ Type) {
 
 fn (mut w LegacyAstWalker) walk_attribute(attr Attribute) {
 	w.stats.aux_nodes++
-	w.scan_dynamic(attr)
+	w.add_string(attr.name)
+	w.walk_expr(attr.value)
+	w.walk_expr(attr.comptime_cond)
 }
 
 fn (mut w LegacyAstWalker) walk_field_init(field FieldInit) {
 	w.stats.aux_nodes++
-	w.scan_dynamic(field)
+	w.add_string(field.name)
+	w.walk_expr(field.value)
 }
 
 fn (mut w LegacyAstWalker) walk_field_decl(field FieldDecl) {
 	w.stats.aux_nodes++
-	w.scan_dynamic(field)
+	w.add_string(field.name)
+	w.walk_expr(field.typ)
+	w.walk_expr(field.value)
+	w.walk_attribute_array(field.attributes)
 }
 
 fn (mut w LegacyAstWalker) walk_parameter(param Parameter) {
 	w.stats.aux_nodes++
-	w.scan_dynamic(param)
+	w.add_string(param.name)
+	w.walk_expr(param.typ)
 }
 
 fn (mut w LegacyAstWalker) walk_match_branch(branch MatchBranch) {
 	w.stats.aux_nodes++
-	w.scan_dynamic(branch)
+	w.walk_expr_array(branch.cond)
+	w.walk_stmt_array(branch.stmts)
 }
 
 fn (mut w LegacyAstWalker) walk_string_inter(inter StringInter) {
 	w.stats.aux_nodes++
-	w.scan_dynamic(inter)
+	w.walk_expr(inter.expr)
+	w.walk_expr(inter.format_expr)
+	w.add_string(inter.resolved_fmt)
 }
 
-fn (mut w LegacyAstWalker) scan_dynamic[T](node T) {
-	$for field in T.fields {
-		$if field.typ is string {
-			w.add_string(node.$(field.name))
-		} $else $if field.typ is []string {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(string), arr.len)
-			for v in arr {
-				w.add_string(v)
-			}
-		} $else $if field.typ is Expr {
-			w.walk_expr(node.$(field.name))
-		} $else $if field.typ is []Expr {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(Expr), arr.len)
-			for v in arr {
-				w.walk_expr(v)
-			}
-		} $else $if field.typ is Stmt {
-			w.walk_stmt(node.$(field.name))
-		} $else $if field.typ is []Stmt {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(Stmt), arr.len)
-			for v in arr {
-				w.walk_stmt(v)
-			}
-		} $else $if field.typ is Type {
-			w.walk_type(node.$(field.name))
-		} $else $if field.typ is []Type {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(Type), arr.len)
-			for v in arr {
-				w.walk_type(v)
-			}
-		} $else $if field.typ is Attribute {
-			w.walk_attribute(node.$(field.name))
-		} $else $if field.typ is []Attribute {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(Attribute), arr.len)
-			for v in arr {
-				w.walk_attribute(v)
-			}
-		} $else $if field.typ is FieldInit {
-			w.walk_field_init(node.$(field.name))
-		} $else $if field.typ is []FieldInit {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(FieldInit), arr.len)
-			for v in arr {
-				w.walk_field_init(v)
-			}
-		} $else $if field.typ is FieldDecl {
-			w.walk_field_decl(node.$(field.name))
-		} $else $if field.typ is []FieldDecl {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(FieldDecl), arr.len)
-			for v in arr {
-				w.walk_field_decl(v)
-			}
-		} $else $if field.typ is Parameter {
-			w.walk_parameter(node.$(field.name))
-		} $else $if field.typ is []Parameter {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(Parameter), arr.len)
-			for v in arr {
-				w.walk_parameter(v)
-			}
-		} $else $if field.typ is MatchBranch {
-			w.walk_match_branch(node.$(field.name))
-		} $else $if field.typ is []MatchBranch {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(MatchBranch), arr.len)
-			for v in arr {
-				w.walk_match_branch(v)
-			}
-		} $else $if field.typ is StringInter {
-			w.walk_string_inter(node.$(field.name))
-		} $else $if field.typ is []StringInter {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(StringInter), arr.len)
-			for v in arr {
-				w.walk_string_inter(v)
-			}
-		} $else $if field.typ is Ident {
-			w.walk_expr(Expr(node.$(field.name)))
-		} $else $if field.typ is []Ident {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(Ident), arr.len)
-			for v in arr {
-				w.walk_expr(Expr(v))
-			}
-		} $else $if field.typ is ImportStmt {
-			w.walk_stmt(Stmt(node.$(field.name)))
-		} $else $if field.typ is []ImportStmt {
-			arr := node.$(field.name)
-			w.add_array_storage(sizeof(ImportStmt), arr.len)
-			for v in arr {
-				w.walk_stmt(Stmt(v))
-			}
-		}
+fn (mut w LegacyAstWalker) walk_ident(ident Ident) {
+	w.walk_expr(Expr(ident))
+}
+
+fn (mut w LegacyAstWalker) walk_expr_array(items []Expr) {
+	w.add_array_storage(sizeof(Expr), items.len)
+	for item in items {
+		w.walk_expr(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_stmt_array(items []Stmt) {
+	w.add_array_storage(sizeof(Stmt), items.len)
+	for item in items {
+		w.walk_stmt(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_attribute_array(items []Attribute) {
+	w.add_array_storage(sizeof(Attribute), items.len)
+	for item in items {
+		w.walk_attribute(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_field_init_array(items []FieldInit) {
+	w.add_array_storage(sizeof(FieldInit), items.len)
+	for item in items {
+		w.walk_field_init(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_field_decl_array(items []FieldDecl) {
+	w.add_array_storage(sizeof(FieldDecl), items.len)
+	for item in items {
+		w.walk_field_decl(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_parameter_array(items []Parameter) {
+	w.add_array_storage(sizeof(Parameter), items.len)
+	for item in items {
+		w.walk_parameter(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_match_branch_array(items []MatchBranch) {
+	w.add_array_storage(sizeof(MatchBranch), items.len)
+	for item in items {
+		w.walk_match_branch(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_string_inter_array(items []StringInter) {
+	w.add_array_storage(sizeof(StringInter), items.len)
+	for item in items {
+		w.walk_string_inter(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_ident_array(items []Ident) {
+	w.add_array_storage(sizeof(Ident), items.len)
+	for item in items {
+		w.walk_ident(item)
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_import_array(items []ImportStmt) {
+	w.add_array_storage(sizeof(ImportStmt), items.len)
+	for item in items {
+		w.walk_stmt(Stmt(item))
+	}
+}
+
+fn (mut w LegacyAstWalker) walk_string_array(items []string) {
+	w.add_array_storage(sizeof(string), items.len)
+	for item in items {
+		w.add_string(item)
 	}
 }

--- a/vlib/v2/ast/flat_reader.v
+++ b/vlib/v2/ast/flat_reader.v
@@ -88,11 +88,13 @@ fn (r &FlatReader) read_file(ff FlatFile) File {
 	imports_id := r.edge(n, 1)
 	stmts_id := r.edge(n, 2)
 	mut attrs := []Attribute{}
-	for cid in r.list_children(attrs_id) {
+	attr_children := r.list_children(attrs_id)
+	for cid in attr_children {
 		attrs << r.read_attribute(cid)
 	}
 	mut imports := []ImportStmt{}
-	for cid in r.list_children(imports_id) {
+	import_children := r.list_children(imports_id)
+	for cid in import_children {
 		c := Cursor{
 			flat: r.flat
 			id:   cid
@@ -102,7 +104,8 @@ fn (r &FlatReader) read_file(ff FlatFile) File {
 		}
 	}
 	mut stmts := []Stmt{}
-	for cid in r.list_children(stmts_id) {
+	stmt_children := r.list_children(stmts_id)
+	for cid in stmt_children {
 		stmts << r.read_stmt(cid)
 	}
 	return File{
@@ -125,7 +128,8 @@ pub fn (flat &FlatAst) read_file_imports(ff FlatFile) []ImportStmt {
 	n := r.node(ff.file_id)
 	imports_id := r.edge(n, 1)
 	mut imports := []ImportStmt{}
-	for cid in r.list_children(imports_id) {
+	import_children := r.list_children(imports_id)
+	for cid in import_children {
 		c := Cursor{
 			flat: r.flat
 			id:   cid
@@ -147,7 +151,8 @@ pub fn (flat &FlatAst) read_file_stmts(ff FlatFile) []Stmt {
 	n := r.node(ff.file_id)
 	stmts_id := r.edge(n, 2)
 	mut stmts := []Stmt{}
-	for cid in r.list_children(stmts_id) {
+	stmt_children := r.list_children(stmts_id)
+	for cid in stmt_children {
 		stmts << r.read_stmt(cid)
 	}
 	return stmts
@@ -244,7 +249,8 @@ fn (r &FlatReader) read_field_decl(id FlatNodeId) FieldDecl {
 	n := r.node(id)
 	attrs_id := r.edge(n, 2)
 	mut attrs := []Attribute{}
-	for cid in r.list_children(attrs_id) {
+	attr_children := r.list_children(attrs_id)
+	for cid in attr_children {
 		attrs << r.read_attribute(cid)
 	}
 	return FieldDecl{
@@ -274,11 +280,13 @@ fn (r &FlatReader) read_match_branch(id FlatNodeId) MatchBranch {
 	cond_id := r.edge(n, 0)
 	stmts_id := r.edge(n, 1)
 	mut cond := []Expr{}
-	for cid in r.list_children(cond_id) {
+	cond_children := r.list_children(cond_id)
+	for cid in cond_children {
 		cond << r.read_expr(cid)
 	}
 	mut stmts := []Stmt{}
-	for cid in r.list_children(stmts_id) {
+	stmt_children := r.list_children(stmts_id)
+	for cid in stmt_children {
 		stmts << r.read_stmt(cid)
 	}
 	return MatchBranch{
@@ -324,7 +332,8 @@ fn (r &FlatReader) read_int(id FlatNodeId) int {
 
 fn (r &FlatReader) read_expr_list(id FlatNodeId) []Expr {
 	mut out := []Expr{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_expr(cid)
 	}
 	return out
@@ -332,7 +341,8 @@ fn (r &FlatReader) read_expr_list(id FlatNodeId) []Expr {
 
 fn (r &FlatReader) read_stmt_list(id FlatNodeId) []Stmt {
 	mut out := []Stmt{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_stmt(cid)
 	}
 	return out
@@ -340,7 +350,8 @@ fn (r &FlatReader) read_stmt_list(id FlatNodeId) []Stmt {
 
 fn (r &FlatReader) read_attr_list(id FlatNodeId) []Attribute {
 	mut out := []Attribute{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_attribute(cid)
 	}
 	return out
@@ -348,7 +359,8 @@ fn (r &FlatReader) read_attr_list(id FlatNodeId) []Attribute {
 
 fn (r &FlatReader) read_field_decl_list(id FlatNodeId) []FieldDecl {
 	mut out := []FieldDecl{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_field_decl(cid)
 	}
 	return out
@@ -356,7 +368,8 @@ fn (r &FlatReader) read_field_decl_list(id FlatNodeId) []FieldDecl {
 
 fn (r &FlatReader) read_field_init_list(id FlatNodeId) []FieldInit {
 	mut out := []FieldInit{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_field_init(cid)
 	}
 	return out
@@ -364,7 +377,8 @@ fn (r &FlatReader) read_field_init_list(id FlatNodeId) []FieldInit {
 
 fn (r &FlatReader) read_parameter_list(id FlatNodeId) []Parameter {
 	mut out := []Parameter{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_parameter(cid)
 	}
 	return out
@@ -456,7 +470,8 @@ fn (r &FlatReader) read_string_list(id FlatNodeId) []string {
 
 fn (r &FlatReader) read_string_inter_list(id FlatNodeId) []StringInter {
 	mut out := []StringInter{}
-	for cid in r.list_children(id) {
+	children := r.list_children(id)
+	for cid in children {
 		out << r.read_string_inter(cid)
 	}
 	return out

--- a/vlib/v2/builder/builder.v
+++ b/vlib/v2/builder/builder.v
@@ -845,10 +845,19 @@ fn (mut b Builder) gen_cleanc_source_with_options(modules []string, emit_files [
 		gen_files << file
 	}
 	if cached_init_calls.len > 0 && b.used_vh_for_parse {
-		mut p := parser.Parser.new(b.pref)
-		header_files := p.parse_files(b.core_cached_parse_paths(), mut b.file_set)
-		for header_file in header_files {
-			gen_files << header_file
+		mut has_vh_files := false
+		for file in gen_files {
+			if file.name.ends_with('.vh') {
+				has_vh_files = true
+				break
+			}
+		}
+		if !has_vh_files {
+			mut p := parser.Parser.new(b.pref)
+			header_files := p.parse_files(b.core_cached_parse_paths(), mut b.file_set)
+			for header_file in header_files {
+				gen_files << header_file
+			}
 		}
 	}
 	mut gen := cleanc.Gen.new_with_env_and_pref(gen_files, b.env, b.pref)

--- a/vlib/v2/builder/builder.v
+++ b/vlib/v2/builder/builder.v
@@ -962,6 +962,19 @@ fn (mut b Builder) write_cached_called_fn_names(cache_dir string, cache_name str
 	os.write_file(cached_called_fn_names_path(cache_dir, cache_name), names.join('\n')) or {}
 }
 
+fn (b &Builder) cgen_builder_stats_enabled() bool {
+	return b.pref != unsafe { nil } && b.pref.stats
+}
+
+fn (b &Builder) mark_cgen_builder_step(stats_enabled bool, cache_name string, mut sw time.StopWatch, stage_start time.Duration, step string) time.Duration {
+	if !stats_enabled {
+		return stage_start
+	}
+	now := sw.elapsed()
+	println('   - C Gen/cache:${cache_name} cache.${step}: ${time.Duration(now - stage_start).milliseconds()}ms')
+	return now
+}
+
 fn cache_type_module_names(cache_bundle_name string, emit_modules []string) []string {
 	if cache_bundle_name == '' {
 		return emit_modules
@@ -1457,17 +1470,29 @@ fn (mut b Builder) ensure_cached_module_object(cache_dir string, cache_name stri
 		return error('missing cached ${cache_name} object for .vh parse')
 	}
 
+	stats_enabled := b.cgen_builder_stats_enabled()
+	mut stats_sw := time.new_stopwatch()
+	mut stage_start := stats_sw.elapsed()
 	cached_called_before := b.cached_called_fn_names.clone()
+	stage_start = b.mark_cgen_builder_step(stats_enabled, cache_name, mut stats_sw, stage_start,
+		'called_before_clone')
 	module_source := b.gen_cleanc_source_for_cache(emit_modules, cache_name, use_markused)
+	stage_start = b.mark_cgen_builder_step(stats_enabled, cache_name, mut stats_sw, stage_start,
+		'source')
 	if module_source == '' {
 		return error('failed to generate C source for ${cache_name}')
 	}
 	os.write_file(c_path, module_source)!
+	stage_start = b.mark_cgen_builder_step(stats_enabled, cache_name, mut stats_sw, stage_start,
+		'write_c')
 
 	compile_cmd := '${cc} ${cc_flags} -w -Wno-incompatible-function-pointer-types -c "${c_path}" -o "${obj_path}"${error_limit_flag}'
 	run_cc_cmd_or_exit(compile_cmd, 'C compilation', b.pref.show_cc)
+	stage_start =
+		b.mark_cgen_builder_step(stats_enabled, cache_name, mut stats_sw, stage_start, 'cc')
 	b.write_cached_called_fn_names(cache_dir, cache_name, cached_called_before)
 	os.write_file(stamp_path, expected_stamp)!
+	_ = b.mark_cgen_builder_step(stats_enabled, cache_name, mut stats_sw, stage_start, 'metadata')
 	return obj_path
 }
 
@@ -1499,17 +1524,29 @@ fn (mut b Builder) ensure_cached_parsed_module_object(cache_dir string, cache_na
 		return error('missing cached ${cache_name} object for .vh parse')
 	}
 
+	stats_enabled := b.cgen_builder_stats_enabled()
+	mut stats_sw := time.new_stopwatch()
+	mut stage_start := stats_sw.elapsed()
 	cached_called_before := b.cached_called_fn_names.clone()
+	stage_start = b.mark_cgen_builder_step(stats_enabled, cache_name, mut stats_sw, stage_start,
+		'called_before_clone')
 	mut module_source := b.gen_cleanc_source_for_cache(module_names, cache_name, use_markused)
+	stage_start = b.mark_cgen_builder_step(stats_enabled, cache_name, mut stats_sw, stage_start,
+		'source')
 	if module_source == '' {
 		return error('failed to generate C source for ${cache_name}')
 	}
 	os.write_file(c_path, module_source)!
+	stage_start = b.mark_cgen_builder_step(stats_enabled, cache_name, mut stats_sw, stage_start,
+		'write_c')
 
 	compile_cmd := '${cc} ${cc_flags} -w -Wno-incompatible-function-pointer-types -c "${c_path}" -o "${obj_path}"${error_limit_flag}'
 	run_cc_cmd_or_exit(compile_cmd, 'C compilation', b.pref.show_cc)
+	stage_start =
+		b.mark_cgen_builder_step(stats_enabled, cache_name, mut stats_sw, stage_start, 'cc')
 	b.write_cached_called_fn_names(cache_dir, cache_name, cached_called_before)
 	os.write_file(stamp_path, expected_stamp)!
+	_ = b.mark_cgen_builder_step(stats_enabled, cache_name, mut stats_sw, stage_start, 'metadata')
 	return obj_path
 }
 
@@ -1542,18 +1579,31 @@ fn (mut b Builder) ensure_cached_virtual_module_object(cache_dir string, groups 
 	}
 
 	emit_files := virtual_module_source_files(groups)
+	stats_enabled := b.cgen_builder_stats_enabled()
+	mut stats_sw := time.new_stopwatch()
+	mut stage_start := stats_sw.elapsed()
 	cached_called_before := b.cached_called_fn_names.clone()
+	stage_start = b.mark_cgen_builder_step(stats_enabled, virtuals_cache_name, mut stats_sw,
+		stage_start, 'called_before_clone')
 	mut module_source := b.gen_cleanc_source_for_cache_files(['main'], emit_files,
 		virtuals_cache_name, use_markused)
+	stage_start = b.mark_cgen_builder_step(stats_enabled, virtuals_cache_name, mut stats_sw,
+		stage_start, 'source')
 	if module_source == '' {
 		return error('failed to generate C source for ${virtuals_cache_name}')
 	}
 	os.write_file(c_path, module_source)!
+	stage_start = b.mark_cgen_builder_step(stats_enabled, virtuals_cache_name, mut stats_sw,
+		stage_start, 'write_c')
 
 	compile_cmd := '${cc} ${cc_flags} -w -Wno-incompatible-function-pointer-types -c "${c_path}" -o "${obj_path}"${error_limit_flag}'
 	run_cc_cmd_or_exit(compile_cmd, 'C compilation', b.pref.show_cc)
+	stage_start = b.mark_cgen_builder_step(stats_enabled, virtuals_cache_name, mut stats_sw,
+		stage_start, 'cc')
 	b.write_cached_called_fn_names(cache_dir, virtuals_cache_name, cached_called_before)
 	os.write_file(stamp_path, expected_stamp)!
+	_ = b.mark_cgen_builder_step(stats_enabled, virtuals_cache_name, mut stats_sw, stage_start,
+		'metadata')
 	return obj_path
 }
 

--- a/vlib/v2/builder/gen_cleanc_parallel.v
+++ b/vlib/v2/builder/gen_cleanc_parallel.v
@@ -7,7 +7,7 @@ import runtime
 import time
 import v2.gen.cleanc
 
-const max_cleanc_pass5_jobs = 8
+const max_cleanc_pass5_jobs = 16
 
 struct GenCleancWeightedFile {
 	idx  int

--- a/vlib/v2/builder/gen_cleanc_parallel.v
+++ b/vlib/v2/builder/gen_cleanc_parallel.v
@@ -7,7 +7,7 @@ import runtime
 import time
 import v2.gen.cleanc
 
-const max_cleanc_pass5_jobs = 4
+const max_cleanc_pass5_jobs = 8
 
 struct GenCleancWeightedFile {
 	idx  int
@@ -157,6 +157,7 @@ fn (mut b Builder) gen_cleanc_parallel(mut gen cleanc.Gen) {
 		}
 		stage_start = mark_cleanc_parallel_step(stats_enabled, mut stats_sw, stage_start,
 			'pass 5 merge')
+		gen.print_pass5_file_times(8)
 
 		gen.gen_pass5_post()
 		_ = mark_cleanc_parallel_step(stats_enabled, mut stats_sw, stage_start, 'pass 5 post')

--- a/vlib/v2/gen/cleanc/cleanc.v
+++ b/vlib/v2/gen/cleanc/cleanc.v
@@ -185,6 +185,15 @@ mut:
 	typedef_c_types            map[string]bool // C struct names with @[typedef] attribute (emit without 'struct' prefix)
 	blocked_fn_keys            map[string]bool // worker-only fn keys reserved to other pass5 chunks
 	cached_vhash               string          // cached git short hash for @VHASH/@VCURRENTHASH
+	pass5_worker_id            int
+	pass5_file_times           []Pass5FileTime
+}
+
+struct Pass5FileTime {
+	file      string
+	ms        i64
+	cost      int
+	worker_id int
 }
 
 struct GenericStructInstance {
@@ -486,6 +495,9 @@ fn new_gen_with_env_and_pref_impl(env &types.Environment, p &pref.Preferences) &
 
 fn (mut g Gen) gen_file(file ast.File) {
 	g.set_file_module(file)
+	file_name := g.cur_file_name
+	file_module := g.cur_module
+	file_import_modules := g.cur_import_modules.clone()
 	mut global_indices := []int{}
 	mut fn_indices := []int{}
 	for i in 0 .. file.stmts.len {
@@ -509,7 +521,7 @@ fn (mut g Gen) gen_file(file ast.File) {
 		// Re-set file/module context before each function body emission,
 		// because body generation can modify g.cur_file_name and g.cur_module
 		// (e.g. via find_generic_fn_decl_by_base_name, resolve_method_on_embedded_decl).
-		g.set_file_module(file)
+		g.restore_file_module_context(file_name, file_module, file_import_modules)
 		stmt_ptr := &file.stmts[fi]
 		fn_decl := (*stmt_ptr) as ast.FnDecl
 		g.gen_fn_decl_ptr(&fn_decl)
@@ -2314,8 +2326,36 @@ fn (mut g Gen) emit_weak_receiver_generic_method_specializations(node &ast.FnDec
 // gen_pass5_files generates function bodies for a range of file indices.
 // Used by parallel dispatch — each worker calls this with its assigned chunk.
 pub fn (mut g Gen) gen_pass5_files(file_indices []int) {
+	stats_enabled := g.cgen_stats_enabled()
 	for fi in file_indices {
-		g.gen_file(g.files[fi])
+		if stats_enabled {
+			mut sw := time.new_stopwatch()
+			g.gen_file(g.files[fi])
+			elapsed_ms := sw.elapsed().milliseconds()
+			if elapsed_ms > 0 {
+				g.pass5_file_times << Pass5FileTime{
+					file:      g.files[fi].name
+					ms:        elapsed_ms
+					cost:      g.pass5_file_cost(fi)
+					worker_id: g.pass5_worker_id
+				}
+			}
+		} else {
+			g.gen_file(g.files[fi])
+		}
+	}
+}
+
+pub fn (g &Gen) print_pass5_file_times(limit int) {
+	if !g.cgen_stats_enabled() || g.pass5_file_times.len == 0 {
+		return
+	}
+	mut times := g.pass5_file_times.clone()
+	times.sort(a.ms > b.ms)
+	stats_scope := g.cgen_stats_scope_label()
+	n := if times.len < limit { times.len } else { limit }
+	for item in times[..n] {
+		println('   - C Gen/${stats_scope} pass 5 file ${item.ms}ms worker=${item.worker_id} cost=${item.cost} ${item.file}')
 	}
 }
 
@@ -2617,6 +2657,7 @@ pub fn (g &Gen) new_pass5_worker(file_indices []int, worker_id int) &Gen {
 		// Each worker gets a unique tmp_counter offset to avoid name collisions
 		// for generated trampolines (_bound_method_N, _bound_recv_N, etc.).
 		tmp_counter:                 (worker_id + 1) * 100_000
+		pass5_worker_id:             worker_id
 		emitted_types:               worker_emitted
 		blocked_fn_keys:             blocked_fn_keys
 		runtime_local_types:         map[string]string{}
@@ -2667,6 +2708,7 @@ pub fn (mut g Gen) merge_pass5_worker(w &Gen) {
 	g.spawn_wrapper_defs << w.spawn_wrapper_defs
 	g.trampoline_defs << w.trampoline_defs
 	g.exported_const_symbols << w.exported_const_symbols
+	g.pass5_file_times << w.pass5_file_times
 	// Merge accumulator maps
 	for k, v in w.needed_interface_wrappers {
 		g.needed_interface_wrappers[k] = v

--- a/vlib/v2/gen/cleanc/cleanc.v
+++ b/vlib/v2/gen/cleanc/cleanc.v
@@ -137,35 +137,38 @@ mut:
 	declared_type_names_in_emit_files map[string]bool
 	source_module_names               map[string]bool
 
-	const_exprs                 map[string]string // const name → C expression string (for inlining)
-	const_types                 map[string]string // const name → C type string
-	const_c_names               map[string]string // generated const name → collision-free C symbol name
-	runtime_const_targets       map[string]bool   // module-scoped consts initialized in __v_init_consts_*
-	used_fn_keys                map[string]bool
-	force_emit_fn_names         map[string]bool   // function C names that must be emitted regardless of mark_used
-	weak_fn_names               map[string]bool   // function C names emitted as weak cross-cache specializations
-	export_fn_names             map[string]string // V-qualified name → export name (from @[export:] attribute)
-	called_fn_names             map[string]bool
-	declared_fn_names           map[string]bool // C function names that have a prototype/body head emitted
-	should_emit_fn_decl_cache   map[string]bool
-	generic_body_scan_cache     map[string]bool
-	collect_generic_scan_calls  bool
-	generic_call_spec_scan_only bool
-	generic_scan_called_names   map[string]bool
-	generic_spec_index          map[string][]string                // fn_name → matching keys in env.generic_types
-	generic_fn_decl_index       map[string]GenericFnDeclInfo       // generic fn C/base name → source location
-	specialized_fn_bases        map[string]bool                    // base C name with at least one _T_ specialization
-	late_generic_specs          map[string][]map[string]types.Type // additional comptime-discovered specs
-	anon_fn_defs                []string        // lifted anonymous function definitions
-	late_struct_defs            []string        // struct definitions discovered during pass 5 codegen
-	pending_late_body_keys      map[string]bool // body_keys in late_struct_defs but not yet flushed to g.sb
-	late_generic_str_instances  []string        // c_names of late generic struct instances needing str macro check
-	pass5_start_pos             int             // position in sb where pass 5 starts
-	deferred_m_includes         []string        // Objective-C .m file #include lines deferred until after type definitions
-	spawned_fns                 map[string]bool // spawn wrapper names already emitted
-	spawn_wrapper_defs          []string        // spawn wrapper struct + function definitions
-	emitted_trampolines         map[string]bool // bound method trampoline names already emitted
-	trampoline_defs             []string        // bound method trampoline definitions
+	const_exprs                           map[string]string // const name → C expression string (for inlining)
+	const_types                           map[string]string // const name → C type string
+	const_c_names                         map[string]string // generated const name → collision-free C symbol name
+	runtime_const_targets                 map[string]bool   // module-scoped consts initialized in __v_init_consts_*
+	used_fn_keys                          map[string]bool
+	force_emit_fn_names                   map[string]bool   // function C names that must be emitted regardless of mark_used
+	weak_fn_names                         map[string]bool   // function C names emitted as weak cross-cache specializations
+	export_fn_names                       map[string]string // V-qualified name → export name (from @[export:] attribute)
+	called_fn_names                       map[string]bool
+	declared_fn_names                     map[string]bool // C function names that have a prototype/body head emitted
+	should_emit_fn_decl_cache             map[string]bool
+	generic_body_scan_cache               map[string]bool
+	collect_generic_scan_calls            bool
+	generic_call_spec_scan_only           bool
+	generic_scan_called_names             map[string]bool
+	generic_spec_index                    map[string][]string                // fn_name → matching keys in env.generic_types
+	generic_fn_decl_index                 map[string]GenericFnDeclInfo       // generic fn C/base name → source location
+	specialized_fn_bases                  map[string]bool                    // base C name with at least one _T_ specialization
+	specialized_receiver_methods          map[string]string                  // receiver|method -> single matching specialized method
+	specialized_receiver_method_ambiguous map[string]bool                    // receiver|method keys with multiple matches
+	specialized_receiver_method_miss      map[string]bool                    // receiver|method keys with no matching specialized method
+	late_generic_specs                    map[string][]map[string]types.Type // additional comptime-discovered specs
+	anon_fn_defs                          []string        // lifted anonymous function definitions
+	late_struct_defs                      []string        // struct definitions discovered during pass 5 codegen
+	pending_late_body_keys                map[string]bool // body_keys in late_struct_defs but not yet flushed to g.sb
+	late_generic_str_instances            []string        // c_names of late generic struct instances needing str macro check
+	pass5_start_pos                       int             // position in sb where pass 5 starts
+	deferred_m_includes                   []string        // Objective-C .m file #include lines deferred until after type definitions
+	spawned_fns                           map[string]bool // spawn wrapper names already emitted
+	spawn_wrapper_defs                    []string        // spawn wrapper struct + function definitions
+	emitted_trampolines                   map[string]bool // bound method trampoline names already emitted
+	trampoline_defs                       []string        // bound method trampoline definitions
 	// @[live] hot code reloading
 	live_fns                []LiveFnInfo                     // @[live] functions detected during code generation
 	live_source_file        string                           // source file containing @[live] functions
@@ -444,52 +447,55 @@ fn new_gen_with_env_and_pref_impl(env &types.Environment, p &pref.Preferences) &
 		declared_type_names_in_emit_files: map[string]bool{}
 		cur_import_modules:                map[string]string{}
 
-		fixed_array_fields:          map[string]bool{}
-		fixed_array_field_elem:      map[string]string{}
-		fixed_array_globals:         map[string]bool{}
-		tuple_aliases:               map[string][]string{}
-		struct_field_types:          map[string]string{}
-		enum_value_to_enum:          map[string]string{}
-		enum_type_fields:            map[string]map[string]bool{}
-		array_aliases:               map[string]bool{}
-		map_aliases:                 map[string]bool{}
-		result_aliases:              map[string]bool{}
-		option_aliases:              map[string]bool{}
-		alias_base_types:            map[string]string{}
-		fn_type_aliases:             map[string]bool{}
-		emitted_result_structs:      map[string]bool{}
-		emitted_option_structs:      map[string]bool{}
-		embedded_field_owner:        map[string]string{}
-		fixed_array_ret_wrappers:    map[string]string{}
-		emit_modules:                map[string]bool{}
-		type_modules:                map[string]bool{}
-		source_module_names:         map[string]bool{}
-		exported_const_seen:         map[string]bool{}
-		exported_const_symbols:      []ExportedConstSymbol{}
-		emitted_interface_bodies:    map[string]bool{}
-		interface_data_fields:       map[string][]InterfaceDataFieldInfo{}
-		interface_wrapper_specs:     map[string]InterfaceWrapperSpec{}
-		needed_interface_wrappers:   map[string]bool{}
-		ierror_wrapper_bases:        map[string]bool{}
-		needed_ierror_wrapper_bases: map[string]bool{}
-		c_file_fn_keys:              map[string]bool{}
-		module_storage_vars:         map[string]string{}
-		c_extern_module_storage:     map[string]string{}
-		runtime_const_targets:       map[string]bool{}
-		const_c_names:               map[string]string{}
-		used_fn_keys:                map[string]bool{}
-		force_emit_fn_names:         map[string]bool{}
-		weak_fn_names:               map[string]bool{}
-		called_fn_names:             map[string]bool{}
-		declared_fn_names:           map[string]bool{}
-		should_emit_fn_decl_cache:   map[string]bool{}
-		generic_body_scan_cache:     map[string]bool{}
-		generic_scan_called_names:   map[string]bool{}
-		generic_fn_decl_index:       map[string]GenericFnDeclInfo{}
-		specialized_fn_bases:        map[string]bool{}
-		c_struct_types:              map[string]bool{}
-		typedef_c_types:             map[string]bool{}
-		blocked_fn_keys:             map[string]bool{}
+		fixed_array_fields:                    map[string]bool{}
+		fixed_array_field_elem:                map[string]string{}
+		fixed_array_globals:                   map[string]bool{}
+		tuple_aliases:                         map[string][]string{}
+		struct_field_types:                    map[string]string{}
+		enum_value_to_enum:                    map[string]string{}
+		enum_type_fields:                      map[string]map[string]bool{}
+		array_aliases:                         map[string]bool{}
+		map_aliases:                           map[string]bool{}
+		result_aliases:                        map[string]bool{}
+		option_aliases:                        map[string]bool{}
+		alias_base_types:                      map[string]string{}
+		fn_type_aliases:                       map[string]bool{}
+		emitted_result_structs:                map[string]bool{}
+		emitted_option_structs:                map[string]bool{}
+		embedded_field_owner:                  map[string]string{}
+		fixed_array_ret_wrappers:              map[string]string{}
+		emit_modules:                          map[string]bool{}
+		type_modules:                          map[string]bool{}
+		source_module_names:                   map[string]bool{}
+		exported_const_seen:                   map[string]bool{}
+		exported_const_symbols:                []ExportedConstSymbol{}
+		emitted_interface_bodies:              map[string]bool{}
+		interface_data_fields:                 map[string][]InterfaceDataFieldInfo{}
+		interface_wrapper_specs:               map[string]InterfaceWrapperSpec{}
+		needed_interface_wrappers:             map[string]bool{}
+		ierror_wrapper_bases:                  map[string]bool{}
+		needed_ierror_wrapper_bases:           map[string]bool{}
+		c_file_fn_keys:                        map[string]bool{}
+		module_storage_vars:                   map[string]string{}
+		c_extern_module_storage:               map[string]string{}
+		runtime_const_targets:                 map[string]bool{}
+		const_c_names:                         map[string]string{}
+		used_fn_keys:                          map[string]bool{}
+		force_emit_fn_names:                   map[string]bool{}
+		weak_fn_names:                         map[string]bool{}
+		called_fn_names:                       map[string]bool{}
+		declared_fn_names:                     map[string]bool{}
+		should_emit_fn_decl_cache:             map[string]bool{}
+		generic_body_scan_cache:               map[string]bool{}
+		generic_scan_called_names:             map[string]bool{}
+		generic_fn_decl_index:                 map[string]GenericFnDeclInfo{}
+		specialized_fn_bases:                  map[string]bool{}
+		specialized_receiver_methods:          map[string]string{}
+		specialized_receiver_method_ambiguous: map[string]bool{}
+		specialized_receiver_method_miss:      map[string]bool{}
+		c_struct_types:                        map[string]bool{}
+		typedef_c_types:                       map[string]bool{}
+		blocked_fn_keys:                       map[string]bool{}
 	}
 }
 
@@ -2591,68 +2597,71 @@ pub fn (g &Gen) new_pass5_worker(file_indices []int, worker_id int) &Gen {
 		pref:  unsafe { g.pref }
 		sb:    strings.new_builder(64_000)
 		// Read-only lookup maps — clone to avoid COW data races
-		fn_param_is_ptr:             g.fn_param_is_ptr.clone()
-		fn_param_types:              g.fn_param_types.clone()
-		fn_return_types:             g.fn_return_types.clone()
-		v_fn_return_types:           g.v_fn_return_types.clone()
-		struct_field_types:          g.struct_field_types.clone()
-		enum_value_to_enum:          g.enum_value_to_enum.clone()
-		enum_type_fields:            g.enum_type_fields.clone()
-		array_aliases:               g.array_aliases.clone()
-		map_aliases:                 g.map_aliases.clone()
-		result_aliases:              g.result_aliases.clone()
-		option_aliases:              g.option_aliases.clone()
-		alias_base_types:            g.alias_base_types.clone()
-		fixed_array_fields:          g.fixed_array_fields.clone()
-		fixed_array_field_elem:      g.fixed_array_field_elem.clone()
-		fixed_array_globals:         g.fixed_array_globals.clone()
-		fixed_array_ret_wrappers:    g.fixed_array_ret_wrappers.clone()
-		tuple_aliases:               g.tuple_aliases.clone()
-		sum_type_variants:           g.sum_type_variants.clone()
-		embedded_field_owner:        g.embedded_field_owner.clone()
-		primitive_type_aliases:      g.primitive_type_aliases.clone()
-		emit_modules:                g.emit_modules.clone()
-		type_modules:                g.type_modules.clone()
-		emit_files:                  g.emit_files.clone()
-		emitted_result_structs:      g.emitted_result_structs.clone()
-		emitted_option_structs:      g.emitted_option_structs.clone()
-		interface_methods:           g.interface_methods.clone()
-		interface_data_fields:       g.interface_data_fields.clone()
-		emitted_interface_bodies:    g.emitted_interface_bodies.clone()
-		interface_wrapper_specs:     g.interface_wrapper_specs.clone()
-		ierror_wrapper_bases:        g.ierror_wrapper_bases.clone()
-		collected_fixed_array_types: g.collected_fixed_array_types.clone()
-		collected_map_types:         g.collected_map_types.clone()
-		c_file_fn_keys:              g.c_file_fn_keys.clone()
-		global_var_modules:          g.global_var_modules.clone()
-		global_var_types:            g.global_var_types.clone()
-		const_exprs:                 g.const_exprs.clone()
-		const_types:                 g.const_types.clone()
-		const_c_names:               g.const_c_names.clone()
-		module_storage_vars:         g.module_storage_vars.clone()
-		c_extern_module_storage:     g.c_extern_module_storage.clone()
-		runtime_const_targets:       g.runtime_const_targets.clone()
-		export_const_symbols:        g.export_const_symbols
-		cache_bundle_name:           g.cache_bundle_name
-		cached_init_calls:           g.cached_init_calls.clone()
-		used_fn_keys:                g.used_fn_keys.clone()
-		force_emit_fn_names:         g.force_emit_fn_names.clone()
-		weak_fn_names:               g.weak_fn_names.clone()
-		export_fn_names:             g.export_fn_names.clone()
-		called_fn_names:             g.called_fn_names.clone()
-		declared_fn_names:           g.declared_fn_names.clone()
-		should_emit_fn_decl_cache:   g.should_emit_fn_decl_cache.clone()
-		generic_body_scan_cache:     g.generic_body_scan_cache.clone()
-		fn_type_aliases:             g.fn_type_aliases.clone()
-		generic_spec_index:          g.generic_spec_index.clone()
-		generic_fn_decl_index:       g.generic_fn_decl_index.clone()
-		specialized_fn_bases:        g.specialized_fn_bases.clone()
-		late_generic_specs:          g.late_generic_specs.clone()
-		generic_scan_called_names:   map[string]bool{}
-		generic_struct_bindings:     g.generic_struct_bindings.clone()
-		generic_struct_instances:    g.generic_struct_instances.clone()
-		c_struct_types:              g.c_struct_types.clone()
-		typedef_c_types:             g.typedef_c_types.clone()
+		fn_param_is_ptr:                       g.fn_param_is_ptr.clone()
+		fn_param_types:                        g.fn_param_types.clone()
+		fn_return_types:                       g.fn_return_types.clone()
+		v_fn_return_types:                     g.v_fn_return_types.clone()
+		struct_field_types:                    g.struct_field_types.clone()
+		enum_value_to_enum:                    g.enum_value_to_enum.clone()
+		enum_type_fields:                      g.enum_type_fields.clone()
+		array_aliases:                         g.array_aliases.clone()
+		map_aliases:                           g.map_aliases.clone()
+		result_aliases:                        g.result_aliases.clone()
+		option_aliases:                        g.option_aliases.clone()
+		alias_base_types:                      g.alias_base_types.clone()
+		fixed_array_fields:                    g.fixed_array_fields.clone()
+		fixed_array_field_elem:                g.fixed_array_field_elem.clone()
+		fixed_array_globals:                   g.fixed_array_globals.clone()
+		fixed_array_ret_wrappers:              g.fixed_array_ret_wrappers.clone()
+		tuple_aliases:                         g.tuple_aliases.clone()
+		sum_type_variants:                     g.sum_type_variants.clone()
+		embedded_field_owner:                  g.embedded_field_owner.clone()
+		primitive_type_aliases:                g.primitive_type_aliases.clone()
+		emit_modules:                          g.emit_modules.clone()
+		type_modules:                          g.type_modules.clone()
+		emit_files:                            g.emit_files.clone()
+		emitted_result_structs:                g.emitted_result_structs.clone()
+		emitted_option_structs:                g.emitted_option_structs.clone()
+		interface_methods:                     g.interface_methods.clone()
+		interface_data_fields:                 g.interface_data_fields.clone()
+		emitted_interface_bodies:              g.emitted_interface_bodies.clone()
+		interface_wrapper_specs:               g.interface_wrapper_specs.clone()
+		ierror_wrapper_bases:                  g.ierror_wrapper_bases.clone()
+		collected_fixed_array_types:           g.collected_fixed_array_types.clone()
+		collected_map_types:                   g.collected_map_types.clone()
+		c_file_fn_keys:                        g.c_file_fn_keys.clone()
+		global_var_modules:                    g.global_var_modules.clone()
+		global_var_types:                      g.global_var_types.clone()
+		const_exprs:                           g.const_exprs.clone()
+		const_types:                           g.const_types.clone()
+		const_c_names:                         g.const_c_names.clone()
+		module_storage_vars:                   g.module_storage_vars.clone()
+		c_extern_module_storage:               g.c_extern_module_storage.clone()
+		runtime_const_targets:                 g.runtime_const_targets.clone()
+		export_const_symbols:                  g.export_const_symbols
+		cache_bundle_name:                     g.cache_bundle_name
+		cached_init_calls:                     g.cached_init_calls.clone()
+		used_fn_keys:                          g.used_fn_keys.clone()
+		force_emit_fn_names:                   g.force_emit_fn_names.clone()
+		weak_fn_names:                         g.weak_fn_names.clone()
+		export_fn_names:                       g.export_fn_names.clone()
+		called_fn_names:                       g.called_fn_names.clone()
+		declared_fn_names:                     g.declared_fn_names.clone()
+		should_emit_fn_decl_cache:             g.should_emit_fn_decl_cache.clone()
+		generic_body_scan_cache:               g.generic_body_scan_cache.clone()
+		fn_type_aliases:                       g.fn_type_aliases.clone()
+		generic_spec_index:                    g.generic_spec_index.clone()
+		generic_fn_decl_index:                 g.generic_fn_decl_index.clone()
+		specialized_fn_bases:                  g.specialized_fn_bases.clone()
+		specialized_receiver_methods:          g.specialized_receiver_methods.clone()
+		specialized_receiver_method_ambiguous: g.specialized_receiver_method_ambiguous.clone()
+		specialized_receiver_method_miss:      g.specialized_receiver_method_miss.clone()
+		late_generic_specs:                    g.late_generic_specs.clone()
+		generic_scan_called_names:             map[string]bool{}
+		generic_struct_bindings:               g.generic_struct_bindings.clone()
+		generic_struct_instances:              g.generic_struct_instances.clone()
+		c_struct_types:                        g.c_struct_types.clone()
+		typedef_c_types:                       g.typedef_c_types.clone()
 		// Per-worker mutable state (starts fresh).
 		// Each worker gets a unique tmp_counter offset to avoid name collisions
 		// for generated trampolines (_bound_method_N, _bound_recv_N, etc.).

--- a/vlib/v2/gen/cleanc/fn.v
+++ b/vlib/v2/gen/cleanc/fn.v
@@ -805,6 +805,38 @@ fn (mut g Gen) remember_specialized_fn_base(fn_name string) {
 	if base_name != '' {
 		g.specialized_fn_bases[base_name] = true
 	}
+	g.remember_specialized_receiver_method(fn_name, base_name)
+}
+
+fn (mut g Gen) remember_specialized_receiver_method(fn_name string, receiver_base string) {
+	if receiver_base == '' {
+		return
+	}
+	generic_tail := fn_name.all_after('_T_')
+	if !generic_tail.contains('__') {
+		return
+	}
+	method_name := fn_name.all_after_last('__')
+	if method_name == '' {
+		return
+	}
+	key := specialized_receiver_method_key(receiver_base, method_name)
+	g.specialized_receiver_method_miss.delete(key)
+	if key in g.specialized_receiver_method_ambiguous {
+		return
+	}
+	if existing := g.specialized_receiver_methods[key] {
+		if existing != fn_name {
+			g.specialized_receiver_methods.delete(key)
+			g.specialized_receiver_method_ambiguous[key] = true
+		}
+		return
+	}
+	g.specialized_receiver_methods[key] = fn_name
+}
+
+fn specialized_receiver_method_key(receiver_type string, method_name string) string {
+	return '${receiver_type}|${method_name}'
 }
 
 fn (mut g Gen) needs_implicit_veb_ctx_param(node &ast.FnDecl, fn_name string) bool {
@@ -6219,44 +6251,48 @@ fn (mut g Gen) collect_returned_idents(stmts []ast.Stmt) map[string]bool {
 
 fn (mut g Gen) collect_returned_idents_from_stmts(stmts []ast.Stmt, mut out map[string]bool) {
 	for stmt in stmts {
-		match stmt {
-			ast.ReturnStmt {
-				if stmt.exprs.len == 1 {
-					if name := returned_ident_name(stmt.exprs[0]) {
-						out[name] = true
-					}
+		g.collect_returned_idents_from_stmt(stmt, mut out)
+	}
+}
+
+fn (mut g Gen) collect_returned_idents_from_stmt(stmt ast.Stmt, mut out map[string]bool) {
+	match stmt {
+		ast.ReturnStmt {
+			if stmt.exprs.len == 1 {
+				if name := returned_ident_name(stmt.exprs[0]) {
+					out[name] = true
 				}
 			}
-			ast.BlockStmt {
-				g.collect_returned_idents_from_stmts(stmt.stmts, mut out)
-			}
-			ast.ComptimeStmt {
-				if stmt.stmt !is ast.EmptyStmt {
-					g.collect_returned_idents_from_stmts([stmt.stmt], mut out)
-				}
-			}
-			ast.DeferStmt {
-				g.collect_returned_idents_from_stmts(stmt.stmts, mut out)
-			}
-			ast.ForStmt {
-				if stmt.init !is ast.EmptyStmt {
-					g.collect_returned_idents_from_stmts([stmt.init], mut out)
-				}
-				if stmt.post !is ast.EmptyStmt {
-					g.collect_returned_idents_from_stmts([stmt.post], mut out)
-				}
-				g.collect_returned_idents_from_stmts(stmt.stmts, mut out)
-			}
-			ast.LabelStmt {
-				if stmt.stmt !is ast.EmptyStmt {
-					g.collect_returned_idents_from_stmts([stmt.stmt], mut out)
-				}
-			}
-			ast.ExprStmt {
-				g.collect_returned_idents_from_expr(stmt.expr, mut out)
-			}
-			else {}
 		}
+		ast.BlockStmt {
+			g.collect_returned_idents_from_stmts(stmt.stmts, mut out)
+		}
+		ast.ComptimeStmt {
+			if stmt.stmt !is ast.EmptyStmt {
+				g.collect_returned_idents_from_stmt(stmt.stmt, mut out)
+			}
+		}
+		ast.DeferStmt {
+			g.collect_returned_idents_from_stmts(stmt.stmts, mut out)
+		}
+		ast.ForStmt {
+			if stmt.init !is ast.EmptyStmt {
+				g.collect_returned_idents_from_stmt(stmt.init, mut out)
+			}
+			if stmt.post !is ast.EmptyStmt {
+				g.collect_returned_idents_from_stmt(stmt.post, mut out)
+			}
+			g.collect_returned_idents_from_stmts(stmt.stmts, mut out)
+		}
+		ast.LabelStmt {
+			if stmt.stmt !is ast.EmptyStmt {
+				g.collect_returned_idents_from_stmt(stmt.stmt, mut out)
+			}
+		}
+		ast.ExprStmt {
+			g.collect_returned_idents_from_expr(stmt.expr, mut out)
+		}
+		else {}
 	}
 }
 
@@ -9156,7 +9192,7 @@ fn (g &Gen) unique_v_method_return_type(method_name string) ?string {
 	return none
 }
 
-fn (g &Gen) resolve_method_on_concrete_type(receiver_type string, method_name string) ?string {
+fn (mut g Gen) resolve_method_on_concrete_type(receiver_type string, method_name string) ?string {
 	clean_type := strip_pointer_type_name(unmangle_c_ptr_type(receiver_type))
 	if clean_type == '' || method_name == '' {
 		return none
@@ -9223,12 +9259,19 @@ fn (mut g Gen) resolve_method_on_declared_receiver_type(receiver ast.Expr, metho
 	return none
 }
 
-fn (g &Gen) resolve_specialized_receiver_method(receiver_type string, method_name string) ?string {
+fn (mut g Gen) resolve_specialized_receiver_method(receiver_type string, method_name string) ?string {
 	if receiver_type == '' || method_name == '' {
 		return none
 	}
 	if g.specialized_fn_bases.len > 0 && receiver_type !in g.specialized_fn_bases {
 		return none
+	}
+	key := specialized_receiver_method_key(receiver_type, method_name)
+	if key in g.specialized_receiver_method_ambiguous || key in g.specialized_receiver_method_miss {
+		return none
+	}
+	if found := g.specialized_receiver_methods[key] {
+		return found
 	}
 	prefix := '${receiver_type}_T_'
 	suffix := '__${method_name}'
@@ -9250,8 +9293,10 @@ fn (g &Gen) resolve_specialized_receiver_method(receiver_type string, method_nam
 		}
 	}
 	if found != '' {
+		g.specialized_receiver_methods[key] = found
 		return found
 	}
+	g.specialized_receiver_method_miss[key] = true
 	return none
 }
 

--- a/vlib/v2/gen/cleanc/pass5_worker_test.v
+++ b/vlib/v2/gen/cleanc/pass5_worker_test.v
@@ -8,3 +8,19 @@ fn test_pass5_worker_clones_global_type_lookup() {
 	g.global_var_types['main__settings'] = 'main__OtherSettings'
 	assert worker.global_var_types['main__settings'] == 'main__Settings'
 }
+
+fn test_specialized_receiver_method_index_tracks_ambiguity() {
+	mut g := Gen.new([])
+	g.fn_return_types['Box_T_i32__get'] = 'int'
+	g.remember_specialized_fn_base('Box_T_i32__get')
+	got := g.resolve_specialized_receiver_method('Box', 'get') or { '' }
+	assert got == 'Box_T_i32__get'
+
+	g.fn_return_types['Box_T_string__get'] = 'string'
+	g.remember_specialized_fn_base('Box_T_string__get')
+	if _ := g.resolve_specialized_receiver_method('Box', 'get') {
+		assert false
+	} else {
+		assert true
+	}
+}

--- a/vlib/v2/gen/cleanc/stmt.v
+++ b/vlib/v2/gen/cleanc/stmt.v
@@ -30,6 +30,14 @@ fn (mut g Gen) set_file_module(file ast.File) {
 	g.cur_module = if file.mod != '' { file.mod.replace('.', '_') } else { 'main' }
 }
 
+fn (mut g Gen) restore_file_module_context(file_name string, module_name string, import_modules map[string]string) {
+	g.cur_file_name = file_name
+	g.cur_module = module_name
+	g.cur_import_modules = import_modules.clone()
+	g.is_module_ident_cache.clear()
+	g.resolved_module_names.clear()
+}
+
 fn (mut g Gen) gen_stmts(stmts []ast.Stmt) {
 	saved_file_name := g.cur_file_name
 	saved_module := g.cur_module

--- a/vlib/v2/gen/cleanc/struct.v
+++ b/vlib/v2/gen/cleanc/struct.v
@@ -5,6 +5,7 @@
 module cleanc
 
 import runtime
+import time
 import v2.ast
 import v2.types
 
@@ -62,6 +63,10 @@ fn (mut g Gen) has_explicit_str_method_for_c_type(c_type_name string) bool {
 // instantiations (e.g. LinkedList[ValueInfo]) and records the concrete type
 // bindings so that methods on generic structs can resolve their generic params.
 fn (mut g Gen) collect_generic_struct_bindings() {
+	stats_enabled := g.cgen_stats_enabled()
+	stats_scope := g.cgen_stats_scope_label()
+	mut stats_sw := time.new_stopwatch()
+	mut stage_start := stats_sw.elapsed()
 	prev_active_generic_types := g.active_generic_types.clone()
 	prev_runtime_local_types := g.runtime_local_types.clone()
 	prev_runtime_decl_types := g.runtime_decl_types.clone()
@@ -94,8 +99,14 @@ fn (mut g Gen) collect_generic_struct_bindings() {
 	if !g.collect_generic_struct_bindings_file_scan_parallel() {
 		g.collect_generic_struct_bindings_file_scan(g.files)
 	}
+	stage_start = g.mark_cgen_step(stats_enabled, stats_scope, mut stats_sw, stage_start,
+		'setup.generic_struct_bindings.file_scan')
 	g.propagate_generic_struct_bindings_for_files(g.files)
+	stage_start = g.mark_cgen_step(stats_enabled, stats_scope, mut stats_sw, stage_start,
+		'setup.generic_struct_bindings.propagate')
 	g.scan_receiver_generic_struct_bindings_for_files(g.files)
+	_ = g.mark_cgen_step(stats_enabled, stats_scope, mut stats_sw, stage_start,
+		'setup.generic_struct_bindings.receiver_scan')
 }
 
 fn (mut g Gen) collect_generic_struct_bindings_file_scan(files []ast.File) {
@@ -211,6 +222,10 @@ fn (mut g Gen) collect_generic_struct_bindings_file_scan_parallel() bool {
 	$if windows {
 		return false
 	} $else {
+		stats_enabled := g.cgen_stats_enabled()
+		stats_scope := g.cgen_stats_scope_label()
+		mut stats_sw := time.new_stopwatch()
+		mut stage_start := stats_sw.elapsed()
 		n_files := g.files.len
 		n_runtime_jobs := runtime.nr_jobs()
 		n_jobs := generic_struct_scan_job_count(n_runtime_jobs, n_files)
@@ -233,6 +248,8 @@ fn (mut g Gen) collect_generic_struct_bindings_file_scan_parallel() bool {
 			w := g.new_generic_struct_scan_worker(ci)
 			workers << voidptr(w)
 		}
+		stage_start = g.mark_cgen_step(stats_enabled, stats_scope, mut stats_sw, stage_start,
+			'setup.generic_struct_bindings.worker_setup')
 		for ci := 0; ci < n_jobs; ci++ {
 			args << GenericStructScanChunkArgs{
 				worker:           workers[ci]
@@ -252,10 +269,14 @@ fn (mut g Gen) collect_generic_struct_bindings_file_scan_parallel() bool {
 		for ci := 0; ci < n_jobs; ci++ {
 			C.pthread_join(thread_ids[ci], unsafe { nil })
 		}
+		stage_start = g.mark_cgen_step(stats_enabled, stats_scope, mut stats_sw, stage_start,
+			'setup.generic_struct_bindings.worker_run')
 		for ci := 0; ci < n_jobs; ci++ {
 			w := unsafe { &Gen(workers[ci]) }
 			g.merge_generic_struct_scan_worker(w)
 		}
+		_ = g.mark_cgen_step(stats_enabled, stats_scope, mut stats_sw, stage_start,
+			'setup.generic_struct_bindings.worker_merge')
 		return true
 	}
 }
@@ -1447,6 +1468,9 @@ fn generic_body_scan_bindings_key(bindings map[string]types.Type) string {
 
 fn (mut g Gen) scan_fn_body_for_generic_types(node ast.FnDecl, spec_name string) {
 	if node.pos.id <= 0 {
+		if !g.stmts_may_need_generic_scan(node.stmts) {
+			return
+		}
 		g.scan_stmts_for_generic_types(node.stmts)
 		return
 	}
@@ -1465,7 +1489,337 @@ fn (mut g Gen) scan_fn_body_for_generic_types(node ast.FnDecl, spec_name string)
 	} else {
 		g.generic_body_scan_cache[cache_key] = true
 	}
+	if !g.stmts_may_need_generic_scan(node.stmts) {
+		return
+	}
 	g.scan_stmts_for_generic_types(node.stmts)
+}
+
+fn (g &Gen) stmts_may_need_generic_scan(stmts []ast.Stmt) bool {
+	for stmt in stmts {
+		match stmt {
+			ast.AssignStmt {
+				for expr in stmt.lhs {
+					if g.expr_may_need_generic_scan(expr) {
+						return true
+					}
+				}
+				for expr in stmt.rhs {
+					if g.expr_may_need_generic_scan(expr) {
+						return true
+					}
+				}
+			}
+			ast.ReturnStmt {
+				for expr in stmt.exprs {
+					if g.expr_may_need_generic_scan(expr) {
+						return true
+					}
+				}
+			}
+			ast.ExprStmt {
+				if g.expr_may_need_generic_scan(stmt.expr) {
+					return true
+				}
+			}
+			ast.ComptimeStmt {
+				if g.stmts_may_need_generic_scan([stmt.stmt]) {
+					return true
+				}
+			}
+			ast.ForStmt {
+				if g.expr_may_need_generic_scan(stmt.cond)
+					|| g.stmts_may_need_generic_scan(stmt.stmts) {
+					return true
+				}
+			}
+			ast.ForInStmt {
+				if g.expr_may_need_generic_scan(stmt.key)
+					|| g.expr_may_need_generic_scan(stmt.value)
+					|| g.expr_may_need_generic_scan(stmt.expr) {
+					return true
+				}
+			}
+			ast.BlockStmt {
+				if g.stmts_may_need_generic_scan(stmt.stmts) {
+					return true
+				}
+			}
+			else {}
+		}
+	}
+	return false
+}
+
+fn (g &Gen) call_lhs_may_need_generic_scan(lhs ast.Expr) bool {
+	call_name := generic_call_short_name(lhs)
+	if call_name != '' {
+		for candidate in generic_call_decl_candidates(call_name) {
+			if candidate in g.generic_fn_decl_index {
+				return true
+			}
+		}
+	}
+	return g.expr_may_need_generic_scan(lhs)
+}
+
+fn (g &Gen) expr_may_need_generic_scan(expr ast.Expr) bool {
+	match expr {
+		ast.Ident {
+			return expr.name.contains('_T_') || expr.name.ends_with('_T')
+		}
+		ast.Type {
+			return type_expr_may_need_generic_scan(expr)
+		}
+		ast.GenericArgOrIndexExpr {
+			return true
+		}
+		ast.GenericArgs {
+			return true
+		}
+		ast.CallOrCastExpr {
+			return g.expr_may_need_generic_scan(expr.lhs) || g.expr_may_need_generic_scan(expr.expr)
+		}
+		ast.CallExpr {
+			if g.call_lhs_may_need_generic_scan(expr.lhs) {
+				return true
+			}
+			for arg in expr.args {
+				if g.expr_may_need_generic_scan(arg) {
+					return true
+				}
+			}
+		}
+		ast.InfixExpr {
+			return g.expr_may_need_generic_scan(expr.lhs) || g.expr_may_need_generic_scan(expr.rhs)
+		}
+		ast.PostfixExpr {
+			return g.expr_may_need_generic_scan(expr.expr)
+		}
+		ast.PrefixExpr {
+			return g.expr_may_need_generic_scan(expr.expr)
+		}
+		ast.ParenExpr {
+			return g.expr_may_need_generic_scan(expr.expr)
+		}
+		ast.ModifierExpr {
+			return g.expr_may_need_generic_scan(expr.expr)
+		}
+		ast.AssocExpr {
+			if type_expr_may_need_generic_scan(expr.typ) || g.expr_may_need_generic_scan(expr.expr) {
+				return true
+			}
+			for field in expr.fields {
+				if g.expr_may_need_generic_scan(field.value) {
+					return true
+				}
+			}
+		}
+		ast.IfGuardExpr {
+			return g.stmts_may_need_generic_scan([ast.Stmt(expr.stmt)])
+		}
+		ast.OrExpr {
+			return g.expr_may_need_generic_scan(expr.expr)
+				|| g.stmts_may_need_generic_scan(expr.stmts)
+		}
+		ast.UnsafeExpr {
+			return g.stmts_may_need_generic_scan(expr.stmts)
+		}
+		ast.LockExpr {
+			for lock_expr in expr.lock_exprs {
+				if g.expr_may_need_generic_scan(lock_expr) {
+					return true
+				}
+			}
+			for lock_expr in expr.rlock_exprs {
+				if g.expr_may_need_generic_scan(lock_expr) {
+					return true
+				}
+			}
+			return g.stmts_may_need_generic_scan(expr.stmts)
+		}
+		ast.IfExpr {
+			if g.expr_may_need_generic_scan(expr.cond) || g.stmts_may_need_generic_scan(expr.stmts) {
+				return true
+			}
+			return expr.else_expr !is ast.EmptyExpr && g.expr_may_need_generic_scan(expr.else_expr)
+		}
+		ast.MatchExpr {
+			if g.expr_may_need_generic_scan(expr.expr) {
+				return true
+			}
+			for branch in expr.branches {
+				for cond in branch.cond {
+					if g.expr_may_need_generic_scan(cond) {
+						return true
+					}
+				}
+				if g.stmts_may_need_generic_scan(branch.stmts) {
+					return true
+				}
+			}
+		}
+		ast.ComptimeExpr {
+			return g.expr_may_need_generic_scan(expr.expr)
+		}
+		ast.SelectExpr {
+			return g.stmts_may_need_generic_scan([expr.stmt])
+				|| g.stmts_may_need_generic_scan(expr.stmts)
+				|| g.expr_may_need_generic_scan(expr.next)
+		}
+		ast.StringInterLiteral {
+			for item in expr.inters {
+				if g.expr_may_need_generic_scan(item.expr)
+					|| g.expr_may_need_generic_scan(item.format_expr) {
+					return true
+				}
+			}
+		}
+		ast.InitExpr {
+			if type_expr_may_need_generic_scan(expr.typ) {
+				return true
+			}
+			for field in expr.fields {
+				if g.expr_may_need_generic_scan(field.value) {
+					return true
+				}
+			}
+		}
+		ast.ArrayInitExpr {
+			if type_expr_may_need_generic_scan(expr.typ) || g.expr_may_need_generic_scan(expr.len) {
+				return true
+			}
+			if g.expr_may_need_generic_scan(expr.init) || g.expr_may_need_generic_scan(expr.cap)
+				|| g.expr_may_need_generic_scan(expr.update_expr) {
+				return true
+			}
+			for item in expr.exprs {
+				if g.expr_may_need_generic_scan(item) {
+					return true
+				}
+			}
+		}
+		ast.MapInitExpr {
+			if type_expr_may_need_generic_scan(expr.typ) {
+				return true
+			}
+			for key in expr.keys {
+				if g.expr_may_need_generic_scan(key) {
+					return true
+				}
+			}
+			for value in expr.vals {
+				if g.expr_may_need_generic_scan(value) {
+					return true
+				}
+			}
+		}
+		ast.IndexExpr {
+			return g.expr_may_need_generic_scan(expr.lhs) || g.expr_may_need_generic_scan(expr.expr)
+		}
+		ast.CastExpr {
+			return type_expr_may_need_generic_scan(expr.typ)
+				|| g.expr_may_need_generic_scan(expr.expr)
+		}
+		ast.AsCastExpr {
+			return type_expr_may_need_generic_scan(expr.typ)
+				|| g.expr_may_need_generic_scan(expr.expr)
+		}
+		ast.Tuple {
+			return true
+		}
+		ast.FieldInit {
+			return g.expr_may_need_generic_scan(expr.value)
+		}
+		ast.KeywordOperator {
+			for arg in expr.exprs {
+				if g.expr_may_need_generic_scan(arg) {
+					return true
+				}
+			}
+		}
+		ast.RangeExpr {
+			return g.expr_may_need_generic_scan(expr.start)
+				|| g.expr_may_need_generic_scan(expr.end)
+		}
+		ast.FnLiteral {
+			for captured in expr.captured_vars {
+				if g.expr_may_need_generic_scan(captured) {
+					return true
+				}
+			}
+			return g.stmts_may_need_generic_scan(expr.stmts)
+		}
+		ast.LambdaExpr {
+			return g.expr_may_need_generic_scan(expr.expr)
+		}
+		ast.SqlExpr {
+			return g.expr_may_need_generic_scan(expr.expr)
+		}
+		else {}
+	}
+
+	return false
+}
+
+fn type_expr_may_need_generic_scan(expr ast.Expr) bool {
+	match expr {
+		ast.Type {
+			if expr is ast.GenericType {
+				return true
+			}
+			if expr is ast.ArrayType {
+				return type_expr_may_need_generic_scan(expr.elem_type)
+			}
+			if expr is ast.ArrayFixedType {
+				return type_expr_may_need_generic_scan(expr.elem_type)
+					|| type_expr_may_need_generic_scan(expr.len)
+			}
+			if expr is ast.MapType {
+				return type_expr_may_need_generic_scan(expr.key_type)
+					|| type_expr_may_need_generic_scan(expr.value_type)
+			}
+			if expr is ast.OptionType {
+				return type_expr_may_need_generic_scan(expr.base_type)
+			}
+			if expr is ast.ResultType {
+				return type_expr_may_need_generic_scan(expr.base_type)
+			}
+			if expr is ast.PointerType {
+				return type_expr_may_need_generic_scan(expr.base_type)
+			}
+			if expr is ast.FnType {
+				for param in expr.params {
+					if type_expr_may_need_generic_scan(param.typ) {
+						return true
+					}
+				}
+				return type_expr_may_need_generic_scan(expr.return_type)
+			}
+			return false
+		}
+		ast.GenericArgOrIndexExpr {
+			return true
+		}
+		ast.GenericArgs {
+			return true
+		}
+		ast.Ident {
+			return expr.name.contains('_T_') || expr.name.ends_with('_T')
+		}
+		ast.ModifierExpr {
+			return type_expr_may_need_generic_scan(expr.expr)
+		}
+		ast.PrefixExpr {
+			return type_expr_may_need_generic_scan(expr.expr)
+		}
+		ast.ParenExpr {
+			return type_expr_may_need_generic_scan(expr.expr)
+		}
+		else {
+			return false
+		}
+	}
 }
 
 fn (mut g Gen) scan_stmts_for_generic_types(stmts []ast.Stmt) {

--- a/vlib/v2/gen/cleanc/types.v
+++ b/vlib/v2/gen/cleanc/types.v
@@ -831,7 +831,7 @@ fn (mut g Gen) collect_runtime_aliases() {
 	}
 	// Also use type-checker output so aliases used only in expressions are captured.
 	if g.env != unsafe { nil } {
-		for typ in g.env.all_expr_types() {
+		for _, typ in g.env.expr_types {
 			if !type_has_valid_data(typ) || typ is types.Void {
 				continue
 			}

--- a/vlib/v2/gen/cleanc/types.v
+++ b/vlib/v2/gen/cleanc/types.v
@@ -3111,6 +3111,267 @@ fn (mut g Gen) infer_numeric_expr_type(node ast.Expr) string {
 }
 
 // get_expr_type returns the C type string for an expression
+fn (mut g Gen) get_ident_expr_type(node ast.Ident) string {
+	if local_type := g.get_local_var_c_type(node.name) {
+		return local_type
+	}
+	if node.name == 'err' {
+		return 'IError'
+	}
+	if global_type := g.global_var_type_for_ident(node.name) {
+		return global_type
+	}
+	// Env pos.id O(1) lookup.
+	if t := g.get_expr_type_from_env(node) {
+		return t
+	}
+	// get_local_var_c_type already checked fn scope + runtime_local_types.
+	// Only module and builtin scope fallbacks remain.
+	if g.env != unsafe { nil } {
+		if g.cur_module != '' {
+			if mut mod_scope := g.env_scope(g.cur_module) {
+				if obj := mod_scope.lookup_parent(node.name, 0) {
+					if obj !is types.Module {
+						raw := obj.typ()
+						if raw is types.Alias {
+							// For struct-valued aliases (like Color = gg.Color),
+							// return the alias C type directly.
+							alias_c := g.types_type_to_c(raw)
+							if alias_c != '' && alias_c != 'int'
+								&& alias_c !in ['voidptr', 'void*', 'charptr', 'char*', 'byteptr', 'u8*'] {
+								return alias_c
+							}
+						} else {
+							typ_name := g.types_type_to_c(raw)
+							if typ_name != '' {
+								return typ_name
+							}
+						}
+					}
+				}
+			}
+		}
+		if g.cur_module != 'builtin' {
+			if mut builtin_scope := g.env_scope('builtin') {
+				if obj := builtin_scope.lookup_parent(node.name, 0) {
+					if obj !is types.Module {
+						raw := obj.typ()
+						if raw !is types.Alias {
+							typ_name := g.types_type_to_c(raw)
+							if typ_name != '' {
+								return typ_name
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	// Module-qualified ident: transformer mangles `module.name` -> `module__name`.
+	// Split and look up the short name in the module's scope.
+	if node.name.contains('__') {
+		parts := node.name.split('__')
+		if parts.len == 2 {
+			mod_name := parts[0]
+			short_name := parts[1]
+			if mut target_scope := g.env_scope(mod_name) {
+				if obj := target_scope.lookup_parent(short_name, 0) {
+					if obj !is types.Module {
+						raw := obj.typ()
+						typ_name := g.types_type_to_c(raw)
+						if typ_name != '' && typ_name != 'int' {
+							return typ_name
+						}
+					}
+				}
+			}
+		}
+	}
+	// Ident already tried env + all scopes above; avoid redundant second lookup below.
+	return 'int'
+}
+
+fn (mut g Gen) get_expr_type_from_env_call_checked(node ast.Expr) ?string {
+	if node is ast.CallExpr {
+		if node.lhs is ast.Ident
+			&& node.lhs.name in ['array__pop', 'array__pop_left', 'array__first', 'array__last']
+			&& node.args.len > 0 {
+			elem_type := g.infer_array_elem_type_from_expr(node.args[0])
+			if elem_type != '' {
+				return elem_type
+			}
+		} else if node.lhs is ast.SelectorExpr
+			&& node.lhs.rhs.name in ['pop', 'pop_left', 'first', 'last'] {
+			arr_expr := if node.args.len > 0 { node.args[0] } else { node.lhs.lhs }
+			elem_type := g.infer_array_elem_type_from_expr(arr_expr)
+			if elem_type != '' {
+				return elem_type
+			}
+		}
+		if ret := g.get_call_return_type(node.lhs, node.args) {
+			if ret != '' {
+				return ret
+			}
+		}
+	} else if node is ast.CallOrCastExpr {
+		if node.expr !is ast.EmptyExpr && g.call_or_cast_lhs_is_type(node.lhs) {
+			cast_t := g.expr_type_to_c(node.lhs)
+			if cast_t != '' && cast_t != 'int' {
+				return cast_t
+			}
+		} else {
+			call_args := if node.expr is ast.EmptyExpr {
+				[]ast.Expr{}
+			} else {
+				[node.expr]
+			}
+			if ret := g.get_call_return_type(node.lhs, call_args) {
+				if ret != '' {
+					return ret
+				}
+			}
+		}
+	}
+	return none
+}
+
+fn (mut g Gen) get_expr_type_from_env_index_checked(node ast.IndexExpr, t string) ?string {
+	if node.expr is ast.RangeExpr {
+		return none
+	}
+	if t.starts_with('Array_') && !t.starts_with('Array_fixed_') {
+		if lhs_raw := g.get_raw_type(node.lhs) {
+			if lhs_raw is types.Array {
+				raw_elem := g.types_type_to_c(lhs_raw.elem_type)
+				if raw_elem != '' && raw_elem != t {
+					return raw_elem
+				}
+			} else if lhs_raw is types.Pointer && lhs_raw.base_type is types.Array {
+				raw_elem := g.types_type_to_c(lhs_raw.base_type.elem_type)
+				if raw_elem != '' && raw_elem != t {
+					return raw_elem
+				}
+			}
+		}
+		return t
+	}
+	if t.starts_with('Array_fixed_') {
+		lhs_type := g.get_expr_type(node.lhs).trim_right('*')
+		if lhs_type.starts_with('Array_fixed_') {
+			mut fixed_t := if t.ends_with('*') { t[..t.len - 1] } else { t }
+			rest := fixed_t['Array_fixed_'.len..]
+			last_underscore := rest.last_index('_') or { -1 }
+			if last_underscore > 0 {
+				return rest[..last_underscore]
+			}
+		}
+		return t
+	}
+	if t in ['void*', 'voidptr'] {
+		if elem_type := g.index_expr_elem_type_from_lhs(node) {
+			return elem_type
+		}
+		container_type := g.get_expr_type(node.lhs)
+		if container_type.starts_with('Array_fixed_') {
+			rest := container_type['Array_fixed_'.len..]
+			last_underscore := rest.last_index('_') or { -1 }
+			if last_underscore > 0 {
+				return rest[..last_underscore]
+			}
+		}
+		return t
+	}
+	return none
+}
+
+fn (mut g Gen) get_expr_type_from_env_selector_checked(node ast.SelectorExpr, t string) ?string {
+	if t in ['void*', 'voidptr'] {
+		field_type := g.selector_field_type(node)
+		if field_type != '' && field_type !in ['void*', 'voidptr'] {
+			return field_type
+		}
+		return t
+	}
+	if t.starts_with('_result_') || t.starts_with('_option_') {
+		field_type := g.selector_field_type(node)
+		if field_type != '' && field_type != t {
+			return field_type
+		}
+		return none
+	}
+	if g.active_generic_types.len > 0 {
+		field_type := g.selector_field_type(node)
+		if field_type != '' && field_type != t {
+			return field_type
+		}
+		return t
+	}
+	if t == 'int' {
+		field_type := g.selector_field_type(node)
+		if field_type != '' && field_type != 'int' {
+			return field_type
+		}
+		return none
+	}
+	field_type := g.selector_field_type(node)
+	if field_type != '' && field_type != t && !is_generic_placeholder_c_type_name(field_type) {
+		return field_type
+	}
+	return t
+}
+
+fn (mut g Gen) get_expr_type_from_env_infix_checked(node ast.InfixExpr, t string) ?string {
+	if t in ['void*', 'voidptr'] && node.op in [.plus, .minus, .mul, .div, .mod] {
+		return none
+	}
+	if t.starts_with('_result_') || t.starts_with('_option_') {
+		lhs_type := g.get_expr_type(node.lhs)
+		rhs_type := g.get_expr_type(node.rhs)
+		if lhs_type.ends_with('*')
+			|| lhs_type in ['void*', 'u8*', 'char*', 'byteptr', 'charptr', 'voidptr'] {
+			return lhs_type
+		}
+		if rhs_type.ends_with('*')
+			|| rhs_type in ['void*', 'u8*', 'char*', 'byteptr', 'charptr', 'voidptr'] {
+			return rhs_type
+		}
+		return none
+	}
+	if t == 'int' && node.op in [.plus, .minus, .mul, .div, .mod] {
+		numeric_type := g.infer_numeric_expr_type(node)
+		if numeric_type != '' && numeric_type !in ['int', 'int_literal'] {
+			return numeric_type
+		}
+		return none
+	}
+	return t
+}
+
+fn (mut g Gen) get_expr_type_from_env_checked(node ast.Expr, t string) ?string {
+	if checked := g.get_expr_type_from_env_call_checked(node) {
+		return checked
+	}
+	if t == 'bool' && node is ast.BasicLiteral && node.kind == .number {
+		return 'int'
+	}
+	match node {
+		ast.IndexExpr {
+			if checked := g.get_expr_type_from_env_index_checked(node, t) {
+				return checked
+			}
+		}
+		ast.SelectorExpr {
+			return g.get_expr_type_from_env_selector_checked(node, t) or { none }
+		}
+		ast.InfixExpr {
+			return g.get_expr_type_from_env_infix_checked(node, t) or { none }
+		}
+		else {}
+	}
+
+	return t
+}
+
 fn (mut g Gen) get_expr_type(node ast.Expr) string {
 	if node is ast.StringLiteral || node is ast.StringInterLiteral {
 		if node is ast.StringLiteral && node.kind == .c {
@@ -3124,83 +3385,7 @@ fn (mut g Gen) get_expr_type(node ast.Expr) string {
 	// For identifiers, check local/parameter types first (authoritative),
 	// then fall back to env position lookup.
 	if node is ast.Ident {
-		if local_type := g.get_local_var_c_type(node.name) {
-			return local_type
-		}
-		if node.name == 'err' {
-			return 'IError'
-		}
-		if global_type := g.global_var_type_for_ident(node.name) {
-			return global_type
-		}
-		// Env pos.id O(1) lookup.
-		if t := g.get_expr_type_from_env(node) {
-			return t
-		}
-		// get_local_var_c_type already checked fn scope + runtime_local_types.
-		// Only module and builtin scope fallbacks remain.
-		if g.env != unsafe { nil } {
-			if g.cur_module != '' {
-				if mut mod_scope := g.env_scope(g.cur_module) {
-					if obj := mod_scope.lookup_parent(node.name, 0) {
-						if obj !is types.Module {
-							raw := obj.typ()
-							if raw is types.Alias {
-								// For struct-valued aliases (like Color = gg.Color),
-								// return the alias C type directly.
-								alias_c := g.types_type_to_c(raw)
-								if alias_c != '' && alias_c != 'int'
-									&& alias_c !in ['voidptr', 'void*', 'charptr', 'char*', 'byteptr', 'u8*'] {
-									return alias_c
-								}
-							} else {
-								typ_name := g.types_type_to_c(raw)
-								if typ_name != '' {
-									return typ_name
-								}
-							}
-						}
-					}
-				}
-			}
-			if g.cur_module != 'builtin' {
-				if mut builtin_scope := g.env_scope('builtin') {
-					if obj := builtin_scope.lookup_parent(node.name, 0) {
-						if obj !is types.Module {
-							raw := obj.typ()
-							if raw !is types.Alias {
-								typ_name := g.types_type_to_c(raw)
-								if typ_name != '' {
-									return typ_name
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-		// Module-qualified ident: transformer mangles `module.name` → `module__name`.
-		// Split and look up the short name in the module's scope.
-		if node.name.contains('__') {
-			parts := node.name.split('__')
-			if parts.len == 2 {
-				mod_name := parts[0]
-				short_name := parts[1]
-				if mut target_scope := g.env_scope(mod_name) {
-					if obj := target_scope.lookup_parent(short_name, 0) {
-						if obj !is types.Module {
-							raw := obj.typ()
-							typ_name := g.types_type_to_c(raw)
-							if typ_name != '' && typ_name != 'int' {
-								return typ_name
-							}
-						}
-					}
-				}
-			}
-		}
-		// Ident already tried env + all scopes above; avoid redundant second lookup below.
-		return 'int'
+		return g.get_ident_expr_type(node)
 	}
 	// For IndexExpr on pointer-to-pointer or pointer-to-string types, prefer raw-type-based
 	// inference over env (env may store the wrong type, e.g. char instead of char*).
@@ -3413,172 +3598,8 @@ fn (mut g Gen) get_expr_type(node ast.Expr) string {
 	}
 	// Try environment lookup
 	if t := g.get_expr_type_from_env(node) {
-		// For array element-returning methods, prefer element type inference over the
-		// generic void* return type from function metadata.
-		if node is ast.CallExpr {
-			if node.lhs is ast.Ident
-				&& node.lhs.name in ['array__pop', 'array__pop_left', 'array__first', 'array__last']
-				&& node.args.len > 0 {
-				elem_type := g.infer_array_elem_type_from_expr(node.args[0])
-				if elem_type != '' {
-					return elem_type
-				}
-			} else if node.lhs is ast.SelectorExpr
-				&& node.lhs.rhs.name in ['pop', 'pop_left', 'first', 'last'] {
-				arr_expr := if node.args.len > 0 { node.args[0] } else { node.lhs.lhs }
-				elem_type := g.infer_array_elem_type_from_expr(arr_expr)
-				if elem_type != '' {
-					return elem_type
-				}
-			}
-			if ret := g.get_call_return_type(node.lhs, node.args) {
-				if ret != '' {
-					return ret
-				}
-			}
-		} else if node is ast.CallOrCastExpr {
-			if node.expr !is ast.EmptyExpr && g.call_or_cast_lhs_is_type(node.lhs) {
-				cast_t := g.expr_type_to_c(node.lhs)
-				if cast_t != '' && cast_t != 'int' {
-					return cast_t
-				}
-			} else {
-				call_args := if node.expr is ast.EmptyExpr {
-					[]ast.Expr{}
-				} else {
-					[node.expr]
-				}
-				if ret := g.get_call_return_type(node.lhs, call_args) {
-					if ret != '' {
-						return ret
-					}
-				}
-			}
-		}
-		// For arithmetic InfixExpr, env may return void* when it should be a
-		// numeric type.  Fall through to operand-based inference.
-		if t in ['void*', 'voidptr'] && node is ast.InfixExpr
-			&& node.op in [.plus, .minus, .mul, .div, .mod] {
-			// fall through to InfixExpr handler below
-		} else if t == 'bool' && node is ast.BasicLiteral && node.kind == .number {
-			// Numeric literals mistyped as bool by env (e.g. `1 in map` context).
-			return 'int'
-		} else if node is ast.IndexExpr && node.expr !is ast.RangeExpr && t.starts_with('Array_')
-			&& !t.starts_with('Array_fixed_') {
-			// Env may return the container type instead of the element type for IndexExpr.
-			// Cross-check against raw type of the LHS container: if the LHS is an Array
-			// whose element type is known, prefer that.
-			if lhs_raw := g.get_raw_type(node.lhs) {
-				if lhs_raw is types.Array {
-					raw_elem := g.types_type_to_c(lhs_raw.elem_type)
-					if raw_elem != '' && raw_elem != t {
-						return raw_elem
-					}
-				} else if lhs_raw is types.Pointer && lhs_raw.base_type is types.Array {
-					raw_elem := g.types_type_to_c(lhs_raw.base_type.elem_type)
-					if raw_elem != '' && raw_elem != t {
-						return raw_elem
-					}
-				}
-			}
-			return t
-		} else if node is ast.IndexExpr && node.expr !is ast.RangeExpr
-			&& t.starts_with('Array_fixed_') {
-			// Env returned the container type for an IndexExpr on a fixed array.
-			// Extract the element type: Array_fixed_u32_8 => u32, Array_fixed_u32_8* => u32
-			lhs_type := g.get_expr_type(node.lhs).trim_right('*')
-			if lhs_type.starts_with('Array_fixed_') {
-				mut fixed_t := if t.ends_with('*') { t[..t.len - 1] } else { t }
-				rest := fixed_t['Array_fixed_'.len..]
-				last_underscore := rest.last_index('_') or { -1 }
-				if last_underscore > 0 {
-					return rest[..last_underscore]
-				}
-			}
-			return t
-		} else if t in ['void*', 'voidptr'] && node is ast.IndexExpr {
-			// Function-typed generic bodies sometimes leave array element access with
-			// a void* env type. Prefer the container element type so `for x in []&T`
-			// does not emit `void* x` and then field-select through it.
-			if elem_type := g.index_expr_elem_type_from_lhs(node) {
-				return elem_type
-			}
-			// For IndexExpr, env returns void* for fixed-array element access.
-			// Try to infer element type from the container type.
-			container_type := g.get_expr_type(node.lhs)
-			if container_type.starts_with('Array_fixed_') {
-				// Array_fixed_u16_8 => element type is u16
-				rest := container_type['Array_fixed_'.len..]
-				last_underscore := rest.last_index('_') or { -1 }
-				if last_underscore > 0 {
-					elem := rest[..last_underscore]
-					return elem
-				}
-			}
-			return t
-		} else if t in ['void*', 'voidptr'] && node is ast.SelectorExpr {
-			// Selector env metadata can also degrade ordinary struct fields to void*.
-			// Prefer the declared field type when it can be recovered from the receiver.
-			field_type := g.selector_field_type(node)
-			if field_type != '' && field_type !in ['void*', 'voidptr'] {
-				return field_type
-			}
-			return t
-		} else if node is ast.SelectorExpr
-			&& (t.starts_with('_result_') || t.starts_with('_option_')) {
-			// Selector env metadata can incorrectly attach wrapper types to ordinary
-			// fields like `s.str` / `s.is_lit`. Re-resolve the field against the
-			// struct instead of trusting the env entry.
-			field_type := g.selector_field_type(node)
-			if field_type != '' && field_type != t {
-				return field_type
-			}
-		} else if node is ast.InfixExpr && (t.starts_with('_result_') || t.starts_with('_option_')) {
-			// Pointer arithmetic can inherit bogus wrapper types from env metadata
-			// even when the operands are plain pointer + integer expressions.
-			lhs_type := g.get_expr_type(node.lhs)
-			rhs_type := g.get_expr_type(node.rhs)
-			if lhs_type.ends_with('*')
-				|| lhs_type in ['void*', 'u8*', 'char*', 'byteptr', 'charptr', 'voidptr'] {
-				return lhs_type
-			}
-			if rhs_type.ends_with('*')
-				|| rhs_type in ['void*', 'u8*', 'char*', 'byteptr', 'charptr', 'voidptr'] {
-				return rhs_type
-			}
-		} else if t == 'int' && node is ast.SelectorExpr {
-			// Selector env types can degrade to `int` for nested field chains
-			// (e.g. a.x.x). Prefer field-resolution fallback when available.
-			field_type := g.selector_field_type(node)
-			if field_type != '' && field_type != 'int' {
-				return field_type
-			}
-		} else if t == 'int' && node is ast.InfixExpr
-			&& node.op in [.plus, .minus, .mul, .div, .mod] {
-			// Arithmetic env types can also degrade to `int` when selector
-			// operands lose their field types. Re-infer numerics from operands.
-			numeric_type := g.infer_numeric_expr_type(node)
-			if numeric_type != '' && numeric_type !in ['int', 'int_literal'] {
-				return numeric_type
-			}
-		} else if node is ast.SelectorExpr && g.active_generic_types.len > 0 {
-			// In specialized generic functions, the env may return the
-			// substituted generic type param (e.g. Slack) instead of the actual
-			// struct field type (e.g. ValueInfo). Cross-check against struct fields.
-			field_type := g.selector_field_type(node)
-			if field_type != '' && field_type != t {
-				return field_type
-			}
-			return t
-		} else if node is ast.SelectorExpr {
-			field_type := g.selector_field_type(node)
-			if field_type != '' && field_type != t
-				&& !is_generic_placeholder_c_type_name(field_type) {
-				return field_type
-			}
-			return t
-		} else {
-			return t
+		if checked := g.get_expr_type_from_env_checked(node, t) {
+			return checked
 		}
 	}
 	// Fallback inference

--- a/vlib/v2/transformer/transformer.v
+++ b/vlib/v2/transformer/transformer.v
@@ -14781,10 +14781,13 @@ fn (mut t Transformer) generate_str_functions_with_explicit(explicit_str_fns map
 	mut generated := map[string]bool{}
 	for {
 		mut found_new := false
-		for fn_name, elem_type in t.needed_str_fns {
+		mut fn_names := t.needed_str_fns.keys()
+		fn_names.sort()
+		for fn_name in fn_names {
 			if fn_name in generated {
 				continue
 			}
+			elem_type := t.needed_str_fns[fn_name] or { continue }
 			if fn_name.starts_with('Array_fixed_') {
 				// Generate fixed array str function
 				generated[fn_name] = true

--- a/vlib/v2/types/checker.v
+++ b/vlib/v2/types/checker.v
@@ -589,6 +589,8 @@ struct PendingFnBody {
 	typ           FnType
 	scope_fn_name string
 	module_name   string
+	flat          &ast.FlatAst   = unsafe { nil }
+	flat_decl_id  ast.FlatNodeId = -1
 }
 
 struct Checker {
@@ -609,6 +611,8 @@ mut:
 	fallback_vars map[string]Type
 	// when true, function declarations only register signatures and queue body checking
 	collect_fn_signatures_only bool
+	pending_fn_body_flat       &ast.FlatAst   = unsafe { nil }
+	pending_fn_body_flat_id    ast.FlatNodeId = -1
 	pending_const_fields       []PendingConstField
 	pending_interface_decls    []PendingInterfaceDecl
 	pending_struct_decls       []PendingStructDecl
@@ -1933,8 +1937,26 @@ fn (mut c Checker) preregister_fn_signatures_from_flat(flat &ast.FlatAst, ff ast
 	c.scope = mod_scope
 	prev_collect := c.collect_fn_signatures_only
 	c.collect_fn_signatures_only = true
-	for stmt in flat.read_file_stmts(ff) {
-		c.preregister_fn_signature_stmt(stmt)
+	decls := ast.Cursor{
+		flat: unsafe { flat }
+		id:   ff.file_id
+	}.list_at(2)
+	for di in 0 .. decls.len() {
+		dc := decls.at(di)
+		if dc.kind() == .stmt_fn_decl {
+			decl := flat.decode_fn_decl_signature(dc.id)
+			prev_flat := c.pending_fn_body_flat
+			prev_flat_id := c.pending_fn_body_flat_id
+			c.pending_fn_body_flat = unsafe { flat }
+			c.pending_fn_body_flat_id = dc.id
+			c.preregister_fn_signature_stmt(ast.Stmt(decl))
+			c.pending_fn_body_flat = prev_flat
+			c.pending_fn_body_flat_id = prev_flat_id
+			continue
+		}
+		if dc.kind() == .stmt_expr {
+			c.preregister_fn_signature_stmt(flat.decode_stmt(dc.id))
+		}
 	}
 	c.collect_fn_signatures_only = prev_collect
 }
@@ -5003,8 +5025,9 @@ fn (mut c Checker) process_pending_fn_bodies() {
 }
 
 fn (mut c Checker) check_pending_fn_body(pending PendingFnBody) bool {
-	decl_generic_params := collect_fn_generic_params(pending.decl)
-	has_decl_generic_params := pending.decl.typ.generic_params.len > 0
+	signature_decl := pending.decl
+	decl_generic_params := collect_fn_generic_params(signature_decl)
+	has_decl_generic_params := signature_decl.typ.generic_params.len > 0
 	has_generic_params := decl_generic_params.len > 0
 	if has_decl_generic_params {
 		mut generic_types := []map[string]Type{}
@@ -5023,7 +5046,7 @@ fn (mut c Checker) check_pending_fn_body(pending PendingFnBody) bool {
 			} else {
 				base_name
 			}
-			if base_name == pending.decl.name || short_name == pending.decl.name {
+			if base_name == signature_decl.name || short_name == signature_decl.name {
 				generic_types = inferred.clone()
 				has_generic_types = true
 				break
@@ -5036,6 +5059,13 @@ fn (mut c Checker) check_pending_fn_body(pending PendingFnBody) bool {
 		c.env.cur_generic_types << generic_types
 	}
 	if !has_decl_generic_params || c.env.cur_generic_types.len > 0 {
+		mut decl := signature_decl
+		if pending.flat != unsafe { nil } && pending.flat_decl_id >= 0 {
+			stmt := pending.flat.decode_stmt(pending.flat_decl_id)
+			if stmt is ast.FnDecl {
+				decl = stmt
+			}
+		}
 		prev_scope := c.scope
 		prev_module := c.cur_file_module
 		prev_fn_root_scope := c.fn_root_scope
@@ -5050,14 +5080,14 @@ fn (mut c Checker) check_pending_fn_body(pending PendingFnBody) bool {
 				c.fallback_vars[param.name] = param.typ
 			}
 		}
-		if pending.decl.is_method {
-			mut receiver_type := c.type_expr(pending.decl.receiver.typ)
-			if pending.decl.receiver.is_mut && receiver_type !is Pointer {
+		if decl.is_method {
+			mut receiver_type := c.type_expr(decl.receiver.typ)
+			if decl.receiver.is_mut && receiver_type !is Pointer {
 				receiver_type = Type(Pointer{
 					base_type: receiver_type
 				})
 			}
-			c.fallback_vars[pending.decl.receiver.name] = receiver_type
+			c.fallback_vars[decl.receiver.name] = receiver_type
 		}
 		if has_generic_params {
 			c.generic_params = decl_generic_params
@@ -5079,12 +5109,12 @@ fn (mut c Checker) check_pending_fn_body(pending PendingFnBody) bool {
 			prev_owned_types = c.owned_var_types.clone()
 			prev_moved = c.moved_vars.clone()
 			prev_borrowed = c.borrowed_vars.clone()
-			c.ownership_enter_fn(pending.decl.name, pending.decl)
+			c.ownership_enter_fn(decl.name, decl)
 		}
-		c.stmt_list(pending.decl.stmts)
+		c.stmt_list(decl.stmts)
 		$if ownership ? {
-			publish_keys := ownership_publish_keys_for(pending.module_name, pending.decl)
-			c.ownership_snapshot_drops_at_fn_exit(pending.decl.name, publish_keys)
+			publish_keys := ownership_publish_keys_for(pending.module_name, decl)
+			c.ownership_snapshot_drops_at_fn_exit(decl.name, publish_keys)
 			c.ownership_publish_pending_return_drops(publish_keys)
 			c.ownership_leave_fn(prev_ownership_fn, prev_owned, prev_owned_types, prev_moved,
 				prev_borrowed)
@@ -5859,6 +5889,8 @@ fn (mut c Checker) fn_decl(decl ast.FnDecl) {
 		typ:           fn_typ
 		scope_fn_name: scope_fn_name
 		module_name:   module_name
+		flat:          c.pending_fn_body_flat
+		flat_decl_id:  c.pending_fn_body_flat_id
 	}
 	if c.collect_fn_signatures_only {
 		c.pending_fn_bodies << pending


### PR DESCRIPTION
## Summary
- parallelize v2 cleanc pass5 generation with a larger worker cap
- add cold-cache cgen profiling stats for cache/source/pass5 timing
- cache specialized receiver method lookup results and returned-ident collection during cleanc generation

## Perf
Cold-cache self-build on `cmd/v2/v2.v`:
- before this work, reported C Gen: ~13047ms, Total: ~14912ms
- before the specialized receiver cache commit, C Gen: ~10177ms, Total: ~11754ms
- after these changes, C Gen: ~1454ms, Total: ~2987ms

A `-stats` run after the final change showed C Gen: ~1429ms, with pass5 worker time down to ~453ms and the slowest pass5 file around ~392ms.

## Validation
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -prod -o cmd/v2/v2prod cmd/v2/v2.v`
- `./vnew -silent vlib/v2/gen/cleanc/pass5_worker_test.v`
- `./vnew -silent vlib/v2/gen/cleanc/cleanc_test.v`
- `./vnew -silent vlib/v2/gen/cleanc/generic_struct_scan_test.v`
- `git diff --check`

Note: `vlib/v2/gen/cleanc/flag_enum_codegen_test.v` still fails on this checkout, but the same failure reproduces with this branch's uncommitted patch reversed, so it appears unrelated to these changes.