### PR TITLE
transform: fix O(n²) late-used-fn-bodies pass (7-10x faster transform)

### DIFF
--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1331,12 +1331,14 @@ fn (mut t Transformer) transform_late_used_fn_bodies(names []string, node_limit 
 	t.cur_file = old_file
 	limit := if node_limit < t.a.nodes.len { node_limit } else { t.a.nodes.len }
 	// Build the fn_decl candidate list once. The scan range [0, limit) is fixed:
-	// transform_fn_body only appends nodes beyond `limit` (those generated nodes
-	// are handled inline below), so the set of candidate fn_decls, their
-	// (file, module) context, and their generic-ness never change across rounds.
-	// Re-deriving all of this every round previously made this pass O(pending *
-	// nodes): a full node walk (millions of node_kind_id calls) plus a repeated
-	// fn_decl_has_unresolved_generics check on every non-matching fn_decl.
+	// transform_fn_body rewrites the current fn_decl in place and appends new
+	// nodes beyond `limit` (those generated nodes are handled inline below); it
+	// never inserts or moves existing top-level nodes below `limit`. So the set
+	// of candidate fn_decls, their (file, module) context, and their generic-ness
+	// never change across rounds. Re-deriving all of this every round previously
+	// made this pass O(pending * nodes): a full node walk (millions of
+	// node_kind_id calls) plus a repeated fn_decl_has_unresolved_generics check
+	// on every non-matching fn_decl.
 	mut candidates := []LateFnCandidate{}
 	mut scan_file := ''
 	mut scan_module := ''

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1329,46 +1329,67 @@ fn (mut t Transformer) transform_late_used_fn_bodies(names []string, node_limit 
 	}
 	t.cur_module = old_module
 	t.cur_file = old_file
-	mut processed := map[int]bool{}
 	limit := if node_limit < t.a.nodes.len { node_limit } else { t.a.nodes.len }
-	for pending.len > 0 {
-		_ := pending.pop()
-		t.transform_pending_late_used_fn_bodies(limit, mut late, mut pending, mut queued, mut
-			processed)
-	}
-}
-
-fn (mut t Transformer) transform_pending_late_used_fn_bodies(limit int, mut late map[string]bool, mut pending []string, mut queued map[string]bool, mut processed map[int]bool) {
-	mut cur_file := ''
-	mut cur_module := ''
+	// Build the fn_decl candidate list once. The scan range [0, limit) is fixed:
+	// transform_fn_body only appends nodes beyond `limit` (those generated nodes
+	// are handled inline below), so the set of candidate fn_decls, their
+	// (file, module) context, and their generic-ness never change across rounds.
+	// Re-deriving all of this every round previously made this pass O(pending *
+	// nodes): a full node walk (millions of node_kind_id calls) plus a repeated
+	// fn_decl_has_unresolved_generics check on every non-matching fn_decl.
+	mut candidates := []LateFnCandidate{}
+	mut scan_file := ''
+	mut scan_module := ''
 	for i in 0 .. limit {
-		if processed[i] {
-			continue
-		}
 		node := t.a.nodes[i]
 		kind_id := node_kind_id(node)
 		if kind_id == 77 {
-			cur_file = node.value
-			cur_module = ''
+			scan_file = node.value
+			scan_module = ''
+		} else if kind_id == 73 {
+			scan_module = node.value
+		} else if kind_id == 61 && !t.fn_decl_has_unresolved_generics(node, scan_module) {
+			candidates << LateFnCandidate{
+				idx:    i
+				file:   scan_file
+				module: scan_module
+			}
+		}
+	}
+	for pending.len > 0 {
+		_ := pending.pop()
+		t.transform_pending_late_used_fn_bodies(mut candidates, mut late, mut pending, mut queued)
+	}
+}
+
+// LateFnCandidate is a non-generic fn_decl reachable by the late-used-fn-bodies
+// pass, together with the file/module context resolved for it during the single
+// structural scan in transform_late_used_fn_bodies.
+struct LateFnCandidate {
+	idx    int
+	file   string
+	module string
+mut:
+	processed bool
+}
+
+fn (mut t Transformer) transform_pending_late_used_fn_bodies(mut candidates []LateFnCandidate, mut late map[string]bool, mut pending []string, mut queued map[string]bool) {
+	for ci in 0 .. candidates.len {
+		if candidates[ci].processed {
 			continue
 		}
-		if kind_id == 73 {
-			cur_module = node.value
+		idx := candidates[ci].idx
+		node := t.a.nodes[idx]
+		if !late_used_fn_matches(late, node, candidates[ci].module) {
 			continue
 		}
-		if kind_id != 61 || t.fn_decl_has_unresolved_generics(node, cur_module) {
-			continue
-		}
-		if !late_used_fn_matches(late, node, cur_module) {
-			continue
-		}
-		processed[i] = true
-		t.cur_file = cur_file
-		t.cur_module = cur_module
+		candidates[ci].processed = true
+		t.cur_file = candidates[ci].file
+		t.cur_module = candidates[ci].module
 		used_before := t.used_fns.clone()
 		node_count_before := t.a.nodes.len
-		t.transform_fn_body(i)
-		for call_name in t.generated_fn_body_call_names(flat.NodeId(i)) {
+		t.transform_fn_body(idx)
+		for call_name in t.generated_fn_body_call_names(flat.NodeId(idx)) {
 			t.enqueue_late_used_call_name(call_name, used_before, mut late, mut pending, mut queued)
 		}
 		for j in node_count_before .. t.a.nodes.len {


### PR DESCRIPTION
## Problem

Profiling the v3 transform phase showed it dominated by a single quadratic pass, `transform_late_used_fn_bodies` in `vlib/v3/transform/transform.v`. Its worklist loop rescanned the **entire** node array `[0, limit)` on every round:

```v
for pending.len > 0 {
    _ := pending.pop()
    transform_pending_late_used_fn_bodies(limit, ...)  // walks ALL nodes from 0 each round
}
```

Every round re-classified each node (millions of `node_kind_id` calls) and re-ran the expensive `fn_decl_has_unresolved_generics` check (→ `type_text_has_generic_placeholder`) on every non-matching `fn_decl`. With ~pending rounds over ~N nodes this is `O(pending × nodes)`.

Profiled call counts on a single input (`markused.v`):

| function | calls |
|---|---|
| `node_kind_id` | 25.7M |
| `type_text_has_generic_placeholder` | 1.79M |
| `fn_decl_has_unresolved_generics` | 373k |

## Fix

Build the `fn_decl` candidate list **once**. The scan range `[0, limit)` is fixed — `transform_fn_body` only appends nodes beyond `limit`, and those generated nodes are already handled inline — so the set of candidate fn_decls, their `(file, module)` context, and their generic-ness never change across rounds. Each round now iterates a compact, pre-filtered list and does only the cheap `late_used_fn_matches` map check that genuinely depends on the growing `late` set.

The round structure and processing order are preserved exactly, so the pass is behavior-preserving.

## Results

| Input | transform before → after | total before → after |
|---|---|---|
| `markused.v` | 2320 ms → **294 ms** (7.9×) | 3450 ms → **843 ms** (4.1×) |
| `v3.v` self-compile | 55033 ms → **5564 ms** (9.9×) | 58015 ms → **7579 ms** (7.7×) |

The win scales with input size, as expected for an O(N²)→O(N) fix.

## Correctness

- **Byte-identical generated C output** on `markused.v` (552 KB) and on the full `v3.v` self-compile (5.67 MB — exercises generics and every module).
- **v3 test suite: no regressions.** The failing tests in this tree fail identically with and without this change (verified by stashing the change, rebuilding, and re-running the same set); they are pre-existing and unrelated.