### PR TITLE
v3: make 10 more tests pass

### DIFF
--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -149,7 +149,7 @@ fn (mut g FlatGen) gen_fixed_array_data_arg(id flat.NodeId, arr types.ArrayFixed
 	}
 	// A fixed-array value (e.g. `[4]u8` color) is sometimes represented as a dynamic
 	// `Array`; a C fixed-array parameter decays to `elem*`, so pass the data pointer.
-	if g.tc.resolve_type(id) is types.Array {
+	if types.unwrap_pointer(g.usable_expr_type(id)) is types.Array {
 		elem_ct := g.tc.c_type(arr.elem_type)
 		g.write('(${elem_ct}*)(')
 		g.gen_expr(id)

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -737,6 +737,10 @@ fn c_inline_header_file_text(text string, vroot string, source_file string, incl
 }
 
 fn c_update_nested_include_context(clean string, line string, mut context []string) {
+	if context.len > 0 && c_line_has_continuation(context[context.len - 1]) {
+		context[context.len - 1] += '\n${line}'
+		return
+	}
 	match c_directive_name(clean) {
 		'if', 'ifdef', 'ifndef', 'elif', 'else' {
 			context << line
@@ -755,6 +759,10 @@ fn c_update_nested_include_context(clean string, line string, mut context []stri
 }
 
 fn c_update_nested_include_prefix(clean string, line string, mut prefix []string) {
+	if prefix.len > 0 && c_line_has_continuation(prefix[prefix.len - 1]) {
+		prefix[prefix.len - 1] += '\n${line}'
+		return
+	}
 	match c_directive_name(clean) {
 		'define', 'undef' {
 			prefix << line
@@ -763,6 +771,10 @@ fn c_update_nested_include_prefix(clean string, line string, mut prefix []string
 			prefix.clear()
 		}
 	}
+}
+
+fn c_line_has_continuation(line string) bool {
+	return line.trim_right(' \t\r').ends_with('\\')
 }
 
 fn c_preserved_nested_include_directive(include_arg string, context []string, prefix []string) string {
@@ -2508,9 +2520,9 @@ fn (mut g FlatGen) gen_sum_value_expr(id flat.NodeId, expected types.Type) bool 
 	field := g.sum_field_name(variant)
 	if g.variant_references_sum(variant, sum_name) {
 		inner_ct := g.value_c_type(g.tc.parse_type(variant))
-		g.write('(${ct}){.typ = ${idx}, .${field} = (${inner_ct}*)memdup((${inner_ct}[]){')
-		g.gen_expr(id)
-		g.write('}, sizeof(${inner_ct}))}')
+		g.write('(${ct}){.typ = ${idx}, .${field} = (${inner_ct}*)memdup(')
+		g.gen_sum_variant_memdup_source(id, actual_type)
+		g.write(', sizeof(${inner_ct}))}')
 		return true
 	}
 	g.write('(${ct}){.typ = ${idx}, .${field} = ')
@@ -2589,9 +2601,9 @@ fn (mut g FlatGen) gen_sum_cast_expr(target_type types.SumType, inner_id flat.No
 			}
 			g.write('}, sizeof(${inner_ct}))}')
 		} else {
-			g.write('(${ct}){.typ = ${idx}, .${field} = (${inner_ct}*)memdup((${inner_ct}[]){')
-			g.gen_expr(inner_id)
-			g.write('}, sizeof(${inner_ct}))}')
+			g.write('(${ct}){.typ = ${idx}, .${field} = (${inner_ct}*)memdup(')
+			g.gen_sum_variant_memdup_source(inner_id, variant_type)
+			g.write(', sizeof(${inner_ct}))}')
 		}
 	} else {
 		g.write('(${ct}){.typ = ${idx}, .${field} = ')
@@ -2601,6 +2613,20 @@ fn (mut g FlatGen) gen_sum_cast_expr(target_type types.SumType, inner_id flat.No
 		g.gen_expr(inner_id)
 		g.write('}')
 	}
+}
+
+fn (mut g FlatGen) gen_sum_variant_memdup_source(value_id flat.NodeId, inner_type types.Type) {
+	if fixed := array_fixed_type(inner_type) {
+		source := g.fixed_array_runtime_copy_source_expr(value_id, fixed)
+		if source.trim_space().len > 0 {
+			g.write(source)
+			return
+		}
+	}
+	inner_ct := g.tc.c_type(inner_type)
+	g.write('(${inner_ct}[]){')
+	g.gen_expr_with_expected_type(value_id, inner_type)
+	g.write('}')
 }
 
 // pointer_variant_arg_needs_heap_copy supports pointer_variant_arg_needs_heap_copy handling in c.
@@ -2816,7 +2842,11 @@ fn (mut g FlatGen) type_name_c_type(type_name string) string {
 		return g.resolve_fn_ptr_type(type_name)
 	}
 	t := g.tc.parse_type(type_name)
-	ct := g.tc.c_type(t)
+	ct := if t is types.OptionType || t is types.ResultType {
+		g.optional_type_name(t)
+	} else {
+		g.tc.c_type(t)
+	}
 	if ct.starts_with('fn_ptr:') {
 		return g.resolve_fn_ptr_type(ct)
 	}
@@ -7461,6 +7491,9 @@ fn (mut g FlatGen) fixed_array_initializer_string(val_id flat.NodeId, fixed type
 	}
 	node := g.a.nodes[int(val_id)]
 	if node.kind == .postfix && node.children_count > 0 {
+		return g.fixed_array_initializer_string(g.a.child(&node, 0), fixed)
+	}
+	if node.kind == .cast_expr && node.children_count > 0 {
 		return g.fixed_array_initializer_string(g.a.child(&node, 0), fixed)
 	}
 	if node.kind == .array_init && node.children_count == 0 {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -846,13 +846,33 @@ fn sanitize_generic_receiver_type_fragment(typ string) string {
 	return s
 }
 
-fn c_string_literal_pointer_arg(arg_node flat.Node, expected types.Type) bool {
-	if arg_node.kind != .char_literal || !arg_node.value.starts_with('c:') {
+fn c_string_pointer_base_arg(base types.Type) bool {
+	clean := if base is types.Alias { base.base_type } else { base }
+	if clean is types.Char {
+		return true
+	}
+	return clean is types.Primitive && clean.name() == 'u8'
+}
+
+fn (g &FlatGen) c_string_pointer_arg(arg_node flat.Node, expected types.Type) bool {
+	if expected !is types.Pointer {
 		return false
 	}
-	if expected is types.Pointer {
-		base := types.unwrap_pointer(expected)
-		return base is types.Char
+	if !c_string_pointer_base_arg(types.unwrap_pointer(expected)) {
+		return false
+	}
+	if arg_node.kind == .char_literal {
+		return arg_node.value.starts_with('c:')
+	}
+	if arg_node.kind == .ident {
+		const_name := g.const_ref_name(arg_node.value)
+		if const_name.len == 0 {
+			return false
+		}
+		if const_id := g.const_vals[const_name] {
+			const_node := g.a.nodes[int(const_id)]
+			return const_node.kind == .char_literal && const_node.value.starts_with('c:')
+		}
 	}
 	return false
 }
@@ -1422,6 +1442,47 @@ fn (mut g FlatGen) emit_args_spawn_expr(cfn string, param_cts []string, arg_expr
 	g.write('pthread_attr_setstacksize(&_at${tmp}, 8388608); ')
 	g.write('int _r${tmp} = pthread_create(&_t${tmp}, &_at${tmp}, ${wrapper}, (void*)_sa${tmp}); ')
 	g.write('pthread_attr_destroy(&_at${tmp}); (void)_r${tmp}; (void*)_t${tmp}; })')
+}
+
+fn (mut g FlatGen) gen_thread_wait_call(fn_node &flat.Node) bool {
+	if fn_node.value != 'wait' || fn_node.children_count == 0 {
+		return false
+	}
+	base_id := g.a.child(fn_node, 0)
+	base_type0 := g.usable_expr_type(base_id)
+	base_type := if base_type0 is types.Unknown || base_type0 is types.Void {
+		g.tc.resolve_type(base_id)
+	} else {
+		base_type0
+	}
+	clean_type := types.unwrap_pointer(base_type)
+	if clean_type !is types.Struct {
+		return false
+	}
+	thread_struct := clean_type as types.Struct
+	thread_name := thread_struct.name.trim_space()
+	mut ret_name := ''
+	if thread_name == 'thread' || thread_name.ends_with('.thread') {
+		ret_name = ''
+	} else if thread_name.starts_with('thread ') {
+		ret_name = thread_name[7..].trim_space()
+	} else {
+		return false
+	}
+	tmp := g.tmp_count
+	g.tmp_count++
+	res_name := '__twres${tmp}'
+	g.write('({ void* ${res_name} = NULL; pthread_join((pthread_t)(')
+	g.gen_expr(base_id)
+	g.write('), &${res_name}); ')
+	if ret_name.len == 0 {
+		g.write('if (${res_name}) free(${res_name}); })')
+		return true
+	}
+	ret_ct := g.fn_return_type_name(g.tc.parse_type(ret_name))
+	val_name := '__twval${tmp}'
+	g.write('${ret_ct} ${val_name}; if (${res_name}) { ${val_name} = *((${ret_ct}*)${res_name}); free(${res_name}); } else { memset(&${val_name}, 0, sizeof(${val_name})); } ${val_name}; })')
+	return true
 }
 
 fn (g &FlatGen) resolved_method_name_for_spawn(clean_type types.Type, method string) string {
@@ -2123,9 +2184,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		return
 	}
 	if g.is_json_decode_call(id, target_name) {
-		ret_type := g.json_decode_result_type(g.a.child(&node, 0)) or {
-			g.call_default_return_type(id)
-		}
+		ret_type := g.json_decode_result_type_for_call(node) or { g.call_default_return_type(id) }
 		g.gen_default_value_for_type(ret_type)
 		return
 	}
@@ -2349,6 +2408,9 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					{
 						base_type := g.usable_expr_type(g.a.child(fn_node, 0))
 						clean_type := concrete_receiver_type(base_type)
+						if g.gen_thread_wait_call(fn_node) {
+							return
+						}
 						if g.gen_interface_method_call(node, fn_node, base_type) {
 							return
 						}
@@ -2495,6 +2557,9 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 				} else {
 					base_type := g.usable_expr_type(g.a.child(fn_node, 0))
 					clean_type := concrete_receiver_type(base_type)
+					if g.gen_thread_wait_call(fn_node) {
+						return
+					}
 					if g.gen_interface_method_call(node, fn_node, base_type) {
 						return
 					}
@@ -2926,7 +2991,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					&& arg_node.op == .amp) {
 					arg_type := g.tc.resolve_type(arg_id)
 					if arg_type !is types.Pointer
-						&& !c_string_literal_pointer_arg(arg_node, param_types[arg_idx]) {
+						&& !g.c_string_pointer_arg(arg_node, param_types[arg_idx]) {
 						needs_addr = true
 					}
 				}
@@ -3372,6 +3437,25 @@ fn (g &FlatGen) call_default_return_type(id flat.NodeId) types.Type {
 	return g.tc.resolve_type(id)
 }
 
+fn (g &FlatGen) json_decode_result_type_for_call(node flat.Node) ?types.Type {
+	if node.children_count == 0 {
+		return none
+	}
+	if ret_type := g.json_decode_result_type(g.a.child(&node, 0)) {
+		return ret_type
+	}
+	if node.children_count < 2 {
+		return none
+	}
+	type_name := g.json_decode_type_arg_name(g.a.child(&node, 1))
+	if type_name.len == 0 {
+		return none
+	}
+	return types.Type(types.ResultType{
+		base_type: g.tc.parse_type(type_name)
+	})
+}
+
 fn (g &FlatGen) json_decode_result_type(callee_id flat.NodeId) ?types.Type {
 	if int(callee_id) < 0 || int(callee_id) >= g.a.nodes.len {
 		return none
@@ -3395,6 +3479,74 @@ fn (g &FlatGen) json_decode_result_type(callee_id flat.NodeId) ?types.Type {
 	return types.Type(types.ResultType{
 		base_type: g.tc.parse_type(type_name)
 	})
+}
+
+fn (g &FlatGen) json_decode_type_arg_name(id flat.NodeId) string {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return ''
+	}
+	node := g.a.nodes[int(id)]
+	match node.kind {
+		.ident {
+			return node.value
+		}
+		.selector {
+			if node.children_count == 0 {
+				return node.value
+			}
+			base := g.json_decode_type_arg_name(g.a.child(&node, 0))
+			if base.len == 0 {
+				return node.value
+			}
+			return '${base}.${node.value}'
+		}
+		.index {
+			if node.children_count < 2 || node.value == 'range' {
+				return ''
+			}
+			base := g.json_decode_type_arg_name(g.a.child(&node, 0))
+			if base.len == 0 {
+				return ''
+			}
+			mut args := []string{}
+			for i in 1 .. node.children_count {
+				arg := g.json_decode_type_arg_name(g.a.child(&node, i))
+				if arg.len == 0 {
+					return ''
+				}
+				args << arg
+			}
+			return '${base}[${args.join(', ')}]'
+		}
+		.array_init {
+			if node.value.len > 0 {
+				return '[]${node.value}'
+			}
+			return ''
+		}
+		.map_init {
+			return node.value
+		}
+		.struct_decl {
+			return node.value
+		}
+		.prefix {
+			if node.children_count == 0 {
+				return ''
+			}
+			child := g.json_decode_type_arg_name(g.a.child(&node, 0))
+			if child.len == 0 {
+				return ''
+			}
+			if node.op == .amp {
+				return '&${child}'
+			}
+			return child
+		}
+		else {
+			return ''
+		}
+	}
 }
 
 fn (g &FlatGen) embedded_method_name_for_type(base_type types.Type, method string) ?string {
@@ -3574,6 +3726,9 @@ fn (g &FlatGen) normalize_call_key(name string) string {
 	if name in g.tc.fn_param_types || name in g.tc.fn_ret_types {
 		return name
 	}
+	if imported := g.selective_import_call_key(name) {
+		return imported
+	}
 	qname := g.tc.qualify_fn_name(name)
 	if qname in g.tc.fn_param_types || qname in g.tc.fn_ret_types {
 		return qname
@@ -3585,6 +3740,41 @@ fn (g &FlatGen) normalize_call_key(name string) string {
 		}
 	}
 	return qname
+}
+
+fn (g &FlatGen) selective_import_call_key(name string) ?string {
+	if name.contains('.') {
+		return none
+	}
+	mut resolved := []string{}
+	if g.tc.cur_file.len > 0 {
+		if candidates := g.tc.file_selective_imports['${g.tc.cur_file}\n${name}'] {
+			for candidate in candidates {
+				if (candidate in g.tc.fn_param_types || candidate in g.tc.fn_ret_types)
+					&& candidate !in resolved {
+					resolved << candidate
+				}
+			}
+		}
+	}
+	if resolved.len == 0 {
+		suffix := '\n${name}'
+		for key, candidates in g.tc.file_selective_imports {
+			if !key.ends_with(suffix) {
+				continue
+			}
+			for candidate in candidates {
+				if (candidate in g.tc.fn_param_types || candidate in g.tc.fn_ret_types)
+					&& candidate !in resolved {
+					resolved << candidate
+				}
+			}
+		}
+	}
+	if resolved.len == 1 {
+		return resolved[0]
+	}
+	return none
 }
 
 // param_types_for supports param types for handling for FlatGen.
@@ -4470,8 +4660,7 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			&& !(arg_node.kind == .prefix && arg_node.op == .amp)
 			&& !g.arg_is_null_pointer_literal(arg_id, arg_node) {
 			arg_type := g.tc.resolve_type(arg_id)
-			if arg_type !is types.Pointer
-				&& !c_string_literal_pointer_arg(arg_node, param_types[arg_idx]) {
+			if arg_type !is types.Pointer && !g.c_string_pointer_arg(arg_node, param_types[arg_idx]) {
 				needs_addr = true
 			}
 		}
@@ -4575,6 +4764,9 @@ fn (g &FlatGen) voidptr_variadic_storage_c_type(actual types.Type) string {
 			continue
 		}
 		break
+	}
+	if clean is types.Char {
+		return 'int'
 	}
 	if clean is types.Primitive {
 		if clean.props.has(.integer) && clean.size < 32 {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -4548,10 +4548,23 @@ fn variadic_elem_is_voidptr(typ types.Type) bool {
 
 fn (mut g FlatGen) gen_voidptr_variadic_arg(arg_id flat.NodeId) {
 	actual := g.tc.resolve_type(arg_id)
+	if voidptr_variadic_type_passes_direct(actual) {
+		g.write('(voidptr)(')
+		g.gen_expr_with_expected_type(arg_id, actual)
+		g.write(')')
+		return
+	}
 	storage_ct := g.voidptr_variadic_storage_c_type(actual)
 	g.write('(voidptr)&((${storage_ct}[]){')
 	g.gen_expr_with_expected_type(arg_id, actual)
 	g.write('}[0])')
+}
+
+fn voidptr_variadic_type_passes_direct(typ types.Type) bool {
+	if typ is types.Alias {
+		return voidptr_variadic_type_passes_direct(typ.base_type)
+	}
+	return typ is types.Pointer || typ is types.Nil
 }
 
 fn (g &FlatGen) voidptr_variadic_storage_c_type(actual types.Type) string {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -2891,12 +2891,17 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 							c_elem := g.tc.c_type(variadic_type.elem_type)
 							count := num_call_args - variadic_idx
 							g.write('new_array_from_c_array(${count}, ${count}, sizeof(${c_elem}), (${c_elem}[]){')
+							is_voidptr_variadic := variadic_elem_is_voidptr(variadic_type.elem_type)
 							for j in i .. node.children_count {
 								if j > i {
 									g.write(', ')
 								}
-								g.gen_expr_with_expected_type(g.a.child(&node, j),
-									variadic_type.elem_type)
+								if is_voidptr_variadic {
+									g.gen_voidptr_variadic_arg(g.a.child(&node, j))
+								} else {
+									g.gen_expr_with_expected_type(g.a.child(&node, j),
+										variadic_type.elem_type)
+								}
 							}
 							g.write('})')
 							break
@@ -2905,7 +2910,11 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 						if arg_type !is types.Array {
 							c_elem := g.tc.c_type(variadic_type.elem_type)
 							g.write('new_array_from_c_array(1, 1, sizeof(${c_elem}), (${c_elem}[]){')
-							g.gen_expr_with_expected_type(arg_id, variadic_type.elem_type)
+							if variadic_elem_is_voidptr(variadic_type.elem_type) {
+								g.gen_voidptr_variadic_arg(arg_id)
+							} else {
+								g.gen_expr_with_expected_type(arg_id, variadic_type.elem_type)
+							}
 							g.write('})')
 							continue
 						}
@@ -4424,11 +4433,16 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 				c_elem := g.tc.c_type(variadic_type.elem_type)
 				count := num_args - variadic_idx
 				g.write('new_array_from_c_array(${count}, ${count}, sizeof(${c_elem}), (${c_elem}[]){')
+				is_voidptr_variadic := variadic_elem_is_voidptr(variadic_type.elem_type)
 				for j in i .. node.children_count {
 					if j > i {
 						g.write(', ')
 					}
-					g.gen_expr_with_expected_type(g.a.child(&node, j), variadic_type.elem_type)
+					if is_voidptr_variadic {
+						g.gen_voidptr_variadic_arg(g.a.child(&node, j))
+					} else {
+						g.gen_expr_with_expected_type(g.a.child(&node, j), variadic_type.elem_type)
+					}
 				}
 				g.write('})')
 			}
@@ -4441,7 +4455,11 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 				if variadic_type is types.Array {
 					c_elem := g.tc.c_type(variadic_type.elem_type)
 					g.write('new_array_from_c_array(1, 1, sizeof(${c_elem}), (${c_elem}[]){')
-					g.gen_expr_with_expected_type(arg_id, variadic_type.elem_type)
+					if variadic_elem_is_voidptr(variadic_type.elem_type) {
+						g.gen_voidptr_variadic_arg(arg_id)
+					} else {
+						g.gen_expr_with_expected_type(arg_id, variadic_type.elem_type)
+					}
 					g.write('})')
 					continue
 				}
@@ -4519,6 +4537,41 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			g.gen_default_value_for_type(param_types[i])
 		}
 	}
+}
+
+fn variadic_elem_is_voidptr(typ types.Type) bool {
+	if typ is types.Pointer {
+		return typ.base_type is types.Void
+	}
+	return false
+}
+
+fn (mut g FlatGen) gen_voidptr_variadic_arg(arg_id flat.NodeId) {
+	actual := g.tc.resolve_type(arg_id)
+	storage_ct := g.voidptr_variadic_storage_c_type(actual)
+	g.write('(voidptr)&((${storage_ct}[]){')
+	g.gen_expr_with_expected_type(arg_id, actual)
+	g.write('}[0])')
+}
+
+fn (g &FlatGen) voidptr_variadic_storage_c_type(actual types.Type) string {
+	mut clean := actual
+	for _ in 0 .. 8 {
+		if clean is types.Alias {
+			clean = clean.base_type
+			continue
+		}
+		break
+	}
+	if clean is types.Primitive {
+		if clean.props.has(.integer) && clean.size < 32 {
+			return 'int'
+		}
+		if clean.props.has(.float) && clean.size == 32 {
+			return 'double'
+		}
+	}
+	return g.tc.c_type(clean)
 }
 
 fn raw_sizeof_arg_value(value string) ?string {

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -210,6 +210,11 @@ fn (mut g FlatGen) collect_interface_impls() {
 	for name, _ in g.tc.structs {
 		struct_names << name
 	}
+	for name, _ in g.tc.type_aliases {
+		if name !in struct_names {
+			struct_names << name
+		}
+	}
 	struct_names.sort()
 	for iface in iface_names {
 		if c_name(iface) == 'IError' {
@@ -248,7 +253,7 @@ fn (mut g FlatGen) gen_interface_value_expr(id flat.NodeId, expected types.Type)
 		}
 	}
 	actual_clean := if actual is types.Pointer { actual.base_type } else { actual }
-	actual_base := if actual_clean is types.Alias { actual_clean.base_type } else { actual_clean }
+	actual_base := actual_clean
 	if actual_base is types.Interface {
 		return false
 	}

--- a/vlib/v3/gen/c/naming/naming.v
+++ b/vlib/v3/gen/c/naming/naming.v
@@ -248,8 +248,7 @@ pub fn sanitize(name string) string {
 		} else if c == `&` {
 			b.write_string('ptr')
 		} else if c == `@` {
-			i++
-			continue
+			b.write_string('__at_')
 		} else if c == `,` || c == ` ` {
 			b.write_u8(`_`)
 		} else {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -445,7 +445,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 	}
 	g.in_return = false
 	match node.kind {
-		.fn_decl, .c_fn_decl {
+		.fn_decl, .c_fn_decl, .struct_decl, .type_decl, .enum_decl, .interface_decl {
 			return
 		}
 		.expr_stmt {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -2863,7 +2863,7 @@ fn (g &FlatGen) json_decode_call_expr_result_type(id flat.NodeId) ?types.Type {
 	if !g.is_json_decode_call(id, target) {
 		return none
 	}
-	return g.json_decode_result_type(callee_id)
+	return g.json_decode_result_type_for_call(node)
 }
 
 fn (g &FlatGen) or_expr_uses_concrete_optional(expr_id flat.NodeId) bool {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -480,9 +480,7 @@ fn (mut g FlatGen) gen_lowered_sum_field_value(sum_name string, field &flat.Node
 			if child_type is types.Pointer && g.type_names_match(child_type.base_type, inner_type) {
 				g.gen_expr(child_id)
 			} else {
-				g.write('(${inner_ct}[]){')
-				g.gen_expr_with_expected_type(child_id, inner_type)
-				g.write('}')
+				g.gen_sum_variant_memdup_source(child_id, inner_type)
 			}
 			g.write(', sizeof(${inner_ct}))')
 			return

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -394,6 +394,11 @@ fn ensure_iface_impls(recv string, cur_module string, tc &types.TypeChecker, mut
 			impls << struct_name
 		}
 	}
+	for alias_name, _ in tc.type_aliases {
+		if alias_name !in impls && tc.named_type_implements_interface(alias_name, iface_name) {
+			impls << alias_name
+		}
+	}
 	iface_impls[recv] = impls
 	if iface_name != recv {
 		iface_impls[iface_name] = impls

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -4103,6 +4103,9 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			if name == '@FILE_LINE' {
 				return p.a.add_val_id(5, '${p.cur_file}:${p.source_line_number(name_pos)}')
 			}
+			if name == '@FILE_LINE' {
+				return p.a.add_val_id(5, '${p.cur_file}:0')
+			}
 			if name == '@MOD' {
 				if p.cur_module.len == 0 {
 					return p.a.add_val_id(5, 'main')

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -5680,6 +5680,10 @@ fn (mut p Parser) predeclare_local_type_names_in_block(open_brace_pos int) {
 			continue
 		}
 		name_tok := s.scan()
+		if name_tok == .lcbr {
+			depth++
+			continue
+		}
 		if name_tok != .name {
 			continue
 		}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -32,24 +32,25 @@ const read_source_chunk_size = 65536
 pub struct Parser {
 	prefs &pref.Preferences
 mut:
-	s                scanner.Scanner
-	tok              token.Token
-	lit              string
-	tok_pos          int
-	peek_tok         token.Token = .eof
-	peek_lit         string
-	peek_pos         int
-	has_peek         bool
-	cur_file         string
-	cur_module       string
-	cur_fn           string
-	pending_flag     bool
-	pending_params   bool
-	pending_export   string
-	skip_next_decl   bool
-	disable_fn_body  bool
-	in_for_container bool
-	local_type_names map[string]string
+	s                 scanner.Scanner
+	tok               token.Token
+	lit               string
+	tok_pos           int
+	peek_tok          token.Token = .eof
+	peek_lit          string
+	peek_pos          int
+	has_peek          bool
+	cur_file          string
+	cur_module        string
+	cur_fn            string
+	pending_flag      bool
+	pending_params    bool
+	pending_export    string
+	skip_next_decl    bool
+	disable_fn_body   bool
+	in_for_container  bool
+	local_type_names  map[string]string
+	local_type_scopes []string
 pub mut:
 	a              &flat.FlatAst = unsafe { nil }
 	parsed_v_files int
@@ -95,6 +96,7 @@ pub fn (mut p Parser) parse_into(path string) {
 	p.skip_next_decl = false
 	p.disable_fn_body = false
 	p.in_for_container = false
+	p.local_type_scopes = []string{}
 	// File marker before content so import resolver can track source files
 	p.a.add_node(flat.Node{
 		kind:  .file
@@ -803,6 +805,7 @@ fn (mut p Parser) fn_operator_overload(receiver_name string, receiver_type strin
 	if p.tok == .lcbr {
 		prev_fn := p.cur_fn
 		p.cur_fn = name
+		p.push_local_type_scope(name)
 		if disable_body {
 			p.mark_disabled_fn(name)
 			p.skip_block()
@@ -816,6 +819,7 @@ fn (mut p Parser) fn_operator_overload(receiver_name string, receiver_type strin
 			}
 			p.check(.rcbr)
 		}
+		p.pop_local_type_scope()
 		p.cur_fn = prev_fn
 	}
 
@@ -897,6 +901,7 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 	mut body_ids := []flat.NodeId{}
 	prev_fn := p.cur_fn
 	p.cur_fn = name
+	p.push_local_type_scope(name)
 	// A disabled `@[if flag ?]` function keeps its signature but gets an empty body
 	// (a no-op stub), so callers still resolve while the body is compiled out.
 	if disable_body {
@@ -912,6 +917,7 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 		}
 		p.check(.rcbr)
 	}
+	p.pop_local_type_scope()
 	p.cur_fn = prev_fn
 
 	mut all_ids := []flat.NodeId{cap: param_ids.len + body_ids.len}
@@ -1066,9 +1072,10 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 			name += '.' + p.expect_name_or_keyword()
 		}
 	}
-	if p.cur_fn.len > 0 && !name.contains('.') {
-		local_name := p.local_type_decl_name(name)
-		p.local_type_names[p.local_type_key(name)] = local_name
+	local_scope := p.current_local_type_scope()
+	if local_scope.len > 0 && !name.contains('.') {
+		local_name := local_type_decl_name_for_scope(name, local_scope)
+		p.local_type_names[p.local_type_key_for_scope(local_scope, name)] = local_name
 		name = local_name
 	}
 	// generic params — skip
@@ -5042,6 +5049,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 
 // fn_literal supports fn literal handling for Parser.
 fn (mut p Parser) fn_literal() flat.NodeId {
+	fn_start := p.tok_pos
 	p.next() // skip 'fn'
 	// capture list: fn [a, b] (params) ret { }
 	mut capture_ids := []flat.NodeId{}
@@ -5080,6 +5088,7 @@ fn (mut p Parser) fn_literal() flat.NodeId {
 	// body
 	mut body_ids := []flat.NodeId{}
 	if p.tok == .lcbr {
+		p.push_local_type_scope(p.fn_literal_local_type_scope(fn_start))
 		p.check(.lcbr)
 		for p.tok != .rcbr && p.tok != .eof {
 			id := p.stmt()
@@ -5088,6 +5097,7 @@ fn (mut p Parser) fn_literal() flat.NodeId {
 			}
 		}
 		p.check(.rcbr)
+		p.pop_local_type_scope()
 	}
 	mut all_ids := []flat.NodeId{cap: capture_ids.len + param_ids.len + body_ids.len}
 	for id in capture_ids {
@@ -5558,19 +5568,49 @@ fn (mut p Parser) parse_type_name() string {
 	return name
 }
 
-fn (p &Parser) local_type_key(name string) string {
-	if p.cur_fn.len == 0 || name.len == 0 {
+fn (p &Parser) current_local_type_scope() string {
+	if p.local_type_scopes.len == 0 {
 		return ''
 	}
-	return '${p.cur_file}\n${p.cur_module}\n${p.cur_fn}\n${name}'
+	return p.local_type_scopes[p.local_type_scopes.len - 1]
 }
 
-fn (p &Parser) local_type_decl_name(name string) string {
-	return '${name}__local_${local_type_scope_part(p.cur_fn)}'
+fn (mut p Parser) push_local_type_scope(scope string) {
+	if scope.len > 0 {
+		p.local_type_scopes << scope
+	}
+}
+
+fn (mut p Parser) pop_local_type_scope() {
+	if p.local_type_scopes.len > 0 {
+		p.local_type_scopes.delete_last()
+	}
+}
+
+fn (p &Parser) fn_literal_local_type_scope(fn_start int) string {
+	mut base := p.current_local_type_scope()
+	if base.len == 0 {
+		base = p.cur_fn
+	}
+	if base.len == 0 {
+		base = 'fn_literal'
+	}
+	return '${base}__fn_literal_${fn_start}'
+}
+
+fn (p &Parser) local_type_key_for_scope(scope string, name string) string {
+	if scope.len == 0 || name.len == 0 {
+		return ''
+	}
+	return '${p.cur_file}\n${p.cur_module}\n${scope}\n${name}'
+}
+
+fn local_type_decl_name_for_scope(name string, scope string) string {
+	return '${name}__local_${local_type_scope_part(scope)}'
 }
 
 fn (p &Parser) resolve_local_type_name(name string) string {
-	if p.cur_fn.len == 0 || name.len == 0 || name.contains('.') {
+	if p.local_type_scopes.len == 0 || name.len == 0 || name.contains('.') {
 		return name
 	}
 	mut suffix := ''
@@ -5580,8 +5620,11 @@ fn (p &Parser) resolve_local_type_name(name string) string {
 		base = name[..idx]
 		suffix = name[idx..]
 	}
-	if mapped := p.local_type_names[p.local_type_key(base)] {
-		return mapped + suffix
+	for i := p.local_type_scopes.len - 1; i >= 0; i-- {
+		scope := p.local_type_scopes[i]
+		if mapped := p.local_type_names[p.local_type_key_for_scope(scope, base)] {
+			return mapped + suffix
+		}
 	}
 	return name
 }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -3797,9 +3797,10 @@ fn (mut p Parser) expr_with_lhs(first flat.NodeId, min_bp token.BindingPower) fl
 		// skip auto-semicolons before infix operators (multi-line expressions)
 		if p.tok == .semicolon {
 			peek_tok := p.peek()
-			if token_is_infix(peek_tok) && peek_tok !in [.key_as, .key_in, .key_is]
-				&& int(peek_tok) != 85 && int(peek_tok) != 0 {
+			if (token_is_infix(peek_tok) || peek_tok == .key_as) && int(peek_tok) != 85
+				&& int(peek_tok) != 0 {
 				p.next()
+				continue
 			}
 		}
 		if token_is_assignment(p.tok) {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -3241,7 +3241,10 @@ fn (mut p Parser) match_branch() flat.NodeId {
 		}
 	}
 
+	branch_block_start := p.tok_pos
 	p.check(.lcbr)
+	block_scope := p.block_local_type_scope(branch_block_start)
+	p.push_local_type_scope(block_scope)
 	for p.tok != .rcbr && p.tok != .eof {
 		if p.looks_like_match_branch_start() {
 			break
@@ -3252,6 +3255,9 @@ fn (mut p Parser) match_branch() flat.NodeId {
 		}
 	}
 	p.check(.rcbr)
+	if block_scope.len > 0 {
+		p.pop_local_type_scope()
+	}
 
 	bstart := p.add_children(branch_ids)
 	return p.a.add_node(flat.Node{
@@ -3280,7 +3286,10 @@ fn (mut p Parser) block_stmt() flat.NodeId {
 }
 
 fn (mut p Parser) parse_block_body() []flat.NodeId {
+	block_start := p.tok_pos
 	p.check(.lcbr)
+	block_scope := p.block_local_type_scope(block_start)
+	p.push_local_type_scope(block_scope)
 	mut ids := []flat.NodeId{}
 	for p.tok != .rcbr && p.tok != .eof {
 		id := p.stmt()
@@ -3289,6 +3298,9 @@ fn (mut p Parser) parse_block_body() []flat.NodeId {
 		}
 	}
 	p.check(.rcbr)
+	if block_scope.len > 0 {
+		p.pop_local_type_scope()
+	}
 	return ids
 }
 
@@ -5596,6 +5608,14 @@ fn (p &Parser) fn_literal_local_type_scope(fn_start int) string {
 		base = 'fn_literal'
 	}
 	return '${base}__fn_literal_${fn_start}'
+}
+
+fn (p &Parser) block_local_type_scope(block_start int) string {
+	base := p.current_local_type_scope()
+	if base.len == 0 {
+		return ''
+	}
+	return '${base}__block_${block_start}'
 }
 
 fn (p &Parser) local_type_key_for_scope(scope string, name string) string {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -4630,7 +4630,7 @@ fn (mut p Parser) index_expr(lhs flat.NodeId) flat.NodeId {
 }
 
 fn (p &Parser) generic_struct_init_type_name(id flat.NodeId) ?string {
-	type_name := p.type_expr_name(id)
+	type_name := p.resolve_local_type_name(p.type_expr_name(id))
 	if !generic_type_name_can_init(type_name) {
 		return none
 	}
@@ -5610,7 +5610,7 @@ fn local_type_decl_name_for_scope(name string, scope string) string {
 }
 
 fn (p &Parser) resolve_local_type_name(name string) string {
-	if p.local_type_scopes.len == 0 || name.len == 0 || name.contains('.') {
+	if p.local_type_scopes.len == 0 || name.len == 0 {
 		return name
 	}
 	mut suffix := ''
@@ -5619,6 +5619,9 @@ fn (p &Parser) resolve_local_type_name(name string) string {
 	if idx >= 0 {
 		base = name[..idx]
 		suffix = name[idx..]
+	}
+	if base.contains('.') {
+		return name
 	}
 	for i := p.local_type_scopes.len - 1; i >= 0; i-- {
 		scope := p.local_type_scopes[i]

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -49,6 +49,7 @@ mut:
 	skip_next_decl   bool
 	disable_fn_body  bool
 	in_for_container bool
+	local_type_names map[string]string
 pub mut:
 	a              &flat.FlatAst = unsafe { nil }
 	parsed_v_files int
@@ -57,9 +58,10 @@ pub mut:
 // new creates a Parser value for parser.
 pub fn Parser.new(prefs &pref.Preferences) &Parser {
 	return &Parser{
-		prefs: unsafe { prefs }
-		s:     scanner.new_scanner(prefs, .normal)
-		a:     &flat.FlatAst{
+		prefs:            unsafe { prefs }
+		s:                scanner.new_scanner(prefs, .normal)
+		local_type_names: map[string]string{}
+		a:                &flat.FlatAst{
 			nodes:           []flat.Node{cap: 256}
 			children:        []flat.NodeId{cap: 512}
 			disabled_fns:    map[string]bool{}
@@ -1046,6 +1048,11 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 			p.next()
 			name += '.' + p.expect_name_or_keyword()
 		}
+	}
+	if p.cur_fn.len > 0 && !name.contains('.') {
+		local_name := p.local_type_decl_name(name)
+		p.local_type_names[p.local_type_key(name)] = local_name
+		name = local_name
 	}
 	// generic params — skip
 	mut is_generic := false
@@ -2582,15 +2589,6 @@ fn (mut p Parser) stmt() flat.NodeId {
 		.key_struct, .key_union {
 			return p.struct_decl()
 		}
-		.key_enum {
-			return p.enum_decl()
-		}
-		.key_type {
-			return p.type_decl()
-		}
-		.key_interface {
-			return p.interface_decl()
-		}
 		.key_match {
 			return p.match_stmt()
 		}
@@ -2635,15 +2633,6 @@ fn (mut p Parser) stmt() flat.NodeId {
 			}
 			if p.tok == .key_struct || p.tok == .key_union {
 				return p.struct_decl()
-			}
-			if p.tok == .key_enum {
-				return p.enum_decl()
-			}
-			if p.tok == .key_type {
-				return p.type_decl()
-			}
-			if p.tok == .key_interface {
-				return p.interface_decl()
 			}
 			return p.assign_or_expr_stmt()
 		}
@@ -4046,7 +4035,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			return p.prefix_expr()
 		}
 		.name, .key_module {
-			name := p.lit
+			mut name := p.lit
 			p.next()
 			if name == 'sql' && p.starts_sql_expr() {
 				return p.sql_expr()
@@ -4129,15 +4118,17 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				}
 				return p.a.add_val(.map_init, map_type)
 			}
+			local_type_name := p.resolve_local_type_name(name)
 			// struct init: Name{...}; vlib/builtin also uses concrete lowercase
 			// runtime structs like array{} and string{}.
-			if !p.in_for_container && p.tok == .lcbr && name.len > 0
-				&& ((name[0] >= `A` && name[0] <= `Z`)
+			if !p.in_for_container && p.tok == .lcbr && local_type_name.len > 0
+				&& ((local_type_name[0] >= `A` && local_type_name[0] <= `Z`)
 				|| name in ['array', 'string', 'map', 'mapnode', '_result', '_option']) {
-				return p.struct_init(name)
+				return p.struct_init(local_type_name)
 			}
 			// type cast: TypeName(expr) or builtin_type(expr)
-			if p.tok == .lpar && name.len > 0 && ((name[0] >= `A` && name[0] <= `Z`)
+			if p.tok == .lpar && local_type_name.len > 0
+				&& ((local_type_name[0] >= `A` && local_type_name[0] <= `Z`)
 				|| is_builtin_type(name)) {
 				p.next() // skip (
 				inner := p.expr(.lowest)
@@ -4145,7 +4136,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				cstart := p.add_child(inner)
 				return p.a.add_node(flat.Node{
 					kind:           .cast_expr
-					value:          name
+					value:          local_type_name
 					children_start: cstart
 					children_count: 1
 				})
@@ -5542,8 +5533,50 @@ fn (mut p Parser) parse_type_name() string {
 		}
 		// generic: Type[T, U]
 		name += p.parse_type_generic_suffix()
+		name = p.resolve_local_type_name(name)
 	}
 	return name
+}
+
+fn (p &Parser) local_type_key(name string) string {
+	if p.cur_fn.len == 0 || name.len == 0 {
+		return ''
+	}
+	return '${p.cur_file}\n${p.cur_module}\n${p.cur_fn}\n${name}'
+}
+
+fn (p &Parser) local_type_decl_name(name string) string {
+	return '${name}__local_${local_type_scope_part(p.cur_fn)}'
+}
+
+fn (p &Parser) resolve_local_type_name(name string) string {
+	if p.cur_fn.len == 0 || name.len == 0 || name.contains('.') {
+		return name
+	}
+	mut suffix := ''
+	mut base := name
+	idx := name.index_u8(`[`)
+	if idx >= 0 {
+		base = name[..idx]
+		suffix = name[idx..]
+	}
+	if mapped := p.local_type_names[p.local_type_key(base)] {
+		return mapped + suffix
+	}
+	return name
+}
+
+fn local_type_scope_part(name string) string {
+	mut out := strings.new_builder(name.len)
+	for ch in name {
+		if (ch >= `a` && ch <= `z`) || (ch >= `A` && ch <= `Z`)
+			|| (ch >= `0` && ch <= `9`) || ch == `_` {
+			out.write_rune(ch)
+		} else {
+			out.write_u8(`_`)
+		}
+	}
+	return out.str()
 }
 
 // ==================== helpers ====================

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -1173,10 +1173,11 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 			}
 			// embedded struct (type on its own line, followed by semicolon)
 			if p.tok == .semicolon || p.tok == .rcbr {
+				embedded_type := p.resolve_local_type_name(field_name)
 				ids << p.a.add_node(flat.Node{
 					kind:  .field_decl
-					value: field_name
-					typ:   field_name
+					value: embedded_type
+					typ:   embedded_type
 				})
 				if p.tok == .semicolon {
 					p.next()

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -1081,24 +1081,29 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 	for p.tok != .rcbr && p.tok != .eof {
 		// access modifiers
 		if p.tok == .key_pub {
-			p.next()
-			if p.tok == .key_mut {
+			peek_tok := p.peek()
+			peek_lit := p.peek_lit
+			if peek_tok == .colon || peek_tok == .key_mut
+				|| (peek_tok == .name && peek_lit == 'module_mut') {
 				p.next()
+				if p.tok == .key_mut {
+					p.next()
+				}
+				if p.tok == .name && p.lit == 'module_mut' {
+					p.next()
+				}
+				if p.tok == .colon {
+					p.next()
+				}
+				continue
 			}
-			if p.tok == .name && p.lit == 'module_mut' {
-				p.next()
-			}
-			if p.tok == .colon {
-				p.next()
-			}
-			continue
 		}
 		if p.tok == .key_mut {
-			p.next()
-			if p.tok == .colon {
+			if p.peek() == .colon {
 				p.next()
+				p.next()
+				continue
 			}
-			continue
 		}
 		if p.tok == .semicolon {
 			p.next()
@@ -2574,6 +2579,18 @@ fn (mut p Parser) stmt() flat.NodeId {
 		.key_fn {
 			return p.fn_decl()
 		}
+		.key_struct, .key_union {
+			return p.struct_decl()
+		}
+		.key_enum {
+			return p.enum_decl()
+		}
+		.key_type {
+			return p.type_decl()
+		}
+		.key_interface {
+			return p.interface_decl()
+		}
 		.key_match {
 			return p.match_stmt()
 		}
@@ -2615,6 +2632,18 @@ fn (mut p Parser) stmt() flat.NodeId {
 			p.next()
 			if p.tok == .key_fn {
 				return p.fn_decl()
+			}
+			if p.tok == .key_struct || p.tok == .key_union {
+				return p.struct_decl()
+			}
+			if p.tok == .key_enum {
+				return p.enum_decl()
+			}
+			if p.tok == .key_type {
+				return p.type_decl()
+			}
+			if p.tok == .key_interface {
+				return p.interface_decl()
 			}
 			return p.assign_or_expr_stmt()
 		}
@@ -3132,14 +3161,13 @@ fn (mut p Parser) match_branch_cond() flat.NodeId {
 		mod_name := p.lit
 		p.next()
 		p.next()
-		if p.tok == .name && p.lit.len > 0 && p.lit[0] >= `A` && p.lit[0] <= `Z` {
-			type_name := p.lit
-			p.next()
+		field_name := p.expect_name_or_keyword()
+		if field_name.len > 0 && field_name[0] >= `A` && field_name[0] <= `Z` {
 			mod_id := p.a.add_val(.ident, mod_name)
 			start := p.add_child(mod_id)
 			return p.a.add_node(flat.Node{
 				kind:           .selector
-				value:          type_name
+				value:          field_name
 				children_start: start
 				children_count: 1
 			})
@@ -3148,13 +3176,10 @@ fn (mut p Parser) match_branch_cond() flat.NodeId {
 		start := p.add_child(base_id)
 		sel := p.a.add_node(flat.Node{
 			kind:           .selector
-			value:          p.lit
+			value:          field_name
 			children_start: start
 			children_count: 1
 		})
-		if p.tok == .name {
-			p.next()
-		}
 		if p.tok != .lcbr && p.tok != .comma {
 			return p.expr_with_lhs(sel, .lowest)
 		}
@@ -3740,7 +3765,8 @@ fn (mut p Parser) expr_with_lhs(first flat.NodeId, min_bp token.BindingPower) fl
 		// skip auto-semicolons before infix operators (multi-line expressions)
 		if p.tok == .semicolon {
 			peek_tok := p.peek()
-			if token_is_infix(peek_tok) && int(peek_tok) != 85 && int(peek_tok) != 0 {
+			if token_is_infix(peek_tok) && peek_tok !in [.key_as, .key_in, .key_is]
+				&& int(peek_tok) != 85 && int(peek_tok) != 0 {
 				p.next()
 			}
 		}
@@ -4039,6 +4065,9 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			}
 			if name == '@LINE' {
 				return p.a.add_val_id(1, '0')
+			}
+			if name == '@FILE_LINE' {
+				return p.a.add_val_id(5, '${p.cur_file}:0')
 			}
 			if name == '@MOD' {
 				if p.cur_module.len == 0 {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -251,6 +251,23 @@ fn vmod_root_for_file(path string) string {
 	return dir
 }
 
+fn (p &Parser) source_line_number(pos int) int {
+	mut line := 1
+	end := if pos < 0 {
+		0
+	} else if pos < p.s.src.len {
+		pos
+	} else {
+		p.s.src.len
+	}
+	for i in 0 .. end {
+		if p.s.src[i] == `\n` {
+			line++
+		}
+	}
+	return line
+}
+
 // next supports next handling for Parser.
 @[inline]
 fn (mut p Parser) next() {
@@ -4035,6 +4052,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			return p.prefix_expr()
 		}
 		.name, .key_module {
+			name_pos := p.tok_pos
 			mut name := p.lit
 			p.next()
 			if name == 'sql' && p.starts_sql_expr() {
@@ -4053,10 +4071,10 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				return p.a.add_val_id(5, p.prefs.vroot + '/v')
 			}
 			if name == '@LINE' {
-				return p.a.add_val_id(1, '0')
+				return p.a.add_val_id(1, '${p.source_line_number(name_pos)}')
 			}
 			if name == '@FILE_LINE' {
-				return p.a.add_val_id(5, '${p.cur_file}:0')
+				return p.a.add_val_id(5, '${p.cur_file}:${p.source_line_number(name_pos)}')
 			}
 			if name == '@MOD' {
 				if p.cur_module.len == 0 {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -5725,10 +5725,13 @@ fn (p &Parser) resolve_local_type_name(name string) string {
 fn local_type_scope_part(name string) string {
 	mut out := strings.new_builder(name.len)
 	for ch in name {
-		if (ch >= `a` && ch <= `z`) || (ch >= `A` && ch <= `Z`)
-			|| (ch >= `0` && ch <= `9`) || ch == `_` {
+		if (ch >= `a` && ch <= `z`) || (ch >= `A` && ch <= `Z`) || (ch >= `0` && ch <= `9`) {
 			out.write_rune(ch)
+		} else if ch == `_` {
+			out.write_string('_u')
 		} else {
+			out.write_string('_x')
+			out.write_string(int(ch).hex())
 			out.write_u8(`_`)
 		}
 	}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -4605,7 +4605,8 @@ fn (mut p Parser) index_expr(lhs flat.NodeId) flat.NodeId {
 	// fast path for the common simple index `arr[i]`: avoid the children array
 	if p.tok == .rsbr {
 		p.next()
-		istart := p.add_children2(lhs, idx)
+		type_arg := if p.tok == .lpar { p.generic_call_type_arg_id(idx) } else { idx }
+		istart := p.add_children2(lhs, type_arg)
 		return p.a.add_node(flat.Node{
 			kind:           .index
 			children_start: istart
@@ -4642,11 +4643,28 @@ fn (mut p Parser) index_expr(lhs flat.NodeId) flat.NodeId {
 		})
 	}
 	p.check(.rsbr)
+	if p.tok == .lpar {
+		for i in 1 .. ids.len {
+			ids[i] = p.generic_call_type_arg_id(ids[i])
+		}
+	}
 	istart := p.add_children(ids)
 	return p.a.add_node(flat.Node{
 		kind:           .index
 		children_start: istart
 		children_count: flat.child_count(ids.len)
+	})
+}
+
+fn (mut p Parser) generic_call_type_arg_id(id flat.NodeId) flat.NodeId {
+	name := p.type_expr_name(id)
+	resolved := p.resolve_local_type_name(name)
+	if name.len == 0 || resolved == name {
+		return id
+	}
+	return p.a.add_node(flat.Node{
+		kind:  .ident
+		value: resolved
 	})
 }
 

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -2810,6 +2810,7 @@ fn (mut p Parser) if_stmt() flat.NodeId {
 				guard_cond = p.a.add_node(flat.Node{
 					kind:           .decl_assign
 					op:             .assign
+					value:          '${lhs_ids.len}'
 					children_start: istart
 					children_count: flat.child_count(all_ids.len)
 				})
@@ -3325,6 +3326,7 @@ fn (mut p Parser) assign_or_expr_stmt() flat.NodeId {
 					flat.NodeKind.assign
 				}
 				op:             token_id_to_op(op_id)
+				value:          '${lhs_ids.len}'
 				children_start: istart
 				children_count: flat.child_count(all_ids.len)
 			})

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -810,7 +810,9 @@ fn (mut p Parser) fn_operator_overload(receiver_name string, receiver_type strin
 			p.mark_disabled_fn(name)
 			p.skip_block()
 		} else {
+			body_start := p.tok_pos
 			p.check(.lcbr)
+			p.predeclare_local_type_names_in_block(body_start)
 			for p.tok != .rcbr && p.tok != .eof {
 				id := p.stmt()
 				if int(id) >= 0 {
@@ -908,7 +910,9 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 		p.mark_disabled_fn(name)
 		p.skip_block()
 	} else {
+		body_start := p.tok_pos
 		p.check(.lcbr)
+		p.predeclare_local_type_names_in_block(body_start)
 		for p.tok != .rcbr && p.tok != .eof {
 			id := p.stmt()
 			if int(id) >= 0 {
@@ -1074,9 +1078,7 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 	}
 	local_scope := p.current_local_type_scope()
 	if local_scope.len > 0 && !name.contains('.') {
-		local_name := local_type_decl_name_for_scope(name, local_scope)
-		p.local_type_names[p.local_type_key_for_scope(local_scope, name)] = local_name
-		name = local_name
+		name = p.declare_local_type_name(name, local_scope)
 	}
 	// generic params — skip
 	mut is_generic := false
@@ -3246,6 +3248,7 @@ fn (mut p Parser) match_branch() flat.NodeId {
 	p.check(.lcbr)
 	block_scope := p.block_local_type_scope(branch_block_start)
 	p.push_local_type_scope(block_scope)
+	p.predeclare_local_type_names_in_block(branch_block_start)
 	for p.tok != .rcbr && p.tok != .eof {
 		if p.looks_like_match_branch_start() {
 			break
@@ -3291,6 +3294,7 @@ fn (mut p Parser) parse_block_body() []flat.NodeId {
 	p.check(.lcbr)
 	block_scope := p.block_local_type_scope(block_start)
 	p.push_local_type_scope(block_scope)
+	p.predeclare_local_type_names_in_block(block_start)
 	mut ids := []flat.NodeId{}
 	for p.tok != .rcbr && p.tok != .eof {
 		id := p.stmt()
@@ -5101,8 +5105,10 @@ fn (mut p Parser) fn_literal() flat.NodeId {
 	// body
 	mut body_ids := []flat.NodeId{}
 	if p.tok == .lcbr {
+		body_start := p.tok_pos
 		p.push_local_type_scope(p.fn_literal_local_type_scope(fn_start))
 		p.check(.lcbr)
+		p.predeclare_local_type_names_in_block(body_start)
 		for p.tok != .rcbr && p.tok != .eof {
 			id := p.stmt()
 			if int(id) >= 0 {
@@ -5626,8 +5632,66 @@ fn (p &Parser) local_type_key_for_scope(scope string, name string) string {
 	return '${p.cur_file}\n${p.cur_module}\n${scope}\n${name}'
 }
 
+fn (mut p Parser) declare_local_type_name(name string, scope string) string {
+	if scope.len == 0 || name.len == 0 || name.contains('.') {
+		return name
+	}
+	key := p.local_type_key_for_scope(scope, name)
+	if mapped := p.local_type_names[key] {
+		return mapped
+	}
+	local_name := local_type_decl_name_for_scope(name, scope)
+	p.local_type_names[key] = local_name
+	return local_name
+}
+
 fn local_type_decl_name_for_scope(name string, scope string) string {
 	return '${name}__local_${local_type_scope_part(scope)}'
+}
+
+fn (mut p Parser) predeclare_local_type_names_in_block(open_brace_pos int) {
+	scope := p.current_local_type_scope()
+	if scope.len == 0 || open_brace_pos < 0 || open_brace_pos >= p.s.src.len {
+		return
+	}
+	mut s := scanner.new_scanner(p.prefs, .normal)
+	s.init(p.s.current_file(), p.s.src)
+	s.offset = open_brace_pos + 1
+	s.pos = s.offset
+	mut depth := 0
+	for {
+		tok := s.scan()
+		if tok == .eof {
+			return
+		}
+		if tok == .lcbr {
+			depth++
+			continue
+		}
+		if tok == .rcbr {
+			if depth == 0 {
+				return
+			}
+			depth--
+			continue
+		}
+		if depth != 0 || (tok != .key_struct && tok != .key_union) {
+			continue
+		}
+		name_tok := s.scan()
+		if name_tok != .name {
+			continue
+		}
+		name := s.lit
+		after_name_tok := s.scan()
+		if after_name_tok != .dot {
+			p.declare_local_type_name(name, scope)
+		}
+		if after_name_tok == .lcbr {
+			depth++
+			continue
+		}
+	}
 }
 
 fn (p &Parser) resolve_local_type_name(name string) string {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -5650,7 +5650,7 @@ fn (mut p Parser) declare_local_type_name(name string, scope string) string {
 }
 
 fn local_type_decl_name_for_scope(name string, scope string) string {
-	return '${name}__local_${local_type_scope_part(scope)}'
+	return '${name}@local@${local_type_scope_part(scope)}'
 }
 
 fn (mut p Parser) predeclare_local_type_names_in_block(open_brace_pos int) {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -4679,7 +4679,7 @@ fn (p &Parser) type_expr_name(id flat.NodeId) string {
 			}
 			mut args := []string{}
 			for i in 1 .. node.children_count {
-				arg := p.type_expr_name(p.a.child(&node, i))
+				arg := p.resolve_local_type_name(p.type_expr_name(p.a.child(&node, i)))
 				if arg.len == 0 {
 					return ''
 				}
@@ -4691,13 +4691,13 @@ fn (p &Parser) type_expr_name(id flat.NodeId) string {
 			if node.value.len == 0 {
 				return ''
 			}
-			return '[]${node.value}'
+			return '[]${p.resolve_local_type_name(node.value)}'
 		}
 		.prefix {
 			if node.children_count == 0 {
 				return ''
 			}
-			child := p.type_expr_name(p.a.child(&node, 0))
+			child := p.resolve_local_type_name(p.type_expr_name(p.a.child(&node, 0)))
 			if child.len == 0 {
 				return ''
 			}

--- a/vlib/v3/tests/c_struct_redeclaration_test.v
+++ b/vlib/v3/tests/c_struct_redeclaration_test.v
@@ -60,6 +60,11 @@ fn test_c_struct_redeclaration_checks_field_signature() {
 	assert alias_good.exit_code == 0, alias_good.output
 	assert !alias_good.output.contains('C compilation failed'), alias_good.output
 
+	late_alias_good := run_v3_source(v3_bin, 'good_c_struct_late_alias_field_redeclaration',
+		'struct C.LateAlias {\n\tx MyInt\n}\n\ntype MyInt = int\n\nstruct C.LateAlias {\n\tx int\n}\n\nfn main() {}\n')
+	assert late_alias_good.exit_code == 0, late_alias_good.output
+	assert !late_alias_good.output.contains('C compilation failed'), late_alias_good.output
+
 	cross_file_bad := run_v3_project(v3_bin, 'bad_c_struct_cross_file_redeclaration', {
 		'a.v': 'module main\n\nstruct C.Split {\n\tx int\n}\n\nfn main() {}\n'
 		'b.v': 'module main\n\nstruct C.Split {\n\tx string\n}\n'

--- a/vlib/v3/tests/c_struct_redeclaration_test.v
+++ b/vlib/v3/tests/c_struct_redeclaration_test.v
@@ -25,6 +25,18 @@ fn run_v3_source(v3_bin string, name string, src string) os.Result {
 	return os.execute('${v3_bin} ${src_path} -b c -o ${out}')
 }
 
+fn run_v3_project(v3_bin string, name string, files map[string]string) os.Result {
+	root := unique_temp_path('${name}_project')
+	os.mkdir_all(root) or { panic(err) }
+	for rel, src in files {
+		path := os.join_path(root, rel)
+		os.mkdir_all(os.dir(path)) or { panic(err) }
+		os.write_file(path, src) or { panic(err) }
+	}
+	out := unique_temp_path(name)
+	return os.execute('${v3_bin} ${root} -b c -o ${out}')
+}
+
 fn test_c_struct_redeclaration_checks_field_signature() {
 	v3_bin := build_v3()
 	bad := run_v3_source(v3_bin, 'bad_c_struct_redeclaration',
@@ -42,4 +54,17 @@ fn test_c_struct_redeclaration_checks_field_signature() {
 		'@[typedef]\nstruct C.XKeyEvent {\n\tkeycode u32\n\tstate u32\n}\n\nstruct C.XKeyEvent {\n\tkeycode u32\n\tstate u32\n}\n\n@[typedef]\nunion C.XClientMessageData {\nmut:\n\tb [20]u8\n\ts [10]i16\n\tl [5]i64\n}\n\nunion C.XClientMessageData {\nmut:\n\tl [5]i64\n}\n\n@[typedef]\nunion C.XEvent {\nmut:\n\ttype int\n\txkey C.XKeyEvent\n}\n\nunion C.XEvent {\nmut:\n\t@type int\n\txkey C.XKeyEvent\n}\n\nfn main() {}\n')
 	assert good.exit_code == 0, good.output
 	assert !good.output.contains('C compilation failed'), good.output
+
+	alias_good := run_v3_source(v3_bin, 'good_c_struct_alias_field_redeclaration',
+		'struct C.Foo {\n\tx byte\n}\n\nstruct C.Foo {\n\tx u8\n}\n\nfn main() {}\n')
+	assert alias_good.exit_code == 0, alias_good.output
+	assert !alias_good.output.contains('C compilation failed'), alias_good.output
+
+	cross_file_bad := run_v3_project(v3_bin, 'bad_c_struct_cross_file_redeclaration', {
+		'a.v': 'module main\n\nstruct C.Split {\n\tx int\n}\n\nfn main() {}\n'
+		'b.v': 'module main\n\nstruct C.Split {\n\tx string\n}\n'
+	})
+	assert cross_file_bad.exit_code != 0, cross_file_bad.output
+	assert cross_file_bad.output.contains('cannot redeclare C struct `C.Split`'), cross_file_bad.output
+	assert !cross_file_bad.output.contains('C compilation failed'), cross_file_bad.output
 }

--- a/vlib/v3/tests/c_variadic_call_codegen_test.v
+++ b/vlib/v3/tests/c_variadic_call_codegen_test.v
@@ -84,3 +84,35 @@ fn main() {
 	assert generated.contains('sscanf("12 34", "%d %d", &a, &b);'), generated
 	assert generated.contains('__varargs_'), generated
 }
+
+fn test_voidptr_variadic_alias_scalars_promote_before_boxing() {
+	v3_bin := c_variadic_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_c_variadic_alias_${os.getpid()}.v')
+	os.write_file(src, 'module main
+
+type Small = u8
+type Floaty = f32
+
+fn sink(args ...voidptr) int {
+	return args.len
+}
+
+fn main() {
+	println(int_str(sink(Small(7), Floaty(1.5))))
+}
+') or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_c_variadic_alias_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '2', run.output
+
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	assert generated.contains('int __vararg_storage_'), generated
+	assert generated.contains('double __vararg_storage_'), generated
+	assert !generated.contains('Small __vararg_storage_'), generated
+	assert !generated.contains('Floaty __vararg_storage_'), generated
+}

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -170,7 +170,7 @@ fn test_local_generic_type_with_qualified_arg_resolves_base_before_qualification
 	for node in a.nodes {
 		match node.kind {
 			.struct_decl {
-				if node.value.starts_with('Box__local_') {
+				if node.value.starts_with('Box@local@') {
 					local_decl_name = node.value
 				}
 			}
@@ -187,7 +187,7 @@ fn test_local_generic_type_with_qualified_arg_resolves_base_before_qualification
 			else {}
 		}
 	}
-	assert local_decl_name.starts_with('Box__local_main')
+	assert local_decl_name.starts_with('Box@local@main')
 	assert array_types == ['${local_decl_name}[other.Thing]']
 	assert init_types == ['${local_decl_name}[other.Thing]']
 }
@@ -199,10 +199,10 @@ fn test_local_sibling_types_are_predeclared_before_fields() {
 	mut local_b := ''
 	for node in a.nodes {
 		if node.kind == .struct_decl {
-			if node.value.starts_with('A__local_main') {
+			if node.value.starts_with('A@local@main') {
 				local_a = node.value
 			}
-			if node.value.starts_with('B__local_main') {
+			if node.value.starts_with('B@local@main') {
 				local_b = node.value
 			}
 		}
@@ -237,7 +237,7 @@ fn test_local_type_scope_names_do_not_collapse_punctuation() {
 		'module main\n\nstruct Foo {}\n\nfn (f Foo) bar() {\n\tstruct Row {\n\t\tmethod int\n\t}\n\t_ := Row{}\n}\n\nfn Foo_bar() {\n\tstruct Row {\n\t\tfunction int\n\t}\n\t_ := Row{}\n}\n')
 	mut row_names := []string{}
 	for node in a.nodes {
-		if node.kind == .struct_decl && node.value.starts_with('Row__local_') {
+		if node.kind == .struct_decl && node.value.starts_with('Row@local@') {
 			row_names << node.value
 		}
 	}

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -194,7 +194,7 @@ fn test_local_generic_type_with_qualified_arg_resolves_base_before_qualification
 
 fn test_local_sibling_types_are_predeclared_before_fields() {
 	a := parse_parser_regression_source('local_sibling_struct_fields',
-		'module main\n\nfn main() {\n\tstruct A {\n\t\tb &B\n\t}\n\tstruct B {\n\t\ta &A\n\t}\n}\n')
+		'module main\n\nfn main() {\n\t_ := []struct {\n\t\tn int\n\t}{}\n\tstruct A {\n\t\tb &B\n\t}\n\tstruct B {\n\t\ta &A\n\t}\n}\n')
 	mut local_a := ''
 	mut local_b := ''
 	for node in a.nodes {

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -191,3 +191,43 @@ fn test_local_generic_type_with_qualified_arg_resolves_base_before_qualification
 	assert array_types == ['${local_decl_name}[other.Thing]']
 	assert init_types == ['${local_decl_name}[other.Thing]']
 }
+
+fn test_local_sibling_types_are_predeclared_before_fields() {
+	a := parse_parser_regression_source('local_sibling_struct_fields',
+		'module main\n\nfn main() {\n\tstruct A {\n\t\tb &B\n\t}\n\tstruct B {\n\t\ta &A\n\t}\n}\n')
+	mut local_a := ''
+	mut local_b := ''
+	for node in a.nodes {
+		if node.kind == .struct_decl {
+			if node.value.starts_with('A__local_main') {
+				local_a = node.value
+			}
+			if node.value.starts_with('B__local_main') {
+				local_b = node.value
+			}
+		}
+	}
+	mut a_fields := []string{}
+	mut b_fields := []string{}
+	for node in a.nodes {
+		if node.kind != .struct_decl {
+			continue
+		}
+		for i in 0 .. node.children_count {
+			field := a.child_node(&node, i)
+			if field.kind != .field_decl {
+				continue
+			}
+			if node.value == local_a {
+				a_fields << '${field.value}:${field.typ}'
+			}
+			if node.value == local_b {
+				b_fields << '${field.value}:${field.typ}'
+			}
+		}
+	}
+	assert local_a.len > 0
+	assert local_b.len > 0
+	assert a_fields == ['b:&${local_b}']
+	assert b_fields == ['a:&${local_a}']
+}

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -160,3 +160,34 @@ fn test_sql_identifier_calls_are_not_parsed_as_sql_expr() {
 	assert sql_expr_count == 0
 	assert call_count == 1
 }
+
+fn test_local_generic_type_with_qualified_arg_resolves_base_before_qualification() {
+	a := parse_parser_regression_source('local_generic_qualified_arg',
+		'module main\n\nimport other\n\nfn main() {\n\tstruct Box[T] {}\n\tmut boxes := []Box[other.Thing]{}\n\tboxes << Box[other.Thing]{}\n}\n')
+	mut local_decl_name := ''
+	mut array_types := []string{}
+	mut init_types := []string{}
+	for node in a.nodes {
+		match node.kind {
+			.struct_decl {
+				if node.value.starts_with('Box__local_') {
+					local_decl_name = node.value
+				}
+			}
+			.array_init {
+				if node.value.contains('Box') {
+					array_types << node.value
+				}
+			}
+			.struct_init {
+				if node.value.contains('Box') {
+					init_types << node.value
+				}
+			}
+			else {}
+		}
+	}
+	assert local_decl_name.starts_with('Box__local_main')
+	assert array_types == ['${local_decl_name}[other.Thing]']
+	assert init_types == ['${local_decl_name}[other.Thing]']
+}

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -232,6 +232,19 @@ fn test_local_sibling_types_are_predeclared_before_fields() {
 	assert b_fields == ['a:&${local_a}']
 }
 
+fn test_local_type_scope_names_do_not_collapse_punctuation() {
+	a := parse_parser_regression_source('local_scope_punctuation_collision',
+		'module main\n\nstruct Foo {}\n\nfn (f Foo) bar() {\n\tstruct Row {\n\t\tmethod int\n\t}\n\t_ := Row{}\n}\n\nfn Foo_bar() {\n\tstruct Row {\n\t\tfunction int\n\t}\n\t_ := Row{}\n}\n')
+	mut row_names := []string{}
+	for node in a.nodes {
+		if node.kind == .struct_decl && node.value.starts_with('Row__local_') {
+			row_names << node.value
+		}
+	}
+	assert row_names.len == 2
+	assert row_names[0] != row_names[1]
+}
+
 fn test_multiline_keyword_infix_expressions_continue_after_semicolon() {
 	a := parse_parser_regression_source('multiline_keyword_infix',
 		'module main\n\nstruct Foo {}\n\nfn main() {\n\tvalue := Foo{}\n\tif value\n\t\tis Foo {}\n\txs := [1, 2]\n\tok := 1\n\t\tin xs\n\t_ := value\n\t\tas Foo\n\t_ = ok\n}\n')

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -231,3 +231,28 @@ fn test_local_sibling_types_are_predeclared_before_fields() {
 	assert a_fields == ['b:&${local_b}']
 	assert b_fields == ['a:&${local_a}']
 }
+
+fn test_multiline_keyword_infix_expressions_continue_after_semicolon() {
+	a := parse_parser_regression_source('multiline_keyword_infix',
+		'module main\n\nstruct Foo {}\n\nfn main() {\n\tvalue := Foo{}\n\tif value\n\t\tis Foo {}\n\txs := [1, 2]\n\tok := 1\n\t\tin xs\n\t_ := value\n\t\tas Foo\n\t_ = ok\n}\n')
+	mut is_count := 0
+	mut in_count := 0
+	mut as_count := 0
+	for node in a.nodes {
+		match node.kind {
+			.is_expr {
+				is_count++
+			}
+			.in_expr {
+				in_count++
+			}
+			.as_expr {
+				as_count++
+			}
+			else {}
+		}
+	}
+	assert is_count == 1
+	assert in_count == 1
+	assert as_count == 1
+}

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -192,6 +192,41 @@ fn test_local_generic_type_with_qualified_arg_resolves_base_before_qualification
 	assert init_types == ['${local_decl_name}[other.Thing]']
 }
 
+fn test_local_type_generic_call_type_arg_is_resolved() {
+	a := parse_parser_regression_source('local_generic_call_type_arg',
+		'module main\n\nfn id[T](x T) T {\n\treturn x\n}\n\nfn main() {\n\tstruct Row {\n\t\tn int\n\t}\n\t_ := id[Row](Row{\n\t\tn: 1\n\t})\n}\n')
+	mut local_row := ''
+	mut call_type_args := []string{}
+	mut init_types := []string{}
+	for node in a.nodes {
+		match node.kind {
+			.struct_decl {
+				if node.value.starts_with('Row@local@') {
+					local_row = node.value
+				}
+			}
+			.index {
+				if node.children_count == 2 {
+					base := a.child_node(&node, 0)
+					arg := a.child_node(&node, 1)
+					if base.kind == .ident && base.value == 'id' {
+						call_type_args << arg.value
+					}
+				}
+			}
+			.struct_init {
+				if node.value.contains('Row') {
+					init_types << node.value
+				}
+			}
+			else {}
+		}
+	}
+	assert local_row.starts_with('Row@local@main')
+	assert call_type_args == [local_row]
+	assert init_types == [local_row]
+}
+
 fn test_local_sibling_types_are_predeclared_before_fields() {
 	a := parse_parser_regression_source('local_sibling_struct_fields',
 		'module main\n\nfn main() {\n\t_ := []struct {\n\t\tn int\n\t}{}\n\tstruct A {\n\t\tb &B\n\t}\n\tstruct B {\n\t\ta &A\n\t}\n}\n')

--- a/vlib/v3/tests/pseudo_vars_codegen_test.v
+++ b/vlib/v3/tests/pseudo_vars_codegen_test.v
@@ -25,6 +25,21 @@ fn test_at_mod_codegen() {
 	assert module_test_result.exit_code == 0, module_test_result.output
 }
 
+fn test_at_file_line_codegen_uses_source_line() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_file_line_codegen_test')
+	build := os.execute('${vexe} -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	main_src := os.join_path(os.temp_dir(), 'v3_file_line_main.v')
+	main_bin := os.join_path(os.temp_dir(), 'v3_file_line_main')
+	os.write_file(main_src,
+		"fn main() {\n\tgot, expected := @FILE_LINE, @FILE + ':' + @LINE.str()\n\tassert got == expected\n\tassert !got.ends_with(':0')\n}\n")!
+	main_result := os.execute('${v3_bin} ${main_src} -o ${main_bin}')
+	assert main_result.exit_code == 0, main_result.output
+	run := os.execute(main_bin)
+	assert run.exit_code == 0, run.output
+}
+
 // test_embed_file_codegen validates that v3 lowers $embed_file to EmbedFileData.
 fn test_embed_file_codegen() {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_embed_file_codegen_test')

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -523,6 +523,9 @@ fn test_voidptr_variadic_spread_requires_voidptr_array() {
 	run_bad(v3_bin, 'bad_voidptr_variadic_multi_return_arg',
 		'fn pair() (int, int) {\n\treturn 1, 2\n}\n\nfn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\tprintln(int_str(sink(pair())))\n}\n',
 		'cannot use `(int, int)`')
+	run_bad(v3_bin, 'bad_voidptr_variadic_enum_shorthand_arg',
+		'enum Color {\n\tred\n}\n\nfn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\tprintln(int_str(sink(.red)))\n}\n',
+		'cannot use `int`')
 	good := run_good(v3_bin, 'good_voidptr_variadic_voidptr_spread',
 		'fn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\tx := 7\n\txs := [voidptr(&x)]\n\tprintln(int_str(sink(...xs)))\n\tprintln(int_str(sink(1)))\n}\n')
 	assert good == '1\n1'

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -403,6 +403,15 @@ fn test_multi_return_if_tail_infers_common_type() {
 	numeric_tail := run_good(v3_bin, 'good_multi_return_if_promoted_numeric_tail',
 		'fn main() {\n\tcond := false\n\tx, _ := if cond {\n\t\t1\n\t\t0\n\t} else {\n\t\t1.5\n\t\t0\n\t}\n\tprintln(typeof(x).name)\n\tprintln((x > 1.4).str())\n}\n')
 	assert numeric_tail == 'f64\ntrue'
+	call_decl_assign := run_good(v3_bin, 'good_multi_return_if_call_decl_assign',
+		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn main() {\n\tflag := false\n\ta, b := if flag {\n\t\tpair(1)\n\t} else {\n\t\tpair(3)\n\t}\n\tprintln(int_str(a + b))\n}\n')
+	assert call_decl_assign == '7'
+	call_assign := run_good(v3_bin, 'good_multi_return_if_call_assign',
+		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn main() {\n\tflag := false\n\tmut a := 0\n\tmut b := 0\n\ta, b = if flag {\n\t\tpair(1)\n\t} else {\n\t\tpair(3)\n\t}\n\tprintln(int_str(a + b))\n}\n')
+	assert call_assign == '7'
+	run_bad(v3_bin, 'bad_multi_return_if_call_mixed_tuple_tail_decl_assign',
+		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn main() {\n\tflag := true\n\ta, b := if flag {\n\t\tpair(1)\n\t} else {\n\t\t3\n\t\t4\n\t}\n\tprintln(int_str(a + b))\n}\n',
+		'multi-return assignment mismatch')
 }
 
 fn test_multi_return_if_assignment_uses_lhs_context() {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -399,7 +399,10 @@ fn test_multi_return_if_tail_infers_common_type() {
 	v3_bin := build_v3()
 	if_tail := run_good(v3_bin, 'good_multi_return_if_common_pointer_tail',
 		'fn main() {\n\tx := 7\n\tp, n := if false {\n\t\tnil\n\t\t0\n\t} else {\n\t\t&x\n\t\t1\n\t}\n\tprintln(typeof(p).name)\n\tprintln(int_str(n))\n}\n')
-	assert if_tail == 'voidptr\n1'
+	assert if_tail == '&void\n1'
+	numeric_tail := run_good(v3_bin, 'good_multi_return_if_promoted_numeric_tail',
+		'fn main() {\n\tcond := false\n\tx, _ := if cond {\n\t\t1\n\t\t0\n\t} else {\n\t\t1.5\n\t\t0\n\t}\n\tprintln(typeof(x).name)\n\tprintln((x > 1.4).str())\n}\n')
+	assert numeric_tail == 'f64\ntrue'
 }
 
 fn test_nested_if_tuple_tail_multi_return_lowers_each_value() {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -405,6 +405,13 @@ fn test_multi_return_if_tail_infers_common_type() {
 	assert numeric_tail == 'f64\ntrue'
 }
 
+fn test_multi_return_if_assignment_uses_lhs_context() {
+	v3_bin := build_v3()
+	enum_tail := run_good(v3_bin, 'good_multi_return_if_assign_enum_and_none_tail',
+		"enum Color {\n\tred\n\tblue\n}\n\nfn main() {\n\tcond := false\n\tmut c := Color.red\n\tmut n := 0\n\tc, n = if cond {\n\t\t.red\n\t\t1\n\t} else {\n\t\t.blue\n\t\t2\n\t}\n\tmut opt := ?int(0)\n\tmut label := ''\n\topt, label = if cond {\n\t\tnone\n\t\t'none'\n\t} else {\n\t\t?int(7)\n\t\t'some'\n\t}\n\tvalue := opt or { 0 }\n\tif c == .blue && label == 'some' {\n\t\tprintln(int_str(n + value))\n\t}\n}\n")
+	assert enum_tail == '9'
+}
+
 fn test_nested_if_tuple_tail_multi_return_lowers_each_value() {
 	v3_bin := build_v3()
 	nested_if_tail := run_good(v3_bin, 'good_nested_if_tail_decl_assign',
@@ -466,6 +473,9 @@ fn test_local_type_names_include_nested_block_scope() {
 	embedded_local := run_good(v3_bin, 'good_local_embedded_struct_field',
 		'fn main() {\n\tstruct Inner {\n\t\tn int\n\t}\n\tstruct Outer {\n\t\tInner\n\t}\n\touter := Outer{\n\t\tInner{\n\t\t\tn: 12\n\t\t}\n\t}\n\tprintln(int_str(outer.n))\n}\n')
 	assert embedded_local == '12'
+	local_generic_arg := run_good(v3_bin, 'good_local_generic_struct_init_local_arg',
+		"fn main() {\n\tstruct Inner {}\n\tstruct Box[T] {}\n\t_ := Box[Inner]{}\n\tprintln('ok')\n}\n")
+	assert local_generic_arg == 'ok'
 }
 
 fn test_bool_match_single_branch_is_exhaustive() {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -402,6 +402,23 @@ fn test_multi_return_if_tail_infers_common_type() {
 	assert if_tail == 'voidptr\n1'
 }
 
+fn test_bool_match_single_branch_is_exhaustive() {
+	v3_bin := build_v3()
+	out := run_good(v3_bin, 'good_bool_match_single_branch_exhaustive',
+		'fn f(b bool) int {\n\tmatch b {\n\t\ttrue, false {\n\t\t\treturn 1\n\t\t}\n\t}\n}\n\nfn main() {\n\tprintln(int_str(f(true) + f(false)))\n}\n')
+	assert out == '2'
+}
+
+fn test_voidptr_variadic_spread_requires_voidptr_array() {
+	v3_bin := build_v3()
+	run_bad(v3_bin, 'bad_voidptr_variadic_int_spread',
+		'fn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\txs := [1, 2]\n\tprintln(int_str(sink(...xs)))\n}\n',
+		'expected `[]&void`')
+	good := run_good(v3_bin, 'good_voidptr_variadic_voidptr_spread',
+		'fn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\tx := 7\n\txs := [voidptr(&x)]\n\tprintln(int_str(sink(...xs)))\n\tprintln(int_str(sink(1)))\n}\n')
+	assert good == '1\n1'
+}
+
 // Regression tests for the post-PR review fixes around generic struct receivers
 // and generic heap struct literals.
 fn test_generic_struct_receiver_and_heap_init() {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -412,6 +412,9 @@ fn test_multi_return_if_tail_infers_common_type() {
 	run_bad(v3_bin, 'bad_multi_return_if_call_mixed_tuple_tail_decl_assign',
 		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn main() {\n\tflag := true\n\ta, b := if flag {\n\t\tpair(1)\n\t} else {\n\t\t3\n\t\t4\n\t}\n\tprintln(int_str(a + b))\n}\n',
 		'multi-return assignment mismatch')
+	run_bad(v3_bin, 'bad_multi_return_if_void_tail_decl_assign',
+		'fn side() {}\nfn main() {\n\tflag := true\n\ta, b := if flag {\n\t\tside()\n\t\t1\n\t} else {\n\t\tside()\n\t\t2\n\t}\n\tprintln(int_str(b))\n}\n',
+		'multi-return assignment mismatch')
 }
 
 fn test_multi_return_if_assignment_uses_lhs_context() {
@@ -468,6 +471,9 @@ fn test_match_tuple_tail_multi_return_is_rejected() {
 	match_assign := run_good(v3_bin, 'good_multi_return_match_call_assign',
 		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn main() {\n\tflag := false\n\tmut a := 0\n\tmut b := 0\n\ta, b = match flag {\n\t\ttrue {\n\t\t\tpair(1)\n\t\t}\n\t\tfalse {\n\t\t\tpair(3)\n\t\t}\n\t}\n\tprintln(int_str(a + b))\n}\n')
 	assert match_assign == '7'
+	run_bad(v3_bin, 'bad_multi_return_match_call_mixed_item_types',
+		'fn pair_int() (int, int) {\n\treturn 1, 2\n}\nfn pair_f64() (f64, int) {\n\treturn 1.5, 2\n}\nfn main() {\n\tflag := true\n\ta, b := match flag {\n\t\ttrue {\n\t\t\tpair_int()\n\t\t}\n\t\tfalse {\n\t\t\tpair_f64()\n\t\t}\n\t}\n\tprintln(int_str(b))\n\tprintln(a)\n}\n',
+		'multi-return assignment mismatch')
 	run_bad(v3_bin, 'bad_multi_return_match_tail_decl_assign',
 		'fn main() {\n\tflag := true\n\ta, b := match flag {\n\t\ttrue {\n\t\t\t1\n\t\t\t2\n\t\t}\n\t\tfalse {\n\t\t\t3\n\t\t\t4\n\t\t}\n\t}\n\tprintln(int_str(a + b))\n}\n',
 		'match expression branches cannot produce multiple assignment values')

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -1084,3 +1084,13 @@ fn test_pr_review_codegen_batch_twentysix() {
 		"fn f() ?[2]int {\n\tdefer {\n\t\t_ := 0\n\t}\n\treturn [1, 2]!\n}\nfn main() {\n\ta := f() or { [0, 0]! }\n\tprintln(int_str(a[0]) + ',' + int_str(a[1]))\n}\n")
 	assert defer_opt_arr == '1,2'
 }
+
+fn test_pr_review_codegen_batch_twentyseven() {
+	v3_bin := build_v3()
+	// Local type names declared inside sibling function literals must include a closure
+	// discriminator. Both closures declare `Row` with different fields; the outer local `Shared`
+	// remains visible from both closure scopes.
+	local_rows := run_good(v3_bin, 'good_fn_literal_local_struct_scope',
+		'fn main() {\n\tstruct Shared {\n\t\tn int\n\t}\n\tfirst := fn () int {\n\t\tstruct Row {\n\t\t\ta int\n\t\t}\n\t\ts := Shared{\n\t\t\tn: 10\n\t\t}\n\t\tr := Row{\n\t\t\ta: 1\n\t\t}\n\t\treturn s.n + r.a\n\t}\n\tsecond := fn () int {\n\t\tstruct Row {\n\t\t\tb int\n\t\t}\n\t\ts := Shared{\n\t\t\tn: 20\n\t\t}\n\t\tr := Row{\n\t\t\tb: 2\n\t\t}\n\t\treturn s.n + r.b\n\t}\n\tprintln(int_str(first() + second()))\n}\n')
+	assert local_rows == '33'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -402,6 +402,13 @@ fn test_multi_return_if_tail_infers_common_type() {
 	assert if_tail == 'voidptr\n1'
 }
 
+fn test_nested_if_tuple_tail_multi_return_lowers_each_value() {
+	v3_bin := build_v3()
+	nested_if_tail := run_good(v3_bin, 'good_nested_if_tail_decl_assign',
+		'fn main() {\n\tc := true\n\td := false\n\ta, b := if c {\n\t\tif d {\n\t\t\t1\n\t\t\t2\n\t\t} else {\n\t\t\t3\n\t\t\t4\n\t\t}\n\t} else {\n\t\t5\n\t\t6\n\t}\n\tprintln(int_str(a + b))\n}\n')
+	assert nested_if_tail == '7'
+}
+
 fn test_multi_rhs_if_expr_is_not_multi_return() {
 	v3_bin := build_v3()
 	decl_out := run_good(v3_bin, 'good_multi_rhs_if_expr_decl_assign',
@@ -427,6 +434,13 @@ fn test_return_if_tuple_tail_multi_return_is_rejected() {
 	run_bad(v3_bin, 'bad_multi_return_if_tail_return',
 		'fn pair(flag bool) (int, int) {\n\treturn if flag {\n\t\t1\n\t\t2\n\t} else {\n\t\t3\n\t\t4\n\t}\n}\nfn main() {\n\ta, b := pair(true)\n\tprintln(int_str(a + b))\n}\n',
 		'if expression branches cannot produce multiple return values')
+}
+
+fn test_local_type_names_include_nested_block_scope() {
+	v3_bin := build_v3()
+	block_rows := run_good(v3_bin, 'good_local_struct_sibling_block_scope',
+		'fn main() {\n\tmut total := 0\n\tif true {\n\t\tstruct Row {\n\t\t\ta int\n\t\t}\n\t\tr := Row{\n\t\t\ta: 1\n\t\t}\n\t\ttotal += r.a\n\t}\n\tif true {\n\t\tstruct Row {\n\t\t\tb int\n\t\t}\n\t\tr := Row{\n\t\t\tb: 2\n\t\t}\n\t\ttotal += r.b\n\t}\n\tprintln(int_str(total))\n}\n')
+	assert block_rows == '3'
 }
 
 fn test_bool_match_single_branch_is_exhaustive() {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -402,6 +402,16 @@ fn test_multi_return_if_tail_infers_common_type() {
 	assert if_tail == 'voidptr\n1'
 }
 
+fn test_multi_rhs_if_expr_is_not_multi_return() {
+	v3_bin := build_v3()
+	decl_out := run_good(v3_bin, 'good_multi_rhs_if_expr_decl_assign',
+		'fn main() {\n\tcond := true\n\ta, b := if cond { 1 } else { 2 }, 3\n\tprintln(int_str(a + b))\n}\n')
+	assert decl_out == '4'
+	assign_out := run_good(v3_bin, 'good_multi_rhs_if_expr_assign',
+		'fn main() {\n\tcond := false\n\tmut a := 0\n\tmut b := 0\n\ta, b = if cond { 1 } else { 2 }, 3\n\tprintln(int_str(a + b))\n}\n')
+	assert assign_out == '5'
+}
+
 fn test_bool_match_single_branch_is_exhaustive() {
 	v3_bin := build_v3()
 	out := run_good(v3_bin, 'good_bool_match_single_branch_exhaustive',

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -485,6 +485,9 @@ fn test_local_type_names_include_nested_block_scope() {
 	local_generic_arg := run_good(v3_bin, 'good_local_generic_struct_init_local_arg',
 		"fn main() {\n\tstruct Inner {}\n\tstruct Box[T] {}\n\t_ := Box[Inner]{}\n\tprintln('ok')\n}\n")
 	assert local_generic_arg == 'ok'
+	mutual_local := run_good(v3_bin, 'good_local_mutual_struct_pointer_fields',
+		"fn main() {\n\tstruct A {\n\t\tb &B\n\t}\n\tstruct B {\n\t\ta &A\n\t}\n\ta := A{}\n\t_ := B{\n\t\ta: &a\n\t}\n\tprintln('ok')\n}\n")
+	assert mutual_local == 'ok'
 }
 
 fn test_bool_match_single_branch_is_exhaustive() {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -419,6 +419,9 @@ fn test_multi_return_if_assignment_uses_lhs_context() {
 	enum_tail := run_good(v3_bin, 'good_multi_return_if_assign_enum_and_none_tail',
 		"enum Color {\n\tred\n\tblue\n}\n\nfn main() {\n\tcond := false\n\tmut c := Color.red\n\tmut n := 0\n\tc, n = if cond {\n\t\t.red\n\t\t1\n\t} else {\n\t\t.blue\n\t\t2\n\t}\n\tmut opt := ?int(0)\n\tmut label := ''\n\topt, label = if cond {\n\t\tnone\n\t\t'none'\n\t} else {\n\t\t?int(7)\n\t\t'some'\n\t}\n\tvalue := opt or { 0 }\n\tif c == .blue && label == 'some' {\n\t\tprintln(int_str(n + value))\n\t}\n}\n")
 	assert enum_tail == '9'
+	swap_tail := run_good(v3_bin, 'good_multi_return_if_assign_stages_tail_values',
+		"fn main() {\n\tcond := true\n\tmut a := 1\n\tmut b := 2\n\ta, b = if cond {\n\t\tb\n\t\ta\n\t} else {\n\t\ta\n\t\tb\n\t}\n\tprintln(int_str(a) + ':' + int_str(b))\n}\n")
+	assert swap_tail == '2:1'
 }
 
 fn test_nested_if_tuple_tail_multi_return_lowers_each_value() {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -423,6 +423,9 @@ fn test_multi_return_if_returning_branches_do_not_produce_assignment_values() {
 	bare_return := run_good(v3_bin, 'good_multi_return_if_branch_bare_return',
 		"fn emit(cond bool) {\n\ta, b := if cond {\n\t\treturn\n\t} else {\n\t\t3\n\t\t4\n\t}\n\tprintln(int_str(a + b))\n}\n\nfn main() {\n\temit(false)\n\tprintln('done')\n}\n")
 	assert bare_return == '7\ndone'
+	panic_branch := run_good(v3_bin, 'good_multi_return_if_branch_panic_tail',
+		"fn main() {\n\tbad := false\n\ta, b := if bad {\n\t\tpanic('x')\n\t} else {\n\t\t5\n\t\t6\n\t}\n\tprintln(int_str(a + b))\n}\n")
+	assert panic_branch == '11'
 }
 
 fn test_multi_rhs_if_expr_is_not_multi_return() {
@@ -480,6 +483,9 @@ fn test_voidptr_variadic_spread_requires_voidptr_array() {
 	run_bad(v3_bin, 'bad_voidptr_variadic_void_arg',
 		'fn side() {}\n\nfn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\tprintln(int_str(sink(side())))\n}\n',
 		'cannot use `void`')
+	run_bad(v3_bin, 'bad_voidptr_variadic_none_arg',
+		'fn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\tprintln(int_str(sink(none)))\n}\n',
+		'cannot use `?void`')
 	good := run_good(v3_bin, 'good_voidptr_variadic_voidptr_spread',
 		'fn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\tx := 7\n\txs := [voidptr(&x)]\n\tprintln(int_str(sink(...xs)))\n\tprintln(int_str(sink(1)))\n}\n')
 	assert good == '1\n1'

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -422,6 +422,13 @@ fn test_match_tuple_tail_multi_return_is_rejected() {
 		'match expression branches cannot produce multiple return values')
 }
 
+fn test_return_if_tuple_tail_multi_return_is_rejected() {
+	v3_bin := build_v3()
+	run_bad(v3_bin, 'bad_multi_return_if_tail_return',
+		'fn pair(flag bool) (int, int) {\n\treturn if flag {\n\t\t1\n\t\t2\n\t} else {\n\t\t3\n\t\t4\n\t}\n}\nfn main() {\n\ta, b := pair(true)\n\tprintln(int_str(a + b))\n}\n',
+		'if expression branches cannot produce multiple return values')
+}
+
 fn test_bool_match_single_branch_is_exhaustive() {
 	v3_bin := build_v3()
 	out := run_good(v3_bin, 'good_bool_match_single_branch_exhaustive',

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -395,6 +395,13 @@ fn test_statement_if_branch_tails_are_not_value_checked() {
 		'if-expression branch type mismatch')
 }
 
+fn test_multi_return_if_tail_infers_common_type() {
+	v3_bin := build_v3()
+	if_tail := run_good(v3_bin, 'good_multi_return_if_common_pointer_tail',
+		'fn main() {\n\tx := 7\n\tp, n := if false {\n\t\tnil\n\t\t0\n\t} else {\n\t\t&x\n\t\t1\n\t}\n\tprintln(typeof(p).name)\n\tprintln(int_str(n))\n}\n')
+	assert if_tail == 'voidptr\n1'
+}
+
 // Regression tests for the post-PR review fixes around generic struct receivers
 // and generic heap struct literals.
 fn test_generic_struct_receiver_and_heap_init() {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -421,6 +421,9 @@ fn test_multi_rhs_if_expr_is_not_multi_return() {
 
 fn test_match_tuple_tail_multi_return_is_rejected() {
 	v3_bin := build_v3()
+	match_call := run_good(v3_bin, 'good_multi_return_match_call_return',
+		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn pick(flag bool) (int, int) {\n\treturn match flag {\n\t\ttrue {\n\t\t\tpair(1)\n\t\t}\n\t\tfalse {\n\t\t\tpair(3)\n\t\t}\n\t}\n}\nfn main() {\n\ta, b := pick(false)\n\tprintln(int_str(a + b))\n}\n')
+	assert match_call == '7'
 	run_bad(v3_bin, 'bad_multi_return_match_tail_decl_assign',
 		'fn main() {\n\tflag := true\n\ta, b := match flag {\n\t\ttrue {\n\t\t\t1\n\t\t\t2\n\t\t}\n\t\tfalse {\n\t\t\t3\n\t\t\t4\n\t\t}\n\t}\n\tprintln(int_str(a + b))\n}\n',
 		'match expression branches cannot produce multiple assignment values')

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -410,6 +410,9 @@ fn test_nested_if_tuple_tail_multi_return_lowers_each_value() {
 	nested_if_tail := run_good(v3_bin, 'good_nested_if_tail_decl_assign',
 		'fn main() {\n\tc := true\n\td := false\n\ta, b := if c {\n\t\tif d {\n\t\t\t1\n\t\t\t2\n\t\t} else {\n\t\t\t3\n\t\t\t4\n\t\t}\n\t} else {\n\t\t5\n\t\t6\n\t}\n\tprintln(int_str(a + b))\n}\n')
 	assert nested_if_tail == '7'
+	prefixed_block_tail := run_good(v3_bin, 'good_prefixed_nested_block_tail_decl_assign',
+		"fn main() {\n\tc := true\n\ta, b := if c {\n\t\t{\n\t\t\tprintln('side')\n\t\t\t1\n\t\t\t2\n\t\t}\n\t} else {\n\t\t3\n\t\t4\n\t}\n\tprintln(int_str(a + b))\n}\n")
+	assert prefixed_block_tail == 'side\n3'
 }
 
 fn test_multi_rhs_if_expr_is_not_multi_return() {
@@ -447,6 +450,9 @@ fn test_local_type_names_include_nested_block_scope() {
 	block_rows := run_good(v3_bin, 'good_local_struct_sibling_block_scope',
 		'fn main() {\n\tmut total := 0\n\tif true {\n\t\tstruct Row {\n\t\t\ta int\n\t\t}\n\t\tr := Row{\n\t\t\ta: 1\n\t\t}\n\t\ttotal += r.a\n\t}\n\tif true {\n\t\tstruct Row {\n\t\t\tb int\n\t\t}\n\t\tr := Row{\n\t\t\tb: 2\n\t\t}\n\t\ttotal += r.b\n\t}\n\tprintln(int_str(total))\n}\n')
 	assert block_rows == '3'
+	embedded_local := run_good(v3_bin, 'good_local_embedded_struct_field',
+		'fn main() {\n\tstruct Inner {\n\t\tn int\n\t}\n\tstruct Outer {\n\t\tInner\n\t}\n\touter := Outer{\n\t\tInner{\n\t\t\tn: 12\n\t\t}\n\t}\n\tprintln(int_str(outer.n))\n}\n')
+	assert embedded_local == '12'
 }
 
 fn test_bool_match_single_branch_is_exhaustive() {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -412,6 +412,16 @@ fn test_multi_rhs_if_expr_is_not_multi_return() {
 	assert assign_out == '5'
 }
 
+fn test_match_tuple_tail_multi_return_is_rejected() {
+	v3_bin := build_v3()
+	run_bad(v3_bin, 'bad_multi_return_match_tail_decl_assign',
+		'fn main() {\n\tflag := true\n\ta, b := match flag {\n\t\ttrue {\n\t\t\t1\n\t\t\t2\n\t\t}\n\t\tfalse {\n\t\t\t3\n\t\t\t4\n\t\t}\n\t}\n\tprintln(int_str(a + b))\n}\n',
+		'match expression branches cannot produce multiple assignment values')
+	run_bad(v3_bin, 'bad_multi_return_match_tail_return',
+		'fn pair(flag bool) (int, int) {\n\treturn match flag {\n\t\ttrue {\n\t\t\t1\n\t\t\t2\n\t\t}\n\t\tfalse {\n\t\t\t3\n\t\t\t4\n\t\t}\n\t}\n}\nfn main() {\n\ta, b := pair(true)\n\tprintln(int_str(a + b))\n}\n',
+		'match expression branches cannot produce multiple return values')
+}
+
 fn test_bool_match_single_branch_is_exhaustive() {
 	v3_bin := build_v3()
 	out := run_good(v3_bin, 'good_bool_match_single_branch_exhaustive',

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -495,6 +495,9 @@ fn test_bool_match_single_branch_is_exhaustive() {
 	out := run_good(v3_bin, 'good_bool_match_single_branch_exhaustive',
 		'fn f(b bool) int {\n\tmatch b {\n\t\ttrue, false {\n\t\t\treturn 1\n\t\t}\n\t}\n}\n\nfn main() {\n\tprintln(int_str(f(true) + f(false)))\n}\n')
 	assert out == '2'
+	alias_out := run_good(v3_bin, 'good_bool_alias_match_single_branch_exhaustive',
+		'type Flag = bool\nfn f(b Flag) int {\n\tmatch b {\n\t\ttrue, false {\n\t\t\treturn 1\n\t\t}\n\t}\n}\n\nfn main() {\n\tprintln(int_str(f(true) + f(false)))\n}\n')
+	assert alias_out == '2'
 }
 
 fn test_voidptr_variadic_spread_requires_voidptr_array() {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -474,6 +474,12 @@ fn test_match_tuple_tail_multi_return_is_rejected() {
 	match_assign := run_good(v3_bin, 'good_multi_return_match_call_assign',
 		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn main() {\n\tflag := false\n\tmut a := 0\n\tmut b := 0\n\ta, b = match flag {\n\t\ttrue {\n\t\t\tpair(1)\n\t\t}\n\t\tfalse {\n\t\t\tpair(3)\n\t\t}\n\t}\n\tprintln(int_str(a + b))\n}\n')
 	assert match_assign == '7'
+	run_bad(v3_bin, 'bad_multi_return_match_call_non_exhaustive_decl_assign',
+		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn main() {\n\tflag := true\n\ta, b := match flag {\n\t\ttrue {\n\t\t\tpair(1)\n\t\t}\n\t}\n\tprintln(int_str(a + b))\n}\n',
+		'match expression must be exhaustive')
+	run_bad(v3_bin, 'bad_multi_return_match_call_non_exhaustive_assign',
+		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn main() {\n\tflag := true\n\tmut a := 0\n\tmut b := 0\n\ta, b = match flag {\n\t\ttrue {\n\t\t\tpair(1)\n\t\t}\n\t}\n\tprintln(int_str(a + b))\n}\n',
+		'match expression must be exhaustive')
 	run_bad(v3_bin, 'bad_multi_return_match_call_mixed_item_types',
 		'fn pair_int() (int, int) {\n\treturn 1, 2\n}\nfn pair_f64() (f64, int) {\n\treturn 1.5, 2\n}\nfn main() {\n\tflag := true\n\ta, b := match flag {\n\t\ttrue {\n\t\t\tpair_int()\n\t\t}\n\t\tfalse {\n\t\t\tpair_f64()\n\t\t}\n\t}\n\tprintln(int_str(b))\n\tprintln(a)\n}\n',
 		'multi-return assignment mismatch')
@@ -519,6 +525,9 @@ fn test_bool_match_single_branch_is_exhaustive() {
 	alias_out := run_good(v3_bin, 'good_bool_alias_match_single_branch_exhaustive',
 		'type Flag = bool\nfn f(b Flag) int {\n\tmatch b {\n\t\ttrue, false {\n\t\t\treturn 1\n\t\t}\n\t}\n}\n\nfn main() {\n\tprintln(int_str(f(true) + f(false)))\n}\n')
 	assert alias_out == '2'
+	run_bad(v3_bin, 'bad_bool_pointer_match_not_exhaustive',
+		'fn f(b &bool) int {\n\tmatch b {\n\t\ttrue, false {\n\t\t\treturn 1\n\t\t}\n\t}\n}\n\nfn main() {\n\tmut b := true\n\tprintln(int_str(f(&b)))\n}\n',
+		'missing return')
 }
 
 fn test_voidptr_variadic_spread_requires_voidptr_array() {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -415,6 +415,16 @@ fn test_nested_if_tuple_tail_multi_return_lowers_each_value() {
 	assert prefixed_block_tail == 'side\n3'
 }
 
+fn test_multi_return_if_returning_branches_do_not_produce_assignment_values() {
+	v3_bin := build_v3()
+	return_values := run_good(v3_bin, 'good_multi_return_if_branch_return_values',
+		"fn choose(cond bool) (string, string) {\n\ta, b := if cond {\n\t\treturn 'x', 'y'\n\t} else {\n\t\t1\n\t\t2\n\t}\n\treturn int_str(a), int_str(b)\n}\n\nfn main() {\n\ta, b := choose(false)\n\tprintln(a + ':' + b)\n\tc, d := choose(true)\n\tprintln(c + ':' + d)\n}\n")
+	assert return_values == '1:2\nx:y'
+	bare_return := run_good(v3_bin, 'good_multi_return_if_branch_bare_return',
+		"fn emit(cond bool) {\n\ta, b := if cond {\n\t\treturn\n\t} else {\n\t\t3\n\t\t4\n\t}\n\tprintln(int_str(a + b))\n}\n\nfn main() {\n\temit(false)\n\tprintln('done')\n}\n")
+	assert bare_return == '7\ndone'
+}
+
 fn test_multi_rhs_if_expr_is_not_multi_return() {
 	v3_bin := build_v3()
 	decl_out := run_good(v3_bin, 'good_multi_rhs_if_expr_decl_assign',
@@ -467,6 +477,9 @@ fn test_voidptr_variadic_spread_requires_voidptr_array() {
 	run_bad(v3_bin, 'bad_voidptr_variadic_int_spread',
 		'fn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\txs := [1, 2]\n\tprintln(int_str(sink(...xs)))\n}\n',
 		'expected `[]&void`')
+	run_bad(v3_bin, 'bad_voidptr_variadic_void_arg',
+		'fn side() {}\n\nfn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\tprintln(int_str(sink(side())))\n}\n',
+		'cannot use `void`')
 	good := run_good(v3_bin, 'good_voidptr_variadic_voidptr_spread',
 		'fn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\tx := 7\n\txs := [voidptr(&x)]\n\tprintln(int_str(sink(...xs)))\n\tprintln(int_str(sink(1)))\n}\n')
 	assert good == '1\n1'

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -186,6 +186,9 @@ fn test_type_checker_reports_core_semantic_errors() {
 	run_bad(v3_bin, 'bad_interface_field',
 		'interface Named {\n\tname string\n}\nstruct Person {}\nfn takes_named(n Named) {}\nfn main() {\n\ttakes_named(Person{})\n}\n',
 		'cannot use `Person` as argument 1 to `takes_named`; expected `Named`')
+	alias_interface_out := run_good(v3_bin, 'alias_receiver_implements_interface',
+		"type Text = string\n\nfn (t Text) display() string {\n\treturn t\n}\n\ninterface Displayable {\n\tdisplay() string\n}\n\nfn print_displayable(ds ...Displayable) {\n\tfor d in ds {\n\t\tprintln(d.display())\n\t}\n}\n\nfn main() {\n\tprint_displayable(Text('test'), Text('hehe'))\n}\n")
+	assert alias_interface_out == 'test\nhehe'
 	run_bad(v3_bin, 'bad_sum_missing_shared_field',
 		'struct A {\n\tid int\n}\nstruct B {\n\tname string\n}\ntype Node = A | B\nfn main() {\n\tn := Node(A{\n\t\tid: 1\n\t})\n\t_ := n.id\n}\n',
 		'unknown field `id` on `Node`')
@@ -1187,4 +1190,18 @@ fn test_pr_review_codegen_batch_twentyseven() {
 	local_rows := run_good(v3_bin, 'good_fn_literal_local_struct_scope',
 		'fn main() {\n\tstruct Shared {\n\t\tn int\n\t}\n\tfirst := fn () int {\n\t\tstruct Row {\n\t\t\ta int\n\t\t}\n\t\ts := Shared{\n\t\t\tn: 10\n\t\t}\n\t\tr := Row{\n\t\t\ta: 1\n\t\t}\n\t\treturn s.n + r.a\n\t}\n\tsecond := fn () int {\n\t\tstruct Row {\n\t\t\tb int\n\t\t}\n\t\ts := Shared{\n\t\t\tn: 20\n\t\t}\n\t\tr := Row{\n\t\t\tb: 2\n\t\t}\n\t\treturn s.n + r.b\n\t}\n\tprintln(int_str(first() + second()))\n}\n')
 	assert local_rows == '33'
+}
+
+fn test_pr_review_codegen_batch_twentyeight() {
+	v3_bin := build_v3()
+	// `char` values passed through `...voidptr` use the same int-width storage as other small
+	// integer varargs, so callees that read `%c`/small-integer slots do not read past the value.
+	char_vararg := run_good(v3_bin, 'good_voidptr_variadic_char_promotes_to_int',
+		'fn sink(args ...voidptr) int {\n\treturn unsafe { *(&int(args[0])) }\n}\nfn main() {\n\tch := char(66)\n\tprintln(int_str(sink(ch)))\n}\n')
+	assert char_vararg == '66'
+	// A local type's synthesized name uses an internal marker, so a user-written top-level type
+	// that matched the old underscore-only spelling cannot overwrite the local declaration.
+	local_collision := run_good(v3_bin, 'good_local_type_name_avoids_user_collision',
+		'struct Row__local_make {\n\tglobal int\n}\nfn make() int {\n\tstruct Row {\n\t\tlocal int\n\t}\n\tlocal := Row{\n\t\tlocal: 3\n\t}\n\tglobal := Row__local_make{\n\t\tglobal: 4\n\t}\n\treturn local.local + global.global\n}\nfn main() {\n\tprintln(int_str(make()))\n}\n')
+	assert local_collision == '7'
 }

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -450,8 +450,17 @@ fn test_match_tuple_tail_multi_return_is_rejected() {
 	match_call := run_good(v3_bin, 'good_multi_return_match_call_return',
 		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn pick(flag bool) (int, int) {\n\treturn match flag {\n\t\ttrue {\n\t\t\tpair(1)\n\t\t}\n\t\tfalse {\n\t\t\tpair(3)\n\t\t}\n\t}\n}\nfn main() {\n\ta, b := pick(false)\n\tprintln(int_str(a + b))\n}\n')
 	assert match_call == '7'
+	match_decl_assign := run_good(v3_bin, 'good_multi_return_match_call_decl_assign',
+		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn main() {\n\tflag := false\n\ta, b := match flag {\n\t\ttrue {\n\t\t\tpair(1)\n\t\t}\n\t\tfalse {\n\t\t\tpair(3)\n\t\t}\n\t}\n\tprintln(int_str(a + b))\n}\n')
+	assert match_decl_assign == '7'
+	match_assign := run_good(v3_bin, 'good_multi_return_match_call_assign',
+		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn main() {\n\tflag := false\n\tmut a := 0\n\tmut b := 0\n\ta, b = match flag {\n\t\ttrue {\n\t\t\tpair(1)\n\t\t}\n\t\tfalse {\n\t\t\tpair(3)\n\t\t}\n\t}\n\tprintln(int_str(a + b))\n}\n')
+	assert match_assign == '7'
 	run_bad(v3_bin, 'bad_multi_return_match_tail_decl_assign',
 		'fn main() {\n\tflag := true\n\ta, b := match flag {\n\t\ttrue {\n\t\t\t1\n\t\t\t2\n\t\t}\n\t\tfalse {\n\t\t\t3\n\t\t\t4\n\t\t}\n\t}\n\tprintln(int_str(a + b))\n}\n',
+		'match expression branches cannot produce multiple assignment values')
+	run_bad(v3_bin, 'bad_multi_return_match_call_mixed_tuple_tail_decl_assign',
+		'fn pair(n int) (int, int) {\n\treturn n, n + 1\n}\nfn main() {\n\tflag := true\n\ta, b := match flag {\n\t\ttrue {\n\t\t\tpair(1)\n\t\t}\n\t\tfalse {\n\t\t\t3\n\t\t\t4\n\t\t}\n\t}\n\tprintln(int_str(a + b))\n}\n',
 		'match expression branches cannot produce multiple assignment values')
 	run_bad(v3_bin, 'bad_multi_return_match_tail_return',
 		'fn pair(flag bool) (int, int) {\n\treturn match flag {\n\t\ttrue {\n\t\t\t1\n\t\t\t2\n\t\t}\n\t\tfalse {\n\t\t\t3\n\t\t\t4\n\t\t}\n\t}\n}\nfn main() {\n\ta, b := pair(true)\n\tprintln(int_str(a + b))\n}\n',

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -511,6 +511,9 @@ fn test_voidptr_variadic_spread_requires_voidptr_array() {
 	run_bad(v3_bin, 'bad_voidptr_variadic_none_arg',
 		'fn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\tprintln(int_str(sink(none)))\n}\n',
 		'cannot use `?void`')
+	run_bad(v3_bin, 'bad_voidptr_variadic_multi_return_arg',
+		'fn pair() (int, int) {\n\treturn 1, 2\n}\n\nfn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\tprintln(int_str(sink(pair())))\n}\n',
+		'cannot use `(int, int)`')
 	good := run_good(v3_bin, 'good_voidptr_variadic_voidptr_spread',
 		'fn sink(args ...voidptr) int {\n\treturn args.len\n}\n\nfn main() {\n\tx := 7\n\txs := [voidptr(&x)]\n\tprintln(int_str(sink(...xs)))\n\tprintln(int_str(sink(1)))\n}\n')
 	assert good == '1\n1'

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1522,6 +1522,20 @@ fn (mut t Transformer) make_membership_eq_expr_with_seen(lhs flat.NodeId, rhs fl
 		return t.make_infix(.eq, lhs, rhs)
 	}
 	mut clean := t.membership_container_type(elem_type)
+	if clean.len > 0 {
+		lhs_type := t.node_type(lhs)
+		if lhs_type == '&${clean}' {
+			lhs_value := t.make_prefix(.mul, lhs)
+			t.a.nodes[int(lhs_value)].typ = clean
+			return t.make_membership_eq_expr_with_seen(lhs_value, rhs, elem_type, seen)
+		}
+		rhs_type := t.node_type(rhs)
+		if rhs_type == '&${clean}' {
+			rhs_value := t.make_prefix(.mul, rhs)
+			t.a.nodes[int(rhs_value)].typ = clean
+			return t.make_membership_eq_expr_with_seen(lhs, rhs_value, elem_type, seen)
+		}
+	}
 	if clean == 'string' {
 		return t.make_call_typed('string__eq', arr2(lhs, rhs), 'bool')
 	}
@@ -1576,6 +1590,9 @@ fn (mut t Transformer) make_membership_eq_expr_with_seen(lhs flat.NodeId, rhs fl
 	}
 	if t.is_sum_type_name(clean) {
 		return t.make_memcmp_eq_expr(lhs, rhs, clean, 'eq')
+	}
+	if t.is_interface_type(clean) {
+		return t.make_memcmp_eq_expr(lhs, rhs, clean, 'iface_eq')
 	}
 	struct_type := t.struct_lookup_name(clean)
 	if struct_type.len > 0 {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1214,17 +1214,25 @@ fn (mut t Transformer) pack_variadic_args(node flat.Node, first_arg int, elem_ty
 		}
 		value_name := t.new_temp('vararg')
 		if variadic_elem_is_voidptr(elem_type) {
-			storage_type := t.voidptr_variadic_storage_type(arg_id)
-			storage_value := if storage_type != t.node_type(arg_id) {
-				t.make_cast(storage_type, value, storage_type)
+			value_arg := if t.voidptr_variadic_arg_passes_direct(arg_id) {
+				if t.node_type(arg_id) == 'voidptr' {
+					value
+				} else {
+					t.make_cast('voidptr', value, 'voidptr')
+				}
 			} else {
-				value
+				storage_type := t.voidptr_variadic_storage_type(arg_id)
+				storage_value := if storage_type != t.node_type(arg_id) {
+					t.make_cast(storage_type, value, storage_type)
+				} else {
+					value
+				}
+				storage_name := t.new_temp('vararg_storage')
+				t.pending_stmts << t.make_decl_assign_typed(storage_name, storage_value,
+					storage_type)
+				t.make_cast('voidptr', t.make_prefix(.amp, t.make_ident(storage_name)), 'voidptr')
 			}
-			storage_name := t.new_temp('vararg_storage')
-			t.pending_stmts << t.make_decl_assign_typed(storage_name, storage_value, storage_type)
-			ptr_value := t.make_cast('voidptr', t.make_prefix(.amp, t.make_ident(storage_name)),
-				'voidptr')
-			t.pending_stmts << t.make_decl_assign_typed(value_name, ptr_value, expected_enum)
+			t.pending_stmts << t.make_decl_assign_typed(value_name, value_arg, expected_enum)
 		} else {
 			t.pending_stmts << t.make_decl_assign_typed(value_name, value, expected_enum)
 		}
@@ -1240,6 +1248,22 @@ fn variadic_elem_is_voidptr(typ types.Type) bool {
 		return typ.base_type is types.Void
 	}
 	return false
+}
+
+fn (t &Transformer) voidptr_variadic_arg_passes_direct(arg_id flat.NodeId) bool {
+	if !isnil(t.tc) {
+		return voidptr_variadic_type_passes_direct(t.tc.resolve_type(arg_id))
+	}
+	typ := t.node_type(arg_id)
+	return typ == 'voidptr' || typ == 'nil' || typ == 'charptr' || typ == 'byteptr'
+		|| typ.starts_with('&')
+}
+
+fn voidptr_variadic_type_passes_direct(typ types.Type) bool {
+	if typ is types.Alias {
+		return voidptr_variadic_type_passes_direct(typ.base_type)
+	}
+	return typ is types.Pointer || typ is types.Nil
 }
 
 fn (t &Transformer) voidptr_variadic_storage_type(arg_id flat.NodeId) string {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1213,12 +1213,48 @@ fn (mut t Transformer) pack_variadic_args(node flat.Node, first_arg int, elem_ty
 			t.transform_expr(arg_id)
 		}
 		value_name := t.new_temp('vararg')
-		t.pending_stmts << t.make_decl_assign_typed(value_name, value, expected_enum)
+		if variadic_elem_is_voidptr(elem_type) {
+			storage_type := t.voidptr_variadic_storage_type(arg_id)
+			storage_value := if storage_type != t.node_type(arg_id) {
+				t.make_cast(storage_type, value, storage_type)
+			} else {
+				value
+			}
+			storage_name := t.new_temp('vararg_storage')
+			t.pending_stmts << t.make_decl_assign_typed(storage_name, storage_value, storage_type)
+			ptr_value := t.make_cast('voidptr', t.make_prefix(.amp, t.make_ident(storage_name)),
+				'voidptr')
+			t.pending_stmts << t.make_decl_assign_typed(value_name, ptr_value, expected_enum)
+		} else {
+			t.pending_stmts << t.make_decl_assign_typed(value_name, value, expected_enum)
+		}
 		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('array_push', arr2(t.make_prefix(.amp,
 			t.make_ident(tmp_name)), t.make_prefix(.amp, t.make_ident(value_name))), 'void'))
 	}
 	t.set_var_type(tmp_name, array_type)
 	return t.make_ident(tmp_name)
+}
+
+fn variadic_elem_is_voidptr(typ types.Type) bool {
+	if typ is types.Pointer {
+		return typ.base_type is types.Void
+	}
+	return false
+}
+
+fn (t &Transformer) voidptr_variadic_storage_type(arg_id flat.NodeId) string {
+	typ := t.node_type(arg_id)
+	match typ {
+		'i8', 'u8', 'i16', 'u16' {
+			return 'int'
+		}
+		'f32' {
+			return 'f64'
+		}
+		else {
+			return typ
+		}
+	}
 }
 
 fn (mut t Transformer) transform_variadic_struct_fields(node flat.Node, field_start int, elem_type types.Type) ?flat.NodeId {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -224,6 +224,12 @@ fn (t &Transformer) resolve_receiver_method_for_type(receiver_type string, metho
 		if t.is_known_fn_name(direct) {
 			return direct
 		}
+		for receiver in generic_receiver_flat_type_variants(clean_type) {
+			flat_method := '${receiver}.${method}'
+			if t.is_known_fn_name(flat_method) {
+				return flat_method
+			}
+		}
 	}
 	if clean_type.starts_with('[]') {
 		elem_type := clean_type[2..]
@@ -433,6 +439,9 @@ fn (mut t Transformer) normalize_generic_call_expr(id flat.NodeId, node flat.Nod
 	if fn_node.kind != .index || fn_node.children_count < 2 || fn_node.value == 'range' {
 		return id
 	}
+	if t.index_callee_is_value_index(fn_node) {
+		return id
+	}
 	base_id := t.a.child(&fn_node, 0)
 	base := t.a.nodes[int(base_id)]
 	if base.kind !in [.ident, .selector] {
@@ -509,6 +518,9 @@ fn (t &Transformer) generic_call_type_arg_name(id flat.NodeId) string {
 		.map_init {
 			return node.value
 		}
+		.struct_decl {
+			return node.value
+		}
 		.prefix {
 			if node.children_count == 0 {
 				return ''
@@ -532,6 +544,9 @@ fn (t &Transformer) generic_call_type_args_name(index_node flat.Node) string {
 	if index_node.kind != .index || index_node.children_count < 2 || index_node.value == 'range' {
 		return ''
 	}
+	if t.index_callee_is_value_index(index_node) {
+		return ''
+	}
 	mut args := []string{}
 	for i in 1 .. index_node.children_count {
 		arg := t.generic_call_type_arg_name(t.a.child(&index_node, i))
@@ -541,6 +556,66 @@ fn (t &Transformer) generic_call_type_args_name(index_node flat.Node) string {
 		args << arg
 	}
 	return args.join(', ')
+}
+
+fn (t &Transformer) index_callee_is_value_index(index_node flat.Node) bool {
+	if index_node.kind != .index || index_node.children_count == 0 || index_node.value == 'range' {
+		return false
+	}
+	base_id := t.a.child(&index_node, 0)
+	if int(base_id) < 0 {
+		return false
+	}
+	base := t.a.nodes[int(base_id)]
+	if base.kind == .ident && t.type_name_is_indexable(t.var_type(base.value)) {
+		return true
+	}
+	if base.kind == .ident || base.kind == .selector {
+		base_type := t.resolve_expr_type(base_id)
+		if t.type_name_is_indexable(base_type) {
+			return true
+		}
+	}
+	if !isnil(t.tc) {
+		if typ := t.tc.expr_type(base_id) {
+			if transform_type_is_indexable(typ) {
+				return true
+			}
+		}
+		if transform_type_is_indexable(t.tc.resolve_type(base_id)) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (t &Transformer) type_name_is_indexable(name string) bool {
+	mut clean := t.normalize_type_alias(name)
+	if clean.len == 0 {
+		return false
+	}
+	if clean.starts_with('&') {
+		clean = t.normalize_type_alias(clean[1..])
+	}
+	return clean == 'string' || clean.starts_with('[]') || clean.starts_with('map[')
+		|| t.is_fixed_array_type(clean)
+}
+
+fn transform_type_is_indexable(typ types.Type) bool {
+	match typ {
+		types.Array, types.ArrayFixed, types.Map, types.String {
+			return true
+		}
+		types.Alias {
+			return transform_type_is_indexable(typ.base_type)
+		}
+		types.Pointer {
+			return transform_type_is_indexable(typ.base_type)
+		}
+		else {
+			return false
+		}
+	}
 }
 
 // transform_call_args transforms all children of a call expression.
@@ -1105,6 +1180,11 @@ fn (t &Transformer) is_named_fn_value_arg(arg_id flat.NodeId) bool {
 
 // transform_const_array_arg_for_param supports transform_const_array_arg_for_param handling.
 fn (mut t Transformer) transform_const_array_arg_for_param(arg_id flat.NodeId, param_type string) ?flat.NodeId {
+	if raw_const_type := t.raw_const_type_name_for_expr(arg_id) {
+		if t.normalize_type_alias(raw_const_type) == t.normalize_type_alias(param_type) {
+			return t.transform_expr(arg_id)
+		}
+	}
 	expr_id := t.const_expr_for_arg(arg_id) or { return none }
 	expr := t.a.nodes[int(expr_id)]
 	elem_type := param_type[2..]
@@ -1269,7 +1349,7 @@ fn voidptr_variadic_type_passes_direct(typ types.Type) bool {
 fn (t &Transformer) voidptr_variadic_storage_type(arg_id flat.NodeId) string {
 	typ := t.node_type(arg_id)
 	match typ {
-		'i8', 'u8', 'i16', 'u16' {
+		'char', 'i8', 'u8', 'i16', 'u16' {
 			return 'int'
 		}
 		'f32' {
@@ -1782,6 +1862,9 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 				if known_str {
 					return t.make_call_typed(str_fn, arr1(expr), 'string')
 				}
+				if qualified in t.sum_types {
+					return t.lower_sum_str(expr, qualified)
+				}
 				return t.make_string_literal('${qualified}{}')
 			} else if t.is_fixed_array_type(clean_typ) {
 				elem_type := fixed_array_elem_type(clean_typ)
@@ -1809,6 +1892,69 @@ fn (mut t Transformer) mark_interface_method_implementers_used(iface_name string
 			t.mark_fn_used_name('${concrete}.${method}')
 		}
 	}
+}
+
+fn (mut t Transformer) lower_sum_str(expr flat.NodeId, sum_name string) flat.NodeId {
+	resolved_sum := t.resolve_sum_name(sum_name)
+	variants := t.sum_types[resolved_sum] or { return t.make_string_literal('${sum_name}{}') }
+	base := t.stable_transformed_expr_for_reuse(expr, resolved_sum, 'sum_str')
+	tag := t.make_selector_op(base, 'typ', 'int', if sum_name.starts_with('&') {
+		.arrow
+	} else {
+		.dot
+	})
+	sum_display := if resolved_sum.contains('.') {
+		resolved_sum.all_after_last('.')
+	} else {
+		resolved_sum
+	}
+	return t.build_sum_str_chain(base, tag, resolved_sum, sum_display, variants, 0)
+}
+
+fn (mut t Transformer) build_sum_str_chain(base flat.NodeId, tag flat.NodeId, sum_name string, sum_display string, variants []string, idx int) flat.NodeId {
+	if idx >= variants.len {
+		return t.make_string_literal('${sum_name}{}')
+	}
+	variant := variants[idx]
+	field := t.sum_field_name(variant)
+	field_sel := t.make_selector_op(base, field, '&${variant}', .dot)
+	variant_base := t.normalize_type_alias(variant)
+	mut value_text := if t.is_fixed_array_type(variant_base) {
+		elem_type := fixed_array_elem_type(variant_base)
+		arr := t.make_call_typed('new_array_from_c_array', [
+			t.make_fixed_array_len_expr(variant_base),
+			t.make_fixed_array_len_expr(variant_base),
+			t.make_sizeof_type(elem_type),
+			field_sel,
+		], '[]${elem_type}')
+		t.wrap_string_conversion(arr, '[]${elem_type}')
+	} else {
+		value := t.make_prefix(.mul, field_sel)
+		t.a.nodes[int(value)].typ = variant
+		t.wrap_string_conversion(value, variant)
+	}
+	display := if variant.contains('.') { variant.all_after_last('.') } else { variant }
+	value_text = t.string_plus(t.string_plus(t.make_string_literal('${display}('), value_text),
+		t.make_string_literal(')'))
+	value_text = t.string_plus(t.string_plus(t.make_string_literal('${sum_display}('), value_text),
+		t.make_string_literal(')'))
+	mut then_stmts := []flat.NodeId{}
+	t.drain_pending(mut then_stmts)
+	then_stmts << t.make_expr_stmt(value_text)
+	cond := t.make_infix(.eq, tag, t.make_int_literal(t.sum_type_index(sum_name, variant)))
+	then_block := t.make_block(then_stmts)
+	else_expr := t.build_sum_str_chain(base, tag, sum_name, sum_display, variants, idx + 1)
+	else_block := t.make_block(arr1(t.make_expr_stmt(else_expr)))
+	start := t.a.children.len
+	t.a.children << cond
+	t.a.children << then_block
+	t.a.children << else_block
+	return t.a.add_node(flat.Node{
+		kind:           .if_expr
+		children_start: start
+		children_count: 3
+		typ:            'string'
+	})
 }
 
 fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ string, format string) flat.NodeId {
@@ -3408,7 +3554,8 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 	}
 	if !isnil(t.tc) {
 		if resolved_method := t.tc.resolved_call_name(id) {
-			if t.is_known_fn_name(resolved_method) {
+			if !receiver_method_name_has_generic_placeholder(resolved_method)
+				&& t.is_known_fn_name(resolved_method) {
 				params := t.call_param_types(resolved_method)
 				if t.resolved_call_uses_receiver_type(base_id, base_type, params) {
 					args := t.transform_receiver_method_args_with_base(node, t.receiver_base_for_resolved_method(base_id,
@@ -3427,7 +3574,8 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 	}
 	if !isnil(t.tc) {
 		if resolved_method := t.tc.resolved_call_name(id) {
-			if t.is_known_fn_name(resolved_method) {
+			if !receiver_method_name_has_generic_placeholder(resolved_method)
+				&& t.is_known_fn_name(resolved_method) {
 				params := t.call_param_types(resolved_method)
 				if !t.resolved_call_uses_receiver_type(base_id, base_type, params) {
 					return none
@@ -3694,6 +3842,27 @@ fn is_builtin_collection_resolved_call(name string) bool {
 		|| is_runtime_collection_helper_name(name) || is_raw_collection_method_name(name, 'map.')
 }
 
+fn receiver_method_name_has_generic_placeholder(name string) bool {
+	if !name.contains('.') {
+		return false
+	}
+	receiver := name.all_before_last('.')
+	if receiver.contains('[') {
+		for marker in ['T', 'U', 'K', 'V', 'A', 'B', 'C', 'X', 'Y', 'Z'] {
+			if receiver.contains('[${marker}]') || receiver.contains('[${marker},')
+				|| receiver.contains(', ${marker}]') || receiver.contains(',${marker}]') {
+				return true
+			}
+		}
+	}
+	for part in receiver.split('_') {
+		if part in ['T', 'U', 'K', 'V', 'A', 'B', 'C', 'X', 'Y', 'Z'] {
+			return true
+		}
+	}
+	return false
+}
+
 fn is_raw_collection_method_name(name string, prefix string) bool {
 	if !name.starts_with(prefix) {
 		return false
@@ -3854,16 +4023,8 @@ fn (t &Transformer) receiver_method_candidates(receiver_type string, method stri
 	}
 	mut candidates := []string{}
 	candidates << '${clean_type}.${method}'
-	base, args, ok := generic_app_parts(clean_type)
-	if ok {
-		suffix := generic_type_suffixes(args)
-		candidates << '${base}_${suffix}.${method}'
-		if base.contains('.') {
-			base_mod := base.all_before_last('.')
-			base_short := base.all_after_last('.')
-			candidates << '${base_short}_${suffix}.${method}'
-			candidates << '${base_mod}.${base_short}_${suffix}.${method}'
-		}
+	for receiver in generic_receiver_flat_type_variants(clean_type) {
+		candidates << '${receiver}.${method}'
 	}
 	if clean_type.starts_with('[]') {
 		elem_type := clean_type[2..]
@@ -3881,6 +4042,26 @@ fn (t &Transformer) receiver_method_candidates(receiver_type string, method stri
 		candidates << '${t.cur_module}.${clean_type}.${method}'
 	}
 	return candidates
+}
+
+fn generic_receiver_flat_type_variants(receiver_type string) []string {
+	base, args, ok := generic_app_parts(receiver_type)
+	if !ok || args.len == 0 {
+		return []string{}
+	}
+	suffix := generic_type_suffixes(args)
+	if suffix.len == 0 {
+		return []string{}
+	}
+	mut receivers := []string{}
+	transform_push_receiver_candidate(mut receivers, '${base}_${suffix}')
+	if base.contains('.') {
+		short_base := base.all_after_last('.')
+		transform_push_receiver_candidate(mut receivers, '${short_base}_${suffix}')
+		transform_push_receiver_candidate(mut receivers,
+			'${base.all_before_last('.')}.${short_base}_${suffix}')
+	}
+	return receivers
 }
 
 fn (t &Transformer) resolve_fixed_array_dynamic_receiver_method(fixed_type string, method string) ?string {
@@ -4337,6 +4518,12 @@ fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string 
 				if elem_type.starts_with('thread ') {
 					return '[]${elem_type[7..]}'
 				}
+			}
+			if clean_type == 'thread' {
+				return 'void'
+			}
+			if clean_type.starts_with('thread ') {
+				return clean_type[7..]
 			}
 		}
 		if fn_node.kind == .selector && fn_node.value in ['keys', 'values']

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1347,7 +1347,7 @@ fn voidptr_variadic_type_passes_direct(typ types.Type) bool {
 }
 
 fn (t &Transformer) voidptr_variadic_storage_type(arg_id flat.NodeId) string {
-	typ := t.node_type(arg_id)
+	typ := t.normalize_type_alias(t.node_type(arg_id))
 	match typ {
 		'char', 'i8', 'u8', 'i16', 'u16' {
 			return 'int'

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -1229,7 +1229,11 @@ fn (mut t Transformer) retype_generic_call_literal_arg(arg_id flat.NodeId, param
 	node := t.a.nodes[int(arg_id)]
 	if node.kind == .array_literal
 		&& t.generic_call_array_literal_can_retype_inline(node, param_type) {
-		return t.transform_expr_for_type(arg_id, param_type)
+		mut values := []flat.NodeId{cap: int(node.children_count)}
+		for i in 0 .. node.children_count {
+			values << t.a.child(&node, i)
+		}
+		return t.make_array_literal_typed(values, param_type)
 	}
 	if node.kind == .ident && node.value.contains('arr_lit') && node.typ.starts_with('[]')
 		&& param_type.starts_with('[]') && node.typ != param_type {
@@ -1523,6 +1527,7 @@ fn (t &Transformer) call_has_source_generic_args(node flat.Node) bool {
 	}
 	fn_node := t.a.child_node(&node, 0)
 	return fn_node.kind == .index && fn_node.children_count >= 2 && fn_node.value != 'range'
+		&& !t.index_callee_is_value_index(fn_node)
 }
 
 fn (t &Transformer) should_skip_generic_call_specialization(decl_key string) bool {
@@ -1537,6 +1542,9 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 	mut callee_id := t.a.child(&node, 0)
 	mut callee := t.a.nodes[int(callee_id)]
 	if callee.kind == .index && callee.children_count > 0 && callee.value != 'range' {
+		if t.index_callee_is_value_index(callee) {
+			return none
+		}
 		callee_id = t.a.child(&callee, 0)
 		callee = t.a.nodes[int(callee_id)]
 	}

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -382,11 +382,20 @@ fn (t &Transformer) json_decode_or_expr_type(expr_id flat.NodeId, expr_node flat
 	if name !in ['json.decode', 'json2.decode', 'x.json2.decode'] {
 		return none
 	}
-	args := t.explicit_generic_call_args(expr_node, t.cur_module) or { return none }
-	if args.len != 1 || args[0].len == 0 {
+	if args := t.explicit_generic_call_args(expr_node, t.cur_module) {
+		if args.len == 1 && args[0].len > 0 {
+			return '!${args[0]}'
+		}
 		return none
 	}
-	return '!${args[0]}'
+	if expr_node.children_count < 2 {
+		return none
+	}
+	type_arg := t.generic_call_type_arg_name(t.a.child(&expr_node, 1))
+	if type_arg.len == 0 {
+		return none
+	}
+	return '!${type_arg}'
 }
 
 // value_type_name returns value type name data for Transformer.

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -4164,13 +4164,17 @@ fn (mut t Transformer) lower_multi_if_assign(node flat.Node, lhs_ids []flat.Node
 
 // multi_if_assign_block supports multi if assign block handling for Transformer.
 fn (mut t Transformer) multi_if_assign_block(block_id flat.NodeId, lhs_ids []flat.NodeId) flat.NodeId {
-	block := t.a.nodes[int(block_id)]
 	parts := t.tuple_block_parts(block_id, lhs_ids.len) or {
-		if nested := t.nested_multi_if_assign_block(block_id, lhs_ids) {
+		if nested := t.nested_multi_tail_assign_block(block_id, lhs_ids) {
 			return nested
 		}
 		return t.transform_expr(block_id)
 	}
+	stmts := t.multi_if_assign_stmts(parts, lhs_ids)
+	return t.make_block(stmts)
+}
+
+fn (mut t Transformer) multi_if_assign_stmts(parts TupleBlockParts, lhs_ids []flat.NodeId) []flat.NodeId {
 	mut stmts := t.transform_stmts(parts.prefix)
 	for i, value_id in parts.values {
 		value := t.transform_expr(value_id)
@@ -4187,13 +4191,10 @@ fn (mut t Transformer) multi_if_assign_block(block_id flat.NodeId, lhs_ids []fla
 		}
 		stmts << t.make_assign(t.transform_lvalue(lhs_id), value)
 	}
-	if block.kind == .block {
-		return t.make_block(stmts)
-	}
-	return t.make_block(stmts)
+	return stmts
 }
 
-fn (mut t Transformer) nested_multi_if_assign_block(block_id flat.NodeId, lhs_ids []flat.NodeId) ?flat.NodeId {
+fn (mut t Transformer) nested_multi_tail_assign_block(block_id flat.NodeId, lhs_ids []flat.NodeId) ?flat.NodeId {
 	if int(block_id) < 0 || lhs_ids.len == 0 {
 		return none
 	}
@@ -4207,15 +4208,20 @@ fn (mut t Transformer) nested_multi_if_assign_block(block_id flat.NodeId, lhs_id
 	}
 	last_id := children[children.len - 1]
 	last := t.a.nodes[int(last_id)]
-	if last.kind != .if_expr {
-		return none
-	}
 	mut stmts := t.transform_stmts(children[..children.len - 1])
-	nested_stmts := t.lower_multi_if_assign(last, lhs_ids)
-	for stmt in nested_stmts {
-		stmts << stmt
+	if last.kind == .if_expr {
+		nested_stmts := t.lower_multi_if_assign(last, lhs_ids)
+		for stmt in nested_stmts {
+			stmts << stmt
+		}
+		return t.make_block(stmts)
 	}
-	return t.make_block(stmts)
+	if last.kind == .block {
+		nested_parts := t.tuple_block_parts(last_id, lhs_ids.len) or { return none }
+		stmts << t.make_block(t.multi_if_assign_stmts(nested_parts, lhs_ids))
+		return t.make_block(stmts)
+	}
+	return none
 }
 
 // tuple_block_parts supports tuple block parts handling for Transformer.

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -3757,7 +3757,9 @@ fn (mut t Transformer) try_expand_multi_return_decl(node flat.Node) ?[]flat.Node
 		return none
 	}
 	if rhs.kind == .if_expr {
-		return t.expand_multi_return_if_decl(rhs_id, rhs, lhs_ids)
+		if expanded := t.expand_multi_return_if_decl(rhs_id, rhs, lhs_ids) {
+			return expanded
+		}
 	}
 	if rhs_types := t.multi_return_types_for_expr(rhs_id, lhs_ids.len) {
 		tmp_name := t.new_temp('multi_ret')
@@ -3797,7 +3799,9 @@ fn (mut t Transformer) try_expand_multi_return_assign(node flat.Node) ?[]flat.No
 		return none
 	}
 	if rhs.kind == .if_expr {
-		return t.expand_multi_return_if_assign(rhs_id, rhs, lhs_ids)
+		if expanded := t.expand_multi_return_if_assign(rhs_id, rhs, lhs_ids) {
+			return expanded
+		}
 	}
 	if rhs_types := t.multi_return_types_for_expr(rhs_id, lhs_ids.len) {
 		tmp_name := t.new_temp('multi_ret')
@@ -4098,6 +4102,9 @@ fn (mut t Transformer) expand_multi_return_if_decl(rhs_id flat.NodeId, rhs flat.
 	if lhs_ids.len == 0 {
 		return none
 	}
+	if !t.if_expr_has_tuple_tail_values(rhs_id, lhs_ids.len) {
+		return none
+	}
 	value_types := t.promoted_multi_if_value_types(rhs_id, rhs, lhs_ids.len)
 	mut result := []flat.NodeId{}
 	for i, lhs_id in lhs_ids {
@@ -4129,11 +4136,57 @@ fn (t &Transformer) promoted_multi_if_value_types(rhs_id flat.NodeId, rhs flat.N
 }
 
 // expand_multi_return_if_assign builds expand multi return if assign data for transform.
-fn (mut t Transformer) expand_multi_return_if_assign(_rhs_id flat.NodeId, rhs flat.Node, lhs_ids []flat.NodeId) ?[]flat.NodeId {
+fn (mut t Transformer) expand_multi_return_if_assign(rhs_id flat.NodeId, rhs flat.Node, lhs_ids []flat.NodeId) ?[]flat.NodeId {
 	if rhs.kind != .if_expr || lhs_ids.len == 0 {
 		return none
 	}
+	if !t.if_expr_has_tuple_tail_values(rhs_id, lhs_ids.len) {
+		return none
+	}
 	return t.lower_multi_if_assign(rhs, lhs_ids)
+}
+
+fn (t &Transformer) if_expr_has_tuple_tail_values(expr_id flat.NodeId, count int) bool {
+	if int(expr_id) < 0 || count <= 0 {
+		return false
+	}
+	node := t.a.nodes[int(expr_id)]
+	if node.kind != .if_expr {
+		return t.branch_has_tuple_tail_values(expr_id, count)
+	}
+	if node.children_count > 1 && t.branch_has_tuple_tail_values(t.a.child(&node, 1), count) {
+		return true
+	}
+	return node.children_count > 2 && t.if_expr_has_tuple_tail_values(t.a.child(&node, 2), count)
+}
+
+fn (t &Transformer) branch_has_tuple_tail_values(branch_id flat.NodeId, count int) bool {
+	if int(branch_id) < 0 || count <= 0 {
+		return false
+	}
+	if parts := t.tuple_block_parts(branch_id, count) {
+		return parts.values.len > 0
+	}
+	branch := t.a.nodes[int(branch_id)]
+	match branch.kind {
+		.if_expr {
+			return t.if_expr_has_tuple_tail_values(branch_id, count)
+		}
+		.expr_stmt {
+			return branch.children_count > 0
+				&& t.branch_has_tuple_tail_values(t.a.child(&branch, 0), count)
+		}
+		.block {
+			if branch.children_count == 0 {
+				return false
+			}
+			return t.branch_has_tuple_tail_values(t.a.child(&branch, branch.children_count - 1),
+				count)
+		}
+		else {
+			return false
+		}
+	}
 }
 
 // lower_multi_if_assign builds lower multi if assign data for transform.

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -4094,11 +4094,11 @@ fn (t &Transformer) multi_return_type_name(items []types.Type) string {
 }
 
 // expand_multi_return_if_decl builds expand multi return if decl data for transform.
-fn (mut t Transformer) expand_multi_return_if_decl(_rhs_id flat.NodeId, rhs flat.Node, lhs_ids []flat.NodeId) ?[]flat.NodeId {
+fn (mut t Transformer) expand_multi_return_if_decl(rhs_id flat.NodeId, rhs flat.Node, lhs_ids []flat.NodeId) ?[]flat.NodeId {
 	if lhs_ids.len == 0 {
 		return none
 	}
-	value_types := t.infer_multi_if_value_types(rhs, lhs_ids.len)
+	value_types := t.promoted_multi_if_value_types(rhs_id, rhs, lhs_ids.len)
 	mut result := []flat.NodeId{}
 	for i, lhs_id in lhs_ids {
 		lhs := t.a.nodes[int(lhs_id)]
@@ -4108,11 +4108,24 @@ fn (mut t Transformer) expand_multi_return_if_decl(_rhs_id flat.NodeId, rhs flat
 		typ := if i < value_types.len { value_types[i] } else { 'int' }
 		result << t.make_decl_assign_typed(lhs.value, t.zero_value_for_type(typ), typ)
 	}
-	if_stmts := t.expand_multi_return_if_assign(_rhs_id, rhs, lhs_ids) or { return none }
+	if_stmts := t.expand_multi_return_if_assign(rhs_id, rhs, lhs_ids) or { return none }
 	for stmt in if_stmts {
 		result << stmt
 	}
 	return result
+}
+
+fn (t &Transformer) promoted_multi_if_value_types(rhs_id flat.NodeId, rhs flat.Node, count int) []string {
+	if !isnil(t.tc) {
+		if item_types := t.tc.multi_expr_tail_types_for_transform(rhs_id, count) {
+			mut result := []string{cap: item_types.len}
+			for item_type in item_types {
+				result << item_type.name()
+			}
+			return result
+		}
+	}
+	return t.infer_multi_if_value_types(rhs, count)
 }
 
 // expand_multi_return_if_assign builds expand multi return if assign data for transform.

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1234,10 +1234,10 @@ fn (mut t Transformer) transform_const_decl(node flat.Node) {
 				t.a.children[cf.children_start] = new_val
 			} else if val.kind in [.struct_init, .cast_expr, .call, .array_literal, .fn_literal,
 				.lambda_expr] {
-				new_val := t.transform_expr(val_id)
+				new_val := t.transform_const_expr_no_pending(val_id)
 				t.a.children[cf.children_start] = new_val
 			} else if val.kind == .infix && val.children_count >= 2 {
-				new_val := t.transform_expr(val_id)
+				new_val := t.transform_const_expr_no_pending(val_id)
 				// Overwrite the field's value slot in place (each const_field owns
 				// its own single-element child range, so this is safe).
 				t.a.children[cf.children_start] = new_val
@@ -1262,6 +1262,16 @@ fn (t &Transformer) const_field_type_name(field flat.Node) string {
 	return field.typ
 }
 
+fn (mut t Transformer) transform_const_expr_no_pending(id flat.NodeId) flat.NodeId {
+	old_pending := t.pending_stmts.clone()
+	t.pending_stmts.clear()
+	transformed := t.transform_expr(id)
+	has_pending := t.pending_stmts.len > 0
+	t.pending_stmts.clear()
+	t.pending_stmts = old_pending
+	return if has_pending { id } else { transformed }
+}
+
 // transform_const_or_expr transforms transform const or expr data for transform.
 fn (mut t Transformer) transform_const_or_expr(_id flat.NodeId, node flat.Node, const_typ string) flat.NodeId {
 	if node.children_count < 2 {
@@ -1271,7 +1281,7 @@ fn (mut t Transformer) transform_const_or_expr(_id flat.NodeId, node flat.Node, 
 	for i in 0 .. node.children_count {
 		child_id := t.a.child(&node, i)
 		if i == 0 {
-			children << t.transform_expr(child_id)
+			children << t.transform_const_expr_no_pending(child_id)
 		} else {
 			children << child_id
 		}
@@ -1680,16 +1690,22 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 			continue
 		}
 		child := t.a.nodes[int(child_id)]
-		if node_kind_id(child) == 75 && child.value.len > 0 && child.typ.len > 0 {
-			raw_typ := if child.typ.starts_with('...') {
-				'[]' + t.normalize_type_alias(child.typ[3..])
+		if node_kind_id(child) == 75 && child.value.len > 0 {
+			raw_typ := if child.typ.len > 0 {
+				if child.typ.starts_with('...') {
+					'[]' + t.normalize_type_alias(child.typ[3..])
+				} else {
+					t.normalize_type_alias(child.typ)
+				}
 			} else {
-				t.normalize_type_alias(child.typ)
+				''
 			}
 			mut typ := if raw_typ.len > 0 {
 				raw_typ
 			} else if param_idx < param_types.len {
 				t.normalize_type_alias(param_types[param_idx].name())
+			} else if param_idx == 0 {
+				t.fn_body_receiver_type(fn_node.value)
 			} else {
 				''
 			}
@@ -1697,7 +1713,9 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 				&& t.normalize_type_alias(typ[1..]) == raw_typ {
 				typ = raw_typ
 			}
-			t.set_var_type(child.value, typ)
+			if typ.len > 0 {
+				t.set_var_type(child.value, typ)
+			}
 			if child.op == .amp {
 				t.mut_param_values[child.value] = true
 			}
@@ -1780,6 +1798,21 @@ fn (t &Transformer) fn_body_param_types(fn_node flat.Node, expected int) []types
 		}
 	}
 	return []types.Type{}
+}
+
+fn (t &Transformer) fn_body_receiver_type(fn_name string) string {
+	if !fn_name.contains('.') {
+		return ''
+	}
+	receiver := fn_name.all_before_last('.')
+	if receiver.len == 0 {
+		return ''
+	}
+	typ := t.normalize_type_in_module(receiver, t.cur_module)
+	if typ.len == 0 || typ == fn_name {
+		return ''
+	}
+	return typ
 }
 
 // fn_param_types_for_name supports fn param types for name handling for Transformer.
@@ -3059,20 +3092,27 @@ fn (mut t Transformer) transform_expr_for_type(id flat.NodeId, target_type strin
 		}
 		if target_type in ['f32', 'f64'] && node.kind == .infix
 			&& node.op in [.plus, .minus, .mul, .div] && node.children_count >= 2 {
-			lhs := t.transform_expr_for_type(t.a.child(&node, 0), target_type)
-			rhs := t.transform_expr_for_type(t.a.child(&node, 1), target_type)
-			start := t.a.children.len
-			t.a.children << lhs
-			t.a.children << rhs
-			return t.a.add_node(flat.Node{
-				kind:           .infix
-				op:             node.op
-				children_start: start
-				children_count: 2
-				pos:            node.pos
-				value:          node.value
-				typ:            target_type
-			})
+			lhs_id := t.a.child(&node, 0)
+			mut lhs_type := t.node_type(lhs_id)
+			if lhs_type.len == 0 {
+				lhs_type = t.resolve_expr_type(lhs_id)
+			}
+			if t.infix_struct_operator_result_type(node, lhs_type).len == 0 {
+				lhs := t.transform_expr_for_type(lhs_id, target_type)
+				rhs := t.transform_expr_for_type(t.a.child(&node, 1), target_type)
+				start := t.a.children.len
+				t.a.children << lhs
+				t.a.children << rhs
+				return t.a.add_node(flat.Node{
+					kind:           .infix
+					op:             node.op
+					children_start: start
+					children_count: 2
+					pos:            node.pos
+					value:          node.value
+					typ:            target_type
+				})
+			}
 		}
 	}
 	expr := t.transform_expr(id)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -3687,13 +3687,18 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 }
 
 fn (mut t Transformer) try_expand_plain_multi_decl(node flat.Node) ?[]flat.NodeId {
-	if node.kind != .decl_assign || node.children_count < 4 || node.children_count % 2 != 0 {
+	if node.kind != .decl_assign || node.children_count < 4 {
+		return none
+	}
+	lhs_count := t.multi_assign_lhs_count(node)
+	rhs_count := t.multi_assign_rhs_count(node)
+	if lhs_count != rhs_count || rhs_count <= 1 {
 		return none
 	}
 	mut result := []flat.NodeId{}
-	for i := 0; i < node.children_count; i += 2 {
-		lhs_id := t.a.child(&node, i)
-		rhs_id := t.a.child(&node, i + 1)
+	for i in 0 .. lhs_count {
+		lhs_id := t.multi_assign_lhs_id(node, i)
+		rhs_id := t.multi_assign_rhs_id(node, i)
 		lhs := t.a.nodes[int(lhs_id)]
 		rhs_node := t.a.nodes[int(rhs_id)]
 		generic_rhs_typ := if rhs_node.kind == .call {
@@ -3748,6 +3753,9 @@ fn (mut t Transformer) try_expand_multi_return_decl(node flat.Node) ?[]flat.Node
 	rhs_id := t.a.child(&node, 1)
 	rhs := t.a.nodes[int(rhs_id)]
 	lhs_ids := t.multi_assign_lhs_ids(node)
+	if t.multi_assign_rhs_count(node) != 1 {
+		return none
+	}
 	if rhs.kind == .if_expr {
 		return t.expand_multi_return_if_decl(rhs_id, rhs, lhs_ids)
 	}
@@ -3785,6 +3793,9 @@ fn (mut t Transformer) try_expand_multi_return_assign(node flat.Node) ?[]flat.No
 	rhs_id := t.a.child(&node, 1)
 	rhs := t.a.nodes[int(rhs_id)]
 	lhs_ids := t.multi_assign_lhs_ids(node)
+	if t.multi_assign_rhs_count(node) != 1 {
+		return none
+	}
 	if rhs.kind == .if_expr {
 		return t.expand_multi_return_if_assign(rhs_id, rhs, lhs_ids)
 	}
@@ -3815,16 +3826,20 @@ fn (mut t Transformer) try_expand_multi_return_assign(node flat.Node) ?[]flat.No
 
 // try_expand_plain_multi_assign supports try expand plain multi assign handling for Transformer.
 fn (mut t Transformer) try_expand_plain_multi_assign(node flat.Node) ?[]flat.NodeId {
-	if node.kind != .assign || node.op != .assign || node.children_count < 4
-		|| node.children_count % 2 != 0 {
+	if node.kind != .assign || node.op != .assign || node.children_count < 4 {
+		return none
+	}
+	lhs_count := t.multi_assign_lhs_count(node)
+	rhs_count := t.multi_assign_rhs_count(node)
+	if lhs_count != rhs_count || rhs_count <= 1 {
 		return none
 	}
 	mut result := []flat.NodeId{}
 	mut lhs_ids := []flat.NodeId{}
 	mut tmp_names := []string{}
-	for i := 0; i < node.children_count; i += 2 {
-		lhs_id := t.a.child(&node, i)
-		rhs_id := t.a.child(&node, i + 1)
+	for i in 0 .. lhs_count {
+		lhs_id := t.multi_assign_lhs_id(node, i)
+		rhs_id := t.multi_assign_rhs_id(node, i)
 		lhs_ids << lhs_id
 		lhs_type := t.lvalue_type(lhs_id)
 		rhs := if lhs_type.len > 0 {
@@ -3850,14 +3865,41 @@ fn (mut t Transformer) try_expand_plain_multi_assign(node flat.Node) ?[]flat.Nod
 
 // multi_assign_lhs_ids supports multi assign lhs ids handling for Transformer.
 fn (t &Transformer) multi_assign_lhs_ids(node flat.Node) []flat.NodeId {
-	mut lhs_ids := []flat.NodeId{}
-	if node.children_count > 0 {
-		lhs_ids << t.a.child(&node, 0)
-	}
-	for i in 2 .. node.children_count {
-		lhs_ids << t.a.child(&node, i)
+	lhs_count := t.multi_assign_lhs_count(node)
+	mut lhs_ids := []flat.NodeId{cap: lhs_count}
+	for i in 0 .. lhs_count {
+		lhs_ids << t.multi_assign_lhs_id(node, i)
 	}
 	return lhs_ids
+}
+
+fn (t &Transformer) multi_assign_lhs_count(node flat.Node) int {
+	if node.value.is_int() {
+		count := node.value.int()
+		if count > 0 && count <= int(node.children_count) {
+			return count
+		}
+	}
+	if node.children_count <= 2 {
+		return if node.children_count > 0 { 1 } else { 0 }
+	}
+	return int(node.children_count) - 1
+}
+
+fn (t &Transformer) multi_assign_rhs_count(node flat.Node) int {
+	lhs_count := t.multi_assign_lhs_count(node)
+	rhs_count := int(node.children_count) - lhs_count
+	return if rhs_count > 0 { rhs_count } else { 0 }
+}
+
+fn (t &Transformer) multi_assign_lhs_id(node flat.Node, index int) flat.NodeId {
+	rhs_count := t.multi_assign_rhs_count(node)
+	child_index := if index < rhs_count { index * 2 } else { rhs_count + index }
+	return t.a.child(&node, child_index)
+}
+
+fn (t &Transformer) multi_assign_rhs_id(node flat.Node, index int) flat.NodeId {
+	return t.a.child(&node, index * 2 + 1)
 }
 
 // multi_return_types_for_expr supports multi return types for expr handling for Transformer.

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -4152,7 +4152,12 @@ fn (mut t Transformer) lower_multi_if_assign(node flat.Node, lhs_ids []flat.Node
 // multi_if_assign_block supports multi if assign block handling for Transformer.
 fn (mut t Transformer) multi_if_assign_block(block_id flat.NodeId, lhs_ids []flat.NodeId) flat.NodeId {
 	block := t.a.nodes[int(block_id)]
-	parts := t.tuple_block_parts(block_id, lhs_ids.len) or { return t.transform_expr(block_id) }
+	parts := t.tuple_block_parts(block_id, lhs_ids.len) or {
+		if nested := t.nested_multi_if_assign_block(block_id, lhs_ids) {
+			return nested
+		}
+		return t.transform_expr(block_id)
+	}
 	mut stmts := t.transform_stmts(parts.prefix)
 	for i, value_id in parts.values {
 		value := t.transform_expr(value_id)
@@ -4171,6 +4176,31 @@ fn (mut t Transformer) multi_if_assign_block(block_id flat.NodeId, lhs_ids []fla
 	}
 	if block.kind == .block {
 		return t.make_block(stmts)
+	}
+	return t.make_block(stmts)
+}
+
+fn (mut t Transformer) nested_multi_if_assign_block(block_id flat.NodeId, lhs_ids []flat.NodeId) ?flat.NodeId {
+	if int(block_id) < 0 || lhs_ids.len == 0 {
+		return none
+	}
+	block := t.a.nodes[int(block_id)]
+	if block.kind != .block || block.children_count == 0 {
+		return none
+	}
+	children := t.a.children_of(&block).clone()
+	if children.len == 0 {
+		return none
+	}
+	last_id := children[children.len - 1]
+	last := t.a.nodes[int(last_id)]
+	if last.kind != .if_expr {
+		return none
+	}
+	mut stmts := t.transform_stmts(children[..children.len - 1])
+	nested_stmts := t.lower_multi_if_assign(last, lhs_ids)
+	for stmt in nested_stmts {
+		stmts << stmt
 	}
 	return t.make_block(stmts)
 }
@@ -4220,6 +4250,29 @@ fn (t &Transformer) tuple_block_parts(block_id flat.NodeId, count int) ?TupleBlo
 	return none
 }
 
+fn (t &Transformer) multi_if_branch_value_ids(block_id flat.NodeId, count int) ?[]flat.NodeId {
+	if parts := t.tuple_block_parts(block_id, count) {
+		return parts.values.clone()
+	}
+	if int(block_id) < 0 || count <= 0 {
+		return none
+	}
+	block := t.a.nodes[int(block_id)]
+	if block.kind != .block || block.children_count == 0 {
+		return none
+	}
+	children := t.a.children_of(&block)
+	if children.len == 0 {
+		return none
+	}
+	last_id := children[children.len - 1]
+	last := t.a.nodes[int(last_id)]
+	if last.kind != .if_expr || last.children_count < 2 {
+		return none
+	}
+	return t.multi_if_branch_value_ids(t.a.child(&last, 1), count)
+}
+
 // infer_multi_if_value_types resolves infer multi if value types information for transform.
 fn (t &Transformer) infer_multi_if_value_types(node flat.Node, count int) []string {
 	mut result := []string{cap: count}
@@ -4227,8 +4280,8 @@ fn (t &Transformer) infer_multi_if_value_types(node flat.Node, count int) []stri
 		return result
 	}
 	then_id := t.a.child(&node, 1)
-	if parts := t.tuple_block_parts(then_id, count) {
-		for value_id in parts.values {
+	if values := t.multi_if_branch_value_ids(then_id, count) {
+		for value_id in values {
 			mut typ := t.tuple_value_type(value_id)
 			if typ.len == 0 {
 				typ = 'int'

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -4229,20 +4229,30 @@ fn (mut t Transformer) multi_if_assign_block(block_id flat.NodeId, lhs_ids []fla
 
 fn (mut t Transformer) multi_if_assign_stmts(parts TupleBlockParts, lhs_ids []flat.NodeId) []flat.NodeId {
 	mut stmts := t.transform_stmts(parts.prefix)
+	mut tmp_names := []string{cap: parts.values.len}
 	for i, value_id in parts.values {
-		value := t.transform_expr(value_id)
+		target_type := if i < lhs_ids.len { t.lvalue_type(lhs_ids[i]) } else { '' }
+		value := if target_type.len > 0 {
+			t.transform_expr_for_type(value_id, target_type)
+		} else {
+			t.transform_expr(value_id)
+		}
 		t.drain_pending(mut stmts)
+		tmp_name := t.new_temp('multi_if')
+		tmp_type := if target_type.len > 0 { target_type } else { t.node_type(value_id) }
+		stmts << t.make_decl_assign_typed(tmp_name, value, tmp_type)
+		tmp_names << tmp_name
+	}
+	for i, tmp_name in tmp_names {
 		if i >= lhs_ids.len {
-			stmts << t.make_expr_stmt(value)
 			continue
 		}
 		lhs_id := lhs_ids[i]
 		lhs := t.a.nodes[int(lhs_id)]
 		if lhs.kind == .ident && lhs.value == '_' {
-			stmts << t.make_expr_stmt(value)
 			continue
 		}
-		stmts << t.make_assign(t.transform_lvalue(lhs_id), value)
+		stmts << t.make_assign(t.transform_lvalue(lhs_id), t.make_ident(tmp_name))
 	}
 	return stmts
 }

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4385,14 +4385,8 @@ fn (tc &TypeChecker) tuple_tail_value_groups(body_id flat.NodeId, count int) ?[]
 		if last.kind in [.block, .match_branch, .if_expr] {
 			return tc.multi_expr_tail_value_groups(last_id, count)
 		}
-		if last.kind == .return_stmt && last.children_count == count {
-			mut values := []flat.NodeId{cap: count}
-			for i in 0 .. last.children_count {
-				values << tc.a.child(&last, i)
-			}
-			mut groups := [][]flat.NodeId{}
-			groups << values
-			return groups
+		if last.kind == .return_stmt {
+			return [][]flat.NodeId{}
 		}
 	}
 	mut values := []flat.NodeId{}
@@ -6407,7 +6401,11 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 						continue
 					}
 					actual := tc.resolve_expr(arg_id, elem_type)
-					if !tc.receiver_compatible(actual, elem_type) {
+					if variadic_elem_accepts_any(elem_type) && !variadic_any_arg_has_value(actual) {
+						tc.type_mismatch(.call_arg_mismatch, 'cannot use `${actual.name()}` as argument ${
+							param_idx + 1} to `${tc.call_display_name(node)}`; expected `${elem_type.name()}`',
+							id)
+					} else if !tc.receiver_compatible(actual, elem_type) {
 						tc.type_mismatch(.call_arg_mismatch, 'cannot use `${actual.name()}` as argument ${
 							param_idx + 1} to `${tc.call_display_name(node)}`; expected `${elem_type.name()}`',
 							id)
@@ -6438,6 +6436,15 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 			actual := tc.resolve_expr(arg_id, elem_type)
 			actual_name := actual.name()
 			actual_raw := actual
+			if variadic_elem_accepts_any(elem_type) && !variadic_any_arg_has_value(actual) {
+				tc.type_mismatch(.call_arg_mismatch, 'cannot use `${actual_name}` as argument ${
+					param_idx + 1} to `${tc.call_display_name(node)}`; expected `${elem_type.name()}`',
+					id)
+				if has_dsl_scope {
+					tc.pop_scope()
+				}
+				continue
+			}
 			if actual is Array {
 				if !tc.receiver_compatible(actual_raw, elem_type)
 					&& !tc.receiver_compatible(actual_raw, expected) {
@@ -6483,6 +6490,10 @@ fn variadic_elem_accepts_any(typ Type) bool {
 	return false
 }
 
+fn variadic_any_arg_has_value(typ Type) bool {
+	return typ !is Void && typ !is Unknown && !type_contains_unknown(typ)
+}
+
 fn (tc &TypeChecker) arg_is_spread(id flat.NodeId) bool {
 	if !tc.valid_node_id(id) {
 		return false
@@ -6499,6 +6510,9 @@ fn (tc &TypeChecker) variadic_any_arg_is_scalar(id flat.NodeId) bool {
 		return false
 	}
 	actual := tc.resolve_type(id)
+	if !variadic_any_arg_has_value(actual) {
+		return false
+	}
 	if _ := array_type_from_receiver(actual) {
 		return false
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4790,17 +4790,17 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 				tc.check_node(child_id)
 			}
 			child := tc.a.nodes[int(child_id)]
-			if child.kind == .match_stmt {
-				if tc.should_diagnose(id) {
-					tc.record_error(.return_mismatch,
-						'match expression branches cannot produce multiple return values', id)
-				}
-				return
-			}
 			actual := tc.resolve_expr(child_id, expected)
 			if tc.type_compatible(actual, expected) {
 				$if ownership ? {
 					tc.ownership_after_return(id, node)
+				}
+				return
+			}
+			if child.kind == .match_stmt {
+				if tc.should_diagnose(id) {
+					tc.record_error(.return_mismatch,
+						'match expression branches cannot produce multiple return values', id)
 				}
 				return
 			}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4288,44 +4288,82 @@ fn (mut tc TypeChecker) check_multi_return_decl_assign(id flat.NodeId, node flat
 }
 
 fn (tc &TypeChecker) multi_expr_tail_types(expr_id flat.NodeId, count int) ?[]Type {
-	values := tc.multi_expr_tail_value_ids(expr_id, count) or { return none }
-	mut types := []Type{cap: values.len}
-	for value_id in values {
+	groups := tc.multi_expr_tail_value_groups(expr_id, count) or { return none }
+	if groups.len == 0 {
+		return none
+	}
+	mut types := []Type{cap: count}
+	for value_id in groups[0] {
 		types << tc.resolve_type(value_id)
+	}
+	for i in 1 .. groups.len {
+		group := groups[i]
+		if group.len != types.len {
+			return none
+		}
+		for j, value_id in group {
+			if !tc.multi_tail_type_compatible(tc.resolve_type(value_id), types[j]) {
+				return none
+			}
+		}
 	}
 	return types
 }
 
-fn (tc &TypeChecker) multi_expr_tail_value_ids(expr_id flat.NodeId, count int) ?[]flat.NodeId {
+fn (tc &TypeChecker) multi_tail_type_compatible(actual Type, expected Type) bool {
+	return tc.type_compatible(actual, expected) || tc.type_compatible(expected, actual)
+}
+
+fn (tc &TypeChecker) multi_expr_tail_value_groups(expr_id flat.NodeId, count int) ?[][]flat.NodeId {
 	if count <= 0 || !tc.valid_node_id(expr_id) {
 		return none
 	}
 	node := tc.a.nodes[int(expr_id)]
 	match node.kind {
 		.if_expr {
-			if node.children_count < 2 {
+			if node.children_count < 3 {
 				return none
 			}
-			return tc.tuple_tail_value_ids(tc.a.child(&node, 1), count)
+			mut groups := [][]flat.NodeId{}
+			then_groups := tc.tuple_tail_value_groups(tc.a.child(&node, 1), count) or {
+				return none
+			}
+			for group in then_groups {
+				groups << group
+			}
+			else_id := tc.a.child(&node, 2)
+			else_groups := tc.multi_expr_tail_value_groups(else_id, count) or { return none }
+			for group in else_groups {
+				groups << group
+			}
+			return groups
 		}
 		.match_stmt {
+			mut groups := [][]flat.NodeId{}
 			for i in 1 .. node.children_count {
 				branch_id := tc.a.child(&node, i)
 				if !tc.valid_node_id(branch_id) {
-					continue
+					return none
 				}
 				branch := tc.a.nodes[int(branch_id)]
 				if branch.kind == .match_branch {
-					return tc.tuple_tail_value_ids(branch_id, count)
+					branch_groups := tc.tuple_tail_value_groups(branch_id, count) or { return none }
+					for group in branch_groups {
+						groups << group
+					}
 				}
 			}
+			if groups.len == 0 {
+				return none
+			}
+			return groups
 		}
 		.block, .match_branch {
-			return tc.tuple_tail_value_ids(expr_id, count)
+			return tc.tuple_tail_value_groups(expr_id, count)
 		}
 		.expr_stmt {
 			if node.children_count > 0 {
-				return tc.multi_expr_tail_value_ids(tc.a.child(&node, 0), count)
+				return tc.multi_expr_tail_value_groups(tc.a.child(&node, 0), count)
 			}
 		}
 		else {}
@@ -4334,7 +4372,7 @@ fn (tc &TypeChecker) multi_expr_tail_value_ids(expr_id flat.NodeId, count int) ?
 	return none
 }
 
-fn (tc &TypeChecker) tuple_tail_value_ids(body_id flat.NodeId, count int) ?[]flat.NodeId {
+fn (tc &TypeChecker) tuple_tail_value_groups(body_id flat.NodeId, count int) ?[][]flat.NodeId {
 	if count <= 0 || !tc.valid_node_id(body_id) {
 		return none
 	}
@@ -4351,11 +4389,16 @@ fn (tc &TypeChecker) tuple_tail_value_ids(body_id flat.NodeId, count int) ?[]fla
 	if tc.valid_node_id(last_id) {
 		last := tc.a.nodes[int(last_id)]
 		if last.kind in [.block, .match_branch, .if_expr, .match_stmt] {
-			if nested := tc.multi_expr_tail_value_ids(last_id, count) {
-				if nested.len == count {
-					return nested
-				}
+			return tc.multi_expr_tail_value_groups(last_id, count)
+		}
+		if last.kind == .return_stmt && last.children_count == count {
+			mut values := []flat.NodeId{cap: count}
+			for i in 0 .. last.children_count {
+				values << tc.a.child(&last, i)
 			}
+			mut groups := [][]flat.NodeId{}
+			groups << values
+			return groups
 		}
 	}
 	mut values := []flat.NodeId{}
@@ -4370,7 +4413,9 @@ fn (tc &TypeChecker) tuple_tail_value_ids(body_id flat.NodeId, count int) ?[]fla
 		}
 		values.prepend(tc.a.child(&child, 0))
 		if values.len == count {
-			return values
+			mut groups := [][]flat.NodeId{}
+			groups << values
+			return groups
 		}
 	}
 	return none

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4346,26 +4346,6 @@ fn (tc &TypeChecker) multi_expr_tail_value_groups(expr_id flat.NodeId, count int
 			}
 			return groups
 		}
-		.match_stmt {
-			mut groups := [][]flat.NodeId{}
-			for i in 1 .. node.children_count {
-				branch_id := tc.a.child(&node, i)
-				if !tc.valid_node_id(branch_id) {
-					return none
-				}
-				branch := tc.a.nodes[int(branch_id)]
-				if branch.kind == .match_branch {
-					branch_groups := tc.tuple_tail_value_groups(branch_id, count) or { return none }
-					for group in branch_groups {
-						groups << group
-					}
-				}
-			}
-			if groups.len == 0 {
-				return none
-			}
-			return groups
-		}
 		.block, .match_branch {
 			return tc.tuple_tail_value_groups(expr_id, count)
 		}
@@ -4396,7 +4376,7 @@ fn (tc &TypeChecker) tuple_tail_value_groups(body_id flat.NodeId, count int) ?[]
 	last_id := tc.a.child(&body, body.children_count - 1)
 	if tc.valid_node_id(last_id) {
 		last := tc.a.nodes[int(last_id)]
-		if last.kind in [.block, .match_branch, .if_expr, .match_stmt] {
+		if last.kind in [.block, .match_branch, .if_expr] {
 			return tc.multi_expr_tail_value_groups(last_id, count)
 		}
 		if last.kind == .return_stmt && last.children_count == count {
@@ -4809,6 +4789,14 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 			} $else {
 				tc.check_node(child_id)
 			}
+			child := tc.a.nodes[int(child_id)]
+			if child.kind == .match_stmt {
+				if tc.should_diagnose(id) {
+					tc.record_error(.return_mismatch,
+						'match expression branches cannot produce multiple return values', id)
+				}
+				return
+			}
 			actual := tc.resolve_expr(child_id, expected)
 			if tc.type_compatible(actual, expected) {
 				$if ownership ? {
@@ -4816,8 +4804,7 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 				}
 				return
 			}
-			child := tc.a.nodes[int(child_id)]
-			if child.kind in [.if_expr, .match_stmt] {
+			if child.kind == .if_expr {
 				if item_types := tc.multi_expr_tail_types(child_id, multi.types.len) {
 					mut all_ok := item_types.len == multi.types.len
 					if all_ok {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4388,6 +4388,9 @@ fn (tc &TypeChecker) tuple_tail_value_groups(body_id flat.NodeId, count int) ?[]
 		if last.kind == .return_stmt {
 			return [][]flat.NodeId{}
 		}
+		if tc.expr_never_returns(last_id) {
+			return [][]flat.NodeId{}
+		}
 	}
 	mut values := []flat.NodeId{}
 	for i := int(body.children_count) - 1; i >= body_start; i-- {
@@ -6491,7 +6494,13 @@ fn variadic_elem_accepts_any(typ Type) bool {
 }
 
 fn variadic_any_arg_has_value(typ Type) bool {
-	return typ !is Void && typ !is Unknown && !type_contains_unknown(typ)
+	if typ is OptionType {
+		return typ.base_type !is Void
+	}
+	if typ is ResultType {
+		return typ.base_type !is Void
+	}
+	return typ !is Void && typ !is None && typ !is Unknown && !type_contains_unknown(typ)
 }
 
 fn (tc &TypeChecker) arg_is_spread(id flat.NodeId) bool {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1475,13 +1475,16 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 	node := tc.a.nodes[int(id)]
 	match node.kind {
 		.decl_assign {
-			// children are interleaved pairs [lhs0, rhs0, lhs1, rhs1, ...].
-			// Multi-return (`a, b := f()`) yields an odd count; we only insert
-			// locals for clean pairs and skip MultiReturn rhs values.
-			mut i := 0
-			for i + 1 < node.children_count {
-				lhs_id := tc.a.child(&node, i)
-				rhs_id := tc.a.child(&node, i + 1)
+			lhs_count := tc.multi_assign_lhs_count(node)
+			rhs_count := tc.multi_assign_rhs_count(node)
+			if rhs_count == 1 && lhs_count > 1 {
+				tc.annotate_node(tc.a.child(&node, 1))
+				return
+			}
+			pair_count := if lhs_count < rhs_count { lhs_count } else { rhs_count }
+			for pair_idx in 0 .. pair_count {
+				lhs_id := tc.multi_assign_lhs_id(node, pair_idx)
+				rhs_id := tc.multi_assign_rhs_id(node, pair_idx)
 				tc.annotate_node(rhs_id)
 				lhs := tc.a.nodes[int(lhs_id)]
 				if lhs.kind == .ident && lhs.value.len > 0 {
@@ -1497,7 +1500,6 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 						tc.remember_expr_type(lhs_id, typ)
 					}
 				}
-				i += 2
 			}
 			return
 		}
@@ -4429,14 +4431,41 @@ fn (tc &TypeChecker) tuple_tail_value_groups(body_id flat.NodeId, count int) ?[]
 
 // multi_assign_lhs_ids supports multi assign lhs ids handling for TypeChecker.
 fn (tc &TypeChecker) multi_assign_lhs_ids(node flat.Node) []flat.NodeId {
-	mut lhs_ids := []flat.NodeId{}
-	if node.children_count > 0 {
-		lhs_ids << tc.a.child(&node, 0)
-	}
-	for i in 2 .. node.children_count {
-		lhs_ids << tc.a.child(&node, i)
+	lhs_count := tc.multi_assign_lhs_count(node)
+	mut lhs_ids := []flat.NodeId{cap: lhs_count}
+	for i in 0 .. lhs_count {
+		lhs_ids << tc.multi_assign_lhs_id(node, i)
 	}
 	return lhs_ids
+}
+
+fn (tc &TypeChecker) multi_assign_lhs_count(node flat.Node) int {
+	if node.value.is_int() {
+		count := node.value.int()
+		if count > 0 && count <= int(node.children_count) {
+			return count
+		}
+	}
+	if node.children_count <= 2 {
+		return if node.children_count > 0 { 1 } else { 0 }
+	}
+	return int(node.children_count) - 1
+}
+
+fn (tc &TypeChecker) multi_assign_rhs_count(node flat.Node) int {
+	lhs_count := tc.multi_assign_lhs_count(node)
+	rhs_count := int(node.children_count) - lhs_count
+	return if rhs_count > 0 { rhs_count } else { 0 }
+}
+
+fn (tc &TypeChecker) multi_assign_lhs_id(node flat.Node, index int) flat.NodeId {
+	rhs_count := tc.multi_assign_rhs_count(node)
+	child_index := if index < rhs_count { index * 2 } else { rhs_count + index }
+	return tc.a.child(&node, child_index)
+}
+
+fn (tc &TypeChecker) multi_assign_rhs_id(node flat.Node, index int) flat.NodeId {
+	return tc.a.child(&node, index * 2 + 1)
 }
 
 // insert_decl_lhs updates insert decl lhs state for types.

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -6658,6 +6658,12 @@ fn (tc &TypeChecker) variadic_any_arg_is_scalar(id flat.NodeId) bool {
 	if tc.arg_is_spread(id) {
 		return false
 	}
+	if !tc.valid_node_id(id) {
+		return false
+	}
+	if tc.a.nodes[int(id)].kind == .enum_val {
+		return false
+	}
 	actual := tc.resolve_type(id)
 	if !variadic_any_arg_has_value(actual) {
 		return false

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -3219,7 +3219,7 @@ fn (tc &TypeChecker) match_without_else_exhaustive_enum_returns(node flat.Node) 
 }
 
 fn (tc &TypeChecker) match_without_else_exhaustive_bool_returns(node flat.Node) bool {
-	if node.children_count < 3 {
+	if node.children_count < 2 {
 		return false
 	}
 	subject_type := unwrap_pointer(tc.resolve_type(tc.a.child(&node, 0)))
@@ -6388,7 +6388,7 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 				variadic_raw := info.params[info.params.len - 1]
 				if variadic_raw is Array {
 					elem_type := array_elem_type(variadic_raw)
-					if variadic_elem_accepts_any(elem_type) {
+					if variadic_elem_accepts_any(elem_type) && tc.variadic_any_arg_is_scalar(arg_id) {
 						if has_dsl_scope {
 							tc.pop_scope()
 						}
@@ -6417,7 +6417,7 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 		expected_raw := expected
 		if info.is_variadic && param_idx == info.params.len - 1 && expected_raw is Array {
 			elem_type := array_elem_type(expected_raw)
-			if variadic_elem_accepts_any(elem_type) {
+			if variadic_elem_accepts_any(elem_type) && tc.variadic_any_arg_is_scalar(arg_id) {
 				if has_dsl_scope {
 					tc.pop_scope()
 				}
@@ -6425,13 +6425,12 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 			}
 			actual := tc.resolve_expr(arg_id, elem_type)
 			actual_name := actual.name()
-			expected_name := elem_type.name()
 			actual_raw := actual
 			if actual is Array {
 				if !tc.receiver_compatible(actual_raw, elem_type)
 					&& !tc.receiver_compatible(actual_raw, expected) {
 					tc.type_mismatch(.call_arg_mismatch, 'cannot use `${actual_name}` as argument ${
-						param_idx + 1} to `${tc.call_display_name(node)}`; expected `${expected_name}`',
+						param_idx + 1} to `${tc.call_display_name(node)}`; expected `${expected.name()}`',
 						id)
 				}
 				if has_dsl_scope {
@@ -6470,6 +6469,28 @@ fn variadic_elem_accepts_any(typ Type) bool {
 		return typ.base_type is Void
 	}
 	return false
+}
+
+fn (tc &TypeChecker) arg_is_spread(id flat.NodeId) bool {
+	if !tc.valid_node_id(id) {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	if node.kind == .prefix && (node.value == '...' || node.op == .none) && node.children_count > 0 {
+		return true
+	}
+	return false
+}
+
+fn (tc &TypeChecker) variadic_any_arg_is_scalar(id flat.NodeId) bool {
+	if tc.arg_is_spread(id) {
+		return false
+	}
+	actual := tc.resolve_type(id)
+	if _ := array_type_from_receiver(actual) {
+		return false
+	}
+	return true
 }
 
 fn (mut tc TypeChecker) specialized_plain_generic_call_info(node flat.Node, info CallInfo) CallInfo {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4312,6 +4312,12 @@ fn (tc &TypeChecker) multi_expr_tail_types(expr_id flat.NodeId, count int) ?[]Ty
 	return types
 }
 
+// multi_expr_tail_types_for_transform returns promoted multi-expression tail
+// types for transform lowering without duplicating checker compatibility rules.
+pub fn (tc &TypeChecker) multi_expr_tail_types_for_transform(expr_id flat.NodeId, count int) ?[]Type {
+	return tc.multi_expr_tail_types(expr_id, count)
+}
+
 fn (tc &TypeChecker) promoted_multi_tail_type(current Type, actual Type) ?Type {
 	if tc.type_compatible(actual, current) {
 		return current

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4304,7 +4304,11 @@ fn (tc &TypeChecker) multi_expr_tail_types(expr_id flat.NodeId, count int) ?[]Ty
 	}
 	mut types := []Type{cap: count}
 	for value_id in groups[0] {
-		types << tc.resolve_type(value_id)
+		typ := tc.resolve_type(value_id)
+		if !type_has_runtime_value(typ) {
+			return none
+		}
+		types << typ
 	}
 	for i in 1 .. groups.len {
 		group := groups[i]
@@ -4313,6 +4317,9 @@ fn (tc &TypeChecker) multi_expr_tail_types(expr_id flat.NodeId, count int) ?[]Ty
 		}
 		for j, value_id in group {
 			actual := tc.resolve_type(value_id)
+			if !type_has_runtime_value(actual) {
+				return none
+			}
 			promoted := tc.promoted_multi_tail_type(types[j], actual) or { return none }
 			types[j] = promoted
 		}
@@ -4375,14 +4382,20 @@ fn (tc &TypeChecker) match_multi_return_types(expr_id flat.NodeId, count int) ?[
 		if multi.types.len != count {
 			return none
 		}
+		for typ in multi.types {
+			if !type_has_runtime_value(typ) {
+				return none
+			}
+		}
 		if !saw_value_branch {
 			types = multi.types.clone()
 			saw_value_branch = true
 			continue
 		}
 		for j, actual in multi.types {
-			promoted := tc.promoted_multi_tail_type(types[j], actual) or { return none }
-			types[j] = promoted
+			if actual.name() != types[j].name() {
+				return none
+			}
 		}
 	}
 	if !saw_value_branch {
@@ -6631,6 +6644,10 @@ fn variadic_elem_accepts_any(typ Type) bool {
 }
 
 fn variadic_any_arg_has_value(typ Type) bool {
+	return type_has_runtime_value(typ)
+}
+
+fn type_has_runtime_value(typ Type) bool {
 	if typ is OptionType {
 		return typ.base_type !is Void
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4302,16 +4302,22 @@ fn (tc &TypeChecker) multi_expr_tail_types(expr_id flat.NodeId, count int) ?[]Ty
 			return none
 		}
 		for j, value_id in group {
-			if !tc.multi_tail_type_compatible(tc.resolve_type(value_id), types[j]) {
-				return none
-			}
+			actual := tc.resolve_type(value_id)
+			promoted := tc.promoted_multi_tail_type(types[j], actual) or { return none }
+			types[j] = promoted
 		}
 	}
 	return types
 }
 
-fn (tc &TypeChecker) multi_tail_type_compatible(actual Type, expected Type) bool {
-	return tc.type_compatible(actual, expected) || tc.type_compatible(expected, actual)
+fn (tc &TypeChecker) promoted_multi_tail_type(current Type, actual Type) ?Type {
+	if tc.type_compatible(actual, current) {
+		return current
+	}
+	if tc.type_compatible(current, actual) {
+		return actual
+	}
+	return none
 }
 
 fn (tc &TypeChecker) multi_expr_tail_value_groups(expr_id flat.NodeId, count int) ?[][]flat.NodeId {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -517,8 +517,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 		}
 	}
 	// Pass 1: collect type-level names (aliases, enums, sum types)
-	mut c_struct_decl_sigs := map[string]string{}
-	for node_idx, node in a.nodes {
+	for node in a.nodes {
 		match node.kind {
 			.file {
 				tc.enter_file(node.value)
@@ -548,24 +547,6 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 			}
 			.struct_decl {
 				qname := tc.qualify_name(node.value)
-				if qname.starts_with('C.') {
-					c_struct_key := qname
-					c_struct_sig := tc.c_struct_decl_signature(a, node)
-					if c_struct_key in c_struct_decl_sigs {
-						existing_sig := c_struct_decl_sigs[c_struct_key]
-						if !c_struct_decl_signatures_compatible(existing_sig, c_struct_sig) {
-							tc.record_error_unfiltered(.duplicate_decl,
-								'cannot redeclare C struct `${qname}`', flat.NodeId(node_idx))
-						}
-						existing_fields := c_struct_decl_signature_field_count(existing_sig)
-						current_fields := c_struct_decl_signature_field_count(c_struct_sig)
-						if current_fields > existing_fields {
-							c_struct_decl_sigs[c_struct_key] = c_struct_sig
-						}
-					} else {
-						c_struct_decl_sigs[c_struct_key] = c_struct_sig
-					}
-				}
 				if qname !in tc.structs {
 					tc.structs[qname] = []StructField{}
 				}
@@ -612,6 +593,8 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	}
 	// Pass 2: collect struct fields, function signatures (type aliases now available)
 	tc.type_cache.parse_enabled = true
+	tc.cur_module = ''
+	tc.check_c_struct_redeclarations(a)
 	tc.cur_module = ''
 	for node in a.nodes {
 		match node.kind {
@@ -802,6 +785,42 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	tc.build_const_suffixes()
 	$if ownership ? {
 		tc.ownership_after_collect()
+	}
+}
+
+fn (mut tc TypeChecker) check_c_struct_redeclarations(a &flat.FlatAst) {
+	mut c_struct_decl_sigs := map[string]string{}
+	for node_idx, node in a.nodes {
+		match node.kind {
+			.file {
+				tc.enter_file(node.value)
+			}
+			.module_decl {
+				tc.enter_module(node.value)
+			}
+			.struct_decl {
+				qname := tc.qualify_name(node.value)
+				if !qname.starts_with('C.') {
+					continue
+				}
+				c_struct_sig := tc.c_struct_decl_signature(a, node)
+				if qname in c_struct_decl_sigs {
+					existing_sig := c_struct_decl_sigs[qname]
+					if !c_struct_decl_signatures_compatible(existing_sig, c_struct_sig) {
+						tc.record_error_unfiltered(.duplicate_decl,
+							'cannot redeclare C struct `${qname}`', flat.NodeId(node_idx))
+					}
+					existing_fields := c_struct_decl_signature_field_count(existing_sig)
+					current_fields := c_struct_decl_signature_field_count(c_struct_sig)
+					if current_fields > existing_fields {
+						c_struct_decl_sigs[qname] = c_struct_sig
+					}
+				} else {
+					c_struct_decl_sigs[qname] = c_struct_sig
+				}
+			}
+			else {}
+		}
 	}
 }
 

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -3049,6 +3049,7 @@ fn (tc &TypeChecker) stmt_definitely_returns(id flat.NodeId) bool {
 				}
 			}
 			return has_else || tc.match_without_else_exhaustive_enum_returns(node)
+				|| tc.match_without_else_exhaustive_bool_returns(node)
 		}
 		else {
 			return false
@@ -3215,6 +3216,42 @@ fn (tc &TypeChecker) match_without_else_exhaustive_enum_returns(node flat.Node) 
 		return true
 	}
 	return false
+}
+
+fn (tc &TypeChecker) match_without_else_exhaustive_bool_returns(node flat.Node) bool {
+	if node.children_count < 3 {
+		return false
+	}
+	subject_type := unwrap_pointer(tc.resolve_type(tc.a.child(&node, 0)))
+	if subject_type !is Primitive {
+		return false
+	}
+	if !subject_type.props.has(.boolean) {
+		return false
+	}
+	mut covered_true := false
+	mut covered_false := false
+	for i in 1 .. node.children_count {
+		branch := tc.a.child_node(&node, i)
+		if branch.kind != .match_branch || branch.value == 'else' {
+			return false
+		}
+		n_conds := branch.value.int()
+		if n_conds <= 0 || n_conds > branch.children_count {
+			return false
+		}
+		for j in 0 .. n_conds {
+			cond := tc.a.child_node(branch, j)
+			if cond.kind == .bool_literal {
+				if cond.value == 'true' {
+					covered_true = true
+				} else if cond.value == 'false' {
+					covered_false = true
+				}
+			}
+		}
+	}
+	return covered_true && covered_false
 }
 
 fn (tc &TypeChecker) match_enum_condition_field(cond &flat.Node, enum_name string) ?string {
@@ -4137,6 +4174,62 @@ fn (mut tc TypeChecker) check_multi_return_decl_assign(id flat.NodeId, node flat
 		return false
 	}
 	rhs_id := tc.a.child(&node, 1)
+	rhs := tc.a.nodes[int(rhs_id)]
+	lhs_ids := tc.multi_assign_lhs_ids(node)
+	if tc.multi_assign_rhs_count(node) != 1 {
+		return false
+	}
+	if rhs.kind == .match_stmt {
+		tc.check_node(rhs_id)
+		if rhs_types := tc.match_multi_return_types(rhs_id, lhs_ids.len) {
+			tc.register_synth_type(rhs_id, MultiReturn{
+				types: rhs_types
+			})
+			for i, lhs_id in lhs_ids {
+				tc.insert_decl_lhs(lhs_id, rhs_types[i])
+			}
+			$if ownership ? {
+				tc.ownership_after_multi_return_decl_assign(lhs_ids, rhs_id, MultiReturn{
+					types: rhs_types
+				}, id)
+			}
+			return true
+		}
+		if tc.should_diagnose(id) {
+			if tc.match_has_tuple_tail_values(rhs_id, lhs_ids.len) {
+				tc.record_error(.assignment_mismatch,
+					'match expression branches cannot produce multiple assignment values', id)
+			} else {
+				tc.record_error(.assignment_mismatch,
+					'multi-return assignment mismatch: expression branches must all produce ${lhs_ids.len} compatible values',
+					id)
+			}
+		}
+		return true
+	}
+	if rhs.kind == .if_expr {
+		tc.check_node(rhs_id)
+		if rhs_types := tc.multi_expr_tail_types(rhs_id, lhs_ids.len) {
+			for i, lhs_id in lhs_ids {
+				tc.insert_decl_lhs(lhs_id, rhs_types[i])
+			}
+			$if ownership ? {
+				tc.ownership_after_multi_return_decl_assign(lhs_ids, rhs_id, MultiReturn{
+					types: rhs_types
+				}, id)
+			}
+			return true
+		}
+		rhs_type := tc.resolve_type(rhs_id)
+		if rhs_type !is MultiReturn || tc.expr_has_tuple_tail_values(rhs_id, lhs_ids.len) {
+			if tc.should_diagnose(id) {
+				tc.record_error(.assignment_mismatch,
+					'multi-return assignment mismatch: expression branches must all produce ${lhs_ids.len} compatible values',
+					id)
+			}
+			return true
+		}
+	}
 	mut rhs_type := tc.resolve_type(rhs_id)
 	mut rhs_checked := false
 	mut rhs_multi := MultiReturn{}
@@ -4175,7 +4268,6 @@ fn (mut tc TypeChecker) check_multi_return_decl_assign(id flat.NodeId, node flat
 		if !rhs_checked {
 			tc.check_node(rhs_id)
 		}
-		lhs_ids := tc.multi_assign_lhs_ids(node)
 		if lhs_ids.len != rhs_multi.types.len {
 			if tc.should_diagnose(id) {
 				tc.record_error(.assignment_mismatch,
@@ -4193,6 +4285,95 @@ fn (mut tc TypeChecker) check_multi_return_decl_assign(id flat.NodeId, node flat
 		return true
 	}
 	return false
+}
+
+fn (tc &TypeChecker) multi_expr_tail_types(expr_id flat.NodeId, count int) ?[]Type {
+	values := tc.multi_expr_tail_value_ids(expr_id, count) or { return none }
+	mut types := []Type{cap: values.len}
+	for value_id in values {
+		types << tc.resolve_type(value_id)
+	}
+	return types
+}
+
+fn (tc &TypeChecker) multi_expr_tail_value_ids(expr_id flat.NodeId, count int) ?[]flat.NodeId {
+	if count <= 0 || !tc.valid_node_id(expr_id) {
+		return none
+	}
+	node := tc.a.nodes[int(expr_id)]
+	match node.kind {
+		.if_expr {
+			if node.children_count < 2 {
+				return none
+			}
+			return tc.tuple_tail_value_ids(tc.a.child(&node, 1), count)
+		}
+		.match_stmt {
+			for i in 1 .. node.children_count {
+				branch_id := tc.a.child(&node, i)
+				if !tc.valid_node_id(branch_id) {
+					continue
+				}
+				branch := tc.a.nodes[int(branch_id)]
+				if branch.kind == .match_branch {
+					return tc.tuple_tail_value_ids(branch_id, count)
+				}
+			}
+		}
+		.block, .match_branch {
+			return tc.tuple_tail_value_ids(expr_id, count)
+		}
+		.expr_stmt {
+			if node.children_count > 0 {
+				return tc.multi_expr_tail_value_ids(tc.a.child(&node, 0), count)
+			}
+		}
+		else {}
+	}
+
+	return none
+}
+
+fn (tc &TypeChecker) tuple_tail_value_ids(body_id flat.NodeId, count int) ?[]flat.NodeId {
+	if count <= 0 || !tc.valid_node_id(body_id) {
+		return none
+	}
+	body := tc.a.nodes[int(body_id)]
+	body_start := if body.kind == .match_branch {
+		if body.value == 'else' { 0 } else { body.value.int() }
+	} else {
+		0
+	}
+	if body.kind !in [.block, .match_branch] || body.children_count <= body_start {
+		return none
+	}
+	last_id := tc.a.child(&body, body.children_count - 1)
+	if tc.valid_node_id(last_id) {
+		last := tc.a.nodes[int(last_id)]
+		if last.kind in [.block, .match_branch, .if_expr, .match_stmt] {
+			if nested := tc.multi_expr_tail_value_ids(last_id, count) {
+				if nested.len == count {
+					return nested
+				}
+			}
+		}
+	}
+	mut values := []flat.NodeId{}
+	for i := int(body.children_count) - 1; i >= body_start; i-- {
+		child_id := tc.a.child(&body, i)
+		if !tc.valid_node_id(child_id) {
+			break
+		}
+		child := tc.a.nodes[int(child_id)]
+		if child.kind != .expr_stmt || child.children_count == 0 {
+			break
+		}
+		values.prepend(tc.a.child(&child, 0))
+		if values.len == count {
+			return values
+		}
+	}
+	return none
 }
 
 // multi_assign_lhs_ids supports multi assign lhs ids handling for TypeChecker.
@@ -4319,6 +4500,63 @@ fn (mut tc TypeChecker) check_multi_return_assign(id flat.NodeId, node flat.Node
 		return false
 	}
 	rhs_id := tc.a.child(&node, 1)
+	rhs := tc.a.nodes[int(rhs_id)]
+	lhs_ids := tc.multi_assign_lhs_ids(node)
+	if tc.multi_assign_rhs_count(node) != 1 {
+		return false
+	}
+	if rhs.kind == .match_stmt {
+		tc.check_node(rhs_id)
+		if rhs_types := tc.match_multi_return_types(rhs_id, lhs_ids.len) {
+			tc.register_synth_type(rhs_id, MultiReturn{
+				types: rhs_types
+			})
+			for i, lhs_id in lhs_ids {
+				lhs_type := tc.resolve_lvalue_type(lhs_id)
+				if !tc.type_compatible(rhs_types[i], lhs_type) {
+					tc.type_mismatch(.assignment_mismatch,
+						'cannot assign `${rhs_types[i].name()}` to `${lhs_type.name()}`', id)
+				}
+			}
+			$if ownership ? {
+				tc.ownership_after_multi_return_assign(lhs_ids, rhs_id, MultiReturn{
+					types: rhs_types
+				}, id)
+			}
+			return true
+		}
+		if tc.should_diagnose(id) {
+			if tc.match_has_tuple_tail_values(rhs_id, lhs_ids.len) {
+				tc.record_error(.assignment_mismatch,
+					'match expression branches cannot produce multiple assignment values', id)
+			} else {
+				tc.record_error(.assignment_mismatch,
+					'multi-return assignment mismatch: expression branches must all produce ${lhs_ids.len} compatible values',
+					id)
+			}
+		}
+		return true
+	}
+	if rhs.kind == .if_expr {
+		tc.check_node(rhs_id)
+		if rhs_types := tc.multi_expr_tail_assign_types(id, rhs_id, lhs_ids) {
+			$if ownership ? {
+				tc.ownership_after_multi_return_assign(lhs_ids, rhs_id, MultiReturn{
+					types: rhs_types
+				}, id)
+			}
+			return true
+		}
+		rhs_type := tc.resolve_type(rhs_id)
+		if rhs_type !is MultiReturn || tc.expr_has_tuple_tail_values(rhs_id, lhs_ids.len) {
+			if tc.should_diagnose(id) {
+				tc.record_error(.assignment_mismatch,
+					'multi-return assignment mismatch: expression branches must all produce ${lhs_ids.len} compatible values',
+					id)
+			}
+			return true
+		}
+	}
 	mut rhs_type := tc.resolve_type(rhs_id)
 	mut rhs_checked := false
 	mut rhs_multi := MultiReturn{}
@@ -4357,7 +4595,6 @@ fn (mut tc TypeChecker) check_multi_return_assign(id flat.NodeId, node flat.Node
 		if !rhs_checked {
 			tc.check_node(rhs_id)
 		}
-		lhs_ids := tc.multi_assign_lhs_ids(node)
 		if lhs_ids.len != rhs_multi.types.len {
 			if tc.should_diagnose(id) {
 				tc.record_error(.assignment_mismatch,
@@ -4498,6 +4735,26 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 					tc.ownership_after_return(id, node)
 				}
 				return
+			}
+			child := tc.a.nodes[int(child_id)]
+			if child.kind in [.if_expr, .match_stmt] {
+				if item_types := tc.multi_expr_tail_types(child_id, multi.types.len) {
+					mut all_ok := item_types.len == multi.types.len
+					if all_ok {
+						for i, item_type in item_types {
+							if !tc.type_compatible(item_type, multi.types[i]) {
+								all_ok = false
+								break
+							}
+						}
+					}
+					if all_ok {
+						$if ownership ? {
+							tc.ownership_after_return(id, node)
+						}
+						return
+					}
+				}
 			}
 		}
 		if node.children_count != multi.types.len {
@@ -6080,6 +6337,12 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 				variadic_raw := info.params[info.params.len - 1]
 				if variadic_raw is Array {
 					elem_type := array_elem_type(variadic_raw)
+					if variadic_elem_accepts_any(elem_type) {
+						if has_dsl_scope {
+							tc.pop_scope()
+						}
+						continue
+					}
 					actual := tc.resolve_expr(arg_id, elem_type)
 					if !tc.receiver_compatible(actual, elem_type) {
 						tc.type_mismatch(.call_arg_mismatch, 'cannot use `${actual.name()}` as argument ${
@@ -6103,6 +6366,12 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 		expected_raw := expected
 		if info.is_variadic && param_idx == info.params.len - 1 && expected_raw is Array {
 			elem_type := array_elem_type(expected_raw)
+			if variadic_elem_accepts_any(elem_type) {
+				if has_dsl_scope {
+					tc.pop_scope()
+				}
+				continue
+			}
 			actual := tc.resolve_expr(arg_id, elem_type)
 			actual_name := actual.name()
 			expected_name := elem_type.name()
@@ -6143,6 +6412,13 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 				id)
 		}
 	}
+}
+
+fn variadic_elem_accepts_any(typ Type) bool {
+	if typ is Pointer {
+		return typ.base_type is Void
+	}
+	return false
 }
 
 fn (mut tc TypeChecker) specialized_plain_generic_call_info(node flat.Node, info CallInfo) CallInfo {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4336,6 +4336,72 @@ fn (mut tc TypeChecker) multi_expr_tail_assign_types(id flat.NodeId, expr_id fla
 	return lhs_types
 }
 
+fn (tc &TypeChecker) match_multi_return_types(expr_id flat.NodeId, count int) ?[]Type {
+	if count <= 0 || !tc.valid_node_id(expr_id) {
+		return none
+	}
+	node := tc.a.nodes[int(expr_id)]
+	if node.kind != .match_stmt || node.children_count < 2 {
+		return none
+	}
+	mut types := []Type{}
+	mut saw_value_branch := false
+	for i in 1 .. node.children_count {
+		branch_id := tc.a.child(&node, i)
+		if !tc.valid_node_id(branch_id) {
+			continue
+		}
+		branch := tc.a.nodes[int(branch_id)]
+		if branch.kind != .match_branch {
+			continue
+		}
+		tail_id := tc.branch_tail_expr_id(branch_id)
+		if !tc.valid_node_id(tail_id) {
+			return none
+		}
+		tail := tc.a.nodes[int(tail_id)]
+		if tail.kind == .return_stmt || tc.expr_never_returns(tail_id) {
+			continue
+		}
+		multi := multi_return_payload_type(tc.resolve_type(tail_id)) or { return none }
+		if multi.types.len != count {
+			return none
+		}
+		if !saw_value_branch {
+			types = multi.types.clone()
+			saw_value_branch = true
+			continue
+		}
+		for j, actual in multi.types {
+			promoted := tc.promoted_multi_tail_type(types[j], actual) or { return none }
+			types[j] = promoted
+		}
+	}
+	if !saw_value_branch {
+		return none
+	}
+	return types
+}
+
+fn (tc &TypeChecker) match_has_tuple_tail_values(expr_id flat.NodeId, count int) bool {
+	if count <= 0 || !tc.valid_node_id(expr_id) {
+		return false
+	}
+	node := tc.a.nodes[int(expr_id)]
+	if node.kind != .match_stmt || node.children_count < 2 {
+		return false
+	}
+	for i in 1 .. node.children_count {
+		branch_id := tc.a.child(&node, i)
+		if groups := tc.tuple_tail_value_groups(branch_id, count) {
+			if groups.len > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // multi_expr_tail_types_for_transform returns promoted multi-expression tail
 // types for transform lowering without duplicating checker compatibility rules.
 pub fn (tc &TypeChecker) multi_expr_tail_types_for_transform(expr_id flat.NodeId, count int) ?[]Type {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -549,8 +549,8 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 			.struct_decl {
 				qname := tc.qualify_name(node.value)
 				if qname.starts_with('C.') {
-					c_struct_key := tc.cur_file + '\n' + qname
-					c_struct_sig := c_struct_decl_signature(a, node)
+					c_struct_key := qname
+					c_struct_sig := tc.c_struct_decl_signature(a, node)
 					if c_struct_key in c_struct_decl_sigs {
 						existing_sig := c_struct_decl_sigs[c_struct_key]
 						if !c_struct_decl_signatures_compatible(existing_sig, c_struct_sig) {
@@ -805,7 +805,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	}
 }
 
-fn c_struct_decl_signature(a &flat.FlatAst, node flat.Node) string {
+fn (tc &TypeChecker) c_struct_decl_signature(a &flat.FlatAst, node flat.Node) string {
 	mut sig := node.typ
 	mut has_fields := false
 	for i in 0 .. node.children_count {
@@ -815,7 +815,8 @@ fn c_struct_decl_signature(a &flat.FlatAst, node flat.Node) string {
 		}
 		has_fields = true
 		field_name := if f.value.starts_with('@') { f.value[1..] } else { f.value }
-		sig += '|${field_name}:${f.typ}'
+		field_typ := if f.typ.len > 0 { f.typ } else { f.value }
+		sig += '|${field_name}:${tc.c_type(tc.parse_type(field_typ))}'
 	}
 	if !has_fields {
 		return ''

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -3224,7 +3224,8 @@ fn (tc &TypeChecker) match_without_else_exhaustive_bool_returns(node flat.Node) 
 	if node.children_count < 2 {
 		return false
 	}
-	subject_type := unwrap_pointer(tc.resolve_type(tc.a.child(&node, 0)))
+	raw_subject_type := unalias_type(tc.resolve_type(tc.a.child(&node, 0)))
+	subject_type := unalias_type(unwrap_pointer(raw_subject_type))
 	if subject_type !is Primitive {
 		return false
 	}
@@ -3254,6 +3255,13 @@ fn (tc &TypeChecker) match_without_else_exhaustive_bool_returns(node flat.Node) 
 		}
 	}
 	return covered_true && covered_false
+}
+
+fn unalias_type(t Type) Type {
+	if t is Alias {
+		return unalias_type(t.base_type)
+	}
+	return t
 }
 
 fn (tc &TypeChecker) match_enum_condition_field(cond &flat.Node, enum_name string) ?string {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4410,6 +4410,45 @@ fn (tc &TypeChecker) match_has_tuple_tail_values(expr_id flat.NodeId, count int)
 	return false
 }
 
+fn (tc &TypeChecker) expr_has_tuple_tail_values(expr_id flat.NodeId, count int) bool {
+	if count <= 0 || !tc.valid_node_id(expr_id) {
+		return false
+	}
+	if groups := tc.tuple_tail_value_groups(expr_id, count) {
+		if groups.len > 0 {
+			return true
+		}
+	}
+	node := tc.a.nodes[int(expr_id)]
+	match node.kind {
+		.if_expr {
+			if node.children_count > 1 && tc.expr_has_tuple_tail_values(tc.a.child(&node, 1), count) {
+				return true
+			}
+			return node.children_count > 2
+				&& tc.expr_has_tuple_tail_values(tc.a.child(&node, 2), count)
+		}
+		.block, .match_branch {
+			body_start := if node.kind == .match_branch {
+				if node.value == 'else' { 0 } else { node.value.int() }
+			} else {
+				0
+			}
+			if node.children_count <= body_start {
+				return false
+			}
+			return tc.expr_has_tuple_tail_values(tc.a.child(&node, node.children_count - 1), count)
+		}
+		.expr_stmt {
+			return node.children_count > 0
+				&& tc.expr_has_tuple_tail_values(tc.a.child(&node, 0), count)
+		}
+		else {
+			return false
+		}
+	}
+}
+
 // multi_expr_tail_types_for_transform returns promoted multi-expression tail
 // types for transform lowering without duplicating checker compatibility rules.
 pub fn (tc &TypeChecker) multi_expr_tail_types_for_transform(expr_id flat.NodeId, count int) ?[]Type {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -6598,6 +6598,9 @@ fn variadic_any_arg_has_value(typ Type) bool {
 	if typ is ResultType {
 		return typ.base_type !is Void
 	}
+	if typ is MultiReturn {
+		return false
+	}
 	return typ !is Void && typ !is None && typ !is Unknown && !type_contains_unknown(typ)
 }
 

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -149,6 +149,7 @@ pub:
 	is_c_variadic        bool
 	params_known         bool
 	has_implicit_veb_ctx bool
+	arg_offset           int
 }
 
 // LocalBinding represents local binding data used by types.
@@ -1590,10 +1591,11 @@ fn (mut tc TypeChecker) annotate_call_expected_exprs(id flat.NodeId, node flat.N
 	}
 	collapsed := if field_init_args > 0 { 1 } else { 0 }
 	recv_extra := if info.has_receiver { 1 } else { 0 }
-	actual_count := node.children_count - 1 - field_init_args + collapsed + recv_extra
+	actual_count := node.children_count - 1 - info.arg_offset - field_init_args + collapsed +
+		recv_extra
 	ctx_count := if info.has_implicit_veb_ctx { 1 } else { 0 }
 	ctx_omitted := ctx_count > 0 && actual_count < info.params.len
-	for i in 1 .. node.children_count {
+	for i in 1 + info.arg_offset .. node.children_count {
 		raw_arg := tc.a.child_node(&node, i)
 		arg_id := tc.call_arg_value(tc.a.child(&node, i))
 		if raw_arg.kind == .field_init {
@@ -1601,7 +1603,7 @@ fn (mut tc TypeChecker) annotate_call_expected_exprs(id flat.NodeId, node flat.N
 			continue
 		}
 		arg_shift := if ctx_omitted { ctx_count } else { 0 }
-		param_idx := (if info.has_receiver { i } else { i - 1 }) + arg_shift
+		param_idx := i - 1 - info.arg_offset + (if info.has_receiver { 1 } else { 0 }) + arg_shift
 		if info.is_c_variadic && param_idx >= c_variadic_fixed_param_count(info) {
 			continue
 		}
@@ -5126,7 +5128,8 @@ fn (tc &TypeChecker) expr_has_option_result_handler(id flat.NodeId) bool {
 
 // check_call validates check call state for types.
 fn (mut tc TypeChecker) check_call(id flat.NodeId, node flat.Node) {
-	if info := tc.resolve_call_info(id, node) {
+	if info0 := tc.resolve_call_info(id, node) {
+		info := tc.specialized_plain_generic_call_info(node, info0)
 		if info.name.len > 0 && !is_array_dsl_call_name(info.name) {
 			tc.remember_resolved_call(id, info.name)
 		}
@@ -5251,12 +5254,18 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 				if resolved_mod := tc.resolve_import_alias(base_node.value) {
 					mod_name := '${resolved_mod}.${fn_node.value}'
 					if mod_name in tc.fn_ret_types {
+						if info := tc.decode_call_info_from_type_arg(node, mod_name, false) {
+							return info
+						}
 						return tc.call_info(mod_name, false)
 					}
 				}
 				if base_node.value == tc.cur_module {
 					mod_name := '${tc.cur_module}.${fn_node.value}'
 					if mod_name in tc.fn_ret_types {
+						if info := tc.decode_call_info_from_type_arg(node, mod_name, false) {
+							return info
+						}
 						return tc.call_info(mod_name, false)
 					}
 				}
@@ -5304,6 +5313,17 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 		}
 		base_type := tc.resolve_type(base_id)
 		clean := unwrap_pointer(base_type)
+		if fn_node.value == 'wait' {
+			if ret_type := tc.thread_wait_return_type(base_type) {
+				return CallInfo{
+					name:         ''
+					params:       tarr1(base_type)
+					return_type:  ret_type
+					has_receiver: true
+					params_known: true
+				}
+			}
+		}
 		if info := tc.pointer_builtin_method_call_info(base_type, fn_node.value) {
 			return info
 		}
@@ -5324,6 +5344,9 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 				has_receiver: true
 				params_known: true
 			}
+		}
+		if info := tc.current_receiver_param_method_call_info(base_id, fn_node.value) {
+			return info
 		}
 		if clean is Alias {
 			if _ := array_type_from_receiver(clean) {
@@ -5633,6 +5656,19 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 				else {}
 			}
 		}
+		if fixed_array := fixed_array_type_from_receiver(clean) {
+			if fn_node.value == 'clone' {
+				return CallInfo{
+					name:         'array.clone'
+					params:       tarr1(base_type)
+					return_type:  Type(Array{
+						elem_type: fixed_array.elem_type
+					})
+					has_receiver: true
+					params_known: true
+				}
+			}
+		}
 		mut array_pointers_fallback := false
 		if fn_node.value == 'pointers' {
 			if _ := array_type_from_receiver(clean) {
@@ -5649,6 +5685,9 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 					has_receiver: true
 					params_known: true
 				}
+			}
+			if info := tc.resolve_generic_struct_method(type_name, fn_node.value) {
+				return info
 			}
 			for mname in receiver_method_name_candidates(clean, fn_node.value, tc.cur_module) {
 				if mname in tc.fn_ret_types {
@@ -5701,9 +5740,6 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 				}
 			}
 			if info := tc.embedded_method_call_info(type_name, fn_node.value) {
-				return info
-			}
-			if info := tc.resolve_generic_struct_method(type_name, fn_node.value) {
 				return info
 			}
 			if fn_node.value == 'use' && clean is Struct
@@ -5843,6 +5879,49 @@ fn (tc &TypeChecker) is_builtin_hex_receiver(typ Type) bool {
 			'u64', 'i64']
 	}
 	return clean is Rune || clean is Char
+}
+
+fn (tc &TypeChecker) current_receiver_param_method_call_info(base_id flat.NodeId, method string) ?CallInfo {
+	if tc.cur_fn_node_id < 0 || int(base_id) < 0 || int(base_id) >= tc.a.nodes.len {
+		return none
+	}
+	base := tc.a.nodes[int(base_id)]
+	if base.kind != .ident {
+		return none
+	}
+	fn_node := tc.a.nodes[tc.cur_fn_node_id]
+	if fn_node.kind != .fn_decl || !fn_node.value.contains('.') {
+		return none
+	}
+	receiver_name := fn_node.value.all_before_last('.')
+	if receiver_name.len == 0 {
+		return none
+	}
+	mut param_type := Type(void_)
+	mut found_param := false
+	for i in 0 .. fn_node.children_count {
+		param := tc.a.child_node(&fn_node, i)
+		if param.kind == .param && param.value == base.value {
+			param_type = tc.parse_type(param.typ)
+			found_param = true
+			break
+		}
+	}
+	if !found_param {
+		return none
+	}
+	receiver_type := tc.parse_type(receiver_name)
+	if !tc.type_compatible(param_type, receiver_type)
+		&& !tc.type_compatible(receiver_type, param_type) {
+		return none
+	}
+	method_name := '${receiver_name}.${method}'
+	for candidate in [method_name, checker_qualified_fn_name(tc.cur_module, method_name)] {
+		if candidate in tc.fn_ret_types {
+			return tc.call_info(candidate, true)
+		}
+	}
+	return none
 }
 
 fn (tc &TypeChecker) type_is_pointer_receiver(typ Type) bool {
@@ -6018,10 +6097,32 @@ fn (mut tc TypeChecker) explicit_generic_call_info(name string, has_receiver boo
 }
 
 fn is_decode_call_name(name string) bool {
-	return match name.len {
-		11 { name == 'json.decode' }
-		12 { name == 'json2.decode' }
-		else { false }
+	return name in ['json.decode', 'json2.decode', 'x.json2.decode']
+}
+
+fn (tc &TypeChecker) decode_call_info_from_type_arg(node flat.Node, name string, has_receiver bool) ?CallInfo {
+	if !is_decode_call_name(name) || node.children_count < 2 {
+		return none
+	}
+	type_arg_id := tc.a.child(&node, 1)
+	type_arg := tc.generic_call_type_arg_name(type_arg_id)
+	if type_arg.len == 0 {
+		return none
+	}
+	info := tc.call_info(name, has_receiver)
+	params := if info.params.len > 0 { info.params[1..].clone() } else { []Type{} }
+	return CallInfo{
+		name:                 info.name
+		params:               params
+		return_type:          Type(ResultType{
+			base_type: tc.parse_type(type_arg)
+		})
+		has_receiver:         info.has_receiver
+		is_variadic:          info.is_variadic
+		is_c_variadic:        info.is_c_variadic
+		params_known:         info.params_known
+		has_implicit_veb_ctx: info.has_implicit_veb_ctx
+		arg_offset:           1
 	}
 }
 
@@ -6120,6 +6221,9 @@ fn (tc &TypeChecker) generic_call_type_arg_name(id flat.NodeId) string {
 		.map_init {
 			return node.value
 		}
+		.struct_decl {
+			return node.value
+		}
 		.prefix {
 			if node.children_count == 0 {
 				return ''
@@ -6171,6 +6275,20 @@ fn array_type_from_receiver(t Type) ?Array {
 	}
 	if t is Alias {
 		return array_type_from_receiver(t.base_type)
+	}
+	return none
+}
+
+fn (tc &TypeChecker) thread_wait_return_type(t Type) ?Type {
+	clean := unwrap_pointer(t)
+	if clean is Struct {
+		thread_name := clean.name.trim_space()
+		if thread_name == 'thread' || thread_name.ends_with('.thread') {
+			return Type(void_)
+		}
+		if thread_name.starts_with('thread ') {
+			return tc.parse_type(thread_name[7..].trim_space())
+		}
 	}
 	return none
 }
@@ -6481,7 +6599,8 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 	}
 	collapsed := if field_init_args > 0 { 1 } else { 0 }
 	recv_extra := if info.has_receiver { 1 } else { 0 }
-	actual_count := node.children_count - 1 - field_init_args + collapsed + recv_extra
+	actual_count := node.children_count - 1 - info.arg_offset - field_init_args + collapsed +
+		recv_extra
 	// A hidden veb `Context` parameter may be supplied implicitly from the
 	// enclosing handler instead of by the caller, so accept argument counts both
 	// with the ctx (route dispatch) and without it (handler delegation).
@@ -6510,7 +6629,7 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 				'cannot use receiver `${recv_type.name()}` as `${info.params[0].name()}`', id)
 		}
 	}
-	for i in 1 .. node.children_count {
+	for i in 1 + info.arg_offset .. node.children_count {
 		arg_id := tc.call_arg_value(tc.a.child(&node, i))
 		// field_init args are fields of the collapsed `@[params]` struct, not positional params
 		if tc.a.child_node(&node, i).kind == .field_init {
@@ -6525,7 +6644,7 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 		// (it is inserted right after the receiver) while mapping the caller's
 		// positional arguments to the callee's params.
 		arg_shift := if ctx_omitted { ctx_count } else { 0 }
-		param_idx := (if info.has_receiver { i } else { i - 1 }) + arg_shift
+		param_idx := i - 1 - info.arg_offset + (if info.has_receiver { 1 } else { 0 }) + arg_shift
 		has_dsl_scope := tc.call_arg_needs_array_dsl_scope(info.name, param_idx)
 		if has_dsl_scope {
 			tc.push_array_dsl_scope(node, info.name)
@@ -6620,6 +6739,9 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 			actual = tc.resolve_expr(arg_id, expected)
 		}
 		if !tc.receiver_compatible(actual, expected) {
+			if json_encode_accepts_arg(info.name, param_idx, expected, actual) {
+				continue
+			}
 			if tc.array_insert_prepend_many_arg_compatible(node, info, param_idx, actual) {
 				continue
 			}
@@ -6634,6 +6756,18 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 				id)
 		}
 	}
+}
+
+fn json_encode_accepts_arg(name string, param_idx int, expected Type, actual Type) bool {
+	if param_idx != 0 || name !in ['json.encode', 'json.encode_pretty'] {
+		return false
+	}
+	if expected is Pointer {
+		if expected.base_type is Void {
+			return type_has_runtime_value(actual)
+		}
+	}
+	return false
 }
 
 fn variadic_elem_accepts_any(typ Type) bool {
@@ -6710,7 +6844,7 @@ fn (mut tc TypeChecker) specialized_plain_generic_call_info(node flat.Node, info
 		}
 	}
 	for param_idx in first_param_idx .. param_texts.len {
-		arg_idx := param_idx - first_param_idx + 1
+		arg_idx := param_idx - first_param_idx + 1 + info.arg_offset
 		if arg_idx >= node.children_count {
 			break
 		}
@@ -6745,6 +6879,7 @@ fn (mut tc TypeChecker) specialized_plain_generic_call_info(node flat.Node, info
 		is_c_variadic:        info.is_c_variadic
 		params_known:         true
 		has_implicit_veb_ctx: info.has_implicit_veb_ctx
+		arg_offset:           info.arg_offset
 	}
 }
 
@@ -8362,8 +8497,8 @@ fn (mut tc TypeChecker) check_match_stmt(id flat.NodeId, node flat.Node) {
 			cond_id := tc.a.child(branch, 0)
 			cond := tc.a.node(cond_id)
 			if pattern := tc.match_type_pattern(cond) {
-				if tc.type_symbol_known(pattern) {
-					tc.smartcasts[subject_key] = tc.parse_type(pattern)
+				if variant_type := tc.match_sum_variant_type(subject_type, pattern) {
+					tc.smartcasts[subject_key] = variant_type
 				}
 			}
 		}
@@ -9597,6 +9732,9 @@ fn (tc &TypeChecker) type_compatible(actual Type, expected Type) bool {
 		return tc.type_compatible(actual.base_type, expected.base_type)
 	}
 	if actual is Alias {
+		if expected is Interface && tc.type_implements_interface(actual, expected) {
+			return true
+		}
 		return tc.type_compatible(actual.base_type, expected)
 	}
 	if expected is Alias {
@@ -9631,6 +9769,12 @@ fn (tc &TypeChecker) type_compatible(actual Type, expected Type) bool {
 			return tc.type_compatible(actual.base_type, expected.base_type)
 		}
 		return tc.type_compatible(actual, expected.base_type)
+	}
+	expected_named_interface := expected.name()
+	if expected_named_interface in tc.interface_names {
+		return tc.type_implements_interface(actual, Interface{
+			name: expected_named_interface
+		})
 	}
 	if expected is SumType {
 		return tc.type_matches_sum(actual_raw, expected_raw)
@@ -9676,7 +9820,20 @@ fn (tc &TypeChecker) type_compatible(actual Type, expected Type) bool {
 		if actual is Nil {
 			return true
 		}
+		if expected.base_type is Void && actual is FnType {
+			return true
+		}
 		if actual is Pointer {
+			if expected.base_type is Interface
+				&& tc.type_implements_interface(actual.base_type, expected.base_type) {
+				return true
+			}
+			expected_base_name := expected.base_type.name()
+			if expected_base_name in tc.interface_names && tc.type_implements_interface(actual.base_type, Interface{
+				name: expected_base_name
+			}) {
+				return true
+			}
 			if expected.base_type is Void || actual.base_type is Void {
 				return true
 			}
@@ -10607,14 +10764,53 @@ fn (tc &TypeChecker) method_signature_compatible(actual_key string, expected_key
 		return false
 	}
 	for i in 1 .. actual_params.len {
-		if !tc.type_compatible(actual_params[i], expected_params[i])
-			|| !tc.type_compatible(expected_params[i], actual_params[i]) {
+		if !tc.method_param_signature_compatible(actual_params[i], expected_params[i]) {
 			return false
 		}
 	}
 	actual_ret := tc.fn_ret_types[actual_key] or { Type(void_) }
 	expected_ret := tc.fn_ret_types[expected_key] or { Type(void_) }
 	return tc.type_compatible(actual_ret, expected_ret)
+}
+
+fn (tc &TypeChecker) method_param_signature_compatible(actual Type, expected Type) bool {
+	if tc.type_compatible(actual, expected) && tc.type_compatible(expected, actual) {
+		return true
+	}
+	return tc.interface_pointer_signature_equivalent(actual, expected)
+}
+
+fn (tc &TypeChecker) interface_pointer_signature_equivalent(a Type, b Type) bool {
+	if a is Pointer {
+		a_iface := tc.interface_name_from_signature_type(a.base_type)
+		b_iface := tc.interface_name_from_signature_type(b)
+		if a_iface.len > 0 && a_iface == b_iface {
+			return true
+		}
+	}
+	if b is Pointer {
+		a_iface := tc.interface_name_from_signature_type(a)
+		b_iface := tc.interface_name_from_signature_type(b.base_type)
+		if a_iface.len > 0 && a_iface == b_iface {
+			return true
+		}
+	}
+	return false
+}
+
+fn (tc &TypeChecker) interface_name_from_signature_type(typ Type) string {
+	if typ is Interface {
+		return typ.name
+	}
+	name := typ.name()
+	if name in tc.interface_names {
+		return name
+	}
+	qname := tc.qualify_name(name)
+	if qname in tc.interface_names {
+		return qname
+	}
+	return ''
 }
 
 // method_type_name supports method type name handling for types.
@@ -10679,6 +10875,31 @@ fn (tc &TypeChecker) sum_has_variant(sum_name string, variant_name string) bool 
 		}
 	}
 	return false
+}
+
+fn (tc &TypeChecker) match_sum_variant_type(subject Type, pattern string) ?Type {
+	if subject is SumType {
+		variants := tc.sum_types[subject.name] or { return none }
+		variant_short := short_type_name(pattern)
+		for variant in variants {
+			if variant == pattern || short_type_name(variant) == variant_short {
+				return tc.parse_type(variant)
+			}
+		}
+		qpattern := tc.qualify_name(pattern)
+		if qpattern != pattern {
+			for variant in variants {
+				if variant == qpattern || short_type_name(variant) == variant_short {
+					return tc.parse_type(variant)
+				}
+			}
+		}
+		return none
+	}
+	if tc.type_symbol_known(pattern) {
+		return tc.parse_type(pattern)
+	}
+	return none
 }
 
 // match_type_pattern supports match type pattern handling for TypeChecker.
@@ -11570,6 +11791,16 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 				base_type: Type(void_)
 			})
 		}
+		.spawn_expr {
+			if node.children_count == 0 {
+				return tc.parse_type('thread')
+			}
+			spawn_ret := tc.resolve_type(tc.a.child(&node, 0))
+			if spawn_ret is Void || spawn_ret is Unknown {
+				return tc.parse_type('thread')
+			}
+			return tc.parse_type('thread ${spawn_ret.name()}')
+		}
 		.enum_val {
 			return Type(int_)
 		}
@@ -11693,6 +11924,16 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 				}
 				base_type := tc.resolve_type(tc.a.child(fn_node, 0))
 				clean_type := unwrap_pointer(base_type)
+				if fn_node.value == 'wait' {
+					if ret_type := tc.thread_wait_return_type(base_type) {
+						return ret_type
+					}
+				}
+				if clean_type is ArrayFixed && fn_node.value == 'clone' {
+					return Type(Array{
+						elem_type: clean_type.elem_type
+					})
+				}
 				if clean_type is Array {
 					if fn_node.value == 'clone' || fn_node.value == 'reverse' {
 						return base_type
@@ -12513,7 +12754,17 @@ pub fn (tc &TypeChecker) resolve_generic_struct_method(type_name string, method 
 	}
 	mut sub_params := []Type{}
 	if param_texts := tc.fn_param_type_texts[generic_key] {
-		for pt in param_texts {
+		for i, pt in param_texts {
+			receiver_clean := pt.trim_space().trim_left('&').trim_space()
+			receiver_base := if receiver_clean.contains('[') {
+				receiver_clean.all_before('[')
+			} else {
+				receiver_clean
+			}
+			if i == 0 && (receiver_base == base || receiver_base == base.all_after_last('.')) {
+				sub_params << generic_method_receiver_param(type_name, pt)
+				continue
+			}
 			sub_params << tc.parse_fn_signature_type(generic_key, subst_generic_text(pt,
 				concrete_args, params))
 		}
@@ -12530,6 +12781,19 @@ pub fn (tc &TypeChecker) resolve_generic_struct_method(type_name string, method 
 		is_variadic:  tc.fn_variadic[generic_key] or { false }
 		params_known: true
 	}
+}
+
+fn generic_method_receiver_param(type_name string, param_text string) Type {
+	if param_text.trim_space().starts_with('&') {
+		return Type(Pointer{
+			base_type: Type(Struct{
+				name: type_name
+			})
+		})
+	}
+	return Type(Struct{
+		name: type_name
+	})
 }
 
 // subst_generic_text textually substitutes the generic parameter names `params` with the

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -3039,21 +3039,16 @@ fn (tc &TypeChecker) stmt_definitely_returns(id flat.NodeId) bool {
 			if node.children_count < 2 {
 				return false
 			}
-			mut has_else := false
 			for i in 1 .. node.children_count {
 				branch := tc.a.child_node(&node, i)
 				if branch.kind != .match_branch {
 					return false
 				}
-				if branch.value == 'else' {
-					has_else = true
-				}
 				if !tc.match_branch_definitely_returns(branch) {
 					return false
 				}
 			}
-			return has_else || tc.match_without_else_exhaustive_enum_returns(node)
-				|| tc.match_without_else_exhaustive_bool_returns(node)
+			return tc.match_has_else_or_exhaustive_coverage(node)
 		}
 		else {
 			return false
@@ -3227,7 +3222,10 @@ fn (tc &TypeChecker) match_without_else_exhaustive_bool_returns(node flat.Node) 
 		return false
 	}
 	raw_subject_type := unalias_type(tc.resolve_type(tc.a.child(&node, 0)))
-	subject_type := unalias_type(unwrap_pointer(raw_subject_type))
+	if raw_subject_type is Pointer {
+		return false
+	}
+	subject_type := raw_subject_type
 	if subject_type !is Primitive {
 		return false
 	}
@@ -3257,6 +3255,23 @@ fn (tc &TypeChecker) match_without_else_exhaustive_bool_returns(node flat.Node) 
 		}
 	}
 	return covered_true && covered_false
+}
+
+fn (tc &TypeChecker) match_has_else_or_exhaustive_coverage(node flat.Node) bool {
+	if node.children_count < 2 {
+		return false
+	}
+	for i in 1 .. node.children_count {
+		branch := tc.a.child_node(&node, i)
+		if branch.kind != .match_branch {
+			return false
+		}
+		if branch.value == 'else' {
+			return true
+		}
+	}
+	return tc.match_without_else_exhaustive_enum_returns(node)
+		|| tc.match_without_else_exhaustive_bool_returns(node)
 }
 
 fn unalias_type(t Type) Type {
@@ -4193,6 +4208,13 @@ fn (mut tc TypeChecker) check_multi_return_decl_assign(id flat.NodeId, node flat
 	}
 	if rhs.kind == .match_stmt {
 		tc.check_node(rhs_id)
+		if !tc.match_has_else_or_exhaustive_coverage(rhs) {
+			if tc.should_diagnose(id) {
+				tc.record_error(.assignment_mismatch,
+					'match expression must be exhaustive for multi-return assignment', id)
+			}
+			return true
+		}
 		if rhs_types := tc.match_multi_return_types(rhs_id, lhs_ids.len) {
 			tc.register_synth_type(rhs_id, MultiReturn{
 				types: rhs_types
@@ -4359,6 +4381,9 @@ fn (tc &TypeChecker) match_multi_return_types(expr_id flat.NodeId, count int) ?[
 	}
 	node := tc.a.nodes[int(expr_id)]
 	if node.kind != .match_stmt || node.children_count < 2 {
+		return none
+	}
+	if !tc.match_has_else_or_exhaustive_coverage(node) {
 		return none
 	}
 	mut types := []Type{}
@@ -4722,6 +4747,13 @@ fn (mut tc TypeChecker) check_multi_return_assign(id flat.NodeId, node flat.Node
 	}
 	if rhs.kind == .match_stmt {
 		tc.check_node(rhs_id)
+		if !tc.match_has_else_or_exhaustive_coverage(rhs) {
+			if tc.should_diagnose(id) {
+				tc.record_error(.assignment_mismatch,
+					'match expression must be exhaustive for multi-return assignment', id)
+			}
+			return true
+		}
 		if rhs_types := tc.match_multi_return_types(rhs_id, lhs_ids.len) {
 			tc.register_synth_type(rhs_id, MultiReturn{
 				types: rhs_types

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4806,21 +4806,11 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 			}
 			if child.kind == .if_expr {
 				if item_types := tc.multi_expr_tail_types(child_id, multi.types.len) {
-					mut all_ok := item_types.len == multi.types.len
-					if all_ok {
-						for i, item_type in item_types {
-							if !tc.type_compatible(item_type, multi.types[i]) {
-								all_ok = false
-								break
-							}
-						}
+					if item_types.len == multi.types.len && tc.should_diagnose(id) {
+						tc.record_error(.return_mismatch,
+							'if expression branches cannot produce multiple return values', id)
 					}
-					if all_ok {
-						$if ownership ? {
-							tc.ownership_after_return(id, node)
-						}
-						return
-					}
+					return
 				}
 			}
 		}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4312,6 +4312,30 @@ fn (tc &TypeChecker) multi_expr_tail_types(expr_id flat.NodeId, count int) ?[]Ty
 	return types
 }
 
+fn (mut tc TypeChecker) multi_expr_tail_assign_types(id flat.NodeId, expr_id flat.NodeId, lhs_ids []flat.NodeId) ?[]Type {
+	groups := tc.multi_expr_tail_value_groups(expr_id, lhs_ids.len) or { return none }
+	if groups.len == 0 {
+		return none
+	}
+	mut lhs_types := []Type{cap: lhs_ids.len}
+	for lhs_id in lhs_ids {
+		lhs_types << tc.resolve_lvalue_type(lhs_id)
+	}
+	for group in groups {
+		if group.len != lhs_types.len {
+			return none
+		}
+		for i, value_id in group {
+			actual := tc.resolve_expr(value_id, lhs_types[i])
+			if !tc.type_compatible(actual, lhs_types[i]) {
+				tc.type_mismatch(.assignment_mismatch,
+					'cannot assign `${actual.name()}` to `${lhs_types[i].name()}`', id)
+			}
+		}
+	}
+	return lhs_types
+}
+
 // multi_expr_tail_types_for_transform returns promoted multi-expression tail
 // types for transform lowering without duplicating checker compatibility rules.
 pub fn (tc &TypeChecker) multi_expr_tail_types_for_transform(expr_id flat.NodeId, count int) ?[]Type {

--- a/vlib/v3/v3_test_failures.txt
+++ b/vlib/v3/v3_test_failures.txt
@@ -1,5 +1,4 @@
 cmd/tools/modules/vshare/api_test.v
-cmd/tools/modules/vshare/clipboard_test.v
 cmd/tools/vcomplete_test.v
 cmd/tools/vcreate/vcreate_init_test.v
 cmd/tools/vcreate/vcreate_web_test.v
@@ -26,18 +25,10 @@ cmd/tools/vsymlink/vsymlink_test.v
 cmd/tools/vtest_test.v
 cmd/tools/vvet/vet_test.v
 cmd/tools/vwhere/vwhere_test.v
-cmd/v/v2_test.v
 cmd/v/vvm_test.v
-cmd/v2/a_test.v
-cmd/v2/big_struct_test.v
-cmd/v2/enum_test.v
-cmd/v2/ownership_test.v
-cmd/v2/run_math_test.v
 examples/dynamic_library_loader/use_test.v
 examples/dynamic_library_loading/use_library_test.v
 examples/pendulum-simulation/modules/sim/params_test.v
-examples/pendulum-simulation/modules/sim/sim_test.v
-examples/pendulum-simulation/modules/sim/vec_test.v
 examples/pendulum-simulation/modules/sim/worker_test.v
 vlib/archive/tar/reader_test.v
 vlib/arrays/arrays_fold_test.v
@@ -78,8 +69,6 @@ vlib/context/empty_test.v
 vlib/context/onecontext/onecontext_test.v
 vlib/context/value_test.v
 vlib/crypto/aes/aes_gcm_test.v
-vlib/crypto/blake3/blake3_block_test.v
-vlib/crypto/blake3/blake3_chunk_test.v
 vlib/crypto/blake3/blake3_test.v
 vlib/crypto/ecdsa/ecdsa_test.v
 vlib/crypto/ecdsa/example/ecdsa_seed_test.v
@@ -134,7 +123,6 @@ vlib/db/sqlite/sqlite_orm_option_field_test.v
 vlib/db/sqlite/sqlite_orm_test.v
 vlib/db/sqlite/sqlite_test.v
 vlib/db/sqlite/sqlite_vfs_lowlevel_test.v
-vlib/dl/rtld_next_test.v
 vlib/encoding/binary/serialize_test.v
 vlib/encoding/binary/stream_test.v
 vlib/encoding/cbor/tests/canonical_test.v
@@ -208,7 +196,6 @@ vlib/json/cjson/cjson_test.v
 vlib/json/tests/json_alias_test.v
 vlib/json/tests/json_decode_anon_struct_test.v
 vlib/json/tests/json_decode_arr_ref_test.v
-vlib/json/tests/json_decode_embed_test.v
 vlib/json/tests/json_decode_option_alias_field_test.v
 vlib/json/tests/json_decode_option_alias_test.v
 vlib/json/tests/json_decode_option_enum_test.v
@@ -221,7 +208,6 @@ vlib/json/tests/json_decode_with_encode_arg_test.v
 vlib/json/tests/json_decode_with_generic_array_test.v
 vlib/json/tests/json_decode_with_generic_test.v
 vlib/json/tests/json_decode_with_sumtype_test.v
-vlib/json/tests/json_embed_test.v
 vlib/json/tests/json_encode_array_of_references_test.v
 vlib/json/tests/json_encode_default_option_none_test.v
 vlib/json/tests/json_encode_embed_test.v
@@ -241,7 +227,6 @@ vlib/json/tests/json_i32_test.v
 vlib/json/tests/json_is_null_attr_test.v
 vlib/json/tests/json_mut_map_test.v
 vlib/json/tests/json_omitempty_test.v
-vlib/json/tests/json_omitempty_types_test.v
 vlib/json/tests/json_option_alias_test.v
 vlib/json/tests/json_option_none_test.v
 vlib/json/tests/json_option_raw_test.v
@@ -430,15 +415,11 @@ vlib/sync/channel_try_unbuf_test.v
 vlib/sync/cond_test.v
 vlib/sync/empty_struct_chan_init_test.v
 vlib/sync/many_times_test.v
-vlib/sync/mutex_test.v
 vlib/sync/once_test.v
 vlib/sync/once_with_param_test.v
 vlib/sync/pool/pool_test.v
-vlib/sync/rwmutex_test.v
 vlib/sync/select_close_test.v
-vlib/sync/stdatomic/atomic_test.v
 vlib/sync/struct_chan_init_test.v
-vlib/sync/thread_test.v
 vlib/sync/tls_test.v
 vlib/sync/waitgroup_test.v
 vlib/term/term_test.v
@@ -544,7 +525,6 @@ vlib/v/slow_tests/inout/compiler_test.v
 vlib/v/slow_tests/prod_test.v
 vlib/v/slow_tests/profile/profile_test.v
 vlib/v/slow_tests/repl/repl_test.v
-vlib/v/tests/aliases/alias_array_fixed_sumtype_test.v
 vlib/v/tests/aliases/alias_array_plus_operator_test.v
 vlib/v/tests/aliases/alias_array_returned_as_interface_test.v
 vlib/v/tests/aliases/alias_basic_types_test.v
@@ -620,10 +600,8 @@ vlib/v/tests/builtin_arrays/array_map_cast_interface_test.v
 vlib/v/tests/builtin_arrays/array_map_ref_it_test.v
 vlib/v/tests/builtin_arrays/array_map_ref_test.v
 vlib/v/tests/builtin_arrays/array_methods_test.v
-vlib/v/tests/builtin_arrays/array_of_functions_direct_call_test.v
 vlib/v/tests/builtin_arrays/array_of_interfaces_builtin_method_test.v
 vlib/v/tests/builtin_arrays/array_of_interfaces_equality_test.v
-vlib/v/tests/builtin_arrays/array_of_option_array_test.v
 vlib/v/tests/builtin_arrays/array_of_option_fixed_array_test.v
 vlib/v/tests/builtin_arrays/array_of_ptrs_test.v
 vlib/v/tests/builtin_arrays/array_of_reference_sumtype_test.v
@@ -653,7 +631,6 @@ vlib/v/tests/builtin_arrays/fixed_array_new_syntax_test.v
 vlib/v/tests/builtin_arrays/fixed_array_of_fn_test.v
 vlib/v/tests/builtin_arrays/fixed_array_of_interfaces_equality_test.v
 vlib/v/tests/builtin_arrays/fixed_array_of_option_multi_size_test.v
-vlib/v/tests/builtin_arrays/fixed_array_of_threads_test.v
 vlib/v/tests/builtin_arrays/fixed_array_of_threads_wait_test.v
 vlib/v/tests/builtin_arrays/fixed_array_test.v
 vlib/v/tests/builtin_arrays/fixed_array_with_map_test.v
@@ -707,7 +684,6 @@ vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_shared_test.
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_struct_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_struct_with_context_interface_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_struct_with_usize_field_test.v
-vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_sumtype_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_variadic_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_with_inner_quotes_test.v
@@ -877,7 +853,6 @@ vlib/v/tests/concurrency/chan_interface_test.v
 vlib/v/tests/concurrency/chan_try_push_int_test.v
 vlib/v/tests/concurrency/chan_try_push_literal_test.v
 vlib/v/tests/concurrency/channels_test.v
-vlib/v/tests/concurrency/default_thread_stack_size_test.v
 vlib/v/tests/concurrency/inherited_vars_test.v
 vlib/v/tests/concurrency/lock_selector_test.v
 vlib/v/tests/concurrency/selector_shared_var_test.v
@@ -913,14 +888,12 @@ vlib/v/tests/concurrency/shared_primitive_test.v
 vlib/v/tests/concurrency/shared_str_test.v
 vlib/v/tests/concurrency/shared_struct_method_call_test.v
 vlib/v/tests/concurrency/shared_unordered_mixed_test.v
-vlib/v/tests/concurrency/spawn_array_mut_test.v
 vlib/v/tests/concurrency/spawn_in_if_match_expr_test.v
 vlib/v/tests/concurrency/spawn_method_on_generic_struct_test.v
 vlib/v/tests/concurrency/spawn_ref_arg_stack_escape_test.v
 vlib/v/tests/concurrency/spawn_with_different_method_receivers_test.v
 vlib/v/tests/concurrency/sync_channel_push_string_literal_test.v
 vlib/v/tests/concurrency/tcc_atomic_postfix_test.v
-vlib/v/tests/concurrency/thread_ptr_ret_test.v
 vlib/v/tests/concurrency/thread_returns_test.v
 vlib/v/tests/concurrency/thread_to_string_test.v
 vlib/v/tests/concurrency/thread_wait_ptr_test.v
@@ -1085,17 +1058,12 @@ vlib/v/tests/fns/go_anon_fn_call_with_ref_arg_test.v
 vlib/v/tests/fns/go_anon_fn_variable_call_test.v
 vlib/v/tests/fns/go_array_wait_test.v
 vlib/v/tests/fns/go_call_anon_fn_with_closure_test.v
-vlib/v/tests/fns/go_call_fn_return_test.v
 vlib/v/tests/fns/go_call_fn_using_map_value_test.v
 vlib/v/tests/fns/go_call_fn_with_anon_fn_arg_test.v
 vlib/v/tests/fns/go_call_fn_with_anon_fn_array_arg_test.v
 vlib/v/tests/fns/go_call_generic_fn_test.v
-vlib/v/tests/fns/go_handle_for_functions_returning_array_test.v
-vlib/v/tests/fns/go_wait_1_test.v
 vlib/v/tests/fns/go_wait_2_test.v
-vlib/v/tests/fns/go_wait_3_test.v
 vlib/v/tests/fns/go_wait_option_test.v
-vlib/v/tests/fns/go_wait_with_fn_of_interface_parameter_test.v
 vlib/v/tests/fns/iter_alias_fn_test.v
 vlib/v/tests/fns/lambda_as_struct_field_value_test.v
 vlib/v/tests/fns/lambda_expr_test.v
@@ -1346,7 +1314,6 @@ vlib/v/tests/interfaces/array_of_empty_interface_result_regression_test.v
 vlib/v/tests/interfaces/big_array_allocation_test.v
 vlib/v/tests/interfaces/empty_interface_ierror_or_block_test.v
 vlib/v/tests/interfaces/interface_arr_auto_str_test.v
-vlib/v/tests/interfaces/interface_arr_for_mut_iter_index_test.v
 vlib/v/tests/interfaces/interface_arr_init_nested_short_syntax_test.v
 vlib/v/tests/interfaces/interface_arr_init_test.v
 vlib/v/tests/interfaces/interface_array_implicit_conversion_test.v
@@ -1417,7 +1384,6 @@ vlib/v/tests/loops/for_in_iterator_of_generic_struct_2_test.v
 vlib/v/tests/loops/for_in_iterator_of_generic_struct_3_test.v
 vlib/v/tests/loops/for_in_iterator_test.v
 vlib/v/tests/loops/for_in_map_of_pointers_test.v
-vlib/v/tests/loops/for_in_mut_array_index_test.v
 vlib/v/tests/loops/for_in_mut_array_with_mul_test.v
 vlib/v/tests/loops/for_in_mut_iterator_val_test.v
 vlib/v/tests/loops/for_in_mut_mutable_app_field_test.v
@@ -1582,7 +1548,6 @@ vlib/v/tests/options/option_sumtype_option_variant_test.v
 vlib/v/tests/options/option_sumtype_test.v
 vlib/v/tests/options/option_sumtype_unwrap_test.v
 vlib/v/tests/options/option_sumtype_variant_test.v
-vlib/v/tests/options/option_unwrap_as_cast_test.v
 vlib/v/tests/options/option_unwrap_fn_test.v
 vlib/v/tests/options/option_unwrap_ifexpr_test.v
 vlib/v/tests/options/option_unwrap_none_test.v
@@ -1714,7 +1679,6 @@ vlib/v/tests/structs/struct_embed_fn_type_test.v
 vlib/v/tests/structs/struct_embed_is_interface_test.v
 vlib/v/tests/structs/struct_embed_test.v
 vlib/v/tests/structs/struct_embedding_with_interface_test.v
-vlib/v/tests/structs/struct_field_default_fn_type_value_init_test.v
 vlib/v/tests/structs/struct_field_default_shadowed_global_test.v
 vlib/v/tests/structs/struct_field_default_union_of_structs_marked_with_noinit_test.v
 vlib/v/tests/structs/struct_field_default_value_optional_test.v
@@ -1726,7 +1690,6 @@ vlib/v/tests/structs/struct_field_option_type_with_default_value_init_test.v
 vlib/v/tests/structs/struct_field_shared_test.v
 vlib/v/tests/structs/struct_generic_sizeof_test.v
 vlib/v/tests/structs/struct_init_on_for_expr_test.v
-vlib/v/tests/structs/struct_init_passing_test.v
 vlib/v/tests/structs/struct_init_short_in_for_expr_test.v
 vlib/v/tests/structs/struct_init_with_complex_fields_test.v
 vlib/v/tests/structs/struct_init_with_fixed_array_field_test.v
@@ -1734,7 +1697,6 @@ vlib/v/tests/structs/struct_init_with_interface_field_test.v
 vlib/v/tests/structs/struct_init_with_interface_pointer_and_embed_test.v
 vlib/v/tests/structs/struct_init_with_multi_option_fn_type_test.v
 vlib/v/tests/structs/struct_init_with_update_test.v
-vlib/v/tests/structs/struct_local_test.v
 vlib/v/tests/structs/struct_option_field_comparison_test.v
 vlib/v/tests/structs/struct_selector_or_block_test.v
 vlib/v/tests/structs/struct_test.v

--- a/vlib/v3/v3_test_failures.txt
+++ b/vlib/v3/v3_test_failures.txt
@@ -402,9 +402,6 @@ vlib/runtime/runtime_test.v
 vlib/runtime/used_memory_test.v
 vlib/sokol/gfx/gfx_test.v
 vlib/stbi/stbi_test.v
-vlib/strconv/atoi_test.v
-vlib/strconv/atou_test.v
-vlib/strconv/f32_str_should_be_different_test.v
 vlib/strconv/format_test.v
 vlib/strings/lorem/lorem_test.v
 vlib/strings/strings_test.v
@@ -1117,7 +1114,6 @@ vlib/v/tests/fns/return_multi_fixed_arr_test.v
 vlib/v/tests/fns/sort_fn_def_test.v
 vlib/v/tests/fns/static_method_as_map_arg_test.v
 vlib/v/tests/fns/variadic_interface_array_arg_test.v
-vlib/v/tests/fns/variadic_voidptr_rvalue_test.v
 vlib/v/tests/for_brace_block_tmpl_test.v
 vlib/v/tests/for_in_iterator_next_test.v
 vlib/v/tests/generic_calls/bug_test.v
@@ -1455,7 +1451,6 @@ vlib/v/tests/modules/interface_array_concat_from_another_module/main_test.v
 vlib/v/tests/modules/interface_from_another_module/ifam_test.v
 vlib/v/tests/modules/methods_struct_another_module/import_symbol_static_method_test.v
 vlib/v/tests/modules/methods_struct_another_module/methods_struct_test.v
-vlib/v/tests/multi_line_with_options_test.v
 vlib/v/tests/multi_return_test.v
 vlib/v/tests/multiple_comptime_tmpl_in_one_fn_test.v
 vlib/v/tests/multiret_with_sumtype_test.v
@@ -1531,14 +1526,12 @@ vlib/v/tests/options/option_map_struct_field_init_test.v
 vlib/v/tests/options/option_map_value_test.v
 vlib/v/tests/options/option_match_case_enum_test.v
 vlib/v/tests/options/option_match_case_test.v
-vlib/v/tests/options/option_match_cases_test.v
 vlib/v/tests/options/option_match_expr_test.v
 vlib/v/tests/options/option_match_none_test.v
 vlib/v/tests/options/option_match_test.v
 vlib/v/tests/options/option_method_selector_test.v
 vlib/v/tests/options/option_multi_ret_test.v
 vlib/v/tests/options/option_multi_return_assign_test.v
-vlib/v/tests/options/option_multi_return_if_test.v
 vlib/v/tests/options/option_multi_return_opt_test.v
 vlib/v/tests/options/option_multi_return_test.v
 vlib/v/tests/options/option_mut_generic_array_test.v
@@ -1726,11 +1719,9 @@ vlib/v/tests/structs/struct_field_default_shadowed_global_test.v
 vlib/v/tests/structs/struct_field_default_union_of_structs_marked_with_noinit_test.v
 vlib/v/tests/structs/struct_field_default_value_optional_test.v
 vlib/v/tests/structs/struct_field_fixed_array_init_with_default_value_test.v
-vlib/v/tests/structs/struct_field_init_with_fixed_array_init_test.v
 vlib/v/tests/structs/struct_field_init_with_fixed_array_opt_test.v
 vlib/v/tests/structs/struct_field_init_with_generic_anon_fn_test.v
 vlib/v/tests/structs/struct_field_init_with_generic_fn_test.v
-vlib/v/tests/structs/struct_field_name_using_keyword_test.v
 vlib/v/tests/structs/struct_field_option_type_with_default_value_init_test.v
 vlib/v/tests/structs/struct_field_shared_test.v
 vlib/v/tests/structs/struct_generic_sizeof_test.v
@@ -1745,7 +1736,6 @@ vlib/v/tests/structs/struct_init_with_multi_option_fn_type_test.v
 vlib/v/tests/structs/struct_init_with_update_test.v
 vlib/v/tests/structs/struct_local_test.v
 vlib/v/tests/structs/struct_option_field_comparison_test.v
-vlib/v/tests/structs/struct_scoped_test.v
 vlib/v/tests/structs/struct_selector_or_block_test.v
 vlib/v/tests/structs/struct_test.v
 vlib/v/tests/structs/struct_transmute_test.v

--- a/vlib/v3/v3_test_passes.txt
+++ b/vlib/v3/v3_test_passes.txt
@@ -3,6 +3,7 @@
 .github/workflows/make_sure_ci_run_with_64bit_compiler_test.v
 cmd/tools/modules/vbugreport/c_error_storage_test.v
 cmd/tools/modules/vbugreport/report_test.v
+cmd/tools/modules/vshare/clipboard_test.v
 cmd/tools/translate_test.v
 cmd/tools/vbump_test.v
 cmd/tools/vcheck_test.v
@@ -20,7 +21,15 @@ cmd/tools/vfmt_test.v
 cmd/tools/vgit-fmt-hook_test.v
 cmd/tools/vtimeout_test.v
 cmd/tools/vwatch_test.v
+cmd/v/v2_test.v
+cmd/v2/a_test.v
+cmd/v2/big_struct_test.v
+cmd/v2/enum_test.v
+cmd/v2/ownership_test.v
+cmd/v2/run_math_test.v
 examples/password/password_test.v
+examples/pendulum-simulation/modules/sim/sim_test.v
+examples/pendulum-simulation/modules/sim/vec_test.v
 examples/readline/readline_test.v
 vlib/benchmark/benchmark_test.v
 vlib/builtin/array_push_element_sizes_test.v
@@ -56,6 +65,8 @@ vlib/crypto/blake2b/blake2b_block_test.v
 vlib/crypto/blake2b/blake2b_test.v
 vlib/crypto/blake2s/blake2s_block_test.v
 vlib/crypto/blake2s/blake2s_test.v
+vlib/crypto/blake3/blake3_block_test.v
+vlib/crypto/blake3/blake3_chunk_test.v
 vlib/crypto/blowfish/blowfish_test.v
 vlib/crypto/cipher/aes_cbc_test.v
 vlib/crypto/cipher/aes_cfb_test.v
@@ -97,6 +108,7 @@ vlib/crypto/sha512/sha512_shavs_test.v
 vlib/crypto/sha512/sha512_test.v
 vlib/dl/dl_test.v
 vlib/dl/loader/loader_test.v
+vlib/dl/rtld_next_test.v
 vlib/encoding/base32/base32_test.v
 vlib/encoding/base58/base58_test.v
 vlib/encoding/base58/base58_usage_test.v
@@ -133,8 +145,11 @@ vlib/hash/huffman/huffman_test.v
 vlib/io/io_cp_test.v
 vlib/io/os_file_reader_test.v
 vlib/io/util/util_test.v
+vlib/json/tests/json_decode_embed_test.v
 vlib/json/tests/json_decode_with_option_arg_test.v
+vlib/json/tests/json_embed_test.v
 vlib/json/tests/json_encode_with_mut_test.v
+vlib/json/tests/json_omitempty_types_test.v
 vlib/math/big/consts_test.v
 vlib/math/bits/bits_test.v
 vlib/math/complex/complex_test.v
@@ -191,7 +206,11 @@ vlib/strconv/write_dec_test.v
 vlib/strings/builder_test.v
 vlib/strings/similarity_test.v
 vlib/strings/textscanner/textscanner_test.v
+vlib/sync/mutex_test.v
+vlib/sync/rwmutex_test.v
 vlib/sync/spinlock_test.v
+vlib/sync/stdatomic/atomic_test.v
+vlib/sync/thread_test.v
 vlib/time/Y2K38_test.v
 vlib/time/misc/misc_test.v
 vlib/time/parse_test.v
@@ -257,6 +276,7 @@ vlib/v/slow_tests/valgrind/autofree_match_test.v
 vlib/v/slow_tests/valgrind/valgrind_test.v
 vlib/v/tests/alias_cast_to_fixed_array_test.v
 vlib/v/tests/aliases/alias_array_built_in_methods_test.v
+vlib/v/tests/aliases/alias_array_fixed_sumtype_test.v
 vlib/v/tests/aliases/alias_array_fixed_test.v
 vlib/v/tests/aliases/alias_array_has_method_test.v
 vlib/v/tests/aliases/alias_array_no_cast_init_test.v
@@ -358,8 +378,10 @@ vlib/v/tests/builtin_arrays/array_of_fixed_array_map_test.v
 vlib/v/tests/builtin_arrays/array_of_fixed_array_test.v
 vlib/v/tests/builtin_arrays/array_of_fns_index_call_with_direct_array_access_test.v
 vlib/v/tests/builtin_arrays/array_of_fns_index_call_with_embeded_array_call_test.v
+vlib/v/tests/builtin_arrays/array_of_functions_direct_call_test.v
 vlib/v/tests/builtin_arrays/array_of_interface_init_test.v
 vlib/v/tests/builtin_arrays/array_of_map_with_default_test.v
+vlib/v/tests/builtin_arrays/array_of_option_array_test.v
 vlib/v/tests/builtin_arrays/array_of_sumtype_append_aggregate_type_test.v
 vlib/v/tests/builtin_arrays/array_of_sumtype_init_test.v
 vlib/v/tests/builtin_arrays/array_of_threads_wait_test.v
@@ -381,6 +403,7 @@ vlib/v/tests/builtin_arrays/fixed_array_literal_range_index_test.v
 vlib/v/tests/builtin_arrays/fixed_array_of_alias_struct_test.v
 vlib/v/tests/builtin_arrays/fixed_array_of_builtin_struct_with_fn_call_test.v
 vlib/v/tests/builtin_arrays/fixed_array_of_option_test.v
+vlib/v/tests/builtin_arrays/fixed_array_of_threads_test.v
 vlib/v/tests/builtin_arrays/fixed_array_op_overload_test.v
 vlib/v/tests/builtin_arrays/fixed_array_return_decl_test.v
 vlib/v/tests/builtin_arrays/fixed_array_to_fixed_size_method_test.v
@@ -424,6 +447,7 @@ vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_match_expr_t
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_of_array_of_structs_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_string_args_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_string_lit_with_fmt_test.v
+vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_sumtype_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_with_escape_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_map_with_generic_struct_value_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_option_none_test.v
@@ -498,6 +522,7 @@ vlib/v/tests/comptime/comptime_value_d_default_test.v
 vlib/v/tests/comptime/comptime_var_on_multiple_args_test.v
 vlib/v/tests/comptime/comptime_voidptr_unsafe_nil_test.v
 vlib/v/tests/concurrency/chan_push_enum_test.v
+vlib/v/tests/concurrency/default_thread_stack_size_test.v
 vlib/v/tests/concurrency/mut_receiver_gowrapper_test.v
 vlib/v/tests/concurrency/select_auto_sync_test.v
 vlib/v/tests/concurrency/semaphore_test.v
@@ -506,8 +531,10 @@ vlib/v/tests/concurrency/shared_fixed_array_init_test.v
 vlib/v/tests/concurrency/shared_map_ptr_test.v
 vlib/v/tests/concurrency/shared_nested_lock_runtime_test.v
 vlib/v/tests/concurrency/shared_struct_field_test.v
+vlib/v/tests/concurrency/spawn_array_mut_test.v
 vlib/v/tests/concurrency/spawn_with_cond_fncall_test.v
 vlib/v/tests/concurrency/thread_array_test.v
+vlib/v/tests/concurrency/thread_ptr_ret_test.v
 vlib/v/tests/concurrency/thread_type_test.v
 vlib/v/tests/concurrency/volatile_vars_test.v
 vlib/v/tests/conditions/ifs/if_assign_test.v
@@ -678,7 +705,12 @@ vlib/v/tests/fns/fn_with_array_of_aliases_argument_test.v
 vlib/v/tests/fns/fn_with_fixed_array_args_test.v
 vlib/v/tests/fns/generic_fn_return_later_declared_generic_struct_test.v
 vlib/v/tests/fns/go_array_wait_without_go_test.v
+vlib/v/tests/fns/go_call_fn_return_test.v
 vlib/v/tests/fns/go_call_interface_method_test.v
+vlib/v/tests/fns/go_handle_for_functions_returning_array_test.v
+vlib/v/tests/fns/go_wait_1_test.v
+vlib/v/tests/fns/go_wait_3_test.v
+vlib/v/tests/fns/go_wait_with_fn_of_interface_parameter_test.v
 vlib/v/tests/fns/iface_method_fixed_arr_test.v
 vlib/v/tests/fns/interface_methods_fixed_arr_test.v
 vlib/v/tests/fns/method_call_chained_multiline_test.v
@@ -814,6 +846,7 @@ vlib/v/tests/interfaces/empty_interface_is_another_empty_interface_check_test.v
 vlib/v/tests/interfaces/empty_interface_test.v
 vlib/v/tests/interfaces/interface_and_embedded_struct_build_test.v
 vlib/v/tests/interfaces/interface_arg_test.v
+vlib/v/tests/interfaces/interface_arr_for_mut_iter_index_test.v
 vlib/v/tests/interfaces/interface_edge_cases/array_of_interfaces_test.v
 vlib/v/tests/interfaces/interface_edge_cases/array_of_interfaces_with_utility_fn_test.v
 vlib/v/tests/interfaces/interface_edge_cases/assign_to_interface_field_test.v
@@ -855,6 +888,7 @@ vlib/v/tests/local_test.v
 vlib/v/tests/loops/for_c_init_with_var_assign_test.v
 vlib/v/tests/loops/for_c_init_with_var_inc_test.v
 vlib/v/tests/loops/for_in_array_with_struct_init_test.v
+vlib/v/tests/loops/for_in_mut_array_index_test.v
 vlib/v/tests/loops/for_in_mut_array_with_infix_expr_test.v
 vlib/v/tests/loops/for_in_mut_reference_selector_val_test.v
 vlib/v/tests/loops/for_in_mut_with_ptrs_test.v
@@ -953,6 +987,7 @@ vlib/v/tests/options/option_struct_field_init_test.v
 vlib/v/tests/options/option_struct_init_default_test.v
 vlib/v/tests/options/option_struct_init_on_if_test.v
 vlib/v/tests/options/option_struct_init_with_opt_test.v
+vlib/v/tests/options/option_unwrap_as_cast_test.v
 vlib/v/tests/options/option_unwrap_assign_test.v
 vlib/v/tests/options/option_unwrap_print_test.v
 vlib/v/tests/options/option_var_2_test.v
@@ -1050,6 +1085,7 @@ vlib/v/tests/structs/struct_eq_op_only_test.v
 vlib/v/tests/structs/struct_eq_op_test.v
 vlib/v/tests/structs/struct_equality_test.v
 vlib/v/tests/structs/struct_field_array_index_test.v
+vlib/v/tests/structs/struct_field_default_fn_type_value_init_test.v
 vlib/v/tests/structs/struct_field_default_value_interface_cast_test.v
 vlib/v/tests/structs/struct_field_default_value_sumtype_cast_test.v
 vlib/v/tests/structs/struct_field_fixed_array_init_test.v
@@ -1067,12 +1103,14 @@ vlib/v/tests/structs/struct_ierror_test.v
 vlib/v/tests/structs/struct_init_alias_array_fixed_test.v
 vlib/v/tests/structs/struct_init_and_assign_test.v
 vlib/v/tests/structs/struct_init_inside_ternary_with_option_field_test.v
+vlib/v/tests/structs/struct_init_passing_test.v
 vlib/v/tests/structs/struct_init_update_test.v
 vlib/v/tests/structs/struct_init_update_with_generics_test.v
 vlib/v/tests/structs/struct_init_update_with_mutable_receiver_test.v
 vlib/v/tests/structs/struct_init_with_chan_field_test.v
 vlib/v/tests/structs/struct_init_with_embed_update_test.v
 vlib/v/tests/structs/struct_init_with_multi_nested_embed_update_test.v
+vlib/v/tests/structs/struct_local_test.v
 vlib/v/tests/structs/struct_map_method_test.v
 vlib/v/tests/structs/struct_multi_embed_method_call_test.v
 vlib/v/tests/structs/struct_of_time_init_with_update_test.v

--- a/vlib/v3/v3_test_passes.txt
+++ b/vlib/v3/v3_test_passes.txt
@@ -180,8 +180,11 @@ vlib/rand/splitmix64/splitmix64_test.v
 vlib/rand/wyrand/wyrand_test.v
 vlib/regex/regex_complex_test.v
 vlib/semver/semver_test.v
+vlib/strconv/atoi_test.v
+vlib/strconv/atou_test.v
 vlib/strconv/converter_test.v
 vlib/strconv/f32_f64_to_string_test.v
+vlib/strconv/f32_str_should_be_different_test.v
 vlib/strconv/f32_ten_pow_table_range_test.v
 vlib/strconv/number_to_base_test.v
 vlib/strconv/write_dec_test.v
@@ -695,6 +698,7 @@ vlib/v/tests/fns/unused_fn_aliased_fixed_array_ret_test.v
 vlib/v/tests/fns/unused_fn_fixed_array_ret_test.v
 vlib/v/tests/fns/variadic_fn_chain_test.v
 vlib/v/tests/fns/variadic_sumtype_test.v
+vlib/v/tests/fns/variadic_voidptr_rvalue_test.v
 vlib/v/tests/gc_free_space_divisor_test.v
 vlib/v/tests/generic_fn_dedup_collision_issue_27398_test.v
 vlib/v/tests/generics/generic_alias_fn_op_call_test.v
@@ -871,6 +875,7 @@ vlib/v/tests/modules/same_module_type_name_fn_test.v
 vlib/v/tests/modules/sub/global_fixed_array_test.v
 vlib/v/tests/modules/sub/sub_test.v
 vlib/v/tests/modules/submodules/submodules_test.v
+vlib/v/tests/multi_line_with_options_test.v
 vlib/v/tests/multi_return_nil_voidptr_test.v
 vlib/v/tests/multiple_paths_in_vmodules/vmodules_overrides_test.v
 vlib/v/tests/multiret_in_or_expr_test.v
@@ -923,7 +928,9 @@ vlib/v/tests/options/option_last_call_test.v
 vlib/v/tests/options/option_map_fn_type_value_test.v
 vlib/v/tests/options/option_map_val_test.v
 vlib/v/tests/options/option_match_case_cast_test.v
+vlib/v/tests/options/option_match_cases_test.v
 vlib/v/tests/options/option_match_eq_test.v
+vlib/v/tests/options/option_multi_return_if_test.v
 vlib/v/tests/options/option_nested_struct_test.v
 vlib/v/tests/options/option_or_block_test.v
 vlib/v/tests/options/option_or_expr_dump_test.v
@@ -1047,7 +1054,9 @@ vlib/v/tests/structs/struct_field_default_value_interface_cast_test.v
 vlib/v/tests/structs/struct_field_default_value_sumtype_cast_test.v
 vlib/v/tests/structs/struct_field_fixed_array_init_test.v
 vlib/v/tests/structs/struct_field_fn_call_test.v
+vlib/v/tests/structs/struct_field_init_with_fixed_array_init_test.v
 vlib/v/tests/structs/struct_field_name_using_c_keyword_test.v
+vlib/v/tests/structs/struct_field_name_using_keyword_test.v
 vlib/v/tests/structs/struct_field_named_as_c_keyword_test.v
 vlib/v/tests/structs/struct_fields_required_test.v
 vlib/v/tests/structs/struct_fields_storing_functions_test.v
@@ -1070,6 +1079,7 @@ vlib/v/tests/structs/struct_of_time_init_with_update_test.v
 vlib/v/tests/structs/struct_option_field_zero_test.v
 vlib/v/tests/structs/struct_pointer_nil_comparison_test.v
 vlib/v/tests/structs/struct_ref_field_nil_const_default_test.v
+vlib/v/tests/structs/struct_scoped_test.v
 vlib/v/tests/structs/struct_shared_field_init_test.v
 vlib/v/tests/structs/struct_shared_field_with_default_init_test.v
 vlib/v/tests/structs/working_with_an_empty_struct_test.v


### PR DESCRIPTION
## Summary
- fix several V3 parser/checker/codegen gaps so 10 more listed tests pass
- handle local type declarations, keyword field/enum cases, @FILE_LINE, tuple-like multi-return if/match, boolean exhaustive match returns, and ...voidptr variadic rvalues
- move the 10 passing tests from v3_test_failures.txt to v3_test_passes.txt

## Validation
- ./vnew -d parallel -g -keepc -o /tmp/v3_local vlib/v3/v3.v
- 10 promoted tests passed with /tmp/v3_local
- ./vnew -silent vlib/v3/tests/parallel_cgen_test.v
- ./vnew -silent vlib/v3/tests/selfhost_backend_prune_test.v
- git diff --check

Note: I also ran ./vnew -silent test vlib/v3/ before the final self-host cleanup; it reported 73 passed / 8 failed. The two self-host-related failures from that run were rerun and now pass.