### PR TITLE
toml: handle comments in nested array tables

### DIFF
--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -318,7 +318,7 @@ fn (mut p Parser) peek_key_at(offset int) !(string, int, bool) {
 			mut next_offset := offset + 1
 			for {
 				next_tok := p.peek_token_at(next_offset)!
-				if next_tok.kind !in [.bare, .minus, .number, .underscore] {
+				if next_tok.kind !in [.bare, .boolean, .minus, .number, .underscore] {
 					break
 				}
 				lit += next_tok.lit

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -1234,6 +1234,11 @@ pub fn (mut p Parser) double_array_of_tables_contents(target_key DottedKey) ![]a
 						' could not parse "${p.tok.kind}" "${p.tok.lit}" in this (excerpt): "...${p.excerpt()}..."')
 				}
 			}
+			.hash {
+				c := p.comment()
+				p.ast_root.comments << c
+				util.printdbg(@MOD + '.' + @STRUCT + '.' + @FN, 'skipping comment "${c.text}"')
+			}
 			else {
 				break
 			}

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -258,6 +258,89 @@ fn (mut p Parser) peek_over(i int, tokens []token.Kind) !(token.Token, int) {
 	return peek_tok, peek_i
 }
 
+fn (mut p Parser) peek_token_at(offset int) !token.Token {
+	if offset == 0 {
+		return p.peek_tok
+	}
+	return p.peek(offset)!
+}
+
+fn unquoted_key_lit(lit string) string {
+	if lit.len < 2 {
+		return lit
+	}
+	quote := lit[0]
+	if lit.len >= 6 && lit[1] == quote && lit[2] == quote {
+		return lit[3..lit.len - 3]
+	}
+	return lit[1..lit.len - 1]
+}
+
+fn (mut p Parser) peek_key_at(offset int) !(string, int, bool) {
+	tok := p.peek_token_at(offset)!
+	match tok.kind {
+		.quoted {
+			return unquoted_key_lit(tok.lit), offset + 1, true
+		}
+		.bare, .boolean, .number, .minus, .underscore {
+			mut lit := tok.lit
+			mut next_offset := offset + 1
+			for {
+				next_tok := p.peek_token_at(next_offset)!
+				if next_tok.kind !in [.bare, .minus, .underscore] {
+					break
+				}
+				lit += next_tok.lit
+				next_offset++
+			}
+			return lit, next_offset, true
+		}
+		else {
+			return '', offset, false
+		}
+	}
+}
+
+fn (mut p Parser) peek_dotted_key_after_lsbr() !DottedKey {
+	mut dotted_key := DottedKey([]string{})
+	mut offset := 0
+	for {
+		tok := p.peek_token_at(offset)!
+		if tok.kind !in space_formatting_kinds() {
+			break
+		}
+		offset++
+	}
+	for {
+		key, next_offset, ok := p.peek_key_at(offset)!
+		if !ok {
+			break
+		}
+		dotted_key << key
+		offset = next_offset
+		for {
+			tok := p.peek_token_at(offset)!
+			if tok.kind !in space_formatting_kinds() {
+				break
+			}
+			offset++
+		}
+		tok := p.peek_token_at(offset)!
+		if tok.kind != .period {
+			break
+		}
+		offset++
+		for {
+			next_tok := p.peek_token_at(offset)!
+			if next_tok.kind !in space_formatting_kinds() {
+				break
+			}
+			offset++
+		}
+	}
+	return dotted_key
+}
+
 // is_at returns true if the token kind is equal to `expected_token`.
 fn (mut p Parser) is_at(expected_token token.Kind) bool {
 	return p.tok.kind == expected_token
@@ -1168,6 +1251,12 @@ pub fn (mut p Parser) double_array_of_tables_contents(target_key DottedKey) ![]a
 				mut arr := []ast.Value{}
 				arr << tbl
 				return arr
+			}
+		}
+		if p.tok.kind == .lsbr {
+			dotted_key := p.peek_dotted_key_after_lsbr()!
+			if dotted_key.len <= target_key.len || !dotted_key.starts_with(target_key) {
+				break
 			}
 		}
 

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -265,22 +265,53 @@ fn (mut p Parser) peek_token_at(offset int) !token.Token {
 	return p.peek(offset)!
 }
 
