### PR TITLE
encoding.cbor: build option payloads via comptime `$zero(field.typ.payload_type)`

### DIFF
--- a/vlib/encoding/cbor/generic.v
+++ b/vlib/encoding/cbor/generic.v
@@ -416,7 +416,7 @@ fn (mut u Unpacker) unpack_struct_into[T](mut result T) ! {
 							u.pos++
 							result.$(field.name) = none
 						} else {
-							mut inner := create_value_from_optional(result.$(field.name))
+							mut inner := $zero(field.typ.payload_type)
 							u.unpack_into(mut inner)!
 							result.$(field.name) = inner
 						}
@@ -568,12 +568,6 @@ fn utf8_validate_slice(data []u8, start int, size int) bool {
 		i += n
 	}
 	return true
-}
-
-// create_value_from_optional returns a zero value of an Option's inner T.
-// Exists so the comptime call site can infer T from a struct field.
-fn create_value_from_optional[T](_val ?T) T {
-	return T{}
 }
 
 // unpack_into fills the target through a mutable reference. The mut


### PR DESCRIPTION
## What

Follow-up to #27535. After refactoring `x.json2`, I swept the rest of the tree for the same comptime workaround pattern — a generic helper whose sole purpose is to recover an option's payload type via inference (`fn f[T](_ ?T) T { return T{} }`). `vlib/encoding/cbor` had its own copy:

```v
// create_value_from_optional returns a zero value of an Option's inner T.
// Exists so the comptime call site can infer T from a struct field.
fn create_value_from_optional[T](_val ?T) T { return T{} }
```

Since #27048 makes `$zero(TypeExpr)` resolve per-field comptime metadata, the payload type can be read directly at the `$for field` site:

```v
$if field.typ is $option {
    ...
    mut inner := $zero(field.typ.payload_type)   // was: create_value_from_optional(result.$(field.name))
    u.unpack_into(mut inner)!
    result.$(field.name) = inner
}
```

The helper (its only call site) is removed.

## Why this is the only change

I ran an exhaustive sweep across `vlib` (orm, toml, x.encoding.asn1, db, the legacy `json` codec, encoding.binary/csv, mcp/flag/veb, the V→C codegen, builtin/datatypes/…). `encoding.cbor` was the **only** module outside json2 carrying this workaround. A repo-wide search for generic `fn f[T](… ?T …) … { return T{} }` / `&T{}` helpers confirms it: the only hits are in `x.json2` (#27535) and this file.

The cbor encoder's separate `get_value_from_optional` helper is **not** touched — it *unwraps an existing value*, which `$zero`/`$new` don't replace.

## Behavior

No change. The helper unconditionally returned `T{}` (zero of the payload); `$zero(field.typ.payload_type)` yields the same value and type, and `inner` is immediately overwritten by `unpack_into`. cbor has no option-pointer (`?&T`) or interface/voidptr fields in this path, so the `$new`/nil-guard caveat does not apply.

## Testing

`v test vlib/encoding/cbor/` → **10 passed, 10 total**, before and after (the option-field decode path is covered by `tests/generic_test.v`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)