### PR TITLE
cgen: route integer interpolation through str_intp

### DIFF
--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -339,7 +339,7 @@ fn test_simple_string_interpolation_does_not_emit_str_intp_runtime() {
 	os.chdir(vroot) or {}
 	test_source := os.join_path(os.vtmp_dir(), 'coutput_simple_interpolation_no_str_intp.vv')
 	os.write_file(test_source,
-		"module main\n\nimport time\n\nfn main() {\n\tt := time.now()\n\tprintln('elapsed \${time.since(t)}')\n}\n")!
+		"module main\n\nfn label() string {\n\treturn 'V'\n}\n\nfn main() {\n\tprintln('elapsed \${label()}')\n}\n")!
 	defer {
 		os.rm(test_source) or {}
 	}
@@ -348,6 +348,64 @@ fn test_simple_string_interpolation_does_not_emit_str_intp_runtime() {
 	ensure_compilation_succeeded(compilation, cmd)
 	assert !compilation.output.contains('builtin__str_intp')
 	assert !compilation.output.contains('StrIntpData')
+}
+
+fn test_skip_unused_os_integer_interpolation_keeps_str_intp_runtime() {
+	os.chdir(vroot) or {}
+	test_root := os.join_path(os.vtmp_dir(), 'coutput_os_int_interpolation_${os.getpid()}')
+	os_module_dir := os.join_path(test_root, 'os')
+	os_function_source := os.join_path(os_module_dir, 'os.v')
+	test_source := os.join_path(test_root, 'main.v')
+	pexe := os.join_path(test_root, 'coutput_os_int_interpolation.exe')
+	os.mkdir_all(os_module_dir)!
+	os.write_file(os_function_source,
+		"module os\n\npub fn coutput_skip_unused_int_interpolation(n int) string {\n\treturn '\${n}'\n}\n")!
+	os.write_file(test_source,
+		'module main\n\nimport os\n\nfn main() {\n\tprintln(os.coutput_skip_unused_int_interpolation(7))\n}\n')!
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	lookup_path := '${test_root}|@vlib|@vmodules'
+	cmd := '${os.quoted_path(vexe)} -skip-unused -path ${os.quoted_path(lookup_path)} -o ${os.quoted_path(pexe)} ${os.quoted_path(test_source)}'
+	compilation := os.execute(cmd)
+	ensure_compilation_succeeded(compilation, cmd)
+	res := os.execute(os.quoted_path(pexe))
+	assert res.exit_code == 0
+	assert res.output.trim_space() == '7'
+}
+
+fn test_skip_unused_aggregate_smartcast_integer_interpolation_uses_simple_path() {
+	os.chdir(vroot) or {}
+	test_source := os.join_path(os.vtmp_dir(), 'coutput_aggregate_smartcast_interpolation.vv')
+	pexe := os.join_path(os.vtmp_dir(), 'coutput_aggregate_smartcast_interpolation.exe')
+	os.write_file(test_source,
+		"module main\n\ntype Value = int | string\n\nfn stringify(x Value) string {\n\treturn match x {\n\t\tint, string { '\${x}' }\n\t}\n}\n\nfn main() {\n\tassert stringify(Value(7)) == '7'\n\tassert stringify(Value('v')) == 'v'\n}\n")!
+	defer {
+		os.rm(test_source) or {}
+		os.rm(pexe) or {}
+	}
+	cmd := '${os.quoted_path(vexe)} -skip-unused -o ${os.quoted_path(pexe)} ${os.quoted_path(test_source)}'
+	compilation := os.execute(cmd)
+	ensure_compilation_succeeded(compilation, cmd)
+	res := os.execute(os.quoted_path(pexe))
+	assert res.exit_code == 0
+}
+
+fn test_skip_unused_runtime_integer_interpolation_marks_auto_str_operand() {
+	os.chdir(vroot) or {}
+	test_source := os.join_path(os.vtmp_dir(), 'coutput_runtime_interpolation_auto_str.vv')
+	pexe := os.join_path(os.vtmp_dir(), 'coutput_runtime_interpolation_auto_str.exe')
+	os.write_file(test_source,
+		"module main\n\nstruct Thing {\n\tn int\n}\n\nfn mixed(n int, thing Thing) string {\n\treturn '\${n} \${thing}'\n}\n\nfn main() {\n\tassert mixed(7, Thing{n: 3}).contains('Thing')\n}\n")!
+	defer {
+		os.rm(test_source) or {}
+		os.rm(pexe) or {}
+	}
+	cmd := '${os.quoted_path(vexe)} -skip-unused -o ${os.quoted_path(pexe)} ${os.quoted_path(test_source)}'
+	compilation := os.execute(cmd)
+	ensure_compilation_succeeded(compilation, cmd)
+	res := os.execute(os.quoted_path(pexe))
+	assert res.exit_code == 0
 }
 
 fn test_auto_str_float_array_still_emits_str_intp_runtime() {

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -838,6 +838,21 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 
 const simple_string_interpolation_default_precision = 987698
 
+fn (mut g Gen) simple_string_interpolation_needs_str_intp(typ ast.Type, fmt u8) bool {
+	if g.is_builtin_mod {
+		return false
+	}
+	if fmt == `s` {
+		return false
+	}
+	if typ.has_option_or_result() {
+		return false
+	}
+	resolved_typ := g.unwrap_generic(typ).clear_flags()
+	return resolved_typ in [ast.i8_type, ast.i16_type, ast.i32_type, ast.int_type, ast.i64_type,
+		ast.isize_type, ast.u8_type, ast.u16_type, ast.u32_type, ast.u64_type, ast.usize_type]
+}
+
 fn (mut g Gen) gen_simple_string_inter_literal(node ast.StringInterLiteral, fmts []u8) bool {
 	if g.is_autofree || g.pref.gc_mode == .boehm_leak {
 		// The fast `string_plus_many` lowering can leave nested temporary
@@ -850,6 +865,9 @@ fn (mut g Gen) gen_simple_string_inter_literal(node ast.StringInterLiteral, fmts
 	}
 	for i in 0 .. node.exprs.len {
 		if i >= node.need_fmts.len || node.need_fmts[i] || i >= fmts.len || fmts[i] == `_` {
+			return false
+		}
+		if g.simple_string_interpolation_needs_str_intp(node.expr_types[i], fmts[i]) {
 			return false
 		}
 		normalized_expr_type := g.table.fully_unaliased_type(g.unwrap_generic(node.expr_types[i]))

--- a/vlib/v/gen/c/testdata/string_interpolation_simple_optimization.c.must_have
+++ b/vlib/v/gen/c/testdata/string_interpolation_simple_optimization.c.must_have
@@ -1,3 +1,4 @@
-return builtin__int_str(n);
-builtin__string_plus_many(3, _MOV((string[3]){prefix, builtin__int_str(n), suffix}))
-builtin__string_plus_many(4, _MOV((string[4]){_S("n="), builtin__int_str(n), _S(":"), suffix}))
+return builtin__str_intp(2, _MOV((StrIntpData[]){{_SLIT0, 0xfe07, {.d_i32 = n}, 0, 0, 0}, {_SLIT0, 0, { .d_c = 0 }, 0, 0, 0}}));
+return builtin__str_intp(4, _MOV((StrIntpData[]){{_SLIT0, 0xfe10, {.d_s = prefix}, 0, 0, 0}, {_SLIT0, 0xfe07, {.d_i32 = n}, 0, 0, 0}, {_SLIT0, 0xfe10, {.d_s = suffix}, 0, 0, 0}, {_SLIT0, 0, { .d_c = 0 }, 0, 0, 0}}));
+return builtin__str_intp(3, _MOV((StrIntpData[]){{_S("n="), 0xfe07, {.d_i32 = n}, 0, 0, 0}, {_S(":"), 0xfe10, {.d_s = suffix}, 0, 0, 0}, {_SLIT0, 0, { .d_c = 0 }, 0, 0, 0}}));
+return builtin__int_literal_str(2147483648U);

--- a/vlib/v/gen/c/testdata/string_interpolation_simple_optimization.vv
+++ b/vlib/v/gen/c/testdata/string_interpolation_simple_optimization.vv
@@ -10,8 +10,13 @@ fn interp_static(n int, suffix string) string {
 	return 'n=${n}:${suffix}'
 }
 
+fn interp_large_literal() string {
+	return '${2147483648}'
+}
+
 fn main() {
 	assert interp_number(42) == '42'
 	assert interp_chain('a', 7, 'b') == 'a7b'
 	assert interp_static(9, 'z') == 'n=9:z'
+	assert interp_large_literal() == '2147483648'
 }

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -6,6 +6,7 @@ module markused
 // Unused functions can be safely skipped by the backends to save CPU time and space.
 import v.ast
 import v.pref
+import v.util
 
 const simple_string_interpolation_default_precision = 987698
 
@@ -48,6 +49,7 @@ mut:
 	all_structs   map[string]ast.StructDecl
 
 	cur_fn                      string
+	cur_mod                     string
 	cur_fn_concrete_types       []ast.Type
 	level                       int
 	is_builtin_mod              bool
@@ -1387,12 +1389,7 @@ fn (mut w Walker) expr(node_ ast.Expr) {
 			w.mark_by_type(node.typ)
 		}
 		ast.StringInterLiteral {
-			if w.string_inter_literal_needs_runtime(node) {
-				w.uses_interp = true
-				w.uses_interp_isnil = w.uses_interp_isnil || w.string_inter_literal_uses_isnil(node)
-			} else {
-				w.mark_simple_string_inter_literal(node)
-			}
+			w.mark_string_inter_literal(node)
 			w.exprs(node.exprs)
 			for expr in node.fwidth_exprs {
 				if expr !is ast.EmptyExpr {
@@ -1585,9 +1582,11 @@ fn (mut w Walker) fn_decl_with_concrete_types(mut node ast.FnDecl, concrete_type
 	w.is_direct_array_access = node.is_direct_arr || w.pref.no_bounds_checking
 	defer { w.is_direct_array_access = last_is_direct_array_access }
 	last_cur_fn := w.cur_fn
+	last_cur_mod := w.cur_mod
 	last_cur_fn_concrete_types := w.cur_fn_concrete_types.clone()
 	defer {
 		w.cur_fn = last_cur_fn
+		w.cur_mod = last_cur_mod
 		w.cur_fn_concrete_types = last_cur_fn_concrete_types
 	}
 	if w.trace_enabled {
@@ -1657,7 +1656,9 @@ fn (mut w Walker) fn_decl_with_concrete_types(mut node ast.FnDecl, concrete_type
 		}
 	}
 	prev_cur_fn := w.cur_fn
+	prev_cur_mod := w.cur_mod
 	w.cur_fn = fkey
+	w.cur_mod = node.mod
 	w.cur_fn_concrete_types = resolved_concrete_types
 	if node.mod == 'x.json2' && node.name == 'get_decoded_sumtype_workaround'
 		&& w.has_sumtype_generic_context(resolved_concrete_types) {
@@ -1772,6 +1773,7 @@ fn (mut w Walker) fn_decl_with_concrete_types(mut node ast.FnDecl, concrete_type
 	w.stmts(node.stmts)
 	w.defer_stmts(node.defer_stmts)
 	w.cur_fn = prev_cur_fn
+	w.cur_mod = prev_cur_mod
 }
 
 fn (mut w Walker) fn_decl_with_fkey(mut node ast.FnDecl, walk_fkey string) {
@@ -2715,6 +2717,16 @@ fn (w &Walker) infer_expr_type(expr ast.Expr) ast.Type {
 	}
 }
 
+fn (mut w Walker) mark_string_inter_literal(node ast.StringInterLiteral) {
+	if w.string_inter_literal_needs_runtime(node) {
+		w.uses_interp = true
+		w.uses_interp_isnil = w.uses_interp_isnil || w.string_inter_literal_uses_isnil(node)
+		w.mark_runtime_string_inter_literal_str_dependencies(node)
+	} else {
+		w.mark_simple_string_inter_literal(node)
+	}
+}
+
 fn (mut w Walker) string_inter_literal_needs_runtime(node ast.StringInterLiteral) bool {
 	if w.pref.autofree || w.pref.gc_mode == .boehm_leak {
 		return true
@@ -2734,6 +2746,9 @@ fn (mut w Walker) string_inter_literal_needs_runtime(node ast.StringInterLiteral
 		}
 		typ := w.resolve_current_generic_type(node.expr_types[i])
 		if typ == 0 || typ == ast.void_type || typ.has_flag(.generic) {
+			return true
+		}
+		if w.simple_string_interpolation_type_needs_runtime(typ, node.fmts[i]) {
 			return true
 		}
 		normalized_expr_type := w.table.fully_unaliased_type(typ)
@@ -2776,6 +2791,21 @@ fn (mut w Walker) string_inter_literal_needs_runtime(node ast.StringInterLiteral
 	return false
 }
 
+fn (w &Walker) simple_string_interpolation_type_needs_runtime(typ ast.Type, fmt u8) bool {
+	if util.module_is_builtin(w.cur_mod) {
+		return false
+	}
+	if fmt == `s` {
+		return false
+	}
+	if typ.has_option_or_result() {
+		return false
+	}
+	resolved_typ := typ.clear_flags()
+	return resolved_typ in [ast.i8_type, ast.i16_type, ast.i32_type, ast.int_type, ast.i64_type,
+		ast.isize_type, ast.u8_type, ast.u16_type, ast.u32_type, ast.u64_type, ast.usize_type]
+}
+
 fn (mut w Walker) string_inter_literal_uses_isnil(node ast.StringInterLiteral) bool {
 	for typ in node.expr_types {
 		resolved_typ := w.table.fully_unaliased_type(w.resolve_current_generic_type(typ))
@@ -2794,6 +2824,18 @@ fn (mut w Walker) mark_simple_string_inter_literal(node ast.StringInterLiteral) 
 	for i in 0 .. node.exprs.len {
 		if i >= node.expr_types.len {
 			break
+		}
+		typ := w.resolve_current_generic_type(node.expr_types[i])
+		if typ != 0 && typ != ast.void_type && typ != ast.string_type {
+			w.uses_str[typ] = true
+		}
+	}
+}
+
+fn (mut w Walker) mark_runtime_string_inter_literal_str_dependencies(node ast.StringInterLiteral) {
+	for i in 0 .. node.exprs.len {
+		if i >= node.expr_types.len || i >= node.fmts.len || node.fmts[i] !in [`s`, `S`] {
+			continue
 		}
 		typ := w.resolve_current_generic_type(node.expr_types[i])
 		if typ != 0 && typ != ast.void_type && typ != ast.string_type {
@@ -3549,6 +3591,7 @@ fn (mut w Walker) mark_generic_body_dependencies_in_expr(expr_ ast.Expr) {
 			w.mark_generic_body_dependencies_in_expr(expr.right)
 		}
 		ast.StringInterLiteral {
+			w.mark_string_inter_literal(expr)
 			for sub_expr in expr.exprs {
 				w.mark_generic_body_dependencies_in_expr(sub_expr)
 			}
@@ -3628,7 +3671,7 @@ fn (mut w Walker) mark_resource_dependencies() {
 	if w.uses_interp_isnil || w.auto_str_needs_isnil() {
 		w.fn_by_name('isnil')
 	}
-	if w.auto_str_needs_str_intp() {
+	if w.uses_interp || w.auto_str_needs_str_intp() {
 		w.fn_by_name('str_intp')
 		w.mark_by_sym_name('StrIntpData')
 		w.mark_by_sym_name('StrIntpMem')


### PR DESCRIPTION
Fixes #27574

Summary:
- Route primitive integer simple interpolation through `str_intp` outside builtin internals, avoiding the `int_str` + `string_plus_many` lowering.
- Keep `markused` in sync for direct and generic string interpolation so `str_intp` runtime helpers stay available when needed.
- Preserve `.str()`/auto-str helper dependencies for `s`-formatted operands when another operand forces runtime interpolation.
- Leave untyped integer literals on the existing stringification path, preserving large literal values such as `${2147483648}`.
- Keep aggregate smartcast interpolation with auto `s` formatting on the existing simple stringification path.
- Add regressions for the `os` + `-skip-unused` helper retention case, mixed integer plus auto-str operands, the large integer literal path, and grouped aggregate smartcasts.

Tests:
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test -run-only test_skip_unused_runtime_integer_interpolation_marks_auto_str_operand vlib/v/gen/c/coutput_test.v`
- `./vnew -silent test -run-only test_skip_unused_aggregate_smartcast_integer_interpolation_uses_simple_path vlib/v/gen/c/coutput_test.v`
- `./vnew -silent test -run-only test_skip_unused_os_integer_interpolation_keeps_str_intp_runtime vlib/v/gen/c/coutput_test.v`
- `./vnew -silent test -run-only test_c_must_have_files vlib/v/gen/c/coutput_test.v`
- `./vnew -skip-unused run vlib/v/gen/c/testdata/string_interpolation_simple_optimization.vv`
- `./vnew run vlib/v/checker/tests/run/comptime_ident_is_type.vv`
- `./vnew -silent test vlib/v/tests/builtin_strings_and_interpolation/`

Notes:
- A full `./vnew -silent vlib/v/gen/c/coutput_test.v` run still hit an unrelated `translated_module.vv` mismatch with empty output instead of `result: 104`.
- A broad `./vnew -silent test vlib/v/` run was stopped after unrelated failures from an untracked `cmd/v2/_tmp_map_empty_raw.v` parser fixture pickup and tcc fallback warning output pollution.
- An attempted parallel coutput validation run failed because `coutput_test.v` shares temp directories and process cwd state across tests; the relevant coutput checks were rerun sequentially with `test -run-only` and passed.