### PR TITLE
net.http: HTTP/2 server stream state machine (RFC 9113 §5.1/§6.1/§6.4)

### DIFF
--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -178,11 +178,23 @@ mut:
 	send_window    i64 = i64(h2_server_default_window)
 	streams        map[u32]&H2ServerStream
 	locally_reset  map[u32]bool // stream ids for which we sent RST_STREAM; drain in-flight frames per RFC 9113 §6.4
+	discard_block  []u8         // accumulates a HEADERS/CONTINUATION block for a locally-reset stream, decoded then discarded
 	last_stream_id u32
-	awaiting_cont  u32 // non-zero when mid-CONTINUATION on this stream
-	closing        bool
-	idle_conns     &TlsIdleConnTracker = unsafe { nil }
-	idle_handle    int
+	// last_processed_stream_id is the highest stream id the server has actually
+	// acted on (RFC 9113 §6.8), used for GOAWAY. Bumped in on_headers at stream
+	// creation — the same moment refused is decided — so it correctly includes a
+	// stream that's still mid-CONTINUATION (HPACK block not yet fully assembled)
+	// if some unrelated error forces a GOAWAY before finalize_headers ever runs.
+	// It excludes streams refused purely for exceeding the concurrency limit:
+	// §5.1.2 defines REFUSED_STREAM as refusal "prior to any processing", and that
+	// RST_STREAM already tells the client the stream is safe to retry elsewhere —
+	// counting it here would only inflate last_stream_id past streams whose
+	// outcome is genuinely uncertain.
+	last_processed_stream_id u32
+	awaiting_cont            u32 // non-zero when mid-CONTINUATION on this stream
+	closing                  bool
+	idle_conns               &TlsIdleConnTracker = unsafe { nil }
+	idle_handle              int
 }
 
 // H2StreamState is the server's view of a client-initiated stream for the
