### PR TITLE
cgen: fix `as`/`is` on an option-type sumtype variant using the wrong union member (#27478)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -13736,7 +13736,11 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		matching_variants := g.matching_sumtype_variant_types(expr_type_without_option,
 			unwrapped_node_typ)
 		index_exprs := g.type_idx_exprs_for_types(matching_variants)
-		payload_sym := g.table.sym(g.as_cast_payload_type(unwrapped_node_typ, matching_variants))
+		payload_type := g.as_cast_payload_type(unwrapped_node_typ, matching_variants)
+		payload_sym := g.table.sym(payload_type)
+		// Use the variant member name, which for an option-type variant
+		// (e.g. `type Foo = ?Bar | Baz`) is `_option_<cname>`, not `_<cname>`.
+		payload_member := g.get_sumtype_variant_name(payload_type, payload_sym)
 		sidx := g.type_sidx(unwrapped_node_typ)
 		if as_cast_operand_needs_tmp_eval(node.expr) {
 			tmp_var := g.expr_to_ctemp_before_stmt(node.expr, node.expr_type).name
@@ -13745,7 +13749,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			} else {
 				tmp_var
 			}
-			obj_expr := '(${expr_str})${dot}_${payload_sym.cname}'
+			obj_expr := '(${expr_str})${dot}_${payload_member}'
 			tag_expr := '(${expr_str})${dot}_typ'
 			g.write_as_cast_call_start(styp, sym)
 			g.write_as_cast_call(obj_expr, tag_expr, sidx, index_exprs)
@@ -13755,7 +13759,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			} else {
 				g.expr_string(node.expr)
 			}
-			obj_expr := '(${expr_str})${dot}_${payload_sym.cname}'
+			obj_expr := '(${expr_str})${dot}_${payload_member}'
 			tag_expr := '(${expr_str})${dot}_typ'
 			g.write_as_cast_call_start(styp, sym)
 			g.write_as_cast_call(obj_expr, tag_expr, sidx, index_exprs)

--- a/vlib/v/tests/options/option_sumtype_option_variant_test.v
+++ b/vlib/v/tests/options/option_sumtype_option_variant_test.v
@@ -10,3 +10,32 @@ fn test_main() {
 	d := ?Any('baz')
 	assert d?.str() == "Any('baz')"
 }
+
+struct Bar {
+	i int
+}
+
+struct Baz {}
+
+type Foo = ?Bar | Baz
+
+// `as`/`is` on an option-type sumtype variant must reference the correct
+// union member (`_option_...`), not the plain one. See vlang/v#27478.
+fn test_as_is_option_variant() {
+	f := Foo(?Bar(Bar{
+		i: 5
+	}))
+	assert f is ?Bar
+	got := f as ?Bar
+	assert got != none
+	assert got?.i == 5
+
+	n := Foo(?Bar(none))
+	assert n is ?Bar
+	got2 := n as ?Bar
+	assert got2 == none
+
+	b := Foo(Baz{})
+	assert b is Baz
+	assert b !is ?Bar
+}


### PR DESCRIPTION
## Fixes #27478

When a sumtype has an **option-type variant** (e.g. `type Foo = ?Bar | Baz`), an `as` cast to that option variant generated C that referenced the wrong union member.

### Reproducer

```v
struct Bar {
	i int
}

struct Baz {}

type Foo = ?Bar | Baz

fn main() {
	f := Foo(?Bar(Bar{i: 5}))
	got := f as ?Bar
	println(got != none)
}
```

### Before

```
error: no member named '_main__Bar' in 'struct main__Foo'; did you mean '_main__Baz'?
  _option_main__Bar got = *(_option_main__Bar*)builtin____as_cast((f)._main__Bar, (f)._typ, ...);
```

The union member generated for the `?Bar` variant is `_option_main__Bar`, but `as_cast` emitted `(f)._main__Bar` (the plain variant cname).

### Fix

In `Gen.as_cast`, build the object expression's member name with `get_sumtype_variant_name`, which already yields the `_option_<cname>` member name for option-type variants, instead of using the bare `payload_sym.cname`. The `is` check was already correct (it only compares the `_typ` tag).

### Test

Added a regression test to `vlib/v/tests/options/option_sumtype_option_variant_test.v` covering `is`, `as`, the `none`-payload case, and the non-option variant. Ran `vlib/v/tests/options/` (214 passed) and `vlib/v/tests/sumtypes/` (48 passed).