### PR TITLE
cgen: fix equality comparision of optional structs

### DIFF
--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -443,11 +443,16 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 					if node.op == .ne {
 						g.write('!')
 					}
+					mut prev_left_is_opt := g.left_is_opt
+					if left.typ.has_flag(.option) {
+						g.left_is_opt = true
+					}
 					g.write('${ptr_typ}_struct_eq(')
 					g.expr(node.left)
 					g.write(', ')
 					g.expr(node.right)
 					g.write(')')
+					g.left_is_opt = prev_left_is_opt
 				}
 			}
 			.sum_type {

--- a/vlib/v/tests/options/option_struct_equality_test.v
+++ b/vlib/v/tests/options/option_struct_equality_test.v
@@ -1,0 +1,13 @@
+struct Id {
+	v int
+}
+
+fn cmp(a ?Id, b ?Id) bool {
+	return a != b
+}
+
+fn test_cmp() {
+	assert cmp(Id{ v: 1 }, Id{
+		v: 2
+	})
+}


### PR DESCRIPTION
Fixes #27494