@@ -441,6 +453,11 @@ fn (mut c H2ServerConn) on_headers(frame H2HeadersFrame, mut handler Handler) ! 
 	// A HEADERS block for a stream that is already open is a trailer section
 	// (RFC 9113 §8.1), not a new request.
 	if mut existing := c.streams[frame.stream_id] {
+		// A fresh top-level HEADERS frame always starts a brand-new block (RFC
+		// 9113 §8.1); any bytes left in trailer_block are from a PRIOR, already-
+		// decoded trailer section and must not be redecoded — decode() mutates
+		// the dynamic table, so replaying old bytes desyncs it (RFC 7541 §2.2).
+		existing.trailer_block = []
 		if existing.end_stream {
 			// Half-closed (remote): the stream already delivered END_STREAM.
 			// The further HEADERS block is invalid (RFC 9113 §5.1, STREAM_CLOSED),
@@ -457,18 +474,29 @@ fn (mut c H2ServerConn) on_headers(frame H2HeadersFrame, mut handler Handler) ! 
 		c.on_trailers(mut existing, frame, mut handler)!
 		return
 	}
+	// A HEADERS frame for a stream we have already RST'd ourselves is a stray
+	// frame that was in flight before the client received our RST_STREAM (most
+	// likely a trailer block). The decoder is stateful and connection-wide (RFC
+	// 7541 §2.2), so the block must still be decoded to stay in sync — it is
+	// then discarded rather than run as a request (we already reset the stream).
+	if frame.stream_id in c.locally_reset {
+		c.discard_block = frame.fragment.clone()
+		if !frame.end_headers {
+			c.awaiting_cont = frame.stream_id
+			return
+		}
+		c.decoder.decode(c.discard_block) or {
+			c.send_goaway(.compression_error, 'HPACK decode error') or {}
+			return error('h2 server: HPACK decode error (COMPRESSION_ERROR)')
+		}
+		c.discard_block = []
+		return
+	}
 	// Stream ids from the client must be odd and strictly increasing.
 	if frame.stream_id & 1 == 0 || frame.stream_id <= c.last_stream_id {
 		return error('h2 server: invalid client stream id ${frame.stream_id}')
 	}
 	c.last_stream_id = frame.stream_id
-	// Prune locally_reset: TCP ordering guarantees all in-flight frames for
-	// streams below the new stream_id have already been delivered.
-	for id in c.locally_reset.keys() {
-		if id < frame.stream_id {
-			c.locally_reset.delete(id)
-		}
-	}
 	mut s := &H2ServerStream{
 		id:          frame.stream_id
 		hpack_block: frame.fragment.clone()
@@ -483,6 +511,8 @@ fn (mut c H2ServerConn) on_headers(frame H2HeadersFrame, mut handler Handler) ! 
 	// finalize_headers. The just-created stream is not yet counted in c.streams.
 	if u32(c.streams.len) >= h2_server_max_concurrent_streams {
 		s.refused = true
+	} else {
+		c.last_processed_stream_id = frame.stream_id
 	}
 	c.streams[frame.stream_id] = s
 	if !frame.end_headers {
@@ -494,6 +524,22 @@ fn (mut c H2ServerConn) on_headers(frame H2HeadersFrame, mut handler Handler) ! 
 
 fn (mut c H2ServerConn) on_continuation(frame H2ContinuationFrame, mut handler Handler) ! {
 	mut s := c.streams[frame.stream_id] or {
+		// Continuing a discard block for a stream we already RST'd (see on_headers).
+		if frame.stream_id in c.locally_reset {
+			if c.discard_block.len + frame.fragment.len > h2_max_recv_header_block {
+				return error('h2 server: discarded header block exceeds ${h2_max_recv_header_block} bytes')
+			}
+			c.discard_block << frame.fragment
+			if frame.end_headers {
+				c.awaiting_cont = 0
+				c.decoder.decode(c.discard_block) or {
+					c.send_goaway(.compression_error, 'HPACK decode error') or {}
+					return error('h2 server: HPACK decode error (COMPRESSION_ERROR)')
+				}
+				c.discard_block = []
+			}
+			return
+		}
 		return error('h2 server: CONTINUATION for unknown stream ${frame.stream_id}')
 	}
 	if s.in_trailers {
@@ -893,7 +939,7 @@ fn (mut c H2ServerConn) send_rst_stream(stream_id u32, code H2ErrorCode) ! {
 
 fn (mut c H2ServerConn) send_goaway(code H2ErrorCode, msg string) ! {
 	c.send_frame(H2GoawayFrame{
-		last_stream_id: c.last_stream_id
+		last_stream_id: c.last_processed_stream_id
 		error_code:     u32(code)
 		debug_data:     msg.bytes()
 	})!

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -163,6 +163,7 @@ mut:
 	send_window   i64
 	trailer_block []u8 // assembled trailer HEADERS + CONTINUATION fragments
 	in_trailers   bool // set once a trailer section (a 2nd HEADERS block) begins
+	refused       bool // §5.1.2: over the concurrency limit — decode then RST(REFUSED_STREAM)
 }
 
 // H2ServerConn drives one server-side HTTP/2 connection over a transport.
@@ -180,6 +181,31 @@ mut:
 	closing        bool
 	idle_conns     &TlsIdleConnTracker = unsafe { nil }
 	idle_handle    int
+}
+
+// H2StreamState is the server's view of a client-initiated stream for the
+// RFC 9113 §5.1 frame-acceptance rules. An open or half-closed stream is kept
+// in c.streams until its response is sent, so:
+//   - active: present in c.streams (open / half-closed local)
+//   - idle:   never opened (id higher than any stream we have accepted)
+//   - closed: opened earlier and already finished or reset (id <= last_stream_id)
+enum H2StreamState {
+	active
+	idle
+	closed
+}
+
+// classify_stream maps a stream id to its §5.1 state from the server's side.
+// id 0 (the connection control stream) is never a request stream; callers that
+// can receive it (WINDOW_UPDATE) handle id 0 before calling this.
+fn (c &H2ServerConn) classify_stream(stream_id u32) H2StreamState {
+	if stream_id in c.streams {
+		return .active
+	}
+	if stream_id > c.last_stream_id {
+		return .idle
+	}
+	return .closed
 }
 
 // serve_h2_conn drives a single HTTP/2 server-side connection until the
@@ -280,6 +306,12 @@ fn (mut c H2ServerConn) dispatch_frame(frame H2Frame, mut handler Handler) ! {
 			c.closing = true
 		}
 		H2RstStreamFrame {
+			// RFC 9113 §5.1/§6.4: RST_STREAM on the connection stream (id 0) or an
+			// idle stream is a connection error PROTOCOL_ERROR. On an open stream it
+			// cancels it; on an already-closed stream it is ignored.
+			if frame.stream_id == 0 || c.classify_stream(frame.stream_id) == .idle {
+				return error('h2 server: RST_STREAM on idle stream ${frame.stream_id}')
+			}
 			c.streams.delete(frame.stream_id)
 		}
 		H2PriorityFrame {
@@ -332,6 +364,10 @@ fn (mut c H2ServerConn) handle_control_frame(frame H2Frame) ! {
 				c.send_window += i64(frame.window_size_increment)
 			} else if mut s := c.streams[frame.stream_id] {
 				s.send_window += i64(frame.window_size_increment)
+			} else if c.classify_stream(frame.stream_id) == .idle {
+				// RFC 9113 §5.1: a WINDOW_UPDATE on an idle stream is a connection
+				// error PROTOCOL_ERROR. On a closed stream it is ignored.
+				return error('h2 server: WINDOW_UPDATE on idle stream ${frame.stream_id}')
 			}
 		}
 		else {}
@@ -412,6 +448,14 @@ fn (mut c H2ServerConn) on_headers(frame H2HeadersFrame, mut handler Handler) ! 
 		end_stream:  frame.end_stream
 		send_window: i64(c.peer.initial_window_size)
 	}
+	// RFC 9113 §5.1.2: a stream that would exceed the concurrency limit we
+	// advertised is refused. We still assemble and HPACK-decode its header block
+	// (the decoder is stateful — skipping it would desync the dynamic table) but
+	// answer with RST_STREAM(REFUSED_STREAM) instead of serving it; see
+	// finalize_headers. The just-created stream is not yet counted in c.streams.
+	if u32(c.streams.len) >= h2_server_max_concurrent_streams {
+		s.refused = true
+	}
 	c.streams[frame.stream_id] = s
 	if !frame.end_headers {
 		c.awaiting_cont = frame.stream_id
@@ -457,6 +501,13 @@ fn (mut c H2ServerConn) finalize_headers(mut s H2ServerStream, mut handler Handl
 		return error('h2 server: HPACK decode error (COMPRESSION_ERROR)')
 	}
 	s.headers_done = true
+	// §5.1.2: an over-limit stream was decoded only to keep HPACK in sync; refuse
+	// it now without validating or running the request.
+	if s.refused {
+		c.send_rst_stream(s.id, .refused_stream)!
+		c.streams.delete(s.id)
+		return
+	}
 	// A well-decoded but malformed request is a STREAM error (RFC 9113 §8.1.1) —
 	// reset just this stream and keep the connection alive.
 	h2_validate_request_pseudo(s.headers) or {
@@ -524,12 +575,19 @@ fn (mut c H2ServerConn) finalize_trailers(mut s H2ServerStream, mut handler Hand
 
 fn (mut c H2ServerConn) on_data(frame H2DataFrame, mut handler Handler) ! {
 	mut s := c.streams[frame.stream_id] or {
-		// DATA for an unknown stream (likely already RST'd); just drop and
-		// keep flow control consistent. Credit flow_size (full wire bytes
-		// including padding) per RFC 7540 §6.9.1.
-		if frame.flow_size > 0 {
-			c.send_window_update(0, u32(frame.flow_size))!
+		// RFC 9113 §5.1/§6.1: DATA is only valid on an open or half-closed (local)
+		// stream. On an idle stream (never opened) it is a connection error
+		// PROTOCOL_ERROR; on a closed stream (already finished or reset) it is a
+		// STREAM_CLOSED stream error.
+		if c.classify_stream(frame.stream_id) == .idle {
+			return error('h2 server: DATA on idle stream ${frame.stream_id}')
 		}
+		// Closed stream: credit the connection window (the peer spent it on bytes
+		// sent legitimately within its window) before RST-ing just this stream.
+		if frame.flow_size > 0 {
+			c.send_window_update(0, u32(frame.flow_size)) or {}
+		}
+		c.send_rst_stream(frame.stream_id, .stream_closed)!
 		return
 	}
 	if !s.headers_done {

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -301,12 +301,6 @@ fn (mut c H2ServerConn) dispatch_frame(frame H2Frame, mut handler Handler) ! {
 			if frame.stream_id != c.awaiting_cont {
 				return error('h2 server: CONTINUATION on the wrong stream')
 			}
-		} else if frame is H2RstStreamFrame && frame.stream_id == c.awaiting_cont {
-			// RFC 9113 §6.4: RST_STREAM is legal at any point including mid-CONTINUATION.
-			// Cancel the stream and clear the CONTINUATION wait without a connection error.
-			c.awaiting_cont = 0
-			c.streams.delete(frame.stream_id)
-			return
 		} else {
 			return error('h2 server: expected CONTINUATION after HEADERS without END_HEADERS')
 		}
@@ -453,6 +447,10 @@ fn (mut c H2ServerConn) on_headers(frame H2HeadersFrame, mut handler Handler) ! 
 			// the HPACK block is decoded: the decoder is stateful and connection-wide
 			// (RFC 7541 §2.2) — skipping a block desyncs all future requests.
 			// finalize_trailers RSTs on over_end after the decode.
+			// If the block is fragmented (END_HEADERS=false), on_trailers sets
+			// awaiting_cont; the client must then complete the CONTINUATION sequence
+			// before the RST fires. Per RFC 9113 §6.10, any non-CONTINUATION frame
+			// during that wait is a connection PROTOCOL_ERROR.
 			existing.over_end = true
 		}
 		c.on_trailers(mut existing, frame, mut handler)!

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -177,6 +177,7 @@ mut:
 	rbuf           []u8
 	send_window    i64 = i64(h2_server_default_window)
 	streams        map[u32]&H2ServerStream
+	locally_reset  map[u32]bool // stream ids for which we sent RST_STREAM; drain in-flight frames per RFC 9113 §6.4
 	last_stream_id u32
 	awaiting_cont  u32 // non-zero when mid-CONTINUATION on this stream
 	closing        bool
@@ -461,6 +462,13 @@ fn (mut c H2ServerConn) on_headers(frame H2HeadersFrame, mut handler Handler) ! 
 		return error('h2 server: invalid client stream id ${frame.stream_id}')
 	}
 	c.last_stream_id = frame.stream_id
+	// Prune locally_reset: TCP ordering guarantees all in-flight frames for
+	// streams below the new stream_id have already been delivered.
+	for id in c.locally_reset.keys() {
+		if id < frame.stream_id {
+			c.locally_reset.delete(id)
+		}
+	}
 	mut s := &H2ServerStream{
 		id:          frame.stream_id
 		hpack_block: frame.fragment.clone()
@@ -525,6 +533,7 @@ fn (mut c H2ServerConn) finalize_headers(mut s H2ServerStream, mut handler Handl
 	// it now without validating or running the request.
 	if s.refused {
 		c.send_rst_stream(s.id, .refused_stream)!
+		c.locally_reset[s.id] = true
 		c.streams.delete(s.id)
 		return
 	}
@@ -532,6 +541,7 @@ fn (mut c H2ServerConn) finalize_headers(mut s H2ServerStream, mut handler Handl
 	// reset just this stream and keep the connection alive.
 	h2_validate_request_pseudo(s.headers) or {
 		c.send_rst_stream(s.id, .protocol_error)!
+		c.locally_reset[s.id] = true
 		c.streams.delete(s.id)
 		return
 	}
@@ -569,6 +579,7 @@ fn (mut c H2ServerConn) finalize_trailers(mut s H2ServerStream, mut handler Hand
 	// HPACK sync; now RST the stream with STREAM_CLOSED and stop.
 	if s.over_end {
 		c.send_rst_stream(s.id, .stream_closed)!
+		c.locally_reset[s.id] = true
 		c.streams.delete(s.id)
 		return
 	}
@@ -594,6 +605,7 @@ fn (mut c H2ServerConn) finalize_trailers(mut s H2ServerStream, mut handler Hand
 	}
 	if reason != '' {
 		c.send_rst_stream(s.id, .protocol_error)!
+		c.locally_reset[s.id] = true
 		c.streams.delete(s.id)
 		return
 	}
@@ -609,12 +621,16 @@ fn (mut c H2ServerConn) on_data(frame H2DataFrame, mut handler Handler) ! {
 		if c.classify_stream(frame.stream_id) == .idle {
 			return error('h2 server: DATA on idle stream ${frame.stream_id}')
 		}
-		// Closed stream: credit the connection window (the peer spent it on bytes
-		// sent legitimately within its window) before RST-ing just this stream.
+		// Credit the connection window (the peer spent it within its window).
 		if frame.flow_size > 0 {
 			c.send_window_update(0, u32(frame.flow_size)) or {}
 		}
-		c.send_rst_stream(frame.stream_id, .stream_closed)!
+		// If we already sent RST_STREAM for this stream, the DATA was in-flight
+		// before the client received the RST. Drain it silently (RFC 9113 §6.4).
+		if frame.stream_id !in c.locally_reset {
+			c.send_rst_stream(frame.stream_id, .stream_closed)!
+			c.locally_reset[frame.stream_id] = true
+		}
 		return
 	}
 	if !s.headers_done {
@@ -629,6 +645,7 @@ fn (mut c H2ServerConn) on_data(frame H2DataFrame, mut handler Handler) ! {
 			c.send_window_update(0, u32(frame.flow_size)) or {}
 		}
 		c.send_rst_stream(s.id, .stream_closed)!
+		c.locally_reset[s.id] = true
 		c.streams.delete(s.id)
 		return
 	}
@@ -638,6 +655,7 @@ fn (mut c H2ServerConn) on_data(frame H2DataFrame, mut handler Handler) ! {
 			// not penalised for bytes it legitimately sent within its window.
 			c.send_window_update(0, u32(frame.flow_size)) or {}
 			c.send_rst_stream(s.id, .refused_stream)!
+			c.locally_reset[s.id] = true
 			c.streams.delete(s.id)
 			return
 		}
@@ -661,6 +679,7 @@ fn (mut c H2ServerConn) on_data(frame H2DataFrame, mut handler Handler) ! {
 fn (mut c H2ServerConn) run_request(mut s H2ServerStream, mut handler Handler) ! {
 	req := c.build_request(s) or {
 		c.send_rst_stream(s.id, .protocol_error)!
+		c.locally_reset[s.id] = true
 		c.streams.delete(s.id)
 		return
 	}

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -22,6 +22,13 @@ const h2_server_default_window = u32(65535)
 // rejected with RST_STREAM(REFUSED_STREAM).
 const h2_server_max_request_body = 8 * 1024 * 1024
 
+// h2_server_max_locally_reset_tracked bounds the locally_reset drain-tracking
+// set (RFC 9113 §6.4). A peer that keeps the connection open while sending an
+// unbounded stream of malformed/refused requests must not be able to grow this
+// set without limit; once full, the oldest entry is evicted (still-open drain
+// windows race against network RTT, so the newest entries matter most).
+const h2_server_max_locally_reset_tracked = 128
+
 // The connection-specific header fields RFC 9113 §8.2.2 forbids in HTTP/2 (a
 // request carrying one is malformed; the server must never echo one in a
 // response) are the module-level `h2_conn_specific_headers` const defined in
@@ -170,16 +177,17 @@ mut:
 // H2ServerConn drives one server-side HTTP/2 connection over a transport.
 struct H2ServerConn {
 mut:
-	transport      H2Transport
-	encoder        H2HpackEncoder
-	decoder        H2HpackDecoder
-	peer           H2PeerSettings
-	rbuf           []u8
-	send_window    i64 = i64(h2_server_default_window)
-	streams        map[u32]&H2ServerStream
-	locally_reset  map[u32]bool // stream ids for which we sent RST_STREAM; drain in-flight frames per RFC 9113 §6.4
-	discard_block  []u8         // accumulates a HEADERS/CONTINUATION block for a locally-reset stream, decoded then discarded
-	last_stream_id u32
+	transport           H2Transport
+	encoder             H2HpackEncoder
+	decoder             H2HpackDecoder
+	peer                H2PeerSettings
+	rbuf                []u8
+	send_window         i64 = i64(h2_server_default_window)
+	streams             map[u32]&H2ServerStream
+	locally_reset       map[u32]bool // stream ids for which we sent RST_STREAM; drain in-flight frames per RFC 9113 §6.4
+	locally_reset_order []u32        // insertion order of locally_reset keys, oldest first, for bounded eviction
+	discard_block       []u8         // accumulates a HEADERS/CONTINUATION block for a locally-reset stream, decoded then discarded
+	last_stream_id      u32
 	// last_processed_stream_id is the highest stream id the server has actually
 	// acted on (RFC 9113 §6.8), used for GOAWAY. Bumped in on_headers at stream
 	// creation — the same moment refused is decided — so it correctly includes a
@@ -195,6 +203,27 @@ mut:
 	closing                  bool
 	idle_conns               &TlsIdleConnTracker = unsafe { nil }
 	idle_handle              int
+}
+
+// mark_locally_reset records that id has been RST_STREAM'd by the server so any
+// in-flight frame for it is drained rather than re-RST (RFC 9113 §6.4). Bounded
+// per h2_server_max_locally_reset_tracked; never evicts the id whose discard
+// block is still being assembled (c.awaiting_cont).
+fn (mut c H2ServerConn) mark_locally_reset(id u32) {
+	if id in c.locally_reset {
+		return
+	}
+	c.locally_reset[id] = true
+	c.locally_reset_order << id
+	for c.locally_reset_order.len > h2_server_max_locally_reset_tracked {
+		mut evict_idx := 0
+		if c.locally_reset_order[evict_idx] == c.awaiting_cont && c.locally_reset_order.len > 1 {
+			evict_idx = 1
+		}
+		evicted := c.locally_reset_order[evict_idx]
+		c.locally_reset_order.delete(evict_idx)
+		c.locally_reset.delete(evicted)
+	}
 }
 
 // H2StreamState is the server's view of a client-initiated stream for the
@@ -317,6 +346,14 @@ fn (mut c H2ServerConn) dispatch_frame(frame H2Frame, mut handler Handler) ! {
 		} else {
 			return error('h2 server: expected CONTINUATION after HEADERS without END_HEADERS')
 		}
+	} else if frame is H2ContinuationFrame {
+		// A CONTINUATION is only legal immediately after a HEADERS/PUSH_PROMISE/
+		// CONTINUATION block that ended without END_HEADERS (RFC 9113 §6.10). With
+		// no block in progress, this is an orphan CONTINUATION — a connection error
+		// even if frame.stream_id was previously locally_reset (the discard path in
+		// on_continuation relies on this gate to guarantee awaiting_cont ==
+		// frame.stream_id before it ever runs).
+		return error('h2 server: unexpected CONTINUATION frame')
 	}
 	match frame {
 		H2SettingsFrame, H2PingFrame, H2WindowUpdateFrame {
@@ -525,6 +562,9 @@ fn (mut c H2ServerConn) on_headers(frame H2HeadersFrame, mut handler Handler) ! 
 fn (mut c H2ServerConn) on_continuation(frame H2ContinuationFrame, mut handler Handler) ! {
 	mut s := c.streams[frame.stream_id] or {
 		// Continuing a discard block for a stream we already RST'd (see on_headers).
+		// Only valid while a discard block on THIS id is actually mid-assembly
+		// (RFC 9113 §6.10): a standalone CONTINUATION with no preceding HEADERS
+		// lacking END_HEADERS is a connection error even if the id was once reset.
 		if frame.stream_id in c.locally_reset {
 			if c.discard_block.len + frame.fragment.len > h2_max_recv_header_block {
 				return error('h2 server: discarded header block exceeds ${h2_max_recv_header_block} bytes')
@@ -579,7 +619,7 @@ fn (mut c H2ServerConn) finalize_headers(mut s H2ServerStream, mut handler Handl
 	// it now without validating or running the request.
 	if s.refused {
 		c.send_rst_stream(s.id, .refused_stream)!
-		c.locally_reset[s.id] = true
+		c.mark_locally_reset(s.id)
 		c.streams.delete(s.id)
 		return
 	}
@@ -587,7 +627,7 @@ fn (mut c H2ServerConn) finalize_headers(mut s H2ServerStream, mut handler Handl
 	// reset just this stream and keep the connection alive.
 	h2_validate_request_pseudo(s.headers) or {
 		c.send_rst_stream(s.id, .protocol_error)!
-		c.locally_reset[s.id] = true
+		c.mark_locally_reset(s.id)
 		c.streams.delete(s.id)
 		return
 	}
@@ -625,7 +665,7 @@ fn (mut c H2ServerConn) finalize_trailers(mut s H2ServerStream, mut handler Hand
 	// HPACK sync; now RST the stream with STREAM_CLOSED and stop.
 	if s.over_end {
 		c.send_rst_stream(s.id, .stream_closed)!
-		c.locally_reset[s.id] = true
+		c.mark_locally_reset(s.id)
 		c.streams.delete(s.id)
 		return
 	}
@@ -651,7 +691,7 @@ fn (mut c H2ServerConn) finalize_trailers(mut s H2ServerStream, mut handler Hand
 	}
 	if reason != '' {
 		c.send_rst_stream(s.id, .protocol_error)!
-		c.locally_reset[s.id] = true
+		c.mark_locally_reset(s.id)
 		c.streams.delete(s.id)
 		return
 	}
@@ -675,7 +715,7 @@ fn (mut c H2ServerConn) on_data(frame H2DataFrame, mut handler Handler) ! {
 		// before the client received the RST. Drain it silently (RFC 9113 §6.4).
 		if frame.stream_id !in c.locally_reset {
 			c.send_rst_stream(frame.stream_id, .stream_closed)!
-			c.locally_reset[frame.stream_id] = true
+			c.mark_locally_reset(frame.stream_id)
 		}
 		return
 	}
@@ -691,7 +731,7 @@ fn (mut c H2ServerConn) on_data(frame H2DataFrame, mut handler Handler) ! {
 			c.send_window_update(0, u32(frame.flow_size)) or {}
 		}
 		c.send_rst_stream(s.id, .stream_closed)!
-		c.locally_reset[s.id] = true
+		c.mark_locally_reset(s.id)
 		c.streams.delete(s.id)
 		return
 	}
@@ -701,7 +741,7 @@ fn (mut c H2ServerConn) on_data(frame H2DataFrame, mut handler Handler) ! {
 			// not penalised for bytes it legitimately sent within its window.
 			c.send_window_update(0, u32(frame.flow_size)) or {}
 			c.send_rst_stream(s.id, .refused_stream)!
-			c.locally_reset[s.id] = true
+			c.mark_locally_reset(s.id)
 			c.streams.delete(s.id)
 			return
 		}
@@ -725,7 +765,7 @@ fn (mut c H2ServerConn) on_data(frame H2DataFrame, mut handler Handler) ! {
 fn (mut c H2ServerConn) run_request(mut s H2ServerStream, mut handler Handler) ! {
 	req := c.build_request(s) or {
 		c.send_rst_stream(s.id, .protocol_error)!
-		c.locally_reset[s.id] = true
+		c.mark_locally_reset(s.id)
 		c.streams.delete(s.id)
 		return
 	}

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -187,8 +187,10 @@ mut:
 // RFC 9113 §5.1 frame-acceptance rules. An open or half-closed stream is kept
 // in c.streams until its response is sent, so:
 //   - active: present in c.streams (open / half-closed local)
-//   - idle:   never opened (id higher than any stream we have accepted)
-//   - closed: opened earlier and already finished or reset (id <= last_stream_id)
+//   - idle:   never opened — an odd id above any we have accepted, OR any even
+//             (server-initiated) id, since this server never opens push streams
+//   - closed: a client (odd) id at or below the highest we have accepted that is
+//             no longer in the map (already finished or reset)
 enum H2StreamState {
 	active
 	idle
@@ -196,16 +198,20 @@ enum H2StreamState {
 }
 
 // classify_stream maps a stream id to its §5.1 state from the server's side.
-// id 0 (the connection control stream) is never a request stream; callers that
-// can receive it (WINDOW_UPDATE) handle id 0 before calling this.
+// `last_stream_id` tracks only client-initiated (odd) ids, so "closed" applies
+// ONLY to an odd id <= last_stream_id; an even id was never opened by this
+// server (it initiates no streams) and is therefore idle, not closed — a frame
+// on it is a connection PROTOCOL_ERROR, not STREAM_CLOSED. id 0 (the connection
+// control stream) is never a request stream; callers that can receive it
+// (WINDOW_UPDATE) handle id 0 before calling this.
 fn (c &H2ServerConn) classify_stream(stream_id u32) H2StreamState {
 	if stream_id in c.streams {
 		return .active
 	}
-	if stream_id > c.last_stream_id {
-		return .idle
+	if stream_id & 1 == 1 && stream_id <= c.last_stream_id {
+		return .closed
 	}
-	return .closed
+	return .idle
 }
 
 // serve_h2_conn drives a single HTTP/2 server-side connection until the

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -439,6 +439,14 @@ fn (mut c H2ServerConn) on_headers(frame H2HeadersFrame, mut handler Handler) ! 
 	// A HEADERS block for a stream that is already open is a trailer section
 	// (RFC 9113 §8.1), not a new request.
 	if mut existing := c.streams[frame.stream_id] {
+		if existing.end_stream {
+			// Half-closed (remote): the stream already delivered END_STREAM (its
+			// response may still be in flight). A further HEADERS block cannot open
+			// a trailer section — RFC 9113 §5.1, STREAM_CLOSED stream error.
+			c.send_rst_stream(frame.stream_id, .stream_closed)!
+			c.streams.delete(frame.stream_id)
+			return
+		}
 		c.on_trailers(mut existing, frame, mut handler)!
 		return
 	}
@@ -599,6 +607,18 @@ fn (mut c H2ServerConn) on_data(frame H2DataFrame, mut handler Handler) ! {
 	if !s.headers_done {
 		return error('h2 server: DATA before END_HEADERS')
 	}
+	if s.end_stream {
+		// Half-closed (remote): the stream already delivered END_STREAM (its
+		// response may still be in flight while we are blocked on flow control).
+		// Further DATA is a STREAM_CLOSED stream error (RFC 9113 §5.1). Credit the
+		// connection window first, then reset just this stream.
+		if frame.flow_size > 0 {
+			c.send_window_update(0, u32(frame.flow_size)) or {}
+		}
+		c.send_rst_stream(s.id, .stream_closed)!
+		c.streams.delete(s.id)
+		return
+	}
 	if frame.data.len > 0 {
 		if s.body.len + frame.data.len > h2_server_max_request_body {
 			// Credit the connection window before resetting so the peer is
@@ -632,7 +652,7 @@ fn (mut c H2ServerConn) run_request(mut s H2ServerStream, mut handler Handler) !
 		return
 	}
 	resp := handler.handle(req)
-	c.send_response(s.id, resp)!
+	c.send_response(s.id, resp, mut handler)!
 	c.streams.delete(s.id)
 }
 
@@ -700,7 +720,7 @@ fn (mut c H2ServerConn) build_request(s &H2ServerStream) !Request {
 	return req
 }
 
-fn (mut c H2ServerConn) send_response(stream_id u32, resp Response) ! {
+fn (mut c H2ServerConn) send_response(stream_id u32, resp Response, mut handler Handler) ! {
 	status := if resp.status_code == 0 { 200 } else { resp.status_code }
 	mut fields := [H2HeaderField{':status', status.str()}]
 	for key in resp.header.keys() {
@@ -718,7 +738,7 @@ fn (mut c H2ServerConn) send_response(stream_id u32, resp Response) ! {
 	block := c.encoder.encode(fields)
 	c.send_header_block(stream_id, block, !has_body)!
 	if has_body {
-		c.send_body(stream_id, body)!
+		c.send_body(stream_id, body, mut handler)!
 	}
 }
 
@@ -754,7 +774,7 @@ fn (mut c H2ServerConn) send_header_block(stream_id u32, block []u8, end_stream 
 	}
 }
 
-fn (mut c H2ServerConn) send_body(stream_id u32, body []u8) ! {
+fn (mut c H2ServerConn) send_body(stream_id u32, body []u8, mut handler Handler) ! {
 	max := int(c.peer.max_frame_size)
 	mut off := 0
 	for off < body.len {
@@ -762,7 +782,15 @@ fn (mut c H2ServerConn) send_body(stream_id u32, body []u8) ! {
 		// (RFC 7540 Section 6.9). When either is exhausted, read frames until
 		// the peer grows a window with WINDOW_UPDATE.
 		for c.send_window <= 0 || c.stream_send_window(stream_id) <= 0 {
-			c.pump_for_window(stream_id)!
+			c.pump_for_window(mut handler)!
+			// pump_for_window dispatches inbound frames; if the peer reset this
+			// stream (RST_STREAM, or an illegal frame on the now half-closed
+			// stream), it is gone from the map. Stop writing its response, but do
+			// NOT error — a single stream's reset is a stream-scoped event and must
+			// not tear down the whole connection.
+			if stream_id !in c.streams {
+				return
+			}
 		}
 		avail := if c.send_window < c.stream_send_window(stream_id) {
 			c.send_window
@@ -799,19 +827,19 @@ fn (c &H2ServerConn) stream_send_window(stream_id u32) i64 {
 	return 0
 }
 
-// pump_for_window reads one frame while a response is blocked on flow control,
-// servicing control frames (SETTINGS / PING / WINDOW_UPDATE) via
-// handle_control_frame and aborting on RST_STREAM for the active stream.
-fn (mut c H2ServerConn) pump_for_window(stream_id u32) ! {
+// pump_for_window reads one frame while a response is blocked on flow control and
+// routes it through the SAME dispatch path as the main loop. Delegating to
+// dispatch_frame (rather than re-implementing a subset) means every rule applies
+// here too: a HEADERS frame arriving before the unblocking WINDOW_UPDATE is
+// HPACK-decoded and — being over the concurrency limit — answered with
+// RST_STREAM(REFUSED_STREAM), instead of being silently dropped (which desynced
+// the HPACK decoder and skipped the required reset). dispatch_frame does not
+// re-enter run_request from here: a new stream is refused (never served), and the
+// active stream is half-closed (remote) so its further DATA/HEADERS are
+// STREAM_CLOSED — the caller (send_body) detects the resulting reset and stops.
+fn (mut c H2ServerConn) pump_for_window(mut handler Handler) ! {
 	frame := c.read_frame()!
-	c.handle_control_frame(frame)!
-	if frame is H2RstStreamFrame {
-		if frame.stream_id == stream_id {
-			return error('h2 server: stream reset by peer while writing response')
-		}
-	}
-	// With SETTINGS_MAX_CONCURRENT_STREAMS=1 no other stream frames are
-	// expected mid-response; ignore anything else defensively.
+	c.dispatch_frame(frame, mut handler)!
 }
 
 fn (mut c H2ServerConn) send_window_update(stream_id u32, inc u32) ! {

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -164,6 +164,7 @@ mut:
 	trailer_block []u8 // assembled trailer HEADERS + CONTINUATION fragments
 	in_trailers   bool // set once a trailer section (a 2nd HEADERS block) begins
 	refused       bool // §5.1.2: over the concurrency limit — decode then RST(REFUSED_STREAM)
+	over_end      bool // §5.1: HEADERS after END_STREAM — decoded for HPACK sync, then RST(STREAM_CLOSED)
 }
 
 // H2ServerConn drives one server-side HTTP/2 connection over a transport.
@@ -300,6 +301,12 @@ fn (mut c H2ServerConn) dispatch_frame(frame H2Frame, mut handler Handler) ! {
 			if frame.stream_id != c.awaiting_cont {
 				return error('h2 server: CONTINUATION on the wrong stream')
 			}
+		} else if frame is H2RstStreamFrame && frame.stream_id == c.awaiting_cont {
+			// RFC 9113 §6.4: RST_STREAM is legal at any point including mid-CONTINUATION.
+			// Cancel the stream and clear the CONTINUATION wait without a connection error.
+			c.awaiting_cont = 0
+			c.streams.delete(frame.stream_id)
+			return
 		} else {
 			return error('h2 server: expected CONTINUATION after HEADERS without END_HEADERS')
 		}
@@ -440,12 +447,13 @@ fn (mut c H2ServerConn) on_headers(frame H2HeadersFrame, mut handler Handler) ! 
 	// (RFC 9113 §8.1), not a new request.
 	if mut existing := c.streams[frame.stream_id] {
 		if existing.end_stream {
-			// Half-closed (remote): the stream already delivered END_STREAM (its
-			// response may still be in flight). A further HEADERS block cannot open
-			// a trailer section — RFC 9113 §5.1, STREAM_CLOSED stream error.
-			c.send_rst_stream(frame.stream_id, .stream_closed)!
-			c.streams.delete(frame.stream_id)
-			return
+			// Half-closed (remote): the stream already delivered END_STREAM.
+			// The further HEADERS block is invalid (RFC 9113 §5.1, STREAM_CLOSED),
+			// but we must still route it through on_trailers → finalize_trailers so
+			// the HPACK block is decoded: the decoder is stateful and connection-wide
+			// (RFC 7541 §2.2) — skipping a block desyncs all future requests.
+			// finalize_trailers RSTs on over_end after the decode.
+			existing.over_end = true
 		}
 		c.on_trailers(mut existing, frame, mut handler)!
 		return
@@ -558,6 +566,13 @@ fn (mut c H2ServerConn) finalize_trailers(mut s H2ServerStream, mut handler Hand
 	trailers := c.decoder.decode(s.trailer_block) or {
 		c.send_goaway(.compression_error, 'HPACK decode error in trailers') or {}
 		return error('h2 server: HPACK decode error in trailers (COMPRESSION_ERROR)')
+	}
+	// A HEADERS block received after END_STREAM (RFC 9113 §5.1): decoded above for
+	// HPACK sync; now RST the stream with STREAM_CLOSED and stop.
+	if s.over_end {
+		c.send_rst_stream(s.id, .stream_closed)!
+		c.streams.delete(s.id)
+		return
 	}
 	// A well-decoded but malformed trailer section is a STREAM error (§8.1.1).
 	mut reason := if !s.end_stream {

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -837,3 +837,83 @@ fn test_h2_server_data_on_even_stream_is_connection_error() {
 	code := drive_until_goaway_or_close(mut client_end, out, 'DATA on even idle stream')
 	assert code == i64(u32(H2ErrorCode.protocol_error)), 'DATA on even idle stream: expected GOAWAY(PROTOCOL_ERROR), got ${code}'
 }
+
+// RFC 9113 §5.1.2: an over-limit stream opened while the server is blocked writing
+// a stalled response (flow control) must still be HPACK-decoded and refused — the
+// stall path (send_body -> pump_for_window) routes frames through the same dispatch
+// as the main loop. Regression for the divergent-reader miss (Codex, #27589
+// discussion_r3488302384): set the initial window to 0 so stream 1's response body
+// stalls, then send HEADERS for stream 3 before the WINDOW_UPDATE that unblocks it.
+fn test_h2_server_refuses_over_limit_stream_during_window_stall() {
+	mut enc := H2HpackEncoder{}
+	mut out := []u8{}
+	out << h2_client_preface.bytes()
+	// Zero initial window -> stream 1's response body cannot be sent until a
+	// WINDOW_UPDATE arrives, parking the server in pump_for_window.
+	out << H2Frame(H2SettingsFrame{
+		settings: [H2Setting{h2_settings_initial_window_size, 0}]
+	}).encode()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	// Over-limit stream 3 arrives while stream 1's response is stalled.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   3
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	// Unblock stream 1 so its response completes after the refusal.
+	out << H2Frame(H2WindowUpdateFrame{
+		stream_id:             1
+		window_size_increment: 1000
+	}).encode()
+
+	mut client_end := spawn_h2_echo_server()
+	client_end.write(out) or {
+		assert false, 'window-stall refusal: client write failed: ${err}'
+		return
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut dec := H2HpackDecoder{}
+	mut rst3 := i64(-1)
+	mut s1_status := 0
+	mut s1_ended := false
+	for _ in 0 .. 64 {
+		f := fr.next() or { break }
+		match f {
+			H2RstStreamFrame {
+				if f.stream_id == 3 {
+					rst3 = i64(f.error_code)
+				}
+			}
+			H2HeadersFrame {
+				if f.stream_id == 1 {
+					for hf in dec.decode(f.fragment) or { []H2HeaderField{} } {
+						if hf.name == ':status' {
+							s1_status = hf.value.int()
+						}
+					}
+				}
+			}
+			H2DataFrame {
+				if f.stream_id == 1 && f.end_stream {
+					s1_ended = true
+				}
+			}
+			else {}
+		}
+
+		if rst3 >= 0 && s1_ended {
+			break
+		}
+	}
+	assert rst3 == i64(u32(H2ErrorCode.refused_stream)), 'over-limit stream during stall: expected RST_STREAM(REFUSED_STREAM) on stream 3, got ${rst3}'
+	assert s1_status == 200, 'stalled stream 1 should still complete with 200, got ${s1_status}'
+	assert s1_ended, 'stalled stream 1 response should complete after WINDOW_UPDATE'
+}

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -653,3 +653,160 @@ fn test_h2_server_accepts_post_with_trailers() {
 	}
 	assert status == 200, 'trailers POST should succeed, got status ${status}'
 }
+
+// drive_until_goaway_or_close writes `out`, then reads frames until it sees a
+// GOAWAY (returns its error code) or the connection closes (returns -1). A
+// RST_STREAM on any stream is a wrong-scope answer for a connection error and
+// returns -2.
+fn drive_until_goaway_or_close(mut client_end PipeEnd, out []u8, label string) i64 {
+	client_end.write(out) or {
+		assert false, '${label}: client write failed: ${err}'
+		return -3
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	for _ in 0 .. 32 {
+		f := fr.next() or { return -1 }
+		match f {
+			H2GoawayFrame {
+				return i64(f.error_code)
+			}
+			H2RstStreamFrame {
+				return -2
+			}
+			else {}
+		}
+	}
+	assert false, '${label}: server sent neither GOAWAY nor closed'
+	return -3
+}
+
+// preface_and_settings returns the client preface followed by an empty SETTINGS
+// frame — the start of every scripted session.
+fn preface_and_settings() []u8 {
+	mut out := []u8{}
+	out << h2_client_preface.bytes()
+	out << H2Frame(H2SettingsFrame{}).encode()
+	return out
+}
+
+// RFC 9113 §5.1: a DATA frame on an idle stream (one never opened) is a
+// connection error of type PROTOCOL_ERROR.
+fn test_h2_server_data_on_idle_stream_is_connection_error() {
+	mut out := preface_and_settings()
+	out << H2Frame(H2DataFrame{
+		stream_id:  1
+		data:       'x'.bytes()
+		end_stream: true
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	code := drive_until_goaway_or_close(mut client_end, out, 'DATA on idle stream')
+	assert code == i64(u32(H2ErrorCode.protocol_error)), 'DATA on idle: expected GOAWAY(PROTOCOL_ERROR), got ${code}'
+}
+
+// RFC 9113 §5.1/§6.4: a RST_STREAM on an idle stream is a connection error of
+// type PROTOCOL_ERROR.
+fn test_h2_server_rst_on_idle_stream_is_connection_error() {
+	mut out := preface_and_settings()
+	out << H2Frame(H2RstStreamFrame{
+		stream_id:  1
+		error_code: u32(H2ErrorCode.cancel)
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	code := drive_until_goaway_or_close(mut client_end, out, 'RST on idle stream')
+	assert code == i64(u32(H2ErrorCode.protocol_error)), 'RST on idle: expected GOAWAY(PROTOCOL_ERROR), got ${code}'
+}
+
+// RFC 9113 §5.1: a WINDOW_UPDATE on an idle stream is a connection error of type
+// PROTOCOL_ERROR.
+fn test_h2_server_window_update_on_idle_stream_is_connection_error() {
+	mut out := preface_and_settings()
+	out << H2Frame(H2WindowUpdateFrame{
+		stream_id:             1
+		window_size_increment: 100
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	code := drive_until_goaway_or_close(mut client_end, out, 'WINDOW_UPDATE on idle stream')
+	assert code == i64(u32(H2ErrorCode.protocol_error)), 'WINDOW_UPDATE on idle: expected GOAWAY(PROTOCOL_ERROR), got ${code}'
+}
+
+// RFC 9113 §5.1/§6.1: a DATA frame on a closed stream (one already served and
+// removed) is a STREAM error of type STREAM_CLOSED — the connection stays up.
+fn test_h2_server_data_on_closed_stream_is_stream_closed() {
+	mut enc := H2HpackEncoder{}
+	block := enc.encode(valid_get_pseudo)
+	mut out := preface_and_settings()
+	// Open and immediately close stream 1 (HEADERS + END_STREAM -> served).
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    block
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	// Then DATA on the now-closed stream 1.
+	out << H2Frame(H2DataFrame{
+		stream_id:  1
+		data:       'x'.bytes()
+		end_stream: true
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	client_end.write(out) or {
+		assert false, 'DATA on closed stream: client write failed: ${err}'
+		return
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut code := i64(-1)
+	for _ in 0 .. 32 {
+		f := fr.next() or { break }
+		if f is H2RstStreamFrame {
+			if f.stream_id == 1 {
+				code = i64(f.error_code)
+				break
+			}
+		}
+	}
+	assert code == i64(u32(H2ErrorCode.stream_closed)), 'DATA on closed: expected RST_STREAM(STREAM_CLOSED), got ${code}'
+}
+
+// RFC 9113 §5.1.2: a HEADERS frame opening a stream beyond the advertised
+// SETTINGS_MAX_CONCURRENT_STREAMS (1) is refused with RST_STREAM(REFUSED_STREAM).
+// Both streams omit END_STREAM so the first stays parked (open) when the second
+// arrives, exercising the concurrency check rather than serial processing.
+fn test_h2_server_refuses_stream_over_concurrency_limit() {
+	mut enc := H2HpackEncoder{}
+	mut out := preface_and_settings()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  false
+	}).encode()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   3
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  false
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	client_end.write(out) or {
+		assert false, 'concurrency limit: client write failed: ${err}'
+		return
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut code := i64(-1)
+	for _ in 0 .. 32 {
+		f := fr.next() or { break }
+		if f is H2RstStreamFrame {
+			if f.stream_id == 3 {
+				code = i64(f.error_code)
+				break
+			}
+		}
+	}
+	assert code == i64(u32(H2ErrorCode.refused_stream)), 'over-limit stream: expected RST_STREAM(REFUSED_STREAM) on stream 3, got ${code}'
+}

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -1027,6 +1027,112 @@ fn test_h2_server_goaway_last_stream_id_includes_mid_continuation_stream() {
 	assert goaway_last_id == u32(1), 'GOAWAY mid-continuation: expected 1 (stream 1 was being acted on), got ${goaway_last_id}'
 }
 
+// RFC 9113 §6.10: a standalone CONTINUATION frame with no preceding HEADERS
+// block lacking END_HEADERS is invalid, even on a stream id the server has
+// already RST'd itself. Regression for Codex, #27589 pullrequestreview-4613845079
+// ("Reject orphan CONTINUATION frames on reset streams"): before the fix,
+// on_continuation's locally_reset branch accepted ANY CONTINUATION for a
+// previously-reset stream id and fed it straight into the stateful HPACK
+// decoder, regardless of whether a discard block was actually in progress.
+//
+// Setup: stream 1 is malformed (missing :scheme) with END_HEADERS already set
+// on its one HEADERS frame, so the server RSTs it immediately and
+// c.awaiting_cont never becomes 1. A lone CONTINUATION frame for stream 1 then
+// arrives out of nowhere. It must be rejected as a connection error
+// (GOAWAY PROTOCOL_ERROR), not silently decoded and discarded.
+fn test_h2_server_rejects_orphan_continuation_on_reset_stream() {
+	// Malformed: :method + :path only, no :scheme -> immediate RST(protocol_error).
+	malformed_block := [u8(0x82), 0x84, 0x01, 0x09, 0x68, 0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c,
+		0x65]
+
+	mut enc := H2HpackEncoder{}
+	stream3_block := enc.encode(valid_get_pseudo)
+	mut out := preface_and_settings()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    malformed_block
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	// Orphan CONTINUATION: no preceding HEADERS without END_HEADERS on stream 1.
+	out << H2Frame(H2ContinuationFrame{
+		stream_id:   1
+		fragment:    [u8(0x40), 0x06, 0x78, 0x2d, 0x73, 0x79, 0x6e, 0x63, 0x01, 0x31]
+		end_headers: true
+	}).encode()
+	// A valid, complete request on stream 3 follows. If the server incorrectly
+	// treats the orphan CONTINUATION as an accepted discard-continuation instead
+	// of a connection error, it keeps serving and answers this one with 200 — the
+	// bug manifests as a response here rather than the frame reader blocking
+	// forever waiting for a GOAWAY that never comes.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   3
+		fragment:    stream3_block
+		end_headers: true
+		end_stream:  true
+	}).encode()
+
+	mut client_end := spawn_h2_echo_server()
+	client_end.write(out) or {
+		assert false, 'orphan CONTINUATION: client write failed: ${err}'
+		return
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut goaway_code := i64(-1)
+	mut s3_status := 0
+	mut dec := H2HpackDecoder{}
+	for _ in 0 .. 32 {
+		f := fr.next() or { break }
+		match f {
+			H2GoawayFrame {
+				goaway_code = i64(f.error_code)
+			}
+			H2HeadersFrame {
+				if f.stream_id == 3 {
+					for hf in dec.decode(f.fragment) or { []H2HeaderField{} } {
+						if hf.name == ':status' {
+							s3_status = hf.value.int()
+						}
+					}
+				}
+			}
+			else {}
+		}
+
+		if goaway_code >= 0 || s3_status != 0 {
+			break
+		}
+	}
+	assert s3_status == 0, 'orphan CONTINUATION on reset stream: server kept serving after an illegal CONTINUATION (stream 3 got ${s3_status})'
+	assert goaway_code == i64(u32(H2ErrorCode.protocol_error)), 'orphan CONTINUATION on reset stream: expected GOAWAY(PROTOCOL_ERROR), got ${goaway_code}'
+}
+
+// RFC 9113 §6.4: the locally_reset drain-tracking set must be bounded — an
+// unbounded set lets a peer that keeps the connection open while sending an
+// endless stream of malformed requests grow server memory without limit.
+// Regression for Codex, #27589 pullrequestreview-4613845079 ("Bound
+// locally_reset tracking for reset streams"): before the fix, c.locally_reset
+// grew by one entry per malformed stream id forever. This is a white-box unit
+// test of mark_locally_reset directly (no I/O) since the bound is an internal
+// invariant, not something a black-box frame exchange can assert cleanly.
+fn test_h2_server_locally_reset_tracking_is_bounded() {
+	_, mut server_end := new_pipe()
+	mut c := &H2ServerConn{
+		transport: H2Transport(server_end)
+	}
+	for i in 0 .. h2_server_max_locally_reset_tracked + 10 {
+		c.mark_locally_reset(u32(2 * i + 1))
+	}
+	assert c.locally_reset.len <= h2_server_max_locally_reset_tracked, 'locally_reset grew unbounded: len=${c.locally_reset.len}'
+	assert c.locally_reset_order.len == c.locally_reset.len
+	// The most recent id must survive eviction; an early one must be gone.
+	last_id := u32(2 * (h2_server_max_locally_reset_tracked + 9) + 1)
+	assert last_id in c.locally_reset, 'most recently reset stream was evicted'
+	assert u32(1) !in c.locally_reset, 'oldest reset stream should have been evicted'
+}
+
 // RFC 9113 §6.4 / RFC 7541 §2.2: a HEADERS block arriving on a stream the
 // server has already RST'd itself (locally_reset) must still be HPACK-decoded
 // before being discarded — the dynamic table is connection-wide, so skipping

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -917,3 +917,111 @@ fn test_h2_server_refuses_over_limit_stream_during_window_stall() {
 	assert s1_status == 200, 'stalled stream 1 should still complete with 200, got ${s1_status}'
 	assert s1_ended, 'stalled stream 1 response should complete after WINDOW_UPDATE'
 }
+
+// RFC 9113 §5.1 / RFC 7541 §2.2: a HEADERS block arriving on a half-closed
+// (remote) stream must be HPACK-decoded before the server sends
+// RST_STREAM(STREAM_CLOSED). The HPACK dynamic table is connection-wide; skipping
+// the decode desyncs it, so a subsequent request that uses an indexed reference to
+// an entry from the skipped block gets GOAWAY(COMPRESSION_ERROR) instead of a 200.
+//
+// Setup: zero initial window stalls stream 1's response body, keeping stream 1 in
+// c.streams while we inject a post-END_STREAM HEADERS for it. That block carries a
+// literal-with-incremental-indexing entry ("x-sync: 1" → dynamic index 62). Stream
+// 3 then references that entry via 0xBE. If the decode was skipped, 0xBE is
+// unresolvable and the connection closes with COMPRESSION_ERROR.
+//
+// HPACK bytes used (RFC 7541 static table indices):
+//   0x82 = indexed(2)  → :method: GET
+//   0x84 = indexed(4)  → :path: /
+//   0x87 = indexed(7)  → :scheme: https
+//   0x01 0x09 ...      → :authority: h.example (literal-without-indexing, name idx 1)
+//   0x40 0x06 x-sync 0x01 1 → literal-incremental "x-sync: 1" → dynamic index 62
+//   0xBE = indexed(62) → x-sync: 1  (fails with COMPRESSION_ERROR if table desynced)
+fn test_h2_server_hpack_sync_after_post_end_stream_headers() {
+	// All-manual HPACK: no H2HpackEncoder so the dynamic table stays predictable.
+	// Static-table references only for the base pseudo-headers; no new entries.
+	base_block := [u8(0x82), 0x84, 0x87, 0x01, 0x09, 0x68, 0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70,
+		0x6c, 0x65]
+	// Literal-with-incremental-indexing: adds "x-sync: 1" to the dynamic table.
+	invalid_block := [u8(0x40), 0x06, 0x78, 0x2d, 0x73, 0x79, 0x6e, 0x63, 0x01, 0x31]
+	// Same pseudo-headers plus indexed(62) = "x-sync: 1" from the dynamic table.
+	mut s3_block := base_block.clone()
+	s3_block << u8(0xBE)
+
+	mut out := []u8{}
+	out << h2_client_preface.bytes()
+	// Zero initial window → stream 1's response body cannot be sent; the server
+	// parks in pump_for_window with stream 1 still in c.streams.
+	out << H2Frame(H2SettingsFrame{
+		settings: [H2Setting{h2_settings_initial_window_size, 0}]
+	}).encode()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    base_block
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	// Post-END_STREAM HEADERS on stream 1 containing the HPACK incremental entry.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    invalid_block
+		end_headers: true
+		end_stream:  false
+	}).encode()
+	// Stream 3 references the entry from the invalid block (dynamic index 62).
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   3
+		fragment:    s3_block
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	// Unblock stream 3's stalled response body.
+	out << H2Frame(H2WindowUpdateFrame{
+		stream_id:             3
+		window_size_increment: 1000
+	}).encode()
+
+	mut client_end := spawn_h2_echo_server()
+	client_end.write(out) or {
+		assert false, 'HPACK sync: client write failed: ${err}'
+		return
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut dec := H2HpackDecoder{}
+	mut rst1 := i64(-1)
+	mut s3_status := 0
+	mut goaway_code := i64(-1)
+	for _ in 0 .. 64 {
+		f := fr.next() or { break }
+		match f {
+			H2GoawayFrame {
+				goaway_code = i64(f.error_code)
+				break
+			}
+			H2RstStreamFrame {
+				if f.stream_id == 1 {
+					rst1 = i64(f.error_code)
+				}
+			}
+			H2HeadersFrame {
+				if f.stream_id == 3 {
+					for hf in dec.decode(f.fragment) or { []H2HeaderField{} } {
+						if hf.name == ':status' {
+							s3_status = hf.value.int()
+						}
+					}
+				}
+			}
+			else {}
+		}
+
+		if s3_status != 0 && rst1 >= 0 {
+			break
+		}
+	}
+	assert goaway_code == -1, 'HPACK sync: unexpected GOAWAY (code ${goaway_code}) — post-END_STREAM block was not decoded'
+	assert rst1 == i64(u32(H2ErrorCode.stream_closed)), 'HPACK sync: expected RST_STREAM(STREAM_CLOSED) on stream 1, got ${rst1}'
+	assert s3_status == 200, 'HPACK sync: stream 3 should get 200 (dynamic table intact), got ${s3_status}'
+}

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -810,3 +810,30 @@ fn test_h2_server_refuses_stream_over_concurrency_limit() {
 	}
 	assert code == i64(u32(H2ErrorCode.refused_stream)), 'over-limit stream: expected RST_STREAM(REFUSED_STREAM) on stream 3, got ${code}'
 }
+
+// RFC 9113 §5.1: an even (server-initiated) stream id is never opened by this
+// server — it is idle, NOT closed, even after the client has opened a higher odd
+// stream. A DATA frame on it must be a connection error PROTOCOL_ERROR, not a
+// STREAM_CLOSED stream error. Regression for the last_stream_id-parity miss
+// (Codex, #27589 discussion_r3488271404).
+fn test_h2_server_data_on_even_stream_is_connection_error() {
+	mut enc := H2HpackEncoder{}
+	mut out := preface_and_settings()
+	// Client opens odd stream 3 (served, advancing last_stream_id to 3)...
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   3
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	// ...then sends DATA on even stream 2, which is below last_stream_id but was
+	// never opened (even ids are server-initiated). It is idle, so -> conn error.
+	out << H2Frame(H2DataFrame{
+		stream_id:  2
+		data:       'x'.bytes()
+		end_stream: true
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	code := drive_until_goaway_or_close(mut client_end, out, 'DATA on even idle stream')
+	assert code == i64(u32(H2ErrorCode.protocol_error)), 'DATA on even idle stream: expected GOAWAY(PROTOCOL_ERROR), got ${code}'
+}

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -918,6 +918,210 @@ fn test_h2_server_refuses_over_limit_stream_during_window_stall() {
 	assert s1_ended, 'stalled stream 1 response should complete after WINDOW_UPDATE'
 }
 
+// RFC 9113 §6.8 / §5.1.2: GOAWAY's last_stream_id is the highest stream the
+// server "might have taken some action on" — a stream refused purely for
+// exceeding the concurrency limit (REFUSED_STREAM) was, per §5.1.2, refused
+// "prior to any processing" and is already told via its own RST_STREAM that it
+// is safe to retry elsewhere. It should not inflate last_stream_id in a later
+// GOAWAY beyond the highest stream actually processed.
+//
+// Setup: stream 1 stays open (ambiguous outcome). Stream 3 is refused (over
+// the concurrency limit). Stream 2 (an even/server-initiated id) then triggers
+// a hard connection error, forcing a GOAWAY. The reported last_stream_id must
+// be 1 (the highest genuinely-processed/ambiguous stream), not 3 (the refused
+// one, whose fate is already known from its own RST_STREAM).
+fn test_h2_server_goaway_last_stream_id_excludes_refused_stream() {
+	mut enc := H2HpackEncoder{}
+	mut out := preface_and_settings()
+	// Stream 1: left open (no END_STREAM) so its outcome stays ambiguous.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  false
+	}).encode()
+	// Stream 3: refused (over concurrency limit) — never processed.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   3
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	// Stream 2 (even, server-initiated) is always invalid — forces a hard
+	// connection error and a best-effort GOAWAY.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   2
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  true
+	}).encode()
+
+	mut client_end := spawn_h2_echo_server()
+	client_end.write(out) or {
+		assert false, 'GOAWAY last_stream_id: client write failed: ${err}'
+		return
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut goaway_last_id := u32(0xFFFFFFFF)
+	mut got_goaway := false
+	for _ in 0 .. 32 {
+		f := fr.next() or { break }
+		if f is H2GoawayFrame {
+			goaway_last_id = f.last_stream_id
+			got_goaway = true
+			break
+		}
+	}
+	assert got_goaway, 'GOAWAY last_stream_id: server did not send a GOAWAY'
+	assert goaway_last_id == u32(1), 'GOAWAY last_stream_id: expected 1 (refused stream 3 must not count), got ${goaway_last_id}'
+}
+
+// RFC 9113 §6.8: GOAWAY's last_stream_id must include a stream that is still
+// mid-CONTINUATION (HEADERS not yet fully assembled) when an unrelated
+// connection error forces a GOAWAY — the server has already started "acting
+// on" that stream (accepted its id, is holding its partial HPACK block) even
+// though finalize_headers has not run yet. Bumping last_processed_stream_id
+// only inside finalize_headers misses this window entirely.
+//
+// Setup: stream 1's HEADERS arrives without END_HEADERS (awaiting
+// CONTINUATION). A WINDOW_UPDATE frame then arrives instead of the expected
+// CONTINUATION — a RFC 9113 §6.10 connection error, unrelated to stream 1's
+// own content. The resulting GOAWAY must report last_stream_id 1, not 0.
+fn test_h2_server_goaway_last_stream_id_includes_mid_continuation_stream() {
+	mut enc := H2HpackEncoder{}
+	mut out := preface_and_settings()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: false
+		end_stream:  true
+	}).encode()
+	// Not a CONTINUATION — violates RFC 9113 §6.10 while stream 1 is still being
+	// assembled, forcing a connection error unrelated to stream 1's own bytes.
+	out << H2Frame(H2WindowUpdateFrame{
+		stream_id:             1
+		window_size_increment: 100
+	}).encode()
+
+	mut client_end := spawn_h2_echo_server()
+	client_end.write(out) or {
+		assert false, 'GOAWAY mid-continuation: client write failed: ${err}'
+		return
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut goaway_last_id := u32(0xFFFFFFFF)
+	mut got_goaway := false
+	for _ in 0 .. 32 {
+		f := fr.next() or { break }
+		if f is H2GoawayFrame {
+			goaway_last_id = f.last_stream_id
+			got_goaway = true
+			break
+		}
+	}
+	assert got_goaway, 'GOAWAY mid-continuation: server did not send a GOAWAY'
+	assert goaway_last_id == u32(1), 'GOAWAY mid-continuation: expected 1 (stream 1 was being acted on), got ${goaway_last_id}'
+}
+
+// RFC 9113 §6.4 / RFC 7541 §2.2: a HEADERS block arriving on a stream the
+// server has already RST'd itself (locally_reset) must still be HPACK-decoded
+// before being discarded — the dynamic table is connection-wide, so skipping
+// the decode desyncs it for every later stream. Regression for Codex,
+// #27589 discussion_r3493008528 ("Decode reset-stream HEADERS before ignoring
+// them"): before the fix, on_headers took the "invalid client stream id" path
+// for this in-flight second HEADERS block — a hard connection error (GOAWAY)
+// instead of a silent, HPACK-synced drain.
+//
+// Setup: stream 1 is malformed (missing :scheme) so the server RSTs it
+// immediately (protocol_error) and marks it locally_reset. A second HEADERS
+// block then arrives on stream 1 — in-flight, as if sent by the client before
+// it received the RST — carrying a literal-with-incremental-indexing entry
+// ("x-sync: 1" → dynamic index 62). Stream 3 (a valid, complete request) then
+// references that entry via 0xBE. If the block was skipped instead of decoded,
+// 0xBE is unresolvable and the connection closes with GOAWAY instead of
+// serving stream 3.
+fn test_h2_server_hpack_sync_after_locally_reset_stream_headers() {
+	// Malformed: :method + :path only, no :scheme -> h2_validate_request_pseudo
+	// rejects it (RFC 9113 §8.1.2.3) and the server RSTs stream 1 immediately.
+	malformed_block := [u8(0x82), 0x84, 0x01, 0x09, 0x68, 0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c,
+		0x65]
+	// Literal-with-incremental-indexing: adds "x-sync: 1" to the dynamic table.
+	invalid_block := [u8(0x40), 0x06, 0x78, 0x2d, 0x73, 0x79, 0x6e, 0x63, 0x01, 0x31]
+	// A complete, valid request (has :scheme) plus indexed(62) = "x-sync: 1".
+	s3_block := [u8(0x82), 0x84, 0x87, 0x01, 0x09, 0x68, 0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c,
+		0x65, 0xBE]
+
+	mut out := preface_and_settings()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    malformed_block
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	// In-flight second HEADERS on stream 1, arriving after the server already
+	// sent RST_STREAM(1) but before the client would have received it.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    invalid_block
+		end_headers: true
+		end_stream:  false
+	}).encode()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   3
+		fragment:    s3_block
+		end_headers: true
+		end_stream:  true
+	}).encode()
+
+	mut client_end := spawn_h2_echo_server()
+	client_end.write(out) or {
+		assert false, 'HPACK sync after local RST: client write failed: ${err}'
+		return
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut dec := H2HpackDecoder{}
+	mut rst1 := i64(-1)
+	mut s3_status := 0
+	mut goaway_code := i64(-1)
+	for _ in 0 .. 64 {
+		f := fr.next() or { break }
+		match f {
+			H2GoawayFrame {
+				goaway_code = i64(f.error_code)
+				break
+			}
+			H2RstStreamFrame {
+				if f.stream_id == 1 {
+					rst1 = i64(f.error_code)
+				}
+			}
+			H2HeadersFrame {
+				if f.stream_id == 3 {
+					for hf in dec.decode(f.fragment) or { []H2HeaderField{} } {
+						if hf.name == ':status' {
+							s3_status = hf.value.int()
+						}
+					}
+				}
+			}
+			else {}
+		}
+
+		if s3_status != 0 && rst1 >= 0 {
+			break
+		}
+	}
+	assert goaway_code == -1, 'HPACK sync after local RST: unexpected GOAWAY (code ${goaway_code}) — in-flight block was not decoded'
+	assert rst1 == i64(u32(H2ErrorCode.protocol_error)), 'HPACK sync after local RST: expected RST_STREAM(PROTOCOL_ERROR) on stream 1, got ${rst1}'
+	assert s3_status == 200, 'HPACK sync after local RST: stream 3 should get 200 (dynamic table intact), got ${s3_status}'
+}
+
 // RFC 9113 §5.1 / RFC 7541 §2.2: a HEADERS block arriving on a half-closed
 // (remote) stream must be HPACK-decoded before the server sends
 // RST_STREAM(STREAM_CLOSED). The HPACK dynamic table is connection-wide; skipping

--- a/vlib/net/http/h2spec/h2spec_expected_failures.txt
+++ b/vlib/net/http/h2spec/h2spec_expected_failures.txt
@@ -12,17 +12,16 @@
 # plus HPACK decode-error scope (§4.3: a decode failure is a connection-level
 # COMPRESSION_ERROR, not RST_STREAM) closed 21; the §5.1/§6.1/§6.4 stream-state
 # rules (frames on idle streams are connection errors, on closed streams are
-# STREAM_CLOSED) closed 8 more — 137 pass, 8 fail — verified stable at --timeout 5.
-# NOTE: a handful of h2spec cases (CONTINUATION sequencing, unknown error codes)
-# are timing-flaky at h2spec's 2s default — they wait for the server's GOAWAY/close
-# — so run_h2spec.sh uses --timeout 5 (H2SPEC_TIMEOUT) to keep the gate stable. Do
-# not add a flaky case to this list; raise the timeout instead. The remaining 8 are
-# genuine server-side conformance gaps: the concurrency limit (§5.1.2 needs true
-# concurrent stream handling — this server is serial, so it processes and closes a
-# stream before the excess one is read), PRIORITY self-dependency, SETTINGS_ENABLE_PUSH
-# validation, and flow-control zero-increment/overflow handling. Remove a line when
-# the server is fixed to pass.
-http2/5.1.2 :: Sends HEADERS frames that causes their advertised concurrent stream limit to be exceeded
+# STREAM_CLOSED) closed 8 more; routing the flow-control stall path
+# (pump_for_window) through the same dispatch closed §5.1.2 (an over-limit stream
+# opened while a response is stalled is now refused) — 138 pass, 7 fail — verified
+# stable at --timeout 5. NOTE: a handful of h2spec cases (CONTINUATION sequencing,
+# unknown error codes) are timing-flaky at h2spec's 2s default — they wait for the
+# server's GOAWAY/close — so run_h2spec.sh uses --timeout 5 (H2SPEC_TIMEOUT) to keep
+# the gate stable. Do not add a flaky case to this list; raise the timeout instead.
+# The remaining 7 are genuine server-side conformance gaps: PRIORITY self-dependency,
+# SETTINGS_ENABLE_PUSH validation, and flow-control zero-increment/overflow handling.
+# Remove a line when the server is fixed to pass.
 http2/5.3.1 :: Sends HEADERS frame that depends on itself
 http2/5.3.1 :: Sends PRIORITY frame that depend on itself
 http2/6.5.2 :: SETTINGS_ENABLE_PUSH (0x2): Sends the value other than 0 or 1

--- a/vlib/net/http/h2spec/h2spec_expected_failures.txt
+++ b/vlib/net/http/h2spec/h2spec_expected_failures.txt
@@ -10,26 +10,21 @@
 # Generated with h2spec v2.6.0 (146 tests). The original baseline was 37 failures
 # (109 pass). Request header/pseudo-header validation (RFC 9113 §8.1.2/§8.2.2/§8.3)
 # plus HPACK decode-error scope (§4.3: a decode failure is a connection-level
-# COMPRESSION_ERROR, not RST_STREAM) closed 21 of them — 129 pass, 16 fail —
-# verified stable at --timeout 5. NOTE: a handful of h2spec cases (CONTINUATION
-# sequencing, unknown error codes) are timing-flaky at h2spec's 2s default — they
-# wait for the server's GOAWAY/close — so run_h2spec.sh uses --timeout 5
-# (H2SPEC_TIMEOUT) to keep the gate stable. Do not add a flaky case to this list;
-# raise the timeout instead. The remaining 16 are genuine server-side conformance
-# gaps: the stream state machine (frames on idle/closed streams), concurrent-stream
-# limit, PRIORITY self-dependency, SETTINGS_ENABLE_PUSH validation, and flow-control
-# zero-increment/overflow handling. Remove a line when the server is fixed to pass.
-http2/5.1 :: closed: Sends a DATA frame
-http2/5.1 :: closed: Sends a DATA frame after sending RST_STREAM frame
-http2/5.1 :: half closed (remote): Sends a DATA frame
-http2/5.1 :: idle: Sends a DATA frame
-http2/5.1 :: idle: Sends a RST_STREAM frame
-http2/5.1 :: idle: Sends a WINDOW_UPDATE frame
+# COMPRESSION_ERROR, not RST_STREAM) closed 21; the §5.1/§6.1/§6.4 stream-state
+# rules (frames on idle streams are connection errors, on closed streams are
+# STREAM_CLOSED) closed 8 more — 137 pass, 8 fail — verified stable at --timeout 5.
+# NOTE: a handful of h2spec cases (CONTINUATION sequencing, unknown error codes)
+# are timing-flaky at h2spec's 2s default — they wait for the server's GOAWAY/close
+# — so run_h2spec.sh uses --timeout 5 (H2SPEC_TIMEOUT) to keep the gate stable. Do
+# not add a flaky case to this list; raise the timeout instead. The remaining 8 are
+# genuine server-side conformance gaps: the concurrency limit (§5.1.2 needs true
+# concurrent stream handling — this server is serial, so it processes and closes a
+# stream before the excess one is read), PRIORITY self-dependency, SETTINGS_ENABLE_PUSH
+# validation, and flow-control zero-increment/overflow handling. Remove a line when
+# the server is fixed to pass.
 http2/5.1.2 :: Sends HEADERS frames that causes their advertised concurrent stream limit to be exceeded
 http2/5.3.1 :: Sends HEADERS frame that depends on itself
 http2/5.3.1 :: Sends PRIORITY frame that depend on itself
-http2/6.1 :: Sends a DATA frame on the stream that is not in "open" or "half-closed (local)" state
-http2/6.4 :: Sends a RST_STREAM frame on a idle stream
 http2/6.5.2 :: SETTINGS_ENABLE_PUSH (0x2): Sends the value other than 0 or 1
 http2/6.9 :: Sends a WINDOW_UPDATE frame with a flow control window increment of 0
 http2/6.9 :: Sends a WINDOW_UPDATE frame with a flow control window increment of 0 on a stream


### PR DESCRIPTION
## What

Adds the server-side HTTP/2 stream state machine (RFC 9113 §5.1/§6.1/§6.4). A new
`classify_stream(id) -> active | idle | closed` helper drives frame-acceptance:

- **DATA / RST_STREAM / WINDOW_UPDATE on an idle stream** (one never opened) → connection
  error `PROTOCOL_ERROR`.
- **DATA on a closed / half-closed-remote stream** → `STREAM_CLOSED` stream error
  (`RST_STREAM`), crediting the connection flow window first.
- **HEADERS opening a stream beyond `SETTINGS_MAX_CONCURRENT_STREAMS`** → still HPACK-decoded
  (the decoder is stateful; skipping it would desync the dynamic table) but answered with
  `RST_STREAM(REFUSED_STREAM)` instead of being served.

This is the second PR in the server-conformance series (follows #27569, request header /
HPACK-scope validation).

## h2spec results

Closes **8** h2spec cases — baseline trimmed 16 → 8, verified with the in-repo gate
(`run_h2spec.sh`, h2spec v2.6.0, `--timeout 5`): **137 passed / 8 failed, no regressions**.

Cases now passing: `http2/5.1` idle DATA/RST/WINDOW_UPDATE, `5.1` closed DATA, `5.1`
closed-after-RST DATA, `5.1` half-closed DATA, `http2/6.1`, `http2/6.4`.

`http2/5.1.2` (concurrency limit) stays baselined: the probe opens both streams with
END_STREAM, so this serial server processes and closes the first before reading the second —
they are never concurrent. The `refused`-stream path is correct for pipelined bodyful requests,
but the h2spec case needs true concurrent stream handling (a planned follow-up).

## Tests

Five new scripted-peer unit tests in `h2_server_test.v` cover the idle (connection-error),
closed (`STREAM_CLOSED`), and over-limit (`REFUSED_STREAM`) paths. `vlib/net/http/h2_server_test.v`
passes under gcc.

🧙 Built with [WOZCODE](https://wozcode.com)
