### PR TITLE
net: record bytes written before a write error (last_write_sent)

### DIFF
--- a/vlib/net/mbedtls/ssl_connection.c.v
+++ b/vlib/net/mbedtls/ssl_connection.c.v
@@ -155,6 +155,10 @@ pub mut:
 	// strings in config.alpn_protocols. mbedtls stores this pointer without
 	// copying, so it must outlive the SSL config; it is freed in shutdown().
 	alpn_list &&char = unsafe { nil }
+	// last_write_sent is the number of bytes the most recent write_ptr call sent.
+	// It is valid even when that call returned an error, so a caller can tell a
+	// zero-byte failure (nothing reached the peer) from a partial write.
+	last_write_sent int
 }
 
 // SSLListener listens on a TCP port and accepts connection secured with TLS
@@ -858,6 +862,7 @@ pub fn (mut s SSLConn) write_ptr(bytes &u8, len int) !int {
 		}
 	}
 
+	s.last_write_sent = 0
 	deadline := ssl_timeout_deadline(s.duration)
 	unsafe {
 		mut ptr_base := bytes
@@ -885,6 +890,7 @@ pub fn (mut s SSLConn) write_ptr(bytes &u8, len int) !int {
 				}
 			}
 			total_sent += sent
+			s.last_write_sent = total_sent
 		}
 	}
 	return total_sent

--- a/vlib/net/mbedtls/ssl_connection.c.v
+++ b/vlib/net/mbedtls/ssl_connection.c.v
@@ -155,9 +155,11 @@ pub mut:
 	// strings in config.alpn_protocols. mbedtls stores this pointer without
 	// copying, so it must outlive the SSL config; it is freed in shutdown().
 	alpn_list &&char = unsafe { nil }
-	// last_write_sent is the number of bytes the most recent write_ptr call sent.
-	// It is valid even when that call returned an error, so a caller can tell a
-	// zero-byte failure (nothing reached the peer) from a partial write.
+	// last_write_sent reports the most recent write_ptr's progress for retry
+	// decisions: 0 = provably nothing was sent (safe to replay), or -1 = the
+	// count is indeterminate because a failed/retryable write may have already
+	// flushed a record to the peer (TLS cannot prove zero). On full success it
+	// equals the bytes written.
 	last_write_sent int
 }
 
@@ -871,6 +873,11 @@ pub fn (mut s SSLConn) write_ptr(bytes &u8, len int) !int {
 			remaining := len - total_sent
 			mut sent := C.mbedtls_ssl_write(&s.ssl, ptr, remaining)
 			if sent <= 0 {
+				// The write did not fully complete; a retryable error can leave a
+				// record partially flushed, so the sent count is no longer
+				// provable. Mark it indeterminate (a later full success below
+				// resets it to the exact length).
+				s.last_write_sent = -1
 				match sent {
 					C.MBEDTLS_ERR_SSL_WANT_READ {
 						s.wait_for_read(ssl_remaining_timeout(deadline))!

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -16,6 +16,10 @@ pub mut:
 	duration time.Duration
 
 	owns_socket bool
+	// last_write_sent is the number of bytes the most recent write_ptr call sent.
+	// It is valid even when that call returned an error, so a caller can tell a
+	// zero-byte failure (nothing reached the peer) from a partial write.
+	last_write_sent int
 }
 
 @[params]
@@ -413,6 +417,7 @@ pub fn (mut s SSLConn) write_ptr(bytes &u8, len int) !int {
 		}
 	}
 
+	s.last_write_sent = 0
 	deadline := ssl_timeout_deadline(s.duration)
 	unsafe {
 		mut ptr_base := bytes
@@ -441,6 +446,7 @@ pub fn (mut s SSLConn) write_ptr(bytes &u8, len int) !int {
 					int(err_res))
 			}
 			total_sent += sent
+			s.last_write_sent = total_sent
 		}
 	}
 	return total_sent

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -16,9 +16,11 @@ pub mut:
 	duration time.Duration
 
 	owns_socket bool
-	// last_write_sent is the number of bytes the most recent write_ptr call sent.
-	// It is valid even when that call returned an error, so a caller can tell a
-	// zero-byte failure (nothing reached the peer) from a partial write.
+	// last_write_sent reports the most recent write_ptr's progress for retry
+	// decisions: 0 = provably nothing was sent (safe to replay), or -1 = the
+	// count is indeterminate because a failed/retryable write may have already
+	// flushed complete records to the peer (TLS cannot prove zero). On full
+	// success it equals the bytes written.
 	last_write_sent int
 }
 
