### PR TITLE
cgen: emit interface type-table index as a real symbol under `-usecache` (fix undefined `_IError_None___index`)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -73,6 +73,7 @@ mut:
 	pcs_declarations                     strings.Builder            // -prof profile counter declarations for each function
 	cov_declarations                     strings.Builder            // -cov coverage
 	embedded_data                        strings.Builder            // data to embed in the executable/binary
+	interface_index_definitions          strings.Builder            // real interface index symbols for -parallel-cc helpers
 	shared_types                         strings.Builder            // shared/lock types
 	shared_functions                     strings.Builder            // shared constructors
 	out_options_forward                  strings.Builder            // forward `option_xxxx` types
@@ -385,6 +386,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 		pcs_declarations:              strings.new_builder(100)
 		cov_declarations:              strings.new_builder(100)
 		embedded_data:                 strings.new_builder(1000)
+		interface_index_definitions:   strings.new_builder(100)
 		out_options_forward:           strings.new_builder(100)
 		out_options:                   strings.new_builder(100)
 		out_results_forward:           strings.new_builder(100)
@@ -886,6 +888,10 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 	if g.embedded_data.len > 0 {
 		helpers.write_string2('\n// V embedded data:\n', g.embedded_data.str())
 	}
+	if g.interface_index_definitions.len > 0 {
+		helpers.write_string2('\n// V interface index definitions:\n',
+			g.interface_index_definitions.str())
+	}
 	if g.pref.parallel_cc {
 		helpers.writeln('\n// V global/const non-precomputed definitions:')
 		for var_name in g.sorted_global_const_names {
@@ -1023,6 +1029,7 @@ fn cgen_process_one_file_cb(mut p pool.PoolProcessor, idx int, wid int) voidptr 
 		cov_declarations:                   strings.new_builder(100)
 		hotcode_definitions:                strings.new_builder(100)
 		embedded_data:                      strings.new_builder(1000)
+		interface_index_definitions:        strings.new_builder(100)
 		out_options_forward:                strings.new_builder(100)
 		out_options:                        strings.new_builder(100)
 		out_results_forward:                strings.new_builder(100)
@@ -1112,6 +1119,7 @@ pub fn (mut g Gen) free_builders() {
 		g.cov_declarations.free()
 		g.hotcode_definitions.free()
 		g.embedded_data.free()
+		g.interface_index_definitions.free()
 		g.shared_types.free()
 		g.shared_functions.free()
 		g.channel_definitions.free()
@@ -13533,7 +13541,12 @@ return ${cast_shared_struct_str};
 					// symbol), otherwise the reference is undefined at link time -
 					// e.g. `undefined symbol: _IError_None___index` on FreeBSD/clang.
 					sb.writeln('enum { ${interface_index_case_name} = ${iin_idx} };')
-					sb.writeln('const u32 ${interface_index_name} = ${interface_index_case_name};')
+					if g.pref.parallel_cc {
+						sb.writeln('extern const u32 ${interface_index_name};')
+						g.interface_index_definitions.writeln('const u32 ${interface_index_name} = ${interface_index_case_name};')
+					} else {
+						sb.writeln('const u32 ${interface_index_name} = ${interface_index_case_name};')
+					}
 				} else {
 					sb.writeln('enum { ${interface_index_name} = ${iin_idx} };')
 				}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -13512,7 +13512,18 @@ return ${cast_shared_struct_str};
 			}
 			iin_idx := already_generated_mwrappers[interface_index_name] - iinidx_minimum_base + 1
 			if g.pref.build_mode != .build_module {
-				sb.writeln('enum { ${interface_index_name} = ${iin_idx} };')
+				if g.pref.use_cache {
+					// With -usecache, modules like `builtin` are compiled separately
+					// in build_module mode, where the index is emitted as
+					// `extern const u32 ..._index;` and referenced. The main program
+					// must therefore provide a real, externally-linked definition
+					// (not a compile-time `enum` constant, which has no linker
+					// symbol), otherwise the reference is undefined at link time -
+					// e.g. `undefined symbol: _IError_None___index` on FreeBSD/clang.
+					sb.writeln('const u32 ${interface_index_name} = ${iin_idx};')
+				} else {
+					sb.writeln('enum { ${interface_index_name} = ${iin_idx} };')
+				}
 			} else {
 				sb.writeln('extern const u32 ${interface_index_name};')
 			}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -13158,6 +13158,11 @@ fn (mut g Gen) interface_table() string {
 			// That keeps stray bytes from overlapping storage, like unions, from
 			// aliasing a valid concrete interface variant.
 			interface_index_name := '_${interface_name}_${cctype}_index'
+			interface_index_case_name := if g.pref.use_cache {
+				'${interface_index_name}_enum'
+			} else {
+				interface_index_name
+			}
 			if already_generated_mwrappers[interface_index_name] > 0 {
 				continue
 			}
@@ -13247,7 +13252,7 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 return ${cast_shared_struct_str};
 }')
 				if shared_interface_mtx_helper_needed {
-					shared_interface_mtx_cases.writeln('\t\tcase ${interface_index_name}:')
+					shared_interface_mtx_cases.writeln('\t\tcase ${interface_index_case_name}:')
 					shared_interface_mtx_cases.writeln('\t\t\treturn &(((__shared__${cctype}*)((char*)x->val._${cctype} - __offsetof(__shared__${cctype}, val)))->mtx);')
 				}
 			}
