### PR TITLE
builder: cover libbacktrace with tcc

### DIFF
--- a/vlib/v/builder/gc_flags_test.v
+++ b/vlib/v/builder/gc_flags_test.v
@@ -58,3 +58,71 @@ fn test_no_gc_thread_local_alloc_uses_source_libgc_without_tla_define() {
 	assert normalized.contains('-D GC_THREADS=1')
 	assert !normalized.contains('THREAD_LOCAL_ALLOC')
 }
+
+fn tcc_compiler_for_test() string {
+	bundled_tcc := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'tcc.exe')
+	if tcc_compiler_is_usable(bundled_tcc) {
+		return bundled_tcc
+	}
+	system_tcc := os.find_abs_path_of_executable('tcc') or { return '' }
+	if tcc_compiler_is_usable(system_tcc) {
+		return system_tcc
+	}
+	return ''
+}
+
+fn tcc_compiler_is_usable(tcc_path string) bool {
+	if tcc_path == '' || !os.is_file(tcc_path) || !os.is_executable(tcc_path) {
+		return false
+	}
+	probe := os.execute('${os.quoted_path(tcc_path)} -v')
+	return probe.exit_code == 0
+}
+
+fn tcc_can_compile_v_program(tcc_path string, test_dir string) bool {
+	exe_path := os.join_path(test_dir, 'tcc_probe')
+	source_path := os.join_path(@VEXEROOT, 'examples', 'hello_world.v')
+	res :=
+		execute_without_vflags('${os.quoted_path(@VEXE)} -cc ${os.quoted_path(tcc_path)} -gc none -no-retry-compilation -o ${os.quoted_path(exe_path)} ${os.quoted_path(source_path)}')
+	return res.exit_code == 0
+}
+
+fn test_tcc_use_libbacktrace_does_not_compile_libbacktrace() {
+	test_dir := os.join_path(os.vtmp_dir(), 'builder_use_libbacktrace_tcc_${os.getpid()}')
+	os.mkdir_all(test_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	tcc_path := tcc_compiler_for_test()
+	vmodules_path := os.join_path(test_dir, 'vmodules')
+	old_vmodules := os.getenv_opt('VMODULES')
+	old_vcache := os.getenv_opt('VCACHE')
+	os.setenv('VMODULES', vmodules_path, true)
+	os.setenv('VCACHE', os.join_path(vmodules_path, '.cache'), true)
+	defer {
+		if vcache := old_vcache {
+			os.setenv('VCACHE', vcache, true)
+		} else {
+			os.unsetenv('VCACHE')
+		}
+		if vmodules := old_vmodules {
+			os.setenv('VMODULES', vmodules, true)
+		} else {
+			os.unsetenv('VMODULES')
+		}
+	}
+	if tcc_path == '' || !tcc_can_compile_v_program(tcc_path, test_dir) {
+		return
+	}
+	source_path := os.join_path(test_dir, 'main.v')
+	exe_path := os.join_path(test_dir, 'main')
+	os.write_file(source_path, "fn main() {\n\tpanic('aaaa')\n}\n") or { panic(err) }
+
+	res :=
+		execute_without_vflags('${os.quoted_path(@VEXE)} -cc ${os.quoted_path(tcc_path)} -gc none -no-retry-compilation -d use_libbacktrace -d trace_thirdparty_obj_files -o ${os.quoted_path(exe_path)} ${os.quoted_path(source_path)}')
+
+	assert res.exit_code == 0, res.output
+	normalized := res.output.replace('\\', '/')
+	assert !normalized.contains('thirdparty/libbacktrace/backtrace'), res.output
+	assert !normalized.contains('Failed build_thirdparty_obj_file'), res.output
+}


### PR DESCRIPTION
## Summary
- add a regression test for `-cc tcc -d use_libbacktrace`
- run the compile in a fresh `VMODULES` cache and assert `thirdparty/libbacktrace/backtrace` is not collected or built
- this covers the open Linux/TCC failure in #27409; the runtime code path was already fixed by 099040e from #27417

Fixes #27409.

## Testing
- `./vnew vlib/v/builder/gc_flags_test.v`
- `./vnew -silent test vlib/v/builder/gc_flags_test.v`
- `./vnew -silent test vlib/v/builder/` (fails locally in pre-existing macOS/TCC cases: `vlib/v/builder/interpreterbuilder/v_interpret_test.v`; `vlib/v/builder/builder_test.v` space-in-path/codesign and 2048 Metal flag cases)