### PR TITLE
gg: fix X11 C aliases for gg import

### DIFF
--- a/vlib/sokol/sapp/sapp_linux.c.v
+++ b/vlib/sokol/sapp/sapp_linux.c.v
@@ -461,6 +461,17 @@ const map_private = 2
 #include <X11/extensions/XInput2.h>
 #include <X11/Xcursor/Xcursor.h>
 
+// X11 C typedefs are unsigned long based. Define them locally so V1 can
+// type-check scalar operations while keeping the public aliases C-backed.
+pub type C.XID = usize
+pub type C.Atom = C.XID
+pub type C.Window = C.XID
+pub type C.Colormap = C.XID
+pub type C.Cursor = C.XID
+pub type C.KeySym = C.XID
+pub type C.Time = C.XID
+pub type C.VisualID = C.XID
+
 // X11 types
 pub type XID = C.XID
 pub type Atom = C.Atom
@@ -914,6 +925,9 @@ fn C.strncmp(s1 &char, s2 &char, n usize) int
 const x_false = 0
 const x_true = 1
 const x_none = Atom(0)
+const x_window_none = Window(0)
+const x_colormap_none = Colormap(0)
+const x_cursor_none = Cursor(0)
 const xa_atom = Atom(4)
 const xa_cardinal = Atom(6)
 const alloc_none = 0

