### PR TITLE
cgen: cover heap struct literals in ternaries

### DIFF
--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -286,6 +286,52 @@ fn test_comptime_for_empty_attrs_does_not_emit_new_array_calls() {
 	assert !compilation.output.contains('.args = builtin____new_array_with_default(0, 0, sizeof(FunctionParam), 0)')
 }
 
+fn assert_function_body_contains(output string, signature string, expected_lines []string) {
+	assert output.contains(signature), 'missing generated function: ${signature}'
+	body := output.all_after(signature).all_before('\n}')
+	for expected_line in expected_lines {
+		assert body.contains(expected_line), 'missing expected C line in ${signature}: ${expected_line}'
+	}
+}
+
+fn test_heap_struct_init_order_ternary_helpers_have_branch_allocs() {
+	os.chdir(vroot) or {}
+	path := os.join_path(testdata_folder, 'heap_struct_init_order.vv')
+	relpath := vroot_relative(path)
+	if should_skip(relpath) {
+		return
+	}
+	file_options := get_file_options(path)
+	cmd := '${os.quoted_path(vexe)} -o - ${file_options.vflags} ${os.quoted_path(path)}'
+	compilation := os.execute(cmd)
+	ensure_compilation_succeeded(compilation, cmd)
+	alloc := '(main__Issue27329Object*)builtin___v_malloc(sizeof(main__Issue27329Object) == 0 ? 1 : sizeof(main__Issue27329Object));'
+	assert_function_body_contains(compilation.output,
+		'VV_LOC main__Issue27329Object* main__issue_27329_if_expr_assignment(bool flag) {', [
+		'main__Issue27329Object* _t1 = ${alloc}',
+		'_t1->ival = 4;',
+		'main__Issue27329Object* _t2 = ${alloc}',
+		'_t2->ival = 5;',
+		'main__Issue27329Object* object = (flag ? ( _t1) : ( _t2));',
+	])
+	assert_function_body_contains(compilation.output,
+		'VV_LOC main__Issue27329Object* main__issue_27329_if_expr_return(bool flag) {', [
+		'main__Issue27329Object* _t2 = ${alloc}',
+		'_t2->ival = 6;',
+		'main__Issue27329Object* _t3 = ${alloc}',
+		'_t3->ival = 7;',
+		'return (flag ? ( _t2) : ( _t3));',
+	])
+	assert_function_body_contains(compilation.output,
+		'VV_LOC main__Issue27329Object* main__issue_27329_match_expr(bool flag) {', [
+		'main__Issue27329Object* _t1 = ${alloc}',
+		'_t1->ival = 8;',
+		'main__Issue27329Object* _t2 = ${alloc}',
+		'_t2->ival = 9;',
+		'main__Issue27329Object* object = ((flag == (true))? ( _t1) : ( _t2));',
+	])
+}
+
 fn test_array_push_no_bounds_checking_keeps_max_len_panics() {
 	os.chdir(vroot) or {}
 	test_source := os.join_path(os.vtmp_dir(), 'coutput_array_push_no_bounds_checking.vv')

--- a/vlib/v/gen/c/testdata/heap_struct_init_order.c.must_have
+++ b/vlib/v/gen/c/testdata/heap_struct_init_order.c.must_have
@@ -5,4 +5,22 @@ builtin___v_malloc(sizeof(main__Issue27329Object) == 0 ? 1 : sizeof(main__Issue2
 volatile main__Issue27329Object*
 return builtin__new_array_from_c_array(3, 3, sizeof(main__Issue27329Object*)
 ->child = _t
+VV_LOC main__Issue27329Object* main__issue_27329_if_expr_assignment(bool flag) {
+main__Issue27329Object* _t1 = (main__Issue27329Object*)builtin___v_malloc(sizeof(main__Issue27329Object) == 0 ? 1 : sizeof(main__Issue27329Object));
+_t1->ival = 4;
+main__Issue27329Object* _t2 = (main__Issue27329Object*)builtin___v_malloc(sizeof(main__Issue27329Object) == 0 ? 1 : sizeof(main__Issue27329Object));
+_t2->ival = 5;
+main__Issue27329Object* object = (flag ? (
+VV_LOC main__Issue27329Object* main__issue_27329_if_expr_return(bool flag) {
+main__Issue27329Object* _t2 = (main__Issue27329Object*)builtin___v_malloc(sizeof(main__Issue27329Object) == 0 ? 1 : sizeof(main__Issue27329Object));
+_t2->ival = 6;
+main__Issue27329Object* _t3 = (main__Issue27329Object*)builtin___v_malloc(sizeof(main__Issue27329Object) == 0 ? 1 : sizeof(main__Issue27329Object));
+_t3->ival = 7;
+return (flag ? (
+VV_LOC main__Issue27329Object* main__issue_27329_match_expr(bool flag) {
+main__Issue27329Object* _t1 = (main__Issue27329Object*)builtin___v_malloc(sizeof(main__Issue27329Object) == 0 ? 1 : sizeof(main__Issue27329Object));
+_t1->ival = 8;
+main__Issue27329Object* _t2 = (main__Issue27329Object*)builtin___v_malloc(sizeof(main__Issue27329Object) == 0 ? 1 : sizeof(main__Issue27329Object));
+_t2->ival = 9;
+main__Issue27329Object* object = ((flag == (true))? (
 // THE END.

--- a/vlib/v/gen/c/testdata/heap_struct_init_order.vv
+++ b/vlib/v/gen/c/testdata/heap_struct_init_order.vv
@@ -57,13 +57,79 @@ fn issue_27329_nested() &Issue27329Object {
 	}
 }
 
+fn issue_27329_if_expr_assignment(flag bool) &Issue27329Object {
+	object := if flag {
+		&Issue27329Object{
+			kind:    issue_27329_kind_true
+			ival:    4
+			len_val: 0
+			child:   unsafe { nil }
+		}
+	} else {
+		&Issue27329Object{
+			kind:    issue_27329_kind_false
+			ival:    5
+			len_val: 0
+			child:   unsafe { nil }
+		}
+	}
+	return object
+}
+
+fn issue_27329_if_expr_return(flag bool) &Issue27329Object {
+	return if flag {
+		&Issue27329Object{
+			kind:    issue_27329_kind_true
+			ival:    6
+			len_val: 0
+			child:   unsafe { nil }
+		}
+	} else {
+		&Issue27329Object{
+			kind:    issue_27329_kind_false
+			ival:    7
+			len_val: 0
+			child:   unsafe { nil }
+		}
+	}
+}
+
+fn issue_27329_match_expr(flag bool) &Issue27329Object {
+	object := match flag {
+		true {
+			&Issue27329Object{
+				kind:    issue_27329_kind_true
+				ival:    8
+				len_val: 0
+				child:   unsafe { nil }
+			}
+		}
+		false {
+			&Issue27329Object{
+				kind:    issue_27329_kind_false
+				ival:    9
+				len_val: 0
+				child:   unsafe { nil }
+			}
+		}
+	}
+
+	return object
+}
+
 fn main() {
 	objects := issue_27329_objects()
 	nested := issue_27329_nested()
+	if_object := issue_27329_if_expr_assignment(true)
+	return_object := issue_27329_if_expr_return(false)
+	match_object := issue_27329_match_expr(true)
 	assert !objects[0].truthy()
 	assert objects[1].truthy()
 	assert objects[2].truthy()
 	assert nested.truthy()
 	assert !nested.child.truthy()
+	assert if_object.truthy()
+	assert !return_object.truthy()
+	assert match_object.truthy()
 	println('ok')
 }


### PR DESCRIPTION
## Summary
- extend the #27329 heap struct init fixture with all-field `&T{...}` literals in `if` assignment, returned `if`, and `match` expression branches
- add C-output checks that those ternary cases keep complete hoisted heap allocations before the branch expression

## Notes
#27349 fixed the stale statement-position bug for direct heap struct init hoists. The later issue comment isolated a ternary-shaped repro, so this adds coverage for that exact shape.

Fixes #27329

## Validation
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew run vlib/v/gen/c/testdata/heap_struct_init_order.vv`
- `VTEST_ONLY=heap_struct_init_order ./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
