### PR TITLE
checker,gen: fix generic type inference from a callback with Result return type

### DIFF
--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1819,7 +1819,11 @@ fn (mut c Checker) infer_fn_generic_types(func &ast.Fn, mut node ast.CallExpr) {
 						}
 						if param_sym.info.func.return_type.has_flag(.generic)
 							&& c.table.sym(param_sym.info.func.return_type).name == gt_name {
-							typ = arg_sym.info.func.return_type.clear_option_and_result()
+							typ = if param_sym.info.func.return_type.has_option_or_result() {
+								arg_sym.info.func.return_type.clear_option_and_result()
+							} else {
+								arg_sym.info.func.return_type
+							}
 							if param_sym.info.func.return_type.nr_muls() > 0 && typ.nr_muls() > 0 {
 								typ = typ.set_nr_muls(0)
 							}

--- a/vlib/v/checker/check_types.v
+++ b/vlib/v/checker/check_types.v
@@ -1819,7 +1819,7 @@ fn (mut c Checker) infer_fn_generic_types(func &ast.Fn, mut node ast.CallExpr) {
 						}
 						if param_sym.info.func.return_type.has_flag(.generic)
 							&& c.table.sym(param_sym.info.func.return_type).name == gt_name {
-							typ = arg_sym.info.func.return_type
+							typ = arg_sym.info.func.return_type.clear_option_and_result()
 							if param_sym.info.func.return_type.nr_muls() > 0 && typ.nr_muls() > 0 {
 								typ = typ.set_nr_muls(0)
 							}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -3890,7 +3890,11 @@ fn (mut g Gen) update_generic_call_concrete_types_from_fn_types(generic_names []
 	}
 	if param_fn.func.return_type.has_flag(.generic) {
 		gt_name := g.table.sym(param_fn.func.return_type).name
-		mut return_type := arg_fn.func.return_type.clear_option_and_result()
+		mut return_type := if param_fn.func.return_type.has_option_or_result() {
+			arg_fn.func.return_type.clear_option_and_result()
+		} else {
+			arg_fn.func.return_type
+		}
 		if arg.expr is ast.LambdaExpr && return_type.has_flag(.generic) {
 			return_type = g.type_resolver.unwrap_generic_expr(arg.expr.expr, return_type)
 			if return_type.has_flag(.generic) {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -3890,7 +3890,7 @@ fn (mut g Gen) update_generic_call_concrete_types_from_fn_types(generic_names []
 	}
 	if param_fn.func.return_type.has_flag(.generic) {
 		gt_name := g.table.sym(param_fn.func.return_type).name
-		mut return_type := arg_fn.func.return_type
+		mut return_type := arg_fn.func.return_type.clear_option_and_result()
 		if arg.expr is ast.LambdaExpr && return_type.has_flag(.generic) {
 			return_type = g.type_resolver.unwrap_generic_expr(arg.expr.expr, return_type)
 			if return_type.has_flag(.generic) {

--- a/vlib/v/tests/generics/generic_fn_callback_result_return_test.v
+++ b/vlib/v/tests/generics/generic_fn_callback_result_return_test.v
@@ -1,13 +1,83 @@
-fn run[T](cb fn () !T) !T {
+fn get_int() int {
+	return 42
+}
+
+fn get_option() ?int {
+	return 42
+}
+
+fn get_result() !int {
+	return 42
+}
+
+fn run_identity[T](cb fn () T) T {
+	return cb()
+}
+
+fn run_option_ret[T](cb fn () T) ?T {
+	mut r := T{}
+	r = cb()
+	return r
+}
+
+fn run_result_ret[T](cb fn () T) !T {
+	mut r := T{}
+	r = cb()
+	return r
+}
+
+fn run_option_cb_option_ret[T](cb fn () ?T) ?T {
+	mut r := T{}
+	r = cb()?
+	return r
+}
+
+fn run_result_cb_option_ret[T](cb fn () !T) ?T {
+	mut r := T{}
+	r = cb() or { panic(err) }
+	return r
+}
+
+fn run_result_cb_result_ret[T](cb fn () !T) !T {
 	mut r := T{}
 	r = cb()!
 	return r
 }
 
-fn test_generic_fn_callback_result_return() {
-	cb := fn () !int {
-		return 42
-	}
+fn test_generic_fn_plain_callback_return_infers_plain_type() {
+	assert run_identity(get_int) == 42
+}
 
-	assert run(cb)! == 42
+fn test_generic_fn_plain_callback_return_infers_option_type() {
+	result := run_identity(get_option)
+	assert result? == 42
+}
+
+fn test_generic_fn_option_callback_return_infers_plain_type() {
+	result := run_option_ret(get_int)
+	assert result? == 42
+}
+
+// TODO: uncomment when issue is fixed (cf. #27876)
+// fn test_generic_fn_option_callback_return_infers_option_type() {
+// 	result := run_option_ret(get_option)
+// 	assert result? == 42
+// }
+
+fn test_generic_fn_result_callback_result_return() {
+	assert run_result_ret(get_int)! == 42
+}
+
+fn test_generic_fn_option_callback_option_return() {
+	result := run_option_cb_option_ret(get_option)
+	assert result? == 42
+}
+
+fn test_generic_fn_result_callback_option_return() {
+	result := run_result_cb_option_ret(get_result)
+	assert result? == 42
+}
+
+fn test_generic_fn_callback_result_return() {
+	assert run_result_cb_result_ret(get_result)! == 42
 }

--- a/vlib/v/tests/generics/generic_fn_callback_result_return_test.v
+++ b/vlib/v/tests/generics/generic_fn_callback_result_return_test.v
@@ -1,0 +1,13 @@
+fn run[T](cb fn () !T) !T {
+	mut r := T{}
+	r = cb()!
+	return r
+}
+
+fn test_generic_fn_callback_result_return() {
+	cb := fn () !int {
+		return 42
+	}
+
+	assert run(cb)! == 42
+}


### PR DESCRIPTION
# Fixes #27108

## Problem

```v
fn run[T](cb fn () !T) !T {
	mut r := T{}
	r = cb()!
	return r
}

fn main() {
	cb := fn () !int {
		return -1
	}
	run(cb)!
}
```

fails with a C compilation error:

```c
error: initializing '_result_int' (aka 'struct _result_int') with an expression of incompatible type 'int'
```

The issue is specific to the combination of: a generic parameter that is itself a callback (`fn () !T`), where the callback's *return type* carries the generic marker inside a Result (`!T`).
> A generic function with a plain (non-callback) parameter and a `!T` return already works fine.
> A callback parameter with a plain (non-Result) return already works fine too.

Note: the wrong inference happens unconditionally whenever a generic function takes a callback parameter typed `fn () !T` — it isn't specific to using `T{}` in the body. It only surfaces as a visible compile error when the body does something that needs T's plain (unwrapped) C representation, like zero-initializing `T{}`; without that, the mismatch can go unnoticed since the code still happens to work despite T being wrong internally.

## Cause

V infers `T` here by structurally comparing the parameter's function type against the argument's actual function type. Two separate places do this comparison (once in the checker, once in a duplicate implementation in cgen), and in both, the branch that extracts the concrete type from the return position took the argument's return type as-is, without stripping its `.result` flag first. So for a closure returning `!int`, `T` got inferred as `!int` (the Result-wrapped type) instead of `int`. This produced two inconsistent monomorphized versions of the generic function — one correctly named/typed for `T=int`, and a second, wrongly named for `T=!int`, which is the one actually invoked at the call site, leading to invalid C.

## Fix

Strip the option/result flags before binding the inferred type, in both places, using the existing `clear_option_and_result()` helper (already used a few lines above for the analogous case where the parameter itself, rather than just its return type, is Result-wrapped).

## Test

Regression test added.

_NB: credits to Claude_