### PR TITLE
markused: fix undeclared C identifier for alias array type

### DIFF
--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -726,6 +726,9 @@ pub fn (mut w Walker) stmt(node_ ast.Stmt) {
 			}
 		}
 		ast.AssignStmt {
+			for t in node.left_types {
+				w.mark_by_type(t)
+			}
 			w.exprs(node.left)
 			w.exprs(node.right)
 		}

--- a/vlib/v/tests/aliases/alias_array_reference_test.v
+++ b/vlib/v/tests/aliases/alias_array_reference_test.v
@@ -1,0 +1,8 @@
+type Arr = []int
+
+fn test_alias_array_reference() {
+	mut a := Arr{len: 1}
+	a[0] = 69
+	p := &a[0]
+	assert *p == 69
+}


### PR DESCRIPTION
_NB: all credits to Claude_

## What

Fixes #27648

C compilation error ("undeclared identifier") when an array type alias is used to declare a variable whose address (or an element's address) is taken later, and the alias isn't referenced anywhere else in the program.

## Why

`-skip-unused` is enabled by default, so cgen only emits a C typedef for an alias type if `markused` recorded it as used. For `a := Array{}`, the RHS `ast.ArrayInit` node's `.typ` is already resolved to the underlying `[]int` type by the checker, not to the `Array` alias — so `markused` never sees the alias and its typedef gets stripped by dead-code elimination. cgen then emits the auto-heap declaration using the *declared* type (the alias), which was never typedef'd, hence the undeclared identifier.

## Fix

`ast.AssignStmt.left_types` holds the declared type(s) of the LHS. Marking those as used keeps `markused` and cgen in sync.

## Test

Regression test added. Note: the alias must not appear anywhere else in the test file (a stray `==` comparison, `<<`, etc. would mark it used through a different path and silently defeat the test).