### PR TITLE
net.http: fix TLS server read/handshake timeouts and idle-shutdown fd race

### DIFF
--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -37,6 +37,7 @@ pub mut:
 	read_timeout            time.Duration = 30 * time.second
 	write_timeout           time.Duration = 30 * time.second
 	accept_timeout          time.Duration = 30 * time.second
+	tls_handshake_timeout   time.Duration = 30 * time.second // fallback handshake budget used when accept_timeout is zero or net.infinite_timeout; ignored on non-TLS servers
 	pool_channel_slots      int           = 1024
 	worker_num              int           = runtime.nr_jobs()
 	max_keep_alive_requests int           = 100 // max requests per keep-alive connection (0 = unlimited)

--- a/vlib/net/http/server_tls_notd_use_openssl.v
+++ b/vlib/net/http/server_tls_notd_use_openssl.v
@@ -10,19 +10,23 @@ import net.mbedtls
 
 const tls_accept_poll_timeout = 100 * time.millisecond
 
-// tls_handshake_timeout bounds a single TLS server handshake when the user did
-// not set a finite `accept_timeout`. The handshake runs on the accept thread,
-// so without a finite bound a client that completes the TCP connect and then
-// stalls mid-handshake would wedge the accept loop forever (no new connections,
-// and `stop()` is never observed).
+// tls_handshake_timeout is the default value for Server.tls_handshake_timeout,
+// used as the fallback handshake budget when Server.accept_timeout is zero or
+// net.infinite_timeout. The handshake runs on the accept thread, so without a
+// finite bound a client that completes the TCP connect and then stalls
+// mid-handshake would wedge the accept loop forever.
 const tls_handshake_timeout = 30 * time.second
 
