### PR TITLE
ci: use FreeBSD version 15.1

### DIFF
--- a/.github/workflows/freebsd_ci.yml
+++ b/.github/workflows/freebsd_ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: freebsd
-          version: '15.0'
+          version: '15.1'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
@@ -79,7 +79,7 @@ jobs:
         uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: freebsd
-          version: '15.0'
+          version: '15.1'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
@@ -120,7 +120,7 @@ jobs:
         uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: freebsd
-          version: '15.0'
+          version: '15.1'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -153,7 +153,7 @@ jobs:
         uses: cross-platform-actions/action@v1.3.0
         with:
           operating_system: freebsd
-          version: '15.0'
+          version: '15.1'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm

--- a/.github/workflows/update_tccbin.yml
+++ b/.github/workflows/update_tccbin.yml
@@ -141,7 +141,7 @@ jobs:
         include:
           - id: freebsd-amd64
             operating_system: freebsd
-            version: '15.0'
+            version: '15.1'
             branch: thirdparty-freebsd-amd64
             script: thirdparty/build_scripts/thirdparty-freebsd-amd64_tcc.sh
             install: sudo pkg install -y bash git gmake rsync


### PR DESCRIPTION
In "CI FreeBSD", "Tools CI" and "Update tccbin" workflows, update FreeBSD version to use 15.1 (available with
[cross-platform-actions/action](https://github.com/cross-platform-actions/action) v1.3.0).

FreeBSD version 15.1 released on June 16, 2026 => https://www.freebsd.org/releases/15.1R/announce/

✅ Run of "CI FreeBSD" workflow with FreeBSD version 15.1 => https://github.com/lcheylus/v/actions/runs/28377241060


