### PR TITLE
flag: fix help text generation for xdocs containing colons

### DIFF
--- a/vlib/flag/flag_to.v
+++ b/vlib/flag/flag_to.v
@@ -312,8 +312,8 @@ fn (fm FlagMapper) get_struct_info[T]() !StructInfo {
 			for attr in field.attrs {
 				trace_println('\tattribute: "${attr}"')
 				if attr.contains(':') {
-					split := attr.split(':')
-					attrs[split[0].trim_space()] = normalize_attr_value(split[1])
+					attr_name, attr_value := attr.split_once(':') or { '', '' }
+					attrs[attr_name.trim_space()] = normalize_attr_value(attr_value)
 				} else {
 					attrs[attr.trim(' ')] = 'true'
 				}

--- a/vlib/flag/flag_to_doc_test.v
+++ b/vlib/flag/flag_to_doc_test.v
@@ -193,3 +193,16 @@ Footer content'
 		fields:      unsafe { field_docs }
 	)! == doc5
 }
+
+struct DocTestXDoc {
+	dim int @[xdoc: 'dimensions, one of: 1, 2, 3.']
+}
+
+fn test_to_doc_with_xdoc_containing_colon() {
+	expected := '
+Options:
+  --dim <int>               dimensions, one of: 1, 2, 3.'
+
+	help := flag.to_doc[DocTestXDoc]()!
+	assert help == expected
+}


### PR DESCRIPTION
Fix `flag.to_doc[T]()`, add test.

Input struct:

```v
struct Preferences {
        dim int @[xdoc: 'dimensions, one of: 1, 2, 3.']
}
```

Before:
```

Options:
  --dim <int>               'dimensions, one of
```

After:
```

Options:
  --dim <int>               dimensions, one of: 1, 2, 3.
```

All `flag` tests passed.