### PR TITLE
v3: fix transform followups

### DIFF
--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -7955,6 +7955,11 @@ fn (mut t Transformer) transform_ident_expr(id flat.NodeId, node flat.Node) flat
 				t.set_node_typ(int(deref), typ[1..])
 				return deref
 			}
+			if !t.in_selector_base && t.pointer_value_rvalues[node.value] && typ.starts_with('&') {
+				deref := t.make_prefix(.mul, id)
+				t.a.nodes[int(deref)].typ = typ[1..]
+				return deref
+			}
 			return id
 		}
 	}


### PR DESCRIPTION
## Summary
- Preserve mutable closure capture state through parser/transform lowering.
- Handle newline-separated const array literals with line comments.
- Treat optional/result void `or` expressions as void payloads and avoid dereferencing pointer-value selector bases.
- Fix `ftruncate`/`_chsize_s` C declarations to use file descriptors.

## Validation
- `make` (temporary clean worktree)
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew test vlib/os/file_test.v`
- `./vnew -gc none -path "$(pwd)/vlib|@vlib|@vmodules" -o /tmp/v3_transform_followups_bin vlib/v3/v3.v`
- Direct V3 compile/run smoke: const array newline/comment source -> `3` / `2`
- Direct V3 compile/run smoke: mutable closure capture callback -> `2`
- Direct V3 compile/run smoke: optional-void `or` fallback -> `fallback`

Note: `./vnew -silent test vlib/v3/tests/review_transform_regressions_test.v` stalled locally in `vtest`; the affected cases were validated with direct V3 smoke compiles instead.
