### PR TITLE
builtin: mark C.GetFinalPathNameByHandleW as @[c_extern] for TCC

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -295,7 +295,13 @@ fn C.CreateFile(lpFilename &u16, dwDesiredAccess u32, dwShareMode u32, lpSecurit
 fn C.CreateFileW(lpFilename &u16, dwDesiredAccess u32, dwShareMode u32, lpSecurityAttributes &u16, dwCreationDisposition u32,
 	dwFlagsAndAttributes u32, hTemplateFile voidptr) voidptr
 
-fn C.GetFinalPathNameByHandleW(hFile voidptr, lpFilePath &u16, nSize u32, dwFlags u32) u32
+$if windows {
+	// The TCC-only declaration is guarded with `#ifdef __TINYC__` in the
+	// header, so it survives cross compilation; GCC/MSVC use the SDK header.
+	#insert "@VEXEROOT/vlib/builtin/cfns_windows_tcc.h"
+
+	fn C.GetFinalPathNameByHandleW(hFile voidptr, lpFilePath &u16, nSize u32, dwFlags u32) u32
+}
 
 fn C.CreatePipe(hReadPipe &voidptr, hWritePipe &voidptr, lpPipeAttributes voidptr, nSize u32) bool
 

--- a/vlib/builtin/cfns_windows_tcc.h
+++ b/vlib/builtin/cfns_windows_tcc.h
@@ -1,0 +1,15 @@
+// TCC's bundled <windows.h> does not include <fileapi.h>, and TCC's own
+// <fileapi.h> cannot be used either because it pulls in <apiset.h>, a header
+// TCC does not ship. As a result GetFinalPathNameByHandleW has no declaration
+// in scope when TCC compiles code that uses it (e.g. os.real_path).
+//
+// Provide the declaration for TCC only. GCC/MSVC get it from the Windows SDK
+// (via <windows.h> -> <fileapi.h>); emitting a V-side extern there would
+// conflict with the SDK's `DWORD WINAPI` signature, since DWORD is
+// `unsigned long`, not `unsigned int`.
+#ifdef __TINYC__
+#ifndef GetFinalPathNameByHandleW
+extern unsigned int GetFinalPathNameByHandleW(void *hFile, unsigned short *lpFilePath,
+	unsigned int nSize, unsigned int dwFlags);
+#endif
+#endif


### PR DESCRIPTION
## Problem

`GetFinalPathNameByHandleW` is declared in `vlib/builtin/cfns.c.v`
without a corresponding `#include`. TCC's bundled `<windows.h>` does not
include `<fileapi.h>`, so the function has no C declaration in scope when
TCC compiles any program that transitively pulls in `builtin` (e.g. via
`os.real_path`). TCC (in C99 mode) treats implicit function declarations
as hard errors:

```
C function `C.GetFinalPathNameByHandleW` was declared in V, but the C
compiler did not see a matching C declaration for `GetFinalPathNameByHandleW`.
```

## Fix

Provide the declaration for **TCC only**, via a small header
(`vlib/builtin/cfns_windows_tcc.h`) that is `#insert`-ed under
`$if windows {}` and guarded with `#ifdef __TINYC__`:

- **TCC**: `__TINYC__` is defined, so the `extern` is supplied. TCC's own
  `<fileapi.h>` cannot be used instead because it pulls in `<apiset.h>`,
  a header TCC does not ship.
- **GCC/MSVC**: `__TINYC__` is not defined, so the `extern` is skipped and
  the call resolves against the SDK header that `<windows.h>` pulls in
  transitively.

The matching V `fn C.GetFinalPathNameByHandleW(...)` declaration is left
bare (no `@[c_extern]`), so V itself emits no C declaration — the header
supplies it for TCC and the SDK supplies it for GCC/MSVC.

## Why gate in the C preprocessor instead of `$if tinyc`?

Under `-cross`, V emits C-function declarations **unconditionally** — a
comptime `$if tinyc { @[c_extern] ... }` guard is *not* preserved as a
C-level guard, so the `extern` would still be emitted and then compiled
by GCC, reproducing the conflict (observed in
`vlib/v/gen/c/coutput_test.v`'s `cross_printfn_v_malloc` fixture).
Gating with `#ifdef __TINYC__` keeps the guard intact in the generated C
across normal and `-cross` builds. The same idiom is already used for
TCC/Windows in `vlib/v/gen/c/cheaders.v`.

## Why not a single `@[c_extern]` or a single `#include <fileapi.h>`?

- A single `@[c_extern]` makes V emit `extern u32 GetFinalPathNameByHandleW(...)`
  on **all** Windows compilers. On GCC/MSVC this conflicts with the SDK's
  `DWORD WINAPI` signature (`DWORD` is `unsigned long`, not `u32`),
  failing with `error: conflicting types for 'GetFinalPathNameByHandleW'`.
  The `#ifndef` guard `@[c_extern]` generates only protects against macro
  names, not real function declarations.
- A single `#include <fileapi.h>` breaks **TCC**, because TCC's
  `<fileapi.h>` includes `<apiset.h>`, which TCC does not ship
  (`builder error: 'apiset.h' not found`).

## Test plan

- [x] Generated C wraps the `extern` in `#ifdef __TINYC__` for both
      normal and `-cross` GCC builds; GCC compiles both with no conflict
- [x] `vlib/os/` test suite passes (24/24) with GCC on Windows

🧙 Built with [WOZCODE](https://wozcode.com)
