### PR TITLE
[codex] v3: improve v1 compilation

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -54,6 +54,8 @@ mut:
 	fn_decl_ret_types            map[string]types.Type // fn decl name (and qualified variants) -> return type
 	struct_decl_infos            map[string]StructDeclInfo
 	struct_decl_short_infos      map[string]StructDeclInfo
+	shared_type_names            map[string]string // __shared__ wrapper name -> wrapped V type text
+	needs_shared_runtime         bool
 	const_runtime_inits          []string
 	const_runtime_init_modules   []string
 	runtime_inits                []string
@@ -69,6 +71,7 @@ mut:
 	cur_fn_ret                   types.Type = types.Type(types.void_)
 	cur_fn_ret_is_optional       bool
 	cur_fn_ret_base              types.Type = types.Type(types.void_)
+	active_locks                 []flat.Node
 	// in_return is true only while generating a `return` statement's value, so a bare
 	// generic literal (`return Box{...}`) may adopt `cur_fn_ret`'s concrete instance —
 	// but a literal in a local decl / argument elsewhere in the body does not.
@@ -157,11 +160,13 @@ pub fn FlatGen.new() FlatGen {
 		fn_decl_ret_types:            map[string]types.Type{}
 		struct_decl_infos:            map[string]StructDeclInfo{}
 		struct_decl_short_infos:      map[string]StructDeclInfo{}
+		shared_type_names:            map[string]string{}
 		cur_param_names:              []string{}
 		cur_param_type_values:        []types.Type{}
 		cur_param_types:              map[string]types.Type{}
 		cur_concrete_optional_params: map[string]bool{}
 		cur_mut_params:               map[string]bool{}
+		active_locks:                 []flat.Node{}
 		needed_optional_types:        map[string]string{}
 		emitted_optional_types:       map[string]bool{}
 		emitted_fns:                  map[string]bool{}
@@ -253,11 +258,14 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.fn_decl_ret_types = map[string]types.Type{}
 	g.struct_decl_infos = map[string]StructDeclInfo{}
 	g.struct_decl_short_infos = map[string]StructDeclInfo{}
+	g.shared_type_names = map[string]string{}
+	g.needs_shared_runtime = false
 	g.cur_param_names = []string{}
 	g.cur_param_type_values = []types.Type{}
 	g.cur_param_types = map[string]types.Type{}
 	g.cur_concrete_optional_params = map[string]bool{}
 	g.cur_mut_params = map[string]bool{}
+	g.active_locks = []flat.Node{}
 	g.needed_optional_types = map[string]string{}
 	g.emitted_optional_types = map[string]bool{}
 	g.emitted_fns = map[string]bool{}
@@ -277,6 +285,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	}
 	g.has_builtins = g.tc.has_builtins
 	g.collect_gen_info()
+	g.collect_shared_type_names()
 	g.precompute_embedded_fields()
 	g.precompute_param_type_index()
 	g.collect_interface_impls()
@@ -321,6 +330,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.builtin_abi_decls()
 	g.global_decls()
 	g.forward_decls()
+	g.shared_dup_fns()
 	g.enum_str_forward_decls()
 	g.callback_wrapper_decls()
 	g.spawn_wrapper_decls()
@@ -2327,6 +2337,11 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 		g.expected_enum = old_expected_enum
 		return
 	}
+	if g.gen_sum_pointer_value_expr(id, expected) {
+		g.expected_expr_type = old_expected
+		g.expected_enum = old_expected_enum
+		return
+	}
 	if g.gen_interface_value_expr(id, expected) {
 		g.expected_expr_type = old_expected
 		g.expected_enum = old_expected_enum
@@ -2340,6 +2355,57 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 	g.gen_expr(id)
 	g.expected_expr_type = old_expected
 	g.expected_enum = old_expected_enum
+}
+
+fn (mut g FlatGen) gen_sum_pointer_value_expr(id flat.NodeId, expected types.Type) bool {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return false
+	}
+	mut sum_type0 := match expected {
+		types.Pointer { expected.base_type }
+		else { return false }
+	}
+
+	if sum_type0 is types.Alias {
+		sum_type0 = sum_type0.base_type
+	}
+	if sum_type0 !is types.SumType {
+		return false
+	}
+	sum_type := sum_type0 as types.SumType
+	node := g.a.nodes[int(id)]
+	if node.kind != .prefix || node.op != .amp || node.children_count == 0 {
+		return false
+	}
+	child_id := g.a.child(&node, 0)
+	child := g.a.nodes[int(child_id)]
+	actual0 := g.sum_cast_actual_type(child_id)
+	mut actual_type := if actual0 is types.Alias { actual0.base_type } else { actual0 }
+	if actual_type is types.Pointer {
+		actual_type = actual_type.base_type
+	}
+	if actual_type is types.SumType {
+		if child.kind == .ident && child.value.starts_with('__sum_ref_')
+			&& g.type_names_match(actual_type, sum_type0) {
+			ct := g.tc.c_type(sum_type0)
+			g.write('(${ct}*)memdup(&')
+			g.gen_expr(child_id)
+			g.write(', sizeof(${ct}))')
+			return true
+		}
+		return false
+	}
+	sum_name := g.resolve_sum_name(sum_type.name)
+	variant := g.resolve_variant(sum_name, actual_type.name())
+	variants := g.tc.sum_types[sum_name] or { return false }
+	if variant !in variants {
+		return false
+	}
+	ct := g.tc.c_type(sum_type0)
+	g.write('(${ct}*)memdup(&')
+	g.gen_sum_cast_expr(sum_type, child_id)
+	g.write(', sizeof(${ct}))')
+	return true
 }
 
 // gen_sum_value_expr emits sum value expr output for c.
@@ -2593,6 +2659,21 @@ fn (mut g FlatGen) gen_sum_shared_field_selector(base_id flat.NodeId, base_type0
 	g.writeln('; ${ct} __field = {0};')
 	g.gen_sum_shared_field_switch('__sum', sum_name, field, []string{})
 	g.write('__field; })')
+	return true
+}
+
+fn (mut g FlatGen) gen_sum_type_tag_selector(base_id flat.NodeId, base_type0 types.Type, op flat.Op) bool {
+	sum_name := g.sum_type_name_for_type(base_type0) or { return false }
+	sum_ct := g.tc.c_type(g.tc.parse_type(sum_name))
+	g.write('({ ${sum_ct} __sum = ')
+	if op == .arrow || base_type0 is types.Pointer {
+		g.write('*(')
+		g.gen_expr(base_id)
+		g.write(')')
+	} else {
+		g.gen_expr(base_id)
+	}
+	g.write('; __sum.typ; })')
 	return true
 }
 
@@ -3386,6 +3467,9 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 		.spawn_expr {
 			g.gen_spawn_expr(node)
 		}
+		.lock_expr {
+			g.gen_lock_expr(node)
+		}
 		.infix {
 			// A very long left-nested `||`/`&&` chain (e.g. from a big match condition or
 			// a `!in [...]` over many values) would recurse once per link and overflow the
@@ -3497,6 +3581,9 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				}
 			}
 			if node.op == .amp && g.gen_amp_c_string_literal(child_id, child) {
+				return
+			} else if node.op == .amp && node.typ.len > 0
+				&& g.gen_sum_pointer_value_expr(id, g.tc.parse_type(node.typ)) {
 				return
 			} else if node.op == .amp && child.kind == .struct_init {
 				g.gen_heap_struct_init(child)
@@ -3696,6 +3783,11 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				} else {
 					g.write('.len')
 				}
+			} else if node.value == '__v_sum_type_tag__'
+				&& g.gen_sum_type_tag_selector(base_id, base_type0, node.op) {
+				// handled
+			} else if g.gen_shared_field_value_selector(base_id, base_type0, node.value, node.op) {
+				// handled
 			} else if g.gen_sum_shared_field_selector(base_id, base_type0, node.value) {
 				// handled
 			} else if base.kind == .call && base.children_count == 2