--- a/vlib/sokol/sapp/sapp_x11_linux.v
+++ b/vlib/sokol/sapp/sapp_x11_linux.v
@@ -967,22 +967,24 @@ fn x11_query_system_dpi() {
 // === Keysym to unicode ===
 
 fn x11_keysym_to_unicode(keysym KeySym) i32 {
+	keysym_value := u64(keysym)
 	// Latin-1 characters (1:1 mapping)
-	if (keysym >= 0x0020 && keysym <= 0x007e) || (keysym >= 0x00a0 && keysym <= 0x00ff) {
-		return i32(keysym)
+	if (keysym_value >= 0x0020 && keysym_value <= 0x007e)
+		|| (keysym_value >= 0x00a0 && keysym_value <= 0x00ff) {
+		return i32(keysym_value)
 	}
 	// Directly encoded 24-bit UCS characters
-	if (keysym & 0xff000000) == 0x01000000 {
-		return i32(keysym & 0x00ffffff)
+	if (keysym_value & 0xff000000) == 0x01000000 {
+		return i32(keysym_value & 0x00ffffff)
 	}
 	// Binary search in table
 	mut min := 0
 	mut max := x11_keysymtab.len - 1
 	for max >= min {
 		mid := (min + max) / 2
-		if u64(x11_keysymtab[mid].keysym) < keysym {
+		if u64(x11_keysymtab[mid].keysym) < keysym_value {
 			min = mid + 1
-		} else if u64(x11_keysymtab[mid].keysym) > keysym {
+		} else if u64(x11_keysymtab[mid].keysym) > keysym_value {
 			max = mid - 1
 		} else {
 			return i32(x11_keysymtab[mid].ucs)
@@ -1090,7 +1092,7 @@ pub fn set_resizable(resizable bool) {
 }
 
 fn x11_set_resizable(resizable bool) {
-	if g_sapp_state.x11.display == unsafe { nil } || g_sapp_state.x11.window == 0 {
+	if g_sapp_state.x11.display == unsafe { nil } || g_sapp_state.x11.window == x_window_none {
 		return
 	}
 	mut hints := C.XAllocSizeHints()
@@ -1144,7 +1146,7 @@ fn x11_create_window(visual_ &C.Visual, depth int) {
 	g_sapp_state.x11.window = C.XCreateWindow(g_sapp_state.x11.display, g_sapp_state.x11.root, 0,
 		0, u32(x11_window_width), u32(x11_window_height), 0, dep, input_output, vis, wamask, &wa)
 	x11_release_error_handler()
-	if g_sapp_state.x11.window == 0 {
+	if g_sapp_state.x11.window == x_window_none {
 		eprintln('sokol_app: X11: failed to create window')
 		return
 	}
@@ -1168,14 +1170,14 @@ fn x11_create_window(visual_ &C.Visual, depth int) {
 }
 
 fn x11_destroy_window() {
-	if g_sapp_state.x11.window != 0 {
+	if g_sapp_state.x11.window != x_window_none {
 		C.XUnmapWindow(g_sapp_state.x11.display, g_sapp_state.x11.window)
 		C.XDestroyWindow(g_sapp_state.x11.display, g_sapp_state.x11.window)
-		g_sapp_state.x11.window = 0
+		g_sapp_state.x11.window = x_window_none
 	}
-	if g_sapp_state.x11.colormap != 0 {
+	if g_sapp_state.x11.colormap != x_colormap_none {
 		C.XFreeColormap(g_sapp_state.x11.display, g_sapp_state.x11.colormap)
-		g_sapp_state.x11.colormap = 0
+		g_sapp_state.x11.colormap = x_colormap_none
 	}
 	C.XFlush(g_sapp_state.x11.display)
 }
@@ -1233,7 +1235,7 @@ fn x11_create_standard_cursor(cursor MouseCursor, name &char, theme &char, size 
 			C.XcursorImageDestroy(img)
 		}
 	}
-	if g_sapp_state.x11.standard_cursors[idx] == 0 && fallback_native != 0 {
+	if g_sapp_state.x11.standard_cursors[idx] == x_cursor_none && fallback_native != 0 {
 		g_sapp_state.x11.standard_cursors[idx] = C.XCreateFontCursor(g_sapp_state.x11.display,
 			fallback_native)
 	}
@@ -1256,14 +1258,14 @@ fn x11_create_standard_cursors() {
 }
 
 fn x11_destroy_standard_cursors() {
-	if g_sapp_state.x11.hidden_cursor != 0 {
+	if g_sapp_state.x11.hidden_cursor != x_cursor_none {
 		C.XFreeCursor(g_sapp_state.x11.display, g_sapp_state.x11.hidden_cursor)
-		g_sapp_state.x11.hidden_cursor = 0
+		g_sapp_state.x11.hidden_cursor = x_cursor_none
 	}
 	for i in 0 .. mousecursor_num {
-		if g_sapp_state.x11.standard_cursors[i] != 0 {
+		if g_sapp_state.x11.standard_cursors[i] != x_cursor_none {
 			C.XFreeCursor(g_sapp_state.x11.display, g_sapp_state.x11.standard_cursors[i])
-			g_sapp_state.x11.standard_cursors[i] = 0
+			g_sapp_state.x11.standard_cursors[i] = x_cursor_none
 		}
 	}
 }
@@ -1279,10 +1281,10 @@ fn x11_update_cursor(cursor MouseCursor, shown bool) {
 	if shown {
 		if g_sapp_state.custom_cursor_bound[idx] {
 			xcursor := g_sapp_state.x11.custom_cursors[idx]
-			if xcursor != 0 {
+			if xcursor != x_cursor_none {
 				C.XDefineCursor(g_sapp_state.x11.display, g_sapp_state.x11.window, xcursor)
 			}
-		} else if g_sapp_state.x11.standard_cursors[idx] != 0 {
+		} else if g_sapp_state.x11.standard_cursors[idx] != x_cursor_none {
 			C.XDefineCursor(g_sapp_state.x11.display, g_sapp_state.x11.window,
 				g_sapp_state.x11.standard_cursors[idx])
 		} else {

--- a/vlib/v/tests/gg_import_check_test.v
+++ b/vlib/v/tests/gg_import_check_test.v
@@ -1,0 +1,21 @@
+import os
+
+const issue_27584_vexe = os.quoted_path(@VEXE)
+
+fn test_importing_gg_checks_cleanly_on_linux() {
+	$if !linux {
+		return
+	}
+	source_path := os.join_path(os.vtmp_dir(), 'issue_27584_import_gg_${os.getpid()}.v')
+	defer {
+		os.rm(source_path) or {}
+	}
+	os.write_file(source_path, 'module main
+
+import gg as _
+
+fn main() {}
+') or { panic(err) }
+	res := os.execute('${issue_27584_vexe} -os linux -check ${os.quoted_path(source_path)}')
+	assert res.exit_code == 0, res.output
+}


### PR DESCRIPTION
## Summary

Fix #27584 

This restores V1 compatibility for importing `gg` on Linux after the X11 Sokol aliases were changed to preserve C typedef names for V3.

The fix defines the missing X11 `C.*` scalar aliases locally, while keeping the public aliases backed by `C.XID`, `C.Atom`, `C.Window`, `C.KeySym`, etc. This lets V1 type-check the X11 scalar operations again without reverting the V3 C ABI work.

A focused regression test was added for the user-facing case: a minimal program importing `gg`.

## Validation

- `./v test vlib/v/tests/gg_import_check_test.v`
- `./v test vlib/v3/tests/x11_source_abi_alias_codegen_test.v`
- `./v fmt -verify vlib/sokol/sapp/sapp_linux.c.v vlib/sokol/sapp/sapp_x11_linux.v vlib/v/tests/project_issue_27584_gg_import_check_test.v`
- `./v -check vlib/v/tests/skip_unused/gg_code.vv`
- `./v test vlib/v/tests/fixed_array_update_c_struct_alias_test.v`
- `./v -silent test vlib/gg/`
- V1 `examples/tetris/tetris.v`: compile + short run
- V3/C `examples/tetris/tetris.v`: compile + short run