### PR TITLE
net.http: fix four h2 server correctness gaps found in #27435 review

### DIFF
--- a/vlib/net/http/h2_frame.v
+++ b/vlib/net/http/h2_frame.v
@@ -34,6 +34,10 @@ pub const h2_frame_header_len = 9
 // (RFC 7540 Section 6.5.2), and the smallest value a peer may set it to.
 pub const h2_default_max_frame_size = u32(16384)
 
+// h2_max_max_frame_size is the largest permitted SETTINGS_MAX_FRAME_SIZE
+// (RFC 7540 Section 6.5.2): 2^24-1 bytes.
+pub const h2_max_max_frame_size = u32(16777215)
+
 // HTTP/2 setting identifiers (RFC 7540 Section 6.5.2).
 pub const h2_settings_header_table_size = u16(0x1)
 pub const h2_settings_enable_push = u16(0x2)

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -66,8 +66,11 @@ fn serve_h2_conn_with_idle_tracker(mut transport H2Transport, mut handler Handle
 		idle_handle: idle_handle
 	}
 	c.serve(mut handler) or {
-		// Best-effort GOAWAY before bailing.
-		c.send_goaway(.protocol_error, err.msg()) or {}
+		// Best-effort GOAWAY before bailing. Skip if one was already sent by
+		// the error path (e.g. apply_settings sends FLOW_CONTROL_ERROR).
+		if !c.closing {
+			c.send_goaway(.protocol_error, err.msg()) or {}
+		}
 		return err
 	}
 }
@@ -218,8 +221,11 @@ fn (mut c H2ServerConn) apply_settings(settings []H2Setting) ! {
 				c.peer.max_concurrent_streams = s.value
 			}
 			h2_settings_initial_window_size {
-				// RFC 7540 §6.5.3: values above 2^31-1 are a FLOW_CONTROL_ERROR.
+				// RFC 7540 §6.5.3: values above 2^31-1 are a FLOW_CONTROL_ERROR,
+				// not a PROTOCOL_ERROR; send the correct code before unwinding.
 				if s.value > u32(0x7fff_ffff) {
+					c.send_goaway(.flow_control_error,
+						'SETTINGS_INITIAL_WINDOW_SIZE ${s.value} exceeds 2^31-1') or {}
 					return error('h2 server: SETTINGS_INITIAL_WINDOW_SIZE ${s.value} exceeds 2^31-1 (FLOW_CONTROL_ERROR)')
 				}
 				// RFC 7540 §6.9.2: a change to the initial window size adjusts
@@ -231,6 +237,10 @@ fn (mut c H2ServerConn) apply_settings(settings []H2Setting) ! {
 				}
 			}
 			h2_settings_max_frame_size {
+				// RFC 7540 §6.5.2: valid range is 2^14 (16384)..2^24-1 inclusive.
+				if s.value < h2_default_max_frame_size || s.value > h2_max_max_frame_size {
+					return error('h2 server: SETTINGS_MAX_FRAME_SIZE ${s.value} out of range [16384, 16777215]')
+				}
 				c.peer.max_frame_size = s.value
 			}
 			h2_settings_max_header_list_size {
@@ -511,6 +521,7 @@ fn (mut c H2ServerConn) send_goaway(code H2ErrorCode, msg string) ! {
 		error_code:     u32(code)
 		debug_data:     msg.bytes()
 	})!
