### PR TITLE
crypto: document bcrypt, scrypt and pbkdf2 in the README

### DIFF
--- a/vlib/crypto/README.md
+++ b/vlib/crypto/README.md
@@ -131,3 +131,47 @@ fn main() {
 	argon2.compare_hash_and_password('correct horse battery staple'.bytes(), hash.bytes())!
 }
 ```
+
+### bcrypt Password Hashing
+
+```v
+import crypto.bcrypt
+
+fn main() {
+	password := 'correct horse battery staple'.bytes()
+	hash := bcrypt.generate_from_password(password, bcrypt.default_cost)!
+	println(hash)
+
+	bcrypt.compare_hash_and_password(password, hash.bytes())!
+}
+```
+
+### scrypt
+
+`scrypt` is a memory-hard key derivation function (RFC 7914). `n` must be a power of two;
+`(n: 16384, r: 8, p: 1)` are common interactive parameters.
+
+```v
+import crypto.scrypt
+
+fn main() {
+	password := 'correct horse battery staple'.bytes()
+	salt := 'some random salt'.bytes()
+	key := scrypt.scrypt(password, salt, 16384, 8, 1, 32)!
+	assert key.len == 32
+}
+```
+
+### PBKDF2
+
+```v
+import crypto.pbkdf2
+import crypto.sha256
+
+fn main() {
+	password := 'correct horse battery staple'.bytes()
+	salt := 'some random salt'.bytes()
+	key := pbkdf2.key(password, salt, 4096, 32, sha256.new())!
+	assert key.len == 32
+}
+```

--- a/vlib/crypto/README.md
+++ b/vlib/crypto/README.md
@@ -166,6 +166,11 @@ fn main() {
 
 ### PBKDF2
 
+`pbkdf2` derives a key from a password (RFC 8018). For password storage prefer a
+memory-hard function such as `argon2` or `scrypt`; if you must use PBKDF2, use a high
+iteration count and tune it for your hardware. OWASP currently recommends at least
+600_000 iterations for PBKDF2-HMAC-SHA256.
+
 ```v
 import crypto.pbkdf2
 import crypto.rand
@@ -175,7 +180,8 @@ fn main() {
 	password := 'correct horse battery staple'.bytes()
 	// generate and persist a unique random salt per password
 	salt := rand.bytes(16)!
-	key := pbkdf2.key(password, salt, 4096, 32, sha256.new())!
+	// tune the iteration count for your deployment (OWASP suggests 600_000+ for SHA-256)
+	key := pbkdf2.key(password, salt, 600_000, 32, sha256.new())!
 	assert key.len == 32
 }
 ```

--- a/vlib/crypto/README.md
+++ b/vlib/crypto/README.md
@@ -152,11 +152,13 @@ fn main() {
 `(n: 16384, r: 8, p: 1)` are common interactive parameters.
 
 ```v
+import crypto.rand
 import crypto.scrypt
 
 fn main() {
 	password := 'correct horse battery staple'.bytes()
-	salt := 'some random salt'.bytes()
+	// generate and persist a unique random salt per password
+	salt := rand.bytes(16)!
 	key := scrypt.scrypt(password, salt, 16384, 8, 1, 32)!
 	assert key.len == 32
 }
@@ -166,11 +168,13 @@ fn main() {
 
 ```v
 import crypto.pbkdf2
+import crypto.rand
 import crypto.sha256
 
 fn main() {
 	password := 'correct horse battery staple'.bytes()
-	salt := 'some random salt'.bytes()
+	// generate and persist a unique random salt per password
+	salt := rand.bytes(16)!
 	key := pbkdf2.key(password, salt, 4096, 32, sha256.new())!
 	assert key.len == 32
 }

--- a/vlib/crypto/README.md
+++ b/vlib/crypto/README.md
@@ -148,8 +148,10 @@ fn main() {
 
 ### scrypt
 
-`scrypt` is a memory-hard key derivation function (RFC 7914). `n` must be a power of two;
-`(n: 16384, r: 8, p: 1)` are common interactive parameters.
+`scrypt` is a memory-hard key derivation function (RFC 7914). `n` must be a power of two.
+For password storage OWASP recommends at least `(n: 2^17, r: 8, p: 1)` (or `(n: 2^14, r: 8, p: 5)`);
+tune the parameters for your hardware. Smaller values such as `(n: 16384, r: 8, p: 1)` are only a
+low-cost interactive/demo profile, not a password-storage profile.
 
 ```v
 import crypto.rand
@@ -159,7 +161,8 @@ fn main() {
 	password := 'correct horse battery staple'.bytes()
 	// generate and persist a unique random salt per password
 	salt := rand.bytes(16)!
-	key := scrypt.scrypt(password, salt, 16384, 8, 1, 32)!
+	// tune the work factor for your deployment (OWASP suggests n >= 2^17 for password storage)
+	key := scrypt.scrypt(password, salt, 131072, 8, 1, 32)!
 	assert key.len == 32
 }
 ```


### PR DESCRIPTION
These pure-V modules already ship in `vlib/crypto` but were undocumented in
`vlib/crypto/README.md`, which previously covered only HKDF and Argon2. A user
searching for password hashing could reasonably conclude V lacks bcrypt or a
memory-hard KDF and reach for external C bindings instead.

This adds runnable example sections (same style as the existing HKDF/Argon2 ones) for:

- **bcrypt** — `generate_from_password` / `compare_hash_and_password`
- **scrypt** — a memory-hard KDF (RFC 7914)
- **PBKDF2** — `key(...)`

All examples compile and pass `v check-md vlib/crypto/README.md` (7/7 OK, 0 errors, 0 fmt errors).

Fixes #27511
