### PR TITLE
checker: reject optional array args for plain arrays

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2574,7 +2574,9 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				} else {
 					arg_typ.nr_muls()
 				}
-				if param_nr_muls == arg_nr_muls
+				if param.typ.has_flag(.option) == arg_typ.has_flag(.option)
+					&& param.typ.has_flag(.result) == arg_typ.has_flag(.result)
+					&& param_nr_muls == arg_nr_muls
 					&& param_typ_sym.info.nr_dims == arg_typ_sym.info.nr_dims
 					&& param_elem_type == arg_elem_type {
 					continue
@@ -3865,7 +3867,9 @@ fn (mut c Checker) method_call(mut node ast.CallExpr, mut continue_check &bool) 
 			if param_typ_sym.info is ast.Array && arg_typ_sym.info is ast.Array {
 				param_elem_type := c.table.unaliased_type(param_typ_sym.info.elem_type)
 				arg_elem_type := c.table.unaliased_type(arg_typ_sym.info.elem_type)
-				if exp_arg_typ.nr_muls() == got_arg_typ.nr_muls()
+				if exp_arg_typ.has_flag(.option) == got_arg_typ.has_flag(.option)
+					&& exp_arg_typ.has_flag(.result) == got_arg_typ.has_flag(.result)
+					&& exp_arg_typ.nr_muls() == got_arg_typ.nr_muls()
 					&& param_typ_sym.info.nr_dims == arg_typ_sym.info.nr_dims
 					&& param_elem_type == arg_elem_type {
 					continue

--- a/vlib/v/checker/tests/option_array_arg_err.out
+++ b/vlib/v/checker/tests/option_array_arg_err.out
@@ -1,0 +1,13 @@
+vlib/v/checker/tests/option_array_arg_err.vv:6:12: error: cannot use `?[]u8` as `[]u8`, it must be unwrapped first in argument 1 to `use_bytes`
+    4 | 
+    5 | fn main() {
+    6 |     use_bytes(?[]u8(none))
+      |               ~~~~~~~~~~~
+    7 |     maybe := ?[]u8(none)
+    8 |     use_bytes(maybe)
+vlib/v/checker/tests/option_array_arg_err.vv:8:12: error: cannot use `?[]u8` as `[]u8`, it must be unwrapped first in argument 1 to `use_bytes`
+    6 |     use_bytes(?[]u8(none))
+    7 |     maybe := ?[]u8(none)
+    8 |     use_bytes(maybe)
+      |               ~~~~~
+    9 | }

--- a/vlib/v/checker/tests/option_array_arg_err.vv
+++ b/vlib/v/checker/tests/option_array_arg_err.vv
@@ -1,0 +1,9 @@
+fn use_bytes(data []u8) int {
+	return data.len
+}
+
+fn main() {
+	use_bytes(?[]u8(none))
+	maybe := ?[]u8(none)
+	use_bytes(maybe)
+}


### PR DESCRIPTION
Fixes #27423.

This prevents the array argument compatibility fallback from accepting top-level Option/Result wrappers when the parameter expects a plain array. It adds a regression for both a direct `?[]u8(none)` argument and an optional array variable.

Tests:
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w vlib/v/checker/fn.v vlib/v/checker/tests/option_array_arg_err.vv`
- `VTEST_ONLY=option_array_arg_err ./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/checker/`
- Direct issue reproducer now fails in checker before C generation

Notes:
- Full `vlib/v/compiler_errors_test.v` and broad `./vnew -silent test vlib/v/` were blocked by unrelated dirty-worktree/untracked changes in this local checkout.