### PR TITLE
net.http: enable HTTP/2 by default for https requests

### DIFF
--- a/vlib/net/http/backend.c.v
+++ b/vlib/net/http/backend.c.v
@@ -21,10 +21,12 @@ fn net_ssl_do(req &Request, port int, method Method, host_name string, path stri
 		eprint(req_headers)
 		eprintln('')
 	}
-	// Advertise ALPN `h2` (with an `http/1.1` fallback) only when HTTP/2 is
-	// requested, so existing callers see no change on the wire. The HTTP/2 read
-	// path now feeds the same streaming callbacks and honors the stop limits,
-	// so they no longer force HTTP/1.1.
+	// Advertise ALPN `h2` (with an `http/1.1` fallback) when HTTP/2 is enabled.
+	// This is the default for https requests, so ordinary get()/fetch() calls
+	// advertise ALPN and use HTTP/2 when the server selects it; callers can opt
+	// out with `enable_http2: false`. The HTTP/2 read path feeds the same
+	// streaming callbacks and honors the stop limits, so they do not force
+	// HTTP/1.1.
 	alpn := if req.enable_http2 { ['h2', 'http/1.1'] } else { []string{} }
 	for {
 		mut ssl_conn := ssl.new_ssl_conn(

--- a/vlib/net/http/h2_client_test.v
+++ b/vlib/net/http/h2_client_test.v
@@ -79,18 +79,19 @@ fn test_h2_authority_omits_default_port() {
 	assert h2_authority('example.com', 8443) == 'example.com:8443'
 }
 
-// Opt-in end-to-end test against a real HTTP/2 server. Run with `-d network`,
+// End-to-end test against a real HTTP/2 server. Run with `-d network`,
 // e.g. `v -d network test vlib/net/http/h2_client_test.v`.
 fn test_http2_fetch_real_server() {
 	$if !network ? {
 		return
 	}
-	resp := fetch(url: 'https://www.google.com/', enable_http2: true)!
+	// HTTP/2 is negotiated by default for https requests.
+	resp := get('https://www.google.com/')!
 	assert resp.version() == .v2_0
 	assert resp.status_code == 200
 	assert resp.body.len > 0
-	// Without opting in, the same server is reached over HTTP/1.1.
-	plain := get('https://www.google.com/')!
+	// Opting out forces HTTP/1.1 against the same server.
+	plain := fetch(url: 'https://www.google.com/', enable_http2: false)!
 	assert plain.version() == .v1_1
 }
 

--- a/vlib/net/http/h2_client_test.v
+++ b/vlib/net/http/h2_client_test.v
@@ -85,6 +85,13 @@ fn test_http2_fetch_real_server() {
 	$if !network ? {
 		return
 	}
+	$if windows && !no_vschannel ? {
+		// On Windows the default HTTPS client is SChannel, which has no ALPN
+		// yet (vlang/v#27383), so it cannot negotiate HTTP/2. Covered with
+		// `-d no_vschannel` (mbedtls client).
+		eprintln('skipping: SChannel client has no ALPN/HTTP2 support yet')
+		return
+	}
 	// HTTP/2 is negotiated by default for https requests.
 	resp := get('https://www.google.com/')!
 	assert resp.version() == .v2_0

--- a/vlib/net/http/http.v
+++ b/vlib/net/http/http.v
@@ -36,7 +36,7 @@ pub mut:
 	in_memory_verification bool   // if true, verify, cert, and cert_key are read from memory, not from a file
 	allow_redirect         bool = true // whether to allow redirect
 	max_retries            int  = 5    // maximum number of retries required when an underlying socket error occurs
-	enable_http2           bool // opt in to HTTP/2 over TLS: advertise ALPN `h2` and, if the server selects it, speak HTTP/2 instead of HTTP/1.1. on_progress / on_progress_body / stop_copying_limit / stop_receiving_limit are honored on the HTTP/2 path; on_progress fires per DATA frame payload rather than per raw network read.
+	enable_http2           bool = true // when true (the default) and the URL is https, advertise ALPN `h2, http/1.1` and use HTTP/2 if the server selects it; set to false to force HTTP/1.1. Ignored for plain http://, and for the Windows SChannel backend which has no ALPN yet (see vlang/v#27383). on_progress / on_progress_body / stop_copying_limit / stop_receiving_limit are honored on the HTTP/2 path; on_progress fires per DATA frame payload rather than per raw network read.
 	// callbacks to allow custom reporting code to run, while the request is running, and to implement streaming
 	on_redirect      RequestRedirectFn     = unsafe { nil }
 	on_progress      RequestProgressFn     = unsafe { nil }

--- a/vlib/net/http/request.v
+++ b/vlib/net/http/request.v
@@ -46,7 +46,7 @@ pub mut:
 	in_memory_verification bool // if true, verify, cert, and cert_key are read from memory, not from a file
 	allow_redirect         bool = true // whether to allow redirect
 	max_retries            int  = 5    // maximum number of retries required when an underlying socket error occurs
-	enable_http2           bool // opt in to HTTP/2 over TLS: advertise ALPN `h2` and, if the server selects it, speak HTTP/2 instead of HTTP/1.1. on_progress / on_progress_body / stop_copying_limit / stop_receiving_limit are honored on the HTTP/2 path; on_progress fires per DATA frame payload rather than per raw network read.
+	enable_http2           bool = true // when true (the default) and the URL is https, advertise ALPN `h2, http/1.1` and use HTTP/2 if the server selects it; set to false to force HTTP/1.1. Ignored for plain http://, and for the Windows SChannel backend which has no ALPN yet (see vlang/v#27383). on_progress / on_progress_body / stop_copying_limit / stop_receiving_limit are honored on the HTTP/2 path; on_progress fires per DATA frame payload rather than per raw network read.
 	// callbacks to allow custom reporting code to run, while the request is running, and to implement streaming
 	on_redirect      RequestRedirectFn     = unsafe { nil }
 	on_progress      RequestProgressFn     = unsafe { nil }


### PR DESCRIPTION
## What

Flips the `enable_http2` default (on `Request` and `FetchConfig`) from `false`
to `true`, so `http.fetch` / `http.get` to an `https://` URL **negotiate HTTP/2
when the server offers it**, and fall back to HTTP/1.1 otherwise. To force
HTTP/1.1, set `enable_http2: false`.

```v
resp := http.get('https://example.com/')        // HTTP/2 if the server supports it
resp.version() // .v2_0 on most modern servers, .v1_1 otherwise

forced := http.fetch(url: 'https://example.com/', enable_http2: false)! // always HTTP/1.1
```

This is the opt-out counterpart to the opt-in support added in #27362, now that
the HTTP/2 client also handles redirects, streaming callbacks (#27369), and flow
control, and has been exercised against real servers.

## Scope

The change is three lines (the two field defaults + the doc) plus a test update.

| File | Change |
|------|--------|
| `request.v`, `http.v` | `enable_http2 bool` → `enable_http2 bool = true`, with updated docs |
| `h2_client_test.v` | the gated real-server test now asserts a default `get()` negotiates HTTP/2 and that `enable_http2: false` forces HTTP/1.1 |

## Behaviour / compatibility

- **Unaffected:** plain `http://` (no ALPN, never HTTP/2), and the Windows
  SChannel backend, which has no ALPN yet and stays on HTTP/1.1 (tracked in
  \#27383).
- **No latency regression:** the client sends the connection preface, its
  SETTINGS, and the request together without waiting for the server's SETTINGS,
  so there's no added round trip; HPACK also shrinks request headers.
- **Transparent fallback:** advertising `h2, http/1.1` is safe — servers that
  don't understand ALPN simply ignore it and the client uses HTTP/1.1.

## Honest tradeoff for the maintainer to weigh

Each `fetch` is still **one connection / one request** (no pooling or
multiplexing yet), so HTTP/2's headline win — multiplexing many requests over
one connection — doesn't yet materialize. This PR is purely about defaulting to
the newer protocol; pooling/multiplexing is a planned follow-up. If you'd rather
keep HTTP/2 opt-in until pooling lands, this PR can simply wait — the opt-in
path (#27362) already works.

## Tests

- Full `vlib/net/http` suite green (mbedtls; 1 Windows-only skip).
- The existing **real-network HTTPS test suite** (`http_httpbin_test.v`:
  GET/POST/PUT/PATCH/DELETE/HEAD against a live server) passes through the new
  default HTTP/2 path unchanged.
- `-d network` test confirms a default `get('https://www.google.com/')`
  returns `HTTP/2.0`, and `enable_http2: false` returns `HTTP/1.1`.
- `-W -cstrict -cc clang` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)