### PR TITLE
cgen: fix `#line` directive glued to expression in array literal branches

### DIFF
--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -90,6 +90,9 @@ fn (mut g Gen) prepare_array_init_exprs(exprs []ast.Expr, expr_types []ast.Type,
 		g.write(' ')
 	} else {
 		g.write(stmt_str)
+		if g.pref.is_vlines && stmt_str.contains('#line') {
+			g.writeln('')
+		}
 	}
 	return prepared
 }

--- a/vlib/v/gen/c/ctempvars.v
+++ b/vlib/v/gen/c/ctempvars.v
@@ -30,6 +30,9 @@ fn (mut g Gen) expr_to_ctemp_before_stmt(expr ast.Expr, expr_type ast.Type) ast.
 	mut x := g.new_ctemp_var(expr, expr_type)
 	g.gen_ctemp_var(mut x)
 	g.write(stmt_str)
+	if g.pref.is_vlines && stmt_str.contains('#line') {
+		g.writeln('')
+	}
 	return x
 }
 

--- a/vlib/v/tests/match_expr_array_literal_with_g_test.v
+++ b/vlib/v/tests/match_expr_array_literal_with_g_test.v
@@ -1,0 +1,37 @@
+import os
+
+const vexe = @VEXE
+
+fn test_match_expr_array_literal_compiles_with_g() {
+	test_dir := os.join_path(os.vtmp_dir(), 'match_expr_array_g_test_${os.getpid()}')
+	os.mkdir_all(test_dir)!
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	source := os.join_path(test_dir, 'test.v')
+	out_c := os.join_path(test_dir, 'test.c')
+	os.write_file(source, "import os
+
+fn pick() []string {
+	home := os.home_dir()
+	return match os.user_os() {
+		'windows' {
+			[os.join_path(os.getenv('LOCALAPPDATA'), 'a'), os.join_path(home, 'b')]
+		}
+		else {
+			[]string{}
+		}
+	}
+}
+
+fn main() {
+	println(pick())
+}
+")!
+	res :=
+		os.execute('${os.quoted_path(vexe)} -g -o ${os.quoted_path(out_c)} -b c ${os.quoted_path(source)}')
+	assert res.exit_code == 0, res.output
+	generated := os.read_file(out_c)!
+	// Ensure no #line directive is glued to the following expression (missing newline).
+	assert !generated.contains('"builtin__new_array'), 'found #line directive glued to expression'
+}


### PR DESCRIPTION
## Summary
- When `-g` is used with match/if-expression branches containing array literals with call elements, `prepare_array_init_exprs` and `expr_to_ctemp_before_stmt` cut the current statement text (including any `#line` directive) via `go_before_last_stmt().trim_space()`, then re-emit it. The `trim_space()` strips the trailing newline from the `#line` directive, gluing the next expression to it. The C preprocessor then treats the expression as trailing tokens of `#line`, causing `expected expression` errors.
- Fix: after writing back the trimmed statement text, emit a newline when `is_vlines` is active and the text contains a `#line` directive.
- Adds a regression test that generates C with `-g` and asserts no `#line` directives are glued to expressions.

Closes #27495