### PR TITLE
compress.deflate: build Huffman trees via the shared hash.huffman builder

### DIFF
--- a/vlib/compress/deflate/deflate.v
+++ b/vlib/compress/deflate/deflate.v
@@ -129,12 +129,12 @@ pub fn compress(data []u8, format CompressParams) ![]u8 {
 	return match format.format {
 		.zlib { compress_zlib(data) }
 		.gzip { compress_gzip(data) }
-		.raw_deflate { deflate_compress_fixed(data) }
+		.raw_deflate { deflate_compress_fixed(data)! }
 	}
 }
 
 pub fn compress_zlib(data []u8) ![]u8 {
-	payload := deflate_compress_fixed(data)
+	payload := deflate_compress_fixed(data)!
 	cksum := adler32.sum(data)
 	mut out := []u8{cap: 2 + payload.len + 4}
 	out << u8(0x78) // CMF: CM=8 deflate, CINFO=7 (32K window)
@@ -146,7 +146,7 @@ pub fn compress_zlib(data []u8) ![]u8 {
 
 // compress_gzip compresses data into a gzip stream (RFC 1952).
 pub fn compress_gzip(data []u8) ![]u8 {
-	payload := deflate_compress_fixed(data)
+	payload := deflate_compress_fixed(data)!
 	mut out := []u8{cap: 10 + payload.len + 8}
 	// 10-byte gzip header: ID1 ID2 CM FLG MTIME(4) XFL OS
 	out << [u8(0x1f), 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff]
@@ -158,7 +158,7 @@ pub fn compress_gzip(data []u8) ![]u8 {
 
 // compress_raw compresses data to a raw RFC 1951 DEFLATE stream.
 pub fn compress_raw(data []u8) ![]u8 {
-	return deflate_compress_fixed(data)
+	return deflate_compress_fixed(data)!
 }
 
 // decompress decompresses a zlib (RFC 1950), gzip (RFC 1952), or raw DEFLATE (RFC 1951) stream.

--- a/vlib/compress/deflate/deflate_compress.v
+++ b/vlib/compress/deflate/deflate_compress.v
@@ -1,5 +1,7 @@
 module deflate
 
+import hash.huffman
+
 const deflate_hash_bits = 15
 const deflate_hash_size = 1 << deflate_hash_bits
 const deflate_max_chain = 64
@@ -8,36 +10,12 @@ const deflate_max_match = 258
 const deflate_window = 32768
 
 // fixed_litlen_encode returns (reversed_codes, code_lengths) for fixed Huffman lit/len.
+// The LSB-first (bit-reversed) codes come straight from the shared canonical
+// builder, since the encoder writes bits LSB-first.
 fn fixed_litlen_encode() ([]u32, []int) {
 	lens := fixed_litlen_lengths()
-	mut max_bits := 0
-	for l in lens {
-		if l > max_bits {
-			max_bits = l
-		}
-	}
-	mut bl_count := []int{len: max_bits + 1}
-	for l in lens {
-		if l > 0 {
-			bl_count[l]++
-		}
-	}
-	mut next_code := []u32{len: max_bits + 1}
-	mut c := u32(0)
-	for bits in 1 .. max_bits + 1 {
-		c = (c + u32(bl_count[bits - 1])) << 1
-		next_code[bits] = c
-	}
-	mut codes := []u32{len: 288}
-	for sym in 0 .. 288 {
-		l := lens[sym]
-		if l == 0 {
-			continue
-		}
-		codes[sym] = bit_reverse(next_code[l], l)
-		next_code[l]++
-	}
-	return codes, lens
+	t := huffman.build(lengths: lens, max_bits: 9, bit_order: .lsb_first) or { panic(err) }
+	return t.codes, lens
 }
 
 // fixed_dist_encode returns (reversed_codes, code_lengths) for fixed Huffman distance.

--- a/vlib/compress/deflate/deflate_compress.v
+++ b/vlib/compress/deflate/deflate_compress.v
@@ -12,9 +12,9 @@ const deflate_window = 32768
 // fixed_litlen_encode returns (reversed_codes, code_lengths) for fixed Huffman lit/len.
 // The LSB-first (bit-reversed) codes come straight from the shared canonical
 // builder, since the encoder writes bits LSB-first.
-fn fixed_litlen_encode() ([]u32, []int) {
+fn fixed_litlen_encode() !([]u32, []int) {
 	lens := fixed_litlen_lengths()
-	t := huffman.build(lengths: lens, max_bits: 9, bit_order: .lsb_first) or { panic(err) }
+	t := huffman.build(lengths: lens, max_bits: 9, bit_order: .lsb_first)!
 	return t.codes, lens
 }
 
@@ -113,8 +113,8 @@ fn (mut w BitWriter) flush() {
 
 // deflate_compress_fixed compresses data to RFC 1951 DEFLATE using fixed Huffman codes.
 @[direct_array_access]
-fn deflate_compress_fixed(data []u8) []u8 {
-	ll_codes, ll_lens := fixed_litlen_encode()
+fn deflate_compress_fixed(data []u8) ![]u8 {
+	ll_codes, ll_lens := fixed_litlen_encode()!
 	d_codes, d_lens := fixed_dist_encode()
 	mut w := BitWriter{}
 	// BFINAL=1, BTYPE=01 (fixed Huffman)

--- a/vlib/compress/deflate/deflate_inflate.v
+++ b/vlib/compress/deflate/deflate_inflate.v
@@ -1,5 +1,7 @@
 module deflate
 
+import hash.huffman
+
 // vfmt off
 // RFC 1951 length/distance decode tables
 const length_bases = [3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59,
@@ -39,7 +41,7 @@ struct HuffTree {
 	max_bits int
 }
 
-fn build_huff_tree(lengths []int) HuffTree {
+fn build_huff_tree(lengths []int) !HuffTree {
 	mut max_bits := 0
 	for l in lengths {
 		if l > max_bits {
@@ -52,36 +54,12 @@ fn build_huff_tree(lengths []int) HuffTree {
 			max_bits: 0
 		}
 	}
-	mut bl_count := []int{len: max_bits + 1}
-	for l in lengths {
-		if l > 0 {
-			bl_count[l]++
-		}
-	}
-	mut next_code := []u32{len: max_bits + 1}
-	mut c := u32(0)
-	for bits in 1 .. max_bits + 1 {
-		c = (c + u32(bl_count[bits - 1])) << 1
-		next_code[bits] = c
-	}
-	table_size := 1 << max_bits
-	mut table := []u32{len: table_size, init: 0xffff_ffff}
-	for sym in 0 .. lengths.len {
-		l := lengths[sym]
-		if l == 0 {
-			continue
-		}
-		code := next_code[l]
-		next_code[l]++
-		// Reverse code for LSB-first bit reader
-		rev := bit_reverse(code, l)
-		step := 1 << l
-		mut idx := int(rev)
-		for idx < table_size {
-			table[idx] = (u32(sym) << 5) | u32(l)
-			idx += step
-		}
-	}
+	// Build the flat LSB-first lookup table the decode loop expects directly
+	// from the lengths via the shared canonical builder: entry = (symbol << 5) |
+	// length, 0xFFFF_FFFF for invalid. flat_table() allocates no intermediate
+	// codes array, so this matches the hand-rolled loop's cost. Over-subscribed
+	// lengths now surface as an error instead of a silently corrupt table.
+	table := huffman.flat_table(lengths: lengths, max_bits: max_bits, bit_order: .lsb_first)!
 	return HuffTree{
 		table:    table
 		max_bits: max_bits
@@ -192,8 +170,8 @@ fn inflate_with_consumed(data []u8) !InflateResult {
 		buf: data
 	}
 	mut out := []u8{}
-	fixed_ll := build_huff_tree(fixed_litlen_lengths())
-	fixed_d := build_huff_tree([]int{len: 32, init: 5})
+	fixed_ll := build_huff_tree(fixed_litlen_lengths())!
+	fixed_d := build_huff_tree([]int{len: 32, init: 5})!
 	for {
 		bfinal := r.read_bits(1)!
 		btype := r.read_bits(2)!
@@ -220,7 +198,7 @@ fn inflate_with_consumed(data []u8) !InflateResult {
 				for i in 0 .. hclen {
 					cl_lens[cl_order[i]] = int(r.read_bits(3)!)
 				}
-				cl_tree := build_huff_tree(cl_lens)
+				cl_tree := build_huff_tree(cl_lens)!
 				mut all_lens := []int{}
 				for all_lens.len < hlit + hdist {
 					sym := r.huff_decode(cl_tree)!
@@ -249,8 +227,8 @@ fn inflate_with_consumed(data []u8) !InflateResult {
 						return error('inflate: bad code length symbol')
 					}
 				}
-				ll_tree := build_huff_tree(all_lens[..hlit])
-				d_tree := build_huff_tree(all_lens[hlit..])
+				ll_tree := build_huff_tree(all_lens[..hlit])!
+				d_tree := build_huff_tree(all_lens[hlit..])!
 				inflate_block(mut r, mut out, ll_tree, d_tree)!
 			}
 			else {
@@ -284,8 +262,8 @@ fn inflate_with_callback(data []u8, cb ChunkCallback, userdata voidptr) !Inflate
 	mut out := []u8{}
 	mut state := InflateStreamState{}
 	mut aborted := false
-	fixed_ll := build_huff_tree(fixed_litlen_lengths())
-	fixed_d := build_huff_tree([]int{len: 32, init: 5})
+	fixed_ll := build_huff_tree(fixed_litlen_lengths())!
+	fixed_d := build_huff_tree([]int{len: 32, init: 5})!
 	for {
 		bfinal := r.read_bits(1)!
 		btype := r.read_bits(2)!
@@ -318,7 +296,7 @@ fn inflate_with_callback(data []u8, cb ChunkCallback, userdata voidptr) !Inflate
 				for i in 0 .. hclen {
 					cl_lens[cl_order[i]] = int(r.read_bits(3)!)
 				}
-				cl_tree := build_huff_tree(cl_lens)
+				cl_tree := build_huff_tree(cl_lens)!
 				mut all_lens := []int{}
 				for all_lens.len < hlit + hdist {
 					sym := r.huff_decode(cl_tree)!
@@ -347,8 +325,8 @@ fn inflate_with_callback(data []u8, cb ChunkCallback, userdata voidptr) !Inflate
 						return error('inflate: bad code length symbol')
 					}
 				}
-				ll_tree := build_huff_tree(all_lens[..hlit])
-				d_tree := build_huff_tree(all_lens[hlit..])
+				ll_tree := build_huff_tree(all_lens[..hlit])!
+				d_tree := build_huff_tree(all_lens[hlit..])!
 				if !inflate_block_stream(mut r, mut out, ll_tree, d_tree, cb, userdata, mut state)! {
 					aborted = true
 				}


### PR DESCRIPTION
## What

Migrates `compress.deflate` onto `hash.huffman` (merged in #27392), removing its two in-tree copies of the canonical Huffman code-assignment (RFC 1951 §3.2.2 `bl_count` / `next_code`).

This is the **second half of #27358** (the first half — the shared module + the HPACK migration — landed in #27392).

## Changes

- **Decode** — `build_huff_tree()` now fills its flat LSB-first lookup table via `huffman.flat_table()`. The table format (`entry = (symbol << 5) | length`, `0xFFFF_FFFF` for invalid) and the `huff_decode` loop are **unchanged**. `build_huff_tree()` now returns `!HuffTree` so an over-subscribed (malformed) code surfaces as a clean error instead of a silently corrupt table; all call sites propagate with `!`.
- **Encode** — `fixed_litlen_encode()` takes its reversed codes straight from `huffman.build(..., bit_order: .lsb_first).codes`.

No behavior change for any valid DEFLATE stream (incomplete codes are still accepted).

## Performance

Benchmarked before/after with `v -prod` (full method + corpora in the [#27392 benchmark comment](https://github.com/vlang/v/pull/27392#issuecomment-4650916973)):

| corpus | baseline | this PR | Δ |
|---|---|---|---|
| text-8MiB (fixed, **decode**) | ~627 MB/s | ~636 MB/s | parity (noise) |
| dyn-2MiB (dynamic, **decode**) | ~345 MB/s | ~346 MB/s | parity (noise) |
| small-256B (fixed, **build**) | ~204k inflates/s | ~227k inflates/s | **+10.8%** |
| dyn-small400 (dynamic, **build**) | ~110k inflates/s | ~118k inflates/s | **+7.5%** |

Decode-dominated throughput is unchanged (the decode loop is byte-for-byte identical); build-dominated workloads (many small streams) are faster, because `flat_table()` skips the invalid table pre-fill for *complete* codes — which V's fixed trees and most dynamic trees are. The build-dominated ranges are non-overlapping across runs, so the speedup is real, not jitter.

## Tests

`compress.deflate` / gzip / zlib / snappy / zstd suites stay green; `-cstrict -cc clang` clean; `v fmt -verify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #27358.