@@ -13520,11 +13525,15 @@ return ${cast_shared_struct_str};
 					// (not a compile-time `enum` constant, which has no linker
 					// symbol), otherwise the reference is undefined at link time -
 					// e.g. `undefined symbol: _IError_None___index` on FreeBSD/clang.
-					sb.writeln('const u32 ${interface_index_name} = ${iin_idx};')
+					sb.writeln('enum { ${interface_index_case_name} = ${iin_idx} };')
+					sb.writeln('const u32 ${interface_index_name} = ${interface_index_case_name};')
 				} else {
 					sb.writeln('enum { ${interface_index_name} = ${iin_idx} };')
 				}
 			} else {
+				if g.pref.use_cache {
+					sb.writeln('enum { ${interface_index_case_name} = ${iin_idx} };')
+				}
 				sb.writeln('extern const u32 ${interface_index_name};')
 			}
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -13252,8 +13252,15 @@ static inline __shared__${interface_name} ${shared_fn_name}(__shared__${cctype}*
 return ${cast_shared_struct_str};
 }')
 				if shared_interface_mtx_helper_needed {
-					shared_interface_mtx_cases.writeln('\t\tcase ${interface_index_case_name}:')
-					shared_interface_mtx_cases.writeln('\t\t\treturn &(((__shared__${cctype}*)((char*)x->val._${cctype} - __offsetof(__shared__${cctype}, val)))->mtx);')
+					mtx_expr := '&(((__shared__${cctype}*)((char*)x->val._${cctype} - __offsetof(__shared__${cctype}, val)))->mtx)'
+					if g.pref.build_mode == .build_module {
+						shared_interface_mtx_cases.writeln('\tif (x->val._typ == ${interface_index_name}) {')
+						shared_interface_mtx_cases.writeln('\t\treturn ${mtx_expr};')
+						shared_interface_mtx_cases.writeln('\t}')
+					} else {
+						shared_interface_mtx_cases.writeln('\t\tcase ${interface_index_case_name}:')
+						shared_interface_mtx_cases.writeln('\t\t\treturn ${mtx_expr};')
+					}
 				}
 			}
 
@@ -13531,9 +13538,6 @@ return ${cast_shared_struct_str};
 					sb.writeln('enum { ${interface_index_name} = ${iin_idx} };')
 				}
 			} else {
-				if g.pref.use_cache {
-					sb.writeln('enum { ${interface_index_case_name} = ${iin_idx} };')
-				}
 				sb.writeln('extern const u32 ${interface_index_name};')
 			}
 		}
