### PR TITLE
net.openssl: fix double-free on shutdown()

### DIFF
--- a/vlib/net/openssl/openssl.c.v
+++ b/vlib/net/openssl/openssl.c.v
@@ -127,6 +127,10 @@ fn C.X509_free(const_cert &C.X509)
 
 fn C.ERR_clear_error()
 
+fn C.ERR_get_error() u64
+
+fn C.ERR_error_string_n(e u64, buf &char, len usize)
+
 fn C.SSL_get_error(ssl &C.SSL, ret i32) i32
 
 fn C.SSL_get_verify_result(ssl &C.SSL) i32
@@ -163,6 +167,27 @@ fn init() {
 	C.v_net_openssl_init_ssl()
 }
 
+// ssl_get_error_queue drains the current thread's OpenSSL error queue and
+// returns a human-readable, semicolon-separated description of every queued
+// entry (oldest first), or an empty string if the queue is empty. It always
+// leaves the queue empty afterwards: this both turns the otherwise opaque
+// `SSL_ERROR_SSL`/`SSL_ERROR_SYSCALL` codes into actionable messages, and
+// prevents a leftover entry from making a later SSL_get_error() misreport the
+// status of the next, unrelated I/O operation.
+fn ssl_get_error_queue() string {
+	mut reasons := []string{}
+	for {
+		code := C.ERR_get_error()
+		if code == 0 {
+			break
+		}
+		mut buf := [256]char{}
+		C.ERR_error_string_n(code, &buf[0], usize(buf.len))
+		reasons << unsafe { cstring_to_vstring(&buf[0]) }
+	}
+	return reasons.join('; ')
+}
+
 // ssl_error returns non error ssl code or error if unrecoverable and we should panic
 fn ssl_error(ret int, ssl voidptr) !SSLError {
 	res := C.SSL_get_error(ssl, ret)
@@ -171,10 +196,15 @@ fn ssl_error(ret int, ssl voidptr) !SSLError {
 	}
 	match unsafe { SSLError(res) } {
 		.ssl_error_syscall {
-			return error_with_code('net.openssl unrecoverable syscall (${res})', res)
+			details := ssl_get_error_queue()
+			suffix := if details == '' { '' } else { ': ${details}' }
+			return error_with_code('net.openssl unrecoverable syscall (${res})${suffix}', res)
 		}
 		.ssl_error_ssl {
-			return error_with_code('net.openssl unrecoverable ssl protocol error (${res})', res)
+			details := ssl_get_error_queue()
+			suffix := if details == '' { '' } else { ': ${details}' }
+			return error_with_code('net.openssl unrecoverable ssl protocol error (${res})${suffix}',
+				res)
 		}
 		else {
 			return unsafe { SSLError(res) }

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -98,37 +98,48 @@ pub fn (mut s SSLConn) shutdown() ! {
 		eprintln(@METHOD)
 	}
 
-	if s.ssl != 0 {
+	if s.ssl != unsafe { nil } {
 		deadline := ssl_timeout_deadline(s.duration)
-		for {
-			mut res := C.SSL_shutdown(voidptr(s.ssl))
+		mut shutdown_done := false
+
+		for !shutdown_done {
+			res := C.SSL_shutdown(voidptr(s.ssl))
 			if res == 1 {
+				shutdown_done = true
 				break
 			}
+			if res == 0 {
+				// Second SSL_shutdown() needed for full bidirectional shutdown.
+				continue
+			}
 
-			err_res := ssl_error(res, s.ssl) or {
-				break // We break to free rest of resources
+			err_res := ssl_error(res, s.ssl) or { break }
+
+			match err_res {
+				.ssl_error_want_read {
+					s.wait_for_read(ssl_remaining_timeout(deadline)) or { break }
+				}
+				.ssl_error_want_write {
+					s.wait_for_write(ssl_remaining_timeout(deadline)) or { break }
+				}
+				else {
+					break
+				}
 			}
-			if err_res == .ssl_error_want_read {
-				s.wait_for_read(ssl_remaining_timeout(deadline))!
-				continue
-			} else if err_res == .ssl_error_want_write {
-				s.wait_for_write(ssl_remaining_timeout(deadline))!
-				continue
-			}
-			if s.ssl != 0 {
-				unsafe { C.SSL_free(voidptr(s.ssl)) }
-			}
-			if s.sslctx != 0 {
-				C.SSL_CTX_free(s.sslctx)
-			}
-			return error('net.openssl Could not connect using SSL. (${err_res}),err')
 		}
-		C.SSL_free(voidptr(s.ssl))
+
+		// Always free SSL object first.
+		if s.ssl != unsafe { nil } {
+			unsafe { C.SSL_free(voidptr(s.ssl)) }
+			s.ssl = unsafe { nil }
+		}
 	}
-	if s.sslctx != 0 {
+
+	if s.sslctx != unsafe { nil } {
 		C.SSL_CTX_free(s.sslctx)
+		s.sslctx = unsafe { nil }
 	}
+
 	if s.owns_socket {
 		net.shutdown(s.handle)
 		net.close(s.handle)!

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -103,6 +103,10 @@ pub fn (mut s SSLConn) shutdown() ! {
 		mut shutdown_done := false
 
 		for !shutdown_done {
+			// Clear the thread's OpenSSL error queue so ssl_error()/SSL_get_error()
+			// below reflect only this call and not a stale entry from an earlier
+			// operation, which could be misread as a fatal SSL_ERROR_SSL.
+			C.ERR_clear_error()
 			res := C.SSL_shutdown(voidptr(s.ssl))
 			if res == 1 {
 				shutdown_done = true
@@ -288,6 +292,8 @@ fn (mut s SSLConn) complete_connect() ! {
 
 	deadline := ssl_timeout_deadline(s.duration)
 	for {
+		// Clear the error queue so SSL_get_error() reflects only this call.
+		C.ERR_clear_error()
 		mut res := C.SSL_connect(voidptr(s.ssl))
 		if res == 1 {
 			break
@@ -308,6 +314,8 @@ fn (mut s SSLConn) complete_connect() ! {
 	if s.config.validate {
 		mut pcert := &C.X509(unsafe { nil })
 		for {
+			// Clear the error queue so SSL_get_error() reflects only this call.
+			C.ERR_clear_error()
 			mut res := C.SSL_do_handshake(voidptr(s.ssl))
 			if res == 1 {
 				break
@@ -370,6 +378,8 @@ pub fn (mut s SSLConn) socket_read_into_ptr(buf_ptr &u8, len int) !int {
 	deadline := ssl_timeout_deadline(s.duration)
 	// s.wait_for_read(deadline - time.now())!
 	for {
+		// Clear the error queue so SSL_get_error() reflects only this call.
+		C.ERR_clear_error()
 		res = C.SSL_read(voidptr(s.ssl), buf_ptr, len)
 		if res > 0 {
 			return res
@@ -440,6 +450,8 @@ pub fn (mut s SSLConn) write_ptr(bytes &u8, len int) !int {
 		for total_sent < len {
 			ptr := ptr_base + total_sent
 			remaining := len - total_sent
+			// Clear the error queue so SSL_get_error() reflects only this call.
+			C.ERR_clear_error()
 			mut sent := C.SSL_write(voidptr(s.ssl), ptr, remaining)
 			if sent <= 0 {
 				// SSL_write did not fully complete: OpenSSL may already have

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -108,11 +108,14 @@ pub fn (mut s SSLConn) shutdown() ! {
 				shutdown_done = true
 				break
 			}
-			if res == 0 {
-				// Second SSL_shutdown() needed for full bidirectional shutdown.
-				continue
-			}
 
+			// res == 0 means our close_notify was sent, but the peer's has not
+			// been received yet, so another SSL_shutdown() call is needed to
+			// finish the bidirectional shutdown; res < 0 signals an error or a
+			// retryable condition. In both cases SSL_get_error() tells us whether
+			// the socket must first become readable/writable before retrying.
+			// Routing res == 0 through ssl_error() instead of looping immediately
+			// avoids busy-spinning on non-blocking sockets.
 			err_res := ssl_error(res, s.ssl) or { break }
 
 			match err_res {


### PR DESCRIPTION
The issue can be reliably reproduced by configuring a SOCKS5 proxy server, as follows:

```c
#0  X509_VERIFY_PARAM_free (param=0xfeff) at ../crypto/x509/x509_vpm.c:100
#1  0x00007ffff7da37fc in SSL_CTX_free (a=0x555555626a00) at ../ssl/ssl_lib.c:4405
#2  0x00007ffff7da4aed in SSL_free (s=0x55555562dfb0) at ../ssl/ssl_lib.c:1446
#3  0x000055555558b144 in net__openssl__SSLConn_shutdown ()
#4  0x00005555555966b1 in net__http__HttpProxy_http_do ()
#5  0x0000555555598b08 in net__http__Request_method_and_url_to_response ()
#6  0x0000555555594b06 in net__http__Request_do ()
#7  0x00005555555947e4 in net.http.fetch ()
#8  0x000055555559bfb9 in main.main ()
#9  0x000055555559c997 in main ()
```

```v
import net.http
import rand
import time

proxy_user := rand.string(16)
proxy_pass := rand.string(16)
proxy_url := 'socks5://${proxy_user}:${proxy_pass}@127.0.0.1:9050'

mut config := http.FetchConfig{
	url: 'https://vlang.io'
	proxy: http.new_http_proxy(proxy_url) or { panic(err) }
}

mut resp := http.Response{}
for {
	resp = http.fetch(config) or {
		println('Failed to fetch data from the server!')
		return
	}

	if resp.status_code != 200 {
		println('Bad status code: ${resp.status_code}\n')
		time.sleep(time.second * 10)
		continue
	}

	break
}
```