### PR TITLE
x.json2: decode option fields via comptime `$zero`/`$new` type accessors

### DIFF
--- a/vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v
+++ b/vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v
@@ -155,7 +155,11 @@ fn test_skip_unused_keeps_json2_embedded_struct_decode_helpers() {
 	}
 	assert res.output.contains('x__json2__decode_struct_key_T_main__Req')
 	assert res.output.contains('x__json2__check_required_struct_fields_T_main__Req')
-	assert res.output.contains('x__json2__create_value_from_optional_T_time__Time')
+	// the `?time.Time` payload of the embedded `Meta` is decoded through a generic
+	// instantiation reachable only via comptime `$for field` codegen; skip-unused
+	// must keep it. Assert the payload decoder itself rather than a specific json2
+	// helper name, so the test does not break when those helpers are refactored.
+	assert res.output.contains('x__json2__Decoder_decode_value_T_time__Time')
 }
 
 fn test_skip_unused_marks_dependencies_inside_generic_anon_fns() {

--- a/vlib/x/json2/decode.v
+++ b/vlib/x/json2/decode.v
@@ -335,10 +335,6 @@ fn create_decoded_ptr[T](_ &T) &T {
 	}
 }
 
-fn create_decoded_option_ptr[U](_ ?&U) &U {
-	return &U{}
-}
-
 fn decoder_field_infos[T]() []DecoderFieldInfo {
 	mut field_infos := []DecoderFieldInfo{}
 	$for field in T.fields {
@@ -551,16 +547,11 @@ fn decode_struct_key[T](mut decoder Decoder, val T, key_info ValueInfo, prefix s
 							}
 						} else {
 							$if field.indirections == 1 {
-								mut decoded_ptr := create_decoded_option_ptr(new_val.$(field.name))
+								mut decoded_ptr := $new(field.typ.payload_type.pointee_type)
 								decoder.decode_value(mut decoded_ptr)!
 								new_val.$(field.name) = decoded_ptr
 							} $else {
-								mut unwrapped_val := create_value_from_optional(new_val.$(field.name)) or {
-									return StructKeyDecodeResult[T]{
-										matched: false
-										value:   val
-									}
-								}
+								mut unwrapped_val := $zero(field.typ.payload_type)
 								decoder.decode_value(mut unwrapped_val)!
 								new_val.$(field.name) = unwrapped_val
 							}
@@ -916,8 +907,6 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 										}
 									} else {
 										$if field.typ is $option {
-											// it would be nicer to do this at the start of the function
-											// but options cant be passed to generic functions
 											if decoder.current_node.value.value_kind == .null {
 												val.$(field.name) = none
 
@@ -926,14 +915,11 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 												}
 											} else {
 												$if field.indirections == 1 {
-													mut decoded_ptr :=
-														create_decoded_option_ptr(val.$(field.name))
+													mut decoded_ptr := $new(field.typ.payload_type.pointee_type)
 													decoder.decode_value(mut decoded_ptr)!
 													val.$(field.name) = decoded_ptr
 												} $else {
-													mut unwrapped_val := create_value_from_optional(val.$(field.name)) or {
-														return
-													}
+													mut unwrapped_val := $zero(field.typ.payload_type)
 													decoder.decode_value(mut unwrapped_val)!
 													val.$(field.name) = unwrapped_val
 												}
@@ -1305,10 +1291,6 @@ fn (mut decoder Decoder) decode_map[V](mut val map[string]V) ! {
 			decoder.decode_error('Expected object, but got ${map_info.value_kind}')!
 		}
 	}
-}
-
-fn create_value_from_optional[T](_val ?T) ?T {
-	return T{}
 }
 
 fn (mut decoder Decoder) decode_enum[T](mut val T) ! {

--- a/vlib/x/json2/decode_sumtype.v
+++ b/vlib/x/json2/decode_sumtype.v
@@ -11,21 +11,17 @@ fn sumtype_variant_name(type_name string) string {
 	return type_name.all_after_last('.')
 }
 
-fn copy_type[T](_t T) T {
-	return T{}
-}
-
 fn (mut decoder Decoder) get_decoded_sumtype_workaround[T](initialized_sumtype T) !T {
 	$if initialized_sumtype is $sumtype || (T is $alias && T.unaliased_typ is $sumtype) {
 		resolved_sumtype := initialized_sumtype
 		$for v in T.variants {
 			if initialized_sumtype is v {
 				$if initialized_sumtype is time.Time {
-					mut val := copy_type(initialized_sumtype)
+					mut val := $zero(v.typ)
 					decoder.decode_sumtype_time(mut val)!
 					return T(val)
 				} $else $if initialized_sumtype !is $option {
-					mut val := copy_type(initialized_sumtype)
+					mut val := $zero(v.typ)
 					decoder.decode_value(mut val)!
 					return T(val)
 				} $else {
@@ -153,7 +149,7 @@ fn (mut decoder Decoder) get_map_type_workaround[T](initialized_sumtype T) bool 
 		$for v in T.variants {
 			if initialized_sumtype is v {
 				$if initialized_sumtype is $map {
-					val := copy_type(initialized_sumtype)
+					val := $zero(v.typ)
 					if decoder.current_node.next != unsafe { nil } {
 						return decoder.check_map_type_valid(val, decoder.current_node.next.next)
 					} else {
@@ -237,7 +233,7 @@ fn (mut decoder Decoder) get_struct_type_workaround[T](initialized_sumtype T) bo
 		$for v in T.variants {
 			if initialized_sumtype is v {
 				$if initialized_sumtype is $struct {
-					val := copy_type(initialized_sumtype)
+					val := $zero(v.typ)
 					return decoder.check_struct_type_valid(val, decoder.current_node)
 				}
 			}
@@ -251,7 +247,7 @@ fn (mut decoder Decoder) get_time_type_workaround[T](initialized_sumtype T) bool
 		$for v in T.variants {
 			if initialized_sumtype is v {
 				$if initialized_sumtype is time.Time {
-					val := copy_type(initialized_sumtype)
+					val := $zero(v.typ)
 					return decoder.check_sumtype_type_valid(val, decoder.current_node)
 				}
 			}


### PR DESCRIPTION
## What

Adopts the comptime `$zero(TypeExpr)` / `$new(TypeExpr)` type accessors that #27048 made reliable, to remove generic *inference-abuse* helpers in `x.json2` whose only job was to recover a payload / pointee / variant type.

### 1. Option struct fields (`decode.v`)

- `?T` value fields → `mut unwrapped_val := $zero(field.typ.payload_type)`
- `?&T` pointer fields → `mut decoded_ptr := $new(field.typ.payload_type.pointee_type)`

Previously routed through:

```v
fn create_value_from_optional[T](_val ?T) ?T { return T{} }
fn create_decoded_option_ptr[U](_ ?&U) &U  { return &U{} }
```

which existed only because an option value couldn't be fed into the comptime machinery — exactly the in-code comment that is now removed:

```v
// it would be nicer to do this at the start of the function
// but options cant be passed to generic functions
```

As a bonus, the `or { ... }` fallbacks on those call sites were dead code — `create_value_from_optional` always returned a value and never `none`.

### 2. Sumtype variant values (`decode_sumtype.v`)

A second helper, `fn copy_type[T](_t T) T { return T{} }`, built a fresh variant value at five call sites. Each sits inside `$for v in T.variants { if initialized_sumtype is v { $if initialized_sumtype is <X> { ... } } }`, where the runtime smart-cast and the comptime `$if` together pin the variant, so `v.typ` is exactly the type `copy_type` inferred from the value. Replaced all five with `$zero(v.typ)` and removed the helper.

### 3. skip-unused test (`vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v`)

`test_skip_unused_keeps_json2_embedded_struct_decode_helpers` hard-coded the generated symbol `x__json2__create_value_from_optional_T_time__Time` — which this PR removes. Updated it to assert `x__json2__Decoder_decode_value_T_time__Time`, the generic instantiation that actually decodes the `?time.Time` payload of the embedded `Meta` struct (reachable only via comptime `$for field` codegen, and present whether or not the json2 helpers exist). Thanks to the `chatgpt-codex-connector` review for catching this.

`create_decoded_ptr` (plain pointer / array-element / map-value paths) is intentionally left as-is — it carries `$interface`/`voidptr` → `nil` guards that `$new` does not replicate.

Net: no public API or behavior change.

## Testing

- `v test vlib/x/json2/` → **61 passed, 61 total**, before and after.
  - `?&T` option-pointer decode is exercised by the nested `reply_to ?&OptionalPointerRegressionMessage` case in `tests/decode_embed_reference_test.v`.
  - `?T` option-value decode is covered broadly (e.g. `json_optional_both_type_field_test.v`).
  - Sumtype struct/map/array/primitive/option variants are covered by `json_sumtype_test.v` & friends; the time.Time variant path was additionally runtime-checked by decoding `{"_type":"Time","value":...}` back to a `time.Time`.
- `v -w test vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v` → **passes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)