@@ -6950,7 +7042,7 @@ fn (mut g FlatGen) queue_const_map_literal_sets(target string, val_id flat.NodeI
 }
 
 fn (mut g FlatGen) queue_fixed_array_runtime_init(target string, val_id flat.NodeId, fixed types.ArrayFixed) bool {
-	expr := g.fixed_array_compound_literal_expr(val_id, fixed)
+	expr := g.fixed_array_runtime_copy_source_expr(val_id, fixed)
 	if expr.trim_space().len == 0 {
 		return false
 	}
@@ -6959,12 +7051,20 @@ fn (mut g FlatGen) queue_fixed_array_runtime_init(target string, val_id flat.Nod
 }
 
 fn (mut g FlatGen) queue_const_fixed_array_runtime_init(target string, val_id flat.NodeId, fixed types.ArrayFixed) bool {
-	expr := g.fixed_array_compound_literal_expr(val_id, fixed)
+	expr := g.fixed_array_runtime_copy_source_expr(val_id, fixed)
 	if expr.trim_space().len == 0 {
 		return false
 	}
 	g.queue_const_runtime_init('\tmemmove(${target}, ${expr}, sizeof(${target}));')
 	return true
+}
+
+fn (mut g FlatGen) fixed_array_runtime_copy_source_expr(val_id flat.NodeId, fixed types.ArrayFixed) string {
+	literal := g.fixed_array_compound_literal_expr(val_id, fixed)
+	if literal.trim_space().len > 0 {
+		return literal
+	}
+	return g.fixed_array_copy_source_string(val_id, fixed)
 }
 
 fn (mut g FlatGen) fixed_array_compound_literal_expr(val_id flat.NodeId, fixed types.ArrayFixed) string {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -89,6 +89,7 @@ mut:
 	active_locks                 []ActiveLock
 	loop_depth                   int
 	loop_label_depths            map[string]int
+	goto_label_lock_depths       map[string]int
 	pending_loop_label           string
 	// in_return is true only while generating a `return` statement's value, so a bare
 	// generic literal (`return Box{...}`) may adopt `cur_fn_ret`'s concrete instance —
@@ -186,6 +187,7 @@ pub fn FlatGen.new() FlatGen {
 		cur_mut_params:               map[string]bool{}
 		active_locks:                 []ActiveLock{}
 		loop_label_depths:            map[string]int{}
+		goto_label_lock_depths:       map[string]int{}
 		needed_optional_types:        map[string]string{}
 		emitted_optional_types:       map[string]bool{}
 		emitted_fns:                  map[string]bool{}
@@ -287,6 +289,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.active_locks = []ActiveLock{}
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
+	g.goto_label_lock_depths = map[string]int{}
 	g.pending_loop_label = ''
 	g.needed_optional_types = map[string]string{}
 	g.emitted_optional_types = map[string]bool{}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -12,6 +12,13 @@ struct ActiveLock {
 	loop_depth  int
 }
 
+struct LoopLabelState {
+	label string
+mut:
+	had_prev   bool
+	prev_depth int
+}
+
 // FlatGen emits flat gen output used by c.
 pub struct FlatGen {
 mut:
@@ -61,7 +68,7 @@ mut:
 	fn_decl_ret_types            map[string]types.Type // fn decl name (and qualified variants) -> return type
 	struct_decl_infos            map[string]StructDeclInfo
 	struct_decl_short_infos      map[string]StructDeclInfo
-	shared_type_names            map[string]string // __shared__ wrapper name -> wrapped V type text
+	shared_type_names            map[string]SharedTypeInfo // __shared__ wrapper name -> wrapped type metadata
 	needs_shared_runtime         bool
 	const_runtime_inits          []string
 	const_runtime_init_modules   []string
@@ -80,6 +87,8 @@ mut:
 	cur_fn_ret_base              types.Type = types.Type(types.void_)
 	active_locks                 []ActiveLock
 	loop_depth                   int
+	loop_label_depths            map[string]int
+	pending_loop_label           string
 	// in_return is true only while generating a `return` statement's value, so a bare
 	// generic literal (`return Box{...}`) may adopt `cur_fn_ret`'s concrete instance —
 	// but a literal in a local decl / argument elsewhere in the body does not.
@@ -168,13 +177,14 @@ pub fn FlatGen.new() FlatGen {
 		fn_decl_ret_types:            map[string]types.Type{}
 		struct_decl_infos:            map[string]StructDeclInfo{}
 		struct_decl_short_infos:      map[string]StructDeclInfo{}
-		shared_type_names:            map[string]string{}
+		shared_type_names:            map[string]SharedTypeInfo{}
 		cur_param_names:              []string{}
 		cur_param_type_values:        []types.Type{}
 		cur_param_types:              map[string]types.Type{}
 		cur_concrete_optional_params: map[string]bool{}
 		cur_mut_params:               map[string]bool{}
 		active_locks:                 []ActiveLock{}
+		loop_label_depths:            map[string]int{}
 		needed_optional_types:        map[string]string{}
 		emitted_optional_types:       map[string]bool{}
 		emitted_fns:                  map[string]bool{}
@@ -266,7 +276,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.fn_decl_ret_types = map[string]types.Type{}
 	g.struct_decl_infos = map[string]StructDeclInfo{}
 	g.struct_decl_short_infos = map[string]StructDeclInfo{}
-	g.shared_type_names = map[string]string{}
+	g.shared_type_names = map[string]SharedTypeInfo{}
 	g.needs_shared_runtime = false
 	g.cur_param_names = []string{}
 	g.cur_param_type_values = []types.Type{}
@@ -275,6 +285,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.cur_mut_params = map[string]bool{}
 	g.active_locks = []ActiveLock{}
 	g.loop_depth = 0
+	g.loop_label_depths = map[string]int{}
+	g.pending_loop_label = ''
 	g.needed_optional_types = map[string]string{}
 	g.emitted_optional_types = map[string]bool{}
 	g.emitted_fns = map[string]bool{}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -5,6 +5,13 @@ import strings
 import v3.flat
 import v3.types
 
+struct ActiveLock {
+	mutexes_var string
+	lock_count  int
+	unlock_fn   string
+	loop_depth  int
+}
+
 // FlatGen emits flat gen output used by c.
 pub struct FlatGen {
 mut:
@@ -71,7 +78,8 @@ mut:
 	cur_fn_ret                   types.Type = types.Type(types.void_)
 	cur_fn_ret_is_optional       bool
 	cur_fn_ret_base              types.Type = types.Type(types.void_)
-	active_locks                 []flat.Node
+	active_locks                 []ActiveLock
+	loop_depth                   int
 	// in_return is true only while generating a `return` statement's value, so a bare
 	// generic literal (`return Box{...}`) may adopt `cur_fn_ret`'s concrete instance —
 	// but a literal in a local decl / argument elsewhere in the body does not.
@@ -166,7 +174,7 @@ pub fn FlatGen.new() FlatGen {
 		cur_param_types:              map[string]types.Type{}
 		cur_concrete_optional_params: map[string]bool{}
 		cur_mut_params:               map[string]bool{}
-		active_locks:                 []flat.Node{}
+		active_locks:                 []ActiveLock{}
 		needed_optional_types:        map[string]string{}
 		emitted_optional_types:       map[string]bool{}
 		emitted_fns:                  map[string]bool{}
@@ -265,7 +273,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.cur_param_types = map[string]types.Type{}
 	g.cur_concrete_optional_params = map[string]bool{}
 	g.cur_mut_params = map[string]bool{}
-	g.active_locks = []flat.Node{}
+	g.active_locks = []ActiveLock{}
+	g.loop_depth = 0
 	g.needed_optional_types = map[string]string{}
 	g.emitted_optional_types = map[string]bool{}
 	g.emitted_fns = map[string]bool{}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -9,6 +9,7 @@ struct ActiveLock {
 	mutexes_var string
 	lock_count  int
 	unlock_fn   string
+	scope_id    int
 	loop_depth  int
 	defer_depth int
 }
@@ -89,7 +90,7 @@ mut:
 	active_locks                 []ActiveLock
 	loop_depth                   int
 	loop_label_depths            map[string]int
-	goto_label_lock_depths       map[string]int
+	goto_label_lock_scopes       map[string][]int
 	pending_loop_label           string
 	// in_return is true only while generating a `return` statement's value, so a bare
 	// generic literal (`return Box{...}`) may adopt `cur_fn_ret`'s concrete instance —
@@ -187,7 +188,7 @@ pub fn FlatGen.new() FlatGen {
 		cur_mut_params:               map[string]bool{}
 		active_locks:                 []ActiveLock{}
 		loop_label_depths:            map[string]int{}
-		goto_label_lock_depths:       map[string]int{}
+		goto_label_lock_scopes:       map[string][]int{}
 		needed_optional_types:        map[string]string{}
 		emitted_optional_types:       map[string]bool{}
 		emitted_fns:                  map[string]bool{}
@@ -289,7 +290,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.active_locks = []ActiveLock{}
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
-	g.goto_label_lock_depths = map[string]int{}
+	g.goto_label_lock_scopes = map[string][]int{}
 	g.pending_loop_label = ''
 	g.needed_optional_types = map[string]string{}
 	g.emitted_optional_types = map[string]bool{}
@@ -3493,7 +3494,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			g.gen_spawn_expr(node)
 		}
 		.lock_expr {
-			g.gen_lock_expr(node)
+			g.gen_lock_expr(id, node)
 		}
 		.infix {
 			// A very long left-nested `||`/`&&` chain (e.g. from a big match condition or

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -10,6 +10,7 @@ struct ActiveLock {
 	lock_count  int
 	unlock_fn   string
 	loop_depth  int
+	defer_depth int
 }
 
 struct LoopLabelState {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1276,7 +1276,7 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 	g.cur_fn_name = node.value
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
-	g.goto_label_lock_depths = g.collect_fn_goto_label_lock_depths(node)
+	g.goto_label_lock_scopes = g.collect_fn_goto_label_lock_scopes(node)
 	g.pending_loop_label = ''
 	g.tc.push_scope()
 	g.defers = []flat.NodeId{}
@@ -1386,7 +1386,7 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 	g.cur_mut_params = old_mut_params.clone()
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
-	g.goto_label_lock_depths = map[string]int{}
+	g.goto_label_lock_scopes = map[string][]int{}
 	g.pending_loop_label = ''
 	g.tc.pop_scope()
 }
@@ -1450,7 +1450,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.cur_fn_name = 'main'
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
-	g.goto_label_lock_depths = g.collect_top_level_goto_label_lock_depths(stmts)
+	g.goto_label_lock_scopes = g.collect_top_level_goto_label_lock_scopes(stmts)
 	g.pending_loop_label = ''
 	g.tc.push_scope()
 	g.defers = []flat.NodeId{}
@@ -1504,7 +1504,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.cur_fn_name = old_fn_name
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
-	g.goto_label_lock_depths = map[string]int{}
+	g.goto_label_lock_scopes = map[string][]int{}
 	g.pending_loop_label = ''
 	g.tc.cur_file = old_tc_file
 	g.tc.cur_module = old_tc_module

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -224,6 +224,10 @@ fn (mut g FlatGen) should_emit_fn_node_in_module(node flat.Node, node_index int,
 	if module_name == 'builtin' && node.value == 'exit' {
 		return true
 	}
+	if module_name == 'sync' && g.needs_shared_runtime
+		&& node.value in ['should_be_zero', 'RwMutex.init', 'RwMutex.lazy_init', 'RwMutex.lock', 'RwMutex.unlock', 'RwMutex.rlock', 'RwMutex.runlock'] {
+		return true
+	}
 	// `array.pointers` is emitted as an intrinsic at call sites; the raw
 	// builtin body has an erased `array` receiver and generates invalid C.
 	if module_name == 'builtin' && node.value == 'array.pointers' {
@@ -835,6 +839,90 @@ fn (g &FlatGen) expr_is_addressable(id flat.NodeId) bool {
 			false
 		}
 	}
+}
+
+fn (mut g FlatGen) gen_mut_sum_lvalue_arg(arg_id flat.NodeId, expected types.Type) bool {
+	mut lvalue_id := arg_id
+	if int(arg_id) >= 0 && int(arg_id) < g.a.nodes.len {
+		arg_node := g.a.nodes[int(arg_id)]
+		if arg_node.kind == .prefix && arg_node.op == .amp && arg_node.children_count > 0 {
+			lvalue_id = g.a.child(&arg_node, 0)
+		}
+	}
+	base0 := if expected is types.Pointer {
+		expected.base_type
+	} else {
+		return false
+	}
+	base := if base0 is types.Alias { base0.base_type } else { base0 }
+	if base !is types.SumType {
+		return false
+	}
+	if !g.expr_is_addressable(lvalue_id) {
+		return false
+	}
+	actual0 := g.tc.resolve_type(lvalue_id)
+	if actual0 is types.Pointer {
+		return false
+	}
+	storage0 := if declared := g.selector_declared_type(lvalue_id) { declared } else { actual0 }
+	storage := if storage0 is types.Alias { storage0.base_type } else { storage0 }
+	if storage !is types.SumType || !g.type_names_match(storage, base) {
+		return false
+	}
+	g.write('&')
+	if !g.gen_sum_storage_lvalue_arg(lvalue_id) {
+		g.gen_expr(lvalue_id)
+	}
+	return true
+}
+
+fn (mut g FlatGen) gen_sum_storage_lvalue_arg(arg_id flat.NodeId) bool {
+	if int(arg_id) < 0 || int(arg_id) >= g.a.nodes.len {
+		return false
+	}
+	node := g.a.nodes[int(arg_id)]
+	if node.kind != .selector || node.children_count == 0 {
+		return false
+	}
+	if _ := g.selector_declared_type(arg_id) {
+		// handled below
+	} else {
+		return false
+	}
+	base_id := g.a.child(&node, 0)
+	base := g.a.nodes[int(base_id)]
+	needs_paren := base.kind !in [.ident, .selector]
+	if needs_paren {
+		g.write('(')
+	}
+	g.gen_expr(base_id)
+	if needs_paren {
+		g.write(')')
+	}
+	mut is_ptr := false
+	if base.kind == .ident {
+		if typ := g.tc.cur_scope.lookup(base.value) {
+			is_ptr = typ is types.Pointer
+		}
+	} else if base.kind == .selector {
+		if declared := g.selector_declared_type(base_id) {
+			is_ptr = declared is types.Pointer
+		} else {
+			resolved := g.tc.resolve_type(base_id)
+			is_ptr = resolved is types.Pointer
+		}
+	} else {
+		resolved := g.tc.resolve_type(base_id)
+		is_ptr = resolved is types.Pointer
+	}
+	if node.op == .arrow || is_ptr {
+		g.write('->')
+	} else {
+		g.write('.')
+	}
+	g.write(c_name(node.value))
+	return true
 }
 
 // gen_method_value_closure handles a method used as a *value* (e.g. `game.draw`
@@ -1817,8 +1905,12 @@ fn (mut g FlatGen) gen_optional_error_from_call(ct string, node flat.Node) {
 // gen_call emits call output for c.
 fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 	fn_node := g.a.child_node(&node, 0)
-	fn_name := fn_node.value
 	target_name := g.call_target_name(g.a.child(&node, 0))
+	fn_name := if fn_node.kind == .selector && fn_node.value in ['error', 'error_with_code'] {
+		target_name
+	} else {
+		fn_node.value
+	}
 	if target_name == 'array.pointers' || fn_name == 'array.pointers' {
 		if node.children_count > 1 {
 			arg_id := g.a.child(&node, 1)
@@ -2584,6 +2676,11 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 						g.expected_enum = pt.name
 					}
 				}
+				if !is_c_call && arg_idx < param_types.len
+					&& g.gen_mut_sum_lvalue_arg(arg_id, param_types[arg_idx]) {
+					g.expected_enum = ''
+					continue
+				}
 				if !is_c_call && arg_idx < param_types.len {
 					if child_id := g.addressed_rvalue_arg(arg_node) {
 						pt := param_types[arg_idx]
@@ -2614,6 +2711,8 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					g.gen_expr_with_expected_type(arg_id, types.unwrap_pointer(pt))
 					g.write('; &_t${g.tmp_count};})')
 					g.tmp_count++
+				} else if needs_addr && g.gen_mut_sum_lvalue_arg(arg_id, param_types[arg_idx]) {
+					// handled
 				} else {
 					if needs_addr {
 						g.write('&')
@@ -2761,6 +2860,9 @@ fn (mut g FlatGen) gen_interface_method_call(node flat.Node, fn_node flat.Node, 
 				continue
 			}
 			if g.gen_pointer_arg_from_array_literal(arg_node, param_types[param_idx]) {
+				continue
+			}
+			if g.gen_mut_sum_lvalue_arg(arg_id, param_types[param_idx]) {
 				continue
 			}
 			if child_id := g.addressed_rvalue_arg(arg_node) {
@@ -3333,6 +3435,9 @@ fn short_receiver_method_name(name string) string {
 // gen_arg_for_expected_type emits arg for expected type output for c.
 fn (mut g FlatGen) gen_arg_for_expected_type(arg_id flat.NodeId, expected types.Type) {
 	arg_node := g.a.nodes[int(arg_id)]
+	if g.gen_mut_sum_lvalue_arg(arg_id, expected) {
+		return
+	}
 	mut needs_addr := false
 	if expected is types.Pointer && !(arg_node.kind == .prefix && arg_node.op == .amp) {
 		arg_type := g.tc.resolve_type(arg_id)
@@ -3341,6 +3446,9 @@ fn (mut g FlatGen) gen_arg_for_expected_type(arg_id flat.NodeId, expected types.
 		}
 	}
 	if needs_addr {
+		if g.gen_mut_sum_lvalue_arg(arg_id, expected) {
+			return
+		}
 		g.write('&')
 	}
 	if !needs_addr && g.gen_sum_variant_arg(arg_id, expected) {
@@ -3818,6 +3926,9 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			&& g.gen_pointer_arg_from_array_literal(arg_node, param_types[arg_idx]) {
 			continue
 		}
+		if arg_idx < typed_param_count && g.gen_mut_sum_lvalue_arg(arg_id, param_types[arg_idx]) {
+			continue
+		}
 		cb_param := if arg_idx >= 0 && arg_idx < param_types.len {
 			param_types[arg_idx]
 		} else {
@@ -3889,6 +4000,8 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			g.gen_expr_with_expected_type(arg_id, types.unwrap_pointer(pt))
 			g.write('; &_t${g.tmp_count};})')
 			g.tmp_count++
+		} else if needs_addr && g.gen_mut_sum_lvalue_arg(arg_id, param_types[arg_idx]) {
+			// handled
 		} else {
 			if arg_idx < typed_param_count {
 				if child_id := g.addressed_rvalue_arg(arg_node) {
@@ -4260,9 +4373,11 @@ fn (mut g FlatGen) c_extern_forward_decls() {
 		raw_name := if node.value.starts_with('C.') { node.value } else { 'C.${node.value}' }
 		raw_cfn := c_name(raw_name)
 		cfn := c_winapi_wide_export_name(raw_cfn)
+		shared_runtime_extern := g.needs_shared_runtime && cfn in c_shared_runtime_extern_symbols
 		if g.has_used_fn_filter() && !(g.spawn_wrapper_defs.len > 0
-			&& cfn in c_spawn_runtime_extern_symbols) && !g.used_fn_contains(raw_name)
-			&& !g.used_fn_contains(raw_cfn) && !g.used_fn_contains(cfn) {
+			&& cfn in c_spawn_runtime_extern_symbols) && !shared_runtime_extern
+			&& !g.used_fn_contains(raw_name) && !g.used_fn_contains(raw_cfn)
+			&& !g.used_fn_contains(cfn) {
 			continue
 		}
 		if !g.should_emit_c_extern_decl(cfn) {
@@ -4313,6 +4428,12 @@ const c_spawn_runtime_extern_symbols = {
 	'pthread_attr_setstacksize': true
 	'pthread_create':            true
 	'pthread_join':              true
+}
+
+const c_shared_runtime_extern_symbols = {
+	'pthread_rwlock_rdlock': true
+	'pthread_rwlock_wrlock': true
+	'pthread_rwlock_unlock': true
 }
 
 fn (g &FlatGen) should_emit_c_extern_decl(cfn string) bool {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -4443,9 +4443,13 @@ const c_spawn_runtime_extern_symbols = {
 }
 
 const c_shared_runtime_extern_symbols = {
-	'pthread_rwlock_rdlock': true
-	'pthread_rwlock_wrlock': true
-	'pthread_rwlock_unlock': true
+	'pthread_rwlock_rdlock':         true
+	'pthread_rwlock_wrlock':         true
+	'pthread_rwlock_unlock':         true
+	'pthread_rwlockattr_init':       true
+	'pthread_rwlockattr_setkind_np': true
+	'pthread_rwlock_init':           true
+	'pthread_rwlockattr_destroy':    true
 }
 
 fn (g &FlatGen) should_emit_c_extern_decl(cfn string) bool {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1841,11 +1841,26 @@ fn (mut g FlatGen) gen_all_defers() {
 
 // gen_defers_from emits defers from output for c.
 fn (mut g FlatGen) gen_defers_from(start int) {
+	g.gen_defers_range(start, g.defers.len)
+}
+
+fn (mut g FlatGen) gen_defers_range(start int, end int) {
 	if g.defers.len == 0 {
 		return
 	}
-	mut i := g.defers.len
-	for i > start {
+	mut defer_start := start
+	if defer_start < 0 {
+		defer_start = 0
+	}
+	mut defer_end := end
+	if defer_end > g.defers.len {
+		defer_end = g.defers.len
+	}
+	if defer_start >= defer_end {
+		return
+	}
+	mut i := defer_end
+	for i > defer_start {
 		i--
 		defer_body := g.a.nodes[int(g.defers[i])]
 		g.writeln('{')

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1274,6 +1274,9 @@ fn (g &FlatGen) resolved_method_name_for_spawn(clean_type types.Type, method str
 fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 	g.tc.cur_module = module_name
 	g.cur_fn_name = node.value
+	g.loop_depth = 0
+	g.loop_label_depths = map[string]int{}
+	g.pending_loop_label = ''
 	g.tc.push_scope()
 	g.defers = []flat.NodeId{}
 	g.fn_defers = []flat.NodeId{}
@@ -1380,6 +1383,9 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 	g.cur_param_types = old_param_types.clone()
 	g.cur_concrete_optional_params = old_concrete_optional_params.clone()
 	g.cur_mut_params = old_mut_params.clone()
+	g.loop_depth = 0
+	g.loop_label_depths = map[string]int{}
+	g.pending_loop_label = ''
 	g.tc.pop_scope()
 }
 
@@ -1440,6 +1446,9 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.tc.cur_module = 'main'
 	old_fn_name := g.cur_fn_name
 	g.cur_fn_name = 'main'
+	g.loop_depth = 0
+	g.loop_label_depths = map[string]int{}
+	g.pending_loop_label = ''
 	g.tc.push_scope()
 	g.defers = []flat.NodeId{}
 	g.fn_defers = []flat.NodeId{}
@@ -1490,6 +1499,9 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.cur_concrete_optional_params = old_concrete_optional_params.clone()
 	g.cur_mut_params = old_mut_params.clone()
 	g.cur_fn_name = old_fn_name
+	g.loop_depth = 0
+	g.loop_label_depths = map[string]int{}
+	g.pending_loop_label = ''
 	g.tc.cur_file = old_tc_file
 	g.tc.cur_module = old_tc_module
 	g.tc.pop_scope()

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -225,7 +225,7 @@ fn (mut g FlatGen) should_emit_fn_node_in_module(node flat.Node, node_index int,
 		return true
 	}
 	if module_name == 'sync' && g.needs_shared_runtime
-		&& node.value in ['should_be_zero', 'RwMutex.init', 'RwMutex.lazy_init', 'RwMutex.lock', 'RwMutex.unlock', 'RwMutex.rlock', 'RwMutex.runlock'] {
+		&& node.value in ['cpanic', 'cpanic_errno', 'should_be_zero', 'RwMutex.init', 'RwMutex.lazy_init', 'RwMutex.lock', 'RwMutex.unlock', 'RwMutex.rlock', 'RwMutex.runlock'] {
 		return true
 	}
 	// `array.pointers` is emitted as an intrinsic at call sites; the raw

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1276,6 +1276,7 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 	g.cur_fn_name = node.value
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
+	g.goto_label_lock_depths = g.collect_fn_goto_label_lock_depths(node)
 	g.pending_loop_label = ''
 	g.tc.push_scope()
 	g.defers = []flat.NodeId{}
@@ -1385,6 +1386,7 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 	g.cur_mut_params = old_mut_params.clone()
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
+	g.goto_label_lock_depths = map[string]int{}
 	g.pending_loop_label = ''
 	g.tc.pop_scope()
 }
@@ -1448,6 +1450,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.cur_fn_name = 'main'
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
+	g.goto_label_lock_depths = g.collect_top_level_goto_label_lock_depths(stmts)
 	g.pending_loop_label = ''
 	g.tc.push_scope()
 	g.defers = []flat.NodeId{}
@@ -1501,6 +1504,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.cur_fn_name = old_fn_name
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
+	g.goto_label_lock_depths = map[string]int{}
 	g.pending_loop_label = ''
 	g.tc.cur_file = old_tc_file
 	g.tc.cur_module = old_tc_module

--- a/vlib/v3/gen/c/fn_d_parallel.v
+++ b/vlib/v3/gen/c/fn_d_parallel.v
@@ -395,6 +395,7 @@ fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 		fn_decl_ret_types:            g.fn_decl_ret_types
 		struct_decl_infos:            g.struct_decl_infos
 		struct_decl_short_infos:      g.struct_decl_short_infos
+		shared_type_names:            g.shared_type_names
 		const_runtime_inits:          g.const_runtime_inits.clone()
 		runtime_inits:                g.runtime_inits.clone()
 		compiler_vroot:               g.compiler_vroot
@@ -406,6 +407,7 @@ fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 		cur_fn_ret:                   g.cur_fn_ret
 		cur_fn_ret_is_optional:       g.cur_fn_ret_is_optional
 		cur_fn_ret_base:              g.cur_fn_ret_base
+		loop_label_depths:            map[string]int{}
 		expected_expr_type:           g.expected_expr_type
 		expected_enum:                g.expected_enum
 		needed_optional_types:        g.needed_optional_types.clone()

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -3,8 +3,41 @@ module c
 import v3.flat
 import v3.types
 
+fn (mut g FlatGen) take_pending_loop_label() string {
+	label := g.pending_loop_label
+	g.pending_loop_label = ''
+	return label
+}
+
+fn (mut g FlatGen) push_loop_label_depth(label string) LoopLabelState {
+	if label.len == 0 {
+		return LoopLabelState{}
+	}
+	mut state := LoopLabelState{
+		label: label
+	}
+	if prev_depth := g.loop_label_depths[label] {
+		state.had_prev = true
+		state.prev_depth = prev_depth
+	}
+	g.loop_label_depths[label] = g.loop_depth + 1
+	return state
+}
+
+fn (mut g FlatGen) pop_loop_label_depth(state LoopLabelState) {
+	if state.label.len == 0 {
+		return
+	}
+	if state.had_prev {
+		g.loop_label_depths[state.label] = state.prev_depth
+	} else {
+		g.loop_label_depths.delete(state.label)
+	}
+}
+
 // gen_for emits for output for c.
 fn (mut g FlatGen) gen_for(node flat.Node) {
+	label_state := g.push_loop_label_depth(g.take_pending_loop_label())
 	g.tc.push_scope()
 	defer_start := g.defers.len
 	init_node := g.a.child_node(&node, 0)
@@ -44,10 +77,15 @@ fn (mut g FlatGen) gen_for(node flat.Node) {
 	g.indent--
 	g.writeln('}')
 	g.tc.pop_scope()
+	g.pop_loop_label_depth(label_state)
 }
 
 // gen_for_in emits for in output for c.
 fn (mut g FlatGen) gen_for_in(node flat.Node) {
+	label_state := g.push_loop_label_depth(g.take_pending_loop_label())
+	defer {
+		g.pop_loop_label_depth(label_state)
+	}
 	g.tc.push_scope()
 	header_count := node.value.int()
 	val_id := g.a.child(&node, 1)

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -114,6 +114,9 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 					g.writeln('memmove(${key_var}, ${key_slot}, sizeof(${key_var}));')
 				} else {
 					g.writeln('${c_key} ${key_var} = *(${c_key}*)(${key_slot});')
+					if clean_container_type.key_type is types.String {
+						g.writeln('${key_var} = string__clone(${key_var});')
+					}
 				}
 				val_slot := '${key_values}.values + ${iter_var} * ${key_values}.value_bytes'
 				if val_fixed := array_fixed_type(clean_container_type.value_type) {

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -34,9 +34,11 @@ fn (mut g FlatGen) gen_for(node flat.Node) {
 		g.writeln(') {')
 	}
 	g.indent++
+	g.loop_depth++
 	for i in 3 .. node.children_count {
 		g.gen_node(g.a.child(&node, i))
 	}
+	g.loop_depth--
 	g.gen_defers_from(defer_start)
 	g.trim_defers(defer_start)
 	g.indent--
@@ -173,9 +175,11 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 			if has_index && container_type !is types.Map {
 				g.tc.cur_scope.insert(idx_var, types.Type(types.int_))
 			}
+			g.loop_depth++
 			for i in body_start .. node.children_count {
 				g.gen_node(g.a.child(&node, i))
 			}
+			g.loop_depth--
 			g.indent--
 			g.writeln('}')
 			if map_snapshot_var.len > 0 {
@@ -189,9 +193,11 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 		return
 	}
 	g.indent++
+	g.loop_depth++
 	for i in body_start .. node.children_count {
 		g.gen_node(g.a.child(&node, i))
 	}
+	g.loop_depth--
 	g.indent--
 	g.writeln('}')
 	g.tc.pop_scope()

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -123,6 +123,7 @@ fn (mut g FlatGen) gen_lock_enter(node flat.Node) ?ActiveLock {
 		lock_count:  lock_count
 		unlock_fn:   unlock_fn
 		loop_depth:  g.loop_depth
+		defer_depth: g.defers.len
 	}
 }
 
@@ -170,8 +171,28 @@ fn (mut g FlatGen) gen_branch_lock_leaves(label string) {
 }
 
 fn (mut g FlatGen) gen_return_cleanup() {
-	g.gen_all_defers()
-	g.gen_active_lock_leaves()
+	if g.active_locks.len == 0 {
+		g.gen_all_defers()
+		return
+	}
+	mut defer_end := g.defers.len
+	mut i := g.active_locks.len - 1
+	for i >= 0 {
+		active := g.active_locks[i]
+		mut defer_start := active.defer_depth
+		if defer_start < 0 {
+			defer_start = 0
+		}
+		if defer_start > defer_end {
+			defer_start = defer_end
+		}
+		g.gen_defers_range(defer_start, defer_end)
+		defer_end = defer_start
+		g.gen_lock_leave(active)
+		i--
+	}
+	g.gen_defers_range(0, defer_end)
+	g.gen_fn_defers()
 }
 
 fn (mut g FlatGen) gen_lock_stmt(node flat.Node) {
@@ -439,7 +460,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			if g.cur_fn_ret is types.Enum {
 				g.expected_enum = g.cur_fn_ret.name
 			}
-			if node.children_count > 0 && g.has_pending_defers() {
+			if node.children_count > 0 && (g.has_pending_defers() || g.active_locks.len > 0) {
 				g.gen_return_with_defers(node)
 				g.expected_enum = ''
 				return

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -150,11 +150,19 @@ fn (mut g FlatGen) gen_active_lock_leaves() {
 	}
 }
 
-fn (mut g FlatGen) gen_branch_lock_leaves() {
+fn (g &FlatGen) branch_target_loop_depth(label string) int {
+	if label.len == 0 {
+		return g.loop_depth
+	}
+	return g.loop_label_depths[label] or { g.loop_depth }
+}
+
+fn (mut g FlatGen) gen_branch_lock_leaves(label string) {
+	target_depth := g.branch_target_loop_depth(label)
 	mut i := g.active_locks.len - 1
 	for i >= 0 {
 		active := g.active_locks[i]
-		if active.loop_depth == g.loop_depth {
+		if active.loop_depth >= target_depth {
 			g.gen_lock_leave(active)
 		}
 		i--
@@ -293,6 +301,9 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 		return
 	}
 	node := g.a.nodes[int(id)]
+	if node.kind !in [.label_stmt, .for_stmt, .for_in_stmt] {
+		g.pending_loop_label = ''
+	}
 	g.in_return = false
 	match node.kind {
 		.fn_decl, .c_fn_decl {
@@ -619,7 +630,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			g.gen_lock_stmt(node)
 		}
 		.break_stmt {
-			g.gen_branch_lock_leaves()
+			g.gen_branch_lock_leaves(node.value)
 			if node.value.len > 0 {
 				g.writeln('goto ${c_name(node.value)}_break;')
 			} else {
@@ -627,7 +638,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			}
 		}
 		.continue_stmt {
-			g.gen_branch_lock_leaves()
+			g.gen_branch_lock_leaves(node.value)
 			if node.value.len > 0 {
 				g.writeln('goto ${c_name(node.value)}_continue;')
 			} else {
@@ -669,6 +680,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			g.indent = 0
 			g.writeln('${c_name(node.value)}: ;')
 			g.indent = old_indent
+			g.pending_loop_label = node.value
 		}
 		.empty, .asm_stmt {}
 		else {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -55,6 +55,171 @@ fn (mut g FlatGen) gen_split_array_append_expr_stmt(node flat.Node) bool {
 	return true
 }
 
+fn (mut g FlatGen) gen_lock_enter(node flat.Node) {
+	lock_count := int(node.children_count) - 1
+	if lock_count <= 0 {
+		return
+	}
+	lock_fn := if node.value == 'rlock' { 'sync__RwMutex__rlock' } else { 'sync__RwMutex__lock' }
+	for i in 0 .. lock_count {
+		g.write('${lock_fn}(&')
+		lock_id := g.a.child(&node, i)
+		if !g.gen_shared_storage_expr(lock_id) {
+			g.gen_expr(lock_id)
+		}
+		g.writeln('->mtx);')
+	}
+}
+
+fn (mut g FlatGen) gen_lock_leave(node flat.Node) {
+	lock_count := int(node.children_count) - 1
+	if lock_count <= 0 {
+		return
+	}
+	unlock_fn := if node.value == 'rlock' {
+		'sync__RwMutex__runlock'
+	} else {
+		'sync__RwMutex__unlock'
+	}
+	mut i := lock_count - 1
+	for i >= 0 {
+		g.write('${unlock_fn}(&')
+		lock_id := g.a.child(&node, i)
+		if !g.gen_shared_storage_expr(lock_id) {
+			g.gen_expr(lock_id)
+		}
+		g.writeln('->mtx);')
+		i--
+	}
+}
+
+fn (mut g FlatGen) gen_active_lock_leaves() {
+	mut i := g.active_locks.len - 1
+	for i >= 0 {
+		g.gen_lock_leave(g.active_locks[i])
+		i--
+	}
+}
+
+fn (mut g FlatGen) gen_return_cleanup() {
+	g.gen_all_defers()
+	g.gen_active_lock_leaves()
+}
+
+fn (mut g FlatGen) gen_lock_stmt(node flat.Node) {
+	g.gen_lock_enter(node)
+	g.active_locks << node
+	if node.children_count > 0 {
+		body_id := g.a.child(&node, node.children_count - 1)
+		if int(body_id) >= 0 {
+			body := g.a.nodes[int(body_id)]
+			if body.kind == .block {
+				g.gen_node(body_id)
+			} else if body.kind == .expr_stmt {
+				g.gen_node(body_id)
+			} else {
+				g.gen_expr(body_id)
+				g.writeln(';')
+			}
+		}
+	}
+	g.active_locks.delete_last()
+	g.gen_lock_leave(node)
+}
+
+fn (g &FlatGen) lock_expr_result_type(node flat.Node) types.Type {
+	if node.typ.len > 0 {
+		typ := g.tc.parse_type(node.typ)
+		if typ !is types.Unknown && typ !is types.Void {
+			return typ
+		}
+	}
+	if node.children_count == 0 {
+		return types.Type(types.void_)
+	}
+	body_id := g.a.child(&node, node.children_count - 1)
+	if int(body_id) < 0 {
+		return types.Type(types.void_)
+	}
+	body := g.a.nodes[int(body_id)]
+	if body.kind == .block && body.children_count > 0 {
+		last_id := g.a.child(&body, body.children_count - 1)
+		last := g.a.nodes[int(last_id)]
+		if last.kind == .expr_stmt && last.children_count > 0 {
+			return g.usable_expr_type(g.a.child(&last, 0))
+		}
+		return g.usable_expr_type(last_id)
+	}
+	if body.kind == .expr_stmt && body.children_count > 0 {
+		return g.usable_expr_type(g.a.child(&body, 0))
+	}
+	return g.usable_expr_type(body_id)
+}
+
+fn (mut g FlatGen) gen_lock_expr(node flat.Node) {
+	result_type := g.lock_expr_result_type(node)
+	if result_type is types.Void || result_type is types.Unknown {
+		g.write('({')
+		g.gen_lock_enter(node)
+		g.active_locks << node
+		if node.children_count > 0 {
+			body_id := g.a.child(&node, node.children_count - 1)
+			if int(body_id) >= 0 {
+				body := g.a.nodes[int(body_id)]
+				if body.kind == .block {
+					g.gen_node(body_id)
+				} else {
+					g.gen_expr(body_id)
+					g.writeln(';')
+				}
+			}
+		}
+		g.active_locks.delete_last()
+		g.gen_lock_leave(node)
+		g.write('0;})')
+		return
+	}
+	ct := g.value_c_type(result_type)
+	tmp := g.tmp_name()
+	g.write('({ ${ct} ${tmp};')
+	g.gen_lock_enter(node)
+	g.active_locks << node
+	if node.children_count > 0 {
+		body_id := g.a.child(&node, node.children_count - 1)
+		if int(body_id) >= 0 {
+			body := g.a.nodes[int(body_id)]
+			if body.kind == .block {
+				last_idx := int(body.children_count) - 1
+				for i in 0 .. last_idx {
+					g.gen_node(g.a.child(&body, i))
+				}
+				if last_idx >= 0 {
+					last_id := g.a.child(&body, last_idx)
+					last := g.a.nodes[int(last_id)]
+					if last.kind == .expr_stmt && last.children_count > 0 {
+						g.write('${tmp} = ')
+						g.gen_expr_with_expected_type(g.a.child(&last, 0), result_type)
+						g.writeln(';')
+					} else {
+						g.gen_node(last_id)
+					}
+				}
+			} else if body.kind == .expr_stmt && body.children_count > 0 {
+				g.write('${tmp} = ')
+				g.gen_expr_with_expected_type(g.a.child(&body, 0), result_type)
+				g.writeln(';')
+			} else {
+				g.write('${tmp} = ')
+				g.gen_expr_with_expected_type(body_id, result_type)
+				g.writeln(';')
+			}
+		}
+	}
+	g.active_locks.delete_last()
+	g.gen_lock_leave(node)
+	g.write('${tmp};})')
+}
+
 // gen_node emits node output for c.
 fn (mut g FlatGen) gen_node(id flat.NodeId) {
 	if int(id) < 0 || int(id) >= g.a.nodes.len {
@@ -194,7 +359,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 				g.expected_enum = ''
 				return
 			}
-			g.gen_all_defers()
+			g.gen_return_cleanup()
 			if node.children_count > 0 {
 				ret_id := g.a.child(&node, 0)
 				if int(ret_id) < 0 || int(ret_id) >= g.a.nodes.len {
@@ -383,6 +548,9 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 		.for_in_stmt {
 			g.gen_for_in(node)
 		}
+		.lock_expr {
+			g.gen_lock_stmt(node)
+		}
 		.break_stmt {
 			if node.value.len > 0 {
 				g.writeln('goto ${c_name(node.value)}_break;')
@@ -452,7 +620,7 @@ fn (g &FlatGen) has_pending_defers() bool {
 fn (mut g FlatGen) gen_return_with_defers(node flat.Node) {
 	ret_id := g.a.child(&node, 0)
 	if int(ret_id) < 0 || int(ret_id) >= g.a.nodes.len {
-		g.gen_all_defers()
+		g.gen_return_cleanup()
 		g.gen_default_return_stmt()
 		return
 	}
@@ -460,7 +628,7 @@ fn (mut g FlatGen) gen_return_with_defers(node flat.Node) {
 	if ret_node.kind == .assoc {
 		tmp := g.tmp_name()
 		g.gen_assoc_return_tmp(ret_node, tmp)
-		g.gen_all_defers()
+		g.gen_return_cleanup()
 		g.writeln('return ${tmp};')
 		return
 	}
@@ -470,7 +638,7 @@ fn (mut g FlatGen) gen_return_with_defers(node flat.Node) {
 		g.write('${wrapper} ${tmp} = ')
 		g.gen_fixed_array_return_wrap(g.cur_fn_ret, ret_id)
 		g.writeln(';')
-		g.gen_all_defers()
+		g.gen_return_cleanup()
 		g.writeln('return ${tmp};')
 		return
 	}
@@ -479,7 +647,7 @@ fn (mut g FlatGen) gen_return_with_defers(node flat.Node) {
 		ret_types := g.cur_fn_ret.types
 		if g.multi_return_types_have_fixed_array(ret_types) {
 			tmp := g.gen_multi_return_temp(ct, ret_types, node)
-			g.gen_all_defers()
+			g.gen_return_cleanup()
 			g.writeln('return ${tmp};')
 			return
 		}
@@ -487,7 +655,7 @@ fn (mut g FlatGen) gen_return_with_defers(node flat.Node) {
 	expr := g.return_expr_string(node, ret_id, ret_node, ct)
 	tmp := g.tmp_name()
 	g.writeln('${ct} ${tmp} = ${expr};')
-	g.gen_all_defers()
+	g.gen_return_cleanup()
 	g.writeln('return ${tmp};')
 }
 
@@ -1109,6 +1277,12 @@ fn (g &FlatGen) usable_expr_type(id flat.NodeId) types.Type {
 		if node.kind in [.expr_stmt, .paren] && node.children_count > 0 {
 			return g.usable_expr_type(g.a.child(&node, 0))
 		}
+		if node.kind == .block && node.children_count > 0 {
+			return g.usable_expr_type(g.a.child(&node, node.children_count - 1))
+		}
+		if node.kind == .lock_expr {
+			return g.lock_expr_result_type(node)
+		}
 		if node.kind in [.as_expr, .cast_expr] && node.value.len > 0 {
 			target_type := g.tc.parse_type(node.value)
 			if !decl_annotation_is_unusable(target_type, node.value) {
@@ -1509,6 +1683,12 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 				g.if_expr_type(&rhs)
 			} else {
 				g.usable_expr_type(rhs_id)
+			}
+			if rhs.kind == .lock_expr {
+				lock_type := g.usable_expr_type(rhs_id)
+				if lock_type !is types.Unknown && lock_type !is types.Void {
+					v_type = lock_type
+				}
 			}
 			if fixed := array_fixed_type(v_type) {
 				if g.fixed_array_decl_is_unusable(fixed) {
@@ -1960,18 +2140,21 @@ fn (mut g FlatGen) gen_assign(node flat.Node) {
 				}
 				g.gen_expr(g.a.child(&node, i))
 				g.write(' ${g.op_str(node.op)} ')
-				if _ := fn_type_from(lhs_type) {
+				rhs_expected_type := g.assign_rhs_expected_type(lhs_id, lhs_type)
+				if _ := fn_type_from(rhs_expected_type) {
 					if c_abi_fn := g.assign_lhs_c_abi_fn_ptr_type(lhs_id) {
-						if g.gen_callback_fn_value_for_field_c_abi(rhs_id, lhs_type, c_abi_fn) {
+						if g.gen_callback_fn_value_for_field_c_abi(rhs_id, rhs_expected_type,
+							c_abi_fn)
+						{
 							g.writeln(';')
 							g.expected_enum = ''
 							i += 2
 							continue
 						}
 					}
-					g.gen_expr_with_expected_type(rhs_id, lhs_type)
+					g.gen_expr_with_expected_type(rhs_id, rhs_expected_type)
 				} else {
-					g.gen_expr(rhs_id)
+					g.gen_expr_with_expected_type(rhs_id, rhs_expected_type)
 				}
 				g.writeln(';')
 				g.expected_enum = ''
@@ -2031,13 +2214,26 @@ fn assign_struct_operator_symbol(op flat.Op) ?string {
 	return none
 }
 
+fn (g &FlatGen) assign_rhs_expected_type(lhs_id flat.NodeId, lhs_type types.Type) types.Type {
+	lhs := g.a.nodes[int(lhs_id)]
+	if lhs.kind == .ident && g.current_param_is_mut(lhs.value) {
+		if lhs_type is types.Pointer {
+			return lhs_type.base_type
+		}
+	}
+	return lhs_type
+}
+
 // assign_lhs_needs_deref supports assign lhs needs deref handling for FlatGen.
 fn (g &FlatGen) assign_lhs_needs_deref(lhs_id flat.NodeId, lhs_type types.Type, rhs_type types.Type, op flat.Op) bool {
-	if op != .assign {
-		return false
-	}
 	lhs := g.a.nodes[int(lhs_id)]
 	if lhs.kind != .ident {
+		return false
+	}
+	if g.current_param_is_mut(lhs.value) {
+		return true
+	}
+	if op != .assign {
 		return false
 	}
 	if lhs_type is types.Pointer {
@@ -2131,6 +2327,7 @@ fn (mut g FlatGen) gen_assign_or_expr(node flat.Node, lhs_idx int, or_node flat.
 	if or_node.value == '!' || or_node.value == '?' {
 		if g.cur_fn_ret_is_optional {
 			fn_opt_ct := g.optional_type_name(g.cur_fn_ret)
+			g.gen_active_lock_leaves()
 			g.writeln('return (${fn_opt_ct}){.ok = false, .err = err};')
 		} else {
 			g.writeln('panic(IError__str(err));')
@@ -2187,6 +2384,7 @@ fn (mut g FlatGen) gen_decl_or_expr(lhs flat.Node, or_node flat.Node) {
 	if or_node.value == '!' || or_node.value == '?' {
 		if g.cur_fn_ret_is_optional {
 			fn_opt_ct := g.optional_type_name(g.cur_fn_ret)
+			g.gen_active_lock_leaves()
 			g.writeln('return (${fn_opt_ct}){.ok = false, .err = err};')
 		} else {
 			g.writeln('panic(IError__str(err));')
@@ -2393,6 +2591,7 @@ fn (mut g FlatGen) gen_or_body_value(or_body flat.Node, value_name string, value
 			expr_id := g.a.child(&child, 0)
 			if g.expr_is_error_call(expr_id) && g.cur_fn_ret_is_optional {
 				fn_opt_ct := g.optional_type_name(g.cur_fn_ret)
+				g.gen_active_lock_leaves()
 				g.write('return ')
 				g.gen_optional_error_from_call(fn_opt_ct, g.a.nodes[int(expr_id)])
 				g.write(';')
@@ -2421,7 +2620,8 @@ fn (g &FlatGen) expr_is_error_call(id flat.NodeId) bool {
 		return false
 	}
 	fn_node := g.a.child_node(&node, 0)
-	return fn_node.value == 'error' || fn_node.value == 'error_with_code'
+	return fn_node.kind == .ident
+		&& (fn_node.value == 'error' || fn_node.value == 'error_with_code')
 }
 
 // gen_or_map_index emits or map index output for c.
@@ -2461,6 +2661,7 @@ fn (mut g FlatGen) gen_or_expr_stmt(node flat.Node) {
 	if node.value == '!' || node.value == '?' {
 		if g.cur_fn_ret_is_optional {
 			fn_opt_ct := g.optional_type_name(g.cur_fn_ret)
+			g.gen_active_lock_leaves()
 			g.writeln('return (${fn_opt_ct}){.ok = false, .err = err};')
 		} else {
 			g.writeln('panic(IError__str(err));')

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -92,7 +92,7 @@ fn (mut g FlatGen) gen_sort_lock_mutexes(mutexes_var string, lock_count int) {
 	g.writeln('}')
 }
 
-fn (mut g FlatGen) gen_lock_enter(node flat.Node) ?ActiveLock {
+fn (mut g FlatGen) gen_lock_enter(scope_id int, node flat.Node) ?ActiveLock {
 	lock_count := int(node.children_count) - 1
 	if lock_count <= 0 {
 		return none
@@ -122,6 +122,7 @@ fn (mut g FlatGen) gen_lock_enter(node flat.Node) ?ActiveLock {
 		mutexes_var: mutexes_var
 		lock_count:  lock_count
 		unlock_fn:   unlock_fn
+		scope_id:    scope_id
 		loop_depth:  g.loop_depth
 		defer_depth: g.defers.len
 	}
@@ -170,52 +171,71 @@ fn (mut g FlatGen) gen_branch_lock_leaves(label string) {
 	}
 }
 
-fn (g &FlatGen) collect_fn_goto_label_lock_depths(node flat.Node) map[string]int {
-	mut depths := map[string]int{}
+fn (g &FlatGen) collect_fn_goto_label_lock_scopes(node flat.Node) map[string][]int {
+	mut scopes := map[string][]int{}
 	for i in 0 .. node.children_count {
-		g.collect_goto_label_lock_depths_from(g.a.child(&node, i), 0, mut depths)
+		g.collect_goto_label_lock_scopes_from(g.a.child(&node, i), []int{}, mut scopes)
 	}
-	return depths
+	return scopes
 }
 
-fn (g &FlatGen) collect_top_level_goto_label_lock_depths(stmts []TopLevelStmt) map[string]int {
-	mut depths := map[string]int{}
+fn (g &FlatGen) collect_top_level_goto_label_lock_scopes(stmts []TopLevelStmt) map[string][]int {
+	mut scopes := map[string][]int{}
 	for stmt in stmts {
-		g.collect_goto_label_lock_depths_from(stmt.id, 0, mut depths)
+		g.collect_goto_label_lock_scopes_from(stmt.id, []int{}, mut scopes)
 	}
-	return depths
+	return scopes
 }
 
-fn (g &FlatGen) collect_goto_label_lock_depths_from(id flat.NodeId, lock_depth int, mut depths map[string]int) {
+fn (g &FlatGen) collect_goto_label_lock_scopes_from(id flat.NodeId, lock_scopes []int, mut scopes map[string][]int) {
 	if int(id) < 0 || int(id) >= g.a.nodes.len {
 		return
 	}
 	node := g.a.nodes[int(id)]
 	if node.kind == .label_stmt && node.value.len > 0 {
-		depths[node.value] = lock_depth
+		scopes[node.value] = lock_scopes.clone()
 	}
-	child_lock_depth := if node.kind == .lock_expr { lock_depth + 1 } else { lock_depth }
+	mut child_lock_scopes := lock_scopes.clone()
+	if node.kind == .lock_expr {
+		child_lock_scopes << int(id)
+	}
 	for i in 0 .. node.children_count {
-		g.collect_goto_label_lock_depths_from(g.a.child(&node, i), child_lock_depth, mut depths)
+		g.collect_goto_label_lock_scopes_from(g.a.child(&node, i), child_lock_scopes, mut scopes)
 	}
 }
 
-fn (g &FlatGen) goto_target_lock_depth(label string) int {
+fn (g &FlatGen) active_lock_scope_ids() []int {
+	mut scopes := []int{cap: g.active_locks.len}
+	for active in g.active_locks {
+		scopes << active.scope_id
+	}
+	return scopes
+}
+
+fn (g &FlatGen) goto_target_lock_scopes(label string) []int {
 	if label.len == 0 {
-		return g.active_locks.len
+		return g.active_lock_scope_ids()
 	}
-	return g.goto_label_lock_depths[label] or { 0 }
+	return g.goto_label_lock_scopes[label] or { []int{} }
 }
 
-fn (mut g FlatGen) gen_goto_lock_leaves(label string) {
-	target_depth := g.goto_target_lock_depth(label)
+fn (mut g FlatGen) gen_goto_lock_leaves(label string) bool {
+	target_scopes := g.goto_target_lock_scopes(label)
+	active_scopes := g.active_lock_scope_ids()
+	for i, target_scope in target_scopes {
+		if i >= active_scopes.len || active_scopes[i] != target_scope {
+			g.writeln('#error goto into a different lock scope is not supported')
+			return false
+		}
+	}
 	mut i := g.active_locks.len - 1
 	for i >= 0 {
-		if i >= target_depth {
+		if i >= target_scopes.len {
 			g.gen_lock_leave(g.active_locks[i])
 		}
 		i--
 	}
+	return true
 }
 
 fn (mut g FlatGen) gen_return_cleanup() {
@@ -243,8 +263,8 @@ fn (mut g FlatGen) gen_return_cleanup() {
 	g.gen_fn_defers()
 }
 
-fn (mut g FlatGen) gen_lock_stmt(node flat.Node) {
-	active := g.gen_lock_enter(node) or { return }
+fn (mut g FlatGen) gen_lock_stmt(id flat.NodeId, node flat.Node) {
+	active := g.gen_lock_enter(int(id), node) or { return }
 	g.active_locks << active
 	if node.children_count > 0 {
 		body_id := g.a.child(&node, node.children_count - 1)
@@ -313,11 +333,11 @@ fn (mut g FlatGen) gen_lock_expr_result_assign(tmp string, result_type types.Typ
 	g.gen_node(id)
 }
 
-fn (mut g FlatGen) gen_lock_expr(node flat.Node) {
+fn (mut g FlatGen) gen_lock_expr(id flat.NodeId, node flat.Node) {
 	result_type := g.lock_expr_result_type(node)
 	if result_type is types.Void || result_type is types.Unknown {
 		g.write('({')
-		active := g.gen_lock_enter(node) or {
+		active := g.gen_lock_enter(int(id), node) or {
 			g.write('0;})')
 			return
 		}
@@ -342,7 +362,7 @@ fn (mut g FlatGen) gen_lock_expr(node flat.Node) {
 	ct := g.value_c_type(result_type)
 	tmp := g.tmp_name()
 	g.write('({ ${ct} ${tmp};')
-	active := g.gen_lock_enter(node) or {
+	active := g.gen_lock_enter(int(id), node) or {
 		g.gen_default_value_for_type(result_type)
 		g.write(';})')
 		return
@@ -706,7 +726,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			g.gen_for_in(node)
 		}
 		.lock_expr {
-			g.gen_lock_stmt(node)
+			g.gen_lock_stmt(id, node)
 		}
 		.break_stmt {
 			g.gen_branch_lock_leaves(node.value)
@@ -752,8 +772,9 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			g.writeln('}')
 		}
 		.goto_stmt {
-			g.gen_goto_lock_leaves(node.value)
-			g.writeln('goto ${c_name(node.value)};')
+			if g.gen_goto_lock_leaves(node.value) {
+				g.writeln('goto ${c_name(node.value)};')
+			}
 		}
 		.label_stmt {
 			old_indent := g.indent

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -353,6 +353,7 @@ fn (mut g FlatGen) gen_lock_expr(node flat.Node) {
 		if int(body_id) >= 0 {
 			body := g.a.nodes[int(body_id)]
 			if body.kind == .block {
+				defer_start := g.defers.len
 				last_idx := int(body.children_count) - 1
 				for i in 0 .. last_idx {
 					g.gen_node(g.a.child(&body, i))
@@ -361,6 +362,8 @@ fn (mut g FlatGen) gen_lock_expr(node flat.Node) {
 					last_id := g.a.child(&body, last_idx)
 					g.gen_lock_expr_result_assign(tmp, result_type, last_id)
 				}
+				g.gen_defers_from(defer_start)
+				g.trim_defers(defer_start)
 			} else {
 				g.gen_lock_expr_result_assign(tmp, result_type, body_id)
 			}

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -2509,7 +2509,7 @@ fn (mut g FlatGen) gen_assign_or_expr(node flat.Node, lhs_idx int, or_node flat.
 	if or_node.value == '!' || or_node.value == '?' {
 		if g.cur_fn_ret_is_optional {
 			fn_opt_ct := g.optional_type_name(g.cur_fn_ret)
-			g.gen_active_lock_leaves()
+			g.gen_return_cleanup()
 			g.writeln('return (${fn_opt_ct}){.ok = false, .err = err};')
 		} else {
 			g.writeln('panic(IError__str(err));')
@@ -2566,7 +2566,7 @@ fn (mut g FlatGen) gen_decl_or_expr(lhs flat.Node, or_node flat.Node) {
 	if or_node.value == '!' || or_node.value == '?' {
 		if g.cur_fn_ret_is_optional {
 			fn_opt_ct := g.optional_type_name(g.cur_fn_ret)
-			g.gen_active_lock_leaves()
+			g.gen_return_cleanup()
 			g.writeln('return (${fn_opt_ct}){.ok = false, .err = err};')
 		} else {
 			g.writeln('panic(IError__str(err));')
@@ -2773,7 +2773,7 @@ fn (mut g FlatGen) gen_or_body_value(or_body flat.Node, value_name string, value
 			expr_id := g.a.child(&child, 0)
 			if g.expr_is_error_call(expr_id) && g.cur_fn_ret_is_optional {
 				fn_opt_ct := g.optional_type_name(g.cur_fn_ret)
-				g.gen_active_lock_leaves()
+				g.gen_return_cleanup()
 				g.write('return ')
 				g.gen_optional_error_from_call(fn_opt_ct, g.a.nodes[int(expr_id)])
 				g.write(';')
@@ -2843,7 +2843,7 @@ fn (mut g FlatGen) gen_or_expr_stmt(node flat.Node) {
 	if node.value == '!' || node.value == '?' {
 		if g.cur_fn_ret_is_optional {
 			fn_opt_ct := g.optional_type_name(g.cur_fn_ret)
-			g.gen_active_lock_leaves()
+			g.gen_return_cleanup()
 			g.writeln('return (${fn_opt_ct}){.ok = false, .err = err};')
 		} else {
 			g.writeln('panic(IError__str(err));')

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -170,6 +170,54 @@ fn (mut g FlatGen) gen_branch_lock_leaves(label string) {
 	}
 }
 
+fn (g &FlatGen) collect_fn_goto_label_lock_depths(node flat.Node) map[string]int {
+	mut depths := map[string]int{}
+	for i in 0 .. node.children_count {
+		g.collect_goto_label_lock_depths_from(g.a.child(&node, i), 0, mut depths)
+	}
+	return depths
+}
+
+fn (g &FlatGen) collect_top_level_goto_label_lock_depths(stmts []TopLevelStmt) map[string]int {
+	mut depths := map[string]int{}
+	for stmt in stmts {
+		g.collect_goto_label_lock_depths_from(stmt.id, 0, mut depths)
+	}
+	return depths
+}
+
+fn (g &FlatGen) collect_goto_label_lock_depths_from(id flat.NodeId, lock_depth int, mut depths map[string]int) {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return
+	}
+	node := g.a.nodes[int(id)]
+	if node.kind == .label_stmt && node.value.len > 0 {
+		depths[node.value] = lock_depth
+	}
+	child_lock_depth := if node.kind == .lock_expr { lock_depth + 1 } else { lock_depth }
+	for i in 0 .. node.children_count {
+		g.collect_goto_label_lock_depths_from(g.a.child(&node, i), child_lock_depth, mut depths)
+	}
+}
+
+fn (g &FlatGen) goto_target_lock_depth(label string) int {
+	if label.len == 0 {
+		return g.active_locks.len
+	}
+	return g.goto_label_lock_depths[label] or { 0 }
+}
+
+fn (mut g FlatGen) gen_goto_lock_leaves(label string) {
+	target_depth := g.goto_target_lock_depth(label)
+	mut i := g.active_locks.len - 1
+	for i >= 0 {
+		if i >= target_depth {
+			g.gen_lock_leave(g.active_locks[i])
+		}
+		i--
+	}
+}
+
 fn (mut g FlatGen) gen_return_cleanup() {
 	if g.active_locks.len == 0 {
 		g.gen_all_defers()
@@ -701,6 +749,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			g.writeln('}')
 		}
 		.goto_stmt {
+			g.gen_goto_lock_leaves(node.value)
 			g.writeln('goto ${c_name(node.value)};')
 		}
 		.label_stmt {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -144,6 +144,19 @@ fn (mut g FlatGen) gen_lock_leave(active ActiveLock) {
 	g.writeln('}')
 }
 
+fn (mut g FlatGen) gen_lock_scope_cleanup(active ActiveLock, defer_end int) int {
+	mut defer_start := active.defer_depth
+	if defer_start < 0 {
+		defer_start = 0
+	}
+	if defer_start > defer_end {
+		defer_start = defer_end
+	}
+	g.gen_defers_range(defer_start, defer_end)
+	g.gen_lock_leave(active)
+	return defer_start
+}
+
 fn (mut g FlatGen) gen_active_lock_leaves() {
 	mut i := g.active_locks.len - 1
 	for i >= 0 {
@@ -159,13 +172,14 @@ fn (g &FlatGen) branch_target_loop_depth(label string) int {
 	return g.loop_label_depths[label] or { g.loop_depth }
 }
 
-fn (mut g FlatGen) gen_branch_lock_leaves(label string) {
+fn (mut g FlatGen) gen_branch_lock_cleanup(label string) {
 	target_depth := g.branch_target_loop_depth(label)
+	mut defer_end := g.defers.len
 	mut i := g.active_locks.len - 1
 	for i >= 0 {
 		active := g.active_locks[i]
 		if active.loop_depth >= target_depth {
-			g.gen_lock_leave(active)
+			defer_end = g.gen_lock_scope_cleanup(active, defer_end)
 		}
 		i--
 	}
@@ -229,9 +243,10 @@ fn (mut g FlatGen) gen_goto_lock_leaves(label string) bool {
 		}
 	}
 	mut i := g.active_locks.len - 1
+	mut defer_end := g.defers.len
 	for i >= 0 {
 		if i >= target_scopes.len {
-			g.gen_lock_leave(g.active_locks[i])
+			defer_end = g.gen_lock_scope_cleanup(g.active_locks[i], defer_end)
 		}
 		i--
 	}
@@ -247,16 +262,7 @@ fn (mut g FlatGen) gen_return_cleanup() {
 	mut i := g.active_locks.len - 1
 	for i >= 0 {
 		active := g.active_locks[i]
-		mut defer_start := active.defer_depth
-		if defer_start < 0 {
-			defer_start = 0
-		}
-		if defer_start > defer_end {
-			defer_start = defer_end
-		}
-		g.gen_defers_range(defer_start, defer_end)
-		defer_end = defer_start
-		g.gen_lock_leave(active)
+		defer_end = g.gen_lock_scope_cleanup(active, defer_end)
 		i--
 	}
 	g.gen_defers_range(0, defer_end)
@@ -729,7 +735,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			g.gen_lock_stmt(id, node)
 		}
 		.break_stmt {
-			g.gen_branch_lock_leaves(node.value)
+			g.gen_branch_lock_cleanup(node.value)
 			if node.value.len > 0 {
 				g.writeln('goto ${c_name(node.value)}_break;')
 			} else {
@@ -737,7 +743,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			}
 		}
 		.continue_stmt {
-			g.gen_branch_lock_leaves(node.value)
+			g.gen_branch_lock_cleanup(node.value)
 			if node.value.len > 0 {
 				g.writeln('goto ${c_name(node.value)}_continue;')
 			} else {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -55,42 +55,91 @@ fn (mut g FlatGen) gen_split_array_append_expr_stmt(node flat.Node) bool {
 	return true
 }
 
-fn (mut g FlatGen) gen_lock_enter(node flat.Node) {
-	lock_count := int(node.children_count) - 1
-	if lock_count <= 0 {
-		return
+fn (mut g FlatGen) gen_lock_mutex_addr(lock_id flat.NodeId) {
+	g.write('(uintptr_t)&')
+	if !g.gen_shared_storage_expr(lock_id) {
+		g.gen_expr(lock_id)
 	}
-	lock_fn := if node.value == 'rlock' { 'sync__RwMutex__rlock' } else { 'sync__RwMutex__lock' }
-	for i in 0 .. lock_count {
-		g.write('${lock_fn}(&')
-		lock_id := g.a.child(&node, i)
-		if !g.gen_shared_storage_expr(lock_id) {
-			g.gen_expr(lock_id)
-		}
-		g.writeln('->mtx);')
-	}
+	g.write('->mtx')
 }
 
-fn (mut g FlatGen) gen_lock_leave(node flat.Node) {
-	lock_count := int(node.children_count) - 1
-	if lock_count <= 0 {
+fn (mut g FlatGen) gen_sort_lock_mutexes(mutexes_var string, lock_count int) {
+	if lock_count < 2 {
 		return
 	}
+	if lock_count == 2 {
+		g.writeln('if (${mutexes_var}[0] > ${mutexes_var}[1]) {')
+		g.indent++
+		g.writeln('uintptr_t ${mutexes_var}_tmp = ${mutexes_var}[0];')
+		g.writeln('${mutexes_var}[0] = ${mutexes_var}[1];')
+		g.writeln('${mutexes_var}[1] = ${mutexes_var}_tmp;')
+		g.indent--
+		g.writeln('}')
+		return
+	}
+	g.writeln('for (int ${mutexes_var}_i = 1; ${mutexes_var}_i < ${lock_count}; ${mutexes_var}_i++) {')
+	g.indent++
+	g.writeln('uintptr_t ${mutexes_var}_key = ${mutexes_var}[${mutexes_var}_i];')
+	g.writeln('int ${mutexes_var}_j = ${mutexes_var}_i - 1;')
+	g.writeln('while (${mutexes_var}_j >= 0 && ${mutexes_var}[${mutexes_var}_j] > ${mutexes_var}_key) {')
+	g.indent++
+	g.writeln('${mutexes_var}[${mutexes_var}_j + 1] = ${mutexes_var}[${mutexes_var}_j];')
+	g.writeln('${mutexes_var}_j--;')
+	g.indent--
+	g.writeln('}')
+	g.writeln('${mutexes_var}[${mutexes_var}_j + 1] = ${mutexes_var}_key;')
+	g.indent--
+	g.writeln('}')
+}
+
+fn (mut g FlatGen) gen_lock_enter(node flat.Node) ?ActiveLock {
+	lock_count := int(node.children_count) - 1
+	if lock_count <= 0 {
+		return none
+	}
+	lock_fn := if node.value == 'rlock' { 'sync__RwMutex__rlock' } else { 'sync__RwMutex__lock' }
 	unlock_fn := if node.value == 'rlock' {
 		'sync__RwMutex__runlock'
 	} else {
 		'sync__RwMutex__unlock'
 	}
-	mut i := lock_count - 1
-	for i >= 0 {
-		g.write('${unlock_fn}(&')
+	mutexes_var := g.tmp_name()
+	g.writeln('uintptr_t ${mutexes_var}[${lock_count}];')
+	for i in 0 .. lock_count {
 		lock_id := g.a.child(&node, i)
-		if !g.gen_shared_storage_expr(lock_id) {
-			g.gen_expr(lock_id)
-		}
-		g.writeln('->mtx);')
-		i--
+		g.write('${mutexes_var}[${i}] = ')
+		g.gen_lock_mutex_addr(lock_id)
+		g.writeln(';')
 	}
+	g.gen_sort_lock_mutexes(mutexes_var, lock_count)
+	g.writeln('for (int ${mutexes_var}_i = 0; ${mutexes_var}_i < ${lock_count}; ${mutexes_var}_i++) {')
+	g.indent++
+	g.writeln('if (${mutexes_var}_i > 0 && ${mutexes_var}[${mutexes_var}_i] == ${mutexes_var}[${mutexes_var}_i - 1]) continue;')
+	g.writeln('${lock_fn}((sync__RwMutex*)${mutexes_var}[${mutexes_var}_i]);')
+	g.indent--
+	g.writeln('}')
+	return ActiveLock{
+		mutexes_var: mutexes_var
+		lock_count:  lock_count
+		unlock_fn:   unlock_fn
+		loop_depth:  g.loop_depth
+	}
+}
+
+fn (mut g FlatGen) gen_lock_leave(active ActiveLock) {
+	if active.lock_count <= 0 {
+		return
+	}
+	if active.lock_count == 1 {
+		g.writeln('${active.unlock_fn}((sync__RwMutex*)${active.mutexes_var}[0]);')
+		return
+	}
+	g.writeln('for (int ${active.mutexes_var}_i = ${active.lock_count - 1}; ${active.mutexes_var}_i >= 0; ${active.mutexes_var}_i--) {')
+	g.indent++
+	g.writeln('if (${active.mutexes_var}_i > 0 && ${active.mutexes_var}[${active.mutexes_var}_i] == ${active.mutexes_var}[${active.mutexes_var}_i - 1]) continue;')
+	g.writeln('${active.unlock_fn}((sync__RwMutex*)${active.mutexes_var}[${active.mutexes_var}_i]);')
+	g.indent--
+	g.writeln('}')
 }
 
 fn (mut g FlatGen) gen_active_lock_leaves() {
@@ -101,14 +150,25 @@ fn (mut g FlatGen) gen_active_lock_leaves() {
 	}
 }
 
+fn (mut g FlatGen) gen_branch_lock_leaves() {
+	mut i := g.active_locks.len - 1
+	for i >= 0 {
+		active := g.active_locks[i]
+		if active.loop_depth == g.loop_depth {
+			g.gen_lock_leave(active)
+		}
+		i--
+	}
+}
+
 fn (mut g FlatGen) gen_return_cleanup() {
 	g.gen_all_defers()
 	g.gen_active_lock_leaves()
 }
 
 fn (mut g FlatGen) gen_lock_stmt(node flat.Node) {
-	g.gen_lock_enter(node)
-	g.active_locks << node
+	active := g.gen_lock_enter(node) or { return }
+	g.active_locks << active
 	if node.children_count > 0 {
 		body_id := g.a.child(&node, node.children_count - 1)
 		if int(body_id) >= 0 {
@@ -124,7 +184,7 @@ fn (mut g FlatGen) gen_lock_stmt(node flat.Node) {
 		}
 	}
 	g.active_locks.delete_last()
-	g.gen_lock_leave(node)
+	g.gen_lock_leave(active)
 }
 
 fn (g &FlatGen) lock_expr_result_type(node flat.Node) types.Type {
@@ -160,8 +220,11 @@ fn (mut g FlatGen) gen_lock_expr(node flat.Node) {
 	result_type := g.lock_expr_result_type(node)
 	if result_type is types.Void || result_type is types.Unknown {
 		g.write('({')
-		g.gen_lock_enter(node)
-		g.active_locks << node
+		active := g.gen_lock_enter(node) or {
+			g.write('0;})')
+			return
+		}
+		g.active_locks << active
 		if node.children_count > 0 {
 			body_id := g.a.child(&node, node.children_count - 1)
 			if int(body_id) >= 0 {
@@ -175,15 +238,19 @@ fn (mut g FlatGen) gen_lock_expr(node flat.Node) {
 			}
 		}
 		g.active_locks.delete_last()
-		g.gen_lock_leave(node)
+		g.gen_lock_leave(active)
 		g.write('0;})')
 		return
 	}
 	ct := g.value_c_type(result_type)
 	tmp := g.tmp_name()
 	g.write('({ ${ct} ${tmp};')
-	g.gen_lock_enter(node)
-	g.active_locks << node
+	active := g.gen_lock_enter(node) or {
+		g.gen_default_value_for_type(result_type)
+		g.write(';})')
+		return
+	}
+	g.active_locks << active
 	if node.children_count > 0 {
 		body_id := g.a.child(&node, node.children_count - 1)
 		if int(body_id) >= 0 {
@@ -216,7 +283,7 @@ fn (mut g FlatGen) gen_lock_expr(node flat.Node) {
 		}
 	}
 	g.active_locks.delete_last()
-	g.gen_lock_leave(node)
+	g.gen_lock_leave(active)
 	g.write('${tmp};})')
 }
 
@@ -552,6 +619,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			g.gen_lock_stmt(node)
 		}
 		.break_stmt {
+			g.gen_branch_lock_leaves()
 			if node.value.len > 0 {
 				g.writeln('goto ${c_name(node.value)}_break;')
 			} else {
@@ -559,6 +627,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			}
 		}
 		.continue_stmt {
+			g.gen_branch_lock_leaves()
 			if node.value.len > 0 {
 				g.writeln('goto ${c_name(node.value)}_continue;')
 			} else {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -224,6 +224,26 @@ fn (g &FlatGen) lock_expr_result_type(node flat.Node) types.Type {
 	return g.usable_expr_type(body_id)
 }
 
+fn (mut g FlatGen) gen_lock_expr_result_assign(tmp string, result_type types.Type, id flat.NodeId) {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return
+	}
+	node := g.a.nodes[int(id)]
+	if node.kind == .expr_stmt && node.children_count > 0 {
+		g.write('${tmp} = ')
+		g.gen_expr_with_expected_type(g.a.child(&node, 0), result_type)
+		g.writeln(';')
+		return
+	}
+	if g.is_expr_kind(node.kind) {
+		g.write('${tmp} = ')
+		g.gen_expr_with_expected_type(id, result_type)
+		g.writeln(';')
+		return
+	}
+	g.gen_node(id)
+}
+
 fn (mut g FlatGen) gen_lock_expr(node flat.Node) {
 	result_type := g.lock_expr_result_type(node)
 	if result_type is types.Void || result_type is types.Unknown {
@@ -270,23 +290,10 @@ fn (mut g FlatGen) gen_lock_expr(node flat.Node) {
 				}
 				if last_idx >= 0 {
 					last_id := g.a.child(&body, last_idx)
-					last := g.a.nodes[int(last_id)]
-					if last.kind == .expr_stmt && last.children_count > 0 {
-						g.write('${tmp} = ')
-						g.gen_expr_with_expected_type(g.a.child(&last, 0), result_type)
-						g.writeln(';')
-					} else {
-						g.gen_node(last_id)
-					}
+					g.gen_lock_expr_result_assign(tmp, result_type, last_id)
 				}
-			} else if body.kind == .expr_stmt && body.children_count > 0 {
-				g.write('${tmp} = ')
-				g.gen_expr_with_expected_type(g.a.child(&body, 0), result_type)
-				g.writeln(';')
 			} else {
-				g.write('${tmp} = ')
-				g.gen_expr_with_expected_type(body_id, result_type)
-				g.writeln(';')
+				g.gen_lock_expr_result_assign(tmp, result_type, body_id)
 			}
 		}
 	}

--- a/vlib/v3/gen/c/str_intp.v
+++ b/vlib/v3/gen/c/str_intp.v
@@ -64,6 +64,9 @@ fn (g &FlatGen) string_interp_child_type(child_id flat.NodeId, child flat.Node) 
 	if child.kind == .ident && g.current_param_is_mut(child.value) {
 		if param_type := g.current_param_type(child.value) {
 			if param_type is types.Pointer {
+				if map_str_clean_type(param_type.base_type) is types.Map {
+					return param_type
+				}
 				return param_type.base_type
 			}
 			return param_type

--- a/vlib/v3/gen/c/str_intp.v
+++ b/vlib/v3/gen/c/str_intp.v
@@ -21,55 +21,81 @@ fn (mut g FlatGen) gen_string_interp(node flat.Node) {
 		if child.kind == .string_literal {
 			sid := g.intern_string(child.value)
 			g.write('_str_${sid}')
-		} else if child.typ == 'string' {
-			g.gen_expr(child_id)
 		} else {
-			mut typ := g.tc.resolve_type(child_id)
-			// For a bare ident, prefer the live cgen scope binding when present: it reflects
-			// locals introduced during generation (e.g. the `err` of an or-body lowered here,
-			// or for-loop vars) that resolve_type may stale-cache as `int`.
-			if child.kind == .ident {
-				if scope_typ := g.tc.cur_scope.lookup(child.value) {
-					if scope_typ !is types.Void {
-						typ = scope_typ
-					}
-				}
-			}
+			typ := g.string_interp_child_type(child_id, child)
 			typ_name := types.Type(typ).name()
-			if typ is types.String {
-				g.gen_expr(child_id)
+			if child.typ == 'string' || typ is types.String {
+				g.gen_string_interp_child_expr(child_id)
 			} else if g.gen_map_str_expr(child_id, typ) {
 				// emitted by gen_map_str_expr
 			} else if typ_name == 'IError' || typ_name.ends_with('.IError') {
 				// IError may resolve as Interface/Alias/Struct depending on context; match by
 				// name and interpolate its `.message` (mirrors the transformer's IError path).
-				g.gen_expr(child_id)
+				g.gen_string_interp_child_expr(child_id)
 				g.write('.message')
 			} else if typ is types.Primitive {
 				prim_name := types.Type(typ).name()
 				g.write('${c_name('${prim_name}.str')}(')
-				g.gen_expr(child_id)
+				g.gen_string_interp_child_expr(child_id)
 				g.write(')')
 			} else if typ is types.ISize || typ is types.USize {
 				g.write('${c_name('${typ.name()}.str')}(')
-				g.gen_expr(child_id)
+				g.gen_string_interp_child_expr(child_id)
 				g.write(')')
 			} else if typ is types.Struct {
 				g.write('${c_name(typ.name)}__str(')
-				g.gen_expr(child_id)
+				g.gen_string_interp_child_expr(child_id)
 				g.write(')')
 			} else if typ is types.SumType {
 				g.write('${c_name(typ.name)}__str(')
-				g.gen_expr(child_id)
+				g.gen_string_interp_child_expr(child_id)
 				g.write(')')
 			} else {
 				g.write('int__str(')
-				g.gen_expr(child_id)
+				g.gen_string_interp_child_expr(child_id)
 				g.write(')')
 			}
 		}
 	}
 	g.write('})')
+}
+
+fn (g &FlatGen) string_interp_child_type(child_id flat.NodeId, child flat.Node) types.Type {
+	if child.kind == .ident && g.current_param_is_mut(child.value) {
+		if param_type := g.current_param_type(child.value) {
+			if param_type is types.Pointer {
+				return param_type.base_type
+			}
+			return param_type
+		}
+	}
+	mut typ := g.tc.resolve_type(child_id)
+	// For a bare ident, prefer the live cgen scope binding when present: it reflects
+	// locals introduced during generation (e.g. the `err` of an or-body lowered here,
+	// or for-loop vars) that resolve_type may stale-cache as `int`.
+	if child.kind == .ident {
+		if scope_typ := g.tc.cur_scope.lookup(child.value) {
+			if scope_typ !is types.Void {
+				typ = scope_typ
+			}
+		}
+	}
+	return typ
+}
+
+fn (mut g FlatGen) gen_string_interp_child_expr(child_id flat.NodeId) {
+	child := g.a.nodes[int(child_id)]
+	if child.kind == .ident && g.current_param_is_mut(child.value) {
+		if param_type := g.current_param_type(child.value) {
+			if param_type is types.Pointer {
+				g.write('(*')
+				g.gen_expr(child_id)
+				g.write(')')
+				return
+			}
+		}
+	}
+	g.gen_expr(child_id)
 }
 
 // is_string_node reports whether is string node applies in c.

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -45,7 +45,55 @@ fn (mut g FlatGen) gen_struct_field_expr_for_field(value_id flat.NodeId, struct_
 			return
 		}
 	}
+	if g.gen_shared_field_expr_for_field(value_id, struct_name, field_name, expected) {
+		return
+	}
 	g.gen_struct_field_expr(value_id, expected)
+}
+
+fn default_init_unalias_type(typ types.Type) types.Type {
+	if typ is types.Alias {
+		return default_init_unalias_type(typ.base_type)
+	}
+	return typ
+}
+
+fn (mut g FlatGen) gen_unset_struct_field_default(struct_name string, field_name string, field_type types.Type, field_c_name string, has_field bool) bool {
+	mut has := has_field
+	if g.shared_field_info(struct_name, field_name) != none {
+		if has {
+			g.write(', ')
+		}
+		g.write('.${field_c_name} = ')
+		g.gen_shared_default_value_for_field(struct_name, field_name, field_type)
+		return true
+	}
+	clean_type := default_init_unalias_type(field_type)
+	if clean_type is types.Map {
+		if has {
+			g.write(', ')
+		}
+		g.write('.${field_c_name} = ')
+		g.write_new_map(clean_type.key_type, clean_type.value_type)
+		return true
+	}
+	if clean_type is types.Array {
+		c_elem := g.tc.c_type(clean_type.elem_type)
+		if has {
+			g.write(', ')
+		}
+		g.write('.${field_c_name} = array_new(sizeof(${c_elem}), 0, 0)')
+		return true
+	}
+	if g.field_needs_default_init(clean_type) {
+		if has {
+			g.write(', ')
+		}
+		g.write('.${field_c_name} = ')
+		g.gen_default_value_for_type(clean_type)
+		return true
+	}
+	return has
 }
 
 // gen_struct_init emits struct init output for c.
@@ -153,28 +201,8 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 			if f.name in set_fields {
 				continue
 			}
-			if f.typ is types.Map {
-				if has_field {
-					g.write(', ')
-				}
-				g.write('.${c_field_name(f.name)} = ')
-				g.write_new_map(f.typ.key_type, f.typ.value_type)
-				has_field = true
-			} else if f.typ is types.Array {
-				c_elem := g.tc.c_type(f.typ.elem_type)
-				if has_field {
-					g.write(', ')
-				}
-				g.write('.${c_field_name(f.name)} = array_new(sizeof(${c_elem}), 0, 0)')
-				has_field = true
-			} else if g.field_needs_default_init(f.typ) {
-				if has_field {
-					g.write(', ')
-				}
-				g.write('.${c_field_name(f.name)} = ')
-				g.gen_default_value_for_type(f.typ)
-				has_field = true
-			}
+			has_field = g.gen_unset_struct_field_default(defaults_key, f.name, f.typ,
+				c_field_name(f.name), has_field)
 		}
 	}
 	g.write('}')
@@ -302,28 +330,8 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 			if f.name in set_fields {
 				continue
 			}
-			if f.typ is types.Map {
-				if has_field {
-					g.write(', ')
-				}
-				g.write('.${c_field_name(f.name)} = ')
-				g.write_new_map(f.typ.key_type, f.typ.value_type)
-				has_field = true
-			} else if f.typ is types.Array {
-				c_elem := g.tc.c_type(f.typ.elem_type)
-				if has_field {
-					g.write(', ')
-				}
-				g.write('.${c_field_name(f.name)} = array_new(sizeof(${c_elem}), 0, 0)')
-				has_field = true
-			} else if g.field_needs_default_init(f.typ) {
-				if has_field {
-					g.write(', ')
-				}
-				g.write('.${c_field_name(f.name)} = ')
-				g.gen_default_value_for_type(f.typ)
-				has_field = true
-			}
+			has_field = g.gen_unset_struct_field_default(defaults_key, f.name, f.typ,
+				c_field_name(f.name), has_field)
 		}
 	}
 	g.write('};')
@@ -554,28 +562,8 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 			if f.name in set_fields {
 				continue
 			}
-			if f.typ is types.Map {
-				if has_field {
-					g.write(', ')
-				}
-				g.write('.${c_field_name(f.name)} = ')
-				g.write_new_map(f.typ.key_type, f.typ.value_type)
-				has_field = true
-			} else if f.typ is types.Array {
-				c_elem := g.tc.c_type(f.typ.elem_type)
-				if has_field {
-					g.write(', ')
-				}
-				g.write('.${c_field_name(f.name)} = array_new(sizeof(${c_elem}), 0, 0)')
-				has_field = true
-			} else if g.field_needs_default_init(f.typ) {
-				if has_field {
-					g.write(', ')
-				}
-				g.write('.${c_field_name(f.name)} = ')
-				g.gen_default_value_for_type(f.typ)
-				has_field = true
-			}
+			has_field = g.gen_unset_struct_field_default(defaults_key, f.name, f.typ,
+				c_field_name(f.name), has_field)
 		}
 	}
 	g.write('}, sizeof(${name}))')
@@ -640,54 +628,44 @@ fn (mut g FlatGen) struct_default_field_type(info StructDeclInfo, field flat.Nod
 
 // gen_default_value_for_type emits default value for type output for c.
 fn (mut g FlatGen) gen_default_value_for_type(typ types.Type) {
-	raw_typ := typ
-	if typ is types.OptionType || typ is types.ResultType {
-		ct := g.optional_type_name(typ)
+	clean_typ := default_init_unalias_type(typ)
+	if clean_typ is types.Map {
+		g.write_new_map(clean_typ.key_type, clean_typ.value_type)
+		return
+	}
+	if clean_typ is types.Array {
+		c_elem := g.tc.c_type(clean_typ.elem_type)
+		g.write('array_new(sizeof(${c_elem}), 0, 0)')
+		return
+	}
+	raw_typ := clean_typ
+	if clean_typ is types.OptionType || clean_typ is types.ResultType {
+		ct := g.optional_type_name(clean_typ)
 		g.write('(${ct}){0}')
 		return
 	}
-	if typ is types.Struct && !typ.name.starts_with('C.') {
+	if clean_typ is types.Struct && !clean_typ.name.starts_with('C.') {
 		ct := g.tc.c_type(raw_typ)
 		g.write('(${ct}){')
 		mut set_fields := map[string]bool{}
-		mut has_field := g.gen_struct_default_fields(typ.name, mut set_fields, false)
-		mut sname := g.tc.qualify_name(typ.name)
-		if typ.name in g.tc.structs {
-			sname = typ.name
+		mut has_field := g.gen_struct_default_fields(clean_typ.name, mut set_fields, false)
+		mut sname := g.tc.qualify_name(clean_typ.name)
+		if clean_typ.name in g.tc.structs {
+			sname = clean_typ.name
 		}
 		if sname in g.tc.structs {
 			for f in g.tc.structs[sname] {
 				if f.name in set_fields {
 					continue
 				}
-				if f.typ is types.Map {
-					if has_field {
-						g.write(', ')
-					}
-					g.write('.${c_name(f.name)} = ')
-					g.write_new_map(f.typ.key_type, f.typ.value_type)
-					has_field = true
-				} else if f.typ is types.Array {
-					c_elem := g.tc.c_type(f.typ.elem_type)
-					if has_field {
-						g.write(', ')
-					}
-					g.write('.${c_name(f.name)} = array_new(sizeof(${c_elem}), 0, 0)')
-					has_field = true
-				} else if g.field_needs_default_init(f.typ) {
-					if has_field {
-						g.write(', ')
-					}
-					g.write('.${c_name(f.name)} = ')
-					g.gen_default_value_for_type(f.typ)
-					has_field = true
-				}
+				has_field = g.gen_unset_struct_field_default(sname, f.name, f.typ, c_name(f.name),
+					has_field)
 			}
 		}
 		g.write('}')
 		return
 	}
-	ct := g.tc.c_type(typ)
+	ct := g.tc.c_type(clean_typ)
 	if g.is_scalar_c_type(ct) {
 		g.write(g.scalar_zero_init(ct))
 		return
@@ -711,8 +689,9 @@ fn (g &FlatGen) struct_field_value_is_plainly_incompatible(value_id flat.NodeId,
 // struct whose type carries field defaults that C's `{0}` would not apply
 // (e.g. `min_len int = 999999`).
 fn (mut g FlatGen) field_needs_default_init(typ types.Type) bool {
-	if typ is types.Struct && !typ.name.starts_with('C.') {
-		return g.struct_has_field_defaults(typ.name)
+	clean_type := default_init_unalias_type(typ)
+	if clean_type is types.Struct && !clean_type.name.starts_with('C.') {
+		return g.struct_has_field_defaults(clean_type.name)
 	}
 	return false
 }
@@ -746,18 +725,19 @@ fn (mut g FlatGen) struct_has_field_defaults_inner(type_name string, mut visited
 			continue
 		}
 		ftyp := g.tc.parse_type(field.typ)
+		clean_ftyp := default_init_unalias_type(ftyp)
 		if field.children_count > 0 {
 			// Defaults for interface/sum-typed fields require boxing the value into
 			// the interface/sum representation, which the codegen default path cannot
 			// do. Treat the whole struct as unsafe to default-emit (leave it
 			// zero-initialized, as before) rather than emit an unboxed value.
-			if ftyp is types.SumType || ftyp is types.Interface {
+			if clean_ftyp is types.SumType || clean_ftyp is types.Interface {
 				return false
 			}
 			found = true
 		}
-		if ftyp is types.Struct && !ftyp.name.starts_with('C.') {
-			if g.struct_has_field_defaults_inner(ftyp.name, mut visited) {
+		if clean_ftyp is types.Struct && !clean_ftyp.name.starts_with('C.') {
+			if g.struct_has_field_defaults_inner(clean_ftyp.name, mut visited) {
 				found = true
 			}
 		}
@@ -802,28 +782,8 @@ fn (mut g FlatGen) gen_params_struct_arg(typ types.Type, node flat.Node, field_s
 				if f.name in set_fields {
 					continue
 				}
-				if f.typ is types.Map {
-					if has_field {
-						g.write(', ')
-					}
-					g.write('.${c_name(f.name)} = ')
-					g.write_new_map(f.typ.key_type, f.typ.value_type)
-					has_field = true
-				} else if f.typ is types.Array {
-					c_elem := g.tc.c_type(f.typ.elem_type)
-					if has_field {
-						g.write(', ')
-					}
-					g.write('.${c_name(f.name)} = array_new(sizeof(${c_elem}), 0, 0)')
-					has_field = true
-				} else if g.field_needs_default_init(f.typ) {
-					if has_field {
-						g.write(', ')
-					}
-					g.write('.${c_name(f.name)} = ')
-					g.gen_default_value_for_type(f.typ)
-					has_field = true
-				}
+				has_field = g.gen_unset_struct_field_default(sname, f.name, f.typ, c_name(f.name),
+					has_field)
 			}
 		}
 		g.write('}')
@@ -940,6 +900,242 @@ struct StructDeclInfo {
 	node      flat.Node
 	module    string
 	full_name string
+}
+
+struct SharedFieldInfo {
+	inner   string
+	wrapper string
+	module  string
+}
+
+fn shared_inner_type_text(raw string) ?string {
+	clean := raw.trim_space()
+	if clean.starts_with('shared ') {
+		return clean[7..].trim_space()
+	}
+	return none
+}
+
+fn (mut g FlatGen) collect_shared_type_names() {
+	g.shared_type_names = map[string]string{}
+	g.needs_shared_runtime = false
+	old_module := g.tc.cur_module
+	for _, info in g.struct_decl_infos {
+		g.tc.cur_module = info.module
+		for i in 0 .. info.node.children_count {
+			field := g.a.child_node(&info.node, i)
+			if field.kind != .field_decl {
+				continue
+			}
+			inner := shared_inner_type_text(field.typ) or { continue }
+			wrapper := g.shared_wrapper_c_name(inner)
+			g.shared_type_names[wrapper] = inner
+			g.needs_shared_runtime = true
+		}
+	}
+	g.tc.cur_module = old_module
+}
+
+fn (g &FlatGen) sorted_shared_wrapper_names() []string {
+	mut names := []string{}
+	for name, _ in g.shared_type_names {
+		names << name
+	}
+	names.sort()
+	return names
+}
+
+fn (mut g FlatGen) shared_value_type_name(inner string) string {
+	typ := g.tc.parse_type(inner)
+	if typ is types.Array {
+		return 'Array_${types.c_type_name_part(g.tc.c_type(typ.elem_type))}'
+	}
+	if typ is types.Map {
+		key := types.c_type_name_part(g.tc.c_type(typ.key_type))
+		val := types.c_type_name_part(g.tc.c_type(typ.value_type))
+		return 'Map_${key}_${val}'
+	}
+	mut ct := g.tc.c_type(typ)
+	if ct.starts_with('fn_ptr:') {
+		ct = g.resolve_fn_ptr_type(ct)
+	}
+	if ct == 'void' {
+		ct = 'int'
+	}
+	return types.c_type_name_part(ct)
+}
+
+fn (mut g FlatGen) shared_value_c_type(inner string) string {
+	typ := g.tc.parse_type(inner)
+	mut ct := if typ is types.OptionType || typ is types.ResultType {
+		g.optional_type_name(typ)
+	} else {
+		g.tc.c_type(typ)
+	}
+	if ct.starts_with('fn_ptr:') {
+		ct = g.resolve_fn_ptr_type(ct)
+	}
+	if ct == 'void' {
+		ct = 'int'
+	}
+	return ct
+}
+
+fn (mut g FlatGen) shared_wrapper_c_name(inner string) string {
+	return '__shared__${g.shared_value_type_name(inner)}'
+}
+
+fn (mut g FlatGen) shared_field_info(type_name string, field_name string) ?SharedFieldInfo {
+	info := g.find_struct_decl(type_name) or { return none }
+	old_module := g.tc.cur_module
+	g.tc.cur_module = info.module
+	defer {
+		g.tc.cur_module = old_module
+	}
+	for i in 0 .. info.node.children_count {
+		field := g.a.child_node(&info.node, i)
+		if field.kind != .field_decl || field.value != field_name {
+			continue
+		}
+		inner := shared_inner_type_text(field.typ) or { return none }
+		return SharedFieldInfo{
+			inner:   inner
+			wrapper: g.shared_wrapper_c_name(inner)
+			module:  info.module
+		}
+	}
+	return none
+}
+
+fn (mut g FlatGen) shared_type_forward_decls() {
+	for name in g.sorted_shared_wrapper_names() {
+		g.writeln('typedef struct ${name} ${name};')
+		g.writeln('static inline void* __dup${name}(void* src, int sz);')
+	}
+}
+
+fn (mut g FlatGen) shared_struct_decls() {
+	names := g.sorted_shared_wrapper_names()
+	if names.len == 0 {
+		return
+	}
+	g.writeln('// V shared types:')
+	old_module := g.tc.cur_module
+	for name in names {
+		inner := g.shared_type_names[name] or { continue }
+		val_ct := g.shared_value_c_type(inner)
+		g.writeln('struct ${name} {')
+		g.writeln('\tsync__RwMutex mtx;')
+		g.writeln('\t${val_ct} val;')
+		g.writeln('};')
+	}
+	g.tc.cur_module = old_module
+	g.writeln('')
+}
+
+fn (mut g FlatGen) shared_dup_fns() {
+	names := g.sorted_shared_wrapper_names()
+	if names.len == 0 {
+		return
+	}
+	for name in names {
+		g.writeln('static inline void* __dup${name}(void* src, int sz) {')
+		g.writeln('\t${name}* dest = (${name}*)malloc((size_t)sz);')
+		g.writeln('\tmemcpy(dest, src, (size_t)sz);')
+		g.writeln('\tsync__RwMutex__init(&dest->mtx);')
+		g.writeln('\treturn dest;')
+		g.writeln('}')
+	}
+	g.writeln('')
+}
+
+fn (mut g FlatGen) gen_shared_storage_expr(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return false
+	}
+	node := g.a.nodes[int(id)]
+	if node.kind != .selector || node.children_count == 0 {
+		return false
+	}
+	base_id := g.a.child(&node, 0)
+	base_type0 := g.usable_expr_type(base_id)
+	return g.gen_shared_field_storage_selector(base_id, base_type0, node.value, node.op)
+}
+
+fn (mut g FlatGen) gen_shared_field_storage_selector(base_id flat.NodeId, base_type0 types.Type, field string, op flat.Op) bool {
+	mut base_type := types.unwrap_pointer(base_type0)
+	if base_type is types.Alias {
+		base_type = types.unwrap_pointer(base_type.base_type)
+	}
+	if base_type !is types.Struct {
+		return false
+	}
+	struct_type := base_type as types.Struct
+	_ = g.shared_field_info(struct_type.name, field) or { return false }
+	base := g.a.nodes[int(base_id)]
+	needs_paren := base.kind !in [.ident, .selector]
+	if needs_paren {
+		g.write('(')
+	}
+	g.gen_expr(base_id)
+	if needs_paren {
+		g.write(')')
+	}
+	if op == .arrow || base_type0 is types.Pointer {
+		g.write('->')
+	} else {
+		g.write('.')
+	}
+	g.write(c_field_name(field))
+	return true
+}
+
+fn (mut g FlatGen) gen_shared_field_value_selector(base_id flat.NodeId, base_type0 types.Type, field string, op flat.Op) bool {
+	mut base_type := types.unwrap_pointer(base_type0)
+	if base_type is types.Alias {
+		base_type = types.unwrap_pointer(base_type.base_type)
+	}
+	if base_type !is types.Struct {
+		return false
+	}
+	struct_type := base_type as types.Struct
+	_ = g.shared_field_info(struct_type.name, field) or { return false }
+	if !g.gen_shared_field_storage_selector(base_id, base_type0, field, op) {
+		return false
+	}
+	g.write('->val')
+	return true
+}
+
+fn (mut g FlatGen) gen_shared_field_expr_for_field(value_id flat.NodeId, struct_name string, field_name string, expected types.Type) bool {
+	info := g.shared_field_info(struct_name, field_name) or { return false }
+	if g.gen_shared_storage_expr(value_id) {
+		return true
+	}
+	g.write('(${info.wrapper}*)__dup${info.wrapper}(&(${info.wrapper}){.mtx = {0}, .val = ')
+	g.gen_struct_field_expr(value_id, expected)
+	g.write('}, sizeof(${info.wrapper}))')
+	return true
+}
+
+fn (mut g FlatGen) gen_shared_default_value_for_field(struct_name string, field_name string, field_type types.Type) bool {
+	info := g.shared_field_info(struct_name, field_name) or { return false }
+	old_module := g.tc.cur_module
+	g.tc.cur_module = info.module
+	inner_type := g.tc.parse_type(info.inner)
+	g.write('(${info.wrapper}*)__dup${info.wrapper}(&(${info.wrapper}){.mtx = {0}, .val = ')
+	if inner_type is types.Map {
+		g.write_new_map(inner_type.key_type, inner_type.value_type)
+	} else if inner_type is types.Array {
+		c_elem := g.tc.c_type(inner_type.elem_type)
+		g.write('array_new(sizeof(${c_elem}), 0, 0)')
+	} else {
+		g.gen_default_value_for_type(inner_type)
+	}
+	g.write('}, sizeof(${info.wrapper}))')
+	g.tc.cur_module = old_module
+	_ = field_type
+	return true
 }
 
 // struct_init_c_type_name supports struct init c type name handling for FlatGen.
@@ -1561,6 +1757,7 @@ fn (mut g FlatGen) struct_decls() {
 	for name, _ in g.interfaces {
 		g.writeln('typedef struct ${c_name(name)} ${c_name(name)};')
 	}
+	g.shared_type_forward_decls()
 	if g.has_builtins {
 		g.writeln('typedef array Array;')
 	}
@@ -1746,6 +1943,7 @@ fn (mut g FlatGen) struct_decls() {
 		}
 		g.emit_struct(name)
 	}
+	g.shared_struct_decls()
 }
 
 // type_forward_decls returns type forward decls data for FlatGen.
@@ -1766,6 +1964,7 @@ fn (mut g FlatGen) type_forward_decls() {
 	for name, _ in g.interfaces {
 		g.writeln('typedef struct ${c_name(name)} ${c_name(name)};')
 	}
+	g.shared_type_forward_decls()
 	if g.has_builtins {
 		g.writeln('typedef array Array;')
 	}
@@ -1808,6 +2007,10 @@ fn (g &FlatGen) is_generic_struct(name string) bool {
 fn (mut g FlatGen) write_struct_field(_struct_name string, f types.StructField) {
 	if f.typ is types.Void {
 		g.writeln('\tint ${c_name(f.name)};')
+		return
+	}
+	if info := g.shared_field_info(_struct_name, f.name) {
+		g.writeln('\t${info.wrapper}* ${c_name(f.name)};')
 		return
 	}
 	mut field_type := f.typ

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -1118,6 +1118,9 @@ fn (mut g FlatGen) shared_value_type_name(inner string) string {
 		val := types.c_type_name_part(g.tc.c_type(typ.value_type))
 		return 'Map_${key}_${val}'
 	}
+	if typ is types.OptionType || typ is types.ResultType {
+		return types.c_type_name_part(g.optional_type_name(typ))
+	}
 	mut ct := g.tc.c_type(typ)
 	if ct.starts_with('fn_ptr:') {
 		ct = g.resolve_fn_ptr_type(ct)

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -908,6 +908,11 @@ struct SharedFieldInfo {
 	module  string
 }
 
+struct SharedTypeInfo {
+	inner  string
+	module string
+}
+
 fn shared_inner_type_text(raw string) ?string {
 	clean := raw.trim_space()
 	if clean.starts_with('shared ') {
@@ -917,7 +922,7 @@ fn shared_inner_type_text(raw string) ?string {
 }
 
 fn (mut g FlatGen) collect_shared_type_names() {
-	g.shared_type_names = map[string]string{}
+	g.shared_type_names = map[string]SharedTypeInfo{}
 	g.needs_shared_runtime = false
 	old_module := g.tc.cur_module
 	for _, info in g.struct_decl_infos {
@@ -929,7 +934,10 @@ fn (mut g FlatGen) collect_shared_type_names() {
 			}
 			inner := shared_inner_type_text(field.typ) or { continue }
 			wrapper := g.shared_wrapper_c_name(inner)
-			g.shared_type_names[wrapper] = inner
+			g.shared_type_names[wrapper] = SharedTypeInfo{
+				inner:  inner
+				module: info.module
+			}
 			g.needs_shared_runtime = true
 		}
 	}
@@ -1022,8 +1030,9 @@ fn (mut g FlatGen) shared_struct_decls() {
 	g.writeln('// V shared types:')
 	old_module := g.tc.cur_module
 	for name in names {
-		inner := g.shared_type_names[name] or { continue }
-		val_ct := g.shared_value_c_type(inner)
+		info := g.shared_type_names[name] or { continue }
+		g.tc.cur_module = info.module
+		val_ct := g.shared_value_c_type(info.inner)
 		g.writeln('struct ${name} {')
 		g.writeln('\tsync__RwMutex mtx;')
 		g.writeln('\t${val_ct} val;')

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -152,7 +152,7 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 		value_id := g.a.child(field, 0)
 		if field.value.len == 0 {
 			if sf := g.struct_field_at(lookup_name, i) {
-				if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(node.value, sf.name,
+				if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(lookup_name, sf.name,
 					value_id)
 				{
 					inner_ct := g.tc.c_type(heap_copy_type)
@@ -160,7 +160,7 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 					g.gen_expr(value_id)
 					g.write(', sizeof(${inner_ct}))')
 				} else {
-					g.gen_struct_field_expr_for_field(value_id, node.value, sf.name, sf.typ)
+					g.gen_struct_field_expr_for_field(value_id, lookup_name, sf.name, sf.typ)
 				}
 				set_fields[sf.name] = true
 			} else {
@@ -168,7 +168,7 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 			}
 		} else {
 			g.write('.${c_field_name(field.value)} = ')
-			if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(node.value, field.value,
+			if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(lookup_name, field.value,
 				value_id)
 			{
 				inner_ct := g.tc.c_type(heap_copy_type)
@@ -180,7 +180,7 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 					if g.struct_field_value_is_plainly_incompatible(value_id, ftyp) {
 						g.gen_default_value_for_type(ftyp)
 					} else {
-						g.gen_struct_field_expr_for_field(value_id, node.value, field.value, ftyp)
+						g.gen_struct_field_expr_for_field(value_id, lookup_name, field.value, ftyp)
 					}
 				} else {
 					g.gen_expr(value_id)
@@ -276,7 +276,7 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 					g.write(', ')
 				}
 				g.write('.${c_field_name(sf.name)} = ')
-				g.gen_struct_field_expr_for_field(value_id, node.value, sf.name, sf.typ)
+				g.gen_struct_field_expr_for_field(value_id, lookup_name, sf.name, sf.typ)
 				set_fields[sf.name] = true
 				has_field = true
 			} else {
@@ -299,7 +299,7 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 				g.write(', ')
 			}
 			g.write('.${c_field_name(field.value)} = ')
-			if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(node.value, field.value,
+			if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(lookup_name, field.value,
 				value_id)
 			{
 				inner_ct := g.tc.c_type(heap_copy_type)
@@ -310,7 +310,7 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 				if g.struct_field_value_is_plainly_incompatible(value_id, ftyp) {
 					g.gen_default_value_for_type(ftyp)
 				} else {
-					g.gen_struct_field_expr_for_field(value_id, node.value, field.value, ftyp)
+					g.gen_struct_field_expr_for_field(value_id, lookup_name, field.value, ftyp)
 				}
 			} else {
 				g.gen_expr(value_id)
@@ -518,7 +518,7 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 					g.gen_expr(value_id)
 					g.write(', sizeof(${inner_ct}))')
 				} else {
-					g.gen_struct_field_expr_for_field(value_id, node.value, sf.name, sf.typ)
+					g.gen_struct_field_expr_for_field(value_id, lookup_name, sf.name, sf.typ)
 				}
 				set_fields[sf.name] = true
 			} else {
@@ -530,8 +530,8 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 		g.write('.${c_field_name(field.value)} = ')
 		if is_sum_literal {
 			g.gen_lowered_sum_field_value(sum_name, field)
-		} else if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(node.value, field.value,
-			value_id)
+		} else if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(lookup_name,
+			field.value, value_id)
 		{
 			inner_ct := g.tc.c_type(heap_copy_type)
 			g.write('(${inner_ct}*)memdup(')
@@ -542,7 +542,7 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 				if g.struct_field_value_is_plainly_incompatible(value_id, ftyp) {
 					g.gen_default_value_for_type(ftyp)
 				} else {
-					g.gen_struct_field_expr_for_field(value_id, node.value, field.value, ftyp)
+					g.gen_struct_field_expr_for_field(value_id, lookup_name, field.value, ftyp)
 				}
 			} else {
 				g.gen_expr(value_id)

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -921,27 +921,182 @@ fn shared_inner_type_text(raw string) ?string {
 	return none
 }
 
+fn shared_generic_app_parts(typ string) (string, []string, bool) {
+	if typ.starts_with('fn(') || typ.starts_with('fn (') {
+		return '', []string{}, false
+	}
+	bracket := typ.index_u8(`[`)
+	if bracket <= 0 {
+		return '', []string{}, false
+	}
+	bracket_end := shared_generic_matching_bracket(typ, bracket)
+	if bracket_end <= bracket || bracket_end >= typ.len {
+		return '', []string{}, false
+	}
+	return typ[..bracket], shared_split_generic_args(typ[bracket + 1..bracket_end]), true
+}
+
+fn shared_generic_matching_bracket(s string, start int) int {
+	mut depth := 0
+	for i in start .. s.len {
+		if s[i] == `[` {
+			depth++
+		} else if s[i] == `]` {
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return s.len
+}
+
+fn shared_split_generic_args(s string) []string {
+	mut parts := []string{}
+	mut bracket_depth := 0
+	mut paren_depth := 0
+	mut start := 0
+	for i in 0 .. s.len {
+		match s[i] {
+			`[` {
+				bracket_depth++
+			}
+			`]` {
+				bracket_depth--
+			}
+			`(` {
+				paren_depth++
+			}
+			`)` {
+				paren_depth--
+			}
+			`,` {
+				if bracket_depth == 0 && paren_depth == 0 {
+					parts << s[start..i].trim_space()
+					start = i + 1
+				}
+			}
+			else {}
+		}
+	}
+	parts << s[start..].trim_space()
+	return parts
+}
+
+fn substitute_shared_generic_type_text(typ string, params []string, args []string) string {
+	clean := typ.trim_space()
+	if clean.len == 0 || args.len == 0 {
+		return typ
+	}
+	for i, param in params {
+		if clean == param {
+			if i < args.len {
+				return args[i]
+			}
+			return clean
+		}
+	}
+	if clean.starts_with('&') {
+		return '&' + substitute_shared_generic_type_text(clean[1..], params, args)
+	}
+	if clean.starts_with('mut ') {
+		return 'mut ' + substitute_shared_generic_type_text(clean[4..], params, args)
+	}
+	if clean.starts_with('?') {
+		return '?' + substitute_shared_generic_type_text(clean[1..], params, args)
+	}
+	if clean.starts_with('!') {
+		return '!' + substitute_shared_generic_type_text(clean[1..], params, args)
+	}
+	if clean.starts_with('...') {
+		return '...' + substitute_shared_generic_type_text(clean[3..], params, args)
+	}
+	if clean.starts_with('shared ') {
+		return 'shared ' + substitute_shared_generic_type_text(clean[7..], params, args)
+	}
+	if clean.starts_with('[]') {
+		return '[]' + substitute_shared_generic_type_text(clean[2..], params, args)
+	}
+	if clean.starts_with('map[') {
+		bracket_end := shared_generic_matching_bracket(clean, 3)
+		if bracket_end < clean.len {
+			key := substitute_shared_generic_type_text(clean[4..bracket_end], params, args)
+			val := substitute_shared_generic_type_text(clean[bracket_end + 1..], params, args)
+			return 'map[${key}]${val}'
+		}
+	}
+	if clean.starts_with('[') {
+		bracket_end := shared_generic_matching_bracket(clean, 0)
+		if bracket_end < clean.len {
+			return clean[..bracket_end + 1] +
+				substitute_shared_generic_type_text(clean[bracket_end + 1..], params, args)
+		}
+	}
+	if clean.starts_with('(') && clean.ends_with(')') && clean.contains(',') {
+		mut parts := []string{}
+		for part in shared_split_generic_args(clean[1..clean.len - 1]) {
+			parts << substitute_shared_generic_type_text(part, params, args)
+		}
+		return '(' + parts.join(', ') + ')'
+	}
+	base, nested_args, ok := shared_generic_app_parts(clean)
+	if ok {
+		mut resolved_args := []string{}
+		for arg in nested_args {
+			resolved_args << substitute_shared_generic_type_text(arg, params, args)
+		}
+		return '${base}[${resolved_args.join(', ')}]'
+	}
+	return clean
+}
+
+fn shared_generic_base_matches_decl(base string, info StructDeclInfo) bool {
+	if base == info.full_name {
+		return true
+	}
+	return !info.full_name.contains('.') && base == info.node.value
+}
+
 fn (mut g FlatGen) collect_shared_type_names() {
 	g.shared_type_names = map[string]SharedTypeInfo{}
 	g.needs_shared_runtime = false
 	old_module := g.tc.cur_module
 	for _, info in g.struct_decl_infos {
 		g.tc.cur_module = info.module
-		for i in 0 .. info.node.children_count {
-			field := g.a.child_node(&info.node, i)
-			if field.kind != .field_decl {
-				continue
-			}
-			inner := shared_inner_type_text(field.typ) or { continue }
-			wrapper := g.shared_wrapper_c_name(inner)
-			g.shared_type_names[wrapper] = SharedTypeInfo{
-				inner:  inner
-				module: info.module
-			}
-			g.needs_shared_runtime = true
+		if info.node.generic_params.len > 0 || info.node.typ.contains('generic') {
+			g.collect_generic_shared_type_names(info)
+			continue
 		}
+		g.collect_shared_type_names_from_info(info, []string{})
 	}
 	g.tc.cur_module = old_module
+}
+
+fn (mut g FlatGen) collect_generic_shared_type_names(info StructDeclInfo) {
+	for type_name, _ in g.tc.structs {
+		base, args, ok := shared_generic_app_parts(type_name)
+		if !ok || !shared_generic_base_matches_decl(base, info) {
+			continue
+		}
+		g.collect_shared_type_names_from_info(info, args)
+	}
+}
+
+fn (mut g FlatGen) collect_shared_type_names_from_info(info StructDeclInfo, args []string) {
+	for i in 0 .. info.node.children_count {
+		field := g.a.child_node(&info.node, i)
+		if field.kind != .field_decl {
+			continue
+		}
+		inner := shared_inner_type_text(field.typ) or { continue }
+		concrete_inner := substitute_shared_generic_type_text(inner, info.node.generic_params, args)
+		wrapper := g.shared_wrapper_c_name(concrete_inner)
+		g.shared_type_names[wrapper] = SharedTypeInfo{
+			inner:  concrete_inner
+			module: info.module
+		}
+		g.needs_shared_runtime = true
+	}
 }
 
 fn (g &FlatGen) sorted_shared_wrapper_names() []string {
@@ -993,8 +1148,37 @@ fn (mut g FlatGen) shared_wrapper_c_name(inner string) string {
 	return '__shared__${g.shared_value_type_name(inner)}'
 }
 
+fn (mut g FlatGen) generic_shared_field_info(type_name string, field_name string) ?SharedFieldInfo {
+	base, args, ok := shared_generic_app_parts(type_name)
+	if !ok {
+		return none
+	}
+	info := g.find_struct_decl(base) or { return none }
+	old_module := g.tc.cur_module
+	g.tc.cur_module = info.module
+	defer {
+		g.tc.cur_module = old_module
+	}
+	for i in 0 .. info.node.children_count {
+		field := g.a.child_node(&info.node, i)
+		if field.kind != .field_decl || field.value != field_name {
+			continue
+		}
+		inner := shared_inner_type_text(field.typ) or { return none }
+		concrete_inner := substitute_shared_generic_type_text(inner, info.node.generic_params, args)
+		return SharedFieldInfo{
+			inner:   concrete_inner
+			wrapper: g.shared_wrapper_c_name(concrete_inner)
+			module:  info.module
+		}
+	}
+	return none
+}
+
 fn (mut g FlatGen) shared_field_info(type_name string, field_name string) ?SharedFieldInfo {
-	info := g.find_struct_decl(type_name) or { return none }
+	info := g.find_struct_decl(type_name) or {
+		return g.generic_shared_field_info(type_name, field_name)
+	}
 	old_module := g.tc.cur_module
 	g.tc.cur_module = info.module
 	defer {

--- a/vlib/v3/tests/c_directive_order_codegen_test.v
+++ b/vlib/v3/tests/c_directive_order_codegen_test.v
@@ -765,6 +765,28 @@ fn main() {
 	return os.read_file(c_out) or { panic(err) }
 }
 
+fn directive_order_gen_c_shared_runtime(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_shared_runtime_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod', "Module { name: 'directive_order_shared_runtime' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+struct SharedOnly {
+	a shared int
+}
+
+fn main() {
+	_ := SharedOnly{}
+}
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_shared_runtime.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
 fn directive_order_gen_c_request_extern(v3_bin string) string {
 	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_request_extern_project')
 	os.rmdir_all(root) or {}
@@ -1044,6 +1066,15 @@ fn test_stdarg_in_inlined_header_uses_headerless_va_defs() {
 fn test_rwmutex_keeps_linux_rwlockattr_prototype() {
 	c_code := directive_order_gen_c_rwmutex(directive_order_build_v3())
 	assert c_code.contains('int pthread_rwlockattr_setkind_np('), c_code
+}
+
+fn test_shared_runtime_keeps_rwmutex_init_prototypes() {
+	c_code := directive_order_gen_c_shared_runtime(directive_order_build_v3())
+	$if !windows {
+		assert c_code.contains('pthread_rwlockattr_init(void*)'), c_code
+		assert c_code.contains('pthread_rwlockattr_setkind_np(void*, i32)'), c_code
+		assert c_code.contains('pthread_rwlock_init(void*, void*)'), c_code
+	}
 }
 
 fn test_request_named_c_function_keeps_extern_prototype() {

--- a/vlib/v3/tests/headerless_wchar_codegen_test.v
+++ b/vlib/v3/tests/headerless_wchar_codegen_test.v
@@ -1,0 +1,31 @@
+import os
+
+const wchar_codegen_vexe = @VEXE
+const wchar_codegen_tests_dir = os.dir(@FILE)
+const wchar_codegen_v3_dir = os.dir(wchar_codegen_tests_dir)
+const wchar_codegen_vlib_dir = os.dir(wchar_codegen_v3_dir)
+const wchar_codegen_v3_src = os.join_path(wchar_codegen_v3_dir, 'v3.v')
+
+fn test_headerless_wchar_prefers_compiler_type() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_headerless_wchar_test_${pid}')
+	build :=
+		os.execute('${wchar_codegen_vexe} -gc none -path "${wchar_codegen_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${wchar_codegen_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_headerless_wchar_${pid}.v')
+	c_out := os.join_path(os.temp_dir(), 'v3_headerless_wchar_${pid}.c')
+	os.write_file(src, "fn main() {\n\tprintln('ok')\n}\n") or { panic(err) }
+	os.rm(c_out) or {}
+	gen_c := os.execute('${v3_bin} ${src} -b c -o ${c_out}')
+	assert gen_c.exit_code == 0, gen_c.output
+
+	c_code := os.read_file(c_out) or { panic(err) }
+	wchar_block := '#ifdef __WCHAR_TYPE__
+typedef __WCHAR_TYPE__ wchar_t;
+#elif defined(_WIN32)
+typedef unsigned short wchar_t;
+#else
+typedef unsigned int wchar_t;'
+	assert c_code.contains(wchar_block), c_code
+}

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -1,0 +1,95 @@
+import os
+import v3.gen.c as cgen
+import v3.markused
+import v3.parser
+import v3.pref
+import v3.transform
+import v3.types
+
+fn lock_codegen_gen_c(name string, source string) string {
+	src := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	os.write_file(src, source) or { panic(err) }
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_file(src)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.diagnose_unknown_calls = true
+	tc.diagnostic_files[src] = true
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	transform.transform(mut a, &tc)
+	tc.annotate_types()
+	used_fns := markused.mark_used(a, tc)
+	mut g := cgen.FlatGen.new()
+	return g.gen_with_used_options(a, used_fns, &tc, true)
+}
+
+fn lock_codegen_fn_fragment(c_code string, name string) string {
+	start := c_code.index('\nvoid ${name}(Counter* c) {') or { return '' }
+	rest := c_code[start + 1..]
+	body_start := rest.index(') {') or { return rest }
+	after_body_start := rest[body_start + 3..]
+	next_fn := after_body_start.index('\nvoid ') or { return rest }
+	return rest[..body_start + 3 + next_fn]
+}
+
+fn assert_lock_cleanup_before_branch(c_code string, name string, branch string) {
+	fragment := lock_codegen_fn_fragment(c_code, name)
+	assert fragment.len > 0, c_code
+	branch_idx := fragment.last_index(branch) or { -1 }
+	assert branch_idx >= 0, fragment
+	before_branch := fragment[..branch_idx]
+	unlock_idx := before_branch.last_index('sync__RwMutex__unlock((sync__RwMutex*)') or { -1 }
+	assert unlock_idx >= 0, fragment
+	lock_idx := before_branch.last_index('sync__RwMutex__lock((sync__RwMutex*)') or { -1 }
+	assert lock_idx >= 0, fragment
+	assert lock_idx < unlock_idx, fragment
+}
+
+fn test_lock_codegen_sorts_deduplicates_and_cleans_branch_exits() {
+	c_code := lock_codegen_gen_c('lock_codegen_regression', 'struct Counter {
+mut:
+	a shared int
+	b shared int
+}
+
+fn multi_lock(mut c Counter) {
+	lock c.b, c.a, c.a {
+		_ := 1
+	}
+}
+
+fn branch_continue(mut c Counter) {
+	for {
+		lock c.a {
+			continue
+		}
+	}
+}
+
+fn branch_break(mut c Counter) {
+	for {
+		lock c.a {
+			break
+		}
+	}
+}
+
+fn main() {
+	mut c := Counter{}
+	multi_lock(mut c)
+	branch_continue(mut c)
+	branch_break(mut c)
+}
+')
+	assert c_code.contains('uintptr_t _t'), c_code
+	assert c_code.contains('if (_t'), c_code
+	assert c_code.contains(' > _t'), c_code
+	assert c_code.contains('== _t'), c_code
+	assert c_code.contains(']) continue;'), c_code
+	assert c_code.contains('sync__RwMutex__lock((sync__RwMutex*)'), c_code
+	assert !c_code.contains('sync__RwMutex__lock(&'), c_code
+	assert_lock_cleanup_before_branch(c_code, 'branch_continue', 'continue;')
+	assert_lock_cleanup_before_branch(c_code, 'branch_break', 'break;')
+}

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -339,10 +339,14 @@ fn read_box(mut b Box[int]) int {
 	return 0
 }
 
-fn main() {
-	mut b := Box[int]{
+fn make_box() Box[int] {
+	return Box{
 		item: 1
 	}
+}
+
+fn main() {
+	mut b := make_box()
 	_ := read_box(mut b)
 }
 ')
@@ -351,6 +355,7 @@ fn main() {
 	assert c_code.contains('struct Box_int {'), c_code
 	assert c_code.contains('\t__shared__int* item;'), c_code
 	assert !c_code.contains('\tint item;'), c_code
+	assert !c_code.contains('__shared__T'), c_code
 	assert c_code.contains('b->item->val'), c_code
 }
 

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -353,3 +353,25 @@ fn main() {
 	assert !c_code.contains('\tint item;'), c_code
 	assert c_code.contains('b->item->val'), c_code
 }
+
+fn test_shared_option_payload_wrappers_are_unique() {
+	c_code := lock_codegen_gen_c('shared_option_payload_wrapper', 'struct Holder {
+mut:
+	a shared ?int
+	b shared ?string
+	c shared !string
+}
+
+fn main() {
+	_ := Holder{}
+}
+')
+	assert c_code.contains('struct __shared__Optional {'), c_code
+	assert c_code.contains('\tOptional val;'), c_code
+	assert c_code.contains('struct __shared__Optional_string {'), c_code
+	assert c_code.contains('\tOptional_string val;'), c_code
+	assert c_code.contains('\t__shared__Optional* a;'), c_code
+	assert c_code.contains('\t__shared__Optional_string* b;'), c_code
+	assert c_code.contains('\t__shared__Optional_string* c;'), c_code
+	assert !c_code.contains('struct __shared__Optional {\n\tsync__RwMutex mtx;\n\tOptional_string val;'), c_code
+}

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -59,11 +59,22 @@ fn lock_codegen_gen_c_sources(name string, files map[string]string) string {
 }
 
 fn lock_codegen_fn_fragment(c_code string, name string) string {
-	start := c_code.index('\nvoid ${name}(Counter* c) {') or { return '' }
+	return lock_codegen_counter_fn_fragment(c_code, name, 'void')
+}
+
+fn lock_codegen_counter_fn_fragment(c_code string, name string, return_type string) string {
+	start := c_code.index('\n${return_type} ${name}(Counter* c) {') or { return '' }
 	rest := c_code[start + 1..]
 	body_start := rest.index(') {') or { return rest }
 	after_body_start := rest[body_start + 3..]
-	next_fn := after_body_start.index('\nvoid ') or { return rest }
+	mut next_fn := after_body_start.len
+	for marker in ['\nvoid ', '\nint ', '\nstring ', '\nArray_', '\nOptional_'] {
+		if idx := after_body_start.index(marker) {
+			if idx < next_fn {
+				next_fn = idx
+			}
+		}
+	}
 	return rest[..body_start + 3 + next_fn]
 }
 
@@ -78,6 +89,39 @@ fn assert_lock_cleanup_before_branch(c_code string, name string, branch string) 
 	lock_idx := before_branch.last_index('sync__RwMutex__lock((sync__RwMutex*)') or { -1 }
 	assert lock_idx >= 0, fragment
 	assert lock_idx < unlock_idx, fragment
+}
+
+fn assert_return_read_before_lock_cleanup(c_code string, name string) {
+	fragment := lock_codegen_counter_fn_fragment(c_code, name, 'int')
+	assert fragment.len > 0, c_code
+	read_idx := fragment.index('->val') or { -1 }
+	assert read_idx >= 0, fragment
+	unlock_idx := fragment.index('sync__RwMutex__unlock((sync__RwMutex*)') or { -1 }
+	assert unlock_idx >= 0, fragment
+	return_idx := fragment.last_index('return ') or { -1 }
+	assert return_idx >= 0, fragment
+	assert read_idx < unlock_idx, fragment
+	assert unlock_idx < return_idx, fragment
+}
+
+fn assert_outer_defer_runs_after_lock_cleanup(c_code string, name string) {
+	fragment := lock_codegen_counter_fn_fragment(c_code, name, 'int')
+	assert fragment.len > 0, c_code
+	first_lock_idx := fragment.index('sync__RwMutex__lock((sync__RwMutex*)') or { -1 }
+	assert first_lock_idx >= 0, fragment
+	read_idx := fragment.index('->val') or { -1 }
+	assert read_idx >= 0, fragment
+	after_read := fragment[read_idx..]
+	unlock_rel := after_read.index('sync__RwMutex__unlock((sync__RwMutex*)') or { -1 }
+	assert unlock_rel >= 0, fragment
+	unlock_idx := read_idx + unlock_rel
+	after_unlock := fragment[unlock_idx + 1..]
+	defer_lock_rel := after_unlock.index('sync__RwMutex__lock((sync__RwMutex*)') or { -1 }
+	assert defer_lock_rel >= 0, fragment
+	defer_lock_idx := unlock_idx + 1 + defer_lock_rel
+	assert first_lock_idx < read_idx, fragment
+	assert read_idx < unlock_idx, fragment
+	assert unlock_idx < defer_lock_idx, fragment
 }
 
 fn test_lock_codegen_sorts_deduplicates_and_cleans_branch_exits() {
@@ -141,6 +185,25 @@ fn lock_if_tail(mut c Counter, cond bool) int {
 	}
 }
 
+fn return_shared(mut c Counter) int {
+	lock c.a {
+		return c.a
+	}
+	return 0
+}
+
+fn defer_after_lock(mut c Counter) int {
+	defer {
+		lock c.a {
+			_ := c.a
+		}
+	}
+	lock c.a {
+		return c.a
+	}
+	return 0
+}
+
 fn main() {
 	mut c := Counter{}
 	multi_lock(mut c)
@@ -149,6 +212,8 @@ fn main() {
 	branch_labeled_break(mut c)
 	branch_labeled_continue(mut c)
 	_ = lock_if_tail(mut c, true)
+	_ = return_shared(mut c)
+	_ = defer_after_lock(mut c)
 }
 ')
 	assert c_code.contains('uintptr_t _t'), c_code
@@ -163,6 +228,8 @@ fn main() {
 	assert_lock_cleanup_before_branch(c_code, 'branch_labeled_break', 'goto outer_break;')
 	assert_lock_cleanup_before_branch(c_code, 'branch_labeled_continue', 'goto outer_continue;')
 	assert c_code.contains(' = (cond ? 1 : 2);'), c_code
+	assert_return_read_before_lock_cleanup(c_code, 'return_shared')
+	assert_outer_defer_runs_after_lock_cleanup(c_code, 'defer_after_lock')
 }
 
 fn test_shared_wrapper_value_type_uses_declaring_module() {

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -91,6 +91,16 @@ fn assert_lock_cleanup_before_branch(c_code string, name string, branch string) 
 	assert lock_idx < unlock_idx, fragment
 }
 
+fn assert_no_lock_cleanup_before_branch(c_code string, name string, branch string) {
+	fragment := lock_codegen_fn_fragment(c_code, name)
+	assert fragment.len > 0, c_code
+	branch_idx := fragment.last_index(branch) or { -1 }
+	assert branch_idx >= 0, fragment
+	before_branch := fragment[..branch_idx]
+	unlock_idx := before_branch.last_index('sync__RwMutex__unlock((sync__RwMutex*)') or { -1 }
+	assert unlock_idx < 0, fragment
+}
+
 fn assert_return_read_before_lock_cleanup(c_code string, name string) {
 	fragment := lock_codegen_counter_fn_fragment(c_code, name, 'int')
 	assert fragment.len > 0, c_code
@@ -204,6 +214,24 @@ fn defer_after_lock(mut c Counter) int {
 	return 0
 }
 
+fn goto_out_of_lock(mut c Counter) {
+	lock c.a {
+		goto done
+	}
+done:
+	lock c.a {
+		_ := c.a
+	}
+}
+
+fn goto_inside_lock(mut c Counter) {
+	lock c.a {
+		goto inside
+	inside:
+		_ := c.a
+	}
+}
+
 fn main() {
 	mut c := Counter{}
 	multi_lock(mut c)
@@ -214,6 +242,8 @@ fn main() {
 	_ = lock_if_tail(mut c, true)
 	_ = return_shared(mut c)
 	_ = defer_after_lock(mut c)
+	goto_out_of_lock(mut c)
+	goto_inside_lock(mut c)
 }
 ')
 	assert c_code.contains('uintptr_t _t'), c_code
@@ -227,6 +257,8 @@ fn main() {
 	assert_lock_cleanup_before_branch(c_code, 'branch_break', 'break;')
 	assert_lock_cleanup_before_branch(c_code, 'branch_labeled_break', 'goto outer_break;')
 	assert_lock_cleanup_before_branch(c_code, 'branch_labeled_continue', 'goto outer_continue;')
+	assert_lock_cleanup_before_branch(c_code, 'goto_out_of_lock', 'goto done;')
+	assert_no_lock_cleanup_before_branch(c_code, 'goto_inside_lock', 'goto inside;')
 	assert c_code.contains(' = (cond ? 1 : 2);'), c_code
 	assert_return_read_before_lock_cleanup(c_code, 'return_shared')
 	assert_outer_defer_runs_after_lock_cleanup(c_code, 'defer_after_lock')

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -134,6 +134,22 @@ fn assert_outer_defer_runs_after_lock_cleanup(c_code string, name string) {
 	assert unlock_idx < defer_lock_idx, fragment
 }
 
+fn assert_lock_expr_defer_runs_before_unlock(c_code string, name string) {
+	fragment := lock_codegen_counter_fn_fragment(c_code, name, 'int')
+	assert fragment.len > 0, c_code
+	result_idx := fragment.index(' = 1;') or { -1 }
+	assert result_idx >= 0, fragment
+	defer_idx := fragment.index('->val = 2;') or { -1 }
+	assert defer_idx >= 0, fragment
+	unlock_idx := fragment.index('sync__RwMutex__unlock((sync__RwMutex*)') or { -1 }
+	assert unlock_idx >= 0, fragment
+	return_idx := fragment.last_index('return ') or { -1 }
+	assert return_idx >= 0, fragment
+	assert result_idx < defer_idx, fragment
+	assert defer_idx < unlock_idx, fragment
+	assert unlock_idx < return_idx, fragment
+}
+
 fn test_lock_codegen_sorts_deduplicates_and_cleans_branch_exits() {
 	c_code := lock_codegen_gen_c('lock_codegen_regression', 'struct Counter {
 mut:
@@ -232,6 +248,16 @@ fn goto_inside_lock(mut c Counter) {
 	}
 }
 
+fn lock_expr_defer_tail(mut c Counter) int {
+	value := lock c.a {
+		defer {
+			c.a = 2
+		}
+		1
+	}
+	return value
+}
+
 fn main() {
 	mut c := Counter{}
 	multi_lock(mut c)
@@ -244,6 +270,7 @@ fn main() {
 	_ = defer_after_lock(mut c)
 	goto_out_of_lock(mut c)
 	goto_inside_lock(mut c)
+	_ = lock_expr_defer_tail(mut c)
 }
 ')
 	assert c_code.contains('uintptr_t _t'), c_code
@@ -262,6 +289,7 @@ fn main() {
 	assert c_code.contains(' = (cond ? 1 : 2);'), c_code
 	assert_return_read_before_lock_cleanup(c_code, 'return_shared')
 	assert_outer_defer_runs_after_lock_cleanup(c_code, 'defer_after_lock')
+	assert_lock_expr_defer_runs_before_unlock(c_code, 'lock_expr_defer_tail')
 }
 
 fn test_shared_wrapper_value_type_uses_declaring_module() {

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -25,6 +25,39 @@ fn lock_codegen_gen_c(name string, source string) string {
 	return g.gen_with_used_options(a, used_fns, &tc, true)
 }
 
+fn lock_codegen_gen_c_sources(name string, files map[string]string) string {
+	root := os.join_path(os.temp_dir(), 'v3_${name}')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(root) or { panic(err) }
+	mut paths := []string{}
+	mut rels := files.keys()
+	rels.sort()
+	for rel in rels {
+		path := os.join_path(root, rel)
+		os.mkdir_all(os.dir(path)) or { panic(err) }
+		os.write_file(path, files[rel]) or { panic(err) }
+		paths << path
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_files(paths)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.diagnose_unknown_calls = true
+	for path in paths {
+		tc.diagnostic_files[path] = true
+	}
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	transform.transform(mut a, &tc)
+	tc.annotate_types()
+	used_fns := markused.mark_used(a, tc)
+	mut g := cgen.FlatGen.new()
+	return g.gen_with_used_options(a, used_fns, &tc, true)
+}
+
 fn lock_codegen_fn_fragment(c_code string, name string) string {
 	start := c_code.index('\nvoid ${name}(Counter* c) {') or { return '' }
 	rest := c_code[start + 1..]
@@ -76,11 +109,35 @@ fn branch_break(mut c Counter) {
 	}
 }
 
+fn branch_labeled_break(mut c Counter) {
+outer:
+	for {
+		lock c.a {
+			for {
+				break outer
+			}
+		}
+	}
+}
+
+fn branch_labeled_continue(mut c Counter) {
+outer:
+	for {
+		lock c.a {
+			for {
+				continue outer
+			}
+		}
+	}
+}
+
 fn main() {
 	mut c := Counter{}
 	multi_lock(mut c)
 	branch_continue(mut c)
 	branch_break(mut c)
+	branch_labeled_break(mut c)
+	branch_labeled_continue(mut c)
 }
 ')
 	assert c_code.contains('uintptr_t _t'), c_code
@@ -92,4 +149,38 @@ fn main() {
 	assert !c_code.contains('sync__RwMutex__lock(&'), c_code
 	assert_lock_cleanup_before_branch(c_code, 'branch_continue', 'continue;')
 	assert_lock_cleanup_before_branch(c_code, 'branch_break', 'break;')
+	assert_lock_cleanup_before_branch(c_code, 'branch_labeled_break', 'goto outer_break;')
+	assert_lock_cleanup_before_branch(c_code, 'branch_labeled_continue', 'goto outer_continue;')
+}
+
+fn test_shared_wrapper_value_type_uses_declaring_module() {
+	c_code := lock_codegen_gen_c_sources('shared_wrapper_decl_module', {
+		'main.v': 'module main
+
+import m
+
+struct Foo {
+	wrong int
+}
+
+fn main() {
+	_ := m.Box{}
+}
+'
+		'm/m.v':  'module m
+
+pub struct Foo {
+pub:
+	value int
+}
+
+pub struct Box {
+pub mut:
+	item shared Foo
+}
+'
+	})
+	assert c_code.contains('struct __shared__m__Foo {'), c_code
+	assert c_code.contains('\tm__Foo val;'), c_code
+	assert !c_code.contains('\tFoo val;'), c_code
 }

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -20,7 +20,8 @@ fn lock_codegen_gen_c(name string, source string) string {
 	assert tc.errors.len == 0, tc.errors.str()
 	transform.transform(mut a, &tc)
 	tc.annotate_types()
-	used_fns := markused.mark_used(a, tc)
+	mut used_fns := markused.mark_used(a, tc)
+	used_fns = transform.monomorphize_with_used(mut a, &tc, used_fns)
 	mut g := cgen.FlatGen.new()
 	return g.gen_with_used_options(a, used_fns, &tc, true)
 }
@@ -53,7 +54,8 @@ fn lock_codegen_gen_c_sources(name string, files map[string]string) string {
 	assert tc.errors.len == 0, tc.errors.str()
 	transform.transform(mut a, &tc)
 	tc.annotate_types()
-	used_fns := markused.mark_used(a, tc)
+	mut used_fns := markused.mark_used(a, tc)
+	used_fns = transform.monomorphize_with_used(mut a, &tc, used_fns)
 	mut g := cgen.FlatGen.new()
 	return g.gen_with_used_options(a, used_fns, &tc, true)
 }
@@ -322,4 +324,32 @@ pub mut:
 	assert c_code.contains('struct __shared__m__Foo {'), c_code
 	assert c_code.contains('\tm__Foo val;'), c_code
 	assert !c_code.contains('\tFoo val;'), c_code
+}
+
+fn test_generic_shared_field_uses_concrete_wrapper() {
+	c_code := lock_codegen_gen_c('generic_shared_field_wrapper', 'struct Box[T] {
+mut:
+	item shared T
+}
+
+fn read_box(mut b Box[int]) int {
+	lock b.item {
+		return b.item
+	}
+	return 0
+}
+
+fn main() {
+	mut b := Box[int]{
+		item: 1
+	}
+	_ := read_box(mut b)
+}
+')
+	assert c_code.contains('struct __shared__int {'), c_code
+	assert c_code.contains('\tint val;'), c_code
+	assert c_code.contains('struct Box_int {'), c_code
+	assert c_code.contains('\t__shared__int* item;'), c_code
+	assert !c_code.contains('\tint item;'), c_code
+	assert c_code.contains('b->item->val'), c_code
 }

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -103,6 +103,17 @@ fn assert_no_lock_cleanup_before_branch(c_code string, name string, branch strin
 	assert unlock_idx < 0, fragment
 }
 
+fn assert_lock_scope_goto_rejected(c_code string, name string, branch string) {
+	fragment := lock_codegen_fn_fragment(c_code, name)
+	assert fragment.len > 0, c_code
+	error_idx := fragment.index('#error goto into a different lock scope is not supported') or {
+		-1
+	}
+	assert error_idx >= 0, fragment
+	branch_idx := fragment.index(branch) or { -1 }
+	assert branch_idx < 0, fragment
+}
+
 fn assert_return_read_before_lock_cleanup(c_code string, name string) {
 	fragment := lock_codegen_counter_fn_fragment(c_code, name, 'int')
 	assert fragment.len > 0, c_code
@@ -250,6 +261,16 @@ fn goto_inside_lock(mut c Counter) {
 	}
 }
 
+fn goto_into_different_lock(mut c Counter) {
+	lock c.a {
+		goto other
+	}
+	lock c.b {
+	other:
+		_ := c.b
+	}
+}
+
 fn lock_expr_defer_tail(mut c Counter) int {
 	value := lock c.a {
 		defer {
@@ -272,6 +293,7 @@ fn main() {
 	_ = defer_after_lock(mut c)
 	goto_out_of_lock(mut c)
 	goto_inside_lock(mut c)
+	goto_into_different_lock(mut c)
 	_ = lock_expr_defer_tail(mut c)
 }
 ')
@@ -288,6 +310,7 @@ fn main() {
 	assert_lock_cleanup_before_branch(c_code, 'branch_labeled_continue', 'goto outer_continue;')
 	assert_lock_cleanup_before_branch(c_code, 'goto_out_of_lock', 'goto done;')
 	assert_no_lock_cleanup_before_branch(c_code, 'goto_inside_lock', 'goto inside;')
+	assert_lock_scope_goto_rejected(c_code, 'goto_into_different_lock', 'goto other;')
 	assert c_code.contains(' = (cond ? 1 : 2);'), c_code
 	assert_return_read_before_lock_cleanup(c_code, 'return_shared')
 	assert_outer_defer_runs_after_lock_cleanup(c_code, 'defer_after_lock')

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -131,6 +131,16 @@ outer:
 	}
 }
 
+fn lock_if_tail(mut c Counter, cond bool) int {
+	return lock c.a {
+		if cond {
+			1
+		} else {
+			2
+		}
+	}
+}
+
 fn main() {
 	mut c := Counter{}
 	multi_lock(mut c)
@@ -138,6 +148,7 @@ fn main() {
 	branch_break(mut c)
 	branch_labeled_break(mut c)
 	branch_labeled_continue(mut c)
+	_ = lock_if_tail(mut c, true)
 }
 ')
 	assert c_code.contains('uintptr_t _t'), c_code
@@ -151,6 +162,7 @@ fn main() {
 	assert_lock_cleanup_before_branch(c_code, 'branch_break', 'break;')
 	assert_lock_cleanup_before_branch(c_code, 'branch_labeled_break', 'goto outer_break;')
 	assert_lock_cleanup_before_branch(c_code, 'branch_labeled_continue', 'goto outer_continue;')
+	assert c_code.contains(' = (cond ? 1 : 2);'), c_code
 }
 
 fn test_shared_wrapper_value_type_uses_declaring_module() {

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -163,6 +163,19 @@ fn assert_lock_expr_defer_runs_before_unlock(c_code string, name string) {
 	assert unlock_idx < return_idx, fragment
 }
 
+fn assert_lock_question_defer_runs_before_error_return(c_code string, name string) {
+	fragment := lock_codegen_counter_fn_fragment(c_code, name, 'Optional')
+	assert fragment.len > 0, c_code
+	defer_idx := fragment.index('->val = 2;') or { -1 }
+	assert defer_idx >= 0, fragment
+	unlock_idx := fragment.index('sync__RwMutex__unlock((sync__RwMutex*)') or { -1 }
+	assert unlock_idx >= 0, fragment
+	return_idx := fragment.index('return _t') or { -1 }
+	assert return_idx >= 0, fragment
+	assert defer_idx < unlock_idx, fragment
+	assert unlock_idx < return_idx, fragment
+}
+
 fn test_lock_codegen_sorts_deduplicates_and_cleans_branch_exits() {
 	c_code := lock_codegen_gen_c('lock_codegen_regression', 'struct Counter {
 mut:
@@ -281,6 +294,20 @@ fn lock_expr_defer_tail(mut c Counter) int {
 	return value
 }
 
+fn may_fail() !int {
+	return error("fail")
+}
+
+fn lock_question_defer(mut c Counter) !int {
+	lock c.a {
+		defer {
+			c.a = 2
+		}
+		may_fail()?
+	}
+	return 0
+}
+
 fn main() {
 	mut c := Counter{}
 	multi_lock(mut c)
@@ -295,6 +322,7 @@ fn main() {
 	goto_inside_lock(mut c)
 	goto_into_different_lock(mut c)
 	_ = lock_expr_defer_tail(mut c)
+	_ = lock_question_defer(mut c) or { 0 }
 }
 ')
 	assert c_code.contains('uintptr_t _t'), c_code
@@ -315,6 +343,7 @@ fn main() {
 	assert_return_read_before_lock_cleanup(c_code, 'return_shared')
 	assert_outer_defer_runs_after_lock_cleanup(c_code, 'defer_after_lock')
 	assert_lock_expr_defer_runs_before_unlock(c_code, 'lock_expr_defer_tail')
+	assert_lock_question_defer_runs_before_error_return(c_code, 'lock_question_defer')
 }
 
 fn test_shared_wrapper_value_type_uses_declaring_module() {

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -93,6 +93,20 @@ fn assert_lock_cleanup_before_branch(c_code string, name string, branch string) 
 	assert lock_idx < unlock_idx, fragment
 }
 
+fn assert_lock_defer_runs_before_branch(c_code string, name string, branch string) {
+	fragment := lock_codegen_fn_fragment(c_code, name)
+	assert fragment.len > 0, c_code
+	branch_idx := fragment.last_index(branch) or { -1 }
+	assert branch_idx >= 0, fragment
+	before_branch := fragment[..branch_idx]
+	defer_idx := before_branch.last_index('->val = 2;') or { -1 }
+	assert defer_idx >= 0, fragment
+	unlock_idx := before_branch.last_index('sync__RwMutex__unlock((sync__RwMutex*)') or { -1 }
+	assert unlock_idx >= 0, fragment
+	assert defer_idx < unlock_idx, fragment
+	assert unlock_idx < branch_idx, fragment
+}
+
 fn assert_no_lock_cleanup_before_branch(c_code string, name string, branch string) {
 	fragment := lock_codegen_fn_fragment(c_code, name)
 	assert fragment.len > 0, c_code
@@ -192,6 +206,9 @@ fn multi_lock(mut c Counter) {
 fn branch_continue(mut c Counter) {
 	for {
 		lock c.a {
+			defer {
+				c.a = 2
+			}
 			continue
 		}
 	}
@@ -200,6 +217,9 @@ fn branch_continue(mut c Counter) {
 fn branch_break(mut c Counter) {
 	for {
 		lock c.a {
+			defer {
+				c.a = 2
+			}
 			break
 		}
 	}
@@ -258,6 +278,9 @@ fn defer_after_lock(mut c Counter) int {
 
 fn goto_out_of_lock(mut c Counter) {
 	lock c.a {
+		defer {
+			c.a = 2
+		}
 		goto done
 	}
 done:
@@ -337,6 +360,9 @@ fn main() {
 	assert_lock_cleanup_before_branch(c_code, 'branch_labeled_break', 'goto outer_break;')
 	assert_lock_cleanup_before_branch(c_code, 'branch_labeled_continue', 'goto outer_continue;')
 	assert_lock_cleanup_before_branch(c_code, 'goto_out_of_lock', 'goto done;')
+	assert_lock_defer_runs_before_branch(c_code, 'branch_continue', 'continue;')
+	assert_lock_defer_runs_before_branch(c_code, 'branch_break', 'break;')
+	assert_lock_defer_runs_before_branch(c_code, 'goto_out_of_lock', 'goto done;')
 	assert_no_lock_cleanup_before_branch(c_code, 'goto_inside_lock', 'goto inside;')
 	assert_lock_scope_goto_rejected(c_code, 'goto_into_different_lock', 'goto other;')
 	assert c_code.contains(' = (cond ? 1 : 2);'), c_code

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -67,6 +67,23 @@ fn test_lifted_fn_literal_mut_param_interpolation_derefs_value() {
 	assert out == '7'
 }
 
+fn test_shared_field_without_sync_import_compiles_and_locks() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'shared_field_without_sync_import',
+		'struct S {\nmut:\n\ta shared int\n}\n\nfn main() {\n\tmut s := S{}\n\tlock s.a {\n\t\ts.a = 7\n\t\tprintln(int_str(s.a))\n\t}\n}\n')
+	assert out == '7'
+}
+
+fn test_imported_shared_field_without_sync_import_compiles_and_locks() {
+	v3_bin := build_v3_review_transform()
+	out := run_good_project(v3_bin, 'imported_shared_field_without_sync_import', {
+		'v.mod':     'Module { name: "imported_shared_field_without_sync_import" }\n'
+		'main.v':    'module main\n\nimport bag\n\nfn main() {\n\tprintln(int_str(bag.value()))\n}\n'
+		'bag/bag.v': 'module bag\n\nstruct S {\nmut:\n\ta shared int\n}\n\npub fn value() int {\n\tmut s := S{}\n\tmut out := 0\n\tlock s.a {\n\t\ts.a = 9\n\t\tout = s.a\n\t}\n\treturn out\n}\n'
+	}, 'main.v')
+	assert out == '9'
+}
+
 fn test_reject_dynamic_arrays_for_fixed_array_expectations() {
 	v3_bin := build_v3_review_transform()
 	run_bad(v3_bin, 'bad_fixed_array_literal_len',

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -261,6 +261,13 @@ fn test_map_str_normalizes_alias_key_and_value_types() {
 	assert out == "{23: 'id'}\n{'price': 1.25}"
 }
 
+fn test_mut_map_param_interpolation_preserves_pointer() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'mut_map_param_interpolation',
+		"type Scores = map[string]int\n\nfn show(mut m map[string]int) {\n\tprintln('\${m}')\n}\n\nfn show_alias(mut m Scores) {\n\tprintln('\${m}')\n}\n\nfn main() {\n\tmut m := map[string]int{}\n\tm['x'] = 3\n\tshow(mut m)\n\tmut scores := Scores(map[string]int{})\n\tscores['y'] = 4\n\tshow_alias(mut scores)\n}\n")
+	assert out == "{'x': 3}\n{'y': 4}"
+}
+
 fn test_map_literal_stringification_evaluates_entries_once() {
 	v3_bin := build_v3_review_transform()
 	out := run_good(v3_bin, 'map_literal_str_side_effects',

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -261,6 +261,13 @@ fn test_map_literal_stringification_evaluates_entries_once() {
 	assert out == "{'k1': 10}\n1,1"
 }
 
+fn test_fn_literal_preserves_mut_param_string_interpolation() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'fn_literal_mut_param_interp',
+		"fn show(mut x int) {\n\t_ := fn () {}\n\tprintln('\${x}')\n}\n\nfn main() {\n\tmut n := 42\n\tshow(mut n)\n}\n")
+	assert out == '42'
+}
+
 fn test_shadowed_minmaxof_calls_are_not_rewritten() {
 	v3_bin := build_v3_review_transform()
 	out := run_good_project(v3_bin, 'shadowed_minmaxof_calls', {

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -60,6 +60,13 @@ fn run_good_project(v3_bin string, name string, files map[string]string, input s
 	return run.output.trim_space()
 }
 
+fn test_lifted_fn_literal_mut_param_interpolation_derefs_value() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'lifted_literal_mut_param_interpolation',
+		'fn main() {\n\tmut n := 7\n\tf := fn (mut x int) {\n\t\tprintln("\${x}")\n\t}\n\tf(mut n)\n}\n')
+	assert out == '7'
+}
+
 fn test_reject_dynamic_arrays_for_fixed_array_expectations() {
 	v3_bin := build_v3_review_transform()
 	run_bad(v3_bin, 'bad_fixed_array_literal_len',

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -267,6 +267,11 @@ fn (mut t Transformer) transform_infix_struct_ops(_id flat.NodeId, node flat.Nod
 		return none
 	}
 	lhs_id := t.a.children[node.children_start]
+	rhs_id := t.a.children[node.children_start + 1]
+	if node.op in [.eq, .ne]
+		&& (t.infix_operand_is_pointer(lhs_id) || t.infix_operand_is_pointer(rhs_id)) {
+		return none
+	}
 	mut lhs_type := t.node_type(lhs_id)
 	checker_lhs_type := t.checker_node_type(lhs_id)
 	lhs_key := t.expr_key(lhs_id)
@@ -346,7 +351,7 @@ fn (mut t Transformer) transform_infix_struct_ops(_id flat.NodeId, node flat.Nod
 	}
 	if !t.has_struct_operator_fn(struct_type, '==') {
 		lhs := t.stable_expr_for_reuse(lhs_id)
-		rhs := t.stable_expr_for_reuse(t.a.children[node.children_start + 1])
+		rhs := t.stable_expr_for_reuse(rhs_id)
 		if field_eq := t.make_struct_field_eq_expr(lhs, rhs, struct_type) {
 			if node.op == .ne {
 				return t.make_prefix(.not, field_eq)
@@ -374,6 +379,9 @@ fn (mut t Transformer) transform_infix_struct_ops(_id flat.NodeId, node flat.Nod
 }
 
 fn (mut t Transformer) transform_transformed_struct_eq(node flat.Node, lhs flat.NodeId, rhs flat.NodeId) ?flat.NodeId {
+	if node.op in [.eq, .ne] && (t.infix_operand_is_pointer(lhs) || t.infix_operand_is_pointer(rhs)) {
+		return none
+	}
 	mut lhs_type := t.node_type(lhs)
 	if lhs_type.starts_with('&') {
 		lhs_type = lhs_type[1..]
@@ -435,6 +443,30 @@ fn (mut t Transformer) transform_transformed_struct_eq(node flat.Node, lhs flat.
 	cmp := t.make_call_typed('memcmp', arr3(t.make_prefix(.amp, cmp_lhs), t.make_prefix(.amp,
 		cmp_rhs), t.make_sizeof_type(struct_type)), 'int')
 	return t.make_infix(node.op, cmp, t.make_int_literal(0))
+}
+
+fn (t &Transformer) infix_operand_is_pointer(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .nil_literal || node.typ.starts_with('&') {
+		return true
+	}
+	if node.kind == .ident && t.var_type(node.value).starts_with('&') {
+		return true
+	}
+	if !isnil(t.tc) {
+		if typ := t.tc.expr_type(id) {
+			if typ is types.Pointer {
+				return true
+			}
+		}
+		if t.tc.resolve_type(id) is types.Pointer {
+			return true
+		}
+	}
+	return false
 }
 
 fn (t &Transformer) checker_node_type(id flat.NodeId) string {
@@ -737,8 +769,8 @@ fn (mut t Transformer) transform_infix_sum_ops(_id flat.NodeId, node flat.Node) 
 		rhs = t.make_prefix(.mul, rhs)
 		t.a.nodes[int(rhs)].typ = rhs_type
 	}
-	tag_eq := t.make_infix(.eq, t.make_selector(lhs, 'typ', 'int'), t.make_selector(rhs, 'typ',
-		'int'))
+	tag_eq := t.make_infix(.eq, t.make_sum_tag_selector(lhs, .dot),
+		t.make_sum_tag_selector(rhs, .dot))
 	cmp := t.make_call_typed('memcmp', arr3(t.make_prefix(.amp, lhs), t.make_prefix(.amp, rhs),
 		t.make_sizeof_type(sum_type)), 'int')
 	value_eq := t.make_infix(.eq, cmp, t.make_int_literal(0))
@@ -1898,6 +1930,11 @@ pub fn (mut t Transformer) make_selector_op(base flat.NodeId, field string, typ 
 		value:          field
 		typ:            typ
 	})
+}
+
+// make_sum_tag_selector builds an internal selector for a sumtype discriminator.
+pub fn (mut t Transformer) make_sum_tag_selector(base flat.NodeId, op flat.Op) flat.NodeId {
+	return t.make_selector_op(base, sum_type_tag_selector_field, 'int', op)
 }
 
 // make_index builds make index data for transform.

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -2539,6 +2539,9 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 		param := t.a.nodes[int(param_id)]
 		if param.value.len > 0 && param.typ.len > 0 {
 			t.set_var_type(param.value, param.typ)
+			if param.op == .amp {
+				t.mut_param_values[param.value] = true
+			}
 		}
 	}
 	mut lifted_body := []flat.NodeId{cap: capture_names.len + body_ids.len}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -2531,6 +2531,7 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 	saved_fn_name := t.cur_fn_name
 	saved_ret_type := t.cur_fn_ret_type
 	saved_vars := t.var_types.clone()
+	saved_mut_param_values := t.mut_param_values.clone()
 	t.cur_fn_name = name
 	t.cur_fn_ret_type = ret_type
 	t.reset_var_types()
@@ -2561,6 +2562,7 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 	new_body := t.transform_stmts(lifted_body)
 	t.pending_stmts = outer_pending
 	t.restore_var_types(saved_vars)
+	t.mut_param_values = saved_mut_param_values.clone()
 	t.cur_fn_name = saved_fn_name
 	t.cur_fn_ret_type = saved_ret_type
 	mut all_ids := []flat.NodeId{cap: param_ids.len + new_body.len}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -923,17 +923,35 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 	}
 	if param_type.starts_with('&') && t.is_sum_type_name(param_type[1..]) {
 		target_sum := param_type[1..]
+		resolved_target_sum := t.resolve_sum_name(target_sum)
 		arg_type := t.node_type(arg_id)
 		arg_key := t.expr_key(arg_id)
 		has_smartcast := t.has_smartcast(arg_key)
+		if has_smartcast {
+			raw_arg_type := t.raw_expr_type_without_smartcast(arg_id)
+			if t.resolve_sum_name(t.trim_pointer_type(raw_arg_type)) == resolved_target_sum {
+				return t.make_plain_expr_for_smartcast(arg_id)
+			}
+		}
 		if !has_smartcast
-			&& t.resolve_sum_name(t.trim_pointer_type(arg_type)) == t.resolve_sum_name(target_sum) {
+			&& t.resolve_sum_name(t.trim_pointer_type(arg_type)) == resolved_target_sum {
 			return t.transform_expr(arg_id)
 		}
 		if arg_node.kind == .prefix && arg_node.op == .amp && arg_node.children_count > 0 {
 			inner_id := t.a.child(arg_node, 0)
+			inner_key := t.expr_key(inner_id)
+			inner_has_smartcast := t.has_smartcast(inner_key)
+			if inner_has_smartcast {
+				raw_inner_type := t.raw_expr_type_without_smartcast(inner_id)
+				if t.resolve_sum_name(t.trim_pointer_type(raw_inner_type)) == resolved_target_sum {
+					inner := t.make_plain_expr_for_smartcast(inner_id)
+					addr := t.make_prefix(.amp, inner)
+					t.a.nodes[int(addr)].typ = param_type
+					return addr
+				}
+			}
 			inner_type := t.node_type(inner_id)
-			if t.resolve_sum_name(t.trim_pointer_type(inner_type)) == t.resolve_sum_name(target_sum) {
+			if t.resolve_sum_name(t.trim_pointer_type(inner_type)) == resolved_target_sum {
 				return t.transform_expr(arg_id)
 			}
 		}
@@ -2542,7 +2560,7 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 	t.pending_stmts.clear()
 	new_body := t.transform_stmts(lifted_body)
 	t.pending_stmts = outer_pending
-	t.var_types = saved_vars
+	t.restore_var_types(saved_vars)
 	t.cur_fn_name = saved_fn_name
 	t.cur_fn_ret_type = saved_ret_type
 	mut all_ids := []flat.NodeId{cap: param_ids.len + new_body.len}
@@ -2881,7 +2899,7 @@ fn (mut t Transformer) try_lower_sum_type_name_method_call(node flat.Node) ?flat
 	resolved_sum := t.resolve_sum_name(clean_type)
 	variants := t.sum_types[resolved_sum] or { return none }
 	base := t.stable_transformed_expr_for_reuse(t.transform_expr(base_id), base_type, 'sum_type')
-	tag := t.make_selector_op(base, 'typ', 'int', if base_type.starts_with('&') {
+	tag := t.make_sum_tag_selector(base, if base_type.starts_with('&') {
 		.arrow
 	} else {
 		.dot

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -86,14 +86,9 @@ fn (mut t Transformer) transform_for_in_body(id flat.NodeId, node flat.Node) []f
 	if header_count < 3 || node.children_count < 3 {
 		return arr1(id)
 	}
-	if t.cur_fn_is_generic {
-		return arr1(id)
-	}
 	key_id := t.a.child(&node, 0) // loop var ident — pass through (do not transform a binding)
 	val_id := t.a.child(&node, 1) // may be flat.empty_node (-1)
 	container_id := t.a.child(&node, 2)
-	iter_type := t.detect_for_in_type(node)
-	has_index := int(val_id) >= 0
 	container_is_range := if int(container_id) >= 0 {
 		t.a.nodes[int(container_id)].kind == .range
 	} else {
@@ -112,6 +107,11 @@ fn (mut t Transformer) transform_for_in_body(id flat.NodeId, node flat.Node) []f
 				1), body_ids)
 		}
 	}
+	if t.cur_fn_is_generic {
+		return t.rebuild_for_in_stmt(id, node)
+	}
+	iter_type := t.detect_for_in_type(node)
+	has_index := int(val_id) >= 0
 	if iter_type.starts_with('map[') {
 		return t.rebuild_for_in_stmt(id, node)
 	}

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -161,7 +161,7 @@ fn (mut t Transformer) transform_if_guard_else_block(else_id flat.NodeId, else_n
 	} else {
 		children << t.transform_stmt(else_id)
 	}
-	t.var_types = saved_var_types
+	t.restore_var_types(saved_var_types)
 	return t.make_block(children)
 }
 
@@ -272,7 +272,7 @@ fn (mut t Transformer) expand_array_index_if_guard(node flat.Node, lhs_name stri
 	} else {
 		then_children << t.transform_stmt(then_id)
 	}
-	t.var_types = saved_var_types
+	t.restore_var_types(saved_var_types)
 	then_block := t.make_block(then_children)
 
 	mut else_block := flat.empty_node
@@ -775,7 +775,7 @@ fn (mut t Transformer) build_if_value_guard_chain(if_node flat.Node, target_name
 	then_children << value_decl
 	then_children << t.a.children_of(&t.a.nodes[int(then_block0)])
 	then_block := t.make_block(then_children)
-	t.var_types = saved_var_types
+	t.restore_var_types(saved_var_types)
 
 	else_id := t.a.child(&if_node, 2)
 	else_node := t.a.nodes[int(else_id)]
@@ -816,7 +816,7 @@ fn (mut t Transformer) build_map_index_if_value_guard_chain(if_node flat.Node, l
 	then_block0 := t.if_value_branch_block(then_id, target_name, target_type)
 	then_children << t.a.children_of(&t.a.nodes[int(then_block0)])
 	then_block := t.make_block(then_children)
-	t.var_types = saved_var_types
+	t.restore_var_types(saved_var_types)
 
 	else_id := t.a.child(&if_node, 2)
 	else_node := t.a.nodes[int(else_id)]
@@ -871,7 +871,7 @@ fn (mut t Transformer) build_array_index_if_value_guard_chain(if_node flat.Node,
 	then_block0 := t.if_value_branch_block(then_id, target_name, target_type)
 	then_children << t.a.children_of(&t.a.nodes[int(then_block0)])
 	then_block := t.make_block(then_children)
-	t.var_types = saved_var_types
+	t.restore_var_types(saved_var_types)
 
 	else_id := t.a.child(&if_node, 2)
 	else_node := t.a.nodes[int(else_id)]
@@ -1118,6 +1118,29 @@ fn (mut t Transformer) transform_if_guard_condition(node flat.Node) flat.NodeId 
 	})
 }
 
+fn (mut t Transformer) transform_if_branch_as_block(branch_id flat.NodeId) flat.NodeId {
+	if int(branch_id) < 0 {
+		return t.make_block([]flat.NodeId{})
+	}
+	branch := t.a.nodes[int(branch_id)]
+	if branch.kind == .block {
+		return t.make_block(t.transform_stmts(t.a.children_of(&branch)))
+	}
+	mut stmts := []flat.NodeId{}
+	if t.is_stmt_kind_id(node_kind_id(branch)) {
+		expanded := t.transform_stmt(branch_id)
+		t.drain_pending(mut stmts)
+		stmts << expanded
+		return t.make_block(stmts)
+	}
+	expr := t.transform_expr(branch_id)
+	t.drain_pending(mut stmts)
+	if int(expr) >= 0 {
+		stmts << t.make_expr_stmt(expr)
+	}
+	return t.make_block(stmts)
+}
+
 // transform_if_branches_with_smartcast is the main if-expr handler that
 // integrates smartcasting. When the condition contains an is_expr, it
 // pushes a smartcast for the then-branch, transforms the body under
@@ -1141,26 +1164,11 @@ fn (mut t Transformer) transform_if_branches_with_smartcast(id flat.NodeId, node
 	for info in all_is {
 		t.push_smartcast(info.expr_name, info.variant_name, info.sum_type_name)
 	}
-	then_node := t.a.nodes[int(then_id)]
-	mut new_then_id := then_id
-	if then_node.kind == .block {
-		child_ids := t.a.children_of(&then_node)
-		new_children := t.transform_stmts(child_ids)
-		block_start := t.a.children.len
-		for c in new_children {
-			t.a.children << c
-		}
-		new_then_id = t.a.add_node(flat.Node{
-			kind:           .block
-			children_start: block_start
-			children_count: flat.child_count(new_children.len)
-		})
-	}
-
+	new_then_id := t.transform_if_branch_as_block(then_id)
 	for _ in all_is {
 		t.pop_smartcast()
 	}
-	t.var_types = saved_var_types
+	t.restore_var_types(saved_var_types)
 
 	// Transform else-block (no smartcast -- the is_expr was false here).
 	mut new_else_id := flat.empty_node
@@ -1169,20 +1177,8 @@ fn (mut t Transformer) transform_if_branches_with_smartcast(id flat.NodeId, node
 		if else_node.kind == .if_expr {
 			// else-if chain: recurse.
 			new_else_id = t.transform_else_if_expr(else_id, else_node)
-		} else if else_node.kind == .block {
-			child_ids := t.a.children_of(&else_node)
-			new_children := t.transform_stmts(child_ids)
-			block_start := t.a.children.len
-			for c in new_children {
-				t.a.children << c
-			}
-			new_else_id = t.a.add_node(flat.Node{
-				kind:           .block
-				children_start: block_start
-				children_count: flat.child_count(new_children.len)
-			})
 		} else {
-			new_else_id = else_id
+			new_else_id = t.transform_if_branch_as_block(else_id)
 		}
 	}
 

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -89,6 +89,28 @@ fn (mut t Transformer) monomorphize_pass() []string {
 	return generated
 }
 
+pub fn erase_generic_templates(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) map[string]bool {
+	mut t := new_transformer(mut a, tc, used_fns)
+	t.prepare()
+	decls := t.cached_generic_fn_decls()
+	if decls.len != 0 {
+		mut erased := map[string]GenericFnDecl{}
+		for key, decl in decls {
+			if building_v_keeps_type_erased_generic_template(key) {
+				continue
+			}
+			erased[key] = decl
+		}
+		t.erase_generic_fn_decls(erased)
+	}
+	t.materialize_generic_structs()
+	return t.used_fns
+}
+
+fn building_v_keeps_type_erased_generic_template(key string) bool {
+	return key in ['token.new_keywords_matcher_trie', 'sync.pool.PoolProcessor.work_on_items']
+}
+
 // is_operator_method_name reports whether a method-name part is an overloaded
 // operator symbol (`+`, `-`, `*`, `/`, `%`, `==`, `<`, `>`, `<=`, `>=`).
 fn is_operator_method_name(name string) bool {
@@ -216,6 +238,8 @@ fn (mut t Transformer) materialize_generic_structs() {
 		t.tc.unions.delete(decl.key)
 		t.tc.params_structs.delete(decl.key)
 	}
+	t.clear_struct_field_type_cache()
+	t.tc.clear_field_lookup_cache()
 }
 
 fn (mut t Transformer) collect_generic_struct_decls() map[string]GenericStructDecl {
@@ -581,7 +605,7 @@ fn (mut t Transformer) transform_specialized_fn_body(clone_id flat.NodeId, modul
 	}
 	t.cur_fn_name = old_fn_name
 	t.cur_fn_ret_type = old_ret_type
-	t.var_types = old_var_types
+	t.restore_var_types(old_var_types)
 	t.cur_fn_is_generic = old_is_generic
 }
 
@@ -1282,7 +1306,6 @@ fn (mut t Transformer) unregister_generic_fn_signature(decl GenericFnDecl) {
 		t.tc.fn_param_types.delete(name)
 		t.tc.fn_variadic.delete(name)
 	}
-	t.rebuild_receiver_method_suffix_index()
 }
 
 fn (mut t Transformer) generic_call_specialization(id flat.NodeId, node flat.Node, module_name string, decls map[string]GenericFnDecl) ?(string, []string) {

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -655,7 +655,7 @@ fn (mut t Transformer) lower_or_body_to_stmts_with_err_expr(body_id flat.NodeId,
 		}
 	}
 	_ = target_type
-	t.var_types = saved_var_types
+	t.restore_var_types(saved_var_types)
 	return result
 }
 
@@ -664,7 +664,8 @@ fn (t &Transformer) is_error_call(node flat.Node) bool {
 		return false
 	}
 	fn_node := t.a.child_node(&node, 0)
-	return fn_node.value == 'error' || fn_node.value == 'error_with_code'
+	return fn_node.kind == .ident
+		&& (fn_node.value == 'error' || fn_node.value == 'error_with_code')
 }
 
 // is_noreturn_call reports whether is noreturn call applies in transform.

--- a/vlib/v3/transform/struct.v
+++ b/vlib/v3/transform/struct.v
@@ -369,11 +369,15 @@ fn (t &Transformer) embedded_field_for_promoted_field(info StructInfo, field_nam
 
 // is_embedded_field reports whether is embedded field applies in transform.
 fn (t &Transformer) is_embedded_field(field FieldInfo) bool {
-	if field.name.len == 0 || field.typ.len == 0 {
+	return field.is_embedded
+}
+
+fn field_decl_is_embedded(name string, typ string) bool {
+	if name.len == 0 || typ.len == 0 {
 		return false
 	}
-	short_typ := if field.typ.contains('.') { field.typ.all_after_last('.') } else { field.typ }
-	short_name := if field.name.contains('.') { field.name.all_after_last('.') } else { field.name }
+	short_typ := if typ.contains('.') { typ.all_after_last('.') } else { typ }
+	short_name := if name.contains('.') { name.all_after_last('.') } else { name }
 	return short_name == short_typ
 }
 

--- a/vlib/v3/transform/sum.v
+++ b/vlib/v3/transform/sum.v
@@ -232,7 +232,7 @@ fn (mut t Transformer) transform_is_expr(id flat.NodeId, node flat.Node) flat.No
 
 // make_sum_is_check builds make sum is check data for transform.
 fn (mut t Transformer) make_sum_is_check(expr flat.NodeId, expr_type string, sum_name string, variant string) flat.NodeId {
-	tag := t.make_selector_op(expr, 'typ', 'int', if expr_type.starts_with('&') {
+	tag := t.make_sum_tag_selector(expr, if expr_type.starts_with('&') {
 		.arrow
 	} else {
 		.dot

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -77,6 +77,7 @@ mut:
 	cur_fn_ret_type              string
 	cur_fn_is_generic            bool
 	var_types                    []VarTypeBinding
+	mut_param_values             map[string]bool
 	pointer_value_lvalues        map[string]bool
 	temp_counter                 int
 	pending_stmts                []flat.NodeId
@@ -85,8 +86,10 @@ mut:
 	in_call_callee               bool
 	in_const_init                bool
 	in_return_expr               bool
-	alias_cache                  &AliasCache = unsafe { nil }
-	sum_cache                    &AliasCache = unsafe { nil }
+	alias_cache                  &AliasCache  = unsafe { nil }
+	sum_cache                    &AliasCache  = unsafe { nil }
+	struct_field_type_cache      &LookupCache = unsafe { nil }
+	variant_short_name_cache     &LookupCache = unsafe { nil }
 	used_fns                     map[string]bool
 	// used_struct_operator_fns holds the callee names of direct calls seen during
 	// monomorphize. Infix operators on generic instances are lowered to direct calls
@@ -134,6 +137,12 @@ mut:
 	entries map[string]string
 }
 
+struct LookupCache {
+mut:
+	entries map[string]string
+	misses  map[string]bool
+}
+
 // StructInfo stores struct info metadata used by transform.
 pub struct StructInfo {
 pub:
@@ -150,6 +159,7 @@ pub:
 	typ          string
 	raw_typ      string
 	default_expr flat.NodeId
+	is_embedded  bool
 }
 
 // TupleBlockParts represents tuple block parts data used by transform.
@@ -237,6 +247,7 @@ fn new_transformer(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[strin
 	return Transformer{
 		a:                      a
 		tc:                     unsafe { tc }
+		mut_param_values:       map[string]bool{}
 		pointer_value_lvalues:  map[string]bool{}
 		invalidated_smartcasts: map[string]bool{}
 		escaping_amp_ptrs:      map[string]bool{}
@@ -284,9 +295,27 @@ fn (mut t Transformer) prepare() {
 	// entries with results computed against a partial view.
 	t.alias_cache = &AliasCache{}
 	t.sum_cache = &AliasCache{}
+	t.struct_field_type_cache = &LookupCache{
+		entries: map[string]string{}
+		misses:  map[string]bool{}
+	}
+	t.variant_short_name_cache = &LookupCache{
+		entries: map[string]string{}
+		misses:  map[string]bool{}
+	}
+}
+
+fn (mut t Transformer) clear_struct_field_type_cache() {
+	if isnil(t.struct_field_type_cache) {
+		return
+	}
+	mut cache := t.struct_field_type_cache
+	cache.entries.clear()
+	cache.misses.clear()
 }
 
 const receiver_method_suffix_ambiguous = '__v_receiver_method_suffix_ambiguous__'
+const sum_type_tag_selector_field = '__v_sum_type_tag__'
 
 fn (mut t Transformer) rebuild_receiver_method_suffix_index() {
 	t.receiver_method_suffix_index.clear()
@@ -329,6 +358,7 @@ fn (mut t Transformer) set_receiver_method_suffix_index(key string, name string)
 // reset_var_types updates reset var types state for transform.
 fn (mut t Transformer) reset_var_types() {
 	t.var_types.clear()
+	t.mut_param_values.clear()
 }
 
 // set_var_type updates set var type state for transform.
@@ -371,6 +401,10 @@ fn (t &Transformer) var_type(name string) string {
 	return ''
 }
 
+fn (mut t Transformer) restore_var_types(saved []VarTypeBinding) {
+	t.var_types = saved
+}
+
 // --- type collection ---
 
 // collect_types updates collect types state for transform.
@@ -398,11 +432,13 @@ fn (mut t Transformer) collect_types() {
 					} else {
 						flat.empty_node
 					}
+					field_typ := t.normalize_field_type(f.typ, owner_type)
 					fields << FieldInfo{
 						name:         f.value
-						typ:          t.normalize_field_type(f.typ, owner_type)
+						typ:          field_typ
 						raw_typ:      f.typ
 						default_expr: default_expr
+						is_embedded:  field_decl_is_embedded(f.value, field_typ)
 					}
 				}
 				info := StructInfo{
@@ -786,7 +822,7 @@ fn (mut t Transformer) transform_top_level_file(file_idx int, file_node flat.Nod
 	t.cur_module = old_module
 	t.cur_fn_name = old_fn_name
 	t.cur_fn_ret_type = old_fn_ret_type
-	t.var_types = old_var_types
+	t.restore_var_types(old_var_types)
 	t.smartcast_stack = old_smartcast_stack
 	t.pending_stmts = old_pending_stmts
 }
@@ -952,11 +988,20 @@ fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Tran
 	w.used_fns = t.used_fns.clone()
 	w.alias_cache = &AliasCache{}
 	w.sum_cache = &AliasCache{}
+	w.struct_field_type_cache = &LookupCache{
+		entries: map[string]string{}
+		misses:  map[string]bool{}
+	}
+	w.variant_short_name_cache = &LookupCache{
+		entries: map[string]string{}
+		misses:  map[string]bool{}
+	}
 	w.generic_fn_decls_cache = map[string]GenericFnDecl{}
 	w.generic_fn_decls_ready = false
 	w.node_module_map_cache = map[int]string{}
 	w.node_module_map_nodes = -1
 	w.var_types = []VarTypeBinding{}
+	w.mut_param_values = map[string]bool{}
 	w.smartcast_stack = []SmartcastContext{}
 	w.invalidated_smartcasts = map[string]bool{}
 	w.pending_stmts = []flat.NodeId{}
@@ -1048,21 +1093,54 @@ fn split_work_items(items []FnWorkItem, n int) [][]FnWorkItem {
 
 // should_transform_fn reports whether should transform fn applies in transform.
 fn (t &Transformer) should_transform_fn(node flat.Node) bool {
-	if t.used_fns.len == 0 {
+	if !t.has_used_fn_filter() {
 		return true
 	}
-	if node.value in t.used_fns {
+	if node.value.starts_with('__anon_fn_') {
 		return true
 	}
-	qname := transform_qualified_fn_name(t.cur_module, node.value)
-	if qname in t.used_fns {
+	if t.cur_module == 'builtin' && node.value == 'exit' {
 		return true
 	}
-	cname := c_name(qname)
-	if cname != qname && cname in t.used_fns {
+	return t.used_fn_contains_in_module(node.value, t.cur_module)
+}
+
+fn (t &Transformer) has_used_fn_filter() bool {
+	return t.used_fns.len > 0 && t.used_fns['main']
+}
+
+fn (t &Transformer) used_fn_contains_name(name string) bool {
+	return name.len > 0 && t.used_fns[name]
+}
+
+fn (t &Transformer) used_fn_contains_in_module(name string, module_name string) bool {
+	if module_name.len > 0 && module_name != 'main' && module_name != 'builtin'
+		&& name.starts_with('${module_name}.') {
+		if t.used_fn_contains_name(name) {
+			return true
+		}
+		cfn := c_name(name)
+		if cfn != name && t.used_fn_contains_name(cfn) {
+			return true
+		}
+	}
+	dfn := transform_dotted_fn_name(module_name, name)
+	qfn := c_name(dfn)
+	if t.used_fn_contains_name(dfn) || t.used_fn_contains_name(qfn) {
 		return true
+	}
+	if module_name.len == 0 || module_name == 'main' || module_name == 'builtin' {
+		cfn := c_name(name)
+		return t.used_fn_contains_name(name) || t.used_fn_contains_name(cfn)
 	}
 	return false
+}
+
+fn transform_dotted_fn_name(mod string, name string) string {
+	if mod.len > 0 && mod != 'main' && mod != 'builtin' {
+		return '${mod}.${name}'
+	}
+	return name
 }
 
 // transform_qualified_fn_name transforms transform qualified fn name data for transform.
@@ -1286,7 +1364,7 @@ fn (mut t Transformer) transform_string_interp_part(child_id flat.NodeId) flat.N
 		expr_id = t.a.child(&child, 0)
 		format = child.typ
 	}
-	transformed := t.transform_expr(expr_id)
+	mut transformed := t.transform_expr(expr_id)
 	mut typ := t.node_type(transformed)
 	if typ.len == 0 {
 		typ = t.reliable_stringify_type(transformed)
@@ -1296,6 +1374,11 @@ fn (mut t Transformer) transform_string_interp_part(child_id flat.NodeId) flat.N
 	}
 	if typ.len == 0 {
 		typ = t.node_type(expr_id)
+	}
+	expr_node := t.a.nodes[int(expr_id)]
+	if expr_node.kind == .ident && t.mut_param_values[expr_node.value] && typ.starts_with('&') {
+		transformed = t.make_prefix(.mul, transformed)
+		typ = typ[1..]
 	}
 	if typ.len == 0 {
 		typ = 'string'
@@ -1547,6 +1630,9 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 				typ = raw_typ
 			}
 			t.set_var_type(child.value, typ)
+			if child.op == .amp {
+				t.mut_param_values[child.value] = true
+			}
 			param_idx++
 		}
 	}
@@ -2697,7 +2783,7 @@ fn (mut t Transformer) build_sum_shared_field_assign_chain(base flat.NodeId, sum
 		return t.make_empty()
 	}
 	variant := variants[idx]
-	tag := t.make_selector_op(base, 'typ', 'int', if sum_type.starts_with('&') {
+	tag := t.make_sum_tag_selector(base, if sum_type.starts_with('&') {
 		.arrow
 	} else {
 		.dot
@@ -3346,13 +3432,17 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 			rhs_id := t.a.child(&node, 1)
 			rhs := t.a.nodes[int(rhs_id)]
 			if rhs.kind == .call {
-				call_typ := t.node_type(rhs_id)
-				if decl_type_is_usable(call_typ) {
+				if call_typ := t.checker_resolved_non_builtin_return_type(rhs_id, rhs) {
 					typ = call_typ
 				} else if !decl_type_is_usable(typ) {
-					raw_call_typ := t.get_call_return_type(rhs_id, rhs)
-					if raw_call_typ.len > 0 {
-						typ = raw_call_typ
+					call_typ := t.node_type(rhs_id)
+					if decl_type_is_usable(call_typ) {
+						typ = call_typ
+					} else {
+						raw_call_typ := t.get_call_return_type(rhs_id, rhs)
+						if raw_call_typ.len > 0 {
+							typ = raw_call_typ
+						}
 					}
 				}
 				generic_typ := t.concrete_generic_call_return_type(rhs_id, rhs)
@@ -4081,22 +4171,7 @@ fn (mut t Transformer) transform_expr_stmt(id flat.NodeId, node flat.Node) []fla
 
 // transform_lock_stmt transforms transform lock stmt data for transform.
 fn (mut t Transformer) transform_lock_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
-	if node.children_count == 0 {
-		return arr1(id)
-	}
-	body_id := t.a.child(&node, node.children_count - 1)
-	if int(body_id) < 0 {
-		return arr1(id)
-	}
-	body := t.a.nodes[int(body_id)]
-	if body.kind == .block {
-		return t.transform_stmts(t.a.children_of(&body))
-	}
-	if t.is_stmt_kind_id(node_kind_id(body)) {
-		return t.transform_stmt(body_id)
-	}
-	new_child := t.transform_expr(body_id)
-	return t.with_pending_before(t.make_expr_stmt(new_child))
+	return t.with_pending_before(t.transform_lock_node(id, node))
 }
 
 // transform_for_stmt transforms transform for stmt data for transform.
@@ -4339,25 +4414,65 @@ fn (mut t Transformer) transform_lock_expr(id flat.NodeId, node flat.Node) flat.
 	if node.children_count == 0 {
 		return id
 	}
+	return t.transform_lock_node(id, node)
+}
+
+fn (mut t Transformer) transform_lock_node(id flat.NodeId, node flat.Node) flat.NodeId {
+	if node.children_count == 0 {
+		return id
+	}
+	mut children := []flat.NodeId{cap: int(node.children_count)}
+	for i in 0 .. node.children_count - 1 {
+		lock_id := t.a.child(&node, i)
+		if int(lock_id) < 0 {
+			continue
+		}
+		children << t.transform_expr(lock_id)
+	}
 	body_id := t.a.child(&node, node.children_count - 1)
 	if int(body_id) < 0 {
 		return id
 	}
 	body := t.a.nodes[int(body_id)]
-	if body.kind == .block {
+	new_body := if body.kind == .block {
 		mut new_block := t.transform_block_expr(body_id, body)
 		block_typ := t.stmt_value_type(new_block)
 		if node.typ == 'void' || block_typ == 'void' {
-			mut children := t.a.children_of(&t.a.nodes[int(new_block)]).clone()
-			children << t.make_expr_stmt(t.make_int_literal(0))
-			new_block = t.make_block(children)
+			mut block_children := t.a.children_of(&t.a.nodes[int(new_block)]).clone()
+			block_children << t.make_expr_stmt(t.make_int_literal(0))
+			new_block = t.make_block(block_children)
 			t.a.nodes[int(new_block)].typ = 'int'
 		} else {
 			t.a.nodes[int(new_block)].typ = node.typ
 		}
-		return new_block
+		new_block
+	} else if t.is_stmt_kind_id(node_kind_id(body)) {
+		t.make_block(t.transform_stmt(body_id))
+	} else {
+		t.transform_expr(body_id)
 	}
-	return t.transform_expr(body_id)
+	children << new_body
+	lock_typ := if node.typ.len > 0 {
+		node.typ
+	} else {
+		body_typ := t.node_type(new_body)
+		if body_typ.len > 0 {
+			body_typ
+		} else {
+			t.stmt_value_type(new_body)
+		}
+	}
+	start := t.a.children.len
+	t.a.children << children
+	return t.a.add_node(flat.Node{
+		kind:           .lock_expr
+		value:          node.value
+		typ:            lock_typ
+		op:             node.op
+		children_start: start
+		children_count: flat.child_count(children.len)
+		pos:            node.pos
+	})
 }
 
 // transform_if_stmt transforms transform if stmt data for transform.
@@ -5076,7 +5191,7 @@ fn (mut t Transformer) build_sum_shared_field_chain(base flat.NodeId, sum_type s
 		return t.zero_value_for_type(field_type)
 	}
 	variant := variants[idx]
-	tag := t.make_selector_op(base, 'typ', 'int', if sum_type.starts_with('&') {
+	tag := t.make_sum_tag_selector(base, if sum_type.starts_with('&') {
 		.arrow
 	} else {
 		.dot
@@ -6159,7 +6274,16 @@ fn (t &Transformer) variant_names_match(a string, b string) bool {
 }
 
 fn (t &Transformer) variant_short_name(name string) string {
-	return variant_short_name_text(name)
+	if isnil(t.variant_short_name_cache) {
+		return variant_short_name_text(name)
+	}
+	mut cache := t.variant_short_name_cache
+	if cached := cache.entries[name] {
+		return cached
+	}
+	short := variant_short_name_text(name)
+	cache.entries[name] = short
+	return short
 }
 
 fn variant_short_name_text(name string) string {
@@ -6950,7 +7074,7 @@ fn (mut t Transformer) build_match_chain(match_expr_id flat.NodeId, orig_expr_id
 			}
 		}
 	}
-	mut body_ids := []flat.NodeId{}
+	mut body_ids := []flat.NodeId{cap: int(branch.children_count) - body_start_idx}
 	for i in body_start_idx .. branch.children_count {
 		body_ids << t.a.child(&branch, i)
 	}
@@ -7060,7 +7184,7 @@ fn (mut t Transformer) build_match_value_chain(match_expr_id flat.NodeId, orig_e
 		}
 	}
 
-	mut body_ids := []flat.NodeId{}
+	mut body_ids := []flat.NodeId{cap: int(branch.children_count) - body_start_idx}
 	for i in body_start_idx .. branch.children_count {
 		body_ids << t.a.child(&branch, i)
 	}
@@ -7142,7 +7266,7 @@ fn (mut t Transformer) build_match_value_type_branch_chain(match_expr_id flat.No
 		sc_pushed++
 	}
 
-	mut body_ids := []flat.NodeId{}
+	mut body_ids := []flat.NodeId{cap: int(branch.children_count) - n_conds}
 	for i in n_conds .. branch.children_count {
 		body_ids << t.a.child(&branch, i)
 	}
@@ -7202,7 +7326,7 @@ fn (mut t Transformer) build_match_type_branch_chain(match_expr_id flat.NodeId, 
 		sc_pushed++
 	}
 
-	mut body_ids := []flat.NodeId{}
+	mut body_ids := []flat.NodeId{cap: int(branch.children_count) - n_conds}
 	for i in n_conds .. branch.children_count {
 		body_ids << t.a.child(&branch, i)
 	}
@@ -7454,6 +7578,9 @@ fn (mut t Transformer) annotate_fn_body(fn_node flat.Node) {
 		child := t.a.nodes[int(child_id)]
 		if child.kind == .param && child.value.len > 0 && child.typ.len > 0 {
 			t.set_var_type(child.value, t.normalize_type_alias(child.typ))
+			if child.op == .amp {
+				t.mut_param_values[child.value] = true
+			}
 		}
 		if child.kind == .decl_assign && child.children_count >= 2 {
 			lhs := t.a.child_node(&child, 0)

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -32,6 +32,8 @@ fn (mut t Transformer) propagate_decl_pair_type(node flat.Node, lhs_idx int, rhs
 	rhs_authority := t.decl_rhs_type(rhs_id)
 	if t.is_fn_pointer_type_name(rhs_authority) {
 		typ = rhs_authority
+	} else if decl_type_should_override_fallback(rhs_authority, fallback_type) {
+		typ = rhs_authority
 	} else if decl_type_is_usable(fallback_type) {
 		typ = fallback_type
 	} else {
@@ -44,6 +46,16 @@ fn (mut t Transformer) propagate_decl_pair_type(node flat.Node, lhs_idx int, rhs
 	if typ.len > 0 {
 		t.set_var_type(lhs.value, t.normalize_type_alias(typ))
 	}
+}
+
+fn decl_type_should_override_fallback(authority string, fallback string) bool {
+	if !decl_type_is_usable(authority) {
+		return false
+	}
+	if !decl_type_is_usable(fallback) {
+		return true
+	}
+	return authority.starts_with('&') && !fallback.starts_with('&')
 }
 
 fn decl_type_is_usable(typ string) bool {
@@ -74,6 +86,11 @@ fn (t &Transformer) decl_rhs_type(id flat.NodeId) string {
 	}
 	if int(id) >= 0 {
 		node := t.a.nodes[int(id)]
+		if node.kind == .call {
+			if ret := t.checker_resolved_non_builtin_return_type(id, node) {
+				return ret
+			}
+		}
 		if node.kind == .map_init {
 			if node.typ.starts_with('map[') {
 				return node.typ
@@ -428,6 +445,38 @@ fn (t &Transformer) qualified_enum_type_selector_name_from_selector_name(base st
 
 // lookup_struct_field_type resolves lookup struct field type information for transform.
 fn (t &Transformer) lookup_struct_field_type(type_name string, field_name string) ?string {
+	if type_name.len == 0 || field_name.len == 0 {
+		return none
+	}
+	key := t.struct_field_type_cache_key(type_name, field_name)
+	if !isnil(t.struct_field_type_cache) {
+		mut cache := t.struct_field_type_cache
+		if cached := cache.entries[key] {
+			return cached
+		}
+		if cache.misses[key] {
+			return none
+		}
+	}
+	resolved := t.lookup_struct_field_type_uncached(type_name, field_name) or {
+		if !isnil(t.struct_field_type_cache) {
+			mut cache := t.struct_field_type_cache
+			cache.misses[key] = true
+		}
+		return none
+	}
+	if !isnil(t.struct_field_type_cache) {
+		mut cache := t.struct_field_type_cache
+		cache.entries[key] = resolved
+	}
+	return resolved
+}
+
+fn (t &Transformer) struct_field_type_cache_key(type_name string, field_name string) string {
+	return '${t.cur_module}\n${type_name}\n${field_name}'
+}
+
+fn (t &Transformer) lookup_struct_field_type_uncached(type_name string, field_name string) ?string {
 	lookup := t.lookup_struct_info_for_field(type_name, field_name) or { return none }
 	for f in lookup.info.fields {
 		if f.name == field_name {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -158,29 +158,32 @@ struct LocalBinding {
 // TypeCache represents type cache data used by types.
 struct TypeCache {
 mut:
-	parse_enabled bool
-	parse_entries map[string]Type
-	c_entries     map[string]string
+	parse_enabled        bool
+	parse_entries        map[string]Type
+	c_entries            map[string]string
+	struct_field_entries map[string]Type
+	struct_field_misses  map[string]bool
 }
 
 // TypeChecker represents type checker data used by types.
 @[heap]
 pub struct TypeChecker {
 pub mut:
-	a                      &flat.FlatAst = unsafe { nil }
-	fn_ret_types           map[string]Type
-	fn_param_types         map[string][]Type
-	fn_ret_type_texts      map[string]string   // generic struct method key -> original return type text (e.g. `Box[T].clone` -> `Box[T]`)
-	fn_param_type_texts    map[string][]string // generic struct method key -> original param type texts (receiver first)
-	fn_type_files          map[string]string
-	fn_type_modules        map[string]string
-	fn_generic_params      map[string][]string
-	fn_variadic            map[string]bool
-	c_variadic_fns         map[string]bool
-	fn_implicit_veb_ctx    map[string]bool
-	structs                map[string][]StructField
-	struct_generic_params  map[string][]string // generic struct base name -> type-param names (e.g. Vec4 -> [T])
-	struct_field_c_abi_fns map[string]string
+	a                            &flat.FlatAst = unsafe { nil }
+	fn_ret_types                 map[string]Type
+	fn_param_types               map[string][]Type
+	fn_ret_type_texts            map[string]string   // generic struct method key -> original return type text (e.g. `Box[T].clone` -> `Box[T]`)
+	fn_param_type_texts          map[string][]string // generic struct method key -> original param type texts (receiver first)
+	fn_type_files                map[string]string
+	fn_type_modules              map[string]string
+	fn_generic_params            map[string][]string
+	fn_variadic                  map[string]bool
+	c_variadic_fns               map[string]bool
+	fn_implicit_veb_ctx          map[string]bool
+	receiver_method_suffix_index map[string]string
+	structs                      map[string][]StructField
+	struct_generic_params        map[string][]string // generic struct base name -> type-param names (e.g. Vec4 -> [T])
+	struct_field_c_abi_fns       map[string]string
 	// concrete `Box[int].method` -> substituted CallInfo for a method *value* on a
 	// generic receiver. The open `Box[T].method` registration is gone by cgen time, so
 	// the checker stashes the resolved signature here for gen_method_value_closure.
@@ -255,61 +258,64 @@ mut:
 pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 	fs := new_scope(unsafe { nil })
 	return TypeChecker{
-		a:                          a
-		fn_ret_types:               map[string]Type{}
-		fn_param_types:             map[string][]Type{}
-		fn_ret_type_texts:          map[string]string{}
-		fn_param_type_texts:        map[string][]string{}
-		fn_type_files:              map[string]string{}
-		fn_type_modules:            map[string]string{}
-		fn_generic_params:          map[string][]string{}
-		fn_variadic:                map[string]bool{}
-		c_variadic_fns:             map[string]bool{}
-		fn_implicit_veb_ctx:        map[string]bool{}
-		structs:                    map[string][]StructField{}
-		struct_generic_params:      map[string][]string{}
-		struct_field_c_abi_fns:     map[string]string{}
-		generic_method_value_info:  map[string]CallInfo{}
-		params_structs:             map[string]bool{}
-		unions:                     map[string]bool{}
-		type_aliases:               map[string]string{}
-		type_alias_c_abi_fns:       map[string]string{}
-		sum_types:                  map[string][]string{}
-		enum_names:                 map[string]bool{}
-		enum_fields:                map[string][]string{}
-		flag_enums:                 map[string]bool{}
-		interface_names:            map[string]bool{}
-		interface_fields:           map[string][]StructField{}
-		interface_embeds:           map[string][]string{}
-		interface_abstract_methods: map[string][]string{}
-		c_globals:                  map[string]Type{}
-		const_types:                map[string]Type{}
-		const_exprs:                map[string]flat.NodeId{}
-		const_modules:              map[string]string{}
-		const_files:                map[string]string{}
-		const_suffixes:             map[string]string{}
-		imports:                    map[string]string{}
-		file_imports:               map[string]string{}
-		file_selective_imports:     map[string][]string{}
-		file_modules:               map[string]string{}
-		file_scope:                 fs
-		cur_scope:                  fs
-		resolved_call_names:        []string{len: a.nodes.len}
-		resolved_call_set:          []bool{len: a.nodes.len}
-		resolved_fn_value_names:    []string{len: a.nodes.len}
-		resolved_fn_value_set:      []bool{len: a.nodes.len}
-		statement_nodes:            []bool{len: a.nodes.len}
-		method_values_by_fn:        map[int][]string{}
-		method_value_locals:        map[string]bool{}
-		method_value_local_depth:   map[string]int{}
-		expr_type_values:           []Type{len: a.nodes.len, init: Type(void_)}
-		expr_type_set:              []bool{len: a.nodes.len}
-		checking_nodes:             []bool{len: a.nodes.len}
-		diagnostic_files:           map[string]bool{}
-		smartcasts:                 map[string]Type{}
-		type_cache:                 &TypeCache{
-			parse_entries: map[string]Type{}
-			c_entries:     map[string]string{}
+		a:                            a
+		fn_ret_types:                 map[string]Type{}
+		fn_param_types:               map[string][]Type{}
+		fn_ret_type_texts:            map[string]string{}
+		fn_param_type_texts:          map[string][]string{}
+		fn_type_files:                map[string]string{}
+		fn_type_modules:              map[string]string{}
+		fn_generic_params:            map[string][]string{}
+		fn_variadic:                  map[string]bool{}
+		c_variadic_fns:               map[string]bool{}
+		fn_implicit_veb_ctx:          map[string]bool{}
+		receiver_method_suffix_index: map[string]string{}
+		structs:                      map[string][]StructField{}
+		struct_generic_params:        map[string][]string{}
+		struct_field_c_abi_fns:       map[string]string{}
+		generic_method_value_info:    map[string]CallInfo{}
+		params_structs:               map[string]bool{}
+		unions:                       map[string]bool{}
+		type_aliases:                 map[string]string{}
+		type_alias_c_abi_fns:         map[string]string{}
+		sum_types:                    map[string][]string{}
+		enum_names:                   map[string]bool{}
+		enum_fields:                  map[string][]string{}
+		flag_enums:                   map[string]bool{}
+		interface_names:              map[string]bool{}
+		interface_fields:             map[string][]StructField{}
+		interface_embeds:             map[string][]string{}
+		interface_abstract_methods:   map[string][]string{}
+		c_globals:                    map[string]Type{}
+		const_types:                  map[string]Type{}
+		const_exprs:                  map[string]flat.NodeId{}
+		const_modules:                map[string]string{}
+		const_files:                  map[string]string{}
+		const_suffixes:               map[string]string{}
+		imports:                      map[string]string{}
+		file_imports:                 map[string]string{}
+		file_selective_imports:       map[string][]string{}
+		file_modules:                 map[string]string{}
+		file_scope:                   fs
+		cur_scope:                    fs
+		resolved_call_names:          []string{len: a.nodes.len}
+		resolved_call_set:            []bool{len: a.nodes.len}
+		resolved_fn_value_names:      []string{len: a.nodes.len}
+		resolved_fn_value_set:        []bool{len: a.nodes.len}
+		statement_nodes:              []bool{len: a.nodes.len}
+		method_values_by_fn:          map[int][]string{}
+		method_value_locals:          map[string]bool{}
+		method_value_local_depth:     map[string]int{}
+		expr_type_values:             []Type{len: a.nodes.len, init: Type(void_)}
+		expr_type_set:                []bool{len: a.nodes.len}
+		checking_nodes:               []bool{len: a.nodes.len}
+		diagnostic_files:             map[string]bool{}
+		smartcasts:                   map[string]Type{}
+		type_cache:                   &TypeCache{
+			parse_entries:        map[string]Type{}
+			c_entries:            map[string]string{}
+			struct_field_entries: map[string]Type{}
+			struct_field_misses:  map[string]bool{}
 		}
 	}
 }
@@ -326,15 +332,26 @@ pub fn (tc &TypeChecker) fork_for_parallel_transform(ast &flat.FlatAst) &TypeChe
 	mut forked := *tc
 	forked.a = ast
 	forked.type_cache = &TypeCache{
-		parse_enabled: if tc.type_cache != unsafe { nil } {
+		parse_enabled:        if tc.type_cache != unsafe { nil } {
 			tc.type_cache.parse_enabled
 		} else {
 			false
 		}
-		parse_entries: map[string]Type{}
-		c_entries:     map[string]string{}
+		parse_entries:        map[string]Type{}
+		c_entries:            map[string]string{}
+		struct_field_entries: map[string]Type{}
+		struct_field_misses:  map[string]bool{}
 	}
 	return &forked
+}
+
+pub fn (tc &TypeChecker) clear_field_lookup_cache() {
+	if isnil(tc.type_cache) {
+		return
+	}
+	mut cache := tc.type_cache
+	cache.struct_field_entries.clear()
+	cache.struct_field_misses.clear()
 }
 
 // reset_node_caches updates reset node caches state for types.
@@ -455,8 +472,10 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	tc.scope_pool_index = 0
 	tc.reset_node_caches(a.nodes.len)
 	tc.type_cache = &TypeCache{
-		parse_entries: map[string]Type{}
-		c_entries:     map[string]string{}
+		parse_entries:        map[string]Type{}
+		c_entries:            map[string]string{}
+		struct_field_entries: map[string]Type{}
+		struct_field_misses:  map[string]bool{}
 	}
 	for node in a.nodes {
 		if node.kind == .struct_decl && node.value == 'string' {
@@ -660,7 +679,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 						mut absm := tc.interface_abstract_methods[iface_name] or { []string{} }
 						absm << f.value
 						tc.interface_abstract_methods[iface_name] = absm
-						tc.fn_ret_types[mname] = tc.parse_type(f.typ)
+						ret_type := tc.parse_type(f.typ)
 						mut ptypes := []Type{}
 						mut is_variadic := false
 						ptypes << Type(Pointer{
@@ -677,8 +696,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 								ptypes << tc.parse_type(child.typ)
 							}
 						}
-						tc.fn_param_types[mname] = ptypes
-						tc.fn_variadic[mname] = is_variadic
+						tc.register_fn_name_alias(mname, ret_type, ptypes, is_variadic, false)
 					} else if f.typ.len > 0 {
 						mut fields := tc.interface_fields[iface_name] or { []StructField{} }
 						fields << StructField{
@@ -1168,6 +1186,8 @@ fn (tc &TypeChecker) has_active_import(alias string) bool {
 	return file_import_key(tc.cur_file, alias) in tc.file_imports
 }
 
+const receiver_method_suffix_ambiguous = '__v_receiver_method_suffix_ambiguous__'
+
 // register_fn_signature updates register fn signature state for types.
 fn (mut tc TypeChecker) register_fn_signature(name string, ret_type Type, params []Type, is_variadic bool, implicit_veb_ctx bool) {
 	tc.register_fn_name_alias(name, ret_type, params, is_variadic, implicit_veb_ctx)
@@ -1190,6 +1210,32 @@ fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, param
 	tc.fn_param_types[name] = params.clone()
 	tc.fn_variadic[name] = is_variadic
 	tc.fn_implicit_veb_ctx[name] = implicit_veb_ctx
+	tc.add_receiver_method_suffix_index(name)
+}
+
+fn (mut tc TypeChecker) add_receiver_method_suffix_index(name string) {
+	if name.len == 0 {
+		return
+	}
+	tc.set_receiver_method_suffix_index(name, name)
+	for i in 0 .. name.len {
+		if name[i] == `.` && i + 1 < name.len {
+			tc.set_receiver_method_suffix_index(name[i + 1..], name)
+		}
+	}
+}
+
+fn (mut tc TypeChecker) set_receiver_method_suffix_index(key string, name string) {
+	if key.len == 0 {
+		return
+	}
+	if existing := tc.receiver_method_suffix_index[key] {
+		if existing != name {
+			tc.receiver_method_suffix_index[key] = receiver_method_suffix_ambiguous
+		}
+		return
+	}
+	tc.receiver_method_suffix_index[key] = name
 }
 
 fn (mut tc TypeChecker) register_c_variadic_fn(name string) {
@@ -5120,6 +5166,7 @@ fn checker_is_raw_collection_method_name(name string, prefix string) bool {
 }
 
 // is_print_style_fn_name reports whether is print style fn name applies in types.
+// XTODO perf
 fn is_print_style_fn_name(name string) bool {
 	return name in ['print', 'println', 'eprint', 'eprintln', 'builtin.print', 'builtin.println',
 		'builtin.eprint', 'builtin.eprintln']
@@ -5402,13 +5449,15 @@ fn (tc &TypeChecker) parse_fn_signature_type(name string, typ string) Type {
 		tc.file_modules[decl_file] or { tc.cur_module }
 	}
 	scoped.type_cache = &TypeCache{
-		parse_enabled: if tc.type_cache != unsafe { nil } {
+		parse_enabled:        if tc.type_cache != unsafe { nil } {
 			tc.type_cache.parse_enabled
 		} else {
 			false
 		}
-		parse_entries: map[string]Type{}
-		c_entries:     map[string]string{}
+		parse_entries:        map[string]Type{}
+		c_entries:            map[string]string{}
+		struct_field_entries: map[string]Type{}
+		struct_field_misses:  map[string]bool{}
 	}
 	return scoped.parse_type(typ)
 }
@@ -8555,8 +8604,28 @@ fn (tc &TypeChecker) interface_field_type(iface_name string, field_name string) 
 
 // struct_field_type supports struct field type handling for TypeChecker.
 fn (tc &TypeChecker) struct_field_type(struct_name string, field_name string) ?Type {
+	cache_key := '${struct_name}\n${field_name}'
+	if !isnil(tc.type_cache) {
+		if typ := tc.type_cache.struct_field_entries[cache_key] {
+			return typ
+		}
+		if tc.type_cache.struct_field_misses[cache_key] {
+			return none
+		}
+	}
 	mut seen := map[string]bool{}
-	return tc.struct_field_type_inner(struct_name, field_name, mut seen)
+	if typ := tc.struct_field_type_inner(struct_name, field_name, mut seen) {
+		if !isnil(tc.type_cache) {
+			mut cache := tc.type_cache
+			cache.struct_field_entries[cache_key] = typ
+		}
+		return typ
+	}
+	if !isnil(tc.type_cache) {
+		mut cache := tc.type_cache
+		cache.struct_field_misses[cache_key] = true
+	}
+	return none
 }
 
 // struct_field_type_name returns the canonical type name for a struct field.
@@ -10863,16 +10932,14 @@ fn push_receiver_method_candidate(mut names []string, name string) {
 fn (tc &TypeChecker) unique_receiver_method_suffix_match(candidates []string) ?string {
 	mut found := ''
 	for candidate in candidates {
-		suffix := '.${candidate}'
-		for name, _ in tc.fn_ret_types {
-			if name != candidate && !name.ends_with(suffix) {
-				continue
-			}
-			if found.len > 0 && found != name {
-				return none
-			}
-			found = name
+		name := tc.receiver_method_suffix_index[candidate] or { continue }
+		if name == receiver_method_suffix_ambiguous {
+			return none
 		}
+		if found.len > 0 && found != name {
+			return none
+		}
+		found = name
 	}
 	if found.len == 0 {
 		return none
@@ -11186,6 +11253,7 @@ const c_reserved_words = ['auto', 'break', 'case', 'char', 'const', 'continue', 
 	'typedef', 'union', 'unsigned', 'void', 'volatile', 'while']
 
 // c_name converts c name data for types.
+// XTODO garbage. remove this
 fn c_name(name string) string {
 	if name.starts_with('C.') {
 		return name[2..]

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -321,6 +321,8 @@ fn main() {
 	}
 	test_files := test_input_files(user_files, backend)
 
+	seed_implicit_sync_import(mut a)
+
 	// Resolve imports recursively
 	resolve_imports(mut a, mut p, prefs, user_files)
 	diagnostic_root := if is_selfhost {
@@ -935,6 +937,42 @@ fn skipped_backend_modules(prefs &pref.Preferences) []string {
 	return skipped
 }
 
+fn seed_implicit_sync_import(mut a flat.FlatAst) {
+	if !ast_needs_sync_import(a) || ast_has_import(a, 'sync') {
+		return
+	}
+	a.add_node(flat.Node{
+		kind:  .import_decl
+		value: 'sync'
+		typ:   'sync'
+	})
+}
+
+fn ast_needs_sync_import(a &flat.FlatAst) bool {
+	for node in a.nodes {
+		if node.kind == .lock_expr {
+			return true
+		}
+		if node.kind == .field_decl && type_text_is_shared(node.typ) {
+			return true
+		}
+	}
+	return false
+}
+
+fn ast_has_import(a &flat.FlatAst, name string) bool {
+	for node in a.nodes {
+		if node.kind == .import_decl && node.value == name {
+			return true
+		}
+	}
+	return false
+}
+
+fn type_text_is_shared(raw string) bool {
+	return raw.trim_space().starts_with('shared ')
+}
+
 // resolve_imports resolves resolve imports information for v3 entry point.
 fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferences, initial_files []string) {
 	mut parsed_modules := map[string]bool{}
@@ -1019,6 +1057,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 					canonicalize_imported_module_name(mut a, first_node, mod_name)
 				}
 			}
+			seed_implicit_sync_import(mut a)
 		}
 		node_idx++
 	}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -414,9 +414,11 @@ fn main() {
 	}
 
 	// Monomorphization only adds specialized generic instantiations to `used_fns`. The V
-	// compiler sources use no generics, so when building V we skip the pass entirely
-	// (`used_fns` passes through unchanged) instead of scanning the whole AST for nothing.
-	if !building_v {
+	// compiler sources use no generics, so when building V we skip specialization and
+	// only erase generic templates that otherwise generate invalid raw C declarations.
+	if building_v {
+		used_fns = transform.erase_generic_templates(mut a, &pre_tc, used_fns)
+	} else {
 		used_fns = transform.monomorphize_with_used(mut a, &pre_tc, used_fns)
 	}
 	b.step('monomorphize')


### PR DESCRIPTION
## Summary

This PR combines the local V3 work from this checkout to improve V3 compiling V1 (`cmd/v`). It adds faster checker/transform lookup paths, reduces repeated receiver-method suffix scans, caches struct-field and variant lookup work, and includes the accompanying V3 C generation changes from the parallel session.

It also adds a V3 headerless wchar codegen regression test.

## Performance

Final local c-only sample:

```text
/tmp/v3_perf_final -o /tmp/v3_v1.c ../../cmd/v

parse                   69.63 ms
check                  176.26 ms
markused               126.55 ms
transform              423.90 ms
annotate types         104.21 ms
monomorphize            86.33 ms
cgen                   468.78 ms
total                 1455.78 ms
```

The stages through `monomorphize` total about 987 ms in that sample.

## Validation

Passed:

```text
./vnew fmt -w <19 touched V files>
git diff --cached --check
./vnew -silent vlib/v3/tests/headerless_wchar_codegen_test.v
./vnew -silent vlib/v3/tests/type_checker_errors_test.v
./vnew -silent vlib/v3/tests/review_checker_regressions_test.v
./vnew -silent vlib/v3/tests/review_transform_regressions_test.v
./vnew -silent vlib/v3/tests/generics_test.v
/tmp/v3_perf_final -o /tmp/v3_v1.c ../../cmd/v
```

Still failing locally on macOS with existing/headerless include expectations:

```text
./vnew -silent vlib/v3/tests/prod_flag_test.v
./vnew -silent vlib/v3/tests/c_directive_order_codegen_test.v
./vnew -silent vlib/v3/tests/posix_wait_header_codegen_test.v
```

The failures are centered on generated `#include <mach-o/dyld.h>` / related macOS header behavior and one `sockaddr_un` redefinition in the POSIX wait header test.