### PR TITLE
builtin: add closure lifetime reclamation

### DIFF
--- a/vlib/builtin/closure/closure.c.v
+++ b/vlib/builtin/closure/closure.c.v
@@ -15,6 +15,12 @@ mut:
 	exec_page_start voidptr
 }
 
+struct ClosureLiveInfo {
+mut:
+	ctx       voidptr
+	owns_data bool
+}
+
 @[heap]
 struct Closure {
 	ClosureMutex
@@ -25,6 +31,7 @@ mut:
 	free_closure_ptr voidptr
 	pages            &ClosurePage = unsafe { nil }
 	v_page_size      int          = int(0x4000)
+	live             map[voidptr]ClosureLiveInfo
 }
 
 __global g_closure = Closure{}
@@ -295,6 +302,26 @@ fn closure_is_managed(exec_ptr voidptr) bool {
 	return false
 }
 
+fn closure_live_set(exec_ptr voidptr, data voidptr, owns_data bool) {
+	if isnil(data) {
+		return
+	}
+	g_closure.live[exec_ptr] = ClosureLiveInfo{
+		ctx:       data
+		owns_data: owns_data
+	}
+}
+
+fn closure_live_delete(exec_ptr voidptr) bool {
+	if info := g_closure.live[exec_ptr] {
+		owns_data := info.owns_data
+		g_closure.live[exec_ptr] = ClosureLiveInfo{}
+		g_closure.live.delete(exec_ptr)
+		return owns_data
+	}
+	return false
+}
+
 // closure_alloc allocates executable memory pages for closures(INTERNAL COMPILER USE ONLY).
 fn closure_alloc() {
 	p := closure_alloc_platform()
@@ -324,6 +351,7 @@ fn closure_init() {
 	// Determine system page size
 	mut page_size := get_page_size_platform()
 	g_closure.v_page_size = page_size // Store calculated size
+	g_closure.live = map[voidptr]ClosureLiveInfo{}
 
 	// Initialize thread-safety lock
 	closure_mtx_lock_init_platform()
@@ -360,8 +388,13 @@ fn closure_init() {
 }
 
 // closure_create creates closure objects at compile-time(INTERNAL COMPILER USE ONLY).
-@[direct_array_access]
 fn closure_create(func voidptr, data voidptr) voidptr {
+	return closure_create_with_data(func, data, true)
+}
+
+// closure_create_with_data creates closure objects with explicit context ownership(INTERNAL COMPILER USE ONLY).
+@[direct_array_access]
+fn closure_create_with_data(func voidptr, data voidptr, owns_data bool) voidptr {
 	closure_mtx_lock_platform()
 
 	mut curr_closure := g_closure.free_closure_ptr
@@ -402,6 +435,7 @@ fn closure_create(func voidptr, data voidptr) voidptr {
 			p[1] = func // Target function to execute
 		}
 	}
+	closure_live_set(curr_closure, data, owns_data)
 	closure_mtx_unlock_platform()
 
 	// Return executable closure object
@@ -421,7 +455,7 @@ fn closure_data(closure voidptr) voidptr {
 	}
 }
 
-// closure_try_destroy frees a managed closure slot and its context when the closure is known to be temporary.
+// closure_try_destroy frees a managed closure slot and its owned context when the closure is known to be temporary.
 @[direct_array_access]
 fn closure_try_destroy(closure voidptr) {
 	if isnil(closure) {
@@ -441,7 +475,8 @@ fn closure_try_destroy(closure voidptr) {
 		} else {
 			data = p[0]
 		}
-		if !isnil(data) {
+		owns_data := closure_live_delete(exec_ptr)
+		if owns_data && !isnil(data) {
 			free(data)
 		}
 		p[0] = g_closure.free_closure_ptr

--- a/vlib/builtin/closure/closure.c.v
+++ b/vlib/builtin/closure/closure.c.v
@@ -9,6 +9,8 @@ const ppc64_architecture = int(11)
 
 type ClosureGetDataFn = fn () voidptr
 
+type ClosureInitFn = fn ()
+
 struct ClosurePage {
 mut:
 	next            &ClosurePage = unsafe { nil }
@@ -17,21 +19,71 @@ mut:
 
 struct ClosureLiveInfo {
 mut:
-	ctx       voidptr
-	owns_data bool
+	ctx        voidptr
+	owns_data  bool
+	generation u64
+}
+
+struct ClosureLifetimeRecord {
+mut:
+	exec_ptr   voidptr
+	generation u64
+}
+
+struct ClosureLifetimeFrame {
+mut:
+	start int
+	end   int
+}
+
+@[heap]
+struct ClosureLifetimeState {
+mut:
+	owner_thread     u64
+	active           bool
+	disposed         bool
+	suspended        int
+	frame_start      int
+	frame_gen        u64
+	generation       u64
+	frame_generation u64
+	records          []ClosureLifetimeRecord
+	frames           []ClosureLifetimeFrame
+	next_free        &ClosureLifetimeState = unsafe { nil }
+}
+
+// Lifetime owns a set of tracked closure callbacks that can be reclaimed together.
+pub struct Lifetime {
+mut:
+	state      &ClosureLifetimeState = unsafe { nil }
+	generation u64
+	disposed   bool
+}
+
+struct FrameToken {
+mut:
+	state            &ClosureLifetimeState = unsafe { nil }
+	thread_id        u64
+	state_generation u64
+	generation       u64
 }
 
 @[heap]
 struct Closure {
 	ClosureMutex
 mut:
-	closure_ptr      voidptr
-	closure_get_data ClosureGetDataFn = unsafe { nil }
-	closure_cap      int
-	free_closure_ptr voidptr
-	pages            &ClosurePage = unsafe { nil }
-	v_page_size      int          = int(0x4000)
-	live             map[voidptr]ClosureLiveInfo
+	closure_ptr              voidptr
+	closure_get_data         ClosureGetDataFn = unsafe { nil }
+	closure_cap              int
+	free_closure_ptr         voidptr
+	pages                    &ClosurePage = unsafe { nil }
+	v_page_size              int          = int(0x4000)
+	live                     map[voidptr]ClosureLiveInfo
+	active_lifetimes         map[u64]&ClosureLifetimeState
+	next_generation          u64
+	free_lifetime_states     &ClosureLifetimeState = unsafe { nil }
+	next_lifetime_generation u64
+	lifetime_state_allocs    u64
 }
 
 __global g_closure = Closure{}
@@ -303,23 +355,363 @@ fn closure_is_managed(exec_ptr voidptr) bool {
 }
 
 fn closure_live_set(exec_ptr voidptr, data voidptr, owns_data bool) {
-	if isnil(data) {
-		return
-	}
+	g_closure.next_generation++
 	g_closure.live[exec_ptr] = ClosureLiveInfo{
-		ctx:       data
-		owns_data: owns_data
+		ctx:        data
+		owns_data:  owns_data
+		generation: g_closure.next_generation
 	}
 }
 
-fn closure_live_delete(exec_ptr voidptr) bool {
+fn closure_live_delete(exec_ptr voidptr) ClosureLiveInfo {
 	if info := g_closure.live[exec_ptr] {
-		owns_data := info.owns_data
 		g_closure.live[exec_ptr] = ClosureLiveInfo{}
 		g_closure.live.delete(exec_ptr)
-		return owns_data
+		return info
 	}
-	return false
+	return ClosureLiveInfo{}
+}
+
+fn new_closure_lifetime_state_no_lock() &ClosureLifetimeState {
+	mut state := g_closure.free_lifetime_states
+	if !isnil(state) {
+		g_closure.free_lifetime_states = state.next_free
+	} else {
+		unsafe {
+			state = &ClosureLifetimeState(malloc(sizeof(ClosureLifetimeState)))
+		}
+		g_closure.lifetime_state_allocs++
+	}
+	g_closure.next_lifetime_generation++
+	unsafe {
+		*state = ClosureLifetimeState{
+			owner_thread: closure_current_thread_id_platform()
+			generation:   g_closure.next_lifetime_generation
+		}
+	}
+	return state
+}
+
+fn new_closure_lifetime_state() &ClosureLifetimeState {
+	closure_mtx_lock_platform()
+	state := new_closure_lifetime_state_no_lock()
+	closure_mtx_unlock_platform()
+	return state
+}
+
+fn closure_lifetime_recycle_state_no_lock(mut state &ClosureLifetimeState) {
+	state.disposed = true
+	state.active = false
+	state.suspended = 0
+	state.frame_start = 0
+	state.frame_gen = 0
+	state.frame_generation = 0
+	unsafe {
+		state.records.free()
+		state.frames.free()
+	}
+	state.records = []ClosureLifetimeRecord{}
+	state.frames = []ClosureLifetimeFrame{}
+	state.next_free = g_closure.free_lifetime_states
+	g_closure.free_lifetime_states = state
+}
+
+fn closure_lifetime_error(state &ClosureLifetimeState, generation u64, thread_id u64) string {
+	if state.disposed || state.generation != generation {
+		return 'closure lifetime used after dispose'
+	}
+	if state.owner_thread != thread_id {
+		return 'closure lifetime used from a different thread'
+	}
+	return ''
+}
+
+fn (mut lifetime Lifetime) ensure_state() !&ClosureLifetimeState {
+	closure_ensure_initialized()
+	if isnil(lifetime.state) {
+		if lifetime.disposed {
+			return error('closure lifetime used after dispose')
+		}
+		lifetime.state = new_closure_lifetime_state()
+		lifetime.generation = lifetime.state.generation
+		return lifetime.state
+	}
+	closure_mtx_lock_platform()
+	state := lifetime.state
+	if lifetime.disposed || state.disposed || state.generation != lifetime.generation {
+		closure_mtx_unlock_platform()
+		return error('closure lifetime used after dispose')
+	}
+	closure_mtx_unlock_platform()
+	return state
+}
+
+fn closure_lifetime_track_no_lock(exec_ptr voidptr) {
+	thread_id := closure_current_thread_id_platform()
+	mut state := g_closure.active_lifetimes[thread_id] or { return }
+	if state.suspended > 0 {
+		return
+	}
+	info := g_closure.live[exec_ptr] or { return }
+	state.records << ClosureLifetimeRecord{
+		exec_ptr:   exec_ptr
+		generation: info.generation
+	}
+}
+
+@[direct_array_access]
+fn closure_slot_data(exec_ptr voidptr) voidptr {
+	unsafe {
+		mut p := closure_slot_meta(exec_ptr)
+		if is_ppc64() {
+			return p[2]
+		}
+		return p[0]
+	}
+}
+
+@[direct_array_access]
+fn closure_release_no_lock(exec_ptr voidptr, generation u64) bool {
+	if !closure_is_managed(exec_ptr) {
+		return false
+	}
+	info := g_closure.live[exec_ptr] or { return false }
+	if generation != 0 && info.generation != generation {
+		return false
+	}
+	data := closure_slot_data(exec_ptr)
+	_ := closure_live_delete(exec_ptr)
+	if info.owns_data && !isnil(data) {
+		unsafe { free(data) }
+	}
+	unsafe {
+		mut p := closure_slot_meta(exec_ptr)
+		p[0] = g_closure.free_closure_ptr
+		if is_ppc64() {
+			p[1] = nil
+			p[2] = nil
+			p[3] = nil
+		} else {
+			p[1] = nil
+		}
+		g_closure.free_closure_ptr = exec_ptr
+	}
+	return true
+}
+
+fn closure_lifetime_release_records_no_lock(records []ClosureLifetimeRecord, start int, end int) {
+	for i in start .. end {
+		record := records[i]
+		closure_release_no_lock(record.exec_ptr, record.generation)
+	}
+}
+
+fn closure_lifetime_reclaim_no_lock(mut state ClosureLifetimeState, retain int) {
+	keep := if retain < 0 { 0 } else { retain }
+	if state.frames.len <= keep {
+		return
+	}
+	reclaim_count := state.frames.len - keep
+	mut cutoff := 0
+	for i in 0 .. reclaim_count {
+		frame := state.frames[i]
+		closure_lifetime_release_records_no_lock(state.records, frame.start, frame.end)
+		cutoff = frame.end
+	}
+	state.frames.delete_many(0, reclaim_count)
+	if cutoff > 0 {
+		state.records.delete_many(0, cutoff)
+		for mut frame in state.frames {
+			frame.start -= cutoff
+			frame.end -= cutoff
+		}
+	}
+}
+
+fn closure_ensure_initialized() {
+	closure_init_once_platform()
+}
+
+// new_lifetime creates a lifetime object for tracking closure callbacks created inside frames.
+pub fn new_lifetime() Lifetime {
+	closure_ensure_initialized()
+	state := new_closure_lifetime_state()
+	return Lifetime{
+		state:      state
+		generation: state.generation
+	}
+}
+
+// lifetime_state_allocs writes the number of allocated closure lifetime bookkeeping states to out.
+@[if track_heap ?]
+pub fn lifetime_state_allocs(out &u64) {
+	closure_ensure_initialized()
+	closure_mtx_lock_platform()
+	unsafe {
+		*out = g_closure.lifetime_state_allocs
+	}
+	closure_mtx_unlock_platform()
+}
+
+fn (mut lifetime Lifetime) begin_frame() !FrameToken {
+	mut state := lifetime.ensure_state()!
+	thread_id := closure_current_thread_id_platform()
+	closure_mtx_lock_platform()
+	err := closure_lifetime_error(state, lifetime.generation, thread_id)
+	if err != '' {
+		closure_mtx_unlock_platform()
+		return error(err)
+	}
+	if state.active {
+		closure_mtx_unlock_platform()
+		return error('closure lifetime frames can not be nested')
+	}
+	if state.suspended > 0 {
+		closure_mtx_unlock_platform()
+		return error('closure lifetime frame while suspended')
+	}
+	if _ := g_closure.active_lifetimes[thread_id] {
+		closure_mtx_unlock_platform()
+		return error('another closure lifetime is already active on this thread')
+	}
+	state.frame_generation++
+	state.active = true
+	state.frame_start = state.records.len
+	state.frame_gen = state.frame_generation
+	g_closure.active_lifetimes[thread_id] = state
+	closure_mtx_unlock_platform()
+	return FrameToken{
+		state:            state
+		thread_id:        thread_id
+		state_generation: lifetime.generation
+		generation:       state.frame_generation
+	}
+}
+
+fn (mut lifetime Lifetime) end_frame(token FrameToken) ! {
+	if isnil(token.state) {
+		return error('invalid closure lifetime frame token')
+	}
+	mut state := token.state
+	thread_id := closure_current_thread_id_platform()
+	closure_mtx_lock_platform()
+	err := closure_lifetime_error(state, token.state_generation, thread_id)
+	if err != '' {
+		closure_mtx_unlock_platform()
+		return error(err)
+	}
+	if token.thread_id != thread_id || token.generation != state.frame_gen || !state.active {
+		closure_mtx_unlock_platform()
+		return error('invalid closure lifetime frame token')
+	}
+	state.frames << ClosureLifetimeFrame{
+		start: state.frame_start
+		end:   state.records.len
+	}
+	state.active = false
+	state.frame_start = 0
+	state.frame_gen = 0
+	g_closure.active_lifetimes[thread_id] = unsafe { nil }
+	g_closure.active_lifetimes.delete(thread_id)
+	closure_mtx_unlock_platform()
+}
+
+// frame runs work while tracking closure callbacks created by that work in this lifetime.
+// The work callback itself is borrowed; only closures allocated while the frame is active
+// are owned by the lifetime and later released by reclaim or dispose.
+pub fn (mut lifetime Lifetime) frame(work fn ()) ! {
+	token := lifetime.begin_frame()!
+	mut ended := false
+	defer {
+		if !ended {
+			lifetime.end_frame(token) or {}
+		}
+	}
+	// Terminal panic can abort before scoped cleanup runs.
+	work()
+	lifetime.end_frame(token)!
+	ended = true
+}
+
+// reclaim releases tracked closure callbacks from old frames while retaining the newest retain frames.
+pub fn (mut lifetime Lifetime) reclaim(retain int) ! {
+	mut state := lifetime.ensure_state()!
+	thread_id := closure_current_thread_id_platform()
+	closure_mtx_lock_platform()
+	err := closure_lifetime_error(state, lifetime.generation, thread_id)
+	if err != '' {
+		closure_mtx_unlock_platform()
+		return error(err)
+	}
+	if state.active {
+		closure_mtx_unlock_platform()
+		return error('closure lifetime reclaim while a frame is active')
+	}
+	closure_lifetime_reclaim_no_lock(mut state, retain)
+	closure_mtx_unlock_platform()
+}
+
+// reclaim_all releases all tracked closure callbacks owned by this lifetime.
+pub fn (mut lifetime Lifetime) reclaim_all() ! {
+	lifetime.reclaim(0)!
+}
+
+// dispose releases all tracked closure callbacks and invalidates this lifetime.
+pub fn (mut lifetime Lifetime) dispose() ! {
+	mut state := lifetime.ensure_state()!
+	thread_id := closure_current_thread_id_platform()
+	closure_mtx_lock_platform()
+	err := closure_lifetime_error(state, lifetime.generation, thread_id)
+	if err != '' {
+		closure_mtx_unlock_platform()
+		return error(err)
+	}
+	if state.active {
+		closure_mtx_unlock_platform()
+		return error('closure lifetime dispose while a frame is active')
+	}
+	if state.suspended > 0 {
+		closure_mtx_unlock_platform()
+		return error('closure lifetime dispose while suspended')
+	}
+	closure_lifetime_reclaim_no_lock(mut state, 0)
+	lifetime.state = unsafe { nil }
+	lifetime.disposed = true
+	closure_lifetime_recycle_state_no_lock(mut state)
+	closure_mtx_unlock_platform()
+}
+
+// suspend runs work without tracking closure callbacks in the active frame of this lifetime.
+// The work callback is borrowed and is not owned or released by the lifetime.
+pub fn (mut lifetime Lifetime) suspend(work fn ()) ! {
+	mut state := lifetime.ensure_state()!
+	thread_id := closure_current_thread_id_platform()
+	closure_mtx_lock_platform()
+	err := closure_lifetime_error(state, lifetime.generation, thread_id)
+	if err != '' {
+		closure_mtx_unlock_platform()
+		return error(err)
+	}
+	if active := g_closure.active_lifetimes[thread_id] {
+		if active != state {
+			closure_mtx_unlock_platform()
+			return error('another closure lifetime is already active on this thread')
+		}
+	}
+	state.suspended++
+	closure_mtx_unlock_platform()
+	defer {
+		closure_mtx_lock_platform()
+		state.suspended--
+		closure_mtx_unlock_platform()
+	}
+	work()
+}
+
+// untracked runs work without tracking closure callbacks in this lifetime.
+// The work callback is borrowed and is not owned or released by the lifetime.
+pub fn (mut lifetime Lifetime) untracked(work fn ()) ! {
+	lifetime.suspend(work)!
 }
 
 // closure_alloc allocates executable memory pages for closures(INTERNAL COMPILER USE ONLY).
@@ -348,10 +740,19 @@ fn closure_alloc() {
 
 // closure_init initializes global closure subsystem(INTERNAL COMPILER USE ONLY).
 fn closure_init() {
+	closure_ensure_initialized()
+}
+
+fn closure_init_body() {
 	// Determine system page size
 	mut page_size := get_page_size_platform()
 	g_closure.v_page_size = page_size // Store calculated size
 	g_closure.live = map[voidptr]ClosureLiveInfo{}
+	g_closure.active_lifetimes = map[u64]&ClosureLifetimeState{}
+	g_closure.next_generation = 0
+	g_closure.free_lifetime_states = unsafe { nil }
+	g_closure.next_lifetime_generation = 0
+	g_closure.lifetime_state_allocs = 0
 
 	// Initialize thread-safety lock
 	closure_mtx_lock_init_platform()
@@ -395,6 +796,7 @@ fn closure_create(func voidptr, data voidptr) voidptr {
 // closure_create_with_data creates closure objects with explicit context ownership(INTERNAL COMPILER USE ONLY).
 @[direct_array_access]
 fn closure_create_with_data(func voidptr, data voidptr, owns_data bool) voidptr {
+	closure_ensure_initialized()
 	closure_mtx_lock_platform()
 
 	mut curr_closure := g_closure.free_closure_ptr
@@ -436,6 +838,7 @@ fn closure_create_with_data(func voidptr, data voidptr, owns_data bool) voidptr 
 		}
 	}
 	closure_live_set(curr_closure, data, owns_data)
+	closure_lifetime_track_no_lock(curr_closure)
 	closure_mtx_unlock_platform()
 
 	// Return executable closure object
@@ -455,39 +858,15 @@ fn closure_data(closure voidptr) voidptr {
 	}
 }
 
-// closure_try_destroy frees a managed closure slot and its owned context when the closure is known to be temporary.
+// Legacy compiler hook for one-shot local cleanup. Scoped lifetime reclaim uses generation checks.
 @[direct_array_access]
 fn closure_try_destroy(closure voidptr) {
 	if isnil(closure) {
 		return
 	}
+	closure_ensure_initialized()
 	exec_ptr := closure_exec_ptr(closure)
 	closure_mtx_lock_platform()
-	if !closure_is_managed(exec_ptr) {
-		closure_mtx_unlock_platform()
-		return
-	}
-	unsafe {
-		mut p := closure_slot_meta(exec_ptr)
-		mut data := nil
-		if is_ppc64() {
-			data = p[2]
-		} else {
-			data = p[0]
-		}
-		owns_data := closure_live_delete(exec_ptr)
-		if owns_data && !isnil(data) {
-			free(data)
-		}
-		p[0] = g_closure.free_closure_ptr
-		if is_ppc64() {
-			p[1] = nil
-			p[2] = nil
-			p[3] = nil
-		} else {
-			p[1] = nil
-		}
-		g_closure.free_closure_ptr = exec_ptr
-	}
+	closure_release_no_lock(exec_ptr, 0)
 	closure_mtx_unlock_platform()
 }

--- a/vlib/builtin/closure/closure_nix.c.v
+++ b/vlib/builtin/closure/closure_nix.c.v
@@ -2,13 +2,18 @@ module closure
 
 $if !freestanding && !vinix {
 	#include <sys/mman.h>
+	#insert "@VEXEROOT/vlib/builtin/closure/closure_once_nix.h"
+
+	fn C.v_closure_init_once(ClosureInitFn)
 }
 
-@[typedef]
-pub struct C.pthread_mutex_t {}
-
 struct ClosureMutex {
-	closure_mtx C.pthread_mutex_t
+	closure_mtx [128]u8
+}
+
+@[inline]
+fn closure_mtx_ptr_platform() voidptr {
+	return unsafe { voidptr(&g_closure.closure_mtx[0]) }
 }
 
 @[inline]
@@ -65,20 +70,39 @@ fn get_page_size_platform() int {
 @[inline]
 fn closure_mtx_lock_init_platform() {
 	$if !freestanding || vinix {
-		C.pthread_mutex_init(&g_closure.closure_mtx, 0)
+		C.pthread_mutex_init(closure_mtx_ptr_platform(), 0)
 	}
 }
 
 @[inline]
 fn closure_mtx_lock_platform() {
 	$if !freestanding || vinix {
-		C.pthread_mutex_lock(&g_closure.closure_mtx)
+		C.pthread_mutex_lock(closure_mtx_ptr_platform())
 	}
 }
 
 @[inline]
 fn closure_mtx_unlock_platform() {
 	$if !freestanding || vinix {
-		C.pthread_mutex_unlock(&g_closure.closure_mtx)
+		C.pthread_mutex_unlock(closure_mtx_ptr_platform())
+	}
+}
+
+@[inline]
+fn closure_current_thread_id_platform() u64 {
+	$if !freestanding {
+		return u64(C.pthread_self())
+	}
+	return u64(0)
+}
+
+@[inline]
+fn closure_init_once_platform() {
+	$if freestanding || vinix {
+		if isnil(g_closure.closure_ptr) {
+			closure_init_body()
+		}
+	} $else {
+		C.v_closure_init_once(closure_init_body)
 	}
 }

--- a/vlib/builtin/closure/closure_once_nix.h
+++ b/vlib/builtin/closure/closure_once_nix.h
@@ -1,0 +1,28 @@
+#ifndef V_CLOSURE_ONCE_NIX_H
+#define V_CLOSURE_ONCE_NIX_H
+
+#include <pthread.h>
+
+typedef void (*v_closure_init_fn)(void);
+
+#ifndef V_CLOSURE_STATIC_INLINE
+# ifdef _MSC_VER
+#  define V_CLOSURE_STATIC_INLINE static __inline
+# else
+#  define V_CLOSURE_STATIC_INLINE static inline
+# endif
+#endif
+
+static pthread_mutex_t v_closure_once_mutex = PTHREAD_MUTEX_INITIALIZER;
+static int v_closure_once_done = 0;
+
+V_CLOSURE_STATIC_INLINE void v_closure_init_once(v_closure_init_fn init_fn) {
+	pthread_mutex_lock(&v_closure_once_mutex);
+	if (!v_closure_once_done) {
+		init_fn();
+		v_closure_once_done = 1;
+	}
+	pthread_mutex_unlock(&v_closure_once_mutex);
+}
+
+#endif

--- a/vlib/builtin/closure/closure_once_windows.h
+++ b/vlib/builtin/closure/closure_once_windows.h
@@ -1,0 +1,28 @@
+#ifndef V_CLOSURE_ONCE_WINDOWS_H
+#define V_CLOSURE_ONCE_WINDOWS_H
+
+#include <windows.h>
+
+typedef void (*v_closure_init_fn)(void);
+
+#ifndef V_CLOSURE_STATIC_INLINE
+# ifdef _MSC_VER
+#  define V_CLOSURE_STATIC_INLINE static __inline
+# else
+#  define V_CLOSURE_STATIC_INLINE static inline
+# endif
+#endif
+
+static SRWLOCK v_closure_once_lock;
+static int v_closure_once_done = 0;
+
+V_CLOSURE_STATIC_INLINE void v_closure_init_once(v_closure_init_fn init_fn) {
+	AcquireSRWLockExclusive(&v_closure_once_lock);
+	if (!v_closure_once_done) {
+		init_fn();
+		v_closure_once_done = 1;
+	}
+	ReleaseSRWLockExclusive(&v_closure_once_lock);
+}
+
+#endif

--- a/vlib/builtin/closure/closure_windows.c.v
+++ b/vlib/builtin/closure/closure_windows.c.v
@@ -1,6 +1,9 @@
 module closure
 
 #include <synchapi.h>
+#insert "@VEXEROOT/vlib/builtin/closure/closure_once_windows.h"
+
+fn C.v_closure_init_once(ClosureInitFn)
 
 struct ClosureMutex {
 	closure_mtx C.SRWLOCK
@@ -50,4 +53,14 @@ fn closure_mtx_lock_platform() {
 @[inline]
 fn closure_mtx_unlock_platform() {
 	C.ReleaseSRWLockExclusive(&g_closure.closure_mtx)
+}
+
+@[inline]
+fn closure_current_thread_id_platform() u64 {
+	return u64(C.GetCurrentThreadId())
+}
+
+@[inline]
+fn closure_init_once_platform() {
+	C.v_closure_init_once(closure_init_body)
 }

--- a/vlib/v/gen/c/autofree.v
+++ b/vlib/v/gen/c/autofree.v
@@ -300,24 +300,69 @@ fn (mut g Gen) detect_used_var_on_return(expr ast.Expr) {
 	}
 }
 
-fn collect_returned_var_names(expr ast.Expr, mut names map[string]bool) {
+fn selector_root_name(expr ast.SelectorExpr) ?string {
+	mut root_expr := expr.expr
+	for root_expr is ast.SelectorExpr {
+		root_expr = root_expr.expr
+	}
+	if root_expr is ast.Ident {
+		return root_expr.name
+	}
+	return none
+}
+
+fn (mut g Gen) selector_return_preserves_owner(expr ast.SelectorExpr) bool {
+	if expr.typ == 0 {
+		return false
+	}
+	if expr.typ.is_any_kind_of_pointer() {
+		return true
+	}
+	base_typ := expr.typ.set_nr_muls(0).clear_option_and_result()
+	if base_typ == 0 || g.type_has_unresolved_generic_parts(base_typ) {
+		return false
+	}
+	unwrapped_typ := g.unwrap_generic(base_typ)
+	sym := g.table.sym(unwrapped_typ)
+	if sym.has_method('free') {
+		return true
+	}
+	unaliased_typ :=
+		g.table.fully_unaliased_type(unwrapped_typ).set_nr_muls(0).clear_option_and_result()
+	if unaliased_typ == 0 || g.type_has_unresolved_generic_parts(unaliased_typ) {
+		return false
+	}
+	final_sym := g.table.final_sym(unaliased_typ)
+	return final_sym.kind in [.array, .map, .string, .struct, .sum_type, .interface]
+		|| final_sym.has_method('free')
+}
+
+fn (mut g Gen) collect_returned_var_names(expr ast.Expr, mut names map[string]bool, mut selector_owner_names map[string]bool) {
 	match expr {
 		ast.Ident {
 			names[expr.name] = true
 		}
+		ast.SelectorExpr {
+			if g.selector_return_preserves_owner(expr) {
+				if root_name := selector_root_name(expr) {
+					selector_owner_names[root_name] = true
+				}
+			}
+		}
 		ast.StructInit {
 			for field_expr in expr.init_fields {
-				collect_returned_var_names(field_expr.expr, mut names)
+				g.collect_returned_var_names(field_expr.expr, mut names, mut selector_owner_names)
 			}
 		}
 		else {}
 	}
 }
 
-fn returned_var_names_from_return(node ast.Return) map[string]bool {
+fn (mut g Gen) returned_var_names_from_return(node ast.Return) (map[string]bool, map[string]bool) {
 	mut names := map[string]bool{}
+	mut selector_owner_names := map[string]bool{}
 	for expr in node.exprs {
-		collect_returned_var_names(expr, mut names)
+		g.collect_returned_var_names(expr, mut names, mut selector_owner_names)
 	}
-	return names
+	return names, selector_owner_names
 }

--- a/vlib/v/gen/c/autofree.v
+++ b/vlib/v/gen/c/autofree.v
@@ -88,6 +88,11 @@ fn (mut g Gen) autofree_scope_vars2(scope &ast.Scope, start_pos int, end_pos int
 					g.trace_autofree('// skipping inherited var "${obj.name}"')
 					continue
 				}
+				if obj.name in g.for_c_init_autofree_keep_vars {
+					g.print_autofree_var(obj, 'ForC init')
+					g.trace_autofree('// skipping ForC init var "${obj.name}"')
+					continue
+				}
 				// if var.typ == 0 {
 				// // TODO: why 0?
 				// continue
@@ -293,4 +298,26 @@ fn (mut g Gen) detect_used_var_on_return(expr ast.Expr) {
 		}
 		else {}
 	}
+}
+
+fn collect_returned_var_names(expr ast.Expr, mut names map[string]bool) {
+	match expr {
+		ast.Ident {
+			names[expr.name] = true
+		}
+		ast.StructInit {
+			for field_expr in expr.init_fields {
+				collect_returned_var_names(field_expr.expr, mut names)
+			}
+		}
+		else {}
+	}
+}
+
+fn returned_var_names_from_return(node ast.Return) map[string]bool {
+	mut names := map[string]bool{}
+	for expr in node.exprs {
+		collect_returned_var_names(expr, mut names)
+	}
+	return names
 }

--- a/vlib/v/gen/c/autofree_labeled_continue_boehm_leak_test.v
+++ b/vlib/v/gen/c/autofree_labeled_continue_boehm_leak_test.v
@@ -1,0 +1,28 @@
+import os
+
+const vroot = os.dir(@VEXE)
+const test_vexe = os.quoted_path(@VEXE)
+const testdata_file = os.join_path(vroot,
+	'vlib/v/gen/c/testdata/autofree_labeled_continue_boehm_leak.vv')
+
+fn missing_boehm_leak_lib(output string) bool {
+	return output.contains('ld: cannot find -lgc') || output.contains('library not found for -lgc')
+		|| output.contains('gc/gc.h') || output.contains('bdw-gc')
+}
+
+fn test_autofree_labeled_continue_boehm_leak_cleanup() {
+	mut exe_path := os.join_path(os.vtmp_dir(), 'autofree_labeled_continue_boehm_leak')
+	$if windows {
+		exe_path += '.exe'
+	}
+	cmd := '${test_vexe} -autofree -gc boehm_leak -o ${os.quoted_path(exe_path)} ${os.quoted_path(testdata_file)}'
+	res := os.execute(cmd)
+	if res.exit_code != 0 && missing_boehm_leak_lib(res.output) {
+		eprintln('skipping boehm_leak labeled continue cleanup test: missing libgc')
+		return
+	}
+	assert res.exit_code == 0, '${cmd}\n${res.output}'
+	run_res := os.execute(os.quoted_path(exe_path))
+	assert run_res.exit_code == 0, run_res.output
+	os.rm(exe_path) or {}
+}

--- a/vlib/v/gen/c/autofree_labeled_continue_codegen_test.v
+++ b/vlib/v/gen/c/autofree_labeled_continue_codegen_test.v
@@ -1,0 +1,97 @@
+import os
+
+const vroot = os.dir(@VEXE)
+const test_vexe = os.quoted_path(@VEXE)
+const autofree_labeled_continue_testdata = os.join_path(vroot,
+	'vlib/v/tests/autofree_labeled_continue_scope_test.v')
+
+fn function_window(source string, signature string) string {
+	start := source.index(signature) or { return '' }
+	mut depth := 0
+	for i := start; i < source.len; i++ {
+		if source[i] == `{` {
+			depth++
+		} else if source[i] == `}` {
+			depth--
+			if depth == 0 {
+				return source[start..i + 1]
+			}
+		}
+	}
+	return source[start..]
+}
+
+fn test_labeled_loop_cleanup_codegen_order() {
+	cmd := '${test_vexe} -autofree -o - ${os.quoted_path(autofree_labeled_continue_testdata)}'
+	res := os.execute(cmd)
+	assert res.exit_code == 0, '${cmd}\n${res.output}'
+	generated := res.output
+
+	fallthrough_fn := function_window(generated,
+		'void main__labeled_fallthrough_cleanup_order(void) {')
+	inner_free_pos := fallthrough_fn.index('main__Tracked_free(&inner);') or {
+		assert false, fallthrough_fn
+		return
+	}
+	after_inner := fallthrough_fn[inner_free_pos..]
+	defer_pos := after_inner.index('main__push_event(7 + target.id - 1);') or {
+		assert false, fallthrough_fn
+		return
+	}
+	free_pos := after_inner.index('main__Tracked_free(&target);') or {
+		assert false, fallthrough_fn
+		return
+	}
+	assert defer_pos < free_pos
+
+	break_fn := function_window(generated, 'void main__for_c_labeled_break(void) {')
+	break_label_pos := break_fn.index('outer__break: {}') or {
+		assert false, break_fn
+		return
+	}
+	init_free_pos := break_fn.index('main__Tracked_free(&init);') or {
+		assert false, break_fn
+		return
+	}
+	assert break_label_pos < init_free_pos
+
+	return_second_fn := function_window(generated,
+		'main__Tracked main__for_c_multi_init_return_second(void) {')
+	return_pos := return_second_fn.index('return ') or {
+		assert false, return_second_fn
+		return
+	}
+	body_free_pos := return_second_fn.index('main__Tracked_free(&body);') or {
+		assert false, return_second_fn
+		return
+	}
+	first_free_pos := return_second_fn.index('main__Tracked_free(&first);') or {
+		assert false, return_second_fn
+		return
+	}
+	assert body_free_pos < return_pos
+	assert first_free_pos < return_pos
+	if second_free_pos := return_second_fn.index('main__Tracked_free(&second);') {
+		assert return_pos < second_free_pos
+	}
+
+	branch_body_fn := function_window(generated,
+		'main__Tracked main__for_c_branch_return_body_after_init_path(bool cond) {')
+	body_decl_pos := branch_body_fn.index('main__Tracked body = main__tracked(5);') or {
+		assert false, branch_body_fn
+		return
+	}
+	body_return_path := branch_body_fn[body_decl_pos..]
+	branch_body_return_pos := body_return_path.index('return ') or {
+		assert false, branch_body_fn
+		return
+	}
+	branch_init_free_pos := body_return_path.index('main__Tracked_free(&init);') or {
+		assert false, branch_body_fn
+		return
+	}
+	assert branch_init_free_pos < branch_body_return_pos
+	if branch_body_free_pos := body_return_path.index('main__Tracked_free(&body);') {
+		assert branch_body_return_pos < branch_body_free_pos
+	}
+}

--- a/vlib/v/gen/c/autofree_labeled_continue_codegen_test.v
+++ b/vlib/v/gen/c/autofree_labeled_continue_codegen_test.v
@@ -44,6 +44,42 @@ fn test_labeled_loop_cleanup_codegen_order() {
 	}
 	assert defer_pos < free_pos
 
+	labeled_break_fn := function_window(generated, 'void main__labeled_break_cleanup_order(void) {')
+	labeled_break_goto_pos := labeled_break_fn.index('goto break_outer__break;') or {
+		assert false, labeled_break_fn
+		return
+	}
+	labeled_break_inner_defer_pos := labeled_break_fn.index('main__push_event(9);') or {
+		assert false, labeled_break_fn
+		return
+	}
+	labeled_break_inner_free_pos := labeled_break_fn.index('main__Tracked_free(&inner);') or {
+		assert false, labeled_break_fn
+		return
+	}
+	labeled_break_middle_defer_pos := labeled_break_fn.index('main__push_event(8);') or {
+		assert false, labeled_break_fn
+		return
+	}
+	labeled_break_middle_free_pos := labeled_break_fn.index('main__Tracked_free(&middle);') or {
+		assert false, labeled_break_fn
+		return
+	}
+	labeled_break_target_defer_pos := labeled_break_fn.index('main__push_event(7);') or {
+		assert false, labeled_break_fn
+		return
+	}
+	labeled_break_target_free_pos := labeled_break_fn.index('main__Tracked_free(&target);') or {
+		assert false, labeled_break_fn
+		return
+	}
+	assert labeled_break_inner_defer_pos < labeled_break_inner_free_pos
+	assert labeled_break_inner_free_pos < labeled_break_middle_defer_pos
+	assert labeled_break_middle_defer_pos < labeled_break_middle_free_pos
+	assert labeled_break_middle_free_pos < labeled_break_target_defer_pos
+	assert labeled_break_target_defer_pos < labeled_break_target_free_pos
+	assert labeled_break_target_free_pos < labeled_break_goto_pos
+
 	break_fn := function_window(generated, 'void main__for_c_labeled_break(void) {')
 	break_label_pos := break_fn.index('outer__break: {}') or {
 		assert false, break_fn
@@ -54,6 +90,56 @@ fn test_labeled_loop_cleanup_codegen_order() {
 		return
 	}
 	assert break_label_pos < init_free_pos
+
+	nested_continue_fn := function_window(generated,
+		'void main__for_c_nested_continue_outer_init_cleanup(void) {')
+	nested_continue_body_free_pos := nested_continue_fn.index('main__Tracked_free(&body);') or {
+		assert false, nested_continue_fn
+		return
+	}
+	nested_continue_inner_free_pos := nested_continue_fn.index('main__Tracked_free(&inner_init);') or {
+		assert false, nested_continue_fn
+		return
+	}
+	nested_continue_goto_pos := nested_continue_fn.index('goto outer__continue_entry;') or {
+		assert false, nested_continue_fn
+		return
+	}
+	nested_continue_after_goto := nested_continue_fn[nested_continue_goto_pos..]
+	nested_continue_before_goto := nested_continue_fn[..nested_continue_goto_pos]
+	nested_continue_outer_free_after_goto_pos := nested_continue_after_goto.index('main__Tracked_free(&outer_init);') or {
+		assert false, nested_continue_fn
+		return
+	}
+	assert nested_continue_body_free_pos < nested_continue_inner_free_pos
+	assert nested_continue_inner_free_pos < nested_continue_goto_pos
+	assert !nested_continue_before_goto.contains('main__Tracked_free(&outer_init);')
+	assert nested_continue_outer_free_after_goto_pos > 0
+
+	nested_break_fn := function_window(generated,
+		'void main__for_c_nested_break_outer_init_cleanup(void) {')
+	nested_break_body_free_pos := nested_break_fn.index('main__Tracked_free(&body);') or {
+		assert false, nested_break_fn
+		return
+	}
+	nested_break_inner_free_pos := nested_break_fn.index('main__Tracked_free(&inner_init);') or {
+		assert false, nested_break_fn
+		return
+	}
+	nested_break_goto_pos := nested_break_fn.index('goto break_outer__break;') or {
+		assert false, nested_break_fn
+		return
+	}
+	nested_break_after_goto := nested_break_fn[nested_break_goto_pos..]
+	nested_break_before_goto := nested_break_fn[..nested_break_goto_pos]
+	nested_break_outer_free_after_goto_pos := nested_break_after_goto.index('main__Tracked_free(&outer_init);') or {
+		assert false, nested_break_fn
+		return
+	}
+	assert nested_break_body_free_pos < nested_break_inner_free_pos
+	assert nested_break_inner_free_pos < nested_break_goto_pos
+	assert !nested_break_before_goto.contains('main__Tracked_free(&outer_init);')
+	assert nested_break_outer_free_after_goto_pos > 0
 
 	return_second_fn := function_window(generated,
 		'main__Tracked main__for_c_multi_init_return_second(void) {')
@@ -74,6 +160,39 @@ fn test_labeled_loop_cleanup_codegen_order() {
 	if second_free_pos := return_second_fn.index('main__Tracked_free(&second);') {
 		assert return_pos < second_free_pos
 	}
+
+	return_field_fn := function_window(generated,
+		'string main__for_c_return_init_field_string(void) {')
+	return_field_return_pos := return_field_fn.index('return ') or {
+		assert false, return_field_fn
+		return
+	}
+	return_field_return_path := return_field_fn[..return_field_return_pos]
+	assert !return_field_return_path.contains('main__Holder_free(&init);')
+	assert !return_field_return_path.contains('builtin__string_free(&(init.label));')
+	assert !return_field_fn.contains('builtin__string_free(&(init.other));')
+
+	return_alias_field_fn := function_window(generated,
+		'main__Label main__for_c_return_init_field_alias_string(void) {')
+	return_alias_field_return_pos := return_alias_field_fn.index('return ') or {
+		assert false, return_alias_field_fn
+		return
+	}
+	return_alias_field_return_path := return_alias_field_fn[..return_alias_field_return_pos]
+	assert !return_alias_field_return_path.contains('main__AliasHolder_free(&init);')
+	assert !return_alias_field_return_path.contains('builtin__string_free(&(init.label));')
+	assert !return_alias_field_fn.contains('builtin__string_free(&(init.other));')
+
+	return_id_fn := function_window(generated, 'int main__for_c_return_init_field_id(void) {')
+	return_id_holder_free_pos := return_id_fn.index('main__Holder_free(&init);') or {
+		assert false, return_id_fn
+		return
+	}
+	return_id_return_pos := return_id_fn.index('return ') or {
+		assert false, return_id_fn
+		return
+	}
+	assert return_id_holder_free_pos < return_id_return_pos
 
 	branch_body_fn := function_window(generated,
 		'main__Tracked main__for_c_branch_return_body_after_init_path(bool cond) {')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -38,6 +38,11 @@ struct ScopeGcPin {
 	post_stmt string
 }
 
+struct ClosureCleanupKeep {
+	cname    string
+	loop_pos int
+}
+
 pub struct Gen {
 	pref                &pref.Preferences = unsafe { nil }
 	field_data_type     ast.Type // cache her to avoid map lookups
@@ -213,6 +218,9 @@ mut:
 	inside_defer_generation              bool
 	defer_vars                           []string
 	closure_structs                      []string
+	closure_cleanup_keep_vars            []ClosureCleanupKeep
+	closure_cleanup_ignore_keep          bool
+	closure_cleanup_target_loop_pos      int
 	str_types                            []StrType       // types that need automatic str() generation
 	generated_str_fns                    []StrType       // types that already have a str() function
 	str_fn_names                         shared []string // remove duplicate function names
@@ -3319,6 +3327,534 @@ fn is_noreturn_callexpr(expr ast.Expr) bool {
 	return false
 }
 
+fn (g &Gen) local_closure_var_has_tracked_context(var ast.Var) bool {
+	if var.name == '_' || var.is_arg || var.is_tmp || var.is_inherited || var.typ == 0 {
+		return false
+	}
+	if g.table.final_sym(var.typ).kind != .function {
+		return false
+	}
+	return match var.expr {
+		ast.AnonFn {
+			if var.expr.inherited_vars.len == 0 {
+				false
+			} else {
+				mut captures_self := false
+				for inherited_var in var.expr.inherited_vars {
+					if inherited_var.name == var.name {
+						captures_self = true
+						break
+					}
+				}
+				!captures_self
+			}
+		}
+		ast.SelectorExpr {
+			var.expr.has_hidden_receiver
+		}
+		else {
+			false
+		}
+	}
+}
+
+fn (g &Gen) local_closure_cleanup_preserves_var(var ast.Var) bool {
+	if g.closure_cleanup_ignore_keep {
+		return false
+	}
+	cname := g.var_cname(var)
+	for keep_var in g.closure_cleanup_keep_vars {
+		if keep_var.cname == cname && (g.closure_cleanup_target_loop_pos == 0
+			|| keep_var.loop_pos == g.closure_cleanup_target_loop_pos) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (mut g Gen) push_local_closure_cleanup_preserve_vars(vars []ast.Var, loop_pos int) int {
+	start := g.closure_cleanup_keep_vars.len
+	for var in vars {
+		cname := g.var_cname(var)
+		if !g.closure_cleanup_keep_vars.any(it.cname == cname && it.loop_pos == loop_pos) {
+			g.closure_cleanup_keep_vars << ClosureCleanupKeep{
+				cname:    cname
+				loop_pos: loop_pos
+			}
+		}
+	}
+	return start
+}
+
+fn (mut g Gen) pop_local_closure_cleanup_preserve_vars(start int) {
+	if g.closure_cleanup_keep_vars.len > start {
+		g.closure_cleanup_keep_vars = g.closure_cleanup_keep_vars[..start].clone()
+	}
+}
+
+fn (mut g Gen) cleanup_for_c_init_local_closure_vars(node ast.ForCStmt, vars []ast.Var) {
+	for var in vars {
+		if local_closure_var_escapes_in_node(ast.Node(ast.Stmt(node)), var.name) {
+			continue
+		}
+		g.writeln('\tbuiltin__closure__closure_try_destroy((voidptr)${g.var_cname(var)});')
+	}
+}
+
+fn local_closure_var_decl_stmt_name(stmt ast.Stmt, name string) bool {
+	if stmt is ast.AssignStmt && stmt.op == .decl_assign {
+		for left in stmt.left {
+			if left is ast.Ident && left.name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+fn local_closure_var_decl_stmt(stmt ast.Stmt, var ast.Var) bool {
+	return local_closure_var_decl_stmt_name(stmt, var.name)
+}
+
+fn local_closure_direct_call(node ast.CallExpr, name string) bool {
+	if node.is_fn_var && node.name == name {
+		return true
+	}
+	return node.name == '' && node.left is ast.Ident && node.left.name == name
+}
+
+fn local_closure_var_mentioned_in_node(node ast.Node, name string) bool {
+	match node {
+		ast.Expr {
+			match node {
+				ast.Ident {
+					if node.name == name {
+						return true
+					}
+				}
+				ast.CallExpr {
+					if local_closure_direct_call(node, name) {
+						return true
+					}
+				}
+				ast.ArrayInit {
+					if node.has_len
+						&& local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.len_expr)), name) {
+						return true
+					}
+					if node.has_cap
+						&& local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.cap_expr)), name) {
+						return true
+					}
+					if node.has_init
+						&& local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.init_expr)), name) {
+						return true
+					}
+					if node.elem_type_expr !is ast.EmptyExpr
+						&& local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.elem_type_expr)), name) {
+						return true
+					}
+					if node.has_update_expr
+						&& local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.update_expr)), name) {
+						return true
+					}
+				}
+				else {}
+			}
+		}
+		ast.Stmt {
+			match node {
+				ast.ForCStmt {
+					if node.has_init
+						&& local_closure_var_mentioned_in_node(ast.Node(node.init), name) {
+						return true
+					}
+					if node.has_cond
+						&& local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.cond)), name) {
+						return true
+					}
+					if node.has_inc && local_closure_var_mentioned_in_node(ast.Node(node.inc), name) {
+						return true
+					}
+				}
+				ast.ForStmt {
+					if !node.is_inf
+						&& local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.cond)), name) {
+						return true
+					}
+				}
+				ast.ForInStmt {
+					if local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.cond)), name) {
+						return true
+					}
+					if local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.high)), name) {
+						return true
+					}
+				}
+				else {}
+			}
+		}
+		ast.IfBranch {
+			if local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.cond)), name) {
+				return true
+			}
+		}
+		ast.CallArg {
+			if local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.expr)), name) {
+				return true
+			}
+		}
+		else {}
+	}
+
+	for child in node.children() {
+		if local_closure_var_mentioned_in_node(child, name) {
+			return true
+		}
+	}
+	return false
+}
+
+fn local_closure_var_escapes_in_node(node ast.Node, name string) bool {
+	match node {
+		ast.Expr {
+			match node {
+				ast.Ident {
+					if node.name == name {
+						return true
+					}
+				}
+				ast.AnonFn {
+					for inherited_var in node.inherited_vars {
+						if inherited_var.name == name {
+							return true
+						}
+					}
+				}
+				ast.CallExpr {
+					if local_closure_direct_call(node, name) {
+						for arg in node.args {
+							if local_closure_var_escapes_in_node(ast.Node(arg), name) {
+								return true
+							}
+						}
+						return local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.or_block)),
+							name)
+					}
+				}
+				ast.ArrayInit {
+					if node.has_len
+						&& local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.len_expr)), name) {
+						return true
+					}
+					if node.has_cap
+						&& local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.cap_expr)), name) {
+						return true
+					}
+					if node.has_init
+						&& local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.init_expr)), name) {
+						return true
+					}
+					if node.elem_type_expr !is ast.EmptyExpr
+						&& local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.elem_type_expr)), name) {
+						return true
+					}
+					if node.has_update_expr
+						&& local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.update_expr)), name) {
+						return true
+					}
+				}
+				ast.GoExpr {
+					if local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.call_expr)), name) {
+						return true
+					}
+				}
+				ast.SpawnExpr {
+					if local_closure_var_mentioned_in_node(ast.Node(ast.Expr(node.call_expr)), name) {
+						return true
+					}
+				}
+				else {}
+			}
+		}
+		ast.Stmt {
+			match node {
+				ast.AssignStmt {
+					if local_closure_var_decl_stmt_name(node, name) {
+						return false
+					}
+				}
+				ast.DeferStmt {
+					if local_closure_var_mentioned_in_node(ast.Node(ast.Stmt(node)), name) {
+						return true
+					}
+				}
+				ast.ForCStmt {
+					if node.has_init && local_closure_var_escapes_in_node(ast.Node(node.init), name) {
+						return true
+					}
+					if node.has_cond
+						&& local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.cond)), name) {
+						return true
+					}
+					if node.has_inc && local_closure_var_escapes_in_node(ast.Node(node.inc), name) {
+						return true
+					}
+				}
+				ast.ForStmt {
+					if !node.is_inf
+						&& local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.cond)), name) {
+						return true
+					}
+				}
+				ast.ForInStmt {
+					if local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.cond)), name) {
+						return true
+					}
+					if local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.high)), name) {
+						return true
+					}
+				}
+				else {}
+			}
+		}
+		ast.IfBranch {
+			if local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.cond)), name) {
+				return true
+			}
+		}
+		ast.CallArg {
+			if local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.expr)), name) {
+				return true
+			}
+		}
+		else {}
+	}
+
+	for child in node.children() {
+		if local_closure_var_escapes_in_node(child, name) {
+			return true
+		}
+	}
+	return false
+}
+
+fn local_closure_var_escapes_in_stmts(stmts []ast.Stmt, var ast.Var) bool {
+	for stmt in stmts {
+		if local_closure_var_decl_stmt(stmt, var) {
+			continue
+		}
+		if local_closure_var_escapes_in_node(ast.Node(stmt), var.name) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (g &Gen) local_closure_cleanup_scope_at(pos int) &ast.Scope {
+	if g.fn_decl != unsafe { nil } && g.fn_decl.scope != unsafe { nil } {
+		fn_scope := g.fn_decl.scope
+		if fn_scope.contains(pos) {
+			return fn_scope.innermost(pos)
+		}
+		return unsafe { nil }
+	}
+	if g.file.scope == unsafe { nil } {
+		return unsafe { nil }
+	}
+	return g.file.scope.innermost(pos)
+}
+
+fn (g &Gen) local_closure_cleanup_scope_in_current_fn(scope &ast.Scope) bool {
+	if scope == unsafe { nil } {
+		return false
+	}
+	if g.fn_decl == unsafe { nil } || g.fn_decl.scope == unsafe { nil } {
+		return true
+	}
+	fn_scope := g.fn_decl.scope
+	for sc := unsafe { scope }; sc != unsafe { nil }; sc = sc.parent {
+		if sc == fn_scope {
+			return true
+		}
+		if sc.detached_from_parent {
+			break
+		}
+	}
+	return false
+}
+
+fn (g &Gen) local_closure_cleanup_can_visit_parent(scope &ast.Scope, free_parent_scopes bool,
+	stop_pos int) bool {
+	if !free_parent_scopes || scope == unsafe { nil } || scope.parent == unsafe { nil }
+		|| scope.detached_from_parent {
+		return false
+	}
+	if stop_pos != -1 && scope.parent.start_pos < stop_pos {
+		return false
+	}
+	if g.fn_decl != unsafe { nil } && g.fn_decl.scope != unsafe { nil } {
+		if scope == g.fn_decl.scope {
+			return false
+		}
+		return g.local_closure_cleanup_scope_in_current_fn(scope.parent)
+	}
+	return true
+}
+
+fn (g &Gen) has_local_closure_vars_to_cleanup(pos int, line_nr int, free_parent_scopes bool,
+	stop_pos int, stmts []ast.Stmt) bool {
+	if g.is_builtin_mod || pos == -1 {
+		return false
+	}
+	scope := g.local_closure_cleanup_scope_at(pos)
+	if scope == unsafe { nil } || scope.start_pos == 0 {
+		return false
+	}
+	return g.has_local_closure_vars_to_cleanup2(scope, scope.start_pos, scope.end_pos, line_nr,
+		free_parent_scopes, stop_pos, stmts)
+}
+
+fn (g &Gen) has_local_closure_vars_to_cleanup2(scope &ast.Scope, start_pos int, end_pos int,
+	line_nr int, free_parent_scopes bool, stop_pos int, stmts []ast.Stmt) bool {
+	if scope == unsafe { nil } {
+		return false
+	}
+	for _, obj in scope.objects {
+		if obj is ast.Var {
+			if obj.pos.pos > end_pos
+				|| (obj.pos.pos < start_pos && obj.pos.line_nr == line_nr)
+				|| !g.local_closure_var_has_tracked_context(obj)
+				|| local_closure_var_escapes_in_stmts(stmts, obj) {
+				continue
+			}
+			return true
+		}
+	}
+	if g.local_closure_cleanup_can_visit_parent(scope, free_parent_scopes, stop_pos) {
+		return g.has_local_closure_vars_to_cleanup2(scope.parent, start_pos, end_pos, line_nr,
+			true, stop_pos, stmts)
+	}
+	return false
+}
+
+fn (mut g Gen) cleanup_local_closure_vars(pos int, line_nr int, free_parent_scopes bool, stop_pos int,
+	stmts []ast.Stmt) {
+	if g.is_builtin_mod || pos == -1 {
+		return
+	}
+	scope := g.local_closure_cleanup_scope_at(pos)
+	if scope == unsafe { nil } || scope.start_pos == 0 {
+		return
+	}
+	g.cleanup_local_closure_vars2(scope, scope.start_pos, scope.end_pos, line_nr,
+		free_parent_scopes, stop_pos, stmts)
+}
+
+fn (mut g Gen) cleanup_local_closure_vars_before_jump(scope &ast.Scope, pos int, line_nr int,
+	free_parent_scopes bool, stop_pos int, stmts []ast.Stmt) {
+	if g.is_builtin_mod || pos == -1 {
+		return
+	}
+	if scope == unsafe { nil } {
+		cleanup_scope := g.local_closure_cleanup_scope_at(pos)
+		if cleanup_scope == unsafe { nil } || cleanup_scope.start_pos == 0 {
+			return
+		}
+		g.cleanup_local_closure_vars2(cleanup_scope, cleanup_scope.start_pos, pos, line_nr,
+			free_parent_scopes, stop_pos, stmts)
+		return
+	}
+	if scope.start_pos == 0 || !g.local_closure_cleanup_scope_in_current_fn(scope) {
+		return
+	}
+	g.cleanup_local_closure_vars2(scope, scope.start_pos, pos, line_nr, free_parent_scopes,
+		stop_pos, stmts)
+}
+
+fn (mut g Gen) cleanup_local_closure_vars2(scope &ast.Scope, start_pos int, end_pos int, line_nr int,
+	free_parent_scopes bool, stop_pos int, stmts []ast.Stmt) {
+	if scope == unsafe { nil } {
+		return
+	}
+	for _, obj in scope.objects {
+		if obj is ast.Var {
+			if obj.pos.pos > end_pos
+				|| (obj.pos.pos < start_pos && obj.pos.line_nr == line_nr)
+				|| !g.local_closure_var_has_tracked_context(obj)
+				|| g.local_closure_cleanup_preserves_var(obj)
+				|| local_closure_var_escapes_in_stmts(stmts, obj) {
+				continue
+			}
+			g.writeln('\tbuiltin__closure__closure_try_destroy((voidptr)${g.var_cname(obj)});')
+		}
+	}
+	if g.local_closure_cleanup_can_visit_parent(scope, free_parent_scopes, stop_pos) {
+		g.cleanup_local_closure_vars2(scope.parent, start_pos, end_pos, line_nr, true, stop_pos,
+			stmts)
+	}
+}
+
+fn (g &Gen) return_needs_local_closure_cleanup(node ast.Return) bool {
+	if g.fn_decl == unsafe { nil } {
+		return false
+	}
+	return g.has_local_closure_vars_to_cleanup(node.pos.pos - 1, node.pos.line_nr, true, -1,
+		g.fn_decl.stmts)
+}
+
+fn (mut g Gen) cleanup_local_closure_vars_on_return(node ast.Return) {
+	if g.fn_decl == unsafe { nil } {
+		return
+	}
+	old_closure_cleanup_ignore_keep := g.closure_cleanup_ignore_keep
+	g.closure_cleanup_ignore_keep = true
+	g.cleanup_local_closure_vars(node.pos.pos - 1, node.pos.line_nr, true, -1, g.fn_decl.stmts)
+	g.closure_cleanup_ignore_keep = old_closure_cleanup_ignore_keep
+}
+
+fn (mut g Gen) cleanup_local_closure_vars_before_synthetic_return(scope &ast.Scope, pos token.Pos) {
+	if g.fn_decl == unsafe { nil } {
+		return
+	}
+	old_closure_cleanup_ignore_keep := g.closure_cleanup_ignore_keep
+	g.closure_cleanup_ignore_keep = true
+	g.cleanup_local_closure_vars_before_jump(scope, pos.pos - 1, pos.line_nr, true, -1,
+		g.fn_decl.stmts)
+	g.closure_cleanup_ignore_keep = old_closure_cleanup_ignore_keep
+}
+
+fn labeled_loop_cleanup_stop_pos(node &ast.Stmt) int {
+	return match node {
+		ast.ForCStmt { node.pos.pos }
+		ast.ForInStmt { node.pos.pos }
+		ast.ForStmt { node.pos.pos }
+		else { -1 }
+	}
+}
+
+fn labeled_loop_scope(node &ast.Stmt) &ast.Scope {
+	return match node {
+		ast.ForCStmt { node.scope }
+		ast.ForInStmt { node.scope }
+		ast.ForStmt { node.scope }
+		else { unsafe { nil } }
+	}
+}
+
+fn (mut g Gen) write_defer_stmts_before_labeled_continue(scope &ast.Scope, target_scope &ast.Scope, pos token.Pos) {
+	if scope == unsafe { nil } || target_scope == unsafe { nil } {
+		return
+	}
+	for cleanup_scope := unsafe { scope }; cleanup_scope != unsafe { nil }
+		&& cleanup_scope != target_scope; cleanup_scope = cleanup_scope.parent {
+		g.write_defer_stmts(cleanup_scope, false, pos)
+		if cleanup_scope.detached_from_parent {
+			break
+		}
+	}
+}
+
 // stmts_with_tmp_var is used in `if` or `match` branches.
 // It returns true, if the last statement was a `return` or `branch`
 fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
@@ -3563,6 +4099,18 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 				}
 			}
 			g.autofree_scope_vars(stmt_pos.pos - 1, stmt_pos.line_nr, false)
