### PR TITLE
cgen: fix generic method &Interface param extra & indirection (#27612)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -7235,6 +7235,16 @@ fn (mut g Gen) ref_or_deref_arg_ex(arg ast.CallArg, expected_type_ ast.Type, lan
 				}
 			} else if effective_arg_sym.kind == expected_ref_inner_sym.kind
 				&& effective_arg_typ.idx() == expected_ref_inner_type.idx() {
+				// Fix: when a &Interface variable is auto-dereferenced by the checker to its
+				// value type, arg_typ loses the pointer flag. Check the actual variable type
+				// to avoid adding an extra & on an already-pointer variable.
+				if effective_arg_expr is ast.Ident && effective_arg_expr.obj is ast.Var {
+					var_typ := (effective_arg_expr.obj as ast.Var).typ
+					if var_typ.clear_flag(.generic) == expected_type.clear_flag(.generic) {
+						g.expr(effective_arg_expr)
+						return
+					}
+				}
 				g.prevent_sum_type_unwrapping_once = g.is_expr_smartcast_to_sumtype(effective_arg_expr,
 					expected_ref_inner_type)
 				if effective_arg_expr in [ast.Ident, ast.SelectorExpr] {

--- a/vlib/v/tests/generic_multi_return_interface_cast_test.v
+++ b/vlib/v/tests/generic_multi_return_interface_cast_test.v
@@ -174,3 +174,19 @@ fn test_generic_as_cast_multi_return_interface() {
 	g2, _ := w2.extract()
 	assert g2.get() == 2
 }
+
+// Regression test: passing &Interface from generic multi-return
+// to a generic method that expects &Interface.
+// ref_or_deref_arg_ex must NOT add extra & to an already-&Interface arg.
+fn (w Wrapper[T]) verify(src &Gettable) int {
+	return src.get()
+}
+
+fn test_generic_method_ref_interface_param() {
+	w1 := Wrapper[TypeA]{
+		src: Holder{&TypeA{10, 20}}
+	}
+	_, ref := w1.extract()
+	result := w1.verify(ref)
+	assert result == 30
+}


### PR DESCRIPTION
fixed: https://github.com/vlang/v/issues/27612

Generic method calls on concrete generic structs could incorrectly add an extra & to &Interface arguments. The checker auto-dereferences &Interface variables to their value type when typing call arguments, and the cgen's expected_type resolution left the .generic flag set. This caused ref_or_deref_arg_ex to miss that the argument was already a pointer and emit an extra &, resulting in &Interface** being passed instead of &Interface*.

Fix: in ref_or_deref_arg_ex, when about to emit & for an Ident referring to a Var, compare the variable's actual type (clearing .generic flag) against the expected type (also clearing .generic flag). If they match, emit the expression directly.

Add regression test using the existing Wrapper[T].extract() infrastructure.


<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
