### PR TITLE
image: add Go-inspired core image module

### DIFF
--- a/vlib/image/LICENSE
+++ b/vlib/image/LICENSE
@@ -1,0 +1,27 @@
+Portions of this module are derived from the Go standard library's image
+packages.
+
+Copyright 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   * Neither the name of Google LLC nor the names of its contributors may be
+     used to endorse or promote products derived from this software without
+     specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vlib/image/README.md
+++ b/vlib/image/README.md
@@ -12,6 +12,8 @@ The module currently includes:
 - `Uniform` images for a single color.
 - `image.color`, with standard color types, color model conversion, palettes,
   Y'CbCr conversion, and CMYK conversion.
+- Format registration hooks with `register_format`, `decode`, and
+  `decode_config`.
 
 ```v
 import image
@@ -30,4 +32,5 @@ assert img.rgba_at(0, 0).r == 255
 ```
 
 The codec packages from Go's image tree, such as PNG, JPEG, and GIF, are not
-part of this module yet.
+part of this module yet. They can be added later by registering decode
+callbacks with this module.

--- a/vlib/image/README.md
+++ b/vlib/image/README.md
@@ -1,0 +1,33 @@
+# image
+
+`image` provides basic in-memory 2D image types and geometry helpers,
+translated from Go's `image` package into V-style APIs.
+
+The module currently includes:
+
+- `Point` and `Rectangle` geometry helpers.
+- Packed pixel buffers: `RGBA`, `RGBA64`, `NRGBA`, `NRGBA64`, `Alpha`,
+  `Alpha16`, `Gray`, `Gray16`, `CMYK`, and `Paletted`.
+- Y'CbCr buffers with common chroma subsampling ratios.
+- `Uniform` images for a single color.
+- `image.color`, with standard color types, color model conversion, palettes,
+  Y'CbCr conversion, and CMYK conversion.
+
+```v
+import image
+import image.color
+
+mut img := image.new_rgba(image.rect(0, 0, 2, 2))
+img.set_rgba(0, 0, color.RGBA{
+	r: 255
+	g: 0
+	b: 0
+	a: 255
+})
+
+assert img.bounds().dx() == 2
+assert img.rgba_at(0, 0).r == 255
+```
+
+The codec packages from Go's image tree, such as PNG, JPEG, and GIF, are not
+part of this module yet.

--- a/vlib/image/color/color.v
+++ b/vlib/image/color/color.v
@@ -1,0 +1,629 @@
+// Copyright (c) 2026 The V Authors. All rights reserved.
+// Portions derived from Go's image/color package.
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of the original Go source is governed by Go's BSD-style license.
+module color
+
+// RGBA represents a 32-bit alpha-premultiplied color.
+pub struct RGBA {
+pub mut:
+	r u8
+	g u8
+	b u8
+	a u8
+}
+
+// rgba returns the alpha-premultiplied red, green, blue, and alpha channels as
+// 16-bit values stored in u32s.
+pub fn (c RGBA) rgba() (u32, u32, u32, u32) {
+	mut r := u32(c.r)
+	r |= r << 8
+	mut g := u32(c.g)
+	g |= g << 8
+	mut b := u32(c.b)
+	b |= b << 8
+	mut a := u32(c.a)
+	a |= a << 8
+	return r, g, b, a
+}
+
+// RGBA64 represents a 64-bit alpha-premultiplied color.
+pub struct RGBA64 {
+pub mut:
+	r u16
+	g u16
+	b u16
+	a u16
+}
+
+// rgba returns the alpha-premultiplied red, green, blue, and alpha channels as
+// 16-bit values stored in u32s.
+pub fn (c RGBA64) rgba() (u32, u32, u32, u32) {
+	return u32(c.r), u32(c.g), u32(c.b), u32(c.a)
+}
+
+// NRGBA represents a non-alpha-premultiplied 32-bit color.
+pub struct NRGBA {
+pub mut:
+	r u8
+	g u8
+	b u8
+	a u8
+}
+
+// rgba returns the alpha-premultiplied red, green, blue, and alpha channels as
+// 16-bit values stored in u32s.
+pub fn (c NRGBA) rgba() (u32, u32, u32, u32) {
+	mut r := u32(c.r)
+	r |= r << 8
+	r *= u32(c.a)
+	r /= 0xff
+	mut g := u32(c.g)
+	g |= g << 8
+	g *= u32(c.a)
+	g /= 0xff
+	mut b := u32(c.b)
+	b |= b << 8
+	b *= u32(c.a)
+	b /= 0xff
+	mut a := u32(c.a)
+	a |= a << 8
+	return r, g, b, a
+}
+
+// NRGBA64 represents a non-alpha-premultiplied 64-bit color.
+pub struct NRGBA64 {
+pub mut:
+	r u16
+	g u16
+	b u16
+	a u16
+}
+
+// rgba returns the alpha-premultiplied red, green, blue, and alpha channels as
+// 16-bit values stored in u32s.
+pub fn (c NRGBA64) rgba() (u32, u32, u32, u32) {
+	mut r := u32(c.r)
+	r *= u32(c.a)
+	r /= 0xffff
+	mut g := u32(c.g)
+	g *= u32(c.a)
+	g /= 0xffff
+	mut b := u32(c.b)
+	b *= u32(c.a)
+	b /= 0xffff
+	return r, g, b, u32(c.a)
+}
+
+// Alpha represents an 8-bit alpha color.
+pub struct Alpha {
+pub mut:
+	a u8
+}
+
+// rgba returns the alpha channel copied into each alpha-premultiplied channel.
+pub fn (c Alpha) rgba() (u32, u32, u32, u32) {
+	mut a := u32(c.a)
+	a |= a << 8
+	return a, a, a, a
+}
+
+// Alpha16 represents a 16-bit alpha color.
+pub struct Alpha16 {
+pub mut:
+	a u16
+}
+
+// rgba returns the alpha channel copied into each alpha-premultiplied channel.
+pub fn (c Alpha16) rgba() (u32, u32, u32, u32) {
+	a := u32(c.a)
+	return a, a, a, a
+}
+
+// Gray represents an 8-bit grayscale color.
+pub struct Gray {
+pub mut:
+	y u8
+}
+
+// rgba returns the grayscale channel as opaque red, green, and blue channels.
+pub fn (c Gray) rgba() (u32, u32, u32, u32) {
+	mut y := u32(c.y)
+	y |= y << 8
+	return y, y, y, 0xffff
+}
+
+// Gray16 represents a 16-bit grayscale color.
+pub struct Gray16 {
+pub mut:
+	y u16
+}
+
+// rgba returns the grayscale channel as opaque red, green, and blue channels.
+pub fn (c Gray16) rgba() (u32, u32, u32, u32) {
+	y := u32(c.y)
+	return y, y, y, 0xffff
+}
+
+// YCbCr represents an opaque JFIF Y'CbCr color.
+pub struct YCbCr {
+pub mut:
+	y  u8
+	cb u8
+	cr u8
+}
+
+// rgba converts c to alpha-premultiplied 16-bit RGBA channels.
+pub fn (c YCbCr) rgba() (u32, u32, u32, u32) {
+	yy1 := i32(c.y) * 0x10101
+	cb1 := i32(c.cb) - 128
+	cr1 := i32(c.cr) - 128
+	r := clamp_u16_from_i32(yy1 + 91881 * cr1, 8)
+	g := clamp_u16_from_i32(yy1 - 22554 * cb1 - 46802 * cr1, 8)
+	b := clamp_u16_from_i32(yy1 + 116130 * cb1, 8)
+	return u32(r), u32(g), u32(b), 0xffff
+}
+
+// NYCbCrA represents a non-alpha-premultiplied JFIF Y'CbCr-with-alpha color.
+pub struct NYCbCrA {
+pub mut:
+	ycbcr YCbCr
+	a     u8
+}
+
+// rgba converts c to alpha-premultiplied 16-bit RGBA channels.
+pub fn (c NYCbCrA) rgba() (u32, u32, u32, u32) {
+	r0, g0, b0, _ := c.ycbcr.rgba()
+	a := u32(c.a) * 0x101
+	return r0 * a / 0xffff, g0 * a / 0xffff, b0 * a / 0xffff, a
+}
+
+// CMYK represents an opaque CMYK color.
+pub struct CMYK {
+pub mut:
+	c u8
+	m u8
+	y u8
+	k u8
+}
+
+// rgba converts c to alpha-premultiplied 16-bit RGBA channels.
+pub fn (c CMYK) rgba() (u32, u32, u32, u32) {
+	w := 0xffff - u32(c.k) * 0x101
+	r := (0xffff - u32(c.c) * 0x101) * w / 0xffff
+	g := (0xffff - u32(c.m) * 0x101) * w / 0xffff
+	b := (0xffff - u32(c.y) * 0x101) * w / 0xffff
+	return r, g, b, 0xffff
+}
+
+// Color is the set of color types provided by this module.
+pub type Color = Alpha
+	| Alpha16
+	| CMYK
+	| Gray
+	| Gray16
+	| NRGBA
+	| NRGBA64
+	| NYCbCrA
+	| RGBA
+	| RGBA64
+	| YCbCr
+
+// rgba returns the alpha-premultiplied red, green, blue, and alpha channels as
+// 16-bit values stored in u32s.
+pub fn (c Color) rgba() (u32, u32, u32, u32) {
+	match c {
+		Alpha {
+			return c.rgba()
+		}
+		Alpha16 {
+			return c.rgba()
+		}
+		CMYK {
+			return c.rgba()
+		}
+		Gray {
+			return c.rgba()
+		}
+		Gray16 {
+			return c.rgba()
+		}
+		NRGBA {
+			return c.rgba()
+		}
+		NRGBA64 {
+			return c.rgba()
+		}
+		NYCbCrA {
+			return c.rgba()
+		}
+		RGBA {
+			return c.rgba()
+		}
+		RGBA64 {
+			return c.rgba()
+		}
+		YCbCr {
+			return c.rgba()
+		}
+	}
+}
+
+// ModelKind identifies one of the standard color conversion models.
+pub enum ModelKind {
+	rgba
+	rgba64
+	nrgba
+	nrgba64
+	alpha
+	alpha16
+	gray
+	gray16
+	ycbcr
+	nycbcra
+	cmyk
+}
+
+// Palette is an ordered list of colors.
+pub struct Palette {
+pub mut:
+	colors []Color
+}
+
+// ConstantModel converts every input color to c.
+pub struct ConstantModel {
+pub mut:
+	c Color
+}
+
+// Model converts colors into a color model.
+pub type Model = ConstantModel | ModelKind | Palette
+
+// convert converts c into the receiver's color model.
+pub fn (m Model) convert(c Color) !Color {
+	match m {
+		ConstantModel {
+			return m.convert(c)
+		}
+		ModelKind {
+			return m.convert(c)
+		}
+		Palette {
+			return m.convert(c)!
+		}
+	}
+}
+
+// convert converts c into the receiver's constant color.
+pub fn (m ConstantModel) convert(c Color) Color {
+	return m.c
+}
+
+// constant_model returns a model that converts every input color to c.
+pub fn constant_model(c Color) Model {
+	return Model(ConstantModel{
+		c: c
+	})
+}
+
+// convert converts c into the receiver's standard color model.
+pub fn (m ModelKind) convert(c Color) Color {
+	match m {
+		.rgba {
+			return Color(to_rgba(c))
+		}
+		.rgba64 {
+			return Color(to_rgba64(c))
+		}
+		.nrgba {
+			return Color(to_nrgba(c))
+		}
+		.nrgba64 {
+			return Color(to_nrgba64(c))
+		}
+		.alpha {
+			return Color(to_alpha(c))
+		}
+		.alpha16 {
+			return Color(to_alpha16(c))
+		}
+		.gray {
+			return Color(to_gray(c))
+		}
+		.gray16 {
+			return Color(to_gray16(c))
+		}
+		.ycbcr {
+			return Color(to_ycbcr(c))
+		}
+		.nycbcra {
+			return Color(to_nycbcra(c))
+		}
+		.cmyk {
+			return Color(to_cmyk(c))
+		}
+	}
+}
+
+pub const rgba_model = Model(ModelKind.rgba)
+pub const rgba64_model = Model(ModelKind.rgba64)
+pub const nrgba_model = Model(ModelKind.nrgba)
+pub const nrgba64_model = Model(ModelKind.nrgba64)
+pub const alpha_model = Model(ModelKind.alpha)
+pub const alpha16_model = Model(ModelKind.alpha16)
+pub const gray_model = Model(ModelKind.gray)
+pub const gray16_model = Model(ModelKind.gray16)
+pub const ycbcr_model = Model(ModelKind.ycbcr)
+pub const nycbcra_model = Model(ModelKind.nycbcra)
+pub const cmyk_model = Model(ModelKind.cmyk)
+
+pub const black = Color(Gray16{})
+pub const white = Color(Gray16{
+	y: 0xffff
+})
+pub const transparent = Color(Alpha16{})
+pub const opaque = Color(Alpha16{
+	a: 0xffff
+})
+
+// to_rgba converts c to RGBA.
+pub fn to_rgba(c Color) RGBA {
+	if c is RGBA {
+		return c
+	}
+	r, g, b, a := c.rgba()
+	return RGBA{u8(r >> 8), u8(g >> 8), u8(b >> 8), u8(a >> 8)}
+}
+
+// to_rgba64 converts c to RGBA64.
+pub fn to_rgba64(c Color) RGBA64 {
+	if c is RGBA64 {
+		return c
+	}
+	r, g, b, a := c.rgba()
+	return RGBA64{u16(r), u16(g), u16(b), u16(a)}
+}
+
+// to_nrgba converts c to NRGBA.
+pub fn to_nrgba(c Color) NRGBA {
+	if c is NRGBA {
+		return c
+	}
+	mut r, mut g, mut b, a := c.rgba()
+	if a == 0xffff {
+		return NRGBA{u8(r >> 8), u8(g >> 8), u8(b >> 8), 0xff}
+	}
+	if a == 0 {
+		return NRGBA{}
+	}
+	r = (r * 0xffff) / a
+	g = (g * 0xffff) / a
+	b = (b * 0xffff) / a
+	return NRGBA{u8(r >> 8), u8(g >> 8), u8(b >> 8), u8(a >> 8)}
+}
+
+// to_nrgba64 converts c to NRGBA64.
+pub fn to_nrgba64(c Color) NRGBA64 {
+	if c is NRGBA64 {
+		return c
+	}
+	mut r, mut g, mut b, a := c.rgba()
+	if a == 0xffff {
+		return NRGBA64{u16(r), u16(g), u16(b), 0xffff}
+	}
+	if a == 0 {
+		return NRGBA64{}
+	}
+	r = (r * 0xffff) / a
+	g = (g * 0xffff) / a
+	b = (b * 0xffff) / a
+	return NRGBA64{u16(r), u16(g), u16(b), u16(a)}
+}
+
+// to_alpha converts c to Alpha.
+pub fn to_alpha(c Color) Alpha {
+	if c is Alpha {
+		return c
+	}
+	_, _, _, a := c.rgba()
+	return Alpha{
+		a: u8(a >> 8)
+	}
+}
+
+// to_alpha16 converts c to Alpha16.
+pub fn to_alpha16(c Color) Alpha16 {
+	if c is Alpha16 {
+		return c
+	}
+	_, _, _, a := c.rgba()
+	return Alpha16{
+		a: u16(a)
+	}
+}
+
+// to_gray converts c to Gray.
+pub fn to_gray(c Color) Gray {
+	if c is Gray {
+		return c
+	}
+	r, g, b, _ := c.rgba()
+	y := (19595 * r + 38470 * g + 7471 * b + (1 << 15)) >> 24
+	return Gray{
+		y: u8(y)
+	}
+}
+
+// to_gray16 converts c to Gray16.
+pub fn to_gray16(c Color) Gray16 {
+	if c is Gray16 {
+		return c
+	}
+	r, g, b, _ := c.rgba()
+	y := (19595 * r + 38470 * g + 7471 * b + (1 << 15)) >> 16
+	return Gray16{
+		y: u16(y)
+	}
+}
+
+// to_ycbcr converts c to YCbCr.
+pub fn to_ycbcr(c Color) YCbCr {
+	if c is YCbCr {
+		return c
+	}
+	r, g, b, _ := c.rgba()
+	y, cb, cr := rgb_to_ycbcr(u8(r >> 8), u8(g >> 8), u8(b >> 8))
+	return YCbCr{
+		y:  y
+		cb: cb
+		cr: cr
+	}
+}
+
+// to_nycbcra converts c to NYCbCrA.
+pub fn to_nycbcra(c Color) NYCbCrA {
+	if c is NYCbCrA {
+		return c
+	}
+	if c is YCbCr {
+		return NYCbCrA{
+			ycbcr: c
+			a:     0xff
+		}
+	}
+	mut r, mut g, mut b, a := c.rgba()
+	if a != 0 {
+		r = (r * 0xffff) / a
+		g = (g * 0xffff) / a
+		b = (b * 0xffff) / a
+	}
+	y, cb, cr := rgb_to_ycbcr(u8(r >> 8), u8(g >> 8), u8(b >> 8))
+	return NYCbCrA{
+		ycbcr: YCbCr{
+			y:  y
+			cb: cb
+			cr: cr
+		}
+		a:     u8(a >> 8)
+	}
+}
+
+// to_cmyk converts c to CMYK.
+pub fn to_cmyk(c Color) CMYK {
+	if c is CMYK {
+		return c
+	}
+	r, g, b, _ := c.rgba()
+	cc, mm, yy, kk := rgb_to_cmyk(u8(r >> 8), u8(g >> 8), u8(b >> 8))
+	return CMYK{
+		c: cc
+		m: mm
+		y: yy
+		k: kk
+	}
+}
+
+// convert returns the palette color closest to c.
+pub fn (p Palette) convert(c Color) !Color {
+	if p.colors.len == 0 {
+		return error('color: empty palette')
+	}
+	return p.colors[p.index(c)]
+}
+
+// index returns the index of the palette color closest to c in RGBA space.
+pub fn (p Palette) index(c Color) int {
+	cr, cg, cb, ca := c.rgba()
+	mut ret := 0
+	mut best_sum := u32(max_u32)
+	for i, v in p.colors {
+		vr, vg, vb, va := v.rgba()
+		sum := sq_diff(cr, vr) + sq_diff(cg, vg) + sq_diff(cb, vb) + sq_diff(ca, va)
+		if sum < best_sum {
+			if sum == 0 {
+				return i
+			}
+			ret = i
+			best_sum = sum
+		}
+	}
+	return ret
+}
+
+// rgb_to_ycbcr converts an RGB triple to a JFIF Y'CbCr triple.
+pub fn rgb_to_ycbcr(r u8, g u8, b u8) (u8, u8, u8) {
+	r1 := i32(r)
+	g1 := i32(g)
+	b1 := i32(b)
+	yy := (19595 * r1 + 38470 * g1 + 7471 * b1 + (1 << 15)) >> 16
+	cb := (-11056 * r1 - 21712 * g1 + 32768 * b1 + (257 << 15)) >> 16
+	cr := (32768 * r1 - 27440 * g1 - 5328 * b1 + (257 << 15)) >> 16
+	return u8(yy), clamp_u8(cb), clamp_u8(cr)
+}
+
+// ycbcr_to_rgb converts a JFIF Y'CbCr triple to an RGB triple.
+pub fn ycbcr_to_rgb(y u8, cb u8, cr u8) (u8, u8, u8) {
+	yy1 := i32(y) * 0x10101
+	cb1 := i32(cb) - 128
+	cr1 := i32(cr) - 128
+	r := (yy1 + 91881 * cr1) >> 16
+	g := (yy1 - 22554 * cb1 - 46802 * cr1) >> 16
+	b := (yy1 + 116130 * cb1) >> 16
+	return clamp_u8(r), clamp_u8(g), clamp_u8(b)
+}
+
+// rgb_to_cmyk converts an RGB triple to a CMYK quadruple.
+pub fn rgb_to_cmyk(r u8, g u8, b u8) (u8, u8, u8, u8) {
+	rr := u32(r)
+	gg := u32(g)
+	bb := u32(b)
+	mut w := rr
+	if w < gg {
+		w = gg
+	}
+	if w < bb {
+		w = bb
+	}
+	if w == 0 {
+		return 0, 0, 0, 0xff
+	}
+	c := (w - rr) * 0xff / w
+	m := (w - gg) * 0xff / w
+	y := (w - bb) * 0xff / w
+	return u8(c), u8(m), u8(y), u8(0xff - w)
+}
+
+// cmyk_to_rgb converts a CMYK quadruple to an RGB triple.
+pub fn cmyk_to_rgb(c u8, m u8, y u8, k u8) (u8, u8, u8) {
+	w := 0xffff - u32(k) * 0x101
+	r := (0xffff - u32(c) * 0x101) * w / 0xffff
+	g := (0xffff - u32(m) * 0x101) * w / 0xffff
+	b := (0xffff - u32(y) * 0x101) * w / 0xffff
+	return u8(r >> 8), u8(g >> 8), u8(b >> 8)
+}
+
+fn sq_diff(x u32, y u32) u32 {
+	d := if x > y { x - y } else { y - x }
+	return (d * d) >> 2
+}
+
+fn clamp_u8(v i32) u8 {
+	if v < 0 {
+		return 0
+	}
+	if v > 0xff {
+		return 0xff
+	}
+	return u8(v)
+}
+
+fn clamp_u16_from_i32(v i32, shift int) u16 {
+	x := v >> shift
+	if x < 0 {
+		return 0
+	}
+	if x > 0xffff {
+		return 0xffff
+	}
+	return u16(x)
+}

