### PR TITLE
net.http: h2 server — close the final 7 h2spec conformance gaps (146/146)

### DIFF
--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -234,7 +234,11 @@ fn (mut c H2ServerConn) mark_locally_reset(id u32) {
 //   - idle:   never opened — an odd id above any we have accepted, OR any even
 //             (server-initiated) id, since this server never opens push streams
 //   - closed: a client (odd) id at or below the highest we have accepted that is
-//             no longer in the map (already finished or reset)
+//             no longer in the map (already finished or reset), OR any id we
+//             have ourselves RST_STREAM'd (c.locally_reset) regardless of
+//             last_stream_id — a self-dependent PRIORITY (RFC 7540 §5.3.1) is
+//             legal on a stream the client never opened via HEADERS, so an id
+//             can be locally-reset without ever having advanced last_stream_id
 enum H2StreamState {
 	active
 	idle
@@ -251,6 +255,17 @@ enum H2StreamState {
 fn (c &H2ServerConn) classify_stream(stream_id u32) H2StreamState {
 	if stream_id in c.streams {
 		return .active
+	}
+	// An id we have ourselves RST_STREAM'd is closed no matter how it got reset:
+	// checking this before the last_stream_id/parity test covers ids that were
+	// never opened via HEADERS at all (e.g. a self-dependent PRIORITY frame on
+	// an id the client never used) — without this, every caller of
+	// classify_stream (on_data, handle_control_frame's WINDOW_UPDATE arm,
+	// dispatch_frame's RST_STREAM arm) would misclassify a later in-flight frame
+	// for that id as idle and force a connection error instead of draining it
+	// per §6.4.
+	if stream_id in c.locally_reset {
+		return .closed
 	}
 	if stream_id & 1 == 1 && stream_id <= c.last_stream_id {
 		return .closed

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -390,10 +390,12 @@ fn (mut c H2ServerConn) dispatch_frame(frame H2Frame, mut handler Handler) ! {
 		H2PriorityFrame {
 			// Priority is advisory and otherwise ignored (deprecated in RFC 9113
 			// §5.3), but RFC 7540 §5.3.1: a stream cannot depend on itself — a
-			// self-dependency is a STREAM error PROTOCOL_ERROR. Skip the RST when
-			// we already reset this id: PRIORITY is legal on a closed stream, and
-			// re-RST-ing one we reset would send a frame on a closed stream (§5.1).
-			if frame.stream_dep == frame.stream_id && frame.stream_id !in c.locally_reset {
+			// self-dependency is a STREAM error PROTOCOL_ERROR. Skip the RST for
+			// any ALREADY-CLOSED stream (locally reset OR completed normally via
+			// run_request — classify_stream treats both as closed): PRIORITY is
+			// legal on a closed stream, and RST_STREAM is not, so re-RST-ing one
+			// would itself send a frame on a closed stream (§5.1).
+			if frame.stream_dep == frame.stream_id && c.classify_stream(frame.stream_id) != .closed {
 				c.send_rst_stream(frame.stream_id, .protocol_error)!
 				c.mark_locally_reset(frame.stream_id)
 				c.streams.delete(frame.stream_id)

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -172,6 +172,7 @@ mut:
 	in_trailers   bool // set once a trailer section (a 2nd HEADERS block) begins
 	refused       bool // §5.1.2: over the concurrency limit — decode then RST(REFUSED_STREAM)
 	over_end      bool // §5.1: HEADERS after END_STREAM — decoded for HPACK sync, then RST(STREAM_CLOSED)
+	self_dep      bool // RFC 7540 §5.3.1: HEADERS priority depends on itself — decode then RST(PROTOCOL_ERROR)
 }
 
 // H2ServerConn drives one server-side HTTP/2 connection over a transport.
@@ -372,7 +373,16 @@ fn (mut c H2ServerConn) dispatch_frame(frame H2Frame, mut handler Handler) ! {
 			c.streams.delete(frame.stream_id)
 		}
 		H2PriorityFrame {
-			// Priority is advisory; ignore.
+			// Priority is advisory and otherwise ignored (deprecated in RFC 9113
+			// §5.3), but RFC 7540 §5.3.1: a stream cannot depend on itself — a
+			// self-dependency is a STREAM error PROTOCOL_ERROR. Skip the RST when
+			// we already reset this id: PRIORITY is legal on a closed stream, and
+			// re-RST-ing one we reset would send a frame on a closed stream (§5.1).
+			if frame.stream_dep == frame.stream_id && frame.stream_id !in c.locally_reset {
+				c.send_rst_stream(frame.stream_id, .protocol_error)!
+				c.mark_locally_reset(frame.stream_id)
+				c.streams.delete(frame.stream_id)
+			}
 		}
 		H2HeadersFrame {
 			c.on_headers(frame, mut handler)!
@@ -417,10 +427,40 @@ fn (mut c H2ServerConn) handle_control_frame(frame H2Frame) ! {
 			}
 		}
 		H2WindowUpdateFrame {
+			inc := frame.window_size_increment
 			if frame.stream_id == 0 {
-				c.send_window += i64(frame.window_size_increment)
+				// RFC 9113 §6.9: a zero increment on the connection is a connection
+				// error PROTOCOL_ERROR. §6.9.1: growing the connection window past
+				// 2^31-1 is a connection error FLOW_CONTROL_ERROR — send the correct
+				// code before unwinding (serve()'s catch defaults to PROTOCOL_ERROR).
+				if inc == 0 {
+					return error('h2 server: connection WINDOW_UPDATE with a zero increment (RFC 9113 §6.9 PROTOCOL_ERROR)')
+				}
+				new_window := c.send_window + i64(inc)
+				if new_window > i64(0x7fff_ffff) {
+					c.send_goaway(.flow_control_error,
+						'connection flow-control window exceeds 2^31-1') or {}
+					return error('h2 server: connection flow-control window exceeded 2^31-1 (RFC 9113 §6.9.1 FLOW_CONTROL_ERROR)')
+				}
+				c.send_window = new_window
 			} else if mut s := c.streams[frame.stream_id] {
-				s.send_window += i64(frame.window_size_increment)
+				// Stream-scoped versions of the same rules are STREAM errors
+				// (RFC 9113 §6.9/§6.9.1): reset the offending stream, keep the
+				// connection alive.
+				if inc == 0 {
+					c.send_rst_stream(s.id, .protocol_error)!
+					c.mark_locally_reset(s.id)
+					c.streams.delete(s.id)
+					return
+				}
+				new_window := s.send_window + i64(inc)
+				if new_window > i64(0x7fff_ffff) {
+					c.send_rst_stream(s.id, .flow_control_error)!
+					c.mark_locally_reset(s.id)
+					c.streams.delete(s.id)
+					return
+				}
+				s.send_window = new_window
 			} else if c.classify_stream(frame.stream_id) == .idle {
 				// RFC 9113 §5.1: a WINDOW_UPDATE on an idle stream is a connection
 				// error PROTOCOL_ERROR. On a closed stream it is ignored.
@@ -442,6 +482,11 @@ fn (mut c H2ServerConn) apply_settings(settings []H2Setting) ! {
 				c.encoder.pending_max_table_size = int(s.value)
 			}
 			h2_settings_enable_push {
+				// RFC 9113 §6.5.2: any value other than 0 or 1 is a connection
+				// error PROTOCOL_ERROR.
+				if s.value > 1 {
+					return error('h2 server: SETTINGS_ENABLE_PUSH ${s.value} is not 0 or 1 (RFC 9113 §6.5.2 PROTOCOL_ERROR)')
+				}
 				c.peer.enable_push = s.value != 0
 			}
 			h2_settings_max_concurrent_streams {
@@ -540,6 +585,7 @@ fn (mut c H2ServerConn) on_headers(frame H2HeadersFrame, mut handler Handler) ! 
 		end_headers: frame.end_headers
 		end_stream:  frame.end_stream
 		send_window: i64(c.peer.initial_window_size)
+		self_dep:    frame.has_priority && frame.stream_dep == frame.stream_id
 	}
 	// RFC 9113 §5.1.2: a stream that would exceed the concurrency limit we
 	// advertised is refused. We still assemble and HPACK-decode its header block
@@ -623,6 +669,15 @@ fn (mut c H2ServerConn) finalize_headers(mut s H2ServerStream, mut handler Handl
 		c.streams.delete(s.id)
 		return
 	}
+	// RFC 7540 §5.3.1: a stream cannot depend on itself; a HEADERS priority
+	// self-dependency is a STREAM error PROTOCOL_ERROR. Decoded above for HPACK
+	// sync, refused now.
+	if s.self_dep {
+		c.send_rst_stream(s.id, .protocol_error)!
+		c.mark_locally_reset(s.id)
+		c.streams.delete(s.id)
+		return
+	}
 	// A well-decoded but malformed request is a STREAM error (RFC 9113 §8.1.1) —
 	// reset just this stream and keep the connection alive.
 	h2_validate_request_pseudo(s.headers) or {
@@ -645,6 +700,10 @@ fn (mut c H2ServerConn) finalize_headers(mut s H2ServerStream, mut handler Handl
 fn (mut c H2ServerConn) on_trailers(mut s H2ServerStream, frame H2HeadersFrame, mut handler Handler) ! {
 	s.in_trailers = true
 	s.end_stream = frame.end_stream
+	// RFC 7540 §5.3.1 applies to ANY HEADERS carrying priority, trailers included.
+	if frame.has_priority && frame.stream_dep == frame.stream_id {
+		s.self_dep = true
+	}
 	s.trailer_block << frame.fragment
 	if !frame.end_headers {
 		c.awaiting_cont = frame.stream_id
@@ -670,7 +729,10 @@ fn (mut c H2ServerConn) finalize_trailers(mut s H2ServerStream, mut handler Hand
 		return
 	}
 	// A well-decoded but malformed trailer section is a STREAM error (§8.1.1).
-	mut reason := if !s.end_stream {
+	mut reason := if s.self_dep {
+		// RFC 7540 §5.3.1: a stream cannot depend on itself.
+		'trailing HEADERS priority depends on itself'
+	} else if !s.end_stream {
 		// A trailer section MUST terminate the stream (RFC 9113 §8.1).
 		'trailing HEADERS without END_STREAM'
 	} else {

--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -678,19 +678,23 @@ fn (mut c H2ServerConn) finalize_headers(mut s H2ServerStream, mut handler Handl
 		return error('h2 server: HPACK decode error (COMPRESSION_ERROR)')
 	}
 	s.headers_done = true
-	// §5.1.2: an over-limit stream was decoded only to keep HPACK in sync; refuse
-	// it now without validating or running the request.
-	if s.refused {
-		c.send_rst_stream(s.id, .refused_stream)!
+	// RFC 7540 §5.3.1: a stream cannot depend on itself; a HEADERS priority
+	// self-dependency is a STREAM error PROTOCOL_ERROR. Checked BEFORE the
+	// concurrency-limit refusal below: REFUSED_STREAM tells the client the
+	// request is safe to retry unchanged, but a self-dependent request is
+	// malformed regardless of the concurrency limit — retrying it would only
+	// repeat the same error, so a stream that is both over-limit and
+	// self-dependent must be reported as PROTOCOL_ERROR, not REFUSED_STREAM.
+	if s.self_dep {
+		c.send_rst_stream(s.id, .protocol_error)!
 		c.mark_locally_reset(s.id)
 		c.streams.delete(s.id)
 		return
 	}
-	// RFC 7540 §5.3.1: a stream cannot depend on itself; a HEADERS priority
-	// self-dependency is a STREAM error PROTOCOL_ERROR. Decoded above for HPACK
-	// sync, refused now.
-	if s.self_dep {
-		c.send_rst_stream(s.id, .protocol_error)!
+	// §5.1.2: an over-limit stream was decoded only to keep HPACK in sync; refuse
+	// it now without validating or running the request.
+	if s.refused {
+		c.send_rst_stream(s.id, .refused_stream)!
 		c.mark_locally_reset(s.id)
 		c.streams.delete(s.id)
 		return

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -1490,6 +1490,54 @@ fn test_h2_server_data_after_priority_self_dep_reset_is_drained() {
 	assert got_response7, 'DATA after PRIORITY self-dep reset: connection should stay usable (stream 7 served)'
 }
 
+// RFC 7540 §5.3.1 / RFC 9113 §5.1.2: a HEADERS frame that is BOTH over the
+// concurrency limit AND self-dependent must be reported as a malformed request
+// (PROTOCOL_ERROR), not REFUSED_STREAM — REFUSED_STREAM tells the client the
+// request is safe to retry as-is, but a self-dependent request will always be
+// malformed, retry or not. Regression for Codex P2 on #27627
+// (pullrequestreview-4620412384).
+fn test_h2_server_self_dep_headers_over_concurrency_limit_is_protocol_error() {
+	mut enc := H2HpackEncoder{}
+	mut out := preface_and_settings()
+	// Stream 1 stays open (no END_STREAM) so it occupies the single concurrency
+	// slot (h2_server_max_concurrent_streams == 1) when stream 3 arrives.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  false
+	}).encode()
+	// Stream 3: over the concurrency limit AND self-dependent.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:    3
+		fragment:     enc.encode(valid_get_pseudo)
+		end_headers:  true
+		end_stream:   true
+		has_priority: true
+		stream_dep:   3
+		weight:       15
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	client_end.write(out) or {
+		assert false, 'self-dep + over-limit HEADERS: client write failed: ${err}'
+		return
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut code := i64(-1)
+	for _ in 0 .. 32 {
+		f := fr.next() or { break }
+		if f is H2RstStreamFrame {
+			if f.stream_id == 3 {
+				code = i64(f.error_code)
+				break
+			}
+		}
+	}
+	assert code == i64(u32(H2ErrorCode.protocol_error)), 'self-dep + over-limit: expected RST_STREAM(PROTOCOL_ERROR), got ${code}'
+}
+
 // A repeated self-dependent PRIORITY on the same id must produce exactly ONE
 // RST_STREAM: after the first reset the stream is closed, and RFC 9113 §5.1
 // forbids sending further non-PRIORITY frames (a second RST) on it.

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -1228,6 +1228,215 @@ fn test_h2_server_hpack_sync_after_locally_reset_stream_headers() {
 	assert s3_status == 200, 'HPACK sync after local RST: stream 3 should get 200 (dynamic table intact), got ${s3_status}'
 }
 
+// RFC 9113 §6.9: a WINDOW_UPDATE with a zero increment on the connection
+// (stream 0) is a connection error of type PROTOCOL_ERROR.
+fn test_h2_server_zero_window_increment_on_connection_is_connection_error() {
+	mut out := preface_and_settings()
+	out << H2Frame(H2WindowUpdateFrame{
+		stream_id:             0
+		window_size_increment: 0
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	code := drive_until_goaway_or_close(mut client_end, out, 'zero WINDOW_UPDATE on connection')
+	assert code == i64(u32(H2ErrorCode.protocol_error)), 'zero conn WINDOW_UPDATE: expected GOAWAY(PROTOCOL_ERROR), got ${code}'
+}
+
+// RFC 9113 §6.9: a WINDOW_UPDATE with a zero increment on a stream is a STREAM
+// error of type PROTOCOL_ERROR — the stream is reset, the connection stays up.
+fn test_h2_server_zero_window_increment_on_stream_is_stream_error() {
+	mut enc := H2HpackEncoder{}
+	mut out := preface_and_settings()
+	// Open stream 1 without END_STREAM so it stays open when the frame arrives.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  false
+	}).encode()
+	out << H2Frame(H2WindowUpdateFrame{
+		stream_id:             1
+		window_size_increment: 0
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	code := drive_until_rst_or_response(mut client_end, out, 'zero WINDOW_UPDATE on stream')
+	assert code == i64(u32(H2ErrorCode.protocol_error)), 'zero stream WINDOW_UPDATE: expected RST_STREAM(PROTOCOL_ERROR), got ${code}'
+}
+
+// RFC 9113 §6.9.1: WINDOW_UPDATE growing the connection flow-control window
+// past 2^31-1 is a connection error of type FLOW_CONTROL_ERROR.
+fn test_h2_server_connection_window_overflow_is_flow_control_error() {
+	mut out := preface_and_settings()
+	// The connection send window starts at 65535, so one maximum increment
+	// (2^31-1) pushes it past 2^31-1.
+	out << H2Frame(H2WindowUpdateFrame{
+		stream_id:             0
+		window_size_increment: u32(0x7fff_ffff)
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	code := drive_until_goaway_or_close(mut client_end, out, 'connection window overflow')
+	assert code == i64(u32(H2ErrorCode.flow_control_error)), 'conn window overflow: expected GOAWAY(FLOW_CONTROL_ERROR), got ${code}'
+}
+
+// RFC 9113 §6.9.1: WINDOW_UPDATE growing a stream's flow-control window past
+// 2^31-1 is a STREAM error of type FLOW_CONTROL_ERROR.
+fn test_h2_server_stream_window_overflow_is_stream_error() {
+	mut enc := H2HpackEncoder{}
+	mut out := preface_and_settings()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  false
+	}).encode()
+	out << H2Frame(H2WindowUpdateFrame{
+		stream_id:             1
+		window_size_increment: u32(0x7fff_ffff)
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	code := drive_until_rst_or_response(mut client_end, out, 'stream window overflow')
+	assert code == i64(u32(H2ErrorCode.flow_control_error)), 'stream window overflow: expected RST_STREAM(FLOW_CONTROL_ERROR), got ${code}'
+}
+
+// RFC 9113 §6.5.2: SETTINGS_ENABLE_PUSH accepts only 0 or 1; any other value is
+// a connection error of type PROTOCOL_ERROR.
+fn test_h2_server_enable_push_out_of_range_is_connection_error() {
+	mut out := []u8{}
+	out << h2_client_preface.bytes()
+	out << H2Frame(H2SettingsFrame{
+		settings: [
+			H2Setting{h2_settings_enable_push, 2},
+		]
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	code := drive_until_goaway_or_close(mut client_end, out, 'ENABLE_PUSH=2')
+	assert code == i64(u32(H2ErrorCode.protocol_error)), 'ENABLE_PUSH=2: expected GOAWAY(PROTOCOL_ERROR), got ${code}'
+}
+
+// RFC 7540 §5.3.1: a HEADERS frame whose priority section depends on its own
+// stream is a STREAM error of type PROTOCOL_ERROR. The header block must still
+// be HPACK-decoded before the RST (RFC 7541 §2.2).
+fn test_h2_server_headers_self_dependency_is_stream_error() {
+	mut enc := H2HpackEncoder{}
+	mut out := preface_and_settings()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:    1
+		fragment:     enc.encode(valid_get_pseudo)
+		end_headers:  true
+		end_stream:   true
+		has_priority: true
+		stream_dep:   1
+		weight:       15
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	code := drive_until_rst_or_response(mut client_end, out, 'HEADERS self-dependency')
+	assert code == i64(u32(H2ErrorCode.protocol_error)), 'HEADERS self-dep: expected RST_STREAM(PROTOCOL_ERROR), got ${code}'
+}
+
+// RFC 7540 §5.3.1: a PRIORITY frame that depends on its own stream is a STREAM
+// error of type PROTOCOL_ERROR.
+fn test_h2_server_priority_self_dependency_is_stream_error() {
+	mut out := preface_and_settings()
+	out << H2Frame(H2PriorityFrame{
+		stream_id:  1
+		stream_dep: 1
+		weight:     15
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	code := drive_until_rst_or_response(mut client_end, out, 'PRIORITY self-dependency')
+	assert code == i64(u32(H2ErrorCode.protocol_error)), 'PRIORITY self-dep: expected RST_STREAM(PROTOCOL_ERROR), got ${code}'
+}
+
+// A repeated self-dependent PRIORITY on the same id must produce exactly ONE
+// RST_STREAM: after the first reset the stream is closed, and RFC 9113 §5.1
+// forbids sending further non-PRIORITY frames (a second RST) on it.
+fn test_h2_server_priority_self_dependency_rst_sent_once() {
+	mut out := preface_and_settings()
+	for _ in 0 .. 3 {
+		out << H2Frame(H2PriorityFrame{
+			stream_id:  1
+			stream_dep: 1
+			weight:     15
+		}).encode()
+	}
+	// A valid request on stream 3 afterwards proves the connection survived and
+	// bounds the read loop with a response.
+	mut enc := H2HpackEncoder{}
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   3
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	client_end.write(out) or {
+		assert false, 'repeated PRIORITY self-dep: client write failed: ${err}'
+		return
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut rst_count := 0
+	mut got_response := false
+	for _ in 0 .. 32 {
+		f := fr.next() or { break }
+		match f {
+			H2RstStreamFrame {
+				if f.stream_id == 1 {
+					rst_count++
+				}
+			}
+			H2HeadersFrame {
+				if f.stream_id == 3 {
+					got_response = true
+					break
+				}
+			}
+			else {}
+		}
+	}
+	assert rst_count == 1, 'repeated PRIORITY self-dep: expected exactly 1 RST_STREAM, got ${rst_count}'
+	assert got_response, 'repeated PRIORITY self-dep: connection should stay usable (stream 3 served)'
+}
+
+// RFC 7540 §5.3.1 applies to any HEADERS carrying a priority section — a
+// trailing HEADERS (trailer section) with a self-dependency is also a STREAM
+// error PROTOCOL_ERROR, and its block is still HPACK-decoded before the RST.
+fn test_h2_server_trailer_self_dependency_is_stream_error() {
+	mut enc := H2HpackEncoder{}
+	req_block := enc.encode([
+		H2HeaderField{':method', 'POST'},
+		H2HeaderField{':scheme', 'https'},
+		H2HeaderField{':path', '/'},
+		H2HeaderField{':authority', 'h.example'},
+	])
+	trailer_block := enc.encode([
+		H2HeaderField{'x-checksum', 'abc'},
+	])
+	mut out := preface_and_settings()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    req_block
+		end_headers: true
+		end_stream:  false
+	}).encode()
+	out << H2Frame(H2DataFrame{
+		stream_id: 1
+		data:      'hi'.bytes()
+	}).encode()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:    1
+		fragment:     trailer_block
+		end_headers:  true
+		end_stream:   true
+		has_priority: true
+		stream_dep:   1
+		weight:       15
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	code := drive_until_rst_or_response(mut client_end, out, 'trailer self-dependency')
+	assert code == i64(u32(H2ErrorCode.protocol_error)), 'trailer self-dep: expected RST_STREAM(PROTOCOL_ERROR), got ${code}'
+}
+
 // RFC 9113 §5.1 / RFC 7541 §2.2: a HEADERS block arriving on a half-closed
 // (remote) stream must be HPACK-decoded before the server sends
 // RST_STREAM(STREAM_CLOSED). The HPACK dynamic table is connection-wide; skipping

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -1346,6 +1346,76 @@ fn test_h2_server_priority_self_dependency_is_stream_error() {
 	assert code == i64(u32(H2ErrorCode.protocol_error)), 'PRIORITY self-dep: expected RST_STREAM(PROTOCOL_ERROR), got ${code}'
 }
 
+// RFC 7540 §5.3.1 / RFC 9113 §5.1: a self-dependent PRIORITY frame for a stream
+// that already completed NORMALLY (full request/response, deleted from
+// c.streams by run_request, never touched locally_reset) must NOT trigger a
+// fresh RST_STREAM — that stream is already closed, and RST_STREAM is not a
+// PRIORITY frame, so sending one on an already-closed stream is itself the
+// §5.1 violation the self-dependency guard exists to police. Regression for
+// Codex P2 on #27627 (pullrequestreview-4620220448).
+fn test_h2_server_priority_self_dep_after_normal_completion_is_ignored() {
+	mut enc := H2HpackEncoder{}
+	mut out := preface_and_settings()
+	// Stream 1: a normal, complete GET request/response -- deleted from
+	// c.streams by run_request, never locally_reset.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	// Self-dependent PRIORITY referencing the now normally-closed stream 1.
+	out << H2Frame(H2PriorityFrame{
+		stream_id:  1
+		stream_dep: 1
+		weight:     15
+	}).encode()
+	// A further valid request proves the connection stays usable.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   3
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	client_end.write(out) or {
+		assert false, 'PRIORITY self-dep after normal completion: client write failed: ${err}'
+		return
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut rst1_count := 0
+	mut resp1_count := 0
+	mut got_response3 := false
+	for _ in 0 .. 32 {
+		f := fr.next() or { break }
+		match f {
+			H2RstStreamFrame {
+				if f.stream_id == 1 {
+					rst1_count++
+				}
+			}
+			H2HeadersFrame {
+				if f.stream_id == 1 {
+					resp1_count++
+				}
+				if f.stream_id == 3 {
+					got_response3 = true
+				}
+			}
+			else {}
+		}
+
+		if got_response3 {
+			break
+		}
+	}
+	assert resp1_count == 1, 'PRIORITY self-dep after normal completion: expected exactly 1 response on stream 1, got ${resp1_count}'
+	assert rst1_count == 0, 'PRIORITY self-dep after normal completion: expected NO RST_STREAM on the already-closed stream 1, got ${rst1_count}'
+	assert got_response3, 'PRIORITY self-dep after normal completion: connection should stay usable (stream 3 served)'
+}
+
 // RFC 9113 §6.4: a self-dependent PRIORITY on a never-opened (idle) stream is
 // itself legal to RST (§5.3.1) — but the id it resets was never added to
 // last_stream_id (only HEADERS advances that counter), so classify_stream must

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -1346,6 +1346,80 @@ fn test_h2_server_priority_self_dependency_is_stream_error() {
 	assert code == i64(u32(H2ErrorCode.protocol_error)), 'PRIORITY self-dep: expected RST_STREAM(PROTOCOL_ERROR), got ${code}'
 }
 
+// RFC 9113 §6.4: a self-dependent PRIORITY on a never-opened (idle) stream is
+// itself legal to RST (§5.3.1) — but the id it resets was never added to
+// last_stream_id (only HEADERS advances that counter), so classify_stream must
+// still recognise it as locally_reset (closed), not idle. Otherwise in-flight
+// DATA for that id — sent by the client before it received our RST — is
+// wrongly treated as a frame on an IDLE stream (a connection PROTOCOL_ERROR)
+// instead of being silently drained per §6.4. Regression for Codex P2 on
+// #27627 (pullrequestreview-4618166175).
+fn test_h2_server_data_after_priority_self_dep_reset_is_drained() {
+	mut enc := H2HpackEncoder{}
+	mut out := preface_and_settings()
+	// Self-dependent PRIORITY on stream 5 -- never opened via HEADERS, so
+	// last_stream_id stays 0. The server should RST(5, PROTOCOL_ERROR).
+	out << H2Frame(H2PriorityFrame{
+		stream_id:  5
+		stream_dep: 5
+		weight:     15
+	}).encode()
+	// DATA in flight for the same id -- must be drained silently (RFC 9113 §6.4),
+	// not treated as DATA-on-idle-stream (a connection error).
+	out << H2Frame(H2DataFrame{
+		stream_id: 5
+		data:      'x'.bytes()
+	}).encode()
+	// A valid request afterwards proves the connection survived (hang-proof: a
+	// buggy server GOAWAYs before this response ever arrives).
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   7
+		fragment:    enc.encode(valid_get_pseudo)
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	mut client_end := spawn_h2_echo_server()
+	client_end.write(out) or {
+		assert false, 'DATA after PRIORITY self-dep reset: client write failed: ${err}'
+		return
+	}
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut got_goaway := false
+	mut rst5_count := 0
+	mut got_response7 := false
+	for _ in 0 .. 32 {
+		f := fr.next() or { break }
+		match f {
+			H2GoawayFrame {
+				// A buggy server GOAWAYs and then never writes again (the test pipe
+				// has no explicit close signal) -- break immediately or the next
+				// fr.next() blocks forever.
+				got_goaway = true
+			}
+			H2RstStreamFrame {
+				if f.stream_id == 5 {
+					rst5_count++
+				}
+			}
+			H2HeadersFrame {
+				if f.stream_id == 7 {
+					got_response7 = true
+				}
+			}
+			else {}
+		}
+
+		if got_goaway || got_response7 {
+			break
+		}
+	}
+	assert !got_goaway, 'DATA after PRIORITY self-dep reset: connection should NOT GOAWAY (in-flight DATA must be drained, not treated as DATA-on-idle)'
+	assert rst5_count == 1, 'DATA after PRIORITY self-dep reset: expected exactly 1 RST_STREAM on stream 5, got ${rst5_count}'
+	assert got_response7, 'DATA after PRIORITY self-dep reset: connection should stay usable (stream 7 served)'
+}
+
 // A repeated self-dependent PRIORITY on the same id must produce exactly ONE
 // RST_STREAM: after the first reset the stream is closed, and RFC 9113 §5.1
 // forbids sending further non-PRIORITY frames (a second RST) on it.

--- a/vlib/net/http/h2spec/README.md
+++ b/vlib/net/http/h2spec/README.md
@@ -13,7 +13,7 @@ sides that internal round-trip tests cannot.
 |------|---------|
 | `h2spec_server.v` | Minimal HTTP/2 target server (TLS + ALPN `h2`, answers 200). The thing h2spec connects to. |
 | `run_h2spec.sh` | Builds the target, starts it, runs a **pinned** h2spec, diffs failures against the baseline. |
-| `h2spec_expected_failures.txt` | Known-failure baseline — currently EMPTY (146/146 pass as of #27627). CI fails on any h2spec failure (mechanically: a regression against an empty baseline). |
+| `h2spec_expected_failures.txt` | Known-failure baseline — currently empty (146/146 pass). |
 | `.github/workflows/h2spec.yml` | CI job: fetches a pinned h2spec release (sha256-verified) and runs the gate. |
 
 ## Running locally
@@ -44,7 +44,7 @@ runner never installs anything — it expects `h2spec` to be provided.
 - ✅ **The harness was run end-to-end with a pinned h2spec v2.6.0**: originally
   146 tests, **109 pass / 37 fail**, identical across four runs (`--timeout 2`
   and `--timeout 5`, two each); the JUnit parser was validated against those real
-  reports. Four follow-up PRs (#27569, #27589, #27627) closed every baselined
+  reports. Three follow-up PRs (#27569, #27589, #27627) closed every baselined
   case; as of #27627 the server passes **all 146 h2spec cases** and
   `h2spec_expected_failures.txt` is empty.
 - ⚠️ **Timing flakiness — handled.** A *separate* handful of h2spec cases
@@ -53,11 +53,11 @@ runner never installs anything — it expects `h2spec` to be provided.
   `--timeout 5` (`H2SPEC_TIMEOUT`). The lesson: always confirm the failure set is
   stable across repeated runs before trusting a per-case h2spec gate — a single
   run can mis-attribute a flaky timeout as a real failure (or regression).
-- The baseline reflects genuine server-side conformance gaps (see the file's
-  header). Each is a tracked item; remove a line as the server is hardened.
-- The baseline was generated locally; the first CI run on Linux validates it. If
-  a case drifts by platform, the harness's "now passing" / regression messages
-  make the one-line fix obvious.
+- The baseline is currently empty, but the mechanism stays in place: a future
+  conformance gap is recorded as a new line and tracked until the server is
+  hardened to pass it, exactly as the original 37-case baseline was closed out.
+- If a case ever drifts by platform, the harness's "now passing" / regression
+  messages make the one-line fix obvious.
 
 ## Expected value
 

--- a/vlib/net/http/h2spec/README.md
+++ b/vlib/net/http/h2spec/README.md
@@ -13,7 +13,7 @@ sides that internal round-trip tests cannot.
 |------|---------|
 | `h2spec_server.v` | Minimal HTTP/2 target server (TLS + ALPN `h2`, answers 200). The thing h2spec connects to. |
 | `run_h2spec.sh` | Builds the target, starts it, runs a **pinned** h2spec, diffs failures against the baseline. |
-| `h2spec_expected_failures.txt` | Known-failure baseline (37 cases). CI fails only on a *regression* (a new failure not listed). |
+| `h2spec_expected_failures.txt` | Known-failure baseline — currently EMPTY (146/146 pass as of #27627). CI fails on any h2spec failure (mechanically: a regression against an empty baseline). |
 | `.github/workflows/h2spec.yml` | CI job: fetches a pinned h2spec release (sha256-verified) and runs the gate. |
 
 ## Running locally
@@ -41,11 +41,12 @@ runner never installs anything — it expects `h2spec` to be provided.
 
 - ✅ `h2spec_server.v` builds (gcc), listens, and negotiates ALPN `h2` (the same
   server driver `test_server_tls_h2_negotiation` exercises end-to-end).
-- ✅ **The harness was run end-to-end with a pinned h2spec v2.6.0**: 146 tests,
-  **109 pass / 37 fail** against the server at this branch's base. The 37-failure
-  set was **identical across four runs** (`--timeout 2` and `--timeout 5`, two
-  each) and is recorded in `h2spec_expected_failures.txt` as the gate baseline.
-  The JUnit parser is validated against those real reports.
+- ✅ **The harness was run end-to-end with a pinned h2spec v2.6.0**: originally
+  146 tests, **109 pass / 37 fail**, identical across four runs (`--timeout 2`
+  and `--timeout 5`, two each); the JUnit parser was validated against those real
+  reports. Four follow-up PRs (#27569, #27589, #27627) closed every baselined
+  case; as of #27627 the server passes **all 146 h2spec cases** and
+  `h2spec_expected_failures.txt` is empty.
 - ⚠️ **Timing flakiness — handled.** A *separate* handful of h2spec cases
   (CONTINUATION sequencing, unknown error codes) wait for the server's GOAWAY/close
   and flake at h2spec's 2s default under load. The runner therefore uses

--- a/vlib/net/http/h2spec/h2spec_expected_failures.txt
+++ b/vlib/net/http/h2spec/h2spec_expected_failures.txt
@@ -9,23 +9,14 @@
 #
 # Generated with h2spec v2.6.0 (146 tests). The original baseline was 37 failures
 # (109 pass). Request header/pseudo-header validation (RFC 9113 §8.1.2/§8.2.2/§8.3)
-# plus HPACK decode-error scope (§4.3: a decode failure is a connection-level
-# COMPRESSION_ERROR, not RST_STREAM) closed 21; the §5.1/§6.1/§6.4 stream-state
-# rules (frames on idle streams are connection errors, on closed streams are
-# STREAM_CLOSED) closed 8 more; routing the flow-control stall path
-# (pump_for_window) through the same dispatch closed §5.1.2 (an over-limit stream
-# opened while a response is stalled is now refused) — 138 pass, 7 fail — verified
-# stable at --timeout 5. NOTE: a handful of h2spec cases (CONTINUATION sequencing,
-# unknown error codes) are timing-flaky at h2spec's 2s default — they wait for the
-# server's GOAWAY/close — so run_h2spec.sh uses --timeout 5 (H2SPEC_TIMEOUT) to keep
-# the gate stable. Do not add a flaky case to this list; raise the timeout instead.
-# The remaining 7 are genuine server-side conformance gaps: PRIORITY self-dependency,
-# SETTINGS_ENABLE_PUSH validation, and flow-control zero-increment/overflow handling.
-# Remove a line when the server is fixed to pass.
-http2/5.3.1 :: Sends HEADERS frame that depends on itself
-http2/5.3.1 :: Sends PRIORITY frame that depend on itself
-http2/6.5.2 :: SETTINGS_ENABLE_PUSH (0x2): Sends the value other than 0 or 1
-http2/6.9 :: Sends a WINDOW_UPDATE frame with a flow control window increment of 0
-http2/6.9 :: Sends a WINDOW_UPDATE frame with a flow control window increment of 0 on a stream
-http2/6.9.1 :: Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1
-http2/6.9.1 :: Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream
+# plus HPACK decode-error scope (§4.3) closed 21; the §5.1/§6.1/§6.4 stream-state
+# rules closed 8 more; routing the flow-control stall path (pump_for_window)
+# through the same dispatch closed §5.1.2; flow-control validation (§6.9/§6.9.1
+# zero-increment and window-overflow), SETTINGS_ENABLE_PUSH range checking
+# (§6.5.2), and priority self-dependency rejection (RFC 7540 §5.3.1) closed the
+# final 7 — the server now passes ALL 146 h2spec cases and this baseline is
+# EMPTY. CI fails on any h2spec failure. NOTE: a handful of h2spec cases
+# (CONTINUATION sequencing, unknown error codes) are timing-flaky at h2spec's 2s
+# default — they wait for the server's GOAWAY/close — so run_h2spec.sh uses
+# --timeout 5 (H2SPEC_TIMEOUT) to keep the gate stable. Do not baseline a flaky
+# case; raise the timeout instead.

--- a/vlib/net/http/h2spec/run_h2spec.sh
+++ b/vlib/net/http/h2spec/run_h2spec.sh
@@ -8,8 +8,11 @@
 #   2. starts it on a free port (TLS + ALPN h2),
 #   3. runs a PINNED h2spec binary against it,
 #   4. compares the set of FAILED case IDs against h2spec_expected_failures.txt,
-#   5. fails only on a regression (a case that newly fails, or a recorded failure
-#      that now passes — so the baseline is kept honest and shrinks over time).
+#   5. fails on a regression (a case that newly fails, or a recorded failure that
+#      now passes). The baseline is currently EMPTY (the server passes all 146
+#      h2spec cases as of vlang/v#27627), so today ANY h2spec failure fails the
+#      gate; the regression-vs-baseline mechanism stays in place so a future gap
+#      can be re-baselined without breaking CI for unrelated work.
 #
 # h2spec is NOT installed here. Provide it via $H2SPEC_BIN or on PATH; CI fetches
 # a pinned release (see .github/workflows/h2spec.yml). This script never runs
@@ -115,8 +118,9 @@ fi
 if [ -n "$now_passing" ]; then
     # Fail too (not just warn): a recorded failure that now passes must be removed
     # from the baseline, otherwise the gate keeps allowing that case and a later
-    # PR can reintroduce the failure unnoticed. (Codex P2.) The 37 baseline cases
-    # are deterministic at H2SPEC_TIMEOUT=5, so this does not flap.
+    # PR can reintroduce the failure unnoticed. (Codex P2.) All 146 cases are
+    # deterministic at H2SPEC_TIMEOUT=5 (baseline is empty as of #27627), so this
+    # does not flap.
     echo "::error:: these recorded failures now PASS — remove them from h2spec_expected_failures.txt to keep the gate honest:" >&2
     echo "$now_passing" >&2
     rc=1


### PR DESCRIPTION
## Summary

Closes the **final 7 h2spec conformance gaps** in the `net.http` HTTP/2 server. The server now passes **all 146 h2spec v2.6.0 cases** and `vlib/net/http/h2spec/h2spec_expected_failures.txt` is **empty** — the CI gate (#27563) now fails on *any* h2spec failure.

Follow-up to #27569 (request header validation, 37→16) and #27589 (stream state machine, 16→7).

## Changes (`h2_server.v`)

**Flow control — RFC 9113 §6.9 / §6.9.1** (in `handle_control_frame`, so both the main dispatch and the `pump_for_window` flow-control stall path enforce it):
- `WINDOW_UPDATE` with a **zero increment**: stream 0 → connection error `PROTOCOL_ERROR`; stream → `RST_STREAM(PROTOCOL_ERROR)`.
- `WINDOW_UPDATE` growing a window **past 2^31-1**: connection → `GOAWAY(FLOW_CONTROL_ERROR)`; stream → `RST_STREAM(FLOW_CONTROL_ERROR)`. The new window is computed and validated before being committed.

**SETTINGS — RFC 9113 §6.5.2:**
- `SETTINGS_ENABLE_PUSH` must be 0 or 1; any other value → connection error `PROTOCOL_ERROR`.

**Priority self-dependency — RFC 7540 §5.3.1** (priority is deprecated in RFC 9113 but the frames must still be validated):
- A `PRIORITY` frame depending on its own stream → `RST_STREAM(PROTOCOL_ERROR)`, sent at most once per id (`locally_reset` guard — no second RST on a stream already reset).
- A `HEADERS` frame (opening **or** trailer) whose priority section depends on its own stream: the header block is still HPACK-decoded first (RFC 7541 §2.2 — the decoder is stateful and connection-wide), then the stream is reset, via a `self_dep` flag mirroring the existing `refused`/`over_end` decode-then-RST pattern.

## Verification

- **h2spec**: 146 tests, 0 failed — **5/5 deterministic runs** (`--timeout 5`, h2spec v2.6.0 pinned sha), plus a re-run after each review fix. Baseline emptied; the gate script warns/fails if any case regresses.
- **Unit tests**: 9 new scripted-peer cases in `h2_server_test.v` covering every closed case + the once-only-RST guarantee (zero-increment conn/stream, overflow conn/stream, `ENABLE_PUSH=2`, HEADERS/PRIORITY/trailer self-dependency, repeated PRIORITY → exactly 1 RST and the connection stays usable).
- Full `vlib/net/http/` suite green (23 passed, 2 skipped).

🧙 Built with [WOZCODE](https://wozcode.com)