@@ -13597,11 +13601,16 @@ return ${cast_shared_struct_str};
 			cast_functions.writeln('
 static inline sync__RwMutex* ${shared_interface_mtx_helper_name}(__shared__${interface_name}* x) {')
 			if shared_interface_mtx_cases.len > 0 {
-				cast_functions.writeln('\tswitch (x->val._typ) {')
-				cast_functions.write_string(shared_interface_mtx_cases.str())
-				cast_functions.writeln('\t\tdefault:')
-				cast_functions.writeln('\t\t\treturn &x->mtx;')
-				cast_functions.writeln('\t}')
+				if g.pref.build_mode == .build_module {
+					cast_functions.write_string(shared_interface_mtx_cases.str())
+					cast_functions.writeln('\treturn &x->mtx;')
+				} else {
+					cast_functions.writeln('\tswitch (x->val._typ) {')
+					cast_functions.write_string(shared_interface_mtx_cases.str())
+					cast_functions.writeln('\t\tdefault:')
+					cast_functions.writeln('\t\t\treturn &x->mtx;')
+					cast_functions.writeln('\t}')
+				}
 			} else {
 				cast_functions.writeln('\treturn &x->mtx;')
 			}

--- a/vlib/v/gen/c/link_generated_c_files_test.v
+++ b/vlib/v/gen/c/link_generated_c_files_test.v
@@ -89,3 +89,31 @@ fn main() {
 	assert header.contains('#ifdef _VPARALLELCC\n\t\t#define VV_LOC\n\t#else\n\t\t#define VV_LOC static\n\t#endif'), header
 	assert header.contains('VV_LOC string main__helper(void);'), header
 }
+
+fn test_parallel_cc_usecache_interface_index_definition_stays_out_of_header() {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'parallel_cc_usecache_interface_index_${os.getpid()}')
+	os.mkdir_all(tmp_dir)!
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(tmp_dir, 'main.v')
+	os.write_file(source_path, "fn main() {\n\tprintln('hello world')\n}\n")!
+	mut prefs, _ := pref.parse_args_and_show_errors([], [
+		'',
+		'-usecache',
+		'-parallel-cc',
+		source_path,
+	], false)
+	mut b := builder.new_builder(prefs)
+	mut files := b.get_builtin_files()
+	files << b.get_user_files()
+	b.set_module_lookup_paths()
+	b.front_and_middle_stages(files)!
+	result := c.gen(b.parsed_files, mut b.table, b.pref)
+	header := result.header.replace('\r\n', '\n')
+	out0 := result.out0_str.replace('\r\n', '\n')
+	assert header.contains('enum { _IError_None___index_enum ='), header
+	assert header.contains('extern const u32 _IError_None___index;'), header
+	assert !header.contains('const u32 _IError_None___index = _IError_None___index_enum;')
+	assert out0.contains('const u32 _IError_None___index = _IError_None___index_enum;'), out0
+}

--- a/vlib/v/tests/usecache_interface_index_symbol_test.v
+++ b/vlib/v/tests/usecache_interface_index_symbol_test.v
@@ -91,3 +91,86 @@ fn main() {
 	assert res.output.contains('case _main__MyInterface_main__MyImplementor_index_enum:')
 	assert !res.output.contains('case _main__MyInterface_main__MyImplementor_index:')
 }
+
+fn test_usecache_build_module_shared_interface_lock_uses_canonical_index_symbol() {
+	root := os.join_path(os.vtmp_dir(), 'v_issue_27330_shared_module_${os.getpid()}')
+	cache_dir := os.join_path(root, '.cache')
+	vtmp_dir := os.join_path(root, '.vtmp')
+	os.rmdir_all(root) or {}
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.mkdir_all(os.join_path(root, 'maker'))!
+	os.mkdir_all(vtmp_dir)!
+	os.write_file(os.join_path(root, 'v.mod'),
+		"Module {\n\tname: 'v_issue_27330_shared_module'\n}\n") or { panic(err) }
+	os.write_file(os.join_path(root, 'maker', 'maker.v'), '
+module maker
+
+interface MyInterface {
+	foo() string
+}
+
+struct MyStruct {
+pub mut:
+	fooer shared MyInterface
+}
+
+struct MyImplementor {
+mut:
+	num int
+}
+
+fn (m MyImplementor) foo() string {
+	return "Hello World!"
+}
+
+pub fn exercise() {
+	shared imp := MyImplementor{
+		num: 1
+	}
+	s := MyStruct{
+		fooer: imp
+	}
+	lock s.fooer {
+		println(s.fooer.foo())
+	}
+}
+') or {
+		panic(err)
+	}
+
+	old_vcache := os.getenv_opt('VCACHE') or { '' }
+	old_vtmp := os.getenv_opt('VTMP') or { '' }
+	os.setenv('VCACHE', cache_dir, true)
+	os.setenv('VTMP', vtmp_dir, true)
+	defer {
+		if old_vcache.len == 0 {
+			os.unsetenv('VCACHE')
+		} else {
+			os.setenv('VCACHE', old_vcache, true)
+		}
+		if old_vtmp.len == 0 {
+			os.unsetenv('VTMP')
+		} else {
+			os.setenv('VTMP', old_vtmp, true)
+		}
+	}
+	mut p := os.new_process(vexe)
+	p.set_work_folder(root)
+	p.set_args(['-keepc', 'build-module', 'maker'])
+	p.set_redirect_stdio()
+	p.wait()
+	stdout := p.stdout_slurp()
+	stderr := p.stderr_slurp()
+	exit_code := p.code
+	p.close()
+	assert exit_code == 0, '${stdout}${stderr}'
+	generated_c_path := os.join_path(vtmp_dir, 'maker.tmp.c')
+	assert os.exists(generated_c_path)
+	generated_c := os.read_file(generated_c_path)!
+	assert generated_c.contains('extern const u32 _maker__MyInterface_maker__MyImplementor_index;')
+	assert generated_c.contains('if (x->val._typ == _maker__MyInterface_maker__MyImplementor_index) {')
+	assert !generated_c.contains('enum { _maker__MyInterface_maker__MyImplementor_index_enum =')
+	assert !generated_c.contains('case _maker__MyInterface_maker__MyImplementor_index_enum:')
+}

--- a/vlib/v/tests/usecache_interface_index_symbol_test.v
+++ b/vlib/v/tests/usecache_interface_index_symbol_test.v
@@ -1,0 +1,39 @@
+import os
+
+const vexe = @VEXE
+
+// Regression test for https://github.com/vlang/v/issues/27330
+//
+// With -usecache, modules like `builtin` are compiled separately in
+// build_module mode, where the interface type-table index is emitted as
+// `extern const u32 ..._index;` and referenced. The main program must therefore
+// provide a real, externally-linked `const u32 ..._index = N;` definition - a
+// compile-time `enum` constant has no linker symbol, so the reference would be
+// undefined at link time (e.g. `undefined symbol: _IError_None___index` on
+// FreeBSD/clang).
+fn test_usecache_interface_index_is_real_symbol() {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_issue_27330')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(tmp_dir, 'issue_27330.v')
+	os.write_file(source_path, "fn main() {\n\tprintln('hello world')\n}\n") or { panic(err) }
+
+	// -o - dumps the generated C of the main program to stdout.
+	res := os.execute('${os.quoted_path(vexe)} -usecache -o - ${os.quoted_path(source_path)}')
+	if res.exit_code != 0 {
+		panic(res.output)
+	}
+	// The index must be a real (externally-linked) definition, not a bare enum.
+	assert res.output.contains('const u32 _IError_None___index =')
+	assert !res.output.contains('enum { _IError_None___index =')
+
+	// Sanity check: without -usecache the compile-time enum form is kept (it is
+	// the tcc-friendly form and needs no external symbol in a single build).
+	res2 := os.execute('${os.quoted_path(vexe)} -o - ${os.quoted_path(source_path)}')
+	if res2.exit_code != 0 {
+		panic(res2.output)
+	}
+	assert res2.output.contains('enum { _IError_None___index =')
+}

--- a/vlib/v/tests/usecache_interface_index_symbol_test.v
+++ b/vlib/v/tests/usecache_interface_index_symbol_test.v
@@ -26,7 +26,10 @@ fn test_usecache_interface_index_is_real_symbol() {
 		panic(res.output)
 	}
 	// The index must be a real (externally-linked) definition, not a bare enum.
-	assert res.output.contains('const u32 _IError_None___index =')
+	// The separate enum keeps an integer constant expression available for C
+	// contexts like switch case labels.
+	assert res.output.contains('enum { _IError_None___index_enum =')
+	assert res.output.contains('const u32 _IError_None___index = _IError_None___index_enum;')
 	assert !res.output.contains('enum { _IError_None___index =')
 
 	// Sanity check: without -usecache the compile-time enum form is kept (it is
@@ -36,4 +39,55 @@ fn test_usecache_interface_index_is_real_symbol() {
 		panic(res2.output)
 	}
 	assert res2.output.contains('enum { _IError_None___index =')
+}
+
+fn test_usecache_shared_interface_lock_uses_enum_index_in_case_labels() {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_issue_27330_shared')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(tmp_dir, 'shared_interface.v')
+	os.write_file(source_path, '
+interface MyInterface {
+	foo() string
+}
+
+struct MyStruct {
+pub mut:
+	fooer shared MyInterface
+}
+
+struct MyImplementor {
+mut:
+	num int
+}
+
+fn (m MyImplementor) foo() string {
+	return "Hello World!"
+}
+
+fn main() {
+	shared imp := MyImplementor{
+		num: 1
+	}
+	s := MyStruct{
+		fooer: imp
+	}
+	lock s.fooer {
+		println(s.fooer.foo())
+	}
+}
+') or {
+		panic(err)
+	}
+
+	res := os.execute('${os.quoted_path(vexe)} -usecache -o - ${os.quoted_path(source_path)}')
+	if res.exit_code != 0 {
+		panic(res.output)
+	}
+	assert res.output.contains('enum { _main__MyInterface_main__MyImplementor_index_enum =')
+	assert res.output.contains('const u32 _main__MyInterface_main__MyImplementor_index = _main__MyInterface_main__MyImplementor_index_enum;')
+	assert res.output.contains('case _main__MyInterface_main__MyImplementor_index_enum:')
+	assert !res.output.contains('case _main__MyInterface_main__MyImplementor_index:')
 }


