### PR TITLE
ci: pin wasmer to 7.1.0 in the wasm backend workflow

### DIFF
--- a/.github/workflows/wasm_backend_ci.yml
+++ b/.github/workflows/wasm_backend_ci.yml
@@ -76,6 +76,8 @@ jobs:
 
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v3.1
+        with:
+          version: '7.1.0'
 
       - name: Prebuild the WASM backend
         run: ./v cmd/tools/builders/wasm_builder.v


### PR DESCRIPTION
## What & why

The `Setup Wasmer` step in the wasm backend CI used `wasmerio/setup-wasmer@v3.1` without a `version`, so the runtime exercised by `v test vlib/v/gen/wasm/` floated to whatever the action resolved at run time.

This pins it to **wasmer 7.1.0** so the backend is always tested against a known, current runtime that supports the advanced WebAssembly features being developed (reference-types, funcref/externref tables, `call_indirect`, tail calls, …) — minimalist runtimes can lack these.

```yaml
- name: Setup Wasmer
  uses: wasmerio/setup-wasmer@v3.1
  with:
    version: '7.1.0'
```

Single-line CI change; no source or test behavior change (the runtime fallback list in the builder is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)