+		}
+	}
+	if !g.inside_veb_tmpl && stmts.len > 0 && !last_stmt_was_return && g.inside_ternary == 0 {
+		stmt := stmts[0]
+		if stmt !is ast.FnDecl {
+			mut stmt_pos := stmt.pos
+			if stmt_pos.pos == 0 && stmt is ast.ExprStmt {
+				stmt_pos = stmt.expr.pos()
+			}
+			if stmt_pos.pos != 0 {
+				g.cleanup_local_closure_vars(stmt_pos.pos - 1, stmt_pos.line_nr, false, -1, stmts)
+			}
 		}
 	}
 	// Branch-local lambda temp args are freed by the scope cleanup above.
@@ -7357,9 +7905,9 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 					}
 				}
 			}
-			g.write('builtin__closure__closure_create(${name}, ')
+			g.write('builtin__closure__closure_create_with_data(${name}, ')
 			if !receiver.typ.is_ptr() {
-				g.write('builtin__memdup_uncollectable(')
+				g.write('builtin__memdup(')
 			}
 			mut has_addr := false
 			if !node.expr_type.is_ptr() {
@@ -7385,7 +7933,11 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			if !receiver.typ.is_ptr() {
 				g.write(', sizeof(${expr_styp}))')
 			}
-			g.write(')')
+			if receiver.typ.is_ptr() {
+				g.write(', false)')
+			} else {
+				g.write(', true)')
+			}
 			return
 		}
 	} else {
@@ -10438,6 +10990,23 @@ fn (mut g Gen) branch_stmt(node ast.BranchStmt) {
 			else {}
 		}
 
+		stop_pos := labeled_loop_cleanup_stop_pos(x)
+		if node.kind == .key_break {
+			g.write_defer_stmts(node.scope, false, node.pos)
+		} else {
+			g.write_defer_stmts_before_labeled_continue(node.scope, labeled_loop_scope(x), node.pos)
+		}
+		if g.needs_scope_cleanup() && !g.is_builtin_mod {
+			g.trace_autofree('// free before labeled continue/break')
+			g.autofree_scope_vars_stop(node.pos.pos - 1, node.pos.line_nr, true, stop_pos)
+		}
+		if g.fn_decl != unsafe { nil } {
+			old_closure_cleanup_target_loop_pos := g.closure_cleanup_target_loop_pos
+			g.closure_cleanup_target_loop_pos = if stop_pos > 0 { stop_pos } else { 0 }
+			g.cleanup_local_closure_vars_before_jump(node.scope, node.pos.pos - 1,
+				node.pos.line_nr, true, stop_pos, g.fn_decl.stmts)
+			g.closure_cleanup_target_loop_pos = old_closure_cleanup_target_loop_pos
+		}
 		if node.kind == .key_break {
 			g.writeln('goto ${node.label}__break;')
 		} else {
@@ -10473,6 +11042,17 @@ fn (mut g Gen) branch_stmt(node ast.BranchStmt) {
 			g.trace_autofree('// free before continue/break')
 			g.autofree_scope_vars_stop(node.pos.pos - 1, node.pos.line_nr, true,
 				g.branch_parent_pos)
+		}
+		if g.fn_decl != unsafe { nil } {
+			old_closure_cleanup_target_loop_pos := g.closure_cleanup_target_loop_pos
+			g.closure_cleanup_target_loop_pos = if g.branch_parent_pos > 0 {
+				g.branch_parent_pos
+			} else {
+				0
+			}
+			g.cleanup_local_closure_vars_before_jump(node.scope, node.pos.pos - 1,
+				node.pos.line_nr, true, g.branch_parent_pos, g.fn_decl.stmts)
+			g.closure_cleanup_target_loop_pos = old_closure_cleanup_target_loop_pos
 		}
 		g.writeln('${node.kind};')
 	}
@@ -10557,6 +11137,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			type0 = resolved_obj_type
 		}
 	}
