### PR TITLE
cgen: fix option sumtype if expr struct init

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6576,11 +6576,13 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				g.expr(g.table.resolve_init(node, g.unwrap_generic(node.typ)))
 			} else {
 				// `user := User{name: 'Bob'}`
+				old_inside_struct_init := g.inside_struct_init
+				old_cur_struct_init_typ := g.cur_struct_init_typ
 				g.inside_struct_init = true
 				g.cur_struct_init_typ = node.typ
 				g.struct_init(node)
-				g.cur_struct_init_typ = 0
-				g.inside_struct_init = false
+				g.cur_struct_init_typ = old_cur_struct_init_typ
+				g.inside_struct_init = old_inside_struct_init
 			}
 		}
 		ast.TypeNode {

--- a/vlib/v/tests/options/option_sumtype_if_expr_struct_field_test.v
+++ b/vlib/v/tests/options/option_sumtype_if_expr_struct_field_test.v
@@ -1,0 +1,47 @@
+struct Circle27440 {
+	radius int
+}
+
+struct Square27440 {
+	size int
+}
+
+type Shape27440 = Circle27440 | Square27440
+
+struct Box27440 {
+	shape ?Shape27440
+}
+
+fn new_box27440(use_circle bool, n int) Box27440 {
+	return Box27440{
+		shape: if use_circle {
+			Shape27440(Circle27440{
+				radius: n
+			})
+		} else {
+			Shape27440(Square27440{
+				size: n
+			})
+		}
+	}
+}
+
+fn test_option_sumtype_if_expr_struct_field() {
+	circle_box := new_box27440(true, 4)
+	circle_shape := circle_box.shape or {
+		assert false
+		return
+	}
+
+	assert circle_shape is Circle27440
+	assert circle_shape.radius == 4
+
+	square_box := new_box27440(false, 5)
+	square_shape := square_box.shape or {
+		assert false
+		return
+	}
+
+	assert square_shape is Square27440
+	assert square_shape.size == 5
+}


### PR DESCRIPTION
## Summary
- Preserve the previous struct-init cgen context when emitting nested struct init expressions.
- Add a regression test for an option-of-sumtype field initialized via an `if` expression.

Fixes #27440

## Testing
- `./vnew -silent test vlib/v/tests/options/option_sumtype_if_expr_struct_field_test.v` (passed before the request to skip further tests)
- `./vnew -silent vlib/v/compiler_errors_test.v` (passed before the request to skip further tests)
- Not completed: `./vnew -silent vlib/v/gen/c/coutput_test.v` (stopped after the request to stop testing)