### PR TITLE
veb: preserve middleware response context

### DIFF
--- a/vlib/veb/context.v
+++ b/vlib/veb/context.v
@@ -83,6 +83,33 @@ pub mut:
 	livereload_poll_interval_ms int = 250
 }
 
+fn clone_response_writer_header(header http.Header) http.Header {
+	mut cloned := http.new_header()
+	mut seen := map[string]bool{}
+	for key in header.keys() {
+		if key in seen {
+			continue
+		}
+		seen[key] = true
+		for value in header.custom_values(key, exact: true) {
+			cloned.add_custom(key.clone(), value.clone()) or {}
+		}
+	}
+	return cloned
+}
+
+fn (mut ctx Context) preserve_for_response_writer(user_context Context) {
+	unsafe {
+		*ctx = user_context
+	}
+	ctx.res.body = user_context.res.body.clone()
+	ctx.res.header = clone_response_writer_header(user_context.res.header)
+	ctx.res.status_msg = user_context.res.status_msg.clone()
+	ctx.res.http_version = user_context.res.http_version.clone()
+	ctx.req.header = clone_response_writer_header(user_context.req.header)
+	ctx.return_file = user_context.return_file.clone()
+}
+
 // returns the request header data from the key
 pub fn (ctx &Context) get_header(key http.CommonHeader) ?string {
 	return ctx.req.header.get(key)

--- a/vlib/veb/controller.v
+++ b/vlib/veb/controller.v
@@ -59,9 +59,8 @@ pub fn controller[A, X](path string, mut global_app A) !&ControllerPath {
 
 			handle_route[A, X](mut global_app, mut user_context, url, host, &routes)
 			// Preserve the handled context on the heap before the stack-local user context goes away.
-			unsafe {
-				*ctx = user_context.Context
-			}
+			mut ctx_mut := unsafe { &Context(ctx) }
+			ctx_mut.preserve_for_response_writer(user_context.Context)
 			return ctx
 		}
 	}

--- a/vlib/veb/middleware_response_lifetime_test.v
+++ b/vlib/veb/middleware_response_lifetime_test.v
@@ -1,0 +1,81 @@
+module veb
+
+import net.http
+
+struct MiddlewareLifetimeContext {
+	Context
+}
+
+@[heap]
+struct MiddlewareLifetimeApp {
+	Middleware[MiddlewareLifetimeContext]
+}
+
+fn (mut app MiddlewareLifetimeApp) lookup(mut ctx MiddlewareLifetimeContext) bool {
+	mut rows := []string{cap: 128}
+	for i in 0 .. 128 {
+		rows << '${ctx.req.url}:${i}:allocated before rejection'
+	}
+	_ = rows.len
+	return true
+}
+
+fn (mut app MiddlewareLifetimeApp) reject_posts(mut ctx MiddlewareLifetimeContext) bool {
+	if ctx.req.method == .post {
+		ctx.res.set_status(.forbidden)
+		ctx.res.header.add(.set_cookie, 'first=1')
+		ctx.res.header.add_custom('X-Between-Cookies', 'yes') or { panic(err) }
+		ctx.res.header.add(.set_cookie, 'second=2')
+		ctx.res.header.add_custom('X-Rejected-By', 'middleware') or { panic(err) }
+		ctx.text('Forbidden')
+		return false
+	}
+	return true
+}
+
+@['/'; get; post]
+fn (mut app MiddlewareLifetimeApp) index(mut ctx MiddlewareLifetimeContext) Result {
+	return ctx.text('ok')
+}
+
+fn test_middleware_terminated_response_survives_after_handler_returns() {
+	mut app := &MiddlewareLifetimeApp{}
+	app.use(handler: app.lookup)
+	app.use(handler: app.reject_posts)
+	routes := generate_routes[MiddlewareLifetimeApp, MiddlewareLifetimeContext](app) or {
+		panic(err)
+	}
+	controllers_sorted := check_duplicate_routes_in_controllers[MiddlewareLifetimeApp](app, routes) or {
+		panic(err)
+	}
+	params := RequestParams{
+		global_app:         unsafe { voidptr(app) }
+		controllers_sorted: controllers_sorted
+		routes:             &routes
+	}
+	req := http.Request{
+		method: .post
+		url:    '/'
+		data:   'x=1'
+		header: http.new_custom_header_from_map({
+			'Host':           '127.0.0.1'
+			'Content-Length': '3'
+		}) or { panic(err) }
+	}
+	completed_context := handle_request_and_route[MiddlewareLifetimeApp, MiddlewareLifetimeContext](mut app,
+		req, 0, params)
+	mut churn := []string{cap: 512}
+	for i in 0 .. 512 {
+		churn << 'after route ${i}'
+	}
+	_ = churn.len
+	gc_collect()
+	raw := completed_context.res.bytestr()
+	assert raw.starts_with('HTTP/1.1 403 Forbidden\r\n'), raw
+	assert raw.contains('X-Rejected-By: middleware\r\n'), raw
+	assert raw.contains('X-Between-Cookies: yes\r\n'), raw
+	assert raw.count('Set-Cookie: first=1\r\n') == 1, raw
+	assert raw.count('Set-Cookie: second=2\r\n') == 1, raw
+	assert raw.count('Set-Cookie:') == 2, raw
+	assert raw.ends_with('\r\n\r\nForbidden'), raw
+}