+	return_needs_local_closure_cleanup := g.return_needs_local_closure_cleanup(node)
 
 	if exprs_len > 0 {
 		// `$veb.html()` expands to statements, so the Result return
@@ -10571,6 +11152,9 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			g.write_defer_stmts_when_needed(node.scope, true, node.pos)
 			if !g.is_builtin_mod {
 				g.autofree_scope_vars(node.pos.pos - 1, node.pos.line_nr, true)
+			}
+			if return_needs_local_closure_cleanup {
+				g.cleanup_local_closure_vars_on_return(node)
 			}
 			// `$veb.html()` returns `veb.Result` and the template body
 			// already writes the rendered string to the response, so just
@@ -10624,11 +11208,17 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				g.trace_autofree('// free before return (no values returned)')
 				g.autofree_scope_vars(node.pos.pos, node.pos.line_nr, false)
 			}
+			if return_needs_local_closure_cleanup {
+				g.cleanup_local_closure_vars_on_return(node)
+			}
 			g.writeln('return (${styp}){0};')
 		} else {
 			if g.needs_scope_cleanup() {
 				g.trace_autofree('// free before return (no values returned)')
 				g.autofree_scope_vars(node.pos.pos - 1, node.pos.line_nr, true)
+			}
+			if return_needs_local_closure_cleanup {
+				g.cleanup_local_closure_vars_on_return(node)
 			}
 			g.writeln('return;')
 		}
@@ -10646,11 +11236,14 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			resolved_call_return_type = expr0.return_type
 		}
 		if g.unwrap_generic(g.recheck_concrete_type(resolved_call_return_type)) == ret_type {
-			if g.defer_stmts.len > 0 {
+			if g.defer_stmts.len > 0 || return_needs_local_closure_cleanup {
 				g.write('${ret_typ} ${tmpvar} = ')
 				g.expr(expr0)
 				g.writeln(';')
 				g.write_defer_stmts_when_needed(node.scope, true, node.pos)
+				if return_needs_local_closure_cleanup {
+					g.cleanup_local_closure_vars_on_return(node)
+				}
 				g.writeln('return ${tmpvar};')
 			} else {
 				g.write_defer_stmts_when_needed(node.scope, true, node.pos)
@@ -10662,7 +11255,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 		}
 	}
 	mut use_tmp_var := g.defer_stmts.len > 0 || g.defer_profile_code.len > 0
-		|| g.cur_lock.lockeds.len > 0
+		|| g.cur_lock.lockeds.len > 0 || return_needs_local_closure_cleanup
 		|| (fn_return_is_multi && exprs_len >= 1 && fn_return_is_option)
 		|| fn_return_is_fixed_array_non_result
 		|| (fn_return_is_multi && ret_expr_types.any(g.table.final_sym(it).kind == .array_fixed))
@@ -10678,6 +11271,9 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				g.gen_option_error(fn_ret_type, expr0)
 				g.writeln(';')
 				g.write_defer_stmts_when_needed(node.scope, true, node.pos)
+				if return_needs_local_closure_cleanup {
+					g.cleanup_local_closure_vars_on_return(node)
+				}
 				g.gen_failing_return_error_for_test_fn(node, test_error_var)
 				return
 			}
@@ -10701,6 +11297,9 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 					}
 				}
 				g.write_defer_stmts_when_needed(node.scope, true, node.pos)
+				if return_needs_local_closure_cleanup {
+					g.cleanup_local_closure_vars_on_return(node)
+				}
 				g.writeln('return ${tmpvar};')
 			}
 			return
@@ -10717,6 +11316,9 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				g.gen_result_error(fn_ret_type, expr0)
 				g.writeln(';')
 				g.write_defer_stmts_when_needed(node.scope, true, node.pos)
+				if return_needs_local_closure_cleanup {
+					g.cleanup_local_closure_vars_on_return(node)
+				}
 				g.gen_failing_return_error_for_test_fn(node, test_error_var)
 				return
 			}
@@ -10729,6 +11331,9 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			g.writeln(';')
 			if use_tmp_var {
 				g.write_defer_stmts_when_needed(node.scope, true, node.pos)
+				if return_needs_local_closure_cleanup {
+					g.cleanup_local_closure_vars_on_return(node)
+				}
 				g.writeln('return ${tmpvar};')
 			}
 			return
@@ -10742,6 +11347,9 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			g.expr(expr0)
 			g.writeln(';')
 			g.write_defer_stmts_when_needed(node.scope, true, node.pos)
+			if return_needs_local_closure_cleanup {
+				g.cleanup_local_closure_vars_on_return(node)
+			}
 			g.writeln('return ${tmpvar};')
 			return
 		}
@@ -10861,9 +11469,15 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				g.writeln(';')
 			}
 			g.write_defer_stmts_when_needed(node.scope, true, node.pos)
+			if return_needs_local_closure_cleanup {
+				g.cleanup_local_closure_vars_on_return(node)
+			}
 			g.writeln('return ${tmpvar};')
 			has_semicolon = true
 		} else if fn_return_is_option || fn_return_is_result {
+			if return_needs_local_closure_cleanup {
+				g.cleanup_local_closure_vars_on_return(node)
+			}
 			g.write('return ${tmpvar}')
 		}
 	} else if exprs_len >= 1 {
@@ -10900,6 +11514,9 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				g.detect_used_var_on_return(expr0)
 			}
 			g.autofree_scope_vars(node.pos.pos - 1, node.pos.line_nr, true)
+			if return_needs_local_closure_cleanup {
+				g.cleanup_local_closure_vars_on_return(node)
+			}
 			g.writeln('return ${tmpvar};')
 			return
 		}
@@ -11008,6 +11625,9 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			g.write_defer_stmts_when_needed(node.scope, true, node.pos)
 			if !g.is_builtin_mod {
 				g.autofree_scope_vars(node.pos.pos - 1, node.pos.line_nr, true)
+			}
+			if return_needs_local_closure_cleanup {
+				g.cleanup_local_closure_vars_on_return(node)
 			}
 			g.write('return ${tmpvar}')
 			has_semicolon = false
@@ -12372,6 +12992,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			g.write_defer_stmts(or_block.scope, true, or_block.pos)
 			// Now that option types are distinct we need a cast here
 			if g.fn_decl == unsafe { nil } || g.fn_decl.return_type == ast.void_type {
+				g.cleanup_local_closure_vars_before_synthetic_return(or_block.scope, or_block.pos)
 				g.writeln('\treturn;')
 			} else {
 				mut fn_return_type := g.fn_decl.return_type
@@ -12392,6 +13013,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 				} else if fn_return_type.has_flag(.option) {
 					g.writeln('\t${err_obj}.state = 2;')
 				}
+				g.cleanup_local_closure_vars_before_synthetic_return(or_block.scope, or_block.pos)
 				g.writeln('\treturn ${err_obj};')
 			}
 		}
@@ -12417,14 +13039,17 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			g.write_defer_stmts(or_block.scope, true, or_block.pos)
 			// Now that option types are distinct we need a cast here
 			if g.fn_decl == unsafe { nil } || g.fn_decl.return_type == ast.void_type {
+				g.cleanup_local_closure_vars_before_synthetic_return(or_block.scope, or_block.pos)
 				g.writeln('\treturn;')
 			} else if g.fn_decl.return_type.clear_option_and_result() == return_type.clear_option_and_result() {
 				styp := g.styp(g.fn_decl.return_type).replace('*', '_ptr')
 				err_obj := g.new_tmp_var()
 				g.writeln2('\t${styp} ${err_obj};',
 					'\tmemcpy(&${err_obj}, &${cvar_name}, sizeof(_option));')
+				g.cleanup_local_closure_vars_before_synthetic_return(or_block.scope, or_block.pos)
 				g.writeln('\treturn ${err_obj};')
 			} else {
+				g.cleanup_local_closure_vars_before_synthetic_return(or_block.scope, or_block.pos)
 				g.write('\treturn ')
 				g.gen_option_error(g.fn_decl.return_type, ast.None{})
 				g.writeln(';')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -266,6 +266,9 @@ mut:
 	sql_last_stmt_out_len                int
 	strs_to_free0                        []string // strings.Builder
 	lambda_autofree_tmp_arg_vars         []string
+	for_c_init_autofree_keep_vars        []string
+	for_c_init_autofree_cleanup_vars     []ast.Var
+	skip_scope_cleanup_start_pos         []int
 	// strs_to_free          []string // strings.Builder
 	// tmp_arg_vars_to_free  []string
 	// autofree_pregen       map[string]string
@@ -3323,6 +3326,24 @@ fn (mut g Gen) stmts(stmts []ast.Stmt) {
 	g.stmts_with_tmp_var(stmts, '')
 }
 
+fn (mut g Gen) push_skip_scope_cleanup(scope &ast.Scope) int {
+	start := g.skip_scope_cleanup_start_pos.len
+	if scope != unsafe { nil } {
+		g.skip_scope_cleanup_start_pos << scope.start_pos
+	}
+	return start
+}
+
+fn (mut g Gen) pop_skip_scope_cleanup(start int) {
+	if g.skip_scope_cleanup_start_pos.len > start {
+		g.skip_scope_cleanup_start_pos = g.skip_scope_cleanup_start_pos[..start].clone()
+	}
+}
+
+fn (g &Gen) should_skip_scope_cleanup(scope &ast.Scope) bool {
+	return scope != unsafe { nil } && scope.start_pos in g.skip_scope_cleanup_start_pos
+}
+
 fn is_noreturn_callexpr(expr ast.Expr) bool {
 	if expr is ast.CallExpr {
 		return expr.is_noreturn
@@ -3802,6 +3823,9 @@ fn (g &Gen) return_needs_local_closure_cleanup(node ast.Return) bool {
 	if g.fn_decl == unsafe { nil } {
 		return false
 	}
+	if g.for_c_init_autofree_cleanup_vars.len > 0 {
+		return true
+	}
 	return g.has_local_closure_vars_to_cleanup(node.pos.pos - 1, node.pos.line_nr, true, -1,
 		g.fn_decl.stmts)
 }
@@ -3814,6 +3838,7 @@ fn (mut g Gen) cleanup_local_closure_vars_on_return(node ast.Return) {
 	g.closure_cleanup_ignore_keep = true
 	g.cleanup_local_closure_vars(node.pos.pos - 1, node.pos.line_nr, true, -1, g.fn_decl.stmts)
 	g.closure_cleanup_ignore_keep = old_closure_cleanup_ignore_keep
+	g.cleanup_for_c_init_autofree_vars_on_return(returned_var_names_from_return(node))
 }
 
 fn (mut g Gen) cleanup_local_closure_vars_before_synthetic_return(scope &ast.Scope, pos token.Pos) {
@@ -3845,14 +3870,128 @@ fn labeled_loop_scope(node &ast.Stmt) &ast.Scope {
 	}
 }
 
-fn (mut g Gen) write_defer_stmts_before_labeled_continue(scope &ast.Scope, target_scope &ast.Scope, pos token.Pos) {
+fn labeled_loop_for_c_init_vars(node &ast.Stmt) []string {
+	return match node {
+		ast.ForCStmt {
+			if !node.has_init || node.init !is ast.AssignStmt {
+				return []
+			}
+			init := node.init as ast.AssignStmt
+			if init.op != .decl_assign {
+				return []
+			}
+			mut vars := []string{}
+			for left in init.left {
+				if left is ast.Ident {
+					vars << left.name
+				}
+			}
+			vars
+		}
+		else {
+			[]
+		}
+	}
+}
+
+fn (mut g Gen) write_defer_stmts_before_labeled_continue_in_scope(scope &ast.Scope, pos token.Pos) {
+	prev_inside_defer_generation := g.inside_defer_generation
+	g.inside_defer_generation = true
+	defer {
+		g.inside_defer_generation = prev_inside_defer_generation
+	}
+	g.indent++
+	for i := g.defer_stmts.len - 1; i >= 0; i-- {
+		defer_stmt := g.defer_stmts[i]
+		if defer_stmt.scope == unsafe { nil } {
+			g.error('Gen.write_defer_stmts_before_labeled_continue(): defer_stmt.scope is nil', pos)
+		}
+		if defer_stmt.mode != .scoped || defer_stmt.scope != scope || defer_stmt.pos.pos >= pos.pos {
+			continue
+		}
+		g.writeln('{ // defer begin')
+		if defer_stmt.ifdef.len > 0 {
+			g.writeln(defer_stmt.ifdef)
+			g.stmts(defer_stmt.stmts)
+			g.writeln2('', '#endif')
+		} else {
+			g.stmts(defer_stmt.stmts)
+		}
+		g.writeln('} // defer end')
+	}
+	g.indent--
+}
+
+fn (mut g Gen) cleanup_scopes_before_labeled_continue(scope &ast.Scope, target_scope &ast.Scope,
+	pos token.Pos, keep_vars []string) {
 	if scope == unsafe { nil } || target_scope == unsafe { nil } {
 		return
 	}
-	for cleanup_scope := unsafe { scope }; cleanup_scope != unsafe { nil }
-		&& cleanup_scope != target_scope; cleanup_scope = cleanup_scope.parent {
-		g.write_defer_stmts(cleanup_scope, false, pos)
+	for cleanup_scope := unsafe { scope }; cleanup_scope != unsafe { nil }; cleanup_scope = cleanup_scope.parent {
+		g.write_defer_stmts_before_labeled_continue_in_scope(cleanup_scope, pos)
+		if g.needs_scope_cleanup() && !g.is_builtin_mod {
+			g.autofree_scope_vars2_before_labeled_continue(cleanup_scope, cleanup_scope.start_pos,
+				pos.pos - 1, cleanup_scope == target_scope, keep_vars)
+		}
+		if cleanup_scope == target_scope || cleanup_scope.detached_from_parent {
+			break
+		}
+	}
+}
+
+fn (mut g Gen) autofree_scope_vars2_before_labeled_continue(scope &ast.Scope, start_pos int,
+	end_pos int, is_target_scope bool, keep_vars []string) {
+	if scope == unsafe { nil } {
+		return
+	}
+	for _, obj in scope.objects {
+		if obj is ast.Var {
+			if obj.name in g.returned_var_names || obj.is_or || obj.is_tmp
+				|| obj.is_inherited || obj.pos.pos > end_pos
+				|| obj.pos.pos < start_pos
+				|| obj.name in g.for_c_init_autofree_keep_vars
+				|| (is_target_scope && obj.name in keep_vars)
+				|| (end_pos < scope.end_pos && obj.expr is ast.IfExpr) {
+				continue
+			}
+			if obj.expr is ast.IfGuardExpr {
+				continue
+			}
+			if obj.expr is ast.UnsafeExpr && obj.expr.expr is ast.CallExpr
+				&& (obj.expr.expr as ast.CallExpr).is_method {
+				if left_var := scope.objects[obj.expr.expr.left.str()] {
+					if func := g.table.find_method(g.table.final_sym(left_var.typ),
+						obj.expr.expr.name)
+					{
+						if func.attrs.contains('reused') && left_var is ast.Var
+							&& left_var.expr is ast.CastExpr {
+							if left_var.expr.expr.is_literal() {
+								continue
+							}
+						}
+					}
+				}
+			}
+			g.autofree_variable(obj)
+		}
+	}
+	for g.autofree_scope_stmts.len > 0 {
+		g.write(g.autofree_scope_stmts.pop())
+	}
+}
+
+fn (mut g Gen) cleanup_local_closure_vars_before_labeled_continue(scope &ast.Scope, target_scope &ast.Scope,
+	pos token.Pos, stmts []ast.Stmt) {
+	if g.fn_decl == unsafe { nil } || scope == unsafe { nil } || target_scope == unsafe { nil } {
+		return
+	}
+	for cleanup_scope := unsafe { scope }; cleanup_scope != unsafe { nil }; cleanup_scope = cleanup_scope.parent {
+		g.cleanup_local_closure_vars2(cleanup_scope, cleanup_scope.start_pos, pos.pos - 1,
+			pos.line_nr, false, -1, stmts)
 		if cleanup_scope.detached_from_parent {
+			break
+		}
+		if cleanup_scope == target_scope {
 			break
 		}
 	}
@@ -4101,7 +4240,10 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 					return last_stmt_was_return
 				}
 			}
-			g.autofree_scope_vars(stmt_pos.pos - 1, stmt_pos.line_nr, false)
+			cleanup_scope := g.file.scope.innermost(stmt_pos.pos - 1)
+			if !g.should_skip_scope_cleanup(cleanup_scope) {
+				g.autofree_scope_vars(stmt_pos.pos - 1, stmt_pos.line_nr, false)
+			}
 		}
 	}
 	if !g.inside_veb_tmpl && stmts.len > 0 && !last_stmt_was_return && g.inside_ternary == 0 {
@@ -4112,7 +4254,11 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 				stmt_pos = stmt.expr.pos()
 			}
 			if stmt_pos.pos != 0 {
-				g.cleanup_local_closure_vars(stmt_pos.pos - 1, stmt_pos.line_nr, false, -1, stmts)
+				cleanup_scope := g.local_closure_cleanup_scope_at(stmt_pos.pos - 1)
+				if !g.should_skip_scope_cleanup(cleanup_scope) {
+					g.cleanup_local_closure_vars(stmt_pos.pos - 1, stmt_pos.line_nr, false, -1,
+						stmts)
+				}
 			}
 		}
 	}
@@ -10994,21 +11140,38 @@ fn (mut g Gen) branch_stmt(node ast.BranchStmt) {
 		}
 
 		stop_pos := labeled_loop_cleanup_stop_pos(x)
+		target_scope := labeled_loop_scope(x)
 		if node.kind == .key_break {
 			g.write_defer_stmts(node.scope, false, node.pos)
 		} else {
-			g.write_defer_stmts_before_labeled_continue(node.scope, labeled_loop_scope(x), node.pos)
+			g.cleanup_scopes_before_labeled_continue(node.scope, target_scope, node.pos,
+				labeled_loop_for_c_init_vars(x))
 		}
