### PR TITLE
wasm: emit a clean error for scalar `?T`/`!T` returns instead of an internal ICE

### DIFF
--- a/vlib/v/gen/wasm/gen.v
+++ b/vlib/v/gen/wasm/gen.v
@@ -243,6 +243,17 @@ pub fn (mut g Gen) fn_decl(node ast.FnDecl) {
 		}
 		else {
 			if rt.idx() != ast.void_type_idx {
+				// A scalar `?T`/`!T` return reaches here (it is not a MultiReturn),
+				// so the option/result guards below — which only run inside the
+				// MultiReturn arm or after the match — are dead for it. Guard before
+				// `get_wasm_type`, which would otherwise abort with an internal
+				// "unreachable type" ICE on the option/result-wrapped type.
+				if rt.has_flag(.option) {
+					g.v_error('option types are not implemented', node.return_type_pos)
+				}
+				if rt.has_flag(.result) {
+					g.v_error('result types are not implemented', node.return_type_pos)
+				}
 				wtyp := g.get_wasm_type(rt)
 				if g.is_param_type(rt) {
 					paramdbg << g.dbg_type_name('__rval(0)', rt)

--- a/vlib/v/gen/wasm/tests/scalar_option_result_error_test.v
+++ b/vlib/v/gen/wasm/tests/scalar_option_result_error_test.v
@@ -1,0 +1,32 @@
+import os
+
+// A scalar `?T`/`!T` return type used to abort the wasm backend with an internal
+// `get_wasm_type: unreachable type ... UnknownTypeInfo` ICE, because the
+// option/result guards only ran inside the MultiReturn arm / after the type was
+// already lowered. The backend must instead emit the intended, located
+// "not implemented" user error.
+fn compile_wasm(src string, name string) os.Result {
+	vexe := os.quoted_path(@VEXE)
+	wrkdir := os.join_path(os.vtmp_dir(), 'wasm_scalar_optres_tests')
+	os.mkdir_all(wrkdir) or { panic(err) }
+	source_path := os.join_path(wrkdir, '${name}.v')
+	output_path := os.join_path(wrkdir, '${name}.wasm')
+	os.write_file(source_path, src) or { panic(err) }
+	return os.execute('${vexe} -b wasm -o ${os.quoted_path(output_path)} ${os.quoted_path(source_path)}')
+}
+
+fn test_scalar_option_return_errors_cleanly() {
+	res := compile_wasm('fn f() ?int {\n\treturn 3\n}\n\nfn main() {\n\tx := f() or { 0 }\n\t_ = x\n}\n',
+		'scalar_option')
+	assert res.exit_code != 0, 'expected a compile error, got: ${res.output}'
+	assert res.output.contains('option types are not implemented'), res.output
+	assert !res.output.contains('get_wasm_type: unreachable'), 'leaked the internal ICE: ${res.output}'
+}
+
+fn test_scalar_result_return_errors_cleanly() {
+	res := compile_wasm('fn f() !int {\n\treturn 3\n}\n\nfn main() {\n\tx := f() or { 0 }\n\t_ = x\n}\n',
+		'scalar_result')
+	assert res.exit_code != 0, 'expected a compile error, got: ${res.output}'
+	assert res.output.contains('result types are not implemented'), res.output
+	assert !res.output.contains('get_wasm_type: unreachable'), 'leaked the internal ICE: ${res.output}'
+}


### PR DESCRIPTION
## Description

On the native wasm backend, a function returning a **scalar** option/result (e.g. `fn f() ?int`) aborts the compiler with an **internal ICE** instead of the intended user-facing error:

```
$ v -b wasm -o /tmp/x.wasm opt.v
wasm error: get_wasm_type: unreachable type 'int' ast.TypeInfo(ast.UnknownTypeInfo{})
```

### Root cause

In `fn_decl` (`vlib/v/gen/wasm/gen.v`), the return-type `match rts.info` handles option/result only:
- inside the `MultiReturn` arm (`option types are not implemented`),
- after the match (`result types are not implemented`),
- and for the void-option case (`returning a void option is forbidden`).

A scalar `?T`/`!T` return is **not** a `MultiReturn`, so it falls into the `else` arm and calls `get_wasm_type(rt)` on the option/result-wrapped type **before** any guard runs — and that aborts with the `unreachable type ... UnknownTypeInfo` ICE. The existing guards were effectively dead code for this case.

### Fix

Guard option/result in the non-void scalar arm, before lowering the type. `g.v_error` already exits, so this short-circuits before `get_wasm_type`.

### After

```
$ v -b wasm -o /tmp/x.wasm opt.v
opt.v:1:8: error: option types are not implemented
    1 | fn f() ?int {
      |        ~~~~
```

- `fn f() !int` → `result types are not implemented` (located).
- `fn f() ?` (void option) → still `returning a void option is forbidden` (unchanged).
- Normal returns and the rest of the wasm test suite are unaffected.

This is in the spirit of #27451 (replace internal `get_wasm_type` ICEs with clean errors), covering the scalar option/result cases specifically.

## Tests

Adds `vlib/v/gen/wasm/tests/scalar_option_result_error_test.v` (asserts the located error is produced and the internal ICE string does not leak). Full `vlib/v/gen/wasm/tests/` suite passes; `v fmt` clean.

## Checklist
- [x] tests pass locally (`v test vlib/v/gen/wasm/tests/`)
- [x] `v fmt -w` applied