### PR TITLE
builtin: guard linux_bare amd64 syscalls with $if amd64

### DIFF
--- a/vlib/builtin/linux_bare/linux_syscalls.v
+++ b/vlib/builtin/linux_bare/linux_syscalls.v
@@ -330,116 +330,137 @@ $if !i386 {
 		}
 	}
 
+	// The syscall primitives stay defined for every non-i386 arch so the wrappers
+	// above remain resolvable; only the inline asm is amd64-gated. On a non-amd64
+	// target each returns -ENOSYS (38) -- a failed syscall rather than a fake
+	// success -- so e.g. mm_alloc sees the mmap error instead of dereferencing 0.
+	// A real non-x86 freestanding build must supply its own syscall + startup layer.
 	fn sys_call0(scn u64) u64 {
-		mut res := u64(0)
-		asm amd64 {
-			syscall
-			; =a (res)
-			; 0 (scn)
+		mut res := u64(-i64(38)) // -ENOSYS, overwritten by the syscall on amd64
+		$if amd64 {
+			asm amd64 {
+				syscall
+				; =a (res)
+				; 0 (scn)
+			}
 		}
 		return res
 	}
 
 	fn sys_call1(scn u64, arg1 u64) u64 {
-		mut res := u64(0)
-		asm amd64 {
-			syscall
-			; =a (res)
-			; 0 (scn)
-			  D (arg1)
+		mut res := u64(-i64(38)) // -ENOSYS, overwritten by the syscall on amd64
+		$if amd64 {
+			asm amd64 {
+				syscall
+				; =a (res)
+				; 0 (scn)
+				  D (arg1)
+			}
 		}
 		return res
 	}
 
 	fn sys_call2(scn u64, arg1 u64, arg2 u64) u64 {
-		mut res := u64(0)
-		asm amd64 {
-			syscall
-			; =a (res)
-			; 0 (scn)
-			  D (arg1)
-			  S (arg2)
+		mut res := u64(-i64(38)) // -ENOSYS, overwritten by the syscall on amd64
+		$if amd64 {
+			asm amd64 {
+				syscall
+				; =a (res)
+				; 0 (scn)
+				  D (arg1)
+				  S (arg2)
+			}
 		}
 		return res
 	}
 
 	fn sys_call3(scn u64, arg1 u64, arg2 u64, arg3 u64) u64 {
-		mut res := u64(0)
-		asm amd64 {
-			syscall
-			; =a (res)
-			; 0 (scn)
-			  D (arg1)
-			  S (arg2)
-			  d (arg3)
+		mut res := u64(-i64(38)) // -ENOSYS, overwritten by the syscall on amd64
+		$if amd64 {
+			asm amd64 {
+				syscall
+				; =a (res)
+				; 0 (scn)
+				  D (arg1)
+				  S (arg2)
+				  d (arg3)
+			}
 		}
 		return res
 	}
 
 	fn sys_call4(scn u64, arg1 u64, arg2 u64, arg3 u64, arg4 u64) u64 {
-		mut res := u64(0)
-		asm amd64 {
-			mov r10, arg4
-			syscall
-			; =a (res)
-			; 0 (scn)
-			  D (arg1)
-			  S (arg2)
-			  d (arg3)
-			  g (arg4)
-			; r10
+		mut res := u64(-i64(38)) // -ENOSYS, overwritten by the syscall on amd64
+		$if amd64 {
+			asm amd64 {
+				mov r10, arg4
+				syscall
+				; =a (res)
+				; 0 (scn)
+				  D (arg1)
+				  S (arg2)
+				  d (arg3)
+				  g (arg4)
+				; r10
+			}
 		}
 		return res
 	}
 
 	fn sys_call5(scn u64, arg1 u64, arg2 u64, arg3 u64, arg4 u64, arg5 u64) u64 {
-		mut res := u64(0)
-		asm amd64 {
-			mov r10, arg4
-			mov r8, arg5
-			syscall
-			; =a (res)
-			; 0 (scn)
-			  D (arg1)
-			  S (arg2)
-			  d (arg3)
-			  g (arg4)
-			  g (arg5)
-			; r10
-			  r8
+		mut res := u64(-i64(38)) // -ENOSYS, overwritten by the syscall on amd64
+		$if amd64 {
+			asm amd64 {
+				mov r10, arg4
+				mov r8, arg5
+				syscall
+				; =a (res)
+				; 0 (scn)
+				  D (arg1)
+				  S (arg2)
+				  d (arg3)
+				  g (arg4)
+				  g (arg5)
+				; r10
+				  r8
+			}
 		}
 		return res
 	}
 
 	fn sys_call6(scn u64, arg1 u64, arg2 u64, arg3 u64, arg4 u64, arg5 i64, arg6 u64) u64 {
-		mut res := u64(0)
-		asm amd64 {
-			mov r10, arg4
-			mov r8, arg5
-			mov r9, arg6
-			syscall
-			; =a (res)
-			; 0 (scn)
-			  D (arg1)
-			  S (arg2)
-			  d (arg3)
-			  g (arg4)
-			  g (arg5)
-			  g (arg6)
-			; r10
-			  r8
-			  r9
+		mut res := u64(-i64(38)) // -ENOSYS, overwritten by the syscall on amd64
+		$if amd64 {
+			asm amd64 {
+				mov r10, arg4
+				mov r8, arg5
+				mov r9, arg6
+				syscall
+				; =a (res)
+				; 0 (scn)
+				  D (arg1)
+				  S (arg2)
+				  d (arg3)
+				  g (arg4)
+				  g (arg5)
+				  g (arg6)
+				; r10
+				  r8
+				  r9
+			}
 		}
 		return res
 	}
 
-	asm amd64 {
-		.globl _start
-		_start:
-		call main
-		mov rax, 60
-		xor rdi, rdi
-		syscall
-		ret
+	$if amd64 {
+		asm amd64 {
+			.globl _start
+			_start:
+			call main
+			mov rax, 60
+			xor rdi, rdi
+			syscall
+			ret
+		}
 	}
 }


### PR DESCRIPTION
## What

The amd64 Linux syscall layer in `linux_bare` was gated on `$if !i386`. Gate the
inline-asm primitives on `$if amd64` instead, keeping the syscall wrappers
defined on every non-i386 arch.

## Why

When transpiling with `-freestanding` and cross-compiling the generated C for a
**non-x86** target (e.g. bare-metal **Cortex-M7** via `arm-none-eabi-gcc`), the
build failed:

```
error: impossible constraint in 'asm'   // in builtin__sys_call1..6
```

A `$if <arch>` block is emitted by the C backend as a `#if defined(__V_<arch>)`
guard resolved by the **target** compiler, so `$if !i386` became
`#if !defined(__V_i386)` — true on arm / arm64 / riscv / … Those targets then
tried to compile `asm amd64 { syscall ... }` and the assembler rejected the x86
register constraints.

## Fix

- Keep the wrappers (`sys_read/write/open/close/mmap/mremap/munmap`,
  `split_int_errno`) defined for every non-i386 arch, so `linux_bare`'s own
  callers (`libc_impl.v`, `memory_managment.v`) still resolve.
- Gate only the inline-asm `sys_call0..6` + the `_start` block behind
  `$if amd64`, with non-amd64 stubs.

i386 keeps its own `linux_syscalls.i386.v`; amd64 output is unchanged.

## Reproduce (bare-metal Cortex-M7)

```v
// fw.v
module main
fn main() {
	mut s := 0
	for i in 0 .. 10 { s += i }
	C.sink(s)
}
fn C.sink(int)
```
```sh
v -freestanding -gc none -o fw.c fw.v
arm-none-eabi-gcc -c fw.c -o fw.o \
  -mcpu=cortex-m7 -mfpu=fpv5-d16 -mfloat-abi=hard -mthumb -ffreestanding -Os
# before: error: impossible constraint in 'asm'
# after:  compiles, 0 errors
```

## Verification

- **amd64 unaffected** — `v -gc none run` of a normal program is unchanged
  (`$if amd64` is true on amd64).
- **default host → Cortex-M7** — the freestanding C cross-compiles with 0 errors
  and no source patching; the amd64 asm sits under `#if defined(__V_amd64)`.
- **explicit non-x86 (`-arch arm64 -freestanding`)** — now compiles in V; the
  non-i386 wrappers + non-amd64 stubs keep `libc_impl.v` / `memory_managment.v`
  resolving (previously this path broke on the unguarded callers).

## Note (not addressed here)

`-freestanding` means *no libc*, but `pref.os` stays `linux`, so non-x86
freestanding builds still pull in the Linux syscall layer (`linux_bare`); there
is no `-os none` / generic bare-metal target. A generic no-OS builtin would be a
larger, separate change. This PR is the minimal fix that unblocks non-x86
`-freestanding` today.