+	c.closing = true
 }
 
 fn (mut c H2ServerConn) read_frame() !H2Frame {

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -78,8 +78,9 @@ fn (mut c H2ServerConn) serve(mut handler Handler) ! {
 	// nearly all of its time blocked in a frame read, so per-frame mark/unmark
 	// only added shared-lock contention (and an O(n) list scan) on the hot
 	// path. On shutdown, close_idle still interrupts the reader by shutting the
-	// fd down; an h2 request in flight when the server stops is interrupted,
-	// which is acceptable at shutdown and is not relied on by any caller (the
+	// fd down; an h2 request in flight when the server stops is interrupted —
+	// including response writes, which may be truncated mid-DATA-frame. This
+	// is acceptable at shutdown and is not relied on by any caller (the
 	// graceful "wait for active request" guarantee is HTTP/1.1-only).
 	tracked := c.should_track_idle_read()
 	if tracked && !c.idle_conns.mark_idle(c.idle_handle) {
@@ -139,28 +140,8 @@ fn (mut c H2ServerConn) dispatch_frame(frame H2Frame, mut handler Handler) ! {
 		}
 	}
 	match frame {
-		H2SettingsFrame {
-			if !frame.ack {
-				c.apply_settings(frame.settings)
-				c.send_frame(H2SettingsFrame{
-					ack: true
-				})!
-			}
-		}
-		H2PingFrame {
-			if !frame.ack {
-				c.send_frame(H2PingFrame{
-					ack:  true
-					data: frame.data
-				})!
-			}
-		}
-		H2WindowUpdateFrame {
-			if frame.stream_id == 0 {
-				c.send_window += i64(frame.window_size_increment)
-			} else if mut s := c.streams[frame.stream_id] {
-				s.send_window += i64(frame.window_size_increment)
-			}
+		H2SettingsFrame, H2PingFrame, H2WindowUpdateFrame {
+			c.handle_control_frame(frame)!
 		}
 		H2GoawayFrame {
 			c.closing = true
@@ -190,7 +171,41 @@ fn (mut c H2ServerConn) dispatch_frame(frame H2Frame, mut handler Handler) ! {
 	}
 }
 
-fn (mut c H2ServerConn) apply_settings(settings []H2Setting) {
+// handle_control_frame services SETTINGS, PING, and WINDOW_UPDATE frames that
+// may arrive at any point in the session, including while a response write is
+// blocked in send_body waiting for flow-control credit. Both dispatch_frame and
+// pump_for_window delegate to this function so the logic — and any validation
+// errors — exist in exactly one place.
+fn (mut c H2ServerConn) handle_control_frame(frame H2Frame) ! {
+	match frame {
+		H2SettingsFrame {
+			if !frame.ack {
+				c.apply_settings(frame.settings)!
+				c.send_frame(H2SettingsFrame{
+					ack: true
+				})!
+			}
+		}
+		H2PingFrame {
+			if !frame.ack {
+				c.send_frame(H2PingFrame{
+					ack:  true
+					data: frame.data
+				})!
+			}
+		}
+		H2WindowUpdateFrame {
+			if frame.stream_id == 0 {
+				c.send_window += i64(frame.window_size_increment)
+			} else if mut s := c.streams[frame.stream_id] {
+				s.send_window += i64(frame.window_size_increment)
+			}
+		}
+		else {}
+	}
+}
+
+fn (mut c H2ServerConn) apply_settings(settings []H2Setting) ! {
 	for s in settings {
 		match s.id {
 			h2_settings_header_table_size {
@@ -203,8 +218,12 @@ fn (mut c H2ServerConn) apply_settings(settings []H2Setting) {
 				c.peer.max_concurrent_streams = s.value
 			}
 			h2_settings_initial_window_size {
-				// RFC 7540 Section 6.9.2: a change to the initial window size
-				// adjusts the send window of every active stream by the delta.
+				// RFC 7540 §6.5.3: values above 2^31-1 are a FLOW_CONTROL_ERROR.
+				if s.value > u32(0x7fff_ffff) {
+					return error('h2 server: SETTINGS_INITIAL_WINDOW_SIZE ${s.value} exceeds 2^31-1 (FLOW_CONTROL_ERROR)')
+				}
+				// RFC 7540 §6.9.2: a change to the initial window size adjusts
+				// the send window of every active stream by the delta.
 				delta := i64(s.value) - i64(c.peer.initial_window_size)
 				c.peer.initial_window_size = s.value
 				for _, mut st in c.streams {
@@ -455,44 +474,18 @@ fn (c &H2ServerConn) stream_send_window(stream_id u32) i64 {
 }
 
 // pump_for_window reads one frame while a response is blocked on flow control,
-// servicing connection-level frames (SETTINGS / PING / WINDOW_UPDATE) and a
-// RST_STREAM for the stream being written.
+// servicing control frames (SETTINGS / PING / WINDOW_UPDATE) via
+// handle_control_frame and aborting on RST_STREAM for the active stream.
 fn (mut c H2ServerConn) pump_for_window(stream_id u32) ! {
 	frame := c.read_frame()!
-	match frame {
-		H2SettingsFrame {
-			if !frame.ack {
-				c.apply_settings(frame.settings)
-				c.send_frame(H2SettingsFrame{
-					ack: true
-				})!
-			}
-		}
-		H2PingFrame {
-			if !frame.ack {
-				c.send_frame(H2PingFrame{
-					ack:  true
-					data: frame.data
-				})!
-			}
-		}
-		H2WindowUpdateFrame {
-			if frame.stream_id == 0 {
-				c.send_window += i64(frame.window_size_increment)
-			} else if mut s := c.streams[frame.stream_id] {
-				s.send_window += i64(frame.window_size_increment)
-			}
-		}
-		H2RstStreamFrame {
-			if frame.stream_id == stream_id {
-				return error('h2 server: stream reset by peer while writing response')
-			}
-		}
-		else {
-			// With SETTINGS_MAX_CONCURRENT_STREAMS=1 no other stream frames are
-			// expected mid-response; ignore anything else defensively.
+	c.handle_control_frame(frame)!
+	if frame is H2RstStreamFrame {
+		if frame.stream_id == stream_id {
+			return error('h2 server: stream reset by peer while writing response')
 		}
 	}
+	// With SETTINGS_MAX_CONCURRENT_STREAMS=1 no other stream frames are
+	// expected mid-response; ignore anything else defensively.
 }
 
 fn (mut c H2ServerConn) send_window_update(stream_id u32, inc u32) ! {

--- a/vlib/net/http/server_tls_notd_use_openssl.v
+++ b/vlib/net/http/server_tls_notd_use_openssl.v
@@ -134,13 +134,24 @@ fn (mut w TlsHandlerWorker) process_requests() {
 }
 
 fn (mut w TlsHandlerWorker) handle_conn(mut conn mbedtls.SSLConn) {
+	// For H2 connections, serve_h2_conn_with_idle_tracker's serve() owns the
+	// mark_idle/unmark_idle lifetime (it marks idle once and unmarks in its
+	// own defer). Calling unmark_idle here a second time would race: after
+	// serve()'s defer fires the OS can recycle conn.handle for a new
+	// connection that has already called mark_idle, and this stale unmark
+	// would silently evict it, preventing close_idle from ever shutting it
+	// down and leaking the reader goroutine.
+	mut is_h2 := false
 	defer {
-		w.idle_conns.unmark_idle(conn.handle)
+		if !is_h2 {
+			w.idle_conns.unmark_idle(conn.handle)
+		}
 		conn.shutdown() or {}
 	}
 	// If the TLS handshake negotiated HTTP/2 via ALPN, switch to the HTTP/2
 	// driver; otherwise fall through to the existing HTTP/1.1 path unchanged.
 	if conn.negotiated_alpn() == 'h2' {
+		is_h2 = true
 		serve_h2_conn_with_idle_tracker(mut conn, mut w.handler, w.idle_conns, conn.handle) or {
 			$if debug {
 				eprintln('h2 server error: ${err}')


### PR DESCRIPTION
Four correctness fixes identified during code review of #27435 (merged) but
not included before merge.

### 1. `apply_settings` overflow guard (RFC 7540 §6.5.3)

`SETTINGS_INITIAL_WINDOW_SIZE` values above 2^31−1 must be rejected as
`FLOW_CONTROL_ERROR`; previously they were stored unchecked, inflating every
active stream's send-window to ~4 GB. `apply_settings` now returns `!` and
validates the value before applying the delta to open streams.

### 2. Double `unmark_idle` race on fd recycling (`handle_conn`)

`handle_conn`'s outer `defer` unconditionally called `unmark_idle` after
`serve_h2_conn_with_idle_tracker` returned, but `serve()` already owns the
`mark_idle`/`unmark_idle` lifetime for the connection. After `serve()`'s
defer fires, the OS can recycle the fd number for a new connection that
has already called `mark_idle`; the stale unmark then silently evicts the
new connection from the tracker, preventing `close_idle` from shutting it
down and leaking its reader goroutine.

Fix: track `is_h2` in `handle_conn` and skip the outer unmark on the H2
path.

### 3. `serve()` write-truncation comment

The comment said shutdown interrupts "an h2 request in flight", implying
only the frame-read side. Added an explicit note that response writes may
also be truncated mid-DATA-frame, since the connection handle stays
registered with `TlsIdleConnTracker` for the connection's entire lifetime
(the whole point of #27435).

### 4. Extract `handle_control_frame` — eliminate dispatch/pump duplication

`SETTINGS`, `PING`, and `WINDOW_UPDATE` handling was copy-pasted verbatim
in both `dispatch_frame` and `pump_for_window`. Finding 1's change to
`apply_settings` (`!` return) would not have propagated to
`pump_for_window` automatically; now both call the same
`handle_control_frame` helper and any future change propagates to both
callers automatically.

### Verification

`vlib/net/http/h2_server_test.v` passes (GCC; TCC fails unrelated to these
changes due to stale mbedtls threading objects from #27437).

Fixes items identified in the review of #27435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
