### PR TITLE
cgen, coroutines: fix `go expr` handle referencing undeclared `thread__tN`

### DIFF
--- a/examples/coroutines/go_handle.v
+++ b/examples/coroutines/go_handle.v
@@ -1,0 +1,24 @@
+// vtest build: false // This should be built with: `v -use-coroutines go_handle.v`
+// Note: the Photon wrapper is not yet trivial enough to build/install on the CI.
+//
+// Demonstrates storing the handle returned by a `go` expression and waiting on
+// it. Because the Photon coroutine wrapper exposes no joinable handle, a `go`
+// whose handle is used is lowered to the regular `spawn` (pthread) path, so the
+// handle can be waited on just like `spawn`.
+module main
+
+struct App {
+mut:
+	worker thread
+}
+
+fn (a App) loop() {
+	println('hello from the worker coroutine')
+}
+
+fn main() {
+	mut a := App{}
+	a.worker = go a.loop()
+	a.worker.wait()
+	println('done')
+}

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -15,8 +15,19 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	if node.call_expr.should_be_skipped {
 		return
 	}
-	is_spawn := mode == .spawn_
-	is_go := mode == .go_
+	mut is_spawn := mode == .spawn_
+	mut is_go := mode == .go_
+	if is_go && node.is_expr {
+		// A `go expr` whose handle is used as a value (e.g. `h := go f()` or
+		// `obj.field = go f()`) needs a real, joinable thread handle. The photon
+		// coroutine wrapper (`photon_thread_create*`) returns void and exposes no
+		// such handle, so fall back to the regular `spawn` (pthread) path here,
+		// which declares and assigns the `thread_<tmp>` handle that is read back
+		// as the expression's value. Plain statement form `go f()` (no handle
+		// used) keeps using the photon work-pool path below.
+		is_spawn = true
+		is_go = false
+	}
 	if is_spawn {
 		g.writeln('/*spawn (thread) */')
 	} else {

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -1075,6 +1075,20 @@ fn (mut w Walker) expr(node_ ast.Expr) {
 		ast.GoExpr {
 			if node.is_expr {
 				w.fn_by_name('free')
+				// A `go expr` whose handle is used as a value is lowered to the
+				// `spawn` (pthread) codegen path (see spawn_and_go_expr), since the
+				// photon coroutine wrapper returns no joinable handle. Mark the same
+				// thread-handle type and pthread error helpers that `spawn` needs,
+				// otherwise -skip-unused prunes them and the generated C fails to link.
+				w.mark_by_type(w.table.find_or_register_thread(node.call_expr.return_type))
+				w.uses_spawn = true
+				if w.pref.os == .windows {
+					w.fn_by_name('panic_lasterr')
+					w.fn_by_name('winapi_lasterr_str')
+				} else {
+					w.fn_by_name('c_error_number_str')
+					w.fn_by_name('panic_error_number')
+				}
 			}
 			w.mark_by_type(node.call_expr.return_type)
 			w.expr(node.call_expr)


### PR DESCRIPTION
## Description

Fixes #27338.

With `-use-coroutines`, a `go expr` whose handle is stored/used (e.g. `a.worker = go a.loop()`) made cgen reference a C variable `thread__tN` that it never declared:

```
error: use of undeclared identifier 'thread__t2'
 a.worker = /*go (coroutine) */ thread__t2;
```

The coroutine branch in `spawn_and_go_expr` only emitted the `photon_thread_create*` call (which returns `void` and yields no joinable handle), yet the handle `thread_<tmp>` was still written back as the expression's value.

## Fix

The Photon wrapper exposes no waitable handle, so a `go` whose handle is **actually used** (`node.is_expr`) is now lowered to the regular `spawn` (pthread) path, which declares and assigns `thread_<tmp>`. The generated C now contains:

```c
pthread_t thread__t2;
...
int _t2_thr_res = pthread_create(&thread__t2, ..., main__App_loop_thread_wrapper, arg__t2);
a.worker = thread__t2;
```

so it compiles **and** the handle is joinable via `.wait()`, matching the non-coroutine `spawn` path. Plain statement-form `go f()` (no handle used) is unchanged and keeps using the Photon work-pool path.

A companion change in `markused` is required: a `go` handle that is used must mark the same thread-handle type and pthread error helpers (`panic_error_number`, `c_error_number_str`, …) that `spawn` needs — otherwise `-skip-unused` (the default) prunes them and the rerouted spawn path fails to link with `undefined symbol 'builtin__panic_error_number'`.

## Verification

- The reproducer now generates a properly-declared `pthread_t` handle (was: undeclared identifier).
- `panic_error_number` / `c_error_number_str` are emitted (no longer pruned).
- The compiler self-compiles cleanly, and existing spawn/thread tests pass (`array_of_threads_wait_test.v`, `spawn_with_cond_fncall_test.v`, `generic_spawn_test.v`).
- Added `examples/coroutines/go_handle.v` documenting the now-working pattern.

> Note: an automated CI test isn't included because `-use-coroutines` requires the Photon `.so` (downloaded at build time, not available on CI) — consistent with the existing coroutines examples being marked `vtest build: false`.