### PR TITLE
compiler: fix invalid UTF-8 and ternary codegen

### DIFF
--- a/vlib/builtin/string.v
+++ b/vlib/builtin/string.v
@@ -62,14 +62,10 @@ mut:
 pub fn (s string) runes() []rune {
 	mut runes := []rune{cap: s.len}
 	for i := 0; i < s.len; i++ {
-		char_len := utf8_char_len(unsafe { s.str[i] })
+		r, char_len := utf8_decode_rune(unsafe { &s.str[i] }, s.len - i)
+		runes << r
 		if char_len > 1 {
-			end := if s.len - 1 >= i + char_len { i + char_len } else { s.len }
-			mut r := unsafe { s[i..end] }
-			runes << r.utf32_code()
 			i += char_len - 1
-		} else {
-			runes << unsafe { s.str[i] }
 		}
 	}
 	return runes
@@ -3236,17 +3232,7 @@ pub fn (mut ri RunesIterator) next() ?rune {
 	if ri.i >= ri.s.len {
 		return none
 	}
-	char_len := utf8_char_len(unsafe { ri.s.str[ri.i] })
-	if char_len == 1 {
-		res := unsafe { ri.s.str[ri.i] }
-		ri.i++
-		return res
-	}
-	start := &u8(unsafe { &ri.s.str[ri.i] })
-	len := if ri.s.len - 1 >= ri.i + char_len { char_len } else { ri.s.len - ri.i }
-	ri.i += char_len
-	if char_len > 4 {
-		return 0
-	}
-	return rune(impl_utf8_to_utf32(start, len))
+	r, char_len := utf8_decode_rune(unsafe { &ri.s.str[ri.i] }, ri.s.len - ri.i)
+	ri.i += if char_len > 0 { char_len } else { 1 }
+	return r
 }

--- a/vlib/builtin/utf8.v
+++ b/vlib/builtin/utf8.v
@@ -3,6 +3,8 @@
 // that can be found in the LICENSE file.
 module builtin
 
+const utf8_replacement_rune = rune(0xfffd)
+
 // utf8_char_len returns the length in bytes of a UTF-8 encoded codepoint that starts with the byte `b`.
 pub fn utf8_char_len(b u8) int {
 	return int(((u32(0xe5000000) >> ((b >> 3) & 0x1e)) & 3) + 1)
@@ -93,39 +95,78 @@ pub fn (_bytes []u8) utf8_to_utf32() !rune {
 	return impl_utf8_to_utf32(_bytes.data, _bytes.len)
 }
 
+@[inline]
+fn utf8_is_continuation(b u8) bool {
+	return (b & 0xc0) == 0x80
+}
+
+@[direct_array_access]
+fn utf8_decode_rune(_bytes &u8, available_len int) (rune, int) {
+	if available_len <= 0 {
+		return 0, 0
+	}
+	b0 := unsafe { _bytes[0] }
+	if b0 < 0x80 {
+		return rune(b0), 1
+	}
+	if b0 < 0xc2 {
+		return utf8_replacement_rune, 1
+	}
+	char_len := if b0 < 0xe0 {
+		2
+	} else if b0 < 0xf0 {
+		3
+	} else if b0 < 0xf5 {
+		4
+	} else {
+		return utf8_replacement_rune, 1
+	}
+	if available_len < char_len {
+		return utf8_replacement_rune, 1
+	}
+	b1 := unsafe { _bytes[1] }
+	if !utf8_is_continuation(b1) {
+		return utf8_replacement_rune, 1
+	}
+	if char_len == 2 {
+		return ((rune(b0) & 0x1f) << 6) | (rune(b1) & 0x3f), 2
+	}
+	if b0 == 0xe0 && b1 < 0xa0 {
+		return utf8_replacement_rune, 1
+	}
+	if b0 == 0xed && b1 >= 0xa0 {
+		return utf8_replacement_rune, 1
+	}
+	b2 := unsafe { _bytes[2] }
+	if !utf8_is_continuation(b2) {
+		return utf8_replacement_rune, 1
+	}
+	if char_len == 3 {
+		return ((rune(b0) & 0x0f) << 12) | ((rune(b1) & 0x3f) << 6) | (rune(b2) & 0x3f), 3
+	}
+	if b0 == 0xf0 && b1 < 0x90 {
+		return utf8_replacement_rune, 1
+	}
+	if b0 == 0xf4 && b1 > 0x8f {
+		return utf8_replacement_rune, 1
+	}
+	b3 := unsafe { _bytes[3] }
+	if !utf8_is_continuation(b3) {
+		return utf8_replacement_rune, 1
+	}
+	return ((rune(b0) & 0x07) << 18) | ((rune(b1) & 0x3f) << 12) | ((rune(b2) & 0x3f) << 6) | (rune(b3) & 0x3f), 4
+}
+
 @[direct_array_access]
 fn impl_utf8_to_utf32(_bytes &u8, _bytes_len int) rune {
 	if _bytes_len == 0 || _bytes_len > 4 {
 		return 0
 	}
-	// return ASCII unchanged
-	if _bytes_len == 1 {
-		return rune(unsafe { _bytes[0] })
+	r, len := utf8_decode_rune(_bytes, _bytes_len)
+	if len != _bytes_len {
+		return utf8_replacement_rune
 	}
-
-	match _bytes_len {
-		2 {
-			b0 := rune(unsafe { _bytes[0] })
-			b1 := rune(unsafe { _bytes[1] })
-			return ((b0 & 0x1F) << 6) | (b1 & 0x3F)
-		}
-		3 {
-			b0 := rune(unsafe { _bytes[0] })
-			b1 := rune(unsafe { _bytes[1] })
-			b2 := rune(unsafe { _bytes[2] })
-			return ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F)
-		}
-		4 {
-			b0 := rune(unsafe { _bytes[0] })
-			b1 := rune(unsafe { _bytes[1] })
-			b2 := rune(unsafe { _bytes[2] })
-			b3 := rune(unsafe { _bytes[3] })
-			return ((b0 & 0x07) << 18) | ((b1 & 0x3F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F)
-		}
-		else {
-			return 0
-		}
-	}
+	return r
 }
 
 // Calculate string length for formatting, i.e. number of "characters"

--- a/vlib/builtin/utf8_test.v
+++ b/vlib/builtin/utf8_test.v
@@ -163,6 +163,43 @@ fn test_utf8_to_utf32_invalid_length() {
 	assert impl_utf8_to_utf32(&u8(invalid.data), invalid.len) == 0
 }
 
+fn test_utf8_to_utf32_invalid_sequences() {
+	replacement := rune(0xfffd)
+	overlong := [u8(0xc1), 0xa1]
+	surrogate := [u8(0xed), 0xa0, 0x80]
+	above_max := [u8(0xf4), 0x90, 0x80, 0x80]
+	incomplete := [u8(0xc3)]
+	lone_continuation := [u8(0x80)]
+
+	assert impl_utf8_to_utf32(&u8(overlong.data), overlong.len) == replacement
+	assert impl_utf8_to_utf32(&u8(surrogate.data), surrogate.len) == replacement
+	assert impl_utf8_to_utf32(&u8(above_max.data), above_max.len) == replacement
+	assert impl_utf8_to_utf32(&u8(incomplete.data), incomplete.len) == replacement
+	assert impl_utf8_to_utf32(&u8(lone_continuation.data), lone_continuation.len) == replacement
+}
+
+fn test_invalid_utf8_string_runes_use_replacement_character() {
+	replacement := rune(0xfffd)
+	invalid := [u8(0xc1), 0xa1, `-`, 0xed, 0xa0, 0x80, `-`, 0xc3].bytestr()
+	expected := [
+		replacement,
+		replacement,
+		rune(`-`),
+		replacement,
+		replacement,
+		replacement,
+		rune(`-`),
+		replacement,
+	]
+
+	assert invalid.runes() == expected
+	mut iterated := []rune{}
+	for r in invalid.runes_iterator() {
+		iterated << r
+	}
+	assert iterated == expected
+}
+
 fn test_utf8_to_utf32_empty() {
 	assert impl_utf8_to_utf32(&u8([]u8{}.data), 0) == 0
 }

--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -14,37 +14,17 @@ fn is_continuation(b u8) bool {
 	return (b & 0xc0) == 0x80
 }
 
-// len return the length as number of unicode chars from a string
-pub fn len(s string) int {
-	if s.len == 0 {
-		return 0
-	}
-
-	mut count := 0
-	mut index := 0
-
-	for {
-		ch_len := utf8_char_len(s[index])
-		index += ch_len
-		count++
-		if index >= s.len {
-			break
-		}
-	}
-	return count
-}
-
-// get_rune convert a UTF-8 unicode codepoint in string[index] into a UTF-32 encoded rune
-pub fn get_rune(s string, index int) rune {
+@[direct_array_access]
+fn decode_rune_at(s string, index int) (rune, int) {
 	if s.len == 0 || index < 0 || index >= s.len {
-		return 0
+		return 0, 0
 	}
 	b0 := s[index]
 	if b0 < 0x80 {
-		return rune(b0)
+		return rune(b0), 1
 	}
 	if b0 < 0xc2 {
-		return replacement_rune
+		return replacement_rune, 1
 	}
 	ch_len := if b0 < 0xe0 {
 		2
@@ -53,42 +33,64 @@ pub fn get_rune(s string, index int) rune {
 	} else if b0 < 0xf5 {
 		4
 	} else {
-		return replacement_rune
+		return replacement_rune, 1
 	}
 	if index + ch_len > s.len {
-		return replacement_rune
+		return replacement_rune, 1
 	}
 	b1 := s[index + 1]
 	if !is_continuation(b1) {
-		return replacement_rune
+		return replacement_rune, 1
 	}
 	if ch_len == 2 {
-		return ((rune(b0) & 0x1f) << 6) | (rune(b1) & 0x3f)
+		return ((rune(b0) & 0x1f) << 6) | (rune(b1) & 0x3f), 2
 	}
 	if b0 == 0xe0 && b1 < 0xa0 {
-		return replacement_rune
+		return replacement_rune, 1
 	}
 	if b0 == 0xed && b1 >= 0xa0 {
-		return replacement_rune
+		return replacement_rune, 1
 	}
 	b2 := s[index + 2]
 	if !is_continuation(b2) {
-		return replacement_rune
+		return replacement_rune, 1
 	}
 	if ch_len == 3 {
-		return ((rune(b0) & 0x0f) << 12) | ((rune(b1) & 0x3f) << 6) | (rune(b2) & 0x3f)
+		return ((rune(b0) & 0x0f) << 12) | ((rune(b1) & 0x3f) << 6) | (rune(b2) & 0x3f), 3
 	}
 	if b0 == 0xf0 && b1 < 0x90 {
-		return replacement_rune
+		return replacement_rune, 1
 	}
 	if b0 == 0xf4 && b1 > 0x8f {
-		return replacement_rune
+		return replacement_rune, 1
 	}
 	b3 := s[index + 3]
 	if !is_continuation(b3) {
-		return replacement_rune
+		return replacement_rune, 1
 	}
-	return ((rune(b0) & 0x07) << 18) | ((rune(b1) & 0x3f) << 12) | ((rune(b2) & 0x3f) << 6) | (rune(b3) & 0x3f)
+	return ((rune(b0) & 0x07) << 18) | ((rune(b1) & 0x3f) << 12) | ((rune(b2) & 0x3f) << 6) | (rune(b3) & 0x3f), 4
+}
+
+// len return the length as number of unicode chars from a string
+pub fn len(s string) int {
+	mut count := 0
+	mut index := 0
+
+	for index < s.len {
+		_, ch_len := decode_rune_at(s, index)
+		if ch_len == 0 {
+			break
+		}
+		index += ch_len
+		count++
+	}
+	return count
+}
+
+// get_rune convert a UTF-8 unicode codepoint in string[index] into a UTF-32 encoded rune
+pub fn get_rune(s string, index int) rune {
+	r, _ := decode_rune_at(s, index)
+	return r
 }
 
 // raw_index - get the raw unicode character from the UTF-8 string by the given index value as UTF-8 string.
@@ -96,20 +98,17 @@ pub fn get_rune(s string, index int) rune {
 pub fn raw_index(s string, index int) string {
 	mut r := []rune{}
 
-	for i := 0; i < s.len; i++ {
+	mut i := 0
+	for i < s.len {
+		decoded, ch_len := decode_rune_at(s, i)
+		if ch_len == 0 {
+			break
+		}
+		r << decoded
 		if r.len - 1 == index {
 			break
 		}
-
-		b := s[i]
-		ch_len := int((u32(0xe5000000) >> ((b >> 3) & 0x1e)) & 3)
-
-		r << if ch_len > 0 {
-			i += ch_len
-			rune(get_rune(s, i - ch_len))
-		} else {
-			rune(b)
-		}
+		i += ch_len
 	}
 
 	return r[index].str()
@@ -433,7 +432,7 @@ fn convert_case(s string, upper_flag bool) string {
 	mut str_res := unsafe { malloc_noscan(s.len + 1) }
 
 	for {
-		ch_len := utf8_char_len(s[index])
+		_, ch_len := decode_rune_at(s, index)
 
 		if ch_len == 1 {
 			if upper_flag == true {

--- a/vlib/encoding/utf8/utf8_util.v
+++ b/vlib/encoding/utf8/utf8_util.v
@@ -7,6 +7,13 @@ module utf8
 
 // Utility functions
 
+const replacement_rune = rune(0xfffd)
+
+@[inline]
+fn is_continuation(b u8) bool {
+	return (b & 0xc0) == 0x80
+}
+
 // len return the length as number of unicode chars from a string
 pub fn len(s string) int {
 	if s.len == 0 {
@@ -29,41 +36,59 @@ pub fn len(s string) int {
 
 // get_rune convert a UTF-8 unicode codepoint in string[index] into a UTF-32 encoded rune
 pub fn get_rune(s string, index int) rune {
-	mut res := 0
-	mut ch_len := 0
-	if s.len > 0 {
-		ch_len = utf8_char_len(s[index])
-
-		if ch_len == 1 {
-			return u16(s[index])
-		}
-		if ch_len > 1 && ch_len < 5 {
-			mut lword := 0
-			for i := 0; i < ch_len; i++ {
-				lword = int(u32(lword) << 8 | u32(s[index + i]))
-			}
-
-			// 2 byte utf-8
-			// byte format: 110xxxxx 10xxxxxx
-			//
-			if ch_len == 2 {
-				res = (lword & 0x1f00) >> 2 | (lword & 0x3f)
-			}
-			// 3 byte utf-8
-			// byte format: 1110xxxx 10xxxxxx 10xxxxxx
-			//
-			else if ch_len == 3 {
-				res = (lword & 0x0f0000) >> 4 | (lword & 0x3f00) >> 2 | (lword & 0x3f)
-			}
-			// 4 byte utf-8
-			// byte format: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
-			//
-			else if ch_len == 4 {
-				res = ((lword & 0x07000000) >> 6) | ((lword & 0x003f0000) >> 4) | ((lword & 0x00003F00) >> 2) | (lword & 0x0000003f)
-			}
-		}
+	if s.len == 0 || index < 0 || index >= s.len {
+		return 0
 	}
-	return res
+	b0 := s[index]
+	if b0 < 0x80 {
+		return rune(b0)
+	}
+	if b0 < 0xc2 {
+		return replacement_rune
+	}
+	ch_len := if b0 < 0xe0 {
+		2
+	} else if b0 < 0xf0 {
+		3
+	} else if b0 < 0xf5 {
+		4
+	} else {
+		return replacement_rune
+	}
+	if index + ch_len > s.len {
+		return replacement_rune
+	}
+	b1 := s[index + 1]
+	if !is_continuation(b1) {
+		return replacement_rune
+	}
+	if ch_len == 2 {
+		return ((rune(b0) & 0x1f) << 6) | (rune(b1) & 0x3f)
+	}
+	if b0 == 0xe0 && b1 < 0xa0 {
+		return replacement_rune
+	}
+	if b0 == 0xed && b1 >= 0xa0 {
+		return replacement_rune
+	}
+	b2 := s[index + 2]
+	if !is_continuation(b2) {
+		return replacement_rune
+	}
+	if ch_len == 3 {
+		return ((rune(b0) & 0x0f) << 12) | ((rune(b1) & 0x3f) << 6) | (rune(b2) & 0x3f)
+	}
+	if b0 == 0xf0 && b1 < 0x90 {
+		return replacement_rune
+	}
+	if b0 == 0xf4 && b1 > 0x8f {
+		return replacement_rune
+	}
+	b3 := s[index + 3]
+	if !is_continuation(b3) {
+		return replacement_rune
+	}
+	return ((rune(b0) & 0x07) << 18) | ((rune(b1) & 0x3f) << 12) | ((rune(b2) & 0x3f) << 6) | (rune(b3) & 0x3f)
 }
 
 // raw_index - get the raw unicode character from the UTF-8 string by the given index value as UTF-8 string.

--- a/vlib/encoding/utf8/utf8_util_test.v
+++ b/vlib/encoding/utf8/utf8_util_test.v
@@ -46,6 +46,19 @@ fn test_utf8_util() {
 	assert utf8.get_rune(c, 6) == `🚀` // 4 bytes
 }
 
+fn test_get_rune_invalid_utf8() {
+	replacement := rune(0xfffd)
+	invalid := [u8(0xc1), 0xa1, `-`, 0xed, 0xa0, 0x80, `-`, 0xc3].bytestr()
+	assert utf8.get_rune(invalid, 0) == replacement
+	assert utf8.get_rune(invalid, 1) == replacement
+	assert utf8.get_rune(invalid, 2) == `-`
+	assert utf8.get_rune(invalid, 3) == replacement
+	assert utf8.get_rune(invalid, 4) == replacement
+	assert utf8.get_rune(invalid, 5) == replacement
+	assert utf8.get_rune(invalid, 6) == `-`
+	assert utf8.get_rune(invalid, 7) == replacement
+}
+
 fn test_raw_indexing() {
 	a := '我是V Lang!'
 

--- a/vlib/encoding/utf8/utf8_util_test.v
+++ b/vlib/encoding/utf8/utf8_util_test.v
@@ -59,6 +59,19 @@ fn test_get_rune_invalid_utf8() {
 	assert utf8.get_rune(invalid, 7) == replacement
 }
 
+fn test_invalid_utf8_indexing_advances_one_byte() {
+	replacement := rune(0xfffd).str()
+	invalid := [u8(0xf5), `a`].bytestr()
+	assert utf8.get_rune(invalid, 0) == rune(0xfffd)
+	assert utf8.get_rune(invalid, 1) == `a`
+	assert utf8.len(invalid) == 2
+	assert utf8.raw_index(invalid, 0) == replacement
+	assert utf8.raw_index(invalid, 1) == 'a'
+	assert utf8.reverse(invalid) == 'a' + replacement
+	assert utf8.to_upper(invalid) == [u8(0xf5), `A`].bytestr()
+	assert utf8.to_lower([u8(0xf5), `A`].bytestr()) == invalid
+}
+
 fn test_raw_indexing() {
 	a := '我是V Lang!'
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -286,6 +286,40 @@ pub:
 	pos token.Pos
 }
 
+// char_literal_rune_value returns the byte-preserving rune value of a parsed char literal.
+pub fn char_literal_rune_value(value string) ?rune {
+	if value.len == 1 {
+		return rune(value[0])
+	}
+	if value.len == 2 && value[0] == `\\` {
+		return match value[1] {
+			`a` { 7 }
+			`b` { 8 }
+			`t` { 9 }
+			`n` { 10 }
+			`v` { 11 }
+			`f` { 12 }
+			`r` { 13 }
+			`e` { 27 }
+			`$` { 36 }
+			`"` { 34 }
+			`'` { 39 }
+			`?` { 63 }
+			`@` { 64 }
+			`\\` { 92 }
+			`\`` { 96 }
+			`{` { 123 }
+			`}` { 125 }
+			else { none }
+		}
+	}
+	runes := value.runes()
+	if runes.len == 1 {
+		return runes[0]
+	}
+	return none
+}
+
 pub struct BoolLiteral {
 pub:
 	val bool

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -1173,7 +1173,7 @@ fn (mut c Checker) eval_comptime_const_expr_with_locals(expr ast.Expr, nlevel in
 			}
 		}
 		ast.CharLiteral {
-			if value := char_literal_rune_value(expr.val) {
+			if value := ast.char_literal_rune_value(expr.val) {
 				return ast.ComptTimeConstValue(value)
 			}
 			return none

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -1173,9 +1173,8 @@ fn (mut c Checker) eval_comptime_const_expr_with_locals(expr ast.Expr, nlevel in
 			}
 		}
 		ast.CharLiteral {
-			runes := expr.val.runes()
-			if runes.len > 0 {
-				return runes[0]
+			if value := char_literal_rune_value(expr.val) {
+				return ast.ComptTimeConstValue(value)
 			}
 			return none
 		}

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -602,41 +602,8 @@ fn (mut c Checker) check_match_branch_last_stmt(mut last_stmt ast.ExprStmt, ret_
 	}
 }
 
-fn char_literal_rune_value(value string) ?rune {
-	if value.len == 1 {
-		return rune(value[0])
-	}
-	if value.len == 2 && value[0] == `\\` {
-		return match value[1] {
-			`a` { 7 }
-			`b` { 8 }
-			`t` { 9 }
-			`n` { 10 }
-			`v` { 11 }
-			`f` { 12 }
-			`r` { 13 }
-			`e` { 27 }
-			`$` { 36 }
-			`"` { 34 }
-			`'` { 39 }
-			`?` { 63 }
-			`@` { 64 }
-			`\\` { 92 }
-			`\`` { 96 }
-			`{` { 123 }
-			`}` { 125 }
-			else { none }
-		}
-	}
-	runes := value.runes()
-	if runes.len == 1 {
-		return runes[0]
-	}
-	return none
-}
-
 fn char_literal_number_value(value string) ?i64 {
-	return i64(char_literal_rune_value(value)?)
+	return i64(ast.char_literal_rune_value(value)?)
 }
 
 fn (mut c Checker) get_comptime_number_value(mut expr ast.Expr) ?i64 {

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -602,7 +602,10 @@ fn (mut c Checker) check_match_branch_last_stmt(mut last_stmt ast.ExprStmt, ret_
 	}
 }
 
-fn char_literal_number_value(value string) ?i64 {
+fn char_literal_rune_value(value string) ?rune {
+	if value.len == 1 {
+		return rune(value[0])
+	}
 	if value.len == 2 && value[0] == `\\` {
 		return match value[1] {
 			`a` { 7 }
@@ -630,6 +633,10 @@ fn char_literal_number_value(value string) ?i64 {
 		return runes[0]
 	}
 	return none
+}
+
+fn char_literal_number_value(value string) ?i64 {
+	return i64(char_literal_rune_value(value)?)
 }
 
 fn (mut c Checker) get_comptime_number_value(mut expr ast.Expr) ?i64 {

--- a/vlib/v/checker/tests/invalid_utf8_string.out
+++ b/vlib/v/checker/tests/invalid_utf8_string.out
@@ -1,3 +1,3 @@
 vlib/v/checker/tests/invalid_utf8_string.vv:1:6: notice: invalid utf8 byte sequence in string literal
     1 | _ := '≤‚ ‘txt'
-      |      ~~~~~~~
+      |      ~~~~~~~~~

--- a/vlib/v/checker/tests/match_duplicate_branch_mixed_int_literals.out
+++ b/vlib/v/checker/tests/match_duplicate_branch_mixed_int_literals.out
@@ -12,3 +12,10 @@ vlib/v/checker/tests/match_duplicate_branch_mixed_int_literals.vv:17:3: error: m
       |         ~~~~~~~~~~~~
    18 |             println('line feed')
    19 |         }
+vlib/v/checker/tests/match_duplicate_branch_mixed_int_literals.vv:29:3: error: match case `255` is handled more than once
+   27 |     match ch {
+   28 |         `\xff` {}
+   29 |         255 {}
+      |         ~~~
+   30 |         else {}
+   31 |     }

--- a/vlib/v/checker/tests/match_duplicate_branch_mixed_int_literals.vv
+++ b/vlib/v/checker/tests/match_duplicate_branch_mixed_int_literals.vv
@@ -23,7 +23,16 @@ fn parse_cast(ch u8) ! {
 	}
 }
 
+fn parse_high_byte(ch u8) {
+	match ch {
+		`\xff` {}
+		255 {}
+		else {}
+	}
+}
+
 fn main() {
 	parse(`<`)!
 	parse_cast(`\n`)!
+	parse_high_byte(255)
 }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7380,6 +7380,10 @@ fn (mut g Gen) char_literal(node ast.CharLiteral) {
 	}
 	if node.val.len == 1 {
 		clit := node.val[0]
+		if clit > 127 {
+			g.write('((rune)${clit})')
+			return
+		}
 		if clit < 32 || clit == 92 || clit > 126 {
 			g.write("'")
 			write_octal_escape(mut g.out, clit)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4210,9 +4210,10 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 				}
 			}
 			g.stmt(stmt)
-			if stmt is ast.ExprStmt && (g.inside_if_option || g.inside_if_result
-				|| g.inside_match_option || g.inside_match_result
-				|| (stmt.expr is ast.IndexExpr && stmt.expr.or_expr.kind != .absent)) {
+			if g.inside_ternary == 0 && stmt is ast.ExprStmt && (g.inside_if_option
+				|| g.inside_if_result || g.inside_match_option
+				|| g.inside_match_result || (stmt.expr is ast.IndexExpr
+				&& stmt.expr.or_expr.kind != .absent)) {
 				g.writeln(';')
 			}
 		}
@@ -7377,11 +7378,6 @@ fn (mut g Gen) char_literal(node ast.CharLiteral) {
 		g.write("'`'")
 		return
 	}
-	// TODO: optimize use L-char instead of u32 when possible
-	if !node.val.is_pure_ascii() {
-		g.write('((rune)0x${node.val.utf32_code().hex()} /* `${node.val}` */)')
-		return
-	}
 	if node.val.len == 1 {
 		clit := node.val[0]
 		if clit < 32 || clit == 92 || clit > 126 {
@@ -7390,6 +7386,11 @@ fn (mut g Gen) char_literal(node ast.CharLiteral) {
 			g.write("'")
 			return
 		}
+	}
+	// TODO: optimize use L-char instead of u32 when possible
+	if !node.val.is_pure_ascii() {
+		g.write('((rune)0x${node.val.utf32_code().hex()} /* `${node.val}` */)')
+		return
 	}
 	g.write("'${node.val}'")
 }

--- a/vlib/v/gen/wasm/asm.v
+++ b/vlib/v/gen/wasm/asm.v
@@ -185,7 +185,7 @@ pub fn (mut g Gen) asm_literal_arg(node ast.AsmTemplate) {
 			}
 		}
 		ast.CharLiteral {
-			u32(arg.val.runes()[0]).str() // there is a better way.
+			u32(ast.char_literal_rune_value(arg.val) or { panic('unreachable') }).str()
 		}
 		ast.IntegerLiteral {
 			arg.val

--- a/vlib/v/gen/wasm/gen.v
+++ b/vlib/v/gen/wasm/gen.v
@@ -1264,7 +1264,7 @@ pub fn (mut g Gen) expr(node ast.Expr, expected ast.Type) {
 			g.set_set(v)
 		}
 		ast.CharLiteral {
-			rns := serialise.eval_escape_codes_raw(node.val) or { panic('unreachable') }.runes()[0]
+			rns := ast.char_literal_rune_value(node.val) or { panic('unreachable') }
 			g.func.i32_const(i32(rns))
 		}
 		ast.Ident {
@@ -1877,11 +1877,7 @@ fn (mut g Gen) eval_enum_field_expr(expr ast.Expr) ?i64 {
 			return expr.val.i64()
 		}
 		ast.CharLiteral {
-			runes := expr.val.runes()
-			if runes.len == 0 {
-				return none
-			}
-			return i64(runes[0])
+			return i64(ast.char_literal_rune_value(expr.val)?)
 		}
 		ast.BoolLiteral {
 			return if expr.val { i64(1) } else { i64(0) }

--- a/vlib/v/gen/wasm/mem.v
+++ b/vlib/v/gen/wasm/mem.v
@@ -215,7 +215,7 @@ pub fn (mut g Gen) literal_to_constant_expression(typ_ ast.Type, init ast.Expr) 
 			return wasm.constexpr_value(int(init.val))
 		}
 		ast.CharLiteral {
-			return wasm.constexpr_value(int(init.val.runes()[0]))
+			return wasm.constexpr_value(int(ast.char_literal_rune_value(init.val)?))
 		}
 		ast.FloatLiteral {
 			if typ == ast.f32_type {

--- a/vlib/v/gen/wasm/serialise/serialise.v
+++ b/vlib/v/gen/wasm/serialise/serialise.v
@@ -350,7 +350,9 @@ pub fn (mut p Pool) append(init ast.Expr, typ ast.Type) (int, bool) {
 		}
 		ast.CharLiteral {
 			// 3 extra bytes for improved program correctness, thank me later
-			rne := u32(eval_escape_codes_raw(init.val) or { panic('Pool.append: ${err}') }.runes()[0])
+			rne := u32(ast.char_literal_rune_value(init.val) or {
+				panic('Pool.append: invalid char literal')
+			})
 			pos := p.alignment(4)
 			p.u32(rne)
 

--- a/vlib/v/tests/char_literal_bytes_test.v
+++ b/vlib/v/tests/char_literal_bytes_test.v
@@ -528,3 +528,19 @@ fn test_high_byte_char_literals_preserve_comptime_value() {
 	assert high_byte_char_literal == rune(255)
 	assert high_byte_char_literal_int == 255
 }
+
+fn high_byte_char_literal_transformer_branch() int {
+	if `\x80` == `\xff` {
+		return 1
+	}
+	if `\x80` < `\xff` {
+		return 2
+	}
+	return 3
+}
+
+fn test_high_byte_char_literals_preserve_transformer_value() {
+	assert `\x80` != `\xff`
+	assert `\x80` < `\xff`
+	assert high_byte_char_literal_transformer_branch() == 2
+}

--- a/vlib/v/tests/char_literal_bytes_test.v
+++ b/vlib/v/tests/char_literal_bytes_test.v
@@ -520,3 +520,11 @@ fn test_high_byte_char_literals_preserve_rune_value() {
 	assert `\x80` == rune(128)
 	assert `\xff` == rune(255)
 }
+
+const high_byte_char_literal = `\xff`
+const high_byte_char_literal_int = int(`\xff`)
+
+fn test_high_byte_char_literals_preserve_comptime_value() {
+	assert high_byte_char_literal == rune(255)
+	assert high_byte_char_literal_int == 255
+}

--- a/vlib/v/tests/char_literal_bytes_test.v
+++ b/vlib/v/tests/char_literal_bytes_test.v
@@ -513,3 +513,10 @@ fn test_all_byte_char_literals() {
 	a = `\xff`
 	assert u8(a) == u8(255)
 }
+
+fn test_high_byte_char_literals_preserve_rune_value() {
+	assert int(`\x80`) == 128
+	assert int(`\xff`) == 255
+	assert `\x80` == rune(128)
+	assert `\xff` == rune(255)
+}

--- a/vlib/v/tests/return_match_expr_with_nest_match_expr_test.v
+++ b/vlib/v/tests/return_match_expr_with_nest_match_expr_test.v
@@ -30,3 +30,37 @@ fn test_return_match_expr_with_nest_match_expr() {
 		b: true
 	})
 }
+
+type Issue27632Operand = i8 | u8
+
+struct Issue27632Instruction {
+	src Issue27632Operand
+	dst Issue27632Operand
+}
+
+fn issue_27632_oops(itn Issue27632Instruction) !bool {
+	return match itn.dst {
+		u8 {
+			match itn.src {
+				u8 {
+					res := if itn.src != 0 { true } else { false }
+					return res
+				}
+				else {
+					panic('failed to cast src')
+				}
+			}
+		}
+		else {
+			panic('failed to cast dst')
+		}
+	}
+}
+
+fn test_issue_27632_return_match_result_nested_if_expr() {
+	itn := Issue27632Instruction{
+		dst: u8(1)
+		src: u8(42)
+	}
+	assert issue_27632_oops(itn)! == true
+}

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -1127,8 +1127,8 @@ pub fn (mut t Transformer) infix_expr(mut node ast.InfixExpr) ast.Expr {
 			ast.CharLiteral {
 				match mut node.right {
 					ast.CharLiteral {
-						left_val := node.left.val.runes()[0]
-						right_val := node.right.val.runes()[0]
+						left_val := ast.char_literal_rune_value(node.left.val) or { return node }
+						right_val := ast.char_literal_rune_value(node.right.val) or { return node }
 
 						match node.op {
 							.eq {


### PR DESCRIPTION
## Summary
- reject malformed UTF-8 sequences with replacement rune handling in builtin and encoding helpers
- avoid adding statement semicolons inside generated C ternary operands for nested return match results
- add regression coverage for #27630 and #27632

## Tests
- `./vnew vlib/builtin/utf8_test.v`
- `./vnew vlib/encoding/utf8/utf8_util_test.v`
- `./vnew vlib/v/tests/return_match_expr_with_nest_match_expr_test.v`
- `./vnew vlib/builtin/string_iterator_test.v`
- `./vnew vlib/v/tests/char_literal_bytes_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/`

Fixes #27630
Fixes #27632