### PR TITLE
v3: extend C oracle baseline

### DIFF
--- a/vlib/os/os_nix.c.v
+++ b/vlib/os/os_nix.c.v
@@ -6,6 +6,7 @@ module os
 #include <sys/utsname.h>
 #include <sys/types.h>
 #include <sys/statvfs.h>
+#include <sys/wait.h>
 #include <utime.h>
 #insert "@VEXEROOT/vlib/os/execute_capture_nix.h"
 

--- a/vlib/sokol/sapp/sapp_linux.c.v
+++ b/vlib/sokol/sapp/sapp_linux.c.v
@@ -462,14 +462,14 @@ const map_private = 2
 #include <X11/Xcursor/Xcursor.h>
 
 // X11 types
-pub type XID = u64
-pub type Atom = u64
-pub type Window = u64
-pub type Colormap = u64
-pub type Cursor = u64
-pub type KeySym = u64
-pub type Time = u64
-pub type VisualID = u64
+pub type XID = C.XID
+pub type Atom = C.Atom
+pub type Window = C.Window
+pub type Colormap = C.Colormap
+pub type Cursor = C.Cursor
+pub type KeySym = C.KeySym
+pub type Time = C.Time
+pub type VisualID = C.VisualID
 
 // X11 types are defined by X11 headers (#preinclude above)
 // Forward declarations for V type checking only
@@ -845,7 +845,7 @@ fn C.XSetWMProtocols(display &C.Display, window Window, protocols &Atom, count i
 fn C.XSetWMNormalHints(display &C.Display, window Window, hints &C.XSizeHints) int
 fn C.XAllocSizeHints() &C.XSizeHints
 fn C.XGetWindowAttributes(display &C.Display, window Window, attrs &C.XWindowAttributes) int
-fn C.XGetWindowProperty(display &C.Display, window Window, property Atom, long_offset i64, long_length i64, delete int, req_type Atom, actual_type &Atom, actual_format &int, nitems &u64, bytes_after &u64, prop &&&u8) int
+fn C.XGetWindowProperty(display &C.Display, window Window, property Atom, long_offset i64, long_length i64, delete int, req_type Atom, actual_type &Atom, actual_format &int, nitems &usize, bytes_after &usize, prop &&u8) int
 fn C.XChangeProperty(display &C.Display, window Window, property Atom, @type Atom, format int, mode int, data &u8, nelements int) int
 fn C.Xutf8SetWMProperties(display &C.Display, window Window, window_name &char, icon_name &char, argv &&char, argc int, normal_hints voidptr, wm_hints voidptr, class_hints voidptr)
 fn C.XSetSelectionOwner(display &C.Display, selection Atom, owner Window, time Time)

--- a/vlib/sokol/sapp/sapp_linux.c.v
+++ b/vlib/sokol/sapp/sapp_linux.c.v
@@ -462,14 +462,14 @@ const map_private = 2
 #include <X11/Xcursor/Xcursor.h>
 
 // X11 types
-pub type XID = C.XID
-pub type Atom = C.Atom
-pub type Window = C.Window
-pub type Colormap = C.Colormap
-pub type Cursor = C.Cursor
-pub type KeySym = C.KeySym
-pub type Time = C.Time
-pub type VisualID = C.VisualID
+pub type XID = u64
+pub type Atom = u64
+pub type Window = u64
+pub type Colormap = u64
+pub type Cursor = u64
+pub type KeySym = u64
+pub type Time = u64
+pub type VisualID = u64
 
 // X11 types are defined by X11 headers (#preinclude above)
 // Forward declarations for V type checking only
@@ -845,7 +845,7 @@ fn C.XSetWMProtocols(display &C.Display, window Window, protocols &Atom, count i
 fn C.XSetWMNormalHints(display &C.Display, window Window, hints &C.XSizeHints) int
 fn C.XAllocSizeHints() &C.XSizeHints
 fn C.XGetWindowAttributes(display &C.Display, window Window, attrs &C.XWindowAttributes) int
-fn C.XGetWindowProperty(display &C.Display, window Window, property Atom, long_offset i64, long_length i64, delete int, req_type Atom, actual_type &Atom, actual_format &int, nitems &usize, bytes_after &usize, prop &&u8) int
+fn C.XGetWindowProperty(display &C.Display, window Window, property Atom, long_offset i64, long_length i64, delete int, req_type Atom, actual_type &Atom, actual_format &int, nitems &u64, bytes_after &u64, prop &&u8) int
 fn C.XChangeProperty(display &C.Display, window Window, property Atom, @type Atom, format int, mode int, data &u8, nelements int) int
 fn C.Xutf8SetWMProperties(display &C.Display, window Window, window_name &char, icon_name &char, argv &&char, argc int, normal_hints voidptr, wm_hints voidptr, class_hints voidptr)
 fn C.XSetSelectionOwner(display &C.Display, selection Atom, owner Window, time Time)

--- a/vlib/sokol/sapp/sapp_linux.c.v
+++ b/vlib/sokol/sapp/sapp_linux.c.v
@@ -462,14 +462,15 @@ const map_private = 2
 #include <X11/Xcursor/Xcursor.h>
 
 // X11 types
-pub type XID = u64
-pub type Atom = u64
-pub type Window = u64
-pub type Colormap = u64
-pub type Cursor = u64
-pub type KeySym = u64
-pub type Time = u64
-pub type VisualID = u64
+pub type XID = C.XID
+pub type Atom = C.Atom
+pub type Window = C.Window
+pub type Colormap = C.Colormap
+pub type Cursor = C.Cursor
+pub type KeySym = C.KeySym
+pub type Time = C.Time
+pub type VisualID = C.VisualID
+pub type XlibULong = C.XID
 
 // X11 types are defined by X11 headers (#preinclude above)
 // Forward declarations for V type checking only
@@ -845,7 +846,7 @@ fn C.XSetWMProtocols(display &C.Display, window Window, protocols &Atom, count i
 fn C.XSetWMNormalHints(display &C.Display, window Window, hints &C.XSizeHints) int
 fn C.XAllocSizeHints() &C.XSizeHints
 fn C.XGetWindowAttributes(display &C.Display, window Window, attrs &C.XWindowAttributes) int
-fn C.XGetWindowProperty(display &C.Display, window Window, property Atom, long_offset i64, long_length i64, delete int, req_type Atom, actual_type &Atom, actual_format &int, nitems &u64, bytes_after &u64, prop &&u8) int
+fn C.XGetWindowProperty(display &C.Display, window Window, property Atom, long_offset i64, long_length i64, delete int, req_type Atom, actual_type &Atom, actual_format &int, nitems &XlibULong, bytes_after &XlibULong, prop &&u8) int
 fn C.XChangeProperty(display &C.Display, window Window, property Atom, @type Atom, format int, mode int, data &u8, nelements int) int
 fn C.Xutf8SetWMProperties(display &C.Display, window Window, window_name &char, icon_name &char, argv &&char, argc int, normal_hints voidptr, wm_hints voidptr, class_hints voidptr)
 fn C.XSetSelectionOwner(display &C.Display, selection Atom, owner Window, time Time)

--- a/vlib/sokol/sapp/sapp_structs.c.v
+++ b/vlib/sokol/sapp/sapp_structs.c.v
@@ -230,20 +230,26 @@ pub:
 
 pub type Swapchain = C.sapp_swapchain
 
+pub type Event = C.sapp_event
+
+pub type FnEventCb = fn (const_event &Event)
+
+pub type FnEventUserDataCb = fn (const_event &Event, user_data voidptr)
+
 @[typedef]
 pub struct C.sapp_desc {
 pub mut:
 	// these are the user-provided callbacks without user data
-	init_cb    fn ()       = unsafe { nil }
-	frame_cb   fn ()       = unsafe { nil }
-	cleanup_cb fn ()       = unsafe { nil }
-	event_cb   fn (&Event) = unsafe { nil } // &sapp_event
+	init_cb    fn ()     = unsafe { nil }
+	frame_cb   fn ()     = unsafe { nil }
+	cleanup_cb fn ()     = unsafe { nil }
+	event_cb   FnEventCb = unsafe { nil } // const sapp_event*
 
 	user_data           voidptr // these are the user-provided callbacks with user data
-	init_userdata_cb    fn (voidptr)         = unsafe { nil }
-	frame_userdata_cb   fn (voidptr)         = unsafe { nil }
-	cleanup_userdata_cb fn (voidptr)         = unsafe { nil }
-	event_userdata_cb   fn (&Event, voidptr) = unsafe { nil }
+	init_userdata_cb    fn (voidptr)      = unsafe { nil }
+	frame_userdata_cb   fn (voidptr)      = unsafe { nil }
+	cleanup_userdata_cb fn (voidptr)      = unsafe { nil }
+	event_userdata_cb   FnEventUserDataCb = unsafe { nil }
 
 	width                        int       // the preferred width of the window / canvas
 	height                       int       // the preferred height of the window / canvas
@@ -298,8 +304,6 @@ pub mut:
 	framebuffer_width  int                         // = window_width * dpi_scale
 	framebuffer_height int                         // = window_height * dpi_scale
 }
-
-pub type Event = C.sapp_event
 
 pub fn (e &Event) str() string {
 	return 'evt: frame_count=${e.frame_count}, type=${EventType(e.type)}'

--- a/vlib/sokol/sapp/sapp_structs.c.v
+++ b/vlib/sokol/sapp/sapp_structs.c.v
@@ -230,26 +230,20 @@ pub:
 
 pub type Swapchain = C.sapp_swapchain
 
-pub type Event = C.sapp_event
-
-pub type FnEventCb = fn (const_event &Event)
-
-pub type FnEventUserDataCb = fn (const_event &Event, user_data voidptr)
-
 @[typedef]
 pub struct C.sapp_desc {
 pub mut:
 	// these are the user-provided callbacks without user data
-	init_cb    fn ()     = unsafe { nil }
-	frame_cb   fn ()     = unsafe { nil }
-	cleanup_cb fn ()     = unsafe { nil }
-	event_cb   FnEventCb = unsafe { nil } // const sapp_event*
+	init_cb    fn ()       = unsafe { nil }
+	frame_cb   fn ()       = unsafe { nil }
+	cleanup_cb fn ()       = unsafe { nil }
+	event_cb   fn (&Event) = unsafe { nil } // &sapp_event
 
 	user_data           voidptr // these are the user-provided callbacks with user data
-	init_userdata_cb    fn (voidptr)      = unsafe { nil }
-	frame_userdata_cb   fn (voidptr)      = unsafe { nil }
-	cleanup_userdata_cb fn (voidptr)      = unsafe { nil }
-	event_userdata_cb   FnEventUserDataCb = unsafe { nil }
+	init_userdata_cb    fn (voidptr)         = unsafe { nil }
+	frame_userdata_cb   fn (voidptr)         = unsafe { nil }
+	cleanup_userdata_cb fn (voidptr)         = unsafe { nil }
+	event_userdata_cb   fn (&Event, voidptr) = unsafe { nil }
 
 	width                        int       // the preferred width of the window / canvas
 	height                       int       // the preferred height of the window / canvas
@@ -304,6 +298,8 @@ pub mut:
 	framebuffer_width  int                         // = window_width * dpi_scale
 	framebuffer_height int                         // = window_height * dpi_scale
 }
+
+pub type Event = C.sapp_event
 
 pub fn (e &Event) str() string {
 	return 'evt: frame_count=${e.frame_count}, type=${EventType(e.type)}'

--- a/vlib/sokol/sapp/sapp_x11_linux.v
+++ b/vlib/sokol/sapp/sapp_x11_linux.v
@@ -1365,8 +1365,8 @@ fn x11_get_clipboard_string() &char {
 		mut data := &u8(nil)
 		mut actual_type := Atom(0)
 		mut actual_format := 0
-		mut item_count := u64(0)
-		mut bytes_after := u64(0)
+		mut item_count := usize(0)
+		mut bytes_after := usize(0)
 		C.XGetWindowProperty(g_sapp_state.x11.display, event.xselection.requestor,
 			event.xselection.property, 0, 0x7fffffff, x_true, g_sapp_state.x11.utf8_string,
 			&actual_type, &actual_format, &item_count, &bytes_after, &&u8(&data))
@@ -1529,13 +1529,13 @@ fn x11_keyrelease_repeat(keycode int) {
 
 // === Window property helpers ===
 
-fn x11_get_window_property(window Window, property Atom, req_type Atom, value &&u8) u64 {
+fn x11_get_window_property(window Window, property Atom, req_type Atom, value &&u8) usize {
 	mut actual_type := Atom(0)
 	mut actual_format := 0
-	mut item_count := u64(0)
-	mut bytes_after := u64(0)
+	mut item_count := usize(0)
+	mut bytes_after := usize(0)
 	C.XGetWindowProperty(g_sapp_state.x11.display, window, property, 0, 0x7fffffff, x_false,
-		req_type, &actual_type, &actual_format, &item_count, &bytes_after, unsafe { &&&u8(value) })
+		req_type, &actual_type, &actual_format, &item_count, &bytes_after, value)
 	return item_count
 }
 
@@ -1610,7 +1610,7 @@ fn x11_parse_dropped_files_list(src &char) bool {
 					digits[1] = u8(*(p + 1))
 					digits[2] = 0
 					p = &char(usize(p) + 2)
-					dst_chr = u8(C.strtol(&char(&digits[0]), &char(0), 16))
+					dst_chr = u8(C.strtol(&char(&digits[0]), nil, 16))
 				}
 			}
 		} else {
@@ -1880,7 +1880,7 @@ fn x11_on_clientmessage(event &C.XEvent) {
 			if g_sapp_state.x11.xdnd.version > x11_xdnd_version {
 				return
 			}
-			mut count := u64(0)
+			mut count := usize(0)
 			mut formats := &Atom(nil)
 			if is_list {
 				count = x11_get_window_property(g_sapp_state.x11.xdnd.source,

--- a/vlib/sokol/sapp/sapp_x11_linux.v
+++ b/vlib/sokol/sapp/sapp_x11_linux.v
@@ -1365,20 +1365,21 @@ fn x11_get_clipboard_string() &char {
 		mut data := &u8(nil)
 		mut actual_type := Atom(0)
 		mut actual_format := 0
-		mut item_count := usize(0)
-		mut bytes_after := usize(0)
+		mut item_count := u64(0)
+		mut bytes_after := u64(0)
 		C.XGetWindowProperty(g_sapp_state.x11.display, event.xselection.requestor,
 			event.xselection.property, 0, 0x7fffffff, x_true, g_sapp_state.x11.utf8_string,
 			&actual_type, &actual_format, &item_count, &bytes_after, &&u8(&data))
 		if data == nil {
 			return nil
 		}
-		if item_count >= usize(g_sapp_state.clipboard.buf_size) {
+		item_size := usize(item_count)
+		if item_size >= usize(g_sapp_state.clipboard.buf_size) {
 			C.XFree(data)
 			return nil
 		}
-		C.memcpy(g_sapp_state.clipboard.buffer, data, usize(item_count))
-		g_sapp_state.clipboard.buffer[item_count] = 0
+		C.memcpy(g_sapp_state.clipboard.buffer, data, item_size)
+		g_sapp_state.clipboard.buffer[item_size] = 0
 		C.XFree(data)
 		return g_sapp_state.clipboard.buffer
 	}
@@ -1532,11 +1533,11 @@ fn x11_keyrelease_repeat(keycode int) {
 fn x11_get_window_property(window Window, property Atom, req_type Atom, value &&u8) usize {
 	mut actual_type := Atom(0)
 	mut actual_format := 0
-	mut item_count := usize(0)
-	mut bytes_after := usize(0)
+	mut item_count := u64(0)
+	mut bytes_after := u64(0)
 	C.XGetWindowProperty(g_sapp_state.x11.display, window, property, 0, 0x7fffffff, x_false,
 		req_type, &actual_type, &actual_format, &item_count, &bytes_after, value)
-	return item_count
+	return usize(item_count)
 }
 
 fn x11_get_window_state() int {

--- a/vlib/sokol/sapp/sapp_x11_linux.v
+++ b/vlib/sokol/sapp/sapp_x11_linux.v
@@ -1365,8 +1365,8 @@ fn x11_get_clipboard_string() &char {
 		mut data := &u8(nil)
 		mut actual_type := Atom(0)
 		mut actual_format := 0
-		mut item_count := u64(0)
-		mut bytes_after := u64(0)
+		mut item_count := XlibULong(0)
+		mut bytes_after := XlibULong(0)
 		C.XGetWindowProperty(g_sapp_state.x11.display, event.xselection.requestor,
 			event.xselection.property, 0, 0x7fffffff, x_true, g_sapp_state.x11.utf8_string,
 			&actual_type, &actual_format, &item_count, &bytes_after, &&u8(&data))
@@ -1533,8 +1533,8 @@ fn x11_keyrelease_repeat(keycode int) {
 fn x11_get_window_property(window Window, property Atom, req_type Atom, value &&u8) usize {
 	mut actual_type := Atom(0)
 	mut actual_format := 0
-	mut item_count := u64(0)
-	mut bytes_after := u64(0)
+	mut item_count := XlibULong(0)
+	mut bytes_after := XlibULong(0)
 	C.XGetWindowProperty(g_sapp_state.x11.display, window, property, 0, 0x7fffffff, x_false,
 		req_type, &actual_type, &actual_format, &item_count, &bytes_after, value)
 	return usize(item_count)

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -161,14 +161,16 @@ pub mut:
 	children        []NodeId
 	user_code_start int
 	disabled_fns    map[string]bool
+	export_fn_names map[string]string
 }
 
 // new creates a FlatAst value for flat.
 pub fn FlatAst.new() FlatAst {
 	return FlatAst{
-		nodes:        []Node{cap: 256}
-		children:     []NodeId{cap: 512}
-		disabled_fns: map[string]bool{}
+		nodes:           []Node{cap: 256}
+		children:        []NodeId{cap: 512}
+		disabled_fns:    map[string]bool{}
+		export_fn_names: map[string]string{}
 	}
 }
 

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3448,6 +3448,11 @@ fn (mut g FlatGen) emit_global_inits() {
 		if cqname == 'g_main_argc' || cqname == 'g_main_argv' {
 			continue
 		}
+		if mod := g.global_modules[qname] {
+			g.tc.cur_module = mod
+		} else {
+			g.tc.cur_module = old_module
+		}
 		if typ := g.global_types[qname] {
 			if typ is types.ArrayFixed {
 				target := c_name(qname)
@@ -3457,9 +3462,6 @@ fn (mut g FlatGen) emit_global_inits() {
 		}
 		if !g.is_safe_global_init(val_id) {
 			continue
-		}
-		if mod := g.global_modules[qname] {
-			g.tc.cur_module = mod
 		}
 		tmp_sb := g.sb
 		tmp_line_start := g.line_start

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -460,11 +460,7 @@ fn (mut g FlatGen) collect_gen_info() {
 				g.modules[alias] = mod_name
 			}
 			if cur_module.len > 0 && mod_name.len > 0 {
-				dep_module := if mod_name.contains('.') {
-					mod_name.all_after_last('.')
-				} else {
-					mod_name
-				}
+				dep_module := mod_name
 				if cur_module !in g.module_imports {
 					g.module_imports[cur_module] = []string{}
 				}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -86,8 +86,9 @@ struct FixedArrayTypedefInfo {
 }
 
 struct CDirective {
-	module string
-	text   string
+	module        string
+	text          string
+	before_import bool
 }
 
 // was_parallel reports whether the last fn codegen actually ran across threads.
@@ -310,6 +311,7 @@ fn node_kind_id(node flat.Node) int {
 fn (mut g FlatGen) collect_gen_info() {
 	mut cur_module := ''
 	mut cur_file := ''
+	mut seen_import_in_file := false
 	for node_idx in 0 .. g.a.nodes.len {
 		node := g.a.nodes[node_idx]
 		kind_id := node_kind_id(node)
@@ -319,6 +321,7 @@ fn (mut g FlatGen) collect_gen_info() {
 			g.tc.cur_file = cur_file
 			cur_module = ''
 			g.tc.cur_module = cur_module
+			seen_import_in_file = false
 			continue
 		}
 		if kind_id == 73 {
@@ -358,7 +361,7 @@ fn (mut g FlatGen) collect_gen_info() {
 			}
 			continue
 		}
-		if g.collect_c_directive(cur_module, node, cur_file) {
+		if g.collect_c_directive(cur_module, node, cur_file, !seen_import_in_file) {
 			continue
 		}
 		if node.kind == .directive && node.value == 'flag' && node.typ.len > 0 {
@@ -454,6 +457,7 @@ fn (mut g FlatGen) collect_gen_info() {
 			continue
 		}
 		if kind_id == 72 {
+			seen_import_in_file = true
 			alias := node.typ.clone()
 			mod_name := node.value.clone()
 			if alias.len > 0 && mod_name.len > 0 {
@@ -475,7 +479,7 @@ fn (mut g FlatGen) collect_gen_info() {
 	g.collect_const_init_order_from_files()
 }
 
-fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, source_file string) bool {
+fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, source_file string, before_import bool) bool {
 	if node.kind != .directive {
 		return false
 	}
@@ -493,24 +497,26 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 		if include_arg.contains('prealloc_atomics.h') || include_arg.contains('stdatomic') {
 			return true
 		}
-		g.add_c_directive(module_name, '#include ${include_arg}')
+		g.add_c_directive(module_name, '#include ${include_arg}', before_import)
 		return true
 	}
 	if node.value in ['define', 'undef', 'ifdef', 'ifndef', 'if', 'elif', 'else', 'endif', 'pragma',
 		'error', 'warning'] {
-		g.add_c_directive(module_name, c_preprocessor_directive_line(node.value, node.typ))
+		g.add_c_directive(module_name, c_preprocessor_directive_line(node.value, node.typ),
+			before_import)
 		return true
 	}
 	return false
 }
 
-fn (mut g FlatGen) add_c_directive(module_name string, text string) {
+fn (mut g FlatGen) add_c_directive(module_name string, text string, before_import bool) {
 	if text.len == 0 {
 		return
 	}
 	g.c_directives << CDirective{
-		module: module_name
-		text:   text
+		module:        module_name
+		text:          text
+		before_import: before_import
 	}
 }
 
@@ -612,14 +618,14 @@ fn (g &FlatGen) visit_module_init(mod string, module_to_init map[string]string, 
 }
 
 fn (g &FlatGen) ordered_c_directives() []string {
-	mut directives_by_module := map[string][]string{}
+	mut directives_by_module := map[string][]CDirective{}
 	mut module_order := []string{}
 	for directive in g.c_directives {
 		if directive.module !in directives_by_module {
-			directives_by_module[directive.module] = []string{}
+			directives_by_module[directive.module] = []CDirective{}
 			module_order << directive.module
 		}
-		directives_by_module[directive.module] << directive.text
+		directives_by_module[directive.module] << directive
 	}
 	mut result := []string{}
 	mut visiting := map[string]bool{}
@@ -630,11 +636,17 @@ fn (g &FlatGen) ordered_c_directives() []string {
 	return dedupe_top_level_c_includes(result)
 }
 
-fn (g &FlatGen) visit_c_directive_module(mod string, directives_by_module map[string][]string, mut visiting map[string]bool, mut visited map[string]bool, mut result []string) {
+fn (g &FlatGen) visit_c_directive_module(mod string, directives_by_module map[string][]CDirective, mut visiting map[string]bool, mut visited map[string]bool, mut result []string) {
 	if mod in visited || mod in visiting {
 		return
 	}
 	visiting[mod] = true
+	directives := directives_by_module[mod] or { []CDirective{} }
+	for directive in directives {
+		if directive.before_import {
+			result << directive.text
+		}
+	}
 	for dep in g.module_imports[mod] or { []string{} } {
 		if dep in directives_by_module {
 			g.visit_c_directive_module(dep, directives_by_module, mut visiting, mut visited, mut
@@ -643,8 +655,10 @@ fn (g &FlatGen) visit_c_directive_module(mod string, directives_by_module map[st
 	}
 	visiting.delete(mod)
 	visited[mod] = true
-	for directive in directives_by_module[mod] or { []string{} } {
-		result << directive
+	for directive in directives {
+		if !directive.before_import {
+			result << directive.text
+		}
 	}
 }
 

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1956,6 +1956,10 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			}
 		}
 		.ident {
+			if c_fn_name := g.test_user_main_fn_value_c_name(id, node) {
+				g.write(c_fn_name)
+				return
+			}
 			looked_up := g.tc.cur_scope.lookup(node.value) or { types.Type(types.void_) }
 			is_local := looked_up !is types.Void
 			const_name := if !is_local { g.const_ref_name(node.value) } else { '' }

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -13,6 +13,7 @@ mut:
 	a                            &flat.FlatAst = unsafe { nil }
 	used_fns                     map[string]bool
 	used_fn_names                []string
+	test_files                   map[string]bool
 	str_lits                     []string
 	str_lit_ids                  map[string]int
 	global_types                 map[string]types.Type
@@ -34,8 +35,9 @@ mut:
 	module_init_fns              []string               // C names of module-level `init()` fns, in source order
 	module_init_fn_modules       map[string]string      // C init fn name -> V module name
 	module_imports               map[string][]string    // module -> imported modules
-	c_includes                   []string
+	c_directives                 []CDirective
 	c_flags                      []string
+	libc_compat_fns              map[string]bool
 	tc                           &types.TypeChecker = unsafe { nil }
 	has_builtins                 bool
 	tmp_count                    int
@@ -73,12 +75,19 @@ mut:
 	param_types_by_short    map[string][]types.Type        // method short-name suffix -> param types (fallback index)
 	spawn_wrapper_names     map[string]string
 	spawn_wrapper_defs      []string
+	callback_wrapper_names  map[string]string
+	callback_wrapper_defs   []string
 	parallel_used           bool
 }
 
 struct FixedArrayTypedefInfo {
 	arr    types.ArrayFixed
 	module string
+}
+
+struct CDirective {
+	module string
+	text   string
 }
 
 // was_parallel reports whether the last fn codegen actually ran across threads.
@@ -95,6 +104,7 @@ pub fn FlatGen.new() FlatGen {
 	return FlatGen{
 		sb:                           strings.new_builder(4096)
 		used_fns:                     map[string]bool{}
+		test_files:                   map[string]bool{}
 		str_lit_ids:                  map[string]int{}
 		global_types:                 map[string]types.Type{}
 		enum_vals:                    map[string]int{}
@@ -110,8 +120,9 @@ pub fn FlatGen.new() FlatGen {
 		module_init_fns:              []string{}
 		module_init_fn_modules:       map[string]string{}
 		module_imports:               map[string][]string{}
-		c_includes:                   []string{}
+		c_directives:                 []CDirective{}
 		c_flags:                      []string{}
+		libc_compat_fns:              map[string]bool{}
 		modules:                      map[string]string{}
 		fn_ptr_types:                 map[string]string{}
 		fixed_array_ret_wrappers:     map[string]bool{}
@@ -132,6 +143,8 @@ pub fn FlatGen.new() FlatGen {
 		param_types_by_short:         map[string][]types.Type{}
 		spawn_wrapper_names:          map[string]string{}
 		spawn_wrapper_defs:           []string{}
+		callback_wrapper_names:       map[string]string{}
+		callback_wrapper_defs:        []string{}
 		str_lits:                     []string{}
 		defers:                       []flat.NodeId{}
 		fn_defers:                    []flat.NodeId{}
@@ -153,6 +166,14 @@ pub fn (mut g FlatGen) gen(a &flat.FlatAst) string {
 // gen_with_used emits with used output for c.
 pub fn (mut g FlatGen) gen_with_used(a &flat.FlatAst, used_fns map[string]bool, tc &types.TypeChecker) string {
 	return g.gen_with_used_options(a, used_fns, tc, false)
+}
+
+pub fn (mut g FlatGen) gen_with_used_test_options(a &flat.FlatAst, used_fns map[string]bool, tc &types.TypeChecker, no_parallel bool, test_files []string) string {
+	g.test_files = map[string]bool{}
+	for file in test_files {
+		g.test_files[file] = true
+	}
+	return g.gen_with_used_options(a, used_fns, tc, no_parallel)
 }
 
 // gen_with_used_options emits with used options output for c.
@@ -183,8 +204,9 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.module_init_fns = []string{}
 	g.module_init_fn_modules = map[string]string{}
 	g.module_imports = map[string][]string{}
-	g.c_includes = []string{}
+	g.c_directives = []CDirective{}
 	g.c_flags = []string{}
+	g.libc_compat_fns = map[string]bool{}
 	g.modules = map[string]string{}
 	g.fn_ptr_types = map[string]string{}
 	g.fixed_array_ret_wrappers = map[string]bool{}
@@ -205,6 +227,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.param_types_by_short = map[string][]types.Type{}
 	g.spawn_wrapper_names = map[string]string{}
 	g.spawn_wrapper_defs = []string{}
+	g.callback_wrapper_names = map[string]string{}
+	g.callback_wrapper_defs = []string{}
 	g.parallel_used = false
 	g.tc = unsafe { tc }
 	if g.tc.a == unsafe { nil } {
@@ -249,6 +273,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.global_decls()
 	g.forward_decls()
 	g.enum_str_forward_decls()
+	g.callback_wrapper_decls()
 	g.spawn_wrapper_decls()
 	g.register_interface_strings()
 	g.string_literals()
@@ -333,32 +358,7 @@ fn (mut g FlatGen) collect_gen_info() {
 			}
 			continue
 		}
-		if node.kind == .directive && node.value in ['include', 'insert'] && node.typ.len > 0 {
-			include_arg := c_include_arg(node.typ, g.compiler_vroot, cur_file)
-			if include_arg.len == 0 {
-				continue
-			}
-			// The atomic helper headers are superseded by the inline C11 `__atomic_*`
-			// helpers emitted in builtin_abi_decls(); also including them would
-			// redefine `v_prealloc_atomic_*` and the `atomic_*` helpers.
-			if include_arg.contains('prealloc_atomics.h') || include_arg.contains('stdatomic') {
-				continue
-			}
-			include := '#include ${include_arg}'
-			if include !in g.c_includes {
-				g.c_includes << include
-			}
-			continue
-		}
-		if node.kind == .directive && node.value == 'define' && node.typ.len > 0 {
-			// `#define NAME [value]` from a `.c.v` file. Emit it into the same ordered
-			// include stream so a define that precedes an `#include` (e.g. viper's
-			// `#define GLFW_INCLUDE_GLCOREARB` before `<GLFW/glfw3.h>`, which selects the
-			// GL core-profile header that declares glGenVertexArrays/…) still does so.
-			define := '#define ${node.typ}'
-			if define !in g.c_includes {
-				g.c_includes << define
-			}
+		if g.collect_c_directive(cur_module, node, cur_file) {
 			continue
 		}
 		if node.kind == .directive && node.value == 'flag' && node.typ.len > 0 {
@@ -479,6 +479,53 @@ fn (mut g FlatGen) collect_gen_info() {
 	g.collect_const_init_order_from_files()
 }
 
+fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, source_file string) bool {
+	if node.kind != .directive {
+		return false
+	}
+	if node.value in ['include', 'insert'] {
+		if node.typ.len == 0 {
+			return true
+		}
+		include_arg := c_include_arg(node.typ, g.compiler_vroot, source_file)
+		if include_arg.len == 0 {
+			return true
+		}
+		// The atomic helper headers are superseded by the inline C11 `__atomic_*`
+		// helpers emitted in builtin_abi_decls(); also including them would
+		// redefine `v_prealloc_atomic_*` and the `atomic_*` helpers.
+		if include_arg.contains('prealloc_atomics.h') || include_arg.contains('stdatomic') {
+			return true
+		}
+		g.add_c_directive(module_name, '#include ${include_arg}')
+		return true
+	}
+	if node.value in ['define', 'undef', 'ifdef', 'ifndef', 'if', 'elif', 'else', 'endif', 'pragma',
+		'error', 'warning'] {
+		g.add_c_directive(module_name, c_preprocessor_directive_line(node.value, node.typ))
+		return true
+	}
+	return false
+}
+
+fn (mut g FlatGen) add_c_directive(module_name string, text string) {
+	if text.len == 0 {
+		return
+	}
+	g.c_directives << CDirective{
+		module: module_name
+		text:   text
+	}
+}
+
+fn c_preprocessor_directive_line(name string, raw string) string {
+	clean := raw.trim_space()
+	if clean.len == 0 {
+		return '#${name}'
+	}
+	return '#${name} ${clean}'
+}
+
 // note_compiler_source_file supports note compiler source file handling for FlatGen.
 fn (mut g FlatGen) note_compiler_source_file(path string) {
 	if g.compiler_vroot.len > 0 || path.len == 0 {
@@ -566,6 +613,81 @@ fn (g &FlatGen) visit_module_init(mod string, module_to_init map[string]string, 
 	if init_fn := module_to_init[mod] {
 		result << init_fn
 	}
+}
+
+fn (g &FlatGen) ordered_c_directives() []string {
+	mut directives_by_module := map[string][]string{}
+	mut module_order := []string{}
+	for directive in g.c_directives {
+		if directive.module !in directives_by_module {
+			directives_by_module[directive.module] = []string{}
+			module_order << directive.module
+		}
+		directives_by_module[directive.module] << directive.text
+	}
+	mut result := []string{}
+	mut visiting := map[string]bool{}
+	mut visited := map[string]bool{}
+	for mod in module_order {
+		g.visit_c_directive_module(mod, directives_by_module, mut visiting, mut visited, mut result)
+	}
+	return dedupe_top_level_c_includes(result)
+}
+
+fn (g &FlatGen) visit_c_directive_module(mod string, directives_by_module map[string][]string, mut visiting map[string]bool, mut visited map[string]bool, mut result []string) {
+	if mod in visited || mod in visiting {
+		return
+	}
+	visiting[mod] = true
+	for dep in g.module_imports[mod] or { []string{} } {
+		if dep in directives_by_module {
+			g.visit_c_directive_module(dep, directives_by_module, mut visiting, mut visited, mut
+				result)
+		}
+	}
+	visiting.delete(mod)
+	visited[mod] = true
+	for directive in directives_by_module[mod] or { []string{} } {
+		result << directive
+	}
+}
+
+fn dedupe_top_level_c_includes(directives []string) []string {
+	mut result := []string{}
+	mut seen_includes := map[string]bool{}
+	mut depth := 0
+	for directive in directives {
+		clean := directive.trim_space()
+		if depth == 0 && c_directive_name(clean) == 'include' {
+			if clean in seen_includes {
+				continue
+			}
+			seen_includes[clean] = true
+		}
+		result << directive
+		name := c_directive_name(clean)
+		if name in ['if', 'ifdef', 'ifndef'] {
+			depth++
+		} else if name == 'endif' && depth > 0 {
+			depth--
+		}
+	}
+	return result
+}
+
+fn c_directive_name(text string) string {
+	if text.len == 0 || text[0] != `#` {
+		return ''
+	}
+	body := text[1..].trim_space()
+	if body.len == 0 {
+		return ''
+	}
+	idx := body.index_u8(` `)
+	if idx < 0 {
+		return body
+	}
+	return body[..idx]
 }
 
 fn c_include_arg(raw string, vroot string, source_file string) string {
@@ -732,7 +854,7 @@ fn c_pkgconfig_arg_is_safe(raw string) bool {
 
 fn c_flag_has_target_prefix(target string) bool {
 	return target in ['darwin', 'macos', 'linux', 'windows', 'freebsd', 'openbsd', 'netbsd',
-		'solaris']
+		'solaris', 'wasm32_emscripten']
 }
 
 fn c_flag_target_enabled(target string) bool {
@@ -775,6 +897,12 @@ fn c_flag_target_enabled(target string) bool {
 		}
 		'solaris' {
 			$if solaris {
+				return true
+			}
+			return false
+		}
+		'wasm32_emscripten' {
+			$if wasm32_emscripten {
 				return true
 			}
 			return false
@@ -933,6 +1061,22 @@ fn (mut g FlatGen) expr_to_string_with_expected_type(id flat.NodeId, expected ty
 	return result
 }
 
+fn (mut g FlatGen) gen_amp_c_string_literal(id flat.NodeId, node flat.Node) bool {
+	if node.kind == .char_literal && node.value.starts_with('c:') {
+		g.gen_expr(id)
+		return true
+	}
+	if node.kind != .char_literal && node.kind != .string_literal {
+		return false
+	}
+	expr := g.expr_to_string(id)
+	if expr.len >= 2 && expr[0] == `"` && expr[expr.len - 1] == `"` {
+		g.write(expr)
+		return true
+	}
+	return false
+}
+
 // gen_expr_with_expected_type emits expr with expected type output for c.
 fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Type) {
 	old_expected := g.expected_expr_type
@@ -942,21 +1086,33 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 		g.expected_enum = expected.name
 	}
 	node := g.a.nodes[int(id)]
+	if node.kind == .dump_expr {
+		if node.children_count > 0 {
+			g.gen_expr_with_expected_type(g.a.child(&node, 0), expected)
+		} else {
+			g.write('0')
+		}
+		g.expected_expr_type = old_expected
+		g.expected_enum = old_expected_enum
+		return
+	}
 	mut actual := g.usable_expr_type(id)
 	if node.kind == .ident {
 		if param_type := g.current_param_type(node.value) {
 			actual = param_type
 		}
 	}
-	if node.kind == .ident {
-		if _ := fn_type_from(expected) {
-			call_name := g.call_key(id, node.value)
-			if call_name in g.tc.fn_param_types || call_name in g.tc.fn_ret_types {
-				g.write(c_name(call_name))
-				g.expected_expr_type = old_expected
-				g.expected_enum = old_expected_enum
-				return
-			}
+	if _ := fn_type_from(expected) {
+		if g.gen_callback_fn_value_for_expected_type(id, expected) {
+			g.expected_expr_type = old_expected
+			g.expected_enum = old_expected_enum
+			return
+		}
+		if call_name := g.callback_direct_fn_value_name(id, expected) {
+			g.write(g.callback_c_fn_name(call_name))
+			g.expected_expr_type = old_expected
+			g.expected_enum = old_expected_enum
+			return
 		}
 	}
 	if expected is types.Array && node.kind == .array_literal {
@@ -1222,16 +1378,56 @@ fn (mut g FlatGen) sizeof_target(value string) string {
 	if value.contains('.') {
 		parts := value.split('.')
 		if parts.len > 1 {
-			if _ := g.tc.cur_scope.lookup(parts[0]) {
-				mut expr := c_name(parts[0])
-				for part in parts[1..] {
-					expr += '.${c_field_name(part)}'
-				}
-				return expr
+			if g.cur_scope_has_local_name(parts[0]) {
+				return sizeof_selector_target(parts[0], parts[1..])
+			}
+			if global := g.sizeof_global_selector_base(parts[0]) {
+				return sizeof_selector_target(global, parts[1..])
 			}
 		}
 	}
 	return g.type_name_c_type(value)
+}
+
+fn sizeof_selector_target(base string, fields []string) string {
+	mut expr := c_name(base)
+	for field in fields {
+		expr += '.${c_field_name(field)}'
+	}
+	return expr
+}
+
+fn (g &FlatGen) cur_scope_has_local_name(name string) bool {
+	mut scope := g.tc.cur_scope
+	for scope != unsafe { nil } && scope != g.tc.file_scope {
+		for existing in scope.names {
+			if existing == name {
+				return true
+			}
+		}
+		scope = scope.parent
+	}
+	return false
+}
+
+fn (g &FlatGen) sizeof_global_selector_base(name string) ?string {
+	if name.len == 0 || name.contains('.') {
+		return none
+	}
+	current_qname := qualify_name_in_module(g.tc.cur_module, name)
+	if current_qname in g.global_types {
+		return current_qname
+	}
+	if mod := g.global_modules[name] {
+		if mod.len == 0 || mod == 'main' || mod == 'builtin' || mod == g.tc.cur_module {
+			return if mod.len > 0 && mod != 'main' && mod != 'builtin' {
+				'${mod}.${name}'
+			} else {
+				name
+			}
+		}
+	}
+	return none
 }
 
 // optional_none_type supports optional none type handling for FlatGen.
@@ -1546,11 +1742,20 @@ fn (g &FlatGen) const_ident_c_name(name string) string {
 	if mod.len > 0 && mod != 'main' && mod != 'builtin' {
 		return c_name('${mod}.${name}')
 	}
+	if (mod == '' || mod == 'main') && name in g.const_modules {
+		return c_name('main.${name}')
+	}
 	return c_name(name)
 }
 
 // fixed_array_len_expr supports fixed array len expr handling for FlatGen.
 fn (mut g FlatGen) fixed_array_len_expr(type_name string, fallback int) string {
+	if type_name.len > 0 {
+		typ := g.tc.parse_type(type_name)
+		if typ is types.ArrayFixed {
+			return g.fixed_array_len_value(typ)
+		}
+	}
 	mut raw_len := ''
 	if type_name.starts_with('[') {
 		idx := type_name.index_u8(`]`)
@@ -1743,6 +1948,13 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 		.string_interp {
 			g.gen_string_interp(node)
 		}
+		.dump_expr {
+			if node.children_count > 0 {
+				g.gen_expr(g.a.child(&node, 0))
+			} else {
+				g.write('0')
+			}
+		}
 		.ident {
 			looked_up := g.tc.cur_scope.lookup(node.value) or { types.Type(types.void_) }
 			is_local := looked_up !is types.Void
@@ -1920,7 +2132,9 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					}
 				}
 			}
-			if node.op == .amp && child.kind == .struct_init {
+			if node.op == .amp && g.gen_amp_c_string_literal(child_id, child) {
+				return
+			} else if node.op == .amp && child.kind == .struct_init {
 				g.gen_heap_struct_init(child)
 			} else if node.op == .amp && child.kind == .assoc {
 				g.gen_heap_assoc_expr(child)
@@ -2602,8 +2816,13 @@ fn (mut g FlatGen) preamble() {
 		g.writeln('#endif')
 		g.writeln('#endif')
 	}
-	for include in g.c_includes {
-		g.writeln(include)
+	if g.libc_compat_fns['gettid'] {
+		g.writeln('#ifdef __linux__')
+		g.writeln('#include <sys/syscall.h>')
+		g.writeln('#endif')
+	}
+	for directive in g.ordered_c_directives() {
+		g.writeln(directive)
 	}
 	g.writeln('')
 	g.writeln('typedef signed char i8;')
@@ -2680,10 +2899,25 @@ fn (mut g FlatGen) write_arch_macros() {
 	g.writeln('#endif')
 }
 
+fn (mut g FlatGen) libc_compat_decls() {
+	if g.libc_compat_fns['gettid'] {
+		g.writeln('#ifdef __linux__')
+		g.writeln('#ifndef SYS_gettid')
+		g.writeln('#define SYS_gettid __NR_gettid')
+		g.writeln('#endif')
+		g.writeln('static inline u32 v3_gettid(void) {')
+		g.writeln('\treturn (u32)syscall(SYS_gettid);')
+		g.writeln('}')
+		g.writeln('#endif')
+		g.writeln('')
+	}
+}
+
 fn (mut g FlatGen) builtin_abi_decls() {
 	if !g.has_builtins {
 		return
 	}
+	g.libc_compat_decls()
 	g.writeln('#define array_new(elem_size, len, cap) __new_array((len), (cap), (elem_size))')
 	g.writeln('#define array_push array__push')
 	g.writeln('void array__push_many(array* a, void* val, int size);')
@@ -2803,7 +3037,7 @@ fn (mut g FlatGen) collect_fixed_array_typedefs_needed() map[string]FixedArrayTy
 		}
 	}
 	for name, fields in g.tc.structs {
-		g.tc.cur_module = module_from_qualified_name(name)
+		g.tc.cur_module = g.fixed_array_typedef_type_module(name, old_module)
 		for field in fields {
 			g.collect_fixed_array_typedef(field.typ, mut needed)
 		}
@@ -3046,6 +3280,17 @@ fn (g &FlatGen) fixed_array_type_defined(typ0 types.Type, emitted_structs map[st
 	return true
 }
 
+fn (mut g FlatGen) fixed_array_typedef_type_module(name string, fallback string) string {
+	if info := g.struct_decl_infos[name] {
+		return info.module
+	}
+	mod := module_from_qualified_name(name)
+	if mod.len > 0 {
+		return mod
+	}
+	return fallback
+}
+
 fn module_from_qualified_name(name string) string {
 	if name.contains('.') {
 		return name.all_before_last('.')
@@ -3145,7 +3390,7 @@ fn (mut g FlatGen) global_decls() {
 		if ct == 'void' {
 			continue
 		}
-		if typ is types.Struct && typ.name.starts_with('C.') {
+		if name.starts_with('C.') {
 			continue
 		}
 		init := if g.can_use_global_brace_zero_init(typ, ct) { ' = {0}' } else { '' }
@@ -3164,13 +3409,12 @@ fn (mut g FlatGen) global_decls() {
 // initializers, so they must run at startup. Without this, such globals stay
 // NULL/zero and the first access segfaults.
 //
-// Only initializers that translate to a plain `name = expr;` assignment are
-// emitted. Fixed-array globals (`[N]T{}`) are skipped: C zero-initializes them
-// already and a C array is not assignable. `&Struct{}` is emitted as a
-// self-contained heap allocation (`(T*)memdup(&(T){...}, sizeof(T))`), so it is
-// safe. Other prefix/array initializers that would need a dropped temporary are
-// skipped, leaving the global zero/NULL — no regression versus never
-// initializing globals at all.
+// Plain initializers are emitted as `name = expr;`. Fixed-array globals are
+// copied from a generated compound literal with `memmove`, since C arrays are
+// not assignable. `&Struct{}` is emitted as a self-contained heap allocation
+// (`(T*)memdup(&(T){...}, sizeof(T))`), so it is safe. Other prefix/array
+// initializers that would need a dropped temporary are skipped, leaving the
+// global zero/NULL -- no regression versus never initializing globals at all.
 fn (mut g FlatGen) emit_global_inits() {
 	old_module := g.tc.cur_module
 	for qname in g.global_init_order {
@@ -3187,6 +3431,8 @@ fn (mut g FlatGen) emit_global_inits() {
 		}
 		if typ := g.global_types[qname] {
 			if typ is types.ArrayFixed {
+				target := c_name(qname)
+				g.queue_fixed_array_runtime_init(target, val_id, typ)
 				continue
 			}
 		}
@@ -3321,6 +3567,7 @@ fn (mut g FlatGen) emit_const(name string, val_id flat.NodeId) {
 		if v_type is types.ArrayFixed {
 			c_elem, dims := g.fixed_array_decl_parts(v_type)
 			g.writeln('${c_elem} ${qname}${dims};')
+			g.queue_fixed_array_runtime_init(qname, val_id, v_type)
 		} else if ct != 'void' {
 			g.writeln('${ct} ${qname};')
 			// The initializer is not a compile-time constant (e.g. `os.args =
@@ -3393,6 +3640,68 @@ fn (mut g FlatGen) queue_map_literal_sets(target string, val_id flat.NodeId, map
 		val := g.expr_to_string_with_expected_type(g.a.child(&node, i + 1), map_type.value_type)
 		g.runtime_inits << '\tmap__set(&${target}, &(${c_key}[]){${key}}, &(${c_val}[]){${val}});'
 	}
+}
+
+fn (mut g FlatGen) queue_fixed_array_runtime_init(target string, val_id flat.NodeId, fixed types.ArrayFixed) bool {
+	expr := g.fixed_array_compound_literal_expr(val_id, fixed)
+	if expr.trim_space().len == 0 {
+		return false
+	}
+	g.runtime_inits << '\tmemmove(${target}, ${expr}, sizeof(${target}));'
+	return true
+}
+
+fn (mut g FlatGen) fixed_array_compound_literal_expr(val_id flat.NodeId, fixed types.ArrayFixed) string {
+	init := g.fixed_array_initializer_string(val_id, fixed)
+	if init.trim_space().len == 0 {
+		return ''
+	}
+	c_elem, dims := g.fixed_array_decl_parts(fixed)
+	return '(${c_elem}${dims})${init}'
+}
+
+fn (mut g FlatGen) fixed_array_initializer_string(val_id flat.NodeId, fixed types.ArrayFixed) string {
+	if int(val_id) < 0 || int(val_id) >= g.a.nodes.len {
+		return ''
+	}
+	node := g.a.nodes[int(val_id)]
+	if node.kind == .postfix && node.children_count > 0 {
+		return g.fixed_array_initializer_string(g.a.child(&node, 0), fixed)
+	}
+	if node.kind == .array_init && node.children_count == 0 {
+		return '{0}'
+	}
+	if node.kind != .array_literal {
+		return ''
+	}
+	mut parts := []string{}
+	for i in 0 .. node.children_count {
+		child_id := g.a.child(&node, i)
+		if fixed.elem_type is types.ArrayFixed {
+			parts << g.fixed_array_initializer_string(child_id, fixed.elem_type)
+		} else {
+			parts << g.fixed_array_elem_initializer_string(child_id, fixed.elem_type)
+		}
+	}
+	return '{${parts.join(', ')}}'
+}
+
+fn (mut g FlatGen) fixed_array_elem_initializer_string(val_id flat.NodeId, elem_type types.Type) string {
+	if int(val_id) < 0 || int(val_id) >= g.a.nodes.len {
+		return '0'
+	}
+	node := g.a.nodes[int(val_id)]
+	if g.is_const_expr(val_id) && !(node.kind == .prefix && node.op == .amp) {
+		const_val := g.const_expr_to_string(val_id, []string{})
+		if const_val.trim_space().len > 0 {
+			return const_val
+		}
+	}
+	expr := g.expr_to_string_with_expected_type(val_id, elem_type)
+	if expr.trim_space().len > 0 {
+		return expr
+	}
+	return '0'
 }
 
 fn (mut g FlatGen) precompute_consts() string {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1001,6 +1001,26 @@ fn (g &FlatGen) enum_value_for_type(type_name string, field_name string) ?int {
 	return none
 }
 
+fn (g &FlatGen) enum_selector_base_name(name string) ?string {
+	if name in g.tc.enum_names || name in g.tc.flag_enums {
+		return name
+	}
+	qname := g.tc.qualify_name(name)
+	if qname in g.tc.enum_names || qname in g.tc.flag_enums {
+		return qname
+	}
+	if name.contains('.') || g.tc.cur_file.len == 0 {
+		return none
+	}
+	candidates := g.tc.file_selective_imports['${g.tc.cur_file}\n${name}'] or { return none }
+	for candidate in candidates {
+		if candidate in g.tc.enum_names || candidate in g.tc.flag_enums {
+			return candidate
+		}
+	}
+	return none
+}
+
 // expr_to_string converts expr to string data for c.
 fn (mut g FlatGen) expr_to_string(id flat.NodeId) string {
 	orig := g.sb
@@ -2297,16 +2317,15 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			if g.gen_method_value_closure(base_id, base_type0, node.value) {
 				return
 			}
+			enum_selector_qbase := if base.kind == .ident && base.value != 'C' && !base_is_local {
+				g.enum_selector_base_name(base.value) or { '' }
+			} else {
+				''
+			}
 			if base.kind == .ident && base.value == 'C' {
 				g.write(node.value)
-			} else if base.kind == .ident && !base_is_local && (base.value in g.tc.enum_names
-				|| g.tc.qualify_name(base.value) in g.tc.enum_names) {
-				qbase := if base.value in g.tc.enum_names {
-					base.value
-				} else {
-					g.tc.qualify_name(base.value)
-				}
-				ekey := '${qbase}.${node.value}'
+			} else if enum_selector_qbase.len > 0 {
+				ekey := '${enum_selector_qbase}.${node.value}'
 				if eval := g.enum_vals[ekey] {
 					g.write('${eval}')
 				} else {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1007,21 +1007,27 @@ fn (mut g FlatGen) gen_export_wrapper_for_fn(node flat.Node, module_name string)
 
 fn (mut g FlatGen) export_wrapper_arg_names(node flat.Node) []string {
 	mut args := []string{}
+	needs_implicit_ctx := g.fn_needs_implicit_veb_ctx(node)
+	insert_implicit_ctx_after_first := needs_implicit_ctx && g.fn_has_receiver_param(node)
+	mut written := 0
+	mut implicit_ctx_written := false
 	for i in 0 .. node.children_count {
 		param_id := g.a.child(&node, i)
 		p := g.a.node(param_id)
 		if p.kind != .param {
 			continue
 		}
-		param_name := if p.value == '_' { '_${args.len}' } else { c_name(p.value) }
+		param_name := if p.value == '_' { '_${written}' } else { c_name(p.value) }
 		args << param_name
-	}
-	if g.fn_needs_implicit_veb_ctx(node) {
-		if g.fn_has_receiver_param(node) && args.len > 0 {
-			args.insert(1, 'ctx')
-		} else {
+		written++
+		if insert_implicit_ctx_after_first && !implicit_ctx_written {
 			args << 'ctx'
+			written++
+			implicit_ctx_written = true
 		}
+	}
+	if needs_implicit_ctx && !implicit_ctx_written {
+		args << 'ctx'
 	}
 	return args
 }

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -105,8 +105,7 @@ fn (g &FlatGen) top_level_stmts() []TopLevelStmt {
 			if int(child_id) < g.a.user_code_start {
 				continue
 			}
-			child := g.a.nodes[int(child_id)]
-			if cgen_is_top_level_stmt(child) {
+			if g.cgen_is_top_level_stmt(child_id) {
 				stmts << TopLevelStmt{
 					id:     child_id
 					file:   file_node.value
@@ -136,11 +135,23 @@ fn (g &FlatGen) top_level_file_module_name(file_node flat.Node) string {
 	return ''
 }
 
-fn cgen_is_top_level_stmt(node flat.Node) bool {
+fn (g &FlatGen) cgen_is_top_level_stmt(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return false
+	}
+	node := g.a.nodes[int(id)]
 	return match node.kind {
 		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
-		.for_in_stmt, .if_expr, .assert_stmt, .block {
+		.for_in_stmt, .if_expr, .assert_stmt {
 			true
+		}
+		.block, .comptime_if {
+			for i in 0 .. node.children_count {
+				if g.cgen_is_top_level_stmt(g.a.child(&node, i)) {
+					return true
+				}
+			}
+			false
 		}
 		else {
 			false
@@ -959,7 +970,7 @@ fn (mut g FlatGen) gen_export_wrapper_for_fn(node flat.Node, module_name string)
 	export_name := g.export_fn_name_in_module(module_name, node.value) or { return }
 	canonical_name := g.fn_c_name_in_module(module_name, node.value)
 	ret_type := g.tc.parse_type(node.typ)
-	ret_ct := g.optional_type_name(ret_type)
+	ret_ct := g.fn_return_type_name(ret_type)
 	g.write(ret_ct)
 	g.write(' ')
 	g.write(export_name)
@@ -3733,7 +3744,7 @@ fn (mut g FlatGen) forward_decls() {
 			if export_name := g.export_fn_name_in_module(cur_module, node.value) {
 				if !forwarded[export_name] {
 					forwarded[export_name] = true
-					g.write(g.optional_type_name(ret_type))
+					g.write(g.fn_return_type_name(ret_type))
 					g.write(' ')
 					g.write(export_name)
 					g.write('(')

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -326,6 +326,18 @@ fn (mut g FlatGen) direct_call_name(name string) string {
 	return c_name(name)
 }
 
+fn (mut g FlatGen) direct_call_name_for_call(id flat.NodeId, name string) string {
+	if g.test_files.len > 0 && (name == 'main' || name == 'main.main') {
+		if resolved := g.tc.resolved_call_name(id) {
+			if resolved == 'main' || resolved == 'main.main' {
+				return g.test_user_main_c_name()
+			}
+		}
+		return c_name(name)
+	}
+	return g.direct_call_name(name)
+}
+
 fn (mut g FlatGen) libc_compat_call_name(name string) ?string {
 	// `builtin.v_gettid()` reaches libc through `C.gettid()` on Linux/glibc, but
 	// that symbol is not declared by all usable C header sets. Route it through a
@@ -696,10 +708,13 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 	mut arg_expr := 'NULL'
 	if fn_node.kind == .ident {
 		call_key := g.call_key(call_id, fn_node.value)
-		cfn := if call_key in g.tc.fn_ret_types || call_key in g.tc.fn_param_types {
-			g.direct_call_name(call_key)
+		looked_up := g.tc.cur_scope.lookup(fn_node.value) or { types.Type(types.void_) }
+		cfn := if looked_up !is types.Void && fn_type_from(looked_up) != none {
+			c_name(fn_node.value)
+		} else if call_key in g.tc.fn_ret_types || call_key in g.tc.fn_param_types {
+			g.direct_call_name_for_call(call_id, call_key)
 		} else {
-			g.direct_call_name(fn_node.value)
+			c_name(fn_node.value)
 		}
 		if call_node.children_count == 1 {
 			wrapper = g.ensure_noarg_spawn_wrapper(cfn, ret_ct)
@@ -2029,10 +2044,15 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 						return
 					}
 					call_key := g.call_key(id, fn_ident.value)
-					if call_key in g.tc.fn_ret_types || call_key in g.tc.fn_param_types {
-						g.write(g.direct_call_name(call_key))
+					looked_up := g.tc.cur_scope.lookup(fn_ident.value) or {
+						types.Type(types.void_)
+					}
+					if looked_up !is types.Void && fn_type_from(looked_up) != none {
+						g.write(c_name(fn_ident.value))
+					} else if call_key in g.tc.fn_ret_types || call_key in g.tc.fn_param_types {
+						g.write(g.direct_call_name_for_call(id, call_key))
 					} else {
-						g.write(g.direct_call_name(fn_ident.value))
+						g.write(c_name(fn_ident.value))
 					}
 				} else {
 					g.gen_expr(fn_id)

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -3,6 +3,20 @@ module c
 import v3.flat
 import v3.types
 
+struct TestHarnessFn {
+	name   string
+	c_name string
+	ret    types.Type
+}
+
+struct TestHarnessHooks {
+mut:
+	testsuite_begin string
+	testsuite_end   string
+	before_each     string
+	after_each      string
+}
+
 // gen_fns emits fns output for c.
 fn (mut g FlatGen) gen_fns() {
 	mut cur_module := ''
@@ -40,6 +54,87 @@ fn (mut g FlatGen) gen_fns() {
 	}
 }
 
+fn (mut g FlatGen) gen_synthetic_main_after_fns() {
+	if g.has_entry_main() {
+		return
+	}
+	top_level_ids := g.top_level_stmt_ids()
+	if top_level_ids.len > 0 {
+		g.gen_top_level_main(top_level_ids)
+	} else if g.test_files.len > 0 {
+		g.gen_test_main()
+	}
+}
+
+fn (g &FlatGen) has_entry_main() bool {
+	mut cur_module := ''
+	for node in g.a.nodes {
+		kind_id := node_kind_id(node)
+		if kind_id == 77 {
+			cur_module = ''
+			continue
+		}
+		if kind_id == 73 {
+			cur_module = node.value
+			continue
+		}
+		if kind_id == 61 && node.value == 'main' && (cur_module.len == 0 || cur_module == 'main') {
+			return true
+		}
+	}
+	return false
+}
+
+fn (g &FlatGen) top_level_stmt_ids() []flat.NodeId {
+	mut ids := []flat.NodeId{}
+	for file_idx, file_node in g.a.nodes {
+		if !g.should_emit_top_level_file(file_idx, file_node) {
+			continue
+		}
+		for i in 0 .. file_node.children_count {
+			child_id := g.a.child(&file_node, i)
+			if int(child_id) < g.a.user_code_start {
+				continue
+			}
+			child := g.a.nodes[int(child_id)]
+			if cgen_is_top_level_stmt(child) {
+				ids << child_id
+			}
+		}
+	}
+	return ids
+}
+
+fn (g &FlatGen) should_emit_top_level_file(file_idx int, file_node flat.Node) bool {
+	if file_idx < g.a.user_code_start || file_node.kind != .file || file_node.children_count == 0 {
+		return false
+	}
+	module_name := g.top_level_file_module_name(file_node)
+	return module_name.len == 0 || module_name == 'main'
+}
+
+fn (g &FlatGen) top_level_file_module_name(file_node flat.Node) string {
+	for i in 0 .. file_node.children_count {
+		child := g.a.child_node(&file_node, i)
+		if child.kind == .module_decl {
+			return child.value
+		}
+	}
+	return ''
+}
+
+fn cgen_is_top_level_stmt(node flat.Node) bool {
+	return match node.kind {
+		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
+		.for_in_stmt, .if_expr, .assert_stmt, .block {
+			true
+		}
+		else {
+			false
+		}
+	}
+}
+
 // should_emit_fn_node reports whether should emit fn node applies in c.
 fn (mut g FlatGen) should_emit_fn_node(node flat.Node, node_index int) bool {
 	return g.should_emit_fn_node_in_module(node, node_index, g.tc.cur_module)
@@ -48,8 +143,6 @@ fn (mut g FlatGen) should_emit_fn_node(node flat.Node, node_index int) bool {
 // should_emit_fn_node_in_module reports whether should emit fn node in module applies in c.
 fn (mut g FlatGen) should_emit_fn_node_in_module(node flat.Node, node_index int, module_name string) bool {
 	_ = node_index
-	cfn := c_name(node.value)
-	dfn := dotted_fn_name_in_module(module_name, node.value)
 	qfn := qualified_fn_name_in_module(module_name, node.value)
 	if module_name == 'builtin' && node.value == 'exit' {
 		return true
@@ -57,15 +150,7 @@ fn (mut g FlatGen) should_emit_fn_node_in_module(node flat.Node, node_index int,
 	if node.value.starts_with('__anon_fn_') || qfn.contains('__anon_fn_') {
 		return true
 	}
-	if module_name == 'main' {
-		if g.has_used_fn_filter() && !g.used_fn_contains(node.value) && !g.used_fn_contains(dfn)
-			&& !g.used_fn_contains(cfn) && !g.used_fn_contains(qfn) {
-			return false
-		}
-		return true
-	}
-	if g.has_used_fn_filter() && !g.used_fn_contains(node.value) && !g.used_fn_contains(dfn)
-		&& !g.used_fn_contains(cfn) && !g.used_fn_contains(qfn) {
+	if g.has_used_fn_filter() && !g.used_fn_contains_in_module(node.value, module_name) {
 		return false
 	}
 	return true
@@ -83,6 +168,19 @@ fn (g &FlatGen) used_fn_contains(name string) bool {
 	return g.used_fns[name]
 }
 
+fn (g &FlatGen) used_fn_contains_in_module(name string, module_name string) bool {
+	dfn := dotted_fn_name_in_module(module_name, name)
+	qfn := qualified_fn_name_in_module(module_name, name)
+	if g.used_fn_contains(dfn) || g.used_fn_contains(qfn) {
+		return true
+	}
+	if module_name.len == 0 || module_name == 'main' || module_name == 'builtin' {
+		cfn := c_name(name)
+		return g.used_fn_contains(name) || g.used_fn_contains(cfn)
+	}
+	return false
+}
+
 // has_used_fn_filter reports whether has used fn filter applies in c.
 fn (g &FlatGen) has_used_fn_filter() bool {
 	return g.used_fns.len > 0 && g.used_fn_contains('main')
@@ -96,6 +194,18 @@ fn (g &FlatGen) emitted_fn_contains(name string) bool {
 // qualified_fn_name supports qualified fn name handling for FlatGen.
 fn (g &FlatGen) qualified_fn_name(name string) string {
 	return qualified_fn_name_in_module(g.tc.cur_module, name)
+}
+
+fn (g &FlatGen) export_fn_name_in_module(module_name string, name string) ?string {
+	qname := dotted_fn_name_in_module(module_name, name)
+	if export_name := g.a.export_fn_names[qname] {
+		return export_name
+	}
+	if (module_name.len == 0 || module_name == 'main' || module_name == 'builtin')
+		&& name in g.a.export_fn_names {
+		return g.a.export_fn_names[name]
+	}
+	return none
 }
 
 // qualified_fn_name_in_module supports qualified fn name in module handling for c.
@@ -113,7 +223,10 @@ fn qualified_fn_name_in_module(module_name string, name string) string {
 }
 
 // direct_call_name supports direct call name handling for FlatGen.
-fn (g &FlatGen) direct_call_name(name string) string {
+fn (mut g FlatGen) direct_call_name(name string) string {
+	if compat_name := g.libc_compat_call_name(name) {
+		return compat_name
+	}
 	if name == 'free' {
 		return 'v_free'
 	}
@@ -124,6 +237,17 @@ fn (g &FlatGen) direct_call_name(name string) string {
 		return 'bool__str'
 	}
 	return c_name(name)
+}
+
+fn (mut g FlatGen) libc_compat_call_name(name string) ?string {
+	// `builtin.v_gettid()` reaches libc through `C.gettid()` on Linux/glibc, but
+	// that symbol is not declared by all usable C header sets. Route it through a
+	// tiny runtime compatibility helper instead of emitting an undeclared call.
+	if name == 'C.gettid' {
+		g.libc_compat_fns['gettid'] = true
+		return 'v3_gettid'
+	}
+	return none
 }
 
 fn (g &FlatGen) import_alias_module(alias string) ?string {
@@ -197,7 +321,7 @@ fn (g &FlatGen) static_method_fn_name(type_ident string, method string) ?string 
 		return none
 	}
 	// Prefer the module-qualified key: a static method defined in the current (or the
-	// type's) module is emitted under its qualified C name (`viper__Animation__load`),
+	// type's) module is emitted under its qualified C name (`game__Animation__load`),
 	// so the call must resolve to the same qualified key even though an unqualified
 	// alias (`Animation.load`) may also be registered.
 	qdirect := '${qtype}.${method}'
@@ -229,23 +353,15 @@ fn (g &FlatGen) resolve_method_name(type_name string, method string) string {
 	return ''
 }
 
-fn net_ip_fixed_arg_type(fn_name string, arg_idx int) ?types.ArrayFixed {
-	if arg_idx != 1 {
-		return none
+fn c_string_literal_pointer_arg(arg_node flat.Node, expected types.Type) bool {
+	if arg_node.kind != .char_literal || !arg_node.value.starts_with('c:') {
+		return false
 	}
-	if fn_name == 'new_ip6' || fn_name == 'net.new_ip6' || fn_name.ends_with('.new_ip6') {
-		return types.ArrayFixed{
-			elem_type: types.Type(types.u8_)
-			len:       16
-		}
+	if expected is types.Pointer {
+		base := types.unwrap_pointer(expected)
+		return base is types.Char
 	}
-	if fn_name == 'new_ip' || fn_name == 'net.new_ip' || fn_name.ends_with('.new_ip') {
-		return types.ArrayFixed{
-			elem_type: types.Type(types.u8_)
-			len:       4
-		}
-	}
-	return none
+	return false
 }
 
 fn (mut g FlatGen) gen_special_c_callback_arg(fn_name string, arg_idx int, arg_id flat.NodeId, expected_param types.Type) bool {
@@ -439,6 +555,15 @@ fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types
 		g.write('; (void*)${wrap_name}; })')
 	}
 	return true
+}
+
+fn (mut g FlatGen) callback_wrapper_decls() {
+	for def in g.callback_wrapper_defs {
+		g.writeln(def)
+	}
+	if g.callback_wrapper_defs.len > 0 {
+		g.writeln('')
+	}
 }
 
 fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
@@ -725,10 +850,257 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 	g.indent--
 	g.writeln('}')
 	g.writeln('')
+	if !is_entry_main {
+		g.gen_export_wrapper_for_fn(node, module_name)
+	}
 	g.cur_param_names = old_param_names.clone()
 	g.cur_param_type_values = old_param_type_values.clone()
 	g.cur_param_types = old_param_types.clone()
 	g.tc.pop_scope()
+}
+
+fn (mut g FlatGen) gen_export_wrapper_for_fn(node flat.Node, module_name string) {
+	export_name := g.export_fn_name_in_module(module_name, node.value) or { return }
+	canonical_name := qualified_fn_name_in_module(module_name, node.value)
+	ret_type := g.tc.parse_type(node.typ)
+	ret_ct := g.optional_type_name(ret_type)
+	g.write(ret_ct)
+	g.write(' ')
+	g.write(export_name)
+	g.write('(')
+	g.write_fn_node_params(node)
+	g.writeln(') {')
+	g.indent++
+	args := g.export_wrapper_arg_names(node)
+	call := '${canonical_name}(${args.join(', ')})'
+	if ret_type is types.Void {
+		g.writeln('${call};')
+	} else {
+		g.writeln('return ${call};')
+	}
+	g.indent--
+	g.writeln('}')
+	g.writeln('')
+}
+
+fn (mut g FlatGen) export_wrapper_arg_names(node flat.Node) []string {
+	mut args := []string{}
+	for i in 0 .. node.children_count {
+		param_id := g.a.child(&node, i)
+		p := g.a.node(param_id)
+		if p.kind != .param {
+			continue
+		}
+		param_name := if p.value == '_' { '_${args.len}' } else { c_name(p.value) }
+		args << param_name
+	}
+	if g.fn_needs_implicit_veb_ctx(node) {
+		if g.fn_has_receiver_param(node) && args.len > 0 {
+			args.insert(1, 'ctx')
+		} else {
+			args << 'ctx'
+		}
+	}
+	return args
+}
+
+fn (mut g FlatGen) gen_top_level_main(stmt_ids []flat.NodeId) {
+	g.tc.cur_module = 'main'
+	old_fn_name := g.cur_fn_name
+	g.cur_fn_name = 'main'
+	g.tc.push_scope()
+	g.defers = []flat.NodeId{}
+	g.fn_defers = []flat.NodeId{}
+	g.fn_defer_counts = map[int]string{}
+	g.defer_capture_names = []string{}
+	g.defer_capture_types = map[string]types.Type{}
+	g.set_cur_fn_ret(types.Type(types.void_))
+	old_param_names := g.cur_param_names.clone()
+	old_param_type_values := g.cur_param_type_values.clone()
+	old_param_types := g.cur_param_types.clone()
+	g.cur_param_names = []string{}
+	g.cur_param_type_values = []types.Type{}
+	g.cur_param_types = map[string]types.Type{}
+	mut fn_defer_ids := []flat.NodeId{}
+	for id in stmt_ids {
+		g.collect_function_defer_ids_from(id, mut fn_defer_ids)
+	}
+	g.prepare_function_defers(fn_defer_ids)
+	g.writeln('int main(int argc, char** argv) {')
+	if g.has_builtins {
+		g.writeln('\tg_main_argc = argc;')
+		g.writeln('\tg_main_argv = argv;')
+	}
+	g.gen_compiler_vexe_env_setup()
+	if g.runtime_inits.len > 0 || g.module_init_fns.len > 0 || g.global_inits.len > 0 {
+		g.writeln('\t_vinit();')
+	}
+	g.indent++
+	g.gen_function_defer_prelude()
+	for id in stmt_ids {
+		g.tc.cur_module = 'main'
+		g.gen_node(id)
+	}
+	g.gen_all_defers()
+	g.writeln('return 0;')
+	g.indent--
+	g.writeln('}')
+	g.writeln('')
+	g.cur_param_names = old_param_names.clone()
+	g.cur_param_type_values = old_param_type_values.clone()
+	g.cur_param_types = old_param_types.clone()
+	g.cur_fn_name = old_fn_name
+	g.tc.pop_scope()
+}
+
+fn (mut g FlatGen) gen_test_main() {
+	tests, hooks := g.test_harness_fns()
+	g.tc.cur_module = 'main'
+	g.writeln('int main(int argc, char** argv) {')
+	if g.has_builtins {
+		g.writeln('\tg_main_argc = argc;')
+		g.writeln('\tg_main_argv = argv;')
+	}
+	g.gen_compiler_vexe_env_setup()
+	if g.runtime_inits.len > 0 || g.module_init_fns.len > 0 || g.global_inits.len > 0 {
+		g.writeln('\t_vinit();')
+	}
+	g.indent++
+	if hooks.testsuite_begin.len > 0 {
+		g.writeln('${hooks.testsuite_begin}();')
+	}
+	for idx, test_fn in tests {
+		if hooks.before_each.len > 0 {
+			g.writeln('${hooks.before_each}();')
+		}
+		g.gen_test_fn_call(test_fn, idx)
+		if hooks.after_each.len > 0 {
+			g.writeln('${hooks.after_each}();')
+		}
+	}
+	if hooks.testsuite_end.len > 0 {
+		g.writeln('${hooks.testsuite_end}();')
+	}
+	g.writeln('return 0;')
+	g.indent--
+	g.writeln('}')
+	g.writeln('')
+}
+
+fn (mut g FlatGen) gen_test_fn_call(test_fn TestHarnessFn, idx int) {
+	if test_fn.ret is types.OptionType || test_fn.ret is types.ResultType {
+		ct := g.optional_type_name(test_fn.ret)
+		tmp_name := '__test_opt_${idx}'
+		g.writeln('${ct} ${tmp_name} = ${test_fn.c_name}();')
+		g.writeln('if (!${tmp_name}.ok) {')
+		g.indent++
+		g.writeln('fprintf(stderr, "test failed: ${c_escape(test_fn.name)}\\n");')
+		g.writeln('return 1;')
+		g.indent--
+		g.writeln('}')
+		return
+	}
+	g.writeln('${test_fn.c_name}();')
+}
+
+fn (g &FlatGen) test_harness_fns() ([]TestHarnessFn, TestHarnessHooks) {
+	mut tests := []TestHarnessFn{}
+	mut hooks := TestHarnessHooks{}
+	for file_idx, file_node in g.a.nodes {
+		if !g.is_user_test_file_node(file_idx, file_node) {
+			continue
+		}
+		module_name := g.test_file_module_name(file_node)
+		if module_name.len > 0 && module_name != 'main' {
+			continue
+		}
+		for i in 0 .. file_node.children_count {
+			child_id := g.a.child(&file_node, i)
+			if int(child_id) < g.a.user_code_start {
+				continue
+			}
+			child := g.a.nodes[int(child_id)]
+			if child.kind != .fn_decl {
+				continue
+			}
+			cname := qualified_fn_name_in_module(module_name, child.value)
+			match child.value {
+				'testsuite_begin' {
+					if hooks.testsuite_begin.len == 0 && g.is_supported_test_hook_decl(child) {
+						hooks.testsuite_begin = cname
+					}
+				}
+				'testsuite_end' {
+					if hooks.testsuite_end.len == 0 && g.is_supported_test_hook_decl(child) {
+						hooks.testsuite_end = cname
+					}
+				}
+				'before_each' {
+					if hooks.before_each.len == 0 && g.is_supported_test_hook_decl(child) {
+						hooks.before_each = cname
+					}
+				}
+				'after_each' {
+					if hooks.after_each.len == 0 && g.is_supported_test_hook_decl(child) {
+						hooks.after_each = cname
+					}
+				}
+				else {
+					if child.value.starts_with('test_') && g.is_supported_test_fn_decl(child) {
+						tests << TestHarnessFn{
+							name:   child.value
+							c_name: cname
+							ret:    g.tc.parse_type(child.typ)
+						}
+					}
+				}
+			}
+		}
+	}
+	return tests, hooks
+}
+
+fn (g &FlatGen) is_supported_test_fn_decl(node flat.Node) bool {
+	if g.test_fn_param_count(node) != 0 {
+		return false
+	}
+	return test_harness_fn_return_supported(g.tc.parse_type(node.typ))
+}
+
+fn (g &FlatGen) is_supported_test_hook_decl(node flat.Node) bool {
+	return g.test_fn_param_count(node) == 0 && g.tc.parse_type(node.typ) is types.Void
+}
+
+fn (g &FlatGen) test_fn_param_count(node flat.Node) int {
+	mut count := 0
+	for i in 0 .. node.children_count {
+		child := g.a.child_node(&node, i)
+		if child.kind == .param {
+			count++
+		}
+	}
+	return count
+}
+
+fn test_harness_fn_return_supported(ret types.Type) bool {
+	return ret is types.Void || ret is types.OptionType || ret is types.ResultType
+}
+
+fn (g &FlatGen) is_user_test_file_node(file_idx int, file_node flat.Node) bool {
+	if file_idx < g.a.user_code_start || file_node.kind != .file || file_node.children_count == 0 {
+		return false
+	}
+	return g.test_files[file_node.value]
+}
+
+fn (g &FlatGen) test_file_module_name(file_node flat.Node) string {
+	for i in 0 .. file_node.children_count {
+		child := g.a.child_node(&file_node, i)
+		if child.kind == .module_decl {
+			return child.value
+		}
+	}
+	return ''
 }
 
 // collect_function_defer_ids updates collect function defer ids state for c.
@@ -1059,7 +1431,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					false
 				}
 				if base.kind == .ident && base.value == 'C' {
-					g.write(fn_node.value)
+					g.write(g.direct_call_name('C.${fn_node.value}'))
 					is_c_call = true
 				} else if g.is_flag_enum_method(fn_node) {
 					g.gen_flag_enum_call(node)
@@ -1619,10 +1991,6 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					g.gen_params_struct_arg(ptyp, node, i)
 					break
 				}
-				if fixed := net_ip_fixed_arg_type(target_name, arg_idx) {
-					g.gen_fixed_array_data_arg(arg_id, fixed)
-					continue
-				}
 				if fixed := array_fixed_type(g.tc.resolve_type(arg_id)) {
 					g.gen_fixed_array_data_arg(arg_id, fixed)
 					continue
@@ -1676,7 +2044,8 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 				if !is_c_call && arg_idx < param_types.len && param_types[arg_idx] is types.Pointer
 					&& !(arg_node.kind == .prefix && arg_node.op == .amp) {
 					arg_type := g.tc.resolve_type(arg_id)
-					if arg_type !is types.Pointer {
+					if arg_type !is types.Pointer
+						&& !c_string_literal_pointer_arg(arg_node, param_types[arg_idx]) {
 						needs_addr = true
 					}
 				}
@@ -2290,15 +2659,8 @@ fn (mut g FlatGen) param_types_for(name string, fallback string) []types.Type {
 }
 
 fn (mut g FlatGen) param_types_for_uncached(name string, fallback string) []types.Type {
-	if name in ['json2.LinkedList[ValueInfo].push', 'json2.LinkedList_ValueInfo.push'] {
-		return [
-			g.tc.parse_type('&json2.LinkedList[ValueInfo]'),
-			g.tc.parse_type('json2.ValueInfo'),
-		]
-	}
-	if name in ['json2.LinkedList[ValueInfo].last', 'json2.LinkedList_ValueInfo.last',
-		'json2.LinkedList[ValueInfo].free', 'json2.LinkedList_ValueInfo.free'] {
-		return [g.tc.parse_type('&json2.LinkedList[ValueInfo]')]
+	if generic_params := g.generic_receiver_method_param_types(name) {
+		return generic_params
 	}
 	if interface_types := g.interface_method_param_types(name) {
 		return interface_types
@@ -2328,6 +2690,16 @@ fn (mut g FlatGen) param_types_for_uncached(name string, fallback string) []type
 		}
 	}
 	return []types.Type{}
+}
+
+fn (g &FlatGen) generic_receiver_method_param_types(name string) ?[]types.Type {
+	if !name.contains('.') || !name.contains('[') || !name.contains(']') {
+		return none
+	}
+	receiver := name.all_before_last('.')
+	method := name.all_after_last('.')
+	info := g.tc.resolve_generic_struct_method(receiver, method) or { return none }
+	return info.params.clone()
 }
 
 // precompute_param_type_index builds short-name -> param-types, preserving the fallback's
@@ -2427,6 +2799,268 @@ fn (mut g FlatGen) gen_arg_for_expected_type(arg_id flat.NodeId, expected types.
 		return
 	}
 	g.gen_expr_with_expected_type(arg_id, expected)
+}
+
+fn (mut g FlatGen) gen_callback_fn_value_for_expected_type(arg_id flat.NodeId, expected types.Type) bool {
+	return g.gen_callback_fn_value_for_expected_c_abi(arg_id, expected, '')
+}
+
+fn (mut g FlatGen) gen_callback_fn_value_for_expected_c_abi(arg_id flat.NodeId, expected types.Type, expected_c_abi string) bool {
+	expected_fn := fn_type_from(expected) or { return false }
+	actual_name := g.callback_fn_value_name(arg_id, expected) or { return false }
+	actual_fn := g.callback_fn_value_type(actual_name) or { return false }
+	wrapper := g.ensure_callback_userdata_wrapper(actual_name, actual_fn, expected_fn,
+		expected_c_abi) or { return false }
+	g.write(wrapper)
+	return true
+}
+
+fn (mut g FlatGen) gen_callback_fn_value_for_field_c_abi(arg_id flat.NodeId, expected types.Type, expected_c_abi string) bool {
+	if expected_c_abi.len == 0 {
+		return false
+	}
+	if g.gen_callback_fn_value_for_expected_c_abi(arg_id, expected, expected_c_abi) {
+		return true
+	}
+	if call_name := g.callback_direct_fn_value_name_for_c_abi(arg_id, expected, expected_c_abi) {
+		g.write(g.callback_c_fn_name(call_name))
+		return true
+	}
+	if _ := g.callback_fn_value_name(arg_id, expected) {
+		g.gen_expr(arg_id)
+		return true
+	}
+	return false
+}
+
+fn (mut g FlatGen) callback_fn_value_name(id flat.NodeId, expected types.Type) ?string {
+	if name := g.tc.resolved_fn_value_name(id) {
+		return name
+	}
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return none
+	}
+	node := g.a.nodes[int(id)]
+	if node.kind in [.cast_expr, .paren, .expr_stmt] && node.children_count > 0 {
+		return g.callback_fn_value_name(g.a.child(&node, 0), expected)
+	}
+	return none
+}
+
+fn (mut g FlatGen) callback_direct_fn_value_name(id flat.NodeId, expected types.Type) ?string {
+	return g.callback_direct_fn_value_name_for_c_abi(id, expected, '')
+}
+
+fn (mut g FlatGen) callback_direct_fn_value_name_for_c_abi(id flat.NodeId, expected types.Type, expected_c_abi string) ?string {
+	expected_fn := fn_type_from(expected) or { return none }
+	actual_name := g.callback_fn_value_name(id, expected) or { return none }
+	actual_fn := g.callback_fn_value_type(actual_name) or { return none }
+	if !g.callback_fn_types_direct_compatible(actual_fn, expected_fn, expected_c_abi) {
+		return none
+	}
+	return actual_name
+}
+
+fn (mut g FlatGen) callback_fn_value_type(name string) ?types.FnType {
+	params := g.tc.fn_param_types[name] or { return none }
+	ret := g.tc.fn_ret_types[name] or { return none }
+	return types.FnType{
+		params:      params.clone()
+		return_type: ret
+	}
+}
+
+fn (mut g FlatGen) callback_fn_types_direct_compatible(actual types.FnType, expected types.FnType, expected_c_abi string) bool {
+	if actual.params.len != expected.params.len {
+		return false
+	}
+	if g.callback_c_type(actual.return_type) != g.callback_expected_return_c_type(expected.return_type,
+		expected_c_abi) {
+		return false
+	}
+	for i in 0 .. expected.params.len {
+		if g.callback_c_type(fn_type_param(actual, i)) != g.callback_expected_param_c_type(expected,
+			i, expected_c_abi) {
+			return false
+		}
+	}
+	return true
+}
+
+fn (mut g FlatGen) ensure_callback_userdata_wrapper(actual_name string, actual types.FnType, expected types.FnType, expected_c_abi string) ?string {
+	if actual.params.len != expected.params.len {
+		return none
+	}
+	actual_ret_ct := g.callback_c_type(actual.return_type)
+	expected_ret_ct := g.callback_expected_return_c_type(expected.return_type, expected_c_abi)
+	if actual_ret_ct != expected_ret_ct {
+		return none
+	}
+	mut needs_wrapper := false
+	mut param_decls := []string{}
+	mut call_args := []string{}
+	for i in 0 .. expected.params.len {
+		expected_param := fn_type_param(expected, i)
+		actual_param := fn_type_param(actual, i)
+		expected_ct := g.callback_expected_param_c_type(expected, i, expected_c_abi)
+		actual_ct := g.callback_c_type(actual_param)
+		param_decls << '${expected_ct} arg${i}'
+		if actual_ct == expected_ct {
+			call_args << 'arg${i}'
+			continue
+		}
+		if g.callback_can_cast_userdata_param(actual_param, expected_param) {
+			call_args << '(${actual_ct})arg${i}'
+			needs_wrapper = true
+			continue
+		}
+		if callback_can_cast_const_abi_param(actual_ct, expected_ct) {
+			call_args << '(${actual_ct})arg${i}'
+			needs_wrapper = true
+			continue
+		}
+		return none
+	}
+	if !needs_wrapper {
+		return none
+	}
+	actual_c_name := g.callback_c_fn_name(actual_name)
+	expected_key := if expected_c_abi.len > 0 {
+		expected_c_abi
+	} else {
+		g.callback_fn_type_key(expected)
+	}
+	key := '${actual_c_name}|${g.callback_fn_type_key(actual)}|${expected_key}'
+	if name := g.callback_wrapper_names[key] {
+		return name
+	}
+	name := c_name('${actual_c_name}_callback_adapter_${callback_stable_key_hash(key)}')
+	g.callback_wrapper_names[key] = name
+	params := if param_decls.len == 0 { 'void' } else { param_decls.join(', ') }
+	call := '${actual_c_name}(${call_args.join(', ')})'
+	body := if expected_ret_ct == 'void' {
+		'static void ${name}(${params}) { ${call}; }'
+	} else {
+		'static ${expected_ret_ct} ${name}(${params}) { return ${call}; }'
+	}
+	g.callback_wrapper_defs << body
+	return name
+}
+
+fn (mut g FlatGen) callback_expected_return_c_type(typ types.Type, expected_c_abi string) string {
+	if expected_c_abi.len > 0 {
+		ret, _ := fn_ptr_typedef_parts(expected_c_abi)
+		return ret.trim_space()
+	}
+	return g.callback_c_type(typ)
+}
+
+fn (mut g FlatGen) callback_expected_param_c_type(expected types.FnType, idx int, expected_c_abi string) string {
+	if expected_c_abi.len > 0 {
+		params := callback_fn_ptr_param_c_types(expected_c_abi)
+		if idx < params.len {
+			return params[idx]
+		}
+	}
+	return g.callback_c_type(fn_type_param(expected, idx))
+}
+
+fn callback_fn_ptr_param_c_types(encoded string) []string {
+	_, params := fn_ptr_typedef_parts(encoded)
+	clean := params.trim_space()
+	if clean.len == 0 || clean == 'void' {
+		return []string{}
+	}
+	mut out := []string{}
+	for param in clean.split(',') {
+		out << param.trim_space()
+	}
+	return out
+}
+
+fn callback_can_cast_const_abi_param(actual_ct string, expected_ct string) bool {
+	actual := actual_ct.trim_space()
+	expected := expected_ct.trim_space()
+	if !expected.starts_with('const ') || !expected.ends_with('*') {
+		return false
+	}
+	return actual == expected['const '.len..].trim_space()
+}
+
+fn (mut g FlatGen) callback_c_type(typ types.Type) string {
+	if typ is types.Void {
+		return 'void'
+	}
+	mut ct := if typ is types.OptionType || typ is types.ResultType {
+		g.optional_type_name(typ)
+	} else {
+		g.tc.c_type(typ)
+	}
+	if ct.starts_with('fn_ptr:') {
+		ct = g.resolve_fn_ptr_type(ct)
+	}
+	return ct
+}
+
+fn (mut g FlatGen) callback_fn_type_key(typ types.FnType) string {
+	mut parts := []string{}
+	for i in 0 .. typ.params.len {
+		parts << g.callback_c_type(fn_type_param(typ, i))
+	}
+	return '${g.callback_c_type(typ.return_type)}|${parts.join(',')}'
+}
+
+fn callback_stable_key_hash(key string) string {
+	mut hash := u64(1469598103934665603)
+	for b in key.bytes() {
+		hash ^= u64(b)
+		hash *= u64(1099511628211)
+	}
+	return '${hash}'
+}
+
+fn (g &FlatGen) callback_can_cast_userdata_param(actual types.Type, expected types.Type) bool {
+	return (callback_is_voidptr_type(expected) && callback_is_nonvoid_pointer_type(actual))
+		|| (callback_is_nonvoid_pointer_type(expected) && callback_is_voidptr_type(actual))
+}
+
+fn callback_is_voidptr_type(typ types.Type) bool {
+	clean := callback_unalias_type(typ)
+	if clean is types.Pointer {
+		base := callback_unalias_type(clean.base_type)
+		return base is types.Void
+	}
+	return false
+}
+
+fn callback_is_nonvoid_pointer_type(typ types.Type) bool {
+	clean := callback_unalias_type(typ)
+	if clean is types.Pointer {
+		base := callback_unalias_type(clean.base_type)
+		return base !is types.Void
+	}
+	return false
+}
+
+fn callback_unalias_type(typ types.Type) types.Type {
+	if typ is types.Alias {
+		return callback_unalias_type(typ.base_type)
+	}
+	return typ
+}
+
+fn (g &FlatGen) callback_c_fn_name(name string) string {
+	if name.starts_with('C.') {
+		return c_name(name.all_after_last('.'))
+	}
+	if name.starts_with('main.') {
+		return c_name(name.all_after_last('.'))
+	}
+	return c_name(name)
+}
+
+fn fn_type_param(typ types.FnType, idx int) types.Type {
+	return typ.params[idx]
 }
 
 // gen_optional_arg emits optional arg output for c.
@@ -2567,12 +3201,19 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 		&& c_name(fn_name) !in g.tc.fn_param_types {
 		param_types = g.param_types_for(fn_name.all_after_last('.'), fn_name.all_after_last('.'))
 	}
-	is_variadic_fn := g.tc.fn_variadic[fn_name] or { false }
+	is_c_variadic_fn := g.tc.c_variadic_fns[fn_name] or { false }
+	is_variadic_fn := !is_c_variadic_fn && (g.tc.fn_variadic[fn_name] or { false })
 	variadic_idx := if is_variadic_fn && param_types.len > 0
 		&& param_types[param_types.len - 1] is types.Array {
 		param_types.len - 1
 	} else {
 		-1
+	}
+	typed_param_count := if is_c_variadic_fn && param_types.len > 0
+		&& param_types[param_types.len - 1] is types.Array {
+		param_types.len - 1
+	} else {
+		param_types.len
 	}
 	num_args := node.children_count - start
 	is_variadic := variadic_idx >= 0 && num_args > param_types.len
@@ -2597,7 +3238,7 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 		}
 		if arg_node.kind == .field_init {
 			// `@[params]` struct argument: trailing `key: value` args form a struct literal
-			ptyp := if arg_idx < param_types.len {
+			ptyp := if arg_idx < typed_param_count {
 				param_types[arg_idx]
 			} else {
 				types.Type(types.void_)
@@ -2605,21 +3246,17 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			g.gen_params_struct_arg(ptyp, node, i)
 			break
 		}
-		if fixed := net_ip_fixed_arg_type(fn_name, arg_idx) {
-			g.gen_fixed_array_data_arg(arg_id, fixed)
-			continue
-		}
 		if fixed := array_fixed_type(g.tc.resolve_type(arg_id)) {
 			g.gen_fixed_array_data_arg(arg_id, fixed)
 			continue
 		}
-		if arg_idx < param_types.len {
+		if arg_idx < typed_param_count {
 			if fixed := array_fixed_type(param_types[arg_idx]) {
 				g.gen_fixed_array_data_arg(arg_id, fixed)
 				continue
 			}
 		}
-		if arg_idx < param_types.len
+		if arg_idx < typed_param_count
 			&& g.gen_pointer_arg_from_array_literal(arg_node, param_types[arg_idx]) {
 			continue
 		}
@@ -2661,10 +3298,11 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			}
 		}
 		mut needs_addr := false
-		if arg_idx < param_types.len && param_types[arg_idx] is types.Pointer
+		if arg_idx < typed_param_count && param_types[arg_idx] is types.Pointer
 			&& !(arg_node.kind == .prefix && arg_node.op == .amp) {
 			arg_type := g.tc.resolve_type(arg_id)
-			if arg_type !is types.Pointer {
+			if arg_type !is types.Pointer
+				&& !c_string_literal_pointer_arg(arg_node, param_types[arg_idx]) {
 				needs_addr = true
 			}
 		}
@@ -2678,7 +3316,7 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			g.write('; &_t${g.tmp_count};})')
 			g.tmp_count++
 		} else {
-			if arg_idx < param_types.len {
+			if arg_idx < typed_param_count {
 				if child_id := g.addressed_rvalue_arg(arg_node) {
 					pt := param_types[arg_idx]
 					if pt is types.Pointer {
@@ -2694,12 +3332,12 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			if needs_addr {
 				g.write('&')
 			}
-			emitted_variant := !needs_addr && arg_idx < param_types.len
+			emitted_variant := !needs_addr && arg_idx < typed_param_count
 				&& g.gen_sum_variant_arg(arg_id, param_types[arg_idx])
 			if !emitted_variant {
-				if arg_idx < param_types.len && g.gen_optional_arg(arg_id, param_types[arg_idx]) {
+				if arg_idx < typed_param_count && g.gen_optional_arg(arg_id, param_types[arg_idx]) {
 					// handled
-				} else if arg_idx < param_types.len {
+				} else if arg_idx < typed_param_count {
 					g.gen_expr_with_expected_type(arg_id, param_types[arg_idx])
 				} else {
 					g.gen_expr(arg_id)
@@ -2718,8 +3356,8 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 		}
 	}
 	num_provided := node.children_count - start
-	if num_provided < param_types.len {
-		for i in num_provided .. param_types.len {
+	if num_provided < typed_param_count {
+		for i in num_provided .. typed_param_count {
 			if num_provided > 0 || i > num_provided {
 				g.write(', ')
 			}
@@ -2969,6 +3607,17 @@ fn (mut g FlatGen) forward_decls() {
 			g.write('(')
 			g.write_fn_node_params(node)
 			g.writeln(');')
+			if export_name := g.export_fn_name_in_module(cur_module, node.value) {
+				if !forwarded[export_name] {
+					forwarded[export_name] = true
+					g.write(g.optional_type_name(ret_type))
+					g.write(' ')
+					g.write(export_name)
+					g.write('(')
+					g.write_fn_node_params(node)
+					g.writeln(');')
+				}
+			}
 		} else if kind_id == 76
 			&& (node.value.starts_with('C.v_filelock_') || node.value.starts_with('v_filelock_')) {
 			g.tc.cur_file = cur_file

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1049,7 +1049,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	for stmt in stmts {
 		g.tc.cur_file = stmt.file
 		g.tc.cur_module = stmt.module
-		g.gen_node(stmt.id)
+		g.gen_top_level_main_stmt(stmt.id)
 	}
 	g.gen_all_defers()
 	g.writeln('return 0;')
@@ -1063,6 +1063,23 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.tc.cur_file = old_tc_file
 	g.tc.cur_module = old_tc_module
 	g.tc.pop_scope()
+}
+
+fn (mut g FlatGen) gen_top_level_main_stmt(id flat.NodeId) {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return
+	}
+	node := g.a.nodes[int(id)]
+	if node.kind == .block {
+		for i in 0 .. node.children_count {
+			child_id := g.a.child(&node, i)
+			if g.cgen_is_top_level_stmt(child_id) {
+				g.gen_top_level_main_stmt(child_id)
+			}
+		}
+		return
+	}
+	g.gen_node(id)
 }
 
 fn (mut g FlatGen) gen_test_main() {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -142,7 +142,7 @@ fn (g &FlatGen) cgen_is_top_level_stmt(id flat.NodeId) bool {
 	node := g.a.nodes[int(id)]
 	return match node.kind {
 		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
-		.for_in_stmt, .if_expr, .assert_stmt {
+		.for_in_stmt, .if_expr, .assert_stmt, .defer_stmt {
 			true
 		}
 		.block, .comptime_if {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -927,7 +927,7 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 			g.writeln('\t_vinit();')
 		}
 	} else {
-		ret_type := g.tc.parse_type(node.typ)
+		ret_type := g.fn_node_return_type(node, module_name)
 		g.set_cur_fn_ret(ret_type)
 		g.write(g.fn_return_type_name(ret_type))
 		g.write(' ')
@@ -969,7 +969,7 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 fn (mut g FlatGen) gen_export_wrapper_for_fn(node flat.Node, module_name string) {
 	export_name := g.export_fn_name_in_module(module_name, node.value) or { return }
 	canonical_name := g.fn_c_name_in_module(module_name, node.value)
-	ret_type := g.tc.parse_type(node.typ)
+	ret_type := g.fn_node_return_type(node, module_name)
 	ret_ct := g.fn_return_type_name(ret_type)
 	g.write(ret_ct)
 	g.write(' ')
@@ -1192,6 +1192,9 @@ fn (g &FlatGen) collect_test_harness_decl_ids(node flat.Node, mut ids []flat.Nod
 }
 
 fn (g &FlatGen) is_supported_test_fn_decl(node flat.Node) bool {
+	if node.generic_params.len > 0 {
+		return false
+	}
 	if g.test_fn_param_count(node) != 0 {
 		return false
 	}
@@ -1199,6 +1202,9 @@ fn (g &FlatGen) is_supported_test_fn_decl(node flat.Node) bool {
 }
 
 fn (g &FlatGen) is_supported_test_hook_decl(node flat.Node) bool {
+	if node.generic_params.len > 0 {
+		return false
+	}
 	return g.test_fn_param_count(node) == 0 && g.tc.parse_type(node.typ) is types.Void
 }
 
@@ -3734,7 +3740,7 @@ fn (mut g FlatGen) forward_decls() {
 			forwarded[qfn] = true
 			g.tc.cur_file = cur_file
 			g.tc.cur_module = cur_module
-			ret_type := g.tc.parse_type(node.typ)
+			ret_type := g.fn_node_return_type(node, cur_module)
 			g.write(g.fn_return_type_name(ret_type))
 			g.write(' ')
 			g.write(qfn)
@@ -3906,6 +3912,80 @@ fn (mut g FlatGen) implicit_veb_ctx_type() types.Type {
 	return g.tc.parse_type('mut Context')
 }
 
+fn (mut g FlatGen) fn_node_return_type(node flat.Node, module_name string) types.Type {
+	for candidate in g.fn_node_signature_names(node, module_name) {
+		if rt := g.tc.fn_ret_types[candidate] {
+			return rt
+		}
+	}
+	if info := g.generic_receiver_method_call_info(node.value) {
+		return info.return_type
+	}
+	return g.tc.parse_type(node.typ)
+}
+
+fn (mut g FlatGen) fn_node_param_types(node flat.Node, module_name string) []types.Type {
+	if g.fn_needs_implicit_veb_ctx(node) {
+		return []types.Type{}
+	}
+	mut explicit_params := 0
+	for i in 0 .. node.children_count {
+		if g.a.child_node(&node, i).kind == .param {
+			explicit_params++
+		}
+	}
+	for candidate in g.fn_node_signature_names(node, module_name) {
+		if params := g.tc.fn_param_types[candidate] {
+			if params.len == explicit_params {
+				return params
+			}
+		}
+	}
+	if info := g.generic_receiver_method_call_info(node.value) {
+		if info.params.len == explicit_params {
+			return info.params.clone()
+		}
+	}
+	return []types.Type{}
+}
+
+fn (g &FlatGen) generic_receiver_method_call_info(name string) ?types.CallInfo {
+	if !name.contains('.') {
+		return none
+	}
+	receiver := name.all_before_last('.')
+	if !receiver.contains('[') || !receiver.contains(']') {
+		return none
+	}
+	return g.tc.resolve_generic_struct_method(receiver, name.all_after_last('.'))
+}
+
+fn (mut g FlatGen) fn_node_signature_names(node flat.Node, module_name string) []string {
+	dotted_name := qualify_name_in_module(module_name, node.value)
+	cname := g.fn_c_name_in_module(module_name, node.value)
+	mut names := []string{}
+	if module_name.len > 0 && module_name != 'main' && module_name != 'builtin' {
+		names << dotted_name
+		names << c_name(dotted_name)
+		names << cname
+		names << node.value
+		names << c_name(node.value)
+	} else {
+		names << node.value
+		names << c_name(node.value)
+		names << dotted_name
+		names << c_name(dotted_name)
+		names << cname
+	}
+	mut deduped := []string{cap: names.len}
+	for name in names {
+		if name.len > 0 && name !in deduped {
+			deduped << name
+		}
+	}
+	return deduped
+}
+
 // write_fn_node_params writes fn node params output for c.
 fn (mut g FlatGen) write_fn_node_params(node flat.Node) {
 	mut params_len := 0
@@ -3923,16 +4003,26 @@ fn (mut g FlatGen) write_fn_node_params(node flat.Node) {
 		return
 	}
 	mut written := 0
+	mut param_idx := 0
 	mut implicit_ctx_written := false
 	insert_implicit_ctx_after_first := needs_implicit_ctx && g.fn_has_receiver_param(node)
+	typed_params := g.fn_node_param_types(node, g.tc.cur_module)
+	concrete_optional_params := g.is_specialized_generic_fn_node(node)
 	for i in 0 .. node.children_count {
 		param_id := g.a.child(&node, i)
 		p := g.a.node(param_id)
 		if p.kind != .param {
 			continue
 		}
-		pt := g.tc.parse_type(p.typ)
-		ct := if pt is types.ArrayFixed {
+		pt := if param_idx < typed_params.len {
+			typed_params[param_idx]
+		} else {
+			g.tc.parse_type(p.typ)
+		}
+		param_idx++
+		ct := if concrete_optional_params && (pt is types.OptionType || pt is types.ResultType) {
+			g.concrete_optional_type_name(pt)
+		} else if pt is types.ArrayFixed {
 			'${g.tc.c_type(pt.elem_type)}*'
 		} else if pt is types.OptionType || pt is types.ResultType {
 			g.optional_type_name(pt)
@@ -3965,6 +4055,29 @@ fn (mut g FlatGen) write_fn_node_params(node flat.Node) {
 	if needs_implicit_ctx && !implicit_ctx_written {
 		g.write_implicit_veb_ctx_param()
 	}
+}
+
+fn (g &FlatGen) is_specialized_generic_fn_node(node flat.Node) bool {
+	return node.value.contains('[') || node.value.contains('_T_')
+}
+
+fn (mut g FlatGen) concrete_optional_type_name(t types.Type) string {
+	mut base_type := types.Type(types.void_)
+	if t is types.OptionType {
+		base_type = t.base_type
+	} else if t is types.ResultType {
+		base_type = t.base_type
+	} else {
+		return g.tc.c_type(t)
+	}
+	mut inner_ct := g.tc.c_type(base_type)
+	if inner_ct.starts_with('fn_ptr:') {
+		inner_ct = g.resolve_fn_ptr_type(inner_ct)
+	}
+	safe_name := inner_ct.replace('*', 'ptr').replace(' ', '_')
+	opt_name := 'Optional_${safe_name}'
+	g.needed_optional_types[opt_name] = inner_ct
+	return opt_name
 }
 
 fn (mut g FlatGen) write_implicit_veb_ctx_param() {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -17,6 +17,12 @@ mut:
 	after_each      string
 }
 
+struct TopLevelStmt {
+	id     flat.NodeId
+	file   string
+	module string
+}
+
 // gen_fns emits fns output for c.
 fn (mut g FlatGen) gen_fns() {
 	mut cur_module := ''
@@ -58,11 +64,13 @@ fn (mut g FlatGen) gen_synthetic_main_after_fns() {
 	if g.has_entry_main() {
 		return
 	}
-	top_level_ids := g.top_level_stmt_ids()
-	if top_level_ids.len > 0 {
-		g.gen_top_level_main(top_level_ids)
-	} else if g.test_files.len > 0 {
+	if g.test_files.len > 0 {
 		g.gen_test_main()
+		return
+	}
+	top_level_stmts := g.top_level_stmts()
+	if top_level_stmts.len > 0 {
+		g.gen_top_level_main(top_level_stmts)
 	}
 }
 
@@ -85,12 +93,13 @@ fn (g &FlatGen) has_entry_main() bool {
 	return false
 }
 
-fn (g &FlatGen) top_level_stmt_ids() []flat.NodeId {
-	mut ids := []flat.NodeId{}
+fn (g &FlatGen) top_level_stmts() []TopLevelStmt {
+	mut stmts := []TopLevelStmt{}
 	for file_idx, file_node in g.a.nodes {
 		if !g.should_emit_top_level_file(file_idx, file_node) {
 			continue
 		}
+		module_name := g.top_level_file_module_name(file_node)
 		for i in 0 .. file_node.children_count {
 			child_id := g.a.child(&file_node, i)
 			if int(child_id) < g.a.user_code_start {
@@ -98,11 +107,15 @@ fn (g &FlatGen) top_level_stmt_ids() []flat.NodeId {
 			}
 			child := g.a.nodes[int(child_id)]
 			if cgen_is_top_level_stmt(child) {
-				ids << child_id
+				stmts << TopLevelStmt{
+					id:     child_id
+					file:   file_node.value
+					module: if module_name.len == 0 { 'main' } else { module_name }
+				}
 			}
 		}
 	}
-	return ids
+	return stmts
 }
 
 fn (g &FlatGen) should_emit_top_level_file(file_idx int, file_node flat.Node) bool {
@@ -904,7 +917,9 @@ fn (mut g FlatGen) export_wrapper_arg_names(node flat.Node) []string {
 	return args
 }
 
-fn (mut g FlatGen) gen_top_level_main(stmt_ids []flat.NodeId) {
+fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
+	old_tc_file := g.tc.cur_file
+	old_tc_module := g.tc.cur_module
 	g.tc.cur_module = 'main'
 	old_fn_name := g.cur_fn_name
 	g.cur_fn_name = 'main'
@@ -922,8 +937,8 @@ fn (mut g FlatGen) gen_top_level_main(stmt_ids []flat.NodeId) {
 	g.cur_param_type_values = []types.Type{}
 	g.cur_param_types = map[string]types.Type{}
 	mut fn_defer_ids := []flat.NodeId{}
-	for id in stmt_ids {
-		g.collect_function_defer_ids_from(id, mut fn_defer_ids)
+	for stmt in stmts {
+		g.collect_function_defer_ids_from(stmt.id, mut fn_defer_ids)
 	}
 	g.prepare_function_defers(fn_defer_ids)
 	g.writeln('int main(int argc, char** argv) {')
@@ -937,9 +952,10 @@ fn (mut g FlatGen) gen_top_level_main(stmt_ids []flat.NodeId) {
 	}
 	g.indent++
 	g.gen_function_defer_prelude()
-	for id in stmt_ids {
-		g.tc.cur_module = 'main'
-		g.gen_node(id)
+	for stmt in stmts {
+		g.tc.cur_file = stmt.file
+		g.tc.cur_module = stmt.module
+		g.gen_node(stmt.id)
 	}
 	g.gen_all_defers()
 	g.writeln('return 0;')
@@ -950,6 +966,8 @@ fn (mut g FlatGen) gen_top_level_main(stmt_ids []flat.NodeId) {
 	g.cur_param_type_values = old_param_type_values.clone()
 	g.cur_param_types = old_param_types.clone()
 	g.cur_fn_name = old_fn_name
+	g.tc.cur_file = old_tc_file
+	g.tc.cur_module = old_tc_module
 	g.tc.pop_scope()
 }
 
@@ -1014,15 +1032,10 @@ fn (g &FlatGen) test_harness_fns() ([]TestHarnessFn, TestHarnessHooks) {
 		if module_name.len > 0 && module_name != 'main' {
 			continue
 		}
-		for i in 0 .. file_node.children_count {
-			child_id := g.a.child(&file_node, i)
-			if int(child_id) < g.a.user_code_start {
-				continue
-			}
+		mut decl_ids := []flat.NodeId{}
+		g.collect_test_harness_decl_ids(file_node, mut decl_ids)
+		for child_id in decl_ids {
 			child := g.a.nodes[int(child_id)]
-			if child.kind != .fn_decl {
-				continue
-			}
 			cname := qualified_fn_name_in_module(module_name, child.value)
 			match child.value {
 				'testsuite_begin' {
@@ -1058,6 +1071,24 @@ fn (g &FlatGen) test_harness_fns() ([]TestHarnessFn, TestHarnessHooks) {
 		}
 	}
 	return tests, hooks
+}
+
+fn (g &FlatGen) collect_test_harness_decl_ids(node flat.Node, mut ids []flat.NodeId) {
+	if node.kind != .file && node.kind != .block {
+		return
+	}
+	for i in 0 .. node.children_count {
+		child_id := g.a.child(&node, i)
+		if int(child_id) < g.a.user_code_start {
+			continue
+		}
+		child := g.a.nodes[int(child_id)]
+		if child.kind == .fn_decl {
+			ids << child_id
+		} else if child.kind == .block {
+			g.collect_test_harness_decl_ids(child, mut ids)
+		}
+	}
 }
 
 fn (g &FlatGen) is_supported_test_fn_decl(node flat.Node) bool {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -48,7 +48,7 @@ fn (mut g FlatGen) gen_fns() {
 			if !g.should_emit_fn_node_in_module(node, i, cur_module) {
 				continue
 			}
-			qfn := qualified_fn_name_in_module(cur_module, node.value)
+			qfn := g.fn_c_name_in_module(cur_module, node.value)
 			if g.emitted_fn_contains(qfn) {
 				continue
 			}
@@ -61,11 +61,11 @@ fn (mut g FlatGen) gen_fns() {
 }
 
 fn (mut g FlatGen) gen_synthetic_main_after_fns() {
-	if g.has_entry_main() {
-		return
-	}
 	if g.test_files.len > 0 {
 		g.gen_test_main()
+		return
+	}
+	if g.has_entry_main() {
 		return
 	}
 	top_level_stmts := g.top_level_stmts()
@@ -157,6 +157,9 @@ fn (mut g FlatGen) should_emit_fn_node(node flat.Node, node_index int) bool {
 fn (mut g FlatGen) should_emit_fn_node_in_module(node flat.Node, node_index int, module_name string) bool {
 	_ = node_index
 	qfn := qualified_fn_name_in_module(module_name, node.value)
+	if g.should_rename_user_main_for_tests(module_name, node.value) {
+		return true
+	}
 	if module_name == 'builtin' && node.value == 'exit' {
 		return true
 	}
@@ -235,10 +238,70 @@ fn qualified_fn_name_in_module(module_name string, name string) string {
 	return c_name(name)
 }
 
+fn is_main_fn_in_main_module(module_name string, name string) bool {
+	return name == 'main' && (module_name.len == 0 || module_name == 'main')
+}
+
+fn (g &FlatGen) should_rename_user_main_for_tests(module_name string, name string) bool {
+	return g.test_files.len > 0 && is_main_fn_in_main_module(module_name, name)
+}
+
+fn (g &FlatGen) fn_c_name_in_module(module_name string, name string) string {
+	if g.should_rename_user_main_for_tests(module_name, name) {
+		return g.test_user_main_c_name()
+	}
+	return qualified_fn_name_in_module(module_name, name)
+}
+
+fn (g &FlatGen) test_user_main_c_name() string {
+	base := 'main__user_main'
+	if !g.c_fn_symbol_exists(base) {
+		return base
+	}
+	limit := g.a.nodes.len + 2
+	for idx in 1 .. limit {
+		candidate := '${base}_${idx}'
+		if !g.c_fn_symbol_exists(candidate) {
+			return candidate
+		}
+	}
+	return '${base}_${limit}'
+}
+
+fn (g &FlatGen) c_fn_symbol_exists(candidate string) bool {
+	mut cur_module := ''
+	for node in g.a.nodes {
+		kind_id := node_kind_id(node)
+		if kind_id == 77 {
+			cur_module = ''
+			continue
+		}
+		if kind_id == 73 {
+			cur_module = node.value
+			continue
+		}
+		if kind_id != 61 {
+			continue
+		}
+		if qualified_fn_name_in_module(cur_module, node.value) == candidate {
+			return true
+		}
+		if export_name := g.export_fn_name_in_module(cur_module, node.value) {
+			if export_name == candidate {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // direct_call_name supports direct call name handling for FlatGen.
 fn (mut g FlatGen) direct_call_name(name string) string {
 	if compat_name := g.libc_compat_call_name(name) {
 		return compat_name
+	}
+	if g.test_files.len > 0 && (name == 'main' || name == 'main.main') {
+		return g.test_user_main_c_name()
 	}
 	if name == 'free' {
 		return 'v_free'
@@ -259,6 +322,26 @@ fn (mut g FlatGen) libc_compat_call_name(name string) ?string {
 	if name == 'C.gettid' {
 		g.libc_compat_fns['gettid'] = true
 		return 'v3_gettid'
+	}
+	return none
+}
+
+fn (g &FlatGen) test_user_main_fn_value_c_name(id flat.NodeId, node flat.Node) ?string {
+	if g.test_files.len == 0 || node.kind != .ident || node.value != 'main' {
+		return none
+	}
+	looked_up := g.tc.cur_scope.lookup(node.value) or { types.Type(types.void_) }
+	if looked_up !is types.Void {
+		return none
+	}
+	if resolved := g.tc.resolved_fn_value_name(id) {
+		if resolved == 'main' || resolved == 'main.main' {
+			return g.test_user_main_c_name()
+		}
+		return none
+	}
+	if g.usable_expr_type(id) is types.FnType {
+		return g.test_user_main_c_name()
 	}
 	return none
 }
@@ -821,7 +904,7 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 	g.insert_cur_implicit_veb_ctx_param(node)
 	fn_defer_ids := g.collect_function_defer_ids(node)
 	g.prepare_function_defers(fn_defer_ids)
-	is_entry_main := node.value == 'main' && (module_name.len == 0 || module_name == 'main')
+	is_entry_main := is_main_fn_in_main_module(module_name, node.value) && g.test_files.len == 0
 	if is_entry_main {
 		g.writeln('int main(int argc, char** argv) {')
 		if g.has_builtins {
@@ -837,7 +920,7 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 		g.set_cur_fn_ret(ret_type)
 		g.write(g.fn_return_type_name(ret_type))
 		g.write(' ')
-		g.write(qualified_fn_name_in_module(module_name, node.value))
+		g.write(g.fn_c_name_in_module(module_name, node.value))
 		g.write('(')
 		g.write_fn_node_params(node)
 		g.writeln(') {')
@@ -874,7 +957,7 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 
 fn (mut g FlatGen) gen_export_wrapper_for_fn(node flat.Node, module_name string) {
 	export_name := g.export_fn_name_in_module(module_name, node.value) or { return }
-	canonical_name := qualified_fn_name_in_module(module_name, node.value)
+	canonical_name := g.fn_c_name_in_module(module_name, node.value)
 	ret_type := g.tc.parse_type(node.typ)
 	ret_ct := g.optional_type_name(ret_type)
 	g.write(ret_ct)
@@ -991,7 +1074,7 @@ fn (mut g FlatGen) gen_test_main() {
 		if hooks.before_each.len > 0 {
 			g.writeln('${hooks.before_each}();')
 		}
-		g.gen_test_fn_call(test_fn, idx)
+		g.gen_test_fn_call(test_fn, hooks, idx)
 		if hooks.after_each.len > 0 {
 			g.writeln('${hooks.after_each}();')
 		}
@@ -1005,7 +1088,7 @@ fn (mut g FlatGen) gen_test_main() {
 	g.writeln('')
 }
 
-fn (mut g FlatGen) gen_test_fn_call(test_fn TestHarnessFn, idx int) {
+fn (mut g FlatGen) gen_test_fn_call(test_fn TestHarnessFn, hooks TestHarnessHooks, idx int) {
 	if test_fn.ret is types.OptionType || test_fn.ret is types.ResultType {
 		ct := g.optional_type_name(test_fn.ret)
 		tmp_name := '__test_opt_${idx}'
@@ -1013,6 +1096,12 @@ fn (mut g FlatGen) gen_test_fn_call(test_fn TestHarnessFn, idx int) {
 		g.writeln('if (!${tmp_name}.ok) {')
 		g.indent++
 		g.writeln('fprintf(stderr, "test failed: ${c_escape(test_fn.name)}\\n");')
+		if hooks.after_each.len > 0 {
+			g.writeln('${hooks.after_each}();')
+		}
+		if hooks.testsuite_end.len > 0 {
+			g.writeln('${hooks.testsuite_end}();')
+		}
 		g.writeln('return 1;')
 		g.indent--
 		g.writeln('}')
@@ -3084,6 +3173,9 @@ fn (g &FlatGen) callback_c_fn_name(name string) string {
 	if name.starts_with('C.') {
 		return c_name(name.all_after_last('.'))
 	}
+	if g.test_files.len > 0 && (name == 'main' || name == 'main.main') {
+		return g.test_user_main_c_name()
+	}
 	if name.starts_with('main.') {
 		return c_name(name.all_after_last('.'))
 	}
@@ -3619,12 +3711,12 @@ fn (mut g FlatGen) forward_decls() {
 			continue
 		}
 
-		is_entry_main := node.value == 'main' && (cur_module.len == 0 || cur_module == 'main')
+		is_entry_main := is_main_fn_in_main_module(cur_module, node.value) && g.test_files.len == 0
 		if kind_id == 61 && !is_entry_main {
 			if !g.should_emit_fn_node_in_module(node, i, cur_module) {
 				continue
 			}
-			qfn := qualified_fn_name_in_module(cur_module, node.value)
+			qfn := g.fn_c_name_in_module(cur_module, node.value)
 			if forwarded[qfn] {
 				continue
 			}

--- a/vlib/v3/gen/c/fn_d_parallel.v
+++ b/vlib/v3/gen/c/fn_d_parallel.v
@@ -434,9 +434,13 @@ fn (g &FlatGen) clone_parallel_type_checker() &types.TypeChecker {
 		a:                             unsafe { g.tc.a }
 		fn_ret_types:                  g.tc.fn_ret_types
 		fn_param_types:                g.tc.fn_param_types
+		fn_ret_type_texts:             g.tc.fn_ret_type_texts
+		fn_param_type_texts:           g.tc.fn_param_type_texts
 		fn_variadic:                   g.tc.fn_variadic
+		fn_implicit_veb_ctx:           g.tc.fn_implicit_veb_ctx
 		c_variadic_fns:                g.tc.c_variadic_fns
 		structs:                       g.tc.structs
+		struct_generic_params:         g.tc.struct_generic_params
 		struct_field_c_abi_fns:        g.tc.struct_field_c_abi_fns
 		unions:                        g.tc.unions
 		type_aliases:                  g.tc.type_aliases

--- a/vlib/v3/gen/c/fn_d_parallel.v
+++ b/vlib/v3/gen/c/fn_d_parallel.v
@@ -436,6 +436,8 @@ fn (g &FlatGen) clone_parallel_type_checker() &types.TypeChecker {
 		fn_param_types:                g.tc.fn_param_types
 		fn_ret_type_texts:             g.tc.fn_ret_type_texts
 		fn_param_type_texts:           g.tc.fn_param_type_texts
+		fn_type_files:                 g.tc.fn_type_files
+		fn_type_modules:               g.tc.fn_type_modules
 		fn_variadic:                   g.tc.fn_variadic
 		fn_implicit_veb_ctx:           g.tc.fn_implicit_veb_ctx
 		c_variadic_fns:                g.tc.c_variadic_fns

--- a/vlib/v3/gen/c/fn_d_parallel.v
+++ b/vlib/v3/gen/c/fn_d_parallel.v
@@ -360,7 +360,7 @@ fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 		a:                        unsafe { g.a }
 		used_fns:                 g.used_fns
 		used_fn_names:            g.used_fn_names
-		test_files:               g.test_files
+		test_files:               g.test_files.clone()
 		str_lits:                 g.str_lits.clone()
 		str_lit_ids:              g.str_lit_ids.clone()
 		global_types:             g.global_types

--- a/vlib/v3/gen/c/fn_d_parallel.v
+++ b/vlib/v3/gen/c/fn_d_parallel.v
@@ -56,6 +56,7 @@ $if !windows {
 fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 	if no_parallel {
 		g.gen_fns()
+		g.gen_synthetic_main_after_fns()
 		return
 	}
 	items := g.collect_fn_gen_items()
@@ -63,10 +64,12 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 	n_jobs := flat_cgen_job_count(runtime.nr_jobs(), n_items)
 	$if windows {
 		g.gen_fn_items(items)
+		g.gen_synthetic_main_after_fns()
 		return
 	} $else {
 		if n_items < min_flat_cgen_parallel_items || n_jobs <= 1 {
 			g.gen_fn_items(items)
+			g.gen_synthetic_main_after_fns()
 			return
 		}
 		g.parallel_used = true
@@ -118,6 +121,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			w := unsafe { &FlatGen(workers[ci]) }
 			g.merge_parallel_worker(w)
 		}
+		g.gen_synthetic_main_after_fns()
 	}
 }
 
@@ -356,6 +360,7 @@ fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 		a:                        unsafe { g.a }
 		used_fns:                 g.used_fns
 		used_fn_names:            g.used_fn_names
+		test_files:               g.test_files
 		str_lits:                 g.str_lits.clone()
 		str_lit_ids:              g.str_lit_ids.clone()
 		global_types:             g.global_types
@@ -372,6 +377,7 @@ fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 		module_init_fns:          g.module_init_fns
 		module_init_fn_modules:   g.module_init_fn_modules
 		module_imports:           g.module_imports
+		libc_compat_fns:          g.libc_compat_fns.clone()
 		tc:                       g.clone_parallel_type_checker()
 		has_builtins:             g.has_builtins
 		tmp_count:                (worker_id + 1) * 100_000
@@ -400,6 +406,10 @@ fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 		param_types_cache:        g.param_types_cache.clone()
 		embedded_fields_by_type:  g.embedded_fields_by_type
 		param_types_by_short:     g.param_types_by_short
+		spawn_wrapper_names:      g.spawn_wrapper_names.clone()
+		spawn_wrapper_defs:       g.spawn_wrapper_defs.clone()
+		callback_wrapper_names:   g.callback_wrapper_names.clone()
+		callback_wrapper_defs:    g.callback_wrapper_defs.clone()
 	}
 }
 
@@ -425,9 +435,12 @@ fn (g &FlatGen) clone_parallel_type_checker() &types.TypeChecker {
 		fn_ret_types:                  g.tc.fn_ret_types
 		fn_param_types:                g.tc.fn_param_types
 		fn_variadic:                   g.tc.fn_variadic
+		c_variadic_fns:                g.tc.c_variadic_fns
 		structs:                       g.tc.structs
+		struct_field_c_abi_fns:        g.tc.struct_field_c_abi_fns
 		unions:                        g.tc.unions
 		type_aliases:                  g.tc.type_aliases
+		type_alias_c_abi_fns:          g.tc.type_alias_c_abi_fns
 		sum_types:                     g.tc.sum_types
 		enum_names:                    g.tc.enum_names
 		enum_fields:                   g.tc.enum_fields
@@ -443,6 +456,7 @@ fn (g &FlatGen) clone_parallel_type_checker() &types.TypeChecker {
 		const_suffixes:                g.tc.const_suffixes
 		imports:                       g.tc.imports
 		file_imports:                  g.tc.file_imports
+		file_selective_imports:        g.tc.file_selective_imports
 		file_modules:                  g.tc.file_modules
 		file_scope:                    fs
 		cur_scope:                     fs
@@ -453,6 +467,8 @@ fn (g &FlatGen) clone_parallel_type_checker() &types.TypeChecker {
 		errors:                        g.tc.errors.clone()
 		resolved_call_names:           g.tc.resolved_call_names
 		resolved_call_set:             g.tc.resolved_call_set
+		resolved_fn_value_names:       g.tc.resolved_fn_value_names
+		resolved_fn_value_set:         g.tc.resolved_fn_value_set
 		expr_type_values:              g.tc.expr_type_values
 		expr_type_set:                 g.tc.expr_type_set
 		checking_nodes:                g.tc.checking_nodes
@@ -483,6 +499,11 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 			g.fn_ptr_types[encoded] = name
 		}
 	}
+	for name, enabled in w.libc_compat_fns {
+		if enabled {
+			g.libc_compat_fns[name] = true
+		}
+	}
 	// Spawn wrappers (thread arg structs + trampoline fns) are generated on demand
 	// inside fn bodies, so a worker that emits a `spawn` produces wrapper defs the
 	// master must also emit. Deduplicate by their deterministic key/def.
@@ -494,6 +515,16 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 	for def in w.spawn_wrapper_defs {
 		if def !in g.spawn_wrapper_defs {
 			g.spawn_wrapper_defs << def
+		}
+	}
+	for key, name in w.callback_wrapper_names {
+		if key !in g.callback_wrapper_names {
+			g.callback_wrapper_names[key] = name
+		}
+	}
+	for def in w.callback_wrapper_defs {
+		if def !in g.callback_wrapper_defs {
+			g.callback_wrapper_defs << def
 		}
 	}
 }

--- a/vlib/v3/gen/c/fn_d_parallel.v
+++ b/vlib/v3/gen/c/fn_d_parallel.v
@@ -527,4 +527,5 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 			g.callback_wrapper_defs << def
 		}
 	}
+	g.gettid_compat = g.gettid_compat || w.gettid_compat
 }

--- a/vlib/v3/gen/c/fn_d_parallel.v
+++ b/vlib/v3/gen/c/fn_d_parallel.v
@@ -527,5 +527,4 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 			g.callback_wrapper_defs << def
 		}
 	}
-	g.gettid_compat = g.gettid_compat || w.gettid_compat
 }

--- a/vlib/v3/gen/c/fn_notd_parallel.v
+++ b/vlib/v3/gen/c/fn_notd_parallel.v
@@ -3,4 +3,5 @@ module c
 // gen_fns_dispatch emits fns dispatch output for c.
 fn (mut g FlatGen) gen_fns_dispatch(_no_parallel bool) {
 	g.gen_fns()
+	g.gen_synthetic_main_after_fns()
 }

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -357,19 +357,6 @@ fn (g &FlatGen) should_emit_interface_dispatch(iface_name string, method string)
 	if g.used_interface_dispatch_key(name) {
 		return true
 	}
-	// If any concrete implementer's method is live, the dispatch is reachable even
-	// when the interface entry itself wasn't directly marked — markused's reachability
-	// can enqueue the implementers (via iface_impls) but miss the interface method when
-	// its short name is ambiguous (e.g. `resize` also on Camera/SamplingJobContext).
-	for impl in g.iface_impls[iface_name] or { []string{} } {
-		im := '${impl}.${method}'
-		short_im := '${impl.all_after_last('.')}.${method}'
-		if g.used_fn_contains(im) || g.used_fn_contains(c_name(im))
-			|| (short_im != im && (g.used_fn_contains(short_im)
-			|| g.used_fn_contains(c_name(short_im)))) {
-			return true
-		}
-	}
 	if decl_key := g.interface_method_signature_key(iface_name, method) {
 		if decl_key != name && g.used_interface_dispatch_key(decl_key) {
 			return true
@@ -391,22 +378,6 @@ fn (g &FlatGen) used_interface_dispatch_key(name string) bool {
 
 fn (g &FlatGen) interface_dispatch_short_name_allowed(iface_name string) bool {
 	return !iface_name.contains('.')
-}
-
-fn (g &FlatGen) interface_dispatch_short_name_is_unambiguous(short_name string, method string) bool {
-	mut matches := 0
-	for iface_name, methods in g.interfaces {
-		if method !in methods {
-			continue
-		}
-		if '${iface_name.all_after_last('.')}.${method}' == short_name {
-			matches++
-			if matches > 1 {
-				return false
-			}
-		}
-	}
-	return matches == 1
 }
 
 // gen_interface_dispatch emits interface dispatch output for c.

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -354,7 +354,7 @@ fn (g &FlatGen) should_emit_interface_dispatch(iface_name string, method string)
 		return true
 	}
 	name := '${iface_name}.${method}'
-	if g.used_fn_contains(name) || g.used_fn_contains(c_name(name)) {
+	if g.used_interface_dispatch_key(name) {
 		return true
 	}
 	// If any concrete implementer's method is live, the dispatch is reachable even
@@ -371,19 +371,26 @@ fn (g &FlatGen) should_emit_interface_dispatch(iface_name string, method string)
 		}
 	}
 	if decl_key := g.interface_method_signature_key(iface_name, method) {
-		if decl_key != name
-			&& (g.used_fn_contains(decl_key) || g.used_fn_contains(c_name(decl_key))) {
+		if decl_key != name && g.used_interface_dispatch_key(decl_key) {
 			return true
 		}
 		decl_short_name := '${decl_key.all_before_last('.').all_after_last('.')}.${method}'
-		if decl_short_name != decl_key
-			&& (g.used_fn_contains(decl_short_name) || g.used_fn_contains(c_name(decl_short_name))) {
+		if decl_short_name != decl_key && g.interface_dispatch_short_name_allowed(iface_name)
+			&& g.used_interface_dispatch_key(decl_short_name) {
 			return true
 		}
 	}
 	short_name := '${iface_name.all_after_last('.')}.${method}'
-	return short_name != name && g.interface_dispatch_short_name_is_unambiguous(short_name, method)
-		&& (g.used_fn_contains(short_name) || g.used_fn_contains(c_name(short_name)))
+	return short_name != name && g.interface_dispatch_short_name_allowed(iface_name)
+		&& g.used_interface_dispatch_key(short_name)
+}
+
+fn (g &FlatGen) used_interface_dispatch_key(name string) bool {
+	return g.used_fn_contains(name) || g.used_fn_contains(c_name(name))
+}
+
+fn (g &FlatGen) interface_dispatch_short_name_allowed(iface_name string) bool {
+	return !iface_name.contains('.')
 }
 
 fn (g &FlatGen) interface_dispatch_short_name_is_unambiguous(short_name string, method string) bool {
@@ -526,8 +533,38 @@ fn (g &FlatGen) interface_dispatch_target_is_emitted(concrete_key string) bool {
 	if !g.has_used_fn_filter() {
 		return true
 	}
-	return g.used_fn_contains(concrete_key) || g.used_fn_contains(c_name(concrete_key))
-		|| g.used_fn_contains(concrete_key.all_after_last('.'))
+	if g.used_interface_dispatch_key(concrete_key) {
+		return true
+	}
+	receiver_name := concrete_key.all_before_last('.')
+	if receiver_name.contains('.') {
+		return false
+	}
+	method := concrete_key.all_after_last('.')
+	short_key := '${receiver_name.all_after_last('.')}.${method}'
+	return short_key != concrete_key
+		&& g.interface_dispatch_target_short_name_is_unambiguous(short_key, method)
+		&& g.used_interface_dispatch_key(short_key)
+}
+
+fn (g &FlatGen) interface_dispatch_target_short_name_is_unambiguous(short_name string, method string) bool {
+	mut seen := map[string]bool{}
+	mut matches := 0
+	for _, impls in g.iface_impls {
+		for concrete in impls {
+			if seen[concrete] {
+				continue
+			}
+			seen[concrete] = true
+			if '${concrete.all_after_last('.')}.${method}' == short_name {
+				matches++
+				if matches > 1 {
+					return false
+				}
+			}
+		}
+	}
+	return matches == 1
 }
 
 // sum_type_index supports sum type index handling for FlatGen.

--- a/vlib/v3/gen/c/names.v
+++ b/vlib/v3/gen/c/names.v
@@ -40,6 +40,7 @@ const c_reserved_words = {
 	'void':     true
 	'volatile': true
 	'while':    true
+	'unix':     true
 }
 
 // c_libc_collisions are libc function names that are not C keywords but clash at
@@ -196,6 +197,9 @@ fn c_name_sanitize(name string) string {
 			b.write_string('__')
 		} else if c == `&` {
 			b.write_string('ptr')
+		} else if c == `@` {
+			i++
+			continue
 		} else if c == `,` || c == ` ` {
 			b.write_u8(`_`)
 		} else {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -285,6 +285,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 							}
 							if expr_ct != base_ct && struct_init_ct != base_ct
 								&& !g.type_names_match(expr_value_type, base)
+								&& !g.expr_is_nil_pointer_payload(ret_id, base)
 								&& !g.type_can_wrap_as_sum(expr_value_type, base)
 								&& !g.types_numeric_compatible(expr_value_type, base)
 								&& !g.call_constructs_type(ret_id, base)
@@ -301,42 +302,19 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 				} else if g.cur_fn_ret is types.MultiReturn {
 					if node.children_count > 1 {
 						ct := g.tc.c_type(g.cur_fn_ret)
-						mr_types := g.cur_fn_ret.types
-						mut has_fixed := false
-						for mt in mr_types {
-							if mt is types.ArrayFixed {
-								has_fixed = true
-								break
-							}
-						}
-						if has_fixed {
-							// A multi-return with a fixed-array member can't be built by a
-							// positional compound literal (array members need memcpy).
-							tmp := g.tmp_name()
-							g.write('return ({ ${ct} ${tmp} = {0};')
+						ret_types := g.cur_fn_ret.types
+						if g.multi_return_types_have_fixed_array(ret_types) {
+							g.gen_multi_return_temp_return(ct, ret_types, node)
+						} else {
+							g.write('return (${ct}){')
 							for i in 0 .. node.children_count {
-								if i < mr_types.len && mr_types[i] is types.ArrayFixed {
-									g.write(' memcpy(${tmp}.arg${i}, ')
-									g.gen_fixed_array_copy_source(g.a.child(&node, i), mr_types[i])
-									g.write(', sizeof(${tmp}.arg${i}));')
-								} else {
-									g.write(' ${tmp}.arg${i} = ')
-									g.gen_expr(g.a.child(&node, i))
-									g.write(';')
+								if i > 0 {
+									g.write(', ')
 								}
+								g.gen_expr(g.a.child(&node, i))
 							}
-							g.writeln(' ${tmp}; });')
-							g.expected_enum = ''
-							return
+							g.writeln('};')
 						}
-						g.write('return (${ct}){')
-						for i in 0 .. node.children_count {
-							if i > 0 {
-								g.write(', ')
-							}
-							g.gen_expr(g.a.child(&node, i))
-						}
-						g.writeln('};')
 					} else {
 						expr_type := g.usable_expr_type(ret_id)
 						if expr_type is types.MultiReturn {
@@ -488,6 +466,15 @@ fn (mut g FlatGen) gen_return_with_defers(node flat.Node) {
 		return
 	}
 	ct := g.return_c_type()
+	if g.cur_fn_ret is types.MultiReturn && node.children_count > 1 {
+		ret_types := g.cur_fn_ret.types
+		if g.multi_return_types_have_fixed_array(ret_types) {
+			tmp := g.gen_multi_return_temp(ct, ret_types, node)
+			g.gen_all_defers()
+			g.writeln('return ${tmp};')
+			return
+		}
+	}
 	expr := g.return_expr_string(node, ret_id, ret_node, ct)
 	tmp := g.tmp_name()
 	g.writeln('${ct} ${tmp} = ${expr};')
@@ -596,6 +583,7 @@ fn (mut g FlatGen) return_expr_string(node flat.Node, ret_id flat.NodeId, ret_no
 		}
 		if expr_ct != base_ct && struct_init_ct != base_ct
 			&& !g.type_names_match(expr_value_type, base)
+			&& !g.expr_is_nil_pointer_payload(ret_id, base)
 			&& !g.type_can_wrap_as_sum(expr_value_type, base)
 			&& !g.types_numeric_compatible(expr_value_type, base)
 			&& !g.call_constructs_type(ret_id, base) && expr_value_type !is types.Primitive
@@ -869,6 +857,56 @@ fn (g &FlatGen) option_c_name_for_base(base types.Type) string {
 	return 'Optional_' + g.tc.c_type(base).replace('*', 'ptr').replace(' ', '_')
 }
 
+fn (g &FlatGen) expr_is_nil_pointer_payload(id flat.NodeId, base types.Type) bool {
+	if !g.type_accepts_nil_pointer(base) {
+		return false
+	}
+	return g.expr_is_nil_value(id)
+}
+
+fn (g &FlatGen) type_accepts_nil_pointer(typ types.Type) bool {
+	if typ is types.Pointer {
+		return true
+	}
+	if typ is types.Alias {
+		return g.type_accepts_nil_pointer(typ.base_type)
+	}
+	return false
+}
+
+fn (g &FlatGen) expr_is_nil_value(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return false
+	}
+	node := g.a.nodes[int(id)]
+	match node.kind {
+		.nil_literal {
+			return true
+		}
+		.expr_stmt {
+			if node.children_count == 0 {
+				return false
+			}
+			return g.expr_is_nil_value(g.a.child(&node, 0))
+		}
+		.block {
+			if node.children_count == 0 {
+				return false
+			}
+			return g.expr_is_nil_value(g.a.child(&node, node.children_count - 1))
+		}
+		.cast_expr, .as_expr {
+			if node.children_count == 0 {
+				return false
+			}
+			return g.expr_is_nil_value(g.a.child(&node, 0))
+		}
+		else {
+			return false
+		}
+	}
+}
+
 // usable_expr_type supports usable expr type handling for FlatGen.
 fn (g &FlatGen) usable_expr_type(id flat.NodeId) types.Type {
 	if int(id) >= 0 && int(id) < g.a.nodes.len {
@@ -1063,20 +1101,8 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 			raw_init_type := g.tc.parse_type(rhs.value)
 			init_type := raw_init_type
 			if init_type is types.ArrayFixed {
-				c_elem := g.tc.c_type(init_type.elem_type)
-				lhs_str := g.decl_lhs_str(lhs_id)
-				len_expr := g.fixed_array_len_expr(rhs.value, init_type.len)
-				if len_expr == '0' {
-					if !lhs_is_defer_capture {
-						g.writeln('${decl_prefix}${c_elem} ${lhs_str}[0];')
-					}
-				} else {
-					if lhs_is_defer_capture {
-						g.writeln('memset(${lhs_str}, 0, sizeof(${lhs_str}));')
-					} else {
-						g.writeln('${decl_prefix}${c_elem} ${lhs_str}[${len_expr}] = {0};')
-					}
-				}
+				g.gen_fixed_array_zero_init_decl(lhs_id, init_type, decl_prefix,
+					lhs_is_defer_capture)
 				if lhs.kind == .ident {
 					g.tc.cur_scope.insert(lhs.value, raw_init_type)
 				}
@@ -1111,6 +1137,11 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 						elem_type: init_type
 					}))
 				}
+			}
+		} else if init_type := g.fixed_array_zero_init_block_type(rhs) {
+			g.gen_fixed_array_zero_init_decl(lhs_id, init_type, decl_prefix, lhs_is_defer_capture)
+			if lhs.kind == .ident {
+				g.tc.cur_scope.insert(lhs.value, init_type)
 			}
 		} else if rhs.kind == .map_init {
 			v_type := g.tc.resolve_type(rhs_id)
@@ -1147,6 +1178,19 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 				g.if_expr_type(&rhs)
 			} else {
 				g.usable_expr_type(rhs_id)
+			}
+			if fixed := array_fixed_type(v_type) {
+				lhs_str := g.decl_lhs_str(lhs_id)
+				if !lhs_is_defer_capture {
+					c_elem, dims := g.fixed_array_decl_parts(fixed)
+					g.writeln('${decl_prefix}${c_elem} ${lhs_str}${dims};')
+				}
+				g.gen_fixed_array_copy_from_node(lhs_str, rhs_id, fixed)
+				if lhs.kind == .ident {
+					g.tc.cur_scope.insert(lhs.value, v_type)
+				}
+				i += 2
+				continue
 			}
 			ct0 := g.tc.c_type(v_type)
 			ct := if v_type is types.OptionType || v_type is types.ResultType {
@@ -1192,6 +1236,48 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 	}
 }
 
+fn (mut g FlatGen) gen_fixed_array_zero_init_decl(lhs_id flat.NodeId, init_type types.ArrayFixed, decl_prefix string, lhs_is_defer_capture bool) {
+	c_elem, dims := g.fixed_array_decl_parts(init_type)
+	lhs_str := g.decl_lhs_str(lhs_id)
+	if g.fixed_array_len_is_zero(init_type) {
+		if !lhs_is_defer_capture {
+			g.writeln('${decl_prefix}${c_elem} ${lhs_str}${dims};')
+		}
+	} else if lhs_is_defer_capture {
+		g.writeln('memset(${lhs_str}, 0, sizeof(${lhs_str}));')
+	} else {
+		g.writeln('${decl_prefix}${c_elem} ${lhs_str}${dims} = {0};')
+	}
+}
+
+fn (mut g FlatGen) fixed_array_zero_init_block_type(node flat.Node) ?types.ArrayFixed {
+	if node.kind != .block || node.children_count != 1 {
+		return none
+	}
+	stmt_id := g.a.child(&node, 0)
+	if int(stmt_id) < 0 {
+		return none
+	}
+	stmt := g.a.nodes[int(stmt_id)]
+	expr_id := if stmt.kind == .expr_stmt && stmt.children_count == 1 {
+		g.a.child(&stmt, 0)
+	} else {
+		stmt_id
+	}
+	if int(expr_id) < 0 {
+		return none
+	}
+	expr := g.a.nodes[int(expr_id)]
+	if expr.kind != .array_init || expr.children_count != 0 {
+		return none
+	}
+	typ := g.tc.parse_type(expr.value)
+	if typ is types.ArrayFixed {
+		return typ
+	}
+	return none
+}
+
 // gen_decl_init_expr emits decl init expr output for c.
 fn (mut g FlatGen) gen_decl_init_expr(rhs_id flat.NodeId, rhs flat.Node, v_type types.Type, c_type string, is_declaration bool) {
 	if g.is_json_decode_call_expr(rhs_id) {
@@ -1210,6 +1296,49 @@ fn (mut g FlatGen) gen_decl_init_expr(rhs_id flat.NodeId, rhs flat.Node, v_type 
 }
 
 // gen_multi_return_decl emits multi return decl output for c.
+fn (g &FlatGen) multi_return_types_have_fixed_array(ret_types []types.Type) bool {
+	for typ in ret_types {
+		if _ := array_fixed_type(typ) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (mut g FlatGen) gen_multi_return_temp(ct string, ret_types []types.Type, node flat.Node) string {
+	tmp := g.tmp_name()
+	g.writeln('${ct} ${tmp};')
+	for i in 0 .. node.children_count {
+		field := '${tmp}.arg${i}'
+		child_id := g.a.child(&node, i)
+		if i < ret_types.len {
+			if fixed := array_fixed_type(ret_types[i]) {
+				g.gen_fixed_array_copy_from_node(field, child_id, fixed)
+				continue
+			}
+			g.write('${field} = ')
+			g.gen_expr_with_expected_type(child_id, ret_types[i])
+			g.writeln(';')
+			continue
+		}
+		g.write('${field} = ')
+		g.gen_expr(child_id)
+		g.writeln(';')
+	}
+	return tmp
+}
+
+fn (mut g FlatGen) gen_multi_return_temp_return(ct string, ret_types []types.Type, node flat.Node) {
+	tmp := g.gen_multi_return_temp(ct, ret_types, node)
+	g.writeln('return ${tmp};')
+}
+
+fn (mut g FlatGen) gen_fixed_array_copy_from_node(dst string, rhs_id flat.NodeId, fixed types.ArrayFixed) {
+	g.write('memmove(${dst}, ')
+	g.gen_fixed_array_data_arg(rhs_id, fixed)
+	g.writeln(', sizeof(${dst}));')
+}
+
 fn (mut g FlatGen) gen_multi_return_decl(node flat.Node) {
 	rhs_id := g.a.child(&node, 1)
 	rhs_type := g.tc.resolve_type(rhs_id)
@@ -1236,6 +1365,17 @@ fn (mut g FlatGen) gen_multi_return_decl(node flat.Node) {
 			'int'
 		}
 		lhs_name := c_name(lhs.value)
+		if j < multi_types.len {
+			if fixed := array_fixed_type(multi_types[j]) {
+				c_elem, dims := g.fixed_array_decl_parts(fixed)
+				g.writeln('${c_elem} ${lhs_name}${dims};')
+				g.writeln('memmove(${lhs_name}, ${tmp}.arg${j}, sizeof(${lhs_name}));')
+				if lhs.kind == .ident {
+					g.tc.cur_scope.insert(lhs.value, multi_types[j])
+				}
+				continue
+			}
+		}
 		g.writeln('${field_type} ${lhs_name} = ${tmp}.arg${j};')
 		if lhs.kind == .ident {
 			inner := if j < multi_types.len {
@@ -1342,17 +1482,23 @@ fn (mut g FlatGen) gen_assign(node flat.Node) {
 			} else {
 				lhs_type := g.usable_expr_type(lhs_id)
 				rhs_type := g.usable_expr_type(rhs_id)
-				if node.op == .assign && lhs_type is types.ArrayFixed {
-					// A fixed array can't be assigned with `=`; copy element bytes.
-					g.write('memcpy(')
-					g.gen_expr(lhs_id)
-					g.write(', ')
-					g.gen_fixed_array_copy_source(rhs_id, lhs_type)
-					g.write(', sizeof(')
-					g.gen_expr(lhs_id)
-					g.writeln('));')
-					i += 2
-					continue
+				if node.op == .assign {
+					if lhs_fixed := array_fixed_type(lhs_type) {
+						if _ := array_fixed_type(rhs_type) {
+							dst := g.expr_to_string(lhs_id)
+							g.writeln('memmove(${dst}, ${g.expr_to_string(rhs_id)}, sizeof(${dst}));')
+							i += 2
+							continue
+						} else if rhs_node.kind == .array_init || rhs_node.kind == .array_literal
+							|| rhs_node.kind == .postfix {
+							dst := g.expr_to_string(lhs_id)
+							g.write('memmove(${dst}, ')
+							g.gen_fixed_array_data_arg(rhs_id, lhs_fixed)
+							g.writeln(', sizeof(${dst}));')
+							i += 2
+							continue
+						}
+					}
 				}
 				if node.op == .plus_assign && (lhs_type is types.String || rhs_type is types.String) {
 					g.gen_expr(g.a.child(&node, i))
@@ -1382,13 +1528,45 @@ fn (mut g FlatGen) gen_assign(node flat.Node) {
 				}
 				g.gen_expr(g.a.child(&node, i))
 				g.write(' ${g.op_str(node.op)} ')
-				g.gen_expr(rhs_id)
+				if _ := fn_type_from(lhs_type) {
+					if c_abi_fn := g.assign_lhs_c_abi_fn_ptr_type(lhs_id) {
+						if g.gen_callback_fn_value_for_field_c_abi(rhs_id, lhs_type, c_abi_fn) {
+							g.writeln(';')
+							g.expected_enum = ''
+							i += 2
+							continue
+						}
+					}
+					g.gen_expr_with_expected_type(rhs_id, lhs_type)
+				} else {
+					g.gen_expr(rhs_id)
+				}
 				g.writeln(';')
 				g.expected_enum = ''
 			}
 		}
 		i += 2
 	}
+}
+
+fn (g &FlatGen) assign_lhs_c_abi_fn_ptr_type(lhs_id flat.NodeId) ?string {
+	if int(lhs_id) < 0 || int(lhs_id) >= g.a.nodes.len {
+		return none
+	}
+	lhs := g.a.nodes[int(lhs_id)]
+	if lhs.kind != .selector || lhs.children_count == 0 || lhs.value.len == 0 {
+		return none
+	}
+	base_id := g.a.child(&lhs, 0)
+	base_type := types.unwrap_pointer(g.usable_expr_type(base_id))
+	mut clean := base_type
+	if base_type is types.Alias {
+		clean = base_type.base_type
+	}
+	if clean is types.Struct {
+		return g.struct_field_c_abi_fn_ptr_type(clean.name, lhs.value)
+	}
+	return none
 }
 
 fn (g &FlatGen) assign_struct_operator_method(lhs_type types.Type, op flat.Op) ?string {
@@ -1446,12 +1624,23 @@ fn (mut g FlatGen) gen_multi_return_assign(node flat.Node) {
 	g.gen_expr_with_expected_type(rhs_id, rhs_type)
 	g.writeln(';')
 	num_lhs := node.children_count - 1
+	mut multi_types := []types.Type{}
+	if rhs_type is types.MultiReturn {
+		multi_types = rhs_type.types.clone()
+	}
 	for j in 0 .. num_lhs {
 		lhs_idx := if j == 0 { 0 } else { j + 1 }
 		lhs_id := g.a.child(&node, lhs_idx)
 		lhs := g.a.nodes[int(lhs_id)]
 		if lhs.kind == .ident && lhs.value == '_' {
 			continue
+		}
+		if j < multi_types.len {
+			if _ := array_fixed_type(multi_types[j]) {
+				dst := g.expr_to_string(lhs_id)
+				g.writeln('memmove(${dst}, ${tmp}.arg${j}, sizeof(${dst}));')
+				continue
+			}
 		}
 		gen_expr_lvalue(mut g, lhs_id)
 		g.writeln(' = ${tmp}.arg${j};')

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -1198,22 +1198,6 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 			} else {
 				ct0
 			}
-			if v_type is types.ArrayFixed {
-				// A fixed array cannot be initialized from another array value
-				// (`T x[N] = expr` is illegal); declare then memcpy.
-				lhs_str := g.decl_lhs_str(lhs_id)
-				if !lhs_is_defer_capture {
-					g.writeln('${decl_prefix}${ct} ${lhs_str};')
-				}
-				g.write('memcpy(${lhs_str}, ')
-				g.gen_fixed_array_copy_source(rhs_id, v_type)
-				g.writeln(', sizeof(${lhs_str}));')
-				if lhs.kind == .ident {
-					g.tc.cur_scope.insert(lhs.value, v_type)
-				}
-				i += 2
-				continue
-			}
 			if ct.starts_with('fn_ptr:') {
 				fp_name := g.resolve_fn_ptr_type(ct)
 				if !lhs_is_defer_capture {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -506,7 +506,7 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 					g.gen_expr(value_id)
 					g.write(', sizeof(${inner_ct}))')
 				} else {
-					g.gen_expr_with_expected_type(value_id, sf.typ)
+					g.gen_struct_field_expr_for_field(value_id, node.value, sf.name, sf.typ)
 				}
 				set_fields[sf.name] = true
 			} else {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -32,6 +32,22 @@ fn (g &FlatGen) struct_init_fields_key(type_name string, fallback string) string
 	return fallback
 }
 
+fn (mut g FlatGen) gen_struct_field_expr(value_id flat.NodeId, expected types.Type) {
+	if g.gen_callback_fn_value_for_expected_type(value_id, expected) {
+		return
+	}
+	g.gen_expr_with_expected_type(value_id, expected)
+}
+
+fn (mut g FlatGen) gen_struct_field_expr_for_field(value_id flat.NodeId, struct_name string, field_name string, expected types.Type) {
+	if c_abi_fn := g.struct_field_c_abi_fn_ptr_type(struct_name, field_name) {
+		if g.gen_callback_fn_value_for_field_c_abi(value_id, expected, c_abi_fn) {
+			return
+		}
+	}
+	g.gen_struct_field_expr(value_id, expected)
+}
+
 // gen_struct_init emits struct init output for c.
 fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 	init_module := g.tc.cur_module
@@ -96,7 +112,7 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 					g.gen_expr(value_id)
 					g.write(', sizeof(${inner_ct}))')
 				} else {
-					g.gen_expr_with_expected_type(value_id, sf.typ)
+					g.gen_struct_field_expr_for_field(value_id, node.value, sf.name, sf.typ)
 				}
 				set_fields[sf.name] = true
 			} else {
@@ -116,7 +132,7 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 					if g.struct_field_value_is_plainly_incompatible(value_id, ftyp) {
 						g.gen_default_value_for_type(ftyp)
 					} else {
-						g.gen_expr_with_expected_type(value_id, ftyp)
+						g.gen_struct_field_expr_for_field(value_id, node.value, field.value, ftyp)
 					}
 				} else {
 					g.gen_expr(value_id)
@@ -128,8 +144,7 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 	}
 	after_fields_module := g.tc.cur_module
 	g.tc.cur_module = init_module
-	qname := g.tc.qualify_name(node.value)
-	sname := if qname in g.tc.structs { qname } else { node.value }
+	sname := g.struct_init_resolved_decl_name(node.value)
 	g.tc.cur_module = after_fields_module
 	has_field = g.gen_struct_default_fields(sname, mut set_fields, has_field)
 	defaults_key := if lookup_name in g.tc.structs { lookup_name } else { sname }
@@ -233,7 +248,7 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 					g.write(', ')
 				}
 				g.write('.${c_field_name(sf.name)} = ')
-				g.gen_expr_with_expected_type(value_id, sf.typ)
+				g.gen_struct_field_expr_for_field(value_id, node.value, sf.name, sf.typ)
 				set_fields[sf.name] = true
 				has_field = true
 			} else {
@@ -267,7 +282,7 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 				if g.struct_field_value_is_plainly_incompatible(value_id, ftyp) {
 					g.gen_default_value_for_type(ftyp)
 				} else {
-					g.gen_expr_with_expected_type(value_id, ftyp)
+					g.gen_struct_field_expr_for_field(value_id, node.value, field.value, ftyp)
 				}
 			} else {
 				g.gen_expr(value_id)
@@ -278,8 +293,7 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 	}
 	after_fields_module := g.tc.cur_module
 	g.tc.cur_module = init_module
-	qname := g.tc.qualify_name(node.value)
-	sname := if qname in g.tc.structs { qname } else { node.value }
+	sname := g.struct_init_resolved_decl_name(node.value)
 	g.tc.cur_module = after_fields_module
 	has_field = g.gen_struct_default_fields(sname, mut set_fields, has_field)
 	defaults_key := if lookup_name in g.tc.structs { lookup_name } else { sname }
@@ -516,7 +530,7 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 				if g.struct_field_value_is_plainly_incompatible(value_id, ftyp) {
 					g.gen_default_value_for_type(ftyp)
 				} else {
-					g.gen_expr_with_expected_type(value_id, ftyp)
+					g.gen_struct_field_expr_for_field(value_id, node.value, field.value, ftyp)
 				}
 			} else {
 				g.gen_expr(value_id)
@@ -527,8 +541,7 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 	}
 	after_fields_module := g.tc.cur_module
 	g.tc.cur_module = init_module
-	qname := g.tc.qualify_name(node.value)
-	sname := if qname in g.tc.structs { qname } else { node.value }
+	sname := g.struct_init_resolved_decl_name(node.value)
 	g.tc.cur_module = after_fields_module
 	has_field = g.gen_struct_default_fields(sname, mut set_fields, has_field)
 	defaults_key := if lookup_name in g.tc.structs { lookup_name } else { sname }
@@ -600,7 +613,8 @@ fn (mut g FlatGen) gen_struct_default_fields(type_name string, mut set_fields ma
 			g.write(', ')
 		}
 		g.write('.${c_name(field.value)} = ')
-		g.gen_expr_with_expected_type(g.a.child(field, 0), g.tc.parse_type(field.typ))
+		g.gen_struct_field_expr_for_field(g.a.child(field, 0), info.full_name, field.value,
+			g.tc.parse_type(field.typ))
 		set_fields[field.value] = true
 		has = true
 	}
@@ -755,7 +769,7 @@ fn (mut g FlatGen) gen_params_struct_arg(typ types.Type, node flat.Node, field_s
 			}
 			g.write('.${c_name(field.value)} = ')
 			if ftyp := g.struct_field_type(typ.name, field.value) {
-				g.gen_expr_with_expected_type(g.a.child(field, 0), ftyp)
+				g.gen_struct_field_expr_for_field(g.a.child(field, 0), typ.name, field.value, ftyp)
 			} else {
 				g.gen_expr(g.a.child(field, 0))
 			}
@@ -991,6 +1005,21 @@ fn (mut g FlatGen) struct_init_c_type_name(type_name string) string {
 
 // find_struct_decl resolves find struct decl information for c.
 fn (g &FlatGen) find_struct_decl(type_name string) ?StructDeclInfo {
+	if info := g.find_struct_decl_preferred(type_name) {
+		return info
+	}
+	if alias_target := g.struct_type_alias_target(type_name) {
+		if info := g.find_struct_decl_preferred(alias_target) {
+			return info
+		}
+		if info := g.find_struct_decl_fallback(alias_target) {
+			return info
+		}
+	}
+	return g.find_struct_decl_fallback(type_name)
+}
+
+fn (g &FlatGen) find_struct_decl_preferred(type_name string) ?StructDeclInfo {
 	short_name := if type_name.contains('.') { type_name.all_after_last('.') } else { type_name }
 	preferred_name := if !type_name.contains('.') && g.tc.cur_module.len > 0
 		&& g.tc.cur_module != 'main' && g.tc.cur_module != 'builtin' {
@@ -1007,37 +1036,64 @@ fn (g &FlatGen) find_struct_decl(type_name string) ?StructDeclInfo {
 		if info := g.struct_decl_infos[type_name] {
 			return info
 		}
-	} else {
-		if info := g.struct_decl_short_infos[type_name] {
-			return info
+	}
+	return none
+}
+
+fn (g &FlatGen) find_struct_decl_fallback(type_name string) ?StructDeclInfo {
+	if type_name.contains('.') {
+		return none
+	}
+	if info := g.struct_decl_short_infos[type_name] {
+		return info
+	}
+	return none
+}
+
+fn (g &FlatGen) struct_type_alias_target(type_name string) ?string {
+	qname := g.tc.qualify_name(type_name)
+	if target := g.tc.type_aliases[qname] {
+		return target
+	}
+	if target := g.tc.type_aliases[type_name] {
+		return target
+	}
+	return none
+}
+
+fn (g &FlatGen) struct_init_resolved_decl_name(type_name string) string {
+	if info := g.find_struct_decl(type_name) {
+		return info.full_name
+	}
+	qname := g.tc.qualify_name(type_name)
+	return if qname in g.tc.structs { qname } else { type_name }
+}
+
+// struct_field_type supports struct field type handling for FlatGen.
+fn (g &FlatGen) struct_field_type(type_name string, field_name string) ?types.Type {
+	fields := g.struct_fields_for_type(type_name) or { return none }
+	for f in fields {
+		if f.name == field_name {
+			return f.typ
 		}
 	}
 	return none
 }
 
-// struct_field_type supports struct field type handling for FlatGen.
-fn (g &FlatGen) struct_field_type(type_name string, field_name string) ?types.Type {
-	if fields := g.tc.structs[type_name] {
-		for f in fields {
-			if f.name == field_name {
-				return f.typ
-			}
-		}
-	}
-	qname := g.tc.qualify_name(type_name)
-	if fields := g.tc.structs[qname] {
-		for f in fields {
-			if f.name == field_name {
-				return f.typ
-			}
-		}
-	}
+fn (g &FlatGen) struct_field_c_abi_fn_ptr_type(type_name string, field_name string) ?string {
 	if info := g.find_struct_decl(type_name) {
-		if fields := g.tc.structs[info.full_name] {
-			for f in fields {
-				if f.name == field_name {
-					return f.typ
-				}
+		if typ := g.tc.struct_field_c_abi_fn_ptr_type(info.full_name, field_name) {
+			return typ
+		}
+	}
+	if typ := g.tc.struct_field_c_abi_fn_ptr_type(type_name, field_name) {
+		return typ
+	}
+	if !type_name.contains('.') {
+		qname := g.tc.qualify_name(type_name)
+		if qname != type_name {
+			if typ := g.tc.struct_field_c_abi_fn_ptr_type(qname, field_name) {
+				return typ
 			}
 		}
 	}
@@ -1086,17 +1142,25 @@ fn (g &FlatGen) struct_embedded_fields(type_name string) []types.StructField {
 }
 
 fn (g &FlatGen) struct_fields_for_type(type_name string) ?[]types.StructField {
-	if fields := g.tc.structs[type_name] {
-		return fields
-	}
-	qname := g.tc.qualify_name(type_name)
-	if fields := g.tc.structs[qname] {
-		return fields
-	}
 	if info := g.find_struct_decl(type_name) {
 		if fields := g.tc.structs[info.full_name] {
 			return fields
 		}
+	}
+	if type_name.contains('.') {
+		if fields := g.tc.structs[type_name] {
+			return fields
+		}
+	} else {
+		qname := g.tc.qualify_name(type_name)
+		if qname != type_name {
+			if fields := g.tc.structs[qname] {
+				return fields
+			}
+		}
+	}
+	if fields := g.tc.structs[type_name] {
+		return fields
 	}
 	if type_name.contains('.') {
 		short_name := type_name.all_after_last('.')
@@ -1217,23 +1281,9 @@ fn (g &FlatGen) struct_field_at(type_name string, index int) ?types.StructField 
 	if index < 0 {
 		return none
 	}
-	if fields := g.tc.structs[type_name] {
-		if index < fields.len {
-			return fields[index]
-		}
-	}
-	qname := g.tc.qualify_name(type_name)
-	if fields := g.tc.structs[qname] {
-		if index < fields.len {
-			return fields[index]
-		}
-	}
-	if info := g.find_struct_decl(type_name) {
-		if fields := g.tc.structs[info.full_name] {
-			if index < fields.len {
-				return fields[index]
-			}
-		}
+	fields := g.struct_fields_for_type(type_name) or { return none }
+	if index < fields.len {
+		return fields[index]
 	}
 	return none
 }
@@ -1263,7 +1313,8 @@ fn (mut g FlatGen) gen_assoc_return_tmp(node flat.Node, tmp string) {
 		if field.kind == .field_init && field.children_count > 0 {
 			g.write('${tmp}.${c_name(field.value)} = ')
 			if ftyp := g.struct_field_type(node.value, field.value) {
-				g.gen_expr_with_expected_type(g.a.child(field, 0), ftyp)
+				g.gen_struct_field_expr_for_field(g.a.child(field, 0), node.value, field.value,
+					ftyp)
 			} else {
 				g.gen_expr(g.a.child(field, 0))
 			}
@@ -1284,7 +1335,8 @@ fn (mut g FlatGen) gen_assoc_expr(node flat.Node) {
 		if field.kind == .field_init && field.children_count > 0 {
 			g.write(' ${tmp}.${c_name(field.value)} = ')
 			if ftyp := g.struct_field_type(node.value, field.value) {
-				g.gen_expr_with_expected_type(g.a.child(field, 0), ftyp)
+				g.gen_struct_field_expr_for_field(g.a.child(field, 0), node.value, field.value,
+					ftyp)
 			} else {
 				g.gen_expr(g.a.child(field, 0))
 			}
@@ -1306,7 +1358,8 @@ fn (mut g FlatGen) gen_heap_assoc_expr(node flat.Node) {
 		if field.kind == .field_init && field.children_count > 0 {
 			g.write(' ${tmp}.${c_name(field.value)} = ')
 			if ftyp := g.struct_field_type(node.value, field.value) {
-				g.gen_expr_with_expected_type(g.a.child(field, 0), ftyp)
+				g.gen_struct_field_expr_for_field(g.a.child(field, 0), node.value, field.value,
+					ftyp)
 			} else {
 				g.gen_expr(g.a.child(field, 0))
 			}
@@ -1676,7 +1729,10 @@ fn (mut g FlatGen) write_struct_field(_struct_name string, f types.StructField) 
 	}
 	raw_field_type := field_type
 	if field_type is types.FnType {
-		ct := g.resolve_fn_ptr_type(g.tc.c_type(raw_field_type))
+		c_abi_fn := g.struct_field_c_abi_fn_ptr_type(_struct_name, f.name) or {
+			g.tc.c_type(raw_field_type)
+		}
+		ct := g.resolve_fn_ptr_type(c_abi_fn)
 		g.writeln('\t${ct} ${c_name(f.name)};')
 	} else if f.typ is types.ArrayFixed {
 		c_elem, dims := g.fixed_array_decl_parts(f.typ)
@@ -1699,8 +1755,12 @@ fn (mut g FlatGen) write_struct_field(_struct_name string, f types.StructField) 
 
 // preseed_struct_fn_ptr_types supports preseed struct fn ptr types handling for FlatGen.
 fn (mut g FlatGen) preseed_struct_fn_ptr_types() {
-	for _, fields in g.tc.structs {
+	for struct_name, fields in g.tc.structs {
 		for f in fields {
+			if c_abi_fn := g.struct_field_c_abi_fn_ptr_type(struct_name, f.name) {
+				g.resolve_fn_ptr_type(c_abi_fn)
+				continue
+			}
 			g.preseed_fn_ptr_type(f.typ)
 		}
 	}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -7,9 +7,22 @@ const trace_markused = false
 
 // mark_used updates mark used state for markused.
 pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
+	return mark_used_with_test_files(a, tc, map[string]bool{})
+}
+
+pub fn mark_used_for_tests(a &flat.FlatAst, tc &types.TypeChecker, test_files []string) map[string]bool {
+	mut file_map := map[string]bool{}
+	for file in test_files {
+		file_map[file] = true
+	}
+	return mark_used_with_test_files(a, tc, file_map)
+}
+
+fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files map[string]bool) map[string]bool {
 	mut cur_module := ''
 	mut imports := map[string]string{}
 	mut fn_decls := map[string]FnDeclInfo{}
+	mut fn_decl_lists := map[string][]FnDeclInfo{}
 	mut struct_decls := map[string]StructDeclInfo{}
 	mut const_decls := map[string]ConstDeclInfo{}
 
@@ -74,17 +87,17 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 				node_id: flat.NodeId(node_idx)
 				module:  cur_module
 			}
-			fn_decls[node.value] = info
+			add_fn_decl_info(mut fn_decls, mut fn_decl_lists, node.value, info)
 			lowered_name := markused_c_name(node.value)
 			if lowered_name != node.value {
-				fn_decls[lowered_name] = info
+				add_fn_decl_info(mut fn_decls, mut fn_decl_lists, lowered_name, info)
 			}
 			qname := qualify_fn(cur_module, node.value)
 			if qname != node.value {
-				fn_decls[qname] = info
+				add_fn_decl_info(mut fn_decls, mut fn_decl_lists, qname, info)
 				lowered_qname := markused_c_name(qname)
 				if lowered_qname != qname {
-					fn_decls[lowered_qname] = info
+					add_fn_decl_info(mut fn_decls, mut fn_decl_lists, lowered_qname, info)
 				}
 			}
 			// Build suffix_map entries
@@ -112,6 +125,8 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 	used['main'] = true
 	enqueue_main_module_roots(fn_decls, mut used, mut queue)
 	enqueue_auto_roots(fn_decls, mut used, mut queue)
+	enqueue_export_roots(a, mut used, mut queue)
+	enqueue_test_file_roots(a, test_files, mut used, mut queue)
 	queue << 'time.Time.new'
 	used['time.Time.new'] = true
 	used['Time.new'] = true
@@ -181,6 +196,7 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 	// that function is reached), so an unreachable function's method value never forces an
 	// otherwise-unused specialization to be transformed/emitted.
 	enqueue_initializer_calls(a, collector, imports, fn_decls, mut used, mut queue)
+	enqueue_top_level_calls(a, collector, imports, fn_decls, mut used, mut queue)
 	// Interface dispatch reachability: calling an interface method `Foo.m` may
 	// dispatch to any concrete `T.m` for a type `T` that implements `Foo`. Those
 	// concrete methods are only referenced from the generated dispatch switch, so
@@ -194,98 +210,99 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 		name := queue[qi]
 		qi++
 		prev_len := queue.len
-		fn_info := fn_decls[name] or {
+		fn_infos := fn_decl_infos_for_queue_name(name, fn_decl_lists, a)
+		if fn_infos.len == 0 {
 			not_in_cg++
 			if trace_markused && qi <= 10 {
 				eprintln('BFS qi=${qi.str()} name="${name}" in_cg=false')
 			}
 			continue
 		}
-		if trace_markused && qi <= 10 {
-			eprintln('BFS qi=${qi.str()} name="${name}" in_cg=true')
-		}
-		in_cg++
-		node_key := int(fn_info.node_id)
-		if node_key < 0 || node_key >= processed_nodes.len {
-			continue
-		}
-		if processed_nodes[node_key] {
-			continue
-		}
-		processed_nodes[node_key] = true
-		// This function is reachable, so any methods it uses as *values* (recorded by
-		// the checker per enclosing function) are reachable too — mark them so they
-		// survive pruning (cgen emits a wrapper that calls them).
-		if mvs := tc.method_values_by_fn[node_key] {
-			for mkey in mvs {
-				enqueue(mkey, mut used, mut queue)
-				lowered_mv := markused_c_name(mkey)
-				if lowered_mv != mkey {
-					enqueue(lowered_mv, mut used, mut queue)
-				}
-				mv_short := mkey.all_after_last('.')
-				if cands := suffix_map[mv_short] {
-					for cand in cands {
-						if cand == mkey || cand.ends_with('.${mkey}') {
-							enqueue(cand, mut used, mut queue)
-						}
-					}
-				}
+		for fn_info in fn_infos {
+			if trace_markused && qi <= 10 {
+				eprintln('BFS qi=${qi.str()} name="${name}" in_cg=true')
 			}
-		}
-		calls.clear()
-		node := a.node(fn_info.node_id)
-		receiver_name, receiver_struct := receiver_info(a, node)
-		collector.collect_calls(node, fn_info.module, imports, receiver_name, receiver_struct, mut
-			calls)
-		total_callees += calls.len
-		for callee in calls {
-			if !valid_symbol_name(callee) {
+			in_cg++
+			node_key := int(fn_info.node_id)
+			if node_key < 0 || node_key >= processed_nodes.len {
 				continue
 			}
-			mut found_direct := false
-			if callee_info := fn_decls[callee] {
-				found_direct = true
-				if enqueue(callee, mut used, mut queue) {
-					if trace_markused && qi == 1 {
-						eprintln('main: all_fns hit: "${callee}"')
-					}
-				}
-				alias := a.node(callee_info.node_id).value
-				if alias != callee && alias !in used {
-					used[alias] = true
-				}
-			} else if callee in tc.fn_ret_types {
-				found_direct = true
-				if enqueue(callee, mut used, mut queue) {
-					if trace_markused && qi == 1 {
-						eprintln('main: resolved hit: "${callee}"')
-					}
-				}
+			if processed_nodes[node_key] {
+				continue
 			}
-			if !found_direct || !callee.contains('.') {
-				short := callee.all_after_last('.')
-				if suffix_candidates := suffix_map[short] {
-					for candidate in suffix_candidates {
-						if candidate in fn_decls || candidate in tc.fn_ret_types {
-							if enqueue(candidate, mut used, mut queue) {
-								suffix_hits++
+			processed_nodes[node_key] = true
+			// This function is reachable, so any methods it uses as *values* (recorded by
+			// the checker per enclosing function) are reachable too -- mark them so they
+			// survive pruning (cgen emits a wrapper that calls them).
+			if mvs := tc.method_values_by_fn[node_key] {
+				for mkey in mvs {
+					enqueue(mkey, mut used, mut queue)
+					lowered_mv := markused_c_name(mkey)
+					if lowered_mv != mkey {
+						enqueue(lowered_mv, mut used, mut queue)
+					}
+					mv_short := mkey.all_after_last('.')
+					if cands := suffix_map[mv_short] {
+						for cand in cands {
+							if cand == mkey || cand.ends_with('.${mkey}') {
+								enqueue(cand, mut used, mut queue)
 							}
 						}
 					}
 				}
 			}
-			if callee.contains('.') {
-				recv := callee.all_before_last('.')
-				method := callee.all_after_last('.')
-				ensure_iface_impls(recv, tc, mut iface_impls, mut checked_iface_impls)
-				if impls := iface_impls[recv] {
-					for impl in impls {
-						impl_method := '${impl}.${method}'
-						enqueue(impl_method, mut used, mut queue)
-						short_impl := '${impl.all_after_last('.')}.${method}'
-						if short_impl != impl_method {
-							enqueue(short_impl, mut used, mut queue)
+			calls.clear()
+			node := a.node(fn_info.node_id)
+			receiver_name, receiver_struct := receiver_info(a, node)
+			collector.collect_calls(node, fn_info.module, imports, receiver_name, receiver_struct, mut
+				calls)
+			total_callees += calls.len
+			for callee in calls {
+				if !valid_symbol_name(callee) {
+					continue
+				}
+				mut found_direct := false
+				if callee_info := fn_decls[callee] {
+					found_direct = true
+					if enqueue(callee, mut used, mut queue) {
+						if trace_markused && qi == 1 {
+							eprintln('main: all_fns hit: "${callee}"')
+						}
+					}
+					add_safe_decl_alias(callee, callee_info, a, mut used)
+				} else if callee in tc.fn_ret_types {
+					found_direct = true
+					if enqueue(callee, mut used, mut queue) {
+						if trace_markused && qi == 1 {
+							eprintln('main: resolved hit: "${callee}"')
+						}
+					}
+				}
+				if !found_direct || !callee.contains('.') {
+					short := callee.all_after_last('.')
+					if suffix_candidates := suffix_map[short] {
+						for candidate in suffix_candidates {
+							if candidate in fn_decls || candidate in tc.fn_ret_types {
+								if enqueue(candidate, mut used, mut queue) {
+									suffix_hits++
+								}
+							}
+						}
+					}
+				}
+				if callee.contains('.') {
+					recv := callee.all_before_last('.')
+					method := callee.all_after_last('.')
+					ensure_iface_impls(recv, fn_info.module, tc, mut iface_impls, mut
+						checked_iface_impls)
+					if impls := iface_impls[recv] {
+						for impl in impls {
+							impl_method := '${impl}.${method}'
+							enqueue(impl_method, mut used, mut queue)
+							short_impl := '${impl.all_after_last('.')}.${method}'
+							if short_impl != impl_method {
+								enqueue(short_impl, mut used, mut queue)
+							}
 						}
 					}
 				}
@@ -313,24 +330,17 @@ pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 }
 
 // ensure_iface_impls supports ensure iface impls handling for markused.
-fn ensure_iface_impls(recv string, tc &types.TypeChecker, mut iface_impls map[string][]string, mut checked map[string]bool) {
-	if recv.len == 0 || recv in checked {
+fn ensure_iface_impls(recv string, cur_module string, tc &types.TypeChecker, mut iface_impls map[string][]string, mut checked map[string]bool) {
+	if recv.len == 0 {
 		return
 	}
-	checked[recv] = true
-	mut iface_name := ''
-	if recv in tc.interface_names {
-		iface_name = recv
-	} else {
-		for name, _ in tc.interface_names {
-			if name.all_after_last('.') == recv {
-				iface_name = name
-				break
-			}
-		}
-	}
-	if iface_name.len == 0 {
+	iface_name := interface_name_for_receiver(recv, cur_module, tc) or { return }
+	if iface_name in checked {
 		return
+	}
+	checked[iface_name] = true
+	if recv != iface_name {
+		checked[recv] = true
 	}
 	mut impls := []string{}
 	for struct_name, _ in tc.structs {
@@ -345,6 +355,22 @@ fn ensure_iface_impls(recv string, tc &types.TypeChecker, mut iface_impls map[st
 	}
 }
 
+fn interface_name_for_receiver(recv string, cur_module string, tc &types.TypeChecker) ?string {
+	if recv in tc.interface_names {
+		return recv
+	}
+	if recv.contains('.') {
+		return none
+	}
+	if cur_module.len > 0 && cur_module != 'main' && cur_module != 'builtin' {
+		qname := '${cur_module}.${recv}'
+		if qname in tc.interface_names {
+			return qname
+		}
+	}
+	return none
+}
+
 // add_suffix_candidate updates add suffix candidate state for markused.
 fn add_suffix_candidate(mut suffix_map map[string][]string, short string, name string) {
 	if !valid_symbol_name(short) || !valid_symbol_name(name) {
@@ -353,6 +379,48 @@ fn add_suffix_candidate(mut suffix_map map[string][]string, short string, name s
 	mut candidates := suffix_map[short] or { []string{} }
 	candidates << name
 	suffix_map[short] = candidates
+}
+
+fn add_fn_decl_info(mut fn_decls map[string]FnDeclInfo, mut fn_decl_lists map[string][]FnDeclInfo, name string, info FnDeclInfo) {
+	fn_decls[name] = info
+	mut infos := fn_decl_lists[name] or { []FnDeclInfo{} }
+	infos << info
+	fn_decl_lists[name] = infos
+}
+
+fn fn_decl_infos_for_queue_name(name string, fn_decl_lists map[string][]FnDeclInfo, a &flat.FlatAst) []FnDeclInfo {
+	infos := fn_decl_lists[name] or { return []FnDeclInfo{} }
+	if infos.len <= 1 {
+		return infos
+	}
+	mut exact_infos := []FnDeclInfo{}
+	for info in infos {
+		node := a.node(info.node_id)
+		if fn_decl_key_is_exact_for_info(name, node.value, info.module) {
+			exact_infos << info
+		}
+	}
+	return exact_infos
+}
+
+fn fn_decl_key_is_exact_for_info(name string, decl_name string, module_name string) bool {
+	qname := qualify_fn(module_name, decl_name)
+	if name == qname {
+		return true
+	}
+	lowered := markused_c_name(qname)
+	return lowered != qname && name == lowered
+}
+
+fn add_safe_decl_alias(callee string, callee_info FnDeclInfo, a &flat.FlatAst, mut used map[string]bool) {
+	alias := a.node(callee_info.node_id).value
+	if alias == callee || alias in used {
+		return
+	}
+	if fn_decl_key_is_exact_for_info(callee, alias, callee_info.module) {
+		return
+	}
+	used[alias] = true
 }
 
 // valid_symbol_name supports valid symbol name handling for markused.
@@ -380,10 +448,7 @@ fn enqueue_initializer_calls(a &flat.FlatAst, collector CallCollector, imports m
 					for callee in calls {
 						if callee_info := fn_decls[callee] {
 							enqueue(callee, mut used, mut queue)
-							alias := a.node(callee_info.node_id).value
-							if alias != callee && alias !in used {
-								used[alias] = true
-							}
+							add_safe_decl_alias(callee, callee_info, a, mut used)
 						} else {
 							enqueue(callee, mut used, mut queue)
 						}
@@ -391,6 +456,93 @@ fn enqueue_initializer_calls(a &flat.FlatAst, collector CallCollector, imports m
 				}
 			}
 			else {}
+		}
+	}
+}
+
+fn enqueue_top_level_calls(a &flat.FlatAst, collector CallCollector, imports map[string]string, fn_decls map[string]FnDeclInfo, mut used map[string]bool, mut queue []string) {
+	if markused_has_entry_main(a) {
+		return
+	}
+	mut calls := []string{cap: 32}
+	for file_idx, file_node in a.nodes {
+		if !markused_should_scan_top_level_file(a, file_idx, file_node) {
+			continue
+		}
+		module_name := markused_top_level_file_module_name(a, file_node)
+		mut local_values := map[string]bool{}
+		mut local_types := map[string]string{}
+		for i in 0 .. file_node.children_count {
+			child_id := a.child(&file_node, i)
+			if int(child_id) < a.user_code_start {
+				continue
+			}
+			child := a.node(child_id)
+			if !markused_is_top_level_stmt(child) {
+				continue
+			}
+			calls.clear()
+			collector.collect_top_level_stmt_calls(child_id, module_name, imports, mut
+				local_values, mut local_types, mut calls)
+			for callee in calls {
+				if callee_info := fn_decls[callee] {
+					enqueue(callee, mut used, mut queue)
+					add_safe_decl_alias(callee, callee_info, a, mut used)
+				} else {
+					enqueue(callee, mut used, mut queue)
+				}
+			}
+		}
+	}
+}
+
+fn markused_has_entry_main(a &flat.FlatAst) bool {
+	mut cur_module := ''
+	for node in a.nodes {
+		match node.kind {
+			.file {
+				cur_module = ''
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.fn_decl {
+				if node.value == 'main' && (cur_module.len == 0 || cur_module == 'main') {
+					return true
+				}
+			}
+			else {}
+		}
+	}
+	return false
+}
+
+fn markused_should_scan_top_level_file(a &flat.FlatAst, file_idx int, file_node flat.Node) bool {
+	if file_idx < a.user_code_start || file_node.kind != .file || file_node.children_count == 0 {
+		return false
+	}
+	module_name := markused_top_level_file_module_name(a, file_node)
+	return module_name.len == 0 || module_name == 'main'
+}
+
+fn markused_top_level_file_module_name(a &flat.FlatAst, file_node flat.Node) string {
+	for i in 0 .. file_node.children_count {
+		child := a.child_node(&file_node, i)
+		if child.kind == .module_decl {
+			return child.value
+		}
+	}
+	return ''
+}
+
+fn markused_is_top_level_stmt(node flat.Node) bool {
+	return match node.kind {
+		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
+		.for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .block {
+			true
+		}
+		else {
+			false
 		}
 	}
 }
@@ -453,6 +605,74 @@ fn enqueue_auto_roots(fn_decls map[string]FnDeclInfo, mut used map[string]bool, 
 	}
 }
 
+fn enqueue_export_roots(a &flat.FlatAst, mut used map[string]bool, mut queue []string) {
+	if a.export_fn_names.len == 0 {
+		return
+	}
+	mut cur_module := ''
+	for node in a.nodes {
+		match node.kind {
+			.module_decl {
+				cur_module = node.value
+			}
+			.fn_decl {
+				qname := qualify_fn(cur_module, node.value)
+				if qname in a.export_fn_names {
+					enqueue(qname, mut used, mut queue)
+				}
+			}
+			else {}
+		}
+	}
+}
+
+fn enqueue_test_file_roots(a &flat.FlatAst, test_files map[string]bool, mut used map[string]bool, mut queue []string) {
+	if test_files.len == 0 {
+		return
+	}
+	for file_idx, file_node in a.nodes {
+		if !is_user_test_file_node(a, file_idx, file_node, test_files) {
+			continue
+		}
+		module_name := test_file_module_name(a, file_node)
+		if module_name.len > 0 && module_name != 'main' {
+			continue
+		}
+		for i in 0 .. file_node.children_count {
+			child_id := a.child(&file_node, i)
+			if int(child_id) < a.user_code_start {
+				continue
+			}
+			child := a.node(child_id)
+			if child.kind == .fn_decl && is_test_harness_root_name(child.value) {
+				enqueue(qualify_fn(module_name, child.value), mut used, mut queue)
+			}
+		}
+	}
+}
+
+fn is_user_test_file_node(a &flat.FlatAst, file_idx int, file_node flat.Node, test_files map[string]bool) bool {
+	if file_idx < a.user_code_start || file_node.kind != .file || file_node.children_count == 0 {
+		return false
+	}
+	return test_files[file_node.value]
+}
+
+fn test_file_module_name(a &flat.FlatAst, file_node flat.Node) string {
+	for i in 0 .. file_node.children_count {
+		child := a.child_node(&file_node, i)
+		if child.kind == .module_decl {
+			return child.value
+		}
+	}
+	return ''
+}
+
+fn is_test_harness_root_name(name string) bool {
+	return name.starts_with('test_')
+		|| name in ['testsuite_begin', 'testsuite_end', 'before_each', 'after_each']
+}
+
 // enqueue_main_module_roots supports enqueue main module roots handling for markused.
 fn enqueue_main_module_roots(fn_decls map[string]FnDeclInfo, mut used map[string]bool, mut queue []string) {
 	for name, info in fn_decls {
@@ -466,8 +686,7 @@ fn enqueue_main_module_roots(fn_decls map[string]FnDeclInfo, mut used map[string
 // is_auto_root_fn reports whether is auto root fn applies in markused.
 fn is_auto_root_fn(name string) bool {
 	short_name := name.all_after_last('.')
-	return short_name == 'init' || short_name == 'testsuite_begin' || short_name == 'testsuite_end'
-		|| short_name.starts_with('test_')
+	return short_name == 'init'
 }
 
 // enqueue_detected_runtime_helpers supports enqueue detected runtime helpers handling for markused.
@@ -672,7 +891,11 @@ fn stringification_type_candidates(type_name string, cur_module string) []string
 
 // enqueue_function_value_selectors supports enqueue function value selectors handling for markused.
 fn enqueue_function_value_selectors(a &flat.FlatAst, fn_decls map[string]FnDeclInfo, mut used map[string]bool, mut queue []string) {
-	for node in a.nodes {
+	ignored_top_level_nodes := markused_ignored_top_level_nodes(a)
+	for node_idx, node in a.nodes {
+		if node_idx < ignored_top_level_nodes.len && ignored_top_level_nodes[node_idx] {
+			continue
+		}
 		if node.kind == .selector && node.children_count > 0 && node.value.len > 0 {
 			base := a.child_node(&node, 0)
 			if base.kind == .ident && base.value.len > 0 {
@@ -685,6 +908,49 @@ fn enqueue_function_value_selectors(a &flat.FlatAst, fn_decls map[string]FnDeclI
 			callee := a.child_node(&node, 0)
 			if callee.kind == .ident && callee.value in fn_decls {
 				enqueue(callee.value, mut used, mut queue)
+			}
+		}
+	}
+}
+
+fn markused_ignored_top_level_nodes(a &flat.FlatAst) []bool {
+	if !markused_has_entry_main(a) {
+		return []bool{}
+	}
+	mut ignored := []bool{len: a.nodes.len}
+	for file_idx, file_node in a.nodes {
+		if !markused_should_scan_top_level_file(a, file_idx, file_node) {
+			continue
+		}
+		for i in 0 .. file_node.children_count {
+			child_id := a.child(&file_node, i)
+			if int(child_id) < a.user_code_start {
+				continue
+			}
+			child := a.node(child_id)
+			if !markused_is_top_level_stmt(child) {
+				continue
+			}
+			markused_mark_node_subtree(a, child_id, mut ignored)
+		}
+	}
+	return ignored
+}
+
+fn markused_mark_node_subtree(a &flat.FlatAst, root flat.NodeId, mut marked []bool) {
+	mut stack := [root]
+	for stack.len > 0 {
+		id := stack.pop()
+		idx := int(id)
+		if idx < 0 || idx >= marked.len || marked[idx] {
+			continue
+		}
+		marked[idx] = true
+		node := a.node(id)
+		for i in 0 .. node.children_count {
+			child_id := a.child(node, i)
+			if int(child_id) >= 0 {
+				stack << child_id
 			}
 		}
 	}
@@ -777,6 +1043,7 @@ fn receiver_info(a &flat.FlatAst, node &flat.Node) (string, string) {
 
 // collect_calls updates collect calls state for markused.
 fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports map[string]string, receiver_name string, receiver_struct string, mut calls []string) {
+	local_values := c.local_value_names(node)
 	mut stack := []flat.NodeId{cap: int(node.children_count)}
 	for i in 0 .. node.children_count {
 		child_id := c.a.child(node, i)
@@ -795,77 +1062,93 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 				c.collect_fn_value_selector(child_id, child, cur_module, imports, mut calls)
 			}
 			.call {
+				mut resolved_call := ''
 				if resolved := c.tc.resolved_call_name(child_id) {
-					calls << resolved
+					resolved_call = resolved
 				}
 				if child.children_count > 0 {
 					callee_id := c.a.child(child, 0)
 					if int(callee_id) >= 0 {
 						callee := c.a.nodes[int(callee_id)]
 						if callee.kind == .ident && callee.value.len > 0 {
+							if resolved_call.len > 0 {
+								calls << resolved_call
+							}
 							calls << callee.value
 							qcallee := qualify_fn(cur_module, callee.value)
 							if qcallee != callee.value {
 								calls << qcallee
 							}
 						} else if callee.kind == .selector && callee.value.len > 0 {
+							mut has_exact_selector_call := false
 							if callee.children_count > 0 {
 								base_id := c.a.child(&callee, 0)
 								if int(base_id) >= 0 {
 									base := c.a.nodes[int(base_id)]
-									if base.kind == .ident && base.value.len > 0 {
-										if receiver_name.len > 0 && base.value == receiver_name {
-											calls << receiver_struct + '.' + callee.value
-											qrecv := qualify_fn(cur_module, receiver_struct + '.' +
-												callee.value)
-											if qrecv != receiver_struct + '.' + callee.value {
-												calls << qrecv
-											}
-										}
-										mod_name := if base.value in imports {
-											imports[base.value]
-										} else {
-											base.value
-										}
-										calls << mod_name + '.' + callee.value
-										calls << qualify_fn(cur_module, base.value + '.' +
-											callee.value)
-										if base.value.len > 0 && base.value[0] >= `A`
-											&& base.value[0] <= `Z` {
-											named_type := c.tc.parse_type(base.value)
-											named_type_name := resolve_type_name(named_type)
-											if named_type_name.len > 0 {
-												calls << named_type_name + '.' + callee.value
-											}
-										}
-									} else if base.kind == .selector && base.children_count > 0 {
-										inner_id := c.a.child(&base, 0)
-										if int(inner_id) >= 0 {
-											inner := c.a.nodes[int(inner_id)]
-											if inner.kind == .ident && inner.value.len > 0 {
-												mod_name := if inner.value in imports {
-													imports[inner.value]
-												} else {
-													inner.value
+									has_exact_selector_call = c.collect_typed_receiver_method(base_id,
+										callee.value, cur_module, imports, local_values, mut calls)
+									if !has_exact_selector_call && base.kind == .ident
+										&& base.value in imports && base.value !in local_values {
+										calls << imports[base.value] + '.' + callee.value
+										has_exact_selector_call = true
+									}
+									if !has_exact_selector_call && resolved_call.len > 0 {
+										calls << resolved_call
+										has_exact_selector_call = true
+									}
+									if !has_exact_selector_call {
+										if base.kind == .ident && base.value.len > 0 {
+											if receiver_name.len > 0 && base.value == receiver_name {
+												calls << receiver_struct + '.' + callee.value
+												qrecv := qualify_fn(cur_module, receiver_struct +
+													'.' + callee.value)
+												if qrecv != receiver_struct + '.' + callee.value {
+													calls << qrecv
 												}
-												calls << mod_name + '.' + base.value + '.' +
-													callee.value
+											}
+											mod_name := if base.value in imports {
+												imports[base.value]
+											} else {
+												base.value
+											}
+											calls << mod_name + '.' + callee.value
+											calls << qualify_fn(cur_module, base.value + '.' +
+												callee.value)
+											if base.value.len > 0 && base.value[0] >= `A`
+												&& base.value[0] <= `Z` {
+												named_type := c.tc.parse_type(base.value)
+												named_type_name := resolve_type_name(named_type)
+												if named_type_name.len > 0 {
+													calls << named_type_name + '.' + callee.value
+												}
+											}
+										} else if base.kind == .selector && base.children_count > 0 {
+											inner_id := c.a.child(&base, 0)
+											if int(inner_id) >= 0 {
+												inner := c.a.nodes[int(inner_id)]
+												if inner.kind == .ident && inner.value.len > 0 {
+													mod_name := if inner.value in imports {
+														imports[inner.value]
+													} else {
+														inner.value
+													}
+													calls << mod_name + '.' + base.value + '.' +
+														callee.value
+												}
 											}
 										}
-									}
-									base_type := c.node_type(base_id)
-									mut type_name := resolve_type_name(base_type)
-									if type_name.len == 0 && base.kind == .ident {
-										type_name = c.value_type_name(base.value, cur_module)
-									}
-									if type_name.len > 0 {
-										calls << type_name + '.' + callee.value
 									}
 								}
 							}
-							calls << callee.value
+							if !has_exact_selector_call {
+								calls << callee.value
+							}
+						} else if resolved_call.len > 0 {
+							calls << resolved_call
 						}
 					}
+				} else if resolved_call.len > 0 {
+					calls << resolved_call
 				}
 				for ci in 1 .. child.children_count {
 					arg_id := c.a.child(child, ci)
@@ -945,6 +1228,375 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 			}
 		}
 	}
+}
+
+fn (c &CallCollector) local_value_names(node &flat.Node) map[string]bool {
+	mut names := map[string]bool{}
+	mut stack := []flat.NodeId{cap: int(node.children_count)}
+	for i in 0 .. node.children_count {
+		child_id := c.a.child(node, i)
+		if int(child_id) >= 0 {
+			stack << child_id
+		}
+	}
+	for stack.len > 0 {
+		id := stack.pop()
+		child := c.a.node(id)
+		if child.kind == .decl_assign {
+			mut i := 0
+			for i < child.children_count {
+				lhs_id := c.a.child(child, i)
+				if int(lhs_id) >= 0 {
+					lhs := c.a.node(lhs_id)
+					if lhs.kind == .ident && lhs.value.len > 0 {
+						names[lhs.value] = true
+					}
+				}
+				i += 2
+			}
+		}
+		for i in 0 .. child.children_count {
+			next_id := c.a.child(child, i)
+			if int(next_id) >= 0 {
+				stack << next_id
+			}
+		}
+	}
+	return names
+}
+
+fn (c &CallCollector) top_level_decl_rhs_type_name(rhs_id flat.NodeId, cur_module string, imports map[string]string) string {
+	rhs := c.a.node(rhs_id)
+	if rhs.kind == .struct_init && rhs.value.len > 0 {
+		return c.struct_lookup_name(markused_resolve_imported_type_name(rhs.value, imports),
+			cur_module)
+	}
+	type_name := resolve_type_name(c.node_type(rhs_id))
+	if type_name.len > 0 {
+		return c.struct_lookup_name(type_name, cur_module)
+	}
+	return ''
+}
+
+fn (c &CallCollector) collect_top_level_stmt_calls(id flat.NodeId, cur_module string, imports map[string]string, mut local_values map[string]bool, mut local_types map[string]string, mut calls []string) {
+	if int(id) < 0 {
+		return
+	}
+	node := c.a.node(id)
+	match node.kind {
+		.decl_assign {
+			c.collect_top_level_decl_assign_calls(node, cur_module, imports, mut local_values, mut
+				local_types, mut calls)
+		}
+		.block, .for_stmt, .for_in_stmt {
+			mut nested_values := local_values.clone()
+			mut nested_types := local_types.clone()
+			c.collect_top_level_child_calls(node, cur_module, imports, mut nested_values, mut
+				nested_types, mut calls)
+		}
+		.if_expr, .match_stmt {
+			c.collect_top_level_branch_calls(node, cur_module, imports, local_values, local_types, mut
+				calls)
+		}
+		else {
+			c.collect_top_level_expr_calls(id, cur_module, imports, local_values, local_types, mut
+				calls)
+		}
+	}
+}
+
+fn (c &CallCollector) collect_top_level_child_calls(node &flat.Node, cur_module string, imports map[string]string, mut local_values map[string]bool, mut local_types map[string]string, mut calls []string) {
+	for i in 0 .. node.children_count {
+		child_id := c.a.child(node, i)
+		if int(child_id) >= 0 {
+			c.collect_top_level_stmt_calls(child_id, cur_module, imports, mut local_values, mut
+				local_types, mut calls)
+		}
+	}
+}
+
+fn (c &CallCollector) collect_top_level_branch_calls(node &flat.Node, cur_module string, imports map[string]string, local_values map[string]bool, local_types map[string]string, mut calls []string) {
+	for i in 0 .. node.children_count {
+		child_id := c.a.child(node, i)
+		if int(child_id) < 0 {
+			continue
+		}
+		mut branch_values := local_values.clone()
+		mut branch_types := local_types.clone()
+		c.collect_top_level_stmt_calls(child_id, cur_module, imports, mut branch_values, mut
+			branch_types, mut calls)
+	}
+}
+
+fn (c &CallCollector) collect_top_level_decl_assign_calls(node &flat.Node, cur_module string, imports map[string]string, mut local_values map[string]bool, mut local_types map[string]string, mut calls []string) {
+	if node.kind != .decl_assign {
+		return
+	}
+	mut i := 0
+	pre_values := local_values.clone()
+	pre_types := local_types.clone()
+	for i + 1 < node.children_count {
+		rhs_id := c.a.child(node, i + 1)
+		if int(rhs_id) >= 0 {
+			mut rhs_values := pre_values.clone()
+			mut rhs_types := pre_types.clone()
+			c.collect_top_level_stmt_calls(rhs_id, cur_module, imports, mut rhs_values, mut
+				rhs_types, mut calls)
+		}
+		i += 2
+	}
+	i = 0
+	for i + 1 < node.children_count {
+		lhs_id := c.a.child(node, i)
+		rhs_id := c.a.child(node, i + 1)
+		if int(lhs_id) >= 0 && int(rhs_id) >= 0 {
+			lhs := c.a.node(lhs_id)
+			if lhs.kind == .ident && lhs.value.len > 0 {
+				local_values[lhs.value] = true
+				type_name := c.top_level_decl_rhs_type_name(rhs_id, cur_module, imports)
+				if type_name.len > 0 {
+					local_types[lhs.value] = type_name
+				}
+			}
+		}
+		i += 2
+	}
+}
+
+fn (c &CallCollector) collect_top_level_expr_calls(id flat.NodeId, cur_module string, imports map[string]string, local_values map[string]bool, local_types map[string]string, mut calls []string) {
+	if int(id) < 0 {
+		return
+	}
+	mut stack := [id]
+	for stack.len > 0 {
+		child_id := stack.pop()
+		child := c.a.node(child_id)
+		match child.kind {
+			.call {
+				c.collect_top_level_call(child_id, child, cur_module, imports, local_values,
+					local_types, mut calls)
+			}
+			.prefix {
+				if child.op == .amp && child.children_count > 0 {
+					inner_id := c.a.child(child, 0)
+					if int(inner_id) >= 0 {
+						inner := c.a.node(inner_id)
+						if inner.kind == .struct_init {
+							calls << 'memdup'
+						}
+					}
+				}
+			}
+			.string_interp {
+				calls << 'string_plus_many'
+			}
+			.infix {
+				if child.op == .plus {
+					calls << 'string__plus'
+				}
+				if child.children_count >= 2 {
+					lhs_id := c.a.child(child, 0)
+					rhs_id := c.a.child(child, 1)
+					if child.op in [.dot, .amp] {
+						lhs_name := c.qualified_expr_name(lhs_id)
+						if lhs_name.len > 0 {
+							rhs := c.a.node(rhs_id)
+							if rhs.kind == .call && rhs.children_count > 0 {
+								fn_node := c.a.child_node(rhs, 0)
+								if fn_node.kind == .ident && fn_node.value.len > 0 {
+									mod_name := if lhs_name in imports {
+										imports[lhs_name]
+									} else {
+										lhs_name
+									}
+									calls << mod_name + '.' + fn_node.value
+									calls << qualify_fn(cur_module, lhs_name + '.' + fn_node.value)
+								}
+							}
+						}
+					}
+					if int(lhs_id) >= 0 {
+						c.collect_struct_operator_call(lhs_id, child.op, cur_module, mut calls)
+					}
+				}
+			}
+			.or_expr {
+				if child.children_count > 0 {
+					expr_id := c.a.child(child, 0)
+					c.collect_zero_struct_default_calls(c.node_type(expr_id), cur_module, imports, mut
+						calls)
+				}
+			}
+			.struct_init {
+				c.collect_struct_default_calls(child, cur_module, imports, mut calls)
+			}
+			else {}
+		}
+
+		if child.children_count > 0 {
+			mut j := int(child.children_count) - 1
+			for j >= 0 {
+				next_id := c.a.child(child, j)
+				if int(next_id) >= 0 {
+					stack << next_id
+				}
+				j--
+			}
+		}
+	}
+}
+
+fn (c &CallCollector) collect_top_level_call(call_id flat.NodeId, call &flat.Node, cur_module string, imports map[string]string, local_values map[string]bool, local_types map[string]string, mut calls []string) {
+	mut resolved_call := ''
+	if resolved := c.tc.resolved_call_name(call_id) {
+		resolved_call = resolved
+	}
+	if call.children_count == 0 {
+		if resolved_call.len > 0 {
+			calls << resolved_call
+		}
+		return
+	}
+	callee_id := c.a.child(call, 0)
+	if int(callee_id) < 0 {
+		return
+	}
+	callee := c.a.node(callee_id)
+	if callee.kind == .ident && callee.value.len > 0 {
+		if resolved_call.len > 0 {
+			calls << resolved_call
+		}
+		calls << callee.value
+		qcallee := qualify_fn(cur_module, callee.value)
+		if qcallee != callee.value {
+			calls << qcallee
+		}
+	} else if callee.kind == .selector && callee.value.len > 0 {
+		c.collect_top_level_selector_call(callee, callee.value, resolved_call, cur_module, imports,
+			local_values, local_types, mut calls)
+	} else if resolved_call.len > 0 {
+		calls << resolved_call
+	}
+	for ci in 1 .. call.children_count {
+		arg_id := c.a.child(call, ci)
+		if int(arg_id) >= 0 {
+			arg := c.a.node(arg_id)
+			if arg.kind == .ident && arg.value.len > 0 {
+				calls << arg.value
+			}
+		}
+	}
+}
+
+fn (c &CallCollector) collect_top_level_selector_call(callee &flat.Node, method string, resolved_call string, cur_module string, imports map[string]string, local_values map[string]bool, local_types map[string]string, mut calls []string) {
+	mut has_exact_selector_call := false
+	if callee.children_count > 0 {
+		base_id := c.a.child(callee, 0)
+		if int(base_id) >= 0 {
+			base := c.a.node(base_id)
+			has_exact_selector_call = c.collect_top_level_typed_receiver_method(base_id, method,
+				cur_module, imports, local_values, local_types, mut calls)
+			if !has_exact_selector_call && base.kind == .ident && base.value in imports
+				&& base.value !in local_values {
+				calls << imports[base.value] + '.' + method
+				has_exact_selector_call = true
+			}
+			if !has_exact_selector_call && resolved_call.len > 0 {
+				calls << resolved_call
+				has_exact_selector_call = true
+			}
+			if !has_exact_selector_call {
+				c.collect_top_level_selector_fallback(base, method, cur_module, imports,
+					local_values, mut calls)
+			}
+		}
+	}
+}
+
+fn (c &CallCollector) collect_top_level_selector_fallback(base &flat.Node, method string, cur_module string, imports map[string]string, local_values map[string]bool, mut calls []string) {
+	if base.kind == .ident && base.value.len > 0 {
+		if base.value in local_values {
+			return
+		}
+		if base.value in imports {
+			return
+		}
+		mod_name := base.value
+		calls << mod_name + '.' + method
+		calls << qualify_fn(cur_module, base.value + '.' + method)
+		if base.value.len > 0 && base.value[0] >= `A` && base.value[0] <= `Z` {
+			named_type := c.tc.parse_type(base.value)
+			named_type_name := resolve_type_name(named_type)
+			if named_type_name.len > 0 {
+				calls << named_type_name + '.' + method
+			}
+		}
+	} else if base.kind == .selector && base.children_count > 0 {
+		inner_id := c.a.child(base, 0)
+		if int(inner_id) >= 0 {
+			inner := c.a.node(inner_id)
+			if inner.kind == .ident && inner.value.len > 0 {
+				mod_name := if inner.value in imports {
+					imports[inner.value]
+				} else {
+					inner.value
+				}
+				calls << mod_name + '.' + base.value + '.' + method
+			}
+		}
+	}
+}
+
+fn (c &CallCollector) collect_top_level_typed_receiver_method(base_id flat.NodeId, method string, cur_module string, imports map[string]string, local_values map[string]bool, local_types map[string]string, mut calls []string) bool {
+	type_name := c.top_level_receiver_type_name(base_id, cur_module, imports, local_values,
+		local_types)
+	if type_name.len == 0 {
+		return false
+	}
+	method_name := c.typed_receiver_method_name(type_name, method, cur_module) or { return false }
+	c.add_typed_receiver_method_name(method_name, mut calls)
+	return true
+}
+
+fn (c &CallCollector) top_level_receiver_type_name(base_id flat.NodeId, cur_module string, imports map[string]string, local_values map[string]bool, local_types map[string]string) string {
+	base := c.a.node(base_id)
+	if base.kind == .ident && base.value.len > 0 {
+		if local_type := local_types[base.value] {
+			return local_type
+		}
+		if base.value in local_values {
+			type_name := resolve_type_name(c.node_type(base_id))
+			if type_name.len > 0 {
+				struct_type := c.struct_lookup_name(type_name, cur_module)
+				if struct_type.len > 0 {
+					return struct_type
+				}
+				return type_name
+			}
+			return ''
+		}
+		if base.value in imports {
+			return ''
+		}
+	}
+	type_name := resolve_type_name(c.node_type(base_id))
+	if type_name.len > 0 {
+		struct_type := c.struct_lookup_name(type_name, cur_module)
+		if struct_type.len > 0 {
+			return struct_type
+		}
+		return type_name
+	}
+	if base.kind == .ident && base.value.len > 0 {
+		return c.value_type_name(base.value, cur_module, imports)
+	}
+	if base.kind == .selector {
+		name := c.qualified_expr_name(base_id)
+		if name.len > 0 {
+			return c.value_type_name(name, cur_module, imports)
+		}
+	}
+	return ''
 }
 
 // collect_struct_operator_call updates collect struct operator call state for markused.
@@ -1247,8 +1899,73 @@ fn (c &CallCollector) node_type(id flat.NodeId) types.Type {
 	return c.tc.resolve_type(id)
 }
 
-fn (c &CallCollector) value_type_name(name string, cur_module string) string {
-	for candidate in [qualify_fn(cur_module, name), name] {
+fn (c &CallCollector) collect_typed_receiver_method(base_id flat.NodeId, method string, cur_module string, imports map[string]string, local_values map[string]bool, mut calls []string) bool {
+	type_name := c.receiver_type_name(base_id, cur_module, imports, local_values)
+	if type_name.len == 0 {
+		return false
+	}
+	method_name := c.typed_receiver_method_name(type_name, method, cur_module) or { return false }
+	c.add_typed_receiver_method_name(method_name, mut calls)
+	return true
+}
+
+fn (c &CallCollector) receiver_type_name(base_id flat.NodeId, cur_module string, imports map[string]string, local_values map[string]bool) string {
+	base_type := c.node_type(base_id)
+	type_name := resolve_type_name(base_type)
+	if type_name.len > 0 {
+		return type_name
+	}
+	base := c.a.node(base_id)
+	if base.kind == .ident && base.value.len > 0 {
+		if base.value in local_values {
+			return ''
+		}
+		return c.value_type_name(base.value, cur_module, imports)
+	}
+	if base.kind == .selector {
+		name := c.qualified_expr_name(base_id)
+		if name.len > 0 {
+			return c.value_type_name(name, cur_module, imports)
+		}
+	}
+	return ''
+}
+
+fn (c &CallCollector) typed_receiver_method_name(type_name string, method string, cur_module string) ?string {
+	if type_name.len == 0 || method.len == 0 {
+		return none
+	}
+	mut candidates := []string{cap: 4}
+	if type_name.contains('.') {
+		candidates << '${type_name}.${method}'
+	} else {
+		if cur_module.len > 0 && cur_module != 'main' && cur_module != 'builtin' {
+			candidates << '${cur_module}.${type_name}.${method}'
+		}
+		candidates << '${type_name}.${method}'
+	}
+	for candidate in candidates {
+		if c.is_known_fn_name(candidate) {
+			return candidate
+		}
+		lowered := markused_c_name(candidate)
+		if lowered != candidate && c.is_known_fn_name(lowered) {
+			return lowered
+		}
+	}
+	return none
+}
+
+fn (c &CallCollector) add_typed_receiver_method_name(method_name string, mut calls []string) {
+	calls << method_name
+	lowered := markused_c_name(method_name)
+	if lowered != method_name {
+		calls << lowered
+	}
+}
+
+fn (c &CallCollector) value_type_name(name string, cur_module string, imports map[string]string) string {
+	for candidate in c.value_name_candidates(name, cur_module, imports) {
 		if typ := c.tc.file_scope.lookup(candidate) {
 			type_name := resolve_type_name(typ)
 			if type_name.len > 0 {
@@ -1261,8 +1978,55 @@ fn (c &CallCollector) value_type_name(name string, cur_module string) string {
 				return type_name
 			}
 		}
+		if info := c.const_decls[candidate] {
+			type_name := c.const_initializer_type_name(info)
+			if type_name.len > 0 {
+				return type_name
+			}
+		}
 	}
 	return ''
+}
+
+fn (c &CallCollector) const_initializer_type_name(info ConstDeclInfo) string {
+	expr := c.a.node(info.expr_id)
+	if expr.kind == .struct_init && expr.value.len > 0 {
+		return c.struct_lookup_name(expr.value, info.module)
+	}
+	type_name := resolve_type_name(c.node_type(info.expr_id))
+	if type_name.len > 0 {
+		return type_name
+	}
+	return ''
+}
+
+fn (c &CallCollector) value_name_candidates(name string, cur_module string, imports map[string]string) []string {
+	mut candidates := []string{cap: 3}
+	qname := qualify_fn(cur_module, name)
+	candidates << qname
+	if qname != name {
+		candidates << name
+	}
+	if name.contains('.') {
+		base := name.all_before_last('.')
+		member := name.all_after_last('.')
+		if base in imports {
+			candidates << '${imports[base]}.${member}'
+		}
+	}
+	return candidates
+}
+
+fn markused_resolve_imported_type_name(name string, imports map[string]string) string {
+	if !name.contains('.') {
+		return name
+	}
+	base := name.all_before_last('.')
+	member := name.all_after_last('.')
+	if base in imports {
+		return '${imports[base]}.${member}'
+	}
+	return name
 }
 
 // collect_zero_struct_default_calls updates collect zero struct default calls state for markused.

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -33,6 +33,10 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	mut fn_with_dot := 0
 	mut contains2_total := 0
 	for node_idx, node in a.nodes {
+		if node.kind == .file {
+			cur_module = ''
+			continue
+		}
 		if node.kind == .module_decl {
 			cur_module = node.value
 			continue
@@ -622,6 +626,9 @@ fn enqueue_export_roots(a &flat.FlatAst, mut used map[string]bool, mut queue []s
 	mut cur_module := ''
 	for node in a.nodes {
 		match node.kind {
+			.file {
+				cur_module = ''
+			}
 			.module_decl {
 				cur_module = node.value
 			}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -638,15 +638,31 @@ fn enqueue_test_file_roots(a &flat.FlatAst, test_files map[string]bool, mut used
 		if module_name.len > 0 && module_name != 'main' {
 			continue
 		}
-		for i in 0 .. file_node.children_count {
-			child_id := a.child(&file_node, i)
-			if int(child_id) < a.user_code_start {
-				continue
-			}
+		mut decl_ids := []flat.NodeId{}
+		markused_collect_test_harness_decl_ids(a, file_node, mut decl_ids)
+		for child_id in decl_ids {
 			child := a.node(child_id)
-			if child.kind == .fn_decl && is_test_harness_root_name(child.value) {
+			if is_test_harness_root_name(child.value) {
 				enqueue(qualify_fn(module_name, child.value), mut used, mut queue)
 			}
+		}
+	}
+}
+
+fn markused_collect_test_harness_decl_ids(a &flat.FlatAst, node flat.Node, mut ids []flat.NodeId) {
+	if node.kind != .file && node.kind != .block {
+		return
+	}
+	for i in 0 .. node.children_count {
+		child_id := a.child(&node, i)
+		if int(child_id) < a.user_code_start {
+			continue
+		}
+		child := a.node(child_id)
+		if child.kind == .fn_decl {
+			ids << child_id
+		} else if child.kind == .block {
+			markused_collect_test_harness_decl_ids(a, child, mut ids)
 		}
 	}
 }

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -552,7 +552,7 @@ fn markused_top_level_file_imports(a &flat.FlatAst, file_node flat.Node) map[str
 fn markused_is_top_level_stmt(node flat.Node) bool {
 	return match node.kind {
 		.expr_stmt, .assign, .decl_assign, .global_decl, .selector_assign, .index_assign,
-		.for_stmt, .for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .block {
+		.for_stmt, .for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .defer_stmt, .block {
 			true
 		}
 		else {

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -141,19 +141,20 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	for seed in ['__new_array', 'new_array_from_c_array', 'array.get', 'array.set', 'array.push',
 		'array.push_many', 'array.slice', 'array.clone', 'array.delete', 'array.ensure_cap',
 		'string.==', 'string.<', 'string.free', 'string.all_before', 'string.all_before_last',
-		'string.all_after', 'string.all_after_last', 'u8.vstring', '[]rune.string', 'map.set',
-		'map.exists', 'map.get', 'map.get_check', 'map.get_and_set', 'map.delete', 'map.clone',
-		'map.clear', 'memdup', 'strings.Builder.write_ptr', 'strings.Builder.write_runes',
-		'strings.Builder.free', 'strconv.format_int', 'strconv.format_uint', 'bool.str', 'ptr_str',
-		'strconv__f32_to_str_l', 'strconv__f64_to_str_l', 'sync.new_channel_st', 'sync.Channel.push',
-		'sync.Channel.pop', 'sync.Channel.close', 'sync.Channel.len', 'sync.Channel.closed',
-		'new_channel_st', 'Channel.push', 'Channel.pop', 'Channel.close', 'Channel.len',
-		'Channel.closed', 'panic', 'u8.is_letter', 'u8.is_capital', 'string.is_capital',
-		'string.to_lower_ascii', 'rune.to_lower', 'data_to_hex_string', 'map_hash_string',
-		'map_hash_int_1', 'map_hash_int_2', 'map_hash_int_4', 'map_hash_int_8', 'map_eq_string',
-		'map_eq_int_1', 'map_eq_int_2', 'map_eq_int_4', 'map_eq_int_8', 'map_clone_string',
-		'map_clone_int_1', 'map_clone_int_2', 'map_clone_int_4', 'map_clone_int_8', 'map_free_string',
-		'map_free_nop', '[]string.join', 'Array_string__join', 'exit', 'v_exit'] {
+		'string.all_after', 'string.all_after_last', 'string.substr', 'string__substr', 'u8.vstring',
+		'[]rune.string', 'map.set', 'map.exists', 'map.get', 'map.get_check', 'map.get_and_set',
+		'map.delete', 'map.clone', 'map.clear', 'memdup', 'strings.Builder.write_ptr',
+		'strings.Builder.write_runes', 'strings.Builder.free', 'strconv.format_int',
+		'strconv.format_uint', 'bool.str', 'ptr_str', 'strconv__f32_to_str_l',
+		'strconv__f64_to_str_l', 'sync.new_channel_st', 'sync.Channel.push', 'sync.Channel.pop',
+		'sync.Channel.close', 'sync.Channel.len', 'sync.Channel.closed', 'new_channel_st',
+		'Channel.push', 'Channel.pop', 'Channel.close', 'Channel.len', 'Channel.closed', 'panic',
+		'u8.is_letter', 'u8.is_capital', 'string.is_capital', 'string.to_lower_ascii',
+		'rune.to_lower', 'data_to_hex_string', 'map_hash_string', 'map_hash_int_1', 'map_hash_int_2',
+		'map_hash_int_4', 'map_hash_int_8', 'map_eq_string', 'map_eq_int_1', 'map_eq_int_2',
+		'map_eq_int_4', 'map_eq_int_8', 'map_clone_string', 'map_clone_int_1', 'map_clone_int_2',
+		'map_clone_int_4', 'map_clone_int_8', 'map_free_string', 'map_free_nop', '[]string.join',
+		'Array_string__join', 'exit', 'v_exit'] {
 		queue << seed
 		used[seed] = true
 	}
@@ -189,14 +190,14 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		const_decls:  const_decls
 	}
 	enqueue_detected_runtime_helpers(a, tc, mut used, mut queue)
-	enqueue_function_value_selectors(a, fn_decls, mut used, mut queue)
+	enqueue_function_value_selectors(a, collector, fn_decls, mut used, mut queue)
 	// Methods used as values (`recv.method` passed as a callback) are reachable only
 	// through a wrapper cgen generates later. The checker records them per enclosing
 	// function in `method_values_by_fn`; they are seeded inside the BFS below (only when
 	// that function is reached), so an unreachable function's method value never forces an
 	// otherwise-unused specialization to be transformed/emitted.
 	enqueue_initializer_calls(a, collector, imports, fn_decls, mut used, mut queue)
-	enqueue_top_level_calls(a, collector, imports, fn_decls, mut used, mut queue)
+	enqueue_top_level_calls(a, collector, fn_decls, mut used, mut queue)
 	// Interface dispatch reachability: calling an interface method `Foo.m` may
 	// dispatch to any concrete `T.m` for a type `T` that implements `Foo`. Those
 	// concrete methods are only referenced from the generated dispatch switch, so
@@ -460,16 +461,14 @@ fn enqueue_initializer_calls(a &flat.FlatAst, collector CallCollector, imports m
 	}
 }
 
-fn enqueue_top_level_calls(a &flat.FlatAst, collector CallCollector, imports map[string]string, fn_decls map[string]FnDeclInfo, mut used map[string]bool, mut queue []string) {
-	if markused_has_entry_main(a) {
-		return
-	}
+fn enqueue_top_level_calls(a &flat.FlatAst, collector CallCollector, fn_decls map[string]FnDeclInfo, mut used map[string]bool, mut queue []string) {
 	mut calls := []string{cap: 32}
 	for file_idx, file_node in a.nodes {
 		if !markused_should_scan_top_level_file(a, file_idx, file_node) {
 			continue
 		}
 		module_name := markused_top_level_file_module_name(a, file_node)
+		file_imports := markused_top_level_file_imports(a, file_node)
 		mut local_values := map[string]bool{}
 		mut local_types := map[string]string{}
 		for i in 0 .. file_node.children_count {
@@ -482,7 +481,7 @@ fn enqueue_top_level_calls(a &flat.FlatAst, collector CallCollector, imports map
 				continue
 			}
 			calls.clear()
-			collector.collect_top_level_stmt_calls(child_id, module_name, imports, mut
+			collector.collect_top_level_stmt_calls(child_id, module_name, file_imports, mut
 				local_values, mut local_types, mut calls)
 			for callee in calls {
 				if callee_info := fn_decls[callee] {
@@ -535,10 +534,21 @@ fn markused_top_level_file_module_name(a &flat.FlatAst, file_node flat.Node) str
 	return ''
 }
 
+fn markused_top_level_file_imports(a &flat.FlatAst, file_node flat.Node) map[string]string {
+	mut imports := map[string]string{}
+	for i in 0 .. file_node.children_count {
+		child := a.child_node(&file_node, i)
+		if child.kind == .import_decl {
+			imports[child.typ] = child.value
+		}
+	}
+	return imports
+}
+
 fn markused_is_top_level_stmt(node flat.Node) bool {
 	return match node.kind {
-		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
-		.for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .block {
+		.expr_stmt, .assign, .decl_assign, .global_decl, .selector_assign, .index_assign,
+		.for_stmt, .for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .block {
 			true
 		}
 		else {
@@ -906,27 +916,57 @@ fn stringification_type_candidates(type_name string, cur_module string) []string
 }
 
 // enqueue_function_value_selectors supports enqueue function value selectors handling for markused.
-fn enqueue_function_value_selectors(a &flat.FlatAst, fn_decls map[string]FnDeclInfo, mut used map[string]bool, mut queue []string) {
+fn enqueue_function_value_selectors(a &flat.FlatAst, collector CallCollector, fn_decls map[string]FnDeclInfo, mut used map[string]bool, mut queue []string) {
 	ignored_top_level_nodes := markused_ignored_top_level_nodes(a)
+	ignored_fn_decl_nodes := markused_ignored_fn_decl_nodes(a)
+	shadowed_value_idents := markused_shadowed_value_idents(collector)
 	for node_idx, node in a.nodes {
+		if node_idx < ignored_fn_decl_nodes.len && ignored_fn_decl_nodes[node_idx] {
+			continue
+		}
+		if node.kind == .ident && node.value.len > 0 {
+			node_id := flat.NodeId(node_idx)
+			is_shadowed := node_idx < shadowed_value_idents.len && shadowed_value_idents[node_idx]
+			if is_shadowed {
+				continue
+			}
+			if resolved := collector.tc.resolved_fn_value_name(node_id) {
+				enqueue(resolved, mut used, mut queue)
+				continue
+			}
+			if node.value in fn_decls && collector.node_is_fn_value(node_id) {
+				enqueue(node.value, mut used, mut queue)
+			}
+			continue
+		}
 		if node_idx < ignored_top_level_nodes.len && ignored_top_level_nodes[node_idx] {
 			continue
 		}
 		if node.kind == .selector && node.children_count > 0 && node.value.len > 0 {
-			base := a.child_node(&node, 0)
+			base_id := a.child(&node, 0)
+			if int(base_id) >= 0 && int(base_id) < shadowed_value_idents.len
+				&& shadowed_value_idents[int(base_id)] {
+				continue
+			}
+			base := a.node(base_id)
 			if base.kind == .ident && base.value.len > 0 {
 				name := '${base.value}.${node.value}'
 				if name in fn_decls {
 					enqueue(name, mut used, mut queue)
 				}
 			}
-		} else if node.kind == .call && node.children_count > 0 {
-			callee := a.child_node(&node, 0)
-			if callee.kind == .ident && callee.value in fn_decls {
-				enqueue(callee.value, mut used, mut queue)
-			}
 		}
 	}
+}
+
+fn markused_ignored_fn_decl_nodes(a &flat.FlatAst) []bool {
+	mut ignored := []bool{len: a.nodes.len}
+	for node_idx, node in a.nodes {
+		if node.kind == .fn_decl {
+			markused_mark_node_subtree(a, flat.NodeId(node_idx), mut ignored)
+		}
+	}
+	return ignored
 }
 
 fn markused_ignored_top_level_nodes(a &flat.FlatAst) []bool {
@@ -951,6 +991,118 @@ fn markused_ignored_top_level_nodes(a &flat.FlatAst) []bool {
 		}
 	}
 	return ignored
+}
+
+fn markused_shadowed_value_idents(collector CallCollector) []bool {
+	a := collector.a
+	mut shadowed := []bool{len: a.nodes.len}
+	for node in a.nodes {
+		if node.kind != .fn_decl {
+			continue
+		}
+		local_values := markused_local_value_names(a, &node)
+		if local_values.len == 0 {
+			continue
+		}
+		markused_mark_shadowed_idents(a, &node, local_values, mut shadowed)
+	}
+	for file_idx, file_node in a.nodes {
+		if !markused_should_scan_top_level_file(a, file_idx, file_node) {
+			continue
+		}
+		mut local_values := map[string]bool{}
+		for i in 0 .. file_node.children_count {
+			child_id := a.child(&file_node, i)
+			if int(child_id) < a.user_code_start {
+				continue
+			}
+			child := a.node(child_id)
+			if !markused_is_top_level_stmt(child) {
+				continue
+			}
+			if local_values.len > 0 {
+				markused_mark_shadowed_idents(a, child, local_values, mut shadowed)
+			}
+			markused_mark_top_level_lhs_idents(a, child, mut shadowed)
+			markused_add_top_level_lhs_names(a, child, mut local_values)
+		}
+	}
+	return shadowed
+}
+
+fn markused_mark_shadowed_idents(a &flat.FlatAst, node &flat.Node, local_values map[string]bool, mut shadowed []bool) {
+	if local_values.len == 0 {
+		return
+	}
+	mut stack := []flat.NodeId{cap: int(node.children_count)}
+	for i in 0 .. node.children_count {
+		child_id := a.child(node, i)
+		if int(child_id) >= 0 {
+			stack << child_id
+		}
+	}
+	for stack.len > 0 {
+		id := stack.pop()
+		idx := int(id)
+		if idx < 0 || idx >= shadowed.len {
+			continue
+		}
+		child := a.node(id)
+		if child.kind == .ident && child.value in local_values {
+			shadowed[idx] = true
+		}
+		for i in 0 .. child.children_count {
+			next_id := a.child(child, i)
+			if int(next_id) >= 0 {
+				stack << next_id
+			}
+		}
+	}
+}
+
+fn markused_mark_top_level_lhs_idents(a &flat.FlatAst, node &flat.Node, mut shadowed []bool) {
+	if node.kind != .decl_assign {
+		return
+	}
+	mut i := 0
+	for i + 1 < node.children_count {
+		lhs_id := a.child(node, i)
+		idx := int(lhs_id)
+		if idx >= 0 && idx < shadowed.len {
+			lhs := a.node(lhs_id)
+			if lhs.kind == .ident {
+				shadowed[idx] = true
+			}
+		}
+		i += 2
+	}
+}
+
+fn markused_add_top_level_lhs_names(a &flat.FlatAst, node &flat.Node, mut local_values map[string]bool) {
+	match node.kind {
+		.decl_assign, .assign {
+			mut i := 0
+			for i + 1 < node.children_count {
+				lhs_id := a.child(node, i)
+				if int(lhs_id) >= 0 {
+					lhs := a.node(lhs_id)
+					if lhs.kind == .ident && lhs.value.len > 0 {
+						local_values[lhs.value] = true
+					}
+				}
+				i += 2
+			}
+		}
+		.global_decl {
+			for i in 0 .. node.children_count {
+				field := a.child_node(node, i)
+				if field.value.len > 0 {
+					local_values[field.value] = true
+				}
+			}
+		}
+		else {}
+	}
 }
 
 fn markused_mark_node_subtree(a &flat.FlatAst, root flat.NodeId, mut marked []bool) {
@@ -1072,10 +1224,15 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 		child := &c.a.nodes[int(child_id)]
 		match child.kind {
 			.ident {
-				c.collect_fn_value_ident(child_id, child.value, cur_module, imports, mut calls)
+				c.collect_fn_value_ident(child_id, child.value, cur_module, imports, local_values, mut
+					calls)
 			}
 			.selector {
-				c.collect_fn_value_selector(child_id, child, cur_module, imports, mut calls)
+				if !c.selector_base_is_local(child, local_values) {
+					c.collect_fn_value_selector(child_id, child, cur_module, imports, mut calls)
+				} else if resolved := c.tc.resolved_fn_value_name(child_id) {
+					calls << resolved
+				}
 			}
 			.call {
 				mut resolved_call := ''
@@ -1090,10 +1247,12 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 							if resolved_call.len > 0 {
 								calls << resolved_call
 							}
-							calls << callee.value
-							qcallee := qualify_fn(cur_module, callee.value)
-							if qcallee != callee.value {
-								calls << qcallee
+							if callee.value !in local_values {
+								calls << callee.value
+								qcallee := qualify_fn(cur_module, callee.value)
+								if qcallee != callee.value {
+									calls << qcallee
+								}
 							}
 						} else if callee.kind == .selector && callee.value.len > 0 {
 							mut has_exact_selector_call := false
@@ -1110,6 +1269,11 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 									}
 									if !has_exact_selector_call && resolved_call.len > 0 {
 										calls << resolved_call
+										has_exact_selector_call = true
+									}
+									if !has_exact_selector_call && base.kind == .ident
+										&& base.value in local_values && !(receiver_name.len > 0
+										&& base.value == receiver_name) {
 										has_exact_selector_call = true
 									}
 									if !has_exact_selector_call {
@@ -1171,7 +1335,8 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 					if int(arg_id) >= 0 {
 						arg := c.a.nodes[int(arg_id)]
 						if arg.kind == .ident && arg.value.len > 0 {
-							calls << arg.value
+							c.collect_fn_value_ident(arg_id, arg.value, cur_module, imports,
+								local_values, mut calls)
 						}
 					}
 				}
@@ -1247,23 +1412,29 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 }
 
 fn (c &CallCollector) local_value_names(node &flat.Node) map[string]bool {
+	return markused_local_value_names(c.a, node)
+}
+
+fn markused_local_value_names(a &flat.FlatAst, node &flat.Node) map[string]bool {
 	mut names := map[string]bool{}
 	mut stack := []flat.NodeId{cap: int(node.children_count)}
 	for i in 0 .. node.children_count {
-		child_id := c.a.child(node, i)
+		child_id := a.child(node, i)
 		if int(child_id) >= 0 {
 			stack << child_id
 		}
 	}
 	for stack.len > 0 {
 		id := stack.pop()
-		child := c.a.node(id)
-		if child.kind == .decl_assign {
+		child := a.node(id)
+		if child.kind == .param && child.value.len > 0 {
+			names[child.value] = true
+		} else if child.kind == .decl_assign {
 			mut i := 0
 			for i < child.children_count {
-				lhs_id := c.a.child(child, i)
+				lhs_id := a.child(child, i)
 				if int(lhs_id) >= 0 {
-					lhs := c.a.node(lhs_id)
+					lhs := a.node(lhs_id)
 					if lhs.kind == .ident && lhs.value.len > 0 {
 						names[lhs.value] = true
 					}
@@ -1272,7 +1443,7 @@ fn (c &CallCollector) local_value_names(node &flat.Node) map[string]bool {
 			}
 		}
 		for i in 0 .. child.children_count {
-			next_id := c.a.child(child, i)
+			next_id := a.child(child, i)
 			if int(next_id) >= 0 {
 				stack << next_id
 			}
@@ -1300,8 +1471,12 @@ fn (c &CallCollector) collect_top_level_stmt_calls(id flat.NodeId, cur_module st
 	}
 	node := c.a.node(id)
 	match node.kind {
-		.decl_assign {
-			c.collect_top_level_decl_assign_calls(node, cur_module, imports, mut local_values, mut
+		.decl_assign, .assign {
+			c.collect_top_level_assign_calls(node, cur_module, imports, mut local_values, mut
+				local_types, mut calls)
+		}
+		.global_decl {
+			c.collect_top_level_global_decl_calls(node, cur_module, imports, mut local_values, mut
 				local_types, mut calls)
 		}
 		.block, .for_stmt, .for_in_stmt {
@@ -1344,8 +1519,8 @@ fn (c &CallCollector) collect_top_level_branch_calls(node &flat.Node, cur_module
 	}
 }
 
-fn (c &CallCollector) collect_top_level_decl_assign_calls(node &flat.Node, cur_module string, imports map[string]string, mut local_values map[string]bool, mut local_types map[string]string, mut calls []string) {
-	if node.kind != .decl_assign {
+fn (c &CallCollector) collect_top_level_assign_calls(node &flat.Node, cur_module string, imports map[string]string, mut local_values map[string]bool, mut local_types map[string]string, mut calls []string) {
+	if node.kind !in [.decl_assign, .assign] {
 		return
 	}
 	mut i := 0
@@ -1379,6 +1554,41 @@ fn (c &CallCollector) collect_top_level_decl_assign_calls(node &flat.Node, cur_m
 	}
 }
 
+fn (c &CallCollector) collect_top_level_global_decl_calls(node &flat.Node, cur_module string, imports map[string]string, mut local_values map[string]bool, mut local_types map[string]string, mut calls []string) {
+	if node.kind != .global_decl {
+		return
+	}
+	pre_values := local_values.clone()
+	pre_types := local_types.clone()
+	for i in 0 .. node.children_count {
+		field := c.a.child_node(node, i)
+		if field.children_count == 0 {
+			continue
+		}
+		expr_id := c.a.child(field, 0)
+		if int(expr_id) >= 0 {
+			mut rhs_values := pre_values.clone()
+			mut rhs_types := pre_types.clone()
+			c.collect_top_level_stmt_calls(expr_id, cur_module, imports, mut rhs_values, mut
+				rhs_types, mut calls)
+		}
+	}
+	for i in 0 .. node.children_count {
+		field := c.a.child_node(node, i)
+		if field.value.len == 0 {
+			continue
+		}
+		local_values[field.value] = true
+		if field.children_count > 0 {
+			expr_id := c.a.child(field, 0)
+			type_name := c.top_level_decl_rhs_type_name(expr_id, cur_module, imports)
+			if type_name.len > 0 {
+				local_types[field.value] = type_name
+			}
+		}
+	}
+}
+
 fn (c &CallCollector) collect_top_level_expr_calls(id flat.NodeId, cur_module string, imports map[string]string, local_values map[string]bool, local_types map[string]string, mut calls []string) {
 	if int(id) < 0 {
 		return
@@ -1390,7 +1600,8 @@ fn (c &CallCollector) collect_top_level_expr_calls(id flat.NodeId, cur_module st
 		match child.kind {
 			.ident {
 				if child.value !in local_values {
-					c.collect_fn_value_ident(child_id, child.value, cur_module, imports, mut calls)
+					c.collect_fn_value_ident(child_id, child.value, cur_module, imports,
+						local_values, mut calls)
 				}
 			}
 			.selector {
@@ -1473,10 +1684,14 @@ fn (c &CallCollector) collect_top_level_expr_calls(id flat.NodeId, cur_module st
 }
 
 fn (c &CallCollector) top_level_selector_base_is_local(node flat.Node, local_values map[string]bool) bool {
+	return c.selector_base_is_local(&node, local_values)
+}
+
+fn (c &CallCollector) selector_base_is_local(node &flat.Node, local_values map[string]bool) bool {
 	if node.children_count == 0 {
 		return false
 	}
-	base_id := c.a.child(&node, 0)
+	base_id := c.a.child(node, 0)
 	if int(base_id) < 0 {
 		return false
 	}
@@ -1504,10 +1719,12 @@ fn (c &CallCollector) collect_top_level_call(call_id flat.NodeId, call &flat.Nod
 		if resolved_call.len > 0 {
 			calls << resolved_call
 		}
-		calls << callee.value
-		qcallee := qualify_fn(cur_module, callee.value)
-		if qcallee != callee.value {
-			calls << qcallee
+		if callee.value !in local_values {
+			calls << callee.value
+			qcallee := qualify_fn(cur_module, callee.value)
+			if qcallee != callee.value {
+				calls << qcallee
+			}
 		}
 	} else if callee.kind == .selector && callee.value.len > 0 {
 		c.collect_top_level_selector_call(callee, callee.value, resolved_call, cur_module, imports,
@@ -1521,7 +1738,8 @@ fn (c &CallCollector) collect_top_level_call(call_id flat.NodeId, call &flat.Nod
 			arg := c.a.node(arg_id)
 			if arg.kind == .ident && arg.value.len > 0 {
 				if arg.value !in local_values {
-					c.collect_fn_value_ident(arg_id, arg.value, cur_module, imports, mut calls)
+					c.collect_fn_value_ident(arg_id, arg.value, cur_module, imports, local_values, mut
+						calls)
 				}
 			}
 		}
@@ -1786,7 +2004,10 @@ fn (c &CallCollector) qualified_expr_name(id flat.NodeId) string {
 }
 
 // collect_fn_value_ident updates collect fn value ident state for markused.
-fn (c &CallCollector) collect_fn_value_ident(id flat.NodeId, name string, cur_module string, imports map[string]string, mut calls []string) {
+fn (c &CallCollector) collect_fn_value_ident(id flat.NodeId, name string, cur_module string, imports map[string]string, local_values map[string]bool, mut calls []string) {
+	if name in local_values {
+		return
+	}
 	if resolved := c.tc.resolved_fn_value_name(id) {
 		calls << resolved
 		return

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -1224,7 +1224,9 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 		child := &c.a.nodes[int(child_id)]
 		match child.kind {
 			.ident {
-				c.collect_fn_value_ident(child_id, child.value, cur_module, imports, local_values, mut
+				ident_values := markused_local_values_for_ident(c.a, node, child_id, child.value,
+					local_values)
+				c.collect_fn_value_ident(child_id, child.value, cur_module, imports, ident_values, mut
 					calls)
 			}
 			.selector {
@@ -1335,8 +1337,10 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 					if int(arg_id) >= 0 {
 						arg := c.a.nodes[int(arg_id)]
 						if arg.kind == .ident && arg.value.len > 0 {
+							arg_values := markused_local_values_for_ident(c.a, node, arg_id,
+								arg.value, local_values)
 							c.collect_fn_value_ident(arg_id, arg.value, cur_module, imports,
-								local_values, mut calls)
+								arg_values, mut calls)
 						}
 					}
 				}
@@ -1401,6 +1405,10 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 		if child.children_count > 0 {
 			mut j := int(child.children_count) - 1
 			for j >= 0 {
+				if child.kind == .decl_assign && j % 2 == 0 {
+					j--
+					continue
+				}
 				next_id := c.a.child(child, j)
 				if int(next_id) >= 0 {
 					stack << next_id
@@ -1450,6 +1458,89 @@ fn markused_local_value_names(a &flat.FlatAst, node &flat.Node) map[string]bool 
 		}
 	}
 	return names
+}
+
+fn markused_local_values_for_ident(a &flat.FlatAst, root &flat.Node, id flat.NodeId, name string, local_values map[string]bool) map[string]bool {
+	if name.len == 0 || name !in local_values
+		|| markused_has_prior_visible_local_value(a, root, id, name) {
+		return local_values
+	}
+	mut values := local_values.clone()
+	values.delete(name)
+	return values
+}
+
+fn markused_has_prior_visible_local_value(a &flat.FlatAst, root &flat.Node, target flat.NodeId, name string) bool {
+	mut locals := map[string]bool{}
+	return markused_scan_prior_local_value(a, root, target, name, mut locals) or { false }
+}
+
+fn markused_scan_prior_local_value(a &flat.FlatAst, node &flat.Node, target flat.NodeId, name string, mut locals map[string]bool) ?bool {
+	if node.kind == .fn_decl {
+		for i in 0 .. node.children_count {
+			child := a.child_node(node, i)
+			if child.kind == .param && child.value.len > 0 {
+				locals[child.value] = true
+			}
+		}
+	}
+	for i in 0 .. node.children_count {
+		child_id := a.child(node, i)
+		if int(child_id) < 0 {
+			continue
+		}
+		if child_id == target {
+			return name in locals
+		}
+		child := a.node(child_id)
+		match child.kind {
+			.fn_decl, .c_fn_decl, .fn_literal {
+				continue
+			}
+			.block, .if_expr, .match_stmt, .for_stmt, .for_in_stmt {
+				mut scoped := locals.clone()
+				if found := markused_scan_prior_local_value(a, child, target, name, mut scoped) {
+					return found
+				}
+			}
+			.decl_assign {
+				mut i2 := 1
+				for i2 < child.children_count {
+					rhs_id := a.child(child, i2)
+					if int(rhs_id) >= 0 {
+						if rhs_id == target {
+							return name in locals
+						}
+						rhs := a.node(rhs_id)
+						if found := markused_scan_prior_local_value(a, rhs, target, name, mut
+							locals)
+						{
+							return found
+						}
+					}
+					i2 += 2
+				}
+				i2 = 0
+				for i2 + 1 < child.children_count {
+					lhs_id := a.child(child, i2)
+					if lhs_id == target {
+						return name in locals
+					}
+					lhs := a.node(lhs_id)
+					if lhs.kind == .ident && lhs.value.len > 0 {
+						locals[lhs.value] = true
+					}
+					i2 += 2
+				}
+			}
+			else {
+				if found := markused_scan_prior_local_value(a, child, target, name, mut locals) {
+					return found
+				}
+			}
+		}
+	}
+	return none
 }
 
 fn (c &CallCollector) top_level_decl_rhs_type_name(rhs_id flat.NodeId, cur_module string, imports map[string]string) string {

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -1747,6 +1747,10 @@ fn (c &CallCollector) qualified_expr_name(id flat.NodeId) string {
 
 // collect_fn_value_ident updates collect fn value ident state for markused.
 fn (c &CallCollector) collect_fn_value_ident(id flat.NodeId, name string, cur_module string, imports map[string]string, mut calls []string) {
+	if resolved := c.tc.resolved_fn_value_name(id) {
+		calls << resolved
+		return
+	}
 	if name.len == 0 || !c.name_may_reference_fn(name, cur_module, imports) {
 		return
 	}
@@ -1760,6 +1764,10 @@ fn (c &CallCollector) collect_fn_value_ident(id flat.NodeId, name string, cur_mo
 
 // collect_fn_value_selector updates collect fn value selector state for markused.
 fn (c &CallCollector) collect_fn_value_selector(id flat.NodeId, node &flat.Node, cur_module string, imports map[string]string, mut calls []string) {
+	if resolved := c.tc.resolved_fn_value_name(id) {
+		calls << resolved
+		return
+	}
 	if node.children_count == 0 {
 		return
 	}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -1388,6 +1388,16 @@ fn (c &CallCollector) collect_top_level_expr_calls(id flat.NodeId, cur_module st
 		child_id := stack.pop()
 		child := c.a.node(child_id)
 		match child.kind {
+			.ident {
+				if child.value !in local_values {
+					c.collect_fn_value_ident(child_id, child.value, cur_module, imports, mut calls)
+				}
+			}
+			.selector {
+				if !c.top_level_selector_base_is_local(child, local_values) {
+					c.collect_fn_value_selector(child_id, child, cur_module, imports, mut calls)
+				}
+			}
 			.call {
 				c.collect_top_level_call(child_id, child, cur_module, imports, local_values,
 					local_types, mut calls)
@@ -1462,6 +1472,18 @@ fn (c &CallCollector) collect_top_level_expr_calls(id flat.NodeId, cur_module st
 	}
 }
 
+fn (c &CallCollector) top_level_selector_base_is_local(node flat.Node, local_values map[string]bool) bool {
+	if node.children_count == 0 {
+		return false
+	}
+	base_id := c.a.child(&node, 0)
+	if int(base_id) < 0 {
+		return false
+	}
+	base := c.a.node(base_id)
+	return base.kind == .ident && base.value in local_values
+}
+
 fn (c &CallCollector) collect_top_level_call(call_id flat.NodeId, call &flat.Node, cur_module string, imports map[string]string, local_values map[string]bool, local_types map[string]string, mut calls []string) {
 	mut resolved_call := ''
 	if resolved := c.tc.resolved_call_name(call_id) {
@@ -1498,7 +1520,9 @@ fn (c &CallCollector) collect_top_level_call(call_id flat.NodeId, call &flat.Nod
 		if int(arg_id) >= 0 {
 			arg := c.a.node(arg_id)
 			if arg.kind == .ident && arg.value.len > 0 {
-				calls << arg.value
+				if arg.value !in local_values {
+					c.collect_fn_value_ident(arg_id, arg.value, cur_module, imports, mut calls)
+				}
 			}
 		}
 	}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -39,6 +39,7 @@ mut:
 	cur_fn           string
 	pending_flag     bool
 	pending_params   bool
+	pending_export   string
 	skip_next_decl   bool
 	disable_fn_body  bool
 	in_for_container bool
@@ -53,9 +54,10 @@ pub fn Parser.new(prefs &pref.Preferences) &Parser {
 		prefs: unsafe { prefs }
 		s:     scanner.new_scanner(prefs, .normal)
 		a:     &flat.FlatAst{
-			nodes:        []flat.Node{cap: 256}
-			children:     []flat.NodeId{cap: 512}
-			disabled_fns: map[string]bool{}
+			nodes:           []flat.Node{cap: 256}
+			children:        []flat.NodeId{cap: 512}
+			disabled_fns:    map[string]bool{}
+			export_fn_names: map[string]string{}
 		}
 	}
 }
@@ -540,7 +542,7 @@ fn (mut p Parser) top_level_stmt() flat.NodeId {
 			return p.parse_decl_after_attrs()
 		}
 		.dollar {
-			return p.parse_comptime_if()
+			return p.parse_top_level_comptime_if()
 		}
 		.hash {
 			return p.directive()
@@ -578,10 +580,12 @@ fn (mut p Parser) parse_decl_after_attrs() flat.NodeId {
 		}
 		p.skip_top_level_stmt()
 		p.skip_next_decl = false
+		p.pending_export = ''
 		return flat.empty_node
 	}
 	res := p.top_level_stmt()
 	p.pending_params = false
+	p.pending_export = ''
 	return res
 }
 
@@ -693,7 +697,7 @@ fn (mut p Parser) fn_operator_overload(receiver_name string, receiver_type strin
 	}
 	for p.tok != .rpar && p.tok != .eof {
 		start_offset := p.s.offset
-		param_ids << p.parse_param_group()
+		param_ids << p.parse_param_group(false)
 		if p.s.offset == start_offset && p.tok != .rpar && p.tok != .eof {
 			p.next()
 		}
@@ -736,16 +740,18 @@ fn (mut p Parser) fn_operator_overload(receiver_name string, receiver_type strin
 		all_ids << id
 	}
 	start := p.add_children(all_ids)
-	return p.a.add_node(flat.Node{
+	id := p.a.add_node(flat.Node{
 		kind:           .fn_decl
 		value:          name
 		typ:            ret_type
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
 	})
+	p.register_pending_export(name)
+	return id
 }
 
-fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type string, is_method bool, _ bool) flat.NodeId {
+fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type string, is_method bool, is_c_decl bool) flat.NodeId {
 	// Capture & clear here so it applies only to this function (not nested closures
 	// or a following declaration), and is cleared even on the extern/no-body path.
 	disable_body := p.disable_fn_body
@@ -768,7 +774,7 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 	}
 	for p.tok != .rpar && p.tok != .eof {
 		start_offset := p.s.offset
-		param_ids << p.parse_param_group()
+		param_ids << p.parse_param_group(is_c_decl)
 		if p.s.offset == start_offset && p.tok != .rpar && p.tok != .eof {
 			p.next()
 		}
@@ -787,7 +793,7 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 			p.next()
 		}
 		start := p.add_children(param_ids)
-		return p.a.add_node(flat.Node{
+		id := p.a.add_node(flat.Node{
 			kind:           .c_fn_decl
 			value:          name
 			typ:            ret_type
@@ -795,6 +801,8 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 			children_start: start
 			children_count: flat.child_count(param_ids.len)
 		})
+		p.pending_export = ''
+		return id
 	}
 
 	// body
@@ -826,7 +834,7 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 		all_ids << id
 	}
 	start := p.add_children(all_ids)
-	return p.a.add_node(flat.Node{
+	id := p.a.add_node(flat.Node{
 		kind:           .fn_decl
 		value:          name
 		typ:            ret_type
@@ -834,6 +842,8 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
 	})
+	p.register_pending_export(name)
+	return id
 }
 
 fn (mut p Parser) mark_disabled_fn(name string) {
@@ -847,7 +857,22 @@ fn (mut p Parser) mark_disabled_fn(name string) {
 	p.a.disabled_fns[name] = true
 }
 
-fn (mut p Parser) parse_param_group() []flat.NodeId {
+fn (mut p Parser) register_pending_export(name string) {
+	if p.pending_export.len == 0 || name.len == 0 {
+		p.pending_export = ''
+		return
+	}
+	qname := if p.cur_module.len > 0 && p.cur_module != 'main' && p.cur_module != 'builtin'
+		&& !name.starts_with('${p.cur_module}.') {
+		'${p.cur_module}.${name}'
+	} else {
+		name
+	}
+	p.a.export_fn_names[qname] = p.pending_export
+	p.pending_export = ''
+}
+
+fn (mut p Parser) parse_param_group(is_c_decl bool) []flat.NodeId {
 	mut ids := []flat.NodeId{}
 	mut names := []string{}
 	mut is_mut := false
@@ -871,6 +896,21 @@ fn (mut p Parser) parse_param_group() []flat.NodeId {
 		}
 		return ids
 	}
+	if is_c_decl && p.c_anon_param_starts_type() {
+		mut typ := p.parse_type_name()
+		if is_mut && !typ.starts_with('&') {
+			typ = '&' + typ
+		}
+		ids << p.a.add_node(flat.Node{
+			kind:  .param
+			value: ''
+			typ:   typ
+		})
+		if p.tok == .comma {
+			p.next()
+		}
+		return ids
+	}
 	names << p.lit
 	p.next()
 	for p.tok == .comma {
@@ -884,7 +924,7 @@ fn (mut p Parser) parse_param_group() []flat.NodeId {
 		}
 	}
 	mut typ := p.parse_type_name()
-	if is_mut {
+	if is_mut && !typ.starts_with('&') {
 		typ = '&' + typ
 	}
 	for name in names {
@@ -898,6 +938,25 @@ fn (mut p Parser) parse_param_group() []flat.NodeId {
 		p.next()
 	}
 	return ids
+}
+
+fn (mut p Parser) c_anon_param_starts_type() bool {
+	if p.tok in [.amp, .and, .question, .not, .lsbr, .lpar, .key_fn, .key_atomic, .key_struct] {
+		return true
+	}
+	if p.tok == .name {
+		if p.lit == '&' {
+			return true
+		}
+		pk := p.peek()
+		if pk == .dot || pk == .rpar || pk == .eof {
+			return true
+		}
+		if pk == .comma && is_builtin_type(p.lit) {
+			return true
+		}
+	}
+	return false
 }
 
 fn (mut p Parser) struct_decl() flat.NodeId {
@@ -1482,6 +1541,7 @@ fn (mut p Parser) import_stmt() flat.NodeId {
 	p.next() // skip 'import'
 	mut name := p.expect_name()
 	mut alias := name
+	mut selective_ids := []flat.NodeId{}
 	for p.tok == .dot {
 		p.next()
 		alias = p.expect_name()
@@ -1495,7 +1555,11 @@ fn (mut p Parser) import_stmt() flat.NodeId {
 	if p.tok == .lcbr {
 		p.next()
 		for p.tok != .rcbr && p.tok != .eof {
-			p.expect_name_or_keyword()
+			sym := p.expect_name_or_keyword()
+			selective_ids << p.a.add_node(flat.Node{
+				kind:  .ident
+				value: sym
+			})
 			if p.tok == .comma {
 				p.next()
 			}
@@ -1506,9 +1570,11 @@ fn (mut p Parser) import_stmt() flat.NodeId {
 		p.next()
 	}
 	return p.a.add_node(flat.Node{
-		kind:  .import_decl
-		value: name
-		typ:   alias
+		kind:           .import_decl
+		value:          name
+		typ:            alias
+		children_start: p.add_children(selective_ids)
+		children_count: flat.child_count(selective_ids.len)
 	})
 }
 
@@ -1571,6 +1637,9 @@ fn (mut p Parser) skip_attrs() {
 					p.pending_flag = true
 				} else if p.lit == 'params' {
 					p.pending_params = true
+				} else if p.lit == 'export' {
+					p.try_parse_export_attr()
+					continue
 				}
 			}
 			p.next()
@@ -1587,6 +1656,9 @@ fn (mut p Parser) skip_attrs() {
 					p.pending_flag = true
 				} else if p.lit == 'params' {
 					p.pending_params = true
+				} else if p.lit == 'export' {
+					p.try_parse_export_attr()
+					continue
 				}
 			}
 			if p.tok == .lsbr {
@@ -1597,6 +1669,19 @@ fn (mut p Parser) skip_attrs() {
 			p.next()
 		}
 	}
+}
+
+fn (mut p Parser) try_parse_export_attr() {
+	p.next()
+	if p.tok != .colon {
+		return
+	}
+	p.next()
+	if int(p.tok) != int(token.Token.string) {
+		return
+	}
+	p.pending_export = strip_quotes(p.lit)
+	p.next()
 }
 
 fn (mut p Parser) skip_top_level_stmt() {
@@ -1682,6 +1767,70 @@ fn (mut p Parser) parse_comptime_if() flat.NodeId {
 		p.skip_block()
 		return p.parse_comptime_else()
 	}
+}
+
+fn (mut p Parser) parse_top_level_comptime_if() flat.NodeId {
+	p.next() // skip $
+	if p.tok != .key_if {
+		// $for or other comptime - skip
+		if p.tok == .key_for {
+			p.next()
+			for p.tok != .lcbr && p.tok != .eof {
+				p.next()
+			}
+			p.skip_block()
+		} else {
+			for p.tok != .semicolon && p.tok != .eof {
+				p.next()
+			}
+			if p.tok == .semicolon {
+				p.next()
+			}
+		}
+		return flat.empty_node
+	}
+	p.next() // skip 'if'
+	cond := p.parse_comptime_cond()
+	if comptime_cond_has_type_test(cond) {
+		p.skip_block()
+		p.skip_comptime_else()
+		return flat.empty_node
+	}
+	taken := eval_comptime_cond(p.prefs, cond)
+	if taken {
+		result := p.top_level_block_stmt()
+		p.skip_comptime_else()
+		return result
+	}
+	p.skip_block()
+	return p.parse_top_level_comptime_else()
+}
+
+fn (mut p Parser) top_level_block_stmt() flat.NodeId {
+	ids := p.parse_top_level_block_body()
+	start := p.add_children(ids)
+	return p.a.add_node(flat.Node{
+		kind:           .block
+		children_start: start
+		children_count: flat.child_count(ids.len)
+	})
+}
+
+fn (mut p Parser) parse_top_level_block_body() []flat.NodeId {
+	p.check(.lcbr)
+	mut ids := []flat.NodeId{}
+	for p.tok != .rcbr && p.tok != .eof {
+		if p.tok == .semicolon {
+			p.next()
+			continue
+		}
+		id := p.top_level_stmt()
+		if int(id) >= 0 {
+			ids << id
+		}
+	}
+	p.check(.rcbr)
+	return ids
 }
 
 fn (mut p Parser) parse_comptime_cond() string {
@@ -1789,6 +1938,29 @@ fn (mut p Parser) parse_comptime_else() flat.NodeId {
 		return p.parse_comptime_if()
 	}
 	return p.block_stmt()
+}
+
+fn (mut p Parser) parse_top_level_comptime_else() flat.NodeId {
+	// Skip auto-semicolons before $else
+	if p.tok == .semicolon && p.peek() == .dollar {
+		p.next()
+	}
+	if p.tok != .dollar {
+		return flat.empty_node
+	}
+	if p.peek() != .key_else {
+		return flat.empty_node
+	}
+	p.next() // skip $
+	p.next() // skip else
+	// $else $if - recurse
+	if p.tok == .dollar || (p.tok == .semicolon && p.peek() == .dollar) {
+		if p.tok == .semicolon {
+			p.next()
+		}
+		return p.parse_top_level_comptime_if()
+	}
+	return p.top_level_block_stmt()
 }
 
 fn eval_comptime_cond(prefs &pref.Preferences, cond string) bool {
@@ -3075,11 +3247,12 @@ fn (mut p Parser) expr_with_lhs(first flat.NodeId, min_bp token.BindingPower) fl
 					continue
 				}
 			}
-			if lhs_node.kind == .selector && lhs_node.value.len > 0
-				&& (p.peek() == .rcbr || p.peek() == .name || p.peek() == .ellipsis) {
+			if lhs_node.kind == .selector && lhs_node.value.len > 0 {
 				base := p.a.child_node(&lhs_node, 0)
 				is_c_struct := base.kind == .ident && base.value == 'C'
 					&& !is_all_upper_ident(lhs_node.value)
+					&& (p.peek() == .rcbr || p.peek() == .name
+					|| p.peek() == .ellipsis)
 				is_v_struct := base.kind == .ident && base.value != 'C' && lhs_node.value[0] >= `A`
 					&& lhs_node.value[0] <= `Z`
 				if is_c_struct || is_v_struct {
@@ -4558,7 +4731,7 @@ fn (mut p Parser) fn_literal() flat.NodeId {
 	mut param_ids := []flat.NodeId{}
 	for p.tok != .rpar && p.tok != .eof {
 		start_offset := p.s.offset
-		param_ids << p.parse_param_group()
+		param_ids << p.parse_param_group(false)
 		if p.s.offset == start_offset && p.tok != .rpar && p.tok != .eof {
 			p.next()
 		}
@@ -4838,7 +5011,7 @@ fn (mut p Parser) parse_fn_type_param() string {
 	if p.tok != .comma && p.tok != .rpar && p.tok != .eof && p.can_start_type_name() {
 		second := p.parse_type_name_progress()
 		if second.len > 0 {
-			return fn_type_param_with_mut(second, is_mut)
+			return '${first} ${fn_type_param_with_mut(second, is_mut)}'
 		}
 	}
 	return fn_type_param_with_mut(first, is_mut)
@@ -5134,7 +5307,7 @@ fn unescape_string(s string) string {
 fn is_builtin_type(name string) bool {
 	return name in ['int', 'i8', 'i16', 'i32', 'i64', 'u8', 'u16', 'u32', 'u64', 'f32', 'f64',
 		'byte', 'bool', 'string', 'rune', 'char', 'voidptr', 'charptr', 'byteptr', 'usize', 'isize',
-		'array', 'map', 'mapnode', '_result', '_option']
+		'array', 'map', 'mapnode', '_result', '_option', 'any']
 }
 
 fn is_all_upper_ident(s string) bool {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -868,6 +868,10 @@ fn (mut p Parser) register_pending_export(name string) {
 	} else {
 		name
 	}
+	if name in p.a.disabled_fns || qname in p.a.disabled_fns {
+		p.pending_export = ''
+		return
+	}
 	p.a.export_fn_names[qname] = p.pending_export
 	p.pending_export = ''
 }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -79,6 +79,14 @@ pub fn (mut p Parser) parse_files(paths []string) &flat.FlatAst {
 // parse_into reads parse into input for parser.
 pub fn (mut p Parser) parse_into(path string) {
 	p.cur_file = path
+	p.cur_module = ''
+	p.cur_fn = ''
+	p.pending_flag = false
+	p.pending_params = false
+	p.pending_export = ''
+	p.skip_next_decl = false
+	p.disable_fn_body = false
+	p.in_for_container = false
 	// File marker before content so import resolver can track source files
 	p.a.add_node(flat.Node{
 		kind:  .file
@@ -5317,6 +5325,9 @@ fn is_builtin_type(name string) bool {
 fn is_c_anon_simple_type_name(name string) bool {
 	if name.len == 0 {
 		return false
+	}
+	if name.ends_with('_t') {
+		return true
 	}
 	return name[0] >= `A` && name[0] <= `Z`
 }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -956,7 +956,7 @@ fn (mut p Parser) c_anon_param_starts_type() bool {
 		if pk == .dot || pk == .rpar || pk == .eof {
 			return true
 		}
-		if pk == .comma && is_builtin_type(p.lit) {
+		if pk == .comma && (is_builtin_type(p.lit) || is_c_anon_simple_type_name(p.lit)) {
 			return true
 		}
 	}
@@ -5312,6 +5312,13 @@ fn is_builtin_type(name string) bool {
 	return name in ['int', 'i8', 'i16', 'i32', 'i64', 'u8', 'u16', 'u32', 'u64', 'f32', 'f64',
 		'byte', 'bool', 'string', 'rune', 'char', 'voidptr', 'charptr', 'byteptr', 'usize', 'isize',
 		'array', 'map', 'mapnode', '_result', '_option', 'any']
+}
+
+fn is_c_anon_simple_type_name(name string) bool {
+	if name.len == 0 {
+		return false
+	}
+	return name[0] >= `A` && name[0] <= `Z`
 }
 
 fn is_all_upper_ident(s string) bool {

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -233,6 +233,32 @@ pub fn get_v_files_from_dir(dir string, user_defines []string, target_os string)
 	return v_files
 }
 
+pub fn is_test_file_for_backend(path string, backend string) bool {
+	file := os.file_name(path)
+	if file.ends_with('_test.v') {
+		return true
+	}
+	if file.ends_with('_test.c.v') {
+		return backend == 'c'
+	}
+	if file.ends_with('_test.js.v') {
+		return backend == 'js'
+	}
+	if !file.ends_with('.v') {
+		return false
+	}
+	base := file[..file.len - 2]
+	if !base.contains('.') {
+		return false
+	}
+	backend_suffix := base.all_after_last('.')
+	test_base := base.all_before_last('.')
+	if !test_base.ends_with('_test') {
+		return false
+	}
+	return backend_suffix == backend
+}
+
 // default_file_base supports default file base handling for pref.
 fn default_file_base(file string) ?string {
 	for marker in ['_default.c.v', '_default.v'] {

--- a/vlib/v3/ssa/builder.v
+++ b/vlib/v3/ssa/builder.v
@@ -1217,7 +1217,7 @@ fn (b &Builder) top_level_stmt_ids() []flat.NodeId {
 fn (b &Builder) is_top_level_stmt(node flat.Node) bool {
 	return match node.kind {
 		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
-		.for_in_stmt, .if_expr, .assert_stmt, .block {
+		.for_in_stmt, .if_expr, .assert_stmt, .defer_stmt, .block {
 			true
 		}
 		else {

--- a/vlib/v3/tests/c_anonymous_param_codegen_test.v
+++ b/vlib/v3/tests/c_anonymous_param_codegen_test.v
@@ -1,0 +1,87 @@
+import os
+
+const c_anon_param_vexe = @VEXE
+const c_anon_param_tests_dir = os.dir(@FILE)
+const c_anon_param_v3_dir = os.dir(c_anon_param_tests_dir)
+const c_anon_param_vlib_dir = os.dir(c_anon_param_v3_dir)
+const c_anon_param_v3_src = os.join_path(c_anon_param_v3_dir, 'v3.v')
+
+fn c_anon_param_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_c_anon_param_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${c_anon_param_vexe} -gc none -path "${c_anon_param_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${c_anon_param_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn test_c_anonymous_params_keep_pointer_call_shape() {
+	v3_bin := c_anon_param_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_c_anon_param_${os.getpid()}.v')
+	os.write_file(src, 'module main
+
+@[typedef]
+struct C.AnonNative {
+	value int
+}
+
+fn C.take_ptr(&C.AnonNative) int
+fn C.take_named(stream &C.AnonNative) int
+fn C.take_void(voidptr) int
+fn C.take_primitive(int, u64) int
+fn C.take_multi(&&C.AnonNative) int
+fn C.take_mixed(&C.AnonNative, voidptr, int, &&C.AnonNative) int
+fn C.take_fn(fn (&C.AnonNative) int) int
+fn C.load_matrix(m [16]f32) int
+fn C.width_runes(r []rune) int
+
+fn callback(n &C.AnonNative) int {
+	return n.value
+}
+
+fn main() {
+	mut native := C.AnonNative{
+		value: 3
+	}
+	ptr := &native
+	pptr := &ptr
+	_ := C.take_ptr(ptr)
+	_ = C.take_ptr(&native)
+	_ = C.take_named(ptr)
+	_ = C.take_void(voidptr(ptr))
+	_ = C.take_primitive(1, u64(2))
+	_ = C.take_multi(pptr)
+	_ = C.take_mixed(ptr, voidptr(ptr), 3, pptr)
+	_ = C.take_fn(callback)
+	mut matrix := [16]f32{}
+	_ = C.load_matrix(matrix)
+	runes := []rune{}
+	_ = C.width_runes(runes)
+}
+') or {
+		panic(err)
+	}
+	c_path := os.join_path(os.temp_dir(), 'v3_c_anon_param_${os.getpid()}.c')
+	os.rm(c_path) or {}
+	compile := os.execute('${v3_bin} ${src} -b c -o ${c_path}')
+	assert compile.exit_code == 0, compile.output
+	generated := os.read_file(c_path) or { panic(err) }
+	assert generated.contains('take_ptr(ptr)'), generated
+	assert generated.contains('take_ptr(&native)'), generated
+	assert generated.contains('take_named(ptr)'), generated
+	assert generated.contains('take_void((void*)(ptr))'), generated
+	assert generated.contains('take_multi(pptr)'), generated
+	assert generated.contains('take_mixed(ptr, (void*)(ptr), 3, pptr)'), generated
+	assert generated.contains('load_matrix(matrix)'), generated
+	assert generated.contains('width_runes(runes)'), generated
+	assert !generated.contains('take_ptr(*'), generated
+	assert !generated.contains('take_named(*'), generated
+	assert !generated.contains('take_void(*'), generated
+	assert !generated.contains('take_multi(*'), generated
+	assert !generated.contains('take_mixed(*'), generated
+	assert !generated.contains('load_matrix(*'), generated
+	assert !generated.contains('width_runes(*'), generated
+	assert !generated.contains('*&native'), generated
+	assert !generated.contains('*(AnonNative*)'), generated
+	assert !generated.contains('*(struct AnonNative*)'), generated
+}

--- a/vlib/v3/tests/c_callback_const_qualifier_codegen_test.v
+++ b/vlib/v3/tests/c_callback_const_qualifier_codegen_test.v
@@ -1,0 +1,220 @@
+import os
+import strings
+
+const const_cb_vexe = @VEXE
+const const_cb_tests_dir = os.dir(@FILE)
+const const_cb_v3_dir = os.dir(const_cb_tests_dir)
+const const_cb_vlib_dir = os.dir(const_cb_v3_dir)
+const const_cb_v3_src = os.join_path(const_cb_v3_dir, 'v3.v')
+
+fn const_cb_build_v3() string {
+	return const_cb_build_v3_with_flags('serial', '')
+}
+
+fn const_cb_build_v3_parallel() string {
+	return const_cb_build_v3_with_flags('parallel', '-d parallel')
+}
+
+fn const_cb_build_v3_with_flags(name string, flags string) string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_const_callback_test_${name}_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${const_cb_vexe} ${flags} -gc none -path "${const_cb_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${const_cb_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn const_cb_write_project(source string) string {
+	root := os.join_path(os.temp_dir(), 'v3_const_callback_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	header := '#ifndef V3_CONST_CALLBACK_NATIVE_H
+#define V3_CONST_CALLBACK_NATIVE_H
+typedef struct native_event {
+	int value;
+} native_event;
+typedef struct native_desc {
+	void (*cb)(const struct native_event*, void*);
+	void (*plain)(struct native_event*, void*);
+	void* user_data;
+} native_desc;
+typedef struct alias_desc {
+	void (*cb)(const struct native_event*, void*);
+	void* user_data;
+} alias_desc;
+#endif
+'
+	os.write_file(os.join_path(root, 'native_callback.h'), header) or { panic(err) }
+	path := os.join_path(root, 'main.v')
+	os.write_file(path, source) or { panic(err) }
+	return path
+}
+
+fn test_c_callback_const_qualifier_codegen() {
+	v3_bin := const_cb_build_v3()
+	src := const_cb_write_project('module main
+
+#include "@DIR/native_callback.h"
+
+@[typedef]
+struct C.native_event {
+	value int
+}
+
+type Event = C.native_event
+type ConstNativeCb = fn (const_event &Event, user_data voidptr)
+
+@[typedef]
+struct C.native_desc {
+mut:
+	cb fn (const_event &C.native_event, voidptr) = unsafe { nil }
+	plain fn (&C.native_event, voidptr) = unsafe { nil }
+	user_data voidptr
+}
+
+@[typedef]
+struct C.alias_desc {
+mut:
+	cb ConstNativeCb = unsafe { nil }
+	user_data voidptr
+}
+
+struct App {
+mut:
+	hits int
+}
+
+fn erased_event(e voidptr, data voidptr) {
+	event := unsafe { &C.native_event(e) }
+	mut app := unsafe { &App(data) }
+	app.hits += event.value
+}
+
+fn plain_event(e &C.native_event, data voidptr) {
+	mut app := unsafe { &App(data) }
+	app.hits += e.value * 10
+}
+
+fn concrete_event(e &C.native_event, data voidptr) {
+	mut app := unsafe { &App(data) }
+	app.hits += e.value * 100
+}
+
+fn main() {
+	mut app := App{}
+	mut desc := C.native_desc{
+		cb: erased_event
+		plain: plain_event
+		user_data: voidptr(&app)
+	}
+	event := C.native_event{value: 3}
+	desc.cb = erased_event
+	desc.cb(&event, desc.user_data)
+	desc.plain(&event, desc.user_data)
+	mut concrete := C.native_desc{
+		user_data: voidptr(&app)
+	}
+	concrete.cb = concrete_event
+	concrete.cb(&event, concrete.user_data)
+	mut alias_desc := C.alias_desc{
+		user_data: voidptr(&app)
+	}
+	alias_desc.cb = concrete_event
+	alias_desc.cb(&event, alias_desc.user_data)
+	println(int_str(app.hits))
+}
+')
+	out := os.join_path(os.temp_dir(), 'v3_const_callback_out_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '633'
+	generated := os.read_file(out + '.c') or { panic(err) }
+	assert generated.contains('typedef void (*'), generated
+	assert generated.contains('(const struct native_event*, void*)'), generated
+	assert generated.contains('(struct native_event*, void*)'), generated
+	assert generated.contains('erased_event_callback_adapter_'), generated
+	assert generated.contains('concrete_event_callback_adapter_'), generated
+	assert generated.contains('const struct native_event* arg0, void* arg1'), generated
+	assert generated.contains('erased_event((void*)arg0, arg1);'), generated
+	assert generated.contains('concrete_event((struct native_event*)arg0, arg1);'), generated
+	assert generated.contains('.cb = erased_event_callback_adapter_'), generated
+	assert generated.contains('desc.cb = erased_event_callback_adapter_'), generated
+	assert generated.contains('concrete.cb = concrete_event_callback_adapter_'), generated
+	assert generated.contains('alias_desc.cb = concrete_event_callback_adapter_'), generated
+	assert generated.contains('.plain = plain_event'), generated
+	assert !generated.contains('.cb = (_fn_ptr'), generated
+	assert !generated.contains('desc.cb = (_fn_ptr'), generated
+	assert !generated.contains('concrete.cb = concrete_event;'), generated
+	assert !generated.contains('alias_desc.cb = concrete_event;'), generated
+	assert !generated.contains('.plain = plain_event_callback_adapter_'), generated
+}
+
+fn test_c_callback_const_qualifier_parallel_worker_codegen() {
+	v3_bin := const_cb_build_v3_parallel()
+	mut src := strings.new_builder(96 * 1024)
+	src.write_string('module main
+
+#include "@DIR/native_callback.h"
+
+@[typedef]
+struct C.native_event {
+	value int
+}
+
+type Event = C.native_event
+type ConstNativeCb = fn (const_event &Event, user_data voidptr)
+
+@[typedef]
+struct C.alias_desc {
+mut:
+	cb ConstNativeCb = unsafe { nil }
+	user_data voidptr
+}
+
+struct App {
+mut:
+	hits int
+}
+
+fn concrete_event(e &C.native_event, data voidptr) {
+	mut app := unsafe { &App(data) }
+	app.hits += e.value
+}
+
+')
+	for i in 0 .. 1100 {
+		src.write_string('fn filler_${i}() int { return ${i} }\n')
+	}
+	src.write_string('
+fn run_parallel(mut app App) {
+	mut desc := C.alias_desc{
+		user_data: voidptr(app)
+	}
+	desc.cb = concrete_event
+	event := C.native_event{value: 7}
+	desc.cb(&event, desc.user_data)
+}
+
+fn main() {
+	mut app := App{}
+	run_parallel(mut app)
+	println(int_str(app.hits))
+}
+')
+	path := const_cb_write_project(src.str())
+	out := os.join_path(os.temp_dir(), 'v3_const_callback_parallel_out_${os.getpid()}')
+	compile := os.execute('VJOBS=2 ${v3_bin} ${path} -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '7'
+	generated := os.read_file(out + '.c') or { panic(err) }
+	assert generated.contains('concrete_event_callback_adapter_'), generated
+	assert generated.contains('const struct native_event* arg0, void* arg1'), generated
+	assert generated.contains('concrete_event((struct native_event*)arg0, arg1);'), generated
+	assert generated.contains('desc.cb = concrete_event_callback_adapter_'), generated
+	assert !generated.contains('const gg__Event'), generated
+	assert !generated.contains('desc.cb = concrete_event;'), generated
+}

--- a/vlib/v3/tests/c_callback_const_qualifier_codegen_test.v
+++ b/vlib/v3/tests/c_callback_const_qualifier_codegen_test.v
@@ -42,6 +42,10 @@ typedef struct alias_desc {
 	void (*cb)(const struct native_event*, void*);
 	void* user_data;
 } alias_desc;
+typedef struct late_alias_desc {
+	void (*cb)(const struct native_event*, void*);
+	void* user_data;
+} late_alias_desc;
 #endif
 '
 	os.write_file(os.join_path(root, 'native_callback.h'), header) or { panic(err) }
@@ -149,6 +153,67 @@ fn main() {
 	assert !generated.contains('concrete.cb = concrete_event;'), generated
 	assert !generated.contains('alias_desc.cb = concrete_event;'), generated
 	assert !generated.contains('.plain = plain_event_callback_adapter_'), generated
+}
+
+fn test_c_callback_c_alias_declared_after_field_codegen() {
+	v3_bin := const_cb_build_v3()
+	src := const_cb_write_project('module main
+
+#include "@DIR/native_callback.h"
+
+@[typedef]
+struct C.late_alias_desc {
+mut:
+	cb fn (&Event, voidptr) = unsafe { nil }
+	user_data voidptr
+}
+
+@[typedef]
+struct C.native_event {
+	value int
+}
+
+type Event = C.native_event
+
+struct App {
+mut:
+	hits int
+}
+
+fn late_alias_event(e &C.native_event, data voidptr) {
+	mut app := unsafe { &App(data) }
+	app.hits += e.value
+}
+
+fn main() {
+	mut app := App{}
+	event := C.native_event{value: 11}
+	mut desc := C.late_alias_desc{
+		cb: late_alias_event
+		user_data: voidptr(&app)
+	}
+	desc.cb(&event, desc.user_data)
+	desc.cb = late_alias_event
+	desc.cb(&event, desc.user_data)
+	println(int_str(app.hits))
+}
+')
+	out := os.join_path(os.temp_dir(), 'v3_const_callback_late_alias_out_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '22'
+	generated := os.read_file(out + '.c') or { panic(err) }
+	assert generated.contains('(const struct native_event*, void*)'), generated
+	assert generated.contains('late_alias_event_callback_adapter_'), generated
+	assert generated.contains('const struct native_event* arg0, void* arg1'), generated
+	assert generated.contains('late_alias_event((struct native_event*)arg0, arg1);'), generated
+	assert generated.contains('.cb = late_alias_event_callback_adapter_'), generated
+	assert generated.contains('desc.cb = late_alias_event_callback_adapter_'), generated
+	assert !generated.contains('main__Event*'), generated
+	assert !generated.contains('.cb = late_alias_event,'), generated
+	assert !generated.contains('desc.cb = late_alias_event;'), generated
 }
 
 fn test_c_callback_const_qualifier_parallel_worker_codegen() {

--- a/vlib/v3/tests/c_callback_const_qualifier_codegen_test.v
+++ b/vlib/v3/tests/c_callback_const_qualifier_codegen_test.v
@@ -155,6 +155,65 @@ fn main() {
 	assert !generated.contains('.plain = plain_event_callback_adapter_'), generated
 }
 
+fn test_generic_heap_positional_c_callback_codegen() {
+	v3_bin := const_cb_build_v3()
+	src := const_cb_write_project('module main
+
+#include "@DIR/native_callback.h"
+
+@[typedef]
+struct C.native_event {
+	value int
+}
+
+@[typedef]
+struct C.native_desc {
+mut:
+	cb fn (const_event &C.native_event, voidptr) = unsafe { nil }
+	plain fn (&C.native_event, voidptr) = unsafe { nil }
+	user_data voidptr
+}
+
+struct App {
+mut:
+	hits int
+}
+
+fn concrete_event(e &C.native_event, data voidptr) {
+	mut app := unsafe { &App(data) }
+	app.hits += e.value
+}
+
+fn plain_event(e &C.native_event, data voidptr) {
+	mut app := unsafe { &App(data) }
+	app.hits += e.value * 10
+}
+
+fn make_desc[T](data T) &C.native_desc {
+	return &C.native_desc{concrete_event, plain_event, voidptr(data)}
+}
+
+fn main() {
+	mut app := App{}
+	event := C.native_event{value: 5}
+	desc := make_desc(&app)
+	desc.cb(&event, desc.user_data)
+	desc.plain(&event, desc.user_data)
+	println(int_str(app.hits))
+}
+')
+	out := os.join_path(os.temp_dir(), 'v3_const_callback_heap_positional_out_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '55'
+	generated := os.read_file(out + '.c') or { panic(err) }
+	assert generated.contains('concrete_event_callback_adapter_'), generated
+	assert generated.contains('.cb = concrete_event_callback_adapter_'), generated
+	assert !generated.contains('.cb = concrete_event,'), generated
+}
+
 fn test_c_callback_c_alias_declared_after_field_codegen() {
 	v3_bin := const_cb_build_v3()
 	src := const_cb_write_project('module main

--- a/vlib/v3/tests/c_directive_order_codegen_test.v
+++ b/vlib/v3/tests/c_directive_order_codegen_test.v
@@ -1,0 +1,93 @@
+import os
+
+const directive_order_vexe = @VEXE
+const directive_order_tests_dir = os.dir(@FILE)
+const directive_order_v3_dir = os.dir(directive_order_tests_dir)
+const directive_order_vlib_dir = os.dir(directive_order_v3_dir)
+const directive_order_v3_src = os.join_path(directive_order_v3_dir, 'v3.v')
+
+fn directive_order_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_c_directive_order_test')
+	build :=
+		os.execute('${directive_order_vexe} -gc none -path "${directive_order_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${directive_order_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn directive_order_write_file(root string, rel string, src string) {
+	path := os.join_path(root, rel)
+	os.mkdir_all(os.dir(path)) or { panic(err) }
+	os.write_file(path, src) or { panic(err) }
+}
+
+fn directive_order_gen_c(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod', "Module { name: 'directive_order' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+import sokol.f as _
+
+fn main() {}
+')
+	directive_order_write_file(root, 'sokol/c/c.v', 'module c
+
+#define SOKOL_GFX_IMPL
+#include "sokol_gfx.h"
+')
+	directive_order_write_file(root, 'sokol/f/f.v', 'module f
+
+import sokol.c as _
+
+#define SOKOL_FONTSTASH_IMPL
+#include "util/sokol_fontstash.h"
+#include "sokol_gfx.h"
+#ifdef KEEP_DUPLICATE_INCLUDE
+#include "sokol_gfx.h"
+#endif
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
+fn directive_order_index(c_code string, needle string) int {
+	return c_code.index(needle) or { -1 }
+}
+
+fn directive_order_count(c_code string, needle string) int {
+	mut count := 0
+	mut rest := c_code
+	for {
+		idx := rest.index(needle) or { break }
+		count++
+		rest = rest[idx + needle.len..]
+	}
+	return count
+}
+
+fn test_c_directives_follow_import_dependency_order() {
+	c_code := directive_order_gen_c(directive_order_build_v3())
+	gfx_define := directive_order_index(c_code, '#define SOKOL_GFX_IMPL')
+	gfx_include := directive_order_index(c_code, '#include "sokol_gfx.h"')
+	fontstash_define := directive_order_index(c_code, '#define SOKOL_FONTSTASH_IMPL')
+	fontstash_include := directive_order_index(c_code, '#include "util/sokol_fontstash.h"')
+	block_start := directive_order_index(c_code, '#ifdef KEEP_DUPLICATE_INCLUDE')
+	assert gfx_define >= 0, c_code
+	assert gfx_include >= 0, c_code
+	assert fontstash_define >= 0, c_code
+	assert fontstash_include >= 0, c_code
+	assert block_start >= 0, c_code
+	assert gfx_define < gfx_include, c_code
+	assert gfx_include < fontstash_define, c_code
+	assert fontstash_define < fontstash_include, c_code
+	assert directive_order_count(c_code, '#include "sokol_gfx.h"') == 2, c_code
+	block_tail := c_code[block_start..]
+	block_include := directive_order_index(block_tail, '#include "sokol_gfx.h"')
+	block_end := directive_order_index(block_tail, '#endif')
+	assert block_include >= 0, c_code
+	assert block_end > block_include, c_code
+}

--- a/vlib/v3/tests/c_directive_order_codegen_test.v
+++ b/vlib/v3/tests/c_directive_order_codegen_test.v
@@ -88,6 +88,50 @@ import foo.bar as _
 	return os.read_file(c_out) or { panic(err) }
 }
 
+fn directive_order_gen_and_run_importer_macro(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_importer_macro_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod', "Module { name: 'directive_order_importer_macro' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#define USE_FOO
+
+import wrapper
+
+fn main() {
+	println(wrapper.value().str())
+}
+')
+	directive_order_write_file(root, 'wrapper/wrapper.v', 'module wrapper
+
+#include "@DIR/foo.h"
+
+fn C.foo_value() int
+
+pub fn value() int {
+	return C.foo_value()
+}
+')
+	directive_order_write_file(root, 'wrapper/foo.h', '#ifndef USE_FOO
+#error "USE_FOO must be defined before foo.h"
+#endif
+
+static inline int foo_value(void) {
+	return 42;
+}
+')
+	bin_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_importer_macro')
+	os.rm(bin_out) or {}
+	os.rm(bin_out + '.c') or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin_out}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '42', run.output
+	return os.read_file(bin_out + '.c') or { panic(err) }
+}
+
 fn directive_order_index(c_code string, needle string) int {
 	return c_code.index(needle) or { -1 }
 }
@@ -135,4 +179,13 @@ fn test_c_directives_preserve_dotted_import_module_identity() {
 	assert foo_bar >= 0, c_code
 	assert foo_user >= 0, c_code
 	assert foo_bar < foo_user, c_code
+}
+
+fn test_importer_macro_is_emitted_before_dependency_include() {
+	c_code := directive_order_gen_and_run_importer_macro(directive_order_build_v3())
+	use_foo := directive_order_index(c_code, '#define USE_FOO')
+	foo_header := directive_order_index(c_code, 'foo.h"')
+	assert use_foo >= 0, c_code
+	assert foo_header >= 0, c_code
+	assert use_foo < foo_header, c_code
 }

--- a/vlib/v3/tests/c_directive_order_codegen_test.v
+++ b/vlib/v3/tests/c_directive_order_codegen_test.v
@@ -54,6 +54,40 @@ import sokol.c as _
 	return os.read_file(c_out) or { panic(err) }
 }
 
+fn directive_order_gen_c_dotted_collision(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_dotted_collision_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod',
+		"Module { name: 'directive_order_dotted_collision' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+import foo.user as _
+import bar as _
+
+fn main() {}
+')
+	directive_order_write_file(root, 'bar/bar.v', 'module bar
+
+#define SHORT_BAR
+')
+	directive_order_write_file(root, 'foo/bar/bar.v', 'module bar
+
+#define FOO_BAR
+')
+	directive_order_write_file(root, 'foo/user/user.v', 'module user
+
+import foo.bar as _
+
+#define FOO_USER
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_dotted_collision.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
 fn directive_order_index(c_code string, needle string) int {
 	return c_code.index(needle) or { -1 }
 }
@@ -90,4 +124,15 @@ fn test_c_directives_follow_import_dependency_order() {
 	block_end := directive_order_index(block_tail, '#endif')
 	assert block_include >= 0, c_code
 	assert block_end > block_include, c_code
+}
+
+fn test_c_directives_preserve_dotted_import_module_identity() {
+	c_code := directive_order_gen_c_dotted_collision(directive_order_build_v3())
+	short_bar := directive_order_index(c_code, '#define SHORT_BAR')
+	foo_bar := directive_order_index(c_code, '#define FOO_BAR')
+	foo_user := directive_order_index(c_code, '#define FOO_USER')
+	assert short_bar >= 0, c_code
+	assert foo_bar >= 0, c_code
+	assert foo_user >= 0, c_code
+	assert foo_bar < foo_user, c_code
 }

--- a/vlib/v3/tests/c_flag_target_filter_codegen_test.v
+++ b/vlib/v3/tests/c_flag_target_filter_codegen_test.v
@@ -1,0 +1,49 @@
+import os
+import v3.pref
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn test_c_backend_only_runs_generic_and_c_backend_test_files() {
+	assert pref.is_test_file_for_backend('/tmp/basic_test.v', 'c')
+	assert pref.is_test_file_for_backend('/tmp/basic_test.c.v', 'c')
+	assert !pref.is_test_file_for_backend('/tmp/basic_test.js.v', 'c')
+	assert !pref.is_test_file_for_backend('/tmp/basic_test.arm64.v', 'c')
+	assert !pref.is_test_file_for_backend('/tmp/basic_test.amd64.v', 'c')
+
+	assert pref.is_test_file_for_backend('/tmp/basic_test.arm64.v', 'arm64')
+	assert pref.is_test_file_for_backend('/tmp/basic_test.amd64.v', 'amd64')
+}
+
+fn test_c_flag_target_filter_keeps_host_linux_and_drops_wasm() {
+	$if !linux {
+		return
+	}
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_c_flag_target_filter_test_${pid}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_c_flag_target_filter_input_${pid}.v')
+	os.write_file(src,
+		"#flag linux -ldl\n#flag wasm32_emscripten --embed-file @VEXEROOT/README.md@/README.md\nfn main() {\n\tprintln('flag-filter-ok')\n}\n") or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_c_flag_target_filter_input_${pid}')
+	os.rm(bin) or {}
+	os.rmdir_all(bin) or {}
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert compile.output.contains('-ldl'), compile.output
+	assert !compile.output.contains('wasm32_emscripten'), compile.output
+	assert !compile.output.contains('--embed-file'), compile.output
+
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'flag-filter-ok'
+}

--- a/vlib/v3/tests/c_global_c_type_storage_codegen_test.v
+++ b/vlib/v3/tests/c_global_c_type_storage_codegen_test.v
@@ -1,0 +1,138 @@
+import os
+import v3.gen.c as cgen
+import v3.markused
+import v3.parser
+import v3.pref
+import v3.transform
+import v3.types
+
+fn gen_c_for_c_global_source(name string, source string) string {
+	src := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	os.write_file(src, source) or { panic(err) }
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_file(src)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.diagnose_unknown_calls = true
+	tc.diagnostic_files[src] = true
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	transform.transform(mut a, &tc)
+	tc.annotate_types()
+	used_fns := markused.mark_used(a, tc)
+	mut g := cgen.FlatGen.new()
+	return g.gen_with_used_options(a, used_fns, &tc, true)
+}
+
+fn gen_c_for_c_global_sources(name string, files map[string]string) string {
+	root := os.join_path(os.temp_dir(), 'v3_${name}')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(root) or { panic(err) }
+	mut paths := []string{}
+	mut rels := files.keys()
+	rels.sort()
+	for rel in rels {
+		path := os.join_path(root, rel)
+		os.mkdir_all(os.dir(path)) or { panic(err) }
+		os.write_file(path, files[rel]) or { panic(err) }
+		paths << path
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_files(paths)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.diagnose_unknown_calls = true
+	tc.diagnostic_files[os.join_path(root, 'main.v')] = true
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	transform.transform(mut a, &tc)
+	tc.annotate_types()
+	used_fns := markused.mark_used(a, tc)
+	mut g := cgen.FlatGen.new()
+	return g.gen_with_used_options(a, used_fns, &tc, true)
+}
+
+fn test_v_owned_global_with_c_struct_type_gets_storage() {
+	c_code := gen_c_for_c_global_source('v_owned_c_struct_global', 'struct C.NativeDesc {
+mut:
+	value int
+}
+
+__global owned C.NativeDesc
+__global C.stdout &C.FILE
+
+fn set_stream_unbuffered(stream &C.FILE) {}
+
+fn set_owned() {
+	owned = C.NativeDesc{
+		value: 7
+	}
+}
+
+fn owned_score() int {
+	return owned.value
+}
+
+fn main() {
+	set_owned()
+	_ := owned_score()
+	set_stream_unbuffered(C.stdout)
+}
+')
+	assert c_code.contains('\nNativeDesc owned = {0};'), c_code
+	assert c_code.contains('owned = (NativeDesc){'), c_code
+	assert c_code.contains('.value = 7'), c_code
+	assert c_code.contains('return owned.value;'), c_code
+	assert c_code.contains('set_stream_unbuffered(stdout);'), c_code
+	assert !c_code.contains('C__stdout'), c_code
+	assert !c_code.contains('\nFILE* stdout'), c_code
+}
+
+fn test_module_v_owned_global_with_c_struct_type_gets_qualified_storage() {
+	c_code := gen_c_for_c_global_sources('v_owned_c_struct_global_module', {
+		'main.v':      'module main
+
+import moda
+
+fn main() {
+	moda.set_owned()
+	_ := moda.owned_score()
+}
+'
+		'moda/moda.v': 'module moda
+
+struct C.NativeDesc {
+mut:
+	value int
+}
+
+__global owned C.NativeDesc
+__global C.stdout &C.FILE
+
+fn set_stream_unbuffered(stream &C.FILE) {}
+
+pub fn set_owned() {
+	owned = C.NativeDesc{
+		value: 7
+	}
+}
+
+pub fn owned_score() int {
+	set_stream_unbuffered(C.stdout)
+	return owned.value
+}
+'
+	})
+	assert c_code.contains('\nNativeDesc moda__owned = {0};'), c_code
+	assert c_code.contains('moda__owned = (NativeDesc){'), c_code
+	assert c_code.contains('.value = 7'), c_code
+	assert c_code.contains('return moda__owned.value;'), c_code
+	assert !c_code.contains('\nNativeDesc owned = {0};'), c_code
+	assert c_code.contains('set_stream_unbuffered(stdout);'), c_code
+	assert !c_code.contains('C__stdout'), c_code
+	assert !c_code.contains('\nFILE* stdout'), c_code
+}

--- a/vlib/v3/tests/c_global_static_codegen_test.v
+++ b/vlib/v3/tests/c_global_static_codegen_test.v
@@ -175,7 +175,7 @@ fn main() {}
 	assert c_code.contains('\nZeroLeading zero;\n')
 	assert c_code.contains('\nNestedZeroLeading nested;\n')
 	assert c_code.contains('\nZeroLeading zero_slots[2];\n')
-	assert c_code.contains('\nint const_empty[(1) - (1)];\n')
+	assert c_code.contains('\nint const_empty[0];\n')
 	assert c_code.contains('\nZeroLeadingConst const_zero;\n')
 	assert c_code.contains('\nZeroLeadingConst const_zero_slots[2];\n')
 	assert !c_code.contains('Array names = 0;')
@@ -185,7 +185,7 @@ fn main() {}
 	assert !c_code.contains('ZeroLeading zero = {0};')
 	assert !c_code.contains('NestedZeroLeading nested = {0};')
 	assert !c_code.contains('ZeroLeading zero_slots[2] = {0};')
-	assert !c_code.contains('int const_empty[(1) - (1)] = {0};')
+	assert !c_code.contains('\nint const_empty[0] = {0};\n')
 	assert !c_code.contains('ZeroLeadingConst const_zero = {0};')
 	assert !c_code.contains('ZeroLeadingConst const_zero_slots[2] = {0};')
 }

--- a/vlib/v3/tests/c_identifier_hygiene_codegen_test.v
+++ b/vlib/v3/tests/c_identifier_hygiene_codegen_test.v
@@ -1,0 +1,93 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn test_c_identifier_hygiene_for_escaped_names_unix_and_main_const() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_c_identifier_hygiene_test_${pid}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_c_identifier_hygiene_input_${pid}.v')
+	os.write_file(src, 'const block_size = 4
+
+struct Token {
+mut:
+	@type int
+	unix i64
+	block_size int
+}
+
+fn bump(unix i64) i64 {
+	return unix + 1
+}
+
+fn rewrite(mut item Token, unix i64) {
+	item.@type = item.@type + 1
+	item.unix = unix + item.unix
+}
+
+fn main() {
+	mut @type := 1
+	mut unix := i64(2)
+	mut item := Token{
+		@type: @type
+		unix: unix
+		block_size: block_size
+	}
+	item.@type += 3
+	item.unix = bump(item.unix)
+	rewrite(mut item, 5)
+	item.block_size = block_size
+	mut block_size := 1
+	println(int_str(item.@type + int(item.unix) + item.block_size + block_size))
+}
+') or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_c_identifier_hygiene_input_${pid}')
+	os.rm(bin) or {}
+	os.rm(bin + '.c') or {}
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+
+	c_code := os.read_file(bin + '.c') or { panic(err) }
+	assert !c_code.contains('@type'), c_code
+	assert !c_code.contains('i64 unix'), c_code
+	assert !c_code.contains('.unix'), c_code
+	assert !c_code.contains('->unix'), c_code
+	assert !c_code.contains('#define block_size'), c_code
+	assert c_code.contains('i64 v_unix'), c_code
+	assert c_code.contains('.v_unix'), c_code
+	assert c_code.contains('->v_unix'), c_code
+	assert c_code.contains('#define main__block_size'), c_code
+	assert c_code.contains('.block_size = main__block_size'), c_code
+
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '18'
+
+	csym_src := os.join_path(os.temp_dir(), 'v3_c_identifier_hygiene_csym_${pid}.v')
+	os.write_file(csym_src, 'fn C.unix(i64) i64
+
+fn main() {
+	println(int_str(int(C.unix(10))))
+}
+') or {
+		panic(err)
+	}
+	csym_c := os.join_path(os.temp_dir(), 'v3_c_identifier_hygiene_csym_${pid}.c')
+	os.rm(csym_c) or {}
+	csym_compile := os.execute('${v3_bin} ${csym_src} -b c -o ${csym_c}')
+	assert csym_compile.exit_code == 0, csym_compile.output
+	csym_code := os.read_file(csym_c) or { panic(err) }
+	assert csym_code.contains('unix(10)'), csym_code
+	assert !csym_code.contains('v_unix(10)'), csym_code
+	assert !csym_code.contains('C.unix'), csym_code
+}

--- a/vlib/v3/tests/c_pointer_null_arg_codegen_test.v
+++ b/vlib/v3/tests/c_pointer_null_arg_codegen_test.v
@@ -1,0 +1,47 @@
+import os
+
+const c_pointer_null_vexe = @VEXE
+const c_pointer_null_tests_dir = os.dir(@FILE)
+const c_pointer_null_v3_dir = os.dir(c_pointer_null_tests_dir)
+const c_pointer_null_vlib_dir = os.dir(c_pointer_null_v3_dir)
+const c_pointer_null_v3_src = os.join_path(c_pointer_null_v3_dir, 'v3.v')
+
+fn c_pointer_null_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_c_pointer_null_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${c_pointer_null_vexe} -gc none -path "${c_pointer_null_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${c_pointer_null_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn c_pointer_null_write_source() string {
+	src := os.join_path(os.temp_dir(), 'v3_c_pointer_null_${os.getpid()}.v')
+	os.write_file(src, 'module main
+
+fn C.take_charptr(ptr &char)
+fn C.take_charptrptr(ptr &&char)
+
+fn main() {
+	C.take_charptrptr(nil)
+	C.take_charptr(&char(0))
+}
+') or {
+		panic(err)
+	}
+	return src
+}
+
+fn test_nil_for_c_pointer_to_pointer_arg_emits_null() {
+	v3_bin := c_pointer_null_build_v3()
+	src := c_pointer_null_write_source()
+	c_path := src + '.c'
+	compile := os.execute('${v3_bin} ${src} -b c -o ${c_path}')
+	assert compile.exit_code == 0, compile.output
+
+	c_code := os.read_file(c_path) or { panic(err) }
+	compact := c_code.replace('\t', '').replace(' ', '').replace('\n', '')
+	assert compact.contains('take_charptrptr(NULL);'), c_code
+	assert !compact.contains('take_charptrptr((char*)(0));'), c_code
+	assert compact.contains('take_charptr((char*)(0));'), c_code
+}

--- a/vlib/v3/tests/c_string_literal_pointer_codegen_test.v
+++ b/vlib/v3/tests/c_string_literal_pointer_codegen_test.v
@@ -1,0 +1,30 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn test_c_string_literal_address_codegen_preserves_regular_addresses() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_c_string_literal_pointer_test')
+	build := os.execute('${vexe} -gc none -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_c_string_literal_pointer_input.v')
+	os.write_file(src,
+		"fn C.puts(&char) int\n\nfn takes_string_ptr(s &string) int {\n\treturn s.len\n}\n\nfn takes_byte_ptr(b &u8) int {\n\treturn int(*b)\n}\n\nfn main() {\n\tC.puts(&c'canary')\n\ttext := 'ordinary'\n\ttext_len := takes_string_ptr(&text)\n\tch := u8(65)\n\tch_value := takes_byte_ptr(&ch)\n\tprintln(int_str(text_len + ch_value))\n}\n") or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_c_string_literal_pointer_input')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	c_code := os.read_file(bin + '.c') or { panic(err) }
+	assert c_code.contains('puts("canary");'), c_code
+	assert !c_code.contains('puts(&"canary");'), c_code
+	assert c_code.contains('takes_string_ptr(&text)'), c_code
+	assert c_code.contains('takes_byte_ptr(&ch)'), c_code
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'canary\n73'
+}

--- a/vlib/v3/tests/c_variadic_call_codegen_test.v
+++ b/vlib/v3/tests/c_variadic_call_codegen_test.v
@@ -1,0 +1,86 @@
+import os
+
+const c_variadic_vexe = @VEXE
+const c_variadic_tests_dir = os.dir(@FILE)
+const c_variadic_v3_dir = os.dir(c_variadic_tests_dir)
+const c_variadic_vlib_dir = os.dir(c_variadic_v3_dir)
+const c_variadic_v3_src = os.join_path(c_variadic_v3_dir, 'v3.v')
+
+fn c_variadic_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_c_variadic_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${c_variadic_vexe} -gc none -path "${c_variadic_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${c_variadic_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn c_variadic_call_lines(generated string, names []string) []string {
+	mut lines := []string{}
+	for line in generated.split_into_lines() {
+		for name in names {
+			if line.contains('${name}(') {
+				lines << line
+				break
+			}
+		}
+	}
+	return lines
+}
+
+fn test_c_variadic_calls_emit_real_args_without_v_pack_array() {
+	v3_bin := c_variadic_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_c_variadic_${os.getpid()}.v')
+	os.write_file(src, "module main
+
+struct C.FILE {}
+
+fn C.printf(fmt &char, args ...voidptr) int
+fn C.fprintf(stream &C.FILE, fmt &char, args ...voidptr) int
+fn C.sscanf(input &char, fmt &char, args ...voidptr) int
+fn C.fflush(stream &C.FILE) int
+
+__global C.stderr &C.FILE
+
+fn sum(xs ...int) int {
+	mut total := 0
+	for x in xs {
+		total += x
+	}
+	return total
+}
+
+fn main() {
+	C.printf(&c'plain\\n')
+	C.printf(&c'name=%s count=%d\\n', &c'ok', 7)
+	C.fprintf(C.stderr, &c'err=%d\\n', 9)
+	C.fflush(C.stderr)
+	mut a := 0
+	mut b := 0
+	C.sscanf(&c'12 34', &c'%d %d', &a, &b)
+	println(int_str(a + b + sum(1, 2, 3)))
+}
+") or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_c_variadic_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.contains('plain'), run.output
+	assert run.output.contains('name=ok count=7'), run.output
+	assert run.output.trim_space().ends_with('52'), run.output
+
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	c_lines := c_variadic_call_lines(generated, ['printf', 'fprintf', 'sscanf'])
+	assert c_lines.len >= 4, generated
+	for line in c_lines {
+		assert !line.contains('__varargs_'), line
+	}
+	assert generated.contains('printf("plain\\n");'), generated
+	assert generated.contains('printf("name=%s count=%d\\n", "ok", 7);'), generated
+	assert generated.contains('fprintf(stderr, "err=%d\\n", 9);'), generated
+	assert generated.contains('sscanf("12 34", "%d %d", &a, &b);'), generated
+	assert generated.contains('__varargs_'), generated
+}

--- a/vlib/v3/tests/callback_userdata_fn_field_codegen_test.v
+++ b/vlib/v3/tests/callback_userdata_fn_field_codegen_test.v
@@ -1,0 +1,444 @@
+import os
+import strings
+
+const callback_vexe = @VEXE
+const callback_tests_dir = os.dir(@FILE)
+const callback_v3_dir = os.dir(callback_tests_dir)
+const callback_vlib_dir = os.dir(callback_v3_dir)
+const callback_v3_src = os.join_path(callback_v3_dir, 'v3.v')
+
+fn callback_build_v3() string {
+	return callback_build_v3_with_flags('serial', '')
+}
+
+fn callback_build_v3_parallel() string {
+	return callback_build_v3_with_flags('parallel', '-d parallel')
+}
+
+fn callback_build_v3_with_flags(name string, flags string) string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_callback_userdata_test_${name}_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${callback_vexe} ${flags} -gc none -path "${callback_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${callback_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn callback_write_source(name string, source string) string {
+	path := os.join_path(os.temp_dir(), 'v3_callback_userdata_${name}_${os.getpid()}.v')
+	os.write_file(path, source) or { panic(err) }
+	return path
+}
+
+fn callback_compile(v3_bin string, source string, name string) os.Result {
+	out := os.join_path(os.temp_dir(), 'v3_callback_userdata_${name}_${os.getpid()}')
+	return os.execute('${v3_bin} ${source} -b c -o ${out}')
+}
+
+fn callback_write_project_file(root string, rel string, source string) string {
+	path := os.join_path(root, rel)
+	os.mkdir_all(os.dir(path)) or { panic(err) }
+	os.write_file(path, source) or { panic(err) }
+	return path
+}
+
+fn callback_adapter_names(generated string, prefix string) []string {
+	mut names := []string{}
+	for line in generated.split_into_lines() {
+		if line.starts_with('static void ${prefix}') {
+			name := line.all_after('static void ').all_before('(')
+			if name !in names {
+				names << name
+			}
+		}
+	}
+	return names
+}
+
+fn test_callback_userdata_fn_field_adapters() {
+	v3_bin := callback_build_v3()
+	good_src := callback_write_source('good', 'module main
+
+struct Event {
+	code int
+}
+
+struct App {
+mut:
+	frames int
+	events int
+	directs int
+}
+
+struct Config {
+	frame fn (voidptr)
+	event fn (&Event, voidptr)
+	native_event fn (&Event, voidptr)
+	direct fn (voidptr)
+	user_data voidptr
+}
+
+type FrameAlias = fn (voidptr)
+type EventAlias = fn (&Event, voidptr)
+
+struct AliasConfig {
+	alias_frame FrameAlias
+	alias_event EventAlias
+	user_data voidptr
+}
+
+struct StructAliasTarget {
+	alias2_frame FrameAlias
+	alias2_event EventAlias
+	user_data voidptr
+}
+
+type StructAlias = StructAliasTarget
+
+@[params]
+struct Params {
+	frame fn (voidptr)
+	event fn (&Event, voidptr)
+	native_event fn (&Event, voidptr)
+	direct fn (voidptr)
+	user_data voidptr
+}
+
+fn run_config(mut app App, cfg Config) int {
+	cfg.frame(cfg.user_data)
+	e := Event{code: 3}
+	cfg.event(&e, cfg.user_data)
+	cfg.native_event(&e, cfg.user_data)
+	cfg.direct(cfg.user_data)
+	return app.frames + app.events + app.directs
+}
+
+fn run_params(mut app App, params Params) int {
+	params.frame(params.user_data)
+	e := Event{code: 4}
+	params.event(&e, params.user_data)
+	params.native_event(&e, params.user_data)
+	params.direct(params.user_data)
+	return app.frames + app.events + app.directs
+}
+
+fn use_cb(cb fn (voidptr), data voidptr) {
+	cb(data)
+}
+
+fn frame(mut app App) {
+	app.frames++
+}
+
+fn on_event(e &Event, mut app App) {
+	app.events += e.code
+}
+
+fn erased_event(e voidptr, data voidptr) {
+	event := unsafe { &Event(e) }
+	mut app := unsafe { &App(data) }
+	app.events += event.code * 10
+}
+
+fn direct(ptr voidptr) {
+	mut app := unsafe { &App(ptr) }
+	app.directs++
+}
+
+fn main() {
+	mut a := App{}
+	cfg := Config{
+		frame: frame
+		event: on_event
+		native_event: erased_event
+		direct: direct
+		user_data: voidptr(&a)
+	}
+	first := run_config(mut a, cfg)
+	mut b := App{}
+	second := run_params(mut b, frame: frame, event: on_event, native_event: erased_event, direct: direct, user_data: voidptr(&b))
+	mut c := App{}
+	use_cb(frame, voidptr(&c))
+	alias_cfg := AliasConfig{alias_frame: frame, alias_event: on_event, user_data: voidptr(&c)}
+	alias_target := StructAlias{alias2_frame: frame, alias2_event: on_event, user_data: voidptr(&c)}
+	if alias_cfg.user_data == voidptr(0) || alias_target.user_data == voidptr(0) {
+		println(int_str(-1))
+	}
+	println(int_str(first + second + c.frames))
+}
+')
+	good_out := os.join_path(os.temp_dir(), 'v3_callback_userdata_good_${os.getpid()}')
+	good_compile := os.execute('${v3_bin} ${good_src} -b c -o ${good_out}')
+	assert good_compile.exit_code == 0, good_compile.output
+	run := os.execute(good_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '82'
+	generated := os.read_file(good_out + '.c') or { panic(err) }
+	assert generated.contains('callback_adapter'), generated
+	assert generated.contains('frame_callback_adapter'), generated
+	assert generated.contains('on_event_callback_adapter'), generated
+	assert generated.contains('erased_event_callback_adapter'), generated
+	assert generated.contains('frame((App*)arg0);'), generated
+	assert generated.contains('on_event(arg0, (App*)arg1);'), generated
+	assert generated.contains('erased_event((void*)arg0, arg1);'), generated
+	assert generated.contains('use_cb(frame_callback_adapter_'), generated
+	assert generated.contains('.alias_frame = frame_callback_adapter_'), generated
+	assert generated.contains('.alias_event = on_event_callback_adapter_'), generated
+	assert generated.contains('.alias2_frame = frame_callback_adapter_'), generated
+	assert generated.contains('.alias2_event = on_event_callback_adapter_'), generated
+	assert generated.contains('.direct = direct'), generated
+	assert !generated.contains('.frame = frame,'), generated
+	assert !generated.contains('.event = on_event,'), generated
+	assert !generated.contains('.native_event = erased_event,'), generated
+	assert !generated.contains('.alias_frame = frame,'), generated
+	assert !generated.contains('.alias_event = on_event,'), generated
+	assert !generated.contains('.alias2_frame = frame,'), generated
+	assert !generated.contains('.alias2_event = on_event,'), generated
+	assert !generated.contains('.frame = (_fn_ptr'), generated
+	assert !generated.contains('.event = (_fn_ptr'), generated
+	assert !generated.contains('.native_event = (_fn_ptr'), generated
+	assert !generated.contains('use_cb((_fn_ptr'), generated
+	assert !generated.contains('use_cb(frame,'), generated
+	assert !generated.contains('direct_callback_adapter'), generated
+
+	wrong_arity := callback_write_source('wrong_arity', 'module main
+struct Config {
+	frame fn (voidptr)
+}
+fn wrong(a voidptr, b int) {}
+fn main() {
+	_ := Config{frame: wrong}
+}
+')
+	arity_compile := callback_compile(v3_bin, wrong_arity, 'wrong_arity')
+	assert arity_compile.exit_code != 0, arity_compile.output
+
+	wrong_return := callback_write_source('wrong_return', 'module main
+struct Config {
+	frame fn (voidptr)
+}
+fn wrong(a voidptr) int {
+	return 1
+}
+fn main() {
+	_ := Config{frame: wrong}
+}
+')
+	return_compile := callback_compile(v3_bin, wrong_return, 'wrong_return')
+	assert return_compile.exit_code != 0, return_compile.output
+
+	wrong_return_pointer := callback_write_source('wrong_return_pointer', 'module main
+struct Event {}
+struct Config {
+	cb fn () &Event
+}
+fn ret_voidptr() voidptr {
+	return voidptr(0)
+}
+fn main() {
+	_ := Config{cb: ret_voidptr}
+}
+')
+	return_pointer_compile := callback_compile(v3_bin, wrong_return_pointer, 'wrong_return_pointer')
+	assert return_pointer_compile.exit_code != 0, return_pointer_compile.output
+
+	wrong_param := callback_write_source('wrong_param', 'module main
+struct Event {}
+struct Other {}
+struct App {}
+struct Config {
+	event fn (&Event, voidptr)
+}
+fn wrong(e &Other, mut app App) {}
+fn main() {
+	_ := Config{event: wrong}
+}
+')
+	param_compile := callback_compile(v3_bin, wrong_param, 'wrong_param')
+	assert param_compile.exit_code != 0, param_compile.output
+
+	wrong_primitive_param := callback_write_source('wrong_primitive_param', 'module main
+struct Config {
+	cb fn (i64)
+}
+fn takes_int(x int) {}
+fn main() {
+	_ := Config{cb: takes_int}
+}
+')
+	primitive_param_compile := callback_compile(v3_bin, wrong_primitive_param,
+		'wrong_primitive_param')
+	assert primitive_param_compile.exit_code != 0, primitive_param_compile.output
+
+	homonym_root := os.join_path(os.temp_dir(), 'v3_callback_userdata_homonym_${os.getpid()}')
+	os.rmdir_all(homonym_root) or {}
+	callback_write_project_file(homonym_root, 'left/left.v', 'module left
+
+pub struct App {
+pub mut:
+	hits int
+}
+
+pub fn hit(mut app App) {
+	app.hits += 10
+}
+')
+	callback_write_project_file(homonym_root, 'right/right.v', 'module right
+
+pub struct App {
+pub mut:
+	hits int
+}
+
+pub fn hit(mut app App) {
+	app.hits += 100
+}
+')
+	homonym_main := callback_write_project_file(homonym_root, 'main.v', 'module main
+
+import left
+import right
+
+struct Config {
+	cb fn (voidptr)
+	user_data voidptr
+}
+
+fn run(cfg Config) {
+	cfg.cb(cfg.user_data)
+}
+
+fn main() {
+	_ := left.App{}
+	mut app := right.App{}
+	cfg := Config{
+		cb: right.hit
+		user_data: voidptr(&app)
+	}
+	run(cfg)
+	println(int_str(app.hits))
+}
+')
+	homonym_out := os.join_path(os.temp_dir(), 'v3_callback_userdata_homonym_out_${os.getpid()}')
+	homonym_compile := os.execute('${v3_bin} ${homonym_main} -b c -o ${homonym_out}')
+	assert homonym_compile.exit_code == 0, homonym_compile.output
+	homonym_run := os.execute(homonym_out)
+	assert homonym_run.exit_code == 0, homonym_run.output
+	assert homonym_run.output.trim_space() == '100'
+	homonym_c := os.read_file(homonym_out + '.c') or { panic(err) }
+	assert homonym_c.contains('right__hit_callback_adapter'), homonym_c
+	assert homonym_c.contains('right__hit((right__App*)arg0);'), homonym_c
+	assert !homonym_c.contains('left__hit_callback_adapter'), homonym_c
+
+	c_fn_src := callback_write_source('c_fn_value', 'module main
+
+fn C.abs(int) int
+
+struct App {
+mut:
+	hits int
+}
+
+fn abs(mut app App) int {
+	app.hits = 99
+	return app.hits
+}
+
+fn call_c(cb fn (int) int) int {
+	return cb(-3)
+}
+
+fn main() {
+	_ := App{}
+	rc := call_c(C.abs)
+	println(int_str(rc))
+}
+')
+	c_fn_out := os.join_path(os.temp_dir(), 'v3_callback_userdata_c_fn_${os.getpid()}')
+	c_fn_compile := os.execute('${v3_bin} ${c_fn_src} -b c -o ${c_fn_out}')
+	assert c_fn_compile.exit_code == 0, c_fn_compile.output
+	c_fn_run := os.execute(c_fn_out)
+	assert c_fn_run.exit_code == 0, c_fn_run.output
+	assert c_fn_run.output.trim_space() == '3'
+	c_fn_c := os.read_file(c_fn_out + '.c') or { panic(err) }
+	assert c_fn_c.contains('call_c(abs)'), c_fn_c
+	assert !c_fn_c.contains('call_c((_fn_ptr'), c_fn_c
+	assert !c_fn_c.contains('int abs(App*'), c_fn_c
+}
+
+fn test_callback_parallel_wrapper_names_are_stable() {
+	v3_bin := callback_build_v3_parallel()
+	mut src := strings.new_builder(128 * 1024)
+	src.write_string('module main
+
+struct EventA {
+	code int
+}
+
+struct EventB {
+	code int
+}
+
+struct App {
+mut:
+	total int
+}
+
+struct ConfigA {
+	cb fn (&EventA, voidptr)
+	user_data voidptr
+}
+
+struct ConfigB {
+	cb fn (&EventB, voidptr)
+	user_data voidptr
+}
+
+fn erased(e voidptr, data voidptr) {
+	_ := e
+	mut app := unsafe { &App(data) }
+	app.total++
+}
+
+')
+	for i in 0 .. 1100 {
+		if i % 2 == 0 {
+			src.write_string('fn use_${i}(mut app App) {
+	e := EventA{code: ${i}}
+	cfg := ConfigA{cb: erased, user_data: voidptr(app)}
+	cfg.cb(&e, cfg.user_data)
+}
+
+')
+		} else {
+			src.write_string('fn use_${i}(mut app App) {
+	e := EventB{code: ${i}}
+	cfg := ConfigB{cb: erased, user_data: voidptr(app)}
+	cfg.cb(&e, cfg.user_data)
+}
+
+')
+		}
+	}
+	src.write_string('fn main() {
+	mut app := App{}
+')
+	for i in 0 .. 1100 {
+		src.write_string('	use_${i}(mut app)
+')
+	}
+	src.write_string('	println(int_str(app.total))
+}
+')
+	parallel_src := callback_write_source('parallel', src.str())
+	parallel_out := os.join_path(os.temp_dir(), 'v3_callback_userdata_parallel_${os.getpid()}')
+	parallel_compile := os.execute('${v3_bin} ${parallel_src} -b c -o ${parallel_out}')
+	assert parallel_compile.exit_code == 0, parallel_compile.output
+	parallel_run := os.execute(parallel_out)
+	assert parallel_run.exit_code == 0, parallel_run.output
+	assert parallel_run.output.trim_space() == '1100'
+	parallel_c := os.read_file(parallel_out + '.c') or { panic(err) }
+	names := callback_adapter_names(parallel_c, 'erased_callback_adapter_')
+	assert names.len == 2, parallel_c
+	assert names[0] != names[1]
+}

--- a/vlib/v3/tests/comptime_top_level_decl_codegen_test.v
+++ b/vlib/v3/tests/comptime_top_level_decl_codegen_test.v
@@ -1,0 +1,95 @@
+import os
+
+const comptime_decl_vexe = @VEXE
+const comptime_decl_tests_dir = os.dir(@FILE)
+const comptime_decl_v3_dir = os.dir(comptime_decl_tests_dir)
+const comptime_decl_vlib_dir = os.dir(comptime_decl_v3_dir)
+const comptime_decl_v3_src = os.join_path(comptime_decl_v3_dir, 'v3.v')
+
+fn comptime_decl_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_comptime_top_level_decl_test')
+	build :=
+		os.execute('${comptime_decl_vexe} -gc none -path "${comptime_decl_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${comptime_decl_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn comptime_decl_count(c_code string, needle string) int {
+	mut count := 0
+	mut rest := c_code
+	for {
+		idx := rest.index(needle) or { break }
+		count++
+		rest = rest[idx + needle.len..]
+	}
+	return count
+}
+
+fn comptime_decl_struct_body(c_code string, name string) string {
+	start := c_code.index('struct ${name} {') or { return '' }
+	rest := c_code[start..]
+	end := rest.index('\n};') or { return rest }
+	return rest[..end]
+}
+
+fn comptime_decl_gen_c(v3_bin string, name string, feature bool) string {
+	root := os.join_path(os.temp_dir(), 'v3_comptime_top_level_decl_${name}_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	main_path := os.join_path(root, 'main.v')
+	os.write_file(main_path, "module main
+
+$if some_feature ? {
+	struct Choice {
+		x int
+	}
+} $else {
+	struct Choice {}
+}
+
+struct Holder {
+	choice Choice
+}
+
+fn main() {
+	$if some_feature ? {
+		holder := Holder{
+			choice: Choice{
+				x: 1
+			}
+		}
+		println(int_str(holder.choice.x))
+	} $else {
+		holder := Holder{
+			choice: Choice{}
+		}
+		_ = holder
+		println('dummy')
+	}
+}
+") or {
+		panic(err)
+	}
+	bin_path := os.join_path(root, 'out')
+	feature_arg := if feature { '-d some_feature' } else { '' }
+	compile := os.execute('${v3_bin} ${main_path} ${feature_arg} -b c -o ${bin_path}')
+	assert compile.exit_code == 0, '${name}: compile failed: ${compile.output}'
+	c_path := bin_path + '.c'
+	assert os.exists(c_path), '${name}: missing generated C ${c_path}'
+	return os.read_file(c_path) or { panic(err) }
+}
+
+fn test_top_level_decls_inside_active_comptime_branch_are_codegen_visible() {
+	v3_bin := comptime_decl_build_v3()
+	else_c := comptime_decl_gen_c(v3_bin, 'else_branch', false)
+	else_choice := comptime_decl_struct_body(else_c, 'Choice')
+	assert comptime_decl_count(else_c, 'struct Choice {') == 1, else_c
+	assert else_choice.contains('_dummy'), else_c
+	assert !else_choice.contains('int x;'), else_c
+
+	feature_c := comptime_decl_gen_c(v3_bin, 'feature_branch', true)
+	feature_choice := comptime_decl_struct_body(feature_c, 'Choice')
+	assert comptime_decl_count(feature_c, 'struct Choice {') == 1, feature_c
+	assert feature_choice.contains('int x;'), feature_c
+	assert !feature_choice.contains('_dummy'), feature_c
+}

--- a/vlib/v3/tests/comptime_top_level_decl_codegen_test.v
+++ b/vlib/v3/tests/comptime_top_level_decl_codegen_test.v
@@ -92,6 +92,18 @@ fn comptime_decl_gen_c_source(v3_bin string, name string, source string, flags s
 	return os.read_file(c_path) or { panic(err) }
 }
 
+fn comptime_decl_compile_run_source(v3_bin string, name string, source string, flags string) os.Result {
+	root := os.join_path(os.temp_dir(), 'v3_comptime_top_level_decl_run_${name}_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	main_path := os.join_path(root, 'main.v')
+	os.write_file(main_path, source) or { panic(err) }
+	bin_path := os.join_path(root, 'out')
+	compile := os.execute('${v3_bin} ${main_path} ${flags} -o ${bin_path}')
+	assert compile.exit_code == 0, '${name}: compile failed: ${compile.output}'
+	return os.execute(bin_path)
+}
+
 fn test_top_level_decls_inside_active_comptime_branch_are_codegen_visible() {
 	v3_bin := comptime_decl_build_v3()
 	else_c := comptime_decl_gen_c(v3_bin, 'else_branch', false)
@@ -138,4 +150,23 @@ $if some_feature ? {
 		'-d some_feature')
 	assert c_code.contains('int main('), c_code
 	assert c_code.contains('active'), c_code
+}
+
+fn test_synthetic_top_level_block_keeps_main_scope_locals() {
+	v3_bin := comptime_decl_build_v3()
+	run := comptime_decl_compile_run_source(v3_bin, 'synthetic_block_main_scope', 'module main
+
+$if linux {
+	x := 1
+	y := 2
+}
+
+fn helper() int {
+	return 0
+}
+
+println(int_str(x + y))
+', '')
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '3'
 }

--- a/vlib/v3/tests/comptime_top_level_decl_codegen_test.v
+++ b/vlib/v3/tests/comptime_top_level_decl_codegen_test.v
@@ -79,6 +79,19 @@ fn main() {
 	return os.read_file(c_path) or { panic(err) }
 }
 
+fn comptime_decl_gen_c_source(v3_bin string, name string, source string, flags string) string {
+	root := os.join_path(os.temp_dir(), 'v3_comptime_top_level_decl_${name}_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	main_path := os.join_path(root, 'main.v')
+	os.write_file(main_path, source) or { panic(err) }
+	c_path := os.join_path(root, 'out.c')
+	compile := os.execute('${v3_bin} ${main_path} ${flags} -b c -o ${c_path}')
+	assert compile.exit_code == 0, '${name}: C output failed: ${compile.output}'
+	assert os.exists(c_path), '${name}: missing generated C ${c_path}'
+	return os.read_file(c_path) or { panic(err) }
+}
+
 fn test_top_level_decls_inside_active_comptime_branch_are_codegen_visible() {
 	v3_bin := comptime_decl_build_v3()
 	else_c := comptime_decl_gen_c(v3_bin, 'else_branch', false)
@@ -92,4 +105,37 @@ fn test_top_level_decls_inside_active_comptime_branch_are_codegen_visible() {
 	assert comptime_decl_count(feature_c, 'struct Choice {') == 1, feature_c
 	assert feature_choice.contains('int x;'), feature_c
 	assert !feature_choice.contains('_dummy'), feature_c
+}
+
+fn test_declaration_only_top_level_comptime_block_does_not_synthesize_main() {
+	v3_bin := comptime_decl_build_v3()
+	c_code := comptime_decl_gen_c_source(v3_bin, 'decl_only_no_main', 'module main
+
+$if some_feature ? {
+	fn helper() int {
+		return 3
+	}
+} $else {
+	struct Helper {}
+}
+',
+		'-d some_feature')
+	assert !c_code.contains('int main('), c_code
+}
+
+fn test_top_level_comptime_block_with_statement_still_synthesizes_main() {
+	v3_bin := comptime_decl_build_v3()
+	c_code := comptime_decl_gen_c_source(v3_bin, 'stmt_synth_main', "module main
+
+$if some_feature ? {
+	println('active')
+} $else {
+	fn helper() int {
+		return 3
+	}
+}
+",
+		'-d some_feature')
+	assert c_code.contains('int main('), c_code
+	assert c_code.contains('active'), c_code
 }

--- a/vlib/v3/tests/current_module_call_return_codegen_test.v
+++ b/vlib/v3/tests/current_module_call_return_codegen_test.v
@@ -1,0 +1,98 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_current_module_call_return_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn write_project() string {
+	root := os.join_path(os.temp_dir(), 'v3_current_module_call_return_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(os.join_path(root, 'clock')) or { panic(err) }
+	os.mkdir_all(os.join_path(root, 'zz_other')) or { panic(err) }
+	os.write_file(os.join_path(root, 'v.mod'), "Module { name: 'current_module_call_return' }\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'clock/clock.v'), 'module clock
+
+pub struct Time {
+pub mut:
+	value int
+}
+
+pub fn new(t Time) Time {
+	return t
+}
+
+pub fn (mut t Time) add_seconds(n int) {
+	t.value += n
+}
+
+pub fn make() int {
+	mut time_to_be_returned := new(Time{
+		value: 2
+	})
+	time_to_be_returned.add_seconds(3)
+	return time_to_be_returned.value
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'zz_other/zz_other.v'), 'module zz_other
+
+pub struct Other {
+pub mut:
+	value int
+}
+
+pub fn new(seed int) Other {
+	return Other{
+		value: seed + 100
+	}
+}
+
+pub fn (mut o Other) add_seconds(n int) {
+	o.value += n + 100
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'main.v'), 'module main
+
+import clock
+import zz_other
+
+fn main() {
+	assert clock.make() == 5
+	_ := zz_other.new(1)
+}
+') or {
+		panic(err)
+	}
+	return os.join_path(root, 'main.v')
+}
+
+fn test_plain_call_prefers_current_module_return_authority() {
+	v3_bin := build_v3()
+	main_path := write_project()
+	out := os.join_path(os.temp_dir(), 'v3_current_module_call_return_out_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${main_path} -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+	generated := os.read_file(out + '.c') or { panic(err) }
+	assert generated.contains('clock__Time time_to_be_returned = clock__new'), generated
+	assert generated.contains('clock__Time__add_seconds(&time_to_be_returned'), generated
+	assert !generated.contains('zz_other__Other time_to_be_returned = clock__new'), generated
+	assert !generated.contains('zz_other__Other__add_seconds(&time_to_be_returned'), generated
+}

--- a/vlib/v3/tests/dump_expr_codegen_test.v
+++ b/vlib/v3/tests/dump_expr_codegen_test.v
@@ -1,0 +1,69 @@
+import os
+
+const dump_expr_vexe = @VEXE
+const dump_expr_tests_dir = os.dir(@FILE)
+const dump_expr_v3_dir = os.dir(dump_expr_tests_dir)
+const dump_expr_vlib_dir = os.dir(dump_expr_v3_dir)
+const dump_expr_v3_src = os.join_path(dump_expr_v3_dir, 'v3.v')
+
+fn dump_expr_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_dump_expr_codegen_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${dump_expr_vexe} -gc none -path "${dump_expr_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${dump_expr_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn dump_expr_compact_c(s string) string {
+	return s.replace('\t', '').replace(' ', '').replace('\n', '')
+}
+
+fn test_dump_expr_is_transparent_for_c_oracle_output() {
+	v3_bin := dump_expr_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_dump_expr_codegen_${os.getpid()}.v')
+	source := [
+		'module main',
+		'',
+		'fn f() int {',
+		'	return dump(3)',
+		'}',
+		'',
+		'fn take_int(n int) int {',
+		'	return n + 1',
+		'}',
+		'',
+		"fn bump(n int) int { println('side'); return n + 1 }",
+		'',
+		'fn main() {',
+		'	x := dump(1 + 2)',
+		'	assert x == 3',
+		'	mut n := 4',
+		'	n = dump(n + 2)',
+		'	assert n == 6',
+		'	assert f() == 3',
+		'	y := take_int(dump(6))',
+		'	assert y == 7',
+		'	z := dump(bump(0))',
+		'	assert z == 1',
+		'	println(int_str(x + n + f() + y + z))',
+		'}',
+	].join('\n')
+	os.write_file(src, source) or { panic(err) }
+	bin := os.join_path(os.temp_dir(), 'v3_dump_expr_codegen_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	lines := run.output.trim_space().replace('\r\n', '\n').split('\n')
+	assert lines == ['side', '20'], run.output
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	compact := dump_expr_compact_c(generated)
+	assert !generated.contains('dump('), generated
+	assert !generated.contains('= ;'), generated
+	assert compact.count('1+2') == 1, generated
+	assert compact.contains('n=n+2;'), generated
+	assert compact.contains('return3;'), generated
+	assert compact.contains('take_int(6)'), generated
+	assert compact.count('bump(0)') == 1, generated
+}

--- a/vlib/v3/tests/enum_match_return_checker_test.v
+++ b/vlib/v3/tests/enum_match_return_checker_test.v
@@ -1,0 +1,174 @@
+import os
+
+const enum_match_vexe = @VEXE
+const enum_match_tests_dir = os.dir(@FILE)
+const enum_match_v3_dir = os.dir(enum_match_tests_dir)
+const enum_match_vlib_dir = os.dir(enum_match_v3_dir)
+const enum_match_v3_src = os.join_path(enum_match_v3_dir, 'v3.v')
+
+fn enum_match_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_enum_match_return_checker_test')
+	build :=
+		os.execute('${enum_match_vexe} -gc none -path "${enum_match_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${enum_match_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn enum_match_run_to_c(v3_bin string, name string, src string) os.Result {
+	src_path := os.join_path(os.temp_dir(), 'v3_enum_match_return_${name}.v')
+	os.write_file(src_path, src) or { panic(err) }
+	c_path := os.join_path(os.temp_dir(), 'v3_enum_match_return_${name}.c')
+	os.rm(c_path) or {}
+	return os.execute('${v3_bin} ${src_path} -b c -o ${c_path}')
+}
+
+fn enum_match_check_good(v3_bin string, name string, src string) {
+	result := enum_match_run_to_c(v3_bin, name, src)
+	assert result.exit_code == 0, result.output
+	assert !result.output.contains('missing return'), result.output
+}
+
+fn enum_match_check_bad(v3_bin string, name string, src string) {
+	result := enum_match_run_to_c(v3_bin, name, src)
+	assert result.exit_code != 0, result.output
+	assert result.output.contains('missing return at end of function'), result.output
+}
+
+fn test_exhaustive_enum_match_without_else_definitely_returns() {
+	v3_bin := enum_match_build_v3()
+	enum_match_check_good(v3_bin, 'exhaustive', 'module main
+
+enum Color {
+	red
+	green
+	blue
+}
+
+fn label(c Color) string {
+	match c {
+		.red {
+			return "red"
+		}
+		.green {
+			return "green"
+		}
+		.blue {
+			return "blue"
+		}
+	}
+}
+
+fn main() {
+	println(label(.red))
+}
+')
+	enum_match_check_good(v3_bin, 'grouped', 'module main
+
+enum Cell {
+	empty
+	blocked
+	live
+}
+
+fn weight(c Cell) int {
+	match c {
+		.empty, .blocked {
+			return 0
+		}
+		.live {
+			return 1
+		}
+	}
+}
+
+fn main() {
+	println(weight(.live))
+}
+')
+}
+
+fn test_non_exhaustive_or_unsupported_match_without_else_does_not_return() {
+	v3_bin := enum_match_build_v3()
+	enum_match_check_bad(v3_bin, 'partial_enum', 'module main
+
+enum Color {
+	red
+	green
+	blue
+}
+
+fn label(c Color) string {
+	match c {
+		.red {
+			return "red"
+		}
+		.green {
+			return "green"
+		}
+	}
+}
+
+fn main() {}
+')
+	enum_match_check_bad(v3_bin, 'non_returning_branch', 'module main
+
+enum Color {
+	red
+	green
+	blue
+}
+
+fn label(c Color) string {
+	match c {
+		.red {
+			return "red"
+		}
+		.green {
+			x := 1
+			_ := x
+		}
+		.blue {
+			return "blue"
+		}
+	}
+}
+
+fn main() {}
+')
+	enum_match_check_bad(v3_bin, 'non_enum_match', 'module main
+
+fn label(i int) string {
+	match i {
+		0 {
+			return "zero"
+		}
+		1 {
+			return "one"
+		}
+	}
+}
+
+fn main() {}
+')
+	enum_match_check_bad(v3_bin, 'flag_enum', 'module main
+
+@[flag]
+enum Permission {
+	read
+	write
+}
+
+fn label(p Permission) string {
+	match p {
+		.read {
+			return "read"
+		}
+		.write {
+			return "write"
+		}
+	}
+}
+
+fn main() {}
+')
+}

--- a/vlib/v3/tests/export_attr_codegen_test.v
+++ b/vlib/v3/tests/export_attr_codegen_test.v
@@ -1,0 +1,253 @@
+import os
+
+const export_attr_vexe = @VEXE
+const export_attr_tests_dir = os.dir(@FILE)
+const export_attr_v3_dir = os.dir(export_attr_tests_dir)
+const export_attr_vlib_dir = os.dir(export_attr_v3_dir)
+const export_attr_v3_src = os.join_path(export_attr_v3_dir, 'v3.v')
+
+fn export_attr_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_export_attr_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${export_attr_vexe} -gc none -path "${export_attr_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${export_attr_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn export_attr_project(name string, files map[string]string) string {
+	root := os.join_path(os.temp_dir(), 'v3_export_attr_${name}_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	mut rels := files.keys()
+	rels.sort()
+	for rel in rels {
+		path := os.join_path(root, rel)
+		os.mkdir_all(os.dir(path)) or { panic(err) }
+		os.write_file(path, files[rel]) or { panic(err) }
+	}
+	return root
+}
+
+fn export_attr_compile(v3_bin string, main_file string, output string) os.Result {
+	return os.execute('${v3_bin} ${main_file} -b c -o ${output}')
+}
+
+fn test_exported_imported_function_is_rooted_and_emitted_as_raw_symbol() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('imported_link', {
+		'main.v':       'module main
+
+import expmod
+
+fn C.raw_exported_answer() int
+
+fn take_callback(cb fn () int) int {
+	return cb()
+}
+
+fn main() {
+	println(C.raw_exported_answer().str())
+	println(expmod.exported_answer().str())
+	println(take_callback(expmod.exported_answer).str())
+}
+'
+		'expmod/mod.v': "module expmod
+
+@[export: 'raw_exported_answer']
+pub fn exported_answer() int {
+	return helper_used()
+}
+
+fn helper_used() int {
+	return 41
+}
+
+fn helper_unused() int {
+	return 99
+}
+"
+	})
+	bin_path := os.join_path(root, 'app')
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), bin_path)
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin_path)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '41\n41\n41', run.output
+
+	c_code := os.read_file(bin_path + '.c') or { panic(err) }
+	assert c_code.contains('int expmod__exported_answer(void) {'), c_code
+	assert c_code.contains('int raw_exported_answer(void) {'), c_code
+	assert c_code.contains('return expmod__exported_answer();'), c_code
+	assert c_code.contains('raw_exported_answer()'), c_code
+	assert c_code.contains('take_callback(expmod__exported_answer)'), c_code
+	assert c_code.contains('expmod__helper_used('), c_code
+	assert !c_code.contains('expmod__helper_unused('), c_code
+}
+
+fn test_duplicate_export_name_is_rejected() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('duplicate', {
+		'main.v': "module main
+
+@[export: 'raw_duplicate']
+fn one() {}
+
+@[export: 'raw_duplicate']
+fn two() {}
+
+fn main() {}
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), os.join_path(root, 'app'))
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('duplicate export name `raw_duplicate`'), compile.output
+}
+
+fn test_export_name_collision_with_runtime_symbol_is_rejected() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('runtime_collision', {
+		'main.v': "module main
+
+@[export: 'v_free']
+fn collides_with_runtime_free() {}
+
+fn main() {}
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), os.join_path(root, 'app'))
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('export name `v_free`'), compile.output
+}
+
+fn test_export_name_collision_with_natural_symbol_is_rejected() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('natural_collision', {
+		'main.v': "module main
+
+@[export: 'natural_name']
+fn natural_name() int {
+	return 1
+}
+
+fn main() {}
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), os.join_path(root, 'app'))
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('export name `natural_name`'), compile.output
+}
+
+fn test_invalid_export_names_are_rejected() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('invalid_names', {
+		'main.v': "module main
+
+@[export: '1bad']
+fn bad_digit() {}
+
+@[export: 'for']
+fn bad_keyword() {}
+
+fn main() {}
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), os.join_path(root, 'app'))
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('invalid export name `1bad`'), compile.output
+	assert compile.output.contains('invalid export name `for`'), compile.output
+}
+
+fn test_export_name_reserved_by_v3_c_preamble_is_rejected() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('preamble_reserved_name', {
+		'main.v': "module main
+
+@[export: 'bool']
+fn collides_with_preamble_bool() bool {
+	return true
+}
+
+@[export: 'string']
+fn collides_with_preamble_string() {}
+
+@[export: 'voidptr']
+fn collides_with_preamble_voidptr() {}
+
+@[export: 'i8']
+fn collides_with_preamble_i8() {}
+
+@[export: 'true']
+fn collides_with_preamble_true() {}
+
+@[export: 'Array']
+fn collides_with_runtime_array() {}
+
+@[export: 'map']
+fn collides_with_runtime_map() int {
+	values := map[string]int{
+		'a': 1
+	}
+	return values['a'] or { 0 }
+}
+
+@[export: 'DenseArray']
+fn collides_with_runtime_dense_array() {}
+
+@[export: 'SortedMap']
+fn collides_with_runtime_sorted_map() {}
+
+@[export: 'Optional']
+fn collides_with_runtime_optional() {}
+
+fn main() {}
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), os.join_path(root, 'app'))
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('invalid export name `bool`'), compile.output
+	assert compile.output.contains('invalid export name `string`'), compile.output
+	assert compile.output.contains('invalid export name `voidptr`'), compile.output
+	assert compile.output.contains('invalid export name `i8`'), compile.output
+	assert compile.output.contains('invalid export name `true`'), compile.output
+	assert compile.output.contains('invalid export name `Array`'), compile.output
+	assert compile.output.contains('invalid export name `map`'), compile.output
+	assert compile.output.contains('invalid export name `DenseArray`'), compile.output
+	assert compile.output.contains('invalid export name `SortedMap`'), compile.output
+	assert compile.output.contains('invalid export name `Optional`'), compile.output
+}
+
+fn test_generic_export_is_rejected_fail_closed() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('generic_export', {
+		'main.v': "module main
+
+@[export: 'raw_generic']
+fn raw_generic[T](value T) T {
+	return value
+}
+
+fn main() {}
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), os.join_path(root, 'app'))
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('generic function `raw_generic` cannot be exported'), compile.output
+}
+
+fn test_exported_function_must_name_params() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('unnamed_param', {
+		'main.v': "module main
+
+@[export: 'raw_unnamed']
+fn unnamed(int) int {
+	return 0
+}
+
+fn main() {}
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), os.join_path(root, 'app'))
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('must name all parameters'), compile.output
+}

--- a/vlib/v3/tests/export_attr_codegen_test.v
+++ b/vlib/v3/tests/export_attr_codegen_test.v
@@ -103,6 +103,39 @@ fn main() {}
 	assert compile.output.contains('duplicate export name `raw_duplicate`'), compile.output
 }
 
+fn test_disabled_export_attr_does_not_register_raw_symbol() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('disabled_export', {
+		'main.v': "module main
+
+@[if missing_export_flag ?]
+@[export: 'raw_disabled_export']
+fn disabled_export() int {
+	return 2
+}
+
+@[export: 'raw_enabled_export']
+fn enabled_export() int {
+	return 7
+}
+
+fn main() {
+	println(enabled_export().str())
+}
+"
+	})
+	bin_path := os.join_path(root, 'app')
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), bin_path)
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin_path)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '7', run.output
+
+	c_code := os.read_file(bin_path + '.c') or { panic(err) }
+	assert c_code.contains('int raw_enabled_export(void) {'), c_code
+	assert !c_code.contains('raw_disabled_export'), c_code
+}
+
 fn test_export_name_collision_with_runtime_symbol_is_rejected() {
 	v3_bin := export_attr_build_v3()
 	root := export_attr_project('runtime_collision', {

--- a/vlib/v3/tests/export_attr_codegen_test.v
+++ b/vlib/v3/tests/export_attr_codegen_test.v
@@ -190,6 +190,30 @@ fn main() {}
 	assert compile.output.contains('invalid export name `for`'), compile.output
 }
 
+fn test_invalid_imported_export_name_is_rejected_before_cgen() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('invalid_imported_name', {
+		'main.v':          'module main
+
+import badexp
+
+fn main() {
+	println(badexp.answer().str())
+}
+'
+		'badexp/badexp.v': "module badexp
+
+@[export: '1bad']
+pub fn answer() int {
+	return 1
+}
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), os.join_path(root, 'app'))
+	assert compile.exit_code != 0
+	assert compile.output.contains('invalid export name `1bad` for `badexp.answer`'), compile.output
+}
+
 fn test_export_name_reserved_by_v3_c_preamble_is_rejected() {
 	v3_bin := export_attr_build_v3()
 	root := export_attr_project('preamble_reserved_name', {

--- a/vlib/v3/tests/export_attr_codegen_test.v
+++ b/vlib/v3/tests/export_attr_codegen_test.v
@@ -195,6 +195,84 @@ fn main() {}
 	assert !compile.output.contains('redefinition'), compile.output
 }
 
+fn test_export_main_collision_with_top_level_script_entry_is_rejected() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('top_level_script_export_main_collision', {
+		'main.v': "
+@[export: 'main']
+fn exported_entry() {}
+
+println('script')
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), os.join_path(root, 'app'))
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('export name `main` for `exported_entry`'), compile.output
+	assert compile.output.contains('synthetic entry point `main`'), compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	assert !compile.output.contains('redefinition'), compile.output
+}
+
+fn test_export_main_collision_with_top_level_match_entry_is_rejected() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('top_level_match_export_main_collision', {
+		'main.v': "
+@[export: 'main']
+fn exported_entry() {}
+
+match 1 {
+	1 { println('one') }
+	else { println('other') }
+}
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), os.join_path(root, 'app'))
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('export name `main` for `exported_entry`'), compile.output
+	assert compile.output.contains('synthetic entry point `main`'), compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	assert !compile.output.contains('redefinition'), compile.output
+}
+
+fn test_export_main_collision_with_test_harness_entry_is_rejected() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('test_harness_export_main_collision', {
+		'main_test.v': "
+@[export: 'main']
+fn exported_entry() {}
+
+fn test_ok() {}
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main_test.v'), os.join_path(root,
+		'app'))
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('export name `main` for `exported_entry`'), compile.output
+	assert compile.output.contains('synthetic entry point `main`'), compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	assert !compile.output.contains('redefinition'), compile.output
+}
+
+fn test_export_main_in_non_main_test_module_does_not_report_synthetic_collision() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('test_harness_non_main_module_export_main', {
+		'foo_test.v': "module foo
+
+@[export: 'main']
+fn exported_entry() {}
+
+fn test_ok() {}
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'foo_test.v'), os.join_path(root,
+		'app'))
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('only module main test files are supported'), compile.output
+	assert !compile.output.contains('synthetic entry point `main`'), compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	assert !compile.output.contains('redefinition'), compile.output
+}
+
 fn test_invalid_export_names_are_rejected() {
 	v3_bin := export_attr_build_v3()
 	root := export_attr_project('invalid_names', {

--- a/vlib/v3/tests/export_attr_codegen_test.v
+++ b/vlib/v3/tests/export_attr_codegen_test.v
@@ -170,6 +170,31 @@ fn main() {}
 	assert compile.output.contains('export name `natural_name`'), compile.output
 }
 
+fn test_export_name_collision_with_libc_remapped_natural_symbol_is_rejected() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('libc_remapped_natural_collision', {
+		'main.v': "module main
+
+fn rint() int {
+	return 1
+}
+
+@[export: 'v_rint']
+fn exported_rint_collision() int {
+	return 2
+}
+
+fn main() {}
+"
+	})
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), os.join_path(root, 'app'))
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('export name `v_rint`'), compile.output
+	assert compile.output.contains('collides with `rint`'), compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	assert !compile.output.contains('redefinition'), compile.output
+}
+
 fn test_invalid_export_names_are_rejected() {
 	v3_bin := export_attr_build_v3()
 	root := export_attr_project('invalid_names', {
@@ -398,4 +423,35 @@ fn main() {}
 	assert c_code.contains('veb__Result raw_show(App* app, Context* ctx, int id);'), c_code
 	assert c_code.contains('veb__Result raw_show(App* app, Context* ctx, int id) {'), c_code
 	assert c_code.contains('return App__show(app, ctx, id);'), c_code
+}
+
+fn test_export_wrapper_for_veb_handler_underscore_param_matches_implicit_ctx_position() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('veb_implicit_ctx_underscore_export_wrapper', {
+		'main.v': "module main
+
+import veb
+
+pub struct Context {
+	veb.Context
+}
+
+pub struct App {}
+
+@[export: 'raw_show_underscore']
+pub fn (app &App) show(_ int) veb.Result {
+	return veb.Result{}
+}
+
+fn main() {}
+"
+	})
+	c_path := os.join_path(root, 'app.c')
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), c_path)
+	assert compile.exit_code == 0, compile.output
+	c_code := os.read_file(c_path) or { panic(err) }
+	assert c_code.contains('veb__Result raw_show_underscore(App* app, Context* ctx, int _2);'), c_code
+	assert c_code.contains('veb__Result raw_show_underscore(App* app, Context* ctx, int _2) {'), c_code
+	assert c_code.contains('return App__show(app, ctx, _2);'), c_code
+	assert !c_code.contains('return App__show(app, ctx, _1);'), c_code
 }

--- a/vlib/v3/tests/export_attr_codegen_test.v
+++ b/vlib/v3/tests/export_attr_codegen_test.v
@@ -284,3 +284,94 @@ fn main() {}
 	assert compile.exit_code != 0, compile.output
 	assert compile.output.contains('must name all parameters'), compile.output
 }
+
+fn test_export_wrapper_fixed_array_return_uses_return_wrapper_type() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('fixed_array_return', {
+		'main.v': "module main
+
+@[export: 'raw_numbers']
+fn numbers() [3]int {
+	mut values := [3]int{}
+	values[0] = 1
+	values[1] = 2
+	values[2] = 3
+	return values
+}
+
+fn main() {}
+"
+	})
+	bin_path := os.join_path(root, 'app')
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), bin_path)
+	assert compile.exit_code == 0, compile.output
+	c_code := os.read_file(bin_path + '.c') or { panic(err) }
+	assert c_code.contains('_v_ret_Array_fixed_int_3 numbers(void);'), c_code
+	assert c_code.contains('_v_ret_Array_fixed_int_3 raw_numbers(void);'), c_code
+	assert c_code.contains('_v_ret_Array_fixed_int_3 numbers(void) {'), c_code
+	assert c_code.contains('_v_ret_Array_fixed_int_3 raw_numbers(void) {'), c_code
+	assert c_code.contains('return numbers();'), c_code
+	assert !c_code.contains('\nArray_fixed_int_3 raw_numbers(void)'), c_code
+}
+
+fn test_export_wrapper_fn_pointer_return_uses_fn_pointer_typedef() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('fn_pointer_return', {
+		'main.v': "module main
+
+type Callback = fn () int
+
+fn callback_value() int {
+	return 7
+}
+
+@[export: 'raw_callback']
+fn callback() Callback {
+	return callback_value
+}
+
+fn main() {}
+"
+	})
+	bin_path := os.join_path(root, 'app')
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), bin_path)
+	assert compile.exit_code == 0, compile.output
+	c_code := os.read_file(bin_path + '.c') or { panic(err) }
+	assert c_code.contains('typedef int (*_fn_ptr_'), c_code
+	assert c_code.contains(' callback(void);'), c_code
+	assert c_code.contains(' raw_callback(void);'), c_code
+	assert c_code.contains(' raw_callback(void) {'), c_code
+	assert c_code.contains('return callback();'), c_code
+	assert !c_code.contains('fn_ptr:'), c_code
+}
+
+fn test_export_wrapper_for_veb_handler_forwards_implicit_ctx() {
+	v3_bin := export_attr_build_v3()
+	root := export_attr_project('veb_implicit_ctx_export_wrapper', {
+		'main.v': "module main
+
+import veb
+
+pub struct Context {
+	veb.Context
+}
+
+pub struct App {}
+
+@[export: 'raw_show']
+pub fn (app &App) show(id int) veb.Result {
+	_ = id
+	return veb.Result{}
+}
+
+fn main() {}
+"
+	})
+	c_path := os.join_path(root, 'app.c')
+	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), c_path)
+	assert compile.exit_code == 0, compile.output
+	c_code := os.read_file(c_path) or { panic(err) }
+	assert c_code.contains('veb__Result raw_show(App* app, Context* ctx, int id);'), c_code
+	assert c_code.contains('veb__Result raw_show(App* app, Context* ctx, int id) {'), c_code
+	assert c_code.contains('return App__show(app, ctx, id);'), c_code
+}

--- a/vlib/v3/tests/fixed_array_const_materialization_codegen_test.v
+++ b/vlib/v3/tests/fixed_array_const_materialization_codegen_test.v
@@ -1,0 +1,68 @@
+import os
+
+const fixed_array_const_vexe = @VEXE
+const fixed_array_const_tests_dir = os.dir(@FILE)
+const fixed_array_const_v3_dir = os.dir(fixed_array_const_tests_dir)
+const fixed_array_const_vlib_dir = os.dir(fixed_array_const_v3_dir)
+const fixed_array_const_v3_src = os.join_path(fixed_array_const_v3_dir, 'v3.v')
+
+fn fixed_array_const_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_fixed_array_const_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${fixed_array_const_vexe} -gc none -path "${fixed_array_const_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${fixed_array_const_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn test_fixed_array_const_materialization_and_nested_for_in() {
+	v3_bin := fixed_array_const_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_fixed_array_const_${os.getpid()}.v')
+	os.write_file(src, 'module main
+
+struct Item {
+	value int
+}
+
+const nums = [[1, 2, 3]!, [4, 5, 6]!]!
+const items = [&Item{value: 7}, &Item{value: 8}]!
+
+fn sum_nums() int {
+	mut total := 0
+	for row in nums {
+		for n in row {
+			total += n
+		}
+	}
+	return total
+}
+
+fn item_sum() int {
+	return items[0].value + items[1].value
+}
+
+fn main() {
+	println(sum_nums().str())
+	println(item_sum().str())
+}
+') or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_fixed_array_const_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space().split_into_lines() == ['21', '15'], run.output
+
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	compact := generated.replace('\t', '').replace(' ', '').replace('\n', '')
+	assert compact.contains('memmove(main__nums,'), generated
+	assert compact.contains('memmove(main__items,'), generated
+	assert compact.contains('introw[3];'), generated
+	assert compact.contains('memmove(row,main__nums['), generated
+	assert !compact.contains('introw=main__nums['), generated
+	assert !compact.contains('<0;'), generated
+	deparenthesized := compact.replace('(', '').replace(')', '')
+	assert deparenthesized.contains('returnmain__items[0]->value+main__items[1]->value;'), generated
+}

--- a/vlib/v3/tests/fixed_array_force_const_codegen_test.v
+++ b/vlib/v3/tests/fixed_array_force_const_codegen_test.v
@@ -1,0 +1,109 @@
+import os
+
+const fixed_array_force_vexe = @VEXE
+const fixed_array_force_tests_dir = os.dir(@FILE)
+const fixed_array_force_v3_dir = os.dir(fixed_array_force_tests_dir)
+const fixed_array_force_vlib_dir = os.dir(fixed_array_force_v3_dir)
+const fixed_array_force_v3_src = os.join_path(fixed_array_force_v3_dir, 'v3.v')
+
+fn fixed_array_force_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_fixed_array_force_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${fixed_array_force_vexe} -gc none -path "${fixed_array_force_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${fixed_array_force_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn fixed_array_force_write_project() string {
+	root := os.join_path(os.temp_dir(), 'v3_fixed_array_force_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	fixture_dir := os.join_path(root, 'fixture')
+	os.mkdir_all(fixture_dir) or { panic(err) }
+	os.write_file(os.join_path(fixture_dir, 'pass_action.h'), '#ifndef V3_FIXED_ARRAY_FORCE_PASS_ACTION_H
+#define V3_FIXED_ARRAY_FORCE_PASS_ACTION_H
+struct pass_action {
+	int colors[4];
+};
+#endif
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(fixture_dir, 'fixture.v'), 'module fixture
+
+#include "@DIR/pass_action.h"
+
+pub struct Color {
+pub:
+	r int
+}
+
+pub struct DirectPass {
+pub:
+	colors [4]Color
+}
+
+pub struct C.pass_action {
+pub:
+	colors [4]int
+}
+
+pub type Pass = C.pass_action
+
+pub const direct_pass = DirectPass{
+	colors: [
+		Color{r: 1},
+		Color{r: 2},
+		Color{r: 3},
+		Color{r: 4},
+	]!
+}
+
+pub const imported_pass = Pass{
+	colors: [
+		5,
+		6,
+		7,
+		8,
+	]!
+}
+
+pub fn pass_score() int {
+	return direct_pass.colors[0].r + direct_pass.colors[1].r + direct_pass.colors[2].r + direct_pass.colors[3].r +
+		imported_pass.colors[0] + imported_pass.colors[1] + imported_pass.colors[2] + imported_pass.colors[3]
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'main.v'), 'module main
+
+import fixture
+
+fn next_function_marker() int {
+	return 6
+}
+
+fn main() {
+	println(int_str(fixture.pass_score() + next_function_marker()))
+}
+') or {
+		panic(err)
+	}
+	return root
+}
+
+fn test_fixed_array_force_array_literal_const_field_does_not_leak_array_temp() {
+	v3_bin := fixed_array_force_build_v3()
+	root := fixed_array_force_write_project()
+	bin := os.join_path(root, 'out')
+	compile := os.execute('${v3_bin} ${root} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '42'
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	assert !generated.contains('__arr_lit_'), generated
+	assert !generated.contains('Array fixture____arr_lit'), generated
+	assert generated.contains('fixture__imported_pass'), generated
+	assert generated.contains('next_function_marker'), generated
+}

--- a/vlib/v3/tests/fixed_array_global_for_in_codegen_test.v
+++ b/vlib/v3/tests/fixed_array_global_for_in_codegen_test.v
@@ -1,0 +1,52 @@
+import os
+
+const fixed_array_global_for_vexe = @VEXE
+const fixed_array_global_for_tests_dir = os.dir(@FILE)
+const fixed_array_global_for_v3_dir = os.dir(fixed_array_global_for_tests_dir)
+const fixed_array_global_for_vlib_dir = os.dir(fixed_array_global_for_v3_dir)
+const fixed_array_global_for_v3_src = os.join_path(fixed_array_global_for_v3_dir, 'v3.v')
+
+fn fixed_array_global_for_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_fixed_array_global_for_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${fixed_array_global_for_vexe} -gc none -path "${fixed_array_global_for_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${fixed_array_global_for_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn test_fixed_array_global_for_in_uses_fixed_array_indexing() {
+	v3_bin := fixed_array_global_for_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_fixed_array_global_for_${os.getpid()}.v')
+	os.write_file(src, 'module main
+
+__global gnums = [6, 7, 8]!
+
+fn sum_gnums() int {
+	mut total := 0
+	for n in gnums {
+		total += n
+	}
+	return total
+}
+
+fn main() {
+	println(sum_gnums().str())
+}
+') or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_fixed_array_global_for_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '21', run.output
+
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	compact := generated.replace('\t', '').replace(' ', '').replace('\n', '')
+	assert compact.contains('intgnums[3]'), generated
+	assert compact.contains('memmove(gnums,'), generated
+	assert compact.contains('=gnums['), generated
+	assert !compact.contains('array_get(gnums,'), generated
+}

--- a/vlib/v3/tests/fixed_array_global_for_in_codegen_test.v
+++ b/vlib/v3/tests/fixed_array_global_for_in_codegen_test.v
@@ -50,3 +50,41 @@ fn main() {
 	assert compact.contains('=gnums['), generated
 	assert !compact.contains('array_get(gnums,'), generated
 }
+
+fn test_imported_fixed_array_global_init_uses_imported_module_context() {
+	v3_bin := fixed_array_global_for_build_v3()
+	root := os.join_path(os.temp_dir(), 'v3_fixed_array_imported_global_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(os.join_path(root, 'm')) or { panic(err) }
+	os.write_file(os.join_path(root, 'main.v'), 'module main
+
+import m
+
+fn main() {
+	println(int_str(m.sum()))
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'm', 'm.v'), 'module m
+
+const seed = 5
+__global table = [seed, 0]!
+
+pub fn sum() int {
+	return table[0]
+}
+') or {
+		panic(err)
+	}
+	bin := os.join_path(root, 'app')
+	compile := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '5', run.output
+
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	compact := generated.replace('\t', '').replace(' ', '').replace('\n', '')
+	assert compact.contains('memmove(m__table,'), generated
+}

--- a/vlib/v3/tests/fixed_array_local_zero_init_codegen_test.v
+++ b/vlib/v3/tests/fixed_array_local_zero_init_codegen_test.v
@@ -1,0 +1,57 @@
+import os
+
+const local_fixed_array_vexe = @VEXE
+const local_fixed_array_tests_dir = os.dir(@FILE)
+const local_fixed_array_v3_dir = os.dir(local_fixed_array_tests_dir)
+const local_fixed_array_vlib_dir = os.dir(local_fixed_array_v3_dir)
+const local_fixed_array_v3_src = os.join_path(local_fixed_array_v3_dir, 'v3.v')
+
+fn local_fixed_array_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_fixed_array_local_zero_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${local_fixed_array_vexe} -gc none -path "${local_fixed_array_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${local_fixed_array_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn test_local_fixed_array_zero_init_declarations_use_direct_c_arrays() {
+	v3_bin := local_fixed_array_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_fixed_array_local_zero_${os.getpid()}.v')
+	os.write_file(src, 'module main
+
+type Handle = voidptr
+
+fn local_score() int {
+	mut direct := [4]int{}
+	direct[0] = 1
+	mut wrapped := unsafe { [4]int{} }
+	wrapped[1] = 2
+	mut handles := unsafe { [32]Handle{} }
+	handles[0] = voidptr(0)
+	mut nested := unsafe { [2][3]int{} }
+	nested[1][2] = 3
+	handle_score := if handles[0] == voidptr(0) { 4 } else { 0 }
+	return direct[0] + wrapped[1] + nested[1][2] + handle_score
+}
+
+fn main() {
+	println(int_str(local_score()))
+}
+') or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_fixed_array_local_zero_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '10'
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	assert generated.contains('int direct[4] = {0};'), generated
+	assert generated.contains('int wrapped[4] = {0};'), generated
+	assert generated.contains('handles[32] = {0};'), generated
+	assert generated.contains('int nested[2][3] = {0};'), generated
+	assert !generated.contains(' = (Array_fixed_'), generated
+	assert !generated.contains('Array_fixed_voidptr_32 handles'), generated
+}

--- a/vlib/v3/tests/fixed_array_multi_return_codegen_test.v
+++ b/vlib/v3/tests/fixed_array_multi_return_codegen_test.v
@@ -1,0 +1,106 @@
+import os
+
+const fixed_array_multi_vexe = @VEXE
+const fixed_array_multi_tests_dir = os.dir(@FILE)
+const fixed_array_multi_v3_dir = os.dir(fixed_array_multi_tests_dir)
+const fixed_array_multi_vlib_dir = os.dir(fixed_array_multi_v3_dir)
+const fixed_array_multi_v3_src = os.join_path(fixed_array_multi_v3_dir, 'v3.v')
+
+fn fixed_array_multi_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_fixed_array_multi_return_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${fixed_array_multi_vexe} -gc none -path "${fixed_array_multi_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${fixed_array_multi_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn compact_c_whitespace(s string) string {
+	return s.replace('\t', '').replace(' ', '').replace('\n', '')
+}
+
+fn has_fixed_array_memmove_copy(compact string, name string) bool {
+	start := compact.index('memmove(${name},') or { return false }
+	end := compact[start..].index(');') or { return false }
+	fragment := compact[start..start + end]
+	return fragment.contains('sizeof(${name})')
+}
+
+fn has_fixed_array_assignment(compact string, typ string, name string) bool {
+	return compact.contains('${typ}${name}=')
+}
+
+fn test_fixed_array_multi_return_payloads_use_c_arrays_and_memmove() {
+	v3_bin := fixed_array_multi_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_fixed_array_multi_return_${os.getpid()}.v')
+	os.write_file(src, 'module main
+
+fn pair() (int, [3]int) {
+	mut xs := [3]int{}
+	xs[0] = 1
+	xs[1] = 2
+	xs[2] = 3
+	return 7, xs
+}
+
+fn literal_pair() ([3]int, int) {
+	mut zs := [3]int{}
+	zs[0] = 4
+	zs[1] = 5
+	zs[2] = 6
+	return zs, 9
+}
+
+fn defer_pair() (int, [2]int) {
+	defer {
+		_ := 0
+	}
+	mut ds := [2]int{}
+	ds[0] = 8
+	ds[1] = 9
+	return 11, ds
+}
+
+fn main() {
+	n, xs := pair()
+	assert n == 7
+	assert xs[0] == 1
+	assert xs[2] == 3
+	mut m := 0
+	mut ys := [3]int{}
+	m, ys = pair()
+	assert m == 7
+	assert ys[1] == 2
+	zs, q := literal_pair()
+	assert q == 9
+	assert zs[2] == 6
+	d, ds := defer_pair()
+	assert d == 11
+	assert ds[1] == 9
+	println(int_str(n + xs[1] + m + ys[2] + q + zs[0] + d + ds[1]))
+}
+') or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_fixed_array_multi_return_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '52'
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	assert generated.contains('int xs[3];'), generated
+	assert generated.contains('int ys[3] = {0};'), generated
+	assert generated.contains('int zs[3];'), generated
+	assert generated.contains('int ds[2];'), generated
+	compact := compact_c_whitespace(generated)
+	assert has_fixed_array_memmove_copy(compact, 'xs'), generated
+	assert has_fixed_array_memmove_copy(compact, 'ys'), generated
+	assert has_fixed_array_memmove_copy(compact, 'zs'), generated
+	assert has_fixed_array_memmove_copy(compact, 'ds'), generated
+	assert !has_fixed_array_assignment(compact, 'Array_fixed_int_3', 'xs'), generated
+	assert !has_fixed_array_assignment(compact, 'Array_fixed_int_3', 'ys'), generated
+	assert !has_fixed_array_assignment(compact, 'Array_fixed_int_3', 'zs'), generated
+	assert !has_fixed_array_assignment(compact, 'Array_fixed_int_2', 'ds'), generated
+	assert !generated.contains('return (multi_return_int_Array_fixed_int_3){7, xs};'), generated
+}

--- a/vlib/v3/tests/fixed_array_typedef_codegen_test.v
+++ b/vlib/v3/tests/fixed_array_typedef_codegen_test.v
@@ -1,0 +1,114 @@
+import os
+
+const fixed_array_vexe = @VEXE
+const fixed_array_tests_dir = os.dir(@FILE)
+const fixed_array_v3_dir = os.dir(fixed_array_tests_dir)
+const fixed_array_vlib_dir = os.dir(fixed_array_v3_dir)
+const fixed_array_v3_src = os.join_path(fixed_array_v3_dir, 'v3.v')
+
+fn fixed_array_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_fixed_array_typedef_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${fixed_array_vexe} -gc none -path "${fixed_array_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${fixed_array_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn fixed_array_write_project(name string, fixture_src string, main_src string) string {
+	root := os.join_path(os.temp_dir(), 'v3_fixed_array_typedef_${name}_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	fixture_dir := os.join_path(root, 'fixture')
+	os.mkdir_all(fixture_dir) or { panic(err) }
+	os.write_file(os.join_path(fixture_dir, 'arrays.c.v'), fixture_src) or { panic(err) }
+	os.write_file(os.join_path(root, 'main.v'), main_src) or { panic(err) }
+	return root
+}
+
+fn test_fixed_array_typedefs_fold_module_const_lengths() {
+	v3_bin := fixed_array_build_v3()
+
+	run_root := fixed_array_write_project('run', 'module fixture
+
+const max_items = 8
+const rows = 6
+const cols = 16
+
+pub struct Widget {
+mut:
+	images [max_items]int
+}
+
+pub struct Nested {
+mut:
+	cells [rows][cols]int
+}
+
+pub fn score() int {
+	mut w := Widget{}
+	mut n := Nested{}
+	w.images[0] = 3
+	n.cells[1][2] = 5
+	return w.images[0] + n.cells[1][2]
+}
+', 'module main
+
+import fixture
+
+fn main() {
+	println(int_str(fixture.score()))
+}
+')
+	run_bin := os.join_path(run_root, 'out')
+	run_compile := os.execute('${v3_bin} ${run_root} -b c -o ${run_bin}')
+	assert run_compile.exit_code == 0, run_compile.output
+	run_c := os.read_file(run_bin + '.c') or { panic(err) }
+	assert !run_c.contains('[max_items]'), run_c
+	assert !run_c.contains('[rows]'), run_c
+	assert !run_c.contains('[cols]'), run_c
+	assert run_c.contains('images[8]'), run_c
+	assert run_c.contains('cells[6][16]'), run_c
+	run := os.execute(run_bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '8'
+
+	shape_root := fixed_array_write_project('shape', 'module fixture
+
+const max_items = 8
+const rows = 6
+const cols = 16
+
+pub struct C.Widget {
+pub mut:
+	images [max_items]int
+}
+
+pub struct Nested {
+mut:
+	cells [rows][cols]int
+}
+
+pub fn shape_score() int {
+	mut n := Nested{}
+	n.cells[1][2] = 5
+	return n.cells[1][2]
+}
+', 'module main
+
+import fixture
+
+fn main() {
+	println(int_str(fixture.shape_score()))
+}
+')
+	shape_c_path := os.join_path(shape_root, 'out.c')
+	shape_compile := os.execute('${v3_bin} ${shape_root} -b c -o ${shape_c_path}')
+	assert shape_compile.exit_code == 0, shape_compile.output
+	shape_c := os.read_file(shape_c_path) or { panic(err) }
+	assert !shape_c.contains('[max_items]'), shape_c
+	assert !shape_c.contains('[rows]'), shape_c
+	assert !shape_c.contains('[cols]'), shape_c
+	assert shape_c.contains('typedef int Array_fixed_int_max_items[8];'), shape_c
+	assert shape_c.contains('typedef int Array_fixed_int_cols[16];'), shape_c
+	assert shape_c.contains('typedef Array_fixed_int_cols Array_fixed_Array_fixed_int_cols_rows[6];'), shape_c
+}

--- a/vlib/v3/tests/fn_nil_context_test.v
+++ b/vlib/v3/tests/fn_nil_context_test.v
@@ -1,0 +1,157 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_fn_nil_context_test')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn run_good(v3_bin string, name string, src string) string {
+	good_src := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	os.write_file(good_src, src) or { panic(err) }
+	good_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	compile := os.execute('${v3_bin} ${good_src} -b c -o ${good_bin}')
+	assert compile.exit_code == 0, '${name}: compile failed: ${compile.output}'
+	assert !compile.output.contains('C compilation failed'), '${name}: C compilation failed: ${compile.output}'
+	run := os.execute(good_bin)
+	assert run.exit_code == 0, '${name}: run failed: ${run.output}'
+	return run.output.trim_space()
+}
+
+fn run_bad(v3_bin string, name string, src string, expected string) {
+	bad_src := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	os.write_file(bad_src, src) or { panic(err) }
+	bad_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	result := os.execute('${v3_bin} ${bad_src} -b c -o ${bad_bin}')
+	assert result.exit_code != 0
+	assert result.output.contains(expected), '${name}: missing `${expected}` in ${result.output}'
+	assert !result.output.contains('C compilation failed')
+}
+
+fn test_unsafe_nil_contextually_matches_fn_fields() {
+	v3_bin := build_v3()
+	default_out := run_good(v3_bin, 'fn_nil_default', 'struct S {
+	f fn (int) ! = unsafe { nil }
+}
+
+fn main() {
+	_ := S{}
+	println(int_str(1))
+}
+')
+	assert default_out == '1'
+	alias_out := run_good(v3_bin, 'fn_alias_nil_field_init', 'type Callback = fn (data voidptr)
+
+struct S {
+	f Callback
+}
+
+fn main() {
+	_ := S{
+		f: unsafe { nil }
+	}
+	println(int_str(2))
+}
+')
+	assert alias_out == '2'
+	run_bad(v3_bin, 'fn_field_rejects_voidptr_variable', 'struct S {
+	f fn (int) !
+}
+
+fn main() {
+	v := unsafe { nil }
+	_ := S{
+		f: v
+	}
+}
+',
+		'cannot initialize field `f` with `&void`; expected `fn(int) !void`')
+	run_bad(v3_bin, 'fn_field_rejects_non_nil_unsafe_pointer', 'struct S {
+	f fn (int) !
+}
+
+fn main() {
+	_ := S{
+		f: unsafe { &int(0) }
+	}
+}
+',
+		'cannot initialize field `f` with `&int`; expected `fn(int) !void`')
+	run_bad(v3_bin, 'fn_field_rejects_voidptr_zero', 'struct S {
+	f fn (int) !
+}
+
+fn main() {
+	_ := S{
+		f: voidptr(0)
+	}
+}
+',
+		'cannot initialize field `f` with `&void`; expected `fn(int) !void`')
+	run_bad(v3_bin, 'fn_field_rejects_integer_zero', 'struct S {
+	f fn (int) !
+}
+
+fn main() {
+	_ := S{
+		f: 0
+	}
+}
+',
+		'cannot initialize field `f` with `int`; expected `fn(int) !void`')
+	run_bad(v3_bin, 'fn_field_rejects_wrong_arity', 'fn no_args() ! {
+	return
+}
+
+struct S {
+	f fn (int) !
+}
+
+fn main() {
+	_ := S{
+		f: no_args
+	}
+}
+',
+		'cannot initialize field `f` with `fn() !void`; expected `fn(int) !void`')
+	run_bad(v3_bin, 'fn_field_rejects_wrong_return', 'fn returns_int(i int) !int {
+	return i
+}
+
+struct S {
+	f fn (int) !
+}
+
+fn main() {
+	_ := S{
+		f: returns_int
+	}
+}
+',
+		'cannot initialize field `f` with `fn(int) !int`; expected `fn(int) !void`')
+	run_bad(v3_bin, 'fn_alias_field_rejects_wrong_arity', 'type Callback = fn (int) !
+
+fn no_args() ! {
+	return
+}
+
+struct S {
+	f Callback
+}
+
+fn main() {
+	_ := S{
+		f: no_args
+	}
+}
+',
+		'cannot initialize field `f` with `fn() !void`; expected `Callback`')
+}

--- a/vlib/v3/tests/fn_value_decl_type_test.v
+++ b/vlib/v3/tests/fn_value_decl_type_test.v
@@ -1,0 +1,369 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_fn_value_decl_type_test')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn run_good(v3_bin string, name string, src string) string {
+	good_src := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	os.write_file(good_src, src) or { panic(err) }
+	good_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	compile := os.execute('${v3_bin} ${good_src} -b c -o ${good_bin}')
+	assert compile.exit_code == 0, '${name}: compile failed: ${compile.output}'
+	assert !compile.output.contains('C compilation failed'), '${name}: C compilation failed: ${compile.output}'
+	run := os.execute(good_bin)
+	assert run.exit_code == 0, '${name}: run failed: ${run.output}'
+	return run.output.trim_space()
+}
+
+fn run_bad(v3_bin string, name string, src string) string {
+	bad_src := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	os.write_file(bad_src, src) or { panic(err) }
+	bad_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	compile := os.execute('${v3_bin} ${bad_src} -b c -o ${bad_bin}')
+	assert compile.exit_code != 0, '${name}: compile unexpectedly succeeded: ${compile.output}'
+	assert !compile.output.contains('C compilation failed'), '${name}: reached C compiler: ${compile.output}'
+	return compile.output
+}
+
+fn gen_c(v3_bin string, name string, src string) string {
+	src_path := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	os.write_file(src_path, src) or { panic(err) }
+	c_path := os.join_path(os.temp_dir(), 'v3_${name}.c')
+	os.rm(c_path) or {}
+	compile := os.execute('${v3_bin} ${src_path} -b c -o ${c_path}')
+	assert compile.exit_code == 0, '${name}: C output failed: ${compile.output}'
+	assert os.exists(c_path), '${name}: missing generated C file ${c_path}'
+	return os.read_file(c_path) or { panic(err) }
+}
+
+fn write_project_file(root string, rel string, src string) {
+	path := os.join_path(root, rel)
+	os.mkdir_all(os.dir(path)) or { panic(err) }
+	os.write_file(path, src) or { panic(err) }
+}
+
+fn write_project(name string, files map[string]string) string {
+	root := os.join_path(os.temp_dir(), 'v3_${name}_project')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(root) or { panic(err) }
+	for rel, src in files {
+		write_project_file(root, rel, src)
+	}
+	return root
+}
+
+fn run_project_good(v3_bin string, name string, files map[string]string) string {
+	root := write_project(name, files)
+	good_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	main_path := os.join_path(root, 'main.v')
+	compile := os.execute('${v3_bin} ${main_path} -b c -o ${good_bin}')
+	assert compile.exit_code == 0, '${name}: compile failed: ${compile.output}'
+	assert !compile.output.contains('C compilation failed'), '${name}: C compilation failed: ${compile.output}'
+	run := os.execute(good_bin)
+	assert run.exit_code == 0, '${name}: run failed: ${run.output}'
+	return run.output.trim_space()
+}
+
+fn run_project_bad(v3_bin string, name string, files map[string]string) string {
+	root := write_project(name, files)
+	bad_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	main_path := os.join_path(root, 'main.v')
+	compile := os.execute('${v3_bin} ${main_path} -b c -o ${bad_bin}')
+	assert compile.exit_code != 0, '${name}: compile unexpectedly succeeded: ${compile.output}'
+	assert !compile.output.contains('C compilation failed'), '${name}: reached C compiler: ${compile.output}'
+	return compile.output
+}
+
+fn gen_project_c(v3_bin string, name string, files map[string]string) string {
+	root := write_project(name, files)
+	c_path := os.join_path(os.temp_dir(), 'v3_${name}.c')
+	os.rm(c_path) or {}
+	main_path := os.join_path(root, 'main.v')
+	compile := os.execute('${v3_bin} ${main_path} -b c -o ${c_path}')
+	assert compile.exit_code == 0, '${name}: C output failed: ${compile.output}'
+	assert os.exists(c_path), '${name}: missing generated C file ${c_path}'
+	return os.read_file(c_path) or { panic(err) }
+}
+
+fn imported_fn_value_project_files() map[string]string {
+	return {
+		'v.mod':           "Module { name: 'fn_value_imported' }\n"
+		'worker/worker.v': "module worker
+
+pub fn inc(i int) int {
+	return i + 1
+}
+
+pub fn dec(i int) int {
+	return i - 1
+}
+
+pub fn read_ok(i int) !int {
+	if i < 0 {
+		return error('negative')
+	}
+	return i + 40
+}
+
+pub fn read_other(i int) !int {
+	return i + 50
+}
+"
+		'main.v':          "module main
+
+import worker
+
+fn inc(i int) int {
+	return i + 1000
+}
+
+struct S {
+	inc int
+}
+
+fn read_from_local() !int {
+	mut loader := worker.read_ok
+	assert loader(2)! == 42
+	loader = worker.read_other
+	return loader(2)!
+}
+
+fn main() {
+	mut f := worker.inc
+	assert f(4) == 5
+	f = worker.dec
+	assert f(4) == 3
+	assert inc(1) == 1001
+	got := read_from_local() or { -1 }
+	assert got == 52
+	worker := S{
+		inc: 7
+	}
+	local_f := worker.inc
+	assert local_f == 7
+	println('imported-ok')
+}
+"
+	}
+}
+
+fn imported_fn_value_expected_shadow_project_files() map[string]string {
+	return {
+		'v.mod':           "Module { name: 'fn_value_expected_shadow' }\n"
+		'worker/worker.v': 'module worker
+
+pub fn inc(i int) int {
+	return i + 1
+}
+'
+		'main.v':          'module main
+
+import worker
+
+struct Holder {
+	inc int
+}
+
+fn take(f fn (int) int) int {
+	return f(4)
+}
+
+fn main() {
+	worker := Holder{
+		inc: 7
+	}
+	got := take(worker.inc)
+	println(int_str(got))
+}
+'
+	}
+}
+
+const optional_fn_src = "fn main() {
+	f := fn (i int) ! {
+		if i == 0 {
+			return error('zero')
+		}
+		return
+	}
+	f(0) or {
+		println('optional-ok')
+		return
+	}
+	println('optional-bad')
+}
+"
+
+const plain_fn_src = 'fn main() {
+	f := fn (i int) int {
+		return i + 2
+	}
+	println(int_str(f(5)))
+	}
+'
+
+const local_ident_expected_shadow_src = 'fn foo() int {
+	return 1
+}
+
+fn take(f fn () int) int {
+	return f()
+}
+
+fn main() {
+	foo := 10
+	got := take(foo)
+	println(int_str(got))
+}
+'
+
+const assignment_expected_shadow_src = 'fn foo(i int) int {
+	return i + 1
+}
+
+fn bar(i int) int {
+	return i + 2
+}
+
+fn main() {
+	mut f := bar
+	foo := 10
+	f = foo
+}
+'
+
+const callback_arg_expected_shadow_src = 'fn foo(i int) int {
+	return i + 1
+}
+
+fn call(f fn (int) int) int {
+	return f(1)
+}
+
+fn main() {
+	foo := 10
+	call(foo)
+}
+'
+
+const struct_field_expected_shadow_src = 'fn foo(i int) int {
+	return i + 1
+}
+
+struct S {
+	f fn (int) int
+}
+
+fn main() {
+	foo := 10
+	s := S{
+		f: foo
+	}
+	_ = s
+}
+'
+
+const local_ident_shadow_src = 'fn foo() int {
+	return 1
+}
+
+fn main() {
+	foo := 10
+	f := foo
+	println(int_str(f))
+}
+'
+
+fn test_local_fn_literal_decl_types_are_callable() {
+	v3_bin := build_v3()
+	assert run_good(v3_bin, 'fn_value_optional_void_local', optional_fn_src) == 'optional-ok'
+	assert run_good(v3_bin, 'fn_value_plain_int_local', plain_fn_src) == '7'
+	assert run_good(v3_bin, 'fn_value_local_ident_shadow', local_ident_shadow_src) == '10'
+	assert run_good(v3_bin, 'fn_value_named_local', 'fn add_one(i int) int {
+	return i + 1
+}
+
+fn main() {
+	f := add_one
+	println(int_str(f(6)))
+}
+') == '7'
+	assert run_good(v3_bin, 'fn_value_struct_field', 'struct S {
+	f fn (int) int
+}
+
+fn main() {
+	s := S{
+		f: fn (i int) int {
+			return i + 3
+		}
+	}
+	println(int_str(s.f(4)))
+}
+') == '7'
+	assert run_project_good(v3_bin, 'fn_value_imported_selector_local',
+		imported_fn_value_project_files()) == 'imported-ok'
+}
+
+fn test_fn_value_expected_context_respects_value_shadowing() {
+	v3_bin := build_v3()
+	ident_output := run_bad(v3_bin, 'fn_value_expected_ident_shadow',
+		local_ident_expected_shadow_src)
+	assert !ident_output.contains('main__foo'), ident_output
+	selector_output := run_project_bad(v3_bin, 'fn_value_expected_import_shadow',
+		imported_fn_value_expected_shadow_project_files())
+	assert !selector_output.contains('worker__inc'), selector_output
+	assign_output := run_bad(v3_bin, 'fn_value_expected_assignment_shadow',
+		assignment_expected_shadow_src)
+	assert !assign_output.contains('main__foo'), assign_output
+	callback_output := run_bad(v3_bin, 'fn_value_expected_callback_shadow',
+		callback_arg_expected_shadow_src)
+	assert !callback_output.contains('main__foo'), callback_output
+	struct_output := run_bad(v3_bin, 'fn_value_expected_struct_field_shadow',
+		struct_field_expected_shadow_src)
+	assert !struct_output.contains('main__foo'), struct_output
+}
+
+fn test_local_fn_literal_decl_generates_fn_pointer_locals() {
+	v3_bin := build_v3()
+	optional_c := gen_c(v3_bin, 'fn_value_optional_void_local_c', optional_fn_src)
+	assert !optional_c.contains('Optional f = __anon_fn'), optional_c
+	assert !optional_c.contains('int f = __anon_fn'), optional_c
+	assert optional_c.contains('typedef struct Optional (*_fn_ptr_'), optional_c
+	assert optional_c.contains(' f = __anon_fn_'), optional_c
+
+	plain_c := gen_c(v3_bin, 'fn_value_plain_int_local_c', plain_fn_src)
+	assert !plain_c.contains('Optional f = __anon_fn'), plain_c
+	assert !plain_c.contains('int f = __anon_fn'), plain_c
+	assert plain_c.contains('typedef int (*_fn_ptr_'), plain_c
+	assert plain_c.contains(' f = __anon_fn_'), plain_c
+
+	shadow_c := gen_c(v3_bin, 'fn_value_local_ident_shadow_c', local_ident_shadow_src)
+	assert shadow_c.contains('int foo = 10'), shadow_c
+	assert shadow_c.contains('int f = foo'), shadow_c
+
+	imported_c := gen_project_c(v3_bin, 'fn_value_imported_selector_local_c',
+		imported_fn_value_project_files())
+	assert !imported_c.contains('int f = worker__inc'), imported_c
+	assert !imported_c.contains('int loader = worker__read_ok'), imported_c
+	assert !imported_c.contains(' f = main__inc'), imported_c
+	assert imported_c.contains('int local_f = worker.inc'), imported_c
+	assert imported_c.contains('typedef int (*_fn_ptr_'), imported_c
+	assert imported_c.contains(' f = worker__inc'), imported_c
+	assert imported_c.contains('f = worker__dec'), imported_c
+	assert imported_c.contains(' loader = worker__read_ok'), imported_c
+	assert imported_c.contains('loader = worker__read_other'), imported_c
+}

--- a/vlib/v3/tests/generic_rhs_decl_type_codegen_test.v
+++ b/vlib/v3/tests/generic_rhs_decl_type_codegen_test.v
@@ -1,0 +1,129 @@
+import os
+
+const generic_rhs_vexe = @VEXE
+const generic_rhs_tests_dir = os.dir(@FILE)
+const generic_rhs_v3_dir = os.dir(generic_rhs_tests_dir)
+const generic_rhs_vlib_dir = os.dir(generic_rhs_v3_dir)
+const generic_rhs_v3_src = os.join_path(generic_rhs_v3_dir, 'v3.v')
+
+fn generic_rhs_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_generic_rhs_decl_type_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${generic_rhs_vexe} -gc none -path "${generic_rhs_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${generic_rhs_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn generic_rhs_write_project() string {
+	root := os.join_path(os.temp_dir(), 'v3_generic_rhs_decl_type_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(os.join_path(root, 'gm')) or { panic(err) }
+	os.write_file(os.join_path(root, 'v.mod'), "Module { name: 'generic_rhs_decl_type' }\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'gm/gm.v'), 'module gm
+
+pub fn pick[T](x T) T {
+	return x
+}
+
+pub fn max2[T](a T, b T) T {
+	if a > b {
+		return a
+	}
+	return b
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'main.v'), "module main
+
+import gm
+
+fn pick(a i32) i32 {
+	return i32(-100)
+}
+
+fn single_decl(x i32, y i32) i32 {
+	a := gm.pick(x)
+	return gm.max2(a, y)
+}
+
+fn multi_decl(x i32, y i32) i32 {
+	a, b := gm.pick(x), gm.pick(y)
+	return gm.max2(a, b)
+}
+
+fn condition_use(x i32, y i32) i32 {
+	a, b := gm.pick(x), gm.pick(y)
+	if gm.max2(a, b) > i32(0) {
+		return gm.max2(a, b)
+	}
+	return i32(0)
+}
+
+fn if_expr_use(x i32, y i32) i32 {
+	a, b := gm.pick(x), gm.pick(y)
+	return if gm.max2(a, b) > i32(4) {
+		gm.max2(a, b)
+	} else {
+		gm.pick(i32(4))
+	}
+}
+
+fn local_homonym(x i32) i32 {
+	a := gm.pick(x)
+	return pick(a)
+}
+
+fn f64_decl(f f64, y f64) f64 {
+	a, b := gm.pick(f), gm.pick(y)
+	return gm.max2(a, b)
+}
+
+fn ptr_unrelated(x &u8) &u8 {
+	p := gm.pick(x)
+	return p
+}
+
+fn string_unrelated(f string) string {
+	return f
+}
+
+fn main() {
+	total := single_decl(i32(3), i32(5)) + multi_decl(i32(3), i32(5)) + condition_use(i32(3),
+		i32(5)) + if_expr_use(i32(3), i32(5)) + local_homonym(i32(3))
+	assert f64_decl(1.25, 2.5) == 2.5
+	mut byte := u8(7)
+	_ := ptr_unrelated(&byte)
+	assert string_unrelated('ok') == 'ok'
+	println(int_str(int(total)))
+}
+") or {
+		panic(err)
+	}
+	return os.join_path(root, 'main.v')
+}
+
+fn test_generic_rhs_decl_types_specialize_later_generic_calls() {
+	v3_bin := generic_rhs_build_v3()
+	main_path := generic_rhs_write_project()
+	out := os.join_path(os.temp_dir(), 'v3_generic_rhs_decl_type_out_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${main_path} -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '-80'
+	generated := os.read_file(out + '.c') or { panic(err) }
+	assert generated.contains('gm__pick_T_i32'), generated
+	assert generated.contains('gm__max2_T_i32'), generated
+	assert generated.contains('gm__pick_T_f64'), generated
+	assert generated.contains('gm__max2_T_f64'), generated
+	assert !generated.contains('gm__pick('), generated
+	assert !generated.contains('gm__max2('), generated
+	assert !generated.contains('gm__max2_T_ptr_u8(&x)'), generated
+	assert !generated.contains('gm__max2_T_string(f)'), generated
+	assert !generated.contains('gm__max2_T_v_int(x)'), generated
+	assert generated.contains('return pick(a);'), generated
+}

--- a/vlib/v3/tests/generics_test.v
+++ b/vlib/v3/tests/generics_test.v
@@ -3,13 +3,14 @@ import os
 const vexe = @VEXE
 const tests_dir = os.dir(@FILE)
 const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
 const v3_src = os.join_path(v3_dir, 'v3.v')
 
 // build_v3 builds v3 data for v3 tests.
 fn build_v3() string {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_generics_test')
-	build := os.execute('${vexe} -o ${v3_bin} ${v3_src}')
-	assert build.exit_code == 0
+	build := os.execute('${vexe} -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
 	return v3_bin
 }
 
@@ -72,6 +73,17 @@ fn run_generic_ok(v3_bin string, name string, src string, expected string) {
 	if expected.len > 0 {
 		assert c_content.len > 0, '${name}: empty C file'
 	}
+}
+
+fn run_generic_exec(v3_bin string, name string, src string) string {
+	src_file := os.join_path(os.temp_dir(), 'v3_gen_${name}.v')
+	os.write_file(src_file, src) or { panic(err) }
+	bin_file := os.join_path(os.temp_dir(), 'v3_gen_${name}')
+	compile := os.execute('${v3_bin} ${src_file} -b c -o ${bin_file}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin_file)
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
 }
 
 // test_generics_rejected_when_building_v validates this v3 regression case.
@@ -409,4 +421,20 @@ fn main() {
 }
 ',
 		'3')
+
+	selector_convert_out := run_generic_exec(v3_bin, 'selector_method_arg_infer', '
+struct Box[T] {
+	value T
+}
+
+fn (b Box[T]) convert[U](value U) U {
+	return value
+}
+
+fn main() {
+	b := Box[int]{value: 1}
+	println(b.convert("ok"))
+}
+')
+	assert selector_convert_out == 'ok'
 }

--- a/vlib/v3/tests/gettid_libc_compat_codegen_test.v
+++ b/vlib/v3/tests/gettid_libc_compat_codegen_test.v
@@ -1,0 +1,47 @@
+import os
+
+const gettid_compat_vexe = @VEXE
+const gettid_compat_tests_dir = os.dir(@FILE)
+const gettid_compat_v3_dir = os.dir(gettid_compat_tests_dir)
+const gettid_compat_vlib_dir = os.dir(gettid_compat_v3_dir)
+const gettid_compat_v3_src = os.join_path(gettid_compat_v3_dir, 'v3.v')
+
+fn gettid_compat_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_gettid_compat_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${gettid_compat_vexe} -gc none -path "${gettid_compat_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${gettid_compat_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn test_v_gettid_uses_declared_libc_compat_helper() {
+	$if !linux {
+		return
+	}
+	v3_bin := gettid_compat_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_gettid_compat_${os.getpid()}.v')
+	bin := os.join_path(os.temp_dir(), 'v3_gettid_compat_${os.getpid()}')
+	os.write_file(src, 'module main
+
+#flag -Werror=implicit-function-declaration
+
+fn main() {
+	println(v_gettid().str())
+}
+') or {
+		panic(err)
+	}
+	os.rm(bin) or {}
+	os.rm(bin + '.c') or {}
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('implicit declaration'), compile.output
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	assert generated.contains('static inline u32 v3_gettid(void)'), generated
+	assert generated.contains('syscall(SYS_gettid)'), generated
+	assert !generated.contains(' gettid('), generated
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space().len > 0, run.output
+}

--- a/vlib/v3/tests/ierror_str_codegen_test.v
+++ b/vlib/v3/tests/ierror_str_codegen_test.v
@@ -1,0 +1,62 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn test_ierror_str_uses_builtin_formatter() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_ierror_str_codegen_test')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_ierror_str_codegen_input.v')
+	os.write_file(src, "fn fail_code(code int) !int {
+	return error_with_code('hi', code)
+}
+
+fn fail_zero() !int {
+	return error_with_code('hi', 0)
+}
+
+fn render(err IError) string {
+	return err.str()
+}
+
+fn main() {
+	fail_code(137) or {
+		assert err.str() == 'hi; code: 137'
+		assert err.msg() == 'hi'
+		assert err.code() == 137
+		assert render(err) == 'hi; code: 137'
+	}
+	fail_zero() or {
+		assert err.str() == 'hi'
+		assert err.msg() == 'hi'
+		assert err.code() == 0
+		assert render(err) == 'hi'
+	}
+	println('ok')
+}
+") or {
+		panic(err)
+	}
+
+	bin := os.join_path(os.temp_dir(), 'v3_ierror_str_codegen_input')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+
+	c_code := os.read_file(bin + '.c') or { panic(err) }
+	assert c_code.contains('IError__str(err)'), c_code
+	assert c_code.contains('return IError__str(err);'), c_code
+	assert !c_code.contains('string__eq(err.message'), c_code
+	assert c_code.contains('IError__msg(&err)'), c_code
+	assert c_code.contains('err.code'), c_code
+
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok'
+}

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -531,6 +531,57 @@ fn test_reachable_main_fn_literal_is_emitted_after_used_filter_transform() {
 	assert c_code.contains('callback_value(__anon_fn_')
 }
 
+fn test_top_level_fn_value_roots_helper() {
+	mut a, mut tc := parse_checked_source('top_level_fn_value_helper_cgen',
+		'module main\n\nfn helper() int {\n\treturn 41\n}\n\nf := helper\nprintln(int_str(f() + 1))\n')
+	mut used := markused.mark_used(a, tc)
+	assert used['helper']
+	used = transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('helper(')
+}
+
+fn test_top_level_fn_value_compile_keeps_helper() {
+	v3_bin := build_v3_bin('top_level_fn_value_test')
+
+	src := os.join_path(os.temp_dir(), 'v3_markused_top_level_fn_value_input.v')
+	bin := os.join_path(os.temp_dir(), 'v3_markused_top_level_fn_value_input')
+	os.write_file(src, '
+fn helper() int {
+	return 41
+}
+
+f := helper
+println(int_str(f() + 1))
+') or {
+		panic(err)
+	}
+	compile := os.execute('${v3_bin} -o ${bin} ${src}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '42'
+	c_code := os.read_file(bin + '.c') or { panic(err) }
+	assert c_code.contains('helper('), c_code
+}
+
+fn test_top_level_fn_value_respects_prior_local_shadow() {
+	used := mark_used_source('top_level_fn_value_prior_shadow', '
+fn helper() int {
+	return 1
+}
+
+helper := 10
+f := helper
+println(int_str(f))
+')
+	assert !used['helper']
+}
+
 fn test_flag_default_value_lowering_keeps_escape_helper() {
 	mut a, mut tc := parse_checked_source('flag_default_value_escape_helper_cgen',
 		'module main\n\nfn escape_default_string(value string) string {\n\treturn value\n}\n\nfn flag_default_value(value string) string {\n\treturn value\n}\n\nfn main() {\n\t_ := flag_default_value("abc")\n}\n')

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -318,6 +318,7 @@ fn (r Remote) read(path string) string {
 	mut used := markused.mark_used(a, tc)
 	assert used['Reader.read']
 	assert !used['moda.Reader.read']
+	assert !used['moda.Remote.read']
 	used = transform.transform_with_used(mut a, tc, used)
 	tc.diagnose_unknown_calls = false
 	tc.reject_unlowered_map_mutation = true
@@ -326,6 +327,144 @@ fn (r Remote) read(path string) string {
 	c_code := g.gen_with_used_options(a, used, tc, true)
 	assert c_code.contains('Reader__read(')
 	assert !c_code.contains('moda__Reader__read(')
+}
+
+fn test_local_receiver_method_does_not_root_imported_interface_by_short_name() {
+	mut a, mut tc := parse_checked_project('local_receiver_imported_interface_short_name', {
+		'main.v':      'module main
+
+import moda
+
+struct Reader {}
+
+fn (r Reader) read() int {
+	return 1
+}
+
+fn main() {
+	_ := Reader{}.read()
+}
+'
+		'moda/moda.v': 'module moda
+
+pub interface Reader {
+	read() int
+}
+
+pub struct Remote {}
+
+pub fn (r Remote) read() int {
+	return 2
+}
+'
+	}, 'main.v')
+	mut used := markused.mark_used(a, tc)
+	assert used['Reader.read']
+	assert !used['moda.Reader.read']
+	assert !used['moda.Remote.read']
+	used = transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('Reader__read(')
+	assert !c_code.contains('moda__Reader__read(')
+	assert !c_code.contains('moda__Remote__read(')
+}
+
+fn test_imported_interface_dispatch_is_emitted_when_exactly_used() {
+	mut a, mut tc := parse_checked_project('imported_interface_dispatch_used', {
+		'main.v':      'module main
+
+import moda
+
+fn call_reader(r moda.Reader) string {
+	return r.read("ok")
+}
+
+fn main() {
+	_ := call_reader(moda.Remote{})
+}
+'
+		'moda/moda.v': 'module moda
+
+pub interface Reader {
+	read(path string) string
+}
+
+pub struct Remote {}
+
+pub fn (r Remote) read(path string) string {
+	return path
+}
+'
+	}, 'main.v')
+	mut used := markused.mark_used(a, tc)
+	assert used['moda.Reader.read']
+	assert used['moda.Remote.read']
+	used = transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('moda__Reader__read(')
+	assert c_code.contains('moda__Remote__read(')
+}
+
+fn test_interface_dispatch_target_does_not_use_bare_method_key_for_imported_homonym() {
+	mut a, mut tc := parse_checked_project('interface_dispatch_target_homonym', {
+		'main.v':      'module main
+
+import moda
+
+interface Reader {
+	read() int
+}
+
+struct Local {}
+
+fn (l Local) read() int {
+	return 1
+}
+
+fn read() int {
+	return 9
+}
+
+fn call_reader(r Reader) int {
+	return r.read()
+}
+
+fn main() {
+	_ := read()
+	_ := call_reader(Local{})
+}
+'
+		'moda/moda.v': 'module moda
+
+pub struct Remote {}
+
+pub fn (r Remote) read() int {
+	return 2
+}
+'
+	}, 'main.v')
+	mut used := markused.mark_used(a, tc)
+	assert used['read']
+	assert used['Reader.read']
+	used.delete('moda.Remote.read')
+	used.delete('Remote.read')
+	used.delete('moda__Remote__read')
+	used = transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('Reader__read(')
+	assert !c_code.contains('moda__Remote__read(')
 }
 
 fn test_unused_main_method_with_interface_dispatch_is_pruned_with_stub() {

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -584,6 +584,25 @@ println(int_str(f))
 	assert !used['helper']
 }
 
+fn test_local_fn_value_keeps_helper_before_future_local_shadow() {
+	used := mark_used_source('local_fn_value_future_shadow', '
+fn cb() int {
+	return 1
+}
+
+fn takes(f fn () int) int {
+	return f()
+}
+
+fn main() {
+	takes(cb)
+	cb := 0
+	_ = cb
+}
+')
+	assert used['cb']
+}
+
 fn test_local_ident_reference_does_not_root_dead_function() {
 	mut a, mut tc := parse_checked_source('local_ident_shadow_dead_fn_cgen', '
 fn C.v3_dead_local_shadow_should_not_link() int

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -65,6 +65,30 @@ fn parse_checked_project(name string, files map[string]string, main_file string)
 	return a, &tc
 }
 
+fn parse_checked_project_in_order(name string, rels []string, sources []string) (&flat.FlatAst, &types.TypeChecker) {
+	root := os.join_path(os.temp_dir(), 'v3_markused_${name}')
+	os.rmdir_all(root) or {}
+	mut paths := []string{}
+	for i, rel in rels {
+		path := os.join_path(root, rel)
+		os.mkdir_all(os.dir(path)) or { panic(err) }
+		os.write_file(path, sources[i]) or { panic(err) }
+		paths << path
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_files(paths)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.diagnose_unknown_calls = true
+	for path in paths {
+		tc.diagnostic_files[path] = true
+	}
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	return a, &tc
+}
+
 // mark_used_source updates mark used source state for v3 tests.
 fn mark_used_source(name string, source string) map[string]bool {
 	a, tc := parse_checked_source(name, source)
@@ -162,6 +186,24 @@ fn main() {
 }
 ')
 	assert used['string__plus']
+}
+
+fn test_moduleless_export_after_module_file_is_rooted() {
+	a, tc := parse_checked_project_in_order('moduleless_export_after_module', [
+		'helper/helper.v',
+		'lonely.v',
+	], ['module helper
+
+pub fn helper_marker() int {
+	return 1
+}
+', "@[export: 'raw_lonely']
+fn lonely() int {
+	return 7
+}
+"])
+	used := markused.mark_used(a, tc)
+	assert used['lonely']
 }
 
 fn test_receiver_method_call_in_selector_assign_rhs_is_used() {

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -10,6 +10,7 @@ import v3.types
 const vexe = @VEXE
 const tests_dir = os.dir(@FILE)
 const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
 const v3_src = os.join_path(v3_dir, 'v3.v')
 
 // parse_checked_source reads parse checked source input for v3 tests.
@@ -73,7 +74,8 @@ fn mark_used_source(name string, source string) map[string]bool {
 // build_v3_bin builds v3 bin data for v3 tests.
 fn build_v3_bin(name string) string {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_markused_${name}')
-	build := os.execute('${vexe} -o ${v3_bin} ${v3_src}')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0, build.output
 	return v3_bin
 }

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -584,6 +584,68 @@ println(int_str(f))
 	assert !used['helper']
 }
 
+fn test_local_ident_reference_does_not_root_dead_function() {
+	mut a, mut tc := parse_checked_source('local_ident_shadow_dead_fn_cgen', '
+fn C.v3_dead_local_shadow_should_not_link() int
+
+fn unused() int {
+	return C.v3_dead_local_shadow_should_not_link()
+}
+
+fn echo(unused int) int {
+	println(unused)
+	return unused
+}
+
+fn main() {
+	unused := 1
+	println(unused)
+	_ := echo(unused)
+}
+')
+	mut used := markused.mark_used(a, tc)
+	assert !used['unused']
+	used = transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert !c_code.contains('unused('), c_code
+	assert !c_code.contains('v3_dead_local_shadow_should_not_link'), c_code
+}
+
+fn test_local_fn_value_call_does_not_root_shadowed_dead_function() {
+	mut a, mut tc := parse_checked_source('local_fn_value_shadow_dead_fn_cgen', '
+fn C.v3_dead_local_fn_value_shadow_should_not_link() int
+
+fn unused() int {
+	return C.v3_dead_local_fn_value_shadow_should_not_link()
+}
+
+fn used() int {
+	return 7
+}
+
+fn main() {
+	unused := used
+	println(unused())
+}
+')
+	mut used := markused.mark_used(a, tc)
+	assert used['used']
+	assert !used['unused']
+	used = transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('used('), c_code
+	assert !c_code.contains('int unused(void)'), c_code
+	assert !c_code.contains('v3_dead_local_fn_value_shadow_should_not_link'), c_code
+}
+
 fn test_flag_default_value_lowering_keeps_escape_helper() {
 	mut a, mut tc := parse_checked_source('flag_default_value_escape_helper_cgen',
 		'module main\n\nfn escape_default_string(value string) string {\n\treturn value\n}\n\nfn flag_default_value(value string) string {\n\treturn value\n}\n\nfn main() {\n\t_ := flag_default_value("abc")\n}\n')

--- a/vlib/v3/tests/markused_typed_receiver_codegen_test.v
+++ b/vlib/v3/tests/markused_typed_receiver_codegen_test.v
@@ -1,0 +1,240 @@
+import os
+import v3.markused
+import v3.parser
+import v3.pref
+import v3.types
+
+const typed_receiver_vexe = @VEXE
+const typed_receiver_tests_dir = os.dir(@FILE)
+const typed_receiver_v3_dir = os.dir(typed_receiver_tests_dir)
+const typed_receiver_vlib_dir = os.dir(typed_receiver_v3_dir)
+const typed_receiver_v3_src = os.join_path(typed_receiver_v3_dir, 'v3.v')
+
+fn typed_receiver_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_markused_typed_receiver_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${typed_receiver_vexe} -gc none -path "${typed_receiver_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${typed_receiver_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn typed_receiver_write_project() string {
+	root := os.join_path(os.temp_dir(), 'v3_markused_typed_receiver_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(os.join_path(root, 'seriesmod')) or { panic(err) }
+	os.mkdir_all(os.join_path(root, 'othermod')) or { panic(err) }
+	os.write_file(os.join_path(root, 'v.mod'), "Module { name: 'typed_receiver_markused' }\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'seriesmod/series.v'), 'module seriesmod
+
+pub struct Series {
+pub:
+	factor int
+}
+
+pub struct LocalSeries {
+pub:
+	factor int
+}
+
+pub struct AlternateSeries {
+pub:
+	value int
+}
+
+pub const default_series = Series{
+	factor: 4
+}
+
+const shadow_series = Series{
+	factor: 9
+}
+
+pub fn run(x int) int {
+	return default_series.measure(x)
+}
+
+pub fn local_shadow() int {
+	shadow_series := LocalSeries{
+		factor: 11
+	}
+	return shadow_series.leak(1)
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'seriesmod/methods.v'), 'module seriesmod
+
+pub fn (s Series) measure(x int) int {
+	return s.factor + x
+}
+
+fn (s Series) unused(x int) int {
+	return s.factor - x
+}
+
+fn (s Series) leak(x int) int {
+	return s.factor + x + 1000
+}
+
+fn (s AlternateSeries) measure(x int) int {
+	return s.value + x + 2000
+}
+
+fn (s LocalSeries) leak(x int) int {
+	return s.factor + x
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'othermod/other.v'), 'module othermod
+
+pub struct Series {
+pub:
+	value int
+}
+
+pub fn touch() int {
+	return 5
+}
+
+pub fn (s Series) measure(x int) int {
+	return s.value + x + 100
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'main.v'), 'module main
+
+import othermod
+import seriesmod
+
+fn main() {
+	assert seriesmod.run(3) == 7
+	assert seriesmod.local_shadow() == 12
+	assert othermod.touch() == 5
+	println(int_str(seriesmod.run(1) + seriesmod.local_shadow() + othermod.touch()))
+}
+') or {
+		panic(err)
+	}
+	return os.join_path(root, 'main.v')
+}
+
+fn typed_receiver_mark_used_project(name string, files map[string]string, main_file string) map[string]bool {
+	root := os.join_path(os.temp_dir(), 'v3_markused_typed_receiver_used_${name}_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	mut paths := []string{}
+	main_path := os.join_path(root, main_file)
+	mut rel_paths := files.keys()
+	rel_paths.sort()
+	if main_file in files {
+		os.mkdir_all(os.dir(main_path)) or { panic(err) }
+		os.write_file(main_path, files[main_file]) or { panic(err) }
+		paths << main_path
+	}
+	for rel in rel_paths {
+		if rel == main_file {
+			continue
+		}
+		path := os.join_path(root, rel)
+		os.mkdir_all(os.dir(path)) or { panic(err) }
+		os.write_file(path, files[rel]) or { panic(err) }
+		paths << path
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_files(paths)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.diagnose_unknown_calls = true
+	for path in paths {
+		tc.diagnostic_files[path] = true
+	}
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	return markused.mark_used(a, tc)
+}
+
+fn test_markused_used_map_does_not_traverse_unused_homonym_method_body() {
+	used := typed_receiver_mark_used_project('homonym_secret', {
+		'main.v':             'module main
+
+import othermod
+import seriesmod
+
+fn main() {
+	_ := seriesmod.run(3)
+	_ := othermod.touch()
+}
+'
+		'seriesmod/series.v': 'module seriesmod
+
+pub struct Series {
+pub:
+	factor int
+}
+
+pub const default_series = Series{
+	factor: 4
+}
+
+pub fn run(x int) int {
+	return default_series.measure(x)
+}
+
+pub fn (s Series) measure(x int) int {
+	return s.factor + x
+}
+'
+		'othermod/other.v':   'module othermod
+
+pub struct Series {
+pub:
+	value int
+}
+
+pub fn touch() int {
+	return 5
+}
+
+struct Helper {}
+
+fn (h Helper) secret() int {
+	return 99
+}
+
+pub fn (s Series) measure(x int) int {
+	return Helper{}.secret() + s.value + x
+}
+'
+	}, 'main.v')
+	assert used['seriesmod.Series.measure'] || used['seriesmod__Series__measure'], used.str()
+	assert !used['Series.measure'], used.str()
+	assert !used['othermod.Series.measure'], used.str()
+	assert !used['othermod__Series__measure'], used.str()
+	assert !used['othermod.secret'], used.str()
+	assert !used['secret'], used.str()
+	assert !used['othermod.Helper.secret'], used.str()
+	assert !used['Helper.secret'], used.str()
+	assert !used['othermod__Helper__secret'], used.str()
+}
+
+fn test_markused_roots_exact_typed_const_receiver_method() {
+	v3_bin := typed_receiver_build_v3()
+	main_path := typed_receiver_write_project()
+	out := os.join_path(os.temp_dir(), 'v3_markused_typed_receiver_out_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${main_path} -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '22'
+	generated := os.read_file(out + '.c') or { panic(err) }
+	assert generated.contains('seriesmod__Series__measure'), generated
+	assert generated.contains('seriesmod__LocalSeries__leak'), generated
+	assert !generated.contains('seriesmod__Series__unused'), generated
+	assert !generated.contains('seriesmod__Series__leak'), generated
+	assert !generated.contains('seriesmod__AlternateSeries__measure'), generated
+}

--- a/vlib/v3/tests/mini_calculator_markused_codegen_test.v
+++ b/vlib/v3/tests/mini_calculator_markused_codegen_test.v
@@ -1,0 +1,307 @@
+import os
+
+const mini_calc_vexe = @VEXE
+const mini_calc_tests_dir = os.dir(@FILE)
+const mini_calc_v3_dir = os.dir(mini_calc_tests_dir)
+const mini_calc_vlib_dir = os.dir(mini_calc_v3_dir)
+const mini_calc_v3_src = os.join_path(mini_calc_v3_dir, 'v3.v')
+const mini_calc_repo_root = os.dir(mini_calc_vlib_dir)
+
+fn mini_calc_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_mini_calc_markused_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${mini_calc_vexe} -gc none -path "${mini_calc_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${mini_calc_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn mini_calc_write_file(root string, rel string, src string) {
+	path := os.join_path(root, rel)
+	os.mkdir_all(os.dir(path)) or { panic(err) }
+	os.write_file(path, src) or { panic(err) }
+}
+
+fn mini_calc_compile_run(v3_bin string, name string, files map[string]string, main_file string) (string, string) {
+	root := os.join_path(os.temp_dir(), 'v3_mini_calc_markused_${name}_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	mini_calc_write_file(root, 'v.mod', "Module { name: 'mini_calc_markused' }\n")
+	for rel, src in files {
+		mini_calc_write_file(root, rel, src)
+	}
+	main_path := os.join_path(root, main_file)
+	bin := os.join_path(root, 'out')
+	compile := os.execute('${v3_bin} ${main_path} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	return run.output.trim_space(), generated
+}
+
+fn mini_calc_compile_bad(v3_bin string, name string, files map[string]string, main_file string) string {
+	root := os.join_path(os.temp_dir(), 'v3_mini_calc_markused_bad_${name}_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	mini_calc_write_file(root, 'v.mod', "Module { name: 'mini_calc_markused_bad' }\n")
+	for rel, src in files {
+		mini_calc_write_file(root, rel, src)
+	}
+	main_path := os.join_path(root, main_file)
+	bin := os.join_path(root, 'out')
+	compile := os.execute('${v3_bin} ${main_path} -b c -o ${bin}')
+	assert compile.exit_code != 0, '${name}: compile unexpectedly succeeded: ${compile.output}'
+	return compile.output
+}
+
+fn test_top_level_for_local_receiver_roots_recursive_chain_only() {
+	v3_bin := mini_calc_build_v3()
+	output, generated := mini_calc_compile_run(v3_bin, 'for_top_level_receiver', {
+		'main.v': 'module main
+
+struct Parser {}
+
+fn (mut p Parser) expr() !int {
+	return p.term()!
+}
+
+fn (mut p Parser) term() !int {
+	return 8
+}
+
+fn (mut p Parser) unused() !int {
+	return 99
+}
+
+for i := 0; i < 1; i++ {
+	mut parser := Parser{}
+	result := parser.expr() or { 0 }
+	println(int_str(result))
+}
+'
+	}, 'main.v')
+	assert output == '8'
+	assert generated.contains('Parser__expr('), generated
+	assert generated.contains('Parser__term('), generated
+	assert !generated.contains('Parser__unused('), generated
+}
+
+fn test_top_level_future_local_receiver_is_not_rooted() {
+	v3_bin := mini_calc_build_v3()
+	output := mini_calc_compile_bad(v3_bin, 'future_local_receiver', {
+		'main.v': 'module main
+
+struct Parser {}
+
+fn (mut p Parser) expr() !int {
+	return 7
+}
+
+result := parser.expr() or { 0 }
+mut parser := Parser{}
+println(int_str(result))
+'
+	}, 'main.v')
+	assert output.contains('unknown function `parser.expr`') || output.contains('unknown__expr')
+		|| output.contains('C compilation failed'), output
+}
+
+fn test_top_level_same_declaration_receiver_is_not_rooted() {
+	v3_bin := mini_calc_build_v3()
+	output := mini_calc_compile_bad(v3_bin, 'same_decl_receiver', {
+		'main.v': 'module main
+
+struct Parser {}
+
+fn (mut p Parser) expr() !int {
+	return 7
+}
+
+parser := parser.expr() or { 0 }
+println(int_str(parser))
+'
+	}, 'main.v')
+	assert output.contains('unknown function `parser.expr`') || output.contains('unknown__expr')
+		|| output.contains('C compilation failed'), output
+}
+
+fn test_top_level_multi_decl_same_statement_receiver_is_not_rooted() {
+	v3_bin := mini_calc_build_v3()
+	output := mini_calc_compile_bad(v3_bin, 'multi_decl_same_statement_receiver', {
+		'main.v': 'module main
+
+struct Parser {}
+
+fn (mut p Parser) expr() !int {
+	return 7
+}
+
+parser, result := Parser{}, parser.expr() or { 0 }
+_ := parser
+println(int_str(result))
+'
+	}, 'main.v')
+	assert output.contains('unknown function `parser.expr`') || output.contains('unknown__expr')
+		|| output.contains('C compilation failed'), output
+}
+
+fn test_top_level_block_and_if_scope_do_not_leak_receiver_type() {
+	v3_bin := mini_calc_build_v3()
+	output, generated := mini_calc_compile_run(v3_bin, 'block_scope', {
+		'main.v': 'module main
+
+struct Parser {}
+
+fn (mut p Parser) expr() !int {
+	return 1
+}
+
+{
+	mut parser := Parser{}
+	_ := parser
+}
+if true {
+	mut parser := Parser{}
+	_ := parser
+}
+println("ok")
+'
+	}, 'main.v')
+	assert output == 'ok'
+	assert !generated.contains('Parser__expr('), generated
+}
+
+fn test_explicit_main_ignores_top_level_receiver_calls() {
+	v3_bin := mini_calc_build_v3()
+	output, generated := mini_calc_compile_run(v3_bin, 'explicit_main', {
+		'main.v': 'module main
+
+struct Parser {}
+
+fn (mut p Parser) expr() !int {
+	return p.term()!
+}
+
+fn (mut p Parser) term() !int {
+	return 7
+}
+
+mut parser := Parser{}
+_ := parser.expr() or { 0 }
+
+fn main() {
+	println("entry")
+}
+'
+	}, 'main.v')
+	assert output == 'entry'
+	assert !generated.contains('Parser__expr('), generated
+	assert !generated.contains('Parser__term('), generated
+}
+
+fn test_top_level_local_receiver_does_not_root_imported_homonym() {
+	v3_bin := mini_calc_build_v3()
+	output, generated := mini_calc_compile_run(v3_bin, 'imported_homonym', {
+		'main.v':         'module main
+
+import othermod
+
+struct Parser {}
+
+fn (mut p Parser) expr() !int {
+	return 5
+}
+
+mut parser := Parser{}
+println(int_str(parser.expr() or { 0 }))
+println(int_str(othermod.touch()))
+'
+		'othermod/mod.v': 'module othermod
+
+pub struct Parser {}
+
+pub fn touch() int {
+	return 2
+}
+
+pub fn (mut p Parser) expr() !int {
+	return 100
+}
+'
+	}, 'main.v')
+	assert output == '5\n2'
+	assert generated.contains('Parser__expr('), generated
+	assert !generated.contains('othermod__Parser__expr('), generated
+}
+
+fn test_top_level_local_receiver_shadows_module_alias() {
+	v3_bin := mini_calc_build_v3()
+	output, generated := mini_calc_compile_run(v3_bin, 'local_receiver_alias_shadow', {
+		'main.v':          'module main
+
+import parsermod as parser
+
+struct Parser {}
+
+fn (mut p Parser) expr() !int {
+	return 12
+}
+
+mut parser := Parser{}
+println(int_str(parser.expr() or { 0 }))
+'
+		'parsermod/mod.v': 'module parsermod
+
+pub fn expr() int {
+	return 3
+}
+'
+	}, 'main.v')
+	assert output == '12'
+	assert generated.contains('Parser__expr('), generated
+	assert !generated.contains('parsermod__expr('), generated
+}
+
+fn test_top_level_import_alias_then_local_receiver_shadow_direct_calls() {
+	v3_bin := mini_calc_build_v3()
+	output, generated := mini_calc_compile_run(v3_bin, 'import_alias_then_local_receiver_shadow', {
+		'main.v':          'module main
+
+import parsermod as parser
+
+struct Parser {}
+
+fn (mut p Parser) expr() !int {
+	return 99
+}
+
+println(int_str(parser.expr()))
+mut parser := Parser{}
+println(int_str(parser.expr() or { 0 }))
+'
+		'parsermod/mod.v': 'module parsermod
+
+pub fn expr() int {
+	return 17
+}
+'
+	}, 'main.v')
+	assert output == '17\n99'
+	assert generated.contains('parsermod__expr('), generated
+	assert generated.contains('Parser__expr('), generated
+}
+
+fn test_mini_calculator_recursive_descent_compiles_and_runs() {
+	v3_bin := mini_calc_build_v3()
+	example := os.join_path(mini_calc_repo_root, 'examples', 'mini_calculator_recursive_descent.v')
+	bin := os.join_path(os.temp_dir(), 'v3_mini_calculator_recursive_descent_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${example} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute("printf '2 * (5-1)\\nexit\\n' | ${bin}")
+	assert run.exit_code == 0, run.output
+	assert run.output.contains('8'), run.output
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	assert generated.contains('Parser__expr('), generated
+	assert generated.contains('Parser__term('), generated
+	assert generated.contains('Parser__factor('), generated
+	assert generated.contains('Parser__number('), generated
+}

--- a/vlib/v3/tests/operator_result_method_checker_test.v
+++ b/vlib/v3/tests/operator_result_method_checker_test.v
@@ -1,0 +1,126 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_operator_result_method_checker_test')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn write_clock_project(name string, main_src string) string {
+	root := os.join_path(os.temp_dir(), 'v3_operator_result_method_${name}')
+	os.rmdir_all(root) or {}
+	clock_dir := os.join_path(root, 'clock')
+	os.mkdir_all(clock_dir) or { panic(err) }
+	os.write_file(os.join_path(root, 'v.mod'), "Module { name: 'operator_result_method' }\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(clock_dir, 'clock.v'), 'module clock
+
+pub struct Moment {
+	value int
+}
+
+pub type Span = i64
+
+pub fn now() Moment {
+	return Moment{
+		value: 1
+	}
+}
+
+pub fn (lhs Moment) - (rhs Moment) Span {
+	return Span(lhs.value - rhs.value)
+}
+
+pub fn (span Span) milliseconds() i64 {
+	return i64(span)
+}
+') or {
+		panic(err)
+	}
+	main_path := os.join_path(root, 'main.v')
+	os.write_file(main_path, main_src) or { panic(err) }
+	return main_path
+}
+
+fn check_to_c(v3_bin string, name string, main_src string) os.Result {
+	main_path := write_clock_project(name, main_src)
+	c_path := os.join_path(os.temp_dir(), 'v3_operator_result_method_${name}.c')
+	os.rm(c_path) or {}
+	return os.execute('${v3_bin} ${main_path} -b c -o ${c_path}')
+}
+
+fn check_standalone_to_c(v3_bin string, name string, main_src string) os.Result {
+	main_path := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	os.write_file(main_path, main_src) or { panic(err) }
+	c_path := os.join_path(os.temp_dir(), 'v3_${name}.c')
+	os.rm(c_path) or {}
+	return os.execute('${v3_bin} ${main_path} -b c -o ${c_path}')
+}
+
+fn test_operator_result_type_is_used_before_method_resolution() {
+	v3_bin := build_v3()
+	good := 'module main
+
+import clock
+
+fn main() {
+	println((clock.now() - clock.now()).milliseconds())
+	println(clock.Span(123000000).milliseconds())
+	span := clock.Span(10)
+	_ := span.milliseconds()
+}
+'
+	good_res := check_to_c(v3_bin, 'good', good)
+	assert good_res.exit_code == 0, good_res.output
+	assert !good_res.output.contains('unknown function `milliseconds`'), good_res.output
+
+	time_good := 'module main
+
+import time
+
+fn main() {
+	println((time.now() - time.now()).milliseconds())
+	println(time.Duration(123000000).milliseconds())
+	d := time.Duration(10)
+	_ := d.milliseconds()
+}
+'
+	time_res := check_to_c(v3_bin, 'time_good', time_good)
+	assert time_res.exit_code == 0, time_res.output
+	assert !time_res.output.contains('unknown function `milliseconds`'), time_res.output
+
+	time_standalone := 'module main
+
+import time
+
+fn main() {
+	d := time.Duration(10); _ := d.milliseconds()
+}
+'
+	time_standalone_res := check_standalone_to_c(v3_bin, 'probe_time_duration_method_clean',
+		time_standalone)
+	assert time_standalone_res.exit_code == 0, time_standalone_res.output
+	assert !time_standalone_res.output.contains('unknown function d.milliseconds'), time_standalone_res.output
+
+	bad := 'module main
+
+import clock
+
+fn main() {
+	println((clock.now() - clock.now()).bogus_method())
+}
+'
+	bad_res := check_to_c(v3_bin, 'bad', bad)
+	assert bad_res.exit_code != 0, bad_res.output
+	assert bad_res.output.contains('unknown function'), bad_res.output
+	assert bad_res.output.contains('bogus_method'), bad_res.output
+}

--- a/vlib/v3/tests/optional_pointer_nil_return_codegen_test.v
+++ b/vlib/v3/tests/optional_pointer_nil_return_codegen_test.v
@@ -1,0 +1,99 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn test_optional_pointer_nil_return_is_success_payload() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_optional_pointer_nil_return_test')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_optional_pointer_nil_return_input.v')
+	os.write_file(src, "struct T {
+	x int
+}
+
+fn maybe(flag bool) ?&T {
+	if flag {
+		return unsafe { nil }
+	}
+	return none
+}
+
+fn maybe_defer(flag bool) ?&T {
+	defer {}
+	if flag {
+		return unsafe { nil }
+	}
+	return none
+}
+
+fn result_maybe(flag bool) !&T {
+	if flag {
+		return unsafe { nil }
+	}
+	return error('no value')
+}
+
+fn result_maybe_defer(flag bool) !&T {
+	defer {}
+	if flag {
+		return unsafe { nil }
+	}
+	return error('no value')
+}
+
+fn check_question_unwrap() ! {
+	a := maybe(true)?
+	assert a == unsafe { nil }
+	c := maybe_defer(true)?
+	assert c == unsafe { nil }
+	r := result_maybe(true)!
+	assert r == unsafe { nil }
+	rd := result_maybe_defer(true)!
+	assert rd == unsafe { nil }
+}
+
+fn main() {
+	check_question_unwrap() or { panic(err) }
+	b := maybe(false) or { unsafe { nil } }
+	assert b == unsafe { nil }
+	d := maybe_defer(false) or { unsafe { nil } }
+	assert d == unsafe { nil }
+	rb := result_maybe(false) or {
+		assert err.msg() == 'no value'
+		unsafe { nil }
+	}
+	assert rb == unsafe { nil }
+	rbd := result_maybe_defer(false) or {
+		assert err.msg() == 'no value'
+		unsafe { nil }
+	}
+	assert rbd == unsafe { nil }
+	println('ok')
+}
+") or {
+		panic(err)
+	}
+
+	bin := os.join_path(os.temp_dir(), 'v3_optional_pointer_nil_return_input')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+
+	c_code := os.read_file(bin + '.c') or { panic(err) }
+	assert c_code.contains('return (Optional_Tptr){.ok = true, .value = NULL};'), c_code
+	assert c_code.contains('Optional_Tptr _t')
+		&& c_code.contains('= (Optional_Tptr){.ok = true, .value =') && c_code.contains('NULL};'), c_code
+
+	assert c_code.contains('return (Optional_Tptr){.ok = false};'), c_code
+	assert c_code.contains('return (Optional_Tptr){.ok = false, .err = (IError)'), c_code
+
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok'
+}

--- a/vlib/v3/tests/optional_struct_lvalue_codegen_test.v
+++ b/vlib/v3/tests/optional_struct_lvalue_codegen_test.v
@@ -1,0 +1,127 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn test_optional_struct_selector_assignment_mutates_payload_storage() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_optional_struct_lvalue_test')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_optional_struct_lvalue_input.v')
+	os.write_file(src, "struct AFoo {
+mut:
+	name string
+}
+
+struct Inner {
+mut:
+	name string
+}
+
+struct Holder {
+mut:
+	opt ?Inner
+}
+
+struct ResultHolder {
+mut:
+	res !Inner
+}
+
+struct Outer {
+mut:
+	inner Inner
+}
+
+fn (mut f AFoo) opt_string(arr ?[]int) ?string {
+	return arr?.len.str()
+}
+
+fn guarded_failure() ?AFoo {
+	mut m := ?AFoo(none)
+	m?.name = 'bad'
+	return m
+}
+
+fn fail_inner() !Inner {
+	return error('boom')
+}
+
+fn mutate_result_source(mut h ResultHolder) ! {
+	h.res!.name = 'result'
+}
+
+fn main() {
+	mut m := ?AFoo(AFoo{})
+	assert m?.opt_string([1, 2, 3])? == '3'
+	m?.name = 'foo'
+	assert m?.name == 'foo'
+	mut holder := Holder{
+		opt: Inner{}
+	}
+	holder.opt?.name = 'holder'
+	assert holder.opt?.name == 'holder'
+	mut outer := ?Outer(Outer{})
+	outer?.inner.name = 'deep'
+	assert outer?.inner.name == 'deep'
+	mut result_ok := ResultHolder{
+		res: Inner{}
+	}
+	mutate_result_source(mut result_ok)!
+	assert result_ok.res!.name == 'result'
+	mut result_bad := ResultHolder{
+		res: fail_inner()
+	}
+	mut saw_result_err := false
+	mutate_result_source(mut result_bad) or {
+		assert err.msg() == 'boom'
+		saw_result_err = true
+	}
+	assert saw_result_err
+	guarded_failure() or {
+		assert err.msg() == ''
+		println('ok')
+		return
+	}
+	assert false
+}
+") or {
+		panic(err)
+	}
+
+	bin := os.join_path(os.temp_dir(), 'v3_optional_struct_lvalue_input')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+
+	c_code := os.read_file(bin + '.c') or { panic(err) }
+	assert c_code.contains('m.value.name ='), c_code
+	assert c_code.contains('holder.opt.value.name ='), c_code
+	assert c_code.contains('outer.value.inner.name ='), c_code
+	assert c_code.contains('if (!m.ok)'), c_code
+	assert c_code.contains('if (!holder.opt.ok)'), c_code
+	assert c_code.contains('if (!outer.ok)'), c_code
+	assert c_code.contains('.err = h->res.err') || c_code.contains('.err = h.res.err'), c_code
+	mutate_result_start := c_code.index('\nOptional mutate_result_source(ResultHolder* h) {') or {
+		-1
+	}
+	assert mutate_result_start >= 0, c_code
+	mutate_result_tail := c_code[mutate_result_start..]
+	mutate_result_guard := mutate_result_tail[..mutate_result_tail.index('h->res.value.name') or {
+		mutate_result_tail.len
+	}]
+	assert !mutate_result_guard.contains('return (Optional){.ok = false};'), mutate_result_guard
+	for line in c_code.split_into_lines() {
+		assert !(line.contains('__or_val_') && line.contains('.name =')), line
+		assert !(line.contains('__or_val_') && line.contains('.inner.name =')), line
+	}
+
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok'
+}

--- a/vlib/v3/tests/optional_struct_lvalue_codegen_test.v
+++ b/vlib/v3/tests/optional_struct_lvalue_codegen_test.v
@@ -56,6 +56,41 @@ fn mutate_result_source(mut h ResultHolder) ! {
 	h.res!.name = 'result'
 }
 
+fn mutate_explicit_or_source(mut holder Holder) {
+	(holder.opt or {
+		assert false
+		return
+	}).name = 'ok'
+}
+
+fn mutate_explicit_or_none() {
+	mut holder := Holder{
+		opt: none
+	}
+	(holder.opt or {
+		assert err.msg() == ''
+		println('none')
+		return
+	}).name = 'bad'
+	assert false
+}
+
+fn mutate_result_explicit_or_ok(mut h ResultHolder) {
+	(h.res or {
+		assert false
+		return
+	}).name = 'explicit-result'
+}
+
+fn mutate_result_explicit_or_err(mut h ResultHolder) {
+	(h.res or {
+		assert err.msg() == 'boom'
+		println('boom')
+		return
+	}).name = 'bad'
+	assert false
+}
+
 fn main() {
 	mut m := ?AFoo(AFoo{})
 	assert m?.opt_string([1, 2, 3])? == '3'
@@ -74,6 +109,8 @@ fn main() {
 	}
 	mutate_result_source(mut result_ok)!
 	assert result_ok.res!.name == 'result'
+	mutate_result_explicit_or_ok(mut result_ok)
+	assert result_ok.res!.name == 'explicit-result'
 	mut result_bad := ResultHolder{
 		res: fail_inner()
 	}
@@ -83,6 +120,10 @@ fn main() {
 		saw_result_err = true
 	}
 	assert saw_result_err
+	mutate_result_explicit_or_err(mut result_bad)
+	mutate_explicit_or_source(mut holder)
+	assert holder.opt?.name == 'ok'
+	mutate_explicit_or_none()
 	guarded_failure() or {
 		assert err.msg() == ''
 		println('ok')
@@ -103,10 +144,16 @@ fn main() {
 	assert c_code.contains('m.value.name ='), c_code
 	assert c_code.contains('holder.opt.value.name ='), c_code
 	assert c_code.contains('outer.value.inner.name ='), c_code
+	assert c_code.contains('holder->opt.value.name =') || c_code.contains('holder.opt.value.name ='), c_code
+
 	assert c_code.contains('if (!m.ok)'), c_code
 	assert c_code.contains('if (!holder.opt.ok)'), c_code
 	assert c_code.contains('if (!outer.ok)'), c_code
 	assert c_code.contains('.err = h->res.err') || c_code.contains('.err = h.res.err'), c_code
+	assert c_code.contains('IError err = holder.opt.err')
+		|| c_code.contains('IError err = holder->opt.err'), c_code
+	assert c_code.contains('IError err = h->res.err') || c_code.contains('IError err = h.res.err'), c_code
+
 	mutate_result_start := c_code.index('\nOptional mutate_result_source(ResultHolder* h) {') or {
 		-1
 	}
@@ -123,5 +170,5 @@ fn main() {
 
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
-	assert run.output.trim_space() == 'ok'
+	assert run.output.trim_space() == 'boom\nnone\nok'
 }

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -115,6 +115,52 @@ fn test_parallel_cgen_merges_worker_gettid_compat() {
 	assert c_code.contains('return v3_gettid();'), c_code
 }
 
+fn write_parallel_user_main_test_project(name string) string {
+	project_dir := os.join_path(os.temp_dir(), 'v3_${name}')
+	os.rmdir_all(project_dir) or {}
+	os.mkdir_all(project_dir) or { panic(err) }
+
+	mut main_src := strings.new_builder(96_000)
+	main_src.writeln('module main')
+	main_src.writeln('')
+	for i in 0 .. 1050 {
+		main_src.writeln('fn helper_${i}() int {')
+		main_src.writeln('\treturn ${i}')
+		main_src.writeln('}')
+		main_src.writeln('')
+	}
+	main_src.writeln('fn main() {')
+	main_src.writeln("\tprintln('user-main')")
+	main_src.writeln('}')
+	main_src.writeln('')
+	main_src.writeln('fn test_call_user_main() {')
+	main_src.writeln('\tmut total := 0')
+	for i in 0 .. 1050 {
+		main_src.writeln('\ttotal += helper_${i}()')
+	}
+	main_src.writeln('\tassert total == 550725')
+	main_src.writeln('\tmain()')
+	main_src.writeln('}')
+	os.write_file(os.join_path(project_dir, 'main_test.v'), main_src.str()) or { panic(err) }
+	return os.join_path(project_dir, 'main_test.v')
+}
+
+fn test_parallel_cgen_worker_keeps_test_user_main_renamed() {
+	v3_bin := build_parallel_v3()
+	main_path := write_parallel_user_main_test_project('parallel_user_main_test_file')
+	bin_out := os.join_path(os.temp_dir(), 'v3_parallel_user_main_test_file_out')
+	compile := os.execute('VJOBS=2 ${v3_bin} ${main_path} -b c -o ${bin_out}')
+	assert compile.exit_code == 0, compile.output
+	assert compile.output.contains('cgen'), compile.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'user-main'
+	c_code := os.read_file(bin_out + '.c') or { panic(err) }
+	assert c_code.count('int main(') == 1, c_code
+	assert c_code.contains('main__user_main'), c_code
+	assert c_code.contains('main__user_main();'), c_code
+}
+
 fn write_parallel_top_level_no_main_project(name string) string {
 	project_dir := os.join_path(os.temp_dir(), 'v3_${name}')
 	os.rmdir_all(project_dir) or {}

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -71,3 +71,87 @@ fn test_parallel_cgen_main_emits_module_init_call() {
 	c_code := os.read_file(c_out) or { panic(err) }
 	assert c_code.all_after('int main').contains('_vinit();')
 }
+
+fn write_parallel_gettid_project(name string) string {
+	project_dir := os.join_path(os.temp_dir(), 'v3_${name}')
+	os.rmdir_all(project_dir) or {}
+	os.mkdir_all(project_dir) or { panic(err) }
+
+	mut main_src := strings.new_builder(96_000)
+	main_src.writeln('module main')
+	main_src.writeln('')
+	main_src.writeln('fn C.gettid() int')
+	main_src.writeln('')
+	for i in 0 .. 1050 {
+		main_src.writeln('fn helper_${i}() int {')
+		main_src.writeln('\treturn ${i}')
+		main_src.writeln('}')
+		main_src.writeln('')
+	}
+	main_src.writeln('fn worker_gettid_value() int {')
+	main_src.writeln('\treturn C.gettid()')
+	main_src.writeln('}')
+	main_src.writeln('')
+	main_src.writeln('fn main() {')
+	main_src.writeln('\tmut total := 0')
+	for i in 0 .. 1050 {
+		main_src.writeln('\ttotal += helper_${i}()')
+	}
+	main_src.writeln('\tprintln(int_str(total + worker_gettid_value()))')
+	main_src.writeln('}')
+	os.write_file(os.join_path(project_dir, 'main.v'), main_src.str()) or { panic(err) }
+	return os.join_path(project_dir, 'main.v')
+}
+
+fn test_parallel_cgen_merges_worker_gettid_compat() {
+	v3_bin := build_parallel_v3()
+	main_path := write_parallel_gettid_project('parallel_gettid_compat')
+	c_out := os.join_path(os.temp_dir(), 'v3_parallel_gettid_compat.c')
+	compile := os.execute('VJOBS=2 ${v3_bin} ${main_path} -o ${c_out}')
+	assert compile.exit_code == 0, compile.output
+	assert compile.output.contains('cgen'), compile.output
+	c_code := os.read_file(c_out) or { panic(err) }
+	assert c_code.contains('static inline u32 v3_gettid(void)'), c_code
+	assert c_code.contains('return v3_gettid();'), c_code
+}
+
+fn write_parallel_top_level_no_main_project(name string) string {
+	project_dir := os.join_path(os.temp_dir(), 'v3_${name}')
+	os.rmdir_all(project_dir) or {}
+	os.mkdir_all(project_dir) or { panic(err) }
+
+	mut main_src := strings.new_builder(48_000)
+	main_src.writeln('module main')
+	main_src.writeln('')
+	for i in 0 .. 320 {
+		main_src.writeln('fn helper_${i}() int {')
+		main_src.writeln('\treturn ${i}')
+		main_src.writeln('}')
+		main_src.writeln('')
+	}
+	main_src.writeln('mut values := map[string]int{}')
+	main_src.writeln("mut total := values['missing'] or {")
+	main_src.writeln('\t7')
+	main_src.writeln('}')
+	for i in 0 .. 320 {
+		main_src.writeln('total += helper_${i}()')
+	}
+	main_src.writeln('println(int_str(total))')
+	os.write_file(os.join_path(project_dir, 'main.v'), main_src.str()) or { panic(err) }
+	return os.join_path(project_dir, 'main.v')
+}
+
+fn test_parallel_transform_lowers_top_level_stmts_without_main_once() {
+	v3_bin := build_parallel_v3()
+	main_path := write_parallel_top_level_no_main_project('parallel_top_level_no_main')
+	bin_out := os.join_path(os.temp_dir(), 'v3_parallel_top_level_no_main_out')
+	compile := os.execute('VJOBS=2 ${v3_bin} --parallel-transform ${main_path} -b c -o ${bin_out}')
+	assert compile.exit_code == 0, compile.output
+	assert compile.output.contains('transform (parallel)'), compile.output
+	assert compile.output.contains('cgen'), compile.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '51047'
+	c_code := os.read_file(bin_out + '.c') or { panic(err) }
+	assert c_code.all_after('int main').count('map__get_check') == 1, c_code
+}

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -1,12 +1,18 @@
 import os
 import strings
 
+const parallel_tests_dir = os.dir(@FILE)
+const parallel_v3_dir = os.dir(parallel_tests_dir)
+const parallel_vlib_dir = os.dir(parallel_v3_dir)
+const parallel_v3_src = os.join_path(parallel_v3_dir, 'v3.v')
+
 // build_parallel_v3 builds parallel v3 data for v3 tests.
 fn build_parallel_v3() string {
 	vexe := @VEXE
-	v3_src := os.join_path(@VEXEROOT, 'vlib', 'v3', 'v3.v')
 	v3_bin := os.join_path(os.temp_dir(), 'v3_parallel_cgen_test')
-	build := os.execute('${vexe} -d parallel -o ${v3_bin} ${v3_src}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${vexe} -d parallel -path "${parallel_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${parallel_v3_src}')
 	assert build.exit_code == 0, build.output
 	return v3_bin
 }

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -12,7 +12,7 @@ fn build_parallel_v3() string {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_parallel_cgen_test')
 	os.rm(v3_bin) or {}
 	build :=
-		os.execute('${vexe} -d parallel -path "${parallel_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${parallel_v3_src}')
+		os.execute('${vexe} -d parallel -gc none -path "${parallel_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${parallel_v3_src}')
 	assert build.exit_code == 0, build.output
 	return v3_bin
 }

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -161,6 +161,65 @@ fn test_parallel_cgen_worker_keeps_test_user_main_renamed() {
 	assert c_code.contains('main__user_main();'), c_code
 }
 
+fn write_parallel_generic_struct_method_project(name string) string {
+	project_dir := os.join_path(os.temp_dir(), 'v3_${name}')
+	os.rmdir_all(project_dir) or {}
+	os.mkdir_all(project_dir) or { panic(err) }
+
+	mut main_src := strings.new_builder(96_000)
+	main_src.writeln('module main')
+	main_src.writeln('')
+	main_src.writeln('struct Box[T] {')
+	main_src.writeln('	value T')
+	main_src.writeln('}')
+	main_src.writeln('')
+	main_src.writeln('fn (b Box[T]) accept(x ?T) T {')
+	main_src.writeln('	value := x or {')
+	main_src.writeln('		return b.value')
+	main_src.writeln('	}')
+	main_src.writeln('	return value')
+	main_src.writeln('}')
+	main_src.writeln('')
+	main_src.writeln('fn use_box_accept() int {')
+	main_src.writeln('	b := Box[int]{')
+	main_src.writeln('		value: 5')
+	main_src.writeln('	}')
+	main_src.writeln('	return b.accept(7) + b.accept(8)')
+	main_src.writeln('}')
+	main_src.writeln('')
+	for i in 0 .. 1050 {
+		main_src.writeln('fn helper_${i}() int {')
+		main_src.writeln('\treturn ${i}')
+		main_src.writeln('}')
+		main_src.writeln('')
+	}
+	main_src.writeln('fn main() {')
+	main_src.writeln('\tmut total := use_box_accept()')
+	for i in 0 .. 1050 {
+		main_src.writeln('\ttotal += helper_${i}()')
+	}
+	main_src.writeln('\tprintln(int_str(total))')
+	main_src.writeln('}')
+	os.write_file(os.join_path(project_dir, 'main.v'), main_src.str()) or { panic(err) }
+	return os.join_path(project_dir, 'main.v')
+}
+
+fn test_parallel_cgen_worker_resolves_generic_struct_method_signature() {
+	v3_bin := build_parallel_v3()
+	main_path := write_parallel_generic_struct_method_project('parallel_generic_struct_method')
+	bin_out := os.join_path(os.temp_dir(), 'v3_parallel_generic_struct_method_out')
+	compile := os.execute('VJOBS=2 ${v3_bin} ${main_path} -b c -o ${bin_out}')
+	assert compile.exit_code == 0, compile.output
+	assert compile.output.contains('cgen (parallel)'), compile.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '550740'
+	c_code := os.read_file(bin_out + '.c') or { panic(err) }
+	assert c_code.contains('Box_int__accept'), c_code
+	assert c_code.contains('Optional_int x'), c_code
+	assert !c_code.contains('?T'), c_code
+}
+
 fn write_parallel_top_level_no_main_project(name string) string {
 	project_dir := os.join_path(os.temp_dir(), 'v3_${name}')
 	os.rmdir_all(project_dir) or {}

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -37,6 +37,23 @@ fn interface_method_param_types(a &flat.FlatAst, iface string, method string) []
 	return []string{}
 }
 
+fn fn_decl_param_pairs(a &flat.FlatAst, kind flat.NodeKind, name string) []string {
+	for node in a.nodes {
+		if node.kind != kind || node.value != name {
+			continue
+		}
+		mut pairs := []string{}
+		for i in 0 .. node.children_count {
+			param := a.child_node(&node, i)
+			if param.kind == .param {
+				pairs << '${param.value}:${param.typ}'
+			}
+		}
+		return pairs
+	}
+	return []string{}
+}
+
 // test_interface_method_generic_type_only_param_is_not_parsed_as_name
 // validates this v3 regression case.
 fn test_interface_method_generic_type_only_param_is_not_parsed_as_name() {
@@ -46,6 +63,44 @@ fn test_interface_method_generic_type_only_param_is_not_parsed_as_name() {
 	assert interface_method_param_types(a, 'Sink', 'append') == ['[]int']
 	assert interface_method_param_types(a, 'Sink', 'visit') == ['&Node']
 	assert interface_method_param_types(a, 'Sink', 'read') == ['[max_len]u8']
+}
+
+fn test_c_function_anonymous_params_are_parsed_as_types() {
+	a := parse_parser_regression_source('c_anon_params',
+		'struct T {}\nstruct C.FILE {}\nstruct C.Widget {}\nstruct C.Node {}\n\nfn C.anon(&C.FILE, voidptr, int, &&T, [4]&C.Widget, ?&C.Node, !&C.Node, fn (&C.Node) int) int\nfn C.named(stream &C.FILE, a, b int) int\nfn C.named_arrays(m [16]f32, r []rune) int\nfn C.variadic(...int) int\nfn JS.js_anon(JS.Number) JS.Number\nfn JS.js_named(x JS.Number) JS.Number\nfn JS.setInterval(any, int, ...any) int\nfn JS.console.dir(any, any)\nfn JS.named_any(x any) any\nfn ordinary(int) {}\n')
+	assert fn_decl_param_pairs(a, .c_fn_decl, 'anon') == [
+		':&C.FILE',
+		':voidptr',
+		':int',
+		':&&T',
+		':[4]&C.Widget',
+		':?&C.Node',
+		':!&C.Node',
+		':fn(&C.Node) int',
+	]
+	assert fn_decl_param_pairs(a, .c_fn_decl, 'named') == [
+		'stream:&C.FILE',
+		'a:int',
+		'b:int',
+	]
+	assert fn_decl_param_pairs(a, .c_fn_decl, 'named_arrays') == [
+		'm:[16]f32',
+		'r:[]rune',
+	]
+	assert fn_decl_param_pairs(a, .c_fn_decl, 'variadic') == [':...int']
+	assert fn_decl_param_pairs(a, .c_fn_decl, 'js_anon') == [':JS.Number']
+	assert fn_decl_param_pairs(a, .c_fn_decl, 'js_named') == ['x:JS.Number']
+	assert fn_decl_param_pairs(a, .c_fn_decl, 'setInterval') == [
+		':any',
+		':int',
+		':...any',
+	]
+	assert fn_decl_param_pairs(a, .c_fn_decl, 'console.dir') == [
+		':any',
+		':any',
+	]
+	assert fn_decl_param_pairs(a, .c_fn_decl, 'named_any') == ['x:any']
+	assert fn_decl_param_pairs(a, .fn_decl, 'ordinary') == ['int:']
 }
 
 fn test_sql_identifier_calls_are_not_parsed_as_sql_expr() {

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -67,7 +67,7 @@ fn test_interface_method_generic_type_only_param_is_not_parsed_as_name() {
 
 fn test_c_function_anonymous_params_are_parsed_as_types() {
 	a := parse_parser_regression_source('c_anon_params',
-		'struct T {}\nstruct C.FILE {}\nstruct C.Widget {}\nstruct C.Node {}\n\nfn C.anon(&C.FILE, voidptr, int, &&T, [4]&C.Widget, ?&C.Node, !&C.Node, fn (&C.Node) int) int\nfn C.named(stream &C.FILE, a, b int) int\nfn C.named_arrays(m [16]f32, r []rune) int\nfn C.variadic(...int) int\nfn JS.js_anon(JS.Number) JS.Number\nfn JS.js_named(x JS.Number) JS.Number\nfn JS.setInterval(any, int, ...any) int\nfn JS.console.dir(any, any)\nfn JS.named_any(x any) any\nfn ordinary(int) {}\n')
+		'struct T {}\nstruct C.FILE {}\nstruct C.Widget {}\nstruct C.Node {}\ntype MyHandle = voidptr\n\nfn C.anon(&C.FILE, voidptr, int, &&T, [4]&C.Widget, ?&C.Node, !&C.Node, fn (&C.Node) int) int\nfn C.custom(MyHandle, int, MyHandle) int\nfn C.named(stream &C.FILE, a, b int) int\nfn C.named_custom(handle MyHandle, a, b int) int\nfn C.named_arrays(m [16]f32, r []rune) int\nfn C.variadic(...int) int\nfn JS.js_anon(JS.Number) JS.Number\nfn JS.js_named(x JS.Number) JS.Number\nfn JS.setInterval(any, int, ...any) int\nfn JS.console.dir(any, any)\nfn JS.named_any(x any) any\nfn ordinary(int) {}\n')
 	assert fn_decl_param_pairs(a, .c_fn_decl, 'anon') == [
 		':&C.FILE',
 		':voidptr',
@@ -78,8 +78,18 @@ fn test_c_function_anonymous_params_are_parsed_as_types() {
 		':!&C.Node',
 		':fn(&C.Node) int',
 	]
+	assert fn_decl_param_pairs(a, .c_fn_decl, 'custom') == [
+		':MyHandle',
+		':int',
+		':MyHandle',
+	]
 	assert fn_decl_param_pairs(a, .c_fn_decl, 'named') == [
 		'stream:&C.FILE',
+		'a:int',
+		'b:int',
+	]
+	assert fn_decl_param_pairs(a, .c_fn_decl, 'named_custom') == [
+		'handle:MyHandle',
 		'a:int',
 		'b:int',
 	]

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -2,6 +2,7 @@ import os
 import v3.flat
 import v3.parser
 import v3.pref
+import v3.types
 
 // parse_parser_regression_source reads parse parser regression source input for v3 tests.
 fn parse_parser_regression_source(name string, source string) &flat.FlatAst {
@@ -10,6 +11,17 @@ fn parse_parser_regression_source(name string, source string) &flat.FlatAst {
 	mut prefs := pref.new_preferences()
 	mut p := parser.Parser.new(prefs)
 	p.parse_into(src)
+	return p.a
+}
+
+fn parse_parser_regression_sources(name string, sources []string) &flat.FlatAst {
+	mut prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	for i, source in sources {
+		src := os.join_path(os.temp_dir(), 'v3_${name}_${i}.v')
+		os.write_file(src, source) or { panic(err) }
+		p.parse_into(src)
+	}
 	return p.a
 }
 
@@ -67,7 +79,7 @@ fn test_interface_method_generic_type_only_param_is_not_parsed_as_name() {
 
 fn test_c_function_anonymous_params_are_parsed_as_types() {
 	a := parse_parser_regression_source('c_anon_params',
-		'struct T {}\nstruct C.FILE {}\nstruct C.Widget {}\nstruct C.Node {}\ntype MyHandle = voidptr\n\nfn C.anon(&C.FILE, voidptr, int, &&T, [4]&C.Widget, ?&C.Node, !&C.Node, fn (&C.Node) int) int\nfn C.custom(MyHandle, int, MyHandle) int\nfn C.named(stream &C.FILE, a, b int) int\nfn C.named_custom(handle MyHandle, a, b int) int\nfn C.named_arrays(m [16]f32, r []rune) int\nfn C.variadic(...int) int\nfn JS.js_anon(JS.Number) JS.Number\nfn JS.js_named(x JS.Number) JS.Number\nfn JS.setInterval(any, int, ...any) int\nfn JS.console.dir(any, any)\nfn JS.named_any(x any) any\nfn ordinary(int) {}\n')
+		'struct T {}\nstruct C.FILE {}\nstruct C.Widget {}\nstruct C.Node {}\ntype MyHandle = voidptr\n\nfn C.anon(&C.FILE, voidptr, int, &&T, [4]&C.Widget, ?&C.Node, !&C.Node, fn (&C.Node) int) int\nfn C.custom(MyHandle, int, MyHandle) int\nfn C.lower(size_t, int, pthread_t) int\nfn C.named(stream &C.FILE, a, b int) int\nfn C.named_custom(handle MyHandle, a, b int) int\nfn C.named_arrays(m [16]f32, r []rune) int\nfn C.variadic(...int) int\nfn JS.js_anon(JS.Number) JS.Number\nfn JS.js_named(x JS.Number) JS.Number\nfn JS.setInterval(any, int, ...any) int\nfn JS.console.dir(any, any)\nfn JS.named_any(x any) any\nfn ordinary(int) {}\n')
 	assert fn_decl_param_pairs(a, .c_fn_decl, 'anon') == [
 		':&C.FILE',
 		':voidptr',
@@ -82,6 +94,11 @@ fn test_c_function_anonymous_params_are_parsed_as_types() {
 		':MyHandle',
 		':int',
 		':MyHandle',
+	]
+	assert fn_decl_param_pairs(a, .c_fn_decl, 'lower') == [
+		':size_t',
+		':int',
+		':pthread_t',
 	]
 	assert fn_decl_param_pairs(a, .c_fn_decl, 'named') == [
 		'stream:&C.FILE',
@@ -111,6 +128,20 @@ fn test_c_function_anonymous_params_are_parsed_as_types() {
 	]
 	assert fn_decl_param_pairs(a, .c_fn_decl, 'named_any') == ['x:any']
 	assert fn_decl_param_pairs(a, .fn_decl, 'ordinary') == ['int:']
+}
+
+fn test_moduleless_file_does_not_inherit_previous_parser_module() {
+	a := parse_parser_regression_sources('moduleless_export', [
+		'module expmod\n\nfn helper() {}\n',
+		"@[export: '1bad']\nfn lonely() {}\n",
+	])
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.check_semantics()
+	assert tc.errors.len == 1, tc.errors.str()
+	assert tc.errors[0].msg.contains('for `lonely`'), tc.errors.str()
+	assert !tc.errors[0].msg.contains('expmod.lonely'), tc.errors.str()
+	assert fn_decl_param_pairs(a, .fn_decl, 'lonely') == []
 }
 
 fn test_sql_identifier_calls_are_not_parsed_as_sql_expr() {

--- a/vlib/v3/tests/posix_wait_header_codegen_test.v
+++ b/vlib/v3/tests/posix_wait_header_codegen_test.v
@@ -1,0 +1,67 @@
+import os
+
+const wait_header_vexe = @VEXE
+const wait_header_tests_dir = os.dir(@FILE)
+const wait_header_v3_dir = os.dir(wait_header_tests_dir)
+const wait_header_vlib_dir = os.dir(wait_header_v3_dir)
+const wait_header_v3_src = os.join_path(wait_header_v3_dir, 'v3.v')
+
+struct WaitHeaderProgram {
+	c_code string
+	out    string
+}
+
+fn wait_header_build_v3() string {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_wait_header_test_${pid}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${wait_header_vexe} -gc none -path "${wait_header_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${wait_header_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn wait_header_compile(v3_bin string, name string, source string) WaitHeaderProgram {
+	pid := os.getpid()
+	src := os.join_path(os.temp_dir(), 'v3_wait_header_${name}_${pid}.v')
+	out := os.join_path(os.temp_dir(), 'v3_wait_header_${name}_${pid}')
+	os.write_file(src, source) or { panic(err) }
+	os.rm(out) or {}
+	os.rm(out + '.c') or {}
+	compile := os.execute('${v3_bin} ${src} -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	return WaitHeaderProgram{
+		c_code: os.read_file(out + '.c') or { panic(err) }
+		out:    out
+	}
+}
+
+fn test_os_import_emits_sys_wait_header() {
+	$if windows {
+		return
+	}
+	v3_bin := wait_header_build_v3()
+	with_os := wait_header_compile(v3_bin, 'with_os_execute', 'module main
+
+import os
+
+fn main() {
+	result := os.execute(\'/bin/sh -c "printf waitpid-ok"\')
+	assert result.exit_code == 0
+	println(result.output)
+}
+')
+	assert with_os.c_code.contains('#include <sys/wait.h>'), with_os.c_code
+	assert with_os.c_code.contains('waitpid('), with_os.c_code
+	run := os.execute(with_os.out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'waitpid-ok', run.output
+
+	hello := wait_header_compile(v3_bin, 'hello', "module main
+
+fn main() {
+	println('hello')
+}
+")
+	assert !hello.c_code.contains('#include <sys/wait.h>'), hello.c_code
+}

--- a/vlib/v3/tests/qualified_positional_struct_init_test.v
+++ b/vlib/v3/tests/qualified_positional_struct_init_test.v
@@ -1,0 +1,65 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn write_project_file(root string, rel string, src string) {
+	path := os.join_path(root, rel)
+	os.mkdir_all(os.dir(path)) or { panic(err) }
+	os.write_file(path, src) or { panic(err) }
+}
+
+fn test_qualified_positional_struct_init_keeps_later_imported_fn() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_qualified_positional_struct_init_test')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	root := os.join_path(os.temp_dir(), 'v3_qualified_positional_struct_init_project')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(root) or { panic(err) }
+	write_project_file(root, 'main.v', 'module main
+
+import m
+
+fn main() {
+	assert m.after() == 10
+}
+')
+	write_project_file(root, 'm/m.v', 'module m
+
+import geom
+
+const shade = geom.Color{1.0, 2.0, 3.0, 4.0}
+
+pub fn after() int {
+	return int(shade.r + shade.g + shade.b + shade.a)
+}
+')
+	write_project_file(root, 'geom/geom.v', 'module geom
+
+pub struct Color {
+pub:
+	r f64
+	g f64
+	b f64
+	a f64
+}
+')
+
+	bin := os.join_path(os.temp_dir(), 'v3_qualified_positional_struct_init_bin')
+	main_path := os.join_path(root, 'main.v')
+	compile := os.execute('${v3_bin} ${main_path} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('unknown function `m.after`'), compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	c_code := os.read_file(bin + '.c') or { panic(err) }
+	assert c_code.contains('(geom__Color){'), c_code
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+}

--- a/vlib/v3/tests/selective_import_codegen_test.v
+++ b/vlib/v3/tests/selective_import_codegen_test.v
@@ -54,6 +54,15 @@ pub fn sub_xy(x int, y int) int {
 
 fn selective_import_compile_run(v3_bin string, name string, main_src string) (string, string) {
 	root := selective_import_write_project(name, main_src)
+	return selective_import_compile_run_root(v3_bin, root)
+}
+
+fn selective_import_compile_run_with_extra(v3_bin string, name string, main_src string, extra_files map[string]string) (string, string) {
+	root := selective_import_write_project_with_extra(name, main_src, extra_files)
+	return selective_import_compile_run_root(v3_bin, root)
+}
+
+fn selective_import_compile_run_root(v3_bin string, root string) (string, string) {
 	bin := os.join_path(root, 'out')
 	compile := os.execute('${v3_bin} ${root} -b c -o ${bin}')
 	assert compile.exit_code == 0, compile.output
@@ -130,6 +139,37 @@ fn main() {
 	assert generated.contains('mymodules__add_xy'), generated
 	assert generated.contains('f(2, 3)'), generated
 	assert !generated.contains('int f = mymodules__add_xy'), generated
+}
+
+fn test_selective_import_function_value_roots_exact_symbol_with_imported_homonym() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run_with_extra(v3_bin,
+		'fn_value_imported_homonym', 'module main
+
+import a { choose }
+import b
+
+fn main() {
+	f := choose
+	println(int_str(f()))
+}
+', {
+		'a/a.v': 'module a
+
+pub fn choose() int {
+	return 11
+}
+'
+		'b/b.v': 'module b
+
+pub fn choose() int {
+	return 99
+}
+'
+	})
+	assert output == '11'
+	assert generated.contains('a__choose'), generated
+	assert !generated.contains('b__choose'), generated
 }
 
 fn test_selective_import_does_not_import_other_symbols_by_suffix() {

--- a/vlib/v3/tests/selective_import_codegen_test.v
+++ b/vlib/v3/tests/selective_import_codegen_test.v
@@ -1,0 +1,267 @@
+import os
+
+const selective_import_vexe = @VEXE
+const selective_import_tests_dir = os.dir(@FILE)
+const selective_import_v3_dir = os.dir(selective_import_tests_dir)
+const selective_import_vlib_dir = os.dir(selective_import_v3_dir)
+const selective_import_v3_src = os.join_path(selective_import_v3_dir, 'v3.v')
+
+fn selective_import_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_selective_import_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${selective_import_vexe} -gc none -path "${selective_import_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${selective_import_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn selective_import_write_file(root string, rel string, src string) {
+	path := os.join_path(root, rel)
+	os.mkdir_all(os.dir(path)) or { panic(err) }
+	os.write_file(path, src) or { panic(err) }
+}
+
+fn selective_import_write_project(name string, main_src string) string {
+	return selective_import_write_project_with_extra(name, main_src, {})
+}
+
+fn selective_import_write_project_with_extra(name string, main_src string, extra_files map[string]string) string {
+	root := os.join_path(os.temp_dir(), 'v3_selective_import_${name}_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	selective_import_write_file(root, 'v.mod', "Module { name: 'selective_import_test' }\n")
+	selective_import_write_file(root, 'mymodules/main_functions.v', 'module mymodules
+
+pub fn add_xy(x int, y int) int {
+	return x + y
+}
+
+pub fn hidden_xy(x int, y int) int {
+	return x * 100 + y
+}
+')
+	selective_import_write_file(root, 'mymodules/submodule/sub_functions.v', 'module submodule
+
+pub fn sub_xy(x int, y int) int {
+	return x - y
+}
+')
+	selective_import_write_file(root, 'main.v', main_src)
+	for rel, src in extra_files {
+		selective_import_write_file(root, rel, src)
+	}
+	return root
+}
+
+fn selective_import_compile_run(v3_bin string, name string, main_src string) (string, string) {
+	root := selective_import_write_project(name, main_src)
+	bin := os.join_path(root, 'out')
+	compile := os.execute('${v3_bin} ${root} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	return run.output.trim_space(), generated
+}
+
+fn selective_import_compile_bad(v3_bin string, name string, main_src string) string {
+	root := selective_import_write_project(name, main_src)
+	return selective_import_compile_bad_root(v3_bin, name, root)
+}
+
+fn selective_import_compile_bad_with_extra(v3_bin string, name string, main_src string, extra_files map[string]string) string {
+	root := selective_import_write_project_with_extra(name, main_src, extra_files)
+	return selective_import_compile_bad_root(v3_bin, name, root)
+}
+
+fn selective_import_compile_bad_root(v3_bin string, name string, root string) string {
+	bin := os.join_path(root, 'out')
+	compile := os.execute('${v3_bin} ${root} -b c -o ${bin}')
+	assert compile.exit_code != 0, '${name}: compile unexpectedly succeeded: ${compile.output}'
+	assert !compile.output.contains('C compilation failed'), compile.output
+	return compile.output
+}
+
+fn selective_import_ambiguous_modules() map[string]string {
+	return {
+		'a/a.v': 'module a
+
+pub fn hit() int {
+	return 1
+}
+'
+		'b/b.v': 'module b
+
+pub fn hit() int {
+	return 2
+}
+'
+	}
+}
+
+fn test_selective_import_calls_module_and_submodule_functions() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run(v3_bin, 'positive', 'module main
+
+import mymodules { add_xy }
+import mymodules.submodule { sub_xy }
+
+fn main() {
+	println(int_str(add_xy(2, 3)))
+	println(int_str(sub_xy(10, 7)))
+}
+')
+	assert output == '5\n3'
+	assert generated.contains('mymodules__add_xy(2, 3)'), generated
+	assert generated.contains('submodule__sub_xy(10, 7)'), generated
+}
+
+fn test_selective_import_symbol_can_be_used_as_function_value() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run(v3_bin, 'fn_value', 'module main
+
+import mymodules { add_xy }
+
+fn main() {
+	f := add_xy
+	println(int_str(f(2, 3)))
+}
+')
+	assert output == '5'
+	assert generated.contains('mymodules__add_xy'), generated
+	assert generated.contains('f(2, 3)'), generated
+	assert !generated.contains('int f = mymodules__add_xy'), generated
+}
+
+fn test_selective_import_does_not_import_other_symbols_by_suffix() {
+	v3_bin := selective_import_build_v3()
+	output := selective_import_compile_bad(v3_bin, 'hidden_symbol', 'module main
+
+import mymodules { add_xy }
+
+fn main() {
+	println(int_str(hidden_xy(2, 3)))
+}
+')
+	assert output.contains('unknown function `hidden_xy`'), output
+}
+
+fn test_selective_import_scope_is_file_local() {
+	v3_bin := selective_import_build_v3()
+	output := selective_import_compile_bad_with_extra(v3_bin, 'file_local', 'module main
+
+import mymodules { add_xy }
+
+fn main() {
+	println(int_str(add_xy(1, 2)))
+}
+', {
+		'other.v': 'module main
+
+fn from_other_file() int {
+	return add_xy(3, 4)
+}
+'
+	})
+	assert output.contains('unknown function `add_xy`'), output
+}
+
+fn test_selective_import_same_symbol_from_two_modules_is_ambiguous() {
+	v3_bin := selective_import_build_v3()
+	output := selective_import_compile_bad_with_extra(v3_bin, 'ambiguous_symbol', 'module main
+
+import a { hit }
+import b { hit }
+
+fn main() {
+	println(int_str(hit()))
+}
+',
+		selective_import_ambiguous_modules())
+	assert output.contains('ambiguous selective import `hit`'), output
+}
+
+fn test_duplicate_selective_import_fails_even_when_unused() {
+	v3_bin := selective_import_build_v3()
+	output := selective_import_compile_bad_with_extra(v3_bin, 'ambiguous_unused', 'module main
+
+import a { hit }
+import b { hit }
+
+fn main() {
+	println("ok")
+}
+',
+		selective_import_ambiguous_modules())
+	assert output.contains('ambiguous selective import `hit`'), output
+}
+
+fn test_duplicate_selective_import_fails_even_with_local_homonym() {
+	v3_bin := selective_import_build_v3()
+	output := selective_import_compile_bad_with_extra(v3_bin, 'ambiguous_local_homonym', 'module main
+
+import a { hit }
+import b { hit }
+
+fn hit() int {
+	return 3
+}
+
+fn main() {
+	println(int_str(hit()))
+}
+',
+		selective_import_ambiguous_modules())
+	assert output.contains('ambiguous selective import `hit`'), output
+}
+
+fn test_duplicate_selective_import_function_value_reports_ambiguous() {
+	v3_bin := selective_import_build_v3()
+	output := selective_import_compile_bad_with_extra(v3_bin, 'ambiguous_fn_value', 'module main
+
+import a { hit }
+import b { hit }
+
+fn main() {
+	f := hit
+	println(int_str(f()))
+}
+',
+		selective_import_ambiguous_modules())
+	assert output.contains('ambiguous selective import `hit`'), output
+	assert !output.contains('unknown identifier `hit`'), output
+}
+
+fn test_local_function_keeps_priority_over_selective_import_homonym() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run(v3_bin, 'local_homonym', 'module main
+
+import mymodules { add_xy }
+
+fn add_xy(x int, y int) int {
+	return x * y
+}
+
+fn main() {
+	println(int_str(add_xy(2, 3)))
+}
+')
+	assert output == '6'
+	assert generated.contains('int add_xy(int x, int y)'), generated
+	assert generated.contains('int__str(add_xy(2, 3))'), generated
+	assert !generated.contains('int__str(mymodules__add_xy(2, 3))'), generated
+}
+
+fn test_selective_import_with_module_alias_keeps_symbol_authority() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run(v3_bin, 'alias', 'module main
+
+import mymodules as mm { add_xy }
+
+fn main() {
+	println(int_str(add_xy(4, 5)))
+}
+')
+	assert output == '9'
+	assert generated.contains('mymodules__add_xy(4, 5)'), generated
+	assert !generated.contains('mm__add_xy'), generated
+}

--- a/vlib/v3/tests/selective_import_codegen_test.v
+++ b/vlib/v3/tests/selective_import_codegen_test.v
@@ -107,6 +107,72 @@ pub fn hit() int {
 	}
 }
 
+fn selective_import_type_collision_modules() map[string]string {
+	return {
+		'geometry/geometry.v': 'module geometry
+
+pub struct Point {
+pub:
+	x int
+}
+
+pub struct Size {
+pub:
+	w int
+}
+
+pub type ItemId = int
+
+pub enum Mode {
+	on = 7
+	off = 8
+}
+
+@[flag]
+pub enum Perm {
+	a
+	b
+}
+
+pub struct Box[T] {
+pub:
+	value T
+}
+'
+		'pixels/pixels.v':     'module pixels
+
+pub struct Point {
+pub:
+	x int
+}
+
+pub struct Size {
+pub:
+	w int
+}
+
+pub type ItemId = int
+
+pub enum Mode {
+	on = 70
+	off = 80
+}
+
+@[flag]
+pub enum Perm {
+	a
+	c
+	b
+}
+
+pub struct Box[T] {
+pub:
+	other T
+}
+'
+	}
+}
+
 fn test_selective_import_calls_module_and_submodule_functions() {
 	v3_bin := selective_import_build_v3()
 	output, generated := selective_import_compile_run(v3_bin, 'positive', 'module main
@@ -304,4 +370,175 @@ fn main() {
 	assert output == '9'
 	assert generated.contains('mymodules__add_xy(4, 5)'), generated
 	assert !generated.contains('mm__add_xy'), generated
+}
+
+fn test_selective_import_resolves_struct_collision() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run_with_extra(v3_bin, 'struct_collision', 'module main
+
+import geometry { Point }
+import pixels
+
+fn main() {
+	p := Point{x: 7}
+	println(int_str(p.x))
+}
+',
+		selective_import_type_collision_modules())
+	assert output == '7'
+	assert generated.contains('geometry__Point p ='), generated
+	assert !generated.contains('pixels__Point p ='), generated
+}
+
+fn test_selective_import_resolves_generic_struct_collision() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run_with_extra(v3_bin,
+		'generic_struct_collision', 'module main
+
+import geometry { Box }
+import pixels
+
+fn main() {
+	b := Box[int]{value: 7}
+	p := pixels.Box[int]{other: 8}
+	println(int_str(b.value + p.other))
+}
+',
+		selective_import_type_collision_modules())
+	assert output == '15'
+	assert generated.contains('struct geometry__Box_int'), generated
+	assert generated.contains('struct pixels__Box_int'), generated
+	assert generated.contains('geometry__Box_int b ='), generated
+	assert generated.contains('pixels__Box_int p ='), generated
+}
+
+fn test_selective_import_resolves_alias_collision() {
+	v3_bin := selective_import_build_v3()
+	output, _ := selective_import_compile_run_with_extra(v3_bin, 'alias_collision', 'module main
+
+import geometry { ItemId }
+import pixels
+
+fn value(id ItemId) int {
+	return int(id)
+}
+
+fn main() {
+	println(int_str(value(ItemId(9))))
+}
+',
+		selective_import_type_collision_modules())
+	assert output == '9'
+}
+
+fn test_selective_import_resolves_enum_collision() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run_with_extra(v3_bin, 'enum_collision', 'module main
+
+import geometry { Mode }
+import pixels
+
+fn is_on(mode Mode) bool {
+	return mode == .on
+}
+
+fn main() {
+	if is_on(.on) {
+		println("on")
+	}
+}
+',
+		selective_import_type_collision_modules())
+	assert output == 'on'
+	assert generated.contains('return mode == 7;'), generated
+	assert generated.contains('is_on(7)'), generated
+	assert !generated.contains('return mode == 70;'), generated
+	assert !generated.contains('is_on(70)'), generated
+}
+
+fn test_selective_import_resolves_flag_enum_collision() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run_with_extra(v3_bin, 'flag_enum_collision', 'module main
+
+import geometry { Perm }
+import pixels
+
+fn main() {
+	m := Perm.a | .b
+	println(int_str(int(m)))
+}
+',
+		selective_import_type_collision_modules())
+	assert output == '3'
+	assert generated.contains('int m = 1 | 2;'), generated
+	assert !generated.contains('int m = 1 | 4;'), generated
+	assert !generated.contains('Perm.a'), generated
+}
+
+fn test_duplicate_selective_import_type_fails() {
+	v3_bin := selective_import_build_v3()
+	output := selective_import_compile_bad_with_extra(v3_bin, 'ambiguous_type', 'module main
+
+import geometry { Point }
+import pixels { Point }
+
+fn main() {
+	p := Point{x: 1}
+	println(int_str(p.x))
+}
+',
+		selective_import_type_collision_modules())
+	assert output.contains('ambiguous selective import `Point`'), output
+}
+
+fn test_duplicate_selective_import_enum_selector_fails() {
+	v3_bin := selective_import_build_v3()
+	output := selective_import_compile_bad_with_extra(v3_bin, 'ambiguous_enum_selector', 'module main
+
+import geometry { Mode }
+import pixels { Mode }
+
+fn main() {
+	mode := Mode.on
+	println(int_str(int(mode)))
+}
+',
+		selective_import_type_collision_modules())
+	assert output.contains('ambiguous selective import `Mode`'), output
+}
+
+fn test_selective_import_enum_selector_keeps_selected_authority() {
+	v3_bin := selective_import_build_v3()
+	output := selective_import_compile_bad_with_extra(v3_bin, 'enum_selector_authority', 'module main
+
+import geometry { Mode }
+import pixels
+
+fn takes_pixel(mode pixels.Mode) {}
+
+fn main() {
+	takes_pixel(Mode.on)
+}
+',
+		selective_import_type_collision_modules())
+	assert output.contains('cannot use `geometry.Mode` as argument 1 to `takes_pixel`; expected `pixels.Mode`'), output
+}
+
+fn test_unselected_type_from_selective_import_is_not_resolved_by_suffix() {
+	v3_bin := selective_import_build_v3()
+	output := selective_import_compile_bad_with_extra(v3_bin, 'unselected_type', 'module main
+
+import geometry { Point }
+import pixels
+
+fn use_size(s Size) int {
+	return s.w
+}
+
+fn main() {
+	println("ok")
+}
+',
+		selective_import_type_collision_modules())
+	assert output.contains('unknown type `Size`'), output
 }

--- a/vlib/v3/tests/selective_import_codegen_test.v
+++ b/vlib/v3/tests/selective_import_codegen_test.v
@@ -566,6 +566,105 @@ fn main() {
 	assert generated.contains('pixels__Box_int p ='), generated
 }
 
+fn test_selective_import_resolves_generic_struct_field_from_decl_file() {
+	v3_bin := selective_import_build_v3()
+	extra := {
+		'types/types.v': 'module types
+
+pub struct Thing {
+pub:
+	v int
+}
+'
+		'other/other.v': 'module other
+
+pub struct Thing {
+pub:
+	v int
+}
+'
+		'box/box.v':     'module box
+
+import types { Thing }
+
+pub struct Box[T] {
+pub:
+	thing Thing
+	value T
+}
+'
+	}
+	output, generated := selective_import_compile_run_with_extra(v3_bin,
+		'generic_struct_field_selective_import', 'module main
+
+import box { Box }
+import other
+
+fn main() {
+	b := Box[int]{value: 7}
+	o := other.Thing{v: 8}
+	println(int_str(b.value + o.v))
+}
+',
+		extra)
+	assert output == '15'
+	assert generated.contains('struct box__Box_int'), generated
+	assert generated.contains('types__Thing thing;'), generated
+	assert !generated.contains('box__Thing thing;'), generated
+	assert !generated.contains('other__Thing thing;'), generated
+}
+
+fn test_selective_import_resolves_generic_struct_method_signature_from_decl_file() {
+	v3_bin := selective_import_build_v3()
+	extra := {
+		'types/types.v': 'module types
+
+pub struct Thing {
+pub:
+	v int
+}
+'
+		'other/other.v': 'module other
+
+pub struct Thing {
+pub:
+	v int
+}
+'
+		'box/box.v':     'module box
+
+import types { Thing }
+
+pub struct Box[T] {
+pub:
+	thing Thing
+	value T
+}
+
+pub fn (b Box[T]) combine(thing Thing) int {
+	return b.value + thing.v
+}
+'
+	}
+	output, generated := selective_import_compile_run_with_extra(v3_bin,
+		'generic_struct_method_signature_selective_import', 'module main
+
+import box { Box }
+import other
+
+fn main() {
+	b := Box[int]{value: 7}
+	_ := other.Thing{v: 1}
+	println(int_str(b.combine(b.thing)))
+}
+',
+		extra)
+	assert output == '7'
+	assert generated.contains('int box__Box_int__combine(box__Box_int b, types__Thing thing)'), generated
+	assert !generated.contains('int box__Box_int__combine(box__Box_int b, box__Thing thing)'), generated
+	assert !generated.contains('int box__Box_int__combine(box__Box_int b, other__Thing thing)'), generated
+}
+
 fn test_selective_import_resolves_alias_collision() {
 	v3_bin := selective_import_build_v3()
 	output, _ := selective_import_compile_run_with_extra(v3_bin, 'alias_collision', 'module main

--- a/vlib/v3/tests/selective_import_codegen_test.v
+++ b/vlib/v3/tests/selective_import_codegen_test.v
@@ -223,6 +223,36 @@ pub fn add_xy(x int, y int) int {
 	assert !generated.contains('other__add_xy(x, y)'), generated
 }
 
+fn test_selective_import_explicit_generic_call_keeps_selected_symbol() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run_with_extra(v3_bin,
+		'explicit_generic_selective_import', 'module main
+
+import util { id }
+import other
+
+fn main() {
+	println(int_str(id[int](1)))
+}
+', {
+		'util/util.v':   'module util
+
+pub fn id[T](x T) T {
+	return x
+}
+'
+		'other/other.v': 'module other
+
+pub fn id[T](x T) T {
+	return x
+}
+'
+	})
+	assert output == '1'
+	assert generated.contains('util__id_T_v_int(1)'), generated
+	assert !generated.contains('other__id_T_v_int(1)'), generated
+}
+
 fn test_selective_import_fn_value_inside_generic_clone_keeps_source_file_symbol() {
 	v3_bin := selective_import_build_v3()
 	output, generated := selective_import_compile_run_with_extra(v3_bin,

--- a/vlib/v3/tests/selective_import_codegen_test.v
+++ b/vlib/v3/tests/selective_import_codegen_test.v
@@ -190,6 +190,130 @@ fn main() {
 	assert generated.contains('submodule__sub_xy(10, 7)'), generated
 }
 
+fn test_selective_import_inside_generic_clone_keeps_source_file_symbol() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run_with_extra(v3_bin,
+		'generic_clone_selective_import', 'module main
+
+import worker
+
+fn main() {
+	println(int_str(worker.use_add[int](0, 2, 3)))
+}
+', {
+		'worker/worker.v': 'module worker
+
+import mymodules { add_xy }
+import other
+
+pub fn use_add[T](marker T, x int, y int) int {
+	_ = marker
+	return add_xy(x, y)
+}
+'
+		'other/other.v':   'module other
+
+pub fn add_xy(x int, y int) int {
+	return x * 100 + y
+}
+'
+	})
+	assert output == '5'
+	assert generated.contains('mymodules__add_xy(x, y)'), generated
+	assert !generated.contains('other__add_xy(x, y)'), generated
+}
+
+fn test_selective_import_fn_value_inside_generic_clone_keeps_source_file_symbol() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run_with_extra(v3_bin,
+		'generic_clone_selective_import_fn_value', 'module main
+
+import worker
+
+fn main() {
+	println(int_str(worker.use_add_cb[int](0, 2, 3)))
+}
+', {
+		'worker/worker.v': 'module worker
+
+import mymodules { add_xy }
+import other
+
+fn takes(cb fn (int, int) int, x int, y int) int {
+	return cb(x, y)
+}
+
+pub fn use_add_cb[T](marker T, x int, y int) int {
+	_ = marker
+	return takes(add_xy, x, y)
+}
+'
+		'other/other.v':   'module other
+
+pub fn add_xy(x int, y int) int {
+	return x * 100 + y
+}
+'
+	})
+	assert output == '5'
+	assert generated.contains('worker__takes(mymodules__add_xy, x, y)'), generated
+	assert !generated.contains('worker__takes(add_xy, x, y)'), generated
+	assert !generated.contains('worker__takes(other__add_xy, x, y)'), generated
+}
+
+fn test_selective_import_type_inside_generic_clone_signature_keeps_source_file_symbol() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run_with_extra(v3_bin,
+		'generic_clone_selective_import_type_signature', 'module main
+
+import worker
+
+fn main() {
+	p := worker.make_point[int](7)
+	println(int_str(worker.take_point[int](p, 2) + p.x))
+}
+', {
+		'worker/worker.v':     'module worker
+
+import geometry { Point }
+import pixels
+
+pub fn make_point[T](x T) Point {
+	_ = x
+	return Point{
+		x: 3
+	}
+}
+
+pub fn take_point[T](p Point, x T) int {
+	_ = x
+	return p.x + 4
+}
+'
+		'geometry/geometry.v': 'module geometry
+
+pub struct Point {
+pub:
+	x int
+}
+'
+		'pixels/pixels.v':     'module pixels
+
+pub struct Point {
+pub:
+	x int
+}
+'
+	})
+	assert output == '10'
+	assert generated.contains('geometry__Point worker__make_point_T_v_int(int x)'), generated
+	assert generated.contains('int worker__take_point_T_v_int(geometry__Point p, int x)'), generated
+	assert !generated.contains('\nPoint worker__make_point_T_v_int(int x)'), generated
+	assert !generated.contains('\npixels__Point worker__make_point_T_v_int(int x)'), generated
+	assert !generated.contains('\nint worker__take_point_T_v_int(Point p, int x)'), generated
+	assert !generated.contains('\nint worker__take_point_T_v_int(pixels__Point p, int x)'), generated
+}
+
 fn test_selective_import_symbol_can_be_used_as_function_value() {
 	v3_bin := selective_import_build_v3()
 	output, generated := selective_import_compile_run(v3_bin, 'fn_value', 'module main
@@ -355,6 +479,36 @@ fn main() {
 	assert generated.contains('int add_xy(int x, int y)'), generated
 	assert generated.contains('int__str(add_xy(2, 3))'), generated
 	assert !generated.contains('int__str(mymodules__add_xy(2, 3))'), generated
+}
+
+fn test_module_homonym_function_signature_uses_module_key() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run_with_extra(v3_bin,
+		'module_homonym_signature', 'module main
+
+import foo
+
+fn value() int {
+	return 7
+}
+
+fn main() {
+	println(int_str(value()))
+	println(foo.value())
+}
+', {
+		'foo/foo.v': 'module foo
+
+pub fn value() string {
+	return "foo"
+}
+'
+	})
+	assert output == '7\nfoo'
+	assert generated.contains('int value(void);'), generated
+	assert generated.contains('string foo__value(void);'), generated
+	assert generated.contains('string foo__value(void) {'), generated
+	assert !generated.contains('int foo__value(void);'), generated
 }
 
 fn test_selective_import_with_module_alias_keeps_symbol_authority() {

--- a/vlib/v3/tests/sizeof_global_selector_codegen_test.v
+++ b/vlib/v3/tests/sizeof_global_selector_codegen_test.v
@@ -1,0 +1,104 @@
+import os
+
+const sizeof_global_vexe = @VEXE
+const sizeof_global_tests_dir = os.dir(@FILE)
+const sizeof_global_v3_dir = os.dir(sizeof_global_tests_dir)
+const sizeof_global_vlib_dir = os.dir(sizeof_global_v3_dir)
+const sizeof_global_v3_src = os.join_path(sizeof_global_v3_dir, 'v3.v')
+
+fn sizeof_global_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_sizeof_global_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${sizeof_global_vexe} -gc none -path "${sizeof_global_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${sizeof_global_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn sizeof_global_write_file(root string, rel string, src string) {
+	path := os.join_path(root, rel)
+	os.mkdir_all(os.dir(path)) or { panic(err) }
+	os.write_file(path, src) or { panic(err) }
+}
+
+fn sizeof_global_write_project() string {
+	root := os.join_path(os.temp_dir(), 'v3_sizeof_global_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	sizeof_global_write_file(root, 'moda/moda.v', 'module moda
+
+pub struct State {
+pub mut:
+	event int
+}
+
+__global global_sizeof_state State
+
+pub fn global_field_size() int {
+	return int(sizeof(global_sizeof_state.event))
+}
+
+pub fn local_field_size() int {
+	global_sizeof_state := State{
+		event: 3
+	}
+	return int(sizeof(global_sizeof_state.event))
+}
+
+pub fn type_size() int {
+	return int(sizeof(State))
+}
+')
+	sizeof_global_write_file(root, 'main.v', 'module main
+
+import moda
+
+struct State {
+	event int
+}
+
+__global global_sizeof_state State
+
+fn main_size() int {
+	return int(sizeof(global_sizeof_state.event))
+}
+
+fn main_type_size() int {
+	return int(sizeof(State))
+}
+
+fn main() {
+	mut score := main_size()
+	score += main_type_size()
+	score += moda.global_field_size()
+	score += moda.local_field_size()
+	score += moda.type_size()
+	score += int(sizeof(moda.State))
+	println(int_str(score))
+}
+')
+	return root
+}
+
+fn test_sizeof_selector_qualifies_global_without_rewriting_locals_or_types() {
+	v3_bin := sizeof_global_build_v3()
+	root := sizeof_global_write_project()
+	c_path := os.join_path(root, 'out.c')
+	compile := os.execute('${v3_bin} ${root} -b c -o ${c_path}')
+	assert compile.exit_code == 0, compile.output
+
+	c_code := os.read_file(c_path) or { panic(err) }
+	compact := c_code.replace('\t', '').replace(' ', '').replace('\n', '')
+	assert compact.contains('intmain_size(void){return(int)(sizeof(global_sizeof_state.event));}'), c_code
+
+	assert compact.contains('sizeof(moda__global_sizeof_state.event)'), c_code
+	assert compact.contains('intmoda__global_field_size(void){return(int)(sizeof(moda__global_sizeof_state.event));}'), c_code
+
+	assert compact.contains('sizeof(global_sizeof_state.event)'), c_code
+	assert compact.contains('moda__Stateglobal_sizeof_state=(moda__State){.event=3};return(int)(sizeof(global_sizeof_state.event));'), c_code
+
+	assert compact.count('sizeof(global_sizeof_state.event)') == 2, c_code
+	assert compact.contains('sizeof(State)'), c_code
+	assert compact.contains('sizeof(moda__State)'), c_code
+	assert !compact.contains('sizeof(moda.State)'), c_code
+	assert !compact.contains('global_sizeof_state__event'), c_code
+}

--- a/vlib/v3/tests/string_int_markused_codegen_test.v
+++ b/vlib/v3/tests/string_int_markused_codegen_test.v
@@ -1,0 +1,114 @@
+import os
+
+const string_int_vexe = @VEXE
+const string_int_tests_dir = os.dir(@FILE)
+const string_int_v3_dir = os.dir(string_int_tests_dir)
+const string_int_vlib_dir = os.dir(string_int_v3_dir)
+const string_int_v3_src = os.join_path(string_int_v3_dir, 'v3.v')
+
+fn string_int_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_string_int_markused_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${string_int_vexe} -gc none -path "${string_int_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${string_int_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn test_top_level_string_int_roots_exact_receiver_method() {
+	v3_bin := string_int_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_string_int_markused_${os.getpid()}.v')
+	os.write_file(src, "module main
+
+struct S {
+	value int
+}
+
+struct U {
+	value int
+}
+
+fn (s S) int() int {
+	return s.value + 1
+}
+
+fn (u U) int() int {
+	return u.value + 100
+}
+
+fn use_local_receiver() {
+	s := S{
+		value: 41
+	}
+	println(s.int())
+}
+
+println('42'.int())
+use_local_receiver()
+") or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_string_int_markused_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('implicit declaration'), compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '42\n42', run.output
+
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	string_int_refs := generated.count('string__int(')
+	assert string_int_refs >= 2, generated
+	assert generated.contains('S__int('), generated
+	assert !generated.contains('U__int('), generated
+}
+
+fn test_top_level_or_block_root_receiver_call_roots_string_int() {
+	v3_bin := string_int_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_string_int_or_root_${os.getpid()}.v')
+	os.write_file(src, "module main
+
+n := arguments()[1] or { '10' }.int()
+println(n)
+") or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_string_int_or_root_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('implicit declaration'), compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '10', run.output
+
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	assert generated.contains('string__int('), generated
+}
+
+fn test_top_level_calls_are_ignored_when_explicit_main_exists() {
+	v3_bin := string_int_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_explicit_main_ignores_top_level_${os.getpid()}.v')
+	os.write_file(src, "module main
+
+fn ignored_top_level_only() {
+	println('ignored')
+}
+
+ignored_top_level_only()
+
+fn main() {
+	println('entry')
+}
+") or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_explicit_main_ignores_top_level_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'entry', run.output
+
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	assert !generated.contains('ignored_top_level_only('), generated
+}

--- a/vlib/v3/tests/struct_init_alias_authority_codegen_test.v
+++ b/vlib/v3/tests/struct_init_alias_authority_codegen_test.v
@@ -1,0 +1,116 @@
+import os
+
+const struct_alias_vexe = @VEXE
+const struct_alias_tests_dir = os.dir(@FILE)
+const struct_alias_v3_dir = os.dir(struct_alias_tests_dir)
+const struct_alias_vlib_dir = os.dir(struct_alias_v3_dir)
+const struct_alias_v3_src = os.join_path(struct_alias_v3_dir, 'v3.v')
+
+fn struct_alias_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_struct_alias_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${struct_alias_vexe} -gc none -path "${struct_alias_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${struct_alias_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn struct_alias_write_project() string {
+	root := os.join_path(os.temp_dir(), 'v3_struct_alias_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	gg_dir := os.join_path(root, 'gg')
+	sgl_dir := os.join_path(root, 'sgl_like')
+	os.mkdir_all(gg_dir) or { panic(err) }
+	os.mkdir_all(sgl_dir) or { panic(err) }
+	os.write_file(os.join_path(gg_dir, 'gg.v'), 'module gg
+
+pub struct Context {
+pub:
+	render_text int
+	foreign_only int = 99
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(sgl_dir, 'sgl_context.h'), '#ifndef V3_STRUCT_ALIAS_SGL_CONTEXT_H
+#define V3_STRUCT_ALIAS_SGL_CONTEXT_H
+struct sgl_context {
+	unsigned int id;
+};
+#endif
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(sgl_dir, 'sgl_like.v'), 'module sgl_like
+
+import gg
+
+#include "@DIR/sgl_context.h"
+
+pub struct C.sgl_context {
+pub:
+	id u32
+}
+
+pub type Context = C.sgl_context
+
+pub struct LocalBase {
+pub:
+	id u32
+}
+
+pub type LocalContext = LocalBase
+
+pub const context = Context{
+	id: 0x00010001
+}
+pub const local_context = LocalContext{
+	id: 7
+}
+
+pub fn context_score() int {
+	return int(context.id + local_context.id) + sizeof(gg.Context) - sizeof(gg.Context)
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'main.v'), 'module main
+
+import sgl_like
+
+struct Context {
+	render_text int = 11
+	main_only int = 12
+}
+
+fn main() {
+	println(int_str(sgl_like.context_score()))
+}
+') or {
+		panic(err)
+	}
+	return root
+}
+
+fn test_struct_init_uses_local_alias_authority_before_short_name_fallback() {
+	v3_bin := struct_alias_build_v3()
+	root := struct_alias_write_project()
+	bin := os.join_path(root, 'out')
+	compile := os.execute('${v3_bin} ${root} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '65544'
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	assert generated.contains('const struct sgl_context sgl_like__context = (struct sgl_context){'), generated
+	assert generated.contains('.id = (u32)(0x00010001)') || generated.contains('.id = 0x00010001'), generated
+
+	assert generated.contains('const sgl_like__LocalBase sgl_like__local_context = (sgl_like__LocalBase){'), generated
+
+	assert !generated.contains('sgl_like__context = (main__Context){'), generated
+	assert !generated.contains('(gg__Context){'), generated
+	assert !generated.contains('.render_text = 0x00010001'), generated
+	assert !generated.contains('.render_text = (u32)(0x00010001)'), generated
+	assert !generated.contains('.main_only = 0x00010001'), generated
+	assert !generated.contains('.main_only = (u32)(0x00010001)'), generated
+}

--- a/vlib/v3/tests/test_file_harness_codegen_test.v
+++ b/vlib/v3/tests/test_file_harness_codegen_test.v
@@ -1,0 +1,180 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn build_v3_with(name string, flags string) string {
+	v3_bin := os.join_path(os.temp_dir(), name)
+	build :=
+		os.execute('${vexe} -gc none ${flags} -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn build_v3() string {
+	return build_v3_with('v3_test_file_harness_test', '')
+}
+
+fn write_source(name string, suffix string, src string) string {
+	src_path := os.join_path(os.temp_dir(), 'v3_${name}${suffix}')
+	os.write_file(src_path, src) or { panic(err) }
+	return src_path
+}
+
+fn gen_c(v3_bin string, name string, suffix string, src string) string {
+	src_path := write_source(name, suffix, src)
+	c_path := os.join_path(os.temp_dir(), 'v3_${name}.c')
+	os.rm(c_path) or {}
+	compile := os.execute('${v3_bin} ${src_path} -b c -o ${c_path}')
+	assert compile.exit_code == 0, '${name}: C output failed: ${compile.output}'
+	assert os.exists(c_path), '${name}: missing generated C file ${c_path}'
+	return os.read_file(c_path) or { panic(err) }
+}
+
+fn compile_and_run(v3_bin string, name string, suffix string, src string) os.Result {
+	src_path := write_source(name, suffix, src)
+	bin_path := os.join_path(os.temp_dir(), 'v3_${name}')
+	compile := os.execute('${v3_bin} ${src_path} -b c -o ${bin_path}')
+	assert compile.exit_code == 0, '${name}: compile failed: ${compile.output}'
+	assert !compile.output.contains("undefined reference to `main'"), compile.output
+	return os.execute(bin_path)
+}
+
+fn compile_expect_failure(v3_bin string, name string, suffix string, src string) os.Result {
+	src_path := write_source(name, suffix, src)
+	bin_path := os.join_path(os.temp_dir(), 'v3_${name}')
+	c_path := bin_path + '.c'
+	os.rm(c_path) or {}
+	compile := os.execute('${v3_bin} ${src_path} -b c -o ${bin_path}')
+	assert compile.exit_code != 0, '${name}: compile unexpectedly succeeded: ${compile.output}'
+	assert !os.exists(c_path), '${name}: generated C despite harness input failure'
+	return compile
+}
+
+fn test_v3_generates_minimal_test_file_harness() {
+	v3_bin := build_v3()
+	order_src := "fn test_one() {
+	println('one')
+}
+
+fn test_two() {
+	println('two')
+}
+"
+	order_c := gen_c(v3_bin, 'harness_order', '_test.c.v', order_src)
+	assert order_c.contains('int main('), order_c
+	one_idx := order_c.index('test_one();') or { -1 }
+	two_idx := order_c.index('test_two();') or { -1 }
+	assert one_idx >= 0, order_c
+	assert two_idx > one_idx, order_c
+	order_run := compile_and_run(v3_bin, 'harness_order_run', '_test.c.v', order_src)
+	assert order_run.exit_code == 0, order_run.output
+	assert order_run.output.trim_space() == 'one\ntwo'
+
+	parallel_v3_bin := build_v3_with('v3_test_file_harness_parallel_test', '-d parallel')
+	parallel_c := gen_c(parallel_v3_bin, 'harness_parallel_order', '_test.c.v', order_src)
+	assert parallel_c.contains('int main('), parallel_c
+	assert parallel_c.contains('test_one();'), parallel_c
+	assert parallel_c.contains('test_two();'), parallel_c
+	parallel_run := compile_and_run(parallel_v3_bin, 'harness_parallel_order_run', '_test.c.v',
+		order_src)
+	assert parallel_run.exit_code == 0, parallel_run.output
+	assert parallel_run.output.trim_space() == 'one\ntwo'
+
+	hooks_src := "fn testsuite_begin() {
+	println('begin')
+}
+
+fn testsuite_end() {
+	println('end')
+}
+
+fn before_each() {
+	println('before')
+}
+
+fn after_each() {
+	println('after')
+}
+
+fn test_option() ? {
+	println('option')
+	return
+}
+
+fn test_result() ! {
+	println('result')
+	return
+}
+"
+	hooks_run := compile_and_run(v3_bin, 'harness_hooks', '_test.v', hooks_src)
+	assert hooks_run.exit_code == 0, hooks_run.output
+	assert hooks_run.output.trim_space() == 'begin\nbefore\noption\nafter\nbefore\nresult\nafter\nend'
+
+	result_fail := compile_and_run(v3_bin, 'harness_result_fail', '_test.v', "fn test_fail() ! {
+	return error('bad')
+}
+")
+	assert result_fail.exit_code != 0
+	assert result_fail.output.contains('test failed: test_fail')
+
+	option_fail := compile_and_run(v3_bin, 'harness_option_fail', '_test.v', 'fn test_fail() ? {
+	return none
+}
+')
+	assert option_fail.exit_code != 0
+	assert option_fail.output.contains('test failed: test_fail')
+
+	assert_fail := compile_and_run(v3_bin, 'harness_assert_fail', '_test.v', 'fn test_fail() {
+	assert false
+}
+')
+	assert assert_fail.exit_code != 0
+	assert assert_fail.output.contains('assert failed')
+
+	invalid_param := compile_expect_failure(v3_bin, 'harness_invalid_param', '_test.v', 'fn test_bad(i int) {
+}
+')
+	assert invalid_param.output.contains('invalid test signature'), invalid_param.output
+
+	invalid_return := compile_expect_failure(v3_bin, 'harness_invalid_return', '_test.v', 'fn test_bad() int {
+	return 1
+}
+')
+	assert invalid_return.output.contains('invalid test signature'), invalid_return.output
+
+	non_main := compile_expect_failure(v3_bin, 'harness_non_main_module', '_test.c.v', 'module sample
+
+fn test_one() {
+}
+')
+	assert non_main.output.contains('no runnable tests'), non_main.output
+
+	result_hook := compile_expect_failure(v3_bin, 'harness_result_hook', '_test.v', 'fn before_each() ! {
+	return
+}
+
+fn test_one() {
+}
+')
+	assert result_hook.output.contains('invalid test hook signature'), result_hook.output
+
+	option_hook := compile_expect_failure(v3_bin, 'harness_option_hook', '_test.v', 'fn after_each() ? {
+	return
+}
+
+fn test_one() {
+}
+')
+	assert option_hook.output.contains('invalid test hook signature'), option_hook.output
+
+	ordinary_c := gen_c(v3_bin, 'harness_plain_file', '.v', "fn test_lonely() {
+	println('lonely')
+}
+")
+	assert !ordinary_c.contains('int main('), ordinary_c
+	assert !ordinary_c.contains('test_lonely();'), ordinary_c
+}

--- a/vlib/v3/tests/test_file_harness_codegen_test.v
+++ b/vlib/v3/tests/test_file_harness_codegen_test.v
@@ -24,31 +24,68 @@ fn write_source(name string, suffix string, src string) string {
 	return src_path
 }
 
+fn write_project(name string, files map[string]string) string {
+	root := os.join_path(os.temp_dir(), 'v3_${name}')
+	os.rmdir_all(root) or {}
+	for rel, src in files {
+		path := os.join_path(root, rel)
+		os.mkdir_all(os.dir(path)) or { panic(err) }
+		os.write_file(path, src) or { panic(err) }
+	}
+	return root
+}
+
 fn gen_c(v3_bin string, name string, suffix string, src string) string {
+	return gen_c_flags(v3_bin, name, suffix, src, '')
+}
+
+fn gen_c_flags(v3_bin string, name string, suffix string, src string, flags string) string {
 	src_path := write_source(name, suffix, src)
 	c_path := os.join_path(os.temp_dir(), 'v3_${name}.c')
 	os.rm(c_path) or {}
-	compile := os.execute('${v3_bin} ${src_path} -b c -o ${c_path}')
+	compile := os.execute('${v3_bin} ${flags} ${src_path} -b c -o ${c_path}')
 	assert compile.exit_code == 0, '${name}: C output failed: ${compile.output}'
 	assert os.exists(c_path), '${name}: missing generated C file ${c_path}'
 	return os.read_file(c_path) or { panic(err) }
 }
 
 fn compile_and_run(v3_bin string, name string, suffix string, src string) os.Result {
+	return compile_and_run_flags(v3_bin, name, suffix, src, '')
+}
+
+fn compile_and_run_flags(v3_bin string, name string, suffix string, src string, flags string) os.Result {
 	src_path := write_source(name, suffix, src)
 	bin_path := os.join_path(os.temp_dir(), 'v3_${name}')
-	compile := os.execute('${v3_bin} ${src_path} -b c -o ${bin_path}')
+	compile := os.execute('${v3_bin} ${flags} ${src_path} -b c -o ${bin_path}')
 	assert compile.exit_code == 0, '${name}: compile failed: ${compile.output}'
 	assert !compile.output.contains("undefined reference to `main'"), compile.output
 	return os.execute(bin_path)
 }
 
+fn compile_project_and_run(v3_bin string, name string, files map[string]string) (os.Result, string) {
+	root := write_project(name, files)
+	return compile_project_root_and_run(v3_bin, name, root)
+}
+
+fn compile_project_root_and_run(v3_bin string, name string, root string) (os.Result, string) {
+	bin_path := os.join_path(root, 'out')
+	compile := os.execute('${v3_bin} ${root} -b c -o ${bin_path}')
+	assert compile.exit_code == 0, '${name}: compile failed: ${compile.output}'
+	run := os.execute(bin_path)
+	c_code := os.read_file(bin_path + '.c') or { panic(err) }
+	return run, c_code
+}
+
 fn compile_expect_failure(v3_bin string, name string, suffix string, src string) os.Result {
+	return compile_expect_failure_flags(v3_bin, name, suffix, src, '')
+}
+
+fn compile_expect_failure_flags(v3_bin string, name string, suffix string, src string, flags string) os.Result {
 	src_path := write_source(name, suffix, src)
 	bin_path := os.join_path(os.temp_dir(), 'v3_${name}')
 	c_path := bin_path + '.c'
 	os.rm(c_path) or {}
-	compile := os.execute('${v3_bin} ${src_path} -b c -o ${bin_path}')
+	compile := os.execute('${v3_bin} ${flags} ${src_path} -b c -o ${bin_path}')
 	assert compile.exit_code != 0, '${name}: compile unexpectedly succeeded: ${compile.output}'
 	assert !os.exists(c_path), '${name}: generated C despite harness input failure'
 	return compile
@@ -177,4 +214,108 @@ fn test_one() {
 ")
 	assert !ordinary_c.contains('int main('), ordinary_c
 	assert !ordinary_c.contains('test_lonely();'), ordinary_c
+}
+
+fn test_v3_test_file_harness_rejects_top_level_stmt() {
+	v3_bin := build_v3()
+	src := "println('top')
+
+fn test_one() {
+	println('test')
+}
+"
+	invalid := compile_expect_failure(v3_bin, 'harness_top_level_and_test', '_test.v', src)
+	assert invalid.output.contains('executable top-level statements are not supported in test files'), invalid.output
+}
+
+fn test_v3_test_file_harness_finds_top_level_comptime_block_tests() {
+	v3_bin := build_v3()
+	src := "$if v3_nested_harness ? {
+	fn before_each() {
+		println('before')
+	}
+
+	fn test_nested() {
+		println('nested')
+	}
+}
+"
+	c_code := gen_c_flags(v3_bin, 'harness_nested_block', '_test.v', src, '-d v3_nested_harness')
+	assert c_code.contains('before_each();'), c_code
+	assert c_code.contains('test_nested();'), c_code
+	run := compile_and_run_flags(v3_bin, 'harness_nested_block_run', '_test.v', src,
+		'-d v3_nested_harness')
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'before\nnested'
+
+	invalid := compile_expect_failure_flags(v3_bin, 'harness_nested_invalid', '_test.v', '$if v3_nested_harness ? {
+	fn test_bad(i int) {
+	}
+}
+',
+		'-d v3_nested_harness')
+	assert invalid.output.contains('invalid test signature'), invalid.output
+}
+
+fn test_v3_top_level_main_preserves_file_import_alias_context() {
+	v3_bin := build_v3()
+	run, c_code := compile_project_and_run(v3_bin, 'harness_file_alias_context', {
+		'v.mod':      'Module { name: "alias_context" }
+'
+		'a/a.v':      'module a
+
+pub fn value() int {
+	return 11
+}
+'
+		'b/b.v':      'module b
+
+pub fn value() int {
+	return 22
+}
+'
+		'aa_alias.v': 'module main
+
+import a as m
+
+a_value := m.value()
+println(int_str(a_value))
+'
+		'zz_alias.v': 'module main
+
+import b as m
+
+b_value := m.value()
+println(int_str(b_value))
+'
+	})
+	assert run.exit_code == 0, run.output
+	lines := run.output.trim_space().split_into_lines()
+	assert lines.len == 2, run.output
+	assert '11' in lines, run.output
+	assert '22' in lines, run.output
+	assert c_code.contains('a__value()'), c_code
+	assert c_code.contains('b__value()'), c_code
+}
+
+fn test_v3_top_level_match_lowers_before_cgen_main() {
+	v3_bin := build_v3()
+	run := compile_and_run(v3_bin, 'harness_top_level_match', '.v', "x := match 2 {
+	2 {
+		7
+	}
+	else {
+		3
+	}
+}
+println(int_str(x))
+match 2 {
+	2 {
+		println('two')
+	}
+	else {}
+}
+")
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '7\ntwo'
 }

--- a/vlib/v3/tests/test_file_harness_codegen_test.v
+++ b/vlib/v3/tests/test_file_harness_codegen_test.v
@@ -158,12 +158,46 @@ fn test_result() ! {
 	assert result_fail.exit_code != 0
 	assert result_fail.output.contains('test failed: test_fail')
 
+	result_fail_cleanup := compile_and_run(v3_bin, 'harness_result_fail_cleanup', '_test.v', "fn testsuite_end() {
+	println('end')
+}
+
+fn after_each() {
+	println('after')
+}
+
+fn test_fail() ! {
+	return error('bad')
+}
+")
+	assert result_fail_cleanup.exit_code != 0
+	assert result_fail_cleanup.output.contains('test failed: test_fail')
+	assert result_fail_cleanup.output.contains('after')
+	assert result_fail_cleanup.output.contains('end')
+
 	option_fail := compile_and_run(v3_bin, 'harness_option_fail', '_test.v', 'fn test_fail() ? {
 	return none
 }
 ')
 	assert option_fail.exit_code != 0
 	assert option_fail.output.contains('test failed: test_fail')
+
+	option_fail_cleanup := compile_and_run(v3_bin, 'harness_option_fail_cleanup', '_test.v', "fn testsuite_end() {
+	println('end')
+}
+
+fn after_each() {
+	println('after')
+}
+
+fn test_fail() ? {
+	return none
+}
+")
+	assert option_fail_cleanup.exit_code != 0
+	assert option_fail_cleanup.output.contains('test failed: test_fail')
+	assert option_fail_cleanup.output.contains('after')
+	assert option_fail_cleanup.output.contains('end')
 
 	assert_fail := compile_and_run(v3_bin, 'harness_assert_fail', '_test.v', 'fn test_fail() {
 	assert false
@@ -226,6 +260,136 @@ fn test_one() {
 "
 	invalid := compile_expect_failure(v3_bin, 'harness_top_level_and_test', '_test.v', src)
 	assert invalid.output.contains('executable top-level statements are not supported in test files'), invalid.output
+}
+
+fn test_v3_test_file_harness_owns_entrypoint_over_user_main() {
+	v3_bin := build_v3()
+	src := "fn main() {
+	println('user-main')
+}
+
+fn test_one() {
+	println('test')
+}
+"
+	c_code := gen_c(v3_bin, 'harness_user_main', '_test.v', src)
+	assert c_code.count('int main(') == 1, c_code
+	assert c_code.contains('test_one();'), c_code
+	run := compile_and_run(v3_bin, 'harness_user_main_run', '_test.v', src)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'test'
+}
+
+fn test_v3_test_file_harness_keeps_user_main_callable() {
+	v3_bin := build_v3()
+	src := "fn main() {
+	println('user-main')
+}
+
+fn test_call_main() {
+	main()
+}
+"
+	c_code := gen_c(v3_bin, 'harness_user_main_callable', '_test.v', src)
+	assert c_code.count('int main(') == 1, c_code
+	assert c_code.contains('main__user_main'), c_code
+	assert c_code.contains('main__user_main();'), c_code
+	assert c_code.contains('test_call_main();'), c_code
+	run := compile_and_run(v3_bin, 'harness_user_main_callable_run', '_test.v', src)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'user-main'
+}
+
+fn test_v3_test_file_harness_forward_declares_user_main() {
+	v3_bin := build_v3()
+	src := "fn test_call_main() {
+	main()
+}
+
+fn main() {
+	println('late-main')
+}
+"
+	c_code := gen_c(v3_bin, 'harness_user_main_forward', '_test.v', src)
+	assert c_code.count('int main(') == 1, c_code
+	proto_idx := c_code.index('void main__user_main(void);') or { -1 }
+	test_idx := c_code.index('void test_call_main(void) {') or { -1 }
+	assert proto_idx >= 0, c_code
+	assert test_idx > proto_idx, c_code
+	assert c_code.contains('main__user_main();'), c_code
+	run := compile_and_run(v3_bin, 'harness_user_main_forward_run', '_test.v', src)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'late-main'
+}
+
+fn test_v3_test_file_harness_renames_user_main_without_collision() {
+	v3_bin := build_v3()
+	src := "fn main__user_main() {
+	println('collision')
+}
+
+fn main() {
+	println('user-main')
+}
+
+fn test_call_both() {
+	main__user_main()
+	main()
+}
+"
+	c_code := gen_c(v3_bin, 'harness_user_main_collision', '_test.v', src)
+	assert c_code.count('int main(') == 1, c_code
+	assert c_code.contains('void main__user_main('), c_code
+	assert c_code.contains('void main__user_main_1('), c_code
+	assert c_code.contains('main__user_main();'), c_code
+	assert c_code.contains('main__user_main_1();'), c_code
+	run := compile_and_run(v3_bin, 'harness_user_main_collision_run', '_test.v', src)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'collision\nuser-main'
+}
+
+fn test_v3_test_file_harness_renames_user_main_fn_value() {
+	v3_bin := build_v3()
+	src := "fn main() {
+	println('user-main')
+}
+
+fn test_fn_value_main() {
+	f := main
+	f()
+}
+"
+	c_code := gen_c(v3_bin, 'harness_user_main_fn_value', '_test.v', src)
+	assert c_code.count('int main(') == 1, c_code
+	assert c_code.contains('main__user_main'), c_code
+	assert c_code.contains('test_fn_value_main();'), c_code
+	assert !c_code.contains('= main;'), c_code
+	run := compile_and_run(v3_bin, 'harness_user_main_fn_value_run', '_test.v', src)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'user-main'
+}
+
+fn test_v3_test_file_harness_renames_user_main_fn_arg() {
+	v3_bin := build_v3()
+	src := "fn takes(cb fn ()) {
+	cb()
+}
+
+fn main() {
+	println('user-main')
+}
+
+fn test_fn_arg_main() {
+	takes(main)
+}
+"
+	c_code := gen_c(v3_bin, 'harness_user_main_fn_arg', '_test.v', src)
+	assert c_code.count('int main(') == 1, c_code
+	assert c_code.contains('takes(main__user_main);'), c_code
+	assert !c_code.contains('takes(main);'), c_code
+	run := compile_and_run(v3_bin, 'harness_user_main_fn_arg_run', '_test.v', src)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'user-main'
 }
 
 fn test_v3_test_file_harness_finds_top_level_comptime_block_tests() {

--- a/vlib/v3/tests/test_file_harness_codegen_test.v
+++ b/vlib/v3/tests/test_file_harness_codegen_test.v
@@ -405,6 +405,33 @@ fn test_fn_arg_main() {
 	assert run.output.trim_space() == 'user-main'
 }
 
+fn test_v3_test_file_harness_does_not_rename_shadowed_main_fn_value_call() {
+	v3_bin := build_v3()
+	src := "fn call_shadowed(main fn ()) {
+	main()
+}
+
+fn local_cb() {
+	println('local-cb')
+}
+
+fn main() {
+	println('user-main')
+}
+
+fn test_shadowed_main() {
+	call_shadowed(local_cb)
+}
+"
+	c_code := gen_c(v3_bin, 'harness_shadowed_main_fn_value_call', '_test.v', src)
+	assert c_code.count('int main(') == 1, c_code
+	assert c_code.contains('main();'), c_code
+	assert !c_code.contains('main__user_main();'), c_code
+	run := compile_and_run(v3_bin, 'harness_shadowed_main_fn_value_call_run', '_test.v', src)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'local-cb'
+}
+
 fn test_v3_test_file_harness_finds_top_level_comptime_block_tests() {
 	v3_bin := build_v3()
 	src := "$if v3_nested_harness ? {

--- a/vlib/v3/tests/test_file_harness_codegen_test.v
+++ b/vlib/v3/tests/test_file_harness_codegen_test.v
@@ -211,6 +211,11 @@ fn test_fail() ? {
 ')
 	assert invalid_param.output.contains('invalid test signature'), invalid_param.output
 
+	generic_test := compile_expect_failure(v3_bin, 'harness_generic_test', '_test.v', 'fn test_generic[T]() {
+}
+')
+	assert generic_test.output.contains('invalid test signature'), generic_test.output
+
 	invalid_return := compile_expect_failure(v3_bin, 'harness_invalid_return', '_test.v', 'fn test_bad() int {
 	return 1
 }
@@ -232,6 +237,14 @@ fn test_one() {
 }
 ')
 	assert result_hook.output.contains('invalid test hook signature'), result_hook.output
+
+	generic_hook := compile_expect_failure(v3_bin, 'harness_generic_hook', '_test.v', 'fn before_each[T]() {
+}
+
+fn test_one() {
+}
+')
+	assert generic_hook.output.contains('invalid test hook signature'), generic_hook.output
 
 	option_hook := compile_expect_failure(v3_bin, 'harness_option_hook', '_test.v', 'fn after_each() ? {
 	return
@@ -419,6 +432,19 @@ fn test_v3_test_file_harness_finds_top_level_comptime_block_tests() {
 ',
 		'-d v3_nested_harness')
 	assert invalid.output.contains('invalid test signature'), invalid.output
+
+	invalid_generic := compile_expect_failure_flags(v3_bin, 'harness_nested_generic_invalid',
+		'_test.v', '$if v3_nested_harness ? {
+	fn before_each[T]() {
+	}
+
+	fn test_nested[T]() {
+	}
+}
+',
+		'-d v3_nested_harness')
+	assert invalid_generic.output.contains('invalid test hook signature'), invalid_generic.output
+	assert invalid_generic.output.contains('invalid test signature'), invalid_generic.output
 }
 
 fn test_v3_top_level_main_preserves_file_import_alias_context() {

--- a/vlib/v3/tests/test_file_harness_codegen_test.v
+++ b/vlib/v3/tests/test_file_harness_codegen_test.v
@@ -536,3 +536,19 @@ match 2 {
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == '7\ntwo'
 }
+
+fn test_v3_top_level_defer_runs_after_synthetic_main_body() {
+	v3_bin := build_v3()
+	run := compile_and_run(v3_bin, 'harness_top_level_defer', '.v', "fn deferred_msg() string {
+	return 'deferred'
+}
+
+defer {
+	println(deferred_msg())
+}
+
+println('body')
+")
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'body\ndeferred'
+}

--- a/vlib/v3/tests/transformer_parity_test.v
+++ b/vlib/v3/tests/transformer_parity_test.v
@@ -466,7 +466,7 @@ fn main() {
 	mut left_shift_count := 0
 	for i in 0 .. main_fn.children_count {
 		child_id := a.child(&main_fn, i)
-		push_many_count += count_call_name(a, child_id, 'array_push_many')
+		push_many_count += count_call_name(a, child_id, 'array__push_many')
 		left_shift_count += count_infix_op(a, child_id, .left_shift)
 	}
 	assert push_many_count == 1

--- a/vlib/v3/tests/type_authority_codegen_test.v
+++ b/vlib/v3/tests/type_authority_codegen_test.v
@@ -1,0 +1,142 @@
+import os
+
+const type_authority_vexe = @VEXE
+const type_authority_tests_dir = os.dir(@FILE)
+const type_authority_v3_dir = os.dir(type_authority_tests_dir)
+const type_authority_vlib_dir = os.dir(type_authority_v3_dir)
+const type_authority_v3_src = os.join_path(type_authority_v3_dir, 'v3.v')
+
+fn type_authority_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_type_authority_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${type_authority_vexe} -gc none -path "${type_authority_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${type_authority_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn type_authority_write_file(root string, rel string, src string) {
+	path := os.join_path(root, rel)
+	os.mkdir_all(os.dir(path)) or { panic(err) }
+	os.write_file(path, src) or { panic(err) }
+}
+
+fn type_authority_write_project() string {
+	root := os.join_path(os.temp_dir(), 'v3_type_authority_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	type_authority_write_file(root, 'dep/dep.v', 'module dep
+
+pub struct Color {
+pub:
+	r int
+}
+
+pub const white = Color{
+	r: 9
+}
+
+pub struct TextCfg {
+pub:
+	color Color
+}
+
+pub fn choose(flag bool, fallback Color) TextCfg {
+	return TextCfg{
+		color: if flag { white } else { fallback }
+	}
+}
+')
+	type_authority_write_file(root, 'fixture/fixture.v', 'module fixture
+
+pub struct Thing {
+pub:
+	n int
+}
+
+pub const vals = [
+	Thing{
+		n: 11
+	},
+	Thing{
+		n: 12
+	},
+	Thing{
+		n: 13
+	},
+]
+
+pub fn pointer_score(idx int) int {
+	first := Thing{
+		n: 3
+	}
+	second := Thing{
+		n: 4
+	}
+	third := Thing{
+		n: 5
+	}
+	mut ptrs := [3]&Thing{}
+	ptrs[0] = &first
+	ptrs[1] = &second
+	ptrs[2] = &third
+	item := ptrs[idx]
+	return item.n
+}
+
+pub fn value_score(idx int) int {
+	item := vals[idx]
+	return item.n
+}
+
+pub fn local_fixed_score() int {
+	mut fixed := [3]Thing{}
+	fixed[1] = Thing{
+		n: 17
+	}
+	return fixed[1].n
+}
+')
+	type_authority_write_file(root, 'main.v', 'module main
+
+import dep
+import fixture
+
+struct Color {
+	wrong int
+}
+
+fn main() {
+	picked := dep.choose(false, dep.Color{
+		r: 5
+	})
+	score := picked.color.r + fixture.pointer_score(2) + fixture.value_score(1) + fixture.local_fixed_score() +
+		sizeof(Color) - sizeof(Color)
+	println(int_str(score))
+}
+')
+	return root
+}
+
+fn test_imported_type_authority_for_if_expr_and_fixed_array_index() {
+	v3_bin := type_authority_build_v3()
+	root := type_authority_write_project()
+	bin := os.join_path(root, 'out')
+	compile := os.execute('${v3_bin} ${root} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '39'
+
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	assert generated.contains('dep__Color __if_val_'), generated
+	assert !generated.contains('\n\tColor __if_val_'), generated
+	assert !generated.contains('\nColor __if_val_'), generated
+	assert !generated.contains('main__Color __if_val_'), generated
+
+	assert generated.contains('fixture__Thing* ptrs[3] = {0};'), generated
+	assert generated.contains('fixture__Thing* item = ptrs[idx];'), generated
+	assert generated.contains('fixture__Thing item = fixture__vals[idx];'), generated
+	assert !generated.contains('Array_fixed_fixture__Thingptr_3 item'), generated
+	assert !generated.contains('Array_fixed_fixture__Thing_3 item'), generated
+	assert generated.contains('fixture__Thing fixed[3] = {0};'), generated
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -3,12 +3,13 @@ import os
 const vexe = @VEXE
 const tests_dir = os.dir(@FILE)
 const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
 const v3_src = os.join_path(v3_dir, 'v3.v')
 
 // build_v3 builds v3 data for v3 tests.
 fn build_v3() string {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_type_checker_errors_test')
-	build := os.execute('${vexe} -o ${v3_bin} ${v3_src}')
+	build := os.execute('${vexe} -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0
 	return v3_bin
 }
@@ -681,6 +682,11 @@ fn test_pr_review_codegen_batch_fourteen() {
 	apply := run_good(v3_bin, 'good_generic_method_fn_type_param',
 		"struct Box[T] {\n\tv T\n}\nfn (b Box[T]) apply(cb fn (T) int) int {\n\treturn cb(b.v)\n}\nfn slen(s string) int {\n\treturn s.len\n}\nfn main() {\n\tb := Box[string]{\n\t\tv: 'hello'\n\t}\n\tprintln(int_str(b.apply(slen)))\n}\n")
 	assert apply == '5'
+	// The same substitution also handles named parameters inside the callback type:
+	// `fn (x T) int` specializes the type part to `fn (int) int`.
+	named_cb := run_good(v3_bin, 'good_generic_fn_named_callback_param',
+		'fn run[T](cb fn (x T) int, v T) int {\n\treturn cb(v)\n}\nfn inc(x int) int {\n\treturn x + 1\n}\nfn main() {\n\tprintln(int_str(run(inc, 4)))\n}\n')
+	assert named_cb == '5'
 	// A method value that escapes its call site is rejected: returned from a factory, stored
 	// in a struct field, or put in a map (the per-site static receiver can't keep several
 	// instances distinct). Immediately-passed callbacks and local bindings still work.

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -269,6 +269,14 @@ fn test_type_checker_reports_core_semantic_errors() {
 		'parent/child/child.v': 'module child\n\n__global flag int\n\nfn init() {\n\tflag = 41\n}\n\npub fn value() int {\n\treturn flag\n}\n'
 	}, 'main.v')
 	assert hier_init_order_out == '41\n41'
+	dotted_collision_init_order_out := run_good_project(v3_bin,
+		'dotted_collision_module_init_order', {
+		'main.v':          'module main\n\nimport foo.user as user\nimport bar as shortbar\n\nfn main() {\n\tprintln(int_str(user.value()))\n\tprintln(int_str(shortbar.value()))\n}\n'
+		'foo/user/user.v': 'module user\n\nimport foo.bar as foobar\n\n__global seen int\n\nfn init() {\n\tseen = foobar.value() + 1\n}\n\npub fn value() int {\n\treturn seen\n}\n'
+		'foo/bar/bar.v':   'module bar\n\n__global flag int\n\nfn init() {\n\tflag = 40\n}\n\npub fn value() int {\n\treturn flag\n}\n'
+		'bar/bar.v':       'module bar\n\n__global flag int\n\nfn init() {\n\tflag = 3\n}\n\npub fn value() int {\n\treturn flag\n}\n'
+	}, 'main.v')
+	assert dotted_collision_init_order_out == '41\n3'
 	transitive_init_order_out := run_good_project(v3_bin, 'transitive_module_init_order', {
 		'main.v':      'module main\n\nimport moda\n\n__global seen int\n\nfn init() {\n\tseen = moda.value()\n}\n\nfn main() {\n\tprintln(int_str(seen))\n\tprintln(int_str(moda.value()))\n}\n'
 		'moda/moda.v': 'module moda\n\nimport modb\n\npub fn value() int {\n\treturn modb.value()\n}\n'

--- a/vlib/v3/tests/x11_source_abi_alias_codegen_test.v
+++ b/vlib/v3/tests/x11_source_abi_alias_codegen_test.v
@@ -1,0 +1,98 @@
+import os
+
+const x11_alias_vexe = @VEXE
+const x11_alias_tests_dir = os.dir(@FILE)
+const x11_alias_v3_dir = os.dir(x11_alias_tests_dir)
+const x11_alias_vlib_dir = os.dir(x11_alias_v3_dir)
+const x11_alias_v3_src = os.join_path(x11_alias_v3_dir, 'v3.v')
+
+fn x11_alias_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_x11_alias_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${x11_alias_vexe} -gc none -path "${x11_alias_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${x11_alias_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn x11_alias_write_project() string {
+	root := os.join_path(os.temp_dir(), 'v3_x11_alias_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	os.write_file(os.join_path(root, 'native_abi.h'), '#ifndef V3_X11_ALIAS_NATIVE_ABI_H
+#define V3_X11_ALIAS_NATIVE_ABI_H
+typedef unsigned long NativeAtom;
+typedef unsigned long NativeKeySym;
+typedef unsigned long NativeWindow;
+#endif
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'main.v'), 'module main
+
+#include "@DIR/native_abi.h"
+
+pub type Atom = C.NativeAtom
+pub type KeySym = C.NativeKeySym
+pub type Window = C.NativeWindow
+pub type LocalId = u64
+
+fn C.take_key(key &KeySym)
+fn C.take_atom(atom &Atom)
+fn C.take_window(window Window)
+fn C.read_prop(window Window, property Atom, actual &Atom, count &usize, bytes &usize, prop &&u8)
+
+fn helper(value &&u8) usize {
+	mut actual_type := Atom(0)
+	mut item_count := usize(0)
+	mut bytes_after := usize(0)
+	window := Window(0)
+	property := Atom(0)
+	C.read_prop(window, property, &actual_type, &item_count, &bytes_after, value)
+	return item_count
+}
+
+fn main() {
+	mut keysym := KeySym(0)
+	C.take_key(&keysym)
+	mut protocols := [1]Atom{}
+	protocols[0] = Atom(1)
+	C.take_atom(&protocols[0])
+	window := Window(0)
+	C.take_window(window)
+	mut value := &u8(unsafe { nil })
+	count := helper(&&u8(&value))
+	mut local_id := LocalId(9)
+	score := int(count) + int(local_id)
+	println(int_str(score))
+}
+') or {
+		panic(err)
+	}
+	return root
+}
+
+fn test_c_typedef_aliases_are_preserved_for_x11_abi_shapes() {
+	v3_bin := x11_alias_build_v3()
+	root := x11_alias_write_project()
+	c_path := os.join_path(root, 'out.c')
+	compile := os.execute('${v3_bin} ${root} -b c -o ${c_path}')
+	assert compile.exit_code == 0, compile.output
+
+	c_code := os.read_file(c_path) or { panic(err) }
+	compact := c_code.replace('\t', '').replace(' ', '').replace('\n', '')
+	assert compact.contains('NativeKeySymkeysym'), c_code
+	assert compact.contains('NativeAtomprotocols[1]'), c_code
+	assert compact.contains('NativeWindowwindow'), c_code
+	assert compact.contains('NativeAtomactual_type'), c_code
+	assert compact.contains('size_titem_count'), c_code
+	assert compact.contains('size_tbytes_after'), c_code
+	assert compact.contains('read_prop(window,property,&actual_type,&item_count,&bytes_after,value);'), c_code
+
+	assert !compact.contains('u64keysym'), c_code
+	assert !compact.contains('u64protocols[1]'), c_code
+	assert !compact.contains('u64actual_type'), c_code
+	assert !compact.contains('0&(u8)(value)'), c_code
+	assert compact.contains('u64local_id'), c_code
+	assert !compact.contains('LocalIdlocal_id'), c_code
+}

--- a/vlib/v3/tests/x11_source_abi_alias_codegen_test.v
+++ b/vlib/v3/tests/x11_source_abi_alias_codegen_test.v
@@ -23,6 +23,7 @@ fn x11_alias_write_project() string {
 #define V3_X11_ALIAS_NATIVE_ABI_H
 typedef unsigned long NativeAtom;
 typedef unsigned long NativeKeySym;
+typedef unsigned long NativeULong;
 typedef unsigned long NativeWindow;
 #endif
 ') or {
@@ -34,22 +35,23 @@ typedef unsigned long NativeWindow;
 
 pub type Atom = C.NativeAtom
 pub type KeySym = C.NativeKeySym
+pub type NativeULong = C.NativeULong
 pub type Window = C.NativeWindow
 pub type LocalId = u64
 
 fn C.take_key(key &KeySym)
 fn C.take_atom(atom &Atom)
 fn C.take_window(window Window)
-fn C.read_prop(window Window, property Atom, actual &Atom, count &usize, bytes &usize, prop &&u8)
+fn C.read_prop(window Window, property Atom, actual &Atom, count &NativeULong, bytes &NativeULong, prop &&u8)
 
 fn helper(value &&u8) usize {
 	mut actual_type := Atom(0)
-	mut item_count := usize(0)
-	mut bytes_after := usize(0)
+	mut item_count := NativeULong(0)
+	mut bytes_after := NativeULong(0)
 	window := Window(0)
 	property := Atom(0)
 	C.read_prop(window, property, &actual_type, &item_count, &bytes_after, value)
-	return item_count
+	return usize(item_count)
 }
 
 fn main() {
@@ -85,13 +87,15 @@ fn test_c_typedef_aliases_are_preserved_for_x11_abi_shapes() {
 	assert compact.contains('NativeAtomprotocols[1]'), c_code
 	assert compact.contains('NativeWindowwindow'), c_code
 	assert compact.contains('NativeAtomactual_type'), c_code
-	assert compact.contains('size_titem_count'), c_code
-	assert compact.contains('size_tbytes_after'), c_code
+	assert compact.contains('NativeULongitem_count'), c_code
+	assert compact.contains('NativeULongbytes_after'), c_code
 	assert compact.contains('read_prop(window,property,&actual_type,&item_count,&bytes_after,value);'), c_code
 
 	assert !compact.contains('u64keysym'), c_code
 	assert !compact.contains('u64protocols[1]'), c_code
 	assert !compact.contains('u64actual_type'), c_code
+	assert !compact.contains('u64item_count'), c_code
+	assert !compact.contains('u64bytes_after'), c_code
 	assert !compact.contains('0&(u8)(value)'), c_code
 	assert compact.contains('u64local_id'), c_code
 	assert !compact.contains('LocalIdlocal_id'), c_code

--- a/vlib/v3/tests/x11_source_abi_alias_codegen_test.v
+++ b/vlib/v3/tests/x11_source_abi_alias_codegen_test.v
@@ -39,31 +39,38 @@ pub type NativeULong = C.NativeULong
 pub type Window = C.NativeWindow
 pub type LocalId = u64
 
-fn C.take_key(key &KeySym)
-fn C.take_atom(atom &Atom)
-fn C.take_window(window Window)
-fn C.read_prop(window Window, property Atom, actual &Atom, count &NativeULong, bytes &NativeULong, prop &&u8)
+@[typedef]
+struct C.Display {}
 
-fn helper(value &&u8) usize {
+@[typedef]
+struct C.XKeyEvent {}
+
+fn C.XLookupString(event &C.XKeyEvent, buf &char, buf_len int, keysym &KeySym, status voidptr) int
+fn C.XSetWMProtocols(display &C.Display, window Window, protocols &Atom, count int) int
+fn C.XGetWindowProperty(display &C.Display, window Window, property Atom, offset i64, length i64, delete int, req_type Atom, actual &Atom, actual_format &int, count &NativeULong, bytes &NativeULong, prop &&u8) int
+
+fn helper(display &C.Display, window Window, value &&u8) usize {
 	mut actual_type := Atom(0)
 	mut item_count := NativeULong(0)
 	mut bytes_after := NativeULong(0)
-	window := Window(0)
+	mut actual_format := 0
 	property := Atom(0)
-	C.read_prop(window, property, &actual_type, &item_count, &bytes_after, value)
+	C.XGetWindowProperty(display, window, property, 0, 1, 0, property, &actual_type,
+		&actual_format, &item_count, &bytes_after, value)
 	return usize(item_count)
 }
 
 fn main() {
+	display := &C.Display(unsafe { nil })
+	mut event := C.XKeyEvent{}
 	mut keysym := KeySym(0)
-	C.take_key(&keysym)
+	C.XLookupString(&event, nil, 0, &keysym, nil)
 	mut protocols := [1]Atom{}
 	protocols[0] = Atom(1)
-	C.take_atom(&protocols[0])
 	window := Window(0)
-	C.take_window(window)
+	C.XSetWMProtocols(display, window, &protocols[0], 1)
 	mut value := &u8(unsafe { nil })
-	count := helper(&&u8(&value))
+	count := helper(display, window, &&u8(&value))
 	mut local_id := LocalId(9)
 	score := int(count) + int(local_id)
 	println(int_str(score))
@@ -89,7 +96,9 @@ fn test_c_typedef_aliases_are_preserved_for_x11_abi_shapes() {
 	assert compact.contains('NativeAtomactual_type'), c_code
 	assert compact.contains('NativeULongitem_count'), c_code
 	assert compact.contains('NativeULongbytes_after'), c_code
-	assert compact.contains('read_prop(window,property,&actual_type,&item_count,&bytes_after,value);'), c_code
+	assert compact.contains('XLookupString(&event,NULL,0,&keysym,NULL);'), c_code
+	assert compact.contains('XSetWMProtocols(display,window,&protocols[0],1);'), c_code
+	assert compact.contains('XGetWindowProperty(display,window,property,0,1,0,property,&actual_type,&actual_format,&item_count,&bytes_after,value);'), c_code
 
 	assert !compact.contains('u64keysym'), c_code
 	assert !compact.contains('u64protocols[1]'), c_code

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -17,8 +17,7 @@ fn (t &Transformer) resolve_call_name(node flat.Node) string {
 	match fn_node.kind {
 		.ident {
 			name := fn_node.value
-			// Try unqualified name first
-			if t.is_known_fn_name(name) {
+			if t.var_type(name).len > 0 {
 				return name
 			}
 			// Try qualified with current module
@@ -27,6 +26,10 @@ fn (t &Transformer) resolve_call_name(node flat.Node) string {
 				if t.is_known_fn_name(qname) {
 					return qname
 				}
+			}
+			// Try unqualified name after current-module authority.
+			if t.is_known_fn_name(name) {
+				return name
 			}
 			return name
 		}
@@ -638,6 +641,9 @@ fn (t &Transformer) call_is_variadic(call_name string) bool {
 	if call_name.len == 0 || isnil(t.tc) {
 		return false
 	}
+	if t.tc.c_variadic_fns[call_name] {
+		return false
+	}
 	return t.tc.fn_variadic[call_name] or { false }
 }
 
@@ -709,9 +715,6 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 		if const_arg := t.transform_const_array_arg_for_param(arg_id, param_type) {
 			return const_arg
 		}
-	}
-	if t.is_fn_pointer_type_name(param_type) && t.is_named_fn_value_arg(arg_id) {
-		return t.make_cast(param_type, t.transform_expr(arg_id), param_type)
 	}
 	return t.transform_expr_for_type(arg_id, param_type)
 }
@@ -1233,17 +1236,8 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 	if is_ref || clean_typ in ['voidptr', 'byteptr', 'charptr'] {
 		return t.make_call_typed('ptr_str', arr1(expr), 'string')
 	}
-	if clean_typ == 'IError' || clean_typ.ends_with('.IError') {
-		start := t.a.children.len
-		t.a.children << expr
-		return t.a.add_node(flat.Node{
-			kind:           .selector
-			op:             .dot
-			children_start: start
-			children_count: 1
-			value:          'message'
-			typ:            'string'
-		})
+	if clean_typ == 'IError' || clean_typ == 'builtin.IError' {
+		return t.make_call_typed('IError.str', arr1(expr), 'string')
 	}
 	match clean_typ {
 		'bool' {

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -285,7 +285,8 @@ fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_
 	t.drain_pending(mut prefix)
 	mut actual_iter_type := iter_type
 	container_type := t.node_type(container)
-	if container_type.len > 0 && !for_iter_type_has_generic_placeholder(actual_iter_type) {
+	if container_type.len > 0 && !for_iter_type_has_generic_placeholder(actual_iter_type)
+		&& !(t.is_fixed_array_type(actual_iter_type) && !t.is_fixed_array_type(container_type)) {
 		actual_iter_type = container_type
 	}
 	if actual_iter_type.starts_with('&[]') {
@@ -318,7 +319,7 @@ fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_
 	elem_var_type := if elem_needs_ref { '&${elem_type}' } else { elem_type }
 	t.set_var_type(elem_name, elem_var_type)
 	len_expr := if t.is_fixed_array_type(actual_iter_type) {
-		t.make_fixed_array_len_expr(actual_iter_type)
+		t.make_for_in_fixed_array_len_expr(actual_iter_type)
 	} else {
 		t.make_selector(container, 'len', 'int')
 	}
@@ -383,9 +384,45 @@ fn (mut t Transformer) detect_for_in_type(node flat.Node) string {
 	container_idx := if header_count >= 3 { header_count - 1 } else { 2 }
 	if node.children_count > container_idx {
 		iter_id := t.a.child(&node, container_idx)
+		if fixed_array_type := t.detect_for_in_global_fixed_array_type(iter_id) {
+			return fixed_array_type
+		}
 		return t.node_type(iter_id)
 	}
 	return ''
+}
+
+fn (t &Transformer) detect_for_in_global_fixed_array_type(id flat.NodeId) ?string {
+	if int(id) < 0 {
+		return none
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind != .ident || node.value.len == 0 {
+		return none
+	}
+	if t.var_type(node.value).len > 0 {
+		return none
+	}
+	mut candidates := []string{}
+	if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin' {
+		candidates << '${t.cur_module}.${node.value}'
+	}
+	candidates << node.value
+	for candidate in candidates {
+		if typ := t.globals[candidate] {
+			normalized := t.normalize_type_alias(typ)
+			if t.is_fixed_array_type(normalized) {
+				return normalized
+			}
+		}
+	}
+	if !isnil(t.tc) {
+		checker_type := t.normalize_type_alias(t.tc.resolve_type(id).name())
+		if t.is_fixed_array_type(checker_type) {
+			return checker_type
+		}
+	}
+	return none
 }
 
 fn for_iter_type_has_generic_placeholder(iter_type string) bool {
@@ -434,7 +471,7 @@ fn (t &Transformer) infer_for_in_elem_type(iter_type string, node flat.Node) str
 		return 'u8'
 	}
 	if t.is_fixed_array_type(iter_type) {
-		return fixed_array_elem_type(iter_type)
+		return for_in_fixed_array_elem_type(iter_type)
 	}
 	// Check if the iterable is a range expression
 	if node.children_count > 0 {
@@ -445,4 +482,50 @@ fn (t &Transformer) infer_for_in_elem_type(iter_type string, node flat.Node) str
 		}
 	}
 	return ''
+}
+
+fn (mut t Transformer) make_for_in_fixed_array_len_expr(s string) flat.NodeId {
+	len_text := for_in_fixed_array_len_text(s)
+	if is_decimal_text(len_text) {
+		return t.make_int_literal(len_text.int())
+	}
+	if !isnil(t.tc) {
+		if v := t.tc.const_int_value(len_text, []string{}) {
+			return t.make_int_literal(v)
+		}
+	}
+	if len_text.contains('.') {
+		base := len_text.all_before_last('.')
+		field := len_text.all_after_last('.')
+		return t.make_selector(t.make_ident(base), field, 'int')
+	}
+	return t.make_ident(len_text)
+}
+
+fn for_in_fixed_array_elem_type(s string) string {
+	clean := s.trim_space()
+	if clean.starts_with('[') {
+		return clean.all_after(']')
+	}
+	open := clean.last_index_u8(`[`)
+	if open < 0 {
+		return ''
+	}
+	return clean[..open]
+}
+
+fn for_in_fixed_array_len_text(s string) string {
+	clean := s.trim_space()
+	if clean.starts_with('[') {
+		return clean.all_after('[').all_before(']').trim_space()
+	}
+	open := clean.last_index_u8(`[`)
+	if open < 0 {
+		return ''
+	}
+	close_rel := clean[open + 1..].index_u8(`]`)
+	if close_rel < 0 {
+		return ''
+	}
+	return clean[open + 1..open + 1 + close_rel].trim_space()
 }

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -400,9 +400,13 @@ fn (mut t Transformer) materialize_generic_struct_spec(spec_name string, decl Ge
 		return
 	}
 	old_module := t.cur_module
+	old_file := t.cur_file
 	old_tc_module := t.tc.cur_module
+	old_tc_file := t.tc.cur_file
 	t.cur_module = decl.module
+	t.cur_file = decl.file
 	t.tc.cur_module = decl.module
+	t.tc.cur_file = decl.file
 	mut fields := []types.StructField{}
 	for i in 0 .. decl.node.children_count {
 		field := t.a.child_node(&decl.node, i)
@@ -424,7 +428,9 @@ fn (mut t Transformer) materialize_generic_struct_spec(spec_name string, decl Ge
 		t.tc.params_structs[spec_name] = true
 	}
 	t.cur_module = old_module
+	t.cur_file = old_file
 	t.tc.cur_module = old_tc_module
+	t.tc.cur_file = old_tc_file
 }
 
 fn (mut t Transformer) collect_generic_fn_decls() map[string]GenericFnDecl {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -604,6 +604,93 @@ fn (mut t Transformer) rewrite_generic_calls(decls map[string]GenericFnDecl, tem
 	}
 }
 
+fn (mut t Transformer) concrete_generic_call_return_type(id flat.NodeId, node flat.Node) string {
+	if node.kind != .call || node.children_count == 0 {
+		return ''
+	}
+	decls := t.cached_generic_fn_decls()
+	if decls.len == 0 {
+		return ''
+	}
+	decl_key := t.generic_call_decl_key(id, node, t.cur_module, decls) or { return '' }
+	decl := decls[decl_key] or { return '' }
+	if t.should_skip_generic_call_specialization(decl_key) {
+		return ''
+	}
+	mut args := []string{}
+	if explicit := t.explicit_generic_call_args(node, t.cur_module) {
+		args = explicit.clone()
+	} else {
+		args = t.infer_generic_call_args_from_params(decl, node) or { return '' }
+	}
+	if args.len == 0 || t.generic_args_have_placeholders(args) {
+		return ''
+	}
+	ret := substitute_generic_type_text(decl.node.typ, args)
+	if ret.len == 0 || t.generic_arg_is_unresolved(ret) {
+		return ''
+	}
+	return t.normalize_type_alias(ret)
+}
+
+fn (mut t Transformer) cached_generic_fn_decls() map[string]GenericFnDecl {
+	if !t.generic_fn_decls_ready {
+		t.generic_fn_decls_cache = t.collect_generic_fn_decls()
+		t.generic_fn_decls_ready = true
+	}
+	return t.generic_fn_decls_cache
+}
+
+fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, node flat.Node) ?[]string {
+	param_names := t.generic_fn_param_names(decl.node, decl.module)
+	if param_names.len == 0 {
+		return none
+	}
+	mut inferred := map[string]string{}
+	mut param_idx := 0
+	for i in 0 .. decl.node.children_count {
+		child := t.a.child_node(&decl.node, i)
+		if child.kind != .param {
+			continue
+		}
+		arg_idx := if t.generic_decl_is_receiver_method(decl.node) && param_idx == 0 {
+			0
+		} else {
+			param_idx + 1
+		}
+		if arg_idx >= int(node.children_count) {
+			param_idx++
+			continue
+		}
+		arg_id := if arg_idx == 0 {
+			t.generic_call_receiver_id(node) or {
+				param_idx++
+				continue
+			}
+		} else {
+			t.a.child(&node, arg_idx)
+		}
+		mut arg_type := t.node_type(arg_id)
+		if arg_type.len == 0 {
+			arg_type = t.generic_arg_expr_type(arg_id)
+		}
+		if arg_type.len > 0 {
+			infer_generic_type_args(child.typ, arg_type, mut inferred)
+			if t.generic_decl_is_receiver_method(decl.node) && param_idx == 0 {
+				t.infer_generic_receiver_suffix_args(child.typ, arg_type, mut inferred)
+				t.infer_generic_embedded_receiver_args(child.typ, arg_type, mut inferred)
+			}
+		}
+		param_idx++
+	}
+	mut args := []string{cap: param_names.len}
+	for name in param_names {
+		arg := inferred[name] or { return none }
+		args << t.generic_arg_for_decl_module(arg, decl.module)
+	}
+	return args
+}
+
 fn (mut t Transformer) rewrite_generic_plain_call(id flat.NodeId, node flat.Node, decl GenericFnDecl, args []string) {
 	spec_value := specialized_generic_fn_value(decl.node.value, args)
 	spec_name := transform_qualified_fn_name(decl.module, spec_value)

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -862,6 +862,7 @@ fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, n
 	if param_names.len == 0 {
 		return none
 	}
+	is_receiver := t.generic_decl_is_receiver_method(decl.node)
 	mut inferred := map[string]string{}
 	mut param_idx := 0
 	for i in 0 .. decl.node.children_count {
@@ -869,22 +870,10 @@ fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, n
 		if child.kind != .param {
 			continue
 		}
-		arg_idx := if t.generic_decl_is_receiver_method(decl.node) && param_idx == 0 {
-			0
-		} else {
-			param_idx + 1
-		}
-		if arg_idx >= int(node.children_count) {
+		is_recv_param := is_receiver && param_idx == 0
+		arg_id := t.generic_call_arg_id_for_param(node, param_idx, is_receiver) or {
 			param_idx++
 			continue
-		}
-		arg_id := if arg_idx == 0 {
-			t.generic_call_receiver_id(node) or {
-				param_idx++
-				continue
-			}
-		} else {
-			t.a.child(&node, arg_idx)
 		}
 		mut arg_type := t.node_type(arg_id)
 		if arg_type.len == 0 {
@@ -892,7 +881,7 @@ fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, n
 		}
 		if arg_type.len > 0 {
 			infer_generic_type_args(child.typ, arg_type, mut inferred)
-			if t.generic_decl_is_receiver_method(decl.node) && param_idx == 0 {
+			if is_recv_param {
 				t.infer_generic_receiver_suffix_args(child.typ, arg_type, mut inferred)
 				t.infer_generic_embedded_receiver_args(child.typ, arg_type, mut inferred)
 			}
@@ -1307,25 +1296,31 @@ fn (t &Transformer) explicit_generic_call_args(node flat.Node, module_name strin
 	return normalize_generic_args(split_generic_args(type_arg), module_name)
 }
 
+fn (t &Transformer) generic_call_arg_id_for_param(node flat.Node, param_idx int, is_receiver bool) ?flat.NodeId {
+	is_recv_param := is_receiver && param_idx == 0
+	selector_form := is_receiver && t.call_is_selector_form(node)
+	if is_recv_param {
+		if selector_form {
+			return t.generic_call_receiver_id(node)
+		}
+		if int(node.children_count) <= 1 {
+			return none
+		}
+		return t.a.child(&node, 1)
+	}
+	arg_idx := if selector_form { param_idx } else { param_idx + 1 }
+	if arg_idx >= int(node.children_count) {
+		return none
+	}
+	return t.a.child(&node, arg_idx)
+}
+
 fn (mut t Transformer) infer_generic_call_args(decl GenericFnDecl, _id flat.NodeId, node flat.Node) ?[]string {
 	param_names := t.generic_fn_param_names(decl.node, decl.module)
 	if param_names.len == 0 {
 		return none
 	}
 	is_receiver := t.generic_decl_is_receiver_method(decl.node)
-	// Determine the call form. The selector form (`recv.method(args)`) embeds the
-	// receiver in the callee, so explicit args begin at child index 1. The
-	// ident-lowered form (`Type__method(recv, args)`) passes the receiver as child
-	// 1, so explicit args begin at child index 2. Using the wrong offset misaligns
-	// every explicit param and makes method-level generic inference silently fail.
-	mut selector_form := false
-	if is_receiver {
-		mut callee := t.a.nodes[int(t.a.child(&node, 0))]
-		if callee.kind == .index && callee.children_count > 0 {
-			callee = t.a.nodes[int(t.a.child(&callee, 0))]
-		}
-		selector_form = callee.kind == .selector
-	}
 	mut inferred := map[string]string{}
 	mut param_idx := 0
 	for i in 0 .. decl.node.children_count {
@@ -1334,26 +1329,9 @@ fn (mut t Transformer) infer_generic_call_args(decl GenericFnDecl, _id flat.Node
 			continue
 		}
 		is_recv_param := is_receiver && param_idx == 0
-		arg_id := if is_recv_param {
-			if selector_form {
-				t.generic_call_receiver_id(node) or {
-					param_idx++
-					continue
-				}
-			} else {
-				if int(node.children_count) <= 1 {
-					param_idx++
-					continue
-				}
-				t.a.child(&node, 1)
-			}
-		} else {
-			arg_idx := if selector_form { param_idx } else { param_idx + 1 }
-			if arg_idx >= int(node.children_count) {
-				param_idx++
-				continue
-			}
-			t.a.child(&node, arg_idx)
+		arg_id := t.generic_call_arg_id_for_param(node, param_idx, is_receiver) or {
+			param_idx++
+			continue
 		}
 		mut arg_type := t.node_type(arg_id)
 		if arg_type.len == 0 {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -430,9 +430,13 @@ fn (mut t Transformer) materialize_generic_struct_spec(spec_name string, decl Ge
 fn (mut t Transformer) collect_generic_fn_decls() map[string]GenericFnDecl {
 	mut decls := map[string]GenericFnDecl{}
 	node_modules := t.node_module_map()
+	mut cur_file := ''
 	mut cur_module := ''
 	for i, node in t.a.nodes {
 		match node.kind {
+			.file {
+				cur_file = node.value
+			}
 			.module_decl {
 				cur_module = node.value
 			}
@@ -445,6 +449,7 @@ fn (mut t Transformer) collect_generic_fn_decls() map[string]GenericFnDecl {
 				decls[key] = GenericFnDecl{
 					id:     flat.NodeId(i)
 					node:   node
+					file:   cur_file
 					module: fn_module
 					key:    key
 				}
@@ -505,6 +510,16 @@ fn (mut t Transformer) collect_node_subtree_ids(id flat.NodeId, mut nodes map[in
 }
 
 fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args []string) flat.NodeId {
+	old_module := t.cur_module
+	old_file := t.cur_file
+	old_tc_module := if isnil(t.tc) { '' } else { t.tc.cur_module }
+	old_tc_file := if isnil(t.tc) { '' } else { t.tc.cur_file }
+	t.cur_module = decl.module
+	t.cur_file = decl.file
+	if !isnil(t.tc) {
+		t.tc.cur_module = decl.module
+		t.tc.cur_file = decl.file
+	}
 	if decl.module.len > 0 {
 		t.a.add_node(flat.Node{
 			kind:  .module_decl
@@ -514,24 +529,41 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 	old_params := t.active_generic_params
 	t.active_generic_params = t.generic_fn_param_names(decl.node, decl.module)
 	clone_id := t.clone_generic_fn_node(decl.node, args)
+	t.specialize_cloned_fn_signature(clone_id, decl, args)
 	clone := t.a.nodes[int(clone_id)]
 	t.register_specialized_fn_signature(decl, clone, args)
 	t.active_generic_params = old_params
-	t.transform_specialized_fn_body(clone_id, decl.module)
+	t.transform_specialized_fn_body(clone_id, decl.module, decl.file)
+	t.cur_module = old_module
+	t.cur_file = old_file
+	if !isnil(t.tc) {
+		t.tc.cur_module = old_tc_module
+		t.tc.cur_file = old_tc_file
+	}
 	return clone_id
 }
 
-fn (mut t Transformer) transform_specialized_fn_body(clone_id flat.NodeId, module_name string) {
+fn (mut t Transformer) transform_specialized_fn_body(clone_id flat.NodeId, module_name string, file_name string) {
 	if int(clone_id) < 0 || int(clone_id) >= t.a.nodes.len {
 		return
 	}
 	old_module := t.cur_module
+	old_file := t.cur_file
+	old_tc_file := if isnil(t.tc) { '' } else { t.tc.cur_file }
 	old_fn_name := t.cur_fn_name
 	old_ret_type := t.cur_fn_ret_type
 	old_var_types := t.var_types.clone()
 	t.cur_module = module_name
+	t.cur_file = file_name
+	if !isnil(t.tc) {
+		t.tc.cur_file = file_name
+	}
 	t.transform_fn_body(int(clone_id))
 	t.cur_module = old_module
+	t.cur_file = old_file
+	if !isnil(t.tc) {
+		t.tc.cur_file = old_tc_file
+	}
 	t.cur_fn_name = old_fn_name
 	t.cur_fn_ret_type = old_ret_type
 	t.var_types = old_var_types
@@ -548,14 +580,49 @@ fn (mut t Transformer) generated_fn_used_names(decl GenericFnDecl, clone_id flat
 	return names
 }
 
+fn (mut t Transformer) specialize_cloned_fn_signature(clone_id flat.NodeId, decl GenericFnDecl, args []string) {
+	if int(clone_id) < 0 || int(clone_id) >= t.a.nodes.len {
+		return
+	}
+	params := t.generic_fn_param_names(decl.node, decl.module)
+	t.a.nodes[int(clone_id)].typ = t.specialized_signature_type_text(decl, decl.node.typ, args,
+		params)
+	mut dst_params := []flat.NodeId{}
+	clone := t.a.nodes[int(clone_id)]
+	for i in 0 .. clone.children_count {
+		dst_id := t.a.child(&clone, i)
+		if t.a.nodes[int(dst_id)].kind == .param {
+			dst_params << dst_id
+		}
+	}
+	mut param_idx := 0
+	for i in 0 .. decl.node.children_count {
+		src := t.a.child_node(&decl.node, i)
+		if src.kind != .param {
+			continue
+		}
+		if param_idx >= dst_params.len {
+			continue
+		}
+		dst_id := dst_params[param_idx]
+		t.a.nodes[int(dst_id)].typ = t.specialized_signature_type_text(decl, src.typ, args, params)
+		param_idx++
+	}
+}
+
 fn (mut t Transformer) register_specialized_fn_signature(decl GenericFnDecl, clone flat.Node, args []string) {
 	old_module := t.cur_module
+	old_file := t.cur_file
 	old_tc_module := if isnil(t.tc) { '' } else { t.tc.cur_module }
+	old_tc_file := if isnil(t.tc) { '' } else { t.tc.cur_file }
 	t.cur_module = decl.module
+	t.cur_file = decl.file
 	if !isnil(t.tc) {
 		t.tc.cur_module = decl.module
+		t.tc.cur_file = decl.file
 	}
-	ret_name := t.subst_type(decl.node.typ, args)
+	generic_params := t.generic_fn_param_names(decl.node, decl.module)
+	ret_name := t.specialized_signature_type_text(decl, decl.node.typ, args, generic_params)
 	ret := if !isnil(t.tc) { t.tc.parse_type(ret_name) } else { types.Type(types.void_) }
 	mut params := []types.Type{}
 	mut variadic := false
@@ -564,7 +631,7 @@ fn (mut t Transformer) register_specialized_fn_signature(decl GenericFnDecl, clo
 		if child.kind != .param {
 			continue
 		}
-		param_type := t.subst_type(child.typ, args)
+		param_type := t.specialized_signature_type_text(decl, child.typ, args, generic_params)
 		if param_type.starts_with('...') {
 			variadic = true
 		}
@@ -585,8 +652,123 @@ fn (mut t Transformer) register_specialized_fn_signature(decl GenericFnDecl, clo
 			t.tc.fn_variadic[name] = variadic
 		}
 		t.tc.cur_module = old_tc_module
+		t.tc.cur_file = old_tc_file
 	}
 	t.cur_module = old_module
+	t.cur_file = old_file
+}
+
+fn (mut t Transformer) specialized_fn_return_type_text(decl GenericFnDecl, args []string) string {
+	return t.specialized_signature_type_text(decl, decl.node.typ, args, t.generic_fn_param_names(decl.node,
+		decl.module))
+}
+
+fn (mut t Transformer) specialized_signature_type_text(decl GenericFnDecl, typ string, args []string, params []string) string {
+	substituted := substitute_generic_type_text_with_params(typ, args, params)
+	qualified := t.qualify_specialized_signature_type_text(substituted, decl)
+	if isnil(t.tc) {
+		return qualified
+	}
+	old_module := t.cur_module
+	old_file := t.cur_file
+	old_tc_module := t.tc.cur_module
+	old_tc_file := t.tc.cur_file
+	t.cur_module = decl.module
+	t.cur_file = decl.file
+	t.tc.cur_module = decl.module
+	t.tc.cur_file = decl.file
+	parsed := t.tc.parse_type(qualified)
+	t.cur_module = old_module
+	t.cur_file = old_file
+	t.tc.cur_module = old_tc_module
+	t.tc.cur_file = old_tc_file
+	if parsed is types.Unknown {
+		return qualified
+	}
+	return parsed.name()
+}
+
+fn (t &Transformer) qualify_specialized_signature_type_text(typ string, decl GenericFnDecl) string {
+	clean := typ.trim_space()
+	if clean.len == 0 || isnil(t.tc) {
+		return typ
+	}
+	if clean.starts_with('&') {
+		return '&' + t.qualify_specialized_signature_type_text(clean[1..], decl)
+	}
+	if clean.starts_with('mut ') {
+		inner := t.qualify_specialized_signature_type_text(clean[4..], decl)
+		if inner.starts_with('&') {
+			return inner
+		}
+		return '&' + inner
+	}
+	if clean.starts_with('?') {
+		return '?' + t.qualify_specialized_signature_type_text(clean[1..], decl)
+	}
+	if clean.starts_with('!') {
+		return '!' + t.qualify_specialized_signature_type_text(clean[1..], decl)
+	}
+	if clean.starts_with('...') {
+		return '...' + t.qualify_specialized_signature_type_text(clean[3..], decl)
+	}
+	if clean.starts_with('[]') {
+		return '[]' + t.qualify_specialized_signature_type_text(clean[2..], decl)
+	}
+	if clean.starts_with('map[') {
+		bracket_end := generic_matching_bracket(clean, 3)
+		if bracket_end < clean.len {
+			key := t.qualify_specialized_signature_type_text(clean[4..bracket_end], decl)
+			val := t.qualify_specialized_signature_type_text(clean[bracket_end + 1..], decl)
+			return 'map[${key}]${val}'
+		}
+	}
+	if clean.starts_with('[') {
+		bracket_end := generic_matching_bracket(clean, 0)
+		if bracket_end < clean.len {
+			return clean[..bracket_end + 1] +
+				t.qualify_specialized_signature_type_text(clean[bracket_end + 1..], decl)
+		}
+	}
+	if clean.starts_with('(') && clean.ends_with(')') && clean.contains(',') {
+		mut parts := []string{}
+		for part in split_generic_args(clean[1..clean.len - 1]) {
+			parts << t.qualify_specialized_signature_type_text(part, decl)
+		}
+		return '(' + parts.join(', ') + ')'
+	}
+	bracket := clean.index_u8(`[`)
+	if bracket > 0 {
+		bracket_end := generic_matching_bracket(clean, bracket)
+		if bracket_end < clean.len {
+			mut parts := []string{}
+			for part in split_generic_args(clean[bracket + 1..bracket_end]) {
+				parts << t.qualify_specialized_signature_type_text(part, decl)
+			}
+			base := t.qualify_specialized_signature_type_text(clean[..bracket], decl)
+			return base + '[' + parts.join(', ') + ']' + clean[bracket_end + 1..]
+		}
+	}
+	if clean.contains('.') || types.is_builtin_type_name(clean)
+		|| clean in ['void', 'none', 'nil', 'C', 'JS'] {
+		return clean
+	}
+	return t.selective_signature_type_symbol(decl.file, clean) or { clean }
+}
+
+fn (t &Transformer) selective_signature_type_symbol(file string, name string) ?string {
+	if isnil(t.tc) || file.len == 0 || name.contains('.') {
+		return none
+	}
+	candidates := t.tc.file_selective_imports[file_import_key(file, name)] or { return none }
+	for candidate in candidates {
+		if candidate in t.tc.type_aliases || candidate in t.tc.structs
+			|| candidate in t.tc.interface_names || candidate in t.tc.flag_enums
+			|| candidate in t.tc.enum_names || candidate in t.tc.sum_types {
+			return candidate
+		}
+	}
+	return none
 }
 
 fn specialized_generic_fn_signature_aliases(decl GenericFnDecl, args []string) []string {
@@ -605,6 +787,8 @@ fn specialized_generic_fn_signature_aliases(decl GenericFnDecl, args []string) [
 		'${qflat_receiver}.${method}',
 		c_name('${flat_receiver}.${method}'),
 		c_name('${qflat_receiver}.${method}'),
+		'${c_name(flat_receiver)}__${c_name(method)}',
+		c_name('${decl.module}.${flat_receiver}.${method}'),
 	]
 }
 
@@ -658,7 +842,7 @@ fn (mut t Transformer) concrete_generic_call_return_type(id flat.NodeId, node fl
 	if args.len == 0 || t.generic_args_have_placeholders(args) {
 		return ''
 	}
-	ret := substitute_generic_type_text(decl.node.typ, args)
+	ret := t.specialized_fn_return_type_text(decl, args)
 	if ret.len == 0 || t.generic_arg_is_unresolved(ret) {
 		return ''
 	}
@@ -726,6 +910,7 @@ fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, n
 fn (mut t Transformer) rewrite_generic_plain_call(id flat.NodeId, node flat.Node, decl GenericFnDecl, args []string) {
 	spec_value := specialized_generic_fn_value(decl.node.value, args)
 	spec_name := transform_qualified_fn_name(decl.module, spec_value)
+	ret_typ := t.specialized_fn_return_type_text(decl, args)
 	mut children := []flat.NodeId{cap: int(node.children_count)}
 	children << t.make_ident(spec_name)
 	for i in 1 .. node.children_count {
@@ -742,7 +927,7 @@ fn (mut t Transformer) rewrite_generic_plain_call(id flat.NodeId, node flat.Node
 		children_count: flat.child_count(children.len)
 		pos:            node.pos
 		value:          ''
-		typ:            substitute_generic_type_text(decl.node.typ, args)
+		typ:            ret_typ
 	}
 	t.clear_resolved_call(id)
 }
@@ -786,6 +971,7 @@ fn (mut t Transformer) rewrite_generic_method_call(id flat.NodeId, node flat.Nod
 	if fn_node.kind == .index && fn_node.children_count > 0 {
 		callee_id = t.a.child(&fn_node, 0)
 	}
+	ret_typ := t.specialized_fn_return_type_text(decl, args)
 	mut children := []flat.NodeId{cap: int(node.children_count)}
 	children << callee_id
 	for i in 1 .. node.children_count {
@@ -802,7 +988,7 @@ fn (mut t Transformer) rewrite_generic_method_call(id flat.NodeId, node flat.Nod
 		children_count: flat.child_count(children.len)
 		pos:            node.pos
 		value:          ''
-		typ:            substitute_generic_type_text(decl.node.typ, args)
+		typ:            ret_typ
 	}
 	t.clear_resolved_call(id)
 }
@@ -816,7 +1002,7 @@ fn (mut t Transformer) rewrite_method_level_generic_call(id flat.NodeId, node fl
 	t.active_generic_params = t.generic_fn_param_names(decl.node, decl.module)
 	spec_value := specialized_generic_fn_value(decl.node.value, args)
 	spec_name := transform_qualified_fn_name(decl.module, spec_value)
-	ret_typ := t.subst_type(decl.node.typ, args)
+	ret_typ := t.specialized_signature_type_text(decl, decl.node.typ, args, t.active_generic_params)
 	t.active_generic_params = old_params
 
 	mut children := []flat.NodeId{cap: int(node.children_count) + 1}
@@ -1481,7 +1667,9 @@ fn (mut t Transformer) clone_generic_node(id flat.NodeId, args []string) flat.No
 		return id
 	}
 	node := t.a.nodes[int(id)]
-	return t.clone_generic_node_from(node, args, false)
+	clone_id := t.clone_generic_node_from(node, args, false)
+	t.copy_cloned_resolution(id, clone_id)
+	return clone_id
 }
 
 fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is_root bool) flat.NodeId {
@@ -1517,6 +1705,33 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 		typ:            t.subst_type(node.typ, args)
 		value:          cloned_value
 	})
+}
+
+fn (mut t Transformer) copy_cloned_resolution(src_id flat.NodeId, dst_id flat.NodeId) {
+	if isnil(t.tc) {
+		return
+	}
+	src_idx := int(src_id)
+	dst_idx := int(dst_id)
+	if src_idx < 0 || dst_idx < 0 {
+		return
+	}
+	if src_idx < t.tc.resolved_call_set.len && t.tc.resolved_call_set[src_idx] {
+		for t.tc.resolved_call_names.len <= dst_idx {
+			t.tc.resolved_call_names << ''
+			t.tc.resolved_call_set << false
+		}
+		t.tc.resolved_call_names[dst_idx] = t.tc.resolved_call_names[src_idx]
+		t.tc.resolved_call_set[dst_idx] = true
+	}
+	if src_idx < t.tc.resolved_fn_value_set.len && t.tc.resolved_fn_value_set[src_idx] {
+		for t.tc.resolved_fn_value_names.len <= dst_idx {
+			t.tc.resolved_fn_value_names << ''
+			t.tc.resolved_fn_value_set << false
+		}
+		t.tc.resolved_fn_value_names[dst_idx] = t.tc.resolved_fn_value_names[src_idx]
+		t.tc.resolved_fn_value_set[dst_idx] = true
+	}
 }
 
 fn substitute_generic_node_value(node flat.Node, args []string) string {
@@ -1733,6 +1948,16 @@ fn (mut t Transformer) collect_generic_param_names_from_type(typ string, module_
 	if ok {
 		for arg in args {
 			t.collect_generic_param_names_from_type(arg, module_name, mut names)
+		}
+		return
+	}
+	bracket := clean.index_u8(`[`)
+	if bracket > 0 {
+		bracket_end := generic_matching_bracket(clean, bracket)
+		if bracket_end > bracket && bracket_end < clean.len {
+			for arg in split_generic_args(clean[bracket + 1..bracket_end]) {
+				t.collect_generic_param_names_from_type(arg, module_name, mut names)
+			}
 		}
 	}
 }

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -6,6 +6,7 @@ import v3.types
 struct GenericStructDecl {
 	id     flat.NodeId
 	node   flat.Node
+	file   string
 	module string
 	key    string
 }
@@ -194,7 +195,8 @@ fn (mut t Transformer) materialize_generic_structs() {
 				}
 				field_type := substitute_generic_type_text_with_params(field.typ, args,
 					decl.node.generic_params)
-				t.collect_generic_struct_spec_from_type(field_type, decl.module, decls, mut specs)
+				t.collect_generic_struct_spec_from_type(field_type, decl.module, decl.file, decls, mut
+					specs)
 			}
 		}
 		if specs.len == before {
@@ -215,9 +217,13 @@ fn (mut t Transformer) materialize_generic_structs() {
 fn (mut t Transformer) collect_generic_struct_decls() map[string]GenericStructDecl {
 	mut decls := map[string]GenericStructDecl{}
 	node_modules := t.node_module_map()
+	mut cur_file := ''
 	mut cur_module := ''
 	for i, node in t.a.nodes {
 		match node.kind {
+			.file {
+				cur_file = node.value
+			}
 			.module_decl {
 				cur_module = node.value
 			}
@@ -230,6 +236,7 @@ fn (mut t Transformer) collect_generic_struct_decls() map[string]GenericStructDe
 				decls[key] = GenericStructDecl{
 					id:     flat.NodeId(i)
 					node:   node
+					file:   cur_file
 					module: module_name
 					key:    key
 				}
@@ -250,12 +257,14 @@ fn generic_struct_decl_key(name string, module_name string) string {
 
 fn (mut t Transformer) collect_generic_struct_specs(decls map[string]GenericStructDecl, mut specs map[string]string) {
 	for _, target in t.tc.type_aliases {
-		t.collect_generic_struct_spec_from_type(target, '', decls, mut specs)
+		t.collect_generic_struct_spec_from_type(target, '', '', decls, mut specs)
 	}
+	mut file_name := ''
 	mut module_name := ''
 	for node in t.a.nodes {
 		match node.kind {
 			.file {
+				file_name = node.value
 				module_name = ''
 			}
 			.module_decl {
@@ -265,57 +274,64 @@ fn (mut t Transformer) collect_generic_struct_specs(decls map[string]GenericStru
 		}
 
 		if node.typ.len > 0 {
-			t.collect_generic_struct_spec_from_type(node.typ, module_name, decls, mut specs)
+			t.collect_generic_struct_spec_from_type(node.typ, module_name, file_name, decls, mut
+				specs)
 		}
 		match node.kind {
 			.struct_init, .array_init, .cast_expr, .as_expr, .sizeof_expr, .typeof_expr, .is_expr {
-				t.collect_generic_struct_spec_from_type(node.value, module_name, decls, mut specs)
+				t.collect_generic_struct_spec_from_type(node.value, module_name, file_name, decls, mut
+					specs)
 			}
 			else {}
 		}
 	}
 }
 
-fn (mut t Transformer) collect_generic_struct_spec_from_type(typ string, module_name string, decls map[string]GenericStructDecl, mut specs map[string]string) {
+fn (mut t Transformer) collect_generic_struct_spec_from_type(typ string, module_name string, file_name string, decls map[string]GenericStructDecl, mut specs map[string]string) {
 	clean := typ.trim_space()
 	if clean.len == 0 {
 		return
 	}
 	if clean.starts_with('&') {
-		t.collect_generic_struct_spec_from_type(clean[1..], module_name, decls, mut specs)
+		t.collect_generic_struct_spec_from_type(clean[1..], module_name, file_name, decls, mut
+			specs)
 		return
 	}
 	if clean.starts_with('mut ') {
-		t.collect_generic_struct_spec_from_type(clean[4..], module_name, decls, mut specs)
+		t.collect_generic_struct_spec_from_type(clean[4..], module_name, file_name, decls, mut
+			specs)
 		return
 	}
 	if clean.starts_with('?') || clean.starts_with('!') {
-		t.collect_generic_struct_spec_from_type(clean[1..], module_name, decls, mut specs)
+		t.collect_generic_struct_spec_from_type(clean[1..], module_name, file_name, decls, mut
+			specs)
 		return
 	}
 	if clean.starts_with('...') {
-		t.collect_generic_struct_spec_from_type(clean[3..], module_name, decls, mut specs)
+		t.collect_generic_struct_spec_from_type(clean[3..], module_name, file_name, decls, mut
+			specs)
 		return
 	}
 	if clean.starts_with('[]') {
-		t.collect_generic_struct_spec_from_type(clean[2..], module_name, decls, mut specs)
+		t.collect_generic_struct_spec_from_type(clean[2..], module_name, file_name, decls, mut
+			specs)
 		return
 	}
 	if clean.starts_with('map[') {
 		bracket_end := generic_matching_bracket(clean, 3)
 		if bracket_end < clean.len {
-			t.collect_generic_struct_spec_from_type(clean[4..bracket_end], module_name, decls, mut
-				specs)
-			t.collect_generic_struct_spec_from_type(clean[bracket_end + 1..], module_name, decls, mut
-				specs)
+			t.collect_generic_struct_spec_from_type(clean[4..bracket_end], module_name, file_name,
+				decls, mut specs)
+			t.collect_generic_struct_spec_from_type(clean[bracket_end + 1..], module_name,
+				file_name, decls, mut specs)
 		}
 		return
 	}
 	if clean.starts_with('[') {
 		bracket_end := generic_matching_bracket(clean, 0)
 		if bracket_end < clean.len {
-			t.collect_generic_struct_spec_from_type(clean[bracket_end + 1..], module_name, decls, mut
-				specs)
+			t.collect_generic_struct_spec_from_type(clean[bracket_end + 1..], module_name,
+				file_name, decls, mut specs)
 		}
 		return
 	}
@@ -324,17 +340,17 @@ fn (mut t Transformer) collect_generic_struct_spec_from_type(typ string, module_
 		return
 	}
 	for arg in args {
-		t.collect_generic_struct_spec_from_type(arg, module_name, decls, mut specs)
+		t.collect_generic_struct_spec_from_type(arg, module_name, file_name, decls, mut specs)
 	}
 	if t.generic_args_have_placeholders(args) {
 		return
 	}
-	spec_base := generic_struct_spec_base_name(base, module_name, decls) or { return }
+	spec_base := t.generic_struct_spec_base_name(base, module_name, file_name, decls) or { return }
 	spec_name := '${spec_base}[${args.join(', ')}]'
 	specs[spec_name] = spec_base
 }
 
-fn generic_struct_spec_base_name(base string, module_name string, decls map[string]GenericStructDecl) ?string {
+fn (t &Transformer) generic_struct_spec_base_name(base string, module_name string, file_name string, decls map[string]GenericStructDecl) ?string {
 	if base in decls {
 		return base
 	}
@@ -347,6 +363,9 @@ fn generic_struct_spec_base_name(base string, module_name string, decls map[stri
 			return qbase
 		}
 	}
+	if resolved := t.selective_import_generic_struct_base(base, file_name, decls) {
+		return resolved
+	}
 	mut found := ''
 	for key, _ in decls {
 		if key.all_after_last('.') == base {
@@ -358,6 +377,19 @@ fn generic_struct_spec_base_name(base string, module_name string, decls map[stri
 	}
 	if found.len > 0 {
 		return found
+	}
+	return none
+}
+
+fn (t &Transformer) selective_import_generic_struct_base(base string, file_name string, decls map[string]GenericStructDecl) ?string {
+	if isnil(t.tc) || base.contains('.') || file_name.len == 0 {
+		return none
+	}
+	candidates := t.tc.file_selective_imports[file_import_key(file_name, base)] or { return none }
+	for candidate in candidates {
+		if candidate in decls {
+			return candidate
+		}
 	}
 	return none
 }

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -2193,12 +2193,11 @@ fn subst_generic_fn_type_text(clean string, args []string, params []string) ?str
 			} else if c == `)` || c == `]` {
 				pdepth--
 			} else if c == `,` && pdepth == 0 {
-				fn_parts << substitute_generic_type_text_with_params(params_str[start..i], args,
-					params)
+				fn_parts << subst_generic_fn_type_param_text(params_str[start..i], args, params)
 				start = i + 1
 			}
 		}
-		fn_parts << substitute_generic_type_text_with_params(params_str[start..], args, params)
+		fn_parts << subst_generic_fn_type_param_text(params_str[start..], args, params)
 	}
 	ret_str := clean[params_end + 1..].trim_space()
 	if ret_str.len > 0 {
@@ -2206,6 +2205,69 @@ fn subst_generic_fn_type_text(clean string, args []string, params []string) ?str
 			args, params)}'
 	}
 	return 'fn(${fn_parts.join(', ')})'
+}
+
+fn subst_generic_fn_type_param_text(param string, args []string, params []string) string {
+	mut text := param.trim_space()
+	mut is_mut := false
+	if text.starts_with('mut ') {
+		is_mut = true
+		text = text[4..].trim_space()
+	}
+	space := generic_top_level_space_index(text)
+	if space > 0 {
+		head := text[..space].trim_space()
+		tail := text[space + 1..].trim_space()
+		if generic_fn_type_param_head_is_name(head, tail) {
+			sub := substitute_generic_type_text_with_params(tail, args, params)
+			if is_mut && sub.len > 0 && !sub.starts_with('&') {
+				return '${head} &${sub}'
+			}
+			return '${head} ${sub}'
+		}
+	}
+	sub := substitute_generic_type_text_with_params(text, args, params)
+	if is_mut && sub.len > 0 && !sub.starts_with('&') {
+		return '&${sub}'
+	}
+	return sub
+}
+
+fn generic_top_level_space_index(s string) int {
+	mut depth := 0
+	for i := 0; i < s.len; i++ {
+		match s[i] {
+			`(`, `[` {
+				depth++
+			}
+			`)`, `]` {
+				depth--
+			}
+			` ` {
+				if depth == 0 {
+					return i
+				}
+			}
+			else {}
+		}
+	}
+	return -1
+}
+
+fn generic_fn_type_param_head_is_name(head string, tail string) bool {
+	if head.len == 0 || tail.len == 0 {
+		return false
+	}
+	if head.starts_with('fn') || head.starts_with('&') || head.starts_with('[') {
+		return false
+	}
+	if head in ['shared', 'atomic', 'chan', 'thread', 'map'] || head.contains('.') {
+		return false
+	}
+	if types.is_builtin_type_name(head) {
+		return false
+	}
+	return (head[0] >= `a` && head[0] <= `z`) || head[0] == `_`
 }
 
 // subst_type substitutes generic placeholders in a type-text using the currently

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -376,6 +376,13 @@ fn (mut t Transformer) make_none_return_stmt_with_err(err_source string) flat.No
 		return t.make_none_return_stmt()
 	}
 	err_expr := t.make_selector(t.make_ident(err_source), 'err', 'IError')
+	return t.make_none_return_stmt_with_err_expr(err_expr)
+}
+
+fn (mut t Transformer) make_none_return_stmt_with_err_expr(err_expr flat.NodeId) flat.NodeId {
+	if int(err_expr) < 0 {
+		return t.make_none_return_stmt()
+	}
 	return t.make_return(t.make_optional_none_with_err(t.cur_fn_ret_type, err_expr),
 		t.cur_fn_ret_type)
 }
@@ -437,9 +444,18 @@ fn (mut t Transformer) lower_or_expr_to_temp(id flat.NodeId, node flat.Node) fla
 
 // lower_or_body_to_stmts converts lower or body to stmts data for transform.
 fn (mut t Transformer) lower_or_body_to_stmts(body_id flat.NodeId, target_name string, target_type string, mode string, err_source string) []flat.NodeId {
+	err_expr := if err_source.len > 0 {
+		t.make_selector(t.make_ident(err_source), 'err', 'IError')
+	} else {
+		flat.empty_node
+	}
+	return t.lower_or_body_to_stmts_with_err_expr(body_id, target_name, target_type, mode, err_expr)
+}
+
+fn (mut t Transformer) lower_or_body_to_stmts_with_err_expr(body_id flat.NodeId, target_name string, target_type string, mode string, err_expr flat.NodeId) []flat.NodeId {
 	if mode == '!' || mode == '?' {
 		if t.is_optional_type_name(t.cur_fn_ret_type) {
-			return arr1(t.make_none_return_stmt_with_err(err_source))
+			return arr1(t.make_none_return_stmt_with_err_expr(err_expr))
 		}
 		return arr1(t.make_panic_stmt('option/result propagation failed'))
 	}
@@ -472,8 +488,8 @@ fn (mut t Transformer) lower_or_body_to_stmts(body_id flat.NodeId, target_name s
 	// Mirrors transform_if_guard_else_block.
 	saved_var_types := t.var_types.clone()
 	t.set_var_type('err', 'IError')
-	err_value := if err_source.len > 0 {
-		t.make_selector(t.make_ident(err_source), 'err', 'IError')
+	err_value := if int(err_expr) >= 0 {
+		err_expr
 	} else {
 		t.make_struct_init('IError')
 	}

--- a/vlib/v3/transform/struct.v
+++ b/vlib/v3/transform/struct.v
@@ -293,6 +293,33 @@ fn (mut t Transformer) add_missing_struct_defaults(id flat.NodeId, node flat.Nod
 
 // lookup_struct_info resolves lookup struct info information for transform.
 fn (t &Transformer) lookup_struct_info(name string) ?StructInfo {
+	if info := t.lookup_struct_info_preferred(name) {
+		return info
+	}
+	normalized := t.normalize_type_alias(name)
+	if normalized != name {
+		return t.lookup_struct_info_direct(normalized)
+	}
+	return none
+}
+
+fn (t &Transformer) lookup_struct_info_preferred(name string) ?StructInfo {
+	if name.contains('.') {
+		if name in t.structs {
+			return t.structs[name]
+		}
+	} else if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin' {
+		qname := '${t.cur_module}.${name}'
+		if qname in t.structs {
+			return t.structs[qname]
+		}
+	} else if name in t.structs {
+		return t.structs[name]
+	}
+	return none
+}
+
+fn (t &Transformer) lookup_struct_info_direct(name string) ?StructInfo {
 	if name.contains('.') {
 		if name in t.structs {
 			return t.structs[name]

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -634,7 +634,7 @@ fn (t &Transformer) file_module_name(file_node flat.Node) string {
 fn transform_is_top_level_stmt(node flat.Node) bool {
 	return match node.kind {
 		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
-		.for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .block {
+		.for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .defer_stmt, .block {
 			true
 		}
 		else {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -2211,14 +2211,13 @@ fn (mut t Transformer) try_lower_optional_selector_lvalue_assign(node flat.Node)
 	if int(lhs_id) < 0 || int(rhs_id) < 0 {
 		return none
 	}
-	lowered_lhs, guard_source, guard_body, guard_mode, err_source := t.lower_optional_selector_lvalue(lhs_id) or {
+	lowered_lhs, guard_source, guard_body, guard_mode := t.lower_optional_selector_lvalue(lhs_id) or {
 		return none
 	}
 	mut result := []flat.NodeId{}
 	t.drain_pending(mut result)
 	not_ok := t.make_prefix(.not, t.make_selector(guard_source, 'ok', 'bool'))
-	guard_stmts := t.optional_selector_lvalue_guard_stmts(guard_body, guard_mode, err_source,
-		guard_source)
+	guard_stmts := t.optional_selector_lvalue_guard_stmts(guard_body, guard_mode, guard_source)
 	result << t.make_if(not_ok, t.make_block(guard_stmts), t.make_empty())
 	lhs_type := t.lvalue_type(lhs_id)
 	sum_target := t.assignment_sum_target(lhs_id, rhs_id, lhs_type)
@@ -2232,19 +2231,19 @@ fn (mut t Transformer) try_lower_optional_selector_lvalue_assign(node flat.Node)
 	return result
 }
 
-fn (mut t Transformer) optional_selector_lvalue_guard_stmts(body_id flat.NodeId, mode string, err_source string, guard_source flat.NodeId) []flat.NodeId {
+fn (mut t Transformer) optional_selector_lvalue_guard_stmts(body_id flat.NodeId, mode string, guard_source flat.NodeId) []flat.NodeId {
+	err_expr := t.make_selector(guard_source, 'err', 'IError')
 	if mode == '!' || mode == '?' {
 		if t.is_optional_type_name(t.cur_fn_ret_type) {
-			err_expr := t.make_selector(guard_source, 'err', 'IError')
 			return arr1(t.make_return(t.make_optional_none_with_err(t.cur_fn_ret_type, err_expr),
 				t.cur_fn_ret_type))
 		}
 		return arr1(t.make_panic_stmt('option/result propagation failed'))
 	}
-	return t.lower_or_body_to_stmts(body_id, '', '', mode, err_source)
+	return t.lower_or_body_to_stmts_with_err_expr(body_id, '', '', mode, err_expr)
 }
 
-fn (mut t Transformer) lower_optional_selector_lvalue(id flat.NodeId) ?(flat.NodeId, flat.NodeId, flat.NodeId, string, string) {
+fn (mut t Transformer) lower_optional_selector_lvalue(id flat.NodeId) ?(flat.NodeId, flat.NodeId, flat.NodeId, string) {
 	if int(id) < 0 {
 		return none
 	}
@@ -2257,7 +2256,14 @@ fn (mut t Transformer) lower_optional_selector_lvalue(id flat.NodeId) ?(flat.Nod
 	if base.kind == .or_expr && base.children_count >= 2 {
 		return t.lower_optional_selector_lvalue_from_or(id, node, base)
 	}
-	lowered_base, guard_source, guard_body, guard_mode, err_source := t.lower_optional_selector_lvalue(base_id) or {
+	if base.kind == .paren && base.children_count > 0 {
+		inner_id := t.a.child(&base, 0)
+		inner := t.a.nodes[int(inner_id)]
+		if inner.kind == .or_expr && inner.children_count >= 2 {
+			return t.lower_optional_selector_lvalue_from_or(id, node, inner)
+		}
+	}
+	lowered_base, guard_source, guard_body, guard_mode := t.lower_optional_selector_lvalue(base_id) or {
 		return none
 	}
 	mut new_children := []flat.NodeId{cap: int(node.children_count)}
@@ -2278,10 +2284,10 @@ fn (mut t Transformer) lower_optional_selector_lvalue(id flat.NodeId) ?(flat.Nod
 		value:          node.value
 		typ:            node.typ
 	})
-	return lowered, guard_source, guard_body, guard_mode, err_source
+	return lowered, guard_source, guard_body, guard_mode
 }
 
-fn (mut t Transformer) lower_optional_selector_lvalue_from_or(id flat.NodeId, node flat.Node, base flat.Node) ?(flat.NodeId, flat.NodeId, flat.NodeId, string, string) {
+fn (mut t Transformer) lower_optional_selector_lvalue_from_or(id flat.NodeId, node flat.Node, base flat.Node) ?(flat.NodeId, flat.NodeId, flat.NodeId, string) {
 	source_id := t.a.child(&base, 0)
 	if !t.optional_selector_lvalue_source(source_id) {
 		return none
@@ -2311,7 +2317,7 @@ fn (mut t Transformer) lower_optional_selector_lvalue_from_or(id flat.NodeId, no
 		value:          node.value
 		typ:            if lhs_type.len > 0 { lhs_type } else { node.typ }
 	})
-	return lowered, source, t.a.child(&base, 1), base.value, t.optional_lvalue_err_source(source_id)
+	return lowered, source, t.a.child(&base, 1), base.value
 }
 
 fn (t &Transformer) optional_selector_lvalue_source(id flat.NodeId) bool {
@@ -2339,20 +2345,6 @@ fn (t &Transformer) optional_selector_lvalue_source(id flat.NodeId) bool {
 			return false
 		}
 	}
-}
-
-fn (t &Transformer) optional_lvalue_err_source(id flat.NodeId) string {
-	if int(id) < 0 {
-		return ''
-	}
-	node := t.a.nodes[int(id)]
-	if node.kind == .ident {
-		return node.value
-	}
-	if node.kind == .paren && node.children_count > 0 {
-		return t.optional_lvalue_err_source(t.a.child(&node, 0))
-	}
-	return ''
 }
 
 fn (mut t Transformer) try_lower_struct_compound_assign(node flat.Node) ?[]flat.NodeId {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -103,7 +103,9 @@ mut:
 	escaping_amp_sources map[string]bool
 	// heaped_amp_locals records which of those sources were actually moved to the heap, so
 	// the `p := &v` alias emits `p = v` (the heap pointer) instead of a fresh memdup copy.
-	heaped_amp_locals map[string]bool
+	heaped_amp_locals      map[string]bool
+	generic_fn_decls_cache map[string]GenericFnDecl
+	generic_fn_decls_ready bool
 }
 
 // AliasCache memoizes normalize_type_alias results. It lives on the heap so the
@@ -553,7 +555,9 @@ fn (t &Transformer) normalize_sum_variant_type(typ string, mod string) string {
 
 // transform_all transforms transform all data for transform.
 fn (mut t Transformer) transform_all() {
-	for i in 0 .. t.a.nodes.len {
+	has_entry_main := t.has_entry_main()
+	node_count := t.a.nodes.len
+	for i in 0 .. node_count {
 		node := t.a.nodes[i]
 		kind_id := node_kind_id(node)
 		if kind_id == 77 {
@@ -573,6 +577,133 @@ fn (mut t Transformer) transform_all() {
 			t.transform_global_decl(node)
 		}
 	}
+	if !has_entry_main {
+		t.transform_top_level_user_stmts()
+	}
+}
+
+fn (t &Transformer) has_entry_main() bool {
+	mut cur_module := ''
+	for node in t.a.nodes {
+		kind_id := node_kind_id(node)
+		if kind_id == 77 {
+			cur_module = ''
+			continue
+		}
+		if kind_id == 73 {
+			cur_module = node.value
+			continue
+		}
+		if kind_id == 61 && node.value == 'main' && (cur_module.len == 0 || cur_module == 'main') {
+			return true
+		}
+	}
+	return false
+}
+
+fn (mut t Transformer) transform_top_level_user_stmts() {
+	node_count := t.a.nodes.len
+	for file_idx in 0 .. node_count {
+		file_node := t.a.nodes[file_idx]
+		if !t.should_transform_top_level_file(file_idx, file_node) {
+			continue
+		}
+		t.transform_top_level_file(file_idx, file_node)
+	}
+}
+
+fn (t &Transformer) should_transform_top_level_file(file_idx int, file_node flat.Node) bool {
+	if file_idx < t.a.user_code_start || file_node.kind != .file || file_node.children_count == 0 {
+		return false
+	}
+	module_name := t.file_module_name(file_node)
+	return module_name.len == 0 || module_name == 'main'
+}
+
+fn (t &Transformer) file_module_name(file_node flat.Node) string {
+	for i in 0 .. file_node.children_count {
+		child := t.a.child_node(&file_node, i)
+		if child.kind == .module_decl {
+			return child.value
+		}
+	}
+	return ''
+}
+
+fn transform_is_top_level_stmt(node flat.Node) bool {
+	return match node.kind {
+		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
+		.for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .block {
+			true
+		}
+		else {
+			false
+		}
+	}
+}
+
+fn (mut t Transformer) transform_top_level_file(file_idx int, file_node flat.Node) {
+	old_file := t.cur_file
+	old_module := t.cur_module
+	old_fn_name := t.cur_fn_name
+	old_fn_ret_type := t.cur_fn_ret_type
+	old_var_types := t.var_types.clone()
+	old_smartcast_stack := t.smartcast_stack.clone()
+	old_pending_stmts := t.pending_stmts.clone()
+	module_name := t.file_module_name(file_node)
+	t.cur_file = file_node.value
+	t.cur_module = if module_name.len == 0 { 'main' } else { module_name }
+	t.cur_fn_name = 'main'
+	t.cur_fn_ret_type = 'void'
+	t.reset_var_types()
+	t.smartcast_stack.clear()
+	t.pending_stmts.clear()
+	mut new_children := []flat.NodeId{cap: int(file_node.children_count)}
+	mut pending_stmts := []flat.NodeId{}
+	for i in 0 .. file_node.children_count {
+		child_id := t.a.child(&file_node, i)
+		if int(child_id) >= t.a.user_code_start {
+			child := t.a.nodes[int(child_id)]
+			if transform_is_top_level_stmt(child) {
+				pending_stmts << child_id
+				continue
+			}
+		}
+		t.append_transformed_top_level_stmts(mut new_children, mut pending_stmts)
+		new_children << child_id
+	}
+	t.append_transformed_top_level_stmts(mut new_children, mut pending_stmts)
+	start := t.a.children.len
+	for child_id in new_children {
+		t.a.children << child_id
+	}
+	t.a.nodes[file_idx] = flat.Node{
+		kind:           .file
+		kind_id:        file_node.kind_id
+		op:             file_node.op
+		children_start: start
+		children_count: flat.child_count(new_children.len)
+		pos:            file_node.pos
+		value:          file_node.value
+		typ:            file_node.typ
+		generic_params: file_node.generic_params
+	}
+	t.cur_file = old_file
+	t.cur_module = old_module
+	t.cur_fn_name = old_fn_name
+	t.cur_fn_ret_type = old_fn_ret_type
+	t.var_types = old_var_types
+	t.smartcast_stack = old_smartcast_stack
+	t.pending_stmts = old_pending_stmts
+}
+
+fn (mut t Transformer) append_transformed_top_level_stmts(mut out []flat.NodeId, mut pending []flat.NodeId) {
+	if pending.len == 0 {
+		return
+	}
+	transformed := t.transform_stmts(pending)
+	out << transformed
+	pending.clear()
 }
 
 // FnWorkItem identifies one top-level function body to transform, together with
@@ -707,6 +838,8 @@ fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Tran
 	w.tc = wtc
 	w.alias_cache = &AliasCache{}
 	w.sum_cache = &AliasCache{}
+	w.generic_fn_decls_cache = map[string]GenericFnDecl{}
+	w.generic_fn_decls_ready = false
 	w.var_types = []VarTypeBinding{}
 	w.smartcast_stack = []SmartcastContext{}
 	w.pending_stmts = []flat.NodeId{}
@@ -1998,6 +2131,9 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 	if lowered := t.try_lower_sum_shared_field_assign(node) {
 		return lowered
 	}
+	if lowered := t.try_lower_optional_selector_lvalue_assign(node) {
+		return lowered
+	}
 	if lowered := t.try_lower_pointer_value_assign(node) {
 		return lowered
 	}
@@ -2059,6 +2195,159 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 		t.annotate_left_shift_assign(new_id)
 	}
 	return t.with_pending_before(new_id)
+}
+
+fn (mut t Transformer) try_lower_optional_selector_lvalue_assign(node flat.Node) ?[]flat.NodeId {
+	if node.kind != .selector_assign || node.children_count != 2 {
+		return none
+	}
+	lhs_id := t.a.child(&node, 0)
+	rhs_id := t.a.child(&node, 1)
+	if int(lhs_id) < 0 || int(rhs_id) < 0 {
+		return none
+	}
+	lowered_lhs, guard_source, guard_body, guard_mode, err_source := t.lower_optional_selector_lvalue(lhs_id) or {
+		return none
+	}
+	mut result := []flat.NodeId{}
+	t.drain_pending(mut result)
+	not_ok := t.make_prefix(.not, t.make_selector(guard_source, 'ok', 'bool'))
+	guard_stmts := t.optional_selector_lvalue_guard_stmts(guard_body, guard_mode, err_source,
+		guard_source)
+	result << t.make_if(not_ok, t.make_block(guard_stmts), t.make_empty())
+	lhs_type := t.lvalue_type(lhs_id)
+	sum_target := t.assignment_sum_target(lhs_id, rhs_id, lhs_type)
+	rhs := if node.op == .assign && sum_target.len > 0 {
+		t.wrap_sum_value(rhs_id, sum_target)
+	} else {
+		t.transform_expr_for_type(rhs_id, lhs_type)
+	}
+	t.drain_pending(mut result)
+	result << t.make_assign_op(lowered_lhs, rhs, node.op)
+	return result
+}
+
+fn (mut t Transformer) optional_selector_lvalue_guard_stmts(body_id flat.NodeId, mode string, err_source string, guard_source flat.NodeId) []flat.NodeId {
+	if mode == '!' || mode == '?' {
+		if t.is_optional_type_name(t.cur_fn_ret_type) {
+			err_expr := t.make_selector(guard_source, 'err', 'IError')
+			return arr1(t.make_return(t.make_optional_none_with_err(t.cur_fn_ret_type, err_expr),
+				t.cur_fn_ret_type))
+		}
+		return arr1(t.make_panic_stmt('option/result propagation failed'))
+	}
+	return t.lower_or_body_to_stmts(body_id, '', '', mode, err_source)
+}
+
+fn (mut t Transformer) lower_optional_selector_lvalue(id flat.NodeId) ?(flat.NodeId, flat.NodeId, flat.NodeId, string, string) {
+	if int(id) < 0 {
+		return none
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind != .selector || node.children_count == 0 || node.value.len == 0 {
+		return none
+	}
+	base_id := t.a.child(&node, 0)
+	base := t.a.nodes[int(base_id)]
+	if base.kind == .or_expr && base.children_count >= 2 {
+		return t.lower_optional_selector_lvalue_from_or(id, node, base)
+	}
+	lowered_base, guard_source, guard_body, guard_mode, err_source := t.lower_optional_selector_lvalue(base_id) or {
+		return none
+	}
+	mut new_children := []flat.NodeId{cap: int(node.children_count)}
+	new_children << lowered_base
+	for i in 1 .. node.children_count {
+		new_children << t.transform_expr(t.a.child(&node, i))
+	}
+	start := t.a.children.len
+	for child in new_children {
+		t.a.children << child
+	}
+	lowered := t.a.add_node(flat.Node{
+		kind:           .selector
+		op:             node.op
+		children_start: start
+		children_count: flat.child_count(new_children.len)
+		pos:            node.pos
+		value:          node.value
+		typ:            node.typ
+	})
+	return lowered, guard_source, guard_body, guard_mode, err_source
+}
+
+fn (mut t Transformer) lower_optional_selector_lvalue_from_or(id flat.NodeId, node flat.Node, base flat.Node) ?(flat.NodeId, flat.NodeId, flat.NodeId, string, string) {
+	source_id := t.a.child(&base, 0)
+	if !t.optional_selector_lvalue_source(source_id) {
+		return none
+	}
+	expr_type, value_type := t.or_expr_types(source_id, base.typ)
+	if !t.is_optional_type_name(expr_type) || value_type.len == 0 || value_type == 'void' {
+		return none
+	}
+	source := t.transform_lvalue(source_id)
+	value_base := t.make_selector(source, 'value', value_type)
+	mut new_children := []flat.NodeId{cap: int(node.children_count)}
+	new_children << value_base
+	for i in 1 .. node.children_count {
+		new_children << t.transform_expr(t.a.child(&node, i))
+	}
+	start := t.a.children.len
+	for child in new_children {
+		t.a.children << child
+	}
+	lhs_type := t.lvalue_type(id)
+	lowered := t.a.add_node(flat.Node{
+		kind:           .selector
+		op:             if value_type.starts_with('&') { flat.Op.arrow } else { node.op }
+		children_start: start
+		children_count: flat.child_count(new_children.len)
+		pos:            node.pos
+		value:          node.value
+		typ:            if lhs_type.len > 0 { lhs_type } else { node.typ }
+	})
+	return lowered, source, t.a.child(&base, 1), base.value, t.optional_lvalue_err_source(source_id)
+}
+
+fn (t &Transformer) optional_selector_lvalue_source(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	match node.kind {
+		.ident {
+			return node.value.len > 0
+		}
+		.paren {
+			if node.children_count == 0 {
+				return false
+			}
+			return t.optional_selector_lvalue_source(t.a.child(&node, 0))
+		}
+		.selector {
+			if node.children_count == 0 || node.value.len == 0 {
+				return false
+			}
+			return t.optional_selector_lvalue_source(t.a.child(&node, 0))
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn (t &Transformer) optional_lvalue_err_source(id flat.NodeId) string {
+	if int(id) < 0 {
+		return ''
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .ident {
+		return node.value
+	}
+	if node.kind == .paren && node.children_count > 0 {
+		return t.optional_lvalue_err_source(t.a.child(&node, 0))
+	}
+	return ''
 }
 
 fn (mut t Transformer) try_lower_struct_compound_assign(node flat.Node) ?[]flat.NodeId {
@@ -2760,6 +3049,12 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 			mut typ := t.infer_decl_type(node)
 			rhs_id := t.a.child(&node, 1)
 			rhs := t.a.nodes[int(rhs_id)]
+			if rhs.kind == .call {
+				generic_typ := t.concrete_generic_call_return_type(rhs_id, rhs)
+				if generic_typ.len > 0 {
+					typ = generic_typ
+				}
+			}
 			if rhs.kind == .call && t.is_strings_builder_new_call(rhs_id, rhs) {
 				typ = 'strings.Builder'
 			} else if rhs.kind == .if_expr {
@@ -2858,7 +3153,7 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 		lhs := t.a.nodes[int(new_children[0])]
 		if lhs.kind == .ident && lhs.value.len > 0 {
 			rhs_typ := t.node_type(new_children[1])
-			if rhs_typ.len > 0
+			if decl_type_is_usable(rhs_typ)
 				&& (inferred_typ.len == 0 || inferred_typ in ['array', 'map', 'unknown']) {
 				t.set_var_type(lhs.value, rhs_typ)
 				inferred_typ = rhs_typ
@@ -2890,17 +3185,33 @@ fn (mut t Transformer) try_expand_plain_multi_decl(node flat.Node) ?[]flat.NodeI
 		lhs_id := t.a.child(&node, i)
 		rhs_id := t.a.child(&node, i + 1)
 		lhs := t.a.nodes[int(lhs_id)]
+		rhs_node := t.a.nodes[int(rhs_id)]
+		generic_rhs_typ := if rhs_node.kind == .call {
+			t.concrete_generic_call_return_type(rhs_id, rhs_node)
+		} else {
+			''
+		}
 		rhs := t.transform_expr(rhs_id)
 		t.drain_pending(mut result)
 		if lhs.kind != .ident || lhs.value == '_' {
 			continue
 		}
-		mut typ := if lhs.typ.len > 0 { lhs.typ } else { t.node_type(rhs) }
+		rhs_authority := t.decl_rhs_type(rhs_id)
+		mut typ := if t.is_fn_pointer_type_name(rhs_authority) { rhs_authority } else { '' }
+		if typ.len == 0 {
+			typ = generic_rhs_typ
+		}
+		if typ.len == 0 {
+			typ = t.node_type(rhs)
+		}
 		if typ.len == 0 {
 			typ = t.node_type(rhs_id)
 		}
 		if typ.len == 0 {
-			typ = t.resolve_expr_type(rhs_id)
+			typ = rhs_authority
+		}
+		if typ.len == 0 && lhs.typ.len > 0 {
+			typ = lhs.typ
 		}
 		if typ.len > 0 {
 			typ = t.normalize_type_alias(typ)
@@ -3746,7 +4057,13 @@ fn (mut t Transformer) transform_infix_expr(id flat.NodeId, node flat.Node) flat
 fn (mut t Transformer) transform_call_expr(id flat.NodeId, node flat.Node) flat.NodeId {
 	call_id := t.normalize_generic_call_expr(id, node)
 	mut call_node := t.a.nodes[int(call_id)]
-	resolved_typ := t.get_call_return_type(call_id, call_node)
+	mut resolved_typ := t.concrete_generic_call_return_type(call_id, call_node)
+	if resolved_typ.len == 0 {
+		resolved_typ = t.current_call_return_type(call_node)
+	}
+	if resolved_typ.len == 0 {
+		resolved_typ = t.get_call_return_type(call_id, call_node)
+	}
 	if resolved_typ.len > 0 {
 		t.a.nodes[int(call_id)].typ = resolved_typ
 		call_node.typ = resolved_typ
@@ -3856,9 +4173,14 @@ fn (mut t Transformer) transform_index_expr(id flat.NodeId, node flat.Node) flat
 	}
 	// Children unchanged: update the type annotation in place (applying the same
 	// `typ = node.value when empty` fixup the rebuild would) instead of copying the node.
+	mut index_typ := node.typ
+	if index_typ.len == 0 && node.value.len > 0 {
+		elem_type := t.index_expr_type(id, node)
+		index_typ = if elem_type.len > 0 { elem_type } else { node.value }
+	}
 	if !changed {
-		if node.typ.len == 0 && node.value.len > 0 {
-			t.a.nodes[int(id)].typ = node.value
+		if index_typ.len > 0 {
+			t.a.nodes[int(id)].typ = index_typ
 		}
 		return id
 	}
@@ -3866,15 +4188,16 @@ fn (mut t Transformer) transform_index_expr(id flat.NodeId, node flat.Node) flat
 	for nc in new_children {
 		t.a.children << nc
 	}
-	return t.a.add_node(flat.Node{
+	new_id := t.a.add_node(flat.Node{
 		kind:           .index
 		op:             node.op
 		children_start: start
 		children_count: node.children_count
 		pos:            node.pos
 		value:          node.value
-		typ:            if node.typ.len > 0 { node.typ } else { node.value }
+		typ:            index_typ
 	})
+	return new_id
 }
 
 // transform_string_interp transforms transform string interp data for transform.
@@ -5517,7 +5840,7 @@ fn (t &Transformer) infer_decl_type(node &flat.Node) string {
 	}
 	if node.children_count >= 2 {
 		rhs_id := t.a.child(node, 1)
-		return t.node_type(rhs_id)
+		return t.decl_rhs_type(rhs_id)
 	}
 	return ''
 }
@@ -5560,15 +5883,18 @@ fn (t &Transformer) resolve_expr_type(id flat.NodeId) string {
 			return ''
 		}
 		.call {
+			mut ret := t.current_call_return_type(node)
+			if ret.len == 0 {
+				ret = t.get_call_return_type(id, node)
+			}
+			if ret.len > 0 {
+				return ret
+			}
 			if node.typ.len > 0 {
 				typ := t.normalize_type_alias(node.typ)
 				if typ !in ['array', 'map'] {
 					return typ
 				}
-			}
-			ret := t.get_call_return_type(id, node)
-			if ret.len > 0 {
-				return ret
 			}
 			return ''
 		}
@@ -5637,7 +5963,7 @@ fn (t &Transformer) resolve_expr_type(id flat.NodeId) string {
 			return t.resolve_selector_type(node)
 		}
 		.index {
-			return t.resolve_index_elem_type(node)
+			return t.index_expr_type(id, node)
 		}
 		.paren {
 			if node.children_count > 0 {
@@ -5727,6 +6053,33 @@ fn (t &Transformer) resolve_expr_type(id flat.NodeId) string {
 			return ''
 		}
 	}
+}
+
+fn (t &Transformer) current_call_return_type(node flat.Node) string {
+	name := t.resolve_call_name(node)
+	if name.len == 0 {
+		return ''
+	}
+	if ret := t.fn_ret_types[name] {
+		return t.call_return_type_name(ret, node)
+	}
+	if !isnil(t.tc) {
+		if ret := t.tc.fn_ret_types[name] {
+			return t.call_return_type_name(ret.name(), node)
+		}
+	}
+	if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin' {
+		qname := '${t.cur_module}.${name}'
+		if ret := t.fn_ret_types[qname] {
+			return t.call_return_type_name(ret, node)
+		}
+		if !isnil(t.tc) {
+			if ret := t.tc.fn_ret_types[qname] {
+				return t.call_return_type_name(ret.name(), node)
+			}
+		}
+	}
+	return ''
 }
 
 // const_type_name supports const type name handling for Transformer.

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -158,6 +158,7 @@ struct VarTypeBinding {
 struct GenericFnDecl {
 	id     flat.NodeId
 	node   flat.Node
+	file   string
 	module string
 	key    string
 }

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -725,6 +725,7 @@ fn (mut t Transformer) transform_all_dispatch(want_parallel bool) bool {
 		t.transform_all()
 		return false
 	}
+	has_entry_main := t.has_entry_main()
 	// Serial phase: transform consts/globals and every function whose body
 	// contains a function literal (the only construct that lifts new top-level
 	// declarations and mutates the shared TypeChecker). Collect the remaining,
@@ -732,7 +733,11 @@ fn (mut t Transformer) transform_all_dispatch(want_parallel bool) bool {
 	pure_items := t.transform_serial_then_collect_pure()
 	base_nodes := t.a.nodes.len
 	base_children := t.a.children.len
-	return t.run_parallel_transform(pure_items, base_nodes, base_children)
+	was_parallel := t.run_parallel_transform(pure_items, base_nodes, base_children)
+	if !has_entry_main {
+		t.transform_top_level_user_stmts()
+	}
+	return was_parallel
 }
 
 // transform_serial_then_collect_pure walks the top level once: it transforms

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -1,6 +1,7 @@
 module transform
 
 import v3.flat
+import v3.types
 
 // propagate_decl_type infers the declared variable type from a .decl_assign node
 // and registers it in var_types so downstream transforms can resolve it.
@@ -8,21 +9,87 @@ fn (mut t Transformer) propagate_decl_type(node flat.Node) {
 	if node.kind != .decl_assign || node.children_count < 2 {
 		return
 	}
-	lhs_id := t.a.child(&node, 0)
+	if node.children_count >= 4 && node.children_count % 2 == 0 {
+		for i := 0; i < node.children_count; i += 2 {
+			t.propagate_decl_pair_type(node, i, i + 1, '')
+		}
+		return
+	}
+	t.propagate_decl_pair_type(node, 0, 1, node.typ)
+}
+
+fn (mut t Transformer) propagate_decl_pair_type(node flat.Node, lhs_idx int, rhs_idx int, fallback_type string) {
+	if lhs_idx >= node.children_count || rhs_idx >= node.children_count {
+		return
+	}
+	lhs_id := t.a.child(&node, lhs_idx)
 	lhs := t.a.nodes[int(lhs_id)]
 	if lhs.kind != .ident || lhs.value.len == 0 {
 		return
 	}
 	mut typ := ''
-	if node.typ.len > 0 {
-		typ = node.typ
+	rhs_id := t.a.child(&node, rhs_idx)
+	rhs_authority := t.decl_rhs_type(rhs_id)
+	if t.is_fn_pointer_type_name(rhs_authority) {
+		typ = rhs_authority
+	} else if decl_type_is_usable(fallback_type) {
+		typ = fallback_type
 	} else {
-		rhs_id := t.a.child(&node, 1)
-		typ = t.resolve_expr_type(rhs_id)
+		if decl_type_is_usable(rhs_authority) {
+			typ = rhs_authority
+		} else if decl_type_is_usable(lhs.typ) {
+			typ = lhs.typ
+		}
 	}
 	if typ.len > 0 {
-		t.set_var_type(lhs.value, typ)
+		t.set_var_type(lhs.value, t.normalize_type_alias(typ))
 	}
+}
+
+fn decl_type_is_usable(typ string) bool {
+	return typ.len > 0 && typ !in ['unknown', 'array', 'map']
+}
+
+fn (t &Transformer) decl_rhs_type(id flat.NodeId) string {
+	if fn_type := t.fn_value_type_name(id) {
+		return fn_type
+	}
+	return t.node_type(id)
+}
+
+fn (t &Transformer) fn_value_type_name(id flat.NodeId) ?string {
+	if isnil(t.tc) || int(id) < 0 {
+		return none
+	}
+	if typ := t.tc.expr_type(id) {
+		if name := fn_value_type_name_from_type(typ) {
+			return t.normalize_type_alias(name)
+		}
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .fn_literal || node.kind == .lambda_expr {
+		typ := t.tc.resolve_type(id)
+		if name := fn_value_type_name_from_type(typ) {
+			return t.normalize_type_alias(name)
+		}
+	}
+	return none
+}
+
+fn fn_value_type_name_from_type(typ types.Type) ?string {
+	name := typ.name()
+	if name.len == 0 {
+		return none
+	}
+	if typ is types.FnType {
+		return name
+	}
+	if typ is types.Alias {
+		if typ.base_type is types.FnType {
+			return name
+		}
+	}
+	return none
 }
 
 // resolve_selector_type resolves the type of a .selector node (e.g. `obj.field`).
@@ -235,11 +302,21 @@ fn (t &Transformer) lookup_struct_info_for_field(type_name string, field_name st
 			lookup_type = short_type
 		}
 	}
-	if lookup_type !in t.structs && !lookup_type.contains('.') && t.cur_module.len > 0
-		&& t.cur_module != 'main' && t.cur_module != 'builtin' {
+	if !lookup_type.contains('.') && t.cur_module.len > 0 && t.cur_module != 'main'
+		&& t.cur_module != 'builtin' {
 		qtype := '${t.cur_module}.${lookup_type}'
 		if qtype in t.structs {
 			lookup_type = qtype
+		} else if !isnil(t.tc) {
+			if target := t.tc.type_aliases[qtype] {
+				lookup_type = target
+			}
+		}
+	}
+	if lookup_type !in t.structs {
+		normalized := t.normalize_type_alias(lookup_type)
+		if normalized != lookup_type {
+			lookup_type = normalized
 		}
 	}
 	info := t.structs[lookup_type] or { return none }
@@ -314,7 +391,7 @@ fn (t &Transformer) normalize_field_type(typ string, owner_type string) string {
 		if !field_base.contains('.') && owner_type.contains('.') {
 			owner_mod := owner_type.all_before_last('.')
 			qbase := '${owner_mod}.${field_base}'
-			if qbase in t.structs || qbase in t.sum_types || qbase in t.enum_types {
+			if t.type_authority_has(qbase) {
 				field_base = qbase
 			}
 		}
@@ -336,7 +413,7 @@ fn (t &Transformer) normalize_field_type(typ string, owner_type string) string {
 	}
 	owner_mod := owner_type.all_before_last('.')
 	qtyp := '${owner_mod}.${typ}'
-	if qtyp in t.structs || qtyp in t.sum_types || qtyp in t.enum_types {
+	if t.type_authority_has(qtyp) {
 		return t.normalize_type_alias(qtyp)
 	}
 	if !isnil(t.tc) {
@@ -345,6 +422,17 @@ fn (t &Transformer) normalize_field_type(typ string, owner_type string) string {
 		}
 	}
 	return t.normalize_type_alias(typ)
+}
+
+fn (t &Transformer) type_authority_has(name string) bool {
+	if name in t.structs || name in t.sum_types || name in t.enum_types {
+		return true
+	}
+	if isnil(t.tc) {
+		return false
+	}
+	return name in t.tc.structs || name in t.tc.sum_types || name in t.tc.enum_names
+		|| name in t.tc.interface_names || name in t.tc.type_aliases
 }
 
 // normalize_type_alias transforms normalize type alias data for transform.
@@ -394,7 +482,10 @@ fn (t &Transformer) normalize_type_alias_uncached(typ string) string {
 	if !typ.contains('.') && t.cur_module.len > 0 && t.cur_module != 'main'
 		&& t.cur_module != 'builtin' {
 		qtyp := '${t.cur_module}.${typ}'
-		if qtyp in t.structs || qtyp in t.sum_types || qtyp in t.enum_types {
+		if target := t.tc.type_aliases[qtyp] {
+			return target
+		}
+		if t.type_authority_has(qtyp) {
 			return qtyp
 		}
 	}
@@ -493,7 +584,7 @@ fn (t &Transformer) normalize_type_in_module(typ string, mod string) string {
 		return t.normalize_type_alias(clean)
 	}
 	qtyp := '${mod}.${clean}'
-	if qtyp in t.structs || qtyp in t.sum_types || qtyp in t.enum_types {
+	if t.type_authority_has(qtyp) {
 		return t.normalize_type_alias(qtyp)
 	}
 	if !isnil(t.tc) {
@@ -520,7 +611,8 @@ fn (t &Transformer) resolve_index_elem_type(node flat.Node) string {
 		ptr_elem_type := t.normalize_type_alias(base_type[1..])
 		// A `mut map`/`mut []T` param is a pointer to the container; indexing it must
 		// still yield the element/value type, so fall through to the container cases.
-		if !ptr_elem_type.starts_with('[]') && !ptr_elem_type.starts_with('map[') {
+		if !ptr_elem_type.starts_with('[]') && !ptr_elem_type.starts_with('map[')
+			&& !t.is_fixed_array_type(ptr_elem_type) {
 			return ptr_elem_type
 		}
 		base_type = ptr_elem_type
@@ -535,11 +627,14 @@ fn (t &Transformer) resolve_index_elem_type(node flat.Node) string {
 		// A range/slice of a fixed array (`arr[..]`, `arr[a..b]`) yields a dynamic
 		// `[]T`, not the fixed array or a bogus `range` type.
 		if t.is_fixed_array_type(base_type) {
-			return '[]${fixed_array_elem_type(base_type)}'
+			return '[]${t.normalize_type_alias(for_in_fixed_array_elem_type(base_type))}'
 		}
 	}
 	if base_type.starts_with('[]') {
 		return t.normalize_type_alias(base_type[2..])
+	}
+	if t.is_fixed_array_type(base_type) {
+		return t.normalize_type_alias(for_in_fixed_array_elem_type(base_type))
 	}
 	if base_type.starts_with('map[') {
 		bracket_end := base_type.index(']') or { return '' }
@@ -552,6 +647,18 @@ fn (t &Transformer) resolve_index_elem_type(node flat.Node) string {
 		return 'u8'
 	}
 	return ''
+}
+
+fn (t &Transformer) index_expr_type(id flat.NodeId, node flat.Node) string {
+	if !isnil(t.tc) {
+		if typ := t.tc.expr_type(id) {
+			name := typ.name()
+			if name.len > 0 && name != 'unknown' {
+				return t.normalize_type_alias(name)
+			}
+		}
+	}
+	return t.resolve_index_elem_type(node)
 }
 
 // node_type returns the v-type string for an expression node, preferring the
@@ -578,7 +685,7 @@ fn (t &Transformer) node_type(id flat.NodeId) string {
 		}
 	}
 	if node.kind == .index {
-		elem_type := t.resolve_index_elem_type(node)
+		elem_type := t.index_expr_type(id, node)
 		if elem_type.len > 0 {
 			return elem_type
 		}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1675,6 +1675,7 @@ pub fn (mut tc TypeChecker) check_semantics() {
 
 fn (mut tc TypeChecker) check_export_attrs() {
 	mut natural_symbols := map[string]string{}
+	synthetic_main_reserved := tc.has_synthetic_c_entry_main()
 	mut cur_module := ''
 	for node in tc.a.nodes {
 		match node.kind {
@@ -1718,6 +1719,11 @@ fn (mut tc TypeChecker) check_export_attrs() {
 					tc.record_error_unfiltered(.unsupported_generic,
 						'invalid export name `${export_name}` for `${qname}`', flat.NodeId(i))
 				}
+				if synthetic_main_reserved && export_name == 'main' {
+					tc.record_error_unfiltered(.unsupported_generic,
+						'export name `main` for `${qname}` collides with synthetic entry point `main`',
+						flat.NodeId(i))
+				}
 				if node.generic_params.len > 0 {
 					tc.record_error_unfiltered(.unsupported_generic,
 						'generic function `${qname}` cannot be exported', flat.NodeId(i))
@@ -1747,6 +1753,136 @@ fn (mut tc TypeChecker) check_export_attrs() {
 			else {}
 		}
 	}
+}
+
+fn (tc &TypeChecker) has_synthetic_c_entry_main() bool {
+	if tc.has_c_test_harness_main() {
+		return true
+	}
+	if tc.has_main_module_fn_main() {
+		return false
+	}
+	return tc.has_c_top_level_main()
+}
+
+fn (tc &TypeChecker) has_main_module_fn_main() bool {
+	mut cur_module := ''
+	for node in tc.a.nodes {
+		match node.kind {
+			.file {
+				cur_module = ''
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.fn_decl {
+				if node.value == 'main' && (cur_module.len == 0 || cur_module == 'main') {
+					return true
+				}
+			}
+			else {}
+		}
+	}
+	return false
+}
+
+fn (tc &TypeChecker) has_c_test_harness_main() bool {
+	for file_idx, file_node in tc.a.nodes {
+		if file_idx < tc.a.user_code_start || file_node.kind != .file || file_node.value.len == 0 {
+			continue
+		}
+		if !tc.is_selected_input_file(file_node.value) {
+			continue
+		}
+		module_name := tc.top_level_file_module_name(file_node)
+		if is_c_backend_test_file(file_node.value)
+			&& (module_name.len == 0 || module_name == 'main') {
+			return true
+		}
+	}
+	return false
+}
+
+fn (tc &TypeChecker) has_c_top_level_main() bool {
+	for file_idx, file_node in tc.a.nodes {
+		if !tc.should_emit_c_top_level_file(file_idx, file_node) {
+			continue
+		}
+		for i in 0 .. file_node.children_count {
+			child_id := tc.a.child(&file_node, i)
+			if int(child_id) < tc.a.user_code_start {
+				continue
+			}
+			if tc.is_c_top_level_stmt(child_id) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+fn (tc &TypeChecker) should_emit_c_top_level_file(file_idx int, file_node flat.Node) bool {
+	if file_idx < tc.a.user_code_start || file_node.kind != .file || file_node.children_count == 0 {
+		return false
+	}
+	module_name := tc.top_level_file_module_name(file_node)
+	return module_name.len == 0 || module_name == 'main'
+}
+
+fn (tc &TypeChecker) top_level_file_module_name(file_node flat.Node) string {
+	if module_name := tc.file_modules[file_node.value] {
+		return module_name
+	}
+	for i in 0 .. file_node.children_count {
+		child := tc.a.child_node(&file_node, i)
+		if child.kind == .module_decl {
+			return child.value
+		}
+	}
+	return ''
+}
+
+fn (tc &TypeChecker) is_c_top_level_stmt(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	return match node.kind {
+		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
+		.for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .defer_stmt {
+			true
+		}
+		.block, .comptime_if {
+			for i in 0 .. node.children_count {
+				if tc.is_c_top_level_stmt(tc.a.child(&node, i)) {
+					return true
+				}
+			}
+			false
+		}
+		else {
+			false
+		}
+	}
+}
+
+fn (tc &TypeChecker) is_selected_input_file(file string) bool {
+	return tc.diagnostic_files.len == 0 || tc.diagnostic_files[file]
+}
+
+fn is_c_backend_test_file(path string) bool {
+	file := path.all_after_last('/').all_after_last('\\')
+	if file.ends_with('_test.v') || file.ends_with('_test.c.v') {
+		return true
+	}
+	if !file.ends_with('.v') {
+		return false
+	}
+	base := file[..file.len - 2]
+	if !base.contains('.') {
+		return false
+	}
+	return base.all_after_last('.') == 'c' && base.all_before_last('.').ends_with('_test')
 }
 
 fn export_qualified_fn_name(module_name string, name string) string {
@@ -3989,6 +4125,9 @@ fn (tc &TypeChecker) generic_call_base_name(base_node flat.Node) ?string {
 		if qfn in tc.fn_ret_types {
 			return qfn
 		}
+		if imported_name := tc.resolve_selective_import_symbol(base_node.value) {
+			return imported_name
+		}
 		if base_node.value in tc.fn_ret_types {
 			return base_node.value
 		}
@@ -5118,6 +5257,10 @@ fn (tc &TypeChecker) call_has_ambiguous_selective_import(node flat.Node) bool {
 		return false
 	}
 	fn_node := tc.a.child_node(&node, 0)
+	if fn_node.kind == .index && fn_node.children_count > 0 {
+		base := tc.a.child_node(fn_node, 0)
+		return base.kind == .ident && tc.selective_import_symbol_is_ambiguous(base.value)
+	}
 	return fn_node.kind == .ident && tc.selective_import_symbol_is_ambiguous(fn_node.value)
 }
 

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -160,6 +160,8 @@ pub mut:
 	fn_param_types         map[string][]Type
 	fn_ret_type_texts      map[string]string   // generic struct method key -> original return type text (e.g. `Box[T].clone` -> `Box[T]`)
 	fn_param_type_texts    map[string][]string // generic struct method key -> original param type texts (receiver first)
+	fn_type_files          map[string]string
+	fn_type_modules        map[string]string
 	fn_generic_params      map[string][]string
 	fn_variadic            map[string]bool
 	c_variadic_fns         map[string]bool
@@ -244,6 +246,8 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		fn_param_types:             map[string][]Type{}
 		fn_ret_type_texts:          map[string]string{}
 		fn_param_type_texts:        map[string][]string{}
+		fn_type_files:              map[string]string{}
+		fn_type_modules:            map[string]string{}
 		fn_generic_params:          map[string][]string{}
 		fn_variadic:                map[string]bool{}
 		c_variadic_fns:             map[string]bool{}
@@ -576,6 +580,8 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 					for name in [qname, node.value] {
 						tc.fn_ret_type_texts[name] = node.typ
 						tc.fn_param_type_texts[name] = param_texts.clone()
+						tc.fn_type_files[name] = tc.cur_file
+						tc.fn_type_modules[name] = tc.cur_module
 						if node.generic_params.len > 0 {
 							tc.fn_generic_params[name] = node.generic_params.clone()
 						}
@@ -4257,11 +4263,13 @@ fn (mut tc TypeChecker) specialized_plain_generic_call_info(node flat.Node, info
 	}
 	mut sub_params := []Type{}
 	for param_text in param_texts {
-		sub_params << tc.parse_type(subst_generic_text(param_text, concrete_args, generic_params))
+		sub_params << tc.parse_fn_signature_type(info.name, subst_generic_text(param_text,
+			concrete_args, generic_params))
 	}
 	ret_text := tc.fn_ret_type_texts[info.name] or { '' }
 	sub_ret := if ret_text.len > 0 {
-		tc.parse_type(subst_generic_text(ret_text, concrete_args, generic_params))
+		tc.parse_fn_signature_type(info.name, subst_generic_text(ret_text, concrete_args,
+			generic_params))
 	} else {
 		info.return_type
 	}
@@ -4275,6 +4283,25 @@ fn (mut tc TypeChecker) specialized_plain_generic_call_info(node flat.Node, info
 		params_known:         true
 		has_implicit_veb_ctx: info.has_implicit_veb_ctx
 	}
+}
+
+fn (tc &TypeChecker) parse_fn_signature_type(name string, typ string) Type {
+	decl_file := tc.fn_type_files[name] or { return tc.parse_type(typ) }
+	mut scoped := *tc
+	scoped.cur_file = decl_file
+	scoped.cur_module = tc.fn_type_modules[name] or {
+		tc.file_modules[decl_file] or { tc.cur_module }
+	}
+	scoped.type_cache = &TypeCache{
+		parse_enabled: if tc.type_cache != unsafe { nil } {
+			tc.type_cache.parse_enabled
+		} else {
+			false
+		}
+		parse_entries: map[string]Type{}
+		c_entries:     map[string]string{}
+	}
+	return scoped.parse_type(typ)
 }
 
 fn (mut tc TypeChecker) infer_generic_type_text_from_type(param_text string, actual Type, generic_params []string, mut inferred map[string]string) {
@@ -9015,12 +9042,14 @@ pub fn (tc &TypeChecker) resolve_generic_struct_method(type_name string, method 
 	// cannot recover `Box[int]`. Re-substituting the text and re-parsing does.
 	mut sub_ret := tc.substitute_generic_type(ret, concrete_args, params)
 	if ret_text := tc.fn_ret_type_texts[generic_key] {
-		sub_ret = tc.parse_type(subst_generic_text(ret_text, concrete_args, params))
+		sub_ret = tc.parse_fn_signature_type(generic_key, subst_generic_text(ret_text,
+			concrete_args, params))
 	}
 	mut sub_params := []Type{}
 	if param_texts := tc.fn_param_type_texts[generic_key] {
 		for pt in param_texts {
-			sub_params << tc.parse_type(subst_generic_text(pt, concrete_args, params))
+			sub_params << tc.parse_fn_signature_type(generic_key, subst_generic_text(pt,
+				concrete_args, params))
 		}
 	} else if ptypes := tc.fn_param_types[generic_key] {
 		for pt in ptypes {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -160,6 +160,7 @@ pub mut:
 	fn_param_types         map[string][]Type
 	fn_ret_type_texts      map[string]string   // generic struct method key -> original return type text (e.g. `Box[T].clone` -> `Box[T]`)
 	fn_param_type_texts    map[string][]string // generic struct method key -> original param type texts (receiver first)
+	fn_generic_params      map[string][]string
 	fn_variadic            map[string]bool
 	c_variadic_fns         map[string]bool
 	fn_implicit_veb_ctx    map[string]bool
@@ -243,6 +244,7 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		fn_param_types:             map[string][]Type{}
 		fn_ret_type_texts:          map[string]string{}
 		fn_param_type_texts:        map[string][]string{}
+		fn_generic_params:          map[string][]string{}
 		fn_variadic:                map[string]bool{}
 		c_variadic_fns:             map[string]bool{}
 		fn_implicit_veb_ctx:        map[string]bool{}
@@ -570,11 +572,14 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 				// so a concrete call must re-substitute the type arguments from the text to
 				// recover applications like the receiver type in the return position
 				// (`Box[T]` -> `Box[int]`). Only such methods carry `[` in their key.
-				if node.value.contains('[') {
-					tc.fn_ret_type_texts[qname] = node.typ
-					tc.fn_param_type_texts[qname] = param_texts.clone()
-					tc.fn_ret_type_texts[node.value] = node.typ
-					tc.fn_param_type_texts[node.value] = param_texts.clone()
+				if node.generic_params.len > 0 || node.value.contains('[') {
+					for name in [qname, node.value] {
+						tc.fn_ret_type_texts[name] = node.typ
+						tc.fn_param_type_texts[name] = param_texts.clone()
+						if node.generic_params.len > 0 {
+							tc.fn_generic_params[name] = node.generic_params.clone()
+						}
+					}
 				}
 			}
 			.struct_decl {
@@ -1687,28 +1692,28 @@ fn (mut tc TypeChecker) check_export_attrs() {
 				qname := export_qualified_fn_name(cur_module, node.value)
 				export_name := tc.a.export_fn_names[qname] or { continue }
 				if export_name.len == 0 {
-					tc.record_error(.unsupported_generic, 'empty export name for `${qname}`',
-						flat.NodeId(i))
+					tc.record_error_unfiltered(.unsupported_generic,
+						'empty export name for `${qname}`', flat.NodeId(i))
 					continue
 				}
 				if !is_valid_export_c_name(export_name) {
-					tc.record_error(.unsupported_generic,
+					tc.record_error_unfiltered(.unsupported_generic,
 						'invalid export name `${export_name}` for `${qname}`', flat.NodeId(i))
 				}
 				if node.generic_params.len > 0 {
-					tc.record_error(.unsupported_generic,
+					tc.record_error_unfiltered(.unsupported_generic,
 						'generic function `${qname}` cannot be exported', flat.NodeId(i))
 				}
 				for pi in 0 .. node.children_count {
 					p := tc.a.child_node(&node, pi)
 					if p.kind == .param && (p.value.len == 0 || p.typ.len == 0) {
-						tc.record_error(.unsupported_generic,
+						tc.record_error_unfiltered(.unsupported_generic,
 							'exported function `${qname}` must name all parameters', flat.NodeId(i))
 					}
 				}
 				if existing := export_symbols[export_name] {
 					if existing != qname {
-						tc.record_error(.unsupported_generic,
+						tc.record_error_unfiltered(.unsupported_generic,
 							'duplicate export name `${export_name}` for `${qname}` and `${existing}`',
 							flat.NodeId(i))
 					}
@@ -1716,7 +1721,7 @@ fn (mut tc TypeChecker) check_export_attrs() {
 					export_symbols[export_name] = qname
 				}
 				if existing := natural_symbols[export_name] {
-					tc.record_error(.unsupported_generic,
+					tc.record_error_unfiltered(.unsupported_generic,
 						'export name `${export_name}` for `${qname}` collides with `${existing}`',
 						flat.NodeId(i))
 				}
@@ -4085,7 +4090,8 @@ fn print_style_param_accepts_string(typ Type) bool {
 }
 
 // check_call_arg_types validates check call arg types state for types.
-fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, info CallInfo) {
+fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, info0 CallInfo) {
+	info := tc.specialized_plain_generic_call_info(node, info0)
 	if node.children_count == 0 {
 		return
 	}
@@ -4225,6 +4231,141 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 				param_idx + 1} to `${tc.call_display_name(node)}`; expected `${expected.name()}`',
 				id)
 		}
+	}
+}
+
+fn (mut tc TypeChecker) specialized_plain_generic_call_info(node flat.Node, info CallInfo) CallInfo {
+	generic_params := tc.fn_generic_params[info.name] or { return info }
+	param_texts := tc.fn_param_type_texts[info.name] or { return info }
+	if generic_params.len == 0 || node.children_count <= 1 {
+		return info
+	}
+	mut inferred := map[string]string{}
+	for i, param_text in param_texts {
+		arg_idx := i + 1
+		if arg_idx >= node.children_count {
+			break
+		}
+		arg_id := tc.call_arg_value(tc.a.child(&node, arg_idx))
+		actual := tc.resolve_type(arg_id)
+		tc.infer_generic_type_text_from_type(param_text, actual, generic_params, mut inferred)
+	}
+	mut concrete_args := []string{cap: generic_params.len}
+	for param in generic_params {
+		arg := inferred[param] or { return info }
+		concrete_args << arg
+	}
+	mut sub_params := []Type{}
+	for param_text in param_texts {
+		sub_params << tc.parse_type(subst_generic_text(param_text, concrete_args, generic_params))
+	}
+	ret_text := tc.fn_ret_type_texts[info.name] or { '' }
+	sub_ret := if ret_text.len > 0 {
+		tc.parse_type(subst_generic_text(ret_text, concrete_args, generic_params))
+	} else {
+		info.return_type
+	}
+	return CallInfo{
+		name:                 info.name
+		params:               sub_params
+		return_type:          sub_ret
+		has_receiver:         info.has_receiver
+		is_variadic:          info.is_variadic
+		is_c_variadic:        info.is_c_variadic
+		params_known:         true
+		has_implicit_veb_ctx: info.has_implicit_veb_ctx
+	}
+}
+
+fn (mut tc TypeChecker) infer_generic_type_text_from_type(param_text string, actual Type, generic_params []string, mut inferred map[string]string) {
+	clean := param_text.trim_space()
+	if clean.len == 0 {
+		return
+	}
+	if clean.starts_with('&') {
+		if actual is Pointer {
+			tc.infer_generic_type_text_from_type(clean[1..], actual.base_type, generic_params, mut
+				inferred)
+		} else {
+			tc.infer_generic_type_text_from_type(clean[1..], actual, generic_params, mut inferred)
+		}
+		return
+	}
+	if clean.starts_with('mut ') {
+		tc.infer_generic_type_text_from_type(clean[4..], actual, generic_params, mut inferred)
+		return
+	}
+	if clean.starts_with('...') {
+		if actual is Array {
+			tc.infer_generic_type_text_from_type(clean[3..], actual.elem_type, generic_params, mut
+				inferred)
+		}
+		return
+	}
+	if clean.starts_with('[]') {
+		if actual is Array {
+			tc.infer_generic_type_text_from_type(clean[2..], actual.elem_type, generic_params, mut
+				inferred)
+		}
+		return
+	}
+	if clean.starts_with('?') {
+		if actual is OptionType {
+			tc.infer_generic_type_text_from_type(clean[1..], actual.base_type, generic_params, mut
+				inferred)
+		}
+		return
+	}
+	if clean.starts_with('!') {
+		if actual is ResultType {
+			tc.infer_generic_type_text_from_type(clean[1..], actual.base_type, generic_params, mut
+				inferred)
+		}
+		return
+	}
+	if clean.starts_with('fn(') || clean.starts_with('fn (') {
+		if actual is FnType {
+			tc.infer_generic_fn_type_text_from_type(clean, actual, generic_params, mut inferred)
+		}
+		return
+	}
+	for param in generic_params {
+		if clean == param && param !in inferred {
+			inferred[param] = actual.name()
+			return
+		}
+	}
+}
+
+fn (mut tc TypeChecker) infer_generic_fn_type_text_from_type(param_text string, actual FnType, generic_params []string, mut inferred map[string]string) {
+	params_start := param_text.index_u8(`(`) + 1
+	mut depth := 1
+	mut params_end := params_start
+	for params_end < param_text.len {
+		if param_text[params_end] == `(` {
+			depth++
+		} else if param_text[params_end] == `)` {
+			depth--
+			if depth == 0 {
+				break
+			}
+		}
+		params_end++
+	}
+	if params_end >= param_text.len {
+		return
+	}
+	parts := split_params(param_text[params_start..params_end])
+	for i, part in parts {
+		if i >= actual.params.len {
+			break
+		}
+		tc.infer_generic_type_text_from_type(normalize_fn_type_param_text(part), fn_param_type(actual,
+			i), generic_params, mut inferred)
+	}
+	ret := param_text[params_end + 1..].trim_space()
+	if ret.len > 0 {
+		tc.infer_generic_type_text_from_type(ret, actual.return_type, generic_params, mut inferred)
 	}
 }
 

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -7837,7 +7837,34 @@ fn (tc &TypeChecker) c_abi_fn_param_type(param string) (string, bool) {
 		base_type := tc.parse_type(param_type[1..])
 		return 'const ${tc.c_type(base_type)}*', true
 	}
+	if param_type.starts_with('&') {
+		if ct := tc.c_abi_alias_pointer_param_c_type(param_type[1..]) {
+			if clean.starts_with('mut ') {
+				return '${ct}*', true
+			}
+			return 'const ${ct}*', true
+		}
+	}
 	return tc.c_type(tc.parse_type(param_type)), false
+}
+
+fn (tc &TypeChecker) c_abi_alias_pointer_param_c_type(typ string) ?string {
+	t := tc.parse_type(typ)
+	if t is Alias {
+		base := c_abi_alias_c_base_type(t.base_type) or { return none }
+		return tc.c_type(base)
+	}
+	return none
+}
+
+fn c_abi_alias_c_base_type(t Type) ?Type {
+	if t is Alias {
+		return c_abi_alias_c_base_type(t.base_type)
+	}
+	if t is Struct && t.name.starts_with('C.') {
+		return t
+	}
+	return none
 }
 
 fn c_abi_fn_param_name(param string) string {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -69,6 +69,18 @@ const export_v3_reserved_c_symbols = {
 	'c_name':        true
 }
 
+const export_c_libc_collision_symbols = {
+	'rint':  true
+	'y0':    true
+	'y1':    true
+	'yn':    true
+	'j0':    true
+	'j1':    true
+	'jn':    true
+	'drem':  true
+	'scalb': true
+}
+
 // tarr1 supports tarr1 handling for types.
 fn tarr1(a Type) []Type {
 	mut r := []Type{}
@@ -1756,6 +1768,9 @@ fn export_natural_c_symbol(module_name string, name string) string {
 	}
 	if name == 'exit' {
 		return 'v_exit'
+	}
+	if name in export_c_libc_collision_symbols {
+		return 'v_${name}'
 	}
 	return c_name(name)
 }

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1038,6 +1038,57 @@ fn (tc &TypeChecker) resolve_selective_import_symbol(name string) ?string {
 	return none
 }
 
+fn (tc &TypeChecker) resolve_selective_import_type_symbol(name string) ?string {
+	candidates := tc.file_selective_imports[file_import_key(tc.cur_file, name)] or { return none }
+	for candidate in candidates {
+		if tc.type_symbol_known(candidate) {
+			return candidate
+		}
+	}
+	return none
+}
+
+fn (tc &TypeChecker) type_symbol_known(name string) bool {
+	return name in tc.type_aliases || name in tc.structs || name in tc.interface_names
+		|| name in tc.flag_enums || name in tc.enum_names || name in tc.sum_types
+}
+
+fn (tc &TypeChecker) type_from_known_symbol(name string) ?Type {
+	if name in tc.type_aliases {
+		return Type(Alias{
+			name:      name
+			base_type: tc.parse_type(tc.type_aliases[name])
+		})
+	}
+	if name in tc.structs {
+		return Type(Struct{
+			name: name
+		})
+	}
+	if name in tc.interface_names {
+		return Type(Interface{
+			name: name
+		})
+	}
+	if name in tc.flag_enums {
+		return Type(Enum{
+			name:    name
+			is_flag: true
+		})
+	}
+	if name in tc.enum_names {
+		return Type(Enum{
+			name: name
+		})
+	}
+	if name in tc.sum_types {
+		return Type(SumType{
+			name: name
+		})
+	}
+	return none
+}
+
 fn (tc &TypeChecker) selective_import_symbol_is_ambiguous(name string) bool {
 	candidates := tc.file_selective_imports[file_import_key(tc.cur_file, name)] or { return false }
 	return candidates.len == 0
@@ -2357,6 +2408,11 @@ fn (tc &TypeChecker) type_name_known(typ string) bool {
 		return true
 	}
 	qtyp := tc.qualify_name(typ)
+	if !typ.contains('.') {
+		if resolved := tc.resolve_selective_import_type_symbol(typ) {
+			return tc.type_symbol_known(resolved)
+		}
+	}
 	return typ in tc.type_aliases || qtyp in tc.type_aliases || typ in tc.structs
 		|| qtyp in tc.structs || typ in tc.interface_names || qtyp in tc.interface_names
 		|| typ in tc.enum_names || qtyp in tc.enum_names || typ in tc.sum_types
@@ -5446,6 +5502,9 @@ fn (mut tc TypeChecker) check_selector(id flat.NodeId, node flat.Node) {
 	base_id := tc.a.child(&node, 0)
 	base := tc.a.nodes[int(base_id)]
 	if tc.is_namespace_selector(node, base) {
+		if typ := tc.enum_selector_type(&node) {
+			tc.register_synth_type(id, typ)
+		}
 		return
 	}
 	tc.check_node(base_id)
@@ -5506,6 +5565,12 @@ fn (tc &TypeChecker) is_namespace_selector(node flat.Node, base flat.Node) bool 
 	}
 	if base.value == 'C' || tc.has_active_import(base.value) {
 		return true
+	}
+	if resolved := tc.resolve_selective_import_type_symbol(base.value) {
+		if resolved in tc.structs || resolved in tc.enum_names || resolved in tc.flag_enums
+			|| resolved in tc.sum_types || resolved in tc.interface_names {
+			return true
+		}
 	}
 	qbase := tc.qualify_name(base.value)
 	if qbase in tc.structs || qbase in tc.enum_names || qbase in tc.sum_types
@@ -6130,6 +6195,13 @@ fn (tc &TypeChecker) resolve_enum_name(name string) ?string {
 	qname := tc.qualify_name(name)
 	if qname in tc.enum_names {
 		return qname
+	}
+	if !name.contains('.') {
+		if resolved := tc.resolve_selective_import_type_symbol(name) {
+			if resolved in tc.enum_names || resolved in tc.flag_enums {
+				return resolved
+			}
+		}
 	}
 	return none
 }
@@ -7408,6 +7480,13 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 		})
 	}
 	if !typ.contains('.') {
+		if resolved := tc.resolve_selective_import_type_symbol(typ) {
+			if resolved_type := tc.type_from_known_symbol(resolved) {
+				return resolved_type
+			}
+		}
+	}
+	if !typ.contains('.') {
 		if resolved := tc.unique_qualified_type_name(typ) {
 			if resolved in tc.type_aliases {
 				return Type(Alias{
@@ -7470,6 +7549,31 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 			return Type(SumType{
 				name: qbase
 			})
+		}
+		if !base.contains('.') {
+			if resolved := tc.resolve_selective_import_type_symbol(base) {
+				if resolved in tc.type_aliases {
+					return Type(Alias{
+						name:      resolved
+						base_type: tc.parse_type(tc.type_aliases[resolved])
+					})
+				}
+				if resolved in tc.structs {
+					return Type(Struct{
+						name: if is_concrete_generic { resolved + generic_suffix } else { resolved }
+					})
+				}
+				if resolved in tc.interface_names {
+					return Type(Interface{
+						name: resolved
+					})
+				}
+				if resolved in tc.sum_types {
+					return Type(SumType{
+						name: resolved
+					})
+				}
+			}
 		}
 		if base in tc.type_aliases {
 			return Type(Alias{
@@ -7544,6 +7648,11 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 
 fn (tc &TypeChecker) is_known_type_text(typ string) bool {
 	qtyp := tc.qualify_name(typ)
+	if !typ.contains('.') {
+		if resolved := tc.resolve_selective_import_type_symbol(typ) {
+			return tc.type_symbol_known(resolved)
+		}
+	}
 	return typ in tc.structs || qtyp in tc.structs || typ in tc.interface_names
 		|| qtyp in tc.interface_names || typ in tc.enum_names || qtyp in tc.enum_names
 		|| typ in tc.sum_types || qtyp in tc.sum_types || typ in tc.type_aliases

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -2,6 +2,73 @@ module types
 
 import v3.flat
 
+const export_c_reserved_words = {
+	'auto':     true
+	'break':    true
+	'case':     true
+	'char':     true
+	'const':    true
+	'continue': true
+	'default':  true
+	'do':       true
+	'double':   true
+	'else':     true
+	'enum':     true
+	'extern':   true
+	'float':    true
+	'for':      true
+	'goto':     true
+	'if':       true
+	'inline':   true
+	'int':      true
+	'long':     true
+	'register': true
+	'restrict': true
+	'return':   true
+	'short':    true
+	'signed':   true
+	'sizeof':   true
+	'static':   true
+	'struct':   true
+	'switch':   true
+	'typedef':  true
+	'union':    true
+	'unsigned': true
+	'void':     true
+	'volatile': true
+	'while':    true
+}
+
+const export_v3_reserved_c_symbols = {
+	'i8':            true
+	'i16':           true
+	'i32':           true
+	'i64':           true
+	'u8':            true
+	'byte':          true
+	'u16':           true
+	'u32':           true
+	'u64':           true
+	'bool':          true
+	'voidptr':       true
+	'int_literal':   true
+	'float_literal': true
+	'chan':          true
+	'string':        true
+	'array':         true
+	'Array':         true
+	'map':           true
+	'mapnode':       true
+	'DenseArray':    true
+	'SortedMap':     true
+	'Optional':      true
+	'IError':        true
+	'true':          true
+	'false':         true
+	'elem_size':     true
+	'c_name':        true
+}
+
 // tarr1 supports tarr1 handling for types.
 fn tarr1(a Type) []Type {
 	mut r := []Type{}
@@ -65,6 +132,7 @@ pub:
 	return_type          Type
 	has_receiver         bool
 	is_variadic          bool
+	is_c_variadic        bool
 	params_known         bool
 	has_implicit_veb_ctx bool
 }
@@ -87,15 +155,17 @@ mut:
 @[heap]
 pub struct TypeChecker {
 pub mut:
-	a                     &flat.FlatAst = unsafe { nil }
-	fn_ret_types          map[string]Type
-	fn_param_types        map[string][]Type
-	fn_ret_type_texts     map[string]string   // generic struct method key -> original return type text (e.g. `Box[T].clone` -> `Box[T]`)
-	fn_param_type_texts   map[string][]string // generic struct method key -> original param type texts (receiver first)
-	fn_variadic           map[string]bool
-	fn_implicit_veb_ctx   map[string]bool
-	structs               map[string][]StructField
-	struct_generic_params map[string][]string // generic struct base name -> type-param names (e.g. Vec4 -> [T])
+	a                      &flat.FlatAst = unsafe { nil }
+	fn_ret_types           map[string]Type
+	fn_param_types         map[string][]Type
+	fn_ret_type_texts      map[string]string   // generic struct method key -> original return type text (e.g. `Box[T].clone` -> `Box[T]`)
+	fn_param_type_texts    map[string][]string // generic struct method key -> original param type texts (receiver first)
+	fn_variadic            map[string]bool
+	c_variadic_fns         map[string]bool
+	fn_implicit_veb_ctx    map[string]bool
+	structs                map[string][]StructField
+	struct_generic_params  map[string][]string // generic struct base name -> type-param names (e.g. Vec4 -> [T])
+	struct_field_c_abi_fns map[string]string
 	// concrete `Box[int].method` -> substituted CallInfo for a method *value* on a
 	// generic receiver. The open `Box[T].method` registration is gone by cgen time, so
 	// the checker stashes the resolved signature here for gen_method_value_closure.
@@ -103,6 +173,7 @@ pub mut:
 	params_structs             map[string]bool
 	unions                     map[string]bool
 	type_aliases               map[string]string
+	type_alias_c_abi_fns       map[string]string
 	sum_types                  map[string][]string
 	enum_names                 map[string]bool
 	enum_fields                map[string][]string
@@ -112,24 +183,27 @@ pub mut:
 	interface_embeds           map[string][]string
 	interface_abstract_methods map[string][]string // iface -> abstract (declared) method names
 
-	c_globals           map[string]Type
-	const_types         map[string]Type
-	const_exprs         map[string]flat.NodeId
-	const_modules       map[string]string
-	const_suffixes      map[string]string // dot-suffix -> full const key (O(1) lookup; '' if ambiguous)
-	imports             map[string]string // alias -> short module name
-	file_imports        map[string]string
-	file_modules        map[string]string
-	file_scope          &Scope = unsafe { nil }
-	cur_scope           &Scope = unsafe { nil }
-	scope_pool          []&Scope
-	scope_pool_index    int
-	has_builtins        bool
-	cur_module          string
-	cur_file            string
-	errors              []TypeError
-	resolved_call_names []string // node_id -> resolved function name
-	resolved_call_set   []bool
+	c_globals               map[string]Type
+	const_types             map[string]Type
+	const_exprs             map[string]flat.NodeId
+	const_modules           map[string]string
+	const_suffixes          map[string]string // dot-suffix -> full const key (O(1) lookup; '' if ambiguous)
+	imports                 map[string]string // alias -> short module name
+	file_imports            map[string]string
+	file_selective_imports  map[string][]string
+	file_modules            map[string]string
+	file_scope              &Scope = unsafe { nil }
+	cur_scope               &Scope = unsafe { nil }
+	scope_pool              []&Scope
+	scope_pool_index        int
+	has_builtins            bool
+	cur_module              string
+	cur_file                string
+	errors                  []TypeError
+	resolved_call_names     []string // node_id -> resolved function name
+	resolved_call_set       []bool
+	resolved_fn_value_names []string // node_id -> resolved function value name
+	resolved_fn_value_set   []bool
 	// Methods used as *values* (`recv.method` passed as a callback), recorded per enclosing
 	// function during semantic checking — which has full scope/type info, runs before
 	// markused, and (unlike a call) routes a value-context selector through check_selector.
@@ -167,12 +241,19 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		a:                          a
 		fn_ret_types:               map[string]Type{}
 		fn_param_types:             map[string][]Type{}
+		fn_ret_type_texts:          map[string]string{}
+		fn_param_type_texts:        map[string][]string{}
 		fn_variadic:                map[string]bool{}
+		c_variadic_fns:             map[string]bool{}
 		fn_implicit_veb_ctx:        map[string]bool{}
 		structs:                    map[string][]StructField{}
+		struct_generic_params:      map[string][]string{}
+		struct_field_c_abi_fns:     map[string]string{}
+		generic_method_value_info:  map[string]CallInfo{}
 		params_structs:             map[string]bool{}
 		unions:                     map[string]bool{}
 		type_aliases:               map[string]string{}
+		type_alias_c_abi_fns:       map[string]string{}
 		sum_types:                  map[string][]string{}
 		enum_names:                 map[string]bool{}
 		enum_fields:                map[string][]string{}
@@ -185,13 +266,20 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		const_types:                map[string]Type{}
 		const_exprs:                map[string]flat.NodeId{}
 		const_modules:              map[string]string{}
+		const_suffixes:             map[string]string{}
 		imports:                    map[string]string{}
 		file_imports:               map[string]string{}
+		file_selective_imports:     map[string][]string{}
 		file_modules:               map[string]string{}
 		file_scope:                 fs
 		cur_scope:                  fs
 		resolved_call_names:        []string{len: a.nodes.len}
 		resolved_call_set:          []bool{len: a.nodes.len}
+		resolved_fn_value_names:    []string{len: a.nodes.len}
+		resolved_fn_value_set:      []bool{len: a.nodes.len}
+		method_values_by_fn:        map[int][]string{}
+		method_value_locals:        map[string]bool{}
+		method_value_local_depth:   map[string]int{}
 		expr_type_values:           []Type{len: a.nodes.len, init: Type(void_)}
 		expr_type_set:              []bool{len: a.nodes.len}
 		checking_nodes:             []bool{len: a.nodes.len}
@@ -231,9 +319,59 @@ pub fn (tc &TypeChecker) fork_for_parallel_transform(ast &flat.FlatAst) &TypeChe
 fn (mut tc TypeChecker) reset_node_caches(n int) {
 	tc.resolved_call_names = []string{len: n}
 	tc.resolved_call_set = []bool{len: n}
+	tc.resolved_fn_value_names = []string{len: n}
+	tc.resolved_fn_value_set = []bool{len: n}
 	tc.expr_type_values = []Type{len: n, init: Type(void_)}
 	tc.expr_type_set = []bool{len: n}
 	tc.checking_nodes = []bool{len: n}
+}
+
+fn (mut tc TypeChecker) extend_node_caches(n int) {
+	if n <= tc.resolved_call_names.len && n <= tc.resolved_fn_value_names.len
+		&& n <= tc.expr_type_values.len && n <= tc.checking_nodes.len {
+		return
+	}
+	old_resolved_call_names := tc.resolved_call_names.clone()
+	old_resolved_call_set := tc.resolved_call_set.clone()
+	old_resolved_fn_value_names := tc.resolved_fn_value_names.clone()
+	old_resolved_fn_value_set := tc.resolved_fn_value_set.clone()
+	old_expr_type_values := tc.expr_type_values.clone()
+	old_expr_type_set := tc.expr_type_set.clone()
+	old_checking_nodes := tc.checking_nodes.clone()
+	tc.resolved_call_names = []string{len: n}
+	tc.resolved_call_set = []bool{len: n}
+	tc.resolved_fn_value_names = []string{len: n}
+	tc.resolved_fn_value_set = []bool{len: n}
+	tc.expr_type_values = []Type{len: n, init: Type(void_)}
+	tc.expr_type_set = []bool{len: n}
+	tc.checking_nodes = []bool{len: n}
+	for i in 0 .. old_resolved_call_names.len {
+		if i >= n {
+			break
+		}
+		tc.resolved_call_names[i] = old_resolved_call_names[i]
+		tc.resolved_call_set[i] = old_resolved_call_set[i]
+	}
+	for i in 0 .. old_resolved_fn_value_names.len {
+		if i >= n {
+			break
+		}
+		tc.resolved_fn_value_names[i] = old_resolved_fn_value_names[i]
+		tc.resolved_fn_value_set[i] = old_resolved_fn_value_set[i]
+	}
+	for i in 0 .. old_expr_type_values.len {
+		if i >= n {
+			break
+		}
+		tc.expr_type_values[i] = old_expr_type_values[i]
+		tc.expr_type_set[i] = old_expr_type_set[i]
+	}
+	for i in 0 .. old_checking_nodes.len {
+		if i >= n {
+			break
+		}
+		tc.checking_nodes[i] = old_checking_nodes[i]
+	}
 }
 
 // push_scope updates push scope state for TypeChecker.
@@ -282,6 +420,14 @@ fn (mut tc TypeChecker) record_error(kind TypeErrorKind, msg string, node flat.N
 	}
 }
 
+fn (mut tc TypeChecker) record_error_unfiltered(kind TypeErrorKind, msg string, node flat.NodeId) {
+	tc.errors << TypeError{
+		msg:  msg
+		kind: kind
+		node: node
+	}
+}
+
 fn (mut tc TypeChecker) record_unsupported_generic(msg string, node flat.NodeId) {
 	if !tc.should_diagnose_unsupported_generic(node) {
 		return
@@ -322,6 +468,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 			.import_decl {
 				tc.imports[node.typ] = node.value
 				tc.file_imports[file_import_key(tc.cur_file, node.typ)] = node.value
+				tc.register_selective_imports(node)
 			}
 			.enum_decl {
 				qn := tc.qualify_name(node.value)
@@ -365,9 +512,16 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 					}
 					tc.sum_types[tc.qualify_name(node.value)] = variants
 				} else if node.typ.len > 0 {
-					tc.type_aliases[tc.qualify_name(node.value)] = tc.qualify_type_text(node.typ)
+					qname := tc.qualify_name(node.value)
+					tc.type_aliases[qname] = tc.qualify_type_text(node.typ)
+					if c_abi_fn := tc.c_abi_fn_ptr_type_from_text(node.typ) {
+						tc.type_alias_c_abi_fns[qname] = c_abi_fn
+					}
 					if tc.cur_module in ['', 'main', 'builtin'] && node.value !in tc.type_aliases {
 						tc.type_aliases[node.value] = tc.qualify_type_text(node.typ)
+						if c_abi_fn := tc.c_abi_fn_ptr_type_from_text(node.typ) {
+							tc.type_alias_c_abi_fns[node.value] = c_abi_fn
+						}
 					}
 				}
 			}
@@ -425,6 +579,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 			}
 			.struct_decl {
 				mut fields := []StructField{}
+				mut field_c_abi_fns := map[string]string{}
 				for i in 0 .. node.children_count {
 					f := a.child_node(&node, i)
 					if f.kind != .field_decl {
@@ -435,6 +590,9 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 					if f.value == field_typ {
 						typ = tc.resolve_known_field_type(field_typ, typ)
 					}
+					if c_abi_fn := tc.c_abi_fn_ptr_type_for_type_text(field_typ) {
+						field_c_abi_fns[f.value] = c_abi_fn
+					}
 					fields << StructField{
 						name: f.value
 						typ:  typ
@@ -442,6 +600,9 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 				}
 				qname := tc.qualify_name(node.value)
 				tc.structs[qname] = fields
+				for field_name, c_abi_fn in field_c_abi_fns {
+					tc.struct_field_c_abi_fns[struct_field_c_abi_key(qname, field_name)] = c_abi_fn
+				}
 				if node.typ.contains('union') {
 					tc.unions[qname] = true
 				}
@@ -463,6 +624,16 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 					}
 				}
 				tc.register_fn_signature(node.value, ret_type, ptypes, is_variadic, false)
+				if is_variadic {
+					tc.register_c_variadic_fn(node.value)
+				}
+				if !node.value.starts_with('C.') {
+					tc.register_fn_signature('C.${node.value}', ret_type, ptypes, is_variadic,
+						false)
+					if is_variadic {
+						tc.register_c_variadic_fn('C.${node.value}')
+					}
+				}
 			}
 			.interface_decl {
 				iface_name := tc.qualify_name(node.value)
@@ -819,12 +990,57 @@ fn (mut tc TypeChecker) enter_module(name string) {
 	}
 }
 
+fn (mut tc TypeChecker) register_selective_imports(node flat.Node) {
+	if node.children_count == 0 {
+		return
+	}
+	for i in 0 .. node.children_count {
+		child_id := tc.a.child(&node, i)
+		child := tc.a.nodes[int(child_id)]
+		if child.kind != .ident {
+			continue
+		}
+		key := file_import_key(tc.cur_file, child.value)
+		if key in tc.file_selective_imports {
+			tc.file_selective_imports[key] = []string{}
+			tc.record_error_unfiltered(.unknown_fn, 'ambiguous selective import `${child.value}`',
+				child_id)
+			continue
+		}
+		mut candidates := []string{}
+		path_name := '${node.value}.${child.value}'
+		if path_name !in candidates {
+			candidates << path_name
+		}
+		alias_name := '${node.typ}.${child.value}'
+		if alias_name != path_name && alias_name !in candidates {
+			candidates << alias_name
+		}
+		tc.file_selective_imports[key] = candidates
+	}
+}
+
 // resolve_import_alias resolves resolve import alias information for types.
 fn (tc &TypeChecker) resolve_import_alias(alias string) ?string {
 	if mod := tc.file_imports[file_import_key(tc.cur_file, alias)] {
 		return mod
 	}
 	return none
+}
+
+fn (tc &TypeChecker) resolve_selective_import_symbol(name string) ?string {
+	candidates := tc.file_selective_imports[file_import_key(tc.cur_file, name)] or { return none }
+	for candidate in candidates {
+		if tc.fn_signature_known(candidate) {
+			return candidate
+		}
+	}
+	return none
+}
+
+fn (tc &TypeChecker) selective_import_symbol_is_ambiguous(name string) bool {
+	candidates := tc.file_selective_imports[file_import_key(tc.cur_file, name)] or { return false }
+	return candidates.len == 0
 }
 
 fn (tc &TypeChecker) resolve_imported_type_text(typ string) string {
@@ -873,6 +1089,20 @@ fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, param
 	tc.fn_implicit_veb_ctx[name] = implicit_veb_ctx
 }
 
+fn (mut tc TypeChecker) register_c_variadic_fn(name string) {
+	if name.len == 0 {
+		return
+	}
+	tc.c_variadic_fns[name] = true
+	lowered_name := c_name(name)
+	if lowered_name != name {
+		tc.c_variadic_fns[lowered_name] = true
+	}
+	if !name.starts_with('C.') {
+		tc.c_variadic_fns['C.${name}'] = true
+	}
+}
+
 // annotate_types performs a scope-aware walk over every function body, tracking
 // local variable types as they are declared, and records complex/contextual
 // expression types. This mirrors what the v2 transformer relies on: the type
@@ -884,6 +1114,7 @@ fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, param
 // visible after its block ends), which is harmless for type lookup since variable
 // names are effectively unique within a function.
 pub fn (mut tc TypeChecker) annotate_types() {
+	tc.extend_node_caches(tc.a.nodes.len)
 	tc.cur_module = ''
 	for node in tc.a.nodes {
 		if node.kind == .file {
@@ -932,6 +1163,7 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 					mut typ := Type(void_)
 					if node.children_count == 2 && node.typ.len > 0 {
 						typ = tc.parse_type(node.typ)
+						tc.annotate_expected_expr(rhs_id, typ)
 					} else {
 						typ = tc.resolve_type(rhs_id)
 					}
@@ -948,12 +1180,124 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 			tc.annotate_for_in(id, node)
 			return
 		}
+		.assign, .selector_assign, .index_assign {
+			tc.annotate_assign_expected_exprs(node)
+		}
+		.struct_init {
+			tc.annotate_struct_init_expected_exprs(node)
+		}
+		.call {
+			tc.annotate_call_expected_exprs(id, node)
+		}
 		else {}
 	}
 
 	tc.remember_expr_type(id, tc.resolve_type(id))
 	for i in 0 .. node.children_count {
 		tc.annotate_node(tc.a.child(&node, i))
+	}
+}
+
+fn (mut tc TypeChecker) annotate_expected_expr(id flat.NodeId, expected Type) {
+	if _ := fn_type_from_type(expected) {
+		_ = tc.resolve_expr(id, expected)
+	}
+}
+
+fn (mut tc TypeChecker) annotate_assign_expected_exprs(node flat.Node) {
+	if node.children_count < 2 {
+		return
+	}
+	mut i := 0
+	for i + 1 < node.children_count {
+		lhs_id := tc.a.child(&node, i)
+		rhs_id := tc.a.child(&node, i + 1)
+		lhs_type := tc.resolve_lvalue_type(lhs_id)
+		tc.annotate_expected_expr(rhs_id, lhs_type)
+		i += 2
+	}
+}
+
+fn (mut tc TypeChecker) annotate_struct_init_expected_exprs(node flat.Node) {
+	init_type := tc.parse_type(node.value)
+	init_struct := struct_type_from_type(init_type) or { return }
+	init_name := init_struct.name
+	fields := tc.structs[init_name] or { []StructField{} }
+	for i in 0 .. node.children_count {
+		field := tc.a.child_node(&node, i)
+		if field.kind != .field_init || field.children_count == 0 {
+			continue
+		}
+		value_id := tc.a.child(field, 0)
+		mut expected := Type(void_)
+		if field.value.len > 0 {
+			expected = tc.struct_field_type(init_name, field.value) or { Type(void_) }
+		} else if i < fields.len {
+			expected = fields[i].typ
+		}
+		tc.annotate_expected_expr(value_id, expected)
+	}
+}
+
+fn (mut tc TypeChecker) annotate_call_expected_exprs(id flat.NodeId, node flat.Node) {
+	info := tc.resolve_call_info(id, node) or { return }
+	if info.name.len > 0 && !is_array_dsl_call_name(info.name) {
+		tc.remember_resolved_call(id, info.name)
+	}
+	if !info.params_known || info.params.len == 0 {
+		return
+	}
+	mut field_init_args := 0
+	for i in 1 .. node.children_count {
+		if tc.a.child_node(&node, i).kind == .field_init {
+			field_init_args++
+		}
+	}
+	collapsed := if field_init_args > 0 { 1 } else { 0 }
+	recv_extra := if info.has_receiver { 1 } else { 0 }
+	actual_count := node.children_count - 1 - field_init_args + collapsed + recv_extra
+	ctx_count := if info.has_implicit_veb_ctx { 1 } else { 0 }
+	ctx_omitted := ctx_count > 0 && actual_count < info.params.len
+	for i in 1 .. node.children_count {
+		raw_arg := tc.a.child_node(&node, i)
+		arg_id := tc.call_arg_value(tc.a.child(&node, i))
+		if raw_arg.kind == .field_init {
+			tc.annotate_params_field_expected_expr(arg_id, raw_arg.value, info)
+			continue
+		}
+		arg_shift := if ctx_omitted { ctx_count } else { 0 }
+		param_idx := (if info.has_receiver { i } else { i - 1 }) + arg_shift
+		if info.is_c_variadic && param_idx >= c_variadic_fixed_param_count(info) {
+			continue
+		}
+		if param_idx >= info.params.len {
+			continue
+		}
+		expected := tc.call_arg_expected_type(info, param_idx)
+		tc.annotate_expected_expr(arg_id, expected)
+	}
+}
+
+fn (tc &TypeChecker) call_arg_expected_type(info CallInfo, param_idx int) Type {
+	expected := info.params[param_idx]
+	if info.is_variadic && param_idx == info.params.len - 1 && expected is Array {
+		return array_elem_type(expected)
+	}
+	return expected
+}
+
+fn (mut tc TypeChecker) annotate_params_field_expected_expr(arg_id flat.NodeId, field_name string, info CallInfo) {
+	if field_name.len == 0 {
+		return
+	}
+	for param in info.params {
+		clean := unwrap_pointer(param)
+		if clean is Struct {
+			if expected := tc.struct_field_type(clean.name, field_name) {
+				tc.annotate_expected_expr(arg_id, expected)
+				return
+			}
+		}
 	}
 }
 
@@ -1085,6 +1429,32 @@ pub fn (tc &TypeChecker) resolved_call_name(id flat.NodeId) ?string {
 	return tc.cached_resolved_call(id)
 }
 
+// resolved_fn_value_name returns the checker-resolved function name for a function value node.
+pub fn (tc &TypeChecker) resolved_fn_value_name(id flat.NodeId) ?string {
+	idx := int(id)
+	if idx >= 0 && idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
+		return tc.resolved_fn_value_names[idx]
+	}
+	return none
+}
+
+// resolve_fn_value_name_for_expected resolves and records a function value in an expected FnType context.
+fn (mut tc TypeChecker) resolve_fn_value_name_for_expected(id flat.NodeId, expected Type) ?string {
+	if name := tc.resolved_fn_value_name(id) {
+		return name
+	}
+	if int(id) < 0 || int(id) >= tc.a.nodes.len {
+		return none
+	}
+	node := tc.a.nodes[int(id)]
+	if tc.fn_value_shadowed_by_value(node) {
+		return none
+	}
+	key := tc.fn_value_match_key(node, expected) or { return none }
+	tc.remember_resolved_fn_value_chain(id, key)
+	return key
+}
+
 // remember_resolved_call supports remember resolved call handling for TypeChecker.
 fn (mut tc TypeChecker) remember_resolved_call(id flat.NodeId, name string) {
 	idx := int(id)
@@ -1097,6 +1467,32 @@ fn (mut tc TypeChecker) remember_resolved_call(id flat.NodeId, name string) {
 	if idx < tc.resolved_call_names.len {
 		tc.resolved_call_names[idx] = name
 		tc.resolved_call_set[idx] = true
+	}
+}
+
+// remember_resolved_fn_value records the exact function declaration used by a function value.
+fn (mut tc TypeChecker) remember_resolved_fn_value(id flat.NodeId, name string) {
+	idx := int(id)
+	if idx < 0 {
+		return
+	}
+	if idx >= tc.resolved_fn_value_names.len {
+		tc.reset_node_caches(tc.a.nodes.len)
+	}
+	if idx < tc.resolved_fn_value_names.len {
+		tc.resolved_fn_value_names[idx] = name
+		tc.resolved_fn_value_set[idx] = true
+	}
+}
+
+fn (mut tc TypeChecker) remember_resolved_fn_value_chain(id flat.NodeId, name string) {
+	tc.remember_resolved_fn_value(id, name)
+	if int(id) < 0 || int(id) >= tc.a.nodes.len {
+		return
+	}
+	node := tc.a.nodes[int(id)]
+	if node.kind in [.cast_expr, .paren, .expr_stmt] && node.children_count > 0 {
+		tc.remember_resolved_fn_value_chain(tc.a.child(&node, 0), name)
 	}
 }
 
@@ -1140,6 +1536,7 @@ fn should_cache_expr_type(kind flat.NodeKind, typ Type) bool {
 
 // check_semantics validates check semantics state for types.
 pub fn (mut tc TypeChecker) check_semantics() {
+	tc.check_export_attrs()
 	tc.cur_module = ''
 	tc.cur_file = ''
 	for i, node in tc.a.nodes {
@@ -1200,6 +1597,129 @@ pub fn (mut tc TypeChecker) check_semantics() {
 
 		_ = i
 	}
+}
+
+fn (mut tc TypeChecker) check_export_attrs() {
+	mut natural_symbols := map[string]string{}
+	mut cur_module := ''
+	for node in tc.a.nodes {
+		match node.kind {
+			.file {
+				tc.enter_file(node.value)
+				cur_module = tc.cur_module
+			}
+			.module_decl {
+				cur_module = node.value
+				tc.enter_module(node.value)
+			}
+			.fn_decl {
+				qname := export_qualified_fn_name(cur_module, node.value)
+				natural_symbol := export_natural_c_symbol(cur_module, node.value)
+				natural_symbols[natural_symbol] = qname
+			}
+			else {}
+		}
+	}
+	mut export_symbols := map[string]string{}
+	cur_module = ''
+	for i, node in tc.a.nodes {
+		match node.kind {
+			.file {
+				tc.enter_file(node.value)
+				cur_module = tc.cur_module
+			}
+			.module_decl {
+				cur_module = node.value
+				tc.enter_module(node.value)
+			}
+			.fn_decl {
+				qname := export_qualified_fn_name(cur_module, node.value)
+				export_name := tc.a.export_fn_names[qname] or { continue }
+				if export_name.len == 0 {
+					tc.record_error(.unsupported_generic, 'empty export name for `${qname}`',
+						flat.NodeId(i))
+					continue
+				}
+				if !is_valid_export_c_name(export_name) {
+					tc.record_error(.unsupported_generic,
+						'invalid export name `${export_name}` for `${qname}`', flat.NodeId(i))
+				}
+				if node.generic_params.len > 0 {
+					tc.record_error(.unsupported_generic,
+						'generic function `${qname}` cannot be exported', flat.NodeId(i))
+				}
+				for pi in 0 .. node.children_count {
+					p := tc.a.child_node(&node, pi)
+					if p.kind == .param && (p.value.len == 0 || p.typ.len == 0) {
+						tc.record_error(.unsupported_generic,
+							'exported function `${qname}` must name all parameters', flat.NodeId(i))
+					}
+				}
+				if existing := export_symbols[export_name] {
+					if existing != qname {
+						tc.record_error(.unsupported_generic,
+							'duplicate export name `${export_name}` for `${qname}` and `${existing}`',
+							flat.NodeId(i))
+					}
+				} else {
+					export_symbols[export_name] = qname
+				}
+				if existing := natural_symbols[export_name] {
+					tc.record_error(.unsupported_generic,
+						'export name `${export_name}` for `${qname}` collides with `${existing}`',
+						flat.NodeId(i))
+				}
+			}
+			else {}
+		}
+	}
+}
+
+fn export_qualified_fn_name(module_name string, name string) string {
+	if module_name.len == 0 || module_name == 'main' || module_name == 'builtin' {
+		return name
+	}
+	return '${module_name}.${name}'
+}
+
+fn export_natural_c_symbol(module_name string, name string) string {
+	if module_name == 'builtin' && name == 'free' {
+		return 'v_free'
+	}
+	if module_name.len > 0 && module_name != 'main' && module_name != 'builtin' {
+		return c_name('${module_name}.${name}')
+	}
+	if name == 'free' {
+		return 'v_free'
+	}
+	if name == 'exit' {
+		return 'v_exit'
+	}
+	return c_name(name)
+}
+
+fn is_valid_export_c_name(name string) bool {
+	if name.len == 0 {
+		return false
+	}
+	if name in export_c_reserved_words {
+		return false
+	}
+	if name in export_v3_reserved_c_symbols {
+		return false
+	}
+	first := name[0]
+	if !((first >= `a` && first <= `z`) || (first >= `A` && first <= `Z`) || first == `_`) {
+		return false
+	}
+	for i in 1 .. name.len {
+		c := name[i]
+		if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_` {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 fn (mut tc TypeChecker) insert_implicit_veb_ctx(node flat.Node) {
@@ -1990,10 +2510,7 @@ fn (tc &TypeChecker) stmt_definitely_returns(id flat.NodeId) bool {
 					return false
 				}
 			}
-			// All branches return. An explicit `else` makes the match exhaustive;
-			// otherwise it is still exhaustive when it covers every variant of the
-			// subject enum (V requires match statements to be exhaustive).
-			return has_else || tc.match_covers_all_enum_variants(node)
+			return has_else || tc.match_without_else_exhaustive_enum_returns(node)
 		}
 		else {
 			return false
@@ -2059,6 +2576,67 @@ fn (tc &TypeChecker) match_branch_definitely_returns(branch &flat.Node) bool {
 		}
 	}
 	return false
+}
+
+fn (tc &TypeChecker) match_without_else_exhaustive_enum_returns(node flat.Node) bool {
+	subject_type := unwrap_pointer(tc.resolve_type(tc.a.child(&node, 0)))
+	if subject_type is Enum {
+		enum_name := tc.resolve_enum_name(subject_type.name) or { subject_type.name }
+		if subject_type.is_flag || enum_name in tc.flag_enums {
+			return false
+		}
+		fields := tc.enum_fields[enum_name] or { return false }
+		if fields.len == 0 {
+			return false
+		}
+		mut covered := map[string]bool{}
+		for i in 1 .. node.children_count {
+			branch := tc.a.child_node(&node, i)
+			if branch.kind != .match_branch || branch.value == 'else' {
+				return false
+			}
+			n_conds := branch.value.int()
+			if n_conds <= 0 || n_conds > branch.children_count {
+				return false
+			}
+			for j in 0 .. n_conds {
+				cond := tc.a.child_node(branch, j)
+				field := tc.match_enum_condition_field(cond, enum_name) or { return false }
+				covered[field] = true
+			}
+		}
+		for field in fields {
+			if field !in covered {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+fn (tc &TypeChecker) match_enum_condition_field(cond &flat.Node, enum_name string) ?string {
+	match cond.kind {
+		.enum_val {
+			field := cond.value.all_after_last('.')
+			if tc.enum_value_matches(cond.value, enum_name) {
+				return field
+			}
+		}
+		.selector {
+			if typ := tc.enum_selector_type(cond) {
+				if typ is Enum {
+					cond_enum_name := tc.resolve_enum_name(typ.name) or { typ.name }
+					if cond_enum_name == enum_name && tc.enum_has_field(enum_name, cond.value) {
+						return cond.value
+					}
+				}
+			}
+		}
+		else {}
+	}
+
+	return none
 }
 
 // node_kind_id supports node kind id handling for types.
@@ -2416,7 +2994,7 @@ fn (mut tc TypeChecker) check_decl_assign(id flat.NodeId, node flat.Node) {
 		lhs_id := tc.a.child(&node, i)
 		rhs_id := tc.a.child(&node, i + 1)
 		tc.check_node(rhs_id)
-		mut rhs_type := tc.resolve_type(rhs_id)
+		mut rhs_type := tc.decl_assign_inferred_type(rhs_id)
 		mut expected := rhs_type
 		if node.children_count == 2 && node.typ.len > 0 {
 			expected = tc.parse_type(node.typ)
@@ -2472,6 +3050,58 @@ fn (mut tc TypeChecker) track_method_value_local(lhs_id flat.NodeId, rhs_id flat
 	}
 }
 
+fn (mut tc TypeChecker) decl_assign_inferred_type(rhs_id flat.NodeId) Type {
+	if int(rhs_id) < 0 || int(rhs_id) >= tc.a.nodes.len {
+		return unknown_type('missing declaration initializer')
+	}
+	rhs := tc.a.nodes[int(rhs_id)]
+	if rhs.kind == .cast_expr && rhs.value.len > 0 {
+		typ := tc.parse_type(rhs.value)
+		if typ is Alias {
+			return typ
+		}
+	}
+	if typ := tc.infer_fn_value_decl_type(rhs_id) {
+		return typ
+	}
+	return tc.resolve_type(rhs_id)
+}
+
+fn (mut tc TypeChecker) infer_fn_value_decl_type(rhs_id flat.NodeId) ?Type {
+	if int(rhs_id) < 0 || int(rhs_id) >= tc.a.nodes.len {
+		return none
+	}
+	rhs := tc.a.nodes[int(rhs_id)]
+	if tc.fn_value_shadowed_by_value(rhs) {
+		return none
+	}
+	key := tc.fn_value_key(rhs) or { return none }
+	typ := tc.fn_type_from_key(key) or { return none }
+	tc.remember_resolved_fn_value_chain(rhs_id, key)
+	tc.register_synth_type(rhs_id, typ)
+	return typ
+}
+
+fn (tc &TypeChecker) fn_value_shadowed_by_value(node flat.Node) bool {
+	match node.kind {
+		.ident {
+			return tc.name_bound_as_value(node.value)
+		}
+		.selector {
+			return tc.selector_base_bound_as_value(node)
+		}
+		.cast_expr, .paren, .expr_stmt {
+			if node.children_count == 0 {
+				return false
+			}
+			return tc.fn_value_shadowed_by_value(tc.a.child_node(&node, 0))
+		}
+		else {
+			return false
+		}
+	}
+}
+
 // lvalue_is_local_var reports whether an assignment target is safe to receive a method value:
 // the blank discard `_` (stores nothing) or a plain function-local variable bound under its bare
 // name in the current scope. Non-local storage (a struct field `h.cb`, an array/map element
@@ -2490,6 +3120,43 @@ fn (tc &TypeChecker) lvalue_is_local_var(lhs_id flat.NodeId) bool {
 		return true
 	}
 	return tc.cur_scope.lookup(lhs.value) != none
+}
+
+fn (tc &TypeChecker) selector_base_bound_as_value(node flat.Node) bool {
+	if node.children_count == 0 {
+		return false
+	}
+	base := tc.a.child_node(&node, 0)
+	match base.kind {
+		.ident {
+			return tc.name_bound_as_value(base.value)
+		}
+		.selector {
+			return tc.selector_base_bound_as_value(base)
+		}
+		.cast_expr, .paren, .expr_stmt {
+			if base.children_count == 0 {
+				return false
+			}
+			return tc.fn_value_shadowed_by_value(tc.a.child_node(base, 0))
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn (tc &TypeChecker) name_bound_as_value(name string) bool {
+	if name.len == 0 {
+		return false
+	}
+	if typ := tc.cur_scope.lookup(name) {
+		return typ !is Void
+	}
+	if typ := tc.file_scope.lookup(name) {
+		return typ !is Void
+	}
+	return false
 }
 
 // check_multi_return_decl_assign validates check multi return decl assign state for types.
@@ -2786,6 +3453,11 @@ fn (mut tc TypeChecker) check_call(id flat.NodeId, node flat.Node) {
 			tc.remember_expr_type(id, info.return_type)
 		}
 		tc.check_call_arg_types(id, node, info)
+		return
+	}
+	if tc.call_has_ambiguous_selective_import(node) {
+		tc.record_error(.unknown_fn, 'ambiguous selective import `${tc.call_display_name(node)}`',
+			id)
 		return
 	}
 	if tc.should_diagnose(id) && !tc.is_known_call(node) {
@@ -3162,6 +3834,9 @@ fn (mut tc TypeChecker) resolve_call_info(_id flat.NodeId, node flat.Node) ?Call
 		if qfn in tc.fn_ret_types {
 			return tc.call_info(qfn, false)
 		}
+		if imported_name := tc.resolve_selective_import_symbol(fn_node.value) {
+			return tc.call_info(imported_name, false)
+		}
 		if fn_node.value in tc.fn_ret_types {
 			return tc.call_info(fn_node.value, false)
 		}
@@ -3204,14 +3879,15 @@ fn (mut tc TypeChecker) resolve_generic_call_info(fn_node flat.Node) ?CallInfo {
 	}
 	if is_decode_call_name(call_name) {
 		return CallInfo{
-			name:         call_name
-			params:       tc.fn_param_types[call_name] or { []Type{} }
-			return_type:  Type(ResultType{
+			name:          call_name
+			params:        tc.fn_param_types[call_name] or { []Type{} }
+			return_type:   Type(ResultType{
 				base_type: tc.parse_type(type_arg)
 			})
-			has_receiver: false
-			is_variadic:  tc.fn_variadic[call_name] or { false }
-			params_known: call_name in tc.fn_param_types
+			has_receiver:  false
+			is_variadic:   tc.fn_variadic[call_name] or { false }
+			is_c_variadic: tc.c_variadic_fns[call_name] or { false }
+			params_known:  call_name in tc.fn_param_types
 		}
 	}
 	return tc.call_info(call_name, false)
@@ -3327,6 +4003,7 @@ fn (tc &TypeChecker) call_info(name string, has_receiver bool) CallInfo {
 		}
 		has_receiver:         has_receiver
 		is_variadic:          tc.fn_variadic[name] or { false }
+		is_c_variadic:        tc.c_variadic_fns[name] or { false }
 		params_known:         params_known
 		has_implicit_veb_ctx: tc.fn_implicit_veb_ctx[name] or { false }
 	}
@@ -3425,6 +4102,12 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 			tc.check_node(arg_id)
 		} else {
 			tc.check_node(arg_id)
+		}
+		if info.is_c_variadic && param_idx >= c_variadic_fixed_param_count(info) {
+			if has_dsl_scope {
+				tc.pop_scope()
+			}
+			continue
 		}
 		if param_idx >= info.params.len {
 			if info.is_variadic && info.params.len > 0 {
@@ -3546,6 +4229,13 @@ fn (tc &TypeChecker) min_required_arg_count(info CallInfo) int {
 		break
 	}
 	return n
+}
+
+fn c_variadic_fixed_param_count(info CallInfo) int {
+	if info.is_c_variadic && info.params.len > 0 && info.params[info.params.len - 1] is Array {
+		return info.params.len - 1
+	}
+	return info.params.len
 }
 
 fn (tc &TypeChecker) is_params_struct_type(typ Type) bool {
@@ -3809,6 +4499,16 @@ fn fn_type_from_type(typ Type) ?FnType {
 	}
 	if typ is Alias {
 		return fn_type_from_type(typ.base_type)
+	}
+	return none
+}
+
+fn struct_type_from_type(typ Type) ?Struct {
+	if typ is Struct {
+		return typ
+	}
+	if typ is Alias {
+		return struct_type_from_type(typ.base_type)
 	}
 	return none
 }
@@ -4167,8 +4867,19 @@ fn (tc &TypeChecker) is_known_call(node flat.Node) bool {
 		if qfn in tc.fn_ret_types || fn_node.value in tc.fn_ret_types {
 			return true
 		}
+		if _ := tc.resolve_selective_import_symbol(fn_node.value) {
+			return true
+		}
 	}
 	return false
+}
+
+fn (tc &TypeChecker) call_has_ambiguous_selective_import(node flat.Node) bool {
+	if node.children_count == 0 {
+		return false
+	}
+	fn_node := tc.a.child_node(&node, 0)
+	return fn_node.kind == .ident && tc.selective_import_symbol_is_ambiguous(fn_node.value)
 }
 
 // call_display_name updates call display name state for TypeChecker.
@@ -5063,6 +5774,10 @@ fn (mut tc TypeChecker) check_ident(id flat.NodeId, node flat.Node) {
 		tc.register_synth_type(id, typ)
 		return
 	}
+	if tc.selective_import_symbol_is_ambiguous(node.value) {
+		tc.register_synth_type(id, unknown_type('ambiguous selective import `${node.value}`'))
+		return
+	}
 	if node.value in tc.fn_ret_types || tc.qualify_fn_name(node.value) in tc.fn_ret_types {
 		return
 	}
@@ -5180,13 +5895,19 @@ fn (mut tc TypeChecker) resolve_expr(id flat.NodeId, expected Type) Type {
 			return expected_raw
 		}
 	}
-	if node.kind == .ident && expected is FnType {
-		if tc.fn_value_matches(node.value, expected_raw) {
+	if _ := fn_type_from_type(expected) {
+		if _ := tc.resolve_fn_value_name_for_expected(id, expected_raw) {
 			tc.register_synth_type(id, expected_raw)
 			return expected_raw
 		}
 	}
 	if node.kind == .fn_literal || node.kind == .lambda_expr {
+		if _ := fn_type_from_type(expected) {
+			tc.register_synth_type(id, expected_raw)
+			return expected_raw
+		}
+	}
+	if tc.expr_is_unsafe_nil(id) {
 		if _ := fn_type_from_type(expected) {
 			tc.register_synth_type(id, expected_raw)
 			return expected_raw
@@ -5213,25 +5934,139 @@ fn (mut tc TypeChecker) resolve_expr(id flat.NodeId, expected Type) Type {
 	return actual
 }
 
-// fn_value_matches supports fn value matches handling for TypeChecker.
-fn (tc &TypeChecker) fn_value_matches(name string, expected Type) bool {
-	if expected is FnType {
-		actual := tc.fn_value_type(name) or { return false }
-		if actual is FnType {
-			if actual.params.len != expected.params.len {
-				return false
+// fn_value_match_key returns the single exact function declaration key accepted for a function value.
+fn (tc &TypeChecker) fn_value_match_key(node flat.Node, expected Type) ?string {
+	expected_fn := fn_type_from_type(expected) or { return none }
+	key := tc.fn_value_key(node) or { return none }
+	actual := tc.fn_type_from_key(key) or { return none }
+	if actual is FnType {
+		if actual.params.len != expected_fn.params.len {
+			return none
+		}
+		for i in 0 .. actual.params.len {
+			actual_param := fn_param_type(actual, i)
+			expected_param := fn_param_type(expected_fn, i)
+			if !tc.fn_param_compatible(actual_param, expected_param) {
+				return none
 			}
-			for i in 0 .. actual.params.len {
-				actual_param := fn_param_type(actual, i)
-				expected_param := fn_param_type(expected, i)
-				if !tc.type_compatible(actual_param, expected_param) {
-					return false
-				}
-			}
-			return tc.type_compatible(actual.return_type, expected.return_type)
+		}
+		if tc.fn_return_compatible(actual.return_type, expected_fn.return_type) {
+			return key
 		}
 	}
-	return false
+	return none
+}
+
+// fn_value_key resolves a function value expression to one exact function declaration key.
+fn (tc &TypeChecker) fn_value_key(node flat.Node) ?string {
+	if node.kind == .ident {
+		return tc.ident_fn_value_key(node.value)
+	}
+	if node.kind == .selector {
+		return tc.selector_fn_value_key(node)
+	}
+	if node.kind in [.cast_expr, .paren, .expr_stmt] && node.children_count > 0 {
+		return tc.fn_value_key(tc.a.child_node(&node, 0))
+	}
+	return none
+}
+
+fn (tc &TypeChecker) ident_fn_value_key(name string) ?string {
+	qfn := tc.qualify_fn_name(name)
+	if tc.fn_signature_known(qfn) {
+		return qfn
+	}
+	if imported_name := tc.resolve_selective_import_symbol(name) {
+		return imported_name
+	}
+	if tc.fn_signature_known(name) {
+		return name
+	}
+	return none
+}
+
+fn (tc &TypeChecker) selector_fn_value_key(node flat.Node) ?string {
+	if node.children_count == 0 || !valid_string_data(node.value) {
+		return none
+	}
+	base := tc.a.child_node(&node, 0)
+	if base.kind == .ident {
+		if base.value == 'C' {
+			key := 'C.${node.value}'
+			if tc.fn_signature_known(key) {
+				return key
+			}
+			return none
+		}
+		if resolved_mod := tc.resolve_import_alias(base.value) {
+			key := '${resolved_mod}.${node.value}'
+			if tc.fn_signature_known(key) {
+				return key
+			}
+			return none
+		}
+		qbase := tc.qualify_name(base.value)
+		key := '${qbase}.${node.value}'
+		if tc.fn_signature_known(key) && (qbase in tc.structs
+			|| qbase in tc.enum_names || qbase in tc.sum_types
+			|| qbase in tc.interface_names) {
+			return key
+		}
+		return none
+	}
+	if base.kind == .selector && base.children_count > 0 {
+		inner := tc.a.child_node(base, 0)
+		if inner.kind == .ident {
+			mod_name := tc.resolve_import_alias(inner.value) or { inner.value }
+			key := '${mod_name}.${base.value}.${node.value}'
+			if tc.fn_signature_known(key) {
+				return key
+			}
+		}
+	}
+	return none
+}
+
+fn (tc &TypeChecker) fn_signature_known(key string) bool {
+	return key in tc.fn_ret_types && key in tc.fn_param_types
+}
+
+fn (tc &TypeChecker) expr_is_unsafe_nil(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= tc.a.nodes.len {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	if node.kind != .block {
+		return false
+	}
+	return tc.expr_tail_is_nil(id)
+}
+
+fn (tc &TypeChecker) expr_tail_is_nil(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= tc.a.nodes.len {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	match node.kind {
+		.nil_literal {
+			return true
+		}
+		.expr_stmt, .paren {
+			if node.children_count == 0 {
+				return false
+			}
+			return tc.expr_tail_is_nil(tc.a.child(&node, 0))
+		}
+		.block {
+			if node.children_count == 0 {
+				return false
+			}
+			return tc.expr_tail_is_nil(tc.a.child(&node, node.children_count - 1))
+		}
+		else {
+			return false
+		}
+	}
 }
 
 // fn_value_type supports fn value type handling for TypeChecker.
@@ -5239,6 +6074,9 @@ fn (tc &TypeChecker) fn_value_type(name string) ?Type {
 	qfn := tc.qualify_fn_name(name)
 	if qfn in tc.fn_ret_types {
 		return tc.fn_type_from_key(qfn)
+	}
+	if imported_name := tc.resolve_selective_import_symbol(name) {
+		return tc.fn_type_from_key(imported_name)
 	}
 	if name in tc.fn_ret_types {
 		return tc.fn_type_from_key(name)
@@ -5254,6 +6092,15 @@ fn (tc &TypeChecker) fn_type_from_key(key string) ?Type {
 		params:      params.clone()
 		return_type: ret
 	})
+}
+
+// struct_field_c_abi_fn_ptr_type returns the C ABI function-pointer type for a struct field.
+pub fn (tc &TypeChecker) struct_field_c_abi_fn_ptr_type(struct_name string, field_name string) ?string {
+	key := struct_field_c_abi_key(struct_name, field_name)
+	if typ := tc.struct_field_c_abi_fns[key] {
+		return typ
+	}
+	return none
 }
 
 // enum_value_matches supports enum value matches handling for TypeChecker.
@@ -5445,14 +6292,68 @@ fn (tc &TypeChecker) type_compatible(actual Type, expected Type) bool {
 			for i in 0 .. actual.params.len {
 				actual_param := fn_param_type(actual, i)
 				expected_param := fn_param_type(expected, i)
-				if !tc.type_compatible(actual_param, expected_param) {
+				if !tc.fn_param_compatible(actual_param, expected_param) {
 					return false
 				}
 			}
-			return tc.type_compatible(actual.return_type, expected.return_type)
+			return tc.fn_return_compatible(actual.return_type, expected.return_type)
 		}
 	}
 	return false
+}
+
+fn (tc &TypeChecker) fn_param_compatible(actual Type, expected Type) bool {
+	if actual is Unknown || expected is Unknown {
+		return false
+	}
+	if tc.c_type(actual) == tc.c_type(expected) {
+		return true
+	}
+	return fn_param_can_cast_userdata_param(actual, expected)
+}
+
+fn (tc &TypeChecker) fn_return_compatible(actual Type, expected Type) bool {
+	if actual.name() == expected.name() {
+		return true
+	}
+	return fn_return_canonical_type_name(actual) == fn_return_canonical_type_name(expected)
+}
+
+fn fn_param_can_cast_userdata_param(actual Type, expected Type) bool {
+	return (fn_param_is_voidptr_type(expected) && fn_param_is_nonvoid_pointer_type(actual))
+		|| (fn_param_is_nonvoid_pointer_type(expected) && fn_param_is_voidptr_type(actual))
+}
+
+fn fn_param_is_voidptr_type(typ Type) bool {
+	clean := fn_param_unalias_type(typ)
+	if clean is Pointer {
+		base := fn_param_unalias_type(clean.base_type)
+		return base is Void
+	}
+	return false
+}
+
+fn fn_param_is_nonvoid_pointer_type(typ Type) bool {
+	clean := fn_param_unalias_type(typ)
+	if clean is Pointer {
+		base := fn_param_unalias_type(clean.base_type)
+		return base !is Void
+	}
+	return false
+}
+
+fn fn_param_unalias_type(typ Type) Type {
+	if typ is Alias {
+		return fn_param_unalias_type(typ.base_type)
+	}
+	return typ
+}
+
+fn fn_return_canonical_type_name(typ Type) string {
+	if typ is Alias {
+		return fn_return_canonical_type_name(typ.base_type)
+	}
+	return typ.name()
 }
 
 // is_ierror_type reports whether is ierror type applies in types.
@@ -6062,12 +6963,13 @@ fn (tc &TypeChecker) embedded_method_call_info_inner(struct_name string, method 
 			if method_name in tc.fn_ret_types {
 				info := tc.call_info(method_name, true)
 				return CallInfo{
-					name:         info.name
-					params:       info.params
-					return_type:  info.return_type
-					has_receiver: info.has_receiver
-					is_variadic:  info.is_variadic
-					params_known: if receiver.contains('[') { false } else { info.params_known }
+					name:          info.name
+					params:        info.params
+					return_type:   info.return_type
+					has_receiver:  info.has_receiver
+					is_variadic:   info.is_variadic
+					is_c_variadic: info.is_c_variadic
+					params_known:  if receiver.contains('[') { false } else { info.params_known }
 				}
 			}
 		}
@@ -6746,6 +7648,110 @@ fn (tc &TypeChecker) parse_fn_type(typ string) Type {
 	})
 }
 
+fn (tc &TypeChecker) c_abi_fn_ptr_type_from_text(typ string) ?string {
+	clean := typ.trim_space()
+	if !clean.starts_with('fn(') && !clean.starts_with('fn (') {
+		return none
+	}
+	params_start := clean.index_u8(`(`) + 1
+	mut depth := 1
+	mut params_end := params_start
+	for params_end < clean.len {
+		if clean[params_end] == `(` {
+			depth++
+		} else if clean[params_end] == `)` {
+			depth--
+			if depth == 0 {
+				break
+			}
+		}
+		params_end++
+	}
+	if params_end >= clean.len {
+		return none
+	}
+	params_str := clean[params_start..params_end]
+	ret_str := clean[params_end + 1..].trim_left(' ')
+	mut params := []string{}
+	mut has_c_abi_param := false
+	if params_str.trim_space().len > 0 {
+		for part in split_params(params_str) {
+			ct, is_c_abi := tc.c_abi_fn_param_type(part)
+			params << ct
+			if is_c_abi {
+				has_c_abi_param = true
+			}
+		}
+	}
+	if !has_c_abi_param {
+		return none
+	}
+	ret_type := if ret_str.len > 0 { tc.parse_type(ret_str) } else { Type(Void{}) }
+	ret_ct := tc.fn_ptr_return_c_type(ret_type)
+	params_ct := if params.len == 0 { 'void' } else { params.join(', ') }
+	return 'fn_ptr:${ret_ct}|${params_ct}'
+}
+
+fn (tc &TypeChecker) c_abi_fn_ptr_type_for_type_text(typ string) ?string {
+	mut seen := map[string]bool{}
+	return tc.c_abi_fn_ptr_type_for_type_text_inner(typ.trim_space(), mut seen)
+}
+
+fn (tc &TypeChecker) c_abi_fn_ptr_type_for_type_text_inner(typ string, mut seen map[string]bool) ?string {
+	if typ.len == 0 || seen[typ] {
+		return none
+	}
+	seen[typ] = true
+	if c_abi_fn := tc.c_abi_fn_ptr_type_from_text(typ) {
+		return c_abi_fn
+	}
+	for name in [tc.qualify_name(typ), typ] {
+		if name.len == 0 {
+			continue
+		}
+		if c_abi_fn := tc.type_alias_c_abi_fns[name] {
+			return c_abi_fn
+		}
+		if target := tc.type_aliases[name] {
+			if c_abi_fn := tc.c_abi_fn_ptr_type_for_type_text_inner(target, mut seen) {
+				return c_abi_fn
+			}
+		}
+	}
+	return none
+}
+
+fn (tc &TypeChecker) c_abi_fn_param_type(param string) (string, bool) {
+	clean := param.trim_space()
+	param_type := normalize_fn_type_param_text(clean)
+	if c_abi_fn_param_name(clean).starts_with('const_') && param_type.starts_with('&') {
+		base_type := tc.parse_type(param_type[1..])
+		return 'const ${tc.c_type(base_type)}*', true
+	}
+	return tc.c_type(tc.parse_type(param_type)), false
+}
+
+fn c_abi_fn_param_name(param string) string {
+	mut text := param.trim_space()
+	if text.starts_with('mut ') {
+		text = text[4..].trim_space()
+	}
+	space := top_level_space_index(text)
+	if space <= 0 {
+		return ''
+	}
+	head := text[..space].trim_space()
+	tail := text[space + 1..].trim_space()
+	if fn_type_param_head_is_name(head, tail) {
+		return head
+	}
+	return ''
+}
+
+fn struct_field_c_abi_key(struct_name string, field_name string) string {
+	return '${struct_name}\n${field_name}'
+}
+
 // resolve_type resolves resolve type information for types.
 pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 	if int(id) < 0 {
@@ -6864,6 +7870,9 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 			}
 			if typ := tc.fn_value_type(node.value) {
 				return typ
+			}
+			if tc.selective_import_symbol_is_ambiguous(node.value) {
+				return unknown_type('ambiguous selective import `${node.value}`')
 			}
 			if node.value == 'err' {
 				return tc.parse_type('IError')
@@ -7153,11 +8162,14 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 			}
 			lt := tc.resolve_type(tc.a.child(&node, 0))
 			lt_raw := lt
+			rt := tc.resolve_type(tc.a.child(&node, 1))
+			rt_raw := rt
+			if operator_ret := tc.infix_operator_return_type(node.op, lt, rt) {
+				return operator_ret
+			}
 			if lt is String {
 				return lt_raw
 			}
-			rt := tc.resolve_type(tc.a.child(&node, 1))
-			rt_raw := rt
 			if rt is String {
 				return rt_raw
 			}
@@ -7573,15 +8585,10 @@ fn (tc &TypeChecker) c_type_uncached(t Type) string {
 		return 'Array'
 	}
 	if t is ArrayFixed {
-		// Prefer the evaluated length so a const-expression size (`[segs + 1]f32`)
-		// names the same type as its literal equivalent (`[5]f32`) and never leaks
-		// operators into the identifier; fall back to the sanitized raw expression.
-		len_name := if resolved := tc.fixed_array_len_value(t) {
-			resolved.str()
-		} else {
-			len_text := if t.len_expr.len > 0 { t.len_expr } else { t.len.str() }
-			c_type_name_part(len_text)
-		}
+		// The typedef name preserves the source length text while
+		// the emitted C dimension is folded separately by fixed_array_len_value.
+		len_text := if t.len_expr.len > 0 { t.len_expr } else { t.len.str() }
+		len_name := c_type_name_part(len_text)
 		return 'Array_fixed_${c_type_name_part(tc.c_type(t.elem_type))}_${len_name}'
 	}
 	if t is Channel {
@@ -7893,6 +8900,48 @@ fn resolve_type_name_for_method(t Type) string {
 		return prim_c_type_from(t.props, t.size)
 	}
 	return ''
+}
+
+fn (tc &TypeChecker) infix_operator_return_type(op flat.Op, lhs Type, rhs Type) ?Type {
+	op_name := infix_operator_name(op) or { return none }
+	lhs_name := resolve_type_name_for_method(unwrap_pointer(lhs))
+	if lhs_name.len == 0 {
+		return none
+	}
+	method_name := '${lhs_name}.${op_name}'
+	for candidate in [method_name, c_name(method_name)] {
+		ret := tc.fn_ret_types[candidate] or { continue }
+		params := tc.fn_param_types[candidate] or { continue }
+		if params.len < 2 {
+			continue
+		}
+		if !tc.receiver_compatible(lhs, params[0]) {
+			continue
+		}
+		if !tc.type_compatible(rhs, params[1]) {
+			continue
+		}
+		return ret
+	}
+	return none
+}
+
+fn infix_operator_name(op flat.Op) ?string {
+	match op {
+		.plus { return '+' }
+		.minus { return '-' }
+		.mul { return '*' }
+		.div { return '/' }
+		.mod { return '%' }
+		.pipe { return '|' }
+		.xor { return '^' }
+		.left_shift { return '<<' }
+		.right_shift { return '>>' }
+		.right_shift_unsigned { return '>>>' }
+		else {}
+	}
+
+	return none
 }
 
 // prim_c_type_from supports prim c type from handling for types.

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -640,13 +640,16 @@ fn validate_test_file_harness_inputs(a &flat.FlatAst, tc &types.TypeChecker, tes
 			errors << 'no runnable tests in ${file_node.value}: only module main test files are supported'
 			continue
 		}
+		if test_file_has_executable_top_level_stmt(a, file_node) {
+			errors << 'invalid test file ${file_node.value}: executable top-level statements are not supported in test files'
+			continue
+		}
 		mut runnable_tests := 0
 		mut invalid_items := 0
-		for i in 0 .. file_node.children_count {
-			child := a.child_node(&file_node, i)
-			if child.kind != .fn_decl {
-				continue
-			}
+		mut decl_ids := []flat.NodeId{}
+		collect_test_harness_decl_ids(a, file_node, mut decl_ids)
+		for child_id in decl_ids {
+			child := a.node(child_id)
 			if child.value.starts_with('test_') {
 				if is_supported_test_harness_fn(a, tc, child) {
 					runnable_tests++
@@ -666,6 +669,57 @@ fn validate_test_file_harness_inputs(a &flat.FlatAst, tc &types.TypeChecker, tes
 		}
 	}
 	return errors
+}
+
+fn test_file_has_executable_top_level_stmt(a &flat.FlatAst, node flat.Node) bool {
+	if node.kind != .file && node.kind != .block {
+		return false
+	}
+	for i in 0 .. node.children_count {
+		child_id := a.child(&node, i)
+		if int(child_id) < a.user_code_start {
+			continue
+		}
+		child := a.node(child_id)
+		if child.kind == .block {
+			if test_file_has_executable_top_level_stmt(a, child) {
+				return true
+			}
+		} else if test_file_is_executable_top_level_stmt(child) {
+			return true
+		}
+	}
+	return false
+}
+
+fn test_file_is_executable_top_level_stmt(node flat.Node) bool {
+	return match node.kind {
+		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
+		.for_in_stmt, .if_expr, .match_stmt, .assert_stmt {
+			true
+		}
+		else {
+			false
+		}
+	}
+}
+
+fn collect_test_harness_decl_ids(a &flat.FlatAst, node flat.Node, mut ids []flat.NodeId) {
+	if node.kind != .file && node.kind != .block {
+		return
+	}
+	for i in 0 .. node.children_count {
+		child_id := a.child(&node, i)
+		if int(child_id) < a.user_code_start {
+			continue
+		}
+		child := a.node(child_id)
+		if child.kind == .fn_decl {
+			ids << child_id
+		} else if child.kind == .block {
+			collect_test_harness_decl_ids(a, child, mut ids)
+		}
+	}
 }
 
 fn is_user_test_file_node(a &flat.FlatAst, file_idx int, file_node flat.Node, test_files map[string]bool) bool {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -294,6 +294,7 @@ fn main() {
 	for uf in user_files {
 		p.parse_into(uf)
 	}
+	test_files := test_input_files(user_files, backend)
 
 	// Resolve imports recursively
 	resolve_imports(mut a, mut p, prefs, user_files)
@@ -319,6 +320,13 @@ fn main() {
 		print_type_errors(pre_tc.errors)
 		exit(1)
 	}
+	test_harness_errors := validate_test_file_harness_inputs(a, pre_tc, test_files)
+	if test_harness_errors.len > 0 {
+		for msg in test_harness_errors {
+			eprintln(msg)
+		}
+		exit(1)
+	}
 	b.step('check')
 
 	if backend == 'eval' {
@@ -336,7 +344,11 @@ fn main() {
 
 	// Mark used functions (dead-code elimination). This is done before transform
 	// so the transformer can skip function bodies that the C backend will prune.
-	mut used_fns := markused.mark_used(a, pre_tc)
+	mut used_fns := if test_files.len > 0 {
+		markused.mark_used_for_tests(a, pre_tc, test_files)
+	} else {
+		markused.mark_used(a, pre_tc)
+	}
 	b.step('markused')
 
 	// Transform (match lowering, string/in lowering, etc.). Parallel transform is an
@@ -405,7 +417,7 @@ fn main() {
 	} else {
 		// C backend (default)
 		mut g := cgen.FlatGen.new()
-		c_code := g.gen_with_used_options(a, used_fns, &pre_tc, no_parallel)
+		c_code := g.gen_with_used_test_options(a, used_fns, &pre_tc, no_parallel, test_files)
 		if !write_text_file_raw(output_file, c_code) {
 			eprintln('error writing ${output_file}')
 			exit(1)
@@ -461,8 +473,13 @@ fn main() {
 			if result.exit_code != 0 && result.output.len > 0 {
 				eprintln('  tcc error: ${result.output.trim_space()}')
 			}
-			cc_cmd = 'cc -std=gnu11 ${opt_flag}${warn_flags} -Wno-int-conversion -Wl,-stack_size,0x4000000 -o ${bin_file} ${output_file} ${c_flags} -lm'
-			exec_cmd = 'cd ${cc_dir} && cc -std=gnu11 ${opt_flag}${warn_flags} -Wno-int-conversion -Wl,-stack_size,0x4000000 -o out src.c ${c_flags} -lm'
+			stack_flag := if prefs.normalized_target_os() == 'macos' {
+				' -Wl,-stack_size,0x4000000'
+			} else {
+				''
+			}
+			cc_cmd = 'cc -std=gnu11 ${opt_flag}${warn_flags} -Wno-int-conversion${stack_flag} -o ${bin_file} ${output_file} ${c_flags} -lm'
+			exec_cmd = 'cd ${cc_dir} && cc -std=gnu11 ${opt_flag}${warn_flags} -Wno-int-conversion${stack_flag} -o out src.c ${c_flags} -lm'
 			println('  > ${cc_cmd}')
 			result = run_compile_command(exec_cmd)
 			if result.exit_code != 0 {
@@ -593,6 +610,109 @@ fn diagnostic_root_for_input(input_file string, user_files []string) string {
 		return os.real_path(os.dir(user_files[0]))
 	}
 	return os.real_path(os.getwd())
+}
+
+fn test_input_files(user_files []string, backend string) []string {
+	mut files := []string{}
+	for file in user_files {
+		if pref.is_test_file_for_backend(file, backend) {
+			files << file
+		}
+	}
+	return files
+}
+
+fn validate_test_file_harness_inputs(a &flat.FlatAst, tc &types.TypeChecker, test_files []string) []string {
+	if test_files.len == 0 {
+		return []
+	}
+	mut selected_files := map[string]bool{}
+	for file in test_files {
+		selected_files[file] = true
+	}
+	mut errors := []string{}
+	for file_idx, file_node in a.nodes {
+		if !is_user_test_file_node(a, file_idx, file_node, selected_files) {
+			continue
+		}
+		module_name := test_file_module_name(a, file_node)
+		if module_name.len > 0 && module_name != 'main' {
+			errors << 'no runnable tests in ${file_node.value}: only module main test files are supported'
+			continue
+		}
+		mut runnable_tests := 0
+		mut invalid_items := 0
+		for i in 0 .. file_node.children_count {
+			child := a.child_node(&file_node, i)
+			if child.kind != .fn_decl {
+				continue
+			}
+			if child.value.starts_with('test_') {
+				if is_supported_test_harness_fn(a, tc, child) {
+					runnable_tests++
+				} else {
+					invalid_items++
+					errors << 'invalid test signature: ${child.value} must be zero-arg and return void, ?, or !'
+				}
+			} else if is_test_harness_hook_name(child.value) {
+				if !is_supported_test_harness_hook(a, tc, child) {
+					invalid_items++
+					errors << 'invalid test hook signature: ${child.value} must be zero-arg void'
+				}
+			}
+		}
+		if runnable_tests == 0 && invalid_items == 0 {
+			errors << 'no runnable tests in ${file_node.value}'
+		}
+	}
+	return errors
+}
+
+fn is_user_test_file_node(a &flat.FlatAst, file_idx int, file_node flat.Node, test_files map[string]bool) bool {
+	if file_idx < a.user_code_start || file_node.kind != .file || file_node.children_count == 0 {
+		return false
+	}
+	return test_files[file_node.value]
+}
+
+fn test_file_module_name(a &flat.FlatAst, file_node flat.Node) string {
+	for i in 0 .. file_node.children_count {
+		child := a.child_node(&file_node, i)
+		if child.kind == .module_decl {
+			return child.value
+		}
+	}
+	return ''
+}
+
+fn is_supported_test_harness_fn(a &flat.FlatAst, tc &types.TypeChecker, node &flat.Node) bool {
+	if test_harness_fn_param_count(a, node) != 0 {
+		return false
+	}
+	return test_harness_fn_return_supported(tc.parse_type(node.typ))
+}
+
+fn is_supported_test_harness_hook(a &flat.FlatAst, tc &types.TypeChecker, node &flat.Node) bool {
+	return test_harness_fn_param_count(a, node) == 0 && tc.parse_type(node.typ) is types.Void
+}
+
+fn test_harness_fn_param_count(a &flat.FlatAst, node &flat.Node) int {
+	mut count := 0
+	for i in 0 .. node.children_count {
+		child := a.child_node(node, i)
+		if child.kind == .param {
+			count++
+		}
+	}
+	return count
+}
+
+fn test_harness_fn_return_supported(ret types.Type) bool {
+	return ret is types.Void || ret is types.OptionType || ret is types.ResultType
+}
+
+fn is_test_harness_hook_name(name string) bool {
+	return name in ['testsuite_begin', 'testsuite_end', 'before_each', 'after_each']
 }
 
 fn set_diagnostic_files(mut tc types.TypeChecker, user_files []string) {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -695,7 +695,7 @@ fn test_file_has_executable_top_level_stmt(a &flat.FlatAst, node flat.Node) bool
 fn test_file_is_executable_top_level_stmt(node flat.Node) bool {
 	return match node.kind {
 		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
-		.for_in_stmt, .if_expr, .match_stmt, .assert_stmt {
+		.for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .defer_stmt {
 			true
 		}
 		else {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -740,6 +740,9 @@ fn test_file_module_name(a &flat.FlatAst, file_node flat.Node) string {
 }
 
 fn is_supported_test_harness_fn(a &flat.FlatAst, tc &types.TypeChecker, node &flat.Node) bool {
+	if node.generic_params.len > 0 {
+		return false
+	}
 	if test_harness_fn_param_count(a, node) != 0 {
 		return false
 	}
@@ -747,6 +750,9 @@ fn is_supported_test_harness_fn(a &flat.FlatAst, tc &types.TypeChecker, node &fl
 }
 
 fn is_supported_test_harness_hook(a &flat.FlatAst, tc &types.TypeChecker, node &flat.Node) bool {
+	if node.generic_params.len > 0 {
+		return false
+	}
 	return test_harness_fn_param_count(a, node) == 0 && tc.parse_type(node.typ) is types.Void
 }
 


### PR DESCRIPTION
## Summary

This extends the V3 C backend baseline so it can be used as a stronger oracle for real V3 programs.

The PR rebases the previous V3 oracle work onto the current upstream V3 tree and improves the C path enough to compile and run the targeted baseline examples, including `hello_world`, `fizz_buzz`, `vlib/v/tests/options/option_test.c.v`, `tetris`, `2048`, and some examples coverage from vlang/v#27420.

## What This Enables

- Builds a more reliable V3 `-b c` oracle for future backend comparisons.
- Improves V3 C generation and type/checker coverage for real examples.
- Keeps `vlib/v/tests/options/option_test.c.v`, the autofree-oriented representative test from vlang/v#27116, executable through the V3 C path.
- Allows `tetris` and `2048` to compile, link, and start successfully under short runtime smoke tests.
- Keeps the work focused on the V3 C baseline; no native backend implementation is included here.

## Validation

Validated with focused V3 regression tests, V3 compiler rebuilds, C oracle probes and covers the #27420 example set except for 11 examples that still need follow-up work.

Highlights:

- `examples/hello_world.v` compiles and runs.
- `examples/fizz_buzz.v` compiles and runs.
- `vlib/v/tests/options/option_test.c.v` compiles and runs through the V3 C path.
- `examples/tetris/tetris.v` compiles, links, and starts.
- `examples/2048/2048.v` compiles, links, and starts.
- The accepted vlang/v#27420 example set reports 21 compile+run successes.
- Focused V3 regression tests pass, including the final test updates for current upstream V3 behavior.