### PR TITLE
cgen: prevent main propagation panic fallthrough

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -12201,6 +12201,17 @@ fn (mut g Gen) or_block_on_value(var_name string, or_block ast.OrExpr, return_ty
 	g.set_current_pos_as_last_stmt_pos()
 }
 
+fn (mut g Gen) write_main_error_propagation_panic_tail() {
+	// Prevent synthetic main() propagation panics from falling through into cleanup
+	// if a backend panic helper unexpectedly returns.
+	if g.pref.is_bare {
+		g.writeln('\twhile (1) {}')
+	} else {
+		g.writeln('\texit(1);')
+	}
+	g.writeln('\tVUNREACHABLE();')
+}
+
 // If user is accessing the return value eg. in assignment, pass the variable name.
 // If the user is not using the option return value. We need to pass a temp var
 // to access its fields (`.ok`, `.error` etc)
@@ -12326,6 +12337,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			} else {
 				g.writeln('\tbuiltin__panic_result_not_set(${err_msg});')
 			}
+			g.write_main_error_propagation_panic_tail()
 		} else if g.fn_decl != unsafe { nil } && g.fn_decl.is_test {
 			g.gen_failing_error_propagation_for_test_fn(or_block, cvar_name)
 		} else {
@@ -12370,6 +12382,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			} else {
 				g.writeln('\tbuiltin__panic_option_not_set( ${err_msg} );')
 			}
+			g.write_main_error_propagation_panic_tail()
 		} else if g.fn_decl != unsafe { nil } && g.fn_decl.is_test {
 			g.gen_failing_error_propagation_for_test_fn(or_block, cvar_name)
 		} else {

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -236,6 +236,31 @@ fn test_or_block_err_var_collision_does_not_emit_self_referential_err() {
 	assert has_visible_or_block_err
 }
 
+fn test_main_error_propagation_panic_branches_do_not_fall_through() {
+	os.chdir(vroot) or {}
+	test_dir := os.join_path(os.vtmp_dir(), 'main_error_propagation_panic_tail_${os.getpid()}')
+	os.mkdir_all(test_dir)!
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	source_path := os.join_path(test_dir, 'main_error_propagation_panic_tail.v')
+	os.write_file(source_path,
+		['module main', '', 'fn fail_result() ! {', "\treturn error('new error')", '}', '', 'fn fail_option() ?int {', '\treturn none', '}', '', 'fn defer_result() ! {', '\tdefer {', "\t\tprintln('result deferred')", '\t}', '\tfail_result()!', '}', '', 'fn defer_option() ?int {', '\tdefer {', "\t\tprintln('option deferred')", '\t}', '\treturn fail_option()', '}', '', 'fn main() {', '\tif arguments().len > 1000 {', '\t\tdefer_option()?', '\t}', '\tdefer_result()!', '}'].join('\n') +
+		'\n')!
+	cmd := '${os.quoted_path(vexe)} -o - ${os.quoted_path(source_path)}'
+	compilation := os.execute(cmd)
+	ensure_compilation_succeeded(compilation, cmd)
+	for panic_call in [
+		'builtin__panic_result_not_set(IError_name_table[',
+		'builtin__panic_option_not_set( IError_name_table[',
+	] {
+		assert compilation.output.contains(panic_call)
+		branch_tail := compilation.output.all_after(panic_call).all_before('}')
+		assert branch_tail.contains('exit(1);')
+		assert branch_tail.contains('VUNREACHABLE();')
+	}
+}
+
 fn test_imported_empty_interface_concat_does_not_emit_noop_array_cast_helper() {
 	os.chdir(vroot) or {}
 	path := os.join_path(vroot,


### PR DESCRIPTION
## Summary
- emit an explicit non-returning tail after synthetic main() option/result propagation panics
- use `exit(1)` for normal targets and an infinite loop for bare targets
- add coutput coverage that checks both result and option panic branches do not fall through

Closes #27401

## Tests
- `TMPDIR=/tmp/v-pr-main-panic-tail ./vnew vlib/v/gen/c/coutput_test.v`
- `TMPDIR=/tmp/v-pr-main-panic-tail ./vnew -silent vlib/v/compiler_errors_test.v`