-fn unquoted_key_lit(lit string) string {
-	if lit.len < 2 {
-		return lit
+fn quoted_from_token(tok token.Token) ast.Quoted {
+	if tok.lit.len < 2 {
+		return ast.Quoted{
+			text: tok.lit
+			pos:  tok.pos()
+		}
 	}
-	quote := lit[0]
-	if lit.len >= 6 && lit[1] == quote && lit[2] == quote {
-		return lit[3..lit.len - 3]
+	quote := tok.lit[0]
+	is_multiline := tok.lit.len >= 6 && tok.lit[1] == quote && tok.lit[2] == quote
+	mut lit := tok.lit[1..tok.lit.len - 1]
+	if is_multiline {
+		lit = tok.lit[3..tok.lit.len - 3]
+		if lit.len > 0 && lit[0] == `\n` {
+			lit = lit[1..]
+		}
 	}
-	return lit[1..lit.len - 1]
+	return ast.Quoted{
+		text:         lit
+		pos:          tok.pos()
+		quote:        quote
+		is_multiline: is_multiline
+	}
+}
+
+fn (mut p Parser) decoded_quoted_key_lit(tok token.Token) !string {
+	mut quoted := quoted_from_token(tok)
+	if p.config.run_checks {
+		if quoted.is_multiline {
+			return error(@MOD + '.' + @STRUCT + '.' + @FN +
+				' multiline string as key is not allowed. (excerpt): "...${p.scanner.excerpt(tok.pos, 10)}..."')
+		}
+		chckr := checker.Checker{
+			scanner: p.scanner
+		}
+		chckr.check_quoted(quoted)!
+	}
+	if p.config.decode_values {
+		decoder.decode_quoted_escapes(mut quoted)!
+	}
+	return quoted.text
 }
 
 fn (mut p Parser) peek_key_at(offset int) !(string, int, bool) {
 	tok := p.peek_token_at(offset)!
 	match tok.kind {
 		.quoted {
-			return unquoted_key_lit(tok.lit), offset + 1, true
+			return p.decoded_quoted_key_lit(tok)!, offset + 1, true
 		}
 		.bare, .boolean, .number, .minus, .underscore {
 			mut lit := tok.lit
@@ -1660,25 +1691,7 @@ pub fn (mut p Parser) bare() !ast.Bare {
 pub fn (mut p Parser) quoted() ast.Quoted {
 	// To get more info about the quote type and enable better checking,
 	// the scanner is returning the literal *with* single- or double-quotes.
-	mut quote := p.tok.lit[0]
-	is_multiline := p.tok.lit.len >= 6 && p.tok.lit[1] == quote && p.tok.lit[2] == quote
-	mut lit := p.tok.lit[1..p.tok.lit.len - 1]
-	if is_multiline {
-		lit = p.tok.lit[3..p.tok.lit.len - 3]
-		// From https://toml.io/en/v1.0.0#string
-		// "Multi-line literal strings [...] A newline immediately following the opening
-		// delimiter will be trimmed. All other content between the delimiters
-		// is interpreted as-is without modification."
-		if lit.len > 0 && lit[0] == `\n` {
-			lit = lit[1..]
-		}
-	}
-	return ast.Quoted{
-		text:         lit
-		pos:          p.tok.pos()
-		quote:        quote
-		is_multiline: is_multiline
-	}
+	return quoted_from_token(p.tok)
 }
 
 // boolean parse and returns an `ast.Bool` type.

--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -287,7 +287,7 @@ fn (mut p Parser) peek_key_at(offset int) !(string, int, bool) {
 			mut next_offset := offset + 1
 			for {
 				next_tok := p.peek_token_at(next_offset)!
-				if next_tok.kind !in [.bare, .minus, .underscore] {
+				if next_tok.kind !in [.bare, .minus, .number, .underscore] {
 					break
 				}
 				lit += next_tok.lit

--- a/vlib/toml/tests/array_of_tables_2_level_test.v
+++ b/vlib/toml/tests/array_of_tables_2_level_test.v
@@ -30,3 +30,19 @@ fn test_nested_array_of_tables() {
 
 	assert toml_json == os.read_file(fprefix + '.out')!
 }
+
+fn test_nested_array_of_tables_with_comment_before_key() {
+	toml_doc := toml.parse_text('[[a]]
+n = "x"
+[[a.b]]
+p = "1"  # comment
+q = "2"
+[[a.b]]
+p = "3"
+# comment
+q = "4"
+')!
+
+	toml_json := to.json(toml_doc)
+	assert toml_json == '{ "a": [ { "n": "x", "b": [ { "p": "1", "q": "2" }, { "p": "3", "q": "4" } ] } ] }'
+}

--- a/vlib/toml/tests/array_of_tables_2_level_test.v
+++ b/vlib/toml/tests/array_of_tables_2_level_test.v
@@ -74,3 +74,17 @@ q = "2"
 	toml_json := to.json(toml_doc)
 	assert toml_json == '{ "a": [ { "n": "x", "b": [ { "p": "1", "c": { "q": "2" } } ] } ] }'
 }
+
+fn test_nested_array_of_tables_with_numeric_dashed_key_child_subtable() {
+	toml_doc := toml.parse_text('[[a]]
+n = "x"
+[[a.1-2]]
+p = "1"
+# comment
+[a.1-2.c]
+q = "2"
+')!
+
+	toml_json := to.json(toml_doc)
+	assert toml_json == '{ "a": [ { "n": "x", "1-2": [ { "p": "1", "c": { "q": "2" } } ] } ] }'
+}

--- a/vlib/toml/tests/array_of_tables_2_level_test.v
+++ b/vlib/toml/tests/array_of_tables_2_level_test.v
@@ -46,3 +46,31 @@ q = "4"
 	toml_json := to.json(toml_doc)
 	assert toml_json == '{ "a": [ { "n": "x", "b": [ { "p": "1", "q": "2" }, { "p": "3", "q": "4" } ] } ] }'
 }
+
+fn test_nested_array_of_tables_with_comment_before_parent_subtable() {
+	toml_doc := toml.parse_text('[[a]]
+n = "x"
+[[a.b]]
+p = "1"
+# comment
+[a.c]
+q = "2"
+')!
+
+	toml_json := to.json(toml_doc)
+	assert toml_json == '{ "a": [ { "n": "x", "b": [ { "p": "1" } ], "c": { "q": "2" } } ] }'
+}
+
+fn test_nested_array_of_tables_with_comment_before_child_subtable() {
+	toml_doc := toml.parse_text('[[a]]
+n = "x"
+[[a.b]]
+p = "1"
+# comment
+[a.b.c]
+q = "2"
+')!
+
+	toml_json := to.json(toml_doc)
+	assert toml_json == '{ "a": [ { "n": "x", "b": [ { "p": "1", "c": { "q": "2" } } ] } ] }'
+}

--- a/vlib/toml/tests/array_of_tables_2_level_test.v
+++ b/vlib/toml/tests/array_of_tables_2_level_test.v
@@ -89,6 +89,20 @@ q = "2"
 	assert toml_json == '{ "a": [ { "n": "x", "1-2": [ { "p": "1", "c": { "q": "2" } } ] } ] }'
 }
 
+fn test_nested_array_of_tables_with_numeric_boolean_key_child_subtable() {
+	toml_doc := toml.parse_text('[[a]]
+n = "x"
+[[a.1-true]]
+p = "1"
+# comment
+[a.1-true.c]
+q = "2"
+')!
+
+	toml_json := to.json(toml_doc)
+	assert toml_json == '{ "a": [ { "n": "x", "1-true": [ { "p": "1", "c": { "q": "2" } } ] } ] }'
+}
+
 fn test_nested_array_of_tables_with_escaped_quoted_key_child_subtable() {
 	toml_doc := toml.parse_text('[[a]]
 n = "x"

--- a/vlib/toml/tests/array_of_tables_2_level_test.v
+++ b/vlib/toml/tests/array_of_tables_2_level_test.v
@@ -88,3 +88,17 @@ q = "2"
 	toml_json := to.json(toml_doc)
 	assert toml_json == '{ "a": [ { "n": "x", "1-2": [ { "p": "1", "c": { "q": "2" } } ] } ] }'
 }
+
+fn test_nested_array_of_tables_with_escaped_quoted_key_child_subtable() {
+	toml_doc := toml.parse_text('[[a]]
+n = "x"
+[[a."b\\"c"]]
+p = "1"
+# comment
+[a."b\\"c".d]
+q = "2"
+')!
+
+	toml_json := to.json(toml_doc)
+	assert toml_json == '{ "a": [ { "n": "x", "b"c": [ { "p": "1", "d": { "q": "2" } } ] } ] }'
+}


### PR DESCRIPTION
## Summary
- keep parsing nested array-of-table contents after comment tokens
- add regression coverage for trailing and own-line comments before the next key

Fixes #27684

## Tests
- ./vnew -silent test vlib/toml/tests/array_of_tables_2_level_test.v
- ./vnew -silent test vlib/toml/