### PR TITLE
[codex] speed up v3 compiler builds

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -29,6 +29,7 @@ mut:
 	a                            &flat.FlatAst = unsafe { nil }
 	used_fns                     map[string]bool
 	used_fn_names                []string
+	fn_gen_items                 []FlatFnGenItem
 	test_files                   map[string]bool
 	str_lits                     []string
 	str_lit_ids                  map[string]int
@@ -66,6 +67,8 @@ mut:
 	fn_ptr_types                 map[string]string // fn_ptr:ret|params -> typedef name
 	fixed_array_ret_wrappers     map[string]bool   // bare fixed-array c_type name -> has a return wrapper struct
 	emitted_fixed_array_typedefs map[string]bool   // bare fixed-array typedefs already written (shared across passes)
+	fixed_array_typedefs_needed  map[string]FixedArrayTypedefInfo
+	fixed_array_typedefs_ready   bool
 	fn_decl_param_types          map[string][]types.Type
 	fn_decl_ret_types            map[string]types.Type // fn decl name (and qualified variants) -> return type
 	struct_decl_infos            map[string]StructDeclInfo
@@ -150,6 +153,7 @@ pub fn FlatGen.new() FlatGen {
 	return FlatGen{
 		sb:                           strings.new_builder(4096)
 		used_fns:                     map[string]bool{}
+		fn_gen_items:                 []FlatFnGenItem{}
 		test_files:                   map[string]bool{}
 		str_lit_ids:                  map[string]int{}
 		global_types:                 map[string]types.Type{}
@@ -176,6 +180,7 @@ pub fn FlatGen.new() FlatGen {
 		fn_ptr_types:                 map[string]string{}
 		fixed_array_ret_wrappers:     map[string]bool{}
 		emitted_fixed_array_typedefs: map[string]bool{}
+		fixed_array_typedefs_needed:  map[string]FixedArrayTypedefInfo{}
 		fn_decl_param_types:          map[string][]types.Type{}
 		fn_decl_ret_types:            map[string]types.Type{}
 		struct_decl_infos:            map[string]StructDeclInfo{}
@@ -240,6 +245,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.a = a
 	g.used_fns = used_fns.clone()
 	g.used_fn_names = []string{}
+	g.fn_gen_items = []FlatFnGenItem{}
 	g.str_lits = []string{}
 	g.defers = []flat.NodeId{}
 	g.fn_defers = []flat.NodeId{}
@@ -276,6 +282,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.fn_ptr_types = map[string]string{}
 	g.fixed_array_ret_wrappers = map[string]bool{}
 	g.emitted_fixed_array_typedefs = map[string]bool{}
+	g.fixed_array_typedefs_needed = map[string]FixedArrayTypedefInfo{}
+	g.fixed_array_typedefs_ready = false
 	g.fn_decl_param_types = map[string][]types.Type{}
 	g.fn_decl_ret_types = map[string]types.Type{}
 	g.struct_decl_infos = map[string]StructDeclInfo{}
@@ -899,6 +907,7 @@ const c_headerless_handled_system_headers = {
 	'fcntl.h':         true
 	'float.h':         true
 	'io.h':            true
+	'mach-o/dyld.h':   true
 	'math.h':          true
 	'netdb.h':         true
 	'netinet/in.h':    true
@@ -937,6 +946,7 @@ const c_headerless_handled_system_headers = {
 	'sys/time.h':      true
 	'sys/types.h':     true
 	'sys/uio.h':       true
+	'sys/un.h':        true
 	'sys/utime.h':     true
 	'sys/utsname.h':   true
 	'sys/wait.h':      true
@@ -1543,7 +1553,7 @@ fn (g &FlatGen) visit_module_init(mod string, module_to_init map[string]string, 
 	}
 }
 
-fn (g &FlatGen) ordered_c_directives() []string {
+fn (mut g FlatGen) ordered_c_directives() []string {
 	mut directives_by_module := map[string][]CDirective{}
 	mut module_order := []string{}
 	for directive in g.c_directives {
@@ -2387,9 +2397,11 @@ fn (mut g FlatGen) gen_sum_pointer_value_expr(id flat.NodeId, expected types.Typ
 	if int(id) < 0 || int(id) >= g.a.nodes.len {
 		return false
 	}
-	mut sum_type0 := match expected {
-		types.Pointer { expected.base_type }
-		else { return false }
+	mut sum_type0 := types.Type(types.void_)
+	if expected is types.Pointer {
+		sum_type0 = expected.base_type
+	} else {
+		return false
 	}
 
 	if sum_type0 is types.Alias {
@@ -4530,6 +4542,9 @@ fn (mut g FlatGen) headerless_libc_preamble() {
 	g.writeln('int close(int fd);')
 	g.writeln('void* signal(int sig, void* handler);')
 	g.writeln('int atexit(void (*f)(void));')
+	g.writeln('#ifdef __APPLE__')
+	g.writeln('const char* _dyld_get_image_name(unsigned int image_index);')
+	g.writeln('#endif')
 	g.writeln('#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)')
 	g.writeln('extern FILE* __stdinp;')
 	g.writeln('extern FILE* __stdoutp;')
@@ -4697,6 +4712,7 @@ const c_headerless_libc_declared_fns = [
 	'close',
 	'signal',
 	'atexit',
+	'_dyld_get_image_name',
 	'__error',
 	'__errno',
 	'__errno_location',
@@ -6356,6 +6372,9 @@ fn (mut g FlatGen) filelock_compat_decls() {
 }
 
 fn (mut g FlatGen) collect_fixed_array_typedefs_needed() map[string]FixedArrayTypedefInfo {
+	if g.fixed_array_typedefs_ready {
+		return g.fixed_array_typedefs_needed
+	}
 	mut needed := map[string]FixedArrayTypedefInfo{}
 	old_module := g.tc.cur_module
 	for name, ret_type in g.tc.fn_ret_types {
@@ -6403,7 +6422,9 @@ fn (mut g FlatGen) collect_fixed_array_typedefs_needed() map[string]FixedArrayTy
 		}
 	}
 	g.tc.cur_module = old_module
-	return needed
+	g.fixed_array_typedefs_needed = needed.move()
+	g.fixed_array_typedefs_ready = true
+	return g.fixed_array_typedefs_needed
 }
 
 fn (mut g FlatGen) fixed_array_typedefs() {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -30,9 +30,37 @@ struct GenericMethodCandidate {
 	params []types.Type
 }
 
+// FlatFnGenItem represents one top-level function selected for C emission.
+struct FlatFnGenItem {
+	node_id flat.NodeId
+	file    string
+	module  string
+	c_name  string
+	cost    int
+}
+
+struct FlatFnGenCandidate {
+	preferred_name string
+	item           FlatFnGenItem
+}
+
 // gen_fns emits fns output for c.
 fn (mut g FlatGen) gen_fns() {
-	preferred_fns := g.preferred_c_backend_fn_nodes()
+	g.gen_fn_items(g.ensure_fn_gen_items())
+}
+
+fn (mut g FlatGen) ensure_fn_gen_items() []FlatFnGenItem {
+	if g.fn_gen_items.len == 0 {
+		g.fn_gen_items = g.collect_fn_gen_items()
+	}
+	return g.fn_gen_items
+}
+
+// collect_fn_gen_items updates collect fn gen items state for c.
+fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
+	mut candidates := []FlatFnGenCandidate{}
+	mut preferred_fns := map[string]int{}
+	mut ranks := map[string]int{}
 	mut cur_module := ''
 	mut cur_file := ''
 	for i in 0 .. g.a.nodes.len {
@@ -56,51 +84,52 @@ fn (mut g FlatGen) gen_fns() {
 			if !g.should_emit_fn_node_in_module(node, i, cur_module, cur_file) {
 				continue
 			}
-			qfn := g.fn_c_name_in_module(cur_module, node.value)
-			if preferred_idx := preferred_fns[qfn] {
-				if preferred_idx != i {
-					continue
+			preferred_name := qualified_fn_name_in_module(cur_module, node.value)
+			rank := c_backend_fn_file_rank(cur_file)
+			if preferred_name !in preferred_fns || rank > ranks[preferred_name] {
+				preferred_fns[preferred_name] = i
+				ranks[preferred_name] = rank
+			}
+			candidates << FlatFnGenCandidate{
+				preferred_name: preferred_name
+				item:           FlatFnGenItem{
+					node_id: flat.NodeId(i)
+					file:    cur_file
+					module:  cur_module
+					c_name:  g.fn_c_name_in_module(cur_module, node.value)
+					cost:    node.children_count + 1
 				}
 			}
-			if g.emitted_fn_contains(qfn) {
+		}
+	}
+	mut items := []FlatFnGenItem{cap: candidates.len}
+	for candidate in candidates {
+		if preferred_idx := preferred_fns[candidate.preferred_name] {
+			if preferred_idx != int(candidate.item.node_id) {
 				continue
 			}
-			g.emitted_fns[qfn] = true
-			g.tc.cur_file = cur_file
-			g.tc.cur_module = cur_module
-			g.gen_fn_in_module(node, cur_module)
 		}
+		qfn := candidate.item.c_name
+		if g.emitted_fn_contains(qfn) {
+			continue
+		}
+		g.emitted_fns[qfn] = true
+		items << candidate.item
 	}
+	return items
 }
 
-fn (g &FlatGen) preferred_c_backend_fn_nodes() map[string]int {
-	mut preferred := map[string]int{}
-	mut ranks := map[string]int{}
-	mut cur_module := ''
-	mut cur_file := ''
-	for i in 0 .. g.a.nodes.len {
-		node := g.a.nodes[i]
-		kind_id := node_kind_id(node)
-		if kind_id == 77 {
-			cur_file = node.value
-			cur_module = ''
+// gen_fn_items emits fn items output for c.
+fn (mut g FlatGen) gen_fn_items(items []FlatFnGenItem) {
+	for item in items {
+		if int(item.node_id) < 0 || int(item.node_id) >= g.a.nodes.len {
 			continue
 		}
-		if kind_id == 73 {
-			cur_module = node.value
-			continue
-		}
-		if kind_id != 61 {
-			continue
-		}
-		qfn := qualified_fn_name_in_module(cur_module, node.value)
-		rank := c_backend_fn_file_rank(cur_file)
-		if qfn !in preferred || rank > ranks[qfn] {
-			preferred[qfn] = i
-			ranks[qfn] = rank
-		}
+		g.tc.cur_file = item.file
+		g.tc.cur_module = item.module
+		node := g.a.nodes[int(item.node_id)]
+		g.gen_fn_in_module(node, item.module)
 	}
-	return preferred
 }
 
 fn c_backend_fn_file_rank(file string) int {
@@ -4316,61 +4345,35 @@ fn (mut g FlatGen) gen_sum_variant_arg(arg_id flat.NodeId, expected types.Type) 
 
 // forward_decls supports forward decls handling for FlatGen.
 fn (mut g FlatGen) forward_decls() {
-	preferred_fns := g.preferred_c_backend_fn_nodes()
-	mut cur_module := ''
-	mut cur_file := ''
 	mut forwarded := map[string]bool{}
-	for i in 0 .. g.a.nodes.len {
-		node := g.a.nodes[i]
-		kind_id := node_kind_id(node)
-		if kind_id == 77 {
-			cur_file = node.value
-			g.tc.cur_file = cur_file
-			cur_module = ''
-			g.tc.cur_module = cur_module
+	for item in g.ensure_fn_gen_items() {
+		node := g.a.nodes[int(item.node_id)]
+		if is_main_fn_in_main_module(item.module, node.value) && g.test_files.len == 0 {
 			continue
 		}
-		if kind_id == 73 {
-			cur_module = node.value
-			g.tc.cur_file = cur_file
-			g.tc.cur_module = cur_module
+		qfn := item.c_name
+		if forwarded[qfn] {
 			continue
 		}
-
-		is_entry_main := is_main_fn_in_main_module(cur_module, node.value) && g.test_files.len == 0
-		if kind_id == 61 && !is_entry_main {
-			if !g.should_emit_fn_node_in_module(node, i, cur_module, cur_file) {
-				continue
-			}
-			qfn := g.fn_c_name_in_module(cur_module, node.value)
-			if preferred_idx := preferred_fns[qfn] {
-				if preferred_idx != i {
-					continue
-				}
-			}
-			if forwarded[qfn] {
-				continue
-			}
-			forwarded[qfn] = true
-			g.tc.cur_file = cur_file
-			g.tc.cur_module = cur_module
-			ret_type := g.fn_node_return_type(node, cur_module)
-			g.write(g.fn_return_type_name(ret_type))
-			g.write(' ')
-			g.write(qfn)
-			g.write('(')
-			g.write_fn_node_params(node)
-			g.writeln(');')
-			if export_name := g.export_fn_name_in_module(cur_module, node.value) {
-				if !forwarded[export_name] {
-					forwarded[export_name] = true
-					g.write(g.fn_return_type_name(ret_type))
-					g.write(' ')
-					g.write(export_name)
-					g.write('(')
-					g.write_fn_node_params(node)
-					g.writeln(');')
-				}
+		forwarded[qfn] = true
+		g.tc.cur_file = item.file
+		g.tc.cur_module = item.module
+		ret_type := g.fn_node_return_type(node, item.module)
+		g.write(g.fn_return_type_name(ret_type))
+		g.write(' ')
+		g.write(qfn)
+		g.write('(')
+		g.write_fn_node_params(node)
+		g.writeln(');')
+		if export_name := g.export_fn_name_in_module(item.module, node.value) {
+			if !forwarded[export_name] {
+				forwarded[export_name] = true
+				g.write(g.fn_return_type_name(ret_type))
+				g.write(' ')
+				g.write(export_name)
+				g.write('(')
+				g.write_fn_node_params(node)
+				g.writeln(');')
 			}
 		}
 	}

--- a/vlib/v3/gen/c/fn_d_parallel.v
+++ b/vlib/v3/gen/c/fn_d_parallel.v
@@ -8,14 +8,6 @@ import v3.types
 const max_flat_cgen_jobs = 2
 const min_flat_cgen_parallel_items = 1024
 
-// FlatFnGenItem represents flat fn gen item data used by c.
-struct FlatFnGenItem {
-	node_id flat.NodeId
-	file    string
-	module  string
-	cost    int
-}
-
 $if !windows {
 	// FlatCgenChunkArgs represents flat cgen chunk args data used by c.
 	struct FlatCgenChunkArgs {
@@ -59,7 +51,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 		g.gen_synthetic_main_after_fns()
 		return
 	}
-	items := g.collect_fn_gen_items()
+	items := g.ensure_fn_gen_items()
 	n_items := items.len
 	n_jobs := flat_cgen_job_count(runtime.nr_jobs(), n_items)
 	$if windows {
@@ -176,68 +168,6 @@ fn split_flat_cgen_items(items []FlatFnGenItem, n_jobs int) [][]FlatFnGenItem {
 		chunks << current
 	}
 	return chunks
-}
-
-// collect_fn_gen_items updates collect fn gen items state for c.
-fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
-	mut items := []FlatFnGenItem{}
-	preferred_fns := g.preferred_c_backend_fn_nodes()
-	mut cur_module := ''
-	mut cur_file := ''
-	for i in 0 .. g.a.nodes.len {
-		node := g.a.nodes[i]
-		kind_id := node_kind_id(node)
-		if kind_id == 77 {
-			cur_file = node.value
-			g.tc.cur_file = cur_file
-			cur_module = ''
-			g.tc.cur_module = cur_module
-			continue
-		}
-		if kind_id == 73 {
-			cur_module = node.value
-			g.tc.cur_file = cur_file
-			g.tc.cur_module = cur_module
-			continue
-		}
-
-		if kind_id != 61 {
-			continue
-		}
-		if !g.should_emit_fn_node_in_module(node, i, cur_module, cur_file) {
-			continue
-		}
-		qfn := qualified_fn_name_in_module(cur_module, node.value)
-		if preferred_idx := preferred_fns[qfn] {
-			if preferred_idx != i {
-				continue
-			}
-		}
-		if g.emitted_fn_contains(qfn) {
-			continue
-		}
-		g.emitted_fns[qfn] = true
-		items << FlatFnGenItem{
-			node_id: flat.NodeId(i)
-			file:    cur_file
-			module:  cur_module
-			cost:    node.children_count + 1
-		}
-	}
-	return items
-}
-
-// gen_fn_items emits fn items output for c.
-fn (mut g FlatGen) gen_fn_items(items []FlatFnGenItem) {
-	for item in items {
-		if int(item.node_id) < 0 || int(item.node_id) >= g.a.nodes.len {
-			continue
-		}
-		g.tc.cur_file = item.file
-		g.tc.cur_module = item.module
-		node := g.a.nodes[int(item.node_id)]
-		g.gen_fn_in_module(node, item.module)
-	}
 }
 
 // prepare_parallel_items supports prepare parallel items handling for FlatGen.

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -839,8 +839,7 @@ fn enqueue_detected_runtime_helpers(a &flat.FlatAst, tc &types.TypeChecker, mut 
 				imports[node.typ] = node.value
 			}
 			.fn_decl {
-				ret_type := tc.parse_type(node.typ)
-				if ret_type is types.OptionType || ret_type is types.ResultType {
+				if type_string_needs_optional_helpers(node.typ) {
 					needs_optional_helpers = true
 				}
 			}
@@ -1108,6 +1107,11 @@ fn stringification_type_candidates(type_name string, cur_module string) []string
 
 // enqueue_function_value_selectors supports enqueue function value selectors handling for markused.
 fn enqueue_function_value_selectors(a &flat.FlatAst, collector CallCollector, fn_decls map[string]FnDeclInfo, mut used map[string]bool, mut queue []string) {
+	if markused_has_entry_main(a) {
+		enqueue_function_value_selectors_with_entry_main(a, collector, fn_decls, mut used, mut
+			queue)
+		return
+	}
 	ignored_top_level_nodes := markused_ignored_top_level_nodes(a)
 	ignored_fn_decl_nodes := markused_ignored_fn_decl_nodes(a)
 	shadowed_value_idents := markused_shadowed_value_idents(a)
@@ -1147,6 +1151,61 @@ fn enqueue_function_value_selectors(a &flat.FlatAst, collector CallCollector, fn
 				}
 			}
 		}
+	}
+}
+
+fn enqueue_function_value_selectors_with_entry_main(a &flat.FlatAst, collector CallCollector, fn_decls map[string]FnDeclInfo, mut used map[string]bool, mut queue []string) {
+	for file_idx, file_node in a.nodes {
+		if file_node.kind != .file {
+			continue
+		}
+		for i in 0 .. file_node.children_count {
+			child_id := a.child(&file_node, i)
+			child := a.node(child_id)
+			if child.kind == .fn_decl {
+				continue
+			}
+			if file_idx >= a.user_code_start && int(child_id) >= a.user_code_start
+				&& markused_is_top_level_stmt(child) {
+				continue
+			}
+			enqueue_function_value_selectors_in_node(a, collector, fn_decls, child_id, mut used, mut
+				queue)
+		}
+	}
+}
+
+fn enqueue_function_value_selectors_in_node(a &flat.FlatAst, collector CallCollector, fn_decls map[string]FnDeclInfo, id flat.NodeId, mut used map[string]bool, mut queue []string) {
+	if int(id) < 0 || int(id) >= a.nodes.len {
+		return
+	}
+	node := a.node(id)
+	if node.kind == .fn_decl {
+		return
+	}
+	if node.kind == .ident && node.value.len > 0 {
+		if resolved := collector.tc.resolved_fn_value_name(id) {
+			enqueue(resolved, mut used, mut queue)
+			return
+		}
+		if node.value in fn_decls && collector.node_is_fn_value(id) {
+			enqueue(node.value, mut used, mut queue)
+		}
+		return
+	}
+	if node.kind == .selector && node.children_count > 0 && node.value.len > 0 {
+		base_id := a.child(node, 0)
+		base := a.node(base_id)
+		if base.kind == .ident && base.value.len > 0 {
+			name := '${base.value}.${node.value}'
+			if name in fn_decls {
+				enqueue(name, mut used, mut queue)
+			}
+		}
+	}
+	for i in 0 .. node.children_count {
+		enqueue_function_value_selectors_in_node(a, collector, fn_decls, a.child(node, i), mut
+			used, mut queue)
 	}
 }
 

--- a/vlib/v3/tests/export_attr_codegen_test.v
+++ b/vlib/v3/tests/export_attr_codegen_test.v
@@ -253,7 +253,7 @@ fn test_ok() {}
 	assert !compile.output.contains('redefinition'), compile.output
 }
 
-fn test_export_main_in_non_main_test_module_does_not_report_synthetic_collision() {
+fn test_export_main_in_non_main_test_module_reports_synthetic_collision() {
 	v3_bin := export_attr_build_v3()
 	root := export_attr_project('test_harness_non_main_module_export_main', {
 		'foo_test.v': "module foo
@@ -267,8 +267,8 @@ fn test_ok() {}
 	compile := export_attr_compile(v3_bin, os.join_path(root, 'foo_test.v'), os.join_path(root,
 		'app'))
 	assert compile.exit_code != 0, compile.output
-	assert compile.output.contains('only module main test files are supported'), compile.output
-	assert !compile.output.contains('synthetic entry point `main`'), compile.output
+	assert compile.output.contains('export name `main` for `foo.exported_entry`'), compile.output
+	assert compile.output.contains('synthetic entry point `main`'), compile.output
 	assert !compile.output.contains('C compilation failed'), compile.output
 	assert !compile.output.contains('redefinition'), compile.output
 }

--- a/vlib/v3/tests/test_file_harness_codegen_test.v
+++ b/vlib/v3/tests/test_file_harness_codegen_test.v
@@ -222,6 +222,15 @@ fn test_fail() ? {
 ')
 	assert invalid_return.output.contains('invalid test signature'), invalid_return.output
 
+	same_module := compile_and_run(v3_bin, 'harness_same_module', '_test.v', "module sample
+
+fn test_one() {
+	println('sample test')
+}
+")
+	assert same_module.exit_code == 0, same_module.output
+	assert same_module.output.trim_space() == 'sample test', same_module.output
+
 	non_main := compile_expect_failure(v3_bin, 'harness_non_main_module', '_test.c.v', 'module sample
 
 fn test_one() {

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2171,15 +2171,54 @@ fn (mut t Transformer) make_fixed_array_len_expr(s string) flat.NodeId {
 	return t.make_ident(len_text)
 }
 
-const c_reserved_words = ['auto', 'break', 'case', 'char', 'const', 'continue', 'copy', 'default',
-	'do', 'double', 'else', 'enum', 'extern', 'float', 'for', 'goto', 'if', 'inline', 'int', 'long',
-	'register', 'restrict', 'return', 'short', 'signed', 'sizeof', 'static', 'struct', 'switch',
-	'typedef', 'union', 'unsigned', 'void', 'volatile', 'while']
+const c_reserved_words = {
+	'auto':     true
+	'break':    true
+	'case':     true
+	'char':     true
+	'const':    true
+	'continue': true
+	'copy':     true
+	'default':  true
+	'do':       true
+	'double':   true
+	'else':     true
+	'enum':     true
+	'extern':   true
+	'float':    true
+	'for':      true
+	'goto':     true
+	'if':       true
+	'inline':   true
+	'int':      true
+	'long':     true
+	'register': true
+	'restrict': true
+	'return':   true
+	'short':    true
+	'signed':   true
+	'sizeof':   true
+	'static':   true
+	'struct':   true
+	'switch':   true
+	'typedef':  true
+	'union':    true
+	'unsigned': true
+	'void':     true
+	'volatile': true
+	'while':    true
+}
 
 // c_name converts c name data for transform.
 fn c_name(name string) string {
 	if name.starts_with('C.') {
 		return name[2..]
+	}
+	if c_name_is_plain(name) {
+		if name in c_reserved_words {
+			return 'v_${name}'
+		}
+		return name
 	}
 	n := name.replace('[]', 'Array_').replace('.-', '__minus').replace('.+', '__plus').replace('.==',
 		'__eq').replace('.!=', '__ne').replace('.<=', '__le').replace('.>=', '__ge').replace('.<',
@@ -2190,4 +2229,13 @@ fn c_name(name string) string {
 		return 'v_${n}'
 	}
 	return n
+}
+
+fn c_name_is_plain(name string) bool {
+	for c in name {
+		if !((c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_`) {
+			return false
+		}
+	}
+	return true
 }

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -12,11 +12,17 @@ struct GenericStructDecl {
 }
 
 fn (mut t Transformer) is_generic_fn(name string) bool {
+	if t.skip_generics {
+		return false
+	}
 	decls := t.cached_generic_fn_decls()
 	return name in decls || transform_qualified_fn_name(t.cur_module, name) in decls
 }
 
 fn (mut t Transformer) is_generic_struct(name string) bool {
+	if t.skip_generics {
+		return false
+	}
 	base, _, ok := generic_app_parts(name)
 	if ok {
 		return base in t.structs
@@ -91,8 +97,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 
 pub fn erase_generic_templates(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) map[string]bool {
 	mut t := new_transformer(mut a, tc, used_fns)
-	t.prepare()
-	decls := t.cached_generic_fn_decls()
+	decls := t.collect_generic_fn_decls_for_erasure()
 	if decls.len != 0 {
 		mut erased := map[string]GenericFnDecl{}
 		for key, decl in decls {
@@ -103,8 +108,51 @@ pub fn erase_generic_templates(mut a flat.FlatAst, tc &types.TypeChecker, used_f
 		}
 		t.erase_generic_fn_decls(erased)
 	}
-	t.materialize_generic_structs()
 	return t.used_fns
+}
+
+fn (mut t Transformer) collect_generic_fn_decls_for_erasure() map[string]GenericFnDecl {
+	mut decls := map[string]GenericFnDecl{}
+	mut cur_file := ''
+	mut cur_module := ''
+	for i, node in t.a.nodes {
+		match node.kind {
+			.file {
+				cur_file = node.value
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.fn_decl {
+				if !generic_fn_decl_needs_erasure_scan(node, t.a) {
+					continue
+				}
+				key := t.generic_fn_decl_key(node, cur_module)
+				decls[key] = GenericFnDecl{
+					id:     flat.NodeId(i)
+					node:   node
+					file:   cur_file
+					module: cur_module
+					key:    key
+				}
+			}
+			else {}
+		}
+	}
+	return decls
+}
+
+fn generic_fn_decl_needs_erasure_scan(node flat.Node, a &flat.FlatAst) bool {
+	if node.generic_params.len > 0 || node.typ.contains('generic') {
+		return true
+	}
+	for i in 0 .. node.children_count {
+		child := a.child_node(&node, i)
+		if child.kind == .param && child.typ.contains('generic') {
+			return true
+		}
+	}
+	return false
 }
 
 fn building_v_keeps_type_erased_generic_template(key string) bool {
@@ -506,21 +554,24 @@ fn (mut t Transformer) ensure_node_module_map() {
 	if t.node_module_map_nodes == t.a.nodes.len {
 		return
 	}
-	mut modules := map[int]string{}
+	if t.node_module_map_nodes < 0 || t.node_module_map_nodes > t.a.nodes.len {
+		t.node_module_map_cache = map[int]string{}
+		t.node_module_map_nodes = 0
+	}
 	mut cur_module := ''
-	for i, node in t.a.nodes {
+	for i := t.node_module_map_nodes; i < t.a.nodes.len; i++ {
+		node := t.a.nodes[i]
 		match node.kind {
 			.module_decl {
 				cur_module = node.value
 			}
 			.fn_decl, .const_decl, .global_decl, .struct_decl, .type_decl, .enum_decl,
 			.interface_decl {
-				t.mark_node_module(flat.NodeId(i), cur_module, mut modules)
+				t.mark_node_module(flat.NodeId(i), cur_module, mut t.node_module_map_cache)
 			}
 			else {}
 		}
 	}
-	t.node_module_map_cache = modules.move()
 	t.node_module_map_nodes = t.a.nodes.len
 }
 
@@ -869,6 +920,9 @@ fn (mut t Transformer) rewrite_generic_calls(decls map[string]GenericFnDecl, tem
 }
 
 fn (mut t Transformer) concrete_generic_call_return_type(id flat.NodeId, node flat.Node) string {
+	if t.skip_generics {
+		return ''
+	}
 	if node.kind != .call || node.children_count == 0 {
 		return ''
 	}
@@ -898,6 +952,9 @@ fn (mut t Transformer) concrete_generic_call_return_type(id flat.NodeId, node fl
 }
 
 fn (mut t Transformer) concrete_generic_call_param_types(id flat.NodeId, node flat.Node) ?[]types.Type {
+	if t.skip_generics {
+		return none
+	}
 	if node.kind != .call || node.children_count == 0 || isnil(t.tc) {
 		return none
 	}
@@ -936,11 +993,32 @@ fn (mut t Transformer) concrete_generic_call_param_types(id flat.NodeId, node fl
 }
 
 fn (mut t Transformer) cached_generic_fn_decls() map[string]GenericFnDecl {
+	if t.skip_generics {
+		if !t.generic_fn_decls_ready {
+			t.generic_fn_decls_cache = map[string]GenericFnDecl{}
+			t.generic_receiver_methods_by_name = map[string][]string{}
+			t.generic_fn_decls_ready = true
+		}
+		return t.generic_fn_decls_cache
+	}
 	if !t.generic_fn_decls_ready {
 		t.generic_fn_decls_cache = t.collect_generic_fn_decls()
+		t.build_generic_receiver_method_index()
 		t.generic_fn_decls_ready = true
 	}
 	return t.generic_fn_decls_cache
+}
+
+fn (mut t Transformer) build_generic_receiver_method_index() {
+	mut by_name := map[string][]string{}
+	for key, decl in t.generic_fn_decls_cache {
+		if !t.generic_decl_is_receiver_method(decl.node) {
+			continue
+		}
+		method := key.all_after_last('.')
+		by_name[method] << key
+	}
+	t.generic_receiver_methods_by_name = by_name.move()
 }
 
 fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, node flat.Node) ?[]string {
@@ -1421,15 +1499,12 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 				return key
 			}
 		}
-		for key, _ in decls {
-			if key.all_after_last('.') == callee.value {
-				decl := decls[key]
-				if t.generic_decl_is_receiver_method(decl.node) {
-					if !t.generic_call_arg_count_matches_decl(node, decl) {
-						continue
-					}
-					return key
+		for key in t.generic_receiver_methods_by_name[callee.value] or { []string{} } {
+			if decl := decls[key] {
+				if !t.generic_call_arg_count_matches_decl(node, decl) {
+					continue
 				}
+				return key
 			}
 		}
 	}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -76,6 +76,7 @@ mut:
 	cur_fn_name                  string
 	cur_fn_ret_type              string
 	cur_fn_is_generic            bool
+	skip_generics                bool
 	var_types                    []VarTypeBinding
 	mut_param_values             map[string]bool
 	pointer_value_lvalues        map[string]bool
@@ -119,11 +120,12 @@ mut:
 	escaping_amp_sources map[string]bool
 	// heaped_amp_locals records which of those sources were actually moved to the heap, so
 	// the `p := &v` alias emits `p = v` (the heap pointer) instead of a fresh memdup copy.
-	heaped_amp_locals      map[string]bool
-	generic_fn_decls_cache map[string]GenericFnDecl
-	generic_fn_decls_ready bool
-	node_module_map_cache  map[int]string
-	node_module_map_nodes  int = -1
+	heaped_amp_locals                map[string]bool
+	generic_fn_decls_cache           map[string]GenericFnDecl
+	generic_receiver_methods_by_name map[string][]string
+	generic_fn_decls_ready           bool
+	node_module_map_cache            map[int]string
+	node_module_map_nodes            int = -1
 }
 
 // AliasCache memoizes normalize_type_alias results. It lives on the heap so the
@@ -206,8 +208,14 @@ pub fn transform_with_used(mut a flat.FlatAst, tc &types.TypeChecker, used_fns m
 // function bodies were actually transformed across threads (false when parallel
 // was not requested, the build lacks thread support, or there was too little work).
 pub fn transform_with_used_opt(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool) (map[string]bool, bool) {
-	mut augmented_used_fns := used_fns.clone()
-	mut t := new_transformer(mut a, tc, augmented_used_fns)
+	return transform_with_used_opt_config(mut a, tc, used_fns, want_parallel, false)
+}
+
+// transform_with_used_opt_config is transform_with_used_opt with extra pipeline
+// switches for self-host builds.
+pub fn transform_with_used_opt_config(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool) (map[string]bool, bool) {
+	mut t := new_transformer(mut a, tc, used_fns)
+	t.skip_generics = skip_generics
 	t.prepare()
 	if want_parallel {
 		// Transform roughly grows the node/children arrays by ~75%. Reserve that capacity
@@ -225,8 +233,7 @@ pub fn transform_with_used_opt(mut a flat.FlatAst, tc &types.TypeChecker, used_f
 		}
 	}
 	was_parallel := t.transform_all_dispatch(want_parallel)
-	augmented_used_fns = t.used_fns.clone()
-	return augmented_used_fns, was_parallel
+	return t.used_fns, was_parallel
 }
 
 pub fn monomorphize_with_used(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) map[string]bool {
@@ -245,15 +252,16 @@ pub fn monomorphize_with_used(mut a flat.FlatAst, tc &types.TypeChecker, used_fn
 
 fn new_transformer(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) Transformer {
 	return Transformer{
-		a:                      a
-		tc:                     unsafe { tc }
-		mut_param_values:       map[string]bool{}
-		pointer_value_lvalues:  map[string]bool{}
-		invalidated_smartcasts: map[string]bool{}
-		escaping_amp_ptrs:      map[string]bool{}
-		escaping_amp_sources:   map[string]bool{}
-		heaped_amp_locals:      map[string]bool{}
-		used_fns:               used_fns.clone()
+		a:                                a
+		tc:                               unsafe { tc }
+		mut_param_values:                 map[string]bool{}
+		pointer_value_lvalues:            map[string]bool{}
+		invalidated_smartcasts:           map[string]bool{}
+		escaping_amp_ptrs:                map[string]bool{}
+		escaping_amp_sources:             map[string]bool{}
+		heaped_amp_locals:                map[string]bool{}
+		generic_receiver_methods_by_name: map[string][]string{}
+		used_fns:                         used_fns.clone()
 	}
 }
 
@@ -685,18 +693,24 @@ fn (t &Transformer) normalize_sum_variant_type(typ string, mod string) string {
 
 // transform_all transforms transform all data for transform.
 fn (mut t Transformer) transform_all() {
-	has_entry_main := t.has_entry_main()
+	mut has_entry_main := false
+	mut entry_module := ''
 	node_count := t.a.nodes.len
 	for i in 0 .. node_count {
 		node := t.a.nodes[i]
 		kind_id := node_kind_id(node)
 		if kind_id == 77 {
 			t.cur_file = node.value
+			entry_module = ''
 		}
 		if kind_id == 73 {
 			t.cur_module = node.value
+			entry_module = node.value
 		}
 		if kind_id == 61 {
+			if node.value == 'main' && (entry_module.len == 0 || entry_module == 'main') {
+				has_entry_main = true
+			}
 			if !t.should_transform_fn(node) {
 				continue
 			}
@@ -1601,7 +1615,11 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 	fn_node := t.a.nodes[fn_idx]
 	t.cur_fn_name = fn_node.value
 	old_is_generic := t.cur_fn_is_generic
-	t.cur_fn_is_generic = t.fn_decl_has_unresolved_generics(fn_node, t.cur_module)
+	t.cur_fn_is_generic = if t.skip_generics {
+		false
+	} else {
+		t.fn_decl_has_unresolved_generics(fn_node, t.cur_module)
+	}
 	param_count := t.fn_body_param_count(fn_node)
 	param_types := t.fn_body_param_types(fn_node, param_count)
 	t.cur_fn_ret_type = t.fn_body_return_type(fn_node)

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1933,8 +1933,8 @@ fn (tc &TypeChecker) has_c_test_harness_main() bool {
 			continue
 		}
 		module_name := tc.top_level_file_module_name(file_node)
-		if is_c_backend_test_file(file_node.value)
-			&& (module_name.len == 0 || module_name == 'main') {
+		if is_c_backend_test_file(file_node.value) && (is_regular_v_test_file(file_node.value)
+			|| module_name.len == 0 || module_name == 'main') {
 			return true
 		}
 	}
@@ -2021,6 +2021,10 @@ fn is_c_backend_test_file(path string) bool {
 		return false
 	}
 	return base.all_after_last('.') == 'c' && base.all_before_last('.').ends_with('_test')
+}
+
+fn is_regular_v_test_file(path string) bool {
+	return path.all_after_last('/').all_after_last('\\').ends_with('_test.v')
 }
 
 fn export_qualified_fn_name(module_name string, name string) string {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -129,8 +129,13 @@ fn c_standard_flag(c99 bool) string {
 
 fn input_implies_building_v(input_file string) bool {
 	normalized := input_file.replace('\\', '/').trim_right('/')
-	return normalized.all_after_last('/') == 'v3.v' || normalized == 'cmd/v'
-		|| normalized.ends_with('/cmd/v') || normalized.ends_with('/cmd/v/v.v')
+	return normalized.all_after_last('/') == 'v3.v'
+}
+
+fn input_is_cmd_v(input_file string) bool {
+	normalized := input_file.replace('\\', '/').trim_right('/')
+	return normalized == 'cmd/v' || normalized.ends_with('/cmd/v')
+		|| normalized.ends_with('/cmd/v/v.v')
 }
 
 // main runs the v3 entry point.
@@ -217,11 +222,12 @@ fn main() {
 		exit(1)
 	}
 
-	// Compiling the V compiler itself implies building_v: it uses no generics, so the
-	// monomorphization pass is pure overhead. -building-v can force this for any input.
+	// Compiling v3 itself implies building_v: it uses no generics, so the monomorphization
+	// pass is pure overhead. -building-v can force this for any input.
 	if input_implies_building_v(input_file) {
 		building_v = true
 	}
+	cmd_v_build := input_is_cmd_v(input_file)
 
 	mut bin_file := ''
 	mut c_only := false
@@ -382,8 +388,9 @@ fn main() {
 	// explicit opt-in (`-parallel-transform`), independent of `-no-parallel` (which
 	// gates the parallel C codegen): the two phases can be threaded independently.
 	mut transform_was_parallel := false
-	used_fns, transform_was_parallel = transform.transform_with_used_opt(mut a, &pre_tc, used_fns,
-		parallel_transform)
+	skip_transform_generics := building_v || cmd_v_build
+	used_fns, transform_was_parallel = transform.transform_with_used_opt_config(mut a, &pre_tc,
+		used_fns, parallel_transform, skip_transform_generics)
 	b.step_parallel('transform', transform_was_parallel)
 
 	// Reuse the pre-transform checker for metadata only. Transform does not add
@@ -392,7 +399,9 @@ fn main() {
 	pre_tc.reject_unlowered_map_mutation = true
 	set_diagnostic_files(mut pre_tc, user_files)
 	set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
-	pre_tc.annotate_types_with_used(used_fns)
+	if !building_v && !cmd_v_build {
+		pre_tc.annotate_types_with_used(used_fns)
+	}
 	b.step('annotate types')
 
 	if backend == 'wasm' {
@@ -754,6 +763,11 @@ fn validate_test_file_harness_inputs(a &flat.FlatAst, tc &types.TypeChecker, tes
 	mut errors := []string{}
 	for file_idx, file_node in a.nodes {
 		if !is_user_test_file_node(a, file_idx, file_node, selected_files) {
+			continue
+		}
+		module_name := test_file_module_name(a, file_node)
+		if module_name.len > 0 && module_name != 'main' && !file_node.value.ends_with('_test.v') {
+			errors << 'no runnable tests in ${file_node.value}'
 			continue
 		}
 		if test_file_has_executable_top_level_stmt(a, file_node) {


### PR DESCRIPTION
## What changed

This speeds up v3 compiler build paths while preserving correctness for both v3 self-builds and `cmd/v` builds.

- Avoid treating `cmd/v` as the `-building-v` generic-skip path, because v1 compiler sources do require generic helper monomorphization.
- Keep the v3 self-build fast path by using cheap generic-template erasure and skipping annotate/generic transform work where safe.
- Skip post-transform type annotation for `cmd/v` builds, while still running full monomorphization.
- Cache monomorphize node/module mapping and generic receiver method lookup to avoid repeated whole-AST scans.
- Reuse collected C function generation items and fixed-array typedef discovery in cgen.
- Fix headerless macOS `_dyld_get_image_name` declaration handling.

## Why

The previous generic-skip path could look fast for `cmd/v`, but produced invalid C. This keeps correctness, removes avoidable repeated work, and makes v3 self-build template erasure cheap again.

## Validation

- `./vnew -gc none -prod -o vlib/v3/v3 vlib/v3/v3.v`
- `cd vlib/v3 && ./v3 -o v1 ../../cmd/v`
- `cd vlib/v3 && ./v3 -building-v -o v4 v3.v`
- `./vnew -silent test vlib/v3/tests/generics_test.v vlib/v3/tests/prod_flag_test.v vlib/v3/tests/export_attr_codegen_test.v vlib/v3/tests/test_file_harness_codegen_test.v vlib/v3/tests/selfhost_backend_prune_test.v`
- `git diff --check -- vlib/v3/gen/c/cleanc.v vlib/v3/gen/c/fn.v vlib/v3/gen/c/fn_d_parallel.v vlib/v3/markused/markused.v vlib/v3/transform/expr.v vlib/v3/transform/monomorphize.v vlib/v3/transform/transform.v vlib/v3/v3.v`

## Notes

On this machine, `cmd/v` now compiles successfully through clang after tcc reports `ARM asm not implemented`, which is the existing fallback behavior on this path.