### PR TITLE
cgen: lower Boehm GC free-space divisor to 1 for the opt modes (fix #27555)

### DIFF
--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -161,7 +161,13 @@ fn (mut g Gen) gen_boehm_gc_init() {
 	}
 	g.writeln('\tGC_set_pages_executable(0);')
 	if g.pref.gc_mode in [.boehm_full_opt, .boehm_incr_opt] {
-		g.writeln('\tGC_set_free_space_divisor(2);')
+		// Let the heap grow to roughly the live set before collecting, instead of
+		// keeping it small. A smaller divisor means rarer stop-the-world pauses;
+		// with thread-local allocation those pauses (not the allocator lock) are
+		// what serializes worker threads on allocation-heavy multithreaded servers
+		// (issue #27555). Emitted before GC_INIT(), so a user `GC_FREE_SPACE_DIVISOR`
+		// env var still wins and memory-constrained programs can raise it again.
+		g.writeln('\tGC_set_free_space_divisor(1);')
 	}
 	if g.pref.use_coroutines {
 		g.writeln('\tGC_allow_register_threads();')
@@ -190,7 +196,9 @@ fn (mut g Gen) gen_shared_library_boehm_init() {
 	// equivalent restriction applies to Windows DLLs.
 	g.writeln('\tGC_set_pages_executable(0);')
 	if g.pref.gc_mode in [.boehm_full_opt, .boehm_incr_opt] {
-		g.writeln('\tGC_set_free_space_divisor(2);')
+		// See gen_boehm_gc_init: rarer stop-the-world pauses for the opt modes,
+		// overridable via the `GC_FREE_SPACE_DIVISOR` env var (issue #27555).
+		g.writeln('\tGC_set_free_space_divisor(1);')
 	}
 	g.writeln('\tGC_INIT();')
 	g.writeln('\tGC_register_displacement(sizeof(void*));')

--- a/vlib/v/gen/c/cmain.v
+++ b/vlib/v/gen/c/cmain.v
@@ -198,7 +198,13 @@ fn (mut g Gen) gen_shared_library_boehm_init() {
 	if g.pref.gc_mode in [.boehm_full_opt, .boehm_incr_opt] {
 		// See gen_boehm_gc_init: rarer stop-the-world pauses for the opt modes,
 		// overridable via the `GC_FREE_SPACE_DIVISOR` env var (issue #27555).
-		g.writeln('\tGC_set_free_space_divisor(1);')
+		// Only tune when this library is the one bringing up the collector. If the
+		// host process already initialized Boehm, the local GC_INIT() below is a
+		// no-op that will not re-read the env var, so setting the divisor here would
+		// silently override the host's process-wide value (and its env override).
+		g.writeln('\tif (!GC_is_init_called()) {')
+		g.writeln('\t\tGC_set_free_space_divisor(1);')
+		g.writeln('\t}')
 	}
 	g.writeln('\tGC_INIT();')
 	g.writeln('\tGC_register_displacement(sizeof(void*));')

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -579,6 +579,10 @@ fn test_user_defined_windows_dllmain_disables_generated_entrypoint() {
 	ensure_compilation_succeeded(compilation, cmd)
 	assert compilation.output.contains('void _vinit_caller() {')
 	assert compilation.output.contains('GC_set_pages_executable(0);')
+	// The shared-library GC tuning (issue #27555) must stay guarded, so loading
+	// the library into an already-GC-initialized host does not clobber the host's
+	// process-wide free-space divisor (its local GC_INIT() would be a no-op).
+	assert compilation.output.contains('if (!GC_is_init_called()) {')
 	assert compilation.output.contains('GC_INIT();')
 	assert compilation.output.contains('DllMain(')
 	assert compilation.output.contains('_vinit_caller();')

--- a/vlib/v/gen/c/testdata/boehm_default_startup.c.must_have
+++ b/vlib/v/gen/c/testdata/boehm_default_startup.c.must_have
@@ -1,2 +1,2 @@
-GC_set_free_space_divisor(2);
+GC_set_free_space_divisor(1);
 GC_INIT();

--- a/vlib/v/tests/gc_free_space_divisor_test.v
+++ b/vlib/v/tests/gc_free_space_divisor_test.v
@@ -1,0 +1,24 @@
+// Regression test for issue #27555: on the optimized `-gc` modes (the default
+// `boehm_full_opt`), `main()` calls `GC_set_free_space_divisor(1)` before
+// `GC_INIT()`, so the heap is allowed to grow to roughly the live set before
+// collecting. That keeps stop-the-world collections rare, which with thread-local
+// allocation is what otherwise serializes worker threads on allocation-heavy
+// multithreaded HTTP servers. An explicit `GC_FREE_SPACE_DIVISOR` env var is
+// applied by `GC_INIT()` afterwards and wins, so the test skips when one is set.
+import os
+
+fn C.GC_get_free_space_divisor() usize
+
+fn test_free_space_divisor_is_tuned_for_throughput() {
+	$if gcboehm_opt ? {
+		if os.getenv('GC_FREE_SPACE_DIVISOR') != '' {
+			eprintln('skipping: explicit GC_FREE_SPACE_DIVISOR override is set')
+			assert true
+			return
+		}
+		assert C.GC_get_free_space_divisor() == 1
+	} $else {
+		eprintln('skipping: not an optimized boehm GC build')
+		assert true
+	}
+}


### PR DESCRIPTION
## Problem

Allocation-heavy **multithreaded HTTP servers regressed on the default GC** after #27544 enabled thread-local allocation (TLA). As reported in #27555 (`json −37%`, io_uring `fortunes`/`static` collapses), the regression is **not codegen** — the reporter's callgrind shows ~identical instructions/allocations per request.

Root cause: TLA removed the global allocator-lock bottleneck, so concurrent `GC_malloc` now scales across cores. With that gone, the remaining bottleneck is Boehm's **stop-the-world collections** — and each STW pause serializes *every* worker thread.

The optimized GC modes (the default `boehm_full_opt`) kept the heap small via `GC_set_free_space_divisor(2)`, which makes collections frequent. On a single-allocation JSON workload the collector does **~7,277 collections per 2M requests** while pinning the heap at ~182 KiB — so once TLA let the workload run fast, those frequent pauses became the dominant cost.

## Fix

Lower the divisor `2 → 1` for the opt modes, so the heap may grow to roughly the live set before collecting. This cuts stop-the-world pauses ~3× while keeping a bounded (~live-set) RSS increase.

It is still emitted **before `GC_INIT()`**, so a user `GC_FREE_SPACE_DIVISOR` env var overrides it — memory-constrained programs can raise it back to `2`/`3`. V's own self-compilation is unaffected (`building_v` forces `-gc none`).

## Measurements (10-core, single-allocation JSON, `jsonbench` from the issue)

| workload | divisor 2 (before) | divisor 1 (after) |
|---|---:|---:|
| **multithreaded** | 1.79M rps | **2.17M rps (+21%)** |
| **single-threaded** collections / 2M req | 7277 | **2224 (3.3× fewer)** |

The +21% mirrors the reporter's −37% on their 64-core box, where more threads are serialized per pause (so the win is larger there). Single-threaded heap grows ~182 KiB → ~593 KiB on this workload.

## Tests

Adds `vlib/v/tests/gc_free_space_divisor_test.v` — a deterministic check that the opt modes run with divisor `1` (skips under `-gc none` and when `GC_FREE_SPACE_DIVISOR` is set). Existing concurrency + GC test suites pass; `v fmt -verify` and `./v self` clean.