### PR TITLE
tests: harden skip-unused json2 test against helper refactors

### DIFF
--- a/vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v
+++ b/vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v
@@ -155,7 +155,11 @@ fn test_skip_unused_keeps_json2_embedded_struct_decode_helpers() {
 	}
 	assert res.output.contains('x__json2__decode_struct_key_T_main__Req')
 	assert res.output.contains('x__json2__check_required_struct_fields_T_main__Req')
-	assert res.output.contains('x__json2__create_value_from_optional_T_time__Time')
+	// the `?time.Time` payload of the embedded `Meta` is decoded through a generic
+	// instantiation reachable only via comptime `$for field` codegen; skip-unused
+	// must keep it. Assert the payload decoder itself rather than a specific json2
+	// helper name, so the test does not break when those helpers are refactored.
+	assert res.output.contains('x__json2__Decoder_decode_value_T_time__Time')
 }
 
 fn test_skip_unused_marks_dependencies_inside_generic_anon_fns() {


### PR DESCRIPTION
## Background

On #27535, the `chatgpt-codex-connector` review [flagged](https://github.com/vlang/v/pull/27535#discussion_r3449280531) that `vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v` would start failing. This PR fixes the underlying brittleness so the test no longer hard-codes a json2 implementation detail.

## The bug

`test_skip_unused_keeps_json2_embedded_struct_decode_helpers` (regression for #26928) asserts that `-skip-unused` keeps generic json2 helpers reachable only through comptime `$for field` codegen. One assertion hard-coded the generated symbol of a specific helper:

```v
assert res.output.contains('x__json2__create_value_from_optional_T_time__Time')
```

`create_value_from_optional` is a json2 implementation detail. #27535 removes it (the option payload is now built inline with `$zero(field.typ.payload_type)`), so the symbol disappears and this assertion fails.

### Reproduction

Compile the test program to C and grep the symbols (this is exactly what the test does):

```v
// issue_26928.v
module main
import time
import x.json2
struct Meta { created_at ?time.Time }
struct Req  { Meta name string }
fn main() { _ := json2.decode[Req]('{"name":"x"}') or { panic(err) } }
```

```
v -w -o - issue_26928.v | grep create_value_from_optional
```

- on `master`: `x__json2__create_value_from_optional_T_time__Time` is present → test passes.
- on the #27535 branch: the symbol is gone → `test_skip_unused_keeps_json2_embedded_struct_decode_helpers` fails at that assertion.

## The fix

Assert the symbol that actually decodes the `?time.Time` payload of the embedded `Meta` — `x__json2__Decoder_decode_value_T_time__Time` — instead of a specific helper name. In this program `time.Time` only appears as that optional embedded field, so the instantiation is reachable **only** through comptime `$for field` codegen — exactly the skip-unused guarantee #26928 is about. Crucially, it is emitted **whether or not** the json2 helpers exist, so the test no longer breaks when they are refactored.

## Testing

`v -w test vlib/v/tests/skip_unused/generic_fn_instantiation_pruning_test.v` → **passes** both:
- on `master` (json2 unchanged), and
- against the #27535 branch (helper removed).

This is independent of #27535 and green on `master` today; once it lands, #27535 just needs a rebase to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)