### PR TITLE
Generic as cast fix

### DIFF
--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -924,7 +924,25 @@ fn (mut g Gen) resolved_scope_var_type_uncached(expr ast.Ident) ast.Type {
 					v.orig_type = refreshed_expr_type
 					v.typ = refreshed_expr_type.clear_option_and_result()
 				} else {
-					v.typ = refreshed_expr_type
+					// When v.generic_typ was resolved to a concrete type (no generic
+					// parts remaining) and the expression-based resolution produces a
+					// different concrete type, prefer the generic_typ result. The
+					// expression AST node's type may be stale if the checker mutated
+					// it to a concrete type from a previous generic specialization.
+					mut overwrite := true
+					if v.generic_typ != 0 && g.cur_concrete_types.len > 0
+						&& refreshed_expr_type != 0 && v.typ != 0 {
+						resolved_from_generic :=
+							g.unwrap_generic(g.recheck_concrete_type(v.generic_typ))
+						if resolved_from_generic != 0
+							&& !g.type_has_unresolved_generic_parts(resolved_from_generic)
+							&& refreshed_expr_type.clear_option_and_result() != resolved_from_generic.clear_option_and_result() {
+							overwrite = false
+						}
+					}
+					if overwrite {
+						v.typ = refreshed_expr_type
+					}
 					if !v.is_unwrapped && v.smartcasts.len == 0 {
 						v.orig_type = ast.no_type
 					}

--- a/vlib/v/tests/generic_as_cast_interface_stale_type_test.v
+++ b/vlib/v/tests/generic_as_cast_interface_stale_type_test.v
@@ -1,0 +1,68 @@
+module main
+
+// Regression test: generic method with `&Interface → as T` cast and
+// multi-return interface conversion. Two concrete types with DIFFERENT
+// struct layouts are used to ensure the C compiler catches any stale-type
+// codegen where the wrong type's interface conversion is emitted.
+
+interface Gettable {
+	get() int
+}
+
+struct TypeA {
+	x int
+	y int
+}
+
+fn (a TypeA) get() int {
+	return a.x + a.y
+}
+
+struct TypeB {
+	msg string
+}
+
+fn (b TypeB) get() int {
+	return b.msg.len
+}
+
+struct Holder {
+	ptr &Gettable
+}
+
+fn (h Holder) inner() &Gettable {
+	return h.ptr
+}
+
+struct Container[T] {
+	src Holder
+}
+
+fn (c Container[T]) extract() (Gettable, &Gettable) {
+	raw_conn := c.src.inner() // &Gettable
+	raw := raw_conn as T // cast &Gettable → concrete T
+	return raw, raw_conn // T returned as Gettable
+}
+
+const _inst_a = Container[TypeA]{
+	src: Holder{&TypeA{1, 2}}
+}
+const _inst_b = Container[TypeB]{
+	src: Holder{&TypeB{'hello'}}
+}
+
+fn test_container_a() {
+	c := Container[TypeA]{
+		src: Holder{&TypeA{10, 20}}
+	}
+	v, _ := c.extract()
+	assert v.get() == 30
+}
+
+fn test_container_b() {
+	c := Container[TypeB]{
+		src: Holder{&TypeB{'hi'}}
+	}
+	v, _ := c.extract()
+	assert v.get() == 2
+}


### PR DESCRIPTION
https://github.com/vlang/v/pull/27610 Merge After Merge

## Summary

Fix stale type in `resolved_scope_var_type_uncached` — when `v.generic_typ` resolves to a different concrete type than the expression AST node, prefer the `generic_typ` result. The expression node may carry a stale type from a previous generic specialization.

### Changes

- **`vlib/v/gen/c/utils.v`**: add `overwrite` guard so `v.typ` is not overwritten by a stale expression type when `generic_typ` provides a different concrete type
- **`generic_as_cast_interface_stale_type_test.v`**: regression test with `&Interface → as T` + multi-return, using two struct types with different layouts
