### PR TITLE
v2: fix x64 tiny CI regressions

### DIFF
--- a/vlib/v2/gen/x64/pe.v
+++ b/vlib/v2/gen/x64/pe.v
@@ -390,6 +390,10 @@ fn (l PeLinker) build_runtime_text() PeRuntimeText {
 		rt.symbols['_errno'] = runtime_base + u32(rt.bytes.len)
 		pe_emit_runtime_errno(mut rt)
 	}
+	if l.uses_undefined_symbol('malloc') {
+		rt.symbols['malloc'] = runtime_base + u32(rt.bytes.len)
+		pe_emit_runtime_malloc(mut rt)
+	}
 	if l.uses_undefined_symbol('calloc') {
 		rt.symbols['calloc'] = runtime_base + u32(rt.bytes.len)
 		pe_emit_runtime_calloc(mut rt)
@@ -1424,6 +1428,33 @@ fn pe_emit_runtime_calloc(mut rt PeRuntimeText) {
 	pe_patch_rel8(mut rt.bytes, no_heap, fail_with_frame)
 	pe_patch_rel8(mut rt.bytes, size_overflow, fail_with_frame)
 	pe_patch_rel8(mut rt.bytes, alloc_failed, fail_with_frame)
+}
+
+fn pe_emit_runtime_malloc(mut rt PeRuntimeText) {
+	rt.bytes << [u8(0x48), 0x83, 0xec, 0x28] // sub rsp, 40
+	rt.bytes << [u8(0x48), 0x89, 0x4c, 0x24, 0x20] // mov [rsp+32], rcx
+	pe_emit_runtime_call_import(mut rt, 'GetProcessHeap')
+	rt.bytes << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	no_heap := pe_emit_jcc8(mut rt.bytes, 0x74) // je
+	rt.bytes << [u8(0x48), 0x89, 0xc1] // mov rcx, rax
+	rt.bytes << [u8(0x31), 0xd2] // xor edx, edx
+	rt.bytes << [u8(0x4c), 0x8b, 0x44, 0x24, 0x20] // mov r8, [rsp+32]
+	rt.bytes << [u8(0x49), 0x83, 0xc0, 0x18] // add r8, 24
+	size_overflow := pe_emit_jcc8(mut rt.bytes, 0x72) // jc
+	pe_emit_runtime_call_import(mut rt, 'HeapAlloc')
+	rt.bytes << [u8(0x48), 0x85, 0xc0] // test rax, rax
+	alloc_failed := pe_emit_jcc8(mut rt.bytes, 0x74) // je
+	pe_emit_runtime_align_heap_allocated_data(mut rt)
+	rt.bytes << [u8(0x4c), 0x89, 0xd8] // mov rax, r11
+	rt.bytes << [u8(0x48), 0x83, 0xc4, 0x28] // add rsp, 40
+	rt.bytes << u8(0xc3) // ret
+	fail := rt.bytes.len
+	rt.bytes << [u8(0x31), 0xc0] // xor eax, eax
+	rt.bytes << [u8(0x48), 0x83, 0xc4, 0x28] // add rsp, 40
+	rt.bytes << u8(0xc3) // ret
+	pe_patch_rel8(mut rt.bytes, no_heap, fail)
+	pe_patch_rel8(mut rt.bytes, size_overflow, fail)
+	pe_patch_rel8(mut rt.bytes, alloc_failed, fail)
 }
 
 fn pe_emit_runtime_free(mut rt PeRuntimeText) {

--- a/vlib/v2/gen/x64/x64_pe_linker_test.v
+++ b/vlib/v2/gen/x64/x64_pe_linker_test.v
@@ -489,6 +489,27 @@ fn test_pe_linker_adds_runtime_kernel32_import_patches_only_when_needed() {
 	assert 'WriteFile' !in names
 }
 
+fn test_pe_linker_adds_malloc_heap_imports_without_crt() {
+	mut obj := CoffObject.new()
+	obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0xc3]
+	obj.add_symbol('main', 5, true, 1)
+	malloc_sym := obj.add_undefined('malloc')
+	obj.add_text_reloc(1, malloc_sym, coff_image_rel_amd64_rel32)
+
+	mut linker := PeLinker.new(obj)
+	image := linker.image() or { panic(err) }
+	names := pe_test_import_names(image)
+	dll_names := pe_test_import_dll_names(image)
+
+	assert names == ['ExitProcess', 'GetProcessHeap', 'HeapAlloc']
+	assert dll_names == ['kernel32.dll']
+	assert pe_test_iat_size(image) == u32((names.len + 1) * 8)
+	assert 'HeapFree' !in names
+	assert 'HeapReAlloc' !in names
+	assert 'ucrtbase.dll' !in dll_names
+	assert 'msvcrt.dll' !in dll_names
+}
+
 fn test_pe_linker_adds_shell32_imports_only_for_windows_arguments_globals() {
 	obj := sample_pe_arguments_coff_object(false)
 	mut linker := PeLinker.new(obj)
@@ -883,6 +904,185 @@ fn test_pe_linker_resolves_errno_with_internal_runtime_data_slot() {
 	assert slot_target < data_rva + data_raw_size
 	slot_off := pe_test_rva_to_file_off(image, slot_target)
 	assert pe_test_u32(image, slot_off) == 0
+}
+
+fn test_pe_linker_resolves_malloc_with_internal_nonzeroing_heap_thunk() {
+	mut obj := CoffObject.new()
+	obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0xc3]
+	obj.add_symbol('main', 5, true, 1)
+	malloc_sym := obj.add_undefined('malloc')
+	obj.add_text_reloc(1, malloc_sym, coff_image_rel_amd64_rel32)
+
+	mut linker := PeLinker.new(obj)
+	image := linker.image() or { panic(err) }
+	names := pe_test_import_names(image)
+	dll_names := pe_test_import_dll_names(image)
+	assert names == ['ExitProcess', 'GetProcessHeap', 'HeapAlloc']
+	assert dll_names == ['kernel32.dll']
+
+	text_off := pe_test_section_header(image, '.text')
+	text_rva := pe_test_u32(image, text_off + 12)
+	text_raw := int(pe_test_u32(image, text_off + 20))
+	text_raw_size := int(pe_test_u32(image, text_off + 16))
+	entry_stub_len := linker.entry_stub_size()
+	runtime_start_rva := text_rva + u32(entry_stub_len + obj.text_data.len)
+
+	mut first_import_thunk_file_off := -1
+	for off in text_raw + entry_stub_len + obj.text_data.len .. text_raw + text_raw_size - 1 {
+		if image[off] == 0xff && image[off + 1] == 0x25 {
+			first_import_thunk_file_off = off
+			break
+		}
+	}
+	assert first_import_thunk_file_off > 0
+	first_import_thunk_rva := text_rva + u32(first_import_thunk_file_off - text_raw)
+
+	malloc_target := pe_test_text_rel32_target(image, text_rva, text_raw, entry_stub_len + 1)
+	assert malloc_target >= runtime_start_rva
+	assert malloc_target < first_import_thunk_rva
+
+	malloc_off := pe_test_rva_to_file_off(image, malloc_target)
+	assert malloc_off > 0
+	mut has_shadow_space_frame := false
+	mut has_size_saved_from_rcx := false
+	mut has_heap_zero_memory_flag := false
+	mut has_plain_heap_flags := false
+	mut has_rdx_alignment_dependency := false
+	mut has_aligned_allocation_padding := false
+	mut has_aligned_cookie_store := false
+	mut has_aligned_return_pointer := false
+	runtime_scan_end := first_import_thunk_file_off
+	for off in malloc_off .. runtime_scan_end - 4 {
+		if image[off..off + 4] == [u8(0x48), 0x83, 0xec, 0x28] {
+			has_shadow_space_frame = true
+		}
+		if image[off..off + 5] == [u8(0x48), 0x89, 0x4c, 0x24, 0x20] {
+			has_size_saved_from_rcx = true
+		}
+		if image[off..off + 5] == [u8(0xba), 0x08, 0, 0, 0] {
+			has_heap_zero_memory_flag = true
+		}
+		if image[off..off + 2] == [u8(0x31), 0xd2] {
+			has_plain_heap_flags = true
+		}
+		if image[off..off + 4] == [u8(0x48), 0x83, 0xfa, 0x10] {
+			has_rdx_alignment_dependency = true
+		}
+		if image[off..off + 4] == [u8(0x49), 0x83, 0xc0, 0x18] {
+			has_aligned_allocation_padding = true
+		}
+		if image[off..off + 3] == [u8(0x4c), 0x89, 0xd8] {
+			has_aligned_return_pointer = true
+		}
+	}
+	for off in malloc_off .. runtime_scan_end - 14 {
+		if image[off..off + 15] == [
+			u8(0x49),
+			0x89,
+			0xc3,
+			0x49,
+			0x83,
+			0xc3,
+			0x17,
+			0x49,
+			0x83,
+			0xe3,
+			0xf0,
+			0x49,
+			0x89,
+			0x43,
+			0xf8,
+		] {
+			has_aligned_cookie_store = true
+		}
+	}
+	assert has_shadow_space_frame
+	assert has_size_saved_from_rcx
+	assert !has_heap_zero_memory_flag
+	assert has_plain_heap_flags
+	assert !has_rdx_alignment_dependency
+	assert has_aligned_allocation_padding
+	assert has_aligned_cookie_store
+	assert has_aligned_return_pointer
+}
+
+fn test_pe_linker_resolves_malloc_and_free_with_compatible_heap_cookie() {
+	mut obj := CoffObject.new()
+	obj.text_data << [u8(0xe8), 0, 0, 0, 0, 0xe8, 0, 0, 0, 0, 0xc3]
+	obj.add_symbol('main', 10, true, 1)
+	malloc_sym := obj.add_undefined('malloc')
+	free_sym := obj.add_undefined('free')
+	obj.add_text_reloc(1, malloc_sym, coff_image_rel_amd64_rel32)
+	obj.add_text_reloc(6, free_sym, coff_image_rel_amd64_rel32)
+
+	mut linker := PeLinker.new(obj)
+	image := linker.image() or { panic(err) }
+	names := pe_test_import_names(image)
+	dll_names := pe_test_import_dll_names(image)
+	assert names == ['ExitProcess', 'GetProcessHeap', 'HeapAlloc', 'HeapFree']
+	assert dll_names == ['kernel32.dll']
+	assert 'HeapReAlloc' !in names
+	assert 'ucrtbase.dll' !in dll_names
+	assert 'msvcrt.dll' !in dll_names
+
+	text_off := pe_test_section_header(image, '.text')
+	text_rva := pe_test_u32(image, text_off + 12)
+	text_raw := int(pe_test_u32(image, text_off + 20))
+	text_raw_size := int(pe_test_u32(image, text_off + 16))
+	entry_stub_len := linker.entry_stub_size()
+	runtime_start_rva := text_rva + u32(entry_stub_len + obj.text_data.len)
+
+	mut first_import_thunk_file_off := -1
+	for off in text_raw + entry_stub_len + obj.text_data.len .. text_raw + text_raw_size - 1 {
+		if image[off] == 0xff && image[off + 1] == 0x25 {
+			first_import_thunk_file_off = off
+			break
+		}
+	}
+	assert first_import_thunk_file_off > 0
+	first_import_thunk_rva := text_rva + u32(first_import_thunk_file_off - text_raw)
+
+	malloc_target := pe_test_text_rel32_target(image, text_rva, text_raw, entry_stub_len + 1)
+	free_target := pe_test_text_rel32_target(image, text_rva, text_raw, entry_stub_len + 6)
+	assert malloc_target >= runtime_start_rva
+	assert malloc_target < first_import_thunk_rva
+	assert free_target >= runtime_start_rva
+	assert free_target < first_import_thunk_rva
+
+	malloc_off := pe_test_rva_to_file_off(image, malloc_target)
+	free_off := pe_test_rva_to_file_off(image, free_target)
+	assert malloc_off > 0
+	assert free_off > 0
+	mut malloc_stores_raw_cookie := false
+	for off in malloc_off .. first_import_thunk_file_off - 14 {
+		if image[off..off + 15] == [
+			u8(0x49),
+			0x89,
+			0xc3,
+			0x49,
+			0x83,
+			0xc3,
+			0x17,
+			0x49,
+			0x83,
+			0xe3,
+			0xf0,
+			0x49,
+			0x89,
+			0x43,
+			0xf8,
+		] {
+			malloc_stores_raw_cookie = true
+		}
+	}
+	assert malloc_stores_raw_cookie
+	mut free_reads_raw_cookie := false
+	for off in free_off .. first_import_thunk_file_off - 3 {
+		if image[off..off + 4] == [u8(0x48), 0x8b, 0x41, 0xf8] {
+			free_reads_raw_cookie = true
+		}
+	}
+	assert free_reads_raw_cookie
 }
 
 fn test_pe_linker_resolves_calloc_with_internal_zeroed_heap_thunk() {

--- a/vlib/v2/gen/x64/x64_runtime_smoke_test.v
+++ b/vlib/v2/gen/x64/x64_runtime_smoke_test.v
@@ -3993,6 +3993,7 @@ fn test_x64_linux_hanoi_example_strict_tiny_no_libc() {
 	$if linux {
 		result := run_x64_host_file_redirected_tiny('hanoi_example_strict_tiny_no_libc',
 			x64_examples_dir(), 'hanoi.v')
+		assert !result.build_output.contains('builtin__malloc_noscan'), '${x64_host_result_context(result)}\nhanoi tiny build kept malloc_noscan fallback:\n${result.build_output}'
 		assert_x64_linux_no_libc_binary(result, x64_hanoi_example_stdout())
 		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes +
 			linux_tiny_string_plus_arena_metadata_bytes)
@@ -4004,6 +4005,7 @@ fn test_x64_linux_hanoi_example_auto_tiny_no_libc() {
 	$if linux {
 		result := run_x64_host_file_redirected_auto('hanoi_example_auto_tiny_no_libc',
 			x64_examples_dir(), 'hanoi.v')
+		assert !result.build_output.contains('builtin__malloc_noscan'), '${x64_host_result_context(result)}\nhanoi tiny build kept malloc_noscan fallback:\n${result.build_output}'
 		assert_x64_linux_no_libc_binary(result, x64_hanoi_example_stdout())
 		assert_x64_linux_tiny_load_segment_layout(result, linux_tiny_int_str_arena_metadata_bytes +
 			linux_tiny_string_plus_arena_metadata_bytes)

--- a/vlib/v2/ssa/builder.v
+++ b/vlib/v2/ssa/builder.v
@@ -12450,6 +12450,14 @@ fn (mut b Builder) build_call_resolved_from_flat(fn_name_in string, c ast.Cursor
 		}
 	}
 
+	if ssa_is_string_str_fn_name(fn_name) && n_args == 1 {
+		arg_c := c.edge(1)
+		arg_type := b.expr_type_from_flat(arg_c)
+		if b.is_string_struct_type(arg_type) {
+			return b.build_expr_from_flat(arg_c)
+		}
+	}
+
 	mut ret_type := b.expr_type_from_flat(c)
 	if fn_name in b.fn_index {
 		fn_idx := b.fn_index[fn_name]


### PR DESCRIPTION
## Summary

This fixes V2 x64 CI regressions exposed by the runtime smoke tests.

The Linux hanoi regression appeared after the recent AST / FlatAst call-lowering changes: the legacy SSA path already avoided `string__str(x)` when `x` was already a `string`, but the FlatAst path did not mirror that guard yet.

As a result, the real `examples/hanoi.v` path was still lowering string parameters through `builtin__string__str`, which made the tiny linker reach `builtin__malloc_noscan -> malloc`. Strict tiny correctly rejected the build, and auto tiny fell back to a hosted binary.

This PR mirrors the existing legacy SSA guard in the FlatAst call path, so `string__str(x)` / `builtin__string__str(x)` now returns `x` directly when `x` is already a string.

It also fixes the related Windows x64 PE smoke failure where some examples now reach `malloc`. The PE runtime now provides a small `malloc` thunk backed by `GetProcessHeap` / `HeapAlloc`, without importing the CRT, so the Windows x64 path can keep linking those smoke examples correctly.

This should restore the failing V2 x64 smoke CI checks on Linux and Windows.

## Validation

- `./v fmt -verify vlib/v2/ssa/builder.v vlib/v2/gen/x64/x64_runtime_smoke_test.v vlib/v2/gen/x64/pe.v vlib/v2/gen/x64/x64_pe_linker_test.v`
- `git diff --check`
- `./v test -run-only test_x64_linux_hanoi_example_strict_tiny_no_libc vlib/v2/gen/x64/x64_runtime_smoke_test.v`
- `./v test -run-only test_x64_linux_hanoi_example_auto_tiny_no_libc vlib/v2/gen/x64/x64_runtime_smoke_test.v`
- `./v test -run-only test_x64_linux_string_plus_two_runtime_strict_tiny_no_libc vlib/v2/gen/x64/x64_runtime_smoke_test.v`
- `./v test vlib/v2/gen/x64/x64_pe_linker_test.v`
- `./v test vlib/v2/ssa/tree_sumtype_lowering_test.v`