### PR TITLE
cgen: include Boehm header before spawn wrappers

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1323,6 +1323,7 @@ pub fn (mut g Gen) init() {
 	}
 	if g.pref.gc_mode in [.boehm_full, .boehm_incr, .boehm_full_opt, .boehm_incr_opt, .boehm_leak] {
 		g.comptime_definitions.writeln('#define _VGCBOEHM (1)')
+		g.includes.writeln(get_boehm_early_include_text())
 	}
 	if g.pref.is_debug {
 		g.comptime_definitions.writeln('#define _VDEBUG (1)')
@@ -14695,6 +14696,25 @@ fn (mut g Gen) panic_debug_info(pos token.Pos) (int, string, string, string) {
 	pafn := g.fn_decl.name.after('.')
 	pamod := g.fn_decl.modname()
 	return paline, pafile, pamod, pafn
+}
+
+fn get_boehm_early_include_text() string {
+	res := '
+	|#ifdef __TINYC__
+	|#include <gc/gc.h>
+	|#else
+	|#if defined(__has_include)
+	|#if __has_include(<gc/gc.h>)
+	|#include <gc/gc.h>
+	|#elif __has_include(<gc.h>)
+	|#include <gc.h>
+	|#endif
+	|#else
+	|#include <gc/gc.h>
+	|#endif
+	|#endif
+	'.strip_margin()
+	return res
 }
 
 // get_guarded_include_text returns C preprocessor code that includes `iname`

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -591,6 +591,37 @@ fn test_user_defined_windows_dllmain_disables_generated_entrypoint() {
 	assert !compilation.output.contains('case DLL_PROCESS_ATTACH')
 }
 
+fn test_boehm_gc_header_precedes_imported_module_spawn_wrappers() {
+	os.chdir(vroot) or {}
+	test_source := os.join_path(os.vtmp_dir(), 'coutput_boehm_gc_spawn_include_order.vv')
+	source_lines := [
+		'module main',
+		'',
+		'import fasthttp',
+		'',
+		'fn handler(_ fasthttp.HttpRequest) !fasthttp.HttpResponse {',
+		"\treturn fasthttp.HttpResponse{content: 'HTTP/1.1 200 OK\\r\\nContent-Length: 0\\r\\n\\r\\n'.bytes()}",
+		'}',
+		'',
+		'fn main() {',
+		'\tmut server := fasthttp.new_server(handler: handler)!',
+		'\tserver.run()!',
+		'}',
+	]
+	os.write_file(test_source, source_lines.join('\n') + '\n')!
+	defer {
+		os.rm(test_source) or {}
+	}
+	cmd := '${os.quoted_path(vexe)} -os linux -gc boehm -o - ${os.quoted_path(test_source)}'
+	compilation := os.execute(cmd)
+	ensure_compilation_succeeded(compilation, cmd)
+	gc_include_pos := compilation.output.index('#include <gc/gc.h>') or { -1 }
+	pthread_create_pos := compilation.output.index('pthread_create(&thread_') or { -1 }
+	assert gc_include_pos >= 0
+	assert pthread_create_pos >= 0
+	assert gc_include_pos < pthread_create_pos
+}
+
 fn test_array_sort_with_compare_uses_stable_sort_adapters() {
 	os.chdir(vroot) or {}
 	test_source := os.join_path(os.vtmp_dir(), 'coutput_array_sort_with_compare_stable_sort.vv')


### PR DESCRIPTION
Fixes #27691.

## Summary
- include the Boehm GC header early for Boehm builds, before generated spawn wrappers from imported modules
- keep the existing later guarded Boehm include responsible for missing-header diagnostics
- add a coutput regression covering fasthttp worker spawn include ordering

## Testing
- `./vnew fmt -w vlib/v/gen/c/cgen.v vlib/v/gen/c/coutput_test.v`
- `VTEST_ONLY=test_boehm_gc_header_precedes_imported_module_spawn_wrappers ./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/`