### PR TITLE
cgen: fix comparing two option-of-struct values (`?Struct == ?Struct`)

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -426,9 +426,8 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 				g.write(')')
 			}
 			.struct {
-				if left_is_option && right_is_option && !left.typ.is_ptr() && !right.typ.is_ptr() {
-					bare_typ := g.equality_fn(left.unaliased.clear_flag(.option))
-					styp := g.base_type(left_type)
+				if left_is_option && right_is_option {
+					bare_typ := g.equality_fn(left.unaliased.clear_flag(.option).set_nr_muls(0))
 					old_inside_opt_or_res := g.inside_opt_or_res
 					g.inside_opt_or_res = true
 					inside_and_rhs := g.infix_left_var_name.len > 0
@@ -450,8 +449,20 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 					}
 					g.write('(${lv}.state == 2 && ${rv}.state == 2) || ')
 					g.write('(${lv}.state == ${rv}.state && ${lv}.state != 2 && ')
-					g.write('${bare_typ}_struct_eq(*(${styp}*)&${lv}.data, *(${styp}*)&${rv}.data))')
-					g.write(')')
+					if left.typ.is_ptr() {
+						ptr_styp := g.styp(left.unaliased.clear_flag(.option))
+						nr_muls := left.typ.nr_muls()
+						deref := '*'.repeat(nr_muls)
+						lp := '*(${ptr_styp}*)&${lv}.data'
+						rp := '*(${ptr_styp}*)&${rv}.data'
+						g.write('(${lp} == ${rp} || (${lp} != 0 && ${rp} != 0 && ')
+						g.write('${bare_typ}_struct_eq(${deref}${lp}, ${deref}${rp})')
+						g.write('))')
+					} else {
+						styp := g.base_type(left_type)
+						g.write('${bare_typ}_struct_eq(*(${styp}*)&${lv}.data, *(${styp}*)&${rv}.data)')
+					}
+					g.write('))')
 					g.inside_opt_or_res = old_inside_opt_or_res
 				} else {
 					ptr_typ := g.equality_fn(left.unaliased)

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -426,32 +426,24 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 				g.write(')')
 			}
 			.struct {
-				if left_is_option && right_is_option {
+				if left_is_option && right_is_option && !left.typ.is_ptr() && !right.typ.is_ptr() {
 					bare_typ := g.equality_fn(left.unaliased.clear_flag(.option))
 					styp := g.base_type(left_type)
 					old_inside_opt_or_res := g.inside_opt_or_res
 					g.inside_opt_or_res = true
+					left_tmp := g.expr_to_ctemp_before_stmt(node.left, left_type)
+					right_tmp := g.expr_to_ctemp_before_stmt(node.right, right_type)
+					lv := left_tmp.name
+					rv := right_tmp.name
 					if node.op == .eq {
 						g.write('(')
 					} else {
 						g.write('!(')
 					}
-					g.write('(')
-					g.expr(node.left)
-					g.write('.state == 2 && ')
-					g.expr(node.right)
-					g.write('.state == 2) || (')
-					g.expr(node.left)
-					g.write('.state == ')
-					g.expr(node.right)
-					g.write('.state && ')
-					g.expr(node.left)
-					g.write('.state != 2 && ')
-					g.write('${bare_typ}_struct_eq(*(${styp}*)&')
-					g.expr(node.left)
-					g.write('.data, *(${styp}*)&')
-					g.expr(node.right)
-					g.write('.data)))')
+					g.write('(${lv}.state == 2 && ${rv}.state == 2) || ')
+					g.write('(${lv}.state == ${rv}.state && ${lv}.state != 2 && ')
+					g.write('${bare_typ}_struct_eq(*(${styp}*)&${lv}.data, *(${styp}*)&${rv}.data))')
+					g.write(')')
 					g.inside_opt_or_res = old_inside_opt_or_res
 				} else {
 					ptr_typ := g.equality_fn(left.unaliased)

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -431,10 +431,18 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 					styp := g.base_type(left_type)
 					old_inside_opt_or_res := g.inside_opt_or_res
 					g.inside_opt_or_res = true
-					left_tmp := g.expr_to_ctemp_before_stmt(node.left, left_type)
-					right_tmp := g.expr_to_ctemp_before_stmt(node.right, right_type)
-					lv := left_tmp.name
-					rv := right_tmp.name
+					inside_and_rhs := g.infix_left_var_name.len > 0
+					mut lv := ''
+					mut rv := ''
+					if inside_and_rhs {
+						lv = g.expr_string(node.left)
+						rv = g.expr_string(node.right)
+					} else {
+						left_tmp := g.expr_to_ctemp_before_stmt(node.left, left_type)
+						right_tmp := g.expr_to_ctemp_before_stmt(node.right, right_type)
+						lv = left_tmp.name
+						rv = right_tmp.name
+					}
 					if node.op == .eq {
 						g.write('(')
 					} else {

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -426,28 +426,56 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 				g.write(')')
 			}
 			.struct {
-				ptr_typ := g.equality_fn(left.unaliased)
-				if left.typ.is_ptr() || right.typ.is_ptr() {
-					// `&lvalue` on either side means the user is comparing addresses; skip the deep `_struct_eq` (`&StructInit{}` still does deep eq).
-					left_is_addr_of_lvalue := node.left is ast.PrefixExpr && node.left.op == .amp
-						&& node.left.right.is_lvalue()
-					right_is_addr_of_lvalue := node.right is ast.PrefixExpr && node.right.op == .amp
-						&& node.right.right.is_lvalue()
-					if left.typ.is_ptr() && right.typ.is_ptr()
-						&& (left_is_addr_of_lvalue || right_is_addr_of_lvalue) {
-						g.gen_plain_infix_expr(node)
+				if left_is_option && right_is_option {
+					bare_typ := g.equality_fn(left.unaliased.clear_flag(.option))
+					styp := g.base_type(left_type)
+					old_inside_opt_or_res := g.inside_opt_or_res
+					g.inside_opt_or_res = true
+					if node.op == .eq {
+						g.write('(')
 					} else {
-						g.gen_struct_pointer_eq_op(node, left_type, right_type, ptr_typ)
+						g.write('!(')
 					}
-				} else {
-					if node.op == .ne {
-						g.write('!')
-					}
-					g.write('${ptr_typ}_struct_eq(')
+					g.write('(')
 					g.expr(node.left)
-					g.write(', ')
+					g.write('.state == 2 && ')
 					g.expr(node.right)
-					g.write(')')
+					g.write('.state == 2) || (')
+					g.expr(node.left)
+					g.write('.state == ')
+					g.expr(node.right)
+					g.write('.state && ')
+					g.expr(node.left)
+					g.write('.state != 2 && ')
+					g.write('${bare_typ}_struct_eq(*(${styp}*)&')
+					g.expr(node.left)
+					g.write('.data, *(${styp}*)&')
+					g.expr(node.right)
+					g.write('.data)))')
+					g.inside_opt_or_res = old_inside_opt_or_res
+				} else {
+					ptr_typ := g.equality_fn(left.unaliased)
+					if left.typ.is_ptr() || right.typ.is_ptr() {
+						left_is_addr_of_lvalue := node.left is ast.PrefixExpr
+							&& node.left.op == .amp && node.left.right.is_lvalue()
+						right_is_addr_of_lvalue := node.right is ast.PrefixExpr
+							&& node.right.op == .amp && node.right.right.is_lvalue()
+						if left.typ.is_ptr() && right.typ.is_ptr()
+							&& (left_is_addr_of_lvalue || right_is_addr_of_lvalue) {
+							g.gen_plain_infix_expr(node)
+						} else {
+							g.gen_struct_pointer_eq_op(node, left_type, right_type, ptr_typ)
+						}
+					} else {
+						if node.op == .ne {
+							g.write('!')
+						}
+						g.write('${ptr_typ}_struct_eq(')
+						g.expr(node.left)
+						g.write(', ')
+						g.expr(node.right)
+						g.write(')')
+					}
 				}
 			}
 			.sum_type {

--- a/vlib/v/tests/option_struct_eq_test.v
+++ b/vlib/v/tests/option_struct_eq_test.v
@@ -1,0 +1,68 @@
+struct Id {
+	v int
+}
+
+struct Person {
+	name string
+	age  int
+}
+
+fn test_option_struct_ne() {
+	assert ?Id(Id{
+		v: 1
+	}) != ?Id(Id{
+		v: 2
+	})
+	assert ?Id(Id{
+		v: 1
+	}) != ?Id(none)
+}
+
+fn test_option_struct_eq() {
+	assert ?Id(Id{
+		v: 1
+	}) == ?Id(Id{
+		v: 1
+	})
+	assert ?Id(none) == ?Id(none)
+}
+
+fn test_option_struct_ne_with_strings() {
+	assert ?Person(Person{
+		name: 'Alice'
+		age:  30
+	}) != ?Person(Person{
+		name: 'Bob'
+		age:  25
+	})
+	assert ?Person(Person{
+		name: 'Alice'
+		age:  30
+	}) != ?Person(none)
+}
+
+fn test_option_struct_eq_with_strings() {
+	assert ?Person(Person{
+		name: 'Alice'
+		age:  30
+	}) == ?Person(Person{
+		name: 'Alice'
+		age:  30
+	})
+	assert ?Person(none) == ?Person(none)
+}
+
+fn cmp(a ?Id, b ?Id) bool {
+	return a != b
+}
+
+fn test_option_struct_eq_in_fn() {
+	assert cmp(Id{ v: 1 }, Id{
+		v: 2
+	}) == true
+	assert cmp(Id{ v: 1 }, Id{
+		v: 1
+	}) == false
+	assert cmp(none, none) == false
+	assert cmp(Id{ v: 1 }, none) == true
+}

--- a/vlib/v/tests/option_struct_eq_test.v
+++ b/vlib/v/tests/option_struct_eq_test.v
@@ -83,3 +83,19 @@ fn test_option_struct_eq_fn_call_result() {
 	assert make_none_id() == make_none_id()
 	assert make_id(1) != make_none_id()
 }
+
+fn test_option_struct_eq_in_short_circuit() {
+	a := ?Id(Id{
+		v: 1
+	})
+	b := ?Id(Id{
+		v: 1
+	})
+	c := ?Id(Id{
+		v: 2
+	})
+	assert true && a == b
+	assert true && a != c
+	assert false || a == b
+	assert !(false && a != b)
+}

--- a/vlib/v/tests/option_struct_eq_test.v
+++ b/vlib/v/tests/option_struct_eq_test.v
@@ -66,3 +66,20 @@ fn test_option_struct_eq_in_fn() {
 	assert cmp(none, none) == false
 	assert cmp(Id{ v: 1 }, none) == true
 }
+
+fn make_id(v int) ?Id {
+	return Id{
+		v: v
+	}
+}
+
+fn make_none_id() ?Id {
+	return none
+}
+
+fn test_option_struct_eq_fn_call_result() {
+	assert make_id(1) == make_id(1)
+	assert make_id(1) != make_id(2)
+	assert make_none_id() == make_none_id()
+	assert make_id(1) != make_none_id()
+}

--- a/vlib/v/tests/option_struct_eq_test.v
+++ b/vlib/v/tests/option_struct_eq_test.v
@@ -99,3 +99,33 @@ fn test_option_struct_eq_in_short_circuit() {
 	assert false || a == b
 	assert !(false && a != b)
 }
+
+fn test_option_ptr_struct_eq() {
+	a := ?&Id(&Id{
+		v: 1
+	})
+	b := ?&Id(&Id{
+		v: 1
+	})
+	c := ?&Id(&Id{
+		v: 2
+	})
+	d := ?&Id(none)
+	e := ?&Id(none)
+	assert a == b
+	assert a != c
+	assert a != d
+	assert d == e
+	assert a != ?&Id(none)
+}
+
+fn test_option_ptr_struct_ne() {
+	a := ?&Id(&Id{
+		v: 1
+	})
+	b := ?&Id(&Id{
+		v: 2
+	})
+	assert a != b
+	assert a != ?&Id(none)
+}


### PR DESCRIPTION
## Summary
- Fixes #27494 — comparing two `?Struct` values with `==` or `!=` generated broken C where one operand was unwrapped while the other stayed as an option type
- The `.struct` case in `infix_expr_eq_op` now handles option types explicitly: checks states first (both none → equal), then uses `_struct_eq` on the unwrapped `.data` for deep structural comparison
- Works correctly with structs containing strings, arrays, and other reference types (uses `_struct_eq` instead of `memcmp`)

## Test plan
- [x] Added `vlib/v/tests/option_struct_eq_test.v` covering `==`, `!=`, none comparisons, and structs with string fields
- [x] `./v self` succeeds
- [x] All `vlib/v/gen/c/` tests pass (15/15)