### PR TITLE
db: add common driver and pg SSL config

### DIFF
--- a/vlib/db/README.md
+++ b/vlib/db/README.md
@@ -1,7 +1,35 @@
 ## Description
 
-`db` is a namespace that contains several useful modules 
+`db` is a namespace that contains several useful modules
 for operating with databases (SQLite, MySQL, MSQL, etc.)
+
+## Common Driver Interface
+
+The top-level `db` module exposes a small `Driver` interface for code that only needs
+common SQL operations:
+
+```v ignore
+import db
+
+mut conn := db.open(db.DriverConfig{
+	kind: .sqlite
+	path: ':memory:'
+})!
+defer { conn.close() or {} }
+
+rows := conn.exec('select 1 as n')!
+println(rows[0].val(0))
+```
+
+SQLite support is available by default. The PostgreSQL, MySQL, and MSSQL adapters are
+compiled in only when their C client libraries are enabled:
+
+- PostgreSQL: `-d db_pg`
+- MySQL: `-d db_mysql`
+- MSSQL/ODBC: `-d db_mssql`
+
+For backend-specific features, continue using `db.pg`, `db.mysql`, `db.sqlite`, or
+`db.mssql` directly.
 
 ## Cross-driver consistency helpers
 

--- a/vlib/db/driver.v
+++ b/vlib/db/driver.v
@@ -261,6 +261,10 @@ $if db_mysql ? {
 		return mysql_rows_to_rows(result.rows(), result.field_names())
 	}
 
