### PR TITLE
v3: prefer input checkout vroot

### DIFF
--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -305,7 +305,7 @@ fn main() {
 	prefs.backend = backend
 	prefs.c99 = c99
 	prefs.user_defines = user_defines
-	prefs.vroot = resolve_vroot(prefs.vroot)
+	prefs.vroot = resolve_vroot_for_input(prefs.vroot, input_file)
 	prefs.selfhost = is_selfhost
 	prefs.building_v = building_v
 	mut p := parser.Parser.new(prefs)
@@ -693,12 +693,34 @@ fn nearest_vmod_root_for_file(path string) string {
 	return ''
 }
 
-// resolve_vroot resolves resolve vroot information for v3 entry point.
-fn resolve_vroot(initial string) string {
+// resolve_vroot_for_input resolves the V repo root for the compiler being built.
+fn resolve_vroot_for_input(initial string, input_file string) string {
+	if root := nearest_vroot_for_path(input_file) {
+		return root
+	}
+	if root := nearest_vroot_for_path(os.getwd()) {
+		return root
+	}
 	if is_valid_vroot(initial) {
 		return initial
 	}
-	mut dir := os.getwd()
+	return initial
+}
+
+fn nearest_vroot_for_path(path string) ?string {
+	if path.len == 0 {
+		return none
+	}
+	mut dir := path
+	if !os.is_abs_path(dir) {
+		cwd := os.getwd()
+		if cwd.len > 0 {
+			dir = os.join_path_single(cwd, dir)
+		}
+	}
+	if !os.is_dir(dir) {
+		dir = os.dir(dir)
+	}
 	for _ in 0 .. 8 {
 		if is_valid_vroot(dir) {
 			return dir
@@ -709,7 +731,7 @@ fn resolve_vroot(initial string) string {
 		}
 		dir = parent
 	}
-	return initial
+	return none
 }
 
 // is_valid_vroot reports whether is valid vroot applies in v3 entry point.


### PR DESCRIPTION
## Summary
- Prefer the V repo containing the input file/current working directory before using the host compiler's baked vroot.
- Fix v3 self-hosting when stage 1 is built with a `v` binary from another checkout.

## Testing
- `v -gc none -prod -o v3 v3.v`
- `./v3 -building-v -o v4 v3.v`
- `./vnew -silent test vlib/v3/tests/selfhost_backend_prune_test.v`