### PR TITLE
checker: reject pointer targets in json.decode

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -1716,7 +1716,9 @@ fn (mut c Checker) fn_call(mut node ast.CallExpr, mut continue_check &bool) ast.
 					parent_sym := c.table.sym(ast.new_type(sym.info.parent_idx))
 					kind = parent_sym.kind
 				}
-				if is_json_decode && kind !in [.struct, .sum_type, .map, .array] {
+				if is_json_decode && c.table.fully_unaliased_type(unwrapped_typ).is_ptr() {
+					c.error('${fn_name}: cannot decode into a pointer type', expr.pos)
+				} else if is_json_decode && kind !in [.struct, .sum_type, .map, .array] {
 					c.error('${fn_name}: expected sum type, struct, map or array, found ${kind}',
 						expr.pos)
 				}

--- a/vlib/v/checker/tests/json_decode.out
+++ b/vlib/v/checker/tests/json_decode.out
@@ -32,10 +32,17 @@ vlib/v/checker/tests/json_decode.vv:14:14: error: json.decode: expected sum type
    14 |     json.decode(Num, '5')! // BAD
       |                 ~~~
    15 |     json.decode(St, 6)! // BAD
-   16 | }
+   16 |     json.decode(&[]St, '[]')! // BAD
 vlib/v/checker/tests/json_decode.vv:15:7: error: json.decode: second argument needs to be a string
    13 |     json.decode(string, '""')! // BAD
    14 |     json.decode(Num, '5')! // BAD
    15 |     json.decode(St, 6)! // BAD
       |          ~~~~~~~~~~~~~
-   16 | }
+   16 |     json.decode(&[]St, '[]')! // BAD
+   17 | }
+vlib/v/checker/tests/json_decode.vv:16:15: error: json.decode: cannot decode into a pointer type
+   14 |     json.decode(Num, '5')! // BAD
+   15 |     json.decode(St, 6)! // BAD
+   16 |     json.decode(&[]St, '[]')! // BAD
+      |                  ^
+   17 | }

--- a/vlib/v/checker/tests/json_decode.vv
+++ b/vlib/v/checker/tests/json_decode.vv
@@ -13,4 +13,5 @@ fn main() {
 	json.decode(string, '""')! // BAD
 	json.decode(Num, '5')! // BAD
 	json.decode(St, 6)! // BAD
+	json.decode(&[]St, '[]')! // BAD
 }


### PR DESCRIPTION
Fixes #27422.

## Summary
- reject pointer target types in `json.decode` during checker validation
- add a checker regression for `json.decode(&[]T, ...)`

## Testing
- `./v -g -keepc -o ./vnew cmd/v`
- `VTEST_ONLY='*/json_decode.vv' ./vnew -silent vlib/v/compiler_errors_test.v`\n- `./vnew -silent test vlib/v/checker/`\n- `./vnew -silent vlib/v/compiler_errors_test.v`\n- `./vnew -silent test vlib/json/tests/`\n\nNote: `./vnew -silent test vlib/v/` was started, but stopped after an unrelated `vlib/v/builder/builder_test.v` failure where a tcc fallback warning was included in expected program stdout.