### PR TITLE
v3: fix alias, fn-value, fixed-array, map, variadic and string-format tests

### DIFF
--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -113,6 +113,21 @@ fn (mut g FlatGen) gen_fixed_array_data_arg(id flat.NodeId, arr types.ArrayFixed
 		g.gen_fixed_array_data_arg(g.a.child(&node, 0), arr)
 		return
 	}
+	if node.kind in [.cast_expr, .as_expr] && node.children_count > 0 {
+		child_id := g.a.child(&node, 0)
+		child := g.a.nodes[int(child_id)]
+		if child.kind == .array_literal {
+			g.gen_fixed_array_data_arg(child_id, arr)
+			return
+		}
+		if child.kind == .postfix && child.children_count > 0 {
+			post_child_id := g.a.child(&child, 0)
+			if g.a.nodes[int(post_child_id)].kind == .array_literal {
+				g.gen_fixed_array_data_arg(post_child_id, arr)
+				return
+			}
+		}
+	}
 	if node.kind == .postfix && node.children_count > 0 {
 		child_id := g.a.child(&node, 0)
 		child := g.a.nodes[int(child_id)]

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2489,7 +2489,7 @@ fn (mut g FlatGen) gen_sum_value_expr(id flat.NodeId, expected types.Type) bool 
 	idx := g.sum_type_index(sum_name, variant)
 	field := g.sum_field_name(variant)
 	if g.variant_references_sum(variant, sum_name) {
-		inner_ct := g.tc.c_type(g.tc.parse_type(variant))
+		inner_ct := g.value_c_type(g.tc.parse_type(variant))
 		g.write('(${ct}){.typ = ${idx}, .${field} = (${inner_ct}*)memdup((${inner_ct}[]){')
 		g.gen_expr(id)
 		g.write('}, sizeof(${inner_ct}))}')
@@ -2536,7 +2536,7 @@ fn (mut g FlatGen) gen_sum_cast_expr(target_type types.SumType, inner_id flat.No
 	variant_is_pointer_arg := actual_type is types.Pointer
 		&& g.type_names_match(actual_type.base_type, variant_type)
 	if g.variant_references_sum(variant_name, target_type.name) {
-		inner_ct := g.tc.c_type(variant_type)
+		inner_ct := g.value_c_type(variant_type)
 		if variant_is_pointer_arg {
 			g.write('(${ct}){.typ = ${idx}, .${field} = ')
 			if g.pointer_variant_arg_needs_heap_copy(inner) {
@@ -2798,7 +2798,11 @@ fn (mut g FlatGen) type_name_c_type(type_name string) string {
 		return g.resolve_fn_ptr_type(type_name)
 	}
 	t := g.tc.parse_type(type_name)
-	return g.tc.c_type(t)
+	ct := g.tc.c_type(t)
+	if ct.starts_with('fn_ptr:') {
+		return g.resolve_fn_ptr_type(ct)
+	}
+	return ct
 }
 
 fn (mut g FlatGen) sizeof_target(value string) string {
@@ -3066,6 +3070,15 @@ fn (mut g FlatGen) const_expr_to_string(id flat.NodeId, seen []string) string {
 					return dep_expr
 				}
 			}
+			if node.kind == .selector && node.children_count > 0 {
+				base := g.a.child_node(&node, 0)
+				if base.kind == .ident {
+					fn_name := '${base.value}.${node.value}'
+					if fn_name in g.tc.fn_ret_types || fn_name in g.tc.fn_param_types {
+						return c_name(fn_name)
+					}
+				}
+			}
 			g.expr_to_string(id)
 		}
 		.infix {
@@ -3102,7 +3115,7 @@ fn (mut g FlatGen) const_expr_to_string(id flat.NodeId, seen []string) string {
 				idx := g.sum_type_index(target_type.name, variant_name)
 				field := g.sum_field_name(variant_name)
 				inner_val := g.const_expr_to_string(inner_id, seen)
-				inner_ct := g.tc.c_type(g.tc.parse_type(variant_name))
+				inner_ct := g.value_c_type(g.tc.parse_type(variant_name))
 				payload := if inner_val.trim_space().len == 0 { '0' } else { inner_val }
 				return '(${ct}){.typ = ${idx}, .${field} = (${inner_ct}[]){${payload}}}'
 			}
@@ -3159,7 +3172,7 @@ fn (mut g FlatGen) const_expr_to_string(id flat.NodeId, seen []string) string {
 							}
 						}
 						variant = g.resolve_variant(sum_name, variant)
-						inner_ct := g.tc.c_type(g.tc.parse_type(variant))
+						inner_ct := g.value_c_type(g.tc.parse_type(variant))
 						const_val := g.const_expr_to_string(val_id, seen)
 						payload := if const_val.trim_space().len > 0 {
 							const_val
@@ -4003,7 +4016,9 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				g.gen_expr(base_id)
 				g.write(', &(${c_key}[]){')
 				g.gen_expr(g.a.child(&node, 1))
-				g.write('}, &(${c_val}[]){0}))')
+				g.write('}, ')
+				g.gen_default_value_addr_for_type(base_type.value_type)
+				g.write('))')
 			} else {
 				mut index_base_type := base_type
 				initial_is_fixed_array_index, _, _ := fixed_array_index_info(index_base_type)
@@ -4315,7 +4330,7 @@ fn (mut g FlatGen) gen_array_infix_eq(node flat.Node, lhs_id flat.NodeId, rhs_id
 	g.write(', ')
 	g.gen_array_value_arg(rhs_id, rhs_type)
 	if elem_type !is types.String {
-		g.write(', sizeof(${g.tc.c_type(elem_type)})')
+		g.write(', sizeof(${g.sizeof_target(g.tc.c_type(elem_type))})')
 	}
 	g.write(')')
 	return true
@@ -6302,9 +6317,10 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('string rune__str(i32 c);')
 	g.writeln('u8* malloc_noscan(ptrdiff_t n);')
 	g.writeln('static inline string v3_c_lit(const char* s, int len) { return (string){.str = (u8*)s, .len = len, .is_lit = 1}; }')
+	g.writeln("static inline string v3_string_pad(string s, int width, int left) { if (width < 0) { left = 1; width = -width; } if (s.len >= width) return s; int pad = width - s.len; u8* out = malloc_noscan((ptrdiff_t)width + 1); if (left) { memcpy(out, s.str, (size_t)s.len); memset(out + s.len, ' ', (size_t)pad); } else { memset(out, ' ', (size_t)pad); memcpy(out + pad, s.str, (size_t)s.len); } out[width] = 0; return (string){.str = out, .len = width, .is_lit = 0}; }")
 	g.writeln('static inline string v3_char_string(int c) { return rune__str((i32)c); }')
 	g.writeln('static inline double v3_f64_fixed_value(double x, int precision) { if (precision == 0) return x < 0.0 ? ceil(x - 0.5) : floor(x + 0.5); if (precision == 6) { double scale = 1000000.0; double ax = fabs(x) * scale; double base = floor(ax); double frac = ax - base; if (frac == 0.5) { double rounded = floor(ax + 0.5) / scale; return x < 0.0 ? -rounded : rounded; } } return x; }')
-	g.writeln('static inline string v3_f64_fixed(double x, int precision) { double y = v3_f64_fixed_value(x, precision); char tmp[128]; int n = snprintf(tmp, sizeof(tmp), "%.*f", precision, y); if (n < 0) return v3_c_lit("", 0); if (n < (int)sizeof(tmp)) { u8* out = malloc_noscan(n + 1); memcpy(out, tmp, n + 1); return (string){.str = out, .len = n, .is_lit = 0}; } u8* out = malloc_noscan(n + 1); snprintf((char*)out, (size_t)n + 1, "%.*f", precision, y); return (string){.str = out, .len = n, .is_lit = 0}; }')
+	g.writeln('static inline string v3_f64_fixed(double x, int precision) { if (precision > 16) { char base[128]; int b = snprintf(base, sizeof(base), "%.16g", x); if (b >= 0 && b < (int)sizeof(base)) { int dot = -1; int has_exp = 0; for (int i = 0; i < b; ++i) { if (base[i] == \'.\') dot = i; if (base[i] == \'e\' || base[i] == \'E\') has_exp = 1; } if (!has_exp) { int frac = dot >= 0 ? b - dot - 1 : 0; if (frac <= precision) { int n = b + (dot < 0 ? 1 : 0) + (precision - frac); u8* out = malloc_noscan(n + 1); memcpy(out, base, b); int pos = b; if (dot < 0) out[pos++] = \'.\'; while (frac++ < precision) out[pos++] = \'0\'; out[pos] = 0; return (string){.str = out, .len = n, .is_lit = 0}; } } } } double y = v3_f64_fixed_value(x, precision); char tmp[128]; int n = snprintf(tmp, sizeof(tmp), "%.*f", precision, y); if (n < 0) return v3_c_lit("", 0); if (n < (int)sizeof(tmp)) { u8* out = malloc_noscan(n + 1); memcpy(out, tmp, n + 1); return (string){.str = out, .len = n, .is_lit = 0}; } u8* out = malloc_noscan(n + 1); snprintf((char*)out, (size_t)n + 1, "%.*f", precision, y); return (string){.str = out, .len = n, .is_lit = 0}; }')
 	g.writeln('static inline string v3_int_zpad(int n, int width) { string s = int__str(n); if (n < 0) return s; while (s.len < width) s = string__plus(v3_c_lit("0", 1), s); return s; }')
 	g.writeln('static inline string v3_i64_zpad(i64 n, int width) { string s = i64__str(n); if (n < 0) return s; while (s.len < width) s = string__plus(v3_c_lit("0", 1), s); return s; }')
 	g.writeln('static inline string v3_u64_zpad(u64 n, int width) { string s = u64__str(n); while (s.len < width) s = string__plus(v3_c_lit("0", 1), s); return s; }')
@@ -7163,8 +7179,8 @@ fn (mut g FlatGen) queue_map_literal_sets(target string, val_id flat.NodeId, map
 	if node.kind != .map_init {
 		return
 	}
-	c_key := g.tc.c_type(map_type.key_type)
-	c_val := g.tc.c_type(map_type.value_type)
+	c_key := g.value_c_type(map_type.key_type)
+	c_val := g.value_c_type(map_type.value_type)
 	for i := 0; i + 1 < node.children_count; i += 2 {
 		key := g.expr_to_string_with_expected_type(g.a.child(&node, i), map_type.key_type)
 		val := g.expr_to_string_with_expected_type(g.a.child(&node, i + 1), map_type.value_type)
@@ -7180,8 +7196,8 @@ fn (mut g FlatGen) queue_const_map_literal_sets(target string, val_id flat.NodeI
 	if node.kind != .map_init {
 		return
 	}
-	c_key := g.tc.c_type(map_type.key_type)
-	c_val := g.tc.c_type(map_type.value_type)
+	c_key := g.value_c_type(map_type.key_type)
+	c_val := g.value_c_type(map_type.value_type)
 	for i := 0; i + 1 < node.children_count; i += 2 {
 		key := g.expr_to_string_with_expected_type(g.a.child(&node, i), map_type.key_type)
 		val := g.expr_to_string_with_expected_type(g.a.child(&node, i + 1), map_type.value_type)

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -2606,7 +2606,14 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 						g.write(c_name(fn_ident.value))
 					}
 				} else {
+					needs_callee_parens := fn_ident.kind !in [.ident, .selector]
+					if needs_callee_parens {
+						g.write('(')
+					}
 					g.gen_expr(fn_id)
+					if needs_callee_parens {
+						g.write(')')
+					}
 				}
 			}
 			g.write('(')
@@ -2715,6 +2722,10 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					}
 					g.gen_params_struct_arg(ptyp, node, i)
 					break
+				}
+				if arg_node.kind == .sizeof_expr {
+					g.write('sizeof(${g.sizeof_target(arg_node.value)})')
+					continue
 				}
 				if fixed := array_fixed_type(g.tc.resolve_type(arg_id)) {
 					g.gen_fixed_array_data_arg(arg_id, fixed)
@@ -3652,6 +3663,19 @@ fn (g &FlatGen) direct_callback_ident_name(id flat.NodeId) ?string {
 	if node.kind in [.cast_expr, .paren, .expr_stmt] && node.children_count > 0 {
 		return g.direct_callback_ident_name(g.a.child(&node, 0))
 	}
+	if node.kind == .selector && node.children_count > 0 {
+		base := g.a.child_node(&node, 0)
+		if base.kind == .ident {
+			name := '${base.value}.${node.value}'
+			if name in g.tc.fn_param_types && name in g.tc.fn_ret_types {
+				return name
+			}
+			qname := '${g.tc.cur_module}.${name}'
+			if qname in g.tc.fn_param_types && qname in g.tc.fn_ret_types {
+				return qname
+			}
+		}
+	}
 	if node.kind != .ident || node.value.len == 0 {
 		return none
 	}
@@ -4201,6 +4225,10 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			}
 			g.gen_params_struct_arg(ptyp, node, i)
 			break
+		}
+		if arg_node.kind == .sizeof_expr {
+			g.write('sizeof(${g.sizeof_target(arg_node.value)})')
+			continue
 		}
 		if fixed := array_fixed_type(g.tc.resolve_type(arg_id)) {
 			g.gen_fixed_array_data_arg(arg_id, fixed)

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -99,11 +99,18 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 	body_start := header_count
 
 	if header_count == 4 {
-		panic('internal error: range for-in reached C backend after transform')
+		low_id := g.a.child(&node, 2)
+		high_id := g.a.child(&node, 3)
+		g.gen_range_for_in(node, g.a.child(&node, 0), low_id, high_id, body_start)
+		return
 	} else if header_count == 3 {
 		container := g.a.child_node(&node, 2)
 		if container.kind == .range {
-			panic('internal error: range for-in reached C backend after transform')
+			if container.children_count >= 2 {
+				g.gen_range_for_in(node, g.a.child(&node, 0), g.a.child(container, 0), g.a.child(container,
+					1), body_start)
+				return
+			}
 		} else {
 			container_type := g.usable_expr_type(g.a.child(&node, 2))
 			has_index := int(val_id) >= 0
@@ -230,6 +237,44 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 		g.tc.pop_scope()
 		return
 	}
+	g.indent++
+	g.loop_depth++
+	for i in body_start .. node.children_count {
+		g.gen_node(g.a.child(&node, i))
+	}
+	g.loop_depth--
+	g.indent--
+	g.writeln('}')
+	g.tc.pop_scope()
+}
+
+fn (mut g FlatGen) gen_range_for_in(node flat.Node, key_id flat.NodeId, low_id flat.NodeId, high_id flat.NodeId, body_start int) {
+	key := g.a.node(key_id)
+	if key.kind != .ident || key.value.len == 0 {
+		g.tc.pop_scope()
+		return
+	}
+	key_name := g.c_loop_local_name(key.value)
+	low_type := g.usable_expr_type(low_id)
+	range_type := if low_type is types.Primitive || low_type is types.ISize
+		|| low_type is types.USize {
+		low_type
+	} else {
+		types.Type(types.int_)
+	}
+	ct := g.value_c_type(range_type)
+	low_name := '__range_low_${g.tmp_count}'
+	g.tmp_count++
+	g.write('${ct} ${low_name} = ')
+	g.gen_expr(low_id)
+	g.writeln(';')
+	high_name := '__range_high_${g.tmp_count}'
+	g.tmp_count++
+	g.write('${ct} ${high_name} = ')
+	g.gen_expr(high_id)
+	g.writeln(';')
+	g.tc.cur_scope.insert(key.value, range_type)
+	g.writeln('for (${ct} ${key_name} = ${low_name}; ${key_name} < ${high_name}; ${key_name}++) {')
 	g.indent++
 	g.loop_depth++
 	for i in body_start .. node.children_count {

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -10,7 +10,7 @@ fn (mut g FlatGen) emit_sum_type(name string) {
 	g.writeln('\tint typ;')
 	g.writeln('\tunion {')
 	for v in variants {
-		ct := g.tc.c_type(g.tc.parse_type(v))
+		ct := g.value_c_type(g.tc.parse_type(v))
 		field := g.sum_field_name(v)
 		g.writeln('\t\t${ct}* ${field};')
 	}

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -13,17 +13,13 @@ fn gen_expr_lvalue(mut g FlatGen, id flat.NodeId) {
 		if base_type is types.Map {
 			c_key := g.tc.c_type(base_type.key_type)
 			c_val := g.tc.c_type(base_type.value_type)
-			zero := if base_type.value_type is types.Array {
-				c_elem := g.tc.c_type(base_type.value_type.elem_type)
-				'&(${c_val}[]){array_new(sizeof(${c_elem}), 0, 0)}'
-			} else {
-				'&(${c_val}[]){0}'
-			}
 			g.write('(*(${c_val}*)map__get_or_set(&')
 			g.gen_expr(base_id)
 			g.write(', &(${c_key}[]){')
 			g.gen_expr(g.a.child(&node, 1))
-			g.write('}, ${zero}))')
+			g.write('}, ')
+			g.gen_default_value_addr_for_type(base_type.value_type)
+			g.write('))')
 			return
 		}
 	}
@@ -1914,8 +1910,8 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 			}
 			if rhs.children_count > 0 {
 				if v_type is types.Map {
-					c_key := g.tc.c_type(v_type.key_type)
-					c_val := g.tc.c_type(v_type.value_type)
+					c_key := g.value_c_type(v_type.key_type)
+					c_val := g.value_c_type(v_type.value_type)
 					for j := 0; j < rhs.children_count; j += 2 {
 						g.write('map__set(&')
 						g.gen_decl_lhs(lhs_id)

--- a/vlib/v3/gen/c/str_intp.v
+++ b/vlib/v3/gen/c/str_intp.v
@@ -17,42 +17,57 @@ fn (mut g FlatGen) gen_string_interp(node flat.Node) {
 			g.write(', ')
 		}
 		child_id := g.a.child(&node, i)
-		child := g.a.nodes[int(child_id)]
+		mut expr_id := child_id
+		mut child := g.a.nodes[int(child_id)]
+		mut format := ''
+		if child.kind == .directive && child.value == 'string_interp_format'
+			&& child.children_count > 0 {
+			expr_id = g.a.child(&child, 0)
+			format = child.typ
+			child = g.a.nodes[int(expr_id)]
+		}
 		if child.kind == .string_literal {
 			sid := g.intern_string(child.value)
 			g.write('_str_${sid}')
 		} else {
-			typ := g.string_interp_child_type(child_id, child)
+			typ := g.string_interp_child_type(expr_id, child)
 			typ_name := types.Type(typ).name()
 			if child.typ == 'string' || typ is types.String {
-				g.gen_string_interp_child_expr(child_id)
-			} else if g.gen_map_str_expr(child_id, typ) {
+				if format.len > 0 {
+					g.gen_formatted_string_interp_child_expr(expr_id, typ, format)
+				} else {
+					g.gen_string_interp_child_expr(expr_id)
+				}
+			} else if format.len > 0
+				&& g.gen_formatted_string_interp_child_expr(expr_id, typ, format) {
+				// emitted by gen_formatted_string_interp_child_expr
+			} else if g.gen_map_str_expr(expr_id, typ) {
 				// emitted by gen_map_str_expr
 			} else if typ_name == 'IError' || typ_name.ends_with('.IError') {
 				// IError may resolve as Interface/Alias/Struct depending on context; match by
 				// name and interpolate its `.message` (mirrors the transformer's IError path).
-				g.gen_string_interp_child_expr(child_id)
+				g.gen_string_interp_child_expr(expr_id)
 				g.write('.message')
 			} else if typ is types.Primitive {
 				prim_name := types.Type(typ).name()
 				g.write('${c_name('${prim_name}.str')}(')
-				g.gen_string_interp_child_expr(child_id)
+				g.gen_string_interp_child_expr(expr_id)
 				g.write(')')
 			} else if typ is types.ISize || typ is types.USize {
 				g.write('${c_name('${typ.name()}.str')}(')
-				g.gen_string_interp_child_expr(child_id)
+				g.gen_string_interp_child_expr(expr_id)
 				g.write(')')
 			} else if typ is types.Struct {
 				g.write('${c_name(typ.name)}__str(')
-				g.gen_string_interp_child_expr(child_id)
+				g.gen_string_interp_child_expr(expr_id)
 				g.write(')')
 			} else if typ is types.SumType {
 				g.write('${c_name(typ.name)}__str(')
-				g.gen_string_interp_child_expr(child_id)
+				g.gen_string_interp_child_expr(expr_id)
 				g.write(')')
 			} else {
 				g.write('int__str(')
-				g.gen_string_interp_child_expr(child_id)
+				g.gen_string_interp_child_expr(expr_id)
 				g.write(')')
 			}
 		}
@@ -84,6 +99,123 @@ fn (g &FlatGen) string_interp_child_type(child_id flat.NodeId, child flat.Node) 
 		}
 	}
 	return typ
+}
+
+struct StringInterpFormat {
+mut:
+	width         int
+	precision     int
+	has_precision bool
+	verb          u8
+	left          bool
+	zero          bool
+}
+
+fn parse_string_interp_format(format string) StringInterpFormat {
+	mut f := StringInterpFormat{}
+	mut i := 0
+	if i < format.len && format[i] == `-` {
+		f.left = true
+		i++
+	}
+	if i < format.len && format[i] == `0` {
+		f.zero = true
+		i++
+	}
+	for i < format.len && format[i] >= `0` && format[i] <= `9` {
+		f.width = f.width * 10 + int(format[i] - `0`)
+		i++
+	}
+	if i < format.len && format[i] == `.` {
+		i++
+		f.has_precision = true
+		for i < format.len && format[i] >= `0` && format[i] <= `9` {
+			f.precision = f.precision * 10 + int(format[i] - `0`)
+			i++
+		}
+	}
+	if i < format.len {
+		f.verb = format[i]
+	}
+	return f
+}
+
+fn string_interp_type_name(typ types.Type) string {
+	mut name := types.Type(typ).name()
+	if name.starts_with('builtin.') {
+		name = name.all_after_last('.')
+	}
+	return name
+}
+
+fn is_string_interp_float_type(name string) bool {
+	return name in ['f32', 'f64', 'float_literal']
+}
+
+fn is_string_interp_signed_int_type(name string) bool {
+	return name in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'int_literal']
+}
+
+fn is_string_interp_unsigned_int_type(name string) bool {
+	return name in ['u8', 'byte', 'u16', 'u32', 'u64', 'usize']
+}
+
+fn (mut g FlatGen) gen_formatted_string_interp_child_expr(child_id flat.NodeId, typ types.Type, format string) bool {
+	f := parse_string_interp_format(format)
+	type_name := string_interp_type_name(typ)
+	left := if f.left { 1 } else { 0 }
+	if is_string_interp_float_type(type_name) && (f.verb == `f` || f.verb == 0) && f.has_precision {
+		precision := if f.verb == `f` {
+			f.precision
+		} else if f.precision > 0 {
+			f.precision - 1
+		} else {
+			0
+		}
+		g.write('v3_string_pad(v3_f64_fixed((double)(')
+		g.gen_string_interp_child_expr(child_id)
+		g.write('), ${precision}), ${f.width}, ${left})')
+		return true
+	}
+	if typ is types.String || type_name == 'string' {
+		if f.width > 0 && (f.verb == `s` || f.verb == 0) {
+			g.write('v3_string_pad(')
+			g.gen_string_interp_child_expr(child_id)
+			g.write(', ${f.width}, ${left})')
+			return true
+		}
+		g.gen_string_interp_child_expr(child_id)
+		return true
+	}
+	if is_string_interp_signed_int_type(type_name) && (f.verb == `d` || f.verb == 0) {
+		if f.zero && f.width > 0 {
+			g.write('v3_i64_zpad((i64)(')
+			g.gen_string_interp_child_expr(child_id)
+			g.write('), ${f.width})')
+			return true
+		}
+		if f.width > 0 {
+			g.write('v3_string_pad(i64__str((i64)(')
+			g.gen_string_interp_child_expr(child_id)
+			g.write(')), ${f.width}, ${left})')
+			return true
+		}
+	}
+	if is_string_interp_unsigned_int_type(type_name) && (f.verb == `d` || f.verb == 0) {
+		if f.zero && f.width > 0 {
+			g.write('v3_u64_zpad((u64)(')
+			g.gen_string_interp_child_expr(child_id)
+			g.write('), ${f.width})')
+			return true
+		}
+		if f.width > 0 {
+			g.write('v3_string_pad(u64__str((u64)(')
+			g.gen_string_interp_child_expr(child_id)
+			g.write(')), ${f.width}, ${left})')
+			return true
+		}
+	}
+	return false
 }
 
 fn (mut g FlatGen) gen_string_interp_child_expr(child_id flat.NodeId) {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -34,6 +34,10 @@ fn (g &FlatGen) struct_init_fields_key(type_name string, fallback string) string
 }
 
 fn (mut g FlatGen) gen_struct_field_expr(value_id flat.NodeId, expected types.Type) {
+	if call_name := g.callback_direct_fn_value_name(value_id, expected) {
+		g.write(g.callback_c_fn_name(call_name))
+		return
+	}
 	if g.gen_callback_fn_value_for_expected_type(value_id, expected) {
 		return
 	}
@@ -106,6 +110,22 @@ fn (mut g FlatGen) gen_unset_struct_field_default(struct_name string, field_name
 		g.write('.${field_c_name} = array_new(sizeof(${c_elem}), 0, 0)')
 		return true
 	}
+	if clean_type is types.String {
+		if has {
+			g.write(', ')
+		}
+		g.write('.${field_c_name} = ')
+		g.gen_default_value_for_type(clean_type)
+		return true
+	}
+	if clean_type is types.Enum {
+		if has {
+			g.write(', ')
+		}
+		g.write('.${field_c_name} = ')
+		g.gen_default_value_for_type(clean_type)
+		return true
+	}
 	if g.field_needs_default_init(clean_type) {
 		if has {
 			g.write(', ')
@@ -176,7 +196,7 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 				if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(lookup_name, sf.name,
 					value_id)
 				{
-					inner_ct := g.tc.c_type(heap_copy_type)
+					inner_ct := g.value_c_type(heap_copy_type)
 					g.write('(${inner_ct}*)memdup(')
 					g.gen_expr(value_id)
 					g.write(', sizeof(${inner_ct}))')
@@ -192,7 +212,7 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 			if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(lookup_name, field.value,
 				value_id)
 			{
-				inner_ct := g.tc.c_type(heap_copy_type)
+				inner_ct := g.value_c_type(heap_copy_type)
 				g.write('(${inner_ct}*)memdup(')
 				g.gen_expr(value_id)
 				g.write(', sizeof(${inner_ct}))')
@@ -323,7 +343,7 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 			if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(lookup_name, field.value,
 				value_id)
 			{
-				inner_ct := g.tc.c_type(heap_copy_type)
+				inner_ct := g.value_c_type(heap_copy_type)
 				g.write('(${inner_ct}*)memdup(')
 				g.gen_expr(value_id)
 				g.write(', sizeof(${inner_ct}))')
@@ -376,9 +396,29 @@ fn (mut g FlatGen) gen_struct_init_with_fixed_array_fields_impl(node flat.Node, 
 fn (mut g FlatGen) gen_fixed_array_copy_source(value_id flat.NodeId, field_type types.Type) {
 	val_node := g.a.node(value_id)
 	if val_node.kind == .array_literal {
-		g.write('(${g.tc.c_type(field_type)})')
+		if fixed := array_fixed_type(field_type) {
+			c_elem, dims := g.fixed_array_decl_parts(fixed)
+			g.write('(${c_elem}${dims})')
+		} else {
+			g.write('(${g.tc.c_type(field_type)})')
+		}
 		g.gen_expr(value_id)
 		return
+	}
+	if val_node.kind in [.cast_expr, .as_expr] && val_node.children_count > 0 {
+		child_id := g.a.child(val_node, 0)
+		child := g.a.node(child_id)
+		if child.kind == .array_literal {
+			g.gen_fixed_array_copy_source(child_id, field_type)
+			return
+		}
+		if child.kind == .postfix && child.children_count > 0 {
+			post_child_id := g.a.child(child, 0)
+			if g.a.node(post_child_id).kind == .array_literal {
+				g.gen_fixed_array_copy_source(post_child_id, field_type)
+				return
+			}
+		}
 	}
 	if val_node.kind == .paren && val_node.children_count > 0 {
 		g.gen_fixed_array_copy_source(g.a.child(val_node, 0), field_type)
@@ -434,7 +474,7 @@ fn (mut g FlatGen) gen_lowered_sum_field_value(sum_name string, field &flat.Node
 		if variant.len > 0 {
 			variant = g.resolve_variant(sum_name, variant)
 			inner_type := g.tc.parse_type(variant)
-			inner_ct := g.tc.c_type(inner_type)
+			inner_ct := g.value_c_type(inner_type)
 			child_type := g.tc.resolve_type(child_id)
 			g.write('(${inner_ct}*)memdup(')
 			if child_type is types.Pointer && g.type_names_match(child_type.base_type, inner_type) {
@@ -534,7 +574,7 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 				if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(lookup_name, sf.name,
 					value_id)
 				{
-					inner_ct := g.tc.c_type(heap_copy_type)
+					inner_ct := g.value_c_type(heap_copy_type)
 					g.write('(${inner_ct}*)memdup(')
 					g.gen_expr(value_id)
 					g.write(', sizeof(${inner_ct}))')
@@ -554,7 +594,7 @@ fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 		} else if heap_copy_type := g.heap_copy_type_for_sum_pointer_field(lookup_name,
 			field.value, value_id)
 		{
-			inner_ct := g.tc.c_type(heap_copy_type)
+			inner_ct := g.value_c_type(heap_copy_type)
 			g.write('(${inner_ct}*)memdup(')
 			g.gen_expr(value_id)
 			g.write(', sizeof(${inner_ct}))')
@@ -655,8 +695,21 @@ fn (mut g FlatGen) gen_default_value_for_type(typ types.Type) {
 		return
 	}
 	if clean_typ is types.Array {
-		c_elem := g.tc.c_type(clean_typ.elem_type)
+		c_elem := g.value_c_type(clean_typ.elem_type)
 		g.write('array_new(sizeof(${c_elem}), 0, 0)')
+		return
+	}
+	if clean_typ is types.String {
+		sid := g.intern_string('')
+		g.write('_str_${sid}')
+		return
+	}
+	if clean_typ is types.Enum {
+		if val := g.enum_default_value_for_type(clean_typ.name) {
+			g.write('${val}')
+		} else {
+			g.write('0')
+		}
 		return
 	}
 	raw_typ := clean_typ
@@ -686,12 +739,61 @@ fn (mut g FlatGen) gen_default_value_for_type(typ types.Type) {
 		g.write('}')
 		return
 	}
-	ct := g.tc.c_type(clean_typ)
+	ct := g.value_c_type(clean_typ)
 	if g.is_scalar_c_type(ct) {
 		g.write(g.scalar_zero_init(ct))
 		return
 	}
 	g.write('(${ct}){0}')
+}
+
+fn (g &FlatGen) enum_default_value_for_type(type_name string) ?int {
+	fields := g.enum_fields_for_type(type_name) or { return none }
+	if fields.len == 0 {
+		return none
+	}
+	if val := g.enum_value_for_type(type_name, fields[0]) {
+		return val
+	}
+	return 0
+}
+
+fn (g &FlatGen) enum_fields_for_type(type_name string) ?[]string {
+	if fields := g.tc.enum_fields[type_name] {
+		return fields
+	}
+	if !type_name.contains('.') && g.tc.cur_module.len > 0 && g.tc.cur_module != 'main'
+		&& g.tc.cur_module != 'builtin' {
+		qname := '${g.tc.cur_module}.${type_name}'
+		if fields := g.tc.enum_fields[qname] {
+			return fields
+		}
+	}
+	if !type_name.contains('.') {
+		mut found := []string{}
+		mut ok := false
+		for ename, fields in g.tc.enum_fields {
+			if ename.all_after_last('.') != type_name {
+				continue
+			}
+			if ok {
+				return none
+			}
+			found = fields.clone()
+			ok = true
+		}
+		if ok {
+			return found
+		}
+	}
+	return none
+}
+
+fn (mut g FlatGen) gen_default_value_addr_for_type(typ types.Type) {
+	ct := g.value_c_type(typ)
+	g.write('&(${ct}[]){')
+	g.gen_default_value_for_type(typ)
+	g.write('}')
 }
 
 fn (g &FlatGen) struct_field_value_is_plainly_incompatible(value_id flat.NodeId, field_type types.Type) bool {
@@ -755,6 +857,12 @@ fn (mut g FlatGen) struct_has_field_defaults_inner(type_name string, mut visited
 			if clean_ftyp is types.SumType || clean_ftyp is types.Interface {
 				return false
 			}
+			found = true
+		}
+		if clean_ftyp is types.String {
+			found = true
+		}
+		if clean_ftyp is types.Enum {
 			found = true
 		}
 		if clean_ftyp is types.Struct && !clean_ftyp.name.starts_with('C.') {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -1520,7 +1520,9 @@ fn (mut p Parser) interface_decl() flat.NodeId {
 			p.next() // skip (
 			mut params := []flat.NodeId{}
 			for p.tok != .rpar && p.tok != .eof {
+				mut is_mut := false
 				if p.tok == .key_mut {
+					is_mut = true
 					p.next()
 				}
 				// Interface method params may be named (e.g. `seed_data []u32`,
@@ -1537,10 +1539,14 @@ fn (mut p Parser) interface_decl() flat.NodeId {
 						p.next()
 					}
 				}
-				ptype := p.parse_type_name()
+				mut ptype := p.parse_type_name()
+				if is_mut && !ptype.starts_with('&') {
+					ptype = '&' + ptype
+				}
 				params << p.a.add_node(flat.Node{
 					kind: .param
 					typ:  ptype
+					op:   if is_mut { .amp } else { .none }
 				})
 				if p.tok == .comma {
 					p.next()

--- a/vlib/v3/tests/const_map_range_codegen_test.v
+++ b/vlib/v3/tests/const_map_range_codegen_test.v
@@ -1,0 +1,48 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn tmp_const_map_range_path(name string) string {
+	return os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+}
+
+fn build_v3_const_map_range() string {
+	v3_bin := tmp_const_map_range_path('const_map_range')
+	build :=
+		os.execute('${os.quoted_path(vexe)} -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(v3_src)}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn run_v3_const_map_range_program(v3_bin string, name string, src string) string {
+	src_path := '${tmp_const_map_range_path(name)}.v'
+	bin_path := tmp_const_map_range_path('${name}_bin')
+	os.write_file(src_path, src) or { panic(err) }
+	compile :=
+		os.execute('${os.quoted_path(v3_bin)} ${os.quoted_path(src_path)} -b c -o ${os.quoted_path(bin_path)}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(os.quoted_path(bin_path))
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
+}
+
+fn test_const_map_initializer_and_range_high_bound_review_fixes() {
+	v3_bin := build_v3_const_map_range()
+	const_map := run_v3_const_map_range_program(v3_bin, 'const_map_initializer',
+		"const m = map[string]int{\n\t'a': 1\n}\n\nfn main() {\n\tprintln(int_str(m['a']))\n}\n")
+	assert const_map == '1'
+	range_high := run_v3_const_map_range_program(v3_bin, 'range_high_once',
+		"__global calls int\n\nfn next_limit() int {\n\tcalls++\n\treturn 3\n}\n\nfn main() {\n\tmut total := 0\n\tfor i in 0 .. next_limit() {\n\t\ttotal += i\n\t}\n\tprintln(int_str(calls) + ':' + int_str(total))\n}\n")
+	assert range_high == '1:3'
+	range_order := run_v3_const_map_range_program(v3_bin, 'range_bound_order',
+		"__global events string\n\nfn low() int {\n\tevents += 'L'\n\treturn 0\n}\n\nfn high() int {\n\tevents += 'H'\n\treturn 2\n}\n\nfn main() {\n\tfor i in low() .. high() {\n\t\tevents += int_str(i)\n\t}\n\tprintln(events)\n}\n")
+	assert range_order == 'LH01'
+	formatted_map := run_v3_const_map_range_program(v3_bin, 'formatted_map_interpolation',
+		"fn main() {\n\tm := {\n\t\t'a': 1\n\t}\n\tprintln('\${m:10}')\n}\n")
+	assert formatted_map == "{'a': 1}"
+}

--- a/vlib/v3/tests/pointer_interface_str_codegen_test.v
+++ b/vlib/v3/tests/pointer_interface_str_codegen_test.v
@@ -1,0 +1,36 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn tmp_pointer_interface_str_path(name string) string {
+	return os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+}
+
+fn build_v3_pointer_interface_str() string {
+	v3_bin := tmp_pointer_interface_str_path('pointer_interface_str')
+	build :=
+		os.execute('${os.quoted_path(vexe)} -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(v3_src)}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn test_pointer_to_interface_stringification_uses_pointer_path() {
+	v3_bin := build_v3_pointer_interface_str()
+	src_path := '${tmp_pointer_interface_str_path('source')}.v'
+	bin_path := tmp_pointer_interface_str_path('bin')
+	os.write_file(src_path,
+		"interface Named {\n\tstr() string\n}\n\nstruct Item {}\n\nfn (i Item) str() string {\n\treturn 'item'\n}\n\nfn main() {\n\tmut value := Named(Item{})\n\tptr := &value\n\ttext := '\${ptr}'\n\tprintln(text.len > 0)\n}\n") or {
+		panic(err)
+	}
+	compile :=
+		os.execute('${os.quoted_path(v3_bin)} ${os.quoted_path(src_path)} -b c -o ${os.quoted_path(bin_path)}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(os.quoted_path(bin_path))
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'true'
+}

--- a/vlib/v3/transform/array.v
+++ b/vlib/v3/transform/array.v
@@ -281,6 +281,9 @@ fn (mut t Transformer) make_struct_runtime_default_value(struct_type string) ?fl
 
 // lower_array_literal_to_runtime converts lower array literal to runtime data for transform.
 fn (mut t Transformer) lower_array_literal_to_runtime(id flat.NodeId, node flat.Node) flat.NodeId {
+	if t.in_const_init {
+		return id
+	}
 	array_type := if checker_alias_type := t.array_literal_checker_alias_type(id) {
 		checker_alias_type
 	} else if alias_type := t.array_literal_alias_type(node) {
@@ -403,12 +406,16 @@ fn (t &Transformer) array_literal_alias_type(node flat.Node) ?string {
 
 // transform_array_literal_for_type transforms transform array literal for type data for transform.
 fn (mut t Transformer) transform_array_literal_for_type(id flat.NodeId, node flat.Node, target_type string) ?flat.NodeId {
-	array_type := if checker_alias_type := t.array_literal_checker_alias_type(id) {
+	target_array_type := t.normalize_type_alias(target_type)
+	array_type := if target_array_type.starts_with('[]')
+		&& t.is_sum_type_name(target_array_type[2..]) {
+		target_array_type
+	} else if checker_alias_type := t.array_literal_checker_alias_type(id) {
 		checker_alias_type
 	} else if alias_type := t.array_literal_alias_type(node) {
 		alias_type
 	} else {
-		t.normalize_type_alias(target_type)
+		target_array_type
 	}
 	if !array_type.starts_with('[]') {
 		return none

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -22,6 +22,9 @@ fn (mut t Transformer) transform_infix_string_ops(_id flat.NodeId, node flat.Nod
 	rhs_raw_type := t.node_type(rhs_id)
 	lhs_clean_type := t.normalize_type_alias(lhs_raw_type)
 	rhs_clean_type := t.normalize_type_alias(rhs_raw_type)
+	if _ := t.operator_alias_type_for_operand(lhs_id, node.op) {
+		return none
+	}
 	lhs_is_string_ptr := t.equality_expr_is_string_pointer(lhs_id, lhs_clean_type)
 	rhs_is_string_ptr := t.equality_expr_is_string_pointer(rhs_id, rhs_clean_type)
 	if node.op in [.plus, .eq, .ne] && (lhs_is_string_ptr || rhs_is_string_ptr) {
@@ -116,6 +119,9 @@ fn (mut t Transformer) transform_infix_array_ops(_id flat.NodeId, node flat.Node
 	lhs_is_array_ptr := t.equality_type_is_array_pointer(lhs_raw_type)
 	rhs_is_array_ptr := t.equality_type_is_array_pointer(rhs_raw_type)
 	if lhs_is_array_ptr && rhs_is_array_ptr {
+		return none
+	}
+	if _ := t.operator_alias_type_for_operand(lhs_id, node.op) {
 		return none
 	}
 	mut lhs_type := t.membership_container_type(lhs_raw_type)
@@ -297,8 +303,8 @@ fn (mut t Transformer) transform_infix_struct_ops(_id flat.NodeId, node flat.Nod
 	}
 	mut is_alias_operator := false
 	if struct_type.len == 0 {
-		if _ := t.struct_operator_call_info(lhs_type, node.op) {
-			struct_type = lhs_type
+		if alias_type := t.operator_alias_type_for_operand(lhs_id, node.op) {
+			struct_type = alias_type
 			is_alias_operator = true
 		}
 	}
@@ -474,12 +480,85 @@ fn (t &Transformer) checker_node_type(id flat.NodeId) string {
 	if isnil(t.tc) || int(id) < 0 {
 		return ''
 	}
+	name := t.raw_checker_node_type(id)
+	if name.len == 0 || name == 'void' {
+		return ''
+	}
+	return t.normalize_type_alias(name)
+}
+
+fn (t &Transformer) raw_checker_node_type(id flat.NodeId) string {
+	if isnil(t.tc) || int(id) < 0 {
+		return ''
+	}
 	typ := t.tc.expr_type(id) or { t.tc.resolve_type(id) }
 	name := typ.name()
 	if name.len == 0 || name == 'void' {
 		return ''
 	}
-	return t.normalize_type_alias(name)
+	return name
+}
+
+fn (t &Transformer) raw_alias_type_for_expr(id flat.NodeId) string {
+	raw_type := t.raw_checker_node_type(id)
+	if raw_type.len == 0 {
+		return ''
+	}
+	is_ptr := raw_type.starts_with('&')
+	clean := t.trim_pointer_type(raw_type)
+	if t.is_type_alias_name(clean) {
+		return raw_type
+	}
+	if is_ptr {
+		return ''
+	}
+	return ''
+}
+
+fn (t &Transformer) is_type_alias_name(name string) bool {
+	if isnil(t.tc) || name.len == 0 {
+		return false
+	}
+	if name in t.tc.type_aliases {
+		return true
+	}
+	if !name.contains('.') && t.cur_module.len > 0 && t.cur_module != 'main'
+		&& t.cur_module != 'builtin' {
+		return '${t.cur_module}.${name}' in t.tc.type_aliases
+	}
+	if !name.contains('.') {
+		for aname, _ in t.tc.type_aliases {
+			if aname.all_after_last('.') == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+fn (t &Transformer) operator_alias_type_for_operand(id flat.NodeId, op flat.Op) ?string {
+	if int(id) < 0 {
+		return none
+	}
+	node := t.a.nodes[int(id)]
+	mut candidates := []string{cap: 3}
+	raw_type := t.raw_checker_node_type(id)
+	if raw_type.len > 0 {
+		candidates << raw_type
+	}
+	if node.typ.len > 0 {
+		candidates << node.typ
+	}
+	for candidate in candidates {
+		clean := t.trim_pointer_type(candidate)
+		if clean.len == 0 || !t.is_type_alias_name(clean) {
+			continue
+		}
+		if _ := t.struct_operator_call_info(clean, op) {
+			return clean
+		}
+	}
+	return none
 }
 
 // StructOperatorCallInfo stores struct operator call info metadata used by transform.

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -133,9 +133,6 @@ fn (t &Transformer) resolve_receiver_method_name(base_id flat.NodeId, method str
 	if base_type.len == 0 {
 		return ''
 	}
-	if method_name := t.resolve_receiver_method_for_type(base_type, method) {
-		return method_name
-	}
 	mut raw_var_clean := ''
 	if raw_var_type := t.raw_var_type_for_expr(base_id) {
 		raw_clean := if raw_var_type.starts_with('&') {
@@ -145,6 +142,9 @@ fn (t &Transformer) resolve_receiver_method_name(base_id flat.NodeId, method str
 		}
 		raw_var_clean = raw_clean
 		if raw_clean.len > 0 && raw_clean != base_type {
+			if alias_method := t.resolve_alias_receiver_method(raw_clean, method) {
+				return alias_method
+			}
 			if method_name := t.resolve_receiver_method_for_type(raw_clean, method) {
 				return method_name
 			}
@@ -157,6 +157,9 @@ fn (t &Transformer) resolve_receiver_method_name(base_id flat.NodeId, method str
 			raw_const_type
 		}
 		if raw_clean.len > 0 && raw_clean != base_type && raw_clean != raw_var_clean {
+			if alias_method := t.resolve_alias_receiver_method(raw_clean, method) {
+				return alias_method
+			}
 			if method_name := t.resolve_receiver_method_for_type(raw_clean, method) {
 				return method_name
 			}
@@ -164,6 +167,9 @@ fn (t &Transformer) resolve_receiver_method_name(base_id flat.NodeId, method str
 	}
 	if alias_method := t.resolve_alias_receiver_method(base_type, method) {
 		return alias_method
+	}
+	if method_name := t.resolve_receiver_method_for_type(base_type, method) {
+		return method_name
 	}
 	if embedded_method := t.resolve_embedded_receiver_method(base_type, method) {
 		return embedded_method
@@ -371,7 +377,7 @@ fn (t &Transformer) raw_var_type_for_expr(id flat.NodeId) ?string {
 	}
 	node := t.a.nodes[int(id)]
 	if node.kind == .ident {
-		typ := t.var_type(node.value)
+		typ := t.raw_var_type(node.value)
 		if typ.len > 0 {
 			return typ
 		}
@@ -1604,6 +1610,16 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 	if clean_typ == 'string' {
 		return expr
 	}
+	iface_name := t.resolve_interface_type_name(clean_typ)
+	if !is_ref && iface_name.len > 0 {
+		if 'str' in t.tc.interface_abstract_method_names(iface_name) {
+			value := t.stable_transformed_expr_for_reuse(expr, clean_typ, 'iface_str')
+			method_name := '${iface_name}.str'
+			t.mark_fn_used_name(method_name)
+			t.mark_interface_method_implementers_used(iface_name, 'str')
+			return t.make_call_typed(method_name, arr1(t.make_prefix(.amp, value)), 'string')
+		}
+	}
 	if is_ref || clean_typ in ['voidptr', 'byteptr', 'charptr'] {
 		return t.make_call_typed('ptr_str', arr1(expr), 'string')
 	}
@@ -1697,6 +1713,17 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 	}
 }
 
+fn (mut t Transformer) mark_interface_method_implementers_used(iface_name string, method string) {
+	if isnil(t.tc) {
+		return
+	}
+	for concrete, _ in t.tc.structs {
+		if t.tc.named_type_implements_interface(concrete, iface_name) {
+			t.mark_fn_used_name('${concrete}.${method}')
+		}
+	}
+}
+
 fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ string, format string) flat.NodeId {
 	if format.len == 0 {
 		return t.wrap_string_conversion(expr, typ)
@@ -1708,15 +1735,21 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	if clean_typ.starts_with('builtin.') {
 		clean_typ = clean_typ.all_after_last('.')
 	}
-	if precision := fixed_decimal_precision(format) {
+	if decimal_format := fixed_decimal_format(format) {
 		if clean_typ in ['f32', 'f64', 'float_literal'] {
 			arg := if clean_typ == 'f64' {
 				expr
 			} else {
 				t.make_cast('f64', expr, 'f64')
 			}
-			return t.make_call_typed('v3_f64_fixed', arr2(arg, t.make_int_literal(precision)),
-				'string')
+			mut formatted := t.make_call_typed('v3_f64_fixed', arr2(arg,
+				t.make_int_literal(decimal_format.precision)), 'string')
+			if decimal_format.width > 0 || decimal_format.left {
+				left := if decimal_format.left { 1 } else { 0 }
+				formatted = t.make_call_typed('v3_string_pad', arr3(formatted,
+					t.make_int_literal(decimal_format.width), t.make_int_literal(left)), 'string')
+			}
+			return formatted
 		}
 	}
 	if format == 'c' {
@@ -1766,26 +1799,60 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	return t.wrap_string_conversion(expr, typ)
 }
 
-fn fixed_decimal_precision(format string) ?int {
-	if format.len < 3 || format[format.len - 1] != `f` {
+struct FixedDecimalFormat {
+	width     int
+	precision int
+	left      bool
+}
+
+fn fixed_decimal_format(format string) ?FixedDecimalFormat {
+	if format.len < 2 {
 		return none
 	}
-	start := if format[0] == `.` {
-		1
-	} else if format.len >= 4 && format[0] == `0` && format[1] == `.` {
-		2
-	} else {
+	mut i := 0
+	mut left := false
+	if i < format.len && format[i] == `-` {
+		left = true
+		i++
+	}
+	if i < format.len && format[i] == `0` {
+		i++
+	}
+	mut width := 0
+	for i < format.len && format[i] >= `0` && format[i] <= `9` {
+		width = width * 10 + int(format[i] - `0`)
+		i++
+	}
+	if i >= format.len || format[i] != `.` {
 		return none
 	}
-	mut n := 0
-	for i in start .. format.len - 1 {
-		ch := format[i]
-		if ch < `0` || ch > `9` {
+	i++
+	mut precision := 0
+	mut has_precision := false
+	for i < format.len && format[i] >= `0` && format[i] <= `9` {
+		has_precision = true
+		precision = precision * 10 + int(format[i] - `0`)
+		i++
+	}
+	if !has_precision {
+		return none
+	}
+	if i < format.len {
+		if format[i] != `f` {
 			return none
 		}
-		n = n * 10 + int(ch - `0`)
+		i++
+	} else if precision > 0 {
+		precision--
 	}
-	return n
+	if i != format.len {
+		return none
+	}
+	return FixedDecimalFormat{
+		width:     width
+		precision: precision
+		left:      left
+	}
 }
 
 fn integer_format_base(format string) ?int {
@@ -1871,6 +1938,10 @@ fn (mut t Transformer) lower_array_str(arr_expr flat.NodeId, base_type string) f
 		loop_body << t.append_string(result_name, t.make_string_literal("'"))
 		loop_body << t.append_string(result_name, elem_str)
 		loop_body << t.append_string(result_name, t.make_string_literal("'"))
+	} else if elem_type == 'rune' {
+		loop_body << t.append_string(result_name, t.make_string_literal('`'))
+		loop_body << t.append_string(result_name, elem_str)
+		loop_body << t.append_string(result_name, t.make_string_literal('`'))
 	} else {
 		loop_body << t.append_string(result_name, elem_str)
 	}
@@ -3231,6 +3302,19 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 	if base_type.starts_with('[]') || base_type.starts_with('map[') {
 		if base_type.starts_with('[]') {
 			return none
+		}
+	}
+	if !isnil(t.tc) {
+		if resolved_method := t.tc.resolved_call_name(id) {
+			if t.is_known_fn_name(resolved_method) {
+				params := t.call_param_types(resolved_method)
+				if t.resolved_call_uses_receiver_type(base_id, base_type, params) {
+					args := t.transform_receiver_method_args_with_base(node, t.receiver_base_for_resolved_method(base_id,
+						resolved_method), resolved_method)
+					ret_type := t.receiver_method_return_type(resolved_method, node.typ)
+					return t.make_call_typed(resolved_method, args, ret_type)
+				}
+			}
 		}
 	}
 	method_name := t.resolve_receiver_method_name(base_id, method)

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -284,9 +284,9 @@ fn (mut t Transformer) lower_range_for_in(id flat.NodeId, node flat.Node, key_id
 		return arr1(id)
 	}
 	range_type := t.range_loop_var_type_name(low_id)
-	t.set_var_type(key.value, range_type)
-	low := t.transform_expr(low_id)
+	low := t.stable_expr_for_reuse(low_id)
 	high := t.stable_expr_for_reuse(high_id)
+	t.set_var_type(key.value, range_type)
 	mut prefix := []flat.NodeId{}
 	t.drain_pending(mut prefix)
 	init := t.make_decl_assign_typed(key.value, low, range_type)

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -850,6 +850,12 @@ fn (mut t Transformer) specialized_fn_return_type_text(decl GenericFnDecl, args 
 		decl.module))
 }
 
+fn (mut t Transformer) specialized_fn_return_display_type_text(decl GenericFnDecl, args []string) string {
+	substituted := substitute_generic_type_text_with_params(decl.node.typ, args, t.generic_fn_param_names(decl.node,
+		decl.module))
+	return t.qualify_specialized_signature_type_text(substituted, decl)
+}
+
 fn (mut t Transformer) specialized_signature_type_text(decl GenericFnDecl, typ string, args []string, params []string) string {
 	substituted := substitute_generic_type_text_with_params(typ, args, params)
 	qualified := t.qualify_specialized_signature_type_text(substituted, decl)
@@ -1034,6 +1040,33 @@ fn (mut t Transformer) concrete_generic_call_return_type(id flat.NodeId, node fl
 		return ''
 	}
 	return t.normalize_type_alias(ret)
+}
+
+fn (mut t Transformer) raw_generic_call_return_type(id flat.NodeId, node flat.Node) string {
+	if t.skip_generics {
+		return ''
+	}
+	if node.kind != .call || node.children_count == 0 {
+		return ''
+	}
+	decls := t.cached_generic_fn_decls()
+	if decls.len == 0 {
+		return ''
+	}
+	decl_key := t.generic_call_decl_key(id, node, t.cur_module, decls) or { return '' }
+	decl := decls[decl_key] or { return '' }
+	if t.should_skip_generic_call_specialization(decl_key) {
+		return ''
+	}
+	args := t.explicit_generic_call_args(node, t.cur_module) or { return '' }
+	if args.len == 0 || t.generic_args_have_placeholders(args) {
+		return ''
+	}
+	ret := t.specialized_fn_return_display_type_text(decl, args)
+	if ret.len == 0 || t.generic_arg_is_unresolved(ret) {
+		return ''
+	}
+	return ret
 }
 
 fn (mut t Transformer) concrete_generic_call_param_types(id flat.NodeId, node flat.Node) ?[]types.Type {

--- a/vlib/v3/transform/struct.v
+++ b/vlib/v3/transform/struct.v
@@ -296,9 +296,36 @@ fn (t &Transformer) lookup_struct_info(name string) ?StructInfo {
 	if info := t.lookup_struct_info_preferred(name) {
 		return info
 	}
+	if imported := t.resolve_imported_type_name(name) {
+		if info := t.lookup_struct_info_direct(imported) {
+			return info
+		}
+	}
 	normalized := t.normalize_type_alias(name)
 	if normalized != name {
 		return t.lookup_struct_info_direct(normalized)
+	}
+	return none
+}
+
+fn (t &Transformer) resolve_imported_type_name(name string) ?string {
+	if isnil(t.tc) || !name.contains('.') || name.starts_with('C.') {
+		return none
+	}
+	dot := name.index_u8(`.`)
+	if dot <= 0 {
+		return none
+	}
+	alias := name[..dot]
+	if mod := t.tc.file_imports[file_import_key(t.cur_file, alias)] {
+		if mod != alias {
+			return mod + name[dot..]
+		}
+	}
+	if mod := t.tc.imports[alias] {
+		if mod != alias {
+			return mod + name[dot..]
+		}
 	}
 	return none
 }
@@ -432,12 +459,13 @@ fn (mut t Transformer) transform_assoc_expr(id flat.NodeId, node flat.Node) flat
 		}
 		value_type := t.node_type(value_id)
 		enum_field_type := t.enum_type_name_for_expected(field_type, assoc_module)
+		sum_field_type := t.struct_field_sum_type(field_type, assoc_module)
 		value := if value_node.kind == .enum_val && enum_field_type.len > 0 {
 			t.transform_enum_shorthand(value_id, value_node, enum_field_type)
 		} else if field_type.starts_with('[]') && t.is_fixed_array_type(value_type) {
 			t.fixed_array_value_to_array(value_id, value_type, field_type)
-		} else if t.is_sum_type_name(field_type) {
-			t.wrap_sum_value(value_id, field_type)
+		} else if sum_field_type.len > 0 {
+			t.wrap_sum_value(value_id, sum_field_type)
 		} else if field_type.len > 0 {
 			t.transform_expr_for_type(value_id, field_type)
 		} else {
@@ -495,6 +523,10 @@ fn (mut t Transformer) transform_amp_assoc_expr_for_type(_id flat.NodeId, node f
 
 // struct_field_sum_type supports struct field sum type handling for Transformer.
 fn (t &Transformer) struct_field_sum_type(field_type string, owner_module string) string {
+	if field_type.starts_with('[]') || field_type.starts_with('map[')
+		|| t.is_fixed_array_type(field_type) {
+		return ''
+	}
 	if t.is_sum_type_name(field_type) {
 		return field_type
 	}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -181,8 +181,9 @@ struct StructFieldLookup {
 
 // VarTypeBinding represents var type binding data used by transform.
 struct VarTypeBinding {
-	name string
-	typ  string
+	name    string
+	typ     string
+	raw_typ string
 }
 
 struct GenericFnDecl {
@@ -382,21 +383,28 @@ fn (mut t Transformer) reset_var_types() {
 
 // set_var_type updates set var type state for transform.
 fn (mut t Transformer) set_var_type(name string, typ string) {
+	t.set_var_type_with_raw(name, typ, typ)
+}
+
+fn (mut t Transformer) set_var_type_with_raw(name string, typ string, raw_typ string) {
 	if name.len == 0 {
 		return
 	}
+	raw := if raw_typ.len > 0 { raw_typ } else { typ }
 	for i, binding in t.var_types {
 		if binding.name == name {
 			t.var_types[i] = VarTypeBinding{
-				name: name
-				typ:  typ
+				name:    name
+				typ:     typ
+				raw_typ: raw
 			}
 			return
 		}
 	}
 	t.var_types << VarTypeBinding{
-		name: name
-		typ:  typ
+		name:    name
+		typ:     typ
+		raw_typ: raw
 	}
 }
 
@@ -414,6 +422,18 @@ fn (mut t Transformer) unset_var_type(name string) {
 fn (t &Transformer) var_type(name string) string {
 	for binding in t.var_types {
 		if binding.name == name {
+			return binding.typ
+		}
+	}
+	return ''
+}
+
+fn (t &Transformer) raw_var_type(name string) string {
+	for binding in t.var_types {
+		if binding.name == name {
+			if binding.raw_typ.len > 0 {
+				return binding.raw_typ
+			}
 			return binding.typ
 		}
 	}
@@ -1212,7 +1232,8 @@ fn (mut t Transformer) transform_const_decl(node flat.Node) {
 				const_typ := t.const_field_type_name(cf)
 				new_val := t.transform_const_or_expr(val_id, val, const_typ)
 				t.a.children[cf.children_start] = new_val
-			} else if val.kind == .struct_init || val.kind == .cast_expr || val.kind == .call {
+			} else if val.kind in [.struct_init, .cast_expr, .call, .array_literal, .fn_literal,
+				.lambda_expr] {
 				new_val := t.transform_expr(val_id)
 				t.a.children[cf.children_start] = new_val
 			} else if val.kind == .infix && val.children_count >= 2 {
@@ -1341,6 +1362,9 @@ fn (mut t Transformer) transform_const_value(id flat.NodeId) flat.NodeId {
 	if block_val := t.const_block_value(node) {
 		return t.transform_const_value(block_val)
 	}
+	if node.kind == .map_init {
+		return id
+	}
 	return t.transform_expr(id)
 }
 
@@ -1398,7 +1422,10 @@ fn (mut t Transformer) transform_string_interp_part(child_id flat.NodeId) flat.N
 		format = child.typ
 	}
 	mut transformed := t.transform_expr(expr_id)
-	mut typ := t.node_type(transformed)
+	mut typ := t.raw_alias_type_for_expr(expr_id)
+	if typ.len == 0 {
+		typ = t.node_type(transformed)
+	}
 	if typ.len == 0 {
 		typ = t.reliable_stringify_type(transformed)
 	}
@@ -1654,7 +1681,11 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 		}
 		child := t.a.nodes[int(child_id)]
 		if node_kind_id(child) == 75 && child.value.len > 0 && child.typ.len > 0 {
-			raw_typ := t.normalize_type_alias(child.typ)
+			raw_typ := if child.typ.starts_with('...') {
+				'[]' + t.normalize_type_alias(child.typ[3..])
+			} else {
+				t.normalize_type_alias(child.typ)
+			}
 			mut typ := if raw_typ.len > 0 {
 				raw_typ
 			} else if param_idx < param_types.len {
@@ -3531,7 +3562,14 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 				}
 			}
 			if typ.len > 0 {
-				t.set_var_type(lhs.value, typ)
+				mut raw_typ := t.raw_decl_type_for_rhs(rhs, typ)
+				if rhs.kind == .call {
+					generic_raw_typ := t.raw_generic_call_return_type(rhs_id, rhs)
+					if generic_raw_typ.len > 0 {
+						raw_typ = generic_raw_typ
+					}
+				}
+				t.set_var_type_with_raw(lhs.value, typ, raw_typ)
 				inferred_typ = typ
 			}
 		}
@@ -5788,7 +5826,13 @@ fn (mut t Transformer) transform_typeof_expr(id flat.NodeId, node flat.Node) fla
 	if expr.kind == .int_literal {
 		return t.make_string_literal('int literal')
 	}
-	mut typ := t.node_type(expr_id)
+	mut typ := ''
+	if expr.kind == .ident {
+		typ = t.raw_var_type(expr.value)
+	}
+	if typ.len == 0 {
+		typ = t.node_type(expr_id)
+	}
 	if typ.len == 0 {
 		typ = t.reliable_stringify_type(expr_id)
 	}
@@ -5822,7 +5866,14 @@ fn (t &Transformer) typeof_type_name(node flat.Node) string {
 		return ''
 	}
 	expr_id := t.a.child(&node, 0)
-	mut typ := t.node_type(expr_id)
+	expr := t.a.nodes[int(expr_id)]
+	mut typ := ''
+	if expr.kind == .ident {
+		typ = t.raw_var_type(expr.value)
+	}
+	if typ.len == 0 {
+		typ = t.node_type(expr_id)
+	}
 	if typ.len == 0 {
 		typ = t.reliable_stringify_type(expr_id)
 	}
@@ -6570,6 +6621,22 @@ fn (t &Transformer) infer_decl_type(node &flat.Node) string {
 	return ''
 }
 
+fn (t &Transformer) raw_decl_type_for_rhs(rhs flat.Node, fallback string) string {
+	if rhs.kind == .struct_init && rhs.value.len > 0 && !isnil(t.tc) {
+		if rhs.value in t.tc.type_aliases {
+			return rhs.value
+		}
+		if !rhs.value.contains('.') && t.cur_module.len > 0 && t.cur_module != 'main'
+			&& t.cur_module != 'builtin' {
+			qname := '${t.cur_module}.${rhs.value}'
+			if qname in t.tc.type_aliases {
+				return qname
+			}
+		}
+	}
+	return fallback
+}
+
 // resolve_expr_type resolves resolve expr type information for transform.
 fn (t &Transformer) resolve_expr_type(id flat.NodeId) string {
 	if int(id) < 0 {
@@ -6641,6 +6708,12 @@ fn (t &Transformer) resolve_expr_type(id flat.NodeId) string {
 			return node.typ
 		}
 		.array_literal {
+			if node.children_count > 0 {
+				elem_type := t.node_type(t.a.child(&node, 0))
+				if t.is_fn_pointer_type_name(elem_type) {
+					return '[]${elem_type}'
+				}
+			}
 			if node.typ.len > 0 {
 				typ := t.normalize_type_alias(node.typ)
 				if typ != 'array' {

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -44,7 +44,7 @@ fn (mut t Transformer) propagate_decl_pair_type(node flat.Node, lhs_idx int, rhs
 		}
 	}
 	if typ.len > 0 {
-		t.set_var_type(lhs.value, t.normalize_type_alias(typ))
+		t.set_var_type_with_raw(lhs.value, t.normalize_type_alias(typ), typ)
 	}
 }
 
@@ -945,6 +945,14 @@ fn (t &Transformer) node_type(id flat.NodeId) string {
 		return resolved
 	}
 	node := t.a.nodes[int(id)]
+	if node.kind == .dump_expr && node.children_count > 0 {
+		return t.node_type(t.a.child(&node, 0))
+	}
+	if node.kind == .fn_literal || node.kind == .lambda_expr {
+		if fn_type := t.fn_value_type_name(id) {
+			return fn_type
+		}
+	}
 	mut deferred_call_typ := ''
 	if node.typ.len > 0 {
 		node_typ := t.normalize_type_alias(node.typ)

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4626,6 +4626,36 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 	if info := tc.resolve_generic_call_info(id, fn_node) {
 		return info
 	}
+	if fn_node.kind == .ident {
+		fn_id := tc.a.child(&node, 0)
+		mut fn_type := Type(void_)
+		if smart_type := tc.smartcast_type(fn_id) {
+			fn_type = smart_type
+		} else if typ := tc.cur_scope.lookup(fn_node.value) {
+			fn_type = typ
+		} else if typ := tc.file_scope.lookup(fn_node.value) {
+			fn_type = typ
+		}
+		if fn_typ := fn_type_from_type(fn_type) {
+			return CallInfo{
+				name:         ''
+				params:       fn_typ.params.clone()
+				return_type:  fn_typ.return_type
+				params_known: true
+			}
+		}
+	}
+	if fn_node.kind !in [.ident, .selector] {
+		fn_type := tc.resolve_type(tc.a.child(&node, 0))
+		if fn_typ := fn_type_from_type(fn_type) {
+			return CallInfo{
+				name:         ''
+				params:       fn_typ.params.clone()
+				return_type:  fn_typ.return_type
+				params_known: true
+			}
+		}
+	}
 	if fn_node.kind == .selector {
 		base_id := tc.a.child(fn_node, 0)
 		base_node := tc.a.nodes[int(base_id)]

--- a/vlib/v3/v3_test_failures.txt
+++ b/vlib/v3/v3_test_failures.txt
@@ -81,7 +81,6 @@ vlib/context/empty_test.v
 vlib/context/onecontext/onecontext_test.v
 vlib/context/value_test.v
 vlib/crypto/aes/aes_gcm_test.v
-vlib/crypto/aes/block_generic_test.v
 vlib/crypto/blake3/blake3_block_test.v
 vlib/crypto/blake3/blake3_chunk_test.v
 vlib/crypto/blake3/blake3_test.v
@@ -159,11 +158,8 @@ vlib/encoding/txtar/txtar_test.v
 vlib/encoding/utf8/east_asian/east_asian_width_test.v
 vlib/encoding/utf8/utf8_is_punct_test.v
 vlib/encoding/utf8/utf8_util_test.v
-vlib/encoding/xml/encoding_test.v
 vlib/encoding/xml/entity_test.v
-vlib/encoding/xml/newline_test.v
 vlib/encoding/xml/parser_test.v
-vlib/encoding/xml/query_test.v
 vlib/encoding/xml/test/local/01_mdn_example/hello_world_test.v
 vlib/encoding/xml/test/local/02_note_message/note_test.v
 vlib/encoding/xml/test/local/03_cd_catalogue/cd_test.v
@@ -176,7 +172,6 @@ vlib/encoding/xml/test/local/12_doctype_entity/spec_entity_test.v
 vlib/encoding/xml/test/local/13_doctype_element/doctype_test.v
 vlib/encoding/xml/test/local/14_attributes/attributes_test.v
 vlib/encoding/xml/test/local/19_single_letter_tag/shared_test.v
-vlib/encoding/xml/test/local/20_bom_file/bom_test.v
 vlib/encoding/xml/test/spec_test.v
 vlib/eventbus/eventbus_test.v
 vlib/fasthttp/fasthttp_linux_regression_test.v
@@ -450,7 +445,6 @@ vlib/sync/once_with_param_test.v
 vlib/sync/pool/pool_test.v
 vlib/sync/rwmutex_test.v
 vlib/sync/select_close_test.v
-vlib/sync/spinlock_test.v
 vlib/sync/stdatomic/atomic_test.v
 vlib/sync/struct_chan_init_test.v
 vlib/sync/thread_test.v
@@ -562,13 +556,11 @@ vlib/v/slow_tests/profile/profile_test.v
 vlib/v/slow_tests/repl/repl_test.v
 vlib/v/tests/aliases/alias_array_fixed_sumtype_test.v
 vlib/v/tests/aliases/alias_array_no_cast_init_test.v
-vlib/v/tests/aliases/alias_array_operator_overloading_test.v
 vlib/v/tests/aliases/alias_array_plus_operator_test.v
 vlib/v/tests/aliases/alias_array_returned_as_interface_test.v
 vlib/v/tests/aliases/alias_basic_types_test.v
 vlib/v/tests/aliases/alias_const_array_fixed_test.v
 vlib/v/tests/aliases/alias_custom_type_map_test.v
-vlib/v/tests/aliases/alias_fixed_arr_test.v
 vlib/v/tests/aliases/alias_fixed_array_infix_expr_test.v
 vlib/v/tests/aliases/alias_fixed_array_init_test.v
 vlib/v/tests/aliases/alias_fixed_array_of_struct_test.v
@@ -583,7 +575,6 @@ vlib/v/tests/aliases/alias_map_clone_test.v
 vlib/v/tests/aliases/alias_map_keys_test.v
 vlib/v/tests/aliases/alias_map_operator_overloading_test.v
 vlib/v/tests/aliases/alias_map_test.v
-vlib/v/tests/aliases/alias_operator_overloading_test.v
 vlib/v/tests/aliases/alias_pointer_struct_field_default_nil_test.v
 vlib/v/tests/aliases/alias_primitive_operator_overloading_test.v
 vlib/v/tests/aliases/alias_set_elem_to_alias_of_fixed_array_test.v
@@ -599,7 +590,6 @@ vlib/v/tests/aliases/aliased_option_fn_call_test.v
 vlib/v/tests/aliases/array_alias_test.v
 vlib/v/tests/aliases/chained_alias_test.v
 vlib/v/tests/aliases/modules/value/value_test.v
-vlib/v/tests/aliases/numeric_alias_empty_init_test.v
 vlib/v/tests/aliases/strings_builder_alias_array_method_test.v
 vlib/v/tests/aliases/type_alias_of_pointer_types_test.v
 vlib/v/tests/aliases/type_alias_str_method_override_test.v
@@ -635,15 +625,12 @@ vlib/v/tests/builtin_arrays/array_count_test.v
 vlib/v/tests/builtin_arrays/array_delete_last_test.v
 vlib/v/tests/builtin_arrays/array_filter_of_fn_mut_arg_test.v
 vlib/v/tests/builtin_arrays/array_fixed_auto_clone_test.v
-vlib/v/tests/builtin_arrays/array_fixed_empty_struct_test.v
 vlib/v/tests/builtin_arrays/array_fixed_map_values_test.v
 vlib/v/tests/builtin_arrays/array_fixed_op_overload_test.v
 vlib/v/tests/builtin_arrays/array_fixed_ptr_test.v
-vlib/v/tests/builtin_arrays/array_get_anon_fn_value_test.v
 vlib/v/tests/builtin_arrays/array_index_option_test.v
 vlib/v/tests/builtin_arrays/array_init_call_order_test.v
 vlib/v/tests/builtin_arrays/array_init_element_size_equal_array_size_test.v
-vlib/v/tests/builtin_arrays/array_init_fixed_test.v
 vlib/v/tests/builtin_arrays/array_init_test.v
 vlib/v/tests/builtin_arrays/array_init_with_fields_test.v
 vlib/v/tests/builtin_arrays/array_init_with_spread_test.v
@@ -651,10 +638,6 @@ vlib/v/tests/builtin_arrays/array_map_cast_interface_test.v
 vlib/v/tests/builtin_arrays/array_map_ref_it_test.v
 vlib/v/tests/builtin_arrays/array_map_ref_test.v
 vlib/v/tests/builtin_arrays/array_methods_test.v
-vlib/v/tests/builtin_arrays/array_of_alias_op_overload_test.v
-vlib/v/tests/builtin_arrays/array_of_anon_fn_call_test.v
-vlib/v/tests/builtin_arrays/array_of_fns_index_call_with_direct_array_access_test.v
-vlib/v/tests/builtin_arrays/array_of_fns_index_call_with_embeded_array_call_test.v
 vlib/v/tests/builtin_arrays/array_of_functions_direct_call_test.v
 vlib/v/tests/builtin_arrays/array_of_interfaces_builtin_method_test.v
 vlib/v/tests/builtin_arrays/array_of_interfaces_equality_test.v
@@ -678,7 +661,6 @@ vlib/v/tests/builtin_arrays/array_with_it_test.v
 vlib/v/tests/builtin_arrays/arraydecompose_nonvariadic_test.v
 vlib/v/tests/builtin_arrays/arrays_and_maps_of_empty_structs_should_work_test.v
 vlib/v/tests/builtin_arrays/dump_fixed_array_on_array_append_test.v
-vlib/v/tests/builtin_arrays/fixed_array_2_test.v
 vlib/v/tests/builtin_arrays/fixed_array_chan_test.v
 vlib/v/tests/builtin_arrays/fixed_array_const_size_test.v
 vlib/v/tests/builtin_arrays/fixed_array_generic_ini_test.v
@@ -716,7 +698,6 @@ vlib/v/tests/builtin_maps/map_enum_keys_test.v
 vlib/v/tests/builtin_maps/map_fn_test.v
 vlib/v/tests/builtin_maps/map_generic_call_test.v
 vlib/v/tests/builtin_maps/map_get_anon_fn_value_test.v
-vlib/v/tests/builtin_maps/map_get_anon_fn_value_with_mut_arg_test.v
 vlib/v/tests/builtin_maps/map_high_order_assign_test.v
 vlib/v/tests/builtin_maps/map_init_with_enum_keys_test.v
 vlib/v/tests/builtin_maps/map_init_with_multi_enum_keys_test.v
@@ -726,7 +707,6 @@ vlib/v/tests/builtin_maps/map_selector_assign_test.v
 vlib/v/tests/builtin_maps/map_sumtype_value_init_test.v
 vlib/v/tests/builtin_maps/map_to_string_test.v
 vlib/v/tests/builtin_maps/map_type_alias_test.v
-vlib/v/tests/builtin_maps/map_value_init_test.v
 vlib/v/tests/builtin_maps/map_value_ref_interp_test.v
 vlib/v/tests/builtin_maps/map_value_with_option_result_test.v
 vlib/v/tests/builtin_maps/map_with_selector_test.v
@@ -743,7 +723,6 @@ vlib/v/tests/builtin_strings_and_interpolation/string_index_or_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_alias_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_array_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_custom_str_test.v
-vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_floats_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_function_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_multi_level_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_multi_return_test.v
@@ -760,7 +739,6 @@ vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_with_inner_q
 vlib/v/tests/builtin_strings_and_interpolation/string_ref_struct_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_struct_interpolation_test.v
 vlib/v/tests/builtin_strings_and_interpolation/tag_autostr_allowrecurse_test.v
-vlib/v/tests/builtin_strings_and_interpolation/vargs_auto_str_method_and_println_test.v
 vlib/v/tests/c_shadowed_c_fn_call_test.v
 vlib/v/tests/c_struct_with_reserved_field_name_test.v
 vlib/v/tests/c_structs/return_csize_test.v
@@ -972,7 +950,6 @@ vlib/v/tests/concurrency/spawn_ref_arg_stack_escape_test.v
 vlib/v/tests/concurrency/spawn_with_different_method_receivers_test.v
 vlib/v/tests/concurrency/sync_channel_push_string_literal_test.v
 vlib/v/tests/concurrency/tcc_atomic_postfix_test.v
-vlib/v/tests/concurrency/thread_array_test.v
 vlib/v/tests/concurrency/thread_ptr_ret_test.v
 vlib/v/tests/concurrency/thread_returns_test.v
 vlib/v/tests/concurrency/thread_to_string_test.v
@@ -1006,7 +983,6 @@ vlib/v/tests/conditions/matches/match_expr_with_opt_result_test.v
 vlib/v/tests/conditions/matches/match_expression_with_fn_names_in_branches_test.v
 vlib/v/tests/conditions/matches/match_interface_test.v
 vlib/v/tests/conditions/matches/match_mutable_selector_sumtype_smartcast_test.v
-vlib/v/tests/conditions/matches/match_return_fn_test.v
 vlib/v/tests/conditions/matches/match_smartcast_test.v
 vlib/v/tests/conditions/matches/match_struct_type_test.v
 vlib/v/tests/conditions/matches/match_sumtype_arr_test.v
@@ -1034,14 +1010,12 @@ vlib/v/tests/consts/const_init_order_test.v
 vlib/v/tests/consts/const_map_init_order_test.v
 vlib/v/tests/consts/const_markused_test.v
 vlib/v/tests/consts/const_name_equals_fn_name_test.v
-vlib/v/tests/consts/const_referencing_each_other_inside_anon_fns_test.v
 vlib/v/tests/consts/const_representation_test.v
 vlib/v/tests/consts/const_resolution_test.v
 vlib/v/tests/consts/const_selector_expr_order_test.v
 vlib/v/tests/consts/const_test.v
 vlib/v/tests/consts/const_use_nested_options_test.v
 vlib/v/tests/defer/defer_return_test.v
-vlib/v/tests/defer/defer_test.v
 vlib/v/tests/defer/defer_use_returned_value_test.v
 vlib/v/tests/defer/scoped_defer_test.v
 vlib/v/tests/empty_array_push_test.v
@@ -1051,7 +1025,6 @@ vlib/v/tests/enums/enum_assign_on_anon_fn_test.v
 vlib/v/tests/enums/enum_attr_test.v
 vlib/v/tests/enums/enum_bitfield_64bit_test.v
 vlib/v/tests/enums/enum_bitfield_test.v
-vlib/v/tests/enums/enum_default_test.v
 vlib/v/tests/enums/enum_default_value_in_struct_test.v
 vlib/v/tests/enums/enum_explicit_size_big_and_small_test.v
 vlib/v/tests/enums/enum_flag_alias_op_test.v
@@ -1081,10 +1054,7 @@ vlib/v/tests/fns/aliased_interface_methods_test.v
 vlib/v/tests/fns/aliased_static_method_test.v
 vlib/v/tests/fns/anon_c_keywords_closure_test.v
 vlib/v/tests/fns/anon_fn_decl_inside_ternary_test.v
-vlib/v/tests/fns/anon_fn_direct_call_with_option_test.v
-vlib/v/tests/fns/anon_fn_in_containers_test.v
 vlib/v/tests/fns/anon_fn_in_generic_call_with_match_and_inner_generic_call_test.v
-vlib/v/tests/fns/anon_fn_option_call_in_if_expr_test.v
 vlib/v/tests/fns/anon_fn_option_test.v
 vlib/v/tests/fns/anon_fn_redefinition_test.v
 vlib/v/tests/fns/anon_fn_test.v
@@ -1100,13 +1070,11 @@ vlib/v/tests/fns/call_struct_params_with_keyword_test.v
 vlib/v/tests/fns/call_to_str_on_option_test.v
 vlib/v/tests/fns/call_with_nil_test.v
 vlib/v/tests/fns/calling_module_functions_with_maps_of_arrays_test.v
-vlib/v/tests/fns/closure_fn_arg_in_map_test.v
 vlib/v/tests/fns/closure_generator_test.v
 vlib/v/tests/fns/closure_in_if_guard_1_test.v
 vlib/v/tests/fns/closure_in_if_guard_2_test.v
 vlib/v/tests/fns/closure_of_instance_method_passed_to_voidptr_parameter_test.v
 vlib/v/tests/fns/closure_of_method_defined_on_alias_test.v
-vlib/v/tests/fns/closure_option_direct_call_test.v
 vlib/v/tests/fns/closure_struct_init_cov_regression_test.v
 vlib/v/tests/fns/closure_test.v
 vlib/v/tests/fns/closure_variable_in_smartcast_test.v
@@ -1140,8 +1108,6 @@ vlib/v/tests/fns/fn_return_match_expr_with_result_test.v
 vlib/v/tests/fns/fn_return_mut_sumtype_test.v
 vlib/v/tests/fns/fn_return_typeof_test.v
 vlib/v/tests/fns/fn_shared_return_test.v
-vlib/v/tests/fns/fn_type_aliases_test.v
-vlib/v/tests/fns/fn_type_call_of_match_expr_test.v
 vlib/v/tests/fns/fn_variadic_test.v
 vlib/v/tests/fns/fn_voidptr_param_call_with_nonpointer_rvalue_test.v
 vlib/v/tests/fns/fn_with_fixed_array_function_args_test.v
@@ -1164,7 +1130,6 @@ vlib/v/tests/fns/go_wait_2_test.v
 vlib/v/tests/fns/go_wait_3_test.v
 vlib/v/tests/fns/go_wait_option_test.v
 vlib/v/tests/fns/go_wait_with_fn_of_interface_parameter_test.v
-vlib/v/tests/fns/iface_method_fixed_arr_test.v
 vlib/v/tests/fns/iter_alias_fn_test.v
 vlib/v/tests/fns/lambda_as_struct_field_value_test.v
 vlib/v/tests/fns/lambda_expr_test.v
@@ -1177,16 +1142,12 @@ vlib/v/tests/fns/method_call_on_rangeexpr_test.v
 vlib/v/tests/fns/method_call_var_comp_test.v
 vlib/v/tests/fns/methods_as_fields_test.v
 vlib/v/tests/fns/mut_closure_fixed_array_thread_test.v
-vlib/v/tests/fns/optional_fn_selector_call_test.v
 vlib/v/tests/fns/param_fixed_array_const_test.v
 vlib/v/tests/fns/recursive_closure_assignment_test.v
 vlib/v/tests/fns/return_multi_fixed_arr_test.v
 vlib/v/tests/fns/sort_fn_def_test.v
 vlib/v/tests/fns/static_method_as_map_arg_test.v
-vlib/v/tests/fns/translated_variadic_test.v
-vlib/v/tests/fns/variadic_fn_chain_test.v
 vlib/v/tests/fns/variadic_interface_array_arg_test.v
-vlib/v/tests/fns/variadic_sumtype_test.v
 vlib/v/tests/fns/variadic_voidptr_rvalue_test.v
 vlib/v/tests/for_brace_block_tmpl_test.v
 vlib/v/tests/for_in_iterator_next_test.v
@@ -1222,9 +1183,7 @@ vlib/v/tests/generics/generic_empty_interface_to_struct_test.v
 vlib/v/tests/generics/generic_fn_call_by_generic_fn_test.v
 vlib/v/tests/generics/generic_fn_call_map_keys_values_test.v
 vlib/v/tests/generics/generic_fn_call_with_reference_argument_test.v
-vlib/v/tests/generics/generic_fn_cast_to_alias_test.v
 vlib/v/tests/generics/generic_fn_infer_fixed_array_test.v
-vlib/v/tests/generics/generic_fn_infer_fn_type_argument_test.v
 vlib/v/tests/generics/generic_fn_infer_map_test.v
 vlib/v/tests/generics/generic_fn_infer_multi_paras_test.v
 vlib/v/tests/generics/generic_fn_infer_nested_generic_fn_test.v
@@ -1540,13 +1499,11 @@ vlib/v/tests/modules/interface_array_concat_from_another_module/main_test.v
 vlib/v/tests/modules/interface_from_another_module/ifam_test.v
 vlib/v/tests/modules/methods_struct_another_module/import_symbol_static_method_test.v
 vlib/v/tests/modules/methods_struct_another_module/methods_struct_test.v
-vlib/v/tests/modules/sub/global_fixed_array_test.v
 vlib/v/tests/multi_line_with_options_test.v
 vlib/v/tests/multi_return_test.v
 vlib/v/tests/multiple_comptime_tmpl_in_one_fn_test.v
 vlib/v/tests/multiret_with_sumtype_test.v
 vlib/v/tests/mut_arg_struct_pointer_rebind_test.v
-vlib/v/tests/nested_anonfunc_and_for_break_test.v
 vlib/v/tests/nested_if_expr_method_call_test.v
 vlib/v/tests/nested_if_return_test.v
 vlib/v/tests/nested_map_of_fn_call_test.v
@@ -1565,7 +1522,6 @@ vlib/v/tests/options/option_anon_struct_test.v
 vlib/v/tests/options/option_arr_auto_str_test.v
 vlib/v/tests/options/option_array_dump_in_generic_fn_test.v
 vlib/v/tests/options/option_array_fixed_interface_sumtype_test.v
-vlib/v/tests/options/option_array_fixed_struct_test.v
 vlib/v/tests/options/option_array_fixed_test.v
 vlib/v/tests/options/option_array_init_mix_test.v
 vlib/v/tests/options/option_array_push_test.v
@@ -1579,7 +1535,6 @@ vlib/v/tests/options/option_concat_str_test.v
 vlib/v/tests/options/option_concatexpr_test.v
 vlib/v/tests/options/option_const_test.v
 vlib/v/tests/options/option_diff_alias_arg_test.v
-vlib/v/tests/options/option_dump_test.v
 vlib/v/tests/options/option_embed_field_test.v
 vlib/v/tests/options/option_empty_map_test.v
 vlib/v/tests/options/option_enum_compare_none_test.v
@@ -1613,7 +1568,6 @@ vlib/v/tests/options/option_ifguard_array_of_option_test.v
 vlib/v/tests/options/option_import_struct_test.v
 vlib/v/tests/options/option_indexexpr_eq_test.v
 vlib/v/tests/options/option_init_ptr_test.v
-vlib/v/tests/options/option_map_fn_type_value_test.v
 vlib/v/tests/options/option_map_fn_value_test.v
 vlib/v/tests/options/option_map_init_test.v
 vlib/v/tests/options/option_map_none_test.v
@@ -1657,7 +1611,6 @@ vlib/v/tests/options/option_ptr_test.v
 vlib/v/tests/options/option_ptr_unwrap_selector_test.v
 vlib/v/tests/options/option_ptr_unwrap_test.v
 vlib/v/tests/options/option_ptr_zero_test.v
-vlib/v/tests/options/option_push_array_opt_test.v
 vlib/v/tests/options/option_reference_of_option_test.v
 vlib/v/tests/options/option_reference_params_test.v
 vlib/v/tests/options/option_result_interface_ret_test.v
@@ -1768,7 +1721,6 @@ vlib/v/tests/retry_test.v
 vlib/v/tests/return_comptime_call_test.v
 vlib/v/tests/return_error_in_if_expr_test.v
 vlib/v/tests/return_fixed_array_test.v
-vlib/v/tests/return_if_expr_with_custom_error_test.v
 vlib/v/tests/return_in_lock_test.v
 vlib/v/tests/return_map_index_with_or_block_test.v
 vlib/v/tests/return_match_expr_of_sumtype_do_not_cast_to_ierror_test.v
@@ -1865,10 +1817,8 @@ vlib/v/tests/sumtypes/init_multiple_branches_test.v
 vlib/v/tests/sumtypes/json2_any_free_test.v
 vlib/v/tests/sumtypes/json2_map_to_any_cgen_regression_test.v
 vlib/v/tests/sumtypes/mut_receiver_of_sumtype_test.v
-vlib/v/tests/sumtypes/sumtype_alias_fntype_smartcast_test.v
 vlib/v/tests/sumtypes/sumtype_arg_mutable_test.v
 vlib/v/tests/sumtypes/sumtype_array_methods_test.v
-vlib/v/tests/sumtypes/sumtype_array_to_vararg_struct_fn_test.v
 vlib/v/tests/sumtypes/sumtype_assign_test.v
 vlib/v/tests/sumtypes/sumtype_cast_alias_test.v
 vlib/v/tests/sumtypes/sumtype_cast_from_voidptr_test.v

--- a/vlib/v3/v3_test_passes.txt
+++ b/vlib/v3/v3_test_passes.txt
@@ -46,6 +46,7 @@ vlib/builtin/utf8_test.v
 vlib/compress/deflate/deflate_test.v
 vlib/compress/snappy/snappy_block_test.v
 vlib/crypto/aes/aes_test.v
+vlib/crypto/aes/block_generic_test.v
 vlib/crypto/argon2/argon2_test.v
 vlib/crypto/bcrypt/bcrypt_test.v
 vlib/crypto/blake2b/blake2b_block_test.v
@@ -109,7 +110,11 @@ vlib/encoding/hex/hex_test.v
 vlib/encoding/leb128/leb128_test.v
 vlib/encoding/utf8/validate/encoding_utf8_test.v
 vlib/encoding/vorbis/vorbis_test.v
+vlib/encoding/xml/encoding_test.v
+vlib/encoding/xml/newline_test.v
+vlib/encoding/xml/query_test.v
 vlib/encoding/xml/test/gtk/gtk_test.v
+vlib/encoding/xml/test/local/20_bom_file/bom_test.v
 vlib/flag/default_flag_options_test.v
 vlib/flag/flag_autofree_test.v
 vlib/flag/flag_parse_test.v
@@ -177,6 +182,7 @@ vlib/strconv/write_dec_test.v
 vlib/strings/builder_test.v
 vlib/strings/similarity_test.v
 vlib/strings/textscanner/textscanner_test.v
+vlib/sync/spinlock_test.v
 vlib/time/Y2K38_test.v
 vlib/time/misc/misc_test.v
 vlib/time/parse_test.v
@@ -243,23 +249,27 @@ vlib/v/tests/alias_cast_to_fixed_array_test.v
 vlib/v/tests/aliases/alias_array_built_in_methods_test.v
 vlib/v/tests/aliases/alias_array_fixed_test.v
 vlib/v/tests/aliases/alias_array_has_method_test.v
+vlib/v/tests/aliases/alias_array_operator_overloading_test.v
 vlib/v/tests/aliases/alias_array_push_test.v
 vlib/v/tests/aliases/alias_assigned_in_increment_part_of_for_c_loop_test.v
 vlib/v/tests/aliases/alias_bool_not_op_test.v
 vlib/v/tests/aliases/alias_char_type_reference_test.v
 vlib/v/tests/aliases/alias_compare_non_alias_test.v
 vlib/v/tests/aliases/alias_eq_op_test.v
+vlib/v/tests/aliases/alias_fixed_arr_test.v
 vlib/v/tests/aliases/alias_fixed_array_append_to_array_test.v
 vlib/v/tests/aliases/alias_fixed_array_compare_test.v
 vlib/v/tests/aliases/alias_generic_mut_reference_issue_24011_test.v
 vlib/v/tests/aliases/alias_generic_parent_operator_overloading_test.v
 vlib/v/tests/aliases/alias_interface_test.v
+vlib/v/tests/aliases/alias_operator_overloading_test.v
 vlib/v/tests/aliases/alias_option_test.v
 vlib/v/tests/aliases/alias_parent_operator_overloading_issue_26416_test.v
 vlib/v/tests/aliases/alias_to_ptr_arg_test.v
 vlib/v/tests/aliases/alias_updated_expr_test.v
 vlib/v/tests/aliases/aliased_array_method_call_test.v
 vlib/v/tests/aliases/aliased_array_operations_test.v
+vlib/v/tests/aliases/numeric_alias_empty_init_test.v
 vlib/v/tests/aliases/type_alias_of_fn_with_mut_args_test.v
 vlib/v/tests/array_empty_no_alloc_test.v
 vlib/v/tests/array_fixed_ternary_test.v
@@ -306,12 +316,15 @@ vlib/v/tests/builtin_arrays/array_delete_many_test.v
 vlib/v/tests/builtin_arrays/array_elements_with_option_test.v
 vlib/v/tests/builtin_arrays/array_equality_test.v
 vlib/v/tests/builtin_arrays/array_filter_using_direct_closure_test.v
+vlib/v/tests/builtin_arrays/array_fixed_empty_struct_test.v
 vlib/v/tests/builtin_arrays/array_fixed_for_loop_test.v
 vlib/v/tests/builtin_arrays/array_fixed_from_unsafe_test.v
 vlib/v/tests/builtin_arrays/array_fixed_init_node_test.v
 vlib/v/tests/builtin_arrays/array_fixed_struct_field_test.v
+vlib/v/tests/builtin_arrays/array_get_anon_fn_value_test.v
 vlib/v/tests/builtin_arrays/array_grow_cap_test.v
 vlib/v/tests/builtin_arrays/array_init_fixed_array_ret_test.v
+vlib/v/tests/builtin_arrays/array_init_fixed_test.v
 vlib/v/tests/builtin_arrays/array_init_i32_test.v
 vlib/v/tests/builtin_arrays/array_insert_as_mut_receiver_test.v
 vlib/v/tests/builtin_arrays/array_insert_variadic_arg_variable_test.v
@@ -319,10 +332,14 @@ vlib/v/tests/builtin_arrays/array_map_or_test.v
 vlib/v/tests/builtin_arrays/array_map_to_fixed_array_test.v
 vlib/v/tests/builtin_arrays/array_method_using_it_in_defer_test.v
 vlib/v/tests/builtin_arrays/array_nested_call_test.v
+vlib/v/tests/builtin_arrays/array_of_alias_op_overload_test.v
 vlib/v/tests/builtin_arrays/array_of_alias_pop_test.v
 vlib/v/tests/builtin_arrays/array_of_alias_slice_test.v
+vlib/v/tests/builtin_arrays/array_of_anon_fn_call_test.v
 vlib/v/tests/builtin_arrays/array_of_fixed_array_map_test.v
 vlib/v/tests/builtin_arrays/array_of_fixed_array_test.v
+vlib/v/tests/builtin_arrays/array_of_fns_index_call_with_direct_array_access_test.v
+vlib/v/tests/builtin_arrays/array_of_fns_index_call_with_embeded_array_call_test.v
 vlib/v/tests/builtin_arrays/array_of_interface_init_test.v
 vlib/v/tests/builtin_arrays/array_of_map_with_default_test.v
 vlib/v/tests/builtin_arrays/array_of_sumtype_append_aggregate_type_test.v
@@ -337,6 +354,7 @@ vlib/v/tests/builtin_arrays/array_string_test.v
 vlib/v/tests/builtin_arrays/array_sumtype_init_test.v
 vlib/v/tests/builtin_arrays/array_to_string_test.v
 vlib/v/tests/builtin_arrays/array_type_alias_test.v
+vlib/v/tests/builtin_arrays/fixed_array_2_test.v
 vlib/v/tests/builtin_arrays/fixed_array_explicit_decompose_test.v
 vlib/v/tests/builtin_arrays/fixed_array_in_op_test.v
 vlib/v/tests/builtin_arrays/fixed_array_of_alias_struct_test.v
@@ -357,6 +375,7 @@ vlib/v/tests/builtin_maps/map_equality_test.v
 vlib/v/tests/builtin_maps/map_fixed_array_if_guard_test.v
 vlib/v/tests/builtin_maps/map_fixed_array_keys_test.v
 vlib/v/tests/builtin_maps/map_generic_keys_with_in_op_test.v
+vlib/v/tests/builtin_maps/map_get_anon_fn_value_with_mut_arg_test.v
 vlib/v/tests/builtin_maps/map_get_assign_blank_test.v
 vlib/v/tests/builtin_maps/map_key_expr_test.v
 vlib/v/tests/builtin_maps/map_literals_method_call_test.v
@@ -364,6 +383,7 @@ vlib/v/tests/builtin_maps/map_mut_fn_test.v
 vlib/v/tests/builtin_maps/map_nested_reference_value_test.v
 vlib/v/tests/builtin_maps/map_reference_value_test.v
 vlib/v/tests/builtin_maps/map_sumtype_values_test.v
+vlib/v/tests/builtin_maps/map_value_init_test.v
 vlib/v/tests/builtin_maps/maps_equal_test.v
 vlib/v/tests/builtin_maps/unsafe_pointers_to_map_values_test.v
 vlib/v/tests/builtin_strings_and_interpolation/high_ascii_const_rune_test.v
@@ -373,6 +393,7 @@ vlib/v/tests/builtin_strings_and_interpolation/str_circular_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_alias_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_escape_backslash_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_float_fmt_test.v
+vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_floats_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_inner_cbr_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_match_expr_test.v
 vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_of_array_of_structs_test.v
@@ -384,6 +405,7 @@ vlib/v/tests/builtin_strings_and_interpolation/string_option_none_test.v
 vlib/v/tests/builtin_strings_and_interpolation/strings_builder_issue_13613_cg_test.v
 vlib/v/tests/builtin_strings_and_interpolation/strings_builder_shift_array_reverse_test.v
 vlib/v/tests/builtin_strings_and_interpolation/strings_unicode_test.v
+vlib/v/tests/builtin_strings_and_interpolation/vargs_auto_str_method_and_println_test.v
 vlib/v/tests/c_const_u8_test.v
 vlib/v/tests/c_structs/cstruct_alias_test.v
 vlib/v/tests/casts/as_cast_already_smartcast_sumtype_test.v
@@ -455,6 +477,7 @@ vlib/v/tests/concurrency/shared_map_ptr_test.v
 vlib/v/tests/concurrency/shared_nested_lock_runtime_test.v
 vlib/v/tests/concurrency/shared_struct_field_test.v
 vlib/v/tests/concurrency/spawn_with_cond_fncall_test.v
+vlib/v/tests/concurrency/thread_array_test.v
 vlib/v/tests/concurrency/thread_type_test.v
 vlib/v/tests/concurrency/volatile_vars_test.v
 vlib/v/tests/conditions/ifs/if_assign_test.v
@@ -508,6 +531,7 @@ vlib/v/tests/conditions/matches/match_in_if_expression_test.v
 vlib/v/tests/conditions/matches/match_in_map_init_test.v
 vlib/v/tests/conditions/matches/match_in_map_or_expr_test.v
 vlib/v/tests/conditions/matches/match_reference_sumtype_var_test.v
+vlib/v/tests/conditions/matches/match_return_fn_test.v
 vlib/v/tests/conditions/matches/match_return_reference_test.v
 vlib/v/tests/conditions/matches/match_sumtype_var_aggregate_var_str_test.v
 vlib/v/tests/conditions/matches/match_sumtype_var_shadow_and_as_test.v
@@ -537,6 +561,7 @@ vlib/v/tests/consts/const_many_pluses_with_raw_string_literal_test.v
 vlib/v/tests/consts/const_order_with_str_interp_test.v
 vlib/v/tests/consts/const_propagate_result_test.v
 vlib/v/tests/consts/const_reference_argument_test.v
+vlib/v/tests/consts/const_referencing_each_other_inside_anon_fns_test.v
 vlib/v/tests/consts/const_with_fn_param_with_the_same_name_test.v
 vlib/v/tests/consts/constant_array_size_test.v
 vlib/v/tests/create_dll/create_win_dll_test.v
@@ -544,6 +569,7 @@ vlib/v/tests/debugger_reserved_arg_name_test.v
 vlib/v/tests/defer/defer_fixed_array_test.v
 vlib/v/tests/defer/defer_if_comptime_test.v
 vlib/v/tests/defer/defer_static_test.v
+vlib/v/tests/defer/defer_test.v
 vlib/v/tests/defer/defer_with_fn_var_test.v
 vlib/v/tests/division_by_zero_runtime_test.v
 vlib/v/tests/enums/enum_allow_multiple_values_match_test.v
@@ -552,6 +578,7 @@ vlib/v/tests/enums/enum_array_init_test.v
 vlib/v/tests/enums/enum_attr_2_test.v
 vlib/v/tests/enums/enum_bitfield_works_with_comptime_conditional_in_the_same_scope_test.v
 vlib/v/tests/enums/enum_custom_static_from_string_test.v
+vlib/v/tests/enums/enum_default_test.v
 vlib/v/tests/enums/enum_field_name_same_as_cpp_keywords_test.v
 vlib/v/tests/enums/enum_field_name_same_as_keyword_test.v
 vlib/v/tests/enums/enum_flag_test.v
@@ -576,7 +603,10 @@ vlib/v/tests/fixed_array_update_expr_test.v
 vlib/v/tests/fn_field_ref_param_struct_init_test.v
 vlib/v/tests/fns/anon_fn_call_test.v
 vlib/v/tests/fns/anon_fn_decl_with_anon_fn_params_test.v
+vlib/v/tests/fns/anon_fn_direct_call_with_option_test.v
 vlib/v/tests/fns/anon_fn_fixed_arr_test.v
+vlib/v/tests/fns/anon_fn_in_containers_test.v
+vlib/v/tests/fns/anon_fn_option_call_in_if_expr_test.v
 vlib/v/tests/fns/anon_fn_returning_question_test.v
 vlib/v/tests/fns/anon_fn_with_array_arguments_test.v
 vlib/v/tests/fns/anon_fn_with_nested_anon_fn_args_test.v
@@ -585,7 +615,9 @@ vlib/v/tests/fns/call_args_variadic_sumtype_test.v
 vlib/v/tests/fns/call_option_param_test.v
 vlib/v/tests/fns/call_or_empty_block_test.v
 vlib/v/tests/fns/closure_context_skip_unused_test.v
+vlib/v/tests/fns/closure_fn_arg_in_map_test.v
 vlib/v/tests/fns/closure_lifetime_api_test.v
+vlib/v/tests/fns/closure_option_direct_call_test.v
 vlib/v/tests/fns/cross_method_call_test.v
 vlib/v/tests/fns/filter_in_map_test.v
 vlib/v/tests/fns/fn_assignment_test.v
@@ -604,6 +636,8 @@ vlib/v/tests/fns/fn_return_alias_of_ptr_test.v
 vlib/v/tests/fns/fn_return_fn_test.v
 vlib/v/tests/fns/fn_return_opt_or_res_of_array_test.v
 vlib/v/tests/fns/fn_return_result_fixed_array_return_fn_propagate_result_test.v
+vlib/v/tests/fns/fn_type_aliases_test.v
+vlib/v/tests/fns/fn_type_call_of_match_expr_test.v
 vlib/v/tests/fns/fn_type_only_argument_test.v
 vlib/v/tests/fns/fn_var_name_using_reserved_test.v
 vlib/v/tests/fns/fn_with_array_of_aliases_argument_test.v
@@ -611,6 +645,7 @@ vlib/v/tests/fns/fn_with_fixed_array_args_test.v
 vlib/v/tests/fns/generic_fn_return_later_declared_generic_struct_test.v
 vlib/v/tests/fns/go_array_wait_without_go_test.v
 vlib/v/tests/fns/go_call_interface_method_test.v
+vlib/v/tests/fns/iface_method_fixed_arr_test.v
 vlib/v/tests/fns/interface_methods_fixed_arr_test.v
 vlib/v/tests/fns/method_call_chained_multiline_test.v
 vlib/v/tests/fns/method_call_chained_test.v
@@ -620,11 +655,15 @@ vlib/v/tests/fns/method_first_last_call_test.v
 vlib/v/tests/fns/methods_on_interfaces_test.v
 vlib/v/tests/fns/multi_return_array_fixed_test.v
 vlib/v/tests/fns/multiline_fn_signature_omitted_comma_test.v
+vlib/v/tests/fns/optional_fn_selector_call_test.v
 vlib/v/tests/fns/return_multi_aliased_fixed_array_test.v
 vlib/v/tests/fns/same_function_signature_nested_fn_test.v
 vlib/v/tests/fns/static_call_on_match_test.v
+vlib/v/tests/fns/translated_variadic_test.v
 vlib/v/tests/fns/unused_fn_aliased_fixed_array_ret_test.v
 vlib/v/tests/fns/unused_fn_fixed_array_ret_test.v
+vlib/v/tests/fns/variadic_fn_chain_test.v
+vlib/v/tests/fns/variadic_sumtype_test.v
 vlib/v/tests/gc_free_space_divisor_test.v
 vlib/v/tests/generic_fn_dedup_collision_issue_27398_test.v
 vlib/v/tests/generics/generic_alias_fn_op_call_test.v
@@ -637,6 +676,8 @@ vlib/v/tests/generics/generic_comptime_map_test.v
 vlib/v/tests/generics/generic_empty_interface_to_multi_struct_test.v
 vlib/v/tests/generics/generic_fn_array_infer_var_test.v
 vlib/v/tests/generics/generic_fn_assign_generics_struct_test.v
+vlib/v/tests/generics/generic_fn_cast_to_alias_test.v
+vlib/v/tests/generics/generic_fn_infer_fn_type_argument_test.v
 vlib/v/tests/generics/generic_fn_infer_fn_type_using_ref_arg_test.v
 vlib/v/tests/generics/generic_fn_infer_map_argument_test.v
 vlib/v/tests/generics/generic_fn_infer_modifier_test.v
@@ -783,6 +824,7 @@ vlib/v/tests/modules/callback_consumer_module/callback_consumer_test.v
 vlib/v/tests/modules/imported_static_method_fn_ref_test.v
 vlib/v/tests/modules/private_mutability/private_mutability_test.v
 vlib/v/tests/modules/same_module_type_name_fn_test.v
+vlib/v/tests/modules/sub/global_fixed_array_test.v
 vlib/v/tests/modules/sub/sub_test.v
 vlib/v/tests/modules/submodules/submodules_test.v
 vlib/v/tests/multi_return_nil_voidptr_test.v
@@ -793,6 +835,7 @@ vlib/v/tests/multiret_with_ptrtype_test.v
 vlib/v/tests/multiret_with_result_test.v
 vlib/v/tests/named_break_continue_test.v
 vlib/v/tests/nest_defer_fn_test.v
+vlib/v/tests/nested_anonfunc_and_for_break_test.v
 vlib/v/tests/nested_fors_with_labels_test.v
 vlib/v/tests/nested_map_index_test.v
 vlib/v/tests/nested_or_in_assign_decl_test.v
@@ -804,6 +847,7 @@ vlib/v/tests/options/nested_or_expr_call_test.v
 vlib/v/tests/options/none_checking_test.v
 vlib/v/tests/options/option_alias_fn_ret_test.v
 vlib/v/tests/options/option_array_compare_test.v
+vlib/v/tests/options/option_array_fixed_struct_test.v
 vlib/v/tests/options/option_array_init_test.v
 vlib/v/tests/options/option_array_test.v
 vlib/v/tests/options/option_assert_eq_none_then_if_guard_test.v
@@ -815,6 +859,7 @@ vlib/v/tests/options/option_cast_eq_none_test.v
 vlib/v/tests/options/option_cast_primitive_test.v
 vlib/v/tests/options/option_compvar_types_test.v
 vlib/v/tests/options/option_default_values_test.v
+vlib/v/tests/options/option_dump_test.v
 vlib/v/tests/options/option_expr_with_array_value_test.v
 vlib/v/tests/options/option_fixed_arr_const_test.v
 vlib/v/tests/options/option_fn_guard_test.v
@@ -830,6 +875,7 @@ vlib/v/tests/options/option_index_amp_test.v
 vlib/v/tests/options/option_init_test.v
 vlib/v/tests/options/option_interface_test.v
 vlib/v/tests/options/option_last_call_test.v
+vlib/v/tests/options/option_map_fn_type_value_test.v
 vlib/v/tests/options/option_map_val_test.v
 vlib/v/tests/options/option_match_case_cast_test.v
 vlib/v/tests/options/option_match_eq_test.v
@@ -844,6 +890,7 @@ vlib/v/tests/options/option_ptr_field_in_interface_cast_test.v
 vlib/v/tests/options/option_ptr_init_empty_test.v
 vlib/v/tests/options/option_ptr_init_test.v
 vlib/v/tests/options/option_ptr_nil_test.v
+vlib/v/tests/options/option_push_array_opt_test.v
 vlib/v/tests/options/option_selector_assign_test.v
 vlib/v/tests/options/option_selector_cast_test.v
 vlib/v/tests/options/option_selector_fn_none_test.v
@@ -907,6 +954,7 @@ vlib/v/tests/reserved_keywords_can_be_escaped_with_at_test.v
 vlib/v/tests/reserved_keywords_if_guard_test.v
 vlib/v/tests/results_test.v
 vlib/v/tests/return_aliases_of_fixed_array_test.v
+vlib/v/tests/return_if_expr_with_custom_error_test.v
 vlib/v/tests/return_match_expr_with_custom_error_test.v
 vlib/v/tests/return_option_call_in_non_option_fn_test.v
 vlib/v/tests/return_option_test.v
@@ -976,6 +1024,8 @@ vlib/v/tests/structs/struct_shared_field_init_test.v
 vlib/v/tests/structs/struct_shared_field_with_default_init_test.v
 vlib/v/tests/structs/working_with_an_empty_struct_test.v
 vlib/v/tests/sumtypes/passing_sumtype_parameter_in_sumtype_matching_results_test.v
+vlib/v/tests/sumtypes/sumtype_alias_fntype_smartcast_test.v
+vlib/v/tests/sumtypes/sumtype_array_to_vararg_struct_fn_test.v
 vlib/v/tests/sumtypes/sumtype_as_cast_1_test.v
 vlib/v/tests/sumtypes/sumtype_as_cast_2_test.v
 vlib/v/tests/sumtypes/sumtype_as_cast_fn_call_test.v


### PR DESCRIPTION
## Summary
- fix V3 handling for alias operators/defaults, explicit generic alias display types, function values in arrays/maps/options, and fixed-array defaults/ABI paths
- improve variadic call lowering, string interpolation formatting, range loops, map defaults, and const/function-value transforms
- move 50 tests from vlib/v3/v3_test_failures.txt to vlib/v3/v3_test_passes.txt
- skipped the tests handled by PR 27625

## Validation
- ./v -g -keepc -o /tmp/v3_next_probe vlib/v3/v3.v
- corrected 50-test V3 sweep: /tmp/v3_next_probe run <selected test> for all moved tests, failures=0
- git diff --check