### PR TITLE
v3: add eval backend

### DIFF
--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -1028,6 +1028,9 @@ fn (mut e Eval) exec_assign(node &flat.Node, declare bool) !FlowSignal {
 	if children.len == 2 {
 		lhs_id := children[0]
 		rhs_id := children[1]
+		if node.op != .assign && node.op != .none && e.target_needs_single_eval(lhs_id) {
+			return e.exec_compound_assignment_pair_flow(node.op, lhs_id, rhs_id, declare)
+		}
 		target_type := e.assignment_target_type_name(lhs_id, declare)
 		signal := e.assignment_value_flow(node.op, lhs_id, rhs_id, target_type)!
 		if signal.kind != .normal {
@@ -1126,6 +1129,47 @@ fn (mut e Eval) exec_assign(node &flat.Node, declare bool) !FlowSignal {
 	return normal_flow()
 }
 
+fn (e &Eval) target_needs_single_eval(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return false
+	}
+	return e.node(id).kind in [.index, .selector]
+}
+
+fn (mut e Eval) exec_compound_assignment_pair_flow(op flat.Op, lhs_id flat.NodeId, rhs_id flat.NodeId, declare bool) !FlowSignal {
+	target_type := e.assignment_target_type_name(lhs_id, declare)
+	rhs_signal := e.eval_expr_flow_expected(rhs_id, target_type)!
+	if rhs_signal.kind != .normal {
+		return rhs_signal
+	}
+	rhs := flow_value(rhs_signal)
+	return e.apply_compound_target_flow(op, lhs_id, rhs, declare, if target_type.len > 0 {
+		target_type
+	} else {
+		e.infer_expr_type_name(rhs_id)
+	})
+}
+
+fn (mut e Eval) apply_compound_target_flow(op flat.Op, lhs_id flat.NodeId, rhs Value, declare bool, type_name string) !FlowSignal {
+	node := e.node(lhs_id)
+	match node.kind {
+		.index {
+			return e.update_index_target_with_op_flow(node, op, rhs)
+		}
+		.selector {
+			return e.update_selector_target_with_op_flow(node, op, rhs)
+		}
+		else {
+			left_signal := e.eval_expr_flow(lhs_id)!
+			if left_signal.kind != .normal {
+				return left_signal
+			}
+			value := e.apply_assignment_op(op, flow_value(left_signal), rhs)!
+			return e.assign_target_typed_flow(lhs_id, value, declare, type_name)
+		}
+	}
+}
+
 fn (mut e Eval) assignment_value(op flat.Op, lhs_id flat.NodeId, rhs_id flat.NodeId) !Value {
 	rhs := e.eval_expr(rhs_id)!
 	if op == .assign || op == .none {
@@ -1165,22 +1209,24 @@ fn (mut e Eval) assignment_value_flow(op flat.Op, lhs_id flat.NodeId, rhs_id fla
 	}
 	left := flow_value(left_signal)
 	return FlowSignal{
-		values: [
-			match op {
-				.plus_assign { e.apply_infix(.plus, left, rhs)! }
-				.minus_assign { e.apply_infix(.minus, left, rhs)! }
-				.mul_assign { e.apply_infix(.mul, left, rhs)! }
-				.div_assign { e.apply_infix(.div, left, rhs)! }
-				.mod_assign { e.apply_infix(.mod, left, rhs)! }
-				.amp_assign { e.apply_infix(.amp, left, rhs)! }
-				.pipe_assign { e.apply_infix(.pipe, left, rhs)! }
-				.xor_assign { e.apply_infix(.xor, left, rhs)! }
-				.left_shift_assign { e.apply_infix(.left_shift, left, rhs)! }
-				.right_shift_assign { e.apply_infix(.right_shift, left, rhs)! }
-				.right_shift_unsigned_assign { e.apply_infix(.right_shift_unsigned, left, rhs)! }
-				else { rhs }
-			},
-		]
+		values: [e.apply_assignment_op(op, left, rhs)!]
+	}
+}
+
+fn (mut e Eval) apply_assignment_op(op flat.Op, left Value, rhs Value) !Value {
+	return match op {
+		.plus_assign { e.apply_infix(.plus, left, rhs)! }
+		.minus_assign { e.apply_infix(.minus, left, rhs)! }
+		.mul_assign { e.apply_infix(.mul, left, rhs)! }
+		.div_assign { e.apply_infix(.div, left, rhs)! }
+		.mod_assign { e.apply_infix(.mod, left, rhs)! }
+		.amp_assign { e.apply_infix(.amp, left, rhs)! }
+		.pipe_assign { e.apply_infix(.pipe, left, rhs)! }
+		.xor_assign { e.apply_infix(.xor, left, rhs)! }
+		.left_shift_assign { e.apply_infix(.left_shift, left, rhs)! }
+		.right_shift_assign { e.apply_infix(.right_shift, left, rhs)! }
+		.right_shift_unsigned_assign { e.apply_infix(.right_shift_unsigned, left, rhs)! }
+		else { rhs }
 	}
 }
 
@@ -1398,6 +1444,28 @@ fn (mut e Eval) update_index_target_flow(node &flat.Node, value Value) !FlowSign
 	return e.update_target_flow(base_id, new_container)
 }
 
+fn (mut e Eval) update_index_target_with_op_flow(node &flat.Node, op flat.Op, rhs Value) !FlowSignal {
+	base_id := e.child(node, 0)
+	container_signal := e.eval_expr_flow(base_id)!
+	if container_signal.kind != .normal {
+		return container_signal
+	}
+	container := flow_value(container_signal)
+	index_signal := if container is MapValue {
+		e.eval_expr_flow_expected(e.child(node, 1), container.key_type_name)!
+	} else {
+		e.eval_expr_flow(e.child(node, 1))!
+	}
+	if index_signal.kind != .normal {
+		return index_signal
+	}
+	index := flow_value(index_signal)
+	old := e.index_value(container, index)!
+	value := e.apply_assignment_op(op, old, rhs)!
+	new_container := e.set_index_value(container, index, value)!
+	return e.update_target_flow(base_id, new_container)
+}
+
 fn (mut e Eval) update_selector_target(node &flat.Node, value Value) ! {
 	signal := e.update_selector_target_flow(node, value)!
 	if signal.kind != .normal {
@@ -1412,6 +1480,19 @@ fn (mut e Eval) update_selector_target_flow(node &flat.Node, value Value) !FlowS
 		return container_signal
 	}
 	new_container := e.set_selector_value(flow_value(container_signal), node.value, value)!
+	return e.update_target_flow(base_id, new_container)
+}
+
+fn (mut e Eval) update_selector_target_with_op_flow(node &flat.Node, op flat.Op, rhs Value) !FlowSignal {
+	base_id := e.child(node, 0)
+	container_signal := e.eval_expr_flow(base_id)!
+	if container_signal.kind != .normal {
+		return container_signal
+	}
+	container := flow_value(container_signal)
+	old := e.eval_selector_value(container, node.value)!
+	value := e.apply_assignment_op(op, old, rhs)!
+	new_container := e.set_selector_value(container, node.value, value)!
 	return e.update_target_flow(base_id, new_container)
 }
 
@@ -2125,6 +2206,9 @@ fn (mut e Eval) eval_expr_flow(id flat.NodeId) !FlowSignal {
 				return value_signal
 			}
 			return value_flow(e.apply_prefix(node.op, flow_value(value_signal))!)
+		}
+		.postfix {
+			return e.eval_postfix_flow(node)
 		}
 		.infix {
 			return e.eval_infix_flow(node)
@@ -3624,15 +3708,88 @@ fn (e &Eval) apply_prefix(op flat.Op, value Value) !Value {
 }
 
 fn (mut e Eval) eval_postfix(node &flat.Node) !Value {
+	return flow_value(e.eval_postfix_flow(node)!)
+}
+
+fn (mut e Eval) eval_postfix_flow(node &flat.Node) !FlowSignal {
 	target_id := e.child(node, 0)
-	old := e.eval_expr(target_id)!
-	if node.op == .inc {
-		e.update_target(target_id, e.apply_infix(.plus, old, Value(i64(1)))!)!
-		return old
+	return e.apply_postfix_target_flow(target_id, node.op)
+}
+
+fn (mut e Eval) apply_postfix_target_flow(target_id flat.NodeId, op flat.Op) !FlowSignal {
+	target := e.node(target_id)
+	match target.kind {
+		.index {
+			return e.update_index_postfix_flow(target, op)
+		}
+		.selector {
+			return e.update_selector_postfix_flow(target, op)
+		}
+		else {
+			old_signal := e.eval_expr_flow(target_id)!
+			if old_signal.kind != .normal {
+				return old_signal
+			}
+			old := flow_value(old_signal)
+			value := e.apply_postfix_op(op, old)!
+			update_signal := e.update_target_flow(target_id, value)!
+			if update_signal.kind != .normal {
+				return update_signal
+			}
+			return value_flow(old)
+		}
 	}
-	if node.op == .dec {
-		e.update_target(target_id, e.apply_infix(.minus, old, Value(i64(1)))!)!
-		return old
+}
+
+fn (mut e Eval) update_index_postfix_flow(node &flat.Node, op flat.Op) !FlowSignal {
+	base_id := e.child(node, 0)
+	container_signal := e.eval_expr_flow(base_id)!
+	if container_signal.kind != .normal {
+		return container_signal
+	}
+	container := flow_value(container_signal)
+	index_signal := if container is MapValue {
+		e.eval_expr_flow_expected(e.child(node, 1), container.key_type_name)!
+	} else {
+		e.eval_expr_flow(e.child(node, 1))!
+	}
+	if index_signal.kind != .normal {
+		return index_signal
+	}
+	index := flow_value(index_signal)
+	old := e.index_value(container, index)!
+	value := e.apply_postfix_op(op, old)!
+	new_container := e.set_index_value(container, index, value)!
+	update_signal := e.update_target_flow(base_id, new_container)!
+	if update_signal.kind != .normal {
+		return update_signal
+	}
+	return value_flow(old)
+}
+
+fn (mut e Eval) update_selector_postfix_flow(node &flat.Node, op flat.Op) !FlowSignal {
+	base_id := e.child(node, 0)
+	container_signal := e.eval_expr_flow(base_id)!
+	if container_signal.kind != .normal {
+		return container_signal
+	}
+	container := flow_value(container_signal)
+	old := e.eval_selector_value(container, node.value)!
+	value := e.apply_postfix_op(op, old)!
+	new_container := e.set_selector_value(container, node.value, value)!
+	update_signal := e.update_target_flow(base_id, new_container)!
+	if update_signal.kind != .normal {
+		return update_signal
+	}
+	return value_flow(old)
+}
+
+fn (mut e Eval) apply_postfix_op(op flat.Op, old Value) !Value {
+	if op == .inc {
+		return e.apply_infix(.plus, old, Value(i64(1)))
+	}
+	if op == .dec {
+		return e.apply_infix(.minus, old, Value(i64(1)))
 	}
 	return old
 }
@@ -4960,7 +5117,7 @@ fn (e &Eval) adapt_value_to_type_name(value Value, type_name string) Value {
 		}
 	}
 	if type_name.starts_with('[]') && value is ArrayValue {
-		elem_type_name := type_name[2..]
+		elem_type_name := e.qualify_nested_type_name(e.current_module_name(), type_name[2..])
 		mut arr := value
 		arr.elem_type_name = elem_type_name
 		mut values := []Value{cap: arr.values.cap}
@@ -4972,10 +5129,15 @@ fn (e &Eval) adapt_value_to_type_name(value Value, type_name string) Value {
 	}
 	if type_name.starts_with('map[') && value is MapValue {
 		key_type_name, value_type_name := split_map_type(type_name)
+		qualified_key_type_name := e.qualify_nested_type_name(e.current_module_name(),
+			key_type_name)
+		qualified_value_type_name := e.qualify_nested_type_name(e.current_module_name(),
+			value_type_name)
 		mut m := MapValue{
-			key_type_name:   key_type_name
-			value_type_name: value_type_name
-			default_value:   e.adapt_value_to_type_name(value.default_value, value_type_name)
+			key_type_name:   qualified_key_type_name
+			value_type_name: qualified_value_type_name
+			default_value:   e.adapt_value_to_type_name(value.default_value,
+				qualified_value_type_name)
 		}
 		for entry in value.entries {
 			m = e.map_set_value(m, entry.key, entry.value)

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -214,6 +214,7 @@ mut:
 	globals           map[string]map[string]Value
 	global_inits      []GlobalEntry
 	structs           map[string]StructInfo
+	enum_fields       map[string][]string
 	sum_types         map[string][]string
 	type_aliases      map[string]TypeAliasInfo
 	type_names        map[string]map[string]bool
@@ -295,6 +296,7 @@ fn (mut e Eval) reset(a &flat.FlatAst) {
 	e.globals = map[string]map[string]Value{}
 	e.global_inits = []GlobalEntry{}
 	e.structs = map[string]StructInfo{}
+	e.enum_fields = map[string][]string{}
 	e.sum_types = map[string][]string{}
 	e.type_aliases = map[string]TypeAliasInfo{}
 	e.type_names = map[string]map[string]bool{}
@@ -408,12 +410,15 @@ fn (mut e Eval) register_files() ! {
 				}
 				.enum_decl {
 					e.type_names[module_name][child.value] = true
+					enum_name := e.qualify_type_name(module_name, child.value)
+					mut enum_fields := []string{}
 					mut next_value := if child.typ == 'flag' { i64(1) } else { i64(0) }
 					for field_id in e.children(child) {
 						field := e.node(field_id)
 						if field.kind != .enum_field {
 							continue
 						}
+						enum_fields << field.value
 						value := if field.children_count > 0 {
 							e.value_as_int(e.eval_expr_in_module(e.child(field, 0), module_name,
 								file_name, '<enum ${child.value}.${field.value}>')!)!
@@ -439,6 +444,10 @@ fn (mut e Eval) register_files() ! {
 						} else {
 							value + 1
 						}
+					}
+					e.enum_fields[enum_name] = enum_fields
+					if module_name in ['main', 'builtin'] {
+						e.enum_fields[child.value] = enum_fields
 					}
 				}
 				.fn_decl {
@@ -1917,7 +1926,7 @@ fn (mut e Eval) eval_expr(id flat.NodeId) !Value {
 			return e.eval_array_init(node)
 		}
 		.map_init {
-			return e.eval_map_init(node)
+			return flow_value(e.eval_map_init_flow(node)!)
 		}
 		.struct_init {
 			return e.eval_struct_init(node)
@@ -2096,6 +2105,9 @@ fn (mut e Eval) eval_expr_flow(id flat.NodeId) !FlowSignal {
 		}
 		.struct_init {
 			return e.eval_struct_init_flow(node)
+		}
+		.map_init {
+			return e.eval_map_init_flow(node)
 		}
 		.assoc {
 			return e.eval_assoc_flow(node)
@@ -2665,10 +2677,66 @@ fn (mut e Eval) write_back_mutated_args(node &flat.Node, result CallResult) ! {
 }
 
 fn (mut e Eval) adapt_return_values(values []Value, return_type string) []Value {
+	return_types := split_multi_return_types(return_type)
+	if return_types.len > 0 {
+		mut adapted := []Value{cap: values.len}
+		for i, value in values {
+			adapted << if i < return_types.len {
+				e.adapt_value_to_type_name(value, return_types[i])
+			} else {
+				value
+			}
+		}
+		return adapted
+	}
 	if values.len == 1 && return_type.len > 0 {
 		return [e.adapt_value_to_type_name(values[0], return_type)]
 	}
 	return values.clone()
+}
+
+fn split_multi_return_types(return_type string) []string {
+	if !return_type.starts_with('(') || !return_type.ends_with(')') {
+		return []string{}
+	}
+	inner := return_type[1..return_type.len - 1]
+	mut types := []string{}
+	mut start := 0
+	mut paren_depth := 0
+	mut bracket_depth := 0
+	for i := 0; i < inner.len; i++ {
+		ch := inner[i]
+		match ch {
+			`(` {
+				paren_depth++
+			}
+			`)` {
+				if paren_depth > 0 {
+					paren_depth--
+				}
+			}
+			`[` {
+				bracket_depth++
+			}
+			`]` {
+				if bracket_depth > 0 {
+					bracket_depth--
+				}
+			}
+			`,` {
+				if paren_depth == 0 && bracket_depth == 0 {
+					types << inner[start..i].trim_space()
+					start = i + 1
+				}
+			}
+			else {}
+		}
+	}
+	last := inner[start..].trim_space()
+	if last.len > 0 {
+		types << last
+	}
+	return if types.len > 1 { types } else { []string{} }
 }
 
 fn (e &Eval) minimum_arg_count(params []flat.NodeId) int {
@@ -3252,13 +3320,21 @@ fn fixed_array_elem_type_name(type_name string) string {
 }
 
 fn (mut e Eval) eval_map_init(node &flat.Node) !Value {
+	return flow_value(e.eval_map_init_flow(node)!)
+}
+
+fn (mut e Eval) eval_map_init_flow(node &flat.Node) !FlowSignal {
 	mut key_type, mut value_type := split_map_type(node.value)
 	children := e.children(node)
 	mut keys := []Value{}
 	mut values := []Value{}
 	mut i := 0
 	for i + 1 < children.len {
-		key := e.eval_expr_expected(children[i], key_type)!
+		key_signal := e.eval_expr_flow_expected(children[i], key_type)!
+		if key_signal.kind != .normal {
+			return key_signal
+		}
+		key := flow_value(key_signal)
 		if key_type.len == 0 {
 			key_type = e.infer_expr_type_name(children[i])
 			if key_type.len == 0 {
@@ -3266,7 +3342,11 @@ fn (mut e Eval) eval_map_init(node &flat.Node) !Value {
 			}
 		}
 		typed_key := e.adapt_value_to_type_name(key, key_type)
-		value := e.eval_expr_expected(children[i + 1], value_type)!
+		value_signal := e.eval_expr_flow_expected(children[i + 1], value_type)!
+		if value_signal.kind != .normal {
+			return value_signal
+		}
+		value := flow_value(value_signal)
 		if value_type.len == 0 {
 			value_type = e.infer_expr_type_name(children[i + 1])
 			if value_type.len == 0 {
@@ -3285,7 +3365,7 @@ fn (mut e Eval) eval_map_init(node &flat.Node) !Value {
 	for j, key in keys {
 		m = e.map_set_value(m, key, values[j])
 	}
-	return m
+	return value_flow(m)
 }
 
 fn (mut e Eval) eval_string_interp_flow(node &flat.Node) !FlowSignal {
@@ -4562,6 +4642,17 @@ fn (mut e Eval) zero_value_for_type_name_in_module(type_name string, module_name
 			key_type_name:   key_type
 			value_type_name: value_type
 			default_value:   e.zero_value_for_type_name_in_module(value_type, module_name)
+		}
+	}
+	enum_name := e.qualify_type_name(module_name, name)
+	if fields := e.enum_fields[enum_name] {
+		if fields.len > 0 {
+			if value := e.lookup_enum_value(enum_name, fields[0]) {
+				return value
+			}
+		}
+		return EnumValue{
+			type_name: enum_name
 		}
 	}
 	sum_name := e.qualify_type_name(module_name, name)

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -229,6 +229,7 @@ mut:
 	functions         map[string]map[string]FunctionDef
 	consts            map[string]map[string]ConstEntry
 	globals           map[string]map[string]Value
+	global_types      map[string]map[string]string
 	global_inits      []GlobalEntry
 	structs           map[string]StructInfo
 	enum_fields       map[string][]string
@@ -311,6 +312,7 @@ fn (mut e Eval) reset(a &flat.FlatAst) {
 	e.functions = map[string]map[string]FunctionDef{}
 	e.consts = map[string]map[string]ConstEntry{}
 	e.globals = map[string]map[string]Value{}
+	e.global_types = map[string]map[string]string{}
 	e.global_inits = []GlobalEntry{}
 	e.structs = map[string]StructInfo{}
 	e.enum_fields = map[string][]string{}
@@ -351,9 +353,25 @@ fn (mut e Eval) ensure_module_maps(module_name string) {
 	if module_name !in e.globals {
 		e.globals[module_name] = map[string]Value{}
 	}
+	if module_name !in e.global_types {
+		e.global_types[module_name] = map[string]string{}
+	}
 	if module_name !in e.type_names {
 		e.type_names[module_name] = map[string]bool{}
 	}
+}
+
+fn (e &Eval) top_level_registration_children(node &flat.Node) []flat.NodeId {
+	mut ids := []flat.NodeId{}
+	for child_id in e.children(node) {
+		child := e.node(child_id)
+		if child.kind == .block {
+			ids << e.top_level_registration_children(child)
+			continue
+		}
+		ids << child_id
+	}
+	return ids
 }
 
 fn (mut e Eval) register_files() ! {
@@ -362,8 +380,9 @@ fn (mut e Eval) register_files() ! {
 			continue
 		}
 		file_name := file_node.value
+		top_level_children := e.top_level_registration_children(&file_node)
 		mut module_name := 'main'
-		for child_id in e.children(&file_node) {
+		for child_id in top_level_children {
 			child := e.node(child_id)
 			if child.kind == .module_decl {
 				module_name = child.value
@@ -379,7 +398,7 @@ fn (mut e Eval) register_files() ! {
 			e.module_imports[module_name] = []string{}
 		}
 		mut import_aliases := map[string]string{}
-		for child_id in e.children(&file_node) {
+		for child_id in top_level_children {
 			child := e.node(child_id)
 			match child.kind {
 				.import_decl {
@@ -423,6 +442,8 @@ fn (mut e Eval) register_files() ! {
 							module_name:  module_name
 							file_name:    file_name
 						}
+						e.global_types[module_name][field.value] = e.qualify_nested_type_name(module_name,
+							field.typ)
 					}
 				}
 				.enum_decl {
@@ -738,6 +759,10 @@ fn (e &Eval) lookup_var_type(name string) ?string {
 		if name in e.scopes[i].types {
 			return e.scopes[i].types[name]
 		}
+	}
+	module_name := e.current_module_name()
+	if module_name in e.global_types && name in e.global_types[module_name] {
+		return e.global_types[module_name][name]
 	}
 	return none
 }

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -4309,9 +4309,20 @@ fn (mut e Eval) maybe_call_os_builtin(fn_name string, args []Value) !MaybeValue 
 			}
 		}
 		'join_path' {
+			parts := args.map(e.value_string(it))
+			if parts.len == 0 {
+				return MaybeValue{
+					found: true
+					value: Value('')
+				}
+			}
+			mut path := parts[0]
+			for part in parts[1..] {
+				path = os.join_path(path, part)
+			}
 			return MaybeValue{
 				found: true
-				value: Value(args.map(e.value_string(it)).join(os.path_separator))
+				value: Value(path)
 			}
 		}
 		'join_path_single' {
@@ -4364,9 +4375,21 @@ fn os_result_value(result os.Result) Value {
 
 fn (mut e Eval) call_value_method(receiver Value, receiver_type_name string, method_name string, args []Value) !MethodCallResult {
 	static_type_name := e.normalize_type_name(receiver_type_name)
+	if value := e.direct_builtin_str_method_value(receiver, static_type_name, method_name, args) {
+		return MethodCallResult{
+			value:    value
+			receiver: receiver
+		}
+	}
 	if static_type_name.len > 0 {
 		if target := e.resolve_method_target(static_type_name, method_name) {
 			return e.call_method_target(receiver, target, args)!
+		}
+	}
+	if value := e.direct_str_method_value(receiver, method_name, args) {
+		return MethodCallResult{
+			value:    value
+			receiver: receiver
 		}
 	}
 	if receiver is string {
@@ -4413,6 +4436,32 @@ fn (mut e Eval) call_value_method(receiver Value, receiver_type_name string, met
 		return result
 	}
 	return error('v3.eval: unsupported method `${method_name}` on `${e.runtime_type_name(receiver)}`')
+}
+
+fn (e &Eval) direct_builtin_str_method_value(receiver Value, static_type_name string, method_name string, args []Value) ?Value {
+	if !is_builtin_str_receiver_type_name(static_type_name) {
+		return none
+	}
+	return e.direct_str_method_value(receiver, method_name, args)
+}
+
+fn (e &Eval) direct_str_method_value(receiver Value, method_name string, args []Value) ?Value {
+	if method_name != 'str' || args.len != 0 {
+		return none
+	}
+	match receiver {
+		bool, i64, f64, string, EnumValue {
+			return Value(e.value_string(receiver))
+		}
+		else {}
+	}
+
+	return none
+}
+
+fn is_builtin_str_receiver_type_name(name string) bool {
+	return name in ['bool', 'int', 'i8', 'i16', 'i32', 'i64', 'isize', 'u8', 'byte', 'u16', 'u32',
+		'u64', 'usize', 'f32', 'f64', 'rune', 'char', 'string']
 }
 
 fn (mut e Eval) call_method_target(receiver Value, target FunctionDef, args []Value) !MethodCallResult {
@@ -5534,7 +5583,7 @@ fn (e &Eval) value_string(value Value) string {
 			return value.str()
 		}
 		EnumValue {
-			return value.value.str()
+			return e.enum_value_string(value)
 		}
 		f64 {
 			return value.str()
@@ -5578,6 +5627,32 @@ fn (e &Eval) value_string(value Value) string {
 			return '<fn>'
 		}
 	}
+}
+
+fn (e &Eval) enum_value_string(value EnumValue) string {
+	enum_name := e.normalize_type_name(value.type_name)
+	if fields := e.enum_fields[enum_name] {
+		module_name := if enum_name.contains('.') {
+			enum_name.all_before_last('.')
+		} else {
+			e.current_module_name()
+		}
+		short_name := enum_name.all_after_last('.')
+		if module_name in e.consts {
+			for field in fields {
+				if entry := e.consts[module_name]['${short_name}.${field}'] {
+					if e.value_as_int(entry.value) or { i64(-1) } == value.value {
+						return field
+					}
+				}
+			}
+		}
+		index := int(value.value)
+		if index >= 0 && index < fields.len {
+			return fields[index]
+		}
+	}
+	return value.value.str()
 }
 
 fn (e &Eval) runtime_type_name(value Value) string {

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -1033,11 +1033,14 @@ fn (mut e Eval) exec_assign(node &flat.Node, declare bool) !FlowSignal {
 		if signal.kind != .normal {
 			return signal
 		}
-		e.assign_target_typed(lhs_id, flow_value(signal), declare, if target_type.len > 0 {
+		assign_signal := e.assign_target_typed_flow(lhs_id, flow_value(signal), declare, if target_type.len > 0 {
 			target_type
 		} else {
 			e.infer_expr_type_name(rhs_id)
 		})!
+		if assign_signal.kind != .normal {
+			return assign_signal
+		}
 		return normal_flow()
 	}
 	if children.len > 2 {
@@ -1055,14 +1058,20 @@ fn (mut e Eval) exec_assign(node &flat.Node, declare bool) !FlowSignal {
 		if value is TupleValue {
 			for i, lhs_id in lhs_ids {
 				item := if i < value.values.len { value.values[i] } else { void_value() }
-				e.assign_target(lhs_id, item, declare)!
+				assign_signal := e.assign_target_flow(lhs_id, item, declare)!
+				if assign_signal.kind != .normal {
+					return assign_signal
+				}
 			}
 			return normal_flow()
 		}
 		if children.len % 2 == 1 {
 			for i, lhs_id in lhs_ids {
 				item := if i == 0 { value } else { void_value() }
-				e.assign_target(lhs_id, item, declare)!
+				assign_signal := e.assign_target_flow(lhs_id, item, declare)!
+				if assign_signal.kind != .normal {
+					return assign_signal
+				}
 			}
 			return normal_flow()
 		}
@@ -1087,7 +1096,10 @@ fn (mut e Eval) exec_assign(node &flat.Node, declare bool) !FlowSignal {
 			i += 2
 		}
 		for idx, lhs_id in assign_lhs_ids {
-			e.assign_target(lhs_id, values[idx], declare)!
+			assign_signal := e.assign_target_flow(lhs_id, values[idx], declare)!
+			if assign_signal.kind != .normal {
+				return assign_signal
+			}
 		}
 		return normal_flow()
 	}
@@ -1105,7 +1117,10 @@ fn (mut e Eval) exec_assign(node &flat.Node, declare bool) !FlowSignal {
 		} else {
 			void_value()
 		}
-		e.assign_target(lhs_id, value, declare)!
+		assign_signal := e.assign_target_flow(lhs_id, value, declare)!
+		if assign_signal.kind != .normal {
+			return assign_signal
+		}
 		i += 2
 	}
 	return normal_flow()
@@ -1144,7 +1159,11 @@ fn (mut e Eval) assignment_value_flow(op flat.Op, lhs_id flat.NodeId, rhs_id fla
 			values: [rhs]
 		}
 	}
-	left := e.eval_expr(lhs_id) or { e.zero_value_like(rhs) }
+	left_signal := e.eval_expr_flow(lhs_id)!
+	if left_signal.kind != .normal {
+		return left_signal
+	}
+	left := flow_value(left_signal)
 	return FlowSignal{
 		values: [
 			match op {
@@ -1227,10 +1246,24 @@ fn flow_values_or_void(values []Value) []Value {
 }
 
 fn (mut e Eval) assign_target(id flat.NodeId, value Value, declare bool) ! {
-	e.assign_target_typed(id, value, declare, '')!
+	signal := e.assign_target_typed_flow(id, value, declare, '')!
+	if signal.kind != .normal {
+		return error('v3.eval: unexpected `${signal.kind}` escaped assignment target')
+	}
 }
 
 fn (mut e Eval) assign_target_typed(id flat.NodeId, value Value, declare bool, type_name string) ! {
+	signal := e.assign_target_typed_flow(id, value, declare, type_name)!
+	if signal.kind != .normal {
+		return error('v3.eval: unexpected `${signal.kind}` escaped assignment target')
+	}
+}
+
+fn (mut e Eval) assign_target_flow(id flat.NodeId, value Value, declare bool) !FlowSignal {
+	return e.assign_target_typed_flow(id, value, declare, '')
+}
+
+fn (mut e Eval) assign_target_typed_flow(id flat.NodeId, value Value, declare bool, type_name string) !FlowSignal {
 	node := e.node(id)
 	match node.kind {
 		.ident {
@@ -1249,15 +1282,17 @@ fn (mut e Eval) assign_target_typed(id flat.NodeId, value Value, declare bool, t
 			}
 		}
 		.selector {
-			e.update_selector_target(node, value)!
+			return e.update_selector_target_flow(node, value)
 		}
 		.index {
-			e.update_index_target(node, value)!
+			return e.update_index_target_flow(node, value)
 		}
 		else {
 			return error('v3.eval: unsupported assignment target `${node.kind}`')
 		}
 	}
+
+	return normal_flow()
 }
 
 fn (e &Eval) infer_expr_type_name(id flat.NodeId) string {
@@ -1335,22 +1370,53 @@ fn array_elem_type_name_from_type(type_name string) string {
 }
 
 fn (mut e Eval) update_target(id flat.NodeId, value Value) ! {
-	e.assign_target(id, value, false)!
+	signal := e.update_target_flow(id, value)!
+	if signal.kind != .normal {
+		return error('v3.eval: unexpected `${signal.kind}` escaped assignment target')
+	}
 }
 
 fn (mut e Eval) update_index_target(node &flat.Node, value Value) ! {
+	signal := e.update_index_target_flow(node, value)!
+	if signal.kind != .normal {
+		return error('v3.eval: unexpected `${signal.kind}` escaped index assignment target')
+	}
+}
+
+fn (mut e Eval) update_index_target_flow(node &flat.Node, value Value) !FlowSignal {
 	base_id := e.child(node, 0)
-	index := e.eval_expr(e.child(node, 1))!
-	container := e.eval_expr(base_id)!
-	new_container := e.set_index_value(container, index, value)!
-	e.update_target(base_id, new_container)!
+	index_signal := e.eval_expr_flow(e.child(node, 1))!
+	if index_signal.kind != .normal {
+		return index_signal
+	}
+	container_signal := e.eval_expr_flow(base_id)!
+	if container_signal.kind != .normal {
+		return container_signal
+	}
+	new_container := e.set_index_value(flow_value(container_signal), flow_value(index_signal),
+		value)!
+	return e.update_target_flow(base_id, new_container)
 }
 
 fn (mut e Eval) update_selector_target(node &flat.Node, value Value) ! {
+	signal := e.update_selector_target_flow(node, value)!
+	if signal.kind != .normal {
+		return error('v3.eval: unexpected `${signal.kind}` escaped selector assignment target')
+	}
+}
+
+fn (mut e Eval) update_selector_target_flow(node &flat.Node, value Value) !FlowSignal {
 	base_id := e.child(node, 0)
-	container := e.eval_expr(base_id)!
-	new_container := e.set_selector_value(container, node.value, value)!
-	e.update_target(base_id, new_container)!
+	container_signal := e.eval_expr_flow(base_id)!
+	if container_signal.kind != .normal {
+		return container_signal
+	}
+	new_container := e.set_selector_value(flow_value(container_signal), node.value, value)!
+	return e.update_target_flow(base_id, new_container)
+}
+
+fn (mut e Eval) update_target_flow(id flat.NodeId, value Value) !FlowSignal {
+	return e.assign_target_flow(id, value, false)
 }
 
 fn (mut e Eval) set_index_value(container Value, index Value, value Value) !Value {
@@ -3666,7 +3732,11 @@ fn (mut e Eval) exec_match(node &flat.Node) !FlowSignal {
 		mut matched := branch.value == 'else'
 		mut matched_cond := Value(void_value())
 		for j in 0 .. cond_count {
-			cond := e.eval_match_condition(e.child(branch, j), target_id)!
+			cond_signal := e.eval_match_condition_flow(e.child(branch, j), target_id)!
+			if cond_signal.kind != .normal {
+				return cond_signal
+			}
+			cond := flow_value(cond_signal)
 			if e.match_condition_matches(target, cond) {
 				matched = true
 				matched_cond = cond
@@ -3713,7 +3783,11 @@ fn (mut e Eval) eval_match_value_flow(node &flat.Node) !FlowSignal {
 		mut matched := branch.value == 'else'
 		mut matched_cond := Value(void_value())
 		for j in 0 .. cond_count {
-			cond := e.eval_match_condition(e.child(branch, j), target_id)!
+			cond_signal := e.eval_match_condition_flow(e.child(branch, j), target_id)!
+			if cond_signal.kind != .normal {
+				return cond_signal
+			}
+			cond := flow_value(cond_signal)
 			if e.match_condition_matches(target, cond) {
 				matched = true
 				matched_cond = cond
@@ -3780,28 +3854,36 @@ fn (e &Eval) smartcast_binding_from_match(target_id flat.NodeId, target Value, c
 }
 
 fn (mut e Eval) eval_match_condition(cond_id flat.NodeId, target_id flat.NodeId) !Value {
+	return flow_value(e.eval_match_condition_flow(cond_id, target_id)!)
+}
+
+fn (mut e Eval) eval_match_condition_flow(cond_id flat.NodeId, target_id flat.NodeId) !FlowSignal {
 	cond := e.node(cond_id)
 	if cond.kind == .enum_val {
 		if enum_type := e.match_target_enum_type_name(target_id) {
 			if value := e.lookup_enum_value(enum_type, cond.value) {
-				return value
+				return value_flow(value)
 			}
 		}
 	}
 	if cond.kind == .ident && is_builtin_type_name(cond.value) {
-		return TypeValue{
+		return value_flow(TypeValue{
 			name: cond.value
-		}
+		})
 	}
-	value := e.eval_expr(cond_id)!
+	signal := e.eval_expr_flow(cond_id)!
+	if signal.kind != .normal {
+		return signal
+	}
+	value := flow_value(signal)
 	if value is RangeValue {
-		return RangeValue{
+		return value_flow(RangeValue{
 			start:     value.start
 			end:       value.end
 			inclusive: true
-		}
+		})
 	}
-	return value
+	return value_flow(value)
 }
 
 fn (e &Eval) match_target_enum_type_name(target_id flat.NodeId) ?string {
@@ -4682,12 +4764,13 @@ fn (mut e Eval) zero_value_for_type_name_in_module(type_name string, module_name
 		return Value(i64(0))
 	}
 	if name.starts_with('[]') {
+		elem_type := e.qualify_nested_type_name(module_name, name[2..])
 		return ArrayValue{
-			elem_type_name: name[2..]
+			elem_type_name: elem_type
 		}
 	}
 	if is_fixed_array_type_name(name) {
-		elem_type := fixed_array_elem_type_name(name)
+		elem_type := e.qualify_nested_type_name(module_name, fixed_array_elem_type_name(name))
 		len := fixed_array_len(name)
 		return ArrayValue{
 			elem_type_name: elem_type
@@ -4697,10 +4780,12 @@ fn (mut e Eval) zero_value_for_type_name_in_module(type_name string, module_name
 	}
 	if name.starts_with('map[') {
 		key_type, value_type := split_map_type(name)
+		qualified_key_type := e.qualify_nested_type_name(module_name, key_type)
+		qualified_value_type := e.qualify_nested_type_name(module_name, value_type)
 		return MapValue{
-			key_type_name:   key_type
-			value_type_name: value_type
-			default_value:   e.zero_value_for_type_name_in_module(value_type, module_name)
+			key_type_name:   qualified_key_type
+			value_type_name: qualified_value_type
+			default_value:   e.zero_value_for_type_name_in_module(qualified_value_type, module_name)
 		}
 	}
 	enum_name := e.qualify_type_name(module_name, name)
@@ -4732,6 +4817,25 @@ fn (mut e Eval) zero_value_for_type_name_in_module(type_name string, module_name
 		return e.zero_struct_value(struct_name)
 	}
 	return void_value()
+}
+
+fn (e &Eval) qualify_nested_type_name(module_name string, type_name string) string {
+	name := type_name.trim_space()
+	if name == '' {
+		return ''
+	}
+	if name.starts_with('[]') {
+		return '[]${e.qualify_nested_type_name(module_name, name[2..])}'
+	}
+	if name.starts_with('map[') {
+		key_type, value_type := split_map_type(name)
+		return 'map[${e.qualify_nested_type_name(module_name, key_type)}]${e.qualify_nested_type_name(module_name,
+			value_type)}'
+	}
+	if name.starts_with('?') || name.starts_with('!') {
+		return '${name[..1]}${e.qualify_nested_type_name(module_name, name[1..])}'
+	}
+	return e.qualify_type_name(module_name, name)
 }
 
 fn (mut e Eval) zero_struct_value(type_name string) StructValue {

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -1731,11 +1731,11 @@ fn (mut e Eval) exec_array_append(node &flat.Node) !FlowSignal {
 		return rhs_signal
 	}
 	rhs := flow_value(rhs_signal)
-	current_signal := e.eval_expr_flow(lhs_id)!
-	if current_signal.kind != .normal {
-		return current_signal
+	resolved := e.resolve_lvalue_flow(lhs_id)!
+	if resolved.signal.kind != .normal {
+		return resolved.signal
 	}
-	current := flow_value(current_signal)
+	current := resolved.value
 	if current !is ArrayValue {
 		return error('v3.eval: `<<` is only supported for arrays')
 	}
@@ -1747,8 +1747,7 @@ fn (mut e Eval) exec_array_append(node &flat.Node) !FlowSignal {
 	} else {
 		arr.values << e.adapt_value_to_type_name(rhs, arr.elem_type_name)
 	}
-	e.update_target(lhs_id, arr)!
-	return normal_flow()
+	return e.write_resolved_lvalue_flow(resolved, arr)
 }
 
 fn (e &Eval) array_append_rhs_spreads(rhs_id flat.NodeId, rhs ArrayValue, elem_type_name string) bool {
@@ -3639,9 +3638,12 @@ fn (mut e Eval) eval_block_value(node &flat.Node) !Value {
 }
 
 fn (mut e Eval) eval_block_value_flow(node &flat.Node) !FlowSignal {
+	return e.eval_block_value_flow_collect(node, false)
+}
+
+fn (mut e Eval) eval_block_value_flow_collect(node &flat.Node, collect_expr_values bool) !FlowSignal {
 	e.open_scope()
 	mut values := []Value{}
-	collect_expr_values := e.block_has_only_expr_stmts(node) && node.children_count > 1
 	for child_id in e.children(node) {
 		child := e.node(child_id)
 		if child.kind == .expr_stmt && child.children_count > 0 {
@@ -3664,7 +3666,9 @@ fn (mut e Eval) eval_block_value_flow(node &flat.Node) !FlowSignal {
 			continue
 		}
 		if child.kind == .block {
-			signal := e.eval_block_value_flow(child)!
+			collect_child_expr_values := node.children_count == 1
+				&& e.block_has_only_expr_stmts(child) && child.children_count > 1
+			signal := e.eval_block_value_flow_collect(child, collect_child_expr_values)!
 			if signal.kind != .normal {
 				e.close_scope()!
 				return signal

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -2032,11 +2032,25 @@ fn (mut e Eval) exec_for_in(node &flat.Node, loop_label string) !FlowSignal {
 	header_count := if node.value.int() > 0 { node.value.int() } else { 3 }
 	key_id := e.child(node, 0)
 	val_id := e.child(node, 1)
-	container_signal := e.eval_expr_flow(e.child(node, 2))!
-	if container_signal.kind != .normal {
-		return container_signal
+	container_id := e.child(node, 2)
+	is_mut_loop := node.op == .amp
+	mut resolved_container := ResolvedLvalue{}
+	mut has_resolved_container := false
+	mut container := Value(void_value())
+	if is_mut_loop && e.is_assignable_target(container_id) {
+		resolved_container = e.resolve_lvalue_flow(container_id)!
+		if resolved_container.signal.kind != .normal {
+			return resolved_container.signal
+		}
+		container = resolved_container.value
+		has_resolved_container = true
+	} else {
+		container_signal := e.eval_expr_flow(container_id)!
+		if container_signal.kind != .normal {
+			return container_signal
+		}
+		container = flow_value(container_signal)
 	}
-	container := flow_value(container_signal)
 	body := e.children(node)[header_count..]
 	if header_count == 4 {
 		start := e.value_as_int(container)!
@@ -2098,7 +2112,6 @@ fn (mut e Eval) exec_for_in(node &flat.Node, loop_label string) !FlowSignal {
 				elem_type_name: container.elem_type_name
 				values:         container.values.clone()
 			}
-			is_mut_loop := node.op == .amp
 			for i, item in arr.values {
 				e.open_scope()
 				e.assign_loop_vars(key_id, val_id, Value(i64(i)), item, true)
@@ -2106,7 +2119,22 @@ fn (mut e Eval) exec_for_in(node &flat.Node, loop_label string) !FlowSignal {
 				if is_mut_loop {
 					if value := e.loop_mut_value(key_id, val_id, true) {
 						arr.values[i] = e.adapt_value_to_type_name(value, arr.elem_type_name)
-						e.update_target(e.child(node, 2), arr)!
+						mut write_signal := FlowSignal{}
+						if has_resolved_container {
+							write_signal = e.write_resolved_lvalue_flow(resolved_container, arr) or {
+								e.close_scope()!
+								return err
+							}
+						} else {
+							write_signal = e.update_target_flow(container_id, arr) or {
+								e.close_scope()!
+								return err
+							}
+						}
+						if write_signal.kind != .normal {
+							e.close_scope()!
+							return write_signal
+						}
 					}
 				}
 				e.close_scope()!
@@ -2134,7 +2162,6 @@ fn (mut e Eval) exec_for_in(node &flat.Node, loop_label string) !FlowSignal {
 				default_value:   container.default_value
 				entries:         container.entries.clone()
 			}
-			is_mut_loop := node.op == .amp
 			for i, entry in m.entries {
 				e.open_scope()
 				e.assign_loop_vars(key_id, val_id, entry.key, entry.value, true)
@@ -2142,7 +2169,22 @@ fn (mut e Eval) exec_for_in(node &flat.Node, loop_label string) !FlowSignal {
 				if is_mut_loop {
 					if value := e.loop_mut_value(key_id, val_id, true) {
 						m.entries[i].value = e.adapt_value_to_type_name(value, m.value_type_name)
-						e.update_target(e.child(node, 2), m)!
+						mut write_signal := FlowSignal{}
+						if has_resolved_container {
+							write_signal = e.write_resolved_lvalue_flow(resolved_container, m) or {
+								e.close_scope()!
+								return err
+							}
+						} else {
+							write_signal = e.update_target_flow(container_id, m) or {
+								e.close_scope()!
+								return err
+							}
+						}
+						if write_signal.kind != .normal {
+							e.close_scope()!
+							return write_signal
+						}
 					}
 				}
 				e.close_scope()!
@@ -2535,6 +2577,23 @@ fn (mut e Eval) eval_expr_flow_expected(id flat.NodeId, expected_type string) !F
 		if node.kind == .enum_val && expected_type.len > 0 {
 			if value := e.lookup_enum_value(expected_type, node.value) {
 				return value_flow(value)
+			}
+		}
+		if expected_type.len > 0 {
+			match node.kind {
+				.if_expr {
+					return e.eval_if_value_flow_expected(node, expected_type)
+				}
+				.match_stmt {
+					return e.eval_match_value_flow_expected(node, expected_type)
+				}
+				.block {
+					return e.eval_block_value_flow_expected(node, expected_type)
+				}
+				.paren {
+					return e.eval_expr_flow_expected(e.child(node, 0), expected_type)
+				}
+				else {}
 			}
 		}
 	}
@@ -2973,10 +3032,14 @@ fn (e &Eval) qualify_expected_type_name(module_name string, type_name string) st
 }
 
 fn (e &Eval) fn_value_param_type_names(fv FnValue) []string {
-	return e.fn_literal_param_type_names(e.node(fv.node))
+	return e.fn_literal_param_type_names_in_module(e.node(fv.node), fv.module_name)
 }
 
 fn (e &Eval) fn_literal_param_type_names(node &flat.Node) []string {
+	return e.fn_literal_param_type_names_in_module(node, e.current_module_name())
+}
+
+fn (e &Eval) fn_literal_param_type_names_in_module(node &flat.Node, module_name string) []string {
 	children := e.children(node)
 	mut i := 0
 	for i < children.len {
@@ -2992,7 +3055,7 @@ fn (e &Eval) fn_literal_param_type_names(node &flat.Node) []string {
 		if child.kind != .param {
 			break
 		}
-		types << child.typ
+		types << e.qualify_expected_type_name(module_name, child.typ)
 		i++
 	}
 	return types
@@ -3631,6 +3694,10 @@ fn (mut e Eval) eval_if_value(node &flat.Node) !Value {
 }
 
 fn (mut e Eval) eval_if_value_flow(node &flat.Node) !FlowSignal {
+	return e.eval_if_value_flow_expected(node, '')
+}
+
+fn (mut e Eval) eval_if_value_flow_expected(node &flat.Node, expected_type string) !FlowSignal {
 	if node.children_count < 2 {
 		return value_flow(void_value())
 	}
@@ -3655,7 +3722,7 @@ fn (mut e Eval) eval_if_value_flow(node &flat.Node) !FlowSignal {
 				smartcast_scope = true
 			}
 		}
-		signal := e.eval_value_expr_flow(e.child(node, 1))!
+		signal := e.eval_value_expr_flow_expected(e.child(node, 1), expected_type)!
 		if smartcast_scope {
 			e.close_scope()!
 		}
@@ -3668,19 +3735,23 @@ fn (mut e Eval) eval_if_value_flow(node &flat.Node) !FlowSignal {
 		e.close_scope()!
 	}
 	if node.children_count > 2 {
-		return e.eval_value_expr_flow(e.child(node, 2))
+		return e.eval_value_expr_flow_expected(e.child(node, 2), expected_type)
 	}
 	return value_flow(void_value())
 }
 
 fn (mut e Eval) eval_value_expr_flow(id flat.NodeId) !FlowSignal {
+	return e.eval_value_expr_flow_expected(id, '')
+}
+
+fn (mut e Eval) eval_value_expr_flow_expected(id flat.NodeId, expected_type string) !FlowSignal {
 	if int(id) >= 0 {
 		node := e.node(id)
 		if node.kind == .block {
-			return e.eval_block_value_flow(node)
+			return e.eval_block_value_flow_expected(node, expected_type)
 		}
 	}
-	return e.eval_expr_flow(id)
+	return e.eval_expr_flow_expected(id, expected_type)
 }
 
 fn (mut e Eval) eval_block_value(node &flat.Node) !Value {
@@ -3692,10 +3763,14 @@ fn (mut e Eval) eval_block_value(node &flat.Node) !Value {
 }
 
 fn (mut e Eval) eval_block_value_flow(node &flat.Node) !FlowSignal {
-	return e.eval_block_value_flow_collect(node, false)
+	return e.eval_block_value_flow_expected(node, '')
 }
 
-fn (mut e Eval) eval_block_value_flow_collect(node &flat.Node, collect_expr_values bool) !FlowSignal {
+fn (mut e Eval) eval_block_value_flow_expected(node &flat.Node, expected_type string) !FlowSignal {
+	return e.eval_block_value_flow_collect(node, false, expected_type)
+}
+
+fn (mut e Eval) eval_block_value_flow_collect(node &flat.Node, collect_expr_values bool, expected_type string) !FlowSignal {
 	e.open_scope()
 	mut values := []Value{}
 	for child_id in e.children(node) {
@@ -3711,7 +3786,7 @@ fn (mut e Eval) eval_block_value_flow_collect(node &flat.Node, collect_expr_valu
 				}
 				continue
 			}
-			signal := e.eval_expr_flow(expr_id)!
+			signal := e.eval_expr_flow_expected(expr_id, expected_type)!
 			if signal.kind != .normal {
 				e.close_scope()!
 				return signal
@@ -3731,7 +3806,8 @@ fn (mut e Eval) eval_block_value_flow_collect(node &flat.Node, collect_expr_valu
 		if child.kind == .block {
 			collect_child_expr_values := node.children_count == 1
 				&& e.block_has_only_expr_stmts(child) && child.children_count > 1
-			signal := e.eval_block_value_flow_collect(child, collect_child_expr_values)!
+			signal := e.eval_block_value_flow_collect(child, collect_child_expr_values,
+				expected_type)!
 			if signal.kind != .normal {
 				e.close_scope()!
 				return signal
@@ -4253,6 +4329,10 @@ fn (mut e Eval) eval_match_value(node &flat.Node) !Value {
 }
 
 fn (mut e Eval) eval_match_value_flow(node &flat.Node) !FlowSignal {
+	return e.eval_match_value_flow_expected(node, '')
+}
+
+fn (mut e Eval) eval_match_value_flow_expected(node &flat.Node, expected_type string) !FlowSignal {
 	target_id := e.child(node, 0)
 	target_signal := e.eval_expr_flow(target_id)!
 	if target_signal.kind != .normal {
@@ -4289,7 +4369,17 @@ fn (mut e Eval) eval_match_value_flow(node &flat.Node) !FlowSignal {
 				stmt_id := e.child(branch, j)
 				stmt := e.node(stmt_id)
 				if stmt.kind == .expr_stmt && stmt.children_count > 0 {
-					signal := e.eval_expr_flow(e.child(stmt, 0))!
+					expr_id := e.child(stmt, 0)
+					expr := e.node(expr_id)
+					if expr.kind == .infix && expr.op == .left_shift {
+						signal := e.exec_stmt(stmt_id)!
+						if signal.kind != .normal {
+							e.close_scope()!
+							return signal
+						}
+						continue
+					}
+					signal := e.eval_expr_flow_expected(expr_id, expected_type)!
 					if signal.kind != .normal {
 						e.close_scope()!
 						return signal

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -415,7 +415,8 @@ fn (mut e Eval) register_files() ! {
 							continue
 						}
 						value := if field.children_count > 0 {
-							e.value_as_int(e.eval_expr(e.child(field, 0))!)!
+							e.value_as_int(e.eval_expr_in_module(e.child(field, 0), module_name,
+								file_name, '<enum ${child.value}.${field.value}>')!)!
 						} else {
 							next_value
 						}
@@ -562,6 +563,18 @@ fn (mut e Eval) evaluate_global_init(entry GlobalEntry) ! {
 	}
 	e.call_stack.delete(e.call_stack.len - 1)
 	e.globals[entry.module_name][entry.name] = e.adapt_value_to_type_name(value, entry.typ)
+}
+
+fn (mut e Eval) eval_expr_in_module(id flat.NodeId, module_name string, file_name string, label string) !Value {
+	e.call_stack << CallFrame{
+		module_name: module_name
+		file_name:   file_name
+		fn_name:     label
+	}
+	defer {
+		e.call_stack.delete(e.call_stack.len - 1)
+	}
+	return e.eval_expr(id)
 }
 
 fn (mut e Eval) register_function(module_name string, file_name string, id flat.NodeId, node &flat.Node) {
@@ -1838,16 +1851,7 @@ fn (mut e Eval) eval_expr(id flat.NodeId) !Value {
 			return Value(node.value)
 		}
 		.string_interp {
-			mut out := ''
-			for child_id in e.children(node) {
-				child := e.node(child_id)
-				if child.kind == .string_literal {
-					out += child.value
-				} else {
-					out += e.value_string(e.eval_expr(child_id)!)
-				}
-			}
-			return Value(out)
+			return flow_value(e.eval_string_interp_flow(node)!)
 		}
 		.ident {
 			return e.eval_ident(node.value)
@@ -2095,6 +2099,9 @@ fn (mut e Eval) eval_expr_flow(id flat.NodeId) !FlowSignal {
 		}
 		.assoc {
 			return e.eval_assoc_flow(node)
+		}
+		.string_interp {
+			return e.eval_string_interp_flow(node)
 		}
 		else {
 			return FlowSignal{
@@ -2955,7 +2962,11 @@ fn (mut e Eval) eval_index(node &flat.Node) !Value {
 		}
 		return e.slice_value(container, start, end)!
 	}
-	index := e.eval_expr(e.child(node, 1))!
+	index := if container is MapValue {
+		e.eval_expr_expected(e.child(node, 1), container.key_type_name)!
+	} else {
+		e.eval_expr(e.child(node, 1))!
+	}
 	return e.index_value(container, index)
 }
 
@@ -2990,7 +3001,11 @@ fn (mut e Eval) eval_index_flow(node &flat.Node) !FlowSignal {
 		}
 		return value_flow(e.slice_value(container, start, end)!)
 	}
-	index_signal := e.eval_expr_flow(e.child(node, 1))!
+	index_signal := if container is MapValue {
+		e.eval_expr_flow_expected(e.child(node, 1), container.key_type_name)!
+	} else {
+		e.eval_expr_flow(e.child(node, 1))!
+	}
 	if index_signal.kind != .normal {
 		return index_signal
 	}
@@ -3007,7 +3022,8 @@ fn (mut e Eval) index_value(container Value, index Value) !Value {
 			return container.values[idx]
 		}
 		MapValue {
-			value, ok := e.map_lookup(container, index)
+			value, ok := e.map_lookup(container, e.adapt_value_to_type_name(index,
+				container.key_type_name))
 			if ok {
 				return value
 			}
@@ -3270,6 +3286,23 @@ fn (mut e Eval) eval_map_init(node &flat.Node) !Value {
 		m = e.map_set_value(m, key, values[j])
 	}
 	return m
+}
+
+fn (mut e Eval) eval_string_interp_flow(node &flat.Node) !FlowSignal {
+	mut out := ''
+	for child_id in e.children(node) {
+		child := e.node(child_id)
+		if child.kind == .string_literal {
+			out += child.value
+			continue
+		}
+		signal := e.eval_expr_flow(child_id)!
+		if signal.kind != .normal {
+			return signal
+		}
+		out += e.value_string(flow_value(signal))
+	}
+	return value_flow(Value(out))
 }
 
 fn split_map_type(type_name string) (string, string) {
@@ -4365,8 +4398,9 @@ fn (e &Eval) value_eq(left Value, right Value) bool {
 }
 
 fn (e &Eval) map_lookup(receiver MapValue, key Value) (Value, bool) {
+	typed_key := e.adapt_value_to_type_name(key, receiver.key_type_name)
 	for entry in receiver.entries {
-		if e.value_eq(entry.key, key) {
+		if e.value_eq(entry.key, typed_key) {
 			return entry.value, true
 		}
 	}
@@ -4379,6 +4413,7 @@ fn (e &Eval) map_contains_key(receiver MapValue, key Value) bool {
 }
 
 fn (e &Eval) map_set_value(receiver MapValue, key Value, value Value) MapValue {
+	entry_key := e.adapt_value_to_type_name(key, receiver.key_type_name)
 	entry_value := e.adapt_value_to_type_name(value, receiver.value_type_name)
 	mut m := MapValue{
 		key_type_name:   receiver.key_type_name
@@ -4387,13 +4422,13 @@ fn (e &Eval) map_set_value(receiver MapValue, key Value, value Value) MapValue {
 		entries:         receiver.entries.clone()
 	}
 	for i, entry in m.entries {
-		if e.value_eq(entry.key, key) {
+		if e.value_eq(entry.key, entry_key) {
 			m.entries[i].value = entry_value
 			return m
 		}
 	}
 	m.entries << MapEntry{
-		key:   key
+		key:   entry_key
 		value: entry_value
 	}
 	return m
@@ -4401,8 +4436,9 @@ fn (e &Eval) map_set_value(receiver MapValue, key Value, value Value) MapValue {
 
 fn (e &Eval) map_delete_value(receiver MapValue, key Value) MapValue {
 	mut m := receiver
+	typed_key := e.adapt_value_to_type_name(key, receiver.key_type_name)
 	for i, entry in m.entries {
-		if e.value_eq(entry.key, key) {
+		if e.value_eq(entry.key, typed_key) {
 			m.entries.delete(i)
 			break
 		}
@@ -4678,6 +4714,18 @@ fn (e &Eval) adapt_value_to_type_name(value Value, type_name string) Value {
 		}
 		arr.values = values
 		return arr
+	}
+	if type_name.starts_with('map[') && value is MapValue {
+		key_type_name, value_type_name := split_map_type(type_name)
+		mut m := MapValue{
+			key_type_name:   key_type_name
+			value_type_name: value_type_name
+			default_value:   e.adapt_value_to_type_name(value.default_value, value_type_name)
+		}
+		for entry in value.entries {
+			m = e.map_set_value(m, entry.key, entry.value)
+		}
+		return m
 	}
 	target_type_name := e.normalize_type_name(type_name)
 	if target_type_name in e.sum_types && !e.value_matches_type_name(value, target_type_name) {

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -1,0 +1,4914 @@
+module eval
+
+import os
+import strconv
+import time
+import v3.flat
+import v3.parser
+import v3.pref
+
+pub type Value = ArrayValue
+	| EnumValue
+	| FnValue
+	| MapValue
+	| ModuleValue
+	| RangeValue
+	| StructValue
+	| SumValue
+	| TupleValue
+	| TypeValue
+	| VoidValue
+	| bool
+	| f64
+	| i64
+	| string
+
+pub struct ArrayValue {
+pub mut:
+	elem_type_name string
+	values         []Value
+}
+
+pub struct EnumValue {
+pub:
+	type_name string
+	value     i64
+}
+
+pub struct FnValue {
+	node          flat.NodeId
+	module_name   string
+	file_name     string
+	captures      map[string]Value
+	capture_types map[string]string
+}
+
+pub struct MapEntry {
+pub:
+	key Value
+pub mut:
+	value Value
+}
+
+pub struct MapValue {
+pub mut:
+	key_type_name   string
+	value_type_name string
+	default_value   Value
+	entries         []MapEntry
+}
+
+pub struct ModuleValue {
+pub:
+	name string
+}
+
+pub struct RangeValue {
+pub:
+	start     i64
+	end       i64
+	inclusive bool
+}
+
+pub struct StructValue {
+pub:
+	type_name string
+pub mut:
+	fields map[string]Value
+}
+
+pub struct SumValue {
+pub:
+	type_name    string
+	variant_name string
+pub mut:
+	payload Value
+}
+
+pub struct TupleValue {
+pub:
+	values []Value
+}
+
+pub struct TypeValue {
+pub:
+	name string
+}
+
+pub struct VoidValue {}
+
+struct FunctionDef {
+	node        flat.NodeId
+	name        string
+	module_name string
+	file_name   string
+}
+
+struct ConstEntry {
+	node        flat.NodeId
+	module_name string
+	file_name   string
+mut:
+	cached     bool
+	evaluating bool
+	value      Value
+}
+
+struct GlobalEntry {
+	name         string
+	typ          string
+	default_node flat.NodeId
+	module_name  string
+	file_name    string
+}
+
+struct StructInfo {
+	module_name string
+	name        string
+mut:
+	fields []FieldInfo
+}
+
+struct TypeAliasInfo {
+	module_name string
+	target      string
+}
+
+struct FieldInfo {
+	name         string
+	typ          string
+	default_node flat.NodeId
+	module_name  string
+	file_name    string
+}
+
+struct ScopeFrame {
+mut:
+	vars        map[string]Value
+	types       map[string]string
+	defer_stmts []flat.NodeId
+}
+
+struct CallFrame {
+	module_name string
+	file_name   string
+	fn_name     string
+}
+
+struct MaybeValue {
+	found bool
+	value Value
+}
+
+struct SmartcastBinding {
+	name      string
+	value     Value
+	type_name string
+}
+
+struct CallResult {
+	values           []Value
+	mutated_args     map[int]Value
+	fn_value_changed bool
+	fn_value         FnValue
+}
+
+struct MethodCallResult {
+	value            Value
+	receiver_changed bool
+	receiver         Value
+	mutated_args     map[int]Value
+}
+
+struct InfixOperatorCallInfo {
+	target  FunctionDef
+	reverse bool
+	negate  bool
+}
+
+enum FlowKind {
+	normal
+	break_
+	continue_
+	return_
+}
+
+struct FlowSignal {
+	kind   FlowKind
+	label  string
+	values []Value
+}
+
+// Eval interprets v3 flat AST nodes directly for a practical subset of V.
+pub struct Eval {
+pub mut:
+	capture_output bool
+	prefs          pref.Preferences
+mut:
+	a                 &flat.FlatAst = unsafe { nil }
+	stdout_data       string
+	stderr_data       string
+	functions         map[string]map[string]FunctionDef
+	consts            map[string]map[string]ConstEntry
+	globals           map[string]map[string]Value
+	global_inits      []GlobalEntry
+	structs           map[string]StructInfo
+	sum_types         map[string][]string
+	type_aliases      map[string]TypeAliasInfo
+	type_names        map[string]map[string]bool
+	module_imports    map[string][]string
+	module_order      []string
+	file_import_alias map[string]map[string]string
+	modules           map[string]bool
+	scopes            []ScopeFrame
+	call_stack        []CallFrame
+}
+
+// new returns a new evaluator configured for direct execution.
+pub fn new(prefs_ &pref.Preferences) Eval {
+	return Eval{
+		prefs: *prefs_
+	}
+}
+
+// create returns a capturing evaluator convenient for tests.
+pub fn create() Eval {
+	return Eval{
+		capture_output: true
+		prefs:          pref.new_preferences()
+	}
+}
+
+// stdout returns the captured stdout stream.
+pub fn (e &Eval) stdout() string {
+	return e.stdout_data
+}
+
+// stderr returns the captured stderr stream.
+pub fn (e &Eval) stderr() string {
+	return e.stderr_data
+}
+
+// run_text parses and executes a single V source string.
+pub fn (mut e Eval) run_text(code string) ![]Value {
+	tmp_file := os.join_path(os.temp_dir(), 'v3_eval_${os.getpid()}_${time.now().unix_micro()}.v')
+	os.write_file(tmp_file, code)!
+	defer {
+		os.rm(tmp_file) or {}
+	}
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_into(tmp_file)
+	return e.run_files(p.a)
+}
+
+// run_files executes parsed flat AST files and invokes `main.main`.
+pub fn (mut e Eval) run_files(a &flat.FlatAst) ![]Value {
+	e.reset(a)
+	e.register_files()!
+	e.run_inits()!
+	return e.call_function('main', 'main', []Value{})!.values
+}
+
+fn void_value() Value {
+	return VoidValue{}
+}
+
+fn normal_flow() FlowSignal {
+	return FlowSignal{
+		kind: .normal
+	}
+}
+
+fn value_flow(value Value) FlowSignal {
+	return FlowSignal{
+		values: [value]
+	}
+}
+
+fn (mut e Eval) reset(a &flat.FlatAst) {
+	e.a = unsafe { a }
+	e.stdout_data = ''
+	e.stderr_data = ''
+	e.functions = map[string]map[string]FunctionDef{}
+	e.consts = map[string]map[string]ConstEntry{}
+	e.globals = map[string]map[string]Value{}
+	e.global_inits = []GlobalEntry{}
+	e.structs = map[string]StructInfo{}
+	e.sum_types = map[string][]string{}
+	e.type_aliases = map[string]TypeAliasInfo{}
+	e.type_names = map[string]map[string]bool{}
+	e.module_imports = map[string][]string{}
+	e.module_order = []string{}
+	e.file_import_alias = map[string]map[string]string{}
+	e.modules = map[string]bool{}
+	e.scopes = []ScopeFrame{}
+	e.call_stack = []CallFrame{}
+}
+
+fn (e &Eval) node(id flat.NodeId) &flat.Node {
+	return e.a.node(id)
+}
+
+fn (e &Eval) child(node &flat.Node, index int) flat.NodeId {
+	return e.a.child(node, index)
+}
+
+fn (e &Eval) child_node(node &flat.Node, index int) &flat.Node {
+	return e.a.child_node(node, index)
+}
+
+fn (e &Eval) children(node &flat.Node) []flat.NodeId {
+	return e.a.children_of(node)
+}
+
+fn (mut e Eval) ensure_module_maps(module_name string) {
+	if module_name !in e.functions {
+		e.functions[module_name] = map[string]FunctionDef{}
+	}
+	if module_name !in e.consts {
+		e.consts[module_name] = map[string]ConstEntry{}
+	}
+	if module_name !in e.globals {
+		e.globals[module_name] = map[string]Value{}
+	}
+	if module_name !in e.type_names {
+		e.type_names[module_name] = map[string]bool{}
+	}
+}
+
+fn (mut e Eval) register_files() ! {
+	for file_id, file_node in e.a.nodes {
+		if file_node.kind != .file || file_node.children_count == 0 {
+			continue
+		}
+		file_name := file_node.value
+		mut module_name := 'main'
+		for child_id in e.children(&file_node) {
+			child := e.node(child_id)
+			if child.kind == .module_decl {
+				module_name = child.value
+				break
+			}
+		}
+		if module_name !in e.modules {
+			e.module_order << module_name
+		}
+		e.modules[module_name] = true
+		e.ensure_module_maps(module_name)
+		if module_name !in e.module_imports {
+			e.module_imports[module_name] = []string{}
+		}
+		mut import_aliases := map[string]string{}
+		for child_id in e.children(&file_node) {
+			child := e.node(child_id)
+			match child.kind {
+				.import_decl {
+					imported_module := child.value.all_after_last('.')
+					if imported_module.len > 0 && imported_module != module_name
+						&& imported_module !in e.module_imports[module_name] {
+						e.module_imports[module_name] << imported_module
+					}
+					import_aliases[child.typ] = child.value.all_after_last('.')
+					import_aliases[child.value.all_after_last('.')] =
+						child.value.all_after_last('.')
+				}
+				.const_decl {
+					for field_id in e.children(child) {
+						field := e.node(field_id)
+						if field.kind != .const_field {
+							continue
+						}
+						e.consts[module_name][field.value] = ConstEntry{
+							node:        field_id
+							module_name: module_name
+							file_name:   file_name
+							value:       void_value()
+						}
+					}
+				}
+				.global_decl {
+					for field_id in e.children(child) {
+						field := e.node(field_id)
+						if field.kind != .field_decl {
+							continue
+						}
+						e.global_inits << GlobalEntry{
+							name:         field.value
+							typ:          field.typ
+							default_node: if field.children_count > 0 {
+								e.child(field, 0)
+							} else {
+								flat.empty_node
+							}
+							module_name:  module_name
+							file_name:    file_name
+						}
+					}
+				}
+				.enum_decl {
+					e.type_names[module_name][child.value] = true
+					mut next_value := if child.typ == 'flag' { i64(1) } else { i64(0) }
+					for field_id in e.children(child) {
+						field := e.node(field_id)
+						if field.kind != .enum_field {
+							continue
+						}
+						value := if field.children_count > 0 {
+							e.value_as_int(e.eval_expr(e.child(field, 0))!)!
+						} else {
+							next_value
+						}
+						e.consts[module_name][field.value] = ConstEntry{
+							node:        field_id
+							module_name: module_name
+							file_name:   file_name
+							cached:      true
+							value:       Value(value)
+						}
+						e.consts[module_name]['${child.value}.${field.value}'] = ConstEntry{
+							node:        field_id
+							module_name: module_name
+							file_name:   file_name
+							cached:      true
+							value:       Value(value)
+						}
+						next_value = if child.typ == 'flag' {
+							if value <= 0 { i64(1) } else { value * 2 }
+						} else {
+							value + 1
+						}
+					}
+				}
+				.fn_decl {
+					e.register_function(module_name, file_name, child_id, child)
+				}
+				.struct_decl {
+					e.type_names[module_name][child.value] = true
+					mut fields := []FieldInfo{}
+					for field_id in e.children(child) {
+						field := e.node(field_id)
+						if field.kind == .field_decl {
+							fields << FieldInfo{
+								name:         field.value
+								typ:          field.typ
+								default_node: if field.children_count > 0 {
+									e.child(field, 0)
+								} else {
+									flat.empty_node
+								}
+								module_name:  module_name
+								file_name:    file_name
+							}
+						}
+					}
+					info := StructInfo{
+						module_name: module_name
+						name:        child.value
+						fields:      fields
+					}
+					qualified_name := e.qualify_type_name(module_name, child.value)
+					e.structs[qualified_name] = info
+					if module_name in ['main', 'builtin'] {
+						e.structs[child.value] = info
+					}
+				}
+				.type_decl {
+					e.type_names[module_name][child.value] = true
+					if child.children_count > 0 {
+						mut variants := []string{}
+						for variant_id in e.children(child) {
+							variant := e.node(variant_id)
+							variants << e.qualify_type_name(module_name, variant.value)
+						}
+						qualified_name := e.qualify_type_name(module_name, child.value)
+						e.sum_types[qualified_name] = variants
+						if module_name in ['main', 'builtin'] {
+							e.sum_types[child.value] = variants
+						}
+					} else if child.typ.len > 0 {
+						info := TypeAliasInfo{
+							module_name: module_name
+							target:      child.typ
+						}
+						qualified_name := e.qualify_type_name(module_name, child.value)
+						e.type_aliases[qualified_name] = info
+						if module_name in ['main', 'builtin'] {
+							e.type_aliases[child.value] = info
+						}
+					}
+				}
+				else {}
+			}
+		}
+		e.file_import_alias[file_name] = import_aliases.clone()
+		_ = file_id
+	}
+	e.evaluate_global_inits()!
+	if 'main' !in e.functions || 'main' !in e.functions['main'] {
+		return error('v3.eval: missing main.main entry point')
+	}
+}
+
+fn (mut e Eval) evaluate_global_inits() ! {
+	for entry in e.global_inits {
+		e.call_stack << CallFrame{
+			module_name: entry.module_name
+			file_name:   entry.file_name
+			fn_name:     '<global ${entry.name}>'
+		}
+		value := if int(entry.default_node) >= 0 {
+			e.eval_expr(entry.default_node)!
+		} else {
+			e.zero_value_for_type_name_in_module(entry.typ, entry.module_name)
+		}
+		e.call_stack.delete(e.call_stack.len - 1)
+		e.globals[entry.module_name][entry.name] = e.adapt_value_to_type_name(value, entry.typ)
+	}
+}
+
+fn (mut e Eval) register_function(module_name string, file_name string, id flat.NodeId, node &flat.Node) {
+	def := FunctionDef{
+		node:        id
+		name:        node.value
+		module_name: module_name
+		file_name:   file_name
+	}
+	e.functions[module_name][node.value] = def
+	if module_name != 'main' && module_name != 'builtin' {
+		e.functions[module_name]['${module_name}.${node.value}'] = def
+	}
+	if node.value.contains('.') {
+		short := node.value.all_after_last('.')
+		receiver := node.value.all_before_last('.').all_after_last('.')
+		e.functions[module_name]['${receiver}.${short}'] = def
+	}
+}
+
+fn (mut e Eval) run_inits() ! {
+	mut visited := map[string]bool{}
+	mut visiting := map[string]bool{}
+	e.run_module_init('main', mut visited, mut visiting)!
+	for module_name in e.module_order {
+		e.run_module_init(module_name, mut visited, mut visiting)!
+	}
+}
+
+fn (mut e Eval) run_module_init(module_name string, mut visited map[string]bool, mut visiting map[string]bool) ! {
+	if module_name in visited {
+		return
+	}
+	if module_name in visiting {
+		return
+	}
+	visiting[module_name] = true
+	if module_name in e.module_imports {
+		for imported_module in e.module_imports[module_name] {
+			e.run_module_init(imported_module, mut visited, mut visiting)!
+		}
+	}
+	visiting.delete(module_name)
+	visited[module_name] = true
+	if module_name in e.functions && 'init' in e.functions[module_name] {
+		e.call_function(module_name, 'init', []Value{})!
+	}
+}
+
+fn (mut e Eval) open_scope() {
+	e.scopes << ScopeFrame{
+		vars:        map[string]Value{}
+		types:       map[string]string{}
+		defer_stmts: []flat.NodeId{}
+	}
+}
+
+fn (mut e Eval) close_scope() ! {
+	if e.scopes.len > 0 {
+		e.run_deferred_stmts()!
+		e.scopes.delete(e.scopes.len - 1)
+	}
+}
+
+fn (mut e Eval) declare_var(name string, value Value) {
+	e.declare_var_typed(name, value, '')
+}
+
+fn (mut e Eval) declare_var_typed(name string, value Value, type_name string) {
+	if name == '_' {
+		return
+	}
+	if e.scopes.len == 0 {
+		e.open_scope()
+	}
+	e.scopes[e.scopes.len - 1].vars[name] = value
+	normalized := e.normalize_type_name(type_name)
+	if normalized.len > 0 {
+		e.scopes[e.scopes.len - 1].types[name] = normalized
+	}
+}
+
+fn (mut e Eval) set_var(name string, value Value) ! {
+	if name == '_' {
+		return
+	}
+	for i := e.scopes.len - 1; i >= 0; i-- {
+		if name in e.scopes[i].vars {
+			e.scopes[i].vars[name] = value
+			return
+		}
+	}
+	module_name := e.current_module_name()
+	if module_name in e.globals && name in e.globals[module_name] {
+		e.globals[module_name][name] = value
+		return
+	}
+	return e.unknown_variable_error(name)
+}
+
+fn (mut e Eval) set_var_type(name string, type_name string) {
+	normalized := e.normalize_type_name(type_name)
+	if normalized.len == 0 {
+		return
+	}
+	for i := e.scopes.len - 1; i >= 0; i-- {
+		if name in e.scopes[i].vars {
+			e.scopes[i].types[name] = normalized
+			return
+		}
+	}
+}
+
+fn (e &Eval) lookup_var(name string) MaybeValue {
+	for i := e.scopes.len - 1; i >= 0; i-- {
+		if name in e.scopes[i].vars {
+			return MaybeValue{
+				found: true
+				value: e.scopes[i].vars[name] or { void_value() }
+			}
+		}
+	}
+	module_name := e.current_module_name()
+	if module_name in e.globals && name in e.globals[module_name] {
+		return MaybeValue{
+			found: true
+			value: e.globals[module_name][name] or { void_value() }
+		}
+	}
+	return MaybeValue{}
+}
+
+fn (e &Eval) lookup_var_type(name string) ?string {
+	for i := e.scopes.len - 1; i >= 0; i-- {
+		if name in e.scopes[i].types {
+			return e.scopes[i].types[name]
+		}
+	}
+	return none
+}
+
+fn (e &Eval) current_module_name() string {
+	if e.call_stack.len == 0 {
+		return 'main'
+	}
+	return e.call_stack[e.call_stack.len - 1].module_name
+}
+
+fn (e &Eval) current_file_name() string {
+	if e.call_stack.len == 0 {
+		return ''
+	}
+	return e.call_stack[e.call_stack.len - 1].file_name
+}
+
+fn (e &Eval) current_function_label() string {
+	if e.call_stack.len == 0 {
+		return '<top-level>'
+	}
+	frame := e.call_stack[e.call_stack.len - 1]
+	return '${frame.module_name}.${frame.fn_name}'
+}
+
+fn (e &Eval) call_stack_trace() string {
+	return e.call_stack.map('${it.module_name}.${it.fn_name}').join(' -> ')
+}
+
+fn (e &Eval) unknown_variable_error(name string) IError {
+	return error('v3.eval: unknown variable `${name}` in `${e.current_function_label()}` stack `${e.call_stack_trace()}`')
+}
+
+fn (mut e Eval) call_function(module_name string, fn_name string, args []Value) !CallResult {
+	builtin := e.maybe_call_builtin(module_name, fn_name, args)!
+	if builtin.found {
+		return CallResult{
+			values: [builtin.value]
+		}
+	}
+	target_module := if module_name == '' { e.current_module_name() } else { module_name }
+	if target_module !in e.functions {
+		return error('v3.eval: unknown module `${target_module}`')
+	}
+	if fn_name !in e.functions[target_module] {
+		return error('v3.eval: unknown function `${target_module}.${fn_name}`')
+	}
+	def := e.functions[target_module][fn_name]
+	node := e.node(def.node)
+	mut params := []flat.NodeId{}
+	mut body_start := 0
+	for child_id in e.children(node) {
+		child := e.node(child_id)
+		if child.kind == .param {
+			params << child_id
+			body_start++
+			continue
+		}
+		break
+	}
+	min_args := e.minimum_arg_count(params)
+	if args.len < min_args {
+		return error('v3.eval: `${target_module}.${fn_name}` expected ${min_args} arguments, got ${args.len}')
+	}
+	e.call_stack << CallFrame{
+		module_name: target_module
+		file_name:   def.file_name
+		fn_name:     fn_name
+	}
+	e.open_scope()
+	e.bind_call_params(params, args)!
+	mut body_ids := e.children(node)
+	if body_start > 0 {
+		body_ids = body_ids[body_start..].clone()
+	}
+	signal := e.exec_stmts(body_ids)!
+	e.run_deferred_stmts()!
+	mutated_args := e.collect_mutated_param_args(params, args)
+	e.close_scope()!
+	e.call_stack.delete(e.call_stack.len - 1)
+	if signal.kind == .return_ {
+		return CallResult{
+			values:       e.adapt_return_values(signal.values, node.typ)
+			mutated_args: mutated_args
+		}
+	}
+	if signal.kind != .normal {
+		return error('v3.eval: unexpected `${signal.kind}` escaped `${target_module}.${fn_name}`')
+	}
+	return CallResult{
+		values:       [void_value()]
+		mutated_args: mutated_args
+	}
+}
+
+fn (mut e Eval) exec_stmts(stmts []flat.NodeId) !FlowSignal {
+	mut i := 0
+	for i < stmts.len {
+		stmt_id := stmts[i]
+		if int(stmt_id) >= 0 {
+			node := e.node(stmt_id)
+			if node.kind == .label_stmt && i + 1 < stmts.len {
+				next_id := stmts[i + 1]
+				if int(next_id) >= 0 {
+					next_node := e.node(next_id)
+					if next_node.kind == .for_stmt {
+						signal := e.exec_for(next_node, node.value)!
+						if signal.kind != .normal {
+							return signal
+						}
+						i += 2
+						continue
+					}
+					if next_node.kind == .for_in_stmt {
+						signal := e.exec_for_in(next_node, node.value)!
+						if signal.kind != .normal {
+							return signal
+						}
+						i += 2
+						continue
+					}
+				}
+			}
+		}
+		signal := e.exec_stmt(stmt_id)!
+		if signal.kind != .normal {
+			return signal
+		}
+		i++
+	}
+	return normal_flow()
+}
+
+fn (mut e Eval) exec_block(node &flat.Node) !FlowSignal {
+	e.open_scope()
+	signal := e.exec_stmts(e.children(node))!
+	e.close_scope()!
+	return signal
+}
+
+fn (mut e Eval) exec_stmt(id flat.NodeId) !FlowSignal {
+	if int(id) < 0 {
+		return normal_flow()
+	}
+	node := e.node(id)
+	match node.kind {
+		.block {
+			return e.exec_block(node)
+		}
+		.expr_stmt {
+			if node.children_count > 0 {
+				expr_id := e.child(node, 0)
+				expr := e.node(expr_id)
+				if expr.kind == .infix && expr.op == .left_shift {
+					e.exec_array_append(expr)!
+				} else {
+					signal := e.eval_expr_flow(expr_id)!
+					if signal.kind != .normal {
+						return signal
+					}
+				}
+			}
+			return normal_flow()
+		}
+		.decl_assign {
+			return e.exec_assign(node, true)
+		}
+		.assign, .selector_assign, .index_assign {
+			return e.exec_assign(node, false)
+		}
+		.return_stmt {
+			mut values := []Value{}
+			for child_id in e.children(node) {
+				signal := e.eval_expr_flow(child_id)!
+				if signal.kind != .normal {
+					return signal
+				}
+				expr_values := flow_values_or_void(signal.values)
+				if expr_values.len > 1 {
+					values << expr_values
+					continue
+				}
+				value := expr_values[0]
+				if value is TupleValue {
+					values << value.values
+				} else {
+					values << value
+				}
+			}
+			if values.len == 0 {
+				values << void_value()
+			}
+			return FlowSignal{
+				kind:   .return_
+				values: values
+			}
+		}
+		.if_expr {
+			return e.exec_if(node)
+		}
+		.match_stmt {
+			return e.exec_match(node)
+		}
+		.for_stmt {
+			return e.exec_for(node, '')
+		}
+		.for_in_stmt {
+			return e.exec_for_in(node, '')
+		}
+		.break_stmt {
+			return FlowSignal{
+				kind:  .break_
+				label: node.value
+			}
+		}
+		.continue_stmt {
+			return FlowSignal{
+				kind:  .continue_
+				label: node.value
+			}
+		}
+		.assert_stmt {
+			cond_signal := e.eval_expr_flow(e.child(node, 0))!
+			if cond_signal.kind != .normal {
+				return cond_signal
+			}
+			cond := flow_value(cond_signal)
+			if !e.value_as_bool(cond)! {
+				mut msg := 'assertion failed'
+				if node.children_count > 1 {
+					msg = e.value_string(e.eval_expr(e.child(node, 1))!)
+				}
+				return error('v3.eval: ${msg}')
+			}
+			return normal_flow()
+		}
+		.defer_stmt {
+			e.register_defer_stmt(id)
+			return normal_flow()
+		}
+		.asm_stmt, .empty, .label_stmt {
+			return normal_flow()
+		}
+		else {
+			_ = e.eval_expr(id)!
+			return normal_flow()
+		}
+	}
+}
+
+fn (mut e Eval) register_defer_stmt(id flat.NodeId) {
+	if e.scopes.len == 0 {
+		e.open_scope()
+	}
+	scope_idx := e.scopes.len - 1
+	e.scopes[scope_idx].defer_stmts << id
+}
+
+fn (mut e Eval) run_deferred_stmts() ! {
+	if e.scopes.len == 0 {
+		return
+	}
+	scope_idx := e.scopes.len - 1
+	defer_stmts := e.scopes[scope_idx].defer_stmts.clone()
+	e.scopes[scope_idx].defer_stmts = []flat.NodeId{}
+	for i := defer_stmts.len; i > 0; i-- {
+		defer_id := defer_stmts[i - 1]
+		defer_node := e.node(defer_id)
+		for child_id in e.children(defer_node) {
+			signal := e.exec_stmt(child_id)!
+			if signal.kind != .normal {
+				return error('v3.eval: unexpected `${signal.kind}` escaped defer')
+			}
+		}
+	}
+}
+
+fn (mut e Eval) exec_assign(node &flat.Node, declare bool) !FlowSignal {
+	children := e.children(node)
+	if children.len == 0 {
+		return normal_flow()
+	}
+	if children.len == 2 {
+		lhs_id := children[0]
+		rhs_id := children[1]
+		target_type := e.assignment_target_type_name(lhs_id, declare)
+		signal := e.assignment_value_flow(node.op, lhs_id, rhs_id, target_type)!
+		if signal.kind != .normal {
+			return signal
+		}
+		e.assign_target_typed(lhs_id, flow_value(signal), declare, if target_type.len > 0 {
+			target_type
+		} else {
+			e.infer_expr_type_name(rhs_id)
+		})!
+		return normal_flow()
+	}
+	if children.len > 2 {
+		value := e.assignment_value(node.op, children[0], children[1])!
+		mut lhs_ids := [children[0]]
+		for i := 2; i < children.len; i++ {
+			lhs_ids << children[i]
+		}
+		if value is TupleValue {
+			for i, lhs_id in lhs_ids {
+				item := if i < value.values.len { value.values[i] } else { void_value() }
+				e.assign_target(lhs_id, item, declare)!
+			}
+			return normal_flow()
+		}
+		if children.len % 2 == 1 {
+			for i, lhs_id in lhs_ids {
+				item := if i == 0 { value } else { void_value() }
+				e.assign_target(lhs_id, item, declare)!
+			}
+			return normal_flow()
+		}
+		mut assign_lhs_ids := [children[0]]
+		mut values := [value]
+		mut i := 2
+		for i < children.len {
+			lhs_id := children[i]
+			rhs_id := if i + 1 < children.len { children[i + 1] } else { flat.empty_node }
+			item := if int(rhs_id) >= 0 {
+				e.assignment_value(node.op, lhs_id, rhs_id)!
+			} else {
+				void_value()
+			}
+			assign_lhs_ids << lhs_id
+			values << item
+			i += 2
+		}
+		for idx, lhs_id in assign_lhs_ids {
+			e.assign_target(lhs_id, values[idx], declare)!
+		}
+		return normal_flow()
+	}
+	mut i := 0
+	for i < children.len {
+		lhs_id := children[i]
+		rhs_id := if i + 1 < children.len { children[i + 1] } else { flat.empty_node }
+		value := if int(rhs_id) >= 0 {
+			e.assignment_value(node.op, lhs_id, rhs_id)!
+		} else {
+			void_value()
+		}
+		e.assign_target(lhs_id, value, declare)!
+		i += 2
+	}
+	return normal_flow()
+}
+
+fn (mut e Eval) assignment_value(op flat.Op, lhs_id flat.NodeId, rhs_id flat.NodeId) !Value {
+	rhs := e.eval_expr(rhs_id)!
+	if op == .assign || op == .none {
+		return rhs
+	}
+	left := e.eval_expr(lhs_id) or { e.zero_value_like(rhs) }
+	return match op {
+		.plus_assign { e.apply_infix(.plus, left, rhs)! }
+		.minus_assign { e.apply_infix(.minus, left, rhs)! }
+		.mul_assign { e.apply_infix(.mul, left, rhs)! }
+		.div_assign { e.apply_infix(.div, left, rhs)! }
+		.mod_assign { e.apply_infix(.mod, left, rhs)! }
+		.amp_assign { e.apply_infix(.amp, left, rhs)! }
+		.pipe_assign { e.apply_infix(.pipe, left, rhs)! }
+		.xor_assign { e.apply_infix(.xor, left, rhs)! }
+		.left_shift_assign { e.apply_infix(.left_shift, left, rhs)! }
+		.right_shift_assign { e.apply_infix(.right_shift, left, rhs)! }
+		.right_shift_unsigned_assign { e.apply_infix(.right_shift_unsigned, left, rhs)! }
+		else { rhs }
+	}
+}
+
+fn (mut e Eval) assignment_value_flow(op flat.Op, lhs_id flat.NodeId, rhs_id flat.NodeId, expected_type string) !FlowSignal {
+	rhs_signal := e.eval_expr_flow_expected(rhs_id, expected_type)!
+	if rhs_signal.kind != .normal {
+		return rhs_signal
+	}
+	rhs := flow_value(rhs_signal)
+	if op == .assign || op == .none {
+		return FlowSignal{
+			values: [rhs]
+		}
+	}
+	left := e.eval_expr(lhs_id) or { e.zero_value_like(rhs) }
+	return FlowSignal{
+		values: [
+			match op {
+				.plus_assign { e.apply_infix(.plus, left, rhs)! }
+				.minus_assign { e.apply_infix(.minus, left, rhs)! }
+				.mul_assign { e.apply_infix(.mul, left, rhs)! }
+				.div_assign { e.apply_infix(.div, left, rhs)! }
+				.mod_assign { e.apply_infix(.mod, left, rhs)! }
+				.amp_assign { e.apply_infix(.amp, left, rhs)! }
+				.pipe_assign { e.apply_infix(.pipe, left, rhs)! }
+				.xor_assign { e.apply_infix(.xor, left, rhs)! }
+				.left_shift_assign { e.apply_infix(.left_shift, left, rhs)! }
+				.right_shift_assign { e.apply_infix(.right_shift, left, rhs)! }
+				.right_shift_unsigned_assign { e.apply_infix(.right_shift_unsigned, left, rhs)! }
+				else { rhs }
+			},
+		]
+	}
+}
+
+fn (mut e Eval) assignment_target_type_name(lhs_id flat.NodeId, declare bool) string {
+	if int(lhs_id) < 0 {
+		return ''
+	}
+	node := e.node(lhs_id)
+	match node.kind {
+		.ident {
+			if !declare {
+				if typ := e.lookup_var_type(node.value) {
+					return typ
+				}
+			}
+			return node.typ
+		}
+		.selector {
+			base := e.eval_expr(e.child(node, 0)) or { return '' }
+			if base is StructValue {
+				return e.struct_field_type_name(base, node.value)
+			}
+		}
+		.index {
+			container := e.eval_expr(e.child(node, 0)) or { return '' }
+			if container is ArrayValue {
+				return container.elem_type_name
+			}
+			if container is MapValue {
+				return container.value_type_name
+			}
+		}
+		else {}
+	}
+
+	return ''
+}
+
+fn flow_value(signal FlowSignal) Value {
+	if signal.values.len > 0 {
+		return signal.values[0]
+	}
+	return void_value()
+}
+
+fn flow_values_value(values []Value) Value {
+	if values.len == 0 {
+		return void_value()
+	}
+	if values.len == 1 {
+		return values[0]
+	}
+	return TupleValue{
+		values: values.clone()
+	}
+}
+
+fn flow_values_or_void(values []Value) []Value {
+	if values.len > 0 {
+		return values.clone()
+	}
+	return [void_value()]
+}
+
+fn (mut e Eval) assign_target(id flat.NodeId, value Value, declare bool) ! {
+	e.assign_target_typed(id, value, declare, '')!
+}
+
+fn (mut e Eval) assign_target_typed(id flat.NodeId, value Value, declare bool, type_name string) ! {
+	node := e.node(id)
+	match node.kind {
+		.ident {
+			if declare {
+				decl_type := if type_name.len > 0 { type_name } else { node.typ }
+				e.declare_var_typed(node.value, e.adapt_value_to_type_name(value, decl_type),
+					decl_type)
+			} else {
+				target_type := if existing := e.lookup_var_type(node.value) {
+					existing
+				} else {
+					if type_name.len > 0 { type_name } else { node.typ }
+				}
+				e.set_var(node.value, e.adapt_value_to_type_name(value, target_type))!
+				e.set_var_type(node.value, target_type)
+			}
+		}
+		.selector {
+			e.update_selector_target(node, value)!
+		}
+		.index {
+			e.update_index_target(node, value)!
+		}
+		else {
+			return error('v3.eval: unsupported assignment target `${node.kind}`')
+		}
+	}
+}
+
+fn (e &Eval) infer_expr_type_name(id flat.NodeId) string {
+	if int(id) < 0 {
+		return ''
+	}
+	node := e.node(id)
+	if node.kind in [.struct_init, .cast_expr, .as_expr] {
+		return e.normalize_type_name(node.value)
+	}
+	if node.typ.len > 0 {
+		return e.normalize_type_name(node.typ)
+	}
+	match node.kind {
+		.int_literal {
+			return 'int'
+		}
+		.float_literal {
+			return 'f64'
+		}
+		.bool_literal {
+			return 'bool'
+		}
+		.char_literal {
+			return 'char'
+		}
+		.string_literal, .string_interp {
+			return 'string'
+		}
+		.ident {
+			if typ := e.lookup_var_type(node.value) {
+				return typ
+			}
+		}
+		.selector {
+			if node.children_count > 0 {
+				if typ := e.type_value_name_from_expr(e.child(node, 0)) {
+					return typ
+				}
+			}
+		}
+		.array_literal {
+			elem_type_name := e.array_literal_elem_type_name(node)
+			if elem_type_name.len > 0 {
+				return '[]${elem_type_name}'
+			}
+		}
+		else {}
+	}
+
+	return ''
+}
+
+fn (e &Eval) array_literal_elem_type_name(node &flat.Node) string {
+	if node.typ.len > 0 {
+		return array_elem_type_name_from_type(node.typ)
+	}
+	if node.value.len > 0 {
+		return array_elem_type_name_from_type(node.value)
+	}
+	if node.children_count > 0 {
+		return e.infer_expr_type_name(e.child(node, 0))
+	}
+	return ''
+}
+
+fn array_elem_type_name_from_type(type_name string) string {
+	if type_name.starts_with('[]') {
+		return type_name[2..]
+	}
+	if is_fixed_array_type_name(type_name) {
+		return fixed_array_elem_type_name(type_name)
+	}
+	return ''
+}
+
+fn (mut e Eval) update_target(id flat.NodeId, value Value) ! {
+	e.assign_target(id, value, false)!
+}
+
+fn (mut e Eval) update_index_target(node &flat.Node, value Value) ! {
+	base_id := e.child(node, 0)
+	index := e.eval_expr(e.child(node, 1))!
+	container := e.eval_expr(base_id)!
+	new_container := e.set_index_value(container, index, value)!
+	e.update_target(base_id, new_container)!
+}
+
+fn (mut e Eval) update_selector_target(node &flat.Node, value Value) ! {
+	base_id := e.child(node, 0)
+	container := e.eval_expr(base_id)!
+	new_container := e.set_selector_value(container, node.value, value)!
+	e.update_target(base_id, new_container)!
+}
+
+fn (mut e Eval) set_index_value(container Value, index Value, value Value) !Value {
+	match container {
+		ArrayValue {
+			mut arr := ArrayValue{
+				elem_type_name: container.elem_type_name
+				values:         container.values.clone()
+			}
+			idx := int(e.value_as_int(index)!)
+			if idx < 0 || idx >= arr.values.len {
+				return error('v3.eval: array index out of bounds')
+			}
+			arr.values[idx] = e.adapt_value_to_type_name(value, arr.elem_type_name)
+			return arr
+		}
+		MapValue {
+			return e.map_set_value(container, index, value)
+		}
+		else {
+			return error('v3.eval: indexed assignment expects array or map')
+		}
+	}
+}
+
+fn (mut e Eval) set_selector_value(container Value, field_name string, value Value) !Value {
+	match container {
+		StructValue {
+			mut st := container
+			st.fields[field_name] = e.adapt_value_to_type_name(value, e.struct_field_type_name(container,
+				field_name))
+			return st
+		}
+		SumValue {
+			mut sv := container
+			sv.payload = e.set_selector_value(sv.payload, field_name, value)!
+			return sv
+		}
+		else {
+			return error('v3.eval: selector assignment expects struct, got `${e.runtime_type_name(container)}`')
+		}
+	}
+}
+
+fn (mut e Eval) exec_array_append(node &flat.Node) ! {
+	lhs_id := e.child(node, 0)
+	rhs_id := e.child(node, 1)
+	rhs := e.eval_expr(rhs_id)!
+	current := e.eval_expr(lhs_id)!
+	if current !is ArrayValue {
+		return error('v3.eval: `<<` is only supported for arrays')
+	}
+	mut arr := current as ArrayValue
+	if rhs is ArrayValue && e.array_append_rhs_spreads(rhs_id, rhs, arr.elem_type_name) {
+		for item in rhs.values {
+			arr.values << e.adapt_value_to_type_name(item, arr.elem_type_name)
+		}
+	} else {
+		arr.values << e.adapt_value_to_type_name(rhs, arr.elem_type_name)
+	}
+	e.update_target(lhs_id, arr)!
+}
+
+fn (e &Eval) array_append_rhs_spreads(rhs_id flat.NodeId, rhs ArrayValue, elem_type_name string) bool {
+	rhs_type_name := e.infer_expr_type_name(rhs_id)
+	if rhs_type_name.len > 0 {
+		return e.array_type_spreads_into_elem(rhs_type_name, elem_type_name)
+	}
+	if rhs.elem_type_name.len > 0 {
+		return e.type_name_matches(rhs.elem_type_name, elem_type_name)
+	}
+	return false
+}
+
+fn (e &Eval) array_type_spreads_into_elem(array_type_name string, elem_type_name string) bool {
+	rhs_elem_type_name := array_elem_type_name_from_type(array_type_name)
+	if rhs_elem_type_name.len == 0 {
+		return false
+	}
+	return e.type_name_matches(rhs_elem_type_name, elem_type_name)
+}
+
+fn (mut e Eval) exec_if(node &flat.Node) !FlowSignal {
+	if node.children_count < 2 {
+		return normal_flow()
+	}
+	cond_id := e.child(node, 0)
+	cond_is_guard := e.node(cond_id).kind == .decl_assign
+	if cond_is_guard {
+		e.open_scope()
+	}
+	cond_signal := e.eval_condition_flow(cond_id)!
+	if cond_signal.kind != .normal {
+		if cond_is_guard {
+			e.close_scope()!
+		}
+		return cond_signal
+	}
+	if e.value_as_bool(flow_value(cond_signal))! {
+		mut smartcast_scope := false
+		if !cond_is_guard {
+			if binding := e.smartcast_binding_from_condition(cond_id) {
+				e.open_scope()
+				e.declare_var_typed(binding.name, binding.value, binding.type_name)
+				smartcast_scope = true
+			}
+		}
+		signal := e.exec_stmt(e.child(node, 1))!
+		if smartcast_scope {
+			e.close_scope()!
+		}
+		if cond_is_guard {
+			e.close_scope()!
+		}
+		return signal
+	}
+	if cond_is_guard {
+		e.close_scope()!
+	}
+	if node.children_count > 2 {
+		return e.exec_stmt(e.child(node, 2))
+	}
+	return normal_flow()
+}
+
+fn (mut e Eval) smartcast_binding_from_condition(cond_id flat.NodeId) ?SmartcastBinding {
+	if int(cond_id) < 0 {
+		return none
+	}
+	node := e.node(cond_id)
+	if node.kind == .paren {
+		return e.smartcast_binding_from_condition(e.child(node, 0))
+	}
+	if node.kind == .infix && node.op == .logical_and {
+		return e.smartcast_binding_from_condition(e.child(node, 0))
+	}
+	if node.kind != .is_expr || node.children_count == 0 {
+		return none
+	}
+	left_id := e.child(node, 0)
+	left := e.node(left_id)
+	if left.kind != .ident {
+		return none
+	}
+	found := e.lookup_var(left.value)
+	if !found.found {
+		return none
+	}
+	if value := e.smartcast_value(found.value, node.value) {
+		return SmartcastBinding{
+			name:      left.value
+			value:     value
+			type_name: e.normalize_type_name(node.value)
+		}
+	}
+	return none
+}
+
+fn (e &Eval) smartcast_value(value Value, target_type string) ?Value {
+	if value is SumValue {
+		if e.type_name_matches(value.variant_name, target_type)
+			|| e.value_matches_type_name(value.payload, target_type) {
+			return value.payload
+		}
+	}
+	return none
+}
+
+fn (mut e Eval) eval_condition(id flat.NodeId) !bool {
+	signal := e.eval_condition_flow(id)!
+	return e.value_as_bool(flow_value(signal))
+}
+
+fn (mut e Eval) eval_condition_flow(id flat.NodeId) !FlowSignal {
+	node := e.node(id)
+	if node.kind == .decl_assign {
+		rhs_id := e.child(node, 1)
+		rhs_signal := e.eval_expr_flow(rhs_id)!
+		if rhs_signal.kind != .normal {
+			return rhs_signal
+		}
+		value := flow_value(rhs_signal)
+		ok := e.value_is_truthy(value)
+		if ok {
+			e.assign_target_typed(e.child(node, 0), e.unwrap_option_like(value), true,
+				e.infer_expr_type_name(rhs_id))!
+		}
+		return value_flow(Value(ok))
+	}
+	signal := e.eval_expr_flow(id)!
+	if signal.kind != .normal {
+		return signal
+	}
+	return value_flow(Value(e.value_as_bool(flow_value(signal))!))
+}
+
+fn (e &Eval) unwrap_option_like(value Value) Value {
+	if value is StructValue {
+		if 'data' in value.fields {
+			return value.fields['data'] or { void_value() }
+		}
+	}
+	return value
+}
+
+fn (e &Eval) value_is_truthy(value Value) bool {
+	match value {
+		bool {
+			return value
+		}
+		VoidValue {
+			return false
+		}
+		StructValue {
+			state := value.fields['state'] or { void_value() }
+			if state is i64 {
+				return state == 0
+			}
+			is_error := value.fields['is_error'] or { void_value() }
+			if is_error is bool {
+				return !is_error
+			}
+			return true
+		}
+		else {
+			return true
+		}
+	}
+}
+
+fn (mut e Eval) exec_for(node &flat.Node, loop_label string) !FlowSignal {
+	if node.children_count < 3 {
+		return normal_flow()
+	}
+	init_id := e.child(node, 0)
+	cond_id := e.child(node, 1)
+	post_id := e.child(node, 2)
+	e.open_scope()
+	if int(init_id) >= 0 && e.node(init_id).kind != .empty {
+		init_signal := e.exec_stmt(init_id)!
+		if init_signal.kind != .normal {
+			e.close_scope()!
+			return init_signal
+		}
+	}
+	body := e.children(node)
+	for {
+		if int(cond_id) >= 0 && e.node(cond_id).kind != .empty {
+			cond_signal := e.eval_condition_flow(cond_id)!
+			if cond_signal.kind != .normal {
+				e.close_scope()!
+				return cond_signal
+			}
+			if !e.value_as_bool(flow_value(cond_signal))! {
+				break
+			}
+		}
+		e.open_scope()
+		signal := e.exec_stmts(body[3..])!
+		e.close_scope()!
+		if signal.kind == .break_ {
+			if e.flow_targets_loop(signal, loop_label) {
+				e.close_scope()!
+				return normal_flow()
+			}
+			e.close_scope()!
+			return signal
+		}
+		if signal.kind == .continue_ {
+			if !e.flow_targets_loop(signal, loop_label) {
+				e.close_scope()!
+				return signal
+			}
+		}
+		if signal.kind == .return_ {
+			e.close_scope()!
+			return signal
+		}
+		if int(post_id) >= 0 && e.node(post_id).kind != .empty {
+			post_signal := e.exec_stmt(post_id)!
+			if post_signal.kind != .normal {
+				e.close_scope()!
+				return post_signal
+			}
+		}
+	}
+	e.close_scope()!
+	return normal_flow()
+}
+
+fn (mut e Eval) exec_for_in(node &flat.Node, loop_label string) !FlowSignal {
+	header_count := if node.value.int() > 0 { node.value.int() } else { 3 }
+	key_id := e.child(node, 0)
+	val_id := e.child(node, 1)
+	container_signal := e.eval_expr_flow(e.child(node, 2))!
+	if container_signal.kind != .normal {
+		return container_signal
+	}
+	container := flow_value(container_signal)
+	body := e.children(node)[header_count..]
+	if header_count == 4 {
+		start := e.value_as_int(container)!
+		end_signal := e.eval_expr_flow(e.child(node, 3))!
+		if end_signal.kind != .normal {
+			return end_signal
+		}
+		end := e.value_as_int(flow_value(end_signal))!
+		for i := start; i < end; i++ {
+			e.open_scope()
+			e.assign_loop_vars(key_id, val_id, Value(i), void_value(), false)
+			signal := e.exec_stmts(body)!
+			e.close_scope()!
+			if signal.kind == .break_ {
+				if e.flow_targets_loop(signal, loop_label) {
+					return normal_flow()
+				}
+				return signal
+			}
+			if signal.kind == .continue_ {
+				if e.flow_targets_loop(signal, loop_label) {
+					continue
+				}
+				return signal
+			}
+			if signal.kind == .return_ {
+				return signal
+			}
+		}
+		return normal_flow()
+	}
+	match container {
+		RangeValue {
+			last := if container.inclusive { container.end + 1 } else { container.end }
+			for i := container.start; i < last; i++ {
+				e.open_scope()
+				e.assign_loop_vars(key_id, val_id, Value(i), void_value(), false)
+				signal := e.exec_stmts(body)!
+				e.close_scope()!
+				if signal.kind == .break_ {
+					if e.flow_targets_loop(signal, loop_label) {
+						return normal_flow()
+					}
+					return signal
+				}
+				if signal.kind == .continue_ {
+					if e.flow_targets_loop(signal, loop_label) {
+						continue
+					}
+					return signal
+				}
+				if signal.kind == .return_ {
+					return signal
+				}
+			}
+		}
+		ArrayValue {
+			mut arr := ArrayValue{
+				elem_type_name: container.elem_type_name
+				values:         container.values.clone()
+			}
+			is_mut_loop := node.op == .amp
+			for i, item in arr.values {
+				e.open_scope()
+				e.assign_loop_vars(key_id, val_id, Value(i64(i)), item, true)
+				signal := e.exec_stmts(body)!
+				if is_mut_loop {
+					if value := e.loop_mut_value(key_id, val_id, true) {
+						arr.values[i] = e.adapt_value_to_type_name(value, arr.elem_type_name)
+						e.update_target(e.child(node, 2), arr)!
+					}
+				}
+				e.close_scope()!
+				if signal.kind == .break_ {
+					if e.flow_targets_loop(signal, loop_label) {
+						return normal_flow()
+					}
+					return signal
+				}
+				if signal.kind == .continue_ {
+					if e.flow_targets_loop(signal, loop_label) {
+						continue
+					}
+					return signal
+				}
+				if signal.kind == .return_ {
+					return signal
+				}
+			}
+		}
+		MapValue {
+			mut m := MapValue{
+				key_type_name:   container.key_type_name
+				value_type_name: container.value_type_name
+				default_value:   container.default_value
+				entries:         container.entries.clone()
+			}
+			is_mut_loop := node.op == .amp
+			for i, entry in m.entries {
+				e.open_scope()
+				e.assign_loop_vars(key_id, val_id, entry.key, entry.value, true)
+				signal := e.exec_stmts(body)!
+				if is_mut_loop {
+					if value := e.loop_mut_value(key_id, val_id, true) {
+						m.entries[i].value = e.adapt_value_to_type_name(value, m.value_type_name)
+						e.update_target(e.child(node, 2), m)!
+					}
+				}
+				e.close_scope()!
+				if signal.kind == .break_ {
+					if e.flow_targets_loop(signal, loop_label) {
+						return normal_flow()
+					}
+					return signal
+				}
+				if signal.kind == .continue_ {
+					if e.flow_targets_loop(signal, loop_label) {
+						continue
+					}
+					return signal
+				}
+				if signal.kind == .return_ {
+					return signal
+				}
+			}
+		}
+		string {
+			for i, ch in container {
+				e.open_scope()
+				e.assign_loop_vars(key_id, val_id, Value(i64(i)), Value(i64(ch)), true)
+				signal := e.exec_stmts(body)!
+				e.close_scope()!
+				if signal.kind == .break_ {
+					if e.flow_targets_loop(signal, loop_label) {
+						return normal_flow()
+					}
+					return signal
+				}
+				if signal.kind == .continue_ {
+					if e.flow_targets_loop(signal, loop_label) {
+						continue
+					}
+					return signal
+				}
+				if signal.kind == .return_ {
+					return signal
+				}
+			}
+		}
+		else {
+			return error('v3.eval: unsupported for-in iterable `${e.runtime_type_name(container)}`')
+		}
+	}
+
+	return normal_flow()
+}
+
+fn (e &Eval) flow_targets_loop(signal FlowSignal, loop_label string) bool {
+	return signal.label.len == 0 || signal.label == loop_label
+}
+
+fn (mut e Eval) assign_loop_vars(key_id flat.NodeId, val_id flat.NodeId, key Value, value Value, has_value bool) {
+	if int(val_id) >= 0 && e.node(val_id).kind != .empty {
+		e.assign_target(key_id, key, true) or {}
+		e.assign_target(val_id, value, true) or {}
+	} else if has_value {
+		e.assign_target(key_id, value, true) or {}
+	} else {
+		e.assign_target(key_id, key, true) or {}
+	}
+}
+
+fn (e &Eval) loop_mut_value(key_id flat.NodeId, val_id flat.NodeId, has_value bool) ?Value {
+	mut value_id := key_id
+	if int(val_id) >= 0 && e.node(val_id).kind != .empty {
+		value_id = val_id
+	} else if !has_value {
+		return none
+	}
+	value_node := e.node(value_id)
+	if value_node.kind != .ident {
+		return none
+	}
+	found := e.lookup_var(value_node.value)
+	if !found.found {
+		return none
+	}
+	return found.value
+}
+
+fn (mut e Eval) eval_expr(id flat.NodeId) !Value {
+	if int(id) < 0 {
+		return void_value()
+	}
+	node := e.node(id)
+	match node.kind {
+		.empty {
+			return void_value()
+		}
+		.int_literal {
+			return Value(strconv.parse_int(clean_number_literal(node.value), 0, 64) or { i64(0) })
+		}
+		.float_literal {
+			return Value(strconv.atof64(clean_number_literal(node.value)) or { 0.0 })
+		}
+		.bool_literal {
+			return Value(node.value == 'true')
+		}
+		.char_literal {
+			return Value(e.char_literal_value(node.value))
+		}
+		.string_literal {
+			return Value(node.value)
+		}
+		.string_interp {
+			mut out := ''
+			for child_id in e.children(node) {
+				child := e.node(child_id)
+				if child.kind == .string_literal {
+					out += child.value
+				} else {
+					out += e.value_string(e.eval_expr(child_id)!)
+				}
+			}
+			return Value(out)
+		}
+		.ident {
+			return e.eval_ident(node.value)
+		}
+		.enum_val {
+			return e.lookup_const(e.current_module_name(), node.value) or { Value(i64(0)) }
+		}
+		.paren {
+			return e.eval_expr(e.child(node, 0))
+		}
+		.prefix {
+			return e.eval_prefix(node)
+		}
+		.postfix {
+			return e.eval_postfix(node)
+		}
+		.infix {
+			if node.op == .logical_and {
+				left := e.eval_expr(e.child(node, 0))!
+				if !e.value_as_bool(left)! {
+					return Value(false)
+				}
+				return Value(e.value_as_bool(e.eval_expr(e.child(node, 1))!)!)
+			}
+			if node.op == .logical_or {
+				left := e.eval_expr(e.child(node, 0))!
+				if e.value_as_bool(left)! {
+					return Value(true)
+				}
+				return Value(e.value_as_bool(e.eval_expr(e.child(node, 1))!)!)
+			}
+			return e.apply_infix(node.op, e.eval_expr(e.child(node, 0))!, e.eval_expr(e.child(node,
+				1))!)
+		}
+		.call {
+			return flow_value(e.eval_call_flow(id, node)!)
+		}
+		.selector {
+			return e.eval_selector(node)
+		}
+		.index {
+			return e.eval_index(node)
+		}
+		.if_expr {
+			return e.eval_if_value(node)
+		}
+		.block {
+			return e.eval_block_value(node)
+		}
+		.array_literal {
+			mut values := []Value{}
+			elem_type_name := e.array_literal_elem_type_name(node)
+			for child_id in e.children(node) {
+				values << e.adapt_value_to_type_name(e.eval_expr_expected(child_id, elem_type_name)!,
+					elem_type_name)
+			}
+			return ArrayValue{
+				elem_type_name: elem_type_name
+				values:         values
+			}
+		}
+		.array_init {
+			return e.eval_array_init(node)
+		}
+		.map_init {
+			return e.eval_map_init(node)
+		}
+		.struct_init {
+			return e.eval_struct_init(node)
+		}
+		.assoc {
+			return e.eval_assoc(node)
+		}
+		.range {
+			return RangeValue{
+				start: e.value_as_int(e.eval_expr(e.child(node, 0))!)!
+				end:   e.value_as_int(e.eval_expr(e.child(node, 1))!)!
+			}
+		}
+		.cast_expr, .as_expr {
+			value := e.eval_expr(e.child(node, 0))!
+			return e.cast_value(value, node.value)
+		}
+		.is_expr {
+			value := e.eval_expr(e.child(node, 0))!
+			return Value(e.value_matches_type_name(value, node.value))
+		}
+		.in_expr {
+			left := e.eval_expr(e.child(node, 0))!
+			right := e.eval_expr(e.child(node, 1))!
+			return Value(e.value_in(left, right))
+		}
+		.or_expr {
+			return e.eval_or_expr(node)
+		}
+		.match_stmt {
+			return e.eval_match_value(node)
+		}
+		.none_expr, .nil_literal {
+			return void_value()
+		}
+		.sizeof_expr {
+			return Value(e.sizeof_type_name(node.value))
+		}
+		.typeof_expr {
+			value := e.eval_expr(e.child(node, 0))!
+			return TypeValue{
+				name: e.runtime_type_name(value)
+			}
+		}
+		.fn_literal {
+			return Value(e.eval_fn_literal(id, node)!)
+		}
+		else {
+			return error('v3.eval: unsupported expression `${node.kind}`')
+		}
+	}
+}
+
+fn (mut e Eval) eval_fn_literal(id flat.NodeId, node &flat.Node) !FnValue {
+	mut captures := map[string]Value{}
+	mut capture_types := map[string]string{}
+	for child_id in e.children(node) {
+		child := e.node(child_id)
+		if child.kind != .ident {
+			break
+		}
+		found := e.lookup_var(child.value)
+		if !found.found {
+			return error('v3.eval: unknown captured variable `${child.value}`')
+		}
+		captures[child.value] = found.value
+		if typ := e.lookup_var_type(child.value) {
+			capture_types[child.value] = typ
+		}
+	}
+	return FnValue{
+		node:          id
+		module_name:   e.current_module_name()
+		file_name:     e.current_file_name()
+		captures:      captures
+		capture_types: capture_types
+	}
+}
+
+fn (mut e Eval) eval_expr_flow(id flat.NodeId) !FlowSignal {
+	if int(id) < 0 {
+		return FlowSignal{
+			values: [void_value()]
+		}
+	}
+	node := e.node(id)
+	match node.kind {
+		.or_expr {
+			return e.eval_or_expr_flow(node)
+		}
+		.call {
+			return e.eval_call_flow(id, node)
+		}
+		.index {
+			return e.eval_index_flow(node)
+		}
+		.if_expr {
+			return e.eval_if_value_flow(node)
+		}
+		.match_stmt {
+			return e.eval_match_value_flow(node)
+		}
+		.selector {
+			left_signal := e.eval_expr_flow(e.child(node, 0))!
+			if left_signal.kind != .normal {
+				return left_signal
+			}
+			return value_flow(e.eval_selector_value(flow_value(left_signal), node.value)!)
+		}
+		.paren {
+			return e.eval_expr_flow(e.child(node, 0))
+		}
+		.prefix {
+			value_signal := e.eval_expr_flow(e.child(node, 0))!
+			if value_signal.kind != .normal {
+				return value_signal
+			}
+			return value_flow(e.apply_prefix(node.op, flow_value(value_signal))!)
+		}
+		.infix {
+			return e.eval_infix_flow(node)
+		}
+		.range {
+			start_signal := e.eval_expr_flow(e.child(node, 0))!
+			if start_signal.kind != .normal {
+				return start_signal
+			}
+			end_signal := e.eval_expr_flow(e.child(node, 1))!
+			if end_signal.kind != .normal {
+				return end_signal
+			}
+			return value_flow(RangeValue{
+				start: e.value_as_int(flow_value(start_signal))!
+				end:   e.value_as_int(flow_value(end_signal))!
+			})
+		}
+		.cast_expr, .as_expr {
+			value_signal := e.eval_expr_flow(e.child(node, 0))!
+			if value_signal.kind != .normal {
+				return value_signal
+			}
+			return value_flow(e.cast_value(flow_value(value_signal), node.value)!)
+		}
+		.is_expr {
+			value_signal := e.eval_expr_flow(e.child(node, 0))!
+			if value_signal.kind != .normal {
+				return value_signal
+			}
+			return value_flow(Value(e.value_matches_type_name(flow_value(value_signal), node.value)))
+		}
+		.in_expr {
+			left_signal := e.eval_expr_flow(e.child(node, 0))!
+			if left_signal.kind != .normal {
+				return left_signal
+			}
+			right_signal := e.eval_expr_flow(e.child(node, 1))!
+			if right_signal.kind != .normal {
+				return right_signal
+			}
+			return value_flow(Value(e.value_in(flow_value(left_signal), flow_value(right_signal))))
+		}
+		.array_literal {
+			mut values := []Value{}
+			elem_type_name := e.array_literal_elem_type_name(node)
+			for child_id in e.children(node) {
+				child_signal := e.eval_expr_flow_expected(child_id, elem_type_name)!
+				if child_signal.kind != .normal {
+					return child_signal
+				}
+				values << e.adapt_value_to_type_name(flow_value(child_signal), elem_type_name)
+			}
+			return value_flow(ArrayValue{
+				elem_type_name: elem_type_name
+				values:         values
+			})
+		}
+		else {
+			return FlowSignal{
+				values: [e.eval_expr(id)!]
+			}
+		}
+	}
+}
+
+fn (mut e Eval) eval_expr_expected(id flat.NodeId, expected_type string) !Value {
+	signal := e.eval_expr_flow_expected(id, expected_type)!
+	if signal.kind != .normal {
+		return flow_value(signal)
+	}
+	return flow_value(signal)
+}
+
+fn (mut e Eval) eval_expr_flow_expected(id flat.NodeId, expected_type string) !FlowSignal {
+	if int(id) >= 0 {
+		node := e.node(id)
+		if node.kind == .enum_val && expected_type.len > 0 {
+			if value := e.lookup_enum_value(expected_type, node.value) {
+				return value_flow(value)
+			}
+		}
+	}
+	return e.eval_expr_flow(id)
+}
+
+fn (mut e Eval) eval_infix_flow(node &flat.Node) !FlowSignal {
+	left_signal := e.eval_expr_flow(e.child(node, 0))!
+	if left_signal.kind != .normal {
+		return left_signal
+	}
+	left := flow_value(left_signal)
+	if node.op == .logical_and {
+		if !e.value_as_bool(left)! {
+			return value_flow(Value(false))
+		}
+		right_signal := e.eval_expr_flow(e.child(node, 1))!
+		if right_signal.kind != .normal {
+			return right_signal
+		}
+		return value_flow(Value(e.value_as_bool(flow_value(right_signal))!))
+	}
+	if node.op == .logical_or {
+		if e.value_as_bool(left)! {
+			return value_flow(Value(true))
+		}
+		right_signal := e.eval_expr_flow(e.child(node, 1))!
+		if right_signal.kind != .normal {
+			return right_signal
+		}
+		return value_flow(Value(e.value_as_bool(flow_value(right_signal))!))
+	}
+	right_signal := e.eval_expr_flow(e.child(node, 1))!
+	if right_signal.kind != .normal {
+		return right_signal
+	}
+	return value_flow(e.apply_infix(node.op, left, flow_value(right_signal))!)
+}
+
+fn clean_number_literal(value string) string {
+	return value.replace('_', '')
+}
+
+fn (e &Eval) char_literal_value(raw string) i64 {
+	mut s := raw
+	if s.len >= 2 && ((s[0] == `'` && s[s.len - 1] == `'`)
+		|| (s[0] == `\`` && s[s.len - 1] == `\``)) {
+		s = s[1..s.len - 1]
+	}
+	if s.len == 0 {
+		return 0
+	}
+	if s.len >= 2 && s[0] == `\\` {
+		return match s[1] {
+			`n` { i64(`\n`) }
+			`t` { i64(`\t`) }
+			`r` { i64(`\r`) }
+			`\\` { i64(`\\`) }
+			`'` { i64(`'`) }
+			`"` { i64(`"`) }
+			`$` { i64(`$`) }
+			`0` { i64(0) }
+			`a` { i64(7) }
+			`b` { i64(8) }
+			`f` { i64(12) }
+			`v` { i64(11) }
+			else { i64(s[0]) }
+		}
+	}
+	return i64(s[0])
+}
+
+fn (mut e Eval) eval_ident(name string) !Value {
+	if name == '_' {
+		return void_value()
+	}
+	found := e.lookup_var(name)
+	if found.found {
+		return found.value
+	}
+	if value := e.lookup_const(e.current_module_name(), name) {
+		return value
+	}
+	mod_name := e.resolve_module_name(name)
+	if mod_name in e.modules || name in ['os', 'time', 'strings'] {
+		return ModuleValue{
+			name: mod_name
+		}
+	}
+	if e.has_type_name(e.current_module_name(), name) {
+		return TypeValue{
+			name: e.qualify_type_name(e.current_module_name(), name)
+		}
+	}
+	return e.unknown_variable_error(name)
+}
+
+fn (e &Eval) resolve_module_name(name string) string {
+	file_name := e.current_file_name()
+	if file_name in e.file_import_alias {
+		aliases := e.file_import_alias[file_name].clone()
+		if name in aliases {
+			return aliases[name]
+		}
+	}
+	return name
+}
+
+fn (e &Eval) has_type_name(module_name string, name string) bool {
+	if module_name in e.type_names && name in e.type_names[module_name] {
+		return true
+	}
+	if name.contains('.') {
+		mod := name.all_before_last('.')
+		short := name.all_after_last('.')
+		return mod in e.type_names && short in e.type_names[mod]
+	}
+	return name in e.structs || name in e.sum_types
+}
+
+fn (mut e Eval) lookup_const(module_name string, name string) ?Value {
+	if module_name in e.consts && name in e.consts[module_name] {
+		mut entry := e.consts[module_name][name]
+		if entry.cached {
+			return entry.value
+		}
+		if entry.evaluating {
+			return none
+		}
+		entry.evaluating = true
+		e.consts[module_name][name] = entry
+		mut value := Value(void_value())
+		if e.node(entry.node).children_count > 0 {
+			e.call_stack << CallFrame{
+				module_name: entry.module_name
+				file_name:   entry.file_name
+				fn_name:     '<const ${name}>'
+			}
+			value = e.eval_expr(e.child(e.node(entry.node), 0)) or {
+				e.call_stack.delete(e.call_stack.len - 1)
+				entry.evaluating = false
+				e.consts[module_name][name] = entry
+				return none
+			}
+			e.call_stack.delete(e.call_stack.len - 1)
+		}
+		entry.cached = true
+		entry.evaluating = false
+		entry.value = value
+		e.consts[module_name][name] = entry
+		return value
+	}
+	for mod_name in e.consts.keys() {
+		if name in e.consts[mod_name] {
+			return e.lookup_const(mod_name, name)
+		}
+	}
+	return none
+}
+
+fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
+	if node.children_count == 0 {
+		return FlowSignal{
+			values: [void_value()]
+		}
+	}
+	callee_id := e.child(node, 0)
+	callee := e.node(callee_id)
+	if value := e.disabled_call_value(node, callee) {
+		return FlowSignal{
+			values: [value]
+		}
+	}
+	if callee.kind == .ident {
+		fn_name := callee.value
+		found := e.lookup_var(fn_name)
+		if found.found && found.value is FnValue {
+			fv := found.value as FnValue
+			args_signal := e.eval_call_arg_values(node, e.fn_value_param_type_names(fv))!
+			if args_signal.kind != .normal {
+				return args_signal
+			}
+			result := e.call_fn_value(fv, args_signal.values)!
+			e.write_back_fn_value(callee_id, result)!
+			e.write_back_mutated_arg_values(node, result.mutated_args)!
+			return FlowSignal{
+				values: [e.call_result_value(result)]
+			}
+		}
+		expected_types := if target := e.function_def(e.current_module_name(), fn_name) {
+			e.function_param_type_names(target, 0)
+		} else {
+			[]string{}
+		}
+		args_signal := e.eval_call_arg_values(node, expected_types)!
+		if args_signal.kind != .normal {
+			return args_signal
+		}
+		result := e.call_function(e.current_module_name(), fn_name, args_signal.values)!
+		e.write_back_mutated_args(node, result)!
+		return FlowSignal{
+			values: [e.call_result_value(result)]
+		}
+	}
+	if callee.kind == .selector {
+		receiver_id := e.child(callee, 0)
+		receiver_signal := e.eval_expr_flow(receiver_id)!
+		if receiver_signal.kind != .normal {
+			return receiver_signal
+		}
+		left := flow_value(receiver_signal)
+		if left is ModuleValue {
+			expected_types := if target := e.function_def(left.name, callee.value) {
+				e.function_param_type_names(target, 0)
+			} else {
+				[]string{}
+			}
+			args_signal := e.eval_call_arg_values(node, expected_types)!
+			if args_signal.kind != .normal {
+				return args_signal
+			}
+			result := e.call_function(left.name, callee.value, args_signal.values)!
+			e.write_back_mutated_args(node, result)!
+			return FlowSignal{
+				values: [e.call_result_value(result)]
+			}
+		}
+		if left is TypeValue {
+			static_name := '${left.name.all_after_last('.')}.${callee.value}'
+			static_module := e.type_value_module_name(left)
+			expected_types := if target := e.function_def(static_module, static_name) {
+				e.function_param_type_names(target, 0)
+			} else {
+				[]string{}
+			}
+			args_signal := e.eval_call_arg_values(node, expected_types)!
+			if args_signal.kind != .normal {
+				return args_signal
+			}
+			result := e.call_function(static_module, static_name, args_signal.values)!
+			e.write_back_mutated_args(node, result)!
+			return FlowSignal{
+				values: [e.call_result_value(result)]
+			}
+		}
+		receiver_type_name := e.infer_expr_type_name(receiver_id)
+		expected_types := e.method_call_param_type_names(left, receiver_type_name, callee.value)
+		args_signal := e.eval_call_arg_values(node, expected_types)!
+		if args_signal.kind != .normal {
+			return args_signal
+		}
+		result := e.call_value_method(left, receiver_type_name, callee.value, args_signal.values)!
+		if result.receiver_changed {
+			if e.is_assignable_target(receiver_id) {
+				e.update_target(receiver_id, result.receiver)!
+			}
+		}
+		e.write_back_mutated_arg_values(node, result.mutated_args)!
+		return FlowSignal{
+			values: [result.value]
+		}
+	}
+	if callee.kind == .fn_literal {
+		fv := e.eval_fn_literal(callee_id, callee)!
+		args_signal := e.eval_call_arg_values(node, e.fn_literal_param_type_names(callee))!
+		if args_signal.kind != .normal {
+			return args_signal
+		}
+		result := e.call_fn_value(fv, args_signal.values)!
+		e.write_back_mutated_arg_values(node, result.mutated_args)!
+		return FlowSignal{
+			values: [e.call_result_value(result)]
+		}
+	}
+	value := e.eval_expr(callee_id)!
+	if value is FnValue {
+		args_signal := e.eval_call_arg_values(node, e.fn_value_param_type_names(value))!
+		if args_signal.kind != .normal {
+			return args_signal
+		}
+		result := e.call_fn_value(value, args_signal.values)!
+		e.write_back_fn_value(callee_id, result)!
+		e.write_back_mutated_arg_values(node, result.mutated_args)!
+		return FlowSignal{
+			values: [e.call_result_value(result)]
+		}
+	}
+	_ = id
+	return error('v3.eval: unsupported call target `${callee.kind}`')
+}
+
+fn (mut e Eval) disabled_call_value(call_node &flat.Node, callee &flat.Node) ?Value {
+	match callee.kind {
+		.ident {
+			found := e.lookup_var(callee.value)
+			if found.found && found.value is FnValue {
+				return none
+			}
+			if value := e.disabled_function_zero_value(e.current_module_name(), callee.value,
+				call_node)
+			{
+				return value
+			}
+		}
+		.selector {
+			if callee.children_count == 0 {
+				return none
+			}
+			base_id := e.child(callee, 0)
+			base := e.node(base_id)
+			receiver_type := e.infer_expr_type_name(base_id)
+			if receiver_type.len > 0 {
+				if target := e.resolve_method_target(receiver_type, callee.value) {
+					if e.is_disabled_fn_name_in_module(target.module_name, target.name) {
+						return e.zero_value_for_disabled_function(call_node, target)
+					}
+				}
+			}
+			if base.kind == .ident {
+				full_name := '${base.value}.${callee.value}'
+				if value := e.disabled_function_zero_value(e.current_module_name(), full_name,
+					call_node)
+				{
+					return value
+				}
+				found := e.lookup_var(base.value)
+				if !found.found {
+					module_name := e.resolve_module_name(base.value)
+					if value := e.disabled_function_zero_value(module_name, callee.value, call_node) {
+						return value
+					}
+				}
+			}
+		}
+		else {}
+	}
+
+	return none
+}
+
+fn (e &Eval) function_def(module_name string, fn_name string) ?FunctionDef {
+	target_module := if module_name == '' { e.current_module_name() } else { module_name }
+	if target_module !in e.functions {
+		return none
+	}
+	if fn_name in e.functions[target_module] {
+		return e.functions[target_module][fn_name]
+	}
+	if target_module !in ['main', 'builtin'] && !fn_name.contains('.') {
+		qualified := '${target_module}.${fn_name}'
+		if qualified in e.functions[target_module] {
+			return e.functions[target_module][qualified]
+		}
+	}
+	return none
+}
+
+fn (e &Eval) function_param_type_names(def FunctionDef, skip int) []string {
+	node := e.node(def.node)
+	mut types := []string{}
+	mut param_index := 0
+	for child_id in e.children(node) {
+		child := e.node(child_id)
+		if child.kind != .param {
+			break
+		}
+		if param_index >= skip {
+			types << child.typ
+		}
+		param_index++
+	}
+	return types
+}
+
+fn (e &Eval) fn_value_param_type_names(fv FnValue) []string {
+	return e.fn_literal_param_type_names(e.node(fv.node))
+}
+
+fn (e &Eval) fn_literal_param_type_names(node &flat.Node) []string {
+	children := e.children(node)
+	mut i := 0
+	for i < children.len {
+		child := e.node(children[i])
+		if child.kind != .ident {
+			break
+		}
+		i++
+	}
+	mut types := []string{}
+	for i < children.len {
+		child := e.node(children[i])
+		if child.kind != .param {
+			break
+		}
+		types << child.typ
+		i++
+	}
+	return types
+}
+
+fn (e &Eval) method_call_param_type_names(receiver Value, receiver_type_name string, method_name string) []string {
+	static_type_name := e.normalize_type_name(receiver_type_name)
+	if static_type_name.len > 0 {
+		if target := e.resolve_method_target(static_type_name, method_name) {
+			return e.function_param_type_names(target, 1)
+		}
+	}
+	if receiver is StructValue {
+		if target := e.resolve_method_target(receiver.type_name, method_name) {
+			return e.function_param_type_names(target, 1)
+		}
+	}
+	if receiver is SumValue {
+		return e.method_call_param_type_names(receiver.payload, receiver.variant_name, method_name)
+	}
+	return []string{}
+}
+
+fn (mut e Eval) eval_call_arg_values(node &flat.Node, expected_types []string) !FlowSignal {
+	mut args := []Value{}
+	for child_index in 1 .. node.children_count {
+		arg_index := child_index - 1
+		expected_type := call_arg_expected_type(expected_types, arg_index)
+		signal := e.eval_expr_flow_expected(e.child(node, child_index), expected_type)!
+		if signal.kind != .normal {
+			return signal
+		}
+		args << flow_value(signal)
+	}
+	return FlowSignal{
+		values: args
+	}
+}
+
+fn call_arg_expected_type(expected_types []string, index int) string {
+	if index < expected_types.len {
+		typ := expected_types[index]
+		if typ.starts_with('...') {
+			return typ[3..]
+		}
+		return typ
+	}
+	if expected_types.len > 0 {
+		last := expected_types[expected_types.len - 1]
+		if last.starts_with('...') {
+			return last[3..]
+		}
+	}
+	return ''
+}
+
+fn (mut e Eval) disabled_function_zero_value(module_name string, fn_name string, call_node &flat.Node) ?Value {
+	target_module := if module_name == '' { e.current_module_name() } else { module_name }
+	mut candidates := []string{cap: 3}
+	candidates << fn_name
+	if target_module.len > 0 && target_module !in ['main', 'builtin'] && !fn_name.contains('.') {
+		candidates << '${target_module}.${fn_name}'
+	}
+	if target_module in e.functions {
+		for candidate in candidates {
+			if candidate in e.functions[target_module] {
+				target := e.functions[target_module][candidate]
+				if e.is_disabled_fn_name_in_module(target.module_name, target.name)
+					|| e.is_disabled_fn_name_in_module(target_module, candidate) {
+					return e.zero_value_for_disabled_function(call_node, target)
+				}
+			}
+		}
+	}
+	for candidate in candidates {
+		if e.is_disabled_fn_name_in_module(target_module, candidate) {
+			return e.zero_value_for_disabled_return_type(call_node.typ, target_module)
+		}
+	}
+	return none
+}
+
+fn (mut e Eval) zero_value_for_disabled_function(call_node &flat.Node, target FunctionDef) Value {
+	target_node := e.node(target.node)
+	return e.zero_value_for_disabled_return_type(if call_node.typ.len > 0 {
+		call_node.typ
+	} else {
+		target_node.typ
+	}, target.module_name)
+}
+
+fn (mut e Eval) zero_value_for_disabled_return_type(return_type string, module_name string) Value {
+	if return_type.len == 0 || return_type == 'void' {
+		return void_value()
+	}
+	return e.zero_value_for_type_name_in_module(return_type, module_name)
+}
+
+fn (e &Eval) is_disabled_fn_name_in_module(module_name string, fn_name string) bool {
+	if fn_name in e.a.disabled_fns {
+		return true
+	}
+	if !fn_name.contains('.') && module_name.len > 0 && module_name !in ['main', 'builtin'] {
+		return '${module_name}.${fn_name}' in e.a.disabled_fns
+	}
+	return false
+}
+
+fn (e &Eval) call_result_value(result CallResult) Value {
+	if result.values.len == 1 {
+		return result.values[0]
+	}
+	return TupleValue{
+		values: result.values
+	}
+}
+
+fn (mut e Eval) write_back_mutated_args(node &flat.Node, result CallResult) ! {
+	e.write_back_mutated_arg_values(node, result.mutated_args)!
+}
+
+fn (mut e Eval) adapt_return_values(values []Value, return_type string) []Value {
+	if values.len == 1 && return_type.len > 0 {
+		return [e.adapt_value_to_type_name(values[0], return_type)]
+	}
+	return values.clone()
+}
+
+fn (e &Eval) minimum_arg_count(params []flat.NodeId) int {
+	if params.len == 0 {
+		return 0
+	}
+	last_param := e.node(params[params.len - 1])
+	if last_param.typ.starts_with('...') {
+		return params.len - 1
+	}
+	return params.len
+}
+
+fn (mut e Eval) bind_call_params(params []flat.NodeId, args []Value) ! {
+	for i, param_id in params {
+		param := e.node(param_id)
+		if param.typ.starts_with('...') {
+			elem_type := param.typ[3..]
+			mut values := []Value{cap: if args.len > i { args.len - i } else { 0 }}
+			for j := i; j < args.len; j++ {
+				values << e.adapt_value_to_type_name(args[j], elem_type)
+			}
+			if param.value.len > 0 {
+				e.declare_var_typed(param.value, ArrayValue{
+					elem_type_name: elem_type
+					values:         values
+				}, '[]${elem_type}')
+			}
+			return
+		}
+		if i < args.len {
+			e.declare_var_typed(param.value, e.adapt_value_to_type_name(args[i], param.typ),
+				param.typ)
+		}
+	}
+}
+
+fn (mut e Eval) collect_mutated_param_args(params []flat.NodeId, args []Value) map[int]Value {
+	mut mutated_args := map[int]Value{}
+	for i, param_id in params {
+		param := e.node(param_id)
+		if param.value.len == 0 {
+			continue
+		}
+		if param.typ.starts_with('...') {
+			continue
+		}
+		found := e.lookup_var(param.value)
+		if !found.found {
+			continue
+		}
+		if param.typ.starts_with('&') {
+			mutated_args[i] = found.value
+			continue
+		}
+		if i < args.len && args[i] is FnValue && found.value is FnValue {
+			fn_value := found.value as FnValue
+			if fn_value.captures.len > 0 {
+				mutated_args[i] = found.value
+			}
+		}
+	}
+	return mutated_args
+}
+
+fn (mut e Eval) write_back_fn_value(callee_id flat.NodeId, result CallResult) ! {
+	if result.fn_value_changed && e.is_assignable_target(callee_id) {
+		e.update_target(callee_id, Value(result.fn_value))!
+	}
+}
+
+fn (mut e Eval) write_back_mutated_arg_values(node &flat.Node, mutated_args map[int]Value) ! {
+	for child_index := 1; child_index < node.children_count; child_index++ {
+		arg_index := child_index - 1
+		if arg_index !in mutated_args {
+			continue
+		}
+		value := mutated_args[arg_index] or { continue }
+		arg_id := e.child(node, child_index)
+		if e.is_assignable_target(arg_id) {
+			e.update_target(arg_id, value)!
+		}
+	}
+}
+
+fn (e &Eval) is_assignable_target(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return false
+	}
+	node := e.node(id)
+	return node.kind in [.ident, .selector, .index]
+}
+
+fn (mut e Eval) call_fn_value(fv FnValue, args []Value) !CallResult {
+	node := e.node(fv.node)
+	mut params := []flat.NodeId{}
+	mut body_start := 0
+	children := e.children(node)
+	for body_start < children.len {
+		child := e.node(children[body_start])
+		if child.kind != .ident {
+			break
+		}
+		body_start++
+	}
+	for body_start < children.len {
+		child_id := children[body_start]
+		child := e.node(child_id)
+		if child.kind == .param {
+			params << child_id
+			body_start++
+			continue
+		}
+		break
+	}
+	e.call_stack << CallFrame{
+		module_name: fv.module_name
+		file_name:   fv.file_name
+		fn_name:     '<anonymous>'
+	}
+	e.open_scope()
+	for name, value in fv.captures {
+		e.declare_var_typed(name, value, fv.capture_types[name] or { '' })
+	}
+	e.bind_call_params(params, args)!
+	signal := e.exec_stmts(children[body_start..])!
+	e.run_deferred_stmts()!
+	mutated_args := e.collect_mutated_param_args(params, args)
+	mut updated_fn_value := fv
+	if fv.captures.len > 0 {
+		mut captures := fv.captures.clone()
+		for name, _ in fv.captures {
+			found := e.lookup_var(name)
+			if found.found {
+				captures[name] = found.value
+			}
+		}
+		updated_fn_value = FnValue{
+			node:          fv.node
+			module_name:   fv.module_name
+			file_name:     fv.file_name
+			captures:      captures
+			capture_types: fv.capture_types.clone()
+		}
+	}
+	e.close_scope()!
+	e.call_stack.delete(e.call_stack.len - 1)
+	if signal.kind == .return_ {
+		return CallResult{
+			values:           e.adapt_return_values(signal.values, node.typ)
+			mutated_args:     mutated_args
+			fn_value_changed: fv.captures.len > 0
+			fn_value:         updated_fn_value
+		}
+	}
+	if signal.kind != .normal {
+		return error('v3.eval: unexpected `${signal.kind}` escaped anonymous function')
+	}
+	return CallResult{
+		values:           [void_value()]
+		mutated_args:     mutated_args
+		fn_value_changed: fv.captures.len > 0
+		fn_value:         updated_fn_value
+	}
+}
+
+fn (mut e Eval) eval_selector(node &flat.Node) !Value {
+	left := e.eval_expr(e.child(node, 0))!
+	return e.eval_selector_value(left, node.value)
+}
+
+fn (mut e Eval) eval_selector_value(left Value, field string) !Value {
+	match left {
+		ModuleValue {
+			if value := e.lookup_const(left.name, field) {
+				return value
+			}
+			return TypeValue{
+				name: '${left.name}.${field}'
+			}
+		}
+		TypeValue {
+			if field == 'name' {
+				return Value(left.name)
+			}
+			mod := e.type_value_module_name(left)
+			enum_key := '${left.name.all_after_last('.')}.${field}'
+			if value := e.lookup_const(mod, enum_key) {
+				return e.enum_value(left.name, value)
+			}
+			if value := e.lookup_const(mod, field) {
+				return e.enum_value(left.name, value)
+			}
+			return TypeValue{
+				name: '${left.name}.${field}'
+			}
+		}
+		ArrayValue {
+			if field == 'len' {
+				return Value(i64(left.values.len))
+			}
+			if field == 'cap' {
+				return Value(i64(left.values.cap))
+			}
+		}
+		MapValue {
+			if field == 'len' {
+				return Value(i64(left.entries.len))
+			}
+		}
+		string {
+			if field == 'len' {
+				return Value(i64(left.len))
+			}
+		}
+		StructValue {
+			if field in left.fields {
+				return left.fields[field] or { void_value() }
+			}
+		}
+		SumValue {
+			return e.eval_sum_selector(left, field)
+		}
+		else {}
+	}
+
+	return error('v3.eval: unsupported selector `${field}` on `${e.runtime_type_name(left)}`')
+}
+
+fn (e &Eval) eval_sum_selector(value SumValue, field string) !Value {
+	if field == '_typ' {
+		return Value(i64(e.sum_variant_index(value.type_name, value.variant_name)))
+	}
+	if value.payload is StructValue {
+		payload := value.payload as StructValue
+		if field in payload.fields {
+			return payload.fields[field] or { void_value() }
+		}
+	}
+	return error('v3.eval: unknown sum type field `${field}` on `${value.type_name}`')
+}
+
+fn (e &Eval) sum_variant_index(type_name string, variant_name string) int {
+	if type_name in e.sum_types {
+		variants := e.sum_types[type_name]
+		sum_module := if type_name.contains('.') {
+			type_name.all_before_last('.')
+		} else {
+			e.current_module_name()
+		}
+		expected_name := e.qualify_type_name(sum_module, variant_name)
+		for i, variant in variants {
+			if variant == expected_name || variant == variant_name {
+				return i
+			}
+		}
+		mut short_match_index := -1
+		for i, variant in variants {
+			if variant.all_after_last('.') == variant_name.all_after_last('.') {
+				if short_match_index >= 0 {
+					return 0
+				}
+				short_match_index = i
+			}
+		}
+		if short_match_index >= 0 {
+			return short_match_index
+		}
+	}
+	return 0
+}
+
+fn (mut e Eval) eval_index(node &flat.Node) !Value {
+	container := e.eval_expr(e.child(node, 0))!
+	if node.value == 'range' {
+		start := if node.children_count > 1 && e.node(e.child(node, 1)).kind != .empty {
+			int(e.value_as_int(e.eval_expr(e.child(node, 1))!)!)
+		} else {
+			0
+		}
+		mut end := 0
+		match container {
+			ArrayValue { end = container.values.len }
+			string { end = container.len }
+			else {}
+		}
+
+		if node.children_count > 2 {
+			end = int(e.value_as_int(e.eval_expr(e.child(node, 2))!)!)
+		}
+		return e.slice_value(container, start, end)!
+	}
+	index := e.eval_expr(e.child(node, 1))!
+	return e.index_value(container, index)
+}
+
+fn (mut e Eval) eval_index_flow(node &flat.Node) !FlowSignal {
+	container_signal := e.eval_expr_flow(e.child(node, 0))!
+	if container_signal.kind != .normal {
+		return container_signal
+	}
+	container := flow_value(container_signal)
+	if node.value == 'range' {
+		mut start := 0
+		if node.children_count > 1 && e.node(e.child(node, 1)).kind != .empty {
+			start_signal := e.eval_expr_flow(e.child(node, 1))!
+			if start_signal.kind != .normal {
+				return start_signal
+			}
+			start = int(e.value_as_int(flow_value(start_signal))!)
+		}
+		mut end := 0
+		match container {
+			ArrayValue { end = container.values.len }
+			string { end = container.len }
+			else {}
+		}
+
+		if node.children_count > 2 {
+			end_signal := e.eval_expr_flow(e.child(node, 2))!
+			if end_signal.kind != .normal {
+				return end_signal
+			}
+			end = int(e.value_as_int(flow_value(end_signal))!)
+		}
+		return value_flow(e.slice_value(container, start, end)!)
+	}
+	index_signal := e.eval_expr_flow(e.child(node, 1))!
+	if index_signal.kind != .normal {
+		return index_signal
+	}
+	return value_flow(e.index_value(container, flow_value(index_signal))!)
+}
+
+fn (mut e Eval) index_value(container Value, index Value) !Value {
+	match container {
+		ArrayValue {
+			idx := int(e.value_as_int(index)!)
+			if idx < 0 || idx >= container.values.len {
+				return error('v3.eval: array index out of bounds')
+			}
+			return container.values[idx]
+		}
+		MapValue {
+			value, ok := e.map_lookup(container, index)
+			if ok {
+				return value
+			}
+			return container.default_value
+		}
+		string {
+			idx := int(e.value_as_int(index)!)
+			if idx < 0 || idx >= container.len {
+				return error('v3.eval: string index out of bounds')
+			}
+			return Value(i64(container[idx]))
+		}
+		else {
+			return error('v3.eval: unsupported index target `${e.runtime_type_name(container)}`')
+		}
+	}
+}
+
+fn (e &Eval) slice_value(container Value, start int, end int) !Value {
+	match container {
+		ArrayValue {
+			mut arr := container
+			arr.values = arr.values[start..end].clone()
+			return arr
+		}
+		string {
+			sliced := container[start..end]
+			return Value(sliced)
+		}
+		else {
+			return error('v3.eval: slicing is only supported for arrays and strings')
+		}
+	}
+}
+
+fn (mut e Eval) eval_if_value(node &flat.Node) !Value {
+	signal := e.eval_if_value_flow(node)!
+	return flow_values_value(signal.values)
+}
+
+fn (mut e Eval) eval_if_value_flow(node &flat.Node) !FlowSignal {
+	if node.children_count < 2 {
+		return value_flow(void_value())
+	}
+	cond_id := e.child(node, 0)
+	cond_is_guard := e.node(cond_id).kind == .decl_assign
+	if cond_is_guard {
+		e.open_scope()
+	}
+	cond_signal := e.eval_condition_flow(cond_id)!
+	if cond_signal.kind != .normal {
+		if cond_is_guard {
+			e.close_scope()!
+		}
+		return cond_signal
+	}
+	if e.value_as_bool(flow_value(cond_signal))! {
+		mut smartcast_scope := false
+		if !cond_is_guard {
+			if binding := e.smartcast_binding_from_condition(cond_id) {
+				e.open_scope()
+				e.declare_var_typed(binding.name, binding.value, binding.type_name)
+				smartcast_scope = true
+			}
+		}
+		signal := e.eval_value_expr_flow(e.child(node, 1))!
+		if smartcast_scope {
+			e.close_scope()!
+		}
+		if cond_is_guard {
+			e.close_scope()!
+		}
+		return signal
+	}
+	if cond_is_guard {
+		e.close_scope()!
+	}
+	if node.children_count > 2 {
+		return e.eval_value_expr_flow(e.child(node, 2))
+	}
+	return value_flow(void_value())
+}
+
+fn (mut e Eval) eval_value_expr_flow(id flat.NodeId) !FlowSignal {
+	if int(id) >= 0 {
+		node := e.node(id)
+		if node.kind == .block {
+			return e.eval_block_value_flow(node)
+		}
+	}
+	return e.eval_expr_flow(id)
+}
+
+fn (mut e Eval) eval_block_value(node &flat.Node) !Value {
+	signal := e.eval_block_value_flow(node)!
+	if signal.kind == .return_ && signal.values.len > 0 {
+		return flow_values_value(signal.values)
+	}
+	return flow_values_value(signal.values)
+}
+
+fn (mut e Eval) eval_block_value_flow(node &flat.Node) !FlowSignal {
+	e.open_scope()
+	mut values := []Value{}
+	collect_expr_values := e.block_has_only_expr_stmts(node) && node.children_count > 1
+	for child_id in e.children(node) {
+		child := e.node(child_id)
+		if child.kind == .expr_stmt && child.children_count > 0 {
+			expr_id := e.child(child, 0)
+			signal := e.eval_expr_flow(expr_id)!
+			if signal.kind != .normal {
+				e.close_scope()!
+				return signal
+			}
+			expr_values := flow_values_or_void(signal.values)
+			if collect_expr_values {
+				for expr_value in expr_values {
+					if expr_value !is VoidValue {
+						values << expr_value
+					}
+				}
+			} else {
+				values = expr_values.clone()
+			}
+			continue
+		}
+		if child.kind == .block {
+			signal := e.eval_block_value_flow(child)!
+			if signal.kind != .normal {
+				e.close_scope()!
+				return signal
+			}
+			values = flow_values_or_void(signal.values)
+			continue
+		}
+		signal := e.exec_stmt(child_id)!
+		if signal.kind != .normal {
+			e.close_scope()!
+			return signal
+		}
+	}
+	e.close_scope()!
+	return FlowSignal{
+		values: flow_values_or_void(values)
+	}
+}
+
+fn (e &Eval) block_has_only_expr_stmts(node &flat.Node) bool {
+	if node.children_count == 0 {
+		return false
+	}
+	for child_id in e.children(node) {
+		if e.node(child_id).kind != .expr_stmt {
+			return false
+		}
+	}
+	return true
+}
+
+fn (mut e Eval) eval_array_init(node &flat.Node) !Value {
+	array_type_name := if node.typ.len > 0 { node.typ } else { node.value }
+	is_fixed_array := is_fixed_array_type_name(array_type_name)
+	elem_type_name := if is_fixed_array {
+		fixed_array_elem_type_name(array_type_name)
+	} else {
+		node.value
+	}
+	mut len := 0
+	mut cap := 0
+	mut has_cap := false
+	mut init := e.zero_value_for_type_name(elem_type_name)
+	mut values := []Value{}
+	for child_id in e.children(node) {
+		child := e.node(child_id)
+		if child.kind == .field_init {
+			if child.value == 'len' {
+				val := e.eval_expr(e.child(child, 0))!
+				len = int(e.value_as_int(val)!)
+			} else if child.value == 'cap' {
+				val := e.eval_expr(e.child(child, 0))!
+				cap = int(e.value_as_int(val)!)
+				has_cap = true
+			} else if child.value == 'init' {
+				val := e.eval_expr_expected(e.child(child, 0), elem_type_name)!
+				init = e.adapt_value_to_type_name(val, elem_type_name)
+			}
+		} else {
+			values << e.adapt_value_to_type_name(e.eval_expr_expected(child_id, elem_type_name)!,
+				elem_type_name)
+		}
+	}
+	if len > 0 || has_cap {
+		array_cap := if has_cap { cap } else { len }
+		values = []Value{len: len, cap: array_cap, init: init}
+	}
+	if is_fixed_array && values.len == 0 {
+		fixed_len := fixed_array_len(array_type_name)
+		values = []Value{len: fixed_len, cap: fixed_len, init: init}
+	}
+	return ArrayValue{
+		elem_type_name: elem_type_name
+		values:         values
+	}
+}
+
+fn is_fixed_array_type_name(type_name string) bool {
+	if type_name.starts_with('[]') || type_name.starts_with('map[') {
+		return false
+	}
+	return type_name.contains('[') && (type_name.ends_with(']') || type_name.starts_with('['))
+}
+
+fn fixed_array_len(type_name string) int {
+	return fixed_array_len_text(type_name).int()
+}
+
+fn fixed_array_len_text(type_name string) string {
+	return type_name.all_after('[').all_before(']').trim_space()
+}
+
+fn fixed_array_elem_type_name(type_name string) string {
+	if type_name.starts_with('[') {
+		return type_name.all_after(']')
+	}
+	return type_name.all_before('[')
+}
+
+fn (mut e Eval) eval_map_init(node &flat.Node) !Value {
+	mut key_type, mut value_type := split_map_type(node.value)
+	children := e.children(node)
+	mut keys := []Value{}
+	mut values := []Value{}
+	mut i := 0
+	for i + 1 < children.len {
+		key := e.eval_expr(children[i])!
+		if key_type.len == 0 {
+			key_type = e.infer_expr_type_name(children[i])
+			if key_type.len == 0 {
+				key_type = e.runtime_type_name(key)
+			}
+		}
+		value := e.eval_expr_expected(children[i + 1], value_type)!
+		if value_type.len == 0 {
+			value_type = e.infer_expr_type_name(children[i + 1])
+			if value_type.len == 0 {
+				value_type = e.runtime_type_name(value)
+			}
+		}
+		keys << key
+		values << value
+		i += 2
+	}
+	mut m := MapValue{
+		key_type_name:   key_type
+		value_type_name: value_type
+		default_value:   e.zero_value_for_type_name(value_type)
+	}
+	for j, key in keys {
+		m = e.map_set_value(m, key, values[j])
+	}
+	return m
+}
+
+fn split_map_type(type_name string) (string, string) {
+	if !type_name.starts_with('map[') {
+		return '', ''
+	}
+	inner := type_name[4..]
+	if idx := inner.index(']') {
+		return inner[..idx], inner[idx + 1..]
+	}
+	return '', ''
+}
+
+fn (mut e Eval) eval_struct_init(node &flat.Node) !Value {
+	type_name := e.normalize_type_name(node.value)
+	mut st := e.zero_struct_value(type_name)
+	mut positional := 0
+	for child_id in e.children(node) {
+		child := e.node(child_id)
+		if child.kind != .field_init {
+			continue
+		}
+		if child.value.len > 0 {
+			field_type := e.struct_field_type_name(st, child.value)
+			value := e.eval_expr_expected(e.child(child, 0), field_type)!
+			st.fields[child.value] = e.adapt_value_to_type_name(value, e.struct_field_type_name(st,
+				child.value))
+		} else {
+			fields := e.struct_fields(type_name)
+			if positional < fields.len {
+				field := fields[positional]
+				field_type := e.qualify_type_name(field.module_name, field.typ)
+				value := e.eval_expr_expected(e.child(child, 0), field_type)!
+				st.fields[field.name] = e.adapt_value_to_type_name(value, e.qualify_type_name(field.module_name,
+					field.typ))
+			}
+			positional++
+		}
+	}
+	return st
+}
+
+fn (mut e Eval) eval_assoc(node &flat.Node) !Value {
+	if node.children_count == 0 {
+		return e.zero_struct_value(node.value)
+	}
+	base := e.eval_expr(e.child(node, 0))!
+	if base !is StructValue {
+		return error('v3.eval: assoc base must be struct')
+	}
+	mut st := base as StructValue
+	for i in 1 .. node.children_count {
+		field := e.child_node(node, i)
+		if field.kind == .field_init {
+			field_type := e.struct_field_type_name(st, field.value)
+			st.fields[field.value] = e.adapt_value_to_type_name(e.eval_expr_expected(e.child(field, 0),
+				field_type)!, field_type)
+		}
+	}
+	return st
+}
+
+fn (mut e Eval) eval_prefix(node &flat.Node) !Value {
+	value := e.eval_expr(e.child(node, 0))!
+	return e.apply_prefix(node.op, value)
+}
+
+fn (e &Eval) apply_prefix(op flat.Op, value Value) !Value {
+	match op {
+		.minus {
+			if value is f64 {
+				negated := -value
+				return Value(negated)
+			}
+			return Value(-e.value_as_int(value)!)
+		}
+		.not {
+			return Value(!e.value_as_bool(value)!)
+		}
+		.bit_not {
+			return Value(~e.value_as_int(value)!)
+		}
+		.amp, .mul {
+			return value
+		}
+		else {
+			return value
+		}
+	}
+}
+
+fn (mut e Eval) eval_postfix(node &flat.Node) !Value {
+	target_id := e.child(node, 0)
+	old := e.eval_expr(target_id)!
+	if node.op == .inc {
+		e.update_target(target_id, e.apply_infix(.plus, old, Value(i64(1)))!)!
+		return old
+	}
+	if node.op == .dec {
+		e.update_target(target_id, e.apply_infix(.minus, old, Value(i64(1)))!)!
+		return old
+	}
+	return old
+}
+
+fn (mut e Eval) eval_or_expr(node &flat.Node) !Value {
+	signal := e.eval_or_expr_flow(node)!
+	if signal.kind == .return_ && signal.values.len > 0 {
+		return signal.values[0]
+	}
+	return flow_value(signal)
+}
+
+fn (mut e Eval) eval_or_expr_flow(node &flat.Node) !FlowSignal {
+	left_id := e.child(node, 0)
+	left_node := e.node(left_id)
+	if left_node.kind == .index {
+		container_signal := e.eval_expr_flow(e.child(left_node, 0))!
+		if container_signal.kind != .normal {
+			return container_signal
+		}
+		container := flow_value(container_signal)
+		if container is MapValue {
+			index_signal := e.eval_expr_flow(e.child(left_node, 1))!
+			if index_signal.kind != .normal {
+				return index_signal
+			}
+			value, ok := e.map_lookup(container, flow_value(index_signal))
+			if ok {
+				return value_flow(e.unwrap_option_like(value))
+			}
+			return e.eval_or_failure(node, container.default_value)
+		}
+	}
+	left_signal := e.eval_expr_flow(left_id)!
+	if left_signal.kind != .normal {
+		return left_signal
+	}
+	left := flow_value(left_signal)
+	if e.value_is_truthy(left) {
+		return FlowSignal{
+			values: [e.unwrap_option_like(left)]
+		}
+	}
+	return e.eval_or_failure(node, left)
+}
+
+fn (mut e Eval) eval_or_failure(node &flat.Node, value Value) !FlowSignal {
+	if node.children_count > 1 && e.node(e.child(node, 1)).kind != .empty {
+		or_id := e.child(node, 1)
+		or_node := e.node(or_id)
+		if or_node.kind == .block {
+			e.open_scope()
+			e.declare_var('err', e.or_block_err_value(value))
+			signal := e.eval_block_value_flow(or_node) or {
+				e.close_scope() or {}
+				return err
+			}
+			e.close_scope()!
+			return signal
+		}
+		return FlowSignal{
+			values: [e.eval_expr(or_id)!]
+		}
+	}
+	if node.value == '?' || node.value == '!' {
+		return FlowSignal{
+			kind:   .return_
+			values: [value]
+		}
+	}
+	return FlowSignal{
+		values: [void_value()]
+	}
+}
+
+fn (e &Eval) or_block_err_value(value Value) Value {
+	if value is VoidValue {
+		return Value('')
+	}
+	return value
+}
+
+fn (mut e Eval) exec_match(node &flat.Node) !FlowSignal {
+	target_id := e.child(node, 0)
+	target := e.eval_expr(target_id)!
+	for i in 1 .. node.children_count {
+		branch := e.child_node(node, i)
+		if branch.kind != .match_branch {
+			continue
+		}
+		cond_count := if branch.value == 'else' { 0 } else { branch.value.int() }
+		mut matched := branch.value == 'else'
+		mut matched_cond := Value(void_value())
+		for j in 0 .. cond_count {
+			cond := e.eval_match_condition(e.child(branch, j), target_id)!
+			if e.match_condition_matches(target, cond) {
+				matched = true
+				matched_cond = cond
+				break
+			}
+		}
+		if matched {
+			e.open_scope()
+			if binding := e.smartcast_binding_from_match(target_id, target, matched_cond) {
+				e.declare_var_typed(binding.name, binding.value, binding.type_name)
+			}
+			signal := e.exec_stmts(e.children(branch)[cond_count..])!
+			e.close_scope()!
+			if signal.kind != .normal {
+				return signal
+			}
+			return normal_flow()
+		}
+	}
+	return normal_flow()
+}
+
+fn (mut e Eval) eval_match_value(node &flat.Node) !Value {
+	signal := e.eval_match_value_flow(node)!
+	if signal.kind == .return_ && signal.values.len > 0 {
+		return flow_values_value(signal.values)
+	}
+	return flow_values_value(signal.values)
+}
+
+fn (mut e Eval) eval_match_value_flow(node &flat.Node) !FlowSignal {
+	target_id := e.child(node, 0)
+	target_signal := e.eval_expr_flow(target_id)!
+	if target_signal.kind != .normal {
+		return target_signal
+	}
+	target := flow_value(target_signal)
+	for i in 1 .. node.children_count {
+		branch := e.child_node(node, i)
+		if branch.kind != .match_branch {
+			continue
+		}
+		cond_count := if branch.value == 'else' { 0 } else { branch.value.int() }
+		mut matched := branch.value == 'else'
+		mut matched_cond := Value(void_value())
+		for j in 0 .. cond_count {
+			cond := e.eval_match_condition(e.child(branch, j), target_id)!
+			if e.match_condition_matches(target, cond) {
+				matched = true
+				matched_cond = cond
+				break
+			}
+		}
+		if matched {
+			e.open_scope()
+			if binding := e.smartcast_binding_from_match(target_id, target, matched_cond) {
+				e.declare_var_typed(binding.name, binding.value, binding.type_name)
+			}
+			mut values := []Value{}
+			for j in cond_count .. branch.children_count {
+				stmt_id := e.child(branch, j)
+				stmt := e.node(stmt_id)
+				if stmt.kind == .expr_stmt && stmt.children_count > 0 {
+					signal := e.eval_expr_flow(e.child(stmt, 0))!
+					if signal.kind != .normal {
+						e.close_scope()!
+						return signal
+					}
+					values = flow_values_or_void(signal.values)
+				} else {
+					signal := e.exec_stmt(stmt_id)!
+					if signal.kind != .normal {
+						e.close_scope()!
+						return signal
+					}
+				}
+			}
+			e.close_scope()!
+			return FlowSignal{
+				values: flow_values_or_void(values)
+			}
+		}
+	}
+	return value_flow(void_value())
+}
+
+fn (e &Eval) match_condition_matches(target Value, cond Value) bool {
+	if cond is RangeValue {
+		return e.value_in(target, cond)
+	}
+	return e.value_eq(target, cond) || e.value_matches_type_name(target, e.value_string(cond))
+}
+
+fn (e &Eval) smartcast_binding_from_match(target_id flat.NodeId, target Value, cond Value) ?SmartcastBinding {
+	if cond !is TypeValue {
+		return none
+	}
+	type_cond := cond as TypeValue
+	target_node := e.node(target_id)
+	if target_node.kind != .ident {
+		return none
+	}
+	if value := e.smartcast_value(target, type_cond.name) {
+		return SmartcastBinding{
+			name:      target_node.value
+			value:     value
+			type_name: e.normalize_type_name(type_cond.name)
+		}
+	}
+	return none
+}
+
+fn (mut e Eval) eval_match_condition(cond_id flat.NodeId, target_id flat.NodeId) !Value {
+	cond := e.node(cond_id)
+	if cond.kind == .enum_val {
+		if enum_type := e.match_target_enum_type_name(target_id) {
+			if value := e.lookup_enum_value(enum_type, cond.value) {
+				return value
+			}
+		}
+	}
+	if cond.kind == .ident && is_builtin_type_name(cond.value) {
+		return TypeValue{
+			name: cond.value
+		}
+	}
+	value := e.eval_expr(cond_id)!
+	if value is RangeValue {
+		return RangeValue{
+			start:     value.start
+			end:       value.end
+			inclusive: true
+		}
+	}
+	return value
+}
+
+fn (e &Eval) match_target_enum_type_name(target_id flat.NodeId) ?string {
+	target := e.node(target_id)
+	match target.kind {
+		.ident {
+			if typ := e.lookup_var_type(target.value) {
+				return typ
+			}
+			if target.typ.len > 0 {
+				return e.normalize_type_name(target.typ)
+			}
+		}
+		.selector {
+			if target.children_count > 0 {
+				return e.type_value_name_from_expr(e.child(target, 0))
+			}
+		}
+		else {}
+	}
+
+	return none
+}
+
+fn (e &Eval) type_value_name_from_expr(id flat.NodeId) ?string {
+	node := e.node(id)
+	match node.kind {
+		.ident {
+			if e.has_type_name(e.current_module_name(), node.value) {
+				return e.qualify_type_name(e.current_module_name(), node.value)
+			}
+		}
+		.selector {
+			if node.children_count > 0 {
+				left := e.node(e.child(node, 0))
+				if left.kind == .ident {
+					mod := e.resolve_module_name(left.value)
+					if e.has_type_name(mod, node.value) {
+						return e.qualify_type_name(mod, node.value)
+					}
+				}
+			}
+		}
+		else {}
+	}
+
+	return none
+}
+
+fn (mut e Eval) lookup_enum_value(enum_type_name string, field string) ?Value {
+	mod := if enum_type_name.contains('.') {
+		enum_type_name.all_before_last('.')
+	} else {
+		e.current_module_name()
+	}
+	enum_key := '${enum_type_name.all_after_last('.')}.${field}'
+	if value := e.lookup_const(mod, enum_key) {
+		return e.enum_value(e.qualify_type_name(mod, enum_type_name), value)
+	}
+	return none
+}
+
+fn (e &Eval) enum_value(type_name string, value Value) Value {
+	return EnumValue{
+		type_name: e.normalize_type_name(type_name)
+		value:     e.value_as_int(value) or { i64(0) }
+	}
+}
+
+fn (mut e Eval) maybe_call_builtin(module_name string, fn_name string, args []Value) !MaybeValue {
+	if module_name in ['', 'main', e.current_module_name()] {
+		match fn_name {
+			'print' {
+				if args.len > 0 {
+					e.write_stdout(e.value_string(args[0]))
+				}
+				return MaybeValue{
+					found: true
+					value: void_value()
+				}
+			}
+			'println' {
+				if args.len > 0 {
+					e.write_stdout(e.value_string(args[0]) + '\n')
+				} else {
+					e.write_stdout('\n')
+				}
+				return MaybeValue{
+					found: true
+					value: void_value()
+				}
+			}
+			'eprint' {
+				if args.len > 0 {
+					e.write_stderr(e.value_string(args[0]))
+				}
+				return MaybeValue{
+					found: true
+					value: void_value()
+				}
+			}
+			'eprintln' {
+				if args.len > 0 {
+					e.write_stderr(e.value_string(args[0]) + '\n')
+				} else {
+					e.write_stderr('\n')
+				}
+				return MaybeValue{
+					found: true
+					value: void_value()
+				}
+			}
+			'int_str', 'i64_str', 'u64_str' {
+				return MaybeValue{
+					found: true
+					value: Value(e.value_as_int(args[0] or { Value(i64(0)) })!.str())
+				}
+			}
+			'str' {
+				return MaybeValue{
+					found: true
+					value: Value(e.value_string(args[0] or { void_value() }))
+				}
+			}
+			'panic' {
+				return error(e.value_string(args[0] or { Value('panic') }))
+			}
+			else {}
+		}
+	}
+	if module_name == 'os' {
+		return e.maybe_call_os_builtin(fn_name, args)
+	}
+	return MaybeValue{}
+}
+
+fn (mut e Eval) maybe_call_os_builtin(fn_name string, args []Value) !MaybeValue {
+	match fn_name {
+		'execute' {
+			cmd := e.expect_string_arg(args, 0)!
+			return MaybeValue{
+				found: true
+				value: os_result_value(os.execute(cmd))
+			}
+		}
+		'user_os' {
+			return MaybeValue{
+				found: true
+				value: Value(os.user_os())
+			}
+		}
+		'getenv' {
+			return MaybeValue{
+				found: true
+				value: Value(os.getenv(e.expect_string_arg(args, 0)!))
+			}
+		}
+		'temp_dir' {
+			return MaybeValue{
+				found: true
+				value: Value(os.temp_dir())
+			}
+		}
+		'getpid' {
+			return MaybeValue{
+				found: true
+				value: Value(i64(os.getpid()))
+			}
+		}
+		'join_path' {
+			return MaybeValue{
+				found: true
+				value: Value(args.map(e.value_string(it)).join(os.path_separator))
+			}
+		}
+		'join_path_single' {
+			a := e.expect_string_arg(args, 0)!
+			b := e.expect_string_arg(args, 1)!
+			return MaybeValue{
+				found: true
+				value: Value(os.join_path_single(a, b))
+			}
+		}
+		'dir' {
+			return MaybeValue{
+				found: true
+				value: Value(os.dir(e.expect_string_arg(args, 0)!))
+			}
+		}
+		'is_dir' {
+			return MaybeValue{
+				found: true
+				value: Value(os.is_dir(e.expect_string_arg(args, 0)!))
+			}
+		}
+		'exists' {
+			return MaybeValue{
+				found: true
+				value: Value(os.exists(e.expect_string_arg(args, 0)!))
+			}
+		}
+		'quoted_path' {
+			return MaybeValue{
+				found: true
+				value: Value(os.quoted_path(e.expect_string_arg(args, 0)!))
+			}
+		}
+		else {
+			return MaybeValue{}
+		}
+	}
+}
+
+fn os_result_value(result os.Result) Value {
+	return StructValue{
+		type_name: 'os.Result'
+		fields:    {
+			'exit_code': Value(i64(result.exit_code))
+			'output':    Value(result.output)
+		}
+	}
+}
+
+fn (mut e Eval) call_value_method(receiver Value, receiver_type_name string, method_name string, args []Value) !MethodCallResult {
+	static_type_name := e.normalize_type_name(receiver_type_name)
+	if static_type_name.len > 0 {
+		if target := e.resolve_method_target(static_type_name, method_name) {
+			return e.call_method_target(receiver, target, args)!
+		}
+	}
+	if receiver is string {
+		value := e.call_string_method(receiver, method_name, args)!
+		return MethodCallResult{
+			value:    value
+			receiver: receiver
+		}
+	}
+	if receiver is ArrayValue {
+		value := e.call_array_method(receiver, method_name, args)!
+		return MethodCallResult{
+			value:    value
+			receiver: receiver
+		}
+	}
+	if receiver is MapValue {
+		value := e.call_map_method(receiver, method_name, args)!
+		return MethodCallResult{
+			value:            value
+			receiver_changed: method_name in ['clear', 'delete']
+			receiver:         value
+		}
+	}
+	if receiver is StructValue {
+		if target := e.resolve_method_target(receiver.type_name, method_name) {
+			return e.call_method_target(receiver, target, args)!
+		}
+	}
+	if receiver is SumValue {
+		result := e.call_value_method(receiver.payload, receiver.variant_name, method_name, args)!
+		if result.receiver_changed {
+			return MethodCallResult{
+				value:            result.value
+				receiver_changed: true
+				receiver:         SumValue{
+					type_name:    receiver.type_name
+					variant_name: receiver.variant_name
+					payload:      result.receiver
+				}
+				mutated_args:     result.mutated_args
+			}
+		}
+		return result
+	}
+	return error('v3.eval: unsupported method `${method_name}` on `${e.runtime_type_name(receiver)}`')
+}
+
+fn (mut e Eval) call_method_target(receiver Value, target FunctionDef, args []Value) !MethodCallResult {
+	mut call_args := []Value{}
+	call_args << receiver
+	call_args << args
+	result := e.call_function(target.module_name, target.name, call_args)!
+	mut value := Value(void_value())
+	if result.values.len == 1 {
+		value = result.values[0]
+	} else {
+		value = TupleValue{
+			values: result.values
+		}
+	}
+	mut updated_receiver := receiver
+	mut receiver_changed := false
+	if 0 in result.mutated_args {
+		receiver_changed = true
+		updated_receiver = result.mutated_args[0] or { receiver }
+	}
+	mut mutated_args := map[int]Value{}
+	for arg_index, mutated_value in result.mutated_args {
+		if arg_index > 0 {
+			mutated_args[arg_index - 1] = mutated_value
+		}
+	}
+	return MethodCallResult{
+		value:            value
+		receiver_changed: receiver_changed
+		receiver:         updated_receiver
+		mutated_args:     mutated_args
+	}
+}
+
+fn (e &Eval) resolve_method_target(type_name string, method_name string) ?FunctionDef {
+	short_type := type_name.all_after_last('.')
+	module_name := if type_name.contains('.') {
+		type_name.all_before_last('.')
+	} else {
+		e.current_module_name()
+	}
+	names := ['${type_name}.${method_name}', '${short_type}.${method_name}']
+	if module_name in e.functions {
+		for name in names {
+			if name in e.functions[module_name] {
+				return e.functions[module_name][name]
+			}
+		}
+	}
+	for mod in e.functions.keys() {
+		for name in names {
+			if name in e.functions[mod] {
+				return e.functions[mod][name]
+			}
+		}
+	}
+	return none
+}
+
+fn (e &Eval) infix_operator_call_info(left Value, op flat.Op) ?InfixOperatorCallInfo {
+	type_name := e.infix_operator_receiver_type_name(left)
+	if type_name.len == 0 {
+		return none
+	}
+	if op_name := infix_operator_symbol(op) {
+		if target := e.resolve_method_target(type_name, op_name) {
+			return InfixOperatorCallInfo{
+				target: target
+			}
+		}
+	}
+	match op {
+		.gt {
+			if target := e.resolve_method_target(type_name, '<') {
+				return InfixOperatorCallInfo{
+					target:  target
+					reverse: true
+				}
+			}
+		}
+		.ge {
+			if target := e.resolve_method_target(type_name, '<') {
+				return InfixOperatorCallInfo{
+					target: target
+					negate: true
+				}
+			}
+		}
+		.le {
+			if target := e.resolve_method_target(type_name, '<') {
+				return InfixOperatorCallInfo{
+					target:  target
+					reverse: true
+					negate:  true
+				}
+			}
+		}
+		.ne {
+			if target := e.resolve_method_target(type_name, '==') {
+				return InfixOperatorCallInfo{
+					target: target
+					negate: true
+				}
+			}
+		}
+		else {}
+	}
+
+	return none
+}
+
+fn (e &Eval) infix_operator_receiver_type_name(value Value) string {
+	return match value {
+		StructValue { value.type_name }
+		else { '' }
+	}
+}
+
+fn infix_operator_symbol(op flat.Op) ?string {
+	return match op {
+		.plus { '+' }
+		.minus { '-' }
+		.mul { '*' }
+		.div { '/' }
+		.mod { '%' }
+		.eq { '==' }
+		.ne { '!=' }
+		.lt { '<' }
+		.gt { '>' }
+		.le { '<=' }
+		.ge { '>=' }
+		else { none }
+	}
+}
+
+fn (mut e Eval) apply_infix_operator_overload(op flat.Op, left Value, right Value) !MaybeValue {
+	if call_info := e.infix_operator_call_info(left, op) {
+		mut receiver := left
+		mut arg := right
+		if call_info.reverse {
+			receiver = right
+			arg = left
+		}
+		result := e.call_method_target(receiver, call_info.target, [arg])!
+		mut value := result.value
+		if call_info.negate {
+			value = Value(!e.value_as_bool(value)!)
+		}
+		return MaybeValue{
+			found: true
+			value: value
+		}
+	}
+	return MaybeValue{}
+}
+
+fn (mut e Eval) call_string_method(receiver string, method_name string, args []Value) !Value {
+	match method_name {
+		'int' {
+			return Value(strconv.parse_int(receiver, 10, 64) or { i64(0) })
+		}
+		'i64' {
+			return Value(strconv.parse_int(receiver, 10, 64) or { i64(0) })
+		}
+		'str' {
+			return Value(receiver)
+		}
+		'contains' {
+			return Value(receiver.contains(e.expect_string_arg(args, 0)!))
+		}
+		'starts_with' {
+			return Value(receiver.starts_with(e.expect_string_arg(args, 0)!))
+		}
+		'ends_with' {
+			return Value(receiver.ends_with(e.expect_string_arg(args, 0)!))
+		}
+		'all_after_last' {
+			return Value(receiver.all_after_last(e.expect_string_arg(args, 0)!))
+		}
+		'all_before_last' {
+			return Value(receiver.all_before_last(e.expect_string_arg(args, 0)!))
+		}
+		'trim_space' {
+			return Value(receiver.trim_space())
+		}
+		else {
+			return error('v3.eval: unsupported string method `${method_name}`')
+		}
+	}
+}
+
+fn (mut e Eval) call_array_method(receiver ArrayValue, method_name string, args []Value) !Value {
+	match method_name {
+		'clone', 'move' {
+			return ArrayValue{
+				elem_type_name: receiver.elem_type_name
+				values:         receiver.values.clone()
+			}
+		}
+		'first' {
+			if receiver.values.len == 0 {
+				return error('v3.eval: array.first on empty array')
+			}
+			return receiver.values[0]
+		}
+		'last' {
+			if receiver.values.len == 0 {
+				return error('v3.eval: array.last on empty array')
+			}
+			return receiver.values[receiver.values.len - 1]
+		}
+		'contains' {
+			return Value(receiver.values.any(e.value_eq(it, args[0] or { void_value() })))
+		}
+		'index' {
+			needle := args[0] or { void_value() }
+			for i, item in receiver.values {
+				if e.value_eq(item, needle) {
+					return Value(i64(i))
+				}
+			}
+			return Value(i64(-1))
+		}
+		'join' {
+			sep := e.expect_string_arg(args, 0) or { '' }
+			return Value(receiver.values.map(e.value_string(it)).join(sep))
+		}
+		else {
+			return error('v3.eval: unsupported array method `${method_name}`')
+		}
+	}
+}
+
+fn (mut e Eval) call_map_method(receiver MapValue, method_name string, args []Value) !Value {
+	match method_name {
+		'keys' {
+			return e.map_keys(receiver)
+		}
+		'values' {
+			return e.map_values(receiver)
+		}
+		'clone', 'move' {
+			return e.map_clone(receiver)
+		}
+		'clear' {
+			return MapValue{
+				key_type_name:   receiver.key_type_name
+				value_type_name: receiver.value_type_name
+				default_value:   receiver.default_value
+			}
+		}
+		'delete' {
+			if args.len == 0 {
+				return receiver
+			}
+			return e.map_delete_value(receiver, args[0])
+		}
+		else {
+			return error('v3.eval: unsupported map method `${method_name}`')
+		}
+	}
+}
+
+fn (mut e Eval) apply_infix(op flat.Op, left Value, right Value) !Value {
+	overloaded := e.apply_infix_operator_overload(op, left, right)!
+	if overloaded.found {
+		return overloaded.value
+	}
+	match op {
+		.plus {
+			if left is string || right is string {
+				return Value(e.value_string(left) + e.value_string(right))
+			}
+			if left is f64 || right is f64 {
+				return Value(e.value_as_f64(left)! + e.value_as_f64(right)!)
+			}
+			return Value(e.value_as_int(left)! + e.value_as_int(right)!)
+		}
+		.minus {
+			if left is f64 || right is f64 {
+				return Value(e.value_as_f64(left)! - e.value_as_f64(right)!)
+			}
+			return Value(e.value_as_int(left)! - e.value_as_int(right)!)
+		}
+		.mul {
+			if left is f64 || right is f64 {
+				return Value(e.value_as_f64(left)! * e.value_as_f64(right)!)
+			}
+			return Value(e.value_as_int(left)! * e.value_as_int(right)!)
+		}
+		.div {
+			if left is f64 || right is f64 {
+				return Value(e.value_as_f64(left)! / e.value_as_f64(right)!)
+			}
+			return Value(e.value_as_int(left)! / e.value_as_int(right)!)
+		}
+		.mod {
+			return Value(e.value_as_int(left)! % e.value_as_int(right)!)
+		}
+		.eq {
+			return Value(e.value_eq(left, right))
+		}
+		.ne {
+			return Value(!e.value_eq(left, right))
+		}
+		.lt {
+			return Value(e.compare_values(left, right) < 0)
+		}
+		.gt {
+			return Value(e.compare_values(left, right) > 0)
+		}
+		.le {
+			return Value(e.compare_values(left, right) <= 0)
+		}
+		.ge {
+			return Value(e.compare_values(left, right) >= 0)
+		}
+		.amp {
+			return Value(e.value_as_int(left)! & e.value_as_int(right)!)
+		}
+		.pipe {
+			return Value(e.value_as_int(left)! | e.value_as_int(right)!)
+		}
+		.xor {
+			return Value(e.value_as_int(left)! ^ e.value_as_int(right)!)
+		}
+		.left_shift {
+			mut result := e.value_as_int(left)!
+			for _ in 0 .. int(e.value_as_int(right)!) {
+				result *= 2
+			}
+			return Value(result)
+		}
+		.right_shift {
+			return Value(e.value_as_int(left)! >> e.value_as_int(right)!)
+		}
+		.right_shift_unsigned {
+			return Value(i64(u64(e.value_as_int(left)!) >>> e.value_as_int(right)!))
+		}
+		else {
+			return error('v3.eval: unsupported infix operator `${op}`')
+		}
+	}
+}
+
+fn (e &Eval) value_in(left Value, right Value) bool {
+	match right {
+		ArrayValue {
+			return right.values.any(e.value_eq(it, left))
+		}
+		MapValue {
+			return e.map_contains_key(right, left)
+		}
+		string {
+			return right.contains(e.value_string(left))
+		}
+		RangeValue {
+			v := e.value_as_int(left) or { return false }
+			if right.inclusive {
+				return v >= right.start && v <= right.end
+			}
+			return v >= right.start && v < right.end
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn (e &Eval) compare_values(left Value, right Value) int {
+	if left is string && right is string {
+		return left.compare(right)
+	}
+	lf := e.value_as_f64(left) or { 0.0 }
+	rf := e.value_as_f64(right) or { 0.0 }
+	if lf < rf {
+		return -1
+	}
+	if lf > rf {
+		return 1
+	}
+	return 0
+}
+
+fn (e &Eval) value_eq(left Value, right Value) bool {
+	match left {
+		bool {
+			return right is bool && left == right
+		}
+		i64 {
+			if right is f64 {
+				return f64(left) == right
+			}
+			return e.value_as_int(right) or { return false } == left
+		}
+		EnumValue {
+			if right is EnumValue {
+				return e.type_name_matches(left.type_name, right.type_name)
+					&& left.value == right.value
+			}
+			return e.value_as_int(right) or { return false } == left.value
+		}
+		f64 {
+			return e.value_as_f64(right) or { return false } == left
+		}
+		string {
+			return right is string && left == right
+		}
+		VoidValue {
+			return right is VoidValue
+		}
+		TypeValue {
+			return right is TypeValue && left.name == right.name
+		}
+		ModuleValue {
+			return right is ModuleValue && left.name == right.name
+		}
+		ArrayValue {
+			if right !is ArrayValue {
+				return false
+			}
+			right_arr := right as ArrayValue
+			if left.values.len != right_arr.values.len {
+				return false
+			}
+			for i, item in left.values {
+				if !e.value_eq(item, right_arr.values[i]) {
+					return false
+				}
+			}
+			return true
+		}
+		StructValue {
+			if right !is StructValue {
+				return false
+			}
+			right_struct := right as StructValue
+			if left.type_name != right_struct.type_name
+				|| left.fields.len != right_struct.fields.len {
+				return false
+			}
+			for name, value in left.fields {
+				right_value := right_struct.fields[name] or { return false }
+				if !e.value_eq(value, right_value) {
+					return false
+				}
+			}
+			return true
+		}
+		SumValue {
+			return right is SumValue && left.type_name == right.type_name
+				&& left.variant_name == right.variant_name
+				&& e.value_eq(left.payload, right.payload)
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn (e &Eval) map_lookup(receiver MapValue, key Value) (Value, bool) {
+	for entry in receiver.entries {
+		if e.value_eq(entry.key, key) {
+			return entry.value, true
+		}
+	}
+	return receiver.default_value, false
+}
+
+fn (e &Eval) map_contains_key(receiver MapValue, key Value) bool {
+	_, ok := e.map_lookup(receiver, key)
+	return ok
+}
+
+fn (e &Eval) map_set_value(receiver MapValue, key Value, value Value) MapValue {
+	entry_value := e.adapt_value_to_type_name(value, receiver.value_type_name)
+	mut m := MapValue{
+		key_type_name:   receiver.key_type_name
+		value_type_name: receiver.value_type_name
+		default_value:   receiver.default_value
+		entries:         receiver.entries.clone()
+	}
+	for i, entry in m.entries {
+		if e.value_eq(entry.key, key) {
+			m.entries[i].value = entry_value
+			return m
+		}
+	}
+	m.entries << MapEntry{
+		key:   key
+		value: entry_value
+	}
+	return m
+}
+
+fn (e &Eval) map_delete_value(receiver MapValue, key Value) MapValue {
+	mut m := receiver
+	for i, entry in m.entries {
+		if e.value_eq(entry.key, key) {
+			m.entries.delete(i)
+			break
+		}
+	}
+	return m
+}
+
+fn (e &Eval) map_keys(receiver MapValue) ArrayValue {
+	return ArrayValue{
+		elem_type_name: receiver.key_type_name
+		values:         receiver.entries.map(it.key)
+	}
+}
+
+fn (e &Eval) map_values(receiver MapValue) ArrayValue {
+	return ArrayValue{
+		elem_type_name: receiver.value_type_name
+		values:         receiver.entries.map(it.value)
+	}
+}
+
+fn (e &Eval) map_clone(receiver MapValue) MapValue {
+	return MapValue{
+		key_type_name:   receiver.key_type_name
+		value_type_name: receiver.value_type_name
+		default_value:   receiver.default_value
+		entries:         receiver.entries.clone()
+	}
+}
+
+fn (mut e Eval) zero_value_like(value Value) Value {
+	match value {
+		bool {
+			return Value(false)
+		}
+		i64 {
+			return Value(i64(0))
+		}
+		f64 {
+			return Value(0.0)
+		}
+		EnumValue {
+			return EnumValue{
+				type_name: value.type_name
+			}
+		}
+		string {
+			return Value('')
+		}
+		ArrayValue {
+			return ArrayValue{
+				elem_type_name: value.elem_type_name
+			}
+		}
+		MapValue {
+			return MapValue{
+				key_type_name:   value.key_type_name
+				value_type_name: value.value_type_name
+				default_value:   value.default_value
+			}
+		}
+		StructValue {
+			return e.zero_struct_value(value.type_name)
+		}
+		SumValue {
+			return SumValue{
+				type_name:    value.type_name
+				variant_name: value.variant_name
+				payload:      e.zero_value_like(value.payload)
+			}
+		}
+		else {
+			return void_value()
+		}
+	}
+}
+
+fn (mut e Eval) zero_value_for_type_name(type_name string) Value {
+	return e.zero_value_for_type_name_in_module(type_name, e.current_module_name())
+}
+
+fn (mut e Eval) zero_value_for_type_name_in_module(type_name string, module_name string) Value {
+	name := type_name.trim_left('&')
+	if name == '' || name == 'void' {
+		return void_value()
+	}
+	if alias := e.type_alias_info_in_module(name, module_name) {
+		return e.zero_value_for_type_name_in_module(alias.target, alias.module_name)
+	}
+	if name == 'bool' {
+		return Value(false)
+	}
+	if name in ['f32', 'f64'] {
+		return Value(0.0)
+	}
+	if name == 'string' {
+		return Value('')
+	}
+	if name in ['int', 'i8', 'i16', 'i32', 'i64', 'u8', 'byte', 'u16', 'u32', 'u64', 'isize', 'usize',
+		'rune', 'char'] {
+		return Value(i64(0))
+	}
+	if name.starts_with('[]') {
+		return ArrayValue{
+			elem_type_name: name[2..]
+		}
+	}
+	if is_fixed_array_type_name(name) {
+		elem_type := fixed_array_elem_type_name(name)
+		len := fixed_array_len(name)
+		return ArrayValue{
+			elem_type_name: elem_type
+			values:         []Value{len: len, cap: len, init: e.zero_value_for_type_name_in_module(elem_type,
+				module_name)}
+		}
+	}
+	if name.starts_with('map[') {
+		key_type, value_type := split_map_type(name)
+		return MapValue{
+			key_type_name:   key_type
+			value_type_name: value_type
+			default_value:   e.zero_value_for_type_name_in_module(value_type, module_name)
+		}
+	}
+	sum_name := e.qualify_type_name(module_name, name)
+	if sum_name in e.sum_types {
+		return SumValue{
+			type_name: sum_name
+			payload:   void_value()
+		}
+	}
+	if name in e.sum_types {
+		return SumValue{
+			type_name: name
+			payload:   void_value()
+		}
+	}
+	struct_name := e.resolve_struct_type_name_in_module(name, module_name)
+	if struct_name in e.structs {
+		return e.zero_struct_value(struct_name)
+	}
+	return void_value()
+}
+
+fn (mut e Eval) zero_struct_value(type_name string) StructValue {
+	name := e.resolve_struct_type_name(type_name)
+	mut fields := map[string]Value{}
+	info := e.struct_info(name)
+	for field in info.fields {
+		fields[field.name] = if int(field.default_node) >= 0 {
+			e.eval_struct_field_default(field)
+		} else {
+			e.zero_value_for_type_name_in_module(field.typ, info.module_name)
+		}
+	}
+	return StructValue{
+		type_name: type_name
+		fields:    fields
+	}
+}
+
+fn (mut e Eval) eval_struct_field_default(field FieldInfo) Value {
+	e.call_stack << CallFrame{
+		module_name: field.module_name
+		file_name:   field.file_name
+		fn_name:     '<field ${field.name}>'
+	}
+	value := e.eval_expr_expected(field.default_node, field.typ) or {
+		e.call_stack.delete(e.call_stack.len - 1)
+		return e.zero_value_for_type_name_in_module(field.typ, field.module_name)
+	}
+	e.call_stack.delete(e.call_stack.len - 1)
+	return e.adapt_value_to_type_name(value, field.typ)
+}
+
+fn (e &Eval) struct_fields(type_name string) []FieldInfo {
+	return e.struct_info(type_name).fields
+}
+
+fn (e &Eval) struct_field_type_name(value StructValue, field_name string) string {
+	info := e.struct_info(value.type_name)
+	for field in info.fields {
+		if field.name == field_name {
+			return e.qualify_type_name(field.module_name, field.typ)
+		}
+	}
+	return ''
+}
+
+fn (e &Eval) struct_info(type_name string) StructInfo {
+	name := e.resolve_struct_type_name(type_name)
+	if name in e.structs {
+		return e.structs[name]
+	}
+	return StructInfo{}
+}
+
+fn (e &Eval) resolve_struct_type_name(type_name string) string {
+	return e.resolve_struct_type_name_in_module(type_name, e.current_module_name())
+}
+
+fn (e &Eval) resolve_struct_type_name_in_module(type_name string, module_name string) string {
+	if type_name.contains('.') {
+		if type_name in e.structs {
+			return type_name
+		}
+		return type_name
+	}
+	qualified := e.qualify_type_name(module_name, type_name)
+	if qualified in e.structs {
+		return qualified
+	}
+	if type_name in e.structs {
+		return type_name
+	}
+	short := type_name.all_after_last('.')
+	if short in e.structs {
+		return short
+	}
+	return type_name
+}
+
+fn (e &Eval) adapt_value_to_type_name(value Value, type_name string) Value {
+	if alias := e.type_alias_info_in_module(type_name, e.current_module_name()) {
+		return e.adapt_value_to_type_name(value, e.qualify_type_name(alias.module_name,
+			alias.target))
+	}
+	if type_name.starts_with('?') {
+		if value is VoidValue || e.is_option_like_value(value) {
+			return value
+		}
+		inner_type := type_name[1..]
+		data := if inner_type.len > 0 {
+			e.adapt_value_to_type_name(value, inner_type)
+		} else {
+			value
+		}
+		return StructValue{
+			type_name: 'Option'
+			fields:    {
+				'state': Value(i64(0))
+				'err':   Value('')
+				'data':  data
+			}
+		}
+	}
+	if type_name.starts_with('!') {
+		if e.is_option_like_value(value) {
+			return value
+		}
+		inner_type := type_name[1..]
+		data := if inner_type.len > 0 {
+			e.adapt_value_to_type_name(value, inner_type)
+		} else {
+			value
+		}
+		return StructValue{
+			type_name: 'Result'
+			fields:    {
+				'is_error': Value(false)
+				'err':      Value('')
+				'data':     data
+			}
+		}
+	}
+	if type_name.starts_with('[]') && value is ArrayValue {
+		elem_type_name := type_name[2..]
+		mut arr := value
+		arr.elem_type_name = elem_type_name
+		mut values := []Value{cap: arr.values.cap}
+		for item in arr.values {
+			values << e.adapt_value_to_type_name(item, elem_type_name)
+		}
+		arr.values = values
+		return arr
+	}
+	target_type_name := e.normalize_type_name(type_name)
+	if target_type_name in e.sum_types && !e.value_matches_type_name(value, target_type_name) {
+		return e.wrap_sum_value(target_type_name, value)
+	}
+	if type_name in e.sum_types && !e.value_matches_type_name(value, type_name) {
+		return e.wrap_sum_value(type_name, value)
+	}
+	return value
+}
+
+fn (e &Eval) is_option_like_value(value Value) bool {
+	if value is StructValue {
+		return 'data' in value.fields && ('state' in value.fields || 'is_error' in value.fields)
+	}
+	return false
+}
+
+fn (e &Eval) wrap_sum_value(type_name string, value Value) Value {
+	return SumValue{
+		type_name:    type_name
+		variant_name: e.runtime_type_name(value)
+		payload:      value
+	}
+}
+
+fn (e &Eval) unwrap_sum_cast_value(value Value, type_name string) Value {
+	if value is SumValue {
+		if !e.type_name_matches(value.type_name, type_name)
+			&& (e.type_name_matches(value.variant_name, type_name)
+			|| e.value_matches_type_name(value.payload, type_name)) {
+			return value.payload
+		}
+	}
+	return value
+}
+
+fn (e &Eval) cast_value(value Value, type_name string) !Value {
+	return e.cast_value_in_module(value, type_name, e.current_module_name())
+}
+
+fn (e &Eval) cast_value_in_module(value Value, type_name string, module_name string) !Value {
+	name := type_name.trim_left('&')
+	if name == '' {
+		return value
+	}
+	if alias := e.type_alias_info_in_module(name, module_name) {
+		return e.cast_value_in_module(value, alias.target, alias.module_name)
+	}
+	target_name := e.qualify_type_name(module_name, name)
+	source := e.unwrap_sum_cast_value(value, target_name)
+	if name in ['int', 'i8', 'i16', 'i32', 'i64', 'u8', 'byte', 'u16', 'u32', 'u64', 'isize', 'usize',
+		'rune', 'char'] {
+		return Value(e.value_as_int(source)!)
+	}
+	if name in ['f32', 'f64'] {
+		return Value(e.value_as_f64(source)!)
+	}
+	if name == 'bool' {
+		return Value(e.value_as_bool(source)!)
+	}
+	if name == 'string' {
+		return Value(e.value_string(source))
+	}
+	if name.starts_with('?') {
+		inner_type := name[1..]
+		data := if inner_type.len > 0 {
+			e.adapt_value_to_type_name(source, inner_type)
+		} else {
+			source
+		}
+		return StructValue{
+			type_name: 'Option'
+			fields:    {
+				'state': Value(i64(0))
+				'err':   Value('')
+				'data':  data
+			}
+		}
+	}
+	if target_name in e.sum_types || name in e.sum_types {
+		sum_name := if target_name in e.sum_types { target_name } else { name }
+		if e.value_matches_type_name(source, sum_name) {
+			return source
+		}
+		return e.wrap_sum_value(sum_name, source)
+	}
+	return source
+}
+
+fn (e &Eval) type_alias_info_in_module(type_name string, module_name string) ?TypeAliasInfo {
+	name := type_name.trim_left('&')
+	if name == '' {
+		return none
+	}
+	qualified := e.qualify_type_name(module_name, name)
+	if alias := e.type_aliases[qualified] {
+		return alias
+	}
+	if alias := e.type_aliases[name] {
+		return alias
+	}
+	return none
+}
+
+fn (e &Eval) value_matches_type_name(value Value, target_name string) bool {
+	name := e.normalize_type_name(target_name)
+	match value {
+		bool {
+			return name == 'bool'
+		}
+		i64 {
+			return name in ['int', 'i8', 'i16', 'i32', 'i64', 'u8', 'byte', 'u16', 'u32', 'u64',
+				'isize', 'usize', 'rune', 'char']
+		}
+		EnumValue {
+			return e.type_name_matches(value.type_name, name)
+		}
+		f64 {
+			return name in ['f32', 'f64']
+		}
+		string {
+			return name == 'string'
+		}
+		ArrayValue {
+			if name == 'array' {
+				return true
+			}
+			if !name.starts_with('[]') {
+				return false
+			}
+			return e.type_name_matches(value.elem_type_name, name[2..])
+		}
+		MapValue {
+			if !name.starts_with('map[') {
+				return false
+			}
+			key_type, value_type := split_map_type(name)
+			return e.type_name_matches(value.key_type_name, key_type)
+				&& e.type_name_matches(value.value_type_name, value_type)
+		}
+		StructValue {
+			return e.type_name_matches(value.type_name, name)
+		}
+		SumValue {
+			return e.type_name_matches(value.type_name, name)
+				|| e.type_name_matches(value.variant_name, name)
+				|| e.value_matches_type_name(value.payload, name)
+		}
+		TypeValue {
+			return name == 'Type' || name == 'types.Type'
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn (e &Eval) type_name_matches(actual string, expected string) bool {
+	return e.normalize_type_name(actual) == e.normalize_type_name(expected)
+}
+
+fn (e &Eval) type_value_module_name(value TypeValue) string {
+	if value.name.contains('.') {
+		return value.name.all_before_last('.')
+	}
+	return e.current_module_name()
+}
+
+fn is_builtin_type_name(name string) bool {
+	return name in ['bool', 'int', 'i8', 'i16', 'i32', 'i64', 'isize', 'u8', 'byte', 'u16', 'u32',
+		'u64', 'usize', 'f32', 'f64', 'rune', 'char', 'string', 'void', 'voidptr', 'charptr',
+		'byteptr', 'array']
+}
+
+fn (e &Eval) qualify_type_name(module_name string, type_name string) string {
+	name := e.resolve_import_alias_type_name(type_name)
+	if name == '' || name.contains('.') || name.starts_with('[]') || name.starts_with('map[')
+		|| is_builtin_type_name(name) {
+		return name
+	}
+	if module_name != '' && module_name != 'main' && module_name != 'builtin' {
+		return '${module_name}.${name}'
+	}
+	return name
+}
+
+fn (e &Eval) resolve_import_alias_type_name(type_name string) string {
+	if !type_name.contains('.') {
+		return type_name
+	}
+	mod_alias := type_name.all_before('.')
+	real_module := e.resolve_module_name(mod_alias)
+	if real_module == mod_alias {
+		return type_name
+	}
+	return '${real_module}.${type_name.all_after('.')}'
+}
+
+fn (e &Eval) normalize_type_name(type_name string) string {
+	name := type_name.trim_left('&')
+	if name == '' {
+		return ''
+	}
+	return e.qualify_type_name(e.current_module_name(), name)
+}
+
+fn (e &Eval) sizeof_type_name(name string) i64 {
+	return match name {
+		'bool', 'i8', 'u8', 'byte', 'char' { i64(1) }
+		'i16', 'u16' { i64(2) }
+		'int', 'i32', 'u32', 'rune', 'f32' { i64(4) }
+		'i64', 'u64', 'isize', 'usize', 'f64' { i64(8) }
+		else { i64(8) }
+	}
+}
+
+fn (e &Eval) expect_string_arg(args []Value, index int) !string {
+	if index >= args.len {
+		return error('v3.eval: missing argument ${index}')
+	}
+	return e.value_string(args[index])
+}
+
+fn (e &Eval) value_as_bool(value Value) !bool {
+	match value {
+		bool { return value }
+		i64 { return value != 0 }
+		EnumValue { return value.value != 0 }
+		VoidValue { return false }
+		else { return error('v3.eval: `${e.runtime_type_name(value)}` can not be used as bool') }
+	}
+}
+
+fn (e &Eval) value_as_int(value Value) !i64 {
+	match value {
+		i64 {
+			return value
+		}
+		EnumValue {
+			return value.value
+		}
+		f64 {
+			return i64(value)
+		}
+		bool {
+			return if value { i64(1) } else { i64(0) }
+		}
+		string {
+			return strconv.parse_int(value, 10, 64) or { i64(0) }
+		}
+		StructValue {
+			if 'value' in value.fields {
+				return e.value_as_int(value.fields['value'] or { void_value() })
+			}
+		}
+		else {}
+	}
+
+	return error('v3.eval: `${e.runtime_type_name(value)}` can not be used as int')
+}
+
+fn (e &Eval) value_as_f64(value Value) !f64 {
+	match value {
+		f64 { return value }
+		i64 { return f64(value) }
+		EnumValue { return f64(value.value) }
+		bool { return if value { 1.0 } else { 0.0 } }
+		string { return strconv.atof64(value) or { 0.0 } }
+		else { return error('v3.eval: `${e.runtime_type_name(value)}` can not be used as float') }
+	}
+}
+
+fn (e &Eval) value_string(value Value) string {
+	match value {
+		bool {
+			return value.str()
+		}
+		i64 {
+			return value.str()
+		}
+		EnumValue {
+			return value.value.str()
+		}
+		f64 {
+			return value.str()
+		}
+		string {
+			return value
+		}
+		VoidValue {
+			return ''
+		}
+		ArrayValue {
+			return '[' + value.values.map(e.value_string(it)).join(', ') + ']'
+		}
+		MapValue {
+			return '{' +
+				value.entries.map('${e.value_string(it.key)}: ${e.value_string(it.value)}').join(', ') +
+				'}'
+		}
+		ModuleValue {
+			return value.name
+		}
+		RangeValue {
+			return '${value.start}..${value.end}'
+		}
+		StructValue {
+			if value.type_name == 'os.Result' && 'output' in value.fields {
+				return e.value_string(value.fields['output'] or { void_value() })
+			}
+			return value.type_name
+		}
+		SumValue {
+			return e.value_string(value.payload)
+		}
+		TupleValue {
+			return value.values.map(e.value_string(it)).join(', ')
+		}
+		TypeValue {
+			return value.name
+		}
+		FnValue {
+			return '<fn>'
+		}
+	}
+}
+
+fn (e &Eval) runtime_type_name(value Value) string {
+	match value {
+		bool { return 'bool' }
+		i64 { return 'int' }
+		EnumValue { return value.type_name }
+		f64 { return 'f64' }
+		string { return 'string' }
+		VoidValue { return 'void' }
+		ArrayValue { return '[]${value.elem_type_name}' }
+		MapValue { return 'map[${value.key_type_name}]${value.value_type_name}' }
+		ModuleValue { return 'module' }
+		RangeValue { return 'range' }
+		StructValue { return value.type_name }
+		SumValue { return value.type_name }
+		TupleValue { return 'tuple' }
+		TypeValue { return value.name }
+		FnValue { return 'fn' }
+	}
+}
+
+fn (mut e Eval) write_stdout(s string) {
+	if e.capture_output {
+		e.stdout_data += s
+	} else {
+		print(s)
+	}
+}
+
+fn (mut e Eval) write_stderr(s string) {
+	if e.capture_output {
+		e.stderr_data += s
+	} else {
+		eprint(s)
+	}
+}

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -153,6 +153,7 @@ struct CallFrame {
 	module_name string
 	file_name   string
 	fn_name     string
+	return_type string
 	scope_idx   int = -1
 }
 
@@ -791,6 +792,7 @@ fn (mut e Eval) call_function(module_name string, fn_name string, args []Value) 
 		module_name: target_module
 		file_name:   def.file_name
 		fn_name:     fn_name
+		return_type: node.typ
 		scope_idx:   e.scopes.len - 1
 	}
 	e.bind_call_params(params, args)!
@@ -801,11 +803,16 @@ fn (mut e Eval) call_function(module_name string, fn_name string, args []Value) 
 	signal := e.exec_stmts(body_ids)!
 	e.run_deferred_stmts()!
 	mutated_args := e.collect_mutated_param_args(params, args)
+	adapted_values := if signal.kind == .return_ {
+		e.adapt_return_values(signal.values, node.typ)
+	} else {
+		[]Value{}
+	}
 	e.close_scope()!
 	e.call_stack.delete(e.call_stack.len - 1)
 	if signal.kind == .return_ {
 		return CallResult{
-			values:       e.adapt_return_values(signal.values, node.typ)
+			values:       adapted_values
 			mutated_args: mutated_args
 		}
 	}
@@ -895,8 +902,14 @@ fn (mut e Eval) exec_stmt(id flat.NodeId) !FlowSignal {
 		}
 		.return_stmt {
 			mut values := []Value{}
+			return_type := e.current_return_type()
+			return_types := split_multi_return_types(return_type)
+			child_count := node.children_count
+			mut child_index := 0
 			for child_id in e.children(node) {
-				signal := e.eval_expr_flow(child_id)!
+				expected_type := return_child_expected_type(return_type, return_types, child_index,
+					child_count)
+				signal := e.eval_expr_flow_expected(child_id, expected_type)!
 				if signal.kind != .normal {
 					return signal
 				}
@@ -911,6 +924,7 @@ fn (mut e Eval) exec_stmt(id flat.NodeId) !FlowSignal {
 				} else {
 					values << value
 				}
+				child_index++
 			}
 			if values.len == 0 {
 				values << void_value()
@@ -2103,6 +2117,9 @@ fn (mut e Eval) eval_expr_flow(id flat.NodeId) !FlowSignal {
 				values:         values
 			})
 		}
+		.array_init {
+			return e.eval_array_init_flow(node)
+		}
 		.struct_init {
 			return e.eval_struct_init_flow(node)
 		}
@@ -2141,6 +2158,26 @@ fn (mut e Eval) eval_expr_flow_expected(id flat.NodeId, expected_type string) !F
 		}
 	}
 	return e.eval_expr_flow(id)
+}
+
+fn (e &Eval) current_return_type() string {
+	if e.call_stack.len == 0 {
+		return ''
+	}
+	return e.call_stack[e.call_stack.len - 1].return_type
+}
+
+fn return_child_expected_type(return_type string, return_types []string, child_index int, child_count int) string {
+	if return_types.len > 0 {
+		if child_count == return_types.len && child_index < return_types.len {
+			return return_types[child_index]
+		}
+		return ''
+	}
+	if child_count == 1 {
+		return return_type
+	}
+	return ''
 }
 
 fn (mut e Eval) eval_infix_flow(node &flat.Node) !FlowSignal {
@@ -2857,6 +2894,7 @@ fn (mut e Eval) call_fn_value(fv FnValue, args []Value) !CallResult {
 		module_name: fv.module_name
 		file_name:   fv.file_name
 		fn_name:     '<anonymous>'
+		return_type: node.typ
 		scope_idx:   e.scopes.len - 1
 	}
 	for name, value in fv.captures {
@@ -2883,11 +2921,16 @@ fn (mut e Eval) call_fn_value(fv FnValue, args []Value) !CallResult {
 			capture_types: fv.capture_types.clone()
 		}
 	}
+	adapted_values := if signal.kind == .return_ {
+		e.adapt_return_values(signal.values, node.typ)
+	} else {
+		[]Value{}
+	}
 	e.close_scope()!
 	e.call_stack.delete(e.call_stack.len - 1)
 	if signal.kind == .return_ {
 		return CallResult{
-			values:           e.adapt_return_values(signal.values, node.typ)
+			values:           adapted_values
 			mutated_args:     mutated_args
 			fn_value_changed: fv.captures.len > 0
 			fn_value:         updated_fn_value
@@ -3252,6 +3295,10 @@ fn (e &Eval) block_has_only_expr_stmts(node &flat.Node) bool {
 }
 
 fn (mut e Eval) eval_array_init(node &flat.Node) !Value {
+	return flow_value(e.eval_array_init_flow(node)!)
+}
+
+fn (mut e Eval) eval_array_init_flow(node &flat.Node) !FlowSignal {
 	array_type_name := if node.typ.len > 0 { node.typ } else { node.value }
 	is_fixed_array := is_fixed_array_type_name(array_type_name)
 	elem_type_name := if is_fixed_array {
@@ -3268,19 +3315,31 @@ fn (mut e Eval) eval_array_init(node &flat.Node) !Value {
 		child := e.node(child_id)
 		if child.kind == .field_init {
 			if child.value == 'len' {
-				val := e.eval_expr(e.child(child, 0))!
-				len = int(e.value_as_int(val)!)
+				signal := e.eval_expr_flow(e.child(child, 0))!
+				if signal.kind != .normal {
+					return signal
+				}
+				len = int(e.value_as_int(flow_value(signal))!)
 			} else if child.value == 'cap' {
-				val := e.eval_expr(e.child(child, 0))!
-				cap = int(e.value_as_int(val)!)
+				signal := e.eval_expr_flow(e.child(child, 0))!
+				if signal.kind != .normal {
+					return signal
+				}
+				cap = int(e.value_as_int(flow_value(signal))!)
 				has_cap = true
 			} else if child.value == 'init' {
-				val := e.eval_expr_expected(e.child(child, 0), elem_type_name)!
-				init = e.adapt_value_to_type_name(val, elem_type_name)
+				signal := e.eval_expr_flow_expected(e.child(child, 0), elem_type_name)!
+				if signal.kind != .normal {
+					return signal
+				}
+				init = e.adapt_value_to_type_name(flow_value(signal), elem_type_name)
 			}
 		} else {
-			values << e.adapt_value_to_type_name(e.eval_expr_expected(child_id, elem_type_name)!,
-				elem_type_name)
+			signal := e.eval_expr_flow_expected(child_id, elem_type_name)!
+			if signal.kind != .normal {
+				return signal
+			}
+			values << e.adapt_value_to_type_name(flow_value(signal), elem_type_name)
 		}
 	}
 	if len > 0 || has_cap {
@@ -3291,10 +3350,10 @@ fn (mut e Eval) eval_array_init(node &flat.Node) !Value {
 		fixed_len := fixed_array_len(array_type_name)
 		values = []Value{len: fixed_len, cap: fixed_len, init: init}
 	}
-	return ArrayValue{
+	return value_flow(ArrayValue{
 		elem_type_name: elem_type_name
 		values:         values
-	}
+	})
 }
 
 fn is_fixed_array_type_name(type_name string) bool {
@@ -4820,6 +4879,12 @@ fn (e &Eval) adapt_value_to_type_name(value Value, type_name string) Value {
 		return m
 	}
 	target_type_name := e.normalize_type_name(type_name)
+	if target_type_name in e.enum_fields {
+		return e.enum_value(target_type_name, value)
+	}
+	if type_name in e.enum_fields {
+		return e.enum_value(type_name, value)
+	}
 	if target_type_name in e.sum_types && !e.value_matches_type_name(value, target_type_name) {
 		return e.wrap_sum_value(target_type_name, value)
 	}

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -1726,11 +1726,6 @@ fn (mut e Eval) set_selector_value(container Value, field_name string, value Val
 fn (mut e Eval) exec_array_append(node &flat.Node) !FlowSignal {
 	lhs_id := e.child(node, 0)
 	rhs_id := e.child(node, 1)
-	rhs_signal := e.eval_expr_flow(rhs_id)!
-	if rhs_signal.kind != .normal {
-		return rhs_signal
-	}
-	rhs := flow_value(rhs_signal)
 	resolved := e.resolve_lvalue_flow(lhs_id)!
 	if resolved.signal.kind != .normal {
 		return resolved.signal
@@ -1740,6 +1735,18 @@ fn (mut e Eval) exec_array_append(node &flat.Node) !FlowSignal {
 		return error('v3.eval: `<<` is only supported for arrays')
 	}
 	mut arr := current as ArrayValue
+	rhs_type_name := e.infer_expr_type_name(rhs_id)
+	rhs_expected_type := if rhs_type_name.len > 0
+		&& e.array_type_spreads_into_elem(rhs_type_name, arr.elem_type_name) {
+		rhs_type_name
+	} else {
+		arr.elem_type_name
+	}
+	rhs_signal := e.eval_expr_flow_expected(rhs_id, rhs_expected_type)!
+	if rhs_signal.kind != .normal {
+		return rhs_signal
+	}
+	rhs := flow_value(rhs_signal)
 	if rhs is ArrayValue && e.array_append_rhs_spreads(rhs_id, rhs, arr.elem_type_name) {
 		for item in rhs.values {
 			arr.values << e.adapt_value_to_type_name(item, arr.elem_type_name)
@@ -2719,11 +2726,11 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 	}
 	if callee.kind == .selector {
 		receiver_id := e.child(callee, 0)
-		receiver_signal := e.eval_expr_flow(receiver_id)!
-		if receiver_signal.kind != .normal {
-			return receiver_signal
+		receiver_resolved := e.resolve_lvalue_flow(receiver_id)!
+		if receiver_resolved.signal.kind != .normal {
+			return receiver_resolved.signal
 		}
-		left := flow_value(receiver_signal)
+		left := receiver_resolved.value
 		if left is ModuleValue {
 			expected_types := if target := e.function_def(left.name, callee.value) {
 				e.function_param_type_names(target, 0)
@@ -2781,7 +2788,10 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 		result := e.call_value_method(left, receiver_type_name, callee.value, args_signal.values)!
 		if result.receiver_changed {
 			if e.is_assignable_target(receiver_id) {
-				e.update_target(receiver_id, result.receiver)!
+				write_signal := e.write_resolved_lvalue_flow(receiver_resolved, result.receiver)!
+				if write_signal.kind != .normal {
+					return write_signal
+				}
 			}
 		}
 		e.write_back_mutated_arg_values(node, result.mutated_args, args_signal.mut_lvalues)!
@@ -5474,6 +5484,12 @@ fn (e &Eval) cast_value_in_module(value Value, type_name string, module_name str
 	}
 	if name == 'string' {
 		return Value(e.value_string(source))
+	}
+	if target_name in e.enum_fields {
+		return e.enum_value(target_name, source)
+	}
+	if name in e.enum_fields {
+		return e.enum_value(name, source)
 	}
 	if name.starts_with('?') {
 		inner_type := name[1..]

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -1005,7 +1005,13 @@ fn (mut e Eval) exec_assign(node &flat.Node, declare bool) !FlowSignal {
 		return normal_flow()
 	}
 	if children.len > 2 {
-		value := e.assignment_value(node.op, children[0], children[1])!
+		first_target_type := e.assignment_target_type_name(children[0], declare)
+		first_signal := e.assignment_value_flow(node.op, children[0], children[1],
+			first_target_type)!
+		if first_signal.kind != .normal {
+			return first_signal
+		}
+		value := flow_value(first_signal)
 		mut lhs_ids := [children[0]]
 		for i := 2; i < children.len; i++ {
 			lhs_ids << children[i]
@@ -1031,7 +1037,12 @@ fn (mut e Eval) exec_assign(node &flat.Node, declare bool) !FlowSignal {
 			lhs_id := children[i]
 			rhs_id := if i + 1 < children.len { children[i + 1] } else { flat.empty_node }
 			item := if int(rhs_id) >= 0 {
-				e.assignment_value(node.op, lhs_id, rhs_id)!
+				target_type := e.assignment_target_type_name(lhs_id, declare)
+				signal := e.assignment_value_flow(node.op, lhs_id, rhs_id, target_type)!
+				if signal.kind != .normal {
+					return signal
+				}
+				flow_value(signal)
 			} else {
 				void_value()
 			}
@@ -1049,7 +1060,12 @@ fn (mut e Eval) exec_assign(node &flat.Node, declare bool) !FlowSignal {
 		lhs_id := children[i]
 		rhs_id := if i + 1 < children.len { children[i + 1] } else { flat.empty_node }
 		value := if int(rhs_id) >= 0 {
-			e.assignment_value(node.op, lhs_id, rhs_id)!
+			target_type := e.assignment_target_type_name(lhs_id, declare)
+			signal := e.assignment_value_flow(node.op, lhs_id, rhs_id, target_type)!
+			if signal.kind != .normal {
+				return signal
+			}
+			flow_value(signal)
 		} else {
 			void_value()
 		}
@@ -2074,6 +2090,12 @@ fn (mut e Eval) eval_expr_flow(id flat.NodeId) !FlowSignal {
 				values:         values
 			})
 		}
+		.struct_init {
+			return e.eval_struct_init_flow(node)
+		}
+		.assoc {
+			return e.eval_assoc_flow(node)
+		}
 		else {
 			return FlowSignal{
 				values: [e.eval_expr(id)!]
@@ -2112,7 +2134,16 @@ fn (mut e Eval) eval_infix_flow(node &flat.Node) !FlowSignal {
 		if !e.value_as_bool(left)! {
 			return value_flow(Value(false))
 		}
+		mut smartcast_scope := false
+		if binding := e.smartcast_binding_from_condition(e.child(node, 0)) {
+			e.open_scope()
+			e.declare_var_typed(binding.name, binding.value, binding.type_name)
+			smartcast_scope = true
+		}
 		right_signal := e.eval_expr_flow(e.child(node, 1))!
+		if smartcast_scope {
+			e.close_scope()!
+		}
 		if right_signal.kind != .normal {
 			return right_signal
 		}
@@ -3211,13 +3242,14 @@ fn (mut e Eval) eval_map_init(node &flat.Node) !Value {
 	mut values := []Value{}
 	mut i := 0
 	for i + 1 < children.len {
-		key := e.eval_expr(children[i])!
+		key := e.eval_expr_expected(children[i], key_type)!
 		if key_type.len == 0 {
 			key_type = e.infer_expr_type_name(children[i])
 			if key_type.len == 0 {
 				key_type = e.runtime_type_name(key)
 			}
 		}
+		typed_key := e.adapt_value_to_type_name(key, key_type)
 		value := e.eval_expr_expected(children[i + 1], value_type)!
 		if value_type.len == 0 {
 			value_type = e.infer_expr_type_name(children[i + 1])
@@ -3225,7 +3257,7 @@ fn (mut e Eval) eval_map_init(node &flat.Node) !Value {
 				value_type = e.runtime_type_name(value)
 			}
 		}
-		keys << key
+		keys << typed_key
 		values << value
 		i += 2
 	}
@@ -3252,6 +3284,10 @@ fn split_map_type(type_name string) (string, string) {
 }
 
 fn (mut e Eval) eval_struct_init(node &flat.Node) !Value {
+	return flow_value(e.eval_struct_init_flow(node)!)
+}
+
+fn (mut e Eval) eval_struct_init_flow(node &flat.Node) !FlowSignal {
 	type_name := e.normalize_type_name(node.value)
 	mut st := e.zero_struct_value(type_name)
 	mut positional := 0
@@ -3262,7 +3298,11 @@ fn (mut e Eval) eval_struct_init(node &flat.Node) !Value {
 		}
 		if child.value.len > 0 {
 			field_type := e.struct_field_type_name(st, child.value)
-			value := e.eval_expr_expected(e.child(child, 0), field_type)!
+			value_signal := e.eval_expr_flow_expected(e.child(child, 0), field_type)!
+			if value_signal.kind != .normal {
+				return value_signal
+			}
+			value := flow_value(value_signal)
 			st.fields[child.value] = e.adapt_value_to_type_name(value, e.struct_field_type_name(st,
 				child.value))
 		} else {
@@ -3270,21 +3310,33 @@ fn (mut e Eval) eval_struct_init(node &flat.Node) !Value {
 			if positional < fields.len {
 				field := fields[positional]
 				field_type := e.qualify_type_name(field.module_name, field.typ)
-				value := e.eval_expr_expected(e.child(child, 0), field_type)!
+				value_signal := e.eval_expr_flow_expected(e.child(child, 0), field_type)!
+				if value_signal.kind != .normal {
+					return value_signal
+				}
+				value := flow_value(value_signal)
 				st.fields[field.name] = e.adapt_value_to_type_name(value, e.qualify_type_name(field.module_name,
 					field.typ))
 			}
 			positional++
 		}
 	}
-	return st
+	return value_flow(st)
 }
 
 fn (mut e Eval) eval_assoc(node &flat.Node) !Value {
+	return flow_value(e.eval_assoc_flow(node)!)
+}
+
+fn (mut e Eval) eval_assoc_flow(node &flat.Node) !FlowSignal {
 	if node.children_count == 0 {
-		return e.zero_struct_value(node.value)
+		return value_flow(e.zero_struct_value(node.value))
 	}
-	base := e.eval_expr(e.child(node, 0))!
+	base_signal := e.eval_expr_flow(e.child(node, 0))!
+	if base_signal.kind != .normal {
+		return base_signal
+	}
+	base := flow_value(base_signal)
 	if base !is StructValue {
 		return error('v3.eval: assoc base must be struct')
 	}
@@ -3293,11 +3345,15 @@ fn (mut e Eval) eval_assoc(node &flat.Node) !Value {
 		field := e.child_node(node, i)
 		if field.kind == .field_init {
 			field_type := e.struct_field_type_name(st, field.value)
-			st.fields[field.value] = e.adapt_value_to_type_name(e.eval_expr_expected(e.child(field, 0),
-				field_type)!, field_type)
+			value_signal := e.eval_expr_flow_expected(e.child(field, 0), field_type)!
+			if value_signal.kind != .normal {
+				return value_signal
+			}
+			st.fields[field.value] = e.adapt_value_to_type_name(flow_value(value_signal),
+				field_type)
 		}
 	}
-	return st
+	return value_flow(st)
 }
 
 fn (mut e Eval) eval_prefix(node &flat.Node) !Value {

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -3702,6 +3702,15 @@ fn (mut e Eval) eval_block_value_flow_collect(node &flat.Node, collect_expr_valu
 		child := e.node(child_id)
 		if child.kind == .expr_stmt && child.children_count > 0 {
 			expr_id := e.child(child, 0)
+			expr := e.node(expr_id)
+			if expr.kind == .infix && expr.op == .left_shift {
+				signal := e.exec_stmt(child_id)!
+				if signal.kind != .normal {
+					e.close_scope()!
+					return signal
+				}
+				continue
+			}
 			signal := e.eval_expr_flow(expr_id)!
 			if signal.kind != .normal {
 				e.close_scope()!

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -1871,15 +1871,47 @@ fn (mut e Eval) eval_condition_flow(id flat.NodeId) !FlowSignal {
 	node := e.node(id)
 	if node.kind == .decl_assign {
 		rhs_id := e.child(node, 1)
-		rhs_signal := e.eval_expr_flow(rhs_id)!
-		if rhs_signal.kind != .normal {
-			return rhs_signal
+		rhs_node := e.node(rhs_id)
+		mut ok := false
+		mut bind_value := Value(void_value())
+		mut bind_type := ''
+		if rhs_node.kind == .index && rhs_node.value != 'range' && rhs_node.children_count > 1 {
+			container_signal := e.eval_expr_flow(e.child(rhs_node, 0))!
+			if container_signal.kind != .normal {
+				return container_signal
+			}
+			container := flow_value(container_signal)
+			index_signal := if container is MapValue {
+				e.eval_expr_flow_expected(e.child(rhs_node, 1), container.key_type_name)!
+			} else {
+				e.eval_expr_flow(e.child(rhs_node, 1))!
+			}
+			if index_signal.kind != .normal {
+				return index_signal
+			}
+			if container is MapValue {
+				value, found := e.map_lookup(container, flow_value(index_signal))
+				ok = found
+				bind_value = value
+				bind_type = container.value_type_name
+			} else {
+				value := e.index_value(container, flow_value(index_signal))!
+				ok = e.value_is_truthy(value)
+				bind_value = e.unwrap_option_like(value)
+				bind_type = e.guard_binding_type_name(rhs_id, value)
+			}
+		} else {
+			rhs_signal := e.eval_expr_flow(rhs_id)!
+			if rhs_signal.kind != .normal {
+				return rhs_signal
+			}
+			value := flow_value(rhs_signal)
+			ok = e.value_is_truthy(value)
+			bind_value = e.unwrap_option_like(value)
+			bind_type = e.guard_binding_type_name(rhs_id, value)
 		}
-		value := flow_value(rhs_signal)
-		ok := e.value_is_truthy(value)
 		if ok {
-			e.assign_target_typed(e.child(node, 0), e.unwrap_option_like(value), true,
-				e.infer_expr_type_name(rhs_id))!
+			e.assign_target_typed(e.child(node, 0), bind_value, true, bind_type)!
 		}
 		return value_flow(Value(ok))
 	}
@@ -1888,6 +1920,18 @@ fn (mut e Eval) eval_condition_flow(id flat.NodeId) !FlowSignal {
 		return signal
 	}
 	return value_flow(Value(e.value_as_bool(flow_value(signal))!))
+}
+
+fn (e &Eval) guard_binding_type_name(rhs_id flat.NodeId, value Value) string {
+	rhs_type := e.infer_expr_type_name(rhs_id)
+	name := rhs_type.trim_left('&')
+	if name.starts_with('?') || name.starts_with('!') {
+		return name[1..]
+	}
+	if name.len > 0 {
+		return name
+	}
+	return e.runtime_type_name(e.unwrap_option_like(value))
 }
 
 fn (e &Eval) unwrap_option_like(value Value) Value {

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -3724,14 +3724,13 @@ fn (mut e Eval) eval_struct_init_flow(node &flat.Node) !FlowSignal {
 			fields := e.struct_fields(type_name)
 			if positional < fields.len {
 				field := fields[positional]
-				field_type := e.qualify_type_name(field.module_name, field.typ)
+				field_type := e.qualify_nested_type_name(field.module_name, field.typ)
 				value_signal := e.eval_expr_flow_expected(e.child(child, 0), field_type)!
 				if value_signal.kind != .normal {
 					return value_signal
 				}
 				value := flow_value(value_signal)
-				st.fields[field.name] = e.adapt_value_to_type_name(value, e.qualify_type_name(field.module_name,
-					field.typ))
+				st.fields[field.name] = e.adapt_value_to_type_name(value, field_type)
 			}
 			positional++
 		}
@@ -5069,8 +5068,9 @@ fn (mut e Eval) eval_struct_field_default(field FieldInfo) Value {
 		e.call_stack.delete(e.call_stack.len - 1)
 		return e.zero_value_for_type_name_in_module(field.typ, field.module_name)
 	}
+	adapted := e.adapt_value_to_type_name(value, field.typ)
 	e.call_stack.delete(e.call_stack.len - 1)
-	return e.adapt_value_to_type_name(value, field.typ)
+	return adapted
 }
 
 fn (e &Eval) struct_fields(type_name string) []FieldInfo {
@@ -5085,7 +5085,7 @@ fn (e &Eval) struct_field_type_name_by_type(type_name string, field_name string)
 	info := e.struct_info(type_name)
 	for field in info.fields {
 		if field.name == field_name {
-			return e.qualify_type_name(field.module_name, field.typ)
+			return e.qualify_nested_type_name(field.module_name, field.typ)
 		}
 	}
 	return ''

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -4316,13 +4316,9 @@ fn (mut e Eval) maybe_call_os_builtin(fn_name string, args []Value) !MaybeValue 
 					value: Value('')
 				}
 			}
-			mut path := parts[0]
-			for part in parts[1..] {
-				path = os.join_path(path, part)
-			}
 			return MaybeValue{
 				found: true
-				value: Value(path)
+				value: Value(os.join_path(parts[0], ...parts[1..]))
 			}
 		}
 		'join_path_single' {

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -3450,7 +3450,8 @@ fn (mut e Eval) eval_or_expr_flow(node &flat.Node) !FlowSignal {
 		}
 		container := flow_value(container_signal)
 		if container is MapValue {
-			index_signal := e.eval_expr_flow(e.child(left_node, 1))!
+			index_signal := e.eval_expr_flow_expected(e.child(left_node, 1),
+				container.key_type_name)!
 			if index_signal.kind != .normal {
 				return index_signal
 			}

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -211,9 +211,10 @@ enum FlowKind {
 }
 
 struct FlowSignal {
-	kind   FlowKind
-	label  string
-	values []Value
+	kind        FlowKind
+	label       string
+	values      []Value
+	mut_lvalues map[int]ResolvedLvalue
 }
 
 // Eval interprets v3 flat AST nodes directly for a practical subset of V.
@@ -2590,7 +2591,7 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 			}
 			result := e.call_fn_value(fv, args_signal.values)!
 			e.write_back_fn_value(callee_id, result)!
-			e.write_back_mutated_arg_values(node, result.mutated_args)!
+			e.write_back_mutated_arg_values(node, result.mutated_args, args_signal.mut_lvalues)!
 			return FlowSignal{
 				values: [e.call_result_value(result)]
 			}
@@ -2605,7 +2606,7 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 			return args_signal
 		}
 		result := e.call_function(e.current_module_name(), fn_name, args_signal.values)!
-		e.write_back_mutated_args(node, result)!
+		e.write_back_mutated_args(node, result, args_signal.mut_lvalues)!
 		return FlowSignal{
 			values: [e.call_result_value(result)]
 		}
@@ -2628,7 +2629,7 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 				return args_signal
 			}
 			result := e.call_function(left.name, callee.value, args_signal.values)!
-			e.write_back_mutated_args(node, result)!
+			e.write_back_mutated_args(node, result, args_signal.mut_lvalues)!
 			return FlowSignal{
 				values: [e.call_result_value(result)]
 			}
@@ -2646,7 +2647,7 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 				return args_signal
 			}
 			result := e.call_function(static_module, static_name, args_signal.values)!
-			e.write_back_mutated_args(node, result)!
+			e.write_back_mutated_args(node, result, args_signal.mut_lvalues)!
 			return FlowSignal{
 				values: [e.call_result_value(result)]
 			}
@@ -2660,7 +2661,7 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 			}
 			result := e.call_fn_value(selector_value, args_signal.values)!
 			e.write_back_fn_value(callee_id, result)!
-			e.write_back_mutated_arg_values(node, result.mutated_args)!
+			e.write_back_mutated_arg_values(node, result.mutated_args, args_signal.mut_lvalues)!
 			return FlowSignal{
 				values: [e.call_result_value(result)]
 			}
@@ -2677,7 +2678,7 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 				e.update_target(receiver_id, result.receiver)!
 			}
 		}
-		e.write_back_mutated_arg_values(node, result.mutated_args)!
+		e.write_back_mutated_arg_values(node, result.mutated_args, args_signal.mut_lvalues)!
 		return FlowSignal{
 			values: [result.value]
 		}
@@ -2689,7 +2690,7 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 			return args_signal
 		}
 		result := e.call_fn_value(fv, args_signal.values)!
-		e.write_back_mutated_arg_values(node, result.mutated_args)!
+		e.write_back_mutated_arg_values(node, result.mutated_args, args_signal.mut_lvalues)!
 		return FlowSignal{
 			values: [e.call_result_value(result)]
 		}
@@ -2702,7 +2703,7 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 		}
 		result := e.call_fn_value(value, args_signal.values)!
 		e.write_back_fn_value(callee_id, result)!
-		e.write_back_mutated_arg_values(node, result.mutated_args)!
+		e.write_back_mutated_arg_values(node, result.mutated_args, args_signal.mut_lvalues)!
 		return FlowSignal{
 			values: [e.call_result_value(result)]
 		}
@@ -2787,11 +2788,28 @@ fn (e &Eval) function_param_type_names(def FunctionDef, skip int) []string {
 			break
 		}
 		if param_index >= skip {
-			types << child.typ
+			types << e.qualify_expected_type_name(def.module_name, child.typ)
 		}
 		param_index++
 	}
 	return types
+}
+
+fn (e &Eval) qualify_expected_type_name(module_name string, type_name string) string {
+	name := type_name.trim_space()
+	if name == '' {
+		return ''
+	}
+	if name.starts_with('&') {
+		return '&${e.qualify_expected_type_name(module_name, name[1..])}'
+	}
+	if name.starts_with('...') {
+		return '...${e.qualify_expected_type_name(module_name, name[3..])}'
+	}
+	if name.starts_with('mut ') {
+		return '&${e.qualify_expected_type_name(module_name, name[4..])}'
+	}
+	return e.qualify_nested_type_name(module_name, name)
 }
 
 fn (e &Eval) fn_value_param_type_names(fv FnValue) []string {
@@ -2860,17 +2878,30 @@ fn (e &Eval) map_method_param_type_names(receiver MapValue, method_name string) 
 
 fn (mut e Eval) eval_call_arg_values(node &flat.Node, expected_types []string) !FlowSignal {
 	mut args := []Value{}
+	mut mut_lvalues := map[int]ResolvedLvalue{}
 	for child_index in 1 .. node.children_count {
 		arg_index := child_index - 1
 		expected_type := call_arg_expected_type(expected_types, arg_index)
-		signal := e.eval_expr_flow_expected(e.child(node, child_index), expected_type)!
+		value_expected_type := call_arg_value_expected_type(expected_type)
+		arg_id := e.child(node, child_index)
+		if expected_type.starts_with('&') && e.is_assignable_target(arg_id) {
+			resolved := e.resolve_lvalue_flow(arg_id)!
+			if resolved.signal.kind != .normal {
+				return resolved.signal
+			}
+			args << resolved.value
+			mut_lvalues[arg_index] = resolved
+			continue
+		}
+		signal := e.eval_expr_flow_expected(arg_id, value_expected_type)!
 		if signal.kind != .normal {
 			return signal
 		}
 		args << flow_value(signal)
 	}
 	return FlowSignal{
-		values: args
+		values:      args
+		mut_lvalues: mut_lvalues
 	}
 }
 
@@ -2889,6 +2920,20 @@ fn call_arg_expected_type(expected_types []string, index int) string {
 		}
 	}
 	return ''
+}
+
+fn call_arg_value_expected_type(type_name string) string {
+	name := type_name.trim_space()
+	if name.starts_with('&') {
+		return call_arg_value_expected_type(name[1..])
+	}
+	if name.starts_with('mut ') {
+		return call_arg_value_expected_type(name[4..])
+	}
+	if name.starts_with('...') {
+		return call_arg_value_expected_type(name[3..])
+	}
+	return name
 }
 
 fn (mut e Eval) disabled_function_zero_value(module_name string, fn_name string, call_node &flat.Node) ?Value {
@@ -2952,8 +2997,8 @@ fn (e &Eval) call_result_value(result CallResult) Value {
 	}
 }
 
-fn (mut e Eval) write_back_mutated_args(node &flat.Node, result CallResult) ! {
-	e.write_back_mutated_arg_values(node, result.mutated_args)!
+fn (mut e Eval) write_back_mutated_args(node &flat.Node, result CallResult, mut_lvalues map[int]ResolvedLvalue) ! {
+	e.write_back_mutated_arg_values(node, result.mutated_args, mut_lvalues)!
 }
 
 fn (mut e Eval) adapt_return_values(values []Value, return_type string) []Value {
@@ -3088,13 +3133,20 @@ fn (mut e Eval) write_back_fn_value(callee_id flat.NodeId, result CallResult) ! 
 	}
 }
 
-fn (mut e Eval) write_back_mutated_arg_values(node &flat.Node, mutated_args map[int]Value) ! {
+fn (mut e Eval) write_back_mutated_arg_values(node &flat.Node, mutated_args map[int]Value, mut_lvalues map[int]ResolvedLvalue) ! {
 	for child_index := 1; child_index < node.children_count; child_index++ {
 		arg_index := child_index - 1
 		if arg_index !in mutated_args {
 			continue
 		}
 		value := mutated_args[arg_index] or { continue }
+		if resolved := mut_lvalues[arg_index] {
+			signal := e.write_resolved_lvalue_flow(resolved, value)!
+			if signal.kind != .normal {
+				return error('v3.eval: unexpected `${signal.kind}` escaped mut argument writeback')
+			}
+			continue
+		}
 		arg_id := e.child(node, child_index)
 		if e.is_assignable_target(arg_id) {
 			e.update_target(arg_id, value)!

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -3725,7 +3725,8 @@ fn (mut e Eval) eval_array_init_flow(node &flat.Node) !FlowSignal {
 	mut len := 0
 	mut cap := 0
 	mut has_cap := false
-	mut init := e.zero_value_for_type_name(elem_type_name)
+	mut init_id := flat.empty_node
+	mut has_init := false
 	mut values := []Value{}
 	for child_id in e.children(node) {
 		child := e.node(child_id)
@@ -3744,11 +3745,8 @@ fn (mut e Eval) eval_array_init_flow(node &flat.Node) !FlowSignal {
 				cap = int(e.value_as_int(flow_value(signal))!)
 				has_cap = true
 			} else if child.value == 'init' {
-				signal := e.eval_expr_flow_expected(e.child(child, 0), elem_type_name)!
-				if signal.kind != .normal {
-					return signal
-				}
-				init = e.adapt_value_to_type_name(flow_value(signal), elem_type_name)
+				init_id = e.child(child, 0)
+				has_init = true
 			}
 		} else {
 			signal := e.eval_expr_flow_expected(child_id, elem_type_name)!
@@ -3760,11 +3758,36 @@ fn (mut e Eval) eval_array_init_flow(node &flat.Node) !FlowSignal {
 	}
 	if len > 0 || has_cap {
 		array_cap := if has_cap { cap } else { len }
-		values = []Value{len: len, cap: array_cap, init: init}
+		return e.eval_array_init_values(len, array_cap, has_init, init_id, elem_type_name)
 	}
 	if is_fixed_array && values.len == 0 {
-		fixed_len := fixed_array_len(array_type_name)
-		values = []Value{len: fixed_len, cap: fixed_len, init: init}
+		fixed_len := e.fixed_array_len(array_type_name)!
+		return e.eval_array_init_values(fixed_len, fixed_len, has_init, init_id, elem_type_name)
+	}
+	return value_flow(ArrayValue{
+		elem_type_name: elem_type_name
+		values:         values
+	})
+}
+
+fn (mut e Eval) eval_array_init_values(len int, cap int, has_init bool, init_id flat.NodeId, elem_type_name string) !FlowSignal {
+	mut values := []Value{cap: cap}
+	for i in 0 .. len {
+		if has_init {
+			e.open_scope()
+			e.declare_var_typed('index', Value(i64(i)), 'int')
+			signal := e.eval_expr_flow_expected(init_id, elem_type_name) or {
+				e.close_scope()!
+				return err
+			}
+			e.close_scope()!
+			if signal.kind != .normal {
+				return signal
+			}
+			values << e.adapt_value_to_type_name(flow_value(signal), elem_type_name)
+		} else {
+			values << e.zero_value_for_type_name(elem_type_name)
+		}
 	}
 	return value_flow(ArrayValue{
 		elem_type_name: elem_type_name
@@ -3779,8 +3802,41 @@ fn is_fixed_array_type_name(type_name string) bool {
 	return type_name.contains('[') && (type_name.ends_with(']') || type_name.starts_with('['))
 }
 
-fn fixed_array_len(type_name string) int {
-	return fixed_array_len_text(type_name).int()
+fn (mut e Eval) fixed_array_len(type_name string) !int {
+	return e.fixed_array_len_in_module(type_name, e.current_module_name())
+}
+
+fn (mut e Eval) fixed_array_len_in_module(type_name string, module_name string) !int {
+	text := fixed_array_len_text(type_name)
+	if len := fixed_array_len_literal(text) {
+		return len
+	}
+	if value := e.lookup_const(module_name, text) {
+		return int(e.value_as_int(value)!)
+	}
+	if text.contains('.') {
+		mod_name := text.all_before_last('.')
+		const_name := text.all_after_last('.')
+		if value := e.lookup_const(mod_name, const_name) {
+			return int(e.value_as_int(value)!)
+		}
+	}
+	return 0
+}
+
+fn fixed_array_len_literal(text string) ?int {
+	normalized := text.replace('_', '')
+	if normalized.len == 0 {
+		return none
+	}
+	mut len := 0
+	for ch in normalized {
+		if ch < `0` || ch > `9` {
+			return none
+		}
+		len = len * 10 + int(ch - `0`)
+	}
+	return len
 }
 
 fn fixed_array_len_text(type_name string) string {
@@ -5195,7 +5251,7 @@ fn (mut e Eval) zero_value_for_type_name_in_module(type_name string, module_name
 	}
 	if is_fixed_array_type_name(name) {
 		elem_type := e.qualify_nested_type_name(module_name, fixed_array_elem_type_name(name))
-		len := fixed_array_len(name)
+		len := e.fixed_array_len_in_module(name, module_name) or { 0 }
 		return ArrayValue{
 			elem_type_name: elem_type
 			values:         []Value{len: len, cap: len, init: e.zero_value_for_type_name_in_module(elem_type,

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -122,6 +122,12 @@ struct GlobalEntry {
 	file_name    string
 }
 
+struct TopLevelStmt {
+	node        flat.NodeId
+	module_name string
+	file_name   string
+}
+
 struct StructInfo {
 	module_name string
 	name        string
@@ -231,6 +237,7 @@ mut:
 	globals           map[string]map[string]Value
 	global_types      map[string]map[string]string
 	global_inits      []GlobalEntry
+	implicit_main     []TopLevelStmt
 	structs           map[string]StructInfo
 	enum_fields       map[string][]string
 	sum_types         map[string][]string
@@ -286,7 +293,10 @@ pub fn (mut e Eval) run_files(a &flat.FlatAst) ![]Value {
 	e.reset(a)
 	e.register_files()!
 	e.run_inits()!
-	return e.call_function('main', 'main', []Value{})!.values
+	if e.has_main_function() {
+		return e.call_function('main', 'main', []Value{})!.values
+	}
+	return e.run_implicit_main()
 }
 
 fn void_value() Value {
@@ -314,6 +324,7 @@ fn (mut e Eval) reset(a &flat.FlatAst) {
 	e.globals = map[string]map[string]Value{}
 	e.global_types = map[string]map[string]string{}
 	e.global_inits = []GlobalEntry{}
+	e.implicit_main = []TopLevelStmt{}
 	e.structs = map[string]StructInfo{}
 	e.enum_fields = map[string][]string{}
 	e.sum_types = map[string][]string{}
@@ -372,6 +383,34 @@ fn (e &Eval) top_level_registration_children(node &flat.Node) []flat.NodeId {
 		ids << child_id
 	}
 	return ids
+}
+
+fn (e &Eval) has_main_function() bool {
+	return 'main' in e.functions && 'main' in e.functions['main']
+}
+
+fn is_top_level_declaration_kind(kind flat.NodeKind) bool {
+	match kind {
+		.empty, .module_decl, .import_decl, .directive, .fn_decl, .c_fn_decl, .struct_decl,
+		.field_decl, .global_decl, .const_decl, .const_field, .enum_decl, .enum_field, .type_decl,
+		.interface_decl, .interface_field, .param, .comptime_if, .comptime_for {
+			return true
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn (mut e Eval) register_implicit_main_stmt(module_name string, file_name string, id flat.NodeId, node &flat.Node) {
+	if module_name != 'main' || is_top_level_declaration_kind(node.kind) {
+		return
+	}
+	e.implicit_main << TopLevelStmt{
+		node:        id
+		module_name: module_name
+		file_name:   file_name
+	}
 }
 
 fn (mut e Eval) register_files() ! {
@@ -546,16 +585,59 @@ fn (mut e Eval) register_files() ! {
 						}
 					}
 				}
-				else {}
+				else {
+					e.register_implicit_main_stmt(module_name, file_name, child_id, child)
+				}
 			}
 		}
 		e.file_import_alias[file_name] = import_aliases.clone()
 		_ = file_id
 	}
 	e.evaluate_global_inits()!
-	if 'main' !in e.functions || 'main' !in e.functions['main'] {
+	if !e.has_main_function() && e.implicit_main.len == 0 {
 		return error('v3.eval: missing main.main entry point')
 	}
+}
+
+fn (mut e Eval) run_implicit_main() ![]Value {
+	e.open_scope()
+	scope_idx := e.scopes.len - 1
+	mut frame := CallFrame{
+		module_name: 'main'
+		file_name:   if e.implicit_main.len > 0 { e.implicit_main[0].file_name } else { '' }
+		fn_name:     'main'
+		return_type: 'void'
+		scope_idx:   scope_idx
+	}
+	e.call_stack << frame
+	mut values := [void_value()]
+	mut escaped := normal_flow()
+	for stmt in e.implicit_main {
+		frame = CallFrame{
+			module_name: stmt.module_name
+			file_name:   stmt.file_name
+			fn_name:     'main'
+			return_type: 'void'
+			scope_idx:   scope_idx
+		}
+		e.call_stack[e.call_stack.len - 1] = frame
+		signal := e.exec_stmt(stmt.node)!
+		if signal.kind == .return_ {
+			values = flow_values_or_void(signal.values)
+			break
+		}
+		if signal.kind != .normal {
+			escaped = signal
+			break
+		}
+	}
+	e.run_deferred_stmts()!
+	e.close_scope()!
+	e.call_stack.delete(e.call_stack.len - 1)
+	if escaped.kind != .normal {
+		return error('v3.eval: unexpected `${escaped.kind}` escaped implicit main')
+	}
+	return values
 }
 
 fn (mut e Eval) evaluate_global_inits() ! {
@@ -4111,7 +4193,10 @@ fn (e &Eval) match_condition_matches(target Value, cond Value) bool {
 	if cond is RangeValue {
 		return e.value_in(target, cond)
 	}
-	return e.value_eq(target, cond) || e.value_matches_type_name(target, e.value_string(cond))
+	if cond is TypeValue {
+		return e.value_matches_type_name(target, cond.name)
+	}
+	return e.value_eq(target, cond)
 }
 
 fn (e &Eval) smartcast_binding_from_match(target_id flat.NodeId, target Value, cond Value) ?SmartcastBinding {

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -122,6 +122,12 @@ struct GlobalEntry {
 	file_name    string
 }
 
+struct EnumInitEntry {
+	node        flat.NodeId
+	module_name string
+	file_name   string
+}
+
 struct TopLevelStmt {
 	node        flat.NodeId
 	module_name string
@@ -237,6 +243,7 @@ mut:
 	globals           map[string]map[string]Value
 	global_types      map[string]map[string]string
 	global_inits      []GlobalEntry
+	enum_inits        []EnumInitEntry
 	implicit_main     []TopLevelStmt
 	structs           map[string]StructInfo
 	enum_fields       map[string][]string
@@ -324,6 +331,7 @@ fn (mut e Eval) reset(a &flat.FlatAst) {
 	e.globals = map[string]map[string]Value{}
 	e.global_types = map[string]map[string]string{}
 	e.global_inits = []GlobalEntry{}
+	e.enum_inits = []EnumInitEntry{}
 	e.implicit_main = []TopLevelStmt{}
 	e.structs = map[string]StructInfo{}
 	e.enum_fields = map[string][]string{}
@@ -439,17 +447,22 @@ fn (mut e Eval) register_files() ! {
 		mut import_aliases := map[string]string{}
 		for child_id in top_level_children {
 			child := e.node(child_id)
+			if child.kind != .import_decl {
+				continue
+			}
+			imported_module := child.value.all_after_last('.')
+			if imported_module.len > 0 && imported_module != module_name
+				&& imported_module !in e.module_imports[module_name] {
+				e.module_imports[module_name] << imported_module
+			}
+			import_aliases[child.typ] = imported_module
+			import_aliases[imported_module] = imported_module
+		}
+		e.file_import_alias[file_name] = import_aliases.clone()
+		for child_id in top_level_children {
+			child := e.node(child_id)
 			match child.kind {
-				.import_decl {
-					imported_module := child.value.all_after_last('.')
-					if imported_module.len > 0 && imported_module != module_name
-						&& imported_module !in e.module_imports[module_name] {
-						e.module_imports[module_name] << imported_module
-					}
-					import_aliases[child.typ] = child.value.all_after_last('.')
-					import_aliases[child.value.all_after_last('.')] =
-						child.value.all_after_last('.')
-				}
+				.import_decl {}
 				.const_decl {
 					for field_id in e.children(child) {
 						field := e.node(field_id)
@@ -489,42 +502,21 @@ fn (mut e Eval) register_files() ! {
 					e.type_names[module_name][child.value] = true
 					enum_name := e.qualify_type_name(module_name, child.value)
 					mut enum_fields := []string{}
-					mut next_value := if child.typ == 'flag' { i64(1) } else { i64(0) }
 					for field_id in e.children(child) {
 						field := e.node(field_id)
 						if field.kind != .enum_field {
 							continue
 						}
 						enum_fields << field.value
-						value := if field.children_count > 0 {
-							e.value_as_int(e.eval_expr_in_module(e.child(field, 0), module_name,
-								file_name, '<enum ${child.value}.${field.value}>')!)!
-						} else {
-							next_value
-						}
-						e.consts[module_name][field.value] = ConstEntry{
-							node:        field_id
-							module_name: module_name
-							file_name:   file_name
-							cached:      true
-							value:       Value(value)
-						}
-						e.consts[module_name]['${child.value}.${field.value}'] = ConstEntry{
-							node:        field_id
-							module_name: module_name
-							file_name:   file_name
-							cached:      true
-							value:       Value(value)
-						}
-						next_value = if child.typ == 'flag' {
-							if value <= 0 { i64(1) } else { value * 2 }
-						} else {
-							value + 1
-						}
 					}
 					e.enum_fields[enum_name] = enum_fields
 					if module_name in ['main', 'builtin'] {
 						e.enum_fields[child.value] = enum_fields
+					}
+					e.enum_inits << EnumInitEntry{
+						node:        child_id
+						module_name: module_name
+						file_name:   file_name
 					}
 				}
 				.fn_decl {
@@ -590,12 +582,50 @@ fn (mut e Eval) register_files() ! {
 				}
 			}
 		}
-		e.file_import_alias[file_name] = import_aliases.clone()
 		_ = file_id
 	}
+	e.evaluate_enum_inits()!
 	e.evaluate_global_inits()!
 	if !e.has_main_function() && e.implicit_main.len == 0 {
 		return error('v3.eval: missing main.main entry point')
+	}
+}
+
+fn (mut e Eval) evaluate_enum_inits() ! {
+	for entry in e.enum_inits {
+		node := e.node(entry.node)
+		mut next_value := if node.typ == 'flag' { i64(1) } else { i64(0) }
+		for field_id in e.children(node) {
+			field := e.node(field_id)
+			if field.kind != .enum_field {
+				continue
+			}
+			value := if field.children_count > 0 {
+				e.value_as_int(e.eval_expr_in_module(e.child(field, 0), entry.module_name,
+					entry.file_name, '<enum ${node.value}.${field.value}>')!)!
+			} else {
+				next_value
+			}
+			e.consts[entry.module_name][field.value] = ConstEntry{
+				node:        field_id
+				module_name: entry.module_name
+				file_name:   entry.file_name
+				cached:      true
+				value:       Value(value)
+			}
+			e.consts[entry.module_name]['${node.value}.${field.value}'] = ConstEntry{
+				node:        field_id
+				module_name: entry.module_name
+				file_name:   entry.file_name
+				cached:      true
+				value:       Value(value)
+			}
+			next_value = if node.typ == 'flag' {
+				if value <= 0 { i64(1) } else { value * 2 }
+			} else {
+				value + 1
+			}
+		}
 	}
 }
 
@@ -1090,7 +1120,7 @@ fn (mut e Eval) exec_stmt(id flat.NodeId) !FlowSignal {
 			if !e.value_as_bool(cond)! {
 				mut msg := 'assertion failed'
 				if node.children_count > 1 {
-					msg = e.value_string(e.eval_expr(e.child(node, 1))!)
+					msg = e.display_string(e.eval_expr(e.child(node, 1))!)!
 				}
 				return error('v3.eval: ${msg}')
 			}
@@ -4040,7 +4070,7 @@ fn (mut e Eval) eval_string_interp_flow(node &flat.Node) !FlowSignal {
 		if signal.kind != .normal {
 			return signal
 		}
-		out += e.value_string(flow_value(signal))
+		out += e.display_string(flow_value(signal))!
 	}
 	return value_flow(Value(out))
 }
@@ -4536,7 +4566,7 @@ fn (mut e Eval) maybe_call_builtin(module_name string, fn_name string, args []Va
 		match fn_name {
 			'print' {
 				if args.len > 0 {
-					e.write_stdout(e.value_string(args[0]))
+					e.write_stdout(e.display_string(args[0])!)
 				}
 				return MaybeValue{
 					found: true
@@ -4545,7 +4575,7 @@ fn (mut e Eval) maybe_call_builtin(module_name string, fn_name string, args []Va
 			}
 			'println' {
 				if args.len > 0 {
-					e.write_stdout(e.value_string(args[0]) + '\n')
+					e.write_stdout(e.display_string(args[0])! + '\n')
 				} else {
 					e.write_stdout('\n')
 				}
@@ -4556,7 +4586,7 @@ fn (mut e Eval) maybe_call_builtin(module_name string, fn_name string, args []Va
 			}
 			'eprint' {
 				if args.len > 0 {
-					e.write_stderr(e.value_string(args[0]))
+					e.write_stderr(e.display_string(args[0])!)
 				}
 				return MaybeValue{
 					found: true
@@ -4565,7 +4595,7 @@ fn (mut e Eval) maybe_call_builtin(module_name string, fn_name string, args []Va
 			}
 			'eprintln' {
 				if args.len > 0 {
-					e.write_stderr(e.value_string(args[0]) + '\n')
+					e.write_stderr(e.display_string(args[0])! + '\n')
 				} else {
 					e.write_stderr('\n')
 				}
@@ -4583,11 +4613,11 @@ fn (mut e Eval) maybe_call_builtin(module_name string, fn_name string, args []Va
 			'str' {
 				return MaybeValue{
 					found: true
-					value: Value(e.value_string(args[0] or { void_value() }))
+					value: Value(e.display_string(args[0] or { void_value() })!)
 				}
 			}
 			'panic' {
-				return error(e.value_string(args[0] or { Value('panic') }))
+				return error(e.display_string(args[0] or { Value('panic') })!)
 			}
 			else {}
 		}
@@ -4757,20 +4787,26 @@ fn (mut e Eval) call_value_method(receiver Value, receiver_type_name string, met
 	return error('v3.eval: unsupported method `${method_name}` on `${e.runtime_type_name(receiver)}`')
 }
 
-fn (e &Eval) direct_builtin_str_method_value(receiver Value, static_type_name string, method_name string, args []Value) ?Value {
+fn (mut e Eval) direct_builtin_str_method_value(receiver Value, static_type_name string, method_name string, args []Value) ?Value {
 	if !is_builtin_str_receiver_type_name(static_type_name) {
 		return none
 	}
 	return e.direct_str_method_value(receiver, method_name, args)
 }
 
-fn (e &Eval) direct_str_method_value(receiver Value, method_name string, args []Value) ?Value {
+fn (mut e Eval) direct_str_method_value(receiver Value, method_name string, args []Value) ?Value {
 	if method_name != 'str' || args.len != 0 {
 		return none
 	}
 	match receiver {
 		bool, i64, f64, string, EnumValue {
 			return Value(e.value_string(receiver))
+		}
+		StructValue {
+			if _ := e.resolve_method_target(receiver.type_name, 'str') {
+				return none
+			}
+			return Value(e.default_struct_string(receiver))
 		}
 		else {}
 	}
@@ -5937,7 +5973,7 @@ fn (e &Eval) value_string(value Value) string {
 			if value.type_name == 'os.Result' && 'output' in value.fields {
 				return e.value_string(value.fields['output'] or { void_value() })
 			}
-			return value.type_name
+			return e.default_struct_string(value)
 		}
 		SumValue {
 			return e.value_string(value.payload)
@@ -5950,6 +5986,85 @@ fn (e &Eval) value_string(value Value) string {
 		}
 		FnValue {
 			return '<fn>'
+		}
+	}
+}
+
+fn (mut e Eval) display_string(value Value) !string {
+	match value {
+		ArrayValue {
+			mut parts := []string{cap: value.values.len}
+			for item in value.values {
+				parts << e.display_string(item)!
+			}
+			return '[' + parts.join(', ') + ']'
+		}
+		MapValue {
+			mut parts := []string{cap: value.entries.len}
+			for entry in value.entries {
+				key := e.display_string(entry.key)!
+				map_value := e.display_string(entry.value)!
+				parts << '${key}: ${map_value}'
+			}
+			return '{' + parts.join(', ') + '}'
+		}
+		StructValue {
+			if value.type_name == 'os.Result' && 'output' in value.fields {
+				return e.display_string(value.fields['output'] or { void_value() })
+			}
+			if target := e.resolve_method_target(value.type_name, 'str') {
+				result := e.call_method_target(value, target, [])!
+				return e.value_string(result.value)
+			}
+			return e.default_struct_string(value)
+		}
+		SumValue {
+			return e.display_string(value.payload)
+		}
+		TupleValue {
+			mut parts := []string{cap: value.values.len}
+			for item in value.values {
+				parts << e.display_string(item)!
+			}
+			return parts.join(', ')
+		}
+		else {
+			return e.value_string(value)
+		}
+	}
+}
+
+fn (e &Eval) default_struct_string(value StructValue) string {
+	if value.fields.len == 0 {
+		return '${value.type_name}{}'
+	}
+	mut names := []string{}
+	fields := e.struct_fields(value.type_name)
+	for field in fields {
+		if field.name in value.fields {
+			names << field.name
+		}
+	}
+	if names.len == 0 {
+		names = value.fields.keys()
+		names.sort()
+	}
+	mut out := '${value.type_name}{\n'
+	for name in names {
+		field_value := value.fields[name] or { void_value() }
+		out += '    ${name}: ${e.struct_field_value_string(field_value)}\n'
+	}
+	out += '}'
+	return out
+}
+
+fn (e &Eval) struct_field_value_string(value Value) string {
+	match value {
+		string {
+			return "'${value}'"
+		}
+		else {
+			return e.value_string(value)
 		}
 	}
 }

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -182,6 +182,21 @@ struct MethodCallResult {
 	mutated_args     map[int]Value
 }
 
+struct LvalueStep {
+	kind       flat.NodeKind
+	container  Value
+	index      Value
+	field_name string
+}
+
+struct ResolvedLvalue {
+mut:
+	signal  FlowSignal
+	root_id flat.NodeId
+	value   Value
+	steps   []LvalueStep
+}
+
 struct InfixOperatorCallInfo {
 	target  FunctionDef
 	reverse bool
@@ -1154,10 +1169,10 @@ fn (mut e Eval) apply_compound_target_flow(op flat.Op, lhs_id flat.NodeId, rhs V
 	node := e.node(lhs_id)
 	match node.kind {
 		.index {
-			return e.update_index_target_with_op_flow(node, op, rhs)
+			return e.update_resolved_lvalue_with_op_flow(lhs_id, op, rhs)
 		}
 		.selector {
-			return e.update_selector_target_with_op_flow(node, op, rhs)
+			return e.update_resolved_lvalue_with_op_flow(lhs_id, op, rhs)
 		}
 		else {
 			left_signal := e.eval_expr_flow(lhs_id)!
@@ -1245,18 +1260,26 @@ fn (mut e Eval) assignment_target_type_name(lhs_id flat.NodeId, declare bool) st
 			return node.typ
 		}
 		.selector {
-			base := e.eval_expr(e.child(node, 0)) or { return '' }
-			if base is StructValue {
-				return e.struct_field_type_name(base, node.value)
+			if node.children_count > 0 {
+				base_type := e.infer_expr_type_name(e.child(node, 0))
+				if base_type.len > 0 {
+					return e.struct_field_type_name_by_type(base_type, node.value)
+				}
 			}
 		}
 		.index {
-			container := e.eval_expr(e.child(node, 0)) or { return '' }
-			if container is ArrayValue {
-				return container.elem_type_name
-			}
-			if container is MapValue {
-				return container.value_type_name
+			if node.children_count > 0 {
+				container_type := e.infer_expr_type_name(e.child(node, 0))
+				if container_type.starts_with('[]') {
+					return container_type[2..]
+				}
+				if is_fixed_array_type_name(container_type) {
+					return fixed_array_elem_type_name(container_type)
+				}
+				if container_type.starts_with('map[') {
+					_, value_type := split_map_type(container_type)
+					return value_type
+				}
 			}
 		}
 		else {}
@@ -1328,10 +1351,10 @@ fn (mut e Eval) assign_target_typed_flow(id flat.NodeId, value Value, declare bo
 			}
 		}
 		.selector {
-			return e.update_selector_target_flow(node, value)
+			return e.update_resolved_lvalue_flow(id, value)
 		}
 		.index {
-			return e.update_index_target_flow(node, value)
+			return e.update_resolved_lvalue_flow(id, value)
 		}
 		else {
 			return error('v3.eval: unsupported assignment target `${node.kind}`')
@@ -1378,6 +1401,25 @@ fn (e &Eval) infer_expr_type_name(id flat.NodeId) string {
 				if typ := e.type_value_name_from_expr(e.child(node, 0)) {
 					return typ
 				}
+				base_type := e.infer_expr_type_name(e.child(node, 0))
+				if base_type.len > 0 {
+					return e.struct_field_type_name_by_type(base_type, node.value)
+				}
+			}
+		}
+		.index {
+			if node.children_count > 0 {
+				container_type := e.infer_expr_type_name(e.child(node, 0))
+				if container_type.starts_with('[]') {
+					return container_type[2..]
+				}
+				if is_fixed_array_type_name(container_type) {
+					return fixed_array_elem_type_name(container_type)
+				}
+				if container_type.starts_with('map[') {
+					_, value_type := split_map_type(container_type)
+					return value_type
+				}
 			}
 		}
 		.array_literal {
@@ -1422,82 +1464,113 @@ fn (mut e Eval) update_target(id flat.NodeId, value Value) ! {
 	}
 }
 
-fn (mut e Eval) update_index_target(node &flat.Node, value Value) ! {
-	signal := e.update_index_target_flow(node, value)!
-	if signal.kind != .normal {
-		return error('v3.eval: unexpected `${signal.kind}` escaped index assignment target')
-	}
-}
-
-fn (mut e Eval) update_index_target_flow(node &flat.Node, value Value) !FlowSignal {
-	base_id := e.child(node, 0)
-	index_signal := e.eval_expr_flow(e.child(node, 1))!
-	if index_signal.kind != .normal {
-		return index_signal
-	}
-	container_signal := e.eval_expr_flow(base_id)!
-	if container_signal.kind != .normal {
-		return container_signal
-	}
-	new_container := e.set_index_value(flow_value(container_signal), flow_value(index_signal),
-		value)!
-	return e.update_target_flow(base_id, new_container)
-}
-
-fn (mut e Eval) update_index_target_with_op_flow(node &flat.Node, op flat.Op, rhs Value) !FlowSignal {
-	base_id := e.child(node, 0)
-	container_signal := e.eval_expr_flow(base_id)!
-	if container_signal.kind != .normal {
-		return container_signal
-	}
-	container := flow_value(container_signal)
-	index_signal := if container is MapValue {
-		e.eval_expr_flow_expected(e.child(node, 1), container.key_type_name)!
-	} else {
-		e.eval_expr_flow(e.child(node, 1))!
-	}
-	if index_signal.kind != .normal {
-		return index_signal
-	}
-	index := flow_value(index_signal)
-	old := e.index_value(container, index)!
-	value := e.apply_assignment_op(op, old, rhs)!
-	new_container := e.set_index_value(container, index, value)!
-	return e.update_target_flow(base_id, new_container)
-}
-
-fn (mut e Eval) update_selector_target(node &flat.Node, value Value) ! {
-	signal := e.update_selector_target_flow(node, value)!
-	if signal.kind != .normal {
-		return error('v3.eval: unexpected `${signal.kind}` escaped selector assignment target')
-	}
-}
-
-fn (mut e Eval) update_selector_target_flow(node &flat.Node, value Value) !FlowSignal {
-	base_id := e.child(node, 0)
-	container_signal := e.eval_expr_flow(base_id)!
-	if container_signal.kind != .normal {
-		return container_signal
-	}
-	new_container := e.set_selector_value(flow_value(container_signal), node.value, value)!
-	return e.update_target_flow(base_id, new_container)
-}
-
-fn (mut e Eval) update_selector_target_with_op_flow(node &flat.Node, op flat.Op, rhs Value) !FlowSignal {
-	base_id := e.child(node, 0)
-	container_signal := e.eval_expr_flow(base_id)!
-	if container_signal.kind != .normal {
-		return container_signal
-	}
-	container := flow_value(container_signal)
-	old := e.eval_selector_value(container, node.value)!
-	value := e.apply_assignment_op(op, old, rhs)!
-	new_container := e.set_selector_value(container, node.value, value)!
-	return e.update_target_flow(base_id, new_container)
-}
-
 fn (mut e Eval) update_target_flow(id flat.NodeId, value Value) !FlowSignal {
 	return e.assign_target_flow(id, value, false)
+}
+
+fn (mut e Eval) update_resolved_lvalue_flow(id flat.NodeId, value Value) !FlowSignal {
+	resolved := e.resolve_lvalue_flow(id)!
+	if resolved.signal.kind != .normal {
+		return resolved.signal
+	}
+	return e.write_resolved_lvalue_flow(resolved, value)
+}
+
+fn (mut e Eval) update_resolved_lvalue_with_op_flow(id flat.NodeId, op flat.Op, rhs Value) !FlowSignal {
+	resolved := e.resolve_lvalue_flow(id)!
+	if resolved.signal.kind != .normal {
+		return resolved.signal
+	}
+	value := e.apply_assignment_op(op, resolved.value, rhs)!
+	return e.write_resolved_lvalue_flow(resolved, value)
+}
+
+fn (mut e Eval) update_resolved_lvalue_postfix_flow(id flat.NodeId, op flat.Op) !FlowSignal {
+	resolved := e.resolve_lvalue_flow(id)!
+	if resolved.signal.kind != .normal {
+		return resolved.signal
+	}
+	value := e.apply_postfix_op(op, resolved.value)!
+	update_signal := e.write_resolved_lvalue_flow(resolved, value)!
+	if update_signal.kind != .normal {
+		return update_signal
+	}
+	return value_flow(resolved.value)
+}
+
+fn (mut e Eval) resolve_lvalue_flow(id flat.NodeId) !ResolvedLvalue {
+	node := e.node(id)
+	match node.kind {
+		.selector {
+			mut base := e.resolve_lvalue_flow(e.child(node, 0))!
+			if base.signal.kind != .normal {
+				return base
+			}
+			value := e.eval_selector_value(base.value, node.value)!
+			base.steps << LvalueStep{
+				kind:       .selector
+				container:  base.value
+				index:      void_value()
+				field_name: node.value
+			}
+			base.value = value
+			return base
+		}
+		.index {
+			mut base := e.resolve_lvalue_flow(e.child(node, 0))!
+			if base.signal.kind != .normal {
+				return base
+			}
+			index_signal := if base.value is MapValue {
+				e.eval_expr_flow_expected(e.child(node, 1), base.value.key_type_name)!
+			} else {
+				e.eval_expr_flow(e.child(node, 1))!
+			}
+			if index_signal.kind != .normal {
+				return ResolvedLvalue{
+					signal: index_signal
+				}
+			}
+			index := flow_value(index_signal)
+			value := e.index_value(base.value, index)!
+			base.steps << LvalueStep{
+				kind:      .index
+				container: base.value
+				index:     index
+			}
+			base.value = value
+			return base
+		}
+		else {
+			signal := e.eval_expr_flow(id)!
+			if signal.kind != .normal {
+				return ResolvedLvalue{
+					signal: signal
+				}
+			}
+			return ResolvedLvalue{
+				root_id: id
+				value:   flow_value(signal)
+			}
+		}
+	}
+}
+
+fn (mut e Eval) write_resolved_lvalue_flow(resolved ResolvedLvalue, value Value) !FlowSignal {
+	mut new_value := value
+	for i := resolved.steps.len - 1; i >= 0; i-- {
+		step := resolved.steps[i]
+		match step.kind {
+			.index {
+				new_value = e.set_index_value(step.container, step.index, new_value)!
+			}
+			.selector {
+				new_value = e.set_selector_value(step.container, step.field_name, new_value)!
+			}
+			else {}
+		}
+	}
+	return e.update_target_flow(resolved.root_id, new_value)
 }
 
 fn (mut e Eval) set_index_value(container Value, index Value, value Value) !Value {
@@ -2759,10 +2832,30 @@ fn (e &Eval) method_call_param_type_names(receiver Value, receiver_type_name str
 			return e.function_param_type_names(target, 1)
 		}
 	}
+	if receiver is ArrayValue {
+		return e.array_method_param_type_names(receiver, method_name)
+	}
+	if receiver is MapValue {
+		return e.map_method_param_type_names(receiver, method_name)
+	}
 	if receiver is SumValue {
 		return e.method_call_param_type_names(receiver.payload, receiver.variant_name, method_name)
 	}
 	return []string{}
+}
+
+fn (e &Eval) array_method_param_type_names(receiver ArrayValue, method_name string) []string {
+	return match method_name {
+		'contains', 'index' { [receiver.elem_type_name] }
+		else { []string{} }
+	}
+}
+
+fn (e &Eval) map_method_param_type_names(receiver MapValue, method_name string) []string {
+	return match method_name {
+		'delete' { [receiver.key_type_name] }
+		else { []string{} }
+	}
 }
 
 fn (mut e Eval) eval_call_arg_values(node &flat.Node, expected_types []string) !FlowSignal {
@@ -3719,11 +3812,8 @@ fn (mut e Eval) eval_postfix_flow(node &flat.Node) !FlowSignal {
 fn (mut e Eval) apply_postfix_target_flow(target_id flat.NodeId, op flat.Op) !FlowSignal {
 	target := e.node(target_id)
 	match target.kind {
-		.index {
-			return e.update_index_postfix_flow(target, op)
-		}
-		.selector {
-			return e.update_selector_postfix_flow(target, op)
+		.index, .selector {
+			return e.update_resolved_lvalue_postfix_flow(target_id, op)
 		}
 		else {
 			old_signal := e.eval_expr_flow(target_id)!
@@ -3739,49 +3829,6 @@ fn (mut e Eval) apply_postfix_target_flow(target_id flat.NodeId, op flat.Op) !Fl
 			return value_flow(old)
 		}
 	}
-}
-
-fn (mut e Eval) update_index_postfix_flow(node &flat.Node, op flat.Op) !FlowSignal {
-	base_id := e.child(node, 0)
-	container_signal := e.eval_expr_flow(base_id)!
-	if container_signal.kind != .normal {
-		return container_signal
-	}
-	container := flow_value(container_signal)
-	index_signal := if container is MapValue {
-		e.eval_expr_flow_expected(e.child(node, 1), container.key_type_name)!
-	} else {
-		e.eval_expr_flow(e.child(node, 1))!
-	}
-	if index_signal.kind != .normal {
-		return index_signal
-	}
-	index := flow_value(index_signal)
-	old := e.index_value(container, index)!
-	value := e.apply_postfix_op(op, old)!
-	new_container := e.set_index_value(container, index, value)!
-	update_signal := e.update_target_flow(base_id, new_container)!
-	if update_signal.kind != .normal {
-		return update_signal
-	}
-	return value_flow(old)
-}
-
-fn (mut e Eval) update_selector_postfix_flow(node &flat.Node, op flat.Op) !FlowSignal {
-	base_id := e.child(node, 0)
-	container_signal := e.eval_expr_flow(base_id)!
-	if container_signal.kind != .normal {
-		return container_signal
-	}
-	container := flow_value(container_signal)
-	old := e.eval_selector_value(container, node.value)!
-	value := e.apply_postfix_op(op, old)!
-	new_container := e.set_selector_value(container, node.value, value)!
-	update_signal := e.update_target_flow(base_id, new_container)!
-	if update_signal.kind != .normal {
-		return update_signal
-	}
-	return value_flow(old)
 }
 
 fn (mut e Eval) apply_postfix_op(op flat.Op, old Value) !Value {
@@ -5031,7 +5078,11 @@ fn (e &Eval) struct_fields(type_name string) []FieldInfo {
 }
 
 fn (e &Eval) struct_field_type_name(value StructValue, field_name string) string {
-	info := e.struct_info(value.type_name)
+	return e.struct_field_type_name_by_type(value.type_name, field_name)
+}
+
+fn (e &Eval) struct_field_type_name_by_type(type_name string, field_name string) string {
+	info := e.struct_info(type_name)
 	for field in info.fields {
 		if field.name == field_name {
 			return e.qualify_type_name(field.module_name, field.typ)

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -510,20 +510,57 @@ fn (mut e Eval) register_files() ! {
 }
 
 fn (mut e Eval) evaluate_global_inits() ! {
+	mut entries_by_module := map[string][]GlobalEntry{}
 	for entry in e.global_inits {
-		e.call_stack << CallFrame{
-			module_name: entry.module_name
-			file_name:   entry.file_name
-			fn_name:     '<global ${entry.name}>'
-		}
-		value := if int(entry.default_node) >= 0 {
-			e.eval_expr(entry.default_node)!
-		} else {
-			e.zero_value_for_type_name_in_module(entry.typ, entry.module_name)
-		}
-		e.call_stack.delete(e.call_stack.len - 1)
-		e.globals[entry.module_name][entry.name] = e.adapt_value_to_type_name(value, entry.typ)
+		mut entries := entries_by_module[entry.module_name]
+		entries << entry
+		entries_by_module[entry.module_name] = entries
 	}
+	mut visited := map[string]bool{}
+	mut visiting := map[string]bool{}
+	e.evaluate_module_global_inits('main', entries_by_module, mut visited, mut visiting)!
+	for module_name in e.module_order {
+		e.evaluate_module_global_inits(module_name, entries_by_module, mut visited, mut visiting)!
+	}
+}
+
+fn (mut e Eval) evaluate_module_global_inits(module_name string, entries_by_module map[string][]GlobalEntry, mut visited map[string]bool, mut visiting map[string]bool) ! {
+	if module_name in visited {
+		return
+	}
+	if module_name in visiting {
+		return
+	}
+	visiting[module_name] = true
+	if module_name in e.module_imports {
+		for imported_module in e.module_imports[module_name] {
+			e.evaluate_module_global_inits(imported_module, entries_by_module, mut visited, mut
+				visiting)!
+		}
+	}
+	visiting.delete(module_name)
+	visited[module_name] = true
+	if module_name !in entries_by_module {
+		return
+	}
+	for entry in entries_by_module[module_name] {
+		e.evaluate_global_init(entry)!
+	}
+}
+
+fn (mut e Eval) evaluate_global_init(entry GlobalEntry) ! {
+	e.call_stack << CallFrame{
+		module_name: entry.module_name
+		file_name:   entry.file_name
+		fn_name:     '<global ${entry.name}>'
+	}
+	value := if int(entry.default_node) >= 0 {
+		e.eval_expr(entry.default_node)!
+	} else {
+		e.zero_value_for_type_name_in_module(entry.typ, entry.module_name)
+	}
+	e.call_stack.delete(e.call_stack.len - 1)
+	e.globals[entry.module_name][entry.name] = e.adapt_value_to_type_name(value, entry.typ)
 }
 
 fn (mut e Eval) register_function(module_name string, file_name string, id flat.NodeId, node &flat.Node) {
@@ -816,7 +853,7 @@ fn (mut e Eval) exec_stmt(id flat.NodeId) !FlowSignal {
 				expr_id := e.child(node, 0)
 				expr := e.node(expr_id)
 				if expr.kind == .infix && expr.op == .left_shift {
-					e.exec_array_append(expr)!
+					return e.exec_array_append(expr)
 				} else {
 					signal := e.eval_expr_flow(expr_id)!
 					if signal.kind != .normal {
@@ -1298,11 +1335,19 @@ fn (mut e Eval) set_selector_value(container Value, field_name string, value Val
 	}
 }
 
-fn (mut e Eval) exec_array_append(node &flat.Node) ! {
+fn (mut e Eval) exec_array_append(node &flat.Node) !FlowSignal {
 	lhs_id := e.child(node, 0)
 	rhs_id := e.child(node, 1)
-	rhs := e.eval_expr(rhs_id)!
-	current := e.eval_expr(lhs_id)!
+	rhs_signal := e.eval_expr_flow(rhs_id)!
+	if rhs_signal.kind != .normal {
+		return rhs_signal
+	}
+	rhs := flow_value(rhs_signal)
+	current_signal := e.eval_expr_flow(lhs_id)!
+	if current_signal.kind != .normal {
+		return current_signal
+	}
+	current := flow_value(current_signal)
 	if current !is ArrayValue {
 		return error('v3.eval: `<<` is only supported for arrays')
 	}
@@ -1315,6 +1360,7 @@ fn (mut e Eval) exec_array_append(node &flat.Node) ! {
 		arr.values << e.adapt_value_to_type_name(rhs, arr.elem_type_name)
 	}
 	e.update_target(lhs_id, arr)!
+	return normal_flow()
 }
 
 fn (e &Eval) array_append_rhs_spreads(rhs_id flat.NodeId, rhs ArrayValue, elem_type_name string) bool {
@@ -3354,7 +3400,11 @@ fn (e &Eval) or_block_err_value(value Value) Value {
 
 fn (mut e Eval) exec_match(node &flat.Node) !FlowSignal {
 	target_id := e.child(node, 0)
-	target := e.eval_expr(target_id)!
+	target_signal := e.eval_expr_flow(target_id)!
+	if target_signal.kind != .normal {
+		return target_signal
+	}
+	target := flow_value(target_signal)
 	for i in 1 .. node.children_count {
 		branch := e.child_node(node, i)
 		if branch.kind != .match_branch {

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -153,6 +153,7 @@ struct CallFrame {
 	module_name string
 	file_name   string
 	fn_name     string
+	scope_idx   int = -1
 }
 
 struct MaybeValue {
@@ -763,12 +764,13 @@ fn (mut e Eval) call_function(module_name string, fn_name string, args []Value) 
 	if args.len < min_args {
 		return error('v3.eval: `${target_module}.${fn_name}` expected ${min_args} arguments, got ${args.len}')
 	}
+	e.open_scope()
 	e.call_stack << CallFrame{
 		module_name: target_module
 		file_name:   def.file_name
 		fn_name:     fn_name
+		scope_idx:   e.scopes.len - 1
 	}
-	e.open_scope()
 	e.bind_call_params(params, args)!
 	mut body_ids := e.children(node)
 	if body_start > 0 {
@@ -953,7 +955,13 @@ fn (mut e Eval) register_defer_stmt(id flat.NodeId) {
 	if e.scopes.len == 0 {
 		e.open_scope()
 	}
-	scope_idx := e.scopes.len - 1
+	node := e.node(id)
+	scope_idx := if node.value == 'function' && e.call_stack.len > 0
+		&& e.call_stack[e.call_stack.len - 1].scope_idx >= 0 {
+		e.call_stack[e.call_stack.len - 1].scope_idx
+	} else {
+		e.scopes.len - 1
+	}
 	e.scopes[scope_idx].defer_stmts << id
 }
 
@@ -2333,6 +2341,20 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 				values: [e.call_result_value(result)]
 			}
 		}
+		selector_value := e.eval_selector_value(left, callee.value) or { void_value() }
+		if selector_value is FnValue {
+			args_signal :=
+				e.eval_call_arg_values(node, e.fn_value_param_type_names(selector_value))!
+			if args_signal.kind != .normal {
+				return args_signal
+			}
+			result := e.call_fn_value(selector_value, args_signal.values)!
+			e.write_back_fn_value(callee_id, result)!
+			e.write_back_mutated_arg_values(node, result.mutated_args)!
+			return FlowSignal{
+				values: [e.call_result_value(result)]
+			}
+		}
 		receiver_type_name := e.infer_expr_type_name(receiver_id)
 		expected_types := e.method_call_param_type_names(left, receiver_type_name, callee.value)
 		args_signal := e.eval_call_arg_values(node, expected_types)!
@@ -2724,12 +2746,13 @@ fn (mut e Eval) call_fn_value(fv FnValue, args []Value) !CallResult {
 		}
 		break
 	}
+	e.open_scope()
 	e.call_stack << CallFrame{
 		module_name: fv.module_name
 		file_name:   fv.file_name
 		fn_name:     '<anonymous>'
+		scope_idx:   e.scopes.len - 1
 	}
-	e.open_scope()
 	for name, value in fv.captures {
 		e.declare_var_typed(name, value, fv.capture_types[name] or { '' })
 	}

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -546,11 +546,12 @@ enum Other {
 fn main() {
 	m := map[Color]int{.red: 7}
 	println(int_str(m[Color.red]))
+	println(int_str(m[.red] or { 0 }))
 }
 	') or {
 		panic(err)
 	}
-	assert e.stdout() == '7\n'
+	assert e.stdout() == '7\n7\n'
 }
 
 fn test_eval_map_lookup_adapts_sum_keys() {
@@ -1988,8 +1989,7 @@ fn maybe() ?int {
 }
 
 fn run() int {
-	_ := "' + '$' +
-		'{maybe() or {
+	_ := "\${maybe() or {
 		return 7
 	}}"
 	return 9

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -351,6 +351,28 @@ fn main() {
 	assert e.stdout() == '0\n1\n0\n'
 }
 
+fn test_eval_array_init_flow_propagates_return() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn run() []int {
+	return []int{len: 1, init: maybe() or { return [7] }}
+}
+
+fn main() {
+	xs := run()
+	println(int_str(xs.len))
+	println(int_str(xs[0]))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n7\n'
+}
+
 fn test_eval_fixed_array_init_uses_declared_len() {
 	mut e := create()
 	e.run_text('
@@ -957,6 +979,48 @@ fn main() {
 	assert e.stdout() == '0\n1\n'
 }
 
+fn test_eval_imported_return_adapts_in_callee_module() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_import_return_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub type Any = int | string
+
+pub fn make() Any {
+	return 1
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+fn main() {
+	x := m.make()
+	println(int_str(x._typ))
+	if x is int {
+		println("int")
+	}
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '0\nint\n'
+}
+
 fn test_eval_value_block_preserves_multi_return_values() {
 	mut e := create()
 	e.run_text("
@@ -1181,6 +1245,33 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == 'true\ntrue\ntrue\ntrue\n'
+}
+
+fn test_eval_enum_shorthand_return_preserves_enum_type() {
+	mut e := create()
+	e.run_text('
+enum Color {
+	red
+	blue
+}
+
+type Any = Color | int
+
+fn color() Color {
+	return .red
+}
+
+fn main() {
+	c := color()
+	x := Any(c)
+	println(c == Color.red)
+	println(x is Color)
+	println(int_str(x._typ))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'true\ntrue\n0\n'
 }
 
 fn test_eval_enum_shorthand_uses_typed_call_and_struct_contexts() {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -412,6 +412,41 @@ fn main() {
 	assert e.stdout() == '1\n2\n2\n1\n2\n'
 }
 
+fn test_eval_match_value_branches_execute_array_append_statements() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	mut xs := []int{}
+	n := match 0 {
+		0 {
+			xs << 1
+			xs.len
+		}
+		else {
+			0
+		}
+	}
+	m := match 1 {
+		0 {
+			0
+		}
+		else {
+			xs << 2
+			xs.len
+		}
+	}
+	println(int_str(n))
+	println(int_str(m))
+	println(int_str(xs.len))
+	println(int_str(xs[0]))
+	println(int_str(xs[1]))
+}
+		') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n2\n2\n1\n2\n'
+}
+
 fn test_eval_or_block_return_propagates_from_array_append_rhs() {
 	mut e := create()
 	e.run_text('
@@ -456,6 +491,31 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == '11\n12\n'
+}
+
+fn test_eval_for_mut_reuses_resolved_array_container() {
+	mut e := create()
+	e.run_text('
+fn next(mut i int) int {
+	old := i
+	i++
+	return old
+}
+
+fn main() {
+	mut buckets := [[1], [10]]
+	mut i := 0
+	for mut x in buckets[next(mut i)] {
+		x++
+	}
+	println(int_str(buckets[0][0]))
+	println(int_str(buckets[1][0]))
+	println(int_str(i))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '2\n10\n1\n'
 }
 
 fn test_eval_array_init_preserves_cap() {
@@ -1841,6 +1901,50 @@ fn main() {
 	assert e.stdout() == 'true\ntrue\n0\n'
 }
 
+fn test_eval_enum_shorthand_return_uses_expected_type_in_value_branches() {
+	mut e := create()
+	e.run_text('
+enum Color {
+	red = 10
+	blue = 20
+}
+
+enum Other {
+	red = 1
+	blue = 2
+}
+
+fn pick_if(b bool) Color {
+	return if b {
+		.red
+	} else {
+		.blue
+	}
+}
+
+fn pick_match(n int) Color {
+	return match n {
+		0 {
+			.red
+		}
+		else {
+			.blue
+		}
+	}
+}
+
+fn main() {
+	println(pick_if(true) == Color.red)
+	println(pick_if(false) == Color.blue)
+	println(pick_match(0) == Color.red)
+	println(pick_match(1) == Color.blue)
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'true\ntrue\ntrue\ntrue\n'
+}
+
 fn test_eval_enum_shorthand_uses_typed_call_and_struct_contexts() {
 	mut e := create()
 	e.run_text('
@@ -1908,6 +2012,57 @@ enum Other {
 
 fn main() {
 	println(m.take(.red))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == 'm-red\n'
+}
+
+fn test_eval_imported_fn_value_param_hints_are_qualified() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_import_fn_value_hint_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub enum Color {
+	red
+	blue
+}
+
+pub fn make_taker() fn (Color) string {
+	return fn (c Color) string {
+		if c == Color.red {
+			return "m-red"
+		}
+		return "wrong"
+	}
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+enum Other {
+	red = 10
+}
+
+fn main() {
+	f := m.make_taker()
+	println(f(.red))
 }
 	') or {
 		panic(err)

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -152,6 +152,33 @@ fn main() {
 	assert e.stdout() == '1\n2\n'
 }
 
+fn test_eval_match_condition_propagates_return() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn run() int {
+	x := 1
+	match x {
+		maybe() or {
+			return 7
+		} {}
+		else {}
+	}
+	return 0
+}
+
+fn main() {
+	println(int_str(run()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
 fn test_eval_match_branch_shadows_outer_locals() {
 	mut e := create()
 	e.run_text('
@@ -642,6 +669,30 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == '0\n1\n0\n1\n'
+}
+
+fn test_eval_index_assignment_lhs_index_propagates_return() {
+	mut e := create()
+	e.run_text('
+fn idx() ?int {
+	return none
+}
+
+fn run() int {
+	mut xs := [0]
+	xs[idx() or {
+		return 7
+	}] = 1
+	return xs[0]
+}
+
+fn main() {
+	println(int_str(run()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
 }
 
 fn test_eval_array_literal_preserves_element_type_for_sum_checks() {
@@ -2604,6 +2655,47 @@ fn main() {
 	p.parse_files([main_file, mod_file])
 	e.run_files(p.a) or { panic(err) }
 	assert e.stdout() == '7\n'
+}
+
+fn test_eval_zero_array_field_qualifies_imported_element_type() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_import_array_elem_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub struct Item {}
+
+pub struct Box {
+pub mut:
+	xs []Item
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+fn main() {
+	mut b := m.Box{}
+	b.xs << [m.Item{}, m.Item{}]
+	println(int_str(b.xs.len))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '2\n'
 }
 
 fn test_eval_is_checks_keep_module_qualified_types_distinct() {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -1237,6 +1237,93 @@ fn main() {
 	assert e.stdout() == '3\n'
 }
 
+fn test_eval_imported_struct_field_default_adapts_in_declaring_module() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_import_field_default_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub struct A {}
+
+pub type Any = A | string
+
+pub struct Box {
+pub:
+	x Any = A{}
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+fn main() {
+	box := m.Box{}
+	println(int_str(box.x._typ))
+	if box.x is m.A {
+		println("a")
+	}
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '0\na\n'
+}
+
+fn test_eval_imported_struct_field_container_type_uses_declaring_module() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_import_field_container_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub struct Item {}
+
+pub struct Box {
+pub mut:
+	xs []Item
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+fn main() {
+	box := m.Box{xs: [m.Item{}]}
+	mut xs := box.xs
+	xs << [m.Item{}, m.Item{}]
+	println(int_str(xs.len))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '3\n'
+}
+
 fn test_eval_value_block_preserves_multi_return_values() {
 	mut e := create()
 	e.run_text("

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -315,7 +315,7 @@ fn main() {
 fn test_eval_array_append_keeps_nested_array_rhs_as_single_element() {
 	mut e := create()
 	e.run_text('
-fn main() {
+	fn main() {
 	mut nested := [][]int{}
 	nested << [1, 2]
 	println(int_str(nested.len))
@@ -333,10 +333,36 @@ fn main() {
 	assert e.stdout() == '1\n2\n2\n2\n4\n'
 }
 
+fn test_eval_array_append_index_target_evaluates_once() {
+	mut e := create()
+	e.run_text('
+	fn next(mut i int) int {
+		old := i
+		i++
+		return old
+	}
+
+	fn main() {
+		mut xs := [][]int{}
+		xs << [1]
+		xs << [2]
+		mut i := 0
+		xs[next(mut i)] << 9
+		println(int_str(xs[0].len))
+		println(int_str(xs[0][1]))
+		println(int_str(xs[1].len))
+		println(int_str(i))
+	}
+		') or {
+		panic(err)
+	}
+	assert e.stdout() == '2\n9\n1\n1\n'
+}
+
 fn test_eval_or_block_return_propagates_from_array_append_rhs() {
 	mut e := create()
 	e.run_text('
-fn maybe() ?int {
+	fn maybe() ?int {
 	return none
 }
 
@@ -1408,11 +1434,13 @@ fn main() {
 fn test_eval_value_block_uses_last_sequential_expression_value() {
 	mut e := create()
 	e.run_text('
-fn trace() {}
+	fn trace() int {
+		return 1
+	}
 
-fn choose(ok bool) int {
-	return if ok {
-		trace()
+	fn choose(ok bool) int {
+		return if ok {
+			trace()
 		2
 	} else {
 		3

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -554,6 +554,34 @@ fn main() {
 	assert e.stdout() == '7\n7\n'
 }
 
+fn test_eval_map_literal_value_flow_propagates_return() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn run() map[string]int {
+	return {
+		"a": maybe() or {
+			return {
+				"b": 7
+			}
+		}
+	}
+}
+
+fn main() {
+	m := run()
+	println(int_str(m["b"]))
+	println(int_str(m["a"]))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n0\n'
+}
+
 fn test_eval_map_lookup_adapts_sum_keys() {
 	mut e := create()
 	e.run_text('
@@ -909,6 +937,26 @@ fn main() {
 	assert e.stdout() == '1\ntwo\n3\n'
 }
 
+fn test_eval_multi_return_adapts_items_to_declared_types() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+fn pair() (Any, Any) {
+	return 1, "s"
+}
+
+fn main() {
+	a, b := pair()
+	println(int_str(a._typ))
+	println(int_str(b._typ))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n1\n'
+}
+
 fn test_eval_value_block_preserves_multi_return_values() {
 	mut e := create()
 	e.run_text("
@@ -1104,6 +1152,35 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == 'a\n'
+}
+
+fn test_eval_enum_zero_values_use_first_field() {
+	mut e := create()
+	e.run_text('
+enum Color {
+	red
+	blue
+}
+
+struct S {
+	c Color
+}
+
+__global g Color
+
+fn main() {
+	s := S{}
+	arr := [2]Color{}
+	m := map[string]Color{}
+	println(s.c == Color.red)
+	println(g == Color.red)
+	println(arr[0] == Color.red)
+	println(m["missing"] == Color.red)
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'true\ntrue\ntrue\ntrue\n'
 }
 
 fn test_eval_enum_shorthand_uses_typed_call_and_struct_contexts() {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -3211,6 +3211,56 @@ fn main() {
 	assert e.stdout() == 'ints\nstrings\nint-map\nstring-map\n'
 }
 
+fn test_eval_primitive_str_methods_are_direct() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	total := 42
+	println(total.str())
+	println(true.str())
+	f := 1.5
+	println(f.str())
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '42\ntrue\n1.5\n'
+}
+
+fn test_eval_enum_stringification_uses_field_names() {
+	mut e := create()
+	e.run_text('
+enum State {
+	idle
+	busy = 10
+}
+
+fn main() {
+	println(State.busy)
+	println("\${State.idle}")
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'busy\nidle\n'
+}
+
+fn test_eval_os_join_path_delegates_to_os() {
+	mut e := create()
+	e.run_text('
+import os
+
+fn main() {
+	println(os.join_path("", "foo"))
+	println(os.join_path("foo", ""))
+}
+	') or {
+		panic(err)
+	}
+	expected := os.join_path('', 'foo') + '\n' + os.join_path('foo', '') + '\n'
+	assert e.stdout() == expected
+}
+
 fn test_v3_eval_backend_cli() {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_eval_backend_test')
 	build := os.execute('${vexe} -o ${v3_bin} ${v3_src}')

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -27,6 +27,32 @@ fn main() {
 	assert e.stdout() == '10\n'
 }
 
+fn test_eval_registers_top_level_comptime_block_declarations() {
+	mut e := create()
+	e.run_text('
+$if windows {
+	fn gated_message() string {
+		return "ok"
+	}
+} $else $if macos {
+	fn gated_message() string {
+		return "ok"
+	}
+} $else {
+	fn gated_message() string {
+		return "ok"
+	}
+}
+
+fn main() {
+	println(gated_message())
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'ok\n'
+}
+
 fn test_eval_disabled_if_call_skips_arguments() {
 	mut e := create()
 	e.run_text('
@@ -1575,6 +1601,26 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == 'true\ntrue\ntrue\ntrue\n'
+}
+
+fn test_eval_global_assignment_uses_declared_type() {
+	mut e := create()
+	e.run_text('
+enum State {
+	idle
+	busy
+}
+
+__global state State
+
+fn main() {
+	state = .busy
+	println(state)
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'busy\n'
 }
 
 fn test_eval_enum_shorthand_return_preserves_enum_type() {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -270,6 +270,30 @@ fn main() {
 	assert e.stdout() == '1\n2\n2\n2\n4\n'
 }
 
+fn test_eval_or_block_return_propagates_from_array_append_rhs() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn run() int {
+	mut xs := []int{}
+	xs << (maybe() or {
+		return 7
+	})
+	return xs.len
+}
+
+fn main() {
+	println(int_str(run()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
 fn test_eval_for_mut_array_writes_back_elements() {
 	mut e := create()
 	e.run_text('
@@ -1506,6 +1530,31 @@ fn main() {
 	assert e.stdout() == '1\n'
 }
 
+fn test_eval_or_block_return_propagates_from_match_subject() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn run() int {
+	match (maybe() or {
+		return 7
+	}) {
+		else {}
+	}
+	return 0
+}
+
+fn main() {
+	println(int_str(run()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
 fn test_eval_map_index_or_uses_lookup_presence() {
 	mut e := create()
 	e.run_text('
@@ -1856,6 +1905,46 @@ fn main() {
 	p.parse_files([main_file, mod_file])
 	e.run_files(p.a) or { panic(err) }
 	assert e.stdout() == '99\n7\n'
+}
+
+fn test_eval_global_initializers_run_imports_before_main() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_global_init_order_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+__global g = 7
+
+pub fn value() int {
+	return g
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+__global x = m.value()
+
+fn main() {
+	println(int_str(x))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '7\n'
 }
 
 fn test_eval_module_inits_run_dependencies_first() {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -448,6 +448,29 @@ fn main() {
 	assert e.stdout() == '9223372036854775805\n9223372036854775805\n'
 }
 
+fn test_eval_compound_index_target_evaluates_once() {
+	mut e := create()
+	e.run_text('
+fn next(mut i int) int {
+	old := i
+	i++
+	return old
+}
+
+fn main() {
+	mut xs := [1, 2]
+	mut i := 0
+	xs[next(mut i)] += 10
+	println(int_str(xs[0]))
+	println(int_str(xs[1]))
+	println(int_str(i))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '11\n2\n1\n'
+}
+
 fn test_eval_struct_method_and_map_update() {
 	mut e := create()
 	e.run_text("
@@ -683,6 +706,54 @@ fn run() int {
 	xs[idx() or {
 		return 7
 	}] = 1
+	return xs[0]
+}
+
+fn main() {
+	println(int_str(run()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
+fn test_eval_postfix_index_target_evaluates_once() {
+	mut e := create()
+	e.run_text('
+fn next(mut i int) int {
+	old := i
+	i++
+	return old
+}
+
+fn main() {
+	mut xs := [1, 2]
+	mut i := 0
+	old := xs[next(mut i)]++
+	println(int_str(old))
+	println(int_str(xs[0]))
+	println(int_str(xs[1]))
+	println(int_str(i))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n2\n2\n1\n'
+}
+
+fn test_eval_postfix_index_target_propagates_flow() {
+	mut e := create()
+	e.run_text('
+fn idx() ?int {
+	return none
+}
+
+fn run() int {
+	mut xs := [0]
+	xs[idx() or {
+		return 7
+	}]++
 	return xs[0]
 }
 
@@ -1070,6 +1141,46 @@ fn main() {
 	p.parse_files([main_file, mod_file])
 	e.run_files(p.a) or { panic(err) }
 	assert e.stdout() == '0\nint\n'
+}
+
+fn test_eval_imported_array_return_qualifies_element_type() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_import_array_return_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub struct Item {}
+
+pub fn items() []Item {
+	return [Item{}]
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+fn main() {
+	mut xs := m.items()
+	xs << [m.Item{}, m.Item{}]
+	println(int_str(xs.len))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '3\n'
 }
 
 fn test_eval_value_block_preserves_multi_return_values() {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -2328,6 +2328,35 @@ fn main() {
 	assert e.stdout() == 'false\nfalse\n'
 }
 
+fn test_eval_optional_if_guard_binds_payload_type() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return 41
+}
+
+fn absent() ?int {
+	return none
+}
+
+fn main() {
+	if x := maybe() {
+		println(int_str(x + 1))
+	} else {
+		println("missing")
+	}
+	if x := absent() {
+		println(int_str(x))
+	} else {
+		println("absent")
+	}
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '42\nabsent\n'
+}
+
 fn test_eval_optional_sum_return_adapts_payload_before_wrapping() {
 	mut e := create()
 	e.run_text('
@@ -2513,6 +2542,29 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == '0\n7\n\nfallback\n'
+}
+
+fn test_eval_map_index_if_guard_uses_lookup_presence() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	mut m := map[string]int{}
+	m["present"] = 0
+	if v := m["present"] {
+		println(int_str(v))
+	} else {
+		println("missing-present")
+	}
+	if v := m["missing"] {
+		println(int_str(v))
+	} else {
+		println("missing")
+	}
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\nmissing\n'
 }
 
 fn test_eval_postfix_option_propagates_failure() {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -553,6 +553,22 @@ fn main() {
 	assert e.stdout() == '7\n'
 }
 
+fn test_eval_map_lookup_adapts_sum_keys() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+fn main() {
+	m := map[Any]int{1: 2, "s": 3}
+	println(int_str(m[1]))
+	println(int_str(m["s"]))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '2\n3\n'
+}
+
 fn test_eval_indexed_writes_adapt_sum_values() {
 	mut e := create()
 	e.run_text('
@@ -604,6 +620,31 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == '1\n0\n'
+}
+
+fn test_eval_typed_map_target_adapts_entries() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+struct S {
+	m map[string]Any
+}
+
+fn main() {
+	s := S{
+		m: {
+			"a": 1
+			"b": "s"
+		}
+	}
+	println(int_str(s.m["a"]._typ))
+	println(int_str(s.m["b"]._typ))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n1\n'
 }
 
 fn test_eval_mut_receiver_method_updates_original() {
@@ -1939,6 +1980,30 @@ fn main() {
 	assert e.stdout() == '7\n'
 }
 
+fn test_eval_or_block_return_propagates_from_string_interpolation() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn run() int {
+	_ := "' + '$' +
+		'{maybe() or {
+		return 7
+	}}"
+	return 9
+}
+
+fn main() {
+	println(int_str(run()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
 fn test_eval_match_expression_propagates_branch_return() {
 	mut e := create()
 	e.run_text('
@@ -2004,6 +2069,51 @@ fn main() {
 	p.parse_files([mod_file, main_file])
 	e.run_files(p.a) or { panic(err) }
 	assert e.stdout() == '7\n'
+}
+
+fn test_eval_enum_initializers_use_declaring_module_context() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_enum_module_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	mod_file := os.join_path(dir, 'm.v')
+	main_file := os.join_path(dir, 'main.v')
+	os.write_file(mod_file, '
+module m
+
+const base = 2
+
+pub enum E {
+	a = base
+	b
+}
+
+pub fn value() int {
+	return int(E.a) * 10 + int(E.b)
+}
+') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+const base = 10
+
+fn main() {
+	println(int_str(m.value()))
+}
+') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([mod_file, main_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '23\n'
 }
 
 fn test_eval_global_initializers_run_after_registration_in_declaring_module() {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -359,6 +359,28 @@ fn test_eval_array_append_index_target_evaluates_once() {
 	assert e.stdout() == '2\n9\n1\n1\n'
 }
 
+fn test_eval_array_append_rhs_uses_element_enum_type() {
+	mut e := create()
+	e.run_text('
+	enum Color {
+		red = 10
+	}
+
+	enum Other {
+		red = 1
+	}
+
+	fn main() {
+		mut xs := []Color{}
+		xs << .red
+		println(xs[0] == Color.red)
+	}
+		') or {
+		panic(err)
+	}
+	assert e.stdout() == 'true\n'
+}
+
 fn test_eval_or_block_return_propagates_from_array_append_rhs() {
 	mut e := create()
 	e.run_text('
@@ -664,7 +686,7 @@ fn main() {
 fn test_eval_map_delete_mutates_receiver() {
 	mut e := create()
 	e.run_text("
-fn main() {
+	fn main() {
 	mut m := map[string]int{}
 	m['a'] = 7
 	m.delete('a')
@@ -678,10 +700,35 @@ fn main() {
 	assert e.stdout() == '0\nfalse\n0\n'
 }
 
+fn test_eval_map_delete_index_receiver_evaluates_once() {
+	mut e := create()
+	e.run_text("
+	fn next(mut i int) int {
+		old := i
+		i++
+		return old
+	}
+
+	fn main() {
+		mut maps := []map[string]int{}
+		maps << map[string]int{'a': 1}
+		maps << map[string]int{'a': 2}
+		mut i := 0
+		maps[next(mut i)].delete('a')
+		println('a' in maps[0])
+		println('a' in maps[1])
+		println(int_str(i))
+	}
+	") or {
+		panic(err)
+	}
+	assert e.stdout() == 'false\ntrue\n1\n'
+}
+
 fn test_eval_map_literal_adapts_sum_values() {
 	mut e := create()
 	e.run_text('
-type Any = int | string
+	type Any = int | string
 
 fn main() {
 	m := map[string]Any{"a": 1, "b": "s"}
@@ -1615,7 +1662,7 @@ fn main() {
 fn test_eval_enum_zero_values_use_first_field() {
 	mut e := create()
 	e.run_text('
-enum Color {
+	enum Color {
 	red
 	blue
 }
@@ -1641,10 +1688,33 @@ fn main() {
 	assert e.stdout() == 'true\ntrue\ntrue\ntrue\n'
 }
 
+fn test_eval_enum_cast_preserves_enum_identity() {
+	mut e := create()
+	e.run_text('
+	enum Color {
+		red
+		blue
+	}
+
+	type Any = Color | int
+
+	fn main() {
+		c := Color(1)
+		x := Any(Color(1))
+		println(c == Color.blue)
+		println(c)
+		println(x is Color)
+	}
+		') or {
+		panic(err)
+	}
+	assert e.stdout() == 'true\nblue\ntrue\n'
+}
+
 fn test_eval_global_assignment_uses_declared_type() {
 	mut e := create()
 	e.run_text('
-enum State {
+	enum State {
 	idle
 	busy
 }

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -532,6 +532,27 @@ fn main() {
 	assert e.stdout() == '0\n1\n'
 }
 
+fn test_eval_map_literal_keys_use_declared_enum_type() {
+	mut e := create()
+	e.run_text('
+enum Color {
+	red
+}
+
+enum Other {
+	red = 10
+}
+
+fn main() {
+	m := map[Color]int{.red: 7}
+	println(int_str(m[Color.red]))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
 fn test_eval_indexed_writes_adapt_sum_values() {
 	mut e := create()
 	e.run_text('
@@ -904,6 +925,29 @@ fn main() {
 	assert e.stdout() == '2\n1\n'
 }
 
+fn test_eval_multi_assign_propagates_rhs_flow() {
+	mut e := create()
+	e.run_text('
+fn maybe_pair() ?(int, int) {
+	return none
+}
+
+fn run() int {
+	a, b := maybe_pair() or {
+		return 7
+	}
+	return a + b
+}
+
+fn main() {
+	println(int_str(run()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
 fn test_eval_struct_equality_compares_fields() {
 	mut e := create()
 	e.run_text('
@@ -1150,6 +1194,26 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == '2\n0\n3\n0\n'
+}
+
+fn test_eval_logical_and_rhs_uses_is_smartcast() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+fn positive(x Any) bool {
+	return x is int && x > 0
+}
+
+fn main() {
+	println(positive(2))
+	println(positive(-1))
+	println(positive("s"))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'true\nfalse\nfalse\n'
 }
 
 fn test_eval_calls_function_value_from_identifier() {
@@ -1838,6 +1902,36 @@ fn run() []int {
 
 fn main() {
 	println(int_str(run()[0]))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
+fn test_eval_or_block_return_propagates_from_struct_init_field() {
+	mut e := create()
+	e.run_text('
+struct S {
+	n int
+}
+
+fn maybe() ?int {
+	return none
+}
+
+fn run() S {
+	return S{
+		n: maybe() or {
+			return S{
+				n: 7
+			}
+		}
+	}
+}
+
+fn main() {
+	println(int_str(run().n))
 }
 	') or {
 		panic(err)

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -1,0 +1,2299 @@
+module eval
+
+import os
+import v3.parser
+
+const vexe = @VEXE
+const v3_dir = os.dir(os.dir(@FILE))
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn test_eval_function_call_and_for_range() {
+	mut e := create()
+	e.run_text('
+fn sum(n int) int {
+	mut acc := 0
+	for i in 0 .. n {
+		acc += i
+	}
+	return acc
+}
+
+fn main() {
+	println(sum(5))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '10\n'
+}
+
+fn test_eval_disabled_if_call_skips_arguments() {
+	mut e := create()
+	e.run_text('
+__global hit int
+
+@[if trace ?]
+fn trace(x int) {}
+
+fn side_effect() int {
+	hit = 99
+	return 1
+}
+
+fn main() {
+	trace(side_effect())
+	println(int_str(hit))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n'
+}
+
+fn test_eval_labeled_for_in_flow_targets_named_loop() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	mut out := ""
+	outer: for x in 0 .. 3 {
+		for y in 0 .. 3 {
+			if x == 1 && y == 0 {
+				continue outer
+			}
+			if x == 2 && y == 1 {
+				break outer
+			}
+			out += "\${x}:\${y};"
+		}
+	}
+	println(out)
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '0:0;0:1;0:2;2:0;\n'
+}
+
+fn test_eval_labeled_c_style_for_flow_targets_named_loop() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	mut out := ""
+	outer: for x := 0; x < 3; x++ {
+		for y := 0; y < 3; y++ {
+			if x == 1 && y == 0 {
+				continue outer
+			}
+			if x == 2 && y == 1 {
+				break outer
+			}
+			out += "\${x}:\${y};"
+		}
+	}
+	println(out)
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '0:0;0:1;0:2;2:0;\n'
+}
+
+fn test_eval_if_expr_value() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	x := if 3 > 2 {
+		41
+	} else {
+		0
+	}
+	println(x + 1)
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '42\n'
+}
+
+fn test_eval_char_literal_escapes() {
+	mut e := create()
+	e.run_text(r"
+fn main() {
+	println(int_str(`\0`))
+	println(int_str(`\\`))
+	println(int_str(`\'`))
+}
+	") or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n92\n39\n'
+}
+
+fn test_eval_match_statement_propagates_return() {
+	mut e := create()
+	e.run_text('
+fn choose(x int) int {
+	match x {
+		0 {
+			return 1
+		}
+		else {}
+	}
+	return 2
+}
+
+fn main() {
+	println(int_str(choose(0)))
+	println(int_str(choose(1)))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n2\n'
+}
+
+fn test_eval_match_branch_shadows_outer_locals() {
+	mut e := create()
+	e.run_text('
+fn stmt_shadow(n int) int {
+	x := 1
+	match n {
+		0 {
+			x := 2
+			if x != 2 {
+				return 99
+			}
+		}
+		else {}
+	}
+	return x
+}
+
+fn value_shadow(n int) int {
+	x := 1
+	y := match n {
+		0 {
+			x := 2
+			x
+		}
+		else {
+			3
+		}
+	}
+	return x * 10 + y
+}
+
+fn main() {
+	println(int_str(stmt_shadow(0)))
+	println(int_str(stmt_shadow(1)))
+	println(int_str(value_shadow(0)))
+	println(int_str(value_shadow(1)))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n1\n12\n13\n'
+}
+
+fn test_eval_c_style_for_scopes_initializer_and_body() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	i := 10
+	for i := 0; i < 1; i++ {}
+	println(int_str(i))
+
+	x := 1
+	for j := 0; j < 2; j++ {
+		x := j + 2
+		_ = x
+	}
+	println(int_str(x))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '10\n1\n'
+}
+
+fn test_eval_array_append_and_string_interpolation() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	mut arr := []int{}
+	arr << 7
+	arr << 9
+	println("\${arr[0]}:\${arr[1]}:\${arr.len}")
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '7:9:2\n'
+}
+
+fn test_eval_array_append_adapts_sum_elements() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+fn main() {
+	mut xs := []Any{}
+	xs << 1
+	xs << "s"
+	println(int_str(xs[0]._typ))
+	println(int_str(xs[1]._typ))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n1\n'
+}
+
+fn test_eval_array_append_keeps_nested_array_rhs_as_single_element() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	mut nested := [][]int{}
+	nested << [1, 2]
+	println(int_str(nested.len))
+	println(int_str(nested[0].len))
+	println(int_str(nested[0][1]))
+
+	mut flat := []int{}
+	flat << [3, 4]
+	println(int_str(flat.len))
+	println(int_str(flat[1]))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n2\n2\n2\n4\n'
+}
+
+fn test_eval_for_mut_array_writes_back_elements() {
+	mut e := create()
+	e.run_text('
+struct Item {
+mut:
+	n int
+}
+
+fn main() {
+	mut xs := [Item{n: 1}, Item{n: 2}]
+	for mut item in xs {
+		item.n += 10
+	}
+	println(int_str(xs[0].n))
+	println(int_str(xs[1].n))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '11\n12\n'
+}
+
+fn test_eval_array_init_preserves_cap() {
+	mut e := create()
+	e.run_text('
+	fn main() {
+	a := []int{cap: 4}
+	b := []int{len: 1, cap: 4}
+	println(int_str(a.len))
+	println(int_str(a.cap))
+	println(int_str(b.len))
+	println(int_str(b.cap))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n4\n1\n4\n'
+}
+
+fn test_eval_array_init_adapts_sum_elements() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+fn main() {
+	xs := []Any{1, "s"}
+	ys := []Any{len: 2, init: 1}
+	println(int_str(xs[0]._typ))
+	println(int_str(xs[1]._typ))
+	println(int_str(ys[1]._typ))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n1\n0\n'
+}
+
+fn test_eval_fixed_array_init_uses_declared_len() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	a := [3]int{}
+	b := [3]int{init: 5}
+	nested := [2][2]int{}
+	dynamic := [][2]int{}
+	println(int_str(a.len))
+	println(int_str(a[2]))
+	println(int_str(b.len))
+	println(int_str(b[1]))
+	println(int_str(nested[1][1]))
+	println(int_str(dynamic.len))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '3\n0\n3\n5\n0\n0\n'
+}
+
+fn test_eval_right_shift_compound_assignment() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	mut x := 8
+	x >>= 1
+	println(int_str(x))
+}
+') or { panic(err) }
+	assert e.stdout() == '4\n'
+}
+
+fn test_eval_unsigned_right_shift_and_compound_assignment() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	println(int_str(i64(-5) >>> 1))
+	mut x := i64(-5)
+	x >>>= 1
+	println(int_str(x))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '9223372036854775805\n9223372036854775805\n'
+}
+
+fn test_eval_struct_method_and_map_update() {
+	mut e := create()
+	e.run_text("
+struct Point {
+	x int
+	y int
+}
+
+fn (p Point) sum() int {
+	return p.x + p.y
+}
+
+fn main() {
+	p := Point{x: 2, y: 5}
+	mut m := map[string]int{}
+	m['a'] = p.sum()
+	m['b'] += 3
+	println(int_str(m['a'] + m['b']))
+}
+") or {
+		panic(err)
+	}
+	assert e.stdout() == '10\n'
+}
+
+fn test_eval_static_method_dispatches_from_type_value() {
+	mut e := create()
+	e.run_text('
+struct Foo {
+	n int
+}
+
+fn Foo.new(n int) Foo {
+	return Foo{n: n}
+}
+
+fn main() {
+	foo := Foo.new(7)
+	println(int_str(foo.n))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
+fn test_eval_overloaded_plus_operator_dispatches_method() {
+	mut e := create()
+	e.run_text('
+struct Number {
+	value int
+}
+
+fn (a Number) + (b Number) Number {
+	return Number{value: a.value + b.value}
+}
+
+fn main() {
+	c := Number{value: 2} + Number{value: 5}
+	println(int_str(c.value))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
+fn test_eval_alias_receiver_method_dispatches_by_static_type() {
+	mut e := create()
+	e.run_text('
+type UserId = int
+
+fn (id UserId) next() int {
+	return int(id) + 1
+}
+
+fn main() {
+	id := UserId(1)
+	println(int_str(id.next()))
+	println(int_str(UserId(2).next()))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '2\n3\n'
+}
+
+fn test_eval_typeof_name_selector_returns_type_name() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	println(typeof(1).name)
+	println(typeof("x").name)
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'int\nstring\n'
+}
+
+fn test_eval_map_delete_mutates_receiver() {
+	mut e := create()
+	e.run_text("
+fn main() {
+	mut m := map[string]int{}
+	m['a'] = 7
+	m.delete('a')
+	println(int_str(m.len))
+	println('a' in m)
+	println(int_str(m['a']))
+}
+") or {
+		panic(err)
+	}
+	assert e.stdout() == '0\nfalse\n0\n'
+}
+
+fn test_eval_map_literal_adapts_sum_values() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+fn main() {
+	m := map[string]Any{"a": 1, "b": "s"}
+	println(int_str(m["a"]._typ))
+	println(int_str(m["b"]._typ))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n1\n'
+}
+
+fn test_eval_indexed_writes_adapt_sum_values() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+fn main() {
+	mut xs := []Any{len: 2}
+	xs[0] = 1
+	xs[1] = "s"
+	println(int_str(xs[0]._typ))
+	println(int_str(xs[1]._typ))
+
+	mut m := map[string]Any{}
+	m["a"] = 1
+	m["b"] = "s"
+	println(int_str(m["a"]._typ))
+	println(int_str(m["b"]._typ))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n1\n0\n1\n'
+}
+
+fn test_eval_array_literal_preserves_element_type_for_sum_checks() {
+	mut e := create()
+	e.run_text('
+type Any = []int | string
+
+fn main() {
+	x := Any([1, 2])
+	println(x is []int)
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'true\n'
+}
+
+fn test_eval_shorthand_map_literal_infers_key_value_types() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	m := {"a": 1}
+	println(int_str(m["a"]))
+	println(int_str(m["missing"]))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n0\n'
+}
+
+fn test_eval_mut_receiver_method_updates_original() {
+	mut e := create()
+	e.run_text('
+struct Point {
+mut:
+	x int
+}
+
+fn (mut p Point) inc() int {
+	p.x += 1
+	return p.x
+}
+
+fn main() {
+	mut p := Point{x: 1}
+	println(int_str(p.inc()))
+	println(int_str(p.x))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '2\n2\n'
+}
+
+fn test_eval_mut_function_arg_updates_original() {
+	mut e := create()
+	e.run_text('
+fn inc(mut x int) {
+	x++
+}
+
+fn main() {
+	mut a := 1
+	inc(mut a)
+	println(int_str(a))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '2\n'
+}
+
+fn test_eval_mut_function_literal_arg_updates_original() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	f := fn (mut x int) {
+		x++
+	}
+	mut a := 1
+	f(mut a)
+	println(int_str(a))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '2\n'
+}
+
+fn test_eval_function_literal_arg_adapts_to_sum_param() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+fn main() {
+	f := fn (x Any) {
+		println(int_str(x._typ))
+	}
+	f(1)
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n'
+}
+
+fn test_eval_variadic_arguments_pack_into_array() {
+	mut e := create()
+	e.run_text('
+fn count(xs ...int) int {
+	return xs.len
+}
+
+fn sum(seed int, xs ...int) int {
+	mut total := seed
+	for x in xs {
+		total += x
+	}
+	return total
+}
+
+fn main() {
+	println(int_str(count()))
+	println(int_str(count(1, 2)))
+	println(int_str(sum(10, 1, 2, 3)))
+	f := fn (xs ...int) int {
+		return xs.len
+	}
+	println(int_str(f(4, 5, 6)))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n2\n16\n3\n'
+}
+
+fn test_eval_function_literal_captures_escaping_scope() {
+	mut e := create()
+	e.run_text('
+fn make() fn () int {
+	x := 7
+	return fn [x] () int {
+		return x
+	}
+}
+
+fn main() {
+	f := make()
+	println(int_str(f()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
+fn test_eval_mut_function_literal_capture_persists_between_calls() {
+	mut e := create()
+	e.run_text('
+fn new_counter() fn () int {
+	mut i := 0
+	return fn [mut i] () int {
+		i++
+		return i
+	}
+}
+
+fn main() {
+	counter := new_counter()
+	println(int_str(counter()))
+	println(int_str(counter()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n2\n'
+}
+
+fn test_eval_mut_closure_param_preserves_capture_state() {
+	mut e := create()
+	e.run_text('
+fn new_counter() fn () int {
+	mut i := 0
+	return fn [mut i] () int {
+		i++
+		return i
+	}
+}
+
+fn use(f fn () int) {
+	println(int_str(f()))
+	println(int_str(f()))
+}
+
+fn main() {
+	counter := new_counter()
+	use(counter)
+	println(int_str(counter()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n2\n3\n'
+}
+
+fn test_eval_mut_method_arg_updates_original() {
+	mut e := create()
+	e.run_text('
+struct S {}
+
+fn (s S) inc(mut x int) {
+	x++
+}
+
+fn main() {
+	s := S{}
+	mut a := 1
+	s.inc(mut a)
+	println(int_str(a))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '2\n'
+}
+
+fn test_eval_multi_return_assignment_spreads_tuple() {
+	mut e := create()
+	e.run_text("
+fn pair() (int, string) {
+	return 2, 'ok'
+}
+
+fn main() {
+	a, b := pair()
+	println(int_str(a))
+	println(b)
+}
+") or {
+		panic(err)
+	}
+	assert e.stdout() == '2\nok\n'
+}
+
+fn test_eval_multi_return_assignment_spreads_three_value_tuple() {
+	mut e := create()
+	e.run_text("
+fn triple() (int, string, int) {
+	return 1, 'two', 3
+}
+
+fn main() {
+	a, b, c := triple()
+	println(int_str(a))
+	println(b)
+	println(int_str(c))
+}
+") or {
+		panic(err)
+	}
+	assert e.stdout() == '1\ntwo\n3\n'
+}
+
+fn test_eval_value_block_preserves_multi_return_values() {
+	mut e := create()
+	e.run_text("
+fn choose(ok bool) (int, string) {
+	return if ok { 1, 'a' } else { 2, 'b' }
+}
+
+fn main() {
+	a, b := choose(true)
+	c, d := choose(false)
+	println('\${a}:\${b}:\${c}:\${d}')
+}
+") or {
+		panic(err)
+	}
+	assert e.stdout() == '1:a:2:b\n'
+}
+
+fn test_eval_value_block_uses_last_sequential_expression_value() {
+	mut e := create()
+	e.run_text('
+fn trace() {}
+
+fn choose(ok bool) int {
+	return if ok {
+		trace()
+		2
+	} else {
+		3
+	}
+}
+
+fn main() {
+	println(int_str(choose(true)))
+	println(int_str(choose(false)))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '2\n3\n'
+}
+
+fn test_eval_multi_assign_preserves_rhs_values() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	mut a := 1
+	mut b := 2
+	a, b = b, a
+	println(int_str(a))
+	println(int_str(b))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '2\n1\n'
+}
+
+fn test_eval_struct_equality_compares_fields() {
+	mut e := create()
+	e.run_text('
+struct Point {
+	x int
+}
+
+fn main() {
+	a := Point{x: 1}
+	b := Point{x: 2}
+	c := Point{x: 1}
+	println(a == b)
+	println(a == c)
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == 'false\ntrue\n'
+}
+
+fn test_eval_scopes_enum_constants_by_enum_type() {
+	mut e := create()
+	e.run_text('
+enum A {
+	x
+}
+
+enum B {
+	x = 10
+}
+
+fn main() {
+	println(int_str(A.x))
+	println(int_str(B.x))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n10\n'
+}
+
+fn test_eval_enum_selector_preserves_sum_variant_type() {
+	mut e := create()
+	e.run_text('
+enum Test {
+	abc
+}
+
+type SumTest = Test | u8
+
+fn main() {
+	b := SumTest(Test.abc)
+	println(b is Test)
+	println(b is u8)
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'true\nfalse\n'
+}
+
+fn test_eval_match_shorthand_enum_uses_target_enum_type() {
+	mut e := create()
+	e.run_text('
+enum A {
+	x
+}
+
+enum B {
+	x = 10
+}
+
+fn main() {
+	match A.x {
+		.x {
+			println("a")
+		}
+		else {
+			println("bad")
+		}
+	}
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == 'a\n'
+}
+
+fn test_eval_match_shorthand_enum_uses_tracked_var_type() {
+	mut e := create()
+	e.run_text('
+enum A {
+	x
+}
+
+enum B {
+	x = 10
+}
+
+fn main() {
+	a := A.x
+	match a {
+		.x {
+			println("a")
+		}
+		else {
+			println("bad")
+		}
+	}
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == 'a\n'
+}
+
+fn test_eval_enum_shorthand_uses_typed_call_and_struct_contexts() {
+	mut e := create()
+	e.run_text('
+enum A {
+	x
+}
+
+enum B {
+	x = 10
+}
+
+struct S {
+	c A
+}
+
+fn take_a(a A) int {
+	return int(a)
+}
+
+fn main() {
+	s := S{c: .x}
+	println(int_str(take_a(.x)))
+	println(int_str(s.c))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n0\n'
+}
+
+fn test_eval_match_range_patterns_are_inclusive() {
+	mut e := create()
+	e.run_text('
+fn classify_stmt(n int) string {
+	mut out := ""
+	match n {
+		1...3 {
+			out = "range"
+		}
+		else {
+			out = "other"
+		}
+	}
+	return out
+}
+
+fn classify_expr(n int) string {
+	return match n {
+		1...3 {
+			"range"
+		}
+		else {
+			"other"
+		}
+	}
+}
+
+fn main() {
+	println(classify_stmt(3))
+	println(classify_expr(1))
+	println(classify_expr(4))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'range\nrange\nother\n'
+}
+
+fn test_eval_match_primitive_sum_branches_are_type_patterns() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+fn classify(x Any) string {
+	return match x {
+		int {
+			"int"
+		}
+		string {
+			"string"
+		}
+		else {
+			"other"
+		}
+	}
+}
+
+fn main() {
+	println(classify(1))
+	println(classify("s"))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'int\nstring\n'
+}
+
+fn test_eval_sum_smartcasts_bind_branch_payloads() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+fn if_cast(x Any) int {
+	if x is int {
+		return x + 1
+	}
+	return 0
+}
+
+fn match_cast(x Any) int {
+	return match x {
+		int {
+			x + 2
+		}
+		else {
+			0
+		}
+	}
+}
+
+fn main() {
+	println(int_str(if_cast(1)))
+	println(int_str(if_cast("s")))
+	println(int_str(match_cast(1)))
+	println(int_str(match_cast("s")))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '2\n0\n3\n0\n'
+}
+
+fn test_eval_calls_function_value_from_identifier() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	f := fn () int {
+		return 1
+	}
+	println(int_str(f()))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n'
+}
+
+fn test_eval_prefix_minus_preserves_float() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	x := 1.5
+	println(-1.5)
+	println(-x)
+}
+	') or { panic(err) }
+	assert e.stdout() == '-1.5\n-1.5\n'
+}
+
+fn test_eval_mixed_numeric_equality_compares_as_float() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	println(1 == 1.5)
+	println(1.5 == 1)
+	println(1 == 1.0)
+	println(1.0 == 1)
+	println(1 != 1.5)
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == 'false\nfalse\ntrue\ntrue\ntrue\n'
+}
+
+fn test_eval_number_literals_strip_separators() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	println(int_str(1_234))
+	println(int_str(0x1_f))
+	println(1_234.5 == 1234.5)
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '1234\n31\ntrue\n'
+}
+
+fn test_eval_sum_numeric_as_cast_unwraps_payload() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+fn main() {
+	x := Any(7)
+	println(int_str(x as int))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
+fn test_eval_alias_field_zero_value_uses_underlying_type() {
+	mut e := create()
+	e.run_text('
+type UserId = int
+
+struct S {
+	id UserId
+}
+
+fn main() {
+	println(int_str(S{}.id))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n'
+}
+
+fn test_eval_alias_to_sum_param_adapts_argument() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+type Alias = Any
+
+fn variant(x Alias) int {
+	return x._typ
+}
+
+fn main() {
+	println(int_str(variant(1)))
+	println(int_str(variant("s")))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n1\n'
+}
+
+fn test_eval_struct_field_writes_adapt_sum_values() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+struct S {
+mut:
+	a Any
+}
+
+fn main() {
+	mut s := S{}
+	s.a = 1
+	println(int_str(s.a._typ))
+	s.a = "s"
+	println(int_str(s.a._typ))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n1\n'
+}
+
+fn test_eval_struct_init_fields_adapt_sum_values() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+struct S {
+	a Any
+	b Any
+}
+
+fn main() {
+	s := S{a: 1, b: "s"}
+	println(int_str(s.a._typ))
+	println(int_str(s.b._typ))
+	t := S{
+		...s
+		a: "x"
+	}
+	println(int_str(t.a._typ))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n1\n1\n'
+}
+
+fn test_eval_defer_runs_before_function_return() {
+	mut e := create()
+	e.run_text('
+fn run() int {
+	defer {
+		println("first")
+	}
+	defer {
+		println("second")
+	}
+	println("body")
+	return 7
+}
+
+fn main() {
+	println(int_str(run()))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == 'body\nsecond\nfirst\n7\n'
+}
+
+fn test_eval_scoped_defers_run_at_scope_exit() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	mut out := ""
+	if true {
+		defer {
+			out += "d"
+		}
+		out += "b"
+	}
+	out += "a"
+	for i in 0 .. 2 {
+		defer {
+			out += int_str(i)
+		}
+		out += "i"
+	}
+	println(out)
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'bdai0i1\n'
+}
+
+fn test_eval_or_block_return_propagates() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn run() int {
+	_ := maybe() or {
+		return 1
+	}
+	return 2
+}
+
+fn main() {
+	println(int_str(run()))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n'
+}
+
+fn test_eval_optional_bool_return_wraps_false_payload() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?bool {
+	return false
+}
+
+fn run_or() bool {
+	return maybe() or {
+		return true
+	}
+}
+
+fn run_guard() string {
+	if v := maybe() {
+		if v {
+			return "true"
+		}
+		return "false"
+	}
+	return "none"
+}
+
+fn main() {
+	println(run_or())
+	println(run_guard())
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'false\nfalse\n'
+}
+
+fn test_eval_optional_sum_return_adapts_payload_before_wrapping() {
+	mut e := create()
+	e.run_text('
+type Any = int | string
+
+fn maybe() ?Any {
+	return 1
+}
+
+fn main() {
+	x := maybe() or {
+		return
+	}
+	println(int_str(x._typ))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n'
+}
+
+fn test_eval_or_block_return_propagates_from_call_argument() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn run() int {
+	println(int_str(maybe() or {
+		return 1
+	}))
+	return 2
+}
+
+fn main() {
+	println(int_str(run()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n'
+}
+
+fn test_eval_or_block_return_propagates_from_nested_infix() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn run() int {
+	x := (maybe() or {
+		return 12
+	}) + 1
+	return x
+}
+
+fn main() {
+	println(int_str(run()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '12\n'
+}
+
+fn test_eval_or_block_return_propagates_from_selector_receiver() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?string {
+	return none
+}
+
+fn run() string {
+	n := (maybe() or {
+		return "early"
+	}).len
+	return int_str(n)
+}
+
+fn main() {
+	println(run())
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'early\n'
+}
+
+fn test_eval_or_block_return_propagates_from_method_receiver() {
+	mut e := create()
+	e.run_text('
+fn maybe_arr() ?[]int {
+	return none
+}
+
+fn run() int {
+	x := (maybe_arr() or {
+		return 12
+	}).first()
+	return x
+}
+
+fn main() {
+	println(int_str(run()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '12\n'
+}
+
+fn test_eval_or_block_return_propagates_from_outer_or_left_operand() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn wrap(x int) ?int {
+	return x
+}
+
+fn run() int {
+	_ := wrap(maybe() or {
+		return 1
+	}) or {
+		return 2
+	}
+	return 3
+}
+
+fn main() {
+	println(int_str(run()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n'
+}
+
+fn test_eval_map_index_or_uses_lookup_presence() {
+	mut e := create()
+	e.run_text('
+fn main() {
+	mut m := map[string]int{}
+	m["present"] = 0
+	println(int_str(m["present"] or { 7 }))
+	println(int_str(m["missing"] or { 7 }))
+
+	mut s := map[string]string{}
+	s["empty"] = ""
+	println(s["empty"] or { "fallback" })
+	println(s["missing"] or { "fallback" })
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n7\n\nfallback\n'
+}
+
+fn test_eval_postfix_option_propagates_failure() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn run() ?int {
+	maybe()?
+	println("after")
+	return 1
+}
+
+fn main() {
+	run() or {
+		println("none")
+		return
+	}
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'none\n'
+}
+
+fn test_eval_or_block_binds_err() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn main() {
+	maybe() or {
+		_ := err
+		println("handled")
+		return
+	}
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'handled\n'
+}
+
+fn test_eval_or_block_return_propagates_from_for_in_header() {
+	mut e := create()
+	e.run_text('
+fn maybe_arr() ?[]int {
+	return none
+}
+
+fn maybe_int() ?int {
+	return none
+}
+
+fn maybe_two() ?int {
+	return 2
+}
+
+fn iterable() int {
+	for x in (maybe_arr() or {
+		return 7
+	}) {
+		_ = x
+	}
+	return 0
+}
+
+fn range_start() int {
+	for i in (maybe_int() or {
+		return 8
+	}) .. 3 {
+		_ = i
+	}
+	return 0
+}
+
+fn range_end() int {
+	for i in 0 .. (maybe_int() or {
+		return 9
+	}) {
+		_ = i
+	}
+	return 0
+}
+
+fn main() {
+	println(int_str(iterable()))
+	println(int_str(range_start()))
+	println(int_str(range_end()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n8\n9\n'
+}
+
+fn test_eval_or_block_return_propagates_from_flow_contexts() {
+	mut e := create()
+	e.run_text('
+fn maybe_bool() ?bool {
+	return none
+}
+
+fn maybe_arr() ?[]int {
+	return none
+}
+
+fn maybe_int() ?int {
+	return none
+}
+
+fn maybe_two() ?int {
+	return 2
+}
+
+fn if_condition() int {
+	if maybe_bool() or {
+		return 1
+	} {
+		return 99
+	}
+	return 0
+}
+
+fn assert_condition() bool {
+	assert maybe_bool() or {
+		return false
+	}
+	return true
+}
+
+fn loop_condition() int {
+	for maybe_bool() or {
+		return 5
+	} {
+		return 99
+	}
+	return 0
+}
+
+fn index_receiver() int {
+	x := (maybe_arr() or {
+		return 6
+	})[0]
+	return x
+}
+
+fn index_value() int {
+	arr := [10]
+	x := arr[maybe_int() or {
+		return 7
+	}]
+	return x
+}
+
+fn if_expr_branch() int {
+	x := if true {
+		maybe_int() or {
+			return 8
+		}
+	} else {
+		0
+	}
+	return x
+}
+
+fn if_guard_scope() int {
+	x := 1
+	if x := maybe_two() {
+		if x != 2 {
+			return 99
+		}
+	}
+	return x
+}
+
+fn main() {
+	println(int_str(if_condition()))
+	println(assert_condition())
+	println(int_str(loop_condition()))
+	println(int_str(index_receiver()))
+	println(int_str(index_value()))
+	println(int_str(if_expr_branch()))
+	println(int_str(if_guard_scope()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\nfalse\n5\n6\n7\n8\n1\n'
+}
+
+fn test_eval_or_block_return_propagates_from_array_literal_element() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn run() []int {
+	_ := [maybe() or {
+		return [7]
+	}]
+	return [0]
+}
+
+fn main() {
+	println(int_str(run()[0]))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n'
+}
+
+fn test_eval_match_expression_propagates_branch_return() {
+	mut e := create()
+	e.run_text('
+fn run(n int) int {
+	x := match n {
+		0 {
+			return 12
+		}
+		else {
+			7
+		}
+	}
+	return x + 1
+}
+
+fn main() {
+	println(int_str(run(0)))
+	println(int_str(run(1)))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '12\n8\n'
+}
+
+fn test_eval_module_const_uses_defining_module_context() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_const_module_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	mod_file := os.join_path(dir, 'm.v')
+	main_file := os.join_path(dir, 'main.v')
+	os.write_file(mod_file, '
+module m
+
+const x = helper()
+
+fn helper() int {
+	return 7
+}
+') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+fn helper() int {
+	return 99
+}
+
+fn main() {
+	println(int_str(m.x))
+}
+') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([mod_file, main_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '7\n'
+}
+
+fn test_eval_global_initializers_run_after_registration_in_declaring_module() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_global_init_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+__global g = helper()
+
+fn helper() int {
+	return 7
+}
+
+pub fn value() int {
+	return g
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+fn helper() int {
+	return 99
+}
+
+__global main_g = helper()
+
+fn main() {
+	println(int_str(main_g))
+	println(int_str(m.value()))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '99\n7\n'
+}
+
+fn test_eval_module_inits_run_dependencies_first() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_init_order_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	moda_file := os.join_path(dir, 'moda.v')
+	modb_file := os.join_path(dir, 'modb.v')
+	os.write_file(modb_file, '
+module modb
+
+__global flag int
+
+fn init() {
+	flag = 41
+}
+
+pub fn value() int {
+	return flag
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(moda_file, '
+module moda
+
+import modb
+
+__global seen int
+
+fn init() {
+	seen = modb.value()
+}
+
+pub fn value() int {
+	return seen
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import moda
+
+fn main() {
+	println(int_str(moda.value()))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, moda_file, modb_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '41\n'
+}
+
+fn test_eval_struct_metadata_uses_current_module() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_struct_scope_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(main_file, '
+module main
+
+import m
+
+struct Point {
+	x int
+}
+
+fn main() {
+	p := Point{}
+	println(int_str(p.x))
+}
+') or {
+		panic(err)
+	}
+	os.write_file(mod_file, '
+module m
+
+struct Point {
+	y int
+}
+') or { panic(err) }
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '0\n'
+}
+
+fn test_eval_struct_field_defaults_use_declaring_module() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_struct_field_module_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub struct Inner {
+	x int
+}
+
+pub struct Outer {
+	inner Inner
+}
+
+pub fn outer_x(o Outer) int {
+	return o.inner.x
+}
+') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+struct Inner {
+	y int
+}
+
+fn main() {
+	outer := m.Outer{}
+	println(int_str(m.outer_x(outer)))
+}
+') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '0\n'
+}
+
+fn test_eval_struct_field_default_initializers_are_preserved() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_struct_field_defaults_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub struct S {
+pub:
+	n int = helper()
+}
+
+fn helper() int {
+	return 7
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+struct S {
+	n int = helper()
+}
+
+fn helper() int {
+	return 3
+}
+
+fn main() {
+	println(int_str(S{}.n))
+	println(int_str(m.S{}.n))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '3\n7\n'
+}
+
+fn test_eval_import_alias_struct_init_resolves_real_module() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_import_alias_struct_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub struct S {
+pub:
+	n int = 7
+}
+	') or { panic(err) }
+	os.write_file(main_file, '
+module main
+
+import m as mm
+
+fn main() {
+	println(int_str(mm.S{}.n))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '7\n'
+}
+
+fn test_eval_is_checks_keep_module_qualified_types_distinct() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_type_scope_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub struct Foo {}
+') or { panic(err) }
+	os.write_file(main_file, '
+module main
+
+import m
+
+struct Foo {}
+
+type Any = Foo | m.Foo
+
+fn classify(x Any) string {
+	if x is Foo {
+		return "local"
+	}
+	if x is m.Foo {
+		return "module"
+	}
+	return "none"
+}
+
+fn main() {
+	println(classify(m.Foo{}))
+}
+') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == 'module\n'
+}
+
+fn test_eval_module_sum_type_keeps_primitive_variants_unqualified() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_primitive_type_scope_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub type Any = u32 | string
+
+pub fn classify(x Any) string {
+	if x is u32 {
+		return "u32"
+	}
+	if x is string {
+		return "string"
+	}
+	return "none"
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+fn main() {
+	println(m.classify(u32(7)))
+	println(m.classify("ok"))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == 'u32\nstring\n'
+}
+
+fn test_eval_sum_tables_are_module_scoped_and_exact() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_sum_scope_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub struct Foo {}
+
+pub type Any = string | bool
+
+pub fn variant_index() int {
+	x := Any("s")
+	return x._typ
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+struct Foo {}
+
+type Any = int | string
+type Both = Foo | m.Foo
+
+fn local_variant_index() int {
+	x := Any("s")
+	return x._typ
+}
+
+fn imported_variant_index() int {
+	x := Both(m.Foo{})
+	return x._typ
+}
+
+fn main() {
+	println(int_str(local_variant_index()))
+	println(int_str(m.variant_index()))
+	println(int_str(imported_variant_index()))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '1\n0\n1\n'
+}
+
+fn test_eval_is_checks_respect_container_element_types() {
+	mut e := create()
+	e.run_text('
+type Any = []int | []string | map[string]int | map[string]string
+
+fn classify(x Any) string {
+	if x is []string {
+		return "strings"
+	}
+	if x is []int {
+		return "ints"
+	}
+	if x is map[string]string {
+		return "string-map"
+	}
+	if x is map[string]int {
+		return "int-map"
+	}
+	return "none"
+}
+
+fn main() {
+	println(classify([]int{len: 1, init: 1}))
+	println(classify([]string{len: 1, init: "s"}))
+	mut mi := map[string]int{}
+	mi["a"] = 1
+	println(classify(mi))
+	mut ms := map[string]string{}
+	ms["a"] = "s"
+	println(classify(ms))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'ints\nstrings\nint-map\nstring-map\n'
+}
+
+fn test_v3_eval_backend_cli() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_eval_backend_test')
+	build := os.execute('${vexe} -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0
+	src := os.join_path(os.temp_dir(), 'v3_eval_backend_sample.v')
+	os.write_file(src, '
+fn main() {
+	mut total := 0
+	for i in 0 .. 7 {
+		total += i
+	}
+	println(int_str(total))
+}
+') or {
+		panic(err)
+	}
+	result := os.execute('${v3_bin} ${src} -b eval')
+	assert result.exit_code == 0
+	assert result.output.contains('21\n')
+}

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -3134,6 +3134,42 @@ fn main() {
 	assert e.stdout() == '23\n'
 }
 
+fn test_eval_enum_initializers_use_file_import_aliases() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_enum_alias_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	dep_file := os.join_path(dir, 'dep.v')
+	main_file := os.join_path(dir, 'main.v')
+	os.write_file(dep_file, '
+module dep
+
+pub const n = 7
+	') or { panic(err) }
+	os.write_file(main_file, '
+module main
+
+import dep as d
+
+enum E {
+	a = d.n
+}
+
+fn main() {
+	println(int_str(int(E.a)))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, dep_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == '7\n'
+}
+
 fn test_eval_global_initializers_run_after_registration_in_declaring_module() {
 	dir := os.join_path(os.temp_dir(), 'v3_eval_global_init_${os.getpid()}')
 	os.rmdir_all(dir) or {}
@@ -3715,6 +3751,47 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == 'busy\nidle\n'
+}
+
+fn test_eval_struct_stringification_matches_v_output() {
+	mut e := create()
+	e.run_text('
+struct Point {
+	x int
+}
+
+struct User {
+	name string
+	age  int
+}
+
+struct Custom {
+	n int
+}
+
+fn (c Custom) str() string {
+	return "custom " + int_str(c.n)
+}
+
+fn main() {
+	println(Point{x: 1})
+	println(User{name: "Ada", age: 2})
+	println(Custom{n: 3})
+	println("\${Custom{n: 4}}")
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == "Point{
+    x: 1
+}
+User{
+    name: 'Ada'
+    age: 2
+}
+custom 3
+custom 4
+"
 }
 
 fn test_eval_os_join_path_delegates_to_os() {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -30,7 +30,7 @@ fn main() {
 fn test_eval_registers_top_level_comptime_block_declarations() {
 	mut e := create()
 	e.run_text('
-$if windows {
+	$if windows {
 	fn gated_message() string {
 		return "ok"
 	}
@@ -53,10 +53,20 @@ fn main() {
 	assert e.stdout() == 'ok\n'
 }
 
+fn test_eval_executes_implicit_main_top_level_statements() {
+	mut e := create()
+	e.run_text('
+	mut x := 1
+	x += 2
+	println(x)
+	') or { panic(err) }
+	assert e.stdout() == '3\n'
+}
+
 fn test_eval_disabled_if_call_skips_arguments() {
 	mut e := create()
 	e.run_text('
-__global hit int
+	__global hit int
 
 @[if trace ?]
 fn trace(x int) {}
@@ -1769,7 +1779,7 @@ fn main() {
 fn test_eval_match_primitive_sum_branches_are_type_patterns() {
 	mut e := create()
 	e.run_text('
-type Any = int | string
+	type Any = int | string
 
 fn classify(x Any) string {
 	return match x {
@@ -1795,10 +1805,38 @@ fn main() {
 	assert e.stdout() == 'int\nstring\n'
 }
 
+fn test_eval_match_value_pattern_is_not_type_pattern() {
+	mut e := create()
+	e.run_text('
+	type Any = int | string
+
+	fn classify(x Any) string {
+		return match x {
+			"int" {
+				"literal"
+			}
+			int {
+				"type"
+			}
+			else {
+				"other"
+			}
+		}
+	}
+
+	fn main() {
+		println(classify(1))
+	}
+		') or {
+		panic(err)
+	}
+	assert e.stdout() == 'type\n'
+}
+
 fn test_eval_sum_smartcasts_bind_branch_payloads() {
 	mut e := create()
 	e.run_text('
-type Any = int | string
+	type Any = int | string
 
 fn if_cast(x Any) int {
 	if x is int {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -381,6 +381,37 @@ fn test_eval_array_append_rhs_uses_element_enum_type() {
 	assert e.stdout() == 'true\n'
 }
 
+fn test_eval_value_blocks_execute_array_append_statements() {
+	mut e := create()
+	e.run_text('
+fn maybe() ?int {
+	return none
+}
+
+fn main() {
+	mut xs := []int{}
+	n := if true {
+		xs << 1
+		xs.len
+	} else {
+		0
+	}
+	m := maybe() or {
+		xs << 2
+		xs.len
+	}
+	println(int_str(n))
+	println(int_str(m))
+	println(int_str(xs.len))
+	println(int_str(xs[0]))
+	println(int_str(xs[1]))
+}
+		') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n2\n2\n1\n2\n'
+}
+
 fn test_eval_or_block_return_propagates_from_array_append_rhs() {
 	mut e := create()
 	e.run_text('

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -471,6 +471,34 @@ fn main() {
 	assert e.stdout() == '11\n2\n1\n'
 }
 
+fn test_eval_selector_index_receiver_evaluates_once_on_write() {
+	mut e := create()
+	e.run_text('
+struct Item {
+mut:
+	x int
+}
+
+fn next(mut i int) int {
+	old := i
+	i++
+	return old
+}
+
+fn main() {
+	mut xs := [Item{x: 1}, Item{x: 2}]
+	mut i := 0
+	xs[next(mut i)].x = 5
+	println(int_str(xs[0].x))
+	println(int_str(xs[1].x))
+	println(int_str(i))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '5\n2\n1\n'
+}
+
 fn test_eval_struct_method_and_map_update() {
 	mut e := create()
 	e.run_text("
@@ -624,6 +652,32 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == '7\n7\n'
+}
+
+fn test_eval_container_methods_use_declared_enum_arg_type() {
+	mut e := create()
+	e.run_text('
+enum Color {
+	red
+	blue
+}
+
+enum Other {
+	red = 10
+}
+
+fn main() {
+	mut m := map[Color]int{.red: 1}
+	m.delete(.red)
+	println(int_str(m.len))
+	xs := [Color.red, Color.blue]
+	println(xs.contains(.red))
+	println(int_str(xs.index(.red)))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\ntrue\n0\n'
 }
 
 fn test_eval_map_literal_value_flow_propagates_return() {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -484,6 +484,32 @@ fn main() {
 	assert e.stdout() == '1\n7\n'
 }
 
+fn test_eval_array_init_evaluates_init_for_each_index() {
+	mut e := create()
+	e.run_text('
+fn bump(mut calls int) int {
+	calls++
+	return calls
+}
+
+fn main() {
+	mut calls := 0
+	xs := []int{len: 3, init: index}
+	ys := []int{len: 3, init: index + bump(mut calls)}
+	fixed := [3]int{init: index}
+	println(int_str(xs[0]))
+	println(int_str(xs[2]))
+	println(int_str(ys[0]))
+	println(int_str(ys[2]))
+	println(int_str(calls))
+	println(int_str(fixed[2]))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n2\n1\n5\n3\n2\n'
+}
+
 fn test_eval_fixed_array_init_uses_declared_len() {
 	mut e := create()
 	e.run_text('
@@ -503,6 +529,32 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == '3\n0\n3\n5\n0\n0\n'
+}
+
+fn test_eval_fixed_array_init_resolves_const_len() {
+	mut e := create()
+	e.run_text('
+const n = 3
+
+struct Box {
+	xs [n]int
+}
+
+fn main() {
+	a := [n]int{}
+	b := [n]int{init: index}
+	box := Box{}
+	println(int_str(a.len))
+	println(int_str(a[2]))
+	println(int_str(b.len))
+	println(int_str(b[2]))
+	println(int_str(box.xs.len))
+	println(int_str(box.xs[2]))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '3\n0\n3\n2\n3\n0\n'
 }
 
 fn test_eval_right_shift_compound_assignment() {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -760,6 +760,34 @@ fn main() {
 	assert e.stdout() == '1\n2\n3\n'
 }
 
+fn test_eval_function_valued_selector_call_updates_captures() {
+	mut e := create()
+	e.run_text('
+struct S {
+	f fn () int
+}
+
+fn new_counter() fn () int {
+	mut i := 0
+	return fn [mut i] () int {
+		i++
+		return i
+	}
+}
+
+fn main() {
+	mut s := S{
+		f: new_counter()
+	}
+	println(int_str(s.f()))
+	println(int_str(s.f()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '1\n2\n'
+}
+
 fn test_eval_mut_method_arg_updates_original() {
 	mut e := create()
 	e.run_text('
@@ -1330,6 +1358,32 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == 'bdai0i1\n'
+}
+
+fn test_eval_defer_fn_runs_at_function_exit() {
+	mut e := create()
+	e.run_text('
+__global hit int
+
+fn run() {
+	for _ in 0 .. 2 {
+		defer(fn) {
+			hit += 100
+		}
+		println(int_str(hit))
+		hit++
+	}
+	println(int_str(hit))
+}
+
+fn main() {
+	run()
+	println(int_str(hit))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n1\n2\n202\n'
 }
 
 fn test_eval_or_block_return_propagates() {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -916,6 +916,33 @@ fn main() {
 	assert e.stdout() == '2\n'
 }
 
+fn test_eval_mut_index_argument_writes_back_once() {
+	mut e := create()
+	e.run_text('
+fn next(mut i int) int {
+	old := i
+	i++
+	return old
+}
+
+fn inc(mut x int) {
+	x++
+}
+
+fn main() {
+	mut xs := [1, 2]
+	mut i := 0
+	inc(mut xs[next(mut i)])
+	println(int_str(xs[0]))
+	println(int_str(xs[1]))
+	println(int_str(i))
+}
+') or {
+		panic(err)
+	}
+	assert e.stdout() == '2\n2\n1\n'
+}
+
 fn test_eval_mut_function_literal_arg_updates_original() {
 	mut e := create()
 	e.run_text('
@@ -1605,6 +1632,54 @@ fn main() {
 		panic(err)
 	}
 	assert e.stdout() == '0\n0\n'
+}
+
+fn test_eval_imported_function_param_hints_are_qualified() {
+	dir := os.join_path(os.temp_dir(), 'v3_eval_import_param_hint_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	main_file := os.join_path(dir, 'main.v')
+	mod_file := os.join_path(dir, 'm.v')
+	os.write_file(mod_file, '
+module m
+
+pub enum Color {
+	red
+	blue
+}
+
+pub fn take(c Color) string {
+	if c == Color.red {
+		return "m-red"
+	}
+	return "wrong"
+}
+	') or {
+		panic(err)
+	}
+	os.write_file(main_file, '
+module main
+
+import m
+
+enum Other {
+	red = 10
+}
+
+fn main() {
+	println(m.take(.red))
+}
+	') or {
+		panic(err)
+	}
+	mut e := create()
+	mut p := parser.Parser.new(&e.prefs)
+	p.parse_files([main_file, mod_file])
+	e.run_files(p.a) or { panic(err) }
+	assert e.stdout() == 'm-red\n'
 }
 
 fn test_eval_match_range_patterns_are_inclusive() {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -4227,11 +4227,16 @@ fn (mut p Parser) array_literal() flat.NodeId {
 			return p.a.add_node(flat.Node{
 				kind:           .array_init
 				value:          elem_type
+				typ:            '[]${elem_type}'
 				children_start: start
 				children_count: flat.child_count(ids.len)
 			})
 		}
-		return p.a.add_val(.array_init, elem_type)
+		return p.a.add_node(flat.Node{
+			kind:  .array_init
+			value: elem_type
+			typ:   '[]${elem_type}'
+		})
 	}
 	// array literal: [1, 2, 3]
 	// or fixed array type: [3]int
@@ -4277,11 +4282,16 @@ fn (mut p Parser) array_literal() flat.NodeId {
 				return p.a.add_node(flat.Node{
 					kind:           .array_init
 					value:          fixed_type
+					typ:            fixed_type
 					children_start: start
 					children_count: flat.child_count(init_ids.len)
 				})
 			}
-			return p.a.add_val(.array_init, fixed_type)
+			return p.a.add_node(flat.Node{
+				kind:  .array_init
+				value: fixed_type
+				typ:   fixed_type
+			})
 		}
 		// single-element array: [expr]
 		start := p.add_children(ids)

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5112,6 +5112,9 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 			return tc.resolve_index_type(node)
 		}
 		.array_init {
+			if node.typ.len > 0 {
+				return tc.parse_type(node.typ)
+			}
 			t := tc.parse_type(node.value)
 			raw_t := t
 			if t is ArrayFixed {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2,6 +2,7 @@ module main
 
 import os
 import v3.bench
+import v3.eval
 import v3.flat
 import v3.gen.arm64
 import v3.gen.c as cgen
@@ -30,7 +31,7 @@ const o_wronly_creat_trunc = 0x601 // O_WRONLY | O_CREAT | O_TRUNC on Darwin
 fn main() {
 	args := os.args[1..]
 	if args.len == 0 {
-		eprintln('usage: v3 <file.v> [-o output|file.c] [-b c|arm64]')
+		eprintln('usage: v3 <file.v> [-o output|file.c] [-b c|arm64|eval]')
 		exit(1)
 	}
 
@@ -132,6 +133,17 @@ fn main() {
 		exit(1)
 	}
 	b.step('check')
+
+	if backend == 'eval' {
+		mut runner := eval.new(prefs)
+		runner.run_files(a) or {
+			eprintln('error: ${err.msg()}')
+			exit(1)
+		}
+		b.step('eval')
+		b.print_report()
+		return
+	}
 
 	// Mark used functions (dead-code elimination). This is done before transform
 	// so the transformer can skip function bodies that the C backend will prune.


### PR DESCRIPTION
## Summary
- add `v3.eval`, a flat-AST interpreter with the v2 eval-style public API (`new`, `create`, `run_text`, `run_files`, `stdout`, `stderr`)
- wire `v3 -b eval` to run the evaluator after parse/type-check and before transform/codegen
- add focused evaluator tests for direct API execution and the v3 CLI eval backend
- keep string slicing addressable for `-gc none -prod` builds
- address eval review findings across multi-return assignment, flow propagation, scoping, typed adaptation, enum/map/array/struct behavior, defers, closures, imported-module context, builtins, top-level comptime declarations, global declared type lookup, implicit-main execution, match type-pattern disambiguation, single-evaluation array append lvalues, sequential value-block results, typed append RHS evaluation, mutating method receiver writeback, enum casts, array initializer semantics, if-guard map/option semantics, and append statements inside value blocks

## Latest Review Pass
- pushed `123b547dc` for the latest review comment: value-block append expression statements now execute through the statement executor before the final block value is produced
- resolved the covered review thread; the current unresolved review-thread count is `0`

## Tests
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew test vlib/v3/eval/eval_test.v`
- `./vnew -check vlib/v3/v3.v`
- `git diff --check -- vlib/v3/eval/eval.v vlib/v3/eval/eval_test.v`
- from `vlib/v3`: `../../vnew -gc none -prod -o /tmp/v3_prod_nogc v3.v`