### PR TITLE
cgen: snapshot Boehm scope GC pins on the stack, fixes #27467

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -8164,26 +8164,47 @@ fn (mut g Gen) scope_gc_pin_pregen(node_pos int) []ScopeGcPin {
 			opened_scope = true
 		}
 		// Snapshot nested heap buffers before the call, then keep those snapshots
-		// reachable after it. This covers Boehm opt/noscan arrays of structs.
+		// reachable across it. This covers Boehm opt/noscan arrays of structs.
+		//
+		// The snapshot is normally placed in a small fixed stack array. Boehm scans
+		// the C stack conservatively, so the leaf pointers stored there stay rooted for
+		// the duration of the call without any GC root (de)registration. Only snapshots
+		// larger than the stack buffer fall back to an explicit `calloc` + `GC_add_roots`
+		// / `GC_remove_roots` pair. This avoids the per-call `GC_add_roots`/`GC_remove_roots`
+		// + `calloc`/`free` churn, which otherwise dominates hot loops that call functions
+		// while holding aggregates of pointers in scope (e.g. JSON encoding).
+		stack_cap := 32
 		tmp_name := g.new_tmp_var()
 		len_tmp_name := g.new_tmp_var()
 		roots_tmp_name := g.new_tmp_var()
+		stack_tmp_name := g.new_tmp_var()
+		on_heap_tmp_name := g.new_tmp_var()
 		setup_gc_state_name := g.new_tmp_var()
 		cleanup_gc_state_name := g.new_tmp_var()
+		styp := g.styp(obj.typ)
 		g.writeln('voidptr ${tmp_name} = &${cvar_name};')
-		g.writeln('int ${len_tmp_name} = ${collect_helper_name}((${g.styp(obj.typ)}*)${tmp_name}, 0, 0);')
-		g.writeln('int ${setup_gc_state_name} = GC_is_disabled();')
-		g.writeln('if (!${setup_gc_state_name}) { GC_disable(); }')
-		g.writeln('voidptr* ${roots_tmp_name} = 0;')
-		g.writeln('if (${len_tmp_name} > 0) {')
+		g.writeln('int ${len_tmp_name} = ${collect_helper_name}((${styp}*)${tmp_name}, 0, 0);')
+		g.writeln('voidptr ${stack_tmp_name}[${stack_cap}];')
+		g.writeln('voidptr* ${roots_tmp_name} = ${stack_tmp_name};')
+		g.writeln('bool ${on_heap_tmp_name} = false;')
+		g.writeln('if (${len_tmp_name} > ${stack_cap}) {')
+		// Oversized snapshot: the original explicit-roots path, guarded against a
+		// collection happening between allocation and registration.
+		g.writeln('\tint ${setup_gc_state_name} = GC_is_disabled();')
+		g.writeln('\tif (!${setup_gc_state_name}) { GC_disable(); }')
 		g.writeln('\t${roots_tmp_name} = (voidptr*)calloc(${len_tmp_name}, sizeof(voidptr));')
 		g.writeln('\tif (${roots_tmp_name} == 0) { builtin___memory_panic(_S("calloc"), sizeof(voidptr) * ${len_tmp_name}); }')
-		g.writeln('\t${collect_helper_name}((${g.styp(obj.typ)}*)${tmp_name}, ${roots_tmp_name}, 0);')
+		g.writeln('\t${on_heap_tmp_name} = true;')
+		g.writeln('\t${collect_helper_name}((${styp}*)${tmp_name}, ${roots_tmp_name}, 0);')
 		g.writeln('\tGC_add_roots(${roots_tmp_name}, ${roots_tmp_name} + ${len_tmp_name});')
+		g.writeln('\tif (!${setup_gc_state_name}) { GC_enable(); }')
+		g.writeln('} else if (${len_tmp_name} > 0) {')
+		// Common case: snapshot into the stack buffer. The fill performs no allocation,
+		// so no collection can run while it is partially filled.
+		g.writeln('\t${collect_helper_name}((${styp}*)${tmp_name}, ${roots_tmp_name}, 0);')
 		g.writeln('}')
-		g.writeln('if (!${setup_gc_state_name}) { GC_enable(); }')
 		pins << ScopeGcPin{
-			post_stmt: 'GC_reachable_here(${tmp_name}); if (${len_tmp_name} > 0) { for (int _v_keep_i = 0; _v_keep_i < ${len_tmp_name}; ++_v_keep_i) { GC_reachable_here(${roots_tmp_name}[_v_keep_i]); } } int ${cleanup_gc_state_name} = GC_is_disabled(); if (!${cleanup_gc_state_name}) { GC_disable(); } if (${len_tmp_name} > 0) { GC_remove_roots(${roots_tmp_name}, ${roots_tmp_name} + ${len_tmp_name}); free(${roots_tmp_name}); } if (!${cleanup_gc_state_name}) { GC_enable(); }'
+			post_stmt: 'GC_reachable_here(${tmp_name}); if (${len_tmp_name} > 0) { for (int _v_keep_i = 0; _v_keep_i < ${len_tmp_name}; ++_v_keep_i) { GC_reachable_here(${roots_tmp_name}[_v_keep_i]); } } GC_reachable_here(${roots_tmp_name}); if (${on_heap_tmp_name}) { int ${cleanup_gc_state_name} = GC_is_disabled(); if (!${cleanup_gc_state_name}) { GC_disable(); } GC_remove_roots(${roots_tmp_name}, ${roots_tmp_name} + ${len_tmp_name}); free(${roots_tmp_name}); if (!${cleanup_gc_state_name}) { GC_enable(); } }'
 		}
 	}
 	return pins


