### PR TITLE
v3: fix arm64 self-host map helpers

### DIFF
--- a/vlib/v3/gen/arm64/gen.v
+++ b/vlib/v3/gen/arm64/gen.v
@@ -1711,15 +1711,23 @@ fn (mut g Gen) emit_load_string_regs_from_ptr(ptr_reg int, data_reg int, len_reg
 	typ := g.m.type_store.types[typ_id]
 	g.emit_load_typed(data_reg, ptr_reg, typ.fields[0])
 	g.emit32(asm_add_imm(Reg(11), Reg(ptr_reg), 8))
-	g.emit_load_typed(len_reg, 11, typ.fields[1])
+	if typ.fields.len == 3 {
+		g.emit32(asm_ldr(Reg(len_reg), Reg(11)))
+	} else {
+		g.emit_load_typed(len_reg, 11, typ.fields[1])
+	}
 }
 
 // emit_load_string_regs_from_fp converts emit load string regs from fp data for arm64.
 fn (mut g Gen) emit_load_string_regs_from_fp(off int, data_reg int, len_reg int, typ_id ssa.TypeID) {
 	typ := g.m.type_store.types[typ_id]
 	g.emit_load_fp(data_reg, off)
-	g.emit_lea_fp(11, off + 8)
-	g.emit_load_typed(len_reg, 11, typ.fields[1])
+	if typ.fields.len == 3 {
+		g.emit_load_fp(len_reg, off + 8)
+	} else {
+		g.emit_lea_fp(11, off + 8)
+		g.emit_load_typed(len_reg, 11, typ.fields[1])
+	}
 }
 
 // emit_store_typed emits emit store typed output for arm64.

--- a/vlib/v3/gen/arm64/gen.v
+++ b/vlib/v3/gen/arm64/gen.v
@@ -1690,12 +1690,20 @@ fn (g &Gen) is_string_struct_type(typ_id ssa.TypeID) bool {
 		return false
 	}
 	typ := g.m.type_store.types[typ_id]
-	if typ.kind != .struct_t || typ.fields.len != 2 || g.m.type_size(typ_id) != 16 {
+	if typ.kind != .struct_t || typ.fields.len < 2 || typ.fields.len > 3
+		|| g.m.type_size(typ_id) != 16 {
 		return false
 	}
 	first := g.m.type_store.types[typ.fields[0]]
 	second := g.m.type_store.types[typ.fields[1]]
-	return first.kind == .ptr_t && second.kind == .int_t && second.width == 32
+	if first.kind != .ptr_t || second.kind != .int_t || second.width != 32 {
+		return false
+	}
+	if typ.fields.len == 3 {
+		third := g.m.type_store.types[typ.fields[2]]
+		return third.kind == .int_t && third.width == 32
+	}
+	return true
 }
 
 // emit_load_string_regs_from_ptr converts emit load string regs from ptr data for arm64.

--- a/vlib/v3/gen/arm64/linker.v
+++ b/vlib/v3/gen/arm64/linker.v
@@ -71,109 +71,87 @@ const bind_symbol_flags_weak_import = 0x01
 // never to local V wrappers. This prevents infinite recursion where
 // V's malloc() wrapper calls C.malloc() which would otherwise resolve
 // back to the V wrapper.
-fn is_force_external_sym(sym_name string) bool {
-	return match sym_name {
-		'_malloc', '_free', '_calloc', '_realloc', '_exit', '_abort', '_memcpy', '_memmove',
-		'_memset', '_memcmp', '___stdoutp', '___stderrp', '_puts', '_printf', '_write', '_read',
-		'_open', '_close', '_fwrite', '_fflush', '_fopen', '_fclose', '_putchar', '_sprintf',
-		'_snprintf', '_fprintf', '_sscanf', '_mmap', '_munmap', '_getcwd', '_access',
-		'_readlink', '_getenv', '_strlen',
+const force_external_syms = ['_malloc', '_free', '_calloc', '_realloc', '_exit', '_abort', '_memcpy',
+	'_memmove', '_memset', '_memcmp', '___stdoutp', '___stderrp', '_puts', '_printf', '_write',
+	'_read', '_open', '_close', '_fwrite', '_fflush', '_fopen', '_fclose', '_putchar', '_sprintf',
+	'_snprintf', '_fprintf', '_sscanf', '_mmap', '_munmap', '_getcwd', '_access', '_readlink',
+	'_getenv', '_strlen',
 	// Filesystem/directory operations
-		'_opendir', '_readdir', '_closedir', '_mkdir', '_rmdir', '_unlink', '_rename', '_remove',
-		'_stat', '_lstat', '_fstat', '_chmod', '_chdir', '_realpath', '_symlink', '_link',
+	'_opendir', '_readdir', '_closedir', '_mkdir', '_rmdir',
+	'_unlink', '_rename', '_remove', '_stat', '_lstat', '_fstat', '_chmod', '_chdir', '_realpath',
+	'_symlink', '_link',
 	// Process/system
-		'_getpid', '_getuid', '_geteuid', '_fork', '_execve', '_execvp', '_waitpid', '_kill',
-		'_system', '_posix_spawn', '_signal', '_atexit',
+	'_getpid', '_getuid', '_geteuid', '_fork', '_execve', '_execvp', '_waitpid',
+	'_kill', '_system', '_posix_spawn', '_signal', '_atexit',
 	// I/O
-		'_fgets', '_fputs', '_fread', '_fseek', '_ftell', '_rewind', '_fileno', '_popen',
-		'_pclose', '_dup', '_dup2', '_pipe', '_isatty', '_freopen', '_dprintf', '_getc',
+	'_fgets', '_fputs', '_fread', '_fseek', '_ftell', '_rewind', '_fileno', '_popen',
+	'_pclose', '_dup', '_dup2', '_pipe', '_isatty', '_freopen', '_dprintf', '_getc',
 	// String/memory
-		'_strdup', '_strcmp', '_strncmp', '_strchr', '_strrchr', '_strerror', '_strncasecmp',
-		'_strcasecmp', '_atoi', '_atof', '_qsort',
+	'_strdup', '_strcmp', '_strncmp', '_strchr', '_strrchr', '_strerror',
+	'_strncasecmp', '_strcasecmp', '_atoi', '_atof', '_qsort',
 	// Time
-		'_time', '_localtime_r', '_gmtime_r', '_mktime', '_gettimeofday', '_clock',
-		'_clock_gettime_nsec_np', '_mach_absolute_time', '_mach_timebase_info', '_nanosleep',
-		'_sleep', '_usleep', '_strftime', '_task_info', '_mach_task_self_',
+	'_time', '_localtime_r', '_gmtime_r', '_mktime', '_gettimeofday', '_clock',
+	'_clock_gettime_nsec_np', '_mach_absolute_time', '_mach_timebase_info', '_nanosleep', '_sleep',
+	'_usleep', '_strftime',
+	'_task_info', '_mach_task_self_',
 	// Other
-		'_rand', '_srand', '_isdigit', '_isspace', '_tolower', '_toupper', '_setenv', '_unsetenv',
-		'_sysconf', '_uname', '_gethostname', '_pthread_mutex_init', '_pthread_mutex_lock',
-		'_pthread_mutex_unlock', '_pthread_mutex_destroy', '_pthread_self', '_pthread_create',
-		'_pthread_join', '_pthread_attr_init', '_pthread_attr_setstacksize',
-		'_pthread_attr_destroy', '_arc4random_buf', '_proc_pidpath', '_backtrace',
-		'_backtrace_symbols', '_backtrace_symbols_fd',
+	'_rand', '_srand', '_isdigit', '_isspace', '_tolower', '_toupper', '_setenv',
+	'_unsetenv', '_sysconf', '_uname', '_gethostname', '_pthread_mutex_init', '_pthread_mutex_lock',
+	'_pthread_mutex_unlock', '_pthread_mutex_destroy', '_pthread_self', '_pthread_create',
+	'_pthread_join', '_pthread_attr_init', '_pthread_attr_setstacksize', '_pthread_attr_destroy',
+	'_arc4random_buf',
+	'_proc_pidpath', '_backtrace', '_backtrace_symbols', '_backtrace_symbols_fd',
 	// macOS specific
-		'_dispatch_semaphore_create', '_dispatch_semaphore_signal', '_dispatch_semaphore_wait',
-		'_dispatch_time', '_dispatch_release', '_setvbuf', '_setbuf', '_memchr', '_getlogin_r',
-		'_getppid', '_getgid', '_getegid', '_ftruncate', '_mkstemp', '_statvfs', '_chown',
-		'_sigaction', '_sigemptyset', '_sigaddset', '_sigprocmask', '_select', '_kqueue', '_abs',
+	'_dispatch_semaphore_create', '_dispatch_semaphore_signal',
+	'_dispatch_semaphore_wait', '_dispatch_time', '_dispatch_release', '_setvbuf', '_setbuf',
+	'_memchr', '_getlogin_r', '_getppid', '_getgid', '_getegid', '_ftruncate', '_mkstemp', '_statvfs',
+	'_chown', '_sigaction', '_sigemptyset', '_sigaddset', '_sigprocmask', '_select', '_kqueue',
+	'_abs',
 	// Terminal I/O
-		'_tcgetattr', '_tcsetattr', '_ioctl', '_getchar', '_getline',
+	'_tcgetattr', '_tcsetattr', '_ioctl', '_getchar', '_getline',
 	// File I/O
-		'_fdopen', '_feof', '_ferror',
+	'_fdopen', '_feof', '_ferror',
 	// Process
-		'_setpgid', '_ptrace', '_wait',
+	'_setpgid', '_ptrace', '_wait',
 	// Time
-		'_timegm', '_clock_gettime',
+	'_timegm', '_clock_gettime',
 	// Memory
-		'_aligned_alloc',
+	'_aligned_alloc',
 	// System
-		'_utime', '_getlogin', '_environ',
+	'_utime', '_getlogin', '_environ',
 	// macOS errno: __error() returns int*
-		'___error',
+	'___error',
 	// macOS stdin
-		'___stdinp',
+	'___stdinp',
 	// macOS dyld
-		'__dyld_get_image_name', '__dyld_get_image_header',
+	'__dyld_get_image_name', '__dyld_get_image_header',
 	// Math
-		'_cos', '_sin', '_tan', '_acos', '_asin', '_atan', '_atan2', '_cosh', '_sinh', '_tanh',
-		'_acosh', '_asinh', '_atanh', '_exp', '_exp2', '_log', '_log2', '_log10', '_pow',
-		'_sqrt', '_cbrt', '_ceil', '_floor', '_round', '_trunc', '_fmod', '_remainder',
-		'_fabs', '_copysign', '_fmax', '_fmin', '_hypot', '_ldexp', '_frexp', '_modf',
-		'_scalbn', '_ilogb', '_logb', '_erf', '_erfc', '_lgamma', '_tgamma', '_j0', '_j1',
-		'_jn', '_y0', '_y1', '_yn',
+	'_cos', '_sin', '_tan', '_acos', '_asin', '_atan', '_atan2',
+	'_cosh', '_sinh', '_tanh', '_acosh', '_asinh', '_atanh',
+	'_exp', '_exp2', '_log', '_log2', '_log10', '_pow', '_sqrt', '_cbrt',
+	'_ceil', '_floor', '_round', '_trunc', '_fmod', '_remainder',
+	'_fabs', '_copysign', '_fmax', '_fmin', '_hypot',
+	'_ldexp', '_frexp', '_modf', '_scalbn', '_ilogb', '_logb',
+	'_erf', '_erfc', '_lgamma', '_tgamma',
+	'_j0', '_j1', '_jn', '_y0', '_y1', '_yn',
 	// Memory protection and cache (hot code reloading)
-		'_mprotect', '_sys_icache_invalidate',
+	'_mprotect', '_sys_icache_invalidate',
 	// Objective-C runtime (from libobjc.A.dylib)
-		'_objc_msgSend', '_objc_getClass', '_sel_registerName', '_objc_alloc_init',
-		'_objc_autoreleasePoolPush', '_objc_autoreleasePoolPop',
+	'_objc_msgSend', '_objc_getClass', '_sel_registerName', '_objc_alloc_init',
+	'_objc_autoreleasePoolPush', '_objc_autoreleasePoolPop',
 	// Metal framework
-		'_MTLCreateSystemDefaultDevice',
+	'_MTLCreateSystemDefaultDevice',
 	// Dynamic loading
-		'_dlopen', '_dlsym' {
-			true
-		}
-		else {
-			false
-		}
-	}
-}
+	'_dlopen', '_dlsym']
 
 // vfmt on
 