-		if g.needs_scope_cleanup() && !g.is_builtin_mod {
+		if node.kind == .key_break && g.needs_scope_cleanup() && !g.is_builtin_mod {
 			g.trace_autofree('// free before labeled continue/break')
 			g.autofree_scope_vars_stop(node.pos.pos - 1, node.pos.line_nr, true, stop_pos)
 		}
 		if g.fn_decl != unsafe { nil } {
-			old_closure_cleanup_target_loop_pos := g.closure_cleanup_target_loop_pos
-			g.closure_cleanup_target_loop_pos = if stop_pos > 0 { stop_pos } else { 0 }
-			g.cleanup_local_closure_vars_before_jump(node.scope, node.pos.pos - 1,
-				node.pos.line_nr, true, stop_pos, g.fn_decl.stmts)
-			g.closure_cleanup_target_loop_pos = old_closure_cleanup_target_loop_pos
+			if node.kind == .key_break {
+				old_closure_cleanup_target_loop_pos := g.closure_cleanup_target_loop_pos
+				g.closure_cleanup_target_loop_pos = if stop_pos > 0 { stop_pos } else { 0 }
+				g.cleanup_local_closure_vars_before_jump(node.scope, node.pos.pos - 1,
+					node.pos.line_nr, true, stop_pos, g.fn_decl.stmts)
+				g.closure_cleanup_target_loop_pos = old_closure_cleanup_target_loop_pos
+			} else {
+				preserve_start := if x is ast.ForCStmt {
+					g.push_local_closure_cleanup_preserve_vars(g.for_c_init_local_closure_vars(x),
+						x.pos.pos)
+				} else {
+					g.closure_cleanup_keep_vars.len
+				}
+				old_closure_cleanup_target_loop_pos := g.closure_cleanup_target_loop_pos
+				g.closure_cleanup_target_loop_pos = if stop_pos > 0 { stop_pos } else { 0 }
+				g.cleanup_local_closure_vars_before_labeled_continue(node.scope, target_scope,
+					node.pos, g.fn_decl.stmts)
+				g.closure_cleanup_target_loop_pos = old_closure_cleanup_target_loop_pos
+				g.pop_local_closure_cleanup_preserve_vars(preserve_start)
+			}
 		}
 		if node.kind == .key_break {
 			g.writeln('goto ${node.label}__break;')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -209,6 +209,7 @@ mut:
 	right_is_opt                         bool             // right hand side on assignment is an option
 	assign_ct_type                       map[int]ast.Type // left hand side resolved comptime type
 	expected_rhs_type_by_pos             map[int]ast.Type // expected value type for local RHS expressions
+	closure_frame_arg_tmps               map[int]string
 	indent                               int
 	empty_line                           bool
 	assign_op                            token.Kind // *=, =, etc (for array_set)
@@ -431,6 +432,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 		boehm_keep_decl:               map[string]bool{}
 		boehm_keep_gen:                map[string]bool{}
 		boehm_keep_busy:               map[string]bool{}
+		closure_frame_arg_tmps:        map[int]string{}
 		generic_parts_cache:           []i8{len: table.type_symbols.len}
 		unwrap_generic_cache:          map[u64]ast.Type{}
 		resolved_scope_var_type_cache: map[u64]ast.Type{}
@@ -1089,6 +1091,7 @@ fn cgen_process_one_file_cb(mut p pool.PoolProcessor, idx int, wid int) voidptr 
 		boehm_keep_decl:                    map[string]bool{}
 		boehm_keep_gen:                     map[string]bool{}
 		boehm_keep_busy:                    map[string]bool{}
+		closure_frame_arg_tmps:             map[int]string{}
 		generic_parts_cache:                []i8{len: global_g.table.type_symbols.len}
 		unwrap_generic_cache:               map[u64]ast.Type{}
 		resolved_scope_var_type_cache:      map[u64]ast.Type{}
@@ -11138,6 +11141,11 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 		}
 	}
 	return_needs_local_closure_cleanup := g.return_needs_local_closure_cleanup(node)
