### PR TITLE
cgen: simplify enum from_string helper

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1566,37 +1566,21 @@ fn (mut g Gen) gen_enum_static_from_string(fn_name string, mod_enum_name string,
 	enum_styp := g.styp(enum_typ)
 	option_enum_typ := enum_typ.set_flag(.option)
 	option_enum_styp := g.styp(option_enum_typ)
-	enum_field_names := g.table.get_enum_field_names(mod_enum_name)
-	enum_field_vals := g.table.get_enum_field_vals(mod_enum_name)
+	enum_decl := g.table.enum_decls[mod_enum_name]
+	enum_prefix := g.gen_enum_prefix(enum_typ)
 
 	mut fn_builder := strings.new_builder(512)
 	g.definitions.writeln('${g.static_non_parallel}${option_enum_styp} ${fn_name}(string name);')
 
 	fn_builder.writeln('${g.static_non_parallel}${option_enum_styp} ${fn_name}(string name) {')
 	fn_builder.writeln('\t${option_enum_styp} t1;')
-	fn_builder.writeln('\tbool exists = false;')
-	fn_builder.writeln('\tint inx = 0;')
-	fn_builder.writeln('\tarray field_names = ((array){.data = 0, .offset = 0, .len = 0, .cap = 0, .flags = 0, .element_size = sizeof(string)});')
-	for field_name in enum_field_names {
-		fn_builder.writeln('\tbuiltin__array_push((array*)&field_names, _MOV((string[]){ _S("${field_name}") }));')
+	for field in enum_decl.fields {
+		fn_builder.writeln('\tif (builtin__fast_string_eq(name, _S("${field.name}"))) {')
+		fn_builder.writeln('\t\tbuiltin___option_ok(&(${enum_styp}[]){ ${enum_prefix}${field.name} }, (_option*)&t1, sizeof(${enum_styp}));')
+		fn_builder.writeln('\t\treturn t1;')
+		fn_builder.writeln('\t}')
 	}
-	fn_builder.writeln('\tarray field_vals = ((array){.data = 0, .offset = 0, .len = 0, .cap = 0, .flags = 0, .element_size = sizeof(i64)});')
-	for field_val in enum_field_vals {
-		fn_builder.writeln('\tbuiltin__array_push((array*)&field_vals, _MOV((i64[]){ ${field_val} }));')
-	}
-	fn_builder.writeln('\tfor (${ast.int_type_name} i = 0; i < ${enum_field_names.len}; ++i) {')
-	fn_builder.writeln('\t\tif (builtin__fast_string_eq(name, (*(string*)builtin__array_get(field_names, i)))) {')
-	fn_builder.writeln('\t\t\texists = true;')
-	fn_builder.writeln('\t\t\tinx = i;')
-	fn_builder.writeln('\t\t\tbreak;')
-	fn_builder.writeln('\t\t}')
-	fn_builder.writeln('\t}')
-	fn_builder.writeln('\tif (exists) {')
-	fn_builder.writeln('\t\tbuiltin___option_ok(&(${enum_styp}[]){ (*(i64*)builtin__array_get(field_vals, inx)) }, (_option*)&t1, sizeof(${enum_styp}));')
-	fn_builder.writeln('\t\treturn t1;')
-	fn_builder.writeln('\t} else {')
-	fn_builder.writeln('\t\treturn (${option_enum_styp}){ .state=2, .err=_const_none__, .data={E_STRUCT} };')
-	fn_builder.writeln('\t}')
+	fn_builder.writeln('\treturn (${option_enum_styp}){ .state=2, .err=_const_none__, .data={E_STRUCT} };')
 	fn_builder.writeln('}')
 	g.auto_fn_definitions << fn_builder.str()
 }

--- a/vlib/v/tests/enums/enum_static_from_string_test.v
+++ b/vlib/v/tests/enums/enum_static_from_string_test.v
@@ -12,6 +12,11 @@ enum Color2 as i64 {
 	green
 }
 
+enum Example {
+	exam1
+	exam2
+}
+
 fn test_enum_static_from_string() {
 	color11 := Color1.from_string('red')?
 	println(color11)
@@ -36,4 +41,16 @@ fn test_enum_static_from_string() {
 	color23 := Color2.from_string('bbbbb') or { Color2.unknown }
 	println(color23)
 	assert color23 == Color2.unknown
+}
+
+fn test_enum_static_from_string_if_guard_match() {
+	str := 'exam1'
+	mut matched := ''
+	if value := Example.from_string(str) {
+		match value {
+			.exam1 { matched = 'exam1' }
+			.exam2 { matched = 'exam2' }
+		}
+	}
+	assert matched == 'exam1'
 }


### PR DESCRIPTION
Fixes #27696.

This changes the generated `Enum.from_string()` helper to compare against enum field names directly and return the corresponding enum constants. That avoids building temporary runtime arrays for the name/value mapping, which removes the array initialization path implicated by the invalid C output report.

A regression test covers using `Enum.from_string()` in an optional `if` guard followed by a `match` on the unwrapped enum value.

Tests:
- `./vnew vlib/v/tests/enums/enum_static_from_string_test.v`
- `./vnew -cc tcc vlib/v/tests/enums/enum_static_from_string_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/`