### PR TITLE
v3: parallel parser behind the v3_no_parallel define, like transform/cgen

### DIFF
--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -52,9 +52,20 @@ mut:
 	in_for_container  bool
 	local_type_names  map[string]string
 	local_type_scopes []string
+	export_records    []ExportRecord
 pub mut:
 	a              &flat.FlatAst = unsafe { nil }
 	parsed_v_files int
+}
+
+// ExportRecord captures one accepted `@[export: name]` registration in file
+// order. The parallel-parse merge replays worker exports through these records
+// so they can be revalidated against disabled fns from earlier chunks (see
+// merge_parsed_worker), reproducing the serial parse's order-dependent check.
+struct ExportRecord {
+	name  string
+	qname string
+	value string
 }
 
 // new creates a Parser value for parser.
@@ -86,11 +97,25 @@ pub fn (mut p Parser) parse_files(paths []string) &flat.FlatAst {
 	return p.a
 }
 
+// parse_files_with_starts parses paths in order like parse_files, recording the
+// first node id of each file's region. Import resolution uses the starts to
+// bound per-file post-processing (module-name canonicalization) when files are
+// parsed in batches instead of one at a time.
+pub fn (mut p Parser) parse_files_with_starts(paths []string) []int {
+	mut starts := []int{cap: paths.len}
+	for path in paths {
+		starts << p.a.nodes.len
+		p.parse_into(path)
+	}
+	return starts
+}
+
 // parse_into reads parse into input for parser.
 pub fn (mut p Parser) parse_into(path string) {
 	p.cur_file = path
 	p.cur_module = ''
 	p.cur_fn = ''
+	p.has_peek = false
 	p.pending_flag = false
 	p.pending_params = false
 	p.pending_export = ''
@@ -1007,6 +1032,11 @@ fn (mut p Parser) register_pending_export(name string) {
 		return
 	}
 	p.a.export_fn_names[qname] = p.pending_export
+	p.export_records << ExportRecord{
+		name:  name
+		qname: qname
+		value: p.pending_export
+	}
 	p.pending_export = ''
 }
 

--- a/vlib/v3/parser/parser_parallel_d_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_d_v3_no_parallel.v
@@ -1,0 +1,8 @@
+module parser
+
+// parse_files_dispatch falls back to the serial parse when v3 is built with
+// the internal `v3_no_parallel` define. Returns each file's first node id in
+// p.a and whether worker threads were used.
+pub fn (mut p Parser) parse_files_dispatch(paths []string, _ bool) ([]int, bool) {
+	return p.parse_files_with_starts(paths), false
+}

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -1,0 +1,249 @@
+module parser
+
+import os
+import runtime
+import v3.flat
+
+// Parallel file parsing. The input file list is split into contiguous,
+// size-balanced chunks; each worker parses its chunk into a private Parser +
+// FlatAst on its own thread, and the master folds the results back in chunk
+// order, shifting node ids and children offsets by the merge position. A
+// file's nodes only ever reference nodes of the same file, and chunks are
+// contiguous slices of the input list merged in input order, so the merged
+// nodes/children arrays are laid out exactly as a serial parse of the same
+// list — the phases downstream see an identical AST either way.
+
+const min_parallel_parse_files = 4
+const min_parallel_parse_bytes = 131072
+const max_parallel_parse_jobs = 8
+
+$if !windows {
+	// ParseChunkArgs is the payload handed to each worker thread.
+	struct ParseChunkArgs {
+		worker     voidptr // &Parser
+		paths_ptr  voidptr // &[]string
+		starts_ptr voidptr // &[]int (worker-local starts; the master shifts them on merge)
+		start      int
+		end        int
+	}
+
+	// C.pthread_t declares C pthread t data used by parser.
+	@[typedef]
+	struct C.pthread_t {}
+
+	// C.pthread_create declares the C pthread_create symbol used by parser.
+	fn C.pthread_create(thread &C.pthread_t, attr voidptr, start_routine fn (voidptr) voidptr, arg voidptr) int
+
+	// C.pthread_join declares the C pthread_join symbol used by parser.
+	fn C.pthread_join(thread C.pthread_t, retval voidptr) int
+
+	// C.pthread_attr_init declares the C pthread_attr_init symbol used by parser.
+	fn C.pthread_attr_init(attr voidptr) int
+
+	// C.pthread_attr_setstacksize declares the C pthread_attr_setstacksize symbol used by parser.
+	fn C.pthread_attr_setstacksize(attr voidptr, stacksize usize) int
+
+	// C.pthread_attr_destroy declares the C pthread_attr_destroy symbol used by parser.
+	fn C.pthread_attr_destroy(attr voidptr) int
+
+	// parse_chunk_thread parses one worker's contiguous range of files into the
+	// worker's private FlatAst, recording each file's worker-local first node id
+	// into its own preallocated slot of the shared starts array.
+	fn parse_chunk_thread(arg voidptr) voidptr {
+		a := unsafe { &ParseChunkArgs(arg) }
+		mut w := unsafe { &Parser(a.worker) }
+		paths := unsafe { &[]string(a.paths_ptr) }
+		mut starts := unsafe { &[]int(a.starts_ptr) }
+		for i in a.start .. a.end {
+			unsafe {
+				(*starts)[i] = w.a.nodes.len
+			}
+			w.parse_into((*paths)[i])
+		}
+		return unsafe { nil }
+	}
+}
+
+// parse_files_dispatch parses paths in order, appending to p.a exactly like a
+// serial parse_into loop, across worker threads when there is enough work.
+// Returns each file's first node id in p.a and whether threads were used.
+pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) ([]int, bool) {
+	$if windows {
+		return p.parse_files_with_starts(paths), false
+	} $else {
+		if !allow_parallel || paths.len < min_parallel_parse_files {
+			return p.parse_files_with_starts(paths), false
+		}
+		mut sizes := []i64{cap: paths.len}
+		mut total_bytes := i64(0)
+		for path in paths {
+			size := i64(os.file_size(path))
+			sizes << size
+			total_bytes += size
+		}
+		n_jobs := parse_job_count(runtime.nr_jobs(), paths.len)
+		if n_jobs <= 1 || total_bytes < min_parallel_parse_bytes {
+			return p.parse_files_with_starts(paths), false
+		}
+		bounds := parse_chunk_bounds(sizes, n_jobs)
+		thread_count := n_jobs - 1
+		mut starts := []int{len: paths.len}
+		// Worker parsers are cheap to build (no AST clone: parse output is
+		// per-file independent), so all of them are created up front. Each
+		// pre-reserves for its chunk's source bytes to avoid growth doubling.
+		mut workers := []&Parser{cap: thread_count}
+		for ci in 0 .. thread_count {
+			mut w := Parser.new(p.prefs)
+			mut chunk_bytes := i64(0)
+			for i in bounds[ci + 1] .. bounds[ci + 2] {
+				chunk_bytes += sizes[i]
+			}
+			w.reserve_for_source(int(chunk_bytes))
+			workers << w
+		}
+		mut args := []ParseChunkArgs{cap: thread_count}
+		for ci in 0 .. thread_count {
+			args << ParseChunkArgs{
+				worker:     voidptr(workers[ci])
+				paths_ptr:  unsafe { voidptr(&paths) }
+				starts_ptr: unsafe { voidptr(&starts) }
+				start:      bounds[ci + 1]
+				end:        bounds[ci + 2]
+			}
+		}
+		mut thread_ids := []C.pthread_t{len: thread_count}
+		attr_buf := [64]u8{}
+		attr := unsafe { voidptr(&attr_buf[0]) }
+		C.pthread_attr_init(attr)
+		// The parser recurses deeply on nested expressions; give workers a
+		// roomy stack, like the transform and cgen workers.
+		C.pthread_attr_setstacksize(attr, 64 * 1024 * 1024)
+		for ci in 0 .. thread_count {
+			C.pthread_create(unsafe { &thread_ids[ci] }, attr, parse_chunk_thread,
+				unsafe { voidptr(&args[ci]) })
+		}
+		C.pthread_attr_destroy(attr)
+		// The master parses chunk 0 straight into p.a while the helpers run —
+		// no merge needed for it, and its layout matches a serial parse.
+		for i in bounds[0] .. bounds[1] {
+			starts[i] = p.a.nodes.len
+			p.parse_into(paths[i])
+		}
+		// Join and merge each helper in fixed chunk order (input file order),
+		// so node numbering stays deterministic and byte-identical to serial.
+		for ci in 0 .. thread_count {
+			C.pthread_join(thread_ids[ci], unsafe { nil })
+			p.merge_parsed_worker(workers[ci], mut starts, bounds[ci + 1], bounds[ci + 2])
+		}
+		return starts, true
+	}
+}
+
+// merge_parsed_worker appends a finished worker's parsed output to the master
+// AST. Worker node ids and children offsets are 0-based (the worker started
+// from an empty FlatAst), so every node-id reference moves by the master's
+// node count and every children_start by the master's children count at merge
+// time. Negative child slots (flat.empty_node sentinels) are left untouched.
+fn (mut p Parser) merge_parsed_worker(w &Parser, mut starts []int, chunk_start int, chunk_end int) {
+	node_shift := p.a.nodes.len
+	child_shift := i32(p.a.children.len)
+	new_children := w.a.children.len
+	if new_children > 0 {
+		old_len := p.a.children.len
+		unsafe {
+			p.a.children.grow_len(new_children)
+			vmemcpy(&p.a.children[old_len], &w.a.children[0],
+				new_children * int(sizeof(flat.NodeId)))
+		}
+		for k in old_len .. p.a.children.len {
+			cid := p.a.children[k]
+			if int(cid) >= 0 {
+				p.a.children[k] = flat.NodeId(int(cid) + node_shift)
+			}
+		}
+	}
+	new_nodes := w.a.nodes.len
+	if new_nodes > 0 {
+		nodes_old_len := p.a.nodes.len
+		unsafe {
+			p.a.nodes.grow_len(new_nodes)
+			vmemcpy(&p.a.nodes[nodes_old_len], &w.a.nodes[0], new_nodes * int(sizeof(flat.Node)))
+		}
+		for k in nodes_old_len .. p.a.nodes.len {
+			// Only nodes with children carry a live children_start; leaving
+			// childless nodes untouched keeps their zero-value fields
+			// byte-identical to a serial parse.
+			if p.a.nodes[k].children_count != 0 {
+				p.a.nodes[k] = p.a.nodes[k].with_shifted_children(child_shift)
+			}
+		}
+	}
+	// Per-file region starts move by the merge offset.
+	for i in chunk_start .. chunk_end {
+		starts[i] += node_shift
+	}
+	// The worker validated its exports against its own files only; revalidate
+	// them here against disabled fns accumulated from earlier chunks, exactly
+	// like the serial parse where register_pending_export sees every previously
+	// parsed file. The worker's own disabled marks are folded in afterwards, so
+	// a disable in a later file keeps earlier exports — matching the serial
+	// order-dependent behavior.
+	for rec in w.export_records {
+		if rec.name in p.a.disabled_fns || rec.qname in p.a.disabled_fns {
+			continue
+		}
+		p.a.export_fn_names[rec.qname] = rec.value
+	}
+	for name, disabled in w.a.disabled_fns {
+		if disabled {
+			p.a.disabled_fns[name] = true
+		}
+	}
+	for name, is_noreturn in w.a.noreturn_fns {
+		if is_noreturn {
+			p.a.noreturn_fns[name] = true
+		}
+	}
+	p.parsed_v_files += w.parsed_v_files
+}
+
+// parse_job_count caps the worker count by the runtime job count, a fixed
+// ceiling and the file count.
+fn parse_job_count(n_runtime_jobs int, n_files int) int {
+	if n_runtime_jobs <= 0 || n_files <= 0 {
+		return 0
+	}
+	mut n := n_runtime_jobs
+	if n > max_parallel_parse_jobs {
+		n = max_parallel_parse_jobs
+	}
+	if n > n_files {
+		n = n_files
+	}
+	return n
+}
+
+// parse_chunk_bounds splits the file list into n contiguous ranges of roughly
+// equal source byte count (parse time tracks source size closely). Contiguity
+// in input order is required so the ordered merge reproduces the serial layout.
+fn parse_chunk_bounds(sizes []i64, n int) []int {
+	mut total := i64(0)
+	for size in sizes {
+		total += size + 1
+	}
+	mut bounds := []int{cap: n + 1}
+	bounds << 0
+	mut acc := i64(0)
+	mut chunk := 1
+	for i in 0 .. sizes.len {
+		acc += sizes[i] + 1
+		if chunk < n && acc >= total * i64(chunk) / i64(n) {
+			bounds << i + 1
+			chunk++
+		}
+	}
+	for bounds.len < n + 1 {
+		bounds << sizes.len
+	}
+	return bounds
+}

