### PR TITLE
time: declare the Linux timerfd C API (timerfd_create/settime/gettime)

### DIFF
--- a/vlib/time/timerfd_linux.c.v
+++ b/vlib/time/timerfd_linux.c.v
@@ -1,0 +1,34 @@
+module time
+
+// Declarations for the Linux timerfd API (timerfd_create(2)): kernel timers
+// delivered as FD READABILITY. Import `time` and call them directly — create,
+// arm with C.timerfd_settime + C.itimerspec, then read 8 bytes (a u64 count
+// of expirations since the last read) from the fd, or register the fd with
+// epoll / os.notify and treat expiry as just another readiness event.
+//
+// This file is only compiled on Linux; guard call sites with `$if linux {`.
+//
+// Example (a 1 s periodic tick inside an event loop):
+// ```v ignore
+// tfd := C.timerfd_create(C.CLOCK_MONOTONIC, C.TFD_CLOEXEC | C.TFD_NONBLOCK)
+// spec := C.itimerspec{
+// 	it_value:    C.timespec{1, 0}
+// 	it_interval: C.timespec{1, 0}
+// }
+// C.timerfd_settime(tfd, 0, &spec, unsafe { nil })
+// // ... register tfd for readability; on the event:
+// mut expirations := u64(0)
+// C.read(tfd, &expirations, 8) // re-levels the fd; > 1 reports missed ticks
+// ```
+
+#include <sys/timerfd.h>
+
+pub struct C.itimerspec {
+pub mut:
+	it_interval C.timespec
+	it_value    C.timespec
+}
+
+fn C.timerfd_create(clockid int, flags int) int
+fn C.timerfd_settime(fd int, flags int, new_value &C.itimerspec, old_value &C.itimerspec) int
+fn C.timerfd_gettime(fd int, curr_value &C.itimerspec) int

--- a/vlib/time/timerfd_test.c.v
+++ b/vlib/time/timerfd_test.c.v
@@ -1,0 +1,26 @@
+import time
+
+fn test_timerfd_periodic_expirations_are_counted() {
+	$if linux {
+		tfd := C.timerfd_create(C.CLOCK_MONOTONIC, C.TFD_CLOEXEC | C.TFD_NONBLOCK)
+		assert tfd >= 0
+		spec := C.itimerspec{
+			it_value:    C.timespec{0, 5_000_000} // first expiry after 5 ms
+			it_interval: C.timespec{0, 5_000_000} // then every 5 ms
+		}
+		assert C.timerfd_settime(tfd, 0, &spec, unsafe { nil }) == 0
+		mut expirations := u64(0)
+		// non-blocking fd, nothing expired yet: read fails with EAGAIN
+		assert C.read(tfd, &expirations, 8) == -1
+		time.sleep(23 * time.millisecond)
+		assert C.read(tfd, &expirations, 8) == 8
+		assert expirations >= 2 // ~4 expected; missed ticks are counted, not lost
+		// disarm: zero it_value stops the timer
+		zero := C.itimerspec{}
+		assert C.timerfd_settime(tfd, 0, &zero, unsafe { nil }) == 0
+		mut curr := C.itimerspec{}
+		assert C.timerfd_gettime(tfd, &curr) == 0
+		assert curr.it_value.tv_sec == 0 && curr.it_value.tv_nsec == 0
+		C.close(tfd)
+	}
+}


### PR DESCRIPTION
## Summary

Declare the Linux `timerfd` API once, in the `time` module (`timerfd_linux.c.v`): `fn C.timerfd_create/C.timerfd_settime/C.timerfd_gettime` + `pub struct C.itimerspec` (reusing the module's existing `C.timespec`) + the `#include <sys/timerfd.h>`.

C declarations are visible to importing modules and the include lands in the generated C globally — so `import time` is enough for event-loop code to use the kernel API directly, instead of every project copying the same three declarations and a hand-built `itimerspec`:

```v ignore
import time

$if linux {
	tfd := C.timerfd_create(C.CLOCK_MONOTONIC, C.TFD_CLOEXEC | C.TFD_NONBLOCK)
	spec := C.itimerspec{
		it_value:    C.timespec{1, 0}
		it_interval: C.timespec{1, 0} // kernel-paced 1 s tick, no drift
	}
	C.timerfd_settime(tfd, 0, &spec, unsafe { nil })
	// register tfd with epoll / os.notify; on readiness:
	mut expirations := u64(0)
	C.read(tfd, &expirations, 8) // re-levels the fd; > 1 reports missed ticks
}
\`\`\`

## Why declarations-only (reworked from the first version of this PR)

The first iteration was a full `os.timerfd` wrapper module — but V values cross-platform APIs, and timerfd is a Linux kernel interface with no honest portable equivalent (kqueue's `EVFILT_TIMER` is not a readable fd you can hand to *another* multiplexer, so a portable façade would leak). Plain declarations in a `_linux.c.v` file are the honest shape: zero abstraction, zero overhead, `$if linux` at call sites, and nothing pretending to be portable.

## Tests

`vlib/time/timerfd_test.c.v` (self-skips off Linux; the module and importers still compile everywhere — verified `v -check -os windows|macos`): periodic 5 ms timer via the declared API, EAGAIN before expiry on a non-blocking fd, missed-tick counting after a 23 ms sleep (`read` returns the u64 expiration count), disarm via zero `it_value`, `timerfd_gettime` readback.

Use case: a per-worker cached `Date:` header refreshed by a 1 s timerfd inside the worker's own epoll loop (no extra thread, no locks) — https://github.com/enghitalo/vanilla/blob/main/examples/async_date_timerfd/main.v — related to #27638 / #27639 / #27641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)