### PR TITLE
tools: fix `v watch run` not reloading on source changes (fix #27463)

### DIFF
--- a/cmd/tools/vwatch.v
+++ b/cmd/tools/vwatch.v
@@ -218,7 +218,7 @@ fn (mut context Context) get_stats_for_affected_vfiles() []VFileStat {
 		mut files := os.ls(path) or { []string{} }
 		next_file: for pf in files {
 			pf_path := os.join_path_single(path, pf)
-			if context.only_watch.len > 0 {
+			if context.only_watch.len > 0 && context.only_watch[0] != '' {
 				// in the whitelist mode, first only allow files, which match at least one of the patterns in context.only_watch:
 				mut matched_pattern_idx := -1
 				for ow_pattern_idx, ow_pattern in context.only_watch {

--- a/cmd/tools/vwatch_test.v
+++ b/cmd/tools/vwatch_test.v
@@ -47,3 +47,57 @@ fn test_watch_keeps_backend_flag_intact() {
 	assert !output.contains('-baend'), output
 	assert !output.contains('Unknown argument `-baend`'), output
 }
+
+// Regression test for https://github.com/vlang/v/issues/27463 :
+// `v watch run main.v` should recompile and rerun the program, when its source changes.
+fn test_watch_run_reloads_on_source_change() {
+	source_path := os.join_path(tsource_dir, 'reload.v')
+	marker_path := os.join_path(toutput_dir, 'reload_marker.txt')
+	os.rm(marker_path) or {}
+	write_versioned_source(source_path, 'V1')!
+
+	mut process := os.new_process(vexe)
+	process.set_work_folder(vroot)
+	process.set_redirect_stdio()
+	process.use_pgroup = true
+	// the marker_path argument is passed through to the compiled and run program (see write_versioned_source):
+	process.set_args(['watch', 'run', source_path, marker_path])
+	process.run()
+
+	// wait for the first compile+run to write the marker file:
+	first_run_done := wait_for_marker(marker_path, 'V1')
+
+	// os.file_last_mod_unix has a 1 second resolution, so make sure the edit lands in a later second,
+	// otherwise the change detection loop can not notice that the source file was modified at all:
+	time.sleep(1500 * time.millisecond)
+	write_versioned_source(source_path, 'V2')!
+
+	// the watcher should detect the change, recompile, and rerun, updating the marker to V2:
+	reloaded := wait_for_marker(marker_path, 'V2')
+
+	if process.is_alive() {
+		process.signal_pgkill()
+	}
+	process.wait()
+	output := process.stdout_slurp() + process.stderr_slurp()
+	process.close()
+
+	assert first_run_done, 'the watched program was never compiled and run\n${output}'
+	assert reloaded, 'the watcher did not recompile and rerun after the source file changed\n${output}'
+}
+
+fn write_versioned_source(source_path string, version string) ! {
+	os.write_file(source_path,
+		"import os\nfn main() {\n\tos.write_file(os.args[1], '${version}') or { panic(err) }\n}\n")!
+}
+
+fn wait_for_marker(marker_path string, expected string) bool {
+	for _ in 0 .. 300 {
+		content := os.read_file(marker_path) or { '' }
+		if content == expected {
+			return true
+		}
+		time.sleep(100 * time.millisecond)
+	}
+	return false
+}


### PR DESCRIPTION
## Fixes #27463

`v watch run main.v` stopped recompiling/restarting when the source file changed — it would just sit idle until Ctrl-C.

### Root cause

The `parse_watch_options` refactor (commit `0c25c3372`) changed the default value of `only_watch`:

- Before: `context.only_watch = ''.split_any(',')` → `[]` (empty array), so the whitelist filter was skipped and **all** source files were watched.
- After: `ParsedWatchOptions.only_watch []string = ['']` → `['']` (one empty string).

In the file scanner, the guard is:

```v
if context.only_watch.len > 0 {
    // whitelist mode: only allow files matching at least one pattern
    ...
}
```

With the new `['']` default, `len > 0` is true, so the scanner enters whitelist mode with a single empty pattern. Since `'/path/main.v'.match_glob('')` is `false`, **no source file ever matches**, every file is skipped, and only the `v` binary itself ends up monitored. Hence edits to `main.v` are never detected.

### Fix

Guard the whitelist filter so the `['']` sentinel default means "watch everything", mirroring how `add_files` already handles the same sentinel (`context.add_files[0] != ''`):

```v
if context.only_watch.len > 0 && context.only_watch[0] != '' {
```

A real `--only-watch=*.v,...` value (and the implied veb suffixes) still works, because its first element is non-empty.

### Test

Added a regression test (`test_watch_run_reloads_on_source_change`) that starts `v watch run`, waits for the first run, edits the source, and asserts the program is recompiled and rerun. Verified it **fails** without the fix and **passes** with it.