### PR TITLE
wasm: add table & element sections, call_indirect, and table instructions

### DIFF
--- a/vlib/wasm/encoding.v
+++ b/vlib/wasm/encoding.v
@@ -63,15 +63,17 @@ fn push_f64(mut buf []u8, v f64) {
 	buf << u8(rv >> u32(56))
 }
 
+fn (mod &Module) get_local_func_idx(name string) int {
+	ftt := mod.functions[name] or { panic('function ${name} does not exist') }
+	return ftt.idx + mod.fn_imports.len
+}
+
 fn (mod &Module) get_function_idx(patch CallPatch) int {
 	mut idx := -1
 
 	match patch {
 		FunctionCallPatch {
-			ftt := mod.functions[patch.name] or {
-				panic('called function ${patch.name} does not exist')
-			}
-			idx = ftt.idx + mod.fn_imports.len
+			idx = mod.get_local_func_idx(patch.name)
 		}
 		ImportCallPatch {
 			for fnidx, c in mod.fn_imports {
@@ -183,6 +185,26 @@ pub fn (mut mod Module) compile() []u8 {
 		}
 		mod.end_section(tpatch)
 	}
+	// https://webassembly.github.io/spec/core/binary/modules.html#table-section
+	//
+	if mod.tables.len > 0 {
+		tpatch := mod.start_section(.table_section)
+		{
+			mod.u32(u32(mod.tables.len))
+			for tbl in mod.tables {
+				mod.buf << u8(tbl.reftype)
+				if max := tbl.max {
+					mod.buf << 0x01 // limit, max present
+					mod.u32(tbl.min)
+					mod.u32(max)
+				} else {
+					mod.buf << 0x00 // limit, max not present
+					mod.u32(tbl.min)
+				}
+			}
+		}
+		mod.end_section(tpatch)
+	}
 	// https://webassembly.github.io/spec/core/binary/modules.html#binary-memsec
 	//
 	if memory := mod.memory {
@@ -249,6 +271,15 @@ pub fn (mut mod Module) compile() []u8 {
 					mod.u32(0)
 				}
 			}
+			for tblidx, tbl in mod.tables {
+				if !tbl.export {
+					continue
+				}
+				lsz++
+				mod.name(tbl.name)
+				mod.buf << 0x01 // table
+				mod.u32(u32(tblidx))
+			}
 			for idx, gbl in mod.globals {
 				if !gbl.export {
 					continue
@@ -269,6 +300,49 @@ pub fn (mut mod Module) compile() []u8 {
 		tpatch := mod.start_section(.start_section)
 		{
 			mod.u32(u32(ftt.idx + mod.fn_imports.len))
+		}
+		mod.end_section(tpatch)
+	}
+	// https://webassembly.github.io/spec/core/binary/modules.html#element-section
+	//
+	if mod.elements.len > 0 {
+		tpatch := mod.start_section(.element_section)
+		{
+			mod.u32(u32(mod.elements.len))
+			for el in mod.elements {
+				match el.mode {
+					.active {
+						if el.tableidx == 0 {
+							mod.buf << 0x00 // active, table 0, vec(funcidx)
+							// offset constant expression
+							mod.buf << 0x41 // i32.const
+							mod.buf << leb128.encode_i32(i32(el.offset))
+							mod.buf << 0x0B // END expression opcode
+						} else {
+							mod.buf << 0x02 // active, explicit tableidx + elemkind
+							mod.u32(u32(el.tableidx))
+							mod.buf << 0x41 // i32.const
+							mod.buf << leb128.encode_i32(i32(el.offset))
+							mod.buf << 0x0B // END expression opcode
+							mod.buf << 0x00 // elemkind: funcref
+						}
+					}
+					.declarative {
+						mod.buf << 0x03 // declarative + elemkind
+						mod.buf << 0x00 // elemkind: funcref
+					}
+					.passive {
+						mod.buf << 0x01 // passive + elemkind
+						mod.buf << 0x00 // elemkind: funcref
+					}
+				}
+
+				// vec(funcidx)
+				mod.u32(u32(el.funcs.len))
+				for fnname in el.funcs {
+					mod.u32(u32(mod.get_local_func_idx(fnname)))
+				}
+			}
 		}
 		mod.end_section(tpatch)
 	}

--- a/vlib/wasm/instructions.v
+++ b/vlib/wasm/instructions.v
@@ -1219,3 +1219,56 @@ pub fn (mut func Function) ref_func_import(mod string, name string) {
 		pos:  func.code.len
 	})
 }
+
+// call_indirect calls a function from table `tableidx` whose type is `typeidx`.
+// The function index to call is popped from the stack as an i32.
+// Obtain `typeidx` from `Module.new_functype`.
+// WebAssembly instruction: `call_indirect`.
+pub fn (mut func Function) call_indirect(typeidx TypeIndex, tableidx TableIndex) {
+	func.code << 0x11 // call_indirect
+	func.u32(u32(typeidx))
+	func.u32(u32(tableidx))
+}
+
+// table_get places the reference at the index (popped from the stack) of table
+// `tableidx` onto the stack.
+// WebAssembly instruction: `table.get`.
+pub fn (mut func Function) table_get(tableidx TableIndex) {
+	func.code << 0x25 // table.get
+	func.u32(u32(tableidx))
+}
+
+// table_set stores a reference (popped from the stack) at the index (popped from
+// the stack) of table `tableidx`.
+// WebAssembly instruction: `table.set`.
+pub fn (mut func Function) table_set(tableidx TableIndex) {
+	func.code << 0x26 // table.set
+	func.u32(u32(tableidx))
+}
+
+// table_size places the current size of table `tableidx` on the stack as an i32.
+// WebAssembly instruction: `table.size`.
+pub fn (mut func Function) table_size(tableidx TableIndex) {
+	func.code << 0xFC
+	func.code << 0x10 // table.size
+	func.u32(u32(tableidx))
+}
+
+// table_grow grows table `tableidx` by `n` entries (popped from the stack),
+// filling them with an init reference (popped from the stack). It places the
+// previous size on the stack as an i32, or -1 on failure.
+// WebAssembly instruction: `table.grow`.
+pub fn (mut func Function) table_grow(tableidx TableIndex) {
+	func.code << 0xFC
+	func.code << 0x0F // table.grow
+	func.u32(u32(tableidx))
+}
+
+// table_fill fills a range of table `tableidx` with a reference. It pops the
+// count, the init reference, and the start index from the stack.
+// WebAssembly instruction: `table.fill`.
+pub fn (mut func Function) table_fill(tableidx TableIndex) {
+	func.code << 0xFC
+	func.code << 0x11 // table.fill
+	func.u32(u32(tableidx))
+}

--- a/vlib/wasm/module.v
+++ b/vlib/wasm/module.v
@@ -69,6 +69,8 @@ mut:
 	fn_imports     []FunctionImport
 	global_imports []GlobalImport
 	segments       []DataSegment
+	tables         []Table
+	elements       []Element
 	debug          bool
 	mod_name       ?string
 }
@@ -108,10 +110,34 @@ struct DataSegment {
 	name ?string
 }
 
+struct Table {
+	name    string
+	export  bool
+	reftype RefType
+	min     u32
+	max     ?u32
+}
+
+enum ElementMode {
+	active
+	declarative
+	passive
+}
+
+struct Element {
+	mode     ElementMode
+	tableidx TableIndex
+	offset   int
+	funcs    []string
+}
+
 pub type LocalIndex = int
 pub type GlobalIndex = int
 pub type GlobalImportIndex = int
 pub type DataSegmentIndex = int
+pub type TableIndex = int
+pub type TypeIndex = int
+pub type ElementIndex = int
 
 pub struct FuncType {
 pub:
@@ -120,7 +146,9 @@ pub:
 	name       ?string
 }
 
-fn (mut mod Module) new_functype(ft FuncType) int {
+// new_functype interns a function type and returns its type index.
+// Use it to obtain the type index required by `call_indirect`.
+pub fn (mut mod Module) new_functype(ft FuncType) TypeIndex {
 	// interns existing types
 	mut idx := mod.functypes.index(ft)
 
@@ -185,6 +213,48 @@ pub fn (mut mod Module) assign_memory(name string, export bool, min u32, max ?u3
 // assign_start assigns the start function to the current module.
 pub fn (mut mod Module) assign_start(name string) {
 	mod.start = name
+}
+
+// assign_table declares a table in the current module and returns its index.
+// `reftype` is the element type (`funcref_t` or `externref_t`); pass `max` as
+// `none` for a growable table.
+pub fn (mut mod Module) assign_table(name string, export bool, reftype RefType, min u32, max ?u32) TableIndex {
+	len := mod.tables.len
+	mod.tables << Table{
+		name:    name
+		export:  export
+		reftype: reftype
+		min:     min
+		max:     max
+	}
+	return len
+}
+
+// new_active_element appends an active element segment that initialises table
+// `tableidx` starting at `offset` with the given (local) function references,
+// and returns its index. An active segment also declares its functions, so a
+// later `ref.func` to any of them validates.
+pub fn (mut mod Module) new_active_element(tableidx TableIndex, offset int, funcs []string) ElementIndex {
+	len := mod.elements.len
+	mod.elements << Element{
+		mode:     .active
+		tableidx: tableidx
+		offset:   offset
+		funcs:    funcs
+	}
+	return len
+}
+
+// new_declarative_element appends a declarative element segment that declares
+// the given (local) functions, so that `ref.func` to a non-exported function
+// validates. It allocates no table space. Returns its index.
+pub fn (mut mod Module) new_declarative_element(funcs []string) ElementIndex {
+	len := mod.elements.len
+	mod.elements << Element{
+		mode:  .declarative
+		funcs: funcs
+	}
+	return len
 }
 
 // new_function_import imports a new function into the current module.

--- a/vlib/wasm/tests/table_test.v
+++ b/vlib/wasm/tests/table_test.v
@@ -1,0 +1,97 @@
+module main
+
+import wasm
+
+// A funcref table populated by an active element segment, dispatched through
+// `call_indirect`.
+fn test_call_indirect() {
+	mut m := wasm.Module{}
+
+	mut f0 := m.new_function('f0', [], [.i32_t])
+	{
+		f0.i32_const(10)
+	}
+	m.commit(f0, false)
+
+	mut f1 := m.new_function('f1', [], [.i32_t])
+	{
+		f1.i32_const(20)
+	}
+	m.commit(f1, false)
+
+	tidx := m.assign_table('__indirect_function_table', true, .funcref_t, 2, none)
+	m.new_active_element(tidx, 0, ['f0', 'f1'])
+
+	sig := m.new_functype(wasm.FuncType{
+		parameters: []wasm.ValType{}
+		results:    [.i32_t]
+	})
+
+	mut dispatch := m.new_function('dispatch', [.i32_t], [.i32_t])
+	{
+		dispatch.local_get(0) // table index argument
+		dispatch.call_indirect(sig, tidx)
+	}
+	m.commit(dispatch, true)
+
+	validate(m.compile()) or { panic(err) }
+}
+
+// A growable externref table exercised with table.size/grow/set/get.
+fn test_externref_table() {
+	mut m := wasm.Module{}
+
+	tidx := m.assign_table('refs', true, .externref_t, 1, none)
+
+	// grow by 3 (filling with null); leaves the previous size on the stack
+	mut grow := m.new_function('grow_refs', [], [.i32_t])
+	{
+		grow.ref_null(.externref_t) // init value
+		grow.i32_const(3) // n
+		grow.table_grow(tidx)
+	}
+	m.commit(grow, true)
+
+	mut size := m.new_function('refs_size', [], [.i32_t])
+	{
+		size.table_size(tidx)
+	}
+	m.commit(size, true)
+
+	// refs[0] = null, then read it back and report whether it is null
+	mut roundtrip := m.new_function('roundtrip', [], [.i32_t])
+	{
+		roundtrip.i32_const(0) // index
+		roundtrip.ref_null(.externref_t) // value
+		roundtrip.table_set(tidx)
+		roundtrip.i32_const(0) // index
+		roundtrip.table_get(tidx)
+		roundtrip.ref_is_null(.externref_t)
+	}
+	m.commit(roundtrip, true)
+
+	validate(m.compile()) or { panic(err) }
+}
+
+// A declarative element segment makes `ref.func` to a non-exported, non-tabled
+// function validate. Without the segment, validation would fail.
+fn test_declarative_element() {
+	mut m := wasm.Module{}
+
+	mut hidden := m.new_function('f_hidden', [], [.i32_t])
+	{
+		hidden.i32_const(42)
+	}
+	m.commit(hidden, false) // NOT exported
+
+	m.new_declarative_element(['f_hidden'])
+
+	mut probe := m.new_function('probe', [], [.i32_t])
+	{
+		probe.ref_func('f_hidden')
+		probe.ref_is_null(.funcref_t)
+	}
+	m.commit(probe, true)
+
+	validate(m.compile()) or { panic(err) }
+}


### PR DESCRIPTION
## What & why

The hand-written wasm encoder (`vlib/wasm`) declared the `table_section` (§4) and `element_section` (§9) ids in its `Section` enum but had **no encoder** for either, **no `call_indirect`**, and **no table instructions**. This means the library cannot emit funcref/externref tables or call functions indirectly — the foundation needed for function values, callbacks/events, interface dispatch, and externref reference slots.

This PR adds those primitives. It is **purely additive**: the new sections are emitted only when populated, so existing modules compile byte-identically.

## Changes

**`module.v`**
- `Table` / `Element` / `ElementMode` structs and the `tables` / `elements` module fields.
- `assign_table(name, export, reftype, min, max) TableIndex` — declare a funcref/externref table (pass `max` as `none` for a growable table).
- `new_active_element(tableidx, offset, funcs) ElementIndex` — populate a table at instantiation.
- `new_declarative_element(funcs) ElementIndex` — declare functions so that `ref.func` to a non-exported function validates. Per the spec, `ref.func N` only validates if `N` is declared via an element segment, export, global, or table; today `ref_func` emits the index with no declaration, so it validates only by accident when the target happens to be exported.
- `new_functype` is now `pub` and returns a `TypeIndex`, so callers can intern a signature for `call_indirect`. New `TableIndex` / `TypeIndex` / `ElementIndex` aliases.

**`instructions.v`**
- `call_indirect(typeidx, tableidx)` (`0x11`).
- `table.get` / `table.set` (`0x25` / `0x26`), `table.grow` / `table.size` / `table.fill` (`0xFC 0x0F`/`0x10`/`0x11`).

**`encoding.v`**
- Emit the **table section** (after the function section) and **element section** (after the start section, supporting active table-0, active explicit-tableidx, and declarative funcref segments), and allow **exporting tables**.
- Element-segment function-index resolution goes through a new `get_local_func_idx` helper, also reused by `get_function_idx`.

## Tests

New `vlib/wasm/tests/table_test.v` (same programmatic-build + `wasm-validate` pattern as `call_test.v`):
1. A funcref table populated by an active element segment, dispatched via `call_indirect`.
2. A growable externref table exercised with `table.size`/`grow`/`set`/`get`.
3. A declarative element segment making `ref.func` to a non-exported function validate.

All `vlib/wasm` tests pass, and the unchanged native wasm backend (`vlib/v/gen/wasm`) stays green. The `call_indirect` dispatch and externref `table.grow` were additionally confirmed to **execute** correctly under wasmer (5.0.4 and 7.1.0), and the declarative-segment requirement was confirmed by observing that, without it, `wasm-validate` fails with *"function 0 is not declared in any elem sections"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