--- a/vlib/image/color/color_test.v
+++ b/vlib/image/color/color_test.v
@@ -1,5 +1,21 @@
 module color
 
+fn delta(x u8, y u8) u8 {
+	if x >= y {
+		return x - y
+	}
+	return y - x
+}
+
+fn assert_same_rgba(c0 Color, c1 Color) {
+	r0, g0, b0, a0 := c0.rgba()
+	r1, g1, b1, a1 := c1.rgba()
+	assert r0 == r1
+	assert g0 == g1
+	assert b0 == b1
+	assert a0 == a1
+}
+
 fn test_rgba_and_nrgba_conversion() {
 	r, g, b, a := RGBA{
 		r: 0x11
@@ -23,6 +39,30 @@ fn test_rgba_and_nrgba_conversion() {
 	assert c.g == 0xff
 }
 
+fn test_sq_diff() {
+	test_cases := [
+		u32(0),
+		1,
+		2,
+		0x0fffd,
+		0x0fffe,
+		0x0ffff,
+		0x10000,
+		0x10001,
+		0x10002,
+		0xfffffffd,
+		0xfffffffe,
+		0xffffffff,
+	]
+	for x in test_cases {
+		for y in test_cases {
+			d := if x > y { x - y } else { y - x }
+			want := (d * d) >> 2
+			assert sq_diff(x, y) == want
+		}
+	}
+}
+
 fn test_ycbcr_and_cmyk_round_trips() {
 	y, cb, cr := rgb_to_ycbcr(255, 0, 0)
 	r, g, b := ycbcr_to_rgb(y, cb, cr)
@@ -39,6 +79,131 @@ fn test_ycbcr_and_cmyk_round_trips() {
 	assert rr == 0
 	assert gg == 255
 	assert bb == 0
+}
+
+fn test_ycbcr_roundtrip_table() {
+	for r := 0; r < 256; r += 7 {
+		for g := 0; g < 256; g += 5 {
+			for b := 0; b < 256; b += 3 {
+				r0 := u8(r)
+				g0 := u8(g)
+				b0 := u8(b)
+				y, cb, cr := rgb_to_ycbcr(r0, g0, b0)
+				r1, g1, b1 := ycbcr_to_rgb(y, cb, cr)
+				assert delta(r0, r1) <= 2
+				assert delta(g0, g1) <= 2
+				assert delta(b0, b1) <= 2
+			}
+		}
+	}
+}
+
+fn test_ycbcr_to_rgb_consistency() {
+	for y := 0; y < 256; y += 7 {
+		for cb := 0; cb < 256; cb += 5 {
+			for cr := 0; cr < 256; cr += 3 {
+				x := YCbCr{
+					y:  u8(y)
+					cb: u8(cb)
+					cr: u8(cr)
+				}
+				r0, g0, b0, _ := x.rgba()
+				r1 := u8(r0 >> 8)
+				g1 := u8(g0 >> 8)
+				b1 := u8(b0 >> 8)
+				r2, g2, b2 := ycbcr_to_rgb(x.y, x.cb, x.cr)
+				assert r1 == r2
+				assert g1 == g2
+				assert b1 == b2
+			}
+		}
+	}
+}
+
+fn test_ycbcr_gray_and_nycbcra_supersets() {
+	for i in 0 .. 256 {
+		assert_same_rgba(Color(YCbCr{
+			y:  u8(i)
+			cb: 0x80
+			cr: 0x80
+		}), Color(Gray{
+			y: u8(i)
+		}))
+		assert_same_rgba(Color(NYCbCrA{
+			ycbcr: YCbCr{
+				y:  0xff
+				cb: 0x80
+				cr: 0x80
+			}
+			a:     u8(i)
+		}), Color(Alpha{
+			a: u8(i)
+		}))
+		assert_same_rgba(Color(NYCbCrA{
+			ycbcr: YCbCr{
+				y:  u8(i)
+				cb: 0x40
+				cr: 0xc0
+			}
+			a:     0xff
+		}), Color(YCbCr{
+			y:  u8(i)
+			cb: 0x40
+			cr: 0xc0
+		}))
+	}
+}
+
+fn test_cmyk_roundtrip_table() {
+	for r := 0; r < 256; r += 7 {
+		for g := 0; g < 256; g += 5 {
+			for b := 0; b < 256; b += 3 {
+				r0 := u8(r)
+				g0 := u8(g)
+				b0 := u8(b)
+				c, m, y, k := rgb_to_cmyk(r0, g0, b0)
+				r1, g1, b1 := cmyk_to_rgb(c, m, y, k)
+				assert delta(r0, r1) <= 1
+				assert delta(g0, g1) <= 1
+				assert delta(b0, b1) <= 1
+			}
+		}
+	}
+}
+
+fn test_cmyk_to_rgb_consistency_and_gray() {
+	for c := 0; c < 256; c += 7 {
+		for m := 0; m < 256; m += 5 {
+			for y := 0; y < 256; y += 3 {
+				for k := 0; k < 256; k += 11 {
+					x := CMYK{
+						c: u8(c)
+						m: u8(m)
+						y: u8(y)
+						k: u8(k)
+					}
+					r0, g0, b0, _ := x.rgba()
+					r1 := u8(r0 >> 8)
+					g1 := u8(g0 >> 8)
+					b1 := u8(b0 >> 8)
+					r2, g2, b2 := cmyk_to_rgb(x.c, x.m, x.y, x.k)
+					assert r1 == r2
+					assert g1 == g2
+					assert b1 == b2
+				}
+			}
+		}
+	}
+	for i in 0 .. 256 {
+		assert_same_rgba(Color(CMYK{
+			c: 0
+			m: 0
+			y: 0
+			k: u8(255 - i)
+		}), Color(Gray{
+			y: u8(i)
+		}))
+	}
 }
 
 fn test_palette_index_and_model() {
@@ -61,4 +226,19 @@ fn test_palette_index_and_model() {
 		b: 0x12
 		a: 0xff
 	})
+
+	p2 := Palette{
+		colors: [
+			Color(RGBA{0xff, 0xff, 0xff, 0xff}),
+			Color(RGBA{0x80, 0x00, 0x00, 0xff}),
+			Color(RGBA{0x7f, 0x00, 0x00, 0x7f}),
+			Color(RGBA{0x00, 0x00, 0x00, 0x7f}),
+			Color(RGBA{0x00, 0x00, 0x00, 0x00}),
+			Color(RGBA{0x40, 0x40, 0x40, 0x40}),
+		]
+	}
+	for i, c in p2.colors {
+		assert p2.index(c) == i
+	}
+	assert p2.convert(Color(RGBA{0x80, 0x00, 0x00, 0x80}))! == Color(RGBA{0x7f, 0x00, 0x00, 0x7f})
 }

--- a/vlib/image/color/color_test.v
+++ b/vlib/image/color/color_test.v
@@ -1,0 +1,64 @@
+module color
+
+fn test_rgba_and_nrgba_conversion() {
+	r, g, b, a := RGBA{
+		r: 0x11
+		g: 0x22
+		b: 0x33
+		a: 0x44
+	}.rgba()
+	assert r == 0x1111
+	assert g == 0x2222
+	assert b == 0x3333
+	assert a == 0x4444
+
+	c := to_nrgba(Color(RGBA64{
+		r: 0x4000
+		g: 0x8000
+		b: 0xc000
+		a: 0x8000
+	}))
+	assert c.a == 0x80
+	assert c.r == 0x7f || c.r == 0x80
+	assert c.g == 0xff
+}
+
+fn test_ycbcr_and_cmyk_round_trips() {
+	y, cb, cr := rgb_to_ycbcr(255, 0, 0)
+	r, g, b := ycbcr_to_rgb(y, cb, cr)
+	assert r >= 253
+	assert g <= 1
+	assert b <= 1
+
+	c, m, yy, k := rgb_to_cmyk(0, 255, 0)
+	assert c == 255
+	assert m == 0
+	assert yy == 255
+	assert k == 0
+	rr, gg, bb := cmyk_to_rgb(c, m, yy, k)
+	assert rr == 0
+	assert gg == 255
+	assert bb == 0
+}
+
+fn test_palette_index_and_model() {
+	p := Palette{
+		colors: [
+			Color(RGBA{0, 0, 0, 255}),
+			Color(RGBA{255, 255, 255, 255}),
+			Color(RGBA{255, 0, 0, 255}),
+		]
+	}
+	assert p.index(Color(RGBA{250, 1, 2, 255})) == 2
+	assert p.convert(Color(RGBA{254, 254, 254, 255}))! == Color(RGBA{255, 255, 255, 255})
+
+	converted := rgba_model.convert(Color(Gray{
+		y: 0x12
+	}))!
+	assert converted == Color(RGBA{
+		r: 0x12
+		g: 0x12
+		b: 0x12
+		a: 0xff
+	})
+}

--- a/vlib/image/format.v
+++ b/vlib/image/format.v
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 The V Authors. All rights reserved.
+// Portions derived from Go's image package.
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of the original Go source is governed by Go's BSD-style license.
+@[has_globals]
+module image
+
+import io
+
+// err_format indicates that decoding encountered an unknown format.
+pub const err_format = 'image: unknown format'
+
+// DecodeFn decodes an image from a registered format.
+pub type DecodeFn = fn (mut PeekReader) !Image
+
+// DecodeConfigFn decodes an image configuration from a registered format.
+pub type DecodeConfigFn = fn (mut PeekReader) !Config
+
+struct Format {
+	name          string
+	magic         string
+	decode        DecodeFn       @[required]
+	decode_config DecodeConfigFn @[required]
+}
+
+__global (
+	registered_formats []Format
+)
+
+// PeekReader is an io.Reader that can also peek ahead without consuming bytes.
+pub interface PeekReader {
+mut:
+	read(mut buf []u8) !int
+	peek(n int) ![]u8
+}
+
+struct BufferedPeekReader {
+mut:
+	reader io.Reader
+	buf    []u8
+	offset int
+}
+
+// register_format registers an image format for use by decode and decode_config.
+pub fn register_format(name string, magic string, decode DecodeFn, decode_config DecodeConfigFn) {
+	registered_formats << Format{
+		name:          name
+		magic:         magic
+		decode:        decode
+		decode_config: decode_config
+	}
+}
+
+fn as_reader(reader io.Reader) PeekReader {
+	return BufferedPeekReader{
+		reader: reader
+	}
+}
+
+// read implements io.Reader for BufferedPeekReader.
+pub fn (mut r BufferedPeekReader) read(mut buf []u8) !int {
+	if buf.len == 0 {
+		return 0
+	}
+	mut copied := 0
+	if r.offset < r.buf.len {
+		copied = copy(mut buf, r.buf[r.offset..])
+		r.offset += copied
+		if copied == buf.len {
+			return copied
+		}
+	}
+	read := r.reader.read(mut buf[copied..]) or {
+		if copied > 0 {
+			return copied
+		}
+		return err
+	}
+	return copied + read
+}
+
+// peek returns the next n bytes without consuming them.
+pub fn (mut r BufferedPeekReader) peek(n int) ![]u8 {
+	if n < 0 {
+		return error('image: negative peek length')
+	}
+	for r.buf.len - r.offset < n {
+		missing := n - (r.buf.len - r.offset)
+		mut tmp := []u8{len: missing}
+		read := r.reader.read(mut tmp)!
+		if read <= 0 {
+			return io.Eof{}
+		}
+		r.buf << tmp[..read]
+	}
+	return r.buf[r.offset..r.offset + n]
+}
+
+fn match_magic(magic string, b []u8) bool {
+	if magic.len != b.len {
+		return false
+	}
+	for i, c in b {
+		if magic[i] != c && magic[i] != `?` {
+			return false
+		}
+	}
+	return true
+}
+
+// sniff determines the registered format of r's data.
+fn sniff(mut r PeekReader) ?Format {
+	for f in registered_formats {
+		b := r.peek(f.magic.len) or { continue }
+		if match_magic(f.magic, b) {
+			return f
+		}
+	}
+	return none
+}
+
+// decode decodes an image from a registered format.
+pub fn decode(reader io.Reader) !(Image, string) {
+	mut r := as_reader(reader)
+	f := sniff(mut r) or { return error(err_format) }
+	m := f.decode(mut r)!
+	return m, f.name
+}
+
+// decode_config decodes the color model and dimensions of a registered format.
+pub fn decode_config(reader io.Reader) !(Config, string) {
+	mut r := as_reader(reader)
+	f := sniff(mut r) or { return error(err_format) }
+	c := f.decode_config(mut r)!
+	return c, f.name
+}

--- a/vlib/image/format_test.v
+++ b/vlib/image/format_test.v
@@ -1,0 +1,87 @@
+module image
+
+import image.color
+import io
+
+struct BytesReader {
+	data []u8
+mut:
+	pos int
+}
+
+fn (mut r BytesReader) read(mut buf []u8) !int {
+	if r.pos >= r.data.len {
+		return io.Eof{}
+	}
+	n := copy(mut buf, r.data[r.pos..])
+	r.pos += n
+	return n
+}
+
+fn fake_decode(mut r PeekReader) !Image {
+	mut header := []u8{len: 5}
+	n := r.read(mut header)!
+	assert n == 5
+	assert header.bytestr() == 'VIMG1'
+	mut img := new_rgba(rect(0, 0, 1, 1))
+	img.set_rgba(0, 0, color.RGBA{
+		r: 10
+		g: 20
+		b: 30
+		a: 255
+	})
+	return img
+}
+
+fn fake_decode_config(mut r PeekReader) !Config {
+	mut header := []u8{len: 5}
+	n := r.read(mut header)!
+	assert n == 5
+	assert header.bytestr() == 'VIMG1'
+	return Config{
+		color_model: color.rgba_model
+		width:       1
+		height:      1
+	}
+}
+
+fn test_match_with_wildcard() {
+	assert match_magic('V?MG', 'VIMG'.bytes())
+	assert match_magic('V?MG', 'VXMG'.bytes())
+	assert !match_magic('V?MG', 'VIM'.bytes())
+	assert !match_magic('V?MG', 'WIMG'.bytes())
+}
+
+fn test_register_decode_and_decode_config() {
+	register_format('vtest', 'VIMG?', fake_decode, fake_decode_config)
+
+	mut reader := BytesReader{
+		data: 'VIMG1payload'.bytes()
+	}
+	img, name := decode(reader)!
+	assert name == 'vtest'
+	assert img.bounds() == rect(0, 0, 1, 1)
+	assert img.at(0, 0) == color.Color(color.RGBA{
+		r: 10
+		g: 20
+		b: 30
+		a: 255
+	})
+
+	mut config_reader := BytesReader{
+		data: 'VIMG1payload'.bytes()
+	}
+	config, config_name := decode_config(config_reader)!
+	assert config_name == 'vtest'
+	assert config.width == 1
+	assert config.height == 1
+
+	mut unknown_reader := BytesReader{
+		data: 'NOPE'.bytes()
+	}
+	if _, _ := decode(unknown_reader) {
+		assert false, 'decode should reject unknown formats'
+	} else {
+		assert err.msg() == err_format
+	}
+}

--- a/vlib/image/geometry.v
+++ b/vlib/image/geometry.v
@@ -1,0 +1,308 @@
+// Copyright (c) 2026 The V Authors. All rights reserved.
+// Portions derived from Go's image package.
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of the original Go source is governed by Go's BSD-style license.
+module image
+
+import image.color
+
+// Point is an x, y coordinate pair. Axes increase right and down.
+pub struct Point {
+pub mut:
+	x int
+	y int
+}
+
+// str returns a string representation like `(3,4)`.
+pub fn (p Point) str() string {
+	return '(${p.x},${p.y})'
+}
+
+// add returns the vector p + q.
+pub fn (p Point) add(q Point) Point {
+	return Point{
+		x: p.x + q.x
+		y: p.y + q.y
+	}
+}
+
+// sub returns the vector p - q.
+pub fn (p Point) sub(q Point) Point {
+	return Point{
+		x: p.x - q.x
+		y: p.y - q.y
+	}
+}
+
+// mul returns the vector p * k.
+pub fn (p Point) mul(k int) Point {
+	return Point{
+		x: p.x * k
+		y: p.y * k
+	}
+}
+
+// div returns the vector p / k.
+pub fn (p Point) div(k int) Point {
+	return Point{
+		x: p.x / k
+		y: p.y / k
+	}
+}
+
+// in_rect reports whether p is inside r.
+pub fn (p Point) in_rect(r Rectangle) bool {
+	return r.min.x <= p.x && p.x < r.max.x && r.min.y <= p.y && p.y < r.max.y
+}
+
+// mod returns the point q in r where p - q is a multiple of r's size.
+pub fn (p Point) mod(r Rectangle) Point {
+	w := r.dx()
+	h := r.dy()
+	mut q := p.sub(r.min)
+	q.x %= w
+	if q.x < 0 {
+		q.x += w
+	}
+	q.y %= h
+	if q.y < 0 {
+		q.y += h
+	}
+	return q.add(r.min)
+}
+
+// eq reports whether p and q are equal.
+pub fn (p Point) eq(q Point) bool {
+	return p == q
+}
+
+// pt returns a Point from x and y.
+pub fn pt(x int, y int) Point {
+	return Point{
+		x: x
+		y: y
+	}
+}
+
+// Rectangle contains points where min.x <= x < max.x and min.y <= y < max.y.
+pub struct Rectangle {
+pub mut:
+	min Point
+	max Point
+}
+
+// str returns a string representation like `(3,4)-(6,5)`.
+pub fn (r Rectangle) str() string {
+	return '${r.min}-${r.max}'
+}
+
+// dx returns r's width.
+pub fn (r Rectangle) dx() int {
+	return r.max.x - r.min.x
+}
+
+// dy returns r's height.
+pub fn (r Rectangle) dy() int {
+	return r.max.y - r.min.y
+}
+
+// size returns r's width and height as a Point.
+pub fn (r Rectangle) size() Point {
+	return Point{
+		x: r.dx()
+		y: r.dy()
+	}
+}
+
+// add returns r translated by p.
+pub fn (r Rectangle) add(p Point) Rectangle {
+	return Rectangle{
+		min: r.min.add(p)
+		max: r.max.add(p)
+	}
+}
+
+// sub returns r translated by -p.
+pub fn (r Rectangle) sub(p Point) Rectangle {
+	return Rectangle{
+		min: r.min.sub(p)
+		max: r.max.sub(p)
+	}
+}
+
+// inset returns r inset by n. A negative n expands the rectangle.
+pub fn (r Rectangle) inset(n int) Rectangle {
+	mut out := r
+	if out.dx() < 2 * n {
+		out.min.x = (out.min.x + out.max.x) / 2
+		out.max.x = out.min.x
+	} else {
+		out.min.x += n
+		out.max.x -= n
+	}
+	if out.dy() < 2 * n {
+		out.min.y = (out.min.y + out.max.y) / 2
+		out.max.y = out.min.y
+	} else {
+		out.min.y += n
+		out.max.y -= n
+	}
+	return out
+}
+
+// intersect returns the largest rectangle contained by r and s.
+pub fn (r Rectangle) intersect(s Rectangle) Rectangle {
+	mut out := r
+	if out.min.x < s.min.x {
+		out.min.x = s.min.x
+	}
+	if out.min.y < s.min.y {
+		out.min.y = s.min.y
+	}
+	if out.max.x > s.max.x {
+		out.max.x = s.max.x
+	}
+	if out.max.y > s.max.y {
+		out.max.y = s.max.y
+	}
+	if out.empty() {
+		return Rectangle{}
+	}
+	return out
+}
+
+// union returns the smallest rectangle containing r and s.
+pub fn (r Rectangle) union(s Rectangle) Rectangle {
+	if r.empty() {
+		return s
+	}
+	if s.empty() {
+		return r
+	}
+	mut out := r
+	if out.min.x > s.min.x {
+		out.min.x = s.min.x
+	}
+	if out.min.y > s.min.y {
+		out.min.y = s.min.y
+	}
+	if out.max.x < s.max.x {
+		out.max.x = s.max.x
+	}
+	if out.max.y < s.max.y {
+		out.max.y = s.max.y
+	}
+	return out
+}
+
+// empty reports whether r contains no points.
+pub fn (r Rectangle) empty() bool {
+	return r.min.x >= r.max.x || r.min.y >= r.max.y
+}
+
+// eq reports whether r and s contain the same set of points.
+pub fn (r Rectangle) eq(s Rectangle) bool {
+	return r == s || (r.empty() && s.empty())
+}
+
+// overlaps reports whether r and s have a non-empty intersection.
+pub fn (r Rectangle) overlaps(s Rectangle) bool {
+	return !r.empty() && !s.empty() && r.min.x < s.max.x && s.min.x < r.max.x && r.min.y < s.max.y
+		&& s.min.y < r.max.y
+}
+
+// inside reports whether every point in r is inside s.
+pub fn (r Rectangle) inside(s Rectangle) bool {
+	if r.empty() {
+		return true
+	}
+	return s.min.x <= r.min.x && r.max.x <= s.max.x && s.min.y <= r.min.y && r.max.y <= s.max.y
+}
+
+// canon returns r with min and max swapped if needed.
+pub fn (r Rectangle) canon() Rectangle {
+	mut out := r
+	if out.max.x < out.min.x {
+		out.min.x, out.max.x = out.max.x, out.min.x
+	}
+	if out.max.y < out.min.y {
+		out.min.y, out.max.y = out.max.y, out.min.y
+	}
+	return out
+}
+
+// at returns opaque white for points inside r and transparent otherwise.
+pub fn (r Rectangle) at(x int, y int) color.Color {
+	if pt(x, y).in_rect(r) {
+		return color.opaque
+	}
+	return color.transparent
+}
+
+// rgba64_at returns opaque white for points inside r and transparent otherwise.
+pub fn (r Rectangle) rgba64_at(x int, y int) color.RGBA64 {
+	if pt(x, y).in_rect(r) {
+		return color.RGBA64{0xffff, 0xffff, 0xffff, 0xffff}
+	}
+	return color.RGBA64{}
+}
+
+// bounds returns r.
+pub fn (r Rectangle) bounds() Rectangle {
+	return r
+}
+
+// color_model returns the color model for rectangles.
+pub fn (r Rectangle) color_model() color.Model {
+	return color.alpha16_model
+}
+
+// rect returns a well-formed rectangle with the given coordinates.
+pub fn rect(x0 int, y0 int, x1 int, y1 int) Rectangle {
+	mut min_x := x0
+	mut max_x := x1
+	if min_x > max_x {
+		min_x, max_x = max_x, min_x
+	}
+	mut min_y := y0
+	mut max_y := y1
+	if min_y > max_y {
+		min_y, max_y = max_y, min_y
+	}
+	return Rectangle{
+		min: pt(min_x, min_y)
+		max: pt(max_x, max_y)
+	}
+}
+
+fn pixel_buffer_length(bytes_per_pixel int, r Rectangle, image_type_name string) int {
+	total_length := mul3_non_neg(bytes_per_pixel, r.dx(), r.dy())
+	if total_length < 0 {
+		panic('image: new_${image_type_name} rectangle has huge or negative dimensions')
+	}
+	return total_length
+}
+
+fn mul3_non_neg(x int, y int, z int) int {
+	if x < 0 || y < 0 || z < 0 {
+		return -1
+	}
+	if y != 0 && x > max_int / y {
+		return -1
+	}
+	xy := x * y
+	if z != 0 && xy > max_int / z {
+		return -1
+	}
+	return xy * z
+}
+
+fn add2_non_neg(x int, y int) int {
+	if x < 0 || y < 0 {
+		return -1
+	}
+	if x > max_int - y {
+		return -1
+	}
+	return x + y
+}

--- a/vlib/image/image.v
+++ b/vlib/image/image.v
@@ -1,0 +1,1224 @@
+// Copyright (c) 2026 The V Authors. All rights reserved.
+// Portions derived from Go's image package.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of the original Go source is governed by Go's BSD-style license.
+module image
+
+import image.color
+
+// Config holds an image's color model and dimensions.
+pub struct Config {
+pub mut:
+	color_model color.Model
+	width       int
+	height      int
+}
+
+// Image is a finite rectangular grid of color values.
+pub interface Image {
+	color_model() color.Model
+	bounds() Rectangle
+	at(x int, y int) color.Color
+}
+
+// RGBA64Image is an image that can return pixels as RGBA64 directly.
+pub interface RGBA64Image {
+	color_model() color.Model
+	bounds() Rectangle
+	at(x int, y int) color.Color
+	rgba64_at(x int, y int) color.RGBA64
+}
+
+// PalettedImage is an image whose pixels are palette indices.
+pub interface PalettedImage {
+	color_model() color.Model
+	bounds() Rectangle
+	at(x int, y int) color.Color
+	color_index_at(x int, y int) u8
+}
+
+// Uniform is an infinite image of a single color.
+pub struct Uniform {
+pub mut:
+	c color.Color
+}
+
+pub const black = Uniform{
+	c: color.black
+}
+pub const white = Uniform{
+	c: color.white
+}
+pub const transparent = Uniform{
+	c: color.transparent
+}
+pub const opaque = Uniform{
+	c: color.opaque
+}
+
+// rgba returns the uniform color as alpha-premultiplied 16-bit channels.
+pub fn (u Uniform) rgba() (u32, u32, u32, u32) {
+	return u.c.rgba()
+}
+
+// color_model returns a model that converts every color to u.c.
+pub fn (u Uniform) color_model() color.Model {
+	return color.constant_model(u.c)
+}
+
+// bounds returns a large rectangle for the infinite uniform image.
+pub fn (u Uniform) bounds() Rectangle {
+	return Rectangle{
+		min: pt(-1_000_000_000, -1_000_000_000)
+		max: pt(1_000_000_000, 1_000_000_000)
+	}
+}
+
+// at returns the uniform image color.
+pub fn (u Uniform) at(x int, y int) color.Color {
+	return u.c
+}
+
+// rgba64_at returns the uniform image color as RGBA64.
+pub fn (u Uniform) rgba64_at(x int, y int) color.RGBA64 {
+	r, g, b, a := u.c.rgba()
+	return color.RGBA64{u16(r), u16(g), u16(b), u16(a)}
+}
+
+// opaque reports whether the uniform image is fully opaque.
+pub fn (u Uniform) opaque() bool {
+	_, _, _, a := u.c.rgba()
+	return a == 0xffff
+}
+
+// new_uniform returns a new Uniform image of c.
+pub fn new_uniform(c color.Color) Uniform {
+	return Uniform{
+		c: c
+	}
+}
+
+// RGBA is an in-memory image with pixels in R, G, B, A byte order.
+pub struct RGBA {
+pub mut:
+	pix    []u8
+	stride int
+	rect   Rectangle
+}
+
+// color_model returns the RGBA color model.
+pub fn (p RGBA) color_model() color.Model {
+	return color.rgba_model
+}
+
+// bounds returns the image bounds.
+pub fn (p RGBA) bounds() Rectangle {
+	return p.rect
+}
+
+// at returns the pixel at x, y as a color.
+pub fn (p RGBA) at(x int, y int) color.Color {
+	return color.Color(p.rgba_at(x, y))
+}
+
+// rgba64_at returns the pixel at x, y as RGBA64.
+pub fn (p RGBA) rgba64_at(x int, y int) color.RGBA64 {
+	if !pt(x, y).in_rect(p.rect) {
+		return color.RGBA64{}
+	}
+	i := p.pix_offset(x, y)
+	r := u16(p.pix[i])
+	g := u16(p.pix[i + 1])
+	b := u16(p.pix[i + 2])
+	a := u16(p.pix[i + 3])
+	return color.RGBA64{
+		r: (r << 8) | r
+		g: (g << 8) | g
+		b: (b << 8) | b
+		a: (a << 8) | a
+	}
+}
+
+// rgba_at returns the pixel at x, y as RGBA.
+pub fn (p RGBA) rgba_at(x int, y int) color.RGBA {
+	if !pt(x, y).in_rect(p.rect) {
+		return color.RGBA{}
+	}
+	i := p.pix_offset(x, y)
+	return color.RGBA{p.pix[i], p.pix[i + 1], p.pix[i + 2], p.pix[i + 3]}
+}
+
+// pix_offset returns the first pix index for x, y.
+pub fn (p RGBA) pix_offset(x int, y int) int {
+	return (y - p.rect.min.y) * p.stride + (x - p.rect.min.x) * 4
+}
+
+// set stores c at x, y.
+pub fn (mut p RGBA) set(x int, y int, c color.Color) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.set_rgba(x, y, color.to_rgba(c))
+}
+
+// set_rgba64 stores c at x, y.
+pub fn (mut p RGBA) set_rgba64(x int, y int, c color.RGBA64) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	i := p.pix_offset(x, y)
+	p.pix[i] = u8(c.r >> 8)
+	p.pix[i + 1] = u8(c.g >> 8)
+	p.pix[i + 2] = u8(c.b >> 8)
+	p.pix[i + 3] = u8(c.a >> 8)
+}
+
+// set_rgba stores c at x, y.
+pub fn (mut p RGBA) set_rgba(x int, y int, c color.RGBA) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	i := p.pix_offset(x, y)
+	p.pix[i] = c.r
+	p.pix[i + 1] = c.g
+	p.pix[i + 2] = c.b
+	p.pix[i + 3] = c.a
+}
+
+// sub_image returns the portion of p visible through r.
+pub fn (p RGBA) sub_image(r Rectangle) RGBA {
+	rr := r.intersect(p.rect)
+	if rr.empty() {
+		return RGBA{}
+	}
+	i := p.pix_offset(rr.min.x, rr.min.y)
+	return RGBA{
+		pix:    p.pix[i..]
+		stride: p.stride
+		rect:   rr
+	}
+}
+
+// opaque reports whether every pixel is fully opaque.
+pub fn (p RGBA) opaque() bool {
+	if p.rect.empty() {
+		return true
+	}
+	mut i0 := 3
+	mut i1 := p.rect.dx() * 4
+	for _ in p.rect.min.y .. p.rect.max.y {
+		for i := i0; i < i1; i += 4 {
+			if p.pix[i] != 0xff {
+				return false
+			}
+		}
+		i0 += p.stride
+		i1 += p.stride
+	}
+	return true
+}
+
+// new_rgba returns a new RGBA image with bounds r.
+pub fn new_rgba(r Rectangle) RGBA {
+	return RGBA{
+		pix:    []u8{len: pixel_buffer_length(4, r, 'RGBA')}
+		stride: 4 * r.dx()
+		rect:   r
+	}
+}
+
+// RGBA64 is an in-memory image with big-endian 16-bit RGBA channels.
+pub struct RGBA64 {
+pub mut:
+	pix    []u8
+	stride int
+	rect   Rectangle
+}
+
+// color_model returns the RGBA64 color model.
+pub fn (p RGBA64) color_model() color.Model {
+	return color.rgba64_model
+}
+
+// bounds returns the image bounds.
+pub fn (p RGBA64) bounds() Rectangle {
+	return p.rect
+}
+
+// at returns the pixel at x, y as a color.
+pub fn (p RGBA64) at(x int, y int) color.Color {
+	return color.Color(p.rgba64_at(x, y))
+}
+
+// rgba64_at returns the pixel at x, y as RGBA64.
+pub fn (p RGBA64) rgba64_at(x int, y int) color.RGBA64 {
+	if !pt(x, y).in_rect(p.rect) {
+		return color.RGBA64{}
+	}
+	i := p.pix_offset(x, y)
+	return color.RGBA64{
+		r: read_u16(p.pix, i)
+		g: read_u16(p.pix, i + 2)
+		b: read_u16(p.pix, i + 4)
+		a: read_u16(p.pix, i + 6)
+	}
+}
+
+// pix_offset returns the first pix index for x, y.
+pub fn (p RGBA64) pix_offset(x int, y int) int {
+	return (y - p.rect.min.y) * p.stride + (x - p.rect.min.x) * 8
+}
+
+// set stores c at x, y.
+pub fn (mut p RGBA64) set(x int, y int, c color.Color) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.set_rgba64(x, y, color.to_rgba64(c))
+}
+
+// set_rgba64 stores c at x, y.
+pub fn (mut p RGBA64) set_rgba64(x int, y int, c color.RGBA64) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	i := p.pix_offset(x, y)
+	write_u16(mut p.pix, i, c.r)
+	write_u16(mut p.pix, i + 2, c.g)
+	write_u16(mut p.pix, i + 4, c.b)
+	write_u16(mut p.pix, i + 6, c.a)
+}
+
+// sub_image returns the portion of p visible through r.
+pub fn (p RGBA64) sub_image(r Rectangle) RGBA64 {
+	rr := r.intersect(p.rect)
+	if rr.empty() {
+		return RGBA64{}
+	}
+	i := p.pix_offset(rr.min.x, rr.min.y)
+	return RGBA64{
+		pix:    p.pix[i..]
+		stride: p.stride
+		rect:   rr
+	}
+}
+
+// opaque reports whether every pixel is fully opaque.
+pub fn (p RGBA64) opaque() bool {
+	if p.rect.empty() {
+		return true
+	}
+	mut i0 := 6
+	mut i1 := p.rect.dx() * 8
+	for _ in p.rect.min.y .. p.rect.max.y {
+		for i := i0; i < i1; i += 8 {
+			if p.pix[i] != 0xff || p.pix[i + 1] != 0xff {
+				return false
+			}
+		}
+		i0 += p.stride
+		i1 += p.stride
+	}
+	return true
+}
+
+// new_rgba64 returns a new RGBA64 image with bounds r.
+pub fn new_rgba64(r Rectangle) RGBA64 {
+	return RGBA64{
+		pix:    []u8{len: pixel_buffer_length(8, r, 'RGBA64')}
+		stride: 8 * r.dx()
+		rect:   r
+	}
+}
+
+// NRGBA is an in-memory image with non-alpha-premultiplied R, G, B, A bytes.
+pub struct NRGBA {
+pub mut:
+	pix    []u8
+	stride int
+	rect   Rectangle
+}
+
+// color_model returns the NRGBA color model.
+pub fn (p NRGBA) color_model() color.Model {
+	return color.nrgba_model
+}
+
+// bounds returns the image bounds.
+pub fn (p NRGBA) bounds() Rectangle {
+	return p.rect
+}
+
+// at returns the pixel at x, y as a color.
+pub fn (p NRGBA) at(x int, y int) color.Color {
+	return color.Color(p.nrgba_at(x, y))
+}
+
+// rgba64_at returns the pixel at x, y as RGBA64.
+pub fn (p NRGBA) rgba64_at(x int, y int) color.RGBA64 {
+	return color.to_rgba64(color.Color(p.nrgba_at(x, y)))
+}
+
+// nrgba_at returns the pixel at x, y as NRGBA.
+pub fn (p NRGBA) nrgba_at(x int, y int) color.NRGBA {
+	if !pt(x, y).in_rect(p.rect) {
+		return color.NRGBA{}
+	}
+	i := p.pix_offset(x, y)
+	return color.NRGBA{p.pix[i], p.pix[i + 1], p.pix[i + 2], p.pix[i + 3]}
+}
+
+// pix_offset returns the first pix index for x, y.
+pub fn (p NRGBA) pix_offset(x int, y int) int {
+	return (y - p.rect.min.y) * p.stride + (x - p.rect.min.x) * 4
+}
+
+// set stores c at x, y.
+pub fn (mut p NRGBA) set(x int, y int, c color.Color) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.set_nrgba(x, y, color.to_nrgba(c))
+}
+
+// set_rgba64 stores c at x, y after converting to non-premultiplied RGBA.
+pub fn (mut p NRGBA) set_rgba64(x int, y int, c color.RGBA64) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	mut r := u32(c.r)
+	mut g := u32(c.g)
+	mut b := u32(c.b)
+	a := u32(c.a)
+	if a != 0 && a != 0xffff {
+		r = (r * 0xffff) / a
+		g = (g * 0xffff) / a
+		b = (b * 0xffff) / a
+	}
+	p.set_nrgba(x, y, color.NRGBA{u8(r >> 8), u8(g >> 8), u8(b >> 8), u8(a >> 8)})
+}
+
+// set_nrgba stores c at x, y.
+pub fn (mut p NRGBA) set_nrgba(x int, y int, c color.NRGBA) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	i := p.pix_offset(x, y)
+	p.pix[i] = c.r
+	p.pix[i + 1] = c.g
+	p.pix[i + 2] = c.b
+	p.pix[i + 3] = c.a
+}
+
+// sub_image returns the portion of p visible through r.
+pub fn (p NRGBA) sub_image(r Rectangle) NRGBA {
+	rr := r.intersect(p.rect)
+	if rr.empty() {
+		return NRGBA{}
+	}
+	i := p.pix_offset(rr.min.x, rr.min.y)
+	return NRGBA{
+		pix:    p.pix[i..]
+		stride: p.stride
+		rect:   rr
+	}
+}
+
+// opaque reports whether every pixel is fully opaque.
+pub fn (p NRGBA) opaque() bool {
+	if p.rect.empty() {
+		return true
+	}
+	mut i0 := 3
+	mut i1 := p.rect.dx() * 4
+	for _ in p.rect.min.y .. p.rect.max.y {
+		for i := i0; i < i1; i += 4 {
+			if p.pix[i] != 0xff {
+				return false
+			}
+		}
+		i0 += p.stride
+		i1 += p.stride
+	}
+	return true
+}
+
+// new_nrgba returns a new NRGBA image with bounds r.
+pub fn new_nrgba(r Rectangle) NRGBA {
+	return NRGBA{
+		pix:    []u8{len: pixel_buffer_length(4, r, 'NRGBA')}
+		stride: 4 * r.dx()
+		rect:   r
+	}
+}
+
+// NRGBA64 is an in-memory image with non-premultiplied big-endian 16-bit channels.
+pub struct NRGBA64 {
+pub mut:
+	pix    []u8
+	stride int
+	rect   Rectangle
+}
+
+// color_model returns the NRGBA64 color model.
+pub fn (p NRGBA64) color_model() color.Model {
+	return color.nrgba64_model
+}
+
+// bounds returns the image bounds.
+pub fn (p NRGBA64) bounds() Rectangle {
+	return p.rect
+}
+
+// at returns the pixel at x, y as a color.
+pub fn (p NRGBA64) at(x int, y int) color.Color {
+	return color.Color(p.nrgba64_at(x, y))
+}
+
+// rgba64_at returns the pixel at x, y as RGBA64.
+pub fn (p NRGBA64) rgba64_at(x int, y int) color.RGBA64 {
+	return color.to_rgba64(color.Color(p.nrgba64_at(x, y)))
+}
+
+// nrgba64_at returns the pixel at x, y as NRGBA64.
+pub fn (p NRGBA64) nrgba64_at(x int, y int) color.NRGBA64 {
+	if !pt(x, y).in_rect(p.rect) {
+		return color.NRGBA64{}
+	}
+	i := p.pix_offset(x, y)
+	return color.NRGBA64{
+		r: read_u16(p.pix, i)
+		g: read_u16(p.pix, i + 2)
+		b: read_u16(p.pix, i + 4)
+		a: read_u16(p.pix, i + 6)
+	}
+}
+
+// pix_offset returns the first pix index for x, y.
+pub fn (p NRGBA64) pix_offset(x int, y int) int {
+	return (y - p.rect.min.y) * p.stride + (x - p.rect.min.x) * 8
+}
+
+// set stores c at x, y.
+pub fn (mut p NRGBA64) set(x int, y int, c color.Color) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.set_nrgba64(x, y, color.to_nrgba64(c))
+}
+
+// set_rgba64 stores c at x, y after converting to non-premultiplied RGBA.
+pub fn (mut p NRGBA64) set_rgba64(x int, y int, c color.RGBA64) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	mut r := u32(c.r)
+	mut g := u32(c.g)
+	mut b := u32(c.b)
+	a := u32(c.a)
+	if a != 0 && a != 0xffff {
+		r = (r * 0xffff) / a
+		g = (g * 0xffff) / a
+		b = (b * 0xffff) / a
+	}
+	p.set_nrgba64(x, y, color.NRGBA64{u16(r), u16(g), u16(b), u16(a)})
+}
+
+// set_nrgba64 stores c at x, y.
+pub fn (mut p NRGBA64) set_nrgba64(x int, y int, c color.NRGBA64) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	i := p.pix_offset(x, y)
+	write_u16(mut p.pix, i, c.r)
+	write_u16(mut p.pix, i + 2, c.g)
+	write_u16(mut p.pix, i + 4, c.b)
+	write_u16(mut p.pix, i + 6, c.a)
+}
+
+// sub_image returns the portion of p visible through r.
+pub fn (p NRGBA64) sub_image(r Rectangle) NRGBA64 {
+	rr := r.intersect(p.rect)
+	if rr.empty() {
+		return NRGBA64{}
+	}
+	i := p.pix_offset(rr.min.x, rr.min.y)
+	return NRGBA64{
+		pix:    p.pix[i..]
+		stride: p.stride
+		rect:   rr
+	}
+}
+
+// opaque reports whether every pixel is fully opaque.
+pub fn (p NRGBA64) opaque() bool {
+	if p.rect.empty() {
+		return true
+	}
+	mut i0 := 6
+	mut i1 := p.rect.dx() * 8
+	for _ in p.rect.min.y .. p.rect.max.y {
+		for i := i0; i < i1; i += 8 {
+			if p.pix[i] != 0xff || p.pix[i + 1] != 0xff {
+				return false
+			}
+		}
+		i0 += p.stride
+		i1 += p.stride
+	}
+	return true
+}
+
+// new_nrgba64 returns a new NRGBA64 image with bounds r.
+pub fn new_nrgba64(r Rectangle) NRGBA64 {
+	return NRGBA64{
+		pix:    []u8{len: pixel_buffer_length(8, r, 'NRGBA64')}
+		stride: 8 * r.dx()
+		rect:   r
+	}
+}
+
+// Alpha is an in-memory image of alpha samples.
+pub struct Alpha {
+pub mut:
+	pix    []u8
+	stride int
+	rect   Rectangle
+}
+
+// color_model returns the Alpha color model.
+pub fn (p Alpha) color_model() color.Model {
+	return color.alpha_model
+}
+
+// bounds returns the image bounds.
+pub fn (p Alpha) bounds() Rectangle {
+	return p.rect
+}
+
+// at returns the pixel at x, y as a color.
+pub fn (p Alpha) at(x int, y int) color.Color {
+	return color.Color(p.alpha_at(x, y))
+}
+
+// rgba64_at returns the pixel at x, y as RGBA64.
+pub fn (p Alpha) rgba64_at(x int, y int) color.RGBA64 {
+	a0 := u16(p.alpha_at(x, y).a)
+	a := (a0 << 8) | a0
+	return color.RGBA64{a, a, a, a}
+}
+
+// alpha_at returns the pixel at x, y as Alpha.
+pub fn (p Alpha) alpha_at(x int, y int) color.Alpha {
+	if !pt(x, y).in_rect(p.rect) {
+		return color.Alpha{}
+	}
+	return color.Alpha{
+		a: p.pix[p.pix_offset(x, y)]
+	}
+}
+
+// pix_offset returns the first pix index for x, y.
+pub fn (p Alpha) pix_offset(x int, y int) int {
+	return (y - p.rect.min.y) * p.stride + (x - p.rect.min.x)
+}
+
+// set stores c at x, y.
+pub fn (mut p Alpha) set(x int, y int, c color.Color) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.pix[p.pix_offset(x, y)] = color.to_alpha(c).a
+}
+
+// set_rgba64 stores c at x, y.
+pub fn (mut p Alpha) set_rgba64(x int, y int, c color.RGBA64) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.pix[p.pix_offset(x, y)] = u8(c.a >> 8)
+}
+
+// set_alpha stores c at x, y.
+pub fn (mut p Alpha) set_alpha(x int, y int, c color.Alpha) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.pix[p.pix_offset(x, y)] = c.a
+}
+
+// sub_image returns the portion of p visible through r.
+pub fn (p Alpha) sub_image(r Rectangle) Alpha {
+	rr := r.intersect(p.rect)
+	if rr.empty() {
+		return Alpha{}
+	}
+	i := p.pix_offset(rr.min.x, rr.min.y)
+	return Alpha{
+		pix:    p.pix[i..]
+		stride: p.stride
+		rect:   rr
+	}
+}
+
+// opaque reports whether every pixel is fully opaque.
+pub fn (p Alpha) opaque() bool {
+	if p.rect.empty() {
+		return true
+	}
+	mut i0 := 0
+	mut i1 := p.rect.dx()
+	for _ in p.rect.min.y .. p.rect.max.y {
+		for i := i0; i < i1; i++ {
+			if p.pix[i] != 0xff {
+				return false
+			}
+		}
+		i0 += p.stride
+		i1 += p.stride
+	}
+	return true
+}
+
+// new_alpha returns a new Alpha image with bounds r.
+pub fn new_alpha(r Rectangle) Alpha {
+	return Alpha{
+		pix:    []u8{len: pixel_buffer_length(1, r, 'Alpha')}
+		stride: r.dx()
+		rect:   r
+	}
+}
+
+// Alpha16 is an in-memory image of big-endian 16-bit alpha samples.
+pub struct Alpha16 {
+pub mut:
+	pix    []u8
+	stride int
+	rect   Rectangle
+}
+
+// color_model returns the Alpha16 color model.
+pub fn (p Alpha16) color_model() color.Model {
+	return color.alpha16_model
+}
+
+// bounds returns the image bounds.
+pub fn (p Alpha16) bounds() Rectangle {
+	return p.rect
+}
+
+// at returns the pixel at x, y as a color.
+pub fn (p Alpha16) at(x int, y int) color.Color {
+	return color.Color(p.alpha16_at(x, y))
+}
+
+// rgba64_at returns the pixel at x, y as RGBA64.
+pub fn (p Alpha16) rgba64_at(x int, y int) color.RGBA64 {
+	a := p.alpha16_at(x, y).a
+	return color.RGBA64{a, a, a, a}
+}
+
+// alpha16_at returns the pixel at x, y as Alpha16.
+pub fn (p Alpha16) alpha16_at(x int, y int) color.Alpha16 {
+	if !pt(x, y).in_rect(p.rect) {
+		return color.Alpha16{}
+	}
+	return color.Alpha16{
+		a: read_u16(p.pix, p.pix_offset(x, y))
+	}
+}
+
+// pix_offset returns the first pix index for x, y.
+pub fn (p Alpha16) pix_offset(x int, y int) int {
+	return (y - p.rect.min.y) * p.stride + (x - p.rect.min.x) * 2
+}
+
+// set stores c at x, y.
+pub fn (mut p Alpha16) set(x int, y int, c color.Color) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.set_alpha16(x, y, color.to_alpha16(c))
+}
+
+// set_rgba64 stores c at x, y.
+pub fn (mut p Alpha16) set_rgba64(x int, y int, c color.RGBA64) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	write_u16(mut p.pix, p.pix_offset(x, y), c.a)
+}
+
+// set_alpha16 stores c at x, y.
+pub fn (mut p Alpha16) set_alpha16(x int, y int, c color.Alpha16) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	write_u16(mut p.pix, p.pix_offset(x, y), c.a)
+}
+
+// sub_image returns the portion of p visible through r.
+pub fn (p Alpha16) sub_image(r Rectangle) Alpha16 {
+	rr := r.intersect(p.rect)
+	if rr.empty() {
+		return Alpha16{}
+	}
+	i := p.pix_offset(rr.min.x, rr.min.y)
+	return Alpha16{
+		pix:    p.pix[i..]
+		stride: p.stride
+		rect:   rr
+	}
+}
+
+// opaque reports whether every pixel is fully opaque.
+pub fn (p Alpha16) opaque() bool {
+	if p.rect.empty() {
+		return true
+	}
+	mut i0 := 0
+	mut i1 := p.rect.dx() * 2
+	for _ in p.rect.min.y .. p.rect.max.y {
+		for i := i0; i < i1; i += 2 {
+			if p.pix[i] != 0xff || p.pix[i + 1] != 0xff {
+				return false
+			}
+		}
+		i0 += p.stride
+		i1 += p.stride
+	}
+	return true
+}
+
+// new_alpha16 returns a new Alpha16 image with bounds r.
+pub fn new_alpha16(r Rectangle) Alpha16 {
+	return Alpha16{
+		pix:    []u8{len: pixel_buffer_length(2, r, 'Alpha16')}
+		stride: 2 * r.dx()
+		rect:   r
+	}
+}
+
+// Gray is an in-memory image of 8-bit grayscale samples.
+pub struct Gray {
+pub mut:
+	pix    []u8
+	stride int
+	rect   Rectangle
+}
+
+// color_model returns the Gray color model.
+pub fn (p Gray) color_model() color.Model {
+	return color.gray_model
+}
+
+// bounds returns the image bounds.
+pub fn (p Gray) bounds() Rectangle {
+	return p.rect
+}
+
+// at returns the pixel at x, y as a color.
+pub fn (p Gray) at(x int, y int) color.Color {
+	return color.Color(p.gray_at(x, y))
+}
+
+// rgba64_at returns the pixel at x, y as RGBA64.
+pub fn (p Gray) rgba64_at(x int, y int) color.RGBA64 {
+	y0 := u16(p.gray_at(x, y).y)
+	yy := (y0 << 8) | y0
+	return color.RGBA64{yy, yy, yy, 0xffff}
+}
+
+// gray_at returns the pixel at x, y as Gray.
+pub fn (p Gray) gray_at(x int, y int) color.Gray {
+	if !pt(x, y).in_rect(p.rect) {
+		return color.Gray{}
+	}
+	return color.Gray{
+		y: p.pix[p.pix_offset(x, y)]
+	}
+}
+
+// pix_offset returns the first pix index for x, y.
+pub fn (p Gray) pix_offset(x int, y int) int {
+	return (y - p.rect.min.y) * p.stride + (x - p.rect.min.x)
+}
+
+// set stores c at x, y.
+pub fn (mut p Gray) set(x int, y int, c color.Color) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.pix[p.pix_offset(x, y)] = color.to_gray(c).y
+}
+
+// set_rgba64 stores c at x, y.
+pub fn (mut p Gray) set_rgba64(x int, y int, c color.RGBA64) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	gray := (19595 * u32(c.r) + 38470 * u32(c.g) + 7471 * u32(c.b) + (1 << 15)) >> 24
+	p.pix[p.pix_offset(x, y)] = u8(gray)
+}
+
+// set_gray stores c at x, y.
+pub fn (mut p Gray) set_gray(x int, y int, c color.Gray) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.pix[p.pix_offset(x, y)] = c.y
+}
+
+// sub_image returns the portion of p visible through r.
+pub fn (p Gray) sub_image(r Rectangle) Gray {
+	rr := r.intersect(p.rect)
+	if rr.empty() {
+		return Gray{}
+	}
+	i := p.pix_offset(rr.min.x, rr.min.y)
+	return Gray{
+		pix:    p.pix[i..]
+		stride: p.stride
+		rect:   rr
+	}
+}
+
+// opaque reports whether every pixel is fully opaque.
+pub fn (p Gray) opaque() bool {
+	return true
+}
+
+// new_gray returns a new Gray image with bounds r.
+pub fn new_gray(r Rectangle) Gray {
+	return Gray{
+		pix:    []u8{len: pixel_buffer_length(1, r, 'Gray')}
+		stride: r.dx()
+		rect:   r
+	}
+}
+
+// Gray16 is an in-memory image of big-endian 16-bit grayscale samples.
+pub struct Gray16 {
+pub mut:
+	pix    []u8
+	stride int
+	rect   Rectangle
+}
+
+// color_model returns the Gray16 color model.
+pub fn (p Gray16) color_model() color.Model {
+	return color.gray16_model
+}
+
+// bounds returns the image bounds.
+pub fn (p Gray16) bounds() Rectangle {
+	return p.rect
+}
+
+// at returns the pixel at x, y as a color.
+pub fn (p Gray16) at(x int, y int) color.Color {
+	return color.Color(p.gray16_at(x, y))
+}
+
+// rgba64_at returns the pixel at x, y as RGBA64.
+pub fn (p Gray16) rgba64_at(x int, y int) color.RGBA64 {
+	yy := p.gray16_at(x, y).y
+	return color.RGBA64{yy, yy, yy, 0xffff}
+}
+
+// gray16_at returns the pixel at x, y as Gray16.
+pub fn (p Gray16) gray16_at(x int, y int) color.Gray16 {
+	if !pt(x, y).in_rect(p.rect) {
+		return color.Gray16{}
+	}
+	return color.Gray16{
+		y: read_u16(p.pix, p.pix_offset(x, y))
+	}
+}
+
+// pix_offset returns the first pix index for x, y.
+pub fn (p Gray16) pix_offset(x int, y int) int {
+	return (y - p.rect.min.y) * p.stride + (x - p.rect.min.x) * 2
+}
+
+// set stores c at x, y.
+pub fn (mut p Gray16) set(x int, y int, c color.Color) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.set_gray16(x, y, color.to_gray16(c))
+}
+
+// set_rgba64 stores c at x, y.
+pub fn (mut p Gray16) set_rgba64(x int, y int, c color.RGBA64) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	gray := (19595 * u32(c.r) + 38470 * u32(c.g) + 7471 * u32(c.b) + (1 << 15)) >> 16
+	write_u16(mut p.pix, p.pix_offset(x, y), u16(gray))
+}
+
+// set_gray16 stores c at x, y.
+pub fn (mut p Gray16) set_gray16(x int, y int, c color.Gray16) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	write_u16(mut p.pix, p.pix_offset(x, y), c.y)
+}
+
+// sub_image returns the portion of p visible through r.
+pub fn (p Gray16) sub_image(r Rectangle) Gray16 {
+	rr := r.intersect(p.rect)
+	if rr.empty() {
+		return Gray16{}
+	}
+	i := p.pix_offset(rr.min.x, rr.min.y)
+	return Gray16{
+		pix:    p.pix[i..]
+		stride: p.stride
+		rect:   rr
+	}
+}
+
+// opaque reports whether every pixel is fully opaque.
+pub fn (p Gray16) opaque() bool {
+	return true
+}
+
+// new_gray16 returns a new Gray16 image with bounds r.
+pub fn new_gray16(r Rectangle) Gray16 {
+	return Gray16{
+		pix:    []u8{len: pixel_buffer_length(2, r, 'Gray16')}
+		stride: 2 * r.dx()
+		rect:   r
+	}
+}
+
+// CMYK is an in-memory image with C, M, Y, K byte order.
+pub struct CMYK {
+pub mut:
+	pix    []u8
+	stride int
+	rect   Rectangle
+}
+
+// color_model returns the CMYK color model.
+pub fn (p CMYK) color_model() color.Model {
+	return color.cmyk_model
+}
+
+// bounds returns the image bounds.
+pub fn (p CMYK) bounds() Rectangle {
+	return p.rect
+}
+
+// at returns the pixel at x, y as a color.
+pub fn (p CMYK) at(x int, y int) color.Color {
+	return color.Color(p.cmyk_at(x, y))
+}
+
+// rgba64_at returns the pixel at x, y as RGBA64.
+pub fn (p CMYK) rgba64_at(x int, y int) color.RGBA64 {
+	return color.to_rgba64(color.Color(p.cmyk_at(x, y)))
+}
+
+// cmyk_at returns the pixel at x, y as CMYK.
+pub fn (p CMYK) cmyk_at(x int, y int) color.CMYK {
+	if !pt(x, y).in_rect(p.rect) {
+		return color.CMYK{}
+	}
+	i := p.pix_offset(x, y)
+	return color.CMYK{p.pix[i], p.pix[i + 1], p.pix[i + 2], p.pix[i + 3]}
+}
+
+// pix_offset returns the first pix index for x, y.
+pub fn (p CMYK) pix_offset(x int, y int) int {
+	return (y - p.rect.min.y) * p.stride + (x - p.rect.min.x) * 4
+}
+
+// set stores c at x, y.
+pub fn (mut p CMYK) set(x int, y int, c color.Color) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.set_cmyk(x, y, color.to_cmyk(c))
+}
+
+// set_rgba64 stores c at x, y.
+pub fn (mut p CMYK) set_rgba64(x int, y int, c color.RGBA64) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	cc, mm, yy, kk := color.rgb_to_cmyk(u8(c.r >> 8), u8(c.g >> 8), u8(c.b >> 8))
+	p.set_cmyk(x, y, color.CMYK{cc, mm, yy, kk})
+}
+
+// set_cmyk stores c at x, y.
+pub fn (mut p CMYK) set_cmyk(x int, y int, c color.CMYK) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	i := p.pix_offset(x, y)
+	p.pix[i] = c.c
+	p.pix[i + 1] = c.m
+	p.pix[i + 2] = c.y
+	p.pix[i + 3] = c.k
+}
+
+// sub_image returns the portion of p visible through r.
+pub fn (p CMYK) sub_image(r Rectangle) CMYK {
+	rr := r.intersect(p.rect)
+	if rr.empty() {
+		return CMYK{}
+	}
+	i := p.pix_offset(rr.min.x, rr.min.y)
+	return CMYK{
+		pix:    p.pix[i..]
+		stride: p.stride
+		rect:   rr
+	}
+}
+
+// opaque reports whether every pixel is fully opaque.
+pub fn (p CMYK) opaque() bool {
+	return true
+}
+
+// new_cmyk returns a new CMYK image with bounds r.
+pub fn new_cmyk(r Rectangle) CMYK {
+	return CMYK{
+		pix:    []u8{len: pixel_buffer_length(4, r, 'CMYK')}
+		stride: 4 * r.dx()
+		rect:   r
+	}
+}
+
+// Paletted is an in-memory image of palette indices.
+pub struct Paletted {
+pub mut:
+	pix     []u8
+	stride  int
+	rect    Rectangle
+	palette color.Palette
+}
+
+// color_model returns the image palette.
+pub fn (p Paletted) color_model() color.Model {
+	return color.Model(p.palette)
+}
+
+// bounds returns the image bounds.
+pub fn (p Paletted) bounds() Rectangle {
+	return p.rect
+}
+
+// at returns the color at x, y.
+pub fn (p Paletted) at(x int, y int) color.Color {
+	if p.palette.colors.len == 0 {
+		return color.transparent
+	}
+	if !pt(x, y).in_rect(p.rect) {
+		return p.palette.colors[0]
+	}
+	i := p.pix_offset(x, y)
+	return p.palette.colors[p.pix[i]]
+}
+
+// rgba64_at returns the color at x, y as RGBA64.
+pub fn (p Paletted) rgba64_at(x int, y int) color.RGBA64 {
+	return color.to_rgba64(p.at(x, y))
+}
+
+// pix_offset returns the first pix index for x, y.
+pub fn (p Paletted) pix_offset(x int, y int) int {
+	return (y - p.rect.min.y) * p.stride + (x - p.rect.min.x)
+}
+
+// set stores c's nearest palette index at x, y.
+pub fn (mut p Paletted) set(x int, y int, c color.Color) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.pix[p.pix_offset(x, y)] = u8(p.palette.index(c))
+}
+
+// set_rgba64 stores c's nearest palette index at x, y.
+pub fn (mut p Paletted) set_rgba64(x int, y int, c color.RGBA64) {
+	p.set(x, y, color.Color(c))
+}
+
+// color_index_at returns the palette index at x, y.
+pub fn (p Paletted) color_index_at(x int, y int) u8 {
+	if !pt(x, y).in_rect(p.rect) {
+		return 0
+	}
+	return p.pix[p.pix_offset(x, y)]
+}
+
+// set_color_index stores index at x, y.
+pub fn (mut p Paletted) set_color_index(x int, y int, index u8) {
+	if !pt(x, y).in_rect(p.rect) {
+		return
+	}
+	p.pix[p.pix_offset(x, y)] = index
+}
+
+// sub_image returns the portion of p visible through r.
+pub fn (p Paletted) sub_image(r Rectangle) Paletted {
+	rr := r.intersect(p.rect)
+	if rr.empty() {
+		return Paletted{
+			palette: p.palette
+		}
+	}
+	i := p.pix_offset(rr.min.x, rr.min.y)
+	return Paletted{
+		pix:     p.pix[i..]
+		stride:  p.stride
+		rect:    rr
+		palette: p.palette
+	}
+}
+
+// opaque reports whether every referenced palette color is fully opaque.
+pub fn (p Paletted) opaque() bool {
+	mut present := []bool{len: 256}
+	mut i0 := 0
+	mut i1 := p.rect.dx()
+	for _ in p.rect.min.y .. p.rect.max.y {
+		for i := i0; i < i1; i++ {
+			present[p.pix[i]] = true
+		}
+		i0 += p.stride
+		i1 += p.stride
+	}
+	for i, c in p.palette.colors {
+		if !present[i] {
+			continue
+		}
+		_, _, _, a := c.rgba()
+		if a != 0xffff {
+			return false
+		}
+	}
+	return true
+}
+
+// new_paletted returns a new Paletted image with bounds r and palette p.
+pub fn new_paletted(r Rectangle, p color.Palette) Paletted {
+	return Paletted{
+		pix:     []u8{len: pixel_buffer_length(1, r, 'Paletted')}
+		stride:  r.dx()
+		rect:    r
+		palette: p
+	}
+}
+
+fn read_u16(pix []u8, i int) u16 {
+	return (u16(pix[i]) << 8) | u16(pix[i + 1])
+}
+
+fn write_u16(mut pix []u8, i int, v u16) {
+	pix[i] = u8(v >> 8)
+	pix[i + 1] = u8(v)
+}

