### PR TITLE
cgen: fix inlined tmpl scope type reuse

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7786,11 +7786,18 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		}
 	}
 
+	mut selector_expr_expr := node.expr
 	mut selector_scope := node.scope
-	if g.file.scope != unsafe { nil } {
+	if selector_expr_expr is ast.Ident {
+		selector_ident := selector_expr_expr as ast.Ident
+		if (selector_scope == unsafe { nil }
+			|| selector_scope.find_var(selector_ident.name) == none)
+			&& g.file.scope != unsafe { nil } {
+			selector_scope = g.file.scope.innermost(node.pos.pos)
+		}
+	} else if selector_scope == unsafe { nil } && g.file.scope != unsafe { nil } {
 		selector_scope = g.file.scope.innermost(node.pos.pos)
 	}
-	mut selector_expr_expr := node.expr
 	// Sumtype smartcast idents dereference the variant pointer eagerly, so the
 	// selector receiver is already a value. Interface smartcasts are more
 	// context-sensitive and may still emit a pointer while inside selector codegen.

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -416,7 +416,9 @@ fn (mut g Gen) comptime_call(mut node ast.ComptimeCall) {
 						g.veb_filter_fn_name = 'veb__filter'
 					}
 					// insert stmts from veb_tmpl fn
+					g.clear_type_resolution_caches()
 					g.stmts(stmt.stmts.filter(it !is ast.Return))
+					g.clear_type_resolution_caches()
 					//
 					if is_html {
 						g.inside_veb_tmpl = prev_inside_veb_tmpl

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -675,7 +675,10 @@ fn (mut g Gen) resolved_scope_var_type(expr ast.Ident) ast.Type {
 	if g.has_active_call_generic_context() {
 		return g.resolved_scope_var_type_uncached(expr)
 	}
-	cache_key := g.expr_resolution_cache_key(expr.pos.pos, 0, cgen_scope_var_type_cache_salt)
+	mut cache_key := g.expr_resolution_cache_key(expr.pos.pos, 0, cgen_scope_var_type_cache_salt)
+	if cache_key != 0 {
+		cache_key = cgen_resolution_hash_mix(cache_key, fnv1a.sum64_string(expr.name))
+	}
 	if cache_key != 0 {
 		if cached := g.resolved_scope_var_type_cache[cache_key] {
 			return cached

--- a/vlib/v/tests/tmpl/template_scope_27685.html
+++ b/vlib/v/tests/tmpl/template_scope_27685.html
@@ -1,0 +1,10 @@
+@if project.credits.len > 0
+@if project.credits[1] != ""
+credit link @{project.credits[1]}
+@else
+credit @{project.credits[0]} (@{project.credits[2]})
+@end
+@end
+@if project.videos.len > 0
+video @{project.videos[0]}
+@end

--- a/vlib/v/tests/tmpl_issue_27685_test.v
+++ b/vlib/v/tests/tmpl_issue_27685_test.v
@@ -1,0 +1,71 @@
+struct Issue27685Project {
+	credits []string
+	videos  []string
+}
+
+fn issue_27685_shadow_scope_for_template_positions() {
+	project := &Issue27685Project{}
+	_ := project
+	// Keep this source scope long enough to overlap with the generated positions
+	// of the template below. Old cgen used file positions for inlined template
+	// selectors, so `project.credits` could resolve through this pointer variable.
+	// 01
+	// 02
+	// 03
+	// 04
+	// 05
+	// 06
+	// 07
+	// 08
+	// 09
+	// 10
+	// 11
+	// 12
+	// 13
+	// 14
+	// 15
+	// 16
+	// 17
+	// 18
+	// 19
+	// 20
+	// 21
+	// 22
+	// 23
+	// 24
+	// 25
+	// 26
+	// 27
+	// 28
+	// 29
+	// 30
+	// 31
+	// 32
+	// 33
+	// 34
+	// 35
+	// 36
+	// 37
+	// 38
+	// 39
+	// 40
+}
+
+fn issue_27685_render_project() string {
+	projects := [
+		Issue27685Project{
+			credits: ['Alice', '', 'Dev']
+			videos:  ['Trailer', 'https://example.com']
+		},
+	]
+	mut rendered := ''
+	for project in projects {
+		rendered = $tmpl('tmpl/template_scope_27685.html')
+	}
+	return rendered.trim_space()
+}
+
+fn test_tmpl_issue_27685_uses_template_scope_for_inherited_selectors() {
+	assert issue_27685_render_project() == 'credit Alice (Dev)
+video Trailer'
+}


### PR DESCRIPTION
Fixes #27685.

This prevents inlined `$tmpl` files from reusing stale type-resolution state from other template/source positions, and keeps selector receiver lookup in the template scope when available.

Validation:
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew vlib/v/tests/tmpl_issue_27685_test.v`
- `./vnew vlib/v/tests/tmpl_test.v`
- `/Users/alexander/code/v4/vnew -d deploy .` in a clone of `ratkingsminion/v-fholio.de`
- `./vnew -silent vlib/v/compiler_errors_test.v`

Additional attempted validation:
- `./vnew -silent vlib/v/gen/c/coutput_test.v` failed on pre-existing untracked fixture `vlib/v/gen/c/testdata/comp_if_unknown.*`.
- `./vnew -silent test vlib/v/` was stopped after unrelated dirty-checkout failures in `vlib/v/doc/doc_private_fn_test.v`, `vlib/v/fmt/fmt_test.v`, `vlib/v/gen/native/blacklist_test.v`, and wasm tests involving untracked wasm builtin files.