### PR TITLE
v3: reject duplicate C struct declarations

### DIFF
--- a/vlib/v3/tests/c_struct_redeclaration_test.v
+++ b/vlib/v3/tests/c_struct_redeclaration_test.v
@@ -1,0 +1,45 @@
+import os
+import rand
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_c_struct_redeclaration_${os.getpid()}_${rand.ulid()}')
+	build := os.execute('${vexe} -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn unique_temp_path(name string) string {
+	return os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}_${rand.ulid()}')
+}
+
+fn run_v3_source(v3_bin string, name string, src string) os.Result {
+	out := unique_temp_path(name)
+	src_path := out + '.v'
+	os.write_file(src_path, src) or { panic(err) }
+	return os.execute('${v3_bin} ${src_path} -b c -o ${out}')
+}
+
+fn test_c_struct_redeclaration_checks_field_signature() {
+	v3_bin := build_v3()
+	bad := run_v3_source(v3_bin, 'bad_c_struct_redeclaration',
+		'struct C.dirent {\n\td_name [256]char\n}\n\nstruct C.dirent {\n\td_name byteptr\n}\n\nfn main() {}\n')
+	assert bad.exit_code != 0, bad.output
+	assert bad.output.contains('cannot redeclare C struct `C.dirent`'), bad.output
+	assert !bad.output.contains('C compilation failed'), bad.output
+	reordered := run_v3_source(v3_bin, 'bad_c_struct_reordered_fields',
+		'struct C.OrderedPair {\n\tleft int\n\tright int\n}\n\nstruct C.OrderedPair {\n\tright int\n\tleft int\n}\n\nfn main() {}\n')
+	assert reordered.exit_code != 0, reordered.output
+	assert reordered.output.contains('cannot redeclare C struct `C.OrderedPair`'), reordered.output
+	assert !reordered.output.contains('C compilation failed'), reordered.output
+
+	good := run_v3_source(v3_bin, 'good_c_struct_redeclaration',
+		'@[typedef]\nstruct C.XKeyEvent {\n\tkeycode u32\n\tstate u32\n}\n\nstruct C.XKeyEvent {\n\tkeycode u32\n\tstate u32\n}\n\n@[typedef]\nunion C.XClientMessageData {\nmut:\n\tb [20]u8\n\ts [10]i16\n\tl [5]i64\n}\n\nunion C.XClientMessageData {\nmut:\n\tl [5]i64\n}\n\n@[typedef]\nunion C.XEvent {\nmut:\n\ttype int\n\txkey C.XKeyEvent\n}\n\nunion C.XEvent {\nmut:\n\t@type int\n\txkey C.XKeyEvent\n}\n\nfn main() {}\n')
+	assert good.exit_code == 0, good.output
+	assert !good.output.contains('C compilation failed'), good.output
+}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -133,6 +133,7 @@ pub enum TypeErrorKind {
 	return_mismatch
 	call_arg_mismatch
 	condition_mismatch
+	duplicate_decl
 	unhandled_node
 	unsupported_generic
 }
@@ -515,7 +516,8 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 		}
 	}
 	// Pass 1: collect type-level names (aliases, enums, sum types)
-	for node in a.nodes {
+	mut c_struct_decl_sigs := map[string]string{}
+	for node_idx, node in a.nodes {
 		match node.kind {
 			.file {
 				tc.enter_file(node.value)
@@ -545,6 +547,24 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 			}
 			.struct_decl {
 				qname := tc.qualify_name(node.value)
+				if qname.starts_with('C.') {
+					c_struct_key := tc.cur_file + '\n' + qname
+					c_struct_sig := c_struct_decl_signature(a, node)
+					if c_struct_key in c_struct_decl_sigs {
+						existing_sig := c_struct_decl_sigs[c_struct_key]
+						if !c_struct_decl_signatures_compatible(existing_sig, c_struct_sig) {
+							tc.record_error_unfiltered(.duplicate_decl,
+								'cannot redeclare C struct `${qname}`', flat.NodeId(node_idx))
+						}
+						existing_fields := c_struct_decl_signature_field_count(existing_sig)
+						current_fields := c_struct_decl_signature_field_count(c_struct_sig)
+						if current_fields > existing_fields {
+							c_struct_decl_sigs[c_struct_key] = c_struct_sig
+						}
+					} else {
+						c_struct_decl_sigs[c_struct_key] = c_struct_sig
+					}
+				}
 				if qname !in tc.structs {
 					tc.structs[qname] = []StructField{}
 				}
@@ -782,6 +802,62 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	$if ownership ? {
 		tc.ownership_after_collect()
 	}
+}
+
+fn c_struct_decl_signature(a &flat.FlatAst, node flat.Node) string {
+	mut sig := node.typ
+	mut has_fields := false
+	for i in 0 .. node.children_count {
+		f := a.child_node(&node, i)
+		if f.kind != .field_decl {
+			continue
+		}
+		has_fields = true
+		field_name := if f.value.starts_with('@') { f.value[1..] } else { f.value }
+		sig += '|${field_name}:${f.typ}'
+	}
+	if !has_fields {
+		return ''
+	}
+	return sig
+}
+
+fn c_struct_decl_signatures_compatible(a string, b string) bool {
+	if a.len == 0 || b.len == 0 || a == b {
+		return true
+	}
+	a_parts := a.split('|')
+	b_parts := b.split('|')
+	if a_parts.len == 0 || b_parts.len == 0 || a_parts[0] != b_parts[0] {
+		return false
+	}
+	if a_parts[0] != 'union' {
+		return false
+	}
+	a_fields := a_parts[1..]
+	b_fields := b_parts[1..]
+	return c_struct_decl_fields_subset(a_fields, b_fields)
+		|| c_struct_decl_fields_subset(b_fields, a_fields)
+}
+
+fn c_struct_decl_fields_subset(small []string, big []string) bool {
+	for field in small {
+		if field !in big {
+			return false
+		}
+	}
+	return true
+}
+
+fn c_struct_decl_signature_field_count(sig string) int {
+	if sig.len == 0 {
+		return 0
+	}
+	parts := sig.split('|')
+	if parts.len <= 1 {
+		return 0
+	}
+	return parts.len - 1
 }
 
 // build_const_suffixes maps every dot-delimited suffix of each const key to that


### PR DESCRIPTION
## Summary
- report a V3 type-checker error when a C struct is redeclared in the same source file with conflicting field types/signatures
- preserve accepted legacy C ABI union redeclarations when signatures match or when one declaration is a partial field view of the other
- keep C struct comparisons order-sensitive, while still accepting exact ordered repeats and empty/forward declarations
- add a focused regression test for issue #8788 and the Sokol/X11-style redeclaration patterns, including `C.XClientMessageData` and reordered struct fields

Fixes #8788

## Testing
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -w vlib/v3/types/checker.v vlib/v3/tests/c_struct_redeclaration_test.v`
- `./vnew -silent test vlib/v3/tests/c_struct_redeclaration_test.v`
- `./vnew -silent test vlib/v3/tests/selfhost_backend_prune_test.v`
- `git diff --check -- vlib/v3/types/checker.v vlib/v3/tests/c_struct_redeclaration_test.v`