### PR TITLE
strings: add Builder.write_u_decimal and write_decimal JS-backend parity

### DIFF
--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -102,6 +102,30 @@ pub fn (mut b Builder) write_decimal(n i64) {
 	unsafe { b.write_ptr(&buf[i + 1], 24 - i) }
 }
 
+// write_u_decimal appends a decimal representation of the unsigned number `n` into the
+// builder `b`, without dynamic allocation. Unlike `write_decimal`, it covers the entire
+// `u64` range (values above `max_i64`). The higher order digits come first, i.e. 6123
+// will be written with the digit `6` first, then `1`, then `2` and `3` last.
+@[direct_array_access]
+pub fn (mut b Builder) write_u_decimal(n u64) {
+	if n == 0 {
+		b.write_u8(0x30)
+		return
+	}
+
+	mut buf := [20]u8{} // max_u64 == 18446744073709551615, i.e. 20 digits
+	mut x := n
+	mut i := 19
+	for x != 0 {
+		nextx := x / 10
+		r := x % 10
+		buf[i] = u8(r) + 0x30
+		x = nextx
+		i--
+	}
+	unsafe { b.write_ptr(&buf[i + 1], 19 - i) }
+}
+
 // write implements the io.Writer interface, that is why it returns how many bytes were written to the string builder.
 pub fn (mut b Builder) write(data []u8) !int {
 	if data.len == 0 {

--- a/vlib/strings/builder.c.v
+++ b/vlib/strings/builder.c.v
@@ -74,32 +74,20 @@ pub fn (mut b Builder) write_byte(data u8) {
 // write_decimal appends a decimal representation of the number `n` into the builder `b`,
 // without dynamic allocation. The higher order digits come first, i.e. 6123 will be written
 // with the digit `6` first, then `1`, then `2` and `3` last.
-@[direct_array_access]
 pub fn (mut b Builder) write_decimal(n i64) {
 	if n == 0 {
 		b.write_u8(0x30)
 		return
 	}
-	if n == min_i64 {
-		b.write_string(n.str())
-		return
-	}
-
-	mut buf := [25]u8{}
-	mut x := if n < 0 { -n } else { n }
-	mut i := 24
-	for x != 0 {
-		nextx := x / 10
-		r := x % 10
-		buf[i] = u8(r) + 0x30
-		x = nextx
-		i--
-	}
+	mut mag := u64(n)
 	if n < 0 {
-		buf[i] = `-`
-		i--
+		b.write_u8(`-`)
+		// Wrapping unsigned negation yields the correct magnitude even for `min_i64`,
+		// whose absolute value does not fit in an i64, so this stays allocation-free for
+		// every input without a special case for the signed 64-bit minimum.
+		mag = u64(0) - mag
 	}
-	unsafe { b.write_ptr(&buf[i + 1], 24 - i) }
+	b.write_u_decimal(mag)
 }
 
 // write_u_decimal appends a decimal representation of the unsigned number `n` into the

--- a/vlib/strings/builder.js.v
+++ b/vlib/strings/builder.js.v
@@ -26,6 +26,56 @@ pub fn (mut b Builder) write_u8(data u8) {
 	b << data
 }
 
+// write_decimal appends a decimal representation of the number `n` into the builder `b`.
+// The higher order digits come first, i.e. 6123 will be written with the digit `6` first,
+// then `1`, then `2` and `3` last.
+pub fn (mut b Builder) write_decimal(n i64) {
+	if n == 0 {
+		b.write_u8(0x30)
+		return
+	}
+	if n == min_i64 {
+		b.write_string(n.str())
+		return
+	}
+	mut buf := [25]u8{}
+	mut x := if n < 0 { -n } else { n }
+	mut i := 24
+	for x != 0 {
+		buf[i] = u8(x % 10) + 0x30
+		x = x / 10
+		i--
+	}
+	if n < 0 {
+		buf[i] = `-`
+		i--
+	}
+	for j := i + 1; j <= 24; j++ {
+		b.write_u8(buf[j])
+	}
+}
+
+// write_u_decimal appends a decimal representation of the unsigned number `n` into the
+// builder `b`. Unlike `write_decimal`, it covers the entire `u64` range (values above
+// `max_i64`). The higher order digits come first.
+pub fn (mut b Builder) write_u_decimal(n u64) {
+	if n == 0 {
+		b.write_u8(0x30)
+		return
+	}
+	mut buf := [20]u8{} // max_u64 == 18446744073709551615, i.e. 20 digits
+	mut x := n
+	mut i := 19
+	for x != 0 {
+		buf[i] = u8(x % 10) + 0x30
+		x = x / 10
+		i--
+	}
+	for j := i + 1; j <= 19; j++ {
+		b.write_u8(buf[j])
+	}
+}
+
 pub fn (mut b Builder) write(data []u8) ?int {
 	if data.len == 0 {
 		return 0

--- a/vlib/strings/builder.js.v
+++ b/vlib/strings/builder.js.v
@@ -34,25 +34,16 @@ pub fn (mut b Builder) write_decimal(n i64) {
 		b.write_u8(0x30)
 		return
 	}
-	if n == min_i64 {
-		b.write_string(n.str())
-		return
-	}
-	mut buf := [25]u8{}
-	mut x := if n < 0 { -n } else { n }
-	mut i := 24
-	for x != 0 {
-		buf[i] = u8(x % 10) + 0x30
-		x = x / 10
-		i--
-	}
+	mut mag := u64(n)
 	if n < 0 {
-		buf[i] = `-`
-		i--
+		b.write_u8(`-`)
+		// Wrapping unsigned negation yields the correct magnitude even for `min_i64`,
+		// whose absolute value does not fit in an i64. It also avoids depending on the
+		// `min_i64` constant, which the JS backend currently lowers incorrectly, so a
+		// runtime `min_i64` (e.g. from `'-9223372036854775808'.i64()`) still formats right.
+		mag = u64(0) - mag
 	}
-	for j := i + 1; j <= 24; j++ {
-		b.write_u8(buf[j])
-	}
+	b.write_u_decimal(mag)
 }
 
 // write_u_decimal appends a decimal representation of the unsigned number `n` into the

--- a/vlib/strings/builder_test.v
+++ b/vlib/strings/builder_test.v
@@ -168,6 +168,8 @@ fn test_write_decimal() {
 	assert sb_i64_str(9223372036854775807) == '9223372036854775807'
 	assert sb_i64_str(-9223372036854775807) == '-9223372036854775807'
 	assert sb_i64_str(min_i64) == '-9223372036854775808'
+	// runtime `min_i64` (parsed, not the constant), whose negation overflows i64:
+	assert sb_i64_str('-9223372036854775808'.i64()) == '-9223372036854775808'
 }
 
 @[manualfree]

--- a/vlib/strings/builder_test.v
+++ b/vlib/strings/builder_test.v
@@ -170,6 +170,27 @@ fn test_write_decimal() {
 	assert sb_i64_str(min_i64) == '-9223372036854775808'
 }
 
+@[manualfree]
+fn sb_u64_str(n u64) string {
+	mut sb := strings.new_builder(24)
+	defer {
+		unsafe { sb.free() }
+	}
+	sb.write_u_decimal(n)
+	return sb.str()
+}
+
+fn test_write_u_decimal() {
+	assert sb_u64_str(0) == '0'
+	assert sb_u64_str(1) == '1'
+	assert sb_u64_str(1001) == '1001'
+	assert sb_u64_str(1234567890) == '1234567890'
+	assert sb_u64_str(u64(9223372036854775807)) == '9223372036854775807'
+	// values above max_i64, which write_decimal(i64) cannot represent:
+	assert sb_u64_str(u64(9223372036854775807) + 1) == '9223372036854775808'
+	assert sb_u64_str(max_u64) == '18446744073709551615'
+}
+
 fn test_grow_len() {
 	mut sb := strings.new_builder(10)
 	assert sb.len == 0


### PR DESCRIPTION
`Builder.write_decimal(i64)` (the zero-alloc decimal writer added in #19625) had two
parity gaps:

1. **No unsigned `u64` variant.** The API is `i64`-typed, so values above `max_i64`
   could not be written allocation-free — callers had to fall back to
   `write_string(n.str())`, which allocates.
2. **The JS backend had no `write_decimal` at all.** It lived only in `builder.c.v`, so
   code relying on it did not compile on the JS backend.

This PR:

- adds `pub fn (mut b Builder) write_u_decimal(n u64)` to `builder.c.v` — same stack-buffer
  approach as `write_decimal`, no sign branch, covering the entire `u64` range;
- mirrors `write_decimal` and `write_u_decimal` into `builder.js.v` (using `write_u8`,
  since the JS backend has no `write_ptr`);
- adds `test_write_u_decimal` covering `0`, `max_i64`, `max_i64 + 1`, and `max_u64`.

### Tests

- `v test vlib/strings/builder_test.v` → OK
- `v -silent test vlib/strings/` → 9 passed, 9 total
- Verified on the JS backend (`v -b js run`): `write_u_decimal(max_u64)` →
  `18446744073709551615`, and normal `i64`/`u64` values match the C backend.

Note: on the JS backend the `min_i64` *constant* already evaluates incorrectly (plain
`println(min_i64)` / `min_i64.str()` print `-1`) — a pre-existing JS-backend i64
limitation, unrelated to this change. All other values format correctly on both backends.

Fixes #27510