+	fn mysql_row_set_to_rows(result mysql.RowSet) []DriverRow {
+		return mysql_rows_to_rows(result.rows, result.names)
+	}
+
 	fn (mut driver MysqlDriver) exec(query string) ![]DriverRow {
 		result := driver.conn.query(query)!
 		if result.result == unsafe { nil } {
@@ -281,7 +285,7 @@ $if db_mysql ? {
 	}
 
 	fn (mut driver MysqlDriver) exec_param_many(query string, params []string) ![]DriverRow {
-		return mysql_rows_to_rows(driver.conn.exec_param_many(query, params)!, []string{})
+		return mysql_row_set_to_rows(driver.conn.exec_param_many_result(query, params)!)
 	}
 
 	fn (mut driver MysqlDriver) validate() !bool {
@@ -304,10 +308,10 @@ $if db_pg ? {
 		conn &pg.Conn = unsafe { nil }
 	}
 
-	fn open_pg(config DriverConfig) !&Driver {
-		conn := pg.connect_direct(pg.Config{
-			host:     if config.host != '' { config.host } else { 'localhost' }
-			port:     if config.port > 0 { config.port } else { 5432 }
+	fn pg_config_from_driver_config(config DriverConfig) !pg.Config {
+		return pg.Config{
+			host:     config.host
+			port:     config.port
 			user:     config.user
 			username: config.username
 			password: config.password
@@ -317,7 +321,11 @@ $if db_pg ? {
 			ssl_cert: config.ssl_cert
 			ssl_ca:   config.ssl_ca
 			ssl_crl:  config.ssl_crl
-		})!
+		}
+	}
+
+	fn open_pg(config DriverConfig) !&Driver {
+		conn := pg.connect_direct(pg_config_from_driver_config(config)!)!
 		mut driver := &PgDriver{
 			conn: conn
 		}
@@ -409,23 +417,28 @@ $if db_mssql ? {
 		return driver
 	}
 
-	fn mssql_row_to_row(row mssql.Row) DriverRow {
+	fn mssql_row_to_row(row mssql.Row, names []string) DriverRow {
 		return DriverRow{
-			vals: row.vals.clone()
+			vals:  row.vals.clone()
+			names: names.clone()
 		}
 	}
 
-	fn mssql_rows_to_rows(rows []mssql.Row) []DriverRow {
+	fn mssql_rows_to_rows(rows []mssql.Row, names []string) []DriverRow {
 		mut normalized := []DriverRow{cap: rows.len}
 		for row in rows {
-			normalized << mssql_row_to_row(row)
+			normalized << mssql_row_to_row(row, names)
 		}
 		return normalized
 	}
 
+	fn mssql_result_to_rows(result mssql.Result) []DriverRow {
+		return mssql_rows_to_rows(result.rows, result.names)
+	}
+
 	fn (mut driver MssqlDriver) exec(query string) ![]DriverRow {
 		res := driver.conn.query(query)!
-		return mssql_rows_to_rows(res.rows)
+		return mssql_result_to_rows(res)
 	}
 
 	fn (mut driver MssqlDriver) exec_one(query string) !DriverRow {

--- a/vlib/db/driver.v
+++ b/vlib/db/driver.v
@@ -197,33 +197,33 @@ $if db_mysql ? {
 	}
 
 	fn open_mysql(config DriverConfig) !&Driver {
-		conn := mysql.connect(mysql.Config{
+		mut mysql_config := mysql.Config{
 			host:       if config.host != '' { config.host } else { '127.0.0.1' }
 			port:       if config.port > 0 { u32(config.port) } else { u32(3306) }
 			user:       config.user
 			username:   config.username
 			password:   config.password
 			dbname:     config.dbname
-			flag:       mysql_connection_flag(config)
 			ssl_mode:   mysql_ssl_mode(config.ssl_mode)!
 			ssl_key:    config.ssl_key
 			ssl_cert:   config.ssl_cert
 			ssl_ca:     config.ssl_ca
 			ssl_capath: config.ssl_capath
 			ssl_cipher: config.ssl_cipher
-		})!
+		}
+		if mysql_uses_ssl_files(config) {
+			mysql_config.flag = .client_ssl
+		}
+		conn := mysql.connect(mysql_config)!
 		mut driver := &MysqlDriver{
 			conn: conn
 		}
 		return driver
 	}
 
-	fn mysql_connection_flag(config DriverConfig) mysql.ConnectionFlag {
-		if config.ssl_key != '' || config.ssl_cert != '' || config.ssl_ca != ''
-			|| config.ssl_capath != '' || config.ssl_cipher != '' {
-			return mysql.ConnectionFlag.client_ssl
-		}
-		return mysql.ConnectionFlag(0)
+	fn mysql_uses_ssl_files(config DriverConfig) bool {
+		return config.ssl_key != '' || config.ssl_cert != '' || config.ssl_ca != ''
+			|| config.ssl_capath != '' || config.ssl_cipher != ''
 	}
 
 	fn mysql_ssl_mode(value string) !mysql.SslMode {
@@ -239,30 +239,49 @@ $if db_mysql ? {
 		}
 	}
 
-	fn mysql_row_to_row(row mysql.Row) DriverRow {
+	fn mysql_row_to_row(row mysql.Row, names []string) DriverRow {
 		return DriverRow{
-			vals: row.vals.clone()
+			vals:  row.vals.clone()
+			names: names.clone()
 		}
 	}
 
-	fn mysql_rows_to_rows(rows []mysql.Row) []DriverRow {
+	fn mysql_rows_to_rows(rows []mysql.Row, names []string) []DriverRow {
 		mut normalized := []DriverRow{cap: rows.len}
 		for row in rows {
-			normalized << mysql_row_to_row(row)
+			normalized << mysql_row_to_row(row, names)
 		}
 		return normalized
 	}
 
+	fn mysql_result_to_rows(result mysql.Result) []DriverRow {
+		if result.result == unsafe { nil } {
+			return []DriverRow{}
+		}
+		return mysql_rows_to_rows(result.rows(), result.field_names())
+	}
+
 	fn (mut driver MysqlDriver) exec(query string) ![]DriverRow {
-		return mysql_rows_to_rows(driver.conn.exec(query)!)
+		result := driver.conn.query(query)!
+		if result.result == unsafe { nil } {
+			return []DriverRow{}
+		}
+		defer {
+			unsafe { result.free() }
+		}
+		return mysql_result_to_rows(result)
 	}
 
 	fn (mut driver MysqlDriver) exec_one(query string) !DriverRow {
-		return mysql_row_to_row(driver.conn.exec_one(query)!)
+		rows := driver.exec(query)!
+		if rows.len == 0 {
+			return DriverRow{}
+		}
+		return rows[0]
 	}
 
 	fn (mut driver MysqlDriver) exec_param_many(query string, params []string) ![]DriverRow {
-		return mysql_rows_to_rows(driver.conn.exec_param_many(query, params)!)
+		return mysql_rows_to_rows(driver.conn.exec_param_many(query, params)!, []string{})
 	}
 
 	fn (mut driver MysqlDriver) validate() !bool {

--- a/vlib/db/driver.v
+++ b/vlib/db/driver.v
@@ -319,30 +319,35 @@ $if db_pg ? {
 		}
 	}
 
-	fn pg_row_to_row(row pg.Row) DriverRow {
+	fn pg_row_to_row(row pg.Row, names []string) DriverRow {
 		return DriverRow{
-			vals: row.values()
+			vals:  row.values()
+			names: names.clone()
 		}
 	}
 
-	fn pg_rows_to_rows(rows []pg.Row) []DriverRow {
-		mut normalized := []DriverRow{cap: rows.len}
-		for row in rows {
-			normalized << pg_row_to_row(row)
+	fn pg_result_to_rows(result pg.Result) []DriverRow {
+		mut normalized := []DriverRow{cap: result.rows.len}
+		for row in result.rows {
+			normalized << pg_row_to_row(row, result.names)
 		}
 		return normalized
 	}
 
 	fn (mut driver PgDriver) exec(query string) ![]DriverRow {
-		return pg_rows_to_rows(driver.conn.exec(query)!)
+		return pg_result_to_rows(driver.conn.exec_result(query)!)
 	}
 
 	fn (mut driver PgDriver) exec_one(query string) !DriverRow {
-		return pg_row_to_row(driver.conn.exec_one(query)!)
+		rows := driver.exec(query)!
+		if rows.len == 0 {
+			return error('no row')
+		}
+		return rows[0]
 	}
 
 	fn (mut driver PgDriver) exec_param_many(query string, params []string) ![]DriverRow {
-		return pg_rows_to_rows(driver.conn.exec_param_many(query, params)!)
+		return pg_result_to_rows(driver.conn.exec_param_many_result(query, params)!)
 	}
 
 	fn (mut driver PgDriver) validate() !bool {

--- a/vlib/db/driver.v
+++ b/vlib/db/driver.v
@@ -1,0 +1,430 @@
+module db
+
+import db.sqlite
+
+$if db_mysql ? {
+	import db.mysql
+}
+$if db_pg ? {
+	import db.pg
+}
+$if db_mssql ? {
+	import db.mssql
+}
+
+// DriverKind selects the backend used by `open`.
+pub enum DriverKind {
+	sqlite
+	mysql
+	pg
+	mssql
+}
+
+// DriverRow is the normalized row type returned by `Driver` implementations.
+pub struct DriverRow {
+pub mut:
+	vals  []string
+	names []string
+}
+
+// val returns the value at `index`.
+pub fn (row DriverRow) val(index int) string {
+	return row.vals[index]
+}
+
+// values returns all row values.
+pub fn (row DriverRow) values() []string {
+	return row.vals.clone()
+}
+
+// get_string returns the value for the given column name, or '' if it is missing.
+pub fn (row DriverRow) get_string(col_name string) string {
+	for i, name in row.names {
+		if name == col_name {
+			if i < row.vals.len {
+				return row.vals[i]
+			}
+			return ''
+		}
+	}
+	return ''
+}
+
+// Driver is the minimal common database connection interface exposed by the
+// top-level `db` module. Backend-specific APIs remain available in their
+// existing modules.
+pub interface Driver {
+mut:
+	exec(query string) ![]DriverRow
+	exec_one(query string) !DriverRow
+	exec_param_many(query string, params []string) ![]DriverRow
+	validate() !bool
+	reset() !
+	close() !
+}
+
+// DriverConfig contains the common connection fields used by `open`.
+//
+// SQLite uses `path` or, when empty, `dbname`.
+// PostgreSQL/MySQL use the network/user fields. MSSQL also accepts ODBC
+// fields such as `conn_str`, `dsn`, `driver`, `server`, `uid`, `pwd`, and
+// `options`.
+pub struct DriverConfig {
+pub:
+	kind DriverKind
+
+	path     string
+	host     string
+	port     int
+	user     string
+	username string
+	password string
+	dbname   string
+
+	conn_str string
+	dsn      string
+	driver   string
+	server   string
+	uid      string
+	pwd      string
+	options  map[string]string
+
+	ssl_mode   string
+	ssl_key    string
+	ssl_cert   string
+	ssl_ca     string
+	ssl_crl    string
+	ssl_capath string
+	ssl_cipher string
+}
+
+@[heap]
+struct SqliteDriver {
+mut:
+	conn sqlite.DB
+}
+
+// open creates a normalized database driver for the selected backend.
+//
+// SQLite support is available by default. PostgreSQL, MySQL, and MSSQL are
+// compiled in only when `-d db_pg`, `-d db_mysql`, or `-d db_mssql` is used,
+// avoiding unconditional dependencies on their C client libraries.
+pub fn open(config DriverConfig) !&Driver {
+	match config.kind {
+		.sqlite {
+			return open_sqlite(config)!
+		}
+		.mysql {
+			$if db_mysql ? {
+				return open_mysql(config)!
+			} $else {
+				return error('db: mysql driver support is not compiled in; rebuild with `-d db_mysql`')
+			}
+		}
+		.pg {
+			$if db_pg ? {
+				return open_pg(config)!
+			} $else {
+				return error('db: pg driver support is not compiled in; rebuild with `-d db_pg`')
+			}
+		}
+		.mssql {
+			$if db_mssql ? {
+				return open_mssql(config)!
+			} $else {
+				return error('db: mssql driver support is not compiled in; rebuild with `-d db_mssql`')
+			}
+		}
+	}
+}
+
+fn open_sqlite(config DriverConfig) !&Driver {
+	path := if config.path != '' { config.path } else { config.dbname }
+	if path == '' {
+		return error('db: sqlite driver requires DriverConfig.path or DriverConfig.dbname')
+	}
+	conn := sqlite.connect(path)!
+	mut driver := &SqliteDriver{
+		conn: conn
+	}
+	return driver
+}
+
+fn sqlite_row_to_row(row sqlite.Row) DriverRow {
+	return DriverRow{
+		vals:  row.vals.clone()
+		names: row.names.clone()
+	}
+}
+
+fn sqlite_rows_to_rows(rows []sqlite.Row) []DriverRow {
+	mut normalized := []DriverRow{cap: rows.len}
+	for row in rows {
+		normalized << sqlite_row_to_row(row)
+	}
+	return normalized
+}
+
+fn (mut driver SqliteDriver) exec(query string) ![]DriverRow {
+	return sqlite_rows_to_rows(driver.conn.exec(query)!)
+}
+
+fn (mut driver SqliteDriver) exec_one(query string) !DriverRow {
+	return sqlite_row_to_row(driver.conn.exec_one(query)!)
+}
+
+fn (mut driver SqliteDriver) exec_param_many(query string, params []string) ![]DriverRow {
+	return sqlite_rows_to_rows(driver.conn.exec_param_many(query, params)!)
+}
+
+fn (mut driver SqliteDriver) validate() !bool {
+	return driver.conn.validate()!
+}
+
+fn (mut driver SqliteDriver) reset() ! {
+	driver.conn.reset()!
+}
+
+fn (mut driver SqliteDriver) close() ! {
+	driver.conn.close()!
+}
+
+$if db_mysql ? {
+	@[heap]
+	struct MysqlDriver {
+	mut:
+		conn mysql.DB
+	}
+
+	fn open_mysql(config DriverConfig) !&Driver {
+		conn := mysql.connect(mysql.Config{
+			host:       if config.host != '' { config.host } else { '127.0.0.1' }
+			port:       if config.port > 0 { u32(config.port) } else { u32(3306) }
+			user:       config.user
+			username:   config.username
+			password:   config.password
+			dbname:     config.dbname
+			flag:       mysql_connection_flag(config)
+			ssl_mode:   mysql_ssl_mode(config.ssl_mode)!
+			ssl_key:    config.ssl_key
+			ssl_cert:   config.ssl_cert
+			ssl_ca:     config.ssl_ca
+			ssl_capath: config.ssl_capath
+			ssl_cipher: config.ssl_cipher
+		})!
+		mut driver := &MysqlDriver{
+			conn: conn
+		}
+		return driver
+	}
+
+	fn mysql_connection_flag(config DriverConfig) mysql.ConnectionFlag {
+		if config.ssl_key != '' || config.ssl_cert != '' || config.ssl_ca != ''
+			|| config.ssl_capath != '' || config.ssl_cipher != '' {
+			return mysql.ConnectionFlag.client_ssl
+		}
+		return mysql.ConnectionFlag(0)
+	}
+
+	fn mysql_ssl_mode(value string) !mysql.SslMode {
+		normalized := value.to_lower().replace('-', '_')
+		return match normalized {
+			'', 'unset' { mysql.SslMode.unset }
+			'disabled', 'disable' { mysql.SslMode.disabled }
+			'preferred', 'prefer' { mysql.SslMode.preferred }
+			'required', 'require' { mysql.SslMode.required }
+			'verify_ca' { mysql.SslMode.verify_ca }
+			'verify_identity', 'verify_full' { mysql.SslMode.verify_identity }
+			else { error('db: unsupported mysql ssl_mode `${value}`') }
+		}
+	}
+
+	fn mysql_row_to_row(row mysql.Row) DriverRow {
+		return DriverRow{
+			vals: row.vals.clone()
+		}
+	}
+
+	fn mysql_rows_to_rows(rows []mysql.Row) []DriverRow {
+		mut normalized := []DriverRow{cap: rows.len}
+		for row in rows {
+			normalized << mysql_row_to_row(row)
+		}
+		return normalized
+	}
+
+	fn (mut driver MysqlDriver) exec(query string) ![]DriverRow {
+		return mysql_rows_to_rows(driver.conn.exec(query)!)
+	}
+
+	fn (mut driver MysqlDriver) exec_one(query string) !DriverRow {
+		return mysql_row_to_row(driver.conn.exec_one(query)!)
+	}
+
+	fn (mut driver MysqlDriver) exec_param_many(query string, params []string) ![]DriverRow {
+		return mysql_rows_to_rows(driver.conn.exec_param_many(query, params)!)
+	}
+
+	fn (mut driver MysqlDriver) validate() !bool {
+		return driver.conn.validate()!
+	}
+
+	fn (mut driver MysqlDriver) reset() ! {
+		driver.conn.reset()!
+	}
+
+	fn (mut driver MysqlDriver) close() ! {
+		driver.conn.close()!
+	}
+}
+
+$if db_pg ? {
+	@[heap]
+	struct PgDriver {
+	mut:
+		conn &pg.Conn = unsafe { nil }
+	}
+
+	fn open_pg(config DriverConfig) !&Driver {
+		conn := pg.connect_direct(pg.Config{
+			host:     if config.host != '' { config.host } else { 'localhost' }
+			port:     if config.port > 0 { config.port } else { 5432 }
+			user:     config.user
+			username: config.username
+			password: config.password
+			dbname:   config.dbname
+			ssl_mode: pg_ssl_mode(config.ssl_mode)!
+			ssl_key:  config.ssl_key
+			ssl_cert: config.ssl_cert
+			ssl_ca:   config.ssl_ca
+			ssl_crl:  config.ssl_crl
+		})!
+		mut driver := &PgDriver{
+			conn: conn
+		}
+		return driver
+	}
+
+	fn pg_ssl_mode(value string) !pg.SslMode {
+		normalized := value.to_lower().replace('-', '_')
+		return match normalized {
+			'', 'unset' { pg.SslMode.unset }
+			'disable', 'disabled' { pg.SslMode.disable }
+			'allow' { pg.SslMode.allow }
+			'prefer', 'preferred' { pg.SslMode.prefer }
+			'require', 'required' { pg.SslMode.require }
+			'verify_ca' { pg.SslMode.verify_ca }
+			'verify_full' { pg.SslMode.verify_full }
+			else { error('db: unsupported pg ssl_mode `${value}`') }
+		}
+	}
+
+	fn pg_row_to_row(row pg.Row) DriverRow {
+		return DriverRow{
+			vals: row.values()
+		}
+	}
+
+	fn pg_rows_to_rows(rows []pg.Row) []DriverRow {
+		mut normalized := []DriverRow{cap: rows.len}
+		for row in rows {
+			normalized << pg_row_to_row(row)
+		}
+		return normalized
+	}
+
+	fn (mut driver PgDriver) exec(query string) ![]DriverRow {
+		return pg_rows_to_rows(driver.conn.exec(query)!)
+	}
+
+	fn (mut driver PgDriver) exec_one(query string) !DriverRow {
+		return pg_row_to_row(driver.conn.exec_one(query)!)
+	}
+
+	fn (mut driver PgDriver) exec_param_many(query string, params []string) ![]DriverRow {
+		return pg_rows_to_rows(driver.conn.exec_param_many(query, params)!)
+	}
+
+	fn (mut driver PgDriver) validate() !bool {
+		return driver.conn.validate()!
+	}
+
+	fn (mut driver PgDriver) reset() ! {
+		driver.conn.reset()!
+	}
+
+	fn (mut driver PgDriver) close() ! {
+		driver.conn.close()!
+	}
+}
+
+$if db_mssql ? {
+	@[heap]
+	struct MssqlDriver {
+	mut:
+		conn mssql.Connection
+	}
+
+	fn open_mssql(config DriverConfig) !&Driver {
+		conn := mssql.connect(mssql.Config{
+			conn_str: config.conn_str
+			dsn:      config.dsn
+			driver:   config.driver
+			server:   if config.server != '' { config.server } else { config.host }
+			port:     config.port
+			uid:      config.uid
+			user:     config.user
+			pwd:      config.pwd
+			password: config.password
+			dbname:   config.dbname
+			options:  config.options
+		})!
+		mut driver := &MssqlDriver{
+			conn: conn
+		}
+		return driver
+	}
+
+	fn mssql_row_to_row(row mssql.Row) DriverRow {
+		return DriverRow{
+			vals: row.vals.clone()
+		}
+	}
+
+	fn mssql_rows_to_rows(rows []mssql.Row) []DriverRow {
+		mut normalized := []DriverRow{cap: rows.len}
+		for row in rows {
+			normalized << mssql_row_to_row(row)
+		}
+		return normalized
+	}
+
+	fn (mut driver MssqlDriver) exec(query string) ![]DriverRow {
+		res := driver.conn.query(query)!
+		return mssql_rows_to_rows(res.rows)
+	}
+
+	fn (mut driver MssqlDriver) exec_one(query string) !DriverRow {
+		rows := driver.exec(query)!
+		if rows.len == 0 {
+			return error('db: query returned no rows')
+		}
+		return rows[0]
+	}
+
+	fn (mut driver MssqlDriver) exec_param_many(_ string, _ []string) ![]DriverRow {
+		return error('db: mssql driver does not support exec_param_many')
+	}
+
+	fn (mut driver MssqlDriver) validate() !bool {
+		driver.conn.query('SELECT 1')!
+		return true
+	}
+
+	fn (mut driver MssqlDriver) reset() ! {
+	}
+
+	fn (mut driver MssqlDriver) close() ! {
+		driver.conn.close()
+	}
+}

--- a/vlib/db/driver_mssql_test.v
+++ b/vlib/db/driver_mssql_test.v
@@ -1,19 +1,19 @@
-// vtest build: db_mysql?
+// vtest build: db_mssql?
 module db
 
-import db.mysql
+import db.mssql
 
-fn test_mysql_rows_to_rows_copies_column_names() {
-	result := mysql.RowSet{
+fn test_mssql_result_to_rows_copies_column_names() {
+	result := mssql.Result{
 		names: ['name', 'status']
 		rows:  [
-			mysql.Row{
+			mssql.Row{
 				vals: ['alice', 'active']
 			},
 		]
 	}
 
-	normalized := mysql_row_set_to_rows(result)
+	normalized := mssql_result_to_rows(result)
 	assert normalized.len == 1
 	assert normalized[0].names == ['name', 'status']
 	assert normalized[0].val(0) == 'alice'

--- a/vlib/db/driver_mysql_test.v
+++ b/vlib/db/driver_mysql_test.v
@@ -1,0 +1,19 @@
+// vtest build: db_mysql?
+module db
+
+import db.mysql
+
+fn test_mysql_rows_to_rows_copies_column_names() {
+	rows := [
+		mysql.Row{
+			vals: ['alice', 'active']
+		},
+	]
+
+	normalized := mysql_rows_to_rows(rows, ['name', 'status'])
+	assert normalized.len == 1
+	assert normalized[0].names == ['name', 'status']
+	assert normalized[0].val(0) == 'alice'
+	assert normalized[0].get_string('name') == 'alice'
+	assert normalized[0].get_string('status') == 'active'
+}

--- a/vlib/db/driver_pg_test.v
+++ b/vlib/db/driver_pg_test.v
@@ -3,6 +3,19 @@ module db
 
 import db.pg
 
+fn test_pg_config_from_driver_config_leaves_host_port_unset() {
+	config := pg_config_from_driver_config(DriverConfig{})!
+	assert config.host == ''
+	assert config.port == 0
+
+	configured := pg_config_from_driver_config(DriverConfig{
+		host: 'db.example.com'
+		port: 15432
+	})!
+	assert configured.host == 'db.example.com'
+	assert configured.port == 15432
+}
+
 fn test_pg_result_to_rows_copies_column_names() {
 	mut vals := []?string{}
 	vals << 'alice'

--- a/vlib/db/driver_pg_test.v
+++ b/vlib/db/driver_pg_test.v
@@ -1,0 +1,29 @@
+// vtest build: db_pg?
+module db
+
+import db.pg
+
+fn test_pg_result_to_rows_copies_column_names() {
+	mut vals := []?string{}
+	vals << 'alice'
+	vals << none
+	result := pg.Result{
+		cols:  {
+			'name':    0
+			'deleted': 1
+		}
+		names: ['name', 'deleted']
+		rows:  [
+			pg.Row{
+				vals: vals
+			},
+		]
+	}
+
+	rows := pg_result_to_rows(result)
+	assert rows.len == 1
+	assert rows[0].names == ['name', 'deleted']
+	assert rows[0].val(0) == 'alice'
+	assert rows[0].get_string('name') == 'alice'
+	assert rows[0].get_string('deleted') == ''
+}

--- a/vlib/db/driver_test.v
+++ b/vlib/db/driver_test.v
@@ -1,0 +1,58 @@
+module main
+
+import db
+
+fn test_sqlite_driver_open_exec() {
+	mut driver := db.open(db.DriverConfig{
+		kind:   .sqlite
+		dbname: ':memory:'
+	})!
+	defer {
+		driver.close() or {}
+	}
+
+	driver.exec('create table users (id integer primary key, name text)')!
+	driver.exec_param_many('insert into users (name) values (?)', ['alice'])!
+
+	row := driver.exec_one('select id, name from users')!
+	assert row.val(0) == '1'
+	assert row.val(1) == 'alice'
+	assert row.get_string('name') == 'alice'
+	assert row.values() == ['1', 'alice']
+
+	assert driver.validate()!
+	driver.reset()!
+}
+
+fn test_optional_backends_report_compile_flag_when_disabled() {
+	$if !db_pg ? {
+		if _ := db.open(db.DriverConfig{
+			kind: .pg
+		})
+		{
+			assert false
+		} else {
+			assert err.msg().contains('-d db_pg')
+		}
+	}
+	$if !db_mysql ? {
+		if _ := db.open(db.DriverConfig{
+			kind: .mysql
+		})
+		{
+			assert false
+		} else {
+			assert err.msg().contains('-d db_mysql')
+		}
+	}
+	$if !db_mssql ? {
+		if _ := db.open(db.DriverConfig{
+			kind: .mssql
+		})
+		{
+			assert false
+		} else {
+			assert err.msg().contains('-d db_mssql')
+		}
+	}
+}

--- a/vlib/db/mssql/_cdefs.c.v
+++ b/vlib/db/mssql/_cdefs.c.v
@@ -11,6 +11,7 @@ type C.SQLLEN = isize
 type C.SQLPOINTER = voidptr
 type C.SQLRETURN = i16
 type C.SQLSMALLINT = i16
+type C.SQLULEN = usize
 type C.SQLUSMALLINT = u16
 
 fn C.SQLAllocHandle(handle_type C.SQLSMALLINT, input_handle C.SQLHANDLE, output_handle &C.SQLHANDLE) C.SQLRETURN
@@ -31,6 +32,10 @@ fn C.SQLExecDirect(statement_handle C.SQLHSTMT, statement_text &C.SQLCHAR, text_
 
 fn C.SQLBindCol(statement_handle C.SQLHSTMT, column_number C.SQLUSMALLINT, target_type C.SQLSMALLINT, target_value C.SQLPOINTER,
 	buffer_length C.SQLLEN, str_len_or_ind &C.SQLLEN) C.SQLRETURN
+
+fn C.SQLDescribeCol(statement_handle C.SQLHSTMT, column_number C.SQLUSMALLINT, column_name &C.SQLCHAR,
+	buffer_length C.SQLSMALLINT, name_length &C.SQLSMALLINT, data_type &C.SQLSMALLINT,
+	column_size &C.SQLULEN, decimal_digits &C.SQLSMALLINT, nullable &C.SQLSMALLINT) C.SQLRETURN
 
 fn C.SQLFetch(statement_handle C.SQLHSTMT) C.SQLRETURN
 

--- a/vlib/db/mssql/mssql.c.v
+++ b/vlib/db/mssql/mssql.c.v
@@ -75,9 +75,11 @@ pub fn (mut conn Connection) query(q string) !Result {
 	affected := hstmt.retrieve_affected_rows()!
 
 	hstmt.prepare_read()!
+	names := hstmt.read_column_names()!
 	raw_rows := hstmt.read_rows()!
 
 	mut res := Result{
+		names:             names
 		rows:              []Row{}
 		num_rows_affected: affected
 	}

--- a/vlib/db/mssql/result.v
+++ b/vlib/db/mssql/result.v
@@ -17,7 +17,8 @@ pub fn (row Row) values() []string {
 
 pub struct Result {
 pub mut:
-	rows []Row
+	names []string
+	rows  []Row
 	// the number of rows affected by sql statement
 	num_rows_affected int
 }

--- a/vlib/db/mssql/stmt_handle.c.v
+++ b/vlib/db/mssql/stmt_handle.c.v
@@ -65,6 +65,28 @@ fn (h HStmt) retrieve_column_count() !int {
 	return int(col_count_buff)
 }
 
+fn (h HStmt) read_column_names() ![]string {
+	if h.column_count <= 0 {
+		return []string{}
+	}
+	mut names := []string{cap: h.column_count}
+	for i := 0; i < h.column_count; i++ {
+		mut name_buf := [256]char{}
+		mut name_len := C.SQLSMALLINT(0)
+		mut data_type := C.SQLSMALLINT(0)
+		mut column_size := C.SQLULEN(0)
+		mut decimal_digits := C.SQLSMALLINT(0)
+		mut nullable := C.SQLSMALLINT(0)
+		retcode := C.SQLDescribeCol(h.hstmt, C.SQLUSMALLINT(i + 1), &C.SQLCHAR(&name_buf[0]),
+			C.SQLSMALLINT(name_buf.len), &name_len, &data_type, &column_size, &decimal_digits,
+			&nullable)
+		check_error(retcode, 'SQLDescribeCol()', C.SQLHANDLE(h.hstmt),
+			C.SQLSMALLINT(C.SQL_HANDLE_STMT))!
+		names << unsafe { (&name_buf[0]).vstring() }
+	}
+	return names
+}
+
 // allocate buffers and bind them to drivers
 fn (mut h HStmt) prepare_read() ! {
 	mut retcode := C.SQLRETURN(C.SQL_SUCCESS)

--- a/vlib/db/mysql/mysql.c.v
+++ b/vlib/db/mysql/mysql.c.v
@@ -777,12 +777,18 @@ pub fn (db &DB) exec_none(query string) int {
 // exec_param_many executes the `query` with parameters provided as `?`'s in the query
 // It returns either the full result set, or an error on failure
 pub fn (db &DB) exec_param_many(query string, params []string) ![]Row {
+	result := db.exec_param_many_result(query, params)!
+	return result.rows
+}
+
+// exec_param_many_result executes the `query` with parameters provided as `?`'s,
+// returning rows and their column names.
+pub fn (db &DB) exec_param_many_result(query string, params []string) !RowSet {
 	stmt := db.prepare(query)!
 	defer {
 		stmt.close()
 	}
-	rows := stmt.execute(params)!
-	return rows
+	return stmt.execute_result(params)!
 }
 
 // exec_param executes the `query` with one parameter provided as an `?` in the query
@@ -837,6 +843,12 @@ pub fn (db &DB) prepare(query string) !StmtHandle {
 // Returns an array of Rows, which will be empty if nothing is returned
 // from the query, or possibly an error value
 pub fn (stmt &StmtHandle) execute(params []string) ![]Row {
+	result := stmt.execute_result(params)!
+	return result.rows
+}
+
+// execute_result executes the statement and returns rows with column names.
+pub fn (stmt &StmtHandle) execute_result(params []string) !RowSet {
 	mut guard := stmt.db.acquire_connection_guard()!
 	defer {
 		guard.release()
@@ -867,7 +879,12 @@ pub fn (stmt &StmtHandle) execute(params []string) ![]Row {
 	// If the query returns no metadata we have no data to return
 	// This happens in insert queries
 	if query_metadata == unsafe { nil } {
-		return []Row{}
+		return RowSet{}
+	}
+	metadata := Result{query_metadata}
+	names := metadata.field_names()
+	defer {
+		unsafe { metadata.free() }
 	}
 	num_cols := C.mysql_num_fields(query_metadata)
 	mut length := []u32{len: num_cols}
@@ -908,7 +925,10 @@ pub fn (stmt &StmtHandle) execute(params []string) ![]Row {
 		}
 		rows << row
 	}
-	return rows
+	return RowSet{
+		names: names
+		rows:  rows
+	}
 }
 
 // close acts on a StmtHandle to close the mysql Stmt

--- a/vlib/db/mysql/result.c.v
+++ b/vlib/db/mysql/result.c.v
@@ -139,6 +139,19 @@ pub fn (r Result) fields() []Field {
 	return fields
 }
 
+// field_names returns the column names for this result set.
+pub fn (r Result) field_names() []string {
+	if r.result == unsafe { nil } {
+		return []string{}
+	}
+	fields := r.fields()
+	mut names := []string{cap: fields.len}
+	for field in fields {
+		names << field.name
+	}
+	return names
+}
+
 // str serializes the field.
 pub fn (f Field) str() string {
 	return '

--- a/vlib/db/mysql/result.c.v
+++ b/vlib/db/mysql/result.c.v
@@ -10,6 +10,13 @@ pub mut:
 	vals []string
 }
 
+// RowSet contains materialized rows and their column names.
+pub struct RowSet {
+pub:
+	names []string
+	rows  []Row
+}
+
 pub struct Field {
 	name             string
 	org_name         string

--- a/vlib/db/pg/README.md
+++ b/vlib/db/pg/README.md
@@ -124,6 +124,24 @@ When you use `pg.connect(pg.Config{ ... })`, empty `Config` fields are omitted f
 generated libpq connection string. That lets libpq defaults, `PGPASSWORD`, and `.pgpass`
 apply when you do not set those fields in code.
 
+`pg.Config` also exposes libpq SSL/TLS connection keywords:
+
+```v ignore
+mut db := pg.connect(pg.Config{
+	host:     'db.example.com'
+	user:     'app'
+	password: 'secret'
+	dbname:   'prod'
+	ssl_mode: .verify_full
+	ssl_ca:   '/etc/ssl/certs/root-ca.pem'
+	ssl_cert: '/etc/ssl/certs/client.pem'
+	ssl_key:  '/etc/ssl/private/client.key'
+})!
+```
+
+The SSL fields map to libpq's `sslmode`, `sslcert`, `sslkey`, `sslrootcert`, and
+`sslcrl` connection parameters.
+
 ## Thread Safety & Connection Pool
 
 `pg.connect()` returns a `&DB` that is safe to share across V threads. Internally
@@ -158,6 +176,16 @@ mut tx := db.begin()!
 tx.exec('UPDATE accounts SET balance = balance - 100 WHERE id = 1')!
 tx.exec('UPDATE accounts SET balance = balance + 100 WHERE id = 2')!
 tx.commit()!
+```
+
+If you need to manage pooling outside `db.pg`, use `pg.connect_direct()` to open one
+physical connection without the built-in pool:
+
+```v ignore
+mut conn := pg.connect_direct(pg.Config{ host: 'localhost', dbname: 'app' })!
+defer { conn.close() or {} }
+
+rows := conn.exec('select 1')!
 ```
 
 ## Using Parameterized Queries

--- a/vlib/db/pg/db.v
+++ b/vlib/db/pg/db.v
@@ -31,6 +31,24 @@ pub fn connect_with_conninfo(conninfo string, pcfg PoolConfig) !&DB {
 	return db
 }
 
+// connect_direct opens a single physical PostgreSQL connection without
+// creating an internal connection pool. The returned `&Conn` is not safe for
+// concurrent use by multiple V threads; callers are responsible for calling
+// `conn.close()` when done.
+pub fn connect_direct(config Config) !&Conn {
+	return connect_direct_with_conninfo(config.conninfo()!)!
+}
+
+// connect_direct_with_conninfo is the conninfo-string variant of `connect_direct`.
+pub fn connect_direct_with_conninfo(conninfo string) !&Conn {
+	slot := connect_slot(conninfo)!
+	return &Conn{
+		conn:       slot.handle
+		created_at: slot.created_at
+		bad:        slot.bad
+	}
+}
+
 // close shuts down the pool and tears down all idle connections.
 // In-flight conns will be closed when released.
 pub fn (mut db DB) close() ! {

--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -117,6 +117,18 @@ pub:
 	rows  []Row
 }
 
+// SslMode controls PostgreSQL SSL/TLS negotiation through libpq's `sslmode`
+// connection keyword.
+pub enum SslMode {
+	unset
+	disable
+	allow
+	prefer
+	require
+	verify_ca
+	verify_full
+}
+
 // Notification represents a notification received from the server via LISTEN/NOTIFY
 pub struct Notification {
 pub:
@@ -133,6 +145,12 @@ pub:
 	username string
 	password string
 	dbname   string
+	// SSL/TLS configuration, passed through to libpq connection keywords.
+	ssl_mode SslMode
+	ssl_key  string // client key file path, maps to sslkey
+	ssl_cert string // client certificate file path, maps to sslcert
+	ssl_ca   string // CA certificate file path, maps to sslrootcert
+	ssl_crl  string // certificate revocation list file path, maps to sslcrl
 }
 
 //
@@ -273,6 +291,18 @@ fn escape_conninfo_value(value string) string {
 	return escaped.bytestr()
 }
 
+fn (mode SslMode) conninfo_value() string {
+	return match mode {
+		.unset { '' }
+		.disable { 'disable' }
+		.allow { 'allow' }
+		.prefer { 'prefer' }
+		.require { 'require' }
+		.verify_ca { 'verify-ca' }
+		.verify_full { 'verify-full' }
+	}
+}
+
 // connection_user returns the configured username, accepting both `user` and `username`.
 pub fn (config Config) connection_user() !string {
 	if config.user != '' && config.username != '' && config.user != config.username {
@@ -285,7 +315,7 @@ pub fn (config Config) connection_user() !string {
 }
 
 fn (config Config) conninfo() !string {
-	mut parts := []string{cap: 5}
+	mut parts := []string{cap: 10}
 	if config.host != '' {
 		parts << 'host=${escape_conninfo_value(config.host)}'
 	}
@@ -301,6 +331,21 @@ fn (config Config) conninfo() !string {
 	}
 	if config.password != '' {
 		parts << 'password=${escape_conninfo_value(config.password)}'
+	}
+	if config.ssl_mode != .unset {
+		parts << 'sslmode=${config.ssl_mode.conninfo_value()}'
+	}
+	if config.ssl_cert != '' {
+		parts << 'sslcert=${escape_conninfo_value(config.ssl_cert)}'
+	}
+	if config.ssl_key != '' {
+		parts << 'sslkey=${escape_conninfo_value(config.ssl_key)}'
+	}
+	if config.ssl_ca != '' {
+		parts << 'sslrootcert=${escape_conninfo_value(config.ssl_ca)}'
+	}
+	if config.ssl_crl != '' {
+		parts << 'sslcrl=${escape_conninfo_value(config.ssl_crl)}'
 	}
 	return parts.join(' ')
 }
@@ -400,7 +445,7 @@ fn (mut c Conn) physical_close() {
 	}
 }
 
-fn res_to_rows(res voidptr) []Row {
+fn res_to_rows(res voidptr) []db.pg.Row {
 	nr_rows := C.PQntuples(res)
 	nr_cols := C.PQnfields(res)
 
@@ -517,12 +562,12 @@ pub fn (c &Conn) q_string(query string) !string {
 
 // q_strings submit a command to the database server and
 // returns the resulting row set. Alias of `exec`
-pub fn (c &Conn) q_strings(query string) ![]Row {
+pub fn (c &Conn) q_strings(query string) ![]db.pg.Row {
 	return c.exec(query)
 }
 
 // exec submits a command to the database server and wait for the result, returning an error on failure and a row set on success
-pub fn (c &Conn) exec(query string) ![]Row {
+pub fn (c &Conn) exec(query string) ![]db.pg.Row {
 	c.ensure_active()!
 	res := C.PQexec(c.conn, &char(query.str))
 	return c.handle_error_or_rows(res, 'exec')
@@ -542,7 +587,7 @@ pub fn (c &Conn) exec_result(query string) !Result {
 	return c.handle_error_or_result(res, 'exec_result')
 }
 
-fn rows_first_or_empty(rows []Row) !Row {
+fn rows_first_or_empty(rows []db.pg.Row) !Row {
 	if rows.len == 0 {
 		return error('no row')
 	}
@@ -563,7 +608,7 @@ pub fn (c &Conn) exec_one(query string) !Row {
 }
 
 // exec_param_many executes a query with the parameters provided as ($1), ($2), ($n)
-pub fn (c &Conn) exec_param_many(query string, params []string) ![]Row {
+pub fn (c &Conn) exec_param_many(query string, params []string) ![]db.pg.Row {
 	c.ensure_active()!
 	unsafe {
 		mut param_vals := []&char{len: params.len}
@@ -591,12 +636,12 @@ pub fn (c &Conn) exec_param_many_result(query string, params []string) !Result {
 }
 
 // exec_param executes a query with 1 parameter ($1), and returns either an error on failure, or the full result set on success
-pub fn (c &Conn) exec_param(query string, param string) ![]Row {
+pub fn (c &Conn) exec_param(query string, param string) ![]db.pg.Row {
 	return c.exec_param_many(query, [param])
 }
 
 // exec_param2 executes a query with 2 parameters ($1) and ($2), and returns either an error on failure, or the full result set on success
-pub fn (c &Conn) exec_param2(query string, param string, param2 string) ![]Row {
+pub fn (c &Conn) exec_param2(query string, param string, param2 string) ![]db.pg.Row {
 	return c.exec_param_many(query, [param, param2])
 }
 
@@ -610,7 +655,7 @@ pub fn (c &Conn) prepare(name string, query string, num_params int) ! {
 }
 
 // exec_prepared sends a request to execute a prepared statement with given parameters, and waits for the result. The number of parameters must match with the parameters declared in the prepared statement.
-pub fn (c &Conn) exec_prepared(name string, params []string) ![]Row {
+pub fn (c &Conn) exec_prepared(name string, params []string) ![]db.pg.Row {
 	c.ensure_active()!
 	unsafe {
 		mut param_vals := []&char{len: params.len}
@@ -648,7 +693,7 @@ fn (c &Conn) mark_bad_if_disconnected() {
 	}
 }
 
-fn (c &Conn) handle_error_or_rows(res voidptr, elabel string) ![]Row {
+fn (c &Conn) handle_error_or_rows(res voidptr, elabel string) ![]db.pg.Row {
 	e := unsafe { C.PQerrorMessage(c.conn).vstring() }
 	if e != '' {
 		C.PQclear(res)
@@ -764,7 +809,7 @@ pub fn (c &Conn) copy_expert(query string, mut file io.ReaderWriter) !int {
 	return 0
 }
 
-fn pg_stmt_worker(c &Conn, query string, data orm.QueryData, where orm.QueryData) ![]Row {
+fn pg_stmt_worker(c &Conn, query string, data orm.QueryData, where orm.QueryData) ![]db.pg.Row {
 	mut param_types := []u32{}
 	mut param_vals := []&char{}
 	mut param_lens := []int{}

--- a/vlib/db/pg/pg_config_test.v
+++ b/vlib/db/pg/pg_config_test.v
@@ -1,0 +1,28 @@
+module pg
+
+fn test_ssl_mode_conninfo_values() {
+	assert SslMode.unset.conninfo_value() == ''
+	assert SslMode.disable.conninfo_value() == 'disable'
+	assert SslMode.allow.conninfo_value() == 'allow'
+	assert SslMode.prefer.conninfo_value() == 'prefer'
+	assert SslMode.require.conninfo_value() == 'require'
+	assert SslMode.verify_ca.conninfo_value() == 'verify-ca'
+	assert SslMode.verify_full.conninfo_value() == 'verify-full'
+}
+
+fn test_conninfo_includes_ssl_options() {
+	conninfo := Config{
+		host:     'db.example.com'
+		port:     15432
+		user:     'app user'
+		password: 'secret'
+		dbname:   'prod'
+		ssl_mode: .verify_full
+		ssl_ca:   '/etc/ssl/root bundle.pem'
+		ssl_cert: '/etc/ssl/client.pem'
+		ssl_key:  '/etc/ssl/client.key'
+		ssl_crl:  '/etc/ssl/root.crl'
+	}.conninfo()!
+
+	assert conninfo == "host=db.example.com port=15432 user='app user' dbname=prod password=secret sslmode=verify-full sslcert=/etc/ssl/client.pem sslkey=/etc/ssl/client.key sslrootcert='/etc/ssl/root bundle.pem' sslcrl=/etc/ssl/root.crl"
+}


### PR DESCRIPTION
## Summary
- add a top-level `db.Driver` facade with `db.open()` and normalized `DriverRow` results
- add `db.pg` SSL/TLS config fields and direct no-pool connection helpers
- document the new APIs and add focused tests

## Testing
- `./vnew -silent test vlib/db/`
- `./vnew -d db_pg test vlib/db/driver_test.v`
- `./vnew check-md vlib/db/README.md vlib/db/pg/README.md`
- `git diff --cached --check`

Fixes #27617
Fixes #27618
Fixes #27619