### PR TITLE
compress: fix deflate leaks and add brotli

### DIFF
--- a/vlib/compress/README.md
+++ b/vlib/compress/README.md
@@ -5,6 +5,7 @@
 At the moment, the following compression algorithms are implemented:
 
 - `compress.bzip2`
+- `compress.brotli`
 - `compress.deflate`
 - `compress.gzip`
 - `compress.lz` supporting the following variations:

--- a/vlib/compress/brotli/README.md
+++ b/vlib/compress/brotli/README.md
@@ -1,0 +1,20 @@
+## Description
+
+`compress.brotli` compresses and decompresses binary data using Brotli.
+
+The module loads the system `libbrotlienc` and `libbrotlidec` shared
+libraries at runtime. Set `V_BROTLI_ENC_LIB` or `V_BROTLI_DEC_LIB` to point to
+custom library locations when they are not in the platform loader path.
+
+## Examples
+
+```v oksyntax
+import compress.brotli
+
+fn main() {
+	uncompressed := 'Hello world!'
+	compressed := brotli.compress(uncompressed.bytes(), mode: .text)!
+	decompressed := brotli.decompress(compressed)!
+	assert decompressed == uncompressed.bytes()
+}
+```

--- a/vlib/compress/brotli/brotli.c.v
+++ b/vlib/compress/brotli/brotli.c.v
@@ -1,0 +1,274 @@
+// Brotli compression/decompression helpers using the system libbrotli runtime.
+module brotli
+
+import os
+
+$if linux {
+	#flag -ldl
+}
+#insert "@VEXEROOT/vlib/compress/brotli/brotli_dl.h"
+
+fn C.v_brotli_open(const_name &char) voidptr
+fn C.v_brotli_sym(handle voidptr, const_name &char) voidptr
+fn C.v_brotli_close(handle voidptr) int
+
+const min_quality = 0
+const max_quality = 11
+const min_lgwin = 10
+const max_lgwin = 24
+const decode_chunk_size = 32 * 1024
+
+const decoder_result_error = 0
+const decoder_result_success = 1
+const decoder_result_needs_more_input = 2
+const decoder_result_needs_more_output = 3
+
+type FNEncoderMaxCompressedSize = fn (usize) usize
+
+type FNEncoderCompress = fn (int, int, int, usize, voidptr, &usize, voidptr) int
+
+type FNDecoderCreateInstance = fn (voidptr, voidptr, voidptr) voidptr
+
+type FNDecoderDestroyInstance = fn (voidptr)
+
+type FNDecoderDecompressStream = fn (voidptr, &usize, &&u8, &usize, &&u8, &usize) int
+
+type FNDecoderGetErrorCode = fn (voidptr) int
+
+type FNDecoderErrorString = fn (int) charptr
+
+// Mode tunes the Brotli encoder for generic, text, or font data.
+pub enum Mode {
+	generic = 0
+	text    = 1
+	font    = 2
+}
+
+// CompressParams controls Brotli compression.
+@[params]
+pub struct CompressParams {
+pub:
+	quality int  = 11
+	lgwin   int  = 22
+	mode    Mode = .generic
+}
+
+// DecompressParams controls Brotli decompression.
+@[params]
+pub struct DecompressParams {}
+
+fn open_library_name(name string) voidptr {
+	return C.v_brotli_open(&char(name.str))
+}
+
+fn open_env_library(env_name string) voidptr {
+	path := os.getenv_opt(env_name) or { return 0 }
+	if path == '' {
+		return 0
+	}
+	return open_library_name(path)
+}
+
+fn open_encoder_library() !voidptr {
+	env_handle := open_env_library('V_BROTLI_ENC_LIB')
+	if env_handle != 0 {
+		return env_handle
+	}
+	$if windows {
+		for name in ['brotlienc.dll', 'libbrotlienc.dll'] {
+			handle := open_library_name(name)
+			if handle != 0 {
+				return handle
+			}
+		}
+	} $else $if macos {
+		for name in ['libbrotlienc.dylib', '/opt/homebrew/lib/libbrotlienc.dylib',
+			'/usr/local/lib/libbrotlienc.dylib'] {
+			handle := open_library_name(name)
+			if handle != 0 {
+				return handle
+			}
+		}
+	} $else {
+		for name in ['libbrotlienc.so', 'libbrotlienc.so.1'] {
+			handle := open_library_name(name)
+			if handle != 0 {
+				return handle
+			}
+		}
+	}
+	return error('brotli: could not load encoder library')
+}
+
+fn open_decoder_library() !voidptr {
+	env_handle := open_env_library('V_BROTLI_DEC_LIB')
+	if env_handle != 0 {
+		return env_handle
+	}
+	$if windows {
+		for name in ['brotlidec.dll', 'libbrotlidec.dll'] {
+			handle := open_library_name(name)
+			if handle != 0 {
+				return handle
+			}
+		}
+	} $else $if macos {
+		for name in ['libbrotlidec.dylib', '/opt/homebrew/lib/libbrotlidec.dylib',
+			'/usr/local/lib/libbrotlidec.dylib'] {
+			handle := open_library_name(name)
+			if handle != 0 {
+				return handle
+			}
+		}
+	} $else {
+		for name in ['libbrotlidec.so', 'libbrotlidec.so.1'] {
+			handle := open_library_name(name)
+			if handle != 0 {
+				return handle
+			}
+		}
+	}
+	return error('brotli: could not load decoder library')
+}
+
+fn close_library(handle voidptr) {
+	C.v_brotli_close(handle)
+}
+
+fn library_symbol(handle voidptr, name string, kind string) !voidptr {
+	sym := C.v_brotli_sym(handle, &char(name.str))
+	if sym == 0 {
+		return error('brotli: could not load ${kind} symbol ${name}')
+	}
+	return sym
+}
+
+// is_available reports whether both Brotli encoder and decoder libraries can be loaded.
+pub fn is_available() bool {
+	enc := open_encoder_library() or { return false }
+	defer {
+		close_library(enc)
+	}
+	dec := open_decoder_library() or { return false }
+	defer {
+		close_library(dec)
+	}
+	library_symbol(enc, 'BrotliEncoderCompress', 'encoder') or { return false }
+	library_symbol(dec, 'BrotliDecoderDecompressStream', 'decoder') or { return false }
+	return true
+}
+
+fn validate_compress_params(params CompressParams) ! {
+	if params.quality < min_quality || params.quality > max_quality {
+		return error('brotli: quality must be between ${min_quality} and ${max_quality}')
+	}
+	if params.lgwin < min_lgwin || params.lgwin > max_lgwin {
+		return error('brotli: lgwin must be between ${min_lgwin} and ${max_lgwin}')
+	}
+}
+
+// compress compresses data as a Brotli stream and returns the compressed bytes.
+pub fn compress(data []u8, params CompressParams) ![]u8 {
+	validate_compress_params(params)!
+	enc := open_encoder_library()!
+	defer {
+		close_library(enc)
+	}
+	max_compressed_size := FNEncoderMaxCompressedSize(library_symbol(enc,
+		'BrotliEncoderMaxCompressedSize', 'encoder')!)
+	encoder_compress := FNEncoderCompress(library_symbol(enc, 'BrotliEncoderCompress', 'encoder')!)
+	dst_capacity := max_compressed_size(usize(data.len))
+	if dst_capacity == 0 {
+		return error('brotli: input is too large')
+	}
+	mut dst := []u8{len: int(dst_capacity)}
+	mut keep_dst := false
+	defer {
+		if !keep_dst {
+			unsafe { dst.free() }
+		}
+	}
+	mut encoded_size := dst_capacity
+	ok := encoder_compress(params.quality, params.lgwin, int(params.mode), usize(data.len),
+		data.data, &encoded_size, dst.data)
+	if ok == 0 {
+		return error('brotli: compression failed')
+	}
+	keep_dst = true
+	return dst[..int(encoded_size)]
+}
+
+// decompress decompresses a Brotli stream and returns the decompressed bytes.
+pub fn decompress(data []u8, _ DecompressParams) ![]u8 {
+	dec := open_decoder_library()!
+	defer {
+		close_library(dec)
+	}
+	decoder_create := FNDecoderCreateInstance(library_symbol(dec, 'BrotliDecoderCreateInstance',
+		'decoder')!)
+	decoder_destroy := FNDecoderDestroyInstance(library_symbol(dec, 'BrotliDecoderDestroyInstance',
+		'decoder')!)
+	decoder_stream := FNDecoderDecompressStream(library_symbol(dec,
+		'BrotliDecoderDecompressStream', 'decoder')!)
+	decoder_get_error := FNDecoderGetErrorCode(library_symbol(dec, 'BrotliDecoderGetErrorCode',
+		'decoder')!)
+	decoder_error_string := FNDecoderErrorString(library_symbol(dec, 'BrotliDecoderErrorString',
+		'decoder')!)
+	state := decoder_create(unsafe { nil }, unsafe { nil }, unsafe { nil })
+	if state == 0 {
+		return error('brotli: could not create decoder state')
+	}
+	defer {
+		decoder_destroy(state)
+	}
+	mut out := []u8{}
+	mut keep_out := false
+	defer {
+		if !keep_out {
+			unsafe { out.free() }
+		}
+	}
+	mut chunk := []u8{len: decode_chunk_size}
+	defer {
+		unsafe { chunk.free() }
+	}
+	mut available_in := usize(data.len)
+	mut next_in := unsafe { &u8(data.data) }
+	for {
+		mut available_out := usize(chunk.len)
+		mut next_out := unsafe { &u8(chunk.data) }
+		mut total_out := usize(0)
+		result := decoder_stream(state, &available_in, &next_in, &available_out, &next_out,
+			&total_out)
+		produced := chunk.len - int(available_out)
+		if produced > 0 {
+			out << chunk[..produced]
+		}
+		match result {
+			decoder_result_success {
+				if available_in != 0 {
+					return error('brotli: trailing data after stream')
+				}
+				keep_out = true
+				return out
+			}
+			decoder_result_needs_more_output {
+				if produced == 0 {
+					return error('brotli: decoder needs more output without producing data')
+				}
+			}
+			decoder_result_needs_more_input {
+				return error('brotli: unexpected end of input')
+			}
+			decoder_result_error {
+				code := decoder_get_error(state)
+				msg := unsafe { tos_clone(&u8(decoder_error_string(code))) }
+				return error('brotli: ${msg}')
+			}
+			else {
+				return error('brotli: unexpected decoder result ${result}')
+			}
+		}
+	}
+	return error('brotli: decoder stopped unexpectedly')
+}

