### PR TITLE
cgen: fix fixed array match return temps

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3448,6 +3448,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 				}
 			} else {
 				mut is_array_fixed_init := false
+				mut is_array_fixed_expr := false
 				mut ret_type := ast.void_type
 
 				g.set_current_pos_as_last_stmt_pos()
@@ -3461,6 +3462,14 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 					if stmt.expr is ast.ArrayInit && stmt.expr.is_fixed {
 						is_array_fixed_init = true
 						ret_type = stmt.expr.typ
+					} else {
+						expr_typ := g.unwrap_generic(g.recheck_concrete_type(stmt.typ))
+						if expr_typ != ast.void_type && expr_typ != 0
+							&& !expr_typ.has_option_or_result()
+							&& g.table.final_sym(expr_typ).kind == .array_fixed {
+							is_array_fixed_expr = true
+							ret_type = expr_typ
+						}
 					}
 					if stmt.expr is ast.IfExpr && g.is_autofree && !g.inside_if_option
 						&& !g.inside_if_result {
@@ -3468,9 +3477,19 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 						g.outer_tmp_var = tmp_var
 					}
 				}
+				ret_sym := g.table.sym(g.unwrap_generic(g.recheck_concrete_type(ret_type)))
+				tmp_is_return_fixed_array := ret_sym.info is ast.ArrayFixed
+					&& ret_sym.info.is_fn_ret
+				fixed_array_tmp_var := if tmp_is_return_fixed_array {
+					'${tmp_var}.ret_arr'
+				} else {
+					tmp_var
+				}
 				if !is_noreturn && !is_if_expr_with_tmp {
 					if is_array_fixed_init {
-						g.write('memcpy(${tmp_var}, (${g.styp(ret_type)})')
+						g.write('memcpy(${fixed_array_tmp_var}, (${g.styp(ret_type)})')
+					} else if is_array_fixed_expr {
+						g.write('memcpy(${fixed_array_tmp_var}, ')
 					} else {
 						g.write('${tmp_var} = ')
 					}
@@ -3483,6 +3502,9 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 				if is_array_fixed_init {
 					lines := g.go_before_last_stmt().trim_right('; \n')
 					g.writeln('${lines}, sizeof(${tmp_var}));')
+				} else if is_array_fixed_expr {
+					lines := g.go_before_last_stmt().trim_right('; \n')
+					g.writeln('${lines}, sizeof(${g.styp(ret_type)}));')
 				}
 				if !g.out.last_n(2).contains(';') {
 					g.writeln(';')

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -175,7 +175,14 @@ fn (mut g Gen) match_expr(node ast.MatchExpr) {
 	}
 	g.write(cur_line)
 	if need_tmp_var {
-		g.write(tmp_var)
+		resolved_sym := g.table.sym(g.unwrap_generic(g.recheck_concrete_type(resolved_return_type)))
+		tmp_is_return_fixed_array := resolved_sym.info is ast.ArrayFixed
+			&& resolved_sym.info.is_fn_ret
+		if tmp_is_return_fixed_array {
+			g.write('${tmp_var}.ret_arr')
+		} else {
+			g.write(tmp_var)
+		}
 	}
 	if is_expr && !need_tmp_var {
 		g.write(')')

--- a/vlib/v/tests/return_fixed_array_test.v
+++ b/vlib/v/tests/return_fixed_array_test.v
@@ -70,3 +70,45 @@ fn issue_27345_shop_category_color() [4]u8 {
 fn test_fixed_array_return_via_local_from_call() {
 	assert issue_27345_shop_category_color() == [u8(1), 2, 3, 4]!
 }
+
+enum FixedArrayReturnMatchMedal {
+	one
+	two
+	three
+	four
+	five
+	six
+}
+
+fn issue_fixed_array_return_match_rgba(r u8, g u8, b u8, a u8) [4]u8 {
+	return [r, g, b, a]!
+}
+
+fn issue_fixed_array_return_from_enum_match(medal FixedArrayReturnMatchMedal) [4]u8 {
+	return match medal {
+		.one { issue_fixed_array_return_match_rgba(1, 2, 3, 4) }
+		.two { issue_fixed_array_return_match_rgba(5, 6, 7, 8) }
+		.three { issue_fixed_array_return_match_rgba(9, 10, 11, 12) }
+		.four { issue_fixed_array_return_match_rgba(13, 14, 15, 16) }
+		.five { issue_fixed_array_return_match_rgba(17, 18, 19, 20) }
+		.six { issue_fixed_array_return_match_rgba(21, 22, 23, 24) }
+	}
+}
+
+fn issue_fixed_array_literal_return_from_enum_match(medal FixedArrayReturnMatchMedal) [4]u8 {
+	return match medal {
+		.one { [u8(1), 2, 3, 4]! }
+		.two { [u8(5), 6, 7, 8]! }
+		.three { [u8(9), 10, 11, 12]! }
+		.four { [u8(13), 14, 15, 16]! }
+		.five { [u8(17), 18, 19, 20]! }
+		.six { [u8(21), 22, 23, 24]! }
+	}
+}
+
+fn test_fixed_array_return_from_large_enum_match_call_branches() {
+	assert issue_fixed_array_return_from_enum_match(.two) == [u8(5), 6, 7, 8]!
+	assert issue_fixed_array_return_from_enum_match(.six) == [u8(21), 22, 23, 24]!
+	assert issue_fixed_array_literal_return_from_enum_match(.two) == [u8(5), 6, 7, 8]!
+	assert issue_fixed_array_literal_return_from_enum_match(.six) == [u8(21), 22, 23, 24]!
+}


### PR DESCRIPTION
## What changed

Fix C codegen for fixed-array values assigned through `match`/`if` branch temps.

The branch temp now uses `memcpy` for fixed-array branch values, and targets `.ret_arr` only when the temp is the `_v_...` wrapper used for functions returning fixed arrays. Match expressions that yield such wrapper temps also expose `.ret_arr` when the surrounding fixed-array return path needs the raw array payload.

## Why

A fixed-array-returning enum `match` could lower to invalid C such as assigning `hud_rgba(...).ret_arr` directly into a `_v_Array_fixed_u8_4` wrapper temp. A related literal-branch shape needs the raw fixed-array temp path instead.

## Validation

- `make` in a clean worktree based on `origin/master`
- `./v test vlib/v/tests/return_fixed_array_test.v`
- `PATH=/Users/alexander/code/v-fix-fixed-array-match-return-temps:$PATH sh build` in `/Users/alexander/code/doka`