### PR TITLE
ci: deploy docs.vlang.io from GitHub Actions (fix #27038)

### DIFF
--- a/.github/workflows/docs_site_ci.yml
+++ b/.github/workflows/docs_site_ci.yml
@@ -61,9 +61,21 @@ jobs:
           rm -rf docs_site
           ./v retry -- git clone --depth=1 --branch main "https://vlang-bot:${{ secrets.VLANG_BOT_SECRET }}@github.com/vlang/docs.git" docs_site
 
-          # Copy the freshly generated pages on top of the published site. Note:
-          # no --delete, so site-only files (CNAME, .nojekyll, README.md) are kept.
-          rsync -a docs_generator/output/ docs_site/
+          # Sync the freshly generated pages onto the published site. --delete so
+          # that pages/assets removed or renamed in doc/docs.md do not linger as
+          # stale files, but protect the site-only files at the repo root that the
+          # generator does not produce (git metadata, CNAME, .nojekyll, README.md,
+          # favicon.ico and the legacy build.vsh).
+          rsync -a --delete \
+            --exclude '/.git' \
+            --exclude '/.gitattributes' \
+            --exclude '/.gitignore' \
+            --exclude '/.nojekyll' \
+            --exclude '/CNAME' \
+            --exclude '/README.md' \
+            --exclude '/favicon.ico' \
+            --exclude '/build.vsh' \
+            docs_generator/output/ docs_site/
 
           git -C docs_site add -A
           # `git diff --cached --quiet` exits 0 with nothing staged, 1 when there

--- a/.github/workflows/docs_site_ci.yml
+++ b/.github/workflows/docs_site_ci.yml
@@ -1,0 +1,83 @@
+name: docs.vlang.io deploy
+
+### Regenerate https://docs.vlang.io/ (the GitHub Pages site served from the
+### `main` branch of https://github.com/vlang/docs ), on every change to
+### doc/docs.md that lands on master.
+###
+### Historically docs.vlang.io was updated by the FreeBSD machine that also runs
+### cmd/tools/fast/fast.v . When that single machine stops, the site silently
+### goes stale (see issue #27038, where it was stuck at the 2026-02-09 snapshot).
+### Generating and deploying from CI removes that single point of failure, the
+### same way modules.vlang.io is deployed from module_docs_ci.yml .
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - 'doc/docs.md'
+      - '**/docs_site_ci.yml'
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: docs_site-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
+
+jobs:
+  deploy-docs-site:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/cache-apt-packages-action
+      - name: Build V
+        run: make -j4 && ./v symlink
+      - name: Install dependencies (the docs generator uses the markdown module)
+        run: ./v retry -- ./v install markdown
+
+      - name: Generate the HTML pages from doc/docs.md
+        run: |
+          set -e
+          # The generator (the `generator` branch of vlang/docs) fetches
+          # doc/docs.md from the master branch of vlang/v, transforms it into one
+          # HTML page per section, and writes them into its own output/ folder.
+          rm -rf docs_generator
+          ./v retry -- git clone --depth=1 --branch generator https://github.com/vlang/docs docs_generator
+          ./v run docs_generator/.
+          [ -f docs_generator/output/introduction.html ]
+
+      - name: Deploy to vlang/docs (main branch -> docs.vlang.io)
+        if: github.event_name != 'pull_request' && github.repository == 'vlang/v' && github.ref == 'refs/heads/master'
+        run: |
+          set -e
+          git config --global user.email "vlang-bot@users.noreply.github.com"
+          git config --global user.name "vlang-bot"
+
+          COMMIT_HASH="$(git rev-parse --short HEAD)"
+          COMMIT_MSG="$(git log -1 --pretty='%s' HEAD)"
+
+          rm -rf docs_site
+          ./v retry -- git clone --depth=1 --branch main "https://vlang-bot:${{ secrets.VLANG_BOT_SECRET }}@github.com/vlang/docs.git" docs_site
+
+          # Copy the freshly generated pages on top of the published site. Note:
+          # no --delete, so site-only files (CNAME, .nojekyll, README.md) are kept.
+          rsync -a docs_generator/output/ docs_site/
+
+          git -C docs_site add -A
+          # `git diff --cached --quiet` exits 0 with nothing staged, 1 when there
+          # are staged changes, and >1 on a real error - so only 1 means "deploy".
+          set +e
+          git -C docs_site diff --cached --quiet
+          diff_rc=$?
+          set -e
+          if [ "$diff_rc" -eq 0 ]; then
+            echo "docs.vlang.io is already up to date for ${COMMIT_HASH}; nothing to deploy."
+            exit 0
+          elif [ "$diff_rc" -ne 1 ]; then
+            echo "::error::git diff --cached failed with exit code ${diff_rc}" >&2
+            exit "$diff_rc"
+          fi
+          git -C docs_site commit -m "update docs for commit ${COMMIT_HASH} - ${COMMIT_MSG}"
+          ./v retry -- git -C docs_site push origin main

--- a/.github/workflows/docs_site_ci.yml
+++ b/.github/workflows/docs_site_ci.yml
@@ -61,35 +61,54 @@ jobs:
           rm -rf docs_site
           ./v retry -- git clone --depth=1 --branch main "https://vlang-bot:${{ secrets.VLANG_BOT_SECRET }}@github.com/vlang/docs.git" docs_site
 
-          # Sync the freshly generated pages onto the published site. --delete so
-          # that pages/assets removed or renamed in doc/docs.md do not linger as
-          # stale files, but protect the site-only files at the repo root that the
-          # generator does not produce (git metadata, CNAME, .nojekyll, README.md,
-          # favicon.ico and the legacy build.vsh).
-          rsync -a --delete \
-            --exclude '/.git' \
-            --exclude '/.gitattributes' \
-            --exclude '/.gitignore' \
-            --exclude '/.nojekyll' \
-            --exclude '/CNAME' \
-            --exclude '/README.md' \
-            --exclude '/favicon.ico' \
-            --exclude '/build.vsh' \
-            docs_generator/output/ docs_site/
+          # The legacy FreeBSD uploader (cmd/tools/fast/fast.v) may still be
+          # pushing to vlang/docs main too, so our push can be rejected as
+          # non-fast-forward. `v retry` would only rerun the same push, never
+          # fetching the new tip, so retry here by re-syncing onto the latest main
+          # and pushing again. The sync is idempotent, so re-applying it on top of
+          # whatever landed meanwhile is safe.
+          deploy_attempts=5
+          for attempt in $(seq 1 "${deploy_attempts}"); do
+            git -C docs_site fetch --depth=1 origin main
+            git -C docs_site reset --hard FETCH_HEAD
 
-          git -C docs_site add -A
-          # `git diff --cached --quiet` exits 0 with nothing staged, 1 when there
-          # are staged changes, and >1 on a real error - so only 1 means "deploy".
-          set +e
-          git -C docs_site diff --cached --quiet
-          diff_rc=$?
-          set -e
-          if [ "$diff_rc" -eq 0 ]; then
-            echo "docs.vlang.io is already up to date for ${COMMIT_HASH}; nothing to deploy."
-            exit 0
-          elif [ "$diff_rc" -ne 1 ]; then
-            echo "::error::git diff --cached failed with exit code ${diff_rc}" >&2
-            exit "$diff_rc"
-          fi
-          git -C docs_site commit -m "update docs for commit ${COMMIT_HASH} - ${COMMIT_MSG}"
-          ./v retry -- git -C docs_site push origin main
+            # Sync the freshly generated pages onto the published site. --delete so
+            # that pages/assets removed or renamed in doc/docs.md do not linger as
+            # stale files, but protect the site-only files at the repo root that the
+            # generator does not produce (git metadata, CNAME, .nojekyll, README.md,
+            # favicon.ico and the legacy build.vsh).
+            rsync -a --delete \
+              --exclude '/.git' \
+              --exclude '/.gitattributes' \
+              --exclude '/.gitignore' \
+              --exclude '/.nojekyll' \
+              --exclude '/CNAME' \
+              --exclude '/README.md' \
+              --exclude '/favicon.ico' \
+              --exclude '/build.vsh' \
+              docs_generator/output/ docs_site/
+
+            git -C docs_site add -A
+            # `git diff --cached --quiet` exits 0 with nothing staged, 1 when there
+            # are staged changes, and >1 on a real error - so only 1 means "deploy".
+            set +e
+            git -C docs_site diff --cached --quiet
+            diff_rc=$?
+            set -e
+            if [ "${diff_rc}" -eq 0 ]; then
+              echo "docs.vlang.io is already up to date for ${COMMIT_HASH}; nothing to deploy."
+              exit 0
+            elif [ "${diff_rc}" -ne 1 ]; then
+              echo "::error::git diff --cached failed with exit code ${diff_rc}" >&2
+              exit "${diff_rc}"
+            fi
+            git -C docs_site commit -m "update docs for commit ${COMMIT_HASH} - ${COMMIT_MSG}"
+
+            if git -C docs_site push origin main; then
+              echo "docs.vlang.io updated for ${COMMIT_HASH} (attempt ${attempt})."
+              exit 0
+            fi
+            echo "push to vlang/docs main was rejected (attempt ${attempt}/${deploy_attempts}); refetching and retrying..."
+          done
+          echo "::error::could not push to vlang/docs main after ${deploy_attempts} attempts" >&2
+          exit 1


### PR DESCRIPTION
## Problem

docs.vlang.io is the GitHub Pages site served from the `main` branch of [vlang/docs](https://github.com/vlang/docs). That branch was only ever updated by the single FreeBSD machine that also runs `cmd/tools/fast/fast.v`. When that machine stops, the site silently goes stale — in #27038 it was stuck at the 2026-02-09 snapshot (its last `main` commit is `2026-02-09 17:20:26`, exactly the date in the issue). modules.vlang.io was unaffected because it is already deployed from GitHub Actions.

#27237 already made the legacy FreeBSD path stop hiding failures. This PR addresses the root cause: a single, unmonitored deploy machine.

## Fix

New workflow `docs_site_ci.yml`. On every push to master that touches `doc/docs.md` (or via manual dispatch) it:
- builds V and installs the `markdown` module,
- clones the `generator` branch of vlang/docs and runs it to turn `docs.md` into the per-section HTML pages,
- rsyncs the output onto a checkout of the vlang/docs `main` branch (no `--delete`, so `CNAME` / `.nojekyll` / `README.md` are preserved) and pushes it.

It reuses the existing `vlang-bot` / `VLANG_BOT_SECRET` credentials already used to push to vlang/vc and vlang/tccbin, and mirrors how modules.vlang.io is deployed from `module_docs_ci.yml`. This removes the single point of failure.

The `git diff --cached --quiet` "nothing changed" guard handles exit codes explicitly (0 = nothing to deploy, 1 = commit & push, >1 = real error → fail), so an index error can't be mistaken for "changes exist".

> Note: requires `vlang-bot` to have push access to vlang/docs (it already pushes to other vlang org repos). The legacy FreeBSD path in `fast.v` can keep running harmlessly; its commit is idempotent and the `git diff` guard means it pushes nothing when the site is already current.

## Test plan

- [x] `docs_site_ci.yml` validates as YAML and reuses the existing `cache-apt-packages-action`
- [x] Reproduced the generator pipeline locally end-to-end: `git clone --depth=1 --branch generator https://github.com/vlang/docs docs_generator && v run docs_generator/.` produces `docs_generator/output/introduction.html` (734 titles, 54 pages)