-fn tls_accept_timeouts(accept_timeout time.Duration) (time.Duration, time.Duration) {
+fn tls_accept_timeouts(accept_timeout time.Duration, handshake_fallback time.Duration) (time.Duration, time.Duration) {
 	// A finite `accept_timeout` doubles as the handshake budget; when it is
-	// infinite (<= 0), fall back to a finite default so the handshake still
-	// times out and shutdown stays responsive.
-	handshake_timeout := if accept_timeout > 0 { accept_timeout } else { tls_handshake_timeout }
-	accept_poll_timeout := if accept_timeout > 0 && accept_timeout < tls_accept_poll_timeout {
+	// zero or net.infinite_timeout (i64.max), fall back to `handshake_fallback`
+	// so the handshake still times out and shutdown stays responsive.
+	// net.infinite_timeout is positive (i64.max), so the > 0 check alone is
+	// not enough — mbedtls's ssl_timeout_deadline treats it as an infinite
+	// deadline exactly like 0 or negative values.
+	is_finite := accept_timeout > 0 && accept_timeout != net.infinite_timeout
+	handshake_timeout := if is_finite { accept_timeout } else { handshake_fallback }
+	accept_poll_timeout := if is_finite && accept_timeout < tls_accept_poll_timeout {
 		accept_timeout
 	} else {
 		tls_accept_poll_timeout
@@ -90,7 +94,8 @@ fn (mut s Server) listen_and_serve_tls() {
 	if s.on_running != unsafe { nil } {
 		s.on_running(mut s)
 	}
-	accept_poll_timeout, handshake_timeout := tls_accept_timeouts(s.accept_timeout)
+	accept_poll_timeout, handshake_timeout := tls_accept_timeouts(s.accept_timeout,
+		s.tls_handshake_timeout)
 	for s.state == .running {
 		mut conn := listener.accept_with_timeouts(accept_poll_timeout, handshake_timeout) or {
 			if s.state != .running {

--- a/vlib/net/http/server_tls_notd_use_openssl.v
+++ b/vlib/net/http/server_tls_notd_use_openssl.v
@@ -10,8 +10,18 @@ import net.mbedtls
 
 const tls_accept_poll_timeout = 100 * time.millisecond
 
+// tls_handshake_timeout bounds a single TLS server handshake when the user did
+// not set a finite `accept_timeout`. The handshake runs on the accept thread,
+// so without a finite bound a client that completes the TCP connect and then
+// stalls mid-handshake would wedge the accept loop forever (no new connections,
+// and `stop()` is never observed).
+const tls_handshake_timeout = 30 * time.second
+
 fn tls_accept_timeouts(accept_timeout time.Duration) (time.Duration, time.Duration) {
-	handshake_timeout := accept_timeout
+	// A finite `accept_timeout` doubles as the handshake budget; when it is
+	// infinite (<= 0), fall back to a finite default so the handshake still
+	// times out and shutdown stays responsive.
+	handshake_timeout := if accept_timeout > 0 { accept_timeout } else { tls_handshake_timeout }
 	accept_poll_timeout := if accept_timeout > 0 && accept_timeout < tls_accept_poll_timeout {
 		accept_timeout
 	} else {

--- a/vlib/net/http/server_tls_timeout_notd_use_openssl_test.v
+++ b/vlib/net/http/server_tls_timeout_notd_use_openssl_test.v
@@ -1,26 +1,41 @@
 module http
 
+import net
 import time
 
 fn test_tls_accept_timeouts_finite_handshake_for_infinite_accept() {
-	// An infinite accept timeout (<= 0) must still yield a finite handshake
-	// timeout, so a client stalling mid-handshake cannot wedge the accept
-	// thread or block shutdown.
-	accept_poll_timeout, handshake_timeout := tls_accept_timeouts(0)
+	// An infinite accept timeout (<= 0, or net.infinite_timeout) must still
+	// yield a finite handshake timeout, so a client stalling mid-handshake
+	// cannot wedge the accept thread or block shutdown.
+	// net.infinite_timeout is i64.max (positive), so the > 0 guard alone is
+	// insufficient — mbedtls treats it as an infinite deadline.
+	accept_poll_timeout, handshake_timeout := tls_accept_timeouts(0, tls_handshake_timeout)
 	assert accept_poll_timeout == tls_accept_poll_timeout
 	assert handshake_timeout == tls_handshake_timeout
-	_, neg_handshake_timeout := tls_accept_timeouts(-1)
+	_, neg_handshake_timeout := tls_accept_timeouts(-1, tls_handshake_timeout)
 	assert neg_handshake_timeout == tls_handshake_timeout
+	_, inf_handshake_timeout := tls_accept_timeouts(net.infinite_timeout, tls_handshake_timeout)
+	assert inf_handshake_timeout == tls_handshake_timeout
 }
 
 fn test_tls_accept_timeouts_cap_poll_without_changing_handshake_timeout() {
-	accept_poll_timeout, handshake_timeout := tls_accept_timeouts(time.second)
+	accept_poll_timeout, handshake_timeout := tls_accept_timeouts(time.second,
+		tls_handshake_timeout)
 	assert accept_poll_timeout == tls_accept_poll_timeout
 	assert handshake_timeout == time.second
 }
 
 fn test_tls_accept_timeouts_keep_short_accept_timeout() {
-	accept_poll_timeout, handshake_timeout := tls_accept_timeouts(50 * time.millisecond)
+	accept_poll_timeout, handshake_timeout := tls_accept_timeouts(50 * time.millisecond,
+		tls_handshake_timeout)
 	assert accept_poll_timeout == 50 * time.millisecond
 	assert handshake_timeout == 50 * time.millisecond
+}
+
+fn test_tls_accept_timeouts_configurable_fallback() {
+	// When accept_timeout is infinite, the handshake_fallback parameter
+	// (Server.tls_handshake_timeout) governs the budget — not the constant.
+	custom_fallback := 5 * time.second
+	_, handshake_timeout := tls_accept_timeouts(0, custom_fallback)
+	assert handshake_timeout == custom_fallback
 }

--- a/vlib/net/http/server_tls_timeout_notd_use_openssl_test.v
+++ b/vlib/net/http/server_tls_timeout_notd_use_openssl_test.v
@@ -2,10 +2,15 @@ module http
 
 import time
 
-fn test_tls_accept_timeouts_preserve_zero_handshake_timeout() {
+fn test_tls_accept_timeouts_finite_handshake_for_infinite_accept() {
+	// An infinite accept timeout (<= 0) must still yield a finite handshake
+	// timeout, so a client stalling mid-handshake cannot wedge the accept
+	// thread or block shutdown.
 	accept_poll_timeout, handshake_timeout := tls_accept_timeouts(0)
 	assert accept_poll_timeout == tls_accept_poll_timeout
-	assert handshake_timeout == 0
+	assert handshake_timeout == tls_handshake_timeout
+	_, neg_handshake_timeout := tls_accept_timeouts(-1)
+	assert neg_handshake_timeout == tls_handshake_timeout
 }
 
 fn test_tls_accept_timeouts_cap_poll_without_changing_handshake_timeout() {


### PR DESCRIPTION
Three correctness follow-ups to the TLS server shutdown work (#27429), in the
default mbedtls backend. These are items #1, #2, and #4 from #27433 (the
perf-oriented items #3/#5 will follow in a separate PR).

### 1. `Server.read_timeout` is honored on HTTPS

Accepted TLS connections share the listener's SSL config — mbedtls binds each
`ssl` to `&l.conf` — but `listen_and_serve_tls` applied the read timeout *per
connection* via `conn.set_read_timeout`, which writes the connection's own
`conf`, a config never bound to its ssl context. So `Server.read_timeout` was
honored on HTTP but **silently ignored on HTTPS**, where every connection fell
back to the fixed `mbedtls_server_read_timeout_ms` (~41s).

Fix: add `SSLListener.set_read_timeout` (writes the listener config actually in
effect), apply it once before the accept loop, and drop the ineffective
per-connection call. Adds a regression test asserting an idle HTTPS keep-alive
is closed near `read_timeout`, not at the mbedtls default.

### 2. Handshake timeout: finite budget in all cases, configurable per Server

The handshake runs on the accept thread. Two gaps let a stalling client wedge
the accept loop forever:

**a.** `accept_timeout <= 0` passed through as the handshake budget — mbedtls
treats ≤ 0 as infinite.

**b.** `net.infinite_timeout` (`i64.max`, a positive value) also passed through
as the handshake budget — the old `> 0` guard let it through, and mbedtls's
`ssl_timeout_deadline` treats `i64.max` as infinite just like `<= 0`.

Fix: `is_finite := accept_timeout > 0 && accept_timeout != net.infinite_timeout`;
finite `accept_timeout` doubles as the handshake budget, otherwise fall back to
`Server.tls_handshake_timeout` (new `pub mut` field, default 30 s).

The field is consistent with the existing `read_timeout`, `write_timeout`, and
`accept_timeout` fields — users who need a tighter budget (hardened
public-facing server) or a longer one (embedded devices with slow crypto
hardware) can set it directly.

> ⚠️ **@medvednikov** — this reverses the deliberate behavior from your commit
> "preserve zero TLS handshake timeout"; updated that test accordingly.
> Per the discussion on #27433 (JalonSolov: "all 5 need to be fixed").
> `Server.tls_handshake_timeout` (the `Server.handshake_timeout` field you
> suggested as an alternative) is now added — same idea, consistent naming.

### 3. `close_idle` no longer races fd reuse

It cloned the tracked fds and called `net.shutdown` *after* releasing the lock,
so a worker could `net.close` a just-unmarked fd and have the OS reuse it for a
freshly accepted socket before the stale snapshot was shut down. Fix: shut the
fds down while holding the lock, which serializes against `unmark_idle`
(`net.shutdown` does not block).

### Verification

Full `vlib/net/http/server_tls_test.v` and the timeout unit tests pass on Linux.

Side observation (not addressed here): on my local Windows the `close_idle` →
`net.shutdown` interrupt does **not** wake a blocked mbedtls TLS read — the read
only unblocks on the read timeout — so the idle-shutdown-interrupt tests there
complete at `read_timeout` rather than promptly. This fix actually improves that
case (read_timeout is now honored, so ~read_timeout instead of ~41s), but the
underlying "net.shutdown doesn't interrupt a blocked mbedtls read on Windows"
gap is separate and worth its own look (related to #27433 item #3).

Refs #27433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