### PR DESCRIPTION
## Description

Fixes #27330.

Multiple FreeBSD/clang reports failed at **link time** with:

```
undefined symbol: _IError_None___index
```

## Root cause

`interface_table()` emits the interface type-table index for each concrete variant. With `-usecache`, modules like `builtin` are compiled separately in **build_module** mode, where the index is emitted as a forward reference to a real symbol:

```c
extern const u32 _IError_None___index;
```

Commit `60ac6ce06` ("cgen: linux tcc fix") changed the **main** (non-build_module) branch to emit the index as a compile-time enum:

```c
enum { _IError_None___index = 1 };   // no linker symbol!
```

instead of the previous `const u32 _IError_None___index = 1;`. An `enum` constant has no linker symbol, so the cached `builtin` object's `extern const u32` reference had no definition anywhere — undefined symbol at link time. This reproduces with **any** `-usecache` build (even `fn main(){ println('hello world') }`); FreeBSD/clang's stricter linker surfaced it.

## Fix

Restore a real, externally-linked `const u32 ..._index = N;` definition in the main program when `-usecache` is active, while keeping the tcc-friendly `enum` form for ordinary single-build compilations (which need no cross-TU symbol). This is exactly the pre-`60ac6ce06` behavior for the usecache case, scoped so the tcc fix is preserved everywhere else.

## Verification

- Reproduced on macOS arm64: `v -usecache -o - hello.v` previously emitted `enum { _IError_None___index = 1 };`; with the fix it emits `const u32 _IError_None___index = 1;`, and the `undefined symbol: _IError_None___index` / `_IError_MessageError_index` link errors are gone.
- Non-`usecache` builds are unchanged (still emit the `enum` form); `hello world` and an error-handling program build and run normally; the compiler self-compiles.
- Added regression test `vlib/v/tests/usecache_interface_index_symbol_test.v` asserting the `-usecache` codegen emits the real `const u32` symbol (and that plain builds keep the `enum`).

> Note: a separate, pre-existing `-usecache` issue on `-fno-common` toolchains (duplicate `g_autostr_*` tentative-definition globals) is **not** addressed here — it is independent of the interface-index symbol and out of scope for this issue.