### PR TITLE
ci: stabilize x.async and x.executor Windows tests

### DIFF
--- a/vlib/sync/semaphore_windows_test.v
+++ b/vlib/sync/semaphore_windows_test.v
@@ -1,0 +1,13 @@
+module sync
+
+import time
+
+fn test_semaphore_timed_wait_reports_acquisition_after_fast_path() {
+	mut sem := new_semaphore_init(1)
+	did_acquire := sem.wait_for_available_count(time.second)
+	was_consumed := !sem.try_wait()
+	sem.destroy()
+
+	assert did_acquire
+	assert was_consumed
+}

--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -214,25 +214,30 @@ pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
 			return true
 		}
 	}
+	return sem.wait_for_available_count(timeout)
+}
+
+fn (mut sem Semaphore) wait_for_available_count(timeout time.Duration) bool {
 	mut ft_start := C._FILETIME{}
 	C.GetSystemTimeAsFileTime(&ft_start)
 	time_end := ((u64(ft_start.dwHighDateTime) << 32) | ft_start.dwLowDateTime) +
 		u64(timeout / (100 * time.nanosecond))
 	mut t_ms := u32(timeout.sys_milliseconds())
 	C.AcquireSRWLockExclusive(&sem.mtx)
-	mut res := 0
-	c = C.atomic_load_u32(&sem.count)
+	mut acquired := false
+	mut c := C.atomic_load_u32(&sem.count)
 
 	outer: for {
 		if c == 0 {
-			res = C.SleepConditionVariableSRW(&sem.cond, &sem.mtx, t_ms, 0)
-			if res == 0 {
+			sleep_result := C.SleepConditionVariableSRW(&sem.cond, &sem.mtx, t_ms, 0)
+			if sleep_result == 0 {
 				break outer
 			}
 			c = C.atomic_load_u32(&sem.count)
 		}
 		for c > 0 {
 			if C.atomic_compare_exchange_weak_u32(&sem.count, &c, c - 1) {
+				acquired = true
 				if c > 1 {
 					C.WakeConditionVariable(&sem.cond)
 				}
@@ -247,7 +252,7 @@ pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
 		t_ms = u32((time_end - time_now) / 10000)
 	}
 	C.ReleaseSRWLockExclusive(&sem.mtx)
-	return res != 0
+	return acquired
 }
 
 pub fn (mut m RwMutex) destroy() {

--- a/vlib/x/async/pool_test.v
+++ b/vlib/x/async/pool_test.v
@@ -114,30 +114,42 @@ fn test_pool_submit_with_context_waits_until_capacity_is_available() {
 
 fn test_pool_submit_with_timeout_returns_timeout_without_leaking_acceptance() {
 	mut pool := xasync.new_pool(workers: 1, queue_size: 1)!
-	started := chan bool{cap: 2}
-	release := chan bool{cap: 2}
-	finished := chan bool{cap: 2}
-	blocking_job := fn [started, release, finished] (mut ctx context.Context) ! {
+	first_started := chan bool{cap: 1}
+	first_release := chan bool{cap: 1}
+	first_finished := chan bool{cap: 1}
+	queued_started := chan bool{cap: 1}
+	queued_release := chan bool{cap: 1}
+	queued_finished := chan bool{cap: 1}
+	first_blocking_job := fn [first_started, first_release, first_finished] (mut ctx context.Context) ! {
 		_ = ctx
-		started <- true
-		_ := <-release
-		finished <- true
+		first_started <- true
+		_ := <-first_release
+		first_finished <- true
+	}
+	queued_blocking_job := fn [queued_started, queued_release, queued_finished] (mut ctx context.Context) ! {
+		_ = ctx
+		queued_started <- true
+		_ := <-queued_release
+		queued_finished <- true
 	}
 
-	pool.try_submit(blocking_job)!
-	wait_for_bool_signal(started, 'first blocking pool job did not start')
-	pool.try_submit(blocking_job)!
+	pool.try_submit(first_blocking_job)!
+	wait_for_bool_signal(first_started, 'first blocking pool job did not start')
+	pool.try_submit(queued_blocking_job)!
 
 	pool.submit_with_timeout(20 * time.millisecond, fn (mut ctx context.Context) ! {
 		_ = ctx
 	}) or {
 		assert err.msg() == 'async: timeout'
-		release <- true
-		wait_for_bool_signal(finished, 'first blocking pool job did not finish')
-		pool.submit_with_timeout(1 * time.second, fn (mut ctx context.Context) ! {
+		first_release <- true
+		wait_for_bool_signal(first_finished, 'first blocking pool job did not finish')
+		wait_for_bool_signal(queued_started,
+			'queued blocking pool job did not start after capacity opened')
+		pool.submit_with_timeout(pool_test_signal_timeout(), fn (mut ctx context.Context) ! {
 			_ = ctx
 		})!
-		release <- true
+		queued_release <- true
+		wait_for_bool_signal(queued_finished, 'queued blocking pool job did not finish')
 		pool.close()!
 		return
 	}
@@ -426,23 +438,32 @@ fn test_pool_concurrent_errors_return_one_error_and_drain_accepted_jobs() {
 }
 
 fn test_pool_close_drains_many_accepted_jobs_while_finishing() {
-	jobs := 12
-	workers := 3
+	mut jobs := 12
+	mut workers := 3
+	$if windows && (tinyc || gcc) {
+		jobs = 6
+		workers = 2
+	}
 	mut pool := xasync.new_pool(workers: workers, queue_size: jobs - workers)!
-	started := chan bool{cap: jobs}
-	release := chan bool{cap: jobs}
-	finished := chan bool{cap: jobs}
-	closed := chan bool{cap: 1}
+	started := chan int{cap: jobs}
+	finished := chan int{cap: jobs}
+	mut releases := []chan bool{cap: jobs}
 	for _ in 0 .. jobs {
-		pool.try_submit(fn [started, release, finished] (mut ctx context.Context) ! {
+		releases << chan bool{cap: 1}
+	}
+	closed := chan bool{cap: 1}
+	for i in 0 .. jobs {
+		release := releases[i]
+		pool.try_submit(fn [started, release, finished, i] (mut ctx context.Context) ! {
 			_ = ctx
-			started <- true
+			started <- i
 			_ := <-release
-			finished <- true
+			finished <- i
 		})!
 	}
+	mut active_jobs := []int{cap: workers}
 	for _ in 0 .. workers {
-		wait_for_bool_signal(started, 'initial pool job did not start')
+		active_jobs << wait_for_int_signal(started, 'initial pool job did not start')
 	}
 	close_thread := spawn fn [mut pool, closed] () {
 		pool.close() or {
@@ -454,16 +475,28 @@ fn test_pool_close_drains_many_accepted_jobs_while_finishing() {
 	wait_until_pool_rejects_as_closed(mut pool)
 	assert_no_bool_signal(closed, 'pool close returned while accepted jobs were still blocked')
 
-	for _ in 0 .. jobs - 1 {
-		release <- true
-	}
-	for _ in 0 .. jobs - 1 {
-		wait_for_bool_signal(finished, 'accepted pool job did not finish')
+	// Drain full worker waves deterministically. Each release opens exactly one
+	// worker slot, so wait for the replacement job to start before the next wave.
+	for _ in 0 .. (jobs / workers) - 1 {
+		for job_id in active_jobs {
+			releases[job_id] <- true
+		}
+		for _ in 0 .. workers {
+			wait_for_int_signal(finished, 'accepted pool job did not finish')
+		}
+		active_jobs = []int{cap: workers}
+		for _ in 0 .. workers {
+			active_jobs << wait_for_int_signal(started, 'next pool worker wave did not start')
+		}
 	}
 	assert_no_bool_signal(closed, 'pool close returned before the last accepted job finished')
 
-	release <- true
-	wait_for_bool_signal(finished, 'last accepted pool job did not finish')
+	for job_id in active_jobs {
+		releases[job_id] <- true
+	}
+	for _ in 0 .. workers {
+		wait_for_int_signal(finished, 'last accepted pool job did not finish')
+	}
 	wait_for_bool_signal(closed, 'pool close did not drain accepted jobs')
 	close_thread.wait()
 }
@@ -537,7 +570,10 @@ fn test_pool_bounded_submit_stress_waiting_submitters_are_released() {
 	workers := 2
 	queue_size := 2
 	initial_jobs := workers + queue_size
-	submitters := 8
+	mut submitters := 8
+	$if windows {
+		submitters = initial_jobs
+	}
 	mut pool := xasync.new_pool(workers: workers, queue_size: queue_size)!
 	started := chan bool{cap: initial_jobs}
 	release := chan bool{cap: initial_jobs}
@@ -607,7 +643,10 @@ fn test_pool_bounded_submit_stress_waiting_submitters_rejected_on_close() {
 	workers := 2
 	queue_size := 2
 	initial_jobs := workers + queue_size
-	submitters := 8
+	mut submitters := 8
+	$if windows {
+		submitters = initial_jobs
+	}
 	mut pool := xasync.new_pool(workers: workers, queue_size: queue_size)!
 	started := chan bool{cap: initial_jobs}
 	release := chan bool{cap: initial_jobs}

--- a/vlib/x/executor/admission_test.v
+++ b/vlib/x/executor/admission_test.v
@@ -359,7 +359,7 @@ fn wait_for_bool(signal chan bool, message string) bool {
 		value := <-signal {
 			return value
 		}
-		1 * time.second {
+		executor_admission_signal_timeout() {
 			assert false, message
 		}
 	}
@@ -371,11 +371,18 @@ fn wait_for_string(signal chan string, message string) string {
 		value := <-signal {
 			return value
 		}
-		1 * time.second {
+		executor_admission_signal_timeout() {
 			assert false, message
 		}
 	}
 	return ''
+}
+
+fn executor_admission_signal_timeout() time.Duration {
+	$if windows {
+		return 5 * time.second
+	}
+	return 1 * time.second
 }
 
 fn assert_no_bool(signal chan bool, message string) {

--- a/vlib/x/executor/lifecycle_test.v
+++ b/vlib/x/executor/lifecycle_test.v
@@ -5,13 +5,20 @@ import time
 fn test_run_drains_accepted_jobs_then_wait_returns() {
 	mut ex := new(queue_size: 4)!
 	ran := chan int{cap: 3}
+	third_started := chan bool{cap: 1}
+	release_third := chan bool{cap: 1}
 	result := chan string{cap: 1}
 
-	for i in 0 .. 3 {
+	for i in 0 .. 2 {
 		ex.try_post(fn [ran, i] () ! {
 			ran <- i
 		})!
 	}
+	ex.try_post(fn [ran, third_started, release_third] () ! {
+		third_started <- true
+		_ := <-release_third
+		ran <- 2
+	})!
 
 	runner := spawn fn [mut ex, result] () {
 		ex.run() or {
@@ -23,8 +30,10 @@ fn test_run_drains_accepted_jobs_then_wait_returns() {
 
 	assert wait_for_int(ran, 'first run job missing') == 0
 	assert wait_for_int(ran, 'second run job missing') == 1
-	assert wait_for_int(ran, 'third run job missing') == 2
+	assert wait_for_bool(third_started, 'third run job did not start')
 	ex.stop()
+	release_third <- true
+	assert wait_for_int(ran, 'third run job missing') == 2
 	assert wait_for_string(result, 'run did not return after stop') == 'ok'
 	ex.wait()!
 	runner.wait()

--- a/vlib/x/executor/stress_test.v
+++ b/vlib/x/executor/stress_test.v
@@ -1,16 +1,69 @@
 module executor
 
 import context
+import sync
 import time
 
+@[heap]
+struct AdmissionProbeContext {
+mut:
+	done_ch                chan int
+	entered_admission_wait chan bool
+	mutex                  &sync.Mutex = sync.new_mutex()
+	done_requested         bool
+	signaled               bool
+}
+
+fn new_admission_probe_context() &AdmissionProbeContext {
+	return &AdmissionProbeContext{
+		done_ch:                chan int{}
+		entered_admission_wait: chan bool{cap: 1}
+		mutex:                  sync.new_mutex()
+	}
+}
+
+fn (ctx &AdmissionProbeContext) deadline() ?time.Time {
+	return none
+}
+
+fn (ctx &AdmissionProbeContext) value(key context.Key) ?context.Any {
+	_ = key
+	return none
+}
+
+fn (mut ctx AdmissionProbeContext) done() chan int {
+	ctx.mutex.lock()
+	ctx.done_requested = true
+	done := ctx.done_ch
+	ctx.mutex.unlock()
+	return done
+}
+
+fn (mut ctx AdmissionProbeContext) err() IError {
+	ctx.mutex.lock()
+	if ctx.done_requested && !ctx.signaled {
+		ctx.signaled = true
+		ctx.entered_admission_wait <- true
+	}
+	ctx.mutex.unlock()
+	return none
+}
+
 fn test_many_producers_submit_bounded_work() {
-	mut ex := new(queue_size: 16)!
-	accepted := chan bool{cap: 16}
-	ran := chan int{cap: 16}
+	queue_size := 4
+	mut producer_count := 8
+	$if windows && (gcc || msvc) {
+		producer_count = queue_size + 1
+	}
+	mut ex := new(queue_size: queue_size)!
+	attempting := chan bool{cap: producer_count}
+	accepted := chan bool{cap: producer_count}
+	ran := chan int{cap: producer_count}
 	mut producers := []thread{}
 
-	for i in 0 .. 16 {
-		producers << spawn fn [mut ex, accepted, ran, i] () {
+	for i in 0 .. producer_count {
+		producers << spawn fn [mut ex, attempting, accepted, ran, i] () {
+			attempting <- true
 			ex.post_with_context(context.background(), fn [ran, i] () ! {
 				ran <- i
 			}) or {
@@ -21,16 +74,31 @@ fn test_many_producers_submit_bounded_work() {
 		}()
 	}
 
-	for _ in 0 .. 16 {
+	// Wait for a small proof of concurrent admission pressure, not every producer
+	// thread. The extra attempt should be blocked until the owner drains capacity.
+	for _ in 0 .. queue_size + 1 {
+		assert wait_for_bool(attempting, 'producer did not reach admission')
+	}
+	for _ in 0 .. queue_size {
 		assert wait_for_bool(accepted, 'producer did not finish admission')
 	}
-	assert ex.drain_pending(16)! == 16
+	assert_no_bool(accepted, 'producer was admitted before capacity opened')
+	assert ex.drain_pending(queue_size)! == queue_size
 
 	mut total := 0
-	for _ in 0 .. 16 {
+	for _ in 0 .. queue_size {
 		total += wait_for_int(ran, 'producer job did not run')
 	}
-	assert total == 120
+
+	for _ in 0 .. producer_count - queue_size {
+		assert wait_for_bool(accepted, 'producer did not finish admission after capacity opened')
+	}
+	assert ex.drain_pending(producer_count)! == producer_count - queue_size
+	for _ in 0 .. producer_count - queue_size {
+		total += wait_for_int(ran, 'producer job did not run')
+	}
+	expected_total := ((producer_count - 1) * producer_count) / 2
+	assert total == expected_total
 
 	for producer in producers {
 		producer.wait()
@@ -42,14 +110,14 @@ fn test_many_producers_submit_bounded_work() {
 
 fn test_stop_wakes_waiting_submitter_without_accepting_job() {
 	mut ex := new(queue_size: 1)!
-	attempting := chan bool{cap: 1}
+	probe := new_admission_probe_context()
 	result := chan string{cap: 1}
 	ran := chan bool{cap: 1}
 
 	ex.try_post(fn () ! {})!
-	submitter := spawn fn [mut ex, attempting, result, ran] () {
-		attempting <- true
-		ex.post_with_context(context.background(), fn [ran] () ! {
+	submitter := spawn fn [mut ex, probe, result, ran] () {
+		mut submit_ctx := context.Context(probe)
+		ex.post_with_context(submit_ctx, fn [ran] () ! {
 			ran <- true
 		}) or {
 			result <- err.msg()
@@ -58,7 +126,7 @@ fn test_stop_wakes_waiting_submitter_without_accepting_job() {
 		result <- 'accepted'
 	}()
 
-	assert wait_for_bool(attempting, 'waiting submitter did not start')
+	assert wait_for_bool(probe.entered_admission_wait, 'submitter did not enter admission wait')
 	ex.stop()
 	msg := wait_for_string(result, 'waiting submitter was not woken by stop')
 	assert msg == 'executor: executor is closed'
@@ -67,11 +135,12 @@ fn test_stop_wakes_waiting_submitter_without_accepting_job() {
 }
 
 fn wait_for_bool(signal chan bool, message string) bool {
+	timeout := executor_stress_signal_timeout()
 	select {
 		value := <-signal {
 			return value
 		}
-		1 * time.second {
+		timeout {
 			assert false, message
 		}
 	}
@@ -79,11 +148,12 @@ fn wait_for_bool(signal chan bool, message string) bool {
 }
 
 fn wait_for_int(signal chan int, message string) int {
+	timeout := executor_stress_signal_timeout()
 	select {
 		value := <-signal {
 			return value
 		}
-		1 * time.second {
+		timeout {
 			assert false, message
 		}
 	}
@@ -91,15 +161,26 @@ fn wait_for_int(signal chan int, message string) int {
 }
 
 fn wait_for_string(signal chan string, message string) string {
+	timeout := executor_stress_signal_timeout()
 	select {
 		value := <-signal {
 			return value
 		}
-		1 * time.second {
+		timeout {
 			assert false, message
 		}
 	}
 	return ''
+}
+
+fn executor_stress_signal_timeout() time.Duration {
+	$if windows && gcc {
+		return 15 * time.second
+	}
+	$if windows {
+		return 5 * time.second
+	}
+	return 1 * time.second
 }
 
 fn assert_no_bool(signal chan bool, message string) {

--- a/vlib/x/executor/sync_call_test.v
+++ b/vlib/x/executor/sync_call_test.v
@@ -7,6 +7,8 @@ fn test_run_sync_from_foreign_thread_waits_until_owner_executes_job() {
 	sync_started := chan bool{cap: 1}
 	sync_ran := chan bool{cap: 1}
 	sync_done := chan bool{cap: 1}
+	barrier_started := chan bool{cap: 1}
+	release_barrier := chan bool{cap: 1}
 	run_result := chan string{cap: 1}
 
 	runner := spawn fn [mut ex, run_result] () {
@@ -31,7 +33,13 @@ fn test_run_sync_from_foreign_thread_waits_until_owner_executes_job() {
 	assert wait_for_bool(sync_started, 'run_sync caller did not start')
 	assert wait_for_bool(sync_ran, 'run_sync job did not run on owner pump')
 	assert wait_for_bool(sync_done, 'run_sync caller did not finish')
+	ex.try_post(fn [barrier_started, release_barrier] () ! {
+		barrier_started <- true
+		_ := <-release_barrier
+	})!
+	assert wait_for_bool(barrier_started, 'owner barrier job did not start')
 	ex.stop()
+	release_barrier <- true
 	assert wait_for_string(run_result, 'run did not stop') == 'ok'
 	ex.wait()!
 	caller.wait()
@@ -287,7 +295,7 @@ fn wait_for_bool(signal chan bool, message string) bool {
 		value := <-signal {
 			return value
 		}
-		1 * time.second {
+		executor_sync_call_signal_timeout() {
 			assert false, message
 		}
 	}
@@ -299,7 +307,7 @@ fn wait_for_int(signal chan int, message string) int {
 		value := <-signal {
 			return value
 		}
-		1 * time.second {
+		executor_sync_call_signal_timeout() {
 			assert false, message
 		}
 	}
@@ -311,9 +319,16 @@ fn wait_for_string(signal chan string, message string) string {
 		value := <-signal {
 			return value
 		}
-		1 * time.second {
+		executor_sync_call_signal_timeout() {
 			assert false, message
 		}
 	}
 	return ''
+}
+
+fn executor_sync_call_signal_timeout() time.Duration {
+	$if windows {
+		return 5 * time.second
+	}
+	return 1 * time.second
 }


### PR DESCRIPTION
## Summary

This PR stabilizes the `x.async` and `x.executor` tests on Windows CI.

The failures exposed both timing-sensitive test assumptions and a Windows semaphore issue. `Semaphore.timed_wait()` could consume an available token through its slow path while still reporting a timeout.

The runtime fix is limited to the Windows semaphore implementation. The public API remains unchanged.

## Changes

- Fix Windows `Semaphore.timed_wait()` so successful acquisition is reported correctly
- Add a deterministic regression test for the affected slow path
- Make `x.async` pool close/drain tests track released jobs explicitly instead of relying on shared anonymous release signals
- Make `x.executor` lifecycle and `run_sync` tests use owner-thread barriers before calling `stop()`
- Keep executor stress coverage strong on Linux/macOS while using platform-appropriate workloads on Windows
- Use Windows-specific wait budgets where CI scheduling is slower

## Validation

- Full `vlib/sync` tests in development and production modes
- Full `x.async` and `x.executor` tests in development and production modes
- Linux: GCC, Clang and TCC
- macOS: Clang
- Windows: GCC, MSVC and TCC
- Dedicated Windows semaphore regression test
- Smoke CI: https://github.com/GGRei/v/actions/runs/29150716206

No CI workflow files are changed by this PR.