--- a/vlib/v3/tests/parallel_parser_test.v
+++ b/vlib/v3/tests/parallel_parser_test.v
@@ -148,6 +148,87 @@ fn test_parallel_parser_compiles_multi_module_project() {
 	assert run.output.trim_space() == expected.trim_space()
 }
 
+// write_parallel_parser_implicit_sync_project writes a project where only an
+// imported module needs the implicit `sync` import (a shared field + lock, no
+// explicit import anywhere), so the seed fires for a module parsed inside a
+// parallel import wave and `sync` must resolve with that module's context.
+fn write_parallel_parser_implicit_sync_project(name string) string {
+	project_dir := os.join_path(os.temp_dir(), 'v3_${name}')
+	os.rmdir_all(project_dir) or {}
+	os.mkdir_all(os.join_path(project_dir, 'locker')) or { panic(err) }
+	// Padding modules keep the import wave above the parallel-parse thresholds.
+	for m in 0 .. 3 {
+		os.mkdir_all(os.join_path(project_dir, 'pad${m}')) or { panic(err) }
+		mut pad_src := strings.new_builder(64_000)
+		pad_src.writeln('module pad${m}')
+		pad_src.writeln('')
+		for i in 0 .. 1200 {
+			pad_src.writeln('pub fn pad_value_${i}() int {')
+			pad_src.writeln('\treturn ${i + m}')
+			pad_src.writeln('}')
+			pad_src.writeln('')
+		}
+		os.write_file(os.join_path(project_dir, 'pad${m}', 'pad${m}.v'), pad_src.str()) or {
+			panic(err)
+		}
+	}
+	os.write_file(os.join_path(project_dir, 'locker', 'locker.v'), 'module locker
+
+pub struct Counter {
+pub mut:
+	value shared int
+}
+
+pub fn bump(mut c Counter) int {
+	mut total := 0
+	lock c.value {
+		c.value += 3
+		total = c.value
+	}
+	return total
+}
+') or {
+		panic(err)
+	}
+	mut main_src := strings.new_builder(4_000)
+	main_src.writeln('module main')
+	main_src.writeln('')
+	main_src.writeln('import locker')
+	for m in 0 .. 3 {
+		main_src.writeln('import pad${m}')
+	}
+	main_src.writeln('')
+	main_src.writeln('fn main() {')
+	main_src.writeln('\tmut c := locker.Counter{}')
+	main_src.writeln('\tmut total := locker.bump(mut c)')
+	for m in 0 .. 3 {
+		main_src.writeln('\ttotal += pad${m}.pad_value_1199()')
+	}
+	main_src.writeln('\tprintln(int_str(total))')
+	main_src.writeln('}')
+	os.write_file(os.join_path(project_dir, 'main.v'), main_src.str()) or { panic(err) }
+	return os.join_path(project_dir, 'main.v')
+}
+
+// test_parallel_parser_seeds_implicit_sync_import_mid_wave validates that the
+// implicit sync import still gets seeded (and resolved) when the module that
+// needs it is parsed inside a parallel import wave rather than one at a time.
+// Only the generated C is checked: linking a shared+lock project fails on
+// master too (markused prunes RwMutex methods that only cgen-synthesized
+// code calls), which is unrelated to import resolution.
+fn test_parallel_parser_seeds_implicit_sync_import_mid_wave() {
+	v3_bin := build_parallel_parser_v3()
+	main_path := write_parallel_parser_implicit_sync_project('parallel_parser_implicit_sync')
+	c_out := os.join_path(os.temp_dir(), 'v3_parallel_parser_implicit_sync_${os.getpid()}.c')
+	compile := os.execute('VJOBS=4 ${v3_bin} ${main_path} -o ${c_out}')
+	assert compile.exit_code == 0, compile.output
+	c_code := os.read_file(c_out) or { panic(err) }
+	// The sync module's own functions only appear when the synthetic
+	// `import sync` was seeded for the mid-wave locker module and its files
+	// were parsed in the next wave.
+	assert c_code.contains('sync__Channel__close'), 'implicit sync import was not seeded/parsed'
+}
+
 // test_no_parallel_parser_keeps_parse_serial validates the runtime opt-out:
 // `--no-parallel` must keep the parse phase off the worker threads.
 fn test_no_parallel_parser_keeps_parse_serial() {

--- a/vlib/v3/tests/parallel_parser_test.v
+++ b/vlib/v3/tests/parallel_parser_test.v
@@ -1,0 +1,162 @@
+import os
+import runtime
+import strings
+import v3.parser
+import v3.pref
+
+const pp_tests_dir = os.dir(@FILE)
+const pp_v3_dir = os.dir(pp_tests_dir)
+const pp_vlib_dir = os.dir(pp_v3_dir)
+const pp_v3_src = os.join_path(pp_v3_dir, 'v3.v')
+
+// parallel_parse_input_files gathers enough real compiler sources to cross the
+// parallel-parse thresholds (min file count and total byte size).
+fn parallel_parse_input_files() []string {
+	mut files := []string{}
+	for sub in ['types', 'transform', 'parser', 'markused', 'flat'] {
+		dir := os.join_path(pp_v3_dir, sub)
+		mut names := os.ls(dir) or { continue }
+		names.sort()
+		for name in names {
+			if name.ends_with('.v') && !name.ends_with('_test.v') {
+				files << os.join_path(dir, name)
+			}
+		}
+	}
+	return files
+}
+
+// test_parallel_parse_matches_serial parses the same file list serially and
+// through the threaded dispatch and requires the resulting flat ASTs to be
+// identical: same node fields, same children ids, same per-file region starts
+// and same side tables. This pins the merge's id/offset shifting to the serial
+// layout byte for byte.
+fn test_parallel_parse_matches_serial() {
+	files := parallel_parse_input_files()
+	assert files.len >= 4
+	prefs := pref.new_preferences()
+	mut ps := parser.Parser.new(prefs)
+	serial_starts := ps.parse_files_with_starts(files)
+	mut pp := parser.Parser.new(prefs)
+	parallel_starts, was_parallel := pp.parse_files_dispatch(files, true)
+	$if !windows {
+		if runtime.nr_jobs() > 1 {
+			assert was_parallel
+		}
+	}
+	assert parallel_starts == serial_starts
+	assert pp.parsed_v_files == ps.parsed_v_files
+	assert pp.a.nodes.len == ps.a.nodes.len
+	assert pp.a.children.len == ps.a.children.len
+	for i in 0 .. ps.a.children.len {
+		assert int(pp.a.children[i]) == int(ps.a.children[i]), 'children[${i}] differs'
+	}
+	for i in 0 .. ps.a.nodes.len {
+		s := ps.a.nodes[i]
+		q := pp.a.nodes[i]
+		assert q.kind == s.kind, 'node ${i} kind differs'
+		assert q.kind_id == s.kind_id, 'node ${i} kind_id differs'
+		assert q.value == s.value, 'node ${i} value differs'
+		assert q.typ == s.typ, 'node ${i} typ differs'
+		assert q.op == s.op, 'node ${i} op differs'
+		assert q.is_mut == s.is_mut, 'node ${i} is_mut differs'
+		assert q.generic_params == s.generic_params, 'node ${i} generic_params differs'
+		assert q.pos.offset == s.pos.offset, 'node ${i} pos differs'
+		assert q.children_count == s.children_count, 'node ${i} children_count differs'
+		if s.children_count != 0 {
+			assert q.children_start == s.children_start, 'node ${i} children_start differs'
+		}
+	}
+	assert pp.a.disabled_fns.keys() == ps.a.disabled_fns.keys()
+	assert pp.a.noreturn_fns.keys() == ps.a.noreturn_fns.keys()
+	assert pp.a.export_fn_names.keys() == ps.a.export_fn_names.keys()
+	for qname, value in ps.a.export_fn_names {
+		assert pp.a.export_fn_names[qname] == value
+	}
+}
+
+// build_parallel_parser_v3 builds parallel parser v3 data for v3 tests.
+fn build_parallel_parser_v3() string {
+	vexe := @VEXE
+	v3_bin := os.join_path(os.temp_dir(), 'v3_parallel_parser_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${vexe} -gc none -path "${pp_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${pp_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+// write_parallel_parser_project writes a multi-module project large enough for
+// the user-file and import waves to be split across parse workers.
+fn write_parallel_parser_project(name string) string {
+	project_dir := os.join_path(os.temp_dir(), 'v3_${name}')
+	os.rmdir_all(project_dir) or {}
+	mut mod_totals := []int{}
+	for m in 0 .. 4 {
+		os.mkdir_all(os.join_path(project_dir, 'mod${m}')) or { panic(err) }
+		mut mod_src := strings.new_builder(64_000)
+		mod_src.writeln('module mod${m}')
+		mod_src.writeln('')
+		mut total := 0
+		for i in 0 .. 900 {
+			mod_src.writeln('pub fn value_${i}() int {')
+			mod_src.writeln('\treturn ${i + m}')
+			mod_src.writeln('}')
+			mod_src.writeln('')
+			total += i + m
+		}
+		mod_totals << total
+		os.write_file(os.join_path(project_dir, 'mod${m}', 'mod${m}.v'), mod_src.str()) or {
+			panic(err)
+		}
+	}
+	mut main_src := strings.new_builder(16_000)
+	main_src.writeln('module main')
+	main_src.writeln('')
+	for m in 0 .. 4 {
+		main_src.writeln('import mod${m}')
+	}
+	main_src.writeln('')
+	main_src.writeln('fn main() {')
+	main_src.writeln('\tmut total := 0')
+	for m in 0 .. 4 {
+		main_src.writeln('\ttotal += mod${m}.value_899()')
+	}
+	main_src.writeln('\tprintln(int_str(total))')
+	main_src.writeln('}')
+	os.write_file(os.join_path(project_dir, 'main.v'), main_src.str()) or { panic(err) }
+	expected := 899 * 4 + 0 + 1 + 2 + 3
+	os.write_file(os.join_path(project_dir, 'expected.txt'), '${expected}') or { panic(err) }
+	return os.join_path(project_dir, 'main.v')
+}
+
+// test_parallel_parser_compiles_multi_module_project validates that a build
+// whose import waves are parsed on worker threads produces a working program,
+// and that the bench output reports the parse phase as parallel.
+fn test_parallel_parser_compiles_multi_module_project() {
+	v3_bin := build_parallel_parser_v3()
+	main_path := write_parallel_parser_project('parallel_parser_project')
+	bin_out := os.join_path(os.temp_dir(), 'v3_parallel_parser_project_out_${os.getpid()}')
+	compile := os.execute('VJOBS=4 ${v3_bin} ${main_path} -b c -o ${bin_out}')
+	assert compile.exit_code == 0, compile.output
+	$if !windows {
+		assert compile.output.contains('parse (parallel)'), compile.output
+	}
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	expected := os.read_file(os.join_path(os.dir(main_path), 'expected.txt')) or { panic(err) }
+	assert run.output.trim_space() == expected.trim_space()
+}
+
+// test_no_parallel_parser_keeps_parse_serial validates the runtime opt-out:
+// `--no-parallel` must keep the parse phase off the worker threads.
+fn test_no_parallel_parser_keeps_parse_serial() {
+	v3_bin := build_parallel_parser_v3()
+	main_path := write_parallel_parser_project('parallel_parser_serial_project')
+	bin_out := os.join_path(os.temp_dir(), 'v3_parallel_parser_serial_out_${os.getpid()}')
+	compile := os.execute('VJOBS=4 ${v3_bin} --no-parallel ${main_path} -b c -o ${bin_out}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('parse (parallel)'), compile.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+}

--- a/vlib/v3/tests/parallel_parser_test.v
+++ b/vlib/v3/tests/parallel_parser_test.v
@@ -337,6 +337,98 @@ fn test_parallel_parser_seeds_implicit_sync_before_explicit_import() {
 	assert c_code.contains('sync__new_waitgroup'), 'explicit sync import did not resolve for the later module'
 }
 
+// write_parallel_parser_splice_project writes a project where an early module
+// needs an implicit import that a later same-wave module does not: `aembed` uses
+// `$embed_file` (implicit `v.embed_file`) and is imported before `zsync`, which
+// imports `sync` explicitly. The synthetic import is spliced in right after
+// aembed's parsed region rather than at the wave tail, so the next resolver pass
+// scans it before zsync's imports — the order serial resolution produced. That
+// splice shifts every node after aembed's region and remaps the children table,
+// so a working run of the program is what proves the remap kept the AST intact.
+fn write_parallel_parser_splice_project(name string) (string, string) {
+	project_dir := os.join_path(os.temp_dir(), 'v3_${name}')
+	os.rmdir_all(project_dir) or {}
+	os.mkdir_all(os.join_path(project_dir, 'aembed')) or { panic(err) }
+	os.mkdir_all(os.join_path(project_dir, 'zsync')) or { panic(err) }
+	os.write_file(os.join_path(project_dir, 'aembed', 'payload.txt'), 'embedded-payload') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(project_dir, 'aembed', 'aembed.v'), "module aembed
+
+pub fn contents() string {
+	f := \$embed_file('payload.txt')
+	return f.to_string().trim_space()
+}
+") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(project_dir, 'zsync', 'zsync.v'), 'module zsync
+
+import sync
+
+pub fn wg_count() int {
+	mut wg := sync.new_waitgroup()
+	wg.add(7)
+	return 7
+}
+') or {
+		panic(err)
+	}
+	// Padding modules keep the import wave above the parallel-parse thresholds.
+	for m in 0 .. 3 {
+		os.mkdir_all(os.join_path(project_dir, 'pad${m}')) or { panic(err) }
+		mut pad_src := strings.new_builder(64_000)
+		pad_src.writeln('module pad${m}')
+		pad_src.writeln('')
+		for i in 0 .. 1200 {
+			pad_src.writeln('pub fn pad_value_${i}() int {')
+			pad_src.writeln('\treturn ${i + m}')
+			pad_src.writeln('}')
+			pad_src.writeln('')
+		}
+		os.write_file(os.join_path(project_dir, 'pad${m}', 'pad${m}.v'), pad_src.str()) or {
+			panic(err)
+		}
+	}
+	mut main_src := strings.new_builder(4_000)
+	main_src.writeln('module main')
+	main_src.writeln('')
+	// aembed (implicit v.embed_file) is imported before zsync (explicit sync).
+	main_src.writeln('import aembed')
+	main_src.writeln('import zsync')
+	for m in 0 .. 3 {
+		main_src.writeln('import pad${m}')
+	}
+	main_src.writeln('')
+	main_src.writeln('fn main() {')
+	main_src.writeln('\tmut total := zsync.wg_count()')
+	for m in 0 .. 3 {
+		main_src.writeln('\ttotal += pad${m}.pad_value_5()')
+	}
+	main_src.writeln("\tprintln(aembed.contents() + ' ' + int_str(total))")
+	main_src.writeln('}')
+	os.write_file(os.join_path(project_dir, 'main.v'), main_src.str()) or { panic(err) }
+	// 7 (wg) + (5+0) + (5+1) + (5+2) = 7 + 18 = 25.
+	expected := 'embedded-payload 25'
+	return os.join_path(project_dir, 'main.v'), expected
+}
+
+// test_parallel_parser_splices_synthetic_import_in_serial_order validates that a
+// synthetic import seeded for an early wave module is spliced into the AST before
+// the later wave modules — not appended at the tail — and that the resulting
+// node/children shift leaves a runnable program. Unlike the shared+lock cases,
+// an `$embed_file` project links, so the program is built and run end to end.
+fn test_parallel_parser_splices_synthetic_import_in_serial_order() {
+	v3_bin := build_parallel_parser_v3()
+	main_path, expected := write_parallel_parser_splice_project('parallel_parser_splice')
+	bin_out := os.join_path(os.temp_dir(), 'v3_parallel_parser_splice_out_${os.getpid()}')
+	compile := os.execute('VJOBS=4 ${v3_bin} ${main_path} -b c -o ${bin_out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == expected, run.output
+}
+
 // test_no_parallel_parser_keeps_parse_serial validates the runtime opt-out:
 // `--no-parallel` must keep the parse phase off the worker threads.
 fn test_no_parallel_parser_keeps_parse_serial() {

--- a/vlib/v3/tests/parallel_parser_test.v
+++ b/vlib/v3/tests/parallel_parser_test.v
@@ -229,6 +229,114 @@ fn test_parallel_parser_seeds_implicit_sync_import_mid_wave() {
 	assert c_code.contains('sync__Channel__close'), 'implicit sync import was not seeded/parsed'
 }
 
+// write_parallel_parser_implicit_before_explicit_sync_project writes a project
+// where a module needing the implicit `sync` import (shared field + lock, no
+// explicit import) is imported *before* another module that imports `sync`
+// explicitly, so both land in the same import wave with the implicit one earlier
+// in parse order. This is the edge case the per-module seed guards: the wave has
+// already parsed the later module (and its explicit `import sync`) by the time
+// the earlier module's boundary is reached, so a whole-array duplicate check
+// would let that later explicit import suppress the earlier module's synthetic
+// import — one serial resolution would have added first, before the later module
+// existed. The seed's already-imported scan is bounded to the module's serial
+// boundary to keep the earlier module resolving its own `sync` usage.
+fn write_parallel_parser_implicit_before_explicit_sync_project(name string) string {
+	project_dir := os.join_path(os.temp_dir(), 'v3_${name}')
+	os.rmdir_all(project_dir) or {}
+	os.mkdir_all(os.join_path(project_dir, 'implock')) or { panic(err) }
+	os.mkdir_all(os.join_path(project_dir, 'explsync')) or { panic(err) }
+	// Padding modules keep the import wave above the parallel-parse thresholds.
+	for m in 0 .. 3 {
+		os.mkdir_all(os.join_path(project_dir, 'pad${m}')) or { panic(err) }
+		mut pad_src := strings.new_builder(64_000)
+		pad_src.writeln('module pad${m}')
+		pad_src.writeln('')
+		for i in 0 .. 1200 {
+			pad_src.writeln('pub fn pad_value_${i}() int {')
+			pad_src.writeln('\treturn ${i + m}')
+			pad_src.writeln('}')
+			pad_src.writeln('')
+		}
+		os.write_file(os.join_path(project_dir, 'pad${m}', 'pad${m}.v'), pad_src.str()) or {
+			panic(err)
+		}
+	}
+	os.write_file(os.join_path(project_dir, 'implock', 'implock.v'), 'module implock
+
+pub struct Counter {
+pub mut:
+	value shared int
+}
+
+pub fn bump(mut c Counter) int {
+	mut total := 0
+	lock c.value {
+		c.value += 3
+		total = c.value
+	}
+	return total
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(project_dir, 'explsync', 'explsync.v'), 'module explsync
+
+import sync
+
+pub fn make_wg() &sync.WaitGroup {
+	return sync.new_waitgroup()
+}
+') or {
+		panic(err)
+	}
+	mut main_src := strings.new_builder(4_000)
+	main_src.writeln('module main')
+	main_src.writeln('')
+	// implock (implicit sync) is imported before explsync (explicit sync), so it
+	// is the earlier module in the shared wave.
+	main_src.writeln('import implock')
+	main_src.writeln('import explsync')
+	for m in 0 .. 3 {
+		main_src.writeln('import pad${m}')
+	}
+	main_src.writeln('')
+	main_src.writeln('fn main() {')
+	main_src.writeln('\tmut c := implock.Counter{}')
+	main_src.writeln('\tmut total := implock.bump(mut c)')
+	main_src.writeln('\twg := explsync.make_wg()')
+	main_src.writeln('\t_ = wg')
+	for m in 0 .. 3 {
+		main_src.writeln('\ttotal += pad${m}.pad_value_1199()')
+	}
+	main_src.writeln('\tprintln(int_str(total))')
+	main_src.writeln('}')
+	os.write_file(os.join_path(project_dir, 'main.v'), main_src.str()) or { panic(err) }
+	return os.join_path(project_dir, 'main.v')
+}
+
+// test_parallel_parser_seeds_implicit_sync_before_explicit_import validates that
+// a module needing the implicit sync import still resolves it when a later module
+// in the same parallel wave imports sync explicitly. The build must succeed (the
+// earlier module's shared/lock lowers against sync) rather than dropping the seed
+// because the later module's already-parsed explicit import was visible in the
+// post-wave array. As with the mid-wave test, only the generated C is checked:
+// linking a shared+lock project fails on master too (markused prunes the RwMutex
+// methods that only cgen-synthesized code calls), which is unrelated here.
+fn test_parallel_parser_seeds_implicit_sync_before_explicit_import() {
+	v3_bin := build_parallel_parser_v3()
+	main_path :=
+		write_parallel_parser_implicit_before_explicit_sync_project('parallel_parser_implicit_before_explicit_sync')
+	c_out := os.join_path(os.temp_dir(),
+		'v3_parallel_parser_implicit_before_explicit_sync_${os.getpid()}.c')
+	compile := os.execute('VJOBS=4 ${v3_bin} ${main_path} -o ${c_out}')
+	assert compile.exit_code == 0, compile.output
+	c_code := os.read_file(c_out) or { panic(err) }
+	// The earlier module's `lock` lowered against sync, and the later module's
+	// explicit sync usage is present too: both coexist after the per-module seed.
+	assert c_code.contains('sync__RwMutex__lock'), 'implicit sync import did not resolve for the earlier module'
+	assert c_code.contains('sync__new_waitgroup'), 'explicit sync import did not resolve for the later module'
+}
+
 // test_no_parallel_parser_keeps_parse_serial validates the runtime opt-out:
 // `--no-parallel` must keep the parse phase off the worker threads.
 fn test_no_parallel_parser_keeps_parse_serial() {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1141,7 +1141,17 @@ fn skipped_backend_modules(prefs &pref.Preferences) []string {
 }
 
 fn seed_implicit_sync_import(mut a flat.FlatAst) {
-	if !ast_needs_sync_import(a) || ast_has_import(a, 'sync') {
+	seed_implicit_sync_import_upto(mut a, a.nodes.len)
+}
+
+// seed_implicit_sync_import_upto is seed_implicit_sync_import with the need
+// scan bounded to the first end_node nodes. The import-resolution wave loop
+// re-checks after each module's parsed region, in parse order, so the seed
+// fires at the same module boundary as the serial one-module-at-a-time loop
+// did. The already-imported check deliberately scans the whole array, so a
+// synthetic import appended for an earlier module is seen and never duplicated.
+fn seed_implicit_sync_import_upto(mut a flat.FlatAst, end_node int) {
+	if !ast_needs_sync_import(a, end_node) || ast_has_import(a, 'sync') {
 		return
 	}
 	a.add_node(flat.Node{
@@ -1152,7 +1162,13 @@ fn seed_implicit_sync_import(mut a flat.FlatAst) {
 }
 
 fn seed_implicit_embed_file_import(mut a flat.FlatAst) {
-	if !ast_needs_embed_file_import(a) || ast_has_import(a, 'v.embed_file') {
+	seed_implicit_embed_file_import_upto(mut a, a.nodes.len)
+}
+
+// seed_implicit_embed_file_import_upto bounds the need scan like
+// seed_implicit_sync_import_upto.
+fn seed_implicit_embed_file_import_upto(mut a flat.FlatAst, end_node int) {
+	if !ast_needs_embed_file_import(a, end_node) || ast_has_import(a, 'v.embed_file') {
 		return
 	}
 	a.add_node(flat.Node{
@@ -1162,8 +1178,9 @@ fn seed_implicit_embed_file_import(mut a flat.FlatAst) {
 	})
 }
 
-fn ast_needs_sync_import(a &flat.FlatAst) bool {
-	for node in a.nodes {
+fn ast_needs_sync_import(a &flat.FlatAst, end_node int) bool {
+	for i in 0 .. end_node {
+		node := a.nodes[i]
 		if node.kind == .lock_expr {
 			return true
 		}
@@ -1202,8 +1219,9 @@ fn type_text_is_channel(typ string) bool {
 	return clean.starts_with('chan ') || clean == 'chan'
 }
 
-fn ast_needs_embed_file_import(a &flat.FlatAst) bool {
-	for node in a.nodes {
+fn ast_needs_embed_file_import(a &flat.FlatAst, end_node int) bool {
+	for i in 0 .. end_node {
+		node := a.nodes[i]
 		if node.kind == .struct_init && node.value == 'embed_file.EmbedFileData' {
 			return true
 		}
@@ -1253,6 +1271,12 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 	mut was_parallel := false
 	mut cur_file := first_file
 	mut node_idx := 0
+	// Synthetic imports appended by the per-module seeding below land after the
+	// whole wave, so the `.file` marker preceding them belongs to the last wave
+	// file, not to the module whose code triggered the seed. This map carries
+	// the triggering module's file explicitly, so module-path resolution uses
+	// the same importing-file context as the serial one-module-at-a-time loop.
+	mut synthetic_import_ctx := map[int]string{}
 	for {
 		// Collect one wave: every not-yet-parsed module imported by the nodes
 		// scanned so far. Parsing appends at the end of the node array and the
@@ -1262,6 +1286,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 		// parallel parser whole waves of files to split across threads.
 		mut wave_files := []string{}
 		mut wave_canon := []string{}
+		mut wave_module_file_ends := []int{}
 		for node_idx < a.nodes.len {
 			node := a.nodes[node_idx]
 			if node.kind == .file && node.value.len > 0 {
@@ -1286,7 +1311,12 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 				continue
 			}
 
-			importing_file := if cur_file.len > 0 { cur_file } else { first_file }
+			mut importing_file := if cur_file.len > 0 { cur_file } else { first_file }
+			if ctx_file := synthetic_import_ctx[node_idx] {
+				if ctx_file.len > 0 {
+					importing_file = ctx_file
+				}
+			}
 			mod_dir := resolve_project_or_pref_module_path_cached(prefs, mod_name, importing_file,
 				project_root, mut module_path_cache)
 			module_identity := import_module_identity_cached(prefs, mod_name, importing_file,
@@ -1316,6 +1346,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 					wave_files << mf
 					wave_canon << canon
 				}
+				wave_module_file_ends << wave_files.len
 			}
 			node_idx++
 		}
@@ -1324,15 +1355,38 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 		}
 		starts, wave_parallel := p.parse_files_dispatch(wave_files, allow_parallel)
 		was_parallel = was_parallel || wave_parallel
+		wave_end_nodes := a.nodes.len
 		for i, canon in wave_canon {
 			if canon.len == 0 {
 				continue
 			}
-			end_node := if i + 1 < starts.len { starts[i + 1] } else { a.nodes.len }
+			end_node := if i + 1 < starts.len { starts[i + 1] } else { wave_end_nodes }
 			canonicalize_imported_module_name(mut a, starts[i], end_node, canon)
 		}
-		seed_implicit_sync_import(mut a)
-		seed_implicit_embed_file_import(mut a)
+		// Re-check the implicit imports at each module boundary, in parse order,
+		// with the need scan bounded to the nodes that existed at that boundary.
+		// This fires the seeds for exactly the module the serial loop's
+		// after-every-module check would have fired them for, and records that
+		// module's last file as the synthetic import's resolution context.
+		mut module_start := 0
+		for module_file_end in wave_module_file_ends {
+			if module_file_end == module_start {
+				continue
+			}
+			region_end := if module_file_end < starts.len {
+				starts[module_file_end]
+			} else {
+				wave_end_nodes
+			}
+			ctx_file := wave_files[module_file_end - 1]
+			seed_start := a.nodes.len
+			seed_implicit_sync_import_upto(mut a, region_end)
+			seed_implicit_embed_file_import_upto(mut a, region_end)
+			for idx in seed_start .. a.nodes.len {
+				synthetic_import_ctx[idx] = ctx_file
+			}
+			module_start = module_file_end
+		}
 	}
 	return was_parallel
 }

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1141,41 +1141,51 @@ fn skipped_backend_modules(prefs &pref.Preferences) []string {
 }
 
 fn seed_implicit_sync_import(mut a flat.FlatAst) {
-	seed_implicit_sync_import_upto(mut a, a.nodes.len)
+	seed_implicit_sync_import_upto(mut a, a.nodes.len, false)
 }
 
-// seed_implicit_sync_import_upto is seed_implicit_sync_import with the need
-// scan bounded to the first end_node nodes. The import-resolution wave loop
-// re-checks after each module's parsed region, in parse order, so the seed
-// fires at the same module boundary as the serial one-module-at-a-time loop
-// did. The already-imported check deliberately scans the whole array, so a
-// synthetic import appended for an earlier module is seen and never duplicated.
-fn seed_implicit_sync_import_upto(mut a flat.FlatAst, end_node int) {
-	if !ast_needs_sync_import(a, end_node) || ast_has_import(a, 'sync') {
-		return
+// seed_implicit_sync_import_upto is seed_implicit_sync_import with the need and
+// already-imported scans both bounded to the first end_node nodes. The import-
+// resolution wave loop re-checks after each module's parsed region, in parse
+// order, so the seed fires at the same module boundary as the serial
+// one-module-at-a-time loop did. Bounding the already-imported scan to end_node
+// (the serial boundary for this module) is what keeps an explicit import in a
+// *later* module of the same wave — already parsed into the array, but not yet
+// reached in serial order — from suppressing a synthetic import that serial
+// resolution would have added first. already_added carries the "a synthetic
+// import was seeded on an earlier boundary" state the bounded scan cannot see,
+// since those synthetic nodes land past end_node at the tail of the array; it
+// keeps the seed global-once across the wave. Returns whether a node was added.
+fn seed_implicit_sync_import_upto(mut a flat.FlatAst, end_node int, already_added bool) bool {
+	if already_added || !ast_needs_sync_import(a, end_node)
+		|| ast_has_import_upto(a, 'sync', end_node) {
+		return false
 	}
 	a.add_node(flat.Node{
 		kind:  .import_decl
 		value: 'sync'
 		typ:   'sync'
 	})
+	return true
 }
 
 fn seed_implicit_embed_file_import(mut a flat.FlatAst) {
-	seed_implicit_embed_file_import_upto(mut a, a.nodes.len)
+	seed_implicit_embed_file_import_upto(mut a, a.nodes.len, false)
 }
 
-// seed_implicit_embed_file_import_upto bounds the need scan like
-// seed_implicit_sync_import_upto.
-fn seed_implicit_embed_file_import_upto(mut a flat.FlatAst, end_node int) {
-	if !ast_needs_embed_file_import(a, end_node) || ast_has_import(a, 'v.embed_file') {
-		return
+// seed_implicit_embed_file_import_upto bounds the need and already-imported
+// scans like seed_implicit_sync_import_upto.
+fn seed_implicit_embed_file_import_upto(mut a flat.FlatAst, end_node int, already_added bool) bool {
+	if already_added || !ast_needs_embed_file_import(a, end_node)
+		|| ast_has_import_upto(a, 'v.embed_file', end_node) {
+		return false
 	}
 	a.add_node(flat.Node{
 		kind:  .import_decl
 		value: 'v.embed_file'
 		typ:   'embed_file'
 	})
+	return true
 }
 
 fn ast_needs_sync_import(a &flat.FlatAst, end_node int) bool {
@@ -1229,8 +1239,14 @@ fn ast_needs_embed_file_import(a &flat.FlatAst, end_node int) bool {
 	return false
 }
 
-fn ast_has_import(a &flat.FlatAst, name string) bool {
-	for node in a.nodes {
+// ast_has_import_upto reports whether an import of name already exists among the
+// first end_node nodes. The wave seeds bound this to a module's serial boundary
+// so later modules parsed into the same wave cannot suppress an earlier module's
+// synthetic import; synthetic nodes appended past that boundary are tracked by
+// the caller's already_added flag instead.
+fn ast_has_import_upto(a &flat.FlatAst, name string, end_node int) bool {
+	for i in 0 .. end_node {
+		node := a.nodes[i]
 		if node.kind == .import_decl && node.value == name {
 			return true
 		}
@@ -1277,6 +1293,13 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 	// the triggering module's file explicitly, so module-path resolution uses
 	// the same importing-file context as the serial one-module-at-a-time loop.
 	mut synthetic_import_ctx := map[int]string{}
+	// The implicit sync/embed_file seeds are global-once: the serial loop added
+	// each at the first module that needed it and never again. These flags carry
+	// that "already seeded" state across module boundaries and waves, since a
+	// synthetic import appended for an earlier module lands past the next
+	// module's bounded already-imported scan and would otherwise be re-added.
+	mut synthetic_sync_added := false
+	mut synthetic_embed_file_added := false
 	for {
 		// Collect one wave: every not-yet-parsed module imported by the nodes
 		// scanned so far. Parsing appends at the end of the node array and the
@@ -1380,8 +1403,12 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			}
 			ctx_file := wave_files[module_file_end - 1]
 			seed_start := a.nodes.len
-			seed_implicit_sync_import_upto(mut a, region_end)
-			seed_implicit_embed_file_import_upto(mut a, region_end)
+			if seed_implicit_sync_import_upto(mut a, region_end, synthetic_sync_added) {
+				synthetic_sync_added = true
+			}
+			if seed_implicit_embed_file_import_upto(mut a, region_end, synthetic_embed_file_added) {
+				synthetic_embed_file_added = true
+			}
 			for idx in seed_start .. a.nodes.len {
 				synthetic_import_ctx[idx] = ctx_file
 			}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -441,7 +441,9 @@ fn main() {
 		builtin_defines << 'ownership'
 	}
 	files << pref.get_v_files_from_dir(builtin_dir, builtin_defines, prefs.target_os)
-	p.parse_files(files)
+	mut parse_was_parallel := false
+	_, builtin_parse_parallel := p.parse_files_dispatch(files, !no_parallel)
+	parse_was_parallel = parse_was_parallel || builtin_parse_parallel
 	mut a := p.a
 	a.user_code_start = a.nodes.len
 
@@ -460,23 +462,23 @@ fn main() {
 	} else {
 		user_files << input_file
 	}
-	for uf in user_files {
-		p.parse_into(uf)
-	}
+	_, user_parse_parallel := p.parse_files_dispatch(user_files, !no_parallel)
+	parse_was_parallel = parse_was_parallel || user_parse_parallel
 	test_files := test_input_files(user_files, backend)
 
 	seed_implicit_sync_import(mut a)
 	seed_implicit_embed_file_import(mut a)
 
 	// Resolve imports recursively
-	resolve_imports(mut a, mut p, prefs, user_files)
+	import_parse_parallel := resolve_imports(mut a, mut p, prefs, user_files, !no_parallel)
+	parse_was_parallel = parse_was_parallel || import_parse_parallel
 	diagnostic_root := if is_selfhost {
 		diagnostic_root_for_input(input_file, user_files)
 	} else {
 		''
 	}
 
-	b.step('parse')
+	b.step_parallel('parse', parse_was_parallel)
 
 	// Type-collect + check BEFORE transform, so the transformer is type-aware
 	// (like v2: check runs before transform). The transformer reads cached
@@ -1223,7 +1225,7 @@ fn type_text_is_shared(raw string) bool {
 }
 
 // resolve_imports resolves resolve imports information for v3 entry point.
-fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferences, initial_files []string) {
+fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferences, initial_files []string, allow_parallel bool) bool {
 	mut parsed_modules := map[string]bool{}
 	parsed_modules['builtin'] = true
 	parsed_modules['main'] = true
@@ -1248,69 +1250,91 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 	mut module_path_cache := map[string]string{}
 	mut module_identity_cache := map[string]string{}
 
+	mut was_parallel := false
 	mut cur_file := first_file
 	mut node_idx := 0
-	for node_idx < a.nodes.len {
-		node := a.nodes[node_idx]
-		if node.kind == .file && node.value.len > 0 {
-			cur_file = node.value
-			node_idx++
-			continue
-		}
-		if node.kind != .import_decl {
-			node_idx++
-			continue
-		}
-		mod_name := node.value
-		if module_identity := parsed_module_identities[mod_name] {
+	for {
+		// Collect one wave: every not-yet-parsed module imported by the nodes
+		// scanned so far. Parsing appends at the end of the node array and the
+		// scan proceeds in node order, so batching a wave and appending its
+		// modules in discovery order reproduces the breadth-first module layout
+		// the previous parse-one-module-inline loop produced — while giving the
+		// parallel parser whole waves of files to split across threads.
+		mut wave_files := []string{}
+		mut wave_canon := []string{}
+		for node_idx < a.nodes.len {
+			node := a.nodes[node_idx]
+			if node.kind == .file && node.value.len > 0 {
+				cur_file = node.value
+				node_idx++
+				continue
+			}
+			if node.kind != .import_decl {
+				node_idx++
+				continue
+			}
+			mod_name := node.value
+			if module_identity := parsed_module_identities[mod_name] {
+				if module_identity.len > 0 {
+					a.nodes[node_idx].value = module_identity
+				}
+				node_idx++
+				continue
+			}
+			if mod_name in parsed_modules {
+				node_idx++
+				continue
+			}
+
+			importing_file := if cur_file.len > 0 { cur_file } else { first_file }
+			mod_dir := resolve_project_or_pref_module_path_cached(prefs, mod_name, importing_file,
+				project_root, mut module_path_cache)
+			module_identity := import_module_identity_cached(prefs, mod_name, importing_file,
+				project_root, mod_dir, mut module_path_cache, mut module_identity_cache)
 			if module_identity.len > 0 {
 				a.nodes[node_idx].value = module_identity
 			}
-			node_idx++
-			continue
-		}
-		if mod_name in parsed_modules {
-			node_idx++
-			continue
-		}
+			mod_dir_exists := mod_dir.len > 0 && os.is_dir(mod_dir)
+			if mod_name in parsed_modules || (mod_dir_exists && module_identity in parsed_modules) {
+				node_idx++
+				continue
+			}
+			parsed_modules[mod_name] = true
+			if mod_dir_exists && module_identity.len > 0 {
+				parsed_modules[module_identity] = true
+			}
+			parsed_module_identities[mod_name] = if module_identity.len > 0 {
+				module_identity
+			} else {
+				mod_name
+			}
 
-		importing_file := if cur_file.len > 0 { cur_file } else { first_file }
-		mod_dir := resolve_project_or_pref_module_path_cached(prefs, mod_name, importing_file,
-			project_root, mut module_path_cache)
-		module_identity := import_module_identity_cached(prefs, mod_name, importing_file,
-			project_root, mod_dir, mut module_path_cache, mut module_identity_cache)
-		if module_identity.len > 0 {
-			a.nodes[node_idx].value = module_identity
-		}
-		mod_dir_exists := mod_dir.len > 0 && os.is_dir(mod_dir)
-		if mod_name in parsed_modules || (mod_dir_exists && module_identity in parsed_modules) {
-			node_idx++
-			continue
-		}
-		parsed_modules[mod_name] = true
-		if mod_dir_exists && module_identity.len > 0 {
-			parsed_modules[module_identity] = true
-		}
-		parsed_module_identities[mod_name] = if module_identity.len > 0 {
-			module_identity
-		} else {
-			mod_name
-		}
-
-		if mod_dir_exists {
-			mod_files := pref.get_v_files_from_dir(mod_dir, prefs.user_defines, prefs.target_os)
-			for mf in mod_files {
-				first_node := a.nodes.len
-				p.parse_into(mf)
-				if module_identity == mod_name {
-					canonicalize_imported_module_name(mut a, first_node, mod_name)
+			if mod_dir_exists {
+				mod_files := pref.get_v_files_from_dir(mod_dir, prefs.user_defines, prefs.target_os)
+				canon := if module_identity == mod_name { mod_name } else { '' }
+				for mf in mod_files {
+					wave_files << mf
+					wave_canon << canon
 				}
 			}
-			seed_implicit_sync_import(mut a)
-			seed_implicit_embed_file_import(mut a)
+			node_idx++
 		}
-		node_idx++
+		if wave_files.len == 0 {
+			break
+		}
+		starts, wave_parallel := p.parse_files_dispatch(wave_files, allow_parallel)
+		was_parallel = was_parallel || wave_parallel
+		for i, canon in wave_canon {
+			if canon.len == 0 {
+				continue
+			}
+			end_node := if i + 1 < starts.len { starts[i + 1] } else { a.nodes.len }
+			canonicalize_imported_module_name(mut a, starts[i], end_node, canon)
+		}
+		seed_implicit_sync_import(mut a)
+		seed_implicit_embed_file_import(mut a)
 	}
+	return was_parallel
 }
 
 fn seed_initial_modules(a &flat.FlatAst, initial_files []string, mut parsed_modules map[string]bool) {
@@ -1333,12 +1357,12 @@ fn seed_initial_modules(a &flat.FlatAst, initial_files []string, mut parsed_modu
 	}
 }
 
-fn canonicalize_imported_module_name(mut a flat.FlatAst, first_node int, import_path string) {
+fn canonicalize_imported_module_name(mut a flat.FlatAst, first_node int, end_node int, import_path string) {
 	if import_path.len == 0 {
 		return
 	}
 	short_name := import_path.all_after_last('.')
-	for i in first_node .. a.nodes.len {
+	for i in first_node .. end_node {
 		if a.nodes[i].kind == .module_decl && a.nodes[i].value == short_name {
 			a.nodes[i].value = import_path
 		}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1141,51 +1141,52 @@ fn skipped_backend_modules(prefs &pref.Preferences) []string {
 }
 
 fn seed_implicit_sync_import(mut a flat.FlatAst) {
-	seed_implicit_sync_import_upto(mut a, a.nodes.len, false)
-}
-
-// seed_implicit_sync_import_upto is seed_implicit_sync_import with the need and
-// already-imported scans both bounded to the first end_node nodes. The import-
-// resolution wave loop re-checks after each module's parsed region, in parse
-// order, so the seed fires at the same module boundary as the serial
-// one-module-at-a-time loop did. Bounding the already-imported scan to end_node
-// (the serial boundary for this module) is what keeps an explicit import in a
-// *later* module of the same wave — already parsed into the array, but not yet
-// reached in serial order — from suppressing a synthetic import that serial
-// resolution would have added first. already_added carries the "a synthetic
-// import was seeded on an earlier boundary" state the bounded scan cannot see,
-// since those synthetic nodes land past end_node at the tail of the array; it
-// keeps the seed global-once across the wave. Returns whether a node was added.
-fn seed_implicit_sync_import_upto(mut a flat.FlatAst, end_node int, already_added bool) bool {
-	if already_added || !ast_needs_sync_import(a, end_node)
-		|| ast_has_import_upto(a, 'sync', end_node) {
-		return false
+	if ast_should_seed_sync_import(a, a.nodes.len, false) {
+		a.add_node(sync_import_node())
 	}
-	a.add_node(flat.Node{
-		kind:  .import_decl
-		value: 'sync'
-		typ:   'sync'
-	})
-	return true
 }
 
 fn seed_implicit_embed_file_import(mut a flat.FlatAst) {
-	seed_implicit_embed_file_import_upto(mut a, a.nodes.len, false)
+	if ast_should_seed_embed_file_import(a, a.nodes.len, false) {
+		a.add_node(embed_file_import_node())
+	}
 }
 
-// seed_implicit_embed_file_import_upto bounds the need and already-imported
-// scans like seed_implicit_sync_import_upto.
-fn seed_implicit_embed_file_import_upto(mut a flat.FlatAst, end_node int, already_added bool) bool {
-	if already_added || !ast_needs_embed_file_import(a, end_node)
-		|| ast_has_import_upto(a, 'v.embed_file', end_node) {
-		return false
+// ast_should_seed_sync_import reports whether a synthetic `import sync` should be
+// seeded for the module whose parsed region ends at end_node. The need and
+// already-imported scans are both bounded to end_node — the module's serial
+// boundary — so an explicit import in a *later* module of the same wave (already
+// parsed into the array, but not yet reached in serial order) can neither suppress
+// nor be conflated with this module's seed. already_added carries the "a synthetic
+// import was already seeded for an earlier module in this wave" state the bounded
+// scan cannot see, because the wave's synthetic nodes are spliced in only after
+// every boundary has been checked; it keeps the seed global-once.
+fn ast_should_seed_sync_import(a &flat.FlatAst, end_node int, already_added bool) bool {
+	return !already_added && ast_needs_sync_import(a, end_node)
+		&& !ast_has_import_upto(a, 'sync', end_node)
+}
+
+// ast_should_seed_embed_file_import bounds its scans like
+// ast_should_seed_sync_import.
+fn ast_should_seed_embed_file_import(a &flat.FlatAst, end_node int, already_added bool) bool {
+	return !already_added && ast_needs_embed_file_import(a, end_node)
+		&& !ast_has_import_upto(a, 'v.embed_file', end_node)
+}
+
+fn sync_import_node() flat.Node {
+	return flat.Node{
+		kind:  .import_decl
+		value: 'sync'
+		typ:   'sync'
 	}
-	a.add_node(flat.Node{
+}
+
+fn embed_file_import_node() flat.Node {
+	return flat.Node{
 		kind:  .import_decl
 		value: 'v.embed_file'
 		typ:   'embed_file'
-	})
-	return true
+	}
 }
 
 fn ast_needs_sync_import(a &flat.FlatAst, end_node int) bool {
@@ -1258,6 +1259,67 @@ fn type_text_is_shared(raw string) bool {
 	return raw.trim_space().starts_with('shared ')
 }
 
+// SyntheticInsertion records a childless synthetic import node to splice into the
+// flat AST before an original-array node index.
+struct SyntheticInsertion {
+	pos  int // original (pre-insertion) node index to insert before
+	node flat.Node
+}
+
+// insert_synthetic_imports rebuilds a.nodes with each synthetic import spliced in
+// before its recorded original-array position, so the next resolver pass scans a
+// module's synthetic import right after that module's own region — in the same
+// order serial one-module-at-a-time resolution appended and scanned it, before
+// the later wave modules were parsed. Every absolute node index is remapped to
+// the shifted layout: an original index j moves right by the number of insertions
+// at positions <= j. The synthetic nodes are childless, so a.children keeps its
+// length and only its stored NodeIds shift. insertions must be sorted ascending
+// by pos (equal positions keep insertion order); the boundary loop produces them
+// in strictly increasing region order.
+fn insert_synthetic_imports(mut a flat.FlatAst, insertions []SyntheticInsertion) {
+	if insertions.len == 0 {
+		return
+	}
+	old_len := a.nodes.len
+	mut new_nodes := []flat.Node{cap: old_len + insertions.len}
+	mut ins_idx := 0
+	for i in 0 .. old_len {
+		for ins_idx < insertions.len && insertions[ins_idx].pos == i {
+			new_nodes << insertions[ins_idx].node
+			ins_idx++
+		}
+		new_nodes << a.nodes[i]
+	}
+	// Insertions at pos == old_len append at the very end (the last wave module's
+	// region ends at the array tail).
+	for ins_idx < insertions.len {
+		new_nodes << insertions[ins_idx].node
+		ins_idx++
+	}
+	a.nodes = new_nodes
+	for k in 0 .. a.children.len {
+		cid := int(a.children[k])
+		if cid >= 0 {
+			a.children[k] = flat.NodeId(cid + synthetic_index_shift(insertions, cid))
+		}
+	}
+	a.user_code_start += synthetic_index_shift(insertions, a.user_code_start)
+}
+
+// synthetic_index_shift returns how far an original node index moves after the
+// insertions: the count of insertions whose position is at or before it.
+fn synthetic_index_shift(insertions []SyntheticInsertion, idx int) int {
+	mut shift := 0
+	for ins in insertions {
+		if ins.pos <= idx {
+			shift++
+		} else {
+			break
+		}
+	}
+	return shift
+}
+
 // resolve_imports resolves resolve imports information for v3 entry point.
 fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferences, initial_files []string, allow_parallel bool) bool {
 	mut parsed_modules := map[string]bool{}
@@ -1287,17 +1349,12 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 	mut was_parallel := false
 	mut cur_file := first_file
 	mut node_idx := 0
-	// Synthetic imports appended by the per-module seeding below land after the
-	// whole wave, so the `.file` marker preceding them belongs to the last wave
-	// file, not to the module whose code triggered the seed. This map carries
-	// the triggering module's file explicitly, so module-path resolution uses
-	// the same importing-file context as the serial one-module-at-a-time loop.
-	mut synthetic_import_ctx := map[int]string{}
 	// The implicit sync/embed_file seeds are global-once: the serial loop added
 	// each at the first module that needed it and never again. These flags carry
-	// that "already seeded" state across module boundaries and waves, since a
-	// synthetic import appended for an earlier module lands past the next
-	// module's bounded already-imported scan and would otherwise be re-added.
+	// that "already seeded" state across module boundaries and waves. Within a
+	// wave the synthetic nodes are only spliced in after every boundary has been
+	// checked, so a later module's bounded already-imported scan cannot yet see an
+	// earlier module's pending seed; the flags stand in for it.
 	mut synthetic_sync_added := false
 	mut synthetic_embed_file_added := false
 	for {
@@ -1334,12 +1391,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 				continue
 			}
 
-			mut importing_file := if cur_file.len > 0 { cur_file } else { first_file }
-			if ctx_file := synthetic_import_ctx[node_idx] {
-				if ctx_file.len > 0 {
-					importing_file = ctx_file
-				}
-			}
+			importing_file := if cur_file.len > 0 { cur_file } else { first_file }
 			mod_dir := resolve_project_or_pref_module_path_cached(prefs, mod_name, importing_file,
 				project_root, mut module_path_cache)
 			module_identity := import_module_identity_cached(prefs, mod_name, importing_file,
@@ -1387,10 +1439,15 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			canonicalize_imported_module_name(mut a, starts[i], end_node, canon)
 		}
 		// Re-check the implicit imports at each module boundary, in parse order,
-		// with the need scan bounded to the nodes that existed at that boundary.
-		// This fires the seeds for exactly the module the serial loop's
-		// after-every-module check would have fired them for, and records that
-		// module's last file as the synthetic import's resolution context.
+		// with each scan bounded to the nodes that existed at that boundary. This
+		// fires the seeds for exactly the module the serial loop's after-every-
+		// module check would have fired them for. The synthetic nodes are then
+		// spliced in right after their triggering module's region (region_end),
+		// not at the wave tail, so the next pass scans an earlier module's
+		// synthetic import before the later wave modules' imports — matching serial
+		// order — and the `.file` marker preceding each synthetic is its own
+		// module's last file, so module-path resolution uses the right context.
+		mut insertions := []SyntheticInsertion{}
 		mut module_start := 0
 		for module_file_end in wave_module_file_ends {
 			if module_file_end == module_start {
@@ -1401,19 +1458,23 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			} else {
 				wave_end_nodes
 			}
-			ctx_file := wave_files[module_file_end - 1]
-			seed_start := a.nodes.len
-			if seed_implicit_sync_import_upto(mut a, region_end, synthetic_sync_added) {
+			if ast_should_seed_sync_import(a, region_end, synthetic_sync_added) {
+				insertions << SyntheticInsertion{
+					pos:  region_end
+					node: sync_import_node()
+				}
 				synthetic_sync_added = true
 			}
-			if seed_implicit_embed_file_import_upto(mut a, region_end, synthetic_embed_file_added) {
+			if ast_should_seed_embed_file_import(a, region_end, synthetic_embed_file_added) {
+				insertions << SyntheticInsertion{
+					pos:  region_end
+					node: embed_file_import_node()
+				}
 				synthetic_embed_file_added = true
-			}
-			for idx in seed_start .. a.nodes.len {
-				synthetic_import_ctx[idx] = ctx_file
 			}
 			module_start = module_file_end
 		}
+		insert_synthetic_imports(mut a, insertions)
 	}
 	return was_parallel
 }


### PR DESCRIPTION
Makes the v3 parse phase run across worker threads, gated exactly like the parallel transformer and cgen: on by default, compiled out with `-d v3_no_parallel`, disabled at runtime with `--no-parallel` (Windows always falls back to serial, like the other phases).

### Design

- The input file list is split into contiguous, size-balanced chunks (by source bytes). Each worker parses its chunk into a private `Parser` + `FlatAst` on its own pthread (64 MB stacks); the master parses chunk 0 directly into `p.a` while the helpers run, then joins and merges workers in input order, shifting child node ids and `children_start` offsets by the merge position.
- A file's nodes never reference another file's nodes and chunks are contiguous slices merged in input order, so the merged nodes/children arrays are **byte-identical to a serial parse** — downstream phases see the same AST either way. No AST clones are needed (unlike the transform workers), so the only extra memory is the workers' own parse output.
- `@[export]` registrations are replayed through per-worker records and revalidated against `disabled_fns` accumulated from earlier chunks, reproducing the serial parse's order-dependent check; `disabled_fns`/`noreturn_fns` are unioned in chunk order.
- `resolve_imports` now collects breadth-first waves of newly discovered modules and parses each wave through the dispatcher instead of parsing one module inline at a time. The old loop also appended modules at the end of the node array in discovery order, so the layout is unchanged — verified by identical generated C vs an unmodified build with both running serially.

### Verification

- New `vlib/v3/tests/parallel_parser_test.v`: asserts the threaded parse produces a node-for-node, child-for-child identical flat AST (plus identical side tables and per-file region starts) vs serial; end-to-end multi-module compile reporting `parse (parallel)`; `--no-parallel` opt-out stays serial.
- Self-host fixpoint holds with parallel parse active at every stage (v3 → v4 → v5 → v6, `v5.c == v6.c`), for both dev and `-prod` builds; output is run-to-run deterministic at fixed `VJOBS`.
- A `--no-parallel -building-v` self-host build contains zero parser thread symbols in the generated C; a `-d v3_no_parallel` build of v3 works and reports the phase as serial.
- Full `vlib/v3/tests/` suite: 112/117 pass; the 5 failures reproduce with identical failing subtests on unmodified master (pre-existing, unrelated).

### Performance (self-hosting v3 with `-prod`, Apple Silicon)

```
before:  parse                  123.34 ms      total 845.08 ms
after:   parse (parallel)        49.51 ms      total 770.13 ms
```

Post-parse RSS goes from ~147 MB to ~185 MB under `-gc none` (worker arrays are never freed) — the same tradeoff the parallel transform makes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)