@@ -426,6 +428,12 @@ pub fn (mut s SSLConn) write_ptr(bytes &u8, len int) !int {
 			remaining := len - total_sent
 			mut sent := C.SSL_write(voidptr(s.ssl), ptr, remaining)
 			if sent <= 0 {
+				// SSL_write did not fully complete: OpenSSL may already have
+				// flushed one or more complete records (which the peer can
+				// decrypt and act on) before returning a retryable error, so the
+				// sent count is no longer provable. Mark it indeterminate; a
+				// later full success below resets it to the exact length.
+				s.last_write_sent = -1
 				err_res := ssl_error(sent, s.ssl)!
 				if err_res == .ssl_error_want_read {
 					s.wait_for_read(ssl_remaining_timeout(deadline))!

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -32,9 +32,11 @@ pub mut:
 	read_timeout   time.Duration
 	write_timeout  time.Duration
 	is_blocking    bool = true
-	// last_write_sent is the number of bytes the most recent write_ptr call sent.
-	// It is valid even when that call returned an error, so a caller can tell a
-	// zero-byte failure (nothing reached the peer) from a partial write.
+	// last_write_sent is the exact number of bytes the most recent write_ptr
+	// call sent, valid even when it then returned an error (send() is
+	// byte-accurate), so a caller can tell a zero-byte failure — 0, safe to
+	// replay — from a partial write. (The TLS backends expose the same field but
+	// use -1 for the indeterminate case they cannot prove; plain TCP never does.)
 	last_write_sent int
 }
 

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -32,6 +32,10 @@ pub mut:
 	read_timeout   time.Duration
 	write_timeout  time.Duration
 	is_blocking    bool = true
+	// last_write_sent is the number of bytes the most recent write_ptr call sent.
+	// It is valid even when that call returned an error, so a caller can tell a
+	// zero-byte failure (nothing reached the peer) from a partial write.
+	last_write_sent int
 }
 
 // dial_tcp will try to create a new TcpConn to the given address.
@@ -233,6 +237,7 @@ pub fn (mut c TcpConn) write_ptr(b &u8, len int) !int {
 			'>>> TcpConn.write_ptr | data.len: ${len:6} | hex: ${unsafe { b.vbytes(len) }.hex()} | data: ' +
 			unsafe { b.vstring_with_len(len) })
 	}
+	c.last_write_sent = 0
 	unsafe {
 		mut ptr_base := &u8(b)
 		mut total_sent := 0
@@ -260,6 +265,7 @@ pub fn (mut c TcpConn) write_ptr(b &u8, len int) !int {
 				}
 			}
 			total_sent += sent
+			c.last_write_sent = total_sent
 		}
 		return total_sent
 	}

--- a/vlib/net/tcp_last_write_sent_test.v
+++ b/vlib/net/tcp_last_write_sent_test.v
@@ -1,0 +1,49 @@
+import net
+import time
+
+// last_write_sent must reflect the bytes the most recent write managed to send,
+// both on success and (crucially) when the write fails, so a caller can tell a
+// zero-byte failure from a partial write. See vlang/v#27459.
+
+fn drain_one_conn(mut l net.TcpListener) {
+	mut c := l.accept() or { return }
+	for {
+		mut buf := []u8{len: 4096}
+		c.read(mut buf) or { break }
+	}
+	c.close() or {}
+}
+
+fn test_last_write_sent_on_success() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	addr := l.addr()!
+	th := spawn drain_one_conn(mut l)
+	mut c := net.dial_tcp(addr.str())!
+	payload := 'hello world'.bytes()
+	n := c.write(payload)!
+	assert n == payload.len
+	assert c.last_write_sent == payload.len
+	c.close() or {}
+	l.close() or {}
+	th.wait()
+}
+
+fn test_last_write_sent_is_zero_on_failed_write_to_closed_conn() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	addr := l.addr()!
+	th := spawn drain_one_conn(mut l)
+	mut c := net.dial_tcp(addr.str())!
+	// Close our side, then attempt a write: it must fail and report zero bytes
+	// sent, so a retry layer can treat it as safe to replay.
+	c.close() or {}
+	time.sleep(5 * time.millisecond)
+	c.write('data'.bytes()) or {
+		assert c.last_write_sent == 0, 'a failed write before any byte left must report 0'
+		l.close() or {}
+		th.wait()
+		return
+	}
+	assert false, 'write to a closed connection unexpectedly succeeded'
+	l.close() or {}
+	th.wait()
+}


### PR DESCRIPTION
## What

Adds a `last_write_sent int` field to `net.TcpConn` and the openssl/mbedtls
`SSLConn`, reporting the most recent `write_ptr`'s progress for retry decisions.
It is tri-state: `0` = provably nothing was sent (safe to replay), `>0` = the
exact byte count (plain TCP, where `send()` is byte-accurate), and `-1` =
indeterminate. The TLS backends use `-1` because a failed `SSL_write` /
`mbedtls_ssl_write` may already have flushed complete records to the peer, so
they cannot prove a zero-byte failure; only plain TCP yields a reliable `0`.

## Why

`write_ptr` accumulates a running `total_sent` in its send loop but drops it on
the error path, so a caller cannot distinguish a **zero-byte failure** (nothing
reached the peer) from a **partial write** (some bytes did). That distinction is
needed to retry safely: a non-idempotent request (POST/PATCH) is only safe to
replay when provably zero bytes were sent.

This unblocks the `net.http` connection-pooling `Transport` (#27412), which
currently has to refuse retrying *any* non-idempotent request whose write failed
— including the common stale-pooled-connection case (server closed the idle
socket, 0 bytes sent), which is provably safe to replay.

See #27459 for the full rationale and the API alternatives considered (a custom
error type — rejected, `net.openssl`/`net.mbedtls` can't import `net`; a
multi-return write — rejected as breaking).

## How

`write_ptr` resets `last_write_sent = 0` on entry and updates it as `total_sent`
grows, in all three backends. The TLS backends additionally set it to `-1` the
moment a write does not fully complete (a retryable/failed `SSL_write` may have
flushed complete records already), so a later wait timeout never reports a false
`0`; a subsequent full success resets it to the exact length. Purely additive —
existing `write`/`write_ptr`/`write_string` return values and error semantics are
unchanged.

## Tests

`tcp_last_write_sent_test.v`: a successful write reports `last_write_sent ==
len`; a write to a closed connection fails and reports `last_write_sent == 0`.
`vlib/net/ssl/` and the core tcp tests pass (both SSL backends compile and run
with the new field).

Closes #27459.

