### PR TITLE
sokol: add opt-in Windows D3D11 support

### DIFF
--- a/thirdparty/sokol/sokol_v.post.h
+++ b/thirdparty/sokol/sokol_v.post.h
@@ -1,9 +1,170 @@
 #if defined(SOKOL_GLCORE) || defined(SOKOL_GLES3)
-	void v_sapp_gl_read_rgba_pixels(int x, int y, int width, int height, unsigned char* pixels) {
+	int v_sapp_read_rgba_pixels(int x, int y, int width, int height, unsigned char* pixels) {
 		glReadPixels(x, y, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+		return 0;
+	}
+#elif defined(SOKOL_D3D11) && defined(_SAPP_WIN32) && defined(SOKOL_APP_INCLUDED)
+	enum {
+		V_SAPP_READBACK_OK = 0,
+		V_SAPP_READBACK_INVALID_ARGS = -1,
+		V_SAPP_READBACK_NO_DEVICE = -2,
+		V_SAPP_READBACK_GET_BUFFER_FAILED = -3,
+		V_SAPP_READBACK_UNSUPPORTED_SOURCE = -4,
+		V_SAPP_READBACK_CREATE_STAGING_FAILED = -5,
+		V_SAPP_READBACK_MAP_FAILED = -6,
+		V_SAPP_READBACK_UNSUPPORTED_FORMAT = -7,
+	};
+
+	static const IID v_sapp_IID_ID3D11Texture2D = {
+		0x6f15aaf2,
+		0xd208,
+		0x4e89,
+		{0x9a, 0xb4, 0x48, 0x95, 0x35, 0xd3, 0x4f, 0x9c}
+	};
+
+	#if defined(__cplusplus)
+		#define v_sapp_d3d11_refiid(iid) iid
+		#define v_sapp_d3d11_release(obj) do { if (obj) { (obj)->Release(); (obj) = 0; } } while (0)
+		static inline HRESULT v_sapp_dxgi_get_buffer(IDXGISwapChain* self, UINT buffer, REFIID riid, void** surface) {
+			return self->GetBuffer(buffer, riid, surface);
+		}
+		static inline void v_sapp_d3d11_get_desc(ID3D11Texture2D* self, D3D11_TEXTURE2D_DESC* desc) {
+			self->GetDesc(desc);
+		}
+		static inline HRESULT v_sapp_d3d11_create_texture_2d(ID3D11Device* self, const D3D11_TEXTURE2D_DESC* desc, ID3D11Texture2D** texture) {
+			return self->CreateTexture2D(desc, NULL, texture);
+		}
+		static inline void v_sapp_d3d11_copy_resource(ID3D11DeviceContext* self, ID3D11Resource* dst, ID3D11Resource* src) {
+			self->CopyResource(dst, src);
+		}
+		static inline HRESULT v_sapp_d3d11_map(ID3D11DeviceContext* self, ID3D11Resource* resource, D3D11_MAPPED_SUBRESOURCE* mapped) {
+			return self->Map(resource, 0, D3D11_MAP_READ, 0, mapped);
+		}
+		static inline void v_sapp_d3d11_unmap(ID3D11DeviceContext* self, ID3D11Resource* resource) {
+			self->Unmap(resource, 0);
+		}
+	#else
+		#define v_sapp_d3d11_refiid(iid) &iid
+		#define v_sapp_d3d11_release(obj) do { if (obj) { (obj)->lpVtbl->Release(obj); (obj) = 0; } } while (0)
+		static inline HRESULT v_sapp_dxgi_get_buffer(IDXGISwapChain* self, UINT buffer, REFIID riid, void** surface) {
+			return self->lpVtbl->GetBuffer(self, buffer, riid, surface);
+		}
+		static inline void v_sapp_d3d11_get_desc(ID3D11Texture2D* self, D3D11_TEXTURE2D_DESC* desc) {
+			self->lpVtbl->GetDesc(self, desc);
+		}
+		static inline HRESULT v_sapp_d3d11_create_texture_2d(ID3D11Device* self, const D3D11_TEXTURE2D_DESC* desc, ID3D11Texture2D** texture) {
+			return self->lpVtbl->CreateTexture2D(self, desc, NULL, texture);
+		}
+		static inline void v_sapp_d3d11_copy_resource(ID3D11DeviceContext* self, ID3D11Resource* dst, ID3D11Resource* src) {
+			self->lpVtbl->CopyResource(self, dst, src);
+		}
+		static inline HRESULT v_sapp_d3d11_map(ID3D11DeviceContext* self, ID3D11Resource* resource, D3D11_MAPPED_SUBRESOURCE* mapped) {
+			return self->lpVtbl->Map(self, resource, 0, D3D11_MAP_READ, 0, mapped);
+		}
+		static inline void v_sapp_d3d11_unmap(ID3D11DeviceContext* self, ID3D11Resource* resource) {
+			self->lpVtbl->Unmap(self, resource, 0);
+		}
+	#endif
+
+	int v_sapp_read_rgba_pixels(int x, int y, int width, int height, unsigned char* pixels) {
+		if ((0 == pixels) || (x < 0) || (y < 0) || (width <= 0) || (height <= 0)) {
+			return V_SAPP_READBACK_INVALID_ARGS;
+		}
+
+		sapp_environment env = sapp_get_environment();
+		ID3D11Device* device = (ID3D11Device*) env.d3d11.device;
+		ID3D11DeviceContext* ctx = (ID3D11DeviceContext*) env.d3d11.device_context;
+		IDXGISwapChain* swap_chain = (IDXGISwapChain*) sapp_d3d11_get_swap_chain();
+		if ((0 == device) || (0 == ctx) || (0 == swap_chain)) {
+			return V_SAPP_READBACK_NO_DEVICE;
+		}
+
+		ID3D11Texture2D* back_buffer = 0;
+		HRESULT hr = v_sapp_dxgi_get_buffer(swap_chain, 0, v_sapp_d3d11_refiid(v_sapp_IID_ID3D11Texture2D), (void**) &back_buffer);
+		if (FAILED(hr) || (0 == back_buffer)) {
+			return V_SAPP_READBACK_GET_BUFFER_FAILED;
+		}
+
+		D3D11_TEXTURE2D_DESC desc;
+		v_sapp_d3d11_get_desc(back_buffer, &desc);
+		if ((desc.SampleDesc.Count != 1) || (desc.ArraySize != 1) || (desc.MipLevels < 1) ||
+			(((UINT) x + (UINT) width) > desc.Width) ||
+			(((UINT) y + (UINT) height) > desc.Height)) {
+			v_sapp_d3d11_release(back_buffer);
+			return V_SAPP_READBACK_UNSUPPORTED_SOURCE;
+		}
+
+		const bool src_bgra =
+			(desc.Format == DXGI_FORMAT_B8G8R8A8_UNORM) ||
+			(desc.Format == DXGI_FORMAT_B8G8R8A8_UNORM_SRGB);
+		const bool src_rgba =
+			(desc.Format == DXGI_FORMAT_R8G8B8A8_UNORM) ||
+			(desc.Format == DXGI_FORMAT_R8G8B8A8_UNORM_SRGB);
+		if (!src_bgra && !src_rgba) {
+			v_sapp_d3d11_release(back_buffer);
+			return V_SAPP_READBACK_UNSUPPORTED_FORMAT;
+		}
+
+		D3D11_TEXTURE2D_DESC staging_desc = desc;
+		staging_desc.Usage = D3D11_USAGE_STAGING;
+		staging_desc.BindFlags = 0;
+		staging_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+		staging_desc.MiscFlags = 0;
+
+		ID3D11Texture2D* staging = 0;
+		hr = v_sapp_d3d11_create_texture_2d(device, &staging_desc, &staging);
+		if (FAILED(hr) || (0 == staging)) {
+			v_sapp_d3d11_release(back_buffer);
+			return V_SAPP_READBACK_CREATE_STAGING_FAILED;
+		}
+
+		v_sapp_d3d11_copy_resource(ctx, (ID3D11Resource*) staging, (ID3D11Resource*) back_buffer);
+
+		D3D11_MAPPED_SUBRESOURCE mapped;
+		hr = v_sapp_d3d11_map(ctx, (ID3D11Resource*) staging, &mapped);
+		if (FAILED(hr)) {
+			v_sapp_d3d11_release(staging);
+			v_sapp_d3d11_release(back_buffer);
+			return V_SAPP_READBACK_MAP_FAILED;
+		}
+
+		const UINT src_top = desc.Height - (UINT) y - (UINT) height;
+		const UINT src_left = (UINT) x;
+		const size_t dst_row_pitch = (size_t) width * 4;
+		for (int row = 0; row < height; row++) {
+			const unsigned char* src = ((const unsigned char*) mapped.pData) +
+				(((size_t) src_top + (size_t) row) * (size_t) mapped.RowPitch) +
+				((size_t) src_left * 4);
+			unsigned char* dst = pixels + ((size_t) (height - 1 - row) * dst_row_pitch);
+			for (int col = 0; col < width; col++) {
+				if (src_bgra) {
+					dst[0] = src[2];
+					dst[1] = src[1];
+					dst[2] = src[0];
+					dst[3] = src[3];
+				} else {
+					dst[0] = src[0];
+					dst[1] = src[1];
+					dst[2] = src[2];
+					dst[3] = src[3];
+				}
+				src += 4;
+				dst += 4;
+			}
+		}
+
+		v_sapp_d3d11_unmap(ctx, (ID3D11Resource*) staging);
+		v_sapp_d3d11_release(staging);
+		v_sapp_d3d11_release(back_buffer);
+		return V_SAPP_READBACK_OK;
 	}
 #else
-	void v_sapp_gl_read_rgba_pixels(int x, int y, int width, int height, unsigned char* pixels) {
-		// TODO
+	int v_sapp_read_rgba_pixels(int x, int y, int width, int height, unsigned char* pixels) {
+		(void) x;
+		(void) y;
+		(void) width;
+		(void) height;
+		(void) pixels;
+		return -100;
 	}
 #endif

--- a/vlib/gg/frame_pacing_test.v
+++ b/vlib/gg/frame_pacing_test.v
@@ -2,6 +2,7 @@
 module gg
 
 import encoding.base64
+import os
 import time
 
 fn test_swap_interval_frame_budget() {
@@ -49,4 +50,17 @@ fn test_screenshot_stdout_payload_contains_expected_marker() {
 	encoded := base64.encode(png)
 	payload := screenshot_stdout_payload(7, png)
 	assert payload == '${gg_record_stdout_prefix} frame=7 format=png encoding=base64 data=${encoded}'
+}
+
+fn test_gg_record_captures_after_frame_fn_to_keep_d3d11_readback_pre_present() {
+	source := os.read_file(os.join_path(@VEXEROOT, 'vlib', 'gg', 'gg.c.v')) or { panic(err) }
+	frame_fn_source :=
+		source.all_after('fn gg_frame_fn').all_before('fn swap_interval_frame_budget')
+	draw_index := frame_fn_source.index('ctx.config.frame_fn(ctx.user_data)') or {
+		panic('gg_frame_fn must call the user frame function')
+	}
+	record_index := frame_fn_source.index('ctx.record_frame()') or {
+		panic('gg_record must capture inside gg_frame_fn')
+	}
+	assert draw_index < record_index, 'gg_record must capture after frame_fn so D3D11 readback happens before Present'
 }

--- a/vlib/gg/frame_pacing_test.v
+++ b/vlib/gg/frame_pacing_test.v
@@ -53,14 +53,34 @@ fn test_screenshot_stdout_payload_contains_expected_marker() {
 }
 
 fn test_gg_record_captures_after_frame_fn_to_keep_d3d11_readback_pre_present() {
-	source := os.read_file(os.join_path(@VEXEROOT, 'vlib', 'gg', 'gg.c.v')) or { panic(err) }
+	source := os.read_file(os.join_path(@DIR, 'gg.c.v')) or { panic(err) }
 	frame_fn_source :=
 		source.all_after('fn gg_frame_fn').all_before('fn swap_interval_frame_budget')
-	draw_index := frame_fn_source.index('ctx.config.frame_fn(ctx.user_data)') or {
+	draw_call := 'ctx.config.frame_fn(ctx.user_data)'
+	draw_index := frame_fn_source.index(draw_call) or {
 		panic('gg_frame_fn must call the user frame function')
 	}
-	record_index := frame_fn_source.index('ctx.record_frame()') or {
+	record_index_after_draw := frame_fn_source[draw_index + draw_call.len..].index('ctx.record_frame()') or {
 		panic('gg_record must capture inside gg_frame_fn')
 	}
+	record_index := draw_index + draw_call.len + record_index_after_draw
 	assert draw_index < record_index, 'gg_record must capture after frame_fn so D3D11 readback happens before Present'
+}
+
+fn test_gg_record_stop_only_helper_runs_before_ui_idle_return() {
+	source := os.read_file(os.join_path(@DIR, 'gg.c.v')) or { panic(err) }
+	frame_fn_source :=
+		source.all_after('fn gg_frame_fn').all_before('fn swap_interval_frame_budget')
+	ticks_branch_start := frame_fn_source.index('if ctx.ticks > 3 {') or {
+		panic('gg_frame_fn must keep the ui idle return branch')
+	}
+	ticks_branch_source := frame_fn_source[ticks_branch_start..].all_before('}')
+	stop_index := ticks_branch_source.index('ctx.stop_recording_if_needed()') or {
+		panic('ui idle return branch must stop recording when the stop frame is reached')
+	}
+	return_index := ticks_branch_source.index('return') or {
+		panic('ui idle return branch must return')
+	}
+	assert stop_index < return_index
+	assert !ticks_branch_source.contains('ctx.record_frame()'), 'ui idle return branch must not capture screenshots'
 }

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -374,7 +374,6 @@ fn gg_frame_fn(mut ctx Context) {
 		ctx.scroll_y = 0
 	}
 
-	ctx.record_frame()
 	ctx.memory_trace_frame()
 
 	if ctx.ui_mode && !ctx.needs_refresh {
@@ -391,6 +390,7 @@ fn gg_frame_fn(mut ctx Context) {
 		ctx.config.update_fn(f32(dt), ctx.user_data)
 	}
 	ctx.config.frame_fn(ctx.user_data)
+	ctx.record_frame()
 	ctx.needs_refresh = false
 }
 

--- a/vlib/gg/gg.c.v
+++ b/vlib/gg/gg.c.v
@@ -381,6 +381,7 @@ fn gg_frame_fn(mut ctx Context) {
 		// Draw 3 more frames after the "stop refresh" command
 		ctx.ticks++
 		if ctx.ticks > 3 {
+			ctx.stop_recording_if_needed()
 			return
 		}
 	}

--- a/vlib/gg/recorder.c.v
+++ b/vlib/gg/recorder.c.v
@@ -20,6 +20,17 @@ fn emit_recorded_frame_to_stdout(frame u64) ! {
 	flush_stdout()
 }
 
+@[if gg_record ?]
+fn (mut ctx Context) stop_recording_if_needed() {
+	if ctx.frame == recorder_settings.stop_at_frame {
+		$if gg_record_trace ? {
+			eprintln('>>> exiting at frame ${ctx.frame}')
+		}
+		flush_stdout()
+		exit(0)
+	}
+}
+
 // record_frame records the current frame to a file or stdout.
 // record_frame acts according to settings specified in `gg.recorder_settings`.
 @[if gg_record ?]
@@ -41,13 +52,7 @@ pub fn (mut ctx Context) record_frame() {
 			}
 		}
 	}
-	if ctx.frame == recorder_settings.stop_at_frame {
-		$if gg_record_trace ? {
-			eprintln('>>> exiting at frame ${ctx.frame}')
-		}
-		flush_stdout()
-		exit(0)
-	}
+	ctx.stop_recording_if_needed()
 }
 
 fn new_gg_recorder_settings() &SSRecorderSettings {

--- a/vlib/gg/recorder.js.v
+++ b/vlib/gg/recorder.js.v
@@ -2,3 +2,6 @@ module gg
 
 @[if gg_record ?]
 pub fn (mut ctx Context) record_frame() {}
+
+@[if gg_record ?]
+fn (mut ctx Context) stop_recording_if_needed() {}

--- a/vlib/sokol/README.md
+++ b/vlib/sokol/README.md
@@ -9,6 +9,19 @@ Each `.h` file in the sokol source code is well-documented as can be seen here:
 
 [sokol_audio.h](https://github.com/floooh/sokol/blob/master/sokol_audio.h)
 
+## Windows graphics backend
+
+On Windows, sokol uses OpenGL by default. Compile with `-d sokol_d3d11` to opt in
+to the D3D11 backend:
+
+```sh
+v -d sokol_d3d11 examples/gg/minimal.v
+```
+
+This selects `SOKOL_D3D11` and links D3D11/DXGI without changing the default
+Windows OpenGL path. Screenshot/readback uses the selected backend, but real
+D3D11 pixel correctness should be validated on Windows.
+
 ## Example from `@VEXEROOT/examples/sokol/sounds/simple_sin_tones.v`
 
 ```v cgen

--- a/vlib/sokol/c/declaration.c.v
+++ b/vlib/sokol/c/declaration.c.v
@@ -24,11 +24,16 @@ $if sokol_wayland ? {
 #flag freebsd -L/usr/local/lib -lX11 -lGL -lXcursor -lXi
 #flag openbsd -DSOKOL_GLCORE
 #flag openbsd -I/usr/X11R6/include -L/usr/X11R6/lib -lX11 -lGL -lXcursor -lXi
-#flag windows -DSOKOL_GLCORE
 #flag windows -lgdi32
 
 $if windows {
-	#flag windows -lopengl32
+	$if sokol_d3d11 ? {
+		#flag windows -DSOKOL_D3D11
+		#flag windows -ld3d11 -ldxgi
+	} $else {
+		#flag windows -DSOKOL_GLCORE
+		#flag windows -lopengl32
+	}
 	$if msvc {
 		$if livemain ? {
 			#define SOKOL_DLL
@@ -78,10 +83,6 @@ $if emscripten ? {
 	// https://github.com/emscripten-core/emscripten/issues/7950
 	//	#flag -s MODULARIZE
 }
-
-// D3D
-//#flag windows -DSOKOL_D3D11
-#flag windows -DSOKOL_GLCORE
 
 // for simplicity, all header includes are here because import order matters and we dont have any way
 // to ensure import order with V yet

--- a/vlib/sokol/gfx/windows_backend_flags_test.v
+++ b/vlib/sokol/gfx/windows_backend_flags_test.v
@@ -1,0 +1,263 @@
+// vtest build: !self_sandboxed_packaging?
+module gfx
+
+import os
+
+fn write_sokol_gfx_probe(test_root string) string {
+	source_path := os.join_path(test_root, 'sokol_gfx_probe.v')
+	os.write_file(source_path, 'import sokol.gfx
+
+fn main() {
+	_ = gfx.Desc{}
+}
+') or { panic(err) }
+	return source_path
+}
+
+fn sokol_declaration_source() string {
+	return os.read_file(os.join_path(@VEXEROOT, 'vlib', 'sokol', 'c', 'declaration.c.v')) or {
+		panic(err)
+	}
+}
+
+fn sokol_screenshot_source() string {
+	return os.read_file(os.join_path(@VEXEROOT, 'vlib', 'sokol', 'sapp', 'screenshot.c.v')) or {
+		panic(err)
+	}
+}
+
+fn sokol_sapp_v_source() string {
+	return os.read_file(os.join_path(@VEXEROOT, 'vlib', 'sokol', 'sapp', 'sapp_v.c.v')) or {
+		panic(err)
+	}
+}
+
+fn sokol_v_post_header_source() string {
+	return os.read_file(os.join_path(@VEXEROOT, 'thirdparty', 'sokol', 'sokol_v.post.h')) or {
+		panic(err)
+	}
+}
+
+fn windows_target_tests_available() bool {
+	$if windows {
+		return true
+	}
+	vcross := os.getenv('VCROSS_COMPILER_NAME')
+	if vcross != '' {
+		if vcross.contains('/') || vcross.contains('\\') {
+			if os.is_file(vcross) && os.is_executable(vcross) {
+				return true
+			}
+		} else if _ := os.find_abs_path_of_executable(vcross) {
+			return true
+		}
+		eprintln('> skipping Windows target cflag/codegen checks: VCROSS_COMPILER_NAME=${vcross} is not executable')
+		return false
+	}
+	if _ := os.find_abs_path_of_executable('x86_64-w64-mingw32-gcc') {
+		return true
+	}
+	eprintln('> skipping Windows target cflag/codegen checks: not on Windows and no usable x86_64-w64-mingw32-gcc or VCROSS_COMPILER_NAME was found')
+	return false
+}
+
+fn assert_contains_readback_token(source string, token string) {
+	assert source.contains(token), 'missing D3D11 screenshot/readback token `${token}`'
+}
+
+fn assert_d3d11_readback_helper_tokens(source string) {
+	for token in [
+		'SOKOL_D3D11',
+		'GetBuffer',
+		'D3D11_USAGE_STAGING',
+		'D3D11_CPU_ACCESS_READ',
+		'CreateTexture2D',
+		'CopyResource',
+		'Map',
+		'RowPitch',
+		'Unmap',
+		'Release',
+	] {
+		assert_contains_readback_token(source, token)
+	}
+	lower_source := source.to_lower()
+	assert lower_source.contains('bgra') && lower_source.contains('rgba'), 'D3D11 screenshot/readback helper must distinguish BGRA and RGBA sources'
+	compact_source := source.replace(' ', '').replace('\t', '').replace('\n', '').replace('\r', '')
+	assert compact_source.contains('dst[0]=src[2]') && compact_source.contains('dst[2]=src[0]'), 'D3D11 screenshot/readback helper must convert BGRA pixels to RGBA'
+}
+
+fn normalized_cflags(output string) string {
+	return '\n' + output.replace('\r\n', '\n') + '\n'
+}
+
+fn cflags_have_define(output string, define string) bool {
+	cflags := normalized_cflags(output)
+	return cflags.contains('\n-D ${define}\n') || cflags.contains('\n-D${define}\n')
+		|| cflags.contains('\n/D ${define}\n') || cflags.contains('\n/D${define}\n')
+}
+
+fn cflags_have_link_flag(output string, lib string) bool {
+	cflags := normalized_cflags(output).to_lower()
+	lib_lower := lib.to_lower()
+	return cflags.contains('-l${lib_lower}') || cflags.contains('${lib_lower}.lib')
+}
+
+fn dump_windows_sokol_gfx_cflags(extra_vflags []string) string {
+	test_root := os.join_path(os.vtmp_dir(), 'sokol_windows_backend_flags_${os.getpid()}')
+	os.rmdir_all(test_root) or {}
+	os.mkdir_all(test_root) or { panic(err) }
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	source_path := write_sokol_gfx_probe(test_root)
+	mut cmd := [
+		os.quoted_path(@VEXE),
+		'-dump-c-flags',
+		'-',
+		'-os',
+		'windows',
+		'-o',
+		os.quoted_path(os.join_path(test_root, 'sokol_gfx_probe.exe')),
+	]
+	cmd << extra_vflags
+	cmd << os.quoted_path(source_path)
+	res := os.execute(cmd.join(' '))
+	assert res.exit_code == 0, res.output
+	return res.output
+}
+
+fn generated_windows_c(extra_vflags []string, source string) string {
+	test_root := os.join_path(os.vtmp_dir(), 'sokol_windows_generated_c_${os.getpid()}')
+	os.rmdir_all(test_root) or {}
+	os.mkdir_all(test_root) or { panic(err) }
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	source_path := os.join_path(test_root, 'main.v')
+	os.write_file(source_path, source) or { panic(err) }
+	mut cmd := [
+		os.quoted_path(@VEXE),
+		'-o',
+		'-',
+		'-os',
+		'windows',
+	]
+	cmd << extra_vflags
+	cmd << os.quoted_path(source_path)
+	res := os.execute(cmd.join(' '))
+	assert res.exit_code == 0, res.output
+	return res.output
+}
+
+fn test_windows_sokol_backend_flags_are_exclusive_in_declaration() {
+	source := sokol_declaration_source()
+	expected := [
+		'$if windows {',
+		'\t$if sokol_d3d11 ? {',
+		'\t\t#flag windows -DSOKOL_D3D11',
+		'\t\t#flag windows -ld3d11 -ldxgi',
+		'\t} $else {',
+		'\t\t#flag windows -DSOKOL_GLCORE',
+		'\t\t#flag windows -lopengl32',
+		'\t}',
+	].join('\n')
+	assert source.contains(expected), source
+}
+
+fn test_windows_sokol_d3d11_define_does_not_leave_duplicate_glcore_flags() {
+	source := sokol_declaration_source()
+	assert source.count('#flag windows -DSOKOL_D3D11') == 1, source
+	assert source.count('#flag windows -DSOKOL_GLCORE') == 1, source
+	assert source.count('#flag windows -lopengl32') == 1, source
+	assert source.count('#flag windows -ld3d11') == 1, source
+	assert source.count('-ldxgi') == 1, source
+	assert !source.to_lower().contains('d3dcompiler'), source
+}
+
+fn test_sokol_screenshot_public_api_signatures_are_preserved() {
+	screenshot_source := sokol_screenshot_source()
+	sapp_v_source := sokol_sapp_v_source()
+	assert screenshot_source.contains('pub struct Screenshot {'), screenshot_source
+	assert screenshot_source.contains('pub fn screenshot_window() &Screenshot {'), screenshot_source
+	assert sapp_v_source.contains('pub fn screenshot(path string) ! {'), sapp_v_source
+	assert sapp_v_source.contains('pub fn screenshot_ppm(path string) ! {'), sapp_v_source
+	assert sapp_v_source.contains('pub fn screenshot_png(path string) ! {'), sapp_v_source
+}
+
+fn test_sokol_d3d11_screenshot_readback_is_implemented_not_guarded_as_unsupported() {
+	sapp_v_source := sokol_sapp_v_source()
+	post_header_source := sokol_v_post_header_source()
+	combined_source := sapp_v_source + '\n' + post_header_source
+	assert !combined_source.contains('sokol.sapp screenshots are not supported with -d sokol_d3d11'), combined_source
+	assert !combined_source.contains('D3D11 readback is not implemented'), combined_source
+	assert_d3d11_readback_helper_tokens(post_header_source)
+	lower_post_header_source := post_header_source.to_lower()
+	assert !lower_post_header_source.contains('todo'), post_header_source
+	assert !lower_post_header_source.contains('no-op'), post_header_source
+}
+
+fn test_windows_sokol_default_backend_cflags_remain_glcore() {
+	if !windows_target_tests_available() {
+		return
+	}
+	cflags := dump_windows_sokol_gfx_cflags([])
+	assert cflags_have_define(cflags, 'SOKOL_GLCORE'), cflags
+	assert !cflags_have_define(cflags, 'SOKOL_D3D11'), cflags
+	assert cflags_have_link_flag(cflags, 'opengl32'), cflags
+	assert !cflags_have_link_flag(cflags, 'd3d11'), cflags
+	assert !cflags_have_link_flag(cflags, 'dxgi'), cflags
+	assert !cflags_have_link_flag(cflags, 'd3dcompiler'), cflags
+}
+
+fn test_windows_sokol_d3d11_backend_cflags_select_only_d3d11() {
+	if !windows_target_tests_available() {
+		return
+	}
+	cflags := dump_windows_sokol_gfx_cflags(['-d', 'sokol_d3d11'])
+	assert cflags_have_define(cflags, 'SOKOL_D3D11'), cflags
+	assert !cflags_have_define(cflags, 'SOKOL_GLCORE'), cflags
+	assert cflags_have_link_flag(cflags, 'd3d11'), cflags
+	assert cflags_have_link_flag(cflags, 'dxgi'), cflags
+	assert !cflags_have_link_flag(cflags, 'opengl32'), cflags
+	assert !cflags_have_link_flag(cflags, 'd3dcompiler'), cflags
+}
+
+fn test_windows_sokol_d3d11_sapp_glue_passes_d3d11_handles() {
+	if !windows_target_tests_available() {
+		return
+	}
+	c_source := generated_windows_c(['-d', 'sokol_d3d11'], 'import sokol.gfx
+import sokol.sapp
+
+fn main() {
+	_ = sapp.create_desc()
+	_ = sapp.create_default_pass(gfx.PassAction{})
+}
+')
+	assert c_source.contains('env.d3d11.device = sapp_env.d3d11.device;'), c_source
+	assert c_source.contains('env.d3d11.device_context = sapp_env.d3d11.device_context;'), c_source
+	assert c_source.contains('swapchain.d3d11.render_view = sapp_sc.d3d11.render_view;'), c_source
+	assert c_source.contains('swapchain.d3d11.resolve_view = sapp_sc.d3d11.resolve_view;'), c_source
+	assert c_source.contains('swapchain.d3d11.depth_stencil_view = sapp_sc.d3d11.depth_stencil_view;'), c_source
+	assert !c_source.contains('swapchain.gl.framebuffer = sapp_sc.gl.framebuffer;'), c_source
+}
+
+fn test_windows_sokol_d3d11_screenshot_entrypoints_codegen_real_readback() {
+	if !windows_target_tests_available() {
+		return
+	}
+	c_source := generated_windows_c(['-d', 'sokol_d3d11'], "import sokol.sapp
+
+fn main() {
+	mut ss := sapp.screenshot_window()
+	unsafe { ss.destroy() }
+	sapp.screenshot_png('d3d11_probe.png') or { panic(err) }
+	sapp.screenshot_ppm('d3d11_probe.ppm') or { panic(err) }
+	sapp.screenshot('d3d11_probe_path.png') or { panic(err) }
+}
+")
+	assert c_source.contains('v_sapp_read_rgba_pixels'), c_source
+	assert !c_source.contains('sokol.sapp screenshots are not supported with -d sokol_d3d11'), c_source
+	assert !c_source.contains('D3D11 readback is not implemented'), c_source
+	assert !c_source.contains('v_sapp_gl_read_rgba_pixels'), c_source
+}

--- a/vlib/sokol/sapp/sapp.c.v
+++ b/vlib/sokol/sapp/sapp.c.v
@@ -51,6 +51,9 @@ pub fn glue_environment() gfx.Environment {
 	env.defaults.sample_count = sapp_env.defaults.sample_count
 	$if macos && !darwin_sokol_glcore33 ? {
 		env.metal.device = sapp_env.metal.device
+	} $else $if windows && sokol_d3d11 ? {
+		env.d3d11.device = sapp_env.d3d11.device
+		env.d3d11.device_context = sapp_env.d3d11.device_context
 	}
 	return env
 }
@@ -71,6 +74,10 @@ pub fn glue_swapchain() gfx.Swapchain {
 		swapchain.metal.current_drawable = sapp_sc.metal.current_drawable
 		swapchain.metal.depth_stencil_texture = sapp_sc.metal.depth_stencil_texture
 		swapchain.metal.msaa_color_texture = sapp_sc.metal.msaa_color_texture
+	} $else $if windows && sokol_d3d11 ? {
+		swapchain.d3d11.render_view = sapp_sc.d3d11.render_view
+		swapchain.d3d11.resolve_view = sapp_sc.d3d11.resolve_view
+		swapchain.d3d11.depth_stencil_view = sapp_sc.d3d11.depth_stencil_view
 	} $else {
 		swapchain.gl.framebuffer = sapp_sc.gl.framebuffer
 	}

--- a/vlib/sokol/sapp/sapp_funcs.c.v
+++ b/vlib/sokol/sapp/sapp_funcs.c.v
@@ -160,5 +160,5 @@ fn C.sapp_x11_get_display() voidptr
 // Android: get native activity handle
 fn C.sapp_android_get_native_activity() voidptr
 
-// V-specific: read RGBA pixels from the OpenGL framebuffer
-fn C.v_sapp_gl_read_rgba_pixels(x i32, y i32, width i32, height i32, pixels charptr)
+// V-specific: read RGBA pixels from the active backend framebuffer
+fn C.v_sapp_read_rgba_pixels(x int, y int, width int, height int, pixels charptr) int

--- a/vlib/sokol/sapp/sapp_v.c.v
+++ b/vlib/sokol/sapp/sapp_v.c.v
@@ -5,11 +5,11 @@ import stbi
 
 #define SOKOL_VALIDATE_NON_FATAL 1
 
-// v_sapp_gl_read_rgba_pixels reads pixles from the OpenGL buffer into `pixels`.
-fn C.v_sapp_gl_read_rgba_pixels(x int, y int, width int, height int, pixels charptr)
+// v_sapp_read_rgba_pixels reads pixels from the active backend into `pixels`.
+fn C.v_sapp_read_rgba_pixels(x int, y int, width int, height int, pixels charptr) int
 
-// screenshot takes a screenshot of the current window and
-// saves it to `path`. The format is inferred from the extension
+// screenshot takes a screenshot of the current backend framebuffer/window contents
+// at call time and saves it to `path`. The format is inferred from the extension
 // of the file name in `path`.
 //
 // Supported formats are: `.png`, `.ppm`.
@@ -31,19 +31,23 @@ pub fn screenshot(path string) ! {
 // saves it to `path` as a .ppm file.
 @[manualfree]
 pub fn screenshot_ppm(path string) ! {
-	ss := screenshot_window()
+	ss := screenshot_window_checked()!
+	defer {
+		unsafe { ss.destroy() }
+	}
 	write_rgba_to_ppm(path, ss.width, ss.height, 4, ss.pixels)!
-	unsafe { ss.destroy() }
 }
 
 // screenshot_png takes a screenshot of the current window and
 // saves it to `path` as a .png file.
 @[manualfree]
 pub fn screenshot_png(path string) ! {
-	ss := screenshot_window()
+	ss := screenshot_window_checked()!
+	defer {
+		unsafe { ss.destroy() }
+	}
 	stbi.set_flip_vertically_on_write(true)
 	stbi.stbi_write_png(path, ss.width, ss.height, 4, ss.pixels, ss.width * 4)!
-	unsafe { ss.destroy() }
 }
 
 // write_rgba_to_ppm writes `pixels` data in RGBA format to PPM3 format.

--- a/vlib/sokol/sapp/screenshot.c.v
+++ b/vlib/sokol/sapp/screenshot.c.v
@@ -10,18 +10,28 @@ mut:
 }
 
 @[manualfree]
-pub fn screenshot_window() &Screenshot {
+fn screenshot_window_checked() !&Screenshot {
 	img_width := width()
 	img_height := height()
 	img_size := img_width * img_height * 4
 	img_pixels := unsafe { &u8(malloc(img_size)) }
-	C.v_sapp_gl_read_rgba_pixels(0, 0, img_width, img_height, img_pixels)
+	readback_status := C.v_sapp_read_rgba_pixels(0, 0, img_width, img_height, img_pixels)
+	if readback_status != 0 {
+		unsafe { free(img_pixels) }
+		return error('sokol.sapp screenshot readback failed with code ${readback_status}')
+	}
 	return &Screenshot{
 		width:  img_width
 		height: img_height
 		size:   img_size
 		pixels: img_pixels
 	}
+}
+
+// screenshot_window captures the current backend framebuffer/window contents at call time.
+@[manualfree]
+pub fn screenshot_window() &Screenshot {
+	return screenshot_window_checked() or { panic(err) }
 }
 
 // free - free *only* the Screenshot pixels.


### PR DESCRIPTION
## Summary

Adds opt-in Windows D3D11 support for sokol.

Windows keeps OpenGL as the default backend. D3D11 is enabled explicitly with:

v -d sokol_d3d11 examples/gg/minimal.v

This wires D3D11 backend selection, sapp device/swapchain glue, gg through sokol, and backend-aware screenshot readback while preserving the existing public screenshot API.

Fix #27652 

## Validation

Passed locally:

- ./v test vlib/sokol/gfx vlib/sokol/sapp vlib/v/live
- ./v check-md vlib/sokol/README.md
- ./v fmt -verify on touched V files
- git diff --check

Windows smoke CI passed with MSVC and GCC:

- default OpenGL compile/link
- D3D11 compile/link for gg/minimal, 2048, tetris
- D3D11 screenshot probe compile/link

## Windows Manual Testing

CI validates compile/link only. Please test on real Windows:

- v -d sokol_d3d11 examples/gg/minimal.v
- v -d sokol_d3d11 examples/2048/2048.v
- v -d sokol_d3d11 examples/tetris/tetris.v

Please confirm rendering, input, resize, clean close, and screenshot PNG/PPM correctness.

Note: D3D11 screenshot/readback is implemented for normal Windows builds, but `-sharedlive -d sokol_d3d11` screenshot/readback is not supported yet and should be handled in a separate follow-up.