### PR TITLE
wasm: add browser stderr builtins

### DIFF
--- a/vlib/builtin/wasm/browser/builtin_notd_no_imports.v
+++ b/vlib/builtin/wasm/browser/builtin_notd_no_imports.v
@@ -3,6 +3,11 @@ module builtin
 fn JS.__panic_abort(&u8, int)
 fn JS.__writeln(&u8, int)
 
+// print prints a message to the browser output host.
+pub fn print(s string) {
+	JS.__writeln(s.str, s.len)
+}
+
 // panic calls the `__panic_abort` JS panic handler.
 @[noreturn]
 pub fn panic(s string) {
@@ -12,5 +17,15 @@ pub fn panic(s string) {
 
 // println prints a message with a line end, to stdout. stdout is flushed.
 pub fn println(s string) {
+	JS.__writeln(s.str, s.len)
+}
+
+// eprint prints a message to the browser output host.
+pub fn eprint(s string) {
+	JS.__writeln(s.str, s.len)
+}
+
+// eprintln prints a message with a line end, to the browser output host.
+pub fn eprintln(s string) {
 	JS.__writeln(s.str, s.len)
 }

--- a/vlib/builtin/wasm/browser/builtin_notd_no_imports.v
+++ b/vlib/builtin/wasm/browser/builtin_notd_no_imports.v
@@ -3,11 +3,6 @@ module builtin
 fn JS.__panic_abort(&u8, int)
 fn JS.__writeln(&u8, int)
 
-// print prints a message to the browser output host.
-pub fn print(s string) {
-	JS.__writeln(s.str, s.len)
-}
-
 // panic calls the `__panic_abort` JS panic handler.
 @[noreturn]
 pub fn panic(s string) {
@@ -17,11 +12,6 @@ pub fn panic(s string) {
 
 // println prints a message with a line end, to stdout. stdout is flushed.
 pub fn println(s string) {
-	JS.__writeln(s.str, s.len)
-}
-
-// eprint prints a message to the browser output host.
-pub fn eprint(s string) {
 	JS.__writeln(s.str, s.len)
 }
 

--- a/vlib/v/gen/wasm/tests/browser_empty_main_test.v
+++ b/vlib/v/gen/wasm/tests/browser_empty_main_test.v
@@ -36,6 +36,24 @@ fn test_wasm_browser_target_allows_empty_main() {
 	}
 }
 
+fn test_wasm_browser_target_allows_eprintln() {
+	vexe := os.quoted_path(@VEXE)
+	wrkdir := os.join_path(os.vtmp_dir(), 'wasm_browser_eprintln_tests')
+	os.mkdir_all(wrkdir)!
+	defer {
+		os.rmdir_all(wrkdir) or {}
+	}
+
+	source_path := os.join_path(wrkdir, 'eprintln_main.v')
+	output_path := os.join_path(wrkdir, 'eprintln_main.wasm')
+	os.write_file(source_path, "pub fn main() { eprintln('browser stderr') }\n")!
+
+	res :=
+		os.execute('${vexe} -b wasm -os browser -o ${os.quoted_path(output_path)} ${os.quoted_path(source_path)}')
+	assert res.exit_code == 0, 'compilation failed: ${res.output}'
+	assert os.exists(output_path), 'missing output for browser eprintln'
+}
+
 fn test_wasm_shared_library_exports_custom_names_without_main() {
 	vexe := os.quoted_path(@VEXE)
 	wrkdir := os.join_path(os.vtmp_dir(), 'wasm_shared_library_tests')

--- a/vlib/v/gen/wasm/tests/browser_empty_main_test.v
+++ b/vlib/v/gen/wasm/tests/browser_empty_main_test.v
@@ -19,12 +19,12 @@ fn test_wasm_browser_target_allows_empty_main() {
 		os.rmdir_all(wrkdir) or {}
 	}
 
-	source_path := os.join_path(wrkdir, 'empty_main.wasm.v')
+	source_path := os.join_path(wrkdir, 'empty_main.v')
 	os.write_file(source_path, 'pub fn main() {}\n')!
 
 	flags_sets := [
-		'-no-bounds-checking -b wasm -os browser',
-		'-no-bounds-checking -enable-globals -b wasm -os browser',
+		'-b wasm -os browser',
+		'-enable-globals -b wasm -os browser',
 	]
 
 	for idx, flags in flags_sets {


### PR DESCRIPTION
## Summary

Fixes #27450.

The native wasm browser target could emit calls to `eprintln`, but the browser-specific wasm builtin only provided `println` and `panic`. That made `v -b wasm -os browser` panic while finalizing the wasm module, even for an empty `main`.

This adds browser wasm definitions for `print`, `eprint`, and `eprintln`, routing them through the existing `__writeln` browser host hook, and updates the empty-main regression test so it no longer masks the issue with `-no-bounds-checking`.

## Validation

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -b wasm -os browser -o "$tmpdir/m.wasm" "$tmpdir/m.v"`
- `./vnew -b wasm -os browser -o /tmp/change_color_by_id.wasm examples/wasm/change_color_by_id/change_color_by_id.wasm.v`
- `./vnew test vlib/v/gen/wasm/tests/browser_empty_main_test.v`
- `./vnew -silent test vlib/v/gen/wasm/tests/`