+	return_expr0 := unwrap_paren_call_expr(expr0)
+	return_call_needs_closure_lifetime_arg_tmp := match return_expr0 {
+		ast.CallExpr { g.call_needs_closure_lifetime_arg_tmp(return_expr0) }
+		else { false }
+	}
 
 	if exprs_len > 0 {
 		// `$veb.html()` expands to statements, so the Result return
@@ -11229,16 +11237,17 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 	ret_typ := g.ret_styp(fn_ret_type)
 
 	// `return fn_call_opt()`
-	if exprs_len == 1 && (fn_return_is_option || fn_return_is_result) && expr0 is ast.CallExpr
-		&& expr0.or_block.kind == .absent {
-		mut resolved_call_return_type := g.resolve_return_type(expr0)
+	if exprs_len == 1 && (fn_return_is_option || fn_return_is_result)
+		&& return_expr0 is ast.CallExpr && return_expr0.or_block.kind == .absent {
+		mut resolved_call_return_type := g.resolve_return_type(return_expr0)
 		if resolved_call_return_type == ast.void_type {
-			resolved_call_return_type = expr0.return_type
+			resolved_call_return_type = return_expr0.return_type
 		}
 		if g.unwrap_generic(g.recheck_concrete_type(resolved_call_return_type)) == ret_type {
-			if g.defer_stmts.len > 0 || return_needs_local_closure_cleanup {
+			if g.defer_stmts.len > 0 || return_needs_local_closure_cleanup
+				|| return_call_needs_closure_lifetime_arg_tmp {
 				g.write('${ret_typ} ${tmpvar} = ')
-				g.expr(expr0)
+				g.expr(return_expr0)
 				g.writeln(';')
 				g.write_defer_stmts_when_needed(node.scope, true, node.pos)
 				if return_needs_local_closure_cleanup {
@@ -11248,7 +11257,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			} else {
 				g.write_defer_stmts_when_needed(node.scope, true, node.pos)
 				g.write('return ')
-				g.expr(expr0)
+				g.expr(return_expr0)
 				g.writeln(';')
 			}
 			return
@@ -11256,6 +11265,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 	}
 	mut use_tmp_var := g.defer_stmts.len > 0 || g.defer_profile_code.len > 0
 		|| g.cur_lock.lockeds.len > 0 || return_needs_local_closure_cleanup
+		|| return_call_needs_closure_lifetime_arg_tmp
 		|| (fn_return_is_multi && exprs_len >= 1 && fn_return_is_option)
 		|| fn_return_is_fixed_array_non_result
 		|| (fn_return_is_multi && ret_expr_types.any(g.table.final_sym(it).kind == .array_fixed))

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -3838,7 +3838,8 @@ fn (mut g Gen) cleanup_local_closure_vars_on_return(node ast.Return) {
 	g.closure_cleanup_ignore_keep = true
 	g.cleanup_local_closure_vars(node.pos.pos - 1, node.pos.line_nr, true, -1, g.fn_decl.stmts)
 	g.closure_cleanup_ignore_keep = old_closure_cleanup_ignore_keep
-	g.cleanup_for_c_init_autofree_vars_on_return(returned_var_names_from_return(node))
+	returned_names, selector_owner_names := g.returned_var_names_from_return(node)
+	g.cleanup_for_c_init_autofree_vars_on_return(returned_names, selector_owner_names)
 }
 
 fn (mut g Gen) cleanup_local_closure_vars_before_synthetic_return(scope &ast.Scope, pos token.Pos) {
@@ -3894,7 +3895,7 @@ fn labeled_loop_for_c_init_vars(node &ast.Stmt) []string {
 	}
 }
 
-fn (mut g Gen) write_defer_stmts_before_labeled_continue_in_scope(scope &ast.Scope, pos token.Pos) {
+fn (mut g Gen) write_defer_stmts_before_labeled_jump_in_scope(scope &ast.Scope, pos token.Pos) {
 	prev_inside_defer_generation := g.inside_defer_generation
 	g.inside_defer_generation = true
 	defer {
@@ -3904,7 +3905,7 @@ fn (mut g Gen) write_defer_stmts_before_labeled_continue_in_scope(scope &ast.Sco
 	for i := g.defer_stmts.len - 1; i >= 0; i-- {
 		defer_stmt := g.defer_stmts[i]
 		if defer_stmt.scope == unsafe { nil } {
-			g.error('Gen.write_defer_stmts_before_labeled_continue(): defer_stmt.scope is nil', pos)
+			g.error('Gen.write_defer_stmts_before_labeled_jump(): defer_stmt.scope is nil', pos)
 		}
 		if defer_stmt.mode != .scoped || defer_stmt.scope != scope || defer_stmt.pos.pos >= pos.pos {
 			continue
@@ -3922,15 +3923,15 @@ fn (mut g Gen) write_defer_stmts_before_labeled_continue_in_scope(scope &ast.Sco
 	g.indent--
 }
 
-fn (mut g Gen) cleanup_scopes_before_labeled_continue(scope &ast.Scope, target_scope &ast.Scope,
+fn (mut g Gen) cleanup_scopes_before_labeled_jump(scope &ast.Scope, target_scope &ast.Scope,
 	pos token.Pos, keep_vars []string) {
 	if scope == unsafe { nil } || target_scope == unsafe { nil } {
 		return
 	}
 	for cleanup_scope := unsafe { scope }; cleanup_scope != unsafe { nil }; cleanup_scope = cleanup_scope.parent {
-		g.write_defer_stmts_before_labeled_continue_in_scope(cleanup_scope, pos)
+		g.write_defer_stmts_before_labeled_jump_in_scope(cleanup_scope, pos)
 		if g.needs_scope_cleanup() && !g.is_builtin_mod {
-			g.autofree_scope_vars2_before_labeled_continue(cleanup_scope, cleanup_scope.start_pos,
+			g.autofree_scope_vars2_before_labeled_jump(cleanup_scope, cleanup_scope.start_pos,
 				pos.pos - 1, cleanup_scope == target_scope, keep_vars)
 		}
 		if cleanup_scope == target_scope || cleanup_scope.detached_from_parent {
@@ -3939,7 +3940,7 @@ fn (mut g Gen) cleanup_scopes_before_labeled_continue(scope &ast.Scope, target_s
 	}
 }
 
-fn (mut g Gen) autofree_scope_vars2_before_labeled_continue(scope &ast.Scope, start_pos int,
+fn (mut g Gen) autofree_scope_vars2_before_labeled_jump(scope &ast.Scope, start_pos int,
 	end_pos int, is_target_scope bool, keep_vars []string) {
 	if scope == unsafe { nil } {
 		return
@@ -3949,7 +3950,6 @@ fn (mut g Gen) autofree_scope_vars2_before_labeled_continue(scope &ast.Scope, st
 			if obj.name in g.returned_var_names || obj.is_or || obj.is_tmp
 				|| obj.is_inherited || obj.pos.pos > end_pos
 				|| obj.pos.pos < start_pos
-				|| obj.name in g.for_c_init_autofree_keep_vars
 				|| (is_target_scope && obj.name in keep_vars)
 				|| (end_pos < scope.end_pos && obj.expr is ast.IfExpr) {
 				continue
@@ -11141,16 +11141,8 @@ fn (mut g Gen) branch_stmt(node ast.BranchStmt) {
 
 		stop_pos := labeled_loop_cleanup_stop_pos(x)
 		target_scope := labeled_loop_scope(x)
-		if node.kind == .key_break {
-			g.write_defer_stmts(node.scope, false, node.pos)
-		} else {
-			g.cleanup_scopes_before_labeled_continue(node.scope, target_scope, node.pos,
-				labeled_loop_for_c_init_vars(x))
-		}
-		if node.kind == .key_break && g.needs_scope_cleanup() && !g.is_builtin_mod {
-			g.trace_autofree('// free before labeled continue/break')
-			g.autofree_scope_vars_stop(node.pos.pos - 1, node.pos.line_nr, true, stop_pos)
-		}
+		g.cleanup_scopes_before_labeled_jump(node.scope, target_scope, node.pos,
+			labeled_loop_for_c_init_vars(x))
 		if g.fn_decl != unsafe { nil } {
 			if node.kind == .key_break {
 				old_closure_cleanup_target_loop_pos := g.closure_cleanup_target_loop_pos

--- a/vlib/v/gen/c/closure_context_codegen_test.v
+++ b/vlib/v/gen/c/closure_context_codegen_test.v
@@ -1,0 +1,894 @@
+import os
+
+const test_vexe = os.quoted_path(@VEXE)
+
+fn bounded_window(text string, marker string, before int, after int) string {
+	pos := text.index(marker) or {
+		assert false, 'missing marker: ${marker}'
+		return ''
+	}
+	start := if pos > before { pos - before } else { 0 }
+	end_limit := pos + marker.len + after
+	end := if end_limit < text.len { end_limit } else { text.len }
+	return text[start..end]
+}
+
+fn function_window(text string, marker string) string {
+	pos := text.index(marker) or {
+		assert false, 'missing marker: ${marker}'
+		return ''
+	}
+	rest := text[pos + marker.len..]
+	end_offset := rest.index('\nVV_LOC ') or { rest.len }
+	return text[pos..pos + marker.len + end_offset]
+}
+
+fn function_window_containing(text string, marker string) string {
+	pos := text.index(marker) or {
+		assert false, 'missing marker: ${marker}'
+		return ''
+	}
+	prefix := text[..pos]
+	start := prefix.last_index('\nVV_LOC ') or { 0 }
+	rest := text[start + 1..]
+	end_offset := rest.index('\nVV_LOC ') or { rest.len }
+	return rest[..end_offset]
+}
+
+fn test_closure_context_codegen_uses_collectable_memdup_and_ownership() {
+	workdir := os.join_path(os.vtmp_dir(), 'closure_context_codegen_${os.getpid()}')
+	os.mkdir_all(workdir)!
+	defer {
+		os.rmdir_all(workdir) or {}
+	}
+	source_path := os.join_path(workdir, 'main.v')
+	exe_path := os.join_path(workdir, 'main')
+	os.write_file(source_path, 'module main
+
+struct Receiver {
+mut:
+	value int
+}
+
+@[heap]
+struct PointerReceiver {
+mut:
+	value int
+}
+
+type IntCallback = fn (int) int
+
+type ZeroCallback = fn () int
+
+type ResultRequestHandler = fn (int) !
+
+__global global_cb = fn (x int) int {
+	return x
+}
+
+struct CallbackBox {
+mut:
+	cb IntCallback = unsafe { nil }
+}
+
+fn make_closure(seed int) fn () int {
+	return fn [seed] () int {
+		return seed + 1
+	}
+}
+
+fn (r Receiver) read() int {
+	return r.value
+}
+
+fn (mut r PointerReceiver) bump() int {
+	r.value++
+	return r.value
+}
+
+fn local_direct_closure() {
+	big := []int{len: 200, init: index}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	_ = h(11)
+}
+
+fn local_escaped_closure(mut callbacks []IntCallback) {
+	big := []int{len: 200, init: index}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	callbacks << h
+}
+
+fn local_return_fn_value(n int) IntCallback {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	return h
+}
+
+fn local_copy_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	k := h
+	return k(n % 200)
+}
+
+fn takes_cb(cb IntCallback, n int) int {
+	return cb(n % 200)
+}
+
+fn local_arg_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	return takes_cb(h, n)
+}
+
+fn local_struct_init_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	box := CallbackBox{
+		cb: h
+	}
+	return box.cb(n % 200)
+}
+
+fn local_struct_assign_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	mut box := CallbackBox{}
+	box.cb = h
+	return box.cb(n % 200)
+}
+
+fn local_global_assign_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	global_cb = h
+	return global_cb(n % 200)
+}
+
+fn local_defer_closure() {
+	big := []int{len: 200, init: index}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	defer {
+		_ = h(0)
+	}
+}
+
+fn local_return_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	if n >= 0 {
+		return h(n % 200)
+	}
+	return 0
+}
+
+fn local_call_then_return_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	_ = h(n % 200)
+	return 0
+}
+
+fn maybe_int(n int) ?int {
+	if n < 0 {
+		return none
+	}
+	return n
+}
+
+fn result_int(n int) !int {
+	if n < 0 {
+		return error("negative")
+	}
+	return n
+}
+
+fn maybe_request(request int) ! {
+	if request < 0 {
+		return error("negative request")
+	}
+}
+
+fn local_option_propagation_cleanup(n int) ?int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	value := maybe_int(n)?
+	return h(value % 200)
+}
+
+fn local_result_propagation_cleanup(n int) !int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	value := result_int(n)!
+	return h(value % 200)
+}
+
+fn local_result_handler_cast_closure_boundary() {
+	offset := 1
+	handle_request := fn [offset] (request int) ! {
+		maybe_request(request)!
+		_ = offset
+	}
+	_ = ResultRequestHandler(handle_request)
+}
+
+fn local_for_c_init_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	for i := takes_cb(h, n); i < 1; i++ {
+		return i
+	}
+	return 0
+}
+
+fn local_for_c_cond_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	mut result := 0
+	for i := 0; i < 1 && takes_cb(h, n) >= 0; i++ {
+		result += i
+	}
+	return result
+}
+
+fn local_for_c_inc_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	mut result := 0
+	for i := 0; i < 1; i += takes_cb(h, n) + 1 {
+		result += i
+	}
+	return result
+}
+
+fn local_for_c_init_closure_body_tail(n int) int {
+	big := []int{len: 200, init: index + n}
+	mut i := 0
+	mut result := 0
+	for h := fn [big] (x int) int {
+		return big[x % big.len]
+	}; i < 2; i++ {
+		result += h(i)
+	}
+	return result
+}
+
+fn local_for_c_init_closure_continue(n int) int {
+	big := []int{len: 200, init: index + n}
+	mut i := 0
+	mut result := 0
+	for h := fn [big] (x int) int {
+		return big[x % big.len]
+	}; i < 2; i++ {
+		if i == 0 {
+			continue
+		}
+		result += h(i)
+	}
+	return result
+}
+
+fn local_multi_for_c_init_closure_body_tail(n int) int {
+	big := []int{len: 200, init: index + n}
+	mut result := 0
+	for h, i := fn [big] (x int) int {
+		return big[x % big.len]
+	}, 0; i < 2; i++ {
+		result += h(i)
+	}
+	return result
+}
+
+fn local_for_c_body_closure_continue_cleanup(n int) int {
+	mut i := 0
+	for ; i < 1; i++ {
+		big := []int{len: 200, init: index + n}
+		h := fn [big] (x int) int {
+			return big[x % big.len]
+		}
+		_ = h(n % 200)
+		continue
+	}
+	return 0
+}
+
+fn local_for_c_init_closure_return_cleanup(n int) int {
+	big := []int{len: 200, init: index + n}
+	mut i := 0
+	for h := fn [big] (x int) int {
+		return big[x % big.len]
+	}; i < 1; i++ {
+		return h(n % 200)
+	}
+	return -1
+}
+
+fn local_for_c_init_closure_labeled_break_cleanup(n int) int {
+	big := []int{len: 200, init: index + n}
+	mut i := 0
+	mut result := 0
+	closure_init_break: for h := fn [big] (x int) int {
+		return big[x % big.len]
+	}; i < 1; i++ {
+		result += h(n % 200)
+		break closure_init_break
+	}
+	return result
+}
+
+fn local_for_c_init_escaped_closure(mut callbacks []ZeroCallback, n int) {
+	big := []int{len: 200, init: index + n}
+	mut i := 0
+	for h := fn [big, n] () int {
+		return big[n % big.len]
+	}; i < 1; i++ {
+		callbacks << h
+	}
+}
+
+fn local_nested_for_c_init_closure_continue_outer(n int) int {
+	outer_big := []int{len: 200, init: index + n}
+	mut i := 0
+	mut result := 0
+	nested_continue_outer: for outer_h := fn [outer_big] (x int) int {
+		return outer_big[x % outer_big.len]
+	}; i < 2; i++ {
+		inner_big := []int{len: 200, init: index + n + 10}
+		mut j := 0
+		for inner_h := fn [inner_big] (x int) int {
+			return inner_big[x % inner_big.len]
+		}; j < 1; j++ {
+			result += outer_h(i) + inner_h(j)
+			continue nested_continue_outer
+		}
+	}
+	return result
+}
+
+fn local_nested_for_c_init_closure_break_outer(n int) int {
+	outer_big := []int{len: 200, init: index + n}
+	mut i := 0
+	mut result := 0
+	nested_break_outer: for outer_h := fn [outer_big] (x int) int {
+		return outer_big[x % outer_big.len]
+	}; i < 2; i++ {
+		inner_big := []int{len: 200, init: index + n + 20}
+		mut j := 0
+		for inner_h := fn [inner_big] (x int) int {
+			return inner_big[x % inner_big.len]
+		}; j < 1; j++ {
+			result += outer_h(i) + inner_h(j)
+			break nested_break_outer
+		}
+	}
+	return result
+}
+
+fn local_for_cond_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	mut result := 0
+	for result < 1 && takes_cb(h, n) >= 0 {
+		break
+	}
+	return result
+}
+
+fn local_for_in_cond_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	for value in []int{len: 1, init: takes_cb(h, n)} {
+		return value
+	}
+	return 0
+}
+
+fn local_for_in_high_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	mut result := 0
+	for i in 0 .. takes_cb(h, n) {
+		result += i
+	}
+	return result
+}
+
+fn local_array_init_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	values := []int{len: 1, init: takes_cb(h, n)}
+	return values[0]
+}
+
+fn local_if_else_condition_closure(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	if n < 0 {
+		return n
+	} else if takes_cb(h, n) >= 0 {
+		return 0
+	}
+	return n
+}
+
+fn local_nested_returning_closure(n int) ZeroCallback {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	nested := fn [h, n] () int {
+		return h(n % 200)
+	}
+	return nested
+}
+
+fn local_nested_stored_closure(mut callbacks []ZeroCallback, n int) {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	nested := fn [h, n] () int {
+		return h(n % 200)
+	}
+	callbacks << nested
+}
+
+fn local_keyword_closure() {
+	big := []int{len: 200, init: index}
+	free := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+}
+
+fn local_labeled_break_closure(n int) int {
+	mut value := 0
+	closure_break: for {
+		big := []int{len: 200, init: index + n}
+		h := fn [big] (x int) int {
+			return big[x % big.len]
+		}
+		value = h(n % 200)
+		break closure_break
+	}
+	return value
+}
+
+fn local_labeled_continue_closure(n int) int {
+	mut value := 0
+	closure_continue: for _ in 0 .. 1 {
+		big := []int{len: 200, init: index + n}
+		h := fn [big] (x int) int {
+			return big[x % big.len]
+		}
+		value = h(n % 200)
+		continue closure_continue
+	}
+	return value
+}
+
+fn local_spawn_closure() {
+	big := []int{len: 200, init: index}
+	h := fn [big] () {
+		_ = big[0]
+	}
+	t := spawn h()
+	t.wait()
+}
+
+fn local_go_closure() {
+	big := []int{len: 200, init: index}
+	h := fn [big] () {
+		_ = big[0]
+	}
+	t := go h()
+	t.wait()
+}
+
+fn main() {
+	receiver := Receiver{
+		value: 10
+	}
+	mut pointer_receiver := &PointerReceiver{
+		value: 10
+	}
+	anon_cb := make_closure(5)
+	value_cb := receiver.read
+	pointer_cb := pointer_receiver.bump
+	local_direct_closure()
+	mut callbacks := []IntCallback{}
+	local_escaped_closure(mut callbacks)
+	local_spawn_closure()
+	local_go_closure()
+	local_defer_closure()
+	local_result_handler_cast_closure_boundary()
+	opt_cleanup := local_option_propagation_cleanup(-1) or { 0 }
+	res_cleanup := local_result_propagation_cleanup(-1) or { 0 }
+	returned_cb := local_return_fn_value(0)
+	returned_nested := local_nested_returning_closure(0)
+	mut zero_callbacks := []ZeroCallback{}
+	local_nested_stored_closure(mut zero_callbacks, 0)
+	local_keyword_closure()
+	mut escaped_for_c_callbacks := []ZeroCallback{}
+	local_for_c_init_escaped_closure(mut escaped_for_c_callbacks, 0)
+	mut total := anon_cb() + value_cb() + pointer_cb() + local_return_closure(0)
+	total += local_call_then_return_closure(0) + opt_cleanup + res_cleanup
+	total += local_for_c_init_closure(0) + local_for_c_cond_closure(0) + local_for_c_inc_closure(0)
+	total += local_for_c_init_closure_body_tail(0) + local_for_c_init_closure_continue(0)
+	total += local_multi_for_c_init_closure_body_tail(0) + local_for_c_body_closure_continue_cleanup(0)
+	total += local_for_c_init_closure_return_cleanup(0) + local_for_c_init_closure_labeled_break_cleanup(0)
+	total += escaped_for_c_callbacks[0]()
+	total += local_nested_for_c_init_closure_continue_outer(0) + local_nested_for_c_init_closure_break_outer(0)
+	total += local_for_cond_closure(0) + local_for_in_cond_closure(0) + local_for_in_high_closure(0)
+	total += local_array_init_closure(0) + local_if_else_condition_closure(0) + returned_nested()
+	total += zero_callbacks[0]() + local_labeled_break_closure(0) + local_labeled_continue_closure(0)
+	total += returned_cb(0) + local_copy_closure(0) + local_arg_closure(0)
+	total += local_struct_init_closure(0) + local_struct_assign_closure(0) + local_global_assign_closure(0)
+	println(total)
+}
+')!
+
+	c_cmd := '${test_vexe} -enable-globals -gc boehm -skip-unused -o - ${os.quoted_path(source_path)}'
+	c_res := os.execute(c_cmd)
+	assert c_res.exit_code == 0, '${c_cmd}\n${c_res.output}'
+	generated := c_res.output.replace('\r\n', '\n')
+	assert !generated.contains('builtin__memdup_uncollectable')
+	assert generated.contains('sizeof(builtin__closure__ClosureLiveInfo)')
+	assert !generated.contains('new_map_noscan_value(sizeof(voidptr), sizeof(builtin__closure__ClosureLiveInfo)')
+	assert !generated.contains('new_map_noscan_key_value(sizeof(voidptr), sizeof(builtin__closure__ClosureLiveInfo)')
+
+	anon_window := bounded_window(generated, 'VV_LOC anon_fn___int main__make_closure(int seed) {',
+		0, 900)
+	assert anon_window.contains('builtin__closure__closure_create_with_data(')
+	assert anon_window.contains('builtin__memdup(&(')
+	assert anon_window.contains(', true)')
+
+	value_method_call := bounded_window(generated,
+		'builtin__closure__closure_create_with_data(_V_closure_main__Receiver_read_', 0, 300)
+	assert value_method_call.contains('builtin__memdup(')
+	assert value_method_call.contains(', true)')
+
+	pointer_method_call := bounded_window(generated,
+		'builtin__closure__closure_create_with_data(_V_closure_main__PointerReceiver_bump_', 0, 300)
+	assert !pointer_method_call.contains('builtin__memdup(')
+	assert pointer_method_call.contains(', false)')
+
+	direct_fn := function_window(generated, 'void main__local_direct_closure(void) {')
+	assert direct_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	escaped_fn := function_window(generated, 'void main__local_escaped_closure')
+	assert !escaped_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	return_value_fn := function_window(generated, 'main__IntCallback main__local_return_fn_value')
+	assert !return_value_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	copy_fn := function_window(generated, 'int main__local_copy_closure(int n) {')
+	assert !copy_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	arg_fn := function_window(generated, 'int main__local_arg_closure(int n) {')
+	assert !arg_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	struct_init_fn := function_window(generated, 'int main__local_struct_init_closure(int n) {')
+	assert !struct_init_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	struct_assign_fn := function_window(generated, 'int main__local_struct_assign_closure(int n) {')
+	assert !struct_assign_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	global_assign_fn := function_window(generated, 'int main__local_global_assign_closure(int n) {')
+	assert !global_assign_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	defer_fn := function_window(generated, 'void main__local_defer_closure(void) {')
+	assert !defer_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	return_fn := function_window(generated, 'int main__local_return_closure(int n) {')
+	return_cleanup_pos := return_fn.index('builtin__closure__closure_try_destroy((voidptr)h);') or {
+		assert false, return_fn
+		return
+	}
+	return_tmp_pos := return_fn.index(' = h(') or {
+		assert false, return_fn
+		return
+	}
+	assert return_tmp_pos < return_cleanup_pos
+	assert return_fn[return_cleanup_pos..].contains('return _')
+
+	call_return_fn := function_window(generated,
+		'int main__local_call_then_return_closure(int n) {')
+	assert call_return_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	option_propagation_fn := function_window(generated,
+		'main__local_option_propagation_cleanup(int n) {')
+	option_call_pos := option_propagation_fn.index('main__maybe_int(n)') or {
+		assert false, option_propagation_fn
+		return
+	}
+	option_after_call := option_propagation_fn[option_call_pos..]
+	option_value_pos := option_after_call.index('int value = ') or {
+		assert false, option_propagation_fn
+		return
+	}
+	option_fail_branch := option_after_call[..option_value_pos]
+	option_cleanup_pos := option_fail_branch.index('builtin__closure__closure_try_destroy((voidptr)h);') or {
+		assert false, option_propagation_fn
+		return
+	}
+	option_hidden_return_pos := option_fail_branch.index('\treturn ') or {
+		assert false, option_propagation_fn
+		return
+	}
+	assert option_cleanup_pos < option_hidden_return_pos
+
+	result_propagation_fn := function_window(generated,
+		'main__local_result_propagation_cleanup(int n) {')
+	result_call_pos := result_propagation_fn.index('main__result_int(n)') or {
+		assert false, result_propagation_fn
+		return
+	}
+	result_after_call := result_propagation_fn[result_call_pos..]
+	result_value_pos := result_after_call.index('int value = ') or {
+		assert false, result_propagation_fn
+		return
+	}
+	result_fail_branch := result_after_call[..result_value_pos]
+	result_cleanup_pos := result_fail_branch.index('builtin__closure__closure_try_destroy((voidptr)h);') or {
+		assert false, result_propagation_fn
+		return
+	}
+	result_hidden_return_pos := result_fail_branch.index('\treturn ') or {
+		assert false, result_propagation_fn
+		return
+	}
+	assert result_cleanup_pos < result_hidden_return_pos
+
+	result_handler_anon_fn := function_window_containing(generated, 'main__maybe_request(request)')
+	assert !result_handler_anon_fn.contains('builtin__closure__closure_try_destroy((voidptr)handle_request);')
+
+	for_c_init_fn := function_window(generated, 'int main__local_for_c_init_closure(int n) {')
+	assert !for_c_init_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	for_c_cond_fn := function_window(generated, 'int main__local_for_c_cond_closure(int n) {')
+	assert !for_c_cond_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	for_c_inc_fn := function_window(generated, 'int main__local_for_c_inc_closure(int n) {')
+	assert !for_c_inc_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	for_c_init_body_tail_fn := function_window(generated,
+		'int main__local_for_c_init_closure_body_tail(int n) {')
+	assert for_c_init_body_tail_fn.contains('for (;')
+	for_c_init_body_tail_call_pos := for_c_init_body_tail_fn.index('result += h(') or {
+		assert false, for_c_init_body_tail_fn
+		return
+	}
+	for_c_init_body_tail_cleanup_pos := for_c_init_body_tail_fn.index('builtin__closure__closure_try_destroy((voidptr)h);') or {
+		assert false, for_c_init_body_tail_fn
+		return
+	}
+	for_c_init_body_tail_return_pos := for_c_init_body_tail_fn.index('return result;') or {
+		assert false, for_c_init_body_tail_fn
+		return
+	}
+	assert for_c_init_body_tail_call_pos < for_c_init_body_tail_cleanup_pos
+	assert for_c_init_body_tail_cleanup_pos < for_c_init_body_tail_return_pos
+
+	for_c_init_continue_fn := function_window(generated,
+		'int main__local_for_c_init_closure_continue(int n) {')
+	assert for_c_init_continue_fn.contains('for (;')
+	for_c_init_continue_pos := for_c_init_continue_fn.index('continue;') or {
+		assert false, for_c_init_continue_fn
+		return
+	}
+	for_c_init_continue_cleanup_pos := for_c_init_continue_fn.index('builtin__closure__closure_try_destroy((voidptr)h);') or {
+		assert false, for_c_init_continue_fn
+		return
+	}
+	for_c_init_continue_return_pos := for_c_init_continue_fn.index('return result;') or {
+		assert false, for_c_init_continue_fn
+		return
+	}
+	assert for_c_init_continue_pos < for_c_init_continue_cleanup_pos
+	assert for_c_init_continue_cleanup_pos < for_c_init_continue_return_pos
+
+	multi_for_c_init_body_tail_fn := function_window(generated,
+		'int main__local_multi_for_c_init_closure_body_tail(int n) {')
+	assert multi_for_c_init_body_tail_fn.contains('while (true)')
+	assert multi_for_c_init_body_tail_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	for_c_body_continue_fn := function_window(generated,
+		'int main__local_for_c_body_closure_continue_cleanup(int n) {')
+	for_c_body_continue_cleanup_pos := for_c_body_continue_fn.index('builtin__closure__closure_try_destroy((voidptr)h);') or {
+		assert false, for_c_body_continue_fn
+		return
+	}
+	for_c_body_continue_pos := for_c_body_continue_fn.index('continue;') or {
+		assert false, for_c_body_continue_fn
+		return
+	}
+	assert for_c_body_continue_cleanup_pos < for_c_body_continue_pos
+
+	for_c_init_return_fn := function_window(generated,
+		'int main__local_for_c_init_closure_return_cleanup(int n) {')
+	for_c_init_return_call_pos := for_c_init_return_fn.index(' = h(') or {
+		assert false, for_c_init_return_fn
+		return
+	}
+	for_c_init_return_cleanup_pos := for_c_init_return_fn.index('builtin__closure__closure_try_destroy((voidptr)h);') or {
+		assert false, for_c_init_return_fn
+		return
+	}
+	for_c_init_return_pos := for_c_init_return_fn.index('\treturn ') or {
+		assert false, for_c_init_return_fn
+		return
+	}
+	assert for_c_init_return_call_pos < for_c_init_return_cleanup_pos
+	assert for_c_init_return_cleanup_pos < for_c_init_return_pos
+
+	for_c_init_labeled_break_fn := function_window(generated,
+		'int main__local_for_c_init_closure_labeled_break_cleanup(int n) {')
+	for_c_init_labeled_break_goto_pos := for_c_init_labeled_break_fn.index('goto closure_init_break__break;') or {
+		assert false, for_c_init_labeled_break_fn
+		return
+	}
+	for_c_init_labeled_break_label_pos := for_c_init_labeled_break_fn.index('closure_init_break__break: {}') or {
+		assert false, for_c_init_labeled_break_fn
+		return
+	}
+	for_c_init_labeled_break_cleanup_pos := for_c_init_labeled_break_fn.index('builtin__closure__closure_try_destroy((voidptr)h);') or {
+		assert false, for_c_init_labeled_break_fn
+		return
+	}
+	assert for_c_init_labeled_break_goto_pos < for_c_init_labeled_break_label_pos
+	assert for_c_init_labeled_break_label_pos < for_c_init_labeled_break_cleanup_pos
+
+	for_c_init_escaped_fn := function_window(generated,
+		'void main__local_for_c_init_escaped_closure')
+	assert !for_c_init_escaped_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	nested_continue_fn := function_window(generated,
+		'int main__local_nested_for_c_init_closure_continue_outer(int n) {')
+	nested_continue_inner_cleanup_pos := nested_continue_fn.index('builtin__closure__closure_try_destroy((voidptr)inner_h);') or {
+		assert false, nested_continue_fn
+		return
+	}
+	nested_continue_goto_pos := nested_continue_fn.index('goto nested_continue_outer__continue_entry;') or {
+		assert false, nested_continue_fn
+		return
+	}
+	nested_continue_outer_cleanup_pos := nested_continue_fn.index('builtin__closure__closure_try_destroy((voidptr)outer_h);') or {
+		assert false, nested_continue_fn
+		return
+	}
+	assert nested_continue_inner_cleanup_pos < nested_continue_goto_pos
+	assert nested_continue_goto_pos < nested_continue_outer_cleanup_pos
+
+	nested_break_fn := function_window(generated,
+		'int main__local_nested_for_c_init_closure_break_outer(int n) {')
+	nested_break_inner_cleanup_pos := nested_break_fn.index('builtin__closure__closure_try_destroy((voidptr)inner_h);') or {
+		assert false, nested_break_fn
+		return
+	}
+	nested_break_goto_pos := nested_break_fn.index('goto nested_break_outer__break;') or {
+		assert false, nested_break_fn
+		return
+	}
+	nested_break_label_pos := nested_break_fn.index('nested_break_outer__break: {}') or {
+		assert false, nested_break_fn
+		return
+	}
+	nested_break_outer_cleanup_pos := nested_break_fn.index('builtin__closure__closure_try_destroy((voidptr)outer_h);') or {
+		assert false, nested_break_fn
+		return
+	}
+	assert nested_break_inner_cleanup_pos < nested_break_goto_pos
+	assert nested_break_goto_pos < nested_break_label_pos
+	assert nested_break_label_pos < nested_break_outer_cleanup_pos
+
+	for_cond_fn := function_window(generated, 'int main__local_for_cond_closure(int n) {')
+	assert !for_cond_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	for_in_cond_fn := function_window(generated, 'int main__local_for_in_cond_closure(int n) {')
+	assert !for_in_cond_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	for_in_high_fn := function_window(generated, 'int main__local_for_in_high_closure(int n) {')
+	assert !for_in_high_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	array_init_fn := function_window(generated, 'int main__local_array_init_closure(int n) {')
+	assert !array_init_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	if_condition_fn := function_window(generated,
+		'int main__local_if_else_condition_closure(int n) {')
+	assert !if_condition_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	nested_returning_fn := function_window(generated,
+		'main__ZeroCallback main__local_nested_returning_closure(int n) {')
+	assert !nested_returning_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+	assert !nested_returning_fn.contains('builtin__closure__closure_try_destroy((voidptr)nested);')
+
+	nested_stored_fn := function_window(generated, 'void main__local_nested_stored_closure')
+	assert !nested_stored_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+	assert !nested_stored_fn.contains('builtin__closure__closure_try_destroy((voidptr)nested);')
+
+	keyword_fn := function_window(generated, 'void main__local_keyword_closure(void) {')
+	assert keyword_fn.contains('(*_v_free)')
+	assert keyword_fn.contains('builtin__closure__closure_try_destroy((voidptr)_v_free);')
+	assert !keyword_fn.contains('builtin__closure__closure_try_destroy((voidptr)__v_free);')
+	assert !keyword_fn.contains('builtin__closure__closure_try_destroy((voidptr)free);')
+
+	labeled_break_fn := function_window(generated, 'int main__local_labeled_break_closure(int n) {')
+	labeled_break_cleanup_pos := labeled_break_fn.index('builtin__closure__closure_try_destroy((voidptr)h);') or {
+		assert false, labeled_break_fn
+		return
+	}
+	labeled_break_goto_pos := labeled_break_fn.index('goto closure_break__break;') or {
+		assert false, labeled_break_fn
+		return
+	}
+	assert labeled_break_cleanup_pos < labeled_break_goto_pos
+
+	labeled_continue_fn := function_window(generated,
+		'int main__local_labeled_continue_closure(int n) {')
+	labeled_continue_cleanup_pos := labeled_continue_fn.index('builtin__closure__closure_try_destroy((voidptr)h);') or {
+		assert false, labeled_continue_fn
+		return
+	}
+	labeled_continue_goto_pos := labeled_continue_fn.index('goto closure_continue__continue_entry;') or {
+		assert false, labeled_continue_fn
+		return
+	}
+	assert labeled_continue_cleanup_pos < labeled_continue_goto_pos
+
+	spawn_fn := function_window(generated, 'void main__local_spawn_closure(void) {')
+	assert spawn_fn.contains('/*spawn (thread) */')
+	assert !spawn_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	go_fn := function_window(generated, 'void main__local_go_closure(void) {')
+	assert go_fn.contains('/*spawn (thread) */') || go_fn.contains('/*go (coroutine) */')
+	assert !go_fn.contains('builtin__closure__closure_try_destroy((voidptr)h);')
+
+	compile_cmd := '${test_vexe} -enable-globals -gc none -skip-unused -o ${os.quoted_path(exe_path)} ${os.quoted_path(source_path)}'
+	compile_res := os.execute(compile_cmd)
+	assert compile_res.exit_code == 0, '${compile_cmd}\n${compile_res.output}'
+	run_res := os.execute(os.quoted_path(exe_path))
+	assert run_res.exit_code == 0, run_res.output
+	assert run_res.output.trim_space() == '71'
+}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2312,6 +2312,12 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			return
 		}
 	}
+	closure_frame_arg_tmps := g.prepare_closure_lifetime_arg_tmps(node)
+	defer {
+		for pos in closure_frame_arg_tmps.keys() {
+			g.closure_frame_arg_tmps.delete(pos)
+		}
+	}
 	old_inside_call := g.inside_call
 	g.inside_call = true
 	// Reset inside_selector_lhs so that receiver expressions inside method
@@ -2444,6 +2450,13 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 	} else {
 		g.fn_call(node)
 	}
+	if closure_frame_arg_tmps.len > 0 {
+		g.writeln(';')
+		for _, tmp in closure_frame_arg_tmps {
+			g.writeln('builtin__closure__closure_try_destroy((voidptr)${tmp});')
+		}
+		g.set_current_pos_as_last_stmt_pos()
+	}
 	if needs_tmp_fn_result_cleanup && !gen_or && !gen_keep_alive && !g.inside_curry_call {
 		if node.return_type == ast.void_type {
 			g.writeln(';')
@@ -2525,6 +2538,105 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			}
 		}
 	}
+}
+
+fn (mut g Gen) is_closure_lifetime_callback_call(node ast.CallExpr) bool {
+	method_name := node.name.all_after_last('.')
+	if !node.is_method || method_name !in ['frame', 'suspend', 'untracked'] || node.args.len != 1 {
+		return false
+	}
+	mut receiver_type := g.unwrap_generic(node.receiver_type)
+	if receiver_type == 0 {
+		receiver_type = g.unwrap_generic(node.left_type)
+	}
+	if receiver_type == 0 {
+		return false
+	}
+	if receiver_type.is_ptr() {
+		receiver_type = receiver_type.deref()
+	}
+	return g.table.sym(receiver_type).name == 'builtin.closure.Lifetime'
+}
+
+fn (mut g Gen) closure_lifetime_arg_needs_tmp(expr ast.Expr) bool {
+	unwrapped_expr := expr.remove_par()
+	return match unwrapped_expr {
+		ast.AnonFn {
+			unwrapped_expr.inherited_vars.len > 0
+		}
+		ast.SelectorExpr {
+			unwrapped_expr.has_hidden_receiver
+		}
+		else {
+			false
+		}
+	}
+}
+
+fn (mut g Gen) call_needs_closure_lifetime_arg_tmp(node ast.CallExpr) bool {
+	return g.is_closure_lifetime_callback_call(node)
+		&& g.closure_lifetime_arg_needs_tmp(node.args[0].expr)
+}
+
+fn (mut g Gen) closure_lifetime_fn_type_tmp_signature(fn_types []ast.Type, tmp string) ?string {
+	for raw_fn_typ in fn_types {
+		fn_typ := g.unwrap_generic(g.recheck_concrete_type(raw_fn_typ))
+		if fn_typ == 0 {
+			continue
+		}
+		fn_sym := g.table.final_sym(fn_typ)
+		if fn_sym.info is ast.FnType {
+			func := fn_sym.info.func
+			return g.fn_var_signature(ast.void_type, func.return_type, func.params.map(it.typ), tmp)
+		}
+	}
+	return none
+}
+
+fn (mut g Gen) closure_lifetime_arg_tmp_signature(node ast.CallExpr, arg ast.CallArg, tmp string) ?string {
+	unwrapped_expr := arg.expr.remove_par()
+	match unwrapped_expr {
+		ast.AnonFn {
+			return g.fn_var_signature(ast.void_type, unwrapped_expr.decl.return_type,
+				unwrapped_expr.decl.params.map(it.typ), tmp)
+		}
+		ast.SelectorExpr {
+			mut fn_types := []ast.Type{}
+			if arg.typ != 0 {
+				fn_types << arg.typ
+			}
+			if unwrapped_expr.typ != 0 {
+				fn_types << unwrapped_expr.typ
+			}
+			if node.expected_arg_types.len > 0 && node.expected_arg_types[0] != 0 {
+				fn_types << node.expected_arg_types[0]
+			}
+			return g.closure_lifetime_fn_type_tmp_signature(fn_types, tmp)
+		}
+		else {}
+	}
+
+	return none
+}
+
+fn (mut g Gen) prepare_closure_lifetime_arg_tmps(node ast.CallExpr) map[int]string {
+	mut tmps := map[int]string{}
+	if !g.call_needs_closure_lifetime_arg_tmp(node) {
+		return tmps
+	}
+	arg := node.args[0]
+	tmp := g.new_tmp_var()
+	fn_type := g.closure_lifetime_arg_tmp_signature(node, arg, tmp) or { return tmps }
+	line := g.go_before_last_stmt().trim_space()
+	g.empty_line = true
+	g.write('${fn_type} = ')
+	g.expr(ast.Expr(arg.expr))
+	g.writeln(';')
+	g.set_current_pos_as_last_stmt_pos()
+	g.write(line)
+	tmps[arg.pos.pos] = tmp
+	g.closure_frame_arg_tmps[arg.pos.pos] = tmp
+	return tmps
 }
 
 fn (mut g Gen) conversion_function_call(prefix string, postfix string, node ast.CallExpr) {
@@ -6409,6 +6521,13 @@ fn (mut g Gen) call_args(node ast.CallExpr) {
 	for i, arg in args {
 		if is_variadic && i == expected_types.len - 1 {
 			break
+		}
+		if tmp := g.closure_frame_arg_tmps[arg.pos.pos] {
+			g.write(tmp)
+			if i < args.len - 1 || is_variadic {
+				g.write(', ')
+			}
+			continue
 		}
 		mut is_smartcast := false
 		if arg.expr is ast.Ident {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1805,7 +1805,7 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 	ctx_struct := g.closure_ctx(node.decl)
 	// it may be possible to optimize `memdup` out if the closure never leaves current scope
 	// TODO: in case of an assignment, this should only call "closure_set_data" and "closure_set_function" (and free the former data)
-	g.write('builtin__closure__closure_create(${fn_name}, (${ctx_struct}*) builtin__memdup_uncollectable(&(${ctx_struct}){')
+	g.write('builtin__closure__closure_create_with_data(${fn_name}, (${ctx_struct}*) builtin__memdup(&(${ctx_struct}){')
 	g.indent++
 	for var in node.inherited_vars {
 		mut has_inherited := false
@@ -1894,7 +1894,7 @@ fn (mut g Gen) gen_anon_fn(mut node ast.AnonFn) {
 		}
 	}
 	g.indent--
-	g.write('}, sizeof(${ctx_struct})))')
+	g.write('}, sizeof(${ctx_struct})), true)')
 
 	g.empty_line = false
 }

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -4,6 +4,7 @@
 module c
 
 import v.ast
+import v.token
 import v.util
 
 struct ForCOverflowGuard {
@@ -205,9 +206,112 @@ fn (g &Gen) for_c_init_local_closure_vars(node ast.ForCStmt) []ast.Var {
 	return vars
 }
 
+fn (mut g Gen) local_var_needs_scope_autofree(var ast.Var) bool {
+	if !g.needs_scope_cleanup() || g.is_builtin_mod || var.name == '_' || var.is_arg || var.is_tmp
+		|| var.is_inherited || var.typ == 0 {
+		return false
+	}
+	base_typ := var.typ.set_nr_muls(0).clear_option_and_result()
+	if g.type_has_unresolved_generic_parts(base_typ) {
+		return false
+	}
+	sym := g.table.sym(base_typ)
+	if sym.kind in [.array, .map, .string] || sym.has_method('free') || var.is_auto_heap {
+		return true
+	}
+	return var.typ.is_ptr() && sym.name.after('.').len > 0 && sym.name.after('.')[0].is_capital()
+		&& g.pref.experimental
+}
+
+fn (mut g Gen) for_c_init_autofree_vars(node ast.ForCStmt) []ast.Var {
+	if !node.has_init || node.init !is ast.AssignStmt {
+		return []
+	}
+	init := node.init as ast.AssignStmt
+	if init.op != .decl_assign {
+		return []
+	}
+	mut vars := []ast.Var{}
+	for left in init.left {
+		if left is ast.Ident {
+			mut obj := if left.obj is ast.Var {
+				left.obj
+			} else {
+				ast.Var{}
+			}
+			if node.scope != unsafe { nil } {
+				if scope_var := node.scope.find_var(left.name) {
+					if scope_var.pos.pos == left.pos.pos {
+						obj = *scope_var
+					}
+				}
+			}
+			if g.local_var_needs_scope_autofree(obj) {
+				vars << obj
+			}
+		}
+	}
+	return vars
+}
+
+fn (mut g Gen) push_for_c_init_autofree_keep_vars(vars []ast.Var) int {
+	start := g.for_c_init_autofree_keep_vars.len
+	for var in vars {
+		g.for_c_init_autofree_keep_vars << var.name
+		g.for_c_init_autofree_cleanup_vars << var
+	}
+	return start
+}
+
+fn (mut g Gen) pop_for_c_init_autofree_keep_vars(start int) {
+	if g.for_c_init_autofree_keep_vars.len > start {
+		g.for_c_init_autofree_keep_vars = g.for_c_init_autofree_keep_vars[..start].clone()
+	}
+	if g.for_c_init_autofree_cleanup_vars.len > start {
+		g.for_c_init_autofree_cleanup_vars = g.for_c_init_autofree_cleanup_vars[..start].clone()
+	}
+}
+
+fn (mut g Gen) cleanup_for_c_init_autofree_vars(vars []ast.Var) {
+	for var in vars {
+		g.autofree_variable(var)
+	}
+	for g.autofree_scope_stmts.len > 0 {
+		g.write(g.autofree_scope_stmts.pop())
+	}
+}
+
+fn (mut g Gen) cleanup_for_c_init_autofree_vars_on_return(returned_names map[string]bool) {
+	for var in g.for_c_init_autofree_cleanup_vars {
+		if var.name in returned_names {
+			continue
+		}
+		g.autofree_variable(var)
+	}
+	for g.autofree_scope_stmts.len > 0 {
+		g.write(g.autofree_scope_stmts.pop())
+	}
+}
+
+fn (mut g Gen) write_loop_scope_cleanup_after_defer(scope &ast.Scope, pos token.Pos, stmts []ast.Stmt,
+	ends_with_branch bool) {
+	if ends_with_branch || scope == unsafe { nil } {
+		return
+	}
+	if g.needs_scope_cleanup() && !g.is_builtin_mod {
+		g.autofree_scope_vars2(scope, scope.start_pos, scope.end_pos, pos.line_nr, false, -1)
+	}
+	if g.fn_decl != unsafe { nil } {
+		g.cleanup_local_closure_vars2(scope, scope.start_pos, scope.end_pos, pos.line_nr, false,
+			-1, stmts)
+	}
+}
+
 fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 	g.loop_depth++
 	init_closure_vars := g.for_c_init_local_closure_vars(node)
+	init_autofree_vars := g.for_c_init_autofree_vars(node)
+	has_init_outer_cleanup := init_closure_vars.len > 0 || init_autofree_vars.len > 0
 	if node.is_multi {
 		g.is_vlines_enabled = false
 		g.inside_for_c_stmt = true
@@ -245,23 +349,34 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 		if node.label.len > 0 {
 			g.writeln('{')
 		}
+		autofree_keep_start := g.push_for_c_init_autofree_keep_vars(init_autofree_vars)
 		preserve_start := g.push_local_closure_cleanup_preserve_vars(init_closure_vars,
 			node.pos.pos)
-		g.stmts(node.stmts)
-		g.pop_local_closure_cleanup_preserve_vars(preserve_start)
+		skip_cleanup_start := g.push_skip_scope_cleanup(node.scope)
+		ends_with_branch := g.stmts_with_tmp_var(node.stmts, '')
+		g.pop_skip_scope_cleanup(skip_cleanup_start)
 		if node.label.len > 0 {
+			g.write_defer_stmts(node.scope, false, node.pos)
+			g.write_loop_scope_cleanup_after_defer(node.scope, node.pos, node.stmts,
+				ends_with_branch)
 			g.writeln('}')
 			g.writeln('${node.label}__continue: {}')
+		} else {
+			g.write_defer_stmts(node.scope, false, node.pos)
+			g.write_loop_scope_cleanup_after_defer(node.scope, node.pos, node.stmts,
+				ends_with_branch)
 		}
-		g.write_defer_stmts(node.scope, false, node.pos)
+		g.pop_local_closure_cleanup_preserve_vars(preserve_start)
+		g.pop_for_c_init_autofree_keep_vars(autofree_keep_start)
 		g.writeln('}')
-		if init_closure_vars.len > 0 && node.label.len > 0 {
+		if has_init_outer_cleanup && node.label.len > 0 {
 			g.writeln('${node.label}__break: {}')
 		}
 		g.cleanup_for_c_init_local_closure_vars(node, init_closure_vars)
+		g.cleanup_for_c_init_autofree_vars(init_autofree_vars)
 		g.indent--
 		g.writeln('}')
-		if init_closure_vars.len == 0 && node.label.len > 0 {
+		if !has_init_outer_cleanup && node.label.len > 0 {
 			g.writeln('${node.label}__break: {}')
 		}
 	} else {
@@ -271,12 +386,14 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 		g.is_vlines_enabled = false
 		g.inside_for_c_stmt = true
 		needs_init_closure_scope := init_closure_vars.len > 0
+		needs_init_autofree_scope := init_autofree_vars.len > 0
 		has_outer_block := has_overflow_guard || needs_init_closure_scope
+			|| needs_init_autofree_scope
 		if has_outer_block {
 			g.writeln('{')
 			g.indent++
 		}
-		if needs_init_closure_scope {
+		if needs_init_closure_scope || needs_init_autofree_scope {
 			g.stmt(node.init)
 		}
 		if has_overflow_guard {
@@ -288,7 +405,7 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 		g.set_current_pos_as_last_stmt_pos()
 		g.skip_stmt_pos = true
 		g.write('for (')
-		if !node.has_init || needs_init_closure_scope {
+		if !node.has_init || needs_init_closure_scope || needs_init_autofree_scope {
 			g.write('; ')
 		} else {
 			g.stmt(node.init)
@@ -329,25 +446,36 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 		if node.label.len > 0 {
 			g.writeln('{')
 		}
+		autofree_keep_start := g.push_for_c_init_autofree_keep_vars(init_autofree_vars)
 		preserve_start := g.push_local_closure_cleanup_preserve_vars(init_closure_vars,
 			node.pos.pos)
-		g.stmts(node.stmts)
-		g.pop_local_closure_cleanup_preserve_vars(preserve_start)
+		skip_cleanup_start := g.push_skip_scope_cleanup(node.scope)
+		ends_with_branch := g.stmts_with_tmp_var(node.stmts, '')
+		g.pop_skip_scope_cleanup(skip_cleanup_start)
 		if node.label.len > 0 {
+			g.write_defer_stmts(node.scope, false, node.pos)
+			g.write_loop_scope_cleanup_after_defer(node.scope, node.pos, node.stmts,
+				ends_with_branch)
 			g.writeln('}')
 			g.writeln('${node.label}__continue: {}')
+		} else {
+			g.write_defer_stmts(node.scope, false, node.pos)
+			g.write_loop_scope_cleanup_after_defer(node.scope, node.pos, node.stmts,
+				ends_with_branch)
 		}
-		g.write_defer_stmts(node.scope, false, node.pos)
+		g.pop_local_closure_cleanup_preserve_vars(preserve_start)
+		g.pop_for_c_init_autofree_keep_vars(autofree_keep_start)
 		g.writeln('}')
-		if needs_init_closure_scope && node.label.len > 0 {
+		if has_init_outer_cleanup && node.label.len > 0 {
 			g.writeln('${node.label}__break: {}')
 		}
 		g.cleanup_for_c_init_local_closure_vars(node, init_closure_vars)
+		g.cleanup_for_c_init_autofree_vars(init_autofree_vars)
 		if has_outer_block {
 			g.indent--
 			g.writeln('}')
 		}
-		if !needs_init_closure_scope && node.label.len > 0 {
+		if !has_init_outer_cleanup && node.label.len > 0 {
 			g.writeln('${node.label}__break: {}')
 		}
 	}
@@ -374,12 +502,18 @@ fn (mut g Gen) for_stmt(node ast.ForStmt) {
 	if node.label.len > 0 {
 		g.writeln('\t{')
 	}
-	g.stmts(node.stmts)
+	skip_cleanup_start := g.push_skip_scope_cleanup(node.scope)
+	ends_with_branch := g.stmts_with_tmp_var(node.stmts, '')
+	g.pop_skip_scope_cleanup(skip_cleanup_start)
 	if node.label.len > 0 {
+		g.write_defer_stmts(node.scope, false, node.pos)
+		g.write_loop_scope_cleanup_after_defer(node.scope, node.pos, node.stmts, ends_with_branch)
 		g.writeln('\t}')
 		g.writeln('\t${node.label}__continue: {}')
+	} else {
+		g.write_defer_stmts(node.scope, false, node.pos)
+		g.write_loop_scope_cleanup_after_defer(node.scope, node.pos, node.stmts, ends_with_branch)
 	}
-	g.write_defer_stmts(node.scope, false, node.pos)
 	g.writeln('}')
 	if node.label.len > 0 {
 		g.writeln('${node.label}__break: {}')
@@ -1045,11 +1179,9 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 	if node.label.len > 0 {
 		g.writeln('\t{')
 	}
-	g.stmts(node.stmts)
-	if node.label.len > 0 {
-		g.writeln('\t}')
-		g.writeln('\t${node.label}__continue: {}')
-	}
+	skip_cleanup_start := g.push_skip_scope_cleanup(node.scope)
+	ends_with_branch := g.stmts_with_tmp_var(node.stmts, '')
+	g.pop_skip_scope_cleanup(skip_cleanup_start)
 
 	if node.kind == .map {
 		// diff := g.new_tmp_var()
@@ -1059,7 +1191,15 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 		// g.writeln('\t${map_len} = ${cond_var}${arw_or_pt}key_values.len;')
 		// g.writeln('}')
 	}
-	g.write_defer_stmts(node.scope, false, node.pos)
+	if node.label.len > 0 {
+		g.write_defer_stmts(node.scope, false, node.pos)
+		g.write_loop_scope_cleanup_after_defer(node.scope, node.pos, node.stmts, ends_with_branch)
+		g.writeln('\t}')
+		g.writeln('\t${node.label}__continue: {}')
+	} else {
+		g.write_defer_stmts(node.scope, false, node.pos)
+		g.write_loop_scope_cleanup_after_defer(node.scope, node.pos, node.stmts, ends_with_branch)
+	}
 	g.writeln('}')
 	if array_debug_value_scope_opened {
 		g.indent--

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -174,8 +174,40 @@ fn (mut g Gen) write_for_c_inc_expr(node ast.ForCStmt) {
 	}
 }
 
+fn (g &Gen) for_c_init_local_closure_vars(node ast.ForCStmt) []ast.Var {
+	if !node.has_init || node.init !is ast.AssignStmt {
+		return []
+	}
+	init := node.init as ast.AssignStmt
+	if init.op != .decl_assign {
+		return []
+	}
+	mut vars := []ast.Var{}
+	for left in init.left {
+		if left is ast.Ident {
+			mut obj := if left.obj is ast.Var {
+				left.obj
+			} else {
+				ast.Var{}
+			}
+			if node.scope != unsafe { nil } {
+				if scope_var := node.scope.find_var(left.name) {
+					if scope_var.pos.pos == left.pos.pos {
+						obj = *scope_var
+					}
+				}
+			}
+			if g.local_closure_var_has_tracked_context(obj) {
+				vars << obj
+			}
+		}
+	}
+	return vars
+}
+
 fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 	g.loop_depth++
+	init_closure_vars := g.for_c_init_local_closure_vars(node)
 	if node.is_multi {
 		g.is_vlines_enabled = false
 		g.inside_for_c_stmt = true
@@ -213,15 +245,23 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 		if node.label.len > 0 {
 			g.writeln('{')
 		}
+		preserve_start := g.push_local_closure_cleanup_preserve_vars(init_closure_vars,
+			node.pos.pos)
 		g.stmts(node.stmts)
+		g.pop_local_closure_cleanup_preserve_vars(preserve_start)
 		if node.label.len > 0 {
 			g.writeln('}')
 			g.writeln('${node.label}__continue: {}')
 		}
+		g.write_defer_stmts(node.scope, false, node.pos)
 		g.writeln('}')
+		if init_closure_vars.len > 0 && node.label.len > 0 {
+			g.writeln('${node.label}__break: {}')
+		}
+		g.cleanup_for_c_init_local_closure_vars(node, init_closure_vars)
 		g.indent--
 		g.writeln('}')
-		if node.label.len > 0 {
+		if init_closure_vars.len == 0 && node.label.len > 0 {
 			g.writeln('${node.label}__break: {}')
 		}
 	} else {
@@ -230,9 +270,16 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 		overflow_guard_flag := if has_overflow_guard { g.new_tmp_var() } else { '' }
 		g.is_vlines_enabled = false
 		g.inside_for_c_stmt = true
-		if has_overflow_guard {
+		needs_init_closure_scope := init_closure_vars.len > 0
+		has_outer_block := has_overflow_guard || needs_init_closure_scope
+		if has_outer_block {
 			g.writeln('{')
 			g.indent++
+		}
+		if needs_init_closure_scope {
+			g.stmt(node.init)
+		}
+		if has_overflow_guard {
 			g.writeln('bool ${overflow_guard_flag} = false;')
 		}
 		if node.label.len > 0 {
@@ -241,7 +288,7 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 		g.set_current_pos_as_last_stmt_pos()
 		g.skip_stmt_pos = true
 		g.write('for (')
-		if !node.has_init {
+		if !node.has_init || needs_init_closure_scope {
 			g.write('; ')
 		} else {
 			g.stmt(node.init)
@@ -282,18 +329,25 @@ fn (mut g Gen) for_c_stmt(node ast.ForCStmt) {
 		if node.label.len > 0 {
 			g.writeln('{')
 		}
+		preserve_start := g.push_local_closure_cleanup_preserve_vars(init_closure_vars,
+			node.pos.pos)
 		g.stmts(node.stmts)
+		g.pop_local_closure_cleanup_preserve_vars(preserve_start)
 		if node.label.len > 0 {
 			g.writeln('}')
 			g.writeln('${node.label}__continue: {}')
 		}
 		g.write_defer_stmts(node.scope, false, node.pos)
 		g.writeln('}')
-		if has_overflow_guard {
+		if needs_init_closure_scope && node.label.len > 0 {
+			g.writeln('${node.label}__break: {}')
+		}
+		g.cleanup_for_c_init_local_closure_vars(node, init_closure_vars)
+		if has_outer_block {
 			g.indent--
 			g.writeln('}')
 		}
-		if node.label.len > 0 {
+		if !needs_init_closure_scope && node.label.len > 0 {
 			g.writeln('${node.label}__break: {}')
 		}
 	}

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -281,9 +281,12 @@ fn (mut g Gen) cleanup_for_c_init_autofree_vars(vars []ast.Var) {
 	}
 }
 
-fn (mut g Gen) cleanup_for_c_init_autofree_vars_on_return(returned_names map[string]bool) {
+fn (mut g Gen) cleanup_for_c_init_autofree_vars_on_return(returned_names map[string]bool, selector_owner_names map[string]bool) {
 	for var in g.for_c_init_autofree_cleanup_vars {
 		if var.name in returned_names {
+			continue
+		}
+		if var.name in selector_owner_names {
 			continue
 		}
 		g.autofree_variable(var)

--- a/vlib/v/gen/c/testdata/autofree_labeled_continue_boehm_leak.vv
+++ b/vlib/v/gen/c/testdata/autofree_labeled_continue_boehm_leak.vv
@@ -1,0 +1,116 @@
+// vtest vflags: -autofree -gc boehm_leak
+
+fn make_label(n int) string {
+	return 'x'.repeat(n)
+}
+
+fn labeled_continue_cleanup() {
+	outer: for _ in 0 .. 1 {
+		target := make_label(7)
+		defer {
+			assert target.len == 7
+		}
+		{
+			inner := make_label(3)
+			assert inner.len == 3
+			continue outer
+		}
+		after := make_label(5)
+		defer {
+			assert after.len == 5
+		}
+	}
+}
+
+fn for_c_init_cleanup() {
+	mut i := 0
+	outer: for init := make_label(4); i < 2; i++ {
+		assert init.len == 4
+		body := make_label(5 + i)
+		assert body.len >= 5
+		if i == 0 {
+			continue outer
+		}
+		break outer
+	}
+}
+
+fn for_c_init_return_cleanup() int {
+	mut i := 0
+	for init := make_label(4); i < 1; i++ {
+		assert init.len == 4
+		body := make_label(5)
+		assert body.len == 5
+		return body.len
+	}
+	return 0
+}
+
+fn for_c_multi_init_return_cleanup() int {
+	mut i := 0
+	for first, second := make_label(4), make_label(3); i < 1; i++ {
+		assert first.len + second.len == 7
+		body := make_label(5)
+		assert body.len == 5
+		return body.len
+	}
+	return 0
+}
+
+fn for_c_return_init_string() string {
+	mut i := 0
+	for init := make_label(6); i < 1; i++ {
+		body := make_label(5)
+		assert body.len == 5
+		return init
+	}
+	return ''
+}
+
+fn for_c_multi_init_return_second_string() string {
+	mut i := 0
+	for first, second := make_label(4), make_label(3); i < 1; i++ {
+		assert first.len == 4
+		body := make_label(5)
+		assert body.len == 5
+		return second
+	}
+	return ''
+}
+
+fn for_c_branch_return_body_after_init_path(cond bool) string {
+	mut i := 0
+	for init := make_label(4); i < 1; i++ {
+		if cond {
+			return init
+		}
+		body := make_label(5)
+		return body
+	}
+	return ''
+}
+
+fn for_c_multi_init_branch_return_body_after_second_path(cond bool) string {
+	mut i := 0
+	for first, second := make_label(4), make_label(3); i < 1; i++ {
+		assert first.len == 4
+		if cond {
+			return second
+		}
+		body := make_label(5)
+		return body
+	}
+	return ''
+}
+
+fn main() {
+	labeled_continue_cleanup()
+	for_c_init_cleanup()
+	assert for_c_init_return_cleanup() == 5
+	assert for_c_multi_init_return_cleanup() == 5
+	assert for_c_return_init_string() == 'xxxxxx'
+	assert for_c_multi_init_return_second_string() == 'xxx'
+	assert for_c_branch_return_body_after_init_path(false) == 'xxxxx'
+	assert for_c_multi_init_branch_return_body_after_second_path(false) == 'xxxxx'
+	gc_check_leaks()
+}

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -113,10 +113,11 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 			core_fns << '_result_ok'
 		}
 		if table.used_features.anon_fn {
-			core_fns << 'memdup_uncollectable'
+			core_fns << 'memdup'
 			core_fns << 'builtin.closure.closure_alloc'
 			core_fns << 'builtin.closure.closure_init'
 			core_fns << 'builtin.closure.closure_create'
+			core_fns << 'builtin.closure.closure_create_with_data'
 			core_fns << 'builtin.closure.closure_data'
 			core_fns << 'builtin.closure.closure_try_destroy'
 		}

--- a/vlib/v/tests/autofree_labeled_continue_scope_test.v
+++ b/vlib/v/tests/autofree_labeled_continue_scope_test.v
@@ -1,0 +1,313 @@
+// vtest build: !sanitize-address-gcc && !sanitize-address-clang
+// vtest vflags: -autofree
+@[has_globals]
+module main
+
+__global (
+	event_code int
+)
+
+struct Tracked {
+	id int
+}
+
+fn (t &Tracked) free() {
+	unsafe {
+		event_code = event_code * 10 + t.id
+	}
+}
+
+fn tracked(id int) Tracked {
+	return Tracked{
+		id: id
+	}
+}
+
+fn push_event(id int) {
+	unsafe {
+		event_code = event_code * 10 + id
+	}
+}
+
+fn reset_events() {
+	unsafe {
+		event_code = 0
+	}
+}
+
+fn events() int {
+	return unsafe { event_code }
+}
+
+fn labeled_continue_cleanup_order() {
+	outer: for _ in 0 .. 1 {
+		target := tracked(1)
+		if target.id == -1 {
+			push_event(9)
+		}
+		defer {
+			push_event(7 + target.id - 1)
+		}
+		{
+			inner := tracked(2)
+			if inner.id == -1 {
+				push_event(9)
+			}
+			continue outer
+		}
+		after := tracked(3)
+		defer {
+			push_event(8)
+		}
+		if after.id == -1 {
+			push_event(9)
+		}
+	}
+}
+
+fn labeled_fallthrough_cleanup_order() {
+	outer: for _ in 0 .. 1 {
+		target := tracked(1)
+		if target.id == -1 {
+			continue outer
+		}
+		defer {
+			push_event(7 + target.id - 1)
+		}
+		{
+			inner := tracked(2)
+			if inner.id == -1 {
+				continue outer
+			}
+		}
+	}
+}
+
+fn for_c_all_continue() {
+	mut i := 0
+	outer: for init := tracked(4); i < 2; i++ {
+		if init.id == -1 {
+			push_event(9)
+		}
+		body := tracked(5 + i)
+		if body.id >= 5 {
+			continue outer
+		}
+	}
+}
+
+fn for_c_mixed_fallthrough_continue() {
+	mut i := 0
+	outer: for init := tracked(4); i < 3; i++ {
+		if init.id == -1 {
+			push_event(9)
+		}
+		body := tracked(5 + i)
+		if i == 1 {
+			continue outer
+		}
+		if body.id == -1 {
+			push_event(9)
+		}
+	}
+}
+
+fn for_c_labeled_break() {
+	mut i := 0
+	outer: for init := tracked(4); i < 1; i++ {
+		if init.id == -1 {
+			push_event(9)
+		}
+		body := tracked(5)
+		if body.id == 5 {
+			break outer
+		}
+	}
+}
+
+fn for_c_return() int {
+	mut i := 0
+	for init := tracked(4); i < 1; i++ {
+		if init.id == -1 {
+			push_event(9)
+		}
+		body := tracked(5)
+		if body.id == 5 {
+			return body.id
+		}
+	}
+	return 0
+}
+
+fn for_c_multi_init_return() int {
+	mut i := 0
+	for first, second := tracked(4), tracked(3); i < 1; i++ {
+		if first.id + second.id == -1 {
+			push_event(9)
+		}
+		body := tracked(5)
+		if body.id == 5 {
+			return body.id
+		}
+	}
+	return 0
+}
+
+fn for_c_return_init_string() string {
+	mut i := 0
+	for init := 'ab'.repeat(3); i < 1; i++ {
+		body := tracked(5)
+		if body.id == 5 {
+			return init
+		}
+	}
+	return ''
+}
+
+fn for_c_multi_init_return_second() Tracked {
+	mut i := 0
+	for first, second := tracked(4), tracked(3); i < 1; i++ {
+		if first.id + second.id == -1 {
+			push_event(9)
+		}
+		body := tracked(5)
+		if body.id == 5 {
+			return second
+		}
+	}
+	return tracked(0)
+}
+
+fn for_c_multi_init_return_second_string() string {
+	mut i := 0
+	for first, second := 'x'.repeat(4), 'y'.repeat(3); i < 1; i++ {
+		assert first.len == 4
+		body := tracked(5)
+		if body.id == 5 {
+			return second
+		}
+	}
+	return ''
+}
+
+fn for_c_branch_return_body_after_init_path(cond bool) Tracked {
+	mut i := 0
+	for init := tracked(4); i < 1; i++ {
+		if cond {
+			return init
+		}
+		body := tracked(5)
+		return body
+	}
+	return tracked(0)
+}
+
+fn for_c_multi_init_branch_return_body_after_second_path(cond bool) Tracked {
+	mut i := 0
+	for first, second := tracked(4), tracked(3); i < 1; i++ {
+		if cond {
+			return second
+		}
+		body := tracked(5)
+		return body
+	}
+	return tracked(0)
+}
+
+fn for_c_branch_return_body_after_init_string_path(cond bool) string {
+	mut i := 0
+	for init := 'z'.repeat(4); i < 1; i++ {
+		if cond {
+			return init
+		}
+		body := tracked(5)
+		if body.id == 5 {
+			return 'body'
+		}
+	}
+	return ''
+}
+
+fn test_labeled_continue_runs_reached_target_defer_before_target_autofree() {
+	reset_events()
+	labeled_continue_cleanup_order()
+	assert events() == 271
+}
+
+fn test_labeled_fallthrough_runs_target_defer_before_target_autofree() {
+	reset_events()
+	labeled_fallthrough_cleanup_order()
+	assert events() == 271
+}
+
+fn test_for_c_all_continue_frees_init_once_after_loop() {
+	reset_events()
+	for_c_all_continue()
+	assert events() == 564
+}
+
+fn test_for_c_mixed_fallthrough_continue_keeps_init_until_loop_exit() {
+	reset_events()
+	for_c_mixed_fallthrough_continue()
+	assert events() == 5674
+}
+
+fn test_for_c_labeled_break_frees_init_once_after_body() {
+	reset_events()
+	for_c_labeled_break()
+	assert events() == 54
+}
+
+fn test_for_c_return_frees_init_once_after_body() {
+	reset_events()
+	assert for_c_return() == 5
+	assert events() == 54
+}
+
+fn test_for_c_multi_init_return_frees_all_init_vars_after_body() {
+	reset_events()
+	assert for_c_multi_init_return() == 5
+	assert events() == 534
+}
+
+fn test_for_c_returned_init_string_is_not_freed_before_return() {
+	reset_events()
+	value := for_c_return_init_string()
+	assert value == 'ababab'
+	assert events() == 5
+}
+
+fn test_for_c_multi_init_returned_second_is_not_freed_before_return() {
+	reset_events()
+	value := for_c_multi_init_return_second()
+	assert value.id == 3
+	assert events() == 54
+}
+
+fn test_for_c_multi_init_returned_second_string_is_not_freed_before_return() {
+	reset_events()
+	value := for_c_multi_init_return_second_string()
+	assert value == 'yyy'
+	assert events() == 5
+}
+
+fn test_for_c_branch_return_body_still_frees_init() {
+	reset_events()
+	value := for_c_branch_return_body_after_init_path(false)
+	assert value.id == 5
+	assert events() == 4
+}
+
+fn test_for_c_multi_init_branch_return_body_still_frees_all_init_vars() {
+	reset_events()
+	value := for_c_multi_init_branch_return_body_after_second_path(false)
+	assert value.id == 5
+	assert events() == 34
+}
+
+fn test_for_c_branch_return_body_string_path_still_frees_init() {
+	reset_events()
+	value := for_c_branch_return_body_after_init_string_path(false)
+	assert value == 'body'
+	assert events() == 5
+}

--- a/vlib/v/tests/autofree_labeled_continue_scope_test.v
+++ b/vlib/v/tests/autofree_labeled_continue_scope_test.v
@@ -7,8 +7,22 @@ __global (
 	event_code int
 )
 
+type Label = string
+
 struct Tracked {
 	id int
+}
+
+struct Holder {
+	label string
+	other string
+	id    int
+}
+
+struct AliasHolder {
+	label Label
+	other string
+	id    int
 }
 
 fn (t &Tracked) free() {
@@ -17,9 +31,41 @@ fn (t &Tracked) free() {
 	}
 }
 
+fn (h &Holder) free() {
+	push_event(h.id)
+	unsafe {
+		h.label.free()
+		h.other.free()
+	}
+}
+
+fn (h &AliasHolder) free() {
+	push_event(h.id)
+	unsafe {
+		h.label.free()
+		h.other.free()
+	}
+}
+
 fn tracked(id int) Tracked {
 	return Tracked{
 		id: id
+	}
+}
+
+fn holder(id int) Holder {
+	return Holder{
+		label: 'x'.repeat(id)
+		other: 'y'.repeat(id + 1)
+		id:    id
+	}
+}
+
+fn alias_holder(id int) AliasHolder {
+	return AliasHolder{
+		label: Label('x'.repeat(id))
+		other: 'y'.repeat(id + 1)
+		id:    id
 	}
 }
 
@@ -83,6 +129,30 @@ fn labeled_fallthrough_cleanup_order() {
 	}
 }
 
+fn labeled_break_cleanup_order() {
+	break_outer: for _ in 0 .. 1 {
+		target := tracked(1)
+		defer {
+			push_event(7)
+		}
+		{
+			middle := tracked(2)
+			defer {
+				push_event(8)
+			}
+			{
+				inner := tracked(3)
+				defer {
+					push_event(9)
+				}
+				if inner.id == 3 {
+					break break_outer
+				}
+			}
+		}
+	}
+}
+
 fn for_c_all_continue() {
 	mut i := 0
 	outer: for init := tracked(4); i < 2; i++ {
@@ -108,6 +178,44 @@ fn for_c_mixed_fallthrough_continue() {
 		}
 		if body.id == -1 {
 			push_event(9)
+		}
+	}
+}
+
+fn for_c_nested_continue_outer_init_cleanup() {
+	mut i := 0
+	outer: for outer_init := tracked(4); i < 2; i++ {
+		if outer_init.id == -1 {
+			push_event(9)
+		}
+		mut j := 0
+		for inner_init := tracked(5); j < 1; j++ {
+			if inner_init.id == -1 {
+				push_event(9)
+			}
+			body := tracked(6)
+			if body.id == 6 {
+				continue outer
+			}
+		}
+	}
+}
+
+fn for_c_nested_break_outer_init_cleanup() {
+	mut i := 0
+	break_outer: for outer_init := tracked(4); i < 1; i++ {
+		if outer_init.id == -1 {
+			push_event(9)
+		}
+		mut j := 0
+		for inner_init := tracked(5); j < 1; j++ {
+			if inner_init.id == -1 {
+				push_event(9)
+			}
+			body := tracked(6)
+			if body.id == 6 {
+				break break_outer
+			}
 		}
 	}
 }
@@ -190,6 +298,39 @@ fn for_c_multi_init_return_second_string() string {
 	return ''
 }
 
+fn for_c_return_init_field_string() string {
+	mut i := 0
+	for init := holder(4); i < 1; i++ {
+		body := tracked(5)
+		if body.id == 5 {
+			return init.label
+		}
+	}
+	return ''
+}
+
+fn for_c_return_init_field_alias_string() Label {
+	mut i := 0
+	for init := alias_holder(4); i < 1; i++ {
+		body := tracked(5)
+		if body.id == 5 {
+			return init.label
+		}
+	}
+	return Label('')
+}
+
+fn for_c_return_init_field_id() int {
+	mut i := 0
+	for init := holder(4); i < 1; i++ {
+		body := tracked(5)
+		if body.id == 5 {
+			return init.id
+		}
+	}
+	return 0
+}
+
 fn for_c_branch_return_body_after_init_path(cond bool) Tracked {
 	mut i := 0
 	for init := tracked(4); i < 1; i++ {
@@ -240,6 +381,12 @@ fn test_labeled_fallthrough_runs_target_defer_before_target_autofree() {
 	assert events() == 271
 }
 
+fn test_labeled_break_runs_all_exited_defers_before_jump() {
+	reset_events()
+	labeled_break_cleanup_order()
+	assert events() == 938271
+}
+
 fn test_for_c_all_continue_frees_init_once_after_loop() {
 	reset_events()
 	for_c_all_continue()
@@ -250,6 +397,18 @@ fn test_for_c_mixed_fallthrough_continue_keeps_init_until_loop_exit() {
 	reset_events()
 	for_c_mixed_fallthrough_continue()
 	assert events() == 5674
+}
+
+fn test_for_c_nested_continue_outer_frees_inner_init_before_jump() {
+	reset_events()
+	for_c_nested_continue_outer_init_cleanup()
+	assert events() == 65654
+}
+
+fn test_for_c_nested_break_outer_frees_inner_init_before_jump() {
+	reset_events()
+	for_c_nested_break_outer_init_cleanup()
+	assert events() == 654
 }
 
 fn test_for_c_labeled_break_frees_init_once_after_body() {
@@ -289,6 +448,27 @@ fn test_for_c_multi_init_returned_second_string_is_not_freed_before_return() {
 	value := for_c_multi_init_return_second_string()
 	assert value == 'yyy'
 	assert events() == 5
+}
+
+fn test_for_c_returned_init_string_field_preserves_owner() {
+	reset_events()
+	value := for_c_return_init_field_string()
+	assert value == 'xxxx'
+	assert events() == 5
+}
+
+fn test_for_c_returned_init_alias_string_field_preserves_owner() {
+	reset_events()
+	value := for_c_return_init_field_alias_string()
+	assert string(value) == 'xxxx'
+	assert events() == 5
+}
+
+fn test_for_c_returned_init_scalar_field_still_frees_owner() {
+	reset_events()
+	value := for_c_return_init_field_id()
+	assert value == 4
+	assert events() == 54
 }
 
 fn test_for_c_branch_return_body_still_frees_init() {

--- a/vlib/v/tests/defer/scoped_defer_test.v
+++ b/vlib/v/tests/defer/scoped_defer_test.v
@@ -183,3 +183,16 @@ fn test_labeled_continue_in_multi_for_c_runs_target_defer_once() {
 	}
 	assert values == [10, 11]
 }
+
+fn test_labeled_continue_does_not_run_unreached_target_defer() {
+	mut values := []int{}
+	outer: for i in 0 .. 2 {
+		if i == 0 {
+			continue outer
+		}
+		defer {
+			values << 10 + i
+		}
+	}
+	assert values == [11]
+}

--- a/vlib/v/tests/defer/scoped_defer_test.v
+++ b/vlib/v/tests/defer/scoped_defer_test.v
@@ -141,3 +141,45 @@ fn test_scoped_defer_can_use_inner_var_declared_in_loop() {
 	}
 	assert values == [0, 1, 2]
 }
+
+fn test_labeled_continue_in_target_loop_runs_target_defer_once() {
+	mut values := []int{}
+	outer: for i in 0 .. 2 {
+		defer {
+			values << 10 + i
+		}
+		continue outer
+	}
+	assert values == [10, 11]
+}
+
+fn test_labeled_continue_runs_target_loop_defer_once() {
+	mut values := []int{}
+	outer: for i in 0 .. 2 {
+		defer {
+			values << 10 + i
+		}
+		if i == 0 {
+			continue outer
+		}
+		{
+			defer {
+				values << 20 + i
+			}
+			continue outer
+		}
+	}
+	assert values == [10, 21, 11]
+}
+
+fn test_labeled_continue_in_multi_for_c_runs_target_defer_once() {
+	mut values := []int{}
+	outer: for i, j := 0, 0; i < 2; i++ {
+		_ = j
+		defer {
+			values << 10 + i
+		}
+		continue outer
+	}
+	assert values == [10, 11]
+}

--- a/vlib/v/tests/fns/closure_context_boehm_root_test.c.v
+++ b/vlib/v/tests/fns/closure_context_boehm_root_test.c.v
@@ -1,0 +1,162 @@
+struct CapturedValueReceiver {
+	value int
+}
+
+fn (r CapturedValueReceiver) get() int {
+	return r.value
+}
+
+@[heap]
+struct CapturedPointerReceiver {
+	value int
+}
+
+fn (r &CapturedPointerReceiver) get() int {
+	return r.value
+}
+
+fn stored_anon_closure() fn () int {
+	value := 27445
+	return fn [value] () int {
+		return value
+	}
+}
+
+fn stored_value_method_closure() fn () int {
+	receiver := CapturedValueReceiver{
+		value: 27445
+	}
+	return receiver.get
+}
+
+fn stored_pointer_method_closure() fn () int {
+	receiver := &CapturedPointerReceiver{
+		value: 27445
+	}
+	return receiver.get
+}
+
+fn collect_and_churn() {
+	$if gcboehm ? {
+		C.GC_gcollect()
+	}
+	for _ in 0 .. 1000 {
+		unsafe {
+			p := malloc(16)
+			vmemset(p, 0x33, 16)
+		}
+	}
+	$if gcboehm ? {
+		C.GC_gcollect()
+	}
+}
+
+fn test_stored_closure_contexts_survive_boehm_collection() {
+	anon_cb := stored_anon_closure()
+	value_method_cb := stored_value_method_closure()
+	pointer_method_cb := stored_pointer_method_closure()
+	collect_and_churn()
+	assert anon_cb() == 27445
+	assert value_method_cb() == 27445
+	assert pointer_method_cb() == 27445
+}
+
+fn consume_with_return(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	if n >= 0 {
+		return h(n % 200)
+	}
+	return 0
+}
+
+fn consume_with_call_then_return(n int) int {
+	big := []int{len: 200, init: index + n}
+	h := fn [big] (x int) int {
+		return big[x % big.len]
+	}
+	_ = h(n % 200)
+	return 0
+}
+
+fn consume_with_labeled_break(n int) int {
+	mut value := 0
+	inner: for {
+		big := []int{len: 200, init: index + n}
+		h := fn [big] (x int) int {
+			return big[x % big.len]
+		}
+		value = h(n % 200)
+		break inner
+	}
+	return value
+}
+
+fn consume_with_labeled_continue(n int) int {
+	mut value := 0
+	outer: for _ in 0 .. 1 {
+		big := []int{len: 200, init: index + n}
+		h := fn [big] (x int) int {
+			return big[x % big.len]
+		}
+		value = h(n % 200)
+		continue outer
+	}
+	return value
+}
+
+fn test_issue_27445_local_closure_contexts_do_not_accumulate() {
+	$if gcboehm ? {
+		gc_collect()
+		start_mb := gc_memory_use() / 1024 / 1024
+		for n in 0 .. 80_000 {
+			big := []int{len: 200, init: index + n}
+			h := fn [big] (x int) int {
+				return big[x % big.len]
+			}
+			_ = h(n % 200)
+			if n % 20_000 == 0 {
+				gc_collect()
+			}
+		}
+		gc_collect()
+		end_mb := gc_memory_use() / 1024 / 1024
+		assert end_mb <= start_mb + 24
+	}
+}
+
+fn test_issue_27445_return_paths_with_local_closure_do_not_accumulate() {
+	$if gcboehm ? {
+		gc_collect()
+		start_mb := gc_memory_use() / 1024 / 1024
+		for n in 0 .. 80_000 {
+			_ = consume_with_return(n)
+			_ = consume_with_call_then_return(n)
+			if n % 20_000 == 0 {
+				gc_collect()
+			}
+		}
+		gc_collect()
+		end_mb := gc_memory_use() / 1024 / 1024
+		assert end_mb <= start_mb + 24
+	}
+}
+
+fn test_issue_27445_labeled_branches_with_local_closure_do_not_accumulate() {
+	$if gcboehm ? {
+		gc_collect()
+		start_mb := gc_memory_use() / 1024 / 1024
+		for n in 0 .. 80_000 {
+			_ = consume_with_labeled_break(n)
+			_ = consume_with_labeled_continue(n)
+			if n % 20_000 == 0 {
+				gc_collect()
+			}
+		}
+		gc_collect()
+		end_mb := gc_memory_use() / 1024 / 1024
+		assert end_mb <= start_mb + 24
+	}
+}

--- a/vlib/v/tests/fns/closure_context_skip_unused_test.v
+++ b/vlib/v/tests/fns/closure_context_skip_unused_test.v
@@ -1,0 +1,87 @@
+import os
+
+const vexe = @VEXE
+
+fn missing_boehm_leak_lib(output string) bool {
+	return output.contains('libgc') && (output.contains('was not found')
+		|| output.contains('cannot find'))
+}
+
+fn closure_skip_unused_source() string {
+	return [
+		'module main',
+		'import builtin.closure',
+		'',
+		'fn make_cb(seed int) fn () int {',
+		'\tvalues := []int{len: 8, init: seed + index}',
+		'\treturn fn [values] () int {',
+		'\t\treturn values[0] + values[7]',
+		'\t}',
+		'}',
+		'',
+		'fn no_capture_work() {}',
+		'',
+		'fn consume(i int) int {',
+		'\th := fn [i] (x int) int {',
+		'\t\treturn i + x',
+		'\t}',
+		'\treturn h(i + 1)',
+		'}',
+		'',
+		'fn run() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tmut total := 0',
+		'\tlifetime.frame(fn () {',
+		'\t\tcb := make_cb(20)',
+		'\t\tassert cb() == 47',
+		'\t})!',
+		'\tlifetime.suspend(fn () {',
+		'\t\tcb := make_cb(30)',
+		'\t\tassert cb() == 67',
+		'\t})!',
+		'\tlifetime.suspend(no_capture_work)!',
+		'\tfor i in 0 .. 64 {',
+		'\t\ttotal += consume(i)',
+		'\t}',
+		'\tlifetime.reclaim_all()!',
+		'\tlifetime.dispose()!',
+		'\tassert total == 4096',
+		'\tprintln(total)',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n')
+}
+
+fn run_closure_skip_unused_case(tmp_dir string, mode string) {
+	source_path := os.join_path(tmp_dir, 'closure_skip_unused_${mode}.v')
+	binary_path := os.join_path(tmp_dir, 'closure_skip_unused_${mode}')
+	os.write_file(source_path, closure_skip_unused_source()) or { panic(err) }
+	compile_cmd := '${os.quoted_path(vexe)} -skip-unused -gc ${mode} -o ${os.quoted_path(binary_path)} ${os.quoted_path(source_path)}'
+	compile_res := os.execute(compile_cmd)
+	if mode == 'boehm_leak' && compile_res.exit_code != 0
+		&& missing_boehm_leak_lib(compile_res.output) {
+		eprintln('skipping boehm_leak closure skip-unused test: missing libgc')
+		return
+	}
+	assert compile_res.exit_code == 0, compile_res.output
+	if mode == 'boehm_leak' {
+		return
+	}
+	run_res := os.execute(os.quoted_path(binary_path))
+	assert run_res.exit_code == 0, run_res.output
+	assert run_res.output.contains('4096'), run_res.output
+}
+
+fn test_closure_context_helpers_are_kept_with_skip_unused() {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_closure_context_skip_unused_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	for mode in ['boehm', 'boehm_leak', 'none'] {
+		run_closure_skip_unused_case(tmp_dir, mode)
+	}
+}

--- a/vlib/v/tests/fns/closure_lifetime_api_test.v
+++ b/vlib/v/tests/fns/closure_lifetime_api_test.v
@@ -663,7 +663,10 @@ fn test_closure_lifetime_dispose_recycles_state_for_later_lifetimes() {
 }
 
 fn test_closure_lifetime_freestanding_no_std_object_compile() {
-	$if windows {
+	$if !linux {
+		return
+	}
+	$if !amd64 {
 		return
 	}
 	$if gcboehm_leak ? {

--- a/vlib/v/tests/fns/closure_lifetime_api_test.v
+++ b/vlib/v/tests/fns/closure_lifetime_api_test.v
@@ -1,0 +1,1260 @@
+import os
+
+const vexe = @VEXE
+
+fn missing_boehm_leak_lib(output string) bool {
+	return output.contains('libgc') && (output.contains('was not found')
+		|| output.contains('cannot find'))
+}
+
+fn count_occurrences(haystack string, needle string) int {
+	mut pos := 0
+	mut count := 0
+	for {
+		idx := haystack[pos..].index(needle) or { break }
+		count++
+		pos += idx + needle.len
+	}
+	return count
+}
+
+fn write_program(tmp_dir string, name string, source string) string {
+	source_path := os.join_path(tmp_dir, '${name}.v')
+	os.write_file(source_path, source) or { panic(err) }
+	return source_path
+}
+
+fn run_program_with_gc(tmp_dir string, name string, source string, mode string) os.Result {
+	source_path := write_program(tmp_dir, '${name}_${mode}', source)
+	return os.execute('${os.quoted_path(vexe)} -gc ${mode} run ${os.quoted_path(source_path)}')
+}
+
+fn compile_program_with_gc(tmp_dir string, name string, source string, mode string) os.Result {
+	source_path := write_program(tmp_dir, '${name}_${mode}', source)
+	binary_path := os.join_path(tmp_dir, '${name}_${mode}')
+	return os.execute('${os.quoted_path(vexe)} -gc ${mode} -o ${os.quoted_path(binary_path)} ${os.quoted_path(source_path)}')
+}
+
+fn compile_freestanding_object(tmp_dir string, name string, source string) os.Result {
+	source_path := write_program(tmp_dir, name, source)
+	object_path := os.join_path(tmp_dir, '${name}.o')
+	return os.execute('${os.quoted_path(vexe)} -gc none -freestanding -no-std -is_o -o ${os.quoted_path(object_path)} ${os.quoted_path(source_path)}')
+}
+
+fn run_program_with_track_heap(tmp_dir string, name string, source string) os.Result {
+	source_path := write_program(tmp_dir, name, source)
+	return os.execute('${os.quoted_path(vexe)} -gc none -d track_heap run ${os.quoted_path(source_path)}')
+}
+
+fn c_output_for_program(tmp_dir string, name string, source string) os.Result {
+	source_path := write_program(tmp_dir, name, source)
+	return os.execute('${os.quoted_path(vexe)} -o - ${os.quoted_path(source_path)}')
+}
+
+fn assert_boehm_leak_compile_or_missing_lib(tmp_dir string, name string, source string) {
+	res := compile_program_with_gc(tmp_dir, name, source, 'boehm_leak')
+	if res.exit_code != 0 && missing_boehm_leak_lib(res.output) {
+		eprintln('skipping boehm_leak compile for ${name}: missing libgc')
+		return
+	}
+	assert res.exit_code == 0, res.output
+}
+
+fn assert_boehm_leak_runtime_or_compile_only(tmp_dir string, name string, source string) {
+	res := run_program_with_gc(tmp_dir, name, source, 'boehm_leak')
+	if res.exit_code == 0 {
+		return
+	}
+	if missing_boehm_leak_lib(res.output) {
+		eprintln('skipping boehm_leak runtime for ${name}: missing libgc')
+		return
+	}
+	if res.output.contains('leaked objects') || res.output.contains('Found ') {
+		eprintln('boehm_leak runtime reported runtime allocations for ${name}; keeping compile-only coverage')
+		assert_boehm_leak_compile_or_missing_lib(tmp_dir, '${name}_compile_only', source)
+		return
+	}
+	assert false, res.output
+}
+
+fn no_captured_closure_lifetime_source() string {
+	return [
+		'module main',
+		'import builtin.closure',
+		'',
+		'fn no_capture_work() {',
+		'\tassert true',
+		'}',
+		'',
+		'fn run() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.frame(no_capture_work)!',
+		'\tlifetime.suspend(no_capture_work)!',
+		'\tlifetime.untracked(no_capture_work)!',
+		'\tlifetime.reclaim_all()!',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n')
+}
+
+fn closure_lifetime_runtime_source() string {
+	return [
+		'module main',
+		'import builtin.closure',
+		'',
+		'fn no_capture_work() {}',
+		'',
+		'@[heap]',
+		'struct CallbackBox {',
+		'mut:',
+		'\tcb fn () int = fn () int { return -1 }',
+		'}',
+		'',
+		'@[heap]',
+		'struct IntBox {',
+		'mut:',
+		'\tvalue int',
+		'}',
+		'',
+		'fn make_cb(value int) fn () int {',
+		'\tpayload := []int{len: 64, init: value + index}',
+		'\treturn fn [payload] () int {',
+		'\t\treturn payload[0] + payload[payload.len - 1]',
+		'\t}',
+		'}',
+		'',
+		'fn call_cb(cb fn () int) int {',
+		'\treturn cb()',
+		'}',
+		'',
+		'fn collect_and_churn() {',
+		'\tgc_collect()',
+		'\tfor _ in 0 .. 512 {',
+		'\t\tunsafe {',
+		'\t\t\tp := malloc(32)',
+		'\t\t\tvmemset(p, 0x55, 32)',
+		'\t\t}',
+		'\t}',
+		'\tgc_collect()',
+		'}',
+		'',
+		'fn outside_lifetime_closure_survives_lifetime_reclaim() ! {',
+		'\toutside := make_cb(10)',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.frame(fn () {',
+		'\t\tinside := make_cb(100)',
+		'\t\tassert inside() == 263',
+		'\t})!',
+		'\tlifetime.reclaim_all()!',
+		'\tcollect_and_churn()',
+		'\tassert outside() == 83',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn reclaim_keeps_requested_recent_frame() ! {',
+		'\tmut first := &CallbackBox{}',
+		'\tmut second := &CallbackBox{}',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.frame(fn [mut first] () {',
+		'\t\tfirst.cb = make_cb(1)',
+		'\t\tassert first.cb() == 65',
+		'\t})!',
+		'\tlifetime.frame(fn [mut second] () {',
+		'\t\tsecond.cb = make_cb(2)',
+		'\t\tassert second.cb() == 67',
+		'\t})!',
+		'\tlifetime.reclaim(1)!',
+		'\tcollect_and_churn()',
+		'\tassert second.cb() == 67',
+		'\tlifetime.reclaim_all()!',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn two_lifetimes_reclaim_independently() ! {',
+		'\tmut first := &CallbackBox{}',
+		'\tmut second := &CallbackBox{}',
+		'\tmut lifetime_a := closure.new_lifetime()',
+		'\tmut lifetime_b := closure.new_lifetime()',
+		'\tlifetime_a.frame(fn [mut first] () {',
+		'\t\tfirst.cb = make_cb(20)',
+		'\t\tassert first.cb() == 103',
+		'\t})!',
+		'\tlifetime_b.frame(fn [mut second] () {',
+		'\t\tsecond.cb = make_cb(30)',
+		'\t\tassert second.cb() == 123',
+		'\t})!',
+		'\tlifetime_a.reclaim_all()!',
+		'\tcollect_and_churn()',
+		'\tassert second.cb() == 123',
+		'\tlifetime_b.reclaim_all()!',
+		'\tlifetime_a.dispose()!',
+		'\tlifetime_b.dispose()!',
+		'}',
+		'',
+		'fn suspended_persistent_callbacks_survive_reclaim_and_spawn() ! {',
+		'\tmut persisted := &CallbackBox{}',
+		'\tmut spawned_value := &IntBox{value: -1}',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.frame(fn [mut lifetime, mut persisted, mut spawned_value] () {',
+		'\t\tshort := make_cb(5)',
+		'\t\tassert short() == 73',
+		'\t\tlifetime.suspend(fn [mut persisted, mut spawned_value] () {',
+		'\t\t\tpersisted.cb = make_cb(40)',
+		'\t\t\tth := spawn call_cb(persisted.cb)',
+		'\t\t\tspawned_value.value = th.wait()',
+		'\t\t}) or { panic(err) }',
+		'\t})!',
+		'\tlifetime.reclaim_all()!',
+		'\tcollect_and_churn()',
+		'\tassert persisted.cb() == 143',
+		'\tassert spawned_value.value == 143',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn stale_reused_slot_does_not_release_suspended_newer_closure() ! {',
+		'\tmut survivor := &CallbackBox{}',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.frame(fn [mut lifetime, mut survivor] () {',
+		'\t\tfor i in 0 .. 96 {',
+		'\t\t\th := fn [i] () int { return i }',
+		'\t\t\tassert h() == i',
+		'\t\t}',
+		'\t\tlifetime.suspend(fn [mut survivor] () {',
+		'\t\t\tsurvivor.cb = make_cb(70)',
+		'\t\t\tassert survivor.cb() == 203',
+		'\t\t}) or { panic(err) }',
+		'\t})!',
+		'\tlifetime.reclaim_all()!',
+		'\tcollect_and_churn()',
+		'\tassert survivor.cb() == 203',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn direct_untracked_callback_is_public_api() ! {',
+		'\tmut marker := &IntBox{value: -1}',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.frame(fn [mut lifetime, mut marker] () {',
+		'\t\tlifetime.untracked(fn [mut marker] () {',
+		'\t\t\tmarker.value = 91',
+		'\t\t}) or { panic(err) }',
+		'\t})!',
+		'\tlifetime.reclaim_all()!',
+		'\tassert marker.value == 91',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn local_cleanup_and_lifetime_reclaim_do_not_double_release() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tfor i in 0 .. 1024 {',
+		'\t\tlifetime.frame(fn [i] () {',
+		'\t\t\th := fn [i] () int { return i + 1 }',
+		'\t\t\tassert h() == i + 1',
+		'\t\t})!',
+		'\t\tlifetime.reclaim_all()!',
+		'\t}',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn lifetime_reclaim_does_not_accumulate_owned_escaping_closures() ! {',
+		'\t$if gcboehm ? {',
+		'\t\tmut cb := &CallbackBox{}',
+		'\t\tmut lifetime := closure.new_lifetime()',
+		'\t\tgc_collect()',
+		'\t\tstart_mb := gc_memory_use() / 1024 / 1024',
+		'\t\tfor n in 0 .. 20_000 {',
+		'\t\t\tlifetime.frame(fn [mut cb, n] () {',
+		'\t\t\t\tbig := []int{len: 512, init: n + index}',
+		'\t\t\t\tcb.cb = fn [big] () int {',
+		'\t\t\t\t\treturn big[0] + big[big.len - 1]',
+		'\t\t\t\t}',
+		'\t\t\t\tassert cb.cb() == 2 * n + 511',
+		'\t\t\t})!',
+		'\t\t\tlifetime.reclaim_all()!',
+		'\t\t\tif n % 5000 == 0 {',
+		'\t\t\t\tgc_collect()',
+		'\t\t\t}',
+		'\t\t}',
+		'\t\tgc_collect()',
+		'\t\tend_mb := gc_memory_use() / 1024 / 1024',
+		'\t\tassert end_mb <= start_mb + 24',
+		'\t}',
+		'}',
+		'',
+		'fn external_captured_frame_callback_survives_reclaim_all() ! {',
+		'\tpayload := []int{len: 64, init: 200 + index}',
+		'\tcb := fn [payload] () {',
+		'\t\tassert payload[0] == 200',
+		'\t\tassert payload[payload.len - 1] == 263',
+		'\t}',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.frame(cb)!',
+		'\tlifetime.reclaim_all()!',
+		'\tcollect_and_churn()',
+		'\tcb()',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn parenthesized_frame_return_with_captured_callback() ! {',
+		'\tx := 37',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tdefer {',
+		'\t\tlifetime.dispose() or {}',
+		'\t}',
+		'\treturn (lifetime.frame(fn [x] () {',
+		'\t\tassert x == 37',
+		'\t}))',
+		'}',
+		'',
+		'fn frame_end_uses_original_token_state_after_lifetime_reassign() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tmut original := lifetime',
+		'\tlifetime.frame(fn [mut lifetime] () {',
+		'\t\tlifetime = closure.new_lifetime()',
+		'\t})!',
+		'\tmut next := closure.new_lifetime()',
+		'\tnext.frame(no_capture_work)!',
+		'\tnext.dispose()!',
+		'\toriginal.dispose()!',
+		'}',
+		'',
+		'fn lifetime_copies_after_dispose_report_error() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tmut copy := lifetime',
+		'\tlifetime.dispose()!',
+		'\tcollect_and_churn()',
+		'\tmut replacement := closure.new_lifetime()',
+		'\treplacement.frame(no_capture_work)!',
+		'\tmut saw_frame := false',
+		'\tmut saw_reclaim := false',
+		'\tmut saw_suspend := false',
+		'\tmut saw_untracked := false',
+		'\tmut saw_dispose := false',
+		'\tcopy.frame(no_capture_work) or {',
+		"\t\tassert err.msg().contains('dispose') || err.msg().contains('after')",
+		'\t\tsaw_frame = true',
+		'\t}',
+		'\tcopy.reclaim_all() or {',
+		"\t\tassert err.msg().contains('dispose') || err.msg().contains('after')",
+		'\t\tsaw_reclaim = true',
+		'\t}',
+		'\tcopy.suspend(no_capture_work) or {',
+		"\t\tassert err.msg().contains('dispose') || err.msg().contains('after')",
+		'\t\tsaw_suspend = true',
+		'\t}',
+		'\tcopy.untracked(no_capture_work) or {',
+		"\t\tassert err.msg().contains('dispose') || err.msg().contains('after')",
+		'\t\tsaw_untracked = true',
+		'\t}',
+		'\tcopy.dispose() or {',
+		"\t\tassert err.msg().contains('dispose') || err.msg().contains('after')",
+		'\t\tsaw_dispose = true',
+		'\t}',
+		'\tassert saw_frame',
+		'\tassert saw_reclaim',
+		'\tassert saw_suspend',
+		'\tassert saw_untracked',
+		'\tassert saw_dispose',
+		'\treplacement.dispose()!',
+		'}',
+		'',
+		'fn run() ! {',
+		'\toutside_lifetime_closure_survives_lifetime_reclaim()!',
+		'\treclaim_keeps_requested_recent_frame()!',
+		'\ttwo_lifetimes_reclaim_independently()!',
+		'\tsuspended_persistent_callbacks_survive_reclaim_and_spawn()!',
+		'\tstale_reused_slot_does_not_release_suspended_newer_closure()!',
+		'\tdirect_untracked_callback_is_public_api()!',
+		'\tlocal_cleanup_and_lifetime_reclaim_do_not_double_release()!',
+		'\tlifetime_reclaim_does_not_accumulate_owned_escaping_closures()!',
+		'\texternal_captured_frame_callback_survives_reclaim_all()!',
+		'\tparenthesized_frame_return_with_captured_callback()!',
+		'\tframe_end_uses_original_token_state_after_lifetime_reassign()!',
+		'\tlifetime_copies_after_dispose_report_error()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n')
+}
+
+fn boehm_leak_clean_lifetime_source() string {
+	return [
+		'module main',
+		'import builtin.closure',
+		'',
+		'fn make_cb(value int) fn () int {',
+		'\treturn fn [value] () int {',
+		'\t\treturn value + 1',
+		'\t}',
+		'}',
+		'',
+		'fn run() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tfor n in 0 .. 128 {',
+		'\t\tlifetime.frame(fn [n] () {',
+		'\t\t\tcb := make_cb(n)',
+		'\t\t\tassert cb() == n + 1',
+		'\t\t})!',
+		'\t\tlifetime.reclaim_all()!',
+		'\t}',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n')
+}
+
+fn gc_none_lifetime_reclaim_memory_source() string {
+	return [
+		'module main',
+		'import builtin.closure',
+		'import runtime',
+		'',
+		'fn used_mb() u64 {',
+		'\tused := runtime.used_memory() or { return 0 }',
+		'\treturn used / 1024 / 1024',
+		'}',
+		'',
+		'fn frame_callback_context_is_reclaimed() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tmut start_mb := u64(0)',
+		'\tfor n in 0 .. 220000 {',
+		'\t\ta0 := n',
+		'\t\ta1 := n + 1',
+		'\t\ta2 := n + 2',
+		'\t\ta3 := n + 3',
+		'\t\ta4 := n + 4',
+		'\t\ta5 := n + 5',
+		'\t\ta6 := n + 6',
+		'\t\ta7 := n + 7',
+		'\t\ta8 := n + 8',
+		'\t\ta9 := n + 9',
+		'\t\ta10 := n + 10',
+		'\t\ta11 := n + 11',
+		'\t\ta12 := n + 12',
+		'\t\ta13 := n + 13',
+		'\t\ta14 := n + 14',
+		'\t\ta15 := n + 15',
+		'\t\tlifetime.frame(fn [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15] () {',
+		'\t\t\tassert a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 == 8 * a0 + 28',
+		'\t\t\tassert a8 + a9 + a10 + a11 + a12 + a13 + a14 + a15 == 8 * a0 + 92',
+		'\t\t})!',
+		'\t\tlifetime.reclaim_all()!',
+		'\t\tif n == 2048 {',
+		'\t\t\tstart_mb = used_mb()',
+		'\t\t}',
+		'\t}',
+		'\tend_mb := used_mb()',
+		'\tif start_mb > 0 && end_mb > start_mb + 64 {',
+		"\t\tpanic('closure frame callback memory grew too much')",
+		'\t}',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn run() ! {',
+		'\tframe_callback_context_is_reclaimed()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n')
+}
+
+fn gc_none_lifetime_bookkeeping_track_heap_source(header_path string) string {
+	c_header_path := header_path.replace('\\', '/')
+	return [
+		'module main',
+		'import builtin.closure',
+		'',
+		'#include "${c_header_path}"',
+		'',
+		'fn no_capture_work() {}',
+		'',
+		'fn exercise(rounds int) ! {',
+		'\tfor _ in 0 .. rounds {',
+		'\t\tmut lifetime := closure.new_lifetime()',
+		'\t\tmut copy := lifetime',
+		'\t\tlifetime.dispose()!',
+		'\t\tcopy.frame(no_capture_work) or {',
+		'\t\t\tcontinue',
+		'\t\t}',
+		"\t\treturn error('disposed lifetime copy was accepted')",
+		'\t}',
+		'}',
+		'',
+		'fn main() {',
+		'\tmut warmup := closure.new_lifetime()',
+		'\twarmup.dispose() or { panic(err) }',
+		'\texercise(128) or { panic(err) }',
+		'\tmut start := u64(0)',
+		'\tunsafe { closure.lifetime_state_allocs(&start) }',
+		'\texercise(1000) or { panic(err) }',
+		'\tmut end := u64(0)',
+		'\tunsafe { closure.lifetime_state_allocs(&end) }',
+		'\tif end != start {',
+		"\t\tpanic('leaked lifetime state recycling bookkeeping: start=\${start} end=\${end}')",
+		'\t}',
+		'}',
+	].join('\n')
+}
+
+fn lazy_concurrent_lifetime_init_source() string {
+	return [
+		'module main',
+		'import builtin.closure',
+		'',
+		'@[heap]',
+		'struct IntBox {',
+		'mut:',
+		'\tvalue int',
+		'}',
+		'',
+		'fn worker(id int, ready chan bool, start chan bool) ! {',
+		'\tready <- true',
+		"\t_ := <-start or { return error('start channel closed') }",
+		'\tfor round in 0 .. 32 {',
+		'\t\tmut box := &IntBox{}',
+		'\t\texpected := id * 1000 + round',
+		'\t\tmut lifetime := closure.new_lifetime()',
+		'\t\tlifetime.frame(fn [mut box, expected] () {',
+		'\t\t\tmake_value := fn [expected] () int { return expected }',
+		'\t\t\tbox.value = make_value()',
+		'\t\t})!',
+		'\t\tassert box.value == expected',
+		'\t\tlifetime.dispose()!',
+		'\t}',
+		'}',
+		'',
+		'fn run() ! {',
+		'\tthread_count := 16',
+		'\tready := chan bool{cap: thread_count}',
+		'\tstart := chan bool{cap: thread_count}',
+		'\tmut threads := []thread !{cap: thread_count}',
+		'\tfor i in 0 .. thread_count {',
+		'\t\tthreads << spawn worker(i, ready, start)',
+		'\t}',
+		'\tfor _ in 0 .. thread_count {',
+		"\t\t_ := <-ready or { return error('ready channel closed') }",
+		'\t}',
+		'\tfor _ in 0 .. thread_count {',
+		'\t\tstart <- true',
+		'\t}',
+		'\tthreads.wait()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n')
+}
+
+fn assert_misuse_program_passes(tmp_dir string, name string, source string) {
+	source_path := write_program(tmp_dir, name, source)
+	res := os.execute('${os.quoted_path(vexe)} run ${os.quoted_path(source_path)}')
+	assert res.exit_code == 0, res.output
+}
+
+fn test_lifetime_public_api_without_captured_closure() {
+	$if gcboehm_leak ? {
+		return
+	}
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_closure_lifetime_no_capture_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source := no_captured_closure_lifetime_source()
+	c_res := c_output_for_program(tmp_dir, 'no_captured_lifetime_codegen', source)
+	assert c_res.exit_code == 0, c_res.output
+	assert !c_res.output.contains('builtin__closure__closure_create')
+	assert !c_res.output.contains('_V_closure_main__')
+	for mode in ['boehm', 'none'] {
+		res := run_program_with_gc(tmp_dir, 'no_captured_lifetime', source, mode)
+		assert res.exit_code == 0, res.output
+	}
+	assert_boehm_leak_compile_or_missing_lib(tmp_dir, 'no_captured_lifetime', source)
+}
+
+fn test_closure_lifetime_runtime_api_contract() {
+	$if gcboehm_leak ? {
+		return
+	}
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_closure_lifetime_runtime_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source := closure_lifetime_runtime_source()
+	for mode in ['boehm', 'none'] {
+		res := run_program_with_gc(tmp_dir, 'closure_lifetime_runtime', source, mode)
+		assert res.exit_code == 0, res.output
+	}
+	assert_boehm_leak_compile_or_missing_lib(tmp_dir, 'closure_lifetime_runtime', source)
+}
+
+fn test_closure_lifetime_boehm_leak_runtime_without_persistent_callbacks() {
+	$if gcboehm_leak ? {
+		return
+	}
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_closure_lifetime_boehm_leak_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	assert_boehm_leak_runtime_or_compile_only(tmp_dir, 'closure_lifetime_boehm_leak_clean',
+		boehm_leak_clean_lifetime_source())
+}
+
+fn test_closure_lifetime_gc_none_does_not_leak_frame_callback_or_bookkeeping() {
+	$if gcboehm_leak ? {
+		return
+	}
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_closure_lifetime_gc_none_memory_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	res := run_program_with_gc(tmp_dir, 'closure_lifetime_gc_none_memory',
+		gc_none_lifetime_reclaim_memory_source(), 'none')
+	assert res.exit_code == 0, res.output
+}
+
+fn test_closure_lifetime_gc_none_reuses_disposed_state_bookkeeping() {
+	$if gcboehm_leak ? {
+		return
+	}
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_closure_lifetime_gc_none_state_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	header_path := os.join_path(tmp_dir, 'track_heap_hooks.h')
+	os.write_file(header_path, [
+		'void vheap_alloc(void* p, unsigned long long n) { (void)p; (void)n; }',
+		'void vheap_free(void* p) { (void)p; }',
+	].join('\n')) or { panic(err) }
+	res := run_program_with_track_heap(tmp_dir, 'closure_lifetime_gc_none_state',
+		gc_none_lifetime_bookkeeping_track_heap_source(header_path))
+	assert res.exit_code == 0, res.output
+}
+
+fn test_closure_lifetime_dispose_recycles_state_for_later_lifetimes() {
+	source_path := os.join_path(os.dir(vexe), 'vlib/builtin/closure/closure.c.v')
+	source := os.read_file(source_path) or { panic(err) }
+	start := source.index('pub fn (mut lifetime Lifetime) dispose() !') or {
+		panic('missing dispose helper')
+	}
+	end := source[start..].index('pub fn (mut lifetime Lifetime) suspend') or {
+		panic('missing dispose helper end')
+	}
+	helper := source[start..start + end]
+	assert helper.contains('closure_lifetime_recycle_state_no_lock(mut state)')
+	assert helper.contains('lifetime.state = unsafe { nil }')
+	assert helper.contains('lifetime.disposed = true')
+	assert !helper.contains('free(state)')
+}
+
+fn test_closure_lifetime_freestanding_no_std_object_compile() {
+	$if windows {
+		return
+	}
+	$if gcboehm_leak ? {
+		return
+	}
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_closure_lifetime_freestanding_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source := [
+		'module main',
+		'import builtin.closure',
+		'',
+		'fn main() {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.dispose() or { panic(err) }',
+		'}',
+	].join('\n')
+	res := compile_freestanding_object(tmp_dir, 'closure_lifetime_freestanding', source)
+	assert res.exit_code == 0, res.output
+}
+
+fn test_closure_lifetime_lazy_concurrent_runtime_init() {
+	$if gcboehm_leak ? {
+		return
+	}
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_closure_lifetime_lazy_init_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source := lazy_concurrent_lifetime_init_source()
+	for mode in ['none', 'boehm'] {
+		res := run_program_with_gc(tmp_dir, 'closure_lifetime_lazy_init', source, mode)
+		assert res.exit_code == 0, res.output
+	}
+}
+
+fn test_closure_lifetime_reclaim_helper_reuses_buffers_without_clone() {
+	source_path := os.join_path(os.dir(vexe), 'vlib/builtin/closure/closure.c.v')
+	source := os.read_file(source_path) or { panic(err) }
+	start := source.index('fn closure_lifetime_reclaim_no_lock') or {
+		panic('missing reclaim helper')
+	}
+	end := source[start..].index('fn closure_ensure_initialized') or {
+		panic('missing reclaim helper end')
+	}
+	helper := source[start..start + end]
+	assert !helper.contains('.clone()')
+	assert helper.contains('delete_many(0, reclaim_count)')
+	assert helper.contains('delete_many(0, cutoff)')
+}
+
+fn test_closure_lifetime_dispose_frees_bookkeeping_buffers_but_keeps_state() {
+	source_path := os.join_path(os.dir(vexe), 'vlib/builtin/closure/closure.c.v')
+	source := os.read_file(source_path) or { panic(err) }
+	start := source.index('fn closure_lifetime_recycle_state_no_lock') or {
+		panic('missing recycle helper')
+	}
+	end := source[start..].index('fn closure_lifetime_error') or {
+		panic('missing recycle helper end')
+	}
+	helper := source[start..start + end]
+	assert helper.contains('state.disposed = true')
+	assert helper.contains('state.records.free()')
+	assert helper.contains('state.frames.free()')
+	assert helper.contains('state.records = []ClosureLifetimeRecord{}')
+	assert helper.contains('state.frames = []ClosureLifetimeFrame{}')
+	assert helper.contains('state.next_free = g_closure.free_lifetime_states')
+	assert helper.contains('g_closure.free_lifetime_states = state')
+	assert !helper.contains('free(state)')
+}
+
+fn test_closure_lifetime_once_headers_keep_helper_internal() {
+	for header_name in ['closure_once_nix.h', 'closure_once_windows.h'] {
+		source_path := os.join_path(os.dir(vexe), 'vlib/builtin/closure/${header_name}')
+		source := os.read_file(source_path) or { panic(err) }
+		assert source.contains('V_CLOSURE_STATIC_INLINE void v_closure_init_once')
+		assert !source.contains('\nvoid v_closure_init_once')
+	}
+}
+
+fn test_closure_lifetime_codegen_emits_single_local_destroy() {
+	$if gcboehm_leak ? {
+		return
+	}
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_closure_lifetime_codegen_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source := [
+		'module main',
+		'import builtin.closure',
+		'',
+		'fn run() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.frame(fn () {',
+		'\t\tvalue := 7',
+		'\t\th := fn [value] () int { return value }',
+		'\t\tassert h() == 7',
+		'\t})!',
+		'\tlifetime.reclaim_all()!',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n')
+	res := c_output_for_program(tmp_dir, 'closure_lifetime_single_destroy', source)
+	assert res.exit_code == 0, res.output
+	assert count_occurrences(res.output, 'builtin__closure__closure_try_destroy((voidptr)h);') == 1
+}
+
+fn test_closure_lifetime_inline_callback_codegen_cleanup() {
+	$if gcboehm_leak ? {
+		return
+	}
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_closure_lifetime_inline_codegen_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source := [
+		'module main',
+		'import builtin.closure',
+		'',
+		'struct View {',
+		'\tvalue int',
+		'}',
+		'',
+		'fn (view View) draw() {',
+		'\tassert view.value == 41',
+		'}',
+		'',
+		'fn frame_bound_method() ! {',
+		'\tview := View{value: 41}',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.frame(view.draw)!',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn outside_suspend_untracked() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tvalue := 7',
+		'\tlifetime.suspend(fn [value] () {',
+		'\t\tassert value == 7',
+		'\t})!',
+		'\tlifetime.untracked(fn [value] () {',
+		'\t\tassert value == 7',
+		'\t})!',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn parenthesized_inline_frame() ! {',
+		'\tvalue := 12',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.frame((fn [value] () {',
+		'\t\tassert value == 12',
+		'\t}))!',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn tail_return_frame(value int) ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\treturn lifetime.frame(fn [value] () {',
+		'\t\tassert value == 9',
+		'\t})',
+		'}',
+		'',
+		'fn main() {',
+		'\tframe_bound_method() or { panic(err) }',
+		'\toutside_suspend_untracked() or { panic(err) }',
+		'\tparenthesized_inline_frame() or { panic(err) }',
+		'\ttail_return_frame(9) or { panic(err) }',
+		'}',
+	].join('\n')
+	res := c_output_for_program(tmp_dir, 'closure_lifetime_inline_cleanup', source)
+	assert res.exit_code == 0, res.output
+	destroy_count := count_occurrences(res.output,
+		'builtin__closure__closure_try_destroy((voidptr)')
+	assert destroy_count == 5, res.output
+	parenthesized_start := res.output.index('VV_LOC _result_void main__parenthesized_inline_frame(void) {') or {
+		panic(res.output)
+	}
+	parenthesized_end := if parenthesized_start + 1200 < res.output.len {
+		parenthesized_start + 1200
+	} else {
+		res.output.len
+	}
+	parenthesized_fn := res.output[parenthesized_start..parenthesized_end]
+	frame_pos := parenthesized_fn.index('builtin__closure__Lifetime_frame') or {
+		panic(parenthesized_fn)
+	}
+	destroy_pos := parenthesized_fn.index('builtin__closure__closure_try_destroy((voidptr)') or {
+		panic(parenthesized_fn)
+	}
+	assert destroy_pos > frame_pos, parenthesized_fn
+	assert !res.output.contains('return builtin__closure__Lifetime_frame(')
+}
+
+fn test_closure_lifetime_borrowed_callback_result_is_not_destroyed() {
+	$if gcboehm_leak ? {
+		return
+	}
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_closure_lifetime_borrowed_callback_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source := [
+		'module main',
+		'import builtin.closure',
+		'',
+		'fn identity(cb fn ()) fn () {',
+		'\treturn cb',
+		'}',
+		'',
+		'fn run() ! {',
+		'\tpayload := []int{len: 32, init: index}',
+		'\tstored := fn [payload] () {',
+		'\t\tassert payload[0] == 0',
+		'\t\tassert payload[payload.len - 1] == 31',
+		'\t}',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.frame(identity(stored))!',
+		'\tlifetime.dispose()!',
+		'\tstored()',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n')
+	c_res := c_output_for_program(tmp_dir, 'closure_lifetime_borrowed_callback_cgen', source)
+	assert c_res.exit_code == 0, c_res.output
+	run_start := c_res.output.index('VV_LOC _result_void main__run(void) {') or {
+		panic(c_res.output)
+	}
+	run_end := c_res.output.index_after('VV_LOC void main__main(void) {', run_start) or {
+		panic(c_res.output)
+	}
+	run_fn := c_res.output[run_start..run_end]
+	assert !run_fn.contains('builtin__closure__closure_try_destroy((voidptr)'), run_fn
+	res := run_program_with_gc(tmp_dir, 'closure_lifetime_borrowed_callback', source, 'none')
+	assert res.exit_code == 0, res.output
+}
+
+fn test_lifetime_rejects_misuse_with_errors() {
+	$if gcboehm_leak ? {
+		return
+	}
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_closure_lifetime_api_${os.getpid()}')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	assert_misuse_program_passes(tmp_dir, 'wrong_thread_reclaim', [
+		'import builtin.closure',
+		'',
+		'fn reclaim_from_thread(lifetime closure.Lifetime) ! {',
+		'\tmut local := lifetime',
+		'\tlocal.reclaim_all()!',
+		'}',
+		'',
+		'fn main() {',
+		'\tlifetime := closure.new_lifetime()',
+		'\tth := spawn reclaim_from_thread(lifetime)',
+		'\tth.wait() or {',
+		"\t\tassert err.msg().contains('different thread')",
+		'\t\treturn',
+		'\t}',
+		'\tassert false',
+		'}',
+	].join('\n'))
+	assert_misuse_program_passes(tmp_dir, 'wrong_thread_dispose', [
+		'import builtin.closure',
+		'',
+		'fn dispose_from_thread(lifetime closure.Lifetime) ! {',
+		'\tmut local := lifetime',
+		'\tlocal.dispose()!',
+		'}',
+		'',
+		'fn main() {',
+		'\tlifetime := closure.new_lifetime()',
+		'\tth := spawn dispose_from_thread(lifetime)',
+		'\tth.wait() or {',
+		"\t\tassert err.msg().contains('different thread')",
+		'\t\treturn',
+		'\t}',
+		'\tassert false',
+		'}',
+	].join('\n'))
+	assert_misuse_program_passes(tmp_dir, 'wrong_thread_suspend', [
+		'import builtin.closure',
+		'',
+		'fn no_capture_work() {}',
+		'',
+		'fn suspend_from_thread(lifetime closure.Lifetime) ! {',
+		'\tmut local := lifetime',
+		'\tlocal.suspend(no_capture_work)!',
+		'}',
+		'',
+		'fn main() {',
+		'\tlifetime := closure.new_lifetime()',
+		'\tth := spawn suspend_from_thread(lifetime)',
+		'\tth.wait() or {',
+		"\t\tassert err.msg().contains('different thread')",
+		'\t\treturn',
+		'\t}',
+		'\tassert false',
+		'}',
+	].join('\n'))
+	assert_misuse_program_passes(tmp_dir, 'wrong_thread_frame', [
+		'import builtin.closure',
+		'',
+		'fn no_capture_work() {}',
+		'',
+		'fn frame_from_thread(lifetime closure.Lifetime) ! {',
+		'\tmut local := lifetime',
+		'\tlocal.frame(no_capture_work)!',
+		'}',
+		'',
+		'fn main() {',
+		'\tlifetime := closure.new_lifetime()',
+		'\tth := spawn frame_from_thread(lifetime)',
+		'\tth.wait() or {',
+		"\t\tassert err.msg().contains('different thread')",
+		'\t\treturn',
+		'\t}',
+		'\tassert false',
+		'}',
+	].join('\n'))
+	assert_misuse_program_passes(tmp_dir, 'nested_same_lifetime_frame', [
+		'import builtin.closure',
+		'',
+		'@[heap]',
+		'struct BoolBox {',
+		'mut:',
+		'\tvalue bool',
+		'}',
+		'',
+		'fn no_capture_work() {}',
+		'',
+		'fn run() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tmut saw := &BoolBox{}',
+		'\tlifetime.frame(fn [mut lifetime, mut saw] () {',
+		'\t\tlifetime.frame(no_capture_work) or {',
+		"\t\t\tassert err.msg().contains('active') || err.msg().contains('nested')",
+		'\t\t\tsaw.value = true',
+		'\t\t\treturn',
+		'\t\t}',
+		'\t\tassert false',
+		'\t})!',
+		'\tassert saw.value',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n'))
+	assert_misuse_program_passes(tmp_dir, 'second_active_lifetime', [
+		'import builtin.closure',
+		'',
+		'@[heap]',
+		'struct BoolBox {',
+		'mut:',
+		'\tvalue bool',
+		'}',
+		'',
+		'fn no_capture_work() {}',
+		'',
+		'fn run() ! {',
+		'\tmut first := closure.new_lifetime()',
+		'\tmut second := closure.new_lifetime()',
+		'\tmut saw := &BoolBox{}',
+		'\tfirst.frame(fn [mut second, mut saw] () {',
+		'\t\tsecond.frame(no_capture_work) or {',
+		"\t\t\tassert err.msg().contains('active') || err.msg().contains('another')",
+		'\t\t\tsaw.value = true',
+		'\t\t\treturn',
+		'\t\t}',
+		'\t\tassert false',
+		'\t})!',
+		'\tassert saw.value',
+		'\tfirst.dispose()!',
+		'\tsecond.dispose()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n'))
+	assert_misuse_program_passes(tmp_dir, 'second_suspend_inside_first_frame', [
+		'import builtin.closure',
+		'',
+		'@[heap]',
+		'struct BoolBox {',
+		'mut:',
+		'\tvalue bool',
+		'}',
+		'',
+		'fn no_capture_work() {}',
+		'',
+		'fn run() ! {',
+		'\tmut first := closure.new_lifetime()',
+		'\tmut second := closure.new_lifetime()',
+		'\tmut saw := &BoolBox{}',
+		'\tfirst.frame(fn [mut second, mut saw] () {',
+		'\t\tsecond.suspend(no_capture_work) or {',
+		"\t\t\tassert err.msg().contains('active') || err.msg().contains('another')",
+		'\t\t\tsaw.value = true',
+		'\t\t\treturn',
+		'\t\t}',
+		'\t\tassert false',
+		'\t})!',
+		'\tassert saw.value',
+		'\tfirst.dispose()!',
+		'\tsecond.dispose()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n'))
+	assert_misuse_program_passes(tmp_dir, 'reclaim_dispose_while_active', [
+		'import builtin.closure',
+		'',
+		'@[heap]',
+		'struct BoolBox {',
+		'mut:',
+		'\tvalue bool',
+		'}',
+		'',
+		'fn run() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tmut saw_reclaim := &BoolBox{}',
+		'\tmut saw_dispose := &BoolBox{}',
+		'\tlifetime.frame(fn [mut lifetime, mut saw_reclaim, mut saw_dispose] () {',
+		'\t\tlifetime.reclaim_all() or {',
+		"\t\t\tassert err.msg().contains('active')",
+		'\t\t\tsaw_reclaim.value = true',
+		'\t\t}',
+		'\t\tlifetime.dispose() or {',
+		"\t\t\tassert err.msg().contains('active')",
+		'\t\t\tsaw_dispose.value = true',
+		'\t\t\treturn',
+		'\t\t}',
+		'\t\tassert false',
+		'\t})!',
+		'\tassert saw_reclaim.value',
+		'\tassert saw_dispose.value',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n'))
+	assert_misuse_program_passes(tmp_dir, 'dispose_while_suspended', [
+		'import builtin.closure',
+		'',
+		'@[heap]',
+		'struct BoolBox {',
+		'mut:',
+		'\tvalue bool',
+		'}',
+		'',
+		'fn run() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tmut saw := &BoolBox{}',
+		'\tlifetime.suspend(fn [mut lifetime, mut saw] () {',
+		'\t\tlifetime.dispose() or {',
+		"\t\t\tassert err.msg().contains('suspend')",
+		'\t\t\tsaw.value = true',
+		'\t\t\treturn',
+		'\t\t}',
+		'\t\tassert false',
+		'\t})!',
+		'\tassert saw.value',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n'))
+	assert_misuse_program_passes(tmp_dir, 'dispose_while_untracked', [
+		'import builtin.closure',
+		'',
+		'@[heap]',
+		'struct BoolBox {',
+		'mut:',
+		'\tvalue bool',
+		'}',
+		'',
+		'fn run() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tmut saw := &BoolBox{}',
+		'\tlifetime.untracked(fn [mut lifetime, mut saw] () {',
+		'\t\tlifetime.dispose() or {',
+		"\t\t\tassert err.msg().contains('suspend')",
+		'\t\t\tsaw.value = true',
+		'\t\t\treturn',
+		'\t\t}',
+		'\t\tassert false',
+		'\t})!',
+		'\tassert saw.value',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n'))
+	assert_misuse_program_passes(tmp_dir, 'frame_while_suspended', [
+		'import builtin.closure',
+		'',
+		'@[heap]',
+		'struct BoolBox {',
+		'mut:',
+		'\tvalue bool',
+		'}',
+		'',
+		'fn no_capture_work() {}',
+		'',
+		'fn run() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tmut saw := &BoolBox{}',
+		'\tlifetime.suspend(fn [mut lifetime, mut saw] () {',
+		'\t\tlifetime.frame(no_capture_work) or {',
+		"\t\t\tassert err.msg().contains('suspend')",
+		'\t\t\tsaw.value = true',
+		'\t\t\treturn',
+		'\t\t}',
+		'\t\tassert false',
+		'\t})!',
+		'\tassert saw.value',
+		'\tlifetime.dispose()!',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n'))
+	assert_misuse_program_passes(tmp_dir, 'use_after_dispose', [
+		'import builtin.closure',
+		'',
+		'fn no_capture_work() {}',
+		'',
+		'fn run() ! {',
+		'\tmut lifetime := closure.new_lifetime()',
+		'\tlifetime.dispose()!',
+		'\tmut saw_frame := false',
+		'\tmut saw_reclaim := false',
+		'\tmut saw_suspend := false',
+		'\tmut saw_untracked := false',
+		'\tmut saw_dispose := false',
+		'\tlifetime.frame(no_capture_work) or {',
+		"\t\tassert err.msg().contains('dispose') || err.msg().contains('after')",
+		'\t\tsaw_frame = true',
+		'\t}',
+		'\tlifetime.reclaim_all() or {',
+		"\t\tassert err.msg().contains('dispose') || err.msg().contains('after')",
+		'\t\tsaw_reclaim = true',
+		'\t}',
+		'\tlifetime.suspend(no_capture_work) or {',
+		"\t\tassert err.msg().contains('dispose') || err.msg().contains('after')",
+		'\t\tsaw_suspend = true',
+		'\t}',
+		'\tlifetime.untracked(no_capture_work) or {',
+		"\t\tassert err.msg().contains('dispose') || err.msg().contains('after')",
+		'\t\tsaw_untracked = true',
+		'\t}',
+		'\tlifetime.dispose() or {',
+		"\t\tassert err.msg().contains('dispose') || err.msg().contains('after')",
+		'\t\tsaw_dispose = true',
+		'\t}',
+		'\tassert saw_frame',
+		'\tassert saw_reclaim',
+		'\tassert saw_suspend',
+		'\tassert saw_untracked',
+		'\tassert saw_dispose',
+		'}',
+		'',
+		'fn main() {',
+		'\trun() or { panic(err) }',
+		'}',
+	].join('\n'))
+}

--- a/vlib/v/tests/loops/for_c_init_closure_cleanup_test.v
+++ b/vlib/v/tests/loops/for_c_init_closure_cleanup_test.v
@@ -1,0 +1,70 @@
+fn test_for_c_init_closure_survives_body_tail_cleanup() {
+	base := 40
+	mut i := 0
+	mut values := []int{}
+	for h := fn [base] (x int) int {
+		return base + x}; i < 3; i++ {
+		values << h(i)
+	}
+	assert values == [40, 41, 42]
+}
+
+fn test_for_c_init_closure_survives_continue_cleanup() {
+	base := 50
+	mut i := 0
+	mut values := []int{}
+	for h := fn [base] (x int) int {
+		return base + x}; i < 3; i++ {
+		if i == 0 {
+			continue
+		}
+		values << h(i)
+	}
+	assert values == [51, 52]
+}
+
+fn test_multi_for_c_init_closure_survives_body_tail_cleanup() {
+	base := 60
+	mut values := []int{}
+	for h, i := fn [base] (x int) int {
+		return base + x}, 0; i < 3; i++ {
+		values << h(i)
+	}
+	assert values == [60, 61, 62]
+}
+
+fn test_nested_for_c_init_closure_continue_outer() {
+	outer_base := 70
+	mut i := 0
+	mut values := []int{}
+	continue_outer: for outer_h := fn [outer_base] (x int) int {
+		return outer_base + x}; i < 2; i++ {
+		inner_base := 80
+		mut j := 0
+		for inner_h := fn [inner_base] (x int) int {
+			return inner_base + x}; j < 1; j++ {
+			values << outer_h(i)
+			values << inner_h(j)
+			continue continue_outer
+		}
+	}
+	assert values == [70, 80, 71, 80]
+}
+
+fn test_nested_for_c_init_closure_break_outer() {
+	outer_base := 90
+	mut i := 0
+	mut values := []int{}
+	break_outer: for outer_h := fn [outer_base] (x int) int {
+		return outer_base + x}; i < 2; i++ {
+		inner_base := 100
+		mut j := 0
+		for inner_h := fn [inner_base] (x int) int {
+			return inner_base + x}; j < 1; j++ {
+			values << outer_h(i)
+			values << inner_h(j)
+			break break_outer
+		}
+	}
+	assert values == [90, 100]
+}


### PR DESCRIPTION
## Summary

This is a recovery of the closure leak work discussed in #27446.

It fixes #27445 by adding the compiler/runtime foundation for captured closure reclamation. Captured closure contexts now use collectable `memdup` instead of `memdup_uncollectable`, while the closure runtime keeps live contexts reachable through a scanned table.

Non-escaping local captured closures are cleaned up when their scope is left, including normal scope exit, `return`, and labeled/non-labeled `break` / `continue`.

The cleanup remains conservative. Closures are not destroyed when they escape through return values, copies, function arguments, struct fields, globals, defer blocks, `spawn`, or `go`.

This PR also adds an explicit, reusable closure lifetime/reclaim API that frame-based or immediate-mode systems can use without exposing raw closure destruction.

Public API added:

- `closure.new_lifetime()`
- `Lifetime.frame(work fn ()) !`
- `Lifetime.reclaim(retain int) !`
- `Lifetime.reclaim_all() !`
- `Lifetime.dispose() !`
- `Lifetime.suspend(work fn ()) !`
- `Lifetime.untracked(work fn ()) !`

The API lets a caller create a lifetime owner, run one transient frame under that owner, reclaim old frame-owned closure contexts, and explicitly keep persistent callbacks outside reclaim when needed.

Important contract: `frame`, `suspend`, and `untracked` borrow their `work` callback. The lifetime owns only the closure contexts created while a frame is active.

## Changes

- Add explicit closure context ownership through `closure_create_with_data`.
- Keep live closure contexts rooted under Boehm while the closure is alive.
- Clear root table entries before deleting them.
- Generate collectable closure contexts for captured anonymous functions.
- Distinguish owned value receivers from borrowed pointer receivers for method-value closures.
- Add conservative local non-escaping closure cleanup in Cgen.
- Add a reusable closure lifetime/reclaim API.
- Add regression coverage for the memory growth pattern, generated-C safety cases, skip-unused, and lifetime API behavior.
- Keep escaping GUI-style handlers alive unless an explicit owner/lifetime policy releases them.

## Follow-up

This PR prepares the ground for vlang/gui#58, but does not claim to fully fix it by itself.

The remaining work should be done in vlang/gui by using the new lifetime API when replacing frame/layout trees in `Window.update()`.

## Tests

All tests below were run on the current PR head `3d974672d`.

```sh
./v_pr19_verify fmt -verify \
  vlib/builtin/closure/closure.c.v \
  vlib/builtin/closure/closure_nix.c.v \
  vlib/builtin/closure/closure_windows.c.v \
  vlib/v/gen/c/cgen.v \
  vlib/v/gen/c/fn.v \
  vlib/v/gen/c/for.v \
  vlib/v/gen/c/closure_context_codegen_test.v \
  vlib/v/tests/fns/closure_context_boehm_root_test.c.v \
  vlib/v/tests/fns/closure_context_skip_unused_test.v \
  vlib/v/tests/fns/closure_lifetime_api_test.v \
  vlib/v/tests/loops/for_c_init_closure_cleanup_test.v

./v_pr19_verify missdoc --verify vlib/builtin/closure/closure.c.v

./v_pr19_verify test vlib/v/gen/c/closure_context_codegen_test.v
./v_pr19_verify test vlib/v/tests/fns/closure_lifetime_api_test.v
./v_pr19_verify -gc none test vlib/v/tests/fns/closure_lifetime_api_test.v
./v_pr19_verify -gc boehm test vlib/v/tests/fns/closure_lifetime_api_test.v
./v_pr19_verify -gc boehm_leak test vlib/v/tests/fns/closure_lifetime_api_test.v
./v_pr19_verify -cstrict test vlib/v/tests/fns/closure_lifetime_api_test.v

./v_pr19_verify test vlib/v/tests/fns/closure_context_skip_unused_test.v
./v_pr19_verify -gc boehm_leak test vlib/v/tests/fns/closure_context_skip_unused_test.v

./v_pr19_verify -gc boehm test vlib/v/tests/fns/closure_context_boehm_root_test.c.v
./v_pr19_verify -gc none test vlib/v/tests/fns/closure_context_boehm_root_test.c.v

./v_pr19_verify -gc none test vlib/v/tests/loops/for_c_init_closure_cleanup_test.v
./v_pr19_verify test vlib/v/tests/defer/scoped_defer_test.v
./v_pr19_verify test vlib/v/gen/c/coutput_test.v

VJOBS=1 ./v_pr19_verify test vlib/v/tests/fns
git diff --check