-// is_objc_sym reports whether a symbol lives in libobjc.A.dylib (not libSystem).
-fn is_objc_sym(sym_name string) bool {
-	return match sym_name {
-		'_objc_msgSend', '_objc_getClass', '_sel_registerName', '_objc_alloc_init',
-		'_objc_autoreleasePoolPush', '_objc_autoreleasePoolPop' {
-			true
-		}
-		else {
-			false
-		}
-	}
-}
+// Symbols that live in libobjc.A.dylib (not libSystem).
+const objc_syms = ['_objc_msgSend', '_objc_getClass', '_sel_registerName', '_objc_alloc_init',
+	'_objc_autoreleasePoolPush', '_objc_autoreleasePoolPop']
 
-// is_metal_sym reports whether a symbol lives in Metal.framework.
-fn is_metal_sym(sym_name string) bool {
-	return match sym_name {
-		'_MTLCreateSystemDefaultDevice' {
-			true
-		}
-		else {
-			false
-		}
-	}
-}
+// Symbols that live in Metal.framework.
+const metal_syms = ['_MTLCreateSystemDefaultDevice']
 
 // Linker represents linker data used by arm64.
 pub struct Linker {
@@ -234,7 +212,9 @@ pub fn Linker.new(macho &MachOObject) &Linker {
 
 // link supports link handling for Linker.
 pub fn (mut l Linker) link(output_path string, entry_name string) {
-	l.buf = []u8{}
+	// Pre-allocate buffer with estimated size to avoid reallocations
+	estimated_size := l.macho.text_data.len + l.macho.str_data.len + l.macho.data_data.len + 0x10000
+	l.buf = []u8{cap: estimated_size}
 	mut t := time.now()
 	mut t_total := time.now()
 
@@ -244,7 +224,7 @@ pub fn (mut l Linker) link(output_path string, entry_name string) {
 		// N_SECT (0x0E) means symbol is defined in a section
 		if (sym.type_ & 0x0E) == 0x0E {
 			// Don't track external symbols as defined - they should come from libc
-			if !is_force_external_sym(sym.name) {
+			if sym.name !in force_external_syms {
 				defined_syms[sym.name] = true
 			}
 		}
@@ -255,7 +235,7 @@ pub fn (mut l Linker) link(output_path string, entry_name string) {
 	// All other undefined symbols are internal V functions or V-embedded C functions
 	// (like wyhash) that resolve to local stubs.
 	for sym in l.macho.symbols {
-		if is_force_external_sym(sym.name) && sym.name !in l.extern_syms {
+		if sym.name in force_external_syms && sym.name !in l.extern_syms {
 			l.extern_syms << sym.name
 			l.sym_to_got[sym.name] = l.extern_syms.len - 1
 		}
@@ -273,7 +253,7 @@ pub fn (mut l Linker) link(output_path string, entry_name string) {
 	// Check if any objc symbols are used → add libobjc
 	mut need_objc := false
 	for sym_name in l.extern_syms {
-		if is_objc_sym(sym_name) {
+		if sym_name in objc_syms {
 			need_objc = true
 			break
 		}
@@ -282,14 +262,14 @@ pub fn (mut l Linker) link(output_path string, entry_name string) {
 		objc_idx := l.dylibs.len
 		l.dylibs << '/usr/lib/libobjc.A.dylib'
 		for sym_name in l.extern_syms {
-			if is_objc_sym(sym_name) {
+			if sym_name in objc_syms {
 				l.sym_to_dylib[sym_name] = objc_idx
 			}
 		}
 	}
 	// Check if any framework symbols are used → add framework dylibs
 	for sym_name in l.extern_syms {
-		if is_metal_sym(sym_name) {
+		if sym_name in metal_syms {
 			if 'Metal' !in l.frameworks {
 				l.frameworks << 'Metal'
 			}
@@ -301,7 +281,7 @@ pub fn (mut l Linker) link(output_path string, entry_name string) {
 		// Map framework symbols to this dylib index
 		if fw == 'Metal' {
 			for sym_name in l.extern_syms {
-				if is_metal_sym(sym_name) {
+				if sym_name in metal_syms {
 					l.sym_to_dylib[sym_name] = fw_idx
 				}
 			}
@@ -418,7 +398,7 @@ pub fn (mut l Linker) link(output_path string, entry_name string) {
 		if (sym.type_ & 0x0E) != 0x0E {
 			continue // Skip undefined symbols
 		}
-		if is_force_external_sym(sym.name) {
+		if sym.name in force_external_syms {
 			continue
 		}
 
@@ -1033,7 +1013,7 @@ fn (mut l Linker) generate_bind_info(got_offset int) []u8 {
 		// bootstrap builds. Bind them as weak imports so dyld does not abort load
 		// when they are absent from libSystem; unresolved weak symbols become NULL.
 		mut bind_flags := u8(0)
-		if sym_name.contains('__') && !is_force_external_sym(sym_name) {
+		if sym_name.contains('__') && sym_name !in force_external_syms {
 			bind_flags = bind_symbol_flags_weak_import
 		}
 
@@ -1143,7 +1123,7 @@ fn (mut l Linker) write_text_with_relocations() {
 		// N_SECT (0x0E) means symbol is defined in a section
 		if (sym.type_ & 0x0E) == 0x0E {
 			// Skip external symbols - they should always resolve to libc
-			is_external := is_force_external_sym(sym.name)
+			is_external := sym.name in force_external_syms
 			if sym.sect == 1 {
 				// Text section symbol (code)
 				addr := code_vmaddr + sym.value
@@ -1195,7 +1175,7 @@ fn (mut l Linker) write_text_with_relocations() {
 			eprintln('LINKER: unresolved symbol "${sym_name}" (idx=${r.sym_idx}) at text offset ${r.addr}')
 			exit(1)
 		}
-		if is_force_external_sym(sym_name) {
+		if sym_name in force_external_syms {
 			// Use stub address for external symbols
 			if sym_name in l.sym_to_got {
 				got_idx := l.sym_to_got[sym_name]

--- a/vlib/v3/gen/arm64/linker.v
+++ b/vlib/v3/gen/arm64/linker.v
@@ -71,87 +71,109 @@ const bind_symbol_flags_weak_import = 0x01
 // never to local V wrappers. This prevents infinite recursion where
 // V's malloc() wrapper calls C.malloc() which would otherwise resolve
 // back to the V wrapper.
-const force_external_syms = ['_malloc', '_free', '_calloc', '_realloc', '_exit', '_abort', '_memcpy',
-	'_memmove', '_memset', '_memcmp', '___stdoutp', '___stderrp', '_puts', '_printf', '_write',
-	'_read', '_open', '_close', '_fwrite', '_fflush', '_fopen', '_fclose', '_putchar', '_sprintf',
-	'_snprintf', '_fprintf', '_sscanf', '_mmap', '_munmap', '_getcwd', '_access', '_readlink',
-	'_getenv', '_strlen',
+fn is_force_external_sym(sym_name string) bool {
+	return match sym_name {
+		'_malloc', '_free', '_calloc', '_realloc', '_exit', '_abort', '_memcpy', '_memmove',
+		'_memset', '_memcmp', '___stdoutp', '___stderrp', '_puts', '_printf', '_write', '_read',
+		'_open', '_close', '_fwrite', '_fflush', '_fopen', '_fclose', '_putchar', '_sprintf',
+		'_snprintf', '_fprintf', '_sscanf', '_mmap', '_munmap', '_getcwd', '_access',
+		'_readlink', '_getenv', '_strlen',
 	// Filesystem/directory operations
-	'_opendir', '_readdir', '_closedir', '_mkdir', '_rmdir',
-	'_unlink', '_rename', '_remove', '_stat', '_lstat', '_fstat', '_chmod', '_chdir', '_realpath',
-	'_symlink', '_link',
+		'_opendir', '_readdir', '_closedir', '_mkdir', '_rmdir', '_unlink', '_rename', '_remove',
+		'_stat', '_lstat', '_fstat', '_chmod', '_chdir', '_realpath', '_symlink', '_link',
 	// Process/system
-	'_getpid', '_getuid', '_geteuid', '_fork', '_execve', '_execvp', '_waitpid',
-	'_kill', '_system', '_posix_spawn', '_signal', '_atexit',
+		'_getpid', '_getuid', '_geteuid', '_fork', '_execve', '_execvp', '_waitpid', '_kill',
+		'_system', '_posix_spawn', '_signal', '_atexit',
 	// I/O
-	'_fgets', '_fputs', '_fread', '_fseek', '_ftell', '_rewind', '_fileno', '_popen',
-	'_pclose', '_dup', '_dup2', '_pipe', '_isatty', '_freopen', '_dprintf', '_getc',
+		'_fgets', '_fputs', '_fread', '_fseek', '_ftell', '_rewind', '_fileno', '_popen',
+		'_pclose', '_dup', '_dup2', '_pipe', '_isatty', '_freopen', '_dprintf', '_getc',
 	// String/memory
-	'_strdup', '_strcmp', '_strncmp', '_strchr', '_strrchr', '_strerror',
-	'_strncasecmp', '_strcasecmp', '_atoi', '_atof', '_qsort',
+		'_strdup', '_strcmp', '_strncmp', '_strchr', '_strrchr', '_strerror', '_strncasecmp',
+		'_strcasecmp', '_atoi', '_atof', '_qsort',
 	// Time
-	'_time', '_localtime_r', '_gmtime_r', '_mktime', '_gettimeofday', '_clock',
-	'_clock_gettime_nsec_np', '_mach_absolute_time', '_mach_timebase_info', '_nanosleep', '_sleep',
-	'_usleep', '_strftime',
-	'_task_info', '_mach_task_self_',
+		'_time', '_localtime_r', '_gmtime_r', '_mktime', '_gettimeofday', '_clock',
+		'_clock_gettime_nsec_np', '_mach_absolute_time', '_mach_timebase_info', '_nanosleep',
+		'_sleep', '_usleep', '_strftime', '_task_info', '_mach_task_self_',
 	// Other
-	'_rand', '_srand', '_isdigit', '_isspace', '_tolower', '_toupper', '_setenv',
-	'_unsetenv', '_sysconf', '_uname', '_gethostname', '_pthread_mutex_init', '_pthread_mutex_lock',
-	'_pthread_mutex_unlock', '_pthread_mutex_destroy', '_pthread_self', '_pthread_create',
-	'_pthread_join', '_pthread_attr_init', '_pthread_attr_setstacksize', '_pthread_attr_destroy',
-	'_arc4random_buf',
-	'_proc_pidpath', '_backtrace', '_backtrace_symbols', '_backtrace_symbols_fd',
+		'_rand', '_srand', '_isdigit', '_isspace', '_tolower', '_toupper', '_setenv', '_unsetenv',
+		'_sysconf', '_uname', '_gethostname', '_pthread_mutex_init', '_pthread_mutex_lock',
+		'_pthread_mutex_unlock', '_pthread_mutex_destroy', '_pthread_self', '_pthread_create',
+		'_pthread_join', '_pthread_attr_init', '_pthread_attr_setstacksize',
+		'_pthread_attr_destroy', '_arc4random_buf', '_proc_pidpath', '_backtrace',
+		'_backtrace_symbols', '_backtrace_symbols_fd',
 	// macOS specific
-	'_dispatch_semaphore_create', '_dispatch_semaphore_signal',
-	'_dispatch_semaphore_wait', '_dispatch_time', '_dispatch_release', '_setvbuf', '_setbuf',
-	'_memchr', '_getlogin_r', '_getppid', '_getgid', '_getegid', '_ftruncate', '_mkstemp', '_statvfs',
-	'_chown', '_sigaction', '_sigemptyset', '_sigaddset', '_sigprocmask', '_select', '_kqueue',
-	'_abs',
+		'_dispatch_semaphore_create', '_dispatch_semaphore_signal', '_dispatch_semaphore_wait',
+		'_dispatch_time', '_dispatch_release', '_setvbuf', '_setbuf', '_memchr', '_getlogin_r',
+		'_getppid', '_getgid', '_getegid', '_ftruncate', '_mkstemp', '_statvfs', '_chown',
+		'_sigaction', '_sigemptyset', '_sigaddset', '_sigprocmask', '_select', '_kqueue', '_abs',
 	// Terminal I/O
-	'_tcgetattr', '_tcsetattr', '_ioctl', '_getchar', '_getline',
+		'_tcgetattr', '_tcsetattr', '_ioctl', '_getchar', '_getline',
 	// File I/O
-	'_fdopen', '_feof', '_ferror',
+		'_fdopen', '_feof', '_ferror',
 	// Process
-	'_setpgid', '_ptrace', '_wait',
+		'_setpgid', '_ptrace', '_wait',
 	// Time
-	'_timegm', '_clock_gettime',
+		'_timegm', '_clock_gettime',
 	// Memory
-	'_aligned_alloc',
+		'_aligned_alloc',
 	// System
-	'_utime', '_getlogin', '_environ',
+		'_utime', '_getlogin', '_environ',
 	// macOS errno: __error() returns int*
-	'___error',
+		'___error',
 	// macOS stdin
-	'___stdinp',
+		'___stdinp',
 	// macOS dyld
-	'__dyld_get_image_name', '__dyld_get_image_header',
+		'__dyld_get_image_name', '__dyld_get_image_header',
 	// Math
-	'_cos', '_sin', '_tan', '_acos', '_asin', '_atan', '_atan2',
-	'_cosh', '_sinh', '_tanh', '_acosh', '_asinh', '_atanh',
-	'_exp', '_exp2', '_log', '_log2', '_log10', '_pow', '_sqrt', '_cbrt',
-	'_ceil', '_floor', '_round', '_trunc', '_fmod', '_remainder',
-	'_fabs', '_copysign', '_fmax', '_fmin', '_hypot',
-	'_ldexp', '_frexp', '_modf', '_scalbn', '_ilogb', '_logb',
-	'_erf', '_erfc', '_lgamma', '_tgamma',
-	'_j0', '_j1', '_jn', '_y0', '_y1', '_yn',
+		'_cos', '_sin', '_tan', '_acos', '_asin', '_atan', '_atan2', '_cosh', '_sinh', '_tanh',
+		'_acosh', '_asinh', '_atanh', '_exp', '_exp2', '_log', '_log2', '_log10', '_pow',
+		'_sqrt', '_cbrt', '_ceil', '_floor', '_round', '_trunc', '_fmod', '_remainder',
+		'_fabs', '_copysign', '_fmax', '_fmin', '_hypot', '_ldexp', '_frexp', '_modf',
+		'_scalbn', '_ilogb', '_logb', '_erf', '_erfc', '_lgamma', '_tgamma', '_j0', '_j1',
+		'_jn', '_y0', '_y1', '_yn',
 	// Memory protection and cache (hot code reloading)
-	'_mprotect', '_sys_icache_invalidate',
+		'_mprotect', '_sys_icache_invalidate',
 	// Objective-C runtime (from libobjc.A.dylib)
-	'_objc_msgSend', '_objc_getClass', '_sel_registerName', '_objc_alloc_init',
-	'_objc_autoreleasePoolPush', '_objc_autoreleasePoolPop',
+		'_objc_msgSend', '_objc_getClass', '_sel_registerName', '_objc_alloc_init',
+		'_objc_autoreleasePoolPush', '_objc_autoreleasePoolPop',
 	// Metal framework
-	'_MTLCreateSystemDefaultDevice',
+		'_MTLCreateSystemDefaultDevice',
 	// Dynamic loading
-	'_dlopen', '_dlsym']
+		'_dlopen', '_dlsym' {
+			true
+		}
+		else {
+			false
+		}
+	}
+}
 
 // vfmt on
 
-// Symbols that live in libobjc.A.dylib (not libSystem).
-const objc_syms = ['_objc_msgSend', '_objc_getClass', '_sel_registerName', '_objc_alloc_init',
-	'_objc_autoreleasePoolPush', '_objc_autoreleasePoolPop']
+// is_objc_sym reports whether a symbol lives in libobjc.A.dylib (not libSystem).
+fn is_objc_sym(sym_name string) bool {
+	return match sym_name {
+		'_objc_msgSend', '_objc_getClass', '_sel_registerName', '_objc_alloc_init',
+		'_objc_autoreleasePoolPush', '_objc_autoreleasePoolPop' {
+			true
+		}
+		else {
+			false
+		}
+	}
+}
 
-// Symbols that live in Metal.framework.
-const metal_syms = ['_MTLCreateSystemDefaultDevice']
+// is_metal_sym reports whether a symbol lives in Metal.framework.
+fn is_metal_sym(sym_name string) bool {
+	return match sym_name {
+		'_MTLCreateSystemDefaultDevice' {
+			true
+		}
+		else {
+			false
+		}
+	}
+}
 
 // Linker represents linker data used by arm64.
 pub struct Linker {
@@ -212,9 +234,7 @@ pub fn Linker.new(macho &MachOObject) &Linker {
 
 // link supports link handling for Linker.
 pub fn (mut l Linker) link(output_path string, entry_name string) {
-	// Pre-allocate buffer with estimated size to avoid reallocations
-	estimated_size := l.macho.text_data.len + l.macho.str_data.len + l.macho.data_data.len + 0x10000
-	l.buf = []u8{cap: estimated_size}
+	l.buf = []u8{}
 	mut t := time.now()
 	mut t_total := time.now()
 
@@ -224,7 +244,7 @@ pub fn (mut l Linker) link(output_path string, entry_name string) {
 		// N_SECT (0x0E) means symbol is defined in a section
 		if (sym.type_ & 0x0E) == 0x0E {
 			// Don't track external symbols as defined - they should come from libc
-			if sym.name !in force_external_syms {
+			if !is_force_external_sym(sym.name) {
 				defined_syms[sym.name] = true
 			}
 		}
@@ -235,7 +255,7 @@ pub fn (mut l Linker) link(output_path string, entry_name string) {
 	// All other undefined symbols are internal V functions or V-embedded C functions
 	// (like wyhash) that resolve to local stubs.
 	for sym in l.macho.symbols {
-		if sym.name in force_external_syms && sym.name !in l.extern_syms {
+		if is_force_external_sym(sym.name) && sym.name !in l.extern_syms {
 			l.extern_syms << sym.name
 			l.sym_to_got[sym.name] = l.extern_syms.len - 1
 		}
@@ -253,7 +273,7 @@ pub fn (mut l Linker) link(output_path string, entry_name string) {
 	// Check if any objc symbols are used → add libobjc
 	mut need_objc := false
 	for sym_name in l.extern_syms {
-		if sym_name in objc_syms {
+		if is_objc_sym(sym_name) {
 			need_objc = true
 			break
 		}
@@ -262,14 +282,14 @@ pub fn (mut l Linker) link(output_path string, entry_name string) {
 		objc_idx := l.dylibs.len
 		l.dylibs << '/usr/lib/libobjc.A.dylib'
 		for sym_name in l.extern_syms {
-			if sym_name in objc_syms {
+			if is_objc_sym(sym_name) {
 				l.sym_to_dylib[sym_name] = objc_idx
 			}
 		}
 	}
 	// Check if any framework symbols are used → add framework dylibs
 	for sym_name in l.extern_syms {
-		if sym_name in metal_syms {
+		if is_metal_sym(sym_name) {
 			if 'Metal' !in l.frameworks {
 				l.frameworks << 'Metal'
 			}
@@ -281,7 +301,7 @@ pub fn (mut l Linker) link(output_path string, entry_name string) {
 		// Map framework symbols to this dylib index
 		if fw == 'Metal' {
 			for sym_name in l.extern_syms {
-				if sym_name in metal_syms {
+				if is_metal_sym(sym_name) {
 					l.sym_to_dylib[sym_name] = fw_idx
 				}
 			}
@@ -398,7 +418,7 @@ pub fn (mut l Linker) link(output_path string, entry_name string) {
 		if (sym.type_ & 0x0E) != 0x0E {
 			continue // Skip undefined symbols
 		}
-		if sym.name in force_external_syms {
+		if is_force_external_sym(sym.name) {
 			continue
 		}
 
@@ -1013,7 +1033,7 @@ fn (mut l Linker) generate_bind_info(got_offset int) []u8 {
 		// bootstrap builds. Bind them as weak imports so dyld does not abort load
 		// when they are absent from libSystem; unresolved weak symbols become NULL.
 		mut bind_flags := u8(0)
-		if sym_name.contains('__') && sym_name !in force_external_syms {
+		if sym_name.contains('__') && !is_force_external_sym(sym_name) {
 			bind_flags = bind_symbol_flags_weak_import
 		}
 
@@ -1123,7 +1143,7 @@ fn (mut l Linker) write_text_with_relocations() {
 		// N_SECT (0x0E) means symbol is defined in a section
 		if (sym.type_ & 0x0E) == 0x0E {
 			// Skip external symbols - they should always resolve to libc
-			is_external := sym.name in force_external_syms
+			is_external := is_force_external_sym(sym.name)
 			if sym.sect == 1 {
 				// Text section symbol (code)
 				addr := code_vmaddr + sym.value
@@ -1175,7 +1195,7 @@ fn (mut l Linker) write_text_with_relocations() {
 			eprintln('LINKER: unresolved symbol "${sym_name}" (idx=${r.sym_idx}) at text offset ${r.addr}')
 			exit(1)
 		}
-		if sym_name in force_external_syms {
+		if is_force_external_sym(sym_name) {
 			// Use stub address for external symbols
 			if sym_name in l.sym_to_got {
 				got_idx := l.sym_to_got[sym_name]

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -19,7 +19,11 @@ fn C.close(int) int
 // C.malloc declares the C malloc symbol used by parser.
 fn C.malloc(int) &u8
 
+// C.realloc declares the C realloc symbol used by parser.
+fn C.realloc(voidptr, int) &u8
+
 const max_source_file_size = 8388608
+const read_source_chunk_size = 65536
 
 // Parser represents parser data used by parser.
 pub struct Parser {
@@ -164,16 +168,28 @@ fn read_source_file_raw(path string) string {
 	if fd < 0 {
 		return ''
 	}
-	size := os.file_size(path)
-	if size == 0 {
+	mut cap := read_source_chunk_size
+	mut buf := C.malloc(cap + 1)
+	if isnil(buf) {
 		C.close(fd)
 		return ''
 	}
-	expected := if size > max_source_file_size { max_source_file_size } else { int(size) }
-	buf := C.malloc(expected + 1)
 	mut total := 0
-	for total < expected {
-		nread := C.read(fd, unsafe { buf + total }, expected - total)
+	for total < max_source_file_size {
+		if total == cap {
+			mut new_cap := cap * 2
+			if new_cap > max_source_file_size {
+				new_cap = max_source_file_size
+			}
+			mut new_buf := C.realloc(buf, new_cap + 1)
+			if isnil(new_buf) {
+				break
+			}
+			buf = new_buf
+			cap = new_cap
+		}
+		remaining := cap - total
+		nread := C.read(fd, unsafe { buf + total }, remaining)
 		if nread <= 0 {
 			break
 		}
@@ -184,6 +200,7 @@ fn read_source_file_raw(path string) string {
 		return ''
 	}
 	unsafe {
+		buf[total] = 0
 		return tos(buf, total)
 	}
 }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -186,7 +186,9 @@ fn read_source_file_raw(path string) string {
 			}
 			mut new_buf := C.realloc(buf, new_cap + 1)
 			if isnil(new_buf) {
-				break
+				C.close(fd)
+				unsafe { C.free(buf) }
+				return ''
 			}
 			buf = new_buf
 			cap = new_cap

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -22,6 +22,9 @@ fn C.malloc(int) &u8
 // C.realloc declares the C realloc symbol used by parser.
 fn C.realloc(voidptr, int) &u8
 
+// C.free declares the C free symbol used by parser.
+fn C.free(voidptr)
+
 const max_source_file_size = 8388608
 const read_source_chunk_size = 65536
 
@@ -197,9 +200,16 @@ fn read_source_file_raw(path string) string {
 	}
 	C.close(fd)
 	if total <= 0 {
+		unsafe { C.free(buf) }
 		return ''
 	}
 	unsafe {
+		if cap > total {
+			new_buf := C.realloc(buf, total + 1)
+			if !isnil(new_buf) {
+				buf = new_buf
+			}
+		}
 		buf[total] = 0
 		return tos(buf, total)
 	}

--- a/vlib/v3/ssa/builder.v
+++ b/vlib/v3/ssa/builder.v
@@ -9176,10 +9176,16 @@ fn (b &Builder) const_string_array_expr_id(id flat.NodeId) ?flat.NodeId {
 	if node.kind == .array_literal {
 		return id
 	}
+	if node.kind == .cast_expr && node.children_count > 0 {
+		return b.const_string_array_expr_id(b.a.child(&node, 0))
+	}
 	if node.kind == .ident {
 		return b.lookup_const_expr(node.value)
 	}
 	if node.kind == .selector {
+		if node.value == 'data' && node.children_count > 0 {
+			return b.const_string_array_expr_id(b.a.child(&node, 0))
+		}
 		name := b.selector_qualified_name(node)
 		if name.len > 0 {
 			return b.lookup_const_expr(name)

--- a/vlib/v3/ssa/builder.v
+++ b/vlib/v3/ssa/builder.v
@@ -1384,19 +1384,20 @@ fn (b &Builder) skip_source_fn(name string) bool {
 		'strings.Builder.free', 'strings.Builder.last_n', 'Builder.write_string', 'Builder.writeln',
 		'Builder.str', 'Builder.write_ptr', 'Builder.write_u8', 'Builder.write_runes', 'Builder.free',
 		'Builder.last_n', 'new_map', 'map__set', 'map__get', 'map__exists', 'map__get_check',
-		'map__get_or_set', 'map__delete', 'map__clear', 'map__clone', 'v3_map_find',
-		'v3_map_set_sized', 'u8.is_digit', 'u8.is_letter', 'u8.is_alnum', 'u8.is_capital', 'bytestr',
-		'[]u8.bytestr', 'Array_u8__bytestr', 'Array_u8__hex', 'Array_rune__string',
-		'array.repeat_to_depth', 'string.all_before_last', 'string__all_before_last',
-		'all_before_last', 'string.all_after_last', 'string__all_after_last', 'all_after_last',
-		'_ht_alloc', '_ht_free', 'f32_to_str_l', 'f32_to_str_l_with_dot', 'f64_to_str_l',
-		'f64_to_str_l_with_dot', 'print', 'println', 'eprint', 'eprintln', 'arguments', 'tos2',
-		'tos3', 'tos_clone', 'v_prealloc_atomic_add_i32', 'v_prealloc_atomic_load_i32',
-		'v_prealloc_atomic_store_i32', 'v_prealloc_atomic_cas_i32', 'FD_ZERO', 'FD_SET', 'FD_ISSET',
-		'v_signal_with_handler_cast', 'normalize_path_in_builder', 'check_fwrite', 'check_fread',
-		'os.check_fwrite', 'os.check_fread', 'fxx_to_str_l_parse', 'fxx_to_str_l_parse_with_dot',
-		'u8.vstring', 'u8.vstring_with_len', 'char.vstring', 'char.vstring_with_len',
-		'byteptr.vstring', 'byteptr.vstring_with_len', 'charptr.vstring', 'charptr.vstring_with_len',
+		'map__get_or_set', 'map__delete', 'map__clear', 'map__clone', 'map__move', 'map__free',
+		'map__reserve', 'map__keys', 'map__values', 'v3_map_find', 'v3_map_set_sized', 'u8.is_digit',
+		'u8.is_letter', 'u8.is_alnum', 'u8.is_capital', 'bytestr', '[]u8.bytestr',
+		'Array_u8__bytestr', 'Array_u8__hex', 'Array_rune__string', 'array.repeat_to_depth',
+		'string.all_before_last', 'string__all_before_last', 'all_before_last',
+		'string.all_after_last', 'string__all_after_last', 'all_after_last', '_ht_alloc', '_ht_free',
+		'f32_to_str_l', 'f32_to_str_l_with_dot', 'f64_to_str_l', 'f64_to_str_l_with_dot', 'print',
+		'println', 'eprint', 'eprintln', 'arguments', 'tos2', 'tos3', 'tos_clone',
+		'v_prealloc_atomic_add_i32', 'v_prealloc_atomic_load_i32', 'v_prealloc_atomic_store_i32',
+		'v_prealloc_atomic_cas_i32', 'FD_ZERO', 'FD_SET', 'FD_ISSET', 'v_signal_with_handler_cast',
+		'normalize_path_in_builder', 'check_fwrite', 'check_fread', 'os.check_fwrite',
+		'os.check_fread', 'fxx_to_str_l_parse', 'fxx_to_str_l_parse_with_dot', 'u8.vstring',
+		'u8.vstring_with_len', 'char.vstring', 'char.vstring_with_len', 'byteptr.vstring',
+		'byteptr.vstring_with_len', 'charptr.vstring', 'charptr.vstring_with_len',
 		'u8.vstring_literal', 'u8.vstring_literal_with_len', 'char.vstring_literal',
 		'char.vstring_literal_with_len', 'byteptr.vstring_literal',
 		'byteptr.vstring_literal_with_len', 'charptr.vstring_literal',
@@ -2561,7 +2562,19 @@ fn (mut b Builder) register_map_runtime_stubs() {
 	mut p1_ptr := []TypeID{}
 	p1_ptr << ptr_map
 	clear_id := b.register_synthetic_function('map__clear', b.void_type, p1_ptr)
-	b.generate_map_ptr_noop_body(clear_id)
+	b.generate_map_clear_body(clear_id)
+	free_id := b.register_synthetic_function('map__free', b.void_type, p1_ptr)
+	b.generate_map_free_body(free_id)
+	keys_id := b.register_synthetic_function('map__keys', b.array_type, p1_ptr)
+	b.generate_map_keys_values_body(keys_id, 0, 4)
+	values_id := b.register_synthetic_function('map__values', b.array_type, p1_ptr)
+	b.generate_map_keys_values_body(values_id, 1, 5)
+
+	mut p2_reserve := []TypeID{}
+	p2_reserve << ptr_map
+	p2_reserve << b.u32_type
+	reserve_id := b.register_synthetic_function('map__reserve', b.void_type, p2_reserve)
+	b.generate_map_reserve_body(reserve_id)
 
 	p2 = []TypeID{}
 	p2 << ptr_map
@@ -2573,13 +2586,52 @@ fn (mut b Builder) register_map_runtime_stubs() {
 	p1_map << b.map_type
 	clone_id := b.register_synthetic_function('map__clone', b.map_type, p1_map)
 	b.generate_map_clone_body(clone_id)
+
+	mut p1_ptr_map := []TypeID{}
+	p1_ptr_map << ptr_map
+	move_id := b.register_synthetic_function('map__move', b.map_type, p1_ptr_map)
+	b.generate_map_move_body(move_id)
 }
 
-// generate_map_ptr_noop_body supports generate map ptr noop body handling for Builder.
-fn (mut b Builder) generate_map_ptr_noop_body(func_id int) {
+// generate_map_reserve_body emits a capacity no-op for the simplified SSA map runtime.
+fn (mut b Builder) generate_map_reserve_body(func_id int) {
 	ptr_map := b.m.type_store.get_ptr(b.map_type)
 	entry := b.m.add_block(func_id, 'entry')
 	_ := b.func_add_argument(func_id, ptr_map, 'm')
+	_ := b.func_add_argument(func_id, b.u32_type, 'n')
+	b.block_instr0(.ret, entry, b.void_type)
+}
+
+// generate_map_clear_body clears the simplified SSA map length.
+fn (mut b Builder) generate_map_clear_body(func_id int) {
+	ptr_map := b.m.type_store.get_ptr(b.map_type)
+	ptr_state := b.m.type_store.get_ptr(b.map_state_type)
+	entry := b.m.add_block(func_id, 'entry')
+	m := b.func_add_argument(func_id, ptr_map, 'm')
+	state := b.map_state_ptr(entry, m)
+	zero_state := b.m.get_or_add_const(ptr_state, '0')
+	has_state := b.block_instr2(.ne, entry, b.i1_type, state, zero_state)
+	blk_clear := b.m.add_block(func_id, 'map_clear_state')
+	blk_done := b.m.add_block(func_id, 'map_clear_done')
+	b.block_instr3(.br, entry, b.void_type, has_state, ValueID(blk_clear), ValueID(blk_done))
+
+	len_ptr := b.map_state_field_ptr(blk_clear, state, 3)
+	zero := b.m.get_or_add_const(b.i64_type, '0')
+	b.block_instr2(.store, blk_clear, b.void_type, zero, len_ptr)
+	b.block_instr1(.jmp, blk_clear, b.void_type, ValueID(blk_done))
+
+	b.block_instr0(.ret, blk_done, b.void_type)
+}
+
+// generate_map_free_body detaches the simplified SSA map state.
+fn (mut b Builder) generate_map_free_body(func_id int) {
+	ptr_map := b.m.type_store.get_ptr(b.map_type)
+	ptr_state := b.m.type_store.get_ptr(b.map_state_type)
+	entry := b.m.add_block(func_id, 'entry')
+	m := b.func_add_argument(func_id, ptr_map, 'm')
+	state_field := b.block_struct_field_ptr(entry, m, b.map_type, 0)
+	zero_state := b.m.get_or_add_const(ptr_state, '0')
+	b.block_instr2(.store, entry, b.void_type, zero_state, state_field)
 	b.block_instr0(.ret, entry, b.void_type)
 }
 
@@ -2599,12 +2651,40 @@ fn (mut b Builder) generate_map_delete_body(func_id int) {
 	b.block_instr3(.br, entry, b.void_type, found, ValueID(blk_found), ValueID(blk_done))
 
 	state := b.map_state_ptr(blk_found, map_ptr)
+	keys_ptr := b.map_state_field_ptr(blk_found, state, 0)
+	vals_ptr := b.map_state_field_ptr(blk_found, state, 1)
 	len_ptr := b.map_state_field_ptr(blk_found, state, 3)
+	key_size_ptr := b.map_state_field_ptr(blk_found, state, 4)
+	val_size_ptr := b.map_state_field_ptr(blk_found, state, 5)
 	len := b.block_instr1(.load, blk_found, b.i64_type, len_ptr)
 	one := b.m.get_or_add_const(b.i64_type, '1')
 	new_len := b.block_instr2(.sub, blk_found, b.i64_type, len, one)
-	b.block_instr2(.store, blk_found, b.void_type, new_len, len_ptr)
-	b.block_instr1(.jmp, blk_found, b.void_type, ValueID(blk_done))
+	deleting_last := b.block_instr2(.eq, blk_found, b.i1_type, idx, new_len)
+	blk_compact := b.m.add_block(func_id, 'map_delete_compact')
+	blk_store_len := b.m.add_block(func_id, 'map_delete_store_len')
+	b.block_instr3(.br, blk_found, b.void_type, deleting_last, ValueID(blk_store_len),
+		ValueID(blk_compact))
+
+	keys := b.block_instr1(.load, blk_compact, ptr_i8, keys_ptr)
+	vals := b.block_instr1(.load, blk_compact, ptr_i8, vals_ptr)
+	key_size := b.block_instr1(.load, blk_compact, b.i64_type, key_size_ptr)
+	val_size := b.block_instr1(.load, blk_compact, b.i64_type, val_size_ptr)
+	key_dst_off := b.block_instr2(.mul, blk_compact, b.i64_type, idx, key_size)
+	val_dst_off := b.block_instr2(.mul, blk_compact, b.i64_type, idx, val_size)
+	key_src_off := b.block_instr2(.mul, blk_compact, b.i64_type, new_len, key_size)
+	val_src_off := b.block_instr2(.mul, blk_compact, b.i64_type, new_len, val_size)
+	key_dst := b.block_instr2(.add, blk_compact, ptr_i8, keys, key_dst_off)
+	val_dst := b.block_instr2(.add, blk_compact, ptr_i8, vals, val_dst_off)
+	key_src := b.block_instr2(.add, blk_compact, ptr_i8, keys, key_src_off)
+	val_src := b.block_instr2(.add, blk_compact, ptr_i8, vals, val_src_off)
+	memcpy_ref_key := b.m.add_value(.func_ref, b.void_type, 'memcpy', b.fn_ids['memcpy'])
+	memcpy_ref_val := b.m.add_value(.func_ref, b.void_type, 'memcpy', b.fn_ids['memcpy'])
+	b.block_instr4(.call, blk_compact, ptr_i8, memcpy_ref_key, key_dst, key_src, key_size)
+	b.block_instr4(.call, blk_compact, ptr_i8, memcpy_ref_val, val_dst, val_src, val_size)
+	b.block_instr1(.jmp, blk_compact, b.void_type, ValueID(blk_store_len))
+
+	b.block_instr2(.store, blk_store_len, b.void_type, new_len, len_ptr)
+	b.block_instr1(.jmp, blk_store_len, b.void_type, ValueID(blk_done))
 
 	b.block_instr0(.ret, blk_done, b.void_type)
 }
@@ -2673,6 +2753,65 @@ fn (mut b Builder) generate_map_clone_body(func_id int) {
 	b.block_instr1(.ret, blk_clone, b.void_type, result)
 
 	b.block_instr1(.ret, blk_empty, b.void_type, m)
+}
+
+// generate_map_move_body moves the simplified SSA map header out of `m` and zeroes `m`.
+fn (mut b Builder) generate_map_move_body(func_id int) {
+	ptr_map := b.m.type_store.get_ptr(b.map_type)
+	ptr_state := b.m.type_store.get_ptr(b.map_state_type)
+	entry := b.m.add_block(func_id, 'entry')
+	m := b.func_add_argument(func_id, ptr_map, 'm')
+	state_field := b.block_struct_field_ptr(entry, m, b.map_type, 0)
+	state := b.block_instr1(.load, entry, ptr_state, state_field)
+
+	result_slot := b.block_instr0(.alloca, entry, ptr_map)
+	result_state_field := b.block_struct_field_ptr(entry, result_slot, b.map_type, 0)
+	b.block_instr2(.store, entry, b.void_type, state, result_state_field)
+
+	zero_state := b.m.get_or_add_const(ptr_state, '0')
+	b.block_instr2(.store, entry, b.void_type, zero_state, state_field)
+	result := b.block_instr1(.load, entry, b.map_type, result_slot)
+	b.block_instr1(.ret, entry, b.void_type, result)
+}
+
+// generate_map_keys_values_body copies one map state storage vector into an array.
+fn (mut b Builder) generate_map_keys_values_body(func_id int, data_field int, size_field int) {
+	ptr_i8 := b.m.type_store.get_ptr(b.i8_type)
+	ptr_map := b.m.type_store.get_ptr(b.map_type)
+	ptr_state := b.m.type_store.get_ptr(b.map_state_type)
+	ptr_array := b.m.type_store.get_ptr(b.array_type)
+	entry := b.m.add_block(func_id, 'entry')
+	m := b.func_add_argument(func_id, ptr_map, 'm')
+	state := b.map_state_ptr(entry, m)
+	zero_state := b.m.get_or_add_const(ptr_state, '0')
+	has_state := b.block_instr2(.ne, entry, b.i1_type, state, zero_state)
+	blk_copy := b.m.add_block(func_id, 'map_array_copy')
+	blk_empty := b.m.add_block(func_id, 'map_array_empty')
+	b.block_instr3(.br, entry, b.void_type, has_state, ValueID(blk_copy), ValueID(blk_empty))
+
+	src_ptr := b.map_state_field_ptr(blk_copy, state, data_field)
+	len_ptr := b.map_state_field_ptr(blk_copy, state, 3)
+	elem_size_ptr := b.map_state_field_ptr(blk_copy, state, size_field)
+	src := b.block_instr1(.load, blk_copy, ptr_i8, src_ptr)
+	len := b.block_instr1(.load, blk_copy, b.i64_type, len_ptr)
+	elem_size := b.block_instr1(.load, blk_copy, b.i64_type, elem_size_ptr)
+	array_new_ref := b.m.add_value(.func_ref, b.void_type, 'array_new', b.fn_ids['array_new'])
+	arr := b.block_instr4(.call, blk_copy, b.array_type, array_new_ref, elem_size, len, len)
+	arr_slot := b.block_instr0(.alloca, blk_copy, ptr_array)
+	b.block_instr2(.store, blk_copy, b.void_type, arr, arr_slot)
+	data_ptr := b.block_struct_field_ptr(blk_copy, arr_slot, b.array_type, 0)
+	data := b.block_instr1(.load, blk_copy, ptr_i8, data_ptr)
+	byte_len := b.block_instr2(.mul, blk_copy, b.i64_type, len, elem_size)
+	memcpy_ref := b.m.add_value(.func_ref, b.void_type, 'memcpy', b.fn_ids['memcpy'])
+	b.block_instr4(.call, blk_copy, ptr_i8, memcpy_ref, data, src, byte_len)
+	result := b.block_instr1(.load, blk_copy, b.array_type, arr_slot)
+	b.block_instr1(.ret, blk_copy, b.void_type, result)
+
+	zero := b.m.get_or_add_const(b.i64_type, '0')
+	one := b.m.get_or_add_const(b.i64_type, '1')
+	empty_ref := b.m.add_value(.func_ref, b.void_type, 'array_new', b.fn_ids['array_new'])
+	empty := b.block_instr4(.call, blk_empty, b.array_type, empty_ref, one, zero, zero)
+	b.block_instr1(.ret, blk_empty, b.void_type, empty)
 }
 
 // register_u8_runtime_stubs updates register u8 runtime stubs state for ssa.
@@ -4873,6 +5012,9 @@ fn (mut b Builder) checker_return_type(fn_name string, module_name string) ?Type
 
 // fn_is_used supports fn is used handling for Builder.
 fn (b &Builder) fn_is_used(name string) bool {
+	if name == 'main' {
+		return true
+	}
 	if name in b.used_fns {
 		return true
 	}

--- a/vlib/v3/ssa/builder.v
+++ b/vlib/v3/ssa/builder.v
@@ -9118,14 +9118,16 @@ fn (mut b Builder) build_const_string_array_arg(id flat.NodeId) ?ValueID {
 	if int(id) < 0 {
 		return none
 	}
-	node := b.a.nodes[int(id)]
-	if node.kind != .ident {
-		return none
-	}
-	expr_id := b.lookup_const_expr(node.value) or { return none }
+	expr_id := b.const_string_array_expr_id(id) or { return none }
 	expr := b.a.nodes[int(expr_id)]
 	if expr.kind != .array_literal || expr.children_count == 0 {
 		return none
+	}
+	for i in 0 .. expr.children_count {
+		child := b.a.nodes[int(b.a.child(&expr, i))]
+		if child.kind != .string_literal {
+			return none
+		}
 	}
 	ptr_string := b.m.type_store.get_ptr(b.str_type)
 	ptr_i8 := b.m.type_store.get_ptr(b.i8_type)
@@ -9134,16 +9136,32 @@ fn (mut b Builder) build_const_string_array_arg(id flat.NodeId) ?ValueID {
 	stride := 16
 	for i in 0 .. expr.children_count {
 		child_id := b.a.child(&expr, i)
-		child := b.a.nodes[int(child_id)]
-		if child.kind != .string_literal {
-			return none
-		}
 		value := b.build_expr(child_id)
 		off := b.m.get_or_add_const(b.i64_type, '${i * stride}')
 		slot := b.emit2(.get_element_ptr, ptr_string, alloca, off)
 		b.emit2(.store, b.void_type, value, slot)
 	}
 	return b.emit1(.bitcast, ptr_i8, alloca)
+}
+
+fn (b &Builder) const_string_array_expr_id(id flat.NodeId) ?flat.NodeId {
+	if int(id) < 0 {
+		return none
+	}
+	node := b.a.nodes[int(id)]
+	if node.kind == .array_literal {
+		return id
+	}
+	if node.kind == .ident {
+		return b.lookup_const_expr(node.value)
+	}
+	if node.kind == .selector {
+		name := b.selector_qualified_name(node)
+		if name.len > 0 {
+			return b.lookup_const_expr(name)
+		}
+	}
+	return none
 }
 
 fn (mut b Builder) default_system_error_value(typ_id TypeID) ValueID {
@@ -9949,9 +9967,30 @@ fn (b &Builder) selector_qualified_name(node flat.Node) string {
 }
 
 fn (mut b Builder) load_map_len(map_ptr ValueID) ValueID {
+	ptr_i64 := b.m.type_store.get_ptr(b.i64_type)
+	ptr_state := b.m.type_store.get_ptr(b.map_state_type)
+	result_slot := b.emit0(.alloca, ptr_i64)
 	state := b.map_state_ptr(b.cur_block, map_ptr)
-	len_ptr := b.map_state_field_ptr(b.cur_block, state, 3)
-	return b.emit1(.load, b.i64_type, len_ptr)
+	zero_state := b.m.get_or_add_const(ptr_state, '0')
+	has_state := b.emit2(.ne, b.i1_type, state, zero_state)
+	blk_load := b.m.add_block(b.cur_func, 'map_len_state')
+	blk_empty := b.m.add_block(b.cur_func, 'map_len_empty')
+	blk_done := b.m.add_block(b.cur_func, 'map_len_done')
+	b.emit3(.br, b.void_type, has_state, ValueID(blk_load), ValueID(blk_empty))
+
+	b.cur_block = blk_load
+	len_ptr := b.map_state_field_ptr(blk_load, state, 3)
+	len := b.emit1(.load, b.i64_type, len_ptr)
+	b.emit2(.store, b.void_type, len, result_slot)
+	b.emit1(.jmp, b.void_type, ValueID(blk_done))
+
+	b.cur_block = blk_empty
+	zero_len := b.m.get_or_add_const(b.i64_type, '0')
+	b.emit2(.store, b.void_type, zero_len, result_slot)
+	b.emit1(.jmp, b.void_type, ValueID(blk_done))
+
+	b.cur_block = blk_done
+	return b.emit1(.load, b.i64_type, result_slot)
 }
 
 fn (mut b Builder) load_selector_field(node flat.Node, struct_typ_id TypeID, field_ptr ValueID) ValueID {

--- a/vlib/v3/ssa/builder.v
+++ b/vlib/v3/ssa/builder.v
@@ -2565,9 +2565,12 @@ fn (mut b Builder) register_map_runtime_stubs() {
 	b.generate_map_clear_body(clear_id)
 	free_id := b.register_synthetic_function('map__free', b.void_type, p1_ptr)
 	b.generate_map_free_body(free_id)
-	keys_id := b.register_synthetic_function('map__keys', b.array_type, p1_ptr)
+	mut p2_arr := []TypeID{}
+	p2_arr << ptr_map
+	p2_arr << b.i64_type
+	keys_id := b.register_synthetic_function('map__keys', b.array_type, p2_arr)
 	b.generate_map_keys_values_body(keys_id, 0, 4)
-	values_id := b.register_synthetic_function('map__values', b.array_type, p1_ptr)
+	values_id := b.register_synthetic_function('map__values', b.array_type, p2_arr)
 	b.generate_map_keys_values_body(values_id, 1, 5)
 
 	mut p2_reserve := []TypeID{}
@@ -2782,6 +2785,7 @@ fn (mut b Builder) generate_map_keys_values_body(func_id int, data_field int, si
 	ptr_array := b.m.type_store.get_ptr(b.array_type)
 	entry := b.m.add_block(func_id, 'entry')
 	m := b.func_add_argument(func_id, ptr_map, 'm')
+	elem_size_arg := b.func_add_argument(func_id, b.i64_type, 'elem_size')
 	state := b.map_state_ptr(entry, m)
 	zero_state := b.m.get_or_add_const(ptr_state, '0')
 	has_state := b.block_instr2(.ne, entry, b.i1_type, state, zero_state)
@@ -2808,9 +2812,8 @@ fn (mut b Builder) generate_map_keys_values_body(func_id int, data_field int, si
 	b.block_instr1(.ret, blk_copy, b.void_type, result)
 
 	zero := b.m.get_or_add_const(b.i64_type, '0')
-	one := b.m.get_or_add_const(b.i64_type, '1')
 	empty_ref := b.m.add_value(.func_ref, b.void_type, 'array_new', b.fn_ids['array_new'])
-	empty := b.block_instr4(.call, blk_empty, b.array_type, empty_ref, one, zero, zero)
+	empty := b.block_instr4(.call, blk_empty, b.array_type, empty_ref, elem_size_arg, zero, zero)
 	b.block_instr1(.ret, blk_empty, b.void_type, empty)
 }
 
@@ -8694,7 +8697,28 @@ fn (mut b Builder) build_call(id flat.NodeId, node flat.Node) ValueID {
 		}
 		args << b.build_expr(arg_id)
 	}
+	if resolved_name in ['map__keys', 'map__values'] && args.len == 2 && param_types.len == 2 {
+		if elem_size := b.map_array_elem_size_arg(id, node) {
+			args << elem_size
+		} else {
+			args << b.m.get_or_add_const(b.i64_type, '1')
+		}
+	}
 	return b.m.add_instr(.call, b.cur_block, ret_type, args)
+}
+
+fn (mut b Builder) map_array_elem_size_arg(id flat.NodeId, node flat.Node) ?ValueID {
+	mut typ_name := b.checked_expr_type_name(id)
+	if typ_name.len == 0 || typ_name == 'unknown' {
+		typ_name = node.typ
+	}
+	if !typ_name.starts_with('[]') {
+		return none
+	}
+	elem_type := b.resolve_type(typ_name[2..])
+	elem_size := b.m.type_size(elem_type)
+	actual_size := if elem_size > 0 { elem_size } else { 1 }
+	return b.m.get_or_add_const(b.i64_type, actual_size.str())
 }
 
 fn (b &Builder) unqualified_call_candidate(name string, arg_count int) ?string {

--- a/vlib/v3/ssa/builder.v
+++ b/vlib/v3/ssa/builder.v
@@ -8752,13 +8752,20 @@ fn (mut b Builder) coerce_value_for_param(value ValueID, param_type TypeID) Valu
 }
 
 fn (mut b Builder) build_flag_enum_method_call(base_id flat.NodeId, method string, node flat.Node) ?ValueID {
-	if !b.is_flag_enum_expr(base_id) {
+	flag_type_name := b.flag_enum_expr_type_name(base_id)
+	if flag_type_name.len == 0 || !b.is_flag_enum_type_name(flag_type_name) {
 		return none
 	}
 	base_addr := b.build_lvalue_addr(base_id)
 	flag_type := b.deref_type(base_addr)
 	mut flag := if node.children_count > 1 {
-		b.build_expr(b.a.child(&node, 1))
+		arg_id := b.a.child(&node, 1)
+		arg_node := b.a.nodes[int(arg_id)]
+		if value := b.enum_const_value_with_type(arg_node, flag_type_name) {
+			b.m.get_or_add_const(flag_type, value.str())
+		} else {
+			b.build_expr(arg_id)
+		}
 	} else {
 		b.m.get_or_add_const(flag_type, '0')
 	}
@@ -8781,18 +8788,35 @@ fn (mut b Builder) build_flag_enum_method_call(base_id flat.NodeId, method strin
 }
 
 fn (b &Builder) is_flag_enum_expr(id flat.NodeId) bool {
+	return b.is_flag_enum_type_name(b.flag_enum_expr_type_name(id))
+}
+
+fn (b &Builder) flag_enum_expr_type_name(id flat.NodeId) string {
 	name := b.checked_expr_type_name(id)
 	if b.is_flag_enum_type_name(name) {
-		return true
+		return name
 	}
 	if int(id) < 0 {
-		return false
+		return ''
 	}
 	node := b.a.nodes[int(id)]
 	if node.typ.len > 0 && b.is_flag_enum_type_name(node.typ) {
-		return true
+		return node.typ
 	}
-	return false
+	if node.kind == .selector && node.children_count > 0 {
+		base_type := b.receiver_type_name(b.a.child(&node, 0)).trim_left('&')
+		field_type := b.field_type_name(base_type, node.value)
+		if field_type.len > 0 {
+			if b.is_flag_enum_type_name(field_type) {
+				return field_type
+			}
+		}
+		if node.value == 'flags'
+			&& (base_type == 'array' || base_type == 'builtin.array' || base_type.starts_with('[]')) {
+			return 'ArrayFlags'
+		}
+	}
+	return ''
 }
 
 fn (mut b Builder) coerce_int_value(value ValueID, to_type TypeID) ValueID {

--- a/vlib/v3/tests/const_string_membership_codegen_test.v
+++ b/vlib/v3/tests/const_string_membership_codegen_test.v
@@ -1,0 +1,31 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn build_v3_const_string_membership() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_const_string_membership_codegen_test_${os.getpid()}')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn test_const_string_array_membership_compiles_on_c_backend() {
+	v3_bin := build_v3_const_string_membership()
+	src_path := os.join_path(os.temp_dir(), 'v3_const_string_membership_${os.getpid()}.v')
+	os.write_file(src_path,
+		"const names = ['malloc', 'free']\n\nfn has_name(name string) bool {\n\treturn name in names\n}\n\nfn main() {\n\tprintln(has_name('malloc'))\n\tprintln(has_name('memcpy'))\n}\n") or {
+		panic(err)
+	}
+	bin_path := os.join_path(os.temp_dir(), 'v3_const_string_membership_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src_path} -b c -o ${bin_path}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(bin_path)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'true\nfalse'
+}

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -21,10 +21,14 @@ fn build_v3() string {
 }
 
 fn run_good(v3_bin string, name string, src string) string {
+	return run_good_backend(v3_bin, name, 'c', src)
+}
+
+fn run_good_backend(v3_bin string, name string, backend string, src string) string {
 	good_src := '${tmp_test_path(name)}.v'
 	os.write_file(good_src, src) or { panic(err) }
 	good_bin := tmp_test_path(name)
-	compile := os.execute('${v3_bin} ${good_src} -b c -o ${good_bin}')
+	compile := os.execute('${v3_bin} ${good_src} -b ${backend} -o ${good_bin}')
 	assert compile.exit_code == 0, compile.output
 	assert !compile.output.contains('C compilation failed'), compile.output
 	run := os.execute(good_bin)
@@ -316,6 +320,9 @@ fn test_map_builtin_method_fallback_checks_arguments() {
 	out := run_good(v3_bin, 'map_builtin_method_fallback',
 		'fn main() {\n\tmut m := map[string]int{}\n\tm["abc"] = 42\n\tmut moved := m.move()\n\tprintln(int_str(m.len))\n\tmoved.clear()\n\tmoved.reserve(6)\n\tmoved.delete("x")\n\tkeys := moved.keys()\n\tvalues := moved.values()\n\tcloned := moved.clone()\n\tprintln(int_str(keys.len + values.len + cloned.len))\n}\n')
 	assert out == '0\n0'
+	empty_arrays_out := run_good(v3_bin, 'map_empty_keys_values_keep_elem_size',
+		"struct State {\n\tlabels map[string]string\n}\n\nfn main() {\n\ts := State{}\n\tmut keys := s.labels.keys()\n\tkeys << 'abc'\n\tprintln(keys[0])\n\tmut values := s.labels.values()\n\tvalues << 'def'\n\tprintln(values[0])\n}\n")
+	assert empty_arrays_out == 'abc\ndef'
 	pointer_out := run_good(v3_bin, 'map_move_pointer_receiver_returns_map',
 		'fn take(m map[string]int) int {\n\treturn m.len\n}\n\nfn main() {\n\tmut m := map[string]int{}\n\tm["abc"] = 42\n\tp := &m\n\tprintln(int_str(take(p.move())))\n\tprintln(int_str(m.len))\n}\n')
 	assert pointer_out == '1\n0'
@@ -350,6 +357,20 @@ fn test_map_builtin_method_fallback_checks_arguments() {
 		'thing/mod.v': 'module thing\n\nstruct Foo {}\nstruct Key {}\n\nfn (m map[string]Foo) keys() int {\n\treturn 31\n}\n\nfn (a []Foo) pointers() int {\n\treturn 42\n}\n\nfn (m map[Key]int) keys() int {\n\treturn 53\n}\n\npub fn run() string {\n\tmut m := map[string]Foo{}\n\tm["x"] = Foo{}\n\titems := [Foo{}]\n\tkeyed := map[Key]int{}\n\treturn int_str(m.keys()) + "\\n" + int_str(items.pointers()) + "\\n" + int_str(keyed.keys())\n}\n'
 	}, 'main.v')
 	assert module_collection_out == '31\n42\n53'
+}
+
+fn test_arm64_string_roundtrip_preserves_literal_flag() {
+	$if macos && arm64 {
+		v3_bin := build_v3()
+		out := run_good_backend(v3_bin, 'arm64_string_roundtrip_preserves_literal_flag', 'arm64',
+			"fn literal_local() string {\n\ts := 'literal-static'\n\treturn s\n}\n\nfn arg_local(s string) string {\n\tlocal := s\n\treturn local\n}\n\nfn main() {\n\ta := literal_local()\n\tb := arg_local('argument-static')\n\tunsafe {\n\t\ta.free()\n\t\tb.free()\n\t}\n\tprintln('ok')\n}\n")
+		assert out == 'ok'
+		map_out := run_good_backend(v3_bin, 'arm64_map_empty_arrays_keep_elem_size', 'arm64',
+			"struct State {\n\tlabels map[string]string\n}\n\nfn main() {\n\ts := State{}\n\tmut keys := s.labels.keys()\n\tkeys << 'abc'\n\tprintln(keys[0])\n\tmut values := s.labels.values()\n\tvalues << 'def'\n\tprintln(values[0])\n}\n")
+		assert map_out == 'abc\ndef'
+	} $else {
+		assert true
+	}
 }
 
 fn test_runtime_inits_run_before_module_init() {

--- a/vlib/v3/tests/ssa_builder_parity_test.v
+++ b/vlib/v3/tests/ssa_builder_parity_test.v
@@ -372,6 +372,23 @@ fn make_array() int {
 	assert has_alloca_len_const(m, 'make_array', '4')
 }
 
+// test_const_string_membership_does_not_heap_build_array validates this v3 regression case.
+fn test_const_string_membership_does_not_heap_build_array() {
+	m := build_transformed_source('const_string_membership', '
+const names = ["malloc", "free", "puts"]
+
+fn has_name(name string) bool {
+	return name in names
+}
+
+fn main() {
+	_ := has_name("malloc")
+}
+')
+	assert has_call_to(m, 'has_name', 'fixed_array_contains_string')
+	assert !has_call_to(m, 'has_name', 'array_new')
+}
+
 // test_string_range_does_not_lower_to_array_slice validates this v3 regression case.
 fn test_string_range_does_not_lower_to_array_slice() {
 	m := build_source('string_range', '
@@ -439,6 +456,20 @@ fn main() {
 	assert keys_fn.blocks.len > 0
 	values_fn := find_func(m, 'map__values')
 	assert values_fn.blocks.len > 0
+}
+
+// test_moved_from_map_len_checks_nil_state validates this v3 regression case.
+fn test_moved_from_map_len_checks_nil_state() {
+	m := build_transformed_source('moved_from_map_len', '
+fn main() {
+	mut values := map[string]int{}
+	moved := values.move()
+	_ := moved
+	_ := values.len
+}
+')
+	assert has_call_to(m, 'main', 'map__move')
+	assert has_instr_op(m, 'main', .br)
 }
 
 // test_array_flags_set_lowers_without_receiver_collision validates this v3 regression case.

--- a/vlib/v3/tests/ssa_builder_parity_test.v
+++ b/vlib/v3/tests/ssa_builder_parity_test.v
@@ -1,8 +1,10 @@
 import os
 import v3.flat
+import v3.markused
 import v3.parser
 import v3.pref
 import v3.ssa
+import v3.transform
 import v3.types
 
 // parse_checked_source reads parse checked source input for v3 tests.
@@ -28,6 +30,18 @@ fn build_source(name string, source string) &ssa.Module {
 fn build_source_with_used(name string, source string, used_fns map[string]bool) &ssa.Module {
 	a, tc := parse_checked_source(name, source)
 	return ssa.build_with_used(a, used_fns, tc)
+}
+
+// build_transformed_source builds source after the normal used-filtered transform path.
+fn build_transformed_source(name string, source string) &ssa.Module {
+	mut a, mut tc := parse_checked_source(name, source)
+	mut used := markused.mark_used(a, tc)
+	used = transform.transform_with_used(mut a, tc, used)
+	tc.diagnose_unknown_calls = false
+	tc.reject_unlowered_map_mutation = true
+	tc.annotate_types()
+	assert tc.errors.len == 0, tc.errors.str()
+	return ssa.build_with_used(a, used, tc)
 }
 
 // find_func resolves find func information for v3 tests.
@@ -381,4 +395,48 @@ fn last_value(values []int) int {
 ')
 	assert has_call_to(m, 'first_value', 'array_get')
 	assert has_call_to(m, 'last_value', 'array_get')
+}
+
+// test_used_filter_keeps_main validates this v3 regression case.
+fn test_used_filter_keeps_main() {
+	mut used := map[string]bool{}
+	used['println'] = true
+	m := build_source_with_used('used_filter_main', '
+fn main() {
+	println("hello")
+}
+', used)
+	main_fn := find_func(m, 'main')
+	assert main_fn.blocks.len > 0
+}
+
+// test_map_move_runtime_helper_builds_ssa validates this v3 regression case.
+fn test_map_move_runtime_helper_builds_ssa() {
+	m := build_transformed_source('map_move_runtime', '
+fn main() {
+	mut values := map[string]int{}
+	moved := values.move()
+	moved.clear()
+	moved.reserve(4)
+	moved.delete("x")
+	keys := moved.keys()
+	vals := moved.values()
+	moved.free()
+	_ := keys
+	_ := vals
+}
+')
+	assert has_call_to(m, 'main', 'map__move')
+	assert has_call_to(m, 'main', 'map__clear')
+	assert has_call_to(m, 'main', 'map__reserve')
+	assert has_call_to(m, 'main', 'map__delete')
+	assert has_call_to(m, 'main', 'map__keys')
+	assert has_call_to(m, 'main', 'map__values')
+	assert has_call_to(m, 'main', 'map__free')
+	move_fn := find_func(m, 'map__move')
+	assert move_fn.blocks.len > 0
+	keys_fn := find_func(m, 'map__keys')
+	assert keys_fn.blocks.len > 0
+	values_fn := find_func(m, 'map__values')
+	assert values_fn.blocks.len > 0
 }

--- a/vlib/v3/tests/ssa_builder_parity_test.v
+++ b/vlib/v3/tests/ssa_builder_parity_test.v
@@ -440,3 +440,17 @@ fn main() {
 	values_fn := find_func(m, 'map__values')
 	assert values_fn.blocks.len > 0
 }
+
+// test_array_flags_set_lowers_without_receiver_collision validates this v3 regression case.
+fn test_array_flags_set_lowers_without_receiver_collision() {
+	m := build_source('array_flags_set', '
+fn main() {
+	mut values := []string{}
+	unsafe {
+		values.flags.set(.noslices | .noshrink)
+	}
+}
+')
+	assert !has_call_to(m, 'main', 'SortedMap.set')
+	assert has_instr_op(m, 'main', .or_)
+}

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1030,9 +1030,11 @@ fn (mut t Transformer) lower_const_string_array_membership_expr(base_id flat.Nod
 		}
 	}
 	needle := t.transform_expr(needle_id)
-	base := t.transform_expr(base_id)
+	base_value := t.transform_expr(base_id)
+	base_data := t.make_cast('&string', t.make_selector(base_value, 'data', 'voidptr'), '&string')
 	len_expr := t.make_int_literal(expr.children_count)
-	return t.make_call_typed('fixed_array_contains_string', arr3(base, len_expr, needle), 'bool')
+	return t.make_call_typed('fixed_array_contains_string', arr3(base_data, len_expr, needle),
+		'bool')
 }
 
 // lower_type_pattern_membership builds lower type pattern membership data for transform.

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -926,7 +926,11 @@ fn (mut t Transformer) transform_in_expr(id flat.NodeId, node flat.Node) flat.No
 		clean_rhs_type := t.membership_container_type(rhs_type)
 		rhs_is_ptr_array := t.membership_container_is_pointer_array(rhs_type)
 		if clean_rhs_type.starts_with('[]') || clean_rhs_type == 'array' {
-			if lowered := t.lower_array_membership_expr(rhs_id, lhs_id, rhs_type, false, node) {
+			if lowered_const := t.lower_const_string_array_membership_expr(rhs_id, lhs_id) {
+				result = lowered_const
+			} else if lowered := t.lower_array_membership_expr(rhs_id, lhs_id, rhs_type, false,
+				node)
+			{
 				result = lowered
 			} else {
 				// dynamic array membership -> array_contains_int/string(arr, val)
@@ -1009,6 +1013,26 @@ fn (mut t Transformer) transform_in_expr(id flat.NodeId, node flat.Node) flat.No
 		})
 	}
 	return result
+}
+
+// lower_const_string_array_membership_expr lowers `needle in const_string_array` without
+// materializing the const array as a dynamic heap array for each membership test.
+fn (mut t Transformer) lower_const_string_array_membership_expr(base_id flat.NodeId, needle_id flat.NodeId) ?flat.NodeId {
+	expr_id := t.const_expr_for_arg(base_id) or { return none }
+	expr := t.a.nodes[int(expr_id)]
+	if expr.kind != .array_literal || expr.children_count == 0 {
+		return none
+	}
+	for i in 0 .. expr.children_count {
+		child := t.a.nodes[int(t.a.child(&expr, i))]
+		if child.kind != .string_literal {
+			return none
+		}
+	}
+	needle := t.transform_expr(needle_id)
+	base := t.transform_expr(base_id)
+	len_expr := t.make_int_literal(expr.children_count)
+	return t.make_call_typed('fixed_array_contains_string', arr3(base, len_expr, needle), 'bool')
 }
 
 // lower_type_pattern_membership builds lower type pattern membership data for transform.


### PR DESCRIPTION
## Summary
- register the lowered map runtime helpers needed by the v3 SSA/ARM64 backend
- implement simplified SSA map move/clear/free/reserve/keys/values behavior and compact delete
- keep the program entry main from being pruned by used-function filtering
- add SSA parity coverage for transformed map methods and main pruning

## Testing
- ./vnew test vlib/v3/tests/ssa_builder_parity_test.v
- ./vnew -gc none -prod -o /tmp/v3_arm_boot vlib/v3/v3.v && /tmp/v3_arm_boot -building-v -b arm64 -o /tmp/v4_arm vlib/v3/v3.v