--- a/vlib/image/image.v
+++ b/vlib/image/image.v
@@ -66,6 +66,11 @@ pub fn (u Uniform) color_model() color.Model {
 	return color.constant_model(u.c)
 }
 
+// convert converts any color to the uniform color.
+pub fn (u Uniform) convert(c color.Color) color.Color {
+	return u.c
+}
+
 // bounds returns a large rectangle for the infinite uniform image.
 pub fn (u Uniform) bounds() Rectangle {
 	return Rectangle{

--- a/vlib/image/image_test.v
+++ b/vlib/image/image_test.v
@@ -2,6 +2,29 @@ module image
 
 import image.color
 
+fn rect_in(f Rectangle, g Rectangle) bool {
+	if !f.inside(g) {
+		return false
+	}
+	for y := f.min.y; y < f.max.y; y++ {
+		for x := f.min.x; x < f.max.x; x++ {
+			if !pt(x, y).in_rect(g) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+fn assert_rgba64_matches_at(img RGBA64Image, x int, y int) {
+	got := img.rgba64_at(x, y)
+	want_r, want_g, want_b, want_a := img.at(x, y).rgba()
+	assert u32(got.r) == want_r
+	assert u32(got.g) == want_g
+	assert u32(got.b) == want_b
+	assert u32(got.a) == want_a
+}
+
 fn test_point_and_rectangle_geometry() {
 	assert pt(3, 4).str() == '(3,4)'
 	assert pt(3, 4).add(pt(1, -2)) == pt(4, 2)
@@ -18,6 +41,61 @@ fn test_point_and_rectangle_geometry() {
 	assert rect(0, 0, 5, 5).union(rect(10, 10, 11, 12)) == rect(0, 0, 11, 12)
 	assert rect(0, 0, 1, 1).overlaps(rect(0, 0, 2, 2))
 	assert rect(0, 0, 1, 1).inside(rect(-1, -1, 2, 2))
+}
+
+fn test_rectangle_invariants_from_go() {
+	rects := [
+		rect(0, 0, 10, 10),
+		rect(10, 0, 20, 10),
+		rect(1, 2, 3, 4),
+		rect(4, 6, 10, 10),
+		rect(2, 3, 12, 5),
+		rect(-1, -2, 0, 0),
+		rect(-1, -2, 4, 6),
+		rect(-10, -20, 30, 40),
+		rect(8, 8, 8, 8),
+		rect(88, 88, 88, 88),
+		rect(6, 5, 4, 3),
+	]
+
+	for r in rects {
+		for s in rects {
+			want_eq := rect_in(r, s) && rect_in(s, r)
+			assert r.eq(s) == want_eq
+
+			a := r.intersect(s)
+			assert rect_in(a, r)
+			assert rect_in(a, s)
+			assert (a == Rectangle{}) != r.overlaps(s)
+
+			mut larger_than_a := [a, a, a, a]
+			larger_than_a[0].min.x--
+			larger_than_a[1].min.y--
+			larger_than_a[2].max.x++
+			larger_than_a[3].max.y++
+			for b in larger_than_a {
+				if b.empty() {
+					continue
+				}
+				assert !(rect_in(b, r) && rect_in(b, s))
+			}
+
+			u := r.union(s)
+			assert rect_in(r, u)
+			assert rect_in(s, u)
+			if u.empty() {
+				continue
+			}
+			mut smaller_than_u := [u, u, u, u]
+			smaller_than_u[0].min.x++
+			smaller_than_u[1].min.y++
+			smaller_than_u[2].max.x--
+			smaller_than_u[3].max.y--
+			for b in smaller_than_u {
+				assert !(rect_in(r, b) && rect_in(s, b))
+			}
+		}
+	}
 }
 
 fn test_rgba_layout_and_sub_image() {
@@ -51,6 +129,20 @@ fn test_rgba_layout_and_sub_image() {
 	assert sub.rect == rect(11, 20, 12, 22)
 	assert sub.pix_offset(11, 20) == 0
 	assert sub.pix[0] == 1
+
+	mut sub_shared := img.sub_image(rect(11, 20, 12, 21))
+	sub_shared.set_rgba(11, 20, color.RGBA{
+		r: 9
+		g: 8
+		b: 7
+		a: 255
+	})
+	assert img.rgba_at(11, 20) == color.RGBA{
+		r: 9
+		g: 8
+		b: 7
+		a: 255
+	}
 }
 
 fn test_nrgba_alpha_gray_and_uniform() {
@@ -129,4 +221,219 @@ fn test_ycbcr_and_nycbcra_layout() {
 	with_alpha.a[0] = 255
 	with_alpha.a[1] = 255
 	assert with_alpha.opaque()
+}
+
+fn check_ycbcr_sub_images(r Rectangle, subsample_ratio YCbCrSubsampleRatio, delta Point) {
+	r1 := r.add(delta)
+	mut img := new_ycbcr(r1, subsample_ratio)
+	assert img.y.len <= 100 * 100
+
+	for y := r1.min.y; y < r1.max.y; y++ {
+		for x := r1.min.x; x < r1.max.x; x++ {
+			yi := img.y_offset(x, y)
+			ci := img.c_offset(x, y)
+			img.y[yi] = u8((16 * y + x) & 0xff)
+			img.cb[ci] = u8((y + 16 * x) & 0xff)
+			img.cr[ci] = u8((y + 16 * x) & 0xff)
+		}
+	}
+
+	for y0 := delta.y + 3; y0 < delta.y + 7; y0++ {
+		for y1 := delta.y + 8; y1 < delta.y + 13; y1++ {
+			for x0 := delta.x + 3; x0 < delta.x + 7; x0++ {
+				for x1 := delta.x + 8; x1 < delta.x + 13; x1++ {
+					sub_rect := rect(x0, y0, x1, y1)
+					sub := img.sub_image(sub_rect)
+					for y := sub.rect.min.y; y < sub.rect.max.y; y++ {
+						for x := sub.rect.min.x; x < sub.rect.max.x; x++ {
+							assert img.ycbcr_at(x, y) == sub.ycbcr_at(x, y)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+fn test_ycbcr_sub_images_from_go() {
+	rects := [
+		rect(0, 0, 16, 16),
+		rect(1, 0, 16, 16),
+		rect(0, 1, 16, 16),
+		rect(1, 1, 16, 16),
+		rect(1, 1, 15, 16),
+		rect(1, 1, 16, 15),
+		rect(1, 1, 15, 15),
+		rect(2, 3, 14, 15),
+		rect(7, 0, 7, 16),
+		rect(0, 8, 16, 8),
+		rect(0, 0, 10, 11),
+		rect(5, 6, 16, 16),
+		rect(7, 7, 8, 8),
+		rect(7, 8, 8, 9),
+		rect(8, 7, 9, 8),
+		rect(8, 8, 9, 9),
+		rect(7, 7, 17, 17),
+		rect(8, 8, 17, 17),
+		rect(9, 9, 17, 17),
+		rect(10, 10, 17, 17),
+	]
+	subsample_ratios := [
+		YCbCrSubsampleRatio.ratio_444,
+		.ratio_422,
+		.ratio_420,
+		.ratio_440,
+		.ratio_411,
+		.ratio_410,
+	]
+	deltas := [
+		pt(0, 0),
+		pt(1000, 1001),
+		pt(5001, -400),
+		pt(-701, -801),
+	]
+	for r in rects {
+		for ratio in subsample_ratios {
+			for delta in deltas {
+				check_ycbcr_sub_images(r, ratio, delta)
+			}
+		}
+	}
+}
+
+fn test_ycbcr_slices_do_not_overlap_from_go() {
+	mut img := new_ycbcr(rect(0, 0, 8, 8), .ratio_420)
+	for i in 0 .. img.y.len {
+		img.y[i] = 10
+	}
+	for i in 0 .. img.cb.len {
+		img.cb[i] = 11
+	}
+	for i in 0 .. img.cr.len {
+		img.cr[i] = 12
+	}
+	for got in img.y {
+		assert got == 10
+	}
+	for got in img.cb {
+		assert got == 11
+	}
+	for got in img.cr {
+		assert got == 12
+	}
+}
+
+fn test_16_bits_per_color_channel_from_go() {
+	models := [
+		color.rgba64_model,
+		color.nrgba64_model,
+		color.alpha16_model,
+		color.gray16_model,
+	]
+	for model in models {
+		c := model.convert(color.Color(color.RGBA64{
+			r: 0x1234
+			g: 0x1234
+			b: 0x1234
+			a: 0x1234
+		}))!
+		r, _, _, _ := c.rgba()
+		assert r == 0x1234
+	}
+
+	mut rgba64 := new_rgba64(rect(0, 0, 10, 10))
+	rgba64.set(1, 2, color.Color(color.NRGBA64{0xffff, 0xffff, 0xffff, 0x1357}))
+	r, _, _, _ := rgba64.at(1, 2).rgba()
+	assert r == 0x1357
+
+	mut nrgba64 := new_nrgba64(rect(0, 0, 10, 10))
+	nrgba64.set(1, 2, color.Color(color.NRGBA64{0xffff, 0xffff, 0xffff, 0x1357}))
+	r2, _, _, _ := nrgba64.at(1, 2).rgba()
+	assert r2 == 0x1357
+
+	mut alpha16 := new_alpha16(rect(0, 0, 10, 10))
+	alpha16.set(1, 2, color.Color(color.NRGBA64{0xffff, 0xffff, 0xffff, 0x1357}))
+	r3, _, _, _ := alpha16.at(1, 2).rgba()
+	assert r3 == 0x1357
+
+	mut gray16 := new_gray16(rect(0, 0, 10, 10))
+	gray16.set(1, 2, color.Color(color.NRGBA64{0xffff, 0xffff, 0xffff, 0x1357}))
+	r4, _, _, _ := gray16.at(1, 2).rgba()
+	assert r4 == 0x1357
+}
+
+fn test_rgba64_at_matches_at_rgba_from_go() {
+	r := rect(0, 0, 3, 2)
+	c := color.RGBA64{
+		r: 0x7fff
+		g: 0x3fff
+		b: 0x0000
+		a: 0x7fff
+	}
+
+	mut alpha := new_alpha(r)
+	alpha.set_rgba64(1, 1, c)
+	assert_rgba64_matches_at(alpha, 1, 1)
+
+	mut alpha16 := new_alpha16(r)
+	alpha16.set_rgba64(1, 1, c)
+	assert_rgba64_matches_at(alpha16, 1, 1)
+
+	mut cmyk := new_cmyk(r)
+	cmyk.set_rgba64(1, 1, c)
+	assert_rgba64_matches_at(cmyk, 1, 1)
+
+	mut gray := new_gray(r)
+	gray.set_rgba64(1, 1, c)
+	assert_rgba64_matches_at(gray, 1, 1)
+
+	mut gray16 := new_gray16(r)
+	gray16.set_rgba64(1, 1, c)
+	assert_rgba64_matches_at(gray16, 1, 1)
+
+	mut nrgba := new_nrgba(r)
+	nrgba.set_rgba64(1, 1, c)
+	assert_rgba64_matches_at(nrgba, 1, 1)
+
+	mut nrgba64 := new_nrgba64(r)
+	nrgba64.set_rgba64(1, 1, c)
+	assert_rgba64_matches_at(nrgba64, 1, 1)
+
+	mut paletted := new_paletted(r, color.Palette{
+		colors: [
+			color.Color(c),
+		]
+	})
+	paletted.set_rgba64(1, 1, c)
+	assert_rgba64_matches_at(paletted, 1, 1)
+
+	mut rgba := new_rgba(r)
+	rgba.set_rgba64(1, 1, c)
+	assert_rgba64_matches_at(rgba, 1, 1)
+
+	mut rgba64 := new_rgba64(r)
+	rgba64.set_rgba64(1, 1, c)
+	assert_rgba64_matches_at(rgba64, 1, 1)
+
+	uniform := new_uniform(color.Color(c))
+	assert_rgba64_matches_at(uniform, 1, 1)
+
+	mut ycbcr := new_ycbcr(r, .ratio_444)
+	for i in 0 .. ycbcr.y.len {
+		ycbcr.y[i] = 0x77
+		ycbcr.cb[i] = 0x88
+		ycbcr.cr[i] = 0x99
+	}
+	assert_rgba64_matches_at(ycbcr, 1, 1)
+
+	mut nycbcra := new_nycbcra(r, .ratio_444)
+	for i in 0 .. nycbcra.ycbcr.y.len {
+		nycbcra.ycbcr.y[i] = 0x77
+		nycbcra.ycbcr.cb[i] = 0x88
+		nycbcra.ycbcr.cr[i] = 0x99
+		nycbcra.a[i] = 0xaa
+	}
+	assert_rgba64_matches_at(nycbcra, 1, 1)
+
+	assert_rgba64_matches_at(r, 1, 1)
 }

--- a/vlib/image/image_test.v
+++ b/vlib/image/image_test.v
@@ -1,0 +1,132 @@
+module image
+
+import image.color
+
+fn test_point_and_rectangle_geometry() {
+	assert pt(3, 4).str() == '(3,4)'
+	assert pt(3, 4).add(pt(1, -2)) == pt(4, 2)
+	assert pt(3, 4).sub(pt(1, -2)) == pt(2, 6)
+	assert pt(-1, 7).mod(rect(0, 0, 5, 5)) == pt(4, 2)
+
+	r := rect(10, 20, 0, 5)
+	assert r.min == pt(0, 5)
+	assert r.max == pt(10, 20)
+	assert r.dx() == 10
+	assert r.dy() == 15
+	assert r.inset(2) == rect(2, 7, 8, 18)
+	assert rect(0, 0, 5, 5).intersect(rect(3, 4, 8, 7)) == rect(3, 4, 5, 5)
+	assert rect(0, 0, 5, 5).union(rect(10, 10, 11, 12)) == rect(0, 0, 11, 12)
+	assert rect(0, 0, 1, 1).overlaps(rect(0, 0, 2, 2))
+	assert rect(0, 0, 1, 1).inside(rect(-1, -1, 2, 2))
+}
+
+fn test_rgba_layout_and_sub_image() {
+	mut img := new_rgba(rect(10, 20, 12, 22))
+	assert img.pix.len == 16
+	assert img.stride == 8
+	assert img.pix_offset(10, 20) == 0
+	assert img.pix_offset(11, 21) == 12
+
+	img.set_rgba(11, 20, color.RGBA{
+		r: 1
+		g: 2
+		b: 3
+		a: 4
+	})
+	assert img.rgba_at(11, 20) == color.RGBA{
+		r: 1
+		g: 2
+		b: 3
+		a: 4
+	}
+	assert img.rgba64_at(11, 20) == color.RGBA64{
+		r: 0x0101
+		g: 0x0202
+		b: 0x0303
+		a: 0x0404
+	}
+	assert !img.opaque()
+
+	sub := img.sub_image(rect(11, 20, 12, 22))
+	assert sub.rect == rect(11, 20, 12, 22)
+	assert sub.pix_offset(11, 20) == 0
+	assert sub.pix[0] == 1
+}
+
+fn test_nrgba_alpha_gray_and_uniform() {
+	mut nrgba := new_nrgba(rect(0, 0, 1, 1))
+	nrgba.set_rgba64(0, 0, color.RGBA64{
+		r: 0x4000
+		g: 0x8000
+		b: 0xc000
+		a: 0x8000
+	})
+	assert nrgba.nrgba_at(0, 0).a == 0x80
+	assert !nrgba.opaque()
+
+	mut gray := new_gray(rect(0, 0, 1, 1))
+	gray.set(0, 0, color.Color(color.RGBA{
+		r: 255
+		g: 255
+		b: 255
+		a: 255
+	}))
+	assert gray.gray_at(0, 0) == color.Gray{
+		y: 255
+	}
+	assert gray.opaque()
+
+	u := new_uniform(color.Color(color.RGBA{
+		r: 4
+		g: 5
+		b: 6
+		a: 255
+	}))
+	assert u.at(-100, 100) == color.Color(color.RGBA{
+		r: 4
+		g: 5
+		b: 6
+		a: 255
+	})
+	assert u.opaque()
+}
+
+fn test_paletted_image() {
+	pal := color.Palette{
+		colors: [
+			color.transparent,
+			color.opaque,
+		]
+	}
+	mut img := new_paletted(rect(0, 0, 2, 1), pal)
+	img.set_color_index(1, 0, 1)
+	assert img.color_index_at(1, 0) == 1
+	assert img.at(1, 0) == color.opaque
+	assert !img.opaque()
+}
+
+fn test_ycbcr_and_nycbcra_layout() {
+	mut img := new_ycbcr(rect(0, 0, 4, 2), .ratio_420)
+	assert img.y.len == 8
+	assert img.cb.len == 2
+	assert img.cr.len == 2
+	assert img.y_stride == 4
+	assert img.c_stride == 2
+	assert img.y_offset(3, 1) == 7
+	assert img.c_offset(3, 1) == 1
+
+	img.y[img.y_offset(0, 0)] = 76
+	img.cb[img.c_offset(0, 0)] = 84
+	img.cr[img.c_offset(0, 0)] = 255
+	c := img.ycbcr_at(0, 0)
+	assert c.y == 76
+	assert c.cb == 84
+	assert c.cr == 255
+	assert img.opaque()
+
+	mut with_alpha := new_nycbcra(rect(0, 0, 2, 1), .ratio_444)
+	assert !with_alpha.opaque()
+	with_alpha.a[0] = 255
+	with_alpha.a[1] = 255
+	assert with_alpha.opaque()
+}

--- a/vlib/image/ycbcr.v
+++ b/vlib/image/ycbcr.v
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 The V Authors. All rights reserved.
+// Portions derived from Go's image package.
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of the original Go source is governed by Go's BSD-style license.
+module image
+
+import image.color
+
+// YCbCrSubsampleRatio is the chroma subsample ratio used by a YCbCr image.
+pub enum YCbCrSubsampleRatio {
+	ratio_444
+	ratio_422
+	ratio_420
+	ratio_440
+	ratio_411
+	ratio_410
+}
+
+// str returns the Go-compatible name of the subsample ratio.
+pub fn (s YCbCrSubsampleRatio) str() string {
+	return match s {
+		.ratio_444 { 'YCbCrSubsampleRatio444' }
+		.ratio_422 { 'YCbCrSubsampleRatio422' }
+		.ratio_420 { 'YCbCrSubsampleRatio420' }
+		.ratio_440 { 'YCbCrSubsampleRatio440' }
+		.ratio_411 { 'YCbCrSubsampleRatio411' }
+		.ratio_410 { 'YCbCrSubsampleRatio410' }
+	}
+}
+
+// YCbCr is an in-memory image of Y'CbCr colors.
+pub struct YCbCr {
+pub mut:
+	y               []u8
+	cb              []u8
+	cr              []u8
+	y_stride        int
+	c_stride        int
+	subsample_ratio YCbCrSubsampleRatio
+	rect            Rectangle
+}
+
+// color_model returns the YCbCr color model.
+pub fn (p YCbCr) color_model() color.Model {
+	return color.ycbcr_model
+}
+
+// bounds returns the image bounds.
+pub fn (p YCbCr) bounds() Rectangle {
+	return p.rect
+}
+
+// at returns the pixel at x, y as a color.
+pub fn (p YCbCr) at(x int, y int) color.Color {
+	return color.Color(p.ycbcr_at(x, y))
+}
+
+// rgba64_at returns the pixel at x, y as RGBA64.
+pub fn (p YCbCr) rgba64_at(x int, y int) color.RGBA64 {
+	return color.to_rgba64(color.Color(p.ycbcr_at(x, y)))
+}
+
+// ycbcr_at returns the pixel at x, y as YCbCr.
+pub fn (p YCbCr) ycbcr_at(x int, y int) color.YCbCr {
+	if !pt(x, y).in_rect(p.rect) {
+		return color.YCbCr{}
+	}
+	yi := p.y_offset(x, y)
+	ci := p.c_offset(x, y)
+	return color.YCbCr{
+		y:  p.y[yi]
+		cb: p.cb[ci]
+		cr: p.cr[ci]
+	}
+}
+
+// y_offset returns the first Y index for x, y.
+pub fn (p YCbCr) y_offset(x int, y int) int {
+	return (y - p.rect.min.y) * p.y_stride + (x - p.rect.min.x)
+}
+
+// c_offset returns the first Cb or Cr index for x, y.
+pub fn (p YCbCr) c_offset(x int, y int) int {
+	match p.subsample_ratio {
+		.ratio_422 {
+			return (y - p.rect.min.y) * p.c_stride + (x / 2 - p.rect.min.x / 2)
+		}
+		.ratio_420 {
+			return (y / 2 - p.rect.min.y / 2) * p.c_stride + (x / 2 - p.rect.min.x / 2)
+		}
+		.ratio_440 {
+			return (y / 2 - p.rect.min.y / 2) * p.c_stride + (x - p.rect.min.x)
+		}
+		.ratio_411 {
+			return (y - p.rect.min.y) * p.c_stride + (x / 4 - p.rect.min.x / 4)
+		}
+		.ratio_410 {
+			return (y / 2 - p.rect.min.y / 2) * p.c_stride + (x / 4 - p.rect.min.x / 4)
+		}
+		.ratio_444 {
+			return (y - p.rect.min.y) * p.c_stride + (x - p.rect.min.x)
+		}
+	}
+}
+
+// sub_image returns the portion of p visible through r.
+pub fn (p YCbCr) sub_image(r Rectangle) YCbCr {
+	rr := r.intersect(p.rect)
+	if rr.empty() {
+		return YCbCr{
+			subsample_ratio: p.subsample_ratio
+		}
+	}
+	yi := p.y_offset(rr.min.x, rr.min.y)
+	ci := p.c_offset(rr.min.x, rr.min.y)
+	return YCbCr{
+		y:               p.y[yi..]
+		cb:              p.cb[ci..]
+		cr:              p.cr[ci..]
+		y_stride:        p.y_stride
+		c_stride:        p.c_stride
+		subsample_ratio: p.subsample_ratio
+		rect:            rr
+	}
+}
+
+// opaque reports whether every pixel is fully opaque.
+pub fn (p YCbCr) opaque() bool {
+	return true
+}
+
+// new_ycbcr returns a new YCbCr image with bounds r and subsample_ratio.
+pub fn new_ycbcr(r Rectangle, subsample_ratio YCbCrSubsampleRatio) YCbCr {
+	w, h, cw, ch := ycbcr_size(r, subsample_ratio)
+	total_length := add2_non_neg(mul3_non_neg(1, w, h), mul3_non_neg(2, cw, ch))
+	if total_length < 0 {
+		panic('image: new_ycbcr rectangle has huge or negative dimensions')
+	}
+	i0 := w * h
+	c_len := cw * ch
+	return YCbCr{
+		y:               []u8{len: i0}
+		cb:              []u8{len: c_len}
+		cr:              []u8{len: c_len}
+		y_stride:        w
+		c_stride:        cw
+		subsample_ratio: subsample_ratio
+		rect:            r
+	}
+}
+
+// NYCbCrA is an in-memory image of non-alpha-premultiplied Y'CbCr with alpha.
+pub struct NYCbCrA {
+pub mut:
+	ycbcr    YCbCr
+	a        []u8
+	a_stride int
+}
+
+// color_model returns the NYCbCrA color model.
+pub fn (p NYCbCrA) color_model() color.Model {
+	return color.nycbcra_model
+}
+
+// bounds returns the image bounds.
+pub fn (p NYCbCrA) bounds() Rectangle {
+	return p.ycbcr.rect
+}
+
+// at returns the pixel at x, y as a color.
+pub fn (p NYCbCrA) at(x int, y int) color.Color {
+	return color.Color(p.nycbcra_at(x, y))
+}
+
+// rgba64_at returns the pixel at x, y as RGBA64.
+pub fn (p NYCbCrA) rgba64_at(x int, y int) color.RGBA64 {
+	return color.to_rgba64(color.Color(p.nycbcra_at(x, y)))
+}
+
+// nycbcra_at returns the pixel at x, y as NYCbCrA.
+pub fn (p NYCbCrA) nycbcra_at(x int, y int) color.NYCbCrA {
+	if !pt(x, y).in_rect(p.ycbcr.rect) {
+		return color.NYCbCrA{}
+	}
+	yi := p.ycbcr.y_offset(x, y)
+	ci := p.ycbcr.c_offset(x, y)
+	ai := p.a_offset(x, y)
+	return color.NYCbCrA{
+		ycbcr: color.YCbCr{
+			y:  p.ycbcr.y[yi]
+			cb: p.ycbcr.cb[ci]
+			cr: p.ycbcr.cr[ci]
+		}
+		a:     p.a[ai]
+	}
+}
+
+// a_offset returns the first alpha index for x, y.
+pub fn (p NYCbCrA) a_offset(x int, y int) int {
+	return (y - p.ycbcr.rect.min.y) * p.a_stride + (x - p.ycbcr.rect.min.x)
+}
+
+// sub_image returns the portion of p visible through r.
+pub fn (p NYCbCrA) sub_image(r Rectangle) NYCbCrA {
+	rr := r.intersect(p.ycbcr.rect)
+	if rr.empty() {
+		return NYCbCrA{
+			ycbcr: YCbCr{
+				subsample_ratio: p.ycbcr.subsample_ratio
+			}
+		}
+	}
+	yi := p.ycbcr.y_offset(rr.min.x, rr.min.y)
+	ci := p.ycbcr.c_offset(rr.min.x, rr.min.y)
+	ai := p.a_offset(rr.min.x, rr.min.y)
+	return NYCbCrA{
+		ycbcr:    YCbCr{
+			y:               p.ycbcr.y[yi..]
+			cb:              p.ycbcr.cb[ci..]
+			cr:              p.ycbcr.cr[ci..]
+			y_stride:        p.ycbcr.y_stride
+			c_stride:        p.ycbcr.c_stride
+			subsample_ratio: p.ycbcr.subsample_ratio
+			rect:            rr
+		}
+		a:        p.a[ai..]
+		a_stride: p.a_stride
+	}
+}
+
+// opaque reports whether every pixel is fully opaque.
+pub fn (p NYCbCrA) opaque() bool {
+	if p.ycbcr.rect.empty() {
+		return true
+	}
+	mut i0 := 0
+	mut i1 := p.ycbcr.rect.dx()
+	for _ in p.ycbcr.rect.min.y .. p.ycbcr.rect.max.y {
+		for i := i0; i < i1; i++ {
+			if p.a[i] != 0xff {
+				return false
+			}
+		}
+		i0 += p.a_stride
+		i1 += p.a_stride
+	}
+	return true
+}
+
+// new_nycbcra returns a new NYCbCrA image with bounds r and subsample_ratio.
+pub fn new_nycbcra(r Rectangle, subsample_ratio YCbCrSubsampleRatio) NYCbCrA {
+	w, h, cw, ch := ycbcr_size(r, subsample_ratio)
+	total_length := add2_non_neg(mul3_non_neg(2, w, h), mul3_non_neg(2, cw, ch))
+	if total_length < 0 {
+		panic('image: new_nycbcra rectangle has huge or negative dimensions')
+	}
+	i0 := w * h
+	c_len := cw * ch
+	return NYCbCrA{
+		ycbcr:    YCbCr{
+			y:               []u8{len: i0}
+			cb:              []u8{len: c_len}
+			cr:              []u8{len: c_len}
+			y_stride:        w
+			c_stride:        cw
+			subsample_ratio: subsample_ratio
+			rect:            r
+		}
+		a:        []u8{len: i0}
+		a_stride: w
+	}
+}
+
+fn ycbcr_size(r Rectangle, subsample_ratio YCbCrSubsampleRatio) (int, int, int, int) {
+	w := r.dx()
+	h := r.dy()
+	mut cw := 0
+	mut ch := 0
+	match subsample_ratio {
+		.ratio_422 {
+			cw = (r.max.x + 1) / 2 - r.min.x / 2
+			ch = h
+		}
+		.ratio_420 {
+			cw = (r.max.x + 1) / 2 - r.min.x / 2
+			ch = (r.max.y + 1) / 2 - r.min.y / 2
+		}
+		.ratio_440 {
+			cw = w
+			ch = (r.max.y + 1) / 2 - r.min.y / 2
+		}
+		.ratio_411 {
+			cw = (r.max.x + 3) / 4 - r.min.x / 4
+			ch = h
+		}
+		.ratio_410 {
+			cw = (r.max.x + 3) / 4 - r.min.x / 4
+			ch = (r.max.y + 1) / 2 - r.min.y / 2
+		}
+		.ratio_444 {
+			cw = w
+			ch = h
+		}
+	}
+
+	return w, h, cw, ch
+}


### PR DESCRIPTION
## Summary
- add a new `image` vlib module with Go-style `Point`, `Rectangle`, uniform images, packed pixel buffers, paletted images, and Y'CbCr buffers
- add `image.color` with standard color structs, model conversion, palette lookup, Y'CbCr conversion, and CMYK conversion
- port Go's `image` format registration/sniff/decode hooks to V `io.Reader` via `register_format`, `decode`, and `decode_config`
- translate the core Go image/color tests for geometry invariants, color conversion arithmetic, buffer layout, sub-images, RGBA64 equivalence, and format registration
- document current scope and add Go BSD attribution for derived code

## Scope
This ports the core Go `image`/`image.color` behavior into V-style APIs. Format-specific codec packages such as PNG, JPEG, and GIF are intentionally left out for follow-up PRs, but the registration hooks needed by such packages are included.

## Tests
- `./vnew -silent test vlib/image/`
- `./vnew check-md vlib/image/README.md`