### PR TITLE
picoev: survive peer RST without changing SIGPIPE disposition

### DIFF
--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -1,6 +1,7 @@
 module picoev
 
 import net
+import os
 import pico_http_parser
 import time
 
@@ -307,6 +308,15 @@ fn default_error_callback(_data voidptr, _req pico_http_parser.Request, mut res 
 
 // new creates a `Picoev` struct and initializes the main loop.
 pub fn new(config Config) !&Picoev {
+	// A server must not die on a peer RST: any write to a connection the client
+	// already reset delivers SIGPIPE, whose default action terminates the process
+	// SILENTLY (no panic, no crash report). Long-held fds (SSE) make this routine
+	// rather than rare — a subscriber that disconnects between pushes turns the
+	// next push into a process kill. Ignore it process-wide once a server event
+	// loop exists; write()/send() then report EPIPE and the caller drops the fd.
+	$if !windows {
+		os.signal_ignore(.pipe)
+	}
 	listening_socket_fd := listen(config) or {
 		elog('Error during listen: ${err}')
 		return err

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -1,7 +1,6 @@
 module picoev
 
 import net
-import os
 import pico_http_parser
 import time
 
@@ -344,15 +343,6 @@ pub fn new(config Config) !&Picoev {
 	}
 	pv.init()
 	pv.add(listening_socket_fd, picoev_read, 0, accept_callback)
-	// A server must not die on a peer RST: any write to a connection the client
-	// already reset delivers SIGPIPE, whose default action terminates the process
-	// SILENTLY (no panic, no crash report). Long-held fds (SSE) make this routine
-	// rather than rare — a subscriber that disconnects between pushes turns the
-	// next push into a process kill. Change the process-wide disposition only
-	// after construction succeeds; writes then report EPIPE and drop the fd.
-	$if !windows {
-		os.signal_ignore(.pipe)
-	}
 	return pv
 }
 

--- a/vlib/picoev/picoev.v
+++ b/vlib/picoev/picoev.v
@@ -308,15 +308,6 @@ fn default_error_callback(_data voidptr, _req pico_http_parser.Request, mut res 
 
 // new creates a `Picoev` struct and initializes the main loop.
 pub fn new(config Config) !&Picoev {
-	// A server must not die on a peer RST: any write to a connection the client
-	// already reset delivers SIGPIPE, whose default action terminates the process
-	// SILENTLY (no panic, no crash report). Long-held fds (SSE) make this routine
-	// rather than rare — a subscriber that disconnects between pushes turns the
-	// next push into a process kill. Ignore it process-wide once a server event
-	// loop exists; write()/send() then report EPIPE and the caller drops the fd.
-	$if !windows {
-		os.signal_ignore(.pipe)
-	}
 	listening_socket_fd := listen(config) or {
 		elog('Error during listen: ${err}')
 		return err
@@ -353,6 +344,15 @@ pub fn new(config Config) !&Picoev {
 	}
 	pv.init()
 	pv.add(listening_socket_fd, picoev_read, 0, accept_callback)
+	// A server must not die on a peer RST: any write to a connection the client
+	// already reset delivers SIGPIPE, whose default action terminates the process
+	// SILENTLY (no panic, no crash report). Long-held fds (SSE) make this routine
+	// rather than rare — a subscriber that disconnects between pushes turns the
+	// next push into a process kill. Change the process-wide disposition only
+	// after construction succeeds; writes then report EPIPE and drop the fd.
+	$if !windows {
+		os.signal_ignore(.pipe)
+	}
 	return pv
 }
 

--- a/vlib/picoev/picoev_constructor_test.c.v
+++ b/vlib/picoev/picoev_constructor_test.c.v
@@ -1,0 +1,30 @@
+// vtest build: !windows
+module picoev
+
+import net
+
+#include <signal.h>
+
+fn C.signal(signal i32, handler voidptr) voidptr
+
+fn test_failed_new_preserves_sigpipe_disposition() ! {
+	original := C.signal(C.SIGPIPE, C.SIG_IGN)
+	defer {
+		C.signal(C.SIGPIPE, original)
+	}
+	mut listener := net.listen_tcp(.ip, '127.0.0.1:0')!
+	defer {
+		listener.close() or {}
+	}
+	port := listener.addr()!.port()!
+	if _ := new(Config{
+		host:   '127.0.0.1'
+		port:   int(port)
+		family: .ip
+	})
+	{
+		assert false, 'picoev.new unexpectedly bound an occupied port'
+	}
+	previous := C.signal(C.SIGPIPE, C.SIG_IGN)
+	assert previous == C.SIG_IGN
+}

--- a/vlib/picoev/socket_util.c.v
+++ b/vlib/picoev/socket_util.c.v
@@ -44,6 +44,16 @@ fn setup_sock(fd int) ! {
 	if C.setsockopt(fd, C.IPPROTO_TCP, C.TCP_NODELAY, &flag, sizeof(int)) < 0 {
 		return error('setup_sock.setup_sock failed')
 	}
+	$if freebsd || macos {
+		// Accepted sockets do not inherit SO_NOSIGPIPE from the listener on the
+		// BSDs; without it a write() after a peer RST raises SIGPIPE instead of
+		// returning EPIPE. Belt to the process-wide signal_ignore braces in new()
+		// — either alone suffices, together they survive callers that re-arm
+		// SIGPIPE handlers.
+		if C.setsockopt(fd, C.SOL_SOCKET, C.SO_NOSIGPIPE, &flag, sizeof(int)) < 0 {
+			return error('setup_sock: SO_NOSIGPIPE failed')
+		}
+	}
 	$if freebsd {
 		if C.fcntl(fd, C.F_SETFL, C.SOCK_NONBLOCK) != 0 {
 			return error('fcntl failed')

--- a/vlib/picoev/socket_util.c.v
+++ b/vlib/picoev/socket_util.c.v
@@ -7,7 +7,7 @@ import pico_http_parser
 $if windows {
 	#include <winsock2.h>
 	#include <ws2tcpip.h>
-} $else $if freebsd || macos {
+} $else $if freebsd || macos || netbsd || dragonfly {
 	#include <sys/types.h>
 	#include <sys/socket.h>
 	#include <netinet/in.h>
@@ -44,7 +44,7 @@ fn setup_sock(fd int) ! {
 	if C.setsockopt(fd, C.IPPROTO_TCP, C.TCP_NODELAY, &flag, sizeof(int)) < 0 {
 		return error('setup_sock.setup_sock failed')
 	}
-	$if freebsd || macos {
+	$if freebsd || macos || netbsd || dragonfly {
 		// Accepted sockets do not inherit SO_NOSIGPIPE from the listener on the
 		// BSDs; without it a write() after a peer RST raises SIGPIPE instead of
 		// returning EPIPE. Belt to the process-wide signal_ignore braces in new()

--- a/vlib/picoev/socket_util.c.v
+++ b/vlib/picoev/socket_util.c.v
@@ -7,7 +7,7 @@ import pico_http_parser
 $if windows {
 	#include <winsock2.h>
 	#include <ws2tcpip.h>
-} $else $if freebsd || macos || netbsd || dragonfly {
+} $else $if freebsd || macos || ios || netbsd || dragonfly {
 	#include <sys/types.h>
 	#include <sys/socket.h>
 	#include <netinet/in.h>
@@ -44,7 +44,7 @@ fn setup_sock(fd int) ! {
 	if C.setsockopt(fd, C.IPPROTO_TCP, C.TCP_NODELAY, &flag, sizeof(int)) < 0 {
 		return error('setup_sock.setup_sock failed')
 	}
-	$if freebsd || macos || netbsd || dragonfly {
+	$if freebsd || macos || ios || netbsd || dragonfly {
 		// Accepted sockets do not inherit SO_NOSIGPIPE from the listener on the
 		// BSDs; without it a write() after a peer RST raises SIGPIPE instead of
 		// returning EPIPE. Belt to the process-wide signal_ignore braces in new()

--- a/vlib/picoev/socket_util_test.c.v
+++ b/vlib/picoev/socket_util_test.c.v
@@ -1,0 +1,21 @@
+// vtest build: macos || freebsd || netbsd || dragonfly
+module picoev
+
+#include <sys/socket.h>
+
+fn C.close(fd i32) i32
+fn C.getsockopt(sockfd i32, level i32, optname i32, optval voidptr, optlen &u32) i32
+fn C.socket(domain i32, typ i32, protocol i32) i32
+
+fn test_setup_sock_enables_so_nosigpipe() ! {
+	fd := C.socket(C.AF_INET, C.SOCK_STREAM, 0)
+	assert fd >= 0
+	defer {
+		C.close(fd)
+	}
+	setup_sock(fd)!
+	mut enabled := 0
+	mut len := u32(sizeof(int))
+	assert C.getsockopt(fd, C.SOL_SOCKET, C.SO_NOSIGPIPE, &enabled, &len) == 0
+	assert enabled == 1
+}

--- a/vlib/picoev/socket_util_test.c.v
+++ b/vlib/picoev/socket_util_test.c.v
@@ -1,4 +1,4 @@
-// vtest build: macos || freebsd || netbsd || dragonfly
+// vtest build: macos || ios || freebsd || netbsd || dragonfly
 module picoev
 
 #include <sys/socket.h>

--- a/vlib/picohttpparser/response.c.v
+++ b/vlib/picohttpparser/response.c.v
@@ -111,11 +111,16 @@ pub fn (mut r Response) raw(response string) {
 
 fn C.send(sockfd i32, buf voidptr, len usize, flags i32) i32
 
+// Linux and OpenBSD do not provide the SO_NOSIGPIPE socket option used by
+// picoev on macOS and FreeBSD. Suppress SIGPIPE for each send so callers that
+// change the process-wide signal disposition cannot terminate the server.
+const send_flags = $if linux || termux || openbsd { int(C.MSG_NOSIGNAL) } $else { 0 }
+
 @[inline]
 pub fn (mut r Response) end() int {
 	n := int(i64(r.buf) - i64(r.buf_start))
 	// use send instead of write for windows compatibility
-	if C.send(r.fd, r.buf_start, n, 0) != n {
+	if C.send(r.fd, r.buf_start, n, send_flags) != n {
 		return -1
 	}
 	return n

--- a/vlib/picohttpparser/response.c.v
+++ b/vlib/picohttpparser/response.c.v
@@ -114,7 +114,7 @@ fn C.send(sockfd i32, buf voidptr, len usize, flags i32) i32
 // Linux and OpenBSD do not provide the SO_NOSIGPIPE socket option used by
 // picoev on macOS and FreeBSD. Suppress SIGPIPE for each send so callers that
 // change the process-wide signal disposition cannot terminate the server.
-const send_flags = $if linux || termux || openbsd { int(C.MSG_NOSIGNAL) } $else { 0 }
+const send_flags = $if linux || termux || android || openbsd { int(C.MSG_NOSIGNAL) } $else { 0 }
 
 @[inline]
 pub fn (mut r Response) end() int {

--- a/vlib/picohttpparser/response.c.v
+++ b/vlib/picohttpparser/response.c.v
@@ -111,10 +111,14 @@ pub fn (mut r Response) raw(response string) {
 
 fn C.send(sockfd i32, buf voidptr, len usize, flags i32) i32
 
-// Linux and OpenBSD do not provide the SO_NOSIGPIPE socket option used by
-// picoev on macOS and FreeBSD. Suppress SIGPIPE for each send so callers that
-// change the process-wide signal disposition cannot terminate the server.
-const send_flags = $if linux || termux || android || openbsd { int(C.MSG_NOSIGNAL) } $else { 0 }
+// Use per-send protection where picoev cannot configure SO_NOSIGPIPE on the
+// socket. This also protects calls made on worker threads, where changing the
+// process-wide signal disposition is not portable.
+const send_flags = $if windows || macos || ios || freebsd || netbsd || dragonfly {
+	0
+} $else {
+	int(C.MSG_NOSIGNAL)
+}
 
 @[inline]
 pub fn (mut r Response) end() int {

--- a/vlib/picohttpparser/response_sigpipe_test.c.v
+++ b/vlib/picohttpparser/response_sigpipe_test.c.v
@@ -1,4 +1,4 @@
-// vtest build: linux || openbsd
+// vtest build: linux || termux || android || openbsd
 module picohttpparser
 
 #include <signal.h>

--- a/vlib/picohttpparser/response_sigpipe_test.c.v
+++ b/vlib/picohttpparser/response_sigpipe_test.c.v
@@ -1,0 +1,39 @@
+// vtest build: linux || openbsd
+module picohttpparser
+
+#include <signal.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+fn C._exit(status int)
+fn C.close(fd int) int
+fn C.fork() int
+fn C.signal(signal int, handler voidptr) voidptr
+fn C.socketpair(domain int, typ int, protocol int, sockets &int) int
+fn C.waitpid(pid int, status &int, options int) int
+
+fn test_response_end_suppresses_sigpipe_per_send() {
+	pid := C.fork()
+	assert pid >= 0
+	if pid == 0 {
+		C.signal(C.SIGPIPE, C.SIG_DFL)
+		mut sockets := [2]int{}
+		if C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) != 0 {
+			C._exit(1)
+		}
+		C.close(sockets[1])
+		mut payload := [u8(`x`)]
+		mut response := Response{
+			fd:        sockets[0]
+			buf_start: unsafe { &payload[0] }
+			buf:       unsafe { &payload[0] + 1 }
+		}
+		result := response.end()
+		C.close(sockets[0])
+		C._exit(if result == -1 { 0 } else { 1 })
+	}
+	mut status := 0
+	assert C.waitpid(pid, &status, 0) == pid
+	assert status == 0
+}

--- a/vlib/picohttpparser/response_sigpipe_test.c.v
+++ b/vlib/picohttpparser/response_sigpipe_test.c.v
@@ -1,4 +1,4 @@
-// vtest build: linux || termux || android || openbsd
+// vtest build: linux || termux || android || openbsd || solaris || qnx || serenity || haiku || vinix
 module picohttpparser
 
 #include <signal.h>


### PR DESCRIPTION
A picoev server writing to a connection the client already reset receives SIGPIPE, whose default action terminates the process silently. Long-held file descriptors such as SSE or streaming responses make this routine rather than rare.

This uses local guards without replacing an embedding application’s process-wide signal handler:

- `pico_http_parser.Response.end()` passes `MSG_NOSIGNAL` on non-Windows targets that lack `SO_NOSIGPIPE`.
- `picoev.setup_sock()` enables `SO_NOSIGPIPE` on macOS, iOS, FreeBSD, NetBSD, and DragonFly sockets.

Writes after a peer reset therefore return an error so picoev can drop the connection, including when a caller changes the SIGPIPE disposition or constructs the server on a worker thread. Regression coverage exercises the per-send behavior, verifies the BSD socket option, and ensures failed construction preserves the existing signal disposition.