### PR TITLE
compiler: walk mut interface dispatch dependencies

### DIFF
--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -3177,14 +3177,14 @@ pub fn (mut w Walker) mark_by_sym(isym ast.TypeSymbol) {
 			}
 		}
 		ast.Interface {
-			for typ in isym.info.types {
+			for typ in isym.info.implementor_types(true) {
 				if typ == ast.map_type {
 					w.features.used_maps++
 				}
 				w.mark_by_type(typ)
-				for method in isym.info.methods {
+				for method_name in isym.info.get_methods() {
 					for ityp in [typ.set_nr_muls(1), typ.set_nr_muls(0)] {
-						mname := int(ityp.clear_flags()).str() + '.' + method.name
+						mname := int(ityp.clear_flags()).str() + '.' + method_name
 						w.fn_by_name(mname)
 					}
 				}

--- a/vlib/v/tests/skip_unused/interface_dispatch_method_dependencies_test.v
+++ b/vlib/v/tests/skip_unused/interface_dispatch_method_dependencies_test.v
@@ -1,0 +1,48 @@
+import os
+
+const vexe = @VEXE
+
+fn test_skip_unused_walks_mut_interface_dispatch_method_dependencies() {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_issue_27404')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(tmp_dir, 'issue_27404.v')
+	binary_path := os.join_path(tmp_dir, 'issue_27404')
+	source := [
+		'module main',
+		'',
+		'interface Visitor {',
+		'\tvisit()',
+		'}',
+		'',
+		'struct Han {',
+		'mut:',
+		'\tn int',
+		'}',
+		'',
+		'fn helper(s string) {',
+		'\tprintln(s)',
+		'}',
+		'',
+		'fn (mut h Han) visit() {',
+		"\thelper('t')",
+		'}',
+		'',
+		'fn run(mut v Visitor) {',
+		'\tv.visit()',
+		'}',
+		'',
+		'fn main() {',
+		'\tmut h := Han{}',
+		'\trun(mut h)',
+		'}',
+	].join('\n')
+	os.write_file(source_path, source) or { panic(err) }
+	res :=
+		os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(binary_path)} ${os.quoted_path(source_path)}')
+	if res.exit_code != 0 {
+		panic(res.output)
+	}
+}


### PR DESCRIPTION
## Summary
- Include mutable interface implementors when markused walks interface method dependencies.
- Use interface method names from get_methods() when marking concrete implementor methods.
- Add a regression for #27404 where a mut interface dispatch method calls another function.

Fixes #27404

## Testing
- Not run (per request).