### PR TITLE
net.http: fix server_tls h2-negotiation test for default-on HTTP/2

### DIFF
--- a/vlib/net/http/server_tls_test.v
+++ b/vlib/net/http/server_tls_test.v
@@ -126,11 +126,13 @@ fn test_server_tls_h2_negotiation() {
 	assert resp.status_code == 200
 	assert resp.body == 'tls hello /h2'
 
-	// Without enable_http2 on the client, the server must keep speaking
-	// HTTP/1.1 to the same listener.
+	// With HTTP/2 disabled on the client, the server must keep speaking
+	// HTTP/1.1 to the same listener. (enable_http2 defaults to true since
+	// vlang/v#27384, so it must be opted out of explicitly here.)
 	resp_h1 := http.fetch(
-		url:      'https://127.0.0.1:${port}/h1'
-		validate: false
+		url:          'https://127.0.0.1:${port}/h1'
+		enable_http2: false
+		validate:     false
 	) or {
 		assert false, 'h1 fetch failed: ${err}'
 		return


### PR DESCRIPTION
## Problem

`test_server_tls_h2_negotiation` (`vlib/net/http/server_tls_test.v`) is **currently red on master CI** — clang-linux, gcc-linux, tcc-linux, clang-macos:

```
vlib/net/http/server_tls_test.v:138: fn test_server_tls_h2_negotiation
   > assert resp_h1.version() == .v1_1
     Left value (len: 8): `HTTP/2.0`
    Right value (len: 8): `HTTP/1.1`
```

The test was written before #27384 and assumed a plain `http.fetch()` (no `enable_http2` field) is served as HTTP/1.1. #27384 flipped `enable_http2` to default `true`, so the client now advertises `h2` via ALPN by default and the server correctly upgrades — making the `.v1_1` assertion fail.

## Fix

The server behavior is correct; the test just needs to opt out of HTTP/2 explicitly on the leg that means to exercise the HTTP/1.1 path. Pass `enable_http2: false` on the `resp_h1` fetch (and update the comment to match). The h2 leg above it already passes `enable_http2: true`, so both directions are now covered explicitly.

## Verification

`v test vlib/net/http/server_tls_test.v` passes; `v fmt -verify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)