### PR TITLE
compiler: fix ownership translation and C backend blockers

### DIFF
--- a/thirdparty/stdatomic/nix/atomic.S
+++ b/thirdparty/stdatomic/nix/atomic.S
@@ -63,9 +63,17 @@ _V_atomic_thread_fence:
 #if defined __aarch64__
         .text
 
+#if defined(__APPLE__)
+        /* Mach-O prepends a leading underscore to C symbols, so the C name
+           `_V_atomic_thread_fence` is the asm symbol `__V_atomic_thread_fence`.
+           Mach-O also has no `.type ... %function` directive. */
+        .global __V_atomic_thread_fence
+__V_atomic_thread_fence:
+#else
         .global _V_atomic_thread_fence
         .type   _V_atomic_thread_fence, %function
 _V_atomic_thread_fence:
+#endif
 #ifdef __TINYC__
         .int 0xd5033bbf
         .int 0xd65f03c0

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -11326,12 +11326,16 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			}
 		}
 	}
-	// When the expression uses `?` or `!` propagation, the evaluated type is
-	// unwrapped (the option/result flag should be stripped).
+	// When the expression uses `?`/`!` propagation or an `or { }` block, the
+	// evaluated value is unwrapped, so the option/result flag should be stripped
+	// from type0. Otherwise a `return opt_var or { ... }` (or `return map[k] or
+	// { ... }` on an option-valued map) is treated as already-optional and the
+	// unwrapped value is returned without being re-wrapped into the option.
 	if exprs_len > 0 {
 		or_kind := match expr0 {
 			ast.SelectorExpr { expr0.or_block.kind }
 			ast.Ident { expr0.or_expr.kind }
+			ast.IndexExpr { expr0.or_expr.kind }
 			else { ast.OrKind.absent }
 		}
 
@@ -11339,6 +11343,8 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 			type0 = type0.clear_flag(.option)
 		} else if or_kind == .propagate_result {
 			type0 = type0.clear_flag(.result)
+		} else if or_kind == .block {
+			type0 = type0.clear_flag(.option).clear_flag(.result)
 		}
 	}
 	if exprs_len > 0 && expr0 is ast.Ident && expr0.obj is ast.Var && expr0.obj.typ != 0 {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -6363,9 +6363,27 @@ fn array_mut_arg_is_addressable(expr ast.Expr) bool {
 }
 
 fn (mut g Gen) call_args(node ast.CallExpr) {
+	// Call arguments are independent expressions: an option/result-typed argument
+	// wraps itself based on its own expected type, not on any enclosing if/match
+	// option context. Reset those flags so that a nested if/match expression used as
+	// a plain (non-option) argument is not wrongly option-wrapped with the enclosing
+	// function's return type (e.g. `return match { X { SV(create(if c { EnumA } else
+	// { EnumB })) } }` in an `?SV` fn would wrap the enum branch as `?SV`).
+	prev_inside_if_option := g.inside_if_option
+	prev_inside_match_option := g.inside_match_option
+	prev_inside_if_result := g.inside_if_result
+	prev_inside_match_result := g.inside_match_result
+	g.inside_if_option = false
+	g.inside_match_option = false
+	g.inside_if_result = false
+	g.inside_match_result = false
 	g.expected_fixed_arr = true
 	defer {
 		g.expected_fixed_arr = false
+		g.inside_if_option = prev_inside_if_option
+		g.inside_match_option = prev_inside_match_option
+		g.inside_if_result = prev_inside_if_result
+		g.inside_match_result = prev_inside_match_result
 	}
 	args := if g.is_js_call {
 		if node.args.len < 1 {

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -925,7 +925,22 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 					g.write(' = ${addr}')
 					g.expr(node.cond)
 					if info.is_fn_ret {
-						g.write('.ret_arr')
+						// g.expr(node.cond) already appends `.ret_arr` when the cond
+						// is itself a fixed-array-returning call or a fixed-ret temp
+						// (see fn.v / cgen.v). Only add it here for other exprs (e.g. a
+						// plain variable holding a fn-ret fixed array) to avoid a
+						// doubled `.ret_arr` (which is not a struct member).
+						mut cond_expr := node.cond
+						if cond_expr is ast.ParExpr {
+							cond_expr = cond_expr.expr
+						}
+						cond_emits_ret_arr := (cond_expr is ast.CallExpr
+							&& !cond_expr.return_type.has_option_or_result()
+							&& g.table.final_sym(cond_expr.return_type).kind == .array_fixed)
+							|| (cond_expr is ast.CTempVar && cond_expr.is_fixed_ret)
+						if !cond_emits_ret_arr {
+							g.write('.ret_arr')
+						}
 					}
 					g.writeln('[${idx}];')
 				}

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -5,6 +5,39 @@ module c
 
 import v.ast
 
+// write_option_wrapper_if_assignment_smartcast handles an option variable that
+// carries an assignment smartcast (recorded when a non-option value was assigned
+// to it earlier in its scope). In that state g.expr() would emit the unwrapped
+// `.data` access, but contexts that need the option wrapper itself (e.g. an
+// `if x := opt { }` guard) must use the variable name directly. Returns true if
+// it wrote the wrapper name; false means the caller should fall back to g.expr().
+fn (mut g Gen) write_option_wrapper_if_assignment_smartcast(expr ast.Expr) bool {
+	if expr is ast.Ident {
+		mut is_assignment_smartcast := false
+		if expr.obj is ast.Var && expr.obj.is_assignment_smartcast {
+			is_assignment_smartcast = true
+		} else if g.file != unsafe { nil } {
+			scope := g.file.scope.innermost(expr.pos.pos)
+			if scope != unsafe { nil } {
+				if v := scope.find_var(expr.name) {
+					is_assignment_smartcast = v.is_assignment_smartcast
+				}
+			}
+		}
+		if !is_assignment_smartcast {
+			return false
+		}
+		name := c_name(expr.name)
+		if expr.is_auto_heap() {
+			g.write('(*${name})')
+		} else {
+			g.write(name)
+		}
+		return true
+	}
+	return false
+}
+
 fn (mut g Gen) resolved_if_guard_expr_type(expr ast.Expr, default_type ast.Type) ast.Type {
 	if expr is ast.IndexExpr {
 		left_type := g.resolved_map_type_from_expr(expr.left, expr.left_type)
@@ -571,7 +604,10 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 				}
 			} else {
 				g.write('if (${var_name} = ')
-				g.expr(branch.cond.expr)
+				if !(guard_expr_type.has_flag(.option)
+					&& g.write_option_wrapper_if_assignment_smartcast(branch.cond.expr)) {
+					g.expr(branch.cond.expr)
+				}
 				if guard_expr_type.has_flag(.option) {
 					dot_or_ptr := if !guard_expr_type.has_flag(.option_mut_param_t) {
 						'.'

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -588,7 +588,14 @@ fn (mut g Gen) gen_struct_pointer_eq_op(node ast.InfixExpr, left_type ast.Type, 
 	mut restore_stmt := false
 	mut left_expr := ''
 	mut right_expr := ''
-	if left_type.is_ptr() && !node.left.is_lvalue() && !inside_and_rhs {
+	// An operand that itself needs statement hoisting (e.g. it contains an `or { }`
+	// block) must be evaluated once into a ctemp, not inlined via expr_string: the
+	// pointer-equality expansion references each operand up to 3 times, and an
+	// `x or { }` is (wrongly) reported as an lvalue by is_lvalue() (it only inspects
+	// the base ident), so without this it would emit the or-block statement multiple
+	// times, tangling the generated C.
+	if left_type.is_ptr() && (!node.left.is_lvalue() || g.need_tmp_var_in_expr(node.left))
+		&& !inside_and_rhs {
 		if !restore_stmt {
 			stmt_str = g.go_before_last_stmt().trim_space()
 			g.empty_line = true
@@ -600,7 +607,8 @@ fn (mut g Gen) gen_struct_pointer_eq_op(node ast.InfixExpr, left_type ast.Type, 
 	} else {
 		left_expr = g.expr_string(node.left)
 	}
-	if right_type.is_ptr() && !node.right.is_lvalue() && !inside_and_rhs {
+	if right_type.is_ptr() && (!node.right.is_lvalue() || g.need_tmp_var_in_expr(node.right))
+		&& !inside_and_rhs {
 		if !restore_stmt {
 			stmt_str = g.go_before_last_stmt().trim_space()
 			g.empty_line = true
@@ -1993,9 +2001,24 @@ fn (mut g Gen) gen_is_none_check(node ast.InfixExpr) {
 			}
 		}
 		// For Ident nodes that have been unwrapped by a smartcast (e.g. from a
-		// none-guard fallthrough), write the variable name directly to avoid
-		// g.expr() generating the unwrapped data access instead of the option wrapper.
-		if node.left is ast.Ident && node.left.obj is ast.Var && node.left.obj.is_unwrapped {
+		// none-guard fallthrough) or by an assignment smartcast (assigning a non-option
+		// value to an option variable elsewhere in the scope), write the variable name
+		// directly to avoid g.expr() generating the unwrapped `.data` access instead of
+		// the option wrapper. A none-check always operates on the option wrapper's
+		// `.state`. The assignment smartcast is recorded on the scope var (not on the
+		// captured node.left.obj), so it is looked up by position here.
+		mut ident_is_assignment_smartcast := false
+		if node.left is ast.Ident && node.left_type.has_flag(.option) {
+			scope := g.file.scope.innermost(node.left.pos.pos)
+			if scope != unsafe { nil } {
+				if v := scope.find_var(node.left.name) {
+					ident_is_assignment_smartcast = v.is_assignment_smartcast
+				}
+			}
+		}
+		if node.left is ast.Ident && node.left.obj is ast.Var
+			&& (node.left.obj.is_unwrapped || node.left.obj.is_assignment_smartcast
+			|| ident_is_assignment_smartcast) {
 			name := c_name(node.left.name)
 			if node.left.is_auto_heap() {
 				g.write('(*${name})')
@@ -2189,7 +2212,7 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 	is_safe_div := node.op == .div && is_integer_div_mod
 	is_safe_mod := node.op == .mod && is_integer_div_mod
 	if resolved_left_type.is_ptr() && node.left.is_auto_deref_var()
-		&& !resolved_right_type.is_pointer() {
+		&& !resolved_right_type.is_any_kind_of_pointer() {
 		g.write('*')
 	} else if !g.inside_interface_deref && node.left is ast.Ident
 		&& g.table.is_interface_var(node.left.obj) {
@@ -2242,7 +2265,7 @@ fn (mut g Gen) gen_plain_infix_expr(node ast.InfixExpr) {
 		g.write('(${g.styp(resolved_right_type)})')
 	}
 	if resolved_right_type.is_ptr() && node.right.is_auto_deref_var()
-		&& !resolved_left_type.is_pointer() {
+		&& !resolved_left_type.is_any_kind_of_pointer() {
 		g.write('*')
 		g.expr(node.right)
 	} else {

--- a/vlib/v/tests/builtin_arrays/array_fixed_for_loop_test.v
+++ b/vlib/v/tests/builtin_arrays/array_fixed_for_loop_test.v
@@ -14,3 +14,29 @@ fn test_main() {
 	arr := foo()
 	assert arr == [4]i16{}
 }
+
+struct Sel {
+	hashes [4]u32
+}
+
+fn (s &Sel) ancestor_hashes() [4]u32 {
+	return s.hashes
+}
+
+// Iterating a fixed array returned *directly* from a call must not double the
+// `.ret_arr` access (regression: produced `call(...).ret_arr.ret_arr[i]`).
+fn test_for_in_fixed_array_return_from_call() {
+	s := Sel{
+		hashes: [u32(1), 2, 0, 4]!
+	}
+	mut nonzero := 0
+	mut sum := u32(0)
+	for hash in s.ancestor_hashes() {
+		if hash != 0 {
+			nonzero++
+		}
+		sum += hash
+	}
+	assert nonzero == 3
+	assert sum == 7
+}

--- a/vlib/v/tests/return_match_expr_with_nest_match_expr_test.v
+++ b/vlib/v/tests/return_match_expr_with_nest_match_expr_test.v
@@ -64,3 +64,31 @@ fn test_issue_27632_return_match_result_nested_if_expr() {
 	}
 	assert issue_27632_oops(itn)! == true
 }
+
+enum MatchResultArgKind {
+	a
+	b
+}
+
+struct MatchResultArgWrapped {
+	value MatchResultArgKind
+}
+
+fn match_result_arg_wrap(value MatchResultArgKind) MatchResultArgWrapped {
+	return MatchResultArgWrapped{
+		value: value
+	}
+}
+
+fn match_result_arg_nested_if(x int, cond bool) !MatchResultArgWrapped {
+	return match x {
+		0 { match_result_arg_wrap(if cond { .a } else { .b }) }
+		else { error('x') }
+	}
+}
+
+fn test_match_result_context_is_cleared_for_call_args() {
+	assert match_result_arg_nested_if(0, false)! == MatchResultArgWrapped{
+		value: .b
+	}
+}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -7477,7 +7477,14 @@ fn (mut g FlatGen) atomic_builtin_compat_decls() {
 	g.writeln('static inline bool atomic_compare_exchange_weak_u64(void* ptr, u64* expected, u64 desired) { return __atomic_compare_exchange_n((u64*)ptr, expected, desired, 1, 5, 5); }')
 	g.writeln('#endif')
 	g.writeln('static inline bool atomic_compare_exchange_weak_ptr(void* ptr, void* expected, ptrdiff_t desired) { return atomic_compare_exchange_strong_ptr(ptr, expected, desired); }')
+	// tcc's arm64 backend rejects inline asm ("ARM asm not implemented"), even the
+	// empty compiler-barrier form. cpu_relax is only a spin-loop hint; the real memory
+	// ordering in those loops comes from the atomic ops, so a no-op is safe under tcc.
+	g.writeln('#ifdef __TINYC__')
+	g.writeln('static inline void cpu_relax(void) { }')
+	g.writeln('#else')
 	g.writeln('static inline void cpu_relax(void) { __asm__ __volatile__("" ::: "memory"); }')
+	g.writeln('#endif')
 }
 
 fn (mut g FlatGen) builtin_abi_decls() {
@@ -7510,7 +7517,17 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('#define memory_order_acq_rel 4')
 	g.writeln('#define memory_order_seq_cst 5')
 	g.writeln('#endif')
+	// tcc has no `__atomic_thread_fence` builtin. On the architectures where
+	// thirdparty/stdatomic/nix/atomic.S provides `_V_atomic_thread_fence`, route to
+	// that shim; on x86_64 Unix the assembly file provides `__atomic_thread_fence`
+	// directly, so keep the normal name there. clang/gcc keep the builtin.
+	g.writeln('#if defined(__TINYC__) && (defined(__i386__) || defined(__arm__) || defined(__aarch64__) || defined(__riscv) || (defined(__x86_64__) && defined(_WIN32)))')
+	g.writeln('extern void _V_atomic_thread_fence(int order);')
+	g.writeln('#define atomic_thread_fence(order) _V_atomic_thread_fence(order)')
+	g.writeln('#define __atomic_thread_fence(order) _V_atomic_thread_fence(order)')
+	g.writeln('#else')
 	g.writeln('#define atomic_thread_fence(order) __atomic_thread_fence(order)')
+	g.writeln('#endif')
 	// Weak fallbacks for the heap-tracking hooks. A program that provides real
 	// implementations (e.g. a `vheap_alloc`/`vheap_free` from a linked C file, as
 	// some projects do) overrides these without a redefinition/static-vs-non-static

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -1598,6 +1598,13 @@ fn (mut p Parser) interface_decl() flat.NodeId {
 			continue
 		}
 		field_name := p.expect_name_or_keyword()
+		if p.tok == .lsbr && p.peek() == .xor {
+			// Lifetime param list on an interface method: `name[^a](...)`. v3 erases
+			// lifetimes, so consume and drop the `[^a]` list; without this the following
+			// `(` is not seen as the method parameter list and the name is mis-parsed as a
+			// `[^a]`-typed (fixed-array) interface field, which then fails in cgen.
+			p.parse_generic_param_names()
+		}
 		if p.tok == .lpar {
 			// method: name(params) ret_type
 			p.next() // skip (
@@ -5617,27 +5624,57 @@ fn (mut p Parser) parse_fn_type_param() string {
 	return fn_type_param_with_mut(first, is_mut)
 }
 
+fn (mut p Parser) consume_lifetime_type_param() bool {
+	if p.tok != .xor {
+		return false
+	}
+	p.next()
+	if p.tok == .name {
+		p.next()
+	}
+	return true
+}
+
 fn (mut p Parser) parse_type_generic_suffix() string {
 	if p.tok != .lsbr {
 		return ''
 	}
 	pk := p.peek()
-	if pk != .name && pk != .amp && pk != .lsbr && pk != .question && pk != .key_fn {
+	if pk != .name && pk != .amp && pk != .lsbr && pk != .question && pk != .key_fn && pk != .xor {
 		return ''
 	}
 	p.next() // skip [
 	mut params := []string{}
-	params << p.parse_type_name()
-	for p.tok == .comma {
-		p.next()
-		params << p.parse_type_name()
+	for p.tok != .rsbr && p.tok != .eof {
+		if !p.consume_lifetime_type_param() {
+			param := p.parse_type_name()
+			if param.len > 0 {
+				params << param
+			}
+		}
+		if p.tok == .comma {
+			p.next()
+			continue
+		}
+		break
 	}
 	p.check(.rsbr)
+	if params.len == 0 {
+		return ''
+	}
 	return '[' + params.join(', ') + ']'
 }
 
 // parse_type_name reads parse type name input for parser.
 fn (mut p Parser) parse_type_name() string {
+	// Lifetime annotation `^a` (as in `&^a T`, `?&^a T`, `Type[^a]`). v3 erases lifetimes -
+	// they have no runtime representation, so consume the caret and the lifetime name and
+	// continue with the underlying type. Without this, `&^a T` parses as just `&` and the
+	// stray `^` desyncs the enclosing declaration (e.g. a `&^a Recv` method receiver made the
+	// method name get consumed as the return type).
+	if p.consume_lifetime_type_param() {
+		return p.parse_type_name()
+	}
 	if p.tok == .name && p.lit == '&' {
 		p.next()
 		return '&' + p.parse_type_name()

--- a/vlib/v3/tests/ownership/ownership_test.v
+++ b/vlib/v3/tests/ownership/ownership_test.v
@@ -22,7 +22,7 @@ fn run_ownership_check(v3_bin string, name string, code string) os.Result {
 	src := os.join_path(tmp_dir, 'main.v')
 	out := os.join_path(tmp_dir, 'out')
 	os.write_file(src, code) or { panic(err) }
-	return os.execute('${v3_bin} -d ownership -b c -o ${out} ${src} 2>&1')
+	return os.execute('${v3_bin} -ownership -b c -o ${out} ${src} 2>&1')
 }
 
 fn run_ownership_check_c_only(v3_bin string, name string, code string) os.Result {
@@ -32,7 +32,7 @@ fn run_ownership_check_c_only(v3_bin string, name string, code string) os.Result
 	src := os.join_path(tmp_dir, 'main.v')
 	out := os.join_path(tmp_dir, 'out.c')
 	os.write_file(src, code) or { panic(err) }
-	return os.execute('${v3_bin} -d ownership -b c -o ${out} ${src} 2>&1')
+	return os.execute('${v3_bin} -ownership -b c -o ${out} ${src} 2>&1')
 }
 
 fn run_ownership_check_with_module(v3_bin string, name string, main_code string, module_name string, module_code string) os.Result {
@@ -46,7 +46,7 @@ fn run_ownership_check_with_module(v3_bin string, name string, main_code string,
 	out := os.join_path(tmp_dir, 'out')
 	os.write_file(src, main_code) or { panic(err) }
 	os.write_file(mod_src, module_code) or { panic(err) }
-	return os.execute('${v3_bin} -d ownership -b c -o ${out} ${src} 2>&1')
+	return os.execute('${v3_bin} -ownership -b c -o ${out} ${src} 2>&1')
 }
 
 fn run_ownership_delegate_check(name string, code string) os.Result {
@@ -230,8 +230,31 @@ fn main() {
 	println(g)
 	_ = h
 }
-')
+	')
 	assert ok_plain_to_owned_method.exit_code == 0, ok_plain_to_owned_method.output
+
+	ok_builtin_string_receiver := run_ownership_check(v3_bin, 'builtin_string_receiver_borrows', "
+fn main() {
+	s := 'hello'.to_owned()
+	println(s.contains('h'))
+	println(s.contains('e'))
+}
+	")
+	assert ok_builtin_string_receiver.exit_code == 0, ok_builtin_string_receiver.output
+
+	fail_user_string_receiver := run_ownership_check(v3_bin, 'user_string_receiver_moves', '
+fn (s string) consume() {
+	_ = s
+}
+
+fn main() {
+	s := "hello".to_owned()
+	s.consume()
+	println(s)
+}
+	')
+	assert fail_user_string_receiver.exit_code != 0
+	assert fail_user_string_receiver.output.contains('use of moved value: `s`'), fail_user_string_receiver.output
 
 	ok_non_owned_clone_return := run_ownership_check(v3_bin, 'owned_receiver_clone_returns_int', '
 struct Resource implements Owned {
@@ -251,6 +274,31 @@ fn main() {
 }
 	')
 	assert ok_non_owned_clone_return.exit_code == 0, ok_non_owned_clone_return.output
+
+	fail_plain_struct_clone := run_ownership_check(v3_bin, 'plain_struct_clone_unknown', '
+struct Plain {
+	id int
+}
+
+fn main() {
+	_ := Plain{id: 1}.clone()
+}
+	')
+	assert fail_plain_struct_clone.exit_code != 0
+	assert fail_plain_struct_clone.output.contains('unknown function'), fail_plain_struct_clone.output
+
+	ok_iclone_default_clone := run_ownership_check(v3_bin, 'iclone_default_clone', '
+struct Resource implements IClone {
+	id int
+}
+
+fn main() {
+	r := Resource{id: 7}
+	c := r.clone()
+	println(c.id)
+}
+	')
+	assert ok_iclone_default_clone.exit_code == 0, ok_iclone_default_clone.output
 
 	fail_inferred_owned_global := run_ownership_check(v3_bin, 'inferred_owned_global', '
 struct Resource implements Owned {

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -77,6 +77,16 @@ fn test_interface_method_generic_type_only_param_is_not_parsed_as_name() {
 	assert interface_method_param_types(a, 'Sink', 'read') == ['[max_len]u8']
 }
 
+fn test_lifetime_generic_suffixes_are_erased() {
+	a := parse_parser_regression_source('lifetime_generic_suffixes',
+		'struct IgnoreMatch {}\nstruct Match[T] {}\n\ninterface Matcher {\n\tmatched[^a](item Match[IgnoreMatch[^a]]) IgnoreMatch[^a]\n}\n\nfn use(item Match[IgnoreMatch[^a]]) {}\nfn after() int {\n\treturn 1\n}\n')
+	assert interface_method_param_types(a, 'Matcher', 'matched') == [
+		'Match[IgnoreMatch]',
+	]
+	assert fn_decl_param_pairs(a, .fn_decl, 'use') == ['item:Match[IgnoreMatch]']
+	assert fn_decl_param_pairs(a, .fn_decl, 'after') == []
+}
+
 fn test_c_function_anonymous_params_are_parsed_as_types() {
 	a := parse_parser_regression_source('c_anon_params',
 		'struct T {}\nstruct C.FILE {}\nstruct C.Widget {}\nstruct C.Node {}\ntype MyHandle = voidptr\n\nfn C.anon(&C.FILE, voidptr, int, &&T, [4]&C.Widget, ?&C.Node, !&C.Node, fn (&C.Node) int) int\nfn C.custom(MyHandle, int, MyHandle) int\nfn C.lower(size_t, int, pthread_t) int\nfn C.named(stream &C.FILE, a, b int) int\nfn C.named_custom(handle MyHandle, a, b int) int\nfn C.named_arrays(m [16]f32, r []rune) int\nfn C.variadic(...int) int\nfn JS.js_anon(JS.Number) JS.Number\nfn JS.js_named(x JS.Number) JS.Number\nfn JS.setInterval(any, int, ...any) int\nfn JS.console.dir(any, any)\nfn JS.named_any(x any) any\nfn ordinary(int) {}\n')

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -3167,6 +3167,46 @@ fn (mut t Transformer) try_lower_flag_enum_call(node flat.Node) ?flat.NodeId {
 	return t.make_infix(.eq, masked, arg_copy)
 }
 
+// try_lower_struct_clone_method_call lowers `x.clone()` on a struct / sum-type value to a
+// plain copy of the receiver. Rust's `#[derive(Clone)]` maps to `implements IClone` in the
+// ownership translation, whose `clone()` is compiler-provided; V aggregates are value types,
+// so the copy is produced simply by evaluating the receiver (it is copied when assigned or
+// passed by value). Collection/string clones are lowered earlier, and a user-defined clone()
+// method is handled by try_lower_receiver_method_call before this runs.
+fn (mut t Transformer) try_lower_struct_clone_method_call(call_id flat.NodeId, node flat.Node) ?flat.NodeId {
+	if node.children_count == 0 {
+		return none
+	}
+	fn_id := t.a.children[node.children_start]
+	fn_node := t.a.nodes[int(fn_id)]
+	if fn_node.kind != .selector || fn_node.value != 'clone' || fn_node.children_count == 0 {
+		return none
+	}
+	base_id := t.a.children[fn_node.children_start]
+	raw_base_type := t.node_type(base_id)
+	mut base_type := raw_base_type
+	if base_type.starts_with('&') {
+		base_type = base_type[1..]
+	}
+	if base_type.starts_with('[]') || base_type.starts_with('map[') || base_type == 'string'
+		|| t.is_fixed_array_type(base_type) {
+		return none
+	}
+	if isnil(t.tc) || !t.tc.named_type_implements_marker(base_type, 'IClone') {
+		return none
+	}
+	// A user-defined clone() would have been lowered already; only supply the default copy.
+	if t.resolve_receiver_method_name(base_id, 'clone').len > 0 {
+		return none
+	}
+	mut receiver := t.transform_expr(base_id)
+	if raw_base_type.starts_with('&') {
+		receiver = t.make_prefix(.mul, receiver)
+		t.a.nodes[int(receiver)].typ = base_type
+	}
+	return receiver
+}
+
 // try_lower_array_method_call supports try lower array method call handling for Transformer.
 fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node flat.Node) ?flat.NodeId {
 	if node.children_count == 0 {
@@ -3923,6 +3963,9 @@ fn (mut t Transformer) try_lower_builtin_call(_id flat.NodeId, node flat.Node) ?
 	}
 	if receiver_call := t.try_lower_receiver_method_call(_id, node) {
 		return receiver_call
+	}
+	if clone_call := t.try_lower_struct_clone_method_call(_id, node) {
+		return clone_call
 	}
 	if string_call := t.try_lower_string_method_call(node) {
 		return string_call

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -198,6 +198,7 @@ pub mut:
 	struct_files                       map[string]string
 	struct_error_embeds_shadow_builtin map[string]bool
 	struct_generic_params              map[string][]string // generic struct base name -> type-param names (e.g. Vec4 -> [T])
+	struct_implements                  map[string][]string
 	struct_field_c_abi_fns             map[string]string
 	// concrete `Box[int].method` -> substituted CallInfo for a method *value* on a
 	// generic receiver. The open `Box[T].method` registration is gone by cgen time, so
@@ -303,6 +304,7 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		struct_files:                       map[string]string{}
 		struct_error_embeds_shadow_builtin: map[string]bool{}
 		struct_generic_params:              map[string][]string{}
+		struct_implements:                  map[string][]string{}
 		struct_field_c_abi_fns:             map[string]string{}
 		generic_method_value_info:          map[string]CallInfo{}
 		params_structs:                     map[string]bool{}
@@ -610,6 +612,10 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 						tc.struct_generic_params[node.value] = node.generic_params.clone()
 					}
 				}
+				implements_types := struct_decl_implements_from_typ(node.typ)
+				if implements_types.len > 0 {
+					tc.struct_implements[qname] = implements_types
+				}
 				if 'union' in node.typ.split(',') {
 					tc.unions[qname] = true
 				}
@@ -741,6 +747,19 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 					}
 				}
 				qname := tc.qualify_name(node.value)
+				// A `C.` struct denotes a single external C type, but several modules may
+				// mirror it with partial or imprecise field views (e.g. `C.termios` in both
+				// `term` and `term.termios`). codegen emits one C struct, so the field table
+				// must be a single canonical view. Keep the most complete (superset) view so
+				// it is deterministic regardless of module collection order, instead of
+				// letting whichever declaration is collected last silently win.
+				if qname.starts_with('C.') {
+					if existing := tc.structs[qname] {
+						if fields.len <= existing.len {
+							continue
+						}
+					}
+				}
 				tc.structs[qname] = fields
 				tc.struct_modules[qname] = tc.cur_module
 				tc.struct_files[qname] = tc.cur_file
@@ -1537,6 +1556,10 @@ fn (mut tc TypeChecker) register_fn_signature(name string, ret_type Type, params
 fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, params []Type, is_variadic bool, implicit_veb_ctx bool) {
 	tc.fn_ret_types[name] = ret_type
 	tc.fn_param_types[name] = params.clone()
+	if tc.cur_file.len > 0 {
+		tc.fn_type_files[name] = tc.cur_file
+		tc.fn_type_modules[name] = tc.cur_module
+	}
 	tc.fn_variadic[name] = is_variadic
 	tc.fn_implicit_veb_ctx[name] = implicit_veb_ctx
 	tc.add_receiver_method_suffix_index(name)
@@ -6866,6 +6889,20 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 				return tc.call_info(mname, true)
 			}
 		}
+		if fn_node.value == 'clone' && tc.type_has_compiler_default_clone(clean) {
+			// `#[derive(Clone)]` in Rust maps to `implements IClone` in the ownership
+			// translation, whose `clone()` is compiler-provided. V structs are value types,
+			// so `.clone()` yields a copy of the receiver: resolve it to the (unwrapped)
+			// receiver type. A user-defined `clone()` method is matched earlier via
+			// `receiver_method_name_candidates`, so this only supplies the default.
+			return CallInfo{
+				name:         ''
+				params:       tarr1(base_type)
+				return_type:  clean
+				has_receiver: true
+				params_known: true
+			}
+		}
 		if fn_node.value == 'str' {
 			return CallInfo{
 				name:         ''
@@ -7777,7 +7814,14 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 		return
 	}
 	if info.has_receiver && info.params.len > 0 {
-		fn_node := tc.a.child_node(&node, 0)
+		mut fn_node := tc.a.child_node(&node, 0)
+		// For an explicit generic method call `recv.method[T](...)`, the call's fn is an
+		// `.index` node (`recv.method` indexed by the type args), so its child 0 is the
+		// `recv.method` selector — a method value — not the receiver. Descend through the
+		// index to the underlying selector so the receiver resolves to `recv`.
+		if fn_node.kind == .index && fn_node.children_count > 0 {
+			fn_node = tc.a.child_node(fn_node, 0)
+		}
 		recv_id := tc.a.child(fn_node, 0)
 		tc.check_node(recv_id)
 		recv_type := tc.cached_expr_type(recv_id) or { tc.resolve_type(recv_id) }
@@ -10787,14 +10831,27 @@ fn (mut tc TypeChecker) resolve_expr(id flat.NodeId, expected Type) Type {
 			return actual
 		}
 	}
-	if node.kind == .enum_val && expected is Enum {
-		if tc.enum_value_matches(node.value, expected.name) {
-			tc.register_synth_type(id, expected_raw)
-			return expected_raw
+	if node.kind == .enum_val {
+		// The expected type may be the enum directly, or an option/result wrapper around
+		// it (`?Enum` / `!Enum`), e.g. `mut field ?LoggingMode` assigned `field = .debug`.
+		// Unwrap the option/result payload so the shorthand resolves against the inner
+		// enum. On success the node is typed as the *inner* enum (not the wrapper): a bare
+		// enum value assigned into an option is auto-wrapped by the assignment/return
+		// machinery, exactly like any other bare value assigned into an option, so the
+		// node itself must stay unwrapped for codegen to emit the wrap.
+		mut enum_expected := expected
+		if payload := contextual_payload_type(expected) {
+			enum_expected = payload
 		}
-		tc.type_mismatch(.assignment_mismatch,
-			'unknown enum field `${node.value}` for `${expected.name}`', id)
-		return Type(int_)
+		if enum_expected is Enum {
+			if tc.enum_value_matches(node.value, enum_expected.name) {
+				tc.register_synth_type(id, enum_expected)
+				return enum_expected
+			}
+			tc.type_mismatch(.assignment_mismatch,
+				'unknown enum field `${node.value}` for `${enum_expected.name}`', id)
+			return Type(int_)
+		}
 	}
 	// A bare generic struct literal (`Box{...}` / `&Box{...}`) adopts a matching concrete
 	// expected instance (`Box[int]` / `&Box[int]`), so `fn make() Box[int] { return
@@ -11834,6 +11891,91 @@ pub fn (tc &TypeChecker) named_type_implements_interface(concrete_name string, i
 		}
 	}
 	return true
+}
+
+fn struct_decl_implements_from_typ(typ string) []string {
+	mut out := []string{}
+	for part in struct_decl_typ_parts(typ) {
+		if !part.starts_with('implements=') {
+			continue
+		}
+		for iface in part['implements='.len..].split('|') {
+			clean := iface.trim_space()
+			if clean.len > 0 {
+				out << clean
+			}
+		}
+	}
+	return out
+}
+
+fn struct_decl_typ_parts(typ string) []string {
+	mut parts := []string{}
+	mut start := 0
+	mut depth := 0
+	for i, ch in typ {
+		if ch == `[` {
+			depth++
+		} else if ch == `]` {
+			if depth > 0 {
+				depth--
+			}
+		} else if ch == `,` && depth == 0 {
+			parts << typ[start..i]
+			start = i + 1
+		}
+	}
+	parts << typ[start..]
+	return parts
+}
+
+fn marker_type_name(name string) string {
+	mut clean := name.trim_space()
+	base, _, ok := generic_type_application_parts(clean)
+	if ok {
+		clean = base
+	}
+	return clean
+}
+
+fn interface_marker_matches(name string, target string) bool {
+	clean := marker_type_name(name)
+	target_clean := marker_type_name(target)
+	return clean == target_clean || clean.all_after_last('.') == target_clean
+		|| clean == target_clean.all_after_last('.')
+}
+
+pub fn (tc &TypeChecker) named_type_implements_marker(concrete_name string, target string) bool {
+	mut name := concrete_name.trim_space()
+	if name.starts_with('&') {
+		name = name[1..].trim_space()
+	}
+	name = marker_type_name(name)
+	mut candidates := [name]
+	if !name.contains('.') {
+		qname := tc.qualify_name(name)
+		if qname != name {
+			candidates << qname
+		}
+	} else if name.starts_with('main.') {
+		candidates << name['main.'.len..]
+	}
+	for candidate in candidates {
+		impls := tc.struct_implements[candidate] or { continue }
+		for impl_name in impls {
+			if interface_marker_matches(impl_name, target) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+fn (tc &TypeChecker) type_has_compiler_default_clone(t Type) bool {
+	if t is Struct {
+		return tc.named_type_implements_marker(t.name, 'IClone')
+	}
+	return false
 }
 
 // interface_impl_names returns the concrete type names (structs and type

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -3253,7 +3253,8 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 				returns_owned = true
 			}
 			if recv_owned && info.params[0] !is Pointer
-				&& !tc.ownership_method_keeps_receiver(fn_node.value) {
+				&& !tc.ownership_method_keeps_receiver(fn_node.value)
+				&& !tc.ownership_string_builtin_keeps_receiver(recv_id, fn_node.value) {
 				if info.name.len > 0 {
 					tc.ownership_state().ownership_fn_params['${info.name}__param_0'] = true
 				}
@@ -3261,7 +3262,8 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 			}
 			recv_name := tc.ownership_expr_ident_name(recv_id)
 			if recv_name.len > 0 && info.params[0] !is Pointer
-				&& !tc.ownership_method_keeps_receiver(fn_node.value) {
+				&& !tc.ownership_method_keeps_receiver(fn_node.value)
+				&& !tc.ownership_string_builtin_keeps_receiver(recv_id, fn_node.value) {
 				tc.ownership_prescan_transfer_owned_descendants_to_param(recv_name, info.name, 0, mut
 					owned_locals, local_types)
 			}
@@ -7155,7 +7157,8 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 			recv_id := tc.a.child(fn_node, 0)
 			recv_name := tc.ownership_expr_ident_name(recv_id)
 			if !tc.ownership_method_keeps_receiver(fn_node.value)
-				&& !tc.ownership_array_builtin_keeps_receiver(recv_id, fn_node.value) {
+				&& !tc.ownership_array_builtin_keeps_receiver(recv_id, fn_node.value)
+				&& !tc.ownership_string_builtin_keeps_receiver(recv_id, fn_node.value) {
 				if info.params[0] is Pointer {
 					if recv_name.len > 0 && tc.ownership_storage_participates(recv_name) {
 						tc.ownership_add_borrow(recv_name, call_name, id, tc.ownership_call_param_is_mut(call_name,
@@ -8707,6 +8710,14 @@ fn (mut tc TypeChecker) ownership_move_var(name string, target string, pos flat.
 fn (mut tc TypeChecker) ownership_move_var_result(name string, target string, pos flat.NodeId, is_fn_call bool, fn_name string, suggest_clone bool) bool {
 	mut st := tc.ownership_state()
 	if moved := tc.ownership_moved_conflict(name) {
+		// Re-moving the exact same value to the same target at the same node is one logical
+		// move recorded twice, not a use-after-move. This happens when a returned struct's
+		// owned descendant (e.g. `args.positional[*]`) is both marked as a return descendant
+		// and swept again as overlapping dynamic storage in the same `return`. Treat it as a
+		// no-op instead of reporting a spurious `use of moved value`.
+		if moved.name == name && moved.info.moved_to == target && moved.info.move_pos == pos {
+			return false
+		}
 		tc.ownership_report_moved(moved.name, moved.info, pos)
 		return false
 	}
@@ -9188,4 +9199,22 @@ fn (mut tc TypeChecker) ownership_array_builtin_keeps_receiver(recv_id flat.Node
 		return false
 	}
 	return unwrap_pointer(tc.resolve_type(recv_id)) is Array
+}
+
+// ownership_string_builtin_keeps_receiver reports whether a method call whose receiver is a
+// builtin `string` should borrow rather than move the receiver. Builtin string methods
+// (`contains`, `starts_with`, `split`, `to_upper`, ...) only read the receiver; none consume
+// the string's heap buffer, so a `string` receiver passed by value borrows just like Rust's
+// `&self` string methods. User-defined by-value string methods still move the receiver.
+fn (mut tc TypeChecker) ownership_string_builtin_keeps_receiver(recv_id flat.NodeId, method_name string) bool {
+	if unwrap_pointer(tc.resolve_type(recv_id)) !is String {
+		return false
+	}
+	return tc.ownership_fn_declared_in_builtin('string.${method_name}')
+}
+
+fn (tc &TypeChecker) ownership_fn_declared_in_builtin(fn_name string) bool {
+	file := tc.fn_type_files[fn_name] or { return false }
+	normalized := file.replace('\\', '/')
+	return normalized.starts_with('vlib/builtin/') || normalized.contains('/vlib/builtin/')
 }

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -30,6 +30,31 @@ fn run_compile_command(cmd string) os.Result {
 	}
 }
 
+fn tcc_atomic_s_arg(prefs &pref.Preferences) string {
+	target_os := prefs.normalized_target_os()
+	mut link_atomic_s := false
+	match target_os {
+		'macos' {
+			// atomic.S has Mach-O-compatible aarch64 symbols, but its x86_64 Unix
+			// stanza is ELF-only (`.type ... %function`). v3 does not yet track a
+			// separate target architecture, so use the compiler build architecture.
+			$if arm64 {
+				link_atomic_s = true
+			}
+		}
+		'linux', 'freebsd', 'openbsd', 'netbsd', 'dragonfly' {
+			link_atomic_s = true
+		}
+		else {}
+	}
+
+	if !link_atomic_s {
+		return ''
+	}
+	atomic_s := os.join_path(prefs.vroot, 'thirdparty', 'stdatomic', 'nix', 'atomic.S')
+	return ' ${atomic_s}'
+}
+
 fn prepare_c_flags_for_link(flags []string, c99 bool) ![]string {
 	support_flags := c_object_compile_support_flags(flags)
 	mut prepared := []string{}
@@ -174,6 +199,7 @@ fn main() {
 	mut no_parallel := false
 	mut parallel_transform := true
 	mut building_v := false
+	mut ownership_mode := false
 	mut c99 := false
 	mut all_backends := false
 	mut compile_backends := []string{}
@@ -205,6 +231,13 @@ fn main() {
 			i++
 		} else if args[i] == '-strict' {
 			is_strict = true
+			i++
+		} else if args[i] == '-ownership' || args[i] == '--ownership' {
+			// The ownership checker itself is compiled into v3 via `-d ownership`.
+			// The runtime `-ownership` flag should only load the builtin ownership
+			// overlays; it must not expose `ownership` to target `$if` blocks or target
+			// `_d_ownership.v` files.
+			ownership_mode = true
 			i++
 		} else if args[i] == '-no-parallel' || args[i] == '--no-parallel' {
 			no_parallel = true
@@ -335,7 +368,11 @@ fn main() {
 
 	mut files := []string{}
 	builtin_dir := builtin_dir_for_vroot(prefs.vroot)
-	files << pref.get_v_files_from_dir(builtin_dir, prefs.user_defines, prefs.target_os)
+	mut builtin_defines := prefs.user_defines.clone()
+	if ownership_mode && 'ownership' !in builtin_defines {
+		builtin_defines << 'ownership'
+	}
+	files << pref.get_v_files_from_dir(builtin_dir, builtin_defines, prefs.target_os)
 	p.parse_files(files)
 	mut a := p.a
 	a.user_code_start = a.nodes.len
@@ -538,8 +575,9 @@ fn main() {
 			tcc_lib_dir := os.join_path_single(tcc_dir, 'lib')
 			tcc_includes := '-I${os.join_path_single(tcc_lib_dir, 'include')}'
 			tcc_lib := '-L${tcc_lib_dir}'
-			cc_cmd = '${tcc_path} ${c_standard} ${tcc_includes} ${tcc_lib} ${warn_flags} -o ${bin_file} ${output_file} ${c_flags} -lm'
-			exec_cmd = 'cd ${cc_dir} && ${tcc_path} ${c_standard} ${tcc_includes} ${tcc_lib} ${warn_flags} -o out src.c ${c_flags} -lm'
+			atomic_s_arg := tcc_atomic_s_arg(prefs)
+			cc_cmd = '${tcc_path} ${c_standard} ${tcc_includes} ${tcc_lib} ${warn_flags} -o ${bin_file} ${output_file}${atomic_s_arg} ${c_flags} -lm'
+			exec_cmd = 'cd ${cc_dir} && ${tcc_path} ${c_standard} ${tcc_includes} ${tcc_lib} ${warn_flags} -o out src.c${atomic_s_arg} ${c_flags} -lm'
 			println('  > ${cc_cmd}')
 			result = run_compile_command(exec_cmd)
 		}


### PR DESCRIPTION
## Summary
- load v3 ownership builtin overlays for runtime `-ownership` without exposing `ownership` to target `$if` blocks or target `_d_ownership.v` file selection
- fix v3 type-checker/parser/transformer cases hit by the ownership-translated ripgrep flags code: optional enum shorthand, explicit generic method receivers, erased lifetimes in prefix and generic-suffix type positions, interface method lifetime params, `IClone`-gated compiler-provided aggregate `clone()`, builtin-only readonly string receiver borrowing, and duplicate aggregate-return descendant moves
- fix related C backend blockers for option/result wrapping, fixed-array return iteration, option smartcasts, pointer equality temping, and tcc atomic fence/relax support while keeping x86_64 Unix fences on the `__atomic_thread_fence` symbol provided by `atomic.S`
- clear enclosing match-result state while generating independent call arguments, and gate `atomic.S` linking to compatible non-prod tcc targets so macOS x86_64 does not assemble the ELF-only x86_64 stanza

## Verification
- `git diff --check`
- built patched classic V compiler: `/Users/alexander/code/v/v -gc none -o /tmp/v-ownership-review3/v_review3_bin cmd/v`
- `./v_review3_bin -gc none vlib/v/tests/return_match_expr_with_nest_match_expr_test.v`
- `/Users/alexander/code/v/v -gc none -path "/tmp/v-ownership-fixes-pr/vlib|@vlib|@vmodules" vlib/v3/tests/parser_regression_test.v`
- `/Users/alexander/code/v/v -gc none -d ownership -path "/tmp/v-ownership-review3/vlib|@vlib|@vmodules" -o /tmp/v3_ownership_review3 /tmp/v-ownership-review3/vlib/v3/v3.v`
- direct smoke with `/tmp/v3_ownership_review3 -ownership -b c`: builtin `string.contains` borrows an owned string, while user-defined `fn (s string) consume()` moves it and reports `use of moved value`
- direct smoke with `/tmp/v3_ownership_review2 -ownership -b c`: plain struct `.clone()` fails with `unknown function`, `struct Resource implements IClone` default `.clone()` compiles, and a user-defined non-`IClone` `.clone()` still compiles
- direct smoke with `/tmp/v3_ownership_review -ownership -b c`: source contained `$if ownership ? { $compile_error(...) }` plus `'x'.to_owned()`, verifying ownership builtins load without leaking the target define
- confirmed the temporary `TypeError.file` / `// DEBUG` diagnostic scaffold is not in this PR branch