### PR TITLE
v3: codegen correctness fixes (enum `${}`, `&T{}` heap, generics, interfaces)

### DIFF
--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -388,7 +388,10 @@ fn (mut g FlatGen) gen_thread_array_wait(base_id flat.NodeId, is_ptr bool, elem_
 // heap-returned value into a result `[]T` (freeing the per-thread allocation).
 fn (mut g FlatGen) ensure_thread_arr_wait_fn(ret_name string) string {
 	is_void := ret_name.len == 0
-	ret_ct := if is_void { 'void' } else { g.tc.c_type(g.tc.parse_type(ret_name)) }
+	// Match the ABI return type the spawn wrapper stores (gen_spawn_expr): an
+	// option/result payload is `Optional_T`, a fixed-array payload its `_v_ret_*`
+	// wrapper — not the bare `c_type`, or the malloc'd and read-back layouts diverge.
+	ret_ct := if is_void { 'void' } else { g.fn_return_type_name(g.tc.parse_type(ret_name)) }
 	key := 'threadwait|${ret_ct}'
 	if name := g.spawn_wrapper_names[key] {
 		return name

--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -56,7 +56,12 @@ fn (mut g FlatGen) gen_array_literal_value(node flat.Node, elem_type types.Type)
 		if i > 0 {
 			g.write(', ')
 		}
-		g.gen_expr(g.a.child(&node, i))
+		// Emit each element against the concrete element type, not the enclosing
+		// `expected_expr_type` (which is the whole array). A bare generic struct element
+		// (`Box{..}` in a `[]Box[int]` literal) otherwise sees the array type, fails the
+		// `generic_struct_init_instance_type` array skip, and is emitted as the bare `Box`
+		// while the array storage is `Box_int` — incompatible C.
+		g.gen_expr_with_expected_type(g.a.child(&node, i), elem_type)
 	}
 	g.write('})')
 }

--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -393,7 +393,10 @@ fn (mut g FlatGen) ensure_thread_arr_wait_fn(ret_name string) string {
 	if name := g.spawn_wrapper_names[key] {
 		return name
 	}
-	name := c_name('__v_thread_arr_wait_${ret_ct}')
+	// Sanitize the payload C type (`Foo*`, `void*`, ...) into an identifier fragment
+	// — `c_name` does not strip `*`, so a raw pointer return type would otherwise put
+	// an asterisk in the helper symbol.
+	name := c_name('__v_thread_arr_wait_${types.c_type_name_part(ret_ct)}')
 	g.spawn_wrapper_names[key] = name
 	if is_void {
 		g.spawn_wrapper_defs << 'static void ${name}(Array a) { for (int __i = 0; __i < a.len; __i++) { void* __r = NULL; pthread_join((pthread_t)(((void**)a.data)[__i]), &__r); if (__r) free(__r); } }'

--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -110,6 +110,15 @@ fn (mut g FlatGen) gen_fixed_array_data_arg(id flat.NodeId, arr types.ArrayFixed
 			return
 		}
 	}
+	// A fixed-array value (e.g. `[4]u8` color) is sometimes represented as a dynamic
+	// `Array`; a C fixed-array parameter decays to `elem*`, so pass the data pointer.
+	if g.tc.resolve_type(id) is types.Array {
+		elem_ct := g.tc.c_type(arr.elem_type)
+		g.write('(${elem_ct}*)(')
+		g.gen_expr(id)
+		g.write(').data')
+		return
+	}
 	g.gen_expr(id)
 }
 
@@ -321,6 +330,11 @@ fn (mut g FlatGen) gen_array_method_call(node flat.Node, fn_node &flat.Node, arr
 			g.gen_expr(g.a.child(&node, 1))
 			g.write(')')
 		}
+		'wait' {
+			// `[]thread T .wait()` joins every spawned thread and (for non-void T)
+			// collects their return values into a fresh `[]T`.
+			g.gen_thread_array_wait(base_id, is_ptr, arr.elem_type)
+		}
 		else {
 			best_mname := g.array_method_fallback(fn_node.value)
 			if best_mname.len > 0 {
@@ -347,6 +361,46 @@ fn (mut g FlatGen) gen_array_method_call(node flat.Node, fn_node &flat.Node, arr
 			}
 		}
 	}
+}
+
+// gen_thread_array_wait emits a call to the (lazily generated) wait function for a
+// `[]thread T` receiver. The element type carries the thread's return type in its
+// name (`thread T`); a bare `thread` denotes a void payload.
+fn (mut g FlatGen) gen_thread_array_wait(base_id flat.NodeId, is_ptr bool, elem_type types.Type) {
+	mut ret_name := ''
+	if elem_type is types.Struct {
+		trimmed := elem_type.name.trim_space()
+		if trimmed != 'thread' && trimmed.starts_with('thread ') {
+			ret_name = trimmed[7..].trim_space()
+		}
+	}
+	fn_name := g.ensure_thread_arr_wait_fn(ret_name)
+	g.write('${fn_name}(')
+	if is_ptr {
+		g.write('*')
+	}
+	g.gen_expr(base_id)
+	g.write(')')
+}
+
+// ensure_thread_arr_wait_fn registers (once per payload type) a function that joins
+// every thread handle in the array and, for a non-void payload, copies each thread's
+// heap-returned value into a result `[]T` (freeing the per-thread allocation).
+fn (mut g FlatGen) ensure_thread_arr_wait_fn(ret_name string) string {
+	is_void := ret_name.len == 0
+	ret_ct := if is_void { 'void' } else { g.tc.c_type(g.tc.parse_type(ret_name)) }
+	key := 'threadwait|${ret_ct}'
+	if name := g.spawn_wrapper_names[key] {
+		return name
+	}
+	name := c_name('__v_thread_arr_wait_${ret_ct}')
+	g.spawn_wrapper_names[key] = name
+	if is_void {
+		g.spawn_wrapper_defs << 'static void ${name}(Array a) { for (int __i = 0; __i < a.len; __i++) { void* __r = NULL; pthread_join((pthread_t)(((void**)a.data)[__i]), &__r); if (__r) free(__r); } }'
+	} else {
+		g.spawn_wrapper_defs << 'static Array ${name}(Array a) { Array __res = array_new(sizeof(${ret_ct}), a.len, a.len); for (int __i = 0; __i < a.len; __i++) { void* __r = NULL; pthread_join((pthread_t)(((void**)a.data)[__i]), &__r); if (__r) { ((${ret_ct}*)__res.data)[__i] = *(${ret_ct}*)__r; free(__r); } } return __res; }'
+	}
+	return name
 }
 
 // array_lookup_suffix supports array lookup suffix handling for c.

--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -331,35 +331,57 @@ fn (mut g FlatGen) gen_array_method_call(node flat.Node, fn_node &flat.Node, arr
 			g.write(')')
 		}
 		'wait' {
-			// `[]thread T .wait()` joins every spawned thread and (for non-void T)
-			// collects their return values into a fresh `[]T`.
-			g.gen_thread_array_wait(base_id, is_ptr, arr.elem_type)
-		}
-		else {
-			best_mname := g.array_method_fallback(fn_node.value)
-			if best_mname.len > 0 {
-				g.write(c_name(best_mname))
-				g.write('(')
-				ptypes := g.tc.fn_param_types[best_mname]
-				wants_ptr := ptypes.len > 0 && ptypes[0] is types.Pointer
-				if wants_ptr && !is_ptr {
-					g.write('&')
-				} else if !wants_ptr && is_ptr {
-					g.write('*')
-				}
-				g.gen_expr(base_id)
-				for i in 1 .. node.children_count {
-					g.write(', ')
-					g.gen_expr(g.a.child(&node, i))
-				}
-				g.write(')')
+			// Only a thread array supports `.wait()` (joining every spawned thread and,
+			// for non-void payloads, collecting their return values into a fresh `[]T`).
+			// The element carries the thread payload in its name (`thread`/`thread T`).
+			// Any other element type is not a thread, so route it through the normal
+			// method fallback instead of joining arbitrary array data as pthread_t handles.
+			mut is_thread := false
+			elem := arr.elem_type
+			if elem is types.Struct {
+				tn := elem.name.trim_space()
+				is_thread = tn == 'thread' || tn.starts_with('thread ')
+			}
+			if is_thread {
+				g.gen_thread_array_wait(base_id, is_ptr, arr.elem_type)
 			} else {
-				g.gen_expr(g.a.child(&node, 0))
-				g.write('(')
-				g.gen_expr(base_id)
-				g.write(')')
+				g.gen_array_method_call_fallback(node, fn_node.value, base_id, is_ptr)
 			}
 		}
+		else {
+			g.gen_array_method_call_fallback(node, fn_node.value, base_id, is_ptr)
+		}
+	}
+}
+
+// gen_array_method_call_fallback emits a call for an array method that has no dedicated
+// codegen arm: it resolves a `[]T.method` function when one is registered, and otherwise
+// emits the selector itself as a direct call. Shared by the catch-all `else` arm and by
+// `.wait()` on non-thread arrays (which is unsupported and falls through here rather than
+// joining elements as thread handles).
+fn (mut g FlatGen) gen_array_method_call_fallback(node flat.Node, mname string, base_id flat.NodeId, is_ptr bool) {
+	best_mname := g.array_method_fallback(mname)
+	if best_mname.len > 0 {
+		g.write(c_name(best_mname))
+		g.write('(')
+		ptypes := g.tc.fn_param_types[best_mname]
+		wants_ptr := ptypes.len > 0 && ptypes[0] is types.Pointer
+		if wants_ptr && !is_ptr {
+			g.write('&')
+		} else if !wants_ptr && is_ptr {
+			g.write('*')
+		}
+		g.gen_expr(base_id)
+		for i in 1 .. node.children_count {
+			g.write(', ')
+			g.gen_expr(g.a.child(&node, i))
+		}
+		g.write(')')
+	} else {
+		g.gen_expr(g.a.child(&node, 0))
+		g.write('(')
+		g.gen_expr(base_id)
+		g.write(')')
 	}
 }
 

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2820,7 +2820,8 @@ fn (mut g FlatGen) fixed_array_typedefs() {
 		if fixed_array_typedef_is_early(info.arr) {
 			continue
 		}
-		g.emit_fixed_array_ret_wrapper(name, info)
+		// Completes the struct forward-declared in fixed_array_early_typedefs().
+		g.emit_fixed_array_ret_wrapper(name, info, true)
 		emitted_wrapper = true
 	}
 	if g.emitted_fixed_array_typedefs.len > old_len || emitted_wrapper {
@@ -2856,14 +2857,30 @@ fn (mut g FlatGen) populate_fixed_array_ret_wrappers() {
 
 // emit_fixed_array_ret_wrapper writes the one-field `struct { T ret_arr[N]; }` wrapper
 // for a fixed-array return type. The element type's C definition must already be emitted.
-fn (mut g FlatGen) emit_fixed_array_ret_wrapper(name string, info FixedArrayTypedefInfo) {
+// `tagged` completes a previously forward-declared named struct (`struct X { ... };`),
+// used for non-early element types whose wrapper is referenced by an fn-pointer typedef
+// emitted earlier; otherwise a fresh anonymous typedef is written.
+fn (mut g FlatGen) emit_fixed_array_ret_wrapper(name string, info FixedArrayTypedefInfo, tagged bool) {
 	arr := info.arr
 	old_module := g.tc.cur_module
 	g.tc.cur_module = info.module
 	elem_ct := g.tc.c_type(arr.elem_type)
 	len_expr := g.fixed_array_len_value(arr)
 	g.tc.cur_module = old_module
-	g.writeln('typedef struct { ${elem_ct} ret_arr[${len_expr}]; } ${fixed_array_ret_wrapper_name(name)};')
+	wname := fixed_array_ret_wrapper_name(name)
+	if tagged {
+		g.writeln('struct ${wname} { ${elem_ct} ret_arr[${len_expr}]; };')
+	} else {
+		g.writeln('typedef struct { ${elem_ct} ret_arr[${len_expr}]; } ${wname};')
+	}
+}
+
+// emit_fixed_array_ret_wrapper_forward forward-declares a named return-wrapper struct so an
+// fn-pointer typedef can name it as a (by-value) return type before the wrapper's element
+// type is defined; the struct body is completed later by emit_fixed_array_ret_wrapper.
+fn (mut g FlatGen) emit_fixed_array_ret_wrapper_forward(name string) {
+	wname := fixed_array_ret_wrapper_name(name)
+	g.writeln('typedef struct ${wname} ${wname};')
 }
 
 // fixed_array_early_typedefs emits, before the fn-ptr typedef block, the bare
@@ -2890,18 +2907,21 @@ fn (mut g FlatGen) fixed_array_early_typedefs() {
 		g.emit_fixed_array_typedef(name, info, needed, mut g.emitted_fixed_array_typedefs)
 		emitted_any = true
 	}
-	// Wrapper structs for fixed-array return types whose element chain is already complete
-	// here (primitive/pointer/enum). Struct/`string`/nested element wrappers are deferred
-	// to fixed_array_typedefs(), after the element definitions are emitted.
+	// Wrapper structs for fixed-array return types. Primitive/pointer/enum element wrappers
+	// are fully defined here. Struct/`string`/nested element wrappers can't be defined yet
+	// (their element type comes later), but an fn-pointer typedef in the next block may name
+	// one as a return type, so forward-declare the named struct now and complete it in
+	// fixed_array_typedefs(), after the element definitions.
 	for name in names {
 		if name !in g.fixed_array_ret_wrappers {
 			continue
 		}
 		info := needed[name] or { continue }
-		if !fixed_array_typedef_is_early(info.arr) {
-			continue
+		if fixed_array_typedef_is_early(info.arr) {
+			g.emit_fixed_array_ret_wrapper(name, info, false)
+		} else {
+			g.emit_fixed_array_ret_wrapper_forward(name)
 		}
-		g.emit_fixed_array_ret_wrapper(name, info)
 		emitted_any = true
 	}
 	if emitted_any {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2951,7 +2951,14 @@ fn (mut g FlatGen) fn_return_type_name(t types.Type) string {
 			return fixed_array_ret_wrapper_name(bare)
 		}
 	}
-	return g.optional_type_name(t)
+	ct := g.optional_type_name(t)
+	// A function/fn-ptr-valued return (`fn f() fn () int`) has the internal `fn_ptr:...`
+	// encoding for its C type; map it to the shared `_fn_ptr_N` typedef, since a C function
+	// cannot be declared returning that raw encoding (it would emit invalid C).
+	if ct.starts_with('fn_ptr:') {
+		return g.resolve_fn_ptr_type(ct)
+	}
+	return ct
 }
 
 // fn_ptr_return_ct maps a fixed-array return c_type name (string form, used by the

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -571,7 +571,51 @@ fn c_flag_arg(raw string, vroot string, source_file string) string {
 	if clean.len == 0 {
 		return ''
 	}
-	return c_resolve_pseudo_paths(clean, vroot, source_file)
+	resolved := c_resolve_pseudo_paths(clean, vroot, source_file)
+	return c_resolve_relative_flag_paths(resolved, source_file)
+}
+
+// c_resolve_relative_flag_paths rewrites relative path arguments in a `#flag`
+// directive (e.g. `-I ./thirdparty`, or a bare `./foo.c`) to absolute paths,
+// resolved against the directory of the source file that carried the directive.
+// V1 does the same: a project's `#flag` paths are relative to its own module dir,
+// not to the compiler's build/working directory.
+fn c_resolve_relative_flag_paths(flag string, source_file string) string {
+	if source_file.len == 0 || !flag.contains('/') {
+		return flag
+	}
+	base_dir := os.dir(source_file)
+	if base_dir.len == 0 {
+		return flag
+	}
+	mut out := []string{}
+	for tok in flag.fields() {
+		out << c_resolve_flag_path_token(tok, base_dir)
+	}
+	return out.join(' ')
+}
+
+fn c_resolve_flag_path_token(tok string, base_dir string) string {
+	for prefix in ['-I', '-L'] {
+		if tok.starts_with(prefix) && tok.len > prefix.len {
+			path := tok[prefix.len..]
+			if c_flag_path_is_relative(path) {
+				return prefix + os.real_path(os.join_path_single(base_dir, path))
+			}
+			return tok
+		}
+	}
+	if !tok.starts_with('-') && c_flag_path_is_relative(tok) {
+		return os.real_path(os.join_path_single(base_dir, tok))
+	}
+	return tok
+}
+
+fn c_flag_path_is_relative(p string) bool {
+	if p.len == 0 || os.is_abs_path(p) {
+		return false
+	}
+	return p.starts_with('./') || p.starts_with('../') || p.contains('/')
 }
 
 fn c_directive_arg_for_target(raw string) ?string {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -58,18 +58,22 @@ mut:
 	cur_fn_ret                   types.Type = types.Type(types.void_)
 	cur_fn_ret_is_optional       bool
 	cur_fn_ret_base              types.Type = types.Type(types.void_)
-	expected_expr_type           types.Type = types.Type(types.void_)
-	expected_enum                string
-	needed_optional_types        map[string]string
-	emitted_optional_types       map[string]bool
-	emitted_fns                  map[string]bool
-	array_method_cache           map[string]string
-	param_types_cache            map[string][]types.Type        // (name|fallback) -> resolved param types
-	embedded_fields_by_type      map[string][]types.StructField // type name -> its embedded fields (usually empty)
-	param_types_by_short         map[string][]types.Type        // method short-name suffix -> param types (fallback index)
-	spawn_wrapper_names          map[string]string
-	spawn_wrapper_defs           []string
-	parallel_used                bool
+	// in_return is true only while generating a `return` statement's value, so a bare
+	// generic literal (`return Box{...}`) may adopt `cur_fn_ret`'s concrete instance —
+	// but a literal in a local decl / argument elsewhere in the body does not.
+	in_return               bool
+	expected_expr_type      types.Type = types.Type(types.void_)
+	expected_enum           string
+	needed_optional_types   map[string]string
+	emitted_optional_types  map[string]bool
+	emitted_fns             map[string]bool
+	array_method_cache      map[string]string
+	param_types_cache       map[string][]types.Type        // (name|fallback) -> resolved param types
+	embedded_fields_by_type map[string][]types.StructField // type name -> its embedded fields (usually empty)
+	param_types_by_short    map[string][]types.Type        // method short-name suffix -> param types (fallback index)
+	spawn_wrapper_names     map[string]string
+	spawn_wrapper_defs      []string
+	parallel_used           bool
 }
 
 struct FixedArrayTypedefInfo {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2800,7 +2800,28 @@ fn (mut g FlatGen) fixed_array_typedefs() {
 	for name, info in needed {
 		g.emit_fixed_array_typedef(name, info, needed, mut g.emitted_fixed_array_typedefs)
 	}
-	if g.emitted_fixed_array_typedefs.len > old_len {
+	// Return wrappers for non-early element types (struct/`string`/nested fixed array):
+	// their bare typedef (above) and element definitions are available now, so a C
+	// function returning `[N]Foo`/`[N]string` can return the wrapper struct instead of the
+	// raw array type C rejects. Sorted for deterministic output.
+	mut wrapper_names := []string{}
+	for name, _ in needed {
+		wrapper_names << name
+	}
+	wrapper_names.sort()
+	mut emitted_wrapper := false
+	for name in wrapper_names {
+		if name !in g.fixed_array_ret_wrappers {
+			continue
+		}
+		info := needed[name] or { continue }
+		if fixed_array_typedef_is_early(info.arr) {
+			continue
+		}
+		g.emit_fixed_array_ret_wrapper(name, info)
+		emitted_wrapper = true
+	}
+	if g.emitted_fixed_array_typedefs.len > old_len || emitted_wrapper {
 		g.writeln('')
 	}
 }
@@ -2819,19 +2840,28 @@ fn fixed_array_typedef_is_early(arr types.ArrayFixed) bool {
 // populate_fixed_array_ret_wrappers records which fixed-array types get a return
 // wrapper struct. It must run before function bodies are generated, so that fn
 // signatures, return statements and call sites all agree on whether a given
-// fixed-array return is wrapped. Only primitive/pointer/enum element types are
-// wrapped (their definitions precede the wrapper typedef block).
+// fixed-array return is wrapped. EVERY fixed-array type is wrapped, because C
+// functions and fn pointers cannot return a raw array type regardless of the element:
+// primitive/pointer/enum element wrappers are emitted early (before structs), while
+// struct/`string`/nested element wrappers are emitted by fixed_array_typedefs(), after
+// the element type is defined.
 fn (mut g FlatGen) populate_fixed_array_ret_wrappers() {
 	needed := g.collect_fixed_array_typedefs_needed()
-	for name, info in needed {
-		// Use the recursive early check so a nested fixed array (`[2][3]int`, whose
-		// `elem_type` is itself an `ArrayFixed`) is still wrapped: its chain bottoms out
-		// in a primitive/pointer/enum, so the bare typedefs are emitted early and a C
-		// function still cannot return the raw array type.
-		if fixed_array_typedef_is_early(info.arr) {
-			g.fixed_array_ret_wrappers[name] = true
-		}
+	for name, _ in needed {
+		g.fixed_array_ret_wrappers[name] = true
 	}
+}
+
+// emit_fixed_array_ret_wrapper writes the one-field `struct { T ret_arr[N]; }` wrapper
+// for a fixed-array return type. The element type's C definition must already be emitted.
+fn (mut g FlatGen) emit_fixed_array_ret_wrapper(name string, info FixedArrayTypedefInfo) {
+	arr := info.arr
+	old_module := g.tc.cur_module
+	g.tc.cur_module = info.module
+	elem_ct := g.tc.c_type(arr.elem_type)
+	len_expr := g.fixed_array_len_value(arr)
+	g.tc.cur_module = old_module
+	g.writeln('typedef struct { ${elem_ct} ret_arr[${len_expr}]; } ${fixed_array_ret_wrapper_name(name)};')
 }
 
 // fixed_array_early_typedefs emits, before the fn-ptr typedef block, the bare
@@ -2858,19 +2888,18 @@ fn (mut g FlatGen) fixed_array_early_typedefs() {
 		g.emit_fixed_array_typedef(name, info, needed, mut g.emitted_fixed_array_typedefs)
 		emitted_any = true
 	}
-	// Wrapper structs for fixed-array return types.
+	// Wrapper structs for fixed-array return types whose element chain is already complete
+	// here (primitive/pointer/enum). Struct/`string`/nested element wrappers are deferred
+	// to fixed_array_typedefs(), after the element definitions are emitted.
 	for name in names {
 		if name !in g.fixed_array_ret_wrappers {
 			continue
 		}
 		info := needed[name] or { continue }
-		arr := info.arr
-		old_module := g.tc.cur_module
-		g.tc.cur_module = info.module
-		elem_ct := g.tc.c_type(arr.elem_type)
-		len_expr := g.fixed_array_len_value(arr)
-		g.tc.cur_module = old_module
-		g.writeln('typedef struct { ${elem_ct} ret_arr[${len_expr}]; } ${fixed_array_ret_wrapper_name(name)};')
+		if !fixed_array_typedef_is_early(info.arr) {
+			continue
+		}
+		g.emit_fixed_array_ret_wrapper(name, info)
 		emitted_any = true
 	}
 	if emitted_any {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -905,6 +905,21 @@ fn (mut g FlatGen) interface_value_to_string(id flat.NodeId, expected types.Type
 	return result
 }
 
+// fixed_array_copy_source_string captures gen_fixed_array_copy_source as a string, so a deferred
+// optional/fixed-array return can embed the memcpy source when saving the value into a temp.
+fn (mut g FlatGen) fixed_array_copy_source_string(value_id flat.NodeId, field_type types.Type) string {
+	orig := g.sb
+	orig_line_start := g.line_start
+	g.sb = strings.new_builder(64)
+	// Emit mid-statement (no leading indent), matching the direct return path.
+	g.line_start = false
+	g.gen_fixed_array_copy_source(value_id, field_type)
+	result := g.sb.str()
+	g.sb = orig
+	g.line_start = orig_line_start
+	return result
+}
+
 // expr_to_string_with_expected_type converts expr to string with expected type data for c.
 fn (mut g FlatGen) expr_to_string_with_expected_type(id flat.NodeId, expected types.Type) string {
 	orig := g.sb

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -40,6 +40,7 @@ mut:
 	has_builtins            bool
 	tmp_count               int
 	line_start              bool
+	field_name_set          map[string]bool // every struct field's C name (lazy) — for const/field collision checks
 	modules                 map[string]string // alias -> full module name
 	fn_ptr_types            map[string]string // fn_ptr:ret|params -> typedef name
 	fixed_array_ret_wrappers map[string]bool // bare fixed-array c_type name -> has a return wrapper struct
@@ -340,6 +341,17 @@ fn (mut g FlatGen) collect_gen_info() {
 			include := '#include ${include_arg}'
 			if include !in g.c_includes {
 				g.c_includes << include
+			}
+			continue
+		}
+		if node.kind == .directive && node.value == 'define' && node.typ.len > 0 {
+			// `#define NAME [value]` from a `.c.v` file. Emit it into the same ordered
+			// include stream so a define that precedes an `#include` (e.g. viper's
+			// `#define GLFW_INCLUDE_GLCOREARB` before `<GLFW/glfw3.h>`, which selects the
+			// GL core-profile header that declares glGenVertexArrays/…) still does so.
+			define := '#define ${node.typ}'
+			if define !in g.c_includes {
+				g.c_includes << define
 			}
 			continue
 		}
@@ -1516,6 +1528,11 @@ fn (mut g FlatGen) fixed_array_len_expr(type_name string, fallback int) string {
 
 // fixed_array_len_value supports fixed array len value handling for FlatGen.
 fn (mut g FlatGen) fixed_array_len_value(arr types.ArrayFixed) string {
+	// Prefer the evaluated integer length: a const-expression size (`[segs + 1]f32`)
+	// otherwise reaches the raw fallback and is c_name-mangled into garbage.
+	if v := g.tc.fixed_array_len_value(arr) {
+		return v.str()
+	}
 	return g.fixed_array_len_raw(arr.len_expr, arr.len)
 }
 
@@ -1535,6 +1552,11 @@ fn (mut g FlatGen) fixed_array_len_raw(raw_len string, fallback int) string {
 	clean_len := raw_len.replace('_', '')
 	if clean_len.len > 0 && clean_len[0] >= `0` && clean_len[0] <= `9` {
 		return clean_len
+	}
+	// A const-expression size (`SEGS + 1`) evaluates to a literal; otherwise the whole
+	// string would be c_name-mangled (`SEGS_+_1`) into an undeclared identifier.
+	if v := g.tc.const_int_value(raw_len, []string{}) {
+		return v.str()
 	}
 	const_name := g.const_ref_name(raw_len)
 	if const_name.len > 0 {
@@ -1564,6 +1586,69 @@ fn (mut g FlatGen) fixed_array_decl_parts(arr types.ArrayFixed) (string, string)
 fn infix_can_skip_child_parens(parent_op flat.Op, child_op flat.Op) bool {
 	return (parent_op == .logical_or && child_op == .logical_or)
 		|| (parent_op == .logical_and && child_op == .logical_and)
+}
+
+// assoc_infix_chain_len counts how many same-operator infix nodes hang off the left
+// spine of `node` (its nesting depth). Capped early since only "very deep" matters.
+fn (g &FlatGen) assoc_infix_chain_len(node flat.Node) int {
+	op := node.op
+	mut cur := node
+	mut depth := 0
+	for {
+		if cur.children_count < 1 {
+			break
+		}
+		lhs_id := g.a.child(&cur, 0)
+		if !g.valid_node_id(lhs_id) {
+			break
+		}
+		lhs := g.a.nodes[int(lhs_id)]
+		if lhs.kind == .infix && lhs.op == op {
+			depth++
+			if depth > 101 {
+				break
+			}
+			cur = lhs
+		} else {
+			break
+		}
+	}
+	return depth
+}
+
+// gen_assoc_infix_chain emits a left-nested `||`/`&&` chain iteratively, producing the
+// same flat `a || b || c …` C as the recursive path but without growing the stack per
+// link (a big match's condition chain can be hundreds deep).
+fn (mut g FlatGen) gen_assoc_infix_chain(node flat.Node) {
+	op := node.op
+	op_s := g.op_str(op)
+	mut operands := []flat.NodeId{cap: 256}
+	mut cur := node
+	for {
+		operands << g.a.child(&cur, 1)
+		lhs_id := g.a.child(&cur, 0)
+		lhs := g.a.nodes[int(lhs_id)]
+		if lhs.kind == .infix && lhs.op == op && g.valid_node_id(g.a.child(&lhs, 0)) {
+			cur = lhs
+		} else {
+			operands << lhs_id
+			break
+		}
+	}
+	for i := operands.len - 1; i >= 0; i-- {
+		if i != operands.len - 1 {
+			g.write(' ${op_s} ')
+		}
+		oid := operands[i]
+		onode := g.a.nodes[int(oid)]
+		if onode.kind == .infix && !infix_can_skip_child_parens(op, onode.op) {
+			g.write('(')
+			g.gen_expr(oid)
+			g.write(')')
+		} else {
+			g.gen_expr(oid)
+		}
+	}
 }
 
 // gen_expr emits expr output for c.
@@ -1688,6 +1773,15 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			g.gen_spawn_expr(node)
 		}
 		.infix {
+			// A very long left-nested `||`/`&&` chain (e.g. from a big match condition or
+			// a `!in [...]` over many values) would recurse once per link and overflow the
+			// stack; emit those iteratively. Only pathologically long chains take this path,
+			// so ordinary code keeps the existing per-node generation unchanged.
+			if (node.op == .logical_or || node.op == .logical_and)
+				&& g.assoc_infix_chain_len(node) > 100 {
+				g.gen_assoc_infix_chain(node)
+				return
+			}
 			lhs_id := g.a.child(&node, 0)
 			rhs_id := g.a.child(&node, 1)
 			old_expected_enum := g.expected_enum
@@ -1937,6 +2031,11 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				(g.tc.cur_scope.lookup(base.value) or { types.Type(types.void_) }) !is types.Void
 			} else {
 				false
+			}
+			// A method used as a value (e.g. `game.draw` passed as a callback) rather
+			// than a field access — bind the receiver and yield a wrapper function.
+			if g.gen_method_value_closure(base_id, base_type0, node.value) {
+				return
 			}
 			if base.kind == .ident && base.value == 'C' {
 				g.write(node.value)
@@ -2803,6 +2902,48 @@ fn (g &FlatGen) fn_ptr_return_ct(ct string) string {
 	return ct
 }
 
+// emit_ready_fixed_array_typedefs emits, during the topological struct emission,
+// any fixed-array bare typedef whose element type is now fully defined (i.e. its
+// element struct has been emitted). Struct fields reference the typedef name
+// (`Array_fixed_vec__Vec4_f32 x`), so the typedef must precede any struct that
+// uses it — which a single later pass cannot guarantee.
+fn (mut g FlatGen) emit_ready_fixed_array_typedefs(needed map[string]FixedArrayTypedefInfo, emitted_structs map[string]bool) {
+	for name, info in needed {
+		if g.emitted_fixed_array_typedefs[name] {
+			continue
+		}
+		if g.fixed_array_elem_defined(info.arr, emitted_structs) {
+			g.emit_fixed_array_typedef(name, info, needed, mut g.emitted_fixed_array_typedefs)
+		}
+	}
+}
+
+// fixed_array_elem_defined reports whether a fixed array's element type is fully
+// available: a primitive/pointer/enum (always), or a struct/`string` already
+// emitted. Aliases are unwrapped to their underlying type first (`SimdFloat4` ->
+// `vec.Vec4[f32]` struct), so an alias to a not-yet-emitted struct is not treated
+// as ready.
+fn (g &FlatGen) fixed_array_elem_defined(arr types.ArrayFixed, emitted_structs map[string]bool) bool {
+	return g.fixed_array_type_defined(arr.elem_type, emitted_structs)
+}
+
+fn (g &FlatGen) fixed_array_type_defined(typ0 types.Type, emitted_structs map[string]bool) bool {
+	mut typ := typ0
+	for typ is types.Alias {
+		typ = typ.base_type
+	}
+	if typ is types.ArrayFixed {
+		return g.fixed_array_type_defined(typ.elem_type, emitted_structs)
+	}
+	if typ is types.Struct {
+		return g.tc.c_type(typ) in emitted_structs
+	}
+	if typ is types.String {
+		return 'string' in emitted_structs
+	}
+	return true
+}
+
 fn module_from_qualified_name(name string) string {
 	if name.contains('.') {
 		return name.all_before_last('.')
@@ -3101,6 +3242,11 @@ fn (mut g FlatGen) emit_const(name string, val_id flat.NodeId) {
 		|| ct in ['bool', 'char', 'i8', 'i16', 'i32', 'int', 'i64', 'u8', 'u16', 'u32', 'u64', 'f32', 'f64', 'float', 'double', 'isize', 'usize'] {
 		if qname == 'max_len' && ct == 'int' {
 			g.writeln('enum { ${qname} = ${expr_str} };')
+		} else if g.name_collides_with_struct_field(qname) {
+			// A `#define` whose name matches a struct field would wrongly expand every
+			// `.field` access; emit a real `const` variable instead (C keeps member and
+			// ordinary-identifier namespaces separate, so there is no collision).
+			g.writeln('static const ${ct} ${qname} = ${expr_str};')
 		} else {
 			g.writeln('#define ${qname} (${expr_str})')
 		}
@@ -3108,6 +3254,21 @@ fn (mut g FlatGen) emit_const(name string, val_id flat.NodeId) {
 		g.writeln('const ${ct} ${qname} = ${expr_str};')
 	}
 	g.tc.cur_module = old_module
+}
+
+// name_collides_with_struct_field reports whether a name is the C name of any struct
+// field, building the set lazily on first use.
+fn (mut g FlatGen) name_collides_with_struct_field(name string) bool {
+	if g.field_name_set.len == 0 {
+		for _, fields in g.tc.structs {
+			for f in fields {
+				g.field_name_set[c_field_name(f.name)] = true
+			}
+		}
+		// Guard against an all-fieldless program re-scanning every call.
+		g.field_name_set[''] = true
+	}
+	return name in g.field_name_set
 }
 
 fn (g &FlatGen) const_expr_needs_runtime_storage(expr string) bool {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1768,7 +1768,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			// A call to a fixed-array-returning function yields the wrapper struct;
 			// unwrap `.ret_arr` so the result behaves as the array value everywhere
 			// (indexing, arg passing, memcpy into a destination).
-			ret_t := g.declared_call_return_type(node)
+			ret_t := g.declared_call_return_type(id)
 			if ret_t is types.ArrayFixed && g.tc.c_type(ret_t) in g.fixed_array_ret_wrappers {
 				g.write('(')
 				g.gen_call(id, node)

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -8,68 +8,68 @@ import v3.types
 // FlatGen emits flat gen output used by c.
 pub struct FlatGen {
 mut:
-	sb                      strings.Builder
-	indent                  int
-	a                       &flat.FlatAst = unsafe { nil }
-	used_fns                map[string]bool
-	used_fn_names           []string
-	str_lits                []string
-	str_lit_ids             map[string]int
-	global_types            map[string]types.Type
-	enum_vals               map[string]int
-	defers                  []flat.NodeId
-	fn_defers               []flat.NodeId
-	fn_defer_counts         map[int]string
-	defer_capture_names     []string
-	defer_capture_types     map[string]types.Type
-	interfaces              map[string][]string
-	const_vals              map[string]flat.NodeId
-	const_modules           map[string]string
-	const_init_order        []string
-	global_modules          map[string]string
-	global_inits            map[string]flat.NodeId // qualified global name -> initializer value node
-	global_init_order       []string               // qualified global names, in declaration order
-	iface_impls             map[string][]string    // interface name -> implementing concrete type names
-	iface_type_ids          map[string]int         // "${iface}::${concrete}" -> 1-based type id
-	module_init_fns         []string               // C names of module-level `init()` fns, in source order
-	module_init_fn_modules  map[string]string      // C init fn name -> V module name
-	module_imports          map[string][]string    // module -> imported modules
-	c_includes              []string
-	c_flags                 []string
-	tc                      &types.TypeChecker = unsafe { nil }
-	has_builtins            bool
-	tmp_count               int
-	line_start              bool
-	field_name_set          map[string]bool // every struct field's C name (lazy) — for const/field collision checks
-	modules                 map[string]string // alias -> full module name
-	fn_ptr_types            map[string]string // fn_ptr:ret|params -> typedef name
-	fixed_array_ret_wrappers map[string]bool // bare fixed-array c_type name -> has a return wrapper struct
-	emitted_fixed_array_typedefs map[string]bool // bare fixed-array typedefs already written (shared across passes)
-	fn_decl_param_types     map[string][]types.Type
-	fn_decl_ret_types       map[string]types.Type // fn decl name (and qualified variants) -> return type
-	struct_decl_infos       map[string]StructDeclInfo
-	struct_decl_short_infos map[string]StructDeclInfo
-	runtime_inits           []string
-	compiler_vroot          string
-	cur_fn_name             string
-	cur_param_names         []string
-	cur_param_type_values   []types.Type
-	cur_param_types         map[string]types.Type
-	cur_fn_ret              types.Type = types.Type(types.void_)
-	cur_fn_ret_is_optional  bool
-	cur_fn_ret_base         types.Type = types.Type(types.void_)
-	expected_expr_type      types.Type = types.Type(types.void_)
-	expected_enum           string
-	needed_optional_types   map[string]string
-	emitted_optional_types  map[string]bool
-	emitted_fns             map[string]bool
-	array_method_cache      map[string]string
-	param_types_cache       map[string][]types.Type        // (name|fallback) -> resolved param types
-	embedded_fields_by_type map[string][]types.StructField // type name -> its embedded fields (usually empty)
-	param_types_by_short    map[string][]types.Type        // method short-name suffix -> param types (fallback index)
-	spawn_wrapper_names     map[string]string
-	spawn_wrapper_defs      []string
-	parallel_used           bool
+	sb                           strings.Builder
+	indent                       int
+	a                            &flat.FlatAst = unsafe { nil }
+	used_fns                     map[string]bool
+	used_fn_names                []string
+	str_lits                     []string
+	str_lit_ids                  map[string]int
+	global_types                 map[string]types.Type
+	enum_vals                    map[string]int
+	defers                       []flat.NodeId
+	fn_defers                    []flat.NodeId
+	fn_defer_counts              map[int]string
+	defer_capture_names          []string
+	defer_capture_types          map[string]types.Type
+	interfaces                   map[string][]string
+	const_vals                   map[string]flat.NodeId
+	const_modules                map[string]string
+	const_init_order             []string
+	global_modules               map[string]string
+	global_inits                 map[string]flat.NodeId // qualified global name -> initializer value node
+	global_init_order            []string               // qualified global names, in declaration order
+	iface_impls                  map[string][]string    // interface name -> implementing concrete type names
+	iface_type_ids               map[string]int         // "${iface}::${concrete}" -> 1-based type id
+	module_init_fns              []string               // C names of module-level `init()` fns, in source order
+	module_init_fn_modules       map[string]string      // C init fn name -> V module name
+	module_imports               map[string][]string    // module -> imported modules
+	c_includes                   []string
+	c_flags                      []string
+	tc                           &types.TypeChecker = unsafe { nil }
+	has_builtins                 bool
+	tmp_count                    int
+	line_start                   bool
+	field_name_set               map[string]bool   // every struct field's C name (lazy) — for const/field collision checks
+	modules                      map[string]string // alias -> full module name
+	fn_ptr_types                 map[string]string // fn_ptr:ret|params -> typedef name
+	fixed_array_ret_wrappers     map[string]bool   // bare fixed-array c_type name -> has a return wrapper struct
+	emitted_fixed_array_typedefs map[string]bool   // bare fixed-array typedefs already written (shared across passes)
+	fn_decl_param_types          map[string][]types.Type
+	fn_decl_ret_types            map[string]types.Type // fn decl name (and qualified variants) -> return type
+	struct_decl_infos            map[string]StructDeclInfo
+	struct_decl_short_infos      map[string]StructDeclInfo
+	runtime_inits                []string
+	compiler_vroot               string
+	cur_fn_name                  string
+	cur_param_names              []string
+	cur_param_type_values        []types.Type
+	cur_param_types              map[string]types.Type
+	cur_fn_ret                   types.Type = types.Type(types.void_)
+	cur_fn_ret_is_optional       bool
+	cur_fn_ret_base              types.Type = types.Type(types.void_)
+	expected_expr_type           types.Type = types.Type(types.void_)
+	expected_enum                string
+	needed_optional_types        map[string]string
+	emitted_optional_types       map[string]bool
+	emitted_fns                  map[string]bool
+	array_method_cache           map[string]string
+	param_types_cache            map[string][]types.Type        // (name|fallback) -> resolved param types
+	embedded_fields_by_type      map[string][]types.StructField // type name -> its embedded fields (usually empty)
+	param_types_by_short         map[string][]types.Type        // method short-name suffix -> param types (fallback index)
+	spawn_wrapper_names          map[string]string
+	spawn_wrapper_defs           []string
+	parallel_used                bool
 }
 
 struct FixedArrayTypedefInfo {
@@ -89,54 +89,54 @@ pub fn (g &FlatGen) c_flags() []string {
 // new creates a FlatGen value for c.
 pub fn FlatGen.new() FlatGen {
 	return FlatGen{
-		sb:                      strings.new_builder(4096)
-		used_fns:                map[string]bool{}
-		str_lit_ids:             map[string]int{}
-		global_types:            map[string]types.Type{}
-		enum_vals:               map[string]int{}
-		interfaces:              map[string][]string{}
-		const_vals:              map[string]flat.NodeId{}
-		const_modules:           map[string]string{}
-		const_init_order:        []string{}
-		global_modules:          map[string]string{}
-		global_inits:            map[string]flat.NodeId{}
-		global_init_order:       []string{}
-		iface_impls:             map[string][]string{}
-		iface_type_ids:          map[string]int{}
-		module_init_fns:         []string{}
-		module_init_fn_modules:  map[string]string{}
-		module_imports:          map[string][]string{}
-		c_includes:              []string{}
-		c_flags:                 []string{}
-		modules:                 map[string]string{}
-		fn_ptr_types:            map[string]string{}
-		fixed_array_ret_wrappers: map[string]bool{}
+		sb:                           strings.new_builder(4096)
+		used_fns:                     map[string]bool{}
+		str_lit_ids:                  map[string]int{}
+		global_types:                 map[string]types.Type{}
+		enum_vals:                    map[string]int{}
+		interfaces:                   map[string][]string{}
+		const_vals:                   map[string]flat.NodeId{}
+		const_modules:                map[string]string{}
+		const_init_order:             []string{}
+		global_modules:               map[string]string{}
+		global_inits:                 map[string]flat.NodeId{}
+		global_init_order:            []string{}
+		iface_impls:                  map[string][]string{}
+		iface_type_ids:               map[string]int{}
+		module_init_fns:              []string{}
+		module_init_fn_modules:       map[string]string{}
+		module_imports:               map[string][]string{}
+		c_includes:                   []string{}
+		c_flags:                      []string{}
+		modules:                      map[string]string{}
+		fn_ptr_types:                 map[string]string{}
+		fixed_array_ret_wrappers:     map[string]bool{}
 		emitted_fixed_array_typedefs: map[string]bool{}
-		fn_decl_param_types:     map[string][]types.Type{}
-		fn_decl_ret_types:       map[string]types.Type{}
-		struct_decl_infos:       map[string]StructDeclInfo{}
-		struct_decl_short_infos: map[string]StructDeclInfo{}
-		cur_param_names:         []string{}
-		cur_param_type_values:   []types.Type{}
-		cur_param_types:         map[string]types.Type{}
-		needed_optional_types:   map[string]string{}
-		emitted_optional_types:  map[string]bool{}
-		emitted_fns:             map[string]bool{}
-		array_method_cache:      map[string]string{}
-		param_types_cache:       map[string][]types.Type{}
-		embedded_fields_by_type: map[string][]types.StructField{}
-		param_types_by_short:    map[string][]types.Type{}
-		spawn_wrapper_names:     map[string]string{}
-		spawn_wrapper_defs:      []string{}
-		str_lits:                []string{}
-		defers:                  []flat.NodeId{}
-		fn_defers:               []flat.NodeId{}
-		fn_defer_counts:         map[int]string{}
-		defer_capture_names:     []string{}
-		defer_capture_types:     map[string]types.Type{}
-		runtime_inits:           []string{}
-		compiler_vroot:          ''
-		line_start:              true
+		fn_decl_param_types:          map[string][]types.Type{}
+		fn_decl_ret_types:            map[string]types.Type{}
+		struct_decl_infos:            map[string]StructDeclInfo{}
+		struct_decl_short_infos:      map[string]StructDeclInfo{}
+		cur_param_names:              []string{}
+		cur_param_type_values:        []types.Type{}
+		cur_param_types:              map[string]types.Type{}
+		needed_optional_types:        map[string]string{}
+		emitted_optional_types:       map[string]bool{}
+		emitted_fns:                  map[string]bool{}
+		array_method_cache:           map[string]string{}
+		param_types_cache:            map[string][]types.Type{}
+		embedded_fields_by_type:      map[string][]types.StructField{}
+		param_types_by_short:         map[string][]types.Type{}
+		spawn_wrapper_names:          map[string]string{}
+		spawn_wrapper_defs:           []string{}
+		str_lits:                     []string{}
+		defers:                       []flat.NodeId{}
+		fn_defers:                    []flat.NodeId{}
+		fn_defer_counts:              map[int]string{}
+		defer_capture_names:          []string{}
+		defer_capture_types:          map[string]types.Type{}
+		runtime_inits:                []string{}
+		compiler_vroot:               ''
+		line_start:                   true
 	}
 }
 
@@ -244,10 +244,12 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.optional_typedefs()
 	g.global_decls()
 	g.forward_decls()
+	g.enum_str_forward_decls()
 	g.spawn_wrapper_decls()
 	g.register_interface_strings()
 	g.string_literals()
 	g.interface_method_stubs()
+	g.enum_str_defs()
 	g.sb.write_string(const_code)
 	if g.runtime_inits.len > 0 || g.module_init_fns.len > 0 || g.global_inits.len > 0 {
 		g.writeln('void _vinit() {')

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1555,14 +1555,16 @@ fn (mut g FlatGen) fixed_array_len_raw(raw_len string, fallback int) string {
 	if raw_len.len == 0 {
 		return '${fallback}'
 	}
+	// A literal or const-expression size (`8`, `SEGS + 1`, `1 << 2`, `8 >>> 1`) folds to an
+	// integer; emit that literal so the C dimension is always valid — `>>>` has no C form,
+	// so a digit-leading expression like `8 >>> 1` must not be passed through raw — and a
+	// non-numeric expr isn't c_name-mangled (`SEGS_+_1`) into an undeclared identifier.
+	if v := g.tc.const_int_value(raw_len, []string{}) {
+		return v.str()
+	}
 	clean_len := raw_len.replace('_', '')
 	if clean_len.len > 0 && clean_len[0] >= `0` && clean_len[0] <= `9` {
 		return clean_len
-	}
-	// A const-expression size (`SEGS + 1`) evaluates to a literal; otherwise the whole
-	// string would be c_name-mangled (`SEGS_+_1`) into an undeclared identifier.
-	if v := g.tc.const_int_value(raw_len, []string{}) {
-		return v.str()
 	}
 	const_name := g.const_ref_name(raw_len)
 	if const_name.len > 0 {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -42,6 +42,8 @@ mut:
 	line_start              bool
 	modules                 map[string]string // alias -> full module name
 	fn_ptr_types            map[string]string // fn_ptr:ret|params -> typedef name
+	fixed_array_ret_wrappers map[string]bool // bare fixed-array c_type name -> has a return wrapper struct
+	emitted_fixed_array_typedefs map[string]bool // bare fixed-array typedefs already written (shared across passes)
 	fn_decl_param_types     map[string][]types.Type
 	fn_decl_ret_types       map[string]types.Type // fn decl name (and qualified variants) -> return type
 	struct_decl_infos       map[string]StructDeclInfo
@@ -107,6 +109,8 @@ pub fn FlatGen.new() FlatGen {
 		c_flags:                 []string{}
 		modules:                 map[string]string{}
 		fn_ptr_types:            map[string]string{}
+		fixed_array_ret_wrappers: map[string]bool{}
+		emitted_fixed_array_typedefs: map[string]bool{}
 		fn_decl_param_types:     map[string][]types.Type{}
 		fn_decl_ret_types:       map[string]types.Type{}
 		struct_decl_infos:       map[string]StructDeclInfo{}
@@ -178,6 +182,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.c_flags = []string{}
 	g.modules = map[string]string{}
 	g.fn_ptr_types = map[string]string{}
+	g.fixed_array_ret_wrappers = map[string]bool{}
+	g.emitted_fixed_array_typedefs = map[string]bool{}
 	g.fn_decl_param_types = map[string][]types.Type{}
 	g.fn_decl_ret_types = map[string]types.Type{}
 	g.struct_decl_infos = map[string]StructDeclInfo{}
@@ -206,6 +212,9 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.collect_interface_impls()
 	g.preseed_struct_fn_ptr_types()
 	g.preseed_global_fn_ptr_types()
+	// Decide fixed-array return wrappers before generating function bodies, so
+	// signatures, returns and call sites all agree on the wrapped types.
+	g.populate_fixed_array_ret_wrappers()
 	const_code := g.precompute_consts()
 	orig_sb := g.sb
 	orig_line_start := g.line_start
@@ -222,6 +231,10 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	// Forward-declare multi-return structs before fn-ptr typedefs, which may name a
 	// multi-return as a by-value return type (full bodies come after struct_decls).
 	g.multi_return_forward_decls()
+	// Bare typedefs for primitive-element fixed arrays and wrapper structs for
+	// fixed-array return types, before fn-ptr typedefs (which may name a fixed
+	// array in param or return position) and the function declarations.
+	g.fixed_array_early_typedefs()
 	g.fn_ptr_typedefs()
 	g.struct_decls()
 	g.fixed_array_typedefs()
@@ -1543,6 +1556,16 @@ fn (mut g FlatGen) fixed_array_decl_parts(arr types.ArrayFixed) (string, string)
 	return g.tc.c_type(arr.elem_type), '[${len_expr}]'
 }
 
+// infix_can_skip_child_parens reports whether a child infix operand needs no
+// surrounding parentheses. For associative logical chains (`||`, `&&`) a child of
+// the same operator is safe unparenthesised; this keeps long lowered chains (e.g.
+// a `match` over hundreds of enum values → `a || b || c || ...`) from nesting
+// parentheses past the C compiler's bracket-depth limit.
+fn infix_can_skip_child_parens(parent_op flat.Op, child_op flat.Op) bool {
+	return (parent_op == .logical_or && child_op == .logical_or)
+		|| (parent_op == .logical_and && child_op == .logical_and)
+}
+
 // gen_expr emits expr output for c.
 fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 	if int(id) < 0 {
@@ -1649,7 +1672,17 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			g.write('0')
 		}
 		.call {
-			g.gen_call(id, node)
+			// A call to a fixed-array-returning function yields the wrapper struct;
+			// unwrap `.ret_arr` so the result behaves as the array value everywhere
+			// (indexing, arg passing, memcpy into a destination).
+			ret_t := g.declared_call_return_type(node)
+			if ret_t is types.ArrayFixed && g.tc.c_type(ret_t) in g.fixed_array_ret_wrappers {
+				g.write('(')
+				g.gen_call(id, node)
+				g.write(').ret_arr')
+			} else {
+				g.gen_call(id, node)
+			}
 		}
 		.spawn_expr {
 			g.gen_spawn_expr(node)
@@ -1706,7 +1739,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			} else {
 				lhs_node := g.a.nodes[int(lhs_id)]
 				rhs_node := g.a.nodes[int(rhs_id)]
-				if lhs_node.kind == .infix {
+				if lhs_node.kind == .infix && !infix_can_skip_child_parens(node.op, lhs_node.op) {
 					g.write('(')
 					g.gen_expr_with_possible_enum_type(lhs_id, rhs_type)
 					g.write(')')
@@ -1714,7 +1747,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					g.gen_expr_with_possible_enum_type(lhs_id, rhs_type)
 				}
 				g.write(' ${g.op_str(node.op)} ')
-				if rhs_node.kind == .infix {
+				if rhs_node.kind == .infix && !infix_can_skip_child_parens(node.op, rhs_node.op) {
 					g.write('(')
 					g.gen_expr_with_possible_enum_type(rhs_id, lhs_type)
 					g.write(')')
@@ -2524,8 +2557,12 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('#ifndef V_COMMIT_HASH')
 	g.writeln('#define V_COMMIT_HASH ""')
 	g.writeln('#endif')
-	g.writeln('static inline void vheap_alloc(void* p, u64 n) { (void)p; (void)n; }')
-	g.writeln('static inline void vheap_free(void* p) { (void)p; }')
+	// Weak fallbacks for the heap-tracking hooks. A program that provides real
+	// implementations (e.g. a `vheap_alloc`/`vheap_free` from a linked C file, as
+	// some projects do) overrides these without a redefinition/static-vs-non-static
+	// clash against that file's own non-static prototype.
+	g.writeln('__attribute__((weak)) void vheap_alloc(void* p, u64 n) { (void)p; (void)n; }')
+	g.writeln('__attribute__((weak)) void vheap_free(void* p) { (void)p; }')
 	// Atomic helpers. We use the C11 __atomic_* builtins (memory order 5 == __ATOMIC_SEQ_CST).
 	// clang/gcc inline the generic _n / RMW builtins. tcc only implements the inline
 	// __atomic_{add,sub,fetch}_* RMW builtins; for load/store/exchange/cas it has no generic
@@ -2611,7 +2648,7 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('')
 }
 
-fn (mut g FlatGen) fixed_array_typedefs() {
+fn (mut g FlatGen) collect_fixed_array_typedefs_needed() map[string]FixedArrayTypedefInfo {
 	mut needed := map[string]FixedArrayTypedefInfo{}
 	old_module := g.tc.cur_module
 	for name, ret_type in g.tc.fn_ret_types {
@@ -2649,14 +2686,121 @@ fn (mut g FlatGen) fixed_array_typedefs() {
 		g.collect_fixed_array_typedef(typ, mut needed)
 	}
 	g.tc.cur_module = old_module
-	mut emitted := map[string]bool{}
+	return needed
+}
+
+fn (mut g FlatGen) fixed_array_typedefs() {
+	needed := g.collect_fixed_array_typedefs_needed()
+	old_len := g.emitted_fixed_array_typedefs.len
 	for name, info in needed {
-		g.emit_fixed_array_typedef(name, info, needed, mut emitted)
+		g.emit_fixed_array_typedef(name, info, needed, mut g.emitted_fixed_array_typedefs)
 	}
-	g.tc.cur_module = old_module
-	if emitted.len > 0 {
+	if g.emitted_fixed_array_typedefs.len > old_len {
 		g.writeln('')
 	}
+}
+
+// fixed_array_typedef_is_early reports whether a fixed array's bare typedef can be
+// emitted before struct definitions: its element chain must bottom out in a
+// primitive/pointer/enum (not a struct or `string`, whose definitions come later).
+fn fixed_array_typedef_is_early(arr types.ArrayFixed) bool {
+	elem := arr.elem_type
+	if elem is types.ArrayFixed {
+		return fixed_array_typedef_is_early(elem)
+	}
+	return fixed_array_elem_is_early_complete(elem)
+}
+
+// populate_fixed_array_ret_wrappers records which fixed-array types get a return
+// wrapper struct. It must run before function bodies are generated, so that fn
+// signatures, return statements and call sites all agree on whether a given
+// fixed-array return is wrapped. Only primitive/pointer/enum element types are
+// wrapped (their definitions precede the wrapper typedef block).
+fn (mut g FlatGen) populate_fixed_array_ret_wrappers() {
+	needed := g.collect_fixed_array_typedefs_needed()
+	for name, info in needed {
+		if fixed_array_elem_is_early_complete(info.arr.elem_type) {
+			g.fixed_array_ret_wrappers[name] = true
+		}
+	}
+}
+
+// fixed_array_early_typedefs emits, before the fn-ptr typedef block, the bare
+// typedefs for fixed arrays whose element chain is a primitive/pointer/enum, plus
+// a one-field struct wrapper `struct { T ret_arr[N]; }` for each fixed-array
+// return type. fn-ptr typedefs may name a fixed array in param position (bare
+// typedef) or return position (wrapper); both must therefore be defined first. C
+// functions cannot return raw array types, hence the wrapper (as V1 does). Bare
+// typedefs of struct/`string`-element fixed arrays are deferred to
+// fixed_array_typedefs(), after the struct definitions.
+fn (mut g FlatGen) fixed_array_early_typedefs() {
+	needed := g.collect_fixed_array_typedefs_needed()
+	mut names := []string{}
+	for name, _ in needed {
+		names << name
+	}
+	names.sort()
+	mut emitted_any := false
+	for name in names {
+		info := needed[name] or { continue }
+		if !fixed_array_typedef_is_early(info.arr) {
+			continue
+		}
+		g.emit_fixed_array_typedef(name, info, needed, mut g.emitted_fixed_array_typedefs)
+		emitted_any = true
+	}
+	// Wrapper structs for fixed-array return types.
+	for name in names {
+		if name !in g.fixed_array_ret_wrappers {
+			continue
+		}
+		info := needed[name] or { continue }
+		arr := info.arr
+		old_module := g.tc.cur_module
+		g.tc.cur_module = info.module
+		elem_ct := g.tc.c_type(arr.elem_type)
+		len_expr := g.fixed_array_len_value(arr)
+		g.tc.cur_module = old_module
+		g.writeln('typedef struct { ${elem_ct} ret_arr[${len_expr}]; } ${fixed_array_ret_wrapper_name(name)};')
+		emitted_any = true
+	}
+	if emitted_any {
+		g.writeln('')
+	}
+}
+
+// fixed_array_ret_wrapper_name is the struct name wrapping a fixed-array return.
+fn fixed_array_ret_wrapper_name(bare_c_name string) string {
+	return '_v_ret_${bare_c_name}'
+}
+
+// fixed_array_elem_is_early_complete reports whether a fixed-array element type's
+// C definition is available before the fn_ptr/return-wrapper typedef block (i.e.
+// it is a primitive, pointer, or enum — not a struct or nested fixed array, whose
+// bare typedefs/definitions are emitted later).
+fn fixed_array_elem_is_early_complete(elem types.Type) bool {
+	return elem is types.Primitive || elem is types.Pointer || elem is types.Enum
+}
+
+// fn_return_type_name is the C type to write for a function/fn-ptr return type,
+// substituting the fixed-array wrapper struct when one exists.
+fn (mut g FlatGen) fn_return_type_name(t types.Type) string {
+	if t is types.ArrayFixed {
+		bare := g.tc.c_type(t)
+		if bare in g.fixed_array_ret_wrappers {
+			return fixed_array_ret_wrapper_name(bare)
+		}
+	}
+	return g.optional_type_name(t)
+}
+
+// fn_ptr_return_ct maps a fixed-array return c_type name (string form, used by the
+// fn-ptr typedef machinery) to its wrapper struct name when one exists.
+fn (g &FlatGen) fn_ptr_return_ct(ct string) string {
+	if ct.starts_with('Array_fixed_') && ct in g.fixed_array_ret_wrappers {
+		return fixed_array_ret_wrapper_name(ct)
+	}
+	return ct
 }
 
 fn module_from_qualified_name(name string) string {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -886,6 +886,25 @@ fn (mut g FlatGen) expr_to_string(id flat.NodeId) string {
 	return result
 }
 
+// interface_value_to_string captures, as a string, the boxed interface value the direct return
+// path emits (`(Iface){._typ = N, ._object = ...}`) — so a deferred return can save it into a
+// temp without dropping `_typ`/`_object`. Mirrors that path: box a concrete value, else (already
+// boxed by the transform) emit it as-is.
+fn (mut g FlatGen) interface_value_to_string(id flat.NodeId, expected types.Type) string {
+	orig := g.sb
+	orig_line_start := g.line_start
+	g.sb = strings.new_builder(64)
+	// Box mid-statement (no leading indent), matching the direct return path.
+	g.line_start = false
+	if !g.gen_interface_value_expr(id, expected) {
+		g.gen_expr(id)
+	}
+	result := g.sb.str()
+	g.sb = orig
+	g.line_start = orig_line_start
+	return result
+}
+
 // expr_to_string_with_expected_type converts expr to string with expected type data for c.
 fn (mut g FlatGen) expr_to_string_with_expected_type(id flat.NodeId, expected types.Type) string {
 	orig := g.sb

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2824,7 +2824,11 @@ fn fixed_array_typedef_is_early(arr types.ArrayFixed) bool {
 fn (mut g FlatGen) populate_fixed_array_ret_wrappers() {
 	needed := g.collect_fixed_array_typedefs_needed()
 	for name, info in needed {
-		if fixed_array_elem_is_early_complete(info.arr.elem_type) {
+		// Use the recursive early check so a nested fixed array (`[2][3]int`, whose
+		// `elem_type` is itself an `ArrayFixed`) is still wrapped: its chain bottoms out
+		// in a primitive/pointer/enum, so the bare typedefs are emitted early and a C
+		// function still cannot return the raw array type.
+		if fixed_array_typedef_is_early(info.arr) {
 			g.fixed_array_ret_wrappers[name] = true
 		}
 	}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1067,26 +1067,13 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					// imported) type, not a value — e.g. `Animation.load(path)` inside
 					// the type's own module. Resolve to the module-qualified static fn.
 					static_fn := g.static_method_fn_name(base.value, fn_node.value) or { '' }
-					static_params := g.param_types_for(static_fn, fn_node.value)
 					g.write(g.direct_call_name(static_fn))
 					g.write('(')
-					for i in 1 .. node.children_count {
-						if i > 1 {
-							g.write(', ')
-						}
-						arg_id := g.a.child(&node, i)
-						arg_idx := i - 1
-						// Decay a fixed-array `[N]T` argument to `T*` when the static
-						// method's parameter is a fixed array (`SimdInt4.load_ptr([4]int)`),
-						// matching how ordinary calls coerce such arguments.
-						if arg_idx < static_params.len {
-							if fixed := array_fixed_type(static_params[arg_idx]) {
-								g.gen_fixed_array_data_arg(arg_id, fixed)
-								continue
-							}
-						}
-						g.gen_expr(arg_id)
-					}
+					// Lower the arguments through the ordinary call path so a static method
+					// parameter that needs coercion — option/result wrapping, fn-pointer alias
+					// callbacks, sum variants, fixed-array decay, variadic/`@[params]` handling —
+					// is emitted against its expected type, not as the raw expression.
+					g.gen_call_args(static_fn, node, 1)
 					g.write(')')
 					return
 				} else if base.kind == .selector {
@@ -2543,7 +2530,12 @@ fn fn_type_from(t types.Type) ?types.FnType {
 // gen_call_args emits call args output for c.
 fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 	mut param_types := g.param_types_for(fn_name, fn_name.all_after_last('.'))
-	if param_types.len == 0 && fn_name.contains('.') {
+	// Retry with the bare method name only when the qualified name is genuinely unresolved —
+	// not when it is a known function that simply takes no parameters. The short-name index
+	// matches any same-named function, so retrying a real 0-param fn (e.g. a static method
+	// `Type.build()`) would adopt an unrelated `build`'s parameters and append phantom args.
+	if param_types.len == 0 && fn_name.contains('.') && fn_name !in g.tc.fn_param_types
+		&& c_name(fn_name) !in g.tc.fn_param_types {
 		param_types = g.param_types_for(fn_name.all_after_last('.'), fn_name.all_after_last('.'))
 	}
 	is_variadic_fn := g.tc.fn_variadic[fn_name] or { false }

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -248,12 +248,20 @@ fn net_ip_fixed_arg_type(fn_name string, arg_idx int) ?types.ArrayFixed {
 	return none
 }
 
-fn (mut g FlatGen) gen_special_c_callback_arg(fn_name string, arg_idx int, arg_id flat.NodeId) bool {
+fn (mut g FlatGen) gen_special_c_callback_arg(fn_name string, arg_idx int, arg_id flat.NodeId, expected_param types.Type) bool {
 	clean_name := fn_name.trim_string_left('C.').all_after_last('.')
 	if clean_name == 'mbedtls_ssl_conf_sni' && arg_idx == 1 {
 		g.write('(int (*)(void *, mbedtls_ssl_context *, const unsigned char *, size_t))')
 		g.gen_expr(arg_id)
 		return true
+	}
+	// Only convert to `(void*)` for an actual C-callback slot. A V `fn (...) ...`
+	// parameter is generated as a `_fn_ptr_*` typedef and must receive the function
+	// pointer directly: `(void*)foo` is an object-pointer-to-function-pointer cast that
+	// strict C rejects and that is not portable across ABIs. C functions (and loosely
+	// typed `voidptr` slots) still need it, because C uses the header prototype.
+	if expected_param is types.FnType {
+		return false
 	}
 	// A V function passed by name to a C function (a callback) must be cast: the V
 	// declaration's parameter type (often `voidptr`) is ignored by C in favour of the
@@ -379,7 +387,11 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 	fn_node := g.a.child_node(&call_node, 0)
 	// The spawned call's return type: heap-captured by the wrapper so a later
 	// `[]thread T .wait()` can recover the value (void callees just return NULL).
-	ret_ct := g.tc.c_type(g.tc.resolve_type(call_id))
+	// Use the callee's ABI return type, not the bare value type: an option/result
+	// return is `Optional_T` (not the generic `Optional`, whose payload is `int`) and a
+	// fixed-array return is its `_v_ret_*` wrapper struct. The wrapper mallocs and
+	// assigns this type, and `[]thread T.wait()` must read back the same layout.
+	ret_ct := g.fn_return_type_name(g.tc.resolve_type(call_id))
 	mut wrapper := ''
 	mut arg_expr := 'NULL'
 	if fn_node.kind == .ident {
@@ -1570,7 +1582,12 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					&& g.gen_pointer_arg_from_array_literal(arg_node, param_types[arg_idx]) {
 					continue
 				}
-				if g.gen_special_c_callback_arg(target_name, arg_idx, arg_id) {
+				cb_param := if arg_idx >= 0 && arg_idx < param_types.len {
+					param_types[arg_idx]
+				} else {
+					types.Type(types.void_)
+				}
+				if g.gen_special_c_callback_arg(target_name, arg_idx, arg_id, cb_param) {
 					continue
 				}
 				if variadic_idx >= 0 && arg_idx == variadic_idx {
@@ -2089,28 +2106,18 @@ fn (g &FlatGen) current_param_type(name string) ?types.Type {
 	return none
 }
 
-// gen_enum_str_call emits enum str call output for c.
+// gen_enum_str_call emits an explicit `enum_val.str()` (with no user-defined `str`)
+// by routing to the compiler-synthesized `<Enum>__autostr`, so it matches `${enum}`
+// interpolation exactly — including `[flag]` enums' `Enum{.a | .b}` form, which the
+// old inline single-value ternary chain could not render.
 fn (mut g FlatGen) gen_enum_str_call(fn_node &flat.Node, enum_type types.Enum) {
-	fields := g.tc.enum_fields[enum_type.name] or { []string{} }
-	if fields.len == 0 {
-		sid := g.intern_string('')
-		g.write('_str_${sid}')
-		return
+	mut name := enum_type.name
+	if name.starts_with('main.') {
+		name = name[5..]
 	}
-	g.write('({ int _e${g.tmp_count} = ')
+	g.write('${c_name(name)}__autostr(')
 	g.gen_expr(g.a.child(fn_node, 0))
-	g.write('; ')
-	for field in fields {
-		ekey := '${enum_type.name}.${field}'
-		if ekey in g.enum_vals {
-			val := g.enum_vals[ekey]
-			sid := g.intern_string(field)
-			g.write('_e${g.tmp_count} == ${val} ? _str_${sid} : ')
-		}
-	}
-	unknown := g.intern_string('')
-	g.write('_str_${unknown}; })')
-	g.tmp_count++
+	g.write(')')
 }
 
 // enum_receiver_method_name supports enum receiver method name handling for FlatGen.
@@ -2556,7 +2563,12 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			&& g.gen_pointer_arg_from_array_literal(arg_node, param_types[arg_idx]) {
 			continue
 		}
-		if g.gen_special_c_callback_arg(fn_name, arg_idx, arg_id) {
+		cb_param := if arg_idx >= 0 && arg_idx < param_types.len {
+			param_types[arg_idx]
+		} else {
+			types.Type(types.void_)
+		}
+		if g.gen_special_c_callback_arg(fn_name, arg_idx, arg_id, cb_param) {
 			continue
 		}
 		if is_variadic && arg_idx == variadic_idx {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -191,9 +191,8 @@ fn (mut g FlatGen) write_method_c_name(id flat.NodeId, node flat.Node, method_na
 fn (g &FlatGen) static_method_fn_name(type_ident string, method string) ?string {
 	qtype := g.tc.qualify_name(type_ident)
 	is_type := type_ident in g.tc.type_aliases || qtype in g.tc.type_aliases
-		|| type_ident in g.tc.structs || qtype in g.tc.structs
-		|| type_ident in g.tc.enum_names || qtype in g.tc.enum_names
-		|| type_ident in g.tc.sum_types || qtype in g.tc.sum_types
+		|| type_ident in g.tc.structs || qtype in g.tc.structs || type_ident in g.tc.enum_names
+		|| qtype in g.tc.enum_names || type_ident in g.tc.sum_types || qtype in g.tc.sum_types
 	if !is_type {
 		return none
 	}
@@ -298,6 +297,18 @@ fn (mut g FlatGen) spawn_wrapper_decls() {
 // field access can't represent the bound receiver, so it binds the receiver into a
 // per-site context global and yields a wrapper function that invokes the method on
 // it. Returns false when the selector is an ordinary field access (handled normally).
+//
+// LIMITATION: the captured receiver lives in a single per-site global, so it is
+// only valid while no later evaluation of the *same* selector site overwrites it.
+// That covers the supported cases — passing/storing a method value and invoking it
+// before the site is re-evaluated (immediate callbacks, a single stored callback).
+// It does NOT support keeping several live method values from one site with
+// different receivers (e.g. building an array of `obj.method` in a loop): they all
+// share the global and would observe the last-bound receiver. A correct general
+// form needs a real per-closure captured environment, which the v3 backend has no
+// ABI for yet (anonymous fns are lifted without true capture). Such escaping method
+// values should be reworked (e.g. capture into an explicit struct + free fn) until
+// closure support lands.
 fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types.Type, method string) bool {
 	clean := types.unwrap_pointer(base_type)
 	if clean !is types.Struct {
@@ -408,8 +419,8 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 				base_expr := g.expr_to_string(base_id)
 				if call_node.children_count == 1 {
 					if receiver_type is types.Pointer {
-						wrapper = g.ensure_receiver_spawn_wrapper(c_name(method_name),
-							receiver_ct, ret_ct)
+						wrapper = g.ensure_receiver_spawn_wrapper(c_name(method_name), receiver_ct,
+							ret_ct)
 						if base_type is types.Pointer {
 							arg_expr = '(${receiver_ct})(${base_expr})'
 						} else {
@@ -449,8 +460,7 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 						param_cts << g.tc.c_type(param_types[i])
 						arg_exprs << g.expr_to_string(g.a.child(&call_node, i))
 					}
-					g.emit_args_spawn_expr(c_name(method_name), param_cts, arg_exprs,
-						ret_ct)
+					g.emit_args_spawn_expr(c_name(method_name), param_cts, arg_exprs, ret_ct)
 					return
 				}
 			}
@@ -1324,26 +1334,28 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 							}
 						}
 					}
-						if !is_method {
-							// Static method on a named type / type alias (e.g. `SimdFloat4.new(...)`,
-							// where `SimdFloat4` names a type, not a value). The base ident resolves to
-							// no value type, so handle it before the instance-method fallback.
-							base_node_s := g.a.child_node(fn_node, 0)
-							if base_node_s.kind == .ident {
-								if static_fn := g.static_method_fn_name(base_node_s.value, fn_node.value) {
-									g.write(g.direct_call_name(static_fn))
-									g.write('(')
-									for i in 1 .. node.children_count {
-										if i > 1 {
-											g.write(', ')
-										}
-										g.gen_expr(g.a.child(&node, i))
+					if !is_method {
+						// Static method on a named type / type alias (e.g. `SimdFloat4.new(...)`,
+						// where `SimdFloat4` names a type, not a value). The base ident resolves to
+						// no value type, so handle it before the instance-method fallback.
+						base_node_s := g.a.child_node(fn_node, 0)
+						if base_node_s.kind == .ident {
+							if static_fn := g.static_method_fn_name(base_node_s.value,
+								fn_node.value)
+							{
+								g.write(g.direct_call_name(static_fn))
+								g.write('(')
+								for i in 1 .. node.children_count {
+									if i > 1 {
+										g.write(', ')
 									}
-									g.write(')')
-									return
+									g.gen_expr(g.a.child(&node, i))
 								}
+								g.write(')')
+								return
 							}
 						}
+					}
 					if !is_method {
 						mut struct_name := clean_type.name()
 						if clean_type is types.Struct {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -301,6 +301,24 @@ fn (mut g FlatGen) spawn_wrapper_decls() {
 	}
 }
 
+// expr_is_addressable reports whether an expression denotes a stable lvalue whose address
+// outlives the enclosing statement expression — a variable, a field/index access reaching one,
+// or a dereference. Rvalues (struct literals, calls, ...) only have temporary storage, so their
+// address must not be captured in a method value's static receiver slot.
+fn (g &FlatGen) expr_is_addressable(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return false
+	}
+	node := g.a.nodes[int(id)]
+	return match node.kind {
+		.ident { true }
+		.index { node.children_count > 0 && g.expr_is_addressable(g.a.child(&node, 0)) }
+		.selector { node.children_count > 0 && g.expr_is_addressable(g.a.child(&node, 0)) }
+		.prefix { node.op == .mul }
+		else { false }
+	}
+}
+
 // gen_method_value_closure handles a method used as a *value* (e.g. `game.draw`
 // passed where a `fn ()` callback is expected) rather than called. A plain struct
 // field access can't represent the bound receiver, so it binds the receiver into a
@@ -383,19 +401,30 @@ fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types
 	g.spawn_wrapper_defs << 'static ${recv_ct} ${ctx_name};'
 	ret_prefix := if ret_ct == 'void' { '' } else { 'return ' }
 	g.spawn_wrapper_defs << 'static ${ret_ct} ${wrap_name}(${wparam_str}) { ${ret_prefix}${cname}(${call_args.join(', ')}); }'
-	// Set the context global to the receiver, then yield the wrapper as the value.
-	g.write('({ ${ctx_name} = ')
 	base_is_ptr := base_type is types.Pointer
-	if recv_is_ptr && !base_is_ptr {
-		g.write('&(')
+	// Set the context global to the receiver, then yield the wrapper as the value.
+	if recv_is_ptr && !base_is_ptr && !g.expr_is_addressable(base_id) {
+		// Pointer receiver bound to an rvalue base (`Foo{..}.tick`, `make_foo().tick`): taking
+		// `&(rvalue)` captures a temporary that dies with the enclosing statement expression,
+		// before the callback runs. Copy the receiver into a durable static slot and point at it.
+		val_ct := g.tc.c_type(types.unwrap_pointer(params[0]))
+		g.spawn_wrapper_defs << 'static ${val_ct} ${ctx_name}_recv;'
+		g.write('({ ${ctx_name}_recv = ')
 		g.gen_expr(base_id)
-		g.write(')')
-	} else if !recv_is_ptr && base_is_ptr {
-		g.write('*(')
-		g.gen_expr(base_id)
-		g.write(')')
+		g.write('; ${ctx_name} = &${ctx_name}_recv')
 	} else {
-		g.gen_expr(base_id)
+		g.write('({ ${ctx_name} = ')
+		if recv_is_ptr && !base_is_ptr {
+			g.write('&(')
+			g.gen_expr(base_id)
+			g.write(')')
+		} else if !recv_is_ptr && base_is_ptr {
+			g.write('*(')
+			g.gen_expr(base_id)
+			g.write(')')
+		} else {
+			g.gen_expr(base_id)
+		}
 	}
 	// Yield the wrapper as the callback value. A V `fn (...) ...` parameter is a
 	// `_fn_ptr_*` typedef and needs the wrapper cast to that function-pointer type; only

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -400,9 +400,11 @@ fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types
 	// Yield the wrapper as the callback value. A V `fn (...) ...` parameter is a
 	// `_fn_ptr_*` typedef and needs the wrapper cast to that function-pointer type; only
 	// a C / `voidptr` callback slot gets the object-pointer `(void*)` cast (which strict
-	// C rejects for function pointers).
-	if g.expected_expr_type is types.FnType {
-		fnptr_ct := g.value_c_type(g.expected_expr_type)
+	// C rejects for function pointers). `fn_type_from` is alias-aware, so a method value
+	// passed through a `type Cb = fn ()` parameter (an `Alias`, not a bare `FnType`) is
+	// recognised too and cast to the function-pointer typedef rather than `(void*)`.
+	if fnt := fn_type_from(g.expected_expr_type) {
+		fnptr_ct := g.value_c_type(fnt)
 		g.write('; (${fnptr_ct})${wrap_name}; })')
 	} else {
 		g.write('; (void*)${wrap_name}; })')

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -184,6 +184,30 @@ fn (mut g FlatGen) write_method_c_name(id flat.NodeId, node flat.Node, method_na
 	g.write(c_name(method_name))
 }
 
+// static_method_fn_name resolves `Type.method(...)` static calls where `Type` is a
+// named type, struct, enum, sum type or type alias (e.g. `SimdFloat4.new` for
+// `type SimdFloat4 = vec.Vec4[f32]`). Returns the fn key, or none if `type_ident`
+// is not a type or has no such static method.
+fn (g &FlatGen) static_method_fn_name(type_ident string, method string) ?string {
+	qtype := g.tc.qualify_name(type_ident)
+	is_type := type_ident in g.tc.type_aliases || qtype in g.tc.type_aliases
+		|| type_ident in g.tc.structs || qtype in g.tc.structs
+		|| type_ident in g.tc.enum_names || qtype in g.tc.enum_names
+		|| type_ident in g.tc.sum_types || qtype in g.tc.sum_types
+	if !is_type {
+		return none
+	}
+	direct := '${type_ident}.${method}'
+	if direct in g.tc.fn_ret_types || direct in g.tc.fn_param_types {
+		return direct
+	}
+	qdirect := '${qtype}.${method}'
+	if qdirect in g.tc.fn_ret_types || qdirect in g.tc.fn_param_types {
+		return qdirect
+	}
+	return none
+}
+
 fn (g &FlatGen) resolve_method_name(type_name string, method string) string {
 	direct := '${type_name}.${method}'
 	if direct in g.tc.fn_param_types || direct in g.tc.fn_ret_types {
@@ -471,7 +495,7 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 	} else {
 		ret_type := g.tc.parse_type(node.typ)
 		g.set_cur_fn_ret(ret_type)
-		g.write(g.optional_type_name(ret_type))
+		g.write(g.fn_return_type_name(ret_type))
 		g.write(' ')
 		g.write(qualified_fn_name_in_module(module_name, node.value))
 		g.write('(')
@@ -1160,6 +1184,26 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 							}
 						}
 					}
+						if !is_method {
+							// Static method on a named type / type alias (e.g. `SimdFloat4.new(...)`,
+							// where `SimdFloat4` names a type, not a value). The base ident resolves to
+							// no value type, so handle it before the instance-method fallback.
+							base_node_s := g.a.child_node(fn_node, 0)
+							if base_node_s.kind == .ident {
+								if static_fn := g.static_method_fn_name(base_node_s.value, fn_node.value) {
+									g.write(g.direct_call_name(static_fn))
+									g.write('(')
+									for i in 1 .. node.children_count {
+										if i > 1 {
+											g.write(', ')
+										}
+										g.gen_expr(g.a.child(&node, i))
+									}
+									g.write(')')
+									return
+								}
+							}
+						}
 					if !is_method {
 						mut struct_name := clean_type.name()
 						if clean_type is types.Struct {
@@ -2678,7 +2722,7 @@ fn (mut g FlatGen) forward_decls() {
 			g.tc.cur_file = cur_file
 			g.tc.cur_module = cur_module
 			ret_type := g.tc.parse_type(node.typ)
-			g.write(g.optional_type_name(ret_type))
+			g.write(g.fn_return_type_name(ret_type))
 			g.write(' ')
 			g.write(qfn)
 			g.write('(')
@@ -2979,7 +3023,7 @@ fn (mut g FlatGen) emit_fn_ptr_typedef(encoded string, name string, mut emitted 
 	}
 	emitted[encoded] = true
 	ret, params := fn_ptr_typedef_parts(encoded)
-	ret_ct := g.fn_ptr_typedef_type(ret, mut emitted)
+	ret_ct := g.fn_ptr_return_ct(g.fn_ptr_typedef_type(ret, mut emitted))
 	params_ct := g.fn_ptr_typedef_params(params, mut emitted)
 	g.writeln('typedef ${ret_ct} (*${name})(${params_ct});')
 }

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -197,11 +197,18 @@ fn (g &FlatGen) static_method_fn_name(type_ident string, method string) ?string 
 	if !is_type {
 		return none
 	}
+	// Prefer the module-qualified key: a static method defined in the current (or the
+	// type's) module is emitted under its qualified C name (`viper__Animation__load`),
+	// so the call must resolve to the same qualified key even though an unqualified
+	// alias (`Animation.load`) may also be registered.
+	qdirect := '${qtype}.${method}'
+	if qtype != type_ident && (qdirect in g.tc.fn_ret_types || qdirect in g.tc.fn_param_types) {
+		return qdirect
+	}
 	direct := '${type_ident}.${method}'
 	if direct in g.tc.fn_ret_types || direct in g.tc.fn_param_types {
 		return direct
 	}
-	qdirect := '${qtype}.${method}'
 	if qdirect in g.tc.fn_ret_types || qdirect in g.tc.fn_param_types {
 		return qdirect
 	}
@@ -249,6 +256,31 @@ fn (mut g FlatGen) gen_special_c_callback_arg(fn_name string, arg_idx int, arg_i
 		g.gen_expr(arg_id)
 		return true
 	}
+	// A V function passed by name to a C function (a callback) must be cast: the V
+	// declaration's parameter type (often `voidptr`) is ignored by C in favour of the
+	// real header prototype, so the bare name trips -Wincompatible-function-pointer-types.
+	// `(void*)` converts cleanly to any function-pointer parameter.
+	if int(arg_id) >= 0 {
+		arg_node := g.a.nodes[int(arg_id)]
+		if arg_node.kind == .ident {
+			is_local := (g.tc.cur_scope.lookup(arg_node.value) or { types.Type(types.void_) }) !is types.Void
+			if !is_local {
+				call_name := g.call_key(arg_id, arg_node.value)
+				fn_key := if call_name in g.tc.fn_ret_types {
+					call_name
+				} else if arg_node.value in g.tc.fn_ret_types {
+					arg_node.value
+				} else {
+					''
+				}
+				if fn_key.len > 0 && !fn_key.starts_with('C.') {
+					g.write('(void*)')
+					g.write(c_name(fn_key))
+					return true
+				}
+			}
+		}
+	}
 	return false
 }
 
@@ -259,6 +291,67 @@ fn (mut g FlatGen) spawn_wrapper_decls() {
 	if g.spawn_wrapper_defs.len > 0 {
 		g.writeln('')
 	}
+}
+
+// gen_method_value_closure handles a method used as a *value* (e.g. `game.draw`
+// passed where a `fn ()` callback is expected) rather than called. A plain struct
+// field access can't represent the bound receiver, so it binds the receiver into a
+// per-site context global and yields a wrapper function that invokes the method on
+// it. Returns false when the selector is an ordinary field access (handled normally).
+fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types.Type, method string) bool {
+	clean := types.unwrap_pointer(base_type)
+	if clean !is types.Struct {
+		return false
+	}
+	struct_name := (clean as types.Struct).name
+	// A real field shadows any same-named method: that's a field access, not a value.
+	if _ := g.struct_field_type(struct_name, method) {
+		return false
+	}
+	method_key := g.resolve_method_name(struct_name, method)
+	if method_key.len == 0 {
+		return false
+	}
+	params := g.tc.fn_param_types[method_key] or { return false }
+	if params.len == 0 {
+		return false
+	}
+	ret := g.tc.fn_ret_types[method_key] or { types.Type(types.void_) }
+	cname := c_name(method_key)
+	recv_is_ptr := params[0] is types.Pointer
+	recv_ct := g.tc.c_type(params[0])
+	ret_ct := g.tc.c_type(ret)
+	idx := g.tmp_count
+	g.tmp_count++
+	ctx_name := '_mvctx_${idx}'
+	wrap_name := '_mvwrap_${idx}'
+	mut wparams := []string{}
+	mut call_args := [ctx_name]
+	for i in 1 .. params.len {
+		pt := g.tc.c_type(params[i])
+		wparams << '${pt} a${i}'
+		call_args << 'a${i}'
+	}
+	wparam_str := if wparams.len == 0 { 'void' } else { wparams.join(', ') }
+	g.spawn_wrapper_defs << 'static ${recv_ct} ${ctx_name};'
+	ret_prefix := if ret_ct == 'void' { '' } else { 'return ' }
+	g.spawn_wrapper_defs << 'static ${ret_ct} ${wrap_name}(${wparam_str}) { ${ret_prefix}${cname}(${call_args.join(', ')}); }'
+	// Set the context global to the receiver, then yield the wrapper as the value.
+	g.write('({ ${ctx_name} = ')
+	base_is_ptr := base_type is types.Pointer
+	if recv_is_ptr && !base_is_ptr {
+		g.write('&(')
+		g.gen_expr(base_id)
+		g.write(')')
+	} else if !recv_is_ptr && base_is_ptr {
+		g.write('*(')
+		g.gen_expr(base_id)
+		g.write(')')
+	} else {
+		g.gen_expr(base_id)
+	}
+	g.write('; (void*)${wrap_name}; })')
+	return true
 }
 
 fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
@@ -273,6 +366,9 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 		return
 	}
 	fn_node := g.a.child_node(&call_node, 0)
+	// The spawned call's return type: heap-captured by the wrapper so a later
+	// `[]thread T .wait()` can recover the value (void callees just return NULL).
+	ret_ct := g.tc.c_type(g.tc.resolve_type(call_id))
 	mut wrapper := ''
 	mut arg_expr := 'NULL'
 	if fn_node.kind == .ident {
@@ -283,7 +379,7 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 			g.direct_call_name(fn_node.value)
 		}
 		if call_node.children_count == 1 {
-			wrapper = g.ensure_noarg_spawn_wrapper(cfn)
+			wrapper = g.ensure_noarg_spawn_wrapper(cfn, ret_ct)
 		} else {
 			// `spawn work(a, b)` packs the arguments into a heap struct so the
 			// spawned thread receives them, instead of silently dropping them.
@@ -295,7 +391,7 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 					param_cts << g.tc.c_type(pt)
 					arg_exprs << g.expr_to_string(g.a.child(&call_node, i + 1))
 				}
-				g.emit_args_spawn_expr(cfn, param_cts, arg_exprs)
+				g.emit_args_spawn_expr(cfn, param_cts, arg_exprs, ret_ct)
 				return
 			}
 		}
@@ -312,7 +408,8 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 				base_expr := g.expr_to_string(base_id)
 				if call_node.children_count == 1 {
 					if receiver_type is types.Pointer {
-						wrapper = g.ensure_receiver_spawn_wrapper(c_name(method_name), receiver_ct)
+						wrapper = g.ensure_receiver_spawn_wrapper(c_name(method_name),
+							receiver_ct, ret_ct)
 						if base_type is types.Pointer {
 							arg_expr = '(${receiver_ct})(${base_expr})'
 						} else {
@@ -329,7 +426,7 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 						}
 						g.emit_args_spawn_expr(c_name(method_name), [receiver_ct], [
 							receiver_value,
-						])
+						], ret_ct)
 						return
 					}
 				} else if param_types.len == int(call_node.children_count) {
@@ -352,7 +449,8 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 						param_cts << g.tc.c_type(param_types[i])
 						arg_exprs << g.expr_to_string(g.a.child(&call_node, i))
 					}
-					g.emit_args_spawn_expr(c_name(method_name), param_cts, arg_exprs)
+					g.emit_args_spawn_expr(c_name(method_name), param_cts, arg_exprs,
+						ret_ct)
 					return
 				}
 			}
@@ -370,32 +468,45 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 	g.write('pthread_attr_destroy(&_a${tmp}); (void)_r${tmp}; (void*)_t${tmp}; })')
 }
 
-fn (mut g FlatGen) ensure_noarg_spawn_wrapper(cfn string) string {
+// spawn_wrapper_body builds the thread-wrapper statement that invokes the spawned
+// call and returns its result as a `void*`. When the callee returns a value, the
+// result is heap-copied so `[]thread T .wait()` can recover it (the wait fn frees
+// it); a void callee returns NULL. `post` runs after the call (e.g. `free(p);`).
+fn spawn_wrapper_body(call_expr string, ret_ct string, post string) string {
+	if ret_ct == 'void' || ret_ct.len == 0 {
+		return '${call_expr}; ${post}return NULL;'
+	}
+	return '${ret_ct}* __tr = (${ret_ct}*)malloc(sizeof(${ret_ct})); *__tr = ${call_expr}; ${post}return (void*)__tr;'
+}
+
+fn (mut g FlatGen) ensure_noarg_spawn_wrapper(cfn string, ret_ct string) string {
 	key := 'noarg|${cfn}'
 	if name := g.spawn_wrapper_names[key] {
 		return name
 	}
 	name := c_name('${cfn}_thread_wrapper')
 	g.spawn_wrapper_names[key] = name
-	g.spawn_wrapper_defs << 'static void* ${name}(void* arg) { (void)arg; ${cfn}(); return NULL; }'
+	body := spawn_wrapper_body('${cfn}()', ret_ct, '')
+	g.spawn_wrapper_defs << 'static void* ${name}(void* arg) { (void)arg; ${body} }'
 	return name
 }
 
-fn (mut g FlatGen) ensure_receiver_spawn_wrapper(cfn string, receiver_ct string) string {
+fn (mut g FlatGen) ensure_receiver_spawn_wrapper(cfn string, receiver_ct string, ret_ct string) string {
 	key := 'receiver|${cfn}|${receiver_ct}'
 	if name := g.spawn_wrapper_names[key] {
 		return name
 	}
 	name := c_name('${cfn}_thread_wrapper')
 	g.spawn_wrapper_names[key] = name
-	g.spawn_wrapper_defs << 'static void* ${name}(void* arg) { ${cfn}((${receiver_ct})arg); return NULL; }'
+	body := spawn_wrapper_body('${cfn}((${receiver_ct})arg)', ret_ct, '')
+	g.spawn_wrapper_defs << 'static void* ${name}(void* arg) { ${body} }'
 	return name
 }
 
 // ensure_args_spawn_wrapper registers (once per callee) a heap-arg struct plus a
 // thread wrapper that unpacks the struct, calls the function with all arguments,
 // and frees the struct. Returns the wrapper name and the arg struct name.
-fn (mut g FlatGen) ensure_args_spawn_wrapper(cfn string, param_cts []string) (string, string) {
+fn (mut g FlatGen) ensure_args_spawn_wrapper(cfn string, param_cts []string, ret_ct string) (string, string) {
 	struct_name := c_name('${cfn}_thread_args')
 	key := 'args|${cfn}'
 	if name := g.spawn_wrapper_names[key] {
@@ -410,14 +521,15 @@ fn (mut g FlatGen) ensure_args_spawn_wrapper(cfn string, param_cts []string) (st
 		call_args << 'p->a${i}'
 	}
 	g.spawn_wrapper_defs << 'typedef struct { ${fields}} ${struct_name};'
-	g.spawn_wrapper_defs << 'static void* ${name}(void* arg) { ${struct_name}* p = (${struct_name}*)arg; ${cfn}(${call_args.join(', ')}); free(p); return NULL; }'
+	body := spawn_wrapper_body('${cfn}(${call_args.join(', ')})', ret_ct, 'free(p); ')
+	g.spawn_wrapper_defs << 'static void* ${name}(void* arg) { ${struct_name}* p = (${struct_name}*)arg; ${body} }'
 	return name, struct_name
 }
 
 // emit_args_spawn_expr writes a statement-expression that heap-allocates the arg
 // struct, populates it, and starts the thread on the packing wrapper.
-fn (mut g FlatGen) emit_args_spawn_expr(cfn string, param_cts []string, arg_exprs []string) {
-	wrapper, struct_name := g.ensure_args_spawn_wrapper(cfn, param_cts)
+fn (mut g FlatGen) emit_args_spawn_expr(cfn string, param_cts []string, arg_exprs []string, ret_ct string) {
+	wrapper, struct_name := g.ensure_args_spawn_wrapper(cfn, param_cts, ret_ct)
 	tmp := g.tmp_count
 	g.tmp_count++
 	g.write('({ ${struct_name}* _sa${tmp} = (${struct_name}*)malloc(sizeof(${struct_name})); ')
@@ -888,6 +1000,34 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					g.gen_call_args(full_name, node, 1)
 					g.write(')')
 					return
+				} else if base.kind == .ident && !base_is_local
+					&& g.static_method_fn_name(base.value, fn_node.value) != none {
+					// `Type.method(...)` where the base ident names a (possibly
+					// imported) type, not a value — e.g. `Animation.load(path)` inside
+					// the type's own module. Resolve to the module-qualified static fn.
+					static_fn := g.static_method_fn_name(base.value, fn_node.value) or { '' }
+					static_params := g.param_types_for(static_fn, fn_node.value)
+					g.write(g.direct_call_name(static_fn))
+					g.write('(')
+					for i in 1 .. node.children_count {
+						if i > 1 {
+							g.write(', ')
+						}
+						arg_id := g.a.child(&node, i)
+						arg_idx := i - 1
+						// Decay a fixed-array `[N]T` argument to `T*` when the static
+						// method's parameter is a fixed array (`SimdInt4.load_ptr([4]int)`),
+						// matching how ordinary calls coerce such arguments.
+						if arg_idx < static_params.len {
+							if fixed := array_fixed_type(static_params[arg_idx]) {
+								g.gen_fixed_array_data_arg(arg_id, fixed)
+								continue
+							}
+						}
+						g.gen_expr(arg_id)
+					}
+					g.write(')')
+					return
 				} else if base.kind == .selector {
 					inner := g.a.child_node(base, 0)
 					inner_is_local := if inner.kind == .ident {
@@ -1301,7 +1441,16 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 			} else {
 				g.call_key(id, fn_name)
 			}
-			param_types := g.param_types_for(actual_fn, fn_name)
+			mut param_types := g.param_types_for(actual_fn, fn_name)
+			if param_types.len == 0 && !is_method {
+				// Calling through a function-typed value (a generic `f F` parameter or a
+				// local fn variable): the callee is not a named function, so recover the
+				// parameter types from the value's own function type. This lets `mut` /
+				// pointer arguments receive their `&` exactly as a direct call would.
+				if ft := fn_type_from(g.tc.resolve_type(g.a.child(&node, 0))) {
+					param_types = ft.params.clone()
+				}
+			}
 			mut arg_start := 1
 			if is_method {
 				base_type := g.receiver_base_type(base_id)
@@ -1318,7 +1467,15 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					&& g.gen_embedded_method_receiver(base_id, base_type, param_types[0], wants_ptr) {
 					arg_start = 1
 				} else {
-					is_ptr_base := base_type is types.Pointer
+					mut is_ptr_base := base_type is types.Pointer
+					// A `string.*` method always takes its receiver by value. If the
+					// receiver mis-resolves to a char pointer (e.g. a `const x =
+					// os.getenv(..)` whose type was inferred as `&char`), the actual
+					// storage is still a `string`, so do not dereference it.
+					if is_ptr_base && method_name.starts_with('string.')
+						&& base_type is types.Pointer && base_type.base_type is types.Char {
+						is_ptr_base = false
+					}
 					if (wants_ptr || atomic_receiver_wants_ptr) && !is_ptr_base {
 						g.write('&')
 					} else if !wants_ptr && !atomic_receiver_wants_ptr && is_ptr_base {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -339,7 +339,10 @@ fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types
 	cname := c_name(method_key)
 	recv_is_ptr := params[0] is types.Pointer
 	recv_ct := g.tc.c_type(params[0])
-	ret_ct := g.tc.c_type(ret)
+	// Use the method's ABI return type (matching `cname`'s signature and the callback
+	// fn-pointer typedef): an option/result is `Optional_T`, a fixed array its
+	// `_v_ret_*` wrapper — not the bare `c_type` (`Optional`/`Array_fixed_*`).
+	ret_ct := g.fn_return_type_name(ret)
 	idx := g.tmp_count
 	g.tmp_count++
 	ctx_name := '_mvctx_${idx}'
@@ -369,7 +372,16 @@ fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types
 	} else {
 		g.gen_expr(base_id)
 	}
-	g.write('; (void*)${wrap_name}; })')
+	// Yield the wrapper as the callback value. A V `fn (...) ...` parameter is a
+	// `_fn_ptr_*` typedef and needs the wrapper cast to that function-pointer type; only
+	// a C / `voidptr` callback slot gets the object-pointer `(void*)` cast (which strict
+	// C rejects for function pointers).
+	if g.expected_expr_type is types.FnType {
+		fnptr_ct := g.value_c_type(g.expected_expr_type)
+		g.write('; (${fnptr_ct})${wrap_name}; })')
+	} else {
+		g.write('; (void*)${wrap_name}; })')
+	}
 	return true
 }
 

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -260,7 +260,8 @@ fn (mut g FlatGen) gen_special_c_callback_arg(fn_name string, arg_idx int, arg_i
 	// pointer directly: `(void*)foo` is an object-pointer-to-function-pointer cast that
 	// strict C rejects and that is not portable across ABIs. C functions (and loosely
 	// typed `voidptr` slots) still need it, because C uses the header prototype.
-	if expected_param is types.FnType {
+	// `fn_type_from` is alias-aware, so a `type Cb = fn ()` parameter is recognised too.
+	if _ := fn_type_from(expected_param) {
 		return false
 	}
 	// A V function passed by name to a C function (a callback) must be cast: the V
@@ -328,15 +329,39 @@ fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types
 		return false
 	}
 	method_key := g.resolve_method_name(struct_name, method)
-	if method_key.len == 0 {
+	mut params := []types.Type{}
+	mut ret := types.Type(types.void_)
+	mut cname := ''
+	if method_key.len > 0 {
+		params = g.tc.fn_param_types[method_key] or { return false }
+		ret = g.tc.fn_ret_types[method_key] or { types.Type(types.void_) }
+		cname = c_name(method_key)
+	} else if ci := g.tc.generic_method_value_info['${struct_name}.${method}'] {
+		// Generic receiver (`Box[int]`): the open `Box[T].get` registration is gone by
+		// cgen, so use the substituted params/return the checker stashed, plus the
+		// monomorphised C name `c_name('Box[int].get')` == `Box_int__get`.
+		params = ci.params.clone()
+		// The receiver param is the un-substituted open `Box[T]`; replace it with the
+		// concrete receiver type (keeping the method's pointer-ness) so its C name
+		// resolves to `Box_int` rather than the template `Box`.
+		if params.len > 0 {
+			recv_concrete := types.unwrap_pointer(base_type)
+			params[0] = if params[0] is types.Pointer {
+				types.Type(types.Pointer{
+					base_type: recv_concrete
+				})
+			} else {
+				recv_concrete
+			}
+		}
+		ret = ci.return_type
+		cname = c_name('${struct_name}.${method}')
+	} else {
 		return false
 	}
-	params := g.tc.fn_param_types[method_key] or { return false }
 	if params.len == 0 {
 		return false
 	}
-	ret := g.tc.fn_ret_types[method_key] or { types.Type(types.void_) }
-	cname := c_name(method_key)
 	recv_is_ptr := params[0] is types.Pointer
 	recv_ct := g.tc.c_type(params[0])
 	// Use the method's ABI return type (matching `cname`'s signature and the callback

--- a/vlib/v3/gen/c/fn_d_parallel.v
+++ b/vlib/v3/gen/c/fn_d_parallel.v
@@ -378,6 +378,7 @@ fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 		line_start:              true
 		modules:                 g.modules
 		fn_ptr_types:            g.fn_ptr_types.clone()
+		fixed_array_ret_wrappers: g.fixed_array_ret_wrappers
 		fn_decl_param_types:     g.fn_decl_param_types
 		fn_decl_ret_types:       g.fn_decl_ret_types
 		struct_decl_infos:       g.struct_decl_infos
@@ -476,6 +477,19 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 	for encoded, name in w.fn_ptr_types {
 		if encoded !in g.fn_ptr_types {
 			g.fn_ptr_types[encoded] = name
+		}
+	}
+	// Spawn wrappers (thread arg structs + trampoline fns) are generated on demand
+	// inside fn bodies, so a worker that emits a `spawn` produces wrapper defs the
+	// master must also emit. Deduplicate by their deterministic key/def.
+	for key, name in w.spawn_wrapper_names {
+		if key !in g.spawn_wrapper_names {
+			g.spawn_wrapper_names[key] = name
+		}
+	}
+	for def in w.spawn_wrapper_defs {
+		if def !in g.spawn_wrapper_defs {
+			g.spawn_wrapper_defs << def
 		}
 	}
 }

--- a/vlib/v3/gen/c/fn_d_parallel.v
+++ b/vlib/v3/gen/c/fn_d_parallel.v
@@ -352,54 +352,54 @@ fn (mut g FlatGen) fn_ptr_type_key(typ types.FnType) string {
 // worker and, under -gc none, never freed.
 fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 	return &FlatGen{
-		sb:                      strings.new_builder(64_000)
-		a:                       unsafe { g.a }
-		used_fns:                g.used_fns
-		used_fn_names:           g.used_fn_names
-		str_lits:                g.str_lits.clone()
-		str_lit_ids:             g.str_lit_ids.clone()
-		global_types:            g.global_types
-		enum_vals:               g.enum_vals
-		interfaces:              g.interfaces
-		const_vals:              g.const_vals
-		const_modules:           g.const_modules
-		const_init_order:        g.const_init_order
-		global_modules:          g.global_modules
-		global_inits:            g.global_inits
-		global_init_order:       g.global_init_order
-		iface_impls:             g.iface_impls
-		iface_type_ids:          g.iface_type_ids
-		module_init_fns:         g.module_init_fns
-		module_init_fn_modules:  g.module_init_fn_modules
-		module_imports:          g.module_imports
-		tc:                      g.clone_parallel_type_checker()
-		has_builtins:            g.has_builtins
-		tmp_count:               (worker_id + 1) * 100_000
-		line_start:              true
-		modules:                 g.modules
-		fn_ptr_types:            g.fn_ptr_types.clone()
+		sb:                       strings.new_builder(64_000)
+		a:                        unsafe { g.a }
+		used_fns:                 g.used_fns
+		used_fn_names:            g.used_fn_names
+		str_lits:                 g.str_lits.clone()
+		str_lit_ids:              g.str_lit_ids.clone()
+		global_types:             g.global_types
+		enum_vals:                g.enum_vals
+		interfaces:               g.interfaces
+		const_vals:               g.const_vals
+		const_modules:            g.const_modules
+		const_init_order:         g.const_init_order
+		global_modules:           g.global_modules
+		global_inits:             g.global_inits
+		global_init_order:        g.global_init_order
+		iface_impls:              g.iface_impls
+		iface_type_ids:           g.iface_type_ids
+		module_init_fns:          g.module_init_fns
+		module_init_fn_modules:   g.module_init_fn_modules
+		module_imports:           g.module_imports
+		tc:                       g.clone_parallel_type_checker()
+		has_builtins:             g.has_builtins
+		tmp_count:                (worker_id + 1) * 100_000
+		line_start:               true
+		modules:                  g.modules
+		fn_ptr_types:             g.fn_ptr_types.clone()
 		fixed_array_ret_wrappers: g.fixed_array_ret_wrappers
-		fn_decl_param_types:     g.fn_decl_param_types
-		fn_decl_ret_types:       g.fn_decl_ret_types
-		struct_decl_infos:       g.struct_decl_infos
-		struct_decl_short_infos: g.struct_decl_short_infos
-		runtime_inits:           g.runtime_inits.clone()
-		compiler_vroot:          g.compiler_vroot
-		cur_param_names:         g.cur_param_names.clone()
-		cur_param_type_values:   g.cur_param_type_values.clone()
-		cur_param_types:         g.cur_param_types.clone()
-		cur_fn_ret:              g.cur_fn_ret
-		cur_fn_ret_is_optional:  g.cur_fn_ret_is_optional
-		cur_fn_ret_base:         g.cur_fn_ret_base
-		expected_expr_type:      g.expected_expr_type
-		expected_enum:           g.expected_enum
-		needed_optional_types:   g.needed_optional_types.clone()
-		emitted_optional_types:  g.emitted_optional_types.clone()
-		emitted_fns:             g.emitted_fns.clone()
-		array_method_cache:      g.array_method_cache.clone()
-		param_types_cache:       g.param_types_cache.clone()
-		embedded_fields_by_type: g.embedded_fields_by_type
-		param_types_by_short:    g.param_types_by_short
+		fn_decl_param_types:      g.fn_decl_param_types
+		fn_decl_ret_types:        g.fn_decl_ret_types
+		struct_decl_infos:        g.struct_decl_infos
+		struct_decl_short_infos:  g.struct_decl_short_infos
+		runtime_inits:            g.runtime_inits.clone()
+		compiler_vroot:           g.compiler_vroot
+		cur_param_names:          g.cur_param_names.clone()
+		cur_param_type_values:    g.cur_param_type_values.clone()
+		cur_param_types:          g.cur_param_types.clone()
+		cur_fn_ret:               g.cur_fn_ret
+		cur_fn_ret_is_optional:   g.cur_fn_ret_is_optional
+		cur_fn_ret_base:          g.cur_fn_ret_base
+		expected_expr_type:       g.expected_expr_type
+		expected_enum:            g.expected_enum
+		needed_optional_types:    g.needed_optional_types.clone()
+		emitted_optional_types:   g.emitted_optional_types.clone()
+		emitted_fns:              g.emitted_fns.clone()
+		array_method_cache:       g.array_method_cache.clone()
+		param_types_cache:        g.param_types_cache.clone()
+		embedded_fields_by_type:  g.embedded_fields_by_type
+		param_types_by_short:     g.param_types_by_short
 	}
 }
 
@@ -461,6 +461,10 @@ fn (g &FlatGen) clone_parallel_type_checker() &types.TypeChecker {
 		diagnostic_files:              g.tc.diagnostic_files
 		cur_fn_ret_type:               g.tc.cur_fn_ret_type
 		smartcasts:                    g.tc.smartcasts
+		// Read-only map cgen uses to recover substituted signatures for generic-receiver
+		// method values (`Box[int].method` as a callback); without it a parallel worker
+		// sees an empty map and gen_method_value_closure falls through.
+		generic_method_value_info: g.tc.generic_method_value_info
 	}
 }
 

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -99,7 +99,16 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 				g.tc.cur_scope.insert(val_var_, clean_container_type.value_type)
 			} else if container_type is types.Array {
 				c_elem := g.value_c_type(container_type.elem_type)
-				container_str := g.expr_to_string(g.a.child(&node, 2))
+				mut container_str := g.expr_to_string(g.a.child(&node, 2))
+				// A call-valued container (e.g. `threads.wait()`, `xs.map(..)`) is not
+				// idempotent and is referenced multiple times below; bind it to a temp so
+				// it runs exactly once.
+				if g.a.nodes[int(g.a.child(&node, 2))].kind == .call {
+					arr_tmp := '__for_arr_${g.tmp_count}'
+					g.tmp_count++
+					g.writeln('Array ${arr_tmp} = ${container_str};')
+					container_str = arr_tmp
+				}
 				g.writeln('for (int ${idx_var} = 0; ${idx_var} < ${container_str}.len; ${idx_var}++) {')
 				g.indent++
 				g.write('${c_elem} ${elem_var} = *(')

--- a/vlib/v3/gen/c/if.v
+++ b/vlib/v3/gen/c/if.v
@@ -10,46 +10,105 @@ struct MultiReturnTailParts {
 
 // gen_if emits if output for c.
 fn (mut g FlatGen) gen_if(node flat.Node) {
-	if node.children_count < 2 {
-		return
-	}
-	cond_id := g.a.child(&node, 0)
-	if !g.valid_node_id(cond_id) {
-		return
-	}
-	cond := g.a.nodes[int(cond_id)]
-	if cond.kind == .decl_assign {
-		g.gen_if_guard(node, cond)
-		return
-	}
-	if cond.kind != .empty {
-		g.write('if (')
-		g.gen_expr(cond_id)
-		g.writeln(') {')
-	} else {
-		g.writeln('{')
-	}
-	g.tc.push_scope()
-	defer_start := g.defers.len
-	g.indent++
-	if cond.kind == .is_expr {
-		g.smartcast_is_expr(&cond)
-	}
-	then_id := g.a.child(&node, 1)
-	if g.valid_node_id(then_id) {
-		then_block := g.a.nodes[int(then_id)]
-		for i in 0 .. then_block.children_count {
-			child_id := g.a.child(&then_block, i)
-			if g.valid_node_id(child_id) {
-				g.gen_node(child_id)
+	// Iterate the `else if` chain rather than recursing through gen_if/gen_if_else for
+	// each link. A lowered match can produce hundreds of chained `if_expr` nodes (one
+	// per arm); recursing once per arm overflows the stack on big matches. The emitted
+	// C is identical — only the generation is flattened into a loop.
+	mut cur := node
+	for {
+		if cur.children_count < 2 {
+			return
+		}
+		cond_id := g.a.child(&cur, 0)
+		if !g.valid_node_id(cond_id) {
+			return
+		}
+		cond := g.a.nodes[int(cond_id)]
+		if cond.kind == .decl_assign {
+			g.gen_if_guard(cur, cond)
+			return
+		}
+		if cond.kind != .empty {
+			g.write('if (')
+			g.gen_expr(cond_id)
+			g.writeln(') {')
+		} else {
+			g.writeln('{')
+		}
+		g.tc.push_scope()
+		defer_start := g.defers.len
+		g.indent++
+		if cond.kind == .is_expr {
+			g.smartcast_is_expr(&cond)
+		}
+		then_id := g.a.child(&cur, 1)
+		if g.valid_node_id(then_id) {
+			then_block := g.a.nodes[int(then_id)]
+			for i in 0 .. then_block.children_count {
+				child_id := g.a.child(&then_block, i)
+				if g.valid_node_id(child_id) {
+					g.gen_node(child_id)
+				}
 			}
 		}
+		g.gen_defers_from(defer_start)
+		g.trim_defers(defer_start)
+		g.indent--
+		g.tc.pop_scope()
+		// else handling — continue the loop for a plain `else if`, recurse only for the
+		// rare guard-else (`else if x := ...`).
+		if cur.children_count <= 2 {
+			g.writeln('}')
+			return
+		}
+		else_id := g.a.child(&cur, 2)
+		if !g.valid_node_id(else_id) {
+			g.writeln('}')
+			return
+		}
+		else_node := g.a.nodes[int(else_id)]
+		if else_node.kind == .if_expr {
+			else_cond_id := g.a.child(&else_node, 0)
+			else_cond_is_guard := if g.valid_node_id(else_cond_id) {
+				g.a.nodes[int(else_cond_id)].kind == .decl_assign
+			} else {
+				false
+			}
+			if else_cond_is_guard {
+				g.writeln('} else {')
+				g.tc.push_scope()
+				g.indent++
+				g.gen_if(else_node)
+				g.indent--
+				g.tc.pop_scope()
+				g.writeln('}')
+				return
+			}
+			g.write('} else ')
+			cur = else_node
+			continue
+		} else if else_node.kind == .block {
+			g.writeln('} else {')
+			g.tc.push_scope()
+			else_defer_start := g.defers.len
+			g.indent++
+			for i in 0 .. else_node.children_count {
+				child_id := g.a.child(&else_node, i)
+				if g.valid_node_id(child_id) {
+					g.gen_node(child_id)
+				}
+			}
+			g.gen_defers_from(else_defer_start)
+			g.trim_defers(else_defer_start)
+			g.indent--
+			g.tc.pop_scope()
+			g.writeln('}')
+			return
+		} else {
+			g.writeln('}')
+			return
+		}
 	}
-	g.gen_defers_from(defer_start)
-	g.trim_defers(defer_start)
-	g.indent--
-	g.tc.pop_scope()
-	g.gen_if_else(node)
 }
 
 // smartcast_is_expr supports smartcast is expr handling for FlatGen.
@@ -467,24 +526,32 @@ fn (mut g FlatGen) gen_if_expr_stmt(node flat.Node) {
 	g.write('_ifexpr;})')
 }
 
-// gen_if_expr_else_if emits if expr else if output for c.
+// gen_if_expr_else_if emits if expr else if output for c. The `else if` chain is
+// iterated rather than recursed: a lowered match-expression can chain hundreds of
+// `if_expr` nodes (one per arm), and recursing once per arm — each frame copying a
+// `flat.Node` and a `Type` by value — overflows the stack. The emitted C is identical.
 fn (mut g FlatGen) gen_if_expr_else_if(node flat.Node, ret_type types.Type) {
-	then_block := g.a.child_node(&node, 1)
-	g.write('if (')
-	g.gen_expr(g.a.child(&node, 0))
-	g.writeln(') {')
-	g.gen_if_expr_block(then_block, ret_type)
-	g.write('} else ')
-	if node.children_count > 2 {
-		else_node := g.a.child_node(&node, 2)
-		if else_node.kind == .if_expr {
-			g.gen_if_expr_else_if(*else_node, ret_type)
-		} else if else_node.kind == .block {
-			g.writeln('{')
-			g.gen_if_expr_block(else_node, ret_type)
-			g.writeln('}')
+	mut cur := node
+	for {
+		then_block := g.a.child_node(&cur, 1)
+		g.write('if (')
+		g.gen_expr(g.a.child(&cur, 0))
+		g.writeln(') {')
+		g.gen_if_expr_block(then_block, ret_type)
+		g.write('} else ')
+		if cur.children_count > 2 {
+			else_node := g.a.child_node(&cur, 2)
+			if else_node.kind == .if_expr {
+				cur = *else_node
+				continue
+			} else if else_node.kind == .block {
+				g.writeln('{')
+				g.gen_if_expr_block(else_node, ret_type)
+				g.writeln('}')
+			}
+			return
 		}
-	} else {
 		g.writeln('{ _ifexpr = (typeof(_ifexpr)){0}; }')
+		return
 	}
 }

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -365,7 +365,8 @@ fn (g &FlatGen) should_emit_interface_dispatch(iface_name string, method string)
 		im := '${impl}.${method}'
 		short_im := '${impl.all_after_last('.')}.${method}'
 		if g.used_fn_contains(im) || g.used_fn_contains(c_name(im))
-			|| (short_im != im && (g.used_fn_contains(short_im) || g.used_fn_contains(c_name(short_im)))) {
+			|| (short_im != im && (g.used_fn_contains(short_im)
+			|| g.used_fn_contains(c_name(short_im)))) {
 			return true
 		}
 	}
@@ -446,7 +447,10 @@ fn (mut g FlatGen) gen_interface_dispatch(iface_name string, cn string, method s
 			types.Type(types.void_)
 		}
 	}
-	ret_ct := g.optional_type_name(ret_type)
+	// Use the ABI return type, not the bare value type: a fixed-array return is its `_v_ret_*`
+	// wrapper struct (a C function cannot return an array by value), matching what the concrete
+	// implementer's method returns and what the call site unwraps.
+	ret_ct := g.fn_return_type_name(ret_type)
 	mut sig_params := if sig_key.len > 0 {
 		g.tc.fn_param_types[sig_key] or { []types.Type{} }
 	} else {

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -357,6 +357,18 @@ fn (g &FlatGen) should_emit_interface_dispatch(iface_name string, method string)
 	if g.used_fn_contains(name) || g.used_fn_contains(c_name(name)) {
 		return true
 	}
+	// If any concrete implementer's method is live, the dispatch is reachable even
+	// when the interface entry itself wasn't directly marked — markused's reachability
+	// can enqueue the implementers (via iface_impls) but miss the interface method when
+	// its short name is ambiguous (e.g. `resize` also on Camera/SamplingJobContext).
+	for impl in g.iface_impls[iface_name] or { []string{} } {
+		im := '${impl}.${method}'
+		short_im := '${impl.all_after_last('.')}.${method}'
+		if g.used_fn_contains(im) || g.used_fn_contains(c_name(im))
+			|| (short_im != im && (g.used_fn_contains(short_im) || g.used_fn_contains(c_name(short_im)))) {
+			return true
+		}
+	}
 	if decl_key := g.interface_method_signature_key(iface_name, method) {
 		if decl_key != name
 			&& (g.used_fn_contains(decl_key) || g.used_fn_contains(c_name(decl_key))) {

--- a/vlib/v3/gen/c/names.v
+++ b/vlib/v3/gen/c/names.v
@@ -42,6 +42,23 @@ const c_reserved_words = {
 	'while':    true
 }
 
+// c_libc_collisions are libc function names that are not C keywords but clash at
+// link/declaration time when a user defines a plain (module `main`) function with
+// the same name (e.g. `fn rint(...)` vs libc's `double rint(double)`). They are
+// mangled to `v_<name>` consistently at definition and call sites. `C.<name>`
+// calls are unaffected (the `C.` prefix is stripped before this check).
+const c_libc_collisions = {
+	'rint':  true
+	'y0':    true
+	'y1':    true
+	'yn':    true
+	'j0':    true
+	'j1':    true
+	'jn':    true
+	'drem':  true
+	'scalb': true
+}
+
 // c_name converts c name data for c.
 fn c_name(name string) string {
 	if name.starts_with('C.') {
@@ -61,13 +78,13 @@ fn c_name(name string) string {
 		return 'v_exit'
 	}
 	if c_name_is_plain(name) {
-		if name in c_reserved_words {
+		if name in c_reserved_words || name in c_libc_collisions {
 			return 'v_${name}'
 		}
 		return name
 	}
 	n := c_name_sanitize(name)
-	if n in c_reserved_words {
+	if n in c_reserved_words || n in c_libc_collisions {
 		return 'v_${n}'
 	}
 	return n

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -612,7 +612,9 @@ fn (mut g FlatGen) return_expr_string(node flat.Node, ret_id flat.NodeId, ret_no
 		return '(${ct}){${g.expr_to_string(ret_id)}}'
 	}
 	if g.cur_fn_ret is types.Interface {
-		return '(${ct}){0}'
+		// Box the concrete value the same way the direct return path does, so a deferred return
+		// preserves `_typ`/`_object` instead of zeroing the interface.
+		return g.interface_value_to_string(ret_id, g.cur_fn_ret)
 	}
 	return g.expr_to_string(ret_id)
 }

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -316,6 +316,11 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 					}
 				} else if ret_node.kind == .assoc {
 					g.gen_return_assoc(ret_node)
+				} else if g.cur_fn_ret is types.ArrayFixed
+					&& g.tc.c_type(g.cur_fn_ret) in g.fixed_array_ret_wrappers {
+					g.write('return ')
+					g.gen_fixed_array_return_wrap(g.cur_fn_ret, ret_id)
+					g.writeln(';')
 				} else {
 					if g.cur_fn_ret is types.Interface {
 						ct := g.tc.c_type(g.cur_fn_ret)
@@ -428,12 +433,34 @@ fn (mut g FlatGen) gen_return_with_defers(node flat.Node) {
 		g.writeln('return ${tmp};')
 		return
 	}
+	if g.cur_fn_ret is types.ArrayFixed
+		&& g.tc.c_type(g.cur_fn_ret) in g.fixed_array_ret_wrappers {
+		wrapper := fixed_array_ret_wrapper_name(g.tc.c_type(g.cur_fn_ret))
+		tmp := g.tmp_name()
+		g.write('${wrapper} ${tmp} = ')
+		g.gen_fixed_array_return_wrap(g.cur_fn_ret, ret_id)
+		g.writeln(';')
+		g.gen_all_defers()
+		g.writeln('return ${tmp};')
+		return
+	}
 	ct := g.return_c_type()
 	expr := g.return_expr_string(node, ret_id, ret_node, ct)
 	tmp := g.tmp_name()
 	g.writeln('${ct} ${tmp} = ${expr};')
 	g.gen_all_defers()
 	g.writeln('return ${tmp};')
+}
+
+// gen_fixed_array_return_wrap emits a fixed-array return value wrapped in its
+// return-wrapper struct: `({ Wrapper __fa_ret; memcpy(__fa_ret.ret_arr, <expr>,
+// sizeof(...)); __fa_ret; })`. C cannot return raw arrays, so the array is copied
+// into the wrapper's `ret_arr` field and the struct is returned by value.
+fn (mut g FlatGen) gen_fixed_array_return_wrap(ret_type types.Type, ret_id flat.NodeId) {
+	wrapper := fixed_array_ret_wrapper_name(g.tc.c_type(ret_type))
+	g.write('({ ${wrapper} __fa_ret; memcpy(__fa_ret.ret_arr, ')
+	g.gen_fixed_array_copy_source(ret_id, ret_type)
+	g.write(', sizeof(__fa_ret.ret_arr)); __fa_ret; })')
 }
 
 fn (mut g FlatGen) gen_default_return_stmt() {
@@ -1041,6 +1068,22 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 				g.optional_type_name(v_type)
 			} else {
 				ct0
+			}
+			if v_type is types.ArrayFixed {
+				// A fixed array cannot be initialized from another array value
+				// (`T x[N] = expr` is illegal); declare then memcpy.
+				lhs_str := g.decl_lhs_str(lhs_id)
+				if !lhs_is_defer_capture {
+					g.writeln('${decl_prefix}${ct} ${lhs_str};')
+				}
+				g.write('memcpy(${lhs_str}, ')
+				g.gen_fixed_array_copy_source(rhs_id, v_type)
+				g.writeln(', sizeof(${lhs_str}));')
+				if lhs.kind == .ident {
+					g.tc.cur_scope.insert(lhs.value, v_type)
+				}
+				i += 2
+				continue
 			}
 			if ct.starts_with('fn_ptr:') {
 				fp_name := g.resolve_fn_ptr_type(ct)

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -249,6 +249,12 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 					}
 					if base is types.Void {
 						g.writeln('return (${ct}){.ok = false};')
+					} else if base is types.ArrayFixed {
+						// The optional's `.value` is a fixed-array member, which can't be set
+						// in the compound literal; build via a temp + memcpy.
+						g.write('return ({ ${ct} __opt = {.ok = true}; memcpy(__opt.value, ')
+						g.gen_fixed_array_copy_source(ret_id, base)
+						g.writeln(', sizeof(__opt.value)); __opt; });')
 					} else {
 						raw_expr_type := g.tc.resolve_type(ret_id)
 						expr_type := g.usable_expr_type(ret_id)
@@ -293,6 +299,34 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 				} else if g.cur_fn_ret is types.MultiReturn {
 					if node.children_count > 1 {
 						ct := g.tc.c_type(g.cur_fn_ret)
+						mr_types := g.cur_fn_ret.types
+						mut has_fixed := false
+						for mt in mr_types {
+							if mt is types.ArrayFixed {
+								has_fixed = true
+								break
+							}
+						}
+						if has_fixed {
+							// A multi-return with a fixed-array member can't be built by a
+							// positional compound literal (array members need memcpy).
+							tmp := g.tmp_name()
+							g.write('return ({ ${ct} ${tmp} = {0};')
+							for i in 0 .. node.children_count {
+								if i < mr_types.len && mr_types[i] is types.ArrayFixed {
+									g.write(' memcpy(${tmp}.arg${i}, ')
+									g.gen_fixed_array_copy_source(g.a.child(&node, i), mr_types[i])
+									g.write(', sizeof(${tmp}.arg${i}));')
+								} else {
+									g.write(' ${tmp}.arg${i} = ')
+									g.gen_expr(g.a.child(&node, i))
+									g.write(';')
+								}
+							}
+							g.writeln(' ${tmp}; });')
+							g.expected_enum = ''
+							return
+						}
 						g.write('return (${ct}){')
 						for i in 0 .. node.children_count {
 							if i > 0 {
@@ -322,14 +356,22 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 					g.gen_fixed_array_return_wrap(g.cur_fn_ret, ret_id)
 					g.writeln(';')
 				} else {
+					g.write('return ')
+					// Most interface returns are already boxed by the transform pass into
+					// a `(Iface){._typ = N, ._object = ...}` literal, in which case
+					// gen_interface_value_expr is a no-op (the value is already an
+					// interface) and we emit it directly. IError is intentionally left
+					// unboxed by the transform, so box the concrete error here. Never emit
+					// a zeroed `(Iface){0}` — that drops `_typ`/`_object` and makes every
+					// dispatch through the returned interface panic as "not implemented".
 					if g.cur_fn_ret is types.Interface {
-						ct := g.tc.c_type(g.cur_fn_ret)
-						g.writeln('return (${ct}){0};')
+						if !g.gen_interface_value_expr(ret_id, g.cur_fn_ret) {
+							g.gen_expr(ret_id)
+						}
 					} else {
-						g.write('return ')
 						g.gen_expr(ret_id)
-						g.writeln(';')
 					}
+					g.writeln(';')
 				}
 			} else {
 				g.gen_default_return_stmt()
@@ -1230,6 +1272,19 @@ fn (mut g FlatGen) gen_assign(node flat.Node) {
 			lhs_id := g.a.child(&node, i)
 			if rhs_node.kind == .array_literal {
 				lhs_type := types.unwrap_pointer(g.tc.resolve_type(lhs_id))
+				if lhs_type is types.ArrayFixed {
+					// A fixed-array field/var can't be `=`-assigned an array literal (which
+					// lowers to a dynamic `Array`); memcpy the element bytes instead.
+					g.write('memcpy(')
+					g.gen_expr(lhs_id)
+					g.write(', ')
+					g.gen_fixed_array_data_arg(rhs_id, lhs_type)
+					g.write(', sizeof(')
+					g.gen_expr(lhs_id)
+					g.writeln('));')
+					i += 2
+					continue
+				}
 				elem_type := if rhs_node.children_count > 0 {
 					g.tc.resolve_type(g.a.child(&rhs_node, 0))
 				} else if lhs_arr := array_like_type(lhs_type) {
@@ -1244,6 +1299,18 @@ fn (mut g FlatGen) gen_assign(node flat.Node) {
 			} else {
 				lhs_type := g.usable_expr_type(lhs_id)
 				rhs_type := g.usable_expr_type(rhs_id)
+				if node.op == .assign && lhs_type is types.ArrayFixed {
+					// A fixed array can't be assigned with `=`; copy element bytes.
+					g.write('memcpy(')
+					g.gen_expr(lhs_id)
+					g.write(', ')
+					g.gen_fixed_array_copy_source(rhs_id, lhs_type)
+					g.write(', sizeof(')
+					g.gen_expr(lhs_id)
+					g.writeln('));')
+					i += 2
+					continue
+				}
 				if node.op == .plus_assign && (lhs_type is types.String || rhs_type is types.String) {
 					g.gen_expr(g.a.child(&node, i))
 					g.write(' = string__plus(')
@@ -1575,6 +1642,11 @@ fn (mut g FlatGen) gen_or_expr(node flat.Node) {
 	g.write('({${opt_ct} ${tmp} = ')
 	g.gen_expr_with_expected_type(expr_id, expr_type)
 	g.write('; ${val_ct} ${val}; if (${tmp}.ok) { ${val} = ${tmp}.value; } else { IError err = ${tmp}.err; (void)err; ')
+	// Bind `err` (IError) in the cgen scope so the or-body's own string interpolations
+	// and selector accesses resolve `err`'s type correctly. Without this, an `${err}`
+	// inside the or-body (common in const-init or-blocks lowered here) falls back to
+	// `int__str(err)`. Mirrors the for-loop / if-guard scope inserts elsewhere in cgen.
+	g.tc.cur_scope.insert('err', g.tc.parse_type('IError'))
 	g.gen_or_body_value(or_body, val, val_type)
 	g.write(' } ${val};})')
 }
@@ -1616,6 +1688,11 @@ fn (mut g FlatGen) gen_or_body_value(or_body flat.Node, value_name string, value
 				fn_opt_ct := g.optional_type_name(g.cur_fn_ret)
 				g.write('return ')
 				g.gen_optional_error_from_call(fn_opt_ct, g.a.nodes[int(expr_id)])
+				g.write(';')
+			} else if g.tc.resolve_type(expr_id) is types.Void {
+				// A diverging/void or-body tail (e.g. `panic(..)`/`exit(..)`) yields no
+				// value; emit it as a bare statement instead of assigning void.
+				g.gen_expr(expr_id)
 				g.write(';')
 			} else {
 				g.write('${value_name} = ')

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -61,6 +61,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 		return
 	}
 	node := g.a.nodes[int(id)]
+	g.in_return = false
 	match node.kind {
 		.fn_decl, .c_fn_decl {
 			return
@@ -184,6 +185,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			g.gen_index_assign(node)
 		}
 		.return_stmt {
+			g.in_return = true
 			if g.cur_fn_ret is types.Enum {
 				g.expected_enum = g.cur_fn_ret.name
 			}

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -682,22 +682,31 @@ fn (g &FlatGen) declared_call_return_type(call_node flat.Node) types.Type {
 		if ret := g.selector_call_return_type(fn_node) {
 			return ret
 		}
-		return types.Type(types.void_)
-	}
-	if fn_node.kind != .ident {
-		return types.Type(types.void_)
-	}
-	if ret := g.tc.fn_ret_types[fn_node.value] {
-		return ret
-	}
-	cfn := c_name(fn_node.value)
-	if cfn != fn_node.value {
-		if ret := g.tc.fn_ret_types[cfn] {
+	} else if fn_node.kind == .ident {
+		if ret := g.tc.fn_ret_types[fn_node.value] {
+			return ret
+		}
+		cfn := c_name(fn_node.value)
+		if cfn != fn_node.value {
+			if ret := g.tc.fn_ret_types[cfn] {
+				return ret
+			}
+		}
+		if ret := g.fn_decl_return_type_for_call_name(fn_node.value) {
 			return ret
 		}
 	}
-	if ret := g.fn_decl_return_type_for_call_name(fn_node.value) {
-		return ret
+	// Indirect call through an fn-pointer value (local var, param, or struct field
+	// like `h.f()`): the target isn't a declared function/method, so resolve its type
+	// and read the fn type's return. Unwrap alias (`type MakeArr = fn () [2]string`)
+	// and pointer layers first. Lets fixed-array-returning callbacks unwrap `.ret_arr`
+	// at the call site whether reached through a local, a param, or a struct field.
+	mut callee_t := types.unwrap_pointer(g.tc.resolve_type(g.a.child(&call_node, 0)))
+	for callee_t is types.Alias {
+		callee_t = types.unwrap_pointer((callee_t as types.Alias).base_type)
+	}
+	if callee_t is types.FnType {
+		return callee_t.return_type
 	}
 	return types.Type(types.void_)
 }

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -475,8 +475,7 @@ fn (mut g FlatGen) gen_return_with_defers(node flat.Node) {
 		g.writeln('return ${tmp};')
 		return
 	}
-	if g.cur_fn_ret is types.ArrayFixed
-		&& g.tc.c_type(g.cur_fn_ret) in g.fixed_array_ret_wrappers {
+	if g.cur_fn_ret is types.ArrayFixed && g.tc.c_type(g.cur_fn_ret) in g.fixed_array_ret_wrappers {
 		wrapper := fixed_array_ret_wrapper_name(g.tc.c_type(g.cur_fn_ret))
 		tmp := g.tmp_name()
 		g.write('${wrapper} ${tmp} = ')
@@ -1642,12 +1641,15 @@ fn (mut g FlatGen) gen_or_expr(node flat.Node) {
 	g.write('({${opt_ct} ${tmp} = ')
 	g.gen_expr_with_expected_type(expr_id, expr_type)
 	g.write('; ${val_ct} ${val}; if (${tmp}.ok) { ${val} = ${tmp}.value; } else { IError err = ${tmp}.err; (void)err; ')
-	// Bind `err` (IError) in the cgen scope so the or-body's own string interpolations
-	// and selector accesses resolve `err`'s type correctly. Without this, an `${err}`
-	// inside the or-body (common in const-init or-blocks lowered here) falls back to
-	// `int__str(err)`. Mirrors the for-loop / if-guard scope inserts elsewhere in cgen.
+	// Bind `err` (IError) in a *temporary* cgen scope so the or-body's own string
+	// interpolations and selector accesses resolve `err`'s type correctly (without this
+	// an `${err}` inside the or-body falls back to `int__str(err)`). The scope is popped
+	// afterwards so an outer local named `err` keeps its real type — e.g.
+	// `err := 1; _ := maybe() or { 0 }; println('${err}')` must still see `err` as int.
+	g.tc.push_scope()
 	g.tc.cur_scope.insert('err', g.tc.parse_type('IError'))
 	g.gen_or_body_value(or_body, val, val_type)
+	g.tc.pop_scope()
 	g.write(' } ${val};})')
 }
 

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -261,7 +261,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 						raw_expr_type := g.tc.resolve_type(ret_id)
 						expr_type := g.usable_expr_type(ret_id)
 						call_ret_type := g.local_fn_call_return_type(ret_id, ret_node)
-						decl_ret_type := g.declared_call_return_type(ret_node)
+						decl_ret_type := g.declared_call_return_type(ret_id)
 						if g.optional_result_matches_base(raw_expr_type, base)
 							|| g.optional_result_matches_base(expr_type, base)
 							|| g.optional_result_matches_base(call_ret_type, base)
@@ -567,7 +567,7 @@ fn (mut g FlatGen) return_expr_string(node flat.Node, ret_id flat.NodeId, ret_no
 		raw_expr_type := g.tc.resolve_type(ret_id)
 		expr_type := g.usable_expr_type(ret_id)
 		call_ret_type := g.local_fn_call_return_type(ret_id, ret_node)
-		decl_ret_type := g.declared_call_return_type(ret_node)
+		decl_ret_type := g.declared_call_return_type(ret_id)
 		if g.optional_result_matches_base(raw_expr_type, base)
 			|| g.optional_result_matches_base(expr_type, base)
 			|| g.optional_result_matches_base(call_ret_type, base)
@@ -673,7 +673,11 @@ fn (g &FlatGen) local_fn_call_return_type(call_id flat.NodeId, call_node flat.No
 // becomes `?int`), which makes the optional C type name appear to differ from
 // the callee's signature. The declared type read from `fn_ret_types`/the fn decl
 // keeps the alias, so propagating `return call()` is recognised as valid.
-fn (g &FlatGen) declared_call_return_type(call_node flat.Node) types.Type {
+fn (g &FlatGen) declared_call_return_type(call_id flat.NodeId) types.Type {
+	if int(call_id) < 0 {
+		return types.Type(types.void_)
+	}
+	call_node := g.a.nodes[int(call_id)]
 	if call_node.kind != .call || call_node.children_count == 0 {
 		return types.Type(types.void_)
 	}
@@ -716,6 +720,26 @@ fn (g &FlatGen) selector_call_return_type(fn_node flat.Node) ?types.Type {
 		return none
 	}
 	base_id := g.a.child(&fn_node, 0)
+	base_node := g.a.nodes[int(base_id)]
+	// A selector whose base names a type or an imported module is not a receiver method but a
+	// static method (`Type.make()`) or import-qualified function (`mod.make()`); the base ident
+	// has no value type, so resolve it the same way gen_call does and read the declared return
+	// type. Without this a fixed-array such call's `_v_ret_*` wrapper is never unwrapped.
+	if base_node.kind == .ident && base_node.value.len > 0 {
+		base_is_local := g.tc.cur_scope.lookup(base_node.value) or { types.Type(types.void_) } !is types.Void
+		if !base_is_local {
+			if static_fn := g.static_method_fn_name(base_node.value, fn_node.value) {
+				if ret := g.tc.fn_ret_types[static_fn] {
+					return ret
+				}
+			}
+			if mod := g.import_alias_module(base_node.value) {
+				if ret := g.tc.fn_ret_types['${mod}.${fn_node.value}'] {
+					return ret
+				}
+			}
+		}
+	}
 	base_type := g.tc.resolve_type(base_id)
 	clean_type := types.unwrap_pointer(base_type)
 	mut receiver_name := clean_type.name()

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -564,6 +564,13 @@ fn (mut g FlatGen) return_expr_string(node flat.Node, ret_id flat.NodeId, ret_no
 		if base is types.Void {
 			return '(${ct}){.ok = false}'
 		}
+		if base is types.ArrayFixed {
+			// The optional's `.value` is a fixed-array member, which can't be set in a compound
+			// literal; build via a temp + memcpy (mirrors the direct return path) so a deferred
+			// return saves the array value instead of dropping it to `{.ok = false}`.
+			src := g.fixed_array_copy_source_string(ret_id, base)
+			return '({ ${ct} __opt = {.ok = true}; memcpy(__opt.value, ${src}, sizeof(__opt.value)); __opt; })'
+		}
 		raw_expr_type := g.tc.resolve_type(ret_id)
 		expr_type := g.usable_expr_type(ret_id)
 		call_ret_type := g.local_fn_call_return_type(ret_id, ret_node)

--- a/vlib/v3/gen/c/str_intp.v
+++ b/vlib/v3/gen/c/str_intp.v
@@ -24,10 +24,23 @@ fn (mut g FlatGen) gen_string_interp(node flat.Node) {
 		} else if child.typ == 'string' {
 			g.gen_expr(child_id)
 		} else {
-			typ := g.tc.resolve_type(child_id)
+			mut typ := g.tc.resolve_type(child_id)
+			// For a bare ident, prefer the live cgen scope binding when present: it reflects
+			// locals introduced during generation (e.g. the `err` of an or-body lowered here,
+			// or for-loop vars) that resolve_type may stale-cache as `int`.
+			if child.kind == .ident {
+				if scope_typ := g.tc.cur_scope.lookup(child.value) {
+					if scope_typ !is types.Void {
+						typ = scope_typ
+					}
+				}
+			}
+			typ_name := types.Type(typ).name()
 			if typ is types.String {
 				g.gen_expr(child_id)
-			} else if typ is types.Struct && typ.name == 'IError' {
+			} else if typ_name == 'IError' || typ_name.ends_with('.IError') {
+				// IError may resolve as Interface/Alias/Struct depending on context; match by
+				// name and interpolate its `.message` (mirrors the transformer's IError path).
 				g.gen_expr(child_id)
 				g.write('.message')
 			} else if typ is types.Primitive {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -27,7 +27,13 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 	if g.gen_lowered_sum_init(node) {
 		return
 	}
-	name := g.struct_init_c_type_name(node.value)
+	mut name := g.struct_init_c_type_name(node.value)
+	// A bare generic struct literal (`Vec4{..}`) carries no type args; when the
+	// surrounding expected type fixes them (e.g. a `Vec4[f32]` return), emit the
+	// concrete instance name so it matches the materialized struct.
+	if inst := g.generic_struct_init_instance_ct(node.value) {
+		name = inst
+	}
 	if node.children_count == 0 && g.is_scalar_zero_init_type(node.value, name) {
 		g.write(g.scalar_zero_init(name))
 		return
@@ -159,7 +165,18 @@ fn (mut g FlatGen) struct_init_has_fixed_array_field(node flat.Node) bool {
 }
 
 fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields(node flat.Node, name string, init_module string) {
+	g.gen_struct_init_with_fixed_array_fields_impl(node, name, init_module, false)
+}
+
+// gen_struct_init_with_fixed_array_fields_impl builds a struct that has fixed-array
+// fields via a temp + per-field `memcpy` (array members can't be assigned in a
+// compound literal). When `heap`, the temp is `memdup`'d and a pointer returned,
+// for `&Struct{...}` initializers.
+fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, name string, init_module string, heap bool) {
 	tmp := g.tmp_name()
+	if heap {
+		g.write('(${name}*)')
+	}
 	g.write('({${name} ${tmp} = (${name}){')
 	mut allowed_fields := map[string]bool{}
 	if fields := g.struct_fields_for_type(node.value) {
@@ -276,7 +293,11 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields(node flat.Node, name 
 		g.gen_fixed_array_copy_source(fixed_values[i], fixed_field_types[i])
 		g.write(', sizeof(${tmp}.${cfield}));')
 	}
-	g.write(' ${tmp};})')
+	if heap {
+		g.write(' memdup(&${tmp}, sizeof(${name}));})')
+	} else {
+		g.write(' ${tmp};})')
+	}
 }
 
 // gen_fixed_array_copy_source emits a `memcpy` source for assigning into a fixed
@@ -391,6 +412,13 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 	name := g.struct_init_c_type_name(node.value)
 	sum_name := g.resolve_sum_name(node.value)
 	is_sum_literal := sum_name in g.tc.sum_types
+	if !is_sum_literal && !g.is_interface_type_name(node.value)
+		&& g.struct_init_has_fixed_array_field(node) {
+		// Fixed-array fields can't be set in the `&(T){...}` compound literal; build
+		// via a temp + memcpy and memdup the result.
+		g.gen_struct_init_with_fixed_array_fields_impl(node, name, init_module, true)
+		return
+	}
 	g.write('(${name}*)memdup(&(${name}){')
 	mut allowed_fields := map[string]bool{}
 	if fields := g.struct_fields_for_type(node.value) {
@@ -826,6 +854,38 @@ struct StructDeclInfo {
 }
 
 // struct_init_c_type_name supports struct init c type name handling for FlatGen.
+// generic_struct_init_instance_ct returns the concrete-instance C type name for a
+// bare generic struct literal whose type args are pinned by the surrounding expected
+// type (e.g. `Vec4{..}` written where a `Vec4[f32]` is expected). Returns none when
+// the literal is already specialized, the base is not a generic struct, or the
+// expected type is not a matching concrete instance.
+fn (g &FlatGen) generic_struct_init_instance_ct(type_name string) ?string {
+	if type_name.contains('[') {
+		return none
+	}
+	short := type_name.all_after_last('.')
+	// Prefer the explicit expected type; fall back to the enclosing function's return
+	// type, since a bare generic literal in return position carries no
+	// expected_expr_type. Only adopt a candidate whose generic base matches the
+	// literal's base, so unrelated expected types never rename the struct.
+	//
+	// Note: `tc.struct_generic_params` is empty by cgen time, so the candidate's
+	// shape (a `Base[args]` instance whose base short-name equals the literal's) is
+	// the sole evidence that this bare literal is a generic struct instantiation.
+	for cand in [g.expected_expr_type, g.cur_fn_ret] {
+		cand_name := types.Type(cand).name()
+		if !cand_name.contains('[') {
+			continue
+		}
+		cand_base := cand_name.all_before('[')
+		if cand_base.len == 0 || cand_base.all_after_last('.') != short {
+			continue
+		}
+		return g.tc.c_type(cand)
+	}
+	return none
+}
+
 fn (mut g FlatGen) struct_init_c_type_name(type_name string) string {
 	typ := g.tc.parse_type(type_name)
 	if typ is types.OptionType || typ is types.ResultType {
@@ -1255,6 +1315,10 @@ fn (mut g FlatGen) emit_interface_struct(name string) {
 
 // struct_decls supports struct decls handling for FlatGen.
 fn (mut g FlatGen) struct_decls() {
+	// Fixed-array typedefs whose element is a struct are emitted interleaved with the
+	// structs below (right after the element struct is defined), so struct fields that
+	// reference them resolve. Primitive-element ones were already emitted earlier.
+	fixed_array_needed := g.collect_fixed_array_typedefs_needed()
 	for name, _ in g.tc.structs {
 		if g.skip_builtin_struct(name) {
 			continue
@@ -1393,6 +1457,7 @@ fn (mut g FlatGen) struct_decls() {
 				}
 				g.emit_struct(name)
 				emitted[cn] = true
+				g.emit_ready_fixed_array_typedefs(fixed_array_needed, emitted)
 				remaining_cnames.delete(cn)
 				emitted_structs << name
 				progress = true

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -889,6 +889,12 @@ fn (g &FlatGen) generic_struct_init_instance_ct(type_name string) ?string {
 		// literal — the heap path (`&Box{..}`) needs the struct (`Box_int`), not the
 		// pointer, type name.
 		base_cand := types.unwrap_pointer(cand)
+		// A fixed/dynamic array type is not a generic struct instance even though its
+		// `.name()` renders like one (`[2]Foo` -> `Foo[2]`); skip it so a `Foo{..}` element
+		// of a `[2]Foo` literal keeps its element type instead of adopting the array type.
+		if base_cand is types.ArrayFixed || base_cand is types.Array {
+			continue
+		}
 		cand_name := base_cand.name()
 		if !cand_name.contains('[') {
 			continue

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -409,7 +409,13 @@ fn channel_init_field(node flat.Node, a &flat.FlatAst, name string) ?flat.NodeId
 // gen_heap_struct_init emits heap struct init output for c.
 fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 	init_module := g.tc.cur_module
-	name := g.struct_init_c_type_name(node.value)
+	mut name := g.struct_init_c_type_name(node.value)
+	// A bare generic heap literal (`&Vec4{..}`) carries no type args; when the
+	// surrounding expected type fixes them (e.g. a `&Vec4[f32]` return), emit the
+	// concrete instance name so the materialized struct matches the value path.
+	if inst := g.generic_struct_init_instance_ct(node.value) {
+		name = inst
+	}
 	sum_name := g.resolve_sum_name(node.value)
 	is_sum_literal := sum_name in g.tc.sum_types
 	if !is_sum_literal && !g.is_interface_type_name(node.value)
@@ -873,7 +879,11 @@ fn (g &FlatGen) generic_struct_init_instance_ct(type_name string) ?string {
 	// shape (a `Base[args]` instance whose base short-name equals the literal's) is
 	// the sole evidence that this bare literal is a generic struct instantiation.
 	for cand in [g.expected_expr_type, g.cur_fn_ret] {
-		cand_name := types.Type(cand).name()
+		// Unwrap a pointer so a `&Box[int]` expected type still matches a bare `Box`
+		// literal — the heap path (`&Box{..}`) needs the struct (`Box_int`), not the
+		// pointer, type name.
+		base_cand := types.unwrap_pointer(cand)
+		cand_name := base_cand.name()
 		if !cand_name.contains('[') {
 			continue
 		}
@@ -881,7 +891,7 @@ fn (g &FlatGen) generic_struct_init_instance_ct(type_name string) ?string {
 		if cand_base.len == 0 || cand_base.all_after_last('.') != short {
 			continue
 		}
-		return g.tc.c_type(cand)
+		return g.tc.c_type(base_cand)
 	}
 	return none
 }

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -871,14 +871,20 @@ fn (g &FlatGen) generic_struct_init_instance_ct(type_name string) ?string {
 	}
 	short := type_name.all_after_last('.')
 	// Prefer the explicit expected type; fall back to the enclosing function's return
-	// type, since a bare generic literal in return position carries no
-	// expected_expr_type. Only adopt a candidate whose generic base matches the
-	// literal's base, so unrelated expected types never rename the struct.
+	// type ONLY for a literal in return position (a bare generic literal there carries
+	// no expected_expr_type) — otherwise a `Box{...}` in a local decl / argument whose
+	// expected type is the bare `Box` would be wrongly materialised as `Box_int`. Only
+	// adopt a candidate whose generic base matches the literal's base, so unrelated
+	// expected types never rename the struct.
 	//
 	// Note: `tc.struct_generic_params` is empty by cgen time, so the candidate's
 	// shape (a `Base[args]` instance whose base short-name equals the literal's) is
 	// the sole evidence that this bare literal is a generic struct instantiation.
-	for cand in [g.expected_expr_type, g.cur_fn_ret] {
+	mut candidates := [g.expected_expr_type]
+	if g.in_return {
+		candidates << g.cur_fn_ret
+	}
+	for cand in candidates {
 		// Unwrap a pointer so a `&Box[int]` expected type still matches a bare `Box`
 		// literal — the heap path (`&Box{..}`) needs the struct (`Box_int`), not the
 		// pointer, type name.

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -169,6 +169,7 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields(node flat.Node, name 
 	}
 	mut fixed_fields := []string{}
 	mut fixed_values := []flat.NodeId{}
+	mut fixed_field_types := []types.Type{}
 	mut set_fields := map[string]bool{}
 	mut has_field := false
 	for i in 0 .. node.children_count {
@@ -182,6 +183,7 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields(node flat.Node, name 
 				if sf.typ is types.ArrayFixed {
 					fixed_fields << sf.name
 					fixed_values << value_id
+					fixed_field_types << sf.typ
 					set_fields[sf.name] = true
 					continue
 				}
@@ -204,6 +206,7 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields(node flat.Node, name 
 			if ftyp is types.ArrayFixed {
 				fixed_fields << field.value
 				fixed_values << value_id
+				fixed_field_types << ftyp
 				set_fields[field.value] = true
 				continue
 			}
@@ -270,10 +273,31 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields(node flat.Node, name 
 	for i in 0 .. fixed_fields.len {
 		cfield := c_field_name(fixed_fields[i])
 		g.write(' memcpy(${tmp}.${cfield}, ')
-		g.gen_expr(fixed_values[i])
+		g.gen_fixed_array_copy_source(fixed_values[i], fixed_field_types[i])
 		g.write(', sizeof(${tmp}.${cfield}));')
 	}
 	g.write(' ${tmp};})')
+}
+
+// gen_fixed_array_copy_source emits a `memcpy` source for assigning into a fixed
+// array. A raw array literal becomes a typed compound literal (a valid expression
+// that decays to a pointer); a dynamic array value copies from its `.data` buffer;
+// other fixed-array expressions (variables, fields, unwrapped calls) decay as-is.
+fn (mut g FlatGen) gen_fixed_array_copy_source(value_id flat.NodeId, field_type types.Type) {
+	val_node := g.a.node(value_id)
+	if val_node.kind == .array_literal {
+		g.write('(${g.tc.c_type(field_type)})')
+		g.gen_expr(value_id)
+		return
+	}
+	val_type := types.unwrap_pointer(g.usable_expr_type(value_id))
+	if val_type is types.Array {
+		g.write('(')
+		g.gen_expr(value_id)
+		g.write(').data')
+		return
+	}
+	g.gen_expr(value_id)
 }
 
 // gen_lowered_sum_init emits lowered sum init output for c.

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -49,19 +49,20 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 	if inst := g.generic_struct_init_instance_ct(node.value) {
 		name = inst
 	}
+	// A bare generic literal stores its fields under the concrete instance key (`Box[int]`);
+	// the bare `node.value` (`Box`) entry is removed by monomorphization, so resolve the
+	// instance for the fixed-array-field test, field-type lookups, and omitted-default emission.
+	lookup_name := g.struct_init_fields_key(node.value, node.value)
 	if node.children_count == 0 && g.is_scalar_zero_init_type(node.value, name) {
 		g.write(g.scalar_zero_init(name))
 		return
 	}
-	if !g.is_interface_type_name(node.value) && g.struct_init_has_fixed_array_field(node) {
+	if !g.is_interface_type_name(node.value)
+		&& g.struct_init_has_fixed_array_field(node, lookup_name) {
 		g.gen_struct_init_with_fixed_array_fields(node, name, init_module)
 		return
 	}
 	g.write('(${name}){')
-	// A bare generic literal stores its fields under the concrete instance key (`Box[int]`);
-	// the bare `node.value` (`Box`) entry is removed by monomorphization, so resolve the
-	// instance for field-type lookups and omitted-default emission below.
-	lookup_name := g.struct_init_fields_key(node.value, node.value)
 	mut allowed_fields := map[string]bool{}
 	if fields := g.struct_fields_for_type(lookup_name) {
 		for f in fields {
@@ -164,18 +165,18 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 	g.write('}')
 }
 
-fn (mut g FlatGen) struct_init_has_fixed_array_field(node flat.Node) bool {
+fn (mut g FlatGen) struct_init_has_fixed_array_field(node flat.Node, type_name string) bool {
 	for i in 0 .. node.children_count {
 		field := g.a.child_node(&node, i)
 		if field.value.len == 0 {
-			if sf := g.struct_field_at(node.value, i) {
+			if sf := g.struct_field_at(type_name, i) {
 				if sf.typ is types.ArrayFixed {
 					return true
 				}
 			}
 			continue
 		}
-		if ftyp := g.struct_field_type(node.value, field.value) {
+		if ftyp := g.struct_field_type(type_name, field.value) {
 			if ftyp is types.ArrayFixed {
 				return true
 			}
@@ -198,8 +199,12 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 		g.write('(${name}*)')
 	}
 	g.write('({${name} ${tmp} = (${name}){')
+	// A bare generic literal stores its fields under the concrete instance key (`Box[int]`);
+	// the bare `node.value` (`Box`) entry is removed by monomorphization, so resolve the
+	// instance for the field lookups and omitted-default emission below.
+	lookup_name := g.struct_init_fields_key(node.value, node.value)
 	mut allowed_fields := map[string]bool{}
-	if fields := g.struct_fields_for_type(node.value) {
+	if fields := g.struct_fields_for_type(lookup_name) {
 		for f in fields {
 			allowed_fields[f.name] = true
 		}
@@ -216,7 +221,7 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 		}
 		value_id := g.a.child(field, 0)
 		if field.value.len == 0 {
-			if sf := g.struct_field_at(node.value, i) {
+			if sf := g.struct_field_at(lookup_name, i) {
 				if sf.typ is types.ArrayFixed {
 					fixed_fields << sf.name
 					fixed_values << value_id
@@ -239,7 +244,7 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 				has_field = true
 			}
 		} else {
-			ftyp := g.struct_field_type(node.value, field.value) or { types.Type(types.void_) }
+			ftyp := g.struct_field_type(lookup_name, field.value) or { types.Type(types.void_) }
 			if ftyp is types.ArrayFixed {
 				fixed_fields << field.value
 				fixed_values << value_id
@@ -277,8 +282,9 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 	sname := if qname in g.tc.structs { qname } else { node.value }
 	g.tc.cur_module = after_fields_module
 	has_field = g.gen_struct_default_fields(sname, mut set_fields, has_field)
-	if sname in g.tc.structs {
-		for f in g.tc.structs[sname] {
+	defaults_key := if lookup_name in g.tc.structs { lookup_name } else { sname }
+	if defaults_key in g.tc.structs {
+		for f in g.tc.structs[defaults_key] {
 			if f.name in set_fields {
 				continue
 			}
@@ -438,18 +444,18 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 	}
 	sum_name := g.resolve_sum_name(node.value)
 	is_sum_literal := sum_name in g.tc.sum_types
+	// A bare generic literal stores its fields under the concrete instance key (`Box[int]`);
+	// the bare `node.value` (`Box`) entry is removed by monomorphization, so resolve the
+	// instance for the fixed-array-field test, field-type lookups, and omitted-default emission.
+	lookup_name := g.struct_init_fields_key(node.value, node.value)
 	if !is_sum_literal && !g.is_interface_type_name(node.value)
-		&& g.struct_init_has_fixed_array_field(node) {
+		&& g.struct_init_has_fixed_array_field(node, lookup_name) {
 		// Fixed-array fields can't be set in the `&(T){...}` compound literal; build
 		// via a temp + memcpy and memdup the result.
 		g.gen_struct_init_with_fixed_array_fields_impl(node, name, init_module, true)
 		return
 	}
 	g.write('(${name}*)memdup(&(${name}){')
-	// A bare generic literal stores its fields under the concrete instance key (`Box[int]`);
-	// the bare `node.value` (`Box`) entry is removed by monomorphization, so resolve the
-	// instance for field-type lookups and omitted-default emission below.
-	lookup_name := g.struct_init_fields_key(node.value, node.value)
 	mut allowed_fields := map[string]bool{}
 	if fields := g.struct_fields_for_type(lookup_name) {
 		for f in fields {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -426,6 +426,10 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 		return
 	}
 	g.write('(${name}*)memdup(&(${name}){')
+	// A bare generic literal stores its fields under the concrete instance key (`Box[int]`);
+	// the bare `node.value` (`Box`) entry is removed by monomorphization, so resolve the
+	// instance name for the positional field lookup below.
+	lookup_name := g.generic_struct_init_instance_name(node.value) or { node.value }
 	mut allowed_fields := map[string]bool{}
 	if fields := g.struct_fields_for_type(node.value) {
 		for f in fields {
@@ -448,8 +452,30 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 		if has_field {
 			g.write(', ')
 		}
-		g.write('.${c_field_name(field.value)} = ')
 		value_id := g.a.child(field, 0)
+		if field.value.len == 0 {
+			// Positional initializer (empty field name): emit a positional C value mapped
+			// to the field at this index (mirrors gen_struct_init); a `. = v` designator
+			// is invalid C.
+			if sf := g.struct_field_at(lookup_name, i) {
+				if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(lookup_name, sf.name,
+					value_id)
+				{
+					inner_ct := g.tc.c_type(heap_copy_type)
+					g.write('(${inner_ct}*)memdup(')
+					g.gen_expr(value_id)
+					g.write(', sizeof(${inner_ct}))')
+				} else {
+					g.gen_expr_with_expected_type(value_id, sf.typ)
+				}
+				set_fields[sf.name] = true
+			} else {
+				g.gen_expr(value_id)
+			}
+			has_field = true
+			continue
+		}
+		g.write('.${c_field_name(field.value)} = ')
 		if is_sum_literal {
 			g.gen_lowered_sum_field_value(sum_name, field)
 		} else if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(node.value, field.value,
@@ -866,6 +892,22 @@ struct StructDeclInfo {
 // the literal is already specialized, the base is not a generic struct, or the
 // expected type is not a matching concrete instance.
 fn (g &FlatGen) generic_struct_init_instance_ct(type_name string) ?string {
+	return g.tc.c_type(g.generic_struct_init_instance_type(type_name)?)
+}
+
+// generic_struct_init_instance_name is the concrete-instance V type name (`Box[int]`)
+// for a bare generic struct literal, so field and default lookups use the materialized
+// key under which the struct's fields are stored (the bare `Box` entry is removed by
+// monomorphization), not just the emitted C type.
+fn (g &FlatGen) generic_struct_init_instance_name(type_name string) ?string {
+	return g.generic_struct_init_instance_type(type_name)?.name()
+}
+
+// generic_struct_init_instance_type resolves the concrete generic instance a bare literal
+// adopts from the surrounding expected/return type (e.g. `Vec4{..}` -> `Vec4[f32]`).
+// Returns none when the literal is already specialized, the base is not a generic struct,
+// or the expected type is not a matching concrete instance.
+fn (g &FlatGen) generic_struct_init_instance_type(type_name string) ?types.Type {
 	if type_name.contains('[') {
 		return none
 	}
@@ -903,7 +945,7 @@ fn (g &FlatGen) generic_struct_init_instance_ct(type_name string) ?string {
 		if cand_base.len == 0 || cand_base.all_after_last('.') != short {
 			continue
 		}
-		return g.tc.c_type(base_cand)
+		return base_cand
 	}
 	return none
 }

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -17,6 +17,21 @@ fn c_field_name(name string) string {
 	return c_name(name)
 }
 
+// struct_init_fields_key returns the key under which the initialized struct's checked fields
+// (and their concrete types) live. For a bare generic literal that adopts a concrete instance
+// (`Box{..}` where `Box[int]` is expected) that is the instance key `Box[int]`; the bare `Box`
+// entry is removed by monomorphization, so field-type lookups and omitted default-field
+// emission must use the instance key or they miss fields like `items []T` (leaving invalid
+// zeroed array/map metadata). Falls back to the given key for non-generic structs.
+fn (g &FlatGen) struct_init_fields_key(type_name string, fallback string) string {
+	if inst := g.generic_struct_init_instance_name(type_name) {
+		if inst in g.tc.structs {
+			return inst
+		}
+	}
+	return fallback
+}
+
 // gen_struct_init emits struct init output for c.
 fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 	init_module := g.tc.cur_module
@@ -43,8 +58,12 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 		return
 	}
 	g.write('(${name}){')
+	// A bare generic literal stores its fields under the concrete instance key (`Box[int]`);
+	// the bare `node.value` (`Box`) entry is removed by monomorphization, so resolve the
+	// instance for field-type lookups and omitted-default emission below.
+	lookup_name := g.struct_init_fields_key(node.value, node.value)
 	mut allowed_fields := map[string]bool{}
-	if fields := g.struct_fields_for_type(node.value) {
+	if fields := g.struct_fields_for_type(lookup_name) {
 		for f in fields {
 			allowed_fields[f.name] = true
 		}
@@ -67,7 +86,7 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 		}
 		value_id := g.a.child(field, 0)
 		if field.value.len == 0 {
-			if sf := g.struct_field_at(node.value, i) {
+			if sf := g.struct_field_at(lookup_name, i) {
 				if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(node.value, sf.name,
 					value_id)
 				{
@@ -92,7 +111,7 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 				g.gen_expr(value_id)
 				g.write(', sizeof(${inner_ct}))')
 			} else {
-				if ftyp := g.struct_field_type(node.value, field.value) {
+				if ftyp := g.struct_field_type(lookup_name, field.value) {
 					if g.struct_field_value_is_plainly_incompatible(value_id, ftyp) {
 						g.gen_default_value_for_type(ftyp)
 					} else {
@@ -112,8 +131,9 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 	sname := if qname in g.tc.structs { qname } else { node.value }
 	g.tc.cur_module = after_fields_module
 	has_field = g.gen_struct_default_fields(sname, mut set_fields, has_field)
-	if sname in g.tc.structs {
-		for f in g.tc.structs[sname] {
+	defaults_key := if lookup_name in g.tc.structs { lookup_name } else { sname }
+	if defaults_key in g.tc.structs {
+		for f in g.tc.structs[defaults_key] {
 			if f.name in set_fields {
 				continue
 			}
@@ -428,10 +448,10 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 	g.write('(${name}*)memdup(&(${name}){')
 	// A bare generic literal stores its fields under the concrete instance key (`Box[int]`);
 	// the bare `node.value` (`Box`) entry is removed by monomorphization, so resolve the
-	// instance name for the positional field lookup below.
-	lookup_name := g.generic_struct_init_instance_name(node.value) or { node.value }
+	// instance for field-type lookups and omitted-default emission below.
+	lookup_name := g.struct_init_fields_key(node.value, node.value)
 	mut allowed_fields := map[string]bool{}
-	if fields := g.struct_fields_for_type(node.value) {
+	if fields := g.struct_fields_for_type(lookup_name) {
 		for f in fields {
 			allowed_fields[f.name] = true
 		}
@@ -486,7 +506,7 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 			g.gen_expr(value_id)
 			g.write(', sizeof(${inner_ct}))')
 		} else {
-			if ftyp := g.struct_field_type(node.value, field.value) {
+			if ftyp := g.struct_field_type(lookup_name, field.value) {
 				if g.struct_field_value_is_plainly_incompatible(value_id, ftyp) {
 					g.gen_default_value_for_type(ftyp)
 				} else {
@@ -505,8 +525,9 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 	sname := if qname in g.tc.structs { qname } else { node.value }
 	g.tc.cur_module = after_fields_module
 	has_field = g.gen_struct_default_fields(sname, mut set_fields, has_field)
-	if sname in g.tc.structs {
-		for f in g.tc.structs[sname] {
+	defaults_key := if lookup_name in g.tc.structs { lookup_name } else { sname }
+	if defaults_key in g.tc.structs {
+		for f in g.tc.structs[defaults_key] {
 			if f.name in set_fields {
 				continue
 			}

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -183,37 +183,81 @@ fn (mut g FlatGen) enum_str_defs() {
 					node.value
 				}
 				cn := c_name(name)
-				is_flag := node.typ == 'flag'
-				g.writeln('string ${cn}__autostr(${cn} it) {')
-				g.writeln('\tswitch (it) {')
-				mut val := 0
-				mut seen := map[int]bool{}
-				for i in 0 .. node.children_count {
-					f := g.a.child_node(&node, i)
-					if f.children_count > 0 {
-						if enum_val := g.enum_field_expr_value(g.a.child(f, 0)) {
-							val = enum_val
+				if node.typ == 'flag' {
+					// `[flag]` enum: a value can combine several bits, so build the V
+					// `Enum{.a | .b}` form by testing each field bit instead of matching a
+					// single case (which would send any combination to the integer path).
+					g.emit_flag_enum_autostr(node, cn)
+				} else {
+					g.writeln('string ${cn}__autostr(${cn} it) {')
+					g.writeln('\tswitch (it) {')
+					mut val := 0
+					mut seen := map[int]bool{}
+					for i in 0 .. node.children_count {
+						f := g.a.child_node(&node, i)
+						if f.children_count > 0 {
+							if enum_val := g.enum_field_expr_value(g.a.child(f, 0)) {
+								val = enum_val
+							}
 						}
+						case_val := val
+						val++
+						// Duplicate field values would produce duplicate C `case` labels; keep first.
+						if case_val in seen {
+							continue
+						}
+						seen[case_val] = true
+						fname := f.value
+						g.writeln('\t\tcase ${cn}__${fname}: return (string){.str = (u8*)"${fname}", .len = ${fname.len}, .is_lit = 1};')
 					}
-					case_val := if is_flag { 1 << val } else { val }
-					val++
-					// Duplicate field values would produce duplicate C `case` labels; keep first.
-					if case_val in seen {
-						continue
-					}
-					seen[case_val] = true
-					fname := f.value
-					g.writeln('\t\tcase ${cn}__${fname}: return (string){.str = (u8*)"${fname}", .len = ${fname.len}, .is_lit = 1};')
+					g.writeln('\t\tdefault: break;')
+					g.writeln('\t}')
+					g.writeln('\treturn strconv__format_int((i64)it, 10);')
+					g.writeln('}')
+					g.writeln('')
 				}
-				g.writeln('\t\tdefault: break;')
-				g.writeln('\t}')
-				g.writeln('\treturn strconv__format_int((i64)it, 10);')
-				g.writeln('}')
-				g.writeln('')
 			}
 			else {}
 		}
 	}
+}
+
+// emit_flag_enum_autostr emits the `<Enum>__autostr` helper for a `[flag]` enum.
+// Matching V, a combined value is rendered as `Enum{.a | .b}` by testing each
+// field's bit; `Enum(0)` renders as `Enum{}`.
+fn (mut g FlatGen) emit_flag_enum_autostr(node flat.Node, cn string) {
+	short := node.value.all_after_last('.')
+	g.writeln('string ${cn}__autostr(${cn} it) {')
+	g.writeln('\tint __fe_v = (int)it;')
+	g.writeln('\tstring __fe_res = (string){.str = (u8*)"${short}{", .len = ${short.len + 1}, .is_lit = 1};')
+	g.writeln('\tbool __fe_first = true;')
+	mut val := 0
+	mut seen := map[int]bool{}
+	for i in 0 .. node.children_count {
+		f := g.a.child_node(&node, i)
+		if f.children_count > 0 {
+			if enum_val := g.enum_field_expr_value(g.a.child(f, 0)) {
+				val = enum_val
+			}
+		}
+		bit := 1 << val
+		val++
+		if bit in seen {
+			continue
+		}
+		seen[bit] = true
+		fname := f.value
+		g.writeln('\tif (${cn}__${fname} != 0 && (__fe_v & ${cn}__${fname}) == ${cn}__${fname}) {')
+		g.writeln('\t\tif (!__fe_first) { __fe_res = string__plus(__fe_res, (string){.str = (u8*)" | ", .len = 3, .is_lit = 1}); }')
+		g.writeln('\t\t__fe_res = string__plus(__fe_res, (string){.str = (u8*)".${fname}", .len = ${
+			fname.len + 1}, .is_lit = 1});')
+		g.writeln('\t\t__fe_first = false;')
+		g.writeln('\t}')
+	}
+	g.writeln('\t__fe_res = string__plus(__fe_res, (string){.str = (u8*)"}", .len = 1, .is_lit = 1});')
+	g.writeln('\treturn __fe_res;')
+	g.writeln('}')
+	g.writeln('')
 }
 
 // enum_field_expr_value supports enum field expr value handling for FlatGen.

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -134,6 +134,88 @@ fn (mut g FlatGen) enum_decls() {
 	}
 }
 
+// enum_str_forward_decls forward-declares the synthesized `<Enum>__autostr` helpers so
+// const initializers / function bodies emitted later can call them. Bodies come from
+// enum_str_defs (after `string` and `strconv__format_int` are available).
+fn (mut g FlatGen) enum_str_forward_decls() {
+	mut cur_module := ''
+	for node in g.a.nodes {
+		match node.kind {
+			.file {
+				cur_module = ''
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.enum_decl {
+				name := if cur_module.len > 0 && cur_module != 'main' && cur_module != 'builtin' {
+					'${cur_module}.${node.value}'
+				} else {
+					node.value
+				}
+				cn := c_name(name)
+				g.writeln('string ${cn}__autostr(${cn} it);')
+			}
+			else {}
+		}
+	}
+	g.writeln('')
+}
+
+// enum_str_defs emits a `<Enum>__autostr` helper per enum: a switch mapping each field's
+// value to its NAME string literal (V's auto-derived `.str()`), falling back to the integer
+// for out-of-range / combined-flag values. This is what `${enum}` interpolation calls when
+// the user has not defined a custom `.str()`.
+fn (mut g FlatGen) enum_str_defs() {
+	mut cur_module := ''
+	for node in g.a.nodes {
+		match node.kind {
+			.file {
+				cur_module = ''
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.enum_decl {
+				name := if cur_module.len > 0 && cur_module != 'main' && cur_module != 'builtin' {
+					'${cur_module}.${node.value}'
+				} else {
+					node.value
+				}
+				cn := c_name(name)
+				is_flag := node.typ == 'flag'
+				g.writeln('string ${cn}__autostr(${cn} it) {')
+				g.writeln('\tswitch (it) {')
+				mut val := 0
+				mut seen := map[int]bool{}
+				for i in 0 .. node.children_count {
+					f := g.a.child_node(&node, i)
+					if f.children_count > 0 {
+						if enum_val := g.enum_field_expr_value(g.a.child(f, 0)) {
+							val = enum_val
+						}
+					}
+					case_val := if is_flag { 1 << val } else { val }
+					val++
+					// Duplicate field values would produce duplicate C `case` labels; keep first.
+					if case_val in seen {
+						continue
+					}
+					seen[case_val] = true
+					fname := f.value
+					g.writeln('\t\tcase ${cn}__${fname}: return (string){.str = (u8*)"${fname}", .len = ${fname.len}, .is_lit = 1};')
+				}
+				g.writeln('\t\tdefault: break;')
+				g.writeln('\t}')
+				g.writeln('\treturn strconv__format_int((i64)it, 10);')
+				g.writeln('}')
+				g.writeln('')
+			}
+			else {}
+		}
+	}
+}
+
 // enum_field_expr_value supports enum field expr value handling for FlatGen.
 fn (g &FlatGen) enum_field_expr_value(id flat.NodeId) ?int {
 	if int(id) < 0 {

--- a/vlib/v3/markused/custom_str_test.v
+++ b/vlib/v3/markused/custom_str_test.v
@@ -205,6 +205,34 @@ fn test_imported_operator_infix_seeds_operator_methods() {
 	assert used['vectors.Vec.<']
 }
 
+// test_flag_enum_seeds_string_plus_helper validates this v3 regression case: a `[flag]`
+// enum's synthesized `<Enum>__autostr` builds its string with `string__plus`, but that
+// generated body is invisible to markused, so the helper must be seeded from the flag-enum
+// declaration or it could be pruned and leave the autostr calling an undefined helper.
+fn test_flag_enum_seeds_string_plus_helper() {
+	main_src := '
+module main
+
+import colors
+
+@[flag]
+enum Perm {
+	read
+	write
+}
+
+fn main() {
+	p := Perm.read | Perm.write
+	_ := p
+	_ := colors.Color.red
+}
+'
+	a, tc := parse_checked_two_file_source('flag_enum_string_plus', main_src, 'colors/colors.v',
+		imported_enum_module_source())
+	mut used := mark_used(a, tc)
+	assert used['string__plus']
+}
+
 // test_optional_struct_zero_seeds_imported_default_helper validates this v3 regression case.
 fn test_optional_struct_zero_seeds_imported_default_helper() {
 	a, tc := parse_checked_two_file_source('imported_struct_default_or',

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -175,6 +175,25 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 	}
 	enqueue_detected_runtime_helpers(a, tc, mut used, mut queue)
 	enqueue_function_value_selectors(a, fn_decls, mut used, mut queue)
+	// Methods used as values (`recv.method` passed as a callback) are reachable only
+	// through a wrapper cgen generates later. The checker recorded them with full type
+	// info; seed them (and their suffix-resolved forms) so they survive pruning and get
+	// transformed/emitted like any other reachable function.
+	for mkey, _ in tc.method_value_targets {
+		enqueue(mkey, mut used, mut queue)
+		lowered := markused_c_name(mkey)
+		if lowered != mkey {
+			enqueue(lowered, mut used, mut queue)
+		}
+		short := mkey.all_after_last('.')
+		if candidates := suffix_map[short] {
+			for cand in candidates {
+				if cand == mkey || cand.ends_with('.${mkey}') {
+					enqueue(cand, mut used, mut queue)
+				}
+			}
+		}
+	}
 	enqueue_initializer_calls(a, collector, imports, fn_decls, mut used, mut queue)
 	// Interface dispatch reachability: calling an interface method `Foo.m` may
 	// dispatch to any concrete `T.m` for a type `T` that implements `Foo`. Those
@@ -208,6 +227,26 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 			continue
 		}
 		processed_nodes[node_key] = true
+		// This function is reachable, so any methods it uses as *values* (recorded by
+		// the checker per enclosing function) are reachable too — mark them so they
+		// survive pruning (cgen emits a wrapper that calls them).
+		if mvs := tc.method_values_by_fn[node_key] {
+			for mkey in mvs {
+				enqueue(mkey, mut used, mut queue)
+				lowered_mv := markused_c_name(mkey)
+				if lowered_mv != mkey {
+					enqueue(lowered_mv, mut used, mut queue)
+				}
+				mv_short := mkey.all_after_last('.')
+				if cands := suffix_map[mv_short] {
+					for cand in cands {
+						if cand == mkey || cand.ends_with('.${mkey}') {
+							enqueue(cand, mut used, mut queue)
+						}
+					}
+				}
+			}
+		}
 		calls.clear()
 		node := a.node(fn_info.node_id)
 		receiver_name, receiver_struct := receiver_info(a, node)

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -176,24 +176,10 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 	enqueue_detected_runtime_helpers(a, tc, mut used, mut queue)
 	enqueue_function_value_selectors(a, fn_decls, mut used, mut queue)
 	// Methods used as values (`recv.method` passed as a callback) are reachable only
-	// through a wrapper cgen generates later. The checker recorded them with full type
-	// info; seed them (and their suffix-resolved forms) so they survive pruning and get
-	// transformed/emitted like any other reachable function.
-	for mkey, _ in tc.method_value_targets {
-		enqueue(mkey, mut used, mut queue)
-		lowered := markused_c_name(mkey)
-		if lowered != mkey {
-			enqueue(lowered, mut used, mut queue)
-		}
-		short := mkey.all_after_last('.')
-		if candidates := suffix_map[short] {
-			for cand in candidates {
-				if cand == mkey || cand.ends_with('.${mkey}') {
-					enqueue(cand, mut used, mut queue)
-				}
-			}
-		}
-	}
+	// through a wrapper cgen generates later. The checker records them per enclosing
+	// function in `method_values_by_fn`; they are seeded inside the BFS below (only when
+	// that function is reached), so an unreachable function's method value never forces an
+	// otherwise-unused specialization to be transformed/emitted.
 	enqueue_initializer_calls(a, collector, imports, fn_decls, mut used, mut queue)
 	// Interface dispatch reachability: calling an interface method `Foo.m` may
 	// dispatch to any concrete `T.m` for a type `T` that implements `Foo`. Those

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -572,6 +572,17 @@ fn enqueue_detected_runtime_helpers(a &flat.FlatAst, tc &types.TypeChecker, mut 
 			.map_init {
 				needs_new_map = true
 			}
+			.enum_decl {
+				// A `[flag]` enum's synthesized `<Enum>__autostr` helper (emitted
+				// unconditionally in cgen) builds its `Enum{.a | .b}` string with
+				// `string__plus`. markused never walks that generated body, so without
+				// seeding the helper here it can be pruned when the program has no other
+				// string concatenation, leaving the autostr calling an undefined
+				// `string__plus`.
+				if node.typ == 'flag' {
+					needs_string_plus_helper = true
+				}
+			}
 			else {}
 		}
 	}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -87,7 +87,11 @@ pub fn (mut p Parser) parse_into(path string) {
 	})
 	src := read_source_file_raw(path)
 	if src.len == 0 {
-		eprintln('error reading ${path}')
+		// An empty but existing `.v` file is valid (declares nothing); only a
+		// genuine read failure (missing file) is an error worth reporting.
+		if !os.exists(path) {
+			eprintln('error reading ${path}')
+		}
 		return
 	}
 	if path.ends_with('.v') {
@@ -2359,10 +2363,31 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 		}
 		return p.a.add_val_id(3, 'false')
 	}
+	if p.tok == .name && p.lit == 'env' {
+		// $env('NAME') evaluates an environment variable at compile time and
+		// becomes a plain string literal (empty when the variable is unset).
+		p.next() // skip 'env'
+		mut env_val := ''
+		if p.tok == .lpar {
+			p.next() // skip (
+			if p.tok == .string {
+				env_val = os.getenv(strip_quotes(p.lit))
+				p.next()
+			}
+			for p.tok != .rpar && p.tok != .eof {
+				p.next()
+			}
+			p.check(.rpar)
+		}
+		return p.a.add_val_id(5, env_val)
+	}
 	for p.tok != .semicolon && p.tok != .eof {
 		p.next()
 	}
-	return flat.empty_node
+	// Unknown comptime expression: return an empty string literal rather than
+	// `empty_node`, so consumers (e.g. const initializers) never store an
+	// invalid (-1) child node.
+	return p.a.add_val_id(5, '')
 }
 
 fn (mut p Parser) parse_comptime_if_expr() flat.NodeId {
@@ -4916,6 +4941,7 @@ fn (mut p Parser) select_expr() flat.NodeId {
 // select_branch resolves select branch information for parser.
 fn (mut p Parser) select_branch() flat.NodeId {
 	mut is_else := false
+	mut is_recv_decl := false
 	mut cond_ids := []flat.NodeId{}
 	if p.tok == .key_else {
 		is_else = true
@@ -4925,9 +4951,13 @@ fn (mut p Parser) select_branch() flat.NodeId {
 		// could be assignment: ch <- val or val := <-ch
 		if token_is_assignment(p.tok) || p.tok == .decl_assign {
 			op := p.tok
+			// Record `val := <-ch` so the type checker can bind `val` (the
+			// channel's element type) in the branch body's scope.
+			if op == .decl_assign {
+				is_recv_decl = true
+			}
 			p.next()
 			cond_ids << p.expr(.lowest)
-			_ = op
 		}
 	}
 	mut body_ids := []flat.NodeId{}
@@ -4939,9 +4969,16 @@ fn (mut p Parser) select_branch() flat.NodeId {
 		all_ids << id
 	}
 	start := p.add_children(all_ids)
+	branch_value := if is_else {
+		'else'
+	} else if is_recv_decl {
+		'recv'
+	} else {
+		''
+	}
 	return p.a.add_node(flat.Node{
 		kind:           .select_branch
-		value:          if is_else { 'else' } else { '' }
+		value:          branch_value
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
 	})

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -29,12 +29,10 @@ mut:
 	tok              token.Token
 	lit              string
 	tok_pos          int
-	tok_is_str_tail  bool
 	prev_tok         token.Token
 	peek_tok         token.Token = .eof
 	peek_lit         string
 	peek_pos         int
-	peek_is_str_tail bool
 	has_peek         bool
 	cur_file         string
 	cur_module       string
@@ -47,7 +45,6 @@ mut:
 pub mut:
 	a              &flat.FlatAst = unsafe { nil }
 	parsed_v_files int
-	parsed_v_lines int
 }
 
 // new creates a Parser value for parser.
@@ -96,7 +93,6 @@ pub fn (mut p Parser) parse_into(path string) {
 	}
 	if path.ends_with('.v') {
 		p.parsed_v_files++
-		p.parsed_v_lines += count_source_lines(src)
 	}
 	mut file_set := token.FileSet.new()
 	file := file_set.add_file(path, -1, src.len)
@@ -135,20 +131,6 @@ pub fn (mut p Parser) parse_into(path string) {
 		children_start: start
 		children_count: flat.child_count(ids.len)
 	})
-}
-
-// count_source_lines supports count source lines handling for parser.
-fn count_source_lines(src string) int {
-	if src.len == 0 {
-		return 0
-	}
-	mut lines := 1
-	for i in 0 .. src.len {
-		if src[i] == `\n` && i + 1 < src.len {
-			lines++
-		}
-	}
-	return lines
 }
 
 // read_source_file_raw reads read source file raw input for parser.
@@ -215,39 +197,29 @@ fn (mut p Parser) next() {
 		p.tok = p.peek_tok
 		p.lit = p.peek_lit
 		p.tok_pos = p.peek_pos
-		p.tok_is_str_tail = p.peek_is_str_tail
 		p.has_peek = false
-		p.normalize_current_token()
 		return
 	}
-	p.tok_is_str_tail = p.s.in_str_incomplete
 	p.tok = p.s.scan()
 	p.lit = p.s.lit
 	p.tok_pos = p.s.pos
-	p.normalize_current_token()
 	for p.tok == .comment {
-		p.tok_is_str_tail = p.s.in_str_incomplete
 		p.tok = p.s.scan()
 		p.lit = p.s.lit
 		p.tok_pos = p.s.pos
-		p.normalize_current_token()
 	}
 }
 
 // peek supports peek handling for Parser.
 fn (mut p Parser) peek() token.Token {
 	if !p.has_peek {
-		p.peek_is_str_tail = p.s.in_str_incomplete
 		p.peek_tok = p.s.scan()
 		p.peek_lit = p.s.lit
 		p.peek_pos = p.s.pos
-		p.normalize_peek_token()
 		for p.peek_tok == .comment {
-			p.peek_is_str_tail = p.s.in_str_incomplete
 			p.peek_tok = p.s.scan()
 			p.peek_lit = p.s.lit
 			p.peek_pos = p.s.pos
-			p.normalize_peek_token()
 		}
 		p.has_peek = true
 	}
@@ -257,285 +229,6 @@ fn (mut p Parser) peek() token.Token {
 // peek_is supports peek is handling for Parser.
 fn (mut p Parser) peek_is(tok token.Token) bool {
 	return p.peek() == tok
-}
-
-// normalize_current_token transforms normalize current token data for parser.
-fn (mut p Parser) normalize_current_token() {
-	p.tok = normalize_scanned_token(p.tok, p.lit, p.s.src, p.tok_pos, p.tok_is_str_tail)
-}
-
-// normalize_peek_token transforms normalize peek token data for parser.
-fn (mut p Parser) normalize_peek_token() {
-	p.peek_tok = normalize_scanned_token(p.peek_tok, p.peek_lit, p.s.src, p.peek_pos,
-		p.peek_is_str_tail)
-}
-
-// token_from_id converts token from id data for parser.
-@[inline]
-fn token_from_id(id int) token.Token {
-	return unsafe { token.Token(id) }
-}
-
-// keyword_token_id supports keyword token id handling for parser.
-fn keyword_token_id(lit string) int {
-	return match lit {
-		'as' { 25 }
-		'asm' { 26 }
-		'assert' { 27 }
-		'atomic' { 28 }
-		'break' { 29 }
-		'const' { 30 }
-		'continue' { 31 }
-		'defer' { 32 }
-		'dump' { 33 }
-		'else' { 34 }
-		'enum' { 35 }
-		'false' { 36 }
-		'fn' { 37 }
-		'for' { 38 }
-		'__global' { 39 }
-		'go' { 40 }
-		'goto' { 41 }
-		'if' { 42 }
-		'import' { 43 }
-		'in' { 44 }
-		'interface' { 45 }
-		'is' { 46 }
-		'isreftype' { 47 }
-		'_likely_' { 48 }
-		'lock' { 49 }
-		'match' { 50 }
-		'module' { 51 }
-		'mut' { 52 }
-		'nil' { 53 }
-		'none' { 54 }
-		'__offsetof' { 55 }
-		'or' { 56 }
-		'pub' { 57 }
-		'return' { 58 }
-		'rlock' { 59 }
-		'select' { 60 }
-		'shared' { 61 }
-		'sizeof' { 62 }
-		'spawn' { 63 }
-		'static' { 64 }
-		'struct' { 65 }
-		'true' { 66 }
-		'type' { 67 }
-		'typeof' { 68 }
-		'union' { 69 }
-		'_unlikely_' { 70 }
-		'unsafe' { 71 }
-		'volatile' { 72 }
-		else { -1 }
-	}
-}
-
-// normalize_scanned_token transforms normalize scanned token data for parser.
-fn normalize_scanned_token(tok token.Token, lit string, src string, pos int, is_str_tail bool) token.Token {
-	if int(tok) == 19 || int(tok) == 105 || int(tok) == 106 {
-		return tok
-	}
-	if lit.len > 0 {
-		first := lit[0]
-		if int(tok) == 87 || int(tok) == 0 {
-			if is_str_tail && int(tok) == 0 {
-				return token_from_id(107)
-			}
-			if first >= `0` && first <= `9` {
-				return token_from_id(92)
-			}
-			if first == `.` && lit.len > 1 && lit[1] >= `0` && lit[1] <= `9` {
-				return token_from_id(92)
-			}
-			if first == `'` || first == `"`
-				|| (first == `r` && lit.len > 1 && (lit[1] == `'` || lit[1] == `"`)) {
-				return token_from_id(107)
-			}
-			if first == `\`` || lit.starts_with('c:') {
-				return token_from_id(7)
-			}
-		}
-		if first != `@` {
-			keyword_id := keyword_token_id(lit)
-			if keyword_id >= 0 {
-				return token_from_id(keyword_id)
-			}
-		}
-		if int(tok) == 0 {
-			return token_from_id(87)
-		}
-		return tok
-	}
-	if pos < 0 || pos >= src.len {
-		return tok
-	}
-	c := src[pos]
-	if c == `.` {
-		if pos + 1 < src.len && src[pos + 1] == `.` {
-			if pos + 2 < src.len && src[pos + 2] == `.` {
-				return token_from_id(18)
-			}
-			return token_from_id(17)
-		}
-		return token_from_id(16)
-	}
-	if c == `:` {
-		if pos + 1 < src.len && src[pos + 1] == `=` {
-			return token_from_id(12)
-		}
-		return token_from_id(8)
-	}
-	if int(tok) != 108 && int(tok) != 0 {
-		return tok
-	}
-	if c == `{` {
-		return token_from_id(73)
-	}
-	if c == `}` {
-		return token_from_id(98)
-	}
-	if c == `(` {
-		return token_from_id(78)
-	}
-	if c == `)` {
-		return token_from_id(103)
-	}
-	if c == `[` {
-		return token_from_id(79)
-	}
-	if c == `]` {
-		return token_from_id(104)
-	}
-	if c == `,` {
-		return token_from_id(9)
-	}
-	if c == `;` {
-		return token_from_id(105)
-	}
-	if c == `!` {
-		if pos + 1 < src.len && src[pos + 1] == `=` {
-			return token_from_id(88)
-		}
-		if pos + 3 < src.len && src[pos + 1] == `i` && src[pos + 2] == `n`
-			&& (src[pos + 3] == ` ` || src[pos + 3] == `\t`) {
-			return token_from_id(90)
-		}
-		if pos + 3 < src.len && src[pos + 1] == `i` && src[pos + 2] == `s`
-			&& (src[pos + 3] == ` ` || src[pos + 3] == `\t`) {
-			return token_from_id(91)
-		}
-		return token_from_id(89)
-	}
-	if c == `=` {
-		if pos + 1 < src.len && src[pos + 1] == `=` {
-			return token_from_id(20)
-		}
-		return token_from_id(4)
-	}
-	if c == `&` {
-		if pos + 1 < src.len && src[pos + 1] == `&` {
-			return token_from_id(1)
-		}
-		if pos + 1 < src.len && src[pos + 1] == `=` {
-			return token_from_id(2)
-		}
-		return token_from_id(0)
-	}
-	if c == `|` {
-		if pos + 1 < src.len && src[pos + 1] == `|` {
-			return token_from_id(77)
-		}
-		if pos + 1 < src.len && src[pos + 1] == `=` {
-			return token_from_id(93)
-		}
-		return token_from_id(94)
-	}
-	if c == `<` {
-		if pos + 1 < src.len && src[pos + 1] == `<` {
-			if pos + 2 < src.len && src[pos + 2] == `=` {
-				return token_from_id(76)
-			}
-			return token_from_id(75)
-		}
-		if pos + 1 < src.len && src[pos + 1] == `-` {
-			return token_from_id(3)
-		}
-		if pos + 1 < src.len && src[pos + 1] == `=` {
-			return token_from_id(74)
-		}
-		return token_from_id(80)
-	}
-	if c == `>` {
-		if pos + 1 < src.len && src[pos + 1] == `>` {
-			if pos + 2 < src.len && src[pos + 2] == `>` {
-				if pos + 3 < src.len && src[pos + 3] == `=` {
-					return token_from_id(102)
-				}
-				return token_from_id(101)
-			}
-			if pos + 2 < src.len && src[pos + 2] == `=` {
-				return token_from_id(100)
-			}
-			return token_from_id(99)
-		}
-		if pos + 1 < src.len && src[pos + 1] == `=` {
-			return token_from_id(21)
-		}
-		return token_from_id(22)
-	}
-	if c == `+` {
-		if pos + 1 < src.len && src[pos + 1] == `+` {
-			return token_from_id(24)
-		}
-		if pos + 1 < src.len && src[pos + 1] == `=` {
-			return token_from_id(96)
-		}
-		return token_from_id(95)
-	}
-	if c == `-` {
-		if pos + 1 < src.len && src[pos + 1] == `-` {
-			return token_from_id(11)
-		}
-		if pos + 1 < src.len && src[pos + 1] == `=` {
-			return token_from_id(82)
-		}
-		return token_from_id(81)
-	}
-	if c == `*` {
-		if pos + 1 < src.len && src[pos + 1] == `=` {
-			return token_from_id(86)
-		}
-		return token_from_id(85)
-	}
-	if c == `/` {
-		if pos + 1 < src.len && src[pos + 1] == `=` {
-			return token_from_id(14)
-		}
-		return token_from_id(13)
-	}
-	if c == `%` {
-		if pos + 1 < src.len && src[pos + 1] == `=` {
-			return token_from_id(84)
-		}
-		return token_from_id(83)
-	}
-	if c == `~` {
-		return token_from_id(6)
-	}
-	if c == `$` {
-		return token_from_id(15)
-	}
-	if c == `#` {
-		if pos + 1 < src.len && src[pos + 1] == `[` {
-			return token_from_id(79)
-		}
-		return token_from_id(23)
-	}
-	if c == `?` {
-		return token_from_id(97)
-	}
-	return tok
 }
 
 fn (mut p Parser) check(expected token.Token) {
@@ -3690,12 +3383,10 @@ fn (mut p Parser) starts_sql_expr() bool {
 	saved_tok := p.tok
 	saved_lit := p.lit
 	saved_tok_pos := p.tok_pos
-	saved_tok_is_str_tail := p.tok_is_str_tail
 	saved_prev_tok := p.prev_tok
 	saved_peek_tok := p.peek_tok
 	saved_peek_lit := p.peek_lit
 	saved_peek_pos := p.peek_pos
-	saved_peek_is_str_tail := p.peek_is_str_tail
 	saved_has_peek := p.has_peek
 	p.next()
 	for p.tok == .dot {
@@ -3710,12 +3401,10 @@ fn (mut p Parser) starts_sql_expr() bool {
 	p.tok = saved_tok
 	p.lit = saved_lit
 	p.tok_pos = saved_tok_pos
-	p.tok_is_str_tail = saved_tok_is_str_tail
 	p.prev_tok = saved_prev_tok
 	p.peek_tok = saved_peek_tok
 	p.peek_lit = saved_peek_lit
 	p.peek_pos = saved_peek_pos
-	p.peek_is_str_tail = saved_peek_is_str_tail
 	p.has_peek = saved_has_peek
 	return ok
 }
@@ -4423,6 +4112,16 @@ fn (mut p Parser) index_expr(lhs flat.NodeId) flat.NodeId {
 		})
 	}
 	idx := p.expr(.logical_or)
+	// fast path for the common simple index `arr[i]`: avoid the children array
+	if p.tok == .rsbr {
+		p.next()
+		istart := p.add_children2(lhs, idx)
+		return p.a.add_node(flat.Node{
+			kind:           .index
+			children_start: istart
+			children_count: 2
+		})
+	}
 	mut ids := []flat.NodeId{}
 	ids << lhs
 	ids << idx
@@ -4743,13 +4442,25 @@ fn (mut p Parser) array_literal() flat.NodeId {
 	// array literal: [1, 2, 3]
 	// or fixed array type: [3]int
 	mut ids := []flat.NodeId{}
+	size_start := p.tok_pos
 	ids << p.expr(.lowest)
 	// check if it's [N]Type (fixed array type)
 	if p.tok == .rsbr {
+		size_end := p.tok_pos
 		p.next()
 		if p.tok == .name || p.tok == .amp || p.tok == .lsbr || p.tok == .question {
-			// fixed array type: [N]Type
-			size_str := p.a.nodes[int(ids[0])].value
+			// fixed array type: [N]Type. Use the literal node value for a plain integer
+			// size, but recover the full source text for a const expression (e.g.
+			// `[segs + 1]f32`) — an infix node has no `.value`, which would otherwise
+			// collapse the type to a dynamic `[]f32`.
+			lit_size := p.a.nodes[int(ids[0])].value
+			size_str := if lit_size.len > 0 {
+				lit_size
+			} else if size_start >= 0 && size_end > size_start && size_end <= p.s.src.len {
+				p.s.src[size_start..size_end].trim_space()
+			} else {
+				lit_size
+			}
 			elem_type := p.parse_type_name()
 			fixed_type := '[${size_str}]${elem_type}'
 			// may have init

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -4912,11 +4912,22 @@ fn (mut p Parser) parse_type_name() string {
 			p.next()
 			return '[]' + p.parse_type_name()
 		}
-		// fixed array [N]T
-		mut len_lit := p.lit
-		p.next()
+		// fixed array [N]T — the size may be a const expression (`[segs + 1]f32`),
+		// not just a single token, so parse the whole expression and recover its
+		// source text when it is not a plain literal (mirrors the array-literal path).
+		size_start := p.tok_pos
+		size_node := p.expr(.lowest)
+		size_end := p.tok_pos
 		p.check(.rsbr)
-		return '[${len_lit}]' + p.parse_type_name()
+		lit_size := p.a.nodes[int(size_node)].value
+		size_str := if lit_size.len > 0 {
+			lit_size
+		} else if size_start >= 0 && size_end > size_start && size_end <= p.s.src.len {
+			p.s.src[size_start..size_end].trim_space()
+		} else {
+			lit_size
+		}
+		return '[${size_str}]' + p.parse_type_name()
 	}
 	// multi-return (T, U)
 	if p.tok == .lpar {

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -72,15 +72,71 @@ pub fn (p &Preferences) get_vlib_module_path(mod string) string {
 // get_module_path returns get module path data for Preferences.
 pub fn (p &Preferences) get_module_path(mod string, importing_file_path string) string {
 	mod_path := mod.replace('.', os.path_separator)
-	relative_path := os.join_path_single(os.dir(importing_file_path), mod_path)
-	if os.is_dir(relative_path) {
+	// Absolutize the importer like V1's Builder.find_module_path does
+	// (`os.real_path(fpath)`). When the input is given as a relative path (e.g.
+	// `v3 -o out .`), the parsed file paths are relative too (`./doka.v`), and a
+	// parent-directory walk starting from `.` could never climb above the project
+	// dir to find sibling modules.
+	abs_importer := os.real_path(importing_file_path)
+	importer_dir := os.dir(abs_importer)
+	// 1. relative to the importing file's directory
+	relative_path := os.join_path_single(importer_dir, mod_path)
+	if dir_is_module(relative_path) {
 		return relative_path
 	}
+	// 2. vlib
 	vlib_path := os.join_path_single(os.join_path_single(p.vroot, 'vlib'), mod_path)
-	if os.is_dir(vlib_path) {
+	if dir_is_module(vlib_path) {
 		return vlib_path
 	}
+	// 3. ~/.vmodules (or $VMODULES)
+	vmodules_path := os.join_path_single(vmodules_dir(), mod_path)
+	if dir_is_module(vmodules_path) {
+		return vmodules_path
+	}
+	// 4. walk up the parent directories of the importing file, like V1's
+	// Builder.find_module_path. This finds sibling projects: e.g. importing
+	// `viper` from ~/code/doka/doka.v resolves to ~/code/viper.
+	mut current_dir := importer_dir
+	for {
+		try_path := os.join_path_single(current_dir, mod_path)
+		if dir_is_module(try_path) {
+			return try_path
+		}
+		parent_dir := os.dir(current_dir)
+		if parent_dir == current_dir {
+			break
+		}
+		current_dir = parent_dir
+	}
 	return ''
+}
+
+// dir_is_module reports whether `dir` is a usable module directory: it must exist
+// and contain at least one `.v` source file. V1 applies the same `.v`-files guard
+// (`module_path_has_v_files`); without it the parent-directory walk could match an
+// unrelated directory that merely shares a module's name (e.g. `~/code/util`),
+// shadowing the real module.
+fn dir_is_module(dir string) bool {
+	if dir.len == 0 || !os.is_dir(dir) {
+		return false
+	}
+	entries := os.ls(dir) or { return false }
+	for entry in entries {
+		if entry.ends_with('.v') {
+			return true
+		}
+	}
+	return false
+}
+
+// vmodules_dir returns the user's global modules directory ($VMODULES or ~/.vmodules).
+fn vmodules_dir() string {
+	env_dir := os.getenv('VMODULES')
+	if env_dir.len > 0 {
+		return env_dir
+	}
+	return os.join_path_single(os.home_dir(), '.vmodules')
 }
 
 // file_has_incompatible_os_suffix converts file has incompatible os suffix data for pref.

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -329,4 +329,13 @@ fn test_fixed_array_length_checks() {
 	good_lit := run_good(v3_bin, 'good_if_branch_array_literal_len',
 		'fn main() {\n\tc := true\n\tx := if c { [1, 2, 3] } else { [4, 5] }\n\tprintln(int_str(x.len))\n}\n')
 	assert good_lit == '3'
+	// `return if cond { ... } else { ... }` with fixed-array-const branches must
+	// coerce each branch to the dynamic `[]T` return type (like a plain return and
+	// the `return match` path), not return the bare C fixed array.
+	good_ret_const := run_good(v3_bin, 'good_return_if_fixed_const',
+		'const wp3 = [1, 2, 3]\nconst wp2 = [4, 5]\nfn pick(c bool) []int {\n\treturn if c { wp3 } else { wp2 }\n}\nfn main() {\n\tprintln(int_str(pick(true).len + pick(false).len))\n}\n')
+	assert good_ret_const == '5'
+	good_ret_lit := run_good(v3_bin, 'good_return_if_array_literal',
+		'fn pick(c bool) []int {\n\treturn if c { [1, 2, 3] } else { [4, 5] }\n}\nfn main() {\n\tprintln(int_str(pick(true).len + pick(false).len))\n}\n')
+	assert good_ret_lit == '5'
 }

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -733,3 +733,17 @@ fn test_pr_review_codegen_batch_sixteen() {
 		"struct Box[T] {\n\tv T\n}\nfn first(a []Box[int]) int {\n\treturn a[0].v\n}\nstruct Holder {\n\titems []Box[int]\n}\nfn make() []Box[int] {\n\treturn [Box{\n\t\tv: 1\n\t}, Box{\n\t\tv: 2\n\t}]\n}\nfn main() {\n\tr := make()\n\ta := first([Box{\n\t\tv: 3\n\t}, Box{\n\t\tv: 4\n\t}])\n\th := Holder{\n\t\titems: [Box{\n\t\t\tv: 5\n\t\t}]\n\t}\n\tprintln(int_str(r[0].v + r[1].v) + ',' + int_str(a) + ',' + int_str(h.items[0].v))\n}\n")
 	assert out == '3,3,5'
 }
+
+fn test_pr_review_codegen_batch_seventeen() {
+	v3_bin := build_v3()
+	// Static method `Type.method(...)` calls now lower their arguments through the ordinary
+	// argument path, so a parameter that needs coercion is emitted against its expected type.
+	// Here `Factory.describe` takes a sum type, so the bare `Circle{..}` argument is wrapped as
+	// a `Shape` variant instead of being passed as the raw struct (which would be wrong C).
+	// `Shader.build()` takes no parameters but shares the short name `build` with `Config.build`
+	// (a method, hence has params); the lowering must not adopt that unrelated signature and
+	// append a phantom argument to the 0-parameter static call.
+	out := run_good(v3_bin, 'good_static_method_arg_lowering',
+		"struct Config {\n\tlengths []int\n}\nfn (c Config) build() int {\n\treturn c.lengths.len\n}\nstruct Shader {\n\tid int\n}\nfn Shader.build() Shader {\n\treturn Shader{\n\t\tid: 42\n\t}\n}\ntype Shape = Circle | Square\nstruct Circle {\n\tr int\n}\nstruct Square {\n\ts int\n}\nstruct Factory {}\nfn Factory.describe(sh Shape) int {\n\treturn match sh {\n\t\tCircle { sh.r }\n\t\tSquare { sh.s }\n\t}\n}\nfn main() {\n\ts := Shader.build()\n\td := Factory.describe(Circle{r: 7})\n\tprintln(int_str(s.id) + ',' + int_str(d))\n}\n")
+	assert out == '42,7'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -339,3 +339,27 @@ fn test_fixed_array_length_checks() {
 		'fn pick(c bool) []int {\n\treturn if c { [1, 2, 3] } else { [4, 5] }\n}\nfn main() {\n\tprintln(int_str(pick(true).len + pick(false).len))\n}\n')
 	assert good_ret_lit == '5'
 }
+
+// Regression tests for the post-PR review fixes around generic struct receivers
+// and generic heap struct literals.
+fn test_generic_struct_receiver_and_heap_init() {
+	v3_bin := build_v3()
+	// Two *different concrete* instantiations are incompatible: `Box[string]` must
+	// not satisfy an expected `Box[int]` (value or pointer form).
+	run_bad(v3_bin, 'bad_generic_concrete_value_arg',
+		"struct Box[T] {\n\tval T\n}\nfn use_int(b Box[int]) int {\n\treturn b.val\n}\nfn main() {\n\tbs := Box[string]{\n\t\tval: 'hi'\n\t}\n\t_ := use_int(bs)\n}\n",
+		'expected `Box[int]`')
+	run_bad(v3_bin, 'bad_generic_concrete_ptr_arg',
+		"struct Box[T] {\n\tval T\n}\nfn use_int(b &Box[int]) int {\n\treturn b.val\n}\nfn main() {\n\tbs := &Box[string]{\n\t\tval: 'hi'\n\t}\n\t_ := use_int(bs)\n}\n",
+		'expected `&Box[int]`')
+	// A generic method on the open `Box[T]` receiver works for every instantiation.
+	good_method := run_good(v3_bin, 'good_generic_method_instances',
+		"struct Box[T] {\n\tval T\n}\nfn (b Box[T]) get() T {\n\treturn b.val\n}\nfn main() {\n\tbi := Box[int]{\n\t\tval: 42\n\t}\n\tbs := Box[string]{\n\t\tval: 'hi'\n\t}\n\tprintln(int_str(bi.get()))\n\tprintln(bs.get())\n}\n")
+	assert good_method == '42\nhi'
+	// A bare generic literal (`Box{..}` / `&Box{..}`) specializes to the expected
+	// concrete instance — and the heap literal must materialize the same concrete
+	// C type (`Box_int`) as the value literal, not the bare template.
+	good_heap := run_good(v3_bin, 'good_generic_bare_value_and_heap_args',
+		'struct Box[T] {\n\tval T\n}\nfn take_val(b Box[int]) int {\n\treturn b.val\n}\nfn take_heap(b &Box[int]) int {\n\treturn b.val\n}\nfn main() {\n\tprintln(int_str(take_val(Box{\n\t\tval: 7\n\t}) + take_heap(&Box{\n\t\tval: 9\n\t})))\n}\n')
+	assert good_heap == '16'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -610,11 +610,11 @@ fn test_pr_review_codegen_batch_eleven() {
 	// reaching cgen and emitting an undefined helper. Append form:
 	run_bad(v3_bin, 'bad_method_value_array_append',
 		'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nfn main() {\n\tmut cbs := []fn () int{}\n\tfor i in 0 .. 3 {\n\t\tc := Counter{\n\t\t\tid: i * 10\n\t\t}\n\t\tcbs << c.report\n\t}\n\tprintln(int_str(cbs.len))\n}\n',
-		'cannot be stored in an array')
+		'cannot escape its call site')
 	// Array-literal form is rejected too.
 	run_bad(v3_bin, 'bad_method_value_array_literal',
 		'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nfn main() {\n\ta := Counter{\n\t\tid: 1\n\t}\n\tb := Counter{\n\t\tid: 2\n\t}\n\tcbs := [a.report, b.report]\n\tprintln(int_str(cbs.len))\n}\n',
-		'cannot be stored in an array')
+		'cannot escape its call site')
 	// The supported single-use forms still work: a method value passed directly as a
 	// callback argument, and an `arr << int` append / `int << int` shift are not flagged.
 	imm := run_good(v3_bin, 'good_method_value_immediate_after_guard',
@@ -660,4 +660,34 @@ fn test_pr_review_codegen_batch_thirteen() {
 	run_bad(v3_bin, 'bad_unsigned_shift_fixed_array_literal_len',
 		'fn take(a [8 >>> 1]int) int {\n\treturn a[0]\n}\nfn main() {\n\t_ := take([1, 2]!)\n}\n',
 		'cannot use')
+}
+
+// Regression tests for the fourteenth PR-review batch (vlang/v#27557).
+fn test_pr_review_codegen_batch_fourteen() {
+	v3_bin := build_v3()
+	// Non-decimal integer literals (hex `0x`, octal `0o`, binary `0b`) fold in const
+	// fixed-array lengths: `0xF & 6` = 6, `0b1100 >> 1` = 6, `0o17 & 8` = 8.
+	nondec := run_good(v3_bin, 'good_non_decimal_const_fixed_array_len',
+		'const flags = 0b1010 | 0b0100\nfn main() {\n\ta := [0xF & 6]int{}\n\tb := [0b1100 >> 1]int{}\n\tc := [0o17 & 8]int{}\n\td := [flags]int{}\n\tprintln(int_str(a.len + b.len + c.len + d.len))\n}\n')
+	// 6 + 6 + 8 + 14 = 34
+	assert nondec == '34'
+	// The length guard evaluates non-decimal too: `[1, 2]` does not match `[0xF & 6]int`.
+	run_bad(v3_bin, 'bad_non_decimal_fixed_array_literal_len',
+		'fn take(a [0xF & 6]int) int {\n\treturn a[0]\n}\nfn main() {\n\t_ := take([1, 2]!)\n}\n',
+		'cannot use')
+	// A generic-receiver method with a function-type parameter substitutes the type params
+	// inside the signature, so `Box[string].apply` expects `fn (string) int`, and a matching
+	// callback is accepted and emitted with the right fn-pointer type.
+	apply := run_good(v3_bin, 'good_generic_method_fn_type_param',
+		"struct Box[T] {\n\tv T\n}\nfn (b Box[T]) apply(cb fn (T) int) int {\n\treturn cb(b.v)\n}\nfn slen(s string) int {\n\treturn s.len\n}\nfn main() {\n\tb := Box[string]{\n\t\tv: 'hello'\n\t}\n\tprintln(int_str(b.apply(slen)))\n}\n")
+	assert apply == '5'
+	// A method value that escapes its call site is rejected: returned from a factory, stored
+	// in a struct field, or put in a map (the per-site static receiver can't keep several
+	// instances distinct). Immediately-passed callbacks and local bindings still work.
+	run_bad(v3_bin, 'bad_method_value_return_escape',
+		'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nfn bind(c Counter) fn () int {\n\treturn c.report\n}\nfn main() {\n\t_ := bind(Counter{\n\t\tid: 1\n\t})\n}\n',
+		'cannot escape its call site')
+	run_bad(v3_bin, 'bad_method_value_struct_field_escape',
+		'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nstruct Engine {\n\tcb fn () int\n}\nfn main() {\n\t_ := Engine{\n\t\tcb: Counter{\n\t\t\tid: 1\n\t\t}.report\n\t}\n}\n',
+		'cannot escape its call site')
 }

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -778,3 +778,19 @@ fn test_pr_review_codegen_batch_eighteen() {
 		"fn work() [0x10]u8 {\n\tmut r := [0x10]u8{}\n\tr[0] = 42\n\tr[15] = 7\n\treturn r\n}\nfn main() {\n\tmut threads := []thread [0x10]u8{}\n\tthreads << spawn work()\n\tresults := threads.wait()\n\tprintln(int_str(results[0][0]) + ',' + int_str(results[0][15]))\n}\n")
 	assert thread_fixed == '42,7'
 }
+
+fn test_pr_review_codegen_batch_nineteen() {
+	v3_bin := build_v3()
+	// A value local whose address escapes (`p := &v` with `p` returned) is moved to the heap at
+	// its declaration, so a mutation between the alias and the return is observed by the caller —
+	// matching V's auto-heap semantics. Copying eagerly at `p := &v` returned stale data (x == 1).
+	escaped := run_good(v3_bin, 'good_escaped_pointer_alias_mutation',
+		'struct Box {\nmut:\n\tx int\n}\nfn make() &Box {\n\tmut v := Box{\n\t\tx: 1\n\t}\n\tp := &v\n\tv.x = 2\n\treturn p\n}\nfn main() {\n\tb := make()\n\tprintln(int_str(b.x))\n}\n')
+	assert escaped == '2'
+	// A static-method call returning a fixed array (`Type.make() [N]T`) is lowered to a selector
+	// whose base is a type, not a receiver value; its `_v_ret_*` wrapper must still be unwrapped to
+	// `.ret_arr`, so the assignment/indexing below sees the array, not the wrapper struct.
+	static_fixed := run_good(v3_bin, 'good_static_method_fixed_array_return',
+		'struct Maker {}\nfn Maker.make() [3]int {\n\treturn [10, 20, 30]!\n}\nfn main() {\n\ta := Maker.make()\n\tprintln(int_str(a[0] + a[1] + a[2]))\n}\n')
+	assert static_fixed == '60'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -867,3 +867,31 @@ fn test_pr_review_codegen_batch_twentytwo() {
 		'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nfn main() {\n\tc := Counter{\n\t\tid: 5\n\t}\n\tcb := c.report\n\t_ = cb\n\tprintln(int_str(c.report()))\n}\n')
 	assert blank == '5'
 }
+
+fn test_pr_review_codegen_batch_twentythree() {
+	v3_bin := build_v3()
+	// A concrete generic with multiple arguments including a later pointer argument
+	// (`Pair[int, &Node]`) must parse as a generic instance, not a fixed array: the `&` only
+	// leads a type argument because of the preceding comma, so a comma-bearing bracket is never
+	// a fixed-array length (which is always a single integer expression).
+	genptr := run_good(v3_bin, 'good_generic_multi_arg_pointer',
+		'struct Node {\n\tval int\n}\nstruct Pair[A, B] {\n\tfirst  A\n\tsecond B\n}\nfn main() {\n\tn := Node{\n\t\tval: 5\n\t}\n\tp := Pair[int, &Node]{\n\t\tfirst:  1\n\t\tsecond: &n\n\t}\n\tprintln(int_str(p.first + p.second.val))\n}\n')
+	assert genptr == '6'
+	// A whole-value assignment between two heaped locals (both moved to `&T` because their
+	// addresses escape) must copy the value through the pointers (`*v = *w`), not alias `w`'s
+	// object. Here `v = w` then mutating `w` must leave the first returned pointer at w's old value.
+	heap2 := run_good(v3_bin, 'good_heaped_local_whole_value_assign',
+		"struct Box {\nmut:\n\tx int\n}\nfn split() (&Box, &Box) {\n\tmut v := Box{\n\t\tx: 1\n\t}\n\tmut w := Box{\n\t\tx: 2\n\t}\n\tp := &v\n\tq := &w\n\tv = w\n\tw.x = 100\n\treturn p, q\n}\nfn main() {\n\ta, b := split()\n\tprintln(int_str(a.x) + ',' + int_str(b.x))\n}\n")
+	assert heap2 == '2,100'
+	// A method value bound to a local and reassigned only on one branch still escapes on the
+	// other path, so returning it is rejected (the marker survives a non-dominating reassignment).
+	mv := 'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nfn plain() int {\n\treturn 0\n}\n'
+	run_bad(v3_bin, 'bad_method_value_conditional_reassign_escape', mv +
+		'fn build_cb(c Counter, cond bool) fn () int {\n\tmut cb := c.report\n\tif cond {\n\t\tcb = plain\n\t}\n\treturn cb\n}\nfn main() {\n\t_ := build_cb(Counter{\n\t\tid: 1\n\t}, false)\n}\n',
+		'cannot escape its call site')
+	// An unconditional reassignment to a non-method value dominates the later use, so the marker
+	// is cleared and the (now plain) callback is accepted.
+	uncond := run_good(v3_bin, 'good_method_value_unconditional_reassign', mv +
+		'fn build_cb(c Counter) int {\n\tmut cb := c.report\n\tcb = plain\n\treturn cb()\n}\nfn main() {\n\tprintln(int_str(build_cb(Counter{\n\t\tid: 1\n\t})))\n}\n')
+	assert uncond == '0'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -379,3 +379,19 @@ fn test_const_expr_fixed_array_and_thread_ptr_wait() {
 		'struct Foo {\n\tx int\n}\nfn work(n int) &Foo {\n\treturn &Foo{\n\t\tx: n\n\t}\n}\nfn main() {\n\tmut threads := []thread &Foo{}\n\tthreads << spawn work(40)\n\tthreads << spawn work(2)\n\tresults := threads.wait()\n\tmut sum := 0\n\tfor r in results {\n\t\tsum += r.x\n\t}\n\tprintln(int_str(sum))\n}\n')
 	assert good_thread == '42'
 }
+
+// Regression tests: a const-expression fixed-array length must work as a STRUCT
+// FIELD type (not only as a literal) and must fold whether or not the operators
+// are spaced (`segs+1` as well as `segs + 1`).
+fn test_const_expr_fixed_array_field_and_spacing() {
+	v3_bin := build_v3()
+	// Struct field `[segs + 1]f32` was emitted as `void verts[4]` (element lost,
+	// size = segs); it must be `[5]f32` with `.len == 5`.
+	good_field := run_good(v3_bin, 'good_const_expr_fixed_array_field',
+		'const segs = 4\nstruct Mesh {\n\tverts [segs + 1]f32\n}\nfn main() {\n\tm := Mesh{}\n\tprintln(int_str(m.verts.len))\n}\n')
+	assert good_field == '5'
+	// Spaced, unspaced, and nested const-expression sizes all fold to a literal.
+	good_forms := run_good(v3_bin, 'good_const_expr_fixed_array_forms',
+		'const segs = 3\nconst mult = 2\nfn main() {\n\ta := [segs + 1]int{}\n\tb := [segs+1]int{}\n\tc := [segs * mult]int{}\n\td := [segs - 1]int{}\n\te := [segs * mult + 1]int{}\n\tprintln(int_str(a.len + b.len + c.len + d.len + e.len))\n}\n')
+	assert good_forms == '23'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -794,3 +794,26 @@ fn test_pr_review_codegen_batch_nineteen() {
 		'struct Maker {}\nfn Maker.make() [3]int {\n\treturn [10, 20, 30]!\n}\nfn main() {\n\ta := Maker.make()\n\tprintln(int_str(a[0] + a[1] + a[2]))\n}\n')
 	assert static_fixed == '60'
 }
+
+fn test_pr_review_codegen_batch_twenty() {
+	v3_bin := build_v3()
+	mv := 'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\n'
+	// Storing a method value into a struct field is an escape: the per-site static receiver slot
+	// is overwritten on the next evaluation, so previously-stored callbacks lose their receiver.
+	run_bad(v3_bin, 'bad_method_value_struct_field_assign', mv +
+		'struct Holder {\nmut:\n\tcb fn () int\n}\nfn main() {\n\tc := Counter{\n\t\tid: 5\n\t}\n\tmut h := Holder{}\n\th.cb = c.report\n\tprintln(int_str(h.cb()))\n}\n',
+		'cannot escape its call site')
+	// Same hazard storing into an array element.
+	run_bad(v3_bin, 'bad_method_value_index_assign', mv +
+		'fn main() {\n\tc := Counter{\n\t\tid: 5\n\t}\n\tmut cbs := []fn () int{len: 1}\n\tcbs[0] = c.report\n\tprintln(int_str(cbs[0]()))\n}\n',
+		'cannot escape its call site')
+	// A method value assigned to a local with `=` is still tracked, so a later escape is caught.
+	run_bad(v3_bin, 'bad_method_value_local_eq_then_return_escape', mv +
+		'fn dummy() int {\n\treturn 0\n}\nfn bind(c Counter) fn () int {\n\tmut cb := dummy\n\tcb = c.report\n\treturn cb\n}\nfn main() {\n\t_ := bind(Counter{\n\t\tid: 1\n\t})\n}\n',
+		'cannot escape its call site')
+	// Assigning a method value to a local (including reassignment) and passing it straight to a
+	// callback parameter does not escape, so it stays valid.
+	ok := run_good(v3_bin, 'good_method_value_local_assign_direct_use', mv +
+		'fn invoke(cb fn () int) int {\n\treturn cb()\n}\nfn main() {\n\tc := Counter{\n\t\tid: 7\n\t}\n\tmut cb := c.report\n\tcb = c.report\n\tprintln(int_str(invoke(cb)))\n}\n')
+	assert ok == '7'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -747,3 +747,34 @@ fn test_pr_review_codegen_batch_seventeen() {
 		"struct Config {\n\tlengths []int\n}\nfn (c Config) build() int {\n\treturn c.lengths.len\n}\nstruct Shader {\n\tid int\n}\nfn Shader.build() Shader {\n\treturn Shader{\n\t\tid: 42\n\t}\n}\ntype Shape = Circle | Square\nstruct Circle {\n\tr int\n}\nstruct Square {\n\ts int\n}\nstruct Factory {}\nfn Factory.describe(sh Shape) int {\n\treturn match sh {\n\t\tCircle { sh.r }\n\t\tSquare { sh.s }\n\t}\n}\nfn main() {\n\ts := Shader.build()\n\td := Factory.describe(Circle{r: 7})\n\tprintln(int_str(s.id) + ',' + int_str(d))\n}\n")
 	assert out == '42,7'
 }
+
+fn test_pr_review_codegen_batch_eighteen() {
+	v3_bin := build_v3()
+	// A method value bound to a local (`cb := c.report`) shares the same per-site static receiver
+	// as the bare selector, so aliasing it out — returned from a factory or appended to an array —
+	// escapes just like `return c.report` and is rejected, not only the direct selector form.
+	mv := 'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\n'
+	run_bad(v3_bin, 'bad_method_value_local_return_escape', mv +
+		'fn bind(c Counter) fn () int {\n\tcb := c.report\n\treturn cb\n}\nfn main() {\n\t_ := bind(Counter{\n\t\tid: 1\n\t})\n}\n',
+		'cannot escape its call site')
+	run_bad(v3_bin, 'bad_method_value_local_append_escape', mv +
+		'fn collect(c Counter) []fn () int {\n\tmut arr := []fn () int{}\n\tcb := c.report\n\tarr << cb\n\treturn arr\n}\nfn main() {\n\t_ := collect(Counter{\n\t\tid: 1\n\t})\n}\n',
+		'cannot escape its call site')
+	// A method-value local passed straight to a callback parameter does not escape and stays valid.
+	direct := run_good(v3_bin, 'good_method_value_local_direct_use', mv +
+		'fn invoke(cb fn () int) int {\n\treturn cb()\n}\nfn main() {\n\tc := Counter{\n\t\tid: 7\n\t}\n\tcb := c.report\n\tprintln(int_str(invoke(cb)))\n}\n')
+	assert direct == '7'
+	// A bare heap generic literal (`&Box{v: 1}` where `&Box[int]` is expected) must read its
+	// omitted-field defaults from the concrete instance key: monomorphization drops the bare `Box`
+	// entry, so an omitted `items []T` needs its `array_new` default or the field has invalid
+	// zeroed array metadata (here a later append would silently drop the elements).
+	heap_default := run_good(v3_bin, 'good_heap_generic_omitted_array_default',
+		"struct Box[T] {\n\tv     T\n\titems []T\n}\nfn make() &Box[int] {\n\treturn &Box{\n\t\tv: 1\n\t}\n}\nfn main() {\n\tmut b := make()\n\tb.items << 10\n\tb.items << 20\n\tprintln(int_str(b.v) + ',' + int_str(b.items.len) + ',' + int_str(b.items[0]) + ',' + int_str(b.items[1]))\n}\n")
+	assert heap_default == '1,2,10,20'
+	// `[]thread T.wait()` recovers the spawned return type from the thread name; a fixed-array
+	// return with a non-decimal length (`[0x10]u8`) must reconstruct the same `_v_ret_*` wrapper
+	// ABI type the spawn wrapper stored, not a bogus generic application of `u8`.
+	thread_fixed := run_good(v3_bin, 'good_thread_wait_nondecimal_fixed_array',
+		"fn work() [0x10]u8 {\n\tmut r := [0x10]u8{}\n\tr[0] = 42\n\tr[15] = 7\n\treturn r\n}\nfn main() {\n\tmut threads := []thread [0x10]u8{}\n\tthreads << spawn work()\n\tresults := threads.wait()\n\tprintln(int_str(results[0][0]) + ',' + int_str(results[0][15]))\n}\n")
+	assert thread_fixed == '42,7'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -439,3 +439,23 @@ fn test_pr_review_codegen_batch_three() {
 		"struct G {\n\tn int\n}\nfn (g G) make() ?string {\n\treturn 'hi'\n}\nfn run(cb fn () ?string) {\n\ts := cb() or { 'none' }\n\tprintln(s)\n}\nfn main() {\n\tg := G{\n\t\tn: 1\n\t}\n\trun(g.make)\n}\n")
 	assert mv == 'hi'
 }
+
+// Regression tests: a bare generic struct literal adopts a matching concrete
+// expected instance (value and heap), and a field-type mismatch is rejected.
+fn test_bare_generic_literal_adopts_expected_instance() {
+	v3_bin := build_v3()
+	val := run_good(v3_bin, 'good_bare_generic_literal_return',
+		'struct Box[T] {\n\tv T\n}\nfn make() Box[int] {\n\treturn Box{\n\t\tv: 7\n\t}\n}\nfn main() {\n\tprintln(int_str(make().v))\n}\n')
+	assert val == '7'
+	heap := run_good(v3_bin, 'good_bare_generic_literal_heap_return',
+		'struct Box[T] {\n\tv T\n}\nfn make() &Box[int] {\n\treturn &Box{\n\t\tv: 9\n\t}\n}\nfn main() {\n\tprintln(int_str(make().v))\n}\n')
+	assert heap == '9'
+	pair := run_good(v3_bin, 'good_bare_generic_literal_multi_param',
+		"struct Pair[L, R] {\n\tl L\n\tr R\n}\nfn make() Pair[string, int] {\n\treturn Pair{\n\t\tl: 'hi'\n\t\tr: 5\n\t}\n}\nfn main() {\n\tp := make()\n\tprintln(p.l)\n\tprintln(int_str(p.r))\n}\n")
+	assert pair == 'hi\n5'
+	// A field whose type does not match the concrete instantiation is rejected by the
+	// checker (rather than adopting the type and emitting broken C).
+	run_bad(v3_bin, 'bad_bare_generic_literal_field_mismatch',
+		"struct Box[T] {\n\tv T\n}\nfn make() Box[int] {\n\treturn Box{\n\t\tv: 'str'\n\t}\n}\nfn main() {\n\t_ := make()\n}\n",
+		'cannot return `Box` as `Box[int]`')
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -363,3 +363,19 @@ fn test_generic_struct_receiver_and_heap_init() {
 		'struct Box[T] {\n\tval T\n}\nfn take_val(b Box[int]) int {\n\treturn b.val\n}\nfn take_heap(b &Box[int]) int {\n\treturn b.val\n}\nfn main() {\n\tprintln(int_str(take_val(Box{\n\t\tval: 7\n\t}) + take_heap(&Box{\n\t\tval: 9\n\t})))\n}\n')
 	assert good_heap == '16'
 }
+
+// Regression tests for the post-PR review fixes: const-expression fixed-array
+// lengths must be folded to a literal (not c_name-mangled into `segs_+_1`), and the
+// `[]thread T.wait()` helper name must sanitize a pointer payload C type (`Foo*`).
+fn test_const_expr_fixed_array_and_thread_ptr_wait() {
+	v3_bin := build_v3()
+	// `[segs + 1]f32` must emit `[5]` for both the array dimension and `.len`.
+	good_len := run_good(v3_bin, 'good_const_expr_fixed_array_len',
+		'const segs = 4\nfn main() {\n\tmut x := [segs + 1]f32{}\n\tx[0] = 1.5\n\tx[segs] = 2.5\n\tprintln(int_str(x.len))\n\tprintln(int_str(int(x[0] + x[segs])))\n}\n')
+	assert good_len == '5\n4'
+	// `[]thread &Foo.wait()` returns `[]&Foo`; the wait helper symbol must not contain
+	// the `*` from the `Foo*` payload C type.
+	good_thread := run_good(v3_bin, 'good_thread_ptr_payload_wait',
+		'struct Foo {\n\tx int\n}\nfn work(n int) &Foo {\n\treturn &Foo{\n\t\tx: n\n\t}\n}\nfn main() {\n\tmut threads := []thread &Foo{}\n\tthreads << spawn work(40)\n\tthreads << spawn work(2)\n\tresults := threads.wait()\n\tmut sum := 0\n\tfor r in results {\n\t\tsum += r.x\n\t}\n\tprintln(int_str(sum))\n}\n')
+	assert good_thread == '42'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -573,3 +573,30 @@ fn test_pr_review_codegen_batch_eight() {
 		"struct Game {\n\tscore int\n}\nfn (g Game) draw() {\n\tprintln('drawing')\n}\ntype Cb = fn ()\nfn run(cb Cb) {\n\tcb()\n}\nfn main() {\n\tg := Game{\n\t\tscore: 5\n\t}\n\trun(g.draw)\n}\n")
 	assert mv_alias == 'drawing'
 }
+
+// Regression tests for the tenth PR-review batch (vlang/v#27557).
+fn test_pr_review_codegen_batch_ten() {
+	v3_bin := build_v3()
+	// Const fixed-array lengths may use shifts and bitwise operators, in both the string
+	// evaluator (recovered length text) and the AST const evaluator (`const n = 1 << 2`).
+	// `1 << 2`=4, `8 >> 1`=4, `3 | 4`=7, `0xF & 6`=6, `(1 << 3) + 2`=10, `16 >> 2 << 1`=8.
+	shifts := run_good(v3_bin, 'good_shift_bitwise_fixed_array_len',
+		'const shift_amt = 1 << 2\nconst my_mask = 0xF & 6\nfn main() {\n\ta := [1 << 2]int{}\n\tb := [shift_amt]int{}\n\tc := [8 >> 1]int{}\n\td := [3 | 4]int{}\n\te := [my_mask]int{}\n\tf := [(1 << 3) + 2]int{}\n\tg := [16 >> 2 << 1]int{}\n\tprintln(int_str(a.len + b.len + c.len + d.len + e.len + f.len + g.len))\n}\n')
+	// 4 + 4 + 4 + 7 + 6 + 10 + 8 = 43
+	assert shifts == '43'
+	// The fixed-array literal length guard evaluates a shift length: `[1, 2]` (two
+	// elements) does not match an expected `[1 << 2]int` (four), so it is rejected.
+	run_bad(v3_bin, 'bad_shift_fixed_array_literal_len',
+		'fn take(a [1 << 2]int) int {\n\treturn a[0]\n}\nfn main() {\n\t_ := take([1, 2]!)\n}\n',
+		'cannot use')
+	// A function returning a fixed array of structs gets a C return wrapper (emitted after
+	// the struct is defined), so it compiles and round-trips instead of emitting a raw
+	// `Array_fixed_Foo_2` return type C rejects.
+	fa_struct := run_good(v3_bin, 'good_fixed_array_struct_return',
+		'struct Foo {\n\tx int\n}\nfn make() [2]Foo {\n\treturn [Foo{\n\t\tx: 1\n\t}, Foo{\n\t\tx: 2\n\t}]!\n}\nfn main() {\n\tr := make()\n\tprintln(int_str(r[0].x + r[1].x))\n}\n')
+	assert fa_struct == '3'
+	// Likewise a fixed array of `string` returns through a wrapper.
+	fa_string := run_good(v3_bin, 'good_fixed_array_string_return',
+		"fn make() [2]string {\n\treturn ['hi', 'yo']!\n}\nfn main() {\n\tr := make()\n\tprintln(r[0] + r[1])\n}\n")
+	assert fa_string == 'hiyo'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -526,3 +526,28 @@ fn test_pr_review_codegen_batch_six() {
 		'fn make() [2][3]int {\n\tmut m := [2][3]int{}\n\tm[0][0] = 1\n\tm[0][1] = 2\n\tm[0][2] = 3\n\tm[1][0] = 4\n\tm[1][1] = 5\n\tm[1][2] = 6\n\treturn m\n}\nfn main() {\n\tr := make()\n\tprintln(int_str(r[0][0] + r[0][1] + r[0][2] + r[1][0] + r[1][1] + r[1][2]))\n}\n')
 	assert nested_ret == '21'
 }
+
+// Regression tests for the seventh PR-review batch (vlang/v#27557).
+fn test_pr_review_codegen_batch_seven() {
+	v3_bin := build_v3()
+	// A parenthesized const fixed-array length must fold by ignoring operators inside the
+	// parentheses: `2 * (segs + 1)` is 10 (not split at the inner `+`), `(segs + 2) / 2`
+	// is 5, so the array dimensions are real numbers, not mangled raw text.
+	paren := run_good(v3_bin, 'good_paren_const_fixed_array_len',
+		'const segs = 4\nfn main() {\n\ta := [2 * (segs + 1)]int{}\n\tb := [(segs + 2) / 2]int{}\n\tprintln(int_str(a.len + b.len))\n}\n')
+	// 10 + 3 = 13
+	assert paren == '13'
+	// A generic method whose signature mentions the receiver type (`Box[T].clone() Box[T]`)
+	// must resolve, on `Box[int]`, to the concrete `Box[int]` return (not the bare `Box`
+	// the collapsed open signature would yield), so the caller types and codegens correctly.
+	clone := run_good(v3_bin, 'good_generic_method_returns_receiver',
+		'struct Box[T] {\n\tv T\n}\nfn (b Box[T]) clone() Box[T] {\n\treturn Box[T]{\n\t\tv: b.v\n\t}\n}\nfn (b Box[T]) get() T {\n\treturn b.v\n}\nfn main() {\n\tb := Box[int]{\n\t\tv: 9\n\t}\n\tc := b.clone()\n\tprintln(int_str(c.get()))\n}\n')
+	assert clone == '9'
+	// An operator overload on a generic struct is specialized only for instances whose
+	// operator is actually used: `Box[NoPlus]` is merely stored (its `+` is never applied),
+	// so the unused `Box_NoPlus__plus` body — which would do `NoPlus + NoPlus` — is not
+	// emitted, while `Box[int] + Box[int]` is.
+	op_gate := run_good(v3_bin, 'good_operator_specialization_gated',
+		"struct Box[T] {\n\tv T\n}\nfn (a Box[T]) + (b Box[T]) Box[T] {\n\treturn Box[T]{\n\t\tv: a.v + b.v\n\t}\n}\nstruct NoPlus {\n\tname string\n}\nfn main() {\n\tx := Box[int]{\n\t\tv: 1\n\t}\n\ty := Box[int]{\n\t\tv: 2\n\t}\n\tz := x + y\n\tprintln(int_str(z.v))\n\tw := Box[NoPlus]{\n\t\tv: NoPlus{\n\t\t\tname: 'hi'\n\t\t}\n\t}\n\tprintln(w.v.name)\n}\n")
+	assert op_gate == '3\nhi'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -600,3 +600,25 @@ fn test_pr_review_codegen_batch_ten() {
 		"fn make() [2]string {\n\treturn ['hi', 'yo']!\n}\nfn main() {\n\tr := make()\n\tprintln(r[0] + r[1])\n}\n")
 	assert fa_string == 'hiyo'
 }
+
+// Regression tests for the eleventh PR-review batch (vlang/v#27557).
+fn test_pr_review_codegen_batch_eleven() {
+	v3_bin := build_v3()
+	// A method value is backed by a per-evaluation-site static receiver, so storing it in
+	// an array (where several instances from one site would share that slot and every
+	// callback would use the last receiver) is rejected with a clear error instead of
+	// reaching cgen and emitting an undefined helper. Append form:
+	run_bad(v3_bin, 'bad_method_value_array_append',
+		'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nfn main() {\n\tmut cbs := []fn () int{}\n\tfor i in 0 .. 3 {\n\t\tc := Counter{\n\t\t\tid: i * 10\n\t\t}\n\t\tcbs << c.report\n\t}\n\tprintln(int_str(cbs.len))\n}\n',
+		'cannot be stored in an array')
+	// Array-literal form is rejected too.
+	run_bad(v3_bin, 'bad_method_value_array_literal',
+		'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nfn main() {\n\ta := Counter{\n\t\tid: 1\n\t}\n\tb := Counter{\n\t\tid: 2\n\t}\n\tcbs := [a.report, b.report]\n\tprintln(int_str(cbs.len))\n}\n',
+		'cannot be stored in an array')
+	// The supported single-use forms still work: a method value passed directly as a
+	// callback argument, and an `arr << int` append / `int << int` shift are not flagged.
+	imm := run_good(v3_bin, 'good_method_value_immediate_after_guard',
+		'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nfn run(cb fn () int) int {\n\treturn cb()\n}\nfn main() {\n\tc := Counter{\n\t\tid: 7\n\t}\n\tmut xs := [1]\n\txs << (2 << 1)\n\tprintln(int_str(run(c.report) + xs.len))\n}\n')
+	// 7 + 2 (xs has [1, 4]) = 9
+	assert imm == '9'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -842,3 +842,28 @@ fn test_pr_review_codegen_batch_twentyone() {
 		'struct Foo {\nmut:\n\tn int\n}\nfn (f &Foo) tick() int {\n\treturn f.n\n}\nfn run(cb fn () int) int {\n\treturn cb()\n}\nfn main() {\n\tprintln(int_str(run(Foo{\n\t\tn: 5\n\t}.tick)))\n}\n')
 	assert mv_rvalue == '5'
 }
+
+fn test_pr_review_codegen_batch_twentytwo() {
+	v3_bin := build_v3()
+	// A bare generic literal retargeted to a concrete instance must run the fixed-array-field
+	// detection against that concrete key (the bare `Box` field table is dropped by
+	// monomorphization), so a `[N]T` field is filled by memcpy instead of the invalid C
+	// `(Box_int){.data = a}` (a C array member cannot be initialized from another array object).
+	fa := run_good(v3_bin, 'good_concrete_generic_fixed_array_field',
+		'struct Box[T] {\n\tdata [2]T\n}\nfn f(a [2]int) Box[int] {\n\treturn Box{\n\t\tdata: a\n\t}\n}\nfn main() {\n\tarr := [10, 20]!\n\tb := f(arr)\n\tprintln(int_str(b.data[0] + b.data[1]))\n}\n')
+	assert fa == '30'
+	// A generic method value used only in an unreachable function must not drive a concrete
+	// specialization: `Box[Pair].doubled` (here `Pair + Pair`) would emit an invalid body and
+	// fail C compilation. Only the reachable `Box[int].doubled` is specialized.
+	dead := run_good(v3_bin, 'good_dead_generic_method_value_not_specialized',
+		'struct Box[T] {\n\tv T\n}\nfn (b Box[T]) doubled() T {\n\treturn b.v + b.v\n}\nstruct Pair {\n\ta int\n}\nfn run_int(cb fn () int) int {\n\treturn cb()\n}\nfn run_pair(cb fn () Pair) Pair {\n\treturn cb()\n}\nfn dead_fn() {\n\tp := Box[Pair]{\n\t\tv: Pair{\n\t\t\ta: 1\n\t\t}\n\t}\n\t_ := run_pair(p.doubled)\n}\nfn main() {\n\tb := Box[int]{\n\t\tv: 5\n\t}\n\tprintln(int_str(run_int(b.doubled)))\n}\n')
+	assert dead == '10'
+	// A reachable generic method value of any instance still specializes correctly.
+	live := run_good(v3_bin, 'good_reachable_generic_method_value_specialized',
+		'struct Box[T] {\n\tv T\n}\nfn (b Box[T]) first() T {\n\treturn b.v\n}\nstruct Pair {\n\ta int\n}\nfn run_pair(cb fn () Pair) Pair {\n\treturn cb()\n}\nfn main() {\n\tp := Box[Pair]{\n\t\tv: Pair{\n\t\t\ta: 7\n\t\t}\n\t}\n\tr := run_pair(p.first)\n\tprintln(int_str(r.a))\n}\n')
+	assert live == '7'
+	// Discarding a method value with `_ =` stores nothing, so it is not an escape.
+	blank := run_good(v3_bin, 'good_method_value_blank_discard',
+		'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nfn main() {\n\tc := Counter{\n\t\tid: 5\n\t}\n\tcb := c.report\n\t_ = cb\n\tprintln(int_str(c.report()))\n}\n')
+	assert blank == '5'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -479,3 +479,26 @@ fn test_pr_review_codegen_batch_four() {
 		'type Cb = fn () int\nfn run(cb Cb) int {\n\treturn cb()\n}\nfn five() int {\n\treturn 5\n}\nfn main() {\n\tprintln(int_str(run(five)))\n}\n')
 	assert alias_cb == '5'
 }
+
+// Regression tests for the fifth PR-review batch (vlang/v#27557).
+fn test_pr_review_codegen_batch_five() {
+	v3_bin := build_v3()
+	// A const-expression fixed-array length using `/` and `%` (and mixed precedence)
+	// must fold to the right literal, not mangle the raw expression into an identifier:
+	// `segs / 2` = 4, `segs % 3` = 2, `segs * 2 + 1` = 17, `segs / 2 * 2` = 8.
+	divmod := run_good(v3_bin, 'good_const_expr_fixed_array_divmod',
+		'const segs = 8\nstruct Buf {\n\ta [segs / 2]u8\n\tb [segs % 3]u8\n\tc [segs * 2 + 1]u8\n\td [segs / 2 * 2]u8\n}\nfn main() {\n\tx := Buf{}\n\tprintln(int_str(x.a.len + x.b.len + x.c.len + x.d.len))\n}\n')
+	// 4 + 2 + 17 + 8 = 31
+	assert divmod == '31'
+	// A bare `[]thread` (threads with no return value) joins to `void`: `.wait()` is a
+	// valid statement that runs every spawned thread to completion.
+	void_wait := run_good(v3_bin, 'good_bare_thread_void_wait',
+		"fn work() {\n\tprintln('w')\n}\nfn main() {\n\tmut threads := []thread{}\n\tthreads << spawn work()\n\tthreads << spawn work()\n\tthreads.wait()\n\tprintln('done')\n}\n")
+	assert void_wait.contains('done')
+	// Because a bare `[]thread`.wait() is `void` (not the receiver `[]thread`), its
+	// result cannot be bound to a variable — guards against the old fallback that typed
+	// the call as the receiver array.
+	run_bad(v3_bin, 'bad_bare_thread_void_wait_assign',
+		"fn work() {\n\tprintln('w')\n}\nfn main() {\n\tmut threads := []thread{}\n\tthreads << spawn work()\n\tx := threads.wait()\n\tprintln(x)\n}\n",
+		'unknown identifier `x`')
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -459,3 +459,23 @@ fn test_bare_generic_literal_adopts_expected_instance() {
 		"struct Box[T] {\n\tv T\n}\nfn make() Box[int] {\n\treturn Box{\n\t\tv: 'str'\n\t}\n}\nfn main() {\n\t_ := make()\n}\n",
 		'cannot return `Box` as `Box[int]`')
 }
+
+// Regression tests for the fourth PR-review batch (vlang/v#27557).
+fn test_pr_review_codegen_batch_four() {
+	v3_bin := build_v3()
+	// A `&Box{...}` value must not be accepted where a `Box[int]` value is expected
+	// (pointer shape must match in the generic-base relaxation).
+	run_bad(v3_bin, 'bad_generic_pointer_shape_arg',
+		'struct Box[T] {\n\tv T\n}\nfn take(b Box[int]) int {\n\treturn b.v\n}\nfn main() {\n\t_ := take(&Box{\n\t\tv: 1\n\t})\n}\n',
+		'cannot use')
+	// A method value on a concrete generic receiver resolves the open `Box[T].get`,
+	// types the value, and codegen materialises the `Box_int__get` wrapper.
+	mval := run_good(v3_bin, 'good_generic_receiver_method_value',
+		'struct Box[T] {\n\tv T\n}\nfn (b Box[T]) get() T {\n\treturn b.v\n}\nfn run(cb fn () int) int {\n\treturn cb()\n}\nfn main() {\n\tb := Box[int]{\n\t\tv: 7\n\t}\n\tprintln(int_str(run(b.get)))\n}\n')
+	assert mval == '7'
+	// A V function passed to a parameter whose type is a `fn`-type *alias* keeps the
+	// function pointer (not `(void*)`).
+	alias_cb := run_good(v3_bin, 'good_fn_type_alias_callback',
+		'type Cb = fn () int\nfn run(cb Cb) int {\n\treturn cb()\n}\nfn five() int {\n\treturn 5\n}\nfn main() {\n\tprintln(int_str(run(five)))\n}\n')
+	assert alias_cb == '5'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -931,3 +931,21 @@ fn test_const_length_fixed_array() {
 		"const segs = 2\nfn f() [segs + 1]int {\n\tmut r := [segs + 1]int{}\n\tr[0] = 5\n\tr[1] = 6\n\tr[2] = 7\n\treturn r\n}\nfn main() {\n\ta := f()\n\tmut sum := 0\n\tfor x in a {\n\t\tsum += x\n\t}\n\tprintln(int_str(a.len) + ',' + int_str(a[1]) + ',' + int_str(sum))\n}\n")
 	assert expr == '3,6,18'
 }
+
+fn test_pr_review_codegen_batch_twentyfive() {
+	v3_bin := build_v3()
+	// An interface-returning function with a pending `defer` saves its return value into a temp
+	// before running the defers. That temp must hold the boxed interface value (`_typ`/`_object`),
+	// not a zeroed `(Iface){0}`; otherwise the later dynamic dispatch panics. The boxing must match
+	// the direct (defer-free) return path.
+	defer_iface := run_good(v3_bin, 'good_interface_return_with_defer',
+		'interface Speaker {\n\tspeak() int\n}\nstruct Dog {\n\tvolume int\n}\nfn (d Dog) speak() int {\n\treturn d.volume\n}\nfn make() Speaker {\n\tdefer {\n\t\t_ := 0\n\t}\n\treturn Dog{\n\t\tvolume: 42\n\t}\n}\nfn main() {\n\ts := make()\n\tprintln(int_str(s.speak()))\n}\n')
+	assert defer_iface == '42'
+	// A local whose address escapes (returned via a pointer) is moved to the heap, so the local is
+	// now a `&T`. Its compound (`v += 1`) and postfix (`v++`) mutations must store through the
+	// pointer (`*v += 1`, `(*v)++`), not perform pointer arithmetic; the returned pointer reflects
+	// the mutated value.
+	heap_compound := run_good(v3_bin, 'good_heaped_local_compound_mutation',
+		"fn compound() int {\n\tmut v := 1\n\tp := &v\n\tv += 1\n\treturn *p\n}\nfn postfix() int {\n\tmut v := 5\n\tp := &v\n\tv++\n\tv++\n\treturn *p\n}\nfn main() {\n\tprintln(int_str(compound()) + ',' + int_str(postfix()))\n}\n")
+	assert heap_compound == '2,7'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -949,3 +949,27 @@ fn test_pr_review_codegen_batch_twentyfive() {
 		"fn compound() int {\n\tmut v := 1\n\tp := &v\n\tv += 1\n\treturn *p\n}\nfn postfix() int {\n\tmut v := 5\n\tp := &v\n\tv++\n\tv++\n\treturn *p\n}\nfn main() {\n\tprintln(int_str(compound()) + ',' + int_str(postfix()))\n}\n")
 	assert heap_compound == '2,7'
 }
+
+fn test_pr_review_codegen_batch_twentysix() {
+	v3_bin := build_v3()
+	// The escape prepass must only heap-move a local whose address is *actually returned*. A
+	// pointer that merely appears in a consuming expression (comparison/boolean here, or a deref)
+	// does not escape, so its source local must stay a plain value — otherwise codegen reads it as
+	// an `int*` in the integer comparison and the result is wrong. `return p == p && v == 1` and
+	// `return *p` both keep `v` on the stack.
+	no_escape := run_good(v3_bin, 'good_escape_only_returned_pointer',
+		"fn check() bool {\n\tmut v := 1\n\tp := &v\n\treturn p == p && v == 1\n}\nfn deref() int {\n\tmut v := 3\n\tp := &v\n\tv = 8\n\treturn *p\n}\nfn main() {\n\tprintln(check().str() + ',' + int_str(deref()))\n}\n")
+	assert no_escape == 'true,8'
+	// A pointer that *is* returned (directly, and inside a returned aggregate) must still heap-move
+	// its source local, so the returned pointer observes mutations made after the address was taken.
+	escapes := run_good(v3_bin, 'good_escape_returned_pointer_and_aggregate',
+		"fn direct() &int {\n\tmut v := 10\n\tp := &v\n\tv += 5\n\treturn p\n}\nfn aggregate() []&int {\n\tmut v := 7\n\tp := &v\n\tv = 9\n\treturn [p]\n}\nfn main() {\n\tarr := aggregate()\n\tprintln(int_str(*direct()) + ',' + int_str(*arr[0]))\n}\n")
+	assert escapes == '15,9'
+	// An optional fixed-array return (`?[N]T`) with a pending `defer` routes through the deferred
+	// return path; that path must apply the same temp + memcpy handling as the direct path (the
+	// `.value` member is a fixed array and cannot be set via a compound literal), so the array value
+	// is preserved instead of being dropped to `{.ok = false}`.
+	defer_opt_arr := run_good(v3_bin, 'good_optional_fixed_array_return_with_defer',
+		"fn f() ?[2]int {\n\tdefer {\n\t\t_ := 0\n\t}\n\treturn [1, 2]!\n}\nfn main() {\n\ta := f() or { [0, 0]! }\n\tprintln(int_str(a[0]) + ',' + int_str(a[1]))\n}\n")
+	assert defer_opt_arr == '1,2'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -913,3 +913,21 @@ fn test_fn_pointer_return_type() {
 		'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nfn plain() int {\n\treturn 7\n}\nfn build_cb(c Counter) fn () int {\n\tmut cb := c.report\n\tcb = plain\n\treturn cb\n}\nfn main() {\n\tf := build_cb(Counter{\n\t\tid: 1\n\t})\n\tprintln(int_str(f()))\n}\n')
 	assert built == '7'
 }
+
+fn test_const_length_fixed_array() {
+	v3_bin := build_v3()
+	// A fixed array whose length is a const round-trips through the checker as the postfix name
+	// `int[seg_count]`. The transform's fixed-array predicate (now const-aware) folds `.len` to the
+	// constant instead of emitting a struct field access on the C array, and parse_type treats the
+	// builtin-base postfix as a fixed array (not a bogus generic), so the decl uses memcpy.
+	direct := run_good(v3_bin, 'good_const_len_fixed_array_call_len',
+		'const seg_count = 3\nfn f() [seg_count]int {\n\tmut r := [seg_count]int{}\n\treturn r\n}\nfn main() {\n\tprintln(int_str(f().len))\n}\n')
+	assert direct == '3'
+	decl := run_good(v3_bin, 'good_const_len_fixed_array_decl_len',
+		"const seg_count = 3\nfn f() [seg_count]int {\n\tmut r := [seg_count]int{}\n\tr[0] = 10\n\treturn r\n}\nfn main() {\n\ta := f()\n\tprintln(int_str(a[0]) + ',' + int_str(a.len))\n}\n")
+	assert decl == '10,3'
+	// An expression length (`[segs + 1]int`) likewise folds, iterates, and indexes correctly.
+	expr := run_good(v3_bin, 'good_expr_len_fixed_array',
+		"const segs = 2\nfn f() [segs + 1]int {\n\tmut r := [segs + 1]int{}\n\tr[0] = 5\n\tr[1] = 6\n\tr[2] = 7\n\treturn r\n}\nfn main() {\n\ta := f()\n\tmut sum := 0\n\tfor x in a {\n\t\tsum += x\n\t}\n\tprintln(int_str(a.len) + ',' + int_str(a[1]) + ',' + int_str(sum))\n}\n")
+	assert expr == '3,6,18'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -622,3 +622,24 @@ fn test_pr_review_codegen_batch_eleven() {
 	// 7 + 2 (xs has [1, 4]) = 9
 	assert imm == '9'
 }
+
+// Regression tests for the twelfth PR-review batch (vlang/v#27557).
+fn test_pr_review_codegen_batch_twelve() {
+	v3_bin := build_v3()
+	// A heap struct literal with POSITIONAL fields must emit positional C values, not a
+	// `. = v` designator. For a *generic* heap literal the fields live under the concrete
+	// instance key (`Box[int]`), so the per-index field lookup must use that, not the bare
+	// `Box`; otherwise `arr << &Box[int]{1, 2}` generates invalid C like `(Box_int){. = 1}`.
+	gpos := run_good(v3_bin, 'good_positional_generic_heap_struct',
+		'struct Box[T] {\n\ta T\n\tb T\n}\nfn main() {\n\tmut arr := []&Box[int]{}\n\tarr << &Box[int]{1, 2}\n\tprintln(int_str(arr[0].a + arr[0].b))\n}\n')
+	assert gpos == '3'
+	// A positional generic heap literal that omits a default-initialized `[]T` field still
+	// gets that field's default (`array_new(...)`) alongside the positional value.
+	gposdef := run_good(v3_bin, 'good_positional_generic_heap_default',
+		'struct Box[T] {\n\tv     T\n\titems []T\n}\nfn main() {\n\tb := &Box[int]{5}\n\tmut its := b.items\n\tits << 10\n\tprintln(int_str(b.v))\n\tprintln(int_str(its.len))\n}\n')
+	assert gposdef == '5\n1'
+	// Non-generic positional heap literals keep working (no regression).
+	pos := run_good(v3_bin, 'good_positional_heap_struct',
+		'struct Point {\n\tx int\n\ty int\n}\nfn main() {\n\tmut arr := []&Point{}\n\tarr << &Point{1, 2}\n\tprintln(int_str(arr[0].x + arr[0].y))\n}\n')
+	assert pos == '3'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -895,3 +895,21 @@ fn test_pr_review_codegen_batch_twentythree() {
 		'fn build_cb(c Counter) int {\n\tmut cb := c.report\n\tcb = plain\n\treturn cb()\n}\nfn main() {\n\tprintln(int_str(build_cb(Counter{\n\t\tid: 1\n\t})))\n}\n')
 	assert uncond == '0'
 }
+
+fn test_fn_pointer_return_type() {
+	v3_bin := build_v3()
+	// A function whose return type is itself a function pointer (`fn () fn (int) int`) must be
+	// declared with the shared `_fn_ptr_N` typedef, not the internal `fn_ptr:...` encoding (which
+	// would emit invalid C). Covers a plain fn return and a method returning a fn pointer.
+	picker := run_good(v3_bin, 'good_fn_pointer_return',
+		'fn add_one(x int) int {\n\treturn x + 1\n}\nfn picker() fn (int) int {\n\treturn add_one\n}\nfn main() {\n\tf := picker()\n\tprintln(int_str(f(41)))\n}\n')
+	assert picker == '42'
+	method_ret := run_good(v3_bin, 'good_method_fn_pointer_return',
+		'struct Calc {\n\tbase int\n}\nfn dbl(x int) int {\n\treturn x * 2\n}\nfn (c Calc) op() fn (int) int {\n\treturn dbl\n}\nfn main() {\n\tc := Calc{\n\t\tbase: 5\n\t}\n\tf := c.op()\n\tprintln(int_str(f(21)))\n}\n')
+	assert method_ret == '42'
+	// A function returning a callback assembled from a reassigned method-value local compiles and
+	// returns the (plain) callback through the fn-pointer return type.
+	built := run_good(v3_bin, 'good_fn_pointer_return_reassigned_method_value',
+		'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nfn plain() int {\n\treturn 7\n}\nfn build_cb(c Counter) fn () int {\n\tmut cb := c.report\n\tcb = plain\n\treturn cb\n}\nfn main() {\n\tf := build_cb(Counter{\n\t\tid: 1\n\t})\n\tprintln(int_str(f()))\n}\n')
+	assert built == '7'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -643,3 +643,21 @@ fn test_pr_review_codegen_batch_twelve() {
 		'struct Point {\n\tx int\n\ty int\n}\nfn main() {\n\tmut arr := []&Point{}\n\tarr << &Point{1, 2}\n\tprintln(int_str(arr[0].x + arr[0].y))\n}\n')
 	assert pos == '3'
 }
+
+// Regression tests for the thirteenth PR-review batch (vlang/v#27557).
+fn test_pr_review_codegen_batch_thirteen() {
+	v3_bin := build_v3()
+	// V's unsigned right shift `>>>` is a valid constant-length operator. It must fold in
+	// the const evaluator (so the array dimension is emitted as a numeric literal, since
+	// `>>>` has no C form) and in the literal-length guard. `8 >>> 1` = 4, `16 >>> 2` = 4,
+	// `(1 << 5) >>> 2` = 8.
+	ushift := run_good(v3_bin, 'good_unsigned_shift_fixed_array_len',
+		'const shamt = 16 >>> 2\nfn main() {\n\ta := [8 >>> 1]int{}\n\tb := [shamt]int{}\n\tc := [(1 << 5) >>> 2]int{}\n\tprintln(int_str(a.len + b.len + c.len))\n}\n')
+	// 4 + 4 + 8 = 16
+	assert ushift == '16'
+	// The fixed-array literal-length guard evaluates `>>>` too: `[1, 2]` (two elements)
+	// does not match an expected `[8 >>> 1]int` (four), so it is rejected.
+	run_bad(v3_bin, 'bad_unsigned_shift_fixed_array_literal_len',
+		'fn take(a [8 >>> 1]int) int {\n\treturn a[0]\n}\nfn main() {\n\t_ := take([1, 2]!)\n}\n',
+		'cannot use')
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -720,3 +720,16 @@ fn test_pr_review_codegen_batch_fifteen() {
 		'struct P {\n\tx int\n}\ntype MakeP = fn () [2]P\nfn mkp() [2]P {\n\treturn [P{\n\t\tx: 3\n\t}, P{\n\t\tx: 4\n\t}]!\n}\nfn runp(f MakeP) int {\n\tr := f()\n\treturn r[0].x + r[1].x\n}\nfn main() {\n\tprintln(int_str(runp(mkp)))\n}\n')
 	assert fp_struct == '7'
 }
+
+fn test_pr_review_codegen_batch_sixteen() {
+	v3_bin := build_v3()
+	// A bare generic struct literal (`Box{..}`) inside an array literal whose expected type is
+	// a concrete generic instance (`[]Box[int]`) must carry that concrete element type into the
+	// array storage AND each element: the array literal emitter passes the element type as the
+	// expected type per element so the element is emitted as `Box_int`, not the open `Box` (which
+	// has no C type), and the storage and element agree. Covers the reviewer's return example plus
+	// the argument and struct-field positions.
+	out := run_good(v3_bin, 'good_generic_struct_array_literal_positions',
+		"struct Box[T] {\n\tv T\n}\nfn first(a []Box[int]) int {\n\treturn a[0].v\n}\nstruct Holder {\n\titems []Box[int]\n}\nfn make() []Box[int] {\n\treturn [Box{\n\t\tv: 1\n\t}, Box{\n\t\tv: 2\n\t}]\n}\nfn main() {\n\tr := make()\n\ta := first([Box{\n\t\tv: 3\n\t}, Box{\n\t\tv: 4\n\t}])\n\th := Holder{\n\t\titems: [Box{\n\t\t\tv: 5\n\t\t}]\n\t}\n\tprintln(int_str(r[0].v + r[1].v) + ',' + int_str(a) + ',' + int_str(h.items[0].v))\n}\n")
+	assert out == '3,3,5'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -423,3 +423,19 @@ fn test_pr_review_codegen_batch_two() {
 		"struct S {\n\tn int\n}\nfn (s S) run(cb fn ()) {\n\tcb()\n}\nfn greet() {\n\tprintln('hi')\n}\nfn main() {\n\ts := S{\n\t\tn: 1\n\t}\n\ts.run(greet)\n}\n")
 	assert cb == 'hi'
 }
+
+// Regression tests for the third PR-review batch (vlang/v#27557).
+fn test_pr_review_codegen_batch_three() {
+	v3_bin := build_v3()
+	// A `[flag]` enum match that lists only single-field branches is NOT exhaustive
+	// (combined/zero values fall through), so a non-void fn needs `else`/missing-return.
+	run_bad(v3_bin, 'bad_flag_enum_match_not_exhaustive',
+		'@[flag]\nenum Perm {\n\tread\n\twrite\n}\nfn f(p Perm) int {\n\tmatch p {\n\t\t.read { return 1 }\n\t\t.write { return 2 }\n\t}\n}\nfn main() {\n\tprintln(int_str(f(Perm.read)))\n}\n',
+		'missing return')
+	// A bound method value returning an option, passed to a V `fn () ?string`
+	// parameter, must emit a wrapper with the `Optional_string` ABI return and a
+	// function-pointer (not `(void*)`) cast.
+	mv := run_good(v3_bin, 'good_method_value_option_return',
+		"struct G {\n\tn int\n}\nfn (g G) make() ?string {\n\treturn 'hi'\n}\nfn run(cb fn () ?string) {\n\ts := cb() or { 'none' }\n\tprintln(s)\n}\nfn main() {\n\tg := G{\n\t\tn: 1\n\t}\n\trun(g.make)\n}\n")
+	assert mv == 'hi'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -817,3 +817,28 @@ fn test_pr_review_codegen_batch_twenty() {
 		'fn invoke(cb fn () int) int {\n\treturn cb()\n}\nfn main() {\n\tc := Counter{\n\t\tid: 7\n\t}\n\tmut cb := c.report\n\tcb = c.report\n\tprintln(int_str(invoke(cb)))\n}\n')
 	assert ok == '7'
 }
+
+fn test_pr_review_codegen_batch_twentyone() {
+	v3_bin := build_v3()
+	// An escaping pointer returned through a copy (`p := &v; q := p; return q`) must still move
+	// `v` to the heap, so a mutation after the alias is seen by the caller (not a dangling stack
+	// pointer). The pointer-alias chain is followed when deciding what escapes.
+	alias := run_good(v3_bin, 'good_returned_pointer_alias_heap',
+		'struct Box {\nmut:\n\tx int\n}\nfn make() &Box {\n\tmut v := Box{\n\t\tx: 1\n\t}\n\tp := &v\n\tq := p\n\tv.x = 2\n\treturn q\n}\nfn main() {\n\tb := make()\n\tprintln(int_str(b.x))\n}\n')
+	assert alias == '2'
+	// An interface method returning a fixed array gets its dispatch stub declared with the
+	// `_v_ret_*` wrapper, not a bare `Array_fixed_*` (a C function cannot return an array). This
+	// holds both when only the concrete implementer is called and through a real interface call.
+	iface_concrete := run_good(v3_bin, 'good_iface_fixed_array_concrete_only',
+		'interface I {\n\tmake() [3]int\n}\nstruct S {}\nfn (s S) make() [3]int {\n\treturn [1, 2, 3]!\n}\nfn main() {\n\ts := S{}\n\ta := s.make()\n\tprintln(int_str(a[0] + a[1] + a[2]))\n}\n')
+	assert iface_concrete == '6'
+	iface_dispatch := run_good(v3_bin, 'good_iface_fixed_array_dispatch',
+		'interface I {\n\tmake() [3]int\n}\nstruct S {}\nfn (s S) make() [3]int {\n\treturn [4, 5, 6]!\n}\nfn use_iface(i I) int {\n\ta := i.make()\n\treturn a[0] + a[1] + a[2]\n}\nfn main() {\n\ts := S{}\n\tprintln(int_str(use_iface(s)))\n}\n')
+	assert iface_dispatch == '15'
+	// A pointer-receiver method value taken on an rvalue base (`Foo{..}.tick`) copies the receiver
+	// into durable static storage instead of capturing `&(temporary)` that dies before the
+	// callback runs.
+	mv_rvalue := run_good(v3_bin, 'good_ptr_receiver_method_value_rvalue',
+		'struct Foo {\nmut:\n\tn int\n}\nfn (f &Foo) tick() int {\n\treturn f.n\n}\nfn run(cb fn () int) int {\n\treturn cb()\n}\nfn main() {\n\tprintln(int_str(run(Foo{\n\t\tn: 5\n\t}.tick)))\n}\n')
+	assert mv_rvalue == '5'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -307,3 +307,26 @@ fn test_type_checker_reports_core_semantic_errors() {
 	assert !cross_module_array_append_c.contains('array_push_many(&xs')
 	assert cross_module_array_append_c.contains('array_push(&xs')
 }
+
+// Regression tests for the post-PR review fixes: fixed-array literals must match
+// the expected fixed length, and genuine fixed-array if-branches of different
+// lengths must mismatch — while bare array literals stay length-agnostic.
+fn test_fixed_array_length_checks() {
+	v3_bin := build_v3()
+	// A literal passed where a fixed array is expected must have the exact length.
+	run_bad(v3_bin, 'bad_fixed_array_arg_len',
+		'fn take4(a [4]int) int {\n\treturn a[0]\n}\nfn main() {\n\t_ := take4([1, 2])\n}\n',
+		'expected `int[4]`')
+	// Genuine fixed arrays of different lengths in if-branches must mismatch.
+	run_bad(v3_bin, 'bad_if_branch_fixed_array_len',
+		'fn main() {\n\ta := [2]int{}\n\tb := [3]int{}\n\tc := true\n\t_ := if c { a } else { b }\n}\n',
+		'if-expression branch type mismatch')
+	// Correct fixed-array length is accepted and round-trips.
+	good4 := run_good(v3_bin, 'good_fixed_array_arg_len',
+		'fn take4(a [4]int) int {\n\treturn a[0] + a[1] + a[2] + a[3]\n}\nfn main() {\n\tprintln(int_str(take4([10, 20, 30, 40])))\n}\n')
+	assert good4 == '100'
+	// Bare array literals are dynamic `[]T`, so different-length branches are fine.
+	good_lit := run_good(v3_bin, 'good_if_branch_array_literal_len',
+		'fn main() {\n\tc := true\n\tx := if c { [1, 2, 3] } else { [4, 5] }\n\tprintln(int_str(x.len))\n}\n')
+	assert good_lit == '3'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -502,3 +502,27 @@ fn test_pr_review_codegen_batch_five() {
 		"fn work() {\n\tprintln('w')\n}\nfn main() {\n\tmut threads := []thread{}\n\tthreads << spawn work()\n\tx := threads.wait()\n\tprintln(x)\n}\n",
 		'unknown identifier `x`')
 }
+
+// Regression tests for the sixth PR-review batch (vlang/v#27557).
+fn test_pr_review_codegen_batch_six() {
+	v3_bin := build_v3()
+	// A bare generic struct literal with POSITIONAL fields (`Box{'str'}`) must validate
+	// each value against the struct field order before adopting the expected concrete
+	// instance; a wrong positional type is a definite mismatch, not a silent adoption
+	// that codegen would init an `int` field from a string.
+	run_bad(v3_bin, 'bad_positional_generic_literal_field_mismatch',
+		"struct Box[T] {\n\tv T\n}\nfn make() Box[int] {\n\treturn Box{'str'}\n}\nfn main() {\n\t_ := make()\n}\n",
+		'cannot return `Box` as `Box[int]`')
+	// A positional bare generic literal whose value matches the concrete field type is
+	// accepted and round-trips.
+	pos_good := run_good(v3_bin, 'good_positional_generic_literal',
+		'struct Box[T] {\n\tv T\n}\nfn make() Box[int] {\n\treturn Box{5}\n}\nfn main() {\n\tprintln(int_str(make().v))\n}\n')
+	assert pos_good == '5'
+	// A function returning a nested fixed array (`[2][3]int`, whose element is itself a
+	// fixed array) must get a C return wrapper (functions cannot return raw arrays) and
+	// the caller must type the result as the full nested array (`int[3][2]` round-trips
+	// through parse_type), so the values survive the wrapper memcpy.
+	nested_ret := run_good(v3_bin, 'good_nested_fixed_array_return',
+		'fn make() [2][3]int {\n\tmut m := [2][3]int{}\n\tm[0][0] = 1\n\tm[0][1] = 2\n\tm[0][2] = 3\n\tm[1][0] = 4\n\tm[1][1] = 5\n\tm[1][2] = 6\n\treturn m\n}\nfn main() {\n\tr := make()\n\tprintln(int_str(r[0][0] + r[0][1] + r[0][2] + r[1][0] + r[1][1] + r[1][2]))\n}\n')
+	assert nested_ret == '21'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -551,3 +551,25 @@ fn test_pr_review_codegen_batch_seven() {
 		"struct Box[T] {\n\tv T\n}\nfn (a Box[T]) + (b Box[T]) Box[T] {\n\treturn Box[T]{\n\t\tv: a.v + b.v\n\t}\n}\nstruct NoPlus {\n\tname string\n}\nfn main() {\n\tx := Box[int]{\n\t\tv: 1\n\t}\n\ty := Box[int]{\n\t\tv: 2\n\t}\n\tz := x + y\n\tprintln(int_str(z.v))\n\tw := Box[NoPlus]{\n\t\tv: NoPlus{\n\t\t\tname: 'hi'\n\t\t}\n\t}\n\tprintln(w.v.name)\n}\n")
 	assert op_gate == '3\nhi'
 }
+
+// Regression tests for the eighth PR-review batch (vlang/v#27557).
+fn test_pr_review_codegen_batch_eight() {
+	v3_bin := build_v3()
+	// A bare *value* generic literal must not adopt a *pointer* expectation: `&Box[int]`
+	// expected from a plain `Box{...}` is a definite mismatch (cgen would emit a `Box_int`
+	// value where a `Box_int*` is required), so it is rejected rather than silently typed
+	// as `&Box[int]`.
+	run_bad(v3_bin, 'bad_value_literal_pointer_expectation',
+		'struct Box[T] {\n\tv T\n}\nfn make() &Box[int] {\n\treturn Box{\n\t\tv: 1\n\t}\n}\nfn main() {\n\t_ := make()\n}\n',
+		'cannot return `Box` as `&Box[int]`')
+	// The pointer form `&Box{...}` still adopts the `&Box[int]` expectation and round-trips.
+	heap := run_good(v3_bin, 'good_amp_generic_literal_pointer',
+		'struct Box[T] {\n\tv T\n}\nfn make() &Box[int] {\n\treturn &Box{\n\t\tv: 7\n\t}\n}\nfn main() {\n\tprintln(int_str(make().v))\n}\n')
+	assert heap == '7'
+	// A method value passed through a function-type *alias* parameter (`type Cb = fn ()`)
+	// must be cast to the generated `_fn_ptr_*` typedef, not `(void*)` (which strict C
+	// rejects for a function pointer). `fn_type_from` unwraps the alias.
+	mv_alias := run_good(v3_bin, 'good_method_value_fn_alias',
+		"struct Game {\n\tscore int\n}\nfn (g Game) draw() {\n\tprintln('drawing')\n}\ntype Cb = fn ()\nfn run(cb Cb) {\n\tcb()\n}\nfn main() {\n\tg := Game{\n\t\tscore: 5\n\t}\n\trun(g.draw)\n}\n")
+	assert mv_alias == 'drawing'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -395,3 +395,31 @@ fn test_const_expr_fixed_array_field_and_spacing() {
 		'const segs = 3\nconst mult = 2\nfn main() {\n\ta := [segs + 1]int{}\n\tb := [segs+1]int{}\n\tc := [segs * mult]int{}\n\td := [segs - 1]int{}\n\te := [segs * mult + 1]int{}\n\tprintln(int_str(a.len + b.len + c.len + d.len + e.len))\n}\n')
 	assert good_forms == '23'
 }
+
+// Regression tests for the second PR-review batch (vlang/v#27557).
+fn test_pr_review_codegen_batch_two() {
+	v3_bin := build_v3()
+	// or-block binds `err` (IError) only inside the or-body; an outer `err` keeps its
+	// type afterwards (was emitted as `err.message` on an int).
+	or_err := run_good(v3_bin, 'good_or_block_err_scope',
+		'fn maybe() ?int {\n\treturn 1\n}\nfn main() {\n\terr := 7\n\t_ := maybe() or { 0 }\n\tprintln(int_str(err))\n}\n')
+	assert or_err == '7'
+	// Generic receiver params are substituted by declared name: `Pair[L, R].right()`
+	// returns `R` (int), not the first arg `L` (string).
+	pair := run_good(v3_bin, 'good_generic_receiver_param_by_name',
+		"struct Pair[L, R] {\n\tleft  L\n\tright R\n}\nfn (p Pair[L, R]) right_val() R {\n\treturn p.right\n}\nfn main() {\n\tp := Pair[string, int]{\n\t\tleft:  'hi'\n\t\tright: 42\n\t}\n\tprintln(int_str(p.right_val()))\n}\n")
+	assert pair == '42'
+	// `[flag]` enum stringification renders combined values as `Enum{.a | .b}`.
+	flag := run_good(v3_bin, 'good_flag_enum_str',
+		'@[flag]\nenum Perm {\n\tread\n\twrite\n\texec\n}\nfn main() {\n\ta := Perm.read | Perm.write\n\tprintln(a.str())\n\tb := Perm.read\n\tprintln(b.str())\n}\n')
+	assert flag == 'Perm{.read | .write}\nPerm{.read}'
+	// spawn of an option-returning fn stores/reads the `Optional_T` ABI layout.
+	spawn_opt := run_good(v3_bin, 'good_spawn_option_return',
+		"fn work() ?string {\n\treturn 'hello'\n}\nfn main() {\n\tmut ts := []thread ?string{}\n\tts << spawn work()\n\trs := ts.wait()\n\tx := rs[0] or { 'none' }\n\tprintln(x)\n}\n")
+	assert spawn_opt == 'hello'
+	// A global V function passed to a method `fn ()` param keeps the function-pointer
+	// typedef (not `(void*)`).
+	cb := run_good(v3_bin, 'good_method_fn_ptr_arg',
+		"struct S {\n\tn int\n}\nfn (s S) run(cb fn ()) {\n\tcb()\n}\nfn greet() {\n\tprintln('hi')\n}\nfn main() {\n\ts := S{\n\t\tn: 1\n\t}\n\ts.run(greet)\n}\n")
+	assert cb == 'hi'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -691,3 +691,32 @@ fn test_pr_review_codegen_batch_fourteen() {
 		'struct Counter {\n\tid int\n}\nfn (c Counter) report() int {\n\treturn c.id\n}\nstruct Engine {\n\tcb fn () int\n}\nfn main() {\n\t_ := Engine{\n\t\tcb: Counter{\n\t\t\tid: 1\n\t\t}.report\n\t}\n}\n',
 		'cannot escape its call site')
 }
+
+fn test_pr_review_codegen_batch_fifteen() {
+	v3_bin := build_v3()
+	// The string length evaluator folds with the same operator precedence as the v3 parser
+	// and AST const evaluator: shifts bind looser than `+`, so `1 << 2 + 1` groups as
+	// `1 << (2 + 1)` = 8 (not `(1 << 2) + 1` = 5) whether the length is recovered from a
+	// const's source text (string evaluator) or a literal expression. Both must agree, else
+	// the literal length check and the generated C dimension would diverge.
+	prec := run_good(v3_bin, 'good_shift_add_precedence_fixed_array_len',
+		'const seg_count = 1 << 2 + 1\nfn main() {\n\ta := [1 << 2 + 1]u8{}\n\tb := [seg_count]u8{}\n\tc := [1 + 2 << 1]u8{}\n\tprintln(int_str(a.len + b.len + c.len))\n}\n')
+	// 8 + 8 + 6 = 22
+	assert prec == '22'
+	// The fixed-array literal-length guard uses the same folded length: a `[1 << 2 + 1]int`
+	// parameter (length 8) rejects a 5-element literal.
+	run_bad(v3_bin, 'bad_shift_add_precedence_literal_len',
+		'fn take(a [1 << 2 + 1]int) int {\n\treturn a[0]\n}\nfn main() {\n\t_ := take([1, 2, 3, 4, 5]!)\n}\n',
+		'cannot use')
+	// An fn-pointer type whose return is a non-early fixed array (`string`/struct element) gets
+	// a return-wrapper struct. The wrapper is forward-declared before the fn-pointer typedef and
+	// completed after the element type, so the C compiles; the wrapped value is unwrapped to
+	// `.ret_arr` at the indirect call, whether the callback is reached through a param or a
+	// struct field.
+	fp_str := run_good(v3_bin, 'good_fn_ptr_returns_fixed_string_array',
+		"type MakeArr = fn () [2]string\nfn mk() [2]string {\n\treturn ['hi', 'there']!\n}\nfn run(f MakeArr) string {\n\tr := f()\n\treturn r[0]\n}\nstruct Holder {\n\tf MakeArr\n}\nfn main() {\n\th := Holder{\n\t\tf: mk\n\t}\n\tprintln(run(mk) + h.f()[1])\n}\n")
+	assert fp_str == 'hithere'
+	fp_struct := run_good(v3_bin, 'good_fn_ptr_returns_fixed_struct_array',
+		'struct P {\n\tx int\n}\ntype MakeP = fn () [2]P\nfn mkp() [2]P {\n\treturn [P{\n\t\tx: 3\n\t}, P{\n\t\tx: 4\n\t}]!\n}\nfn runp(f MakeP) int {\n\tr := f()\n\treturn r[0].x + r[1].x\n}\nfn main() {\n\tprintln(int_str(runp(mkp)))\n}\n')
+	assert fp_struct == '7'
+}

--- a/vlib/v3/transform/array.v
+++ b/vlib/v3/transform/array.v
@@ -22,7 +22,7 @@ fn (mut t Transformer) make_array_clone_call(base_id flat.NodeId, base_type stri
 
 // lower_array_init_to_runtime converts lower array init to runtime data for transform.
 fn (mut t Transformer) lower_array_init_to_runtime(id flat.NodeId, node flat.Node) flat.NodeId {
-	if node.value.len == 0 || is_fixed_array_type(node.value) {
+	if node.value.len == 0 || t.is_fixed_array_type(node.value) {
 		return id
 	}
 	elem_type := node.value
@@ -139,7 +139,7 @@ fn (mut t Transformer) transform_array_literal_for_type(_id flat.NodeId, node fl
 
 fn (mut t Transformer) transform_fixed_array_literal_for_type(_id flat.NodeId, node flat.Node, target_type string) ?flat.NodeId {
 	fixed_type := t.normalize_type_alias(target_type)
-	if !is_fixed_array_type(fixed_type) {
+	if !t.is_fixed_array_type(fixed_type) {
 		return none
 	}
 	elem_type := fixed_array_elem_type(fixed_type)
@@ -188,7 +188,7 @@ fn (mut t Transformer) try_lower_array_append_stmt(id flat.NodeId) ?[]flat.NodeI
 	rhs_node := t.a.nodes[int(rhs_id)]
 	mut push_many := t.array_append_rhs_is_push_many(lhs_id, rhs_id, rhs_type, elem_type)
 	if rhs_node.kind == .array_literal && !elem_type.starts_with('[]')
-		&& !is_fixed_array_type(elem_type) {
+		&& !t.is_fixed_array_type(elem_type) {
 		// `[]scalar << [a, b, c]` always appends the literal's elements. Retype the
 		// literal from the destination so a mis-inferred element type (e.g. `[]int`
 		// for `[f32_expr, ..]`) is corrected and the append stays a clean push_many,
@@ -222,7 +222,7 @@ fn (mut t Transformer) try_lower_array_append_stmt(id flat.NodeId) ?[]flat.NodeI
 
 	lhs_addr := t.runtime_addr(lhs, lhs_type)
 	if push_many {
-		call := if is_fixed_array_type(rhs_type) {
+		call := if t.is_fixed_array_type(rhs_type) {
 			t.make_call_typed('array_push_many_ptr', arr3(lhs_addr, rhs,
 				t.make_fixed_array_len_expr(rhs_type)), 'void')
 		} else {
@@ -376,7 +376,7 @@ fn (t &Transformer) array_append_rhs_is_push_many(lhs_id flat.NodeId, rhs_id fla
 		}
 		return false
 	}
-	if is_fixed_array_type(clean_rhs_type) {
+	if t.is_fixed_array_type(clean_rhs_type) {
 		return t.array_append_elem_types_match(fixed_array_elem_type(clean_rhs_type), elem_type)
 	}
 	if !isnil(t.tc) {

--- a/vlib/v3/transform/array.v
+++ b/vlib/v3/transform/array.v
@@ -187,7 +187,17 @@ fn (mut t Transformer) try_lower_array_append_stmt(id flat.NodeId) ?[]flat.NodeI
 	mut rhs_type := t.normalize_type_alias(t.node_type(rhs_id))
 	rhs_node := t.a.nodes[int(rhs_id)]
 	mut push_many := t.array_append_rhs_is_push_many(lhs_id, rhs_id, rhs_type, elem_type)
-	if push_many && rhs_node.kind == .array_literal && !rhs_type.starts_with('[]') {
+	if rhs_node.kind == .array_literal && !elem_type.starts_with('[]')
+		&& !is_fixed_array_type(elem_type) {
+		// `[]scalar << [a, b, c]` always appends the literal's elements. Retype the
+		// literal from the destination so a mis-inferred element type (e.g. `[]int`
+		// for `[f32_expr, ..]`) is corrected and the append stays a clean push_many,
+		// instead of degrading to a single push of the whole array. (An array-typed
+		// element is genuinely ambiguous, so leave that to the inferred decision.)
+		push_many = true
+		t.a.nodes[int(rhs_id)].typ = array_type
+		rhs_type = array_type
+	} else if push_many && rhs_node.kind == .array_literal && !rhs_type.starts_with('[]') {
 		t.a.nodes[int(rhs_id)].typ = array_type
 		rhs_type = array_type
 	}

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -174,11 +174,19 @@ fn (mut t Transformer) transform_infix_struct_ops(_id flat.NodeId, node flat.Nod
 	if lhs_type.starts_with('&') {
 		return none
 	}
-	struct_type := t.struct_lookup_name(lhs_type)
+	mut struct_type := t.struct_lookup_name(lhs_type)
+	if struct_type.len == 0 {
+		// Generic-struct instance operand (e.g. `Vec4[f32]`): keep the instance type
+		// so the operator lowers to the monomorphized method (`vec__Vec4_f32__plus`).
+		struct_type = t.generic_struct_instance_name(lhs_type)
+	}
 	if struct_type.len == 0 {
 		return none
 	}
-	if checker_lhs_type.len > 0 && !has_smartcast {
+	// Skip the checker/transformer agreement guard for generic-struct instances:
+	// they resolve reliably, and an alias name (`SimdFloat4`) vs the resolved form
+	// (`vec.Vec4[f32]`) would otherwise spuriously fail the comparison.
+	if checker_lhs_type.len > 0 && !has_smartcast && !struct_type.contains('[') {
 		checker_struct_type := t.struct_lookup_name(checker_lhs_type)
 		if checker_struct_type.len > 0 && checker_struct_type != struct_type {
 			return none
@@ -400,6 +408,49 @@ fn (t &Transformer) struct_operator_fn_name(struct_type string, op_name string) 
 	cmethod_name := c_name(method_name)
 	if t.is_known_operator_fn_name(cmethod_name, require_used) {
 		return cmethod_name
+	}
+	if name := t.generic_struct_operator_fn_name(struct_type, op_name) {
+		return name
+	}
+	return none
+}
+
+// generic_struct_instance_name returns `type_name` when it is a generic-struct
+// instance (its base is a known generic struct), else ''.
+fn (t &Transformer) generic_struct_instance_name(type_name string) string {
+	if isnil(t.tc) {
+		return ''
+	}
+	base, _, ok := generic_app_parts(type_name)
+	if !ok {
+		return ''
+	}
+	if base in t.tc.struct_generic_params {
+		return type_name
+	}
+	return ''
+}
+
+// generic_struct_operator_fn_name handles operator overloads on a generic-struct
+// instance (e.g. `Vec4[f32] + Vec4[f32]`). The operator is declared on the generic
+// form (`Vec4[T].+`) and specialized to `vec__Vec4_f32__plus` by the monomorphizer
+// (which runs after this lowering). When the generic operator exists, anticipate
+// the specialized C name so the infix lowers to that call.
+fn (t &Transformer) generic_struct_operator_fn_name(struct_type string, op_name string) ?string {
+	if isnil(t.tc) {
+		return none
+	}
+	base, _, ok := generic_app_parts(struct_type)
+	if !ok {
+		return none
+	}
+	params := t.tc.struct_generic_params[base] or { return none }
+	if params.len == 0 {
+		return none
+	}
+	generic_key := '${base}[${params.join(', ')}].${op_name}'
+	if generic_key in t.tc.fn_ret_types || generic_key in t.tc.fn_param_types {
+		return c_name('${struct_type}.${op_name}')
 	}
 	return none
 }

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -415,18 +415,21 @@ fn (t &Transformer) struct_operator_fn_name(struct_type string, op_name string) 
 	return none
 }
 
-// generic_struct_instance_name returns `type_name` when it is a generic-struct
-// instance (its base is a known generic struct), else ''.
+// generic_struct_instance_name returns the resolved generic-struct instance type
+// for `type_name` (its base is a known generic struct), else ''. A type alias to a
+// generic instance (`SimdFloat4` -> `vec.Vec4[f32]`) is normalized first, so an
+// operand typed by its alias still lowers to the monomorphized operator.
 fn (t &Transformer) generic_struct_instance_name(type_name string) string {
 	if isnil(t.tc) {
 		return ''
 	}
-	base, _, ok := generic_app_parts(type_name)
+	normalized := t.normalize_type_alias(type_name)
+	base, _, ok := generic_app_parts(normalized)
 	if !ok {
 		return ''
 	}
 	if base in t.tc.struct_generic_params {
-		return type_name
+		return normalized
 	}
 	return ''
 }
@@ -497,6 +500,14 @@ fn (t &Transformer) infix_struct_operator_result_type(node flat.Node, lhs_type_i
 	lhs_type := if lhs_type_in.starts_with('&') { lhs_type_in[1..] } else { lhs_type_in }
 	struct_type := t.struct_lookup_name(lhs_type)
 	if struct_type.len == 0 {
+		// Generic-struct instance (`Vec4[f32]`): the specialized operator method is
+		// not registered until monomorphization, so derive the result from the
+		// generic operator's (substituted) return type.
+		if rt := t.generic_struct_operator_return_type(t.generic_struct_instance_name(lhs_type),
+			node.op)
+		{
+			return rt
+		}
 		return ''
 	}
 	if call_info := t.struct_operator_call_info(struct_type, node.op) {
@@ -506,6 +517,40 @@ fn (t &Transformer) infix_struct_operator_result_type(node flat.Node, lhs_type_i
 		}
 	}
 	return ''
+}
+
+// generic_struct_operator_return_type returns the result type of an operator on a
+// generic-struct instance (`Vec4[f32]`), derived from the generic operator's
+// declared return type (`Vec4[T].- -> Vec4[T]`) with the instance's type arguments
+// substituted (`-> Vec4[f32]`), qualified with the struct's module so the outer
+// expression resolves to the monomorphized operator.
+fn (t &Transformer) generic_struct_operator_return_type(struct_type string, op flat.Op) ?string {
+	if struct_type.len == 0 || isnil(t.tc) {
+		return none
+	}
+	op_name := struct_operator_symbol(op) or { return none }
+	full_base, args, ok := generic_app_parts(struct_type)
+	if !ok {
+		return none
+	}
+	params := t.tc.struct_generic_params[full_base] or { return none }
+	generic_key := '${full_base}[${params.join(', ')}].${op_name}'
+	mut ret := ''
+	if r := t.fn_ret_types[generic_key] {
+		ret = r
+	} else if r := t.tc.fn_ret_types[generic_key] {
+		ret = r.name()
+	} else {
+		return none
+	}
+	substituted := substitute_generic_type_text_with_params(ret, args, params)
+	// Qualify a returned instance of the same struct family with the struct's module.
+	rbase, _, rok := generic_app_parts(substituted)
+	if rok && full_base.contains('.') && !rbase.contains('.')
+		&& rbase == full_base.all_after_last('.') {
+		return '${full_base.all_before_last('.')}.${substituted}'
+	}
+	return substituted
 }
 
 // transform_infix_sum_ops transforms transform infix sum ops data for transform.

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -771,7 +771,7 @@ fn (mut t Transformer) transform_in_expr(id flat.NodeId, node flat.Node) flat.No
 				fn_name := array_contains_fn_name(elem)
 				result = t.make_call_typed(fn_name, arr2(new_rhs, new_lhs), 'bool')
 			}
-		} else if is_fixed_array_type(clean_rhs_type) {
+		} else if t.is_fixed_array_type(clean_rhs_type) {
 			// fixed array membership -> fixed_array_contains_int/string(arr, len, val)
 			new_lhs := t.transform_expr(lhs_id)
 			new_rhs := t.transform_expr(rhs_id)
@@ -1192,7 +1192,7 @@ fn (mut t Transformer) transform_fixed_array_len(_id flat.NodeId, node flat.Node
 	}
 	base_id := t.a.children[node.children_start]
 	base_type := t.node_type(base_id)
-	if !is_fixed_array_type(base_type) {
+	if !t.is_fixed_array_type(base_type) {
 		return none
 	}
 	return t.make_fixed_array_len_expr(base_type)
@@ -1455,7 +1455,7 @@ pub fn (mut t Transformer) make_sizeof_type(type_name string) flat.NodeId {
 
 // is_fixed_array_type reports whether a v-type string denotes a fixed array
 // like `int[5]` (as opposed to a dynamic array `[]int` or a map `map[...]...`).
-fn is_fixed_array_type(s string) bool {
+fn (t &Transformer) is_fixed_array_type(s string) bool {
 	if s.starts_with('[]') || s.starts_with('map[') {
 		return false
 	}
@@ -1465,7 +1465,18 @@ fn is_fixed_array_type(s string) bool {
 	if !s.contains('[') || !s.ends_with(']') {
 		return false
 	}
-	return is_decimal_text(fixed_array_len_text(s))
+	len_text := fixed_array_len_text(s)
+	if is_decimal_text(len_text) {
+		return true
+	}
+	// A postfix fixed-array name (`ArrayFixed.name()`) can carry a non-decimal length — a const
+	// (`int[seg_count]`) or an expression (`int[segs + 1]`) — once the checker round-trips
+	// `[n]int` to `int[n]`. Accept it when the bracket text resolves to an integer constant,
+	// which distinguishes it from a generic instance (`vec.Vec4[f32]`, whose bracket is a type).
+	if len_text.contains(',') || isnil(t.tc) {
+		return false
+	}
+	return t.tc.const_int_value(len_text, []string{}) != none
 }
 
 // fixed_array_len supports fixed array len handling for transform.

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1505,6 +1505,15 @@ fn (mut t Transformer) make_fixed_array_len_expr(s string) flat.NodeId {
 	if is_decimal_text(len_text) {
 		return t.make_int_literal(len_text.int())
 	}
+	// Fold a const length — a bare const (`SEGS`) or an expression (`segs + 1`) — to
+	// its integer value. A fixed array's `.len` is a compile-time constant; emitting
+	// the raw expression as an ident would c_name-mangle it into an undeclared
+	// identifier such as `segs_+_1`.
+	if !isnil(t.tc) {
+		if v := t.tc.const_int_value(len_text, []string{}) {
+			return t.make_int_literal(v)
+		}
+	}
 	if len_text.contains('.') {
 		base := len_text.all_before_last('.')
 		field := len_text.all_after_last('.')

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -703,7 +703,7 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 	}
 	if param_type.starts_with('[]') {
 		arg_type := t.node_type(arg_id)
-		if is_fixed_array_type(arg_type) {
+		if t.is_fixed_array_type(arg_type) {
 			return t.fixed_array_value_to_array(arg_id, arg_type, param_type)
 		}
 		if const_arg := t.transform_const_array_arg_for_param(arg_id, param_type) {
@@ -1297,7 +1297,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 					return t.make_call_typed(str_fn, arr1(expr), 'string')
 				}
 				return t.make_string_literal('${qualified}{}')
-			} else if is_fixed_array_type(clean_typ) {
+			} else if t.is_fixed_array_type(clean_typ) {
 				elem_type := fixed_array_elem_type(clean_typ)
 				arr := t.fixed_array_value_to_array(expr, clean_typ, '[]${elem_type}')
 				return t.wrap_string_conversion(arr, '[]${elem_type}')
@@ -1520,12 +1520,12 @@ fn (mut t Transformer) try_lower_array_method_call(node flat.Node) ?flat.NodeId 
 	}
 	base_id := t.a.children[fn_node.children_start]
 	mut base_type := t.node_type(base_id)
-	if !base_type.starts_with('[]') && !is_fixed_array_type(base_type) {
+	if !base_type.starts_with('[]') && !t.is_fixed_array_type(base_type) {
 		base_node := t.a.nodes[int(base_id)]
 		if base_node.kind in [.call, .selector, .as_expr] {
 			new_base := t.transform_expr(base_id)
 			new_base_type := t.node_type(new_base)
-			if new_base_type.starts_with('[]') || is_fixed_array_type(new_base_type) {
+			if new_base_type.starts_with('[]') || t.is_fixed_array_type(new_base_type) {
 				selector := t.make_selector(new_base, fn_node.value, '')
 				mut children := []flat.NodeId{cap: int(node.children_count)}
 				children << selector
@@ -1548,7 +1548,7 @@ fn (mut t Transformer) try_lower_array_method_call(node flat.Node) ?flat.NodeId 
 		}
 	}
 	clean_base_type := if base_type.starts_with('&') { base_type[1..] } else { base_type }
-	if is_fixed_array_type(clean_base_type) {
+	if t.is_fixed_array_type(clean_base_type) {
 		elem_type := fixed_array_elem_type(clean_base_type)
 		array_type := '[]${elem_type}'
 		tmp_name := t.new_temp('fixed_arr')

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -2854,6 +2854,22 @@ fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string 
 				}
 			}
 		}
+		// A method on a concrete generic instance (`Box[int].clone`) is registered under
+		// the open form (`Box[T].clone`), whose stored return type collapsed `Box[T]` to
+		// the bare base. Resolve it through the checker, which re-substitutes the concrete
+		// arguments from the signature text, so the inferred decl type is `Box[int]`.
+		if !isnil(t.tc) && fn_node.kind == .selector && fn_node.children_count > 0 {
+			base_type := t.node_type(t.a.child(fn_node, 0))
+			clean_base := if base_type.starts_with('&') { base_type[1..] } else { base_type }
+			if clean_base.contains('[') && clean_base.ends_with(']') {
+				if ci := t.tc.resolve_generic_struct_method(clean_base, fn_node.value) {
+					rn := ci.return_type.name()
+					if rn.len > 0 && rn != 'void' && rn != 'unknown' {
+						return t.normalize_type_alias(rn)
+					}
+				}
+			}
+		}
 	}
 	if !isnil(t.tc) {
 		if name := t.tc.resolved_call_name(id) {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1154,6 +1154,24 @@ fn (t &Transformer) enum_str_method_name(typ string) ?string {
 	return none
 }
 
+// enum_autostr_call builds a call to the compiler-synthesized `<Enum>__autostr` helper
+// (emitted by cgen's enum_str_defs) which returns the enum field NAME. Used as the default
+// `${enum}` stringification when the user has not defined a custom `.str()` — V auto-derives
+// one. Mirrors the struct-str qualification so the C name matches cgen's enum_decls naming.
+fn (mut t Transformer) enum_autostr_call(expr flat.NodeId, typ string) flat.NodeId {
+	mut qualified := typ
+	if qualified.starts_with('main.') {
+		qualified = qualified[5..]
+	} else if !typ.contains('.') && t.cur_module.len > 0 && t.cur_module != 'main'
+		&& t.cur_module != 'builtin' {
+		q := '${t.cur_module}.${typ}'
+		if q in t.enum_types {
+			qualified = q
+		}
+	}
+	return t.make_call_typed('${c_name(qualified)}__autostr', arr1(expr), 'string')
+}
+
 // wrap_string_conversion transforms wrap string conversion data for transform.
 fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat.NodeId {
 	mut clean_typ := typ
@@ -1197,8 +1215,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 			if method := t.enum_str_method_name(clean_typ) {
 				return t.make_call_typed(method, arr1(expr), 'string')
 			}
-			return t.make_call_typed('strconv__format_int', arr2(expr, t.make_int_literal(10)),
-				'string')
+			return t.enum_autostr_call(expr, clean_typ)
 		}
 		if qtyp != clean_typ {
 			qparsed := t.tc.parse_type(qtyp)
@@ -1206,8 +1223,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 				if method := t.enum_str_method_name(qtyp) {
 					return t.make_call_typed(method, arr1(expr), 'string')
 				}
-				return t.make_call_typed('strconv__format_int', arr2(expr, t.make_int_literal(10)),
-					'string')
+				return t.enum_autostr_call(expr, qtyp)
 			}
 		}
 	}
@@ -1252,8 +1268,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 				if method := t.enum_str_method_name(clean_typ) {
 					return t.make_call_typed(method, arr1(expr), 'string')
 				}
-				return t.make_call_typed('strconv__format_int', arr2(expr, t.make_int_literal(10)),
-					'string')
+				return t.enum_autostr_call(expr, clean_typ)
 			}
 			mut qenum := clean_typ
 			if !clean_typ.contains('.') && t.cur_module.len > 0 && t.cur_module != 'main'
@@ -1264,8 +1279,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 				if method := t.enum_str_method_name(qenum) {
 					return t.make_call_typed(method, arr1(expr), 'string')
 				}
-				return t.make_call_typed('strconv__format_int', arr2(expr, t.make_int_literal(10)),
-					'string')
+				return t.enum_autostr_call(expr, qenum)
 			}
 			if clean_typ in t.structs || clean_typ in t.sum_types {
 				mut qualified := clean_typ

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -125,7 +125,7 @@ fn (mut t Transformer) transform_for_in_body(id flat.NodeId, node flat.Node) []f
 		iter_type
 	}
 	if effective_iter.starts_with('[]') || effective_iter == 'string'
-		|| is_fixed_array_type(effective_iter) {
+		|| t.is_fixed_array_type(effective_iter) {
 		body_ids := t.a.children_of(&node)[header_count..].clone()
 		return t.lower_indexed_for_in(id, node, key_id, val_id, container_id, effective_iter,
 			has_index, body_ids)
@@ -317,7 +317,7 @@ fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_
 	elem_needs_ref := elem_is_mut && !elem_type.starts_with('&')
 	elem_var_type := if elem_needs_ref { '&${elem_type}' } else { elem_type }
 	t.set_var_type(elem_name, elem_var_type)
-	len_expr := if is_fixed_array_type(actual_iter_type) {
+	len_expr := if t.is_fixed_array_type(actual_iter_type) {
 		t.make_fixed_array_len_expr(actual_iter_type)
 	} else {
 		t.make_selector(container, 'len', 'int')
@@ -433,7 +433,7 @@ fn (t &Transformer) infer_for_in_elem_type(iter_type string, node flat.Node) str
 	if iter_type == 'string' {
 		return 'u8'
 	}
-	if is_fixed_array_type(iter_type) {
+	if t.is_fixed_array_type(iter_type) {
 		return fixed_array_elem_type(iter_type)
 	}
 	// Check if the iterable is a range expression

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -408,11 +408,11 @@ fn (t &Transformer) if_expr_result_type(id flat.NodeId, node flat.Node) string {
 		}
 	}
 	branch_typ := t.if_expr_branch_result_type(node)
-	if branch_typ.starts_with('[]') && is_fixed_array_type(checked_typ)
+	if branch_typ.starts_with('[]') && t.is_fixed_array_type(checked_typ)
 		&& fixed_array_elem_type(checked_typ) == branch_typ[2..] {
 		return branch_typ
 	}
-	if branch_typ.starts_with('[]') && is_fixed_array_type(node_typ)
+	if branch_typ.starts_with('[]') && t.is_fixed_array_type(node_typ)
 		&& fixed_array_elem_type(node_typ) == branch_typ[2..] {
 		return branch_typ
 	}
@@ -455,8 +455,8 @@ fn (t &Transformer) if_expr_branch_type_overrides(branch_typ string, stale_typ s
 			return true
 		}
 	}
-	if stale_typ.starts_with('[]') || is_fixed_array_type(stale_typ) {
-		return !branch_typ.starts_with('[]') && !is_fixed_array_type(branch_typ)
+	if stale_typ.starts_with('[]') || t.is_fixed_array_type(stale_typ) {
+		return !branch_typ.starts_with('[]') && !t.is_fixed_array_type(branch_typ)
 	}
 	if stale_typ.starts_with('map[') {
 		return !branch_typ.starts_with('map[')
@@ -665,11 +665,11 @@ fn (t &Transformer) merge_if_expr_types(current string, next string) string {
 	if next == 'array' && current.starts_with('[]') {
 		return current
 	}
-	if current.starts_with('[]') && is_fixed_array_type(next)
+	if current.starts_with('[]') && t.is_fixed_array_type(next)
 		&& current[2..] == fixed_array_elem_type(next) {
 		return current
 	}
-	if next.starts_with('[]') && is_fixed_array_type(current)
+	if next.starts_with('[]') && t.is_fixed_array_type(current)
 		&& next[2..] == fixed_array_elem_type(current) {
 		return next
 	}

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -987,6 +987,9 @@ fn (mut t Transformer) transform_if_branch_value(id flat.NodeId, target_type str
 	if t.is_sum_type_name(target_type) {
 		return t.wrap_sum_value(id, target_type)
 	}
+	if converted := t.fixed_array_value_to_dynamic(id, target_type) {
+		return converted
+	}
 	return t.transform_expr_for_type(id, target_type)
 }
 

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -51,6 +51,11 @@ fn (mut t Transformer) monomorphize_pass() []string {
 					cur_module = node.value
 				}
 				.call {
+					// An infix operator on a generic instance was already lowered to a
+					// direct call (`Vec_int__plus(a, b)`) before this pass. Record the
+					// callee so `specialize_generic_struct_methods` emits an operator
+					// overload only for instances whose operator is actually called.
+					t.record_called_fn_name(node)
 					call_module := node_modules[i] or { cur_module }
 					decl_key, args := t.generic_call_specialization(flat.NodeId(i), node,
 						call_module, decls) or { continue }
@@ -85,6 +90,20 @@ fn is_operator_method_name(name string) bool {
 	return name in ['+', '-', '*', '/', '%', '==', '!=', '<', '>', '<=', '>=']
 }
 
+// record_called_fn_name records the callee name of a direct call so operator overloads
+// (lowered to direct calls before this pass) can be specialized only when actually
+// called. Operator method names are mangled (`Vec_int__plus`), matching the name
+// `specialize_generic_struct_methods` would emit for that instance and operator.
+fn (mut t Transformer) record_called_fn_name(node flat.Node) {
+	if node.children_count < 1 {
+		return
+	}
+	fn_node := t.a.child_node(&node, 0)
+	if fn_node.kind == .ident && fn_node.value.len > 0 {
+		t.used_struct_operator_fns[fn_node.value] = true
+	}
+}
+
 // specialize_generic_struct_methods specializes every generic method of each
 // instantiated generic struct (e.g. for `Vec4[f32]`, generate `vec__Vec4_f32__plus`,
 // `vec__Vec4_f32__one`, ...). It only handles methods whose generic parameters are
@@ -109,8 +128,17 @@ fn (mut t Transformer) specialize_generic_struct_methods(struct_decls map[string
 			// every method here would generate unused (and possibly unresolved) bodies.
 			// The exception is a method used as a *value* (`b.method`): it has no call
 			// node to drive specialization, so specialize the ones the checker recorded.
-			if !is_operator_method_name(decl_key.all_after_last('.')) {
-				mvkey := '${spec}.${decl_key.all_after_last('.')}'
+			method := decl_key.all_after_last('.')
+			if is_operator_method_name(method) {
+				// Specialize an operator overload only for an instance whose operator is
+				// actually applied somewhere (recorded by record_used_struct_operator).
+				// Otherwise a stored-but-never-operated instance whose type argument does
+				// not support the operation would emit a body that fails C compilation.
+				if c_name('${spec}.${method}') !in t.used_struct_operator_fns {
+					continue
+				}
+			} else {
+				mvkey := '${spec}.${method}'
 				if isnil(t.tc) || mvkey !in t.tc.generic_method_value_info {
 					continue
 				}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -1812,6 +1812,14 @@ fn substitute_generic_type_text_with_params(typ string, args []string, params []
 				substitute_generic_type_text_with_params(clean[bracket_end + 1..], args, params)
 		}
 	}
+	if clean.starts_with('fn(') || clean.starts_with('fn (') {
+		// Substitute the generic params inside a function-type parameter so a specialized
+		// method body emits e.g. `fn (string) int`, not the placeholder `fn (T) int` (which
+		// cgen would otherwise render as `fn (int) int`).
+		if sub := subst_generic_fn_type_text(clean, args, params) {
+			return sub
+		}
+	}
 	base, nested_args, ok := generic_app_parts(clean)
 	if ok {
 		mut resolved_args := []string{}
@@ -1821,6 +1829,54 @@ fn substitute_generic_type_text_with_params(typ string, args []string, params []
 		return '${base}[${resolved_args.join(', ')}]'
 	}
 	return clean
+}
+
+// subst_generic_fn_type_text substitutes generic params inside a `fn (...) ...` type text,
+// recursing into each parameter type and the return type. Returns none when the signature
+// is malformed (unbalanced parens).
+fn subst_generic_fn_type_text(clean string, args []string, params []string) ?string {
+	params_start := clean.index_u8(`(`) + 1
+	mut depth := 1
+	mut params_end := params_start
+	for params_end < clean.len {
+		if clean[params_end] == `(` {
+			depth++
+		} else if clean[params_end] == `)` {
+			depth--
+			if depth == 0 {
+				break
+			}
+		}
+		params_end++
+	}
+	if params_end >= clean.len {
+		return none
+	}
+	params_str := clean[params_start..params_end]
+	mut fn_parts := []string{}
+	if params_str.trim_space().len > 0 {
+		mut pdepth := 0
+		mut start := 0
+		for i := 0; i < params_str.len; i++ {
+			c := params_str[i]
+			if c == `(` || c == `[` {
+				pdepth++
+			} else if c == `)` || c == `]` {
+				pdepth--
+			} else if c == `,` && pdepth == 0 {
+				fn_parts << substitute_generic_type_text_with_params(params_str[start..i], args,
+					params)
+				start = i + 1
+			}
+		}
+		fn_parts << substitute_generic_type_text_with_params(params_str[start..], args, params)
+	}
+	ret_str := clean[params_end + 1..].trim_space()
+	if ret_str.len > 0 {
+		return 'fn(${fn_parts.join(', ')}) ${substitute_generic_type_text_with_params(ret_str,
+			args, params)}'
+	}
+	return 'fn(${fn_parts.join(', ')})'
 }
 
 // subst_type substitutes generic placeholders in a type-text using the currently

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -107,8 +107,13 @@ fn (mut t Transformer) specialize_generic_struct_methods(struct_decls map[string
 			// they are reached through infix expressions, not call nodes. Regular
 			// methods are specialized on demand by the call-driven path, so emitting
 			// every method here would generate unused (and possibly unresolved) bodies.
+			// The exception is a method used as a *value* (`b.method`): it has no call
+			// node to drive specialization, so specialize the ones the checker recorded.
 			if !is_operator_method_name(decl_key.all_after_last('.')) {
-				continue
+				mvkey := '${spec}.${decl_key.all_after_last('.')}'
+				if isnil(t.tc) || mvkey !in t.tc.generic_method_value_info {
+					continue
+				}
 			}
 			if decl.node.generic_params.len != 0 {
 				// Method has its own generic parameters beyond the struct's; leave it
@@ -119,8 +124,8 @@ fn (mut t Transformer) specialize_generic_struct_methods(struct_decls map[string
 			if emitted[spec_key] {
 				continue
 			}
-			generated << t.generated_fn_used_names(decl, t.emit_generic_fn_specialization(decl,
-				args), args)
+			generated << t.generated_fn_used_names(decl,
+				t.emit_generic_fn_specialization(decl, args), args)
 			emitted[spec_key] = true
 			any = true
 		}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -142,6 +142,13 @@ fn (mut t Transformer) specialize_generic_struct_methods(struct_decls map[string
 				if isnil(t.tc) || mvkey !in t.tc.generic_method_value_info {
 					continue
 				}
+				// Only specialize a method value the checker recorded inside a *reachable*
+				// function: markused seeds the concrete instance key (`Box[int].report`) into
+				// `used_fns` per reachable function, so one used only in dead code is skipped —
+				// its body may be invalid for that type argument and would fail C compilation.
+				if t.used_fns.len > 0 && mvkey !in t.used_fns && c_name(mvkey) !in t.used_fns {
+					continue
+				}
 			}
 			if decl.node.generic_params.len != 0 {
 				// Method has its own generic parameters beyond the struct's; leave it

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -31,6 +31,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 	if decls.len == 0 {
 		return []string{}
 	}
+	struct_decls := t.collect_generic_struct_decls()
 	template_nodes := t.generic_decl_template_nodes(decls)
 	mut emitted := map[string]bool{}
 	mut generated := []string{}
@@ -66,10 +67,65 @@ fn (mut t Transformer) monomorphize_pass() []string {
 				else {}
 			}
 		}
+		// Specialize methods of instantiated generic structs that are never reached
+		// through an explicit call node — notably operator overloads (`a + b`), which
+		// are infix expressions lowered to method calls only later in the pipeline.
+		if t.specialize_generic_struct_methods(struct_decls, decls, mut emitted, mut generated) {
+			changed = true
+		}
 	}
 	t.rewrite_generic_calls(decls, template_nodes)
 	t.erase_generic_fn_decls(decls)
 	return generated
+}
+
+// is_operator_method_name reports whether a method-name part is an overloaded
+// operator symbol (`+`, `-`, `*`, `/`, `%`, `==`, `<`, `>`, `<=`, `>=`).
+fn is_operator_method_name(name string) bool {
+	return name in ['+', '-', '*', '/', '%', '==', '!=', '<', '>', '<=', '>=']
+}
+
+// specialize_generic_struct_methods specializes every generic method of each
+// instantiated generic struct (e.g. for `Vec4[f32]`, generate `vec__Vec4_f32__plus`,
+// `vec__Vec4_f32__one`, ...). It only handles methods whose generic parameters are
+// exactly the struct's parameters (no extra method-level `[U]`); those are left to
+// the call-driven path. Returns whether any new specialization was emitted.
+fn (mut t Transformer) specialize_generic_struct_methods(struct_decls map[string]GenericStructDecl, decls map[string]GenericFnDecl, mut emitted map[string]bool, mut generated []string) bool {
+	mut specs := map[string]string{}
+	t.collect_generic_struct_specs(struct_decls, mut specs)
+	mut any := false
+	for spec, base in specs {
+		_, args, ok := generic_app_parts(spec)
+		if !ok || args.len == 0 {
+			continue
+		}
+		for decl_key, decl in decls {
+			if !decl_key.contains('.') || decl_key.all_before_last('.') != base {
+				continue
+			}
+			// Only operator overloads need struct-instantiation-driven specialization:
+			// they are reached through infix expressions, not call nodes. Regular
+			// methods are specialized on demand by the call-driven path, so emitting
+			// every method here would generate unused (and possibly unresolved) bodies.
+			if !is_operator_method_name(decl_key.all_after_last('.')) {
+				continue
+			}
+			if decl.node.generic_params.len != 0 {
+				// Method has its own generic parameters beyond the struct's; leave it
+				// to the call-driven specialization which can infer them.
+				continue
+			}
+			spec_key := generic_fn_spec_key(decl_key, args)
+			if emitted[spec_key] {
+				continue
+			}
+			generated << t.generated_fn_used_names(decl, t.emit_generic_fn_specialization(decl,
+				args), args)
+			emitted[spec_key] = true
+			any = true
+		}
+	}
+	return any
 }
 
 fn (mut t Transformer) materialize_generic_structs() {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -439,9 +439,12 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 			value: decl.module
 		})
 	}
+	old_params := t.active_generic_params
+	t.active_generic_params = t.generic_fn_param_names(decl.node, decl.module)
 	clone_id := t.clone_generic_fn_node(decl.node, args)
 	clone := t.a.nodes[int(clone_id)]
 	t.register_specialized_fn_signature(decl, clone, args)
+	t.active_generic_params = old_params
 	t.transform_specialized_fn_body(clone_id, decl.module)
 	return clone_id
 }
@@ -480,7 +483,7 @@ fn (mut t Transformer) register_specialized_fn_signature(decl GenericFnDecl, clo
 	if !isnil(t.tc) {
 		t.tc.cur_module = decl.module
 	}
-	ret_name := substitute_generic_type_text(decl.node.typ, args)
+	ret_name := t.subst_type(decl.node.typ, args)
 	ret := if !isnil(t.tc) { t.tc.parse_type(ret_name) } else { types.Type(types.void_) }
 	mut params := []types.Type{}
 	mut variadic := false
@@ -489,7 +492,7 @@ fn (mut t Transformer) register_specialized_fn_signature(decl GenericFnDecl, clo
 		if child.kind != .param {
 			continue
 		}
-		param_type := substitute_generic_type_text(child.typ, args)
+		param_type := t.subst_type(child.typ, args)
 		if param_type.starts_with('...') {
 			variadic = true
 		}
@@ -585,8 +588,31 @@ fn (mut t Transformer) rewrite_generic_plain_call(id flat.NodeId, node flat.Node
 	t.clear_resolved_call(id)
 }
 
+// call_is_selector_form reports whether a call node embeds its receiver inside the
+// callee (`recv.method(args)`) rather than passing it as an explicit child
+// (`Type.method(recv, args)`, the ident-lowered form).
+fn (t &Transformer) call_is_selector_form(node flat.Node) bool {
+	if node.children_count == 0 {
+		return false
+	}
+	mut callee := t.a.nodes[int(t.a.child(&node, 0))]
+	if callee.kind == .index && callee.children_count > 0 {
+		callee = t.a.nodes[int(t.a.child(&callee, 0))]
+	}
+	return callee.kind == .selector
+}
+
 fn (mut t Transformer) rewrite_generic_method_call(id flat.NodeId, node flat.Node, decl GenericFnDecl, args []string) {
 	if node.children_count == 0 {
+		return
+	}
+	// Method-level generics (`method[U](...)`) cannot be resolved from the receiver
+	// type alone — the receiver carries no `_U` suffix — so the call must name the
+	// specialized function explicitly, passing the receiver as the first argument
+	// (exactly like a plain generic call). Pure struct-generic methods keep the
+	// selector callee, which cgen resolves via the already-monomorphized receiver.
+	if decl.node.generic_params.len > 0 {
+		t.rewrite_method_level_generic_call(id, node, decl, args)
 		return
 	}
 	fn_id := t.a.child(&node, 0)
@@ -618,6 +644,50 @@ fn (mut t Transformer) rewrite_generic_method_call(id flat.NodeId, node flat.Nod
 		pos:            node.pos
 		value:          ''
 		typ:            substitute_generic_type_text(decl.node.typ, args)
+	}
+	t.clear_resolved_call(id)
+}
+
+// rewrite_method_level_generic_call rewrites a call to a method-level generic into
+// an explicit call of the specialized function: `SpecName(receiver, args...)`. It
+// handles both the selector form (receiver inside the callee) and the
+// ident-lowered form (receiver already an explicit child).
+fn (mut t Transformer) rewrite_method_level_generic_call(id flat.NodeId, node flat.Node, decl GenericFnDecl, args []string) {
+	old_params := t.active_generic_params
+	t.active_generic_params = t.generic_fn_param_names(decl.node, decl.module)
+	spec_value := specialized_generic_fn_value(decl.node.value, args)
+	spec_name := transform_qualified_fn_name(decl.module, spec_value)
+	ret_typ := t.subst_type(decl.node.typ, args)
+	t.active_generic_params = old_params
+
+	mut children := []flat.NodeId{cap: int(node.children_count) + 1}
+	children << t.make_ident(spec_name)
+	if t.call_is_selector_form(node) {
+		// Receiver is embedded in the selector callee; explicit args are children 1..n.
+		if recv_id := t.generic_call_receiver_id(node) {
+			children << recv_id
+		}
+		for i in 1 .. node.children_count {
+			children << t.a.child(&node, i)
+		}
+	} else {
+		// Ident-lowered form: receiver and args are already explicit children 1..n.
+		for i in 1 .. node.children_count {
+			children << t.a.child(&node, i)
+		}
+	}
+	start := t.a.children.len
+	for child in children {
+		t.a.children << child
+	}
+	t.a.nodes[int(id)] = flat.Node{
+		kind:           .call
+		op:             node.op
+		children_start: start
+		children_count: flat.child_count(children.len)
+		pos:            node.pos
+		value:          ''
+		typ:            ret_typ
 	}
 	t.clear_resolved_call(id)
 }
@@ -815,7 +885,14 @@ fn (t &Transformer) generic_call_arg_count_matches_decl(node flat.Node, decl Gen
 			is_variadic = true
 		}
 	}
-	actual := if decl.node.value.contains('.') {
+	// param_count includes the receiver for methods. The call's child count
+	// depends on form: the selector form (`recv.method(args)`) keeps the receiver
+	// inside the callee child, so children = [callee, args...] and the callee child
+	// offsets the receiver param (actual == children_count). The ident-lowered form
+	// (`Type.method(recv, args)`) carries the receiver as a real child, so
+	// children = [callee, recv, args...] and actual == children_count - 1.
+	is_receiver := decl.node.value.contains('.')
+	actual := if is_receiver && t.call_is_selector_form(node) {
 		int(node.children_count)
 	} else {
 		int(node.children_count) - 1
@@ -890,6 +967,20 @@ fn (mut t Transformer) infer_generic_call_args(decl GenericFnDecl, _id flat.Node
 	if param_names.len == 0 {
 		return none
 	}
+	is_receiver := t.generic_decl_is_receiver_method(decl.node)
+	// Determine the call form. The selector form (`recv.method(args)`) embeds the
+	// receiver in the callee, so explicit args begin at child index 1. The
+	// ident-lowered form (`Type__method(recv, args)`) passes the receiver as child
+	// 1, so explicit args begin at child index 2. Using the wrong offset misaligns
+	// every explicit param and makes method-level generic inference silently fail.
+	mut selector_form := false
+	if is_receiver {
+		mut callee := t.a.nodes[int(t.a.child(&node, 0))]
+		if callee.kind == .index && callee.children_count > 0 {
+			callee = t.a.nodes[int(t.a.child(&callee, 0))]
+		}
+		selector_form = callee.kind == .selector
+	}
 	mut inferred := map[string]string{}
 	mut param_idx := 0
 	for i in 0 .. decl.node.children_count {
@@ -897,21 +988,26 @@ fn (mut t Transformer) infer_generic_call_args(decl GenericFnDecl, _id flat.Node
 		if child.kind != .param {
 			continue
 		}
-		arg_idx := if t.generic_decl_is_receiver_method(decl.node) && param_idx == 0 {
-			0
+		is_recv_param := is_receiver && param_idx == 0
+		arg_id := if is_recv_param {
+			if selector_form {
+				t.generic_call_receiver_id(node) or {
+					param_idx++
+					continue
+				}
+			} else {
+				if int(node.children_count) <= 1 {
+					param_idx++
+					continue
+				}
+				t.a.child(&node, 1)
+			}
 		} else {
-			param_idx + 1
-		}
-		if arg_idx >= int(node.children_count) {
-			param_idx++
-			continue
-		}
-		arg_id := if arg_idx == 0 {
-			t.generic_call_receiver_id(node) or {
+			arg_idx := if selector_form { param_idx } else { param_idx + 1 }
+			if arg_idx >= int(node.children_count) {
 				param_idx++
 				continue
 			}
-		} else {
 			t.a.child(&node, arg_idx)
 		}
 		mut arg_type := t.node_type(arg_id)
@@ -920,7 +1016,7 @@ fn (mut t Transformer) infer_generic_call_args(decl GenericFnDecl, _id flat.Node
 		}
 		if arg_type.len > 0 {
 			infer_generic_type_args(child.typ, arg_type, mut inferred)
-			if t.generic_decl_is_receiver_method(decl.node) && param_idx == 0 {
+			if is_recv_param {
 				t.infer_generic_receiver_suffix_args(child.typ, arg_type, mut inferred)
 				t.infer_generic_embedded_receiver_args(child.typ, arg_type, mut inferred)
 			}
@@ -1168,8 +1264,11 @@ fn infer_generic_type_args(param_type string, arg_type string, mut inferred map[
 		}
 		return
 	}
-	if param.starts_with('&') && arg.starts_with('&') {
-		infer_generic_type_args(param[1..], arg[1..], mut inferred)
+	if param.starts_with('&') {
+		// A `&T` / `mut T` parameter binds to a by-value argument too (the arg type
+		// carries no `&`), so strip the reference from the parameter regardless of
+		// whether the argument is itself a reference.
+		infer_generic_type_args(param[1..], arg.trim_left('&'), mut inferred)
 		return
 	}
 	if param.starts_with('mut ') {
@@ -1230,7 +1329,7 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 	if node.kind == .selector && node.value == 'name' && node.children_count > 0 {
 		base := t.a.child_node(&node, 0)
 		if base.kind == .ident && is_generic_fn_placeholder_name(base.value) {
-			idx := generic_param_index(base.value)
+			idx := t.active_generic_param_index(base.value)
 			if idx < args.len {
 				return t.make_string_literal(args[idx])
 			}
@@ -1247,7 +1346,7 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 	cloned_value := if is_root {
 		specialized_generic_fn_value(node.value, args)
 	} else {
-		substitute_generic_node_value(node, args)
+		t.subst_node_value(node, args)
 	}
 	return t.a.add_node(flat.Node{
 		kind:           node.kind
@@ -1256,7 +1355,7 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 		pos:            node.pos
 		children_start: start
 		children_count: flat.child_count(children.len)
-		typ:            substitute_generic_type_text(node.typ, args)
+		typ:            t.subst_type(node.typ, args)
 		value:          cloned_value
 	})
 }
@@ -1691,6 +1790,37 @@ fn substitute_generic_type_text_with_params(typ string, args []string, params []
 	return clean
 }
 
+// subst_type substitutes generic placeholders in a type-text using the currently
+// active generic parameter names (so non-canonical params resolve by name). Falls
+// back to positional substitution when no params are active.
+fn (t &Transformer) subst_type(typ string, args []string) string {
+	return substitute_generic_type_text_with_params(typ, args, t.active_generic_params)
+}
+
+// subst_node_value is the param-aware counterpart of substitute_generic_node_value.
+fn (t &Transformer) subst_node_value(node flat.Node, args []string) string {
+	match node.kind {
+		.call, .array_init, .struct_init, .cast_expr, .as_expr, .sizeof_expr, .typeof_expr,
+		.is_expr, .type_decl, .field_decl, .param {
+			return t.subst_type(node.value, args)
+		}
+		else {
+			return node.value
+		}
+	}
+}
+
+// active_generic_param_index returns the position of a placeholder name within the
+// active generic params, or the positional fallback when none are active.
+fn (t &Transformer) active_generic_param_index(name string) int {
+	for i, p in t.active_generic_params {
+		if p == name {
+			return i
+		}
+	}
+	return generic_param_index(name)
+}
+
 fn specialized_generic_fn_value(value string, args []string) string {
 	if value.contains('.') {
 		receiver := value.all_before_last('.')
@@ -1713,10 +1843,75 @@ fn generic_type_args_short(args []string) string {
 }
 
 fn generic_type_arg_short(type_arg string) string {
-	if type_arg.contains('.') {
-		return type_arg.all_after_last('.')
+	clean := type_arg.trim_space()
+	// Function-type args (`fn (A, B) R`) and other compound types cannot appear
+	// verbatim in a C identifier and must not be naively shortened by the last
+	// `.` (which would truncate `fn(...) mod.R` to `R)`). Reduce them to a
+	// deterministic sanitized fragment instead.
+	if clean.contains('(') || clean.contains(' ') {
+		return sanitize_type_name_fragment(clean)
 	}
-	return type_arg
+	if clean.contains('.') {
+		return clean.all_after_last('.')
+	}
+	return clean
+}
+
+// sanitize_type_name_fragment reduces an arbitrary type text (notably a function
+// type) to a deterministic fragment that is a valid C identifier piece: module
+// qualifiers are dropped, `[]`/`&` become readable prefixes, and every other run
+// of non-identifier characters collapses to a single underscore.
+fn sanitize_type_name_fragment(typ string) string {
+	mut out := []u8{}
+	mut prev_us := false
+	mut i := 0
+	for i < typ.len {
+		c := typ[i]
+		if (c >= `A` && c <= `Z`) || (c >= `a` && c <= `z`) || (c >= `0` && c <= `9`) {
+			out << c
+			prev_us = false
+			i++
+		} else if c == `[` && i + 1 < typ.len && typ[i + 1] == `]` {
+			for ch in 'Array_'.bytes() {
+				out << ch
+			}
+			prev_us = false
+			i += 2
+		} else if c == `&` {
+			for ch in 'ptr_'.bytes() {
+				out << ch
+			}
+			prev_us = false
+			i++
+		} else if c == `.` {
+			// Drop the preceding module qualifier (everything emitted since the
+			// last separator), keeping only the unqualified name.
+			for out.len > 0 {
+				last := out[out.len - 1]
+				if (last >= `A` && last <= `Z`) || (last >= `a` && last <= `z`)
+					|| (last >= `0` && last <= `9`) {
+					out.delete_last()
+				} else {
+					break
+				}
+			}
+			i++
+		} else {
+			if !prev_us {
+				out << `_`
+				prev_us = true
+			}
+			i++
+		}
+	}
+	mut s := out.bytestr()
+	for s.starts_with('_') {
+		s = s[1..]
+	}
+	for s.ends_with('_') {
+		s = s[..s.len - 1]
+	}
+	return s
 }
 
 fn generic_type_suffixes(args []string) string {

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -466,6 +466,11 @@ fn (mut t Transformer) lower_or_body_to_stmts(body_id flat.NodeId, target_name s
 	if body.children_count == 0 {
 		return result
 	}
+	// The or-body is its own scope: `err` (and any locals it declares) are bound only
+	// for its lowering and restored afterwards, so the previous binding (e.g. an outer
+	// `err := 1`) survives and a subsequent `${err}` is not mis-typed as `IError`.
+	// Mirrors transform_if_guard_else_block.
+	saved_var_types := t.var_types.clone()
 	t.set_var_type('err', 'IError')
 	err_value := if err_source.len > 0 {
 		t.make_selector(t.make_ident(err_source), 'err', 'IError')
@@ -522,6 +527,7 @@ fn (mut t Transformer) lower_or_body_to_stmts(body_id flat.NodeId, target_name s
 		}
 	}
 	_ = target_type
+	t.var_types = saved_var_types
 	return result
 }
 

--- a/vlib/v3/transform/return.v
+++ b/vlib/v3/transform/return.v
@@ -316,7 +316,13 @@ fn (mut t Transformer) match_branch_return_block(branch flat.Node, body_start_id
 	} else {
 		tail_expr
 	}
-	ret_val := t.wrap_sum_return_expr(actual_tail)
+	// Convert a fixed-array branch value (e.g. a fixed-array const) to a dynamic
+	// array when the function returns `[]T`, matching a plain `return <expr>`.
+	ret_val := if converted := t.fixed_array_return_value(actual_tail) {
+		converted
+	} else {
+		t.wrap_sum_return_expr(actual_tail)
+	}
 	t.drain_pending(mut all)
 	all << t.make_return(ret_val, ret_typ)
 	return t.make_block(all)

--- a/vlib/v3/transform/return.v
+++ b/vlib/v3/transform/return.v
@@ -180,7 +180,14 @@ fn (mut t Transformer) return_block_from_branch(branch_id flat.NodeId, ret_typ s
 	if branch.kind != .block {
 		// single expression branch: just `return <expr>`
 		mut all := []flat.NodeId{}
-		ret_val := t.wrap_sum_return_expr(branch_id)
+		// Convert a fixed-array branch value (e.g. a fixed-array const) to a dynamic
+		// array when the function returns `[]T`, matching a plain `return <expr>` and
+		// the `return match {...}` path (match_branch_return_block).
+		ret_val := if converted := t.fixed_array_return_value(branch_id) {
+			converted
+		} else {
+			t.wrap_sum_return_expr(branch_id)
+		}
 		t.drain_pending(mut all)
 		all << t.make_return(ret_val, ret_typ)
 		return t.make_block(all)
@@ -210,7 +217,11 @@ fn (mut t Transformer) return_block_from_branch(branch_id flat.NodeId, ret_typ s
 		}
 		return t.make_block(all)
 	}
-	ret_val := t.wrap_sum_return_expr(tail_expr)
+	ret_val := if converted := t.fixed_array_return_value(tail_expr) {
+		converted
+	} else {
+		t.wrap_sum_return_expr(tail_expr)
+	}
 	t.drain_pending(mut all)
 	ret := t.make_return(ret_val, ret_typ)
 	all << ret

--- a/vlib/v3/transform/struct.v
+++ b/vlib/v3/transform/struct.v
@@ -77,7 +77,7 @@ fn (mut t Transformer) transform_struct_fields(id flat.NodeId, node flat.Node) f
 					}
 				}
 			}
-			if val_node.kind == .array_literal && is_fixed_array_type(field_type) {
+			if val_node.kind == .array_literal && t.is_fixed_array_type(field_type) {
 				t.a.nodes[int(val_id)].typ = field_type
 			}
 			value_type := t.node_type(val_id)
@@ -86,7 +86,7 @@ fn (mut t Transformer) transform_struct_fields(id flat.NodeId, node flat.Node) f
 			// Check if the value is an enum shorthand and the field type is an enum
 			mut new_val := if val_node.kind == .enum_val && enum_field_type.len > 0 {
 				t.transform_enum_shorthand(val_id, val_node, enum_field_type)
-			} else if field_type.starts_with('[]') && is_fixed_array_type(value_type) {
+			} else if field_type.starts_with('[]') && t.is_fixed_array_type(value_type) {
 				t.fixed_array_value_to_array(val_id, value_type, field_type)
 			} else if sum_field_type.len > 0 {
 				t.wrap_sum_value(val_id, sum_field_type)
@@ -396,14 +396,14 @@ fn (mut t Transformer) transform_assoc_expr(id flat.NodeId, node flat.Node) flat
 		value_id := t.a.child(&field, 0)
 		value_node := t.a.nodes[int(value_id)]
 		field_type := field_types[field.value] or { '' }
-		if value_node.kind == .array_literal && is_fixed_array_type(field_type) {
+		if value_node.kind == .array_literal && t.is_fixed_array_type(field_type) {
 			t.a.nodes[int(value_id)].typ = field_type
 		}
 		value_type := t.node_type(value_id)
 		enum_field_type := t.enum_type_name_for_expected(field_type, assoc_module)
 		value := if value_node.kind == .enum_val && enum_field_type.len > 0 {
 			t.transform_enum_shorthand(value_id, value_node, enum_field_type)
-		} else if field_type.starts_with('[]') && is_fixed_array_type(value_type) {
+		} else if field_type.starts_with('[]') && t.is_fixed_array_type(value_type) {
 			t.fixed_array_value_to_array(value_id, value_type, field_type)
 		} else if t.is_sum_type_name(field_type) {
 			t.wrap_sum_value(value_id, field_type)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1722,18 +1722,30 @@ fn (mut t Transformer) fixed_array_return_value(child_id flat.NodeId) ?flat.Node
 	if t.is_optional_type_name(ret_type) {
 		ret_type = t.optional_base_type(ret_type)
 	}
-	mut array_type := ret_type
+	// A function whose declared return type is itself a fixed array keeps
+	// fixed-array (by-value) semantics; the C backend returns it via a wrapper
+	// struct. Only a *dynamic* array return needs a fixed→dynamic conversion of a
+	// fixed-array return value.
 	if is_fixed_array_type(ret_type) {
-		array_type = '[]${fixed_array_elem_type(ret_type)}'
+		return none
 	}
+	return t.fixed_array_value_to_dynamic(child_id, ret_type)
+}
+
+// fixed_array_value_to_dynamic converts a fixed-array *value* (e.g. a fixed-array
+// const or variable, not a literal — those have their own lowering) to a dynamic
+// array when `target_type` is `[]T` with a matching element type. Returns none
+// when no conversion is needed/possible.
+fn (mut t Transformer) fixed_array_value_to_dynamic(value_id flat.NodeId, target_type string) ?flat.NodeId {
+	array_type := target_type
 	if !array_type.starts_with('[]') {
 		return none
 	}
-	child_type := t.node_type(child_id)
+	child_type := t.node_type(value_id)
 	if !is_fixed_array_type(child_type) || fixed_array_elem_type(child_type) != array_type[2..] {
 		return none
 	}
-	return t.fixed_array_value_to_array(child_id, child_type, array_type)
+	return t.fixed_array_value_to_array(value_id, child_type, array_type)
 }
 
 // transform_assign_stmt transforms transform assign stmt data for transform.

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1997,6 +1997,13 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 			if lhs_type.len == 0 {
 				lhs_type = t.lvalue_type(lhs_id)
 			}
+			// A value local moved to the heap (its type became `&T`) is assigned by storing a
+			// value through the pointer (cgen emits `*v = ...`), so coerce the RHS to the value
+			// type `T`, not `&T`. Otherwise a heaped-local RHS (`v = w`, both `&T`) is copied as a
+			// pointer — aliasing `w`'s object — instead of dereferenced to its value.
+			if lhs.kind == .ident && lhs.value in t.heaped_amp_locals && lhs_type.starts_with('&') {
+				lhs_type = lhs_type[1..]
+			}
 			sum_target := t.assignment_sum_target(lhs_id, child_id, lhs_type)
 			if node.op == .assign && sum_target.len > 0 {
 				new_children << t.wrap_sum_value(child_id, sum_target)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -96,6 +96,14 @@ mut:
 	// on return. Recomputed per function (structural pre-pass in transform_fn_body),
 	// consumed when the `p := &v` decl is transformed (RHS rewritten to a heap copy).
 	escaping_amp_ptrs map[string]bool
+	// escaping_amp_sources holds the source locals `v` of such `p := &v` escapes — the
+	// values whose address leaves the frame. The local itself is moved to the heap at its
+	// declaration (its type becomes `&T`) so a mutation between `p := &v` and `return p`
+	// is observed by the caller; copying eagerly at the alias would return stale data.
+	escaping_amp_sources map[string]bool
+	// heaped_amp_locals records which of those sources were actually moved to the heap, so
+	// the `p := &v` alias emits `p = v` (the heap pointer) instead of a fresh memdup copy.
+	heaped_amp_locals map[string]bool
 }
 
 // AliasCache memoizes normalize_type_alias results. It lives on the heap so the
@@ -1029,6 +1037,11 @@ fn (t &Transformer) try_heap_escaping_amp(node flat.Node, rhs_id flat.NodeId) bo
 	if amp_node.kind != .ident {
 		return false
 	}
+	// The source local was moved to the heap at its declaration: the alias is now just that
+	// `&T` pointer (handled below), regardless of its rewritten pointer type.
+	if amp_node.value in t.heaped_amp_locals {
+		return true
+	}
 	local_type := t.node_type(amp_child)
 	return local_type.len > 0 && !local_type.starts_with('&') && !local_type.starts_with('[]')
 		&& !local_type.starts_with('map[') && !local_type.starts_with('?')
@@ -1036,15 +1049,58 @@ fn (t &Transformer) try_heap_escaping_amp(node flat.Node, rhs_id flat.NodeId) bo
 }
 
 // heap_escaping_amp_rhs rewrites `&v` into `(&T)memdup(&v, sizeof(T))`, a heap copy
-// of the value local `v` so the escaping pointer outlives the stack frame.
+// of the value local `v` so the escaping pointer outlives the stack frame. When `v` was
+// itself moved to the heap at its declaration, the alias is simply that pointer — copying
+// would resurrect the stale-mutation bug the move avoids.
 fn (mut t Transformer) heap_escaping_amp_rhs(rhs_id flat.NodeId) flat.NodeId {
 	rhs := t.a.nodes[int(rhs_id)]
 	amp_child := t.a.child(&rhs, 0)
+	amp_node := t.a.nodes[int(amp_child)]
+	if amp_node.kind == .ident && amp_node.value in t.heaped_amp_locals {
+		return t.transform_expr(amp_child)
+	}
 	local_type := t.node_type(amp_child)
 	addr := t.make_prefix(.amp, t.transform_expr(amp_child))
 	size := t.make_sizeof_type(local_type)
 	dup := t.make_call_typed('memdup', arr2(addr, size), 'voidptr')
 	return t.make_cast('&${local_type}', dup, '&${local_type}')
+}
+
+// heapable_value_type reports whether a local of this declared type can be moved to the heap
+// as a `&T` — a plain value type, not an already-reference / container / optional type (those
+// either carry their own indirection or are not addressable as a single `T`).
+fn (t &Transformer) heapable_value_type(typ string) bool {
+	return typ.len > 0 && !typ.starts_with('&') && !typ.starts_with('[]')
+		&& !typ.starts_with('map[') && !typ.starts_with('?') && !typ.starts_with('!')
+		&& !typ.starts_with('[') && typ != 'unknown' && typ != 'void'
+}
+
+// heap_escaping_source_decl rewrites `mut v := <init>` (where `&v` escapes) into a heap
+// allocation so `v` is a `&T` to a heap object. A struct literal becomes `&T{..}` (the cgen
+// memdup's it); any other initializer is copied into a stack temp and memdup'd. Subsequent
+// `v.field = ..` writes then mutate the heap object the returned pointer alias also sees.
+fn (mut t Transformer) heap_escaping_source_decl(node flat.Node, var_name string, elem_typ string) []flat.NodeId {
+	rhs_id := t.a.child(&node, 1)
+	rhs := t.a.nodes[int(rhs_id)]
+	ptr_typ := '&${elem_typ}'
+	mut stmts := []flat.NodeId{}
+	transformed_init := t.transform_expr(rhs_id)
+	// Statements lifted out while transforming the initializer must precede the heap decl.
+	t.drain_pending(mut stmts)
+	mut heap_rhs := flat.NodeId(0)
+	if rhs.kind == .struct_init {
+		heap_rhs = t.make_prefix(.amp, transformed_init)
+	} else {
+		tmp := t.new_temp('esc')
+		stmts << t.make_decl_assign_typed(tmp, transformed_init, elem_typ)
+		addr := t.make_prefix(.amp, t.make_ident(tmp))
+		size := t.make_sizeof_type(elem_typ)
+		dup := t.make_call_typed('memdup', arr2(addr, size), 'voidptr')
+		heap_rhs = t.make_cast(ptr_typ, dup, ptr_typ)
+	}
+	t.heaped_amp_locals[var_name] = true
+	stmts << t.make_decl_assign_typed(var_name, heap_rhs, ptr_typ)
+	return stmts
 }
 
 // mark_escaping_amp_ptrs runs a structural pre-pass over a function body to find
@@ -1055,22 +1111,29 @@ fn (mut t Transformer) heap_escaping_amp_rhs(rhs_id flat.NodeId) flat.NodeId {
 // at rewrite time when `v`'s type is known.
 fn (mut t Transformer) mark_escaping_amp_ptrs(body_ids []flat.NodeId) {
 	t.escaping_amp_ptrs = map[string]bool{}
+	t.escaping_amp_sources = map[string]bool{}
+	t.heaped_amp_locals = map[string]bool{}
 	mut amp_ptrs := map[string]bool{}
+	mut amp_sources := map[string]string{} // pointer `p` -> source local `v`
 	mut returned := map[string]bool{}
 	for id in body_ids {
-		t.scan_escape_pass(id, mut amp_ptrs, mut returned)
+		t.scan_escape_pass(id, mut amp_ptrs, mut amp_sources, mut returned)
 	}
 	for name, _ in amp_ptrs {
 		if name in returned {
 			t.escaping_amp_ptrs[name] = true
+			if src := amp_sources[name] {
+				t.escaping_amp_sources[src] = true
+			}
 		}
 	}
 }
 
 // scan_escape_pass recursively collects, in a function-body subtree, (a) the LHS
-// names of `p := &ident` declarations into `amp_ptrs`, and (b) every ident name
-// appearing inside a return statement into `returned`.
-fn (mut t Transformer) scan_escape_pass(id flat.NodeId, mut amp_ptrs map[string]bool, mut returned map[string]bool) {
+// names of `p := &ident` declarations into `amp_ptrs` (and the source `ident` into
+// `amp_sources[p]`), and (b) every ident name appearing inside a return statement
+// into `returned`.
+fn (mut t Transformer) scan_escape_pass(id flat.NodeId, mut amp_ptrs map[string]bool, mut amp_sources map[string]string, mut returned map[string]bool) {
 	if int(id) < 0 || int(id) >= t.a.nodes.len {
 		return
 	}
@@ -1083,6 +1146,7 @@ fn (mut t Transformer) scan_escape_pass(id flat.NodeId, mut amp_ptrs map[string]
 			amp_child := t.a.nodes[int(t.a.child(&rhs, 0))]
 			if amp_child.kind == .ident {
 				amp_ptrs[lhs.value] = true
+				amp_sources[lhs.value] = amp_child.value
 			}
 		}
 	}
@@ -1092,7 +1156,7 @@ fn (mut t Transformer) scan_escape_pass(id flat.NodeId, mut amp_ptrs map[string]
 		}
 	}
 	for i in 0 .. node.children_count {
-		t.scan_escape_pass(t.a.child(&node, i), mut amp_ptrs, mut returned)
+		t.scan_escape_pass(t.a.child(&node, i), mut amp_ptrs, mut amp_sources, mut returned)
 	}
 }
 
@@ -2687,6 +2751,16 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 			}
 		}
 	}
+	// A value local whose address escapes (`p := &v` with `p` returned) is moved to the heap
+	// at its own declaration so writes after the alias are visible to the caller. Must run
+	// before the `p := &v` alias is transformed (the source is declared first).
+	if node.children_count == 2 {
+		src := t.a.child_node(&node, 0)
+		if src.kind == .ident && src.value in t.escaping_amp_sources
+			&& src.value !in t.heaped_amp_locals && t.heapable_value_type(inferred_typ) {
+			return t.heap_escaping_source_decl(node, src.value, inferred_typ)
+		}
+	}
 	mut new_children := []flat.NodeId{cap: int(node.children_count)}
 	for i in 0 .. node.children_count {
 		child_id := t.a.child(&node, i)
@@ -2694,6 +2768,17 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 			new_children << t.transform_lvalue(child_id)
 		} else if node.children_count == 2 && t.try_heap_escaping_amp(node, child_id) {
 			new_children << t.heap_escaping_amp_rhs(child_id)
+			// When `v` was heap-moved it is already a `&T`, so `p := &v` is really `p := v`
+			// (a `&T`), not `&&T` as the literal `&v` would infer. Adopt the source's pointer
+			// type for `p` so its declaration and later uses are consistent.
+			amp := t.a.nodes[int(child_id)]
+			if amp.children_count > 0 {
+				amp_src := t.a.nodes[int(t.a.child(&amp, 0))]
+				if amp_src.kind == .ident && amp_src.value in t.heaped_amp_locals {
+					inferred_typ = t.var_type(amp_src.value)
+					t.set_var_type(t.a.nodes[int(t.a.child(&node, 0))].value, inferred_typ)
+				}
+			}
 		} else {
 			lhs_id := t.a.child(&node, 0)
 			lhs_type := if inferred_typ.len > 0 {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1099,6 +1099,9 @@ fn (mut t Transformer) heap_escaping_source_decl(node flat.Node, var_name string
 		heap_rhs = t.make_cast(ptr_typ, dup, ptr_typ)
 	}
 	t.heaped_amp_locals[var_name] = true
+	// The local is now a `&T`, so its compound/postfix mutations (`v += 1`, `v++`) must store
+	// through the pointer (`*v += 1`); mark it as a pointer-value lvalue so that lowering fires.
+	t.pointer_value_lvalues[var_name] = true
 	stmts << t.make_decl_assign_typed(var_name, heap_rhs, ptr_typ)
 	return stmts
 }
@@ -1113,6 +1116,9 @@ fn (mut t Transformer) mark_escaping_amp_ptrs(body_ids []flat.NodeId) {
 	t.escaping_amp_ptrs = map[string]bool{}
 	t.escaping_amp_sources = map[string]bool{}
 	t.heaped_amp_locals = map[string]bool{}
+	// Cleared per function: heaped locals add their names below (in heap_escaping_source_decl);
+	// for-loop element vars set and restore their own entries within the loop body.
+	t.pointer_value_lvalues = map[string]bool{}
 	mut amp_ptrs := map[string]bool{}
 	mut amp_sources := map[string]string{} // pointer `p` -> source local `v`
 	mut ptr_aliases := map[string]string{} // copy `q := p` -> aliased pointer `p`

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1178,7 +1178,7 @@ fn (mut t Transformer) scan_escape_pass(id flat.NodeId, mut amp_ptrs map[string]
 	}
 	if node.kind == .return_stmt {
 		for i in 0 .. node.children_count {
-			t.collect_subtree_idents(t.a.child(&node, i), mut returned)
+			t.collect_return_escape_idents(t.a.child(&node, i), mut returned)
 		}
 	}
 	for i in 0 .. node.children_count {
@@ -1187,18 +1187,42 @@ fn (mut t Transformer) scan_escape_pass(id flat.NodeId, mut amp_ptrs map[string]
 	}
 }
 
-// collect_subtree_idents gathers every ident name in a subtree (used to find which
-// names flow into a return statement).
-fn (mut t Transformer) collect_subtree_idents(id flat.NodeId, mut names map[string]bool) {
+// collect_return_escape_idents gathers the idents in a return-expression subtree that occupy an
+// actual escape position — the returned value itself, or a member of a returned aggregate
+// (struct/array/map literal, multi-return). It deliberately stops at operators that consume their
+// operands into a fresh value: infix (`==`, `&&`, arithmetic, …), postfix, `is`/`in`, and any
+// non-`&` prefix (deref `*p`, `!x`, `-x`). That way a pointer that is merely compared or
+// dereferenced in the return expression — e.g. `return p == p && v == 1` — is not mistaken for a
+// pointer that escapes, so its source local is not needlessly heap-moved (which would also make
+// later non-pointer uses of that local read through an `int*`).
+fn (mut t Transformer) collect_return_escape_idents(id flat.NodeId, mut names map[string]bool) {
 	if int(id) < 0 || int(id) >= t.a.nodes.len {
 		return
 	}
 	node := t.a.nodes[int(id)]
-	if node.kind == .ident && node.value.len > 0 {
-		names[node.value] = true
+	match node.kind {
+		.ident {
+			if node.value.len > 0 {
+				names[node.value] = true
+			}
+			return
+		}
+		.infix, .postfix, .is_expr, .in_expr {
+			// These yield a new scalar/bool; their operands do not escape through the return.
+			return
+		}
+		.prefix {
+			// `&x` propagates an address (which may escape); any other prefix (`*x`, `!x`, `-x`)
+			// produces a fresh value, so its operand does not escape.
+			if node.op != .amp {
+				return
+			}
+		}
+		else {}
 	}
+
 	for i in 0 .. node.children_count {
-		t.collect_subtree_idents(t.a.child(&node, i), mut names)
+		t.collect_return_escape_idents(t.a.child(&node, i), mut names)
 	}
 }
 

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -75,6 +75,13 @@ mut:
 	alias_cache           &AliasCache = unsafe { nil }
 	sum_cache             &AliasCache = unsafe { nil }
 	used_fns              map[string]bool
+	// used_struct_operator_fns holds the callee names of direct calls seen during
+	// monomorphize. Infix operators on generic instances are lowered to direct calls
+	// (`Vec_int__plus(a, b)`) before this pass, so an operator overload is specialized for
+	// an instantiated generic struct only when its mangled name appears here — an instance
+	// whose type argument never has the operator applied is not emitted with a body that
+	// would fail C compilation.
+	used_struct_operator_fns map[string]bool
 	// active_generic_params holds the generic parameter names of the decl currently
 	// being specialized/rewritten, in the same order as the inferred type `args`.
 	// It lets type-text substitution map placeholders by name (so non-canonical

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -75,6 +75,20 @@ mut:
 	alias_cache           &AliasCache = unsafe { nil }
 	sum_cache             &AliasCache = unsafe { nil }
 	used_fns              map[string]bool
+	// active_generic_params holds the generic parameter names of the decl currently
+	// being specialized/rewritten, in the same order as the inferred type `args`.
+	// It lets type-text substitution map placeholders by name (so non-canonical
+	// params like `D`/`F` resolve to the right arg) instead of by the positional
+	// `generic_param_index` heuristic (which collapses anything outside the T/U/C
+	// sequences to index 0). Empty for struct-generic specialization, which keeps
+	// the legacy positional behaviour.
+	active_generic_params []string
+	// escaping_amp_ptrs holds the names of pointer locals `p` declared as `p := &v`
+	// (v a value local) whose pointer escapes the function (is returned). V semantics
+	// auto-heap such a `v`; v3 otherwise takes the address of a stack local that dies
+	// on return. Recomputed per function (structural pre-pass in transform_fn_body),
+	// consumed when the `p := &v` decl is transformed (RHS rewritten to a heap copy).
+	escaping_amp_ptrs map[string]bool
 }
 
 // AliasCache memoizes normalize_type_alias results. It lives on the heap so the
@@ -991,6 +1005,105 @@ fn (mut t Transformer) transform_const_string_interp(_id flat.NodeId, node flat.
 }
 
 // transform_fn_body transforms transform fn body data for transform.
+// try_heap_escaping_amp reports whether a `p := &v` decl is an escaping address of
+// a value local that must be heap-copied: `p` is in escaping_amp_ptrs (returned)
+// and `v` resolves to a non-reference value type.
+fn (t &Transformer) try_heap_escaping_amp(node flat.Node, rhs_id flat.NodeId) bool {
+	lhs := t.a.nodes[int(t.a.child(&node, 0))]
+	if lhs.kind != .ident || lhs.value !in t.escaping_amp_ptrs {
+		return false
+	}
+	rhs := t.a.nodes[int(rhs_id)]
+	if rhs.kind != .prefix || rhs.op != .amp || rhs.children_count == 0 {
+		return false
+	}
+	amp_child := t.a.child(&rhs, 0)
+	amp_node := t.a.nodes[int(amp_child)]
+	if amp_node.kind != .ident {
+		return false
+	}
+	local_type := t.node_type(amp_child)
+	return local_type.len > 0 && !local_type.starts_with('&') && !local_type.starts_with('[]')
+		&& !local_type.starts_with('map[') && !local_type.starts_with('?')
+		&& !local_type.starts_with('!')
+}
+
+// heap_escaping_amp_rhs rewrites `&v` into `(&T)memdup(&v, sizeof(T))`, a heap copy
+// of the value local `v` so the escaping pointer outlives the stack frame.
+fn (mut t Transformer) heap_escaping_amp_rhs(rhs_id flat.NodeId) flat.NodeId {
+	rhs := t.a.nodes[int(rhs_id)]
+	amp_child := t.a.child(&rhs, 0)
+	local_type := t.node_type(amp_child)
+	addr := t.make_prefix(.amp, t.transform_expr(amp_child))
+	size := t.make_sizeof_type(local_type)
+	dup := t.make_call_typed('memdup', arr2(addr, size), 'voidptr')
+	return t.make_cast('&${local_type}', dup, '&${local_type}')
+}
+
+// mark_escaping_amp_ptrs runs a structural pre-pass over a function body to find
+// `p := &v` declarations whose pointer `p` is later returned. Such a `v` is a local
+// value whose address escapes, so it must be heap-copied (V auto-heaps it); the
+// names are recorded in `escaping_amp_ptrs` and consumed by the decl-assign
+// transform. Purely structural (no type info needed here): the type check happens
+// at rewrite time when `v`'s type is known.
+fn (mut t Transformer) mark_escaping_amp_ptrs(body_ids []flat.NodeId) {
+	t.escaping_amp_ptrs = map[string]bool{}
+	mut amp_ptrs := map[string]bool{}
+	mut returned := map[string]bool{}
+	for id in body_ids {
+		t.scan_escape_pass(id, mut amp_ptrs, mut returned)
+	}
+	for name, _ in amp_ptrs {
+		if name in returned {
+			t.escaping_amp_ptrs[name] = true
+		}
+	}
+}
+
+// scan_escape_pass recursively collects, in a function-body subtree, (a) the LHS
+// names of `p := &ident` declarations into `amp_ptrs`, and (b) every ident name
+// appearing inside a return statement into `returned`.
+fn (mut t Transformer) scan_escape_pass(id flat.NodeId, mut amp_ptrs map[string]bool, mut returned map[string]bool) {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .decl_assign && node.children_count == 2 {
+		lhs := t.a.nodes[int(t.a.child(&node, 0))]
+		rhs := t.a.nodes[int(t.a.child(&node, 1))]
+		if lhs.kind == .ident && lhs.value.len > 0 && rhs.kind == .prefix && rhs.op == .amp
+			&& rhs.children_count > 0 {
+			amp_child := t.a.nodes[int(t.a.child(&rhs, 0))]
+			if amp_child.kind == .ident {
+				amp_ptrs[lhs.value] = true
+			}
+		}
+	}
+	if node.kind == .return_stmt {
+		for i in 0 .. node.children_count {
+			t.collect_subtree_idents(t.a.child(&node, i), mut returned)
+		}
+	}
+	for i in 0 .. node.children_count {
+		t.scan_escape_pass(t.a.child(&node, i), mut amp_ptrs, mut returned)
+	}
+}
+
+// collect_subtree_idents gathers every ident name in a subtree (used to find which
+// names flow into a return statement).
+fn (mut t Transformer) collect_subtree_idents(id flat.NodeId, mut names map[string]bool) {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .ident && node.value.len > 0 {
+		names[node.value] = true
+	}
+	for i in 0 .. node.children_count {
+		t.collect_subtree_idents(t.a.child(&node, i), mut names)
+	}
+}
+
 fn (mut t Transformer) transform_fn_body(fn_idx int) {
 	fn_node := t.a.nodes[fn_idx]
 	t.cur_fn_name = fn_node.value
@@ -1035,6 +1148,7 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 			body_ids << child_id
 		}
 	}
+	t.mark_escaping_amp_ptrs(body_ids)
 	new_body := t.transform_stmts(body_ids)
 	// Rebuild function children: params then new body
 	start := t.a.children.len
@@ -2571,6 +2685,8 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 		child_id := t.a.child(&node, i)
 		if i == 0 || (node.children_count > 2 && i > 1) {
 			new_children << t.transform_lvalue(child_id)
+		} else if node.children_count == 2 && t.try_heap_escaping_amp(node, child_id) {
+			new_children << t.heap_escaping_amp_rhs(child_id)
 		} else {
 			lhs_id := t.a.child(&node, 0)
 			lhs_type := if inferred_typ.len > 0 {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1932,7 +1932,7 @@ fn (mut t Transformer) fixed_array_return_value(child_id flat.NodeId) ?flat.Node
 	// fixed-array (by-value) semantics; the C backend returns it via a wrapper
 	// struct. Only a *dynamic* array return needs a fixed→dynamic conversion of a
 	// fixed-array return value.
-	if is_fixed_array_type(ret_type) {
+	if t.is_fixed_array_type(ret_type) {
 		return none
 	}
 	return t.fixed_array_value_to_dynamic(child_id, ret_type)
@@ -1948,7 +1948,7 @@ fn (mut t Transformer) fixed_array_value_to_dynamic(value_id flat.NodeId, target
 		return none
 	}
 	child_type := t.node_type(value_id)
-	if !is_fixed_array_type(child_type) || fixed_array_elem_type(child_type) != array_type[2..] {
+	if !t.is_fixed_array_type(child_type) || fixed_array_elem_type(child_type) != array_type[2..] {
 		return none
 	}
 	return t.fixed_array_value_to_array(value_id, child_type, array_type)
@@ -2173,7 +2173,7 @@ fn (t &Transformer) assignment_sum_target(lhs_id flat.NodeId, rhs_id flat.NodeId
 	if lhs_type.starts_with('&') {
 		return ''
 	}
-	if lhs_type.starts_with('[]') || is_fixed_array_type(lhs_type) {
+	if lhs_type.starts_with('[]') || t.is_fixed_array_type(lhs_type) {
 		return ''
 	}
 	if t.is_sum_type_name(lhs_type) {
@@ -2768,7 +2768,7 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 				}
 			}
 			if node.typ.len == 0 {
-				if rhs.kind == .array_literal && is_fixed_array_type(typ) {
+				if rhs.kind == .array_literal && t.is_fixed_array_type(typ) {
 					typ = '[]${fixed_array_elem_type(typ)}'
 					t.a.nodes[int(rhs_id)].typ = typ
 				}
@@ -5573,7 +5573,7 @@ fn (t &Transformer) resolve_expr_type(id flat.NodeId) string {
 					return typ
 				}
 			}
-			if is_fixed_array_type(node.value) {
+			if t.is_fixed_array_type(node.value) {
 				return node.value
 			}
 			if node.value.len > 0 {
@@ -5732,7 +5732,7 @@ fn (t &Transformer) const_type_key(name string) ?string {
 fn (t &Transformer) const_entry_type_name(name string, typ types.Type) ?string {
 	tname := t.normalize_type_alias(typ.name())
 	if tname.len > 0 && tname != 'unknown' {
-		if is_fixed_array_type(tname) {
+		if t.is_fixed_array_type(tname) {
 			if expr_id := t.tc.const_exprs[name] {
 				expr := t.a.nodes[int(expr_id)]
 				if expr.kind == .call {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1115,9 +1115,25 @@ fn (mut t Transformer) mark_escaping_amp_ptrs(body_ids []flat.NodeId) {
 	t.heaped_amp_locals = map[string]bool{}
 	mut amp_ptrs := map[string]bool{}
 	mut amp_sources := map[string]string{} // pointer `p` -> source local `v`
+	mut ptr_aliases := map[string]string{} // copy `q := p` -> aliased pointer `p`
 	mut returned := map[string]bool{}
 	for id in body_ids {
-		t.scan_escape_pass(id, mut amp_ptrs, mut amp_sources, mut returned)
+		t.scan_escape_pass(id, mut amp_ptrs, mut amp_sources, mut ptr_aliases, mut returned)
+	}
+	// A pointer may be returned through a copy (`p := &v; q := p; return q`): `q` is collected
+	// as returned but `p` is not, so propagate "returned" backward along the `q := p` aliases
+	// until a fixpoint. Then `p` (and its source `v`) is recognised as escaping below.
+	for _ in 0 .. ptr_aliases.len {
+		mut changed := false
+		for q, p in ptr_aliases {
+			if q in returned && p !in returned {
+				returned[p] = true
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
 	}
 	for name, _ in amp_ptrs {
 		if name in returned {
@@ -1131,9 +1147,9 @@ fn (mut t Transformer) mark_escaping_amp_ptrs(body_ids []flat.NodeId) {
 
 // scan_escape_pass recursively collects, in a function-body subtree, (a) the LHS
 // names of `p := &ident` declarations into `amp_ptrs` (and the source `ident` into
-// `amp_sources[p]`), and (b) every ident name appearing inside a return statement
-// into `returned`.
-fn (mut t Transformer) scan_escape_pass(id flat.NodeId, mut amp_ptrs map[string]bool, mut amp_sources map[string]string, mut returned map[string]bool) {
+// `amp_sources[p]`), (b) plain pointer copies `q := p` into `ptr_aliases[q] = p`, and
+// (c) every ident name appearing inside a return statement into `returned`.
+fn (mut t Transformer) scan_escape_pass(id flat.NodeId, mut amp_ptrs map[string]bool, mut amp_sources map[string]string, mut ptr_aliases map[string]string, mut returned map[string]bool) {
 	if int(id) < 0 || int(id) >= t.a.nodes.len {
 		return
 	}
@@ -1148,6 +1164,10 @@ fn (mut t Transformer) scan_escape_pass(id flat.NodeId, mut amp_ptrs map[string]
 				amp_ptrs[lhs.value] = true
 				amp_sources[lhs.value] = amp_child.value
 			}
+		} else if lhs.kind == .ident && lhs.value.len > 0 && rhs.kind == .ident && rhs.value.len > 0 {
+			// `q := p` aliases an existing pointer; recorded so a returned alias still marks the
+			// underlying `p := &v` as escaping.
+			ptr_aliases[lhs.value] = rhs.value
 		}
 	}
 	if node.kind == .return_stmt {
@@ -1156,7 +1176,8 @@ fn (mut t Transformer) scan_escape_pass(id flat.NodeId, mut amp_ptrs map[string]
 		}
 	}
 	for i in 0 .. node.children_count {
-		t.scan_escape_pass(t.a.child(&node, i), mut amp_ptrs, mut amp_sources, mut returned)
+		t.scan_escape_pass(t.a.child(&node, i), mut amp_ptrs, mut amp_sources, mut ptr_aliases, mut
+			returned)
 	}
 }
 

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -4162,7 +4162,12 @@ fn (mut t Transformer) transform_prefix_expr(id flat.NodeId, node flat.Node) fla
 	if node.op == .amp && node.children_count == 1 {
 		child_id := t.a.child(&node, 0)
 		child := t.a.nodes[int(child_id)]
-		if t.in_return_expr && child.kind == .struct_init {
+		if child.kind == .struct_init {
+			// `&T{...}` (address of a struct literal) is ALWAYS a heap allocation in V,
+			// in any context — not just in a return. Keeping it as a `.prefix .amp`
+			// struct_init routes it through cgen's gen_heap_struct_init; otherwise the
+			// generic fall-through lowers it to `&<stack temp>`, which dangles once the
+			// frame dies (e.g. `arr << &T{...}` storing a stack pointer in the array).
 			if expr := t.transform_amp_struct_init_for_type(id, node, node.typ) {
 				return expr
 			}

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -534,7 +534,7 @@ fn (t &Transformer) resolve_index_elem_type(node flat.Node) string {
 		}
 		// A range/slice of a fixed array (`arr[..]`, `arr[a..b]`) yields a dynamic
 		// `[]T`, not the fixed array or a bogus `range` type.
-		if is_fixed_array_type(base_type) {
+		if t.is_fixed_array_type(base_type) {
 			return '[]${fixed_array_elem_type(base_type)}'
 		}
 	}

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -518,7 +518,9 @@ fn (t &Transformer) resolve_index_elem_type(node flat.Node) string {
 	base_type = t.normalize_type_alias(base_type)
 	if base_type.starts_with('&') {
 		ptr_elem_type := t.normalize_type_alias(base_type[1..])
-		if !ptr_elem_type.starts_with('[]') {
+		// A `mut map`/`mut []T` param is a pointer to the container; indexing it must
+		// still yield the element/value type, so fall through to the container cases.
+		if !ptr_elem_type.starts_with('[]') && !ptr_elem_type.starts_with('map[') {
 			return ptr_elem_type
 		}
 		base_type = ptr_elem_type
@@ -529,6 +531,11 @@ fn (t &Transformer) resolve_index_elem_type(node flat.Node) string {
 		}
 		if base_type.starts_with('[]') {
 			return base_type
+		}
+		// A range/slice of a fixed array (`arr[..]`, `arr[a..b]`) yields a dynamic
+		// `[]T`, not the fixed array or a bogus `range` type.
+		if is_fixed_array_type(base_type) {
+			return '[]${fixed_array_elem_type(base_type)}'
 		}
 	}
 	if base_type.starts_with('[]') {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -105,24 +105,24 @@ pub mut:
 	interface_embeds           map[string][]string
 	interface_abstract_methods map[string][]string // iface -> abstract (declared) method names
 
-	c_globals                     map[string]Type
-	const_types                   map[string]Type
-	const_exprs                   map[string]flat.NodeId
-	const_modules                 map[string]string
-	const_suffixes                map[string]string // dot-suffix -> full const key (O(1) lookup; '' if ambiguous)
-	imports                       map[string]string // alias -> short module name
-	file_imports                  map[string]string
-	file_modules                  map[string]string
-	file_scope                    &Scope = unsafe { nil }
-	cur_scope                     &Scope = unsafe { nil }
-	scope_pool                    []&Scope
-	scope_pool_index              int
-	has_builtins                  bool
-	cur_module                    string
-	cur_file                      string
-	errors                        []TypeError
-	resolved_call_names           []string // node_id -> resolved function name
-	resolved_call_set             []bool
+	c_globals           map[string]Type
+	const_types         map[string]Type
+	const_exprs         map[string]flat.NodeId
+	const_modules       map[string]string
+	const_suffixes      map[string]string // dot-suffix -> full const key (O(1) lookup; '' if ambiguous)
+	imports             map[string]string // alias -> short module name
+	file_imports        map[string]string
+	file_modules        map[string]string
+	file_scope          &Scope = unsafe { nil }
+	cur_scope           &Scope = unsafe { nil }
+	scope_pool          []&Scope
+	scope_pool_index    int
+	has_builtins        bool
+	cur_module          string
+	cur_file            string
+	errors              []TypeError
+	resolved_call_names []string // node_id -> resolved function name
+	resolved_call_set   []bool
 	// `Type.method` keys for methods used as *values* (`recv.method` passed as a
 	// callback). Recorded during semantic checking — which has full scope/type info,
 	// runs before markused, and (unlike a call) routes a value-context selector through
@@ -3671,15 +3671,53 @@ fn array_like_elem_type(t Type) ?Type {
 
 // if_branch_types_compatible reports whether two if-expression branch types are
 // compatible. Bare array literals (`[a, b, c]`) resolve to a fixed `T[n]`, but V
-// treats them as dynamic `[]T`; two array branches with compatible element types
-// must therefore not be flagged as a mismatch merely because their lengths differ.
-fn (tc &TypeChecker) if_branch_types_compatible(a Type, b Type) bool {
+// treats them as dynamic `[]T`; two *literal* branches with compatible element
+// types must therefore not be flagged as a mismatch merely because their lengths
+// differ. The length-agnostic relaxation is limited to literal tails: genuine
+// fixed-array values keep their length (handled by `type_compatible` above), so
+// e.g. `[2]int` vs `[3]int` branches still mismatch.
+fn (tc &TypeChecker) if_branch_types_compatible(a Type, b Type, a_is_array_lit bool, b_is_array_lit bool) bool {
 	if tc.type_compatible(a, b) || tc.type_compatible(b, a) {
 		return true
+	}
+	if !a_is_array_lit || !b_is_array_lit {
+		return false
 	}
 	a_elem := array_like_elem_type(a) or { return false }
 	b_elem := array_like_elem_type(b) or { return false }
 	return tc.type_compatible(a_elem, b_elem) || tc.type_compatible(b_elem, a_elem)
+}
+
+// branch_tail_is_array_literal reports whether a branch's value tail is a bare
+// array literal (`[a, b, c]`) — directly, or through a const whose initializer is
+// one. V types such values as dynamic `[]T` regardless of element count, so they
+// must not constrain if-branch length compatibility. Explicit fixed-array
+// initializers (`[N]T{...}`, parsed as `.array_init`) are genuine fixed arrays and
+// keep their length.
+fn (tc &TypeChecker) branch_tail_is_array_literal(id flat.NodeId) bool {
+	return tc.expr_is_bare_array_literal(tc.branch_tail_expr_id(id))
+}
+
+// expr_is_bare_array_literal reports whether `id` is a bare `[a, b, c]` literal,
+// directly or through a single const reference.
+fn (tc &TypeChecker) expr_is_bare_array_literal(id flat.NodeId) bool {
+	if !tc.valid_node_id(id) {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	if node.kind == .array_literal {
+		return true
+	}
+	if node.kind == .ident {
+		for cand in [tc.qualify_name(node.value), node.value] {
+			if expr_id := tc.const_exprs[cand] {
+				if tc.valid_node_id(expr_id) {
+					return tc.a.nodes[int(expr_id)].kind == .array_literal
+				}
+			}
+		}
+	}
+	return false
 }
 
 // fixed_array_elem_type supports fixed array elem type handling for types.
@@ -3848,8 +3886,9 @@ fn (mut tc TypeChecker) check_if_expr(id flat.NodeId, node flat.Node) {
 		else_type = tc.branch_tail_type(else_id)
 	}
 	if then_type !is Void && else_type !is Void {
-		if tc.branch_has_value_tail(then_id) && tc.branch_has_value_tail(tc.a.child(&node, 2))
-			&& !tc.if_branch_types_compatible(then_type, else_type) {
+		else_id := tc.a.child(&node, 2)
+		if tc.branch_has_value_tail(then_id) && tc.branch_has_value_tail(else_id)
+			&& !tc.if_branch_types_compatible(then_type, else_type, tc.branch_tail_is_array_literal(then_id), tc.branch_tail_is_array_literal(else_id)) {
 			if tc.should_diagnose(id) {
 				tc.record_error(.if_branch_mismatch,
 					'if-expression branch type mismatch: then `${then_type.name()}` vs else `${else_type.name()}`',
@@ -4688,6 +4727,19 @@ fn (mut tc TypeChecker) resolve_expr(id flat.NodeId, expected Type) Type {
 				if !tc.receiver_compatible(elem_actual, elem_expected) {
 					all_ok = false
 					break
+				}
+			}
+			// A fixed-array expectation additionally requires the literal to have
+			// exactly the expected number of elements; otherwise `[1, 2]` would be
+			// accepted as e.g. `[4]int` and the C backend would copy/read past the
+			// compound literal. Element-type propagation above still happens either
+			// way; only the type adoption is gated. Unresolvable const lengths stay
+			// lenient (we cannot verify them here).
+			if all_ok && expected is ArrayFixed {
+				if expected_len := tc.fixed_array_len_value(expected) {
+					if node.children_count != expected_len {
+						all_ok = false
+					}
 				}
 			}
 			if all_ok {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -123,6 +123,14 @@ pub mut:
 	errors                        []TypeError
 	resolved_call_names           []string // node_id -> resolved function name
 	resolved_call_set             []bool
+	// `Type.method` keys for methods used as *values* (`recv.method` passed as a
+	// callback). Recorded during semantic checking — which has full scope/type info,
+	// runs before markused, and (unlike a call) routes a value-context selector through
+	// check_selector — so markused can keep these methods (reachable only via a wrapper)
+	// out of the dead-code pruner.
+	method_value_targets          map[string]bool
+	method_values_by_fn           map[int][]string // enclosing fn node id -> method-value `Type.method` keys
+	cur_fn_node_id                int = -1
 	expr_type_values              []Type // node_id -> complex/contextual resolved type
 	expr_type_set                 []bool
 	checking_nodes                []bool
@@ -1130,6 +1138,7 @@ pub fn (mut tc TypeChecker) check_semantics() {
 			.fn_decl {
 				tc.check_decl_type_strings(flat.NodeId(i), node)
 				tc.cur_fn_ret_type = tc.parse_type(node.typ)
+				tc.cur_fn_node_id = i
 				tc.push_scope()
 				for pi in 0 .. node.children_count {
 					p := tc.a.child_node(&node, pi)
@@ -1139,6 +1148,7 @@ pub fn (mut tc TypeChecker) check_semantics() {
 				}
 				tc.insert_implicit_veb_ctx(node)
 				tc.check_fn_body(node)
+				tc.cur_fn_node_id = -1
 				is_disabled_stub := node.value in tc.a.disabled_fns
 				if !type_allows_implicit_return(tc.cur_fn_ret_type)
 					&& !tc.fn_body_definitely_returns(node) && !is_disabled_stub
@@ -4305,6 +4315,26 @@ fn (mut tc TypeChecker) check_selector(id flat.NodeId, node flat.Node) {
 	tc.check_node(base_id)
 	base_type := tc.resolve_type(base_id)
 	tc.register_synth_type(base_id, base_type)
+	// A value-context selector whose name is a method (not a field) of a struct
+	// receiver is a method value; record the concrete `Type.method` so it survives
+	// dead-code elimination (cgen emits a wrapper that calls it).
+	clean_recv := unwrap_pointer(base_type)
+	if clean_recv is Struct {
+		if tc.struct_field_type(clean_recv.name, node.value) == none {
+			mkey := '${clean_recv.name}.${node.value}'
+			if mkey in tc.fn_param_types {
+				// Record per enclosing function so markused marks it only when that
+				// function is reachable (over-marking unreachable method values can pull
+				// in code that crashes cgen). Non-fn contexts (const inits) are always
+				// emitted, so mark those unconditionally.
+				if tc.cur_fn_node_id >= 0 {
+					tc.method_values_by_fn[tc.cur_fn_node_id] << mkey
+				} else {
+					tc.method_value_targets[mkey] = true
+				}
+			}
+		}
+	}
 	if typ := tc.selector_type(id, node) {
 		tc.register_synth_type(id, typ)
 		return
@@ -5005,7 +5035,7 @@ pub fn (tc &TypeChecker) fixed_array_len_value(arr ArrayFixed) ?int {
 }
 
 // const_int_value supports const int value handling for TypeChecker.
-fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
+pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 	if name in seen {
 		return none
 	}
@@ -5024,6 +5054,24 @@ fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 	}
 	if is_decimal_int_literal(name) {
 		return name.int()
+	}
+	// Simple const arithmetic in string form, e.g. a fixed-array size `[SEGS + 1]`.
+	// Split on the rightmost low-precedence operator first (left associativity); each
+	// side can itself be a const, a literal, or a nested expression.
+	for op in [' + ', ' - ', ' * '] {
+		if idx := name.last_index(op) {
+			lhs := name[..idx].trim_space()
+			rhs := name[idx + op.len..].trim_space()
+			if lhs.len > 0 && rhs.len > 0 {
+				l := tc.const_int_value(lhs, seen) or { continue }
+				r := tc.const_int_value(rhs, seen) or { continue }
+				return match op {
+					' + ' { l + r }
+					' - ' { l - r }
+					else { l * r }
+				}
+			}
+		}
 	}
 	return none
 }
@@ -5932,6 +5980,22 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 		if base in tc.sum_types {
 			return Type(SumType{
 				name: base
+			})
+		}
+		if is_concrete_generic {
+			// A concrete generic instance (`Vec4[f32]`) is a monomorphized struct, even
+			// when the generic base decl has been erased after monomorphization. It is
+			// never a fixed array, so don't fall through to the `[N]T` handler below.
+			// Qualify an imported base (`Vec4` -> `vec.Vec4`) so its c_type matches the
+			// materialized struct (`vec__Vec4_f32`) everywhere it appears.
+			mut full := typ
+			if !base.contains('.') {
+				if resolved := tc.unique_qualified_type_name(base) {
+					full = resolved + generic_suffix
+				}
+			}
+			return Type(Struct{
+				name: full
 			})
 		}
 	}
@@ -6930,7 +6994,18 @@ fn (tc &TypeChecker) c_type_uncached(t Type) string {
 		return c_name(t.name)
 	}
 	if t is Alias {
-		return tc.c_type(t.base_type)
+		// Follow the alias chain iteratively. A self-referential / cyclic alias (whose
+		// base resolves back to itself) would otherwise recurse forever here — the cache
+		// is only populated after the recursive call returns — overflowing the stack.
+		mut cur := Type(t)
+		for _ in 0 .. 1000 {
+			if cur is Alias {
+				cur = cur.base_type
+			} else {
+				return tc.c_type(cur)
+			}
+		}
+		return 'void*'
 	}
 	if t is MultiReturn {
 		mut parts := []string{}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -92,6 +92,7 @@ pub mut:
 	fn_variadic                map[string]bool
 	fn_implicit_veb_ctx        map[string]bool
 	structs                    map[string][]StructField
+	struct_generic_params      map[string][]string // generic struct base name -> type-param names (e.g. Vec4 -> [T])
 	params_structs             map[string]bool
 	unions                     map[string]bool
 	type_aliases               map[string]string
@@ -318,6 +319,12 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 				qname := tc.qualify_name(node.value)
 				if qname !in tc.structs {
 					tc.structs[qname] = []StructField{}
+				}
+				if node.generic_params.len > 0 {
+					tc.struct_generic_params[qname] = node.generic_params.clone()
+					if qname != node.value {
+						tc.struct_generic_params[node.value] = node.generic_params.clone()
+					}
 				}
 				if node.typ.contains('union') {
 					tc.unions[qname] = true
@@ -2623,7 +2630,9 @@ fn (mut tc TypeChecker) resolve_call_info(_id flat.NodeId, node flat.Node) ?Call
 			static_name := '${qbase}.${fn_node.value}'
 			if static_name in tc.fn_ret_types && (qbase in tc.structs
 				|| qbase in tc.enum_names || qbase in tc.sum_types
-				|| qbase in tc.interface_names) {
+				|| qbase in tc.interface_names || qbase in tc.type_aliases) {
+				// `qbase in tc.type_aliases` covers static methods on a type alias,
+				// e.g. `fn SimdFloat4.new()` for `type SimdFloat4 = vec.Vec4[f32]`.
 				return tc.call_info(static_name, false)
 			}
 			if fn_node.value == 'zero' && qbase in tc.flag_enums {
@@ -2852,6 +2861,9 @@ fn (mut tc TypeChecker) resolve_call_info(_id flat.NodeId, node flat.Node) ?Call
 				return tc.call_info(mname, true)
 			}
 			if info := tc.embedded_method_call_info(type_name, fn_node.value) {
+				return info
+			}
+			if info := tc.resolve_generic_struct_method(type_name, fn_node.value) {
 				return info
 			}
 			if fn_node.value == 'use' && clean is Struct
@@ -3403,7 +3415,37 @@ fn (tc &TypeChecker) receiver_compatible(actual Type, expected Type) bool {
 	if actual is Pointer {
 		return tc.type_compatible(actual.base_type, expected)
 	}
+	if tc.generic_receiver_base_match(actual, expected) {
+		return true
+	}
 	return false
+}
+
+// generic_receiver_base_match reports whether `actual` is a generic-struct
+// instance (e.g. `Vec4[f32]`) whose base matches `expected` — the generic
+// receiver form a generic method is declared against (`Vec4` / `Vec4[T]`).
+fn (tc &TypeChecker) generic_receiver_base_match(actual Type, expected Type) bool {
+	a_full := unwrap_pointer(actual).name()
+	e_full := unwrap_pointer(expected).name()
+	a := strip_generic_args_name(a_full)
+	if a.len == 0 || a != strip_generic_args_name(e_full) {
+		return false
+	}
+	if a !in tc.struct_generic_params {
+		return false
+	}
+	// At least one side must be a concrete instance (differs from the base form).
+	return a_full != e_full
+}
+
+// strip_generic_args_name returns the base name of a generic instance type
+// (`Box[int]` -> `Box`); array/map types (leading `[`) yield the name unchanged.
+fn strip_generic_args_name(name string) string {
+	bracket := name.index_u8(`[`)
+	if bracket <= 0 {
+		return name
+	}
+	return name[..bracket]
 }
 
 // is_zero_literal reports whether is zero literal applies in types.
@@ -6929,6 +6971,67 @@ fn c_type_name_part(s string) string {
 }
 
 // resolve_type_name_for_method resolves resolve type name for method information for types.
+// resolve_generic_struct_method resolves a method call on a generic-struct
+// instance (e.g. `Vec4[f32].r_sqrt`). The method is registered against the
+// generic form (`Vec4[T].r_sqrt`); this maps the instance's concrete type
+// arguments onto the generic parameters and substitutes them into the method's
+// signature, so the pre-transform checker accepts the call. The transformer's
+// monomorphize pass later materialises the concrete method body.
+fn (mut tc TypeChecker) resolve_generic_struct_method(type_name string, method string) ?CallInfo {
+	bracket := type_name.index_u8(`[`)
+	if bracket <= 0 || !type_name.ends_with(']') {
+		return none
+	}
+	base := type_name[..bracket]
+	args_str := type_name[bracket + 1..type_name.len - 1]
+	mut concrete_args := []string{}
+	for a in split_generic_arg_list(args_str) {
+		concrete_args << a.trim_space()
+	}
+	params := tc.struct_generic_params[base] or { return none }
+	if params.len == 0 || params.len != concrete_args.len {
+		return none
+	}
+	generic_key := '${base}[${params.join(', ')}].${method}'
+	ret := tc.fn_ret_types[generic_key] or { return none }
+	sub_ret := tc.substitute_generic_type(ret, concrete_args)
+	mut sub_params := []Type{}
+	if ptypes := tc.fn_param_types[generic_key] {
+		for pt in ptypes {
+			sub_params << tc.substitute_generic_type(pt, concrete_args)
+		}
+	}
+	return CallInfo{
+		name:         generic_key
+		params:       sub_params
+		return_type:  sub_ret
+		has_receiver: true
+		is_variadic:  tc.fn_variadic[generic_key] or { false }
+		params_known: true
+	}
+}
+
+// split_generic_arg_list splits a comma-separated generic argument list at the
+// top bracket level (so nested types like `map[int]string` stay intact).
+fn split_generic_arg_list(s string) []string {
+	mut parts := []string{}
+	mut depth := 0
+	mut start := 0
+	for i := 0; i < s.len; i++ {
+		c := s[i]
+		if c == `[` || c == `(` {
+			depth++
+		} else if c == `]` || c == `)` {
+			depth--
+		} else if c == `,` && depth == 0 {
+			parts << s[start..i]
+			start = i + 1
+		}
+	}
+	parts << s[start..]
+	return parts
+}
+
 fn resolve_type_name_for_method(t Type) string {
 	if t is Alias {
 		return t.name

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -3535,17 +3535,25 @@ fn (mut tc TypeChecker) generic_literal_fields_compatible(node flat.Node, expect
 	fields := tc.structs[e_base] or { tc.structs[e_base.all_after_last('.')] or { return true } }
 	for i in 0 .. node.children_count {
 		fi := tc.a.child_node(&node, i)
-		if fi.kind != .field_init || fi.value.len == 0 || fi.children_count == 0 {
+		if fi.kind != .field_init || fi.children_count == 0 {
 			continue
 		}
 		mut decl_typ := Type(void_)
 		mut found := false
-		for f in fields {
-			if f.name == fi.value {
-				decl_typ = f.typ
-				found = true
-				break
+		if fi.value.len > 0 {
+			// Named initializer (`Box{v: 'x'}`): match by field name.
+			for f in fields {
+				if f.name == fi.value {
+					decl_typ = f.typ
+					found = true
+					break
+				}
 			}
+		} else if i < fields.len {
+			// Positional initializer (`Box{'x'}`): the parser emits a `field_init` with
+			// an empty name, so match by field order like `check_struct_init` does.
+			decl_typ = fields[i].typ
+			found = true
 		}
 		if !found {
 			continue
@@ -6234,9 +6242,15 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 		return unknown_type('generic type parameter `${typ}`')
 	}
 	if typ.contains('[') && !typ.starts_with('[') {
-		bracket := typ.index_u8(`[`)
-		bracket_end := typ.index_u8(`]`)
-		if bracket_end > bracket {
+		// Postfix fixed-array name (`ArrayFixed.name()`): the element comes first and
+		// each dimension is appended, so the OUTERMOST dimension is the trailing `[N]`
+		// (`int[3][2]` is `[2][3]int`). Split on the last bracket pair so a nested fixed
+		// array recovers the outer length and recurses into the inner element, instead of
+		// taking the first `[N]` and dropping the rest. For a single dimension the last
+		// and first brackets coincide, so this matches the previous behaviour.
+		bracket := typ.last_index_u8(`[`)
+		bracket_end := typ.last_index_u8(`]`)
+		if bracket >= 0 && bracket_end > bracket {
 			len_text := typ[bracket + 1..bracket_end].trim_space()
 			return Type(ArrayFixed{
 				elem_type: tc.parse_type(typ[..bracket])

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -3484,6 +3484,70 @@ fn (tc &TypeChecker) is_concrete_generic_instance(name string) bool {
 	return tc.generic_args_are_concrete(args)
 }
 
+// bare_generic_literal_adopts reports whether a struct literal written as the bare
+// generic base (`Box{...}`, no type args) should adopt the concrete `expected`
+// instance (`Box[int]`, optionally behind a pointer). The base short-names must match
+// and the base must be a known generic struct, so a non-generic same-named struct is
+// left to ordinary checking.
+fn (tc &TypeChecker) bare_generic_literal_adopts(lit_value string, expected Type) bool {
+	if lit_value.len == 0 || lit_value.contains('[') {
+		return false
+	}
+	e_base, _, e_ok := generic_type_application_parts(unwrap_pointer(expected).name())
+	if !e_ok || e_base.all_after_last('.') != lit_value.all_after_last('.') {
+		return false
+	}
+	return e_base in tc.struct_generic_params
+		|| e_base.all_after_last('.') in tc.struct_generic_params
+}
+
+// generic_literal_fields_compatible checks a bare generic struct literal's named
+// field initializers against the expected concrete instantiation (`Box[int]`),
+// substituting the struct's type parameters into each field's declared type. It
+// returns false only on a *definite* mismatch (e.g. `Box{v: 'str'}` for `Box[int]`),
+// so a clearly-unrelated literal yields a clean checker error instead of adopting the
+// type and emitting broken C; unresolvable fields stay lenient.
+fn (mut tc TypeChecker) generic_literal_fields_compatible(node flat.Node, expected Type) bool {
+	e_base, e_args, e_ok := generic_type_application_parts(unwrap_pointer(expected).name())
+	if !e_ok {
+		return true
+	}
+	params := tc.struct_generic_params[e_base] or {
+		tc.struct_generic_params[e_base.all_after_last('.')] or { return true }
+	}
+	if params.len != e_args.len {
+		return true
+	}
+	fields := tc.structs[e_base] or { tc.structs[e_base.all_after_last('.')] or { return true } }
+	for i in 0 .. node.children_count {
+		fi := tc.a.child_node(&node, i)
+		if fi.kind != .field_init || fi.value.len == 0 || fi.children_count == 0 {
+			continue
+		}
+		mut decl_typ := Type(void_)
+		mut found := false
+		for f in fields {
+			if f.name == fi.value {
+				decl_typ = f.typ
+				found = true
+				break
+			}
+		}
+		if !found {
+			continue
+		}
+		sub := tc.substitute_generic_type(decl_typ, e_args, params)
+		if sub is Unknown || sub is Void {
+			continue
+		}
+		actual := tc.resolve_expr(tc.a.child(fi, 0), sub)
+		if !tc.receiver_compatible(actual, sub) {
+			return false
+		}
+	}
+	return true
+}
+
 // strip_generic_args_name returns the base name of a generic instance type
 // (`Box[int]` -> `Box`); array/map types (leading `[`) yield the name unchanged.
 fn strip_generic_args_name(name string) string {
@@ -4735,6 +4799,23 @@ fn (mut tc TypeChecker) resolve_expr(id flat.NodeId, expected Type) Type {
 		tc.type_mismatch(.assignment_mismatch,
 			'unknown enum field `${node.value}` for `${expected.name}`', id)
 		return Type(int_)
+	}
+	// A bare generic struct literal (`Box{...}` / `&Box{...}`) adopts a matching concrete
+	// expected instance (`Box[int]` / `&Box[int]`), so `fn make() Box[int] { return
+	// Box{...} }` and bare literals passed/assigned where a concrete instance is expected
+	// type-check and carry the concrete type into codegen.
+	if node.kind == .struct_init && tc.bare_generic_literal_adopts(node.value, expected)
+		&& tc.generic_literal_fields_compatible(node, expected) {
+		tc.register_synth_type(id, expected_raw)
+		return expected_raw
+	}
+	if node.kind == .prefix && node.op == .amp && node.children_count == 1 && expected is Pointer {
+		child := tc.a.nodes[int(tc.a.child(&node, 0))]
+		if child.kind == .struct_init && tc.bare_generic_literal_adopts(child.value, expected)
+			&& tc.generic_literal_fields_compatible(child, expected) {
+			tc.register_synth_type(id, expected_raw)
+			return expected_raw
+		}
 	}
 	if node.kind == .array_literal {
 		mut elem_expected := Type(void_)

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -2080,6 +2080,17 @@ fn (mut tc TypeChecker) check_node(id flat.NodeId) {
 		tc.check_select_stmt(node)
 		return
 	}
+	// A method value stored in an array escapes the single-use guarantee of its per-site
+	// static receiver, so reject `[obj.method]` literals and `arr << obj.method` appends.
+	if node.kind == .array_literal {
+		for i in 0 .. node.children_count {
+			tc.reject_stored_method_value(tc.a.child(&node, i))
+		}
+	} else if node.kind == .infix && node.op == .left_shift && node.children_count >= 2 {
+		if unwrap_pointer(tc.resolve_type(tc.a.child(&node, 0))) is Array {
+			tc.reject_stored_method_value(tc.a.child(&node, 1))
+		}
+	}
 
 	for i in 0 .. node.children_count {
 		tc.check_node(tc.a.child(&node, i))
@@ -4484,6 +4495,48 @@ fn (mut tc TypeChecker) check_struct_init(id flat.NodeId, node flat.Node) {
 		tc.check_node(tc.a.child(&node, i))
 	}
 	_ = id
+}
+
+// expr_is_method_value reports whether `id` is a selector that resolves to a *method
+// value* — a struct method used as a value (`obj.draw`), not a field access or a method
+// call. cgen backs such a value with a per-evaluation-site static receiver slot, which is
+// only safe for an immediately-consumed callback; it cannot hold several live instances
+// from the same site at once (see gen_method_value_closure).
+fn (tc &TypeChecker) expr_is_method_value(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	if node.kind != .selector || node.children_count == 0 {
+		return false
+	}
+	clean := unwrap_pointer(tc.resolve_type(tc.a.child(&node, 0)))
+	if clean !is Struct {
+		return false
+	}
+	sname := (clean as Struct).name
+	if tc.struct_field_type(sname, node.value) != none {
+		return false
+	}
+	if '${sname}.${node.value}' in tc.fn_param_types {
+		return true
+	}
+	if _ := tc.resolve_generic_struct_method(sname, node.value) {
+		return true
+	}
+	return false
+}
+
+// reject_stored_method_value reports a clear error when a method value is stored into an
+// array, where the per-site static receiver slot cannot keep multiple instances distinct
+// (e.g. `cbs << obj.method` in a loop would make every callback use the last receiver).
+// Without this the value reaches cgen and emits C referencing an unsupported helper.
+fn (mut tc TypeChecker) reject_stored_method_value(id flat.NodeId) {
+	if tc.expr_is_method_value(id) && tc.should_diagnose(id) {
+		tc.record_error(.assignment_mismatch,
+			'a method value (`obj.method`) cannot be stored in an array (no closure capture); pass it directly as a callback argument',
+			id)
+	}
 }
 
 // check_selector validates check selector state for types.

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -3419,21 +3419,30 @@ fn (tc &TypeChecker) receiver_compatible(actual Type, expected Type) bool {
 	if tc.type_compatible(actual, expected) {
 		return true
 	}
+	// Check the generic-base relaxation before the pointer fallbacks: it unwraps
+	// pointers itself, so a bare `&Box{...}` literal still matches an expected
+	// `&Box[int]` (while `&Box[string]` vs `&Box[int]` stays rejected).
+	if tc.generic_receiver_base_match(actual, expected) {
+		return true
+	}
 	if expected is Pointer {
 		return tc.type_compatible(actual, expected.base_type)
 	}
 	if actual is Pointer {
 		return tc.type_compatible(actual.base_type, expected)
 	}
-	if tc.generic_receiver_base_match(actual, expected) {
-		return true
-	}
 	return false
 }
 
-// generic_receiver_base_match reports whether `actual` is a generic-struct
-// instance (e.g. `Vec4[f32]`) whose base matches `expected` — the generic
-// receiver form a generic method is declared against (`Vec4` / `Vec4[T]`).
+// generic_receiver_base_match relaxes compatibility between two same-base generic
+// struct types when at least one side is the open/bare generic form — a bare
+// `Vec4{...}` literal specializing to the expected `Vec4[f32]`, or a concrete
+// `Vec4[f32]` value matching the open `Vec4` / `Vec4[T]` method-receiver form.
+//
+// It deliberately does NOT relax two *different concrete* instantiations. Because
+// `receiver_compatible` is also used for ordinary call arguments, field inits,
+// array literals, and expected-type propagation, conflating them would let
+// `Box[string]` satisfy an expected `Box[int]` and emit incompatible C structs.
 fn (tc &TypeChecker) generic_receiver_base_match(actual Type, expected Type) bool {
 	a_full := unwrap_pointer(actual).name()
 	e_full := unwrap_pointer(expected).name()
@@ -3444,8 +3453,29 @@ fn (tc &TypeChecker) generic_receiver_base_match(actual Type, expected Type) boo
 	if a !in tc.struct_generic_params {
 		return false
 	}
-	// At least one side must be a concrete instance (differs from the base form).
-	return a_full != e_full
+	if a_full == e_full {
+		return false
+	}
+	// Reject two *different concrete* instantiations (`Box[string]` vs `Box[int]`),
+	// which produce incompatible C structs. Relax only when at least one side is
+	// the open/bare generic form: a bare `Box{...}` literal specializing to the
+	// expected `Box[int]`, or a concrete `Box[int]` value matching the open
+	// `Box`/`Box[T]` method-receiver form.
+	if tc.is_concrete_generic_instance(a_full) && tc.is_concrete_generic_instance(e_full) {
+		return false
+	}
+	return true
+}
+
+// is_concrete_generic_instance reports whether `name` is a fully concrete generic
+// instantiation (e.g. `Box[int]`), as opposed to the bare base (`Box`) or an open
+// parameter form (`Box[T]`).
+fn (tc &TypeChecker) is_concrete_generic_instance(name string) bool {
+	_, args, ok := generic_type_application_parts(name)
+	if !ok {
+		return false
+	}
+	return tc.generic_args_are_concrete(args)
 }
 
 // strip_generic_args_name returns the base name of a generic instance type

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5424,13 +5424,17 @@ fn (tc &TypeChecker) struct_field_type_inner(struct_name string, field_name stri
 	for field in tc.structs[lookup_name] or { []StructField{} } {
 		if field.name == field_name {
 			if is_generic {
-				return tc.substitute_generic_type(field.typ, generic_args)
+				return tc.substitute_generic_type(field.typ, generic_args, tc.struct_generic_params[base_name] or {
+					[]string{}
+				})
 			}
 			return field.typ
 		}
 		mut embedded_type := embedded_field_type(field) or { continue }
 		embedded_type = if is_generic {
-			tc.substitute_generic_type(embedded_type, generic_args)
+			tc.substitute_generic_type(embedded_type, generic_args, tc.struct_generic_params[base_name] or {
+				[]string{}
+			})
 		} else {
 			embedded_type
 		}
@@ -5445,13 +5449,22 @@ fn (tc &TypeChecker) struct_field_type_inner(struct_name string, field_name stri
 	return none
 }
 
-fn (tc &TypeChecker) substitute_generic_type(typ Type, args []string) Type {
+// substitute_generic_type replaces generic placeholders in `typ` with the concrete
+// `args`. When `param_names` (the struct/fn's declared type parameters, e.g.
+// `['L', 'R']`) is provided, a placeholder is matched to its arg by its declared
+// position — so `Pair[L, R]`'s `R` resolves to `args[1]`, not the letter-based
+// `generic_param_index` guess (which maps any unrecognised name to 0). The
+// letter-based fallback is kept only for callers that have no declared names.
+fn (tc &TypeChecker) substitute_generic_type(typ Type, args []string, param_names []string) Type {
 	if args.len == 0 {
 		return typ
 	}
 	if typ is Unknown {
 		if name := generic_placeholder_from_unknown(typ) {
-			idx := generic_param_index(name)
+			mut idx := if param_names.len > 0 { param_names.index(name) } else { -1 }
+			if idx < 0 {
+				idx = generic_param_index(name)
+			}
 			if idx >= 0 && idx < args.len {
 				return tc.parse_type(args[idx].trim_space())
 			}
@@ -5460,51 +5473,51 @@ fn (tc &TypeChecker) substitute_generic_type(typ Type, args []string) Type {
 	}
 	if typ is Array {
 		return Type(Array{
-			elem_type: tc.substitute_generic_type(typ.elem_type, args)
+			elem_type: tc.substitute_generic_type(typ.elem_type, args, param_names)
 		})
 	}
 	if typ is ArrayFixed {
 		return Type(ArrayFixed{
-			elem_type: tc.substitute_generic_type(typ.elem_type, args)
+			elem_type: tc.substitute_generic_type(typ.elem_type, args, param_names)
 			len:       typ.len
 			len_expr:  typ.len_expr
 		})
 	}
 	if typ is Map {
 		return Type(Map{
-			key_type:   tc.substitute_generic_type(typ.key_type, args)
-			value_type: tc.substitute_generic_type(typ.value_type, args)
+			key_type:   tc.substitute_generic_type(typ.key_type, args, param_names)
+			value_type: tc.substitute_generic_type(typ.value_type, args, param_names)
 		})
 	}
 	if typ is Pointer {
 		return Type(Pointer{
-			base_type: tc.substitute_generic_type(typ.base_type, args)
+			base_type: tc.substitute_generic_type(typ.base_type, args, param_names)
 		})
 	}
 	if typ is OptionType {
 		return Type(OptionType{
-			base_type: tc.substitute_generic_type(typ.base_type, args)
+			base_type: tc.substitute_generic_type(typ.base_type, args, param_names)
 		})
 	}
 	if typ is ResultType {
 		return Type(ResultType{
-			base_type: tc.substitute_generic_type(typ.base_type, args)
+			base_type: tc.substitute_generic_type(typ.base_type, args, param_names)
 		})
 	}
 	if typ is FnType {
 		mut params := []Type{}
 		for param in typ.params {
-			params << tc.substitute_generic_type(param, args)
+			params << tc.substitute_generic_type(param, args, param_names)
 		}
 		return Type(FnType{
 			params:      params
-			return_type: tc.substitute_generic_type(typ.return_type, args)
+			return_type: tc.substitute_generic_type(typ.return_type, args, param_names)
 		})
 	}
 	if typ is MultiReturn {
 		mut parts := []Type{}
 		for part in typ.types {
-			parts << tc.substitute_generic_type(part, args)
+			parts << tc.substitute_generic_type(part, args, param_names)
 		}
 		return Type(MultiReturn{
 			types: parts
@@ -7178,11 +7191,11 @@ fn (mut tc TypeChecker) resolve_generic_struct_method(type_name string, method s
 	}
 	generic_key := '${base}[${params.join(', ')}].${method}'
 	ret := tc.fn_ret_types[generic_key] or { return none }
-	sub_ret := tc.substitute_generic_type(ret, concrete_args)
+	sub_ret := tc.substitute_generic_type(ret, concrete_args, params)
 	mut sub_params := []Type{}
 	if ptypes := tc.fn_param_types[generic_key] {
 		for pt in ptypes {
-			sub_params << tc.substitute_generic_type(pt, concrete_args)
+			sub_params << tc.substitute_generic_type(pt, concrete_args, params)
 		}
 	}
 	return CallInfo{

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -58,7 +58,8 @@ pub enum TypeErrorKind {
 }
 
 // CallInfo stores call info metadata used by types.
-struct CallInfo {
+pub struct CallInfo {
+pub:
 	name                 string
 	params               []Type
 	return_type          Type
@@ -86,13 +87,17 @@ mut:
 @[heap]
 pub struct TypeChecker {
 pub mut:
-	a                          &flat.FlatAst = unsafe { nil }
-	fn_ret_types               map[string]Type
-	fn_param_types             map[string][]Type
-	fn_variadic                map[string]bool
-	fn_implicit_veb_ctx        map[string]bool
-	structs                    map[string][]StructField
-	struct_generic_params      map[string][]string // generic struct base name -> type-param names (e.g. Vec4 -> [T])
+	a                     &flat.FlatAst = unsafe { nil }
+	fn_ret_types          map[string]Type
+	fn_param_types        map[string][]Type
+	fn_variadic           map[string]bool
+	fn_implicit_veb_ctx   map[string]bool
+	structs               map[string][]StructField
+	struct_generic_params map[string][]string // generic struct base name -> type-param names (e.g. Vec4 -> [T])
+	// concrete `Box[int].method` -> substituted CallInfo for a method *value* on a
+	// generic receiver. The open `Box[T].method` registration is gone by cgen time, so
+	// the checker stashes the resolved signature here for gen_method_value_closure.
+	generic_method_value_info  map[string]CallInfo
 	params_structs             map[string]bool
 	unions                     map[string]bool
 	type_aliases               map[string]string
@@ -3450,6 +3455,15 @@ fn (tc &TypeChecker) receiver_compatible(actual Type, expected Type) bool {
 // array literals, and expected-type propagation, conflating them would let
 // `Box[string]` satisfy an expected `Box[int]` and emit incompatible C structs.
 fn (tc &TypeChecker) generic_receiver_base_match(actual Type, expected Type) bool {
+	// Both sides must share pointer shape before unwrapping: a `&Box{...}` value must
+	// not satisfy an expected `Box[int]` value. The C argument path only
+	// auto-dereferences when the actual/expected type names match exactly, so the bare
+	// `Box` vs `Box[int]` mismatch would otherwise be emitted as a pointer where a value
+	// is required. (A pointer receiver on a value-receiver method is handled by
+	// receiver_compatible's pointer fallbacks, not here.)
+	if (actual is Pointer) != (expected is Pointer) {
+		return false
+	}
 	a_full := unwrap_pointer(actual).name()
 	e_full := unwrap_pointer(expected).name()
 	a := strip_generic_args_name(a_full)
@@ -3618,8 +3632,16 @@ fn (tc &TypeChecker) selector_fn_type(node flat.Node) ?FnType {
 
 fn (tc &TypeChecker) method_value_type(receiver_name string, method string) ?Type {
 	method_name := '${receiver_name}.${method}'
-	ret_type := tc.fn_ret_types[method_name] or { return none }
-	params := tc.fn_param_types[method_name] or { []Type{} }
+	mut ret_type := tc.fn_ret_types[method_name] or { Type(void_) }
+	mut params := tc.fn_param_types[method_name] or { []Type{} }
+	if method_name !in tc.fn_ret_types && method_name !in tc.fn_param_types {
+		// A concrete generic receiver (`Box[int]`) has its methods registered under the
+		// open key (`Box[T].method`); resolve and substitute so a method *value* on a
+		// generic struct is typed instead of reported as an unknown field.
+		ci := tc.resolve_generic_struct_method(receiver_name, method) or { return none }
+		ret_type = ci.return_type
+		params = ci.params.clone()
+	}
 	mut bound_params := []Type{}
 	if params.len > 1 {
 		bound_params = params[1..].clone()
@@ -4460,7 +4482,16 @@ fn (mut tc TypeChecker) check_selector(id flat.NodeId, node flat.Node) {
 	clean_recv := unwrap_pointer(base_type)
 	if clean_recv is Struct {
 		if tc.struct_field_type(clean_recv.name, node.value) == none {
-			mkey := '${clean_recv.name}.${node.value}'
+			mut mkey := '${clean_recv.name}.${node.value}'
+			if mkey !in tc.fn_param_types {
+				// Generic receiver methods are registered under the open key
+				// (`Box[T].method`); mark that one reachable for the wrapper, and stash
+				// the substituted signature for cgen (the open form is gone by cgen time).
+				if ci := tc.resolve_generic_struct_method(clean_recv.name, node.value) {
+					tc.generic_method_value_info['${clean_recv.name}.${node.value}'] = ci
+					mkey = ci.name
+				}
+			}
 			if mkey in tc.fn_param_types {
 				// Record per enclosing function so markused marks it only when that
 				// function is reachable (over-marking unreachable method values can pull
@@ -7261,7 +7292,7 @@ pub fn c_type_name_part(s string) string {
 // arguments onto the generic parameters and substitutes them into the method's
 // signature, so the pre-transform checker accepts the call. The transformer's
 // monomorphize pass later materialises the concrete method body.
-fn (mut tc TypeChecker) resolve_generic_struct_method(type_name string, method string) ?CallInfo {
+pub fn (tc &TypeChecker) resolve_generic_struct_method(type_name string, method string) ?CallInfo {
 	bracket := type_name.index_u8(`[`)
 	if bracket <= 0 || !type_name.ends_with(']') {
 		return none

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -6590,12 +6590,14 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 				name: base
 			})
 		}
-		if is_concrete_generic {
+		if is_concrete_generic && !is_builtin_type_name(base) {
 			// A concrete generic instance (`Vec4[f32]`) is a monomorphized struct, even
 			// when the generic base decl has been erased after monomorphization. It is
 			// never a fixed array, so don't fall through to the `[N]T` handler below.
 			// Qualify an imported base (`Vec4` -> `vec.Vec4`) so its c_type matches the
-			// materialized struct (`vec__Vec4_f32`) everywhere it appears.
+			// materialized struct (`vec__Vec4_f32`) everywhere it appears. A builtin base
+			// (`int[seg_count]`) cannot be a generic application, so let it fall through to
+			// the fixed-array handler — its bracket is a const/expression length.
 			mut full := typ
 			if !base.contains('.') {
 				if resolved := tc.unique_qualified_type_name(base) {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -140,7 +140,11 @@ pub mut:
 	// Such an alias shares the same per-site static receiver slot as the bare selector, so it
 	// escapes (and corrupts other live callbacks) just like `return c.report`; the escape
 	// checks below treat a reference to one of these locals as a method value. Reset per fn.
-	method_value_locals           map[string]bool
+	method_value_locals map[string]bool
+	// Scope depth at which each method-value local was marked, so a reassignment to a
+	// non-method value only clears the marker when it dominates later uses (same-or-shallower
+	// scope); a reassignment in a deeper conditional/loop scope keeps the maybe-method marker.
+	method_value_local_depth      map[string]int
 	cur_fn_node_id                int = -1
 	expr_type_values              []Type // node_id -> complex/contextual resolved type
 	expr_type_set                 []bool
@@ -1164,6 +1168,7 @@ pub fn (mut tc TypeChecker) check_semantics() {
 				tc.cur_fn_ret_type = tc.parse_type(node.typ)
 				tc.cur_fn_node_id = i
 				tc.method_value_locals = map[string]bool{}
+				tc.method_value_local_depth = map[string]int{}
 				tc.push_scope()
 				for pi in 0 .. node.children_count {
 					p := tc.a.child_node(&node, pi)
@@ -1671,6 +1676,12 @@ fn generic_type_application_parts(typ string) (string, []string, bool) {
 fn is_fixed_array_len_text(inner string) bool {
 	s := inner.trim_space()
 	if s.len == 0 {
+		return false
+	}
+	// A fixed-array length is a single integer expression; a comma means the brackets hold a
+	// generic argument LIST (`Pair[int, &Node]`), not a length. Without this an `&` (or `-`)
+	// that merely leads a later pointer type argument would be read as a length operator.
+	if s.contains(',') {
 		return false
 	}
 	if v_int_literal_value(s) != none {
@@ -2421,6 +2432,18 @@ fn (mut tc TypeChecker) check_decl_assign(id flat.NodeId, node flat.Node) {
 	}
 }
 
+// cur_scope_depth returns the number of enclosing scopes (the current scope's parent-chain
+// length), used to tell a dominating top-level reassignment from one nested in a branch/loop.
+fn (tc &TypeChecker) cur_scope_depth() int {
+	mut d := 0
+	mut s := tc.cur_scope
+	for s != unsafe { nil } {
+		d++
+		s = s.parent
+	}
+	return d
+}
+
 // track_method_value_local records (or clears) a local variable bound to a method value, so a
 // later `return cb` / `arr << cb` aliasing the same per-site static receiver is rejected as an
 // escape just like the bare `return c.report`.
@@ -2434,9 +2457,18 @@ fn (mut tc TypeChecker) track_method_value_local(lhs_id flat.NodeId, rhs_id flat
 	}
 	if tc.expr_is_method_value(rhs_id) {
 		tc.method_value_locals[lhs.value] = true
+		tc.method_value_local_depth[lhs.value] = tc.cur_scope_depth()
 	} else if lhs.value in tc.method_value_locals {
-		// Reassigned to a non-method-value: the alias no longer holds one.
-		tc.method_value_locals.delete(lhs.value)
+		// Reassigned to a non-method-value. Only clear the marker when this reassignment
+		// dominates later uses — at the same or a shallower scope than where the local was
+		// marked. A reassignment in a deeper conditional/loop scope does not run on every path
+		// (`mut cb := c.report; if x { cb = plain }; return cb`), so the local may still hold the
+		// method value; keep the maybe-method marker and let the later escape be rejected.
+		marked_depth := tc.method_value_local_depth[lhs.value] or { 0 }
+		if tc.cur_scope_depth() <= marked_depth {
+			tc.method_value_locals.delete(lhs.value)
+			tc.method_value_local_depth.delete(lhs.value)
+		}
 	}
 }
 

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -2440,11 +2440,12 @@ fn (mut tc TypeChecker) track_method_value_local(lhs_id flat.NodeId, rhs_id flat
 	}
 }
 
-// lvalue_is_local_var reports whether an assignment target is a plain function-local variable —
-// bound under its bare name in the current scope. Non-local storage (a struct field `h.cb`, an
-// array/map element `cbs[i]`, or a module-level global, which lives in file_scope under its
-// qualified name and so misses a bare lookup) is not a local. A method value may alias a local
-// (tracked for a later escape) but must not be stored into anything that outlives the call site.
+// lvalue_is_local_var reports whether an assignment target is safe to receive a method value:
+// the blank discard `_` (stores nothing) or a plain function-local variable bound under its bare
+// name in the current scope. Non-local storage (a struct field `h.cb`, an array/map element
+// `cbs[i]`, or a module-level global, which lives in file_scope under its qualified name and so
+// misses a bare lookup) is not. A method value may alias a local (tracked for a later escape) but
+// must not be stored into anything that outlives the call site.
 fn (tc &TypeChecker) lvalue_is_local_var(lhs_id flat.NodeId) bool {
 	if int(lhs_id) < 0 {
 		return false
@@ -2452,6 +2453,9 @@ fn (tc &TypeChecker) lvalue_is_local_var(lhs_id flat.NodeId) bool {
 	lhs := tc.a.nodes[int(lhs_id)]
 	if lhs.kind != .ident || lhs.value.len == 0 {
 		return false
+	}
+	if lhs.value == '_' {
+		return true
 	}
 	return tc.cur_scope.lookup(lhs.value) != none
 }
@@ -4727,6 +4731,14 @@ fn (mut tc TypeChecker) check_selector(id flat.NodeId, node flat.Node) {
 				// value can only appear inside a function body — escaping to a const/global
 				// is rejected elsewhere — so a non-fn context needs no recording here.
 				tc.method_values_by_fn[tc.cur_fn_node_id] << mkey
+				// Also record the concrete instance key (`Box[int].report`) — distinct from the
+				// open key (`Box[T].report`) above — so monomorphize can gate a generic method's
+				// specialization on *this* instance's method value being reachable (it shares the
+				// open key with every other instance, e.g. `Box[Pair]`).
+				concrete_mkey := '${clean_recv.name}.${node.value}'
+				if concrete_mkey != mkey {
+					tc.method_values_by_fn[tc.cur_fn_node_id] << concrete_mkey
+				}
 			}
 		}
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5255,24 +5255,40 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 	if is_decimal_int_literal(name) {
 		return name.int()
 	}
-	// Simple const arithmetic in string form, e.g. a fixed-array size `[SEGS + 1]` or
-	// `[SEGS+1]`. Split on the rightmost low-precedence operator first (left
-	// associativity); each side is trimmed, so spaced and unspaced forms both work and
-	// each side can itself be a const, a literal, or a nested expression. A leading `-`
-	// (unary) leaves an empty lhs and is skipped.
-	for op in ['+', '-', '*'] {
-		if idx := name.last_index(op) {
-			lhs := name[..idx].trim_space()
-			rhs := name[idx + op.len..].trim_space()
-			if lhs.len > 0 && rhs.len > 0 {
-				l := tc.const_int_value(lhs, seen) or { continue }
-				r := tc.const_int_value(rhs, seen) or { continue }
-				return match op {
-					'+' { l + r }
-					'-' { l - r }
-					else { l * r }
-				}
+	// Simple const arithmetic in string form, e.g. a fixed-array size `[SEGS + 1]`,
+	// `[SEGS+1]`, `[segs / 2]` or `[segs % 4]`. Split on the rightmost operator of the
+	// lowest precedence level present (`+ -`, then `* / % `), so both precedence and left
+	// associativity hold; each side is trimmed (spaced and unspaced forms both work) and
+	// resolved recursively. A leading `-` (unary) leaves an empty lhs and is skipped.
+	for level in [['+', '-'], ['*', '/', '%']] {
+		mut idx := -1
+		mut op := ''
+		for i := 0; i < name.len; i++ {
+			ch := name[i..i + 1]
+			if ch in level {
+				idx = i
+				op = ch
 			}
+		}
+		if idx <= 0 {
+			continue
+		}
+		lhs := name[..idx].trim_space()
+		rhs := name[idx + 1..].trim_space()
+		if lhs.len == 0 || rhs.len == 0 {
+			continue
+		}
+		l := tc.const_int_value(lhs, seen) or { return none }
+		r := tc.const_int_value(rhs, seen) or { return none }
+		if (op == '/' || op == '%') && r == 0 {
+			return none
+		}
+		return match op {
+			'+' { l + r }
+			'-' { l - r }
+			'*' { l * r }
+			'/' { l / r }
+			else { l % r }
 		}
 	}
 	return none
@@ -6595,14 +6611,23 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 						})
 					}
 					if fn_node.value == 'wait' {
-						// `[]thread T`.wait() joins all threads and returns `[]T`.
+						// `[]thread T`.wait() joins all threads and returns `[]T`. A bare
+						// `[]thread` (threads with no return value) joins to `void`. Any
+						// other array element type is not a thread and `.wait()` is
+						// unsupported, so reject it rather than mis-typing the call as the
+						// receiver array (which would emit invalid C joining non-handles).
 						elem := array_elem_type(clean_type)
-						if elem is Struct && elem.name.starts_with('thread ') {
-							return Type(Array{
-								elem_type: tc.parse_type(elem.name[7..])
-							})
+						if elem is Struct {
+							if elem.name == 'thread' {
+								return Type(void_)
+							}
+							if elem.name.starts_with('thread ') {
+								return Type(Array{
+									elem_type: tc.parse_type(elem.name[7..])
+								})
+							}
 						}
-						return base_type
+						return unknown_type('`.wait()` requires an array of threads')
 					}
 					if fn_node.value == 'clone' {
 						return base_type

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5370,10 +5370,10 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 		return tc.const_int_value(expr[1..expr.len - 1].trim_space(), seen)
 	}
 	// Operators grouped by precedence level, lowest first: `+ - | ^` (additive/bitwise),
-	// then `* / % & << >>` (multiplicative/shift), matching V/Go precedence. Split on the
-	// rightmost top-level operator of the lowest level present. Two-character operators
-	// (`<<`, `>>`) are matched before single characters; `idx + op.len` skips the operator.
-	for level in [['+', '-', '|', '^'], ['*', '/', '%', '&', '<<', '>>']] {
+	// then `* / % & << >> >>>` (multiplicative/shift), matching V/Go precedence. Split on
+	// the rightmost top-level operator of the lowest level present. Longer operators are
+	// matched first (`>>>` before `>>`, two-char before one); `idx + op.len` skips it.
+	for level in [['+', '-', '|', '^'], ['*', '/', '%', '&', '<<', '>>', '>>>']] {
 		mut idx := -1
 		mut op := ''
 		mut depth := 0
@@ -5391,6 +5391,13 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 				continue
 			}
 			if depth == 0 {
+				three := if i + 3 <= expr.len { expr[i..i + 3] } else { '' }
+				if three.len == 3 && three in level {
+					idx = i
+					op = three
+					i += 3
+					continue
+				}
 				two := if i + 2 <= expr.len { expr[i..i + 2] } else { '' }
 				if two.len == 2 && two in level {
 					idx = i
@@ -5418,7 +5425,7 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 		if (op == '/' || op == '%') && r == 0 {
 			return none
 		}
-		if (op == '<<' || op == '>>') && (r < 0 || r >= 64) {
+		if (op == '<<' || op == '>>' || op == '>>>') && (r < 0 || r >= 64) {
 			return none
 		}
 		return match op {
@@ -5431,7 +5438,8 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 			'^' { l ^ r }
 			'&' { l & r }
 			'<<' { l << r }
-			else { l >> r }
+			'>>' { l >> r }
+			else { int(u64(l) >> r) }
 		}
 	}
 	return none

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -90,6 +90,8 @@ pub mut:
 	a                     &flat.FlatAst = unsafe { nil }
 	fn_ret_types          map[string]Type
 	fn_param_types        map[string][]Type
+	fn_ret_type_texts     map[string]string   // generic struct method key -> original return type text (e.g. `Box[T].clone` -> `Box[T]`)
+	fn_param_type_texts   map[string][]string // generic struct method key -> original param type texts (receiver first)
 	fn_variadic           map[string]bool
 	fn_implicit_veb_ctx   map[string]bool
 	structs               map[string][]StructField
@@ -382,6 +384,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 				qname := tc.qualify_fn_name(node.value)
 				ret_type := tc.parse_type(node.typ)
 				mut ptypes := []Type{}
+				mut param_texts := []string{}
 				mut is_variadic := false
 				for i in 0 .. node.children_count {
 					child := a.child_node(&node, i)
@@ -390,6 +393,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 							is_variadic = true
 						}
 						ptypes << tc.parse_type(child.typ)
+						param_texts << child.typ
 					}
 				}
 				needs_ctx := tc.fn_needs_implicit_veb_ctx(node)
@@ -398,6 +402,17 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 				if tc.cur_module in ['', 'main', 'builtin'] && qname != node.value
 					&& node.value !in tc.fn_param_types {
 					tc.register_fn_signature(node.value, ret_type, ptypes, is_variadic, needs_ctx)
+				}
+				// A generic struct method (`Box[T].clone`) keeps its original signature
+				// TEXT: the parsed types collapse a non-concrete `Box[T]` to the bare base,
+				// so a concrete call must re-substitute the type arguments from the text to
+				// recover applications like the receiver type in the return position
+				// (`Box[T]` -> `Box[int]`). Only such methods carry `[` in their key.
+				if node.value.contains('[') {
+					tc.fn_ret_type_texts[qname] = node.typ
+					tc.fn_param_type_texts[qname] = param_texts.clone()
+					tc.fn_ret_type_texts[node.value] = node.typ
+					tc.fn_param_type_texts[node.value] = param_texts.clone()
 				}
 			}
 			.struct_decl {
@@ -5242,6 +5257,27 @@ pub fn (tc &TypeChecker) fixed_array_len_value(arr ArrayFixed) ?int {
 	return tc.const_int_value(arr.len_expr, []string{})
 }
 
+// const_expr_paren_wraps_whole reports whether `s` is a single parenthesised group that
+// encloses the entire string (`(a + b)`), as opposed to one that only covers part of it
+// (`(a) + (b)`), so a const length wrapped in redundant parentheses can be unwrapped.
+fn const_expr_paren_wraps_whole(s string) bool {
+	if s.len < 2 || s[0] != `(` || s[s.len - 1] != `)` {
+		return false
+	}
+	mut depth := 0
+	for i := 0; i < s.len; i++ {
+		if s[i] == `(` {
+			depth++
+		} else if s[i] == `)` {
+			depth--
+			if depth == 0 {
+				return i == s.len - 1
+			}
+		}
+	}
+	return false
+}
+
 // const_int_value supports const int value handling for TypeChecker.
 pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 	if name in seen {
@@ -5264,16 +5300,28 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 		return name.int()
 	}
 	// Simple const arithmetic in string form, e.g. a fixed-array size `[SEGS + 1]`,
-	// `[SEGS+1]`, `[segs / 2]` or `[segs % 4]`. Split on the rightmost operator of the
-	// lowest precedence level present (`+ -`, then `* / % `), so both precedence and left
-	// associativity hold; each side is trimmed (spaced and unspaced forms both work) and
-	// resolved recursively. A leading `-` (unary) leaves an empty lhs and is skipped.
+	// `[SEGS+1]`, `[segs / 2]`, `[segs % 4]` or `[2 * (segs + 1)]`. A length wrapped
+	// wholly in parentheses is the inner expression, so strip the outer pair and
+	// re-evaluate. Otherwise split on the rightmost operator of the lowest precedence
+	// level present (`+ -`, then `* / %`) that sits OUTSIDE any parentheses, so a nested
+	// operator (the `+` inside `2 * (segs + 1)`) is not chosen; precedence and left
+	// associativity hold and each side is trimmed and resolved recursively. A leading `-`
+	// (unary) leaves an empty lhs and is skipped.
+	expr := name.trim_space()
+	if const_expr_paren_wraps_whole(expr) {
+		return tc.const_int_value(expr[1..expr.len - 1].trim_space(), seen)
+	}
 	for level in [['+', '-'], ['*', '/', '%']] {
 		mut idx := -1
 		mut op := ''
-		for i := 0; i < name.len; i++ {
-			ch := name[i..i + 1]
-			if ch in level {
+		mut depth := 0
+		for i := 0; i < expr.len; i++ {
+			ch := expr[i..i + 1]
+			if ch == '(' {
+				depth++
+			} else if ch == ')' {
+				depth--
+			} else if depth == 0 && ch in level {
 				idx = i
 				op = ch
 			}
@@ -5281,8 +5329,8 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 		if idx <= 0 {
 			continue
 		}
-		lhs := name[..idx].trim_space()
-		rhs := name[idx + 1..].trim_space()
+		lhs := expr[..idx].trim_space()
+		rhs := expr[idx + 1..].trim_space()
 		if lhs.len == 0 || rhs.len == 0 {
 			continue
 		}
@@ -6715,6 +6763,13 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 							unknown_type('unknown return type for `${mname}`')
 						}
 					}
+					// A method on a concrete generic instance (`Box[int].clone`) is
+					// registered under the open form (`Box[T].clone`); resolve it so the
+					// call types as the substituted return (`Box[int]`) rather than the
+					// bare base the collapsed open signature would yield.
+					if ci := tc.resolve_generic_struct_method(clean_type.name, fn_node.value) {
+						return ci.return_type
+					}
 				}
 				if clean_type is Interface {
 					mname := '${clean_type.name}.${fn_node.value}'
@@ -7348,9 +7403,19 @@ pub fn (tc &TypeChecker) resolve_generic_struct_method(type_name string, method 
 	}
 	generic_key := '${base}[${params.join(', ')}].${method}'
 	ret := tc.fn_ret_types[generic_key] or { return none }
-	sub_ret := tc.substitute_generic_type(ret, concrete_args, params)
+	// Prefer substituting the original signature TEXT: parsing `Box[T]` collapses the
+	// non-concrete application to the bare `Box`, so substituting the already-parsed type
+	// cannot recover `Box[int]`. Re-substituting the text and re-parsing does.
+	mut sub_ret := tc.substitute_generic_type(ret, concrete_args, params)
+	if ret_text := tc.fn_ret_type_texts[generic_key] {
+		sub_ret = tc.parse_type(subst_generic_text(ret_text, concrete_args, params))
+	}
 	mut sub_params := []Type{}
-	if ptypes := tc.fn_param_types[generic_key] {
+	if param_texts := tc.fn_param_type_texts[generic_key] {
+		for pt in param_texts {
+			sub_params << tc.parse_type(subst_generic_text(pt, concrete_args, params))
+		}
+	} else if ptypes := tc.fn_param_types[generic_key] {
 		for pt in ptypes {
 			sub_params << tc.substitute_generic_type(pt, concrete_args, params)
 		}
@@ -7363,6 +7428,69 @@ pub fn (tc &TypeChecker) resolve_generic_struct_method(type_name string, method 
 		is_variadic:  tc.fn_variadic[generic_key] or { false }
 		params_known: true
 	}
+}
+
+// subst_generic_text textually substitutes the generic parameter names `params` with the
+// concrete argument texts `args` inside a type text, preserving the generic application
+// form so a method signature mentioning the receiver type (`Box[T]`) becomes the concrete
+// instance (`Box[int]`) when re-parsed, instead of collapsing to the bare base. Prefix and
+// container forms (`&`, `mut`, `?`, `!`, `...`, `[]`, `map[`, `[N]`) recurse into the
+// element type; a bare parameter name is replaced with its argument.
+fn subst_generic_text(typ string, args []string, params []string) string {
+	clean := typ.trim_space()
+	if clean.len == 0 || args.len == 0 || params.len != args.len {
+		return clean
+	}
+	if clean.starts_with('&') {
+		return '&' + subst_generic_text(clean[1..], args, params)
+	}
+	if clean.starts_with('mut ') {
+		return 'mut ' + subst_generic_text(clean[4..], args, params)
+	}
+	if clean.starts_with('?') {
+		return '?' + subst_generic_text(clean[1..], args, params)
+	}
+	if clean.starts_with('!') {
+		return '!' + subst_generic_text(clean[1..], args, params)
+	}
+	if clean.starts_with('...') {
+		return '...' + subst_generic_text(clean[3..], args, params)
+	}
+	if clean.starts_with('[]') {
+		return '[]' + subst_generic_text(clean[2..], args, params)
+	}
+	if clean.starts_with('map[') {
+		bracket_end := find_matching_bracket(clean, 3)
+		if bracket_end < clean.len {
+			key := subst_generic_text(clean[4..bracket_end], args, params)
+			val := subst_generic_text(clean[bracket_end + 1..], args, params)
+			return 'map[${key}]${val}'
+		}
+	}
+	if clean.starts_with('[') {
+		bracket_end := find_matching_bracket(clean, 0)
+		if bracket_end < clean.len {
+			return clean[..bracket_end + 1] + subst_generic_text(clean[bracket_end +
+				1..], args, params)
+		}
+	}
+	bracket := clean.index_u8(`[`)
+	if bracket > 0 {
+		bracket_end := find_matching_bracket(clean, bracket)
+		if bracket_end < clean.len {
+			mut parts := []string{}
+			for part in split_params(clean[bracket + 1..bracket_end]) {
+				parts << subst_generic_text(part, args, params)
+			}
+			return clean[..bracket] + '[' + parts.join(', ') + ']' + clean[bracket_end + 1..]
+		}
+	}
+	for i, p in params {
+		if clean == p {
+			return args[i]
+		}
+	}
+	return clean
 }
 
 // split_generic_arg_list splits a comma-separated generic argument list at the

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -7023,8 +7023,16 @@ fn (tc &TypeChecker) c_type_uncached(t Type) string {
 		return 'Array'
 	}
 	if t is ArrayFixed {
-		len_text := if t.len_expr.len > 0 { t.len_expr } else { t.len.str() }
-		return 'Array_fixed_${c_type_name_part(tc.c_type(t.elem_type))}_${c_type_name_part(len_text)}'
+		// Prefer the evaluated length so a const-expression size (`[segs + 1]f32`)
+		// names the same type as its literal equivalent (`[5]f32`) and never leaks
+		// operators into the identifier; fall back to the sanitized raw expression.
+		len_name := if resolved := tc.fixed_array_len_value(t) {
+			resolved.str()
+		} else {
+			len_text := if t.len_expr.len > 0 { t.len_expr } else { t.len.str() }
+			c_type_name_part(len_text)
+		}
+		return 'Array_fixed_${c_type_name_part(tc.c_type(t.elem_type))}_${len_name}'
 	}
 	if t is Channel {
 		return 'chan'
@@ -7120,11 +7128,28 @@ fn (tc &TypeChecker) optional_c_type_name(base_type Type) string {
 	return 'Optional_${inner_ct.replace('*', 'ptr').replace(' ', '_')}'
 }
 
-// c_type_name_part supports c type name part handling for types.
-fn c_type_name_part(s string) string {
-	return s.replace('*', 'ptr').replace(' ', '_').replace(',', '_').replace('|', '_').replace(':',
-		'_').replace('.', '_').replace('[', '_').replace(']', '_').replace('(', '_').replace(')',
-		'_').replace('-', '_')
+// c_type_name_part turns a C type or length expression into a fragment that is safe
+// to embed inside a C identifier: `*` becomes `ptr` (so pointer payloads stay
+// distinguishable), and every other character that is not a letter, digit, or `_`
+// becomes `_`. This keeps const-expression fixed-array lengths (e.g. `segs + 1`) and
+// pointer return types (`Foo*`) from producing invalid identifiers such as
+// `Array_fixed_f32_segs_+_1` or `__v_thread_arr_wait_Foo*`.
+pub fn c_type_name_part(s string) string {
+	mut b := []u8{cap: s.len + 2}
+	for i := 0; i < s.len; i++ {
+		c := s[i]
+		if c == `*` {
+			b << `p`
+			b << `t`
+			b << `r`
+		} else if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`)
+			|| (c >= `0` && c <= `9`) || c == `_` {
+			b << c
+		} else {
+			b << `_`
+		}
+	}
+	return b.bytestr()
 }
 
 // resolve_type_name_for_method resolves resolve type name for method information for types.

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1670,6 +1670,56 @@ fn is_decimal_int_literal(s string) bool {
 	return true
 }
 
+// v_int_literal_value parses a complete V integer literal — decimal, hex (`0x`), octal
+// (`0o`), or binary (`0b`), with optional `_` digit separators — to its value. Returns
+// none when `s` is not a whole integer literal (a const name, an expression, etc.), so
+// const-length folding accepts `0xF & 6` / `[0b1100 >> 1]int`, not just decimal text.
+fn v_int_literal_value(s string) ?int {
+	if s.len == 0 {
+		return none
+	}
+	t := s.replace('_', '')
+	if t.len == 0 {
+		return none
+	}
+	mut base := 10
+	mut digits := t
+	if t.len >= 2 && t[0] == `0` {
+		c := t[1]
+		if c == `x` || c == `X` {
+			base = 16
+			digits = t[2..]
+		} else if c == `o` || c == `O` {
+			base = 8
+			digits = t[2..]
+		} else if c == `b` || c == `B` {
+			base = 2
+			digits = t[2..]
+		}
+	}
+	if digits.len == 0 {
+		return none
+	}
+	mut value := 0
+	for ch in digits {
+		mut d := 0
+		if ch >= `0` && ch <= `9` {
+			d = int(ch - `0`)
+		} else if ch >= `a` && ch <= `f` {
+			d = int(ch - `a`) + 10
+		} else if ch >= `A` && ch <= `F` {
+			d = int(ch - `A`) + 10
+		} else {
+			return none
+		}
+		if d >= base {
+			return none
+		}
+		value = value * base + d
+	}
+	return value
+}
+
 // is_bare_generic_param reports whether is bare generic param applies in types.
 fn is_bare_generic_param(typ string) bool {
 	return typ.len == 1 && typ[0] >= `A` && typ[0] <= `Z`
@@ -2080,11 +2130,16 @@ fn (mut tc TypeChecker) check_node(id flat.NodeId) {
 		tc.check_select_stmt(node)
 		return
 	}
-	// A method value stored in an array escapes the single-use guarantee of its per-site
-	// static receiver, so reject `[obj.method]` literals and `arr << obj.method` appends.
+	// A method value stored in a container escapes the single-use guarantee of its per-site
+	// static receiver, so reject `[obj.method]` / `arr << obj.method` / `{'k': obj.method}`.
 	if node.kind == .array_literal {
 		for i in 0 .. node.children_count {
 			tc.reject_stored_method_value(tc.a.child(&node, i))
+		}
+	} else if node.kind == .map_init {
+		// children alternate key, value, key, value, ...; check the value positions.
+		for j := 1; j < node.children_count; j += 2 {
+			tc.reject_stored_method_value(tc.a.child(&node, j))
 		}
 	} else if node.kind == .infix && node.op == .left_shift && node.children_count >= 2 {
 		if unwrap_pointer(tc.resolve_type(tc.a.child(&node, 0))) is Array {
@@ -2516,6 +2571,12 @@ fn (mut tc TypeChecker) resolve_lvalue_type(lhs_id flat.NodeId) Type {
 
 // check_return validates check return state for types.
 fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
+	// A returned method value escapes the function, where its per-site static receiver
+	// can't keep multiple returned callbacks distinct (a factory `fn bind(c) fn () int {
+	// return c.report }`); reject it rather than emitting invalid C.
+	for i in 0 .. node.children_count {
+		tc.reject_stored_method_value(tc.a.child(&node, i))
+	}
 	expected := tc.cur_fn_ret_type
 	if expected is Void {
 		if node.children_count > 0 && tc.should_diagnose(id) {
@@ -4465,6 +4526,9 @@ fn (mut tc TypeChecker) check_struct_init(id flat.NodeId, node flat.Node) {
 				continue
 			}
 			value_id := tc.a.child(&field, 0)
+			// A method value stored in a struct field escapes the evaluation site (several
+			// instances from the same `Foo{cb: obj.method}` site would share one receiver).
+			tc.reject_stored_method_value(value_id)
 			mut expected := Type(void_)
 			if field.value.len > 0 {
 				mut found := false
@@ -4527,14 +4591,17 @@ fn (tc &TypeChecker) expr_is_method_value(id flat.NodeId) bool {
 	return false
 }
 
-// reject_stored_method_value reports a clear error when a method value is stored into an
-// array, where the per-site static receiver slot cannot keep multiple instances distinct
-// (e.g. `cbs << obj.method` in a loop would make every callback use the last receiver).
-// Without this the value reaches cgen and emits C referencing an unsupported helper.
+// reject_stored_method_value reports a clear error when a method value escapes its
+// evaluation site — stored in an array/map/struct field or returned. The per-site static
+// receiver slot cannot keep several live instances distinct, so a factory like
+// `fn bind(c Counter) fn () int { return c.report }` (or storage in a loop) would make
+// every escaped callback use the last receiver; without this the value also reaches cgen
+// and emits C referencing an unsupported helper. Pass method values directly as a
+// callback argument instead (a real closure capture is not yet supported).
 fn (mut tc TypeChecker) reject_stored_method_value(id flat.NodeId) {
 	if tc.expr_is_method_value(id) && tc.should_diagnose(id) {
 		tc.record_error(.assignment_mismatch,
-			'a method value (`obj.method`) cannot be stored in an array (no closure capture); pass it directly as a callback argument',
+			'a method value (`obj.method`) cannot escape its call site (no closure capture); pass it directly as a callback argument',
 			id)
 	}
 }
@@ -5354,8 +5421,8 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 			return tc.const_int_expr(expr_id, next_seen)
 		}
 	}
-	if is_decimal_int_literal(name) {
-		return name.int()
+	if v := v_int_literal_value(name) {
+		return v
 	}
 	// Simple const arithmetic in string form, e.g. a fixed-array size `[SEGS + 1]`,
 	// `[SEGS+1]`, `[segs / 2]`, `[segs % 4]` or `[2 * (segs + 1)]`. A length wrapped
@@ -5453,8 +5520,8 @@ fn (tc &TypeChecker) const_int_expr(id flat.NodeId, seen []string) ?int {
 	node := tc.a.nodes[int(id)]
 	match node.kind {
 		.int_literal {
-			if is_decimal_int_literal(node.value) {
-				return node.value.int()
+			if v := v_int_literal_value(node.value) {
+				return v
 			}
 		}
 		.ident {
@@ -7595,6 +7662,39 @@ fn subst_generic_text(typ string, args []string, params []string) string {
 		if bracket_end < clean.len {
 			return clean[..bracket_end + 1] + subst_generic_text(clean[bracket_end +
 				1..], args, params)
+		}
+	}
+	if clean.starts_with('fn(') || clean.starts_with('fn (') {
+		// A function-type parameter (`fn (T) int`) carries the generic params in its own
+		// signature; substitute each parameter and the return type so a `Box[string].apply`
+		// callback is expected as `fn (string) int`, not the unsubstituted `fn (T) int`.
+		params_start := clean.index_u8(`(`) + 1
+		mut depth := 1
+		mut params_end := params_start
+		for params_end < clean.len {
+			if clean[params_end] == `(` {
+				depth++
+			} else if clean[params_end] == `)` {
+				depth--
+				if depth == 0 {
+					break
+				}
+			}
+			params_end++
+		}
+		if params_end < clean.len {
+			mut fn_parts := []string{}
+			params_str := clean[params_start..params_end]
+			if params_str.trim_space().len > 0 {
+				for part in split_params(params_str) {
+					fn_parts << subst_generic_text(normalize_fn_type_param_text(part), args, params)
+				}
+			}
+			ret_str := clean[params_end + 1..].trim_space()
+			if ret_str.len > 0 {
+				return 'fn(${fn_parts.join(', ')}) ${subst_generic_text(ret_str, args, params)}'
+			}
+			return 'fn(${fn_parts.join(', ')})'
 		}
 	}
 	bracket := clean.index_u8(`[`)

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1900,6 +1900,12 @@ fn (tc &TypeChecker) match_covers_all_enum_variants(node flat.Node) bool {
 	} else {
 		return false
 	}
+	// A `[flag]` enum value can hold combined or zero bits (`.read | .write`, `0`) that
+	// no single-field branch covers, so listing every field is NOT exhaustive — such a
+	// match needs an explicit `else`.
+	if enum_name in tc.flag_enums {
+		return false
+	}
 	all_fields := tc.enum_fields[enum_name] or { return false }
 	if all_fields.len == 0 {
 		return false

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4857,8 +4857,13 @@ fn (mut tc TypeChecker) resolve_expr(id flat.NodeId, expected Type) Type {
 	// A bare generic struct literal (`Box{...}` / `&Box{...}`) adopts a matching concrete
 	// expected instance (`Box[int]` / `&Box[int]`), so `fn make() Box[int] { return
 	// Box{...} }` and bare literals passed/assigned where a concrete instance is expected
-	// type-check and carry the concrete type into codegen.
-	if node.kind == .struct_init && tc.bare_generic_literal_adopts(node.value, expected)
+	// type-check and carry the concrete type into codegen. A *value* literal only adopts a
+	// *value* expectation: `bare_generic_literal_adopts` unwraps the pointer, so without
+	// the `expected !is Pointer` guard `return Box{...}` would be accepted for an expected
+	// `&Box[int]`, and cgen would emit a `Box_int` value where a `Box_int*` is required.
+	// The pointer case is the `prefix .amp` (`&Box{...}`) path below.
+	if node.kind == .struct_init && expected !is Pointer
+		&& tc.bare_generic_literal_adopts(node.value, expected)
 		&& tc.generic_literal_fields_compatible(node, expected) {
 		tc.register_synth_type(id, expected_raw)
 		return expected_raw

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -135,7 +135,12 @@ pub mut:
 	// markused, and (unlike a call) routes a value-context selector through check_selector.
 	// markused seeds these (keeping the wrapper-only method out of the dead-code pruner)
 	// only when their enclosing function is reachable.
-	method_values_by_fn           map[int][]string // enclosing fn node id -> method-value `Type.method` keys
+	method_values_by_fn map[int][]string // enclosing fn node id -> method-value `Type.method` keys
+	// Local variables bound to a method value (`cb := c.report`) in the current function.
+	// Such an alias shares the same per-site static receiver slot as the bare selector, so it
+	// escapes (and corrupts other live callbacks) just like `return c.report`; the escape
+	// checks below treat a reference to one of these locals as a method value. Reset per fn.
+	method_value_locals           map[string]bool
 	cur_fn_node_id                int = -1
 	expr_type_values              []Type // node_id -> complex/contextual resolved type
 	expr_type_set                 []bool
@@ -1158,6 +1163,7 @@ pub fn (mut tc TypeChecker) check_semantics() {
 				tc.check_decl_type_strings(flat.NodeId(i), node)
 				tc.cur_fn_ret_type = tc.parse_type(node.typ)
 				tc.cur_fn_node_id = i
+				tc.method_value_locals = map[string]bool{}
 				tc.push_scope()
 				for pi in 0 .. node.children_count {
 					p := tc.a.child_node(&node, pi)
@@ -1650,10 +1656,38 @@ fn generic_type_application_parts(typ string) (string, []string, bool) {
 		return '', []string{}, false
 	}
 	inner := typ[bracket + 1..bracket_end].trim_space()
-	if is_decimal_int_literal(inner) {
+	if is_fixed_array_len_text(inner) {
 		return '', []string{}, false
 	}
 	return typ[..bracket], split_params(inner), true
+}
+
+// is_fixed_array_len_text reports whether a postfix `Base[inner]` bracket holds a fixed-array
+// length rather than a generic type argument. `ArrayFixed.name()` renders the length as a decimal
+// (`u8[16]`), a non-decimal literal (`u8[0x10]`), or the source length expression (`u8[segs + 1]`);
+// a generic argument is always a type, never a number or arithmetic expression. Recognising all
+// three keeps such a postfix name parsing as a fixed array (e.g. when `[]thread T.wait()` recovers
+// the spawned return type) instead of a bogus generic application.
+fn is_fixed_array_len_text(inner string) bool {
+	s := inner.trim_space()
+	if s.len == 0 {
+		return false
+	}
+	if v_int_literal_value(s) != none {
+		return true
+	}
+	for i in 0 .. s.len {
+		c := s[i]
+		if c in [`+`, `*`, `/`, `%`, `|`, `^`, `<`, `>`] {
+			return true
+		}
+		// A leading `-`/`&` is a negative literal / pointer-type argument; elsewhere they are the
+		// subtraction / bitwise-and operators of a length expression.
+		if (c == `-` || c == `&`) && i > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // is_decimal_int_literal reports whether is decimal int literal applies in types.
@@ -2382,7 +2416,27 @@ fn (mut tc TypeChecker) check_decl_assign(id flat.NodeId, node flat.Node) {
 			}
 		}
 		tc.insert_decl_lhs(lhs_id, expected)
+		tc.track_method_value_local(lhs_id, rhs_id)
 		i += 2
+	}
+}
+
+// track_method_value_local records (or clears) a local variable bound to a method value, so a
+// later `return cb` / `arr << cb` aliasing the same per-site static receiver is rejected as an
+// escape just like the bare `return c.report`.
+fn (mut tc TypeChecker) track_method_value_local(lhs_id flat.NodeId, rhs_id flat.NodeId) {
+	if int(lhs_id) < 0 {
+		return
+	}
+	lhs := tc.a.nodes[int(lhs_id)]
+	if lhs.kind != .ident || lhs.value.len == 0 || lhs.value == '_' {
+		return
+	}
+	if tc.expr_is_method_value(rhs_id) {
+		tc.method_value_locals[lhs.value] = true
+	} else if lhs.value in tc.method_value_locals {
+		// Reassigned to a non-method-value: the alias no longer holds one.
+		tc.method_value_locals.delete(lhs.value)
 	}
 }
 
@@ -2467,6 +2521,9 @@ fn (mut tc TypeChecker) check_assign(id flat.NodeId, node flat.Node) {
 		if !tc.type_compatible(rhs_type, lhs_type) {
 			tc.type_mismatch(.assignment_mismatch,
 				'cannot assign `${rhs_type.name()}` to `${lhs_type.name()}`', id)
+		}
+		if node.kind == .assign {
+			tc.track_method_value_local(lhs_id, rhs_id)
 		}
 		i += 2
 	}
@@ -4570,6 +4627,11 @@ fn (tc &TypeChecker) expr_is_method_value(id flat.NodeId) bool {
 		return false
 	}
 	node := tc.a.nodes[int(id)]
+	// A local bound to a method value (`cb := c.report`) carries the same escape hazard as the
+	// bare selector, so a reference to it counts as a method value here too.
+	if node.kind == .ident {
+		return node.value in tc.method_value_locals
+	}
 	if node.kind != .selector || node.children_count == 0 {
 		return false
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5436,11 +5436,16 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 	if const_expr_paren_wraps_whole(expr) {
 		return tc.const_int_value(expr[1..expr.len - 1].trim_space(), seen)
 	}
-	// Operators grouped by precedence level, lowest first: `+ - | ^` (additive/bitwise),
-	// then `* / % & << >> >>>` (multiplicative/shift), matching V/Go precedence. Split on
-	// the rightmost top-level operator of the lowest level present. Longer operators are
-	// matched first (`>>>` before `>>`, two-char before one); `idx + op.len` skips it.
-	for level in [['+', '-', '|', '^'], ['*', '/', '%', '&', '<<', '>>', '>>>']] {
+	// Operators grouped by precedence level, lowest first, MATCHING the v3 parser's binding
+	// power (token.left_binding_power) so a length text recovered from source folds to the
+	// same value as the AST const evaluator below: `|` < `^` < `<< >> >>>` < `+ -` <
+	// `* / % &`. The parser keeps shifts below additive operators (so `arr << a + b` appends
+	// `a + b`), hence `1 << 2 + 1` groups as `1 << (2 + 1)` — split on `<<` before `+` here
+	// too, not the reverse. Split on the rightmost top-level operator of the lowest level
+	// present; longer operators match first (`>>>` before `>>`, two-char before one) and
+	// `idx + op.len` skips the operator.
+	for level in [['|'], ['^'], ['<<', '>>', '>>>'], ['+', '-'],
+		['*', '/', '%', '&']] {
 		mut idx := -1
 		mut op := ''
 		mut depth := 0

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5316,26 +5316,47 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 	if const_expr_paren_wraps_whole(expr) {
 		return tc.const_int_value(expr[1..expr.len - 1].trim_space(), seen)
 	}
-	for level in [['+', '-'], ['*', '/', '%']] {
+	// Operators grouped by precedence level, lowest first: `+ - | ^` (additive/bitwise),
+	// then `* / % & << >>` (multiplicative/shift), matching V/Go precedence. Split on the
+	// rightmost top-level operator of the lowest level present. Two-character operators
+	// (`<<`, `>>`) are matched before single characters; `idx + op.len` skips the operator.
+	for level in [['+', '-', '|', '^'], ['*', '/', '%', '&', '<<', '>>']] {
 		mut idx := -1
 		mut op := ''
 		mut depth := 0
-		for i := 0; i < expr.len; i++ {
+		mut i := 0
+		for i < expr.len {
 			ch := expr[i..i + 1]
 			if ch == '(' {
 				depth++
-			} else if ch == ')' {
-				depth--
-			} else if depth == 0 && ch in level {
-				idx = i
-				op = ch
+				i++
+				continue
 			}
+			if ch == ')' {
+				depth--
+				i++
+				continue
+			}
+			if depth == 0 {
+				two := if i + 2 <= expr.len { expr[i..i + 2] } else { '' }
+				if two.len == 2 && two in level {
+					idx = i
+					op = two
+					i += 2
+					continue
+				}
+				if ch in level {
+					idx = i
+					op = ch
+				}
+			}
+			i++
 		}
 		if idx <= 0 {
 			continue
 		}
 		lhs := expr[..idx].trim_space()
-		rhs := expr[idx + 1..].trim_space()
+		rhs := expr[idx + op.len..].trim_space()
 		if lhs.len == 0 || rhs.len == 0 {
 			continue
 		}
@@ -5344,12 +5365,20 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 		if (op == '/' || op == '%') && r == 0 {
 			return none
 		}
+		if (op == '<<' || op == '>>') && (r < 0 || r >= 64) {
+			return none
+		}
 		return match op {
 			'+' { l + r }
 			'-' { l - r }
 			'*' { l * r }
 			'/' { l / r }
-			else { l % r }
+			'%' { l % r }
+			'|' { l | r }
+			'^' { l ^ r }
+			'&' { l & r }
+			'<<' { l << r }
+			else { l >> r }
 		}
 	}
 	return none
@@ -5383,6 +5412,7 @@ fn (tc &TypeChecker) const_int_expr(id flat.NodeId, seen []string) ?int {
 			return match node.op {
 				.minus { -value }
 				.plus { value }
+				.bit_not { ~value }
 				else { none }
 			}
 		}
@@ -5413,6 +5443,33 @@ fn (tc &TypeChecker) const_int_expr(id flat.NodeId, seen []string) ?int {
 						return none
 					}
 					return left % right
+				}
+				.amp {
+					return left & right
+				}
+				.pipe {
+					return left | right
+				}
+				.xor {
+					return left ^ right
+				}
+				.left_shift {
+					if right < 0 || right >= 64 {
+						return none
+					}
+					return left << right
+				}
+				.right_shift {
+					if right < 0 || right >= 64 {
+						return none
+					}
+					return left >> right
+				}
+				.right_shift_unsigned {
+					if right < 0 || right >= 64 {
+						return none
+					}
+					return int(u64(left) >> right)
 				}
 				else {
 					return none

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -130,12 +130,11 @@ pub mut:
 	errors              []TypeError
 	resolved_call_names []string // node_id -> resolved function name
 	resolved_call_set   []bool
-	// `Type.method` keys for methods used as *values* (`recv.method` passed as a
-	// callback). Recorded during semantic checking — which has full scope/type info,
-	// runs before markused, and (unlike a call) routes a value-context selector through
-	// check_selector — so markused can keep these methods (reachable only via a wrapper)
-	// out of the dead-code pruner.
-	method_value_targets          map[string]bool
+	// Methods used as *values* (`recv.method` passed as a callback), recorded per enclosing
+	// function during semantic checking — which has full scope/type info, runs before
+	// markused, and (unlike a call) routes a value-context selector through check_selector.
+	// markused seeds these (keeping the wrapper-only method out of the dead-code pruner)
+	// only when their enclosing function is reachable.
 	method_values_by_fn           map[int][]string // enclosing fn node id -> method-value `Type.method` keys
 	cur_fn_node_id                int = -1
 	expr_type_values              []Type // node_id -> complex/contextual resolved type
@@ -4635,16 +4634,13 @@ fn (mut tc TypeChecker) check_selector(id flat.NodeId, node flat.Node) {
 					mkey = ci.name
 				}
 			}
-			if mkey in tc.fn_param_types {
+			if mkey in tc.fn_param_types && tc.cur_fn_node_id >= 0 {
 				// Record per enclosing function so markused marks it only when that
-				// function is reachable (over-marking unreachable method values can pull
-				// in code that crashes cgen). Non-fn contexts (const inits) are always
-				// emitted, so mark those unconditionally.
-				if tc.cur_fn_node_id >= 0 {
-					tc.method_values_by_fn[tc.cur_fn_node_id] << mkey
-				} else {
-					tc.method_value_targets[mkey] = true
-				}
+				// function is reachable; over-marking an unreachable method value can pull
+				// in (and fail to compile) an otherwise-unused specialization. A method
+				// value can only appear inside a function body — escaping to a const/global
+				// is rejected elsewhere — so a non-fn context needs no recording here.
+				tc.method_values_by_fn[tc.cur_fn_node_id] << mkey
 			}
 		}
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5137,10 +5137,12 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 	if is_decimal_int_literal(name) {
 		return name.int()
 	}
-	// Simple const arithmetic in string form, e.g. a fixed-array size `[SEGS + 1]`.
-	// Split on the rightmost low-precedence operator first (left associativity); each
-	// side can itself be a const, a literal, or a nested expression.
-	for op in [' + ', ' - ', ' * '] {
+	// Simple const arithmetic in string form, e.g. a fixed-array size `[SEGS + 1]` or
+	// `[SEGS+1]`. Split on the rightmost low-precedence operator first (left
+	// associativity); each side is trimmed, so spaced and unspaced forms both work and
+	// each side can itself be a const, a literal, or a nested expression. A leading `-`
+	// (unary) leaves an empty lhs and is skipped.
+	for op in ['+', '-', '*'] {
 		if idx := name.last_index(op) {
 			lhs := name[..idx].trim_space()
 			rhs := name[idx + op.len..].trim_space()
@@ -5148,8 +5150,8 @@ pub fn (tc &TypeChecker) const_int_value(name string, seen []string) ?int {
 				l := tc.const_int_value(lhs, seen) or { continue }
 				r := tc.const_int_value(rhs, seen) or { continue }
 				return match op {
-					' + ' { l + r }
-					' - ' { l - r }
+					'+' { l + r }
+					'-' { l - r }
 					else { l * r }
 				}
 			}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -2440,6 +2440,22 @@ fn (mut tc TypeChecker) track_method_value_local(lhs_id flat.NodeId, rhs_id flat
 	}
 }
 
+// lvalue_is_local_var reports whether an assignment target is a plain function-local variable —
+// bound under its bare name in the current scope. Non-local storage (a struct field `h.cb`, an
+// array/map element `cbs[i]`, or a module-level global, which lives in file_scope under its
+// qualified name and so misses a bare lookup) is not a local. A method value may alias a local
+// (tracked for a later escape) but must not be stored into anything that outlives the call site.
+fn (tc &TypeChecker) lvalue_is_local_var(lhs_id flat.NodeId) bool {
+	if int(lhs_id) < 0 {
+		return false
+	}
+	lhs := tc.a.nodes[int(lhs_id)]
+	if lhs.kind != .ident || lhs.value.len == 0 {
+		return false
+	}
+	return tc.cur_scope.lookup(lhs.value) != none
+}
+
 // check_multi_return_decl_assign validates check multi return decl assign state for types.
 fn (mut tc TypeChecker) check_multi_return_decl_assign(id flat.NodeId, node flat.Node) bool {
 	if node.children_count < 3 {
@@ -2522,8 +2538,16 @@ fn (mut tc TypeChecker) check_assign(id flat.NodeId, node flat.Node) {
 			tc.type_mismatch(.assignment_mismatch,
 				'cannot assign `${rhs_type.name()}` to `${lhs_type.name()}`', id)
 		}
-		if node.kind == .assign {
-			tc.track_method_value_local(lhs_id, rhs_id)
+		if node.kind in [.assign, .selector_assign, .index_assign] {
+			if tc.expr_is_method_value(rhs_id) && !tc.lvalue_is_local_var(lhs_id) {
+				// Storing a method value into a struct field (`h.cb = ..`), an array/map element
+				// (`cbs[i] = ..`), or a global lets it outlive the per-site static `_mvctx_N`
+				// receiver slot, which the next evaluation of the same site overwrites — so every
+				// stored callback would use the last receiver. Reject it like the other escapes.
+				tc.reject_stored_method_value(rhs_id)
+			} else {
+				tc.track_method_value_local(lhs_id, rhs_id)
+			}
 		}
 		i += 2
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -575,6 +575,9 @@ fn (tc &TypeChecker) const_type_from_initializer(name string, typ Type) Type {
 		return typ
 	}
 	expr_id := tc.const_exprs[name] or { return typ }
+	if int(expr_id) < 0 || int(expr_id) >= tc.a.nodes.len {
+		return typ
+	}
 	expr := tc.a.nodes[int(expr_id)]
 	if expr.kind != .call || expr.children_count == 0 {
 		return typ
@@ -1432,6 +1435,18 @@ fn (mut tc TypeChecker) check_type_string_for_unsupported_generics(typ string, n
 		tc.check_type_string_for_unsupported_generics(clean[7..], node_id, generic_params)
 		return
 	}
+	if clean == 'thread' || clean == 'chan' {
+		return
+	}
+	if clean.starts_with('thread ') {
+		// `thread T` is a thread handle; only its element type T needs checking.
+		tc.check_type_string_for_unsupported_generics(clean[7..], node_id, generic_params)
+		return
+	}
+	if clean.starts_with('chan ') {
+		tc.check_type_string_for_unsupported_generics(clean[5..], node_id, generic_params)
+		return
+	}
 	if clean.starts_with('...') {
 		tc.check_type_string_for_unsupported_generics(clean[3..], node_id, generic_params)
 		return
@@ -1844,12 +1859,57 @@ fn (tc &TypeChecker) stmt_definitely_returns(id flat.NodeId) bool {
 					return false
 				}
 			}
-			return has_else
+			// All branches return. An explicit `else` makes the match exhaustive;
+			// otherwise it is still exhaustive when it covers every variant of the
+			// subject enum (V requires match statements to be exhaustive).
+			return has_else || tc.match_covers_all_enum_variants(node)
 		}
 		else {
 			return false
 		}
 	}
+}
+
+// match_covers_all_enum_variants reports whether a `match` over an enum subject
+// lists every variant of that enum (so it is exhaustive without an `else`).
+fn (tc &TypeChecker) match_covers_all_enum_variants(node flat.Node) bool {
+	if node.children_count < 2 {
+		return false
+	}
+	subject_type := unwrap_pointer(tc.resolve_type(tc.a.child(&node, 0)))
+	mut enum_name := ''
+	if subject_type is Enum {
+		enum_name = subject_type.name
+	} else {
+		return false
+	}
+	all_fields := tc.enum_fields[enum_name] or { return false }
+	if all_fields.len == 0 {
+		return false
+	}
+	mut covered := map[string]bool{}
+	for i in 1 .. node.children_count {
+		branch := tc.a.child_node(&node, i)
+		if branch.kind != .match_branch {
+			return false
+		}
+		if branch.value == 'else' {
+			return true
+		}
+		n_conds := branch.value.int()
+		for j in 0 .. n_conds {
+			cond := tc.a.child_node(branch, j)
+			if cond.kind == .enum_val {
+				covered[cond.value.all_after_last('.')] = true
+			}
+		}
+	}
+	for f in all_fields {
+		if f !in covered {
+			return false
+		}
+	}
+	return true
 }
 
 // match_branch_definitely_returns
@@ -1973,9 +2033,50 @@ fn (mut tc TypeChecker) check_node(id flat.NodeId) {
 		tc.check_array_init(node)
 		return
 	}
+	if node.kind == .select_stmt {
+		tc.check_select_stmt(node)
+		return
+	}
 
 	for i in 0 .. node.children_count {
 		tc.check_node(tc.a.child(&node, i))
+	}
+}
+
+// check_select_stmt validates a `select { ... }` statement. A receive branch
+// `val := <-ch` binds `val` (the channel's element type) in the branch body's
+// scope; other branches (sends, bare conditions, `else`) are checked as-is.
+fn (mut tc TypeChecker) check_select_stmt(node flat.Node) {
+	for i in 0 .. node.children_count {
+		branch_id := tc.a.child(&node, i)
+		if !tc.valid_node_id(branch_id) {
+			continue
+		}
+		branch := tc.a.nodes[int(branch_id)]
+		if branch.kind != .select_branch {
+			tc.check_node(branch_id)
+			continue
+		}
+		tc.push_scope()
+		mut body_start := 0
+		if branch.value == 'recv' && branch.children_count >= 2 {
+			// children[0] = bound var ident, children[1] = `<-ch` receive expr.
+			var_id := tc.a.child(&branch, 0)
+			recv_id := tc.a.child(&branch, 1)
+			tc.check_node(recv_id)
+			elem_type := tc.resolve_type(recv_id)
+			if tc.valid_node_id(var_id) {
+				var_node := tc.a.nodes[int(var_id)]
+				if var_node.kind == .ident && var_node.value.len > 0 {
+					tc.cur_scope.insert(var_node.value, elem_type)
+				}
+			}
+			body_start = 2
+		}
+		for j in body_start .. branch.children_count {
+			tc.check_node(tc.a.child(&branch, j))
+		}
+		tc.pop_scope()
 	}
 }
 
@@ -3505,6 +3606,30 @@ fn array_elem_type(arr Array) Type {
 	return arr.elem_type
 }
 
+// array_like_elem_type returns the element type of an `Array` or `ArrayFixed`.
+fn array_like_elem_type(t Type) ?Type {
+	if t is Array {
+		return t.elem_type
+	}
+	if t is ArrayFixed {
+		return t.elem_type
+	}
+	return none
+}
+
+// if_branch_types_compatible reports whether two if-expression branch types are
+// compatible. Bare array literals (`[a, b, c]`) resolve to a fixed `T[n]`, but V
+// treats them as dynamic `[]T`; two array branches with compatible element types
+// must therefore not be flagged as a mismatch merely because their lengths differ.
+fn (tc &TypeChecker) if_branch_types_compatible(a Type, b Type) bool {
+	if tc.type_compatible(a, b) || tc.type_compatible(b, a) {
+		return true
+	}
+	a_elem := array_like_elem_type(a) or { return false }
+	b_elem := array_like_elem_type(b) or { return false }
+	return tc.type_compatible(a_elem, b_elem) || tc.type_compatible(b_elem, a_elem)
+}
+
 // fixed_array_elem_type supports fixed array elem type handling for types.
 fn fixed_array_elem_type(arr ArrayFixed) Type {
 	return arr.elem_type
@@ -3672,8 +3797,7 @@ fn (mut tc TypeChecker) check_if_expr(id flat.NodeId, node flat.Node) {
 	}
 	if then_type !is Void && else_type !is Void {
 		if tc.branch_has_value_tail(then_id) && tc.branch_has_value_tail(tc.a.child(&node, 2))
-			&& !tc.type_compatible(then_type, else_type)
-			&& !tc.type_compatible(else_type, then_type) {
+			&& !tc.if_branch_types_compatible(then_type, else_type) {
 			if tc.should_diagnose(id) {
 				tc.record_error(.if_branch_mismatch,
 					'if-expression branch type mismatch: then `${then_type.name()}` vs else `${else_type.name()}`',
@@ -3954,6 +4078,105 @@ fn choose_if_tail_type(current Type, next Type) Type {
 		return next
 	}
 	return current
+}
+
+// branch_tail_expr_id returns the value-producing tail expression of a branch
+// body (a `block` or `match_branch`), unwrapping a trailing `expr_stmt`. Returns
+// `empty_node` when the branch has no expression tail.
+fn (tc &TypeChecker) branch_tail_expr_id(id flat.NodeId) flat.NodeId {
+	if !tc.valid_node_id(id) {
+		return flat.empty_node
+	}
+	node := tc.a.nodes[int(id)]
+	mut last_id := flat.empty_node
+	if node.kind == .block {
+		if node.children_count == 0 {
+			return flat.empty_node
+		}
+		last_id = tc.a.child(&node, node.children_count - 1)
+	} else if node.kind == .match_branch {
+		body_start := if node.value == 'else' { 0 } else { node.value.int() }
+		if node.children_count <= body_start {
+			return flat.empty_node
+		}
+		last_id = tc.a.child(&node, node.children_count - 1)
+	} else {
+		return id
+	}
+	if !tc.valid_node_id(last_id) {
+		return flat.empty_node
+	}
+	last := tc.a.nodes[int(last_id)]
+	if last.kind == .expr_stmt {
+		if last.children_count > 0 {
+			return tc.a.child(&last, 0)
+		}
+		return flat.empty_node
+	}
+	return last_id
+}
+
+// branches_compatible_with propagates `expected` into every value-producing tail
+// of a match/if expression (so context-dependent tails such as enum shorthand
+// `.foo`, `none`, or fn literals type against it instead of defaulting to e.g.
+// `int`). Returns true when the node is a match/if expression and every branch
+// tail is compatible with `expected`.
+fn (mut tc TypeChecker) branches_compatible_with(id flat.NodeId, expected Type) bool {
+	if !tc.valid_node_id(id) {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	if node.kind == .match_stmt {
+		mut saw_branch := false
+		for i in 1 .. node.children_count {
+			branch_id := tc.a.child(&node, i)
+			if !tc.valid_node_id(branch_id) {
+				continue
+			}
+			if tc.a.nodes[int(branch_id)].kind != .match_branch {
+				continue
+			}
+			tail := tc.branch_tail_expr_id(branch_id)
+			if !tc.valid_node_id(tail) {
+				return false
+			}
+			saw_branch = true
+			actual := tc.resolve_expr(tail, expected)
+			if !tc.receiver_compatible(actual, expected) {
+				return false
+			}
+		}
+		return saw_branch
+	}
+	if node.kind == .if_expr {
+		// A value if-expression needs an else branch (child 2). children: cond,
+		// then-block, else (block or nested if_expr).
+		if node.children_count <= 2 {
+			return false
+		}
+		then_tail := tc.branch_tail_expr_id(tc.a.child(&node, 1))
+		if !tc.valid_node_id(then_tail) {
+			return false
+		}
+		then_actual := tc.resolve_expr(then_tail, expected)
+		if !tc.receiver_compatible(then_actual, expected) {
+			return false
+		}
+		else_id := tc.a.child(&node, 2)
+		if !tc.valid_node_id(else_id) {
+			return false
+		}
+		if tc.a.nodes[int(else_id)].kind == .if_expr {
+			return tc.branches_compatible_with(else_id, expected)
+		}
+		else_tail := tc.branch_tail_expr_id(else_id)
+		if !tc.valid_node_id(else_tail) {
+			return false
+		}
+		else_actual := tc.resolve_expr(else_tail, expected)
+		return tc.receiver_compatible(else_actual, expected)
+	}
+	return false
 }
 
 // extract_smartcasts supports extract smartcasts handling for TypeChecker.
@@ -4367,11 +4590,46 @@ fn (mut tc TypeChecker) resolve_expr(id flat.NodeId, expected Type) Type {
 		return Type(int_)
 	}
 	if node.kind == .array_literal {
-		if expected is Array && node.children_count == 0 {
-			tc.register_synth_type(id, expected_raw)
-			return expected_raw
+		mut elem_expected := Type(void_)
+		mut expected_is_array := false
+		if expected is Array {
+			elem_expected = array_elem_type(expected)
+			expected_is_array = true
+		} else if expected is ArrayFixed {
+			elem_expected = fixed_array_elem_type(expected)
+			expected_is_array = true
 		}
-		if expected is ArrayFixed && node.children_count == 0 {
+		if expected_is_array {
+			// Empty literal `[]` simply adopts the expected array type.
+			if node.children_count == 0 {
+				tc.register_synth_type(id, expected_raw)
+				return expected_raw
+			}
+			// Non-empty literal: propagate the expected element type down to each
+			// element so context-dependent elements (enum shorthand `[.foo]`, `none`,
+			// fn literals) type against it instead of defaulting to a fixed `int[N]`.
+			// Adopt the expected array type when every element fits.
+			mut all_ok := true
+			for i in 0 .. node.children_count {
+				child_id := tc.a.child(&node, i)
+				elem_actual := tc.resolve_expr(child_id, elem_expected)
+				if !tc.receiver_compatible(elem_actual, elem_expected) {
+					all_ok = false
+					break
+				}
+			}
+			if all_ok {
+				tc.register_synth_type(id, expected_raw)
+				return expected_raw
+			}
+		}
+	}
+	if node.kind == .match_stmt || node.kind == .if_expr {
+		// Match/if used as a value expression: propagate the expected type into
+		// each branch tail so enum-shorthand / `none` / fn-literal tails type
+		// against it (e.g. `return match s { 'a' { .foo } ... }` with an enum
+		// return type), then adopt the expected type when every branch fits.
+		if expected !is Void && expected !is Unknown && tc.branches_compatible_with(id, expected) {
 			tc.register_synth_type(id, expected_raw)
 			return expected_raw
 		}
@@ -5384,6 +5642,14 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 			elem_type: Type(void_)
 		})
 	}
+	if typ.starts_with('thread ') || typ == 'thread' {
+		// A thread handle. The element type (the spawned fn's return type) is kept
+		// in the struct name (`thread T`) so `array_of_threads.wait()` can recover
+		// `[]T`. The handle itself lowers to `void*` in C (see c_type).
+		return Type(Struct{
+			name: typ
+		})
+	}
 	if typ.starts_with('?') {
 		return Type(OptionType{
 			base_type: tc.parse_type(typ[1..])
@@ -6007,6 +6273,16 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 							})
 						})
 					}
+					if fn_node.value == 'wait' {
+						// `[]thread T`.wait() joins all threads and returns `[]T`.
+						elem := array_elem_type(clean_type)
+						if elem is Struct && elem.name.starts_with('thread ') {
+							return Type(Array{
+								elem_type: tc.parse_type(elem.name[7..])
+							})
+						}
+						return base_type
+					}
 					if fn_node.value == 'clone' {
 						return base_type
 					}
@@ -6486,6 +6762,11 @@ fn (tc &TypeChecker) resolve_index_type(node flat.Node) Type {
 		if inner0 is Alias {
 			inner = inner0.base_type
 		}
+		if inner is Map {
+			// `mut m map[K]V` params resolve to a pointer-to-map; indexing still
+			// yields the value type V, not the whole map.
+			return map_value_type(inner)
+		}
 		if inner is Array {
 			return array_elem_type(inner)
 		}
@@ -6584,7 +6865,7 @@ fn (tc &TypeChecker) c_type_uncached(t Type) string {
 		return 'Optional'
 	}
 	if t is Struct {
-		if t.name == 'thread' || t.name.ends_with('.thread') {
+		if t.name == 'thread' || t.name.ends_with('.thread') || t.name.starts_with('thread ') {
 			return 'void*'
 		}
 		if t.name.starts_with('C.') {


### PR DESCRIPTION
A batch of v3 (C backend) codegen correctness fixes, developed and verified by compiling a large real-world Metal application end-to-end. All changes are confined to `vlib/v3/`.

## Verification
- **Self-host stable**: `v3 → v4 → v5 → v6`, with **v5 == v6 byte-identical**.
- **No regressions** in `vlib/v3/tests`.
- The target app builds with the v3 C backend and renders correctly (Metal), matching V1-built behavior.

## Highlights (latest two fixes)

**1. `&T{...}` (address of a struct literal) heap allocation outside return position**
`&T{...}` is always a heap allocation in V, in any context. v3 only routed it through `gen_heap_struct_init` when it appeared in a `return`; elsewhere (e.g. `arr << &T{...}`) the generic fall-through lowered it to `&<stack temp>`, so the array stored a dangling stack pointer that read stale and was later clobbered once the frame died. Now handled in all contexts.

**2. `${enum}` string interpolation printed the integer ordinal instead of the field name**
v3 generated no enum `.str()`, so `wrap_string_conversion` fell back to `strconv__format_int`. The transformer now routes enum stringification to a synthesized `<Enum>__autostr` helper, and cgen emits it (a `switch` mapping each field value to its name literal; integer fallback for out-of-range / combined-flag values). A user-defined `.str()` still takes precedence. Verified against V1 for explicit values, `[]enum`, user-`str()` override, and out-of-range.

## Other fixes in this batch
- Fixed-array return wrapping + typedef ordering; fixed-array-of-fixed-array element typing.
- Generic struct-init resolution (`Vec4[f32]{...}` → correct base type, incl. return position).
- Method-value closures; method-level generics (`decompress[K,D,F]`).
- `IError` string interpolation; `[]thread T .wait()` resolution.
- `mut` arg passed to a fn-pointer param now correctly takes its address.
- Misc C codegen conflicts (name mangling, heap-alloc helpers).

The first three commits (`dok1`, `doka fixes`, `doka ok`) are the accumulated batch; the final commit is the two highlighted fixes above. Suitable for squash-merge.