### PR TITLE
cgen: fix invalid C for `&` reference of fixed array alias

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -1871,7 +1871,8 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 							}
 						}
 						if !is_used_var_styp {
-							if !val_type.has_flag(.option) && left_sym.is_array_fixed() {
+							if !val_type.has_flag(.option) && left_sym.is_array_fixed()
+								&& var_type.nr_muls() == 0 {
 								if left_sym.info is ast.Alias {
 									parent_sym := g.table.final_sym(left_sym.info.parent_type)
 									styp = g.styp(left_sym.info.parent_type)

--- a/vlib/v/tests/aliases/alias_fixed_array_unsafe_reference_test.v
+++ b/vlib/v/tests/aliases/alias_fixed_array_unsafe_reference_test.v
@@ -1,0 +1,7 @@
+type Arr = [8]int
+
+fn test_alias_fixed_array_unsafe_reference() {
+	a := Arr{}
+	n := unsafe { &a }
+	assert n != unsafe { nil }
+}


### PR DESCRIPTION
# Fixes #27688

## Problem
```v
type Arr = [8]int

fn main() {
	a := Arr{}
	n := unsafe { &a }
}
```
generated invalid C and crashed the C compiler:
```c
cc:  error: array initializer must be an initializer list or wide string literal
cc:  4276 |         Array_fixed_int_8 m = &a;
```
`&a[0]` (element address) already worked; this is specifically about referencing the whole array value.

## Cause

In `vlib/v/gen/c/assign.v`, `left_sym := g.table.sym(g.unwrap_generic(var_type))` looks up the base symbol of the declared type, ignoring `nr_muls` (pointer level) entirely — that's how `g.table.sym()` works, it resolves the type index regardless of how many `&` it carries. So for `n`'s declared type `&Arr` (a pointer to the alias), `left_sym` still resolves to the `Arr` alias symbol itself, exactly as it would for a plain `Arr` value.

A later block treats any declaration whose `left_sym.is_array_fixed()` as a fixed-array declaration and overwrites the already-correct `styp` (which did include the pointer star, e.g. `main__Arr*`) with `g.styp(left_sym.info.parent_type)` — the alias's *parent* type, which carries no pointer information at all. This silently drops the `*`, producing `Array_fixed_int_8 n = &a;`, i.e. an array-typed variable assigned a pointer value: invalid C.

## Fix

Guard that block so it only fires when `var_type` isn't itself a pointer:

```v
if !val_type.has_flag(.option) && var_type.nr_muls() == 0
    && left_sym.is_array_fixed() {
```

## Test

Regression test added (isolated: the alias name isn't referenced anywhere else in the file, see prior PR discussion on why that matters).

_NB: credits to Claude_