### PR TITLE
v3: cover sha3 issue compile

### DIFF
--- a/vlib/v3/tests/sha3_issue_compile_test.v
+++ b/vlib/v3/tests/sha3_issue_compile_test.v
@@ -1,0 +1,39 @@
+import os
+
+const sha3_issue_vexe = @VEXE
+const sha3_issue_tests_dir = os.dir(@FILE)
+const sha3_issue_v3_dir = os.dir(sha3_issue_tests_dir)
+const sha3_issue_vlib_dir = os.dir(sha3_issue_v3_dir)
+const sha3_issue_v3_src = os.join_path(sha3_issue_v3_dir, 'v3.v')
+
+// test_sha3_issue_26961_compile validates that v3 can compile the sha3 benchmark
+// program from https://github.com/vlang/v/issues/26961 .
+fn test_sha3_issue_26961_compile() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_sha3_issue_26961_${pid}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${sha3_issue_vexe} -gc none -path "${sha3_issue_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${sha3_issue_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_sha3_issue_26961_${pid}.v')
+	bin := os.join_path(os.temp_dir(), 'v3_sha3_issue_26961_bin_${pid}')
+	os.write_file(src, 'import crypto.sha3
+import time
+
+fn main() {
+	a := []u8{len: 10_000_000}
+	t1 := time.now()
+	_ := sha3.sum512(a)
+	println(time.since(t1))
+}
+') or {
+		panic(err)
+	}
+	os.rm(bin) or {}
+	os.rm(bin + '.c') or {}
+
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert os.exists(bin), compile.output
+}


### PR DESCRIPTION
## Summary
- add a focused V3 regression test for the SHA3 benchmark from #26961
- verify V3 can compile and link the program without including unrelated C99-mode changes

## Testing
- `./vnew test vlib/v3/tests/sha3_issue_compile_test.v`

## Notes
- This PR is intentionally sha-only; the C99 work is separate.