### PR TITLE
tools: fix vdoc dropping the module overview comment when the first symbol also has a doc comment (fixes #27672)

### DIFF
--- a/cmd/tools/vdoc/document/doc.v
+++ b/cmd/tools/vdoc/document/doc.v
@@ -386,9 +386,25 @@ pub fn (mut d Doc) file_ast(mut file_ast ast.File) map[string]DocNode {
 			if post_module_comments.len > 0 {
 				last_post_module_comment := post_module_comments[post_module_comments.len - 1]
 				if stmt is ast.Import || last_post_module_comment.pos.line_nr + 1 < stmt.pos.line_nr {
+					// None of the comments are directly above the following statement,
+					// so treat all of them as the module's overview comment.
 					d.head.comments << post_module_comments
 				} else {
-					preceding_comments << post_module_comments
+					// The comments directly above the following statement (with no
+					// blank line separating them) document that statement, while an
+					// earlier block, separated by a blank line, is the module overview.
+					mut split_idx := post_module_comments.len
+					mut next_line := stmt.pos.line_nr
+					for split_idx > 0 {
+						cmt := post_module_comments[split_idx - 1]
+						if cmt.pos.last_line + 1 < next_line {
+							break
+						}
+						next_line = cmt.pos.line_nr
+						split_idx--
+					}
+					d.head.comments << post_module_comments[..split_idx]
+					preceding_comments << post_module_comments[split_idx..]
 				}
 				post_module_comments = []
 			}

--- a/cmd/tools/vdoc/document/doc.v
+++ b/cmd/tools/vdoc/document/doc.v
@@ -384,8 +384,11 @@ pub fn (mut d Doc) file_ast(mut file_ast ast.File) map[string]DocNode {
 		}
 		if collect_post_module_comments {
 			if post_module_comments.len > 0 {
+				// Attributes are consumed before the declaration, so anchor the
+				// adjacency checks on the first attribute line when present.
+				stmt_line := stmt_doc_anchor_line(stmt)
 				last_post_module_comment := post_module_comments[post_module_comments.len - 1]
-				if stmt is ast.Import || last_post_module_comment.pos.line_nr + 1 < stmt.pos.line_nr {
+				if stmt is ast.Import || last_post_module_comment.pos.last_line + 1 < stmt_line {
 					// None of the comments are directly above the following statement,
 					// so treat all of them as the module's overview comment.
 					d.head.comments << post_module_comments
@@ -394,7 +397,7 @@ pub fn (mut d Doc) file_ast(mut file_ast ast.File) map[string]DocNode {
 					// blank line separating them) document that statement, while an
 					// earlier block, separated by a blank line, is the module overview.
 					mut split_idx := post_module_comments.len
-					mut next_line := stmt.pos.line_nr
+					mut next_line := stmt_line
 					for split_idx > 0 {
 						cmt := post_module_comments[split_idx - 1]
 						if cmt.pos.last_line + 1 < next_line {

--- a/cmd/tools/vdoc/document/utils.v
+++ b/cmd/tools/vdoc/document/utils.v
@@ -23,9 +23,10 @@ pub fn ast_comment_to_doc_comment(ast_node ast.Comment) DocComment {
 		text:     text
 		is_multi: ast_node.is_multi
 		pos:      token.Pos{
-			line_nr: ast_node.pos.line_nr
-			col:     0 // ast_node.pos.pos - ast_node.text.len
-			len:     text.len
+			line_nr:   ast_node.pos.line_nr
+			last_line: ast_node.pos.last_line
+			col:       0 // ast_node.pos.pos - ast_node.text.len
+			len:       text.len
 		}
 	}
 }

--- a/cmd/tools/vdoc/document/utils.v
+++ b/cmd/tools/vdoc/document/utils.v
@@ -205,6 +205,41 @@ pub fn (d Doc) stmt_name(stmt ast.Stmt) string {
 	}
 }
 
+// stmt_doc_anchor_line returns the source line that a statement's documentation
+// comment is expected to sit directly above. Attributes are parsed and consumed
+// before the declaration itself, so `stmt.pos` points at the declaration keyword,
+// *below* any attribute lines. When the statement carries attributes, the doc
+// comment is above the topmost attribute, so its line is used instead.
+fn stmt_doc_anchor_line(stmt ast.Stmt) int {
+	return match stmt {
+		ast.ConstDecl, ast.EnumDecl, ast.FnDecl, ast.GlobalDecl, ast.InterfaceDecl, ast.StructDecl {
+			attrs_first_line(stmt.attrs, stmt.pos.line_nr)
+		}
+		ast.TypeDecl {
+			match stmt {
+				ast.AliasTypeDecl, ast.FnTypeDecl, ast.SumTypeDecl {
+					attrs_first_line(stmt.attrs, stmt.pos.line_nr)
+				}
+			}
+		}
+		else {
+			stmt.pos.line_nr
+		}
+	}
+}
+
+// attrs_first_line returns the topmost source line among `attrs`, or
+// `default_line` when there are no positioned attributes.
+fn attrs_first_line(attrs []ast.Attr, default_line int) int {
+	mut anchor := default_line
+	for a in attrs {
+		if a.pos.line_nr > 0 && a.pos.line_nr < anchor {
+			anchor = a.pos.line_nr
+		}
+	}
+	return anchor
+}
+
 // stmt_pub returns a boolean if a given `ast.Stmt` node
 // is exposed to the public.
 pub fn (d Doc) stmt_pub(stmt ast.Stmt) bool {

--- a/cmd/tools/vdoc/testdata/module_and_attributed_symbol_comments/main.comments.out
+++ b/cmd/tools/vdoc/testdata/module_and_attributed_symbol_comments/main.comments.out
@@ -1,0 +1,7 @@
+module main
+    This is the overview comment of the module. It is placed in the first comment right after the module name.
+
+fn bar()
+    bar is the documentation for bar
+fn foo()
+    foo is the documentation for foo

--- a/cmd/tools/vdoc/testdata/module_and_attributed_symbol_comments/main.out
+++ b/cmd/tools/vdoc/testdata/module_and_attributed_symbol_comments/main.out
@@ -1,0 +1,4 @@
+module main
+
+fn bar()
+fn foo()

--- a/cmd/tools/vdoc/testdata/module_and_attributed_symbol_comments/main.v
+++ b/cmd/tools/vdoc/testdata/module_and_attributed_symbol_comments/main.v
@@ -1,0 +1,11 @@
+module main
+
+// This is the overview comment of the module.
+// It is placed in the first comment right after the module name.
+
+// foo is the documentation for foo
+@[deprecated: 'use bar instead']
+pub fn foo() {}
+
+// bar is the documentation for bar
+pub fn bar() {}

--- a/cmd/tools/vdoc/testdata/module_and_symbol_comments/main.comments.out
+++ b/cmd/tools/vdoc/testdata/module_and_symbol_comments/main.comments.out
@@ -1,0 +1,7 @@
+module main
+    This is the overview comment of the module. It is placed in the first comment right after the module name.
+
+const color01 = 'red'
+    color01 is the documentation for color01
+const color02 = 'blue'
+    color02 is the documentation for color02

--- a/cmd/tools/vdoc/testdata/module_and_symbol_comments/main.out
+++ b/cmd/tools/vdoc/testdata/module_and_symbol_comments/main.out
@@ -1,0 +1,4 @@
+module main
+
+const color01 = 'red'
+const color02 = 'blue'

--- a/cmd/tools/vdoc/testdata/module_and_symbol_comments/main.v
+++ b/cmd/tools/vdoc/testdata/module_and_symbol_comments/main.v
@@ -1,0 +1,10 @@
+module main
+
+// This is the overview comment of the module.
+// It is placed in the first comment right after the module name.
+
+// color01 is the documentation for color01
+pub const color01 = 'red'
+
+// color02 is the documentation for color02
+pub const color02 = 'blue'


### PR DESCRIPTION
## Problem

Fixes #27672.

`v doc` is documented so that "An overview of the module must be placed in the first comment right after the module's name." That works — until the **first symbol** in the file also has its own doc comment. In that case the module overview comment silently disappears.

Given:
```v
module main
// Documentation for module main

// color01 - documentation for color01
pub const color01 = 'red'

// color02 - documentation for color02
pub const color02 = 'blue'
```

`v doc -comments` produced (module overview lost):
```
module main

const color01 = 'red'
    color01 - documentation for color01
const color02 = 'blue'
    color02 - documentation for color02
```

## Cause

In `file_ast()` the comments that follow the `module` statement are gathered into `post_module_comments`. When the next statement is reached, the code looked only at the **last** collected comment: if that last comment was directly above the statement, the **entire** block (including the module overview, which is separated by a blank line) was attached to that statement's `preceding_comments`. Rendering (`merge_doc_comments`) only keeps the last contiguous block, so the blank-line-separated module overview was dropped entirely.

## Fix

When the trailing comment is adjacent to the following statement, walk the collected comments backwards and split them at the first blank-line gap: the contiguous block directly above the statement documents that statement, while an earlier block (the module overview) is assigned to the module head.

`ast_comment_to_doc_comment()` now also preserves `pos.last_line`, so the adjacency check is correct for multi-line comments too.

After the fix:
```
module main
    Documentation for module main

const color01 = 'red'
    color01 - documentation for color01
const color02 = 'blue'
    color02 - documentation for color02
```

## Tests

Added a regression case under `cmd/tools/vdoc/testdata/module_and_symbol_comments/` (exercised by `vdoc_file_test.v`). All existing `cmd/tools/vdoc` tests still pass.