### PR TITLE
fmt: don't prefix current-module types inside `fn` typed struct fields (#27475)

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1642,6 +1642,20 @@ pub fn (t &Table) delete_cached_type_to_str(typ Type, import_aliases_len int) {
 	}
 }
 
+// invalidate_type_to_str_cache clears every cached `type_to_str` result.
+// vfmt calls this whenever it enters a new module (see Fmt.set_current_module_name),
+// because strings that were memoized before the current module was known (e.g. while
+// parsing, when `cmod_prefix` was still empty) keep stale `mod.` prefixes on types
+// that actually belong to the current module. Those stale entries are otherwise reused
+// when the signature of a `fn` typed struct field is rebuilt, producing output like
+// `fn (s main.Struct) bool` instead of `fn (s Struct) bool` (issue #27475).
+pub fn (t &Table) invalidate_type_to_str_cache() {
+	mut mt := unsafe { &Table(t) }
+	lock mt.cached_type_to_str {
+		mt.cached_type_to_str.clear()
+	}
+}
+
 // import_aliases is a map of imported symbol aliases 'module.Type' => 'Type'
 pub fn (t &Table) type_to_str_using_aliases(typ Type, import_aliases map[string]string) string {
 	cache_key := (u64(import_aliases.len) << 32) | u64(typ)

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -268,6 +268,11 @@ fn (mut f Fmt) write_generic_types(gtypes []ast.Type) {
 pub fn (mut f Fmt) set_current_module_name(cmodname string) {
 	f.cur_mod = cmodname
 	f.table.cmod_prefix = cmodname + '.'
+	// Drop type_to_str strings that were memoized before the module context was
+	// known (during parsing `cmod_prefix` is still empty), so that types of the
+	// current module are not left with a stale `mod.` prefix when a `fn` typed
+	// field signature is rebuilt later on (issue #27475).
+	f.table.invalidate_type_to_str_cache()
 }
 
 fn (f &Fmt) get_modname_prefix(mname string) (string, string) {

--- a/vlib/v/fmt/tests/struct_fn_field_current_module_type_keep.vv
+++ b/vlib/v/fmt/tests/struct_fn_field_current_module_type_keep.vv
@@ -1,0 +1,14 @@
+struct Struct1 {}
+
+struct Struct2 {}
+
+// Regression test for https://github.com/vlang/v/issues/27475 :
+// types of the current module must not gain a `main.` prefix inside the
+// signature of a `fn` typed struct field (the bug only showed up when the
+// file had no imports, i.e. an empty alias map).
+struct Holder {
+	field1 fn (s1 Struct1, s2 Struct2) bool
+	field2 Struct1
+	field3 fn (s Struct1) Struct2
+	field4 fn (int, Struct1) (Struct2, bool)
+}


### PR DESCRIPTION
## Fix #27475

`v fmt` was prefixing same-module types with the module name inside the signature of a `fn` typed struct field:

```v
struct Holder {
	field1 fn (s1 Struct1, s2 Struct2) bool // <- became fn (s1 main.Struct1, s2 main.Struct2) bool
	field2 Struct1                          // <- correct, stayed Struct1
}
```

### Root cause

`type_to_str` results are memoized in a cache keyed only by the type index and the number of import aliases. While **parsing**, the signature of a `fn` typed struct field is rendered (to build the type's name) before the module context is known, so `cmod_prefix` is still empty and the parameter types are cached with a full `mod.` prefix.

When the file has **no imports**, the alias map vfmt passes is also empty, so the cache key collides with the parse-time one and vfmt reuses the stale, prefixed strings — producing `fn (s main.Struct) bool` instead of `fn (s Struct) bool`. Plain struct fields were unaffected because their leading prefix is stripped by `no_cur_mod`, which cannot reach prefixes nested inside `fn (...)`. This is also why the bug disappeared as soon as the file had any `import` (non-empty alias map → different cache key).

### Fix

Invalidate the `type_to_str` cache when vfmt enters a module (`Fmt.set_current_module_name`), so signatures are rebuilt with the correct module context. Imported types still keep their prefix.

### Test

Added `vlib/v/fmt/tests/struct_fn_field_current_module_type_keep.vv`, which fails before the fix and passes after. `fmt_keep_test.v` and `fmt_test.v` both pass.