### PR TITLE
v3: lower runtime and call normalization in transformer

### DIFF
--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -299,6 +299,9 @@ fn (mut g FlatGen) gen_array_method_call(node flat.Node, fn_node &flat.Node, arr
 			g.gen_expr(base_id)
 			g.write(')')
 		}
+		'pointers' {
+			g.gen_array_pointers_expr(base_id, is_ptr)
+		}
 		'str' {
 			amp := if is_ptr { '' } else { '&' }
 			g.write('strings__Builder__str(${amp}')
@@ -390,6 +393,57 @@ fn (mut g FlatGen) gen_array_method_call_fallback(node flat.Node, mname string, 
 	}
 }
 
+// gen_array_pointers_expr emits `array.pointers()` without compiling the erased
+// raw `array` builtin body, which has no concrete element type in v3 Cgen.
+fn (mut g FlatGen) gen_array_pointers_expr(base_id flat.NodeId, is_ptr bool) {
+	base_type := types.unwrap_pointer(g.tc.resolve_type(base_id))
+	if fixed := array_fixed_type(base_type) {
+		g.gen_fixed_array_pointers_expr(base_id, is_ptr, fixed)
+		return
+	}
+	tmp := g.tmp_count
+	g.tmp_count++
+	src_name := '__arr_ptrs_src_${tmp}'
+	res_name := '__arr_ptrs_res_${tmp}'
+	idx_name := '__arr_ptrs_i_${tmp}'
+	g.write('({ Array ${src_name} = ')
+	if is_ptr {
+		g.write('*')
+	}
+	g.gen_expr(base_id)
+	g.write('; Array ${res_name} = array_new(sizeof(voidptr), ${src_name}.len, ${src_name}.len); for (int ${idx_name} = 0; ${idx_name} < ${src_name}.len; ${idx_name}++) { ((voidptr*)${res_name}.data)[${idx_name}] = (voidptr)((u8*)${src_name}.data + ((u64)${idx_name} * (u64)${src_name}.element_size)); } ${res_name}; })')
+}
+
+fn (mut g FlatGen) gen_fixed_array_pointers_expr(base_id flat.NodeId, is_ptr bool, fixed types.ArrayFixed) {
+	tmp := g.tmp_count
+	g.tmp_count++
+	src_name := '__arr_ptrs_fixed_src_${tmp}'
+	res_name := '__arr_ptrs_res_${tmp}'
+	idx_name := '__arr_ptrs_i_${tmp}'
+	len_text := g.fixed_array_len_value(fixed)
+	if !is_ptr && !g.expr_is_addressable(base_id) {
+		panic('fixed array .pointers receiver should be addressable after checking')
+	}
+	g.write('({ ')
+	g.write('typeof(')
+	if is_ptr {
+		g.gen_expr(base_id)
+	} else {
+		g.write('&(')
+		g.gen_expr(base_id)
+		g.write(')')
+	}
+	g.write(') ${src_name} = ')
+	if is_ptr {
+		g.gen_expr(base_id)
+	} else {
+		g.write('&(')
+		g.gen_expr(base_id)
+		g.write(')')
+	}
+	g.write('; Array ${res_name} = array_new(sizeof(voidptr), ${len_text}, ${len_text}); for (int ${idx_name} = 0; ${idx_name} < ${len_text}; ${idx_name}++) { ((voidptr*)${res_name}.data)[${idx_name}] = (voidptr)&((*${src_name})[${idx_name}]); } ${res_name}; })')
+}
+
 // gen_thread_array_wait emits a call to the (lazily generated) wait function for a
 // `[]thread T` receiver. The element type carries the thread's return type in its
 // name (`thread T`); a bare `thread` denotes a void payload.
@@ -475,16 +529,6 @@ fn (mut g FlatGen) gen_map_ref_arg(base_id flat.NodeId, base_type types.Type) {
 		g.write('&')
 		g.gen_expr(base_id)
 	}
