### PR TITLE
v3: stop emitting C includes

### DIFF
--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -476,6 +476,17 @@ $if windows {
 
 // pthread.h
 fn C.pthread_self() usize
+
+fn C.pthread_create(thread voidptr, attr voidptr, start_routine voidptr, arg voidptr) i32
+
+fn C.pthread_join(thread voidptr, retval voidptr) i32
+
+fn C.pthread_attr_init(attr voidptr) i32
+
+fn C.pthread_attr_setstacksize(attr voidptr, stacksize usize) i32
+
+fn C.pthread_attr_destroy(attr voidptr) i32
+
 fn C.pthread_mutex_init(voidptr, voidptr) i32
 
 fn C.pthread_mutex_lock(voidptr) i32
@@ -550,6 +561,14 @@ fn C.close(fd i32) i32
 fn C.pipe(pipefds &int) i32
 
 fn C.dup2(oldfd i32, newfd i32) i32
+
+fn C.fcntl(fd i32, cmd i32, arg ...voidptr) i32
+
+fn C.execlp(file &char, arg &char, va ...voidptr) i32
+
+fn C._exit(code i32)
+
+fn C.signal(sig i32, handler voidptr) voidptr
 
 // used by gl, stbi, freetype
 fn C.glTexImage2D()

--- a/vlib/net/openssl/openssl.c.v
+++ b/vlib/net/openssl/openssl.c.v
@@ -103,7 +103,7 @@ fn C.SSL_CTX_set_options(ctx &C.SSL_CTX, options i32)
 
 fn C.SSL_CTX_set_verify_depth(s &C.SSL_CTX, depth i32)
 
-fn C.SSL_CTX_load_verify_locations(ctx &C.SSL_CTX, const_file &char, ca_path &char) i32
+fn C.SSL_CTX_load_verify_locations(ctx &C.SSL_CTX, const_file &char, const_ca_path &char) i32
 
 fn C.SSL_CTX_free(ctx &C.SSL_CTX)
 

--- a/vlib/os/os_stat_default.c.v
+++ b/vlib/os/os_stat_default.c.v
@@ -12,14 +12,14 @@ pub fn stat(path string) !Stat {
 			return error_posix()
 		}
 		return Stat{
-			dev:   s.st_dev
+			dev:   u64(s.st_dev)
 			inode: s.st_ino
 			nlink: s.st_nlink
 			mode:  s.st_mode
 			uid:   s.st_uid
 			gid:   s.st_gid
-			rdev:  s.st_rdev
-			size:  s.st_size
+			rdev:  u64(s.st_rdev)
+			size:  u64(s.st_size)
 			atime: s.st_atime
 			mtime: s.st_mtime
 			ctime: s.st_ctime
@@ -37,14 +37,14 @@ pub fn lstat(path string) !Stat {
 			return error_posix()
 		}
 		return Stat{
-			dev:   s.st_dev
+			dev:   u64(s.st_dev)
 			inode: s.st_ino
 			nlink: s.st_nlink
 			mode:  s.st_mode
 			uid:   s.st_uid
 			gid:   s.st_gid
-			rdev:  s.st_rdev
-			size:  s.st_size
+			rdev:  u64(s.st_rdev)
+			size:  u64(s.st_size)
 			atime: s.st_atime
 			mtime: s.st_mtime
 			ctime: s.st_ctime

--- a/vlib/os/os_structs_stat_darwin.c.v
+++ b/vlib/os/os_structs_stat_darwin.c.v
@@ -1,0 +1,32 @@
+module os
+
+pub struct C.stat {
+	st_dev           i32
+	st_mode          u16
+	st_nlink         u16
+	st_ino           u64
+	st_uid           u32
+	st_gid           u32
+	st_rdev          i32
+	st_atime         i64
+	st_atimensec     i64
+	st_mtime         i64
+	st_mtimensec     i64
+	st_ctime         i64
+	st_ctimensec     i64
+	st_birthtime     i64
+	st_birthtimensec i64
+	st_size          i64
+	st_blocks        i64
+	st_blksize       i32
+	st_flags         u32
+	st_gen           u32
+	st_lspare        i32
+	st_qspare        [2]i64
+}
+
+pub struct C.__stat64 {
+	st_size  u64
+	st_mode  u32
+	st_mtime i64
+}

--- a/vlib/os/os_windows.c.v
+++ b/vlib/os/os_windows.c.v
@@ -21,7 +21,7 @@ pub const path_devnull = r'\\.\nul'
 fn C.CreateSymbolicLinkW(&u16, &u16, u32) i32
 
 // See https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createhardlinkw
-fn C.CreateHardLinkW(&u16, &u16, C.SECURITY_ATTRIBUTES) i32
+fn C.CreateHardLinkW(&u16, &u16, &C.SECURITY_ATTRIBUTES) i32
 
 // See https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getshortpathnamew
 fn C.GetShortPathNameW(&u16, &u16, u32) u32

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -3,15 +3,8 @@ module bench
 import os
 import time
 
-#include <sys/resource.h>
-
-// C.rusage declares C rusage data used by bench.
-struct C.rusage {
-	ru_maxrss i64
-}
-
 // C.getrusage declares the C getrusage symbol used by bench.
-fn C.getrusage(who int, usage &C.rusage) int
+fn C.getrusage(who int, usage voidptr) int
 
 // Step represents step data used by bench.
 pub struct Step {
@@ -78,9 +71,10 @@ fn current_rss_kb() i64 {
 
 // macos_peak_rss_kb supports macos peak rss kb handling for bench.
 fn macos_peak_rss_kb() i64 {
-	mut usage := C.rusage{}
-	if C.getrusage(0, &usage) == 0 {
-		return usage.ru_maxrss / 1024
+	mut usage := [256]u8{}
+	if C.getrusage(0, &usage[0]) == 0 {
+		ru_maxrss := unsafe { *(&i64(&usage[32])) }
+		return ru_maxrss / 1024
 	}
 	return 0
 }

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -36,12 +36,13 @@ mut:
 	module_init_fn_modules       map[string]string      // C init fn name -> V module name
 	module_imports               map[string][]string    // module -> imported modules
 	c_directives                 []CDirective
+	inlined_c_structs            map[string]bool
+	inlined_c_fns                map[string]bool
+	inlined_c_declared_fns       map[string]bool
 	c_flags                      []string
 	libc_compat_fns              map[string]bool
 	tc                           &types.TypeChecker = unsafe { nil }
 	has_builtins                 bool
-	has_stdatomic_header         bool
-	has_stdatomic_compat_header  bool
 	tmp_count                    int
 	line_start                   bool
 	field_name_set               map[string]bool   // every struct field's C name (lazy) — for const/field collision checks
@@ -94,6 +95,13 @@ struct CDirective {
 	before_import bool
 }
 
+struct CInlineHeader {
+	text                 string
+	preserved_directives []string
+	preserved_c_fns      []string
+	preserved_c_structs  []string
+}
+
 // was_parallel reports whether the last fn codegen actually ran across threads.
 pub fn (g &FlatGen) was_parallel() bool {
 	return g.parallel_used
@@ -130,6 +138,9 @@ pub fn FlatGen.new() FlatGen {
 		module_init_fn_modules:       map[string]string{}
 		module_imports:               map[string][]string{}
 		c_directives:                 []CDirective{}
+		inlined_c_structs:            map[string]bool{}
+		inlined_c_fns:                map[string]bool{}
+		inlined_c_declared_fns:       map[string]bool{}
 		c_flags:                      []string{}
 		libc_compat_fns:              map[string]bool{}
 		modules:                      map[string]string{}
@@ -214,10 +225,11 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.module_init_fn_modules = map[string]string{}
 	g.module_imports = map[string][]string{}
 	g.c_directives = []CDirective{}
+	g.inlined_c_structs = map[string]bool{}
+	g.inlined_c_fns = map[string]bool{}
+	g.inlined_c_declared_fns = map[string]bool{}
 	g.c_flags = []string{}
 	g.libc_compat_fns = map[string]bool{}
-	g.has_stdatomic_header = false
-	g.has_stdatomic_compat_header = false
 	g.modules = map[string]string{}
 	g.fn_ptr_types = map[string]string{}
 	g.fixed_array_ret_wrappers = map[string]bool{}
@@ -252,6 +264,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.collect_interface_impls()
 	g.preseed_struct_fn_ptr_types()
 	g.preseed_global_fn_ptr_types()
+	g.preseed_c_extern_fn_ptr_types()
 	// Decide fixed-array return wrappers before generating function bodies, so
 	// signatures, returns and call sites all agree on the wrapped types.
 	g.populate_fixed_array_ret_wrappers()
@@ -266,7 +279,10 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	unsafe { g.sb.free() }
 	g.sb = orig_sb
 	g.line_start = orig_line_start
+	g.c99_feature_test_macros()
+	g.emit_preserved_c_directives()
 	g.preamble()
+	g.emit_c_directives()
 	g.enum_decls()
 	g.type_alias_decls()
 	g.type_forward_decls()
@@ -280,9 +296,10 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.fn_ptr_typedefs()
 	g.struct_decls()
 	g.fixed_array_typedefs()
-	g.builtin_abi_decls()
 	g.multi_return_typedefs()
 	g.optional_typedefs()
+	g.c_extern_forward_decls()
+	g.builtin_abi_decls()
 	g.global_decls()
 	g.forward_decls()
 	g.enum_str_forward_decls()
@@ -327,6 +344,7 @@ fn node_kind_id(node flat.Node) int {
 
 // collect_gen_info updates collect gen info state for c.
 fn (mut g FlatGen) collect_gen_info() {
+	g.collect_c_flags_from_directives()
 	mut cur_module := ''
 	mut cur_file := ''
 	mut seen_import_in_file := false
@@ -382,19 +400,10 @@ fn (mut g FlatGen) collect_gen_info() {
 		if g.collect_c_directive(cur_module, node, cur_file, !seen_import_in_file) {
 			continue
 		}
-		if node.kind == .directive && node.value == 'flag' && node.typ.len > 0 {
-			flag := c_flag_arg(node.typ, g.compiler_vroot, cur_file)
-			if flag.len > 0 && flag !in g.c_flags {
-				g.c_flags << flag
-			}
+		if node.kind == .directive && node.value == 'flag' {
 			continue
 		}
-		if node.kind == .directive && node.value == 'pkgconfig' && node.typ.len > 0 {
-			for flag in c_pkgconfig_flags(node.typ) {
-				if flag.len > 0 && flag !in g.c_flags {
-					g.c_flags << flag
-				}
-			}
+		if node.kind == .directive && node.value == 'pkgconfig' {
 			continue
 		}
 		if kind_id == 62 {
@@ -497,6 +506,35 @@ fn (mut g FlatGen) collect_gen_info() {
 	g.collect_const_init_order_from_files()
 }
 
+fn (mut g FlatGen) collect_c_flags_from_directives() {
+	mut cur_file := ''
+	for node in g.a.nodes {
+		kind_id := node_kind_id(node)
+		if kind_id == 77 {
+			cur_file = node.value
+			g.note_compiler_source_file(node.value)
+			continue
+		}
+		if node.kind != .directive || node.typ.len == 0 {
+			continue
+		}
+		if node.value == 'flag' {
+			flag := c_flag_arg(node.typ, g.compiler_vroot, cur_file)
+			if flag.len > 0 && flag !in g.c_flags {
+				g.c_flags << flag
+			}
+			continue
+		}
+		if node.value == 'pkgconfig' {
+			for flag in c_pkgconfig_flags(node.typ) {
+				if flag.len > 0 && flag !in g.c_flags {
+					g.c_flags << flag
+				}
+			}
+		}
+	}
+}
+
 fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, source_file string, before_import bool) bool {
 	if node.kind != .directive {
 		return false
@@ -511,16 +549,29 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 		}
 		// These helper headers are superseded by the inline compiler helpers emitted in
 		// builtin_abi_decls(); also including them would redefine the helpers.
-		if include_arg.contains('prealloc_atomics.h') || include_arg.contains('filelock_helpers.h') {
+		if include_arg.contains('prealloc_atomics.h') || include_arg.contains('filelock_helpers.h')
+			|| include_arg.contains('stdatomic') {
 			return true
 		}
-		if is_stdatomic_header(include_arg) {
-			g.has_stdatomic_header = true
+		include_dirs := c_flag_include_dirs(g.c_flags)
+		if header := c_inline_header_text(include_arg, g.compiler_vroot, source_file, include_dirs) {
+			header_text := header.text
+			g.collect_inlined_c_structs(header_text)
+			g.collect_inlined_c_fns(header_text)
+			g.collect_inlined_c_declared_fns(header_text)
+			g.collect_preserved_c_fns(header.preserved_c_fns)
+			g.collect_preserved_c_structs(header.preserved_c_structs)
+			for directive in header.preserved_directives {
+				g.add_c_directive(module_name, directive, before_import)
+			}
+			if header_text.len > 0 {
+				g.add_c_directive(module_name, header_text, before_import)
+			}
+		} else if c_should_preserve_uninlined_include(include_arg) {
+			g.collect_preserved_c_fns(c_preserved_system_include_declared_fns(include_arg))
+			g.collect_preserved_c_structs(c_preserved_system_include_struct_names(include_arg))
+			g.add_c_directive(module_name, '#include ${include_arg}', before_import)
 		}
-		if is_stdatomic_compat_header(include_arg) {
-			g.has_stdatomic_compat_header = true
-		}
-		g.add_c_directive(module_name, '#include ${include_arg}', before_import)
 		return true
 	}
 	if node.value in ['define', 'undef', 'ifdef', 'ifndef', 'if', 'elif', 'else', 'endif', 'pragma',
@@ -532,15 +583,683 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 	return false
 }
 
-fn is_stdatomic_header(include_arg string) bool {
-	normalized := include_arg.replace('\\', '/')
-	return normalized == '<stdatomic.h>' || normalized == '"stdatomic.h"'
-		|| normalized.ends_with('/stdatomic.h"') || is_stdatomic_compat_header(normalized)
+fn c_inline_header_text(include_arg string, vroot string, source_file string, include_dirs []string) ?CInlineHeader {
+	if replacement := c_system_include_replacement(include_arg) {
+		return CInlineHeader{
+			text: replacement
+		}
+	}
+	mut seen := map[string]bool{}
+	for path in c_include_file_paths(include_arg, vroot, source_file, include_dirs) {
+		if header := c_inline_header_file(path, vroot, include_dirs, mut seen) {
+			return header
+		}
+	}
+	return none
 }
 
-fn is_stdatomic_compat_header(include_arg string) bool {
-	normalized := include_arg.replace('\\', '/')
-	return normalized.contains('/thirdparty/stdatomic/') && normalized.ends_with('/atomic.h"')
+fn c_inline_header_file(path string, vroot string, include_dirs []string, mut seen map[string]bool) ?CInlineHeader {
+	if path.len == 0 || !os.exists(path) {
+		return none
+	}
+	real_path := os.real_path(path)
+	if seen[real_path] {
+		return CInlineHeader{}
+	}
+	seen[real_path] = true
+	text := os.read_file(real_path) or { return none }
+	return c_inline_header_file_text(text, vroot, real_path, include_dirs, mut seen)
+}
+
+fn c_inline_header_file_text(text string, vroot string, source_file string, include_dirs []string, mut seen map[string]bool) CInlineHeader {
+	mut lines := []string{}
+	mut preserved_directives := []string{}
+	mut preserved_c_fns := []string{}
+	mut preserved_c_structs := []string{}
+	mut include_context := []string{}
+	mut include_prefix := []string{}
+	for line in text.split_into_lines() {
+		clean := line.trim_space()
+		if c_directive_name(clean) == 'include' {
+			include_arg := c_include_arg(c_directive_arg(clean), vroot, source_file)
+			if replacement := c_system_include_replacement(include_arg) {
+				lines << replacement
+				continue
+			}
+			mut inlined := false
+			for path in c_include_file_paths(include_arg, vroot, source_file, include_dirs) {
+				if nested := c_inline_header_file(path, vroot, include_dirs, mut seen) {
+					if nested.text.len > 0 {
+						lines << nested.text
+					}
+					preserved_directives << nested.preserved_directives
+					preserved_c_fns << nested.preserved_c_fns
+					preserved_c_structs << nested.preserved_c_structs
+					inlined = true
+					break
+				}
+			}
+			if !inlined && c_should_preserve_uninlined_include(include_arg) {
+				preserved_directives << c_preserved_nested_include_directive(include_arg,
+					include_context, include_prefix)
+				preserved_c_fns << c_preserved_system_include_declared_fns(include_arg)
+				preserved_c_structs << c_preserved_system_include_struct_names(include_arg)
+			}
+			continue
+		}
+		lines << line
+		c_update_nested_include_context(clean, line, mut include_context)
+		c_update_nested_include_prefix(clean, line, mut include_prefix)
+	}
+	return CInlineHeader{
+		text:                 lines.join('\n')
+		preserved_directives: preserved_directives
+		preserved_c_fns:      preserved_c_fns
+		preserved_c_structs:  preserved_c_structs
+	}
+}
+
+fn c_update_nested_include_context(clean string, line string, mut context []string) {
+	match c_directive_name(clean) {
+		'if', 'ifdef', 'ifndef', 'elif', 'else' {
+			context << line
+		}
+		'endif' {
+			for context.len > 0 {
+				name := c_directive_name(context[context.len - 1].trim_space())
+				context.delete_last()
+				if name in ['if', 'ifdef', 'ifndef'] {
+					break
+				}
+			}
+		}
+		else {}
+	}
+}
+
+fn c_update_nested_include_prefix(clean string, line string, mut prefix []string) {
+	match c_directive_name(clean) {
+		'define', 'undef' {
+			prefix << line
+		}
+		else {
+			prefix.clear()
+		}
+	}
+}
+
+fn c_preserved_nested_include_directive(include_arg string, context []string, prefix []string) string {
+	if context.len == 0 && prefix.len == 0 {
+		return '#include ${include_arg}'
+	}
+	mut lines := context.clone()
+	lines << prefix
+	lines << '#include ${include_arg}'
+	for _ in 0 .. c_nested_include_context_depth(context) {
+		lines << '#endif'
+	}
+	return lines.join('\n')
+}
+
+fn c_nested_include_context_depth(context []string) int {
+	mut depth := 0
+	for line in context {
+		if c_directive_name(line.trim_space()) in ['if', 'ifdef', 'ifndef'] {
+			depth++
+		}
+	}
+	return depth
+}
+
+fn c_flag_include_dirs(flags []string) []string {
+	mut dirs := []string{}
+	for flag in flags {
+		tokens := flag.fields()
+		mut i := 0
+		for i < tokens.len {
+			tok := tokens[i]
+			mut dir := ''
+			if tok == '-I' {
+				if i + 1 < tokens.len {
+					dir = tokens[i + 1]
+					i++
+				}
+			} else if tok.starts_with('-I') && tok.len > 2 {
+				dir = tok[2..]
+			}
+			if dir.len > 0 && dir !in dirs {
+				dirs << dir
+			}
+			i++
+		}
+	}
+	return dirs
+}
+
+fn c_system_include_replacement(include_arg string) ?string {
+	match include_arg.trim_space() {
+		'<stdint.h>' {
+			return c_stdint_header_text()
+		}
+		else {
+			return none
+		}
+	}
+}
+
+fn c_should_preserve_uninlined_include(include_arg string) bool {
+	clean := include_arg.trim_space()
+	if clean.len == 0 {
+		return false
+	}
+	if clean[0] == `<` {
+		return !c_headerless_system_include_is_handled(clean)
+	}
+	return true
+}
+
+fn c_preserved_system_include_declared_fns(include_arg string) []string {
+	match include_arg.trim_space() {
+		'<bcrypt.h>' {
+			return ['BCryptGenRandom']
+		}
+		'<dlfcn.h>' {
+			return ['dlopen', 'dlsym', 'dlclose', 'dlerror']
+		}
+		else {
+			return []string{}
+		}
+	}
+}
+
+fn c_preserved_system_include_struct_names(include_arg string) []string {
+	match include_arg.trim_space() {
+		'<X11/Xlib.h>', '<X11/Xutil.h>', '<X11/Xresource.h>', '<X11/XKBlib.h>',
+		'<X11/extensions/XInput2.h>', '<X11/Xcursor/Xcursor.h>' {
+			return c_x11_preserved_struct_names.clone()
+		}
+		else {
+			return []string{}
+		}
+	}
+}
+
+const c_x11_preserved_struct_names = [
+	'Display',
+	'Screen',
+	'Visual',
+	'XButtonEvent',
+	'XClientMessageData',
+	'XClientMessageEvent',
+	'XCrossingEvent',
+	'XcursorImage',
+	'XDestroyWindowEvent',
+	'XEvent',
+	'XFocusChangeEvent',
+	'XGenericEventCookie',
+	'XIEventMask',
+	'XIRawEvent',
+	'XIValuatorState',
+	'XkbDescRec',
+	'XkbKeyAliasRec',
+	'XkbKeyNameRec',
+	'XkbNamesRec',
+	'XKeyEvent',
+	'XMotionEvent',
+	'XPropertyEvent',
+	'XrmValue',
+	'XSelectionClearEvent',
+	'XSelectionEvent',
+	'XSelectionRequestEvent',
+	'XSetWindowAttributes',
+	'XSizeHints',
+	'XVisualInfo',
+	'XWindowAttributes',
+]
+
+fn c_headerless_system_include_is_handled(include_arg string) bool {
+	if include_arg.len < 3 || include_arg[0] != `<` || include_arg[include_arg.len - 1] != `>` {
+		return false
+	}
+	name := include_arg[1..include_arg.len - 1]
+	return name in c_headerless_handled_system_headers
+}
+
+const c_headerless_handled_system_headers = {
+	'arpa/inet.h':     true
+	'conio.h':         true
+	'dirent.h':        true
+	'errno.h':         true
+	'execinfo.h':      true
+	'fcntl.h':         true
+	'float.h':         true
+	'io.h':            true
+	'math.h':          true
+	'netdb.h':         true
+	'netinet/in.h':    true
+	'netinet/tcp.h':   true
+	'poll.h':          true
+	'process.h':       true
+	'pthread.h':       true
+	'pthread_np.h':    true
+	'semaphore.h':     true
+	'signal.h':        true
+	'stdarg.h':        true
+	'stdatomic.h':     true
+	'stdbool.h':       true
+	'stddef.h':        true
+	'stdint.h':        true
+	'stdio.h':         true
+	'stdlib.h':        true
+	'string.h':        true
+	'synchapi.h':      true
+	'sys/epoll.h':     true
+	'sys/event.h':     true
+	'sys/file.h':      true
+	'sys/ioctl.h':     true
+	'sys/mman.h':      true
+	'sys/ptrace.h':    true
+	'sys/random.h':    true
+	'sys/resource.h':  true
+	'sys/select.h':    true
+	'sys/sendfile.h':  true
+	'sys/socket.h':    true
+	'sys/stat.h':      true
+	'sys/statvfs.h':   true
+	'sys/syscall.h':   true
+	'sys/sysctl.h':    true
+	'sys/syslimits.h': true
+	'sys/time.h':      true
+	'sys/types.h':     true
+	'sys/uio.h':       true
+	'sys/utime.h':     true
+	'sys/utsname.h':   true
+	'sys/wait.h':      true
+	'termios.h':       true
+	'time.h':          true
+	'unistd.h':        true
+	'utime.h':         true
+	'wchar.h':         true
+	'windows.h':       true
+	'winsock2.h':      true
+	'ws2tcpip.h':      true
+}
+
+fn c_stdint_header_text() string {
+	return '#if !defined(__V_HEADERLESS_STDINT_H) && !defined(_STDINT_H) && !defined(_STDINT_H_) && !defined(_STDINT) && !defined(_STDINT_H_INCLUDED) && !defined(_GCC_STDINT_H) && !defined(_MSC_STDINT_H_)
+#define __V_HEADERLESS_STDINT_H
+typedef signed char int8_t;
+typedef short int16_t;
+typedef int int32_t;
+typedef long long int64_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+#ifndef INT8_MIN
+#define INT8_MIN (-128)
+#endif
+#ifndef INT16_MIN
+#define INT16_MIN (-32767 - 1)
+#endif
+#ifndef INT32_MIN
+#define INT32_MIN (-2147483647 - 1)
+#endif
+#ifndef INT64_MIN
+#define INT64_MIN (-9223372036854775807LL - 1)
+#endif
+#ifndef INT8_MAX
+#define INT8_MAX 127
+#endif
+#ifndef INT16_MAX
+#define INT16_MAX 32767
+#endif
+#ifndef INT32_MAX
+#define INT32_MAX 2147483647
+#endif
+#ifndef INT64_MAX
+#define INT64_MAX 9223372036854775807LL
+#endif
+#ifndef UINT8_MAX
+#define UINT8_MAX 255U
+#endif
+#ifndef UINT16_MAX
+#define UINT16_MAX 65535U
+#endif
+#ifndef UINT32_MAX
+#define UINT32_MAX 4294967295U
+#endif
+#ifndef UINT64_MAX
+#define UINT64_MAX 18446744073709551615ULL
+#endif
+#ifndef INT32_C
+#define INT32_C(c) c
+#endif
+#ifndef UINT32_C
+#define UINT32_C(c) c ## U
+#endif
+#ifndef INT64_C
+#define INT64_C(c) c ## LL
+#endif
+#ifndef UINT64_C
+#define UINT64_C(c) c ## ULL
+#endif
+#endif'
+}
+
+fn (mut g FlatGen) collect_inlined_c_structs(text string) {
+	for line in text.split_into_lines() {
+		clean := line.trim_space()
+		mut rest := ''
+		if clean.starts_with('typedef struct ') {
+			rest = clean['typedef struct '.len..]
+		} else if clean.starts_with('typedef union ') {
+			rest = clean['typedef union '.len..]
+		} else if clean.starts_with('struct ') {
+			rest = clean['struct '.len..]
+		} else if clean.starts_with('union ') {
+			rest = clean['union '.len..]
+		} else {
+			continue
+		}
+		tag := c_header_struct_tag(rest)
+		if tag.len > 0 {
+			g.inlined_c_structs[tag] = true
+		}
+	}
+	for alias in c_typedef_struct_aliases(text) {
+		g.inlined_c_structs[alias] = true
+	}
+	for alias in c_typedef_union_aliases(text) {
+		g.inlined_c_structs[alias] = true
+	}
+}
+
+fn (mut g FlatGen) collect_inlined_c_fns(text string) {
+	mut pending_static := false
+	for line in text.split_into_lines() {
+		clean := line.trim_space()
+		if clean.len == 0 {
+			continue
+		}
+		if clean.starts_with('static ') {
+			name := c_header_fn_name(clean)
+			if name.len > 0 {
+				g.inlined_c_fns[name] = true
+				pending_static = false
+			} else {
+				pending_static = c_static_fn_prefix_can_continue(clean)
+			}
+			continue
+		}
+		if pending_static {
+			name := c_header_fn_name(clean)
+			if name.len > 0 {
+				g.inlined_c_fns[name] = true
+				pending_static = false
+				continue
+			}
+			if clean.ends_with(';') || clean.contains('{') || clean.starts_with('#') {
+				pending_static = false
+			}
+		}
+	}
+}
+
+fn (mut g FlatGen) collect_inlined_c_declared_fns(text string) {
+	for line in text.split_into_lines() {
+		name := c_header_declared_fn_name(line.trim_space())
+		if name.len > 0 {
+			g.inlined_c_declared_fns[name] = true
+		}
+	}
+}
+
+fn (mut g FlatGen) collect_preserved_c_fns(names []string) {
+	for name in names {
+		g.inlined_c_declared_fns[name] = true
+	}
+}
+
+fn (mut g FlatGen) collect_preserved_c_structs(names []string) {
+	for name in names {
+		g.inlined_c_structs[name] = true
+	}
+}
+
+fn c_static_fn_prefix_can_continue(line string) bool {
+	return line in ['static', 'static inline', 'static __inline', 'static __inline__']
+		|| line.starts_with('static inline ') || line.starts_with('static __inline ')
+		|| line.starts_with('static __inline__ ')
+}
+
+fn c_header_struct_tag(rest string) string {
+	mut end := 0
+	for end < rest.len {
+		c := rest[end]
+		if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_` {
+			end++
+			continue
+		}
+		break
+	}
+	return rest[..end]
+}
+
+fn c_typedef_struct_aliases(text string) []string {
+	return c_typedef_aggregate_aliases(text, 'struct')
+}
+
+fn c_typedef_union_aliases(text string) []string {
+	return c_typedef_aggregate_aliases(text, 'union')
+}
+
+fn c_typedef_aggregate_aliases(text string, kind string) []string {
+	mut aliases := []string{}
+	prefix := 'typedef ${kind}'
+	mut start := 0
+	for start < text.len {
+		rel_idx := text[start..].index(prefix) or { break }
+		idx := start + rel_idx
+		mut pos := idx + prefix.len
+		if pos < text.len && c_ident_char(text[pos]) {
+			start = pos + 1
+			continue
+		}
+		for pos < text.len && text[pos].is_space() {
+			pos++
+		}
+		if pos < text.len && text[pos] != `{` {
+			tag := c_header_struct_tag(text[pos..])
+			if tag.len == 0 {
+				start = pos + 1
+				continue
+			}
+			pos += tag.len
+			for pos < text.len && text[pos].is_space() {
+				pos++
+			}
+		}
+		if pos >= text.len || text[pos] != `{` {
+			start = pos + 1
+			continue
+		}
+		close_idx := c_matching_brace_end(text, pos)
+		if close_idx < 0 {
+			break
+		}
+		semi_rel_idx := text[close_idx + 1..].index_u8(`;`)
+		if semi_rel_idx < 0 {
+			break
+		}
+		semi_idx := close_idx + 1 + semi_rel_idx
+		for alias in c_typedef_declarator_aliases(text[close_idx + 1..semi_idx]) {
+			aliases << alias
+		}
+		start = semi_idx + 1
+	}
+	return aliases
+}
+
+fn c_matching_brace_end(text string, open_idx int) int {
+	mut depth := 0
+	for i in open_idx .. text.len {
+		if text[i] == `{` {
+			depth++
+		} else if text[i] == `}` {
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+fn c_typedef_declarator_aliases(decl string) []string {
+	mut aliases := []string{}
+	for part in decl.split(',') {
+		alias := c_last_ident(part)
+		if alias.len > 0 {
+			aliases << alias
+		}
+	}
+	return aliases
+}
+
+fn c_last_ident(text string) string {
+	mut end := text.len
+	for end > 0 && !c_ident_char(text[end - 1]) {
+		end--
+	}
+	mut start := end
+	for start > 0 && c_ident_char(text[start - 1]) {
+		start--
+	}
+	if start == end {
+		return ''
+	}
+	return text[start..end]
+}
+
+fn c_header_fn_name(line string) string {
+	paren := line.index_u8(`(`)
+	if paren < 0 {
+		return ''
+	}
+	mut end := paren
+	for end > 0 && line[end - 1].is_space() {
+		end--
+	}
+	mut start := end
+	for start > 0 && c_ident_char(line[start - 1]) {
+		start--
+	}
+	if start == end {
+		return ''
+	}
+	name := line[start..end]
+	if name in ['if', 'for', 'while', 'switch'] {
+		return ''
+	}
+	return name
+}
+
+fn c_header_declared_fn_name(line string) string {
+	if line.len == 0 || line[0] == `#` || !line.ends_with(';') || !line.contains('(') {
+		return ''
+	}
+	if line.starts_with('typedef ') || line.contains('(*') || line.contains('=')
+		|| line.contains('{') || line.contains('}') {
+		return ''
+	}
+	for prefix in ['return ', 'if ', 'if(', 'for ', 'for(', 'while ', 'while(', 'switch ', 'switch(',
+		'case ', 'do ', 'else '] {
+		if line.starts_with(prefix) {
+			return ''
+		}
+	}
+	paren := line.index_u8(`(`)
+	mut end := paren
+	for end > 0 && line[end - 1].is_space() {
+		end--
+	}
+	mut start := end
+	for start > 0 && c_ident_char(line[start - 1]) {
+		start--
+	}
+	if start == 0 {
+		return ''
+	}
+	return c_header_fn_name(line)
+}
+
+fn c_ident_char(ch u8) bool {
+	return (ch >= `a` && ch <= `z`) || (ch >= `A` && ch <= `Z`)
+		|| (ch >= `0` && ch <= `9`) || ch == `_`
+}
+
+fn c_include_file_path(include_arg string, vroot string, source_file string) string {
+	clean := include_arg.trim_space()
+	if clean.len < 2 {
+		return ''
+	}
+	if clean[0] == `<` {
+		return ''
+	}
+	mut path := ''
+	if clean[0] == `"` && clean[clean.len - 1] == `"` {
+		path = clean[1..clean.len - 1]
+	} else {
+		path = clean
+	}
+	path = c_resolve_pseudo_paths(path, vroot, source_file)
+	if path.len == 0 || os.is_abs_path(path) {
+		return path
+	}
+	if source_file.len == 0 {
+		return path
+	}
+	return os.join_path_single(os.dir(source_file), path)
+}
+
+fn c_include_file_paths(include_arg string, vroot string, source_file string, include_dirs []string) []string {
+	clean := include_arg.trim_space()
+	if clean.len < 2 {
+		return []string{}
+	}
+	mut raw_path := clean
+	mut search_source_dir := true
+	if clean[0] == `"` && clean[clean.len - 1] == `"` {
+		raw_path = clean[1..clean.len - 1]
+	} else if clean[0] == `<` && clean[clean.len - 1] == `>` {
+		raw_path = clean[1..clean.len - 1]
+		search_source_dir = false
+	}
+	mut paths := []string{}
+	if search_source_dir {
+		first := c_include_file_path(include_arg, vroot, source_file)
+		if first.len > 0 {
+			paths << first
+		}
+	}
+	resolved_path := c_resolve_pseudo_paths(raw_path, vroot, source_file)
+	if os.is_abs_path(resolved_path) {
+		if resolved_path !in paths {
+			paths << resolved_path
+		}
+		return paths
+	}
+	for dir in include_dirs {
+		if dir.len == 0 {
+			continue
+		}
+		path := os.join_path_single(dir, resolved_path)
+		if path !in paths {
+			paths << path
+		}
+	}
+	return paths
 }
 
 fn (mut g FlatGen) add_c_directive(module_name string, text string, before_import bool) {
@@ -670,6 +1389,122 @@ fn (g &FlatGen) ordered_c_directives() []string {
 	return dedupe_top_level_c_includes(result)
 }
 
+fn (mut g FlatGen) emit_c_directives() {
+	mut emitted := false
+	for directive in g.ordered_c_directives() {
+		if c_contains_preserved_system_include_directive(directive) {
+			continue
+		}
+		g.writeln(directive)
+		emitted = true
+	}
+	if emitted {
+		g.writeln('')
+	}
+}
+
+fn (mut g FlatGen) emit_preserved_c_directives() {
+	mut emitted := false
+	directives := g.ordered_c_directives()
+	for i, directive in directives {
+		if !c_contains_preserved_system_include_directive(directive) {
+			continue
+		}
+		if directive.contains('\n') {
+			g.emit_preserved_c_directive(directive)
+			emitted = true
+			continue
+		}
+		prefix := c_lifted_include_context_prefix(directives, i)
+		for line in prefix {
+			g.writeln(line)
+			emitted = true
+		}
+		g.emit_preserved_c_directive(directive)
+		emitted = true
+		for _ in 0 .. c_lifted_include_context_depth(prefix) {
+			g.writeln('#endif')
+		}
+	}
+	if emitted {
+		g.writeln('')
+	}
+}
+
+fn (mut g FlatGen) emit_preserved_c_directive(directive string) {
+	if c_preserved_directive_needs_mach_panic_alias(directive) {
+		g.writeln('#define panic mach_panic')
+		g.writeln(directive)
+		g.writeln('#undef panic')
+		return
+	}
+	g.writeln(directive)
+}
+
+fn c_preserved_directive_needs_mach_panic_alias(directive string) bool {
+	for line in directive.split_into_lines() {
+		clean := line.trim_space()
+		if clean == '#include <mach/mach.h>' || clean == '#include <mach/mach_time.h>' {
+			return true
+		}
+	}
+	return false
+}
+
+fn c_lifted_include_context_prefix(directives []string, include_index int) []string {
+	mut prefix := []string{}
+	for i := include_index - 1; i >= 0; i-- {
+		clean := directives[i].trim_space()
+		if c_is_preserved_system_include_directive(clean) {
+			continue
+		}
+		if !c_is_liftable_include_context_directive(clean) {
+			break
+		}
+		prefix << directives[i]
+	}
+	prefix.reverse_in_place()
+	return prefix
+}
+
+fn c_lifted_include_context_depth(prefix []string) int {
+	mut depth := 0
+	for directive in prefix {
+		clean := directive.trim_space()
+		if clean.starts_with('#ifdef') || clean.starts_with('#ifndef') || clean.starts_with('#if ') {
+			depth++
+		}
+	}
+	return depth
+}
+
+fn c_is_liftable_include_context_directive(directive string) bool {
+	clean := directive.trim_space()
+	if clean.len == 0 || clean.contains('\n') || clean.starts_with('#endif') {
+		return false
+	}
+	return clean.starts_with('#define') || clean.starts_with('#undef')
+		|| clean.starts_with('#ifdef') || clean.starts_with('#ifndef') || clean.starts_with('#if ')
+		|| clean.starts_with('#elif') || clean.starts_with('#else')
+}
+
+fn c_is_preserved_system_include_directive(directive string) bool {
+	clean := directive.trim_space()
+	return clean.starts_with('#include <') && clean.ends_with('>') && !clean.contains('\n')
+}
+
+fn c_contains_preserved_system_include_directive(directive string) bool {
+	if c_is_preserved_system_include_directive(directive) {
+		return true
+	}
+	for line in directive.split_into_lines() {
+		if c_is_preserved_system_include_directive(line) {
+			return true
+		}
+	}
+	return false
+}
+
 fn (g &FlatGen) visit_c_directive_module(mod string, directives_by_module map[string][]CDirective, mut visiting map[string]bool, mut visited map[string]bool, mut result []string) {
 	if mod in visited || mod in visiting {
 		return
@@ -732,6 +1567,21 @@ fn c_directive_name(text string) string {
 		return body
 	}
 	return body[..idx]
+}
+
+fn c_directive_arg(text string) string {
+	if text.len == 0 || text[0] != `#` {
+		return ''
+	}
+	body := text[1..].trim_space()
+	mut idx := 0
+	for idx < body.len && !body[idx].is_space() {
+		idx++
+	}
+	if idx >= body.len {
+		return ''
+	}
+	return body[idx..].trim_space()
 }
 
 fn c_include_arg(raw string, vroot string, source_file string) string {
@@ -2322,6 +3172,14 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				g.write(', ${len_expr}, ')
 				g.gen_expr(lhs_id)
 				g.write(')')
+			} else if clean_rhs is types.Struct && clean_rhs.name == 'array' {
+				lhs_type := g.usable_expr_type(lhs_id)
+				fn_name := array_membership_fn_name(lhs_type, false)
+				g.write('${fn_name}(')
+				g.gen_expr(rhs_id)
+				g.write(', ')
+				g.gen_expr(lhs_id)
+				g.write(')')
 			} else {
 				panic('internal error: non-map membership reached C backend in ${g.cur_fn_name}: rhs=${rhs_type.name()} kind=${rhs.kind} value=${rhs.value}')
 			}
@@ -2367,7 +3225,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				''
 			}
 			if base.kind == .ident && base.value == 'C' {
-				g.write(node.value)
+				g.write(c_winapi_wide_export_name(node.value))
 			} else if enum_selector_qbase.len > 0 {
 				ekey := '${enum_selector_qbase}.${node.value}'
 				if eval := g.enum_vals[ekey] {
@@ -2841,58 +3699,6 @@ fn (g &FlatGen) is_module_qualified_enum(base flat.Node) bool {
 }
 
 fn (mut g FlatGen) preamble() {
-	g.c99_feature_test_macros()
-	g.writeln('#include <stdio.h>')
-	g.writeln('#include <stdlib.h>')
-	g.writeln('#include <string.h>')
-	g.writeln('#include <stddef.h>')
-	g.writeln('#include <float.h>')
-	g.writeln('#include <stdint.h>') // guarantees UINTPTR_MAX for the pointer-width atomic helpers
-	g.writeln('#include <math.h>')
-	g.writeln('#include <unistd.h>')
-	g.c99_atomic_compat_decls()
-	if g.has_builtins {
-		g.writeln('#include <time.h>')
-		g.writeln('#include <sys/time.h>')
-		g.writeln('#include <errno.h>')
-		g.writeln('#include <signal.h>')
-		g.writeln('#include <execinfo.h>')
-		g.writeln('#include <dirent.h>')
-		g.writeln('#include <sys/stat.h>')
-		g.writeln('#include <fcntl.h>')
-		g.writeln('#include <sys/ioctl.h>')
-		g.writeln('#include <sys/utsname.h>')
-		g.writeln('#include <pthread.h>')
-		g.writeln('#include <semaphore.h>')
-		g.writeln('#include <termios.h>')
-		g.writeln('#include <unistd.h>')
-		g.writeln('#include <arpa/inet.h>')
-		g.writeln('#include <netdb.h>')
-		g.writeln('#include <netinet/in.h>')
-		g.writeln('#include <netinet/tcp.h>')
-		g.writeln('#include <sys/socket.h>')
-		g.writeln('#ifdef __APPLE__')
-		g.writeln('#define panic mach_panic')
-		g.writeln('#include <mach/mach.h>')
-		g.writeln('#include <mach/task.h>')
-		g.writeln('#include <mach/mach_time.h>')
-		g.writeln('#include <mach-o/dyld.h>')
-		g.writeln('#undef panic')
-		g.writeln('#ifndef PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP')
-		g.writeln('#define PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP 0')
-		g.writeln('#define pthread_rwlockattr_setkind_np(attr, kind) 0')
-		g.writeln('#endif')
-		g.writeln('#endif')
-	}
-	if g.libc_compat_fns['gettid'] {
-		g.writeln('#ifdef __linux__')
-		g.writeln('#include <sys/syscall.h>')
-		g.writeln('#endif')
-	}
-	for directive in g.ordered_c_directives() {
-		g.writeln(directive)
-	}
-	g.writeln('')
 	g.writeln('typedef signed char i8;')
 	g.writeln('typedef short i16;')
 	g.writeln('typedef int i32;')
@@ -2902,16 +3708,47 @@ fn (mut g FlatGen) preamble() {
 	g.writeln('typedef unsigned short u16;')
 	g.writeln('typedef unsigned int u32;')
 	g.writeln('typedef unsigned long long u64;')
+	g.writeln('#ifdef _MSC_VER')
+	g.writeln('#ifdef _WIN64')
+	g.writeln('typedef unsigned __int64 size_t;')
+	g.writeln('typedef __int64 ptrdiff_t;')
+	g.writeln('typedef unsigned __int64 uintptr_t;')
+	g.writeln('typedef __int64 intptr_t;')
+	g.writeln('#else')
+	g.writeln('typedef unsigned int size_t;')
+	g.writeln('typedef int ptrdiff_t;')
+	g.writeln('typedef unsigned int uintptr_t;')
+	g.writeln('typedef int intptr_t;')
+	g.writeln('#endif')
+	g.writeln('#else')
+	g.writeln('typedef __SIZE_TYPE__ size_t;')
+	g.writeln('typedef __PTRDIFF_TYPE__ ptrdiff_t;')
+	g.writeln('typedef __UINTPTR_TYPE__ uintptr_t;')
+	g.writeln('typedef __INTPTR_TYPE__ intptr_t;')
+	g.writeln('#endif')
+	g.writeln('#if !defined(_TIME_T) && !defined(_TIME_T_DEFINED) && !defined(__time_t_defined) && !defined(_BSD_TIME_T_DEFINED_) && !defined(_TIME_T_DECLARED)')
+	g.writeln('typedef long long time_t;')
+	g.writeln('#endif')
 	g.writeln('#ifndef __bool_true_false_are_defined')
-	g.writeln('typedef int bool;')
+	g.writeln('#ifdef _MSC_VER')
+	g.writeln('typedef unsigned char bool;')
+	g.writeln('#else')
+	g.writeln('typedef _Bool bool;')
+	g.writeln('#endif')
+	g.writeln('#define __bool_true_false_are_defined 1')
 	g.writeln('#endif')
 	g.writeln('typedef void* voidptr;')
 	g.writeln('typedef int int_literal;')
 	g.writeln('typedef double float_literal;')
 	g.writeln('struct sync__Channel;')
 	g.writeln('typedef struct sync__Channel* chan;')
+	g.writeln('#ifndef true')
 	g.writeln('#define true 1')
+	g.writeln('#endif')
+	g.writeln('#ifndef false')
 	g.writeln('#define false 0')
+	g.writeln('#endif')
+	g.headerless_libc_preamble()
 	g.write_arch_macros()
 	g.writeln('')
 	if !g.has_builtins {
@@ -2943,22 +3780,1582 @@ fn (mut g FlatGen) c99_feature_test_macros() {
 	g.writeln('#endif')
 }
 
-fn (mut g FlatGen) c99_atomic_compat_decls() {
-	if g.has_stdatomic_header {
-		return
+fn (mut g FlatGen) headerless_libc_preamble() {
+	g.writeln('#ifndef NULL')
+	g.writeln('#define NULL ((void*)0)')
+	g.writeln('#endif')
+	g.writeln('#ifndef offsetof')
+	g.writeln('#if defined(_MSC_VER) && !defined(__clang__)')
+	g.writeln('#define offsetof(type, member) ((size_t)&(((type*)0)->member))')
+	g.writeln('#else')
+	g.writeln('#define offsetof(type, member) __builtin_offsetof(type, member)')
+	g.writeln('#endif')
+	g.writeln('#endif')
+	g.writeln('#ifndef UINTPTR_MAX')
+	g.writeln('#if defined(__LP64__) || defined(_WIN64)')
+	g.writeln('#define UINTPTR_MAX 18446744073709551615ULL')
+	g.writeln('#else')
+	g.writeln('#define UINTPTR_MAX 4294967295U')
+	g.writeln('#endif')
+	g.writeln('#endif')
+	g.writeln('#ifndef EOF')
+	g.writeln('#define EOF (-1)')
+	g.writeln('#endif')
+	g.writeln('#ifndef RAND_MAX')
+	g.writeln('#define RAND_MAX 2147483647')
+	g.writeln('#endif')
+	g.writeln('#ifndef FLT_EPSILON')
+	g.writeln('#define FLT_EPSILON 1.19209290e-7F')
+	g.writeln('#endif')
+	g.writeln('#ifndef DBL_EPSILON')
+	g.writeln('#define DBL_EPSILON 2.2204460492503131e-16')
+	g.writeln('#endif')
+	g.writeln('#ifndef FLT_MAX')
+	g.writeln('#ifdef __FLT_MAX__')
+	g.writeln('#define FLT_MAX __FLT_MAX__')
+	g.writeln('#else')
+	g.writeln('#define FLT_MAX 3.4028234663852886e+38F')
+	g.writeln('#endif')
+	g.writeln('#endif')
+	g.writeln('#ifndef DBL_MAX')
+	g.writeln('#ifdef __DBL_MAX__')
+	g.writeln('#define DBL_MAX __DBL_MAX__')
+	g.writeln('#else')
+	g.writeln('#define DBL_MAX 1.7976931348623158e+308')
+	g.writeln('#endif')
+	g.writeln('#endif')
+	g.writeln('#ifndef SEEK_SET')
+	g.writeln('#define SEEK_SET 0')
+	g.writeln('#endif')
+	g.writeln('#ifndef SEEK_CUR')
+	g.writeln('#define SEEK_CUR 1')
+	g.writeln('#endif')
+	g.writeln('#ifndef SEEK_END')
+	g.writeln('#define SEEK_END 2')
+	g.writeln('#endif')
+	g.writeln('#ifndef _IOFBF')
+	g.writeln('#define _IOFBF 0')
+	g.writeln('#endif')
+	g.writeln('#ifndef _IOLBF')
+	g.writeln('#define _IOLBF 1')
+	g.writeln('#endif')
+	g.writeln('#ifndef _IONBF')
+	g.writeln('#define _IONBF 2')
+	g.writeln('#endif')
+	g.headerless_windows_sdk_types()
+	g.writeln('#if !defined(__FILE_defined) && !defined(_FILE_DEFINED) && !defined(_FILEDEFED) && !defined(__DEFINED_FILE) && !defined(_FILE_DECLARED) && !defined(__FILE_DECLARED)')
+	g.writeln('typedef struct FILE FILE;')
+	g.writeln('#endif')
+	g.writeln('typedef struct DIR DIR;')
+	g.writeln('#if !defined(_SSIZE_T) && !defined(_SSIZE_T_DEFINED) && !defined(__ssize_t_defined) && !defined(_SSIZE_T_DECLARED)')
+	g.writeln('typedef intptr_t ssize_t;')
+	g.writeln('#endif')
+	g.writeln('extern char** environ;')
+	g.writeln('char* getenv(const char* name);')
+	g.writeln('int setenv(const char* name, const char* value, int overwrite);')
+	g.writeln('void abort(void);')
+	g.writeln('void* memset(void* s, int c, size_t n);')
+	g.writeln('void* memcpy(void* dest, const void* src, size_t n);')
+	g.writeln('void* memmove(void* dest, const void* src, size_t n);')
+	g.writeln('int memcmp(const void* s1, const void* s2, size_t n);')
+	g.writeln('size_t strlen(const char* s);')
+	g.writeln('int strcmp(const char* s1, const char* s2);')
+	g.writeln('int strncmp(const char* s1, const char* s2, size_t n);')
+	g.writeln('char* strncpy(char* dest, const char* src, size_t n);')
+	g.writeln('double floor(double x);')
+	g.writeln('double ceil(double x);')
+	g.writeln('float floorf(float x);')
+	g.writeln('float ceilf(float x);')
+	g.writeln('double sqrt(double x);')
+	g.writeln('double pow(double x, double y);')
+	g.writeln('double ldexp(double x, int exp);')
+	g.writeln('double fmod(double x, double y);')
+	g.writeln('double cos(double x);')
+	g.writeln('double acos(double x);')
+	g.writeln('double fabs(double x);')
+	g.writeln('#ifndef _WIN32')
+	g.writeln('int open(const char* path, int flags, ...);')
+	g.writeln('ssize_t read(int fd, void* buf, size_t count);')
+	g.writeln('int fork(void);')
+	g.writeln('int dup2(int oldfd, int newfd);')
+	g.writeln('int execlp(const char* file, const char* arg, ...);')
+	g.writeln('int execvp(const char* file, char* const argv[]);')
+	g.writeln('void _exit(int status);')
+	g.writeln('#endif')
+	g.writeln('int access(const char* path, int mode);')
+	g.writeln('char* realpath(const char* path, char* resolved_path);')
+	g.writeln('char* strrchr(const char* s, int c);')
+	g.writeln('char* strstr(const char* haystack, const char* needle);')
+	g.writeln('int snprintf(char* str, size_t size, const char* format, ...);')
+	g.writeln('int fcntl(int fd, int cmd, ...);')
+	g.writeln('int pipe(int* pipefds);')
+	g.writeln('int close(int fd);')
+	g.writeln('void* signal(int sig, void* handler);')
+	g.writeln('int atexit(void (*f)(void));')
+	g.writeln('#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)')
+	g.writeln('extern FILE* __stdinp;')
+	g.writeln('extern FILE* __stdoutp;')
+	g.writeln('extern FILE* __stderrp;')
+	g.writeln('#define stdin __stdinp')
+	g.writeln('#define stdout __stdoutp')
+	g.writeln('#define stderr __stderrp')
+	g.writeln('int* __error(void);')
+	g.writeln('#define errno (*__error())')
+	g.writeln('#elif defined(__OpenBSD__)')
+	g.writeln('struct __sFstub { long _stub; };')
+	g.writeln('extern struct __sFstub __stdin[];')
+	g.writeln('extern struct __sFstub __stdout[];')
+	g.writeln('extern struct __sFstub __stderr[];')
+	g.writeln('#define stdin ((FILE*)__stdin)')
+	g.writeln('#define stdout ((FILE*)__stdout)')
+	g.writeln('#define stderr ((FILE*)__stderr)')
+	g.writeln('extern int errno;')
+	g.writeln('#elif defined(__NetBSD__)')
+	g.writeln('#if defined(__LP64__) || defined(_LP64)')
+	g.writeln('struct __netbsd_FILE_stub { unsigned char _opaque[152]; };')
+	g.writeln('#else')
+	g.writeln('struct __netbsd_FILE_stub { unsigned char _opaque[88]; };')
+	g.writeln('#endif')
+	g.writeln('extern struct __netbsd_FILE_stub __sF[];')
+	g.writeln('#define stdin ((FILE*)&__sF[0])')
+	g.writeln('#define stdout ((FILE*)&__sF[1])')
+	g.writeln('#define stderr ((FILE*)&__sF[2])')
+	g.writeln('extern int errno;')
+	g.writeln('#elif defined(__ANDROID__)')
+	g.writeln('extern FILE* stdin;')
+	g.writeln('extern FILE* stdout;')
+	g.writeln('extern FILE* stderr;')
+	g.writeln('int* __errno(void);')
+	g.writeln('#define errno (*__errno())')
+	g.writeln('#elif defined(__linux__)')
+	g.writeln('extern FILE* stdin;')
+	g.writeln('extern FILE* stdout;')
+	g.writeln('extern FILE* stderr;')
+	g.writeln('int* __errno_location(void);')
+	g.writeln('#define errno (*__errno_location())')
+	g.writeln('#elif defined(_WIN32)')
+	g.writeln('extern FILE* stdin;')
+	g.writeln('extern FILE* stdout;')
+	g.writeln('extern FILE* stderr;')
+	g.writeln('int* _errno(void);')
+	g.writeln('#define errno (*_errno())')
+	g.writeln('#else')
+	g.writeln('extern FILE* stdin;')
+	g.writeln('extern FILE* stdout;')
+	g.writeln('extern FILE* stderr;')
+	g.writeln('extern int errno;')
+	g.writeln('#endif')
+	g.writeln('typedef int pid_t;')
+	g.writeln('#if !defined(_OFF_T) && !defined(_OFF_T_DEFINED) && !defined(__off_t_defined) && !defined(_BSD_OFF_T_DEFINED_) && !defined(_OFF_T_DECLARED)')
+	g.writeln('typedef long long off_t;')
+	g.writeln('#endif')
+	g.writeln('typedef void* pthread_t;')
+	g.writeln('typedef union { unsigned char _opaque[64]; long long _align; } pthread_attr_t;')
+	g.writeln('typedef union { unsigned char _opaque[128]; long long _align; } pthread_mutex_t;')
+	g.writeln('typedef union { unsigned char _opaque[128]; long long _align; } pthread_cond_t;')
+	g.writeln('typedef union { unsigned char _opaque[256]; long long _align; } pthread_rwlock_t;')
+	g.writeln('typedef union { unsigned char _opaque[64]; long long _align; } pthread_rwlockattr_t;')
+	g.writeln('typedef union { unsigned char _opaque[64]; long long _align; } pthread_condattr_t;')
+	g.writeln('typedef union { unsigned char _opaque[128]; long long _align; } sem_t;')
+	g.writeln('typedef union { unsigned char _opaque[128]; long long _align; } sigset_t;')
+	g.headerless_stdarg_decls()
+	g.writeln('#ifndef PTHREAD_MUTEX_INITIALIZER')
+	g.writeln('#ifdef __APPLE__')
+	g.writeln('#define PTHREAD_MUTEX_INITIALIZER { ._opaque = { 0xa7, 0xab, 0xaa, 0x32 } }')
+	g.writeln('#else')
+	g.writeln('#define PTHREAD_MUTEX_INITIALIZER { 0 }')
+	g.writeln('#endif')
+	g.writeln('#endif')
+	g.writeln('int pthread_mutex_init(void* mutex, void* attr);')
+	g.writeln('int pthread_mutex_lock(void* mutex);')
+	g.writeln('int pthread_mutex_unlock(void* mutex);')
+	g.writeln('int pthread_mutex_destroy(void* mutex);')
+	g.writeln('typedef struct SRWLOCK { void* Ptr; } SRWLOCK;')
+	g.writeln('typedef struct CONDITION_VARIABLE { void* Ptr; } CONDITION_VARIABLE;')
+	g.writeln('typedef void* atomic_uintptr_t;')
+	g.writeln('#if !defined(__cplusplus) && !defined(_WCHAR_T) && !defined(_WCHAR_T_DEFINED) && !defined(__WCHAR_T) && !defined(__wchar_t_defined) && !defined(_BSD_WCHAR_T_DEFINED_) && !defined(_WCHAR_T_DECLARED)')
+	g.writeln('#ifdef _WIN32')
+	g.writeln('typedef unsigned short wchar_t;')
+	g.writeln('#else')
+	g.writeln('typedef unsigned int wchar_t;')
+	g.writeln('#endif')
+	g.writeln('#endif')
+	g.writeln('#ifndef FD_SET')
+	g.writeln('#ifndef FD_SETSIZE')
+	g.writeln('#define FD_SETSIZE 1024')
+	g.writeln('#endif')
+	g.headerless_fd_set_struct()
+	g.writeln('#endif')
+	g.headerless_windows_console_structs()
+	g.headerless_winsize_struct()
+	g.headerless_addrinfo_struct()
+	g.headerless_sockaddr_structs()
+	g.headerless_epoll_structs()
+	g.headerless_kevent_struct()
+	g.headerless_dirent_struct()
+	g.headerless_statvfs_struct()
+	g.headerless_timeval_struct()
+	g.headerless_rusage_struct()
+	g.headerless_timespec_struct()
+	g.headerless_utsname_struct()
+	g.headerless_stat_struct()
+	g.headerless_tm_struct()
+	g.headerless_termios_struct()
+	g.headerless_platform_constants()
+}
+
+fn (mut g FlatGen) headerless_windows_sdk_types() {
+	g.writeln('#ifndef WINAPI')
+	g.writeln('#if defined(_WIN32) && (defined(__i386__) || defined(_M_IX86))')
+	g.writeln('#define WINAPI __stdcall')
+	g.writeln('#else')
+	g.writeln('#define WINAPI')
+	g.writeln('#endif')
+	g.writeln('#endif')
+	g.writeln('#ifdef _WIN32')
+	g.writeln('#if !defined(_WINDEF_) && !defined(_MINWINDEF_)')
+	g.writeln('typedef unsigned long DWORD;')
+	g.writeln('typedef int BOOL;')
+	g.writeln('typedef void* HANDLE;')
+	g.writeln('#endif')
+	g.writeln('#if !defined(_SECURITY_ATTRIBUTES_DEFINED) && !defined(_SECURITY_ATTRIBUTES)')
+	g.writeln('#define _SECURITY_ATTRIBUTES_DEFINED')
+	g.writeln('typedef struct SECURITY_ATTRIBUTES { DWORD nLength; void* lpSecurityDescriptor; BOOL bInheritHandle; } SECURITY_ATTRIBUTES;')
+	g.writeln('#endif')
+	g.writeln('#if !defined(_OVERLAPPED_) && !defined(_OVERLAPPED_DECLARED)')
+	g.writeln('#define _OVERLAPPED_DECLARED')
+	g.writeln('typedef struct OVERLAPPED { uintptr_t Internal; uintptr_t InternalHigh; union { struct { DWORD Offset; DWORD OffsetHigh; }; void* Pointer; }; HANDLE hEvent; } OVERLAPPED;')
+	g.writeln('#endif')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_stdarg_decls() {
+	g.writeln('#ifndef va_start')
+	g.writeln('#if defined(_MSC_VER) && !defined(__clang__)')
+	g.writeln('typedef char* va_list;')
+	g.writeln('#define __V_VA_ALIGN(type) ((sizeof(type) + sizeof(void*) - 1) & ~(sizeof(void*) - 1))')
+	g.writeln('#define va_start(ap, last) ((void)((ap) = (va_list)&(last) + __V_VA_ALIGN(last)))')
+	g.writeln('#define va_arg(ap, type) (*(type*)(((ap) += __V_VA_ALIGN(type)) - __V_VA_ALIGN(type)))')
+	g.writeln('#define va_end(ap) ((void)((ap) = (va_list)0))')
+	g.writeln('#define va_copy(dst, src) ((void)((dst) = (src)))')
+	g.writeln('#else')
+	g.writeln('typedef __builtin_va_list va_list;')
+	g.writeln('#define va_start(ap, last) __builtin_va_start(ap, last)')
+	g.writeln('#define va_arg(ap, type) __builtin_va_arg(ap, type)')
+	g.writeln('#define va_end(ap) __builtin_va_end(ap)')
+	g.writeln('#define va_copy(dst, src) __builtin_va_copy(dst, src)')
+	g.writeln('#endif')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_fd_set_struct() {
+	g.writeln('#ifdef _WIN32')
+	g.writeln('typedef uintptr_t SOCKET;')
+	g.writeln('struct fd_set { unsigned int fd_count; SOCKET fd_array[FD_SETSIZE]; };')
+	g.writeln('typedef struct fd_set fd_set;')
+	g.writeln('static inline void v_fd_zero(fd_set* set) { set->fd_count = 0; }')
+	g.writeln('static inline void v_fd_set(SOCKET fd, fd_set* set) { for (unsigned int i = 0; i < set->fd_count; i++) { if (set->fd_array[i] == fd) { return; } } if (set->fd_count < FD_SETSIZE) { set->fd_array[set->fd_count++] = fd; } }')
+	g.writeln('static inline int v_fd_isset(SOCKET fd, fd_set* set) { for (unsigned int i = 0; i < set->fd_count; i++) { if (set->fd_array[i] == fd) { return 1; } } return 0; }')
+	g.writeln('#define FD_ZERO(set) v_fd_zero(set)')
+	g.writeln('#define FD_SET(fd, set) v_fd_set((SOCKET)(fd), set)')
+	g.writeln('#define FD_ISSET(fd, set) v_fd_isset((SOCKET)(fd), set)')
+	g.writeln('#elif defined(__APPLE__)')
+	g.writeln('#define __V_FD_BITS 32')
+	g.writeln('struct fd_set { unsigned int fds_bits[FD_SETSIZE / __V_FD_BITS]; };')
+	g.writeln('typedef struct fd_set fd_set;')
+	g.writeln('#define FD_ZERO(set) memset((set), 0, sizeof(*(set)))')
+	g.writeln('#define FD_SET(fd, set) ((set)->fds_bits[(fd) / __V_FD_BITS] |= (1U << ((fd) % __V_FD_BITS)))')
+	g.writeln('#define FD_ISSET(fd, set) (((set)->fds_bits[(fd) / __V_FD_BITS] & (1U << ((fd) % __V_FD_BITS))) != 0)')
+	g.writeln('#else')
+	g.writeln('#define __V_FD_BITS (8 * (int)sizeof(unsigned long))')
+	g.writeln('struct fd_set { unsigned long fds_bits[FD_SETSIZE / __V_FD_BITS]; };')
+	g.writeln('typedef struct fd_set fd_set;')
+	g.writeln('#define FD_ZERO(set) memset((set), 0, sizeof(*(set)))')
+	g.writeln('#define FD_SET(fd, set) ((set)->fds_bits[(fd) / __V_FD_BITS] |= (1UL << ((fd) % __V_FD_BITS)))')
+	g.writeln('#define FD_ISSET(fd, set) (((set)->fds_bits[(fd) / __V_FD_BITS] & (1UL << ((fd) % __V_FD_BITS))) != 0)')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_windows_console_structs() {
+	g.writeln('#if defined(_WIN32)')
+	g.writeln('typedef struct COORD { i16 X; i16 Y; } COORD;')
+	g.writeln('typedef struct SMALL_RECT { u16 Left; u16 Top; u16 Right; u16 Bottom; } SMALL_RECT;')
+	g.writeln('typedef union uChar { u16 UnicodeChar; u8 AsciiChar; } uChar;')
+	g.writeln('typedef struct KEY_EVENT_RECORD { int bKeyDown; u16 wRepeatCount; u16 wVirtualKeyCode; u16 wVirtualScanCode; uChar uChar; u32 dwControlKeyState; } KEY_EVENT_RECORD;')
+	g.writeln('typedef struct MOUSE_EVENT_RECORD { COORD dwMousePosition; u32 dwButtonState; u32 dwControlKeyState; u32 dwEventFlags; } MOUSE_EVENT_RECORD;')
+	g.writeln('typedef struct WINDOW_BUFFER_SIZE_RECORD { COORD dwSize; } WINDOW_BUFFER_SIZE_RECORD;')
+	g.writeln('typedef struct MENU_EVENT_RECORD { u32 dwCommandId; } MENU_EVENT_RECORD;')
+	g.writeln('typedef struct FOCUS_EVENT_RECORD { int bSetFocus; } FOCUS_EVENT_RECORD;')
+	g.writeln('typedef union Event { KEY_EVENT_RECORD KeyEvent; MOUSE_EVENT_RECORD MouseEvent; WINDOW_BUFFER_SIZE_RECORD WindowBufferSizeEvent; MENU_EVENT_RECORD MenuEvent; FOCUS_EVENT_RECORD FocusEvent; } Event;')
+	g.writeln('typedef struct INPUT_RECORD { u16 EventType; Event Event; } INPUT_RECORD;')
+	g.writeln('typedef struct CONSOLE_SCREEN_BUFFER_INFO { COORD dwSize; COORD dwCursorPosition; u16 wAttributes; SMALL_RECT srWindow; COORD dwMaximumWindowSize; } CONSOLE_SCREEN_BUFFER_INFO;')
+	g.writeln('typedef struct CHAR_INFO { uChar Char; u16 Attributes; } CHAR_INFO;')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_winsize_struct() {
+	g.writeln('struct winsize { unsigned short ws_row; unsigned short ws_col; unsigned short ws_xpixel; unsigned short ws_ypixel; };')
+}
+
+fn (mut g FlatGen) headerless_addrinfo_struct() {
+	g.writeln('#if defined(_WIN32)')
+	g.writeln('struct addrinfo { int ai_flags; int ai_family; int ai_socktype; int ai_protocol; size_t ai_addrlen; char* ai_canonname; void* ai_addr; struct addrinfo* ai_next; };')
+	g.writeln('#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)')
+	g.writeln('struct addrinfo { int ai_flags; int ai_family; int ai_socktype; int ai_protocol; unsigned int ai_addrlen; char* ai_canonname; void* ai_addr; struct addrinfo* ai_next; };')
+	g.writeln('#else')
+	g.writeln('struct addrinfo { int ai_flags; int ai_family; int ai_socktype; int ai_protocol; unsigned int ai_addrlen; void* ai_addr; char* ai_canonname; struct addrinfo* ai_next; };')
+	g.writeln('#endif')
+	g.writeln('typedef struct addrinfo addrinfo;')
+}
+
+fn (mut g FlatGen) headerless_sockaddr_structs() {
+	g.writeln('#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)')
+	g.writeln('struct sockaddr { u8 sa_len; u8 sa_family; char sa_data[14]; };')
+	g.writeln('struct sockaddr_in { u8 sin_len; u8 sin_family; u16 sin_port; u32 sin_addr; char sin_zero[8]; };')
+	g.writeln('struct sockaddr_in6 { u8 sin6_len; u8 sin6_family; u16 sin6_port; u32 sin6_flowinfo; u8 sin6_addr[16]; u32 sin6_scope_id; };')
+	g.writeln('struct sockaddr_un { u8 sun_len; u8 sun_family; char sun_path[104]; };')
+	g.writeln('#else')
+	g.writeln('struct sockaddr { u16 sa_family; char sa_data[14]; };')
+	g.writeln('struct sockaddr_in { u16 sin_family; u16 sin_port; u32 sin_addr; char sin_zero[8]; };')
+	g.writeln('struct sockaddr_in6 { u16 sin6_family; u16 sin6_port; u32 sin6_flowinfo; u8 sin6_addr[16]; u32 sin6_scope_id; };')
+	g.writeln('struct sockaddr_un { u16 sun_family; char sun_path[108]; };')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_epoll_structs() {
+	g.writeln('#if defined(__linux__) || defined(__ANDROID__)')
+	g.writeln('typedef union epoll_data { void* ptr; int fd; u32 u32; u64 u64; } epoll_data_t;')
+	g.writeln('struct epoll_event { u32 events; epoll_data_t data; } __attribute__((packed));')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_kevent_struct() {
+	g.writeln('#if defined(__NetBSD__)')
+	g.writeln('struct kevent { uintptr_t ident; u32 filter; u32 flags; u32 fflags; i64 data; void* udata; u64 ext[4]; };')
+	g.writeln('#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)')
+	g.writeln('struct kevent { uintptr_t ident; i16 filter; u16 flags; u32 fflags; intptr_t data; void* udata; };')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_dirent_struct() {
+	g.writeln('#if defined(__APPLE__)')
+	g.writeln('struct dirent { u64 d_ino; u64 d_seekoff; u16 d_reclen; u16 d_namlen; u8 d_type; char d_name[1024]; };')
+	g.writeln('#elif defined(__FreeBSD__)')
+	g.writeln('struct dirent { u64 d_ino; i64 d_seekoff; u16 d_reclen; u8 d_type; u8 __pad0; u16 d_namlen; u16 __pad1; char d_name[256]; };')
+	g.writeln('#elif defined(__OpenBSD__)')
+	g.writeln('struct dirent { u64 d_ino; i64 d_seekoff; u16 d_reclen; u8 d_type; u8 d_namlen; u8 __d_padding[4]; char d_name[256]; };')
+	g.writeln('#elif defined(__NetBSD__)')
+	g.writeln('struct dirent { u64 d_ino; u16 d_reclen; u16 d_namlen; u8 d_type; char d_name[512]; };')
+	g.writeln('#elif defined(__DragonFly__)')
+	g.writeln('struct dirent { u64 d_ino; u16 d_namlen; u8 d_type; u8 __unused1; u32 __unused2; char d_name[256]; };')
+	g.writeln('#elif defined(__linux__) && (defined(__i386__) || defined(__arm__))')
+	g.writeln('struct dirent { unsigned long d_ino; long d_off; unsigned short d_reclen; unsigned char d_type; char d_name[256]; };')
+	g.writeln('#else')
+	g.writeln('struct dirent { u64 d_ino; i64 d_off; unsigned short d_reclen; unsigned char d_type; char d_name[256]; };')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_statvfs_struct() {
+	g.writeln('#ifdef __NetBSD__')
+	g.writeln('struct statvfs { unsigned long f_flag; unsigned long f_bsize; unsigned long f_frsize; unsigned long f_iosize; u64 f_blocks; u64 f_bfree; u64 f_bavail; u64 f_bresvd; u64 f_files; u64 f_ffree; u64 f_favail; u64 f_fresvd; u64 f_syncreads; u64 f_syncwrites; u64 f_asyncreads; u64 f_asyncwrites; struct { i32 __fsid_val[2]; } f_fsidx; unsigned long f_fsid; unsigned long f_namemax; u32 f_owner; u64 f_spare[4]; char f_fstypename[32]; char f_mntonname[1024]; char f_mntfromname[1024]; char f_mntfromlabel[1024]; };')
+	g.writeln('#else')
+	g.writeln('struct statvfs { unsigned long f_bsize; unsigned long f_frsize; unsigned long f_blocks; unsigned long f_bfree; unsigned long f_bavail; unsigned long f_files; unsigned long f_ffree; unsigned long f_favail; unsigned long f_fsid; unsigned long f_flag; unsigned long f_namemax; int __f_spare[6]; };')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_timeval_struct() {
+	g.writeln('#ifdef _WIN32')
+	g.writeln('struct timeval { long tv_sec; long tv_usec; };')
+	g.writeln('#else')
+	g.writeln('struct timeval { long tv_sec; long tv_usec; };')
+	g.writeln('#endif')
+	g.writeln('typedef struct timeval timeval;')
+}
+
+fn (mut g FlatGen) headerless_rusage_struct() {
+	g.writeln('struct rusage { struct timeval ru_utime; struct timeval ru_stime; long ru_maxrss; long ru_ixrss; long ru_idrss; long ru_isrss; long ru_minflt; long ru_majflt; long ru_nswap; long ru_inblock; long ru_oublock; long ru_msgsnd; long ru_msgrcv; long ru_nsignals; long ru_nvcsw; long ru_nivcsw; };')
+}
+
+fn (mut g FlatGen) headerless_timespec_struct() {
+	g.writeln('#if !defined(_STRUCT_TIMESPEC) && !defined(_TIMESPEC_DEFINED) && !defined(_TIMESPEC_DECLARED) && !defined(__timespec_defined)')
+	g.writeln('#ifdef _WIN32')
+	g.writeln('struct timespec { i64 tv_sec; long tv_nsec; };')
+	g.writeln('#else')
+	g.writeln('struct timespec { long tv_sec; long tv_nsec; };')
+	g.writeln('#endif')
+	g.writeln('#endif')
+	g.writeln('typedef struct timespec timespec;')
+}
+
+fn (mut g FlatGen) headerless_tm_struct() {
+	g.writeln('#ifdef _WIN32')
+	g.writeln('struct tm { int tm_sec; int tm_min; int tm_hour; int tm_mday; int tm_mon; int tm_year; int tm_wday; int tm_yday; int tm_isdst; };')
+	g.writeln('#else')
+	g.writeln('struct tm { int tm_sec; int tm_min; int tm_hour; int tm_mday; int tm_mon; int tm_year; int tm_wday; int tm_yday; int tm_isdst; long tm_gmtoff; const char* tm_zone; };')
+	g.writeln('#endif')
+	g.writeln('typedef struct tm tm;')
+}
+
+fn (mut g FlatGen) headerless_termios_struct() {
+	g.writeln('#if defined(__APPLE__)')
+	g.writeln('struct termios { size_t c_iflag; size_t c_oflag; size_t c_cflag; size_t c_lflag; u8 c_cc[20]; size_t c_ispeed; size_t c_ospeed; };')
+	g.writeln('#elif defined(__linux__) || defined(__ANDROID__)')
+	g.writeln('struct termios { int c_iflag; int c_oflag; int c_cflag; int c_lflag; u8 c_line; u8 c_cc[32]; int c_ispeed; int c_ospeed; };')
+	g.writeln('#elif defined(__sun)')
+	g.writeln('struct termios { int c_iflag; int c_oflag; int c_cflag; int c_lflag; u8 c_cc[20]; };')
+	g.writeln('#elif defined(__QNX__) || defined(__QNXNTO__)')
+	g.writeln('struct termios { int c_iflag; int c_oflag; int c_cflag; int c_lflag; u8 c_cc[20]; u32 reserved[3]; int c_ispeed; int c_ospeed; };')
+	g.writeln('#else')
+	g.writeln('struct termios { int c_iflag; int c_oflag; int c_cflag; int c_lflag; u8 c_cc[20]; int c_ispeed; int c_ospeed; };')
+	g.writeln('#endif')
+	g.writeln('typedef struct termios termios;')
+}
+
+fn (mut g FlatGen) headerless_utsname_struct() {
+	g.writeln('#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)')
+	g.writeln('struct utsname { char sysname[256]; char nodename[256]; char release[256]; char version[256]; char machine[256]; };')
+	g.writeln('#else')
+	g.writeln('struct utsname { char sysname[65]; char nodename[65]; char release[65]; char version[65]; char machine[65]; char domainname[65]; };')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_stat_struct() {
+	g.writeln('#ifdef __APPLE__')
+	g.writeln('struct stat { int st_dev; unsigned short st_mode; unsigned short st_nlink; u64 st_ino; u32 st_uid; u32 st_gid; int st_rdev; i64 st_atime; i64 st_atimensec; i64 st_mtime; i64 st_mtimensec; i64 st_ctime; i64 st_ctimensec; i64 st_birthtime; i64 st_birthtimensec; i64 st_size; i64 st_blocks; int st_blksize; u32 st_flags; u32 st_gen; int st_lspare; i64 st_qspare[2]; };')
+	g.writeln('#elif defined(__linux__)')
+	g.headerless_linux_stat_struct()
+	g.writeln('#elif defined(_WIN32)')
+	g.writeln('struct stat { u64 st_dev; u64 st_ino; u32 st_mode; u64 st_nlink; u32 st_uid; u32 st_gid; u64 st_rdev; u64 st_size; int st_atime; int st_mtime; int st_ctime; };')
+	g.writeln('#elif defined(__FreeBSD__)')
+	g.headerless_freebsd_stat_struct()
+	g.writeln('#elif defined(__OpenBSD__)')
+	g.headerless_openbsd_stat_struct()
+	g.writeln('#elif defined(__NetBSD__)')
+	g.headerless_netbsd_stat_struct()
+	g.writeln('#elif defined(__DragonFly__)')
+	g.headerless_dragonfly_stat_struct()
+	g.writeln('#elif defined(__sun)')
+	g.headerless_solaris_stat_struct()
+	g.writeln('#elif defined(__QNX__) || defined(__QNXNTO__)')
+	g.headerless_qnx_stat_struct()
+	g.writeln('#else')
+	g.writeln('#error unsupported headerless Unix struct stat layout for this platform')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_freebsd_stat_struct() {
+	g.writeln('#if defined(__i386__)')
+	g.writeln('struct stat { u64 st_dev; u64 st_ino; u64 st_nlink; u16 st_mode; i16 st_bsdflags; u32 st_uid; u32 st_gid; i32 st_padding1; u64 st_rdev; i32 st_atim_ext; i64 st_atime; long st_atimensec; i32 st_mtim_ext; i64 st_mtime; long st_mtimensec; i32 st_ctim_ext; i64 st_ctime; long st_ctimensec; i32 st_btim_ext; i64 st_birthtime; long st_birthtimensec; i64 st_size; i64 st_blocks; i32 st_blksize; u32 st_flags; u64 st_gen; u64 st_filerev; u64 st_spare[9]; };')
+	g.writeln('#else')
+	g.writeln('struct stat { u64 st_dev; u64 st_ino; u64 st_nlink; u16 st_mode; i16 st_bsdflags; u32 st_uid; u32 st_gid; i32 st_padding1; u64 st_rdev; i64 st_atime; long st_atimensec; i64 st_mtime; long st_mtimensec; i64 st_ctime; long st_ctimensec; i64 st_birthtime; long st_birthtimensec; i64 st_size; i64 st_blocks; i32 st_blksize; u32 st_flags; u64 st_gen; u64 st_filerev; u64 st_spare[9]; };')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_openbsd_stat_struct() {
+	g.writeln('struct stat { u32 st_mode; i32 st_dev; u64 st_ino; u32 st_nlink; u32 st_uid; u32 st_gid; i32 st_rdev; i64 st_atime; long st_atimensec; i64 st_mtime; long st_mtimensec; i64 st_ctime; long st_ctimensec; i64 __st_birthtime; long __st_birthtimensec; i64 st_size; i64 st_blocks; i32 st_blksize; u32 st_flags; u32 st_gen; };')
+}
+
+fn (mut g FlatGen) headerless_netbsd_stat_struct() {
+	g.writeln('struct stat { u64 st_dev; u32 st_mode; u64 st_ino; u32 st_nlink; u32 st_uid; u32 st_gid; u64 st_rdev; i64 st_atime; long st_atimensec; i64 st_mtime; long st_mtimensec; i64 st_ctime; long st_ctimensec; i64 st_birthtime; long st_birthtimensec; i64 st_size; i64 st_blocks; i32 st_blksize; u32 st_flags; u32 st_gen; u32 st_spare[2]; };')
+}
+
+fn (mut g FlatGen) headerless_dragonfly_stat_struct() {
+	g.writeln('struct stat { u64 st_ino; u32 st_nlink; u32 st_dev; u16 st_mode; u16 st_padding1; u32 st_uid; u32 st_gid; u32 st_rdev; i64 st_atime; long st_atimensec; i64 st_mtime; long st_mtimensec; i64 st_ctime; long st_ctimensec; i64 st_size; i64 st_blocks; u32 __old_st_blksize; u32 st_flags; u32 st_gen; i32 st_lspare; i64 st_blksize; i64 st_qspare2; };')
+}
+
+fn (mut g FlatGen) headerless_solaris_stat_struct() {
+	g.writeln('#if defined(_LP64)')
+	g.writeln('struct stat { u64 st_dev; u64 st_ino; u32 st_mode; u32 st_nlink; u32 st_uid; u32 st_gid; u64 st_rdev; i64 st_size; long st_atime; long st_atimensec; long st_mtime; long st_mtimensec; long st_ctime; long st_ctimensec; long st_blksize; i64 st_blocks; char st_fstype[16]; };')
+	g.writeln('#else')
+	g.writeln('struct stat { unsigned long st_dev; long st_pad1[3]; unsigned long st_ino; u32 st_mode; u32 st_nlink; u32 st_uid; u32 st_gid; unsigned long st_rdev; long st_pad2[2]; long st_size; long st_pad3; long st_atime; long st_atimensec; long st_mtime; long st_mtimensec; long st_ctime; long st_ctimensec; long st_blksize; long st_blocks; char st_fstype[16]; long st_pad4[8]; };')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_qnx_stat_struct() {
+	g.writeln('#if _FILE_OFFSET_BITS - 0 == 64')
+	g.writeln('struct stat { u64 st_ino; i64 st_size; u64 st_dev; u64 st_rdev; u32 st_uid; u32 st_gid; long st_mtime; long st_atime; long st_ctime; u32 st_mode; u32 st_nlink; long st_blocksize; i32 st_nblocks; long st_blksize; i64 st_blocks; };')
+	g.writeln('#elif defined(__BIGENDIAN__)')
+	g.writeln('struct stat { unsigned long st_ino_hi; unsigned long st_ino; long st_size_hi; long st_size; unsigned long st_dev; unsigned long st_rdev; u32 st_uid; u32 st_gid; long st_mtime; long st_atime; long st_ctime; u32 st_mode; u32 st_nlink; long st_blocksize; i32 st_nblocks; long st_blksize; long st_blocks_hi; long st_blocks; };')
+	g.writeln('#else')
+	g.writeln('struct stat { unsigned long st_ino; unsigned long st_ino_hi; long st_size; long st_size_hi; unsigned long st_dev; unsigned long st_rdev; u32 st_uid; u32 st_gid; long st_mtime; long st_atime; long st_ctime; u32 st_mode; u32 st_nlink; long st_blocksize; i32 st_nblocks; long st_blksize; long st_blocks; long st_blocks_hi; };')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_linux_stat_struct() {
+	g.writeln('#if defined(__x86_64__) && !defined(__ILP32__)')
+	g.writeln('struct stat { u64 st_dev; u64 st_ino; u64 st_nlink; u32 st_mode; u32 st_uid; u32 st_gid; int __pad0; u64 st_rdev; i64 st_size; i64 st_blksize; i64 st_blocks; i64 st_atime; i64 st_atimensec; i64 st_mtime; i64 st_mtimensec; i64 st_ctime; i64 st_ctimensec; i64 __glibc_reserved[3]; };')
+	g.writeln('#elif defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__loongarch_lp64)')
+	g.writeln('struct stat { u64 st_dev; u64 st_ino; u32 st_mode; u32 st_nlink; u32 st_uid; u32 st_gid; u64 st_rdev; unsigned long __pad1; i64 st_size; int st_blksize; int __pad2; i64 st_blocks; i64 st_atime; i64 st_atimensec; i64 st_mtime; i64 st_mtimensec; i64 st_ctime; i64 st_ctimensec; unsigned int __glibc_reserved[2]; };')
+	g.writeln('#elif defined(__i386__) || defined(__arm__)')
+	g.writeln('struct stat { u64 st_dev; unsigned short __pad1; unsigned long st_ino; u32 st_mode; unsigned long st_nlink; u32 st_uid; u32 st_gid; u64 st_rdev; unsigned short __pad2; long st_size; long st_blksize; long st_blocks; long st_atime; unsigned long st_atimensec; long st_mtime; unsigned long st_mtimensec; long st_ctime; unsigned long st_ctimensec; unsigned long __glibc_reserved4; unsigned long __glibc_reserved5; };')
+	g.writeln('#else')
+	g.writeln('#error unsupported Linux struct stat layout for this architecture')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_platform_constants() {
+	g.writeln('#define STDIN_FILENO 0')
+	g.writeln('#define STDOUT_FILENO 1')
+	g.writeln('#define STDERR_FILENO 2')
+	g.writeln('#define F_OK 0')
+	g.writeln('#define WEXITSTATUS(status) (((status) >> 8) & 0xff)')
+	g.writeln('#define WTERMSIG(status) ((status) & 0x7f)')
+	g.writeln('#define WIFEXITED(status) (WTERMSIG(status) == 0)')
+	g.writeln('#define WIFSIGNALED(status) ((((status) & 0x7f) + 1) >= 2)')
+	g.writeln('#define WNOHANG 1')
+	g.writeln('#define LOCK_SH 1')
+	g.writeln('#define LOCK_EX 2')
+	g.writeln('#define LOCK_NB 4')
+	g.writeln('#define LOCK_UN 8')
+	g.writeln('#define ENOENT 2')
+	g.writeln('#define RUSAGE_SELF 0')
+	g.writeln('#ifdef __APPLE__')
+	g.headerless_darwin_constants()
+	g.writeln('#elif defined(_WIN32)')
+	g.headerless_windows_constants()
+	g.writeln('#elif defined(__FreeBSD__)')
+	g.headerless_bsd_constants('0x00100000', '12', '13', '4', '47', '28', '0x00020000', '0x0800',
+		true)
+	g.writeln('#elif defined(__OpenBSD__)')
+	g.headerless_bsd_constants('0x10000', '8', '9', '3', '28', '24', '0x0400', '', false)
+	g.writeln('#elif defined(__NetBSD__)')
+	g.headerless_bsd_constants('0x00400000', '8', '9', '3', '28', '24', '0x0400', '0x0800', false)
+	g.writeln('#elif defined(__DragonFly__)')
+	g.headerless_bsd_constants('0x00020000', '8', '9', '4', '47', '28', '0x0400', '0x0800', false)
+	g.writeln('#elif defined(__sun)')
+	g.headerless_solaris_constants()
+	g.writeln('#elif defined(__QNX__) || defined(__QNXNTO__)')
+	g.headerless_qnx_constants()
+	g.writeln('#elif defined(__linux__) || defined(__ANDROID__)')
+	g.headerless_linux_constants()
+	g.writeln('#else')
+	g.writeln('#error unsupported headerless C platform constants')
+	g.writeln('#endif')
+	g.headerless_signal_constants()
+	g.headerless_ptrace_constants()
+	g.headerless_sysctl_constants()
+	g.writeln('#ifndef MSG_NOSIGNAL')
+	g.writeln('#define MSG_NOSIGNAL 0')
+	g.writeln('#endif')
+	g.writeln('#ifndef SO_NOSIGPIPE')
+	g.writeln('#define SO_NOSIGPIPE 0')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_signal_constants() {
+	g.writeln('#define SIGKILL 9')
+	g.writeln('#define SIGTERM 15')
+	g.writeln('#define SIGPIPE 13')
+	g.writeln('#define SIG_IGN ((void*)1)')
+	g.writeln('#if defined(__linux__) || defined(__ANDROID__)')
+	g.writeln('#define SIGSTOP 19')
+	g.writeln('#define SIGCONT 18')
+	g.writeln('#define SIG_BLOCK 0')
+	g.writeln('#else')
+	g.writeln('#define SIGSTOP 17')
+	g.writeln('#define SIGCONT 19')
+	g.writeln('#define SIG_BLOCK 1')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_ptrace_constants() {
+	g.writeln('#if defined(__linux__) || defined(__ANDROID__)')
+	g.writeln('#define PTRACE_ATTACH 16')
+	g.writeln('#define PTRACE_DETACH 17')
+	g.writeln('#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)')
+	g.writeln('#define PT_TRACE_ME 0')
+	g.writeln('#define PT_ATTACH 10')
+	g.writeln('#define PT_DETACH 11')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_sysctl_constants() {
+	g.writeln('#if defined(__FreeBSD__)')
+	g.writeln('#define CTL_KERN 1')
+	g.writeln('#define CTL_VM 2')
+	g.writeln('#define KERN_PROC 14')
+	g.writeln('#define KERN_PROC_PID 1')
+	g.writeln('#define KERN_PROC_ARGS 7')
+	g.writeln('#define KERN_PROC_PATHNAME 12')
+	g.writeln('#define KERN_PROC_INC_THREAD 0x10')
+	g.writeln('#elif defined(__OpenBSD__)')
+	g.writeln('#define CTL_KERN 1')
+	g.writeln('#define CTL_VM 2')
+	g.writeln('#define KERN_PROC 66')
+	g.writeln('#define KERN_PROC_PID 1')
+	g.writeln('#define KERN_PROC_ARGS 55')
+	g.writeln('#define KERN_PROC_ARGV 1')
+	g.writeln('#define VM_UVMEXP 4')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_mmap_constants(map_anonymous string) {
+	g.writeln('#define PROT_READ 0x1')
+	g.writeln('#define PROT_WRITE 0x2')
+	g.writeln('#define PROT_EXEC 0x4')
+	g.writeln('#define MAP_PRIVATE 0x0002')
+	g.writeln('#define MAP_ANONYMOUS ${map_anonymous}')
+	g.writeln('#define MAP_ANON MAP_ANONYMOUS')
+	g.writeln('#define MAP_FAILED ((void*)-1)')
+}
+
+fn (mut g FlatGen) headerless_linux_syscall_constants() {
+	g.writeln('#ifndef SYS_getrandom')
+	g.writeln('#if defined(__x86_64__)')
+	g.writeln('#define SYS_getrandom 318')
+	g.writeln('#elif defined(__i386__)')
+	g.writeln('#define SYS_getrandom 355')
+	g.writeln('#elif defined(__arm__)')
+	g.writeln('#define SYS_getrandom 384')
+	g.writeln('#elif defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__loongarch_lp64)')
+	g.writeln('#define SYS_getrandom 278')
+	g.writeln('#else')
+	g.writeln('#define SYS_getrandom 278')
+	g.writeln('#endif')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_linux_sysconf_constants() {
+	g.writeln('#if defined(__ANDROID__)')
+	g.writeln('#define _SC_PAGESIZE 0x0027')
+	g.writeln('#define _SC_NPROCESSORS_ONLN 0x0061')
+	g.writeln('#define _SC_PHYS_PAGES 0x0062')
+	g.writeln('#define _SC_AVPHYS_PAGES 0x0063')
+	g.writeln('#else')
+	g.writeln('#define _SC_PAGESIZE 30')
+	g.writeln('#define _SC_NPROCESSORS_ONLN 84')
+	g.writeln('#define _SC_PHYS_PAGES 85')
+	g.writeln('#define _SC_AVPHYS_PAGES 86')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) headerless_kqueue_common_constants() {
+	g.writeln('#define EVFILT_READ (-1)')
+	g.writeln('#define EVFILT_WRITE (-2)')
+	g.writeln('#define EV_ADD 0x0001')
+	g.writeln('#define EV_DELETE 0x0002')
+	g.writeln('#define EV_ENABLE 0x0004')
+	g.writeln('#define EV_DISABLE 0x0008')
+	g.writeln('#define EV_ONESHOT 0x0010')
+	g.writeln('#define EV_CLEAR 0x0020')
+	g.writeln('#define EV_RECEIPT 0x0040')
+	g.writeln('#define EV_DISPATCH 0x0080')
+	g.writeln('#define EV_EOF 0x8000')
+	g.writeln('#define EV_ERROR 0x4000')
+	g.writeln('#define EV_SET(kevp, a, b, c, d, e, f) do { struct kevent* __kevp = (struct kevent*)(kevp); __kevp->ident = (uintptr_t)(a); __kevp->filter = (b); __kevp->flags = (c); __kevp->fflags = (d); __kevp->data = (intptr_t)(e); __kevp->udata = (void*)(f); } while (0)')
+}
+
+fn (mut g FlatGen) headerless_darwin_kqueue_constants() {
+	g.headerless_kqueue_common_constants()
+	g.writeln('#define EVFILT_AIO (-3)')
+	g.writeln('#define EVFILT_VNODE (-4)')
+	g.writeln('#define EVFILT_PROC (-5)')
+	g.writeln('#define EVFILT_SIGNAL (-6)')
+	g.writeln('#define EVFILT_TIMER (-7)')
+	g.writeln('#define EVFILT_MACHPORT (-8)')
+	g.writeln('#define EVFILT_FS (-9)')
+	g.writeln('#define EVFILT_USER (-10)')
+	g.writeln('#define EVFILT_VM (-12)')
+	g.writeln('#define EVFILT_EXCEPT (-15)')
+	g.writeln('#define EVFILT_SYSCOUNT 18')
+	g.writeln('#define EV_UDATA_SPECIFIC 0x0100')
+	g.writeln('#define EV_DISPATCH2 (EV_DISPATCH | EV_UDATA_SPECIFIC)')
+	g.writeln('#define EV_VANISHED 0x0200')
+	g.writeln('#define EV_SYSFLAGS 0xF000')
+	g.writeln('#define EV_FLAG0 0x1000')
+	g.writeln('#define EV_FLAG1 0x2000')
+}
+
+fn (mut g FlatGen) headerless_darwin_constants() {
+	g.writeln('#define O_RDONLY 0x0000')
+	g.writeln('#define O_WRONLY 0x0001')
+	g.writeln('#define O_RDWR 0x0002')
+	g.writeln('#define O_NONBLOCK 0x0004')
+	g.writeln('#define O_APPEND 0x0008')
+	g.writeln('#define O_SYNC 0x0080')
+	g.writeln('#define O_CREAT 0x0200')
+	g.writeln('#define O_TRUNC 0x0400')
+	g.writeln('#define O_EXCL 0x0800')
+	g.writeln('#define O_NOCTTY 0x20000')
+	g.writeln('#define O_CLOEXEC 0x01000000')
+	g.writeln('#define F_GETFD 1')
+	g.writeln('#define F_SETFD 2')
+	g.writeln('#define F_GETFL 3')
+	g.writeln('#define F_SETFL 4')
+	g.writeln('#define F_SETLK 8')
+	g.writeln('#define F_SETLKW 9')
+	g.writeln('#define FD_CLOEXEC 1')
+	g.writeln('#define F_RDLCK 1')
+	g.writeln('#define F_UNLCK 2')
+	g.writeln('#define F_WRLCK 3')
+	g.writeln('#define EACCES 13')
+	g.writeln('#define EFAULT 14')
+	g.writeln('#define EINTR 4')
+	g.writeln('#define EINVAL 22')
+	g.writeln('#define EAGAIN 35')
+	g.writeln('#define EWOULDBLOCK 35')
+	g.writeln('#define EINPROGRESS 36')
+	g.writeln('#define EBUSY 16')
+	g.writeln('#define EDEADLK 11')
+	g.writeln('#define ETIMEDOUT 60')
+	g.writeln('#define EPROTONOSUPPORT 43')
+	g.writeln('#define EAFNOSUPPORT 47')
+	g.writeln('#define EADDRNOTAVAIL 49')
+	g.writeln('#define EAI_SYSTEM 11')
+	g.writeln('#define CLOCK_REALTIME 0')
+	g.writeln('#define CLOCK_MONOTONIC 6')
+	g.writeln('#define _SC_PAGESIZE 29')
+	g.headerless_mmap_constants('0x1000')
+	g.headerless_darwin_kqueue_constants()
+	g.writeln('#define FIONREAD 0x4004667f')
+	g.writeln('#define TIOCGWINSZ 0x40087468')
+	g.writeln('#define TCSANOW 0')
+	g.writeln('#define TCSADRAIN 1')
+	g.writeln('#define TCSAFLUSH 2')
+	g.writeln('#define IGNBRK 1')
+	g.writeln('#define BRKINT 2')
+	g.writeln('#define PARMRK 8')
+	g.writeln('#define INPCK 16')
+	g.writeln('#define ISTRIP 32')
+	g.writeln('#define ICRNL 256')
+	g.writeln('#define IXON 512')
+	g.writeln('#define OPOST 1')
+	g.writeln('#define CS8 768')
+	g.writeln('#define ISIG 128')
+	g.writeln('#define ICANON 256')
+	g.writeln('#define ECHO 8')
+	g.writeln('#define IEXTEN 1024')
+	g.writeln('#define TOSTOP 4194304')
+	g.writeln('#define VMIN 16')
+	g.writeln('#define VTIME 17')
+	g.writeln('#define PTHREAD_PROCESS_PRIVATE 2')
+	g.writeln('#define PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP 0')
+	g.writeln('#define S_IFMT 0170000')
+	g.writeln('#define S_IFIFO 0010000')
+	g.writeln('#define S_IFCHR 0020000')
+	g.writeln('#define S_IFDIR 0040000')
+	g.writeln('#define S_IFBLK 0060000')
+	g.writeln('#define S_IFREG 0100000')
+	g.writeln('#define S_IFLNK 0120000')
+	g.writeln('#define S_IFSOCK 0140000')
+	g.writeln('#define S_IRUSR 0000400')
+	g.writeln('#define S_IWUSR 0000200')
+	g.writeln('#define S_IXUSR 0000100')
+	g.writeln('#define S_IRGRP 0000040')
+	g.writeln('#define S_IWGRP 0000020')
+	g.writeln('#define S_IXGRP 0000010')
+	g.writeln('#define S_IROTH 0000004')
+	g.writeln('#define S_IWOTH 0000002')
+	g.writeln('#define S_IXOTH 0000001')
+	g.headerless_darwin_net_constants()
+	g.writeln('#define SIG_ERR ((void (*)(int))-1)')
+	g.writeln('struct flock { off_t l_start; off_t l_len; pid_t l_pid; short l_type; short l_whence; };')
+}
+
+fn (mut g FlatGen) headerless_bsd_constants(o_cloexec string, f_setlk string, f_setlkw string, clock_monotonic string, sc_pagesize string, af_inet6 string, msg_nosignal string, so_nosigpipe string, flock_sysid bool) {
+	g.writeln('#define O_RDONLY 0x0000')
+	g.writeln('#define O_WRONLY 0x0001')
+	g.writeln('#define O_RDWR 0x0002')
+	g.writeln('#define O_NONBLOCK 0x0004')
+	g.writeln('#define O_APPEND 0x0008')
+	g.writeln('#define O_SYNC 0x0080')
+	g.writeln('#define O_CREAT 0x0200')
+	g.writeln('#define O_TRUNC 0x0400')
+	g.writeln('#define O_EXCL 0x0800')
+	g.writeln('#define O_NOCTTY 0x8000')
+	g.writeln('#define O_CLOEXEC ${o_cloexec}')
+	g.writeln('#define F_GETFD 1')
+	g.writeln('#define F_SETFD 2')
+	g.writeln('#define F_GETFL 3')
+	g.writeln('#define F_SETFL 4')
+	g.writeln('#define F_SETLK ${f_setlk}')
+	g.writeln('#define F_SETLKW ${f_setlkw}')
+	g.writeln('#define FD_CLOEXEC 1')
+	g.writeln('#define F_RDLCK 1')
+	g.writeln('#define F_UNLCK 2')
+	g.writeln('#define F_WRLCK 3')
+	g.writeln('#define EACCES 13')
+	g.writeln('#define EFAULT 14')
+	g.writeln('#define EINTR 4')
+	g.writeln('#define EINVAL 22')
+	g.writeln('#define EAGAIN 35')
+	g.writeln('#define EWOULDBLOCK 35')
+	g.writeln('#define EINPROGRESS 36')
+	g.writeln('#define EBUSY 16')
+	g.writeln('#define EDEADLK 11')
+	g.writeln('#define ETIMEDOUT 60')
+	g.writeln('#define EPROTONOSUPPORT 43')
+	g.writeln('#define EAFNOSUPPORT 47')
+	g.writeln('#define EADDRNOTAVAIL 49')
+	g.writeln('#define EAI_SYSTEM 11')
+	g.writeln('#define CLOCK_REALTIME 0')
+	g.writeln('#define CLOCK_MONOTONIC ${clock_monotonic}')
+	g.writeln('#define _SC_PAGESIZE ${sc_pagesize}')
+	g.headerless_mmap_constants('0x1000')
+	g.headerless_kqueue_common_constants()
+	g.writeln('#define FIONREAD 0x4004667f')
+	g.writeln('#define TIOCGWINSZ 0x40087468')
+	g.writeln('#define TCSANOW 0')
+	g.writeln('#define TCSADRAIN 1')
+	g.writeln('#define TCSAFLUSH 2')
+	g.writeln('#define IGNBRK 1')
+	g.writeln('#define BRKINT 2')
+	g.writeln('#define PARMRK 8')
+	g.writeln('#define INPCK 16')
+	g.writeln('#define ISTRIP 32')
+	g.writeln('#define ICRNL 256')
+	g.writeln('#define IXON 512')
+	g.writeln('#define OPOST 1')
+	g.writeln('#define CS8 768')
+	g.writeln('#define ISIG 128')
+	g.writeln('#define ICANON 256')
+	g.writeln('#define ECHO 8')
+	g.writeln('#define IEXTEN 1024')
+	g.writeln('#define TOSTOP 4194304')
+	g.writeln('#define VMIN 16')
+	g.writeln('#define VTIME 17')
+	g.writeln('#define PTHREAD_PROCESS_PRIVATE 0')
+	g.writeln('#define PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP 0')
+	g.writeln('#define S_IFMT 0170000')
+	g.writeln('#define S_IFIFO 0010000')
+	g.writeln('#define S_IFCHR 0020000')
+	g.writeln('#define S_IFDIR 0040000')
+	g.writeln('#define S_IFBLK 0060000')
+	g.writeln('#define S_IFREG 0100000')
+	g.writeln('#define S_IFLNK 0120000')
+	g.writeln('#define S_IFSOCK 0140000')
+	g.writeln('#define S_IRUSR 0000400')
+	g.writeln('#define S_IWUSR 0000200')
+	g.writeln('#define S_IXUSR 0000100')
+	g.writeln('#define S_IRGRP 0000040')
+	g.writeln('#define S_IWGRP 0000020')
+	g.writeln('#define S_IXGRP 0000010')
+	g.writeln('#define S_IROTH 0000004')
+	g.writeln('#define S_IWOTH 0000002')
+	g.writeln('#define S_IXOTH 0000001')
+	g.headerless_bsd_net_constants(af_inet6, msg_nosignal, so_nosigpipe)
+	g.writeln('#define SIG_ERR ((void (*)(int))-1)')
+	if flock_sysid {
+		g.writeln('struct flock { off_t l_start; off_t l_len; pid_t l_pid; short l_type; short l_whence; int l_sysid; };')
+	} else {
+		g.writeln('struct flock { off_t l_start; off_t l_len; pid_t l_pid; short l_type; short l_whence; };')
 	}
-	g.writeln('typedef volatile uintptr_t atomic_uintptr_t;')
-	g.writeln('#ifndef memory_order_relaxed')
-	g.writeln('#define memory_order_relaxed 0')
-	g.writeln('#define memory_order_consume 1')
-	g.writeln('#define memory_order_acquire 2')
-	g.writeln('#define memory_order_release 3')
-	g.writeln('#define memory_order_acq_rel 4')
-	g.writeln('#define memory_order_seq_cst 5')
+}
+
+fn (mut g FlatGen) headerless_solaris_constants() {
+	g.writeln('#define O_RDONLY 0')
+	g.writeln('#define O_WRONLY 1')
+	g.writeln('#define O_RDWR 2')
+	g.writeln('#define O_APPEND 0x08')
+	g.writeln('#define O_SYNC 0x10')
+	g.writeln('#define O_NONBLOCK 0x80')
+	g.writeln('#define O_CREAT 0x100')
+	g.writeln('#define O_TRUNC 0x200')
+	g.writeln('#define O_EXCL 0x400')
+	g.writeln('#define O_NOCTTY 0x800')
+	g.writeln('#define O_CLOEXEC 0x800000')
+	g.writeln('#define F_GETFD 1')
+	g.writeln('#define F_SETFD 2')
+	g.writeln('#define F_GETFL 3')
+	g.writeln('#define F_SETFL 4')
+	g.writeln('#define F_SETLK 6')
+	g.writeln('#define F_SETLKW 7')
+	g.writeln('#define FD_CLOEXEC 1')
+	g.writeln('#define F_RDLCK 1')
+	g.writeln('#define F_WRLCK 2')
+	g.writeln('#define F_UNLCK 3')
+	g.writeln('#define EINTR 4')
+	g.writeln('#define EINVAL 22')
+	g.writeln('#define EAGAIN 11')
+	g.writeln('#define EWOULDBLOCK EAGAIN')
+	g.writeln('#define EINPROGRESS 150')
+	g.writeln('#define EBUSY 16')
+	g.writeln('#define EDEADLK 45')
+	g.writeln('#define ETIMEDOUT 145')
+	g.writeln('#define EPROTONOSUPPORT 120')
+	g.writeln('#define EAFNOSUPPORT 124')
+	g.writeln('#define EADDRNOTAVAIL 126')
+	g.writeln('#define EAI_SYSTEM 11')
+	g.writeln('#define CLOCK_REALTIME 0')
+	g.writeln('#define CLOCK_MONOTONIC 4')
+	g.writeln('#define _SC_PAGESIZE 11')
+	g.headerless_mmap_constants('0x100')
+	g.writeln('#define FIONREAD 0x4004667f')
+	g.writeln("#define TIOCGWINSZ (('T' << 8) | 104)")
+	g.writeln("#define TCSANOW (('T' << 8) | 14)")
+	g.writeln("#define TCSADRAIN (('T' << 8) | 15)")
+	g.writeln("#define TCSAFLUSH (('T' << 8) | 16)")
+	g.writeln('#define IGNBRK 0000001')
+	g.writeln('#define BRKINT 0000002')
+	g.writeln('#define PARMRK 0000010')
+	g.writeln('#define INPCK 0000020')
+	g.writeln('#define ISTRIP 0000040')
+	g.writeln('#define ICRNL 0000400')
+	g.writeln('#define IXON 0002000')
+	g.writeln('#define OPOST 0000001')
+	g.writeln('#define CS8 0000060')
+	g.writeln('#define ISIG 0000001')
+	g.writeln('#define ICANON 0000002')
+	g.writeln('#define ECHO 0000010')
+	g.writeln('#define IEXTEN 0100000')
+	g.writeln('#define TOSTOP 0000400')
+	g.writeln('#define VMIN 4')
+	g.writeln('#define VTIME 5')
+	g.writeln('#define PTHREAD_PROCESS_PRIVATE 0')
+	g.writeln('#define PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP 0')
+	g.writeln('#define S_IFMT 0170000')
+	g.writeln('#define S_IFIFO 0010000')
+	g.writeln('#define S_IFCHR 0020000')
+	g.writeln('#define S_IFDIR 0040000')
+	g.writeln('#define S_IFBLK 0060000')
+	g.writeln('#define S_IFREG 0100000')
+	g.writeln('#define S_IFLNK 0120000')
+	g.writeln('#define S_IFSOCK 0140000')
+	g.writeln('#define S_IRUSR 0000400')
+	g.writeln('#define S_IWUSR 0000200')
+	g.writeln('#define S_IXUSR 0000100')
+	g.writeln('#define S_IRGRP 0000040')
+	g.writeln('#define S_IWGRP 0000020')
+	g.writeln('#define S_IXGRP 0000010')
+	g.writeln('#define S_IROTH 0000004')
+	g.writeln('#define S_IWOTH 0000002')
+	g.writeln('#define S_IXOTH 0000001')
+	g.headerless_solaris_net_constants()
+	g.writeln('#define SIG_ERR ((void (*)(int))-1)')
+	g.writeln('struct flock { short l_type; short l_whence; off_t l_start; off_t l_len; int l_sysid; pid_t l_pid; long l_pad[4]; };')
+}
+
+fn (mut g FlatGen) headerless_qnx_constants() {
+	g.writeln('#define O_RDONLY 000000')
+	g.writeln('#define O_WRONLY 000001')
+	g.writeln('#define O_RDWR 000002')
+	g.writeln('#define O_APPEND 000010')
+	g.writeln('#define O_SYNC 000040')
+	g.writeln('#define O_NONBLOCK 000200')
+	g.writeln('#define O_CREAT 000400')
+	g.writeln('#define O_TRUNC 001000')
+	g.writeln('#define O_EXCL 002000')
+	g.writeln('#define O_NOCTTY 004000')
+	g.writeln('#define O_CLOEXEC 020000')
+	g.writeln('#define F_GETFD 1')
+	g.writeln('#define F_SETFD 2')
+	g.writeln('#define F_GETFL 3')
+	g.writeln('#define F_SETFL 4')
+	g.writeln('#define F_SETLK 6')
+	g.writeln('#define F_SETLKW 7')
+	g.writeln('#define FD_CLOEXEC 1')
+	g.writeln('#define F_RDLCK 1')
+	g.writeln('#define F_WRLCK 2')
+	g.writeln('#define F_UNLCK 3')
+	g.writeln('#define EINTR 4')
+	g.writeln('#define EINVAL 22')
+	g.writeln('#define EAGAIN 11')
+	g.writeln('#define EWOULDBLOCK EAGAIN')
+	g.writeln('#define EINPROGRESS 236')
+	g.writeln('#define EBUSY 16')
+	g.writeln('#define EDEADLK 45')
+	g.writeln('#define ETIMEDOUT 260')
+	g.writeln('#define EPROTONOSUPPORT 243')
+	g.writeln('#define EAFNOSUPPORT 247')
+	g.writeln('#define EADDRNOTAVAIL 249')
+	g.writeln('#define EAI_SYSTEM 11')
+	g.writeln('#define CLOCK_REALTIME 0')
+	g.writeln('#define CLOCK_MONOTONIC 2')
+	g.writeln('#define _SC_PAGESIZE 11')
+	g.headerless_mmap_constants('0x00080000')
+	g.writeln('#define FIONREAD 0x4004667f')
+	g.writeln('#define TIOCGWINSZ 0x40087468')
+	g.writeln('#define TCSANOW 0x0001')
+	g.writeln('#define TCSADRAIN 0x0002')
+	g.writeln('#define TCSAFLUSH 0x0004')
+	g.writeln('#define IGNBRK 0x00000001')
+	g.writeln('#define BRKINT 0x00000002')
+	g.writeln('#define PARMRK 0x00000008')
+	g.writeln('#define INPCK 0x00000010')
+	g.writeln('#define ISTRIP 0x00000020')
+	g.writeln('#define ICRNL 0x00000100')
+	g.writeln('#define IXON 0x00000400')
+	g.writeln('#define OPOST 0x00000001')
+	g.writeln('#define CS8 0x30')
+	g.writeln('#define ISIG 0x00000001')
+	g.writeln('#define ICANON 0x00000002')
+	g.writeln('#define ECHO 0x00000008')
+	g.writeln('#define IEXTEN 0x00008000')
+	g.writeln('#define TOSTOP 0x00000100')
+	g.writeln('#define VMIN 16')
+	g.writeln('#define VTIME 17')
+	g.writeln('#define PTHREAD_PROCESS_PRIVATE 0')
+	g.writeln('#define PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP 0')
+	g.writeln('#define S_IFMT 0170000')
+	g.writeln('#define S_IFIFO 0010000')
+	g.writeln('#define S_IFCHR 0020000')
+	g.writeln('#define S_IFDIR 0040000')
+	g.writeln('#define S_IFBLK 0060000')
+	g.writeln('#define S_IFREG 0100000')
+	g.writeln('#define S_IFLNK 0120000')
+	g.writeln('#define S_IFSOCK 0140000')
+	g.writeln('#define S_IRUSR 0000400')
+	g.writeln('#define S_IWUSR 0000200')
+	g.writeln('#define S_IXUSR 0000100')
+	g.writeln('#define S_IRGRP 0000040')
+	g.writeln('#define S_IWGRP 0000020')
+	g.writeln('#define S_IXGRP 0000010')
+	g.writeln('#define S_IROTH 0000004')
+	g.writeln('#define S_IWOTH 0000002')
+	g.writeln('#define S_IXOTH 0000001')
+	g.headerless_qnx_net_constants()
+	g.writeln('#define SIG_ERR ((void (*)(int))-1)')
+	g.writeln('struct flock { short l_type; short l_whence; int l_zero1; off_t l_start; off_t l_len; pid_t l_pid; unsigned int l_sysid; };')
+}
+
+fn (mut g FlatGen) headerless_windows_constants() {
+	g.writeln('#define O_RDONLY 0x0000')
+	g.writeln('#define O_WRONLY 0x0001')
+	g.writeln('#define O_RDWR 0x0002')
+	g.writeln('#define O_APPEND 0x0008')
+	g.writeln('#define O_CREAT 0x0100')
+	g.writeln('#define O_TRUNC 0x0200')
+	g.writeln('#define O_EXCL 0x0400')
+	g.writeln('#define O_BINARY 0x8000')
+	g.writeln('#define _O_BINARY 0x8000')
+	g.writeln('#define F_GETFD 1')
+	g.writeln('#define F_SETFD 2')
+	g.writeln('#define F_GETFL 3')
+	g.writeln('#define F_SETFL 4')
+	g.writeln('#define FD_CLOEXEC 1')
+	g.writeln('#define EINTR 4')
+	g.writeln('#define EINVAL 22')
+	g.writeln('#define EAGAIN 11')
+	g.writeln('#define EWOULDBLOCK 11')
+	g.writeln('#define EINPROGRESS 10036')
+	g.writeln('#define EBUSY 16')
+	g.writeln('#define EDEADLK 36')
+	g.writeln('#define ETIMEDOUT 10060')
+	g.writeln('#define EPROTONOSUPPORT 10043')
+	g.writeln('#define EAFNOSUPPORT 10047')
+	g.writeln('#define EADDRNOTAVAIL 10049')
+	g.writeln('#define EAI_SYSTEM 11')
+	g.writeln('#define CLOCK_REALTIME 0')
+	g.writeln('#define CLOCK_MONOTONIC 1')
+	g.writeln('#define _SC_PAGESIZE 30')
+	g.writeln('#define FIONREAD 0x4004667f')
+	g.writeln('#define FIONBIO 0x8004667eU')
+	g.writeln('#define TCSANOW 0')
+	g.writeln('#define TCSADRAIN 1')
+	g.writeln('#define TCSAFLUSH 2')
+	g.writeln('#define PTHREAD_PROCESS_PRIVATE 0')
+	g.writeln('#define PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP 0')
+	g.writeln('#define S_IFMT 0170000')
+	g.writeln('#define S_IFIFO 0010000')
+	g.writeln('#define S_IFCHR 0020000')
+	g.writeln('#define S_IFDIR 0040000')
+	g.writeln('#define S_IFBLK 0060000')
+	g.writeln('#define S_IFREG 0100000')
+	g.writeln('#define S_IFLNK 0120000')
+	g.writeln('#define S_IFSOCK 0140000')
+	g.writeln('#define S_IREAD 0000400')
+	g.writeln('#define S_IWRITE 0000200')
+	g.writeln('#define S_IEXEC 0000100')
+	g.writeln('#define S_IRUSR 0000400')
+	g.writeln('#define S_IWUSR 0000200')
+	g.writeln('#define S_IXUSR 0000100')
+	g.headerless_windows_net_constants()
+	g.writeln('#define SIG_ERR ((void (*)(int))-1)')
+	g.writeln('#define GENERIC_READ 0x80000000U')
+	g.writeln('#define GENERIC_WRITE 0x40000000U')
+	g.writeln('#define FILE_SHARE_READ 0x00000001U')
+	g.writeln('#define FILE_SHARE_WRITE 0x00000002U')
+	g.writeln('#define FILE_SHARE_DELETE 0x00000004U')
+	g.writeln('#define OPEN_EXISTING 3')
+	g.writeln('#define OPEN_ALWAYS 4')
+	g.writeln('#define FILE_ATTRIBUTE_NORMAL 0x00000080U')
+	g.writeln('#define FILE_ATTRIBUTE_DIRECTORY 0x00000010U')
+	g.writeln('#define INVALID_FILE_ATTRIBUTES 0xffffffffU')
+	g.writeln('#define LOCKFILE_FAIL_IMMEDIATELY 0x00000001U')
+	g.writeln('#define LOCKFILE_EXCLUSIVE_LOCK 0x00000002U')
+	g.writeln('#define MAXDWORD 0xffffffffU')
+	g.writeln('#define MEM_COMMIT 0x00001000U')
+	g.writeln('#define MEM_RESERVE 0x00002000U')
+	g.writeln('#define PAGE_READWRITE 0x04U')
+	g.writeln('#define PAGE_EXECUTE_READ 0x20U')
+	g.writeln('#define TLS_OUT_OF_INDEXES 0xffffffffU')
+	g.writeln('#define TRUE 1')
+	g.writeln('#define FALSE 0')
+	g.writeln('#define INFINITE 0xffffffffU')
+	g.writeln('#define INVALID_HANDLE_VALUE ((void*)-1)')
+	g.writeln('#define STD_INPUT_HANDLE 0xfffffff6U')
+	g.writeln('#define STD_OUTPUT_HANDLE 0xfffffff5U')
+	g.writeln('#define STD_ERROR_HANDLE 0xfffffff4U')
+	g.writeln('#define ENABLE_PROCESSED_INPUT 0x0001')
+	g.writeln('#define ENABLE_LINE_INPUT 0x0002')
+	g.writeln('#define ENABLE_ECHO_INPUT 0x0004')
+	g.writeln('#define ENABLE_WINDOW_INPUT 0x0008')
+	g.writeln('#define ENABLE_MOUSE_INPUT 0x0010')
+	g.writeln('#define ENABLE_EXTENDED_FLAGS 0x0080')
+	g.writeln('#define STARTF_USESTDHANDLES 0x00000100U')
+	g.writeln('#define CREATE_NEW_PROCESS_GROUP 0x00000200U')
+	g.writeln('#define CREATE_UNICODE_ENVIRONMENT 0x00000400U')
+	g.writeln('#define NORMAL_PRIORITY_CLASS 0x00000020U')
+	g.writeln('#define CREATE_NO_WINDOW 0x08000000U')
+	g.writeln('#define HANDLE_FLAG_INHERIT 0x00000001U')
+	g.writeln('#define CTRL_BREAK_EVENT 1')
+	g.writeln('#define STILL_ACTIVE 259')
+	g.writeln('#define KEY_EVENT 0x0001')
+	g.writeln('#define MOUSE_EVENT 0x0002')
+	g.writeln('#define WINDOW_BUFFER_SIZE_EVENT 0x0004')
+	g.writeln('#define MENU_EVENT 0x0008')
+	g.writeln('#define FOCUS_EVENT 0x0010')
+	g.writeln('#define MOUSE_MOVED 0x0001')
+	g.writeln('#define DOUBLE_CLICK 0x0002')
+	g.writeln('#define MOUSE_WHEELED 0x0004')
+	g.writeln('#define VK_BACK 0x08')
+	g.writeln('#define VK_RETURN 0x0d')
+	g.writeln('#define VK_PRIOR 0x21')
+	g.writeln('#define VK_NEXT 0x22')
+	g.writeln('#define VK_END 0x23')
+	g.writeln('#define VK_HOME 0x24')
+	g.writeln('#define VK_LEFT 0x25')
+	g.writeln('#define VK_UP 0x26')
+	g.writeln('#define VK_RIGHT 0x27')
+	g.writeln('#define VK_DOWN 0x28')
+	g.writeln('#define VK_INSERT 0x2d')
+	g.writeln('#define VK_DELETE 0x2e')
+	g.writeln('#define ERROR_ACCESS_DENIED 5')
+	g.writeln('#define ERROR_CLASS_ALREADY_EXISTS 1410')
+	g.writeln('#define HWND_MESSAGE ((void*)-3)')
+	g.writeln('#define MB_ERR_INVALID_CHARS 0x00000008U')
+	g.writeln('#define GMEM_MOVEABLE 0x0002U')
+	g.writeln('#define CF_UNICODETEXT 13')
+}
+
+fn (mut g FlatGen) headerless_linux_constants() {
+	g.writeln('#define O_RDONLY 0')
+	g.writeln('#define O_WRONLY 1')
+	g.writeln('#define O_RDWR 2')
+	g.writeln('#define O_CREAT 0100')
+	g.writeln('#define O_EXCL 0200')
+	g.writeln('#define O_NOCTTY 0400')
+	g.writeln('#define O_TRUNC 01000')
+	g.writeln('#define O_APPEND 02000')
+	g.writeln('#define O_NONBLOCK 04000')
+	g.writeln('#define O_SYNC 04010000')
+	g.writeln('#define O_CLOEXEC 02000000')
+	g.writeln('#define F_GETFD 1')
+	g.writeln('#define F_SETFD 2')
+	g.writeln('#define F_GETFL 3')
+	g.writeln('#define F_SETFL 4')
+	g.writeln('#define F_SETLK 6')
+	g.writeln('#define F_SETLKW 7')
+	g.writeln('#define FD_CLOEXEC 1')
+	g.writeln('#define F_RDLCK 0')
+	g.writeln('#define F_WRLCK 1')
+	g.writeln('#define F_UNLCK 2')
+	g.writeln('#define EINTR 4')
+	g.writeln('#define EIO 5')
+	g.writeln('#define EBADF 9')
+	g.writeln('#define EINVAL 22')
+	g.writeln('#define EAGAIN 11')
+	g.writeln('#define EWOULDBLOCK 11')
+	g.writeln('#define ENOMEM 12')
+	g.writeln('#define EFAULT 14')
+	g.writeln('#define EINPROGRESS 115')
+	g.writeln('#define ESPIPE 29')
+	g.writeln('#define EBUSY 16')
+	g.writeln('#define EDEADLK 35')
+	g.writeln('#define ETIMEDOUT 110')
+	g.writeln('#define EOVERFLOW 75')
+	g.writeln('#define EPROTONOSUPPORT 93')
+	g.writeln('#define EAFNOSUPPORT 97')
+	g.writeln('#define EADDRNOTAVAIL 99')
+	g.writeln('#define EAI_SYSTEM -11')
+	g.writeln('#define CLOCK_REALTIME 0')
+	g.writeln('#define CLOCK_MONOTONIC 1')
+	g.headerless_linux_sysconf_constants()
+	g.headerless_mmap_constants('0x20')
+	g.headerless_linux_syscall_constants()
+	g.writeln('#define FIONREAD 0x541b')
+	g.writeln('#define TIOCGWINSZ 0x5413')
+	g.writeln('#define EPOLLIN 0x001')
+	g.writeln('#define EPOLLPRI 0x002')
+	g.writeln('#define EPOLLOUT 0x004')
+	g.writeln('#define EPOLLERR 0x008')
+	g.writeln('#define EPOLLHUP 0x010')
+	g.writeln('#define EPOLLRDHUP 0x2000')
+	g.writeln('#define EPOLLEXCLUSIVE (1U << 28)')
+	g.writeln('#define EPOLLWAKEUP (1U << 29)')
+	g.writeln('#define EPOLLONESHOT (1U << 30)')
+	g.writeln('#define EPOLLET (1U << 31)')
+	g.writeln('#define EPOLL_CTL_ADD 1')
+	g.writeln('#define EPOLL_CTL_DEL 2')
+	g.writeln('#define EPOLL_CTL_MOD 3')
+	g.writeln('#define TCSANOW 0')
+	g.writeln('#define TCSADRAIN 1')
+	g.writeln('#define TCSAFLUSH 2')
+	g.writeln('#define IGNBRK 0000001')
+	g.writeln('#define BRKINT 0000002')
+	g.writeln('#define PARMRK 0000010')
+	g.writeln('#define INPCK 0000020')
+	g.writeln('#define ISTRIP 0000040')
+	g.writeln('#define ICRNL 0000400')
+	g.writeln('#define IXON 0002000')
+	g.writeln('#define OPOST 0000001')
+	g.writeln('#define CS8 0000060')
+	g.writeln('#define ISIG 0000001')
+	g.writeln('#define ICANON 0000002')
+	g.writeln('#define ECHO 0000010')
+	g.writeln('#define IEXTEN 0100000')
+	g.writeln('#define TOSTOP 0000400')
+	g.writeln('#define VMIN 6')
+	g.writeln('#define VTIME 5')
+	g.writeln('#define PTHREAD_PROCESS_PRIVATE 0')
+	g.writeln('#define PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP 2')
+	g.writeln('#define S_IFMT 00170000')
+	g.writeln('#define S_IFIFO 0010000')
+	g.writeln('#define S_IFCHR 0020000')
+	g.writeln('#define S_IFDIR 0040000')
+	g.writeln('#define S_IFBLK 0060000')
+	g.writeln('#define S_IFREG 0100000')
+	g.writeln('#define S_IFLNK 0120000')
+	g.writeln('#define S_IFSOCK 0140000')
+	g.writeln('#define S_IRUSR 0000400')
+	g.writeln('#define S_IWUSR 0000200')
+	g.writeln('#define S_IXUSR 0000100')
+	g.writeln('#define S_IRGRP 0000040')
+	g.writeln('#define S_IWGRP 0000020')
+	g.writeln('#define S_IXGRP 0000010')
+	g.writeln('#define S_IROTH 0000004')
+	g.writeln('#define S_IWOTH 0000002')
+	g.writeln('#define S_IXOTH 0000001')
+	g.headerless_linux_net_constants()
+	g.writeln('#define SIG_ERR ((void (*)(int))-1)')
+	g.writeln('struct flock { short l_type; short l_whence; off_t l_start; off_t l_len; pid_t l_pid; };')
+}
+
+fn (mut g FlatGen) headerless_darwin_net_constants() {
+	g.writeln('#define AF_UNSPEC 0')
+	g.writeln('#define AF_UNIX 1')
+	g.writeln('#define AF_INET 2')
+	g.writeln('#define AF_INET6 30')
+	g.writeln('#define SOCK_STREAM 1')
+	g.writeln('#define SOCK_DGRAM 2')
+	g.writeln('#define SOCK_RAW 3')
+	g.writeln('#define SOCK_SEQPACKET 5')
+	g.writeln('#define IPPROTO_IP 0')
+	g.writeln('#define IPPROTO_ICMP 1')
+	g.writeln('#define IPPROTO_TCP 6')
+	g.writeln('#define IPPROTO_UDP 17')
+	g.writeln('#define IPPROTO_IPV6 41')
+	g.writeln('#define IPPROTO_ICMPV6 58')
+	g.writeln('#define IPPROTO_RAW 255')
+	g.writeln('#define SOL_SOCKET 0xffff')
+	g.writeln('#define SO_DEBUG 0x0001')
+	g.writeln('#define SO_REUSEADDR 0x0004')
+	g.writeln('#define SO_KEEPALIVE 0x0008')
+	g.writeln('#define SO_DONTROUTE 0x0010')
+	g.writeln('#define SO_BROADCAST 0x0020')
+	g.writeln('#define SO_LINGER 0x0080')
+	g.writeln('#define SO_OOBINLINE 0x0100')
+	g.writeln('#define SO_SNDBUF 0x1001')
+	g.writeln('#define SO_RCVBUF 0x1002')
+	g.writeln('#define SO_SNDLOWAT 0x1003')
+	g.writeln('#define SO_RCVLOWAT 0x1004')
+	g.writeln('#define SO_SNDTIMEO 0x1005')
+	g.writeln('#define SO_RCVTIMEO 0x1006')
+	g.writeln('#define SO_ERROR 0x1007')
+	g.writeln('#define SO_TYPE 0x1008')
+	g.writeln('#define SO_NOSIGPIPE 0x1022')
+	g.writeln('#define TCP_NODELAY 1')
+	g.writeln('#define IP_HDRINCL 2')
+	g.writeln('#define IP_MULTICAST_IF 9')
+	g.writeln('#define IP_MULTICAST_TTL 10')
+	g.writeln('#define IP_MULTICAST_LOOP 11')
+	g.writeln('#define IP_ADD_MEMBERSHIP 12')
+	g.writeln('#define IP_DROP_MEMBERSHIP 13')
+	g.writeln('#define IPV6_MULTICAST_IF 9')
+	g.writeln('#define IPV6_MULTICAST_HOPS 10')
+	g.writeln('#define IPV6_MULTICAST_LOOP 11')
+	g.writeln('#define IPV6_ADD_MEMBERSHIP 12')
+	g.writeln('#define IPV6_JOIN_GROUP 12')
+	g.writeln('#define IPV6_DROP_MEMBERSHIP 13')
+	g.writeln('#define IPV6_LEAVE_GROUP 13')
+	g.writeln('#define IPV6_V6ONLY 27')
+	g.writeln('#define AI_PASSIVE 0x00000001')
+	g.writeln('#define MSG_DONTWAIT 0x80')
+}
+
+fn (mut g FlatGen) headerless_bsd_net_constants(af_inet6 string, msg_nosignal string, so_nosigpipe string) {
+	g.writeln('#define AF_UNSPEC 0')
+	g.writeln('#define AF_UNIX 1')
+	g.writeln('#define AF_INET 2')
+	g.writeln('#define AF_INET6 ${af_inet6}')
+	g.writeln('#define SOCK_STREAM 1')
+	g.writeln('#define SOCK_DGRAM 2')
+	g.writeln('#define SOCK_RAW 3')
+	g.writeln('#define SOCK_SEQPACKET 5')
+	g.writeln('#if defined(__FreeBSD__)')
+	g.writeln('#define SOCK_NONBLOCK 0x20000000')
 	g.writeln('#endif')
-	g.writeln('#ifndef atomic_thread_fence')
-	g.writeln('#define atomic_thread_fence(order) __sync_synchronize()')
-	g.writeln('#endif')
+	g.writeln('#define IPPROTO_IP 0')
+	g.writeln('#define IPPROTO_ICMP 1')
+	g.writeln('#define IPPROTO_TCP 6')
+	g.writeln('#define IPPROTO_UDP 17')
+	g.writeln('#define IPPROTO_IPV6 41')
+	g.writeln('#define IPPROTO_ICMPV6 58')
+	g.writeln('#define IPPROTO_RAW 255')
+	g.writeln('#define SOL_SOCKET 0xffff')
+	g.writeln('#define SO_DEBUG 0x0001')
+	g.writeln('#define SO_REUSEADDR 0x0004')
+	g.writeln('#define SO_KEEPALIVE 0x0008')
+	g.writeln('#define SO_DONTROUTE 0x0010')
+	g.writeln('#define SO_BROADCAST 0x0020')
+	g.writeln('#define SO_LINGER 0x0080')
+	g.writeln('#define SO_OOBINLINE 0x0100')
+	g.writeln('#define SO_REUSEPORT 0x0200')
+	if so_nosigpipe.len > 0 {
+		g.writeln('#define SO_NOSIGPIPE ${so_nosigpipe}')
+	}
+	g.writeln('#define SO_SNDBUF 0x1001')
+	g.writeln('#define SO_RCVBUF 0x1002')
+	g.writeln('#define SO_SNDLOWAT 0x1003')
+	g.writeln('#define SO_RCVLOWAT 0x1004')
+	g.writeln('#define SO_SNDTIMEO 0x1005')
+	g.writeln('#define SO_RCVTIMEO 0x1006')
+	g.writeln('#define SO_ERROR 0x1007')
+	g.writeln('#define SO_TYPE 0x1008')
+	g.writeln('#define TCP_NODELAY 1')
+	g.writeln('#define IP_HDRINCL 2')
+	g.writeln('#define IP_MULTICAST_IF 9')
+	g.writeln('#define IP_MULTICAST_TTL 10')
+	g.writeln('#define IP_MULTICAST_LOOP 11')
+	g.writeln('#define IP_ADD_MEMBERSHIP 12')
+	g.writeln('#define IP_DROP_MEMBERSHIP 13')
+	g.writeln('#define IPV6_MULTICAST_IF 9')
+	g.writeln('#define IPV6_MULTICAST_HOPS 10')
+	g.writeln('#define IPV6_MULTICAST_LOOP 11')
+	g.writeln('#define IPV6_ADD_MEMBERSHIP 12')
+	g.writeln('#define IPV6_JOIN_GROUP 12')
+	g.writeln('#define IPV6_DROP_MEMBERSHIP 13')
+	g.writeln('#define IPV6_LEAVE_GROUP 13')
+	g.writeln('#define IPV6_V6ONLY 27')
+	g.writeln('#define AI_PASSIVE 0x00000001')
+	g.writeln('#define MSG_DONTWAIT 0x80')
+	g.writeln('#define MSG_NOSIGNAL ${msg_nosignal}')
+}
+
+fn (mut g FlatGen) headerless_solaris_net_constants() {
+	g.writeln('#define AF_UNSPEC 0')
+	g.writeln('#define AF_UNIX 1')
+	g.writeln('#define AF_INET 2')
+	g.writeln('#define AF_INET6 26')
+	g.writeln('#define SOCK_STREAM 2')
+	g.writeln('#define SOCK_DGRAM 1')
+	g.writeln('#define SOCK_RAW 4')
+	g.writeln('#define SOCK_SEQPACKET 6')
+	g.writeln('#define IPPROTO_IP 0')
+	g.writeln('#define IPPROTO_ICMP 1')
+	g.writeln('#define IPPROTO_TCP 6')
+	g.writeln('#define IPPROTO_UDP 17')
+	g.writeln('#define IPPROTO_IPV6 41')
+	g.writeln('#define IPPROTO_ICMPV6 58')
+	g.writeln('#define IPPROTO_RAW 255')
+	g.writeln('#define SOL_SOCKET 0xffff')
+	g.writeln('#define SO_DEBUG 0x0001')
+	g.writeln('#define SO_REUSEADDR 0x0004')
+	g.writeln('#define SO_KEEPALIVE 0x0008')
+	g.writeln('#define SO_DONTROUTE 0x0010')
+	g.writeln('#define SO_BROADCAST 0x0020')
+	g.writeln('#define SO_LINGER 0x0080')
+	g.writeln('#define SO_OOBINLINE 0x0100')
+	g.writeln('#define SO_SNDBUF 0x1001')
+	g.writeln('#define SO_RCVBUF 0x1002')
+	g.writeln('#define SO_SNDLOWAT 0x1003')
+	g.writeln('#define SO_RCVLOWAT 0x1004')
+	g.writeln('#define SO_SNDTIMEO 0x1005')
+	g.writeln('#define SO_RCVTIMEO 0x1006')
+	g.writeln('#define SO_ERROR 0x1007')
+	g.writeln('#define SO_TYPE 0x1008')
+	g.writeln('#define TCP_NODELAY 1')
+	g.writeln('#define IP_HDRINCL 2')
+	g.writeln('#define IP_MULTICAST_IF 0x10')
+	g.writeln('#define IP_MULTICAST_TTL 0x11')
+	g.writeln('#define IP_MULTICAST_LOOP 0x12')
+	g.writeln('#define IP_ADD_MEMBERSHIP 0x13')
+	g.writeln('#define IP_DROP_MEMBERSHIP 0x14')
+	g.writeln('#define IPV6_MULTICAST_IF 0x6')
+	g.writeln('#define IPV6_MULTICAST_HOPS 0x7')
+	g.writeln('#define IPV6_MULTICAST_LOOP 0x8')
+	g.writeln('#define IPV6_ADD_MEMBERSHIP 0x9')
+	g.writeln('#define IPV6_JOIN_GROUP 0x9')
+	g.writeln('#define IPV6_DROP_MEMBERSHIP 0xa')
+	g.writeln('#define IPV6_LEAVE_GROUP 0xa')
+	g.writeln('#define IPV6_V6ONLY 0x27')
+	g.writeln('#define AI_PASSIVE 0x0008')
+	g.writeln('#define MSG_DONTWAIT 0x80')
+	g.writeln('#define MSG_NOSIGNAL 0x200')
+}
+
+fn (mut g FlatGen) headerless_qnx_net_constants() {
+	g.writeln('#define AF_UNSPEC 0')
+	g.writeln('#define AF_UNIX 1')
+	g.writeln('#define AF_INET 2')
+	g.writeln('#define AF_INET6 24')
+	g.writeln('#define SOCK_STREAM 1')
+	g.writeln('#define SOCK_DGRAM 2')
+	g.writeln('#define SOCK_RAW 3')
+	g.writeln('#define SOCK_SEQPACKET 5')
+	g.writeln('#define IPPROTO_IP 0')
+	g.writeln('#define IPPROTO_ICMP 1')
+	g.writeln('#define IPPROTO_TCP 6')
+	g.writeln('#define IPPROTO_UDP 17')
+	g.writeln('#define IPPROTO_IPV6 41')
+	g.writeln('#define IPPROTO_ICMPV6 58')
+	g.writeln('#define IPPROTO_RAW 255')
+	g.writeln('#define SOL_SOCKET 0xffff')
+	g.writeln('#define SO_DEBUG 0x0001')
+	g.writeln('#define SO_REUSEADDR 0x0004')
+	g.writeln('#define SO_KEEPALIVE 0x0008')
+	g.writeln('#define SO_DONTROUTE 0x0010')
+	g.writeln('#define SO_BROADCAST 0x0020')
+	g.writeln('#define SO_LINGER 0x0080')
+	g.writeln('#define SO_OOBINLINE 0x0100')
+	g.writeln('#define SO_SNDBUF 0x1001')
+	g.writeln('#define SO_RCVBUF 0x1002')
+	g.writeln('#define SO_SNDLOWAT 0x1003')
+	g.writeln('#define SO_RCVLOWAT 0x1004')
+	g.writeln('#define SO_SNDTIMEO 0x1005')
+	g.writeln('#define SO_RCVTIMEO 0x1006')
+	g.writeln('#define SO_ERROR 0x1007')
+	g.writeln('#define SO_TYPE 0x1008')
+	g.writeln('#define TCP_NODELAY 1')
+	g.writeln('#define IP_HDRINCL 2')
+	g.writeln('#define IP_MULTICAST_IF 9')
+	g.writeln('#define IP_MULTICAST_TTL 10')
+	g.writeln('#define IP_MULTICAST_LOOP 11')
+	g.writeln('#define IP_ADD_MEMBERSHIP 12')
+	g.writeln('#define IP_DROP_MEMBERSHIP 13')
+	g.writeln('#define IPV6_MULTICAST_IF 9')
+	g.writeln('#define IPV6_MULTICAST_HOPS 10')
+	g.writeln('#define IPV6_MULTICAST_LOOP 11')
+	g.writeln('#define IPV6_ADD_MEMBERSHIP 12')
+	g.writeln('#define IPV6_JOIN_GROUP 12')
+	g.writeln('#define IPV6_DROP_MEMBERSHIP 13')
+	g.writeln('#define IPV6_LEAVE_GROUP 13')
+	g.writeln('#define IPV6_V6ONLY 27')
+	g.writeln('#define AI_PASSIVE 0x00000001')
+	g.writeln('#define MSG_DONTWAIT 0x80')
+	g.writeln('#define MSG_NOSIGNAL 0x0800')
+}
+
+fn (mut g FlatGen) headerless_linux_net_constants() {
+	g.writeln('#define AF_UNSPEC 0')
+	g.writeln('#define AF_UNIX 1')
+	g.writeln('#define AF_INET 2')
+	g.writeln('#define AF_INET6 10')
+	g.writeln('#define SOCK_STREAM 1')
+	g.writeln('#define SOCK_DGRAM 2')
+	g.writeln('#define SOCK_RAW 3')
+	g.writeln('#define SOCK_SEQPACKET 5')
+	g.writeln('#define SOCK_NONBLOCK 04000')
+	g.writeln('#define IPPROTO_IP 0')
+	g.writeln('#define IPPROTO_ICMP 1')
+	g.writeln('#define IPPROTO_TCP 6')
+	g.writeln('#define IPPROTO_UDP 17')
+	g.writeln('#define IPPROTO_IPV6 41')
+	g.writeln('#define IPPROTO_ICMPV6 58')
+	g.writeln('#define IPPROTO_RAW 255')
+	g.writeln('#define SOL_SOCKET 1')
+	g.writeln('#define SO_DEBUG 1')
+	g.writeln('#define SO_REUSEADDR 2')
+	g.writeln('#define SO_TYPE 3')
+	g.writeln('#define SO_ERROR 4')
+	g.writeln('#define SO_DONTROUTE 5')
+	g.writeln('#define SO_BROADCAST 6')
+	g.writeln('#define SO_SNDBUF 7')
+	g.writeln('#define SO_RCVBUF 8')
+	g.writeln('#define SO_KEEPALIVE 9')
+	g.writeln('#define SO_OOBINLINE 10')
+	g.writeln('#define SO_LINGER 13')
+	g.writeln('#define SO_REUSEPORT 15')
+	g.writeln('#define SO_RCVLOWAT 18')
+	g.writeln('#define SO_SNDLOWAT 19')
+	g.writeln('#define SO_RCVTIMEO 20')
+	g.writeln('#define SO_SNDTIMEO 21')
+	g.writeln('#define TCP_NODELAY 1')
+	g.writeln('#define TCP_DEFER_ACCEPT 9')
+	g.writeln('#define TCP_QUICKACK 12')
+	g.writeln('#define TCP_FASTOPEN 23')
+	g.writeln('#define IP_HDRINCL 3')
+	g.writeln('#define IP_MULTICAST_IF 32')
+	g.writeln('#define IP_MULTICAST_TTL 33')
+	g.writeln('#define IP_MULTICAST_LOOP 34')
+	g.writeln('#define IP_ADD_MEMBERSHIP 35')
+	g.writeln('#define IP_DROP_MEMBERSHIP 36')
+	g.writeln('#define IPV6_MULTICAST_IF 17')
+	g.writeln('#define IPV6_MULTICAST_HOPS 18')
+	g.writeln('#define IPV6_MULTICAST_LOOP 19')
+	g.writeln('#define IPV6_ADD_MEMBERSHIP 20')
+	g.writeln('#define IPV6_JOIN_GROUP 20')
+	g.writeln('#define IPV6_DROP_MEMBERSHIP 21')
+	g.writeln('#define IPV6_LEAVE_GROUP 21')
+	g.writeln('#define IPV6_V6ONLY 26')
+	g.writeln('#define AI_PASSIVE 0x0001')
+	g.writeln('#define SOMAXCONN 4096')
+	g.writeln('#define MSG_DONTWAIT 0x40')
+	g.writeln('#define MSG_NOSIGNAL 0x4000')
+}
+
+fn (mut g FlatGen) headerless_windows_net_constants() {
+	g.writeln('#define AF_UNSPEC 0')
+	g.writeln('#define AF_UNIX 1')
+	g.writeln('#define AF_INET 2')
+	g.writeln('#define AF_INET6 23')
+	g.writeln('#define SOCK_STREAM 1')
+	g.writeln('#define SOCK_DGRAM 2')
+	g.writeln('#define SOCK_RAW 3')
+	g.writeln('#define SOCK_SEQPACKET 5')
+	g.writeln('#define SOCKET_ERROR (-1)')
+	g.writeln('#define WSAEWOULDBLOCK 10035')
+	g.writeln('#define IPPROTO_IP 0')
+	g.writeln('#define IPPROTO_ICMP 1')
+	g.writeln('#define IPPROTO_TCP 6')
+	g.writeln('#define IPPROTO_UDP 17')
+	g.writeln('#define IPPROTO_IPV6 41')
+	g.writeln('#define IPPROTO_ICMPV6 58')
+	g.writeln('#define IPPROTO_RAW 255')
+	g.writeln('#define SOL_SOCKET 0xffff')
+	g.writeln('#define SO_DEBUG 0x0001')
+	g.writeln('#define SO_REUSEADDR 0x0004')
+	g.writeln('#define SO_KEEPALIVE 0x0008')
+	g.writeln('#define SO_DONTROUTE 0x0010')
+	g.writeln('#define SO_BROADCAST 0x0020')
+	g.writeln('#define SO_LINGER 0x0080')
+	g.writeln('#define SO_OOBINLINE 0x0100')
+	g.writeln('#define SO_SNDBUF 0x1001')
+	g.writeln('#define SO_RCVBUF 0x1002')
+	g.writeln('#define SO_SNDLOWAT 0x1003')
+	g.writeln('#define SO_RCVLOWAT 0x1004')
+	g.writeln('#define SO_SNDTIMEO 0x1005')
+	g.writeln('#define SO_RCVTIMEO 0x1006')
+	g.writeln('#define SO_ERROR 0x1007')
+	g.writeln('#define SO_TYPE 0x1008')
+	g.writeln('#define TCP_NODELAY 1')
+	g.writeln('#define IP_HDRINCL 2')
+	g.writeln('#define IP_MULTICAST_IF 9')
+	g.writeln('#define IP_MULTICAST_TTL 10')
+	g.writeln('#define IP_MULTICAST_LOOP 11')
+	g.writeln('#define IP_ADD_MEMBERSHIP 12')
+	g.writeln('#define IP_DROP_MEMBERSHIP 13')
+	g.writeln('#define IPV6_MULTICAST_IF 9')
+	g.writeln('#define IPV6_MULTICAST_HOPS 10')
+	g.writeln('#define IPV6_MULTICAST_LOOP 11')
+	g.writeln('#define IPV6_ADD_MEMBERSHIP 12')
+	g.writeln('#define IPV6_JOIN_GROUP 12')
+	g.writeln('#define IPV6_DROP_MEMBERSHIP 13')
+	g.writeln('#define IPV6_LEAVE_GROUP 13')
+	g.writeln('#define IPV6_V6ONLY 27')
+	g.writeln('#define AI_PASSIVE 0x00000001')
+	g.writeln('#define MSG_DONTWAIT 0')
+	g.writeln('#define MSG_NOSIGNAL 0')
 }
 
 fn (mut g FlatGen) write_arch_macros() {
@@ -3001,7 +5398,21 @@ fn (mut g FlatGen) libc_compat_decls() {
 	if g.libc_compat_fns['gettid'] {
 		g.writeln('#ifdef __linux__')
 		g.writeln('#ifndef SYS_gettid')
-		g.writeln('#define SYS_gettid __NR_gettid')
+		g.writeln('#if defined(__x86_64__)')
+		g.writeln('#define SYS_gettid 186')
+		g.writeln('#elif defined(__aarch64__)')
+		g.writeln('#define SYS_gettid 178')
+		g.writeln('#elif defined(__i386__)')
+		g.writeln('#define SYS_gettid 224')
+		g.writeln('#elif defined(__arm__)')
+		g.writeln('#define SYS_gettid 224')
+		g.writeln('#elif defined(__riscv) && __riscv_xlen == 64')
+		g.writeln('#define SYS_gettid 178')
+		g.writeln('#elif defined(__loongarch_lp64)')
+		g.writeln('#define SYS_gettid 178')
+		g.writeln('#else')
+		g.writeln('#error unsupported Linux gettid syscall number for this architecture')
+		g.writeln('#endif')
 		g.writeln('#endif')
 		g.writeln('static inline u32 v3_gettid(void) {')
 		g.writeln('\treturn (u32)syscall(SYS_gettid);')
@@ -3024,33 +5435,49 @@ fn (mut g FlatGen) prealloc_atomic_compat_decls() {
 }
 
 fn (mut g FlatGen) atomic_builtin_compat_decls() {
-	if g.has_stdatomic_compat_header {
-		return
-	}
 	// Atomic helpers. We use compiler __atomic_* builtins (memory order 5 == __ATOMIC_SEQ_CST).
 	// clang/gcc inline the generic _n / RMW builtins. tcc only implements the inline
 	// __atomic_{add,sub,fetch}_* RMW builtins; for load/store/exchange/cas it has no generic
 	// _n form, so we route those to the sized __atomic_*_N libcalls (resolved from libc).
+	g.writeln('static inline byte atomic_fetch_add_byte(void* ptr, byte delta) { return __atomic_fetch_add((byte*)ptr, delta, 5); }')
+	g.writeln('static inline u16 atomic_fetch_add_u16(void* ptr, u16 delta) { return __atomic_fetch_add((u16*)ptr, delta, 5); }')
 	g.writeln('static inline u32 atomic_fetch_add_u32(void* ptr, u32 delta) { return __atomic_fetch_add((u32*)ptr, delta, 5); }')
 	g.writeln('static inline u64 atomic_fetch_add_u64(void* ptr, u64 delta) { return __atomic_fetch_add((u64*)ptr, delta, 5); }')
+	g.writeln('static inline void* atomic_fetch_add_ptr(void* ptr, void* delta) { return (void*)(uintptr_t)__atomic_fetch_add((uintptr_t*)ptr, (uintptr_t)delta, 5); }')
+	g.writeln('static inline byte atomic_fetch_sub_byte(void* ptr, byte delta) { return __atomic_fetch_sub((byte*)ptr, delta, 5); }')
+	g.writeln('static inline u16 atomic_fetch_sub_u16(void* ptr, u16 delta) { return __atomic_fetch_sub((u16*)ptr, delta, 5); }')
+	g.writeln('static inline u32 atomic_fetch_sub_u32(void* ptr, u32 delta) { return __atomic_fetch_sub((u32*)ptr, delta, 5); }')
 	g.writeln('static inline u64 atomic_fetch_sub_u64(void* ptr, u64 delta) { return __atomic_fetch_sub((u64*)ptr, delta, 5); }')
+	g.writeln('static inline void* atomic_fetch_sub_ptr(void* ptr, void* delta) { return (void*)(uintptr_t)__atomic_fetch_sub((uintptr_t*)ptr, (uintptr_t)delta, 5); }')
 	g.writeln('static inline byte atomic_load_byte(void* ptr) { return __atomic_fetch_add((byte*)ptr, 0, 5); }')
 	g.writeln('static inline u16 atomic_load_u16(void* ptr) { return __atomic_fetch_add((u16*)ptr, 0, 5); }')
 	g.writeln('static inline u32 atomic_load_u32(void* ptr) { return __atomic_fetch_add((u32*)ptr, 0, 5); }')
 	g.writeln('static inline u64 atomic_load_u64(void* ptr) { return __atomic_fetch_add((u64*)ptr, 0, 5); }')
-	g.writeln('static inline void* atomic_load_ptr(void* ptr) { return *(void* volatile*)ptr; }')
 	g.writeln('#ifdef __TINYC__')
+	g.writeln('#if UINTPTR_MAX == 0xFFFFFFFF')
+	g.writeln('static inline void* atomic_load_ptr(void* ptr) { return (void*)(size_t)__atomic_load_4((u32*)ptr, 5); }')
+	g.writeln('#else')
+	g.writeln('static inline void* atomic_load_ptr(void* ptr) { return (void*)(size_t)__atomic_load_8((u64*)ptr, 5); }')
+	g.writeln('#endif')
+	g.writeln('static inline byte atomic_exchange_byte(void* ptr, byte val) { return __atomic_exchange_1((byte*)ptr, val, 5); }')
+	g.writeln('static inline u16 atomic_exchange_u16(void* ptr, u16 val) { return __atomic_exchange_2((u16*)ptr, val, 5); }')
+	g.writeln('static inline u32 atomic_exchange_u32(void* ptr, u32 val) { return __atomic_exchange_4((u32*)ptr, val, 5); }')
+	g.writeln('static inline u64 atomic_exchange_u64(void* ptr, u64 val) { return __atomic_exchange_8((u64*)ptr, val, 5); }')
 	g.writeln('static inline void atomic_store_byte(void* ptr, byte val) { __atomic_store_1((byte*)ptr, val, 5); }')
 	g.writeln('static inline void atomic_store_u16(void* ptr, u16 val) { __atomic_store_2((u16*)ptr, val, 5); }')
 	g.writeln('static inline void atomic_store_u32(void* ptr, u32 val) { __atomic_store_4((u32*)ptr, val, 5); }')
 	g.writeln('static inline void atomic_store_u64(void* ptr, u64 val) { __atomic_store_8((u64*)ptr, val, 5); }')
 	g.writeln('#if UINTPTR_MAX == 0xFFFFFFFF')
+	g.writeln('static inline void* atomic_exchange_ptr(void* ptr, void* val) { return (void*)(size_t)__atomic_exchange_4((u32*)ptr, (u32)(size_t)val, 5); }')
 	g.writeln('static inline void atomic_store_ptr(void* ptr, void* val) { __atomic_store_4((u32*)ptr, (u32)(size_t)val, 5); }')
 	g.writeln('#else')
+	g.writeln('static inline void* atomic_exchange_ptr(void* ptr, void* val) { return (void*)(size_t)__atomic_exchange_8((u64*)ptr, (u64)(size_t)val, 5); }')
 	g.writeln('static inline void atomic_store_ptr(void* ptr, void* val) { __atomic_store_8((u64*)ptr, (u64)(size_t)val, 5); }')
 	g.writeln('#endif')
+	g.writeln('static inline bool atomic_compare_exchange_strong_byte(void* ptr, byte* expected, byte desired) { return __atomic_compare_exchange_1((byte*)ptr, expected, desired, 5, 5); }')
 	g.writeln('static inline bool atomic_compare_exchange_strong_u16(void* ptr, u16* expected, u16 desired) { return __atomic_compare_exchange_2((u16*)ptr, expected, desired, 5, 5); }')
 	g.writeln('static inline bool atomic_compare_exchange_strong_u32(void* ptr, u32* expected, u32 desired) { return __atomic_compare_exchange_4((u32*)ptr, expected, desired, 5, 5); }')
+	g.writeln('static inline bool atomic_compare_exchange_strong_u64(void* ptr, u64* expected, u64 desired) { return __atomic_compare_exchange_8((u64*)ptr, expected, desired, 5, 5); }')
 	g.writeln('#if UINTPTR_MAX == 0xFFFFFFFF')
 	g.writeln('static inline bool atomic_compare_exchange_strong_ptr(void* ptr, void* expected, ptrdiff_t desired) { return __atomic_compare_exchange_4((u32*)ptr, (u32*)expected, (u32)desired, 5, 5); }')
 	g.writeln('#else')
@@ -3061,13 +5488,21 @@ fn (mut g FlatGen) atomic_builtin_compat_decls() {
 	g.writeln('static inline bool atomic_compare_exchange_weak_u32(void* ptr, u32* expected, u32 desired) { return __atomic_compare_exchange_4((u32*)ptr, expected, desired, 5, 5); }')
 	g.writeln('static inline bool atomic_compare_exchange_weak_u64(void* ptr, u64* expected, u64 desired) { return __atomic_compare_exchange_8((u64*)ptr, expected, desired, 5, 5); }')
 	g.writeln('#else')
+	g.writeln('static inline void* atomic_load_ptr(void* ptr) { return __atomic_load_n((void**)ptr, 5); }')
+	g.writeln('static inline byte atomic_exchange_byte(void* ptr, byte val) { return __atomic_exchange_n((byte*)ptr, val, 5); }')
+	g.writeln('static inline u16 atomic_exchange_u16(void* ptr, u16 val) { return __atomic_exchange_n((u16*)ptr, val, 5); }')
+	g.writeln('static inline u32 atomic_exchange_u32(void* ptr, u32 val) { return __atomic_exchange_n((u32*)ptr, val, 5); }')
+	g.writeln('static inline u64 atomic_exchange_u64(void* ptr, u64 val) { return __atomic_exchange_n((u64*)ptr, val, 5); }')
+	g.writeln('static inline void* atomic_exchange_ptr(void* ptr, void* val) { return __atomic_exchange_n((void**)ptr, val, 5); }')
 	g.writeln('static inline void atomic_store_byte(void* ptr, byte val) { __atomic_store_n((byte*)ptr, val, 5); }')
 	g.writeln('static inline void atomic_store_u16(void* ptr, u16 val) { __atomic_store_n((u16*)ptr, val, 5); }')
 	g.writeln('static inline void atomic_store_u32(void* ptr, u32 val) { __atomic_store_n((u32*)ptr, val, 5); }')
 	g.writeln('static inline void atomic_store_u64(void* ptr, u64 val) { __atomic_store_n((u64*)ptr, val, 5); }')
 	g.writeln('static inline void atomic_store_ptr(void* ptr, void* val) { __atomic_store_n((void**)ptr, val, 5); }')
+	g.writeln('static inline bool atomic_compare_exchange_strong_byte(void* ptr, byte* expected, byte desired) { return __atomic_compare_exchange_n((byte*)ptr, expected, desired, 0, 5, 5); }')
 	g.writeln('static inline bool atomic_compare_exchange_strong_u16(void* ptr, u16* expected, u16 desired) { return __atomic_compare_exchange_n((u16*)ptr, expected, desired, 0, 5, 5); }')
 	g.writeln('static inline bool atomic_compare_exchange_strong_u32(void* ptr, u32* expected, u32 desired) { return __atomic_compare_exchange_n((u32*)ptr, expected, desired, 0, 5, 5); }')
+	g.writeln('static inline bool atomic_compare_exchange_strong_u64(void* ptr, u64* expected, u64 desired) { return __atomic_compare_exchange_n((u64*)ptr, expected, desired, 0, 5, 5); }')
 	g.writeln('static inline bool atomic_compare_exchange_strong_ptr(void* ptr, void* expected, ptrdiff_t desired) { return __atomic_compare_exchange_n((void**)ptr, (void**)expected, (void*)desired, 0, 5, 5); }')
 	g.writeln('static inline bool atomic_compare_exchange_weak_byte(void* ptr, byte* expected, byte desired) { return __atomic_compare_exchange_n((byte*)ptr, expected, desired, 1, 5, 5); }')
 	g.writeln('static inline bool atomic_compare_exchange_weak_u16(void* ptr, u16* expected, u16 desired) { return __atomic_compare_exchange_n((u16*)ptr, expected, desired, 1, 5, 5); }')
@@ -3083,6 +5518,20 @@ fn (mut g FlatGen) builtin_abi_decls() {
 		return
 	}
 	g.libc_compat_decls()
+	g.writeln('#ifndef __linux__')
+	g.writeln('#define pthread_rwlockattr_setkind_np(attr, kind) 0')
+	g.writeln('#endif')
+	g.writeln('#ifndef V_OS_FILELOCK_HELPERS_H')
+	g.writeln('#ifdef _WIN32')
+	g.writeln('BOOL LockFileEx(HANDLE handle, DWORD flags, DWORD reserved, DWORD low, DWORD high, OVERLAPPED* overlap);')
+	g.writeln('BOOL UnlockFileEx(HANDLE handle, DWORD reserved, DWORD low, DWORD high, OVERLAPPED* overlap);')
+	g.writeln('static inline int v_filelock_lock(HANDLE handle, int exclusive, int immediate, u64 start, u64 len) { OVERLAPPED overlap; memset(&overlap, 0, sizeof(overlap)); overlap.Offset = (DWORD)(start & 0xffffffffULL); overlap.OffsetHigh = (DWORD)(start >> 32); DWORD flags = immediate ? LOCKFILE_FAIL_IMMEDIATELY : 0; if (exclusive) { flags |= LOCKFILE_EXCLUSIVE_LOCK; } DWORD low = len == 0 ? MAXDWORD : (DWORD)(len & 0xffffffffULL); DWORD high = len == 0 ? MAXDWORD : (DWORD)(len >> 32); return LockFileEx(handle, flags, 0, low, high, &overlap) ? 0 : -1; }')
+	g.writeln('static inline int v_filelock_unlock(HANDLE handle, u64 start, u64 len) { OVERLAPPED overlap; memset(&overlap, 0, sizeof(overlap)); overlap.Offset = (DWORD)(start & 0xffffffffULL); overlap.OffsetHigh = (DWORD)(start >> 32); DWORD low = len == 0 ? MAXDWORD : (DWORD)(len & 0xffffffffULL); DWORD high = len == 0 ? MAXDWORD : (DWORD)(len >> 32); return UnlockFileEx(handle, 0, low, high, &overlap) ? 0 : -1; }')
+	g.writeln('#else')
+	g.writeln('static inline int v_filelock_lock(int fd, int exclusive, int immediate, u64 start, u64 len) { struct flock fl; memset(&fl, 0, sizeof(fl)); fl.l_type = exclusive ? F_WRLCK : F_RDLCK; fl.l_whence = SEEK_SET; fl.l_start = (off_t)start; fl.l_len = len == 0 ? 0 : (off_t)len; return fcntl(fd, immediate ? F_SETLK : F_SETLKW, &fl); }')
+	g.writeln('static inline int v_filelock_unlock(int fd, u64 start, u64 len) { struct flock fl; memset(&fl, 0, sizeof(fl)); fl.l_type = F_UNLCK; fl.l_whence = SEEK_SET; fl.l_start = (off_t)start; fl.l_len = len == 0 ? 0 : (off_t)len; return fcntl(fd, F_SETLK, &fl); }')
+	g.writeln('#endif')
+	g.writeln('#endif')
 	g.writeln('#define array_new(elem_size, len, cap) __new_array((len), (cap), (elem_size))')
 	g.writeln('#define array_push array__push')
 	g.writeln('void array__push_many(array* a, void* val, int size);')
@@ -3097,13 +5546,20 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('#ifndef V_COMMIT_HASH')
 	g.writeln('#define V_COMMIT_HASH ""')
 	g.writeln('#endif')
+	g.writeln('#ifndef memory_order_relaxed')
+	g.writeln('#define memory_order_relaxed 0')
+	g.writeln('#define memory_order_acquire 2')
+	g.writeln('#define memory_order_release 3')
+	g.writeln('#define memory_order_acq_rel 4')
+	g.writeln('#define memory_order_seq_cst 5')
+	g.writeln('#endif')
+	g.writeln('#define atomic_thread_fence(order) __atomic_thread_fence(order)')
 	// Weak fallbacks for the heap-tracking hooks. A program that provides real
 	// implementations (e.g. a `vheap_alloc`/`vheap_free` from a linked C file, as
 	// some projects do) overrides these without a redefinition/static-vs-non-static
 	// clash against that file's own non-static prototype.
 	g.writeln('__attribute__((weak)) void vheap_alloc(void* p, u64 n) { (void)p; (void)n; }')
 	g.writeln('__attribute__((weak)) void vheap_free(void* p) { (void)p; }')
-	g.filelock_compat_decls()
 	g.prealloc_atomic_compat_decls()
 	g.atomic_builtin_compat_decls()
 	g.writeln('static inline double math__abs(double a) { return a < 0 ? -a : a; }')
@@ -3134,59 +5590,6 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('#define min_int min_i32')
 	g.writeln('#endif')
 	g.writeln('')
-}
-
-fn (mut g FlatGen) filelock_compat_decls() {
-	if !g.libc_compat_fns['filelock'] {
-		return
-	}
-	g.writeln('#ifndef V_OS_FILELOCK_HELPERS_H')
-	g.writeln('#define V_OS_FILELOCK_HELPERS_H')
-	g.writeln('#ifdef _WIN32')
-	g.writeln('#include <windows.h>')
-	g.writeln('static int v_filelock_lock(HANDLE handle, int exclusive, int immediate, unsigned long long start, unsigned long long len) {')
-	g.writeln('\tOVERLAPPED overlap;')
-	g.writeln('\tmemset(&overlap, 0, sizeof(overlap));')
-	g.writeln('\toverlap.Offset = (DWORD)(start & 0xffffffffULL);')
-	g.writeln('\toverlap.OffsetHigh = (DWORD)(start >> 32);')
-	g.writeln('\tDWORD flags = immediate ? LOCKFILE_FAIL_IMMEDIATELY : 0;')
-	g.writeln('\tif (exclusive) { flags |= LOCKFILE_EXCLUSIVE_LOCK; }')
-	g.writeln('\tDWORD low = len == 0 ? MAXDWORD : (DWORD)(len & 0xffffffffULL);')
-	g.writeln('\tDWORD high = len == 0 ? MAXDWORD : (DWORD)(len >> 32);')
-	g.writeln('\treturn LockFileEx(handle, flags, 0, low, high, &overlap) ? 0 : -1;')
-	g.writeln('}')
-	g.writeln('static int v_filelock_unlock(HANDLE handle, unsigned long long start, unsigned long long len) {')
-	g.writeln('\tOVERLAPPED overlap;')
-	g.writeln('\tmemset(&overlap, 0, sizeof(overlap));')
-	g.writeln('\toverlap.Offset = (DWORD)(start & 0xffffffffULL);')
-	g.writeln('\toverlap.OffsetHigh = (DWORD)(start >> 32);')
-	g.writeln('\tDWORD low = len == 0 ? MAXDWORD : (DWORD)(len & 0xffffffffULL);')
-	g.writeln('\tDWORD high = len == 0 ? MAXDWORD : (DWORD)(len >> 32);')
-	g.writeln('\treturn UnlockFileEx(handle, 0, low, high, &overlap) ? 0 : -1;')
-	g.writeln('}')
-	g.writeln('#else')
-	g.writeln('#include <fcntl.h>')
-	g.writeln('#include <unistd.h>')
-	g.writeln('static int v_filelock_lock(int fd, int exclusive, int immediate, unsigned long long start, unsigned long long len) {')
-	g.writeln('\tstruct flock fl;')
-	g.writeln('\tmemset(&fl, 0, sizeof(fl));')
-	g.writeln('\tfl.l_type = exclusive ? F_WRLCK : F_RDLCK;')
-	g.writeln('\tfl.l_whence = SEEK_SET;')
-	g.writeln('\tfl.l_start = (off_t)start;')
-	g.writeln('\tfl.l_len = len == 0 ? 0 : (off_t)len;')
-	g.writeln('\treturn fcntl(fd, immediate ? F_SETLK : F_SETLKW, &fl);')
-	g.writeln('}')
-	g.writeln('static int v_filelock_unlock(int fd, unsigned long long start, unsigned long long len) {')
-	g.writeln('\tstruct flock fl;')
-	g.writeln('\tmemset(&fl, 0, sizeof(fl));')
-	g.writeln('\tfl.l_type = F_UNLCK;')
-	g.writeln('\tfl.l_whence = SEEK_SET;')
-	g.writeln('\tfl.l_start = (off_t)start;')
-	g.writeln('\tfl.l_len = len == 0 ? 0 : (off_t)len;')
-	g.writeln('\treturn fcntl(fd, F_SETLK, &fl);')
-	g.writeln('}')
-	g.writeln('#endif')
-	g.writeln('#endif')
 }
 
 fn (mut g FlatGen) collect_fixed_array_typedefs_needed() map[string]FixedArrayTypedefInfo {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1,5 +1,6 @@
 module c
 
+import strings
 import v3.flat
 import v3.types
 
@@ -354,6 +355,13 @@ fn (mut g FlatGen) direct_call_name_for_call(id flat.NodeId, name string) string
 }
 
 fn (mut g FlatGen) libc_compat_call_name(name string) ?string {
+	if name.starts_with('C.') {
+		cfn := c_name(name)
+		wide_cfn := c_winapi_wide_export_name(cfn)
+		if wide_cfn != cfn {
+			return wide_cfn
+		}
+	}
 	// `builtin.v_gettid()` reaches libc through `C.gettid()` on Linux/glibc, but
 	// that symbol is not declared by all usable C header sets. Route it through a
 	// tiny runtime compatibility helper instead of emitting an undeclared call.
@@ -1124,7 +1132,7 @@ fn (mut g FlatGen) gen_top_level_main_stmt(id flat.NodeId) {
 		return
 	}
 	node := g.a.nodes[int(id)]
-	if node.kind == .block {
+	if node.kind in [.block, .comptime_if] {
 		for i in 0 .. node.children_count {
 			child_id := g.a.child(&node, i)
 			if g.cgen_is_top_level_stmt(child_id) {
@@ -3808,29 +3816,428 @@ fn (mut g FlatGen) forward_decls() {
 					g.writeln(');')
 				}
 			}
-		} else if kind_id == 76
-			&& (node.value.starts_with('C.v_filelock_') || node.value.starts_with('v_filelock_')) {
-			if g.libc_compat_fns['filelock']
-				&& node.value in ['C.v_filelock_lock', 'C.v_filelock_unlock', 'v_filelock_lock', 'v_filelock_unlock'] {
-				continue
-			}
-			g.tc.cur_file = cur_file
-			g.tc.cur_module = cur_module
-			ret_type := g.tc.parse_type(node.typ)
-			cfn := c_name(node.value)
-			if forwarded[cfn] {
-				continue
-			}
-			forwarded[cfn] = true
-			g.write(g.optional_type_name(ret_type))
-			g.write(' ')
-			g.write(cfn)
-			g.write('(')
-			g.write_c_fn_node_params(node)
-			g.writeln(');')
 		}
 	}
 	g.writeln('')
+}
+
+fn (mut g FlatGen) c_extern_forward_decls() {
+	mut cur_module := ''
+	mut cur_file := ''
+	mut decls := map[string]string{}
+	mut names := []string{}
+	for i in 0 .. g.a.nodes.len {
+		node := g.a.nodes[i]
+		kind_id := node_kind_id(node)
+		if kind_id == 77 {
+			cur_file = node.value
+			cur_module = ''
+			g.tc.cur_file = cur_file
+			g.tc.cur_module = cur_module
+			continue
+		}
+		if kind_id == 73 {
+			cur_module = node.value
+			g.tc.cur_file = cur_file
+			g.tc.cur_module = cur_module
+			continue
+		}
+		if kind_id != 76 {
+			continue
+		}
+		raw_name := if node.value.starts_with('C.') { node.value } else { 'C.${node.value}' }
+		raw_cfn := c_name(raw_name)
+		cfn := c_winapi_wide_export_name(raw_cfn)
+		if g.has_used_fn_filter() && !(g.spawn_wrapper_defs.len > 0
+			&& cfn in c_spawn_runtime_extern_symbols) && !g.used_fn_contains(raw_name)
+			&& !g.used_fn_contains(raw_cfn) && !g.used_fn_contains(cfn) {
+			continue
+		}
+		if !g.should_emit_c_extern_decl(cfn) {
+			continue
+		}
+		g.tc.cur_file = cur_file
+		g.tc.cur_module = cur_module
+		if cfn !in decls {
+			names << cfn
+		}
+		decls[cfn] = g.c_extern_decl_line(node, cfn)
+	}
+	names.sort()
+	for name in names {
+		g.writeln(decls[name])
+	}
+	if names.len > 0 {
+		g.writeln('')
+	}
+}
+
+fn (mut g FlatGen) preseed_c_extern_fn_ptr_types() {
+	for i in 0 .. g.a.nodes.len {
+		node := g.a.nodes[i]
+		if node_kind_id(node) != 76 {
+			continue
+		}
+		ret_type := g.tc.parse_type(node.typ)
+		g.preseed_fn_ptr_type(ret_type)
+		for j in 0 .. node.children_count {
+			param_id := g.a.child(&node, j)
+			p := g.a.node(param_id)
+			if p.kind != .param {
+				continue
+			}
+			raw_typ := if p.typ.len > 0 { p.typ } else { p.value }
+			if raw_typ.len == 0 || raw_typ.starts_with('...') {
+				continue
+			}
+			g.preseed_fn_ptr_type(g.tc.parse_type(raw_typ))
+		}
+	}
+}
+
+const c_spawn_runtime_extern_symbols = {
+	'pthread_attr_destroy':      true
+	'pthread_attr_init':         true
+	'pthread_attr_setstacksize': true
+	'pthread_create':            true
+	'pthread_join':              true
+}
+
+fn (g &FlatGen) should_emit_c_extern_decl(cfn string) bool {
+	if cfn.contains('.') {
+		return false
+	}
+	if cfn in c_static_helper_symbols {
+		return false
+	}
+	if cfn in g.inlined_c_fns {
+		return false
+	}
+	if cfn in g.inlined_c_declared_fns {
+		return false
+	}
+	return true
+}
+
+const c_static_helper_symbols = {
+	'EV_SET':                              true
+	'FD_ISSET':                            true
+	'FD_SET':                              true
+	'FD_ZERO':                             true
+	'WEXITSTATUS':                         true
+	'WIFEXITED':                           true
+	'WIFSIGNALED':                         true
+	'WTERMSIG':                            true
+	'access':                              true
+	'atexit':                              true
+	'atomic_compare_exchange_strong_byte': true
+	'atomic_compare_exchange_strong_ptr':  true
+	'atomic_compare_exchange_strong_u16':  true
+	'atomic_compare_exchange_strong_u32':  true
+	'atomic_compare_exchange_strong_u64':  true
+	'atomic_compare_exchange_weak_byte':   true
+	'atomic_compare_exchange_weak_ptr':    true
+	'atomic_compare_exchange_weak_u16':    true
+	'atomic_compare_exchange_weak_u32':    true
+	'atomic_compare_exchange_weak_u64':    true
+	'atomic_exchange_byte':                true
+	'atomic_exchange_ptr':                 true
+	'atomic_exchange_u16':                 true
+	'atomic_exchange_u32':                 true
+	'atomic_exchange_u64':                 true
+	'atomic_fetch_add_byte':               true
+	'atomic_fetch_add_ptr':                true
+	'atomic_fetch_add_u16':                true
+	'atomic_fetch_add_u32':                true
+	'atomic_fetch_add_u64':                true
+	'atomic_fetch_sub_byte':               true
+	'atomic_fetch_sub_ptr':                true
+	'atomic_fetch_sub_u16':                true
+	'atomic_fetch_sub_u32':                true
+	'atomic_fetch_sub_u64':                true
+	'atomic_load_byte':                    true
+	'atomic_load_ptr':                     true
+	'atomic_load_u16':                     true
+	'atomic_load_u32':                     true
+	'atomic_load_u64':                     true
+	'atomic_store_byte':                   true
+	'atomic_store_ptr':                    true
+	'atomic_store_u16':                    true
+	'atomic_store_u32':                    true
+	'atomic_store_u64':                    true
+	'close':                               true
+	'cpu_relax':                           true
+	'dup2':                                true
+	'execlp':                              true
+	'execvp':                              true
+	'fcntl':                               true
+	'fork':                                true
+	'getenv':                              true
+	'open':                                true
+	'pipe':                                true
+	'posix_spawn':                         true
+	'posix_spawnp':                        true
+	'read':                                true
+	'realpath':                            true
+	'setenv':                              true
+	'signal':                              true
+	'snprintf':                            true
+	'strrchr':                             true
+	'strstr':                              true
+	'v_filelock_lock':                     true
+	'v_filelock_unlock':                   true
+	'v_os_exec_capture_start':             true
+	'v_os_execute_capture_start':          true
+	'vschannel_cleanup':                   true
+	'vschannel_init':                      true
+	'v_prealloc_atomic_add_i32':           true
+	'v_prealloc_atomic_cas_i32':           true
+	'v_prealloc_atomic_load_i32':          true
+	'v_prealloc_atomic_store_i32':         true
+	'v_signal_with_handler_cast':          true
+	'wyhash':                              true
+	'wyhash64':                            true
+	'_exit':                               true
+	'_wymix':                              true
+	'_vcleanup':                           true
+	'_vinit':                              true
+}
+
+fn (mut g FlatGen) c_extern_decl_line(node flat.Node, cfn string) string {
+	mut sb := strings.new_builder(96)
+	ret_type := g.tc.parse_type(node.typ)
+	sb.write_string(g.fn_return_type_name(ret_type))
+	sb.write_string(' ')
+	call_conv := c_extern_calling_convention(cfn)
+	if call_conv.len > 0 {
+		sb.write_string(call_conv)
+		sb.write_u8(` `)
+	}
+	sb.write_string(cfn)
+	sb.write_u8(`(`)
+	sb.write_string(g.c_extern_decl_params(node))
+	sb.write_string(');')
+	return sb.str()
+}
+
+fn c_extern_calling_convention(cfn string) string {
+	if cfn in c_winapi_extern_symbols {
+		return 'WINAPI'
+	}
+	return ''
+}
+
+fn c_winapi_wide_export_name(cfn string) string {
+	match cfn {
+		'CopyFile' { return 'CopyFileW' }
+		'CreateDirectory' { return 'CreateDirectoryW' }
+		'CreateFile' { return 'CreateFileW' }
+		'CreateWindowEx' { return 'CreateWindowExW' }
+		'DefWindowProc' { return 'DefWindowProcW' }
+		'FindFirstFile' { return 'FindFirstFileW' }
+		'FindNextFile' { return 'FindNextFileW' }
+		'GetCommandLine' { return 'GetCommandLineW' }
+		'GetFullPathName' { return 'GetFullPathNameW' }
+		'GetLongPathName' { return 'GetLongPathNameW' }
+		'GetModuleFileName' { return 'GetModuleFileNameW' }
+		'LoadLibrary' { return 'LoadLibraryW' }
+		'ReadConsole' { return 'ReadConsoleW' }
+		'RegOpenKeyEx' { return 'RegOpenKeyExW' }
+		'RegQueryValueEx' { return 'RegQueryValueExW' }
+		'RegSetValueEx' { return 'RegSetValueExW' }
+		'RegisterClassEx' { return 'RegisterClassExW' }
+		'RemoveDirectory' { return 'RemoveDirectoryW' }
+		'SendMessageTimeout' { return 'SendMessageTimeoutW' }
+		'SetConsoleTitle' { return 'SetConsoleTitleW' }
+		'WriteConsole' { return 'WriteConsoleW' }
+		else { return cfn }
+	}
+}
+
+const c_winapi_extern_symbols = {
+	'AddVectoredExceptionHandler':   true
+	'CaptureStackBackTrace':         true
+	'CloseClipboard':                true
+	'CloseHandle':                   true
+	'CopyFile':                      true
+	'CopyFileW':                     true
+	'CreateDirectory':               true
+	'CreateDirectoryW':              true
+	'CreateFile':                    true
+	'CreateFileW':                   true
+	'CreateHardLinkW':               true
+	'CreatePipe':                    true
+	'CreateProcessW':                true
+	'CreateSymbolicLinkW':           true
+	'CreateWindowEx':                true
+	'CreateWindowExW':               true
+	'DefWindowProc':                 true
+	'DefWindowProcW':                true
+	'DeleteFileW':                   true
+	'DestroyWindow':                 true
+	'EmptyClipboard':                true
+	'ExpandEnvironmentStringsW':     true
+	'FindClose':                     true
+	'FindFirstFile':                 true
+	'FindFirstFileW':                true
+	'FindNextFile':                  true
+	'FindNextFileW':                 true
+	'FormatMessageW':                true
+	'FreeEnvironmentStringsW':       true
+	'GenerateConsoleCtrlEvent':      true
+	'GetClipboardData':              true
+	'GetClipboardOwner':             true
+	'GetCommandLine':                true
+	'GetCommandLineW':               true
+	'GetComputerNameW':              true
+	'GetConsoleMode':                true
+	'GetConsoleScreenBufferInfo':    true
+	'GetCurrentDirectoryW':          true
+	'GetCurrentProcess':             true
+	'GetCurrentThreadId':            true
+	'GetEnvironmentStringsW':        true
+	'GetExitCodeProcess':            true
+	'GetFinalPathNameByHandleW':     true
+	'GetFileAttributesW':            true
+	'GetFileSizeEx':                 true
+	'GetFileType':                   true
+	'GetFullPathName':               true
+	'GetFullPathNameW':              true
+	'GetLastError':                  true
+	'GetLongPathName':               true
+	'GetLongPathNameW':              true
+	'GetModuleFileName':             true
+	'GetModuleFileNameW':            true
+	'GetModuleHandleA':              true
+	'GetNumberOfConsoleInputEvents': true
+	'GetProcAddress':                true
+	'GetProcessHeap':                true
+	'GetShortPathNameW':             true
+	'GetStdHandle':                  true
+	'GetSystemTimeAsFileTime':       true
+	'GetTempFileNameW':              true
+	'GetTempPathW':                  true
+	'GetTickCount':                  true
+	'GetUserNameW':                  true
+	'GlobalAlloc':                   true
+	'GlobalFree':                    true
+	'GlobalLock':                    true
+	'GlobalUnlock':                  true
+	'HeapAlloc':                     true
+	'HeapFree':                      true
+	'InitializeConditionVariable':   true
+	'IsDebuggerPresent':             true
+	'LoadLibrary':                   true
+	'LoadLibraryW':                  true
+	'LocalFree':                     true
+	'MoveFileW':                     true
+	'MultiByteToWideChar':           true
+	'OpenClipboard':                 true
+	'PeekNamedPipe':                 true
+	'ReadConsole':                   true
+	'ReadConsoleInput':              true
+	'ReadConsoleW':                  true
+	'ReadFile':                      true
+	'RegCloseKey':                   true
+	'RegOpenKeyEx':                  true
+	'RegOpenKeyExW':                 true
+	'RegQueryValueEx':               true
+	'RegQueryValueExW':              true
+	'RegSetValueEx':                 true
+	'RegSetValueExW':                true
+	'RegisterClassEx':               true
+	'RegisterClassExW':              true
+	'RemoveDirectory':               true
+	'RemoveDirectoryW':              true
+	'ScrollConsoleScreenBuffer':     true
+	'SetClipboardData':              true
+	'SetConsoleCursorPosition':      true
+	'SetConsoleMode':                true
+	'SetConsoleTitle':               true
+	'SetConsoleTitleW':              true
+	'SetCurrentDirectoryW':          true
+	'SetEndOfFile':                  true
+	'SetFileAttributesW':            true
+	'SetFilePointerEx':              true
+	'SetHandleInformation':          true
+	'SetLastError':                  true
+	'SetUnhandledExceptionFilter':   true
+	'Sleep':                         true
+	'SleepConditionVariableSRW':     true
+	'SendMessageTimeout':            true
+	'SendMessageTimeoutW':           true
+	'SymCleanup':                    true
+	'SymFromAddr':                   true
+	'SymGetLineFromAddr64':          true
+	'SymInitialize':                 true
+	'SymSetOptions':                 true
+	'TerminateProcess':              true
+	'TlsAlloc':                      true
+	'TlsFree':                       true
+	'TlsGetValue':                   true
+	'TlsSetValue':                   true
+	'TryAcquireSRWLockExclusive':    true
+	'TryAcquireSRWLockShared':       true
+	'VirtualAlloc':                  true
+	'VirtualFree':                   true
+	'VirtualProtect':                true
+	'WSAAddressToStringA':           true
+	'WaitForSingleObject':           true
+	'WakeConditionVariable':         true
+	'WriteConsole':                  true
+	'WriteConsoleW':                 true
+	'WriteFile':                     true
+}
+
+fn (mut g FlatGen) c_extern_decl_params(node flat.Node) string {
+	if node.children_count == 0 {
+		return 'void'
+	}
+	mut parts := []string{}
+	for i in 0 .. node.children_count {
+		param_id := g.a.child(&node, i)
+		p := g.a.node(param_id)
+		if p.kind != .param {
+			continue
+		}
+		raw_typ := if p.typ.len > 0 { p.typ } else { p.value }
+		if raw_typ.len == 0 {
+			continue
+		}
+		if raw_typ.starts_with('...') {
+			if parts.len > 0 {
+				parts << '...'
+			}
+			continue
+		}
+		pt := g.tc.parse_type(raw_typ)
+		mut ct := if pt is types.OptionType || pt is types.ResultType {
+			g.optional_type_name(pt)
+		} else {
+			g.tc.c_type(pt)
+		}
+		if ct.starts_with('fn_ptr:') {
+			ct = g.resolve_fn_ptr_type(ct)
+		}
+		if c_extern_param_needs_const_prefix(p.value, raw_typ, pt) {
+			ct = 'const ${ct}'
+		}
+		if p.typ.len > 0 && p.value.len > 0 {
+			param_name := if p.value == '_' { '_${parts.len}' } else { c_name(p.value) }
+			parts << '${ct} ${param_name}'
+		} else {
+			parts << ct
+		}
+	}
+	if parts.len == 0 {
+		return 'void'
+	}
+	return parts.join(', ')
+}
+
+fn c_extern_param_needs_const_prefix(param_name string, raw_typ string, pt types.Type) bool {
+	return param_name.starts_with('const_') && !raw_typ.trim_space().starts_with('mut ')
+		&& pt is types.Pointer
 }
 
 fn (mut g FlatGen) insert_cur_implicit_veb_ctx_param(node flat.Node) {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -1444,11 +1444,74 @@ fn (g &FlatGen) map_callback_names(key_type types.Type) (string, string, string,
 
 // skip_builtin_struct supports skip builtin struct handling for FlatGen.
 fn (g &FlatGen) skip_builtin_struct(name string) bool {
-	_ = g
-	if name.starts_with('C.') {
+	if name.starts_with('C.') && g.inlined_c_structs[name[2..]] {
 		return true
 	}
-	return false
+	return name in c_preamble_defined_structs
+}
+
+const c_preamble_defined_structs = {
+	'C.DIR':                        true
+	'C.FILE':                       true
+	'C.CONDITION_VARIABLE':         true
+	'C.IError':                     true
+	'C.SRWLOCK':                    true
+	'C.addrinfo':                   true
+	'C.atomic_uintptr_t':           true
+	'C.dirent':                     true
+	'C.epoll_data':                 true
+	'C.epoll_data_t':               true
+	'C.epoll_event':                true
+	'C.Event':                      true
+	'C.fd_set':                     true
+	'C.CHAR_INFO':                  true
+	'C.CONSOLE_SCREEN_BUFFER_INFO': true
+	'C.COORD':                      true
+	'C.FOCUS_EVENT_RECORD':         true
+	'C.INPUT_RECORD':               true
+	'C.KEY_EVENT_RECORD':           true
+	'C.kevent':                     true
+	'C.MENU_EVENT_RECORD':          true
+	'C.MOUSE_EVENT_RECORD':         true
+	'C.pthread_t':                  true
+	'C.pthread_cond_t':             true
+	'C.pthread_condattr_t':         true
+	'C.pthread_attr_t':             true
+	'C.pthread_mutex_t':            true
+	'C.pthread_rwlock_t':           true
+	'C.pthread_rwlockattr_t':       true
+	'C.rusage':                     true
+	'C.sem_t':                      true
+	'C.SECURITY_ATTRIBUTES':        true
+	'C.sigset_t':                   true
+	'C.SMALL_RECT':                 true
+	'C.OVERLAPPED':                 true
+	'C.sockaddr':                   true
+	'C.sockaddr_in':                true
+	'C.sockaddr_in6':               true
+	'C.sockaddr_un':                true
+	'C.stat':                       true
+	'C.statvfs':                    true
+	'C.termios':                    true
+	'C.timeval':                    true
+	'C.timespec':                   true
+	'C.tm':                         true
+	'C.uChar':                      true
+	'C.utsname':                    true
+	'C.wchar_t':                    true
+	'C.WINDOW_BUFFER_SIZE_RECORD':  true
+	'C.winsize':                    true
+}
+
+fn c_struct_needs_typedef(name string) bool {
+	if !name.starts_with('C.') {
+		return true
+	}
+	raw := name[2..]
+	if raw.len > 0 && raw[0] >= `a` && raw[0] <= `z` && !raw.ends_with('_t') {
+		return false
+	}
+	return true
 }
 
 // emit_interface_struct emits emit interface struct output for c.
@@ -1480,6 +1543,9 @@ fn (mut g FlatGen) struct_decls() {
 	fixed_array_needed := g.collect_fixed_array_typedefs_needed()
 	for name, _ in g.tc.structs {
 		if g.skip_builtin_struct(name) {
+			continue
+		}
+		if !c_struct_needs_typedef(name) {
 			continue
 		}
 		tag := if name in g.tc.unions { 'union' } else { 'struct' }
@@ -1685,6 +1751,9 @@ fn (mut g FlatGen) type_forward_decls() {
 		if g.skip_builtin_struct(name) {
 			continue
 		}
+		if !c_struct_needs_typedef(name) {
+			continue
+		}
 		tag := if name in g.tc.unions { 'union' } else { 'struct' }
 		g.writeln('typedef ${tag} ${c_name(name)} ${c_name(name)};')
 	}
@@ -1703,7 +1772,7 @@ fn (mut g FlatGen) type_forward_decls() {
 // emit_struct emits emit struct output for c.
 fn (mut g FlatGen) emit_struct(name string) {
 	old_module := g.tc.cur_module
-	g.tc.cur_module = module_from_qualified_name(name)
+	g.tc.cur_module = g.fixed_array_typedef_type_module(name, old_module)
 	if name in g.tc.structs {
 		fields := g.tc.structs[name]
 		tag := if name in g.tc.unions { 'union' } else { 'struct' }

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -2515,6 +2515,10 @@ fn (c &CallCollector) typed_receiver_method_name(type_name string, method string
 		candidates << markused_array_receiver_method_candidates(type_name, method, cur_module)
 	} else if type_name.contains('.') {
 		candidates << '${type_name}.${method}'
+		unqualified_type := markused_unqualified_receiver_type_name(type_name)
+		if unqualified_type != type_name {
+			candidates << '${unqualified_type}.${method}'
+		}
 	} else {
 		if cur_module.len > 0 && cur_module != 'main' && cur_module != 'builtin' {
 			candidates << '${cur_module}.${type_name}.${method}'
@@ -2574,6 +2578,8 @@ fn markused_map_receiver_method_candidates(receiver_type string, method string, 
 	key_type := markused_map_key_type(clean_type)
 	value_type := markused_map_value_type(clean_type)
 	mut candidates := []string{}
+	candidates << '${clean_type}.${method}'
+	candidates << 'map.${method}'
 	if key_type.len == 0 || value_type.len == 0 {
 		markused_push_receiver_candidate(mut candidates, '${clean_type}.${method}')
 		return candidates
@@ -2807,6 +2813,20 @@ fn markused_matching_bracket(s string, start int) int {
 		}
 	}
 	return s.len
+}
+
+fn markused_unqualified_receiver_type_name(type_name string) string {
+	if !type_name.starts_with('map[') {
+		return type_name.all_after_last('.')
+	}
+	key_start := 'map['.len
+	key_end := type_name.index_u8(`]`)
+	if key_end < key_start {
+		return type_name
+	}
+	key := type_name[key_start..key_end].all_after_last('.')
+	value := type_name[key_end + 1..].all_after_last('.')
+	return 'map[${key}]${value}'
 }
 
 fn (c &CallCollector) add_typed_receiver_method_name(method_name string, mut calls []string) {

--- a/vlib/v3/test_all.vsh
+++ b/vlib/v3/test_all.vsh
@@ -3,7 +3,6 @@
 import os
 
 const total_steps = 6
-const temp_prefix = 'v3_test_all'
 
 struct Config {
 	vexe         string
@@ -15,20 +14,21 @@ struct Config {
 	c99_flag     string
 	host_backend string
 	host_os      string
+	temp_prefix  string
 }
 
 fn main() {
 	cfg := parse_config()
 	os.chdir(cfg.repo_root) or { fail('failed to enter ${cfg.repo_root}: ${err}') }
 
-	v3_bin := temp_path('v3')
-	hello_c_bin := temp_path('hello_c')
-	hello_arm_bin := temp_path('hello_arm64')
-	v4_arm_bin := temp_path('v4_arm64')
-	v3_lang_bin := temp_path('v3_lang')
-	v4_bin := temp_path('v4_chain')
-	v5_bin := temp_path('v5_chain')
-	v6_bin := temp_path('v6_chain')
+	v3_bin := temp_path(cfg, 'v3')
+	hello_c_bin := temp_path(cfg, 'hello_c')
+	hello_arm_bin := temp_path(cfg, 'hello_arm64')
+	v4_arm_bin := temp_path(cfg, 'v4_arm64')
+	v3_lang_bin := temp_path(cfg, 'v3_lang')
+	v4_bin := temp_path(cfg, 'v4_chain')
+	v5_bin := temp_path(cfg, 'v5_chain')
+	v6_bin := temp_path(cfg, 'v6_chain')
 	cleanup_files([
 		v3_bin,
 		hello_c_bin,
@@ -85,7 +85,7 @@ fn main() {
 	lang_v := os.join_path(cfg.tests_dir, 'test_all_lang_features.v')
 	lang_out := os.join_path(cfg.tests_dir, 'test_all_lang_features.out')
 	run('${q(v3_bin)} ${cfg.c99_flag} ${q(lang_v)} -b c -o ${q(v3_lang_bin)}')
-	v3_c_out := run_output(q(v3_lang_bin))
+	v3_c_out := run_output(cfg, q(v3_lang_bin))
 	expected_out := read_text_file(lang_out)
 	assert_same_text('language feature output', v3_c_out, expected_out)
 	println('  v3 C OK (${v3_c_out.split_into_lines().len} lines)')
@@ -115,6 +115,7 @@ fn parse_config() Config {
 		c99_flag:     if c99 { '-c99' } else { '' }
 		host_backend: native_backend_arch()
 		host_os:      os.user_os()
+		temp_prefix:  'v3_test_all_${os.getpid()}'
 	}
 }
 
@@ -152,8 +153,8 @@ fn native_backend_arch() string {
 	}
 }
 
-fn temp_path(name string) string {
-	return os.join_path(os.temp_dir(), '${temp_prefix}_${name}')
+fn temp_path(cfg Config, name string) string {
+	return os.join_path(os.temp_dir(), '${cfg.temp_prefix}_${name}')
 }
 
 fn absolute_path(path string) string {
@@ -178,8 +179,8 @@ fn run(cmd string) {
 	}
 }
 
-fn run_output(cmd string) string {
-	stdout_path := temp_path('stdout')
+fn run_output(cfg Config, cmd string) string {
+	stdout_path := temp_path(cfg, 'stdout')
 	cleanup_files([stdout_path])
 	println('> ${cmd}')
 	code := os.system('${cmd} > ${q(stdout_path)}')

--- a/vlib/v3/tests/c_anonymous_param_codegen_test.v
+++ b/vlib/v3/tests/c_anonymous_param_codegen_test.v
@@ -32,6 +32,8 @@ fn C.take_primitive(int, u64) int
 fn C.take_multi(&&C.AnonNative) int
 fn C.take_mixed(&C.AnonNative, voidptr, int, &&C.AnonNative) int
 fn C.take_fn(fn (&C.AnonNative) int) int
+fn C.XLookupString(event &C.AnonNative) int
+fn C.SSL_new() voidptr
 fn C.load_matrix(m [16]f32) int
 fn C.width_runes(r []rune) int
 
@@ -53,6 +55,10 @@ fn main() {
 	_ = C.take_multi(pptr)
 	_ = C.take_mixed(ptr, voidptr(ptr), 3, pptr)
 	_ = C.take_fn(callback)
+	_ = C.XLookupString(ptr)
+	ssl := C.SSL_new()
+	if ssl == unsafe { nil } {
+	}
 	mut matrix := [16]f32{}
 	_ = C.load_matrix(matrix)
 	runes := []rune{}
@@ -72,6 +78,13 @@ fn main() {
 	assert generated.contains('take_void((void*)(ptr))'), generated
 	assert generated.contains('take_multi(pptr)'), generated
 	assert generated.contains('take_mixed(ptr, (void*)(ptr), 3, pptr)'), generated
+	fn_ptr_idx := generated.index('typedef int (*_fn_ptr_') or { -1 }
+	take_fn_proto_idx := generated.index('int take_fn(_fn_ptr_') or { -1 }
+	assert fn_ptr_idx >= 0, generated
+	assert take_fn_proto_idx >= 0, generated
+	assert fn_ptr_idx < take_fn_proto_idx, generated
+	assert generated.contains('int XLookupString(AnonNative* event);'), generated
+	assert generated.contains('void* SSL_new(void);'), generated
 	assert generated.contains('load_matrix(matrix)'), generated
 	assert generated.contains('width_runes(runes)'), generated
 	assert !generated.contains('take_ptr(*'), generated

--- a/vlib/v3/tests/c_directive_order_codegen_test.v
+++ b/vlib/v3/tests/c_directive_order_codegen_test.v
@@ -105,7 +105,7 @@ fn main() {
 ')
 	directive_order_write_file(root, 'wrapper/wrapper.v', 'module wrapper
 
-#include "@DIR/foo.h"
+#insert "foo.h"
 
 fn C.foo_value() int
 
@@ -132,6 +132,648 @@ static inline int foo_value(void) {
 	return os.read_file(bin_out + '.c') or { panic(err) }
 }
 
+fn directive_order_gen_and_run_dir_header(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_dir_header_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod', "Module { name: 'directive_order_dir_header' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+import wrapper
+
+fn main() {
+	println(wrapper.value().str())
+}
+')
+	directive_order_write_file(root, 'wrapper/wrapper.v', 'module wrapper
+
+#insert "@DIR/dir_value.h"
+
+fn C.dir_value() int
+
+pub fn value() int {
+	return C.dir_value()
+}
+')
+	directive_order_write_file(root, 'wrapper/dir_value.h', 'static inline int dir_value(void) {
+	return 24;
+}
+')
+	bin_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_dir_header')
+	os.rm(bin_out) or {}
+	os.rm(bin_out + '.c') or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin_out}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '24', run.output
+	return os.read_file(bin_out + '.c') or { panic(err) }
+}
+
+fn directive_order_gen_and_run_flag_include_dir_header(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_flag_include_dir_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod',
+		"Module { name: 'directive_order_flag_include_dir' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#flag -I @DIR/include
+#insert "flag_value.c"
+
+fn C.flag_value() int
+
+fn main() {
+	println(C.flag_value().str())
+}
+')
+	directive_order_write_file(root, 'include/flag_value.c', '#include <flag_value.h>
+
+static inline int flag_value(void) {
+	return flag_value_inner();
+}
+')
+	directive_order_write_file(root, 'include/flag_value.h', 'static inline int flag_value_inner(void) {
+	return 52;
+}
+')
+	bin_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_flag_include_dir')
+	os.rm(bin_out) or {}
+	os.rm(bin_out + '.c') or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin_out}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '52', run.output
+	return os.read_file(bin_out + '.c') or { panic(err) }
+}
+
+fn directive_order_gen_and_run_late_flag_include_dir_header(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_late_flag_include_dir_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod',
+		"Module { name: 'directive_order_late_flag_include_dir' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#insert "late_flag_value.c"
+#flag -I @DIR/include
+
+fn C.late_flag_value() int
+
+fn main() {
+	println(C.late_flag_value().str())
+}
+')
+	directive_order_write_file(root, 'include/late_flag_value.c', '#include <late_flag_value.h>
+
+static inline int late_flag_value(void) {
+	return late_flag_value_inner();
+}
+')
+	directive_order_write_file(root, 'include/late_flag_value.h', 'static inline int late_flag_value_inner(void) {
+	return 63;
+}
+')
+	bin_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_late_flag_include_dir')
+	os.rm(bin_out) or {}
+	os.rm(bin_out + '.c') or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin_out}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '63', run.output
+	return os.read_file(bin_out + '.c') or { panic(err) }
+}
+
+fn directive_order_gen_and_run_multiline_static_inline(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_multiline_static_inline_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod',
+		"Module { name: 'directive_order_multiline_static_inline' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#insert "multiline_value.h"
+
+fn C.multiline_value() int
+
+fn main() {
+	println(C.multiline_value().str())
+}
+')
+	directive_order_write_file(root, 'multiline_value.h', 'static inline
+int multiline_value(void) {
+	return 33;
+}
+')
+	bin_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_multiline_static_inline')
+	os.rm(bin_out) or {}
+	os.rm(bin_out + '.c') or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin_out}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '33', run.output
+	return os.read_file(bin_out + '.c') or { panic(err) }
+}
+
+fn directive_order_gen_c_extern_after_header(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_extern_after_header_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod',
+		"Module { name: 'directive_order_extern_after_header' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#insert "native_thing.h"
+
+@[typedef]
+struct C.NativeThing {
+	value int
+}
+
+fn C.native_use(item &C.NativeThing) int
+
+fn main() {
+	mut item := C.NativeThing{
+		value: 7
+	}
+	_ := C.native_use(&item)
+}
+')
+	directive_order_write_file(root, 'native_thing.h', 'typedef struct NativeThing {
+	int value;
+} NativeThing;
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_extern_after_header.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
+fn directive_order_gen_c_header_declared_prototype(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_header_declared_proto_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod',
+		"Module { name: 'directive_order_header_declared_proto' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#insert "declared_proto.h"
+
+fn C.declared_text() &char
+
+fn main() {
+	_ := C.declared_text()
+}
+')
+	directive_order_write_file(root, 'declared_proto.h', 'const char* declared_text(void);
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_header_declared_proto.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
+fn directive_order_gen_c_struct_field_after_header(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_struct_field_after_header_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod',
+		"Module { name: 'directive_order_struct_field_after_header' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#insert "field_thing.h"
+
+@[typedef]
+struct C.FieldThing {
+	value int
+}
+
+struct Wrap {
+	item C.FieldThing
+}
+
+fn main() {
+	_ := Wrap{}
+}
+')
+	directive_order_write_file(root, 'field_thing.h', 'typedef struct {
+	int value;
+} FieldThing;
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_struct_field_after_header.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
+fn directive_order_gen_and_run_anonymous_typedef(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_anonymous_typedef_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod',
+		"Module { name: 'directive_order_anonymous_typedef' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#insert "anonymous_thing.h"
+
+@[typedef]
+struct C.AnonymousThing {
+	value int
+}
+
+fn C.anonymous_value(item &C.AnonymousThing) int
+
+fn main() {
+	mut item := C.AnonymousThing{
+		value: 31
+	}
+	println(C.anonymous_value(&item).str())
+}
+')
+	directive_order_write_file(root, 'anonymous_thing.h', 'typedef struct {
+	int value;
+} AnonymousThing;
+
+static inline int anonymous_value(AnonymousThing* item) {
+	return item->value;
+}
+')
+	bin_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_anonymous_typedef')
+	os.rm(bin_out) or {}
+	os.rm(bin_out + '.c') or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin_out}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '31', run.output
+	return os.read_file(bin_out + '.c') or { panic(err) }
+}
+
+fn directive_order_gen_and_run_tagged_typedef_alias(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_tagged_typedef_alias_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod',
+		"Module { name: 'directive_order_tagged_typedef_alias' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#insert "tagged_thing.h"
+
+@[typedef]
+struct C.TaggedAlias {
+	value int
+}
+
+fn C.tagged_value(item &C.TaggedAlias) int
+
+fn main() {
+	mut item := C.TaggedAlias{
+		value: 43
+	}
+	println(C.tagged_value(&item).str())
+}
+')
+	directive_order_write_file(root, 'tagged_thing.h', 'typedef struct TaggedImpl {
+	int value;
+} TaggedAlias;
+
+static inline int tagged_value(TaggedAlias* item) {
+	return item->value;
+}
+')
+	bin_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_tagged_typedef_alias')
+	os.rm(bin_out) or {}
+	os.rm(bin_out + '.c') or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin_out}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '43', run.output
+	return os.read_file(bin_out + '.c') or { panic(err) }
+}
+
+fn directive_order_gen_c_union_typedef_aliases(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_union_typedef_aliases_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod',
+		"Module { name: 'directive_order_union_typedef_aliases' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#insert "union_thing.h"
+
+@[typedef]
+union C.AnonymousUnion {
+	value int
+}
+
+@[typedef]
+union C.TaggedUnionAlias {
+	value int
+}
+
+struct WrapUnion {
+	anonymous C.AnonymousUnion
+	tagged    C.TaggedUnionAlias
+}
+
+fn main() {
+	_ := WrapUnion{}
+}
+')
+	directive_order_write_file(root, 'union_thing.h', 'typedef union {
+	int value;
+} AnonymousUnion;
+
+typedef union TaggedUnionImpl {
+	int value;
+} TaggedUnionAlias;
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_union_typedef_aliases.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
+fn directive_order_gen_and_run_nested_include(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_nested_include_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod', "Module { name: 'directive_order_nested_include' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#insert "outer.h"
+
+@[typedef]
+struct C.NestedThing {
+	value int
+}
+
+fn C.nested_value(item &C.NestedThing) int
+
+fn main() {
+	mut item := C.NestedThing{
+		value: 11
+	}
+	println(C.nested_value(&item).str())
+}
+')
+	directive_order_write_file(root, 'outer.h', '#include "types.h"
+
+static inline int nested_value(NestedThing* item) {
+	return NESTED_BIAS + item->value;
+}
+')
+	directive_order_write_file(root, 'types.h', '#include <stdint.h>
+
+#define NESTED_BIAS 5
+
+typedef struct {
+	uint32_t value;
+} NestedThing;
+')
+	bin_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_nested_include')
+	os.rm(bin_out) or {}
+	os.rm(bin_out + '.c') or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin_out}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '16', run.output
+	return os.read_file(bin_out + '.c') or { panic(err) }
+}
+
+fn directive_order_gen_c_unresolved_system_include(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_unresolved_system_include_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod',
+		"Module { name: 'directive_order_unresolved_system_include' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#include <platform_user_header.h>
+#define USE_DLFCN
+#define PLATFORM_API_COMPAT 7
+#ifdef USE_DLFCN
+#include <dlfcn.h>
+#endif
+#include <stdint.h>
+
+fn C.dlopen(filename &char, flags i32) voidptr
+
+fn main() {
+	nil_cstr := &char(unsafe { nil })
+	_ = C.dlopen(nil_cstr, 0)
+}
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_unresolved_system_include.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
+fn directive_order_gen_c_nested_preserved_system_include(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_nested_preserved_include_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod',
+		"Module { name: 'directive_order_nested_preserved_include' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#insert "nested_preserved.h"
+
+fn main() {}
+')
+	directive_order_write_file(root, 'nested_preserved.h', '#if defined(__linux__)
+#define NESTED_PLATFORM_HEADER 1
+#include <nested_platform_header.h>
+#endif
+
+#include <stdint.h>
+
+typedef uint64_t NestedWord;
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_nested_preserved_include.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
+fn directive_order_gen_c_preserved_x11_aggregates(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_x11_aggregates_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod', "Module { name: 'directive_order_x11_aggregates' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#include <X11/Xlib.h>
+
+@[typedef]
+union C.XClientMessageData {
+mut:
+	l [5]i64
+}
+
+@[typedef]
+union C.XEvent {
+mut:
+	@type   int
+	xclient C.XClientMessageData
+}
+
+struct Wrap {
+	event C.XEvent
+}
+
+fn main() {
+	_ := Wrap{}
+}
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_x11_aggregates.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
+fn directive_order_gen_c_preserved_bcrypt_fn(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_bcrypt_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod', "Module { name: 'directive_order_bcrypt' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#include <bcrypt.h>
+
+fn C.BCryptGenRandom(alg int, buffer voidptr, len int, flags int) int
+
+fn main() {
+	_ := C.BCryptGenRandom(0, voidptr(0), 0, 0)
+}
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_bcrypt.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
+fn directive_order_gen_c_preserved_mach_headers(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_mach_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod', "Module { name: 'directive_order_mach' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+
+fn main() {}
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_mach.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
+fn directive_order_gen_and_run_stdarg_header(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_stdarg_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod', "Module { name: 'directive_order_stdarg' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#include "stdarg_user.h"
+
+fn C.stdarg_sum(count int, ...int) int
+
+fn main() {
+	println(C.stdarg_sum(3, 1, 2, 3).str())
+}
+')
+	directive_order_write_file(root, 'stdarg_user.h', '#include <stdarg.h>
+#include <stddef.h>
+
+struct StdargThing {
+	char tag;
+	int value;
+};
+
+static inline int stdarg_sum(int count, ...) {
+	va_list ap;
+	va_start(ap, count);
+	int total = (int)offsetof(struct StdargThing, value);
+	total -= (int)offsetof(struct StdargThing, value);
+	for (int i = 0; i < count; i++) {
+		total += va_arg(ap, int);
+	}
+	va_end(ap);
+	return total;
+}
+')
+	bin_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_stdarg')
+	os.rm(bin_out) or {}
+	os.rm(bin_out + '.c') or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin_out}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '6', run.output
+	return os.read_file(bin_out + '.c') or { panic(err) }
+}
+
+fn directive_order_gen_c_rwmutex(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_rwmutex_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod', "Module { name: 'directive_order_rwmutex' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+import sync
+
+fn main() {
+	mut m := sync.new_rwmutex()
+	m.lock()
+	m.unlock()
+}
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_rwmutex.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
+fn directive_order_gen_c_request_extern(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_request_extern_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod', "Module { name: 'directive_order_request_extern' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+fn C.request(code int) int
+
+fn main() {
+	_ := C.request(7)
+}
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_request_extern.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
 fn directive_order_index(c_code string, needle string) int {
 	return c_code.index(needle) or { -1 }
 }
@@ -147,27 +789,28 @@ fn directive_order_count(c_code string, needle string) int {
 	return count
 }
 
+fn directive_order_has_include_directive(c_code string) bool {
+	for line in c_code.split_into_lines() {
+		if line.trim_space().starts_with('#include') {
+			return true
+		}
+	}
+	return false
+}
+
 fn test_c_directives_follow_import_dependency_order() {
 	c_code := directive_order_gen_c(directive_order_build_v3())
 	gfx_define := directive_order_index(c_code, '#define SOKOL_GFX_IMPL')
-	gfx_include := directive_order_index(c_code, '#include "sokol_gfx.h"')
 	fontstash_define := directive_order_index(c_code, '#define SOKOL_FONTSTASH_IMPL')
-	fontstash_include := directive_order_index(c_code, '#include "util/sokol_fontstash.h"')
 	block_start := directive_order_index(c_code, '#ifdef KEEP_DUPLICATE_INCLUDE')
 	assert gfx_define >= 0, c_code
-	assert gfx_include >= 0, c_code
 	assert fontstash_define >= 0, c_code
-	assert fontstash_include >= 0, c_code
 	assert block_start >= 0, c_code
-	assert gfx_define < gfx_include, c_code
-	assert gfx_include < fontstash_define, c_code
-	assert fontstash_define < fontstash_include, c_code
-	assert directive_order_count(c_code, '#include "sokol_gfx.h"') == 2, c_code
+	assert gfx_define < fontstash_define, c_code
+	assert !directive_order_has_include_directive(c_code), c_code
 	block_tail := c_code[block_start..]
-	block_include := directive_order_index(block_tail, '#include "sokol_gfx.h"')
 	block_end := directive_order_index(block_tail, '#endif')
-	assert block_include >= 0, c_code
-	assert block_end > block_include, c_code
+	assert block_end >= 0, c_code
 }
 
 fn test_c_directives_preserve_dotted_import_module_identity() {
@@ -184,8 +827,212 @@ fn test_c_directives_preserve_dotted_import_module_identity() {
 fn test_importer_macro_is_emitted_before_dependency_include() {
 	c_code := directive_order_gen_and_run_importer_macro(directive_order_build_v3())
 	use_foo := directive_order_index(c_code, '#define USE_FOO')
-	foo_header := directive_order_index(c_code, 'foo.h"')
+	foo_header := directive_order_index(c_code, 'static inline int foo_value')
 	assert use_foo >= 0, c_code
 	assert foo_header >= 0, c_code
 	assert use_foo < foo_header, c_code
+	assert !c_code.contains('int foo_value(void);'), c_code
+	assert !directive_order_has_include_directive(c_code), c_code
+}
+
+fn test_dir_include_is_expanded_before_header_probe() {
+	c_code := directive_order_gen_and_run_dir_header(directive_order_build_v3())
+	dir_header := directive_order_index(c_code, 'static inline int dir_value')
+	assert dir_header >= 0, c_code
+	assert !c_code.contains('int dir_value(void);'), c_code
+	assert !directive_order_has_include_directive(c_code), c_code
+}
+
+fn test_quoted_include_uses_flag_include_dirs() {
+	c_code := directive_order_gen_and_run_flag_include_dir_header(directive_order_build_v3())
+	flag_header := directive_order_index(c_code, 'static inline int flag_value')
+	assert flag_header >= 0, c_code
+	assert directive_order_index(c_code, 'static inline int flag_value_inner') >= 0, c_code
+	assert !c_code.contains('int flag_value(void);'), c_code
+	assert !directive_order_has_include_directive(c_code), c_code
+}
+
+fn test_quoted_include_uses_later_flag_include_dirs() {
+	c_code := directive_order_gen_and_run_late_flag_include_dir_header(directive_order_build_v3())
+	flag_header := directive_order_index(c_code, 'static inline int late_flag_value')
+	assert flag_header >= 0, c_code
+	assert directive_order_index(c_code, 'static inline int late_flag_value_inner') >= 0, c_code
+
+	assert !c_code.contains('int late_flag_value(void);'), c_code
+	assert !directive_order_has_include_directive(c_code), c_code
+}
+
+fn test_multiline_static_inline_header_is_not_redeclared() {
+	c_code := directive_order_gen_and_run_multiline_static_inline(directive_order_build_v3())
+	header_idx := directive_order_index(c_code, 'static inline\nint multiline_value')
+	assert header_idx >= 0, c_code
+	assert !c_code.contains('int multiline_value(void);'), c_code
+	assert !directive_order_has_include_directive(c_code), c_code
+}
+
+fn test_inlined_headers_are_emitted_before_extern_prototypes() {
+	c_code := directive_order_gen_c_extern_after_header(directive_order_build_v3())
+	header_idx := directive_order_index(c_code, 'typedef struct NativeThing')
+	proto_idx := directive_order_index(c_code, 'int native_use(NativeThing*')
+	assert header_idx >= 0, c_code
+	assert proto_idx >= 0, c_code
+	assert header_idx < proto_idx, c_code
+	assert !directive_order_has_include_directive(c_code), c_code
+}
+
+fn test_header_declared_prototypes_are_not_redeclared() {
+	c_code := directive_order_gen_c_header_declared_prototype(directive_order_build_v3())
+	header_idx := directive_order_index(c_code, 'const char* declared_text(void);')
+	assert header_idx >= 0, c_code
+	assert directive_order_count(c_code, 'declared_text(void);') == 1, c_code
+	assert !directive_order_has_include_directive(c_code), c_code
+}
+
+fn test_inlined_headers_are_emitted_before_type_declarations() {
+	c_code := directive_order_gen_c_struct_field_after_header(directive_order_build_v3())
+	header_idx := directive_order_index(c_code, '} FieldThing;')
+	wrap_idx := directive_order_index(c_code, 'struct Wrap {')
+	assert header_idx >= 0, c_code
+	assert wrap_idx >= 0, c_code
+	assert header_idx < wrap_idx, c_code
+	assert !c_code.contains('typedef struct FieldThing'), c_code
+	assert !directive_order_has_include_directive(c_code), c_code
+}
+
+fn test_anonymous_typedef_struct_header_is_not_duplicated() {
+	c_code := directive_order_gen_and_run_anonymous_typedef(directive_order_build_v3())
+	assert c_code.contains('} AnonymousThing;'), c_code
+	assert c_code.contains('static inline int anonymous_value'), c_code
+	assert !c_code.contains('typedef struct AnonymousThing'), c_code
+	assert !directive_order_has_include_directive(c_code), c_code
+}
+
+fn test_tagged_typedef_struct_alias_header_is_not_duplicated() {
+	c_code := directive_order_gen_and_run_tagged_typedef_alias(directive_order_build_v3())
+	assert c_code.contains('} TaggedAlias;'), c_code
+	assert c_code.contains('static inline int tagged_value'), c_code
+	assert !c_code.contains('typedef struct TaggedAlias'), c_code
+	assert !directive_order_has_include_directive(c_code), c_code
+}
+
+fn test_inlined_typedef_union_headers_are_not_duplicated() {
+	c_code := directive_order_gen_c_union_typedef_aliases(directive_order_build_v3())
+	assert c_code.contains('} AnonymousUnion;'), c_code
+	assert c_code.contains('} TaggedUnionAlias;'), c_code
+	assert !c_code.contains('typedef union AnonymousUnion'), c_code
+	assert !c_code.contains('union AnonymousUnion {\n'), c_code
+	assert !c_code.contains('typedef union TaggedUnionAlias'), c_code
+	assert !c_code.contains('union TaggedUnionAlias {\n'), c_code
+	assert !directive_order_has_include_directive(c_code), c_code
+}
+
+fn test_nested_local_header_includes_are_inlined_recursively() {
+	c_code := directive_order_gen_and_run_nested_include(directive_order_build_v3())
+	bias_idx := directive_order_index(c_code, '#define NESTED_BIAS 5')
+	stdint_idx := directive_order_index(c_code, 'typedef unsigned int uint32_t;')
+	typedef_idx := directive_order_index(c_code, '} NestedThing;')
+	outer_fn_idx := directive_order_index(c_code, 'static inline int nested_value')
+	assert bias_idx >= 0, c_code
+	assert stdint_idx >= 0, c_code
+	assert typedef_idx >= 0, c_code
+	assert outer_fn_idx >= 0, c_code
+	assert stdint_idx < typedef_idx, c_code
+	assert bias_idx < outer_fn_idx, c_code
+	assert typedef_idx < outer_fn_idx, c_code
+	assert !c_code.contains('typedef struct NestedThing'), c_code
+	assert !directive_order_has_include_directive(c_code), c_code
+}
+
+fn test_unresolved_system_include_is_preserved() {
+	c_code := directive_order_gen_c_unresolved_system_include(directive_order_build_v3())
+	assert c_code.contains('#include <platform_user_header.h>'), c_code
+	assert c_code.contains('#include <dlfcn.h>'), c_code
+	assert !c_code.contains('#include <stdint.h>'), c_code
+	assert c_code.contains('typedef unsigned int uint32_t;'), c_code
+	assert !c_code.contains('void* dlopen(char* filename, int flags);'), c_code
+	api_compat_idx := directive_order_index(c_code, '#define PLATFORM_API_COMPAT 7')
+	guard_idx := directive_order_index(c_code, '#ifdef USE_DLFCN')
+	dlfcn_idx := directive_order_index(c_code, '#include <dlfcn.h>')
+	time_t_idx := directive_order_index(c_code, 'typedef long long time_t;')
+	off_t_idx := directive_order_index(c_code, 'typedef long long off_t;')
+	wchar_idx := directive_order_index(c_code, 'typedef unsigned int wchar_t;')
+	fd_set_idx := directive_order_index(c_code, '#ifndef FD_SET')
+	assert api_compat_idx >= 0, c_code
+	assert guard_idx >= 0, c_code
+	assert dlfcn_idx >= 0, c_code
+	assert time_t_idx >= 0, c_code
+	assert off_t_idx >= 0, c_code
+	assert wchar_idx >= 0, c_code
+	assert fd_set_idx >= 0, c_code
+	assert c_code.contains('#if !defined(_TIME_T) && !defined(_TIME_T_DEFINED) && !defined(__time_t_defined)'), c_code
+	assert c_code.contains('#if !defined(_OFF_T) && !defined(_OFF_T_DEFINED) && !defined(__off_t_defined)'), c_code
+	assert api_compat_idx < dlfcn_idx, c_code
+	assert guard_idx < dlfcn_idx, c_code
+	assert dlfcn_idx < time_t_idx, c_code
+	assert dlfcn_idx < off_t_idx, c_code
+	assert dlfcn_idx < wchar_idx, c_code
+	assert dlfcn_idx < fd_set_idx, c_code
+}
+
+fn test_nested_preserved_system_include_is_lifted_before_preamble() {
+	c_code := directive_order_gen_c_nested_preserved_system_include(directive_order_build_v3())
+	include_idx := directive_order_index(c_code, '#include <nested_platform_header.h>')
+	preamble_idx := directive_order_index(c_code, 'typedef signed char i8;')
+	stdint_guard_idx := directive_order_index(c_code,
+		'#if !defined(__V_HEADERLESS_STDINT_H) && !defined(_STDINT_H)')
+	nested_word_idx := directive_order_index(c_code, 'typedef uint64_t NestedWord;')
+	assert include_idx >= 0, c_code
+	assert preamble_idx >= 0, c_code
+	assert stdint_guard_idx >= 0, c_code
+	assert nested_word_idx >= 0, c_code
+	assert include_idx < preamble_idx, c_code
+	assert preamble_idx < stdint_guard_idx, c_code
+	assert stdint_guard_idx < nested_word_idx, c_code
+	assert c_code.contains('#if defined(__linux__)\n#define NESTED_PLATFORM_HEADER 1\n#include <nested_platform_header.h>\n#endif'), c_code
+}
+
+fn test_preserved_system_header_aggregates_are_not_redeclared() {
+	c_code := directive_order_gen_c_preserved_x11_aggregates(directive_order_build_v3())
+	assert c_code.contains('#include <X11/Xlib.h>'), c_code
+	assert !c_code.contains('typedef union XEvent XEvent;'), c_code
+	assert !c_code.contains('union XEvent {\n'), c_code
+	assert !c_code.contains('typedef union XClientMessageData XClientMessageData;'), c_code
+	assert !c_code.contains('union XClientMessageData {\n'), c_code
+}
+
+fn test_preserved_system_header_functions_are_not_redeclared() {
+	c_code := directive_order_gen_c_preserved_bcrypt_fn(directive_order_build_v3())
+	assert c_code.contains('#include <bcrypt.h>'), c_code
+	assert directive_order_count(c_code, 'BCryptGenRandom(') == 1, c_code
+}
+
+fn test_preserved_mach_headers_are_wrapped_with_panic_alias() {
+	c_code := directive_order_gen_c_preserved_mach_headers(directive_order_build_v3())
+	preamble_idx := directive_order_index(c_code, 'typedef signed char i8;')
+	assert preamble_idx >= 0, c_code
+	assert c_code.contains('#define panic mach_panic\n#include <mach/mach.h>\n#undef panic'), c_code
+	assert c_code.contains('#define panic mach_panic\n#include <mach/mach_time.h>\n#undef panic'), c_code
+	assert directive_order_index(c_code, '#undef panic') < preamble_idx, c_code
+}
+
+fn test_stdarg_in_inlined_header_uses_headerless_va_defs() {
+	c_code := directive_order_gen_and_run_stdarg_header(directive_order_build_v3())
+	assert !c_code.contains('#include <stdarg.h>'), c_code
+	assert !c_code.contains('#include <stddef.h>'), c_code
+	assert c_code.contains('typedef __builtin_va_list va_list;'), c_code
+	assert c_code.contains('#define va_start(ap, last) __builtin_va_start(ap, last)'), c_code
+	assert c_code.contains('#define va_arg(ap, type) __builtin_va_arg(ap, type)'), c_code
+	assert c_code.contains('#define offsetof(type, member) __builtin_offsetof(type, member)'), c_code
+	assert c_code.contains('offsetof(struct StdargThing, value)'), c_code
+	assert c_code.contains('static inline int stdarg_sum(int count, ...)'), c_code
+}
+
+fn test_rwmutex_keeps_linux_rwlockattr_prototype() {
+	c_code := directive_order_gen_c_rwmutex(directive_order_build_v3())
+	assert c_code.contains('int pthread_rwlockattr_setkind_np('), c_code
+}
+
+fn test_request_named_c_function_keeps_extern_prototype() {
+	c_code := directive_order_gen_c_request_extern(directive_order_build_v3())
+	assert c_code.contains('int request(int'), c_code
 }

--- a/vlib/v3/tests/fn_value_decl_type_test.v
+++ b/vlib/v3/tests/fn_value_decl_type_test.v
@@ -298,9 +298,27 @@ fn make_int() int {
 fn main() {
 	f := make_int
 	x := f()
-	println(int_str(x))
+println(int_str(x))
 }
 '
+
+const local_fn_value_call_return_shadow_src = "fn f() int {
+	return 1
+}
+
+fn actual() string {
+	return 'ok'
+}
+
+fn use(f fn () string) string {
+	s := f()
+	return s
+}
+
+fn main() {
+println(use(actual))
+}
+"
 
 fn test_local_fn_literal_decl_types_are_callable() {
 	v3_bin := build_v3()
@@ -309,6 +327,7 @@ fn test_local_fn_literal_decl_types_are_callable() {
 	assert run_good(v3_bin, 'fn_value_local_ident_shadow', local_ident_shadow_src) == '10'
 	assert run_good(v3_bin, 'fn_value_local_call_shadows_global_return',
 		local_fn_call_shadow_global_return_src) == '12'
+	assert run_good(v3_bin, 'fn_value_call_return_shadow', local_fn_value_call_return_shadow_src) == 'ok'
 	assert run_good(v3_bin, 'fn_value_named_local', 'fn add_one(i int) int {
 	return i + 1
 }
@@ -371,6 +390,10 @@ fn test_local_fn_literal_decl_generates_fn_pointer_locals() {
 	shadow_c := gen_c(v3_bin, 'fn_value_local_ident_shadow_c', local_ident_shadow_src)
 	assert shadow_c.contains('int foo = 10'), shadow_c
 	assert shadow_c.contains('int f = foo'), shadow_c
+	call_shadow_c := gen_c(v3_bin, 'fn_value_call_return_shadow_c',
+		local_fn_value_call_return_shadow_src)
+	assert call_shadow_c.contains('string s = f();'), call_shadow_c
+	assert !call_shadow_c.contains('int s = f();'), call_shadow_c
 
 	shadow_call_c := gen_c(v3_bin, 'fn_value_local_call_shadows_global_return_c',
 		local_fn_call_shadow_global_return_src)

--- a/vlib/v3/tests/gettid_libc_compat_codegen_test.v
+++ b/vlib/v3/tests/gettid_libc_compat_codegen_test.v
@@ -39,7 +39,13 @@ fn main() {
 	assert !compile.output.contains('implicit declaration'), compile.output
 	generated := os.read_file(bin + '.c') or { panic(err) }
 	assert generated.contains('static inline u32 v3_gettid(void)'), generated
+	assert generated.contains('#elif defined(__arm__)'), generated
+	assert generated.contains('#elif defined(__riscv) && __riscv_xlen == 64'), generated
+	assert generated.contains('#elif defined(__loongarch_lp64)'), generated
+	assert generated.contains('#error unsupported Linux gettid syscall number for this architecture'), generated
 	assert generated.contains('syscall(SYS_gettid)'), generated
+	assert !generated.contains('#include <sys/syscall.h>'), generated
+	assert !generated.contains('__NR_gettid'), generated
 	assert !generated.contains(' gettid('), generated
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output

--- a/vlib/v3/tests/markused_typed_receiver_codegen_test.v
+++ b/vlib/v3/tests/markused_typed_receiver_codegen_test.v
@@ -158,6 +158,26 @@ fn typed_receiver_mark_used_project(name string, files map[string]string, main_f
 	return markused.mark_used(a, tc)
 }
 
+fn test_builtin_map_receiver_methods_keep_plain_map_lookup() {
+	used := typed_receiver_mark_used_project('builtin_map_methods', {
+		'main.v': 'module main
+
+fn main() {
+	mut m := map[int]int{}
+	m[1] = 1
+	keys := m.keys()
+	values := m.values()
+	assert keys.len == 1
+	assert values.len == 1
+	m.clear()
+	assert m.len == 0
+}
+'
+	}, 'main.v')
+	assert used['map.clear'], used.keys().str()
+	assert !used['map[int]int.clear'], used.keys().str()
+}
+
 fn test_markused_used_map_does_not_traverse_unused_homonym_method_body() {
 	used := typed_receiver_mark_used_project('homonym_secret', {
 		'main.v':             'module main

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -285,4 +285,6 @@ fn test_parallel_transform_selfhost_builds_v3() {
 	c_code := os.read_file(bin_out + '.c') or { panic(err) }
 	assert c_code.contains('Array_u8__bytestr'), c_code
 	assert c_code.contains('Array_u8__hex'), c_code
+	assert c_code.contains('typedef void* pthread_t;'), c_code
+	assert !c_code.contains('typedef struct pthread_t pthread_t;'), c_code
 }

--- a/vlib/v3/tests/posix_wait_header_codegen_test.v
+++ b/vlib/v3/tests/posix_wait_header_codegen_test.v
@@ -36,7 +36,27 @@ fn wait_header_compile(v3_bin string, name string, source string) WaitHeaderProg
 	}
 }
 
-fn test_os_import_emits_sys_wait_header() {
+fn wait_header_gen_c(v3_bin string, name string, source string) string {
+	pid := os.getpid()
+	src := os.join_path(os.temp_dir(), 'v3_wait_header_${name}_${pid}.v')
+	c_path := os.join_path(os.temp_dir(), 'v3_wait_header_${name}_${pid}.c')
+	os.write_file(src, source) or { panic(err) }
+	os.rm(c_path) or {}
+	compile := os.execute('${v3_bin} ${src} -b c -o ${c_path}')
+	assert compile.exit_code == 0, compile.output
+	return os.read_file(c_path) or { panic(err) }
+}
+
+fn wait_header_has_include_directive(c_code string) bool {
+	for line in c_code.split_into_lines() {
+		if line.trim_space().starts_with('#include') {
+			return true
+		}
+	}
+	return false
+}
+
+fn test_os_import_uses_waitpid_without_headers() {
 	$if windows {
 		return
 	}
@@ -48,14 +68,195 @@ import os
 fn main() {
 	result := os.execute(\'/bin/sh -c "printf waitpid-ok"\')
 	assert result.exit_code == 0
+	stat_info := os.stat(@FILE) or { panic(err) }
+	assert stat_info.size > 0
+	uname_info := os.uname()
+	assert uname_info.sysname.len > 0
+	entries := os.ls(os.dir(@FILE)) or { panic(err) }
+	usage := os.disk_usage(os.dir(@FILE)) or { panic(err) }
+	os.signal_ignore(.pipe)
+	signals_ok := C.SIGSTOP > 0 && C.SIGCONT > 0 && C.SIGTERM == 15 && C.SIGKILL == 9
 	println(result.output)
+	println((entries.len > 0 && usage.total > 0 && signals_ok).str())
 }
 ')
-	assert with_os.c_code.contains('#include <sys/wait.h>'), with_os.c_code
+	assert !wait_header_has_include_directive(with_os.c_code), with_os.c_code
 	assert with_os.c_code.contains('waitpid('), with_os.c_code
+	assert with_os.c_code.contains('int close(int fd);'), with_os.c_code
+	assert with_os.c_code.contains('typedef _Bool bool;'), with_os.c_code
+	assert with_os.c_code.contains('typedef unsigned char bool;'), with_os.c_code
+	assert with_os.c_code.contains('#define __bool_true_false_are_defined 1'), with_os.c_code
+	assert with_os.c_code.contains('#if !defined(__FILE_defined) && !defined(_FILE_DEFINED) && !defined(_FILEDEFED) && !defined(__DEFINED_FILE) && !defined(_FILE_DECLARED) && !defined(__FILE_DECLARED)'), with_os.c_code
+	assert with_os.c_code.contains('typedef intptr_t ssize_t;'), with_os.c_code
+	assert with_os.c_code.contains('int setenv(const char* name, const char* value, int overwrite);'), with_os.c_code
+	assert with_os.c_code.contains('void abort(void);'), with_os.c_code
+	assert with_os.c_code.contains('void* memset(void* s, int c, size_t n);'), with_os.c_code
+	assert with_os.c_code.contains('void* memcpy(void* dest, const void* src, size_t n);'), with_os.c_code
+	assert with_os.c_code.contains('void* memmove(void* dest, const void* src, size_t n);'), with_os.c_code
+	assert with_os.c_code.contains('int memcmp(const void* s1, const void* s2, size_t n);'), with_os.c_code
+	assert with_os.c_code.contains('size_t strlen(const char* s);'), with_os.c_code
+	assert with_os.c_code.contains('int strcmp(const char* s1, const char* s2);'), with_os.c_code
+	assert with_os.c_code.contains('int strncmp(const char* s1, const char* s2, size_t n);'), with_os.c_code
+	assert with_os.c_code.contains('char* strncpy(char* dest, const char* src, size_t n);'), with_os.c_code
+	assert with_os.c_code.contains('double floor(double x);'), with_os.c_code
+	assert with_os.c_code.contains('double ceil(double x);'), with_os.c_code
+	assert with_os.c_code.contains('float floorf(float x);'), with_os.c_code
+	assert with_os.c_code.contains('float ceilf(float x);'), with_os.c_code
+	assert with_os.c_code.contains('double sqrt(double x);'), with_os.c_code
+	assert with_os.c_code.contains('double pow(double x, double y);'), with_os.c_code
+	assert with_os.c_code.contains('double ldexp(double x, int exp);'), with_os.c_code
+	assert with_os.c_code.contains('double fmod(double x, double y);'), with_os.c_code
+	assert with_os.c_code.contains('double cos(double x);'), with_os.c_code
+	assert with_os.c_code.contains('double acos(double x);'), with_os.c_code
+	assert with_os.c_code.contains('double fabs(double x);'), with_os.c_code
+	assert with_os.c_code.contains('int open(const char* path, int flags, ...);'), with_os.c_code
+	assert with_os.c_code.contains('ssize_t read(int fd, void* buf, size_t count);'), with_os.c_code
+	assert with_os.c_code.contains('int fork(void);'), with_os.c_code
+	assert with_os.c_code.contains('int dup2(int oldfd, int newfd);'), with_os.c_code
+	assert with_os.c_code.contains('int execlp(const char* file, const char* arg, ...);'), with_os.c_code
+	assert with_os.c_code.contains('int execvp(const char* file, char* const argv[]);'), with_os.c_code
+	assert with_os.c_code.contains('void _exit(int status);'), with_os.c_code
+	ssize_typedef_idx := with_os.c_code.index('typedef intptr_t ssize_t;') or { -1 }
+	read_proto_idx := with_os.c_code.index('ssize_t read(int fd, void* buf, size_t count);') or {
+		-1
+	}
+	assert ssize_typedef_idx >= 0 && ssize_typedef_idx < read_proto_idx, with_os.c_code
+	assert with_os.c_code.contains('int access(const char* path, int mode);'), with_os.c_code
+	assert with_os.c_code.contains('char* realpath(const char* path, char* resolved_path);'), with_os.c_code
+	assert with_os.c_code.contains('char* strrchr(const char* s, int c);'), with_os.c_code
+	assert with_os.c_code.contains('char* strstr(const char* haystack, const char* needle);'), with_os.c_code
+	assert with_os.c_code.contains('int snprintf(char* str, size_t size, const char* format, ...);'), with_os.c_code
+	assert with_os.c_code.contains('#elif defined(__ANDROID__)'), with_os.c_code
+	assert with_os.c_code.contains('int* __errno(void);'), with_os.c_code
+	assert with_os.c_code.contains('#define errno (*__errno())'), with_os.c_code
+	assert with_os.c_code.contains('int* __errno_location(void);'), with_os.c_code
+	assert with_os.c_code.contains('#define errno (*__errno_location())'), with_os.c_code
+	assert with_os.c_code.contains('#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)'), with_os.c_code
+	assert with_os.c_code.contains('#define stdout __stdoutp'), with_os.c_code
+	assert with_os.c_code.contains('#elif defined(__OpenBSD__)'), with_os.c_code
+	assert with_os.c_code.contains('extern struct __sFstub __stdout[];'), with_os.c_code
+	assert with_os.c_code.contains('#define stdout ((FILE*)__stdout)'), with_os.c_code
+	assert with_os.c_code.contains('#elif defined(__NetBSD__)'), with_os.c_code
+	assert with_os.c_code.contains('struct __netbsd_FILE_stub { unsigned char _opaque[152]; };'), with_os.c_code
+	assert with_os.c_code.contains('#define stdout ((FILE*)&__sF[1])'), with_os.c_code
+	assert with_os.c_code.contains('typedef union { unsigned char _opaque[128]; long long _align; } pthread_mutex_t;'), with_os.c_code
+	assert with_os.c_code.contains('typedef union { unsigned char _opaque[256]; long long _align; } pthread_rwlock_t;'), with_os.c_code
+	assert with_os.c_code.contains('#define PTHREAD_MUTEX_INITIALIZER'), with_os.c_code
+	assert with_os.c_code.contains('int pthread_mutex_lock(void* mutex);'), with_os.c_code
+	assert with_os.c_code.contains('int pthread_mutex_unlock(void* mutex);'), with_os.c_code
+	assert with_os.c_code.contains('typedef union { unsigned char _opaque[128]; long long _align; } sigset_t;'), with_os.c_code
+	assert with_os.c_code.contains('struct winsize { unsigned short ws_row; unsigned short ws_col; unsigned short ws_xpixel; unsigned short ws_ypixel; };'), with_os.c_code
+	assert with_os.c_code.contains('typedef union epoll_data { void* ptr; int fd; u32 u32; u64 u64; } epoll_data_t;'), with_os.c_code
+	assert with_os.c_code.contains('struct epoll_event { u32 events; epoll_data_t data; } __attribute__((packed));'), with_os.c_code
+	assert with_os.c_code.contains('#elif defined(__linux__) && (defined(__i386__) || defined(__arm__))'), with_os.c_code
+	assert with_os.c_code.contains('struct dirent { unsigned long d_ino; long d_off; unsigned short d_reclen; unsigned char d_type; char d_name[256]; };'), with_os.c_code
+	assert with_os.c_code.contains('struct dirent { u64 d_ino; i64 d_off; unsigned short d_reclen; unsigned char d_type; char d_name[256]; };'), with_os.c_code
+	assert with_os.c_code.contains('struct dirent { u64 d_ino; u64 d_seekoff; u16 d_reclen; u16 d_namlen; u8 d_type; char d_name[1024]; };'), with_os.c_code
+	assert with_os.c_code.contains('struct dirent { u64 d_ino; i64 d_seekoff; u16 d_reclen; u8 d_type; u8 __pad0; u16 d_namlen; u16 __pad1; char d_name[256]; };'), with_os.c_code
+	assert with_os.c_code.contains('struct statvfs { unsigned long f_flag; unsigned long f_bsize; unsigned long f_frsize; unsigned long f_iosize; u64 f_blocks;'), with_os.c_code
+	assert with_os.c_code.contains('char f_mntfromlabel[1024];'), with_os.c_code
+	assert with_os.c_code.contains('struct statvfs { unsigned long f_bsize; unsigned long f_frsize; unsigned long f_blocks; unsigned long f_bfree; unsigned long f_bavail;'), with_os.c_code
+	assert with_os.c_code.contains('#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)'), with_os.c_code
+	assert with_os.c_code.contains('struct utsname { char sysname[256]; char nodename[256]; char release[256]; char version[256]; char machine[256]; };'), with_os.c_code
+	assert with_os.c_code.contains('struct utsname { char sysname[65]; char nodename[65]; char release[65]; char version[65]; char machine[65]; char domainname[65]; };'), with_os.c_code
+	assert with_os.c_code.contains('#if defined(__x86_64__) && !defined(__ILP32__)'), with_os.c_code
+	assert with_os.c_code.contains('struct stat { u64 st_dev; u64 st_ino; u64 st_nlink; u32 st_mode; u32 st_uid; u32 st_gid; int __pad0; u64 st_rdev; i64 st_size; i64 st_blksize; i64 st_blocks; i64 st_atime; i64 st_atimensec; i64 st_mtime; i64 st_mtimensec; i64 st_ctime; i64 st_ctimensec; i64 __glibc_reserved[3]; };'), with_os.c_code
+	assert with_os.c_code.contains('#elif defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64) || defined(__loongarch_lp64)'), with_os.c_code
+	assert with_os.c_code.contains('#elif defined(__i386__) || defined(__arm__)'), with_os.c_code
+	assert with_os.c_code.contains('struct stat { u64 st_dev; unsigned short __pad1; unsigned long st_ino; u32 st_mode; unsigned long st_nlink;'), with_os.c_code
+	assert with_os.c_code.contains('#error unsupported Linux struct stat layout for this architecture'), with_os.c_code
+	assert with_os.c_code.contains('i32 st_atim_ext; i64 st_atime; long st_atimensec;'), with_os.c_code
+	assert with_os.c_code.contains('struct stat { u64 st_dev; u64 st_ino; u64 st_nlink; u16 st_mode; i16 st_bsdflags;'), with_os.c_code
+	assert with_os.c_code.contains('struct stat { u32 st_mode; i32 st_dev; u64 st_ino; u32 st_nlink;'), with_os.c_code
+	assert with_os.c_code.contains('struct stat { u64 st_dev; u32 st_mode; u64 st_ino; u32 st_nlink;'), with_os.c_code
+	assert with_os.c_code.contains('struct stat { u64 st_ino; u32 st_nlink; u32 st_dev; u16 st_mode;'), with_os.c_code
+	assert with_os.c_code.contains('#elif defined(__sun)'), with_os.c_code
+	assert with_os.c_code.contains('struct stat { u64 st_dev; u64 st_ino; u32 st_mode; u32 st_nlink; u32 st_uid; u32 st_gid;'), with_os.c_code
+	assert with_os.c_code.contains('char st_fstype[16];'), with_os.c_code
+	assert with_os.c_code.contains('#elif defined(__QNX__) || defined(__QNXNTO__)'), with_os.c_code
+	assert with_os.c_code.contains('#if _FILE_OFFSET_BITS - 0 == 64'), with_os.c_code
+	assert with_os.c_code.contains('struct stat { u64 st_ino; i64 st_size; u64 st_dev; u64 st_rdev;'), with_os.c_code
+	assert with_os.c_code.contains('#elif defined(__BIGENDIAN__)'), with_os.c_code
+	assert with_os.c_code.contains('#error unsupported headerless Unix struct stat layout for this platform'), with_os.c_code
+	assert with_os.c_code.contains('i64 st_birthtime;'), with_os.c_code
+	assert with_os.c_code.contains('struct rusage { struct timeval ru_utime; struct timeval ru_stime; long ru_maxrss; long ru_ixrss; long ru_idrss;'), with_os.c_code
+	assert with_os.c_code.contains('#if !defined(_STRUCT_TIMESPEC) && !defined(_TIMESPEC_DEFINED) && !defined(_TIMESPEC_DECLARED) && !defined(__timespec_defined)'), with_os.c_code
+	assert with_os.c_code.contains('typedef struct timespec timespec;'), with_os.c_code
+	assert !with_os.c_code.contains('typedef struct stat stat;'), with_os.c_code
+	assert !with_os.c_code.contains('typedef struct sigset_t sigset_t;'), with_os.c_code
+	assert !with_os.c_code.contains('struct winsize {\n\tws_row'), with_os.c_code
+	assert !with_os.c_code.contains('struct rusage {\n\tru_maxrss int'), with_os.c_code
+	assert !with_os.c_code.contains('typedef union epoll_data_t epoll_data_t;'), with_os.c_code
+	assert !with_os.c_code.contains('u64 d_seekoff;\n\tu64 d_reclen;'), with_os.c_code
+	assert with_os.c_code.contains('#define SIGSTOP'), with_os.c_code
+	assert with_os.c_code.contains('#define SIGCONT'), with_os.c_code
+	assert with_os.c_code.contains('#define SIGTERM 15'), with_os.c_code
+	assert with_os.c_code.contains('#define SIGKILL 9'), with_os.c_code
+	assert with_os.c_code.contains('#define SIGPIPE 13'), with_os.c_code
+	assert with_os.c_code.contains('#define SIG_IGN ((void*)1)'), with_os.c_code
+	assert with_os.c_code.contains('#define SIG_BLOCK'), with_os.c_code
+	assert with_os.c_code.contains('#define PTRACE_ATTACH 16'), with_os.c_code
+	assert with_os.c_code.contains('#define PTRACE_DETACH 17'), with_os.c_code
+	assert with_os.c_code.contains('#define PT_TRACE_ME 0'), with_os.c_code
+	assert with_os.c_code.contains('#define PT_ATTACH 10'), with_os.c_code
+	assert with_os.c_code.contains('#define PT_DETACH 11'), with_os.c_code
+	assert with_os.c_code.contains('#define WNOHANG 1'), with_os.c_code
+	assert with_os.c_code.contains('#define ENOENT 2'), with_os.c_code
+	assert with_os.c_code.contains('#define RUSAGE_SELF 0'), with_os.c_code
+	assert with_os.c_code.contains('#define EACCES 13'), with_os.c_code
+	assert with_os.c_code.contains('#define EIO 5'), with_os.c_code
+	assert with_os.c_code.contains('#define EBADF 9'), with_os.c_code
+	assert with_os.c_code.contains('#define ENOMEM 12'), with_os.c_code
+	assert with_os.c_code.contains('#define EFAULT 14'), with_os.c_code
+	assert with_os.c_code.contains('#define ESPIPE 29'), with_os.c_code
+	assert with_os.c_code.contains('#define EOVERFLOW 75'), with_os.c_code
+	assert with_os.c_code.contains('#define _SC_PAGESIZE 0x0027'), with_os.c_code
+	assert with_os.c_code.contains('#define _SC_NPROCESSORS_ONLN 0x0061'), with_os.c_code
+	assert with_os.c_code.contains('#define _SC_PHYS_PAGES 0x0062'), with_os.c_code
+	assert with_os.c_code.contains('#define _SC_AVPHYS_PAGES 0x0063'), with_os.c_code
+	assert with_os.c_code.contains('#define _SC_PAGESIZE 30'), with_os.c_code
+	assert with_os.c_code.contains('#define _SC_NPROCESSORS_ONLN 84'), with_os.c_code
+	assert with_os.c_code.contains('#define _SC_PHYS_PAGES 85'), with_os.c_code
+	assert with_os.c_code.contains('#define _SC_AVPHYS_PAGES 86'), with_os.c_code
+	assert with_os.c_code.contains('#define PROT_READ 0x1'), with_os.c_code
+	assert with_os.c_code.contains('#define PROT_WRITE 0x2'), with_os.c_code
+	assert with_os.c_code.contains('#define PROT_EXEC 0x4'), with_os.c_code
+	assert with_os.c_code.contains('#define MAP_PRIVATE 0x0002'), with_os.c_code
+	assert with_os.c_code.contains('#define MAP_ANONYMOUS 0x20'), with_os.c_code
+	assert with_os.c_code.contains('#define MAP_ANONYMOUS 0x1000'), with_os.c_code
+	assert with_os.c_code.contains('#define MAP_FAILED ((void*)-1)'), with_os.c_code
+	assert with_os.c_code.contains('#define SYS_getrandom 318'), with_os.c_code
+	assert with_os.c_code.contains('#define SYS_getrandom 355'), with_os.c_code
+	assert with_os.c_code.contains('#define SYS_getrandom 384'), with_os.c_code
+	assert with_os.c_code.contains('#define SYS_getrandom 278'), with_os.c_code
+	assert with_os.c_code.contains('#define CTL_KERN 1'), with_os.c_code
+	assert with_os.c_code.contains('#define CTL_VM 2'), with_os.c_code
+	assert with_os.c_code.contains('#define KERN_PROC_PATHNAME 12'), with_os.c_code
+	assert with_os.c_code.contains('#define KERN_PROC_INC_THREAD 0x10'), with_os.c_code
+	assert with_os.c_code.contains('#define KERN_PROC_ARGS 55'), with_os.c_code
+	assert with_os.c_code.contains('#define KERN_PROC_ARGV 1'), with_os.c_code
+	assert with_os.c_code.contains('#define VM_UVMEXP 4'), with_os.c_code
+	assert with_os.c_code.contains('__atomic_load_4((u32*)ptr, 5)'), with_os.c_code
+	assert with_os.c_code.contains('__atomic_load_8((u64*)ptr, 5)'), with_os.c_code
+	assert with_os.c_code.contains('__atomic_load_n((void**)ptr, 5)'), with_os.c_code
+	assert !with_os.c_code.contains('*(void* volatile*)ptr'), with_os.c_code
+	assert with_os.c_code.contains('#define SOCK_NONBLOCK 04000'), with_os.c_code
+	assert with_os.c_code.contains('#define SOCK_NONBLOCK 0x20000000'), with_os.c_code
+	assert with_os.c_code.contains('#define SO_REUSEPORT 15'), with_os.c_code
+	assert with_os.c_code.contains('#define TCP_QUICKACK 12'), with_os.c_code
+	assert with_os.c_code.contains('#define TCP_DEFER_ACCEPT 9'), with_os.c_code
+	assert with_os.c_code.contains('#define TCP_FASTOPEN 23'), with_os.c_code
+	assert with_os.c_code.contains('#define SOMAXCONN 4096'), with_os.c_code
+	assert with_os.c_code.contains('#define MEM_COMMIT 0x00001000U'), with_os.c_code
+	assert with_os.c_code.contains('#define MEM_RESERVE 0x00002000U'), with_os.c_code
+	assert with_os.c_code.contains('#define PAGE_READWRITE 0x04U'), with_os.c_code
+	assert with_os.c_code.contains('#define PAGE_EXECUTE_READ 0x20U'), with_os.c_code
+	assert with_os.c_code.contains('#define TLS_OUT_OF_INDEXES 0xffffffffU'), with_os.c_code
+	assert with_os.c_code.contains('#define SOCKET_ERROR (-1)'), with_os.c_code
+	assert with_os.c_code.contains('#define WSAEWOULDBLOCK 10035'), with_os.c_code
 	run := os.execute(with_os.out)
 	assert run.exit_code == 0, run.output
-	assert run.output.trim_space() == 'waitpid-ok', run.output
+	assert run.output.trim_space() == 'waitpid-ok\ntrue', run.output
 
 	hello := wait_header_compile(v3_bin, 'hello', "module main
 
@@ -63,5 +264,530 @@ fn main() {
 	println('hello')
 }
 ")
-	assert !hello.c_code.contains('#include <sys/wait.h>'), hello.c_code
+	assert !wait_header_has_include_directive(hello.c_code), hello.c_code
+}
+
+fn test_user_c_decl_emits_extern_prototype_without_headers() {
+	$if windows {
+		return
+	}
+	v3_bin := wait_header_build_v3()
+	program := wait_header_compile(v3_bin, 'user_c_getppid', 'module main
+
+#flag -Werror=implicit-function-declaration
+
+fn C.getppid() int
+
+fn main() {
+	println(C.getppid().str())
+}
+')
+	assert !wait_header_has_include_directive(program.c_code), program.c_code
+	assert program.c_code.contains('int getppid(void);'), program.c_code
+	run := os.execute(program.out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space().int() > 0, run.output
+}
+
+fn test_windows_crt_underscore_c_decls_emit_extern_prototypes() {
+	v3_bin := wait_header_build_v3()
+	c_code := wait_header_gen_c(v3_bin, 'windows_crt_underscore_decls', 'module main
+
+fn C._wfopen(&u16, &u16) voidptr
+fn C._wsystem(&u16) int
+fn C._wgetenv(&u16) voidptr
+fn C._waccess(&u16, int) int
+fn C._wchdir(&u16) int
+fn C._chsize_s(voidptr, u64) int
+
+fn main() {
+	p := &u16(unsafe { nil })
+	h := voidptr(0)
+	_ = C._wfopen(p, p)
+	_ = C._wsystem(p)
+	_ = C._wgetenv(p)
+	_ = C._waccess(p, 0)
+	_ = C._wchdir(p)
+	_ = C._chsize_s(h, u64(0))
+}
+')
+	assert !wait_header_has_include_directive(c_code), c_code
+	assert c_code.contains('#ifdef _MSC_VER'), c_code
+	assert c_code.contains('typedef unsigned __int64 size_t;'), c_code
+	assert c_code.contains('typedef __int64 ptrdiff_t;'), c_code
+	assert c_code.contains('typedef unsigned __int64 uintptr_t;'), c_code
+	assert c_code.contains('typedef __int64 intptr_t;'), c_code
+	assert c_code.contains('#elif defined(_WIN32)'), c_code
+	assert c_code.contains('int* _errno(void);'), c_code
+	assert c_code.contains('#define errno (*_errno())'), c_code
+	assert c_code.contains('void* _wfopen(u16*, u16*);'), c_code
+	assert c_code.contains('int _wsystem(u16*);'), c_code
+	assert c_code.contains('void* _wgetenv(u16*);'), c_code
+	assert c_code.contains('int _waccess(u16*, int);'), c_code
+	assert c_code.contains('int _wchdir(u16*);'), c_code
+	assert c_code.contains('int _chsize_s(void*, u64);'), c_code
+}
+
+fn test_windows_sdk_types_are_emitted_before_extern_prototypes() {
+	v3_bin := wait_header_build_v3()
+	c_code := wait_header_gen_c(v3_bin, 'windows_sdk_type_order', 'module main
+
+@[typedef]
+struct C.SECURITY_ATTRIBUTES {}
+
+fn C.CreateHardLinkW(&u16, &u16, &C.SECURITY_ATTRIBUTES) int
+
+fn main() {
+	path := &u16(unsafe { nil })
+	attrs := &C.SECURITY_ATTRIBUTES(unsafe { nil })
+	_ = C.CreateHardLinkW(path, path, attrs)
+}
+')
+	security_typedef := 'typedef struct SECURITY_ATTRIBUTES { DWORD nLength; void* lpSecurityDescriptor; BOOL bInheritHandle; } SECURITY_ATTRIBUTES;'
+	security_typedef_idx := c_code.index(security_typedef) or { -1 }
+	prototype_idx := c_code.index('int WINAPI CreateHardLinkW(u16*, u16*, SECURITY_ATTRIBUTES*);') or {
+		-1
+	}
+	assert security_typedef_idx >= 0, c_code
+	assert prototype_idx >= 0, c_code
+	assert security_typedef_idx < prototype_idx, c_code
+	assert !c_code.contains('typedef struct SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;'), c_code
+}
+
+fn test_winapi_extern_prototypes_use_calling_convention() {
+	v3_bin := wait_header_build_v3()
+	c_code := wait_header_gen_c(v3_bin, 'winapi_calling_convention', 'module main
+
+fn C.GetStdHandle(u32) voidptr
+fn C.CreateFileW(&u16, u32, u32, voidptr, u32, u32, voidptr) voidptr
+
+fn main() {
+	path := &u16(unsafe { nil })
+	_ = C.GetStdHandle(u32(0))
+	_ = C.CreateFileW(path, 0, 0, voidptr(0), 0, 0, voidptr(0))
+}
+')
+	assert c_code.contains('#ifndef WINAPI'), c_code
+	assert c_code.contains('#define WINAPI __stdcall'), c_code
+	assert c_code.contains('void* WINAPI GetStdHandle(u32);'), c_code
+	assert c_code.contains('void* WINAPI CreateFileW(u16*, u32, u32, void*, u32, u32, void*);'), c_code
+	assert !c_code.contains('void* GetStdHandle(u32);'), c_code
+	assert !c_code.contains('void* CreateFileW(u16*, u32, u32, void*, u32, u32, void*);'), c_code
+}
+
+fn test_unsuffixed_winapi_decls_use_wide_exports() {
+	v3_bin := wait_header_build_v3()
+	c_code := wait_header_gen_c(v3_bin, 'winapi_unsuffixed_wide_exports', 'module main
+
+fn C.GetModuleFileName(voidptr, &u16, u32) u32
+fn C.CreateFile(&u16, u32, u32, voidptr, u32, u32, voidptr) voidptr
+fn C.LoadLibrary(&u16) voidptr
+fn C.DefWindowProc(voidptr, u32, usize, isize) isize
+
+fn main() {
+	path := &u16(unsafe { nil })
+	_ = C.GetModuleFileName(voidptr(0), path, 0)
+	_ = C.CreateFile(path, 0, 0, voidptr(0), 0, 0, voidptr(0))
+	_ = C.LoadLibrary(path)
+	_ = voidptr(&C.DefWindowProc)
+}
+')
+	assert c_code.contains('u32 WINAPI GetModuleFileNameW(void*, u16*, u32);'), c_code
+	assert c_code.contains('void* WINAPI CreateFileW(u16*, u32, u32, void*, u32, u32, void*);'), c_code
+	assert c_code.contains('void* WINAPI LoadLibraryW(u16*);'), c_code
+	assert c_code.contains('ptrdiff_t WINAPI DefWindowProcW(void*, u32, size_t, ptrdiff_t);'), c_code
+	assert c_code.contains('GetModuleFileNameW('), c_code
+	assert c_code.contains('CreateFileW('), c_code
+	assert c_code.contains('LoadLibraryW('), c_code
+	assert c_code.contains('&DefWindowProcW'), c_code
+	assert !c_code.contains('GetModuleFileName('), c_code
+	assert !c_code.contains('CreateFile('), c_code
+	assert !c_code.contains('LoadLibrary('), c_code
+	assert !c_code.contains('&DefWindowProc)'), c_code
+}
+
+fn test_synthesized_c_extern_prototypes_preserve_const_pointer_params() {
+	v3_bin := wait_header_build_v3()
+	c_code := wait_header_gen_c(v3_bin, 'c_extern_const_pointer_params', 'module main
+
+fn C.SSL_CTX_load_verify_locations(ctx voidptr, const_file &char, const_ca_path &char) int
+
+fn main() {
+	path := &char(unsafe { nil })
+	_ = C.SSL_CTX_load_verify_locations(voidptr(0), path, path)
+}
+')
+	assert c_code.contains('int SSL_CTX_load_verify_locations(void* ctx, const char* const_file, const char* const_ca_path);'), c_code
+	assert !c_code.contains('int SSL_CTX_load_verify_locations(void* ctx, char* const_file'), c_code
+}
+
+fn test_windows_sync_structs_use_headerless_preamble_storage() {
+	v3_bin := wait_header_build_v3()
+	c_code := wait_header_gen_c(v3_bin, 'windows_sync_struct_storage', 'module main
+
+@[typedef]
+struct C.SRWLOCK {}
+
+@[typedef]
+struct C.CONDITION_VARIABLE {}
+
+struct SyncHolder {
+	rw C.SRWLOCK
+	cv C.CONDITION_VARIABLE
+}
+
+fn main() {
+	_ := SyncHolder{}
+}
+')
+	assert !wait_header_has_include_directive(c_code), c_code
+	assert c_code.contains('typedef struct SRWLOCK { void* Ptr; } SRWLOCK;'), c_code
+	assert c_code.contains('typedef struct CONDITION_VARIABLE { void* Ptr; } CONDITION_VARIABLE;'), c_code
+	assert c_code.contains('SRWLOCK rw;'), c_code
+	assert c_code.contains('CONDITION_VARIABLE cv;'), c_code
+	assert !c_code.contains('typedef struct SRWLOCK SRWLOCK;'), c_code
+	assert !c_code.contains('typedef struct CONDITION_VARIABLE CONDITION_VARIABLE;'), c_code
+}
+
+fn test_epoll_data_tag_uses_headerless_preamble_definition() {
+	v3_bin := wait_header_build_v3()
+	c_code := wait_header_gen_c(v3_bin, 'epoll_data_tag_storage', 'module main
+
+@[typedef]
+union C.epoll_data {
+mut:
+	ptr voidptr
+	fd  int
+	u32 u32
+	u64 u64
+}
+
+@[packed]
+struct C.epoll_event {
+	events u32
+	data   C.epoll_data
+}
+
+fn main() {
+	_ := C.epoll_event{}
+}
+')
+	assert c_code.contains('typedef union epoll_data { void* ptr; int fd; u32 u32; u64 u64; } epoll_data_t;'), c_code
+	assert !c_code.contains('union epoll_data {\n'), c_code
+}
+
+fn test_windows_console_records_use_headerless_preamble_definitions() {
+	v3_bin := wait_header_build_v3()
+	c_code := wait_header_gen_c(v3_bin, 'windows_console_records', 'module main
+
+pub union C.Event {
+	KeyEvent              C.KEY_EVENT_RECORD
+	MouseEvent            C.MOUSE_EVENT_RECORD
+	WindowBufferSizeEvent C.WINDOW_BUFFER_SIZE_RECORD
+	MenuEvent             C.MENU_EVENT_RECORD
+	FocusEvent            C.FOCUS_EVENT_RECORD
+}
+
+@[typedef]
+pub struct C.INPUT_RECORD {
+	EventType u16
+	Event     C.Event
+}
+
+pub union C.uChar {
+mut:
+	UnicodeChar rune
+	AsciiChar   u8
+}
+
+@[typedef]
+pub struct C.KEY_EVENT_RECORD {
+	bKeyDown          int
+	wRepeatCount      u16
+	wVirtualKeyCode   u16
+	wVirtualScanCode  u16
+	uChar             C.uChar
+	dwControlKeyState u32
+}
+
+@[typedef]
+pub struct C.MOUSE_EVENT_RECORD {
+	dwMousePosition   C.COORD
+	dwButtonState     u32
+	dwControlKeyState u32
+	dwEventFlags      u32
+}
+
+@[typedef]
+pub struct C.WINDOW_BUFFER_SIZE_RECORD {
+	dwSize C.COORD
+}
+
+@[typedef]
+pub struct C.MENU_EVENT_RECORD {
+	dwCommandId u32
+}
+
+@[typedef]
+pub struct C.FOCUS_EVENT_RECORD {
+	bSetFocus int
+}
+
+@[typedef]
+pub struct C.COORD {
+	X i16
+	Y i16
+}
+
+@[typedef]
+pub struct C.SMALL_RECT {
+	Left   u16
+	Top    u16
+	Right  u16
+	Bottom u16
+}
+
+@[typedef]
+pub struct C.CONSOLE_SCREEN_BUFFER_INFO {
+	dwSize              C.COORD
+	dwCursorPosition    C.COORD
+	wAttributes         u16
+	srWindow            C.SMALL_RECT
+	dwMaximumWindowSize C.COORD
+}
+
+@[typedef]
+pub struct C.CHAR_INFO {
+	Char       C.uChar
+	Attributes u16
+}
+
+fn main() {
+	_ := C.INPUT_RECORD{}
+	_ := C.CHAR_INFO{}
+}
+')
+	assert c_code.contains('typedef union uChar { u16 UnicodeChar; u8 AsciiChar; } uChar;'), c_code
+	assert c_code.contains('typedef struct KEY_EVENT_RECORD { int bKeyDown; u16 wRepeatCount; u16 wVirtualKeyCode; u16 wVirtualScanCode; uChar uChar; u32 dwControlKeyState; } KEY_EVENT_RECORD;'), c_code
+	assert c_code.contains('typedef struct INPUT_RECORD { u16 EventType; Event Event; } INPUT_RECORD;'), c_code
+	assert !c_code.contains('union uChar {\n'), c_code
+	assert !c_code.contains('struct uChar'), c_code
+	assert !c_code.contains('struct KEY_EVENT_RECORD {\n'), c_code
+}
+
+fn test_time_import_uses_platform_tm_layout_without_headers() {
+	$if windows {
+		return
+	}
+	v3_bin := wait_header_build_v3()
+	program := wait_header_compile(v3_bin, 'time_tm_layout', 'module main
+
+import time
+
+fn main() {
+	now := time.now()
+	println((now.year > 0).str())
+}
+')
+	assert !wait_header_has_include_directive(program.c_code), program.c_code
+	assert program.c_code.contains('struct tm { int tm_sec; int tm_min; int tm_hour; int tm_mday; int tm_mon; int tm_year; int tm_wday; int tm_yday; int tm_isdst; long tm_gmtoff; const char* tm_zone; };'), program.c_code
+	assert program.c_code.contains('typedef struct tm tm;'), program.c_code
+	assert !program.c_code.contains('int tm_gmtoff;'), program.c_code
+	run := os.execute(program.out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'true', run.output
+}
+
+fn test_term_import_uses_platform_termios_layout_without_headers() {
+	$if windows {
+		return
+	}
+	v3_bin := wait_header_build_v3()
+	program := wait_header_compile(v3_bin, 'term_termios', 'module main
+
+import term
+import term.termios
+
+fn main() {
+	mut t := termios.Termios{}
+	t.disable_echo()
+	width, height := term.get_terminal_size()
+	println((width > 0 && height > 0).str())
+}
+')
+	assert !wait_header_has_include_directive(program.c_code), program.c_code
+	assert program.c_code.contains('struct termios { size_t c_iflag; size_t c_oflag; size_t c_cflag; size_t c_lflag; u8 c_cc[20]; size_t c_ispeed; size_t c_ospeed; };'), program.c_code
+	assert program.c_code.contains('struct termios { int c_iflag; int c_oflag; int c_cflag; int c_lflag; u8 c_line; u8 c_cc[32]; int c_ispeed; int c_ospeed; };'), program.c_code
+	assert program.c_code.contains('struct termios { int c_iflag; int c_oflag; int c_cflag; int c_lflag; u8 c_cc[20]; };'), program.c_code
+	assert program.c_code.contains('struct termios { int c_iflag; int c_oflag; int c_cflag; int c_lflag; u8 c_cc[20]; u32 reserved[3]; int c_ispeed; int c_ospeed; };'), program.c_code
+	assert program.c_code.contains('struct termios { int c_iflag; int c_oflag; int c_cflag; int c_lflag; u8 c_cc[20]; int c_ispeed; int c_ospeed; };'), program.c_code
+	assert program.c_code.contains('#define VMIN'), program.c_code
+	assert program.c_code.contains('#define TIOCGWINSZ'), program.c_code
+	run := os.execute(program.out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'true', run.output
+}
+
+fn test_filelock_uses_headerless_fcntl_helpers() {
+	$if windows {
+		return
+	}
+	v3_bin := wait_header_build_v3()
+	program := wait_header_compile(v3_bin, 'filelock_helpers', "module main
+
+import os
+
+fn C.open(&char, i32, i32) i32
+fn C.close(i32) i32
+fn C.v_filelock_lock(i32, i32, i32, u64, u64) i32
+fn C.v_filelock_unlock(i32, u64, u64) i32
+
+fn main() {
+	path := os.join_path(os.temp_dir(), 'v3_headerless_filelock_target')
+	os.write_file(path, 'abcdef') or { panic(err) }
+	fd := C.open(&char(path.str), C.O_RDWR, 0)
+	println(fd)
+	lock_result := C.v_filelock_lock(fd, 1, 1, u64(0), u64(3))
+	unlock_result := C.v_filelock_unlock(fd, u64(0), u64(3))
+	println(lock_result)
+	println(unlock_result)
+	C.close(fd)
+	os.rm(path) or {}
+}
+")
+	assert !wait_header_has_include_directive(program.c_code), program.c_code
+	assert program.c_code.contains('#define LOCK_EX 2'), program.c_code
+	assert program.c_code.contains('int open(const char* path, int flags, ...);'), program.c_code
+	assert !program.c_code.contains('int open(char*'), program.c_code
+	assert program.c_code.contains('#elif defined(_WIN32)'), program.c_code
+	assert program.c_code.contains('#define GENERIC_READ 0x80000000U'), program.c_code
+	assert program.c_code.contains('#define OPEN_ALWAYS 4'), program.c_code
+	assert program.c_code.contains('static inline int v_filelock_lock(int fd, int exclusive, int immediate, u64 start, u64 len) { struct flock fl;'), program.c_code
+	assert program.c_code.contains('return fcntl(fd, immediate ? F_SETLK : F_SETLKW, &fl);'), program.c_code
+	assert program.c_code.contains('typedef struct SECURITY_ATTRIBUTES { DWORD nLength; void* lpSecurityDescriptor; BOOL bInheritHandle; } SECURITY_ATTRIBUTES;'), program.c_code
+	assert program.c_code.contains('BOOL LockFileEx(HANDLE handle, DWORD flags, DWORD reserved, DWORD low, DWORD high, OVERLAPPED* overlap);'), program.c_code
+	assert program.c_code.contains('return LockFileEx(handle, flags, 0, low, high, &overlap) ? 0 : -1;'), program.c_code
+	assert program.c_code.contains('return UnlockFileEx(handle, 0, low, high, &overlap) ? 0 : -1;'), program.c_code
+	run := os.execute(program.out)
+	assert run.exit_code == 0, run.output
+	lines := run.output.trim_space().split_into_lines()
+	assert lines.len == 3, run.output
+	assert lines[0].int() != -1, run.output
+	assert lines[1] == '0', run.output
+	assert lines[2] == '0', run.output
+}
+
+fn test_net_import_uses_headerless_socket_constants() {
+	$if windows {
+		return
+	}
+	v3_bin := wait_header_build_v3()
+	program := wait_header_compile(v3_bin, 'net_socket_constants', 'module main
+
+import net
+
+fn C.getaddrinfo(&char, &char, &C.addrinfo, &&C.addrinfo) int
+fn C.freeaddrinfo(&C.addrinfo)
+
+fn main() {
+	println((int(net.SocketType.tcp) > 0).str())
+	println((int(net.AddrFamily.ip) > 0).str())
+	host := "127.0.0.1"
+	service := "80"
+	mut hints := C.addrinfo{}
+	unsafe { vmemset(&hints, 0, int(sizeof(hints))) }
+	hints.ai_family = C.AF_INET
+	hints.ai_socktype = C.SOCK_STREAM
+	hints.ai_flags = C.AI_PASSIVE
+	mut results := &C.addrinfo(unsafe { nil })
+	code := C.getaddrinfo(&char(host.str), &char(service.str), &hints, &results)
+	if code != 0 {
+		println("false")
+		return
+	}
+	ok := !isnil(results) && results.ai_family == C.AF_INET
+	C.freeaddrinfo(results)
+	println(ok.str())
+}
+')
+	assert !wait_header_has_include_directive(program.c_code), program.c_code
+	assert program.c_code.contains('typedef unsigned short wchar_t;'), program.c_code
+	assert program.c_code.contains('typedef unsigned int wchar_t;'), program.c_code
+	assert program.c_code.contains('typedef uintptr_t SOCKET;'), program.c_code
+	assert program.c_code.contains('struct fd_set { unsigned int fd_count; SOCKET fd_array[FD_SETSIZE]; };'), program.c_code
+	assert program.c_code.contains('static inline void v_fd_set(SOCKET fd, fd_set* set)'), program.c_code
+	assert program.c_code.contains('#elif defined(__APPLE__)'), program.c_code
+	assert program.c_code.contains('#define __V_FD_BITS 32'), program.c_code
+	assert program.c_code.contains('struct fd_set { unsigned int fds_bits[FD_SETSIZE / __V_FD_BITS]; };'), program.c_code
+	assert program.c_code.contains('struct fd_set { unsigned long fds_bits[FD_SETSIZE / __V_FD_BITS]; };'), program.c_code
+	assert program.c_code.contains('struct kevent { uintptr_t ident; u32 filter; u32 flags; u32 fflags; i64 data; void* udata; u64 ext[4]; };'), program.c_code
+	assert program.c_code.contains('struct kevent { uintptr_t ident; i16 filter; u16 flags; u32 fflags; intptr_t data; void* udata; };'), program.c_code
+	assert program.c_code.contains('struct winsize { unsigned short ws_row; unsigned short ws_col; unsigned short ws_xpixel; unsigned short ws_ypixel; };'), program.c_code
+	assert program.c_code.contains('struct addrinfo { int ai_flags; int ai_family; int ai_socktype; int ai_protocol; size_t ai_addrlen; char* ai_canonname; void* ai_addr; struct addrinfo* ai_next; };'), program.c_code
+	assert program.c_code.contains('struct addrinfo { int ai_flags; int ai_family; int ai_socktype; int ai_protocol; unsigned int ai_addrlen; char* ai_canonname; void* ai_addr; struct addrinfo* ai_next; };'), program.c_code
+	assert program.c_code.contains('struct addrinfo { int ai_flags; int ai_family; int ai_socktype; int ai_protocol; unsigned int ai_addrlen; void* ai_addr; char* ai_canonname; struct addrinfo* ai_next; };'), program.c_code
+	assert program.c_code.contains('typedef struct addrinfo addrinfo;'), program.c_code
+	assert !program.c_code.contains('int ai_family; int ai_socktype; int ai_flags;'), program.c_code
+	assert program.c_code.contains('struct sockaddr { u8 sa_len; u8 sa_family; char sa_data[14]; };'), program.c_code
+	assert program.c_code.contains('struct sockaddr_in { u8 sin_len; u8 sin_family; u16 sin_port; u32 sin_addr; char sin_zero[8]; };'), program.c_code
+	assert program.c_code.contains('struct sockaddr_in6 { u8 sin6_len; u8 sin6_family; u16 sin6_port; u32 sin6_flowinfo; u8 sin6_addr[16]; u32 sin6_scope_id; };'), program.c_code
+	assert program.c_code.contains('struct sockaddr { u16 sa_family; char sa_data[14]; };'), program.c_code
+	assert program.c_code.contains('struct sockaddr_in { u16 sin_family; u16 sin_port; u32 sin_addr; char sin_zero[8]; };'), program.c_code
+	assert program.c_code.contains('struct sockaddr_in6 { u16 sin6_family; u16 sin6_port; u32 sin6_flowinfo; u8 sin6_addr[16]; u32 sin6_scope_id; };'), program.c_code
+	assert !program.c_code.contains('struct sockaddr_in6 {\n\tu16 sin6_family;\n\tu16 sin6_port;\n\tu32 sin6_addr[4];'), program.c_code
+	assert program.c_code.contains('#define FLT_EPSILON 1.19209290e-7F'), program.c_code
+	assert program.c_code.contains('#define DBL_EPSILON 2.2204460492503131e-16'), program.c_code
+	assert program.c_code.contains('#define FLT_MAX __FLT_MAX__'), program.c_code
+	assert program.c_code.contains('#define DBL_MAX __DBL_MAX__'), program.c_code
+	assert program.c_code.contains('#define KEY_EVENT 0x0001'), program.c_code
+	assert program.c_code.contains('#define MOUSE_MOVED 0x0001'), program.c_code
+	assert program.c_code.contains('#define DOUBLE_CLICK 0x0002'), program.c_code
+	assert program.c_code.contains('#define MOUSE_WHEELED 0x0004'), program.c_code
+	assert program.c_code.contains('#define VK_BACK 0x08'), program.c_code
+	assert program.c_code.contains('#define VK_RETURN 0x0d'), program.c_code
+	assert program.c_code.contains('struct timeval { long tv_sec; long tv_usec; };'), program.c_code
+	assert program.c_code.contains('typedef struct timeval timeval;'), program.c_code
+	assert program.c_code.contains('struct rusage { struct timeval ru_utime; struct timeval ru_stime; long ru_maxrss; long ru_ixrss; long ru_idrss;'), program.c_code
+	assert !program.c_code.contains('u64 tv_sec;'), program.c_code
+	assert program.c_code.contains('struct timespec { i64 tv_sec; long tv_nsec; };'), program.c_code
+	assert program.c_code.contains('struct timespec { long tv_sec; long tv_nsec; };'), program.c_code
+	assert program.c_code.contains('typedef struct timespec timespec;'), program.c_code
+	assert !program.c_code.contains('struct timespec {\n\ttv_sec'), program.c_code
+	assert program.c_code.contains('#define F_GETFL 3'), program.c_code
+	assert program.c_code.contains('#define F_SETFL 4'), program.c_code
+	assert program.c_code.contains('#define SOCK_STREAM 1'), program.c_code
+	assert program.c_code.contains('#define AF_INET 2'), program.c_code
+	assert program.c_code.contains('#define SOL_SOCKET'), program.c_code
+	assert program.c_code.contains('#define EV_SET(kevp, a, b, c, d, e, f) do'), program.c_code
+	assert program.c_code.contains('#define EVFILT_READ (-1)'), program.c_code
+	assert program.c_code.contains('#define EVFILT_MACHPORT (-8)'), program.c_code
+	assert program.c_code.contains('#define EV_ADD 0x0001'), program.c_code
+	assert program.c_code.contains('#define EV_CLEAR 0x0020'), program.c_code
+	assert program.c_code.contains('#define EV_ERROR 0x4000'), program.c_code
+	assert program.c_code.contains('#elif defined(__FreeBSD__)'), program.c_code
+	assert program.c_code.contains('#define O_CLOEXEC 0x00100000'), program.c_code
+	assert program.c_code.contains('#define F_SETLK 12'), program.c_code
+	assert program.c_code.contains('#define AF_INET6 28'), program.c_code
+	assert program.c_code.contains('#elif defined(__OpenBSD__)'), program.c_code
+	assert program.c_code.contains('#define O_CLOEXEC 0x10000'), program.c_code
+	assert program.c_code.contains('#define AF_INET6 24'), program.c_code
+	assert program.c_code.contains('#elif defined(__sun)'), program.c_code
+	assert program.c_code.contains('#define O_NONBLOCK 0x80'), program.c_code
+	assert program.c_code.contains('#define SOCK_STREAM 2'), program.c_code
+	assert program.c_code.contains('#define AI_PASSIVE 0x0008'), program.c_code
+	assert program.c_code.contains('#elif defined(__QNX__) || defined(__QNXNTO__)'), program.c_code
+
+	assert program.c_code.contains('#define O_NONBLOCK 000200'), program.c_code
+	assert program.c_code.contains('#define EINPROGRESS 236'), program.c_code
+	assert program.c_code.contains('#elif defined(__linux__) || defined(__ANDROID__)'), program.c_code
+	assert program.c_code.contains('#define EPOLLIN 0x001'), program.c_code
+	assert program.c_code.contains('#define EPOLLET (1U << 31)'), program.c_code
+	assert program.c_code.contains('#define EPOLL_CTL_ADD 1'), program.c_code
+
+	assert program.c_code.contains('#error unsupported headerless C platform constants'), program.c_code
+
+	assert program.c_code.contains('#define TCP_NODELAY 1'), program.c_code
+	run := os.execute(program.out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'true\ntrue\ntrue', run.output
 }

--- a/vlib/v3/tests/prod_flag_test.v
+++ b/vlib/v3/tests/prod_flag_test.v
@@ -41,8 +41,8 @@ fn test_c99_flag_uses_c99_c_compile_mode() {
 	assert run.output.trim_space() == 'hello world'
 }
 
-// test_c99_flag_emits_linux_feature_macros_before_includes validates this v3 regression case.
-fn test_c99_flag_emits_linux_feature_macros_before_includes() {
+// test_c99_flag_emits_linux_feature_macros_in_headerless_preamble validates this v3 regression case.
+fn test_c99_flag_emits_linux_feature_macros_in_headerless_preamble() {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_c99_feature_macro_test')
 	build := os.execute('${vexe} -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0, build.output
@@ -54,23 +54,24 @@ fn test_c99_flag_emits_linux_feature_macros_before_includes() {
 	c_code := os.read_file(out_c) or { panic(err) }
 	gnu_idx := c_code.index('#define _GNU_SOURCE') or { -1 }
 	posix_idx := c_code.index('#define _POSIX_C_SOURCE 200809L') or { -1 }
-	include_idx := c_code.index('#include <stdio.h>') or { -1 }
+	typedef_idx := c_code.index('typedef signed char i8;') or { -1 }
 	assert gnu_idx >= 0, c_code[..200]
 	assert posix_idx >= 0, c_code[..200]
-	assert include_idx >= 0, c_code[..200]
-	assert gnu_idx < include_idx, c_code[..200]
-	assert posix_idx < include_idx, c_code[..200]
+	assert typedef_idx >= 0, c_code[..200]
+	assert gnu_idx < typedef_idx, c_code[..200]
+	assert posix_idx < typedef_idx, c_code[..200]
+	assert !c_code.contains('#include'), c_code[..200]
 }
 
-// test_c99_flag_preserves_stdatomic_header validates this v3 regression case.
-fn test_c99_flag_preserves_stdatomic_header() {
+// test_c99_flag_uses_headerless_stdatomic_fallback validates this v3 regression case.
+fn test_c99_flag_uses_headerless_stdatomic_fallback() {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_c99_stdatomic_test')
 	build := os.execute('${vexe} -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0, build.output
 
 	src := os.join_path(os.temp_dir(), 'v3_c99_stdatomic_swap.v')
 	os.write_file(src,
-		"import sync.stdatomic\n\nfn main() {\n\tmut x := u64(1)\n\told := C.atomic_exchange_u64(voidptr(&x), u64(7))\n\tassert old == u64(1)\n\tassert x == u64(7)\n\tprintln('atomic exchange ok')\n}\n") or {
+		"import sync.stdatomic\n\nfn main() {\n\tmut b := u8(1)\n\told_b_add := C.atomic_fetch_add_byte(voidptr(&b), u8(2))\n\tassert old_b_add == u8(1)\n\tassert b == u8(3)\n\told_b_sub := C.atomic_fetch_sub_byte(voidptr(&b), u8(1))\n\tassert old_b_sub == u8(3)\n\tassert b == u8(2)\n\n\tmut h := u16(10)\n\told_h_add := C.atomic_fetch_add_u16(voidptr(&h), u16(4))\n\tassert old_h_add == u16(10)\n\told_h_sub := C.atomic_fetch_sub_u16(voidptr(&h), u16(3))\n\tassert old_h_sub == u16(14)\n\tassert h == u16(11)\n\n\tmut w := u32(20)\n\told_w_sub := C.atomic_fetch_sub_u32(voidptr(&w), u32(5))\n\tassert old_w_sub == u32(20)\n\tassert w == u32(15)\n\n\tmut x := u64(1)\n\told := C.atomic_exchange_u64(voidptr(&x), u64(7))\n\tassert old == u64(1)\n\tassert x == u64(7)\n\tmut expected := u64(7)\n\tassert C.atomic_compare_exchange_strong_u64(voidptr(&x), &expected, u64(9))\n\tassert x == u64(9)\n\tprintln('atomic helpers ok')\n}\n") or {
 		panic(err)
 	}
 
@@ -81,11 +82,11 @@ fn test_c99_flag_preserves_stdatomic_header() {
 
 	run := os.execute(out_bin)
 	assert run.exit_code == 0, run.output
-	assert run.output.trim_space() == 'atomic exchange ok'
+	assert run.output.trim_space() == 'atomic helpers ok'
 }
 
-// test_c99_flag_system_stdatomic_include_suppresses_fallback_typedef validates this v3 regression case.
-fn test_c99_flag_system_stdatomic_include_suppresses_fallback_typedef() {
+// test_c99_flag_system_stdatomic_include_is_headerless validates this v3 regression case.
+fn test_c99_flag_system_stdatomic_include_is_headerless() {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_c99_system_stdatomic_test')
 	build := os.execute('${vexe} -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0, build.output
@@ -100,9 +101,16 @@ fn test_c99_flag_system_stdatomic_include_suppresses_fallback_typedef() {
 	gen_c := os.execute('${v3_bin} -c99 ${src} -o ${out_c}')
 	assert gen_c.exit_code == 0, gen_c.output
 	c_code := os.read_file(out_c) or { panic(err) }
-	assert c_code.contains('#include <stdatomic.h>'), c_code
+	assert !c_code.contains('#include'), c_code
 	assert !c_code.contains('typedef volatile uintptr_t atomic_uintptr_t;'), c_code
+	assert c_code.contains('typedef void* atomic_uintptr_t;'), c_code
+	assert c_code.contains('static inline byte atomic_fetch_add_byte'), c_code
+	assert c_code.contains('static inline u16 atomic_fetch_add_u16'), c_code
 	assert c_code.contains('static inline u64 atomic_fetch_add_u64'), c_code
+	assert c_code.contains('static inline u16 atomic_fetch_sub_u16'), c_code
+	assert c_code.contains('static inline u32 atomic_fetch_sub_u32'), c_code
+	assert c_code.contains('static inline u64 atomic_exchange_u64'), c_code
+	assert c_code.contains('static inline bool atomic_compare_exchange_strong_u64'), c_code
 
 	out_bin := os.join_path(os.temp_dir(), 'v3_c99_system_stdatomic')
 	compile := os.execute('${v3_bin} -prod -c99 ${src} -o ${out_bin}')

--- a/vlib/v3/tests/spawn_args_test.v
+++ b/vlib/v3/tests/spawn_args_test.v
@@ -22,6 +22,14 @@ fn gen_c(v3_bin string, name string, src string) string {
 	return os.read_file(c_out) or { '' }
 }
 
+fn assert_spawn_pthread_decls(c_code string) {
+	assert c_code.contains('i32 pthread_attr_init(void* attr);'), c_code
+	assert c_code.contains('i32 pthread_attr_setstacksize(void* attr, size_t stacksize);'), c_code
+	assert c_code.contains('i32 pthread_create(void* thread, void* attr, void* start_routine, void* arg);'), c_code
+	assert c_code.contains('i32 pthread_attr_destroy(void* attr);'), c_code
+	assert c_code.contains('i32 pthread_join(void* thread, void* retval);'), c_code
+}
+
 // A `spawn` of a free function with arguments must pack the arguments into a heap
 // struct and run the real function through a wrapper, instead of emitting a
 // `(void*)0` no-op that silently drops the call and its arguments.
@@ -45,6 +53,7 @@ fn main() {
 ')
 	assert c_code.contains('add_thread_args'), c_code
 	assert c_code.contains('pthread_create'), c_code
+	assert_spawn_pthread_decls(c_code)
 	assert c_code.contains('add(p->a0, p->a1, p->a2)'), c_code
 }
 

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -1,4 +1,5 @@
 import os
+import rand
 
 const vexe = @VEXE
 const tests_dir = os.dir(@FILE)
@@ -8,14 +9,15 @@ const v3_src = os.join_path(v3_dir, 'v3.v')
 
 // build_v3 builds v3 data for v3 tests.
 fn build_v3() string {
-	v3_bin := tmp_test_path('type_checker_errors_test')
+	v3_bin := os.join_path(os.temp_dir(),
+		'v3_type_checker_errors_test_${os.getpid()}_${rand.ulid()}')
 	build := os.execute('${vexe} -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0
 	return v3_bin
 }
 
-fn tmp_test_path(name string) string {
-	return os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+fn unique_temp_path(name string) string {
+	return os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}_${rand.ulid()}')
 }
 
 // run_bad supports run bad handling for v3 tests.
@@ -28,9 +30,10 @@ fn run_bad_selfhost(v3_bin string, name string, src string, expected string) {
 }
 
 fn run_bad_with_flags(v3_bin string, name string, src string, expected string, flags string) {
-	bad_src := '${tmp_test_path(name)}.v'
+	out := unique_temp_path(name)
+	bad_src := out + '.v'
 	os.write_file(bad_src, src) or { panic(err) }
-	bad_bin := tmp_test_path(name)
+	bad_bin := out
 	result := os.execute('${v3_bin} ${bad_src} ${flags} -b c -o ${bad_bin}')
 	assert result.exit_code != 0
 	assert result.output.contains(expected)
@@ -39,9 +42,10 @@ fn run_bad_with_flags(v3_bin string, name string, src string, expected string, f
 
 // run_good supports run good handling for v3 tests.
 fn run_good(v3_bin string, name string, src string) string {
-	good_src := '${tmp_test_path(name)}.v'
+	out := unique_temp_path(name)
+	good_src := out + '.v'
 	os.write_file(good_src, src) or { panic(err) }
-	good_bin := tmp_test_path(name)
+	good_bin := out
 	compile := os.execute('${v3_bin} ${good_src} -b c -o ${good_bin}')
 	assert compile.exit_code == 0, '${name}: compile failed: ${compile.output}'
 	assert !compile.output.contains('C compilation failed'), '${name}: C compilation failed: ${compile.output}'
@@ -59,7 +63,7 @@ fn write_project_file(root string, rel string, src string) {
 
 // run_bad_project supports run bad project handling for v3 tests.
 fn run_bad_project(v3_bin string, name string, files map[string]string, input string, expected string) {
-	root := '${tmp_test_path(name)}_project'
+	root := unique_temp_path('${name}_project')
 	if os.exists(root) {
 		os.rmdir_all(root) or { panic(err) }
 	}
@@ -68,7 +72,7 @@ fn run_bad_project(v3_bin string, name string, files map[string]string, input st
 		write_project_file(root, rel, src)
 	}
 	input_path := if input.len == 0 { root } else { os.join_path(root, input) }
-	bad_bin := tmp_test_path(name)
+	bad_bin := unique_temp_path(name)
 	result := os.execute('${v3_bin} ${input_path} -b c -o ${bad_bin}')
 	assert result.exit_code != 0
 	assert result.output.contains(expected)
@@ -77,7 +81,7 @@ fn run_bad_project(v3_bin string, name string, files map[string]string, input st
 
 // run_good_project supports run good project handling for v3 tests.
 fn run_good_project(v3_bin string, name string, files map[string]string, input string) string {
-	root := '${tmp_test_path(name)}_project'
+	root := unique_temp_path('${name}_project')
 	if os.exists(root) {
 		os.rmdir_all(root) or { panic(err) }
 	}
@@ -86,7 +90,7 @@ fn run_good_project(v3_bin string, name string, files map[string]string, input s
 		write_project_file(root, rel, src)
 	}
 	input_path := if input.len == 0 { root } else { os.join_path(root, input) }
-	good_bin := tmp_test_path(name)
+	good_bin := unique_temp_path(name)
 	compile := os.execute('${v3_bin} ${input_path} -b c -o ${good_bin}')
 	assert compile.exit_code == 0, '${name}: compile failed: ${compile.output}'
 	assert !compile.output.contains('C compilation failed'), '${name}: C compilation failed: ${compile.output}'
@@ -97,7 +101,7 @@ fn run_good_project(v3_bin string, name string, files map[string]string, input s
 
 // gen_c_project emits c project output for v3 tests.
 fn gen_c_project(v3_bin string, name string, files map[string]string, input string) string {
-	root := '${tmp_test_path(name)}_project'
+	root := unique_temp_path('${name}_project')
 	if os.exists(root) {
 		os.rmdir_all(root) or { panic(err) }
 	}
@@ -106,7 +110,7 @@ fn gen_c_project(v3_bin string, name string, files map[string]string, input stri
 		write_project_file(root, rel, src)
 	}
 	input_path := if input.len == 0 { root } else { os.join_path(root, input) }
-	c_out := '${tmp_test_path(name)}.c'
+	c_out := unique_temp_path(name) + '.c'
 	os.rm(c_out) or {}
 	compile := os.execute('${v3_bin} ${input_path} -o ${c_out}')
 	assert compile.exit_code == 0

--- a/vlib/v3/tests/union_byte_contains_codegen_test.v
+++ b/vlib/v3/tests/union_byte_contains_codegen_test.v
@@ -31,6 +31,6 @@ fn run_good(v3_bin string, name string, source string) string {
 fn test_union_aliasing_and_byte_array_contains_codegen() {
 	v3_bin := build_v3()
 	out := run_good(v3_bin, 'union_byte_contains_codegen_input',
-		"union Bits {\nmut:\n\tf f64\n\tu u64\n}\n\nfn main() {\n\tmut u := Bits{}\n\tu.f = 12.5\n\tif u.u != u64(0) {\n\t\tprintln('union ok')\n\t} else {\n\t\tprintln('union bad')\n\t}\n\tmut bytes := []u8{len: 4, init: 0}\n\tbytes[1] = `.`\n\tif `.` in bytes {\n\t\tprintln('byte contains ok')\n\t} else {\n\t\tprintln('byte contains bad')\n\t}\n\tprintln('${12.5}')\n}\n")
+		"union Bits {\nmut:\n\tf f64\n\tu u64\n}\n\nfn main() {\n\tmut u := Bits{}\n\tu.f = 12.5\n\tif u.u != u64(0) {\n\t\tprintln('union ok')\n\t} else {\n\t\tprintln('union bad')\n\t}\n\tmut bytes := []u8{len: 4, init: 0}\n\tbytes[1] = `.`\n\tif `.` in bytes {\n\t\tprintln('byte contains ok')\n\t} else {\n\t\tprintln('byte contains bad')\n\t}\n\tprintln(12.5.str())\n}\n")
 	assert out == 'union ok\nbyte contains ok\n12.5'
 }

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -59,6 +59,69 @@ fn (t &Transformer) resolve_call_name(node flat.Node) string {
 	}
 }
 
+fn (t &Transformer) local_fn_decl_return_type(name string) ?string {
+	if name.len == 0 {
+		return none
+	}
+	mut cur_module := ''
+	for node in t.a.nodes {
+		match node.kind {
+			.file {
+				cur_module = ''
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.fn_decl {
+				if node.value == name && transform_same_module(cur_module, t.cur_module) {
+					return node.typ
+				}
+			}
+			else {}
+		}
+	}
+	return none
+}
+
+fn (t &Transformer) local_fn_value_return_type(name string) ?string {
+	typ := t.normalize_type_alias(t.var_type(name))
+	return fn_type_return_type_text(typ)
+}
+
+fn fn_type_return_type_text(typ string) ?string {
+	clean := typ.trim_space()
+	if !(clean.starts_with('fn(') || clean.starts_with('fn (')) {
+		return none
+	}
+	open_idx := clean.index_u8(`(`)
+	if open_idx < 0 {
+		return none
+	}
+	mut depth := 0
+	for i in open_idx .. clean.len {
+		if clean[i] == `(` {
+			depth++
+		} else if clean[i] == `)` {
+			depth--
+			if depth == 0 {
+				ret := clean[i + 1..].trim_space()
+				if ret.len == 0 {
+					return 'void'
+				}
+				return ret
+			}
+		}
+	}
+	return none
+}
+
+fn transform_same_module(a string, b string) bool {
+	if a == b {
+		return true
+	}
+	return a in ['', 'main'] && b in ['', 'main']
+}
+
 // is_known_fn_name reports whether is known fn name applies in transform.
 fn (t &Transformer) is_known_fn_name(name string) bool {
 	if name in t.fn_ret_types {
@@ -3411,6 +3474,16 @@ fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string 
 	}
 	if node.children_count > 0 {
 		fn_node := t.a.child_node(&node, 0)
+		if fn_node.kind == .ident {
+			if ret := t.local_fn_value_return_type(fn_node.value) {
+				return t.call_return_type_name(ret, node)
+			}
+			if t.var_type(fn_node.value).len == 0 {
+				if ret := t.local_fn_decl_return_type(fn_node.value) {
+					return t.call_return_type_name(ret, node)
+				}
+			}
+		}
 		if fn_node.kind == .selector && fn_node.value in ['clone', 'reverse']
 			&& fn_node.children_count > 0 {
 			base_id := t.a.child(fn_node, 0)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -6137,8 +6137,18 @@ fn (t &Transformer) resolve_expr_type(id flat.NodeId) string {
 }
 
 fn (t &Transformer) current_call_return_type(node flat.Node) string {
-	if t.is_local_fn_value_call(node) {
-		return ''
+	if node.children_count > 0 {
+		fn_node := t.a.child_node(&node, 0)
+		if fn_node.kind == .ident {
+			if ret := t.local_fn_value_return_type(fn_node.value) {
+				return t.call_return_type_name(ret, node)
+			}
+			if t.var_type(fn_node.value).len == 0 {
+				if ret := t.local_fn_decl_return_type(fn_node.value) {
+					return t.call_return_type_name(ret, node)
+				}
+			}
+		}
 	}
 	name := t.resolve_call_name(node)
 	if name.len == 0 {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -3839,6 +3839,34 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 				params_known: true
 			}
 		}
+		if clean is Map {
+			if fn_node.value == 'keys' {
+				return CallInfo{
+					name:         'map.keys'
+					params:       tarr1(base_type)
+					return_type:  Type(Array{
+						elem_type: clean.key_type
+					})
+					has_receiver: true
+					params_known: true
+				}
+			}
+			if fn_node.value == 'values' {
+				return CallInfo{
+					name:         'map.values'
+					params:       tarr1(base_type)
+					return_type:  Type(Array{
+						elem_type: clean.value_type
+					})
+					has_receiver: true
+					params_known: true
+				}
+			}
+			map_method := 'map.${fn_node.value}'
+			if map_method in tc.fn_ret_types {
+				return tc.call_info(map_method, true)
+			}
+		}
 		if clean is Array {
 			match fn_node.value {
 				'first', 'last', 'pop' {
@@ -8756,6 +8784,12 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 						return Type(Array{
 							elem_type: clean_type.value_type
 						})
+					}
+					map_mname := 'map.${fn_node.value}'
+					if map_mname in tc.fn_ret_types {
+						return tc.fn_ret_types[map_mname] or {
+							unknown_type('unknown return type for `${map_mname}`')
+						}
 					}
 					return unknown_type('unknown map method `${fn_node.value}`')
 				}


### PR DESCRIPTION
## Summary
- make the v3 C backend headerless by emitting ABI/libc declarations instead of generated `#include` lines
- add/consume opaque `fn C.*` declarations for libc/POSIX calls and Darwin stat layout needed by v3 self-hosting
- address review regressions: platform-specific `termios`, source-relative/`@DIR`/nested local header inlining, anonymous typedef structs, inlined headers before generated C extern prototypes, used user `fn C.*` extern prototypes, callback-typed and uppercase C prototypes, glibc `errno` TLS accessor, aligned opaque pthread objects, functional Unix filelock helpers/constants, early helper prototypes like `close`, `C.pthread_t` predecl skipping, platform `struct stat`/`utsname` layouts, and `stdint.h` replacements for inlined headers
- address latest review regressions: gate Linux `struct stat` by supported arch layout, add Windows constants and `LockFileEx`/`UnlockFileEx` range-lock helpers, respect local function-value shadowing when inferring call return types, emit Windows CRT underscore prototypes, and provide headerless Unix/Windows net socket constants
- address newest review regressions: keep `C.tm` and `C.addrinfo` on headerless libc-shaped layouts, add MSVC sized typedef branches, define `SYS_gettid` for supported Linux arch layouts without `__NR_gettid`, suppress extern redeclarations for multiline `static inline` local header functions, use Winsock-shaped `fd_set` on Windows, and keep Windows `wchar_t` 16-bit
- address final review regressions: emit the full stdatomic helper fallback set while suppressing duplicate extern redeclarations, emit inlined C headers before generated type declarations, provide a headerless `C.timeval` layout, and split `termios` layouts for BSD/Solaris/QNX targets
- keep remaining C-owned structs headerless-owned: `dirent`, `statvfs`, `sigset_t`, `SRWLOCK`, and `CONDITION_VARIABLE`, and add platform signal constants for process/signal APIs
- resolve project includes through collected `#flag -I` directories without emitting includes, including nested angle-form project headers like vschannel, and use the Windows CRT `_errno()` accessor for `C.errno`
- preserve builtin `map` receiver lookup/marking with the plain `map.*` fallback while keeping typed `keys`/`values` returns, and record aliases for tagged typedef structs from inlined headers
- add headerless socket address layouts, float epsilon constants, and Windows console event/virtual-key constants
- fix v3 regressions exposed by the headerless path: stdatomic exchange helpers, array membership codegen, map receiver reachability, integer `<<=`, and temp-path collisions in `test_all.vsh`

## Testing
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w vlib/v3/gen/c/cleanc.v vlib/v3/gen/c/fn.v vlib/v3/gen/c/struct.v vlib/v3/markused/markused.v vlib/v3/transform/fn.v vlib/v3/transform/transform.v vlib/v3/types/checker.v vlib/v3/tests/c_anonymous_param_codegen_test.v vlib/v3/tests/c_directive_order_codegen_test.v vlib/v3/tests/fn_value_decl_type_test.v vlib/v3/tests/gettid_libc_compat_codegen_test.v vlib/v3/tests/markused_typed_receiver_codegen_test.v vlib/v3/tests/parallel_cgen_test.v vlib/v3/tests/posix_wait_header_codegen_test.v vlib/v3/tests/prod_flag_test.v`
- `./vnew -silent vlib/v3/tests/c_anonymous_param_codegen_test.v`
- `./vnew -silent vlib/v3/tests/c_directive_order_codegen_test.v`
- `./vnew -silent vlib/v3/tests/posix_wait_header_codegen_test.v`
- `./vnew test vlib/v3/tests/posix_wait_header_codegen_test.v`
- `./vnew -silent vlib/v3/tests/gettid_libc_compat_codegen_test.v`
- `./vnew -silent vlib/v3/tests/fn_value_decl_type_test.v`
- `./vnew -silent vlib/v3/tests/current_module_call_return_codegen_test.v`
- `./vnew -silent vlib/v3/tests/c_callback_const_qualifier_codegen_test.v`
- `./vnew -silent vlib/v3/tests/markused_test.v`
- `./vnew -silent vlib/v3/tests/markused_typed_receiver_codegen_test.v`
- `./vnew -silent vlib/v3/tests/prod_flag_test.v`
- `./vnew -silent vlib/v3/tests/parallel_cgen_test.v`
- `./vnew -silent test vlib/v3/tests/`
- `/tmp/v3_phase6_review_check vlib/v3/tests/test_all_lang_features.v -b c -o /tmp/v3_phase6_review_lang && /tmp/v3_phase6_review_lang`
- `TMPDIR=$(mktemp -d /tmp/v5_v3_test_all.XXXXXX) ./vnew vlib/v3/test_all.vsh`
- `git diff --check`
- `rg -n '^\s*#include\b' /tmp/v3_phase6_review_lang.c || true` (no matches)
- `rg -n "#include|include <|include \"|writeln\\('.*include|write\\('.*include" vlib/v3/gen/c || true` (no matches)