### PR TITLE
v3: fix ripgrep ownership channel and generic lowering

### DIFF
--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -760,6 +760,26 @@ fn (mut g FlatGen) write_method_c_name(id flat.NodeId, node flat.Node, method_na
 	g.write(g.cname(g.method_call_name_for_call(id, node, method_name)))
 }
 
+fn (mut g FlatGen) gen_channel_close_call(base_id flat.NodeId) {
+	g.write('sync__Channel__close(')
+	if g.channel_close_receiver_needs_deref(base_id) {
+		g.write('*(')
+		g.gen_expr(base_id)
+		g.write(')')
+	} else {
+		g.write('(sync__Channel*)(')
+		g.gen_expr(base_id)
+		g.write(')')
+	}
+	g.write(', array_new(sizeof(IError), 0, 0))')
+}
+
+fn (g &FlatGen) channel_close_receiver_needs_deref(base_id flat.NodeId) bool {
+	base_type := g.tc.resolve_type(base_id)
+	return base_type is types.Pointer
+		&& cgen_is_channel_close_receiver_type(types.unwrap_pointer(base_type))
+}
+
 fn (g &FlatGen) method_call_name_for_call(id flat.NodeId, node flat.Node, method_name string) string {
 	if concrete := g.concrete_generic_method_name_from_call_receiver(node, method_name) {
 		return concrete
@@ -1159,29 +1179,43 @@ fn (g &FlatGen) resolve_concrete_generic_method_name(type_name string, method st
 	if !ok || args.len == 0 {
 		return none
 	}
-	suffix := generic_receiver_type_suffixes(args)
-	mut candidates := ['${base}_${suffix}.${method}']
-	if base.contains('.') {
-		base_mod := base.all_before_last('.')
-		base_short := base.all_after_last('.')
-		candidates << '${base_short}_${suffix}.${method}'
-		candidates << '${base_mod}.${base_short}_${suffix}.${method}'
-	}
-	for candidate in candidates {
-		if candidate in g.tc.fn_param_types || candidate in g.tc.fn_ret_types {
-			return candidate
+	for suffix in generic_receiver_type_suffix_variants(args) {
+		mut candidates := ['${base}_${suffix}.${method}']
+		if base.contains('.') {
+			base_mod := base.all_before_last('.')
+			base_short := base.all_after_last('.')
+			candidates << '${base_short}_${suffix}.${method}'
+			candidates << '${base_mod}.${base_short}_${suffix}.${method}'
+		}
+		for candidate in candidates {
+			if candidate in g.tc.fn_param_types || candidate in g.tc.fn_ret_types {
+				return candidate
+			}
 		}
 	}
 	return none
 }
 
 fn generic_receiver_type_suffixes(args []string) string {
+	variants := generic_receiver_type_suffix_variants(args)
+	if variants.len > 0 {
+		return variants[0]
+	}
+	return ''
+}
+
+fn generic_receiver_type_suffix_variants(args []string) []string {
+	mut raw_parts := []string{cap: args.len}
 	mut parts := []string{cap: args.len}
 	for arg in args {
-		parts << c_name(generic_receiver_type_arg_short(arg).replace('[]', 'Array_').replace('&',
-			'ptr_'))
+		raw := generic_receiver_type_arg_short(arg).replace('[]', 'Array_').replace('&', 'ptr_')
+		raw_parts << raw
+		parts << c_name(raw)
 	}
-	return parts.join('_')
+	mut variants := []string{}
+	codegen_push_unique(mut variants, raw_parts.join('_'))
+	codegen_push_unique(mut variants, parts.join('_'))
+	return variants
 }
 
 fn generic_receiver_type_arg_short(type_arg string) string {
@@ -2818,6 +2852,25 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		return
 	}
 	resolved_target_name := g.tc.resolved_call_name(id) or { '' }
+	if node.children_count >= 2 && (fn_name == 'sync__Channel__close'
+		|| target_name == 'sync__Channel__close'
+		|| target_name == 'C.sync__Channel__close'
+		|| resolved_target_name == 'sync__Channel__close') {
+		g.write('sync__Channel__close(')
+		g.gen_expr(g.a.child(&node, 1))
+		if node.children_count > 2 {
+			g.write(', ')
+			g.gen_expr(g.a.child(&node, 2))
+		} else {
+			g.write(', array_new(sizeof(IError), 0, 0)')
+		}
+		g.write(')')
+		return
+	}
+	if resolved_target_name == 'chan.close' && fn_node.kind == .selector {
+		g.gen_channel_close_call(g.a.child(fn_node, 0))
+		return
+	}
 	if resolved_target_name in ['free', 'builtin.free'] && node.children_count == 2 {
 		arg_id := g.a.child(&node, 1)
 		arg_type := g.usable_expr_type(arg_id)
@@ -2869,8 +2922,9 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 	if fn_node.kind == .selector && fn_node.value == 'close' {
 		base_id := g.a.child(fn_node, 0)
 		base_type := g.tc.resolve_type(base_id)
-		if base_type is types.Channel {
-			panic('channel close should be lowered by v3 transform')
+		if cgen_is_channel_close_receiver_type(base_type) {
+			g.gen_channel_close_call(base_id)
+			return
 		}
 	}
 	if g.gen_flag_enum_from_call(fn_node, node) {
@@ -2879,12 +2933,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 	if target_name.starts_with('C.') {
 		g.write(g.direct_call_name_for_call(id, target_name))
 		g.write('(')
-		start := if fn_node.kind == .selector {
-			g.selector_module_call_arg_start(fn_node, node)
-		} else {
-			1
-		}
-		g.gen_call_args(target_name, node, start)
+		g.gen_call_args(target_name, node, 1)
 		g.write(')')
 		return
 	}
@@ -3265,6 +3314,10 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 				} else {
 					base_type := g.usable_expr_type(g.a.child(fn_node, 0))
 					clean_type := concrete_receiver_type(base_type)
+					if cgen_is_channel_close_receiver_type(clean_type) && fn_node.value == 'close' {
+						g.gen_channel_close_call(g.a.child(fn_node, 0))
+						return
+					}
 					if g.gen_thread_wait_call(fn_node) {
 						return
 					}
@@ -4122,6 +4175,18 @@ fn concrete_receiver_type(base_type types.Type) types.Type {
 		return clean_type.base_type
 	}
 	return clean_type
+}
+
+fn cgen_is_channel_close_receiver_type(base_type types.Type) bool {
+	clean_type := concrete_receiver_type(base_type)
+	if clean_type is types.Channel {
+		return true
+	}
+	mut name := clean_type.name().trim_space()
+	for name.starts_with('&') {
+		name = name[1..].trim_space()
+	}
+	return name == 'chan' || name.starts_with('chan ')
 }
 
 fn (g &FlatGen) receiver_storage_type(base_id flat.NodeId) ?types.Type {
@@ -6344,14 +6409,18 @@ fn codegen_specialized_receiver_fn_candidates(mut result []string, fn_base strin
 
 fn codegen_generic_type_suffix_variants(args []string) []string {
 	mut suffixes := []string{}
+	mut short_raw_parts := []string{cap: args.len}
 	mut short_parts := []string{cap: args.len}
 	mut full_parts := []string{cap: args.len}
 	for arg in args {
 		clean := trimmed_space(arg)
-		short_parts << c_name(generic_receiver_type_arg_short(clean).replace('[]', 'Array_').replace('&',
-			'ptr_'))
+		short_raw := generic_receiver_type_arg_short(clean).replace('[]', 'Array_').replace('&',
+			'ptr_')
+		short_raw_parts << short_raw
+		short_parts << c_name(short_raw)
 		full_parts << c_name(clean.replace('[]', 'Array_').replace('&', 'ptr_'))
 	}
+	codegen_push_unique(mut suffixes, short_raw_parts.join('_'))
 	codegen_push_unique(mut suffixes, short_parts.join('_'))
 	codegen_push_unique(mut suffixes, full_parts.join('_'))
 	return suffixes
@@ -8591,14 +8660,15 @@ fn fn_ptr_typedef_generic_placeholder_struct_tag(typ string) ?string {
 	if clean.starts_with('struct ') {
 		clean = clean['struct '.len..].trim_space()
 	}
-	if !clean.contains('__') {
+	segment := if clean.contains('__') {
+		clean.all_after_last('__')
+	} else {
+		clean
+	}
+	if !segment.contains('_') {
 		return none
 	}
-	short := clean.all_after_last('__')
-	if !short.contains('_') {
-		return none
-	}
-	suffix := short.all_after_last('_')
+	suffix := segment.all_after_last('_')
 	if suffix.len == 1 && suffix[0] >= `A` && suffix[0] <= `Z` {
 		return 'struct ${clean}${ptr_suffix}'
 	}

--- a/vlib/v3/tests/channel_close_codegen_test.v
+++ b/vlib/v3/tests/channel_close_codegen_test.v
@@ -1,0 +1,78 @@
+import os
+
+const channel_close_vexe = @VEXE
+const channel_close_tests_dir = os.dir(@FILE)
+const channel_close_v3_dir = os.dir(channel_close_tests_dir)
+const channel_close_vlib_dir = os.dir(channel_close_v3_dir)
+const channel_close_v3_src = os.join_path(channel_close_v3_dir, 'v3.v')
+
+fn channel_close_tmp_path(name string) string {
+	return os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+}
+
+fn channel_close_build_v3() string {
+	v3_bin := channel_close_tmp_path('channel_close_codegen_test')
+	build :=
+		os.execute('${channel_close_vexe} -gc none -path "${channel_close_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${channel_close_v3_src}')
+	if build.exit_code != 0 {
+		panic(build.output)
+	}
+	return v3_bin
+}
+
+fn channel_close_run_good(v3_bin string, name string, src string) string {
+	src_path := '${channel_close_tmp_path(name)}.v'
+	os.write_file(src_path, src) or { panic(err) }
+	bin_path := channel_close_tmp_path(name)
+	compile := os.execute('${v3_bin} ${src_path} -b c -o ${bin_path}')
+	if compile.exit_code != 0 {
+		panic('${name}: ${compile.output}')
+	}
+	if compile.output.contains('C compilation failed') {
+		panic('${name}: ${compile.output}')
+	}
+	run := os.execute(bin_path)
+	if run.exit_code != 0 {
+		panic('${name}: ${run.output}')
+	}
+	return run.output.trim_space()
+}
+
+fn channel_close_gen_c(v3_bin string, name string, src string) string {
+	src_path := '${channel_close_tmp_path(name)}.v'
+	os.write_file(src_path, src) or { panic(err) }
+	c_path := '${channel_close_tmp_path(name)}.c'
+	os.rm(c_path) or {}
+	compile := os.execute('${v3_bin} ${src_path} -b c -o ${c_path}')
+	if compile.exit_code != 0 {
+		panic('${name}: ${compile.output}')
+	}
+	if !os.exists(c_path) {
+		panic('${name}: missing generated C at ${c_path}')
+	}
+	return os.read_file(c_path) or { panic(err) }
+}
+
+fn test_channel_alias_close_method_wins_over_runtime_lowering() {
+	v3_bin := channel_close_build_v3()
+	out := channel_close_run_good(v3_bin, 'channel_alias_close_method',
+		'type MyChan = chan int\n\nfn (c MyChan) close() int {\n\treturn 71\n}\n\nfn main() {\n\tch := MyChan(unsafe { nil })\n\tprintln(int_str(ch.close()))\n}\n')
+	if out != '71' {
+		panic('alias close output: ${out}')
+	}
+}
+
+fn test_pointer_channel_close_lowers_to_runtime_with_error_array() {
+	v3_bin := channel_close_build_v3()
+	c_source := channel_close_gen_c(v3_bin, 'pointer_channel_close_runtime',
+		'fn main() {\n\tmut ch := chan bool{cap: 1}\n\tp := &ch\n\tp.close()\n}\n')
+	if !c_source.contains('sync__Channel__close(*p,') {
+		panic('missing pointer channel close runtime call')
+	}
+	if !c_source.contains('sizeof(IError)') {
+		panic('missing close error array')
+	}
+	if c_source.contains('sync__Channel__close(*p);') {
+		panic('found one-arg pointer channel close')
+	}
+}

--- a/vlib/v3/tests/generic_cross_module_arg_codegen_test.v
+++ b/vlib/v3/tests/generic_cross_module_arg_codegen_test.v
@@ -100,6 +100,26 @@ fn test_generic_builder_call_infers_static_wrapped_nested_generic_arg() {
 	assert out == '24'
 }
 
+fn test_static_generic_type_function_with_builtin_arg_uses_emitted_name() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_static_builtin_arg_builder_call', {
+		'worker/worker.v': 'module worker\n\npub struct Summary[W] {\npub:\n\tw W\n}\n\npub fn Summary.new[W](w W) Summary[W] {\n\treturn Summary[W]{\n\t\tw: w\n\t}\n}\n\npub enum PrinterKind {\n\tsummary\n}\n\npub struct Printer[W] {\npub:\n\tkind PrinterKind\n\tsummary Summary[W]\n}\n\npub fn Printer.summary[W](summary Summary[W]) Printer[W] {\n\treturn Printer[W]{\n\t\tkind: .summary\n\t\tsummary: summary\n\t}\n}\n\npub struct Worker[W] {\npub:\n\tprinter Printer[W]\n}\n\npub struct Builder {}\n\npub fn Builder.new() Builder {\n\treturn Builder{}\n}\n\npub fn (builder Builder) build[W](printer Printer[W]) Worker[W] {\n\t_ = builder\n\treturn Worker[W]{\n\t\tprinter: printer\n\t}\n}\n'
+		'user/user.v':     'module user\n\nimport worker\n\npub fn run() int {\n\tbuilder := worker.Builder.new()\n\tprinter := worker.Printer.summary(worker.Summary.new(7))\n\tw := builder.build(printer)\n\treturn w.printer.summary.w\n}\n'
+		'main.v':          'module main\n\nimport user\n\nfn main() {\n\tprintln(int_str(user.run()))\n}\n'
+	})
+	assert out == '7'
+}
+
+fn test_static_generic_type_function_with_imported_generic_arg_uses_emitted_name() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_static_imported_arg_builder_call', {
+		'printer/printer.v': 'module printer\n\npub struct Standard[W] {\npub:\n\tw W\n}\n\npub fn Standard.new[W](w W) Standard[W] {\n\treturn Standard[W]{\n\t\tw: w\n\t}\n}\n'
+		'core/core.v':       'module core\n\nimport printer\n\nstruct BufferWriter {\n\tn int\n}\n\nstruct Printer[W] {\n\tstandard printer.Standard[W]\n}\n\nfn Printer.standard[W](standard printer.Standard[W]) Printer[W] {\n\treturn Printer[W]{\n\t\tstandard: standard\n\t}\n}\n\npub fn run() int {\n\tstandard := printer.Standard.new(BufferWriter{\n\t\tn: 61\n\t})\n\tprinter_ := Printer.standard(standard)\n\treturn printer_.standard.w.n\n}\n'
+		'main.v':            'module main\n\nimport core\n\nfn main() {\n\tprintln(int_str(core.run()))\n}\n'
+	})
+	assert out == '61'
+}
+
 fn test_generic_struct_interface_dispatch_emits_required_methods() {
 	v3_bin := generic_cross_build_v3()
 	out := generic_cross_run_project(v3_bin, 'generic_interface_dispatch', {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -4468,12 +4468,20 @@ fn (mut t Transformer) try_lower_channel_method_call(call_id flat.NodeId, node f
 		return none
 	}
 	base_id := t.a.child(&fn_node, 0)
-	if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id, 'chan.close') {
-		return exact_call
-	}
 	mut base_type := t.node_type(base_id)
 	if base_type.len == 0 {
 		base_type = t.lvalue_type(base_id)
+	}
+	if !isnil(t.tc) {
+		if resolved_method := t.tc.resolved_call_name(call_id) {
+			if resolved_method != 'chan.close' && resolved_method != 'sync__Channel__close' {
+				if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id,
+					'chan.close')
+				{
+					return exact_call
+				}
+			}
+		}
 	}
 	mut clean_type := base_type
 	mut ptr_depth := 0
@@ -4482,8 +4490,17 @@ fn (mut t Transformer) try_lower_channel_method_call(call_id flat.NodeId, node f
 		clean_type = clean_type[1..].trim_space()
 	}
 	if clean_type != 'chan' && !clean_type.starts_with('chan ') {
+		if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id,
+			'chan.close')
+		{
+			return exact_call
+		}
 		return none
 	}
+	return t.lower_runtime_channel_close(base_id, ptr_depth)
+}
+
+fn (mut t Transformer) lower_runtime_channel_close(base_id flat.NodeId, ptr_depth int) flat.NodeId {
 	t.mark_fn_used('sync__Channel__close')
 	errs := t.make_array_new_call('IError', t.make_int_literal(0), t.make_int_literal(0))
 	fn_expr := t.make_selector(t.make_ident('C'), 'sync__Channel__close', '')
@@ -5178,6 +5195,27 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 	}
 	if base_type.len == 0 {
 		return none
+	}
+	if method == 'close' && !isnil(t.tc) {
+		if resolved_method := t.tc.resolved_call_name(id) {
+			if resolved_method != 'chan.close' && resolved_method != 'sync__Channel__close' {
+				if exact_call := t.lower_checker_selected_receiver_method(id, node, base_id,
+					'chan.close')
+				{
+					return exact_call
+				}
+			}
+		}
+	}
+	if method == 'close' && (base_type == 'chan' || base_type.starts_with('chan ')) {
+		return t.lower_runtime_channel_close(base_id, if base_is_pointer { 1 } else { 0 })
+	}
+	if method == 'close' && !isnil(t.tc) {
+		if resolved_method := t.tc.resolved_call_name(id) {
+			if resolved_method == 'chan.close' || resolved_method == 'sync__Channel__close' {
+				return t.lower_runtime_channel_close(base_id, if base_is_pointer { 1 } else { 0 })
+			}
+		}
 	}
 	if t.cur_fn_is_generic && base_type.contains('[')
 		&& t.type_text_has_generic_placeholder(base_type, t.cur_module) {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -3105,7 +3105,7 @@ fn (t &Transformer) generic_resolved_call_decl_key(resolved string, callee flat.
 }
 
 fn (t &Transformer) resolved_generic_decl_matches_callee_receiver(callee flat.Node, node flat.Node, decl GenericFnDecl, module_name string) bool {
-	if !decl.node.value.contains('.') {
+	if !t.generic_decl_is_receiver_method(decl.node) {
 		return true
 	}
 	mut base_id := flat.empty_node
@@ -3237,7 +3237,7 @@ fn (t &Transformer) generic_call_arg_count_matches_decl(node flat.Node, decl Gen
 	// offsets the receiver param (actual == children_count). The ident-lowered form
 	// (`Type.method(recv, args)`) carries the receiver as a real child, so
 	// children = [callee, recv, args...] and actual == children_count - 1.
-	is_receiver := decl.node.value.contains('.')
+	is_receiver := t.generic_decl_is_receiver_method(decl.node)
 		&& !t.generic_call_is_static_assoc_selector(node, decl)
 	actual_args := t.generic_call_effective_arg_count(node)
 	actual := if is_receiver && t.call_is_selector_form(node) {
@@ -4900,7 +4900,24 @@ fn generic_fn_decl_base_value(value string) string {
 }
 
 fn (t &Transformer) generic_decl_is_receiver_method(node flat.Node) bool {
-	return node.value.contains('.')
+	if !node.value.contains('.') || node.children_count == 0 {
+		return false
+	}
+	first := t.a.child_node(&node, 0)
+	if first.kind != .param || first.typ.len == 0 {
+		return false
+	}
+	mut first_type := first.typ.trim_space()
+	if first_type.starts_with('mut ') {
+		first_type = first_type[4..].trim_space()
+	}
+	if first_type.starts_with('&') {
+		first_type = first_type[1..].trim_space()
+	}
+	method_name := generic_fn_decl_base_value(node.value)
+	clean_first := t.normalize_type_alias(first_type)
+	return receiver_param_matches_method_name(clean_first, method_name)
+		|| receiver_param_matches_method_name(first_type, method_name)
 }
 
 fn (mut t Transformer) generic_decl_has_method_level_params(decl GenericFnDecl) bool {


### PR DESCRIPTION
Follow-up to merged PR #27686. The ownership/ripgrep_v fixes were pushed after that PR merged, so this puts the single follow-up commit on a fresh branch based on current `origin/master`.

## Summary
- Preserve checker-selected `chan` alias `close()` methods instead of lowering them to the builtin runtime close.
- Emit `sync__Channel__close` with the required `IError` array argument, including pointer-to-channel receiver paths.
- Fix generic static associated functions with dotted names from being treated as receiver methods.
- Broaden generic emitted-name suffix lookup for static/generic call sites seen while compiling ripgrep_v.

## Validation
- `./v -ownership vlib/v3/tests/channel_close_codegen_test.v`
- `./v -ownership vlib/v3/tests/generic_cross_module_arg_codegen_test.v`
- `/Users/alexander/code/v/v -ownership main.v` from `/Users/alexander/code/ripgrep_v`

Note: the broad `vlib/v3/tests/post_merge_review_fixes_test.v` still stops earlier at the existing `assert item.n == 2` for-mut receiver regression, so this PR includes a focused channel-close regression instead.