### PR TITLE
v3: use aggregate zero initializers in C gen

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2027,6 +2027,10 @@ fn (mut g FlatGen) global_decls() {
 		if typ is types.ArrayFixed {
 			c_elem := g.tc.c_type(typ.elem_type)
 			len_expr := g.fixed_array_len_value(typ)
+			if len_expr == '0' {
+				g.writeln('${c_elem} ${c_name(name)}[0];')
+				continue
+			}
 			g.writeln('${c_elem} ${c_name(name)}[${len_expr}] = {0};')
 			continue
 		}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1043,6 +1043,13 @@ fn (mut g FlatGen) fixed_array_len_value(arr types.ArrayFixed) string {
 	return g.fixed_array_len_raw(arr.len_expr, arr.len)
 }
 
+fn (mut g FlatGen) fixed_array_len_is_zero(arr types.ArrayFixed) bool {
+	if value := g.tc.fixed_array_len_value(arr) {
+		return value == 0
+	}
+	return g.fixed_array_len_value(arr).trim_space() == '0'
+}
+
 fn (mut g FlatGen) fixed_array_len_raw(raw_len string, fallback int) string {
 	if raw_len.len == 0 {
 		return '${fallback}'

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2030,7 +2030,13 @@ fn (mut g FlatGen) builtin_compat_decls() {
 }
 
 fn (mut g FlatGen) global_decls() {
+	old_module := g.tc.cur_module
 	for name, typ in g.global_types {
+		if mod := g.global_modules[name] {
+			g.tc.cur_module = mod
+		} else {
+			g.tc.cur_module = old_module
+		}
 		if typ is types.ArrayFixed {
 			c_elem := g.tc.c_type(typ.elem_type)
 			len_expr := g.fixed_array_len_value(typ)
@@ -2048,6 +2054,7 @@ fn (mut g FlatGen) global_decls() {
 		init := if g.can_use_global_brace_zero_init(typ, ct) { ' = {0}' } else { '' }
 		g.writeln('${ct} ${c_name(name)}${init};')
 	}
+	g.tc.cur_module = old_module
 	if g.global_types.len > 0 {
 		g.writeln('')
 	}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2027,7 +2027,7 @@ fn (mut g FlatGen) global_decls() {
 		if typ is types.ArrayFixed {
 			c_elem := g.tc.c_type(typ.elem_type)
 			len_expr := g.fixed_array_len_value(typ)
-			g.writeln('${c_elem} ${c_name(name)}[${len_expr}];')
+			g.writeln('${c_elem} ${c_name(name)}[${len_expr}] = {0};')
 			continue
 		}
 		ct := g.tc.c_type(typ)
@@ -2037,7 +2037,8 @@ fn (mut g FlatGen) global_decls() {
 		if typ is types.Struct && typ.name.starts_with('C.') {
 			continue
 		}
-		g.writeln('${ct} ${c_name(name)};')
+		init := if g.is_aggregate_zero_init_type(typ, ct) { ' = {0}' } else { '' }
+		g.writeln('${ct} ${c_name(name)}${init};')
 	}
 	if g.global_types.len > 0 {
 		g.writeln('')

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2027,11 +2027,8 @@ fn (mut g FlatGen) global_decls() {
 		if typ is types.ArrayFixed {
 			c_elem := g.tc.c_type(typ.elem_type)
 			len_expr := g.fixed_array_len_value(typ)
-			if len_expr == '0' {
-				g.writeln('${c_elem} ${c_name(name)}[0];')
-				continue
-			}
-			g.writeln('${c_elem} ${c_name(name)}[${len_expr}] = {0};')
+			init := if g.has_zero_sized_leading_init_slot(typ) { '' } else { ' = {0}' }
+			g.writeln('${c_elem} ${c_name(name)}[${len_expr}]${init};')
 			continue
 		}
 		ct := g.tc.c_type(typ)
@@ -2041,7 +2038,7 @@ fn (mut g FlatGen) global_decls() {
 		if typ is types.Struct && typ.name.starts_with('C.') {
 			continue
 		}
-		init := if g.is_aggregate_zero_init_type(typ, ct) { ' = {0}' } else { '' }
+		init := if g.can_use_global_brace_zero_init(typ, ct) { ' = {0}' } else { '' }
 		g.writeln('${ct} ${c_name(name)}${init};')
 	}
 	if g.global_types.len > 0 {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -761,7 +761,7 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 			}
 			g.gen_decl_lhs(lhs_id)
 			g.write(' = ')
-			g.gen_expr(rhs_id)
+			g.gen_decl_init_expr(rhs_id, rhs, v_type, ct)
 			g.writeln(';')
 			if lhs.kind == .ident {
 				g.tc.cur_scope.insert(lhs.value, v_type)
@@ -769,6 +769,14 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 		}
 		i += 2
 	}
+}
+
+fn (mut g FlatGen) gen_decl_init_expr(rhs_id flat.NodeId, rhs flat.Node, v_type types.Type, c_type string) {
+	if rhs.kind == .int_literal && rhs.value == '0' && g.is_aggregate_zero_init_type(v_type, c_type) {
+		g.write('{0}')
+		return
+	}
+	g.gen_expr(rhs_id)
 }
 
 fn (mut g FlatGen) gen_multi_return_decl(node flat.Node) {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -761,7 +761,7 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 			}
 			g.gen_decl_lhs(lhs_id)
 			g.write(' = ')
-			g.gen_decl_init_expr(rhs_id, rhs, v_type, ct)
+			g.gen_decl_init_expr(rhs_id, rhs, v_type, ct, !lhs_is_defer_capture)
 			g.writeln(';')
 			if lhs.kind == .ident {
 				g.tc.cur_scope.insert(lhs.value, v_type)
@@ -771,9 +771,13 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 	}
 }
 
-fn (mut g FlatGen) gen_decl_init_expr(rhs_id flat.NodeId, rhs flat.Node, v_type types.Type, c_type string) {
+fn (mut g FlatGen) gen_decl_init_expr(rhs_id flat.NodeId, rhs flat.Node, v_type types.Type, c_type string, is_declaration bool) {
 	if rhs.kind == .int_literal && rhs.value == '0' && g.is_aggregate_zero_init_type(v_type, c_type) {
-		g.write('{0}')
+		if is_declaration {
+			g.write('{0}')
+		} else {
+			g.write('(${c_type}){0}')
+		}
 		return
 	}
 	g.gen_expr(rhs_id)

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -524,6 +524,42 @@ fn (g &FlatGen) is_aggregate_zero_init_type(typ types.Type, c_type string) bool 
 	}
 }
 
+fn (mut g FlatGen) can_use_global_brace_zero_init(typ types.Type, c_type string) bool {
+	return g.is_aggregate_zero_init_type(typ, c_type) && !g.has_zero_sized_leading_init_slot(typ)
+}
+
+fn (mut g FlatGen) has_zero_sized_leading_init_slot(typ types.Type) bool {
+	mut visited := map[string]bool{}
+	return g.has_zero_sized_leading_init_slot_inner(typ, mut visited)
+}
+
+fn (mut g FlatGen) has_zero_sized_leading_init_slot_inner(typ types.Type, mut visited map[string]bool) bool {
+	return match typ {
+		types.Alias {
+			g.has_zero_sized_leading_init_slot_inner(typ.base_type, mut visited)
+		}
+		types.ArrayFixed {
+			if g.fixed_array_len_value(typ) == '0' {
+				true
+			} else {
+				g.has_zero_sized_leading_init_slot_inner(typ.elem_type, mut visited)
+			}
+		}
+		types.Struct {
+			if typ.name in visited {
+				false
+			} else {
+				visited[typ.name] = true
+				first := g.struct_field_at(typ.name, 0) or { return false }
+				g.has_zero_sized_leading_init_slot_inner(first.typ, mut visited)
+			}
+		}
+		else {
+			false
+		}
+	}
+}
+
 fn (g &FlatGen) scalar_zero_init(c_type string) string {
 	if c_type in ['float', 'double'] {
 		return '0.0'

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -506,6 +506,24 @@ fn (g &FlatGen) is_scalar_c_type(c_type string) bool {
 		'int', 'isize', 'usize', 'size_t', 'ptrdiff_t', 'float', 'double', 'voidptr']
 }
 
+fn (g &FlatGen) is_aggregate_zero_init_type(typ types.Type, c_type string) bool {
+	if g.is_scalar_c_type(c_type) {
+		return false
+	}
+	return match typ {
+		types.Alias {
+			g.is_aggregate_zero_init_type(typ.base_type, c_type)
+		}
+		types.Array, types.ArrayFixed, types.Channel, types.Map, types.String, types.Struct,
+		types.Interface, types.SumType, types.OptionType, types.ResultType, types.MultiReturn {
+			true
+		}
+		else {
+			false
+		}
+	}
+}
+
 fn (g &FlatGen) scalar_zero_init(c_type string) string {
 	if c_type in ['float', 'double'] {
 		return '0.0'

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -546,12 +546,29 @@ fn (mut g FlatGen) has_zero_sized_leading_init_slot_inner(typ types.Type, mut vi
 			}
 		}
 		types.Struct {
-			if typ.name in visited {
-				false
+			if info := g.find_struct_decl(typ.name) {
+				if info.full_name in visited {
+					false
+				} else {
+					visited[info.full_name] = true
+					old_module := g.tc.cur_module
+					g.tc.cur_module = info.module
+					first := g.struct_field_at(info.full_name, 0) or {
+						g.tc.cur_module = old_module
+						return false
+					}
+					has := g.has_zero_sized_leading_init_slot_inner(first.typ, mut visited)
+					g.tc.cur_module = old_module
+					has
+				}
 			} else {
-				visited[typ.name] = true
-				first := g.struct_field_at(typ.name, 0) or { return false }
-				g.has_zero_sized_leading_init_slot_inner(first.typ, mut visited)
+				if typ.name in visited {
+					false
+				} else {
+					visited[typ.name] = true
+					first := g.struct_field_at(typ.name, 0) or { return false }
+					g.has_zero_sized_leading_init_slot_inner(first.typ, mut visited)
+				}
 			}
 		}
 		else {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -539,7 +539,7 @@ fn (mut g FlatGen) has_zero_sized_leading_init_slot_inner(typ types.Type, mut vi
 			g.has_zero_sized_leading_init_slot_inner(typ.base_type, mut visited)
 		}
 		types.ArrayFixed {
-			if g.fixed_array_len_value(typ) == '0' {
+			if g.fixed_array_len_is_zero(typ) {
 				true
 			} else {
 				g.has_zero_sized_leading_init_slot_inner(typ.elem_type, mut visited)

--- a/vlib/v3/tests/c_global_static_codegen_test.v
+++ b/vlib/v3/tests/c_global_static_codegen_test.v
@@ -1,4 +1,5 @@
 import os
+import v3.flat
 import v3.gen.c as cgen
 import v3.markused
 import v3.parser
@@ -20,6 +21,43 @@ fn gen_c_for_source(name string, source string) string {
 	assert tc.errors.len == 0, tc.errors.str()
 	transform.transform(mut a, &tc)
 	tc.annotate_types()
+	used_fns := markused.mark_used(a, tc)
+	mut g := cgen.FlatGen.new()
+	return g.gen_with_used_options(a, used_fns, &tc, true)
+}
+
+fn gen_c_for_source_with_scalar_zero_decl(name string, source string, decl_name string, decl_type string) string {
+	src := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	os.write_file(src, source) or { panic(err) }
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_file(src)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.diagnose_unknown_calls = true
+	tc.diagnostic_files[src] = true
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	transform.transform(mut a, &tc)
+	tc.annotate_types()
+	zero_id := a.add_node(flat.Node{
+		kind:  .int_literal
+		value: '0'
+	})
+	mut patched := false
+	for i, node in a.nodes {
+		if node.kind != .decl_assign || node.children_count != 2 {
+			continue
+		}
+		lhs_id := a.child(&node, 0)
+		lhs := a.nodes[int(lhs_id)]
+		if lhs.kind == .ident && lhs.value == decl_name {
+			a.nodes[i].typ = decl_type
+			a.children[int(node.children_start) + 1] = zero_id
+			patched = true
+		}
+	}
+	assert patched
 	used_fns := markused.mark_used(a, tc)
 	mut g := cgen.FlatGen.new()
 	return g.gen_with_used_options(a, used_fns, &tc, true)
@@ -50,4 +88,40 @@ fn main() {
 }
 ')
 	assert c_code.contains('static int x = 0;')
+}
+
+fn test_aggregate_globals_are_brace_zero_initialized() {
+	c_code := gen_c_for_source('aggregate_global_zero_init', 'struct Box {
+	value int
+}
+
+__global (
+	names []string
+	lookup map[string]int
+	box Box
+)
+
+fn main() {}
+')
+	assert c_code.contains('Array names = {0};')
+	assert c_code.contains('map lookup = {0};')
+	assert c_code.contains('Box box = {0};')
+	assert !c_code.contains('Array names = 0;')
+	assert !c_code.contains('map lookup = 0;')
+	assert !c_code.contains('Box box = 0;')
+}
+
+fn test_aggregate_decl_with_scalar_zero_uses_brace_initializer() {
+	c_code := gen_c_for_source_with_scalar_zero_decl('aggregate_decl_scalar_zero', 'struct Box {
+	value int
+}
+
+fn main() {
+	box := Box{}
+	_ = box.value
+}
+',
+		'box', 'Box')
+	assert c_code.contains('Box box = {0};'), c_code
+	assert !c_code.contains('Box box = 0;')
 }

--- a/vlib/v3/tests/c_global_static_codegen_test.v
+++ b/vlib/v3/tests/c_global_static_codegen_test.v
@@ -95,12 +95,25 @@ fn test_aggregate_globals_are_brace_zero_initialized() {
 	value int
 }
 
+struct ZeroLeading {
+	z [0]int
+	value int
+}
+
+struct NestedZeroLeading {
+	zero ZeroLeading
+	value int
+}
+
 __global (
 	names []string
 	lookup map[string]int
 	box Box
 	empty [0]int
 	slots [2]int
+	zero ZeroLeading
+	nested NestedZeroLeading
+	zero_slots [2]ZeroLeading
 )
 
 fn main() {}
@@ -110,10 +123,16 @@ fn main() {}
 	assert c_code.contains('Box box = {0};')
 	assert c_code.contains('int empty[0];')
 	assert c_code.contains('int slots[2] = {0};')
+	assert c_code.contains('\nZeroLeading zero;\n')
+	assert c_code.contains('\nNestedZeroLeading nested;\n')
+	assert c_code.contains('\nZeroLeading zero_slots[2];\n')
 	assert !c_code.contains('Array names = 0;')
 	assert !c_code.contains('map lookup = 0;')
 	assert !c_code.contains('Box box = 0;')
 	assert !c_code.contains('int empty[0] = {0};')
+	assert !c_code.contains('ZeroLeading zero = {0};')
+	assert !c_code.contains('NestedZeroLeading nested = {0};')
+	assert !c_code.contains('ZeroLeading zero_slots[2] = {0};')
 }
 
 fn test_aggregate_decl_with_scalar_zero_uses_brace_initializer() {

--- a/vlib/v3/tests/c_global_static_codegen_test.v
+++ b/vlib/v3/tests/c_global_static_codegen_test.v
@@ -99,6 +99,8 @@ __global (
 	names []string
 	lookup map[string]int
 	box Box
+	empty [0]int
+	slots [2]int
 )
 
 fn main() {}
@@ -106,9 +108,12 @@ fn main() {}
 	assert c_code.contains('Array names = {0};')
 	assert c_code.contains('map lookup = {0};')
 	assert c_code.contains('Box box = {0};')
+	assert c_code.contains('int empty[0];')
+	assert c_code.contains('int slots[2] = {0};')
 	assert !c_code.contains('Array names = 0;')
 	assert !c_code.contains('map lookup = 0;')
 	assert !c_code.contains('Box box = 0;')
+	assert !c_code.contains('int empty[0] = {0};')
 }
 
 fn test_aggregate_decl_with_scalar_zero_uses_brace_initializer() {

--- a/vlib/v3/tests/c_global_static_codegen_test.v
+++ b/vlib/v3/tests/c_global_static_codegen_test.v
@@ -125,3 +125,20 @@ fn main() {
 	assert c_code.contains('Box box = {0};'), c_code
 	assert !c_code.contains('Box box = 0;')
 }
+
+fn test_defer_capture_aggregate_decl_with_scalar_zero_uses_compound_literal() {
+	c_code := gen_c_for_source_with_scalar_zero_decl('defer_capture_aggregate_decl_scalar_zero', 'struct Box {
+	value int
+}
+
+fn main() {
+	box := Box{}
+	defer(fn) {
+		_ = box.value
+	}
+}
+',
+		'box', 'Box')
+	assert c_code.contains('box = (Box){0};'), c_code
+	assert !c_code.contains('box = {0};')
+}

--- a/vlib/v3/tests/c_global_static_codegen_test.v
+++ b/vlib/v3/tests/c_global_static_codegen_test.v
@@ -26,6 +26,39 @@ fn gen_c_for_source(name string, source string) string {
 	return g.gen_with_used_options(a, used_fns, &tc, true)
 }
 
+fn gen_c_for_sources(name string, files map[string]string) string {
+	root := os.join_path(os.temp_dir(), 'v3_${name}')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(root) or { panic(err) }
+	mut paths := []string{}
+	mut rels := files.keys()
+	rels.sort()
+	for rel in rels {
+		path := os.join_path(root, rel)
+		os.mkdir_all(os.dir(path)) or { panic(err) }
+		os.write_file(path, files[rel]) or { panic(err) }
+		paths << path
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_files(paths)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.diagnose_unknown_calls = true
+	for path in paths {
+		tc.diagnostic_files[path] = true
+	}
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	transform.transform(mut a, &tc)
+	tc.annotate_types()
+	used_fns := markused.mark_used(a, tc)
+	mut g := cgen.FlatGen.new()
+	return g.gen_with_used_options(a, used_fns, &tc, true)
+}
+
 fn gen_c_for_source_with_scalar_zero_decl(name string, source string, decl_name string, decl_type string) string {
 	src := os.join_path(os.temp_dir(), 'v3_${name}.v')
 	os.write_file(src, source) or { panic(err) }
@@ -149,6 +182,33 @@ fn main() {}
 	assert !c_code.contains('int const_empty[(1) - (1)] = {0};')
 	assert !c_code.contains('ZeroLeadingConst const_zero = {0};')
 	assert !c_code.contains('ZeroLeadingConst const_zero_slots[2] = {0};')
+}
+
+fn test_imported_zero_length_leading_field_global_uses_decl_only() {
+	c_code := gen_c_for_sources('imported_zero_leading_global', {
+		'main.v':      'module main
+
+import moda
+
+__global imported moda.ImportedZero
+__global imported_slots [2]moda.ImportedZero
+
+fn main() {}
+'
+		'moda/moda.v': 'module moda
+
+const zero_len = 1 - 1
+
+pub struct ImportedZero {
+	z [zero_len]int
+	value int
+}
+'
+	})
+	assert c_code.contains('\nmoda__ImportedZero imported;\n')
+	assert c_code.contains('\nmoda__ImportedZero imported_slots[2];\n')
+	assert !c_code.contains('moda__ImportedZero imported = {0};')
+	assert !c_code.contains('moda__ImportedZero imported_slots[2] = {0};')
 }
 
 fn test_aggregate_decl_with_scalar_zero_uses_brace_initializer() {

--- a/vlib/v3/tests/c_global_static_codegen_test.v
+++ b/vlib/v3/tests/c_global_static_codegen_test.v
@@ -91,7 +91,9 @@ fn main() {
 }
 
 fn test_aggregate_globals_are_brace_zero_initialized() {
-	c_code := gen_c_for_source('aggregate_global_zero_init', 'struct Box {
+	c_code := gen_c_for_source('aggregate_global_zero_init', 'const zero_len = 1 - 1
+
+struct Box {
 	value int
 }
 
@@ -105,6 +107,11 @@ struct NestedZeroLeading {
 	value int
 }
 
+struct ZeroLeadingConst {
+	z [zero_len]int
+	value int
+}
+
 __global (
 	names []string
 	lookup map[string]int
@@ -114,6 +121,9 @@ __global (
 	zero ZeroLeading
 	nested NestedZeroLeading
 	zero_slots [2]ZeroLeading
+	const_empty [zero_len]int
+	const_zero ZeroLeadingConst
+	const_zero_slots [2]ZeroLeadingConst
 )
 
 fn main() {}
@@ -126,6 +136,9 @@ fn main() {}
 	assert c_code.contains('\nZeroLeading zero;\n')
 	assert c_code.contains('\nNestedZeroLeading nested;\n')
 	assert c_code.contains('\nZeroLeading zero_slots[2];\n')
+	assert c_code.contains('\nint const_empty[(1) - (1)];\n')
+	assert c_code.contains('\nZeroLeadingConst const_zero;\n')
+	assert c_code.contains('\nZeroLeadingConst const_zero_slots[2];\n')
 	assert !c_code.contains('Array names = 0;')
 	assert !c_code.contains('map lookup = 0;')
 	assert !c_code.contains('Box box = 0;')
@@ -133,6 +146,9 @@ fn main() {}
 	assert !c_code.contains('ZeroLeading zero = {0};')
 	assert !c_code.contains('NestedZeroLeading nested = {0};')
 	assert !c_code.contains('ZeroLeading zero_slots[2] = {0};')
+	assert !c_code.contains('int const_empty[(1) - (1)] = {0};')
+	assert !c_code.contains('ZeroLeadingConst const_zero = {0};')
+	assert !c_code.contains('ZeroLeadingConst const_zero_slots[2] = {0};')
 }
 
 fn test_aggregate_decl_with_scalar_zero_uses_brace_initializer() {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -3763,7 +3763,8 @@ fn (tc &TypeChecker) fixed_array_lengths_compatible(actual ArrayFixed, expected 
 	return actual_len == expected_len
 }
 
-fn (tc &TypeChecker) fixed_array_len_value(arr ArrayFixed) ?int {
+// fixed_array_len_value returns the evaluated fixed-array length when it can be resolved.
+pub fn (tc &TypeChecker) fixed_array_len_value(arr ArrayFixed) ?int {
 	if arr.len > 0 {
 		return arr.len
 	}


### PR DESCRIPTION
## Summary
- emit explicit `{0}` initializers for aggregate v3 C globals when safe
- skip explicit brace-zero initializers for zero-length fixed-array globals and aggregate globals whose first initializer slot is zero-sized, including evaluated const/expression fixed-array lengths
- preserve declaring-module context while checking globals and imported struct fields for zero-sized leading slots
- guard declaration codegen so aggregate declarations with a scalar zero RHS emit `{0}` instead of invalid `= 0`
- add v3 C codegen regression coverage for aggregate globals and cached/synthetic scalar-zero aggregate declarations

## Fixed Issues
- Fixes #27492

## Tests
- `./vnew fmt -w vlib/v3/gen/c/struct.v vlib/v3/gen/c/cleanc.v vlib/v3/gen/c/stmt.v vlib/v3/types/checker.v vlib/v3/tests/c_global_static_codegen_test.v`
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent test vlib/v3/tests/c_global_static_codegen_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v3/gen/c/`
- `git diff --check`

## Broader test notes
- `./vnew -silent test vlib/v3/` still has unrelated existing failures in `vlib/v3/tests/generics_test.v` and `vlib/v3/tests/type_checker_errors_test.v` (`transitive_module_init_order` emits an undeclared `modb__value`).
- `./vnew -silent test vlib/v/` was stopped after unrelated failures in interpreter/eval paths and builder tests affected by tcc fallback warning output.