--- a/vlib/veb/veb.v
+++ b/vlib/veb/veb.v
@@ -220,9 +220,7 @@ fn handle_ssl_request[A, X](req http.Request, params &SslRequestParams) ?&Contex
 			user_context, url, host)
 		{
 			// Preserve the handled context on the heap before the stack-local user context goes away.
-			unsafe {
-				*ctx = user_context.Context
-			}
+			ctx.preserve_for_response_writer(user_context.Context)
 			return ctx
 		}
 	}
@@ -233,9 +231,7 @@ fn handle_ssl_request[A, X](req http.Request, params &SslRequestParams) ?&Contex
 	}
 	handle_route[A, X](mut global_app, mut user_context, url, host, params.routes)
 	// Preserve the handled context on the heap before the stack-local user context goes away.
-	unsafe {
-		*ctx = user_context.Context
-	}
+	ctx.preserve_for_response_writer(user_context.Context)
 	return ctx
 }
 

--- a/vlib/veb/veb_fasthttp.v
+++ b/vlib/veb/veb_fasthttp.v
@@ -248,9 +248,7 @@ fn handle_request_and_route[A, X](mut app A, req http.Request, _client_fd int, p
 			url, host)
 		{
 			// Preserve the handled context on the heap before the stack-local user context goes away.
-			unsafe {
-				*ctx = user_context.Context
-			}
+			ctx.preserve_for_response_writer(user_context.Context)
 			return ctx
 		}
 	}
@@ -269,9 +267,7 @@ fn handle_request_and_route[A, X](mut app A, req http.Request, _client_fd int, p
 		unsafe { prealloc_scope_checkpoint(c'veb route returned') }
 	}
 	// Preserve the handled context on the heap before the stack-local user context goes away.
-	unsafe {
-		*ctx = user_context.Context
-	}
+	ctx.preserve_for_response_writer(user_context.Context)
 	return ctx
 }
 


### PR DESCRIPTION
Fixes #27695.

This preserves the response/request strings that veb's response writer reads after the stack-local user context has returned. Middleware that terminates a request now keeps its status line, headers, and body stable until fasthttp serializes the response.

Changes:
- replace raw `*ctx = user_context.Context` copies with `preserve_for_response_writer`
- clone response body/status/version/header data, plus request fields used by connection handling
- add a regression for middleware that allocates, terminates with `403`, then serializes after GC

Tests:
- `./vnew -silent test vlib/veb/middleware_response_lifetime_test.v`
- `./vnew -silent test vlib/veb/tests/middleware_test.v`
- `./vnew -silent test vlib/veb/controller_static_regression_test.v`
- `./vnew -silent test vlib/veb/tests/controller_test.v`
- `./vnew -silent test vlib/veb/tests/nested_embedded_controller_regression_test.v`
- `./vnew -silent test vlib/veb/`