### PR TITLE
checker: infer generic function values from call args

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -2288,8 +2288,7 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 				c.table.cur_concrete_types)
 			param = unwrapped
 		}
-		param.typ = c.resolve_short_syntax_call_arg_type(call_arg, param.typ, func.generic_names,
-			concrete_types)
+		param.typ = c.resolve_call_arg_param_type(call_arg, param, func.generic_names, concrete_types)
 		// registers if the arg must be passed by ref to disable auto deref args
 		call_arg.should_be_ptr = param.typ.is_ptr() && !param.is_mut
 		if func.is_variadic && call_arg.expr is ast.ArrayDecompose {
@@ -4067,6 +4066,28 @@ fn (mut c Checker) handle_generic_anon_fn_arg(node &ast.CallExpr, generic_names 
 	if c.table.register_fn_concrete_types(anon.decl.fkey(), anon_concrete_types) {
 		anon.decl.ninstances++
 	}
+}
+
+fn (mut c Checker) resolve_call_arg_param_type(arg ast.CallArg, param ast.Param, generic_names []string, concrete_types []ast.Type) ast.Type {
+	if !param.typ.has_flag(.generic) || generic_names.len == 0
+		|| generic_names.len != concrete_types.len {
+		return param.typ
+	}
+	if arg.expr is ast.StructInit {
+		expr := arg.expr as ast.StructInit
+		if expr.is_short_syntax && expr.typ == ast.void_type {
+			return c.table.convert_generic_param_type(param, generic_names, concrete_types) or {
+				param.typ
+			}
+		}
+	}
+	param_sym := c.table.final_sym(param.typ)
+	if param_sym.kind == .function {
+		if typ := c.table.convert_generic_param_type(param, generic_names, concrete_types) {
+			return typ
+		}
+	}
+	return param.typ
 }
 
 fn (mut c Checker) resolve_short_syntax_call_arg_type(arg ast.CallArg, param_typ ast.Type, generic_names []string, concrete_types []ast.Type) ast.Type {

--- a/vlib/v/tests/generics/generic_fn_value_inference_test.v
+++ b/vlib/v/tests/generics/generic_fn_value_inference_test.v
@@ -7,3 +7,18 @@ fn apply_f64(value f64, f fn (f64) f64) f64 {
 fn test_generic_fn_value_is_inferred_from_expected_fn_type() {
 	assert apply_f64(-1.25, math.abs) == 1.25
 }
+
+struct GenericFnArgFoo {}
+
+fn generic_fn_arg_handler[T](x T) int {
+	_ := x
+	return 41
+}
+
+fn generic_fn_arg_run[T](h fn (T) int) int {
+	return h(T{}) + 1
+}
+
+fn test_generic_fn_value_is_monomorphized_from_generic_call_arg() {
+	assert generic_fn_arg_run[GenericFnArgFoo](generic_fn_arg_handler) == 42
+}


### PR DESCRIPTION
Fixes #27421.

## Summary
- resolve generic function-valued arguments against the concrete parameter type for generic calls
- keep the existing short struct init generic argument behavior
- add a regression test for passing a generic function value into a generic function call

## Testing
- ./v -g -keepc -o ./vnew cmd/v
- ./vnew -e <issue repro>
- ./vnew test vlib/v/tests/generics/generic_fn_value_inference_test.v
- ./vnew -silent test vlib/v/checker/
- ./vnew -silent test vlib/v/tests/generics/