### PR TITLE
bitfield: add way to convert back into byte array

### DIFF
--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -53,6 +53,21 @@ pub fn (bf BitField) str() string {
 	return output.bytestr()
 }
 
+// bytes converts the bit array into an array of bytes.
+pub fn (bf BitField) bytes() []u8 {
+	mut output := []u8{}
+	mut i := 0
+	for f in bf.field {
+		for j in 1..5 {
+			s := bits.reverse_32(f) // un-reverse the action of from_bytes, if slot_size changes this may break
+			b := u8((s >> (slot_size - (j * 8))) & 255)
+			if i * 8 >= bf.size { break } else { i += 1 } // exclude unused bytes
+			output << b
+		}
+	}
+	return output
+}
+
 // new creates an empty bit array capable of storing `size` bits.
 pub fn new(size int) BitField {
 	output := BitField{

--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -58,9 +58,10 @@ pub fn (bf BitField) bytes() []u8 {
 	mut output := []u8{}
 	mut i := 0
 	for f in bf.field {
+		// un-reverse the action of from_bytes, if slot_size changes this may break
+		// reversing all at once is more efficient and simpler than doing it bytewise or bitwise
+		s := bits.reverse_32(f)
 		for j in 1 .. 5 {
-			// un-reverse the action of from_bytes, if slot_size changes this may break
-			s := bits.reverse_32(f)
 			b := u8((s >> (slot_size - (j * 8))) & 255)
 			// exclude unused bytes
 			if i * 8 >= bf.size {

--- a/vlib/bitfield/bitfield.v
+++ b/vlib/bitfield/bitfield.v
@@ -58,10 +58,16 @@ pub fn (bf BitField) bytes() []u8 {
 	mut output := []u8{}
 	mut i := 0
 	for f in bf.field {
-		for j in 1..5 {
-			s := bits.reverse_32(f) // un-reverse the action of from_bytes, if slot_size changes this may break
+		for j in 1 .. 5 {
+			// un-reverse the action of from_bytes, if slot_size changes this may break
+			s := bits.reverse_32(f)
 			b := u8((s >> (slot_size - (j * 8))) & 255)
-			if i * 8 >= bf.size { break } else { i += 1 } // exclude unused bytes
+			// exclude unused bytes
+			if i * 8 >= bf.size {
+				break
+			} else {
+				i += 1
+			}
 			output << b
 		}
 	}

--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -404,6 +404,6 @@ fn test_bitfield_to_bytes() {
 	str := 'Hello, world!'
 	b_from_str := str.bytes()
 	bf := bitfield.from_bytes(b_from_str)
-	b_from_bf  := bf.bytes()
+	b_from_bf := bf.bytes()
 	assert b_from_bf == b_from_str
 }

--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -399,3 +399,11 @@ fn test_zero_length_slice_and_pos() {
 	empty_bf := bitfield.new(0)
 	assert empty_bf.pos(needle) == 0
 }
+
+fn test_bitfield_to_bytes() {
+	str := 'Hello, world!'
+	b_from_str := str.bytes()
+	bf := bitfield.from_bytes(b_from_str)
+	b_from_bf  := bf.bytes()
+	assert b_from_bf == b_from_str
+}

--- a/vlib/bitfield/bitfield_test.v
+++ b/vlib/bitfield/bitfield_test.v
@@ -400,10 +400,50 @@ fn test_zero_length_slice_and_pos() {
 	assert empty_bf.pos(needle) == 0
 }
 
-fn test_bitfield_to_bytes() {
+fn test_string_bitfield_to_bytes() {
 	str := 'Hello, world!'
 	b_from_str := str.bytes()
 	bf := bitfield.from_bytes(b_from_str)
 	b_from_bf := bf.bytes()
 	assert b_from_bf == b_from_str
+}
+
+fn test_bytes_bitfield_to_bytes() {
+	mut expected := []u8{}
+	mut bf := bitfield.from_bytes(expected)
+	mut b_from_bf := bf.bytes()
+	assert b_from_bf == expected
+
+	expected << 0x01
+	bf = bitfield.from_bytes(expected)
+	b_from_bf = bf.bytes()
+	assert b_from_bf == expected
+
+	expected = [u8(0xff)]
+	bf = bitfield.from_bytes(expected)
+	b_from_bf = bf.bytes()
+	assert b_from_bf == expected
+
+	expected = [u8(0x80)]
+	bf = bitfield.from_bytes(expected)
+	b_from_bf = bf.bytes()
+	assert b_from_bf == expected
+
+	expected = [u8(0x0f)]
+	bf = bitfield.from_bytes(expected)
+	b_from_bf = bf.bytes()
+	assert b_from_bf == expected
+
+	expected = [u8(0xf0)]
+	bf = bitfield.from_bytes(expected)
+	b_from_bf = bf.bytes()
+	assert b_from_bf == expected
+}
+
+fn test_unaligned_bitfield_to_bytes() {
+	expected := [u8(0x00), 0x00, 0x00, 0x00, 0b10000000]
+	mut bf := bitfield.new(33)
+	bf.set_bit(32)
+	b_from_bf := bf.bytes()
+	assert b_from_bf == expected
 }


### PR DESCRIPTION
This allows a `bitfield` to be converted back into a `[]u8` losslessly.

Before this I wrote a version in my own code which steps through bit-wise, as that was the only way to do so with public functions. But this, accessing `BitField.field` directly and operating on 32-bits at a time, should be far more performant.