--- a/vlib/compress/brotli/brotli_dl.h
+++ b/vlib/compress/brotli/brotli_dl.h
@@ -1,0 +1,43 @@
+#ifndef V_COMPRESS_BROTLI_DL_H
+#define V_COMPRESS_BROTLI_DL_H
+
+#if defined(_WIN32)
+#include <windows.h>
+
+static void* v_brotli_open(const char* name) {
+	return (void*)LoadLibraryA(name);
+}
+
+static void* v_brotli_sym(void* handle, const char* name) {
+	return (void*)GetProcAddress((HMODULE)handle, name);
+}
+
+static int v_brotli_close(void* handle) {
+	return FreeLibrary((HMODULE)handle) != 0;
+}
+#else
+#include <dlfcn.h>
+#ifdef dlopen
+#undef dlopen
+#endif
+#ifdef dlsym
+#undef dlsym
+#endif
+#ifdef dlclose
+#undef dlclose
+#endif
+
+static void* v_brotli_open(const char* name) {
+	return dlopen(name, RTLD_LAZY);
+}
+
+static void* v_brotli_sym(void* handle, const char* name) {
+	return dlsym(handle, name);
+}
+
+static int v_brotli_close(void* handle) {
+	return dlclose(handle) == 0;
+}
+#endif
+
+#endif

