### PR TITLE
cmd: handle v share API failures

### DIFF
--- a/cmd/tools/modules/vshare/api.v
+++ b/cmd/tools/modules/vshare/api.v
@@ -1,0 +1,40 @@
+module vshare
+
+import json
+
+const max_response_excerpt_len = 200
+
+struct ShareResponse {
+	hash  string
+	error string
+}
+
+// share_url_from_response validates the playground share API response and returns the public URL.
+pub fn share_url_from_response(status_code int, body string) !string {
+	if status_code < 200 || status_code >= 300 {
+		excerpt := response_excerpt(body)
+		if excerpt == '' {
+			return error('Failed to share code: playground returned HTTP ${status_code}')
+		}
+		return error('Failed to share code: playground returned HTTP ${status_code}: ${excerpt}')
+	}
+	response := json.decode(ShareResponse, body) or {
+		return error('Failed to decode playground response: ${err.msg()}')
+	}
+	if response.error != '' {
+		return error('Failed to share code: ${response.error}')
+	}
+	if response.hash == '' {
+		return error('Failed to share code: playground response did not include a hash')
+	}
+	return 'https://play.vlang.io/p/${response.hash}'
+}
+
+fn response_excerpt(body string) string {
+	mut text := body.trim_space()
+	text = text.replace('\r', ' ').replace('\n', ' ')
+	if text.len <= max_response_excerpt_len {
+		return text
+	}
+	return text[..max_response_excerpt_len] + '...'
+}

--- a/cmd/tools/modules/vshare/api_test.v
+++ b/cmd/tools/modules/vshare/api_test.v
@@ -1,0 +1,38 @@
+module vshare
+
+fn test_share_url_from_response_accepts_successful_response() {
+	url := share_url_from_response(200, '{"hash":"21cf286fdb","error":""}')!
+	assert url == 'https://play.vlang.io/p/21cf286fdb'
+}
+
+fn test_share_url_from_response_reports_http_errors() {
+	if url := share_url_from_response(502, 'error code: 502') {
+		assert false, 'expected an error, got ${url}'
+	} else {
+		assert err.msg() == 'Failed to share code: playground returned HTTP 502: error code: 502'
+	}
+}
+
+fn test_share_url_from_response_reports_malformed_json() {
+	if url := share_url_from_response(200, 'error code: 502') {
+		assert false, 'expected an error, got ${url}'
+	} else {
+		assert err.msg().starts_with('Failed to decode playground response:')
+	}
+}
+
+fn test_share_url_from_response_reports_api_errors() {
+	if url := share_url_from_response(200, '{"hash":"","error":"snippet was not saved"}') {
+		assert false, 'expected an error, got ${url}'
+	} else {
+		assert err.msg() == 'Failed to share code: snippet was not saved'
+	}
+}
+
+fn test_share_url_from_response_requires_hash() {
+	if url := share_url_from_response(200, '{"hash":"","error":""}') {
+		assert false, 'expected an error, got ${url}'
+	} else {
+		assert err.msg() == 'Failed to share code: playground response did not include a hash'
+	}
+}

--- a/cmd/tools/vshare.v
+++ b/cmd/tools/vshare.v
@@ -1,14 +1,8 @@
 module main
 
-import json
 import net.http
 import os
 import vshare
-
-struct Response {
-	hash  string
-	error string
-}
 
 fn main() {
 	if os.args.len < 3 {
@@ -35,10 +29,15 @@ fn main() {
 
 	share := http.post_form('https://play.vlang.io/share', {
 		'code': content
-	})!
+	}) or {
+		eprintln('Failed to share code: ${err.msg()}')
+		exit(1)
+	}
 
-	response := json.decode(Response, share.body)!
-	url := 'https://play.vlang.io/p/${response.hash}'
+	url := vshare.share_url_from_response(share.status_code, share.body) or {
+		eprintln(err.msg())
+		exit(1)
+	}
 
 	println(url)
 	if vshare.copy_to_clipboard(url) {


### PR DESCRIPTION
## Summary
- handle network, HTTP, malformed JSON, API error, and missing hash failures in `v share` without panicking
- keep the successful playground URL behavior unchanged
- add focused tests for share response parsing

Refs #27447.

## Testing
- `./vnew fmt -w cmd/tools/vshare.v cmd/tools/modules/vshare/api.v cmd/tools/modules/vshare/api_test.v`
- `./vnew -silent test cmd/tools/modules/vshare/`
- live smoke check: `./vnew share <temp .v file>` now exits with `Failed to share code: playground returned HTTP 502: error code: 502` instead of a V panic while play.vlang.io returns 502