### PR TITLE
v3: cache transform call param declaration lookup

### DIFF
--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1149,9 +1149,49 @@ fn (mut t Transformer) call_param_types_from_decl(call_name string) ?[]types.Typ
 	if call_name.len == 0 || isnil(t.tc) {
 		return none
 	}
+	if params := t.call_param_types_decl_cache[call_name] {
+		return params
+	}
+	if t.call_param_types_decl_misses[call_name] {
+		return none
+	}
+	t.ensure_call_param_types_decl_index()
+	decl := t.call_param_types_decl_index[call_name] or {
+		t.call_param_types_decl_misses[call_name] = true
+		return none
+	}
+	node := t.a.nodes[decl.idx]
+	mut params := []types.Type{}
+	for i in 0 .. node.children_count {
+		child := t.a.child_node(&node, i)
+		if child.kind != .param {
+			continue
+		}
+		mut param_type := t.parse_decl_param_type(child.typ, decl.module, decl.file)
+		if param_type is types.Unknown || (param_type is types.Void && child.typ != 'void') {
+			t.call_param_types_decl_misses[call_name] = true
+			return none
+		}
+		if (child.is_mut || child.typ.starts_with('mut ')
+			|| child.typ.starts_with('&')) && param_type !is types.Pointer {
+			param_type = types.Type(types.Pointer{
+				base_type: param_type
+			})
+		}
+		params << param_type
+	}
+	t.call_param_types_decl_cache[call_name] = params.clone()
+	return params
+}
+
+fn (mut t Transformer) ensure_call_param_types_decl_index() {
+	if t.call_param_types_index_ready {
+		return
+	}
+	t.call_param_types_decl_index.clear()
 	mut file_name := ''
 	mut module_name := ''
-	for node in t.a.nodes {
+	for i, node in t.a.nodes {
 		if node.kind == .file {
 			file_name = node.value
 			module_name = t.tc.file_modules[file_name] or { '' }
@@ -1164,30 +1204,36 @@ fn (mut t Transformer) call_param_types_from_decl(call_name string) ?[]types.Typ
 		if node.kind != .fn_decl {
 			continue
 		}
-		if !fn_decl_name_matches_call(node.value, module_name, call_name) {
-			continue
+		t.add_call_param_types_decl_key(node.value, i, file_name, module_name)
+		qname := transform_qualified_fn_name(module_name, node.value)
+		if qname != node.value {
+			t.add_call_param_types_decl_key(qname, i, file_name, module_name)
 		}
-		mut params := []types.Type{}
-		for i in 0 .. node.children_count {
-			child := t.a.child_node(&node, i)
-			if child.kind != .param {
-				continue
-			}
-			mut param_type := t.parse_decl_param_type(child.typ, module_name, file_name)
-			if param_type is types.Unknown || (param_type is types.Void && child.typ != 'void') {
-				return none
-			}
-			if (child.is_mut || child.typ.starts_with('mut ')
-				|| child.typ.starts_with('&')) && param_type !is types.Pointer {
-				param_type = types.Type(types.Pointer{
-					base_type: param_type
-				})
-			}
-			params << param_type
-		}
-		return params
 	}
-	return none
+	t.call_param_types_index_ready = true
+}
+
+fn (mut t Transformer) add_call_param_types_decl_key(key string, idx int, file string, module_name string) {
+	if key.len == 0 {
+		return
+	}
+	if key !in t.call_param_types_decl_index {
+		t.call_param_types_decl_index[key] = FnParamDeclRef{
+			idx:    idx
+			file:   file
+			module: module_name
+		}
+	}
+	t.call_param_types_decl_misses.delete(key)
+	cname := c_name(key)
+	if cname != key && cname !in t.call_param_types_decl_index {
+		t.call_param_types_decl_index[cname] = FnParamDeclRef{
+			idx:    idx
+			file:   file
+			module: module_name
+		}
+	}
+	t.call_param_types_decl_misses.delete(cname)
 }
 
 fn (mut t Transformer) parse_decl_param_type(typ string, module_name string, file_name string) types.Type {
@@ -1322,14 +1368,6 @@ fn (t &Transformer) decl_fn_type_param_in_module(param string, module_name strin
 		return '&' + scoped
 	}
 	return scoped
-}
-
-fn fn_decl_name_matches_call(name string, module_name string, call_name string) bool {
-	if name == call_name || c_name(name) == call_name {
-		return true
-	}
-	qname := transform_qualified_fn_name(module_name, name)
-	return qname == call_name || c_name(qname) == call_name
 }
 
 // call_is_variadic updates call is variadic state for Transformer.

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -109,6 +109,10 @@ mut:
 	generic_unresolved_cache     &GenericUnresolvedCache = unsafe { nil }
 	struct_field_type_cache      &LookupCache            = unsafe { nil }
 	variant_short_name_cache     &LookupCache            = unsafe { nil }
+	call_param_types_decl_cache  map[string][]types.Type
+	call_param_types_decl_misses map[string]bool
+	call_param_types_decl_index  map[string]FnParamDeclRef
+	call_param_types_index_ready bool
 	used_fns                     map[string]bool
 	// sum_eq_types records sum types whose deep-equality helper fn
 	// (__v3_sum_eq_<name>) is called somewhere, keyed by sum name with the
@@ -267,6 +271,12 @@ struct GenericFnDecl {
 struct GenericCallSpec {
 	decl_key string
 	args     []string
+}
+
+struct FnParamDeclRef {
+	idx    int
+	file   string
+	module string
 }
 
 // --- entry point ---
@@ -487,6 +497,9 @@ fn new_transformer(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[strin
 		generic_receiver_methods_by_name: map[string][]string{}
 		generic_call_spec_cache:          map[int]GenericCallSpec{}
 		generic_call_spec_misses:         map[int]bool{}
+		call_param_types_decl_cache:      map[string][]types.Type{}
+		call_param_types_decl_misses:     map[string]bool{}
+		call_param_types_decl_index:      map[string]FnParamDeclRef{}
 		sum_variant_names:                map[string]bool{}
 		used_fns:                         used_fns.clone()
 		interface_boxed_types:            map[string]bool{}
@@ -1445,6 +1458,10 @@ fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Tran
 	w.generic_fn_decls_ready = false
 	w.generic_call_spec_cache = map[int]GenericCallSpec{}
 	w.generic_call_spec_misses = map[int]bool{}
+	w.call_param_types_decl_cache = map[string][]types.Type{}
+	w.call_param_types_decl_misses = map[string]bool{}
+	w.call_param_types_decl_index = map[string]FnParamDeclRef{}
+	w.call_param_types_index_ready = false
 	w.node_module_map_cache = []string{}
 	w.node_module_map_nodes = -1
 	w.var_types = []VarTypeBinding{}


### PR DESCRIPTION
## Summary
- cache v3 transform call parameter declaration lookups by call name
- build a lazy declaration index once per transformer worker instead of rescanning the full AST for each lookup
- preserve per-worker private caches for parallel transform

## Validation
- `./vnew fmt -w vlib/v3/transform/fn.v vlib/v3/transform/transform.v`
- `../../vnew -gc none -prealloc -prod -o v3 v3.v`
- `./v3 -building-v -o v4 v3.v` (transform 74.92 ms, cgen 103.94 ms, total 453.39 ms)
- `./vnew -silent test vlib/v3/transform/`
- `./vnew -silent test vlib/v3/tests/comptime_review_round4_test.v`
- `./vnew -silent test vlib/v3/tests/review_transform_regressions_test.v`

## Notes
- `vlib/v3/tests/string_interpolation_stringify_codegen_test.v` still fails with the pre-existing `Box_v_int__str` C error; reproduced on clean `HEAD`.
- v3 build still emits existing notices in `vlib/v3/transform/comptime.v`.