--- a/vlib/compress/brotli/brotli_test.v
+++ b/vlib/compress/brotli/brotli_test.v
@@ -1,0 +1,62 @@
+module brotli
+
+fn skip_without_brotli() bool {
+	if is_available() {
+		return false
+	}
+	eprintln('skipping compress.brotli tests; libbrotli is not available')
+	return true
+}
+
+fn test_brotli_roundtrip_text() {
+	if skip_without_brotli() {
+		return
+	}
+	data := 'Hello Brotli! '.repeat(1000).bytes()
+	compressed := compress(data, mode: .text, quality: 5)!
+	assert compressed.len < data.len
+	decompressed := decompress(compressed)!
+	assert decompressed == data
+}
+
+fn test_brotli_roundtrip_empty() {
+	if skip_without_brotli() {
+		return
+	}
+	data := []u8{}
+	compressed := compress(data)!
+	decompressed := decompress(compressed)!
+	assert decompressed == data
+}
+
+fn test_brotli_roundtrip_binary() {
+	if skip_without_brotli() {
+		return
+	}
+	data := []u8{len: 4096, init: u8(index * 31 + (index >> 2))}
+	compressed := compress(data, quality: 3)!
+	decompressed := decompress(compressed)!
+	assert decompressed == data
+}
+
+fn test_brotli_invalid_params() {
+	if skip_without_brotli() {
+		return
+	}
+	compress('bad params'.bytes(), quality: 12) or {
+		assert err.msg() == 'brotli: quality must be between 0 and 11'
+		return
+	}
+	assert false
+}
+
+fn test_brotli_invalid_stream() {
+	if skip_without_brotli() {
+		return
+	}
+	decompress('not brotli'.bytes()) or {
+		assert err.msg().starts_with('brotli:')
+		return
+	}
+	assert false
+}

