### PR TITLE
cmd/tools/vdoc: fix `v vlib-docs` panic on modules without valid files for the platform (fix #27464)

### DIFF
--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -75,7 +75,7 @@ fn (vd &VDoc) gen_json(d doc.Doc) string {
 fn (mut vd VDoc) gen_plaintext(d doc.Doc) string {
 	cfg := vd.cfg
 	mut pw := strings.new_builder(200)
-	if cfg.is_color {
+	if cfg.is_color && d.head.content.contains(' ') {
 		content_arr := d.head.content.split(' ')
 		pw.writeln('${term.bright_blue(content_arr[0])} ${term.green(content_arr[1])}')
 	} else {
@@ -369,6 +369,13 @@ fn (mut vd VDoc) generate_docs_from_file() {
 				vd.emit_generate_err(err)
 				exit(1)
 			}
+		}
+		if dcs.head.name == '' && dcs.contents.len == 0 {
+			// The folder had no valid V files for the target platform (e.g. the
+			// `ios`/`macos` modules when generating docs on Linux), so `generate`
+			// skipped it. There is nothing to document, so do not add an empty
+			// `Doc` that would later be rendered (and crash on its empty head).
+			continue
 		}
 		if cfg.is_multi || (!cfg.is_multi && cfg.include_readme) {
 			readme := vd.get_readme(dirpath)

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -404,22 +404,25 @@ fn (mut vd VDoc) generate_docs_from_file() {
 		exit(1)
 	}
 	vd.vprintln('Rendering docs...')
+	if vd.docs.len == 0 {
+		// Every discovered module was skipped (e.g. a tree containing only files
+		// that are filtered out for the target platform), so there is nothing to
+		// render. Report it and fail, regardless of the output destination, instead
+		// of silently creating/cleaning an empty output directory and exiting 0.
+		if dirs.len == 0 {
+			eprintln('vdoc: No documentation found')
+		} else {
+			eprintln('vdoc: No documentation found for ${dirs[0]}')
+		}
+		exit(1)
+	}
 	if out.path == '' || out.path == 'stdout' || out.path == '-' {
 		if out.typ == .html {
 			vd.render_static_html(out)
 		}
 		outputs := vd.render(out)
-		if outputs.len == 0 {
-			if dirs.len == 0 {
-				eprintln('vdoc: No documentation found')
-			} else {
-				eprintln('vdoc: No documentation found for ${dirs[0]}')
-			}
-			exit(1)
-		} else {
-			first := outputs.keys()[0]
-			println(outputs[first])
-		}
+		first := outputs.keys()[0]
+		println(outputs[first])
 	} else {
 		if !os.exists(out.path) {
 			os.mkdir_all(out.path) or { panic(err) }

--- a/cmd/tools/vdoc/vdoc_test.v
+++ b/cmd/tools/vdoc/vdoc_test.v
@@ -317,3 +317,42 @@ fn test_markdown_renderer_preserves_wrapped_readme_markdown() ! {
 	assert out.contains('the most simple token')
 	assert out.contains('is not <code>abc</code> OR <code>ebc</code>')
 }
+
+fn test_doc_multi_skips_modules_without_valid_files_for_platform() {
+	// https://github.com/vlang/v/issues/27464
+	// A module whose only V files are filtered out for the target platform (e.g.
+	// the `ios`/`macos` modules when generating docs on Linux) is skipped during
+	// generation. It must not produce an empty `Doc` that later crashes rendering.
+	base_dir := 'skip_platform_modules'
+	good_dir := os.join_path(base_dir, 'good')
+	skipped_dir := os.join_path(base_dir, 'winonly')
+	os.mkdir_all(good_dir)!
+	os.mkdir_all(skipped_dir)!
+	os.write_file(os.join_path(good_dir, 'good.v'), "module good
+
+// hello returns a greeting.
+pub fn hello() string {
+	return 'hi'
+}
+")!
+	// This file only compiles on Windows, so on every other platform the `winonly`
+	// module has no valid V files and gets skipped. The test never runs on Windows
+	// (see the `vtest build: !windows` directive at the top of the file).
+	os.write_file(os.join_path(skipped_dir, 'winonly_windows.c.v'), 'module winonly
+
+// only_win does nothing useful here.
+pub fn only_win() int {
+	return 1
+}
+')!
+	// `-color` exercises the original crash path in `gen_plaintext`.
+	res := os.execute_opt('${vexe_} doc -no-timestamp -m -color -f text -o - ${os.quoted_path(
+		'./' + base_dir)}') or { panic(err) }
+	// The crash showed up as a non-zero exit code (V panic), so this is the key check.
+	assert res.exit_code == 0
+	assert res.output.contains('hello')
+	// The skipped module must not be documented (its public symbol must be absent).
+	// Note: `os.execute_opt` merges stderr, where the `Skipping folder: ...winonly`
+	// notice is printed, so we check for the rendered symbol rather than the name.
+	assert !res.output.contains('only_win')
+}

--- a/cmd/tools/vdoc/vdoc_test.v
+++ b/cmd/tools/vdoc/vdoc_test.v
@@ -356,3 +356,28 @@ pub fn only_win() int {
 	// notice is printed, so we check for the rendered symbol rather than the name.
 	assert !res.output.contains('only_win')
 }
+
+fn test_doc_multi_all_modules_skipped_fails_for_file_output() {
+	// https://github.com/vlang/v/issues/27464 (review follow-up)
+	// When every discovered module is filtered out for the target platform, there
+	// is nothing to document. Writing to a real output path must fail with the same
+	// `No documentation found` error as the stdout path, instead of silently
+	// creating/cleaning an empty output directory and exiting 0.
+	base_dir := 'all_skipped_modules'
+	skipped_dir := os.join_path(base_dir, 'winonly')
+	out_dir := os.join_path(base_dir, 'out')
+	os.mkdir_all(skipped_dir)!
+	os.write_file(os.join_path(skipped_dir, 'winonly_windows.c.v'), 'module winonly
+
+pub fn only_win() int {
+	return 1
+}
+')!
+	// `os.execute` (not `execute_opt`) so the expected non-zero exit is not an error.
+	res := os.execute('${vexe_} doc -no-timestamp -m -f html -o ${os.quoted_path('./' + out_dir)} ${os.quoted_path(
+		'./' + base_dir)}')
+	assert res.exit_code != 0
+	assert res.output.contains('No documentation found')
+	// The output directory must not have been created.
+	assert !os.exists(out_dir)
+}


### PR DESCRIPTION
## Fix #27464 — `v vlib-docs` panics with `array.get: index out of range`

### Problem
Running `v vlib-docs` (which is `v doc vlib`) panics on platforms where some
vlib modules have no valid V files for the host OS:

```
vdoc: No valid V files were found. Skipping folder: /home/user/v/vlib/ios.
vdoc: No valid V files were found. Skipping folder: /home/user/v/vlib/macos.
V panic: array.get: index out of range (i,a.len):1, 1
```

When a folder's only V files are filtered out for the target platform (e.g. the
`ios`/`macos` modules on Linux), `document.Doc.generate()` skips it and returns
an **empty** `Doc` — empty `head`, empty `contents`. That empty doc was still
added to the render list. Rendering it in `gen_plaintext()` then did
`d.head.content.split(' ')[1]` on an empty head content (`''.split(' ')` → `['']`,
length 1), panicking with `array.get: index out of range (i,a.len):1, 1`.

### Fix
- In `generate_docs_from_file`, skip docs for modules that were emptied out by
  the platform filter (empty head name + no contents) so they are never rendered
  (they have nothing to document anyway). This also avoids emitting junk empty
  HTML/markdown pages for such modules.
- Defensively guard the color branch in `gen_plaintext` so it no longer assumes
  `head.content` always contains a space.

### Reproduction (before the fix)
A module whose only `.v` file is platform-restricted (e.g. `*_windows.c.v`) is
skipped on every other OS, triggering the panic. This is covered by the new test
`test_doc_multi_skips_modules_without_valid_files_for_platform`.

### Tests
- New regression test added in `cmd/tools/vdoc/vdoc_test.v`; reproduces the
  original panic without the fix and passes with it.
- `v test cmd/tools/vdoc/` — the new and existing vdoc tests pass. (The pre-existing
  `vdoc_file_test.v` `comments` case differs identically on master and is unrelated
  to this change.)