-}
-
-// gen_map_delete emits map delete output for c.
-fn (mut g FlatGen) gen_map_delete(node flat.Node, fn_node &flat.Node, m types.Map, base_type types.Type) {
-	c_key := g.tc.c_type(m.key_type)
-	g.write('map__delete(')
-	g.gen_map_ref_arg(g.a.child(fn_node, 0), base_type)
-	g.write(', &(${c_key}[]){')
-	g.gen_expr(g.a.child(&node, 1))
-	g.write('})')
 }
 
 // gen_index_assign emits index assign output for c.

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3137,9 +3137,14 @@ fn (mut g FlatGen) builtin_abi_decls() {
 }
 
 fn (mut g FlatGen) filelock_compat_decls() {
+	if !g.libc_compat_fns['filelock'] {
+		return
+	}
+	g.writeln('#ifndef V_OS_FILELOCK_HELPERS_H')
+	g.writeln('#define V_OS_FILELOCK_HELPERS_H')
 	g.writeln('#ifdef _WIN32')
 	g.writeln('#include <windows.h>')
-	g.writeln('int v_filelock_lock(void* handle, int exclusive, int immediate, u64 start, u64 len) {')
+	g.writeln('static int v_filelock_lock(HANDLE handle, int exclusive, int immediate, unsigned long long start, unsigned long long len) {')
 	g.writeln('\tOVERLAPPED overlap;')
 	g.writeln('\tmemset(&overlap, 0, sizeof(overlap));')
 	g.writeln('\toverlap.Offset = (DWORD)(start & 0xffffffffULL);')
@@ -3148,19 +3153,21 @@ fn (mut g FlatGen) filelock_compat_decls() {
 	g.writeln('\tif (exclusive) { flags |= LOCKFILE_EXCLUSIVE_LOCK; }')
 	g.writeln('\tDWORD low = len == 0 ? MAXDWORD : (DWORD)(len & 0xffffffffULL);')
 	g.writeln('\tDWORD high = len == 0 ? MAXDWORD : (DWORD)(len >> 32);')
-	g.writeln('\treturn LockFileEx((HANDLE)handle, flags, 0, low, high, &overlap) ? 0 : -1;')
+	g.writeln('\treturn LockFileEx(handle, flags, 0, low, high, &overlap) ? 0 : -1;')
 	g.writeln('}')
-	g.writeln('int v_filelock_unlock(void* handle, u64 start, u64 len) {')
+	g.writeln('static int v_filelock_unlock(HANDLE handle, unsigned long long start, unsigned long long len) {')
 	g.writeln('\tOVERLAPPED overlap;')
 	g.writeln('\tmemset(&overlap, 0, sizeof(overlap));')
 	g.writeln('\toverlap.Offset = (DWORD)(start & 0xffffffffULL);')
 	g.writeln('\toverlap.OffsetHigh = (DWORD)(start >> 32);')
 	g.writeln('\tDWORD low = len == 0 ? MAXDWORD : (DWORD)(len & 0xffffffffULL);')
 	g.writeln('\tDWORD high = len == 0 ? MAXDWORD : (DWORD)(len >> 32);')
-	g.writeln('\treturn UnlockFileEx((HANDLE)handle, 0, low, high, &overlap) ? 0 : -1;')
+	g.writeln('\treturn UnlockFileEx(handle, 0, low, high, &overlap) ? 0 : -1;')
 	g.writeln('}')
 	g.writeln('#else')
-	g.writeln('int v_filelock_lock(i32 fd, i32 exclusive, i32 immediate, u64 start, u64 len) {')
+	g.writeln('#include <fcntl.h>')
+	g.writeln('#include <unistd.h>')
+	g.writeln('static int v_filelock_lock(int fd, int exclusive, int immediate, unsigned long long start, unsigned long long len) {')
 	g.writeln('\tstruct flock fl;')
 	g.writeln('\tmemset(&fl, 0, sizeof(fl));')
 	g.writeln('\tfl.l_type = exclusive ? F_WRLCK : F_RDLCK;')
@@ -3169,7 +3176,7 @@ fn (mut g FlatGen) filelock_compat_decls() {
 	g.writeln('\tfl.l_len = len == 0 ? 0 : (off_t)len;')
 	g.writeln('\treturn fcntl(fd, immediate ? F_SETLK : F_SETLKW, &fl);')
 	g.writeln('}')
-	g.writeln('int v_filelock_unlock(i32 fd, u64 start, u64 len) {')
+	g.writeln('static int v_filelock_unlock(int fd, unsigned long long start, unsigned long long len) {')
 	g.writeln('\tstruct flock fl;')
 	g.writeln('\tmemset(&fl, 0, sizeof(fl));')
 	g.writeln('\tfl.l_type = F_UNLCK;')
@@ -3178,6 +3185,7 @@ fn (mut g FlatGen) filelock_compat_decls() {
 	g.writeln('\tfl.l_len = len == 0 ? 0 : (off_t)len;')
 	g.writeln('\treturn fcntl(fd, F_SETLK, &fl);')
 	g.writeln('}')
+	g.writeln('#endif')
 	g.writeln('#endif')
 }
 

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -174,6 +174,11 @@ fn (mut g FlatGen) should_emit_fn_node_in_module(node flat.Node, node_index int,
 	if module_name == 'builtin' && node.value == 'exit' {
 		return true
 	}
+	// `array.pointers` is emitted as an intrinsic at call sites; the raw
+	// builtin body has an erased `array` receiver and generates invalid C.
+	if module_name == 'builtin' && node.value == 'array.pointers' {
+		return false
+	}
 	if node.value.starts_with('__anon_fn_') || qfn.contains('__anon_fn_') {
 		return true
 	}
@@ -196,6 +201,16 @@ fn (g &FlatGen) used_fn_contains(name string) bool {
 }
 
 fn (g &FlatGen) used_fn_contains_in_module(name string, module_name string) bool {
+	if module_name.len > 0 && module_name != 'main' && module_name != 'builtin'
+		&& name.starts_with('${module_name}.') {
+		if g.used_fn_contains(name) {
+			return true
+		}
+		cfn := c_name(name)
+		if cfn != name && g.used_fn_contains(cfn) {
+			return true
+		}
+	}
 	dfn := dotted_fn_name_in_module(module_name, name)
 	qfn := qualified_fn_name_in_module(module_name, name)
 	if g.used_fn_contains(dfn) || g.used_fn_contains(qfn) {
@@ -345,6 +360,10 @@ fn (mut g FlatGen) libc_compat_call_name(name string) ?string {
 	if name == 'C.gettid' {
 		g.libc_compat_fns['gettid'] = true
 		return 'v3_gettid'
+	}
+	if name in ['C.v_filelock_lock', 'C.v_filelock_unlock'] {
+		g.libc_compat_fns['filelock'] = true
+		return c_name(name)
 	}
 	return none
 }
@@ -546,11 +565,25 @@ fn (g &FlatGen) expr_is_addressable(id flat.NodeId) bool {
 	}
 	node := g.a.nodes[int(id)]
 	return match node.kind {
-		.ident { true }
-		.index { node.children_count > 0 && g.expr_is_addressable(g.a.child(&node, 0)) }
-		.selector { node.children_count > 0 && g.expr_is_addressable(g.a.child(&node, 0)) }
-		.prefix { node.op == .mul }
-		else { false }
+		.ident {
+			true
+		}
+		.index {
+			node.value != 'range' && node.children_count > 0
+				&& g.expr_is_addressable(g.a.child(&node, 0))
+		}
+		.selector {
+			node.children_count > 0 && g.expr_is_addressable(g.a.child(&node, 0))
+		}
+		.prefix {
+			node.op == .mul
+		}
+		.paren {
+			node.children_count > 0 && g.expr_is_addressable(g.a.child(&node, 0))
+		}
+		else {
+			false
+		}
 	}
 }
 
@@ -1500,6 +1533,15 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 	fn_node := g.a.child_node(&node, 0)
 	fn_name := fn_node.value
 	target_name := g.call_target_name(g.a.child(&node, 0))
+	if target_name == 'array.pointers' || fn_name == 'array.pointers' {
+		if node.children_count > 1 {
+			arg_id := g.a.child(&node, 1)
+			g.gen_array_pointers_expr(arg_id, g.tc.resolve_type(arg_id) is types.Pointer)
+		} else {
+			g.write('array_new(sizeof(voidptr), 0, 0)')
+		}
+		return
+	}
 	if target_name in ['json.decode', 'json2.decode'] {
 		ret_type := g.json_decode_result_type(g.a.child(&node, 0)) or {
 			g.call_default_return_type(id)
@@ -1540,10 +1582,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		base_id := g.a.child(fn_node, 0)
 		base_type := g.tc.resolve_type(base_id)
 		if base_type is types.Channel {
-			g.write('sync__Channel__close(')
-			g.gen_expr(base_id)
-			g.write(', array_new(sizeof(IError), 0, 0))')
-			return
+			panic('channel close should be lowered by v3 transform')
 		}
 	}
 	match fn_name {
@@ -1689,31 +1728,15 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 							g.write(', ${len_expr})')
 							return
 						}
-						if clean_type is types.Map {
-							if fn_node.value == 'delete' {
-								g.gen_map_delete(node, fn_node, clean_type, base_type)
-								return
-							} else if fn_node.value == 'clone' {
-								g.write('map__clone(')
-								g.gen_map_ref_arg(g.a.child(fn_node, 0), base_type)
-								g.write(')')
-								return
-							} else if fn_node.value == 'clear' {
-								g.write('map__clear(')
-								g.gen_map_ref_arg(g.a.child(fn_node, 0), base_type)
-								g.write(')')
-								return
-							} else if fn_node.value == 'free' {
-								g.write('map__free(')
-								if base_type is types.Pointer {
-									g.gen_expr(g.a.child(fn_node, 0))
-								} else {
-									g.write('&')
-									g.gen_expr(g.a.child(fn_node, 0))
-								}
-								g.write(')')
-								return
-							}
+						if clean_type is types.Map && fn_node.value == 'clone' {
+							g.write('map__clone(')
+							g.gen_map_ref_arg(g.a.child(fn_node, 0), base_type)
+							g.write(')')
+							return
+						}
+						if clean_type is types.Map
+							&& fn_node.value in ['delete', 'clear', 'free', 'move', 'reserve'] {
+							panic('map method `${fn_node.value}` should be lowered by v3 transform')
 						}
 						if clean_type is types.String {
 							method_name = 'string.${fn_node.value}'
@@ -1844,31 +1867,15 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 						g.write(', ${len_expr})')
 						return
 					}
-					if clean_type is types.Map {
-						if fn_node.value == 'delete' {
-							g.gen_map_delete(node, fn_node, clean_type, base_type)
-							return
-						} else if fn_node.value == 'clone' {
-							g.write('map__clone(')
-							g.gen_map_ref_arg(g.a.child(fn_node, 0), base_type)
-							g.write(')')
-							return
-						} else if fn_node.value == 'clear' {
-							g.write('map__clear(')
-							g.gen_map_ref_arg(g.a.child(fn_node, 0), base_type)
-							g.write(')')
-							return
-						} else if fn_node.value == 'free' {
-							g.write('map__free(')
-							if base_type is types.Pointer {
-								g.gen_expr(g.a.child(fn_node, 0))
-							} else {
-								g.write('&')
-								g.gen_expr(g.a.child(fn_node, 0))
-							}
-							g.write(')')
-							return
-						}
+					if clean_type is types.Map && fn_node.value == 'clone' {
+						g.write('map__clone(')
+						g.gen_map_ref_arg(g.a.child(fn_node, 0), base_type)
+						g.write(')')
+						return
+					}
+					if clean_type is types.Map
+						&& fn_node.value in ['delete', 'clear', 'free', 'move', 'reserve'] {
+						panic('map method `${fn_node.value}` should be lowered by v3 transform')
 					}
 					if clean_type is types.String {
 						method_name = 'string.${fn_node.value}'
@@ -3803,6 +3810,10 @@ fn (mut g FlatGen) forward_decls() {
 			}
 		} else if kind_id == 76
 			&& (node.value.starts_with('C.v_filelock_') || node.value.starts_with('v_filelock_')) {
+			if g.libc_compat_fns['filelock']
+				&& node.value in ['C.v_filelock_lock', 'C.v_filelock_unlock', 'v_filelock_lock', 'v_filelock_unlock'] {
+				continue
+			}
 			g.tc.cur_file = cur_file
 			g.tc.cur_module = cur_module
 			ret_type := g.tc.parse_type(node.typ)

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -1392,9 +1392,13 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 								base_id := c.a.child(&callee, 0)
 								if int(base_id) >= 0 {
 									base := c.a.nodes[int(base_id)]
-									has_exact_selector_call = c.collect_typed_receiver_method(base_id,
-										callee.value, cur_module, imports, local_values,
-										local_types, mut calls)
+									has_exact_selector_call = c.collect_checker_selected_call(resolved_call, mut
+										calls)
+									if !has_exact_selector_call {
+										has_exact_selector_call = c.collect_typed_receiver_method(base_id,
+											callee.value, cur_module, imports, local_values,
+											local_types, mut calls)
+									}
 									if !has_exact_selector_call && base.kind == .ident
 										&& base.value in imports && base.value !in local_values {
 										calls << imports[base.value] + '.' + callee.value
@@ -2022,8 +2026,11 @@ fn (c &CallCollector) collect_top_level_selector_call(callee &flat.Node, method 
 		base_id := c.a.child(callee, 0)
 		if int(base_id) >= 0 {
 			base := c.a.node(base_id)
-			has_exact_selector_call = c.collect_top_level_typed_receiver_method(base_id, method,
-				cur_module, imports, local_values, local_types, mut calls)
+			has_exact_selector_call = c.collect_checker_selected_call(resolved_call, mut calls)
+			if !has_exact_selector_call {
+				has_exact_selector_call = c.collect_top_level_typed_receiver_method(base_id,
+					method, cur_module, imports, local_values, local_types, mut calls)
+			}
 			if !has_exact_selector_call && base.kind == .ident && base.value in imports
 				&& base.value !in local_values {
 				calls << imports[base.value] + '.' + method
@@ -2039,6 +2046,36 @@ fn (c &CallCollector) collect_top_level_selector_call(callee &flat.Node, method 
 			}
 		}
 	}
+}
+
+fn (c &CallCollector) collect_checker_selected_call(resolved_call string, mut calls []string) bool {
+	if resolved_call.len == 0 || markused_is_builtin_collection_resolved_call(resolved_call)
+		|| !c.is_known_fn_name(resolved_call) {
+		return false
+	}
+	c.add_typed_receiver_method_name(resolved_call, mut calls)
+	return true
+}
+
+fn markused_is_builtin_collection_resolved_call(name string) bool {
+	return name.len == 0 || markused_is_raw_collection_method_name(name, 'array.')
+		|| name == 'array_clone' || markused_is_runtime_collection_helper_name(name)
+		|| markused_is_raw_collection_method_name(name, 'map.')
+}
+
+fn markused_is_raw_collection_method_name(name string, prefix string) bool {
+	if !name.starts_with(prefix) {
+		return false
+	}
+	rest := name[prefix.len..]
+	return rest.len > 0 && !rest.contains('.')
+}
+
+fn markused_is_runtime_collection_helper_name(name string) bool {
+	return name in ['array__clone', 'array__reverse', 'array__prepend', 'array__insert',
+		'array__push_many', 'array__needs_unique_shift', 'map__delete', 'map__move', 'map__reserve',
+		'map__keys', 'map__values', 'map__clear', 'map__free', 'map__get', 'map__get_check',
+		'map__exists', 'map__set']
 }
 
 fn (c &CallCollector) collect_top_level_selector_fallback(base &flat.Node, method string, cur_module string, imports map[string]string, local_values map[string]bool, mut calls []string) {
@@ -2474,6 +2511,8 @@ fn (c &CallCollector) typed_receiver_method_name(type_name string, method string
 	mut candidates := []string{cap: 4}
 	if type_name.starts_with('map[') {
 		candidates << markused_map_receiver_method_candidates(type_name, method, cur_module)
+	} else if type_name.starts_with('[]') {
+		candidates << markused_array_receiver_method_candidates(type_name, method, cur_module)
 	} else if type_name.contains('.') {
 		candidates << '${type_name}.${method}'
 	} else {
@@ -2494,31 +2533,196 @@ fn (c &CallCollector) typed_receiver_method_name(type_name string, method string
 	return none
 }
 
+fn markused_can_prefix_collection_receiver(cur_module string) bool {
+	return cur_module.len > 0 && cur_module != 'main' && cur_module != 'builtin'
+}
+
+fn markused_push_receiver_candidate(mut candidates []string, candidate string) {
+	if candidate.len > 0 && candidate !in candidates {
+		candidates << candidate
+	}
+}
+
+fn markused_array_receiver_method_candidates(receiver_type string, method string, cur_module string) []string {
+	mut clean_type := receiver_type.trim_space()
+	for {
+		if clean_type.starts_with('&') {
+			clean_type = clean_type[1..].trim_space()
+			continue
+		}
+		break
+	}
+	mut candidates := []string{}
+	markused_push_receiver_candidate(mut candidates, '${clean_type}.${method}')
+	if !clean_type.starts_with('[]') || clean_type.len <= 2 {
+		return candidates
+	}
+	elem_type := clean_type[2..]
+	short_elem := if elem_type.contains('.') { elem_type.all_after_last('.') } else { elem_type }
+	markused_push_receiver_candidate(mut candidates, '[]${short_elem}.${method}')
+	if elem_type.contains('.') {
+		markused_push_receiver_candidate(mut candidates,
+			'${elem_type.all_before_last('.')}.[]${short_elem}.${method}')
+	} else if markused_can_prefix_collection_receiver(cur_module) {
+		markused_push_receiver_candidate(mut candidates, '${cur_module}.[]${short_elem}.${method}')
+	}
+	return candidates
+}
+
 fn markused_map_receiver_method_candidates(receiver_type string, method string, cur_module string) []string {
 	clean_type := markused_clean_map_type(receiver_type)
 	key_type := markused_map_key_type(clean_type)
 	value_type := markused_map_value_type(clean_type)
 	mut candidates := []string{}
-	candidates << '${clean_type}.${method}'
 	if key_type.len == 0 || value_type.len == 0 {
+		markused_push_receiver_candidate(mut candidates, '${clean_type}.${method}')
 		return candidates
 	}
-	short_value := if value_type.contains('.') {
-		value_type.all_after_last('.')
-	} else {
-		value_type
+	key_types := markused_receiver_type_text_variants(key_type)
+	value_types := markused_receiver_type_text_variants(value_type)
+	mut map_types := []string{}
+	for key in key_types {
+		for value in value_types {
+			markused_push_receiver_candidate(mut map_types, 'map[${key}]${value}')
+		}
 	}
-	short_map := 'map[${key_type}]${short_value}'
-	if short_map != clean_type {
-		candidates << '${short_map}.${method}'
+	for map_type in map_types {
+		markused_push_receiver_candidate(mut candidates, '${map_type}.${method}')
 	}
-	if value_type.contains('.') {
-		mod_name := value_type.all_before_last('.')
-		candidates << '${mod_name}.${short_map}.${method}'
-	} else if cur_module.len > 0 && cur_module != 'main' && cur_module != 'builtin' {
-		candidates << '${cur_module}.${short_map}.${method}'
+	mut module_names := []string{}
+	if markused_can_prefix_collection_receiver(cur_module) {
+		markused_push_receiver_candidate(mut module_names, cur_module)
+	}
+	for mod_name in markused_receiver_type_text_module_names(key_type) {
+		markused_push_receiver_candidate(mut module_names, mod_name)
+	}
+	for mod_name in markused_receiver_type_text_module_names(value_type) {
+		markused_push_receiver_candidate(mut module_names, mod_name)
+	}
+	for mod_name in module_names {
+		for map_type in map_types {
+			markused_push_receiver_candidate(mut candidates, '${mod_name}.${map_type}.${method}')
+		}
 	}
 	return candidates
+}
+
+fn markused_receiver_type_text_variants(type_text string) []string {
+	clean := type_text.trim_space()
+	mut names := []string{}
+	markused_push_receiver_candidate(mut names, clean)
+	markused_push_receiver_candidate(mut names, markused_receiver_type_text_short_spelling(clean))
+	if markused_type_text_is_fixed_array(clean) {
+		source := markused_receiver_type_text_source_fixed_spelling(clean)
+		markused_push_receiver_candidate(mut names, source)
+		markused_push_receiver_candidate(mut names,
+			markused_receiver_type_text_short_spelling(source))
+	}
+	return names
+}
+
+fn markused_receiver_type_text_source_fixed_spelling(type_text string) string {
+	clean := type_text.trim_space()
+	if clean.len == 0 || clean.starts_with('[') || !markused_type_text_is_fixed_array(clean) {
+		return clean
+	}
+	elem, dims := markused_postfix_fixed_array_parts(clean)
+	if elem.len == 0 || dims.len == 0 {
+		return clean
+	}
+	mut source := elem
+	for i := dims.len; i > 0; i-- {
+		source = '[${dims[i - 1]}]${source}'
+	}
+	return source
+}
+
+fn markused_postfix_fixed_array_parts(type_text string) (string, []string) {
+	clean := type_text.trim_space()
+	mut end := clean.len
+	mut dims := []string{}
+	for end > 0 && clean[end - 1] == `]` {
+		start := markused_trailing_matching_bracket_start(clean, end)
+		if start < 0 {
+			break
+		}
+		dims << clean[start + 1..end - 1].trim_space()
+		end = start
+	}
+	return clean[..end], dims
+}
+
+fn markused_trailing_matching_bracket_start(s string, end int) int {
+	mut depth := 0
+	for i := end - 1; i >= 0; i-- {
+		if s[i] == `]` {
+			depth++
+		} else if s[i] == `[` {
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+fn markused_receiver_type_text_short_spelling(type_text string) string {
+	clean := type_text.trim_space()
+	if clean.starts_with('[]') {
+		return '[]' + markused_receiver_type_text_short_spelling(clean[2..])
+	}
+	if clean.starts_with('[') {
+		bracket_end := markused_matching_bracket(clean, 0)
+		if bracket_end < clean.len {
+			return clean[..bracket_end + 1] +
+				markused_receiver_type_text_short_spelling(clean[bracket_end + 1..])
+		}
+	}
+	if clean.starts_with('map[') {
+		bracket_end := markused_matching_bracket(clean, 3)
+		if bracket_end < clean.len {
+			key := markused_receiver_type_text_short_spelling(clean[4..bracket_end])
+			value := markused_receiver_type_text_short_spelling(clean[bracket_end + 1..])
+			return 'map[${key}]${value}'
+		}
+	}
+	if clean.contains('.') {
+		return clean.all_after_last('.')
+	}
+	return clean
+}
+
+fn markused_receiver_type_text_module_names(type_text string) []string {
+	clean := type_text.trim_space()
+	mut names := []string{}
+	if clean.starts_with('[]') {
+		return markused_receiver_type_text_module_names(clean[2..])
+	}
+	if clean.starts_with('[') {
+		bracket_end := markused_matching_bracket(clean, 0)
+		if bracket_end < clean.len {
+			return markused_receiver_type_text_module_names(clean[bracket_end + 1..])
+		}
+	}
+	if clean.starts_with('map[') {
+		key_type := markused_map_key_type(clean)
+		value_type := markused_map_value_type(clean)
+		for name in markused_receiver_type_text_module_names(key_type) {
+			markused_push_receiver_candidate(mut names, name)
+		}
+		for name in markused_receiver_type_text_module_names(value_type) {
+			markused_push_receiver_candidate(mut names, name)
+		}
+		return names
+	}
+	if markused_type_text_is_fixed_array(clean) {
+		return markused_receiver_type_text_module_names(markused_fixed_array_elem_type(clean))
+	}
+	if clean.contains('.') {
+		markused_push_receiver_candidate(mut names, clean.all_before_last('.'))
+	}
+	return names
 }
 
 fn markused_clean_map_type(receiver_type string) string {
@@ -2537,11 +2741,42 @@ fn markused_clean_map_type(receiver_type string) string {
 	return clean
 }
 
+fn markused_type_text_is_fixed_array(type_text string) bool {
+	clean := type_text.trim_space()
+	if clean.len == 0 || clean.starts_with('[]') || clean.starts_with('map[') {
+		return false
+	}
+	if clean.starts_with('[') {
+		bracket_end := markused_matching_bracket(clean, 0)
+		return bracket_end < clean.len
+	}
+	if !clean.contains('[') || !clean.ends_with(']') {
+		return false
+	}
+	len_text := markused_fixed_array_len_text(clean)
+	return len_text.len > 0 && !len_text.contains(',')
+}
+
+fn markused_fixed_array_len_text(type_text string) string {
+	return type_text.all_after('[').all_before(']').trim_space()
+}
+
+fn markused_fixed_array_elem_type(type_text string) string {
+	if type_text.starts_with('[') {
+		bracket_end := markused_matching_bracket(type_text, 0)
+		if bracket_end < type_text.len {
+			return type_text[bracket_end + 1..]
+		}
+		return ''
+	}
+	return type_text.all_before('[')
+}
+
 fn markused_map_key_type(type_str string) string {
 	if !type_str.starts_with('map[') {
 		return ''
 	}
-	bracket_end := type_str.index(']') or { return '' }
+	bracket_end := markused_matching_bracket(type_str, 3)
 	if bracket_end > 4 {
 		return type_str[4..bracket_end]
 	}
@@ -2552,11 +2787,26 @@ fn markused_map_value_type(type_str string) string {
 	if !type_str.starts_with('map[') {
 		return ''
 	}
-	bracket_end := type_str.index(']') or { return '' }
+	bracket_end := markused_matching_bracket(type_str, 3)
 	if bracket_end + 1 < type_str.len {
 		return type_str[bracket_end + 1..]
 	}
 	return ''
+}
+
+fn markused_matching_bracket(s string, start int) int {
+	mut depth := 0
+	for i in start .. s.len {
+		if s[i] == `[` {
+			depth++
+		} else if s[i] == `]` {
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return s.len
 }
 
 fn (c &CallCollector) add_typed_receiver_method_name(method_name string, mut calls []string) {
@@ -2720,9 +2970,15 @@ fn resolve_type_name(t types.Type) string {
 	} else if t is types.String {
 		return 'string'
 	} else if t is types.Array {
-		return 'Array'
+		return '[]${markused_nested_type_name(t.elem_type)}'
+	} else if t is types.ArrayFixed {
+		mut len_text := t.len.str()
+		if t.len_expr.len > 0 {
+			len_text = t.len_expr
+		}
+		return '${markused_nested_type_name(t.elem_type)}[${len_text}]'
 	} else if t is types.Map {
-		return 'map[${t.key_type.name()}]${t.value_type.name()}'
+		return 'map[${markused_nested_type_name(t.key_type)}]${markused_nested_type_name(t.value_type)}'
 	} else if t is types.Pointer {
 		return resolve_type_name(t.base_type)
 	} else if t is types.Primitive {
@@ -2766,6 +3022,10 @@ fn resolve_type_name(t types.Type) string {
 		return 'rune'
 	}
 	return ''
+}
+
+fn markused_nested_type_name(t types.Type) string {
+	return t.name()
 }
 
 // markused_c_name converts markused c name data for markused.

--- a/vlib/v3/tests/fn_value_decl_type_test.v
+++ b/vlib/v3/tests/fn_value_decl_type_test.v
@@ -287,11 +287,28 @@ fn main() {
 }
 '
 
+const local_fn_call_shadow_global_return_src = 'fn f() string {
+	return "global"
+}
+
+fn make_int() int {
+	return 12
+}
+
+fn main() {
+	f := make_int
+	x := f()
+	println(int_str(x))
+}
+'
+
 fn test_local_fn_literal_decl_types_are_callable() {
 	v3_bin := build_v3()
 	assert run_good(v3_bin, 'fn_value_optional_void_local', optional_fn_src) == 'optional-ok'
 	assert run_good(v3_bin, 'fn_value_plain_int_local', plain_fn_src) == '7'
 	assert run_good(v3_bin, 'fn_value_local_ident_shadow', local_ident_shadow_src) == '10'
+	assert run_good(v3_bin, 'fn_value_local_call_shadows_global_return',
+		local_fn_call_shadow_global_return_src) == '12'
 	assert run_good(v3_bin, 'fn_value_named_local', 'fn add_one(i int) int {
 	return i + 1
 }
@@ -354,6 +371,11 @@ fn test_local_fn_literal_decl_generates_fn_pointer_locals() {
 	shadow_c := gen_c(v3_bin, 'fn_value_local_ident_shadow_c', local_ident_shadow_src)
 	assert shadow_c.contains('int foo = 10'), shadow_c
 	assert shadow_c.contains('int f = foo'), shadow_c
+
+	shadow_call_c := gen_c(v3_bin, 'fn_value_local_call_shadows_global_return_c',
+		local_fn_call_shadow_global_return_src)
+	assert shadow_call_c.contains('int x ='), shadow_call_c
+	assert !shadow_call_c.contains('string x ='), shadow_call_c
 
 	imported_c := gen_project_c(v3_bin, 'fn_value_imported_selector_local_c',
 		imported_fn_value_project_files())

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -8,8 +8,12 @@ const repo_dir = os.dir(vlib_dir)
 const v3_src = os.join_path(v3_dir, 'v3.v')
 const compiler_src_dir = os.join_path(repo_dir, 'cmd', 'v')
 
+fn tmp_test_path(name string) string {
+	return os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+}
+
 fn build_v3() string {
-	v3_bin := os.join_path(os.temp_dir(), 'v3_post_merge_review_fixes_test')
+	v3_bin := tmp_test_path('post_merge_review_fixes_test')
 	build :=
 		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0, build.output
@@ -17,15 +21,36 @@ fn build_v3() string {
 }
 
 fn run_good(v3_bin string, name string, src string) string {
-	good_src := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	good_src := '${tmp_test_path(name)}.v'
 	os.write_file(good_src, src) or { panic(err) }
-	good_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	good_bin := tmp_test_path(name)
 	compile := os.execute('${v3_bin} ${good_src} -b c -o ${good_bin}')
 	assert compile.exit_code == 0, compile.output
 	assert !compile.output.contains('C compilation failed'), compile.output
 	run := os.execute(good_bin)
 	assert run.exit_code == 0, run.output
 	return run.output.trim_space()
+}
+
+fn run_bad(v3_bin string, name string, src string, expected string) {
+	bad_src := '${tmp_test_path(name)}.v'
+	os.write_file(bad_src, src) or { panic(err) }
+	bad_bin := tmp_test_path(name)
+	compile := os.execute('${v3_bin} ${bad_src} -b c -o ${bad_bin}')
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains(expected), compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+}
+
+fn gen_c(v3_bin string, name string, src string) string {
+	src_path := '${tmp_test_path(name)}.v'
+	os.write_file(src_path, src) or { panic(err) }
+	c_path := '${tmp_test_path(name)}.c'
+	os.rm(c_path) or {}
+	compile := os.execute('${v3_bin} ${src_path} -b c -o ${c_path}')
+	assert compile.exit_code == 0, compile.output
+	assert os.exists(c_path)
+	return os.read_file(c_path) or { panic(err) }
 }
 
 fn write_project_file(root string, rel string, src string) {
@@ -35,7 +60,7 @@ fn write_project_file(root string, rel string, src string) {
 }
 
 fn run_good_project(v3_bin string, name string, files map[string]string, input string) string {
-	root := os.join_path(os.temp_dir(), 'v3_${name}_project')
+	root := '${tmp_test_path(name)}_project'
 	if os.exists(root) {
 		os.rmdir_all(root) or { panic(err) }
 	}
@@ -44,7 +69,7 @@ fn run_good_project(v3_bin string, name string, files map[string]string, input s
 		write_project_file(root, rel, src)
 	}
 	input_path := if input.len == 0 { root } else { os.join_path(root, input) }
-	good_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	good_bin := tmp_test_path(name)
 	compile := os.execute('${v3_bin} ${input_path} -b c -o ${good_bin}')
 	assert compile.exit_code == 0, compile.output
 	assert !compile.output.contains('C compilation failed'), compile.output
@@ -70,11 +95,53 @@ fn test_compiler_vexe_env_uses_running_executable() {
 	assert c_source.contains('setenv("VEXE", v3_vexe, 1);')
 }
 
+fn test_filelock_helpers_are_inlined_in_generated_c() {
+	v3_bin := build_v3()
+	c_source := gen_c(v3_bin, 'filelock_helpers_inline',
+		'import os.filelock\n\nfn C.v_filelock_lock(i32, i32, i32, u64, u64) i32\nfn C.v_filelock_unlock(i32, u64, u64) i32\n\nfn main() {\n\t_ = filelock.LockMode.exclusive\n\t_ = C.v_filelock_lock(i32(-1), 1, 1, u64(0), u64(0))\n\t_ = C.v_filelock_unlock(i32(-1), u64(0), u64(0))\n}\n')
+	assert !c_source.contains('filelock_helpers.h')
+	assert c_source.contains('static int v_filelock_lock(')
+	assert c_source.contains('static int v_filelock_unlock(')
+	assert c_source.contains('#ifndef V_OS_FILELOCK_HELPERS_H')
+	assert !c_source.contains('v_filelock_status')
+	status_source := gen_c(v3_bin, 'filelock_custom_prefix_decl',
+		'import os.filelock\n\nfn C.v_filelock_lock(i32, i32, i32, u64, u64) i32\nfn C.v_filelock_unlock(i32, u64, u64) i32\nfn C.v_filelock_status() int\n\nfn main() {\n\t_ = filelock.LockMode.exclusive\n\t_ = C.v_filelock_lock(i32(-1), 1, 1, u64(0), u64(0))\n\t_ = C.v_filelock_status()\n}\n')
+	assert status_source.contains('int v_filelock_status(')
+	user_name_source := gen_c(v3_bin, 'filelock_user_names_not_helpers',
+		'fn v_filelock_lock() int {\n\treturn 3\n}\n\nfn v_filelock_unlock() int {\n\treturn 4\n}\n\nfn main() {\n\tprintln(int_str(v_filelock_lock() + v_filelock_unlock()))\n}\n')
+	assert !user_name_source.contains('static int v_filelock_lock(')
+	assert !user_name_source.contains('static int v_filelock_unlock(')
+}
+
 fn test_assoc_return_runs_defers() {
 	v3_bin := build_v3()
 	out := run_good(v3_bin, 'assoc_return_runs_defers',
 		'struct Point {\n\tx int\n\ty int\n}\n\n__global hit int\n\nfn make_point() Point {\n\tbase := Point{\n\t\tx: 1\n\t\ty: 2\n\t}\n\tdefer {\n\t\thit = 7\n\t}\n\treturn Point{\n\t\t...base\n\t\tx: 5\n\t}\n}\n\nfn main() {\n\tp := make_point()\n\tprintln(int_str(p.x))\n\tprintln(int_str(hit))\n}\n')
 	assert out == '5\n7'
+}
+
+fn test_pointer_arithmetic_deref_keeps_pointer_type() {
+	v3_bin := build_v3()
+	out := run_good(v3_bin, 'pointer_arithmetic_deref',
+		'fn main() {\n\tmut nums := [1, 2]!\n\tp := unsafe { &nums[0] }\n\tv := unsafe { *(p + 1) }\n\tprintln(int_str(v))\n}\n')
+	assert out == '2'
+}
+
+fn test_array_alias_free_uses_array_builtin_inside_alias_method() {
+	v3_bin := build_v3()
+	out := run_good(v3_bin, 'array_alias_free_builtin',
+		'import strings\n\nfn main() {\n\tmut b := strings.new_builder(4)\n\tb.write_string("ok")\n\tunsafe { b.free() }\n\tprintln("ok")\n}\n')
+	assert out == 'ok'
+}
+
+fn test_channel_alias_close_method_wins_over_builtin() {
+	v3_bin := build_v3()
+	out := run_good(v3_bin, 'channel_alias_close_method_before_builtin',
+		'type MyChan = chan int\n\nfn (c MyChan) close() int {\n\treturn 71\n}\n\nfn main() {\n\tch := MyChan(unsafe { nil })\n\tprintln(int_str(ch.close()))\n}\n')
+	assert out == '71'
+	pointer_c := gen_c(v3_bin, 'pointer_channel_close_lowers_to_runtime',
+		'fn main() {\n\tmut ch := chan bool{cap: 1}\n\tp := &ch\n\tp.close()\n}\n')
+	assert pointer_c.contains('sync__Channel__close(*p,')
 }
 
 fn test_qualified_enum_str_requires_exact_receiver() {
@@ -85,4 +152,136 @@ fn test_qualified_enum_str_requires_exact_receiver() {
 		'modb/modb.v': "module modb\n\npub enum Color {\n\tblue\n}\n\npub fn (c Color) str() string {\n\treturn 'custom'\n}\n"
 	}, 'main.v')
 	assert out == 'red\ncustom'
+}
+
+fn test_array_builtin_method_fallback_keeps_return_type() {
+	v3_bin := build_v3()
+	out := run_good(v3_bin, 'array_builtin_method_fallback',
+		'fn main() {\n\tmut nums := []int{}\n\tnums << 1\n\tnums << 2\n\tnums << 3\n\tptrs := unsafe { nums.pointers() }\n\tprintln(int_str(ptrs.len))\n}\n')
+	assert out == '3'
+	ptr_out := run_good(v3_bin, 'array_pointers_pointer_receiver',
+		'fn main() {\n\tmut nums := []int{}\n\tnums << 1\n\tp := &nums\n\tptrs := unsafe { p.pointers() }\n\tprintln(int_str(ptrs.len))\n}\n')
+	assert ptr_out == '1'
+	reverse_out := run_good(v3_bin, 'array_reverse_pointer_receiver',
+		'fn main() {\n\tmut nums := []int{}\n\tnums << 1\n\tnums << 2\n\tp := &nums\n\tp.reverse()\n\tprintln("ok")\n}\n')
+	assert reverse_out == 'ok'
+	exact_out := run_good(v3_bin, 'exact_array_receiver_method_before_builtin',
+		'fn (a []int) pointers() []int {\n\treturn a\n}\n\nfn main() {\n\tnums := [9]\n\tptrs := nums.pointers()\n\tprintln(int_str(ptrs[0]))\n}\n')
+	assert exact_out == '9'
+	exact_clear_out := run_good(v3_bin, 'exact_array_clear_method_before_cgen',
+		'fn (a []int) clear() int {\n\treturn 5\n}\n\nfn main() {\n\tmut nums := []int{}\n\tnums << 1\n\tprintln(int_str(nums.clear()))\n\tprintln(int_str(nums.len))\n}\n')
+	assert exact_clear_out == '5\n1'
+	exact_clone_out := run_good(v3_bin, 'exact_array_clone_method_before_builtin',
+		'fn (a []int) clone() int {\n\treturn 12\n}\n\nfn main() {\n\tmut nums := []int{}\n\tnums << 1\n\tprintln(int_str(nums.clone()))\n}\n')
+	assert exact_clone_out == '12'
+	exact_reverse_out := run_good(v3_bin, 'exact_array_reverse_method_before_builtin',
+		'fn (a []int) reverse() int {\n\treturn 13\n}\n\nfn main() {\n\tmut nums := []int{}\n\tnums << 1\n\tprintln(int_str(nums.reverse()))\n}\n')
+	assert exact_reverse_out == '13'
+	module_array_prefix_out := run_good_project(v3_bin, 'array_prefix_module_receiver_method', {
+		'main.v':            'module main\n\nimport array_utils\n\nfn main() {\n\tprintln(array_utils.run())\n}\n'
+		'array_utils/mod.v': 'module array_utils\n\nfn (a []int) reverse() int {\n\treturn 73\n}\n\npub fn run() string {\n\tmut nums := []int{}\n\tnums << 1\n\treturn int_str(nums.reverse())\n}\n'
+	}, 'main.v')
+	assert module_array_prefix_out == '73'
+	module_array_runtime_prefix_out := run_good_project(v3_bin,
+		'array_runtime_prefix_module_receiver_method', {
+		'main.v':             'module main\n\nimport array__utils\n\nfn main() {\n\tprintln(array__utils.run())\n}\n'
+		'array__utils/mod.v': 'module array__utils\n\nfn (a []int) reverse() int {\n\treturn 83\n}\n\npub fn run() string {\n\tmut nums := []int{}\n\tnums << 1\n\treturn int_str(nums.reverse())\n}\n'
+	}, 'main.v')
+	assert module_array_runtime_prefix_out == '83'
+	module_array_move_out := run_good_project(v3_bin, 'module_array_move_receiver_method', {
+		'main.v':      'module main\n\nimport thing\n\nfn main() {\n\tprintln(thing.run())\n}\n'
+		'thing/mod.v': 'module thing\n\nfn (a []int) move() int {\n\treturn 91\n}\n\npub fn run() string {\n\tmut nums := []int{}\n\tnums << 1\n\treturn int_str(nums.move())\n}\n'
+	}, 'main.v')
+	assert module_array_move_out == '91'
+	exact_prepend_out := run_good(v3_bin, 'exact_array_prepend_method_before_builtin',
+		'fn (a []int) prepend(x int) int {\n\treturn x + 1\n}\n\nfn main() {\n\tmut nums := []int{}\n\tnums << 1\n\tprintln(int_str(nums.prepend(4)))\n}\n')
+	assert exact_prepend_out == '5'
+	run_bad(v3_bin, 'exact_array_first_method_checked_before_builtin',
+		'fn (a []int) first() string {\n\treturn "bad"\n}\n\nfn take_int(x int) {}\n\nfn main() {\n\tmut nums := []int{}\n\tnums << 1\n\ttake_int(nums.first())\n}\n',
+		'cannot use `string` as argument 1 to `take_int`; expected `int`')
+	fixed_dynamic_out := run_good(v3_bin, 'fixed_array_dynamic_receiver_method_before_builtin',
+		'fn (a []int) pointers() int {\n\treturn 41\n}\n\nfn main() {\n\tfixed := [3]int{}\n\tprintln(int_str(fixed.pointers()))\n}\n')
+	assert fixed_dynamic_out == '41'
+	nested_fixed_dynamic_out := run_good(v3_bin, 'nested_fixed_array_dynamic_receiver_method',
+		'fn (a [][2]int) pointers() int {\n\treturn 82\n}\n\nfn main() {\n\tfixed := [3][2]int{}\n\tprintln(int_str(fixed.pointers()))\n}\n')
+	assert nested_fixed_dynamic_out == '82'
+	fixed_alias_shape_out := run_good(v3_bin, 'fixed_array_builtin_not_alias_method',
+		'type F = [2]int\n\nfn (f F) pointers() int {\n\treturn 66\n}\n\nfn main() {\n\tmut fixed := [2]int{}\n\tptrs := unsafe { fixed.pointers() }\n\tprintln(int_str(ptrs.len))\n}\n')
+	assert fixed_alias_shape_out == '2'
+	plain_array_contains_out := run_good(v3_bin, 'plain_array_contains_not_alias_method',
+		'type A = []int\n\nfn (a A) contains(x int) int {\n\treturn 0\n}\n\nfn main() {\n\tnums := [1, 2, 3]\n\tif nums.contains(2) {\n\t\tprintln("builtin")\n\t} else {\n\t\tprintln("alias")\n\t}\n\talias := A(nums)\n\tprintln(int_str(alias.contains(2)))\n}\n')
+	assert plain_array_contains_out == 'builtin\n0'
+	module_primitive_out := run_good_project(v3_bin, 'module_primitive_array_receiver_method', {
+		'main.v':      'module main\n\nimport thing\n\nfn main() {\n\tprintln(thing.run())\n}\n'
+		'thing/mod.v': 'module thing\n\nfn (a []int) pointers() int {\n\treturn 64\n}\n\npub fn run() string {\n\tmut nums := []int{}\n\tnums << 1\n\treturn int_str(nums.pointers())\n}\n'
+	}, 'main.v')
+	assert module_primitive_out == '64'
+	fixed_out := run_good(v3_bin, 'fixed_array_pointers_original_storage',
+		'fn main() {\n\tmut fixed := [3]int{}\n\tfixed[0] = 1\n\tptrs := unsafe { fixed.pointers() }\n\tunsafe {\n\t\tp0 := &int(ptrs[0])\n\t\t*p0 = 9\n\t}\n\tprintln(int_str(fixed[0]))\n}\n')
+	assert fixed_out == '9'
+	fixed_expr_out := run_good(v3_bin, 'fixed_array_pointers_evaluates_receiver_once',
+		'__global calls int\n\nfn next() int {\n\tcalls = calls + 1\n\treturn 0\n}\n\nfn main() {\n\tmut rows := [1][2]int{}\n\trows[0][0] = 5\n\tptrs := unsafe { rows[next()].pointers() }\n\tunsafe {\n\t\tp0 := &int(ptrs[0])\n\t\t*p0 = 8\n\t}\n\tprintln(int_str(calls))\n\tprintln(int_str(rows[0][0]))\n}\n')
+	assert fixed_expr_out == '1\n8'
+	run_bad(v3_bin, 'fixed_array_pointers_rejects_rvalue_receiver',
+		'fn make_fixed() [2]int {\n\treturn [7, 8]!\n}\n\nfn main() {\n\t_ := unsafe { make_fixed().pointers() }\n}\n',
+		'fixed array receiver for `pointers` must be addressable')
+	run_bad(v3_bin, 'fixed_array_pointers_rejects_map_index_receiver',
+		'fn main() {\n\tmut m := map[string][2]int{}\n\tm["x"] = [1, 2]!\n\t_ := unsafe { m["x"].pointers() }\n}\n',
+		'fixed array receiver for `pointers` must be addressable')
+	fixed_len_expr_out := run_good(v3_bin, 'fixed_array_pointers_folds_len_expr',
+		'const segs = 2\n\nfn main() {\n\tmut const_len := [segs + 1]int{}\n\tconst_ptrs := unsafe { const_len.pointers() }\n\tmut shift_len := [8 >>> 1]int{}\n\tshift_ptrs := unsafe { shift_len.pointers() }\n\tprintln(int_str(const_ptrs.len))\n\tprintln(int_str(shift_ptrs.len))\n}\n')
+	assert fixed_len_expr_out == '3\n4'
+	run_bad(v3_bin, 'fixed_array_pointers_rejects_extra_arg',
+		'fn extra_arg() int {\n\treturn 1\n}\n\nfn main() {\n\tmut fixed := [3]int{}\n\t_ := unsafe { fixed.pointers(extra_arg()) }\n}\n',
+		'argument count mismatch for `fixed.pointers`: expected 1, got 2')
+}
+
+fn test_map_builtin_method_fallback_checks_arguments() {
+	v3_bin := build_v3()
+	run_bad(v3_bin, 'map_keys_rejects_extra_arg',
+		'fn extra_arg() int {\n\treturn 1\n}\n\nfn main() {\n\tmut m := map[string]int{}\n\t_ := m.keys(extra_arg())\n}\n',
+		'argument count mismatch for `m.keys`: expected 1, got 2')
+	run_bad(v3_bin, 'map_delete_rejects_bad_key_type',
+		'fn main() {\n\tmut m := map[string]int{}\n\tm.delete(123)\n}\n',
+		'cannot use `int` as argument 2 to `m.delete`; expected `string`')
+	run_bad(v3_bin, 'map_reserve_rejects_bad_count_type',
+		'fn main() {\n\tmut m := map[string]int{}\n\tm.reserve("bad")\n}\n',
+		'cannot use `string` as argument 2 to `m.reserve`; expected `u32`')
+	out := run_good(v3_bin, 'map_builtin_method_fallback',
+		'fn main() {\n\tmut m := map[string]int{}\n\tm["abc"] = 42\n\tmut moved := m.move()\n\tprintln(int_str(m.len))\n\tmoved.clear()\n\tmoved.reserve(6)\n\tmoved.delete("x")\n\tkeys := moved.keys()\n\tvalues := moved.values()\n\tcloned := moved.clone()\n\tprintln(int_str(keys.len + values.len + cloned.len))\n}\n')
+	assert out == '0\n0'
+	pointer_out := run_good(v3_bin, 'map_move_pointer_receiver_returns_map',
+		'fn take(m map[string]int) int {\n\treturn m.len\n}\n\nfn main() {\n\tmut m := map[string]int{}\n\tm["abc"] = 42\n\tp := &m\n\tprintln(int_str(take(p.move())))\n\tprintln(int_str(m.len))\n}\n')
+	assert pointer_out == '1\n0'
+	exact_out := run_good(v3_bin, 'exact_map_receiver_method_before_builtin',
+		'fn (m map[string]int) keys() int {\n\treturn 77\n}\n\nfn main() {\n\tmut m := map[string]int{}\n\tm["x"] = 1\n\tn := m.keys()\n\tprintln(int_str(n))\n}\n')
+	assert exact_out == '77'
+	alias_rvalue_out := run_good(v3_bin, 'map_alias_rvalue_receiver_method_before_builtin',
+		'type M = map[string]int\n\nfn (m M) delete(k string) int {\n\treturn 66\n}\n\nfn make_m() M {\n\tmut m := M(map[string]int{})\n\tm["x"] = 1\n\treturn m\n}\n\nfn main() {\n\tprintln(int_str(make_m().delete("x")))\n}\n')
+	assert alias_rvalue_out == '66'
+	plain_map_out := run_good(v3_bin, 'plain_map_builtin_not_alias_method',
+		'type M = map[string]int\n\nfn (m M) keys() int {\n\treturn 66\n}\n\nfn main() {\n\tmut m := map[string]int{}\n\tm["x"] = 1\n\tkeys := m.keys()\n\tprintln(int_str(keys.len))\n}\n')
+	assert plain_map_out == '1'
+	module_map_runtime_prefix_out := run_good_project(v3_bin,
+		'map_runtime_prefix_module_receiver_method', {
+		'main.v':           'module main\n\nimport map__utils\n\nfn main() {\n\tprintln(map__utils.run())\n}\n'
+		'map__utils/mod.v': 'module map__utils\n\nfn (m map[string]int) keys() int {\n\treturn 84\n}\n\npub fn run() string {\n\tmut m := map[string]int{}\n\tm["x"] = 1\n\treturn int_str(m.keys())\n}\n'
+	}, 'main.v')
+	assert module_map_runtime_prefix_out == '84'
+	module_map_out := run_good_project(v3_bin, 'map_module_receiver_method', {
+		'main.v':    'module main\n\nimport map\n\nfn main() {\n\tprintln(map.run())\n}\n'
+		'map/mod.v': 'module map\n\nfn (m map[string]int) keys() int {\n\treturn 85\n}\n\npub fn run() string {\n\tmut m := map[string]int{}\n\tm["x"] = 1\n\treturn int_str(m.keys())\n}\n'
+	}, 'main.v')
+	assert module_map_out == '85'
+	fixed_key_out := run_good(v3_bin, 'fixed_array_key_map_receiver_method_before_builtin',
+		'fn (m map[[2]string]int) keys() int {\n\treturn 88\n}\n\nfn main() {\n\tmut m := map[[2]string]int{}\n\tkey := ["a", "b"]!\n\tm[key] = 1\n\tprintln(int_str(m.keys()))\n}\n')
+	assert fixed_key_out == '88'
+	nested_fixed_key_out := run_good(v3_bin, 'nested_fixed_array_key_map_receiver_method',
+		'fn (m map[[3][2]int]int) keys() int {\n\treturn 99\n}\n\nfn main() {\n\tmut m := map[[3][2]int]int{}\n\tkey := [3][2]int{}\n\tm[key] = 1\n\tprintln(int_str(m.keys()))\n}\n')
+	assert nested_fixed_key_out == '99'
+	module_collection_out := run_good_project(v3_bin, 'module_collection_receiver_methods', {
+		'main.v':      'module main\n\nimport thing\n\nfn main() {\n\tprintln(thing.run())\n}\n'
+		'thing/mod.v': 'module thing\n\nstruct Foo {}\nstruct Key {}\n\nfn (m map[string]Foo) keys() int {\n\treturn 31\n}\n\nfn (a []Foo) pointers() int {\n\treturn 42\n}\n\nfn (m map[Key]int) keys() int {\n\treturn 53\n}\n\npub fn run() string {\n\tmut m := map[string]Foo{}\n\tm["x"] = Foo{}\n\titems := [Foo{}]\n\tkeyed := map[Key]int{}\n\treturn int_str(m.keys()) + "\\n" + int_str(items.pointers()) + "\\n" + int_str(keyed.keys())\n}\n'
+	}, 'main.v')
+	assert module_collection_out == '31\n42\n53'
 }

--- a/vlib/v3/tests/transformer_parity_test.v
+++ b/vlib/v3/tests/transformer_parity_test.v
@@ -24,6 +24,22 @@ fn parse_transform_file(src string, source string) &flat.FlatAst {
 	return a
 }
 
+// parse_checked_transform_source reads parse checked transform source input for v3 tests.
+fn parse_checked_transform_source(source string) &flat.FlatAst {
+	src := os.join_path(os.temp_dir(), 'v3_transformer_checked_parity_test.v')
+	os.write_file(src, source) or { panic(err) }
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_file(src)
+	mut tc := types.TypeChecker.new(a)
+	tc.diagnose_unknown_calls = true
+	tc.collect(a)
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	transform.transform(mut a, &tc)
+	return a
+}
+
 // find_fn resolves find fn information for v3 tests.
 fn find_fn(a &flat.FlatAst, name string) flat.Node {
 	for node in a.nodes {
@@ -107,6 +123,25 @@ fn count_call_name(a &flat.FlatAst, id flat.NodeId, name string) int {
 		total += count_call_name(a, a.child(&node, i), name)
 	}
 	return total
+}
+
+fn first_call_arg_opt(a &flat.FlatAst, id flat.NodeId, name string, arg_idx int) ?flat.Node {
+	if int(id) < 0 {
+		return none
+	}
+	node := a.nodes[int(id)]
+	if node.kind == .call && node.children_count > arg_idx + 1 {
+		fn_node := a.child_node(&node, 0)
+		if fn_node.kind == .ident && fn_node.value == name {
+			return *a.child_node(&node, arg_idx + 1)
+		}
+	}
+	for i in 0 .. node.children_count {
+		if found := first_call_arg_opt(a, a.child(&node, i), name, arg_idx) {
+			return found
+		}
+	}
+	return none
 }
 
 // count_infix_op supports count infix op handling for v3 tests.
@@ -600,4 +635,355 @@ fn main() {
 	}
 	assert or_count == 0
 	assert get_check_count == 1
+}
+
+fn test_map_methods_lower_to_runtime_calls() {
+	a := parse_transform_source('
+fn main() {
+	mut m := map[string]int{}
+	m.delete("a")
+	m.clear()
+	m.free()
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut delete_count := 0
+	mut clear_count := 0
+	mut free_count := 0
+	mut selector_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		delete_count += count_call_name(a, child_id, 'map__delete')
+		clear_count += count_call_name(a, child_id, 'map__clear')
+		free_count += count_call_name(a, child_id, 'map__free')
+		selector_count += count_selector_value(a, child_id, 'delete')
+		selector_count += count_selector_value(a, child_id, 'clear')
+		selector_count += count_selector_value(a, child_id, 'free')
+	}
+	assert delete_count == 1
+	assert clear_count == 1
+	assert free_count == 1
+	assert selector_count == 0
+}
+
+fn test_map_delete_fixed_array_key_uses_full_key_type() {
+	a := parse_transform_source('
+fn main() {
+	mut m := map[[2]string]int{}
+	key := ["foo", "bar"]!
+	m[key] = 5
+	m.delete(key)
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut key_tmp := ''
+	mut delete_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		delete_count += count_call_name(a, child_id, 'map__delete')
+		if arg := first_call_arg_opt(a, child_id, 'map__delete', 1) {
+			assert arg.kind == .prefix
+			assert arg.op == .amp
+			ident := a.child_node(&arg, 0)
+			assert ident.kind == .ident
+			key_tmp = ident.value
+		}
+	}
+	assert delete_count == 1
+	assert key_tmp.len > 0
+	mut found_key_decl := false
+	for i in 0 .. main_fn.children_count {
+		stmt := a.child_node(&main_fn, i)
+		if stmt.kind == .decl_assign && stmt.children_count >= 2 {
+			lhs := a.child_node(stmt, 0)
+			if lhs.kind == .ident && lhs.value == key_tmp {
+				assert stmt.typ == '[2]string'
+				found_key_decl = true
+			}
+		}
+	}
+	assert found_key_decl
+}
+
+fn test_exact_map_receiver_method_wins_over_builtin_lowering() {
+	a := parse_checked_transform_source('
+fn (m map[string]int) keys() int {
+	return 7
+}
+
+fn main() {
+	mut m := map[string]int{}
+	n := m.keys()
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut exact_count := 0
+	mut builtin_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		exact_count += count_call_name(a, child_id, 'map[string]int.keys')
+		exact_count += count_call_name(a, child_id, 'main.map[string]int.keys')
+		builtin_count += count_call_name(a, child_id, 'map__keys')
+		builtin_count += count_call_name(a, child_id, 'map.keys')
+	}
+	assert exact_count == 1
+	assert builtin_count == 0
+}
+
+fn test_channel_close_lowers_to_runtime_call() {
+	a := parse_transform_source('
+fn main() {
+	ch := chan bool{cap: 1}
+	ch.close()
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut close_count := 0
+	mut selector_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		close_count += count_call_name(a, child_id, 'sync__Channel__close')
+		close_count += count_selector_value(a, child_id, 'sync__Channel__close')
+		selector_count += count_selector_value(a, child_id, 'close')
+	}
+	assert close_count == 1
+	assert selector_count == 0
+}
+
+fn test_static_assoc_call_lowers_to_direct_call() {
+	a := parse_checked_transform_source('
+struct Tool {}
+
+fn Tool.make(x int) int {
+	return x
+}
+
+fn main() {
+	n := Tool.make(7)
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut direct_count := 0
+	mut selector_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		direct_count += count_call_name(a, child_id, 'Tool.make')
+		selector_count += count_selector_value(a, child_id, 'make')
+	}
+	assert direct_count == 1
+	assert selector_count == 0
+}
+
+fn test_array_builtin_method_fallback_lowers_to_direct_call() {
+	a := parse_checked_transform_source('
+@[unsafe]
+fn (a array) pointers() []voidptr {
+	return []voidptr{}
+}
+
+fn main() {
+	nums := [1, 2, 3]
+	unsafe {
+		ptrs := nums.pointers()
+	}
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut direct_count := 0
+	mut selector_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		direct_count += count_call_name(a, child_id, 'array.pointers')
+		selector_count += count_selector_value(a, child_id, 'pointers')
+	}
+	assert direct_count == 1
+	assert selector_count == 0
+}
+
+fn test_array_reverse_pointer_receiver_derefs_before_runtime_call() {
+	a := parse_transform_source('
+fn main() {
+	mut nums := []int{}
+	nums << 1
+	p := &nums
+	rev := p.reverse()
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut direct_count := 0
+	mut selector_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		direct_count += count_call_name(a, child_id, 'array__reverse')
+		selector_count += count_selector_value(a, child_id, 'reverse')
+	}
+	assert direct_count == 1
+	assert selector_count == 0
+	mut arg := flat.Node{}
+	mut found_arg := false
+	for i in 0 .. main_fn.children_count {
+		if candidate := first_call_arg_opt(a, a.child(&main_fn, i), 'array__reverse', 0) {
+			arg = candidate
+			found_arg = true
+			break
+		}
+	}
+	assert found_arg
+	assert arg.kind == .prefix
+	assert arg.op == .mul
+	assert arg.children_count == 1
+	ident := a.child_node(&arg, 0)
+	assert ident.kind == .ident
+	assert ident.value == 'p'
+}
+
+fn test_fixed_array_pointers_uses_intrinsic_without_copy() {
+	a := parse_checked_transform_source('
+@[unsafe]
+fn (a array) pointers() []voidptr {
+	return []voidptr{}
+}
+
+fn main() {
+	mut fixed := [3]int{}
+	unsafe {
+		ptrs := fixed.pointers()
+	}
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut direct_count := 0
+	mut copy_count := 0
+	mut selector_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		direct_count += count_call_name(a, child_id, 'array.pointers')
+		copy_count += count_call_name(a, child_id, 'new_array_from_c_array')
+		selector_count += count_selector_value(a, child_id, 'pointers')
+	}
+	assert direct_count == 1
+	assert copy_count == 0
+	assert selector_count == 0
+}
+
+fn test_fixed_array_dynamic_receiver_method_wins_over_array_builtin() {
+	a := parse_checked_transform_source('
+@[unsafe]
+fn (a array) pointers() []voidptr {
+	return []voidptr{}
+}
+
+fn (a []int) pointers() int {
+	return 7
+}
+
+fn main() {
+	mut fixed := [3]int{}
+	n := fixed.pointers()
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut dynamic_count := 0
+	mut builtin_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		dynamic_count += count_call_name(a, child_id, '[]int.pointers')
+		dynamic_count += count_call_name(a, child_id, 'main.[]int.pointers')
+		builtin_count += count_call_name(a, child_id, 'array.pointers')
+	}
+	assert dynamic_count == 1
+	assert builtin_count == 0
+}
+
+fn test_exact_array_receiver_method_wins_over_builtin_fallback() {
+	a := parse_checked_transform_source('
+@[unsafe]
+fn (a array) pointers() []voidptr {
+	return []voidptr{}
+}
+
+fn (a []int) pointers() []int {
+	return a
+}
+
+fn main() {
+	mut nums := []int{}
+	nums << 1
+	nums << 2
+	nums << 3
+	ptrs := nums.pointers()
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut exact_count := 0
+	mut builtin_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		exact_count += count_call_name(a, child_id, '[]int.pointers')
+		exact_count += count_call_name(a, child_id, 'main.[]int.pointers')
+		builtin_count += count_call_name(a, child_id, 'array.pointers')
+	}
+	assert exact_count == 1
+	assert builtin_count == 0
+}
+
+fn test_pointer_rvalue_arg_lowers_to_temp_address() {
+	a := parse_checked_transform_source('
+fn make_int() int {
+	return 7
+}
+
+fn takes_ptr(x &int) int {
+	return *x
+}
+
+fn main() {
+	y := takes_ptr(make_int())
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut call_count := 0
+	mut make_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		call_count += count_call_name(a, child_id, 'takes_ptr')
+		make_count += count_call_name(a, child_id, 'make_int')
+	}
+	assert call_count == 1
+	assert make_count == 1
+	mut arg := flat.Node{}
+	mut found_arg := false
+	for i in 0 .. main_fn.children_count {
+		if candidate := first_call_arg_opt(a, a.child(&main_fn, i), 'takes_ptr', 0) {
+			arg = candidate
+			found_arg = true
+			break
+		}
+	}
+	assert found_arg
+	assert arg.kind == .prefix
+	assert arg.op == .amp
+	assert arg.children_count == 1
+	ident := a.child_node(&arg, 0)
+	assert ident.kind == .ident
+	assert ident.value.starts_with('__ptr_arg_')
+}
+
+fn test_map_values_membership_lowers_without_type_annotation() {
+	a := parse_checked_transform_source('
+fn main() {
+	mut names := map[string]string{}
+	found := "alex" in names.values()
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut in_count := 0
+	mut for_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		in_count += count_kind(a, child_id, .in_expr)
+		for_count += count_kind(a, child_id, .for_stmt)
+	}
+	assert in_count == 0
+	assert for_count == 1
 }

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -8,10 +8,14 @@ const v3_src = os.join_path(v3_dir, 'v3.v')
 
 // build_v3 builds v3 data for v3 tests.
 fn build_v3() string {
-	v3_bin := os.join_path(os.temp_dir(), 'v3_type_checker_errors_test')
+	v3_bin := tmp_test_path('type_checker_errors_test')
 	build := os.execute('${vexe} -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0
 	return v3_bin
+}
+
+fn tmp_test_path(name string) string {
+	return os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
 }
 
 // run_bad supports run bad handling for v3 tests.
@@ -24,9 +28,9 @@ fn run_bad_selfhost(v3_bin string, name string, src string, expected string) {
 }
 
 fn run_bad_with_flags(v3_bin string, name string, src string, expected string, flags string) {
-	bad_src := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	bad_src := '${tmp_test_path(name)}.v'
 	os.write_file(bad_src, src) or { panic(err) }
-	bad_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	bad_bin := tmp_test_path(name)
 	result := os.execute('${v3_bin} ${bad_src} ${flags} -b c -o ${bad_bin}')
 	assert result.exit_code != 0
 	assert result.output.contains(expected)
@@ -35,9 +39,9 @@ fn run_bad_with_flags(v3_bin string, name string, src string, expected string, f
 
 // run_good supports run good handling for v3 tests.
 fn run_good(v3_bin string, name string, src string) string {
-	good_src := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	good_src := '${tmp_test_path(name)}.v'
 	os.write_file(good_src, src) or { panic(err) }
-	good_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	good_bin := tmp_test_path(name)
 	compile := os.execute('${v3_bin} ${good_src} -b c -o ${good_bin}')
 	assert compile.exit_code == 0, '${name}: compile failed: ${compile.output}'
 	assert !compile.output.contains('C compilation failed'), '${name}: C compilation failed: ${compile.output}'
@@ -55,7 +59,7 @@ fn write_project_file(root string, rel string, src string) {
 
 // run_bad_project supports run bad project handling for v3 tests.
 fn run_bad_project(v3_bin string, name string, files map[string]string, input string, expected string) {
-	root := os.join_path(os.temp_dir(), 'v3_${name}_project')
+	root := '${tmp_test_path(name)}_project'
 	if os.exists(root) {
 		os.rmdir_all(root) or { panic(err) }
 	}
@@ -64,7 +68,7 @@ fn run_bad_project(v3_bin string, name string, files map[string]string, input st
 		write_project_file(root, rel, src)
 	}
 	input_path := if input.len == 0 { root } else { os.join_path(root, input) }
-	bad_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	bad_bin := tmp_test_path(name)
 	result := os.execute('${v3_bin} ${input_path} -b c -o ${bad_bin}')
 	assert result.exit_code != 0
 	assert result.output.contains(expected)
@@ -73,7 +77,7 @@ fn run_bad_project(v3_bin string, name string, files map[string]string, input st
 
 // run_good_project supports run good project handling for v3 tests.
 fn run_good_project(v3_bin string, name string, files map[string]string, input string) string {
-	root := os.join_path(os.temp_dir(), 'v3_${name}_project')
+	root := '${tmp_test_path(name)}_project'
 	if os.exists(root) {
 		os.rmdir_all(root) or { panic(err) }
 	}
@@ -82,7 +86,7 @@ fn run_good_project(v3_bin string, name string, files map[string]string, input s
 		write_project_file(root, rel, src)
 	}
 	input_path := if input.len == 0 { root } else { os.join_path(root, input) }
-	good_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	good_bin := tmp_test_path(name)
 	compile := os.execute('${v3_bin} ${input_path} -b c -o ${good_bin}')
 	assert compile.exit_code == 0, '${name}: compile failed: ${compile.output}'
 	assert !compile.output.contains('C compilation failed'), '${name}: C compilation failed: ${compile.output}'
@@ -93,7 +97,7 @@ fn run_good_project(v3_bin string, name string, files map[string]string, input s
 
 // gen_c_project emits c project output for v3 tests.
 fn gen_c_project(v3_bin string, name string, files map[string]string, input string) string {
-	root := os.join_path(os.temp_dir(), 'v3_${name}_project')
+	root := '${tmp_test_path(name)}_project'
 	if os.exists(root) {
 		os.rmdir_all(root) or { panic(err) }
 	}
@@ -102,7 +106,7 @@ fn gen_c_project(v3_bin string, name string, files map[string]string, input stri
 		write_project_file(root, rel, src)
 	}
 	input_path := if input.len == 0 { root } else { os.join_path(root, input) }
-	c_out := os.join_path(os.temp_dir(), 'v3_${name}.c')
+	c_out := '${tmp_test_path(name)}.c'
 	os.rm(c_out) or {}
 	compile := os.execute('${v3_bin} ${input_path} -o ${c_out}')
 	assert compile.exit_code == 0

--- a/vlib/v3/transform/array.v
+++ b/vlib/v3/transform/array.v
@@ -10,12 +10,14 @@ fn (mut t Transformer) make_array_new_call(elem_type string, len_expr flat.NodeI
 }
 
 fn (mut t Transformer) make_array_push_many_call(lhs_addr flat.NodeId, rhs flat.NodeId, rhs_type string) flat.NodeId {
+	t.mark_fn_used('array__push_many')
 	rhs_value := t.stable_transformed_expr_for_reuse(rhs, rhs_type, 'push_many')
 	return t.make_call_typed('array__push_many', arr3(lhs_addr, t.make_selector(rhs_value, 'data',
 		'voidptr'), t.make_selector(rhs_value, 'len', 'int')), 'void')
 }
 
 fn (mut t Transformer) make_array_clone_call(base_id flat.NodeId, base_type string) flat.NodeId {
+	t.mark_fn_used('array__clone')
 	receiver := t.transform_expr(base_id)
 	return t.make_call_typed('array__clone', arr1(t.runtime_addr(receiver, base_type)), base_type)
 }
@@ -304,6 +306,9 @@ fn (mut t Transformer) lower_array_prepend_call(node flat.Node, fn_node flat.Nod
 	}
 	value_name := t.new_temp('arr_val')
 	t.pending_stmts << t.make_decl_assign_typed(value_name, value, elem_type)
+	t.mark_fn_used('array__prepend')
+	t.mark_fn_used('array__insert')
+	t.mark_fn_used('array__needs_unique_shift')
 	return t.make_call_typed('array__prepend', arr2(t.runtime_addr(base, base_type), t.make_prefix(.amp,
 		t.make_ident(value_name))), 'void')
 }
@@ -325,6 +330,8 @@ fn (mut t Transformer) lower_array_insert_call(node flat.Node, fn_node flat.Node
 	}
 	value_name := t.new_temp('arr_val')
 	t.pending_stmts << t.make_decl_assign_typed(value_name, value, elem_type)
+	t.mark_fn_used('array__insert')
+	t.mark_fn_used('array__needs_unique_shift')
 	return t.make_call_typed('array__insert', arr3(t.runtime_addr(base, base_type), index, t.make_prefix(.amp,
 		t.make_ident(value_name))), 'void')
 }
@@ -338,6 +345,7 @@ fn (mut t Transformer) lower_array_push_many_call(node flat.Node, fn_node flat.N
 	count_id := t.a.child(&node, 2)
 	base := t.transform_lvalue(base_id)
 	base_addr := t.runtime_addr(base, base_type)
+	t.mark_fn_used('array__push_many')
 	if t.push_many_count_is_type_name(count_id) {
 		value := if elem_type in t.sum_types || t.resolve_sum_name(elem_type) in t.sum_types {
 			t.wrap_sum_value(value_id, elem_type)

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1296,6 +1296,14 @@ pub fn (mut t Transformer) make_call_typed(fn_name string, args []flat.NodeId, t
 	return t.make_call_expr_typed(fn_ident, args, typ)
 }
 
+fn (mut t Transformer) mark_fn_used(fn_name string) {
+	if fn_name.len == 0 || t.used_fns.len == 0 {
+		return
+	}
+	t.used_fns[fn_name] = true
+	t.used_fns[c_name(fn_name)] = true
+}
+
 // make_call_expr_typed builds make call expr typed data for transform.
 pub fn (mut t Transformer) make_call_expr_typed(fn_expr flat.NodeId, args []flat.NodeId, typ string) flat.NodeId {
 	start := t.a.children.len

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -120,6 +120,36 @@ fn (t &Transformer) resolve_receiver_method_name(base_id flat.NodeId, method str
 	return ''
 }
 
+fn (t &Transformer) resolve_collection_receiver_method_name(base_id flat.NodeId, method string, clean_base_type string) string {
+	if method.len == 0 {
+		return ''
+	}
+	if raw_var_type := t.raw_var_type_for_expr(base_id) {
+		raw_clean := if raw_var_type.starts_with('&') { raw_var_type[1..] } else { raw_var_type }
+		if raw_clean.len > 0 && raw_clean != clean_base_type {
+			if method_name := t.resolve_receiver_method_for_type(raw_clean, method) {
+				return method_name
+			}
+		}
+	}
+	if raw_const_type := t.raw_const_type_name_for_expr(base_id) {
+		raw_clean := if raw_const_type.starts_with('&') {
+			raw_const_type[1..]
+		} else {
+			raw_const_type
+		}
+		if raw_clean.len > 0 && raw_clean != clean_base_type {
+			if method_name := t.resolve_receiver_method_for_type(raw_clean, method) {
+				return method_name
+			}
+		}
+	}
+	if method_name := t.resolve_receiver_method_for_type(clean_base_type, method) {
+		return method_name
+	}
+	return ''
+}
+
 // resolve_receiver_method_for_type resolves resolve_receiver_method_for_type logic in transform.
 fn (t &Transformer) resolve_receiver_method_for_type(receiver_type string, method string) ?string {
 	mut clean_type := receiver_type
@@ -149,6 +179,11 @@ fn (t &Transformer) resolve_receiver_method_for_type(receiver_type string, metho
 			qualified_array := '${elem_type.all_before_last('.')}.[]${short_elem}.${method}'
 			if t.is_known_fn_name(qualified_array) {
 				return qualified_array
+			}
+		} else if transform_can_prefix_collection_receiver(t.cur_module) {
+			current_module_array := '${t.cur_module}.[]${short_elem}.${method}'
+			if t.is_known_fn_name(current_module_array) {
+				return current_module_array
 			}
 		}
 	} else if clean_type.contains('.') {
@@ -488,10 +523,11 @@ fn (mut t Transformer) try_lower_join_path_call(id flat.NodeId, node flat.Node) 
 	if node.children_count <= 1 {
 		return t.make_string_literal('')
 	}
+	t.mark_fn_used('os.join_path_single')
 	mut result := t.transform_expr(t.a.child(&node, 1))
 	for i in 2 .. node.children_count {
 		arg := t.transform_expr(t.a.child(&node, i))
-		result = t.make_call_typed('join_path_single', arr2(result, arg), 'string')
+		result = t.make_call_typed('os.join_path_single', arr2(result, arg), 'string')
 	}
 	return result
 }
@@ -611,20 +647,96 @@ fn (t &Transformer) static_assoc_fn_name(base_id flat.NodeId, method string) ?st
 	}
 	base := t.a.nodes[int(base_id)]
 	if base.kind == .ident {
-		name := '${base.value}.${method}'
-		if t.is_known_fn_name(name) {
-			return name
+		if base.value == 'C' || t.is_import_alias_ident(base_id) {
+			return none
 		}
-	} else if base.kind == .selector && base.children_count > 0 {
-		inner := t.a.child_node(&base, 0)
-		if inner.kind == .ident {
-			name := '${inner.value}.${base.value}.${method}'
+		for type_name in t.static_assoc_type_candidates(base.value) {
+			name := '${type_name}.${method}'
 			if t.is_known_fn_name(name) {
 				return name
 			}
 		}
+	} else if base.kind == .selector && base.children_count > 0 {
+		inner := t.a.child_node(&base, 0)
+		if inner.kind == .ident {
+			type_ident := '${inner.value}.${base.value}'
+			for type_name in t.static_assoc_type_candidates(type_ident) {
+				name := '${type_name}.${method}'
+				if t.is_known_fn_name(name) {
+					return name
+				}
+			}
+		}
 	}
 	return none
+}
+
+fn (t &Transformer) is_import_alias_ident(id flat.NodeId) bool {
+	if int(id) < 0 || isnil(t.tc) {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	return node.kind == .ident && node.value in t.tc.imports
+}
+
+fn (t &Transformer) static_assoc_type_candidates(type_ident string) []string {
+	if type_ident.len == 0 {
+		return []string{}
+	}
+	mut candidates := []string{}
+	candidates << type_ident
+	if !type_ident.contains('.') && t.cur_module.len > 0 && t.cur_module != 'main'
+		&& t.cur_module != 'builtin' {
+		candidates << '${t.cur_module}.${type_ident}'
+	}
+	if !isnil(t.tc) {
+		qname := t.tc.qualify_name(type_ident)
+		if qname !in candidates {
+			candidates << qname
+		}
+	}
+	mut result := []string{}
+	for candidate in candidates {
+		if t.is_static_assoc_type_name(candidate) && candidate !in result {
+			result << candidate
+		}
+	}
+	return result
+}
+
+fn (t &Transformer) is_static_assoc_type_name(type_name string) bool {
+	if type_name in t.structs || type_name in t.enum_types || type_name in t.sum_types {
+		return true
+	}
+	if isnil(t.tc) {
+		return false
+	}
+	return type_name in t.tc.structs || type_name in t.tc.enum_names || type_name in t.tc.sum_types
+		|| type_name in t.tc.interface_names || type_name in t.tc.type_aliases
+}
+
+// try_lower_static_assoc_call lowers `Type.method(args)` to a direct call to
+// `Type.method(args)` once the checker/transformer has proven that the base is a
+// type, not a value receiver.
+fn (mut t Transformer) try_lower_static_assoc_call(id flat.NodeId, node flat.Node) ?flat.NodeId {
+	if node.children_count == 0 {
+		return none
+	}
+	fn_id := t.a.child(&node, 0)
+	fn_node := t.a.nodes[int(fn_id)]
+	if fn_node.kind != .selector || fn_node.children_count == 0 {
+		return none
+	}
+	base_id := t.a.child(&fn_node, 0)
+	static_fn := t.static_assoc_fn_name(base_id, fn_node.value) or { return none }
+	normalized := t.transform_call_args(id, node)
+	normalized_node := t.a.nodes[int(normalized)]
+	mut args := []flat.NodeId{cap: int(normalized_node.children_count) - 1}
+	for i in 1 .. normalized_node.children_count {
+		args << t.a.child(&normalized_node, i)
+	}
+	ret_type := t.receiver_method_return_type(static_fn, node.typ)
+	return t.make_call_typed(static_fn, args, ret_type)
 }
 
 // call_param_types updates call param types state for Transformer.
@@ -704,6 +816,9 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 		t.pending_stmts << t.make_decl_assign_typed(tmp_name, wrapped, target_sum)
 		return t.make_prefix(.amp, t.make_ident(tmp_name))
 	}
+	if ptr_arg := t.transform_pointer_rvalue_arg(arg_id, *arg_node, param_type) {
+		return ptr_arg
+	}
 	if t.is_sum_type_name(param_type) {
 		return t.wrap_sum_value(arg_id, param_type)
 	}
@@ -719,8 +834,53 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 	return t.transform_expr_for_type(arg_id, param_type)
 }
 
+fn (mut t Transformer) transform_pointer_rvalue_arg(arg_id flat.NodeId, arg_node flat.Node, param_type string) ?flat.NodeId {
+	if !param_type.starts_with('&') {
+		return none
+	}
+	mut value_id := arg_id
+	mut value_node := arg_node
+	if arg_node.kind == .prefix && arg_node.op == .amp && arg_node.children_count > 0 {
+		value_id = t.a.child(&arg_node, 0)
+		value_node = t.a.nodes[int(value_id)]
+	}
+	if !is_pointer_arg_temp_rvalue(value_node) {
+		return none
+	}
+	value_type := param_type[1..]
+	if value_type.len == 0 || value_type == 'void' || value_type == 'unknown' {
+		return none
+	}
+	arg_type := t.node_type(value_id)
+	if arg_type.len == 0 || arg_type == 'void' || arg_type == 'unknown'
+		|| is_pointer_like_type_name(arg_type) {
+		return none
+	}
+	value := t.transform_expr_for_type(value_id, value_type)
+	tmp_name := t.new_temp('ptr_arg')
+	t.pending_stmts << t.make_decl_assign_typed(tmp_name, value, value_type)
+	addr := t.make_prefix(.amp, t.make_ident(tmp_name))
+	t.a.nodes[int(addr)].typ = param_type
+	return addr
+}
+
+fn is_pointer_arg_temp_rvalue(node flat.Node) bool {
+	return node.kind == .call || (node.kind == .index && node.value == 'range')
+}
+
+fn is_pointer_like_type_name(typ string) bool {
+	mut clean := typ
+	if clean.starts_with('mut ') {
+		clean = clean[4..]
+	}
+	return clean.starts_with('&') || clean in ['voidptr', 'byteptr', 'charptr']
+}
+
 fn (mut t Transformer) append_missing_params_struct_args(mut args []flat.NodeId, params []types.Type, param_offset int) {
-	mut param_idx := args.len - 1 + param_offset
+	mut param_idx := param_offset
+	if args.len > 0 {
+		param_idx = args.len - 1 + param_offset
+	}
 	for param_idx < params.len {
 		param_type := params[param_idx].name()
 		struct_type := t.params_struct_type_name(param_type) or { break }
@@ -1085,8 +1245,8 @@ fn int_stringify_rank(typ string) int {
 
 // is_numeric_stringify_type reports whether is numeric stringify type applies in transform.
 fn (t &Transformer) is_numeric_stringify_type(typ string) bool {
-	is_number := typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'usize', 'u8', 'byte', 'u16',
-		'u32', 'u64', 'f32', 'f64', 'rune']
+	is_number := typ in ['int', 'int literal', 'i8', 'i16', 'i32', 'i64', 'isize', 'usize', 'u8',
+		'byte', 'u16', 'u32', 'u64', 'f32', 'f64', 'float literal', 'rune']
 	return is_number || typ in t.enum_types
 }
 
@@ -1247,14 +1407,14 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 			return t.make_call_typed('strconv__format_uint', arr2(expr, t.make_int_literal(10)),
 				'string')
 		}
-		'int', 'i8', 'i16', 'i32', 'i64', 'isize', 'usize' {
+		'int', 'int literal', 'i8', 'i16', 'i32', 'i64', 'isize', 'usize' {
 			return t.make_call_typed('strconv__format_int', arr2(expr, t.make_int_literal(10)),
 				'string')
 		}
 		'f32' {
 			return t.make_call_typed('strconv__f32_to_str_l', arr1(expr), 'string')
 		}
-		'f64' {
+		'f64', 'float literal' {
 			return t.make_call_typed('strconv__f64_to_str_l', arr1(expr), 'string')
 		}
 		else {
@@ -1480,7 +1640,10 @@ fn (mut t Transformer) try_lower_flag_enum_call(node flat.Node) ?flat.NodeId {
 	if t.is_runtime_array_flags_selector(base_id) {
 		return none
 	}
-	base_type := t.node_type(base_id)
+	mut base_type := t.node_type(base_id)
+	if base_type.len == 0 {
+		base_type = t.lvalue_type(base_id)
+	}
 	if !t.is_flag_enum_type(base_type) {
 		return none
 	}
@@ -1496,7 +1659,7 @@ fn (mut t Transformer) try_lower_flag_enum_call(node flat.Node) ?flat.NodeId {
 }
 
 // try_lower_array_method_call supports try lower array method call handling for Transformer.
-fn (mut t Transformer) try_lower_array_method_call(node flat.Node) ?flat.NodeId {
+fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node flat.Node) ?flat.NodeId {
 	if node.children_count == 0 {
 		return none
 	}
@@ -1505,15 +1668,22 @@ fn (mut t Transformer) try_lower_array_method_call(node flat.Node) ?flat.NodeId 
 	if fn_node.kind != .selector || fn_node.children_count == 0 {
 		return none
 	}
+	array_builtin_method := t.array_builtin_method_name(fn_node.value) or { '' }
 	if fn_node.value !in ['clone', 'reverse', 'contains', 'index', 'join', 'any', 'all', 'count',
 		'equals', 'prepend', 'insert', 'push_many'] {
-		if fn_node.value !in ['filter', 'map', 'sort', 'sorted', 'sort_with_compare',
-			'sorted_with_compare'] {
+		if fn_node.value !in ['filter', 'map', 'sort', 'sorted', 'sort_with_compare', 'sorted_with_compare']
+			&& array_builtin_method.len == 0 {
 			return none
 		}
 	}
 	base_id := t.a.children[fn_node.children_start]
 	mut base_type := t.node_type(base_id)
+	if (!base_type.starts_with('[]') && !t.is_fixed_array_type(base_type)) || base_type == 'array' {
+		lvalue_base_type := t.lvalue_type(base_id)
+		if lvalue_base_type.starts_with('[]') || t.is_fixed_array_type(lvalue_base_type) {
+			base_type = lvalue_base_type
+		}
+	}
 	if !base_type.starts_with('[]') && !t.is_fixed_array_type(base_type) {
 		base_node := t.a.nodes[int(base_id)]
 		if base_node.kind in [.call, .selector, .as_expr] {
@@ -1537,11 +1707,31 @@ fn (mut t Transformer) try_lower_array_method_call(node flat.Node) ?flat.NodeId 
 					pos:            node.pos
 					typ:            node.typ
 				}
-				return t.try_lower_array_method_call(new_node)
+				return t.try_lower_array_method_call(call_id, new_node)
 			}
 		}
 	}
 	clean_base_type := if base_type.starts_with('&') { base_type[1..] } else { base_type }
+	if t.is_fixed_array_type(clean_base_type) && fn_node.value == 'pointers'
+		&& array_builtin_method.len > 0 {
+		method_name := t.resolve_receiver_method_name(base_id, fn_node.value)
+		if method_name.len > 0 && method_name != array_builtin_method
+			&& t.call_resolved_to_method(call_id, method_name) {
+			args := t.transform_receiver_method_args(node, base_id, method_name)
+			ret_type := t.receiver_method_return_type(method_name, node.typ)
+			t.mark_fn_used(method_name)
+			return t.make_call_typed(method_name, args, ret_type)
+		}
+		if dynamic_method := t.resolve_fixed_array_dynamic_receiver_method(clean_base_type,
+			fn_node.value)
+		{
+			return t.lower_fixed_array_dynamic_receiver_method_call(node, base_id, clean_base_type,
+				dynamic_method)
+		}
+		args := t.transform_receiver_method_args(node, base_id, array_builtin_method)
+		ret_type := t.receiver_method_return_type(array_builtin_method, node.typ)
+		return t.make_call_typed(array_builtin_method, args, ret_type)
+	}
 	if t.is_fixed_array_type(clean_base_type) {
 		elem_type := fixed_array_elem_type(clean_base_type)
 		array_type := '[]${elem_type}'
@@ -1565,10 +1755,15 @@ fn (mut t Transformer) try_lower_array_method_call(node flat.Node) ?flat.NodeId 
 			pos:            node.pos
 			typ:            node.typ
 		}
-		return t.try_lower_array_method_call(new_node)
+		return t.try_lower_array_method_call(call_id, new_node)
 	}
 	if !clean_base_type.starts_with('[]') {
 		return none
+	}
+	if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id,
+		array_builtin_method)
+	{
+		return exact_call
 	}
 	elem_type := clean_base_type[2..]
 	if fn_node.value == 'prepend' {
@@ -1582,9 +1777,10 @@ fn (mut t Transformer) try_lower_array_method_call(node flat.Node) ?flat.NodeId 
 	}
 	if fn_node.value == 'contains' {
 		method_name := t.resolve_receiver_method_name(base_id, fn_node.value)
-		if method_name.len > 0 {
+		if method_name.len > 0 && t.call_resolved_to_method(call_id, method_name) {
 			args := t.transform_receiver_method_args(node, base_id, method_name)
 			ret_type := t.receiver_method_return_type(method_name, node.typ)
+			t.mark_fn_used(method_name)
 			return t.make_call_typed(method_name, args, ret_type)
 		}
 	}
@@ -1618,8 +1814,9 @@ fn (mut t Transformer) try_lower_array_method_call(node flat.Node) ?flat.NodeId 
 				return none
 			}
 			method_name := t.resolve_receiver_method_name(base_id, 'equals')
-			if method_name.len > 0 {
+			if method_name.len > 0 && t.call_resolved_to_method(call_id, method_name) {
 				args := t.transform_receiver_method_args(node, base_id, method_name)
+				t.mark_fn_used(method_name)
 				return t.make_call_typed(method_name, args, 'bool')
 			}
 			receiver := t.transform_expr(base_id)
@@ -1635,12 +1832,25 @@ fn (mut t Transformer) try_lower_array_method_call(node flat.Node) ?flat.NodeId 
 
 	match fn_node.value {
 		'clone' {
+			method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value,
+				clean_base_type)
+			if method_name.len > 0 && t.call_resolved_to_method(call_id, method_name) {
+				args := t.transform_receiver_method_args(node, base_id, method_name)
+				ret_type := t.receiver_method_return_type(method_name, node.typ)
+				t.mark_fn_used(method_name)
+				return t.make_call_typed(method_name, args, ret_type)
+			}
 			receiver := t.transform_expr(base_id)
+			t.mark_fn_used('array__clone')
 			return t.make_call_typed('array__clone', arr1(t.runtime_addr(receiver, base_type)),
 				clean_base_type)
 		}
 		'reverse' {
-			receiver := t.transform_expr(base_id)
+			mut receiver := t.transform_expr(base_id)
+			if base_type.starts_with('&') {
+				receiver = t.make_prefix(.mul, receiver)
+				t.a.nodes[int(receiver)].typ = clean_base_type
+			}
 			return t.make_call_typed('array__reverse', arr1(receiver), clean_base_type)
 		}
 		'contains' {
@@ -1682,20 +1892,58 @@ fn (mut t Transformer) try_lower_array_method_call(node flat.Node) ?flat.NodeId 
 			return t.make_call_typed('Array_string__join', arr2(receiver, arg), 'string')
 		}
 		else {
+			if array_method_stays_in_cgen(fn_node.value) {
+				method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value,
+					clean_base_type)
+				if method_name.len > 0 && method_name != array_builtin_method
+					&& t.call_resolved_to_method(call_id, method_name) {
+					args := t.transform_receiver_method_args(node, base_id, method_name)
+					ret_type := t.receiver_method_return_type(method_name, node.typ)
+					t.mark_fn_used(method_name)
+					return t.make_call_typed(method_name, args, ret_type)
+				}
+				return none
+			}
+			if array_builtin_method.len > 0 {
+				method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value,
+					clean_base_type)
+				if method_name.len > 0 && method_name != array_builtin_method {
+					args := t.transform_receiver_method_args(node, base_id, method_name)
+					ret_type := t.receiver_method_return_type(method_name, node.typ)
+					t.mark_fn_used(method_name)
+					return t.make_call_typed(method_name, args, ret_type)
+				}
+				args := t.transform_receiver_method_args(node, base_id, array_builtin_method)
+				ret_type := t.receiver_method_return_type(array_builtin_method, node.typ)
+				return t.make_call_typed(array_builtin_method, args, ret_type)
+			}
 			return none
 		}
 	}
 }
 
+fn (t &Transformer) array_builtin_method_name(method string) ?string {
+	method_name := 'array.${method}'
+	if t.is_known_fn_name(method_name) {
+		return method_name
+	}
+	return none
+}
+
+fn array_method_stays_in_cgen(method string) bool {
+	return method in ['last', 'first', 'delete_last', 'pop', 'clear', 'repeat', 'repeat_to_depth',
+		'trim', 'ensure_cap', 'delete', 'free', 'str', 'bytestr', 'wait']
+}
+
 // try_lower_map_method_call supports try lower map method call handling for Transformer.
-fn (mut t Transformer) try_lower_map_method_call(node flat.Node) ?flat.NodeId {
+fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.Node) ?flat.NodeId {
 	if node.children_count == 0 {
 		return none
 	}
 	fn_id := t.a.children[node.children_start]
 	fn_node := t.a.nodes[int(fn_id)]
 	if fn_node.kind != .selector || fn_node.children_count == 0
-		|| fn_node.value !in ['keys', 'values'] {
+		|| fn_node.value !in ['keys', 'values', 'delete', 'clear', 'free', 'move', 'reserve'] {
 		return none
 	}
 	base_id := t.a.children[fn_node.children_start]
@@ -1703,6 +1951,54 @@ fn (mut t Transformer) try_lower_map_method_call(node flat.Node) ?flat.NodeId {
 	clean_type := t.clean_map_type(base_type)
 	if !clean_type.starts_with('map[') {
 		return none
+	}
+	builtin_method := 'map.${fn_node.value}'
+	if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id,
+		builtin_method)
+	{
+		return exact_call
+	}
+	method_name := t.resolve_receiver_method_name(base_id, fn_node.value)
+	if method_name.len > 0 && method_name != builtin_method
+		&& t.call_resolved_to_method(call_id, method_name) {
+		args := t.transform_receiver_method_args(node, base_id, method_name)
+		ret_type := t.receiver_method_return_type(method_name, node.typ)
+		t.mark_fn_used(method_name)
+		return t.make_call_typed(method_name, args, ret_type)
+	}
+	base := t.transform_expr(base_id)
+	if fn_node.value in ['clear', 'free'] {
+		t.mark_fn_used('map__${fn_node.value}')
+		return t.make_call_typed('map__${fn_node.value}', arr1(t.runtime_addr(base, base_type)),
+			'void')
+	}
+	if fn_node.value == 'move' {
+		t.mark_fn_used('map__move')
+		return t.make_call_typed('map__move', arr1(t.runtime_addr(base, base_type)), clean_type)
+	}
+	if fn_node.value == 'reserve' {
+		if node.children_count < 2 {
+			return none
+		}
+		t.mark_fn_used('map__reserve')
+		capacity := t.transform_expr_for_type(t.a.child(&node, 1), 'u32')
+		return t.make_call_typed('map__reserve', arr2(t.runtime_addr(base, base_type), capacity),
+			'void')
+	}
+	if fn_node.value == 'delete' {
+		if node.children_count < 2 {
+			return none
+		}
+		key_type := t.map_key_type(clean_type)
+		if key_type.len == 0 {
+			return none
+		}
+		t.mark_fn_used('map__delete')
+		key_name := t.new_temp('map_key')
+		t.pending_stmts << t.make_decl_assign_typed(key_name, t.transform_expr_for_type(t.a.child(&node, 1),
+			key_type), key_type)
+		return t.make_call_typed('map__delete', arr2(t.runtime_addr(base, base_type), t.make_prefix(.amp,
+			t.make_ident(key_name))), 'void')
 	}
 	elem_type := if fn_node.value == 'keys' {
 		t.map_key_type(clean_type)
@@ -1712,13 +2008,51 @@ fn (mut t Transformer) try_lower_map_method_call(node flat.Node) ?flat.NodeId {
 	if elem_type.len == 0 {
 		return none
 	}
-	base := t.transform_expr(base_id)
+	t.mark_fn_used('map__${fn_node.value}')
 	return t.make_call_typed('map__${fn_node.value}', arr1(t.runtime_addr(base, base_type)),
 		'[]${elem_type}')
 }
 
+// try_lower_channel_method_call lowers channel source methods to runtime calls before
+// backend selection.
+fn (mut t Transformer) try_lower_channel_method_call(call_id flat.NodeId, node flat.Node) ?flat.NodeId {
+	if node.children_count == 0 {
+		return none
+	}
+	fn_id := t.a.children[node.children_start]
+	fn_node := t.a.nodes[int(fn_id)]
+	if fn_node.kind != .selector || fn_node.children_count == 0 || fn_node.value != 'close' {
+		return none
+	}
+	base_id := t.a.child(&fn_node, 0)
+	if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id, 'chan.close') {
+		return exact_call
+	}
+	mut base_type := t.node_type(base_id)
+	if base_type.len == 0 {
+		base_type = t.lvalue_type(base_id)
+	}
+	mut clean_type := base_type
+	mut ptr_depth := 0
+	for clean_type.starts_with('&') {
+		ptr_depth++
+		clean_type = clean_type[1..].trim_space()
+	}
+	if !clean_type.starts_with('chan ') {
+		return none
+	}
+	t.mark_fn_used('sync__Channel__close')
+	errs := t.make_array_new_call('IError', t.make_int_literal(0), t.make_int_literal(0))
+	fn_expr := t.make_selector(t.make_ident('C'), 'sync__Channel__close', '')
+	mut receiver := t.transform_expr(base_id)
+	for _ in 0 .. ptr_depth {
+		receiver = t.make_prefix(.mul, receiver)
+	}
+	return t.make_call_expr_typed(fn_expr, arr2(receiver, errs), 'void')
+}
+
 // try_lower_move_method_call supports try lower move method call handling for Transformer.
-fn (mut t Transformer) try_lower_move_method_call(node flat.Node) ?flat.NodeId {
+fn (mut t Transformer) try_lower_move_method_call(call_id flat.NodeId, node flat.Node) ?flat.NodeId {
 	if node.children_count != 1 {
 		return none
 	}
@@ -1730,8 +2064,14 @@ fn (mut t Transformer) try_lower_move_method_call(node flat.Node) ?flat.NodeId {
 	base_id := t.a.child(&fn_node, 0)
 	base_type := t.node_type(base_id)
 	clean_array_type := t.membership_container_type(base_type)
-	clean_map_type := t.clean_map_type(base_type)
-	if clean_array_type.starts_with('[]') || clean_map_type.starts_with('map[') {
+	if clean_array_type.starts_with('[]') {
+		if !isnil(t.tc) {
+			if resolved := t.tc.resolved_call_name(call_id) {
+				if !is_builtin_collection_resolved_call(resolved) && t.is_known_fn_name(resolved) {
+					return none
+				}
+			}
+		}
 		return t.transform_expr(base_id)
 	}
 	return none
@@ -1868,13 +2208,19 @@ fn (mut t Transformer) try_lower_builtin_call(_id flat.NodeId, node flat.Node) ?
 	if pool_call := t.try_lower_pool_generic_method_call(node) {
 		return pool_call
 	}
-	if move_call := t.try_lower_move_method_call(node) {
+	if static_call := t.try_lower_static_assoc_call(_id, node) {
+		return static_call
+	}
+	if move_call := t.try_lower_move_method_call(_id, node) {
 		return move_call
 	}
-	if map_call := t.try_lower_map_method_call(node) {
+	if channel_call := t.try_lower_channel_method_call(_id, node) {
+		return channel_call
+	}
+	if map_call := t.try_lower_map_method_call(_id, node) {
 		return map_call
 	}
-	if array_call := t.try_lower_array_method_call(node) {
+	if array_call := t.try_lower_array_method_call(_id, node) {
 		return array_call
 	}
 	if type_name_call := t.try_lower_sum_type_name_method_call(node) {
@@ -2189,6 +2535,9 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 	method := fn_node.value
 	base_id := t.a.child(&fn_node, 0)
 	base_node := t.a.nodes[int(base_id)]
+	if t.is_import_alias_ident(base_id) {
+		return none
+	}
 	// `Type.fn(...)` / `module.Type.fn(...)` is a static associated function, not a method:
 	// the base names a type, so it must not be lowered into `fn(receiver, ...)`.
 	if _ := t.static_assoc_fn_name(base_id, method) {
@@ -2504,6 +2853,51 @@ fn (t &Transformer) receiver_method_return_type(method_name string, fallback str
 	return fallback
 }
 
+fn (t &Transformer) call_resolved_to_method(call_id flat.NodeId, method_name string) bool {
+	if isnil(t.tc) {
+		return true
+	}
+	if resolved := t.tc.resolved_call_name(call_id) {
+		return resolved == method_name
+	}
+	return false
+}
+
+fn (mut t Transformer) lower_checker_selected_receiver_method(call_id flat.NodeId, node flat.Node, base_id flat.NodeId, builtin_name string) ?flat.NodeId {
+	if isnil(t.tc) {
+		return none
+	}
+	resolved := t.tc.resolved_call_name(call_id) or { return none }
+	if resolved == builtin_name || is_builtin_collection_resolved_call(resolved)
+		|| !t.is_known_fn_name(resolved) {
+		return none
+	}
+	args := t.transform_receiver_method_args(node, base_id, resolved)
+	ret_type := t.receiver_method_return_type(resolved, node.typ)
+	t.mark_fn_used(resolved)
+	return t.make_call_typed(resolved, args, ret_type)
+}
+
+fn is_builtin_collection_resolved_call(name string) bool {
+	return name.len == 0 || is_raw_collection_method_name(name, 'array.') || name == 'array_clone'
+		|| is_runtime_collection_helper_name(name) || is_raw_collection_method_name(name, 'map.')
+}
+
+fn is_raw_collection_method_name(name string, prefix string) bool {
+	if !name.starts_with(prefix) {
+		return false
+	}
+	rest := name[prefix.len..]
+	return rest.len > 0 && !rest.contains('.')
+}
+
+fn is_runtime_collection_helper_name(name string) bool {
+	return name in ['array__clone', 'array__reverse', 'array__prepend', 'array__insert',
+		'array__push_many', 'array__needs_unique_shift', 'map__delete', 'map__move', 'map__reserve',
+		'map__keys', 'map__values', 'map__clear', 'map__free', 'map__get', 'map__get_check',
+		'map__exists', 'map__set']
+}
+
 // resolve_smartcast_sum_receiver_method supports resolve_smartcast_sum_receiver_method handling.
 fn (t &Transformer) resolve_smartcast_sum_receiver_method(base_id flat.NodeId, method string) ?string {
 	key := t.expr_key(base_id)
@@ -2592,6 +2986,8 @@ fn (t &Transformer) receiver_method_candidates(receiver_type string, method stri
 		candidates << '[]${short_elem}.${method}'
 		if elem_type.contains('.') {
 			candidates << '${elem_type.all_before_last('.')}.[]${short_elem}.${method}'
+		} else if transform_can_prefix_collection_receiver(t.cur_module) {
+			candidates << '${t.cur_module}.[]${short_elem}.${method}'
 		}
 	} else if clean_type.contains('.') {
 		short_type := clean_type.all_after_last('.')
@@ -2602,30 +2998,211 @@ fn (t &Transformer) receiver_method_candidates(receiver_type string, method stri
 	return candidates
 }
 
+fn (t &Transformer) resolve_fixed_array_dynamic_receiver_method(fixed_type string, method string) ?string {
+	elem_type := fixed_array_outer_elem_type(fixed_type)
+	if elem_type.len == 0 {
+		return none
+	}
+	return t.resolve_receiver_method_for_type('[]${elem_type}', method)
+}
+
+fn (mut t Transformer) lower_fixed_array_dynamic_receiver_method_call(node flat.Node, base_id flat.NodeId, fixed_type string, method_name string) flat.NodeId {
+	elem_type := fixed_array_outer_elem_type(fixed_type)
+	array_type := '[]${elem_type}'
+	tmp_name := t.new_temp('fixed_arr')
+	t.pending_stmts << t.make_decl_assign_typed(tmp_name, t.fixed_array_value_to_array(base_id,
+		fixed_type, array_type), array_type)
+	args := t.transform_receiver_method_args_with_base(node, t.make_ident(tmp_name), method_name)
+	ret_type := t.receiver_method_return_type(method_name, node.typ)
+	t.mark_fn_used(method_name)
+	return t.make_call_typed(method_name, args, ret_type)
+}
+
+fn fixed_array_outer_elem_type(type_text string) string {
+	clean := type_text.trim_space()
+	if clean.len == 0 {
+		return ''
+	}
+	if clean.starts_with('[') {
+		bracket_end := generic_matching_bracket(clean, 0)
+		if bracket_end < clean.len {
+			return clean[bracket_end + 1..]
+		}
+		return ''
+	}
+	elem, dims := transform_postfix_fixed_array_parts(clean)
+	if elem.len == 0 || dims.len == 0 {
+		return fixed_array_elem_type(clean)
+	}
+	mut out := elem
+	for i := dims.len - 1; i > 0; i-- {
+		out += '[${dims[i]}]'
+	}
+	return out
+}
+
+fn transform_push_receiver_candidate(mut candidates []string, candidate string) {
+	if candidate.len > 0 && candidate !in candidates {
+		candidates << candidate
+	}
+}
+
+fn transform_can_prefix_collection_receiver(module_name string) bool {
+	return module_name.len > 0 && module_name != 'main' && module_name != 'builtin'
+}
+
+fn (t &Transformer) receiver_type_text_variants(type_text string) []string {
+	clean := type_text.trim_space()
+	mut names := []string{}
+	transform_push_receiver_candidate(mut names, clean)
+	transform_push_receiver_candidate(mut names, receiver_type_text_short_spelling(clean))
+	if t.is_fixed_array_type(clean) {
+		source := t.receiver_type_text_source_fixed_spelling(clean)
+		transform_push_receiver_candidate(mut names, source)
+		transform_push_receiver_candidate(mut names, receiver_type_text_short_spelling(source))
+	}
+	return names
+}
+
+fn (t &Transformer) receiver_type_text_source_fixed_spelling(type_text string) string {
+	clean := type_text.trim_space()
+	if clean.len == 0 || clean.starts_with('[') || !t.is_fixed_array_type(clean) {
+		return clean
+	}
+	elem, dims := transform_postfix_fixed_array_parts(clean)
+	if elem.len == 0 || dims.len == 0 {
+		return clean
+	}
+	mut source := elem
+	for i := dims.len; i > 0; i-- {
+		source = '[${dims[i - 1]}]${source}'
+	}
+	return source
+}
+
+fn transform_postfix_fixed_array_parts(type_text string) (string, []string) {
+	clean := type_text.trim_space()
+	mut end := clean.len
+	mut dims := []string{}
+	for end > 0 && clean[end - 1] == `]` {
+		start := transform_trailing_matching_bracket_start(clean, end)
+		if start < 0 {
+			break
+		}
+		dims << clean[start + 1..end - 1].trim_space()
+		end = start
+	}
+	return clean[..end], dims
+}
+
+fn transform_trailing_matching_bracket_start(s string, end int) int {
+	mut depth := 0
+	for i := end - 1; i >= 0; i-- {
+		if s[i] == `]` {
+			depth++
+		} else if s[i] == `[` {
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+fn receiver_type_text_short_spelling(type_text string) string {
+	clean := type_text.trim_space()
+	if clean.starts_with('[]') {
+		return '[]' + receiver_type_text_short_spelling(clean[2..])
+	}
+	if clean.starts_with('[') {
+		bracket_end := generic_matching_bracket(clean, 0)
+		if bracket_end < clean.len {
+			return clean[..bracket_end + 1] + receiver_type_text_short_spelling(clean[bracket_end +
+				1..])
+		}
+	}
+	if clean.starts_with('map[') {
+		bracket_end := generic_matching_bracket(clean, 3)
+		if bracket_end < clean.len {
+			key := receiver_type_text_short_spelling(clean[4..bracket_end])
+			value := receiver_type_text_short_spelling(clean[bracket_end + 1..])
+			return 'map[${key}]${value}'
+		}
+	}
+	if clean.contains('.') {
+		return clean.all_after_last('.')
+	}
+	return clean
+}
+
+fn (t &Transformer) receiver_type_text_module_names(type_text string) []string {
+	clean := type_text.trim_space()
+	mut names := []string{}
+	if clean.starts_with('[]') {
+		return t.receiver_type_text_module_names(clean[2..])
+	}
+	if clean.starts_with('[') {
+		bracket_end := generic_matching_bracket(clean, 0)
+		if bracket_end < clean.len {
+			return t.receiver_type_text_module_names(clean[bracket_end + 1..])
+		}
+	}
+	if clean.starts_with('map[') {
+		key_type := t.map_key_type(clean)
+		value_type := t.map_value_type(clean)
+		for name in t.receiver_type_text_module_names(key_type) {
+			transform_push_receiver_candidate(mut names, name)
+		}
+		for name in t.receiver_type_text_module_names(value_type) {
+			transform_push_receiver_candidate(mut names, name)
+		}
+		return names
+	}
+	if t.is_fixed_array_type(clean) {
+		return t.receiver_type_text_module_names(fixed_array_elem_type(clean))
+	}
+	if clean.contains('.') {
+		transform_push_receiver_candidate(mut names, clean.all_before_last('.'))
+	}
+	return names
+}
+
 // map_receiver_method_candidates supports map receiver method candidates handling for Transformer.
 fn (t &Transformer) map_receiver_method_candidates(receiver_type string, method string) []string {
 	clean_type := t.clean_map_type(receiver_type)
 	key_type := t.map_key_type(clean_type)
 	value_type := t.map_value_type(clean_type)
 	mut candidates := []string{}
-	candidates << '${clean_type}.${method}'
 	if key_type.len == 0 || value_type.len == 0 {
+		transform_push_receiver_candidate(mut candidates, '${clean_type}.${method}')
 		return candidates
 	}
-	short_value := if value_type.contains('.') {
-		value_type.all_after_last('.')
-	} else {
-		value_type
+	key_types := t.receiver_type_text_variants(key_type)
+	value_types := t.receiver_type_text_variants(value_type)
+	mut map_types := []string{}
+	for key in key_types {
+		for value in value_types {
+			transform_push_receiver_candidate(mut map_types, 'map[${key}]${value}')
+		}
 	}
-	short_map := 'map[${key_type}]${short_value}'
-	if short_map != clean_type {
-		candidates << '${short_map}.${method}'
+	for map_type in map_types {
+		transform_push_receiver_candidate(mut candidates, '${map_type}.${method}')
 	}
-	if value_type.contains('.') {
-		mod_name := value_type.all_before_last('.')
-		candidates << '${mod_name}.${short_map}.${method}'
-	} else if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin' {
-		candidates << '${t.cur_module}.${short_map}.${method}'
+	mut module_names := []string{}
+	if transform_can_prefix_collection_receiver(t.cur_module) {
+		transform_push_receiver_candidate(mut module_names, t.cur_module)
+	}
+	for mod_name in t.receiver_type_text_module_names(key_type) {
+		transform_push_receiver_candidate(mut module_names, mod_name)
+	}
+	for mod_name in t.receiver_type_text_module_names(value_type) {
+		transform_push_receiver_candidate(mut module_names, mod_name)
+	}
+	for mod_name in module_names {
+		for map_type in map_types {
+			transform_push_receiver_candidate(mut candidates, '${mod_name}.${map_type}.${method}')
+		}
 	}
 	return candidates
 }
@@ -2826,6 +3403,12 @@ fn (mut t Transformer) is_method_call(node flat.Node) bool {
 // get_call_return_type looks up the return type for a resolved call.
 // Handles both checker-resolved calls and transform-time name resolution.
 fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string {
+	if t.is_local_fn_value_call(node) {
+		return ''
+	}
+	if ret := t.checker_resolved_non_builtin_return_type(id, node) {
+		return ret
+	}
 	if node.children_count > 0 {
 		fn_node := t.a.child_node(&node, 0)
 		if fn_node.kind == .selector && fn_node.value in ['clone', 'reverse']
@@ -2837,14 +3420,33 @@ fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string 
 				return clean_type
 			}
 		}
-		if fn_node.kind == .selector && fn_node.value == 'keys' && fn_node.children_count > 0 {
+		if fn_node.kind == .selector && fn_node.value == 'wait' && fn_node.children_count > 0 {
+			base_id := t.a.child(fn_node, 0)
+			base_type := t.node_type(base_id)
+			clean_type := t.membership_container_type(base_type)
+			if clean_type.starts_with('[]') {
+				elem_type := clean_type[2..]
+				if elem_type == 'thread' {
+					return 'void'
+				}
+				if elem_type.starts_with('thread ') {
+					return '[]${elem_type[7..]}'
+				}
+			}
+		}
+		if fn_node.kind == .selector && fn_node.value in ['keys', 'values']
+			&& fn_node.children_count > 0 {
 			base_id := t.a.child(fn_node, 0)
 			base_type := t.node_type(base_id)
 			clean_type := t.clean_map_type(base_type)
 			if clean_type.starts_with('map[') {
-				key_type := t.map_key_type(clean_type)
-				if key_type.len > 0 {
-					return '[]${key_type}'
+				elem_type := if fn_node.value == 'keys' {
+					t.map_key_type(clean_type)
+				} else {
+					t.map_value_type(clean_type)
+				}
+				if elem_type.len > 0 {
+					return '[]${elem_type}'
 				}
 			}
 		}
@@ -2899,6 +3501,18 @@ fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string 
 		}
 	}
 	return ''
+}
+
+fn (t &Transformer) checker_resolved_non_builtin_return_type(id flat.NodeId, node flat.Node) ?string {
+	if isnil(t.tc) {
+		return none
+	}
+	name := t.tc.resolved_call_name(id) or { return none }
+	if is_builtin_collection_resolved_call(name) {
+		return none
+	}
+	ret := t.tc.fn_ret_types[name] or { return none }
+	return t.call_return_type_name(ret.name(), node)
 }
 
 // call_return_type_name updates call return type name state for Transformer.

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -45,6 +45,9 @@ fn (mut t Transformer) array_index_info(index_id flat.NodeId) ?ArrayIndexInfo {
 	if value_type.len == 0 {
 		return none
 	}
+	if t.is_optional_type_name(value_type) {
+		return none
+	}
 	return ArrayIndexInfo{
 		base_id:    base_id
 		index_id:   index_expr_id

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -200,6 +200,7 @@ pub fn transform_with_used_opt(mut a flat.FlatAst, tc &types.TypeChecker, used_f
 		}
 	}
 	was_parallel := t.transform_all_dispatch(want_parallel)
+	augmented_used_fns = t.used_fns.clone()
 	return augmented_used_fns, was_parallel
 }
 
@@ -855,14 +856,15 @@ fn (t &Transformer) clone_ast_base(base_nodes int, base_children int) &flat.Flat
 }
 
 // fork_worker builds a worker Transformer that shares this transformer's
-// read-only collected maps (structs, sum types, fn return types, used_fns, …)
-// and operates on its own cloned AST `ast` and forked TypeChecker `wtc`. All
-// per-function mutable state and memoization caches are reset/private so the
-// worker can run on its own thread.
+// read-only collected maps (structs, sum types, fn return types, …) and
+// operates on its own cloned AST `ast` and forked TypeChecker `wtc`. All
+// per-function mutable state, helper-root tracking, and memoization caches are
+// reset/private so the worker can run on its own thread.
 fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Transformer {
 	mut w := *t
 	w.a = ast
 	w.tc = wtc
+	w.used_fns = t.used_fns.clone()
 	w.alias_cache = &AliasCache{}
 	w.sum_cache = &AliasCache{}
 	w.generic_fn_decls_cache = map[string]GenericFnDecl{}
@@ -919,6 +921,11 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 			t.a.nodes[it.fn_idx] = n.with_shifted_children(child_shift)
 		} else {
 			t.a.nodes[it.fn_idx] = n
+		}
+	}
+	for name, used in w.used_fns {
+		if used {
+			t.used_fns[name] = true
 		}
 	}
 }
@@ -3090,6 +3097,10 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 			rhs_id := t.a.child(&node, 1)
 			rhs := t.a.nodes[int(rhs_id)]
 			if rhs.kind == .call {
+				call_typ := t.get_call_return_type(rhs_id, rhs)
+				if call_typ.len > 0 {
+					typ = call_typ
+				}
 				generic_typ := t.concrete_generic_call_return_type(rhs_id, rhs)
 				if generic_typ.len > 0 {
 					typ = generic_typ
@@ -4100,10 +4111,10 @@ fn (mut t Transformer) transform_call_expr(id flat.NodeId, node flat.Node) flat.
 	mut call_node := t.a.nodes[int(call_id)]
 	mut resolved_typ := t.concrete_generic_call_return_type(call_id, call_node)
 	if resolved_typ.len == 0 {
-		resolved_typ = t.current_call_return_type(call_node)
+		resolved_typ = t.get_call_return_type(call_id, call_node)
 	}
 	if resolved_typ.len == 0 {
-		resolved_typ = t.get_call_return_type(call_id, call_node)
+		resolved_typ = t.current_call_return_type(call_node)
 	}
 	if resolved_typ.len > 0 {
 		t.a.nodes[int(call_id)].typ = resolved_typ
@@ -5928,9 +5939,9 @@ fn (t &Transformer) resolve_expr_type(id flat.NodeId) string {
 			if concrete_typ.len > 0 {
 				return concrete_typ
 			}
-			mut ret := t.current_call_return_type(node)
+			mut ret := t.get_call_return_type(id, node)
 			if ret.len == 0 {
-				ret = t.get_call_return_type(id, node)
+				ret = t.current_call_return_type(node)
 			}
 			if ret.len > 0 {
 				return ret
@@ -6078,6 +6089,25 @@ fn (t &Transformer) resolve_expr_type(id flat.NodeId) string {
 				if node.op == .plus && rhs_type == 'string' {
 					return 'string'
 				}
+				if node.op in [.plus, .minus] && lhs_type.starts_with('&')
+					&& t.is_integer_type_name(rhs_type) {
+					return lhs_type
+				}
+				if node.op == .plus && rhs_type.starts_with('&') && t.is_integer_type_name(lhs_type) {
+					return rhs_type
+				}
+				if node.op in [.plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor] {
+					if lhs_type.len > 0 && rhs_type.len > 0 && t.is_numeric_stringify_type(lhs_type)
+						&& t.is_numeric_stringify_type(rhs_type) {
+						return promote_numeric_stringify_type(lhs_type, rhs_type)
+					}
+					if lhs_type.len > 0 && t.is_numeric_stringify_type(lhs_type) {
+						return lhs_type
+					}
+					if rhs_type.len > 0 && t.is_numeric_stringify_type(rhs_type) {
+						return rhs_type
+					}
+				}
 			}
 			return ''
 		}
@@ -6107,6 +6137,9 @@ fn (t &Transformer) resolve_expr_type(id flat.NodeId) string {
 }
 
 fn (t &Transformer) current_call_return_type(node flat.Node) string {
+	if t.is_local_fn_value_call(node) {
+		return ''
+	}
 	name := t.resolve_call_name(node)
 	if name.len == 0 {
 		return ''
@@ -6131,6 +6164,22 @@ fn (t &Transformer) current_call_return_type(node flat.Node) string {
 		}
 	}
 	return ''
+}
+
+fn (t &Transformer) is_local_fn_value_call(node flat.Node) bool {
+	if node.kind != .call || node.children_count == 0 {
+		return false
+	}
+	fn_id := t.a.child(&node, 0)
+	if int(fn_id) < 0 {
+		return false
+	}
+	fn_node := t.a.nodes[int(fn_id)]
+	if fn_node.kind != .ident || fn_node.value.len == 0 {
+		return false
+	}
+	local_type := t.var_type(fn_node.value)
+	return local_type.starts_with('fn ') || t.is_fn_pointer_type_name(local_type)
 }
 
 // const_type_name supports const type name handling for Transformer.

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -778,8 +778,14 @@ fn (t &Transformer) node_type(id flat.NodeId) string {
 		return resolved
 	}
 	node := t.a.nodes[int(id)]
+	mut deferred_call_typ := ''
 	if node.typ.len > 0 {
-		return t.normalize_type_alias(node.typ)
+		node_typ := t.normalize_type_alias(node.typ)
+		if node.kind == .call && node_typ in ['int', 'array', 'map', 'unknown'] {
+			deferred_call_typ = node_typ
+		} else {
+			return node_typ
+		}
 	}
 	if node.kind == .selector {
 		sel_type := t.resolve_selector_type(node)
@@ -808,13 +814,20 @@ fn (t &Transformer) node_type(id flat.NodeId) string {
 		return node.value
 	}
 	if !isnil(t.tc) {
+		mut name := ''
 		if typ := t.tc.expr_type(id) {
-			name := typ.name()
-			if name.len > 0 && name != 'void' && (name != 'int'
-				|| node.kind in [.ident, .int_literal, .infix, .prefix, .paren, .selector, .index, .call]) {
-				return name
-			}
+			name = typ.name()
 		}
+		if name.len == 0 || name == 'unknown' {
+			name = t.tc.resolve_type(id).name()
+		}
+		if name.len > 0 && name != 'void' && (name != 'int'
+			|| node.kind in [.ident, .int_literal, .infix, .prefix, .paren, .selector, .index, .call]) {
+			return t.normalize_type_alias(name)
+		}
+	}
+	if deferred_call_typ.len > 0 {
+		return deferred_call_typ
 	}
 	return ''
 }
@@ -893,7 +906,7 @@ fn (t &Transformer) map_value_type(type_str string) string {
 	if !type_str.starts_with('map[') {
 		return ''
 	}
-	bracket_end := type_str.index(']') or { return '' }
+	bracket_end := generic_matching_bracket(type_str, 3)
 	if bracket_end + 1 < type_str.len {
 		return type_str[bracket_end + 1..]
 	}
@@ -906,7 +919,7 @@ fn (t &Transformer) map_key_type(type_str string) string {
 	if !type_str.starts_with('map[') {
 		return ''
 	}
-	bracket_end := type_str.index(']') or { return '' }
+	bracket_end := generic_matching_bracket(type_str, 3)
 	if bracket_end > 4 {
 		return type_str[4..bracket_end]
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1469,7 +1469,7 @@ fn (mut tc TypeChecker) insert_loop_var(id flat.NodeId, typ Type) {
 pub fn (tc &TypeChecker) expr_type(id flat.NodeId) ?Type {
 	if int(id) >= 0 {
 		node := tc.a.nodes[int(id)]
-		if node.kind == .call && node.typ.len > 0 {
+		if node.kind == .call && node.typ.len > 0 && node.typ !in ['int', 'array', 'map', 'unknown'] {
 			return tc.parse_type(node.typ)
 		}
 	}
@@ -3741,7 +3741,7 @@ fn (tc &TypeChecker) should_diagnose_unknown_call(id flat.NodeId) bool {
 }
 
 // resolve_call_info resolves resolve call info information for types.
-fn (mut tc TypeChecker) resolve_call_info(_id flat.NodeId, node flat.Node) ?CallInfo {
+fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallInfo {
 	if node.children_count == 0 {
 		return none
 	}
@@ -3812,6 +3812,13 @@ fn (mut tc TypeChecker) resolve_call_info(_id flat.NodeId, node flat.Node) ?Call
 				return_type:  Type(void_)
 				has_receiver: true
 				params_known: true
+			}
+		}
+		if clean is Array {
+			for mname in exact_array_receiver_method_candidates(clean, fn_node.value, tc.cur_module) {
+				if mname in tc.fn_ret_types {
+					return tc.call_info(mname, true)
+				}
 			}
 		}
 		if clean is Array && fn_node.value == 'clone' {
@@ -3992,9 +3999,33 @@ fn (mut tc TypeChecker) resolve_call_info(_id flat.NodeId, node flat.Node) ?Call
 					params_known: true
 				}
 			}
-			mname := '${type_name}.${fn_node.value}'
-			if mname in tc.fn_ret_types {
-				return tc.call_info(mname, true)
+			for mname in receiver_method_name_candidates(clean, fn_node.value, tc.cur_module) {
+				if mname in tc.fn_ret_types {
+					if clean_map := map_type_from_receiver(clean) {
+						if info := tc.map_builtin_call_info(base_type, clean_map, fn_node.value,
+							mname)
+						{
+							return info
+						}
+					}
+					return tc.call_info(mname, true)
+				}
+			}
+			if fixed_array := fixed_array_type_from_receiver(clean) {
+				if fn_node.value == 'pointers' {
+					if info := tc.fixed_array_dynamic_receiver_call_info(base_type, fixed_array,
+						fn_node.value)
+					{
+						return info
+					}
+					if base_type !is Pointer && !tc.expr_can_take_address(base_id) {
+						tc.record_error(.call_arg_mismatch,
+							'fixed array receiver for `pointers` must be addressable', id)
+					}
+					if info := tc.fixed_array_pointers_call_info(base_type) {
+						return info
+					}
+				}
 			}
 			if info := tc.embedded_method_call_info(type_name, fn_node.value) {
 				return info
@@ -4252,6 +4283,174 @@ fn (tc &TypeChecker) call_info(name string, has_receiver bool) CallInfo {
 	}
 }
 
+fn map_type_from_receiver(t Type) ?Map {
+	if t is Map {
+		return t
+	}
+	if t is Alias {
+		return map_type_from_receiver(t.base_type)
+	}
+	return none
+}
+
+fn fixed_array_type_from_receiver(t Type) ?ArrayFixed {
+	if t is ArrayFixed {
+		return t
+	}
+	if t is Alias {
+		return fixed_array_type_from_receiver(t.base_type)
+	}
+	return none
+}
+
+fn (tc &TypeChecker) fixed_array_dynamic_receiver_call_info(base_type Type, arr ArrayFixed, method string) ?CallInfo {
+	array_type := Array{
+		elem_type: arr.elem_type
+	}
+	mut candidates := []string{}
+	push_receiver_method_candidate(mut candidates,
+		'${resolve_type_name_for_method(Type(array_type))}.${method}')
+	append_array_receiver_method_candidates(mut candidates, array_type, method, tc.cur_module)
+	for mname in candidates {
+		if mname !in tc.fn_ret_types {
+			continue
+		}
+		info := tc.call_info(mname, true)
+		mut params := info.params.clone()
+		if params.len > 0 {
+			params[0] = base_type
+		}
+		return CallInfo{
+			name:                 info.name
+			params:               params
+			return_type:          info.return_type
+			has_receiver:         info.has_receiver
+			is_variadic:          info.is_variadic
+			is_c_variadic:        info.is_c_variadic
+			params_known:         info.params_known
+			has_implicit_veb_ctx: info.has_implicit_veb_ctx
+		}
+	}
+	return none
+}
+
+fn (tc &TypeChecker) fixed_array_pointers_call_info(base_type Type) ?CallInfo {
+	mname := 'array.pointers'
+	return_type := tc.fn_ret_types[mname] or { return none }
+	return CallInfo{
+		name:         mname
+		params:       tarr1(base_type)
+		return_type:  return_type
+		has_receiver: true
+		params_known: true
+	}
+}
+
+fn (tc &TypeChecker) expr_can_take_address(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	match node.kind {
+		.ident {
+			return true
+		}
+		.index {
+			if node.value == 'range' {
+				return false
+			}
+			if node.children_count > 0 {
+				base_id := tc.a.child(&node, 0)
+				base_type0 := unwrap_pointer(tc.resolve_type(base_id))
+				mut base_type := base_type0
+				if base_type0 is Alias {
+					base_type = base_type0.base_type
+				}
+				if base_type is Map {
+					return false
+				}
+			}
+			return node.children_count > 0 && tc.expr_can_take_address(tc.a.child(&node, 0))
+		}
+		.selector {
+			if node.children_count == 0 {
+				return false
+			}
+			return tc.expr_can_take_address(tc.a.child(&node, 0))
+		}
+		.prefix {
+			return node.op == .mul
+		}
+		.paren {
+			if node.children_count == 0 {
+				return false
+			}
+			return tc.expr_can_take_address(tc.a.child(&node, 0))
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn (tc &TypeChecker) map_builtin_call_info(base_type Type, m Map, method string, mname string) ?CallInfo {
+	if !checker_is_raw_collection_method_name(mname, 'map.') {
+		return none
+	}
+	params := match method {
+		'delete' {
+			tarr2(base_type, m.key_type)
+		}
+		'clear', 'free', 'keys', 'values' {
+			tarr1(base_type)
+		}
+		'move' {
+			tarr1(base_type)
+		}
+		'reserve' {
+			tarr2(base_type, Type(u32_))
+		}
+		else {
+			return none
+		}
+	}
+
+	return_type := match method {
+		'keys' {
+			Type(Array{
+				elem_type: m.key_type
+			})
+		}
+		'values' {
+			Type(Array{
+				elem_type: m.value_type
+			})
+		}
+		'move' {
+			Type(m)
+		}
+		else {
+			Type(void_)
+		}
+	}
+
+	return CallInfo{
+		name:         mname
+		params:       params
+		return_type:  return_type
+		has_receiver: true
+		params_known: true
+	}
+}
+
+fn checker_is_raw_collection_method_name(name string, prefix string) bool {
+	if !name.starts_with(prefix) {
+		return false
+	}
+	rest := name[prefix.len..]
+	return rest.len > 0 && !rest.contains('.')
+}
+
 // is_print_style_fn_name reports whether is print style fn name applies in types.
 fn is_print_style_fn_name(name string) bool {
 	return name in ['print', 'println', 'eprint', 'eprintln', 'builtin.print', 'builtin.println',
@@ -4275,12 +4474,6 @@ fn print_style_param_accepts_string(typ Type) bool {
 fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, info0 CallInfo) {
 	info := tc.specialized_plain_generic_call_info(node, info0)
 	if node.children_count == 0 {
-		return
-	}
-	if info.name.starts_with('map.') {
-		for i in 1 .. node.children_count {
-			tc.check_node(tc.call_arg_value(tc.a.child(&node, i)))
-		}
 		return
 	}
 	if !info.params_known {
@@ -5059,9 +5252,10 @@ fn (tc &TypeChecker) module_const_receiver_method_name(base_node flat.Node, meth
 	if type_name.len == 0 {
 		return none
 	}
-	method_name := '${type_name}.${method}'
-	if method_name in tc.fn_ret_types {
-		return method_name
+	for method_name in receiver_method_name_candidates(clean, method, mod_name) {
+		if method_name in tc.fn_ret_types {
+			return method_name
+		}
 	}
 	return none
 }
@@ -5235,7 +5429,12 @@ fn (tc &TypeChecker) is_known_call(node flat.Node) bool {
 			}
 			base_name := resolve_type_name_for_method(clean_type.base_type)
 			if base_name.len > 0 {
-				return '${base_name}.${fn_node.value}' in tc.fn_ret_types
+				for base_mname in receiver_method_name_candidates(clean_type.base_type,
+					fn_node.value, tc.cur_module) {
+					if base_mname in tc.fn_ret_types {
+						return true
+					}
+				}
 			}
 		}
 		if clean_type is Struct {
@@ -8272,7 +8471,7 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 	if kind_id == 32 {
 		return tc.lambda_expr_type(node)
 	}
-	if kind_id == 12 && node.typ.len > 0 {
+	if kind_id == 12 && node.typ.len > 0 && node.typ !in ['int', 'array', 'map', 'unknown'] {
 		return tc.parse_type(node.typ)
 	}
 	if t := tc.resolved_call_type(id) {
@@ -8300,7 +8499,8 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 			return typ
 		}
 	}
-	if node.typ.len > 0 && node.typ != 'unknown' {
+	if node.typ.len > 0 && node.typ != 'unknown' && !(kind_id == 12
+		&& node.typ in ['int', 'array', 'map']) {
 		return tc.parse_type(node.typ)
 	}
 	match node.kind {
@@ -8532,11 +8732,30 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 							unknown_type('unknown return type for `${arr_mname1}`')
 						}
 					}
+					array_mname := 'array.${fn_node.value}'
+					if array_mname in tc.fn_ret_types {
+						return tc.fn_ret_types[array_mname] or {
+							unknown_type('unknown return type for `${array_mname}`')
+						}
+					}
 					return unknown_type('unknown array method `${fn_node.value}`')
 				}
 				if clean_type is Map {
 					if fn_node.value == 'clone' {
 						return base_type
+					}
+					if fn_node.value in ['delete', 'clear', 'free'] {
+						return Type(void_)
+					}
+					if fn_node.value == 'keys' {
+						return Type(Array{
+							elem_type: clean_type.key_type
+						})
+					}
+					if fn_node.value == 'values' {
+						return Type(Array{
+							elem_type: clean_type.value_type
+						})
 					}
 					return unknown_type('unknown map method `${fn_node.value}`')
 				}
@@ -8564,10 +8783,12 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 					}
 					base_name := resolve_type_name_for_method(clean_type.base_type)
 					if base_name.len > 0 {
-						base_mname := '${base_name}.${fn_node.value}'
-						if base_mname in tc.fn_ret_types {
-							return tc.fn_ret_types[base_mname] or {
-								unknown_type('unknown return type for `${base_mname}`')
+						for base_mname in receiver_method_name_candidates(clean_type.base_type,
+							fn_node.value, tc.cur_module) {
+							if base_mname in tc.fn_ret_types {
+								return tc.fn_ret_types[base_mname] or {
+									unknown_type('unknown return type for `${base_mname}`')
+								}
 							}
 						}
 					}
@@ -9377,15 +9598,198 @@ fn resolve_type_name_for_method(t Type) string {
 		return 'string'
 	}
 	if t is Array {
-		return 'array'
+		return '[]${nested_type_name(t.elem_type)}'
+	}
+	if t is ArrayFixed {
+		mut len_text := t.len.str()
+		if t.len_expr.len > 0 {
+			len_text = t.len_expr
+		}
+		return '${nested_type_name(t.elem_type)}[${len_text}]'
 	}
 	if t is Map {
-		return 'map'
+		return 'map[${nested_type_name(t.key_type)}]${nested_type_name(t.value_type)}'
 	}
 	if t is Primitive {
 		return prim_c_type_from(t.props, t.size)
 	}
 	return ''
+}
+
+fn receiver_type_name_variant(t Type, fixed_array_prefix bool, shorten_modules bool) string {
+	if t is Alias {
+		return receiver_leaf_type_name(t.name, shorten_modules)
+	}
+	if t is Struct {
+		return receiver_leaf_type_name(t.name, shorten_modules)
+	}
+	if t is Interface {
+		return receiver_leaf_type_name(t.name, shorten_modules)
+	}
+	if t is SumType {
+		return receiver_leaf_type_name(t.name, shorten_modules)
+	}
+	if t is Enum {
+		return receiver_leaf_type_name(t.name, shorten_modules)
+	}
+	if t is String {
+		return 'string'
+	}
+	if t is Array {
+		return '[]${receiver_type_name_variant(t.elem_type, fixed_array_prefix, shorten_modules)}'
+	}
+	if t is ArrayFixed {
+		mut len_text := t.len.str()
+		if t.len_expr.len > 0 {
+			len_text = t.len_expr
+		}
+		elem := receiver_type_name_variant(t.elem_type, fixed_array_prefix, shorten_modules)
+		if fixed_array_prefix {
+			return '[${len_text}]${elem}'
+		}
+		return '${elem}[${len_text}]'
+	}
+	if t is Map {
+		key := receiver_type_name_variant(t.key_type, fixed_array_prefix, shorten_modules)
+		value := receiver_type_name_variant(t.value_type, fixed_array_prefix, shorten_modules)
+		return 'map[${key}]${value}'
+	}
+	if t is Primitive {
+		return prim_c_type_from(t.props, t.size)
+	}
+	return receiver_leaf_type_name(t.name(), shorten_modules)
+}
+
+fn receiver_leaf_type_name(name string, shorten_modules bool) string {
+	if shorten_modules && name.contains('.') {
+		return name.all_after_last('.')
+	}
+	return name
+}
+
+fn receiver_type_name_variants(t Type) []string {
+	mut names := []string{}
+	push_receiver_method_candidate(mut names, receiver_type_name_variant(t, false, false))
+	push_receiver_method_candidate(mut names, receiver_type_name_variant(t, false, true))
+	push_receiver_method_candidate(mut names, receiver_type_name_variant(t, true, false))
+	push_receiver_method_candidate(mut names, receiver_type_name_variant(t, true, true))
+	return names
+}
+
+fn receiver_type_module_names(t Type) []string {
+	mut names := []string{}
+	if t is Array {
+		for name in receiver_type_module_names(t.elem_type) {
+			push_receiver_method_candidate(mut names, name)
+		}
+	} else if t is ArrayFixed {
+		for name in receiver_type_module_names(t.elem_type) {
+			push_receiver_method_candidate(mut names, name)
+		}
+	} else if t is Map {
+		for name in receiver_type_module_names(t.key_type) {
+			push_receiver_method_candidate(mut names, name)
+		}
+		for name in receiver_type_module_names(t.value_type) {
+			push_receiver_method_candidate(mut names, name)
+		}
+	} else {
+		name := t.name()
+		if name.contains('.') {
+			push_receiver_method_candidate(mut names, name.all_before_last('.'))
+		}
+	}
+	return names
+}
+
+fn push_receiver_method_candidate(mut names []string, name string) {
+	if name.len > 0 && name !in names {
+		names << name
+	}
+}
+
+fn module_can_prefix_collection_receiver(module_name string) bool {
+	return module_name.len > 0 && module_name != 'main' && module_name != 'builtin'
+}
+
+fn exact_array_receiver_method_candidates(t Array, method string, module_name string) []string {
+	mut names := []string{}
+	append_array_receiver_method_candidates(mut names, t, method, module_name)
+	return names
+}
+
+fn append_array_receiver_method_candidates(mut names []string, t Array, method string, module_name string) {
+	elem_types := receiver_type_name_variants(t.elem_type)
+	if elem_types.len == 0 {
+		return
+	}
+	for elem_type in elem_types {
+		push_receiver_method_candidate(mut names, '[]${elem_type}.${method}')
+	}
+	mut module_names := receiver_type_module_names(t.elem_type)
+	if module_can_prefix_collection_receiver(module_name) {
+		push_receiver_method_candidate(mut module_names, module_name)
+	}
+	for mod_name in module_names {
+		for elem_type in elem_types {
+			push_receiver_method_candidate(mut names, '${mod_name}.[]${elem_type}.${method}')
+		}
+	}
+}
+
+fn append_map_receiver_method_candidates(mut names []string, t Map, method string, module_name string) {
+	key_types := receiver_type_name_variants(t.key_type)
+	value_types := receiver_type_name_variants(t.value_type)
+	if key_types.len == 0 || value_types.len == 0 {
+		return
+	}
+	mut map_types := []string{}
+	for key_type in key_types {
+		for value_type in value_types {
+			push_receiver_method_candidate(mut map_types, 'map[${key_type}]${value_type}')
+		}
+	}
+	for map_type in map_types {
+		push_receiver_method_candidate(mut names, '${map_type}.${method}')
+	}
+	mut module_names := []string{}
+	if module_can_prefix_collection_receiver(module_name) {
+		push_receiver_method_candidate(mut module_names, module_name)
+	}
+	for mod_name in receiver_type_module_names(t.key_type) {
+		push_receiver_method_candidate(mut module_names, mod_name)
+	}
+	for mod_name in receiver_type_module_names(t.value_type) {
+		push_receiver_method_candidate(mut module_names, mod_name)
+	}
+	for mod_name in module_names {
+		for map_type in map_types {
+			push_receiver_method_candidate(mut names, '${mod_name}.${map_type}.${method}')
+		}
+	}
+}
+
+fn receiver_method_name_candidates(t Type, method string, module_name string) []string {
+	mut names := []string{}
+	type_name := resolve_type_name_for_method(t)
+	if type_name.len > 0 {
+		push_receiver_method_candidate(mut names, '${type_name}.${method}')
+	}
+	mut clean := t
+	if clean is Alias {
+		clean = clean.base_type
+	}
+	if clean is Array {
+		append_array_receiver_method_candidates(mut names, clean, method, module_name)
+		array_name := 'array.${method}'
+		push_receiver_method_candidate(mut names, array_name)
+	}
+	if clean is Map {
+		append_map_receiver_method_candidates(mut names, clean, method, module_name)
+		map_name := 'map.${method}'
+		push_receiver_method_candidate(mut names, map_name)
+	}
+	return names
 }
 
 fn (tc &TypeChecker) infix_operator_return_type(op flat.Op, lhs Type, rhs Type) ?Type {


### PR DESCRIPTION
## Summary
- Move more V3 source-level normalization into the transformer, including map delete/clear/free, channel close, selected array runtime helpers, static associated calls, and selected call-argument normalization cases.
- Add transformer-side handling for pointer rvalue arguments, array/map builtin receiver fallbacks, and import-alias guardrails so module-qualified calls keep their generic specialization path.
- Keep C backend handling focused on ABI/emission details, with guardrails for moved operations and a raw-array `array.pointers` call-site intrinsic where the erased builtin body cannot generate valid C.
- Preserve transformer-created helper roots through markused and parallel transform worker merges.

## Tests
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent vlib/v3/tests/transformer_parity_test.v`
- `./vnew -silent vlib/v3/tests/post_merge_review_fixes_test.v`
- `./vnew -silent vlib/v3/tests/c_variadic_call_codegen_test.v`
- `./vnew -silent vlib/v3/tests/posix_wait_header_codegen_test.v`
- `./vnew -silent vlib/v3/tests/c_directive_order_codegen_test.v`
- `./vnew -silent vlib/v3/tests/type_checker_errors_test.v`
- `./vnew -silent vlib/v3/tests/parallel_cgen_test.v`
- `./vnew -silent vlib/v3/tests/mini_calculator_markused_codegen_test.v`
- `./vnew -silent vlib/v3/tests/generic_rhs_decl_type_codegen_test.v`
- `./vnew vlib/v3/test_all.vsh`