### PR TITLE
vfmt: keep first multiline fn parameter

### DIFF
--- a/vlib/v/fmt/tests/fn_with_long_args_keep.vv
+++ b/vlib/v/fmt/tests/fn_with_long_args_keep.vv
@@ -9,4 +9,12 @@ fn process_keyholder2(super_long_argument1 string, super_long_argument2 string, 
 	return ''
 }
 
+fn this_function_has_an_excessively_long_name(total_minutes_v_made_me_cry i32,
+	minutes_cried_today i32) !i32 {
+	if minutes_cried_today < 1 {
+		return error('do not lie to me')
+	}
+	return total_minutes_v_made_me_cry + minutes_cried_today
+}
+
 fn main() {}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -1429,7 +1429,7 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool, bool) {
 		|| (p.peek_token(2).kind == .comma && (p.tok.kind != .key_mut
 		|| p.peek_tok.lit[0].is_capital())) || p.peek_token(2).kind == .rpar
 		|| (p.peek_tok.kind == .name && p.peek_token(2).kind == .dot)))
-	mut prev_param_newline := p.tok.pos().line_nr
+	mut prev_param_newline := p.prev_tok.pos().line_nr
 	// TODO: copy paste, merge 2 branches
 	if types_only {
 		mut param_no := 1


### PR DESCRIPTION
Fixes #27594.

## Summary
- record function parameter newlines relative to the opening `(` token
- add a vfmt keep regression for a function signature where the first parameter starts on the next line

## Testing
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w vlib/v/parser/fn.v`
- `./vnew fmt -w vlib/v/fmt/tests/fn_with_long_args_keep.vv`
- `VTEST_ONLY=fn_with_long_args_keep.vv ./vnew -silent vlib/v/fmt/fmt_keep_test.v`
- `./vnew -silent test vlib/v/parser/`
- `./vnew -silent test vlib/v/fmt/`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/` fails locally due to existing untracked `vlib/v/tests/fns/closure_reclaim_with_gc_test.c.v` (`1 failed, 2281 passed, 22 skipped, 2304 total`)
