### PR TITLE
v3: gate optional backend imports in self-host

### DIFF
--- a/vlib/v3/tests/selfhost_backend_prune_test.v
+++ b/vlib/v3/tests/selfhost_backend_prune_test.v
@@ -1,0 +1,45 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn build_selfhost_prune_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_selfhost_backend_prune_boot_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(v3_bin)} ${os.quoted_path(v3_src)}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn selfhost_to_c(v3_bin string, name string, flags string) string {
+	out_bin := os.join_path(os.temp_dir(), 'v3_selfhost_backend_prune_${name}_${os.getpid()}')
+	out_c := out_bin + '.c'
+	os.rm(out_bin) or {}
+	os.rm(out_c) or {}
+	cmd := '${os.quoted_path(v3_bin)} --no-parallel -selfhost ${flags} -o ${os.quoted_path(out_bin)} ${os.quoted_path(v3_src)}'
+	res := os.execute(cmd)
+	assert res.exit_code == 0, res.output
+	assert os.exists(out_c), 'missing generated C output ${out_c}'
+	return os.read_file(out_c) or { panic(err) }
+}
+
+fn test_selfhost_default_prunes_optional_backends() {
+	v3_bin := build_selfhost_prune_v3()
+	c_src := selfhost_to_c(v3_bin, 'default', '')
+	assert !c_src.contains('v3__gen__wasm__'), 'default self-host compiled the wasm backend'
+	assert !c_src.contains('v3__gen__arm64__'), 'default self-host compiled the arm64 backend'
+	assert !c_src.contains('v3__ssa__'), 'default self-host compiled the SSA backend'
+	assert !c_src.contains('v3__eval__'), 'default self-host compiled the eval backend'
+}
+
+fn test_selfhost_compile_backend_wasm_opts_wasm_back_in() {
+	v3_bin := build_selfhost_prune_v3()
+	c_src := selfhost_to_c(v3_bin, 'wasm', '-compile-backend wasm')
+	assert c_src.contains('v3__gen__wasm__Gen__new'), 'wasm backend was not compiled after opt-in'
+	assert !c_src.contains('v3__gen__arm64__'), 'wasm opt-in compiled the arm64 backend'
+	assert !c_src.contains('v3__ssa__'), 'wasm opt-in compiled the SSA backend'
+	assert !c_src.contains('v3__eval__'), 'wasm opt-in compiled the eval backend'
+}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2,18 +2,25 @@ module main
 
 import os
 import v3.bench
-import v3.eval
 import v3.flat
-import v3.gen.arm64
 import v3.gen.c as cgen
-import v3.gen.wasm
 import v3.markused
 import v3.parser
 import v3.pref
-import v3.ssa
-import v3.ssa.optimize
 import v3.transform
 import v3.types
+
+$if !skip_eval ? {
+	import v3.eval
+}
+$if !skip_arm64 ? {
+	import v3.gen.arm64
+	import v3.ssa
+	import v3.ssa.optimize
+}
+$if !skip_wasm ? {
+	import v3.gen.wasm
+}
 
 // run_compile_command supports run compile command handling for v3 entry point.
 fn run_compile_command(cmd string) os.Result {


### PR DESCRIPTION
## Summary
- Gate optional v3 backend imports behind the existing `skip_*` compile defines.
- Add self-host regression coverage that default C output excludes wasm/arm64/eval backend symbols and `-compile-backend wasm` opts wasm back in.

## Testing
- `./vnew fmt -w vlib/v3/v3.v vlib/v3/tests/selfhost_backend_prune_test.v`
- `./vnew test vlib/v3/tests/selfhost_backend_prune_test.v`
- `./vnew -o /tmp/v3_wasm_backend_check vlib/v3/v3.v`
- `/tmp/v3_wasm_backend_check -b wasm -o /tmp/v3_wasm_backend_check_hello.wasm vlib/v3/tests/hello.v`
- `./vnew -d skip_wasm -d skip_arm64 -d skip_eval -o /tmp/v3_skip_optional_backends.c vlib/v3/v3.v`