--- a/vlib/compress/deflate/deflate.v
+++ b/vlib/compress/deflate/deflate.v
@@ -134,7 +134,10 @@ pub fn compress(data []u8, format CompressParams) ![]u8 {
 }
 
 pub fn compress_zlib(data []u8) ![]u8 {
-	payload := deflate_compress_fixed(data)!
+	mut payload := deflate_compress_fixed(data)!
+	defer {
+		unsafe { payload.free() }
+	}
 	cksum := adler32.sum(data)
 	mut out := []u8{cap: 2 + payload.len + 4}
 	out << u8(0x78) // CMF: CM=8 deflate, CINFO=7 (32K window)
@@ -146,7 +149,10 @@ pub fn compress_zlib(data []u8) ![]u8 {
 
 // compress_gzip compresses data into a gzip stream (RFC 1952).
 pub fn compress_gzip(data []u8) ![]u8 {
-	payload := deflate_compress_fixed(data)!
+	mut payload := deflate_compress_fixed(data)!
+	defer {
+		unsafe { payload.free() }
+	}
 	mut out := []u8{cap: 10 + payload.len + 8}
 	// 10-byte gzip header: ID1 ID2 CM FLG MTIME(4) XFL OS
 	out << [u8(0x1f), 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff]

--- a/vlib/compress/deflate/deflate_compress.v
+++ b/vlib/compress/deflate/deflate_compress.v
@@ -9,22 +9,29 @@ const deflate_min_match = 3
 const deflate_max_match = 258
 const deflate_window = 32768
 
-// fixed_litlen_encode returns (reversed_codes, code_lengths) for fixed Huffman lit/len.
-// The LSB-first (bit-reversed) codes come straight from the shared canonical
-// builder, since the encoder writes bits LSB-first.
-fn fixed_litlen_encode() !([]u32, []int) {
-	lens := fixed_litlen_lengths()
-	t := huffman.build(lengths: lens, max_bits: 9, bit_order: .lsb_first)!
-	return t.codes, lens
+const fixed_litlen_codes = build_fixed_litlen_codes()
+const fixed_dist_codes = build_fixed_dist_codes()
+
+// build_fixed_litlen_codes returns reversed codes for fixed Huffman lit/len.
+// The LSB-first codes come straight from the shared canonical builder, since
+// the encoder writes bits LSB-first.
+fn build_fixed_litlen_codes() []u32 {
+	mut t := huffman.build(lengths: fixed_litlen_lens, max_bits: 9, bit_order: .lsb_first) or {
+		panic('deflate: failed to build fixed lit/len Huffman codes: ${err}')
+	}
+	defer {
+		unsafe { t.lengths.free() }
+	}
+	return t.codes
 }
 
-// fixed_dist_encode returns (reversed_codes, code_lengths) for fixed Huffman distance.
-fn fixed_dist_encode() ([]u32, []int) {
-	mut codes := []u32{len: 30}
-	for i in 0 .. 30 {
+// build_fixed_dist_codes returns reversed codes for fixed Huffman distance.
+fn build_fixed_dist_codes() []u32 {
+	mut codes := []u32{len: fixed_dist_lens.len}
+	for i in 0 .. fixed_dist_lens.len {
 		codes[i] = bit_reverse(u32(i), 5)
 	}
-	return codes, []int{len: 30, init: 5}
+	return codes
 }
 
 fn length_code_info(length int) (int, int, int) {
@@ -114,8 +121,10 @@ fn (mut w BitWriter) flush() {
 // deflate_compress_fixed compresses data to RFC 1951 DEFLATE using fixed Huffman codes.
 @[direct_array_access]
 fn deflate_compress_fixed(data []u8) ![]u8 {
-	ll_codes, ll_lens := fixed_litlen_encode()!
-	d_codes, d_lens := fixed_dist_encode()
+	ll_codes := fixed_litlen_codes
+	ll_lens := fixed_litlen_lens
+	d_codes := fixed_dist_codes
+	d_lens := fixed_dist_lens
 	mut w := BitWriter{}
 	// BFINAL=1, BTYPE=01 (fixed Huffman)
 	w.write_bits(1, 1)
@@ -126,7 +135,13 @@ fn deflate_compress_fixed(data []u8) ![]u8 {
 		return w.buf
 	}
 	mut last := []int{len: deflate_hash_size, init: -1}
+	defer {
+		unsafe { last.free() }
+	}
 	mut prev := []int{len: data.len, init: -1}
+	defer {
+		unsafe { prev.free() }
+	}
 	mut pos := 0
 	for pos < data.len {
 		off, match_len := find_lz_match(data, pos, last, prev)

--- a/vlib/compress/deflate/deflate_inflate.v
+++ b/vlib/compress/deflate/deflate_inflate.v
@@ -34,6 +34,10 @@ fn fixed_litlen_lengths() []int {
 	return lens
 }
 
+fn fixed_dist_lengths() []int {
+	return []int{len: 32, init: 5}
+}
+
 // HuffTree is a MSB-first Huffman lookup table for DEFLATE decoding.
 // Indexed by the next max_bits bits read LSB-first from the stream.
 struct HuffTree {
@@ -64,6 +68,21 @@ fn build_huff_tree(lengths []int) !HuffTree {
 		table:    table
 		max_bits: max_bits
 	}
+}
+
+const fixed_litlen_lens = fixed_litlen_lengths()
+const fixed_dist_lens = fixed_dist_lengths()
+const fixed_ll_tree = build_fixed_huff_tree(fixed_litlen_lens, 'lit/len')
+const fixed_d_tree = build_fixed_huff_tree(fixed_dist_lens, 'distance')
+
+fn build_fixed_huff_tree(lengths []int, name string) HuffTree {
+	return build_huff_tree(lengths) or {
+		panic('deflate: failed to build fixed ${name} Huffman tree: ${err}')
+	}
+}
+
+fn (mut t HuffTree) free() {
+	unsafe { t.table.free() }
 }
 
 struct BitReader {
@@ -170,8 +189,6 @@ fn inflate_with_consumed(data []u8) !InflateResult {
 		buf: data
 	}
 	mut out := []u8{}
-	fixed_ll := build_huff_tree(fixed_litlen_lengths())!
-	fixed_d := build_huff_tree([]int{len: 32, init: 5})!
 	for {
 		bfinal := r.read_bits(1)!
 		btype := r.read_bits(2)!
@@ -188,48 +205,10 @@ fn inflate_with_consumed(data []u8) !InflateResult {
 				}
 			}
 			1 {
-				inflate_block(mut r, mut out, fixed_ll, fixed_d)!
+				inflate_block(mut r, mut out, fixed_ll_tree, fixed_d_tree)!
 			}
 			2 {
-				hlit := int(r.read_bits(5)!) + 257
-				hdist := int(r.read_bits(5)!) + 1
-				hclen := int(r.read_bits(4)!) + 4
-				mut cl_lens := []int{len: 19}
-				for i in 0 .. hclen {
-					cl_lens[cl_order[i]] = int(r.read_bits(3)!)
-				}
-				cl_tree := build_huff_tree(cl_lens)!
-				mut all_lens := []int{}
-				for all_lens.len < hlit + hdist {
-					sym := r.huff_decode(cl_tree)!
-					if sym <= 15 {
-						all_lens << int(sym)
-					} else if sym == 16 {
-						if all_lens.len == 0 {
-							return error('inflate: repeat with empty history')
-						}
-						rep := int(r.read_bits(2)!) + 3
-						last := all_lens[all_lens.len - 1]
-						for _ in 0 .. rep {
-							all_lens << last
-						}
-					} else if sym == 17 {
-						rep := int(r.read_bits(3)!) + 3
-						for _ in 0 .. rep {
-							all_lens << 0
-						}
-					} else if sym == 18 {
-						rep := int(r.read_bits(7)!) + 11
-						for _ in 0 .. rep {
-							all_lens << 0
-						}
-					} else {
-						return error('inflate: bad code length symbol')
-					}
-				}
-				ll_tree := build_huff_tree(all_lens[..hlit])!
-				d_tree := build_huff_tree(all_lens[hlit..])!
-				inflate_block(mut r, mut out, ll_tree, d_tree)!
+				inflate_dynamic_block(mut r, mut out)!
 			}
 			else {
 				return error('inflate: reserved block type')
@@ -262,8 +241,6 @@ fn inflate_with_callback(data []u8, cb ChunkCallback, userdata voidptr) !Inflate
 	mut out := []u8{}
 	mut state := InflateStreamState{}
 	mut aborted := false
-	fixed_ll := build_huff_tree(fixed_litlen_lengths())!
-	fixed_d := build_huff_tree([]int{len: 32, init: 5})!
 	for {
 		bfinal := r.read_bits(1)!
 		btype := r.read_bits(2)!
@@ -284,50 +261,13 @@ fn inflate_with_callback(data []u8, cb ChunkCallback, userdata voidptr) !Inflate
 				}
 			}
 			1 {
-				if !inflate_block_stream(mut r, mut out, fixed_ll, fixed_d, cb, userdata, mut state)! {
+				if !inflate_block_stream(mut r, mut out, fixed_ll_tree, fixed_d_tree, cb, userdata, mut
+					state)! {
 					aborted = true
 				}
 			}
 			2 {
-				hlit := int(r.read_bits(5)!) + 257
-				hdist := int(r.read_bits(5)!) + 1
-				hclen := int(r.read_bits(4)!) + 4
-				mut cl_lens := []int{len: 19}
-				for i in 0 .. hclen {
-					cl_lens[cl_order[i]] = int(r.read_bits(3)!)
-				}
-				cl_tree := build_huff_tree(cl_lens)!
-				mut all_lens := []int{}
-				for all_lens.len < hlit + hdist {
-					sym := r.huff_decode(cl_tree)!
-					if sym <= 15 {
-						all_lens << int(sym)
-					} else if sym == 16 {
-						if all_lens.len == 0 {
-							return error('inflate: repeat with empty history')
-						}
-						rep := int(r.read_bits(2)!) + 3
-						last := all_lens[all_lens.len - 1]
-						for _ in 0 .. rep {
-							all_lens << last
-						}
-					} else if sym == 17 {
-						rep := int(r.read_bits(3)!) + 3
-						for _ in 0 .. rep {
-							all_lens << 0
-						}
-					} else if sym == 18 {
-						rep := int(r.read_bits(7)!) + 11
-						for _ in 0 .. rep {
-							all_lens << 0
-						}
-					} else {
-						return error('inflate: bad code length symbol')
-					}
-				}
-				ll_tree := build_huff_tree(all_lens[..hlit])!
-				d_tree := build_huff_tree(all_lens[hlit..])!
-				if !inflate_block_stream(mut r, mut out, ll_tree, d_tree, cb, userdata, mut state)! {
+				if !inflate_dynamic_block_stream(mut r, mut out, cb, userdata, mut state)! {
 					aborted = true
 				}
 			}
@@ -355,6 +295,107 @@ fn inflate_with_callback(data []u8, cb ChunkCallback, userdata voidptr) !Inflate
 		delivered: state.delivered
 		aborted:   aborted
 	}
+}
+
+@[direct_array_access]
+fn inflate_dynamic_block(mut r BitReader, mut out []u8) ! {
+	hlit := int(r.read_bits(5)!) + 257
+	hdist := int(r.read_bits(5)!) + 1
+	hclen := int(r.read_bits(4)!) + 4
+	mut cl_lens := []int{len: 19}
+	defer {
+		unsafe { cl_lens.free() }
+	}
+	for i in 0 .. hclen {
+		cl_lens[cl_order[i]] = int(r.read_bits(3)!)
+	}
+	mut cl_tree := build_huff_tree(cl_lens)!
+	defer {
+		cl_tree.free()
+	}
+	mut all_lens := read_dynamic_lengths(mut r, cl_tree, hlit, hdist)!
+	defer {
+		unsafe { all_lens.free() }
+	}
+	mut ll_tree := build_huff_tree(all_lens[..hlit])!
+	defer {
+		ll_tree.free()
+	}
+	mut d_tree := build_huff_tree(all_lens[hlit..])!
+	defer {
+		d_tree.free()
+	}
+	inflate_block(mut r, mut out, ll_tree, d_tree)!
+}
+
+@[direct_array_access]
+fn inflate_dynamic_block_stream(mut r BitReader, mut out []u8, cb ChunkCallback, userdata voidptr, mut state InflateStreamState) !bool {
+	hlit := int(r.read_bits(5)!) + 257
+	hdist := int(r.read_bits(5)!) + 1
+	hclen := int(r.read_bits(4)!) + 4
+	mut cl_lens := []int{len: 19}
+	defer {
+		unsafe { cl_lens.free() }
+	}
+	for i in 0 .. hclen {
+		cl_lens[cl_order[i]] = int(r.read_bits(3)!)
+	}
+	mut cl_tree := build_huff_tree(cl_lens)!
+	defer {
+		cl_tree.free()
+	}
+	mut all_lens := read_dynamic_lengths(mut r, cl_tree, hlit, hdist)!
+	defer {
+		unsafe { all_lens.free() }
+	}
+	mut ll_tree := build_huff_tree(all_lens[..hlit])!
+	defer {
+		ll_tree.free()
+	}
+	mut d_tree := build_huff_tree(all_lens[hlit..])!
+	defer {
+		d_tree.free()
+	}
+	return inflate_block_stream(mut r, mut out, ll_tree, d_tree, cb, userdata, mut state)!
+}
+
+fn read_dynamic_lengths(mut r BitReader, cl_tree HuffTree, hlit int, hdist int) ![]int {
+	mut all_lens := []int{cap: hlit + hdist}
+	mut keep_all_lens := false
+	defer {
+		if !keep_all_lens {
+			unsafe { all_lens.free() }
+		}
+	}
+	for all_lens.len < hlit + hdist {
+		sym := r.huff_decode(cl_tree)!
+		if sym <= 15 {
+			all_lens << int(sym)
+		} else if sym == 16 {
+			if all_lens.len == 0 {
+				return error('inflate: repeat with empty history')
+			}
+			rep := int(r.read_bits(2)!) + 3
+			last := all_lens[all_lens.len - 1]
+			for _ in 0 .. rep {
+				all_lens << last
+			}
+		} else if sym == 17 {
+			rep := int(r.read_bits(3)!) + 3
+			for _ in 0 .. rep {
+				all_lens << 0
+			}
+		} else if sym == 18 {
+			rep := int(r.read_bits(7)!) + 11
+			for _ in 0 .. rep {
+				all_lens << 0
+			}
+		} else {
+			return error('inflate: bad code length symbol')
+		}
+	}
+	keep_all_lens = true
+	return all_lens
 }
 
 @[direct_array_access]

--- a/vlib/hash/huffman/huffman.v
+++ b/vlib/hash/huffman/huffman.v
@@ -82,6 +82,9 @@ fn next_codes(lengths []int, max_bits int) !([]u32, bool) {
 		return error('huffman: max_bits ${max_bits} exceeds 32 (u32 code storage)')
 	}
 	mut bl_count := []int{len: max_bits + 1}
+	defer {
+		unsafe { bl_count.free() }
+	}
 	for sym, l in lengths {
 		if l < 0 {
 			return error('huffman: negative length ${l} for symbol ${sym}')
@@ -121,6 +124,9 @@ fn next_codes(lengths []int, max_bits int) !([]u32, bool) {
 // codes array. See next_codes() for the validation rules.
 pub fn build(cfg Config) !Table {
 	mut next_code, _ := next_codes(cfg.lengths, cfg.max_bits)!
+	defer {
+		unsafe { next_code.free() }
+	}
 	mut codes := []u32{len: cfg.lengths.len}
 	for sym, l in cfg.lengths {
 		if l == 0 {
@@ -154,6 +160,9 @@ pub fn flat_table(cfg Config) ![]u32 {
 		return error('huffman: max_bits ${cfg.max_bits} > max_flat_bits ${max_flat_bits}; use build() + decode_map()')
 	}
 	mut next_code, complete := next_codes(cfg.lengths, cfg.max_bits)!
+	defer {
+		unsafe { next_code.free() }
+	}
 	table_size := 1 << cfg.max_bits
 	// A complete code writes every table slot, so the invalid pre-fill is dead
 	// work; allocate zeroed (vcalloc) and skip it. An incomplete code leaves

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -3,6 +3,7 @@
 // that can be found in the LICENSE file.
 module http
 
+import compress.brotli
 import compress.gzip
 import compress.zlib
 import net.http.chunked
@@ -112,6 +113,9 @@ fn decode_response_body(body string, content_encoding string) string {
 		decoded = match encoding {
 			'gzip', 'x-gzip' {
 				gzip.decompress(decoded) or { return body }
+			}
+			'br' {
+				brotli.decompress(decoded) or { return body }
 			}
 			'deflate' {
 				zlib.decompress(decoded) or { return body }

--- a/vlib/net/http/response_test.v
+++ b/vlib/net/http/response_test.v
@@ -1,5 +1,6 @@
 module http
 
+import compress.brotli
 import compress.gzip
 import compress.zlib
 
@@ -98,6 +99,20 @@ fn test_parse_response_with_deflate_content_encoding() {
 	compressed_body := zlib.compress(expected_body.bytes())!
 	content :=
 		'HTTP/1.1 200 OK\r\nContent-Encoding: deflate\r\nContent-Length: ${compressed_body.len}\r\n\r\n' +
+		compressed_body.bytestr()
+	resp := parse_response(content)!
+	assert resp.body == expected_body
+}
+
+fn test_parse_response_with_brotli_content_encoding() {
+	if !brotli.is_available() {
+		eprintln('skipping Brotli HTTP response test; libbrotli is not available')
+		return
+	}
+	expected_body := '{"a": 1}'
+	compressed_body := brotli.compress(expected_body.bytes(), mode: .text)!
+	content :=
+		'HTTP/1.1 200 OK\r\nContent-Encoding: br\r\nContent-Length: ${compressed_body.len}\r\n\r\n' +
 		compressed_body.bytestr()
 	resp := parse_response(content)!
 	assert resp.body == expected_body


### PR DESCRIPTION
## Summary

- Fix pure-V deflate/gzip/zlib `-gc none` scratch leaks by reusing fixed Huffman tables and freeing compression hash-chain scratch, dynamic inflate Huffman tables, and Huffman builder work arrays.
- Free copied raw-deflate payloads in gzip/zlib container writers.
- Add `compress.brotli` with runtime-loaded system libbrotli support and wire `Content-Encoding: br` decoding into `net.http.Response` when libbrotli is available.

Closes #27606.
Closes #27607.
Closes #27608.

## Tests

- `./vnew -silent test vlib/compress/deflate/`
- `./vnew -silent test vlib/compress/deflate/ vlib/compress/gzip/ vlib/compress/zlib/`
- `./vnew -silent test vlib/hash/huffman/ vlib/compress/ vlib/net/http/response_test.v vlib/net/http/h2_hpack_test.v`
- `./vnew -gc none -silent test vlib/compress/deflate/ vlib/compress/gzip/ vlib/compress/zlib/`
- `./vnew -silent test vlib/compress/brotli/`
- `./vnew -gc none -silent test vlib/compress/brotli/`
- `./vnew -cstrict -cc clang -silent test vlib/compress/brotli/`
- `./vnew check-md vlib/compress/README.md vlib/compress/brotli/README.md`