### PR DESCRIPTION
## What

Fixes #27467 — `x.json2` encode/decode (and other code) is several times slower under `-prod` + Boehm GC than on `0.5.1`. The push fix (#27468/#27470) did **not** resolve it; this is a separate, larger regression.

## Root cause

The deep scope GC pin machinery added in #26946 (`c5efd0f6f`) keeps nested heap buffers of an aggregate alive across a call: it snapshots their leaf pointers and registers them as explicit GC roots. The codegen did this with, **per qualifying variable, around every standalone call statement, in `-prod` + Boehm**:

```c
// before the call
roots = calloc(len, sizeof(voidptr));
collect_leaf_pointers(&var, roots);
GC_add_roots(roots, roots + len);
// after the call
GC_remove_roots(roots, roots + len);
free(roots);
```

`encode_struct_fields` holds `[]string` key lists plus the struct being encoded, and makes a call per field, so this fires millions of times. `GC_remove_roots` is O(root-ranges) and not meant for high-frequency use — `sample` showed it consuming ~100% of the encode loop. With `-gc none` (no pins emitted) master already matches `0.5.1`, which isolates the cost to this machinery.

## Fix

Place the snapshot in a **small fixed stack array** instead of a `calloc`'d heap block + explicit roots:

```c
voidptr roots_stack[32];
voidptr* roots = roots_stack;
bool on_heap = false;
if (len > 32) {                 // rare: oversized snapshot, original proven path
    ... calloc + GC_add_roots ...
    on_heap = true;
} else if (len > 0) {
    collect_leaf_pointers(&var, roots);   // common: fill the stack buffer
}
// after the call:
GC_reachable_here(var); for (i) GC_reachable_here(roots[i]); GC_reachable_here(roots);
if (on_heap) { GC_remove_roots(...); free(...); }
```

Boehm scans the C stack conservatively, so leaf pointers stored in `roots_stack` stay rooted for the duration of the call **with no GC root (de)registration**. The semantics are unchanged:

- The stack fill performs no allocation, so no collection can run while it is partially filled (same window guarantee the original got from `GC_disable`).
- `GC_reachable_here(roots[i])` after the call keeps each leaf live across it, exactly as before.
- Snapshots larger than the stack buffer (e.g. encoding a 200-element array at the top level) fall back to the **original** `calloc` + `GC_add_roots` / `GC_remove_roots` path unchanged.

## Measurements

Issue repro, `v -prod` (default Boehm GC), Apple clang `-O3 -flto`, macOS arm64. `0.5.1` is the official `v_macos_arm64.zip` release (`0c3183c`). Median of 5 runs, same machine/session:

| | encode 2000× | decode 2000× |
|---|---|---|
| **V 0.5.1** | ~120 ms | ~193 ms |
| **master (before)** | ~1620 ms (~13.5×) | ~770 ms (~4×) |
| **master + this PR** | **~330 ms** | **~185 ms** |

Decode is fully recovered (matches/beats `0.5.1`). Encode is ~4.9× faster; the residual gap to `0.5.1` is the actual encode work plus per-call snapshot walks (the explicit-root churn is gone). Byte-identical output on all (`sink=35286000`).

## Correctness

This is GC-correctness-sensitive, so it was verified against the #26946 guardrails and beyond:

- All #26946 testdata stress tests still print `ok` under `-prod -gc boehm_full_opt` (`boehm_runtime_push_keep_alive_nix`, `boehm_json_decode_keep_alive_nix`, `boehm_ifexpr_string_slice_array_nix`).
- `vlib/v/gen/c/coutput_test.v` passes (includes the `boehm_scope_pin_heap_snapshot_nix` `.must_have` codegen assertions and the boehm runtime tests).
- An additional aggressive use-after-collect stress (3-level nested structs/arrays of strings held across heavy `pressure_heap()` GC churn) passes 12/12 runs.
- `vlib/x/json2/` suite passes (60/61, 1 pre-existing skip).
- `v self` rebuilds cleanly with the patched compiler.

`-gc boehm_incr_opt` is pre-existing broken on macOS arm64 (the unpatched master fails identically), so it was not used for verification.

## Notes / follow-ups

- The remaining per-call snapshot walk could be reduced further by pinning less aggressively (only around calls that can actually trigger GC, or once per scope rather than per call), but that is a larger change with more correctness surface; this PR keeps the pin semantics identical and only relocates the snapshot storage.
- Stack buffer cap is 32 pointers (256 B/pin); larger aggregates use the heap fallback.
