### PR TITLE
checker: reject multi-return elements that disagree on option-ness (fix #27562)

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -577,6 +577,16 @@ fn (mut c Checker) check_basic(got ast.Type, expected ast.Type) bool {
 			return false
 		}
 		for i in 0 .. exp_types.len {
+			// Each multi-return element lowers to a distinct C struct field, so an
+			// optional/result element (`?T`/`!T`, a `_option_T`/`_result_T` struct) is
+			// not layout-compatible with a plain `T`. Comparing via `check_types` below
+			// ignores these flags (it matches by type index), which would let
+			// `(string, ?string)` masquerade as `(string, string)` and emit mismatched
+			// `multi_return_*` structs. Require the option/result-ness to match exactly.
+			if got_types[i].has_flag(.option) != exp_types[i].has_flag(.option)
+				|| got_types[i].has_flag(.result) != exp_types[i].has_flag(.result) {
+				return false
+			}
 			if !c.check_types(got_types[i], exp_types[i]) {
 				return false
 			}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -579,10 +579,12 @@ fn (mut c Checker) check_basic(got ast.Type, expected ast.Type) bool {
 		for i in 0 .. exp_types.len {
 			// Each multi-return element lowers to a distinct C struct field, so an
 			// optional/result element (`?T`/`!T`, a `_option_T`/`_result_T` struct) is
-			// not layout-compatible with a plain `T`. Comparing via `check_types` below
-			// ignores these flags (it matches by type index), which would let
-			// `(string, ?string)` masquerade as `(string, string)` and emit mismatched
-			// `multi_return_*` structs. Require the option/result-ness to match exactly.
+			// not layout-compatible with a plain `T`. `check_types` below matches by type
+			// index and ignores these flags, which would let `(string, ?string)`
+			// masquerade as `(string, string)` and emit mismatched `multi_return_*`
+			// structs. Keep this a strict layout check (both directions): the safe
+			// `T` -> `?T` element promotion is opted into only where codegen wraps it (the
+			// `return` and `or {}` paths, via `can_use_expected_multi_return_*`).
 			if got_types[i].has_flag(.option) != exp_types[i].has_flag(.option)
 				|| got_types[i].has_flag(.result) != exp_types[i].has_flag(.result) {
 				return false

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -2874,8 +2874,13 @@ fn (mut c Checker) check_or_last_stmt(mut stmt ast.Stmt, ret_type ast.Type, defa
 				}
 
 				c.expected_or_type = ast.void_type
-				type_fits := c.check_types(last_stmt_typ, ret_type)
-					&& last_stmt_typ.nr_muls() == ret_type.nr_muls()
+				// A multi-return `or {}` default may supply a plain `T` element where the
+				// expected slot is `?T`; the or-block codegen wraps it (see `concat_expr`'s
+				// `inside_or_block` path), so allow that promotion explicitly here. The
+				// strict `check_types` multi-return check above otherwise rejects it.
+				type_fits := (c.check_types(last_stmt_typ, ret_type)
+					&& last_stmt_typ.nr_muls() == ret_type.nr_muls())
+					|| c.can_use_expected_multi_return_expr_type(last_stmt_typ, ret_type, stmt.expr)
 				is_noreturn := is_noreturn_callexpr(stmt.expr)
 				if type_fits || is_noreturn {
 					return

--- a/vlib/v/checker/tests/multi_return_option_element_mismatch_err.out
+++ b/vlib/v/checker/tests/multi_return_option_element_mismatch_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/multi_return_option_element_mismatch_err.vv:5:47: error: wrong return type `(string, ?string)` in the `or {}` block, expected `(string, string)`
+    3 | // mismatched `multi_return_*` C structs. See issue #27562.
+    4 | fn parse(s string) ?(string, string) {
+    5 |     subtype, parameter := s.split_once(';') or { s, ?string(none) }
+      |                                                  ^
+    6 |     return subtype, parameter
+    7 | }
+vlib/v/checker/tests/multi_return_option_element_mismatch_err.vv:10:25: error: mismatched types `(string, string)` and `(string, ?string)`
+    8 |
+    9 | fn extract(s string) (string, ?string) {
+   10 |     rawurl, description := if s.contains(' ') {
+      |                            ~~
+   11 |         s[..1], s[1..]
+   12 |     } else {

--- a/vlib/v/checker/tests/multi_return_option_element_mismatch_err.out
+++ b/vlib/v/checker/tests/multi_return_option_element_mismatch_err.out
@@ -12,3 +12,10 @@ vlib/v/checker/tests/multi_return_option_element_mismatch_err.vv:10:25: error: m
       |                            ~~
    11 |         s[..1], s[1..]
    12 |     } else {
+vlib/v/checker/tests/multi_return_option_element_mismatch_err.vv:20:25: error: mismatched types `(string, ?string)` and `(string, string)`
+   18 | // the same mismatch must be caught regardless of which branch is the optional one
+   19 | fn extract_rev(s string) (string, ?string) {
+   20 |     rawurl, description := if s.contains(' ') {
+      |                            ~~
+   21 |         s, ?string(none)
+   22 |     } else {

--- a/vlib/v/checker/tests/multi_return_option_element_mismatch_err.vv
+++ b/vlib/v/checker/tests/multi_return_option_element_mismatch_err.vv
@@ -14,3 +14,13 @@ fn extract(s string) (string, ?string) {
 	}
 	return rawurl, description
 }
+
+// the same mismatch must be caught regardless of which branch is the optional one
+fn extract_rev(s string) (string, ?string) {
+	rawurl, description := if s.contains(' ') {
+		s, ?string(none)
+	} else {
+		s[..1], s[1..]
+	}
+	return rawurl, description
+}

--- a/vlib/v/checker/tests/multi_return_option_element_mismatch_err.vv
+++ b/vlib/v/checker/tests/multi_return_option_element_mismatch_err.vv
@@ -1,0 +1,16 @@
+// An optional multi-return element (`?T`) lowers to a different C struct than a
+// plain `T`, so mixing them must be rejected at the V level instead of emitting
+// mismatched `multi_return_*` C structs. See issue #27562.
+fn parse(s string) ?(string, string) {
+	subtype, parameter := s.split_once(';') or { s, ?string(none) }
+	return subtype, parameter
+}
+
+fn extract(s string) (string, ?string) {
+	rawurl, description := if s.contains(' ') {
+		s[..1], s[1..]
+	} else {
+		s, ?string(none)
+	}
+	return rawurl, description
+}

--- a/vlib/v/checker/tests/multi_return_option_result_return_expr_err.out
+++ b/vlib/v/checker/tests/multi_return_option_result_return_expr_err.out
@@ -5,6 +5,13 @@ vlib/v/checker/tests/multi_return_option_result_return_expr_err.vv:10:9: error: 
       |            ~~
    11 | }
    12 |
+vlib/v/checker/tests/multi_return_option_result_return_expr_err.vv:15:10: error: return type mismatch, it should be `(int, int)`, but it is instead `(!int, int literal)`
+   13 | fn return_match_with_result_value(x bool) (int, int) {
+   14 |     return match x {
+   15 |         true { result_int(), 1 }
+      |                ~~~~~~~~~~
+   16 |         else { 2, 2 }
+   17 |     }
 vlib/v/checker/tests/multi_return_option_result_return_expr_err.vv:14:9: error: cannot use `!int` as type `int` in return argument
    12 |
    13 | fn return_match_with_result_value(x bool) (int, int) {


### PR DESCRIPTION
## What

Fixes #27562.

When a multi-return value's element is supplied as an option (`?string(none)`) in one place but the destination slot is a plain `string`, V silently generated two mismatched multi-return C structs — `multi_return_string_string` (element typed `string`) and `multi_return_string_option_string` (element typed `_option_string`) — and only the C compiler caught the resulting type mismatch.

## Why

`Checker.check_basic` compares two multi-return types element-by-element with a recursive `check_types` call. That call matches by type **index** and ignores the `.option`/`.result` flags, so `(string, ?string)` was treated as compatible with `(string, string)`. But each multi-return element lowers to a distinct C struct field, and `?T` is a `_option_T` struct that is **not** layout-compatible with a plain `T` — hence the bad C.

## Fix

In the multi-return branch of `check_basic`, require each element's option/result-ness to match exactly before falling through to the index-based comparison.

This turns both reported reproducers into clear V-level errors:

- **Pattern A** — `or`-block default mixing `string` and `?string`:
  ```
  error: wrong return type `(string, ?string)` in the `or {}` block, expected `(string, string)`
  ```
- **Pattern B** — `if`/`match` branches disagreeing on an element's optional-ness:
  ```
  error: mismatched types `(string, string)` and `(string, ?string)`
  ```

Legitimate element coercion in `return` (e.g. returning `(string, string)` where the function declares `(string, ?string)`) is unaffected — it goes through the dedicated `can_use_expected_multi_return_*` path that builds the correct struct, not this comparison.

## Tests

- New: `vlib/v/checker/tests/multi_return_option_element_mismatch_err.{vv,out}` covering both patterns.
- Updated: `multi_return_option_result_return_expr_err.out` — the stricter check now also flags the `!int`-in-`match` branch precisely at the offending element (in addition to the existing return-argument error).
- Full `vlib/v/compiler_errors_test.v` passes (1580 ok), and the multi-return / option / or-block runtime suites in `vlib/v/tests` pass. The compiler self-builds through the modified checker.