### PR TITLE
v3: speed up self compilation

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -180,7 +180,7 @@ function pointers.
 | cc        | 79 ms    | 17,312 KB |
 | **total** | **~259 ms** | **17,312 KB** |
 
-All v3 steps (parse + check + transform + annotate types + markused + gen +
+All v3 steps (parse + check + markused + transform + annotate types + gen +
 write) complete in ~8 ms for hello world, including 38 builtin files, and
 ~157 ms for `test.v` with the C backend.
 
@@ -203,14 +203,14 @@ falls back to `cc`.
 
 | Phase          | Time      | Peak RSS |
 |----------------|----------:|---------:|
-| parse          | 47.33 ms  | 73 MB    |
-| check          | 43.92 ms  | 131 MB   |
-| transform      | 94.83 ms  | 274 MB   |
-| annotate types | 30.46 ms  | 307 MB   |
-| markused       | 48.53 ms  | 354 MB   |
-| gen C/write    | 94.67 ms  | 455 MB   |
-| cc             | 707.84 ms | 455 MB   |
-| **total**      | **1,092.92 ms** | **455 MB** |
+| parse          | 59.47 ms  | 73 MB    |
+| check          | 46.57 ms  | 126 MB   |
+| markused       | 39.81 ms  | 150 MB   |
+| transform      | 70.79 ms  | 277 MB   |
+| annotate types | 25.05 ms  | 309 MB   |
+| gen C/write    | 53.75 ms  | 353 MB   |
+| cc             | 746.53 ms | 353 MB   |
+| **total**      | **1,042.14 ms** | **353 MB** |
 
 ## Comparison with V1
 

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -3,6 +3,14 @@ module bench
 import os
 import time
 
+#include <sys/resource.h>
+
+struct C.rusage {
+	ru_maxrss i64
+}
+
+fn C.getrusage(who int, usage &C.rusage) int
+
 pub struct Step {
 pub:
 	name    string
@@ -45,7 +53,7 @@ pub fn (b &Bench) print_report() {
 
 fn current_rss_kb() i64 {
 	$if macos {
-		return macos_rss_kb()
+		return macos_peak_rss_kb()
 	}
 	$if linux {
 		return linux_rss_kb()
@@ -53,10 +61,10 @@ fn current_rss_kb() i64 {
 	return 0
 }
 
-fn macos_rss_kb() i64 {
-	result := os.execute('ps -o rss= -p ${C.getpid()}')
-	if result.exit_code == 0 {
-		return result.output.trim_space().i64()
+fn macos_peak_rss_kb() i64 {
+	mut usage := C.rusage{}
+	if C.getrusage(0, &usage) == 0 {
+		return usage.ru_maxrss / 1024
 	}
 	return 0
 }
@@ -73,5 +81,3 @@ fn linux_rss_kb() i64 {
 	}
 	return 0
 }
-
-fn C.getpid() int

--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -305,10 +305,19 @@ fn (mut g FlatGen) array_method_fallback(method string) string {
 	return best_mname
 }
 
-fn (mut g FlatGen) gen_map_delete(node flat.Node, fn_node &flat.Node, m types.Map) {
+fn (mut g FlatGen) gen_map_ref_arg(base_id flat.NodeId, base_type types.Type) {
+	if base_type is types.Pointer {
+		g.gen_expr(base_id)
+	} else {
+		g.write('&')
+		g.gen_expr(base_id)
+	}
+}
+
+fn (mut g FlatGen) gen_map_delete(node flat.Node, fn_node &flat.Node, m types.Map, base_type types.Type) {
 	c_key := g.tc.c_type(m.key_type)
-	g.write('map__delete(&')
-	g.gen_expr(g.a.child(fn_node, 0))
+	g.write('map__delete(')
+	g.gen_map_ref_arg(g.a.child(fn_node, 0), base_type)
 	g.write(', &(${c_key}[]){')
 	g.gen_expr(g.a.child(&node, 1))
 	g.write('})')

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -581,16 +581,16 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 						}
 						if clean_type is types.Map {
 							if fn_node.value == 'delete' {
-								g.gen_map_delete(node, fn_node, clean_type)
+								g.gen_map_delete(node, fn_node, clean_type, base_type)
 								return
 							} else if fn_node.value == 'clone' {
-								g.write('map__clone(&')
-								g.gen_expr(g.a.child(fn_node, 0))
+								g.write('map__clone(')
+								g.gen_map_ref_arg(g.a.child(fn_node, 0), base_type)
 								g.write(')')
 								return
 							} else if fn_node.value == 'clear' {
-								g.write('map__clear(&')
-								g.gen_expr(g.a.child(fn_node, 0))
+								g.write('map__clear(')
+								g.gen_map_ref_arg(g.a.child(fn_node, 0), base_type)
 								g.write(')')
 								return
 							} else if fn_node.value == 'free' {
@@ -725,16 +725,16 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					}
 					if clean_type is types.Map {
 						if fn_node.value == 'delete' {
-							g.gen_map_delete(node, fn_node, clean_type)
+							g.gen_map_delete(node, fn_node, clean_type, base_type)
 							return
 						} else if fn_node.value == 'clone' {
-							g.write('map__clone(&')
-							g.gen_expr(g.a.child(fn_node, 0))
+							g.write('map__clone(')
+							g.gen_map_ref_arg(g.a.child(fn_node, 0), base_type)
 							g.write(')')
 							return
 						} else if fn_node.value == 'clear' {
-							g.write('map__clear(&')
-							g.gen_expr(g.a.child(fn_node, 0))
+							g.write('map__clear(')
+							g.gen_map_ref_arg(g.a.child(fn_node, 0), base_type)
 							g.write(')')
 							return
 						} else if fn_node.value == 'free' {

--- a/vlib/v3/gen/c/names.v
+++ b/vlib/v3/gen/c/names.v
@@ -1,5 +1,7 @@
 module c
 
+import strings
+
 const c_reserved_words = ['auto', 'break', 'case', 'char', 'const', 'continue', 'copy', 'default',
 	'do', 'double', 'else', 'enum', 'extern', 'float', 'for', 'goto', 'if', 'inline', 'int', 'long',
 	'register', 'restrict', 'return', 'short', 'signed', 'sizeof', 'static', 'struct', 'switch',
@@ -19,13 +21,103 @@ fn c_name(name string) string {
 	if name == 'exit' {
 		return 'v_exit'
 	}
-	n := name.replace('[]', 'Array_').replace('.-', '__minus').replace('.+', '__plus').replace('.==',
-		'__eq').replace('.!=', '__ne').replace('.<=', '__le').replace('.>=', '__ge').replace('.<',
-		'__lt').replace('.>', '__gt').replace('&', 'ptr').replace('[', '_').replace(']', '').replace(',', '_').replace(' ', '_').replace('.', '__')
+	if c_name_is_plain(name) {
+		if name in c_reserved_words {
+			return 'v_${name}'
+		}
+		return name
+	}
+	n := c_name_sanitize(name)
 	if n in c_reserved_words {
 		return 'v_${n}'
 	}
 	return n
+}
+
+fn c_name_sanitize(name string) string {
+	mut b := strings.new_builder(name.len + 8)
+	mut i := 0
+	for i < name.len {
+		c := name[i]
+		if c == `[` {
+			if i + 1 < name.len && name[i + 1] == `]` {
+				b.write_string('Array_')
+				i += 2
+				continue
+			}
+			b.write_u8(`_`)
+		} else if c == `]` {
+			i++
+			continue
+		} else if c == `.` {
+			if i + 1 < name.len {
+				next := name[i + 1]
+				if next == `-` {
+					b.write_string('__minus')
+					i += 2
+					continue
+				}
+				if next == `+` {
+					b.write_string('__plus')
+					i += 2
+					continue
+				}
+				if i + 2 < name.len {
+					op := name[i + 2]
+					if next == `=` && op == `=` {
+						b.write_string('__eq')
+						i += 3
+						continue
+					}
+					if next == `!` && op == `=` {
+						b.write_string('__ne')
+						i += 3
+						continue
+					}
+					if next == `<` && op == `=` {
+						b.write_string('__le')
+						i += 3
+						continue
+					}
+					if next == `>` && op == `=` {
+						b.write_string('__ge')
+						i += 3
+						continue
+					}
+				}
+				if next == `<` {
+					b.write_string('__lt')
+					i += 2
+					continue
+				}
+				if next == `>` {
+					b.write_string('__gt')
+					i += 2
+					continue
+				}
+			}
+			b.write_string('__')
+		} else if c == `&` {
+			b.write_string('ptr')
+		} else if c == `,` || c == ` ` {
+			b.write_u8(`_`)
+		} else {
+			b.write_u8(c)
+		}
+		i++
+	}
+	return b.str()
+}
+
+fn c_name_is_plain(name string) bool {
+	for i in 0 .. name.len {
+		c := name[i]
+		if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_` {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 fn c_escape(s string) string {

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -1,0 +1,8 @@
+module c
+
+fn test_c_name_sanitize_operator_overloads() {
+	assert c_name('Point.<') == 'Point__lt'
+	assert c_name('Point.<=') == 'Point__le'
+	assert c_name('Point.>') == 'Point__gt'
+	assert c_name('Point.>=') == 'Point__ge'
+}

--- a/vlib/v3/markused/custom_str_test.v
+++ b/vlib/v3/markused/custom_str_test.v
@@ -1,0 +1,334 @@
+module markused
+
+import os
+import v3.flat
+import v3.gen.c as cgen
+import v3.parser
+import v3.pref
+import v3.transform
+import v3.types
+
+const custom_str_tests_dir = os.dir(@FILE)
+const custom_str_v3_dir = os.dir(custom_str_tests_dir)
+const custom_str_v3_src = os.join_path(custom_str_v3_dir, 'v3.v')
+const custom_str_vexe = @VEXE
+
+fn parse_checked_two_file_source(name string, main_source string, module_rel string, module_source string) (&flat.FlatAst, &types.TypeChecker) {
+	root := os.join_path(os.temp_dir(), 'v3_markused_${name}_project')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(root) or { panic(err) }
+	main_src := os.join_path(root, 'main.v')
+	module_src := os.join_path(root, module_rel)
+	os.mkdir_all(os.dir(module_src)) or { panic(err) }
+	os.write_file(main_src, main_source) or { panic(err) }
+	os.write_file(module_src, module_source) or { panic(err) }
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_files([main_src, module_src])
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.diagnose_unknown_calls = true
+	tc.diagnostic_files[main_src] = true
+	tc.diagnostic_files[module_src] = true
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	return a, &tc
+}
+
+fn build_v3_bin(name string) string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_markused_${name}')
+	build := os.execute('${custom_str_vexe} -o ${v3_bin} ${custom_str_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn imported_enum_main_source(expr string) string {
+	return '
+module main
+
+import colors
+
+fn main() {
+	c := colors.Color.red
+	${expr}
+}
+'
+}
+
+fn imported_optional_enum_main_source(expr string) string {
+	return '
+module main
+
+import colors
+
+fn maybe_color() ?colors.Color {
+	return colors.Color.red
+}
+
+fn main() {
+	${expr}
+}
+'
+}
+
+fn imported_enum_module_source() string {
+	return '
+module colors
+
+pub enum Color {
+	red
+	blue
+}
+
+pub fn (c Color) str() string {
+	return "red"
+}
+'
+}
+
+fn imported_operator_main_source(expr string) string {
+	return '
+module main
+
+import vectors
+
+fn main() {
+	a := vectors.new_vec(1)
+	b := vectors.new_vec(2)
+	${expr}
+}
+'
+}
+
+fn imported_operator_module_source() string {
+	return '
+module vectors
+
+pub struct Vec {
+	x int
+}
+
+pub fn new_vec(x int) Vec {
+	return Vec{
+		x: x
+	}
+}
+
+pub fn (a Vec) + (b Vec) Vec {
+	return Vec{
+		x: a.x + b.x
+	}
+}
+
+pub fn (a Vec) < (b Vec) bool {
+	return a.x < b.x
+}
+'
+}
+
+fn imported_operator_usage_source() string {
+	return 'sum := a + b
+	gt := b > a
+	if gt {
+		_ := sum
+	}'
+}
+
+fn imported_struct_default_main_source(expr string) string {
+	return '
+module main
+
+import defaults
+
+fn main() {
+	${expr}
+}
+'
+}
+
+fn imported_struct_default_module_source() string {
+	return '
+module defaults
+
+pub struct Box {
+	value int = default_value()
+}
+
+pub fn default_value() int {
+	return 7
+}
+
+pub fn maybe_box() ?Box {
+	return none
+}
+'
+}
+
+fn test_string_interpolation_seeds_imported_enum_str_method() {
+	a, tc := parse_checked_two_file_source('imported_enum_interp_str',
+		imported_enum_main_source('_ := "\${c}"'), 'colors/colors.v', imported_enum_module_source())
+	used := mark_used(a, tc)
+	assert used['colors.Color.str']
+}
+
+fn test_optional_string_interpolation_seeds_imported_enum_str_method() {
+	a, tc := parse_checked_two_file_source('imported_optional_enum_interp_str',
+		imported_optional_enum_main_source('_ := "\${maybe_color()}"'), 'colors/colors.v',
+		imported_enum_module_source())
+	used := mark_used(a, tc)
+	assert used['colors.Color.str']
+}
+
+fn test_imported_operator_infix_seeds_operator_methods() {
+	a, tc := parse_checked_two_file_source('imported_operator_infix',
+		imported_operator_main_source(imported_operator_usage_source()), 'vectors/vectors.v',
+		imported_operator_module_source())
+	used := mark_used(a, tc)
+	assert used['vectors.Vec.+']
+	assert used['vectors.Vec.<']
+}
+
+fn test_optional_struct_zero_seeds_imported_default_helper() {
+	a, tc := parse_checked_two_file_source('imported_struct_default_or',
+		imported_struct_default_main_source('box := defaults.maybe_box() or { return }\n\t_ := box'),
+		'defaults/defaults.v', imported_struct_default_module_source())
+	used := mark_used(a, tc)
+	assert used['defaults.default_value']
+}
+
+fn test_string_interpolation_lowers_to_imported_enum_str_after_used_filter_transform() {
+	mut a, mut tc := parse_checked_two_file_source('imported_enum_interp_str_cgen',
+		imported_enum_main_source('_ := "\${c}"'), 'colors/colors.v', imported_enum_module_source())
+	used := mark_used(a, tc)
+	assert used['colors.Color.str']
+	transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('colors__Color__str(')
+}
+
+fn test_imported_operator_infix_lowers_after_used_filter_transform() {
+	mut a, mut tc := parse_checked_two_file_source('imported_operator_infix_cgen',
+		imported_operator_main_source(imported_operator_usage_source()), 'vectors/vectors.v',
+		imported_operator_module_source())
+	used := mark_used(a, tc)
+	assert used['vectors.Vec.+']
+	assert used['vectors.Vec.<']
+	transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('vectors__Vec__plus(')
+	assert c_code.contains('vectors__Vec__lt(')
+}
+
+fn test_optional_struct_zero_lowers_to_imported_default_after_used_filter_transform() {
+	mut a, mut tc := parse_checked_two_file_source('imported_struct_default_or_cgen',
+		imported_struct_default_main_source('box := defaults.maybe_box() or { return }\n\t_ := box'),
+		'defaults/defaults.v', imported_struct_default_module_source())
+	used := mark_used(a, tc)
+	assert used['defaults.default_value']
+	transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('defaults__default_value(')
+}
+
+fn test_optional_string_interpolation_lowers_to_imported_enum_str_after_used_filter_transform() {
+	mut a, mut tc := parse_checked_two_file_source('imported_optional_enum_interp_str_cgen',
+		imported_optional_enum_main_source('_ := "\${maybe_color()}"'), 'colors/colors.v',
+		imported_enum_module_source())
+	used := mark_used(a, tc)
+	assert used['colors.Color.str']
+	transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('colors__Color__str(')
+}
+
+fn test_imported_enum_print_compile_keeps_str_method() {
+	v3_bin := build_v3_bin('imported_enum_print_str_test')
+
+	root := os.join_path(os.temp_dir(), 'v3_markused_imported_enum_print_input')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(os.join_path(root, 'colors')) or { panic(err) }
+	os.write_file(os.join_path(root, 'main.v'), imported_enum_main_source('println(c)')) or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'colors/colors.v'), imported_enum_module_source()) or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_markused_imported_enum_print_input_bin')
+	compile := os.execute('${v3_bin} -o ${bin} ${root}')
+	assert compile.exit_code == 0, compile.output
+}
+
+fn test_imported_operator_compile_keeps_operator_methods() {
+	v3_bin := build_v3_bin('imported_operator_test')
+
+	root := os.join_path(os.temp_dir(), 'v3_markused_imported_operator_input')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(os.join_path(root, 'vectors')) or { panic(err) }
+	os.write_file(os.join_path(root, 'main.v'),
+		imported_operator_main_source(imported_operator_usage_source())) or { panic(err) }
+	os.write_file(os.join_path(root, 'vectors/vectors.v'), imported_operator_module_source()) or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_markused_imported_operator_input_bin')
+	compile := os.execute('${v3_bin} -o ${bin} ${root}')
+	assert compile.exit_code == 0, compile.output
+}
+
+fn test_optional_struct_zero_compile_keeps_imported_default_helper() {
+	v3_bin := build_v3_bin('imported_struct_default_or_test')
+
+	root := os.join_path(os.temp_dir(), 'v3_markused_imported_struct_default_or_input')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(os.join_path(root, 'defaults')) or { panic(err) }
+	os.write_file(os.join_path(root, 'main.v'),
+		imported_struct_default_main_source('box := defaults.maybe_box() or { return }\n\t_ := box')) or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'defaults/defaults.v'),
+		imported_struct_default_module_source()) or { panic(err) }
+	bin := os.join_path(os.temp_dir(), 'v3_markused_imported_struct_default_or_input_bin')
+	compile := os.execute('${v3_bin} -o ${bin} ${root}')
+	assert compile.exit_code == 0, compile.output
+}
+
+fn test_imported_optional_enum_interpolation_compile_keeps_str_method() {
+	v3_bin := build_v3_bin('imported_optional_enum_interp_str_test')
+
+	root := os.join_path(os.temp_dir(), 'v3_markused_imported_optional_enum_interp_input')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(os.join_path(root, 'colors')) or { panic(err) }
+	os.write_file(os.join_path(root, 'main.v'),
+		imported_optional_enum_main_source('_ := "\${maybe_color()}"')) or { panic(err) }
+	os.write_file(os.join_path(root, 'colors/colors.v'), imported_enum_module_source()) or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_markused_imported_optional_enum_interp_input_bin')
+	compile := os.execute('${v3_bin} -o ${bin} ${root}')
+	assert compile.exit_code == 0, compile.output
+}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -128,10 +128,11 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 		'string.==', 'string.<', 'string.free', 'string.all_before', 'string.all_before_last',
 		'string.all_after', 'string.all_after_last', 'u8.vstring', '[]rune.string', 'map.set',
 		'map.exists', 'map.get', 'map.get_check', 'map.get_and_set', 'map.delete', 'map.clone',
-		'map.clear', 'strings.Builder.write_ptr', 'strings.Builder.write_runes',
-		'strings.Builder.free', 'strconv.format_int', 'strconv.format_uint', 'sync.new_channel_st',
-		'sync.Channel.push', 'sync.Channel.pop', 'sync.Channel.close', 'new_channel_st',
-		'Channel.push', 'Channel.pop', 'Channel.close'] {
+		'map.clear', 'memdup', 'strings.Builder.write_ptr', 'strings.Builder.write_runes',
+		'strings.Builder.free', 'strconv.format_int', 'strconv.format_uint', 'bool.str', 'ptr_str',
+		'strconv__f32_to_str_l', 'strconv__f64_to_str_l', 'sync.new_channel_st', 'sync.Channel.push',
+		'sync.Channel.pop', 'sync.Channel.close', 'new_channel_st', 'Channel.push', 'Channel.pop',
+		'Channel.close'] {
 		queue << seed
 		used[seed] = true
 	}
@@ -174,20 +175,8 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 	// concrete methods are only referenced from the generated dispatch switch, so
 	// without this they would be pruned and produce undefined-symbol errors.
 	mut iface_impls := map[string][]string{}
-	for iface_name, _ in tc.interface_names {
-		mut impls := []string{}
-		for struct_name, _ in tc.structs {
-			if tc.named_type_implements_interface(struct_name, iface_name) {
-				impls << struct_name
-			}
-		}
-		iface_impls[iface_name] = impls
-		short := iface_name.all_after_last('.')
-		if short != iface_name && short !in iface_impls {
-			iface_impls[short] = impls
-		}
-	}
-	mut processed_nodes := map[int]bool{}
+	mut checked_iface_impls := map[string]bool{}
+	mut processed_nodes := []bool{len: a.nodes.len}
 	mut calls := []string{cap: 128}
 	mut qi := 0
 	for qi < queue.len {
@@ -206,7 +195,10 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 		}
 		in_cg++
 		node_key := int(fn_info.node_id)
-		if node_key in processed_nodes {
+		if node_key < 0 || node_key >= processed_nodes.len {
+			continue
+		}
+		if processed_nodes[node_key] {
 			continue
 		}
 		processed_nodes[node_key] = true
@@ -255,6 +247,7 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 			if callee.contains('.') {
 				recv := callee.all_before_last('.')
 				method := callee.all_after_last('.')
+				ensure_iface_impls(recv, tc, mut iface_impls, mut checked_iface_impls)
 				if impls := iface_impls[recv] {
 					for impl in impls {
 						impl_method := '${impl}.${method}'
@@ -286,6 +279,38 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 		eprintln('markused: total used: ${used.len}')
 	}
 	return used
+}
+
+fn ensure_iface_impls(recv string, tc &types.TypeChecker, mut iface_impls map[string][]string, mut checked map[string]bool) {
+	if recv.len == 0 || recv in checked {
+		return
+	}
+	checked[recv] = true
+	mut iface_name := ''
+	if recv in tc.interface_names {
+		iface_name = recv
+	} else {
+		for name, _ in tc.interface_names {
+			if name.all_after_last('.') == recv {
+				iface_name = name
+				break
+			}
+		}
+	}
+	if iface_name.len == 0 {
+		return
+	}
+	mut impls := []string{}
+	for struct_name, _ in tc.structs {
+		if tc.named_type_implements_interface(struct_name, iface_name) {
+			impls << struct_name
+		}
+	}
+	iface_impls[recv] = impls
+	if iface_name != recv {
+		iface_impls[iface_name] = impls
+		checked[iface_name] = true
+	}
 }
 
 fn add_suffix_candidate(mut suffix_map map[string][]string, short string, name string) {
@@ -405,8 +430,15 @@ fn is_auto_root_fn(name string) bool {
 fn enqueue_detected_runtime_helpers(a &flat.FlatAst, tc &types.TypeChecker, mut used map[string]bool, mut queue []string) {
 	mut needs_optional_helpers := false
 	mut needs_string_interp_helpers := false
+	mut needs_string_plus_helper := false
+	mut needs_string_membership_helpers := false
+	mut needs_new_map := false
+	mut cur_module := ''
 	for node in a.nodes {
 		match node.kind {
+			.module_decl {
+				cur_module = node.value
+			}
 			.fn_decl {
 				ret_type := tc.parse_type(node.typ)
 				if ret_type is types.OptionType || ret_type is types.ResultType {
@@ -418,8 +450,18 @@ fn enqueue_detected_runtime_helpers(a &flat.FlatAst, tc &types.TypeChecker, mut 
 					needs_optional_helpers = true
 				}
 			}
-			.none_expr, .or_expr {
+			.none_expr {
 				needs_optional_helpers = true
+			}
+			.or_expr {
+				needs_optional_helpers = true
+				if node.children_count > 0 {
+					expr_id := a.child(&node, 0)
+					expr_type := tc.expr_type(expr_id) or { tc.resolve_type(expr_id) }
+					if type_needs_zero_map(expr_type) {
+						needs_new_map = true
+					}
+				}
 			}
 			.call {
 				if node.children_count > 0 {
@@ -428,10 +470,46 @@ fn enqueue_detected_runtime_helpers(a &flat.FlatAst, tc &types.TypeChecker, mut 
 						&& (fn_node.value == 'error' || fn_node.value == 'error_with_code') {
 						needs_optional_helpers = true
 					}
+					if fn_node.kind == .ident
+						&& fn_node.value in ['print', 'println', 'eprint', 'eprintln']
+						&& node.children_count >= 2 {
+						enqueue_stringified_custom_str_method(a.child(&node, 1), cur_module, tc, mut
+							used, mut queue)
+					}
 				}
 			}
 			.string_interp {
 				needs_string_interp_helpers = true
+				needs_string_plus_helper = true
+				for i in 0 .. node.children_count {
+					enqueue_stringified_custom_str_method(a.child(&node, i), cur_module, tc, mut
+						used, mut queue)
+				}
+			}
+			.assign {
+				if node.op == .plus_assign && node.children_count == 2 {
+					lhs_id := a.child(&node, 0)
+					rhs_id := a.child(&node, 1)
+					rhs := a.node(rhs_id)
+					lhs_type := markused_membership_container_type(tc, tc.resolve_type(lhs_id))
+					rhs_type := markused_membership_container_type(tc, tc.resolve_type(rhs_id))
+					if lhs_type == 'string' || rhs_type == 'string'
+						|| rhs.kind in [.string_literal, .string_interp] {
+						needs_string_plus_helper = true
+					}
+				}
+			}
+			.in_expr {
+				if node.children_count >= 2 {
+					rhs_id := a.child(&node, 1)
+					rhs_type := markused_membership_container_type(tc, tc.resolve_type(rhs_id))
+					if rhs_type == 'string' {
+						needs_string_membership_helpers = true
+					}
+				}
+			}
+			.map_init {
+				needs_new_map = true
 			}
 			else {}
 		}
@@ -447,6 +525,87 @@ fn enqueue_detected_runtime_helpers(a &flat.FlatAst, tc &types.TypeChecker, mut 
 			enqueue(helper, mut used, mut queue)
 		}
 	}
+	if needs_string_plus_helper {
+		enqueue('string__plus', mut used, mut queue)
+	}
+	if needs_string_membership_helpers {
+		for helper in ['string__contains', 'string__contains_u8'] {
+			enqueue(helper, mut used, mut queue)
+		}
+	}
+	if needs_new_map {
+		enqueue('new_map', mut used, mut queue)
+	}
+}
+
+fn enqueue_stringified_custom_str_method(expr_id flat.NodeId, cur_module string, tc &types.TypeChecker, mut used map[string]bool, mut queue []string) {
+	mut typ := tc.expr_type(expr_id) or { tc.resolve_type(expr_id) }
+	for _ in 0 .. 8 {
+		if typ is types.Alias {
+			typ = typ.base_type
+			continue
+		}
+		if typ is types.OptionType {
+			typ = typ.base_type
+			continue
+		}
+		if typ is types.ResultType {
+			typ = typ.base_type
+			continue
+		}
+		break
+	}
+	match typ {
+		types.Enum {
+			enqueue_enum_str_method(typ.name, cur_module, tc, mut used, mut queue)
+		}
+		types.Struct {
+			enqueue_structlike_str_method(typ.name, cur_module, tc, mut used, mut queue)
+		}
+		types.SumType {
+			enqueue_structlike_str_method(typ.name, cur_module, tc, mut used, mut queue)
+		}
+		else {}
+	}
+}
+
+fn enqueue_enum_str_method(type_name string, cur_module string, tc &types.TypeChecker, mut used map[string]bool, mut queue []string) {
+	for candidate in stringification_type_candidates(type_name, cur_module) {
+		method := '${candidate}.str'
+		if method in tc.fn_ret_types {
+			enqueue(method, mut used, mut queue)
+			lowered := markused_c_name(method)
+			if lowered != method {
+				enqueue(lowered, mut used, mut queue)
+			}
+		}
+	}
+}
+
+fn enqueue_structlike_str_method(type_name string, cur_module string, tc &types.TypeChecker, mut used map[string]bool, mut queue []string) {
+	for candidate in stringification_type_candidates(type_name, cur_module) {
+		lowered := '${markused_c_name(candidate)}__str'
+		if lowered in tc.fn_ret_types {
+			enqueue(lowered, mut used, mut queue)
+		}
+		method := '${candidate}.str'
+		if method in tc.fn_ret_types {
+			enqueue(method, mut used, mut queue)
+		}
+	}
+}
+
+fn stringification_type_candidates(type_name string, cur_module string) []string {
+	if type_name.len == 0 {
+		return []string{}
+	}
+	mut candidates := []string{cap: 2}
+	candidates << type_name
+	if !type_name.contains('.') && cur_module.len > 0 && cur_module != 'main'
+		&& cur_module != 'builtin' {
+		candidates << '${cur_module}.${type_name}'
+	}
+	return candidates
 }
 
 fn enqueue_function_value_selectors(a &flat.FlatAst, fn_decls map[string]FnDeclInfo, mut used map[string]bool, mut queue []string) {
@@ -470,6 +629,50 @@ fn enqueue_function_value_selectors(a &flat.FlatAst, fn_decls map[string]FnDeclI
 
 fn type_string_needs_optional_helpers(typ string) bool {
 	return typ.len > 0 && (typ[0] == `?` || typ[0] == `!`)
+}
+
+fn type_needs_zero_map(typ types.Type) bool {
+	mut clean := typ
+	for _ in 0 .. 8 {
+		if clean is types.Alias {
+			clean = clean.base_type
+			continue
+		}
+		if clean is types.OptionType {
+			clean = clean.base_type
+			continue
+		}
+		if clean is types.ResultType {
+			clean = clean.base_type
+			continue
+		}
+		break
+	}
+	return clean is types.Map
+}
+
+fn markused_membership_container_type(tc &types.TypeChecker, typ types.Type) string {
+	mut clean := typ.name().trim_space()
+	for {
+		if clean.starts_with('shared ') {
+			clean = clean[7..].trim_space()
+			continue
+		}
+		if clean.starts_with('&') {
+			clean = clean[1..].trim_space()
+			continue
+		}
+		if clean in tc.type_aliases {
+			alias := tc.type_aliases[clean].trim_space()
+			if alias == clean {
+				break
+			}
+			clean = alias
+			continue
+		}
+		break
+	}
+	return clean
 }
 
 fn qualify_fn(mod string, name string) string {
@@ -641,30 +844,19 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 						}
 					}
 					if int(lhs_id) >= 0 {
-						lhs_type := c.node_type(lhs_id)
-						lhs_name := resolve_type_name(lhs_type)
-						if lhs_name.len > 0 {
-							op_name := match child.op {
-								.minus { '-' }
-								.plus { '+' }
-								.eq { '==' }
-								.ne { '!=' }
-								.lt { '<' }
-								.gt { '>' }
-								.le { '<=' }
-								.ge { '>=' }
-								else { '' }
-							}
-
-							if op_name.len > 0 {
-								calls << lhs_name + '.' + op_name
-							}
-						}
+						c.collect_struct_operator_call(lhs_id, child.op, cur_module, mut calls)
 					}
 				}
 			}
+			.or_expr {
+				if child.children_count > 0 {
+					expr_id := c.a.child(child, 0)
+					c.collect_zero_struct_default_calls(c.node_type(expr_id), cur_module, imports, mut
+						calls)
+				}
+			}
 			.struct_init {
-				c.collect_struct_default_calls(child, imports, mut calls)
+				c.collect_struct_default_calls(child, cur_module, imports, mut calls)
 			}
 			else {}
 		}
@@ -679,6 +871,119 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 				j--
 			}
 		}
+	}
+}
+
+fn (c &CallCollector) collect_struct_operator_call(lhs_id flat.NodeId, op flat.Op, cur_module string, mut calls []string) {
+	lhs_type := c.node_type(lhs_id)
+	lhs_name := resolve_type_name(lhs_type)
+	struct_type := c.struct_lookup_name(lhs_name, cur_module)
+	if struct_type.len == 0 {
+		return
+	}
+	method_name := c.struct_operator_call_name(struct_type, op) or { return }
+	c.add_operator_call_name(method_name, mut calls)
+}
+
+fn (c &CallCollector) struct_operator_call_name(struct_type string, op flat.Op) ?string {
+	if op_name := markused_struct_operator_symbol(op) {
+		if method_name := c.struct_operator_fn_name(struct_type, op_name) {
+			return method_name
+		}
+	}
+	match op {
+		.gt, .ge, .le {
+			if method_name := c.struct_operator_fn_name(struct_type, '<') {
+				return method_name
+			}
+		}
+		.ne {
+			if method_name := c.struct_operator_fn_name(struct_type, '==') {
+				return method_name
+			}
+		}
+		else {}
+	}
+
+	return none
+}
+
+fn markused_struct_operator_symbol(op flat.Op) ?string {
+	match op {
+		.plus { return '+' }
+		.minus { return '-' }
+		.mul { return '*' }
+		.div { return '/' }
+		.mod { return '%' }
+		.eq { return '==' }
+		.ne { return '!=' }
+		.lt { return '<' }
+		.gt { return '>' }
+		.le { return '<=' }
+		.ge { return '>=' }
+		else {}
+	}
+
+	return none
+}
+
+fn (c &CallCollector) struct_operator_fn_name(struct_type string, op_name string) ?string {
+	method_name := '${struct_type}.${op_name}'
+	if c.is_known_fn_name(method_name) {
+		return method_name
+	}
+	cmethod_name := markused_c_name(method_name)
+	if c.is_known_fn_name(cmethod_name) {
+		return cmethod_name
+	}
+	return none
+}
+
+fn (c &CallCollector) is_known_fn_name(name string) bool {
+	return name in c.fn_decls || name in c.tc.fn_ret_types || name in c.tc.fn_param_types
+}
+
+fn (c &CallCollector) struct_lookup_name(type_name string, cur_module string) string {
+	if type_name.len == 0 {
+		return ''
+	}
+	if type_name.contains('.') {
+		if type_name in c.struct_decls {
+			return type_name
+		}
+		short_type := type_name.all_after_last('.')
+		type_mod := type_name.all_before_last('.')
+		if info := c.struct_decls[short_type] {
+			if info.module == type_mod {
+				return short_type
+			}
+		}
+		if info := c.struct_decls[type_name] {
+			if info.module == type_mod {
+				return type_name
+			}
+		}
+		return ''
+	}
+	if info := c.struct_decls[type_name] {
+		if info.module.len == 0 || info.module == cur_module {
+			return type_name
+		}
+	}
+	if cur_module.len > 0 && cur_module != 'main' && cur_module != 'builtin' {
+		qtype := '${cur_module}.${type_name}'
+		if qtype in c.struct_decls {
+			return qtype
+		}
+	}
+	return ''
+}
+
+fn (c &CallCollector) add_operator_call_name(method_name string, mut calls []string) {
+	calls << method_name
+	lowered := markused_c_name(method_name)
+	if lowered != method_name {
+		calls << lowered
 	}
 }
 
@@ -711,7 +1016,8 @@ fn (c &CallCollector) collect_fn_value_ident(id flat.NodeId, name string, cur_mo
 	if name.len == 0 || !c.name_may_reference_fn(name, cur_module, imports) {
 		return
 	}
-	if !c.node_is_fn_value(id) && !c.name_has_fn_decl(name, cur_module, imports) {
+	has_fn_decl := c.name_has_fn_decl(name, cur_module, imports)
+	if !has_fn_decl && !c.node_is_fn_value(id) {
 		return
 	}
 	c.add_fn_value_candidates(name, cur_module, imports, mut calls)
@@ -730,7 +1036,8 @@ fn (c &CallCollector) collect_fn_value_selector(id flat.NodeId, node &flat.Node,
 	if !c.name_may_reference_fn(name, cur_module, imports) {
 		return
 	}
-	if !c.node_is_fn_value(id) && !c.name_has_fn_decl(name, cur_module, imports) {
+	has_fn_decl := c.name_has_fn_decl(name, cur_module, imports)
+	if !has_fn_decl && !c.node_is_fn_value(id) {
 		return
 	}
 	c.add_fn_value_candidates(name, cur_module, imports, mut calls)
@@ -744,21 +1051,39 @@ fn (c &CallCollector) collect_fn_value_selector(id flat.NodeId, node &flat.Node,
 }
 
 fn (c &CallCollector) name_may_reference_fn(name string, cur_module string, imports map[string]string) bool {
-	for candidate in c.const_ref_candidates(name, cur_module, imports) {
-		if candidate in c.fn_decls || candidate in c.const_decls {
-			return true
+	return c.name_has_candidate_decl(name, cur_module, imports, true)
+}
+
+fn (c &CallCollector) name_has_fn_decl(name string, cur_module string, imports map[string]string) bool {
+	return c.name_has_candidate_decl(name, cur_module, imports, false)
+}
+
+fn (c &CallCollector) name_has_candidate_decl(name string, cur_module string, imports map[string]string, include_consts bool) bool {
+	if c.candidate_matches_decl(name, include_consts) {
+		return true
+	}
+	qname := qualify_fn(cur_module, name)
+	if qname != name && c.candidate_matches_decl(qname, include_consts) {
+		return true
+	}
+	if name.contains('.') {
+		base := name.all_before_last('.')
+		member := name.all_after_last('.')
+		if base in imports {
+			imported_name := imports[base] + '.' + member
+			if c.candidate_matches_decl(imported_name, include_consts) {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-fn (c &CallCollector) name_has_fn_decl(name string, cur_module string, imports map[string]string) bool {
-	for candidate in c.const_ref_candidates(name, cur_module, imports) {
-		if candidate in c.fn_decls {
-			return true
-		}
+fn (c &CallCollector) candidate_matches_decl(candidate string, include_consts bool) bool {
+	if candidate in c.fn_decls {
+		return true
 	}
-	return false
+	return include_consts && candidate in c.const_decls
 }
 
 fn (c &CallCollector) node_is_fn_value(id flat.NodeId) bool {
@@ -785,46 +1110,42 @@ fn (c &CallCollector) add_fn_value_candidates(name string, cur_module string, im
 }
 
 fn (c &CallCollector) add_const_alias_candidates(name string, cur_module string, imports map[string]string, mut calls []string) {
-	for const_name in c.const_ref_candidates(name, cur_module, imports) {
-		info := c.const_decls[const_name] or { continue }
-		expr := c.a.node(info.expr_id)
-		match expr.kind {
-			.ident {
-				c.add_fn_value_candidates(expr.value, info.module, imports, mut calls)
-			}
-			.selector {
-				if expr.children_count > 0 {
-					base := c.a.child_node(expr, 0)
-					if base.kind == .ident && base.value.len > 0 && expr.value.len > 0 {
-						c.add_fn_value_candidates('${base.value}.${expr.value}', info.module,
-							imports, mut calls)
-						if base.value in imports {
-							c.add_fn_value_candidates('${imports[base.value]}.${expr.value}',
-								info.module, imports, mut calls)
-						}
-					}
-				}
-			}
-			else {}
-		}
-	}
-}
-
-fn (c &CallCollector) const_ref_candidates(name string, cur_module string, imports map[string]string) []string {
-	mut candidates := []string{}
-	candidates << name
+	c.add_const_alias_candidate(name, imports, mut calls)
 	qname := qualify_fn(cur_module, name)
 	if qname != name {
-		candidates << qname
+		c.add_const_alias_candidate(qname, imports, mut calls)
 	}
 	if name.contains('.') {
 		base := name.all_before_last('.')
 		member := name.all_after_last('.')
 		if base in imports {
-			candidates << imports[base] + '.' + member
+			c.add_const_alias_candidate(imports[base] + '.' + member, imports, mut calls)
 		}
 	}
-	return candidates
+}
+
+fn (c &CallCollector) add_const_alias_candidate(const_name string, imports map[string]string, mut calls []string) {
+	info := c.const_decls[const_name] or { return }
+	expr := c.a.node(info.expr_id)
+	match expr.kind {
+		.ident {
+			c.add_fn_value_candidates(expr.value, info.module, imports, mut calls)
+		}
+		.selector {
+			if expr.children_count > 0 {
+				base := c.a.child_node(expr, 0)
+				if base.kind == .ident && base.value.len > 0 && expr.value.len > 0 {
+					c.add_fn_value_candidates('${base.value}.${expr.value}', info.module, imports, mut
+						calls)
+					if base.value in imports {
+						c.add_fn_value_candidates('${imports[base.value]}.${expr.value}',
+							info.module, imports, mut calls)
+					}
+				}
+			}
+		}
+		else {}
+	}
 }
 
 fn (c &CallCollector) node_type(id flat.NodeId) types.Type {
@@ -834,8 +1155,39 @@ fn (c &CallCollector) node_type(id flat.NodeId) types.Type {
 	return c.tc.resolve_type(id)
 }
 
-fn (c &CallCollector) collect_struct_default_calls(init &flat.Node, imports map[string]string, mut calls []string) {
-	info := c.struct_decls[init.value] or { return }
+fn (c &CallCollector) collect_zero_struct_default_calls(typ types.Type, cur_module string, imports map[string]string, mut calls []string) {
+	type_name := zero_value_struct_type_name(typ)
+	if type_name.len == 0 {
+		return
+	}
+	c.collect_struct_default_calls_for_type(type_name, cur_module, imports, mut calls)
+}
+
+fn zero_value_struct_type_name(typ types.Type) string {
+	mut clean := typ
+	for _ in 0 .. 8 {
+		if clean is types.Alias {
+			clean = clean.base_type
+			continue
+		}
+		if clean is types.OptionType {
+			clean = clean.base_type
+			continue
+		}
+		if clean is types.ResultType {
+			clean = clean.base_type
+			continue
+		}
+		break
+	}
+	if clean is types.Struct {
+		return clean.name
+	}
+	return ''
+}
+
+fn (c &CallCollector) collect_struct_default_calls(init &flat.Node, cur_module string, imports map[string]string, mut calls []string) {
+	info := c.struct_decl_info(init.value, cur_module) or { return }
 	mut set_fields := map[string]bool{}
 	for i in 0 .. init.children_count {
 		field := c.a.child_node(init, i)
@@ -843,10 +1195,27 @@ fn (c &CallCollector) collect_struct_default_calls(init &flat.Node, imports map[
 			set_fields[field.value] = true
 		}
 	}
+	c.collect_struct_default_calls_from_info(info, set_fields, imports, mut calls)
+}
+
+fn (c &CallCollector) collect_struct_default_calls_for_type(type_name string, cur_module string, imports map[string]string, mut calls []string) {
+	info := c.struct_decl_info(type_name, cur_module) or { return }
+	c.collect_struct_default_calls_from_info(info, map[string]bool{}, imports, mut calls)
+}
+
+fn (c &CallCollector) struct_decl_info(type_name string, cur_module string) ?StructDeclInfo {
+	struct_name := c.struct_lookup_name(type_name, cur_module)
+	if struct_name.len == 0 {
+		return none
+	}
+	return c.struct_decls[struct_name] or { none }
+}
+
+fn (c &CallCollector) collect_struct_default_calls_from_info(info StructDeclInfo, provided map[string]bool, imports map[string]string, mut calls []string) {
 	node := c.a.node(info.node_id)
 	for i in 0 .. node.children_count {
 		field := c.a.child_node(node, i)
-		if field.kind != .field_decl || field.children_count == 0 || field.value in set_fields {
+		if field.kind != .field_decl || field.children_count == 0 || field.value in provided {
 			continue
 		}
 		c.collect_calls(field, info.module, imports, '', '', mut calls)
@@ -922,8 +1291,22 @@ fn markused_c_name(name string) string {
 	if name == 'malloc' {
 		return 'v_malloc'
 	}
+	if markused_c_name_is_plain(name) {
+		return name
+	}
 	return name.replace('[]', 'Array_').replace('.-', '__minus').replace('.+', '__plus').replace('.==',
 		'__eq').replace('.!=', '__ne').replace('.<=', '__le').replace('.>=', '__ge').replace('.<',
 		'__lt').replace('.>', '__gt').replace('&', 'ptr').replace('[', '_').replace(']', '').replace(',',
 		'_').replace(' ', '_').replace('.', '__')
+}
+
+fn markused_c_name_is_plain(name string) bool {
+	for i in 0 .. name.len {
+		c := name[i]
+		if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_` {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/vlib/v3/ssa/builder.v
+++ b/vlib/v3/ssa/builder.v
@@ -37,6 +37,9 @@ const arm64_force_external_syms = ['_malloc', '_free', '_calloc', '_realloc', '_
 	'_objc_alloc_init', '_objc_autoreleasePoolPush', '_objc_autoreleasePoolPop',
 	'_MTLCreateSystemDefaultDevice', '_dlopen', '_dlsym']
 
+const bench_runtime_stub_names = ['current_rss_kb', 'macos_peak_rss_kb', 'linux_rss_kb',
+	'bench.current_rss_kb', 'bench.macos_peak_rss_kb', 'bench.linux_rss_kb']
+
 pub struct Builder {
 mut:
 	m                  &Module            = unsafe { nil }
@@ -1087,6 +1090,9 @@ fn (b &Builder) has_fn_decl(name string) bool {
 }
 
 fn (b &Builder) skip_source_fn(name string) bool {
+	if name in bench_runtime_stub_names {
+		return true
+	}
 	if name in ['_wymix', 'wyhash', 'wyhash64', 'string__eq', 'string__lt', 'array_new', 'array_get',
 		'string__plus', 'string_plus_many', 'string.trim_right', 'array_push', 'array_push_many',
 		'array.push_many', 'array_clone', 'panic', 'fast_string_eq', 'strings.new_builder',
@@ -1101,14 +1107,13 @@ fn (b &Builder) skip_source_fn(name string) bool {
 		'array.repeat_to_depth', 'string.all_before_last', 'string__all_before_last',
 		'all_before_last', 'string.all_after_last', 'string__all_after_last', 'all_after_last',
 		'_ht_alloc', '_ht_free', 'f32_to_str_l', 'f32_to_str_l_with_dot', 'f64_to_str_l',
-		'f64_to_str_l_with_dot', 'print', 'println', 'eprint', 'eprintln', 'current_rss_kb',
-		'macos_rss_kb', 'linux_rss_kb', 'arguments', 'tos2', 'tos3', 'tos_clone',
-		'v_prealloc_atomic_add_i32', 'v_prealloc_atomic_load_i32', 'v_prealloc_atomic_store_i32',
-		'v_prealloc_atomic_cas_i32', 'FD_ZERO', 'FD_SET', 'FD_ISSET', 'v_signal_with_handler_cast',
-		'normalize_path_in_builder', 'check_fwrite', 'check_fread', 'os.check_fwrite',
-		'os.check_fread', 'fxx_to_str_l_parse', 'fxx_to_str_l_parse_with_dot', 'u8.vstring',
-		'u8.vstring_with_len', 'char.vstring', 'char.vstring_with_len', 'byteptr.vstring',
-		'byteptr.vstring_with_len', 'charptr.vstring', 'charptr.vstring_with_len',
+		'f64_to_str_l_with_dot', 'print', 'println', 'eprint', 'eprintln', 'arguments', 'tos2',
+		'tos3', 'tos_clone', 'v_prealloc_atomic_add_i32', 'v_prealloc_atomic_load_i32',
+		'v_prealloc_atomic_store_i32', 'v_prealloc_atomic_cas_i32', 'FD_ZERO', 'FD_SET', 'FD_ISSET',
+		'v_signal_with_handler_cast', 'normalize_path_in_builder', 'check_fwrite', 'check_fread',
+		'os.check_fwrite', 'os.check_fread', 'fxx_to_str_l_parse', 'fxx_to_str_l_parse_with_dot',
+		'u8.vstring', 'u8.vstring_with_len', 'char.vstring', 'char.vstring_with_len',
+		'byteptr.vstring', 'byteptr.vstring_with_len', 'charptr.vstring', 'charptr.vstring_with_len',
 		'u8.vstring_literal', 'u8.vstring_literal_with_len', 'char.vstring_literal',
 		'char.vstring_literal_with_len', 'byteptr.vstring_literal',
 		'byteptr.vstring_literal_with_len', 'charptr.vstring_literal',
@@ -1582,8 +1587,7 @@ fn (mut b Builder) generate_string_int_body(func_id int) {
 }
 
 fn (mut b Builder) register_bench_runtime_stubs() {
-	for name in ['current_rss_kb', 'macos_rss_kb', 'linux_rss_kb', 'bench.current_rss_kb',
-		'bench.macos_rss_kb', 'bench.linux_rss_kb'] {
+	for name in bench_runtime_stub_names {
 		id := b.register_synthetic_function(name, b.i64_type, []TypeID{})
 		b.generate_const_i64_body(id, '0')
 	}

--- a/vlib/v3/ssa/builder_test.v
+++ b/vlib/v3/ssa/builder_test.v
@@ -1,0 +1,11 @@
+module ssa
+
+fn test_bench_runtime_stubs_include_macos_peak_rss_helper() {
+	assert 'macos_peak_rss_kb' in bench_runtime_stub_names
+	assert 'bench.macos_peak_rss_kb' in bench_runtime_stub_names
+	assert 'macos_rss_kb' !in bench_runtime_stub_names
+	assert 'bench.macos_rss_kb' !in bench_runtime_stub_names
+	b := Builder{}
+	assert b.skip_source_fn('macos_peak_rss_kb')
+	assert b.skip_source_fn('bench.macos_peak_rss_kb')
+}

--- a/vlib/v3/tests/checker_print_test.v
+++ b/vlib/v3/tests/checker_print_test.v
@@ -1,0 +1,103 @@
+import os
+import v3.parser
+import v3.pref
+import v3.types
+
+const checker_print_tests_dir = os.dir(@FILE)
+const checker_print_v3_dir = os.dir(checker_print_tests_dir)
+const checker_print_v3_src = os.join_path(checker_print_v3_dir, 'v3.v')
+const checker_print_vexe = @VEXE
+
+fn check_print_sources(name string, files map[string]string) []types.TypeError {
+	root := os.join_path(os.temp_dir(), 'v3_checker_print_${name}')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(root) or { panic(err) }
+	mut paths := []string{}
+	for rel, src in files {
+		path := os.join_path(root, rel)
+		os.mkdir_all(os.dir(path)) or { panic(err) }
+		os.write_file(path, src) or { panic(err) }
+		paths << path
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_files(paths)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	for path in paths {
+		tc.diagnostic_files[path] = true
+	}
+	tc.diagnose_unknown_calls = true
+	tc.check_semantics()
+	return tc.errors
+}
+
+fn build_checker_print_v3_bin(name string) string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_checker_print_${name}')
+	build := os.execute('${checker_print_vexe} -o ${v3_bin} ${checker_print_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn test_bare_println_allows_non_string_for_stringify_lowering() {
+	errors := check_print_sources('bare_println', {
+		'main.v': 'module main
+
+fn println(s string) {}
+
+fn main() {
+	println(123)
+}
+'
+	})
+	assert errors.len == 0, errors.str()
+}
+
+fn test_local_println_non_string_param_keeps_declared_arg_type() {
+	errors := check_print_sources('local_println_int_param', {
+		'main.v': 'module main
+
+fn println(i int) {}
+
+fn main() {
+	println("x")
+}
+'
+	})
+	assert errors.len == 1, errors.str()
+	assert errors[0].msg == 'cannot use `string` as argument 1 to `println`; expected `int`'
+}
+
+fn test_qualified_println_keeps_declared_arg_type() {
+	errors := check_print_sources('qualified_println', {
+		'main.v':    'module main
+
+import log
+
+fn main() {
+	log.println(123)
+}
+'
+		'log/log.v': 'module log
+
+pub fn println(s string) {}
+'
+	})
+	assert errors.len == 1, errors.str()
+	assert errors[0].msg == 'cannot use `int` as argument 1 to `log.println`; expected `string`'
+}
+
+fn test_eprint_bool_compile_uses_stringification() {
+	v3_bin := build_checker_print_v3_bin('eprint_bool')
+	src := os.join_path(os.temp_dir(), 'v3_checker_print_eprint_bool.v')
+	bin := os.join_path(os.temp_dir(), 'v3_checker_print_eprint_bool')
+	os.write_file(src, '
+fn main() {
+	eprint(true)
+}
+') or { panic(err) }
+	compile := os.execute('${v3_bin} -o ${bin} ${src}')
+	assert compile.exit_code == 0, compile.output
+}

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -1,0 +1,406 @@
+import os
+import v3.flat
+import v3.gen.c as cgen
+import v3.markused
+import v3.parser
+import v3.pref
+import v3.transform
+import v3.types
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn parse_checked_source(name string, source string) (&flat.FlatAst, &types.TypeChecker) {
+	src := os.join_path(os.temp_dir(), 'v3_markused_${name}.v')
+	os.write_file(src, source) or { panic(err) }
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_file(src)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.diagnose_unknown_calls = true
+	tc.diagnostic_files[src] = true
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	return a, &tc
+}
+
+fn mark_used_source(name string, source string) map[string]bool {
+	a, tc := parse_checked_source(name, source)
+	return markused.mark_used(a, tc)
+}
+
+fn build_v3_bin(name string) string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_markused_${name}')
+	build := os.execute('${vexe} -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn test_map_literals_seed_new_map_runtime_helper() {
+	used := mark_used_source('map_literal_new_map', '
+fn make_map() map[string]int {
+	return map[string]int{}
+}
+
+fn main() {
+	_ := make_map()
+}
+')
+	assert used['new_map']
+}
+
+fn test_optional_map_or_seeds_new_map_runtime_helper() {
+	used := mark_used_source('option_map_or_new_map', '
+fn maybe_map() ?map[string]int {
+	return none
+}
+
+fn main() {
+	m := maybe_map() or { return }
+	_ := m
+}
+')
+	assert used['new_map']
+}
+
+fn test_string_membership_seeds_contains_runtime_helpers() {
+	used := mark_used_source('string_membership_contains', '
+fn has_needle() bool {
+	return "bc" in "abcd"
+}
+
+fn main() {
+	_ := has_needle()
+}
+')
+	assert used['string__contains']
+	assert used['string__contains_u8']
+}
+
+fn test_string_interpolation_seeds_string_plus_and_formatter_helpers() {
+	used := mark_used_source('string_interp_plus_formatter', '
+fn message(name string) string {
+	return "hello \${name} \${true}"
+}
+
+fn main() {
+	_ := message("v")
+}
+')
+	assert used['string__plus']
+	assert used['bool.str']
+}
+
+fn test_print_bool_seeds_formatter_runtime_helper() {
+	used := mark_used_source('print_bool_formatter', '
+fn println(s string) {}
+
+fn main() {
+	println(true)
+}
+')
+	assert used['bool.str']
+}
+
+fn test_string_compound_assign_seeds_string_plus_runtime_helper() {
+	used := mark_used_source('string_plus_assign', '
+fn main() {
+	mut s := "a"
+	s += "b"
+	_ := s
+}
+')
+	assert used['string__plus']
+}
+
+fn test_return_local_address_seeds_memdup_runtime_helper() {
+	used := mark_used_source('return_local_address_memdup', '
+struct Box {
+	x int
+}
+
+fn make_box() &Box {
+	b := Box{
+		x: 1
+	}
+	return &b
+}
+
+fn main() {
+	_ := make_box()
+}
+')
+	assert used['memdup']
+}
+
+fn test_map_literals_lower_to_new_map_after_used_filter_transform() {
+	mut a, mut tc := parse_checked_source('map_literal_new_map_cgen', '
+fn make_map() map[string]int {
+	return map[string]int{}
+}
+
+fn main() {
+	_ := make_map()
+}
+')
+	used := markused.mark_used(a, tc)
+	assert used['new_map']
+	transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('new_map(sizeof(string), sizeof(int)')
+}
+
+fn test_optional_map_or_lowers_to_new_map_after_used_filter_transform() {
+	mut a, mut tc := parse_checked_source('option_map_or_new_map_cgen', '
+fn maybe_map() ?map[string]int {
+	return none
+}
+
+fn main() {
+	m := maybe_map() or { return }
+	_ := m
+}
+')
+	used := markused.mark_used(a, tc)
+	assert used['new_map']
+	transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('new_map(sizeof(string), sizeof(int)')
+}
+
+fn test_string_membership_lowers_to_contains_after_used_filter_transform() {
+	mut a, mut tc := parse_checked_source('string_membership_contains_cgen', '
+fn has_needle() bool {
+	return "bc" in "abcd"
+}
+
+fn main() {
+	_ := has_needle()
+}
+')
+	used := markused.mark_used(a, tc)
+	assert used['string__contains']
+	assert used['string__contains_u8']
+	transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('string__contains(')
+}
+
+fn test_string_compound_assign_lowers_to_plus_after_used_filter_transform() {
+	mut a, mut tc := parse_checked_source('string_plus_assign_cgen', '
+fn main() {
+	mut s := "a"
+	s += "b"
+	_ := s
+}
+')
+	used := markused.mark_used(a, tc)
+	assert used['string__plus']
+	transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('string__plus(')
+}
+
+fn test_string_interpolation_lowers_to_formatter_after_used_filter_transform() {
+	mut a, mut tc := parse_checked_source('string_interp_formatter_cgen', '
+fn main() {
+	_ := "\${true}"
+}
+')
+	used := markused.mark_used(a, tc)
+	assert used['bool.str']
+	transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('bool__str(')
+}
+
+fn test_print_bool_lowers_to_formatter_after_used_filter_transform() {
+	mut a, mut tc := parse_checked_source('print_bool_formatter_cgen', '
+fn println(s string) {}
+
+fn main() {
+	println(true)
+}
+')
+	used := markused.mark_used(a, tc)
+	assert used['bool.str']
+	transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('bool__str(')
+}
+
+fn test_return_local_address_lowers_to_memdup_after_used_filter_transform() {
+	mut a, mut tc := parse_checked_source('return_local_address_memdup_cgen', '
+struct Box {
+	x int
+}
+
+fn make_box() &Box {
+	b := Box{
+		x: 1
+	}
+	return &b
+}
+
+fn main() {
+	_ := make_box()
+}
+')
+	used := markused.mark_used(a, tc)
+	assert used['memdup']
+	transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('memdup(')
+}
+
+fn test_map_literal_compile_keeps_new_map_runtime_helper() {
+	v3_bin := build_v3_bin('map_literal_test')
+
+	src := os.join_path(os.temp_dir(), 'v3_markused_map_literal_input.v')
+	bin := os.join_path(os.temp_dir(), 'v3_markused_map_literal_input')
+	os.write_file(src, '
+fn make_map() map[string]int {
+	return map[string]int{}
+}
+
+fn main() {
+	_ := make_map()
+}
+') or {
+		panic(err)
+	}
+	compile := os.execute('${v3_bin} -o ${bin} ${src}')
+	assert compile.exit_code == 0, compile.output
+}
+
+fn test_optional_map_or_compile_keeps_new_map_runtime_helper() {
+	v3_bin := build_v3_bin('option_map_or_test')
+
+	src := os.join_path(os.temp_dir(), 'v3_markused_option_map_or_input.v')
+	bin := os.join_path(os.temp_dir(), 'v3_markused_option_map_or_input')
+	os.write_file(src, '
+fn maybe_map() ?map[string]int {
+	return none
+}
+
+fn main() {
+	m := maybe_map() or { return }
+	_ := m
+}
+') or {
+		panic(err)
+	}
+	compile := os.execute('${v3_bin} -o ${bin} ${src}')
+	assert compile.exit_code == 0, compile.output
+}
+
+fn test_return_local_address_compile_keeps_memdup_runtime_helper() {
+	v3_bin := build_v3_bin('return_local_address_test')
+
+	src := os.join_path(os.temp_dir(), 'v3_markused_return_local_address_input.v')
+	bin := os.join_path(os.temp_dir(), 'v3_markused_return_local_address_input')
+	os.write_file(src, '
+struct Box {
+	x int
+}
+
+fn make_box() &Box {
+	b := Box{
+		x: 1
+	}
+	return &b
+}
+
+fn main() {
+	_ := make_box()
+}
+') or {
+		panic(err)
+	}
+	compile := os.execute('${v3_bin} -o ${bin} ${src}')
+	assert compile.exit_code == 0, compile.output
+}
+
+fn test_print_bool_compile_keeps_formatter_runtime_helper() {
+	v3_bin := build_v3_bin('print_bool_test')
+
+	src := os.join_path(os.temp_dir(), 'v3_markused_print_bool_input.v')
+	bin := os.join_path(os.temp_dir(), 'v3_markused_print_bool_input')
+	os.write_file(src, '
+fn main() {
+	println(true)
+}
+') or { panic(err) }
+	compile := os.execute('${v3_bin} -o ${bin} ${src}')
+	assert compile.exit_code == 0, compile.output
+}
+
+fn test_string_plus_compile_keeps_plus_runtime_helper() {
+	v3_bin := build_v3_bin('string_plus_test')
+
+	src := os.join_path(os.temp_dir(), 'v3_markused_string_plus_input.v')
+	bin := os.join_path(os.temp_dir(), 'v3_markused_string_plus_input')
+	os.write_file(src, '
+fn main() {
+	flag := true
+	mut s := "a"
+	s += "\${flag}"
+	_ := s
+}
+') or {
+		panic(err)
+	}
+	compile := os.execute('${v3_bin} -o ${bin} ${src}')
+	assert compile.exit_code == 0, compile.output
+}
+
+fn test_string_membership_compile_keeps_contains_runtime_helpers() {
+	v3_bin := build_v3_bin('string_membership_test')
+
+	src := os.join_path(os.temp_dir(), 'v3_markused_string_membership_input.v')
+	bin := os.join_path(os.temp_dir(), 'v3_markused_string_membership_input')
+	os.write_file(src, '
+fn has_needle() bool {
+	return "bc" in "abcd"
+}
+
+fn main() {
+	_ := has_needle()
+}
+') or {
+		panic(err)
+	}
+	compile := os.execute('${v3_bin} -o ${bin} ${src}')
+	assert compile.exit_code == 0, compile.output
+}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1555,7 +1555,7 @@ fn (mut t Transformer) try_lower_builtin_call(_id flat.NodeId, node flat.Node) ?
 	}
 	name := fn_node.value
 	match name {
-		'println', 'eprintln', 'print' {
+		'println', 'eprintln', 'print', 'eprint' {
 			if node.children_count < 2 {
 				return t.transform_call_args(_id, node)
 			}

--- a/vlib/v3/transform/sum.v
+++ b/vlib/v3/transform/sum.v
@@ -27,6 +27,26 @@ fn (t &Transformer) resolve_variant(sum_name string, variant string) string {
 }
 
 fn (t &Transformer) resolve_sum_name(sum_name string) string {
+	if sum_name.len == 0 {
+		return sum_name
+	}
+	if isnil(t.sum_cache) {
+		return t.resolve_sum_name_uncached(sum_name)
+	}
+	mut c := t.sum_cache
+	if c.module != t.cur_module {
+		c.module = t.cur_module
+		c.entries.clear()
+	}
+	if cached := c.entries[sum_name] {
+		return cached
+	}
+	result := t.resolve_sum_name_uncached(sum_name)
+	c.entries[sum_name] = result
+	return result
+}
+
+fn (t &Transformer) resolve_sum_name_uncached(sum_name string) string {
 	if sum_name in t.sum_types {
 		return sum_name
 	}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -67,6 +67,8 @@ mut:
 	in_const_init         bool
 	in_return_expr        bool
 	alias_cache           &AliasCache = unsafe { nil }
+	sum_cache             &AliasCache = unsafe { nil }
+	used_fns              map[string]bool
 }
 
 // AliasCache memoizes normalize_type_alias results. It lives on the heap so the
@@ -113,10 +115,15 @@ struct VarTypeBinding {
 // --- entry point ---
 
 pub fn transform(mut a flat.FlatAst, tc &types.TypeChecker) {
+	transform_with_used(mut a, tc, map[string]bool{})
+}
+
+pub fn transform_with_used(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) {
 	mut t := Transformer{
 		a:                     a
 		tc:                    unsafe { tc }
 		pointer_value_lvalues: map[string]bool{}
+		used_fns:              used_fns
 	}
 	t.collect_types()
 	t.collect_const_suffixes()
@@ -125,6 +132,7 @@ pub fn transform(mut a flat.FlatAst, tc &types.TypeChecker) {
 	// During collection those maps are incomplete, so caching there would poison
 	// entries with results computed against a partial view.
 	t.alias_cache = &AliasCache{}
+	t.sum_cache = &AliasCache{}
 	t.transform_all()
 }
 
@@ -437,6 +445,9 @@ fn (mut t Transformer) transform_all() {
 			t.cur_module = node.value
 		}
 		if kind_id == 61 {
+			if !t.should_transform_fn(node) {
+				continue
+			}
 			t.transform_fn_body(i)
 		} else if kind_id == 65 {
 			t.transform_const_decl(node)
@@ -444,6 +455,31 @@ fn (mut t Transformer) transform_all() {
 			t.transform_global_decl(node)
 		}
 	}
+}
+
+fn (t &Transformer) should_transform_fn(node flat.Node) bool {
+	if t.used_fns.len == 0 {
+		return true
+	}
+	if node.value in t.used_fns {
+		return true
+	}
+	qname := transform_qualified_fn_name(t.cur_module, node.value)
+	if qname in t.used_fns {
+		return true
+	}
+	cname := c_name(qname)
+	if cname != qname && cname in t.used_fns {
+		return true
+	}
+	return false
+}
+
+fn transform_qualified_fn_name(mod string, name string) string {
+	if mod.len == 0 || mod == 'main' || mod == 'builtin' {
+		return name
+	}
+	return '${mod}.${name}'
 }
 
 // transform_const_decl transforms the initializer expression of each const field

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -305,6 +305,9 @@ fn (t &Transformer) normalize_type_alias(typ string) string {
 	if typ.len == 0 || isnil(t.tc) {
 		return typ
 	}
+	if is_plain_builtin_alias_type(typ) {
+		return typ
+	}
 	if isnil(t.alias_cache) {
 		return t.normalize_type_alias_uncached(typ)
 	}
@@ -361,6 +364,18 @@ fn (t &Transformer) normalize_type_alias_uncached(typ string) string {
 		}
 	}
 	return typ
+}
+
+fn is_plain_builtin_alias_type(typ string) bool {
+	return match typ {
+		'bool', 'string', 'void', 'int', 'i8', 'i16', 'i32', 'i64', 'u8', 'u16', 'u32', 'u64',
+		'f32', 'f64', 'rune', 'isize', 'usize', 'voidptr', 'byteptr', 'charptr' {
+			true
+		}
+		else {
+			false
+		}
+	}
 }
 
 fn is_generic_placeholder_type_name(typ string) bool {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -65,6 +65,13 @@ struct LocalBinding {
 	typ  Type
 }
 
+struct TypeCache {
+mut:
+	parse_enabled bool
+	parse_entries map[string]Type
+	c_entries     map[string]string
+}
+
 @[heap]
 pub struct TypeChecker {
 pub mut:
@@ -110,6 +117,8 @@ pub mut:
 	diagnostic_files              map[string]bool
 	cur_fn_ret_type               Type = Type(void_)
 	smartcasts                    map[string]Type
+mut:
+	type_cache &TypeCache = unsafe { nil }
 }
 
 pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
@@ -146,6 +155,10 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		checking_nodes:             []bool{len: a.nodes.len}
 		diagnostic_files:           map[string]bool{}
 		smartcasts:                 map[string]Type{}
+		type_cache:                 &TypeCache{
+			parse_entries: map[string]Type{}
+			c_entries:     map[string]string{}
+		}
 	}
 }
 
@@ -205,6 +218,10 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	tc.cur_scope = tc.file_scope
 	tc.scope_pool_index = 0
 	tc.reset_node_caches(a.nodes.len)
+	tc.type_cache = &TypeCache{
+		parse_entries: map[string]Type{}
+		c_entries:     map[string]string{}
+	}
 	for node in a.nodes {
 		if node.kind == .struct_decl && node.value == 'string' {
 			tc.has_builtins = true
@@ -275,6 +292,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 		}
 	}
 	// Pass 2: collect struct fields, function signatures (type aliases now available)
+	tc.type_cache.parse_enabled = true
 	tc.cur_module = ''
 	for node in a.nodes {
 		match node.kind {
@@ -2172,6 +2190,10 @@ fn (tc &TypeChecker) call_info(name string, has_receiver bool) CallInfo {
 		params = p.clone()
 		params_known = true
 	}
+	if is_print_style_fn_name(name) && params.len == 1
+		&& print_style_param_accepts_string(params[0]) {
+		params[0] = unknown_type('print argument')
+	}
 	return CallInfo{
 		name:         name
 		params:       params
@@ -2180,6 +2202,23 @@ fn (tc &TypeChecker) call_info(name string, has_receiver bool) CallInfo {
 		is_variadic:  tc.fn_variadic[name] or { false }
 		params_known: params_known
 	}
+}
+
+fn is_print_style_fn_name(name string) bool {
+	return name in ['print', 'println', 'eprint', 'eprintln', 'builtin.print', 'builtin.println',
+		'builtin.eprint', 'builtin.eprintln']
+}
+
+fn print_style_param_accepts_string(typ Type) bool {
+	mut clean := typ
+	for _ in 0 .. 8 {
+		if clean is Alias {
+			clean = clean.base_type
+			continue
+		}
+		break
+	}
+	return clean is String
 }
 
 fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, info CallInfo) {
@@ -4124,6 +4163,20 @@ fn (tc &TypeChecker) smartcast_type(id flat.NodeId) ?Type {
 
 // parse_type converts a V type string (from parser) to a structured Type.
 pub fn (tc &TypeChecker) parse_type(typ string) Type {
+	if tc.type_cache != unsafe { nil } && tc.type_cache.parse_enabled {
+		key := tc.cur_module + '\n' + typ
+		mut cache := unsafe { tc.type_cache }
+		if cached := cache.parse_entries[key] {
+			return cached
+		}
+		result := tc.parse_type_uncached(typ)
+		cache.parse_entries[key] = result
+		return result
+	}
+	return tc.parse_type_uncached(typ)
+}
+
+fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 	if typ.len == 0 {
 		return Type(void_)
 	}
@@ -5206,6 +5259,23 @@ fn (tc &TypeChecker) resolve_index_type(node flat.Node) Type {
 }
 
 pub fn (tc &TypeChecker) c_type(t Type) string {
+	if t is Pointer || t is FnType || t is Struct || t is Interface || t is SumType || t is Alias
+		|| t is MultiReturn || t is ArrayFixed {
+		if tc.type_cache != unsafe { nil } {
+			key := t.name()
+			mut cache := unsafe { tc.type_cache }
+			if cached := cache.c_entries[key] {
+				return cached
+			}
+			result := tc.c_type_uncached(t)
+			cache.c_entries[key] = result
+			return result
+		}
+	}
+	return tc.c_type_uncached(t)
+}
+
+fn (tc &TypeChecker) c_type_uncached(t Type) string {
 	if t is Void {
 		return 'void'
 	}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -133,8 +133,13 @@ fn main() {
 	}
 	b.step('check')
 
+	// Mark used functions (dead-code elimination). This is done before transform
+	// so the transformer can skip function bodies that the C backend will prune.
+	used_fns := markused.mark_used(a, pre_tc)
+	b.step('markused')
+
 	// Transform (match lowering, string/in lowering, etc.)
-	transform.transform(mut a, &pre_tc)
+	transform.transform_with_used(mut a, &pre_tc, used_fns)
 	b.step('transform')
 
 	// Reuse the pre-transform checker for metadata only. Transform does not add
@@ -146,10 +151,6 @@ fn main() {
 		pre_tc.diagnostic_files[uf] = true
 	}
 	b.step('annotate types')
-
-	// Mark used functions (dead-code elimination)
-	used_fns := markused.mark_used(a, pre_tc)
-	b.step('markused')
 
 	if backend == 'arm64' {
 		// SSA + ARM64 native backend


### PR DESCRIPTION
## Summary
- fix v3 self-host crash from map methods on mutable map parameters by emitting pointer-aware map receivers
- move markused before transform so transform skips pruned function bodies
- speed up v3 self compilation with C-name lowering, type/transform caches, cheaper markused paths, and cheaper macOS RSS sampling
- update v3 README timing/order for the self-host benchmark

## Timings
Warm C-only samples for `vlib/v3/v3.v` on this machine:
- `./v3 -o /tmp/v3.c v3.v`: ~247-254 ms internally, ~0.247-0.248s wall
- `~/code/v/vprod -o /tmp/v1.c v3.v`: ~0.201-0.205s wall in best warmed samples

The original self-host chain now completes through `v6`; the first v3-generated stage was ~1042 ms including `cc` fallback.

## Tests
- `./vnew -gc none -prod -o vlib/v3/v3 vlib/v3/v3.v`
- `cd vlib/v3 && ./v3 -parallel-transform -parallel -o v4 v3.v && ./v4 -o v5 v3.v && ./v5 -o v6 v3.v`
- direct runtime check for `m.delete()` and `m.clear()` on `mut map[string]bool` parameters
- `./vnew -silent test vlib/v3/` (18 passed; known existing failures: `vlib/v3/tests/generics_test.v`, `vlib/v3/tests/type_checker_errors_test.v`)
- `./vnew check-md vlib/v3/README.md`
