### PR TITLE
v3: fix ownership-mode regressions

### DIFF
--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -268,7 +268,7 @@ fn launch_v3_ownership_compiler(is_verbose bool, args []string) {
 		println('Launching ${tool_name}: ${os.quoted_path(v3_exe)} ${quoted_args}')
 	}
 	os.setenv('VCHILD', 'true', true)
-	os.setenv('VEXE', os.real_path(v3_exe), true)
+	os.setenv('VEXE', os.real_path(vexe), true)
 	res := os.system('${os.quoted_path(v3_exe)} ${quoted_args}')
 	exit(res)
 }

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -8535,7 +8535,7 @@ fn (mut g FlatGen) fn_ptr_typedef_type(typ string, mut emitted map[string]bool) 
 	if tagged := fn_ptr_typedef_generic_placeholder_struct_tag(clean) {
 		return tagged
 	}
-	if fn_ptr_typedef_is_generic_placeholder(clean) {
+	if g.fn_ptr_typedef_is_generic_placeholder(clean) {
 		return 'int'
 	}
 	return clean
@@ -8553,13 +8553,17 @@ fn fn_ptr_typedef_normalized(typ string) string {
 	return 'fn_ptr:${payload}|void'
 }
 
-fn fn_ptr_typedef_is_generic_placeholder(typ string) bool {
+fn (g &FlatGen) fn_ptr_typedef_is_generic_placeholder(typ string) bool {
 	mut clean := trimmed_space(typ)
 	for clean.ends_with('*') {
 		clean = clean[..clean.len - 1].trim_space()
 	}
 	if clean.starts_with('struct ') {
 		clean = clean['struct '.len..].trim_space()
+	}
+	if g.type_name_known(clean)
+		|| (clean.contains('__') && g.type_name_known(clean.replace('__', '.'))) {
+		return false
 	}
 	short := if clean.contains('__') {
 		clean.all_after_last('__')
@@ -8568,15 +8572,13 @@ fn fn_ptr_typedef_is_generic_placeholder(typ string) bool {
 	} else {
 		clean
 	}
-	for part in short.split('_') {
-		if part in ['T', 'U', 'V', 'K', 'R'] {
-			return true
-		}
-		if part.len == 1 && part[0] >= `A` && part[0] <= `Z` {
-			return true
-		}
+	if !codegen_generic_placeholder_name(short) {
+		return false
 	}
-	return false
+	if g.type_name_known(short) {
+		return false
+	}
+	return true
 }
 
 fn fn_ptr_typedef_generic_placeholder_struct_tag(typ string) ?string {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1192,6 +1192,14 @@ fn generic_receiver_type_arg_short(type_arg string) string {
 	if clean.contains('(') || clean.contains(' ') {
 		return sanitize_generic_receiver_type_fragment(clean)
 	}
+	base, args, ok := shared_generic_app_parts(clean)
+	if ok {
+		mut parts := [generic_receiver_type_arg_short(base)]
+		for arg in args {
+			parts << generic_receiver_type_arg_short(arg)
+		}
+		return parts.join('_')
+	}
 	if clean.contains('.') {
 		return clean.all_after_last('.')
 	}
@@ -5161,6 +5169,18 @@ fn (mut g FlatGen) param_types_for(name string, fallback string) []types.Type {
 }
 
 fn (mut g FlatGen) param_types_for_uncached(name string, fallback string) []types.Type {
+	if name.contains('__') {
+		dotted_name := name.replace('__', '.')
+		dotted_decl_types := g.param_types_from_decl(dotted_name, dotted_name)
+		for candidate in [dotted_name, dotted_name.all_after_last('.')] {
+			if params := g.tc.fn_param_types[candidate] {
+				return merge_decl_pointer_param_abi(params, dotted_decl_types)
+			}
+		}
+		if dotted_decl_types.len > 0 {
+			return dotted_decl_types
+		}
+	}
 	decl_types := g.param_types_from_decl(name, fallback)
 	for candidate in [name, fallback] {
 		if params := g.tc.fn_param_types[candidate] {
@@ -5173,6 +5193,9 @@ fn (mut g FlatGen) param_types_for_uncached(name string, fallback string) []type
 			}
 		}
 	}
+	if decl_types.len > 0 {
+		return decl_types
+	}
 	if name.contains('__') {
 		short_name := name.all_after_last('__')
 		if params := g.param_types_by_short[short_name] {
@@ -5184,9 +5207,6 @@ fn (mut g FlatGen) param_types_for_uncached(name string, fallback string) []type
 	}
 	if interface_types := g.interface_method_param_types(name) {
 		return interface_types
-	}
-	if decl_types.len > 0 {
-		return decl_types
 	}
 	if name.contains('.') {
 		// O(1) lookup via the precomputed short-name index instead of scanning the whole
@@ -5210,7 +5230,10 @@ fn merge_decl_pointer_param_abi(params []types.Type, decl_types []types.Type) []
 	mut merged := params.clone()
 	mut changed := false
 	for i, decl_type in decl_types {
-		if decl_type is types.Pointer && merged[i] !is types.Pointer {
+		if decl_type is types.Unknown || decl_type is types.Void {
+			continue
+		}
+		if decl_type.name() != merged[i].name() {
 			merged[i] = decl_type
 			changed = true
 		}
@@ -7177,7 +7200,8 @@ fn (g &FlatGen) addressed_byvalue_arg(arg_node flat.Node) ?flat.NodeId {
 	}
 	child_id := g.a.child(&arg_node, 0)
 	child := g.a.nodes[int(child_id)]
-	if child.kind in [.struct_init, .cast_expr] {
+	if child.kind in [.struct_init, .cast_expr, .call]
+		|| (child.kind == .index && child.value == 'range') {
 		return child_id
 	}
 	return none
@@ -8544,10 +8568,15 @@ fn fn_ptr_typedef_is_generic_placeholder(typ string) bool {
 	} else {
 		clean
 	}
-	if short in ['T', 'U', 'V', 'K', 'R'] {
-		return true
+	for part in short.split('_') {
+		if part in ['T', 'U', 'V', 'K', 'R'] {
+			return true
+		}
+		if part.len == 1 && part[0] >= `A` && part[0] <= `Z` {
+			return true
+		}
 	}
-	return short.len == 1 && short[0] >= `A` && short[0] <= `Z`
+	return false
 }
 
 fn fn_ptr_typedef_generic_placeholder_struct_tag(typ string) ?string {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -901,7 +901,8 @@ fn (mut g FlatGen) pointer_value_return_expr_string(ret_id flat.NodeId, expected
 }
 
 fn (mut g FlatGen) write_pointer_value_return_expr(ret_id flat.NodeId, expected types.Type) bool {
-	actual := g.usable_expr_type(ret_id)
+	source_id := g.pointer_value_return_source_id(ret_id)
+	actual := g.usable_expr_type(source_id)
 	expected0 := if expected is types.Alias { expected.base_type } else { expected }
 	if expected0 is types.Pointer {
 		return false
@@ -909,18 +910,40 @@ fn (mut g FlatGen) write_pointer_value_return_expr(ret_id flat.NodeId, expected 
 	if actual is types.Pointer {
 		if g.type_names_match(actual.base_type, expected0) {
 			g.write('*(')
-			g.gen_expr(ret_id)
+			g.gen_expr(source_id)
 			g.write(')')
 			return true
 		}
 	}
 	if pointer_value_type_names_match(actual.name(), expected0.name()) {
 		g.write('*(')
-		g.gen_expr(ret_id)
+		g.gen_expr(source_id)
 		g.write(')')
 		return true
 	}
 	return false
+}
+
+fn (g &FlatGen) pointer_value_return_source_id(id flat.NodeId) flat.NodeId {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return id
+	}
+	node := g.a.nodes[int(id)]
+	match node.kind {
+		.expr_stmt, .paren {
+			if node.children_count > 0 {
+				return g.pointer_value_return_source_id(g.a.child(&node, 0))
+			}
+		}
+		.block {
+			if node.children_count == 1 {
+				return g.pointer_value_return_source_id(g.a.child(&node, 0))
+			}
+		}
+		else {}
+	}
+
+	return id
 }
 
 fn pointer_value_type_names_match(actual string, expected string) bool {

--- a/vlib/v3/tests/review_ownership_pr_regressions_test.v
+++ b/vlib/v3/tests/review_ownership_pr_regressions_test.v
@@ -54,3 +54,11 @@ fn test_value_new_chain_uses_checked_return_type_for_generic_receiver() {
 	})
 	assert out == '23'
 }
+
+fn test_fn_ptr_typedef_keeps_concrete_upper_suffix_type() {
+	v3_bin := review_pr_build_v3()
+	out := review_pr_run_project(v3_bin, 'fn_ptr_concrete_upper_suffix_type', {
+		'main.v': 'module main\n\nstruct Foo_T {\n\tn int\n}\n\nfn apply(cb fn (Foo_T) int) int {\n\treturn cb(Foo_T{\n\t\tn: 8\n\t})\n}\n\nfn take(foo Foo_T) int {\n\treturn foo.n + 2\n}\n\nfn main() {\n\tprintln(int_str(apply(take)))\n}\n'
+	})
+	assert out == '10'
+}

--- a/vlib/v3/tests/review_ownership_pr_regressions_test.v
+++ b/vlib/v3/tests/review_ownership_pr_regressions_test.v
@@ -46,6 +46,16 @@ fn test_imported_decl_param_uses_callee_module_for_unqualified_type() {
 	assert out == '5'
 }
 
+fn test_imported_decl_param_uses_callee_file_selective_import() {
+	v3_bin := review_pr_build_v3()
+	out := review_pr_run_project(v3_bin, 'imported_decl_param_selective_import', {
+		'other/other.v':   'module other\n\npub struct S {\npub:\n\tn int\n}\n'
+		'callee/callee.v': 'module callee\n\nimport other { S }\n\npub fn take(s S) int {\n\treturn s.n + 3\n}\n'
+		'main.v':          'module main\n\nimport callee\nimport other\n\nstruct S {\n\ttext string\n}\n\nfn main() {\n\tprintln(int_str(callee.take(other.S{\n\t\tn: 4\n\t})))\n}\n'
+	})
+	assert out == '7'
+}
+
 fn test_value_new_chain_uses_checked_return_type_for_generic_receiver() {
 	v3_bin := review_pr_build_v3()
 	out := review_pr_run_project(v3_bin, 'generic_value_new_chain', {

--- a/vlib/v3/tests/review_ownership_pr_regressions_test.v
+++ b/vlib/v3/tests/review_ownership_pr_regressions_test.v
@@ -1,0 +1,56 @@
+import os
+
+const review_pr_vexe = @VEXE
+const review_pr_tests_dir = os.dir(@FILE)
+const review_pr_v3_dir = os.dir(review_pr_tests_dir)
+const review_pr_vlib_dir = os.dir(review_pr_v3_dir)
+const review_pr_v3_src = os.join_path(review_pr_v3_dir, 'v3.v')
+
+fn review_pr_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_review_pr_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${review_pr_vexe} -gc none -path "${review_pr_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${review_pr_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn review_pr_write_file(root string, rel string, source string) {
+	path := os.join_path(root, rel)
+	os.mkdir_all(os.dir(path)) or { panic(err) }
+	os.write_file(path, source) or { panic(err) }
+}
+
+fn review_pr_run_project(v3_bin string, name string, files map[string]string) string {
+	root := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	os.write_file(os.join_path(root, 'v.mod'), "Module { name: '${name}' }\n") or { panic(err) }
+	for rel, source in files {
+		review_pr_write_file(root, rel, source)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
+}
+
+fn test_imported_decl_param_uses_callee_module_for_unqualified_type() {
+	v3_bin := review_pr_build_v3()
+	out := review_pr_run_project(v3_bin, 'imported_decl_param_module', {
+		'callee/callee.v': 'module callee\n\npub struct S {\npub:\n\tn int\n}\n\npub fn take(s S) int {\n\treturn s.n + 1\n}\n'
+		'main.v':          'module main\n\nimport callee\n\nstruct S {\n\ttext string\n}\n\nfn main() {\n\tprintln(int_str(callee.take(callee.S{\n\t\tn: 4\n\t})))\n}\n'
+	})
+	assert out == '5'
+}
+
+fn test_value_new_chain_uses_checked_return_type_for_generic_receiver() {
+	v3_bin := review_pr_build_v3()
+	out := review_pr_run_project(v3_bin, 'generic_value_new_chain', {
+		'factory/factory.v': 'module factory\n\npub struct Box[T] {\npub:\n\tvalue T\n}\n\npub fn (box Box[T]) get() T {\n\treturn box.value\n}\n\npub struct Factory {}\n\npub fn (factory Factory) new() Box[int] {\n\t_ = factory\n\treturn Box[int]{\n\t\tvalue: 23\n\t}\n}\n'
+		'main.v':            'module main\n\nimport factory\n\nfn main() {\n\tfactory := factory.Factory{}\n\tprintln(int_str(factory.new().get()))\n}\n'
+	})
+	assert out == '23'
+}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1232,6 +1232,12 @@ fn (t &Transformer) decl_param_type_in_module(typ string, module_name string) st
 				1..], module_name)
 		}
 	}
+	if clean.starts_with('fn(') || clean.starts_with('fn (') {
+		if scoped_fn_type := t.decl_fn_type_in_module(clean, module_name) {
+			return scoped_fn_type
+		}
+		return clean
+	}
 	base, args, ok := generic_app_parts(clean)
 	if ok {
 		mut scoped_args := []string{}
@@ -1241,9 +1247,9 @@ fn (t &Transformer) decl_param_type_in_module(typ string, module_name string) st
 		scoped_base := t.decl_param_type_in_module(base, module_name)
 		return scoped_base + '[' + scoped_args.join(', ') + ']'
 	}
-	if clean.starts_with('fn(') || clean.starts_with('fn (') || clean.contains('.')
-		|| module_name.len == 0 || module_name == 'main' || module_name == 'builtin'
-		|| types.is_builtin_type_name(clean) || is_generic_placeholder_type_name(clean) {
+	if clean.contains('.') || module_name.len == 0 || module_name == 'main'
+		|| module_name == 'builtin' || types.is_builtin_type_name(clean)
+		|| is_generic_placeholder_type_name(clean) {
 		return clean
 	}
 	qualified := '${module_name}.${clean}'
@@ -1256,6 +1262,52 @@ fn (t &Transformer) decl_param_type_in_module(typ string, module_name string) st
 		return qualified
 	}
 	return clean
+}
+
+fn (t &Transformer) decl_fn_type_in_module(typ string, module_name string) ?string {
+	params, ret := fn_type_text_parts(typ) or { return none }
+	mut scoped_params := []string{cap: params.len}
+	for param in params {
+		scoped_params << t.decl_fn_type_param_in_module(param, module_name)
+	}
+	if ret.len > 0 {
+		return 'fn(${scoped_params.join(', ')}) ${t.decl_param_type_in_module(ret, module_name)}'
+	}
+	return 'fn(${scoped_params.join(', ')})'
+}
+
+fn (t &Transformer) decl_fn_type_param_in_module(param string, module_name string) string {
+	mut text := param.trim_space()
+	mut is_mut := false
+	if text.starts_with('mut ') {
+		is_mut = true
+		text = text[4..].trim_space()
+	}
+	space := generic_top_level_space_index(text)
+	if space > 0 {
+		head := text[..space].trim_space()
+		tail := text[space + 1..].trim_space()
+		if generic_fn_type_param_head_is_name(head, tail) {
+			text = tail
+		}
+	}
+	for marker in ['[]', '&', 'map[', 'fn(', 'fn ('] {
+		marker_idx := text.index(marker) or { continue }
+		if marker_idx <= 0 {
+			continue
+		}
+		head := text[..marker_idx].trim_space()
+		tail := text[marker_idx..].trim_space()
+		if generic_fn_type_param_head_is_name(head, tail) {
+			text = tail
+		}
+		break
+	}
+	scoped := t.decl_param_type_in_module(text, module_name)
+	if is_mut && scoped.len > 0 && !scoped.starts_with('&') {
+		return '&' + scoped
+	}
+	return scoped
 }
 
 fn fn_decl_name_matches_call(name string, module_name string, call_name string) bool {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1167,7 +1167,7 @@ fn (t &Transformer) call_param_types_from_decl(call_name string) ?[]types.Type {
 			if child.kind != .param {
 				continue
 			}
-			mut param_type := t.tc.parse_type(child.typ)
+			mut param_type := t.parse_decl_param_type(child.typ, module_name)
 			if param_type is types.Unknown || (param_type is types.Void && child.typ != 'void') {
 				return none
 			}
@@ -1182,6 +1182,80 @@ fn (t &Transformer) call_param_types_from_decl(call_name string) ?[]types.Type {
 		return params
 	}
 	return none
+}
+
+fn (t &Transformer) parse_decl_param_type(typ string, module_name string) types.Type {
+	return t.tc.parse_type(t.decl_param_type_in_module(typ, module_name))
+}
+
+fn (t &Transformer) decl_param_type_in_module(typ string, module_name string) string {
+	clean := typ.trim_space()
+	if clean.len == 0 {
+		return clean
+	}
+	if clean.starts_with('&') {
+		return '&' + t.decl_param_type_in_module(clean[1..], module_name)
+	}
+	if clean.starts_with('mut ') {
+		return 'mut ' + t.decl_param_type_in_module(clean[4..], module_name)
+	}
+	if clean.starts_with('shared ') {
+		return 'shared ' + t.decl_param_type_in_module(clean[7..], module_name)
+	}
+	if clean.starts_with('atomic ') {
+		return 'atomic ' + t.decl_param_type_in_module(clean[7..], module_name)
+	}
+	if clean.starts_with('?') {
+		return '?' + t.decl_param_type_in_module(clean[1..], module_name)
+	}
+	if clean.starts_with('!') {
+		return '!' + t.decl_param_type_in_module(clean[1..], module_name)
+	}
+	if clean.starts_with('...') {
+		return '...' + t.decl_param_type_in_module(clean[3..], module_name)
+	}
+	if clean.starts_with('[]') {
+		return '[]' + t.decl_param_type_in_module(clean[2..], module_name)
+	}
+	if clean.starts_with('map[') {
+		bracket_end := generic_matching_bracket(clean, 3)
+		if bracket_end < clean.len {
+			key := t.decl_param_type_in_module(clean[4..bracket_end], module_name)
+			value := t.decl_param_type_in_module(clean[bracket_end + 1..], module_name)
+			return 'map[${key}]${value}'
+		}
+	}
+	if clean.starts_with('[') {
+		bracket_end := generic_matching_bracket(clean, 0)
+		if bracket_end < clean.len {
+			return clean[..bracket_end + 1] + t.decl_param_type_in_module(clean[bracket_end +
+				1..], module_name)
+		}
+	}
+	base, args, ok := generic_app_parts(clean)
+	if ok {
+		mut scoped_args := []string{}
+		for arg in args {
+			scoped_args << t.decl_param_type_in_module(arg, module_name)
+		}
+		scoped_base := t.decl_param_type_in_module(base, module_name)
+		return scoped_base + '[' + scoped_args.join(', ') + ']'
+	}
+	if clean.starts_with('fn(') || clean.starts_with('fn (') || clean.contains('.')
+		|| module_name.len == 0 || module_name == 'main' || module_name == 'builtin'
+		|| types.is_builtin_type_name(clean) || is_generic_placeholder_type_name(clean) {
+		return clean
+	}
+	qualified := '${module_name}.${clean}'
+	if t.type_authority_has(qualified) {
+		return qualified
+	}
+	if !isnil(t.tc) && (qualified in t.tc.type_aliases || qualified in t.tc.structs
+		|| qualified in t.tc.enum_names || qualified in t.tc.sum_types
+		|| qualified in t.tc.interface_names) {
+		return qualified
+	}
+	return clean
 }
 
 fn fn_decl_name_matches_call(name string, module_name string, call_name string) bool {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1108,7 +1108,7 @@ fn (mut t Transformer) try_lower_static_assoc_call(id flat.NodeId, node flat.Nod
 }
 
 // call_param_types updates call param types state for Transformer.
-fn (t &Transformer) call_param_types(call_name string) []types.Type {
+fn (mut t Transformer) call_param_types(call_name string) []types.Type {
 	if call_name.len == 0 || isnil(t.tc) {
 		return []types.Type{}
 	}
@@ -1119,7 +1119,7 @@ fn (t &Transformer) call_param_types(call_name string) []types.Type {
 	return params
 }
 
-fn (t &Transformer) call_param_types_for_node(call_name string, node flat.Node) []types.Type {
+fn (mut t Transformer) call_param_types_for_node(call_name string, node flat.Node) []types.Type {
 	if node.children_count > 0 {
 		fn_node := t.a.child_node(&node, 0)
 		if fn_node.kind == .selector && fn_node.children_count > 0 {
@@ -1145,12 +1145,18 @@ fn (t &Transformer) call_param_types_for_node(call_name string, node flat.Node) 
 	return t.call_param_types(call_name)
 }
 
-fn (t &Transformer) call_param_types_from_decl(call_name string) ?[]types.Type {
+fn (mut t Transformer) call_param_types_from_decl(call_name string) ?[]types.Type {
 	if call_name.len == 0 || isnil(t.tc) {
 		return none
 	}
+	mut file_name := ''
 	mut module_name := ''
 	for node in t.a.nodes {
+		if node.kind == .file {
+			file_name = node.value
+			module_name = t.tc.file_modules[file_name] or { '' }
+			continue
+		}
 		if node.kind == .module_decl {
 			module_name = node.value
 			continue
@@ -1167,7 +1173,7 @@ fn (t &Transformer) call_param_types_from_decl(call_name string) ?[]types.Type {
 			if child.kind != .param {
 				continue
 			}
-			mut param_type := t.parse_decl_param_type(child.typ, module_name)
+			mut param_type := t.parse_decl_param_type(child.typ, module_name, file_name)
 			if param_type is types.Unknown || (param_type is types.Void && child.typ != 'void') {
 				return none
 			}
@@ -1184,8 +1190,16 @@ fn (t &Transformer) call_param_types_from_decl(call_name string) ?[]types.Type {
 	return none
 }
 
-fn (t &Transformer) parse_decl_param_type(typ string, module_name string) types.Type {
-	return t.tc.parse_type(t.decl_param_type_in_module(typ, module_name))
+fn (mut t Transformer) parse_decl_param_type(typ string, module_name string, file_name string) types.Type {
+	scoped := t.decl_param_type_in_module(typ, module_name)
+	old_file := t.tc.cur_file
+	old_module := t.tc.cur_module
+	t.tc.cur_file = file_name
+	t.tc.cur_module = module_name
+	parsed := t.tc.parse_type(scoped)
+	t.tc.cur_file = old_file
+	t.tc.cur_module = old_module
+	return parsed
 }
 
 fn (t &Transformer) decl_param_type_in_module(typ string, module_name string) string {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -685,7 +685,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 		})
 	}
 	call_name := t.call_name_for_node(id, node)
-	mut params := t.call_param_types(call_name)
+	mut params := t.call_param_types_for_node(call_name, node)
 	if concrete_params := t.concrete_generic_call_param_types(id, node) {
 		params = concrete_params.clone()
 	}
@@ -929,7 +929,13 @@ fn (t &Transformer) call_param_offset(call_name string, node flat.Node, params [
 		return 0
 	}
 	fn_node := t.a.child_node(&node, 0)
-	if fn_node.kind != .selector || fn_node.children_count == 0 {
+	if fn_node.kind != .selector {
+		return 0
+	}
+	if fn_node.children_count == 0 {
+		if t.selector_call_name_has_receiver_param(call_name, fn_node.value, params) {
+			return 1
+		}
 		return 0
 	}
 	base_id := t.a.child(fn_node, 0)
@@ -958,6 +964,26 @@ fn (t &Transformer) call_param_offset(call_name string, node flat.Node, params [
 	return 0
 }
 
+fn (t &Transformer) selector_call_name_has_receiver_param(call_name string, method string, params []types.Type) bool {
+	if params.len == 0 || method.len == 0 || call_name.len == 0
+		|| !call_name.ends_with('.${method}') {
+		return false
+	}
+	first_type := t.normalize_type_alias(params[0].name())
+	clean_first := if first_type.starts_with('&') { first_type[1..] } else { first_type }
+	if receiver_param_matches_method_name(clean_first, call_name) {
+		return true
+	}
+	receiver := call_name.all_before_last('.')
+	clean_receiver := if receiver.starts_with('&') { receiver[1..] } else { receiver }
+	if receiver_param_types_match(clean_first, clean_receiver)
+		|| t.normalize_type_alias(clean_first) == t.normalize_type_alias(clean_receiver)
+		|| clean_first.all_after_last('.') == clean_receiver.all_after_last('.') {
+		return true
+	}
+	return false
+}
+
 // static_assoc_fn_name returns the name of the static associated function a selector
 // call resolves to, if the base names a type (`Type.fn` or `module.Type.fn`) and that
 // function exists. Such calls take no receiver, so the base must not be prepended as an
@@ -969,6 +995,15 @@ fn (t &Transformer) static_assoc_fn_name(base_id flat.NodeId, method string) ?st
 	base := t.a.nodes[int(base_id)]
 	if base.kind == .ident {
 		if base.value == 'C' || t.is_import_alias_ident(base_id) {
+			return none
+		}
+		if t.var_type(base.value).len > 0 {
+			return none
+		}
+		base_type := t.node_type(base_id)
+		clean_base_type := if base_type.starts_with('&') { base_type[1..] } else { base_type }
+		if clean_base_type.len > 0 && clean_base_type != 'unknown' && clean_base_type != 'void'
+			&& base.value != clean_base_type && base.value != clean_base_type.all_after_last('.') {
 			return none
 		}
 		for type_name in t.static_assoc_type_candidates(base.value) {
@@ -997,7 +1032,19 @@ fn (t &Transformer) is_import_alias_ident(id flat.NodeId) bool {
 		return false
 	}
 	node := t.a.nodes[int(id)]
-	return node.kind == .ident && node.value in t.tc.imports
+	if node.kind != .ident || node.value !in t.tc.imports {
+		return false
+	}
+	if t.var_type(node.value).len > 0 {
+		return false
+	}
+	if typ := t.tc.expr_type(id) {
+		name := typ.name()
+		if name.len > 0 && name != 'unknown' && name != 'void' {
+			return false
+		}
+	}
+	return true
 }
 
 fn (t &Transformer) static_assoc_type_candidates(type_ident string) []string {
@@ -1065,8 +1112,84 @@ fn (t &Transformer) call_param_types(call_name string) []types.Type {
 	if call_name.len == 0 || isnil(t.tc) {
 		return []types.Type{}
 	}
+	if params := t.call_param_types_from_decl(call_name) {
+		return params
+	}
 	params := t.tc.fn_param_types[call_name] or { return []types.Type{} }
 	return params
+}
+
+fn (t &Transformer) call_param_types_for_node(call_name string, node flat.Node) []types.Type {
+	if node.children_count > 0 {
+		fn_node := t.a.child_node(&node, 0)
+		if fn_node.kind == .selector && fn_node.children_count > 0 {
+			base_id := t.a.child(fn_node, 0)
+			method_name := t.resolve_receiver_method_name(base_id, fn_node.value)
+			if method_name.len > 0 {
+				if params := t.call_param_types_from_decl(method_name) {
+					return params
+				}
+			}
+			mut base_type := t.lvalue_type(base_id)
+			if base_type.starts_with('&') {
+				base_type = base_type[1..]
+			}
+			for candidate in ['${base_type}.${fn_node.value}',
+				'${t.normalize_type_in_module(base_type, t.cur_module)}.${fn_node.value}'] {
+				if params := t.call_param_types_from_decl(candidate) {
+					return params
+				}
+			}
+		}
+	}
+	return t.call_param_types(call_name)
+}
+
+fn (t &Transformer) call_param_types_from_decl(call_name string) ?[]types.Type {
+	if call_name.len == 0 || isnil(t.tc) {
+		return none
+	}
+	mut module_name := ''
+	for node in t.a.nodes {
+		if node.kind == .module_decl {
+			module_name = node.value
+			continue
+		}
+		if node.kind != .fn_decl {
+			continue
+		}
+		if !fn_decl_name_matches_call(node.value, module_name, call_name) {
+			continue
+		}
+		mut params := []types.Type{}
+		for i in 0 .. node.children_count {
+			child := t.a.child_node(&node, i)
+			if child.kind != .param {
+				continue
+			}
+			mut param_type := t.tc.parse_type(child.typ)
+			if param_type is types.Unknown || (param_type is types.Void && child.typ != 'void') {
+				return none
+			}
+			if (child.is_mut || child.typ.starts_with('mut ')
+				|| child.typ.starts_with('&')) && param_type !is types.Pointer {
+				param_type = types.Type(types.Pointer{
+					base_type: param_type
+				})
+			}
+			params << param_type
+		}
+		return params
+	}
+	return none
+}
+
+fn fn_decl_name_matches_call(name string, module_name string, call_name string) bool {
+	if name == call_name || c_name(name) == call_name {
+		return true
+	}
+	qname := transform_qualified_fn_name(module_name, name)
+	return qname == call_name || c_name(qname) == call_name
 }
 
 // call_is_variadic updates call is variadic state for Transformer.

--- a/vlib/v3/transform/fn_lambda_capture_test.v
+++ b/vlib/v3/transform/fn_lambda_capture_test.v
@@ -66,3 +66,14 @@ fn test_lambda_capture_collector_scans_callee_and_range_bound() {
 	assert 'i' !in capture_names
 	assert 'n' !in capture_names
 }
+
+fn test_decl_param_type_in_module_qualifies_fn_type_params() {
+	t := Transformer{
+		structs: {
+			'callee.S':      StructInfo{}
+			'callee.Result': StructInfo{}
+		}
+	}
+	assert t.decl_param_type_in_module('fn(S) int', 'callee') == 'fn(callee.S) int'
+	assert t.decl_param_type_in_module('fn(cb fn(S) Result) Result', 'callee') == 'fn(fn(callee.S) callee.Result) callee.Result'
+}

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -326,10 +326,68 @@ fn (mut t Transformer) try_expand_if_expr_value(id flat.NodeId, node flat.Node) 
 		return none
 	}
 	mut result_type := t.if_expr_result_type(id, node)
+	if guard_result_type := t.if_expr_guard_result_type(node) {
+		result_type = guard_result_type
+	}
 	if result_type.len == 0 || result_type == 'void' {
 		return none
 	}
 	return t.try_expand_if_expr_value_for_type(id, node, result_type)
+}
+
+fn (mut t Transformer) if_expr_guard_result_type(node flat.Node) ?string {
+	if node.kind != .if_expr || node.children_count < 3 {
+		return none
+	}
+	cond_id := t.a.child(&node, 0)
+	cond := t.a.nodes[int(cond_id)]
+	if cond.kind != .decl_assign || cond.children_count < 2 {
+		return none
+	}
+	lhs_id := t.a.child(&cond, 0)
+	rhs_id := t.a.child(&cond, 1)
+	lhs := t.a.nodes[int(lhs_id)]
+	if lhs.kind != .ident || lhs.value.len == 0 {
+		return none
+	}
+	mut rhs_type := t.optional_result_expr_type_name(rhs_id)
+	if !t.is_optional_type_name(rhs_type) {
+		return none
+	}
+	rhs_type = t.qualify_optional_type(rhs_type)
+	value_type := t.optional_base_type(rhs_type)
+	saved_var_types := t.var_types.clone()
+	if lhs.value != '_' && value_type != 'void' {
+		t.set_var_type(lhs.value, value_type)
+	}
+	then_type := t.stmt_value_type(t.a.child(&node, 1))
+	t.restore_var_types(saved_var_types)
+
+	t.set_var_type('err', 'IError')
+	else_id := t.a.child(&node, 2)
+	else_node := t.a.nodes[int(else_id)]
+	else_type := if else_node.kind == .if_expr {
+		if nested := t.if_expr_guard_result_type(else_node) {
+			nested
+		} else {
+			t.if_expr_result_type(else_id, else_node)
+		}
+	} else {
+		t.stmt_value_type(else_id)
+	}
+	t.restore_var_types(saved_var_types)
+
+	mut result := ''
+	if then_type.len > 0 {
+		result = t.merge_if_expr_types(result, t.normalize_type_alias(then_type))
+	}
+	if else_type.len > 0 {
+		result = t.merge_if_expr_types(result, t.normalize_type_alias(else_type))
+	}
+	if result.len == 0 || result == 'void' || result == 'unknown' {
+		return none
+	}
+	return result
 }
 
 // try_expand_if_expr_value_for_type
@@ -520,6 +578,9 @@ fn (t &Transformer) stmt_value_type_with_smartcasts(id flat.NodeId, contexts []S
 	}
 	node := t.a.nodes[int(id)]
 	match node.kind {
+		.return_stmt {
+			return ''
+		}
 		.expr_stmt {
 			if node.children_count > 0 {
 				return t.node_type_with_smartcasts(t.a.child(&node, node.children_count - 1),
@@ -782,11 +843,20 @@ fn (mut t Transformer) build_if_value_guard_chain(if_node flat.Node, target_name
 
 	else_id := t.a.child(&if_node, 2)
 	else_node := t.a.nodes[int(else_id)]
-	else_block := if else_node.kind == .if_expr {
+	err_value := t.make_selector(t.make_ident(tmp_name), 'err', 'IError')
+	err_decl := t.make_decl_assign_typed('err', err_value, 'IError')
+	saved_else_var_types := t.var_types.clone()
+	t.set_var_type('err', 'IError')
+	else_block0 := if else_node.kind == .if_expr {
 		t.make_block(t.build_if_value_chain(else_id, target_name, target_type))
 	} else {
 		t.if_value_branch_block(else_id, target_name, target_type)
 	}
+	t.restore_var_types(saved_else_var_types)
+	mut else_children := []flat.NodeId{cap: int(t.a.nodes[int(else_block0)].children_count) + 1}
+	else_children << err_decl
+	else_children << t.a.children_of(&t.a.nodes[int(else_block0)])
+	else_block := t.make_block(else_children)
 	result << t.make_if(ok_cond, then_block, else_block)
 	return result
 }

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -1258,6 +1258,9 @@ fn (mut t Transformer) unused_fn_subtree_nodes() []bool {
 				t.cur_module = node.value
 			}
 			.fn_decl {
+				if node.value.starts_with('test_') {
+					continue
+				}
 				if !t.should_transform_fn(node) {
 					t.collect_node_subtree_flags(flat.NodeId(i), mut nodes)
 				}
@@ -2700,12 +2703,9 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 		callee_id = t.a.child(&callee, 0)
 		callee = t.a.nodes[int(callee_id)]
 	}
-	if callee.kind == .ident && t.plain_concrete_fn_known(callee.value, module_name, decls) {
-		return none
-	}
 	if !isnil(t.tc) {
 		if resolved := t.tc.resolved_call_name(id) {
-			key := t.generic_resolved_call_decl_key(resolved, callee, module_name, decls) or {
+			key := t.generic_resolved_call_decl_key(resolved, callee, node, module_name, decls) or {
 				return none
 			}
 			if decl := decls[key] {
@@ -2718,9 +2718,6 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 		}
 	}
 	if callee.kind == .ident {
-		if t.local_concrete_fn_shadows_generic(callee.value, module_name, decls) {
-			return none
-		}
 		if key := t.generic_flat_receiver_call_decl_key(callee.value, module_name, decls) {
 			if decl := decls[key] {
 				if t.generic_call_arg_count_matches_decl(node, decl) {
@@ -2734,6 +2731,10 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 					return key
 				}
 			}
+		}
+		if t.local_concrete_fn_shadows_generic(callee.value, module_name, decls)
+			|| t.plain_concrete_fn_known(callee.value, module_name, decls) {
+			return none
 		}
 		for candidate in t.generic_plain_call_candidates(callee.value, module_name) {
 			key := generic_fn_decl_base_value(candidate)
@@ -2767,7 +2768,10 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 			}
 		}
 		method_keys := t.generic_receiver_methods_by_name[callee.value] or { return none }
-		mut base_type := t.node_type(base_id)
+		mut base_type := t.syntactic_static_call_return_type(base_id)
+		if base_type.len == 0 {
+			base_type = t.node_type(base_id)
+		}
 		if base_type.starts_with('&') {
 			base_type = base_type[1..]
 		}
@@ -2783,6 +2787,9 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 		}
 		for key in method_keys {
 			if decl := decls[key] {
+				if !t.generic_receiver_decl_matches_type(base_type, decl, module_name) {
+					continue
+				}
 				if !t.generic_call_arg_count_matches_decl(node, decl) {
 					continue
 				}
@@ -2791,6 +2798,61 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 		}
 	}
 	return none
+}
+
+fn (t &Transformer) generic_receiver_decl_matches_type(base_type string, decl GenericFnDecl, module_name string) bool {
+	decl_receiver := generic_fn_decl_base_value(decl.node.value).all_before_last('.')
+	if decl_receiver.len == 0 {
+		return false
+	}
+	mut clean_base := base_type.trim_space()
+	if clean_base.starts_with('&') {
+		clean_base = clean_base[1..]
+	}
+	if clean_base.len == 0 {
+		return false
+	}
+	base, _, ok := generic_app_parts(clean_base)
+	if ok {
+		clean_base = base
+	}
+	mut call_receivers := []string{}
+	for candidate in [clean_base, t.normalize_type_alias(clean_base),
+		t.normalize_type_in_module(clean_base, module_name)] {
+		if candidate.len > 0 && candidate !in call_receivers {
+			call_receivers << candidate
+		}
+		if candidate.contains('.') {
+			short := candidate.all_after_last('.')
+			if short.len > 0 && short !in call_receivers {
+				call_receivers << short
+			}
+		}
+	}
+	mut decl_receivers := []string{}
+	for candidate in [decl_receiver, t.normalize_type_alias(decl_receiver),
+		t.normalize_type_in_module(decl_receiver, decl.module)] {
+		if candidate.len > 0 && candidate !in decl_receivers {
+			decl_receivers << candidate
+		}
+		if candidate.contains('.') {
+			short := candidate.all_after_last('.')
+			if short.len > 0 && short !in decl_receivers {
+				decl_receivers << short
+			}
+		} else if decl.module.len > 0 && decl.module !in ['main', 'builtin'] {
+			qualified := '${decl.module}.${candidate}'
+			if qualified !in decl_receivers {
+				decl_receivers << qualified
+			}
+		}
+	}
+	for call_receiver in call_receivers {
+		if call_receiver in decl_receivers {
+			return true
+		}
+	}
+	return false
 }
 
 fn (t &Transformer) generic_static_assoc_call_decl_key(base_id flat.NodeId, method string, decls map[string]GenericFnDecl) ?string {
@@ -2998,23 +3060,24 @@ fn generic_flat_receiver_matches(receiver string, decl_receiver string, module_n
 	return false
 }
 
-fn (t &Transformer) generic_resolved_call_decl_key(resolved string, callee flat.Node, module_name string, decls map[string]GenericFnDecl) ?string {
-	if callee.kind == .ident
-		&& t.local_concrete_fn_shadows_generic(callee.value, module_name, decls) {
-		return none
-	}
+fn (t &Transformer) generic_resolved_call_decl_key(resolved string, callee flat.Node, node flat.Node, module_name string, decls map[string]GenericFnDecl) ?string {
 	key := generic_fn_decl_base_value(resolved)
-	if key in decls {
+	if decl := decls[key] {
+		if !t.resolved_generic_decl_matches_callee_receiver(callee, node, decl, module_name) {
+			return none
+		}
 		return key
-	}
-	if callee.kind == .ident && t.resolved_call_is_concrete_fn(resolved, key) {
-		return none
 	}
 	if flat_key := t.generic_flat_receiver_call_decl_key(key, module_name, decls) {
 		return flat_key
 	}
 	if flat_key := t.generic_flat_receiver_call_decl_key(resolved, module_name, decls) {
 		return flat_key
+	}
+	if callee.kind == .ident
+		&& (t.local_concrete_fn_shadows_generic(callee.value, module_name, decls)
+		|| t.resolved_call_is_concrete_fn(resolved, key)) {
+		return none
 	}
 	resolved_mod := if key.contains('.') { key.all_before_last('.') } else { module_name }
 	short := key.all_after_last('.')
@@ -3039,6 +3102,73 @@ fn (t &Transformer) generic_resolved_call_decl_key(resolved string, callee flat.
 		}
 	}
 	return none
+}
+
+fn (t &Transformer) resolved_generic_decl_matches_callee_receiver(callee flat.Node, node flat.Node, decl GenericFnDecl, module_name string) bool {
+	if !decl.node.value.contains('.') {
+		return true
+	}
+	mut base_id := flat.empty_node
+	if callee.kind == .selector && callee.children_count > 0 {
+		base_id = t.a.child(&callee, 0)
+	} else if callee.kind == .ident && node.children_count > 1 {
+		base_id = t.a.child(&node, 1)
+	} else {
+		return true
+	}
+	mut base_type := t.syntactic_static_call_return_type(base_id)
+	if base_type.len == 0 {
+		base_type = t.node_type(base_id)
+	}
+	if base_type.len == 0 {
+		return true
+	}
+	return t.generic_receiver_decl_matches_type(base_type, decl, module_name)
+}
+
+fn (t &Transformer) syntactic_static_call_return_type(id flat.NodeId) string {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return ''
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind != .call || node.children_count == 0 {
+		return ''
+	}
+	callee := t.a.child_node(&node, 0)
+	if callee.kind != .selector || callee.children_count == 0 {
+		return ''
+	}
+	base := t.a.child_node(callee, 0)
+	mut owner := ''
+	if base.kind == .ident {
+		owner = base.value
+	} else if base.kind == .selector && base.children_count > 0 {
+		inner := t.a.child_node(base, 0)
+		if inner.kind == .ident {
+			owner = '${inner.value}.${base.value}'
+		}
+	}
+	if owner.len == 0 {
+		return ''
+	}
+	name := '${owner}.${callee.value}'
+	for candidate in [name, transform_qualified_fn_name(t.cur_module, name)] {
+		if ret := t.fn_ret_types[candidate] {
+			return ret
+		}
+		if !isnil(t.tc) {
+			if typ := t.tc.fn_ret_types[candidate] {
+				ret_name := typ.name()
+				if ret_name.len > 0 && ret_name != 'unknown' && ret_name != 'void' {
+					return ret_name
+				}
+			}
+		}
+	}
+	if callee.value == 'new' {
+		return owner
+	}
+	return ''
 }
 
 fn (t &Transformer) resolved_call_is_concrete_fn(resolved string, key string) bool {
@@ -4167,6 +4297,12 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 	} else {
 		t.subst_node_value(node, args)
 	}
+	if is_root && t.cur_module.len > 0 {
+		t.a.add_node(flat.Node{
+			kind:  .module_decl
+			value: t.cur_module
+		})
+	}
 	clone_id := t.a.add_node(flat.Node{
 		kind:           node.kind
 		kind_id:        node.kind_id
@@ -4381,9 +4517,6 @@ fn (mut t Transformer) retarget_cloned_implicit_generic_call(clone_id flat.NodeI
 	is_receiver := t.generic_decl_is_receiver_method(decl.node)
 		&& !t.generic_call_is_static_assoc_selector(source, decl)
 	if t.should_skip_generic_call_specialization(decl_key) || t.call_has_source_generic_args(source) {
-		return
-	}
-	if is_receiver && !t.generic_decl_has_method_level_params(decl) {
 		return
 	}
 	callee_id := t.a.child(&clone, 0)
@@ -5229,7 +5362,8 @@ fn (t &Transformer) resolve_substituted_type_text(typ string) string {
 	if parsed is types.Unknown {
 		return typ
 	}
-	return parsed.name()
+	resolved := parsed.name()
+	return resolved
 }
 
 fn (t &Transformer) subst_comptime_type_condition(cond string, args []string) string {
@@ -5315,6 +5449,14 @@ fn generic_type_arg_short(type_arg string) string {
 	// deterministic sanitized fragment instead.
 	if clean.contains('(') || clean.contains(' ') {
 		return sanitize_type_name_fragment(clean)
+	}
+	base, args, ok := generic_app_parts(clean)
+	if ok {
+		mut parts := [generic_type_arg_short(base)]
+		for arg in args {
+			parts << generic_type_arg_short(arg)
+		}
+		return parts.join('_')
 	}
 	if clean.contains('.') {
 		short := clean.all_after_last('.')

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -3166,9 +3166,39 @@ fn (t &Transformer) syntactic_static_call_return_type(id flat.NodeId) string {
 		}
 	}
 	if callee.value == 'new' {
-		return owner
+		for type_name in t.static_assoc_type_candidates(owner) {
+			return type_name
+		}
+		if t.syntactic_new_owner_is_type_like(base, owner) {
+			return owner
+		}
 	}
 	return ''
+}
+
+fn (t &Transformer) syntactic_new_owner_is_type_like(base flat.Node, owner string) bool {
+	short_owner := owner.all_after_last('.')
+	if short_owner.len == 0 || !v3_type_name_starts_upper(short_owner) {
+		return false
+	}
+	if base.kind == .ident {
+		return t.var_type(base.value).len == 0 && !t.ident_is_import_alias(base.value)
+	}
+	if base.kind == .selector && base.children_count > 0 {
+		inner := t.a.child_node(&base, 0)
+		if inner.kind != .ident || t.var_type(inner.value).len > 0 {
+			return false
+		}
+		return t.ident_is_import_alias(inner.value) || v3_type_name_starts_upper(inner.value)
+	}
+	return false
+}
+
+fn v3_type_name_starts_upper(name string) bool {
+	if name.len == 0 {
+		return false
+	}
+	return name[0] >= `A` && name[0] <= `Z`
 }
 
 fn (t &Transformer) resolved_call_is_concrete_fn(resolved string, key string) bool {

--- a/vlib/v3/transform/return.v
+++ b/vlib/v3/transform/return.v
@@ -321,6 +321,48 @@ fn (mut t Transformer) try_expand_return_if(_id flat.NodeId, node flat.Node) ?[]
 	return arr1(t.build_return_if_chain(val_id, node.typ, extra_return_vals))
 }
 
+fn (t &Transformer) match_branch_tuple_parts(branch flat.Node, body_start_idx int, count int) ?TupleBlockParts {
+	if count <= 1 || branch.children_count <= body_start_idx {
+		return none
+	}
+	children := t.a.children_of(&branch).clone()
+	mut values := []flat.NodeId{}
+	mut prefix_end := children.len
+	for i := children.len - 1; i >= body_start_idx; i-- {
+		child_id := children[i]
+		child := t.a.nodes[int(child_id)]
+		if values.len == 0 && child.kind == .block {
+			if nested := t.tuple_block_parts(child_id, count) {
+				mut prefix := children[body_start_idx..i].clone()
+				for prefix_id in nested.prefix {
+					prefix << prefix_id
+				}
+				return TupleBlockParts{
+					prefix: prefix
+					values: nested.values.clone()
+				}
+			}
+		}
+		if child.kind != .expr_stmt || child.children_count == 0 {
+			break
+		}
+		for j := int(child.children_count) - 1; j >= 0; j-- {
+			values.prepend(t.a.child(&child, j))
+			if values.len == count {
+				break
+			}
+		}
+		prefix_end = i
+		if values.len == count {
+			return TupleBlockParts{
+				prefix: children[body_start_idx..prefix_end].clone()
+				values: values.clone()
+			}
+		}
+	}
+	return none
+}
+
 // match_branch_return_block supports match branch return block handling for Transformer.
 fn (mut t Transformer) match_branch_return_block(branch flat.Node, body_start_idx int, ret_typ string) flat.NodeId {
 	mut body_ids := []flat.NodeId{}
@@ -329,6 +371,16 @@ fn (mut t Transformer) match_branch_return_block(branch flat.Node, body_start_id
 	}
 	if body_ids.len == 0 {
 		return t.make_block([]flat.NodeId{})
+	}
+	tuple_count := t.current_return_multi_count()
+	if tuple_count > 1 {
+		if parts := t.match_branch_tuple_parts(branch, body_start_idx, tuple_count) {
+			mut all := t.transform_stmts(parts.prefix)
+			ret_vals := t.return_values_from_ids(parts.values)
+			t.drain_pending(mut all)
+			all << t.make_return_values(ret_vals, ret_typ)
+			return t.make_block(all)
+		}
 	}
 	mut all := []flat.NodeId{}
 	if body_ids.len > 1 {
@@ -351,7 +403,7 @@ fn (mut t Transformer) match_branch_return_block(branch flat.Node, body_start_id
 		tail_id
 	}
 	tail_expr_node := t.a.nodes[int(tail_expr)]
-	if tail_expr_node.kind == .match_stmt {
+	if tail_expr_node.kind in [.if_expr, .match_stmt] {
 		nested_return := t.make_return(tail_expr, ret_typ)
 		for stmt in t.transform_stmt(nested_return) {
 			all << stmt

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -4570,6 +4570,11 @@ fn (t &Transformer) infer_typed_optional_target(optional_target string, expr_typ
 		if value_type.contains('.') && base == value_type.all_after_last('.') {
 			return '?${value_type}'
 		}
+		if value_type.contains('.') && base.contains('.')
+			&& base.all_after_last('.') == value_type.all_after_last('.')
+			&& !t.is_known_type_name(base) && t.is_known_type_name(value_type) {
+			return '?${value_type}'
+		}
 		return optional_target
 	}
 	if optional_target != 'Optional' || isnil(t.tc) {
@@ -9314,9 +9319,12 @@ fn (t &Transformer) stmt_value_type(id flat.NodeId) string {
 	}
 	node := t.a.nodes[int(id)]
 	match node.kind {
+		.return_stmt {
+			return ''
+		}
 		.expr_stmt {
 			if node.children_count > 0 {
-				return t.node_type(t.a.child(&node, node.children_count - 1))
+				return t.expr_value_type(t.a.child(&node, node.children_count - 1))
 			}
 			return ''
 		}
@@ -9330,7 +9338,50 @@ fn (t &Transformer) stmt_value_type(id flat.NodeId) string {
 			return ''
 		}
 		else {
-			return t.node_type(id)
+			return t.expr_value_type(id)
+		}
+	}
+}
+
+fn (t &Transformer) expr_value_type(id flat.NodeId) string {
+	if int(id) < 0 {
+		return ''
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .call {
+		if ret := t.ierror_call_return_type(node) {
+			return ret
+		}
+		call_ret := t.get_call_return_type(id, node)
+		if call_ret.len > 0 && call_ret !in ['unknown', 'void'] {
+			return call_ret
+		}
+	}
+	return t.node_type(id)
+}
+
+fn (t &Transformer) ierror_call_return_type(node flat.Node) ?string {
+	if node.kind != .call || node.children_count == 0 {
+		return none
+	}
+	fn_node := t.a.child_node(&node, 0)
+	if fn_node.kind != .selector || fn_node.children_count == 0 {
+		return none
+	}
+	base_type := t.node_type(t.a.child(fn_node, 0))
+	clean_base := if base_type.starts_with('&') { base_type[1..] } else { base_type }
+	if clean_base !in ['IError', 'builtin.IError'] {
+		return none
+	}
+	match fn_node.value {
+		'msg', 'str' {
+			return 'string'
+		}
+		'code' {
+			return 'int'
+		}
+		else {
+			return none
 		}
 	}
 }

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -680,9 +680,7 @@ fn (t &Transformer) normalize_field_type(typ string, owner_type string) string {
 			mut normalized_arg := t.normalize_field_type(arg, owner_type)
 			if field_base.contains('.') {
 				field_mod := field_base.all_before_last('.')
-				if normalized_arg.starts_with('${field_mod}.') {
-					normalized_arg = normalized_arg.all_after_last('.')
-				}
+				normalized_arg = strip_field_module_prefix_from_type(normalized_arg, field_mod)
 			}
 			normalized_args << normalized_arg
 		}
@@ -815,6 +813,65 @@ fn (t &Transformer) normalize_type_alias_uncached(typ string) string {
 		}
 	}
 	return typ
+}
+
+fn strip_field_module_prefix_from_type(typ string, module_name string) string {
+	clean := typ.trim_space()
+	if clean.len == 0 || module_name.len == 0 {
+		return clean
+	}
+	if clean.starts_with('&') {
+		return '&' + strip_field_module_prefix_from_type(clean[1..], module_name)
+	}
+	if clean.starts_with('mut ') {
+		return 'mut ' + strip_field_module_prefix_from_type(clean[4..], module_name)
+	}
+	if clean.starts_with('?') || clean.starts_with('!') {
+		return clean[..1] + strip_field_module_prefix_from_type(clean[1..], module_name)
+	}
+	if clean.starts_with('...') {
+		return '...' + strip_field_module_prefix_from_type(clean[3..], module_name)
+	}
+	if clean.starts_with('[]') {
+		return '[]' + strip_field_module_prefix_from_type(clean[2..], module_name)
+	}
+	if clean.starts_with('map[') {
+		bracket_end := generic_matching_bracket(clean, 3)
+		if bracket_end < clean.len {
+			key := strip_field_module_prefix_from_type(clean[4..bracket_end], module_name)
+			value := strip_field_module_prefix_from_type(clean[bracket_end + 1..], module_name)
+			return 'map[${key}]${value}'
+		}
+	}
+	if clean.starts_with('[') {
+		bracket_end := generic_matching_bracket(clean, 0)
+		if bracket_end < clean.len {
+			return clean[..bracket_end + 1] +
+				strip_field_module_prefix_from_type(clean[bracket_end + 1..], module_name)
+		}
+	}
+	base, args, ok := generic_app_parts(clean)
+	if ok {
+		stripped_base := strip_field_module_prefix_from_base(base, module_name)
+		mut stripped_args := []string{cap: args.len}
+		for arg in args {
+			stripped_args << strip_field_module_prefix_from_type(arg, module_name)
+		}
+		return '${stripped_base}[${stripped_args.join(', ')}]'
+	}
+	return strip_field_module_prefix_from_base(clean, module_name)
+}
+
+fn strip_field_module_prefix_from_base(name string, module_name string) string {
+	prefix := '${module_name}.'
+	if !name.starts_with(prefix) {
+		return name
+	}
+	short := name[prefix.len..]
+	if short.starts_with('Array_') {
+		return name
+	}
+	return short
 }
 
 fn (t &Transformer) is_known_type_name(typ string) bool {


### PR DESCRIPTION
Split out from the local WIP that was mixed with #27686.\n\nChanges:\n- keep VEXE pointing at the launcher when invoking the v3 ownership compiler\n- fix ownership-mode lowering around pointer/value returns, if guards, generic receiver calls, and related type propagation\n\nTests:\n- ./vnew -silent test vlib/v3/tests/ownership/ownership_test.v\n- ./vnew -silent vlib/v/compiler_errors_test.v