### PR TITLE
v3: fix 50 more tracked tests

### DIFF
--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -145,13 +145,13 @@ pub mut:
 	typ            string
 	generic_params []string
 	kind_id        int
+	is_mut         bool
 pub:
 	pos            token.Pos
 	children_start i32
 	children_count i16
 	kind           NodeKind
 	op             Op
-	is_mut         bool
 }
 
 // FlatAst represents flat ast data used by flat.
@@ -163,6 +163,18 @@ pub mut:
 	user_code_start int
 	disabled_fns    map[string]bool
 	export_fn_names map[string]string
+}
+
+// set_node_is_mut updates a node's mut declaration marker in place.
+pub fn (mut a FlatAst) set_node_is_mut(id NodeId, is_mut bool) {
+	if int(id) < 0 || int(id) >= a.nodes.len {
+		return
+	}
+	// Mutate the array slot in place; copying flat.Node would duplicate managed fields.
+	unsafe {
+		mut node := &a.nodes[int(id)]
+		node.is_mut = is_mut
+	}
 }
 
 // new creates a FlatAst value for flat.

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1050,7 +1050,7 @@ fn c_include_should_remain_in_inlined_text(include_arg string) bool {
 		return true
 	}
 	if c_headerless_system_include_is_handled(clean) {
-		return false
+		return c_preserved_system_include_struct_names(clean).len > 0
 	}
 	return clean in ['<assert.h>', '<EGL/egl.h>', '<GL/gl.h>', '<GLES3/gl3.h>', '<GLES3/gl3ext.h>',
 		'<X11/Xmd.h>', '<X11/cursorfont.h>']

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1049,9 +1049,11 @@ fn c_include_should_remain_in_inlined_text(include_arg string) bool {
 	if clean[0] == `"` {
 		return true
 	}
-	return clean in ['<assert.h>', '<stdlib.h>', '<stdio.h>', '<math.h>', '<string.h>', '<limits.h>',
-		'<poll.h>', '<EGL/egl.h>', '<GL/gl.h>', '<GLES3/gl3.h>', '<GLES3/gl3ext.h>', '<X11/Xmd.h>',
-		'<X11/cursorfont.h>']
+	if c_headerless_system_include_is_handled(clean) {
+		return false
+	}
+	return clean in ['<assert.h>', '<EGL/egl.h>', '<GL/gl.h>', '<GLES3/gl3.h>', '<GLES3/gl3ext.h>',
+		'<X11/Xmd.h>', '<X11/cursorfont.h>']
 }
 
 fn c_preserved_system_include_declared_fns(include_arg string) []string {
@@ -2747,6 +2749,24 @@ fn (mut g FlatGen) gen_cast_from_mut_param_address(id flat.NodeId, ct string) bo
 	return true
 }
 
+fn (mut g FlatGen) gen_current_mut_param_address(id flat.NodeId) bool {
+	node := g.a.nodes[int(id)]
+	if node.kind != .prefix || node.op != .amp || node.children_count != 1 {
+		return false
+	}
+	child_id := g.a.child(&node, 0)
+	child := g.a.nodes[int(child_id)]
+	if child.kind != .ident || !g.current_param_is_mut(child.value) {
+		return false
+	}
+	param_type := g.current_param_type(child.value) or { return false }
+	if param_type !is types.Pointer {
+		return false
+	}
+	g.write(c_name(child.value))
+	return true
+}
+
 fn (mut g FlatGen) gen_current_mut_param_value_read(id flat.NodeId, expected types.Type) bool {
 	if int(id) < 0 || int(id) >= g.a.nodes.len {
 		return false
@@ -2780,6 +2800,12 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 		g.expected_enum = expected.name
 	}
 	node := g.a.nodes[int(id)]
+	if g.is_ierror_type_name(expected.name()) && g.expr_is_error_call(id) {
+		g.gen_ierror_from_error_call(node)
+		g.expected_expr_type = old_expected
+		g.expected_enum = old_expected_enum
+		return
+	}
 	if node.kind == .dump_expr {
 		if node.children_count > 0 {
 			g.gen_expr_with_expected_type(g.a.child(&node, 0), expected)
@@ -2789,6 +2815,19 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 		g.expected_expr_type = old_expected
 		g.expected_enum = old_expected_enum
 		return
+	}
+	if expected is types.MultiReturn && node.kind == .if_expr {
+		g.gen_if_expr_stmt(node)
+		g.expected_expr_type = old_expected
+		g.expected_enum = old_expected_enum
+		return
+	}
+	if expected is types.MultiReturn && node.kind == .block {
+		if g.gen_multi_return_block_expr(&node, expected) {
+			g.expected_expr_type = old_expected
+			g.expected_enum = old_expected_enum
+			return
+		}
 	}
 	mut actual := g.usable_expr_type(id)
 	if node.kind == .ident {
@@ -4634,6 +4673,8 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			}
 			if node.op == .amp && g.gen_amp_c_string_literal(child_id, child) {
 				return
+			} else if node.op == .amp && g.gen_current_mut_param_address(id) {
+				return
 			} else if node.op == .amp && node.typ.len > 0
 				&& g.gen_sum_pointer_value_expr(id, g.tc.parse_type(node.typ)) {
 				return
@@ -4860,12 +4901,25 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				g.gen_expr(cast_arg_id)
 				g.write(')->${c_name(node.value)}')
 			} else if base.kind == .cast_expr && base.children_count > 0
-				&& (base.value.starts_with('C.') || base.value.contains('__')) {
+				&& (base.value.starts_with('C.') || base.value.starts_with('&C.')
+				|| (base.value.contains('__') && !base.value.starts_with('&'))) {
 				cast_child_id := g.a.child(&base, 0)
-				cast_name := if base.value.starts_with('C.') { base.value[2..] } else { base.value }
-				g.write('((${c_name(cast_name)}*)')
-				g.gen_expr(cast_child_id)
-				g.write(')->${c_name(node.value)}')
+				cast_type := g.tc.parse_type(base.value)
+				if cast_type is types.Pointer {
+					ct := g.cast_c_type(cast_type)
+					g.write('((${ct})')
+					g.gen_expr(cast_child_id)
+					g.write(')->${c_name(node.value)}')
+				} else {
+					cast_name := if base.value.starts_with('C.') {
+						base.value[2..]
+					} else {
+						base.value
+					}
+					g.write('((${c_name(cast_name)}*)')
+					g.gen_expr(cast_child_id)
+					g.write(')->${c_name(node.value)}')
+				}
 			} else if base.kind == .cast_expr && base.children_count > 0 {
 				needs_paren := base.kind !in [.ident, .selector]
 				if needs_paren {
@@ -5280,6 +5334,25 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					} else {
 						g.gen_expr(expr_id)
 						g.write('.${field}')
+					}
+				}
+			} else if clean is types.Interface || g.is_ierror_type_name(types.Type(clean).name()) {
+				target := g.tc.parse_type(node.value)
+				if target is types.Pointer {
+					g.write('(${g.tc.c_type(target)})')
+					g.gen_expr(expr_id)
+					if expr_type.is_pointer() {
+						g.write('->_object')
+					} else {
+						g.write('._object')
+					}
+				} else {
+					g.write('(*(${g.tc.c_type(target)}*)')
+					g.gen_expr(expr_id)
+					if expr_type.is_pointer() {
+						g.write('->_object)')
+					} else {
+						g.write('._object)')
 					}
 				}
 			} else {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -5313,7 +5313,12 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 		}
 		.as_expr {
 			expr_id := g.a.child(&node, 0)
-			expr_type := g.tc.resolve_type(expr_id)
+			expr_type0 := g.usable_expr_type(expr_id)
+			expr_type := if expr_type0 is types.Unknown || expr_type0 is types.Void {
+				g.tc.resolve_type(expr_id)
+			} else {
+				expr_type0
+			}
 			clean := types.unwrap_pointer(expr_type)
 			if clean is types.SumType {
 				qv := g.resolve_variant(clean.name, node.value)

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -2329,6 +2329,21 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		}
 		return
 	}
+	resolved_target_name := g.tc.resolved_call_name(id) or { '' }
+	if resolved_target_name in ['free', 'builtin.free'] && node.children_count == 2 {
+		arg_id := g.a.child(&node, 1)
+		arg_type := g.usable_expr_type(arg_id)
+		clean_type := types.unwrap_pointer(arg_type)
+		if _ := array_like_type(clean_type) {
+			g.write('array__free(')
+			if arg_type !is types.Pointer {
+				g.write('&')
+			}
+			g.gen_expr(arg_id)
+			g.write(')')
+			return
+		}
+	}
 	if g.is_json_decode_call(id, target_name) {
 		ret_type := g.json_decode_result_type_for_call(node) or { g.call_default_return_type(id) }
 		g.gen_default_value_for_type(ret_type)
@@ -2944,6 +2959,11 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					} else if call_key in g.tc.fn_ret_types || call_key in g.tc.fn_param_types {
 						emitted_callee_name = g.direct_call_name_for_call(id, call_key)
 						g.write(emitted_callee_name)
+					} else if specialized := g.specialized_generic_plain_fn_name_for_call(id, node,
+						fn_ident.value)
+					{
+						emitted_callee_name = g.direct_call_name_for_call(id, specialized)
+						g.write(emitted_callee_name)
 					} else if specialized := g.specialized_generic_method_name_for_call_with_arg_count(id,
 						fn_ident.value, -1)
 					{
@@ -2973,6 +2993,11 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 				g.call_key(id, fn_name)
 			}
 			mut param_types := g.param_types_for(actual_fn, fn_name)
+			if !is_method {
+				if fn_value_params := g.fn_value_call_param_types(g.a.child(&node, 0)) {
+					param_types = fn_value_params.clone()
+				}
+			}
 			callee_uses_specialized_generic_abi :=
 				g.call_callee_uses_specialized_generic_abi(g.a.child(&node, 0))
 			concrete_optional_args := g.call_uses_concrete_optional_params(actual_fn)
@@ -4933,6 +4958,316 @@ fn fn_type_from(t types.Type) ?types.FnType {
 	return none
 }
 
+fn (mut g FlatGen) specialized_generic_plain_fn_name_for_call(id flat.NodeId, node flat.Node, name string) ?string {
+	if name.len == 0 || name.contains('[') || node.children_count == 0 {
+		return none
+	}
+	base := g.generic_plain_fn_base_for_call(id, name) or { return none }
+	generic_params := g.tc.fn_generic_params[base] or { return none }
+	if generic_params.len == 0 {
+		return none
+	}
+	param_texts := g.tc.fn_param_type_texts[base] or { return none }
+	mut inferred := map[string]string{}
+	for i, param_text in param_texts {
+		arg_idx := i + 1
+		if arg_idx >= int(node.children_count) {
+			break
+		}
+		arg_type := g.generic_call_arg_type_text(g.a.child(&node, arg_idx))
+		if arg_type.len > 0 {
+			infer_codegen_generic_type_args(param_text, arg_type, mut inferred)
+		}
+	}
+	if ret_text := g.tc.fn_ret_type_texts[base] {
+		ret_type := g.call_default_return_type(id).name()
+		if ret_type.len > 0 {
+			infer_codegen_generic_type_args(ret_text, ret_type, mut inferred)
+		}
+	}
+	mut args := []string{cap: generic_params.len}
+	for param in generic_params {
+		arg := inferred[param] or { return none }
+		if codegen_generic_arg_is_unresolved(arg) {
+			return none
+		}
+		args << arg
+	}
+	if args.len == 0 {
+		return none
+	}
+	for candidate in g.specialized_generic_plain_fn_candidates(base, args) {
+		if candidate in g.tc.fn_param_types || candidate in g.tc.fn_ret_types {
+			return candidate
+		}
+	}
+	return none
+}
+
+fn (g &FlatGen) generic_plain_fn_base_for_call(id flat.NodeId, name string) ?string {
+	mut candidates := []string{}
+	if resolved := g.tc.resolved_call_name(id) {
+		candidates << resolved
+	}
+	if !name.contains('.') && g.tc.cur_module.len > 0 && g.tc.cur_module !in ['', 'main', 'builtin'] {
+		candidates << '${g.tc.cur_module}.${name}'
+	}
+	candidates << name
+	if name.contains('__') {
+		candidates << name.replace('__', '.')
+	}
+	normalized := g.normalize_call_key(name)
+	candidates << normalized
+	short := name.all_after_last('.')
+	mut found := ''
+	for candidate in candidates {
+		if base := g.known_generic_plain_fn_base(candidate) {
+			return base
+		}
+	}
+	for key, _ in g.tc.fn_generic_params {
+		if key == short || key.ends_with('.${short}') || c_name(key) == name {
+			if key.starts_with('${g.tc.cur_module}.') {
+				return key
+			}
+			if found.len > 0 && found != key {
+				return none
+			}
+			found = key
+		}
+	}
+	if found.len > 0 {
+		return found
+	}
+	return none
+}
+
+fn (g &FlatGen) known_generic_plain_fn_base(name string) ?string {
+	if name.len == 0 {
+		return none
+	}
+	if name in g.tc.fn_generic_params {
+		if !name.contains('.') {
+			if module_name := g.tc.fn_type_modules[name] {
+				if module_name.len > 0 && module_name !in ['main', 'builtin'] {
+					qualified := '${module_name}.${name}'
+					if qualified in g.tc.fn_generic_params {
+						return qualified
+					}
+				}
+			}
+		}
+		return name
+	}
+	if name.starts_with('main.') {
+		short := name.all_after_last('.')
+		if short in g.tc.fn_generic_params {
+			return short
+		}
+	}
+	if name.contains('__') {
+		dotted := name.replace('__', '.')
+		if dotted in g.tc.fn_generic_params {
+			return dotted
+		}
+	}
+	return none
+}
+
+fn (g &FlatGen) generic_call_arg_type_text(id flat.NodeId) string {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return ''
+	}
+	node := g.a.nodes[int(id)]
+	if node.typ.len > 0 && node.typ !in ['unknown', 'generic'] {
+		return node.typ
+	}
+	typ := g.usable_expr_type(id)
+	name := typ.name()
+	if name == 'void' || name == 'unknown' || name == 'generic' {
+		return ''
+	}
+	return name
+}
+
+fn (mut g FlatGen) specialized_generic_plain_fn_candidates(base string, args []string) []string {
+	mut suffixes := codegen_generic_type_suffix_variants(args)
+	mut bases := []string{}
+	bases << base
+	if base.contains('.') {
+		bases << base.all_after_last('.')
+	} else if module_name := g.tc.fn_type_modules[base] {
+		if module_name.len > 0 && module_name !in ['main', 'builtin'] {
+			bases.insert(0, '${module_name}.${base}')
+		}
+	} else if g.tc.cur_module.len > 0 && g.tc.cur_module !in ['', 'main', 'builtin'] {
+		bases << '${g.tc.cur_module}.${base}'
+	}
+	mut result := []string{}
+	for suffix in suffixes {
+		for fn_base in bases {
+			if fn_base.len == 0 || suffix.len == 0 {
+				continue
+			}
+			spec := '${fn_base}_T_${suffix}'
+			codegen_push_unique(mut result, spec)
+			codegen_push_unique(mut result, c_name(spec))
+		}
+	}
+	return result
+}
+
+fn codegen_generic_type_suffix_variants(args []string) []string {
+	mut suffixes := []string{}
+	mut short_parts := []string{cap: args.len}
+	mut full_parts := []string{cap: args.len}
+	for arg in args {
+		clean := arg.trim_space()
+		short_parts << c_name(generic_receiver_type_arg_short(clean).replace('[]', 'Array_').replace('&',
+			'ptr_'))
+		full_parts << c_name(clean.replace('[]', 'Array_').replace('&', 'ptr_'))
+	}
+	codegen_push_unique(mut suffixes, short_parts.join('_'))
+	codegen_push_unique(mut suffixes, full_parts.join('_'))
+	return suffixes
+}
+
+fn codegen_push_unique(mut values []string, value string) {
+	if value.len > 0 && value !in values {
+		values << value
+	}
+}
+
+fn infer_codegen_generic_type_args(param_type string, arg_type string, mut inferred map[string]string) {
+	param := param_type.trim_space()
+	arg := arg_type.trim_space()
+	if param.len == 0 || arg.len == 0 || arg in ['unknown', 'generic'] {
+		return
+	}
+	if codegen_generic_placeholder_name(param) {
+		if param !in inferred {
+			inferred[param] = arg
+		}
+		return
+	}
+	if param.starts_with('&') {
+		infer_codegen_generic_type_args(param[1..], arg.trim_left('&'), mut inferred)
+		return
+	}
+	if param.starts_with('mut ') {
+		infer_codegen_generic_type_args(param[4..], arg.trim_left('&'), mut inferred)
+		return
+	}
+	if param.starts_with('...') {
+		infer_codegen_generic_type_args(param[3..], arg.trim_left('[]'), mut inferred)
+		return
+	}
+	if param.starts_with('[]') && arg.starts_with('[]') {
+		infer_codegen_generic_type_args(param[2..], arg[2..], mut inferred)
+		return
+	}
+	if (param.starts_with('?') && arg.starts_with('?'))
+		|| (param.starts_with('!') && arg.starts_with('!')) {
+		infer_codegen_generic_type_args(param[1..], arg[1..], mut inferred)
+		return
+	}
+	if param.starts_with('map[') && arg.starts_with('map[') {
+		p_end := shared_generic_matching_bracket(param, 3)
+		a_end := shared_generic_matching_bracket(arg, 3)
+		if p_end < param.len && a_end < arg.len {
+			infer_codegen_generic_type_args(param[4..p_end], arg[4..a_end], mut inferred)
+			infer_codegen_generic_type_args(param[p_end + 1..], arg[a_end + 1..], mut inferred)
+		}
+		return
+	}
+	p_base, p_args, p_ok := shared_generic_app_parts(param)
+	if p_ok {
+		a_base, a_args, a_ok := shared_generic_app_parts(arg)
+		if a_ok && p_base.all_after_last('.') == a_base.all_after_last('.') {
+			for i, p_arg in p_args {
+				if i < a_args.len {
+					infer_codegen_generic_type_args(p_arg, a_args[i], mut inferred)
+				}
+			}
+		}
+	}
+}
+
+fn codegen_generic_placeholder_name(name string) bool {
+	clean := name.trim_space()
+	if clean.len == 0 || clean.contains('.') || clean.contains('[') || clean.contains(']')
+		|| clean.contains(' ') {
+		return false
+	}
+	if clean.len == 1 {
+		return clean[0] >= `A` && clean[0] <= `Z`
+	}
+	return clean[0] >= `A` && clean[0] <= `Z` && clean[1] >= `0` && clean[1] <= `9`
+}
+
+fn codegen_generic_arg_is_unresolved(arg string) bool {
+	clean := arg.trim_space()
+	if clean.len == 0 {
+		return true
+	}
+	if codegen_generic_placeholder_name(clean) {
+		return true
+	}
+	if clean.starts_with('&') || clean.starts_with('?') || clean.starts_with('!') {
+		return codegen_generic_arg_is_unresolved(clean[1..])
+	}
+	if clean.starts_with('mut ') {
+		return codegen_generic_arg_is_unresolved(clean[4..])
+	}
+	if clean.starts_with('...') {
+		return codegen_generic_arg_is_unresolved(clean[3..])
+	}
+	if clean.starts_with('[]') {
+		return codegen_generic_arg_is_unresolved(clean[2..])
+	}
+	if clean.starts_with('map[') {
+		bracket_end := shared_generic_matching_bracket(clean, 3)
+		if bracket_end < clean.len {
+			return codegen_generic_arg_is_unresolved(clean[4..bracket_end])
+				|| codegen_generic_arg_is_unresolved(clean[bracket_end + 1..])
+		}
+	}
+	_, nested_args, ok := shared_generic_app_parts(clean)
+	if ok {
+		for nested in nested_args {
+			if codegen_generic_arg_is_unresolved(nested) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+fn (g &FlatGen) fn_value_call_param_types(callee_id flat.NodeId) ?[]types.Type {
+	if int(callee_id) < 0 {
+		return none
+	}
+	node := g.a.nodes[int(callee_id)]
+	if node.kind == .ident {
+		if typ := g.cur_param_types[node.value] {
+			if ft := fn_type_from(typ) {
+				return ft.params.clone()
+			}
+		}
+	}
+	if node.typ.len > 0 {
+		if ft := fn_type_from(g.tc.parse_type(node.typ)) {
+			return ft.params.clone()
+		}
+	}
+	if node.kind != .ident {
+		if ft := fn_type_from(g.tc.resolve_type(callee_id)) {
+			return ft.params.clone()
+		}
+	}
+	return none
+}
+
 fn (g &FlatGen) selector_call_can_emit_direct(resolved string, node flat.Node) bool {
 	if resolved.len == 0 || node.children_count == 0 {
 		return false
@@ -5357,7 +5692,7 @@ fn (g &FlatGen) is_flag_enum_method(fn_node &flat.Node) bool {
 		return false
 	}
 	method := fn_node.value
-	if method !in ['has', 'all', 'set', 'clear'] {
+	if method !in ['has', 'all', 'set', 'clear', 'is_empty'] {
 		return false
 	}
 	base_type := g.tc.resolve_type(g.a.child(fn_node, 0))
@@ -5415,6 +5750,11 @@ fn (mut g FlatGen) gen_flag_enum_call(node flat.Node) {
 				g.gen_flag_enum_arg(g.a.child(&node, 1), base_type)
 			}
 			g.write(')')
+		}
+		'is_empty' {
+			g.write('(')
+			g.gen_expr(base_id)
+			g.write(' == 0)')
 		}
 		else {}
 	}
@@ -6260,11 +6600,14 @@ fn (g &FlatGen) type_name_known_in_current_module(name string) bool {
 }
 
 fn (g &FlatGen) type_name_known(name string) bool {
+	if types.is_builtin_type_name(name) || name in ['C', 'JS'] {
+		return true
+	}
 	qname := g.tc.qualify_name(name)
 	return name in g.struct_decl_infos || qname in g.struct_decl_infos || name in g.tc.type_aliases
-		|| qname in g.tc.type_aliases || name in g.tc.enum_names || qname in g.tc.enum_names
-		|| name in g.tc.sum_types || qname in g.tc.sum_types || name in g.tc.interface_names
-		|| qname in g.tc.interface_names
+		|| qname in g.tc.type_aliases || name in g.tc.structs || qname in g.tc.structs
+		|| name in g.tc.enum_names || qname in g.tc.enum_names || name in g.tc.sum_types
+		|| qname in g.tc.sum_types || name in g.tc.interface_names || qname in g.tc.interface_names
 }
 
 fn (mut g FlatGen) fn_returns_veb_result(node flat.Node) bool {
@@ -6328,7 +6671,7 @@ fn (mut g FlatGen) fn_node_return_type(node flat.Node, module_name string) types
 }
 
 fn (mut g FlatGen) fn_node_return_type_from_signatures(node flat.Node, module_name string) ?types.Type {
-	dotted_name := qualify_name_in_module(module_name, node.value)
+	dotted_name := dotted_fn_name_in_module(module_name, node.value)
 	cname := g.fn_c_name_in_module(module_name, node.value)
 	if module_name.len > 0 && module_name != 'main' && module_name != 'builtin' {
 		if rt := g.tc.fn_ret_types[dotted_name] {
@@ -6404,7 +6747,7 @@ fn (mut g FlatGen) fn_node_param_types(node flat.Node, module_name string) []typ
 }
 
 fn (mut g FlatGen) fn_node_param_types_from_signatures(node flat.Node, module_name string, explicit_params int) ?[]types.Type {
-	dotted_name := qualify_name_in_module(module_name, node.value)
+	dotted_name := dotted_fn_name_in_module(module_name, node.value)
 	cname := g.fn_c_name_in_module(module_name, node.value)
 	if module_name.len > 0 && module_name != 'main' && module_name != 'builtin' {
 		if params := g.matching_fn_param_types(dotted_name, explicit_params) {
@@ -6481,7 +6824,7 @@ fn (g &FlatGen) generic_receiver_method_call_info(name string) ?types.CallInfo {
 }
 
 fn (mut g FlatGen) fn_node_signature_names(node flat.Node, module_name string) []string {
-	dotted_name := qualify_name_in_module(module_name, node.value)
+	dotted_name := dotted_fn_name_in_module(module_name, node.value)
 	cname := g.fn_c_name_in_module(module_name, node.value)
 	mut names := []string{}
 	if module_name.len > 0 && module_name != 'main' && module_name != 'builtin' {
@@ -6594,6 +6937,9 @@ fn (mut g FlatGen) concrete_optional_type_name(t types.Type) string {
 		return g.tc.c_type(t)
 	}
 	if base_type is types.Void {
+		return 'Optional'
+	}
+	if g.type_contains_generic_placeholder(base_type) {
 		return 'Optional'
 	}
 	mut inner_ct := g.tc.c_type(base_type)
@@ -6863,11 +7209,21 @@ fn (mut g FlatGen) emit_multi_return_typedef(ret types.Type, mut emitted map[str
 		}
 		emitted[name] = true
 		if forward_only {
+			for typ in ret.types {
+				ct := g.tc.c_type(typ)
+				if ct.starts_with('fn_ptr:') {
+					g.resolve_fn_ptr_type(ct)
+				}
+			}
 			g.writeln('typedef struct ${name} ${name};')
 		} else {
 			g.writeln('struct ${name} {')
 			for i, typ in ret.types {
-				g.writeln('\t${g.tc.c_type(typ)} arg${i};')
+				mut ct := g.tc.c_type(typ)
+				if ct.starts_with('fn_ptr:') {
+					ct = g.resolve_fn_ptr_type(ct)
+				}
+				g.writeln('\t${ct} arg${i};')
 			}
 			g.writeln('};')
 		}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -654,10 +654,62 @@ fn (g &FlatGen) concrete_generic_method_name_from_call_receiver(node flat.Node, 
 	}
 	receiver_type := types.unwrap_pointer(g.usable_expr_type(g.a.child(fn_node, 0)))
 	receiver_name := receiver_type.name()
-	if !receiver_name.contains('[') || !receiver_name.contains(']') {
+	if receiver_name.contains('[') && receiver_name.contains(']') {
+		if resolved := g.resolve_concrete_generic_method_name(receiver_name, method) {
+			return resolved
+		}
+	}
+	if receiver_name.contains('_') {
+		return g.method_name_by_receiver_param_type(receiver_type, method)
+	}
+	return none
+}
+
+fn (g &FlatGen) method_name_by_receiver_param_type(receiver_type types.Type, method string) ?string {
+	clean_receiver := concrete_receiver_type(receiver_type)
+	receiver_ct := g.tc.c_type(clean_receiver)
+	mut candidates := []string{}
+	for name, params in g.fn_decl_param_types {
+		if !name.contains('.') || name.contains('__') || name.all_after_last('.') != method
+			|| params.len == 0 {
+			continue
+		}
+		param_receiver := concrete_receiver_type(params[0])
+		if g.tc.c_type(param_receiver) != receiver_ct
+			&& !g.type_names_match(param_receiver, clean_receiver) {
+			continue
+		}
+		candidates << name
+	}
+	if candidates.len == 0 {
 		return none
 	}
-	return g.resolve_concrete_generic_method_name(receiver_name, method)
+	candidates.sort()
+	mut best := candidates[0]
+	mut best_score := g.receiver_param_method_candidate_score(best)
+	for candidate in candidates[1..] {
+		score := g.receiver_param_method_candidate_score(candidate)
+		if score > best_score {
+			best = candidate
+			best_score = score
+		}
+	}
+	return best
+}
+
+fn (g &FlatGen) receiver_param_method_candidate_score(name string) int {
+	mut score := 0
+	if g.tc.cur_module.len > 0 && g.tc.cur_module != 'main' && g.tc.cur_module != 'builtin'
+		&& name.starts_with('${g.tc.cur_module}.') {
+		score += 100
+	}
+	if name.contains('_') {
+		score += 10
+	}
+	if !name.contains('[') {
+		score += 5
+	}
+	return score
 }
 
 fn (g &FlatGen) specialized_generic_method_name_for_call_with_arg_count(id flat.NodeId, method_name string, arg_count int) ?string {
@@ -3039,6 +3091,11 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 				} else {
 					mut is_ptr_base := base_type is types.Pointer
 						|| g.receiver_ident_storage_is_pointer(base_id)
+					base_node := g.a.nodes[int(base_id)]
+					if receiver_wants_ptr && base_node.kind == .ident
+						&& !g.receiver_ident_storage_is_pointer(base_id) {
+						is_ptr_base = false
+					}
 					// A `string.*` method always takes its receiver by value. If the
 					// receiver mis-resolves to a char pointer (e.g. a `const x =
 					// os.getenv(..)` whose type was inferred as `&char`), the actual
@@ -3199,7 +3256,14 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					&& param_types[arg_idx] is types.Pointer && !(arg_node.kind == .prefix
 					&& arg_node.op == .amp) && !g.arg_is_null_pointer_literal(arg_id, arg_node) {
 					arg_type := g.tc.resolve_type(arg_id)
-					if arg_type !is types.Pointer
+					arg_is_pointer_param := arg_node.kind == .ident && (g.current_param_type(arg_node.value) or {
+						types.Type(types.void_)
+					}) is types.Pointer
+					value_local_mut_receiver := arg_idx == 0 && (g.method_receiver_is_mut(fn_name)
+						|| g.method_receiver_is_mut(g.direct_call_name(fn_name)))
+						&& arg_node.kind == .ident && !g.local_storage_is_pointer(arg_node.value)
+						&& !arg_is_pointer_param
+					if (arg_type !is types.Pointer || value_local_mut_receiver)
 						&& !g.c_string_pointer_arg(arg_node, param_types[arg_idx]) {
 						needs_addr = !(arg_node.kind == .ident
 							&& g.local_storage_is_pointer(arg_node.value))
@@ -3904,7 +3968,9 @@ fn (g &FlatGen) embedded_receiver_path_for_expected_name(base_name string, expec
 		if embedded_type_name == expected_name {
 			return [field]
 		}
-		if nested := g.embedded_receiver_path_for_expected_name(embedded_type_name, expected_name, mut seen) {
+		if nested := g.embedded_receiver_path_for_expected_name(embedded_type_name, expected_name, mut
+			seen)
+		{
 			mut path := [field]
 			path << nested
 			return path
@@ -5577,8 +5643,15 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			&& !(arg_node.kind == .prefix && arg_node.op == .amp)
 			&& !g.arg_is_null_pointer_literal(arg_id, arg_node) {
 			arg_type := g.tc.resolve_type(arg_id)
-			if arg_type !is types.Pointer && !g.c_string_pointer_arg(arg_node, param_types[arg_idx]) {
-				needs_addr = true
+			arg_is_pointer_param := arg_node.kind == .ident && (g.current_param_type(arg_node.value) or {
+				types.Type(types.void_)
+			}) is types.Pointer
+			value_local_mut_receiver := arg_idx == 0 && (g.method_receiver_is_mut(fn_name)
+				|| g.method_receiver_is_mut(g.direct_call_name(fn_name))) && arg_node.kind == .ident
+				&& !g.local_storage_is_pointer(arg_node.value) && !arg_is_pointer_param
+			if (arg_type !is types.Pointer || value_local_mut_receiver)
+				&& !g.c_string_pointer_arg(arg_node, param_types[arg_idx]) {
+				needs_addr = !(arg_node.kind == .ident && g.local_storage_is_pointer(arg_node.value))
 			}
 		}
 		is_rvalue := arg_node.kind == .call

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -3092,7 +3092,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					mut is_ptr_base := base_type is types.Pointer
 						|| g.receiver_ident_storage_is_pointer(base_id)
 					base_node := g.a.nodes[int(base_id)]
-					if receiver_wants_ptr && base_node.kind == .ident
+					if receiver_wants_ptr && base_node.kind == .ident && base_type !is types.Pointer
 						&& !g.receiver_ident_storage_is_pointer(base_id) {
 						is_ptr_base = false
 					}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -3852,11 +3852,11 @@ fn (g &FlatGen) embedded_method_name_for_struct(type_name string, method string)
 }
 
 fn (mut g FlatGen) gen_embedded_method_receiver(base_id flat.NodeId, base_type types.Type, expected_type types.Type, wants_ptr bool) bool {
-	field := g.embedded_receiver_field_for_expected(base_type, expected_type) or { return false }
-	field_is_ptr := field.typ is types.Pointer
-	if wants_ptr && !field_is_ptr {
+	path := g.embedded_receiver_path_for_expected(base_type, expected_type) or { return false }
+	target_is_ptr := path[path.len - 1].typ is types.Pointer
+	if wants_ptr && !target_is_ptr {
 		g.write('&')
-	} else if !wants_ptr && field_is_ptr {
+	} else if !wants_ptr && target_is_ptr {
 		g.write('*')
 	}
 	needs_paren := g.a.nodes[int(base_id)].kind !in [.ident, .selector]
@@ -3867,21 +3867,47 @@ fn (mut g FlatGen) gen_embedded_method_receiver(base_id flat.NodeId, base_type t
 	if needs_paren {
 		g.write(')')
 	}
-	first_op := if base_type is types.Pointer { '->' } else { '.' }
-	g.write('${first_op}${c_name(field.name)}')
+	mut access_is_ptr := base_type is types.Pointer
+	for field in path {
+		op := if access_is_ptr { '->' } else { '.' }
+		g.write('${op}${c_field_name(field.name)}')
+		access_is_ptr = field.typ is types.Pointer
+	}
 	return true
 }
 
 fn (g &FlatGen) embedded_receiver_field_for_expected(base_type types.Type, expected_type types.Type) ?types.StructField {
+	path := g.embedded_receiver_path_for_expected(base_type, expected_type) or { return none }
+	if path.len == 0 {
+		return none
+	}
+	return path[0]
+}
+
+fn (g &FlatGen) embedded_receiver_path_for_expected(base_type types.Type, expected_type types.Type) ?[]types.StructField {
 	base_name := g.type_lookup_name(base_type)
 	expected_name := g.type_lookup_name(expected_type)
 	if base_name.len == 0 || expected_name.len == 0 {
 		return none
 	}
+	mut seen := map[string]bool{}
+	return g.embedded_receiver_path_for_expected_name(base_name, expected_name, mut seen)
+}
+
+fn (g &FlatGen) embedded_receiver_path_for_expected_name(base_name string, expected_name string, mut seen map[string]bool) ?[]types.StructField {
+	if seen[base_name] {
+		return none
+	}
+	seen[base_name] = true
 	for field in g.struct_embedded_fields(base_name) {
 		embedded_type_name := g.embedded_field_type_name(field)
 		if embedded_type_name == expected_name {
-			return field
+			return [field]
+		}
+		if nested := g.embedded_receiver_path_for_expected_name(embedded_type_name, expected_name, mut seen) {
+			mut path := [field]
+			path << nested
+			return path
 		}
 	}
 	return none

--- a/vlib/v3/gen/c/if.v
+++ b/vlib/v3/gen/c/if.v
@@ -288,7 +288,8 @@ fn (mut g FlatGen) gen_if_else(node flat.Node) {
 // gen_if_expr emits if expr output for c.
 fn (mut g FlatGen) gen_if_expr(node flat.Node) {
 	then_block := g.a.child_node(&node, 1)
-	mut needs_stmt_expr := then_block.children_count > 1
+	mut needs_stmt_expr := g.expected_expr_type is types.MultiReturn
+		|| then_block.children_count > 1
 	if !needs_stmt_expr && node.children_count > 2 {
 		else_node := g.a.child_node(&node, 2)
 		if else_node.kind == .block && else_node.children_count > 1 {
@@ -387,10 +388,15 @@ fn (g &FlatGen) multi_return_tail_parts(block &flat.Node, count int) ?MultiRetur
 	for i := int(block.children_count) - 1; i >= 0; i-- {
 		child_id := g.a.child(block, i)
 		child := g.a.nodes[int(child_id)]
-		if child.kind != .expr_stmt || child.children_count != 1 {
+		if child.kind != .expr_stmt || child.children_count == 0 {
 			break
 		}
-		values.prepend(g.a.child(&child, 0))
+		for j := int(child.children_count) - 1; j >= 0; j-- {
+			values.prepend(g.a.child(&child, j))
+			if values.len == count {
+				break
+			}
+		}
 		if values.len == count {
 			return MultiReturnTailParts{
 				prefix_count: i
@@ -412,9 +418,40 @@ fn (mut g FlatGen) gen_if_expr_multi_return_block(block &flat.Node, ret_type typ
 			g.write(', ')
 		}
 		g.write('.arg${i} = ')
-		g.gen_expr(value_id)
+		g.gen_expr_with_expected_type(value_id, ret_type.types[i])
 	}
 	g.writeln('};')
+	return true
+}
+
+fn (mut g FlatGen) gen_multi_return_block_expr(block &flat.Node, ret_type types.MultiReturn) bool {
+	parts := g.multi_return_tail_parts(block, ret_type.types.len) or { return false }
+	ct := g.tc.c_type(types.Type(ret_type))
+	if parts.prefix_count == 0 {
+		g.write('(${ct}){')
+		for i, value_id in parts.values {
+			if i > 0 {
+				g.write(', ')
+			}
+			g.write('.arg${i} = ')
+			g.gen_expr_with_expected_type(value_id, ret_type.types[i])
+		}
+		g.write('}')
+		return true
+	}
+	g.write('({')
+	for i in 0 .. parts.prefix_count {
+		g.gen_node(g.a.child(block, i))
+	}
+	g.write('${ct} _multi_ret = (${ct}){')
+	for i, value_id in parts.values {
+		if i > 0 {
+			g.write(', ')
+		}
+		g.write('.arg${i} = ')
+		g.gen_expr_with_expected_type(value_id, ret_type.types[i])
+	}
+	g.write('}; _multi_ret;})')
 	return true
 }
 

--- a/vlib/v3/gen/c/if.v
+++ b/vlib/v3/gen/c/if.v
@@ -412,7 +412,13 @@ fn (mut g FlatGen) gen_if_expr_multi_return_block(block &flat.Node, ret_type typ
 	for i in 0 .. parts.prefix_count {
 		g.gen_node(g.a.child(block, i))
 	}
-	g.write('_ifexpr = (${g.tc.c_type(types.Type(ret_type))}){')
+	ct := g.tc.c_type(types.Type(ret_type))
+	if g.multi_return_types_have_fixed_array(ret_type.types) {
+		tmp := g.gen_multi_return_tail_temp(ct, ret_type.types, parts.values)
+		g.writeln('_ifexpr = ${tmp};')
+		return true
+	}
+	g.write('_ifexpr = (${ct}){')
 	for i, value_id in parts.values {
 		if i > 0 {
 			g.write(', ')
@@ -427,6 +433,15 @@ fn (mut g FlatGen) gen_if_expr_multi_return_block(block &flat.Node, ret_type typ
 fn (mut g FlatGen) gen_multi_return_block_expr(block &flat.Node, ret_type types.MultiReturn) bool {
 	parts := g.multi_return_tail_parts(block, ret_type.types.len) or { return false }
 	ct := g.tc.c_type(types.Type(ret_type))
+	if g.multi_return_types_have_fixed_array(ret_type.types) {
+		g.write('({')
+		for i in 0 .. parts.prefix_count {
+			g.gen_node(g.a.child(block, i))
+		}
+		tmp := g.gen_multi_return_tail_temp(ct, ret_type.types, parts.values)
+		g.write('${tmp};})')
+		return true
+	}
 	if parts.prefix_count == 0 {
 		g.write('(${ct}){')
 		for i, value_id in parts.values {
@@ -453,6 +468,28 @@ fn (mut g FlatGen) gen_multi_return_block_expr(block &flat.Node, ret_type types.
 	}
 	g.write('}; _multi_ret;})')
 	return true
+}
+
+fn (mut g FlatGen) gen_multi_return_tail_temp(ct string, ret_types []types.Type, values []flat.NodeId) string {
+	tmp := g.tmp_name()
+	g.writeln('${ct} ${tmp};')
+	for i, value_id in values {
+		field := '${tmp}.arg${i}'
+		if i < ret_types.len {
+			if fixed := array_fixed_type(ret_types[i]) {
+				g.gen_fixed_array_copy_from_node(field, value_id, fixed)
+				continue
+			}
+			g.write('${field} = ')
+			g.gen_expr_with_expected_type(value_id, ret_types[i])
+			g.writeln(';')
+			continue
+		}
+		g.write('${field} = ')
+		g.gen_expr(value_id)
+		g.writeln(';')
+	}
+	return tmp
 }
 
 // is_expr_kind reports whether is expr kind applies in c.

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -925,20 +925,16 @@ fn (mut g FlatGen) gen_interface_dispatch(iface_name string, cn string, method s
 		for concrete in impls {
 			id := g.iface_type_id(iface_name, concrete)
 			concrete_key := '${concrete}.${method}'
-			if id == 0 || concrete_key !in g.tc.fn_param_types
-				|| !g.interface_dispatch_target_is_emitted(concrete_key) {
+			method_key := g.tc.concrete_method_signature_key(concrete, method) or { concrete_key }
+			if id == 0 || method_key !in g.tc.fn_param_types
+				|| !g.interface_dispatch_target_is_emitted(method_key) {
 				continue
 			}
-			concrete_params := g.tc.fn_param_types[concrete_key] or { []types.Type{} }
+			concrete_params := g.tc.fn_param_types[method_key] or { []types.Type{} }
 			recv_is_ptr := concrete_params.len > 0 && concrete_params[0] is types.Pointer
-			cct := g.tc.c_type(g.tc.parse_type(concrete))
-			recv := if recv_is_ptr {
-				'(${cct}*)i->_object'
-			} else {
-				'*(${cct}*)i->_object'
-			}
+			recv := g.interface_dispatch_receiver_expr(concrete, concrete_params, recv_is_ptr)
 			g.write('\t\tcase ${id}: ')
-			mut call := '${c_name(concrete_key)}(${recv}'
+			mut call := '${c_name(method_key)}(${recv}'
 			for ai, an in arg_names {
 				arg_idx := ai + 1
 				concrete_param := if arg_idx < concrete_params.len {
@@ -974,6 +970,28 @@ fn (mut g FlatGen) gen_interface_dispatch(iface_name string, cn string, method s
 		g.writeln('\treturn (${ret_ct}){0};')
 	}
 	g.writeln('}')
+}
+
+fn (g &FlatGen) interface_dispatch_receiver_expr(concrete string, concrete_params []types.Type, wants_ptr bool) string {
+	cct := g.tc.c_type(g.tc.parse_type(concrete))
+	if concrete_params.len == 0 {
+		return if wants_ptr { '(${cct}*)i->_object' } else { '*(${cct}*)i->_object' }
+	}
+	concrete_type := g.tc.parse_type(concrete)
+	expected_type := concrete_params[0]
+	if field := g.embedded_receiver_field_for_expected(concrete_type, expected_type) {
+		field_is_ptr := field.typ is types.Pointer
+		base := '(${cct}*)i->_object'
+		access := '${base}->${c_name(field.name)}'
+		if wants_ptr && !field_is_ptr {
+			return '&${access}'
+		}
+		if !wants_ptr && field_is_ptr {
+			return '*${access}'
+		}
+		return access
+	}
+	return if wants_ptr { '(${cct}*)i->_object' } else { '*(${cct}*)i->_object' }
 }
 
 fn (g &FlatGen) interface_method_signature_key(iface_name string, method string) ?string {

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -979,17 +979,19 @@ fn (g &FlatGen) interface_dispatch_receiver_expr(concrete string, concrete_param
 	}
 	concrete_type := g.tc.parse_type(concrete)
 	expected_type := concrete_params[0]
-	if field := g.embedded_receiver_field_for_expected(concrete_type, expected_type) {
-		field_is_ptr := field.typ is types.Pointer
+	if path := g.embedded_receiver_path_for_expected(concrete_type, expected_type) {
 		base := '(${cct}*)i->_object'
-		access := '${base}->${c_name(field.name)}'
-		if wants_ptr && !field_is_ptr {
-			return '&${access}'
+		mut access := base
+		mut access_is_ptr := true
+		for field in path {
+			op := if access_is_ptr { '->' } else { '.' }
+			access = '(${access})${op}${c_field_name(field.name)}'
+			access_is_ptr = field.typ is types.Pointer
 		}
-		if !wants_ptr && field_is_ptr {
-			return '*${access}'
+		if access_is_ptr == wants_ptr {
+			return access
 		}
-		return access
+		return if wants_ptr { '&(${access})' } else { '*(${access})' }
 	}
 	return if wants_ptr { '(${cct}*)i->_object' } else { '*(${cct}*)i->_object' }
 }

--- a/vlib/v3/gen/c/names.v
+++ b/vlib/v3/gen/c/names.v
@@ -15,8 +15,38 @@ fn c_local_name(name string) string {
 
 // c_escape supports c escape handling for c.
 fn c_escape(s string) string {
-	return s.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n').replace('\t', '\\t').replace('\r',
-		'\\r')
+	mut out := strings.new_builder(s.len * 4)
+	for b in s.bytes() {
+		match b {
+			`\\` {
+				out.write_string('\\\\')
+			}
+			`"` {
+				out.write_string('\\"')
+			}
+			`\n` {
+				out.write_string('\\n')
+			}
+			`\t` {
+				out.write_string('\\t')
+			}
+			`\r` {
+				out.write_string('\\r')
+			}
+			else {
+				if b < 32 || b == 127 {
+					v := int(b)
+					out.write_u8(`\\`)
+					out.write_u8(u8(`0` + ((v >> 6) & 7)))
+					out.write_u8(u8(`0` + ((v >> 3) & 7)))
+					out.write_u8(u8(`0` + (v & 7)))
+				} else {
+					out.write_u8(b)
+				}
+			}
+		}
+	}
+	return out.str()
 }
 
 fn c_byte_string_escape(s string) string {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -867,6 +867,26 @@ fn (g &FlatGen) has_pending_defers() bool {
 }
 
 fn (mut g FlatGen) gen_pointer_value_return_expr(ret_id flat.NodeId, expected types.Type) bool {
+	return g.write_pointer_value_return_expr(ret_id, expected)
+}
+
+fn (mut g FlatGen) pointer_value_return_expr_string(ret_id flat.NodeId, expected types.Type) ?string {
+	orig := g.sb
+	orig_line_start := g.line_start
+	g.sb = strings.new_builder(64)
+	g.line_start = false
+	if !g.write_pointer_value_return_expr(ret_id, expected) {
+		g.sb = orig
+		g.line_start = orig_line_start
+		return none
+	}
+	result := g.sb.str()
+	g.sb = orig
+	g.line_start = orig_line_start
+	return result
+}
+
+fn (mut g FlatGen) write_pointer_value_return_expr(ret_id flat.NodeId, expected types.Type) bool {
 	actual := g.usable_expr_type(ret_id)
 	expected0 := if expected is types.Alias { expected.base_type } else { expected }
 	if expected0 is types.Pointer {
@@ -1167,9 +1187,19 @@ fn (mut g FlatGen) return_expr_string(node flat.Node, ret_id flat.NodeId, ret_no
 	}
 	if g.cur_fn_ret is types.MultiReturn {
 		if node.children_count > 1 {
+			ret_types := g.cur_fn_ret.types
 			mut parts := []string{cap: int(node.children_count)}
 			for i in 0 .. node.children_count {
-				parts << g.expr_to_string(g.a.child(&node, i))
+				child_id := g.a.child(&node, i)
+				if i < ret_types.len {
+					if expr := g.pointer_value_return_expr_string(child_id, ret_types[i]) {
+						parts << expr
+					} else {
+						parts << g.expr_to_string_with_expected_type(child_id, ret_types[i])
+					}
+				} else {
+					parts << g.expr_to_string(child_id)
+				}
 			}
 			return '(${ct}){${parts.join(', ')}}'
 		}

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -633,6 +633,15 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 						g.writeln('}};')
 						return
 					}
+					if base is types.MultiReturn {
+						expr_type := g.usable_expr_type(ret_id)
+						if ret_node.kind in [.block, .if_expr] || expr_type is types.MultiReturn {
+							g.write('return (${ct}){.ok = true, .value = ')
+							g.gen_expr_with_expected_type(ret_id, base)
+							g.writeln('};')
+							return
+						}
+					}
 					if ret_node.kind == .none_expr {
 						g.writeln('return (${ct}){.ok = false};')
 						return
@@ -715,22 +724,21 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 								if i > 0 {
 									g.write(', ')
 								}
-								g.gen_expr(g.a.child(&node, i))
+								child_id := g.a.child(&node, i)
+								if i < ret_types.len
+									&& g.gen_pointer_value_return_expr(child_id, ret_types[i]) {
+								} else if i < ret_types.len {
+									g.gen_expr_with_expected_type(child_id, ret_types[i])
+								} else {
+									g.gen_expr(child_id)
+								}
 							}
 							g.writeln('};')
 						}
 					} else {
-						expr_type := g.usable_expr_type(ret_id)
-						if expr_type is types.MultiReturn {
-							g.write('return ')
-							g.gen_expr(ret_id)
-							g.writeln(';')
-						} else {
-							ct := g.tc.c_type(g.cur_fn_ret)
-							g.write('return (${ct}){')
-							g.gen_expr(ret_id)
-							g.writeln('};')
-						}
+						g.write('return ')
+						g.gen_expr_with_expected_type(ret_id, g.cur_fn_ret)
+						g.writeln(';')
 					}
 				} else if ret_node.kind == .assoc {
 					g.gen_return_assoc(ret_node)
@@ -757,6 +765,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 						if !g.gen_interface_value_expr(ret_id, g.cur_fn_ret) {
 							g.gen_expr(ret_id)
 						}
+					} else if g.gen_pointer_value_return_expr(ret_id, g.cur_fn_ret) {
 					} else if !g.gen_heap_local_address_expr(ret_id, g.cur_fn_ret)
 						&& !g.gen_sum_constructor_call_with_expected_type(ret_id, ret_node, g.cur_fn_ret) {
 						g.gen_expr_with_expected_type(ret_id, g.cur_fn_ret)
@@ -855,6 +864,40 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 // has_pending_defers reports whether has pending defers applies in c.
 fn (g &FlatGen) has_pending_defers() bool {
 	return g.defers.len > 0 || g.fn_defers.len > 0
+}
+
+fn (mut g FlatGen) gen_pointer_value_return_expr(ret_id flat.NodeId, expected types.Type) bool {
+	actual := g.usable_expr_type(ret_id)
+	expected0 := if expected is types.Alias { expected.base_type } else { expected }
+	if expected0 is types.Pointer {
+		return false
+	}
+	if actual is types.Pointer {
+		if g.type_names_match(actual.base_type, expected0) {
+			g.write('*(')
+			g.gen_expr(ret_id)
+			g.write(')')
+			return true
+		}
+	}
+	if pointer_value_type_names_match(actual.name(), expected0.name()) {
+		g.write('*(')
+		g.gen_expr(ret_id)
+		g.write(')')
+		return true
+	}
+	return false
+}
+
+fn pointer_value_type_names_match(actual string, expected string) bool {
+	if !actual.starts_with('&') {
+		return false
+	}
+	clean_actual := actual[1..]
+	if clean_actual == expected {
+		return true
+	}
+	return clean_actual.all_after_last('.') == expected.all_after_last('.')
 }
 
 // gen_return_with_defers emits return with defers output for c.
@@ -1054,6 +1097,13 @@ fn (mut g FlatGen) return_expr_string(node flat.Node, ret_id flat.NodeId, ret_no
 			}
 			return '(${ct}){.ok = true, .value = (${base_ct}){${parts.join(', ')}}}'
 		}
+		if base is types.MultiReturn {
+			expr_type := g.usable_expr_type(ret_id)
+			if ret_node.kind in [.block, .if_expr] || expr_type is types.MultiReturn {
+				return '(${ct}){.ok = true, .value = ${g.expr_to_string_with_expected_type(ret_id,
+					base)}}'
+			}
+		}
 		if ret_node.kind == .none_expr {
 			return '(${ct}){.ok = false}'
 		}
@@ -1123,11 +1173,7 @@ fn (mut g FlatGen) return_expr_string(node flat.Node, ret_id flat.NodeId, ret_no
 			}
 			return '(${ct}){${parts.join(', ')}}'
 		}
-		expr_type := g.usable_expr_type(ret_id)
-		if expr_type is types.MultiReturn {
-			return g.expr_to_string(ret_id)
-		}
-		return '(${ct}){${g.expr_to_string(ret_id)}}'
+		return g.expr_to_string_with_expected_type(ret_id, g.cur_fn_ret)
 	}
 	if g.cur_fn_ret is types.Interface {
 		// Box the concrete value the same way the direct return path does, so a deferred return

--- a/vlib/v3/gen/c/str_intp.v
+++ b/vlib/v3/gen/c/str_intp.v
@@ -251,8 +251,7 @@ fn (g &FlatGen) is_string_node(id flat.NodeId) bool {
 // string_literals supports string literals handling for FlatGen.
 fn (mut g FlatGen) string_literals() {
 	for i, s in g.str_lits {
-		escaped := s.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n').replace('\t',
-			'\\t').replace('\r', '\\r')
+		escaped := c_escape(s)
 		g.writeln('string _str_${i} = {"${escaped}", ${s.len}, 1};')
 	}
 	if g.str_lits.len > 0 {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -44,6 +44,9 @@ fn (mut g FlatGen) gen_struct_field_expr(value_id flat.NodeId, expected types.Ty
 	if g.gen_pointer_value_struct_field(value_id, expected) {
 		return
 	}
+	if g.gen_optional_arg(value_id, expected) {
+		return
+	}
 	g.gen_expr_with_expected_type(value_id, expected)
 }
 

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -41,7 +41,33 @@ fn (mut g FlatGen) gen_struct_field_expr(value_id flat.NodeId, expected types.Ty
 	if g.gen_callback_fn_value_for_expected_type(value_id, expected) {
 		return
 	}
+	if g.gen_pointer_value_struct_field(value_id, expected) {
+		return
+	}
 	g.gen_expr_with_expected_type(value_id, expected)
+}
+
+fn (mut g FlatGen) gen_pointer_value_struct_field(value_id flat.NodeId, expected types.Type) bool {
+	actual := g.tc.resolve_type(value_id)
+	expected0 := if expected is types.Alias { expected.base_type } else { expected }
+	if expected0 is types.Pointer {
+		return false
+	}
+	if actual is types.Pointer {
+		if g.type_names_match(actual.base_type, expected0) {
+			g.write('*(')
+			g.gen_expr(value_id)
+			g.write(')')
+			return true
+		}
+	}
+	if pointer_value_type_names_match(actual.name(), expected0.name()) {
+		g.write('*(')
+		g.gen_expr(value_id)
+		g.write(')')
+		return true
+	}
+	return false
 }
 
 fn (mut g FlatGen) gen_struct_field_expr_for_field(value_id flat.NodeId, struct_name string, field_name string, expected types.Type) {

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -17,6 +17,9 @@ fn (mut g FlatGen) optional_type_name(t types.Type) string {
 	if base_type is types.Void {
 		return 'Optional'
 	}
+	if g.type_contains_generic_placeholder(base_type) {
+		return 'Optional'
+	}
 	mut inner_ct := g.tc.c_type(base_type)
 	if inner_ct.starts_with('fn_ptr:') {
 		inner_ct = g.resolve_fn_ptr_type(inner_ct)
@@ -140,6 +143,9 @@ fn (mut g FlatGen) collect_optional_typedefs() {
 }
 
 fn (mut g FlatGen) collect_optional_typedef_type(t types.Type) {
+	if g.type_contains_generic_placeholder(t) {
+		return
+	}
 	match t {
 		types.OptionType {
 			g.optional_type_name(t)
@@ -181,6 +187,131 @@ fn (mut g FlatGen) collect_optional_typedef_type(t types.Type) {
 		}
 		else {}
 	}
+}
+
+fn (g &FlatGen) type_contains_generic_placeholder(t types.Type) bool {
+	match t {
+		types.Unknown {
+			return true
+		}
+		types.Array {
+			return g.type_contains_generic_placeholder(t.elem_type)
+		}
+		types.ArrayFixed {
+			return g.type_contains_generic_placeholder(t.elem_type)
+		}
+		types.Channel {
+			return g.type_contains_generic_placeholder(t.elem_type)
+		}
+		types.Map {
+			return g.type_contains_generic_placeholder(t.key_type)
+				|| g.type_contains_generic_placeholder(t.value_type)
+		}
+		types.Pointer {
+			return g.type_contains_generic_placeholder(t.base_type)
+		}
+		types.FnType {
+			for param in t.params {
+				if g.type_contains_generic_placeholder(param) {
+					return true
+				}
+			}
+			return g.type_contains_generic_placeholder(t.return_type)
+		}
+		types.OptionType {
+			return g.type_contains_generic_placeholder(t.base_type)
+		}
+		types.ResultType {
+			return g.type_contains_generic_placeholder(t.base_type)
+		}
+		types.Struct {
+			return g.type_name_contains_generic_placeholder(t.name)
+		}
+		types.Interface {
+			return g.type_name_contains_generic_placeholder(t.name)
+		}
+		types.Enum {
+			return g.type_name_contains_generic_placeholder(t.name)
+		}
+		types.SumType {
+			return g.type_name_contains_generic_placeholder(t.name)
+		}
+		types.Alias {
+			return g.type_name_contains_generic_placeholder(t.name)
+				|| g.type_contains_generic_placeholder(t.base_type)
+		}
+		types.MultiReturn {
+			for typ in t.types {
+				if g.type_contains_generic_placeholder(typ) {
+					return true
+				}
+			}
+			return false
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn (g &FlatGen) type_name_contains_generic_placeholder(name string) bool {
+	clean := name.trim_space()
+	if clean.len == 0 {
+		return false
+	}
+	if !clean.contains('[') {
+		return g.is_bare_generic_placeholder_name(clean)
+	}
+	mut depth := 0
+	mut start := 0
+	for i in 0 .. clean.len {
+		ch := clean[i]
+		if ch == `[` {
+			if depth == 0 {
+				start = i + 1
+			}
+			depth++
+		} else if ch == `]` {
+			depth--
+			if depth == 0 {
+				if g.generic_args_contain_placeholder(clean[start..i]) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+fn (g &FlatGen) generic_args_contain_placeholder(args string) bool {
+	mut depth := 0
+	mut start := 0
+	for i in 0 .. args.len {
+		ch := args[i]
+		if ch == `[` || ch == `(` {
+			depth++
+		} else if ch == `]` || ch == `)` {
+			if depth > 0 {
+				depth--
+			}
+		} else if ch == `,` && depth == 0 {
+			if g.type_name_contains_generic_placeholder(args[start..i].trim_space()) {
+				return true
+			}
+			start = i + 1
+		}
+	}
+	return g.type_name_contains_generic_placeholder(args[start..].trim_space())
+}
+
+fn (g &FlatGen) is_bare_generic_placeholder_name(name string) bool {
+	if name.len != 1 || name[0] < `A` || name[0] > `Z` {
+		return false
+	}
+	if types.is_builtin_type_name(name) || name in ['C', 'JS'] {
+		return false
+	}
+	return !g.type_name_known(name)
 }
 
 // emit_optional_typedef emits emit optional typedef output for c.

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -2117,8 +2117,8 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 			mut j := int(child.children_count) - 1
 			for j >= 0 {
 				if child.kind == .call && j == 0 {
-					if receiver_id := c.call_callee_receiver_expr(child) {
-						stack << receiver_id
+					if callee_expr_id := c.call_callee_expr_to_collect(child) {
+						stack << callee_expr_id
 					}
 					j--
 					continue
@@ -2137,7 +2137,7 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 	}
 }
 
-fn (c &CallCollector) call_callee_receiver_expr(node &flat.Node) ?flat.NodeId {
+fn (c &CallCollector) call_callee_expr_to_collect(node &flat.Node) ?flat.NodeId {
 	if node.kind != .call || node.children_count == 0 {
 		return none
 	}
@@ -2146,14 +2146,23 @@ fn (c &CallCollector) call_callee_receiver_expr(node &flat.Node) ?flat.NodeId {
 		return none
 	}
 	callee := c.a.node(callee_id)
-	if callee.kind != .selector || callee.children_count == 0 {
+	if callee.kind == .selector {
+		if callee.children_count == 0 {
+			return none
+		}
+		base_id := c.a.child(callee, 0)
+		if int(base_id) >= 0 && c.expr_contains_call(base_id) {
+			return base_id
+		}
 		return none
 	}
-	base_id := c.a.child(callee, 0)
-	if int(base_id) < 0 || !c.expr_contains_call(base_id) {
+	if callee.kind == .ident {
 		return none
 	}
-	return base_id
+	if c.expr_contains_call(callee_id) {
+		return callee_id
+	}
+	return none
 }
 
 fn (c &CallCollector) expr_contains_call(id flat.NodeId) bool {

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -296,6 +296,10 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 			receiver_name, receiver_struct := receiver_info(a, node)
 			collector.collect_calls(node, fn_info.module, imports, receiver_name, receiver_struct, mut
 				calls)
+			mut call_set := map[string]bool{}
+			for call in calls {
+				call_set[call] = true
+			}
 			initializer_refs.clear()
 			collector.collect_initializer_refs(node, fn_info.module, imports, mut initializer_refs)
 			for initializer_ref in initializer_refs {
@@ -319,7 +323,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 							eprintln('main: all_fns hit: "${callee}"')
 						}
 					}
-					add_safe_decl_alias(callee, callee_info, a, mut used)
+					add_safe_decl_alias(callee, callee_info, a, mut used, mut queue)
 				} else if callee in tc.fn_ret_types {
 					found_direct = true
 					if enqueue(callee, mut used, mut queue) {
@@ -337,11 +341,14 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 				}
 				if !found_direct {
 					short := callee.all_after_last('.')
-					if suffix_candidates := suffix_map[short] {
-						for candidate in suffix_candidates {
-							if candidate in fn_decls || candidate in tc.fn_ret_types {
-								if enqueue(candidate, mut used, mut queue) {
-									suffix_hits++
+					qcallee := qualify_fn(fn_info.module, callee)
+					if qcallee == callee || !call_set[qcallee] {
+						if suffix_candidates := suffix_map[short] {
+							for candidate in suffix_candidates {
+								if candidate in fn_decls || candidate in tc.fn_ret_types {
+									if enqueue(candidate, mut used, mut queue) {
+										suffix_hits++
+									}
 								}
 							}
 						}
@@ -365,9 +372,11 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 					}
 					if impls := iface_impls[recv] {
 						for impl in impls {
-							impl_method := '${impl}.${method}'
+							impl_method := tc.concrete_method_signature_key(impl, method) or {
+								'${impl}.${method}'
+							}
 							enqueue(impl_method, mut used, mut queue)
-							short_impl := '${impl.all_after_last('.')}.${method}'
+							short_impl := '${impl_method.all_before_last('.').all_after_last('.')}.${method}'
 							if short_impl != impl_method {
 								enqueue(short_impl, mut used, mut queue)
 							}
@@ -562,7 +571,7 @@ fn fn_decl_key_is_exact_for_info(name string, decl_name string, module_name stri
 	return lowered != qname && name == lowered
 }
 
-fn add_safe_decl_alias(callee string, callee_info FnDeclInfo, a &flat.FlatAst, mut used map[string]bool) {
+fn add_safe_decl_alias(callee string, callee_info FnDeclInfo, a &flat.FlatAst, mut used map[string]bool, mut queue []string) {
 	alias := a.node(callee_info.node_id).value
 	if fn_decl_key_is_exact_for_info(callee, alias, callee_info.module) {
 		return
@@ -578,8 +587,8 @@ fn add_safe_decl_alias(callee string, callee_info FnDeclInfo, a &flat.FlatAst, m
 		aliases << lowered
 	}
 	for candidate in aliases {
-		if candidate != callee && candidate !in used {
-			used[candidate] = true
+		if candidate != callee {
+			enqueue(candidate, mut used, mut queue)
 		}
 	}
 }
@@ -652,7 +661,7 @@ fn enqueue_initializer_callee(callee string, fn_decls map[string]FnDeclInfo, a &
 	}
 	if callee_info := fn_decls[callee] {
 		enqueue(callee, mut used, mut queue)
-		add_safe_decl_alias(callee, callee_info, a, mut used)
+		add_safe_decl_alias(callee, callee_info, a, mut used, mut queue)
 	} else {
 		enqueue(callee, mut used, mut queue)
 	}
@@ -755,7 +764,7 @@ fn enqueue_top_level_calls(a &flat.FlatAst, collector CallCollector, fn_decls ma
 			for callee in calls {
 				if callee_info := fn_decls[callee] {
 					enqueue(callee, mut used, mut queue)
-					add_safe_decl_alias(callee, callee_info, a, mut used)
+					add_safe_decl_alias(callee, callee_info, a, mut used, mut queue)
 				} else {
 					enqueue(callee, mut used, mut queue)
 				}
@@ -1933,10 +1942,14 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 								}
 							}
 							if callee.value !in local_values {
-								calls << callee.value
 								qcallee := qualify_fn(cur_module, callee.value)
-								if qcallee != callee.value {
+								if qcallee != callee.value && c.is_known_fn_name(qcallee) {
 									calls << qcallee
+								} else {
+									calls << callee.value
+									if qcallee != callee.value {
+										calls << qcallee
+									}
 								}
 							}
 						} else if callee.kind == .selector && callee.value.len > 0 {
@@ -2103,6 +2116,13 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 		if child.children_count > 0 {
 			mut j := int(child.children_count) - 1
 			for j >= 0 {
+				if child.kind == .call && j == 0 {
+					if receiver_id := c.call_callee_receiver_expr(child) {
+						stack << receiver_id
+					}
+					j--
+					continue
+				}
 				if child.kind == .decl_assign && j % 2 == 0 {
 					j--
 					continue
@@ -2115,6 +2135,46 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 			}
 		}
 	}
+}
+
+fn (c &CallCollector) call_callee_receiver_expr(node &flat.Node) ?flat.NodeId {
+	if node.kind != .call || node.children_count == 0 {
+		return none
+	}
+	callee_id := c.a.child(node, 0)
+	if int(callee_id) < 0 {
+		return none
+	}
+	callee := c.a.node(callee_id)
+	if callee.kind != .selector || callee.children_count == 0 {
+		return none
+	}
+	base_id := c.a.child(callee, 0)
+	if int(base_id) < 0 || !c.expr_contains_call(base_id) {
+		return none
+	}
+	return base_id
+}
+
+fn (c &CallCollector) expr_contains_call(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return false
+	}
+	mut stack := [id]
+	for stack.len > 0 {
+		cur_id := stack.pop()
+		node := c.a.node(cur_id)
+		if node.kind == .call {
+			return true
+		}
+		for i in 0 .. node.children_count {
+			child_id := c.a.child(node, i)
+			if int(child_id) >= 0 {
+				stack << child_id
+			}
+		}
+	}
+	return false
 }
 
 fn (c &CallCollector) collect_initializer_refs(node &flat.Node, cur_module string, imports map[string]string, mut refs []string) {
@@ -2156,6 +2216,10 @@ fn (c &CallCollector) collect_initializer_refs(node &flat.Node, cur_module strin
 		if child.children_count > 0 {
 			mut j := int(child.children_count) - 1
 			for j >= 0 {
+				if child.kind == .call && j == 0 {
+					j--
+					continue
+				}
 				if child.kind == .decl_assign && j % 2 == 0 {
 					j--
 					continue
@@ -3066,8 +3130,11 @@ fn markused_infer_alias_generic_type(param_text string, actual types.Type, gener
 		}
 		return
 	}
-	if clean in generic_params && actual is types.Alias {
-		inferred[clean] = actual.name
+	if clean in generic_params {
+		type_name := resolve_type_name(actual)
+		if type_name.len > 0 {
+			inferred[clean] = type_name
+		}
 	}
 }
 
@@ -3902,6 +3969,13 @@ fn (c &CallCollector) receiver_type_name(base_id flat.NodeId, cur_module string,
 	type_name := resolve_type_name(base_type)
 	if type_name.len > 0 {
 		return type_name
+	}
+	if base.kind == .index {
+		if elem_type := c.top_level_index_elem_type_name(base_id, cur_module, imports,
+			local_values, local_types)
+		{
+			return elem_type
+		}
 	}
 	if base.kind == .ident && base.value.len > 0 {
 		if local_type := local_types[base.value] {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -2678,7 +2678,9 @@ fn (mut p Parser) stmt() flat.NodeId {
 			if p.tok == .key_static {
 				return p.static_decl_stmt()
 			}
-			return p.assign_or_expr_stmt()
+			stmt_id := p.assign_or_expr_stmt()
+			p.mark_node_mut(stmt_id)
+			return stmt_id
 		}
 		.key_static {
 			return p.static_decl_stmt()
@@ -2762,9 +2764,15 @@ fn (mut p Parser) stmt() flat.NodeId {
 	}
 }
 
+fn (mut p Parser) mark_node_mut(id flat.NodeId) {
+	p.a.set_node_is_mut(id, true)
+}
+
 fn (mut p Parser) static_decl_stmt() flat.NodeId {
 	p.next() // skip `static`
+	mut is_mut := false
 	if p.tok == .key_mut {
+		is_mut = true
 		p.next()
 	}
 	lhs := p.expr(.lowest)
@@ -2779,6 +2787,7 @@ fn (mut p Parser) static_decl_stmt() flat.NodeId {
 			kind:           .decl_assign
 			op:             .assign
 			value:          'static'
+			is_mut:         is_mut
 			children_start: istart
 			children_count: 2
 		})
@@ -3538,10 +3547,16 @@ fn (mut p Parser) assign_or_expr_stmt() flat.NodeId {
 		lhs_ids << lhs
 		for p.tok == .comma {
 			p.next()
+			mut lhs_is_mut := false
 			if p.tok == .key_mut {
+				lhs_is_mut = true
 				p.next()
 			}
-			lhs_ids << p.expr(.lowest)
+			lhs_id := p.expr(.lowest)
+			if lhs_is_mut {
+				p.mark_node_mut(lhs_id)
+			}
+			lhs_ids << lhs_id
 		}
 		if p.tok == .decl_assign || token_is_assignment(p.tok) {
 			op_id := int(p.tok)

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -3812,9 +3812,12 @@ fn (mut p Parser) expr_with_lhs(first flat.NodeId, min_bp token.BindingPower) fl
 		if p.tok == .lsbr {
 			base_type_name := p.resolve_local_type_name(p.type_expr_name(lhs))
 			if type_name_can_init(base_type_name) && p.current_generic_suffix_followed_by_lcbr() {
+				before_suffix_offset := p.s.offset
 				suffix := p.parse_type_generic_suffix()
-				lhs = p.struct_init(p.resolve_local_type_name(base_type_name + suffix))
-				continue
+				if p.s.offset != before_suffix_offset && p.tok == .lcbr {
+					lhs = p.struct_init(p.resolve_local_type_name(base_type_name + suffix))
+					continue
+				}
 			}
 			lhs = p.index_expr(lhs)
 			continue

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -3826,7 +3826,8 @@ fn (mut p Parser) expr_with_lhs(first flat.NodeId, min_bp token.BindingPower) fl
 		// index / generic
 		if p.tok == .lsbr {
 			base_type_name := p.resolve_local_type_name(p.type_expr_name(lhs))
-			if type_name_can_init(base_type_name) && p.current_generic_suffix_followed_by_lcbr() {
+			if type_name_can_init(base_type_name)
+				&& p.current_generic_struct_init_suffix_followed_by_lcbr() {
 				before_suffix_offset := p.s.offset
 				suffix := p.parse_type_generic_suffix()
 				if p.s.offset != before_suffix_offset && p.tok == .lcbr {
@@ -5673,30 +5674,99 @@ fn (mut p Parser) current_lbr_starts_array_type() bool {
 	return p.lbr_starts_array_type_from_offset(p.s.offset)
 }
 
-fn (mut p Parser) current_generic_suffix_followed_by_lcbr() bool {
-	if p.tok != .lsbr {
+fn (mut p Parser) current_generic_struct_init_suffix_followed_by_lcbr() bool {
+	args := p.current_generic_suffix_args_followed_by_lcbr() or { return false }
+	if args.len == 0 {
 		return false
 	}
+	for arg in args {
+		if !generic_struct_init_suffix_arg_can_be_type(arg) {
+			return false
+		}
+	}
+	return true
+}
+
+fn (mut p Parser) current_generic_suffix_args_followed_by_lcbr() ?[]string {
+	if p.tok != .lsbr {
+		return none
+	}
 	mut idx := p.s.offset
-	mut depth := 1
+	mut arg_start := idx
+	mut bracket_depth := 1
+	mut paren_depth := 0
+	mut args := []string{}
 	for idx < p.s.src.len {
 		c := p.s.src[idx]
 		if c == `[` {
-			depth++
+			bracket_depth++
 		} else if c == `]` {
-			depth--
-			if depth == 0 {
+			bracket_depth--
+			if bracket_depth == 0 {
+				args << p.s.src[arg_start..idx].trim_space()
 				idx++
 				for idx < p.s.src.len && (p.s.src[idx] == ` ` || p.s.src[idx] == `\t`
 					|| p.s.src[idx] == `\n` || p.s.src[idx] == `\r`) {
 					idx++
 				}
-				return idx < p.s.src.len && p.s.src[idx] == `{`
+				if idx < p.s.src.len && p.s.src[idx] == `{` {
+					return args
+				}
+				return none
 			}
+		} else if c == `(` {
+			paren_depth++
+		} else if c == `)` {
+			if paren_depth > 0 {
+				paren_depth--
+			}
+		} else if c == `,` && bracket_depth == 1 && paren_depth == 0 {
+			args << p.s.src[arg_start..idx].trim_space()
+			arg_start = idx + 1
 		}
 		idx++
 	}
+	return none
+}
+
+fn generic_struct_init_suffix_arg_can_be_type(arg string) bool {
+	clean := arg.trim_space()
+	if clean.len == 0 {
+		return false
+	}
+	first := clean[0]
+	if (first >= `A` && first <= `Z`) || first == `&` || first == `?` || first == `!`
+		|| first == `[` || first == `(` || first == `^` {
+		return true
+	}
+	if clean == 'fn' || clean.starts_with('fn ') || clean.starts_with('fn(') {
+		return true
+	}
+	first_ident := generic_suffix_first_ident(clean)
+	if first_ident in ['map', 'chan', 'thread', 'shared', 'atomic', 'mut', 'struct', 'none', 'nil'] {
+		return true
+	}
+	if is_builtin_type(first_ident) {
+		return true
+	}
+	dot_idx := clean.last_index_u8(`.`)
+	if dot_idx >= 0 {
+		after_dot := clean[dot_idx + 1..]
+		return after_dot.len > 0 && after_dot[0] >= `A` && after_dot[0] <= `Z`
+	}
 	return false
+}
+
+fn generic_suffix_first_ident(s string) string {
+	mut idx := 0
+	for idx < s.len {
+		c := s[idx]
+		if !((c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_`) {
+			break
+		}
+		idx++
+	}
+	return s[..idx]
 }
 
 fn (mut p Parser) lbr_starts_array_type_from_offset(offset int) bool {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -1323,20 +1323,26 @@ fn (mut p Parser) global_decl() flat.NodeId {
 				p.next()
 				full_name += '.' + p.expect_name_or_keyword()
 			}
+			mut gtype := ''
+			mut val_id := flat.empty_node
+			if p.tok != .assign {
+				gtype = p.parse_type_name()
+			}
 			if p.tok == .assign {
-				// global with initializer: __global name = expr
+				// global with initializer: __global name = expr, or __global name Type = expr
 				p.next()
-				val_id := p.expr(.lowest)
+				val_id = p.expr(.lowest)
+			}
+			if int(val_id) >= 0 {
 				vstart := p.add_child(val_id)
 				ids << p.a.add_node(flat.Node{
 					kind:           .field_decl
 					value:          full_name
-					typ:            ''
+					typ:            gtype
 					children_start: vstart
 					children_count: 1
 				})
 			} else {
-				gtype := p.parse_type_name()
 				ids << p.a.add_node(flat.Node{
 					kind:  .field_decl
 					value: full_name

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -1099,8 +1099,8 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 	mut is_generic := false
 	mut generic_params := []string{}
 	if p.tok == .lsbr {
-		is_generic = true
 		generic_params = p.parse_generic_param_names()
+		is_generic = generic_params.len > 0
 	}
 	// implements clause
 	mut implements_types := []string{}
@@ -3342,6 +3342,10 @@ fn (mut p Parser) match_branch_cond() flat.NodeId {
 			typ:   typ
 		})
 	}
+	if p.tok == .name && p.lit == 'map' && p.peek() == .lsbr {
+		typ := p.parse_type_name()
+		return p.a.add_val(.ident, typ)
+	}
 	if p.tok == .name && p.peek() == .dot {
 		mod_name := p.lit
 		p.next()
@@ -3800,6 +3804,12 @@ fn (mut p Parser) expr_with_lhs(first flat.NodeId, min_bp token.BindingPower) fl
 		}
 		// index / generic
 		if p.tok == .lsbr {
+			base_type_name := p.resolve_local_type_name(p.type_expr_name(lhs))
+			if type_name_can_init(base_type_name) && p.current_generic_suffix_followed_by_lcbr() {
+				suffix := p.parse_type_generic_suffix()
+				lhs = p.struct_init(p.resolve_local_type_name(base_type_name + suffix))
+				continue
+			}
 			lhs = p.index_expr(lhs)
 			continue
 		}
@@ -4501,6 +4511,10 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 					children_start: p.add_child(id)
 					children_count: 1
 				})
+			} else if p.tok == .name && p.lit == 'C' && p.peek() == .dot {
+				if cast := p.pointer_cast_expr_from_current_amp() {
+					return cast
+				}
 			} else if p.tok == .lsbr && p.peek() == .rsbr {
 				type_name := '&' + p.parse_type_name()
 				if p.tok == .lpar {
@@ -4664,6 +4678,39 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			return p.a.add(flat.NodeKind.empty)
 		}
 	}
+}
+
+fn (mut p Parser) pointer_cast_expr_from_current_amp() ?flat.NodeId {
+	saved_s := p.s
+	saved_tok := p.tok
+	saved_lit := p.lit
+	saved_tok_pos := p.tok_pos
+	saved_peek_tok := p.peek_tok
+	saved_peek_lit := p.peek_lit
+	saved_peek_pos := p.peek_pos
+	saved_has_peek := p.has_peek
+	type_name := '&' + p.parse_type_name()
+	if type_name.len > 1 && p.tok == .lpar {
+		p.next()
+		inner := p.expr(.lowest)
+		p.check(.rpar)
+		cstart := p.add_child(inner)
+		return p.a.add_node(flat.Node{
+			kind:           .cast_expr
+			value:          type_name
+			children_start: cstart
+			children_count: 1
+		})
+	}
+	p.s = saved_s
+	p.tok = saved_tok
+	p.lit = saved_lit
+	p.tok_pos = saved_tok_pos
+	p.peek_tok = saved_peek_tok
+	p.peek_lit = saved_peek_lit
+	p.peek_pos = saved_peek_pos
+	p.has_peek = saved_has_peek
+	return none
 }
 
 fn (mut p Parser) selector_or_method(lhs flat.NodeId) flat.NodeId {
@@ -4880,9 +4927,42 @@ fn (mut p Parser) generic_call_type_arg_id(id flat.NodeId) flat.NodeId {
 fn (p &Parser) generic_struct_init_type_name(id flat.NodeId) ?string {
 	type_name := p.resolve_local_type_name(p.type_expr_name(id))
 	if !generic_type_name_can_init(type_name) {
+		if p.index_expr_is_lifetime_erased_type_name(id) && type_name_can_init(type_name) {
+			return type_name
+		}
 		return none
 	}
 	return type_name
+}
+
+fn (p &Parser) index_expr_is_lifetime_erased_type_name(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return false
+	}
+	node := p.a.nodes[int(id)]
+	if node.kind != .index || node.children_count < 2 || node.value == 'range' {
+		return false
+	}
+	mut saw_lifetime_arg := false
+	for i in 1 .. node.children_count {
+		child := p.a.child(&node, i)
+		if p.type_expr_is_lifetime_arg(child) {
+			saw_lifetime_arg = true
+			continue
+		}
+		if p.type_expr_name(child).len > 0 {
+			return false
+		}
+	}
+	return saw_lifetime_arg
+}
+
+fn (p &Parser) type_expr_is_lifetime_arg(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return false
+	}
+	node := p.a.nodes[int(id)]
+	return node.kind == .prefix && node.op == .xor && node.children_count == 1
 }
 
 fn (p &Parser) type_expr_name(id flat.NodeId) string {
@@ -4914,11 +4994,18 @@ fn (p &Parser) type_expr_name(id flat.NodeId) string {
 			}
 			mut args := []string{}
 			for i in 1 .. node.children_count {
-				arg := p.resolve_local_type_name(p.type_expr_name(p.a.child(&node, i)))
+				child_id := p.a.child(&node, i)
+				if p.type_expr_is_lifetime_arg(child_id) {
+					continue
+				}
+				arg := p.resolve_local_type_name(p.type_expr_name(child_id))
 				if arg.len == 0 {
 					return ''
 				}
 				args << arg
+			}
+			if args.len == 0 {
+				return base
 			}
 			return '${base}[${args.join(', ')}]'
 		}
@@ -4949,6 +5036,14 @@ fn (p &Parser) type_expr_name(id flat.NodeId) string {
 
 fn generic_type_name_can_init(type_name string) bool {
 	if !type_name.contains('[') {
+		return false
+	}
+	base := type_name.all_before('[')
+	return type_name_can_init(base)
+}
+
+fn type_name_can_init(type_name string) bool {
+	if type_name.len == 0 {
 		return false
 	}
 	base := type_name.all_before('[')
@@ -5552,6 +5647,32 @@ fn (mut p Parser) current_lbr_starts_array_type() bool {
 		return false
 	}
 	return p.lbr_starts_array_type_from_offset(p.s.offset)
+}
+
+fn (mut p Parser) current_generic_suffix_followed_by_lcbr() bool {
+	if p.tok != .lsbr {
+		return false
+	}
+	mut idx := p.s.offset
+	mut depth := 1
+	for idx < p.s.src.len {
+		c := p.s.src[idx]
+		if c == `[` {
+			depth++
+		} else if c == `]` {
+			depth--
+			if depth == 0 {
+				idx++
+				for idx < p.s.src.len && (p.s.src[idx] == ` ` || p.s.src[idx] == `\t`
+					|| p.s.src[idx] == `\n` || p.s.src[idx] == `\r`) {
+					idx++
+				}
+				return idx < p.s.src.len && p.s.src[idx] == `{`
+			}
+		}
+		idx++
+	}
+	return false
 }
 
 fn (mut p Parser) lbr_starts_array_type_from_offset(offset int) bool {

--- a/vlib/v3/tests/c_directive_order_codegen_test.v
+++ b/vlib/v3/tests/c_directive_order_codegen_test.v
@@ -766,6 +766,38 @@ static inline int stdarg_sum(int count, ...) {
 	return os.read_file(bin_out + '.c') or { panic(err) }
 }
 
+fn directive_order_gen_c_nested_poll_header(v3_bin string) string {
+	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_poll_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	directive_order_write_file(root, 'v.mod', "Module { name: 'directive_order_poll' }\n")
+	directive_order_write_file(root, 'main.v', 'module main
+
+#insert "poll_user.h"
+
+struct C.pollfd {
+	fd int
+	events i16
+	revents i16
+}
+
+fn C.poll_user_fd(item &C.pollfd) int
+
+fn main() {}
+')
+	directive_order_write_file(root, 'poll_user.h', '#include <poll.h>
+
+static inline int poll_user_fd(struct pollfd* item) {
+	return item->fd;
+}
+')
+	c_out := os.join_path(os.temp_dir(), 'v3_c_directive_order_poll.c')
+	os.rm(c_out) or {}
+	result := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${c_out}')
+	assert result.exit_code == 0, result.output
+	return os.read_file(c_out) or { panic(err) }
+}
+
 fn directive_order_gen_c_rwmutex(v3_bin string) string {
 	root := os.join_path(os.temp_dir(), 'v3_c_directive_order_rwmutex_project')
 	os.rmdir_all(root) or {}
@@ -1093,6 +1125,14 @@ fn test_stdarg_in_inlined_header_uses_headerless_va_defs() {
 	assert c_code.contains('#define offsetof(type, member) __builtin_offsetof(type, member)'), c_code
 	assert c_code.contains('offsetof(struct StdargThing, value)'), c_code
 	assert c_code.contains('static inline int stdarg_sum(int count, ...)'), c_code
+}
+
+fn test_poll_in_inlined_header_preserves_system_struct() {
+	c_code := directive_order_gen_c_nested_poll_header(directive_order_build_v3())
+	assert c_code.contains('#include <poll.h>'), c_code
+	assert c_code.contains('static inline int poll_user_fd(struct pollfd* item)'), c_code
+	assert !c_code.contains('typedef struct pollfd pollfd;'), c_code
+	assert !c_code.contains('struct pollfd {\n'), c_code
 }
 
 fn test_rwmutex_keeps_linux_rwlockattr_prototype() {

--- a/vlib/v3/tests/c_global_c_type_storage_codegen_test.v
+++ b/vlib/v3/tests/c_global_c_type_storage_codegen_test.v
@@ -56,6 +56,181 @@ fn gen_c_for_c_global_sources(name string, files map[string]string) string {
 	return g.gen_with_used_options(a, used_fns, &tc, true)
 }
 
+fn test_c_pointer_cast_selector_uses_cast_field_value() {
+	c_code := gen_c_for_c_global_source('c_pointer_cast_selector', 'module main
+
+@[typedef]
+struct C.log__Logger {
+mut:
+	_object voidptr
+}
+
+fn raw_object(logger &C.log__Logger) voidptr {
+	pobject := &C.log__Logger(logger)._object
+	return pobject
+}
+
+fn main() {
+	logger := &C.log__Logger(voidptr(0))
+	_ := raw_object(logger)
+}
+')
+	assert c_code.contains('void* pobject = ((struct log__Logger*)logger)->_object;')
+	assert !c_code.contains('void** pobject')
+	assert !c_code.contains('__addr_')
+}
+
+fn test_mut_parameter_address_uses_lowered_pointer() {
+	c_code := gen_c_for_c_global_source('mut_parameter_address', 'module main
+
+struct Reader {
+mut:
+	pos int
+}
+
+struct ReaderBox {
+mut:
+	rdr &Reader
+}
+
+fn ReaderBox.new(rdr &Reader) ReaderBox {
+	return ReaderBox{
+		rdr: rdr
+	}
+}
+
+fn wrap(mut read_from Reader) ReaderBox {
+	return ReaderBox.new(&read_from)
+}
+
+fn main() {
+	mut reader := Reader{}
+	_ := wrap(mut reader)
+}
+')
+	assert c_code.contains('ReaderBox__new(read_from)'), c_code
+	assert !c_code.contains('ReaderBox__new(&read_from)'), c_code
+}
+
+fn test_mut_parameter_address_boxed_as_interface_uses_concrete_pointer() {
+	c_code := gen_c_for_c_global_source('mut_parameter_address_interface', 'module main
+
+interface Reader {
+	read() int
+}
+
+struct FileReader {}
+
+fn (r FileReader) read() int {
+	return 1
+}
+
+struct ReaderBox {
+mut:
+	rdr &Reader
+}
+
+fn ReaderBox.new(rdr &Reader) ReaderBox {
+	return ReaderBox{
+		rdr: rdr
+	}
+}
+
+fn wrap(mut read_from FileReader) ReaderBox {
+	return ReaderBox.new(&read_from)
+}
+
+fn main() {
+	mut reader := FileReader{}
+	_ := wrap(mut reader)
+}
+')
+	assert c_code.contains('FileReader* __iface_src_'), c_code
+	assert c_code.contains('(Reader){._typ = '), c_code
+	assert !c_code.contains('FileReader** __iface_src_'), c_code
+}
+
+fn test_mut_parameter_pointer_return_stays_pointer() {
+	c_code := gen_c_for_c_global_source('mut_parameter_pointer_return', 'module main
+
+struct Builder {
+mut:
+	value int
+}
+
+fn identity(mut builder Builder) &Builder {
+	builder.value = 1
+	return builder
+}
+
+fn main() {
+	mut builder := Builder{}
+	_ := identity(mut builder)
+}
+')
+	assert c_code.contains('Builder* identity(Builder* builder)'), c_code
+	assert c_code.contains('return builder;'), c_code
+	assert !c_code.contains('return *(builder);'), c_code
+}
+
+fn test_pointer_struct_field_from_mut_parameter_stays_pointer() {
+	c_code := gen_c_for_c_global_source('mut_parameter_pointer_struct_field', 'module main
+
+struct Reader {
+mut:
+	pos int
+}
+
+struct Holder {
+mut:
+	rdr &Reader
+}
+
+fn Holder.new(mut rdr Reader) Holder {
+	return Holder{
+		rdr: rdr
+	}
+}
+
+fn main() {
+	mut rdr := Reader{}
+	_ := Holder.new(mut rdr)
+}
+')
+	assert c_code.contains('.rdr = rdr'), c_code
+	assert !c_code.contains('.rdr = *(rdr)'), c_code
+}
+
+fn test_pointer_struct_field_from_selector_address_stays_pointer() {
+	c_code := gen_c_for_c_global_source('selector_address_pointer_struct_field', 'module main
+
+struct Config {}
+
+struct Searcher {
+mut:
+	config Config
+}
+
+struct Holder {
+mut:
+	config &Config
+}
+
+fn Holder.new(searcher &Searcher) Holder {
+	return Holder{
+		config: &searcher.config
+	}
+}
+
+fn main() {
+	searcher := Searcher{}
+	_ := Holder.new(&searcher)
+}
+')
+	assert c_code.contains('.config = &searcher->config'), c_code
+	assert !c_code.contains('.config = *(&searcher->config)'), c_code
+}
+
 fn test_v_owned_global_with_c_struct_type_gets_storage() {
 	c_code := gen_c_for_c_global_source('v_owned_c_struct_global', 'struct C.NativeDesc {
 mut:

--- a/vlib/v3/tests/c_string_literal_pointer_codegen_test.v
+++ b/vlib/v3/tests/c_string_literal_pointer_codegen_test.v
@@ -28,3 +28,24 @@ fn test_c_string_literal_address_codegen_preserves_regular_addresses() {
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == 'canary\n73'
 }
+
+fn test_embedded_nul_string_literal_codegen_escapes_c_source() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_c_string_literal_nul_test')
+	build := os.execute('${vexe} -gc none -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_c_string_literal_nul_input.v')
+	os.write_file(src,
+		"fn main() {\n\ttext := 'ab\\x00cd'\n\tbytes := text.bytes()\n\tassert text.len == 5\n\tassert bytes.len == 5\n\tassert bytes[0] == `a`\n\tassert bytes[1] == `b`\n\tassert bytes[2] == u8(0)\n\tassert bytes[3] == `c`\n\tassert bytes[4] == `d`\n\tprintln('ok')\n}\n") or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_c_string_literal_nul_input')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	c_code := os.read_file(bin + '.c') or { panic(err) }
+	assert c_code.contains('ab\\000cd'), c_code
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok'
+}

--- a/vlib/v3/tests/fixed_array_multi_return_codegen_test.v
+++ b/vlib/v3/tests/fixed_array_multi_return_codegen_test.v
@@ -104,3 +104,41 @@ fn main() {
 	assert !has_fixed_array_assignment(compact, 'Array_fixed_int_2', 'ds'), generated
 	assert !generated.contains('return (multi_return_int_Array_fixed_int_3){7, xs};'), generated
 }
+
+fn test_deferred_multi_return_pointer_value_slot_uses_expected_type() {
+	v3_bin := fixed_array_multi_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_deferred_multi_return_pointer_value_${os.getpid()}.v')
+	os.write_file(src, 'module main
+
+struct S {
+	value int
+}
+
+fn f() (S, int) {
+	defer {
+		_ := 0
+	}
+	s := S{
+		value: 41
+	}
+	return &s, 1
+}
+
+fn main() {
+	s, n := f()
+	println(int_str(s.value + n))
+}
+') or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_deferred_multi_return_pointer_value_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '42'
+	generated := os.read_file(bin + '.c') or { panic(err) }
+	compact := compact_c_whitespace(generated)
+	assert compact.contains('{*&s,1}'), generated
+	assert !compact.contains('{&s,1}'), generated
+}

--- a/vlib/v3/tests/fixed_array_multi_return_codegen_test.v
+++ b/vlib/v3/tests/fixed_array_multi_return_codegen_test.v
@@ -30,6 +30,10 @@ fn has_fixed_array_assignment(compact string, typ string, name string) bool {
 	return compact.contains('${typ}${name}=')
 }
 
+fn has_fixed_array_memmove_source(compact string, name string) bool {
+	return compact.contains(',${name},sizeof(')
+}
+
 fn test_fixed_array_multi_return_payloads_use_c_arrays_and_memmove() {
 	v3_bin := fixed_array_multi_build_v3()
 	src := os.join_path(os.temp_dir(), 'v3_fixed_array_multi_return_${os.getpid()}.v')
@@ -61,6 +65,20 @@ fn defer_pair() (int, [2]int) {
 	return 11, ds
 }
 
+fn choose_pair(c bool) (int, [3]int) {
+	mut choice := [3]int{}
+	choice[0] = 10
+	choice[1] = 11
+	choice[2] = 12
+	return if c {
+		13
+		choice
+	} else {
+		17
+		choice
+	}
+}
+
 fn main() {
 	n, xs := pair()
 	assert n == 7
@@ -77,7 +95,11 @@ fn main() {
 	d, ds := defer_pair()
 	assert d == 11
 	assert ds[1] == 9
-	println(int_str(n + xs[1] + m + ys[2] + q + zs[0] + d + ds[1]))
+	choice_n, choice := choose_pair(false)
+	assert choice_n == 17
+	assert choice[0] == 10
+	assert choice[2] == 12
+	println(int_str(n + xs[1] + m + ys[2] + q + zs[0] + d + ds[1] + choice_n + choice[2]))
 }
 ') or {
 		panic(err)
@@ -87,22 +109,26 @@ fn main() {
 	assert compile.exit_code == 0, compile.output
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
-	assert run.output.trim_space() == '52'
+	assert run.output.trim_space() == '81'
 	generated := os.read_file(bin + '.c') or { panic(err) }
 	assert generated.contains('int xs[3];'), generated
 	assert generated.contains('int ys[3] = {0};'), generated
 	assert generated.contains('int zs[3];'), generated
 	assert generated.contains('int ds[2];'), generated
+	assert generated.contains('int choice[3];'), generated
 	compact := compact_c_whitespace(generated)
 	assert has_fixed_array_memmove_copy(compact, 'xs'), generated
 	assert has_fixed_array_memmove_copy(compact, 'ys'), generated
 	assert has_fixed_array_memmove_copy(compact, 'zs'), generated
 	assert has_fixed_array_memmove_copy(compact, 'ds'), generated
+	assert has_fixed_array_memmove_copy(compact, 'choice'), generated
+	assert has_fixed_array_memmove_source(compact, 'choice'), generated
 	assert !has_fixed_array_assignment(compact, 'Array_fixed_int_3', 'xs'), generated
 	assert !has_fixed_array_assignment(compact, 'Array_fixed_int_3', 'ys'), generated
 	assert !has_fixed_array_assignment(compact, 'Array_fixed_int_3', 'zs'), generated
 	assert !has_fixed_array_assignment(compact, 'Array_fixed_int_2', 'ds'), generated
 	assert !generated.contains('return (multi_return_int_Array_fixed_int_3){7, xs};'), generated
+	assert !compact.contains('.arg1=choice'), generated
 }
 
 fn test_deferred_multi_return_pointer_value_slot_uses_expected_type() {

--- a/vlib/v3/tests/flag_enum_mut_receiver_checker_test.v
+++ b/vlib/v3/tests/flag_enum_mut_receiver_checker_test.v
@@ -1,0 +1,128 @@
+import os
+
+const flag_enum_mut_receiver_vexe = @VEXE
+const flag_enum_mut_receiver_tests_dir = os.dir(@FILE)
+const flag_enum_mut_receiver_v3_dir = os.dir(flag_enum_mut_receiver_tests_dir)
+const flag_enum_mut_receiver_vlib_dir = os.dir(flag_enum_mut_receiver_v3_dir)
+const flag_enum_mut_receiver_v3_src = os.join_path(flag_enum_mut_receiver_v3_dir, 'v3.v')
+
+fn flag_enum_mut_receiver_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_flag_enum_mut_receiver_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${flag_enum_mut_receiver_vexe} -gc none -path "${flag_enum_mut_receiver_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${flag_enum_mut_receiver_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn flag_enum_mut_receiver_run_bad(v3_bin string, name string, source string, expected string) {
+	src := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}.v')
+	os.write_file(src, source) or { panic(err) }
+	bin := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains(expected), compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+}
+
+fn flag_enum_mut_receiver_run_good(v3_bin string, name string, source string) string {
+	src := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}.v')
+	os.write_file(src, source) or { panic(err) }
+	bin := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
+}
+
+fn test_flag_enum_set_clear_require_mutable_receiver() {
+	v3_bin := flag_enum_mut_receiver_build_v3()
+	expected := 'flag enum method `set` requires a mutable receiver'
+	expected_clear := 'flag enum method `clear` requires a mutable receiver'
+	flag_enum_mut_receiver_run_bad(v3_bin, 'bad_flag_enum_immutable_set', '@[flag]
+enum Mode {
+	a
+	b
+}
+
+fn main() {
+	flags := Mode.a
+	flags.set(.b)
+}
+',
+		expected)
+	flag_enum_mut_receiver_run_bad(v3_bin, 'bad_flag_enum_rvalue_set', '@[flag]
+enum Mode {
+	a
+	b
+}
+
+fn make_flags() Mode {
+	return Mode.a
+}
+
+fn main() {
+	make_flags().set(.b)
+}
+',
+		expected)
+	flag_enum_mut_receiver_run_bad(v3_bin, 'bad_flag_enum_immutable_clear', '@[flag]
+enum Mode {
+	a
+	b
+}
+
+fn main() {
+	flags := Mode.a | Mode.b
+	flags.clear(.b)
+}
+',
+		expected_clear)
+	flag_enum_mut_receiver_run_bad(v3_bin, 'bad_flag_enum_immutable_field_set', '@[flag]
+enum Mode {
+	a
+	b
+}
+
+struct Box {
+	mode Mode
+}
+
+fn main() {
+	box := Box{
+		mode: Mode.a
+	}
+	box.mode.set(.b)
+}
+',
+		expected)
+	out := flag_enum_mut_receiver_run_good(v3_bin, 'good_flag_enum_mut_set_clear', '@[flag]
+enum Mode {
+	a
+	b
+}
+
+struct Box {
+	mode Mode
+}
+
+fn main() {
+	mut flags := Mode.a
+	flags.set(.b)
+	assert flags.has(.b)
+	flags.clear(.a)
+	assert !flags.has(.a)
+	mut box := Box{
+		mode: Mode.a
+	}
+	box.mode.set(.b)
+	assert box.mode.has(.b)
+	box.mode.clear(.a)
+	assert !box.mode.has(.a)
+	println("ok")
+}
+')
+	assert out == 'ok'
+}

--- a/vlib/v3/tests/fn_value_decl_type_test.v
+++ b/vlib/v3/tests/fn_value_decl_type_test.v
@@ -349,7 +349,7 @@ fn take(f fn (int) int) int {
 
 fn main() {
 	foo := other_callback
-	println(int_str(take(foo)))
+println(int_str(take(foo)))
 }
 '
 

--- a/vlib/v3/tests/generic_cross_module_arg_codegen_test.v
+++ b/vlib/v3/tests/generic_cross_module_arg_codegen_test.v
@@ -1,0 +1,149 @@
+import os
+
+const generic_cross_vexe = @VEXE
+const generic_cross_tests_dir = os.dir(@FILE)
+const generic_cross_v3_dir = os.dir(generic_cross_tests_dir)
+const generic_cross_vlib_dir = os.dir(generic_cross_v3_dir)
+const generic_cross_v3_src = os.join_path(generic_cross_v3_dir, 'v3.v')
+
+fn generic_cross_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_generic_cross_module_arg_test')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${generic_cross_vexe} -gc none -path "${generic_cross_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${generic_cross_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn generic_cross_write_file(root string, rel string, source string) {
+	path := os.join_path(root, rel)
+	os.mkdir_all(os.dir(path)) or { panic(err) }
+	os.write_file(path, source) or { panic(err) }
+}
+
+fn generic_cross_run_project(v3_bin string, name string, files map[string]string) string {
+	root := os.join_path(os.temp_dir(), 'v3_${name}_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	os.write_file(os.join_path(root, 'v.mod'), "Module { name: '${name}' }\n") or { panic(err) }
+	for rel, source in files {
+		generic_cross_write_file(root, rel, source)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	compile := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
+}
+
+fn test_imported_generic_arg_uses_qualified_local_type_in_specialized_signature() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_cross_module_arg', {
+		'wrap/wrap.v': 'module wrap\n\npub struct Box[T] {\npub:\n\tvalue T\n}\n'
+		'user/user.v': 'module user\n\nimport wrap\n\nstruct Local {\n\tn int\n}\n\nstruct Holder[T] {\n\tbox wrap.Box[T]\n}\n\nfn Holder.make[T](box wrap.Box[T]) Holder[T] {\n\treturn Holder[T]{\n\t\tbox: box\n\t}\n}\n\nfn take(box wrap.Box[Local]) int {\n\treturn box.value.n\n}\n\npub fn run() int {\n\tbox := wrap.Box[Local]{\n\t\tvalue: Local{\n\t\t\tn: 7\n\t\t}\n\t}\n\tholder := Holder.make(box)\n\treturn take(holder.box)\n}\n'
+		'main.v':      'module main\n\nimport user\n\nfn main() {\n\tprintln(int_str(user.run()))\n}\n'
+	})
+	assert out == '7'
+}
+
+fn test_nested_generic_return_infers_outer_static_method_arg() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_nested_return_arg', {
+		'wrap/wrap.v': 'module wrap\n\npub struct Box[T] {\npub:\n\tvalue T\n}\n\npub fn Box.new[T](value T) Box[T] {\n\treturn Box[T]{\n\t\tvalue: value\n\t}\n}\n'
+		'user/user.v': 'module user\n\nimport wrap\n\nstruct Local {\n\tn int\n}\n\nstruct Holder[T] {\n\tbox wrap.Box[T]\n}\n\nfn Holder.from[T](box wrap.Box[T]) Holder[T] {\n\treturn Holder[T]{\n\t\tbox: box\n\t}\n}\n\npub fn run() int {\n\tholder := Holder.from(wrap.Box.new(Local{\n\t\tn: 9\n\t}))\n\treturn holder.box.value.n\n}\n'
+		'main.v':      'module main\n\nimport user\n\nfn main() {\n\tprintln(int_str(user.run()))\n}\n'
+	})
+	assert out == '9'
+}
+
+fn test_specialized_receiver_method_body_specializes_nested_generic_method_return() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_nested_receiver_method_return', {
+		'printer/printer.v': 'module printer\n\npub struct Standard[W] {\npub:\n\tw W\n}\n\npub struct Sink[W] {\npub:\n\tw W\n}\n\npub fn Standard.new[W](w W) Standard[W] {\n\treturn Standard[W]{\n\t\tw: w\n\t}\n}\n\npub fn (standard Standard[W]) sink() Sink[W] {\n\treturn Sink[W]{\n\t\tw: standard.w\n\t}\n}\n\npub fn (sink Sink[W]) value() W {\n\treturn sink.w\n}\n'
+		'user/user.v':       'module user\n\nimport printer\n\nstruct Local {\n\tn int\n}\n\nstruct Worker[W] {\n\tstandard printer.Standard[W]\n}\n\nfn (worker Worker[W]) run() W {\n\tsink := worker.standard.sink()\n\treturn sink.value()\n}\n\npub fn run() int {\n\tworker := Worker[Local]{\n\t\tstandard: printer.Standard.new(Local{\n\t\t\tn: 11\n\t\t})\n\t}\n\treturn worker.run().n\n}\n'
+		'main.v':            'module main\n\nimport user\n\nfn main() {\n\tprintln(int_str(user.run()))\n}\n'
+	})
+	assert out == '11'
+}
+
+fn test_specialized_receiver_method_body_offsets_explicit_receiver_args() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_receiver_explicit_arg_offset', {
+		'printer/printer.v': 'module printer\n\npub struct Matcher {\npub:\n\tn int\n}\n\npub fn (m Matcher) clone() Matcher {\n\treturn m\n}\n\npub struct Standard[W] {\npub:\n\tw W\n}\n\npub struct Sink[W] {\npub:\n\tw W\n\tn int\n}\n\npub fn Standard.new[W](w W) Standard[W] {\n\treturn Standard[W]{\n\t\tw: w\n\t}\n}\n\npub fn (mut standard Standard[W]) sink_with_matcher(matcher Matcher) Sink[W] {\n\treturn Sink[W]{\n\t\tw: standard.w\n\t\tn: matcher.n\n\t}\n}\n\npub fn (sink Sink[W]) value() W {\n\treturn sink.w\n}\n\npub fn (sink Sink[W]) count() int {\n\treturn sink.n\n}\n'
+		'user/user.v':       'module user\n\nimport printer\n\nstruct Local {\n\tn int\n}\n\nstruct Worker[W] {\nmut:\n\tstandard printer.Standard[W]\n}\n\nfn (mut worker Worker[W]) run(matcher printer.Matcher) int {\n\tsink := worker.standard.sink_with_matcher(matcher.clone())\n\treturn sink.value().n + sink.count()\n}\n\npub fn run() int {\n\tmut worker := Worker[Local]{\n\t\tstandard: printer.Standard.new(Local{\n\t\t\tn: 13\n\t\t})\n\t}\n\treturn worker.run(printer.Matcher{\n\t\tn: 5\n\t})\n}\n'
+		'main.v':            'module main\n\nimport user\n\nfn main() {\n\tprintln(int_str(user.run()))\n}\n'
+	})
+	assert out == '18'
+}
+
+fn test_multiline_generic_builder_call_infers_all_arguments() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_multiline_builder_call', {
+		'worker/worker.v': 'module worker\n\npub struct Matcher {\npub:\n\tn int\n}\n\npub struct Searcher {\npub:\n\tn int\n}\n\npub fn Searcher.new() Searcher {\n\treturn Searcher{\n\t\tn: 3\n\t}\n}\n\npub struct Printer[W] {\npub:\n\tw W\n}\n\npub fn Printer.new[W](w W) Printer[W] {\n\treturn Printer[W]{\n\t\tw: w\n\t}\n}\n\npub struct Worker[W] {\npub:\n\tmatcher Matcher\n\tsearcher Searcher\n\tprinter Printer[W]\n}\n\npub struct Builder {}\n\npub fn Builder.new() Builder {\n\treturn Builder{}\n}\n\npub fn (builder Builder) build[W](matcher Matcher, searcher Searcher, printer Printer[W]) Worker[W] {\n\t_ = builder\n\treturn Worker[W]{\n\t\tmatcher: matcher\n\t\tsearcher: searcher\n\t\tprinter: printer\n\t}\n}\n'
+		'user/user.v':     'module user\n\nimport worker\n\nstruct Local {\n\tn int\n}\n\npub fn run() int {\n\tbuilder := worker.Builder.new()\n\tprinter := worker.Printer.new(Local{\n\t\tn: 17\n\t})\n\tmut w := builder.build(worker.Matcher{\n\t\tn: 2\n\t}, worker.Searcher.new(),\n\t\tprinter)\n\treturn w.matcher.n + w.searcher.n + w.printer.w.n\n}\n'
+		'main.v':          'module main\n\nimport user\n\nfn main() {\n\tprintln(int_str(user.run()))\n}\n'
+	})
+	assert out == '22'
+}
+
+fn test_generic_builder_call_infers_static_wrapped_nested_generic_arg() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_static_wrapped_builder_call', {
+		'worker/worker.v': 'module worker\n\npub struct Matcher {\npub:\n\tn int\n}\n\npub struct Searcher {\npub:\n\tn int\n}\n\npub fn Searcher.new() Searcher {\n\treturn Searcher{\n\t\tn: 3\n\t}\n}\n\npub struct Summary[W] {\npub:\n\tw W\n}\n\npub fn Summary.new[W](w W) Summary[W] {\n\treturn Summary[W]{\n\t\tw: w\n\t}\n}\n\npub enum PrinterKind {\n\tsummary\n}\n\npub struct Printer[W] {\npub:\n\tkind PrinterKind\n\tsummary Summary[W]\n}\n\npub fn Printer.summary[W](summary Summary[W]) Printer[W] {\n\treturn Printer[W]{\n\t\tkind: .summary\n\t\tsummary: summary\n\t}\n}\n\npub struct Worker[W] {\npub:\n\tmatcher Matcher\n\tsearcher Searcher\n\tprinter Printer[W]\n}\n\npub struct Builder {}\n\npub fn Builder.new() Builder {\n\treturn Builder{}\n}\n\npub fn (builder Builder) build[W](matcher Matcher, searcher Searcher, printer Printer[W]) Worker[W] {\n\t_ = builder\n\treturn Worker[W]{\n\t\tmatcher: matcher\n\t\tsearcher: searcher\n\t\tprinter: printer\n\t}\n}\n'
+		'user/user.v':     'module user\n\nimport worker\n\nstruct Local {\n\tn int\n}\n\npub fn run() int {\n\tbuilder := worker.Builder.new()\n\tsummary_printer := worker.Printer.summary(worker.Summary.new(Local{\n\t\tn: 19\n\t}))\n\tmut w := builder.build(worker.Matcher{\n\t\tn: 2\n\t}, worker.Searcher.new(),\n\t\tsummary_printer)\n\treturn w.matcher.n + w.searcher.n + w.printer.summary.w.n\n}\n'
+		'main.v':          'module main\n\nimport user\n\nfn main() {\n\tprintln(int_str(user.run()))\n}\n'
+	})
+	assert out == '24'
+}
+
+fn test_generic_struct_interface_dispatch_emits_required_methods() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_interface_dispatch', {
+		'sink/sink.v': 'module sink\n\npub interface Sink {\nmut:\n\tbegin() bool\n}\n\npub struct Box[W] {\nmut:\n\tvalue W\n\tcount int\n}\n\npub fn Box.new[W](value W) Box[W] {\n\treturn Box[W]{\n\t\tvalue: value\n\t}\n}\n\npub fn (mut b Box[W]) begin() bool {\n\tb.count++\n\treturn true\n}\n\npub fn use_sink(mut sink Sink) bool {\n\treturn sink.begin()\n}\n'
+		'user/user.v': 'module user\n\nimport sink\n\nstruct Local {\n\tn int\n}\n\npub fn run() int {\n\tmut boxed := sink.Box.new(Local{\n\t\tn: 29\n\t})\n\tok := sink.use_sink(&boxed)\n\treturn if ok { 29 } else { 0 }\n}\n'
+		'main.v':      'module main\n\nimport user\n\nfn main() {\n\tprintln(int_str(user.run()))\n}\n'
+	})
+	assert out == '29'
+}
+
+fn test_interface_generated_generic_method_body_preserves_cross_module_arg_type() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_interface_nested_cross_module_arg', {
+		'sink/sink.v': 'module sink\n\npub interface Sink {\nmut:\n\tbegin() int\n}\n\npub struct Values[^a] {\n\tn int\n}\n\npub struct Helper {}\n\npub fn (helper Helper) apply[^a, W](values Values[^a], mut writer W) int {\n\t_ = helper\n\t_ = values\n\t_ = writer\n\treturn 31\n}\n\npub struct Counter[W] {\nmut:\n\twriter W\n}\n\npub struct Summary[W] {\nmut:\n\tcounter Counter[W]\n}\n\npub fn Summary.new[W](writer W) Summary[W] {\n\treturn Summary[W]{\n\t\tcounter: Counter[W]{\n\t\t\twriter: writer\n\t\t}\n\t}\n}\n\npub struct Box[^a, W] {\nmut:\n\tsummary &^a Summary[W]\n\thelper Helper\n}\n\npub fn (mut b Box[^a, W]) begin[^a]() int {\n\tvalues := Values[^a]{\n\t\tn: 1\n\t}\n\treturn b.helper.apply(values, mut b.summary.counter)\n}\n\npub fn use_sink(mut sink Sink) int {\n\treturn sink.begin()\n}\n\npub fn use_summary[^a, W](summary &^a Summary[W]) int {\n\tmut boxed := Box[^a, W]{\n\t\tsummary: summary\n\t\thelper: Helper{}\n\t}\n\treturn use_sink(&boxed)\n}\n'
+		'user/user.v': 'module user\n\nimport sink\n\nstruct LocalWriter {\n\tn int\n}\n\npub fn run() int {\n\tmut summary := sink.Summary.new(LocalWriter{\n\t\tn: 37\n\t})\n\treturn sink.use_summary(&summary)\n}\n'
+		'main.v':      'module main\n\nimport user\n\nfn main() {\n\tprintln(int_str(user.run()))\n}\n'
+	})
+	assert out == '31'
+}
+
+fn test_generated_generic_body_late_transforms_lifetime_helper() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_interface_late_lifetime_helper', {
+		'sink/sink.v': "module sink\n\npub interface Sink {\nmut:\n\tbegin() int\n}\n\npub struct Link {\n\tn int\n}\n\npub struct Cache[^a] {\n\ttag &^a string\nmut:\n\tlink ?Link\n}\n\npub fn Cache.new[^a](tag &^a string) Cache[^a] {\n\treturn Cache[^a]{\n\t\ttag: tag\n\t}\n}\n\nfn marker_text() string {\n\treturn 'cache'\n}\n\nfn default_link_text() string {\n\treturn '\${marker_text()}'\n}\n\nfn default_link_n() int {\n\t_ := default_link_text()\n\treturn 43\n}\n\npub fn (mut cache Cache[^a]) fill[^a]() {\n\tcache.link = Link{\n\t\tn: default_link_n()\n\t}\n}\n\npub fn (mut cache Cache[^a]) get[^a]() ?&Link {\n\tif cache.link == none {\n\t\tcache.fill()\n\t}\n\treturn unsafe { &cache.link? }\n}\n\npub struct Box[W] {\n\tvalue W\n}\n\npub fn Box.new[W](value W) Box[W] {\n\treturn Box[W]{\n\t\tvalue: value\n\t}\n}\n\npub fn (mut b Box[W]) begin() int {\n\t_ = b\n\tlabel := 'cache'\n\tmut cache := Cache.new(&label)\n\tlink := cache.get() or { return 0 }\n\treturn link.n\n}\n\npub fn use_sink(mut sink Sink) int {\n\treturn sink.begin()\n}\n"
+		'user/user.v': 'module user\n\nimport sink\n\nstruct Local {\n\tn int\n}\n\npub fn run() int {\n\tmut boxed := sink.Box.new(Local{\n\t\tn: 5\n\t})\n\treturn sink.use_sink(&boxed)\n}\n'
+		'main.v':      'module main\n\nimport user\n\nfn main() {\n\tprintln(int_str(user.run()))\n}\n'
+	})
+	assert out == '43'
+}
+
+fn test_specialized_generic_mut_receiver_body_uses_emitted_method_name() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_specialized_mut_receiver_body_name', {
+		'printer/printer.v': 'module printer\n\npub struct Impl[W] {\n\tvalue W\nmut:\n\tcount int\n}\n\npub fn Impl.new[W](value W) Impl[W] {\n\treturn Impl[W]{\n\t\tvalue: value\n\t}\n}\n\npub fn (mut imp Impl[W]) run() int {\n\timp.bump()\n\treturn imp.count\n}\n\nfn (mut imp Impl[W]) bump() {\n\timp.count += 47\n}\n'
+		'user/user.v':       'module user\n\nimport printer\n\nstruct BufferWriter {}\n\npub fn run() int {\n\tmut imp := printer.Impl.new(BufferWriter{})\n\treturn imp.run()\n}\n'
+		'main.v':            'module main\n\nimport user\n\nfn main() {\n\tprintln(int_str(user.run()))\n}\n'
+	})
+	assert out == '47'
+}
+
+fn test_lifetime_receiver_method_body_specializes_nested_methods() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_lifetime_receiver_nested_methods', {
+		'printer/printer.v': 'module printer\n\npub struct Sink[^a, W] {\n\ttag &^a string\n\tvalue W\nmut:\n\tcount int\n}\n\npub fn Sink.new[^a, W](tag &^a string, value W) Sink[^a, W] {\n\treturn Sink[^a, W]{\n\t\ttag: tag\n\t\tvalue: value\n\t}\n}\n\npub fn (mut sink Sink[^a, W]) run[^a]() !int {\n\tsink.bump()!\n\tif sink.active() {\n\t\tsink.bump_more()!\n\t\treturn sink.count\n\t}\n\treturn 0\n}\n\nfn (mut sink Sink[^a, W]) bump[^a]() ! {\n\tsink.count += 50\n}\n\nfn (mut sink Sink[^a, W]) bump_more[^a]() ! {\n\tsink.count += 3\n}\n\nfn (sink Sink[^a, W]) active[^a]() bool {\n\treturn sink.tag.len > 0\n}\n'
+		'user/user.v':       "module user\n\nimport printer\n\nstruct BufferWriter {}\n\npub fn run() int {\n\tlabel := 'x'\n\tmut sink := printer.Sink.new(&label, BufferWriter{})\n\treturn sink.run() or { 0 }\n}\n"
+		'main.v':            'module main\n\nimport user\n\nfn main() {\n\tprintln(int_str(user.run()))\n}\n'
+	})
+	assert out == '53'
+}

--- a/vlib/v3/tests/ierror_promoted_methods_codegen_test.v
+++ b/vlib/v3/tests/ierror_promoted_methods_codegen_test.v
@@ -165,6 +165,67 @@ fn main() {
 	assert run.output.trim_space() == 'ok'
 }
 
+fn test_interface_dispatch_uses_nested_promoted_receiver_path() {
+	v3_bin := build_v3()
+
+	root := os.join_path(os.temp_dir(), 'v3_interface_nested_promoted_receiver_${os.getpid()}')
+	os.mkdir_all(root) or { panic(err) }
+	src := os.join_path(root, 'main.v')
+	os.write_file(src, 'interface HasNumber {
+	m() int
+}
+
+struct Inner {
+	n int
+}
+
+fn (inner Inner) m() int {
+	return inner.n
+}
+
+struct Mid {
+	pad int
+	Inner
+}
+
+struct Outer {
+	tag int
+	Mid
+}
+
+fn use(item HasNumber) int {
+	return item.m()
+}
+
+fn main() {
+	item := Outer{
+		tag: 100
+		Mid: Mid{
+			pad: 200
+			Inner: Inner{
+				n: 42
+			}
+		}
+	}
+	println(int_str(use(item)))
+}
+') or {
+		panic(err)
+	}
+
+	bin := os.join_path(os.temp_dir(), 'v3_interface_nested_promoted_receiver_out_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+
+	c_code := os.read_file('${bin}.c') or { '' }
+	assert c_code.contains('Inner__m((((Outer*)i->_object)->Mid).Inner)'), c_code
+
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '42'
+}
+
 fn test_ierror_embed_compatible_method_dependencies_are_marked_used() {
 	v3_bin := build_v3()
 

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -919,6 +919,24 @@ fn main() {
 	assert used['cb']
 }
 
+fn test_fn_value_call_callee_call_roots_inner_factory() {
+	used := mark_used_source('fn_value_call_callee_call', '
+fn cb() int {
+	return 7
+}
+
+fn make_cb() fn () int {
+	return cb
+}
+
+fn main() {
+	_ := make_cb()()
+}
+')
+	assert used['make_cb']
+	assert used['cb']
+}
+
 fn test_local_ident_reference_does_not_root_dead_function() {
 	mut a, mut tc := parse_checked_source('local_ident_shadow_dead_fn_cgen', '
 fn C.v3_dead_local_shadow_should_not_link() int

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -188,6 +188,112 @@ fn main() {
 	assert used['string__plus']
 }
 
+fn test_generic_struct_operator_roots_operator_dependencies() {
+	used := mark_used_source('generic_struct_operator_dependencies', '
+struct Time {
+	seconds int
+}
+
+fn (t Time) unix() int {
+	return t.seconds
+}
+
+fn (a Time) < (b Time) bool {
+	return a.unix() < b.unix()
+}
+
+fn min[T](a T, b T) T {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+fn main() {
+	a := Time{
+		seconds: 1
+	}
+	b := Time{
+		seconds: 2
+	}
+	_ := min(a, b)
+}
+')
+	assert used['Time.<']
+	assert used['Time.unix']
+}
+
+fn test_for_in_const_array_roots_receiver_method() {
+	used := mark_used_source('for_in_const_array_receiver_method', '
+enum FlagId {
+	after_context
+}
+
+struct Doc {}
+
+const flags = [FlagId.after_context]
+
+fn (id FlagId) doc_short() Doc {
+	_ := id
+	return Doc{}
+}
+
+fn (d Doc) replace(from string, to string) string {
+	_ := d
+	_ := from
+	_ := to
+	return "Show n lines after each match."
+}
+
+fn main() {
+	for flag in flags {
+		_ := flag.doc_short().replace("NUM", "n")
+	}
+}
+')
+	assert used['FlagId.doc_short']
+	assert used['Doc.replace']
+}
+
+fn test_error_argument_roots_nested_receiver_and_static_methods() {
+	used := mark_used_source('error_arg_nested_receiver_static_methods', '
+struct ErrorKind {}
+
+struct GlobError {
+	kind ErrorKind
+}
+
+struct Parser {}
+
+fn ErrorKind.unopened_alternates() ErrorKind {
+	return ErrorKind{}
+}
+
+fn (e GlobError) msg() string {
+	_ := e
+	return "unopened alternates"
+}
+
+fn (p Parser) mk_error(kind ErrorKind) GlobError {
+	return GlobError{
+		kind: kind
+	}
+}
+
+fn (mut p Parser) pop_alternate() ! {
+	return error(p.mk_error(ErrorKind.unopened_alternates()).msg())
+}
+
+fn main() {
+	mut p := Parser{}
+	p.pop_alternate() or { return }
+}
+')
+	assert used['Parser.mk_error']
+	assert used['GlobError.msg']
+	assert used['ErrorKind.unopened_alternates']
+}
+
 fn test_map_str_seeds_string_plus_runtime_helper() {
 	used := mark_used_source('map_str_string_plus', '
 fn render(m map[string]int) string {
@@ -319,6 +425,105 @@ fn main() {
 ')
 	assert used['Reader.read']
 	assert used['File.read']
+}
+
+fn test_module_global_interface_dispatch_keeps_dispatch_stub() {
+	mut a, mut tc := parse_checked_project('module_global_interface_dispatch', {
+		'main.v':               'module main
+
+import m
+
+fn main() {
+	m.error("x")
+}
+'
+		'm/default.c.v':        'module m
+
+__global default_logger &Logger
+
+pub fn error(s string) {
+	default_logger.error(s)
+}
+'
+		'm/logger_interface.v': 'module m
+
+pub enum Level {
+	info
+}
+
+pub interface Logger {
+	get_level() Level
+mut:
+	fatal(s string)
+	error(s string)
+	warn(s string)
+	info(s string)
+	debug(s string)
+	set_level(level Level)
+	set_always_flush(should_flush bool)
+	free()
+}
+'
+		'm/safe_log.v':         'module m
+
+pub struct BaseLog {}
+
+pub struct ThreadSafeLog {
+	BaseLog
+}
+
+pub fn (l BaseLog) get_level() Level {
+	_ := l
+	return .info
+}
+
+pub fn (mut l ThreadSafeLog) fatal(s string) {
+	_ := l
+	_ := s
+}
+
+pub fn (mut l ThreadSafeLog) error(s string) {}
+
+pub fn (mut l ThreadSafeLog) warn(s string) {
+	_ := l
+	_ := s
+}
+
+pub fn (mut l ThreadSafeLog) info(s string) {
+	_ := l
+	_ := s
+}
+
+pub fn (mut l ThreadSafeLog) debug(s string) {
+	_ := l
+	_ := s
+}
+
+pub fn (mut l ThreadSafeLog) set_level(level Level) {
+	_ := l
+	_ := level
+}
+
+pub fn (mut l ThreadSafeLog) set_always_flush(should_flush bool) {
+	_ := l
+	_ := should_flush
+}
+
+pub fn (mut l ThreadSafeLog) free() {
+	_ := l
+}
+'
+	}, 'main.v')
+	mut used := markused.mark_used(a, tc)
+	assert used['m.Logger.error']
+	assert used['m.ThreadSafeLog.error']
+	assert used['m.BaseLog.get_level'] == false
+	used = transform.transform_with_used(mut a, tc, used)
+	assert used['m.Logger.error']
+	mut g := cgen.FlatGen.new()
+	c_code := g.gen_with_used_options(a, used, tc, true)
+	assert c_code.contains('m__Logger__error(')
+	assert c_code.contains('case 1: m__ThreadSafeLog__error')
 }
 
 fn test_unreachable_interface_dispatch_stub_is_not_emitted_after_used_filter_transform() {
@@ -636,6 +841,50 @@ println(int_str(f() + 1))
 	assert run.output.trim_space() == '42'
 	c_code := os.read_file(bin + '.c') or { panic(err) }
 	assert c_code.contains('helper('), c_code
+}
+
+fn test_same_module_unqualified_homonym_call_uses_qualified_key() {
+	a, tc := parse_checked_project('same_module_unqualified_homonym_call', {
+		'main.v': 'module main
+
+import a
+
+fn main() {
+	println(a.glob_match(false))
+}
+'
+		'a/a.v':  'module a
+
+fn helper() string {
+	return "a"
+}
+
+pub fn glob_match(flag bool) string {
+	if !flag {
+		return helper()
+	}
+	return "other"
+}
+'
+		'b/b.v':  'module b
+
+fn helper() string {
+	return "b"
+}
+
+pub fn glob_match(flag bool) string {
+	if !flag {
+		return helper()
+	}
+	return "other"
+}
+'
+	}, 'main.v')
+	used := markused.mark_used(a, tc)
+	assert used['a.glob_match']
+	assert used['a.helper']
+	assert !used['b.glob_match']
+	assert !used['b.helper']
 }
 
 fn test_top_level_fn_value_respects_prior_local_shadow() {

--- a/vlib/v3/tests/option_arg_codegen_test.v
+++ b/vlib/v3/tests/option_arg_codegen_test.v
@@ -47,6 +47,33 @@ fn test_optional_argument_codegen_wraps_values_and_none() {
 	assert out == 'ok'
 }
 
+fn test_error_call_argument_expected_ierror_not_result_wrapper() {
+	v3_bin := build_v3()
+	source := "fn wrap(err IError) string {\n\treturn err.msg()\n}\n\nfn f() !string {\n\treturn wrap(error('x'))\n}\n\nfn main() {\n\ts := f() or { '' }\n\tassert s == 'x'\n\tprintln('ok')\n}\n"
+	out := run_good(v3_bin, 'error_call_argument_expected_ierror', source)
+	assert out == 'ok'
+	c_code := generated_c(v3_bin, 'error_call_argument_expected_ierror_c', source)
+	assert c_code.contains('wrap((IError){._typ = 0'), c_code
+	assert !c_code.contains('wrap((Optional_string)'), c_code
+}
+
+fn test_ierror_parameter_method_call_inside_static_method_uses_interface_method() {
+	v3_bin := build_v3()
+	source := "struct CommandError {\n\tmessage string\n}\n\nfn CommandError.io(ioerr IError) CommandError {\n\treturn CommandError{\n\t\tmessage: ioerr.msg()\n\t}\n}\n\nfn (err CommandError) msg() string {\n\treturn err.message\n}\n\nfn (err CommandError) code() int {\n\treturn 0\n}\n\nfn main() {\n\terr := CommandError.io(error('ok'))\n\tassert err.msg() == 'ok'\n\tprintln('ok')\n}\n"
+	out := run_good(v3_bin, 'ierror_static_method_param_msg', source)
+	assert out == 'ok'
+}
+
+fn test_ierror_as_expr_unboxes_concrete_payload() {
+	v3_bin := build_v3()
+	source := "struct InvalidPatternError {\n\tvalid_up_to int\n}\n\nfn (err InvalidPatternError) msg() string {\n\treturn 'invalid'\n}\n\nfn (err InvalidPatternError) code() int {\n\treturn 0\n}\n\nfn fail() !string {\n\treturn InvalidPatternError{\n\t\tvalid_up_to: 3\n\t}\n}\n\nfn main() {\n\tfail() or {\n\t\tperr := err as InvalidPatternError\n\t\tassert perr.valid_up_to == 3\n\t\tprintln('ok')\n\t\treturn\n\t}\n\tpanic('expected error')\n}\n"
+	out := run_good(v3_bin, 'ierror_as_expr_unbox_payload', source)
+	assert out == 'ok'
+	c_code := generated_c(v3_bin, 'ierror_as_expr_unbox_payload_c', source)
+	assert c_code.contains('._object'), c_code
+	assert !c_code.contains('InvalidPatternError perr = err;'), c_code
+}
+
 fn test_optional_abi_distinguishes_plain_t_name_from_specialized_generic() {
 	v3_bin := build_v3()
 	c_code := generated_c(v3_bin, 'optional_plain_t_name_abi',

--- a/vlib/v3/tests/optional_struct_lvalue_codegen_test.v
+++ b/vlib/v3/tests/optional_struct_lvalue_codegen_test.v
@@ -28,6 +28,64 @@ mut:
 	opt ?Inner
 }
 
+fn holder_from_inner(inner Inner) Holder {
+	return Holder{
+		opt: inner
+	}
+}
+
+struct Borrowed[^a] {
+	path &^a string
+}
+
+fn Borrowed.new[^a](path &^a string) Borrowed[^a] {
+	return Borrowed[^a]{
+		path: path
+	}
+}
+
+fn (b Borrowed[^a]) path_len[^a]() int {
+	return (*b.path).len
+}
+
+struct GenericHolder[^a, W] {
+	opt ?Borrowed[^a]
+	w   W
+}
+
+fn generic_holder_from_path[^a, W](path &^a string, w W) GenericHolder[^a, W] {
+	borrowed := Borrowed.new(path)
+	return GenericHolder[^a, W]{
+		opt: borrowed
+		w:   w
+	}
+}
+
+struct Link {
+	n int
+}
+
+struct LinkCache[^a] {
+	tag &^a string
+mut:
+	link ?Link
+}
+
+fn LinkCache.new[^a](tag &^a string) LinkCache[^a] {
+	return LinkCache[^a]{
+		tag: tag
+	}
+}
+
+fn (mut cache LinkCache[^a]) get[^a]() ?&Link {
+	if cache.link == none {
+		cache.link = Link{
+			n: 41
+		}
+	}
+	return unsafe { &cache.link? }
+}
+
 struct ResultHolder {
 mut:
 	res !Inner
@@ -101,6 +159,18 @@ fn main() {
 	}
 	holder.opt?.name = 'holder'
 	assert holder.opt?.name == 'holder'
+	wrapped_holder := holder_from_inner(Inner{
+		name: 'wrapped'
+	})
+	assert wrapped_holder.opt?.name == 'wrapped'
+	path_text := 'wrapped-path'
+	generic_holder := generic_holder_from_path(&path_text, 4)
+	generic_borrowed := generic_holder.opt or { panic('missing borrowed') }
+	assert generic_borrowed.path_len() == path_text.len
+	cache_tag := 'cache'
+	mut cache := LinkCache.new(&cache_tag)
+	link := cache.get() or { panic('missing link') }
+	assert link.n == 41
 	mut outer := ?Outer(Outer{})
 	outer?.inner.name = 'deep'
 	assert outer?.inner.name == 'deep'
@@ -143,6 +213,11 @@ fn main() {
 	c_code := os.read_file(bin + '.c') or { panic(err) }
 	assert c_code.contains('m.value.name ='), c_code
 	assert c_code.contains('holder.opt.value.name ='), c_code
+	assert c_code.contains('.opt = (Optional_Inner){.ok = true, .value = inner}')
+		|| c_code.contains('.opt = (Optional_main__Inner){.ok = true, .value = inner}'), c_code
+	assert c_code.contains('.opt = (Optional_Borrowed') && c_code.contains('.value = borrowed'), c_code
+	assert c_code.contains('if (!cache->link.ok)') || c_code.contains('if (!cache.link.ok)'), c_code
+	assert c_code.contains('&cache->link.value') || c_code.contains('&cache.link.value'), c_code
 	assert c_code.contains('outer.value.inner.name ='), c_code
 	assert c_code.contains('holder->opt.value.name =') || c_code.contains('holder.opt.value.name ='), c_code
 
@@ -164,8 +239,9 @@ fn main() {
 	}]
 	assert !mutate_result_guard.contains('return (Optional){.ok = false};'), mutate_result_guard
 	for line in c_code.split_into_lines() {
-		assert !(line.contains('__or_val_') && line.contains('.name =')), line
-		assert !(line.contains('__or_val_') && line.contains('.inner.name =')), line
+		assert !(line.contains('__or_val_') && line.contains('.name =') && !line.contains('= (')), line
+		assert !(line.contains('__or_val_') && line.contains('.inner.name =')
+			&& !line.contains('= (')), line
 	}
 
 	run := os.execute(bin)

--- a/vlib/v3/tests/ownership/ownership_test.v
+++ b/vlib/v3/tests/ownership/ownership_test.v
@@ -2399,6 +2399,26 @@ fn main() {
 	assert fail_array_append_unknown_len_read.exit_code != 0
 	assert fail_array_append_unknown_len_read.output.contains('use of moved value: `arr[*]`'), fail_array_append_unknown_len_read.output
 
+	ok_array_loop_dynamic_append_return := run_ownership_check(v3_bin,
+		'array_loop_dynamic_append_return', '
+fn split_parts(glob string) []string {
+	mut parts := []string{}
+	for i := 0; i < glob.len; i++ {
+		if glob[i] == `,` {
+			parts << glob[0..i].to_owned()
+		}
+	}
+	parts << glob[0..].to_owned()
+	return parts
+}
+
+fn main() {
+	parts := split_parts("a,b")
+	println(int_str(parts.len))
+}
+')
+	assert ok_array_loop_dynamic_append_return.exit_code == 0, ok_array_loop_dynamic_append_return.output
+
 	fail_array_pop_return := run_ownership_check(v3_bin, 'array_pop_returns_owned', '
 fn main() {
 	mut arr := ["item".to_owned()]

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -306,6 +306,33 @@ fn test_uppercase_index_condition_before_block_is_not_struct_init() {
 	assert foo_index_count == 1
 }
 
+fn test_uppercase_identifier_index_condition_before_block_is_not_struct_init() {
+	a := parse_parser_regression_source('uppercase_identifier_index_condition_block',
+		'const Foo = [true, false]\n\nfn main() {\n\tidx := 0\n\tif Foo[idx] {\n\t\tprintln("ok")\n\t}\n}\n')
+	mut foo_struct_inits := []string{}
+	mut foo_index_count := 0
+	for node in a.nodes {
+		match node.kind {
+			.struct_init {
+				if node.value == 'Foo' {
+					foo_struct_inits << node.value
+				}
+			}
+			.index {
+				if node.children_count == 2 {
+					base := a.child_node(&node, 0)
+					if base.kind == .ident && base.value == 'Foo' {
+						foo_index_count++
+					}
+				}
+			}
+			else {}
+		}
+	}
+	assert foo_struct_inits == []
+	assert foo_index_count == 1
+}
+
 fn test_local_sibling_types_are_predeclared_before_fields() {
 	a := parse_parser_regression_source('local_sibling_struct_fields',
 		'module main\n\nfn main() {\n\t_ := []struct {\n\t\tn int\n\t}{}\n\tstruct A {\n\t\tb &B\n\t}\n\tstruct B {\n\t\ta &A\n\t}\n}\n')

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -279,6 +279,33 @@ fn test_local_type_generic_call_type_arg_is_resolved() {
 	assert init_types == [local_row]
 }
 
+fn test_uppercase_index_condition_before_block_is_not_struct_init() {
+	a := parse_parser_regression_source('uppercase_index_condition_block',
+		'const Foo = [true]\n\nfn main() {\n\tif Foo[0] {\n\t\tprintln("ok")\n\t}\n}\n')
+	mut foo_struct_inits := []string{}
+	mut foo_index_count := 0
+	for node in a.nodes {
+		match node.kind {
+			.struct_init {
+				if node.value == 'Foo' {
+					foo_struct_inits << node.value
+				}
+			}
+			.index {
+				if node.children_count == 2 {
+					base := a.child_node(&node, 0)
+					if base.kind == .ident && base.value == 'Foo' {
+						foo_index_count++
+					}
+				}
+			}
+			else {}
+		}
+	}
+	assert foo_struct_inits == []
+	assert foo_index_count == 1
+}
+
 fn test_local_sibling_types_are_predeclared_before_fields() {
 	a := parse_parser_regression_source('local_sibling_struct_fields',
 		'module main\n\nfn main() {\n\t_ := []struct {\n\t\tn int\n\t}{}\n\tstruct A {\n\t\tb &B\n\t}\n\tstruct B {\n\t\ta &A\n\t}\n}\n')

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -66,6 +66,26 @@ fn fn_decl_param_pairs(a &flat.FlatAst, kind flat.NodeKind, name string) []strin
 	return []string{}
 }
 
+fn struct_init_values(a &flat.FlatAst) []string {
+	mut values := []string{}
+	for node in a.nodes {
+		if node.kind == .struct_init {
+			values << node.value
+		}
+	}
+	return values
+}
+
+fn cast_expr_values(a &flat.FlatAst) []string {
+	mut values := []string{}
+	for node in a.nodes {
+		if node.kind == .cast_expr {
+			values << node.value
+		}
+	}
+	return values
+}
+
 // test_interface_method_generic_type_only_param_is_not_parsed_as_name
 // validates this v3 regression case.
 fn test_interface_method_generic_type_only_param_is_not_parsed_as_name() {
@@ -85,6 +105,28 @@ fn test_lifetime_generic_suffixes_are_erased() {
 	]
 	assert fn_decl_param_pairs(a, .fn_decl, 'use') == ['item:Match[IgnoreMatch]']
 	assert fn_decl_param_pairs(a, .fn_decl, 'after') == []
+}
+
+fn test_lifetime_generic_struct_init_suffixes_are_erased() {
+	a := parse_parser_regression_source('lifetime_generic_struct_init_suffixes',
+		'struct Candidate {}\nstruct Slot[T] {}\n\nfn make[^a]() {\n\t_ := Candidate[^a]{}\n\t_ := Slot[int, ^a]{}\n}\n')
+	assert struct_init_values(a) == ['Candidate', 'Slot[int]']
+}
+
+fn test_c_pointer_cast_selector_parses_cast_before_selector() {
+	a := parse_parser_regression_source('c_pointer_cast_selector', 'module main
+
+@[typedef]
+struct C.log__Logger {
+mut:
+	_object voidptr
+}
+
+fn object(logger &C.log__Logger) voidptr {
+	return &C.log__Logger(logger)._object
+}
+')
+	assert '&C.log__Logger' in cast_expr_values(a)
 }
 
 fn test_c_function_anonymous_params_are_parsed_as_types() {

--- a/vlib/v3/tests/review_cgen_regressions_test.v
+++ b/vlib/v3/tests/review_cgen_regressions_test.v
@@ -114,6 +114,30 @@ pub fn free(values []int) int {
 	assert out == '5'
 }
 
+fn test_pointer_receiver_on_pointer_parameter_passes_parameter_directly() {
+	v3_bin := build_v3_review_cgen()
+	out := review_cgen_run_good(v3_bin, 'pointer_receiver_on_pointer_param', 'struct S {
+	n int
+}
+
+fn (s &S) value_plus(delta int) int {
+	return s.n + delta
+}
+
+fn use_pointer_param(s &S) int {
+	return s.value_plus(5)
+}
+
+fn main() {
+	s := S{
+		n: 37
+	}
+	println(int_str(use_pointer_param(&s)))
+}
+')
+	assert out == '42'
+}
+
 fn test_pointer_value_compatibility_keeps_qualified_struct_names() {
 	v3_bin := build_v3_review_cgen()
 	files := {

--- a/vlib/v3/tests/review_cgen_regressions_test.v
+++ b/vlib/v3/tests/review_cgen_regressions_test.v
@@ -1,0 +1,206 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn build_v3_review_cgen() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_review_cgen_regressions_test')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn review_cgen_write_project_file(root string, rel string, src string) {
+	path := os.join_path(root, rel)
+	os.mkdir_all(os.dir(path)) or { panic(err) }
+	os.write_file(path, src) or { panic(err) }
+}
+
+fn review_cgen_run_good(v3_bin string, name string, src string) string {
+	good_src := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	os.write_file(good_src, src) or { panic(err) }
+	good_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	compile := os.execute('${v3_bin} ${good_src} -b c -o ${good_bin}')
+	assert compile.exit_code == 0, '${name}: compile failed\n${compile.output}'
+	assert !compile.output.contains('C compilation failed'), '${name}: C compilation failed\n${compile.output}'
+	run := os.execute(good_bin)
+	assert run.exit_code == 0, '${name}: run failed\n${run.output}'
+	return run.output.trim_space()
+}
+
+fn review_cgen_run_good_project(v3_bin string, name string, files map[string]string, input string) string {
+	root := os.join_path(os.temp_dir(), 'v3_${name}_project')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(root) or { panic(err) }
+	for rel, src in files {
+		review_cgen_write_project_file(root, rel, src)
+	}
+	input_path := if input.len == 0 { root } else { os.join_path(root, input) }
+	good_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	compile := os.execute('${v3_bin} ${input_path} -b c -o ${good_bin}')
+	assert compile.exit_code == 0, '${name}: compile failed\n${compile.output}'
+	assert !compile.output.contains('C compilation failed'), '${name}: C compilation failed\n${compile.output}'
+	run := os.execute(good_bin)
+	assert run.exit_code == 0, '${name}: run failed\n${run.output}'
+	return run.output.trim_space()
+}
+
+fn review_cgen_run_bad_project(v3_bin string, name string, files map[string]string, input string, expected string) {
+	root := os.join_path(os.temp_dir(), 'v3_${name}_project')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(root) or { panic(err) }
+	for rel, src in files {
+		review_cgen_write_project_file(root, rel, src)
+	}
+	input_path := if input.len == 0 { root } else { os.join_path(root, input) }
+	bad_bin := os.join_path(os.temp_dir(), 'v3_${name}')
+	result := os.execute('${v3_bin} ${input_path} -b c -o ${bad_bin}')
+	assert result.exit_code != 0, '${name}: expected failure, got success\n${result.output}'
+	assert result.output.contains(expected), '${name}: expected `${expected}` in\n${result.output}'
+	assert !result.output.contains('C compilation failed'), '${name}: reached C compilation\n${result.output}'
+}
+
+fn test_module_qualified_free_call_is_not_rewritten_to_array_intrinsic() {
+	v3_bin := build_v3_review_cgen()
+	out := review_cgen_run_good_project(v3_bin, 'module_qualified_free_call', {
+		'v.mod':  'Module { name: "module_qualified_free_call" }\n'
+		'main.v': 'module main
+
+import m
+
+fn main() {
+	values := [2, 3]
+	println(int_str(m.free(values)))
+}
+'
+		'm/m.v':  'module m
+
+pub fn free(values []int) int {
+	return values[0] + values.len
+}
+'
+	}, 'main.v')
+	assert out == '4'
+}
+
+fn test_selectively_imported_free_call_is_not_rewritten_to_array_intrinsic() {
+	v3_bin := build_v3_review_cgen()
+	out := review_cgen_run_good_project(v3_bin, 'selective_import_free_call', {
+		'v.mod':  'Module { name: "selective_import_free_call" }\n'
+		'main.v': 'module main
+
+import m { free }
+
+fn main() {
+	values := [3, 4]
+	println(int_str(free(values)))
+}
+'
+		'm/m.v':  'module m
+
+pub fn free(values []int) int {
+	return values[0] + values.len
+}
+'
+	}, 'main.v')
+	assert out == '5'
+}
+
+fn test_pointer_value_compatibility_keeps_qualified_struct_names() {
+	v3_bin := build_v3_review_cgen()
+	files := {
+		'v.mod': 'Module { name: "pointer_value_qualified_names" }\n'
+		'a/a.v': 'module a
+
+pub struct Foo {
+pub:
+	value int
+}
+
+pub fn make() &Foo {
+	return &Foo{
+		value: 7
+	}
+}
+'
+		'b/b.v': 'module b
+
+pub struct Foo {
+pub:
+	value int
+}
+'
+	}
+	mut return_files := files.clone()
+	return_files['main.v'] = 'module main
+
+import a
+import b
+
+fn f() b.Foo {
+	return a.make()
+}
+
+fn main() {}
+'
+	review_cgen_run_bad_project(v3_bin, 'bad_pointer_value_cross_module_return', return_files,
+		'main.v', 'cannot return')
+	mut field_files := files.clone()
+	field_files['main.v'] = 'module main
+
+import a
+import b
+
+struct Holder {
+	item b.Foo
+}
+
+fn make_holder() Holder {
+	return Holder{
+		item: a.make()
+	}
+	}
+
+fn main() {}
+'
+	review_cgen_run_bad_project(v3_bin, 'bad_pointer_value_cross_module_field', field_files,
+		'main.v', 'cannot initialize field')
+}
+
+fn test_optional_single_letter_struct_keeps_concrete_payload_type() {
+	v3_bin := build_v3_review_cgen()
+	out := review_cgen_run_good(v3_bin, 'optional_single_letter_struct', 'struct T {
+	value int
+}
+
+fn maybe_t(ok bool) ?T {
+	if !ok {
+		return none
+	}
+	return T{
+		value: 7
+	}
+}
+
+fn result_t() !T {
+	return T{
+		value: 8
+	}
+}
+
+fn main() {
+	a := maybe_t(true) or { T{} }
+	b := result_t() or { T{} }
+	println(int_str(a.value + b.value))
+}
+')
+	assert out == '15'
+}

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -58,6 +58,13 @@ fn test_reject_pointer_expressions_for_value_returns() {
 		'cannot initialize field `x` with `&int`; expected `int`')
 }
 
+fn test_multi_return_tail_slots_use_return_compatibility() {
+	v3_bin := build_v3_review_checker()
+	if_out := run_good(v3_bin, 'good_multi_return_if_pointer_value_tail',
+		'struct S {\n\tn int\n}\nfn pick(ok bool) (S, int) {\n\ts := S{\n\t\tn: 5\n\t}\n\treturn if ok {\n\t\t&s\n\t\t1\n\t} else {\n\t\t&s\n\t\t2\n\t}\n}\nfn main() {\n\ta, b := pick(false)\n\tprintln(int_str(a.n) + "," + int_str(b))\n}\n')
+	assert if_out == '5,2'
+}
+
 fn test_numeric_alias_returns_preserve_integer_float_direction() {
 	v3_bin := build_v3_review_checker()
 	run_bad(v3_bin, 'bad_int_alias_float_return',

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -53,6 +53,19 @@ fn test_reject_pointer_expressions_for_value_returns() {
 		'fn f() int {\n\tx := 1\n\treturn &x\n}\nfn main() {}\n', 'cannot return `&int` as `int`')
 	run_bad(v3_bin, 'bad_result_return_pointer_to_value',
 		'fn f() !int {\n\tx := 1\n\treturn &x\n}\nfn main() {}\n', 'cannot return `&int` as `!int`')
+	run_bad(v3_bin, 'bad_field_pointer_to_value',
+		'struct S {\n\tx int\n}\n\nfn main() {\n\tx := 1\n\t_ := S{\n\t\tx: &x\n\t}\n}\n',
+		'cannot initialize field `x` with `&int`; expected `int`')
+}
+
+fn test_numeric_alias_returns_preserve_integer_float_direction() {
+	v3_bin := build_v3_review_checker()
+	run_bad(v3_bin, 'bad_int_alias_float_return',
+		'type Id = int\n\nfn f() Id {\n\treturn 1.5\n}\n\nfn main() {}\n',
+		'cannot return `f64` as `Id`')
+	out := run_good(v3_bin, 'good_float_alias_int_return',
+		'type Amount = f64\n\nfn f() Amount {\n\treturn 1\n}\n\nfn main() {\n\tprintln(f().str())\n}\n')
+	assert out == '1.0'
 }
 
 fn test_voidptr_params_reject_non_pointer_values() {

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -55,6 +55,15 @@ fn test_reject_pointer_expressions_for_value_returns() {
 		'fn f() !int {\n\tx := 1\n\treturn &x\n}\nfn main() {}\n', 'cannot return `&int` as `!int`')
 }
 
+fn test_voidptr_params_reject_non_pointer_values() {
+	v3_bin := build_v3_review_checker()
+	run_bad(v3_bin, 'bad_voidptr_scalar_arg', 'fn f(p voidptr) {}\n\nfn main() {\n\tf(1)\n}\n',
+		'cannot use `int` as argument 1 to `f`; expected `&void`')
+	out := run_good(v3_bin, 'good_voidptr_pointer_arg',
+		'fn f(p voidptr) int {\n\t_ = p\n\treturn 7\n}\n\nfn main() {\n\tx := 1\n\tprintln(int_str(f(&x)))\n}\n')
+	assert out == '7'
+}
+
 fn test_restrict_synthetic_hex_fallback_receivers() {
 	v3_bin := build_v3_review_checker()
 	run_bad(v3_bin, 'bad_struct_hex_method', 'struct S {}\nfn main() {\n\t_ := S{}.hex()\n}\n',

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -65,6 +65,21 @@ fn test_multi_return_tail_slots_use_return_compatibility() {
 	assert if_out == '5,2'
 }
 
+fn test_none_is_not_ierror_value() {
+	v3_bin := build_v3_review_checker()
+	run_bad(v3_bin, 'bad_none_ierror_param',
+		'fn take(e IError) {\n\t_ = e\n}\n\nfn main() {\n\ttake(none)\n}\n',
+		'cannot use `?void` as argument 1 to `take`; expected `IError`')
+	run_bad(v3_bin, 'bad_none_ierror_field',
+		'struct Holder {\n\terr IError\n}\n\nfn main() {\n\t_ := Holder{\n\t\terr: none\n\t}\n}\n',
+		'cannot initialize field `err` with `?void`; expected `IError`')
+	run_bad(v3_bin, 'bad_none_ierror_return',
+		'fn make() IError {\n\treturn none\n}\nfn main() {}\n', 'cannot return `?void` as `IError`')
+	out := run_good(v3_bin, 'good_none_option_context',
+		'fn maybe() ?int {\n\treturn none\n}\n\nfn main() {\n\tif maybe() == none {\n\t\tprintln("option")\n\t}\n}\n')
+	assert out == 'option'
+}
+
 fn test_numeric_alias_returns_preserve_integer_float_direction() {
 	v3_bin := build_v3_review_checker()
 	run_bad(v3_bin, 'bad_int_alias_float_return',

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -68,6 +68,13 @@ fn test_numeric_alias_returns_preserve_integer_float_direction() {
 	assert out == '1.0'
 }
 
+fn test_alias_with_nested_type_separator_stays_alias() {
+	v3_bin := build_v3_review_checker()
+	out := run_good(v3_bin, 'good_alias_nested_type_separator',
+		'type Bits = [1 | 2]int\n\nfn values() Bits {\n\treturn [1, 2, 3]!\n}\n\nfn main() {\n\tbits := values()\n\tprintln(int_str(bits[0] + bits[1] + bits[2]))\n}\n')
+	assert out == '6'
+}
+
 fn test_voidptr_params_reject_non_pointer_values() {
 	v3_bin := build_v3_review_checker()
 	run_bad(v3_bin, 'bad_voidptr_scalar_arg', 'fn f(p voidptr) {}\n\nfn main() {\n\tf(1)\n}\n',

--- a/vlib/v3/tests/selective_import_codegen_test.v
+++ b/vlib/v3/tests/selective_import_codegen_test.v
@@ -623,6 +623,45 @@ pub fn value() string {
 	assert !generated.contains('int foo__value(void);'), generated
 }
 
+fn test_module_local_error_method_signature_uses_module_key() {
+	v3_bin := selective_import_build_v3()
+	output, generated := selective_import_compile_run_with_extra(v3_bin,
+		'module_local_error_method_signature', 'module main
+
+import foo
+
+fn main() {
+	err := foo.make_error()
+	println(err.str())
+}
+', {
+		'foo/foo.v': 'module foo
+
+pub struct Error {
+	message string
+}
+
+pub fn make_error() Error {
+	return Error{
+		message: "local"
+	}
+}
+
+pub fn (err Error) msg() string {
+	return err.message
+}
+
+pub fn (err Error) str() string {
+	return err.msg()
+}
+'
+	})
+	assert output == 'local'
+	assert generated.contains('string foo__Error__msg(foo__Error err)'), generated
+	assert generated.contains('return foo__Error__msg(err);'), generated
+	assert !generated.contains('string foo__Error__msg(Error err)'), generated
+}
+
 fn test_selective_import_with_module_alias_keeps_symbol_authority() {
 	v3_bin := selective_import_build_v3()
 	output, generated := selective_import_compile_run(v3_bin, 'alias', 'module main

--- a/vlib/v3/tests/selector_expr_receiver_markused_codegen_test.v
+++ b/vlib/v3/tests/selector_expr_receiver_markused_codegen_test.v
@@ -42,6 +42,7 @@ fn main() {
 	generated := os.read_file(bin + '.c') or { panic(err) }
 	assert generated.contains('string__trim_space'), generated
 	assert generated.contains('string__to_upper'), generated
+	assert generated.contains('rune__to_upper'), generated
 
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output

--- a/vlib/v3/tests/string_interpolation_stringify_codegen_test.v
+++ b/vlib/v3/tests/string_interpolation_stringify_codegen_test.v
@@ -73,6 +73,68 @@ fn main() {
 	assert run.output.trim_space() == 'ok'
 }
 
+fn test_string_interpolation_method_call_marks_callee_used() {
+	v3_bin := string_interp_build_v3()
+	src := 'struct Begin {
+	value int
+}
+
+fn (b Begin) to_json() string {
+	return \'\${b.value}\'
+}
+
+struct Message {
+	begin Begin
+}
+
+fn (m Message) to_json() string {
+	return \'{"begin":\${m.begin.to_json()}}\'
+}
+
+fn main() {
+	msg := Message{
+		begin: Begin{
+			value: 7
+		}
+	}
+	println(msg.to_json())
+}
+'
+	bin := os.join_path(os.temp_dir(), 'v3_string_interp_method_markused_${os.getpid()}')
+	compile := compile_v3_input(v3_bin, 'v3_string_interp_method_markused', src, bin)
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '{"begin":7}'
+}
+
+fn test_string_interpolation_discovered_str_method_emits_helpers() {
+	v3_bin := string_interp_build_v3()
+	src := "struct Wrap {}
+
+fn str_helper() string {
+	return 'wrapped'
+}
+
+fn (w Wrap) str() string {
+	_ = w
+	return str_helper()
+}
+
+fn main() {
+	println('\${Wrap{}}')
+}
+"
+	bin := os.join_path(os.temp_dir(), 'v3_string_interp_str_helper_${os.getpid()}')
+	compile := compile_v3_input(v3_bin, 'v3_string_interp_str_helper', src, bin)
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'wrapped'
+}
+
 fn test_defer_string_interpolation_with_generic_type_arguments() {
 	v3_bin := string_interp_build_v3()
 	src := "struct Box[T] {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -1154,6 +1154,12 @@ fn test_pr_review_codegen_batch_twentytwo() {
 	dead := run_good(v3_bin, 'good_dead_generic_method_value_not_specialized',
 		'struct Box[T] {\n\tv T\n}\nfn (b Box[T]) doubled() T {\n\treturn b.v + b.v\n}\nstruct Pair {\n\ta int\n}\nfn run_int(cb fn () int) int {\n\treturn cb()\n}\nfn run_pair(cb fn () Pair) Pair {\n\treturn cb()\n}\nfn dead_fn() {\n\tp := Box[Pair]{\n\t\tv: Pair{\n\t\t\ta: 1\n\t\t}\n\t}\n\t_ := run_pair(p.doubled)\n}\nfn main() {\n\tb := Box[int]{\n\t\tv: 5\n\t}\n\tprintln(int_str(run_int(b.doubled)))\n}\n')
 	assert dead == '10'
+	// An unused interface must not force every structurally matching generic receiver method to
+	// specialize: `Box[NoPlus].run` satisfies `Runner.run`, but no value is boxed as `Runner` and
+	// the method body is invalid for `NoPlus`.
+	unused_iface := run_good(v3_bin, 'good_unused_interface_no_generic_method_specialization',
+		"interface Runner {\n\trun() int\n}\nstruct Box[T] {\n\tv T\n}\nfn (b Box[T]) run() int {\n\treturn b.v + b.v\n}\nstruct NoPlus {\n\tvalue int\n}\nfn main() {\n\tb := Box[NoPlus]{\n\t\tv: NoPlus{\n\t\t\tvalue: 1\n\t\t}\n\t}\n\t_ = b\n\tprintln('ok')\n}\n")
+	assert unused_iface == 'ok'
 	// A reachable generic method value of any instance still specializes correctly.
 	live := run_good(v3_bin, 'good_reachable_generic_method_value_specialized',
 		'struct Box[T] {\n\tv T\n}\nfn (b Box[T]) first() T {\n\treturn b.v\n}\nstruct Pair {\n\ta int\n}\nfn run_pair(cb fn () Pair) Pair {\n\treturn cb()\n}\nfn main() {\n\tp := Box[Pair]{\n\t\tv: Pair{\n\t\t\ta: 7\n\t\t}\n\t}\n\tr := run_pair(p.first)\n\tprintln(int_str(r.a))\n}\n')

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -464,6 +464,9 @@ fn test_statement_if_branch_tails_are_not_value_checked() {
 
 fn test_multi_return_if_tail_infers_common_type() {
 	v3_bin := build_v3()
+	result_error := run_good(v3_bin, 'good_result_multi_return_error_return',
+		"fn pair(fail bool) !(int, int) {\n\tif fail {\n\t\treturn error('x')\n\t}\n\treturn 1, 2\n}\nfn main() {\n\ta, b := pair(false) or { panic(err.msg()) }\n\tprintln(int_str(a + b))\n\t_, _ := pair(true) or {\n\t\tprintln(err.msg())\n\t\treturn\n\t}\n}\n")
+	assert result_error == '3\nx'
 	if_tail := run_good(v3_bin, 'good_multi_return_if_common_pointer_tail',
 		'fn main() {\n\tx := 7\n\tp, n := if false {\n\t\tnil\n\t\t0\n\t} else {\n\t\t&x\n\t\t1\n\t}\n\tprintln(typeof(p).name)\n\tprintln(int_str(n))\n}\n')
 	assert if_tail == '&void\n1'
@@ -581,6 +584,15 @@ fn test_local_type_names_include_nested_block_scope() {
 	assert mutual_local == 'ok'
 }
 
+fn test_module_local_error_type_shadows_builtin_error() {
+	v3_bin := build_v3()
+	out := run_good_project(v3_bin, 'good_module_local_error_type', {
+		'main.v':       'module main\n\nimport fixture\n\nfn main() {\n\terr := fixture.make_error()\n\tprintln(err.msg())\n}\n'
+		'fixture/fi.v': "module fixture\n\npub struct Error {\n\tmessage string\n}\n\npub fn make_error() Error {\n\treturn Error{\n\t\tmessage: 'local'\n\t}\n}\n\npub fn (err Error) msg() string {\n\treturn err.message\n}\n"
+	}, 'main.v')
+	assert out == 'local'
+}
+
 fn test_bool_match_single_branch_is_exhaustive() {
 	v3_bin := build_v3()
 	out := run_good(v3_bin, 'good_bool_match_single_branch_exhaustive',
@@ -632,6 +644,9 @@ fn test_generic_struct_receiver_and_heap_init() {
 	good_method := run_good(v3_bin, 'good_generic_method_instances',
 		"struct Box[T] {\n\tval T\n}\nfn (b Box[T]) get() T {\n\treturn b.val\n}\nfn main() {\n\tbi := Box[int]{\n\t\tval: 42\n\t}\n\tbs := Box[string]{\n\t\tval: 'hi'\n\t}\n\tprintln(int_str(bi.get()))\n\tprintln(bs.get())\n}\n")
 	assert good_method == '42\nhi'
+	generic_return := run_good(v3_bin, 'good_generic_return_open_struct_param',
+		'struct Match[T] {\n\tvalue T\n\thas   bool\n}\nfn choose[T](use_second bool, first Match[T], second Match[T]) Match[T] {\n\tif use_second {\n\t\treturn second\n\t}\n\treturn first\n}\nfn (m Match[T]) or[T](other Match[T]) Match[T] {\n\tif m.has {\n\t\treturn m\n\t}\n\treturn other\n}\nfn main() {\n\ta := Match[int]{\n\t\tvalue: 1\n\t\thas: true\n\t}\n\tb := Match[int]{\n\t\tvalue: 2\n\t}\n\tprintln(int_str(choose(true, a, b).value))\n\tprintln(int_str(b.or(a).value))\n}\n')
+	assert generic_return == '2\n1'
 	// A bare generic literal (`Box{..}` / `&Box{..}`) specializes to the expected
 	// concrete instance — and the heap literal must materialize the same concrete
 	// C type (`Box_int`) as the value literal, not the bare template.

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1034,7 +1034,10 @@ fn (mut t Transformer) transform_infix_optional_none_ops(_id flat.NodeId, node f
 		}
 		return eq
 	}
-	opt_type := t.node_type(opt_id)
+	mut opt_type := t.optional_result_expr_type_name(opt_id)
+	if opt_type.len == 0 {
+		opt_type = t.node_type(opt_id)
+	}
 	if !t.is_optional_type_name(opt_type) {
 		return none
 	}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -2141,6 +2141,9 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 			}
 		}
 		parsed := t.tc.parse_type(clean_typ)
+		if parsed is types.MultiReturn {
+			return t.lower_multi_return_str(expr, parsed, clean_typ)
+		}
 		if parsed is types.Enum {
 			if method := t.enum_str_method_name(clean_typ) {
 				return t.make_call_typed(method, arr1(expr), 'string')
@@ -2276,13 +2279,33 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 	}
 }
 
+// lower_multi_return_str formats a multi-return value as `(a, b, ...)`.
+fn (mut t Transformer) lower_multi_return_str(expr flat.NodeId, multi types.MultiReturn, typ string) flat.NodeId {
+	base := t.stable_transformed_expr_for_reuse(expr, typ, 'multi_ret_str')
+	mut result := t.make_string_literal('(')
+	for i, item in multi.types {
+		if i > 0 {
+			result = t.string_plus(result, t.make_string_literal(', '))
+		}
+		item_type := item.name()
+		mut item_str := t.wrap_string_conversion(t.make_selector(base, 'arg${i}', item_type),
+			item_type)
+		if item is types.String {
+			item_str = t.string_plus(t.string_plus(t.make_string_literal("'"), item_str),
+				t.make_string_literal("'"))
+		} else if item is types.Rune {
+			item_str = t.string_plus(t.string_plus(t.make_string_literal('`'), item_str),
+				t.make_string_literal('`'))
+		}
+		result = t.string_plus(result, item_str)
+	}
+	return t.string_plus(result, t.make_string_literal(')'))
+}
+
 fn (t &Transformer) stringify_aggregate_type_name(typ string) ?string {
 	clean := typ.trim_space()
 	if clean.len == 0 {
 		return none
-	}
-	if clean in t.structs || clean in t.sum_types {
-		return clean
 	}
 	if clean.contains('.') {
 		if !isnil(t.tc) && (clean in t.tc.structs || clean in t.tc.sum_types) {
@@ -2298,6 +2321,17 @@ fn (t &Transformer) stringify_aggregate_type_name(typ string) ?string {
 		if !isnil(t.tc) && (qname in t.tc.structs || qname in t.tc.sum_types) {
 			return qname
 		}
+	}
+	if qualified := t.qualified_types[clean] {
+		if qualified in t.structs || qualified in t.sum_types {
+			return qualified
+		}
+		if !isnil(t.tc) && (qualified in t.tc.structs || qualified in t.tc.sum_types) {
+			return qualified
+		}
+	}
+	if clean in t.structs || clean in t.sum_types {
+		return clean
 	}
 	if !isnil(t.tc) && (clean in t.tc.structs || clean in t.tc.sum_types) {
 		return clean

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -868,9 +868,12 @@ fn (t &Transformer) call_param_offset(call_name string, node flat.Node, params [
 	}
 	method_name := t.resolve_receiver_method_name(base_id, fn_node.value)
 	if method_name.len == 0 {
+		if t.receiver_method_param_offset(base_id, node, params, '') == 1 {
+			return 1
+		}
 		return 0
 	}
-	if t.receiver_method_param_offset(base_id, node, params) == 1 {
+	if t.receiver_method_param_offset(base_id, node, params, method_name) == 1 {
 		return 1
 	}
 	if call_name.len == 0 || call_name == method_name || call_name == c_name(method_name) {
@@ -5307,7 +5310,7 @@ fn (mut t Transformer) transform_receiver_method_args_with_base(node flat.Node, 
 	mut args := []flat.NodeId{cap: int(node.children_count)}
 	args << base
 	params := t.call_param_types(method_name)
-	param_offset := t.receiver_method_param_offset(base, node, params)
+	param_offset := t.receiver_method_param_offset(base, node, params, method_name)
 	explicit_args := int(node.children_count) - 1
 	expected_explicit := params.len - param_offset
 	is_variadic := t.call_is_variadic(method_name) || (params.len > 0
@@ -5368,7 +5371,7 @@ fn (mut t Transformer) transform_receiver_method_args_with_base(node flat.Node, 
 }
 
 // receiver_method_param_offset supports receiver method param offset handling for Transformer.
-fn (t &Transformer) receiver_method_param_offset(base_id flat.NodeId, node flat.Node, params []types.Type) int {
+fn (t &Transformer) receiver_method_param_offset(base_id flat.NodeId, node flat.Node, params []types.Type, method_name string) int {
 	if params.len == 0 {
 		return 0
 	}
@@ -5376,7 +5379,8 @@ fn (t &Transformer) receiver_method_param_offset(base_id flat.NodeId, node flat.
 	first_type := t.normalize_type_alias(params[0].name())
 	clean_first := if first_type.starts_with('&') { first_type[1..] } else { first_type }
 	clean_base := if base_type.starts_with('&') { base_type[1..] } else { base_type }
-	if clean_first == clean_base
+	if receiver_param_types_match(clean_first, clean_base)
+		|| receiver_param_matches_method_name(clean_first, method_name)
 		|| t.normalize_type_alias(clean_first) == t.normalize_type_alias(clean_base)
 		|| clean_first.all_after_last('.') == clean_base.all_after_last('.') {
 		return 1
@@ -5385,6 +5389,62 @@ fn (t &Transformer) receiver_method_param_offset(base_id flat.NodeId, node flat.
 		return 1
 	}
 	return 0
+}
+
+fn receiver_param_matches_method_name(first string, method_name string) bool {
+	if first.len == 0 || method_name.len == 0 || !method_name.contains('.') {
+		return false
+	}
+	mut receiver := method_name.all_before_last('.')
+	if receiver.len == 0 {
+		return false
+	}
+	if receiver.starts_with('&') {
+		receiver = receiver[1..]
+	}
+	mut first_base := first
+	first_generic_base, _, first_is_generic := generic_app_parts(first)
+	if first_is_generic {
+		first_base = first_generic_base
+	}
+	mut receiver_base := receiver
+	receiver_generic_base, _, receiver_is_generic := generic_app_parts(receiver)
+	if receiver_is_generic {
+		receiver_base = receiver_generic_base
+	}
+	first_short := first_base.all_after_last('.')
+	receiver_short := receiver_base.all_after_last('.')
+	return first_base == receiver_base || first_short == receiver_short
+		|| receiver_short.starts_with('${first_short}_')
+		|| c_name(receiver_base).starts_with('${c_name(first_base)}_')
+}
+
+fn receiver_param_types_match(first string, base string) bool {
+	if first == base {
+		return true
+	}
+	first_base, first_args, first_ok := generic_app_parts(first)
+	base_base, base_args, base_ok := generic_app_parts(base)
+	if !first_ok || !base_ok || first_args.len != base_args.len {
+		return false
+	}
+	if first_base != base_base && first_base.all_after_last('.') != base_base.all_after_last('.') {
+		return false
+	}
+	for i, first_arg in first_args {
+		base_arg := base_args[i]
+		if first_arg == base_arg {
+			continue
+		}
+		if generic_type_arg_short(first_arg) == generic_type_arg_short(base_arg) {
+			continue
+		}
+		if c_name(first_arg) == c_name(base_arg) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // try_lower_string_method_call supports try lower string method call handling for Transformer.

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -3207,7 +3207,7 @@ fn (mut t Transformer) try_lower_flag_enum_call(node flat.Node) ?flat.NodeId {
 // so the copy is produced simply by evaluating the receiver (it is copied when assigned or
 // passed by value). Collection/string clones are lowered earlier, and a user-defined clone()
 // method is handled by try_lower_receiver_method_call before this runs.
-fn (mut t Transformer) try_lower_struct_clone_method_call(call_id flat.NodeId, node flat.Node) ?flat.NodeId {
+fn (mut t Transformer) try_lower_struct_clone_method_call(_call_id flat.NodeId, node flat.Node) ?flat.NodeId {
 	if node.children_count == 0 {
 		return none
 	}

--- a/vlib/v3/transform/interface.v
+++ b/vlib/v3/transform/interface.v
@@ -130,10 +130,43 @@ fn (mut t Transformer) transform_global_amp_interface_cast(node flat.Node, targe
 	})
 }
 
+fn (t &Transformer) mut_param_address_source_type(id flat.NodeId) ?string {
+	if int(id) < 0 {
+		return none
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind != .prefix || node.op != .amp || node.children_count != 1 {
+		return none
+	}
+	child := t.a.nodes[int(t.a.child(&node, 0))]
+	if child.kind != .ident || child.value.len == 0 || !t.mut_param_values[child.value] {
+		return none
+	}
+	mut base_type := t.var_type(child.value)
+	if base_type.len == 0 {
+		base_type = t.raw_var_type(child.value)
+	}
+	base_type = base_type.trim_space()
+	if base_type.starts_with('mut ') {
+		base_type = base_type[4..].trim_space()
+	}
+	if base_type.len == 0 {
+		return none
+	}
+	clean := t.normalize_type_alias(base_type)
+	if clean.starts_with('&') {
+		return clean
+	}
+	return '&${clean}'
+}
+
 // make_interface_literal_from_expr converts make interface literal from expr data for transform.
 fn (mut t Transformer) make_interface_literal_from_expr(id flat.NodeId, iface_name string, share_source bool) ?flat.NodeId {
 	fields := t.tc.interface_fields[iface_name] or { []types.StructField{} }
-	source_type := t.node_type(id)
+	mut source_type := t.node_type(id)
+	if adjusted := t.mut_param_address_source_type(id) {
+		source_type = adjusted
+	}
 	if source_type.len == 0 {
 		return none
 	}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -120,8 +120,55 @@ fn (mut t Transformer) monomorphize_pass() []string {
 		}
 	}
 	t.rewrite_generic_call_sites(decls, generic_call_sites)
+	if t.refresh_decl_assign_types_after_generic_rewrite() {
+		t.generic_call_spec_cache = map[int]GenericCallSpec{}
+		t.generic_call_spec_misses = map[int]bool{}
+		extra_call_sites := t.collect_generic_call_sites_after_type_refresh(decls, template_nodes,
+			ignored_nodes, mut emitted, mut generated, mut recorded_call_sites)
+		if extra_call_sites.len > 0 {
+			t.rewrite_generic_call_sites(decls, extra_call_sites)
+			t.refresh_decl_assign_types_after_generic_rewrite()
+		}
+	}
 	t.erase_generic_fn_decls(decls)
 	return generated
+}
+
+fn (mut t Transformer) collect_generic_call_sites_after_type_refresh(decls map[string]GenericFnDecl, template_nodes []bool, ignored_nodes []bool, mut emitted map[string]bool, mut generated []string, mut recorded_call_sites map[int]bool) []GenericCallSite {
+	mut sites := []GenericCallSite{}
+	t.ensure_node_module_map()
+	node_count := t.a.nodes.len
+	for i in 0 .. node_count {
+		if (i < template_nodes.len && template_nodes[i])
+			|| (i < ignored_nodes.len && ignored_nodes[i]) {
+			continue
+		}
+		node := t.a.nodes[i]
+		if node.kind != .call {
+			continue
+		}
+		call_module := t.node_module_or(i, '')
+		decl_key, args := t.cached_generic_call_specialization(flat.NodeId(i), node, call_module,
+			decls) or { continue }
+		decl := decls[decl_key] or { continue }
+		if !t.call_has_source_generic_args(node) && t.generic_args_contain_alias(args, decl.module) {
+			t.a.nodes[i].value = args.join(', ')
+		}
+		if i !in recorded_call_sites {
+			sites << GenericCallSite{
+				id:     flat.NodeId(i)
+				module: call_module
+			}
+			recorded_call_sites[i] = true
+		}
+		spec_key := generic_fn_spec_key(decl_key, args)
+		if emitted[spec_key] {
+			continue
+		}
+		generated << t.generated_fn_used_names(decl, t.emit_generic_fn_specialization(decl, args), args)
+		emitted[spec_key] = true
+	}
+	return sites
 }
 
 fn (mut t Transformer) seed_generic_specialization_args(decls map[string]GenericStructDecl) {
@@ -347,17 +394,19 @@ fn (mut t Transformer) specialize_generic_struct_methods(struct_decls map[string
 				if c_name('${spec}.${method}') !in t.used_struct_operator_fns {
 					continue
 				}
-			} else {
+			} else if !t.generic_struct_method_needed_for_interface(spec, method) {
 				mvkey := '${spec}.${method}'
-				if isnil(t.tc) || mvkey !in t.tc.generic_method_value_info {
-					continue
-				}
-				// Only specialize a method value the checker recorded inside a *reachable*
-				// function: markused seeds the concrete instance key (`Box[int].report`) into
-				// `used_fns` per reachable function, so one used only in dead code is skipped —
-				// its body may be invalid for that type argument and would fail C compilation.
-				if t.used_fns.len > 0 && mvkey !in t.used_fns && c_name(mvkey) !in t.used_fns {
-					continue
+				if mvkey !in t.used_fns && c_name(mvkey) !in t.used_fns {
+					if isnil(t.tc) || mvkey !in t.tc.generic_method_value_info {
+						continue
+					}
+					// Only specialize a method value the checker recorded inside a *reachable*
+					// function: markused seeds the concrete instance key (`Box[int].report`) into
+					// `used_fns` per reachable function, so one used only in dead code is skipped —
+					// its body may be invalid for that type argument and would fail C compilation.
+					if t.used_fns.len > 0 && mvkey !in t.used_fns && c_name(mvkey) !in t.used_fns {
+						continue
+					}
 				}
 			}
 			if decl.node.generic_params.len != 0 {
@@ -382,8 +431,26 @@ fn (t &Transformer) needs_generic_struct_method_specialization(decls map[string]
 	if !isnil(t.tc) && t.tc.generic_method_value_info.len > 0 {
 		return true
 	}
+	if !isnil(t.tc) && t.tc.interface_names.len > 0 {
+		return true
+	}
 	for decl_key, _ in decls {
 		if decl_key.contains('.') && is_operator_method_name(decl_key.all_after_last('.')) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (t &Transformer) generic_struct_method_needed_for_interface(spec string, method string) bool {
+	if isnil(t.tc) || spec.len == 0 || method.len == 0 {
+		return false
+	}
+	for iface_name, _ in t.tc.interface_names {
+		if method !in t.tc.interface_abstract_method_names(iface_name) {
+			continue
+		}
+		if t.tc.named_type_implements_interface(spec, iface_name) {
 			return true
 		}
 	}
@@ -667,10 +734,11 @@ fn (mut t Transformer) collect_generic_struct_spec_from_type(typ string, module_
 		return
 	}
 	spec_base := t.generic_struct_spec_base_name(base, module_name, file_name, decls) or { return }
-	spec_name := '${spec_base}[${args.join(', ')}]'
+	scoped_args := t.generic_struct_args_in_scope(args, module_name, file_name)
+	spec_name := '${spec_base}[${scoped_args.join(', ')}]'
 	specs[spec_name] = spec_base
 	spec_module := if decl := decls[spec_base] { decl.module } else { module_name }
-	t.record_generic_specialization_args_in_module(spec_base, spec_module, args)
+	t.record_generic_specialization_args_in_module(spec_base, spec_module, scoped_args)
 }
 
 fn (mut t Transformer) collect_generic_sum_specs(decls map[string]GenericSumDecl, mut specs map[string]GenericSpecContext) {
@@ -831,6 +899,28 @@ fn (t &Transformer) generic_sum_spec_base_name(base string, module_name string, 
 fn (mut t Transformer) generic_sum_spec_name_in_scope(base string, args []string, module_name string, file_name string) string {
 	scoped_args := t.generic_sum_args_in_scope(args, module_name, file_name)
 	return '${base}[${scoped_args.join(', ')}]'
+}
+
+fn (mut t Transformer) generic_struct_args_in_scope(args []string, module_name string, file_name string) []string {
+	if isnil(t.tc) {
+		return args.clone()
+	}
+	old_module := t.tc.cur_module
+	old_file := t.tc.cur_file
+	t.tc.cur_module = module_name
+	t.tc.cur_file = file_name
+	mut scoped := []string{cap: args.len}
+	for arg in args {
+		parsed := t.tc.parse_type(arg)
+		scoped << if parsed is types.Unknown {
+			t.normalize_sum_variant_type(arg, module_name, [])
+		} else {
+			parsed.name()
+		}
+	}
+	t.tc.cur_module = old_module
+	t.tc.cur_file = old_file
+	return scoped
 }
 
 fn (mut t Transformer) generic_sum_args_in_scope(args []string, module_name string, file_name string) []string {
@@ -1183,7 +1273,106 @@ fn (mut t Transformer) generated_fn_used_names(decl GenericFnDecl, clone_id flat
 	qname := transform_qualified_fn_name(decl.module, clone.value)
 	mut names := [clone.value, qname, c_name(clone.value), c_name(qname)]
 	names << specialized_generic_fn_signature_aliases(decl, args)
+	old_module := t.cur_module
+	old_file := t.cur_file
+	t.cur_module = decl.module
+	t.cur_file = decl.file
+	names << t.generated_fn_body_call_names(clone_id)
+	for name in names {
+		t.mark_fn_used_name(name)
+	}
+	t.cur_module = old_module
+	t.cur_file = old_file
 	return names
+}
+
+fn (mut t Transformer) generated_fn_body_call_names(root flat.NodeId) []string {
+	mut names := []string{}
+	mut seen := map[string]bool{}
+	t.collect_generated_fn_body_call_names(root, mut names, mut seen)
+	return names
+}
+
+fn (mut t Transformer) collect_generated_fn_body_call_names(id flat.NodeId, mut names []string, mut seen map[string]bool) {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .call {
+		call_name := t.generated_call_name_for_used(id, node)
+		if call_name.len > 0 {
+			t.push_generated_used_name(call_name, mut names, mut seen)
+		}
+	}
+	for i in 0 .. node.children_count {
+		t.collect_generated_fn_body_call_names(t.a.child(&node, i), mut names, mut seen)
+	}
+}
+
+fn (mut t Transformer) generated_call_name_for_used(id flat.NodeId, node flat.Node) string {
+	if node.children_count > 0 {
+		fn_id := t.a.child(&node, 0)
+		fn_node := t.a.nodes[int(fn_id)]
+		if fn_node.kind == .selector && fn_node.value.len > 0 && fn_node.children_count > 0 {
+			base_id := t.a.child(&fn_node, 0)
+			base_type := t.node_type(base_id).trim_left('&')
+			_, _, base_is_generic := generic_app_parts(base_type)
+			if base_is_generic {
+				return '${base_type}.${fn_node.value}'
+			}
+		}
+	}
+	call_name := t.call_name_for_node(id, node)
+	if call_name.len > 0 {
+		return call_name
+	}
+	if node.children_count == 0 {
+		return ''
+	}
+	fn_id := t.a.child(&node, 0)
+	fn_node := t.a.nodes[int(fn_id)]
+	if fn_node.kind == .ident && fn_node.value.len > 0 {
+		return fn_node.value
+	}
+	if fn_node.kind == .selector && fn_node.value.len > 0 && fn_node.children_count > 0 {
+		base_id := t.a.child(&fn_node, 0)
+		method_name := t.resolve_receiver_method_name(base_id, fn_node.value)
+		if method_name.len > 0 {
+			return method_name
+		}
+		base_type := t.node_type(base_id).trim_left('&')
+		_, _, base_is_generic := generic_app_parts(base_type)
+		if base_is_generic {
+			return '${base_type}.${fn_node.value}'
+		}
+	}
+	return ''
+}
+
+fn (mut t Transformer) push_generated_used_name(name string, mut names []string, mut seen map[string]bool) {
+	if name.len == 0 || seen[name] {
+		return
+	}
+	seen[name] = true
+	names << name
+	cn := c_name(name)
+	if cn != name && !seen[cn] {
+		seen[cn] = true
+		names << cn
+	}
+	if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin'
+		&& !name.contains('.') && !name.contains('__') {
+		qname := '${t.cur_module}.${name}'
+		if !seen[qname] {
+			seen[qname] = true
+			names << qname
+		}
+		qcn := c_name(qname)
+		if qcn != qname && !seen[qcn] {
+			seen[qcn] = true
+			names << qcn
+		}
+	}
 }
 
 fn (mut t Transformer) specialize_cloned_fn_signature(clone_id flat.NodeId, decl GenericFnDecl, args []string) {
@@ -1432,6 +1621,36 @@ fn (mut t Transformer) rewrite_generic_call_sites(decls map[string]GenericFnDecl
 			t.rewrite_generic_plain_call(site.id, node, decl, args)
 		}
 	}
+}
+
+fn (mut t Transformer) refresh_decl_assign_types_after_generic_rewrite() bool {
+	mut changed := false
+	for i in 0 .. t.a.nodes.len {
+		node := t.a.nodes[i]
+		if node.kind != .decl_assign || node.children_count != 2 {
+			continue
+		}
+		lhs_id := t.a.child(&node, 0)
+		rhs_id := t.a.child(&node, 1)
+		if int(lhs_id) < 0 || int(rhs_id) < 0 || int(rhs_id) >= t.a.nodes.len {
+			continue
+		}
+		rhs := t.a.nodes[int(rhs_id)]
+		if rhs.kind != .call || rhs.typ.len == 0 || t.generic_arg_is_unresolved(rhs.typ) {
+			continue
+		}
+		if node.typ.len > 0 && !t.generic_arg_is_unresolved(node.typ) {
+			continue
+		}
+		t.a.nodes[i].typ = rhs.typ
+		changed = true
+		lhs := t.a.nodes[int(lhs_id)]
+		if lhs.kind == .ident {
+			t.a.nodes[int(lhs_id)].typ = rhs.typ
+			t.set_var_type(lhs.value, rhs.typ)
+		}
+	}
+	return changed
 }
 
 fn (mut t Transformer) concrete_generic_call_return_type(id flat.NodeId, node flat.Node) string {
@@ -1937,12 +2156,50 @@ fn (mut t Transformer) generic_call_specialization(id flat.NodeId, node flat.Nod
 			return decl_key, args
 		}
 	}
+	if args := t.infer_generic_call_args_from_receiver_record(decl, node, module_name) {
+		if args.len > 0 && !t.generic_args_have_placeholders(args) {
+			return decl_key, args
+		}
+	}
 	if args := t.explicit_generic_call_args(node, module_name) {
 		if args.len > 0 && !t.generic_args_have_placeholders(args) {
 			return decl_key, args
 		}
 	}
 	return none
+}
+
+fn (mut t Transformer) infer_generic_call_args_from_receiver_record(decl GenericFnDecl, node flat.Node, call_module string) ?[]string {
+	if !t.generic_decl_is_receiver_method(decl.node) || node.children_count == 0 {
+		return none
+	}
+	recv_id := t.generic_call_receiver_id(node) or { return none }
+	recv_type := t.generic_call_arg_type_for_inference(recv_id)
+	recorded := t.recorded_generic_specialization_args(recv_type) or { return none }
+	if recorded.len == 0 {
+		return none
+	}
+	params := t.generic_fn_param_names(decl.node, decl.module)
+	if params.len == 0 {
+		return none
+	}
+	mut args := []string{}
+	mut recorded_idx := 0
+	for param in params {
+		if !is_generic_fn_placeholder_name(param) {
+			continue
+		}
+		if recorded_idx >= recorded.len {
+			return none
+		}
+		args << t.generic_arg_for_call_and_decl_module(recorded[recorded_idx], call_module,
+			decl.module)
+		recorded_idx++
+	}
+	if args.len == 0 {
+		return none
+	}
+	return args
 }
 
 fn (t &Transformer) call_has_source_generic_args(node flat.Node) bool {
@@ -1989,6 +2246,13 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 	if callee.kind == .ident {
 		if t.local_concrete_fn_shadows_generic(callee.value, module_name, decls) {
 			return none
+		}
+		if key := t.generic_flat_receiver_call_decl_key(callee.value, module_name, decls) {
+			if decl := decls[key] {
+				if t.generic_call_arg_count_matches_decl(node, decl) {
+					return key
+				}
+			}
 		}
 		for candidate in t.generic_plain_call_candidates(callee.value, module_name) {
 			key := generic_fn_decl_base_value(candidate)
@@ -2039,6 +2303,77 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 		}
 	}
 	return none
+}
+
+fn (t &Transformer) generic_flat_receiver_call_decl_key(name string, module_name string, decls map[string]GenericFnDecl) ?string {
+	if !name.contains('_') {
+		return none
+	}
+	receiver, method := generic_flat_receiver_call_parts(name) or { return none }
+	if receiver.len == 0 || method.len == 0 {
+		return none
+	}
+	method_keys := t.generic_receiver_methods_by_name[method] or { return none }
+	for key in method_keys {
+		decl := decls[key] or { continue }
+		decl_receiver := generic_fn_decl_base_value(decl.node.value).all_before_last('.')
+		if decl_receiver.len == 0 {
+			continue
+		}
+		if generic_flat_receiver_matches(receiver, decl_receiver, module_name, decl.module) {
+			return key
+		}
+	}
+	return none
+}
+
+fn generic_flat_receiver_call_parts(name string) ?(string, string) {
+	if name.contains('.') {
+		receiver := name.all_before_last('.')
+		method := name.all_after_last('.')
+		if receiver.len > 0 && method.len > 0 {
+			return receiver, method
+		}
+	}
+	if name.contains('__') {
+		receiver := name.all_before_last('__')
+		method := name.all_after_last('__')
+		if receiver.len > 0 && method.len > 0 {
+			return receiver, method
+		}
+	}
+	return none
+}
+
+fn generic_flat_receiver_matches(receiver string, decl_receiver string, module_name string, decl_module string) bool {
+	mut bases := []string{}
+	bases << decl_receiver
+	if decl_module.len > 0 && decl_module != 'main' && decl_module != 'builtin'
+		&& !decl_receiver.contains('.') {
+		bases << '${decl_module}.${decl_receiver}'
+	}
+	if module_name.len > 0 && module_name != 'main' && module_name != 'builtin'
+		&& !decl_receiver.contains('.') {
+		bases << '${module_name}.${decl_receiver}'
+	}
+	if decl_receiver.contains('.') {
+		short_receiver := decl_receiver.all_after_last('.')
+		bases << short_receiver
+		bases << '${decl_receiver.all_before_last('.')}.${short_receiver}'
+	}
+	for base in bases {
+		if base.len == 0 {
+			continue
+		}
+		if receiver.starts_with('${base}_') {
+			return true
+		}
+		cbase := c_name(base)
+		if cbase != base && receiver.starts_with('${cbase}_') {
+			return true
+		}
+	}
+	return false
 }
 
 fn (t &Transformer) generic_resolved_call_decl_key(resolved string, callee flat.Node, module_name string, decls map[string]GenericFnDecl) ?string {
@@ -2281,14 +2616,72 @@ fn (t &Transformer) generic_arg_for_decl_module(arg string, module_name string) 
 	if qualified != normalized {
 		return qualified
 	}
-	if module_name.len > 0 && normalized.starts_with('${module_name}.') {
-		short := normalized.all_after_last('.')
-		if short.starts_with('Array_') {
-			return normalized
+	if module_name.len > 0 {
+		stripped := strip_decl_module_from_generic_arg(normalized, module_name)
+		if stripped != normalized {
+			return stripped
 		}
-		return short
 	}
 	return normalized
+}
+
+fn strip_decl_module_from_generic_arg(arg string, module_name string) string {
+	clean := arg.trim_space()
+	if clean.len == 0 || module_name.len == 0 {
+		return clean
+	}
+	if clean.starts_with('&') {
+		return '&' + strip_decl_module_from_generic_arg(clean[1..], module_name)
+	}
+	if clean.starts_with('mut ') {
+		return 'mut ' + strip_decl_module_from_generic_arg(clean[4..], module_name)
+	}
+	if clean.starts_with('?') || clean.starts_with('!') {
+		return clean[..1] + strip_decl_module_from_generic_arg(clean[1..], module_name)
+	}
+	if clean.starts_with('...') {
+		return '...' + strip_decl_module_from_generic_arg(clean[3..], module_name)
+	}
+	if clean.starts_with('[]') {
+		return '[]' + strip_decl_module_from_generic_arg(clean[2..], module_name)
+	}
+	if clean.starts_with('map[') {
+		bracket_end := generic_matching_bracket(clean, 3)
+		if bracket_end < clean.len {
+			key := strip_decl_module_from_generic_arg(clean[4..bracket_end], module_name)
+			val := strip_decl_module_from_generic_arg(clean[bracket_end + 1..], module_name)
+			return 'map[${key}]${val}'
+		}
+	}
+	if clean.starts_with('[') {
+		bracket_end := generic_matching_bracket(clean, 0)
+		if bracket_end < clean.len {
+			return clean[..bracket_end + 1] + strip_decl_module_from_generic_arg(clean[bracket_end +
+				1..], module_name)
+		}
+	}
+	base, args, ok := generic_app_parts(clean)
+	if ok {
+		stripped_base := strip_decl_module_from_generic_base(base, module_name)
+		mut stripped_args := []string{cap: args.len}
+		for generic_arg in args {
+			stripped_args << strip_decl_module_from_generic_arg(generic_arg, module_name)
+		}
+		return '${stripped_base}[${stripped_args.join(', ')}]'
+	}
+	return strip_decl_module_from_generic_base(clean, module_name)
+}
+
+fn strip_decl_module_from_generic_base(name string, module_name string) string {
+	prefix := '${module_name}.'
+	if !name.starts_with(prefix) {
+		return name
+	}
+	short := name[prefix.len..]
+	if short.starts_with('Array_') {
+		return name
+	}
+	return short
 }
 
 fn (t &Transformer) generic_arg_is_alias_name(arg string, module_name string) bool {
@@ -2439,6 +2832,12 @@ fn (t &Transformer) generic_arg_expr_type(id flat.NodeId) string {
 	}
 	node := t.a.nodes[int(id)]
 	match node.kind {
+		.ident {
+			typ := t.var_type(node.value)
+			if typ.len > 0 {
+				return typ
+			}
+		}
 		.array_literal {
 			if checker_alias_type := t.array_literal_checker_alias_type(id) {
 				return checker_alias_type
@@ -2513,11 +2912,21 @@ fn (t &Transformer) generic_arg_expr_type(id flat.NodeId) string {
 	return t.node_type(id)
 }
 
-fn (t &Transformer) generic_call_arg_type_for_inference(id flat.NodeId) string {
+fn (mut t Transformer) generic_call_arg_type_for_inference(id flat.NodeId) string {
 	if int(id) < 0 || int(id) >= t.a.nodes.len {
 		return ''
 	}
 	node := t.a.nodes[int(id)]
+	if node.kind == .call {
+		concrete_ret := t.concrete_generic_call_return_type(id, node)
+		if concrete_ret.len > 0 && !t.generic_arg_is_unresolved(concrete_ret) {
+			return concrete_ret
+		}
+		call_ret := t.get_call_return_type(id, node)
+		if call_ret.len > 0 && !t.generic_arg_is_unresolved(call_ret) {
+			return call_ret
+		}
+	}
 	if node.kind in [.array_literal, .fn_literal, .lambda_expr] {
 		typ := t.generic_arg_expr_type(id)
 		if typ.len > 0 {
@@ -2576,6 +2985,7 @@ fn (t &Transformer) infer_generic_receiver_suffix_args(param_type string, arg_ty
 	if suffix.len == 0 {
 		return
 	}
+	mut assigned := false
 	for i, param_arg in param_args {
 		if !is_generic_fn_placeholder_name(param_arg) || param_arg in inferred {
 			continue
@@ -2584,21 +2994,24 @@ fn (t &Transformer) infer_generic_receiver_suffix_args(param_type string, arg_ty
 		if decoded.len == 0 {
 			continue
 		}
-		if i == 0 {
+		if i == 0 || !assigned {
 			inferred[param_arg] = decoded
+			assigned = true
 		}
 	}
 }
 
 fn (t &Transformer) infer_generic_receiver_recorded_args(param_args []string, args []string, mut inferred map[string]string) {
-	for i, param_arg in param_args {
-		if i >= args.len {
-			return
-		}
+	mut arg_idx := 0
+	for param_arg in param_args {
 		if !is_generic_fn_placeholder_name(param_arg) || param_arg in inferred {
 			continue
 		}
-		inferred[param_arg] = args[i]
+		if arg_idx >= args.len {
+			return
+		}
+		inferred[param_arg] = args[arg_idx]
+		arg_idx++
 	}
 }
 

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -442,7 +442,7 @@ fn (t &Transformer) needs_generic_struct_method_specialization(decls map[string]
 	return false
 }
 
-fn (t &Transformer) generic_struct_method_needed_for_interface(spec string, method string) bool {
+fn (mut t Transformer) generic_struct_method_needed_for_interface(spec string, method string) bool {
 	if isnil(t.tc) || spec.len == 0 || method.len == 0 {
 		return false
 	}
@@ -450,11 +450,116 @@ fn (t &Transformer) generic_struct_method_needed_for_interface(spec string, meth
 		if method !in t.tc.interface_abstract_method_names(iface_name) {
 			continue
 		}
-		if t.tc.named_type_implements_interface(spec, iface_name) {
+		if !t.tc.named_type_implements_interface(spec, iface_name) {
+			continue
+		}
+		if !t.has_used_fn_filter()
+			|| (t.interface_dispatch_method_used(iface_name, method)
+			&& t.interface_boxed_type_used(iface_name, spec)) {
 			return true
 		}
 	}
 	return false
+}
+
+fn (t &Transformer) interface_dispatch_method_used(iface_name string, method string) bool {
+	name := '${iface_name}.${method}'
+	if t.used_interface_dispatch_key(name) {
+		return true
+	}
+	if decl_key := t.tc.interface_method_signature_key(iface_name, method) {
+		if decl_key != name && t.used_interface_dispatch_key(decl_key) {
+			return true
+		}
+		decl_short_name := '${decl_key.all_before_last('.').all_after_last('.')}.${method}'
+		if decl_short_name != decl_key && t.interface_dispatch_short_name_allowed(iface_name)
+			&& t.used_interface_dispatch_key(decl_short_name) {
+			return true
+		}
+	}
+	for alias in t.interface_alias_names(iface_name) {
+		alias_name := '${alias}.${method}'
+		if t.used_interface_dispatch_key(alias_name) {
+			return true
+		}
+		short_alias_name := '${alias.all_after_last('.')}.${method}'
+		if short_alias_name != alias_name && t.interface_dispatch_short_name_allowed(alias)
+			&& t.used_interface_dispatch_key(short_alias_name) {
+			return true
+		}
+	}
+	short_name := '${iface_name.all_after_last('.')}.${method}'
+	return short_name != name && t.interface_dispatch_short_name_allowed(iface_name)
+		&& t.used_interface_dispatch_key(short_name)
+}
+
+fn (t &Transformer) interface_alias_names(iface_name string) []string {
+	mut aliases := []string{}
+	for alias, target in t.tc.type_aliases {
+		qtarget := t.tc.qualify_name(target)
+		if target == iface_name || qtarget == iface_name {
+			aliases << alias
+		}
+	}
+	return aliases
+}
+
+fn (t &Transformer) used_interface_dispatch_key(name string) bool {
+	return t.used_fn_contains_name(name) || t.used_fn_contains_name(c_name(name))
+}
+
+fn (t &Transformer) interface_dispatch_short_name_allowed(iface_name string) bool {
+	return !iface_name.contains('.')
+}
+
+fn (mut t Transformer) interface_boxed_type_used(iface_name string, concrete_type string) bool {
+	t.collect_interface_boxed_types()
+	return t.interface_boxed_types[interface_boxed_type_key(iface_name, concrete_type)]
+		|| t.interface_boxed_types[interface_boxed_type_key(iface_name, c_name(concrete_type))]
+}
+
+fn (mut t Transformer) collect_interface_boxed_types() {
+	if t.interface_boxed_types_done || isnil(t.tc) {
+		return
+	}
+	t.interface_boxed_types_done = true
+	for node in t.a.nodes {
+		if node.kind != .struct_init || node.children_count == 0 {
+			continue
+		}
+		iface_name := t.interface_literal_name(node.value) or { continue }
+		for i in 0 .. node.children_count {
+			field := t.a.child_node(&node, i)
+			if field.kind != .field_init || field.value != '_object' {
+				continue
+			}
+			concrete_type := if field.typ.starts_with('&') { field.typ[1..] } else { field.typ }
+			t.mark_interface_boxed_type(iface_name, concrete_type)
+		}
+	}
+}
+
+fn (t &Transformer) interface_literal_name(name string) ?string {
+	if name in t.tc.interface_names {
+		return name
+	}
+	qname := t.tc.qualify_name(name)
+	if qname in t.tc.interface_names {
+		return qname
+	}
+	return none
+}
+
+fn (mut t Transformer) mark_interface_boxed_type(iface_name string, concrete_type string) {
+	if iface_name.len == 0 || concrete_type.len == 0 {
+		return
+	}
+	t.interface_boxed_types[interface_boxed_type_key(iface_name, concrete_type)] = true
+	t.interface_boxed_types[interface_boxed_type_key(iface_name, c_name(concrete_type))] = true
+}
+
+fn interface_boxed_type_key(iface_name string, concrete_type string) string {
+	return '${iface_name}\n${concrete_type}'
 }
 
 fn (mut t Transformer) materialize_generic_structs() {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -1454,7 +1454,7 @@ fn (mut t Transformer) concrete_generic_call_return_type(id flat.NodeId, node fl
 	if explicit := t.explicit_generic_call_args(node, t.cur_module) {
 		args = explicit.clone()
 	} else {
-		args = t.infer_generic_call_args_from_params(decl, node) or { return '' }
+		args = t.infer_generic_call_args_from_params(decl, node, t.cur_module) or { return '' }
 	}
 	if args.len == 0 || t.generic_args_have_placeholders(args) {
 		return ''
@@ -1513,7 +1513,7 @@ fn (mut t Transformer) concrete_generic_call_param_types(id flat.NodeId, node fl
 	if explicit := t.explicit_generic_call_args(node, t.cur_module) {
 		args = explicit.clone()
 	} else {
-		args = t.infer_generic_call_args_from_params(decl, node) or { return none }
+		args = t.infer_generic_call_args_from_params(decl, node, t.cur_module) or { return none }
 	}
 	if args.len == 0 || t.generic_args_have_placeholders(args) {
 		return none
@@ -1563,7 +1563,7 @@ fn (mut t Transformer) build_generic_receiver_method_index() {
 	t.generic_receiver_methods_by_name = by_name.move()
 }
 
-fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, node flat.Node) ?[]string {
+fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, node flat.Node, call_module string) ?[]string {
 	param_names := t.generic_fn_param_names(decl.node, decl.module)
 	if param_names.len == 0 {
 		return none
@@ -1594,7 +1594,7 @@ fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, n
 	mut args := []string{cap: param_names.len}
 	for name in param_names {
 		arg := inferred[name] or { return none }
-		args << t.generic_arg_for_decl_module(arg, decl.module)
+		args << t.generic_arg_for_call_and_decl_module(arg, call_module, decl.module)
 	}
 	return args
 }
@@ -1932,7 +1932,7 @@ fn (mut t Transformer) generic_call_specialization(id flat.NodeId, node flat.Nod
 			return decl_key, args
 		}
 	}
-	if args := t.infer_generic_call_args(decl, id, node) {
+	if args := t.infer_generic_call_args(decl, id, node, module_name) {
 		if args.len > 0 && !t.generic_args_have_placeholders(args) {
 			return decl_key, args
 		}
@@ -2227,7 +2227,7 @@ fn (t &Transformer) generic_call_arg_id_for_param(node flat.Node, param_idx int,
 	return t.a.child(&node, arg_idx)
 }
 
-fn (mut t Transformer) infer_generic_call_args(decl GenericFnDecl, _id flat.NodeId, node flat.Node) ?[]string {
+fn (mut t Transformer) infer_generic_call_args(decl GenericFnDecl, _id flat.NodeId, node flat.Node, call_module string) ?[]string {
 	param_names := t.generic_fn_param_names(decl.node, decl.module)
 	if param_names.len == 0 {
 		return none
@@ -2262,9 +2262,14 @@ fn (mut t Transformer) infer_generic_call_args(decl GenericFnDecl, _id flat.Node
 	mut args := []string{cap: param_names.len}
 	for name in param_names {
 		arg := inferred[name] or { return none }
-		args << t.generic_arg_for_decl_module(arg, decl.module)
+		args << t.generic_arg_for_call_and_decl_module(arg, call_module, decl.module)
 	}
 	return args
+}
+
+fn (t &Transformer) generic_arg_for_call_and_decl_module(arg string, call_module string, decl_module string) string {
+	call_normalized := t.normalize_type_in_module(arg, call_module)
+	return t.generic_arg_for_decl_module(call_normalized, decl_module)
 }
 
 fn (t &Transformer) generic_arg_for_decl_module(arg string, module_name string) string {
@@ -2833,8 +2838,9 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 	for i in 0 .. node.children_count {
 		children << t.clone_generic_node(t.a.child(&node, i), args)
 	}
-	cloned_typ := t.subst_type(node.typ, args)
+	cloned_typ := t.resolve_substituted_type_text(t.subst_type(node.typ, args))
 	t.retarget_cloned_new_map_call(node, mut children, cloned_typ)
+	t.retarget_cloned_implicit_generic_call(node, mut children)
 	start := t.a.children.len
 	for child in children {
 		t.a.children << child
@@ -2906,6 +2912,62 @@ fn (mut t Transformer) retarget_cloned_new_map_call(node flat.Node, mut children
 	children[4] = t.make_ident(eq_fn)
 	children[5] = t.make_ident(clone_fn)
 	children[6] = t.make_ident(free_fn)
+}
+
+fn (mut t Transformer) retarget_cloned_implicit_generic_call(node flat.Node, mut children []flat.NodeId) {
+	if node.kind != .call || children.len == 0 || t.skip_generics {
+		return
+	}
+	decls := t.cached_generic_fn_decls()
+	if decls.len == 0 {
+		return
+	}
+	decl_key := t.generic_call_decl_key(flat.empty_node, node, t.cur_module, decls) or { return }
+	decl := decls[decl_key] or { return }
+	if t.should_skip_generic_call_specialization(decl_key) || t.call_has_source_generic_args(node)
+		|| t.generic_decl_is_receiver_method(decl.node) {
+		return
+	}
+	callee_id := children[0]
+	if int(callee_id) < 0 || int(callee_id) >= t.a.nodes.len {
+		return
+	}
+	callee := t.a.nodes[int(callee_id)]
+	if callee.kind != .ident || callee.value.contains('[') {
+		return
+	}
+	param_names := t.generic_fn_param_names(decl.node, decl.module)
+	if param_names.len == 0 {
+		return
+	}
+	mut inferred := map[string]string{}
+	mut param_idx := 0
+	for i in 0 .. decl.node.children_count {
+		child := t.a.child_node(&decl.node, i)
+		if child.kind != .param {
+			continue
+		}
+		arg_pos := param_idx + 1
+		if arg_pos >= children.len {
+			param_idx++
+			continue
+		}
+		arg_type := t.generic_call_arg_type_for_inference(children[arg_pos])
+		if arg_type.len > 0 {
+			infer_generic_type_args(child.typ, arg_type, mut inferred)
+		}
+		param_idx++
+	}
+	mut call_args := []string{cap: param_names.len}
+	for name in param_names {
+		arg := inferred[name] or { return }
+		call_args << t.generic_arg_for_decl_module(arg, decl.module)
+	}
+	if call_args.len == 0 || t.generic_args_have_placeholders(call_args) {
+		return
+	}
+	spec_value := specialized_generic_fn_value(decl.node.value, call_args)
+	t.a.nodes[int(callee_id)].value = transform_qualified_fn_name(decl.module, spec_value)
 }
 
 fn (mut t Transformer) copy_cloned_resolution(src_id flat.NodeId, dst_id flat.NodeId) {
@@ -3592,8 +3654,11 @@ fn (t &Transformer) subst_node_value(node flat.Node, args []string) string {
 			}
 			return node.value
 		}
-		.call, .array_init, .map_init, .struct_init, .assoc, .cast_expr, .as_expr, .sizeof_expr,
-		.typeof_expr, .is_expr, .type_decl, .field_decl, .param {
+		.array_init, .map_init, .struct_init, .assoc, .cast_expr, .as_expr, .sizeof_expr,
+		.typeof_expr, .is_expr {
+			return t.resolve_substituted_type_text(t.subst_type(node.value, args))
+		}
+		.call, .type_decl, .field_decl, .param {
 			return t.subst_type(node.value, args)
 		}
 		.comptime_if {
@@ -3603,6 +3668,18 @@ fn (t &Transformer) subst_node_value(node flat.Node, args []string) string {
 			return node.value
 		}
 	}
+}
+
+fn (t &Transformer) resolve_substituted_type_text(typ string) string {
+	clean := typ.trim_space()
+	if clean.len == 0 || isnil(t.tc) {
+		return typ
+	}
+	parsed := t.tc.parse_type(clean)
+	if parsed is types.Unknown {
+		return typ
+	}
+	return parsed.name()
 }
 
 fn (t &Transformer) subst_comptime_type_condition(cond string, args []string) string {

--- a/vlib/v3/transform/return.v
+++ b/vlib/v3/transform/return.v
@@ -70,6 +70,22 @@ fn (mut t Transformer) make_return_values(vals []flat.NodeId, ret_typ string) fl
 	})
 }
 
+fn (t &Transformer) current_return_multi_count() int {
+	if isnil(t.tc) || t.cur_fn_ret_type.len == 0 {
+		return 0
+	}
+	items := multi_return_types_from_type(t.tc.parse_type(t.cur_fn_ret_type), 0) or { return 0 }
+	return items.len
+}
+
+fn (mut t Transformer) return_values_from_ids(ids []flat.NodeId) []flat.NodeId {
+	mut vals := []flat.NodeId{cap: ids.len}
+	for i, id in ids {
+		vals << t.transform_return_child(id, i, ids.len)
+	}
+	return vals
+}
+
 // return_expr_is_err supports return expr is err handling for Transformer.
 fn (t &Transformer) return_expr_is_err(id flat.NodeId) bool {
 	if int(id) < 0 {
@@ -198,6 +214,20 @@ fn (mut t Transformer) return_block_from_branch(branch_id flat.NodeId, ret_typ s
 	}
 	if stmt_ids.len == 0 {
 		return t.make_block([]flat.NodeId{})
+	}
+	tuple_count := t.current_return_multi_count() - extra_return_vals.len
+	if tuple_count > 1 {
+		if parts := t.tuple_block_parts(branch_id, tuple_count) {
+			mut all := t.transform_stmts(parts.prefix)
+			mut ret_ids := parts.values.clone()
+			for extra in extra_return_vals {
+				ret_ids << extra
+			}
+			ret_vals := t.return_values_from_ids(ret_ids)
+			t.drain_pending(mut all)
+			all << t.make_return_values(ret_vals, ret_typ)
+			return t.make_block(all)
+		}
 	}
 	// all but the last are kept as statements (transformed); the last becomes a return
 	lead := stmt_ids[..stmt_ids.len - 1].clone()

--- a/vlib/v3/transform/sum.v
+++ b/vlib/v3/transform/sum.v
@@ -724,7 +724,17 @@ fn (mut t Transformer) transform_as_expr(id flat.NodeId, node flat.Node) flat.No
 	}
 	resolved_clean_type := t.resolve_sum_name(clean_type)
 	if clean_type.len == 0 || resolved_clean_type !in t.sum_types {
-		return t.transform_expr(expr_id)
+		child := t.transform_expr(expr_id)
+		start := t.a.children.len
+		t.a.children << child
+		return t.a.add_node(flat.Node{
+			kind:           .as_expr
+			value:          node.value
+			typ:            node.typ
+			children_start: start
+			children_count: 1
+			pos:            node.pos
+		})
 	}
 	qv := t.resolve_variant(clean_type, node.value)
 	if qv.len > 0 && t.normalize_type_alias(clean_type0) == t.normalize_type_alias(qv) {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -2778,12 +2778,12 @@ fn (mut t Transformer) transform_return_stmt(id flat.NodeId, node flat.Node) []f
 
 fn (mut t Transformer) return_values_with_extra(first_id flat.NodeId, extra_ids []flat.NodeId) []flat.NodeId {
 	total := extra_ids.len + 1
-	mut vals := []flat.NodeId{cap: total}
-	vals << t.transform_return_child(first_id, 0, total)
-	for i, extra_id in extra_ids {
-		vals << t.transform_return_child(extra_id, i + 1, total)
+	mut ids := []flat.NodeId{cap: total}
+	ids << first_id
+	for extra_id in extra_ids {
+		ids << extra_id
 	}
-	return vals
+	return t.return_values_from_ids(ids)
 }
 
 fn (mut t Transformer) transform_return_child(child_id flat.NodeId, child_index int, total_children int) flat.NodeId {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -246,20 +246,90 @@ pub fn transform_with_used_opt_config(mut a flat.FlatAst, tc &types.TypeChecker,
 			unsafe { a.children.grow_cap(reserve_children) }
 		}
 	}
+	base_node_count := t.a.nodes.len
 	was_parallel := t.transform_all_dispatch(want_parallel)
+	mut late_names := t.new_call_names_from_used_fn_bodies(used_fns, base_node_count)
+	late_names << newly_used_fn_names(used_fns, t.used_fns)
+	t.transform_late_used_fn_bodies(late_names, base_node_count)
 	return t.used_fns, was_parallel
+}
+
+fn (mut t Transformer) new_call_names_from_used_fn_bodies(used map[string]bool, node_limit int) []string {
+	if used.len == 0 || node_limit <= 0 {
+		return []string{}
+	}
+	mut names := []string{}
+	mut seen := map[string]bool{}
+	mut cur_module := ''
+	limit := if node_limit < t.a.nodes.len { node_limit } else { t.a.nodes.len }
+	for i in 0 .. limit {
+		node := t.a.nodes[i]
+		kind_id := node_kind_id(node)
+		if kind_id == 77 {
+			cur_module = ''
+			continue
+		}
+		if kind_id == 73 {
+			cur_module = node.value
+			continue
+		}
+		if kind_id != 61 || t.fn_decl_has_unresolved_generics(node, cur_module) {
+			continue
+		}
+		if !node.value.starts_with('__anon_fn_') && !late_used_fn_matches(used, node, cur_module) {
+			continue
+		}
+		for call_name in t.generated_fn_body_call_names(flat.NodeId(i)) {
+			if call_name.len == 0 || seen[call_name] {
+				continue
+			}
+			if used[call_name] || used[c_name(call_name)]
+				|| late_used_fn_contains_in_module(used, call_name, cur_module) {
+				continue
+			}
+			seen[call_name] = true
+			names << call_name
+		}
+	}
+	return names
+}
+
+fn newly_used_fn_names(before map[string]bool, after map[string]bool) []string {
+	mut names := []string{}
+	for name, used in after {
+		if !used || name.len == 0 || name.contains('__') {
+			continue
+		}
+		if before[name] || before[c_name(name)] {
+			continue
+		}
+		if name.contains('.') && before[name.all_after_last('.')] {
+			continue
+		}
+		names << name
+	}
+	return names
 }
 
 pub fn monomorphize_with_used(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) map[string]bool {
 	mut augmented_used_fns := used_fns.clone()
 	mut t := new_transformer(mut a, tc, augmented_used_fns)
 	t.prepare()
-	for name in t.monomorphize_pass() {
+	base_node_count := t.a.nodes.len
+	generated_names := t.monomorphize_pass()
+	mut late_names := []string{}
+	for name in generated_names {
+		was_used := used_fns[name] || used_fns[c_name(name)]
 		augmented_used_fns[name] = true
 		augmented_used_fns[c_name(name)] = true
 		t.used_fns[name] = true
 		t.used_fns[c_name(name)] = true
+		if !was_used {
+			late_names << name
+		}
 	}
+	late_names << t.new_call_names_from_used_fn_bodies(used_fns, t.a.nodes.len)
+	t.transform_late_used_fn_bodies(late_names, base_node_count)
 	t.materialize_generic_structs()
 	return t.used_fns
 }
@@ -1192,7 +1262,124 @@ fn (t &Transformer) should_transform_fn(node flat.Node) bool {
 	if t.cur_module == 'builtin' && node.value == 'exit' {
 		return true
 	}
+	if node.value.contains('[') {
+		base_value := generic_fn_decl_base_value(node.value)
+		if base_value != node.value && t.used_fn_contains_in_module(base_value, t.cur_module) {
+			return true
+		}
+	}
 	return t.used_fn_contains_in_module(node.value, t.cur_module)
+}
+
+fn (mut t Transformer) transform_late_used_fn_bodies(names []string, node_limit int) {
+	if names.len == 0 || node_limit <= 0 {
+		return
+	}
+	mut late := map[string]bool{}
+	mut queued := map[string]bool{}
+	mut pending := []string{}
+	for name in names {
+		add_late_used_fn_name(name, mut late, mut pending, mut queued)
+	}
+	mut processed := map[int]bool{}
+	limit := if node_limit < t.a.nodes.len { node_limit } else { t.a.nodes.len }
+	for pending.len > 0 {
+		_ := pending.pop()
+		t.transform_pending_late_used_fn_bodies(limit, mut late, mut pending, mut queued, mut
+			processed)
+	}
+}
+
+fn (mut t Transformer) transform_pending_late_used_fn_bodies(limit int, mut late map[string]bool, mut pending []string, mut queued map[string]bool, mut processed map[int]bool) {
+	mut cur_file := ''
+	mut cur_module := ''
+	for i in 0 .. limit {
+		if processed[i] {
+			continue
+		}
+		node := t.a.nodes[i]
+		kind_id := node_kind_id(node)
+		if kind_id == 77 {
+			cur_file = node.value
+			cur_module = ''
+			continue
+		}
+		if kind_id == 73 {
+			cur_module = node.value
+			continue
+		}
+		if kind_id != 61 || t.fn_decl_has_unresolved_generics(node, cur_module) {
+			continue
+		}
+		if !late_used_fn_matches(late, node, cur_module) {
+			continue
+		}
+		processed[i] = true
+		t.cur_file = cur_file
+		t.cur_module = cur_module
+		used_before := t.used_fns.clone()
+		t.transform_fn_body(i)
+		for call_name in t.generated_fn_body_call_names(flat.NodeId(i)) {
+			t.enqueue_late_used_call_name(call_name, used_before, mut late, mut pending, mut queued)
+		}
+	}
+}
+
+fn (mut t Transformer) enqueue_late_used_call_name(name string, used_before map[string]bool, mut late map[string]bool, mut pending []string, mut queued map[string]bool) {
+	if name.len == 0 {
+		return
+	}
+	was_used := used_before[name] || used_before[c_name(name)]
+		|| late_used_fn_contains_in_module(used_before, name, t.cur_module)
+	t.mark_fn_used_name(name)
+	if was_used {
+		return
+	}
+	add_late_used_fn_name(name, mut late, mut pending, mut queued)
+}
+
+fn add_late_used_fn_name(name string, mut late map[string]bool, mut pending []string, mut queued map[string]bool) {
+	if name.len == 0 {
+		return
+	}
+	late[name] = true
+	late[c_name(name)] = true
+	if !queued[name] {
+		queued[name] = true
+		pending << name
+	}
+}
+
+fn late_used_fn_matches(used map[string]bool, node flat.Node, module_name string) bool {
+	if late_used_fn_contains_in_module(used, node.value, module_name) {
+		return true
+	}
+	if node.value.contains('[') {
+		base_value := generic_fn_decl_base_value(node.value)
+		return base_value != node.value
+			&& late_used_fn_contains_in_module(used, base_value, module_name)
+	}
+	return false
+}
+
+fn late_used_fn_contains_in_module(used map[string]bool, name string, module_name string) bool {
+	if name.len == 0 {
+		return false
+	}
+	if module_name.len > 0 && module_name != 'main' && module_name != 'builtin'
+		&& name.starts_with('${module_name}.') {
+		return used[name] || used[c_name(name)]
+	}
+	dfn := transform_dotted_fn_name(module_name, name)
+	qfn := c_name(dfn)
+	if used[dfn] || used[qfn] {
+		return true
+	}
+	if module_name.len == 0 || module_name == 'main' || module_name == 'builtin' {
+		cfn := c_name(name)
+		return used[name] || used[cfn]
+	}
+	return false
 }
 
 fn (t &Transformer) has_used_fn_filter() bool {
@@ -1468,6 +1655,7 @@ fn (mut t Transformer) transform_string_interp_part(child_id flat.NodeId) flat.N
 		expr_id = t.a.child(&child, 0)
 		format = child.typ
 	}
+	t.mark_string_interp_call_part_used(expr_id)
 	mut transformed := t.transform_expr(expr_id)
 	mut typ := t.raw_alias_type_for_expr(expr_id)
 	if typ.len == 0 {
@@ -1492,6 +1680,40 @@ fn (mut t Transformer) transform_string_interp_part(child_id flat.NodeId) flat.N
 	}
 	t.ensure_stringify_generic_instances_for_type(typ)
 	return t.wrap_formatted_string_conversion(transformed, typ, format)
+}
+
+fn (mut t Transformer) mark_string_interp_call_part_used(expr_id flat.NodeId) {
+	if int(expr_id) < 0 || int(expr_id) >= t.a.nodes.len {
+		return
+	}
+	node := t.a.nodes[int(expr_id)]
+	if node.kind != .call {
+		return
+	}
+	call_name := t.call_name_for_node(expr_id, node)
+	if call_name.len > 0 {
+		t.mark_fn_used_name(call_name)
+		return
+	}
+	if node.children_count == 0 {
+		return
+	}
+	fn_id := t.a.child(&node, 0)
+	if int(fn_id) < 0 || int(fn_id) >= t.a.nodes.len {
+		return
+	}
+	fn_node := t.a.nodes[int(fn_id)]
+	if fn_node.kind == .ident && fn_node.value.len > 0 {
+		t.mark_fn_used_name(fn_node.value)
+		return
+	}
+	if fn_node.kind == .selector && fn_node.value.len > 0 && fn_node.children_count > 0 {
+		base_id := t.a.child(&fn_node, 0)
+		method_name := t.resolve_receiver_method_name(base_id, fn_node.value)
+		if method_name.len > 0 {
+			t.mark_fn_used_name(method_name)
+		}
+	}
 }
 
 fn (t &Transformer) string_interp_needs_value_read(name string, typ string) bool {
@@ -6186,6 +6408,11 @@ fn (mut t Transformer) transform_prefix_expr(id flat.NodeId, node flat.Node) fla
 				return t.make_cast('&${info.value_type}', ptr, '&${info.value_type}')
 			}
 		}
+		if child.kind == .or_expr && child.children_count >= 2 {
+			if addr := t.transform_amp_optional_unwrap(node, child) {
+				return addr
+			}
+		}
 		if child.kind == .call && child.children_count == 2 {
 			callee := t.a.child_node(&child, 0)
 			arg_id := t.a.child(&child, 1)
@@ -6292,6 +6519,37 @@ fn (mut t Transformer) rewrite_signed_literal_str_call(op flat.Op, child_id flat
 	}
 	signed_base := t.make_prefix(op, base_id)
 	return t.make_method_call(signed_base, 'str', []flat.NodeId{})
+}
+
+fn (mut t Transformer) transform_amp_optional_unwrap(node flat.Node, child flat.Node) ?flat.NodeId {
+	source_id := t.a.child(&child, 0)
+	body_id := t.a.child(&child, 1)
+	source_type := t.optional_result_expr_type_name(source_id)
+	if !t.is_optional_type_name(source_type) || !t.expr_can_take_address(source_id) {
+		return none
+	}
+	value_type := t.optional_base_type(t.qualify_optional_type(source_type))
+	if value_type.len == 0 || value_type == 'void' {
+		return none
+	}
+	target_type := if node.typ.len > 0 {
+		node.typ
+	} else {
+		'&${value_type}'
+	}
+	if !target_type.starts_with('&') {
+		return none
+	}
+	source := t.transform_expr(source_id)
+	not_ok := t.make_prefix(.not, t.make_selector(source, 'ok', 'bool'))
+	err_expr := t.make_selector(source, 'err', 'IError')
+	else_block := t.make_block(t.lower_or_body_to_stmts_with_err_expr(body_id, '', '', child.value,
+		err_expr))
+	t.pending_stmts << t.make_if(not_ok, else_block, t.make_empty())
+	value := t.make_selector(source, 'value', value_type)
+	addr := t.make_prefix(.amp, value)
+	t.a.nodes[int(addr)].typ = target_type
+	return addr
 }
 
 // transform_amp_sum_cast_from_as_expr supports transform_amp_sum_cast_from_as_expr handling.

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -94,6 +94,8 @@ mut:
 	struct_field_type_cache      &LookupCache = unsafe { nil }
 	variant_short_name_cache     &LookupCache = unsafe { nil }
 	used_fns                     map[string]bool
+	interface_boxed_types        map[string]bool
+	interface_boxed_types_done   bool
 	// used_struct_operator_fns holds the callee names of direct calls seen during
 	// monomorphize. Infix operators on generic instances are lowered to direct calls
 	// (`Vec_int__plus(a, b)`) before this pass, so an operator overload is specialized for
@@ -350,6 +352,7 @@ fn new_transformer(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[strin
 		generic_call_spec_misses:         map[int]bool{}
 		sum_variant_names:                map[string]bool{}
 		used_fns:                         used_fns.clone()
+		interface_boxed_types:            map[string]bool{}
 	}
 }
 

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -4625,7 +4625,12 @@ fn (t &Transformer) tuple_block_parts(block_id flat.NodeId, count int) ?TupleBlo
 		if child.kind != .expr_stmt || child.children_count == 0 {
 			break
 		}
-		values.prepend(t.a.child(&child, 0))
+		for j := int(child.children_count) - 1; j >= 0; j-- {
+			values.prepend(t.a.child(&child, j))
+			if values.len == count {
+				break
+			}
+		}
 		prefix_end = i
 		if values.len == count {
 			return TupleBlockParts{

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -654,7 +654,12 @@ fn (t &Transformer) normalize_field_type(typ string, owner_type string) string {
 	owner_base, owner_args, owner_is_generic_app := generic_app_parts(owner_type)
 	if owner_is_generic_app {
 		if owner_base.len > 0 {
-			substituted := substitute_generic_type_text(typ, owner_args)
+			params := t.generic_struct_param_names_for_base(owner_base)
+			substituted := if params.len > 0 {
+				substitute_generic_type_text_with_params(typ, owner_args, params)
+			} else {
+				substitute_generic_type_text(typ, owner_args)
+			}
 			if substituted != typ {
 				return t.normalize_field_type(substituted, owner_type)
 			}
@@ -697,6 +702,26 @@ fn (t &Transformer) normalize_field_type(typ string, owner_type string) string {
 		}
 	}
 	return t.normalize_type_alias(typ)
+}
+
+fn (t &Transformer) generic_struct_param_names_for_base(base string) []string {
+	if isnil(t.tc) {
+		return []string{}
+	}
+	if params := t.tc.struct_generic_params[base] {
+		return params.clone()
+	}
+	short := base.all_after_last('.')
+	if params := t.tc.struct_generic_params[short] {
+		return params.clone()
+	}
+	if !base.contains('.') && t.cur_module.len > 0 && t.cur_module != 'main'
+		&& t.cur_module != 'builtin' {
+		if params := t.tc.struct_generic_params['${t.cur_module}.${base}'] {
+			return params.clone()
+		}
+	}
+	return []string{}
 }
 
 fn (t &Transformer) type_authority_has(name string) bool {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -11279,7 +11279,7 @@ fn (mut tc TypeChecker) resolve_expr(id flat.NodeId, expected Type) Type {
 		return tc.resolve_expr(tc.a.child(&node, 0), expected)
 	}
 	if node.kind == .none_expr {
-		if expected is OptionType || expected is ResultType || is_ierror_type(expected) {
+		if expected is OptionType || expected is ResultType {
 			tc.register_synth_type(id, expected)
 			return expected
 		}
@@ -11744,7 +11744,7 @@ fn (tc &TypeChecker) type_compatible(actual Type, expected Type) bool {
 		return true
 	}
 	if actual is None {
-		return expected is OptionType || expected is ResultType || is_ierror_type(expected)
+		return expected is OptionType || expected is ResultType
 	}
 	if expected is OptionType {
 		if actual is OptionType {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -116,9 +116,13 @@ fn unknown_type(reason string) Type {
 // TypeError represents type error data used by types.
 pub struct TypeError {
 pub:
-	msg  string
-	kind TypeErrorKind
-	node flat.NodeId
+	msg        string
+	kind       TypeErrorKind
+	node       flat.NodeId
+	file       string
+	node_kind  string
+	node_value string
+	node_pos   string
 }
 
 // TypeErrorKind lists type error kind values used by types.
@@ -530,17 +534,49 @@ fn (mut tc TypeChecker) record_error(kind TypeErrorKind, msg string, node flat.N
 		return
 	}
 	tc.errors << TypeError{
-		msg:  msg
-		kind: kind
-		node: node
+		msg:        msg
+		kind:       kind
+		node:       node
+		file:       tc.cur_file
+		node_kind:  if int(node) >= 0 && int(node) < tc.a.nodes.len {
+			tc.a.nodes[int(node)].kind.str()
+		} else {
+			''
+		}
+		node_value: if int(node) >= 0 && int(node) < tc.a.nodes.len {
+			tc.a.nodes[int(node)].value
+		} else {
+			''
+		}
+		node_pos:   if int(node) >= 0 && int(node) < tc.a.nodes.len {
+			tc.a.nodes[int(node)].pos.str()
+		} else {
+			''
+		}
 	}
 }
 
 fn (mut tc TypeChecker) record_error_unfiltered(kind TypeErrorKind, msg string, node flat.NodeId) {
 	tc.errors << TypeError{
-		msg:  msg
-		kind: kind
-		node: node
+		msg:        msg
+		kind:       kind
+		node:       node
+		file:       tc.cur_file
+		node_kind:  if int(node) >= 0 && int(node) < tc.a.nodes.len {
+			tc.a.nodes[int(node)].kind.str()
+		} else {
+			''
+		}
+		node_value: if int(node) >= 0 && int(node) < tc.a.nodes.len {
+			tc.a.nodes[int(node)].value
+		} else {
+			''
+		}
+		node_pos:   if int(node) >= 0 && int(node) < tc.a.nodes.len {
+			tc.a.nodes[int(node)].pos.str()
+		} else {
+			''
+		}
 	}
 }
 
@@ -553,6 +589,33 @@ fn (mut tc TypeChecker) record_unsupported_generic(msg string, node flat.NodeId)
 		kind: .unsupported_generic
 		node: node
 	}
+}
+
+fn split_sum_variant_texts(text string) []string {
+	mut parts := []string{}
+	mut start := 0
+	mut depth := 0
+	for i in 0 .. text.len {
+		ch := text[i]
+		if ch == `[` || ch == `(` || ch == `{` {
+			depth++
+		} else if ch == `]` || ch == `)` || ch == `}` {
+			if depth > 0 {
+				depth--
+			}
+		} else if ch == `|` && depth == 0 {
+			part := text[start..i].trim_space()
+			if part.len > 0 {
+				parts << part
+			}
+			start = i + 1
+		}
+	}
+	part := text[start..].trim_space()
+	if part.len > 0 {
+		parts << part
+	}
+	return parts
 }
 
 // collect supports collect handling for TypeChecker.
@@ -648,6 +711,21 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 						}
 					}
 				} else if node.typ.len > 0 {
+					if node.typ.contains('|') {
+						mut variants := []string{}
+						for part in split_sum_variant_texts(node.typ) {
+							variants << tc.qualify_sum_variant_name(part, node.generic_params)
+						}
+						qname := tc.qualify_name(node.value)
+						tc.sum_types[qname] = variants
+						if node.generic_params.len > 0 {
+							tc.sum_generic_params[qname] = node.generic_params.clone()
+							if qname != node.value {
+								tc.sum_generic_params[node.value] = node.generic_params.clone()
+							}
+						}
+						continue
+					}
 					qname := tc.qualify_name(node.value)
 					tc.type_aliases[qname] = tc.qualify_type_text(node.typ)
 					if c_abi_fn := tc.c_abi_fn_ptr_type_from_text(node.typ) {
@@ -3546,7 +3624,8 @@ fn (mut tc TypeChecker) check_struct_field_defaults(node flat.Node) {
 		expected := tc.parse_type(field.typ)
 		tc.check_node(default_id)
 		actual := tc.resolve_expr(default_id, expected)
-		if !tc.type_compatible(actual, expected) {
+		if !tc.expr_compatible(default_id, actual, expected)
+			&& !tc.pointer_value_compatible(actual, expected) {
 			tc.type_mismatch(.assignment_mismatch,
 				'cannot initialize field `${field.value}` with `${actual.name()}`; expected `${expected.name()}`',
 				default_id)
@@ -4162,6 +4241,10 @@ fn (mut tc TypeChecker) check_cast_expr(id flat.NodeId, node flat.Node) {
 	}
 	actual := tc.resolve_type(child_id)
 	if actual is Unknown || type_contains_unknown(actual) {
+		return
+	}
+	if is_ierror_type(target)
+		&& (actual is None || (actual is OptionType && actual.base_type is Void)) {
 		return
 	}
 	if !tc.type_implements_interface(actual, target_iface) {
@@ -4784,7 +4867,7 @@ fn (mut tc TypeChecker) check_decl_assign(id flat.NodeId, node flat.Node) {
 		if node.children_count == 2 && node.typ.len > 0 {
 			expected = tc.parse_type(node.typ)
 			rhs_type = tc.resolve_expr(rhs_id, expected)
-			if !tc.type_compatible(rhs_type, expected) {
+			if !tc.expr_compatible(rhs_id, rhs_type, expected) {
 				tc.type_mismatch(.assignment_mismatch,
 					'cannot assign `${rhs_type.name()}` to `${expected.name()}`', id)
 			}
@@ -5285,6 +5368,20 @@ fn (tc &TypeChecker) multi_expr_tail_value_groups(expr_id flat.NodeId, count int
 			}
 			return groups
 		}
+		.match_stmt {
+			if node.children_count < 2 || !tc.match_has_else_or_exhaustive_coverage(node) {
+				return none
+			}
+			mut groups := [][]flat.NodeId{}
+			for i in 1 .. node.children_count {
+				branch_id := tc.a.child(&node, i)
+				branch_groups := tc.tuple_tail_value_groups(branch_id, count) or { return none }
+				for group in branch_groups {
+					groups << group
+				}
+			}
+			return groups
+		}
 		.block, .match_branch {
 			return tc.tuple_tail_value_groups(expr_id, count)
 		}
@@ -5315,7 +5412,7 @@ fn (tc &TypeChecker) tuple_tail_value_groups(body_id flat.NodeId, count int) ?[]
 	last_id := tc.a.child(&body, body.children_count - 1)
 	if tc.valid_node_id(last_id) {
 		last := tc.a.nodes[int(last_id)]
-		if last.kind in [.block, .match_branch, .if_expr] {
+		if last.kind in [.block, .match_branch, .if_expr, .match_stmt] {
 			return tc.multi_expr_tail_value_groups(last_id, count)
 		}
 		if last.kind == .return_stmt {
@@ -5335,7 +5432,12 @@ fn (tc &TypeChecker) tuple_tail_value_groups(body_id flat.NodeId, count int) ?[]
 		if child.kind != .expr_stmt || child.children_count == 0 {
 			break
 		}
-		values.prepend(tc.a.child(&child, 0))
+		for j := int(child.children_count) - 1; j >= 0; j-- {
+			values.prepend(tc.a.child(&child, j))
+			if values.len == count {
+				break
+			}
+		}
 		if values.len == count {
 			mut groups := [][]flat.NodeId{}
 			groups << values
@@ -5460,7 +5562,7 @@ fn (mut tc TypeChecker) check_assign(id flat.NodeId, node flat.Node) {
 			tc.check_node(rhs_id)
 		}
 		rhs_type := tc.resolve_expr(rhs_id, expected_type)
-		if !tc.type_compatible(rhs_type, expected_type) {
+		if !tc.expr_compatible(rhs_id, rhs_type, expected_type) {
 			tc.type_mismatch(.assignment_mismatch,
 				'cannot assign `${rhs_type.name()}` to `${expected_type.name()}`', id)
 		}
@@ -5725,6 +5827,9 @@ fn (mut tc TypeChecker) resolve_lvalue_type(lhs_id flat.NodeId) Type {
 	}
 	if lhs.kind == .selector {
 		tc.check_selector(lhs_id, lhs)
+		if typ := tc.selector_type(lhs_id, lhs) {
+			return typ
+		}
 		return tc.resolve_type(lhs_id)
 	}
 	if lhs.kind == .index {
@@ -5789,6 +5894,29 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 			return
 		}
 	}
+	if expected is ResultType && node.children_count == 1
+		&& !tc.result_return_uses_multi_tail(tc.a.child(&node, 0), expected) {
+		child_id := tc.a.child(&node, 0)
+		$if ownership ? {
+			tc.ownership_check_node_with_deferred_aggregate_consumption(child_id)
+		} $else {
+			tc.check_node(child_id)
+		}
+		if bad_type := tc.invalid_ierror_return_expr_type_name(child_id, expected) {
+			if tc.should_diagnose_invalid_ierror_return(id) {
+				tc.record_error_unfiltered(.return_mismatch,
+					'cannot return `${bad_type}` as `${Type(expected).name()}`', id)
+			}
+			return
+		}
+		actual := tc.resolve_expr(child_id, expected)
+		if tc.return_type_compatible(child_id, actual, expected) {
+			$if ownership ? {
+				tc.ownership_after_return(id, node)
+			}
+			return
+		}
+	}
 	if multi := multi_return_payload_type(expected) {
 		if node.children_count == 1 {
 			child_id := tc.a.child(&node, 0)
@@ -5797,7 +5925,6 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 			} $else {
 				tc.check_node(child_id)
 			}
-			child := tc.a.nodes[int(child_id)]
 			actual := tc.resolve_expr(child_id, expected)
 			if tc.type_compatible(actual, expected) {
 				$if ownership ? {
@@ -5805,18 +5932,23 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 				}
 				return
 			}
-			if child.kind == .match_stmt {
-				if tc.should_diagnose(id) {
-					tc.record_error(.return_mismatch,
-						'match expression branches cannot produce multiple return values', id)
-				}
-				return
-			}
-			if child.kind == .if_expr {
-				if item_types := tc.multi_expr_tail_types(child_id, multi.types.len) {
-					if item_types.len == multi.types.len && tc.should_diagnose(id) {
-						tc.record_error(.return_mismatch,
-							'if expression branches cannot produce multiple return values', id)
+			if item_types := tc.multi_expr_tail_types(child_id, multi.types.len) {
+				if item_types.len == multi.types.len {
+					mut ok := true
+					for i, item_type in item_types {
+						if !tc.type_compatible(item_type, multi.types[i]) {
+							ok = false
+							if tc.should_diagnose(id) {
+								tc.type_mismatch(.return_mismatch,
+									'cannot return `${item_type.name()}` as `${multi.types[i].name()}`',
+									id)
+							}
+						}
+					}
+					if ok {
+						$if ownership ? {
+							tc.ownership_after_return(id, node)
+						}
 					}
 					return
 				}
@@ -5838,7 +5970,7 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 				tc.check_node(child_id)
 			}
 			actual := tc.resolve_expr(child_id, multi.types[i])
-			if !tc.type_compatible(actual, multi.types[i]) {
+			if !tc.return_type_compatible(child_id, actual, multi.types[i]) {
 				tc.type_mismatch(.return_mismatch,
 					'cannot return `${actual.name()}` as `${multi.types[i].name()}`', id)
 			}
@@ -5881,11 +6013,25 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 	}
 }
 
+fn (tc &TypeChecker) result_return_uses_multi_tail(expr_id flat.NodeId, expected Type) bool {
+	multi := multi_return_payload_type(expected) or { return false }
+	return tc.expr_has_tuple_tail_values(expr_id, multi.types.len)
+}
+
 fn (tc &TypeChecker) return_type_compatible(expr_id flat.NodeId, actual Type, expected Type) bool {
-	if tc.type_compatible(actual, expected) {
+	if tc.expr_compatible(expr_id, actual, expected) {
+		return true
+	}
+	if return_numeric_alias_compatible(actual, expected) {
+		return true
+	}
+	if tc.pointer_value_compatible(actual, expected) {
 		return true
 	}
 	if expected is ResultType {
+		if tc.zero_literal_can_be_pointer(expr_id, expected.base_type) {
+			return true
+		}
 		if is_ierror_type(actual) || tc.type_embeds_error(actual) {
 			return true
 		}
@@ -5901,15 +6047,110 @@ fn (tc &TypeChecker) return_type_compatible(expr_id flat.NodeId, actual Type, ex
 	return false
 }
 
+fn (tc &TypeChecker) pointer_value_compatible(actual Type, expected Type) bool {
+	if actual is Pointer {
+		return tc.type_compatible(actual.base_type, expected)
+			|| pointer_value_type_names_match(Type(actual).name(), expected.name())
+			|| bare_type_names_match(actual.base_type.name(), expected.name())
+	}
+	return pointer_value_type_names_match(actual.name(), expected.name())
+}
+
+fn pointer_value_type_names_match(actual string, expected string) bool {
+	if !actual.starts_with('&') {
+		return false
+	}
+	clean_actual := actual[1..]
+	return clean_actual == expected
+}
+
+fn bare_type_names_match(actual string, expected string) bool {
+	return actual == expected
+}
+
+fn return_numeric_alias_compatible(actual Type, expected Type) bool {
+	if expected is Alias {
+		return type_is_numeric(actual) && type_is_numeric(expected.base_type)
+	}
+	return false
+}
+
+fn type_is_numeric(typ Type) bool {
+	clean := if typ is Alias { typ.base_type } else { typ }
+	return clean.is_integer() || clean.is_float()
+}
+
+fn (tc &TypeChecker) expr_compatible(expr_id flat.NodeId, actual Type, expected Type) bool {
+	return tc.type_compatible(actual, expected) || tc.zero_literal_can_be_pointer(expr_id, expected)
+}
+
+fn (tc &TypeChecker) zero_literal_can_be_pointer(expr_id flat.NodeId, expected Type) bool {
+	if !tc.is_zero_literal(expr_id) && !tc.expr_is_unsafe_zero_literal(expr_id) {
+		return false
+	}
+	clean := if expected is Alias { expected.base_type } else { expected }
+	return clean is Pointer
+}
+
+fn (tc &TypeChecker) expr_is_unsafe_zero_literal(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= tc.a.nodes.len {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	if node.kind != .block {
+		return false
+	}
+	return tc.expr_tail_is_zero_literal(id)
+}
+
+fn (tc &TypeChecker) expr_tail_is_zero_literal(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= tc.a.nodes.len {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	match node.kind {
+		.int_literal {
+			return node.value == '0'
+		}
+		.expr_stmt, .paren {
+			if node.children_count == 0 {
+				return false
+			}
+			return tc.expr_tail_is_zero_literal(tc.a.child(&node, 0))
+		}
+		.block {
+			if node.children_count == 0 {
+				return false
+			}
+			return tc.expr_tail_is_zero_literal(tc.a.child(&node, node.children_count - 1))
+		}
+		else {
+			return false
+		}
+	}
+}
+
 fn (tc &TypeChecker) mut_param_expr_base(expr_id flat.NodeId, typ Type) ?Type {
 	if int(expr_id) < 0 || int(expr_id) >= tc.a.nodes.len {
 		return none
 	}
 	node := tc.a.nodes[int(expr_id)]
-	if node.kind != .ident || node.value.len == 0 {
-		return none
+	if node.kind == .ident && node.value.len > 0 {
+		return tc.mut_param_base_for_current_ident(node.value, typ)
 	}
-	return tc.mut_param_base_for_current_ident(node.value, typ)
+	if node.kind == .prefix && node.op == .amp && node.children_count > 0 {
+		child := tc.a.nodes[int(tc.a.child(&node, 0))]
+		if child.kind == .ident && child.value.len > 0 {
+			base := tc.cur_fn_mut_param_base_types[child.value] or { return none }
+			if !tc.mut_param_binding_matches_lvalue(child.value) {
+				return none
+			}
+			return Type(Pointer{
+				base_type: base
+			})
+		}
+	}
+	return none
 }
 
 fn (tc &TypeChecker) should_diagnose_invalid_ierror_return(id flat.NodeId) bool {
@@ -5951,6 +6192,9 @@ fn (mut tc TypeChecker) invalid_ierror_return_expr_type_name(id flat.NodeId, exp
 		return none
 	}
 	if tc.type_compatible(raw_type, expected.base_type) {
+		return none
+	}
+	if tc.zero_literal_can_be_pointer(id, expected.base_type) {
 		return none
 	}
 	node := tc.a.nodes[int(id)]
@@ -6884,6 +7128,24 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 					params_known: true
 				}
 			}
+			if clean.is_flag && fn_node.value in ['set', 'clear'] {
+				return CallInfo{
+					name:         ''
+					params:       tarr2(base_type, base_type)
+					return_type:  Type(void_)
+					has_receiver: true
+					params_known: true
+				}
+			}
+			if clean.is_flag && fn_node.value == 'is_empty' {
+				return CallInfo{
+					name:         ''
+					params:       tarr1(base_type)
+					return_type:  Type(bool_)
+					has_receiver: true
+					params_known: true
+				}
+			}
 			if fn_node.value == 'str' {
 				return CallInfo{
 					name:         '${clean.name}.str'
@@ -6967,12 +7229,12 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 				}
 			}
 		}
+		if imported_name := tc.resolve_selective_import_symbol(fn_node.value) {
+			return tc.call_info(imported_name, false)
+		}
 		qfn := tc.qualify_fn_name(fn_node.value)
 		if qfn in tc.fn_ret_types {
 			return tc.call_info(qfn, false)
-		}
-		if imported_name := tc.resolve_selective_import_symbol(fn_node.value) {
-			return tc.call_info(imported_name, false)
 		}
 		if fn_node.value in tc.fn_ret_types {
 			return tc.call_info(fn_node.value, false)
@@ -7040,12 +7302,17 @@ fn (tc &TypeChecker) current_receiver_param_method_call_info(base_id flat.NodeId
 		return none
 	}
 	receiver_type := tc.parse_type(receiver_name)
-	if !tc.type_compatible(param_type, receiver_type)
-		&& !tc.type_compatible(receiver_type, param_type) {
+	if !tc.receiver_compatible(param_type, receiver_type) {
 		return none
 	}
 	method_name := '${receiver_name}.${method}'
-	for candidate in [method_name, checker_qualified_fn_name(tc.cur_module, method_name)] {
+	qualified_method_name := checker_qualified_fn_name(tc.cur_module, method_name)
+	mut candidates := []string{}
+	if qualified_method_name != method_name {
+		candidates << qualified_method_name
+	}
+	candidates << method_name
+	for candidate in candidates {
 		if candidate in tc.fn_ret_types {
 			return tc.call_info(candidate, true)
 		}
@@ -7953,8 +8220,15 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 		} else {
 			actual = tc.resolve_expr(arg_id, expected)
 		}
-		if !tc.receiver_compatible(actual, expected) && !tc.type_compatible(actual, expected) {
+		if !tc.receiver_compatible(actual, expected)
+			&& !tc.expr_compatible(arg_id, actual, expected) {
 			if json_encode_accepts_arg(info.name, param_idx, expected, actual) {
+				continue
+			}
+			if free_array_arg_compatible(info.name, param_idx, expected, actual) {
+				continue
+			}
+			if voidptr_arg_compatible(expected, actual) {
 				continue
 			}
 			if tc.array_insert_prepend_many_arg_compatible(node, info, param_idx, actual) {
@@ -7983,6 +8257,24 @@ fn json_encode_accepts_arg(name string, param_idx int, expected Type, actual Typ
 		}
 	}
 	return false
+}
+
+fn free_array_arg_compatible(name string, param_idx int, expected Type, actual Type) bool {
+	if param_idx != 0 || name !in ['free', 'builtin.free'] || !fn_param_is_voidptr_type(expected) {
+		return false
+	}
+	mut clean := unwrap_pointer(actual)
+	if clean is Alias {
+		clean = clean.base_type
+	}
+	return clean is Array
+}
+
+fn voidptr_arg_compatible(expected Type, actual Type) bool {
+	if !fn_param_is_voidptr_type(expected) {
+		return false
+	}
+	return type_has_runtime_value(actual)
 }
 
 fn variadic_elem_accepts_any(typ Type) bool {
@@ -10033,7 +10325,8 @@ fn (mut tc TypeChecker) check_is_expr(id flat.NodeId, node flat.Node) {
 	}
 	if is_ierror_type(expr_type) {
 		if node.value.len > 0 {
-			if _ := tc.resolve_ierror_match_pattern(node.value) {
+			if node.value == 'none' {
+			} else if _ := tc.resolve_ierror_match_pattern(node.value) {
 			} else if tc.should_diagnose(id) {
 				tc.record_error(.condition_mismatch,
 					'`${node.value}` is not compatible with `IError`', id)
@@ -10346,7 +10639,8 @@ fn (mut tc TypeChecker) check_struct_init(id flat.NodeId, node flat.Node) {
 			}
 			if expected !is Void {
 				actual := tc.resolve_expr(value_id, expected)
-				if !tc.type_compatible(actual, expected) {
+				if !tc.expr_compatible(value_id, actual, expected)
+					&& !tc.pointer_value_compatible(actual, expected) {
 					tc.type_mismatch(.assignment_mismatch,
 						'cannot initialize field `${field.value}` with `${actual.name()}`; expected `${expected.name()}`',
 						field_id)
@@ -10786,11 +11080,17 @@ fn (mut tc TypeChecker) check_ident(id flat.NodeId, node flat.Node) {
 		tc.register_synth_type(id, typ)
 		return
 	}
+	qname := tc.qualify_name(node.value)
+	if qname != node.value {
+		if typ := tc.file_scope.lookup(qname) {
+			tc.register_synth_type(id, typ)
+			return
+		}
+	}
 	if node.value == 'err' {
 		tc.register_synth_type(id, tc.parse_type('IError'))
 		return
 	}
-	qname := tc.qualify_name(node.value)
 	if typ := tc.const_types[qname] {
 		tc.register_synth_type(id, typ)
 		return
@@ -11263,6 +11563,13 @@ fn (tc &TypeChecker) type_compatible(actual Type, expected Type) bool {
 	if type_contains_unknown(actual) || type_contains_unknown(expected) {
 		return true
 	}
+	if (actual.name().contains('[') || expected.name().contains('['))
+		&& tc.generic_type_name_matches(actual.name(), expected.name()) {
+		return true
+	}
+	if tc.sum_variant_type_for_pattern(expected.name(), actual.name()) != none {
+		return true
+	}
 	if actual is Alias && expected is Alias {
 		return tc.type_compatible(actual.base_type, expected.base_type)
 	}
@@ -11288,7 +11595,7 @@ fn (tc &TypeChecker) type_compatible(actual Type, expected Type) bool {
 		return true
 	}
 	if actual is None {
-		return expected is OptionType || expected is ResultType
+		return expected is OptionType || expected is ResultType || is_ierror_type(expected)
 	}
 	if expected is OptionType {
 		if actual is OptionType {
@@ -12038,7 +12345,7 @@ pub fn (tc &TypeChecker) ierror_impl_names() []string {
 	return impls
 }
 
-fn (tc &TypeChecker) concrete_method_signature_key(concrete_name string, method string) ?string {
+pub fn (tc &TypeChecker) concrete_method_signature_key(concrete_name string, method string) ?string {
 	key := '${concrete_name}.${method}'
 	if key in tc.fn_param_types || key in tc.fn_ret_types {
 		return key
@@ -12046,6 +12353,11 @@ fn (tc &TypeChecker) concrete_method_signature_key(concrete_name string, method 
 	if indexed := tc.receiver_method_suffix_index[key] {
 		if indexed != receiver_method_suffix_ambiguous {
 			return indexed
+		}
+	}
+	if info := tc.embedded_method_call_info(concrete_name, method) {
+		if info.name.len > 0 {
+			return info.name
 		}
 	}
 	return none
@@ -12983,6 +13295,17 @@ fn (tc &TypeChecker) sum_base_name(sum_name string) string {
 	if qname in tc.sum_types {
 		return qname
 	}
+	if sum_name.contains('.') {
+		resolved := tc.resolve_imported_type_text(sum_name)
+		if resolved in tc.sum_types {
+			return resolved
+		}
+		if unique := tc.unique_qualified_type_name(sum_name.all_after_last('.')) {
+			if unique in tc.sum_types {
+				return unique
+			}
+		}
+	}
 	return sum_name
 }
 
@@ -13210,6 +13533,15 @@ pub fn (tc &TypeChecker) sum_variant_type_for_pattern(sum_name string, variant_n
 	qvariant := tc.qualify_name(variant_name)
 	if qvariant != variant_name {
 		candidates << qvariant
+	}
+	if variant_name.contains('.') {
+		resolved := tc.resolve_imported_type_text(variant_name)
+		if resolved != variant_name {
+			candidates << resolved
+		}
+		if unique := tc.unique_qualified_type_name(variant_name.all_after_last('.')) {
+			candidates << unique
+		}
 	}
 	for variant in variants {
 		concrete := tc.concrete_sum_variant_name(sum_name, variant)
@@ -13558,6 +13890,11 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 			reason: 'unknown'
 		})
 	}
+	if qtyp != typ {
+		if scoped_type := tc.type_from_known_symbol(qtyp) {
+			return scoped_type
+		}
+	}
 	if !typ.contains('.') {
 		if resolved := tc.resolve_selective_import_type_symbol(typ) {
 			if resolved_type := tc.type_from_known_symbol(resolved) {
@@ -13597,20 +13934,14 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 			name: typ
 		})
 	}
-	if typ in tc.structs {
-		return Type(Struct{
-			name: typ
-		})
-	}
 	if qtyp in tc.structs {
 		return Type(Struct{
 			name: qtyp
 		})
 	}
-	if typ in tc.flag_enums {
-		return Type(Enum{
-			name:    typ
-			is_flag: true
+	if typ in tc.structs {
+		return Type(Struct{
+			name: typ
 		})
 	}
 	if qtyp in tc.flag_enums {
@@ -13619,9 +13950,10 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 			is_flag: true
 		})
 	}
-	if typ in tc.enum_names {
+	if typ in tc.flag_enums {
 		return Type(Enum{
-			name: typ
+			name:    typ
+			is_flag: true
 		})
 	}
 	if qtyp in tc.enum_names {
@@ -13629,14 +13961,19 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 			name: qtyp
 		})
 	}
-	if typ in tc.sum_types {
-		return Type(SumType{
+	if typ in tc.enum_names {
+		return Type(Enum{
 			name: typ
 		})
 	}
 	if qtyp in tc.sum_types {
 		return Type(SumType{
 			name: qtyp
+		})
+	}
+	if typ in tc.sum_types {
+		return Type(SumType{
+			name: typ
 		})
 	}
 	if !typ.contains('.') {
@@ -14222,6 +14559,11 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 				return typ
 			}
 			qname := tc.qualify_name(node.value)
+			if qname != node.value {
+				if typ := tc.file_scope.lookup(qname) {
+					return typ
+				}
+			}
 			if qname in tc.const_types {
 				return tc.const_types[qname] or { unknown_type('unknown const `${qname}`') }
 			}
@@ -14572,6 +14914,14 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 			lt_raw := lt
 			rt := tc.resolve_type(rhs_id)
 			rt_raw := rt
+			if node.op in [.plus, .minus] {
+				if lt is Pointer && rt.is_integer() {
+					return lt_raw
+				}
+				if node.op == .plus && rt is Pointer && lt.is_integer() {
+					return rt_raw
+				}
+			}
 			if operator_ret := tc.infix_operator_return_type(node.op, lt, rt) {
 				return operator_ret
 			}
@@ -14605,7 +14955,18 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 				return tc.parse_type(node.typ)
 			}
 			if node.op == .amp {
-				inner := tc.resolve_type(tc.a.child(&node, 0))
+				child_id := tc.a.child(&node, 0)
+				child := tc.a.nodes[int(child_id)]
+				if child.kind == .ident && child.value.len > 0 {
+					if base := tc.cur_fn_mut_param_base_types[child.value] {
+						if tc.mut_param_binding_matches_lvalue(child.value) {
+							return Type(Pointer{
+								base_type: base
+							})
+						}
+					}
+				}
+				inner := tc.resolve_type(child_id)
 				return Type(Pointer{
 					base_type: inner
 				})

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -6022,7 +6022,7 @@ fn (tc &TypeChecker) return_type_compatible(expr_id flat.NodeId, actual Type, ex
 	if tc.expr_compatible(expr_id, actual, expected) {
 		return true
 	}
-	if return_numeric_alias_compatible(actual, expected) {
+	if tc.return_numeric_alias_compatible(actual, expected) {
 		return true
 	}
 	if tc.pointer_value_compatible(actual, expected) {
@@ -6049,11 +6049,20 @@ fn (tc &TypeChecker) return_type_compatible(expr_id flat.NodeId, actual Type, ex
 
 fn (tc &TypeChecker) pointer_value_compatible(actual Type, expected Type) bool {
 	if actual is Pointer {
+		if !pointer_value_base_can_match(actual.base_type) {
+			return false
+		}
 		return tc.type_compatible(actual.base_type, expected)
 			|| pointer_value_type_names_match(Type(actual).name(), expected.name())
 			|| bare_type_names_match(actual.base_type.name(), expected.name())
 	}
 	return pointer_value_type_names_match(actual.name(), expected.name())
+}
+
+fn pointer_value_base_can_match(typ Type) bool {
+	clean := if typ is Alias { typ.base_type } else { typ }
+	return clean is Struct || clean is Interface || clean is SumType || clean is Array
+		|| clean is ArrayFixed || clean is Map || clean is Channel
 }
 
 fn pointer_value_type_names_match(actual string, expected string) bool {
@@ -6068,9 +6077,9 @@ fn bare_type_names_match(actual string, expected string) bool {
 	return actual == expected
 }
 
-fn return_numeric_alias_compatible(actual Type, expected Type) bool {
+fn (tc &TypeChecker) return_numeric_alias_compatible(actual Type, expected Type) bool {
 	if expected is Alias {
-		return type_is_numeric(actual) && type_is_numeric(expected.base_type)
+		return type_is_numeric(expected.base_type) && tc.type_compatible(actual, expected.base_type)
 	}
 	return false
 }

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -14025,6 +14025,11 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 		generic_suffix := typ[bracket..]
 		_, generic_args, _ := generic_type_application_parts(typ)
 		is_concrete_generic := tc.generic_args_are_concrete(generic_args)
+		struct_generic_suffix := if is_concrete_generic {
+			tc.qualified_generic_suffix(generic_args)
+		} else {
+			generic_suffix
+		}
 		sum_generic_suffix := if is_concrete_generic {
 			tc.qualified_generic_suffix(generic_args)
 		} else {
@@ -14039,7 +14044,7 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 		}
 		if qbase in tc.structs {
 			return Type(Struct{
-				name: if is_concrete_generic { qbase + generic_suffix } else { qbase }
+				name: qbase + struct_generic_suffix
 			})
 		}
 		if qbase in tc.interface_names {
@@ -14062,7 +14067,7 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 				}
 				if resolved in tc.structs {
 					return Type(Struct{
-						name: if is_concrete_generic { resolved + generic_suffix } else { resolved }
+						name: resolved + struct_generic_suffix
 					})
 				}
 				if resolved in tc.interface_names {
@@ -14085,7 +14090,7 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 		}
 		if base in tc.structs {
 			return Type(Struct{
-				name: if is_concrete_generic { typ } else { base }
+				name: base + struct_generic_suffix
 			})
 		}
 		if base in tc.interface_names {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5957,6 +5957,14 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 				}
 				return
 			}
+			if ok := tc.multi_expr_tail_return_compatible(id, child_id, multi.types) {
+				if ok {
+					$if ownership ? {
+						tc.ownership_after_return(id, node)
+					}
+				}
+				return
+			}
 			if item_types := tc.multi_expr_tail_types(child_id, multi.types.len) {
 				if item_types.len == multi.types.len {
 					mut ok := true
@@ -6036,6 +6044,49 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 	$if ownership ? {
 		tc.ownership_after_return(id, node)
 	}
+}
+
+fn (mut tc TypeChecker) multi_expr_tail_return_compatible(return_id flat.NodeId, expr_id flat.NodeId, expected []Type) ?bool {
+	if !tc.multi_expr_tail_return_compat_supported(expr_id) {
+		return none
+	}
+	groups := tc.multi_expr_tail_value_groups(expr_id, expected.len) or { return none }
+	if groups.len == 0 {
+		return none
+	}
+	mut ok := true
+	for group in groups {
+		if group.len != expected.len {
+			return none
+		}
+		for i, value_id in group {
+			actual := tc.resolve_expr(value_id, expected[i])
+			if !type_has_runtime_value(actual) {
+				return none
+			}
+			if !tc.return_type_compatible(value_id, actual, expected[i]) {
+				ok = false
+				tc.type_mismatch(.return_mismatch,
+					'cannot return `${actual.name()}` as `${expected[i].name()}`', return_id)
+			}
+		}
+	}
+	return ok
+}
+
+fn (tc &TypeChecker) multi_expr_tail_return_compat_supported(expr_id flat.NodeId) bool {
+	if !tc.valid_node_id(expr_id) {
+		return false
+	}
+	node := tc.a.nodes[int(expr_id)]
+	// Raw tuple-tail return lowering is currently only implemented for if-expressions.
+	if node.kind == .if_expr {
+		return true
+	}
+	if node.kind == .expr_stmt && node.children_count > 0 {
+		return tc.multi_expr_tail_return_compat_supported(tc.a.child(&node, 0))
+	}
+	return false
 }
 
 fn (tc &TypeChecker) result_return_uses_multi_tail(expr_id flat.NodeId, expected Type) bool {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -711,9 +711,10 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 						}
 					}
 				} else if node.typ.len > 0 {
-					if node.typ.contains('|') {
+					sum_variant_texts := split_sum_variant_texts(node.typ)
+					if sum_variant_texts.len > 1 {
 						mut variants := []string{}
-						for part in split_sum_variant_texts(node.typ) {
+						for part in sum_variant_texts {
 							variants << tc.qualify_sum_variant_name(part, node.generic_params)
 						}
 						qname := tc.qualify_name(node.value)

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -268,6 +268,7 @@ pub mut:
 	cur_fn_node_id                  int = -1
 	cur_fn_mut_param_base_types     map[string]Type
 	cur_fn_mut_param_binding_owners map[string]ScopeBindingOwner
+	cur_fn_mut_local_binding_owners map[string]ScopeBindingOwner
 	expr_type_values                []Type // node_id -> complex/contextual resolved type
 	expr_type_set                   []bool
 	checking_nodes                  []bool
@@ -351,6 +352,7 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		method_value_local_depth:           map[string]int{}
 		cur_fn_mut_param_base_types:        map[string]Type{}
 		cur_fn_mut_param_binding_owners:    map[string]ScopeBindingOwner{}
+		cur_fn_mut_local_binding_owners:    map[string]ScopeBindingOwner{}
 		expr_type_values:                   []Type{len: a.nodes.len, init: Type(void_)}
 		expr_type_set:                      []bool{len: a.nodes.len}
 		checking_nodes:                     []bool{len: a.nodes.len}
@@ -1742,8 +1744,10 @@ pub fn (mut tc TypeChecker) annotate_types_with_used(used_fns map[string]bool) {
 			}
 			mut saved_mut_params := tc.cur_fn_mut_param_base_types.move()
 			mut saved_mut_param_owners := tc.cur_fn_mut_param_binding_owners.move()
+			mut saved_mut_local_owners := tc.cur_fn_mut_local_binding_owners.move()
 			tc.cur_fn_mut_param_base_types = map[string]Type{}
 			tc.cur_fn_mut_param_binding_owners = map[string]ScopeBindingOwner{}
+			tc.cur_fn_mut_local_binding_owners = map[string]ScopeBindingOwner{}
 			tc.cur_scope = tc.file_scope
 			tc.push_scope()
 			for pi in 0 .. node.children_count {
@@ -1760,6 +1764,7 @@ pub fn (mut tc TypeChecker) annotate_types_with_used(used_fns map[string]bool) {
 			tc.pop_scope()
 			tc.cur_fn_mut_param_base_types = saved_mut_params.move()
 			tc.cur_fn_mut_param_binding_owners = saved_mut_param_owners.move()
+			tc.cur_fn_mut_local_binding_owners = saved_mut_local_owners.move()
 		}
 	}
 }
@@ -2292,12 +2297,15 @@ pub fn (mut tc TypeChecker) check_semantics() {
 			.fn_decl {
 				mut saved_mut_params := tc.cur_fn_mut_param_base_types.move()
 				mut saved_mut_param_owners := tc.cur_fn_mut_param_binding_owners.move()
+				mut saved_mut_local_owners := tc.cur_fn_mut_local_binding_owners.move()
 				tc.cur_fn_mut_param_base_types = map[string]Type{}
 				tc.cur_fn_mut_param_binding_owners = map[string]ScopeBindingOwner{}
+				tc.cur_fn_mut_local_binding_owners = map[string]ScopeBindingOwner{}
 				tc.check_decl_type_strings(flat.NodeId(i), node)
 				tc.check_fn_decl_semantics(i, node, tc.cur_file, tc.cur_module)
 				tc.cur_fn_mut_param_base_types = saved_mut_params.move()
 				tc.cur_fn_mut_param_binding_owners = saved_mut_param_owners.move()
+				tc.cur_fn_mut_local_binding_owners = saved_mut_local_owners.move()
 			}
 			.c_fn_decl {
 				if tc.reject_unsupported_generics {
@@ -4622,8 +4630,10 @@ fn (mut tc TypeChecker) check_fn_literal(node flat.Node) {
 	saved_ret := tc.cur_fn_ret_type
 	mut saved_mut_params := tc.cur_fn_mut_param_base_types.move()
 	mut saved_mut_param_owners := tc.cur_fn_mut_param_binding_owners.move()
+	mut saved_mut_local_owners := tc.cur_fn_mut_local_binding_owners.move()
 	tc.cur_fn_mut_param_base_types = map[string]Type{}
 	tc.cur_fn_mut_param_binding_owners = map[string]ScopeBindingOwner{}
+	tc.cur_fn_mut_local_binding_owners = map[string]ScopeBindingOwner{}
 	tc.cur_fn_ret_type = tc.parse_type(node.typ)
 	$if ownership ? {
 		tc.ownership_begin_fn_literal(node)
@@ -4648,6 +4658,7 @@ fn (mut tc TypeChecker) check_fn_literal(node flat.Node) {
 	tc.cur_fn_ret_type = saved_ret
 	tc.cur_fn_mut_param_base_types = saved_mut_params.move()
 	tc.cur_fn_mut_param_binding_owners = saved_mut_param_owners.move()
+	tc.cur_fn_mut_local_binding_owners = saved_mut_local_owners.move()
 }
 
 // check_lambda_expr validates check lambda expr state for types.
@@ -4873,7 +4884,7 @@ fn (mut tc TypeChecker) check_decl_assign(id flat.NodeId, node flat.Node) {
 					'cannot assign `${rhs_type.name()}` to `${expected.name()}`', id)
 			}
 		}
-		tc.insert_decl_lhs(lhs_id, expected)
+		tc.insert_decl_lhs(lhs_id, expected, tc.decl_lhs_is_mut(node, lhs_id))
 		$if ownership ? {
 			tc.ownership_after_decl_assign(lhs_id, rhs_id, expected, id)
 		}
@@ -5060,7 +5071,7 @@ fn (mut tc TypeChecker) check_multi_return_decl_assign(id flat.NodeId, node flat
 				types: rhs_types
 			})
 			for i, lhs_id in lhs_ids {
-				tc.insert_decl_lhs(lhs_id, rhs_types[i])
+				tc.insert_decl_lhs(lhs_id, rhs_types[i], tc.decl_lhs_is_mut(node, lhs_id))
 			}
 			$if ownership ? {
 				tc.ownership_after_multi_return_decl_assign(lhs_ids, rhs_id, MultiReturn{
@@ -5085,7 +5096,7 @@ fn (mut tc TypeChecker) check_multi_return_decl_assign(id flat.NodeId, node flat
 		tc.check_node(rhs_id)
 		if rhs_types := tc.multi_expr_tail_types(rhs_id, lhs_ids.len) {
 			for i, lhs_id in lhs_ids {
-				tc.insert_decl_lhs(lhs_id, rhs_types[i])
+				tc.insert_decl_lhs(lhs_id, rhs_types[i], tc.decl_lhs_is_mut(node, lhs_id))
 			}
 			$if ownership ? {
 				tc.ownership_after_multi_return_decl_assign(lhs_ids, rhs_id, MultiReturn{
@@ -5151,7 +5162,7 @@ fn (mut tc TypeChecker) check_multi_return_decl_assign(id flat.NodeId, node flat
 			return true
 		}
 		for i, lhs_id in lhs_ids {
-			tc.insert_decl_lhs(lhs_id, rhs_multi.types[i])
+			tc.insert_decl_lhs(lhs_id, rhs_multi.types[i], tc.decl_lhs_is_mut(node, lhs_id))
 		}
 		$if ownership ? {
 			tc.ownership_after_multi_return_decl_assign(lhs_ids, rhs_id, rhs_multi, id)
@@ -5488,7 +5499,17 @@ fn (tc &TypeChecker) multi_assign_rhs_id(node flat.Node, index int) flat.NodeId 
 }
 
 // insert_decl_lhs updates insert decl lhs state for types.
-fn (mut tc TypeChecker) insert_decl_lhs(lhs_id flat.NodeId, typ Type) {
+fn (tc &TypeChecker) decl_lhs_is_mut(node flat.Node, lhs_id flat.NodeId) bool {
+	if node.is_mut {
+		return true
+	}
+	if int(lhs_id) < 0 || int(lhs_id) >= tc.a.nodes.len {
+		return false
+	}
+	return tc.a.nodes[int(lhs_id)].is_mut
+}
+
+fn (mut tc TypeChecker) insert_decl_lhs(lhs_id flat.NodeId, typ Type, is_mut bool) {
 	if int(lhs_id) < 0 || typ is Void {
 		return
 	}
@@ -5499,7 +5520,10 @@ fn (mut tc TypeChecker) insert_decl_lhs(lhs_id flat.NodeId, typ Type) {
 			tc.record_error(.assignment_mismatch, 'redefinition of ${lhs.value}', lhs_id)
 			return
 		}
-		tc.cur_scope.insert(lhs.value, typ)
+		owner := tc.cur_scope.insert_with_owner(lhs.value, typ)
+		if is_mut && lhs.value != '_' {
+			tc.cur_fn_mut_local_binding_owners[lhs.value] = owner
+		}
 		tc.register_synth_type(lhs_id, typ)
 	}
 }
@@ -7884,6 +7908,59 @@ fn (tc &TypeChecker) expr_can_take_address(id flat.NodeId) bool {
 	}
 }
 
+fn (tc &TypeChecker) flag_enum_mutating_receiver_method(fn_node flat.Node, recv_type Type, info CallInfo) ?string {
+	if !info.has_receiver || fn_node.kind != .selector || fn_node.value !in ['set', 'clear'] {
+		return none
+	}
+	clean := unwrap_pointer(recv_type)
+	if clean is Enum && (clean.is_flag || clean.name in tc.flag_enums) {
+		return fn_node.value
+	}
+	return none
+}
+
+fn (tc &TypeChecker) flag_enum_receiver_is_mutable_lvalue(recv_id flat.NodeId) bool {
+	if !tc.expr_can_take_address(recv_id) {
+		return false
+	}
+	return tc.expr_root_is_mutable_lvalue(recv_id)
+}
+
+fn (tc &TypeChecker) expr_root_is_mutable_lvalue(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= tc.a.nodes.len {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	match node.kind {
+		.ident {
+			return tc.ident_is_mutable_lvalue(node.value)
+		}
+		.index, .selector, .paren {
+			return node.children_count > 0 && tc.expr_root_is_mutable_lvalue(tc.a.child(&node, 0))
+		}
+		.prefix {
+			return node.op == .mul
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn (tc &TypeChecker) ident_is_mutable_lvalue(name string) bool {
+	if name.len == 0 {
+		return false
+	}
+	if tc.mut_param_binding_matches_lvalue(name) {
+		return true
+	}
+	owner := tc.cur_fn_mut_local_binding_owners[name] or { return false }
+	if tc.cur_scope == unsafe { nil } {
+		return false
+	}
+	return tc.cur_scope.nearest_binding_owned_by(name, owner)
+}
+
 fn (tc &TypeChecker) map_builtin_call_info(base_type Type, m Map, method string, mname string) ?CallInfo {
 	if !checker_is_raw_collection_method_name(mname, 'map.') {
 		return none
@@ -8115,6 +8192,12 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 			&& !tc.receiver_embeds(recv_type, info.params[0]) {
 			tc.type_mismatch(.call_arg_mismatch,
 				'cannot use receiver `${recv_type.name()}` as `${info.params[0].name()}`', id)
+		}
+		if method := tc.flag_enum_mutating_receiver_method(fn_node, recv_type, info) {
+			if !tc.flag_enum_receiver_is_mutable_lvalue(recv_id) && tc.should_diagnose(id) {
+				tc.record_error(.call_arg_mismatch,
+					'flag enum method `${method}` requires a mutable receiver', id)
+			}
 		}
 	}
 	for i in 1 + info.arg_offset .. node.children_count {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -12290,13 +12290,28 @@ pub fn (tc &TypeChecker) named_type_implements_interface(concrete_name string, i
 	// Methods defined directly on the interface (default implementations) are
 	// inherited and need not be reimplemented.
 	for method in tc.interface_abstract_method_names(iface_name) {
-		concrete_key := tc.concrete_method_signature_key(concrete_name, method) or { return false }
 		expected_key := tc.interface_method_signature_key(iface_name, method) or {
 			'${iface_name}.${method}'
 		}
-		if !tc.method_signature_compatible(concrete_key, expected_key) {
-			return false
+		if concrete_key := tc.concrete_method_signature_key(concrete_name, method) {
+			if !tc.method_signature_compatible(concrete_key, expected_key) {
+				return false
+			}
+			continue
 		}
+		if info := tc.resolve_generic_struct_method(concrete_name, method) {
+			if !tc.method_call_info_signature_compatible(info, expected_key) {
+				return false
+			}
+			continue
+		}
+		if info := tc.resolve_generic_sum_method(concrete_name, method) {
+			if !tc.method_call_info_signature_compatible(info, expected_key) {
+				return false
+			}
+			continue
+		}
+		return false
 	}
 	for field in tc.interface_field_list(iface_name) {
 		actual_field := tc.struct_field_type(concrete_name, field.name) or { return false }
@@ -12448,6 +12463,16 @@ pub fn (tc &TypeChecker) concrete_method_signature_key(concrete_name string, met
 	if key in tc.fn_param_types || key in tc.fn_ret_types {
 		return key
 	}
+	for candidate in tc.concrete_generic_method_signature_candidates(concrete_name, method) {
+		if candidate in tc.fn_param_types || candidate in tc.fn_ret_types {
+			return candidate
+		}
+		if indexed := tc.receiver_method_suffix_index[candidate] {
+			if indexed != receiver_method_suffix_ambiguous {
+				return indexed
+			}
+		}
+	}
 	if indexed := tc.receiver_method_suffix_index[key] {
 		if indexed != receiver_method_suffix_ambiguous {
 			return indexed
@@ -12459,6 +12484,54 @@ pub fn (tc &TypeChecker) concrete_method_signature_key(concrete_name string, met
 		}
 	}
 	return none
+}
+
+fn (tc &TypeChecker) concrete_generic_method_signature_candidates(concrete_name string, method string) []string {
+	base, args, ok := generic_type_application_parts(concrete_name)
+	if !ok || args.len == 0 || method.len == 0 {
+		return []string{}
+	}
+	short_args := generic_type_args_short_for_signature(args)
+	suffix := generic_type_suffix_for_signature(args)
+	short_base := base.all_after_last('.')
+	mut candidates := []string{}
+	for receiver in [base, short_base] {
+		candidates << '${receiver}[${short_args}].${method}'
+		candidates << '${receiver}_${suffix}.${method}'
+		candidates << naming.c_name('${receiver}[${short_args}].${method}')
+		candidates << naming.c_name('${receiver}_${suffix}.${method}')
+		candidates << '${naming.c_name(receiver)}_${suffix}__${naming.c_name(method)}'
+	}
+	return candidates
+}
+
+fn generic_type_args_short_for_signature(args []string) string {
+	mut parts := []string{cap: args.len}
+	for arg in args {
+		parts << generic_type_arg_short_for_signature(arg)
+	}
+	return parts.join(', ')
+}
+
+fn generic_type_suffix_for_signature(args []string) string {
+	mut parts := []string{cap: args.len}
+	for arg in args {
+		parts << naming.c_name(generic_type_arg_short_for_signature(arg).replace('[]', 'Array_').replace('&',
+			'ptr_'))
+	}
+	return parts.join('_')
+}
+
+fn generic_type_arg_short_for_signature(type_arg string) string {
+	clean := type_arg.trim_space()
+	if clean.contains('.') {
+		short := clean.all_after_last('.')
+		if short.starts_with('Array_') {
+			return clean
+		}
+		return short
+	}
+	return clean
 }
 
 pub fn (tc &TypeChecker) named_type_compatible_with_ierror(concrete_name string) bool {
@@ -13327,6 +13400,20 @@ fn (tc &TypeChecker) method_signature_compatible(actual_key string, expected_key
 	actual_ret := tc.fn_ret_types[actual_key] or { Type(void_) }
 	expected_ret := tc.fn_ret_types[expected_key] or { Type(void_) }
 	return tc.type_compatible(actual_ret, expected_ret)
+}
+
+fn (tc &TypeChecker) method_call_info_signature_compatible(actual CallInfo, expected_key string) bool {
+	expected_params := tc.fn_param_types[expected_key] or { return false }
+	if actual.params.len != expected_params.len {
+		return false
+	}
+	for i in 1 .. actual.params.len {
+		if !tc.method_param_signature_compatible(actual.params[i], expected_params[i]) {
+			return false
+		}
+	}
+	expected_ret := tc.fn_ret_types[expected_key] or { Type(void_) }
+	return tc.type_compatible(actual.return_type, expected_ret)
 }
 
 fn (tc &TypeChecker) method_param_signature_compatible(actual Type, expected Type) bool {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -8274,7 +8274,12 @@ fn voidptr_arg_compatible(expected Type, actual Type) bool {
 	if !fn_param_is_voidptr_type(expected) {
 		return false
 	}
-	return type_has_runtime_value(actual)
+	return voidptr_arg_type_passes_direct(actual)
+}
+
+fn voidptr_arg_type_passes_direct(typ Type) bool {
+	clean := fn_param_unalias_type(typ)
+	return clean is Pointer || clean is Nil
 }
 
 fn variadic_elem_accepts_any(typ Type) bool {

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -5582,7 +5582,21 @@ fn (mut tc TypeChecker) ownership_owned_descendant_names(prefix string) []string
 		}
 	}
 	names.sort()
-	return names
+	mut deduped := []string{cap: names.len}
+	for name in names {
+		mut covered_by_dynamic := false
+		for existing in deduped {
+			if ownership_storage_key_has_dynamic_index(existing)
+				&& ownership_storage_keys_overlap(name, existing) {
+				covered_by_dynamic = true
+				break
+			}
+		}
+		if !covered_by_dynamic {
+			deduped << name
+		}
+	}
+	return deduped
 }
 
 fn (mut tc TypeChecker) ownership_mark_array_literal_elements(lhs_name string, rhs_id flat.NodeId, pos flat.NodeId) bool {

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -262,8 +262,10 @@ fn (mut tc TypeChecker) check_fn_items_serial(items []CheckWorkItem) {
 fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file string, module_name string) {
 	mut saved_mut_params := tc.cur_fn_mut_param_base_types.move()
 	mut saved_mut_param_owners := tc.cur_fn_mut_param_binding_owners.move()
+	mut saved_mut_local_owners := tc.cur_fn_mut_local_binding_owners.move()
 	tc.cur_fn_mut_param_base_types = map[string]Type{}
 	tc.cur_fn_mut_param_binding_owners = map[string]ScopeBindingOwner{}
+	tc.cur_fn_mut_local_binding_owners = map[string]ScopeBindingOwner{}
 	tc.cur_file = file
 	tc.cur_module = module_name
 	tc.cur_scope = tc.file_scope
@@ -297,6 +299,7 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 	tc.cur_fn_ret_type = Type(void_)
 	tc.cur_fn_mut_param_base_types = saved_mut_params.move()
 	tc.cur_fn_mut_param_binding_owners = saved_mut_param_owners.move()
+	tc.cur_fn_mut_local_binding_owners = saved_mut_local_owners.move()
 }
 
 fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
@@ -325,6 +328,7 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 	w.method_value_local_depth = map[string]int{}
 	w.cur_fn_mut_param_base_types = map[string]Type{}
 	w.cur_fn_mut_param_binding_owners = map[string]ScopeBindingOwner{}
+	w.cur_fn_mut_local_binding_owners = map[string]ScopeBindingOwner{}
 	w.generic_method_value_info = map[string]CallInfo{}
 	w.smartcasts = map[string]Type{}
 	w.cur_fn_ret_type = Type(void_)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -650,7 +650,7 @@ fn expand_single_test_file_inputs(user_files []string, prefs &pref.Preferences) 
 	for file in user_files {
 		if pref.is_test_file_for_backend(file, prefs.backend) {
 			module_name := declared_module_in_file(file)
-			if module_name.len > 0 && module_name != 'main' && module_name != 'builtin' {
+			if module_name.len > 0 && module_name != 'builtin' {
 				for module_file in same_dir_module_source_files(file, module_name, prefs) {
 					append_unique_file(mut expanded, mut seen, module_file)
 				}
@@ -826,7 +826,8 @@ fn print_type_errors(errors []types.TypeError) {
 	eprintln('type checker found ${errors.len} error(s):')
 	max_errors := if errors.len < 20 { errors.len } else { 20 }
 	for ei in 0 .. max_errors {
-		eprintln('  ${errors[ei].msg}')
+		err := errors[ei]
+		eprintln('  [${err.file}] ${err.node_pos} node=${err.node} ${err.node_kind} `${err.node_value}`: ${err.msg}')
 	}
 	if errors.len > 20 {
 		eprintln('  ... and ${errors.len - 20} more')

--- a/vlib/v3/v3_test_failures.txt
+++ b/vlib/v3/v3_test_failures.txt
@@ -8,17 +8,12 @@ cmd/tools/vdoc/document/get_parent_mod_issue_14224_test.v
 cmd/tools/vdoc/vdoc_file_test.v
 cmd/tools/vdoc/vdoc_test.v
 cmd/tools/vpm/args_test.v
-cmd/tools/vpm/dependency_test.v
 cmd/tools/vpm/install_local_test.v
 cmd/tools/vpm/install_test.v
-cmd/tools/vpm/install_version_input_test.v
 cmd/tools/vpm/install_version_test.v
-cmd/tools/vpm/link_test.v
 cmd/tools/vpm/outdated_test.v
-cmd/tools/vpm/remove_test.v
 cmd/tools/vpm/search_test.v
 cmd/tools/vpm/settings_test.v
-cmd/tools/vpm/update_test.v
 cmd/tools/vpm/vcs_test.v
 cmd/tools/vretry_test.v
 cmd/tools/vsymlink/vsymlink_test.v
@@ -86,17 +81,12 @@ vlib/crypto/hkdf/hkdf_test.v
 vlib/crypto/pem/pem_test.v
 vlib/crypto/ripemd160/ripemd160_test.v
 vlib/crypto/scrypt/scrypt_test.v
-vlib/datatypes/bloom_filter_test.v
 vlib/datatypes/bstree_test.v
 vlib/datatypes/doubly_linked_list_test.v
-vlib/datatypes/fsm/fsm_test.v
-vlib/datatypes/heap_test.v
 vlib/datatypes/linked_list_test.v
 vlib/datatypes/lockfree/counter_test.v
 vlib/datatypes/lockfree/ringbuffer_test.v
 vlib/datatypes/quadtree_test.v
-vlib/datatypes/queue_test.v
-vlib/datatypes/set_test.v
 vlib/datatypes/stack_test.v
 vlib/db/mssql/mssql_test.v
 vlib/db/mysql/mysql_orm_test.v
@@ -172,7 +162,6 @@ vlib/flag/quoted_xdoc_attr_test.v
 vlib/flag/v_flag_parser_style_flags_test.v
 vlib/flag/v_style_flags_test.v
 vlib/gg/color_test.v
-vlib/gg/draw_fns_api_test.v
 vlib/gg/draw_rect_empty_test.v
 vlib/gg/frame_pacing_test.v
 vlib/gg/image_private_test.v
@@ -230,8 +219,6 @@ vlib/json/tests/json_raw_test.v
 vlib/json/tests/json_struct_option_test.v
 vlib/json/tests/json_sumtype_test.v
 vlib/json/tests/json_test.v
-vlib/log/default_test.v
-vlib/log/file_log_test.v
 vlib/log/log_test.v
 vlib/maps/maps_clone_test.v
 vlib/maps/maps_test.v
@@ -253,7 +240,6 @@ vlib/mcp/server_test.v
 vlib/mcp/spec_compliance_test.v
 vlib/ncurses/ncurses_test.v
 vlib/net/conv/conv_test.v
-vlib/net/ftp/ftp_test.v
 vlib/net/html/dom_test.v
 vlib/net/html/html_test.v
 vlib/net/html/parser_test.v
@@ -420,13 +406,9 @@ vlib/term/ui/2_term_and_ui_compilation_test.v
 vlib/term/ui/input_nix_test.v
 vlib/term/ui/mouse_config_test.v
 vlib/term/ui/termios_nix_test.v
-vlib/term/ui/ui_test.v
-vlib/time/chrono_test.v
 vlib/time/custom_format_test.v
 vlib/time/duration_test.v
-vlib/time/operator_test.v
 vlib/time/parse_autofree_test.v
-vlib/time/stopwatch_internal_test.v
 vlib/time/unix_test.v
 vlib/toml/scanner/scanner_test.v
 vlib/toml/tests/array_of_tables_1_level_test.v
@@ -493,7 +475,6 @@ vlib/v/gen/js/sourcemap/basic_test.v
 vlib/v/gen/js/sourcemap/compare_test.v
 vlib/v/gen/wasm/features_test.v
 vlib/v/generics/new_generics_regression_test.v
-vlib/v/live/live_test.v
 vlib/v/parser/check_cross_variables_regression_test.v
 vlib/v/parser/enum_comptime_test.v
 vlib/v/parser/parenthesized_propagated_index_or_block_test.v
@@ -504,7 +485,6 @@ vlib/v/scanner/scanner_test.v
 vlib/v/slow_tests/assembly/asm_empty_statement_test.v
 vlib/v/slow_tests/inout/compiler_test.v
 vlib/v/slow_tests/prod_test.v
-vlib/v/slow_tests/profile/profile_test.v
 vlib/v/slow_tests/repl/repl_test.v
 vlib/v/tests/aliases/alias_array_plus_operator_test.v
 vlib/v/tests/aliases/alias_array_returned_as_interface_test.v
@@ -559,7 +539,6 @@ vlib/v/tests/assign/cross_assign_test.v
 vlib/v/tests/autofree_arrays_reverse_iter_test.v
 vlib/v/tests/autofree_discarded_call_return_value_test.v
 vlib/v/tests/autofree_error_sentinel_test.v
-vlib/v/tests/autofree_generic_math_test.v
 vlib/v/tests/autofree_labeled_continue_scope_test.v
 vlib/v/tests/blank_ident_test.v
 vlib/v/tests/builtin_arrays/array_cast_test.v
@@ -676,7 +655,6 @@ vlib/v/tests/casts/autocast_in_if_conds_4_test.v
 vlib/v/tests/casts/autocast_in_if_conds_5_test.v
 vlib/v/tests/casts/cast_alias_to_generic_type_from_smartcast_test.v
 vlib/v/tests/casts/cast_comptime_test.v
-vlib/v/tests/casts/cast_f64_to_u64_boundary_test.v
 vlib/v/tests/casts/cast_int_to_interface_test.v
 vlib/v/tests/casts/cast_interface_to_impl_test.v
 vlib/v/tests/casts/cast_interface_value_in_match_test.v
@@ -709,7 +687,6 @@ vlib/v/tests/comptime/comptime_call_tmpl_dollar_literal_issue_14788_test.v
 vlib/v/tests/comptime/comptime_call_tmpl_variable_scope_test.v
 vlib/v/tests/comptime/comptime_call_type_test.v
 vlib/v/tests/comptime/comptime_closure_field_access_test.v
-vlib/v/tests/comptime/comptime_concrete_type_register_test.v
 vlib/v/tests/comptime/comptime_default_value_indexexpr_test.v
 vlib/v/tests/comptime/comptime_default_value_test.v
 vlib/v/tests/comptime/comptime_deref_or_ref_test.v
@@ -863,7 +840,6 @@ vlib/v/tests/concurrency/shared_unordered_mixed_test.v
 vlib/v/tests/concurrency/spawn_in_if_match_expr_test.v
 vlib/v/tests/concurrency/spawn_method_on_generic_struct_test.v
 vlib/v/tests/concurrency/spawn_ref_arg_stack_escape_test.v
-vlib/v/tests/concurrency/sync_channel_push_string_literal_test.v
 vlib/v/tests/concurrency/tcc_atomic_postfix_test.v
 vlib/v/tests/concurrency/thread_returns_test.v
 vlib/v/tests/concurrency/thread_to_string_test.v
@@ -989,7 +965,6 @@ vlib/v/tests/fns/closure_with_sumtype_var_test.v
 vlib/v/tests/fns/const_call_or_expr_test.v
 vlib/v/tests/fns/decompose_variadic_test.v
 vlib/v/tests/fns/filter_test.v
-vlib/v/tests/fns/fixed_array_on_voidptr_test.v
 vlib/v/tests/fns/fixed_array_result_return_test.v
 vlib/v/tests/fns/fn_call_comptime_array_arg_test.v
 vlib/v/tests/fns/fn_call_interface_args_test.v
@@ -1003,8 +978,6 @@ vlib/v/tests/fns/fn_generic_resolve_test.v
 vlib/v/tests/fns/fn_high_test.v
 vlib/v/tests/fns/fn_index_direct_call_test.v
 vlib/v/tests/fns/fn_literal_type_test.v
-vlib/v/tests/fns/fn_multi_return_test.v
-vlib/v/tests/fns/fn_multiple_returns_test.v
 vlib/v/tests/fns/fn_mut_arg_of_interface_test.v
 vlib/v/tests/fns/fn_mut_args_test.v
 vlib/v/tests/fns/fn_name_using_keyword_test.v
@@ -1081,7 +1054,6 @@ vlib/v/tests/generics/generic_fn_call_with_reference_argument_test.v
 vlib/v/tests/generics/generic_fn_infer_fixed_array_test.v
 vlib/v/tests/generics/generic_fn_infer_map_test.v
 vlib/v/tests/generics/generic_fn_infer_multi_paras_test.v
-vlib/v/tests/generics/generic_fn_infer_nested_generic_fn_test.v
 vlib/v/tests/generics/generic_fn_infer_struct_test.v
 vlib/v/tests/generics/generic_fn_infer_variadic_test.v
 vlib/v/tests/generics/generic_fn_method_call_on_generic_param_test.v
@@ -1124,7 +1096,6 @@ vlib/v/tests/generics/generic_options_with_reserved_ident_test.v
 vlib/v/tests/generics/generic_receiver_embed_test.v
 vlib/v/tests/generics/generic_resolve_test.v
 vlib/v/tests/generics/generic_return_array_generic_test.v
-vlib/v/tests/generics/generic_selector_field_test.v
 vlib/v/tests/generics/generic_selector_indexexpr_test.v
 vlib/v/tests/generics/generic_selector_test.v
 vlib/v/tests/generics/generic_selector_type_test.v
@@ -1133,14 +1104,12 @@ vlib/v/tests/generics/generic_spawn_test.v
 vlib/v/tests/generics/generic_static_call_test.v
 vlib/v/tests/generics/generic_static_method_test.v
 vlib/v/tests/generics/generic_struct_default_interface_field_test.v
-vlib/v/tests/generics/generic_struct_field_unwrap_test.v
 vlib/v/tests/generics/generic_struct_fn_field_closure_test.v
 vlib/v/tests/generics/generic_struct_init_ptr_test.v
 vlib/v/tests/generics/generic_struct_init_with_field_struct_init_test.v
 vlib/v/tests/generics/generic_struct_init_with_generic_cast_test.v
 vlib/v/tests/generics/generic_struct_init_with_reference_struct_type_test.v
 vlib/v/tests/generics/generic_struct_init_with_update_expr_test.v
-vlib/v/tests/generics/generic_struct_recursive_test.v
 vlib/v/tests/generics/generic_sumtype_cast_test.v
 vlib/v/tests/generics/generic_sumtype_init_in_generic_fn_call_test.v
 vlib/v/tests/generics/generic_sumtype_insts_test.v
@@ -1157,7 +1126,6 @@ vlib/v/tests/generics/generics_array_drop_test.v
 vlib/v/tests/generics/generics_array_method_call_with_multi_types_test.v
 vlib/v/tests/generics/generics_array_of_interface_method_call_test.v
 vlib/v/tests/generics/generics_array_of_threads_test.v
-vlib/v/tests/generics/generics_array_typedef_test.v
 vlib/v/tests/generics/generics_call_with_fixed_array_arg_test.v
 vlib/v/tests/generics/generics_call_with_interface_arg_test.v
 vlib/v/tests/generics/generics_chans_select_test.v
@@ -1186,7 +1154,6 @@ vlib/v/tests/generics/generics_method_chaining_call_test.v
 vlib/v/tests/generics/generics_method_on_alias_struct_receiver_test.v
 vlib/v/tests/generics/generics_method_on_embed_struct_test.v
 vlib/v/tests/generics/generics_method_on_generic_structs_test.v
-vlib/v/tests/generics/generics_method_on_nested_struct2_test.v
 vlib/v/tests/generics/generics_method_on_nested_struct_test.v
 vlib/v/tests/generics/generics_method_on_receiver_aliases_types_test.v
 vlib/v/tests/generics/generics_method_returning_option_test.v
@@ -1198,7 +1165,6 @@ vlib/v/tests/generics/generics_method_with_multi_types_test.v
 vlib/v/tests/generics/generics_method_with_sumtype_args_test.v
 vlib/v/tests/generics/generics_multi_type_comptime_call_test.v
 vlib/v/tests/generics/generics_multi_types_struct_init_test.v
-vlib/v/tests/generics/generics_mut_receiver_local_copy_regression_test.v
 vlib/v/tests/generics/generics_mutual_recursive_struct_reference_test.v
 vlib/v/tests/generics/generics_nested_struct_init_test.v
 vlib/v/tests/generics/generics_option_fn_concrete_type_test.v
@@ -1235,7 +1201,6 @@ vlib/v/tests/generics/generics_with_embed_generics_test.v
 vlib/v/tests/generics/generics_with_generics_fn_return_generics_fn_type_test.v
 vlib/v/tests/generics/generics_with_generics_fn_return_generics_map_type_test.v
 vlib/v/tests/generics/generics_with_generics_fn_type_parameter_test.v
-vlib/v/tests/generics/generics_with_multi_generics_fn_name_test.v
 vlib/v/tests/generics/generics_with_multi_nested_generic_method_call_ref_arg_test.v
 vlib/v/tests/generics/generics_with_multi_nested_generic_method_call_test.v
 vlib/v/tests/generics/generics_with_nested_external_generics_fn_test.v
@@ -1244,7 +1209,6 @@ vlib/v/tests/generics/generics_with_nested_generic_struct_init_test.v
 vlib/v/tests/generics/generics_with_nested_generic_type_parameter_test.v
 vlib/v/tests/generics/generics_with_nested_generics_fn_test.v
 vlib/v/tests/generics/generics_with_pointer_index_test.v
-vlib/v/tests/generics/generics_with_variadic_generic_args_test.v
 vlib/v/tests/generics/mixed_generic_and_concrete_fn_type_factories_regression_test.v
 vlib/v/tests/generics/return_closure_f64_test.v
 vlib/v/tests/generics/return_closure_generic_struct_result_test.v
@@ -1408,7 +1372,6 @@ vlib/v/tests/options/option_fn_alias_test.v
 vlib/v/tests/options/option_fn_multi_ret_test.v
 vlib/v/tests/options/option_fn_test.v
 vlib/v/tests/options/option_fn_variadic_test.v
-vlib/v/tests/options/option_fn_voidptr_test.v
 vlib/v/tests/options/option_fntype_assign_test.v
 vlib/v/tests/options/option_for_mut_test.v
 vlib/v/tests/options/option_free_method_test.v
@@ -1462,7 +1425,6 @@ vlib/v/tests/options/option_ptr_arg_test.v
 vlib/v/tests/options/option_ptr_cast_test.v
 vlib/v/tests/options/option_ptr_field_nil_check_unwrap_test.v
 vlib/v/tests/options/option_ptr_field_test.v
-vlib/v/tests/options/option_ptr_generic_test.v
 vlib/v/tests/options/option_ptr_iface_test.v
 vlib/v/tests/options/option_ptr_ptr_test.v
 vlib/v/tests/options/option_ptr_test.v
@@ -1570,7 +1532,6 @@ vlib/v/tests/reserved_keywords_array_test.v
 vlib/v/tests/reserved_keywords_as_struct_field_test.v
 vlib/v/tests/result_call_or_block_with_stmts_test.v
 vlib/v/tests/result_with_index_expr_test.v
-vlib/v/tests/results_multi_return_test.v
 vlib/v/tests/retry_test.v
 vlib/v/tests/return_comptime_call_test.v
 vlib/v/tests/return_error_in_if_expr_test.v
@@ -1608,7 +1569,6 @@ vlib/v/tests/structs/empty_struct_test.v
 vlib/v/tests/structs/free_method_test.v
 vlib/v/tests/structs/multiple_embed_struct_init_test.v
 vlib/v/tests/structs/multiple_embed_struct_with_duplicate_field_init_test.v
-vlib/v/tests/structs/mut_receiver_returned_as_reference_test.v
 vlib/v/tests/structs/mut_test.v
 vlib/v/tests/structs/operator_overloading_index_test.v
 vlib/v/tests/structs/operator_overloading_type_alias_generic_parent_test.v
@@ -1632,7 +1592,6 @@ vlib/v/tests/structs/struct_generic_sizeof_test.v
 vlib/v/tests/structs/struct_init_on_for_expr_test.v
 vlib/v/tests/structs/struct_init_short_in_for_expr_test.v
 vlib/v/tests/structs/struct_init_with_complex_fields_test.v
-vlib/v/tests/structs/struct_init_with_fixed_array_field_test.v
 vlib/v/tests/structs/struct_init_with_interface_field_test.v
 vlib/v/tests/structs/struct_init_with_interface_pointer_and_embed_test.v
 vlib/v/tests/structs/struct_init_with_multi_option_fn_type_test.v
@@ -1879,7 +1838,6 @@ vlib/v3/tests/ssa_optimize_verifier_test.v
 vlib/v3/tests/ssa_passes_test.v
 vlib/v3/tests/ssa_worker_test.v
 vlib/v3/tests/test_file_harness_codegen_test.v
-vlib/v3/tests/type_authority_codegen_test.v
 vlib/v3/tests/type_checker_errors_test.v
 vlib/v3/tests/wasm_codegen_test.v
 vlib/veb/assets/assets_test.v
@@ -1913,12 +1871,7 @@ vlib/veb/tests/veb_app_test.v
 vlib/veb/tests/veb_should_listen_on_both_ipv4_and_ipv6_by_default_test.v
 vlib/veb/tests/veb_test.v
 vlib/veb/tr_test.v
-vlib/wasm/tests/arith_test.v
-vlib/wasm/tests/block_test.v
-vlib/wasm/tests/call_test.v
-vlib/wasm/tests/debug_test.v
 vlib/wasm/tests/patch_test.v
-vlib/wasm/tests/table_test.v
 vlib/wasm/tests/var_test.v
 vlib/x/async/context_internal_test.v
 vlib/x/async/group_test.v
@@ -1976,7 +1929,6 @@ vlib/x/encoding/asn1/utf8string_test.v
 vlib/x/encoding/asn1/util_test.v
 vlib/x/encoding/asn1/visiblestring_test.v
 vlib/x/executor/admission_test.v
-vlib/x/executor/config_test.v
 vlib/x/executor/errors_test.v
 vlib/x/executor/lifecycle_test.v
 vlib/x/executor/owner_test.v
@@ -2037,7 +1989,6 @@ vlib/x/json2/tests/json2_tests/json2_test.v
 vlib/x/json2/tests/json2_tests/json_module_compatibility_test/json_decode_todo_test.v
 vlib/x/json2/tests/json2_tests/json_module_compatibility_test/json_test.v
 vlib/x/json2/tests/json_module_compatibility_test/json_decode_with_encode_arg_test.v
-vlib/x/json2/tests/json_module_compatibility_test/json_decode_with_option_arg_test.v
 vlib/x/json2/tests/json_module_compatibility_test/json_test.v
 vlib/x/json2/tests/json_optional_both_type_field_test.v
 vlib/x/json2/tests/json_sumtype_test.v
@@ -2052,7 +2003,6 @@ vlib/x/templating/dtm/dynamic_template_manager_behavior_test.v
 vlib/x/templating/dtm/dynamic_template_manager_cache_system_test.v
 vlib/x/templating/dtm/dynamic_template_manager_test.v
 vlib/x/templating/dtm2/dynamic_template_manager2_test.v
-vlib/x/ttf/ttf_test.v
 vlib/yaml/yaml_conformance_test.v
 vlib/yaml/yaml_edge_cases_test.v
 vlib/yaml/yaml_json_roundtrip_test.v

--- a/vlib/v3/v3_test_passes.txt
+++ b/vlib/v3/v3_test_passes.txt
@@ -19,6 +19,11 @@ cmd/tools/vcreate/vcreate_new_test.v
 cmd/tools/vdoc/vdoc_run_examples_test.v
 cmd/tools/vfmt_test.v
 cmd/tools/vgit-fmt-hook_test.v
+cmd/tools/vpm/dependency_test.v
+cmd/tools/vpm/install_version_input_test.v
+cmd/tools/vpm/link_test.v
+cmd/tools/vpm/remove_test.v
+cmd/tools/vpm/update_test.v
 cmd/tools/vtimeout_test.v
 cmd/tools/vwatch_test.v
 cmd/v/v2_test.v
@@ -109,7 +114,12 @@ vlib/crypto/sha512/sha512_256_shavs_test.v
 vlib/crypto/sha512/sha512_shavs_monte_test.v
 vlib/crypto/sha512/sha512_shavs_test.v
 vlib/crypto/sha512/sha512_test.v
+vlib/datatypes/bloom_filter_test.v
+vlib/datatypes/fsm/fsm_test.v
+vlib/datatypes/heap_test.v
+vlib/datatypes/queue_test.v
 vlib/datatypes/ringbuffer_test.v
+vlib/datatypes/set_test.v
 vlib/dl/dl_test.v
 vlib/dl/loader/loader_test.v
 vlib/dl/rtld_next_test.v
@@ -141,6 +151,7 @@ vlib/flag/default_flag_options_test.v
 vlib/flag/flag_autofree_test.v
 vlib/flag/flag_parse_test.v
 vlib/flag/usage_example_test.v
+vlib/gg/draw_fns_api_test.v
 vlib/hash/adler32/adler32_test.v
 vlib/hash/crc32/crc32_test.v
 vlib/hash/crc64/crc64_test.v
@@ -157,6 +168,8 @@ vlib/json/tests/json_decode_with_option_arg_test.v
 vlib/json/tests/json_embed_test.v
 vlib/json/tests/json_encode_with_mut_test.v
 vlib/json/tests/json_omitempty_types_test.v
+vlib/log/default_test.v
+vlib/log/file_log_test.v
 vlib/math/big/consts_test.v
 vlib/math/bits/bits_test.v
 vlib/math/complex/complex_test.v
@@ -175,6 +188,7 @@ vlib/math/square_test.v
 vlib/math/unsigned/uint128_test.v
 vlib/math/unsigned/uint256_test.v
 vlib/net/dial_tcp_with_bind_test.v
+vlib/net/ftp/ftp_test.v
 vlib/net/http/chunked/dechunk_test.v
 vlib/net/http/mime/mime_test.v
 vlib/net/mbedtls/mbedtls_tcc_arm64_compiles_test.v
@@ -219,10 +233,14 @@ vlib/sync/rwmutex_test.v
 vlib/sync/spinlock_test.v
 vlib/sync/stdatomic/atomic_test.v
 vlib/sync/thread_test.v
+vlib/term/ui/ui_test.v
 vlib/time/Y2K38_test.v
+vlib/time/chrono_test.v
 vlib/time/misc/misc_test.v
+vlib/time/operator_test.v
 vlib/time/parse_test.v
 vlib/time/relative_test.v
+vlib/time/stopwatch_internal_test.v
 vlib/time/stopwatch_test.v
 vlib/time/time_addition_test.v
 vlib/time/time_format_test.v
@@ -270,6 +288,7 @@ vlib/v/gen/wasm/tests/wasm_test.v
 vlib/v/gen/wasm/tests_decompile/must_have_test.v
 vlib/v/help/help_test.v
 vlib/v/live/live_macos_objc_duplication_test.v
+vlib/v/live/live_test.v
 vlib/v/mathutil/mathutil_test.v
 vlib/v/parser/map_init_fmt_regression_test.v
 vlib/v/parser/parse_file_spawn_execute_regression_test.v
@@ -287,6 +306,7 @@ vlib/v/slow_tests/map_issue_22139_clear_test.v
 vlib/v/slow_tests/map_issue_22143_clear_test.v
 vlib/v/slow_tests/map_issue_22145_clear_test.v
 vlib/v/slow_tests/map_issue_22148_clear_test.v
+vlib/v/slow_tests/profile/profile_test.v
 vlib/v/slow_tests/repl/import_vmodules_submodule_test.v
 vlib/v/slow_tests/repl/repl_time_state_test.v
 vlib/v/slow_tests/run_project_folders_test.v
@@ -358,6 +378,7 @@ vlib/v/tests/assign/multiple_assign_array_index_test.v
 vlib/v/tests/assign/multiple_assign_test.v
 vlib/v/tests/assign/tuple_reassign_to_heap_struct_local_test.v
 vlib/v/tests/attribute_test.v
+vlib/v/tests/autofree_generic_math_test.v
 vlib/v/tests/autofree_if_expr_call_arg_with_struct_init_test.v
 vlib/v/tests/autofree_net_addr_len_test.v
 vlib/v/tests/autofree_result_method_chain_test.v
@@ -487,6 +508,7 @@ vlib/v/tests/casts/as_cast_is_expr_sumtype_fn_result_test.v
 vlib/v/tests/casts/as_cast_selector_test.v
 vlib/v/tests/casts/assert_as_cast_selector_test.v
 vlib/v/tests/casts/cast_bool_to_int_test.v
+vlib/v/tests/casts/cast_f64_to_u64_boundary_test.v
 vlib/v/tests/casts/cast_fixed_array_to_ptr_ptr_test.v
 vlib/v/tests/casts/cast_in_comptime_if_test.v
 vlib/v/tests/casts/cast_in_index_of_ref_fixed_array_test.v
@@ -507,6 +529,7 @@ vlib/v/tests/comptime/comptime_bittness_and_endianess_test.v
 vlib/v/tests/comptime/comptime_call_map_receiver_test.v
 vlib/v/tests/comptime/comptime_call_slice_arg_test.v
 vlib/v/tests/comptime/comptime_call_void_test.v
+vlib/v/tests/comptime/comptime_concrete_type_register_test.v
 vlib/v/tests/comptime/comptime_const_def_test.v
 vlib/v/tests/comptime/comptime_enum_test.v
 vlib/v/tests/comptime/comptime_for_break_test.v
@@ -562,6 +585,7 @@ vlib/v/tests/concurrency/shared_struct_field_test.v
 vlib/v/tests/concurrency/spawn_array_mut_test.v
 vlib/v/tests/concurrency/spawn_with_cond_fncall_test.v
 vlib/v/tests/concurrency/spawn_with_different_method_receivers_test.v
+vlib/v/tests/concurrency/sync_channel_push_string_literal_test.v
 vlib/v/tests/concurrency/thread_array_test.v
 vlib/v/tests/concurrency/thread_ptr_ret_test.v
 vlib/v/tests/concurrency/thread_type_test.v
@@ -714,6 +738,7 @@ vlib/v/tests/fns/closure_lifetime_api_test.v
 vlib/v/tests/fns/closure_option_direct_call_test.v
 vlib/v/tests/fns/cross_method_call_test.v
 vlib/v/tests/fns/filter_in_map_test.v
+vlib/v/tests/fns/fixed_array_on_voidptr_test.v
 vlib/v/tests/fns/fn_assignment_test.v
 vlib/v/tests/fns/fn_call_fixed_array_literal_args_test.v
 vlib/v/tests/fns/fn_call_generic_array_arg_test.v
@@ -722,6 +747,8 @@ vlib/v/tests/fns/fn_call_mut_sumtype_args_test.v
 vlib/v/tests/fns/fn_expecting_ref_but_returning_struct_test.v
 vlib/v/tests/fns/fn_expecting_ref_but_returning_struct_time_module_test.v
 vlib/v/tests/fns/fn_heap_promoted_test.v
+vlib/v/tests/fns/fn_multi_return_test.v
+vlib/v/tests/fns/fn_multiple_returns_test.v
 vlib/v/tests/fns/fn_mut_arg_of_array_test.v
 vlib/v/tests/fns/fn_mut_arg_of_sumtype_ref_test.v
 vlib/v/tests/fns/fn_mut_interface_param_impl_receiver_test.v
@@ -786,6 +813,7 @@ vlib/v/tests/generics/generic_fn_infer_fn_type_argument_test.v
 vlib/v/tests/generics/generic_fn_infer_fn_type_using_ref_arg_test.v
 vlib/v/tests/generics/generic_fn_infer_map_argument_test.v
 vlib/v/tests/generics/generic_fn_infer_modifier_test.v
+vlib/v/tests/generics/generic_fn_infer_nested_generic_fn_test.v
 vlib/v/tests/generics/generic_fn_infer_nested_struct_test.v
 vlib/v/tests/generics/generic_fn_infer_test.v
 vlib/v/tests/generics/generic_fn_multi_return_test.v
@@ -806,11 +834,14 @@ vlib/v/tests/generics/generic_muls_test.v
 vlib/v/tests/generics/generic_pointer_indirect_test.v
 vlib/v/tests/generics/generic_recursive_fn_test.v
 vlib/v/tests/generics/generic_return_test.v
+vlib/v/tests/generics/generic_selector_field_test.v
 vlib/v/tests/generics/generic_selector_infix_test.v
 vlib/v/tests/generics/generic_selector_len_test.v
 vlib/v/tests/generics/generic_sort_multi_instantiation_test.v
 vlib/v/tests/generics/generic_struct_cstruct_test.v
 vlib/v/tests/generics/generic_struct_field_fn_with_multiple_instantiations_test.v
+vlib/v/tests/generics/generic_struct_field_unwrap_test.v
+vlib/v/tests/generics/generic_struct_recursive_test.v
 vlib/v/tests/generics/generic_struct_return_test.v
 vlib/v/tests/generics/generic_struct_test.v
 vlib/v/tests/generics/generic_struct_with_linked_list_of_refs_field_test.v
@@ -821,6 +852,7 @@ vlib/v/tests/generics/generics_anon_fn_decl_with_type_only_arg_test.v
 vlib/v/tests/generics/generics_array_append_test.v
 vlib/v/tests/generics/generics_array_init_test.v
 vlib/v/tests/generics/generics_array_map_with_generic_callback_test.v
+vlib/v/tests/generics/generics_array_typedef_test.v
 vlib/v/tests/generics/generics_assign_reference_generic_struct_test.v
 vlib/v/tests/generics/generics_call_with_reference_arg_test.v
 vlib/v/tests/generics/generics_fixed_array_assign_test.v
@@ -830,12 +862,14 @@ vlib/v/tests/generics/generics_in_big_struct_method_test.v
 vlib/v/tests/generics/generics_in_generics_test.v
 vlib/v/tests/generics/generics_indirect_test.v
 vlib/v/tests/generics/generics_map_with_generic_type_key_test.v
+vlib/v/tests/generics/generics_method_on_nested_struct2_test.v
 vlib/v/tests/generics/generics_method_on_receiver_types_test.v
 vlib/v/tests/generics/generics_method_ordering_test.v
 vlib/v/tests/generics/generics_method_str_overload_test.v
 vlib/v/tests/generics/generics_method_with_generic_anon_fn_argument_test.v
 vlib/v/tests/generics/generics_method_with_nested_generic_method_test.v
 vlib/v/tests/generics/generics_multi_array_in_test.v
+vlib/v/tests/generics/generics_mut_receiver_local_copy_regression_test.v
 vlib/v/tests/generics/generics_return_multi_array_test.v
 vlib/v/tests/generics/generics_return_multiple_generics_struct_test.v
 vlib/v/tests/generics/generics_return_recursive_generics_struct_test.v
@@ -858,6 +892,7 @@ vlib/v/tests/generics/generics_with_empty_array_arg_test.v
 vlib/v/tests/generics/generics_with_fixed_array_type_test.v
 vlib/v/tests/generics/generics_with_generics_struct_init_test.v
 vlib/v/tests/generics/generics_with_generics_struct_receiver_test.v
+vlib/v/tests/generics/generics_with_multi_generics_fn_name_test.v
 vlib/v/tests/generics/generics_with_multi_generics_struct_types_test.v
 vlib/v/tests/generics/generics_with_multiple_generics_struct_receiver_test.v
 vlib/v/tests/generics/generics_with_nested_generics_fn_infer_call_test.v
@@ -865,6 +900,7 @@ vlib/v/tests/generics/generics_with_nested_generics_fn_inst_call_test.v
 vlib/v/tests/generics/generics_with_recursive_generics_fn_test.v
 vlib/v/tests/generics/generics_with_recursive_generics_struct_test.v
 vlib/v/tests/generics/generics_with_reference_generic_args_test.v
+vlib/v/tests/generics/generics_with_variadic_generic_args_test.v
 vlib/v/tests/generics/infer_generic_array_type_in_nested_call_test.v
 vlib/v/tests/generics/lamda_param_and_ret_test.v
 vlib/v/tests/generics/modules/simplemodule/importing_test.v
@@ -1001,6 +1037,7 @@ vlib/v/tests/options/option_fixed_arr_const_test.v
 vlib/v/tests/options/option_fn_guard_test.v
 vlib/v/tests/options/option_fn_struct_init_test.v
 vlib/v/tests/options/option_fn_var_test.v
+vlib/v/tests/options/option_fn_voidptr_test.v
 vlib/v/tests/options/option_for_or_block_test.v
 vlib/v/tests/options/option_generic_alias_test.v
 vlib/v/tests/options/option_generic_inferred_call_test.v
@@ -1029,6 +1066,7 @@ vlib/v/tests/options/option_print_errors_test.v
 vlib/v/tests/options/option_print_ptr_test.v
 vlib/v/tests/options/option_ptr_arg_none_test.v
 vlib/v/tests/options/option_ptr_field_in_interface_cast_test.v
+vlib/v/tests/options/option_ptr_generic_test.v
 vlib/v/tests/options/option_ptr_init_empty_test.v
 vlib/v/tests/options/option_ptr_init_test.v
 vlib/v/tests/options/option_ptr_nil_test.v
@@ -1098,6 +1136,7 @@ vlib/v/tests/reserved_keyword_asm_test.v
 vlib/v/tests/reserved_keywords_can_be_escaped_with_at_test.v
 vlib/v/tests/reserved_keywords_if_guard_test.v
 vlib/v/tests/resolve_generic_2_test.v
+vlib/v/tests/results_multi_return_test.v
 vlib/v/tests/results_test.v
 vlib/v/tests/return_aliases_of_fixed_array_test.v
 vlib/v/tests/return_fixed_array_test.v
@@ -1127,6 +1166,7 @@ vlib/v/tests/structs/embed_error_in_returning_result_test.v
 vlib/v/tests/structs/embed_method_call_test.v
 vlib/v/tests/structs/empty_struct_compare_test.v
 vlib/v/tests/structs/missing_config_struct_arg_test.v
+vlib/v/tests/structs/mut_receiver_returned_as_reference_test.v
 vlib/v/tests/structs/nested_struct_embed_method_call_test.v
 vlib/v/tests/structs/nested_struct_embed_selector_test.v
 vlib/v/tests/structs/operator_overloading_cmp_test.v
@@ -1169,6 +1209,7 @@ vlib/v/tests/structs/struct_init_update_with_generics_test.v
 vlib/v/tests/structs/struct_init_update_with_mutable_receiver_test.v
 vlib/v/tests/structs/struct_init_with_chan_field_test.v
 vlib/v/tests/structs/struct_init_with_embed_update_test.v
+vlib/v/tests/structs/struct_init_with_fixed_array_field_test.v
 vlib/v/tests/structs/struct_init_with_multi_nested_embed_update_test.v
 vlib/v/tests/structs/struct_local_test.v
 vlib/v/tests/structs/struct_map_method_test.v
@@ -1275,11 +1316,17 @@ vlib/v3/tests/string_int_markused_codegen_test.v
 vlib/v3/tests/struct_default_transform_test.v
 vlib/v3/tests/struct_init_alias_authority_codegen_test.v
 vlib/v3/tests/transformer_parity_test.v
+vlib/v3/tests/type_authority_codegen_test.v
 vlib/v3/tests/union_byte_contains_codegen_test.v
 vlib/v3/tests/unknown_fn_error_test.v
 vlib/v3/tests/veb_implicit_ctx_test.v
 vlib/v3/tests/x11_source_abi_alias_codegen_test.v
 vlib/veb/tests/use_openssl_no_mbedtls_test.v
+vlib/wasm/tests/arith_test.v
+vlib/wasm/tests/block_test.v
+vlib/wasm/tests/call_test.v
+vlib/wasm/tests/debug_test.v
+vlib/wasm/tests/table_test.v
 vlib/x/benchmark/benchmark_test.v
 vlib/x/crypto/ascon/aead128_test.v
 vlib/x/crypto/ascon/ascon_test.v
@@ -1288,4 +1335,7 @@ vlib/x/crypto/ascon/hash_test.v
 vlib/x/crypto/ascon/xof_test.v
 vlib/x/crypto/sm4/sm4_test.v
 vlib/x/dataframe/dataframe_test.v
+vlib/x/executor/config_test.v
+vlib/x/json2/tests/json_module_compatibility_test/json_decode_with_option_arg_test.v
 vlib/x/json2/tests/scanner_test.v
+vlib/x/ttf/ttf_test.v


### PR DESCRIPTION
## Summary
- expand V3 test-file handling for sibling module sources
- improve V3 checker/cgen support for pointer/null/voidptr, generic/sum/match, and multi-return tuple tails
- move 50 verified tests from `v3_test_failures.txt` to `v3_test_passes.txt`
- address review feedback for qualified/selectively imported `free` calls, concrete one-letter optional payload types, and fully qualified pointer-value matches
- emit late generic helper dependencies from generated/specialized bodies, including cross-module generic receiver methods, lifetime helpers, and string interpolation/stringify helpers
- tighten C call argument emission for generated pointer/mut receiver calls and add optional-struct lvalue regressions

## Testing
- `./vnew fmt -w vlib/v3/v3.v vlib/v3/markused/markused.v vlib/v3/tests/markused_test.v vlib/v3/gen/c/cleanc.v vlib/v3/gen/c/fn.v vlib/v3/gen/c/if.v vlib/v3/gen/c/stmt.v vlib/v3/gen/c/struct.v vlib/v3/gen/c/types.v vlib/v3/parser/parser.v vlib/v3/transform/fn.v vlib/v3/transform/transform.v vlib/v3/types/checker.v`
- `./vnew fmt -w vlib/v3/gen/c/fn.v vlib/v3/gen/c/types.v vlib/v3/tests/review_cgen_regressions_test.v`
- `./vnew fmt -w vlib/v3/gen/c/fn.v vlib/v3/types/checker.v vlib/v3/tests/review_cgen_regressions_test.v`
- `./vnew -gc none -path "/Users/alexander/code/v/vlib|@vlib|@vmodules" -o /tmp/v3_batch_fix vlib/v3/v3.v`
- `./vnew -gc none -path "/Users/alexander/code/v/vlib|@vlib|@vmodules" -o /tmp/v3_review_fix vlib/v3/v3.v`
- `./vnew -gc none -path "/Users/alexander/code/v/vlib|@vlib|@vmodules" -o /tmp/v3_review_fix2 vlib/v3/v3.v`
- selected 50 paths with `/tmp/v3_batch_fix`: passed
- selected 50 paths with `/tmp/v3_review_fix`: passed
- selected 50 paths with `/tmp/v3_review_fix2`: passed
- `./vnew -silent vlib/v3/tests/markused_test.v`
- `./vnew -silent vlib/v3/tests/review_cgen_regressions_test.v`
- `git diff --check -- vlib/v3/v3.v vlib/v3/markused/markused.v vlib/v3/tests/markused_test.v vlib/v3/gen/c/cleanc.v vlib/v3/gen/c/fn.v vlib/v3/gen/c/if.v vlib/v3/gen/c/stmt.v vlib/v3/gen/c/struct.v vlib/v3/gen/c/types.v vlib/v3/parser/parser.v vlib/v3/transform/fn.v vlib/v3/transform/transform.v vlib/v3/types/checker.v vlib/v3/v3_test_failures.txt vlib/v3/v3_test_passes.txt`
- `git diff --check -- vlib/v3/gen/c/fn.v vlib/v3/gen/c/types.v vlib/v3/tests/review_cgen_regressions_test.v`
- `git diff --check -- vlib/v3/gen/c/fn.v vlib/v3/types/checker.v vlib/v3/tests/review_cgen_regressions_test.v`
- `git diff --cached --check`
- `./v test vlib/v3/tests/generic_cross_module_arg_codegen_test.v vlib/v3/tests/string_interpolation_stringify_codegen_test.v vlib/v3/tests/optional_struct_lvalue_codegen_test.v`