### PR TITLE
x.multiwindow/gg: complete native event coverage part2

### DIFF
--- a/.github/workflows/gg_regressions_ci.yml
+++ b/.github/workflows/gg_regressions_ci.yml
@@ -69,32 +69,72 @@ jobs:
       - name: Multiwindow Linux checks
         run: |
           set -euo pipefail
-          env -u DISPLAY -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE ./v -d gg_multiwindow test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v
-          env -u DISPLAY -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE ./v -d gg_multiwindow -d sokol_wayland test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v
-          xvfb-run -a -s "-screen 0 1280x1024x24" env -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE LIBGL_ALWAYS_SOFTWARE=true ./v -d gg_multiwindow -d x_multiwindow_x11 test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v
+          env -u DISPLAY -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE ./v -d gg_multiwindow test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v vlib/gg/frame_pacing_test.v vlib/gg/draw_fns_api_test.v vlib/gg/draw_rect_empty_test.v
+          env -u DISPLAY -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE ./v -d gg_multiwindow -d sokol_wayland test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v vlib/gg/frame_pacing_test.v vlib/gg/draw_fns_api_test.v vlib/gg/draw_rect_empty_test.v
+          xvfb-run -a -s "-screen 0 1280x1024x24" env -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE LIBGL_ALWAYS_SOFTWARE=true ./v -d gg_multiwindow -d x_multiwindow_x11 test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v vlib/gg/frame_pacing_test.v vlib/gg/draw_fns_api_test.v vlib/gg/draw_rect_empty_test.v
           ./v -d gg_multiwindow -o /tmp/gg_multiwindow_default examples/gg/multiwindow.v
           ./v -d gg_multiwindow -d x_multiwindow_x11 -o /tmp/gg_multiwindow_x11 examples/gg/multiwindow.v
           ./v -d gg_multiwindow -d sokol_wayland -o /tmp/gg_multiwindow_wayland examples/gg/multiwindow.v
-          stdout="$(mktemp)"
-          stderr="$(mktemp)"
-          set +e
-          env -u DISPLAY -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE /tmp/gg_multiwindow_default >"$stdout" 2>"$stderr"
-          status=$?
-          set -e
-          echo "::group::gg multiwindow example stdout"
-          cat "$stdout"
-          echo "::endgroup::"
-          echo "::group::gg multiwindow example stderr"
-          cat "$stderr"
-          echo "::endgroup::"
-          grep -Fq "gg multi-window backend:" "$stdout"
-          grep -Fq "mock backend selected; stopping after initial lifecycle events" "$stdout"
-          grep -Fq "live windows:" "$stdout"
-          grep -Fq "window created:" "$stdout"
-          if [ "$status" -ne 0 ]; then
-            echo "headless gg multiwindow example failed with status $status"
-            exit "$status"
-          fi
+          run_headless_example() {
+            local label="$1"
+            local binary="$2"
+            local stdout
+            local stderr
+            local status
+            stdout="$(mktemp)"
+            stderr="$(mktemp)"
+            set +e
+            env -u DISPLAY -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE \
+              timeout 20s stdbuf -oL -eL "$binary" >"$stdout" 2>"$stderr"
+            status=$?
+            set -e
+            echo "::group::${label} stdout"
+            cat "$stdout"
+            echo "::endgroup::"
+            echo "::group::${label} stderr"
+            cat "$stderr"
+            echo "::endgroup::"
+            grep -Fq "gg multi-window backend:" "$stdout"
+            grep -Fq "mock backend selected; stopping after initial lifecycle events" "$stdout"
+            grep -Fq "live windows:" "$stdout"
+            grep -Fq "window created:" "$stdout"
+            if [ "$status" -ne 0 ]; then
+              echo "${label} failed with status $status"
+              exit "$status"
+            fi
+          }
+          run_x11_example() {
+            local label="$1"
+            local binary="$2"
+            local stdout
+            local stderr
+            local status
+            stdout="$(mktemp)"
+            stderr="$(mktemp)"
+            set +e
+            xvfb-run -a -s "-screen 0 1280x1024x24" \
+              env -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE LIBGL_ALWAYS_SOFTWARE=true \
+              timeout 12s stdbuf -oL -eL "$binary" >"$stdout" 2>"$stderr"
+            status=$?
+            set -e
+            echo "::group::${label} stdout"
+            cat "$stdout"
+            echo "::endgroup::"
+            echo "::group::${label} stderr"
+            cat "$stderr"
+            echo "::endgroup::"
+            grep -Fq "gg multi-window backend:" "$stdout"
+            grep -Fq "live windows:" "$stdout"
+            grep -Fq "window created:" "$stdout"
+            if [ "$status" -eq 124 ]; then
+              echo "${label} reached the controlled timeout after producing expected launch logs."
+              return 0
+            fi
+            return "$status"
+          }
+          run_headless_example "gg multiwindow headless mock" /tmp/gg_multiwindow_default
+          run_headless_example "gg multiwindow Wayland-build headless mock" /tmp/gg_multiwindow_wayland
+          run_x11_example "gg multiwindow Xvfb/X11" /tmp/gg_multiwindow_x11
 
       - name: Sample and compare
         id: compare

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -495,6 +495,93 @@ jobs:
         run: v run ci/linux_ci.vsh all_code_is_formatted_gcc
       - name: Install dependencies for examples and tools
         run: v run ci/linux_ci.vsh install_dependencies_for_examples_and_tools_gcc
+      - name: Multiwindow Linux checks
+        run: |
+          set -euo pipefail
+
+          env -u DISPLAY -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE \
+            ./v test vlib/gg/legacy_import_multiwindow_isolation_test.v
+
+          env -u DISPLAY -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE \
+            ./v -d gg_multiwindow test \
+              vlib/x/multiwindow \
+              vlib/gg/multiwindow_api_d_gg_multiwindow_test.v \
+              vlib/gg/frame_pacing_test.v \
+              vlib/gg/draw_fns_api_test.v \
+              vlib/gg/draw_rect_empty_test.v
+
+          env -u DISPLAY -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE \
+            ./v -d gg_multiwindow -d sokol_wayland test \
+              vlib/x/multiwindow \
+              vlib/gg/multiwindow_api_d_gg_multiwindow_test.v \
+              vlib/gg/frame_pacing_test.v \
+              vlib/gg/draw_fns_api_test.v \
+              vlib/gg/draw_rect_empty_test.v
+
+          xvfb-run -a -s "-screen 0 1280x1024x24" \
+            env -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE LIBGL_ALWAYS_SOFTWARE=true \
+            ./v -d gg_multiwindow -d x_multiwindow_x11 test \
+              vlib/x/multiwindow \
+              vlib/gg/multiwindow_api_d_gg_multiwindow_test.v \
+              vlib/gg/frame_pacing_test.v \
+              vlib/gg/draw_fns_api_test.v \
+              vlib/gg/draw_rect_empty_test.v
+
+          ./v -d gg_multiwindow -o /tmp/gg_multiwindow_default examples/gg/multiwindow.v
+          ./v -d gg_multiwindow -d x_multiwindow_x11 -o /tmp/gg_multiwindow_x11 examples/gg/multiwindow.v
+          ./v -d gg_multiwindow -d sokol_wayland -o /tmp/gg_multiwindow_wayland examples/gg/multiwindow.v
+
+          run_headless_example() {
+            label="$1"
+            binary="$2"
+            stdout="$(mktemp)"
+            stderr="$(mktemp)"
+            env -u DISPLAY -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE \
+              "$binary" >"$stdout" 2>"$stderr"
+            echo "::group::${label} stdout"
+            cat "$stdout"
+            echo "::endgroup::"
+            echo "::group::${label} stderr"
+            cat "$stderr"
+            echo "::endgroup::"
+            grep -Fq "gg multi-window backend: mock" "$stdout"
+            grep -Fq "capability families:" "$stdout"
+            grep -Fq "mock backend selected; stopping after initial lifecycle events" "$stdout"
+            grep -Fq "live windows:" "$stdout"
+            grep -Fq "window created:" "$stdout"
+          }
+
+          run_x11_example() {
+            label="$1"
+            binary="$2"
+            stdout="$(mktemp)"
+            stderr="$(mktemp)"
+            set +e
+            xvfb-run -a -s "-screen 0 1280x1024x24" \
+              env -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE LIBGL_ALWAYS_SOFTWARE=true \
+              timeout 12s stdbuf -oL -eL "$binary" >"$stdout" 2>"$stderr"
+            status=$?
+            set -e
+            echo "::group::${label} stdout"
+            cat "$stdout"
+            echo "::endgroup::"
+            echo "::group::${label} stderr"
+            cat "$stderr"
+            echo "::endgroup::"
+            grep -Fq "gg multi-window backend:" "$stdout"
+            grep -Fq "capability families:" "$stdout"
+            grep -Fq "live windows:" "$stdout"
+            grep -Fq "window created:" "$stdout"
+            if [ "$status" -eq 124 ]; then
+              echo "X11 example reached the controlled timeout after producing expected launch logs."
+              return 0
+            fi
+            return "$status"
+          }
+
+          run_headless_example "gg multiwindow headless mock" /tmp/gg_multiwindow_default
+          run_headless_example "gg multiwindow Wayland-build headless mock" /tmp/gg_multiwindow_wayland
+          run_x11_example "gg multiwindow Xvfb/X11" /tmp/gg_multiwindow_x11
       - name: Recompile V with -cstrict and gcc
         run: v run ci/linux_ci.vsh recompile_v_with_cstrict_gcc
       - name: Valgrind v.c

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -51,9 +51,46 @@ jobs:
       - name: Legacy gg import multiwindow isolation
         run: ./v test vlib/gg/legacy_import_multiwindow_isolation_test.v
       - name: Multiwindow Metal smoke
-        run: ./v -d gg_multiwindow -d sokol_metal test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v vlib/gg/frame_pacing_test.v vlib/gg/draw_fns_api_test.v
+        run: ./v -d gg_multiwindow -d sokol_metal test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v vlib/gg/frame_pacing_test.v vlib/gg/draw_fns_api_test.v vlib/gg/draw_rect_empty_test.v
+      - name: Test AppKit GLCore rejection guard
+        run: ./v -d gg_multiwindow -d darwin_sokol_glcore33 test vlib/x/multiwindow/multiwindow_test.v
       - name: Compile gg multiwindow example with Metal
         run: ./v -d gg_multiwindow -d sokol_metal -o /tmp/gg_multiwindow_metal examples/gg/multiwindow.v
+      - name: Run gg multiwindow example with Metal
+        run: |
+          python3 - <<'PY'
+          import subprocess
+          import sys
+
+          proc = subprocess.Popen(['/tmp/gg_multiwindow_metal'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+          timed_out = False
+          try:
+              stdout, stderr = proc.communicate(timeout=12)
+          except subprocess.TimeoutExpired:
+              timed_out = True
+              proc.kill()
+              stdout, stderr = proc.communicate()
+
+          print('::group::gg multiwindow Metal stdout')
+          print(stdout, end='')
+          print('::endgroup::')
+          print('::group::gg multiwindow Metal stderr')
+          print(stderr, end='')
+          print('::endgroup::')
+
+          for marker in ['gg multi-window backend:', 'live windows:', 'window created:']:
+              if marker not in stdout:
+                  print(f'Missing expected output marker: {marker}', file=sys.stderr)
+                  sys.exit(1)
+
+          if timed_out:
+              print('Metal example reached the controlled timeout after producing expected launch logs.')
+              sys.exit(0)
+
+          if proc.returncode != 0:
+              print(f'Metal example exited with {proc.returncode}.', file=sys.stderr)
+              sys.exit(proc.returncode)
+          PY
       - name: Test symlink
         run: v run ci/macos_ci.vsh test_symlink
       - name: v doctor

--- a/.github/workflows/windows_ci_gcc.yml
+++ b/.github/workflows/windows_ci_gcc.yml
@@ -149,7 +149,7 @@ jobs:
           gcc /tmp/d3d11_probe.c -ld3d11 -ldxgi -o /tmp/d3d11_probe.exe
       - name: Multiwindow D3D11 smoke with GCC
         shell: msys2 {0}
-        run: ./v.exe -cc gcc -d gg_multiwindow -d sokol_d3d11 test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v vlib/gg/frame_pacing_test.v vlib/gg/draw_fns_api_test.v
+        run: ./v.exe -cc gcc -d gg_multiwindow -d sokol_d3d11 test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v vlib/gg/frame_pacing_test.v vlib/gg/draw_fns_api_test.v vlib/gg/draw_rect_empty_test.v
       - name: Compile gg multiwindow example with D3D11 and GCC
         shell: msys2 {0}
         run: ./v.exe -cc gcc -d gg_multiwindow -d sokol_d3d11 -o gg_multiwindow_gcc.exe examples/gg/multiwindow.v

--- a/.github/workflows/windows_ci_msvc.yml
+++ b/.github/workflows/windows_ci_msvc.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Legacy gg import multiwindow isolation
         run: v -cc msvc test vlib/gg/legacy_import_multiwindow_isolation_test.v
       - name: Multiwindow D3D11 smoke
-        run: v -cc msvc -d gg_multiwindow -d sokol_d3d11 test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v vlib/gg/frame_pacing_test.v vlib/gg/draw_fns_api_test.v
+        run: v -cc msvc -d gg_multiwindow -d sokol_d3d11 test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v vlib/gg/frame_pacing_test.v vlib/gg/draw_fns_api_test.v vlib/gg/draw_rect_empty_test.v
       - name: Compile gg multiwindow example with D3D11
         run: v -cc msvc -d gg_multiwindow -d sokol_d3d11 -o "$env:TEMP\gg_multiwindow.exe" examples/gg/multiwindow.v
       - name: backend x64 regressions

--- a/ci/linux_ci.vsh
+++ b/ci/linux_ci.vsh
@@ -186,6 +186,7 @@ fn install_dependencies_for_examples_and_tools_gcc() {
 	exec('v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev')
 	// Wayland development libraries for sokol Wayland support
 	exec('v retry -- sudo apt install --quiet -y libwayland-dev libxkbcommon-dev libwayland-egl1-mesa libxkbcommon-x11-dev wayland-protocols libegl-dev')
+	exec('v retry -- sudo apt install --quiet -y libx11-dev libgl1-mesa-dri xauth xvfb')
 }
 
 fn recompile_v_with_cstrict_gcc() {

--- a/examples/gg/multiwindow.v
+++ b/examples/gg/multiwindow.v
@@ -10,10 +10,51 @@ module main
 
 import gg
 
-struct EventState {
-	mock bool
+const visible_last_event_limit = 4
+const visible_title_limit = 220
+const visual_margin = 18
+const visual_badge_size = 16
+const visual_counter_height = 12
+const client_chrome_titlebar_height = 36
+const client_chrome_frame_thickness = 5
+const client_chrome_resize_margin = 18
+const client_chrome_close_button_size = 18
+const client_chrome_close_button_margin = 9
+const client_chrome_control_gap = 7
+const client_chrome_title_text_scale = 2
+
+struct WindowDashboard {
+	id gg.WindowId
 mut:
-	resized int
+	label              string
+	live               bool
+	width              int
+	height             int
+	lifecycle          int
+	inputs             int
+	key                int
+	text               int
+	mouse              int
+	scroll             int
+	focus              int
+	drop               int
+	touch              int
+	clipboard          int
+	window             int
+	other              int
+	native_decorations bool
+	last_events        []string
+	last_families      []string
+}
+
+struct EventState {
+	mock        bool
+	input_limit int = 12
+mut:
+	caps           gg.Capabilities
+	resized        int
+	printed_inputs int
+	windows        []WindowDashboard
 }
 
 fn main() {
@@ -23,16 +64,34 @@ fn main() {
 	}
 }
 
+fn new_app_prefer_renderer() !&gg.App {
+	return gg.new_app(require_renderer: true) or {
+		println('render dashboard fallback: require_renderer unavailable')
+		return gg.new_app()!
+	}
+}
+
 fn run_example() ! {
-	mut app := gg.new_app()!
+	mut app := new_app_prefer_renderer()!
 	defer {
 		app.stop() or {}
 	}
 
-	caps := app.capabilities()
+	mut caps := app.capabilities()
 	println('gg multi-window backend: ${caps.backend}')
+	print_capability_families(caps)
 	if caps.mock {
+		println('render dashboard fallback: explicit swapchain unavailable')
 		println('mock backend selected; stopping after initial lifecycle events')
+	} else if caps.explicit_swapchain {
+		println('render dashboard enabled: explicit swapchain available')
+		println('visual dashboards enabled in each window; titles mirror exact state and counters')
+	} else {
+		println('render dashboard fallback: explicit swapchain unavailable')
+		println('renderer unavailable; titles show per-window state, backend, capabilities, last events, and counters')
+	}
+	if !caps.mock {
+		println('input logging enabled for key/mouse/focus/scroll/drop/touch events; first 12 events will be printed')
 	}
 
 	main_window := app.create_window(
@@ -50,42 +109,980 @@ fn run_example() ! {
 	resize_or_ignore_unsupported(mut app, main_window, 720, 420)!
 	resize_or_ignore_unsupported(mut app, tools_window, 360, 260)!
 
-	println('live windows:')
-	for info in app.window_infos()! {
-		println('  ${info.title}: ${info.width}x${info.height}')
-	}
-
 	mut state := &EventState{
 		mock: caps.mock
+		caps: caps
 	}
-	app.run(
-		event_fn: fn [mut state] (event gg.WindowEvent, mut app gg.App) ! {
-			match event.kind {
-				.window_created {
-					println('window created: ${event.window}')
-				}
-				.window_resized {
-					state.resized++
-					println('window resized: ${event.window} -> ${event.width}x${event.height}')
-					if state.mock && state.resized >= 2 {
-						app.stop()!
-					}
-				}
-				.window_close_requested {
-					println('window close requested: ${event.window}')
-					if app.window_exists(event.window) {
-						app.destroy_window(event.window)!
-					}
-				}
-				.window_destroyed {
-					println('window destroyed: ${event.window}')
-					if app.window_ids()!.len == 0 {
-						app.stop()!
-					}
+	state.track_window(main_window, 'Main', 720, 420)
+	state.track_window(tools_window, 'Tools', 360, 260)
+	state.sync_runtime(mut app)!
+	caps = state.caps
+	print_interactive_chrome_help(state.caps, state.has_client_chrome())
+	state.update_all_titles(mut app)!
+
+	println('live windows:')
+	for info in app.window_infos()! {
+		println('  ${info.title}: ${info.width}x${info.height} native_decorations=${info.native_decorations}')
+	}
+
+	if caps.explicit_swapchain {
+		app.run(
+			frame_fn: fn [mut state] (mut app gg.App) ! {
+				state.draw(mut app)!
+			}
+			event_fn: fn [mut state] (event gg.WindowEvent, mut app gg.App) ! {
+				handle_window_event(event, mut app, mut state)!
+			}
+			input_fn: fn [mut state] (event gg.WindowInputEvent, mut app gg.App) ! {
+				handle_input_event(event, mut app, mut state)!
+			}
+		)!
+	} else {
+		app.run(
+			event_fn: fn [mut state] (event gg.WindowEvent, mut app gg.App) ! {
+				handle_window_event(event, mut app, mut state)!
+			}
+			input_fn: fn [mut state] (event gg.WindowInputEvent, mut app gg.App) ! {
+				handle_input_event(event, mut app, mut state)!
+			}
+		)!
+	}
+}
+
+fn print_capability_families(caps gg.Capabilities) {
+	println('capability families:')
+	println('  windows=${caps.multi_window} owner_queue=${caps.owner_queue} native=${caps.native}')
+	println('  render explicit_swapchain=${caps.explicit_swapchain} gl=${caps.gl} metal=${caps.metal} d3d11=${caps.d3d11}')
+	println('  input=${caps.input_events} mouse=${caps.mouse_events} keyboard=${caps.keyboard_events} text=${caps.text_events} focus=${caps.focus_events} drop=${caps.drop_events} touch=${caps.touch_events}')
+	println('  chrome interactive_move_resize=${caps.interactive_move_resize} native_decorations=${caps.native_decorations} cursor_shapes=${caps.cursor_shapes}')
+}
+
+fn print_interactive_chrome_help(caps gg.Capabilities, has_client_chrome bool) {
+	if has_client_chrome {
+		println('Wayland client-side titlebar/frame enabled as fallback: drag the titlebar to move; drag frame edges/corners to resize; click the close button')
+		println('move/resize is started from gg.App input_fn using the current native user-action serial')
+		return
+	}
+	if caps.interactive_move_resize && caps.native_decorations {
+		println('interactive move/resize available through native decorations; client chrome demo disabled')
+		return
+	}
+	println('interactive move/resize unavailable for this backend; dashboard remains event-only')
+}
+
+fn handle_window_event(event gg.WindowEvent, mut app gg.App, mut state EventState) ! {
+	state.note_lifecycle(event)
+	state.update_window_title(mut app, event.window)!
+	match event.kind {
+		.window_created {
+			println('window created: ${event.window}')
+		}
+		.window_resized {
+			state.resized++
+			println('window resized: ${event.window} -> ${event.width}x${event.height}')
+			if state.mock && state.resized >= 2 {
+				app.stop()!
+			}
+		}
+		.window_close_requested {
+			println('window close requested: ${event.window}')
+			if app.window_exists(event.window) {
+				app.destroy_window(event.window)!
+			}
+		}
+		.window_destroyed {
+			println('window destroyed: ${event.window}')
+			if app.window_ids()!.len == 0 {
+				app.stop()!
+			}
+		}
+	}
+}
+
+fn handle_input_event(event gg.WindowInputEvent, mut app gg.App, mut state EventState) ! {
+	message := input_event_summary(event)
+	if message == '' {
+		return
+	}
+	state.note_input(event, message)
+	state.sync_runtime(mut app) or {}
+	native_decorations := state.window_native_decorations(event.window)
+	update_client_chrome_cursor(event, mut app, state.caps, native_decorations) or {}
+	action_message := maybe_begin_client_chrome_action(event, mut app, state.caps,
+		native_decorations) or { 'interactive chrome action failed: ${err.msg()}' }
+	if action_message != '' {
+		println(action_message)
+		state.note_chrome_action(event.window, action_message)
+	}
+	state.update_window_title(mut app, event.window)!
+	if state.printed_inputs >= state.input_limit {
+		return
+	}
+	state.printed_inputs++
+	println('input ${state.printed_inputs}/${state.input_limit}: ${message}')
+}
+
+fn (mut state EventState) track_window(id gg.WindowId, label string, width int, height int) {
+	if index := state.window_index(id) {
+		mut dashboard := state.windows[index]
+		dashboard.label = label
+		dashboard.live = true
+		dashboard.width = width
+		dashboard.height = height
+		state.windows[index] = dashboard
+		return
+	}
+	state.windows << WindowDashboard{
+		id:     id
+		label:  label
+		live:   true
+		width:  width
+		height: height
+	}
+}
+
+fn (state &EventState) window_index(id gg.WindowId) ?int {
+	target := id.str()
+	for i, dashboard in state.windows {
+		if dashboard.id.str() == target {
+			return i
+		}
+	}
+	return none
+}
+
+fn (mut state EventState) sync_runtime(mut app gg.App) ! {
+	state.caps = app.capabilities()
+	for info in app.window_infos()! {
+		index := state.ensure_window(info.id)
+		mut dashboard := state.windows[index]
+		dashboard.width = info.width
+		dashboard.height = info.height
+		dashboard.native_decorations = info.native_decorations
+		state.windows[index] = dashboard
+	}
+}
+
+fn (state &EventState) window_native_decorations(id gg.WindowId) bool {
+	if index := state.window_index(id) {
+		return state.windows[index].native_decorations
+	}
+	return state.caps.native_decorations
+}
+
+fn (state &EventState) has_client_chrome() bool {
+	for dashboard in state.windows {
+		if dashboard.live && client_chrome_enabled(state.caps, dashboard.native_decorations) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (mut state EventState) ensure_window(id gg.WindowId) int {
+	if index := state.window_index(id) {
+		return index
+	}
+	state.windows << WindowDashboard{
+		id:    id
+		label: 'Window ${state.windows.len + 1}'
+		live:  true
+	}
+	return state.windows.len - 1
+}
+
+fn (mut state EventState) note_lifecycle(event gg.WindowEvent) {
+	index := state.ensure_window(event.window)
+	mut dashboard := state.windows[index]
+	dashboard.lifecycle++
+	dashboard.window++
+	match event.kind {
+		.window_created {
+			dashboard.live = true
+			dashboard.width = event.width
+			dashboard.height = event.height
+			dashboard.add_last_event('created ${event.width}x${event.height}', 'window')
+		}
+		.window_resized {
+			dashboard.live = true
+			dashboard.width = event.width
+			dashboard.height = event.height
+			dashboard.add_last_event('resized ${event.width}x${event.height}', 'window')
+		}
+		.window_close_requested {
+			dashboard.add_last_event('close requested', 'window')
+		}
+		.window_destroyed {
+			dashboard.live = false
+			dashboard.add_last_event('destroyed', 'window')
+		}
+	}
+
+	state.windows[index] = dashboard
+}
+
+fn (mut state EventState) note_input(event gg.WindowInputEvent, message string) {
+	index := state.ensure_window(event.window)
+	mut dashboard := state.windows[index]
+	dashboard.inputs++
+	family := input_event_family(event.event)
+	match family {
+		'key' { dashboard.key++ }
+		'text' { dashboard.text++ }
+		'mouse' { dashboard.mouse++ }
+		'scroll' { dashboard.scroll++ }
+		'focus' { dashboard.focus++ }
+		'drop' { dashboard.drop++ }
+		'touch' { dashboard.touch++ }
+		'clipboard' { dashboard.clipboard++ }
+		'window' { dashboard.window++ }
+		else { dashboard.other++ }
+	}
+
+	dashboard.add_last_event(short_event_message(event.window, message), family)
+	state.windows[index] = dashboard
+}
+
+fn (mut state EventState) note_chrome_action(id gg.WindowId, message string) {
+	index := state.ensure_window(id)
+	mut dashboard := state.windows[index]
+	dashboard.window++
+	dashboard.add_last_event(short_event_message(id, message), 'window')
+	state.windows[index] = dashboard
+}
+
+fn input_event_family(input gg.Event) string {
+	return match input.typ {
+		.key_down, .key_up { 'key' }
+		.char { 'text' }
+		.mouse_down, .mouse_up, .mouse_move, .mouse_enter, .mouse_leave { 'mouse' }
+		.mouse_scroll { 'scroll' }
+		.focused, .unfocused { 'focus' }
+		.files_dropped { 'drop' }
+		.touches_began, .touches_moved, .touches_ended, .touches_cancelled { 'touch' }
+		.clipboard_pasted { 'clipboard' }
+		.resized, .iconified, .restored, .suspended, .resumed, .quit_requested { 'window' }
+		else { 'other' }
+	}
+}
+
+fn (mut dashboard WindowDashboard) add_last_event(message string, family string) {
+	dashboard.last_events << message
+	dashboard.last_families << family
+	for dashboard.last_events.len > visible_last_event_limit {
+		dashboard.last_events.delete(0)
+	}
+	for dashboard.last_families.len > visible_last_event_limit {
+		dashboard.last_families.delete(0)
+	}
+}
+
+fn short_event_message(window gg.WindowId, message string) string {
+	prefix := '${window}: '
+	if message.starts_with(prefix) {
+		return message[prefix.len..]
+	}
+	return message
+}
+
+fn (mut state EventState) update_all_titles(mut app gg.App) ! {
+	for dashboard in state.windows {
+		state.update_window_title(mut app, dashboard.id)!
+	}
+}
+
+fn (mut state EventState) update_window_title(mut app gg.App, id gg.WindowId) ! {
+	if !app.window_exists(id) {
+		return
+	}
+	index := state.window_index(id) or { return }
+	app.set_window_title(id, state.window_title(state.windows[index]))!
+}
+
+fn (state &EventState) window_title(dashboard WindowDashboard) string {
+	live := if dashboard.live { 'live ${dashboard.width}x${dashboard.height}' } else { 'closed' }
+	caps := compact_capabilities(state.caps, dashboard.native_decorations)
+	chrome := state.chrome_title_hint(dashboard)
+	last := if dashboard.last_events.len == 0 {
+		'last: waiting'
+	} else {
+		'last: ' + dashboard.last_events.join(' | ')
+	}
+	counters := 'events l=${dashboard.lifecycle} in=${dashboard.inputs} key=${dashboard.key} text=${dashboard.text} mouse=${dashboard.mouse}+${dashboard.scroll} focus=${dashboard.focus} drop=${dashboard.drop} touch=${dashboard.touch} clip=${dashboard.clipboard} win=${dashboard.window} other=${dashboard.other}'
+	return truncate_title('${dashboard.label} | ${state.caps.backend} ${caps} | ${chrome} | ${live} | ${counters} | ${last}')
+}
+
+fn (state &EventState) chrome_title_hint(dashboard WindowDashboard) string {
+	if client_chrome_enabled(state.caps, dashboard.native_decorations) {
+		return 'chrome: Wayland client-side titlebar/frame fallback'
+	}
+	if state.caps.interactive_move_resize && dashboard.native_decorations {
+		return 'chrome: native decorations'
+	}
+	return 'chrome: move/resize unavailable'
+}
+
+fn compact_capabilities(caps gg.Capabilities, native_decorations bool) string {
+	mut tags := []string{}
+	if caps.native {
+		tags << 'native'
+	} else {
+		tags << 'mock'
+	}
+	if caps.explicit_swapchain {
+		tags << 'render'
+	}
+	if caps.mouse_events {
+		tags << 'mouse'
+	}
+	if caps.keyboard_events {
+		tags << 'key'
+	}
+	if caps.text_events {
+		tags << 'text'
+	}
+	if caps.focus_events {
+		tags << 'focus'
+	}
+	if caps.drop_events {
+		tags << 'drop'
+	}
+	if caps.touch_events {
+		tags << 'touch'
+	}
+	if caps.interactive_move_resize {
+		tags << 'move-resize'
+	}
+	if native_decorations {
+		tags << 'native-decor'
+	} else if caps.wayland && caps.interactive_move_resize {
+		tags << 'client-chrome'
+	}
+	return '[' + tags.join(',') + ']'
+}
+
+fn truncate_title(title string) string {
+	if title.len <= visible_title_limit {
+		return title
+	}
+	return title[..visible_title_limit] + '...'
+}
+
+fn (mut state EventState) draw(mut app gg.App) ! {
+	caps := state.caps
+	for dashboard in state.windows {
+		if !dashboard.live || !app.window_exists(dashboard.id) {
+			continue
+		}
+		app.draw_window(dashboard.id, fn [dashboard, caps] (mut window gg.WindowContext) ! {
+			draw_window_dashboard(mut window, dashboard, caps)
+		})!
+	}
+}
+
+fn draw_window_dashboard(mut window gg.WindowContext, dashboard WindowDashboard, caps gg.Capabilities) {
+	size := window.size()
+	width := max_int(220, size.width)
+	height := max_int(180, size.height)
+	inner_width := max_int(64, width - 2 * visual_margin)
+	client_chrome := client_chrome_enabled(caps, dashboard.native_decorations)
+	content_top := if client_chrome {
+		client_chrome_titlebar_height + client_chrome_frame_thickness
+	} else {
+		0
+	}
+	window.draw_rect_filled(0, 0, f32(width), f32(height), dashboard_background(caps))
+	draw_client_chrome_zones(mut window, dashboard, caps, width, height)
+	if client_chrome {
+		window.draw_rect_empty(f32(client_chrome_frame_thickness + 6), f32(content_top + 6), f32(
+			width - 2 * client_chrome_frame_thickness - 12), f32(height - content_top -
+			client_chrome_frame_thickness - 12), gg.rgb(88, 101, 118))
+	} else {
+		window.draw_rect_filled(0, 0, f32(width), 10, backend_color(caps))
+		window.draw_rect_empty(8, 8, f32(width - 16), f32(height - 16), gg.rgb(96, 116, 142))
+	}
+
+	draw_lifecycle_panel(mut window, dashboard, caps, width, height, content_top)
+	draw_capability_badges(mut window, caps, visual_margin, content_top + 28)
+	draw_counter_bars(mut window, dashboard, visual_margin, content_top + 72, inner_width)
+	draw_last_event_strip(mut window, dashboard, visual_margin, height - 54, inner_width)
+}
+
+fn draw_client_chrome_zones(mut window gg.WindowContext, dashboard WindowDashboard, caps gg.Capabilities, width int, height int) {
+	if !client_chrome_enabled(caps, dashboard.native_decorations) {
+		return
+	}
+	titlebar := client_chrome_titlebar_height
+	frame := client_chrome_frame_thickness
+	inner_width := max_int(0, width - 2 * frame)
+	inner_height := max_int(0, height - titlebar - frame)
+	window.draw_rect_filled(0, 0, f32(width), f32(height), gg.rgb(44, 50, 60))
+	window.draw_rect_filled(f32(frame), f32(titlebar), f32(inner_width), f32(inner_height),
+		dashboard_background(caps))
+	window.draw_rect_filled(f32(frame), f32(frame), f32(inner_width), f32(titlebar - frame), gg.rgb(48,
+		56, 68))
+	window.draw_rect_filled(f32(frame), f32(frame), f32(inner_width), 1, gg.rgb(89, 101, 118))
+	window.draw_rect_filled(f32(frame), f32(titlebar - 1), f32(inner_width), 1, gg.rgb(24, 30, 38))
+	window.draw_rect_empty(0, 0, f32(width), f32(height), gg.rgb(20, 25, 32))
+	window.draw_rect_empty(1, 1, f32(width - 2), f32(height - 2), gg.rgb(82, 94, 110))
+	draw_client_chrome_title(mut window, dashboard.label, width)
+	draw_client_chrome_titlebar_separators(mut window, width)
+	draw_client_chrome_minimize_button(mut window, width)
+	draw_client_chrome_maximize_button(mut window, width)
+	draw_client_chrome_close_button(mut window, width)
+}
+
+fn draw_client_chrome_minimize_button(mut window gg.WindowContext, width int) {
+	x := window_control_button_x(width, 2)
+	y := close_button_y()
+	size := f32(client_chrome_close_button_size)
+	draw_client_chrome_control_button(mut window, x, y, gg.rgb(68, 78, 92), gg.rgb(126, 140, 158))
+	window.draw_rect_filled(x + 5, y + size - 6, size - 10, 2, gg.rgb(218, 224, 232))
+}
+
+fn draw_client_chrome_maximize_button(mut window gg.WindowContext, width int) {
+	x := window_control_button_x(width, 1)
+	y := close_button_y()
+	draw_client_chrome_control_button(mut window, x, y, gg.rgb(68, 78, 92), gg.rgb(126, 140, 158))
+	window.draw_rect_empty(x + 5, y + 5, 8, 8, gg.rgb(218, 224, 232))
+	window.draw_rect_filled(x + 6, y + 5, 6, 1, gg.rgb(218, 224, 232))
+}
+
+fn draw_client_chrome_close_button(mut window gg.WindowContext, width int) {
+	x := close_button_x(width)
+	y := close_button_y()
+	size := f32(client_chrome_close_button_size)
+	draw_client_chrome_control_button(mut window, x, y, gg.rgb(178, 71, 72), gg.rgb(234, 150, 145))
+	for offset in 0 .. 5 {
+		step := f32(offset * 2)
+		window.draw_rect_filled(x + 5 + step, y + 5 + step, 2, 2, gg.rgb(250, 236, 232))
+		window.draw_rect_filled(x + 5 + step, y + size - 7 - step, 2, 2, gg.rgb(250, 236, 232))
+	}
+}
+
+fn draw_client_chrome_control_button(mut window gg.WindowContext, x f32, y f32, fill gg.Color, border gg.Color) {
+	size := f32(client_chrome_close_button_size)
+	window.draw_rect_filled(x, y, size, size, fill)
+	window.draw_rect_empty(x, y, size, size, border)
+}
+
+fn draw_client_chrome_titlebar_separators(mut window gg.WindowContext, width int) {
+	frame := client_chrome_frame_thickness
+	inner_width := max_int(0, width - 2 * frame)
+	titlebar := client_chrome_titlebar_height
+	separator_x := int(window_control_button_x(width, 2)) - client_chrome_control_gap
+	window.draw_rect_filled(f32(frame), f32(titlebar), f32(inner_width), 1, gg.rgb(14, 18, 24))
+	window.draw_rect_filled(f32(frame), f32(titlebar + 1), f32(inner_width), 1, gg.rgb(77, 88, 104))
+	if separator_x > frame + 80 {
+		window.draw_rect_filled(f32(separator_x), f32(frame + 6), 1, f32(titlebar - frame - 12), gg.rgb(28,
+			34, 43))
+		window.draw_rect_filled(f32(separator_x + 1), f32(frame + 6), 1,
+			f32(titlebar - frame - 12), gg.rgb(83, 94, 110))
+	}
+}
+
+fn draw_client_chrome_title(mut window gg.WindowContext, title string, width int) {
+	x := client_chrome_frame_thickness + 14
+	y := (client_chrome_titlebar_height - 7 * client_chrome_title_text_scale) / 2
+	max_width := int(window_control_button_x(width, 2)) - x - 18
+	draw_tiny_text(mut window, title, x, y, max_width, client_chrome_title_text_scale, gg.rgb(230,
+		235, 240))
+}
+
+fn draw_tiny_text(mut window gg.WindowContext, text string, x int, y int, max_width int, scale int, color gg.Color) {
+	if max_width <= 0 || scale <= 0 {
+		return
+	}
+	upper := text.to_upper()
+	mut cursor_x := x
+	for i in 0 .. upper.len {
+		if cursor_x + 5 * scale > x + max_width {
+			return
+		}
+		ch := upper[i]
+		if ch == ` ` {
+			cursor_x += 4 * scale
+			continue
+		}
+		glyph := tiny_title_glyph(ch)
+		for row, bits in glyph {
+			for col in 0 .. bits.len {
+				if bits[col] == `1` {
+					window.draw_rect_filled(f32(cursor_x + col * scale), f32(y + row * scale),
+						f32(scale), f32(scale), color)
 				}
 			}
 		}
-	)!
+		cursor_x += 6 * scale
+	}
+}
+
+fn tiny_title_glyph(ch u8) []string {
+	return match ch {
+		`A` { ['01110', '10001', '10001', '11111', '10001', '10001', '10001'] }
+		`B` { ['11110', '10001', '10001', '11110', '10001', '10001', '11110'] }
+		`C` { ['01111', '10000', '10000', '10000', '10000', '10000', '01111'] }
+		`D` { ['11110', '10001', '10001', '10001', '10001', '10001', '11110'] }
+		`E` { ['11111', '10000', '10000', '11110', '10000', '10000', '11111'] }
+		`F` { ['11111', '10000', '10000', '11110', '10000', '10000', '10000'] }
+		`G` { ['01111', '10000', '10000', '10011', '10001', '10001', '01110'] }
+		`H` { ['10001', '10001', '10001', '11111', '10001', '10001', '10001'] }
+		`I` { ['11111', '00100', '00100', '00100', '00100', '00100', '11111'] }
+		`J` { ['00111', '00010', '00010', '00010', '10010', '10010', '01100'] }
+		`K` { ['10001', '10010', '10100', '11000', '10100', '10010', '10001'] }
+		`L` { ['10000', '10000', '10000', '10000', '10000', '10000', '11111'] }
+		`M` { ['10001', '11011', '10101', '10101', '10001', '10001', '10001'] }
+		`N` { ['10001', '11001', '10101', '10011', '10001', '10001', '10001'] }
+		`O` { ['01110', '10001', '10001', '10001', '10001', '10001', '01110'] }
+		`P` { ['11110', '10001', '10001', '11110', '10000', '10000', '10000'] }
+		`Q` { ['01110', '10001', '10001', '10001', '10101', '10010', '01101'] }
+		`R` { ['11110', '10001', '10001', '11110', '10100', '10010', '10001'] }
+		`S` { ['01111', '10000', '10000', '01110', '00001', '00001', '11110'] }
+		`T` { ['11111', '00100', '00100', '00100', '00100', '00100', '00100'] }
+		`U` { ['10001', '10001', '10001', '10001', '10001', '10001', '01110'] }
+		`V` { ['10001', '10001', '10001', '10001', '01010', '01010', '00100'] }
+		`W` { ['10001', '10001', '10001', '10101', '10101', '10101', '01010'] }
+		`X` { ['10001', '01010', '00100', '00100', '00100', '01010', '10001'] }
+		`Y` { ['10001', '01010', '00100', '00100', '00100', '00100', '00100'] }
+		`Z` { ['11111', '00001', '00010', '00100', '01000', '10000', '11111'] }
+		`0` { ['01110', '10001', '10011', '10101', '11001', '10001', '01110'] }
+		`1` { ['00100', '01100', '00100', '00100', '00100', '00100', '01110'] }
+		`2` { ['01110', '10001', '00001', '00010', '00100', '01000', '11111'] }
+		`3` { ['11110', '00001', '00001', '01110', '00001', '00001', '11110'] }
+		`4` { ['10010', '10010', '10010', '11111', '00010', '00010', '00010'] }
+		`5` { ['11111', '10000', '10000', '11110', '00001', '00001', '11110'] }
+		`6` { ['01110', '10000', '10000', '11110', '10001', '10001', '01110'] }
+		`7` { ['11111', '00001', '00010', '00100', '01000', '01000', '01000'] }
+		`8` { ['01110', '10001', '10001', '01110', '10001', '10001', '01110'] }
+		`9` { ['01110', '10001', '10001', '01111', '00001', '00001', '01110'] }
+		`-` { ['00000', '00000', '00000', '01110', '00000', '00000', '00000'] }
+		else { ['11111', '00001', '00010', '00100', '00100', '00000', '00100'] }
+	}
+}
+
+fn draw_lifecycle_panel(mut window gg.WindowContext, dashboard WindowDashboard, caps gg.Capabilities, width int, height int, content_top int) {
+	status_color := if dashboard.live { gg.rgb(82, 196, 126) } else { gg.rgb(196, 82, 82) }
+	activity_color := if dashboard.last_families.len == 0 {
+		gg.rgb(78, 88, 104)
+	} else {
+		event_family_color(dashboard.last_families[dashboard.last_families.len - 1])
+	}
+	panel_y := content_top + 20
+	window.draw_rect_filled(visual_margin, panel_y, 46, 8, status_color)
+	if client_chrome_enabled(caps, dashboard.native_decorations) {
+		window.draw_rect_filled(f32(width - 54), f32(panel_y), 34, 34, activity_color)
+		window.draw_rect_empty(f32(width - 56), f32(panel_y - 2), 38, 38, gg.rgb(176, 188, 204))
+	} else {
+		window.draw_rect_filled(visual_margin + 56, panel_y, 72, 8, gg.rgb(78, 88, 104))
+		window.draw_rect_empty(visual_margin + 56, panel_y, 72, 8, gg.rgb(122, 135, 152))
+	}
+	window.draw_rect_filled(visual_margin, f32(height - 20), f32(max_int(8, min_int(width - 2 * visual_margin,
+		dashboard.width / 5))), 4, status_color)
+}
+
+fn draw_capability_badges(mut window gg.WindowContext, caps gg.Capabilities, x int, y int) {
+	mut badge_x := x
+	draw_capability_badge(mut window, badge_x, y, caps.native, gg.rgb(46, 180, 125))
+	badge_x += visual_badge_size + 8
+	draw_capability_badge(mut window, badge_x, y, caps.explicit_swapchain, gg.rgb(86, 160, 255))
+	badge_x += visual_badge_size + 8
+	draw_capability_badge(mut window, badge_x, y, caps.mouse_events, gg.rgb(244, 172, 68))
+	badge_x += visual_badge_size + 8
+	draw_capability_badge(mut window, badge_x, y, caps.keyboard_events, gg.rgb(238, 98, 98))
+	badge_x += visual_badge_size + 8
+	draw_capability_badge(mut window, badge_x, y, caps.text_events, gg.rgb(184, 116, 255))
+	badge_x += visual_badge_size + 8
+	draw_capability_badge(mut window, badge_x, y, caps.focus_events, gg.rgb(94, 217, 236))
+	badge_x += visual_badge_size + 8
+	draw_capability_badge(mut window, badge_x, y, caps.drop_events, gg.rgb(238, 214, 92))
+	badge_x += visual_badge_size + 8
+	draw_capability_badge(mut window, badge_x, y, caps.touch_events, gg.rgb(255, 137, 196))
+}
+
+fn draw_capability_badge(mut window gg.WindowContext, x int, y int, enabled bool, color gg.Color) {
+	fill := if enabled { color } else { gg.rgb(42, 48, 58) }
+	border := if enabled { gg.rgb(220, 230, 240) } else { gg.rgb(80, 88, 100) }
+	window.draw_rect_filled(f32(x), f32(y), visual_badge_size, visual_badge_size, fill)
+	window.draw_rect_empty(f32(x), f32(y), visual_badge_size, visual_badge_size, border)
+}
+
+fn draw_counter_bars(mut window gg.WindowContext, dashboard WindowDashboard, x int, y int, width int) {
+	max_value := dashboard.max_counter()
+	mut row_y := y
+	draw_counter_bar(mut window, x, row_y, width, dashboard.lifecycle, max_value,
+		event_family_color('window'))
+	row_y += visual_counter_height + 7
+	draw_counter_bar(mut window, x, row_y, width, dashboard.key, max_value,
+		event_family_color('key'))
+	row_y += visual_counter_height + 7
+	draw_counter_bar(mut window, x, row_y, width, dashboard.mouse + dashboard.scroll, max_value,
+		event_family_color('mouse'))
+	row_y += visual_counter_height + 7
+	draw_counter_bar(mut window, x, row_y, width, dashboard.focus, max_value,
+		event_family_color('focus'))
+	row_y += visual_counter_height + 7
+	draw_counter_bar(mut window, x, row_y, width, dashboard.drop + dashboard.touch +
+		dashboard.clipboard, max_value, event_family_color('drop'))
+	row_y += visual_counter_height + 7
+	draw_counter_bar(mut window, x, row_y, width, dashboard.text + dashboard.other, max_value,
+		event_family_color('text'))
+}
+
+fn draw_counter_bar(mut window gg.WindowContext, x int, y int, width int, value int, max_value int, color gg.Color) {
+	window.draw_rect_filled(f32(x), f32(y), f32(width), visual_counter_height, gg.rgb(38, 45, 56))
+	if value <= 0 {
+		window.draw_rect_empty(f32(x), f32(y), f32(width), visual_counter_height,
+			gg.rgb(64, 73, 88))
+		return
+	}
+	bar_width := scaled_width(value, max_value, width)
+	window.draw_rect_filled(f32(x), f32(y), f32(bar_width), visual_counter_height, color)
+	window.draw_rect_empty(f32(x), f32(y), f32(width), visual_counter_height, gg.rgb(132, 148, 168))
+}
+
+fn draw_last_event_strip(mut window gg.WindowContext, dashboard WindowDashboard, x int, y int, width int) {
+	slot_width := max_int(18, width / visible_last_event_limit)
+	for slot in 0 .. visible_last_event_limit {
+		family := if slot < dashboard.last_families.len {
+			dashboard.last_families[slot]
+		} else {
+			'empty'
+		}
+		color := event_family_color(family)
+		slot_x := x + slot * slot_width
+		window.draw_rect_filled(f32(slot_x), f32(y), f32(slot_width - 6), 22, color)
+		window.draw_rect_empty(f32(slot_x), f32(y), f32(slot_width - 6), 22, gg.rgb(156, 170, 188))
+	}
+}
+
+fn (dashboard WindowDashboard) max_counter() int {
+	mut maximum := 1
+	maximum = max_int(maximum, dashboard.lifecycle)
+	maximum = max_int(maximum, dashboard.key)
+	maximum = max_int(maximum, dashboard.text)
+	maximum = max_int(maximum, dashboard.mouse + dashboard.scroll)
+	maximum = max_int(maximum, dashboard.focus)
+	maximum = max_int(maximum, dashboard.drop + dashboard.touch + dashboard.clipboard)
+	maximum = max_int(maximum, dashboard.window)
+	maximum = max_int(maximum, dashboard.other)
+	return maximum
+}
+
+fn scaled_width(value int, max_value int, width int) int {
+	if value <= 0 || width <= 0 {
+		return 0
+	}
+	raw := value * width / max_int(1, max_value)
+	return max_int(8, min_int(width, raw))
+}
+
+fn dashboard_background(caps gg.Capabilities) gg.Color {
+	if caps.mock {
+		return gg.rgb(28, 34, 42)
+	}
+	if caps.win32 {
+		return gg.rgb(24, 36, 54)
+	}
+	if caps.backend == .appkit {
+		return gg.rgb(38, 31, 45)
+	}
+	if caps.x11 {
+		return gg.rgb(28, 42, 34)
+	}
+	if caps.wayland {
+		return gg.rgb(38, 39, 28)
+	}
+	return gg.rgb(30, 32, 38)
+}
+
+fn backend_color(caps gg.Capabilities) gg.Color {
+	if caps.mock {
+		return gg.rgb(104, 120, 140)
+	}
+	if caps.win32 {
+		return gg.rgb(66, 150, 255)
+	}
+	if caps.backend == .appkit {
+		return gg.rgb(236, 112, 164)
+	}
+	if caps.x11 {
+		return gg.rgb(82, 196, 126)
+	}
+	if caps.wayland {
+		return gg.rgb(230, 196, 76)
+	}
+	return gg.rgb(150, 160, 176)
+}
+
+fn event_family_color(family string) gg.Color {
+	return match family {
+		'window' { gg.rgb(88, 166, 255) }
+		'key' { gg.rgb(238, 98, 98) }
+		'text' { gg.rgb(184, 116, 255) }
+		'mouse' { gg.rgb(244, 172, 68) }
+		'scroll' { gg.rgb(245, 196, 82) }
+		'focus' { gg.rgb(94, 217, 236) }
+		'drop' { gg.rgb(238, 214, 92) }
+		'touch' { gg.rgb(255, 137, 196) }
+		'clipboard' { gg.rgb(116, 222, 164) }
+		'other' { gg.rgb(170, 180, 196) }
+		else { gg.rgb(52, 60, 72) }
+	}
+}
+
+fn max_int(a int, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+fn min_int(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+fn input_event_summary(event gg.WindowInputEvent) string {
+	input := event.event
+	match input.typ {
+		.key_down {
+			return '${event.window}: key down ${input.key_code} repeat=${input.key_repeat} modifiers=${input.modifiers}'
+		}
+		.key_up {
+			return '${event.window}: key up ${input.key_code} modifiers=${input.modifiers}'
+		}
+		.char {
+			return '${event.window}: char code ${input.char_code}'
+		}
+		.mouse_down {
+			return '${event.window}: mouse down ${input.mouse_button} at ${input.mouse_x},${input.mouse_y}'
+		}
+		.mouse_up {
+			return '${event.window}: mouse up ${input.mouse_button} at ${input.mouse_x},${input.mouse_y}'
+		}
+		.mouse_move {
+			return '${event.window}: mouse move ${input.mouse_x},${input.mouse_y} delta=${input.mouse_dx},${input.mouse_dy}'
+		}
+		.mouse_scroll {
+			return '${event.window}: scroll ${input.scroll_x},${input.scroll_y} at ${input.mouse_x},${input.mouse_y}'
+		}
+		.mouse_enter {
+			return '${event.window}: mouse enter'
+		}
+		.mouse_leave {
+			return '${event.window}: mouse leave'
+		}
+		.touches_began {
+			return '${event.window}: touches began count=${input.num_touches}'
+		}
+		.touches_moved {
+			return '${event.window}: touches moved count=${input.num_touches}'
+		}
+		.touches_ended {
+			return '${event.window}: touches ended count=${input.num_touches}'
+		}
+		.touches_cancelled {
+			return '${event.window}: touches cancelled count=${input.num_touches}'
+		}
+		.resized {
+			return '${event.window}: resized ${input.window_width}x${input.window_height} framebuffer=${input.framebuffer_width}x${input.framebuffer_height}'
+		}
+		.iconified {
+			return '${event.window}: iconified'
+		}
+		.restored {
+			return '${event.window}: restored'
+		}
+		.focused {
+			return '${event.window}: focused'
+		}
+		.unfocused {
+			return '${event.window}: unfocused'
+		}
+		.suspended {
+			return '${event.window}: suspended'
+		}
+		.resumed {
+			return '${event.window}: resumed'
+		}
+		.quit_requested {
+			return '${event.window}: quit requested'
+		}
+		.clipboard_pasted {
+			return '${event.window}: clipboard pasted'
+		}
+		.files_dropped {
+			return '${event.window}: ${event.dropped_files.len} file(s) dropped'
+		}
+		else {
+			return ''
+		}
+	}
+}
+
+fn maybe_begin_client_chrome_action(event gg.WindowInputEvent, mut app gg.App, caps gg.Capabilities, native_decorations bool) !string {
+	if !client_chrome_enabled(caps, native_decorations) {
+		return ''
+	}
+	input := event.event
+	if input.typ != .mouse_down || input.mouse_button != .left {
+		return ''
+	}
+	if close_button_hit_at(input.mouse_x, input.mouse_y, input.window_width, input.window_height) {
+		app.destroy_window(event.window)!
+		return '${event.window}: client chrome close button destroyed window'
+	}
+	inactive_control := inactive_client_chrome_control_hit_at(input.mouse_x, input.mouse_y,
+		input.window_width, input.window_height)
+	if inactive_control {
+		return ''
+	}
+	if edge := resize_edge_at(input.mouse_x, input.mouse_y, input.window_width, input.window_height) {
+		app.begin_window_resize(event.window, edge)!
+		return '${event.window}: interactive resize ${edge} started'
+	}
+	if move_hit_at(input.mouse_x, input.mouse_y, input.window_width, input.window_height) {
+		app.begin_window_move(event.window)!
+		return '${event.window}: interactive move started'
+	}
+	return ''
+}
+
+fn update_client_chrome_cursor(event gg.WindowInputEvent, mut app gg.App, caps gg.Capabilities, native_decorations bool) ! {
+	if !client_chrome_enabled(caps, native_decorations) || !caps.cursor_shapes {
+		return
+	}
+	input := event.event
+	match input.typ {
+		.mouse_leave {
+			app.set_window_cursor(event.window, .default)!
+		}
+		.mouse_enter, .mouse_move {
+			shape := client_chrome_cursor_shape_at(input.mouse_x, input.mouse_y,
+				input.window_width, input.window_height)
+			app.set_window_cursor(event.window, shape)!
+		}
+		else {}
+	}
+}
+
+fn client_chrome_cursor_shape_at(x f32, y f32, width int, height int) gg.WindowCursorShape {
+	if close_button_hit_at(x, y, width, height) {
+		return .pointer
+	}
+	if inactive_client_chrome_control_hit_at(x, y, width, height) {
+		return .default
+	}
+	if edge := resize_edge_at(x, y, width, height) {
+		return cursor_shape_for_resize_edge(edge)
+	}
+	if move_hit_at(x, y, width, height) {
+		return .move
+	}
+	return .default
+}
+
+fn cursor_shape_for_resize_edge(edge gg.WindowResizeEdge) gg.WindowCursorShape {
+	return match edge {
+		.top, .bottom { .ns_resize }
+		.left, .right { .ew_resize }
+		.top_left, .bottom_right { .nwse_resize }
+		.top_right, .bottom_left { .nesw_resize }
+	}
+}
+
+fn client_chrome_enabled(caps gg.Capabilities, native_decorations bool) bool {
+	return caps.wayland && caps.interactive_move_resize && !native_decorations
+}
+
+fn move_hit_at(x f32, y f32, width int, height int) bool {
+	if width <= 2 * client_chrome_resize_margin || height <= client_chrome_titlebar_height {
+		return false
+	}
+	if client_chrome_titlebar_control_hit_at(x, y, width, height) {
+		return false
+	}
+	return x > f32(client_chrome_resize_margin) && x < f32(width - client_chrome_resize_margin)
+		&& y >= 0 && y <= f32(client_chrome_titlebar_height)
+}
+
+fn inactive_client_chrome_control_hit_at(x f32, y f32, width int, height int) bool {
+	return window_control_button_hit_at(x, y, width, height, 1)
+		|| window_control_button_hit_at(x, y, width, height, 2)
+}
+
+fn client_chrome_titlebar_control_hit_at(x f32, y f32, width int, height int) bool {
+	return close_button_hit_at(x, y, width, height)
+		|| inactive_client_chrome_control_hit_at(x, y, width, height)
+}
+
+fn close_button_hit_at(x f32, y f32, width int, height int) bool {
+	return window_control_button_hit_at(x, y, width, height, 0)
+}
+
+fn window_control_button_hit_at(x f32, y f32, width int, height int, index_from_right int) bool {
+	if width <= 0 || height <= client_chrome_titlebar_height {
+		return false
+	}
+	button_x := window_control_button_x(width, index_from_right)
+	button_y := close_button_y()
+	button_size := f32(client_chrome_close_button_size)
+	return x >= button_x && x <= button_x + button_size && y >= button_y
+		&& y <= button_y + button_size
+}
+
+fn close_button_x(width int) f32 {
+	return window_control_button_x(width, 0)
+}
+
+fn window_control_button_x(width int, index_from_right int) f32 {
+	step := client_chrome_close_button_size + client_chrome_control_gap
+	return f32(width - client_chrome_close_button_margin - client_chrome_close_button_size -
+		index_from_right * step)
+}
+
+fn close_button_y() f32 {
+	return f32((client_chrome_titlebar_height - client_chrome_close_button_size) / 2)
+}
+
+fn resize_edge_at(x f32, y f32, width int, height int) ?gg.WindowResizeEdge {
+	if width <= 0 || height <= 0 {
+		return none
+	}
+	margin := f32(client_chrome_resize_margin)
+	w := f32(width)
+	h := f32(height)
+	near_left := x >= 0 && x <= margin
+	near_right := x >= w - margin && x <= w
+	near_top := y >= 0 && y <= margin
+	near_bottom := y >= h - margin && y <= h
+	if near_top && near_left {
+		return gg.WindowResizeEdge.top_left
+	}
+	if near_top && near_right {
+		return gg.WindowResizeEdge.top_right
+	}
+	if near_top {
+		return gg.WindowResizeEdge.top
+	}
+	if near_bottom && near_left {
+		return gg.WindowResizeEdge.bottom_left
+	}
+	if near_bottom && near_right {
+		return gg.WindowResizeEdge.bottom_right
+	}
+	if near_bottom {
+		return gg.WindowResizeEdge.bottom
+	}
+	if near_left {
+		return gg.WindowResizeEdge.left
+	}
+	if near_right {
+		return gg.WindowResizeEdge.right
+	}
+	return none
 }
 
 fn resize_or_ignore_unsupported(mut app gg.App, window gg.WindowId, width int, height int) ! {

--- a/vlib/gg/README.md
+++ b/vlib/gg/README.md
@@ -109,6 +109,75 @@ current. Linux X11 rendering, including under Xvfb, needs both flags:
 xvfb-run -a v -d gg_multiwindow -d x_multiwindow_x11 run examples/gg/multiwindow.v
 ```
 
+### Multi-Window Events
+
+`gg.App.run()` dispatches window lifecycle events through `event_fn` and input
+events through `input_fn`. Lifecycle events use `gg.WindowEvent` and cover
+created, resized, close-requested and destroyed windows. Input events use
+`gg.WindowInputEvent`, which adds the target `gg.WindowId` to the normal
+`gg.Event` payload so existing key, mouse, scroll, focus and window-state event
+fields keep the same gg-facing types.
+For native multi-window events, `gg.Event.frame_count` is assigned by the
+underlying multi-window owner poll cycle so events collected by the same
+`app.poll_events()` call share a frame count.
+
+`input_fn` has the `gg.AppInputFn` shape:
+
+```v ignore
+fn (event gg.WindowInputEvent, mut app gg.App) !
+```
+
+For manual owner loops, call `app.poll_events()` to collect backend events, then
+`app.drain_events()` for lifecycle events and `app.drain_input_events()` for
+window-scoped input events. `app.run()` dispatches lifecycle and input callbacks
+from the ordered backend queue; the separate drain functions are useful when the
+application wants to process the two streams independently.
+
+Input support is capability-driven. Check `app.capabilities()` before relying
+on a class of native events: `input_events`, `mouse_events`, `keyboard_events`,
+`text_events`, `focus_events`, `drop_events` and `touch_events` report what the
+selected backend can actually deliver. `cursor_shapes` reports whether
+`app.set_window_cursor(id, shape)` can update native hover cursor feedback, and
+is independent from interactive move/resize support. `interactive_move_resize`
+reports whether the runtime backend has the native handles needed for
+`app.begin_window_move(id)` and `app.begin_window_resize(id, edge)`;
+individual calls can still fail when the platform requires a recent user-action
+serial. `native_decorations` reports whether native/server-side window
+decorations are effective for the running backend. Plain capability probes do
+not necessarily open a display, so runtime globals are authoritative only after
+`gg.new_app()` via `app.capabilities()`; on Wayland that includes `wl_touch` for
+touch, `wl_data_device` for drops, seats for interactive move/resize, and
+xdg-decoration negotiation for native decorations. Wayland cursor-shape
+reporting is stricter: `cursor_shapes` is true only after a
+`wp_cursor_shape_device_v1` has been created for the active `wl_pointer`.
+Wayland requests server-side decorations through xdg-decoration when available;
+the compositor's `configure(mode)` decides the effective `server_side` or
+`client_side` mode. If `server_side` is refused or xdg-decoration is
+unavailable, apps and examples may draw a client-side fallback. Wayland cursor
+shape feedback uses `wp_cursor_shape_manager_v1` when the compositor exposes it
+and the seat has a pointer; cursor theme selection remains compositor-side.
+`wl_cursor_theme` client-side fallback is not implemented, so
+`app.capabilities()` reports `cursor_shapes == false` on Wayland compositors
+that do not advertise cursor-shape-v1.
+Backends must leave unsupported
+classes false instead of emulating partial support. Current native backends route
+window-scoped mouse, keyboard, focus, resize and iconified/restored events where
+the platform implementation supports them. `drop_events` is true on native
+backends that clone dropped file paths into `WindowInputEvent.dropped_files`;
+`touch_events` is true only where native touch input is wired. Win32 reports the
+`WM_TOUCH` began/moved/ended states; AppKit also reports cancelled touches from
+`touchesCancelledWithEvent:`. Clipboard paste is reported as an event signal;
+clipboard contents are not carried by `WindowInputEvent`. X11 text uses
+XIM/XIC with `Xutf8LookupString`, and X11 file drops use XDND `text/uri-list`.
+Wayland text uses xkb keymap/state for key-press characters, and Wayland file
+drops use `wl_data_device`/`wl_data_offer` `text/uri-list`; neither Linux text
+path implements full IME/composed text yet.
+
+The multi-window event queue is separate from legacy `gg.Context` callbacks.
+Normal single-window applications keep using the existing `event_fn`,
+`keydown_fn`, `move_fn`, `scroll_fn` and related callbacks on `gg.Context`, and
+do not import or initialize `x.multiwindow`.
+
 `gg.App` manages native windows through `x.multiwindow`. The lower-level
 `x.multiwindow` layer owns native lifetimes and the owner queue; `gg.App` owns
 `sokol.gfx`/`sokol.sgl` renderer state only after rendering is initialized.

--- a/vlib/gg/legacy_import_multiwindow_isolation_test.v
+++ b/vlib/gg/legacy_import_multiwindow_isolation_test.v
@@ -62,6 +62,121 @@ fn main() {
 		'-os macos -cc clang')
 }
 
+fn test_legacy_context_event_source_has_no_multiwindow_input_dependency() {
+	legacy_source := os.read_file(os.join_path(@DIR, 'gg.c.v')) or { panic(err) }
+
+	assert !legacy_source.contains('x.multiwindow')
+	assert !legacy_source.contains('WindowInputEvent')
+	assert !legacy_source.contains('drain_input_events')
+	assert !legacy_source.contains('input_fn')
+}
+
+fn test_legacy_context_callbacks_do_not_pull_multiwindow_input_markers() {
+	vlib_dir := os.dir(@DIR)
+	unique := 'gg_legacy_callbacks_no_multiwindow_${os.getpid()}_${time.now().unix_nano()}'
+	source_path := os.join_path(os.temp_dir(), '${unique}.v')
+	mut bin_path := os.join_path(os.temp_dir(), '${unique}_bin')
+	$if windows {
+		bin_path += '.exe'
+	}
+	source := 'import gg
+
+fn on_event(e &gg.Event, data voidptr) {
+	_ = e
+	_ = data
+}
+
+fn on_keydown(key gg.KeyCode, modifier gg.Modifier, data voidptr) {
+	_ = key
+	_ = modifier
+	_ = data
+}
+
+fn on_keyup(key gg.KeyCode, modifier gg.Modifier, data voidptr) {
+	_ = key
+	_ = modifier
+	_ = data
+}
+
+fn on_char(code u32, data voidptr) {
+	_ = code
+	_ = data
+}
+
+fn on_move(x f32, y f32, data voidptr) {
+	_ = x
+	_ = y
+	_ = data
+}
+
+fn on_click(x f32, y f32, button gg.MouseButton, data voidptr) {
+	_ = x
+	_ = y
+	_ = button
+	_ = data
+}
+
+fn on_unclick(x f32, y f32, button gg.MouseButton, data voidptr) {
+	_ = x
+	_ = y
+	_ = button
+	_ = data
+}
+
+fn main() {
+	ctx := gg.new_context(
+		width:         1
+		height:        1
+		create_window: false
+		event_fn:      on_event
+		keydown_fn:    on_keydown
+		keyup_fn:      on_keyup
+		char_fn:       on_char
+		move_fn:       on_move
+		click_fn:      on_click
+		unclick_fn:    on_unclick
+		scroll_fn:     on_event
+		enter_fn:      on_event
+		leave_fn:      on_event
+		resized_fn:    on_event
+		quit_fn:       on_event
+	)
+	assert ctx.width == 1
+	assert ctx.height == 1
+}
+'
+	os.write_file(source_path, source) or { panic(err) }
+	defer {
+		os.rm(source_path) or {}
+		os.rm(bin_path) or {}
+	}
+
+	assert_legacy_host_import_has_no_multiwindow_markers(vlib_dir, source_path, '${unique}_host')
+	assert_legacy_import_has_no_multiwindow_markers(vlib_dir, source_path, '${unique}_windows_tcc',
+		'-os windows -cc tcc')
+	assert_legacy_import_has_no_multiwindow_markers(vlib_dir, source_path, '${unique}_darwin',
+		'-os macos -cc clang')
+
+	if legacy_host_gg_import_available() {
+		compile_cmd := '${os.quoted_path(@VEXE)} ${legacy_child_host_v_flags()} -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(bin_path)} ${os.quoted_path(source_path)}'
+		compile_result := os.execute(compile_cmd)
+		assert compile_result.exit_code == 0, 'legacy callbacks smoke compile failed
+command: ${compile_cmd}
+exit_code: ${compile_result.exit_code}
+output:
+${compile_result.output}'
+
+		run_result := os.execute(os.quoted_path(bin_path))
+		assert run_result.exit_code == 0, 'legacy callbacks smoke run failed
+command: ${bin_path}
+exit_code: ${run_result.exit_code}
+output:
+${run_result.output}'
+	} else {
+		legacy_skip_host_gg_import_probe('${unique}_host_smoke')
+	}
+}
+
 fn test_missing_gg_multiwindow_flag_reports_clear_error_without_native_deps() {
 	vlib_dir := os.dir(@DIR)
 	unique := 'gg_missing_multiwindow_flag_${os.getpid()}_${time.now().unix_nano()}'
@@ -146,13 +261,18 @@ fn main() {
 	id := gg.WindowId{}
 	app.set_window_title(id, 'disabled') or { expect_opt_in_error(err) }
 	app.resize_window(id, 1, 1) or { expect_opt_in_error(err) }
+	app.set_window_cursor(id, gg.WindowCursorShape.pointer) or { expect_opt_in_error(err) }
+	app.begin_window_move(id) or { expect_opt_in_error(err) }
+	app.begin_window_resize(id, gg.WindowResizeEdge.bottom_right) or { expect_opt_in_error(err) }
 	app.window_info(id) or { expect_opt_in_error(err) }
 	app.window_ids() or { expect_opt_in_error(err) }
 	app.window_infos() or { expect_opt_in_error(err) }
 	app.drain_events() or { expect_opt_in_error(err) }
+	app.drain_input_events() or { expect_opt_in_error(err) }
 	app.poll_events() or { expect_opt_in_error(err) }
 	app.drain_pending(1) or { expect_opt_in_error(err) }
 	app.run(event_fn: fn (_ gg.WindowEvent, mut _ gg.App) ! {}) or { expect_opt_in_error(err) }
+	app.run(input_fn: fn (_ gg.WindowInputEvent, mut _ gg.App) ! {}) or { expect_opt_in_error(err) }
 	app.stop() or { expect_opt_in_error(err) }
 }
 "
@@ -188,6 +308,20 @@ ${run_result.output}'
 	}
 }
 
+fn test_legacy_generated_code_filter_preserves_non_line_worktree_paths() {
+	worktree_dir := os.dir(os.dir(@DIR))
+	generated := '#line 1 "${worktree_dir}/vlib/x/multiwindow/app.v"
+#include "${worktree_dir}/vlib/builtin/gc_debugger_linux.h"
+#include "${worktree_dir}/vlib/x/multiwindow/wayland_backend.c.v"
+'
+	filtered := legacy_generated_code_without_path_metadata(generated)
+
+	assert !filtered.contains('#line ')
+	assert !filtered.contains(worktree_dir)
+	assert filtered.contains('#include "<worktree>/vlib/builtin/gc_debugger_linux.h"')
+	assert filtered.contains('vlib/x/multiwindow/wayland_backend.c.v')
+}
+
 fn assert_legacy_import_has_no_multiwindow_markers(vlib_dir string, source_path string, label string, target_args string) {
 	assert_source_has_no_multiwindow_markers(vlib_dir, source_path, label, target_args)
 }
@@ -214,10 +348,27 @@ exit_code: ${result.exit_code}
 output:
 ${result.output}'
 
-	generated := os.read_file(c_path) or { panic(err) }
+	generated := legacy_generated_code_without_path_metadata(os.read_file(c_path) or { panic(err) })
 	for forbidden in legacy_multiwindow_forbidden_markers() {
 		assert !generated.contains(forbidden), '${label} legacy gg import leaked `${forbidden}` into generated C'
 	}
+}
+
+fn legacy_generated_code_without_path_metadata(generated string) string {
+	worktree_dir := os.dir(os.dir(@DIR))
+	worktree_dir_slashes := worktree_dir.replace('\\', '/')
+	mut lines := []string{cap: generated.len / 80}
+	for line in generated.split_into_lines() {
+		if line.starts_with('#line ') {
+			continue
+		}
+		mut cleaned := line.replace(worktree_dir, '<worktree>')
+		if worktree_dir_slashes != worktree_dir {
+			cleaned = cleaned.replace(worktree_dir_slashes, '<worktree>')
+		}
+		lines << cleaned
+	}
+	return lines.join('\n')
 }
 
 fn legacy_child_host_v_flags() string {
@@ -270,6 +421,9 @@ fn legacy_multiwindow_forbidden_markers() []string {
 		'vlib/x/multiwindow',
 		'multiwindow__App',
 		'multiwindow__Backend',
+		'multiwindow__InputEvent',
+		'multiwindow__InputEventKind',
+		'multiwindow__QueuedEvent',
 		'X11Backend',
 		'WaylandBackend',
 		'AppKitBackend',

--- a/vlib/gg/multiwindow_api_d_gg_multiwindow_test.v
+++ b/vlib/gg/multiwindow_api_d_gg_multiwindow_test.v
@@ -4,6 +4,7 @@ module gg
 // Compile with `-d gg_multiwindow`; this test exercises the opt-in facade.
 import os
 import time
+import sokol.sapp
 import sokol.sgl
 import x.multiwindow
 
@@ -17,6 +18,16 @@ fn test_multiwindow_new_app_reports_core_capabilities() {
 	assert caps.multi_window
 	assert caps.owner_queue
 	assert !caps.explicit_swapchain
+	assert caps.input_events
+	assert caps.mouse_events
+	assert caps.keyboard_events
+	assert caps.text_events
+	assert caps.focus_events
+	assert caps.drop_events
+	assert caps.touch_events
+	assert !caps.cursor_shapes
+	assert !caps.interactive_move_resize
+	assert !caps.native_decorations
 
 	app.stop()!
 }
@@ -56,6 +67,16 @@ fn test_multiwindow_capabilities_for_backend_delegates_to_core() {
 	assert caps.mock
 	assert caps.multi_window
 	assert caps.owner_queue
+	assert caps.input_events
+	assert caps.mouse_events
+	assert caps.keyboard_events
+	assert caps.text_events
+	assert caps.focus_events
+	assert caps.drop_events
+	assert caps.touch_events
+	assert !caps.cursor_shapes
+	assert !caps.interactive_move_resize
+	assert !caps.native_decorations
 }
 
 fn test_multiwindow_plain_capabilities_use_core_probe_without_app_source_guard() {
@@ -83,13 +104,182 @@ fn test_multiwindow_capabilities_with_renderer_signature_source_guard() {
 	assert !source.contains('pub fn capabilities_for_backend_with_renderer(backend MultiWindowBackend,')
 }
 
+fn test_multiwindow_interactive_move_resize_source_guard() {
+	source := multiwindow_facade_source()
+	disabled_source := multiwindow_disabled_facade_source()
+
+	assert source.contains('pub enum WindowResizeEdge {')
+	assert disabled_source.contains('pub enum WindowResizeEdge {')
+	for edge_name in ['top', 'bottom', 'left', 'right', 'top_left', 'top_right', 'bottom_left',
+		'bottom_right'] {
+		assert source.contains('\t${edge_name}')
+		assert disabled_source.contains('\t${edge_name}')
+	}
+
+	assert source.contains('pub fn (mut app App) begin_window_move(id WindowId) !')
+	assert source.contains('app.core.begin_window_move(id.core)!')
+	assert source.contains('pub fn (mut app App) begin_window_resize(id WindowId, edge WindowResizeEdge) !')
+	assert source.contains('app.core.begin_window_resize(id.core, window_resize_edge_to_core(edge))!')
+	assert source.contains('fn window_resize_edge_to_core(edge WindowResizeEdge) multiwindow.WindowResizeEdge')
+	assert source.contains('interactive_move_resize bool')
+	assert source.contains('native_decorations')
+	assert source.contains('interactive_move_resize: caps.interactive_move_resize')
+	assert source.contains('native_decorations:      caps.native_decorations')
+	assert source.contains('pub enum WindowCursorShape {')
+	assert disabled_source.contains('pub enum WindowCursorShape {')
+	for shape_name in ['default', 'pointer', 'move', 'n_resize', 's_resize', 'e_resize', 'w_resize',
+		'ne_resize', 'nw_resize', 'se_resize', 'sw_resize', 'ew_resize', 'ns_resize', 'nesw_resize',
+		'nwse_resize', 'grab', 'grabbing'] {
+		assert source.contains('\t${shape_name}')
+		assert disabled_source.contains('\t${shape_name}')
+	}
+	assert source.contains('pub fn (mut app App) set_window_cursor(id WindowId, shape WindowCursorShape) !')
+	assert source.contains('app.core.set_window_cursor(id.core, window_cursor_shape_to_core(shape))!')
+	assert source.contains('fn window_cursor_shape_to_core(shape WindowCursorShape) multiwindow.CursorShape')
+	assert source.contains('cursor_shapes           bool')
+	assert source.contains('cursor_shapes:           caps.cursor_shapes')
+
+	assert disabled_source.contains('pub fn (mut app App) set_window_cursor(id WindowId, shape WindowCursorShape) !')
+	assert disabled_source.contains('pub fn (mut app App) begin_window_move(id WindowId) !')
+	assert disabled_source.contains('pub fn (mut app App) begin_window_resize(id WindowId, edge WindowResizeEdge) !')
+	disabled_cursor_source :=
+		disabled_source.all_after('// set_window_cursor updates').all_before('// begin_window_move starts')
+	disabled_move_source :=
+		disabled_source.all_after('// begin_window_move starts').all_before('// begin_window_resize starts')
+	disabled_resize_source :=
+		disabled_source.all_after('// begin_window_resize starts').all_before('// window_info returns')
+	assert disabled_cursor_source.contains('return error(err_multiwindow_not_enabled)')
+	assert disabled_move_source.contains('return error(err_multiwindow_not_enabled)')
+	assert disabled_resize_source.contains('return error(err_multiwindow_not_enabled)')
+	assert !disabled_source.contains('import x.multiwindow')
+}
+
+fn test_multiwindow_resize_edge_conversion_matches_core() {
+	assert window_resize_edge_to_core(.top) == multiwindow.WindowResizeEdge.top
+	assert window_resize_edge_to_core(.bottom) == multiwindow.WindowResizeEdge.bottom
+	assert window_resize_edge_to_core(.left) == multiwindow.WindowResizeEdge.left
+	assert window_resize_edge_to_core(.right) == multiwindow.WindowResizeEdge.right
+	assert window_resize_edge_to_core(.top_left) == multiwindow.WindowResizeEdge.top_left
+	assert window_resize_edge_to_core(.top_right) == multiwindow.WindowResizeEdge.top_right
+	assert window_resize_edge_to_core(.bottom_left) == multiwindow.WindowResizeEdge.bottom_left
+	assert window_resize_edge_to_core(.bottom_right) == multiwindow.WindowResizeEdge.bottom_right
+}
+
+fn test_multiwindow_cursor_shape_conversion_matches_core() {
+	assert window_cursor_shape_to_core(.default) == multiwindow.CursorShape.default
+	assert window_cursor_shape_to_core(.pointer) == multiwindow.CursorShape.pointer
+	assert window_cursor_shape_to_core(.move) == multiwindow.CursorShape.move
+	assert window_cursor_shape_to_core(.n_resize) == multiwindow.CursorShape.n_resize
+	assert window_cursor_shape_to_core(.s_resize) == multiwindow.CursorShape.s_resize
+	assert window_cursor_shape_to_core(.e_resize) == multiwindow.CursorShape.e_resize
+	assert window_cursor_shape_to_core(.w_resize) == multiwindow.CursorShape.w_resize
+	assert window_cursor_shape_to_core(.ne_resize) == multiwindow.CursorShape.ne_resize
+	assert window_cursor_shape_to_core(.nw_resize) == multiwindow.CursorShape.nw_resize
+	assert window_cursor_shape_to_core(.se_resize) == multiwindow.CursorShape.se_resize
+	assert window_cursor_shape_to_core(.sw_resize) == multiwindow.CursorShape.sw_resize
+	assert window_cursor_shape_to_core(.ew_resize) == multiwindow.CursorShape.ew_resize
+	assert window_cursor_shape_to_core(.ns_resize) == multiwindow.CursorShape.ns_resize
+	assert window_cursor_shape_to_core(.nesw_resize) == multiwindow.CursorShape.nesw_resize
+	assert window_cursor_shape_to_core(.nwse_resize) == multiwindow.CursorShape.nwse_resize
+	assert window_cursor_shape_to_core(.grab) == multiwindow.CursorShape.grab
+	assert window_cursor_shape_to_core(.grabbing) == multiwindow.CursorShape.grabbing
+}
+
 fn test_multiwindow_ci_does_not_run_gg_api_tests_under_fake_wayland_display() {
-	source := multiwindow_gg_regressions_workflow_source()
+	source := multiwindow_business_multiwindow_workflow_sources()
 	for line in source.split_into_lines() {
 		if line.contains('vlib/gg/multiwindow_api_d_gg_multiwindow_test.v') {
 			assert !line.contains('WAYLAND_DISPLAY=wayland-v-multiwindow-fake')
 		}
 	}
+}
+
+fn test_multiwindow_linux_ci_covers_multiwindow_workflows_source_guard() {
+	source := multiwindow_linux_workflow_source()
+	deps_source := multiwindow_linux_ci_script_source()
+	gcc_section := source.all_after('  gcc-linux:').all_before('\n  clang-linux:')
+
+	assert !source.contains('Install dependencies for gg multiwindow')
+	assert source.count('- name: Multiwindow Linux checks') == 1
+	assert gcc_section.contains('run: v run ci/linux_ci.vsh install_dependencies_for_examples_and_tools_gcc')
+	assert !gcc_section.contains('sudo apt install')
+	build_index := gcc_section.index('- name: Build V') or {
+		assert false, 'gcc-linux is missing the Build V step'
+		return
+	}
+	install_index := gcc_section.index('run: v run ci/linux_ci.vsh install_dependencies_for_examples_and_tools_gcc') or {
+		assert false, 'linux_ci.yml is missing the examples/tools dependency install step'
+		return
+	}
+	checks_index := gcc_section.index('- name: Multiwindow Linux checks') or {
+		assert false, 'linux_ci.yml is missing the unified Multiwindow Linux checks step'
+		return
+	}
+	next_gcc_step_index := gcc_section.index('- name: Recompile V with -cstrict and gcc') or {
+		assert false, 'gcc-linux is missing the step after Multiwindow Linux checks'
+		return
+	}
+	assert build_index < install_index
+	assert install_index < checks_index
+	assert checks_index < next_gcc_step_index
+	checks_body := gcc_section[checks_index..next_gcc_step_index]
+	for dependency in [
+		'libx11-dev',
+		'libxi-dev',
+		'libxcursor-dev',
+		'libxrandr-dev',
+		'libxkbcommon-dev',
+		'libxkbcommon-x11-dev',
+		'libgl-dev',
+		'libgl1-mesa-dri',
+		'libegl-dev',
+		'libwayland-dev',
+		'libwayland-egl1-mesa',
+		'wayland-protocols',
+		'xauth',
+		'xvfb',
+	] {
+		assert deps_source.contains(dependency), 'ci/linux_ci.vsh is missing dependency `${dependency}`'
+	}
+	assert checks_body.contains('vlib/gg/legacy_import_multiwindow_isolation_test.v')
+	assert checks_body.contains('env -u DISPLAY -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE')
+	assert checks_body.contains('./v -d gg_multiwindow test')
+	assert checks_body.contains('./v -d gg_multiwindow -d sokol_wayland test')
+	assert checks_body.contains('xvfb-run -a -s "-screen 0 1280x1024x24"')
+	assert checks_body.contains('./v -d gg_multiwindow -d x_multiwindow_x11 test')
+	assert checks_body.contains('vlib/x/multiwindow')
+	assert checks_body.contains('vlib/gg/multiwindow_api_d_gg_multiwindow_test.v')
+	assert checks_body.contains('vlib/gg/frame_pacing_test.v')
+	assert checks_body.contains('vlib/gg/draw_fns_api_test.v')
+	assert checks_body.contains('vlib/gg/draw_rect_empty_test.v')
+	assert checks_body.count('vlib/gg/draw_rect_empty_test.v') >= 3
+	assert checks_body.contains('./v -d gg_multiwindow -o /tmp/gg_multiwindow_default examples/gg/multiwindow.v')
+	assert checks_body.contains('./v -d gg_multiwindow -d x_multiwindow_x11 -o /tmp/gg_multiwindow_x11 examples/gg/multiwindow.v')
+	assert checks_body.contains('./v -d gg_multiwindow -d sokol_wayland -o /tmp/gg_multiwindow_wayland examples/gg/multiwindow.v')
+	assert checks_body.contains('run_headless_example "gg multiwindow headless mock" /tmp/gg_multiwindow_default')
+	assert checks_body.contains('run_headless_example "gg multiwindow Wayland-build headless mock" /tmp/gg_multiwindow_wayland')
+	assert checks_body.contains('run_x11_example "gg multiwindow Xvfb/X11" /tmp/gg_multiwindow_x11')
+	assert checks_body.contains('timeout 12s stdbuf -oL -eL "$binary" >"$stdout" 2>"$stderr"')
+	assert checks_body.contains('grep -Fq "capability families:" "$stdout"')
+	assert !checks_body.contains('gg_regressions_ci.yml')
+}
+
+fn test_multiwindow_ci_covers_draw_rect_empty_test_source_guard() {
+	linux_source := multiwindow_linux_workflow_source()
+	gg_regressions_source := multiwindow_workflow_source('gg_regressions_ci.yml')
+	macos_source := multiwindow_workflow_source('macos_ci.yml')
+	windows_msvc_source := multiwindow_workflow_source('windows_ci_msvc.yml')
+	windows_gcc_source := multiwindow_workflow_source('windows_ci_gcc.yml')
+	draw_tests := 'vlib/gg/frame_pacing_test.v vlib/gg/draw_fns_api_test.v vlib/gg/draw_rect_empty_test.v'
+
+	assert linux_source.count('vlib/gg/draw_rect_empty_test.v') >= 3
+	assert gg_regressions_source.count(draw_tests) == 3
+	assert macos_source.contains(draw_tests)
+	assert windows_msvc_source.contains(draw_tests)
+	assert windows_gcc_source.contains(draw_tests)
+
+	assert gg_regressions_source.contains("      - 'vlib/**'")
+	assert gg_regressions_source.contains("      - '!vlib/v3/**'")
 }
 
 fn test_multiwindow_auto_capabilities_match_new_app_lifecycle_policy() {
@@ -392,6 +582,230 @@ fn test_multiwindow_create_destroy_window_lifecycle_and_events() {
 	app.stop()!
 }
 
+fn test_multiwindow_interactive_move_resize_mock_reports_unsupported() {
+	mut app := new_app(backend: .mock)!
+	win := app.create_window(title: 'Interactive inspector', width: 320, height: 240)!
+	assert app.drain_events()!.len == 1
+
+	mut move_rejected := false
+	app.begin_window_move(win) or {
+		assert err.msg() == 'multiwindow: backend capability is unsupported'
+		move_rejected = true
+	}
+	assert move_rejected
+
+	for edge in all_window_resize_edges_for_test() {
+		mut resize_rejected := false
+		app.begin_window_resize(win, edge) or {
+			assert err.msg() == 'multiwindow: backend capability is unsupported'
+			resize_rejected = true
+		}
+		assert resize_rejected, 'mock backend accepted interactive resize edge ${edge}'
+	}
+
+	fixed := app.create_window(title: 'Fixed inspector', width: 320, height: 240, resizable: false)!
+	assert app.drain_events()!.len == 1
+	mut fixed_resize_rejected := false
+	app.begin_window_resize(fixed, .bottom_right) or {
+		assert err.msg() == 'multiwindow: backend capability is unsupported'
+		fixed_resize_rejected = true
+	}
+	assert fixed_resize_rejected
+	app.stop()!
+}
+
+fn test_multiwindow_cursor_shape_mock_reports_unsupported() {
+	mut app := new_app(backend: .mock)!
+	win := app.create_window(title: 'Cursor inspector', width: 320, height: 240)!
+	assert app.drain_events()!.len == 1
+	assert !app.capabilities().cursor_shapes
+
+	mut cursor_rejected := false
+	app.set_window_cursor(win, .pointer) or {
+		assert err.msg() == 'multiwindow: backend capability is unsupported'
+		cursor_rejected = true
+	}
+	assert cursor_rejected
+	app.stop()!
+}
+
+fn all_window_resize_edges_for_test() []WindowResizeEdge {
+	return [
+		WindowResizeEdge.top,
+		.bottom,
+		.left,
+		.right,
+		.top_left,
+		.top_right,
+		.bottom_left,
+		.bottom_right,
+	]
+}
+
+fn test_multiwindow_drain_input_events_routes_gg_event_without_lifecycle_pollution() {
+	mut app := new_app(backend: .mock)!
+	win := app.create_window(title: 'Input inspector', width: 320, height: 240)!
+	assert app.drain_events()!.len == 1
+
+	app.enqueue_mock_input_for_test(WindowInputEvent{
+		window:        win
+		event:         Event{
+			typ:      .mouse_scroll
+			mouse_x:  10
+			mouse_y:  20
+			scroll_y: -1.5
+		}
+		dropped_files: ['/tmp/input.txt']
+	})!
+
+	assert app.poll_events()! == 1
+	assert app.drain_events()!.len == 0
+	input_events := app.drain_input_events()!
+	assert input_events.len == 1
+	assert input_events[0].window == win
+	assert input_events[0].event.typ == .mouse_scroll
+	assert input_events[0].event.mouse_x == 10
+	assert input_events[0].event.mouse_y == 20
+	assert input_events[0].event.scroll_y == -1.5
+	assert input_events[0].dropped_files == ['/tmp/input.txt']
+	assert app.drain_input_events()!.len == 0
+	app.stop()!
+}
+
+fn test_multiwindow_window_input_event_roundtrip_covers_all_real_sokol_event_types() {
+	event_types := multiwindow_real_sokol_event_types()
+	assert event_types.len == int(sapp.EventType.num)
+	assert input_event_type_to_core(.num) == multiwindow.InputEventKind.invalid
+	mut app := new_app(backend: .mock)!
+	win := app.create_window(title: 'Input roundtrip', width: 320, height: 240)!
+	assert app.drain_events()!.len == 1
+
+	mut expected_events := []WindowInputEvent{cap: event_types.len}
+	for i, typ in event_types {
+		expected_events << multiwindow_window_input_event_for_type(win, typ, u64(i + 1))
+	}
+	for event in expected_events {
+		app.enqueue_mock_input_for_test(event)!
+	}
+
+	assert app.poll_events()! == expected_events.len
+	actual_events := app.drain_input_events()!
+	assert actual_events.len == expected_events.len
+	for i, actual in actual_events {
+		assert_window_input_event_roundtrip(actual, expected_events[i])
+	}
+	assert app.drain_events()!.len == 0
+	assert app.drain_input_events()!.len == 0
+	app.stop()!
+}
+
+fn assert_window_input_event_roundtrip(actual WindowInputEvent, expected WindowInputEvent) {
+	assert actual.window == expected.window
+	assert actual.dropped_files == expected.dropped_files
+	assert actual.event.frame_count == expected.event.frame_count
+	assert actual.event.typ == expected.event.typ
+	assert actual.event.key_code == expected.event.key_code
+	assert actual.event.char_code == expected.event.char_code
+	assert actual.event.key_repeat == expected.event.key_repeat
+	assert actual.event.modifiers == expected.event.modifiers
+	assert actual.event.mouse_button == expected.event.mouse_button
+	assert actual.event.mouse_x == expected.event.mouse_x
+	assert actual.event.mouse_y == expected.event.mouse_y
+	assert actual.event.mouse_dx == expected.event.mouse_dx
+	assert actual.event.mouse_dy == expected.event.mouse_dy
+	assert actual.event.scroll_x == expected.event.scroll_x
+	assert actual.event.scroll_y == expected.event.scroll_y
+	assert actual.event.num_touches == expected.event.num_touches
+	for i in 0 .. actual.event.num_touches {
+		assert actual.event.touches[i].identifier == expected.event.touches[i].identifier
+		assert actual.event.touches[i].pos_x == expected.event.touches[i].pos_x
+		assert actual.event.touches[i].pos_y == expected.event.touches[i].pos_y
+		assert actual.event.touches[i].android_tooltype == expected.event.touches[i].android_tooltype
+		assert actual.event.touches[i].changed == expected.event.touches[i].changed
+	}
+	assert actual.event.window_width == expected.event.window_width
+	assert actual.event.window_height == expected.event.window_height
+	assert actual.event.framebuffer_width == expected.event.framebuffer_width
+	assert actual.event.framebuffer_height == expected.event.framebuffer_height
+}
+
+fn multiwindow_real_sokol_event_types() []sapp.EventType {
+	return [
+		sapp.EventType.invalid,
+		.key_down,
+		.key_up,
+		.char,
+		.mouse_down,
+		.mouse_up,
+		.mouse_scroll,
+		.mouse_move,
+		.mouse_enter,
+		.mouse_leave,
+		.touches_began,
+		.touches_moved,
+		.touches_ended,
+		.touches_cancelled,
+		.resized,
+		.iconified,
+		.restored,
+		.focused,
+		.unfocused,
+		.suspended,
+		.resumed,
+		.quit_requested,
+		.clipboard_pasted,
+		.files_dropped,
+	]
+}
+
+fn multiwindow_window_input_event_for_type(win WindowId, typ sapp.EventType, frame_count u64) WindowInputEvent {
+	mut touches := [8]TouchPoint{}
+	touches[0] = TouchPoint{
+		identifier:       7
+		pos_x:            11.5
+		pos_y:            12.5
+		android_tooltype: unsafe { sapp.TouchToolType(1) }
+		changed:          true
+	}
+	touches[1] = TouchPoint{
+		identifier:       8
+		pos_x:            21.5
+		pos_y:            22.5
+		android_tooltype: unsafe { sapp.TouchToolType(2) }
+		changed:          false
+	}
+	dropped_files := if typ == .files_dropped {
+		['/tmp/a.txt', '/tmp/b.txt']
+	} else {
+		[]string{}
+	}
+	return WindowInputEvent{
+		window:        win
+		event:         Event{
+			frame_count:        frame_count
+			typ:                typ
+			key_code:           .escape
+			char_code:          u32(0xe9)
+			key_repeat:         true
+			modifiers:          0x105
+			mouse_button:       .middle
+			mouse_x:            40.5
+			mouse_y:            41.5
+			mouse_dx:           -2.25
+			mouse_dy:           3.5
+			scroll_x:           -1.25
+			scroll_y:           2.5
+			num_touches:        2
+			touches:            touches
+			window_width:       640
+			window_height:      360
+			framebuffer_width:  1280
+			framebuffer_height: 720
+		}
+		dropped_files: dropped_files
+	}
+}
+
 fn test_multiwindow_rejects_invalid_window_size_from_core() {
 	mut app := new_app(backend: .mock)!
 	app.create_window(width: 0, height: 240) or {
@@ -517,6 +931,20 @@ fn test_multiwindow_draw_window_commits_each_frame_source_guard() {
 	assert draw_window_source.contains('gfx.end_pass()\n\tgfx.commit()\n\tapp.core.end_render(frame)!')
 }
 
+fn test_multiwindow_window_context_rect_helpers_source_guard() {
+	source := multiwindow_facade_source()
+	disabled_source := multiwindow_disabled_facade_source()
+
+	assert source.contains('pub fn (context &WindowContext) draw_rect_filled')
+	assert source.contains('pub fn (context &WindowContext) draw_rect_empty')
+	assert source.contains('sgl.set_context(context.sgl_context)')
+	assert source.contains('sgl.begin_quads()')
+	assert source.contains('sgl.begin_lines()')
+	assert !source.contains('pub fn (context &WindowContext) draw_text')
+	assert disabled_source.contains('pub fn (context &WindowContext) draw_rect_filled')
+	assert disabled_source.contains('pub fn (context &WindowContext) draw_rect_empty')
+}
+
 fn test_multiwindow_run_rejects_missing_callbacks() {
 	mut app := new_app(backend: .mock)!
 	app.run() or {
@@ -542,6 +970,14 @@ fn test_multiwindow_zero_value_app_methods_return_initialized_error() {
 		rejected += 1
 	}
 	app.resize_window(id, 1, 1) or {
+		assert err.msg() == err_multiwindow_app_not_initialized
+		rejected += 1
+	}
+	app.begin_window_move(id) or {
+		assert err.msg() == err_multiwindow_app_not_initialized
+		rejected += 1
+	}
+	app.begin_window_resize(id, .bottom_right) or {
 		assert err.msg() == err_multiwindow_app_not_initialized
 		rejected += 1
 	}
@@ -573,6 +1009,11 @@ fn test_multiwindow_zero_value_app_methods_return_initialized_error() {
 		assert err.msg() == err_multiwindow_app_not_initialized
 		rejected += 1
 		[]WindowEvent{}
+	}
+	_ := app.drain_input_events() or {
+		assert err.msg() == err_multiwindow_app_not_initialized
+		rejected += 1
+		[]WindowInputEvent{}
 	}
 	_ := app.poll_events() or {
 		assert err.msg() == err_multiwindow_app_not_initialized
@@ -616,7 +1057,7 @@ fn test_multiwindow_zero_value_app_methods_return_initialized_error() {
 		rejected += 1
 	}
 
-	assert rejected == 16
+	assert rejected == 19
 	assert !app.window_exists(id)
 	assert !app.capabilities().multi_window
 }
@@ -672,6 +1113,117 @@ fn test_multiwindow_run_event_callback_routes_mock_close_requested_from_core_pol
 	assert seen.close_requested
 }
 
+struct MockInputCallbackSeen {
+mut:
+	created bool
+	input   bool
+}
+
+fn test_multiwindow_run_input_callback_preserves_lifecycle_input_order() {
+	mut app := new_app(backend: .mock, queue_size: 2)!
+	win := app.create_window(title: 'Input callback target')!
+	app.enqueue_mock_input_for_test(WindowInputEvent{
+		window: win
+		event:  Event{
+			typ:      .key_down
+			key_code: .a
+		}
+	})!
+	mut seen := &MockInputCallbackSeen{}
+
+	app.run(
+		event_fn: fn [win, mut seen] (event WindowEvent, mut app App) ! {
+			if event.kind == .window_created {
+				assert event.window == win
+				assert !seen.input
+				seen.created = true
+			}
+			_ = app
+		}
+		input_fn: fn [win, mut seen] (event WindowInputEvent, mut app App) ! {
+			assert event.window == win
+			assert event.event.typ == .key_down
+			assert event.event.key_code == .a
+			assert seen.created
+			seen.input = true
+			app.stop()!
+		}
+	)!
+
+	assert seen.created
+	assert seen.input
+}
+
+struct MockInputLifecycleInputCallbackSeen {
+mut:
+	order []string
+}
+
+fn test_multiwindow_run_input_callback_preserves_input_lifecycle_input_order() {
+	mut app := new_app(backend: .mock, queue_size: 2)!
+	win := app.create_window(title: 'Input lifecycle input callback target')!
+	assert app.drain_events()!.len == 1
+	app.enqueue_mock_input_for_test(WindowInputEvent{
+		window: win
+		event:  Event{
+			typ: .mouse_enter
+		}
+	})!
+	app.core.enqueue_mock_close_requested_for_test(win.core)!
+	app.enqueue_mock_input_for_test(WindowInputEvent{
+		window: win
+		event:  Event{
+			typ:       .char
+			char_code: u32(120)
+		}
+	})!
+	mut seen := &MockInputLifecycleInputCallbackSeen{}
+
+	app.run(
+		event_fn: fn [win, mut seen] (event WindowEvent, mut app App) ! {
+			assert event.window == win
+			assert event.kind == .window_close_requested
+			seen.order << 'lifecycle-close'
+			_ = app
+		}
+		input_fn: fn [win, mut seen] (event WindowInputEvent, mut app App) ! {
+			assert event.window == win
+			match event.event.typ {
+				.mouse_enter {
+					seen.order << 'input-enter'
+				}
+				.char {
+					assert event.event.char_code == u32(120)
+					seen.order << 'input-char'
+					app.stop()!
+				}
+				else {
+					assert false, 'unexpected input event ${event.event.typ}'
+				}
+			}
+		}
+	)!
+
+	assert seen.order == ['input-enter', 'lifecycle-close', 'input-char']
+}
+
+fn test_multiwindow_run_input_only_handles_close_requested_without_event_callback() {
+	mut app := new_app(backend: .mock, queue_size: 2)!
+	win := app.create_window(title: 'Input-only close target')!
+	app.core.enqueue_mock_close_requested_for_test(win.core)!
+
+	app.run(
+		input_fn: fn (event WindowInputEvent, mut app App) ! {
+			_ = event
+			_ = app
+			assert false, 'input-only close test should not receive lifecycle as input'
+		}
+	)!
+
+	assert !app.window_exists(win)
+	assert app.core.status() == multiwindow.AppStatus.stopped
+}
+
 fn test_multiwindow_event_only_run_idles_when_idle_source_guard() {
 	source := multiwindow_facade_source()
 	run_source :=
@@ -682,9 +1234,18 @@ fn test_multiwindow_event_only_run_idles_when_idle_source_guard() {
 	assert source.contains('const multiwindow_event_idle_sleep = 8 * time.millisecond')
 	assert run_source.contains('polled_events := app.poll_events()!')
 	assert run_source.contains('drained_jobs = app.core.drain_pending(config.max_pending_jobs) or {')
-	assert run_source.contains('dispatched_events := app.dispatch_run_events(config.event_fn)!')
+	assert run_source.contains('dispatched_events := app.dispatch_run_events(config.event_fn, config.input_fn)!')
 	assert run_source.contains('} else if polled_events == 0 && drained_jobs == 0 && dispatched_events == 0 {\n\t\t\ttime.sleep(multiwindow_event_idle_sleep)\n\t\t}')
-	assert dispatch_source.all_before('if event_fn == unsafe { nil }').contains('events := app.drain_events()!')
+	assert dispatch_source.contains('events := app.core.drain_queued_events()!')
+	assert dispatch_source.contains('if event_fn != unsafe { nil }')
+	assert dispatch_source.contains('app.dispatch_lifecycle_without_event_callback(window_event)!')
+	assert dispatch_source.contains('if input_fn != unsafe { nil }')
+	assert dispatch_source.contains('fn (mut app App) dispatch_lifecycle_without_event_callback')
+	assert dispatch_source.contains('.window_close_requested')
+	assert dispatch_source.contains('app.destroy_window(event.window)!')
+	assert dispatch_source.contains('.window_destroyed')
+	assert dispatch_source.contains('fn (mut app App) stop_if_no_windows() !')
+	assert dispatch_source.contains('app.core.status() == .running && app.window_ids()!.len == 0')
 	assert !source.contains('event_idle_sleeps')
 	assert !source.contains('stop_after_idle_sleeps')
 }
@@ -693,13 +1254,13 @@ fn test_multiwindow_dispatch_without_event_callback_still_drains_lifecycle_event
 	mut app := new_app(backend: .mock)!
 	win := app.create_window(title: 'Frame-only lifecycle drain')!
 
-	drained_created := app.dispatch_run_events(unsafe { nil })!
+	drained_created := app.dispatch_run_events(unsafe { nil }, unsafe { nil })!
 	assert drained_created == 1
 
 	app.sgl_contexts[win.str()] = sgl.Context{}
 	app.core.destroy_window(win.core)!
 
-	drained_destroyed := app.dispatch_run_events(unsafe { nil })!
+	drained_destroyed := app.dispatch_run_events(unsafe { nil }, unsafe { nil })!
 	assert drained_destroyed == 1
 	assert win.str() !in app.sgl_contexts
 
@@ -917,6 +1478,9 @@ fn main() {
 	assert app.capabilities().mock
 	win := app.create_window(title: 'Main')!
 	assert app.window_exists(win)
+	mut no_input := []gg.WindowInputEvent{}
+	no_input = app.drain_input_events()!
+	assert no_input.len == 0
 	app.try_post(fn (mut app gg.App) ! {
 		_ = app.create_window(title: 'Queued')!
 	})!
@@ -938,6 +1502,41 @@ fn main() {
 	run_cmd := os.quoted_path(bin_path)
 	run := os.execute(run_cmd)
 	multiwindow_assert_command_ok('run child gg import smoke', run_cmd, run)
+}
+
+fn test_multiwindow_user_program_input_fn_compile_imports_only_gg() {
+	vlib_dir := os.dir(@DIR)
+	source_path, out_path_base := multiwindow_temp_paths('gg_multiwindow_input_fn_compile')
+	c_path := '${out_path_base}.c'
+	source := 'import gg
+
+fn on_input(event gg.WindowInputEvent, mut app gg.App) ! {
+	_ = event.window
+	_ = event.event.typ
+	_ = event.dropped_files
+	_ = app.capabilities()
+}
+
+fn main() {
+	mut app := gg.new_app(backend: .mock)!
+	empty := gg.WindowInputEvent{}
+	_ = empty.event.typ
+	app.run(input_fn: on_input) or {}
+	app.stop() or {}
+}
+'
+	assert source.contains('import gg')
+	assert !source.contains('x.multiwindow')
+	os.write_file(source_path, source) or { panic(err) }
+	defer {
+		os.rm(source_path) or {}
+		os.rm(c_path) or {}
+		os.rm(out_path_base) or {}
+	}
+
+	cmd := '${os.quoted_path(@VEXE)}${multiwindow_child_v_flags()} -b c -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(c_path)} ${os.quoted_path(source_path)}'
+	compile := os.execute(cmd)
+	multiwindow_assert_command_ok('compile child input_fn API smoke', cmd, compile)
 }
 
 fn test_multiwindow_user_program_window_info_title_and_resize_imports_only_gg() {
@@ -1283,6 +1882,8 @@ fn main() {
 	assert context.window_id().str() == win.str()
 	app.draw_window(win, fn (mut window gg.WindowContext) ! {
 		_ = window.window_id()
+		window.draw_rect_filled(0, 0, 8, 8, gg.rgb(20, 40, 60))
+		window.draw_rect_empty(0, 0, 8, 8, gg.white)
 	}) or {}
 	app.run(frame_fn: fn (mut app gg.App) ! {
 		_ = app.capabilities()
@@ -1343,11 +1944,146 @@ fn test_multiwindow_checked_in_example_compiles_without_running() {
 	multiwindow_assert_command_ok('compile checked-in gg multiwindow example', cmd, compile)
 }
 
-fn test_multiwindow_checked_in_example_wraps_resize_unsupported_source_guard() {
+fn test_multiwindow_checked_in_example_uses_window_context_draw_api_source_guard() {
 	source := multiwindow_example_source()
+
+	assert source.contains('import gg')
+	assert !source.contains('import sokol')
+	assert !source.contains('import x.multiwindow')
+	assert source.contains('frame_fn:')
+	assert source.contains('state.draw(mut app)!')
+	assert source.contains('app.draw_window')
+	assert source.contains('draw_rect_filled')
+	assert source.contains('draw_rect_empty')
+}
+
+fn test_multiwindow_checked_in_example_headless_mock_outputs_event_markers() {
+	$if linux {
+		vlib_dir := os.dir(@DIR)
+		example_path := os.join_path(vlib_dir, '..', 'examples', 'gg', 'multiwindow.v')
+		cmd := 'env -u DISPLAY -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE ${os.quoted_path(@VEXE)}${multiwindow_child_v_flags()} -path "${vlib_dir}|@vlib|@vmodules" run ${os.quoted_path(example_path)}'
+		run := os.execute(cmd)
+		multiwindow_assert_command_ok('run checked-in gg multiwindow example headless mock', cmd,
+			run)
+		output := run.output
+		for marker in [
+			'gg multi-window backend: mock',
+			'capability families:',
+			'windows=true owner_queue=true native=false',
+			'render explicit_swapchain=false',
+			'input=true mouse=true keyboard=true text=true focus=true drop=true touch=true',
+			'mock backend selected; stopping after initial lifecycle events',
+			'live windows:',
+			'window created:',
+			'window resized:',
+		] {
+			assert output.contains(marker), 'example output is missing marker `${marker}`:
+${output}'
+		}
+		assert !output.contains('multi-window example failed')
+		assert !output.contains('input marker:')
+	} $else {
+		return
+	}
+}
+
+fn test_multiwindow_checked_in_example_capabilities_and_input_summary_source_guard() {
+	source := multiwindow_example_source()
+	input_summary_source :=
+		source.all_after('fn input_event_summary').all_before('fn resize_or_ignore_unsupported')
 
 	assert source.contains('resize_or_ignore_unsupported')
 	assert source.contains("err.msg() == 'multiwindow: backend capability is unsupported'")
+	assert source.contains('print_capability_families(caps)')
+	assert source.contains('capability families:')
+	assert source.contains('keyboard=')
+	assert source.contains('caps.keyboard_events')
+	assert source.contains('touch=')
+	assert source.contains('caps.touch_events')
+	assert source.contains('caps.cursor_shapes')
+	assert source.contains('input_event_summary(event)')
+	assert source.contains('input_fn: fn [mut state] (event gg.WindowInputEvent, mut app gg.App) !')
+	assert source.contains('visual dashboards enabled in each window')
+	assert source.contains('input logging enabled for key/mouse/focus/scroll/drop/touch events')
+	assert source.contains('Wayland client-side titlebar/frame enabled')
+	assert source.contains('chrome: Wayland client-side titlebar/frame')
+	assert source.contains('app.destroy_window(event.window)!')
+	assert source.contains('interactive move started')
+	assert source.contains('native_decorations := state.window_native_decorations(event.window)')
+	assert source.contains('update_client_chrome_cursor(event, mut app, state.caps, native_decorations)')
+	assert source.contains('maybe_begin_client_chrome_action(event, mut app, state.caps,')
+	assert source.contains('app.set_window_cursor(event.window, shape)!')
+	assert !source.contains('x.multiwindow')
+	assert !source.contains('enqueue_mock_input_for_test')
+	assert !source.contains('input marker:')
+
+	resize_edge_source :=
+		source.all_after('fn resize_edge_at').all_before('fn resize_or_ignore_unsupported')
+	top_left_index := resize_edge_source.index('return gg.WindowResizeEdge.top_left') or { -1 }
+	top_right_index := resize_edge_source.index('return gg.WindowResizeEdge.top_right') or { -1 }
+	top_index := resize_edge_source.index('return gg.WindowResizeEdge.top\n') or { -1 }
+	bottom_index := resize_edge_source.index('return gg.WindowResizeEdge.bottom\n') or { -1 }
+	left_index := resize_edge_source.index('return gg.WindowResizeEdge.left\n') or { -1 }
+	right_index := resize_edge_source.index('return gg.WindowResizeEdge.right\n') or { -1 }
+	assert top_left_index >= 0
+	assert top_right_index >= 0
+	assert top_index > top_left_index
+	assert top_index > top_right_index
+	assert top_index < bottom_index
+	assert top_index < left_index
+	assert top_index < right_index
+
+	client_chrome_action_source :=
+		source.all_after('fn maybe_begin_client_chrome_action').all_before('fn update_client_chrome_cursor')
+	resize_action_index := client_chrome_action_source.index('if edge := resize_edge_at') or { -1 }
+	move_action_index := client_chrome_action_source.index('if move_hit_at') or { -1 }
+	assert resize_action_index >= 0
+	assert move_action_index > resize_action_index
+
+	chrome_draw_source :=
+		source.all_after('fn draw_client_chrome_zones').all_before('fn draw_client_chrome_close_button')
+	chrome_draw_guard := chrome_draw_source.all_before('titlebar := client_chrome_titlebar_height')
+	assert chrome_draw_guard.contains('if !client_chrome_enabled(caps, dashboard.native_decorations) {\n\t\treturn\n\t}')
+	assert !chrome_draw_guard.contains('draw_rect_')
+	assert chrome_draw_source.contains('draw_client_chrome_titlebar_separators(mut window, width)')
+	assert chrome_draw_source.contains('draw_client_chrome_minimize_button(mut window, width)')
+	assert chrome_draw_source.contains('draw_client_chrome_maximize_button(mut window, width)')
+	assert chrome_draw_source.contains('draw_client_chrome_close_button(mut window, width)')
+	assert source.count('draw_client_chrome_close_button(mut window, width)') == 1
+	assert source.contains('fn inactive_client_chrome_control_hit_at')
+	assert source.contains('inactive_control := inactive_client_chrome_control_hit_at(input.mouse_x')
+	assert source.contains('if inactive_control {\n\t\treturn')
+	client_chrome_predicate :=
+		source.all_after('fn client_chrome_enabled(caps gg.Capabilities, native_decorations bool) bool').all_before('fn move_hit_at')
+	assert client_chrome_predicate.contains('return caps.wayland && caps.interactive_move_resize && !native_decorations')
+
+	for branch in [
+		'.key_down {',
+		'.key_up {',
+		'.char {',
+		'.mouse_down {',
+		'.mouse_up {',
+		'.mouse_move {',
+		'.mouse_scroll {',
+		'.mouse_enter {',
+		'.mouse_leave {',
+		'.touches_began {',
+		'.touches_moved {',
+		'.touches_ended {',
+		'.touches_cancelled {',
+		'.resized {',
+		'.iconified {',
+		'.restored {',
+		'.focused {',
+		'.unfocused {',
+		'.suspended {',
+		'.resumed {',
+		'.quit_requested {',
+		'.clipboard_pasted {',
+		'.files_dropped {',
+	] {
+		assert input_summary_source.contains(branch), 'input_event_summary is missing branch `${branch}`'
+	}
 	assert !multiwindow_source_has_unwrapped_resize_window(source)
 }
 
@@ -1379,10 +2115,45 @@ fn multiwindow_facade_source() string {
 	return os.read_file(os.join_path(@DIR, 'multiwindow_d_gg_multiwindow.v')) or { panic(err) }
 }
 
-fn multiwindow_gg_regressions_workflow_source() string {
+fn multiwindow_disabled_facade_source() string {
+	return os.read_file(os.join_path(@DIR, 'multiwindow_notd_gg_multiwindow.v')) or { panic(err) }
+}
+
+fn multiwindow_linux_workflow_source() string {
+	return multiwindow_workflow_source('linux_ci.yml')
+}
+
+fn multiwindow_linux_ci_script_source() string {
 	vlib_dir := os.dir(@DIR)
-	workflow_path := os.join_path(vlib_dir, '..', '.github', 'workflows', 'gg_regressions_ci.yml')
-	return os.read_file(workflow_path) or { panic(err) }
+	script_path := os.join_path(vlib_dir, '..', 'ci', 'linux_ci.vsh')
+	return os.read_file(script_path) or {
+		assert false, 'expected business Linux CI script at ${script_path}: ${err.msg()}'
+		return ''
+	}
+}
+
+fn multiwindow_workflow_source(workflow_name string) string {
+	vlib_dir := os.dir(@DIR)
+	workflow_path := os.join_path(vlib_dir, '..', '.github', 'workflows', workflow_name)
+	return os.read_file(workflow_path) or {
+		assert false, 'expected business workflow at ${workflow_path}: ${err.msg()}'
+		return ''
+	}
+}
+
+fn multiwindow_business_multiwindow_workflow_sources() string {
+	vlib_dir := os.dir(@DIR)
+	workflow_dir := os.join_path(vlib_dir, '..', '.github', 'workflows')
+	mut sources := []string{}
+	for workflow_name in ['linux_ci.yml', 'macos_ci.yml', 'windows_ci_msvc.yml', 'windows_ci_gcc.yml',
+		'windows_ci_tcc.yml'] {
+		workflow_path := os.join_path(workflow_dir, workflow_name)
+		if os.exists(workflow_path) {
+			sources << os.read_file(workflow_path) or { panic(err) }
+		}
+	}
+	assert sources.len > 0
+	return sources.join('\n')
 }
 
 fn multiwindow_example_source() string {

--- a/vlib/gg/multiwindow_d_gg_multiwindow.v
+++ b/vlib/gg/multiwindow_d_gg_multiwindow.v
@@ -3,6 +3,7 @@ module gg
 
 import x.multiwindow
 import sokol.gfx
+import sokol.sapp
 import sokol.sgl
 import sync
 import time
@@ -32,6 +33,40 @@ pub enum WindowEventKind {
 	window_destroyed
 	window_close_requested
 	window_resized
+}
+
+// WindowResizeEdge identifies the edge or corner used for an interactive,
+// user-driven native resize operation.
+pub enum WindowResizeEdge {
+	top
+	bottom
+	left
+	right
+	top_left
+	top_right
+	bottom_left
+	bottom_right
+}
+
+// WindowCursorShape identifies a native cursor image for hover feedback.
+pub enum WindowCursorShape {
+	default
+	pointer
+	move
+	n_resize
+	s_resize
+	e_resize
+	w_resize
+	ne_resize
+	nw_resize
+	se_resize
+	sw_resize
+	ew_resize
+	ns_resize
+	nesw_resize
+	nwse_resize
+	grab
+	grabbing
 }
 
 // WindowId identifies a window managed by gg.App.
@@ -72,35 +107,46 @@ pub:
 // WindowInfo is a snapshot of a live gg.App window.
 pub struct WindowInfo {
 pub:
-	id         WindowId
-	title      string
-	width      int
-	height     int
-	min_width  int
-	min_height int
-	resizable  bool
-	visible    bool
-	high_dpi   bool
-	borderless bool
-	fullscreen bool
+	id                 WindowId
+	title              string
+	width              int
+	height             int
+	min_width          int
+	min_height         int
+	resizable          bool
+	visible            bool
+	high_dpi           bool
+	borderless         bool
+	fullscreen         bool
+	native_decorations bool
 }
 
 // Capabilities reports the active gg.App backend contract.
 pub struct Capabilities {
 pub:
-	backend            MultiWindowBackend
-	mock               bool
-	native             bool
-	multi_window       bool
-	owner_queue        bool
-	explicit_swapchain bool
-	readback           bool
-	d3d11              bool
-	metal              bool
-	x11                bool
-	wayland            bool
-	win32              bool
-	gl                 bool
+	backend                 MultiWindowBackend
+	mock                    bool
+	native                  bool
+	multi_window            bool
+	owner_queue             bool
+	explicit_swapchain      bool
+	readback                bool
+	d3d11                   bool
+	metal                   bool
+	x11                     bool
+	wayland                 bool
+	win32                   bool
+	gl                      bool
+	input_events            bool
+	mouse_events            bool
+	keyboard_events         bool
+	text_events             bool
+	focus_events            bool
+	drop_events             bool
+	touch_events            bool
+	cursor_shapes           bool
+	interactive_move_resize bool
+	native_decorations      bool
 }
 
 // WindowEvent is the multi-window event wrapper. The existing gg.Event remains
@@ -114,6 +160,14 @@ pub:
 	height int
 }
 
+// WindowInputEvent routes a normal gg.Event to a specific gg.App window.
+pub struct WindowInputEvent {
+pub:
+	window        WindowId
+	event         Event
+	dropped_files []string
+}
+
 // AppJobFn is executed later by app.drain_pending() on the owner side.
 pub type AppJobFn = fn (mut app App) !
 
@@ -123,6 +177,9 @@ pub type AppFrameFn = fn (mut app App) !
 
 // AppEventFn is called by App.run() for each drained multi-window event.
 pub type AppEventFn = fn (event WindowEvent, mut app App) !
+
+// AppInputFn is called by App.run() for each drained multi-window input event.
+pub type AppInputFn = fn (event WindowInputEvent, mut app App) !
 
 // WindowDrawFn records drawing commands for one WindowContext.
 pub type WindowDrawFn = fn (mut window WindowContext) !
@@ -134,6 +191,7 @@ pub struct RunConfig {
 pub:
 	frame_fn         AppFrameFn = unsafe { nil }
 	event_fn         AppEventFn = unsafe { nil }
+	input_fn         AppInputFn = unsafe { nil }
 	max_pending_jobs int        = 64
 }
 
@@ -205,6 +263,24 @@ pub fn (mut app App) set_window_title(id WindowId, title string) ! {
 pub fn (mut app App) resize_window(id WindowId, width int, height int) ! {
 	app.ensure_initialized()!
 	app.core.resize_window(id.core, width, height)!
+}
+
+// set_window_cursor updates the native hover cursor for a live window.
+pub fn (mut app App) set_window_cursor(id WindowId, shape WindowCursorShape) ! {
+	app.ensure_initialized()!
+	app.core.set_window_cursor(id.core, window_cursor_shape_to_core(shape))!
+}
+
+// begin_window_move starts a user-driven native move for a live window.
+pub fn (mut app App) begin_window_move(id WindowId) ! {
+	app.ensure_initialized()!
+	app.core.begin_window_move(id.core)!
+}
+
+// begin_window_resize starts a user-driven native resize for a live resizable window.
+pub fn (mut app App) begin_window_resize(id WindowId, edge WindowResizeEdge) ! {
+	app.ensure_initialized()!
+	app.core.begin_window_resize(id.core, window_resize_edge_to_core(edge))!
 }
 
 // window_info returns a snapshot of a live window.
@@ -286,7 +362,18 @@ pub fn (mut app App) drain_events() ![]WindowEvent {
 	return events
 }
 
-// poll_events lets the backend route native lifecycle events into the gg.App queue.
+// drain_input_events returns and clears pending window-scoped input events.
+pub fn (mut app App) drain_input_events() ![]WindowInputEvent {
+	app.ensure_initialized()!
+	core_events := app.core.drain_input_events()!
+	mut events := []WindowInputEvent{cap: core_events.len}
+	for event in core_events {
+		events << window_input_event_from_core(event)
+	}
+	return events
+}
+
+// poll_events lets the backend route native lifecycle/input events into the gg.App queue.
 pub fn (mut app App) poll_events() !int {
 	app.ensure_initialized()!
 	return app.core.poll_events()!
@@ -322,7 +409,8 @@ pub fn (mut app App) run(config RunConfig) ! {
 	app.ensure_initialized()!
 	has_frame_fn := config.frame_fn != unsafe { nil }
 	has_event_fn := config.event_fn != unsafe { nil }
-	if !has_frame_fn && !has_event_fn {
+	has_input_fn := config.input_fn != unsafe { nil }
+	if !has_frame_fn && !has_event_fn && !has_input_fn {
 		return error(err_multiwindow_nil_run_fn)
 	}
 	renderer_available := app.capabilities().explicit_swapchain
@@ -349,7 +437,7 @@ pub fn (mut app App) run(config RunConfig) ! {
 		if app.core.status() != .running {
 			break
 		}
-		dispatched_events := app.dispatch_run_events(config.event_fn)!
+		dispatched_events := app.dispatch_run_events(config.event_fn, config.input_fn)!
 		if app.core.status() != .running {
 			break
 		}
@@ -361,21 +449,56 @@ pub fn (mut app App) run(config RunConfig) ! {
 	}
 }
 
-fn (mut app App) dispatch_run_events(event_fn AppEventFn) !int {
-	events := app.drain_events()!
-	if event_fn == unsafe { nil } {
-		// Frame-only loops still need lifecycle side effects from drain_events().
-		return events.len
-	}
+fn (mut app App) dispatch_run_events(event_fn AppEventFn, input_fn AppInputFn) !int {
+	events := app.core.drain_queued_events()!
 	mut dispatched := 0
 	for event in events {
-		event_fn(event, mut app)!
+		match event.kind {
+			.lifecycle {
+				window_event := window_event_from_core(event.lifecycle)
+				if window_event.kind == .window_destroyed {
+					app.discard_window_sgl_context(window_event.window)
+				}
+				if event_fn != unsafe { nil } {
+					event_fn(window_event, mut app)!
+				} else {
+					app.dispatch_lifecycle_without_event_callback(window_event)!
+				}
+			}
+			.input {
+				if input_fn != unsafe { nil } {
+					input_fn(window_input_event_from_core(event.input), mut app)!
+				}
+			}
+		}
+
 		dispatched++
 		if app.core.status() != .running {
 			return dispatched
 		}
 	}
 	return dispatched
+}
+
+fn (mut app App) dispatch_lifecycle_without_event_callback(event WindowEvent) ! {
+	match event.kind {
+		.window_close_requested {
+			if app.window_exists(event.window) {
+				app.destroy_window(event.window)!
+			}
+			app.stop_if_no_windows()!
+		}
+		.window_destroyed {
+			app.stop_if_no_windows()!
+		}
+		else {}
+	}
+}
+
+fn (mut app App) stop_if_no_windows() ! {
+	if app.core.status() == .running && app.window_ids()!.len == 0 {
+		app.stop()!
+	}
 }
 
 // draw_window renders one live window through its WindowContext.
@@ -444,6 +567,36 @@ pub fn (context &WindowContext) framebuffer_size() Size {
 // size returns the current draw size. Logical scaling will be added with native DPI routing.
 pub fn (context &WindowContext) size() Size {
 	return context.framebuffer_size()
+}
+
+// draw_rect_filled draws a filled rectangle into this window's current draw frame.
+// Coordinates are in window framebuffer pixels with top-left origin.
+pub fn (context &WindowContext) draw_rect_filled(x f32, y f32, w f32, h f32, color Color) {
+	sgl.set_context(context.sgl_context)
+	sgl.c4b(color.r, color.g, color.b, color.a)
+	sgl.begin_quads()
+	sgl.v2f(x, y)
+	sgl.v2f(x + w, y)
+	sgl.v2f(x + w, y + h)
+	sgl.v2f(x, y + h)
+	sgl.end()
+}
+
+// draw_rect_empty draws a one-pixel outline rectangle into this window's current draw frame.
+// Coordinates are in window framebuffer pixels with top-left origin.
+pub fn (context &WindowContext) draw_rect_empty(x f32, y f32, w f32, h f32, color Color) {
+	sgl.set_context(context.sgl_context)
+	sgl.c4b(color.r, color.g, color.b, color.a)
+	sgl.begin_lines()
+	sgl.v2f(x, y)
+	sgl.v2f(x + w, y)
+	sgl.v2f(x, y)
+	sgl.v2f(x, y + h)
+	sgl.v2f(x + w, y)
+	sgl.v2f(x + w, y + h)
+	sgl.v2f(x, y + h)
+	sgl.v2f(x + w, y + h)
+	sgl.end()
 }
 
 fn (mut app App) wrap_job(f AppJobFn) multiwindow.AppJobFn {
@@ -615,19 +768,29 @@ fn (config WindowConfig) to_core() multiwindow.WindowConfig {
 
 fn capabilities_from_core(caps multiwindow.Capabilities) Capabilities {
 	return Capabilities{
-		backend:            backend_from_core(caps.backend)
-		mock:               caps.mock
-		native:             caps.native
-		multi_window:       caps.multi_window
-		owner_queue:        caps.owner_queue
-		explicit_swapchain: caps.explicit_swapchain
-		readback:           caps.readback
-		d3d11:              caps.d3d11
-		metal:              caps.metal
-		x11:                caps.x11
-		wayland:            caps.wayland
-		win32:              caps.win32
-		gl:                 caps.gl
+		backend:                 backend_from_core(caps.backend)
+		mock:                    caps.mock
+		native:                  caps.native
+		multi_window:            caps.multi_window
+		owner_queue:             caps.owner_queue
+		explicit_swapchain:      caps.explicit_swapchain
+		readback:                caps.readback
+		d3d11:                   caps.d3d11
+		metal:                   caps.metal
+		x11:                     caps.x11
+		wayland:                 caps.wayland
+		win32:                   caps.win32
+		gl:                      caps.gl
+		input_events:            caps.input_events
+		mouse_events:            caps.mouse_events
+		keyboard_events:         caps.keyboard_events
+		text_events:             caps.text_events
+		focus_events:            caps.focus_events
+		drop_events:             caps.drop_events
+		touch_events:            caps.touch_events
+		cursor_shapes:           caps.cursor_shapes
+		interactive_move_resize: caps.interactive_move_resize
+		native_decorations:      caps.native_decorations
 	}
 }
 
@@ -639,17 +802,18 @@ fn window_id_from_core(id multiwindow.WindowId) WindowId {
 
 fn window_info_from_core(info multiwindow.WindowInfo) WindowInfo {
 	return WindowInfo{
-		id:         window_id_from_core(info.id)
-		title:      info.title
-		width:      info.width
-		height:     info.height
-		min_width:  info.min_width
-		min_height: info.min_height
-		resizable:  info.resizable
-		visible:    info.visible
-		high_dpi:   info.high_dpi
-		borderless: info.borderless
-		fullscreen: info.fullscreen
+		id:                 window_id_from_core(info.id)
+		title:              info.title
+		width:              info.width
+		height:             info.height
+		min_width:          info.min_width
+		min_height:         info.min_height
+		resizable:          info.resizable
+		visible:            info.visible
+		high_dpi:           info.high_dpi
+		borderless:         info.borderless
+		fullscreen:         info.fullscreen
+		native_decorations: info.native_decorations
 	}
 }
 
@@ -662,11 +826,216 @@ fn window_event_from_core(event multiwindow.Event) WindowEvent {
 	}
 }
 
+fn window_input_event_from_core(event multiwindow.InputEvent) WindowInputEvent {
+	return WindowInputEvent{
+		window:        window_id_from_core(event.window_id)
+		event:         gg_event_from_core_input(event)
+		dropped_files: event.dropped_files.clone()
+	}
+}
+
+fn gg_event_from_core_input(event multiwindow.InputEvent) Event {
+	mut touches := [8]TouchPoint{}
+	touch_count := input_touch_count(event.num_touches)
+	for i in 0 .. touch_count {
+		touch := event.touches[i]
+		touches[i] = TouchPoint{
+			identifier:       touch.identifier
+			pos_x:            touch.pos_x
+			pos_y:            touch.pos_y
+			android_tooltype: unsafe { sapp.TouchToolType(touch.android_tooltype) }
+			changed:          touch.changed
+		}
+	}
+	return Event{
+		frame_count:        event.frame_count
+		typ:                input_event_type_from_core(event.kind)
+		key_code:           unsafe { KeyCode(event.key_code) }
+		char_code:          event.char_code
+		key_repeat:         event.key_repeat
+		modifiers:          event.modifiers
+		mouse_button:       mouse_button_from_core(event.mouse_button)
+		mouse_x:            event.mouse_x
+		mouse_y:            event.mouse_y
+		mouse_dx:           event.mouse_dx
+		mouse_dy:           event.mouse_dy
+		scroll_x:           event.scroll_x
+		scroll_y:           event.scroll_y
+		num_touches:        touch_count
+		touches:            touches
+		window_width:       event.window_width
+		window_height:      event.window_height
+		framebuffer_width:  event.framebuffer_width
+		framebuffer_height: event.framebuffer_height
+	}
+}
+
 fn event_kind_from_core(kind multiwindow.EventKind) WindowEventKind {
 	return match kind {
 		.window_created { .window_created }
 		.window_destroyed { .window_destroyed }
 		.window_close_requested { .window_close_requested }
 		.window_resized { .window_resized }
+	}
+}
+
+fn window_resize_edge_to_core(edge WindowResizeEdge) multiwindow.WindowResizeEdge {
+	return match edge {
+		.top { .top }
+		.bottom { .bottom }
+		.left { .left }
+		.right { .right }
+		.top_left { .top_left }
+		.top_right { .top_right }
+		.bottom_left { .bottom_left }
+		.bottom_right { .bottom_right }
+	}
+}
+
+fn window_cursor_shape_to_core(shape WindowCursorShape) multiwindow.CursorShape {
+	return match shape {
+		.default { .default }
+		.pointer { .pointer }
+		.move { .move }
+		.n_resize { .n_resize }
+		.s_resize { .s_resize }
+		.e_resize { .e_resize }
+		.w_resize { .w_resize }
+		.ne_resize { .ne_resize }
+		.nw_resize { .nw_resize }
+		.se_resize { .se_resize }
+		.sw_resize { .sw_resize }
+		.ew_resize { .ew_resize }
+		.ns_resize { .ns_resize }
+		.nesw_resize { .nesw_resize }
+		.nwse_resize { .nwse_resize }
+		.grab { .grab }
+		.grabbing { .grabbing }
+	}
+}
+
+fn input_event_type_from_core(kind multiwindow.InputEventKind) sapp.EventType {
+	return match kind {
+		.invalid { .invalid }
+		.key_down { .key_down }
+		.key_up { .key_up }
+		.char { .char }
+		.mouse_down { .mouse_down }
+		.mouse_up { .mouse_up }
+		.mouse_scroll { .mouse_scroll }
+		.mouse_move { .mouse_move }
+		.mouse_enter { .mouse_enter }
+		.mouse_leave { .mouse_leave }
+		.touches_began { .touches_began }
+		.touches_moved { .touches_moved }
+		.touches_ended { .touches_ended }
+		.touches_cancelled { .touches_cancelled }
+		.resized { .resized }
+		.iconified { .iconified }
+		.restored { .restored }
+		.focused { .focused }
+		.unfocused { .unfocused }
+		.suspended { .suspended }
+		.resumed { .resumed }
+		.quit_requested { .quit_requested }
+		.clipboard_pasted { .clipboard_pasted }
+		.files_dropped { .files_dropped }
+	}
+}
+
+fn mouse_button_from_core(button int) MouseButton {
+	return match button {
+		0 { .left }
+		1 { .right }
+		2 { .middle }
+		else { .invalid }
+	}
+}
+
+fn input_touch_count(count int) int {
+	if count < 0 {
+		return 0
+	}
+	if count > 8 {
+		return 8
+	}
+	return count
+}
+
+$if test {
+	fn input_event_to_core(event WindowInputEvent) multiwindow.InputEvent {
+		gg_event := event.event
+		mut touches := [8]multiwindow.InputTouchPoint{}
+		touch_count := input_touch_count(gg_event.num_touches)
+		for i in 0 .. touch_count {
+			touch := gg_event.touches[i]
+			touches[i] = multiwindow.InputTouchPoint{
+				identifier:       touch.identifier
+				pos_x:            touch.pos_x
+				pos_y:            touch.pos_y
+				android_tooltype: int(touch.android_tooltype)
+				changed:          touch.changed
+			}
+		}
+		return multiwindow.InputEvent{
+			kind:               input_event_type_to_core(gg_event.typ)
+			window_id:          event.window.core
+			frame_count:        gg_event.frame_count
+			key_code:           int(gg_event.key_code)
+			char_code:          gg_event.char_code
+			key_repeat:         gg_event.key_repeat
+			modifiers:          gg_event.modifiers
+			mouse_button:       int(gg_event.mouse_button)
+			mouse_x:            gg_event.mouse_x
+			mouse_y:            gg_event.mouse_y
+			mouse_dx:           gg_event.mouse_dx
+			mouse_dy:           gg_event.mouse_dy
+			scroll_x:           gg_event.scroll_x
+			scroll_y:           gg_event.scroll_y
+			num_touches:        touch_count
+			touches:            touches
+			window_width:       gg_event.window_width
+			window_height:      gg_event.window_height
+			framebuffer_width:  gg_event.framebuffer_width
+			framebuffer_height: gg_event.framebuffer_height
+			dropped_files:      event.dropped_files.clone()
+		}
+	}
+
+	fn input_event_type_to_core(typ sapp.EventType) multiwindow.InputEventKind {
+		return match typ {
+			.invalid { .invalid }
+			.key_down { .key_down }
+			.key_up { .key_up }
+			.char { .char }
+			.mouse_down { .mouse_down }
+			.mouse_up { .mouse_up }
+			.mouse_scroll { .mouse_scroll }
+			.mouse_move { .mouse_move }
+			.mouse_enter { .mouse_enter }
+			.mouse_leave { .mouse_leave }
+			.touches_began { .touches_began }
+			.touches_moved { .touches_moved }
+			.touches_ended { .touches_ended }
+			.touches_cancelled { .touches_cancelled }
+			.resized { .resized }
+			.iconified { .iconified }
+			.restored { .restored }
+			.focused { .focused }
+			.unfocused { .unfocused }
+			.suspended { .suspended }
+			.resumed { .resumed }
+			.quit_requested { .quit_requested }
+			.clipboard_pasted { .clipboard_pasted }
+			.files_dropped { .files_dropped }
+			else { .invalid }
+		}
+	}
+
+	// enqueue_mock_input_for_test injects a window-scoped input event into the
+	// mock backend without exposing x.multiwindow to user programs.
+	pub fn (mut app App) enqueue_mock_input_for_test(event WindowInputEvent) ! {
+		app.ensure_initialized()!
+		app.core.enqueue_mock_input_for_test(input_event_to_core(event))!
 	}
 }

--- a/vlib/gg/multiwindow_notd_gg_multiwindow.v
+++ b/vlib/gg/multiwindow_notd_gg_multiwindow.v
@@ -21,6 +21,40 @@ pub enum WindowEventKind {
 	window_resized
 }
 
+// WindowResizeEdge identifies the edge or corner used for an interactive,
+// user-driven native resize operation.
+pub enum WindowResizeEdge {
+	top
+	bottom
+	left
+	right
+	top_left
+	top_right
+	bottom_left
+	bottom_right
+}
+
+// WindowCursorShape identifies a native cursor image for hover feedback.
+pub enum WindowCursorShape {
+	default
+	pointer
+	move
+	n_resize
+	s_resize
+	e_resize
+	w_resize
+	ne_resize
+	nw_resize
+	se_resize
+	sw_resize
+	ew_resize
+	ns_resize
+	nesw_resize
+	nwse_resize
+	grab
+	grabbing
+}
+
 // WindowId identifies a window managed by gg.App.
 pub struct WindowId {}
 
@@ -58,35 +92,46 @@ pub:
 // WindowInfo is a snapshot of a live gg.App window.
 pub struct WindowInfo {
 pub:
-	id         WindowId
-	title      string
-	width      int
-	height     int
-	min_width  int
-	min_height int
-	resizable  bool
-	visible    bool
-	high_dpi   bool
-	borderless bool
-	fullscreen bool
+	id                 WindowId
+	title              string
+	width              int
+	height             int
+	min_width          int
+	min_height         int
+	resizable          bool
+	visible            bool
+	high_dpi           bool
+	borderless         bool
+	fullscreen         bool
+	native_decorations bool
 }
 
 // Capabilities reports the active gg.App backend contract.
 pub struct Capabilities {
 pub:
-	backend            MultiWindowBackend
-	mock               bool
-	native             bool
-	multi_window       bool
-	owner_queue        bool
-	explicit_swapchain bool
-	readback           bool
-	d3d11              bool
-	metal              bool
-	x11                bool
-	wayland            bool
-	win32              bool
-	gl                 bool
+	backend                 MultiWindowBackend
+	mock                    bool
+	native                  bool
+	multi_window            bool
+	owner_queue             bool
+	explicit_swapchain      bool
+	readback                bool
+	d3d11                   bool
+	metal                   bool
+	x11                     bool
+	wayland                 bool
+	win32                   bool
+	gl                      bool
+	input_events            bool
+	mouse_events            bool
+	keyboard_events         bool
+	text_events             bool
+	focus_events            bool
+	drop_events             bool
+	touch_events            bool
+	cursor_shapes           bool
+	interactive_move_resize bool
+	native_decorations      bool
 }
 
 // WindowEvent is the multi-window event wrapper. The existing gg.Event remains
@@ -100,6 +145,14 @@ pub:
 	height int
 }
 
+// WindowInputEvent routes a normal gg.Event to a specific gg.App window.
+pub struct WindowInputEvent {
+pub:
+	window        WindowId
+	event         Event
+	dropped_files []string
+}
+
 // AppJobFn is executed later by app.drain_pending() on the owner side.
 pub type AppJobFn = fn (mut app App) !
 
@@ -109,6 +162,9 @@ pub type AppFrameFn = fn (mut app App) !
 
 // AppEventFn is called by App.run() for each drained multi-window event.
 pub type AppEventFn = fn (event WindowEvent, mut app App) !
+
+// AppInputFn is called by App.run() for each drained multi-window input event.
+pub type AppInputFn = fn (event WindowInputEvent, mut app App) !
 
 // WindowDrawFn records drawing commands for one WindowContext.
 pub type WindowDrawFn = fn (mut window WindowContext) !
@@ -120,6 +176,7 @@ pub struct RunConfig {
 pub:
 	frame_fn         AppFrameFn = unsafe { nil }
 	event_fn         AppEventFn = unsafe { nil }
+	input_fn         AppInputFn = unsafe { nil }
 	max_pending_jobs int        = 64
 }
 
@@ -178,6 +235,29 @@ pub fn (mut app App) resize_window(id WindowId, width int, height int) ! {
 	return error(err_multiwindow_not_enabled)
 }
 
+// set_window_cursor updates the native hover cursor for a live window.
+pub fn (mut app App) set_window_cursor(id WindowId, shape WindowCursorShape) ! {
+	_ = app
+	_ = id
+	_ = shape
+	return error(err_multiwindow_not_enabled)
+}
+
+// begin_window_move starts a user-driven native move for a live window.
+pub fn (mut app App) begin_window_move(id WindowId) ! {
+	_ = app
+	_ = id
+	return error(err_multiwindow_not_enabled)
+}
+
+// begin_window_resize starts a user-driven native resize for a live resizable window.
+pub fn (mut app App) begin_window_resize(id WindowId, edge WindowResizeEdge) ! {
+	_ = app
+	_ = id
+	_ = edge
+	return error(err_multiwindow_not_enabled)
+}
+
 // window_info returns a snapshot of a live window.
 pub fn (app &App) window_info(id WindowId) !WindowInfo {
 	_ = app
@@ -231,7 +311,13 @@ pub fn (mut app App) drain_events() ![]WindowEvent {
 	return error(err_multiwindow_not_enabled)
 }
 
-// poll_events lets the backend route native lifecycle events into the gg.App queue.
+// drain_input_events returns and clears pending window-scoped input events.
+pub fn (mut app App) drain_input_events() ![]WindowInputEvent {
+	_ = app
+	return error(err_multiwindow_not_enabled)
+}
+
+// poll_events lets the backend route native lifecycle/input events into the gg.App queue.
 pub fn (mut app App) poll_events() !int {
 	_ = app
 	return error(err_multiwindow_not_enabled)
@@ -307,4 +393,24 @@ pub fn (context &WindowContext) framebuffer_size() Size {
 // size returns the current draw size. Logical scaling will be added with native DPI routing.
 pub fn (context &WindowContext) size() Size {
 	return context.framebuffer_size()
+}
+
+// draw_rect_filled is available when compiling with `-d gg_multiwindow`.
+pub fn (context &WindowContext) draw_rect_filled(x f32, y f32, w f32, h f32, color Color) {
+	_ = context
+	_ = x
+	_ = y
+	_ = w
+	_ = h
+	_ = color
+}
+
+// draw_rect_empty is available when compiling with `-d gg_multiwindow`.
+pub fn (context &WindowContext) draw_rect_empty(x f32, y f32, w f32, h f32, color Color) {
+	_ = context
+	_ = x
+	_ = y
+	_ = w
+	_ = h
+	_ = color
 }

--- a/vlib/x/multiwindow/README.md
+++ b/vlib/x/multiwindow/README.md
@@ -16,12 +16,13 @@ The module provides:
 - generation-checked `WindowId` handles;
 - backend capability reporting and backend selection;
 - lifecycle events routed to a specific window;
+- backend-neutral input events routed to a specific window;
 - an owner-thread job queue for cross-thread work;
 - explicit swapchain handoff for `sokol.gfx` rendering.
 
-It does not provide high-level input handling, layout, widgets, text rendering,
-or a default event loop. The `gg` facade supplies the higher-level loop and
-drawing API.
+It does not provide layout, widgets, text rendering, high-level input semantics,
+or a default event loop. The `gg` facade supplies the higher-level loop, `gg.Event`
+mapping, and drawing API.
 
 ## Creating an App
 
@@ -83,7 +84,35 @@ the display server, graphics device, or platform API is unavailable.
 - `explicit_swapchain`: render calls can return a `gfx.Swapchain`;
 - `mock`, `native`, `x11`, `wayland`, `win32`: selected platform flags;
 - `gl`, `metal`, `d3d11`: active renderer API flags;
+- `input_events`, `mouse_events`, `keyboard_events`, `text_events`,
+  `focus_events`, `drop_events`, `touch_events`: native input classes the
+  backend can actually deliver;
+- `cursor_shapes`: native hover cursor shape updates are supported via
+  `set_window_cursor(id, shape)`. This is independent from native interactive
+  move/resize support;
+- `interactive_move_resize`: native user-driven move/resize can be requested
+  when the running backend has the required handles and current user action;
+- `native_decorations`: native/server-side decorations are effective for the
+  running backend;
 - `readback`: reserved for backends that expose readback support.
+
+Plain capability probes do not necessarily connect to the display server, so
+runtime optional globals can be unknown before startup and most of those probes
+report implementation support. For Wayland, use `app.capabilities()` after
+`new_app()` for the authoritative runtime state: `drop_events` requires a
+`wl_data_device`, `touch_events` requires `wl_touch`, and interactive
+move/resize requires a seat. Wayland cursor-shape reporting is stricter:
+`cursor_shapes` is true only after a `wp_cursor_shape_device_v1` has been
+created for the active `wl_pointer`. Wayland requests server-side decorations
+through xdg-decoration when the protocol is available; the compositor's
+`configure(mode)` decides the effective `server_side` or `client_side` mode. If
+`server_side` is refused or xdg-decoration is unavailable, apps and examples may
+draw a client-side fallback. Wayland cursor-shape feedback uses
+`wp_cursor_shape_manager_v1` when the compositor exposes it and the seat has a
+pointer; this keeps cursor theme selection compositor-side. `wl_cursor_theme`
+client-side fallback is not implemented, so `app.capabilities()` reports
+`cursor_shapes == false` on Wayland compositors that do not advertise
+cursor-shape-v1.
 
 Backend notes:
 
@@ -141,13 +170,17 @@ The simple read helpers `status()`, `capabilities()`, `window_exists()`, and
 
 ## Events
 
-Events are explicit. Native events are not delivered to user code until the
-owner thread calls:
+Events are explicit. Native lifecycle and input events are not delivered to user
+code until the owner thread calls:
 
 - `poll_events()` to collect backend/native events into the App queue;
-- `drain_events()` to retrieve and clear queued events.
+- `drain_events()` to retrieve and clear queued lifecycle events;
+- `drain_input_events()` to retrieve and clear queued input events without
+  consuming lifecycle events;
+- `drain_queued_events()` to retrieve lifecycle and input events together in the
+  exact order accepted by `App`.
 
-Event kinds are:
+Lifecycle event kinds are:
 
 - `.window_created`: emitted by `create_window()` with the actual initial size;
 - `.window_destroyed`: emitted by `destroy_window()`, `stop()`, or accepted
@@ -157,6 +190,65 @@ Event kinds are:
   notifications with the actual size.
 
 Backend events for stale or already-destroyed window handles are filtered.
+
+`InputEvent` is the low-level backend-neutral payload used by the `gg` facade to
+rebuild `gg.Event` for a specific window. Input kinds include key down/up, char,
+mouse down/up/move/scroll/enter/leave, resize, iconified/restored,
+focus/unfocus, clipboard paste, file drop, and touch families. Backends report
+which families are implemented through the capability booleans above;
+unsupported input classes must remain false rather than being partially
+emulated.
+
+Native input events that do not already carry a frame counter are stamped by
+`App.poll_events()`; all input events accepted in the same poll cycle share that
+`frame_count`. Mock/test events can provide an explicit non-zero `frame_count`,
+which is preserved.
+
+Current native input support is intentionally capability-scoped:
+
+- Mock can synthesize every input family for deterministic tests.
+- Win32 routes mouse, keyboard, text/char, focus, resize, iconified/restored,
+  clipboard paste signals, file drops via `WM_DROPFILES`, and `WM_TOUCH`
+  down/move/up touch input. `WM_TOUCH` handles are read and closed in the
+  window procedure; `WM_TOUCH` does not expose a cancelled state, so
+  `touches_cancelled` is not emitted by the Win32 backend unless a future
+  Pointer Input path owns `POINTER_FLAG_CANCELED`.
+- AppKit routes mouse, keyboard, text/char, focus, resize, iconified/restored,
+  clipboard paste signals, and file drops through `NSDraggingDestination` file
+  URLs. It also routes AppKit `NSResponder` touch phases; positions come from
+  `NSTouch.normalizedPosition` mapped into the current framebuffer, with
+  `touches_cancelled` emitted only for `touchesCancelledWithEvent:`.
+- X11 routes mouse, keyboard, text/char, focus, resize, iconified/restored, and
+  clipboard paste signal input events. Text uses Xlib XIM/XIC with
+  `Xutf8LookupString`; this covers committed UTF-8 text from the active input
+  method without exposing Xlib objects through the public API.
+- X11 receives file drops with XDND `text/uri-list` selection conversion. It
+  decodes local `file://` URIs and queues `.files_dropped` with routed
+  `dropped_files`.
+- Wayland routes pointer, keyboard, text/char through xkb keymap/state, focus,
+  clipboard paste signal, resize input events, touch when the seat exposes
+  `wl_touch`, and file drops when `wl_data_device`/`wl_data_offer`
+  `text/uri-list` is available.
+  Data-offer payloads are received through a non-blocking fd and drained from
+  the owner poll path; the backend only sends `wl_data_offer.finish` after a
+  valid `copy` or `move` action has been received. Pending drops whose source
+  never closes the transfer fd are rejected and cleaned up after a bounded
+  number of owner poll cycles.
+  Wayland text follows the existing `sapp` `xkb_state_key_get_utf8` model for
+  key presses; full IME/composed text is not implemented. Wayland synthesizes
+  key-repeat from compositor repeat_info/xkb; pointer frame batching is not
+  synthesized yet; event callbacks are
+  routed as the compositor delivers them.
+- Native drop and touch input are false unless a backend explicitly reports the
+  corresponding capability. Clipboard paste is an input signal; clipboard
+  contents are not stored on `InputEvent`.
+
+`QueuedEvent` is the ordered queue entry used when lifecycle and input events
+must be consumed as a single stream. Its `kind` field tells whether the entry
+contains a lifecycle `Event` or an `InputEvent`. Use `drain_queued_events()` when
+relative ordering matters, for example input -> close-request -> input; use the
+separate `drain_events()` and `drain_input_events()` helpers only when that
+cross-family ordering is not needed.
 
 ## Rendering
 
@@ -216,7 +308,7 @@ programmatic resize.
 - Native app creation can still fail even when plain capabilities report that a
   backend is supported, for example when a display cannot be opened.
 - The mock backend is not a renderer and cannot produce swapchains.
-- The module has no high-level input, layout, or drawing abstraction.
+- The module has no layout, widget, text rendering, or drawing abstraction.
 
 ## Validation
 

--- a/vlib/x/multiwindow/app.v
+++ b/vlib/x/multiwindow/app.v
@@ -11,7 +11,8 @@ mut:
 	status          AppStatus = .running
 	backend         Backend
 	windows         []WindowSlot
-	events          []Event
+	events          []QueuedEvent
+	frame_count     u64
 	owner_thread_id u64
 	state_mutex     &sync.Mutex        = sync.new_mutex()
 	owner           &executor.Executor = unsafe { nil }
@@ -23,16 +24,20 @@ pub fn new_app(config Config) !&App {
 		return error(err_queue_size_invalid)
 	}
 	mut backend := new_backend(config.backend, config.require_renderer)!
-	backend.start(config.require_renderer)!
-	mut owner := executor.new(queue_size: config.queue_size)!
-	return &App{
+	mut app := &App{
 		config:          config
 		status:          .running
 		backend:         backend
 		owner_thread_id: sync.thread_id()
 		state_mutex:     sync.new_mutex()
-		owner:           owner
 	}
+	app.backend.start(config.require_renderer)!
+	mut owner := executor.new(queue_size: config.queue_size) or {
+		app.backend.stop() or {}
+		return err
+	}
+	app.owner = owner
+	return app
 }
 
 // status reports the application lifecycle state.
@@ -64,12 +69,12 @@ pub fn (mut app App) create_window(config WindowConfig) !WindowId {
 		config: window_config_with_size(config, actual_size.width, actual_size.height)
 		status: .alive
 	}
-	app.events << Event{
+	app.events << queued_lifecycle_event(Event{
 		kind:      .window_created
 		window_id: id
 		width:     actual_size.width
 		height:    actual_size.height
-	}
+	})
 	return id
 }
 
@@ -85,10 +90,10 @@ pub fn (mut app App) destroy_window(id WindowId) ! {
 	index := app.live_window_index(id)!
 	app.backend.destroy_window(id)!
 	app.windows[index].status = .destroyed
-	app.events << Event{
+	app.events << queued_lifecycle_event(Event{
 		kind:      .window_destroyed
 		window_id: id
-	}
+	})
 }
 
 // set_window_title updates the native title and then the authoritative App state.
@@ -117,12 +122,54 @@ pub fn (mut app App) resize_window(id WindowId, width int, height int) ! {
 	actual_size := app.backend.resize_window(id, width, height)!
 	app.windows[index].config = window_config_with_size(app.windows[index].config,
 		actual_size.width, actual_size.height)
-	app.events << Event{
+	app.events << queued_lifecycle_event(Event{
 		kind:      .window_resized
 		window_id: id
 		width:     actual_size.width
 		height:    actual_size.height
+	})
+}
+
+// set_window_cursor updates the native hover cursor for a live window when the
+// selected backend reports capabilities().cursor_shapes.
+pub fn (mut app App) set_window_cursor(id WindowId, shape CursorShape) ! {
+	app.assert_owner_thread()!
+	app.state_mutex.lock()
+	defer {
+		app.state_mutex.unlock()
 	}
+	app.ensure_running_locked()!
+	app.live_window_index(id)!
+	app.backend.set_window_cursor(id, shape)!
+}
+
+// begin_window_move starts a user-driven native move for a live window.
+// Backends that require a recent native input serial may reject the request
+// when it is not made from a deliberate user-action path.
+pub fn (mut app App) begin_window_move(id WindowId) ! {
+	app.assert_owner_thread()!
+	app.state_mutex.lock()
+	defer {
+		app.state_mutex.unlock()
+	}
+	app.ensure_running_locked()!
+	app.live_window_index(id)!
+	app.backend.begin_window_move(id)!
+}
+
+// begin_window_resize starts a user-driven native resize for a live resizable window.
+pub fn (mut app App) begin_window_resize(id WindowId, edge WindowResizeEdge) ! {
+	app.assert_owner_thread()!
+	app.state_mutex.lock()
+	defer {
+		app.state_mutex.unlock()
+	}
+	app.ensure_running_locked()!
+	index := app.live_window_index(id)!
+	if !app.windows[index].config.resizable {
+		return error(err_capability_unsupported)
+	}
+	app.backend.begin_window_resize(id, edge)!
 }
 
 // window_info returns a snapshot of the authoritative App-side window state.
@@ -133,7 +180,9 @@ pub fn (app &App) window_info(id WindowId) !WindowInfo {
 		app.state_mutex.unlock()
 	}
 	index := app.live_window_index(id)!
-	return window_info_from_slot(app.windows[index])
+	slot := app.windows[index]
+	native_decorations := app.backend.window_native_decorations(slot.id, slot.config)!
+	return window_info_from_slot(slot, native_decorations)
 }
 
 // window_ids returns live window ids in stable slot order.
@@ -162,7 +211,8 @@ pub fn (app &App) window_infos() ![]WindowInfo {
 	mut infos := []WindowInfo{cap: app.windows.len}
 	for slot in app.windows {
 		if slot.status == .alive {
-			infos << window_info_from_slot(slot)
+			native_decorations := app.backend.window_native_decorations(slot.id, slot.config)!
+			infos << window_info_from_slot(slot, native_decorations)
 		}
 	}
 	return infos
@@ -204,12 +254,34 @@ pub fn (mut app App) drain_events() ![]Event {
 	defer {
 		app.state_mutex.unlock()
 	}
+	return app.drain_lifecycle_events_locked()
+}
+
+// drain_input_events returns and clears pending input events without consuming
+// lifecycle events.
+pub fn (mut app App) drain_input_events() ![]InputEvent {
+	app.assert_owner_thread()!
+	app.state_mutex.lock()
+	defer {
+		app.state_mutex.unlock()
+	}
+	return app.drain_input_events_locked()
+}
+
+// drain_queued_events returns and clears pending lifecycle/input events in the
+// exact order accepted by App.
+pub fn (mut app App) drain_queued_events() ![]QueuedEvent {
+	app.assert_owner_thread()!
+	app.state_mutex.lock()
+	defer {
+		app.state_mutex.unlock()
+	}
 	events := app.events.clone()
 	app.events.clear()
 	return events
 }
 
-// poll_events lets the backend route native lifecycle events into App events.
+// poll_events lets the backend route native lifecycle and input events into App events.
 pub fn (mut app App) poll_events() !int {
 	app.assert_owner_thread()!
 	app.state_mutex.lock()
@@ -217,38 +289,136 @@ pub fn (mut app App) poll_events() !int {
 		app.state_mutex.unlock()
 	}
 	app.ensure_running_locked()!
-	events := app.backend.poll_events()!
+	app.frame_count++
+	frame_count := app.frame_count
+	events := app.backend.poll_queued_events()!
 	mut accepted := 0
 	for event in events {
 		match event.kind {
-			.window_close_requested {
-				app.live_window_index(event.window_id) or { continue }
-				app.events << event
-				accepted++
-			}
-			.window_destroyed {
-				if app.mark_destroyed_from_backend_locked(event.window_id) {
-					app.events << event
+			.lifecycle {
+				if app.accept_lifecycle_event_locked(event.lifecycle) {
 					accepted++
 				}
 			}
-			.window_resized {
-				if event.width <= 0 || event.height <= 0 {
-					continue
+			.input {
+				if app.accept_input_event_locked(event.input, frame_count) {
+					accepted++
 				}
-				index := app.live_window_index(event.window_id) or { continue }
-				app.windows[index].config = window_config_with_size(app.windows[index].config,
-					event.width, event.height)
-				app.events << event
-				accepted++
-			}
-			else {
-				app.events << event
-				accepted++
 			}
 		}
 	}
 	return accepted
+}
+
+fn (mut app App) drain_lifecycle_events_locked() []Event {
+	mut lifecycle_events := []Event{cap: app.events.len}
+	mut remaining_events := []QueuedEvent{cap: app.events.len}
+	for event in app.events {
+		match event.kind {
+			.lifecycle {
+				lifecycle_events << event.lifecycle
+			}
+			.input {
+				remaining_events << event
+			}
+		}
+	}
+	app.events = remaining_events
+	return lifecycle_events
+}
+
+fn (mut app App) drain_input_events_locked() []InputEvent {
+	mut input_events := []InputEvent{cap: app.events.len}
+	mut remaining_events := []QueuedEvent{cap: app.events.len}
+	for event in app.events {
+		match event.kind {
+			.lifecycle {
+				remaining_events << event
+			}
+			.input {
+				input_events << event.input
+			}
+		}
+	}
+	app.events = remaining_events
+	return input_events
+}
+
+fn (mut app App) accept_lifecycle_event_locked(event Event) bool {
+	match event.kind {
+		.window_close_requested {
+			app.live_window_index(event.window_id) or { return false }
+			app.events << queued_lifecycle_event(event)
+			return true
+		}
+		.window_destroyed {
+			if app.mark_destroyed_from_backend_locked(event.window_id) {
+				app.events << queued_lifecycle_event(event)
+				return true
+			}
+			return false
+		}
+		.window_resized {
+			if event.width <= 0 || event.height <= 0 {
+				return false
+			}
+			index := app.live_window_index(event.window_id) or { return false }
+			app.windows[index].config = window_config_with_size(app.windows[index].config,
+				event.width, event.height)
+			app.events << queued_lifecycle_event(event)
+			return true
+		}
+		else {
+			app.events << queued_lifecycle_event(event)
+			return true
+		}
+	}
+}
+
+fn (mut app App) accept_input_event_locked(event InputEvent, frame_count u64) bool {
+	input_event := input_event_with_frame_count(event, frame_count)
+	if input_event.kind == .resized {
+		if input_event.window_width <= 0 || input_event.window_height <= 0 {
+			return false
+		}
+		index := app.live_window_index(input_event.window_id) or { return false }
+		app.windows[index].config = window_config_with_size(app.windows[index].config,
+			input_event.window_width, input_event.window_height)
+		app.events << queued_input_event(input_event)
+		return true
+	}
+	app.live_window_index(input_event.window_id) or { return false }
+	app.events << queued_input_event(input_event)
+	return true
+}
+
+fn input_event_with_frame_count(event InputEvent, frame_count u64) InputEvent {
+	if event.frame_count != 0 {
+		return event
+	}
+	return InputEvent{
+		kind:               event.kind
+		window_id:          event.window_id
+		frame_count:        frame_count
+		key_code:           event.key_code
+		char_code:          event.char_code
+		key_repeat:         event.key_repeat
+		modifiers:          event.modifiers
+		mouse_button:       event.mouse_button
+		mouse_x:            event.mouse_x
+		mouse_y:            event.mouse_y
+		mouse_dx:           event.mouse_dx
+		mouse_dy:           event.mouse_dy
+		scroll_x:           event.scroll_x
+		scroll_y:           event.scroll_y
+		num_touches:        event.num_touches
+		touches:            event.touches
+		window_width:       event.window_width
+		window_height:      event.window_height
+		framebuffer_width:  event.framebuffer_width
+		framebuffer_height: event.framebuffer_height
+		dropped_files:      event.dropped_files.clone()
+	}
 }
 
 $if test {
@@ -271,6 +441,22 @@ $if test {
 		})
 	}
 
+	// enqueue_mock_input_for_test injects a mock-native input event into the
+	// backend queue only in test builds.
+	pub fn (mut app App) enqueue_mock_input_for_test(event InputEvent) ! {
+		app.assert_owner_thread()!
+		app.state_mutex.lock()
+		defer {
+			app.state_mutex.unlock()
+		}
+		app.ensure_running_locked()!
+		app.live_window_index(event.window_id)!
+		if app.backend.kind != .mock {
+			return error(err_capability_unsupported)
+		}
+		app.backend.mock.enqueue_input_event(event)
+	}
+
 	// enqueue_mock_close_requested_unchecked_for_test intentionally bypasses
 	// WindowId liveness validation so App.poll_events() filtering can be tested.
 	fn (mut app App) enqueue_mock_close_requested_unchecked_for_test(id WindowId) ! {
@@ -287,6 +473,21 @@ $if test {
 			kind:      .window_close_requested
 			window_id: id
 		})
+	}
+
+	// enqueue_mock_input_unchecked_for_test intentionally bypasses WindowId
+	// liveness validation so App.poll_events() filtering can be tested.
+	fn (mut app App) enqueue_mock_input_unchecked_for_test(event InputEvent) ! {
+		app.assert_owner_thread()!
+		app.state_mutex.lock()
+		defer {
+			app.state_mutex.unlock()
+		}
+		app.ensure_running_locked()!
+		if app.backend.kind != .mock {
+			return error(err_capability_unsupported)
+		}
+		app.backend.mock.enqueue_input_event(event)
 	}
 }
 
@@ -351,10 +552,10 @@ pub fn (mut app App) stop() ! {
 		if slot.status == .alive {
 			app.backend.destroy_window(slot.id)!
 			app.windows[i].status = .destroyed
-			app.events << Event{
+			app.events << queued_lifecycle_event(Event{
 				kind:      .window_destroyed
 				window_id: slot.id
-			}
+			})
 		}
 	}
 	app.status = .stopped
@@ -426,21 +627,22 @@ fn window_config_with_size(config WindowConfig, width int, height int) WindowCon
 	}
 }
 
-fn window_info_from_slot(slot WindowSlot) WindowInfo {
+fn window_info_from_slot(slot WindowSlot, native_decorations bool) WindowInfo {
 	config := slot.config
 	return WindowInfo{
-		id:         slot.id
-		status:     slot.status
-		title:      config.title
-		width:      config.width
-		height:     config.height
-		min_width:  config.min_width
-		min_height: config.min_height
-		resizable:  config.resizable
-		visible:    config.visible
-		high_dpi:   config.high_dpi
-		borderless: config.borderless
-		fullscreen: config.fullscreen
+		id:                 slot.id
+		status:             slot.status
+		title:              config.title
+		width:              config.width
+		height:             config.height
+		min_width:          config.min_width
+		min_height:         config.min_height
+		resizable:          config.resizable
+		visible:            config.visible
+		high_dpi:           config.high_dpi
+		borderless:         config.borderless
+		fullscreen:         config.fullscreen
+		native_decorations: native_decorations
 	}
 }
 

--- a/vlib/x/multiwindow/appkit_backend.c.v
+++ b/vlib/x/multiwindow/appkit_backend.c.v
@@ -15,6 +15,37 @@ $if darwin {
 		#include "@VMODROOT/vlib/x/multiwindow/appkit_backend.m"
 	}
 
+	@[typedef]
+	struct C.VMultiwindowAppKitQueuedEvent {
+	mut:
+		sequence           u64
+		event_kind         int
+		lifecycle_kind     int
+		input_kind         int
+		key_code           int
+		char_code          u32
+		key_repeat         int
+		modifiers          u32
+		mouse_button       int
+		mouse_x            f32
+		mouse_y            f32
+		mouse_dx           f32
+		mouse_dy           f32
+		scroll_x           f32
+		scroll_y           f32
+		window_width       int
+		window_height      int
+		framebuffer_width  int
+		framebuffer_height int
+		dropped_file_count int
+		dropped_files      &&char = unsafe { nil }
+		touch_count        int
+		touch_ids          [8]u64
+		touch_x            [8]f32
+		touch_y            [8]f32
+		touch_changed      [8]int
+	}
+
 	fn C.v_multiwindow_appkit_is_main_thread() int
 	fn C.v_multiwindow_appkit_prepare_application() int
 	fn C.v_multiwindow_appkit_create_metal_device(out_device &voidptr) int
@@ -23,16 +54,22 @@ $if darwin {
 	fn C.v_multiwindow_appkit_destroy_window(state voidptr)
 	fn C.v_multiwindow_appkit_release_window(state voidptr)
 	fn C.v_multiwindow_appkit_set_window_title(state voidptr, title &char) int
+	fn C.v_multiwindow_appkit_set_cursor_shape(state voidptr, shape int) int
 	fn C.v_multiwindow_appkit_resize_window(state voidptr, width int, height int, out_width &int, out_height &int, out_framebuffer_width &int, out_framebuffer_height &int) int
 	fn C.v_multiwindow_appkit_poll_events()
-	fn C.v_multiwindow_appkit_take_close_requested(state voidptr) int
-	fn C.v_multiwindow_appkit_take_resized(state voidptr, out_width &int, out_height &int, out_framebuffer_width &int, out_framebuffer_height &int) int
-	fn C.v_multiwindow_appkit_take_destroyed(state voidptr) int
+	fn C.v_multiwindow_appkit_take_queued_event(state voidptr, out_event &C.VMultiwindowAppKitQueuedEvent) int
+	fn C.v_multiwindow_appkit_release_queued_event_resources(event &C.VMultiwindowAppKitQueuedEvent)
 	fn C.v_multiwindow_appkit_begin_frame(state voidptr, device voidptr, out_drawable &voidptr, out_depth_texture &voidptr, out_framebuffer_width &int, out_framebuffer_height &int) int
 	fn C.v_multiwindow_appkit_end_frame(state voidptr)
 	fn C.v_multiwindow_appkit_abort_frame(state voidptr)
 }
 
+struct AppKitNativeQueuedEvent {
+	sequence u64
+	event    QueuedEvent
+}
+
+@[heap; markused]
 struct AppKitWindowRecord {
 	id    WindowId
 	state voidptr
@@ -78,6 +115,15 @@ fn (backend &AppKitBackend) capabilities() Capabilities {
 		owner_queue:        true
 		explicit_swapchain: appkit_metal_supported() && backend.renderer_ready()
 		metal:              appkit_metal_supported() && backend.renderer_ready()
+		input_events:       true
+		mouse_events:       true
+		keyboard_events:    true
+		text_events:        true
+		focus_events:       true
+		drop_events:        true
+		touch_events:       true
+		cursor_shapes:      true
+		native_decorations: true
 	}
 }
 
@@ -216,52 +262,209 @@ fn (mut backend AppKitBackend) resize_window(id WindowId, width int, height int)
 	}
 }
 
+$if darwin {
+	@[markused]
+	fn appkit_input_kind(kind int) InputEventKind {
+		return match kind {
+			1 { InputEventKind.key_down }
+			2 { InputEventKind.key_up }
+			3 { InputEventKind.char }
+			4 { InputEventKind.mouse_down }
+			5 { InputEventKind.mouse_up }
+			6 { InputEventKind.mouse_scroll }
+			7 { InputEventKind.mouse_move }
+			8 { InputEventKind.mouse_enter }
+			9 { InputEventKind.mouse_leave }
+			10 { InputEventKind.focused }
+			11 { InputEventKind.unfocused }
+			12 { InputEventKind.resized }
+			13 { InputEventKind.iconified }
+			14 { InputEventKind.restored }
+			15 { InputEventKind.clipboard_pasted }
+			16 { InputEventKind.files_dropped }
+			17 { InputEventKind.touches_began }
+			18 { InputEventKind.touches_moved }
+			19 { InputEventKind.touches_ended }
+			20 { InputEventKind.touches_cancelled }
+			else { InputEventKind.invalid }
+		}
+	}
+
+	@[markused]
+	fn appkit_dropped_files_from_native(native_event C.VMultiwindowAppKitQueuedEvent) []string {
+		if native_event.dropped_file_count <= 0 || native_event.dropped_files == unsafe { nil } {
+			return []string{}
+		}
+		mut files := []string{cap: native_event.dropped_file_count}
+		for i in 0 .. native_event.dropped_file_count {
+			path := unsafe { native_event.dropped_files[i] }
+			if path != unsafe { nil } {
+				files << unsafe { tos_clone(&u8(path)) }
+			}
+		}
+		return files
+	}
+
+	@[markused]
+	fn appkit_queued_event_from_native(record AppKitWindowRecord, native_event C.VMultiwindowAppKitQueuedEvent) ?QueuedEvent {
+		if native_event.event_kind == 1 {
+			kind := match native_event.lifecycle_kind {
+				1 { EventKind.window_close_requested }
+				2 { EventKind.window_destroyed }
+				3 { EventKind.window_resized }
+				else { return none }
+			}
+
+			mut event := Event{
+				kind:      kind
+				window_id: record.id
+			}
+			if kind == .window_resized {
+				event = Event{
+					kind:      kind
+					window_id: record.id
+					width:     native_event.window_width
+					height:    native_event.window_height
+				}
+			}
+			return queued_lifecycle_event(event)
+		}
+		if native_event.event_kind == 2 {
+			input_kind := appkit_input_kind(native_event.input_kind)
+			if input_kind == .invalid {
+				return none
+			}
+			mut touch_count := native_event.touch_count
+			if touch_count < 0 {
+				touch_count = 0
+			}
+			if touch_count > 8 {
+				touch_count = 8
+			}
+			mut touches := [8]InputTouchPoint{}
+			for i in 0 .. touch_count {
+				touches[i] = InputTouchPoint{
+					identifier: native_event.touch_ids[i]
+					pos_x:      native_event.touch_x[i]
+					pos_y:      native_event.touch_y[i]
+					changed:    native_event.touch_changed[i] != 0
+				}
+			}
+			return queued_input_event(InputEvent{
+				kind:               input_kind
+				window_id:          record.id
+				key_code:           native_event.key_code
+				char_code:          native_event.char_code
+				key_repeat:         native_event.key_repeat != 0
+				modifiers:          native_event.modifiers
+				mouse_button:       native_event.mouse_button
+				mouse_x:            native_event.mouse_x
+				mouse_y:            native_event.mouse_y
+				mouse_dx:           native_event.mouse_dx
+				mouse_dy:           native_event.mouse_dy
+				scroll_x:           native_event.scroll_x
+				scroll_y:           native_event.scroll_y
+				num_touches:        touch_count
+				touches:            touches
+				window_width:       native_event.window_width
+				window_height:      native_event.window_height
+				framebuffer_width:  native_event.framebuffer_width
+				framebuffer_height: native_event.framebuffer_height
+				dropped_files:      appkit_dropped_files_from_native(native_event)
+			})
+		}
+		return none
+	}
+}
+
+fn (mut backend AppKitBackend) set_window_cursor(id WindowId, shape CursorShape) ! {
+	$if darwin {
+		index := backend.window_record_index(id) or { return error(err_window_not_found) }
+		if C.v_multiwindow_appkit_set_cursor_shape(backend.windows[index].state, int(shape)) == 0 {
+			return error(err_capability_unsupported)
+		}
+		return
+	} $else {
+		_ = id
+		_ = shape
+		return error(err_backend_unsupported)
+	}
+}
+
 fn (mut backend AppKitBackend) poll_events() ![]Event {
-	mut events := []Event{}
+	queued_events := backend.poll_queued_events()!
+	mut events := []Event{cap: queued_events.len}
+	for event in queued_events {
+		if event.kind == .lifecycle {
+			events << event.lifecycle
+		}
+	}
+	return events
+}
+
+fn (mut backend AppKitBackend) poll_queued_events() ![]QueuedEvent {
+	mut native_events := []AppKitNativeQueuedEvent{}
 	$if darwin {
 		if !backend.started {
-			return events
+			return []QueuedEvent{}
 		}
 		C.v_multiwindow_appkit_poll_events()
 		mut i := 0
 		for i < backend.windows.len {
 			record := backend.windows[i]
-			if C.v_multiwindow_appkit_take_destroyed(record.state) != 0 {
+			mut destroyed := false
+			for {
+				mut native_event := C.VMultiwindowAppKitQueuedEvent{}
+				if C.v_multiwindow_appkit_take_queued_event(record.state, &native_event) == 0 {
+					break
+				}
+				if native_event.event_kind == 1 && native_event.lifecycle_kind == 2 {
+					destroyed = true
+				}
+				if native_event.window_width > 0 && native_event.window_height > 0
+					&& ((native_event.event_kind == 1 && native_event.lifecycle_kind == 3)
+					|| (native_event.event_kind == 2 && native_event.input_kind == 12)) {
+					backend.windows[i].width = native_event.window_width
+					backend.windows[i].height = native_event.window_height
+					backend.windows[i].framebuffer_width = native_event.framebuffer_width
+					backend.windows[i].framebuffer_height = native_event.framebuffer_height
+				}
+				event := appkit_queued_event_from_native(record, native_event) or {
+					C.v_multiwindow_appkit_release_queued_event_resources(&native_event)
+					continue
+				}
+				C.v_multiwindow_appkit_release_queued_event_resources(&native_event)
+				native_events << AppKitNativeQueuedEvent{
+					sequence: native_event.sequence
+					event:    event
+				}
+			}
+			if destroyed {
 				C.v_multiwindow_appkit_release_window(record.state)
 				backend.windows.delete(i)
-				events << Event{
-					kind:      .window_destroyed
-					window_id: record.id
-				}
 				continue
-			}
-			mut width := 0
-			mut height := 0
-			mut framebuffer_width := 0
-			mut framebuffer_height := 0
-			if C.v_multiwindow_appkit_take_resized(record.state, &width, &height,
-				&framebuffer_width, &framebuffer_height) != 0 {
-				backend.windows[i].width = width
-				backend.windows[i].height = height
-				backend.windows[i].framebuffer_width = framebuffer_width
-				backend.windows[i].framebuffer_height = framebuffer_height
-				events << Event{
-					kind:      .window_resized
-					window_id: record.id
-					width:     width
-					height:    height
-				}
-			}
-			if C.v_multiwindow_appkit_take_close_requested(record.state) != 0 {
-				events << Event{
-					kind:      .window_close_requested
-					window_id: record.id
-				}
 			}
 			i++
 		}
 	}
+	appkit_sort_native_events(mut native_events)
+	mut events := []QueuedEvent{cap: native_events.len}
+	for native_event in native_events {
+		events << native_event.event
+	}
 	return events
+}
+
+fn appkit_sort_native_events(mut events []AppKitNativeQueuedEvent) {
+	for i in 1 .. events.len {
+		mut j := i
+		for j > 0 && events[j - 1].sequence > events[j].sequence {
+			event := events[j]
+			events[j] = events[j - 1]
+			events[j - 1] = event
+			j--
+		}
+	}
 }
 
 fn (mut backend AppKitBackend) stop() ! {

--- a/vlib/x/multiwindow/appkit_backend.m
+++ b/vlib/x/multiwindow/appkit_backend.m
@@ -1,30 +1,419 @@
 #include <Cocoa/Cocoa.h>
+#include <IOKit/hidsystem/IOLLEvent.h>
 #include <Metal/Metal.h>
 #include <QuartzCore/CAMetalLayer.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 #include "appkit_backend_helpers.h"
 
+#define V_MULTIWINDOW_CURSOR_SHAPE_DEFAULT 0
+#define V_MULTIWINDOW_CURSOR_SHAPE_POINTER 1
+#define V_MULTIWINDOW_CURSOR_SHAPE_MOVE 2
+#define V_MULTIWINDOW_CURSOR_SHAPE_N_RESIZE 3
+#define V_MULTIWINDOW_CURSOR_SHAPE_S_RESIZE 4
+#define V_MULTIWINDOW_CURSOR_SHAPE_E_RESIZE 5
+#define V_MULTIWINDOW_CURSOR_SHAPE_W_RESIZE 6
+#define V_MULTIWINDOW_CURSOR_SHAPE_NE_RESIZE 7
+#define V_MULTIWINDOW_CURSOR_SHAPE_NW_RESIZE 8
+#define V_MULTIWINDOW_CURSOR_SHAPE_SE_RESIZE 9
+#define V_MULTIWINDOW_CURSOR_SHAPE_SW_RESIZE 10
+#define V_MULTIWINDOW_CURSOR_SHAPE_EW_RESIZE 11
+#define V_MULTIWINDOW_CURSOR_SHAPE_NS_RESIZE 12
+#define V_MULTIWINDOW_CURSOR_SHAPE_NESW_RESIZE 13
+#define V_MULTIWINDOW_CURSOR_SHAPE_NWSE_RESIZE 14
+#define V_MULTIWINDOW_CURSOR_SHAPE_GRAB 15
+#define V_MULTIWINDOW_CURSOR_SHAPE_GRABBING 16
+
+@class VMultiwindowAppKitWindowState;
+
+@interface VMultiwindowAppKitView : NSView <NSDraggingDestination>
+@property(weak) VMultiwindowAppKitWindowState *state;
+@property(strong) NSTrackingArea *trackingArea;
+@end
+
 @interface VMultiwindowAppKitWindowState : NSObject <NSWindowDelegate>
+{
+	BOOL keyDown[512];
+}
 @property(strong) NSWindow *window;
-@property(strong) NSView *view;
+@property(strong) VMultiwindowAppKitView *view;
 @property(strong) CAMetalLayer *layer;
 @property(strong) id<MTLTexture> depthTexture;
 @property(strong) id<CAMetalDrawable> currentDrawable;
+@property(strong) NSMutableArray<NSValue *> *queuedEvents;
 @property(assign) BOOL highDpi;
-@property(assign) BOOL closeRequested;
-@property(assign) BOOL destroyed;
-@property(assign) BOOL resized;
+@property(assign) BOOL suppressResizeEvent;
+@property(assign) uint32_t flagsChangedStore;
+@property(assign) uint8_t mouseButtons;
+@property(assign) float mouseX;
+@property(assign) float mouseY;
+@property(assign) float mouseDx;
+@property(assign) float mouseDy;
+@property(assign) BOOL mousePosValid;
 @property(assign) int width;
 @property(assign) int height;
 @property(assign) int framebufferWidth;
 @property(assign) int framebufferHeight;
+@property(assign) int cursorShape;
 - (void)updateDimensions;
 - (BOOL)ensureDepthTextureWithDevice:(id<MTLDevice>)device;
+- (void)queueLifecycleEvent:(int)kind;
+- (void)queueResizeEvents;
+- (void)queueInputEvent:(VMultiwindowAppKitQueuedEvent)event;
+- (void)queueKeyEvent:(int)kind keyCode:(int)keyCode repeat:(BOOL)repeat modifiers:(uint32_t)modifiers;
+- (void)queueCharEventsFromString:(NSString *)characters repeat:(BOOL)repeat modifiers:(uint32_t)modifiers;
+- (void)queueTouchEvent:(int)kind changedPhase:(NSTouchPhase)phase event:(NSEvent *)event view:(NSView *)view;
+- (void)updateMousePositionFromEvent:(NSEvent *)event clearDelta:(BOOL)clearDelta;
+- (void)updateMousePositionFromWindowPoint:(NSPoint)point clearDelta:(BOOL)clearDelta;
+- (void)setKeyDown:(BOOL)down forKeyCode:(int)keyCode;
+- (void)clearKeyDownState;
+- (void)clearQueuedEvents;
+- (void)applyCursorShape;
 @end
 
+static uint64_t v_multiwindow_appkit_next_event_sequence(void) {
+	static uint64_t sequence = 1;
+	return sequence++;
+}
+
+static VMultiwindowAppKitQueuedEvent v_multiwindow_appkit_zero_event(void) {
+	VMultiwindowAppKitQueuedEvent event = {0};
+	event.mouse_button = V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_INVALID;
+	return event;
+}
+
+static NSCursor *v_multiwindow_appkit_cursor_for_shape(int shape) {
+	switch (shape) {
+	case V_MULTIWINDOW_CURSOR_SHAPE_POINTER:
+		return [NSCursor pointingHandCursor];
+	case V_MULTIWINDOW_CURSOR_SHAPE_MOVE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_GRAB:
+		return [NSCursor openHandCursor];
+	case V_MULTIWINDOW_CURSOR_SHAPE_GRABBING:
+		return [NSCursor closedHandCursor];
+	case V_MULTIWINDOW_CURSOR_SHAPE_N_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_S_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_NS_RESIZE:
+		return [NSCursor resizeUpDownCursor];
+	case V_MULTIWINDOW_CURSOR_SHAPE_E_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_W_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_EW_RESIZE:
+		return [NSCursor resizeLeftRightCursor];
+	case V_MULTIWINDOW_CURSOR_SHAPE_NE_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_SW_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_NESW_RESIZE:
+		return [NSCursor resizeUpDownCursor];
+	case V_MULTIWINDOW_CURSOR_SHAPE_NW_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_SE_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_NWSE_RESIZE:
+		return [NSCursor resizeLeftRightCursor];
+	default:
+		return [NSCursor arrowCursor];
+	}
+}
+
+static char *v_multiwindow_appkit_copy_cstring(const char *value) {
+	if (value == NULL) {
+		return NULL;
+	}
+	size_t len = strlen(value);
+	char *copy = (char *)calloc(len + 1, 1);
+	if (copy == NULL) {
+		return NULL;
+	}
+	memcpy(copy, value, len);
+	return copy;
+}
+
+void v_multiwindow_appkit_release_queued_event_resources(VMultiwindowAppKitQueuedEvent *event) {
+	if (event == NULL || event->dropped_files == NULL) {
+		return;
+	}
+	for (int i = 0; i < event->dropped_file_count; i++) {
+		free(event->dropped_files[i]);
+	}
+	free(event->dropped_files);
+	event->dropped_files = NULL;
+	event->dropped_file_count = 0;
+}
+
+static uint32_t v_multiwindow_appkit_modifiers(NSEvent *event) {
+	NSEventModifierFlags flags = event != nil ? event.modifierFlags : NSEvent.modifierFlags;
+	NSUInteger buttons = NSEvent.pressedMouseButtons;
+	uint32_t modifiers = 0;
+	if (flags & NSEventModifierFlagShift) {
+		modifiers |= 1;
+	}
+	if (flags & NSEventModifierFlagControl) {
+		modifiers |= 2;
+	}
+	if (flags & NSEventModifierFlagOption) {
+		modifiers |= 4;
+	}
+	if (flags & NSEventModifierFlagCommand) {
+		modifiers |= 8;
+	}
+	if (buttons & (1u << 0)) {
+		modifiers |= V_MULTIWINDOW_APPKIT_MODIFIER_LMB;
+	}
+	if (buttons & (1u << 1)) {
+		modifiers |= V_MULTIWINDOW_APPKIT_MODIFIER_RMB;
+	}
+	if (buttons & (1u << 2)) {
+		modifiers |= V_MULTIWINDOW_APPKIT_MODIFIER_MMB;
+	}
+	return modifiers;
+}
+
+static const int *v_multiwindow_appkit_keycodes(void) {
+	static int keycodes[128];
+	static int initialized = 0;
+	if (initialized) {
+		return keycodes;
+	}
+	initialized = 1;
+	keycodes[0x1D] = 48;
+	keycodes[0x12] = 49;
+	keycodes[0x13] = 50;
+	keycodes[0x14] = 51;
+	keycodes[0x15] = 52;
+	keycodes[0x17] = 53;
+	keycodes[0x16] = 54;
+	keycodes[0x1A] = 55;
+	keycodes[0x1C] = 56;
+	keycodes[0x19] = 57;
+	keycodes[0x00] = 65;
+	keycodes[0x0B] = 66;
+	keycodes[0x08] = 67;
+	keycodes[0x02] = 68;
+	keycodes[0x0E] = 69;
+	keycodes[0x03] = 70;
+	keycodes[0x05] = 71;
+	keycodes[0x04] = 72;
+	keycodes[0x22] = 73;
+	keycodes[0x26] = 74;
+	keycodes[0x28] = 75;
+	keycodes[0x25] = 76;
+	keycodes[0x2E] = 77;
+	keycodes[0x2D] = 78;
+	keycodes[0x1F] = 79;
+	keycodes[0x23] = 80;
+	keycodes[0x0C] = 81;
+	keycodes[0x0F] = 82;
+	keycodes[0x01] = 83;
+	keycodes[0x11] = 84;
+	keycodes[0x20] = 85;
+	keycodes[0x09] = 86;
+	keycodes[0x0D] = 87;
+	keycodes[0x07] = 88;
+	keycodes[0x10] = 89;
+	keycodes[0x06] = 90;
+	keycodes[0x27] = 39;
+	keycodes[0x2A] = 92;
+	keycodes[0x2B] = 44;
+	keycodes[0x18] = 61;
+	keycodes[0x32] = 96;
+	keycodes[0x21] = 91;
+	keycodes[0x1B] = 45;
+	keycodes[0x2F] = 46;
+	keycodes[0x1E] = 93;
+	keycodes[0x29] = 59;
+	keycodes[0x2C] = 47;
+	keycodes[0x0A] = 161;
+	keycodes[0x33] = 259;
+	keycodes[0x39] = 280;
+	keycodes[0x75] = 261;
+	keycodes[0x7D] = 264;
+	keycodes[0x77] = 269;
+	keycodes[0x24] = 257;
+	keycodes[0x35] = 256;
+	keycodes[0x7A] = 290;
+	keycodes[0x78] = 291;
+	keycodes[0x63] = 292;
+	keycodes[0x76] = 293;
+	keycodes[0x60] = 294;
+	keycodes[0x61] = 295;
+	keycodes[0x62] = 296;
+	keycodes[0x64] = 297;
+	keycodes[0x65] = 298;
+	keycodes[0x6D] = 299;
+	keycodes[0x67] = 300;
+	keycodes[0x6F] = 301;
+	keycodes[0x69] = 302;
+	keycodes[0x6B] = 303;
+	keycodes[0x71] = 304;
+	keycodes[0x6A] = 305;
+	keycodes[0x40] = 306;
+	keycodes[0x4F] = 307;
+	keycodes[0x50] = 308;
+	keycodes[0x5A] = 309;
+	keycodes[0x73] = 268;
+	keycodes[0x72] = 260;
+	keycodes[0x7B] = 263;
+	keycodes[0x3A] = 342;
+	keycodes[0x3B] = 341;
+	keycodes[0x38] = 340;
+	keycodes[0x37] = 343;
+	keycodes[0x6E] = 348;
+	keycodes[0x47] = 282;
+	keycodes[0x79] = 267;
+	keycodes[0x74] = 266;
+	keycodes[0x7C] = 262;
+	keycodes[0x3D] = 346;
+	keycodes[0x3E] = 345;
+	keycodes[0x3C] = 344;
+	keycodes[0x36] = 347;
+	keycodes[0x31] = 32;
+	keycodes[0x30] = 258;
+	keycodes[0x7E] = 265;
+	keycodes[0x52] = 320;
+	keycodes[0x53] = 321;
+	keycodes[0x54] = 322;
+	keycodes[0x55] = 323;
+	keycodes[0x56] = 324;
+	keycodes[0x57] = 325;
+	keycodes[0x58] = 326;
+	keycodes[0x59] = 327;
+	keycodes[0x5B] = 328;
+	keycodes[0x5C] = 329;
+	keycodes[0x45] = 334;
+	keycodes[0x41] = 330;
+	keycodes[0x4B] = 331;
+	keycodes[0x4C] = 335;
+	keycodes[0x51] = 336;
+	keycodes[0x43] = 332;
+	keycodes[0x4E] = 333;
+	return keycodes;
+}
+
+static int v_multiwindow_appkit_key_code(unsigned short native_key_code) {
+	const int *keycodes = v_multiwindow_appkit_keycodes();
+	if (native_key_code < 128) {
+		return keycodes[native_key_code];
+	}
+	return 0;
+}
+
+static NSEventModifierFlags v_multiwindow_appkit_modifier_flag_for_key_code(int key_code) {
+	switch (key_code) {
+	case 280:
+		return NSEventModifierFlagCapsLock;
+	case 340:
+	case 344:
+		return NSEventModifierFlagShift;
+	case 341:
+	case 345:
+		return NSEventModifierFlagControl;
+	case 342:
+	case 346:
+		return NSEventModifierFlagOption;
+	case 343:
+	case 347:
+		return NSEventModifierFlagCommand;
+	default:
+		return 0;
+	}
+}
+
+static BOOL v_multiwindow_appkit_modifier_key_is_pressed(NSEventModifierFlags flags, int key_code, BOOL *out_pressed) {
+	if (out_pressed == NULL) {
+		return NO;
+	}
+	switch (key_code) {
+	case 340:
+		*out_pressed = (flags & NX_DEVICELSHIFTKEYMASK) != 0;
+		return YES;
+	case 344:
+		*out_pressed = (flags & NX_DEVICERSHIFTKEYMASK) != 0;
+		return YES;
+	case 341:
+		*out_pressed = (flags & NX_DEVICELCTLKEYMASK) != 0;
+		return YES;
+	case 345:
+		*out_pressed = (flags & NX_DEVICERCTLKEYMASK) != 0;
+		return YES;
+	case 342:
+		*out_pressed = (flags & NX_DEVICELALTKEYMASK) != 0;
+		return YES;
+	case 346:
+		*out_pressed = (flags & NX_DEVICERALTKEYMASK) != 0;
+		return YES;
+	case 343:
+		*out_pressed = (flags & NX_DEVICELCMDKEYMASK) != 0;
+		return YES;
+	case 347:
+		*out_pressed = (flags & NX_DEVICERCMDKEYMASK) != 0;
+		return YES;
+	default:
+		break;
+	}
+	NSEventModifierFlags modifierFlag = v_multiwindow_appkit_modifier_flag_for_key_code(key_code);
+	if (modifierFlag == 0) {
+		return NO;
+	}
+	*out_pressed = (flags & modifierFlag) != 0;
+	return YES;
+}
+
+static BOOL v_multiwindow_appkit_touch_sets_share_identity(NSSet<NSTouch *> *touches, NSTouch *target) {
+	if (target == nil) {
+		return NO;
+	}
+	id targetIdentity = target.identity;
+	for (NSTouch *touch in touches) {
+		if (touch == target) {
+			return YES;
+		}
+		id identity = touch.identity;
+		if (identity != nil && targetIdentity != nil && identity == targetIdentity) {
+			return YES;
+		}
+		if (identity != nil && targetIdentity != nil && [identity isEqual:targetIdentity]) {
+			return YES;
+		}
+	}
+	return NO;
+}
+
+static float v_multiwindow_appkit_clamp_unit(CGFloat value) {
+	if (value < 0.0) {
+		return 0.0f;
+	}
+	if (value > 1.0) {
+		return 1.0f;
+	}
+	return (float)value;
+}
+
+static void v_multiwindow_appkit_fill_touch_point(VMultiwindowAppKitWindowState *state, VMultiwindowAppKitQueuedEvent *event, int index, NSTouch *touch, BOOL changed) {
+	if (state == nil || event == NULL || touch == nil || index < 0 || index >= V_MULTIWINDOW_APPKIT_MAX_TOUCH_POINTS) {
+		return;
+	}
+	id identity = touch.identity;
+	const void *identity_ptr = identity != nil ? (__bridge const void *)identity : (__bridge const void *)touch;
+	float width = state.framebufferWidth > 1 ? (float)(state.framebufferWidth - 1) : 0.0f;
+	float height = state.framebufferHeight > 1 ? (float)(state.framebufferHeight - 1) : 0.0f;
+	NSPoint normalized = touch.normalizedPosition;
+	float x = v_multiwindow_appkit_clamp_unit(normalized.x) * width;
+	float y = (1.0f - v_multiwindow_appkit_clamp_unit(normalized.y)) * height;
+	event->touch_ids[index] = (uint64_t)(uintptr_t)identity_ptr;
+	event->touch_x[index] = x;
+	event->touch_y[index] = y;
+	event->touch_changed[index] = changed ? 1 : 0;
+}
+
 @implementation VMultiwindowAppKitWindowState
+- (instancetype)init {
+	self = [super init];
+	if (self != nil) {
+		self.queuedEvents = [NSMutableArray array];
+	}
+	return self;
+}
+
 - (void)updateDimensions {
 	NSView *content = self.window.contentView != nil ? self.window.contentView : self.view;
 	NSRect bounds = content != nil ? content.bounds : NSMakeRect(0, 0, 1, 1);
@@ -82,40 +471,585 @@
 	return self.depthTexture != nil;
 }
 
+- (void)fillDimensionsForEvent:(VMultiwindowAppKitQueuedEvent *)event {
+	if (event == NULL) {
+		return;
+	}
+	event->window_width = self.width;
+	event->window_height = self.height;
+	event->framebuffer_width = self.framebufferWidth;
+	event->framebuffer_height = self.framebufferHeight;
+}
+
+- (void)queueEvent:(VMultiwindowAppKitQueuedEvent)event {
+	if (self.queuedEvents == nil) {
+		self.queuedEvents = [NSMutableArray array];
+	}
+	event.sequence = v_multiwindow_appkit_next_event_sequence();
+	VMultiwindowAppKitQueuedEvent *queued = calloc(1, sizeof(VMultiwindowAppKitQueuedEvent));
+	if (queued == NULL) {
+		v_multiwindow_appkit_release_queued_event_resources(&event);
+		return;
+	}
+	*queued = event;
+	[self.queuedEvents addObject:[NSValue valueWithPointer:queued]];
+}
+
+- (void)queueLifecycleEvent:(int)kind {
+	VMultiwindowAppKitQueuedEvent event = v_multiwindow_appkit_zero_event();
+	event.event_kind = V_MULTIWINDOW_APPKIT_EVENT_LIFECYCLE;
+	event.lifecycle_kind = kind;
+	[self fillDimensionsForEvent:&event];
+	[self queueEvent:event];
+}
+
+- (void)queueResizeEvents {
+	[self queueLifecycleEvent:V_MULTIWINDOW_APPKIT_LIFECYCLE_RESIZED];
+	VMultiwindowAppKitQueuedEvent event = v_multiwindow_appkit_zero_event();
+	event.event_kind = V_MULTIWINDOW_APPKIT_EVENT_INPUT;
+	event.input_kind = V_MULTIWINDOW_APPKIT_INPUT_RESIZED;
+	[self fillDimensionsForEvent:&event];
+	[self queueEvent:event];
+}
+
+- (void)queueInputEvent:(VMultiwindowAppKitQueuedEvent)event {
+	event.event_kind = V_MULTIWINDOW_APPKIT_EVENT_INPUT;
+	[self fillDimensionsForEvent:&event];
+	[self queueEvent:event];
+}
+
+- (void)queueKeyEvent:(int)kind keyCode:(int)keyCode repeat:(BOOL)repeat modifiers:(uint32_t)modifiers {
+	if (keyCode == 0) {
+		return;
+	}
+	if (keyCode >= 0 && keyCode < 512) {
+		keyDown[keyCode] = kind == V_MULTIWINDOW_APPKIT_INPUT_KEY_DOWN;
+	}
+	VMultiwindowAppKitQueuedEvent event = v_multiwindow_appkit_zero_event();
+	event.input_kind = kind;
+	event.key_code = keyCode;
+	event.key_repeat = repeat ? 1 : 0;
+	event.modifiers = modifiers;
+	[self queueInputEvent:event];
+}
+
+- (void)queueCharEventsFromString:(NSString *)characters repeat:(BOOL)repeat modifiers:(uint32_t)modifiers {
+	NSUInteger length = characters.length;
+	for (NSUInteger i = 0; i < length; i++) {
+		unichar unit = [characters characterAtIndex:i];
+		uint32_t codepoint = unit;
+		if (unit >= 0xD800 && unit <= 0xDBFF) {
+			if ((i + 1) >= length) {
+				continue;
+			}
+			unichar low = [characters characterAtIndex:i + 1];
+			if (low < 0xDC00 || low > 0xDFFF) {
+				continue;
+			}
+			codepoint = 0x10000u + (((uint32_t)unit - 0xD800u) << 10) + ((uint32_t)low - 0xDC00u);
+			i++;
+		} else if (unit >= 0xDC00 && unit <= 0xDFFF) {
+			continue;
+		}
+		if ((codepoint & 0xFF00u) == 0xF700u) {
+			continue;
+		}
+		VMultiwindowAppKitQueuedEvent event = v_multiwindow_appkit_zero_event();
+		event.input_kind = V_MULTIWINDOW_APPKIT_INPUT_CHAR;
+		event.char_code = codepoint;
+		event.key_repeat = repeat ? 1 : 0;
+		event.modifiers = modifiers;
+		[self queueInputEvent:event];
+	}
+}
+
+- (void)queueTouchEvent:(int)kind changedPhase:(NSTouchPhase)phase event:(NSEvent *)event view:(NSView *)view {
+	if (event == nil || view == nil) {
+		return;
+	}
+	NSSet<NSTouch *> *changedTouches = [event touchesMatchingPhase:phase inView:view];
+	NSSet<NSTouch *> *allTouches = [event touchesMatchingPhase:NSTouchPhaseAny inView:view];
+	if (allTouches.count == 0) {
+		allTouches = changedTouches;
+	}
+	if (allTouches.count == 0) {
+		return;
+	}
+	VMultiwindowAppKitQueuedEvent queued = v_multiwindow_appkit_zero_event();
+	queued.input_kind = kind;
+	queued.modifiers = v_multiwindow_appkit_modifiers(event);
+	int index = 0;
+	for (NSTouch *touch in allTouches) {
+		if (index >= V_MULTIWINDOW_APPKIT_MAX_TOUCH_POINTS) {
+			break;
+		}
+		BOOL changed = v_multiwindow_appkit_touch_sets_share_identity(changedTouches, touch);
+		v_multiwindow_appkit_fill_touch_point(self, &queued, index, touch, changed);
+		index++;
+	}
+	if (index == 0) {
+		return;
+	}
+	queued.touch_count = index;
+	queued.mouse_x = queued.touch_x[0];
+	queued.mouse_y = queued.touch_y[0];
+	[self queueInputEvent:queued];
+}
+
+- (void)updateMousePositionFromEvent:(NSEvent *)event clearDelta:(BOOL)clearDelta {
+	NSPoint point = event.locationInWindow;
+	[self updateMousePositionFromWindowPoint:point clearDelta:clearDelta];
+}
+
+- (void)updateMousePositionFromWindowPoint:(NSPoint)point clearDelta:(BOOL)clearDelta {
+	NSView *content = self.window.contentView != nil ? self.window.contentView : self.view;
+	if (content != nil) {
+		point = [content convertPoint:point fromView:nil];
+	}
+	NSRect bounds = content != nil ? content.bounds : NSMakeRect(0, 0, self.width, self.height);
+	CGFloat logicalWidth = NSWidth(bounds) > 0 ? NSWidth(bounds) : (CGFloat)self.width;
+	CGFloat logicalHeight = NSHeight(bounds) > 0 ? NSHeight(bounds) : (CGFloat)self.height;
+	CGFloat scaleX = logicalWidth > 0 ? ((CGFloat)self.framebufferWidth / logicalWidth) : 1.0;
+	CGFloat scaleY = logicalHeight > 0 ? ((CGFloat)self.framebufferHeight / logicalHeight) : 1.0;
+	float newX = (float)(point.x * scaleX);
+	float newY = (float)((CGFloat)self.framebufferHeight - (point.y * scaleY) - 1.0);
+	if (clearDelta || !self.mousePosValid) {
+		self.mouseDx = 0.0f;
+		self.mouseDy = 0.0f;
+	} else {
+		self.mouseDx = newX - self.mouseX;
+		self.mouseDy = newY - self.mouseY;
+	}
+	self.mouseX = newX;
+	self.mouseY = newY;
+	self.mousePosValid = YES;
+}
+
+- (void)setKeyDown:(BOOL)down forKeyCode:(int)keyCode {
+	if (keyCode < 0 || keyCode >= 512) {
+		return;
+	}
+	keyDown[keyCode] = down;
+}
+
+- (void)clearKeyDownState {
+	for (NSUInteger i = 0; i < sizeof(keyDown) / sizeof(keyDown[0]); i++) {
+		keyDown[i] = NO;
+	}
+}
+
+- (void)clearQueuedEvents {
+	for (NSValue *value in self.queuedEvents) {
+		VMultiwindowAppKitQueuedEvent *event = (VMultiwindowAppKitQueuedEvent *)value.pointerValue;
+		v_multiwindow_appkit_release_queued_event_resources(event);
+		free(event);
+	}
+	[self.queuedEvents removeAllObjects];
+}
+
+- (void)applyCursorShape {
+	[v_multiwindow_appkit_cursor_for_shape(self.cursorShape) set];
+}
+
 - (BOOL)windowShouldClose:(id)sender {
 	(void)sender;
-	self.closeRequested = YES;
+	[self queueLifecycleEvent:V_MULTIWINDOW_APPKIT_LIFECYCLE_CLOSE_REQUESTED];
 	return NO;
 }
 
 - (void)windowWillClose:(NSNotification *)notification {
 	(void)notification;
-	self.destroyed = YES;
+	self.currentDrawable = nil;
+	self.depthTexture = nil;
+	[self queueLifecycleEvent:V_MULTIWINDOW_APPKIT_LIFECYCLE_DESTROYED];
 }
 
 - (void)windowDidResize:(NSNotification *)notification {
 	(void)notification;
 	int old_width = self.width;
 	int old_height = self.height;
+	int old_framebuffer_width = self.framebufferWidth;
+	int old_framebuffer_height = self.framebufferHeight;
 	[self updateDimensions];
 	self.depthTexture = nil;
-	if (self.width != old_width || self.height != old_height) {
-		self.resized = YES;
+	if (self.width != old_width || self.height != old_height ||
+	    self.framebufferWidth != old_framebuffer_width ||
+	    self.framebufferHeight != old_framebuffer_height) {
+		if (!self.suppressResizeEvent) {
+			[self queueResizeEvents];
+		}
 	}
 }
 
 - (void)windowDidChangeBackingProperties:(NSNotification *)notification {
 	(void)notification;
+	int old_width = self.width;
+	int old_height = self.height;
+	int old_framebuffer_width = self.framebufferWidth;
+	int old_framebuffer_height = self.framebufferHeight;
 	[self updateDimensions];
 	self.depthTexture = nil;
-	self.resized = YES;
+	if (self.width != old_width || self.height != old_height ||
+	    self.framebufferWidth != old_framebuffer_width ||
+	    self.framebufferHeight != old_framebuffer_height) {
+		if (!self.suppressResizeEvent) {
+			[self queueResizeEvents];
+		}
+	}
 }
 
 - (void)windowDidChangeScreen:(NSNotification *)notification {
 	(void)notification;
+	int old_width = self.width;
+	int old_height = self.height;
+	int old_framebuffer_width = self.framebufferWidth;
+	int old_framebuffer_height = self.framebufferHeight;
 	[self updateDimensions];
 	self.depthTexture = nil;
-	self.resized = YES;
+	if (self.width != old_width || self.height != old_height ||
+	    self.framebufferWidth != old_framebuffer_width ||
+	    self.framebufferHeight != old_framebuffer_height) {
+		if (!self.suppressResizeEvent) {
+			[self queueResizeEvents];
+		}
+	}
+}
+
+- (void)windowDidBecomeKey:(NSNotification *)notification {
+	(void)notification;
+	[self clearKeyDownState];
+	self.flagsChangedStore = (uint32_t)NSEvent.modifierFlags;
+	VMultiwindowAppKitQueuedEvent event = v_multiwindow_appkit_zero_event();
+	event.input_kind = V_MULTIWINDOW_APPKIT_INPUT_FOCUSED;
+	event.modifiers = v_multiwindow_appkit_modifiers(nil);
+	[self queueInputEvent:event];
+}
+
+- (void)windowDidResignKey:(NSNotification *)notification {
+	(void)notification;
+	[self clearKeyDownState];
+	self.flagsChangedStore = (uint32_t)NSEvent.modifierFlags;
+	VMultiwindowAppKitQueuedEvent event = v_multiwindow_appkit_zero_event();
+	event.input_kind = V_MULTIWINDOW_APPKIT_INPUT_UNFOCUSED;
+	event.modifiers = v_multiwindow_appkit_modifiers(nil);
+	[self queueInputEvent:event];
+}
+
+- (void)windowDidMiniaturize:(NSNotification *)notification {
+	(void)notification;
+	VMultiwindowAppKitQueuedEvent event = v_multiwindow_appkit_zero_event();
+	event.input_kind = V_MULTIWINDOW_APPKIT_INPUT_ICONIFIED;
+	event.modifiers = v_multiwindow_appkit_modifiers(nil);
+	[self queueInputEvent:event];
+}
+
+- (void)windowDidDeminiaturize:(NSNotification *)notification {
+	(void)notification;
+	VMultiwindowAppKitQueuedEvent event = v_multiwindow_appkit_zero_event();
+	event.input_kind = V_MULTIWINDOW_APPKIT_INPUT_RESTORED;
+	event.modifiers = v_multiwindow_appkit_modifiers(nil);
+	[self queueInputEvent:event];
+}
+@end
+
+@implementation VMultiwindowAppKitView
+- (BOOL)acceptsFirstResponder {
+	return YES;
+}
+
+- (BOOL)canBecomeKeyView {
+	return YES;
+}
+
+- (BOOL)acceptsFirstMouse:(NSEvent *)event {
+	(void)event;
+	return YES;
+}
+
+- (void)updateTrackingAreas {
+	if (self.trackingArea != nil) {
+		[self removeTrackingArea:self.trackingArea];
+		self.trackingArea = nil;
+	}
+	NSTrackingAreaOptions options = NSTrackingMouseEnteredAndExited |
+		NSTrackingActiveInKeyWindow |
+		NSTrackingEnabledDuringMouseDrag |
+		NSTrackingCursorUpdate |
+		NSTrackingInVisibleRect |
+		NSTrackingAssumeInside;
+	self.trackingArea = [[NSTrackingArea alloc] initWithRect:self.bounds
+	                                                 options:options
+	                                                   owner:self
+	                                                userInfo:nil];
+	[self addTrackingArea:self.trackingArea];
+	[super updateTrackingAreas];
+}
+
+- (void)cursorUpdate:(NSEvent *)event {
+	(void)event;
+	VMultiwindowAppKitWindowState *state = self.state;
+	if (state != nil) {
+		[state applyCursorShape];
+	}
+}
+
+- (void)queueMouseEvent:(NSEvent *)event kind:(int)kind button:(int)button clearDelta:(BOOL)clearDelta {
+	VMultiwindowAppKitWindowState *state = self.state;
+	if (state == nil) {
+		return;
+	}
+	[state updateMousePositionFromEvent:event clearDelta:clearDelta];
+	VMultiwindowAppKitQueuedEvent queued = v_multiwindow_appkit_zero_event();
+	queued.input_kind = kind;
+	queued.modifiers = v_multiwindow_appkit_modifiers(event);
+	queued.mouse_button = button;
+	queued.mouse_x = state.mouseX;
+	queued.mouse_y = state.mouseY;
+	queued.mouse_dx = state.mouseDx;
+	queued.mouse_dy = state.mouseDy;
+	[state queueInputEvent:queued];
+}
+
+- (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender {
+	NSPasteboard *pasteboard = sender.draggingPasteboard;
+	if ([pasteboard canReadObjectForClasses:@[ NSURL.class ]
+	                                options:@{ NSPasteboardURLReadingFileURLsOnlyKey: @YES }]) {
+		return NSDragOperationCopy;
+	}
+	return NSDragOperationNone;
+}
+
+- (NSDragOperation)draggingUpdated:(id<NSDraggingInfo>)sender {
+	return [self draggingEntered:sender];
+}
+
+- (BOOL)performDragOperation:(id<NSDraggingInfo>)sender {
+	VMultiwindowAppKitWindowState *state = self.state;
+	if (state == nil) {
+		return NO;
+	}
+	NSPasteboard *pasteboard = sender.draggingPasteboard;
+	NSArray<NSURL *> *urls = [pasteboard readObjectsForClasses:@[ NSURL.class ]
+	                                                   options:@{ NSPasteboardURLReadingFileURLsOnlyKey: @YES }];
+	if (urls.count == 0) {
+		return NO;
+	}
+	[state updateMousePositionFromWindowPoint:sender.draggingLocation clearDelta:YES];
+	VMultiwindowAppKitQueuedEvent queued = v_multiwindow_appkit_zero_event();
+	queued.input_kind = V_MULTIWINDOW_APPKIT_INPUT_FILES_DROPPED;
+	queued.modifiers = v_multiwindow_appkit_modifiers(nil);
+	queued.mouse_x = state.mouseX;
+	queued.mouse_y = state.mouseY;
+	queued.dropped_files = (char **)calloc(urls.count, sizeof(char *));
+	if (queued.dropped_files == NULL) {
+		return NO;
+	}
+	for (NSURL *url in urls) {
+		if (!url.fileURL) {
+			continue;
+		}
+		const char *path = url.standardizedURL.path.UTF8String;
+		char *copy = v_multiwindow_appkit_copy_cstring(path);
+		if (copy == NULL) {
+			continue;
+		}
+		queued.dropped_files[queued.dropped_file_count] = copy;
+		queued.dropped_file_count++;
+	}
+	if (queued.dropped_file_count == 0) {
+		v_multiwindow_appkit_release_queued_event_resources(&queued);
+		return NO;
+	}
+	[state queueInputEvent:queued];
+	return YES;
+}
+
+- (void)mouseEntered:(NSEvent *)event {
+	if (self.state.mouseButtons == 0) {
+		[self queueMouseEvent:event kind:V_MULTIWINDOW_APPKIT_INPUT_MOUSE_ENTER button:V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_INVALID clearDelta:YES];
+	}
+}
+
+- (void)mouseExited:(NSEvent *)event {
+	if (self.state.mouseButtons == 0) {
+		[self queueMouseEvent:event kind:V_MULTIWINDOW_APPKIT_INPUT_MOUSE_LEAVE button:V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_INVALID clearDelta:YES];
+	}
+}
+
+- (void)mouseDown:(NSEvent *)event {
+	[self.window makeFirstResponder:self];
+	[self queueMouseEvent:event kind:V_MULTIWINDOW_APPKIT_INPUT_MOUSE_DOWN button:V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_LEFT clearDelta:NO];
+	self.state.mouseButtons |= (1u << V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_LEFT);
+}
+
+- (void)mouseUp:(NSEvent *)event {
+	[self queueMouseEvent:event kind:V_MULTIWINDOW_APPKIT_INPUT_MOUSE_UP button:V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_LEFT clearDelta:NO];
+	self.state.mouseButtons &= ~(1u << V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_LEFT);
+}
+
+- (void)rightMouseDown:(NSEvent *)event {
+	[self.window makeFirstResponder:self];
+	[self queueMouseEvent:event kind:V_MULTIWINDOW_APPKIT_INPUT_MOUSE_DOWN button:V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_RIGHT clearDelta:NO];
+	self.state.mouseButtons |= (1u << V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_RIGHT);
+}
+
+- (void)rightMouseUp:(NSEvent *)event {
+	[self queueMouseEvent:event kind:V_MULTIWINDOW_APPKIT_INPUT_MOUSE_UP button:V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_RIGHT clearDelta:NO];
+	self.state.mouseButtons &= ~(1u << V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_RIGHT);
+}
+
+- (void)otherMouseDown:(NSEvent *)event {
+	if (event.buttonNumber == 2) {
+		[self.window makeFirstResponder:self];
+		[self queueMouseEvent:event kind:V_MULTIWINDOW_APPKIT_INPUT_MOUSE_DOWN button:V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_MIDDLE clearDelta:NO];
+		self.state.mouseButtons |= (1u << V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_MIDDLE);
+	}
+}
+
+- (void)otherMouseUp:(NSEvent *)event {
+	if (event.buttonNumber == 2) {
+		[self queueMouseEvent:event kind:V_MULTIWINDOW_APPKIT_INPUT_MOUSE_UP button:V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_MIDDLE clearDelta:NO];
+		self.state.mouseButtons &= ~(1u << V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_MIDDLE);
+	}
+}
+
+- (void)mouseMoved:(NSEvent *)event {
+	[self queueMouseEvent:event kind:V_MULTIWINDOW_APPKIT_INPUT_MOUSE_MOVE button:V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_INVALID clearDelta:NO];
+}
+
+- (void)mouseDragged:(NSEvent *)event {
+	[self queueMouseEvent:event kind:V_MULTIWINDOW_APPKIT_INPUT_MOUSE_MOVE button:V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_INVALID clearDelta:NO];
+}
+
+- (void)rightMouseDragged:(NSEvent *)event {
+	[self queueMouseEvent:event kind:V_MULTIWINDOW_APPKIT_INPUT_MOUSE_MOVE button:V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_INVALID clearDelta:NO];
+}
+
+- (void)otherMouseDragged:(NSEvent *)event {
+	if (event.buttonNumber == 2) {
+		[self queueMouseEvent:event kind:V_MULTIWINDOW_APPKIT_INPUT_MOUSE_MOVE button:V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_INVALID clearDelta:NO];
+	}
+}
+
+- (void)scrollWheel:(NSEvent *)event {
+	VMultiwindowAppKitWindowState *state = self.state;
+	if (state == nil) {
+		return;
+	}
+	[state updateMousePositionFromEvent:event clearDelta:YES];
+	float dx = (float)event.scrollingDeltaX;
+	float dy = (float)event.scrollingDeltaY;
+	if (event.hasPreciseScrollingDeltas) {
+		dx *= 0.1f;
+		dy *= 0.1f;
+	}
+	if (dx == 0.0f && dy == 0.0f) {
+		return;
+	}
+	VMultiwindowAppKitQueuedEvent queued = v_multiwindow_appkit_zero_event();
+	queued.input_kind = V_MULTIWINDOW_APPKIT_INPUT_MOUSE_SCROLL;
+	queued.modifiers = v_multiwindow_appkit_modifiers(event);
+	queued.mouse_x = state.mouseX;
+	queued.mouse_y = state.mouseY;
+	queued.scroll_x = dx;
+	queued.scroll_y = dy;
+	[state queueInputEvent:queued];
+}
+
+- (void)touchesBeganWithEvent:(NSEvent *)event {
+	[self.state queueTouchEvent:V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_BEGAN
+	               changedPhase:NSTouchPhaseBegan
+	                      event:event
+	                       view:self];
+}
+
+- (void)touchesMovedWithEvent:(NSEvent *)event {
+	[self.state queueTouchEvent:V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_MOVED
+	               changedPhase:NSTouchPhaseMoved
+	                      event:event
+	                       view:self];
+}
+
+- (void)touchesEndedWithEvent:(NSEvent *)event {
+	[self.state queueTouchEvent:V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_ENDED
+	               changedPhase:NSTouchPhaseEnded
+	                      event:event
+	                       view:self];
+}
+
+- (void)touchesCancelledWithEvent:(NSEvent *)event {
+	[self.state queueTouchEvent:V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_CANCELLED
+	               changedPhase:NSTouchPhaseCancelled
+	                      event:event
+	                       view:self];
+}
+
+- (void)keyDown:(NSEvent *)event {
+	VMultiwindowAppKitWindowState *state = self.state;
+	if (state == nil) {
+		return;
+	}
+	uint32_t modifiers = v_multiwindow_appkit_modifiers(event);
+	int keyCode = v_multiwindow_appkit_key_code(event.keyCode);
+	[state queueKeyEvent:V_MULTIWINDOW_APPKIT_INPUT_KEY_DOWN keyCode:keyCode repeat:event.isARepeat modifiers:modifiers];
+	if ((modifiers & 8u) == 0) {
+		[state queueCharEventsFromString:event.characters repeat:event.isARepeat modifiers:modifiers];
+	}
+	if (modifiers == 8 && keyCode == 86) {
+		VMultiwindowAppKitQueuedEvent queued = v_multiwindow_appkit_zero_event();
+		queued.input_kind = V_MULTIWINDOW_APPKIT_INPUT_CLIPBOARD_PASTED;
+		queued.modifiers = modifiers;
+		[state queueInputEvent:queued];
+	}
+}
+
+- (BOOL)performKeyEquivalent:(NSEvent *)event {
+	if (v_multiwindow_appkit_key_code(event.keyCode) == 86 &&
+	    v_multiwindow_appkit_modifiers(event) == 8) {
+		[self keyDown:event];
+		return YES;
+	}
+	if (v_multiwindow_appkit_key_code(event.keyCode) == 258) {
+		[self keyDown:event];
+		return YES;
+	}
+	return NO;
+}
+
+- (void)keyUp:(NSEvent *)event {
+	VMultiwindowAppKitWindowState *state = self.state;
+	if (state == nil) {
+		return;
+	}
+	int keyCode = v_multiwindow_appkit_key_code(event.keyCode);
+	[state queueKeyEvent:V_MULTIWINDOW_APPKIT_INPUT_KEY_UP keyCode:keyCode repeat:event.isARepeat modifiers:v_multiwindow_appkit_modifiers(event)];
+}
+
+- (void)flagsChanged:(NSEvent *)event {
+	VMultiwindowAppKitWindowState *state = self.state;
+	if (state == nil) {
+		return;
+	}
+	uint32_t oldFlags = state.flagsChangedStore;
+	uint32_t newFlags = (uint32_t)event.modifierFlags;
+	state.flagsChangedStore = newFlags;
+	int keyCode = v_multiwindow_appkit_key_code(event.keyCode);
+	BOOL wasPressed = NO;
+	BOOL isPressed = NO;
+	if (keyCode == 0 ||
+	    !v_multiwindow_appkit_modifier_key_is_pressed((NSEventModifierFlags)oldFlags, keyCode, &wasPressed) ||
+	    !v_multiwindow_appkit_modifier_key_is_pressed((NSEventModifierFlags)newFlags, keyCode, &isPressed)) {
+		return;
+	}
+
+	if (wasPressed == isPressed) {
+		[state setKeyDown:isPressed forKeyCode:keyCode];
+		return;
+	}
+	[state queueKeyEvent:isPressed ? V_MULTIWINDOW_APPKIT_INPUT_KEY_DOWN : V_MULTIWINDOW_APPKIT_INPUT_KEY_UP
+	             keyCode:keyCode
+	              repeat:NO
+	           modifiers:v_multiwindow_appkit_modifiers(event)];
 }
 @end
 
@@ -197,14 +1131,18 @@ int v_multiwindow_appkit_create_window(void *device_ptr, const char *title, int 
 			[window setMinSize:NSMakeSize((CGFloat)(min_width > 0 ? min_width : 1),
 			                              (CGFloat)(min_height > 0 ? min_height : 1))];
 		}
-		NSView *view = [[NSView alloc] initWithFrame:rect];
+		VMultiwindowAppKitView *view = [[VMultiwindowAppKitView alloc] initWithFrame:rect];
 		if (view == nil) {
 			return 0;
 		}
+		view.acceptsTouchEvents = YES;
 		VMultiwindowAppKitWindowState *state = [[VMultiwindowAppKitWindowState alloc] init];
 		state.window = window;
 		state.view = view;
+		view.state = state;
+		[view registerForDraggedTypes:@[ NSPasteboardTypeFileURL ]];
 		state.highDpi = high_dpi ? YES : NO;
+		state.flagsChangedStore = (uint32_t)NSEvent.modifierFlags;
 		if (device_ptr != NULL) {
 			id<MTLDevice> device = (__bridge id<MTLDevice>)device_ptr;
 			CAMetalLayer *layer = [CAMetalLayer layer];
@@ -221,11 +1159,9 @@ int v_multiwindow_appkit_create_window(void *device_ptr, const char *title, int 
 		}
 		window.contentView = view;
 		window.delegate = state;
+		[window makeFirstResponder:view];
 		[window center];
 		[state updateDimensions];
-		state.resized = NO;
-		state.closeRequested = NO;
-		state.destroyed = NO;
 		if (visible) {
 			[window makeKeyAndOrderFront:nil];
 			[NSApp activateIgnoringOtherApps:YES];
@@ -260,20 +1196,23 @@ void v_multiwindow_appkit_destroy_window(void *state_ptr) {
 		VMultiwindowAppKitWindowState *state = (__bridge VMultiwindowAppKitWindowState *)state_ptr;
 		state.currentDrawable = nil;
 		state.depthTexture = nil;
+		[state clearQueuedEvents];
 		if (state.window != nil) {
 			state.window.delegate = nil;
 			[state.window orderOut:nil];
 			[state.window close];
 		}
+		state.view.state = nil;
 		state.window = nil;
 		state.view = nil;
 		state.layer = nil;
-		state.destroyed = YES;
 	}
 }
 
 void v_multiwindow_appkit_release_window(void *state_ptr) {
 	if (state_ptr != NULL) {
+		VMultiwindowAppKitWindowState *state = (__bridge VMultiwindowAppKitWindowState *)state_ptr;
+		[state clearQueuedEvents];
 		CFBridgingRelease(state_ptr);
 	}
 }
@@ -292,6 +1231,23 @@ int v_multiwindow_appkit_set_window_title(void *state_ptr, const char *title) {
 	}
 }
 
+int v_multiwindow_appkit_set_cursor_shape(void *state_ptr, int shape) {
+	@autoreleasepool {
+		if (state_ptr == NULL || ![NSThread isMainThread] ||
+		    shape < V_MULTIWINDOW_CURSOR_SHAPE_DEFAULT ||
+		    shape > V_MULTIWINDOW_CURSOR_SHAPE_GRABBING) {
+			return 0;
+		}
+		VMultiwindowAppKitWindowState *state = (__bridge VMultiwindowAppKitWindowState *)state_ptr;
+		if (state.window == nil) {
+			return 0;
+		}
+		state.cursorShape = shape;
+		[state applyCursorShape];
+		return 1;
+	}
+}
+
 int v_multiwindow_appkit_resize_window(void *state_ptr, int width, int height, int *out_width, int *out_height, int *out_framebuffer_width, int *out_framebuffer_height) {
 	@autoreleasepool {
 		if (state_ptr == NULL || ![NSThread isMainThread] || width <= 0 || height <= 0) {
@@ -301,10 +1257,11 @@ int v_multiwindow_appkit_resize_window(void *state_ptr, int width, int height, i
 		if (state.window == nil) {
 			return 0;
 		}
+		state.suppressResizeEvent = YES;
 		[state.window setContentSize:NSMakeSize((CGFloat)width, (CGFloat)height)];
 		[state updateDimensions];
+		state.suppressResizeEvent = NO;
 		state.depthTexture = nil;
-		state.resized = NO;
 		if (out_width != NULL) {
 			*out_width = state.width;
 		}
@@ -340,51 +1297,22 @@ void v_multiwindow_appkit_poll_events(void) {
 	}
 }
 
-int v_multiwindow_appkit_take_close_requested(void *state_ptr) {
-	if (state_ptr == NULL || ![NSThread isMainThread]) {
+int v_multiwindow_appkit_take_queued_event(void *state_ptr, VMultiwindowAppKitQueuedEvent *out_event) {
+	if (state_ptr == NULL || out_event == NULL || ![NSThread isMainThread]) {
 		return 0;
 	}
 	VMultiwindowAppKitWindowState *state = (__bridge VMultiwindowAppKitWindowState *)state_ptr;
-	if (!state.closeRequested) {
+	if (state.queuedEvents.count == 0) {
 		return 0;
 	}
-	state.closeRequested = NO;
-	return 1;
-}
-
-int v_multiwindow_appkit_take_resized(void *state_ptr, int *out_width, int *out_height, int *out_framebuffer_width, int *out_framebuffer_height) {
-	if (state_ptr == NULL || ![NSThread isMainThread]) {
+	NSValue *value = state.queuedEvents[0];
+	VMultiwindowAppKitQueuedEvent *event = (VMultiwindowAppKitQueuedEvent *)value.pointerValue;
+	[state.queuedEvents removeObjectAtIndex:0];
+	if (event == NULL) {
 		return 0;
 	}
-	VMultiwindowAppKitWindowState *state = (__bridge VMultiwindowAppKitWindowState *)state_ptr;
-	if (!state.resized) {
-		return 0;
-	}
-	state.resized = NO;
-	if (out_width != NULL) {
-		*out_width = state.width;
-	}
-	if (out_height != NULL) {
-		*out_height = state.height;
-	}
-	if (out_framebuffer_width != NULL) {
-		*out_framebuffer_width = state.framebufferWidth;
-	}
-	if (out_framebuffer_height != NULL) {
-		*out_framebuffer_height = state.framebufferHeight;
-	}
-	return 1;
-}
-
-int v_multiwindow_appkit_take_destroyed(void *state_ptr) {
-	if (state_ptr == NULL || ![NSThread isMainThread]) {
-		return 0;
-	}
-	VMultiwindowAppKitWindowState *state = (__bridge VMultiwindowAppKitWindowState *)state_ptr;
-	if (!state.destroyed) {
-		return 0;
-	}
-	state.destroyed = NO;
+	*out_event = *event;
+	free(event);
 	return 1;
 }
 

--- a/vlib/x/multiwindow/appkit_backend_helpers.h
+++ b/vlib/x/multiwindow/appkit_backend_helpers.h
@@ -1,9 +1,78 @@
 #ifndef V_MULTIWINDOW_APPKIT_BACKEND_HELPERS_H
 #define V_MULTIWINDOW_APPKIT_BACKEND_HELPERS_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define V_MULTIWINDOW_APPKIT_EVENT_LIFECYCLE 1
+#define V_MULTIWINDOW_APPKIT_EVENT_INPUT 2
+
+#define V_MULTIWINDOW_APPKIT_LIFECYCLE_CLOSE_REQUESTED 1
+#define V_MULTIWINDOW_APPKIT_LIFECYCLE_DESTROYED 2
+#define V_MULTIWINDOW_APPKIT_LIFECYCLE_RESIZED 3
+
+#define V_MULTIWINDOW_APPKIT_INPUT_KEY_DOWN 1
+#define V_MULTIWINDOW_APPKIT_INPUT_KEY_UP 2
+#define V_MULTIWINDOW_APPKIT_INPUT_CHAR 3
+#define V_MULTIWINDOW_APPKIT_INPUT_MOUSE_DOWN 4
+#define V_MULTIWINDOW_APPKIT_INPUT_MOUSE_UP 5
+#define V_MULTIWINDOW_APPKIT_INPUT_MOUSE_SCROLL 6
+#define V_MULTIWINDOW_APPKIT_INPUT_MOUSE_MOVE 7
+#define V_MULTIWINDOW_APPKIT_INPUT_MOUSE_ENTER 8
+#define V_MULTIWINDOW_APPKIT_INPUT_MOUSE_LEAVE 9
+#define V_MULTIWINDOW_APPKIT_INPUT_FOCUSED 10
+#define V_MULTIWINDOW_APPKIT_INPUT_UNFOCUSED 11
+#define V_MULTIWINDOW_APPKIT_INPUT_RESIZED 12
+#define V_MULTIWINDOW_APPKIT_INPUT_ICONIFIED 13
+#define V_MULTIWINDOW_APPKIT_INPUT_RESTORED 14
+#define V_MULTIWINDOW_APPKIT_INPUT_CLIPBOARD_PASTED 15
+#define V_MULTIWINDOW_APPKIT_INPUT_FILES_DROPPED 16
+#define V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_BEGAN 17
+#define V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_MOVED 18
+#define V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_ENDED 19
+#define V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_CANCELLED 20
+
+#define V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_LEFT 0
+#define V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_RIGHT 1
+#define V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_MIDDLE 2
+#define V_MULTIWINDOW_APPKIT_MOUSE_BUTTON_INVALID 256
+#define V_MULTIWINDOW_APPKIT_MAX_TOUCH_POINTS 8
+
+#define V_MULTIWINDOW_APPKIT_MODIFIER_LMB 0x100
+#define V_MULTIWINDOW_APPKIT_MODIFIER_RMB 0x200
+#define V_MULTIWINDOW_APPKIT_MODIFIER_MMB 0x400
+
+typedef struct VMultiwindowAppKitQueuedEvent {
+	uint64_t sequence;
+	int event_kind;
+	int lifecycle_kind;
+	int input_kind;
+	int key_code;
+	uint32_t char_code;
+	int key_repeat;
+	uint32_t modifiers;
+	int mouse_button;
+	float mouse_x;
+	float mouse_y;
+	float mouse_dx;
+	float mouse_dy;
+	float scroll_x;
+	float scroll_y;
+	int window_width;
+	int window_height;
+	int framebuffer_width;
+	int framebuffer_height;
+	int dropped_file_count;
+	char **dropped_files;
+	int touch_count;
+	uint64_t touch_ids[V_MULTIWINDOW_APPKIT_MAX_TOUCH_POINTS];
+	float touch_x[V_MULTIWINDOW_APPKIT_MAX_TOUCH_POINTS];
+	float touch_y[V_MULTIWINDOW_APPKIT_MAX_TOUCH_POINTS];
+	int touch_changed[V_MULTIWINDOW_APPKIT_MAX_TOUCH_POINTS];
+} VMultiwindowAppKitQueuedEvent;
 
 int v_multiwindow_appkit_is_main_thread(void);
 int v_multiwindow_appkit_prepare_application(void);
@@ -13,11 +82,11 @@ int v_multiwindow_appkit_create_window(void *device_ptr, const char *title, int 
 void v_multiwindow_appkit_destroy_window(void *state_ptr);
 void v_multiwindow_appkit_release_window(void *state_ptr);
 int v_multiwindow_appkit_set_window_title(void *state_ptr, const char *title);
+int v_multiwindow_appkit_set_cursor_shape(void *state_ptr, int shape);
 int v_multiwindow_appkit_resize_window(void *state_ptr, int width, int height, int *out_width, int *out_height, int *out_framebuffer_width, int *out_framebuffer_height);
 void v_multiwindow_appkit_poll_events(void);
-int v_multiwindow_appkit_take_close_requested(void *state_ptr);
-int v_multiwindow_appkit_take_resized(void *state_ptr, int *out_width, int *out_height, int *out_framebuffer_width, int *out_framebuffer_height);
-int v_multiwindow_appkit_take_destroyed(void *state_ptr);
+int v_multiwindow_appkit_take_queued_event(void *state_ptr, VMultiwindowAppKitQueuedEvent *out_event);
+void v_multiwindow_appkit_release_queued_event_resources(VMultiwindowAppKitQueuedEvent *event);
 int v_multiwindow_appkit_begin_frame(void *state_ptr, void *device_ptr, void **out_drawable, void **out_depth_texture, int *out_framebuffer_width, int *out_framebuffer_height);
 void v_multiwindow_appkit_end_frame(void *state_ptr);
 void v_multiwindow_appkit_abort_frame(void *state_ptr);

--- a/vlib/x/multiwindow/backend.v
+++ b/vlib/x/multiwindow/backend.v
@@ -306,6 +306,47 @@ fn (mut backend Backend) resize_window(id WindowId, width int, height int) !Wind
 	}
 }
 
+fn (backend &Backend) window_native_decorations(id WindowId, config WindowConfig) !bool {
+	if config.borderless {
+		return false
+	}
+	return match backend.kind {
+		.auto { error(err_backend_unsupported) }
+		.mock { false }
+		.x11 { true }
+		.wayland { backend.wayland.window_native_decorations(id)! }
+		.appkit { true }
+		.win32 { true }
+	}
+}
+
+fn (mut backend Backend) set_window_cursor(id WindowId, shape CursorShape) ! {
+	match backend.kind {
+		.auto { return error(err_backend_unsupported) }
+		.mock { backend.mock.set_window_cursor(id, shape)! }
+		.x11 { backend.x11.set_window_cursor(id, shape)! }
+		.wayland { backend.wayland.set_window_cursor(id, shape)! }
+		.appkit { backend.appkit.set_window_cursor(id, shape)! }
+		.win32 { backend.win32.set_window_cursor(id, shape)! }
+	}
+}
+
+fn (mut backend Backend) begin_window_move(id WindowId) ! {
+	match backend.kind {
+		.wayland { backend.wayland.begin_window_move(id)! }
+		.auto { return error(err_backend_unsupported) }
+		else { return error(err_capability_unsupported) }
+	}
+}
+
+fn (mut backend Backend) begin_window_resize(id WindowId, edge WindowResizeEdge) ! {
+	match backend.kind {
+		.wayland { backend.wayland.begin_window_resize(id, edge)! }
+		.auto { return error(err_backend_unsupported) }
+		else { return error(err_capability_unsupported) }
+	}
+}
+
 fn (mut backend Backend) poll_events() ![]Event {
 	match backend.kind {
 		.auto { return error(err_backend_unsupported) }
@@ -314,6 +355,34 @@ fn (mut backend Backend) poll_events() ![]Event {
 		.wayland { return backend.wayland.poll_events()! }
 		.appkit { return backend.appkit.poll_events()! }
 		.win32 { return backend.win32.poll_events()! }
+	}
+}
+
+fn (mut backend Backend) poll_queued_events() ![]QueuedEvent {
+	match backend.kind {
+		.mock {
+			return backend.mock.poll_queued_events()!
+		}
+		.x11 {
+			return backend.x11.poll_queued_events()!
+		}
+		.wayland {
+			return backend.wayland.poll_queued_events()!
+		}
+		.appkit {
+			return backend.appkit.poll_queued_events()!
+		}
+		.win32 {
+			return backend.win32.poll_queued_events()!
+		}
+		else {
+			events := backend.poll_events()!
+			mut queued_events := []QueuedEvent{cap: events.len}
+			for event in events {
+				queued_events << queued_lifecycle_event(event)
+			}
+			return queued_events
+		}
 	}
 }
 

--- a/vlib/x/multiwindow/mock_backend.v
+++ b/vlib/x/multiwindow/mock_backend.v
@@ -2,7 +2,7 @@ module multiwindow
 
 struct MockBackend {
 mut:
-	pending_events []Event
+	pending_events []QueuedEvent
 	windows        []MockWindowRecord
 }
 
@@ -24,6 +24,13 @@ fn (backend MockBackend) capabilities() Capabilities {
 		multi_window:       true
 		owner_queue:        true
 		explicit_swapchain: false
+		input_events:       true
+		mouse_events:       true
+		keyboard_events:    true
+		text_events:        true
+		focus_events:       true
+		drop_events:        true
+		touch_events:       true
 	}
 }
 
@@ -56,7 +63,30 @@ fn (mut backend MockBackend) resize_window(id WindowId, width int, height int) !
 	return actual_size
 }
 
+fn (mut backend MockBackend) set_window_cursor(id WindowId, shape CursorShape) ! {
+	_ = shape
+	backend.window_record_index(id) or { return error(err_window_not_found) }
+	return error(err_capability_unsupported)
+}
+
 fn (mut backend MockBackend) poll_events() ![]Event {
+	mut lifecycle_events := []Event{cap: backend.pending_events.len}
+	mut remaining_events := []QueuedEvent{cap: backend.pending_events.len}
+	for event in backend.pending_events {
+		match event.kind {
+			.lifecycle {
+				lifecycle_events << event.lifecycle
+			}
+			.input {
+				remaining_events << event
+			}
+		}
+	}
+	backend.pending_events = remaining_events
+	return lifecycle_events
+}
+
+fn (mut backend MockBackend) poll_queued_events() ![]QueuedEvent {
 	events := backend.pending_events.clone()
 	backend.pending_events.clear()
 	return events
@@ -68,7 +98,11 @@ fn (mut backend MockBackend) stop() ! {
 }
 
 fn (mut backend MockBackend) enqueue_event(event Event) {
-	backend.pending_events << event
+	backend.pending_events << queued_lifecycle_event(event)
+}
+
+fn (mut backend MockBackend) enqueue_input_event(event InputEvent) {
+	backend.pending_events << queued_input_event(event)
 }
 
 fn (backend &MockBackend) window_record_index(id WindowId) ?int {

--- a/vlib/x/multiwindow/multiwindow_test.v
+++ b/vlib/x/multiwindow/multiwindow_test.v
@@ -43,6 +43,12 @@ fn test_destroy_child_keeps_app_and_other_windows_alive() {
 	app.stop()!
 }
 
+fn test_dropped_files_from_uri_list_decodes_local_file_urls() {
+	payload := '# comment\r\nfile:///tmp/a%20b.txt\r\nfile://localhost/home/me/c%23d.txt\nhttp://ignored\nfile://remotehost/not-local\n'
+	files := dropped_files_from_uri_list(payload)
+	assert files == ['/tmp/a b.txt', '/home/me/c#d.txt']
+}
+
 fn test_destroy_last_window_keeps_app_running_without_live_windows() {
 	mut app := new_app()!
 	only := app.create_window(title: 'Only')!
@@ -147,6 +153,59 @@ fn test_resize_window_uses_actual_backend_size_for_state_and_event() {
 	app.stop()!
 }
 
+fn test_interactive_move_resize_api_exists_and_mock_reports_unsupported() {
+	mut app := new_app()!
+	win := app.create_window(title: 'Interactive mock')!
+
+	mut move_rejected := false
+	app.begin_window_move(win) or {
+		assert err.msg() == err_capability_unsupported
+		move_rejected = true
+	}
+	assert move_rejected, 'mock backend accepted interactive move'
+
+	edges := [
+		WindowResizeEdge.top,
+		.bottom,
+		.left,
+		.right,
+		.top_left,
+		.top_right,
+		.bottom_left,
+		.bottom_right,
+	]
+	for edge in edges {
+		mut resize_rejected := false
+		app.begin_window_resize(win, edge) or {
+			assert err.msg() == err_capability_unsupported
+			resize_rejected = true
+		}
+		assert resize_rejected, 'mock backend accepted interactive resize edge ${edge}'
+	}
+
+	fixed := app.create_window(title: 'Fixed', resizable: false)!
+	mut fixed_resize_rejected := false
+	app.begin_window_resize(fixed, .bottom_right) or {
+		assert err.msg() == err_capability_unsupported
+		fixed_resize_rejected = true
+	}
+	assert fixed_resize_rejected, 'non-resizable window accepted interactive resize'
+	app.stop()!
+}
+
+fn test_cursor_shape_api_exists_and_mock_reports_unsupported() {
+	mut app := new_app()!
+	assert !app.capabilities().cursor_shapes
+	win := app.create_window(title: 'Cursor mock')!
+	mut cursor_rejected := false
+	app.set_window_cursor(win, .pointer) or {
+		assert err.msg() == err_capability_unsupported
+		cursor_rejected = true
+	}
+	assert cursor_rejected, 'mock backend accepted cursor shape'
+	app.stop()!
+}
+
 fn test_create_window_uses_actual_backend_initial_size_for_state_and_event() {
 	mut app := new_app()!
 	win := app.create_window(
@@ -231,6 +290,209 @@ fn test_mock_stale_backend_close_requested_is_filtered_by_app_poll_events() {
 		return
 	}
 	assert false, 'stale WindowId remained valid after slot reuse'
+}
+
+fn test_mock_input_events_are_routed_without_polluting_lifecycle_drain() {
+	mut app := new_app()!
+	win := app.create_window(title: 'Input route')!
+	assert app.drain_events()!.len == 1
+
+	app.enqueue_mock_input_for_test(InputEvent{
+		kind:      .mouse_move
+		window_id: win
+		mouse_x:   12.5
+		mouse_y:   34.5
+	})!
+
+	assert app.poll_events()! == 1
+	assert app.drain_events()!.len == 0
+	input_events := app.drain_input_events()!
+	assert input_events.len == 1
+	assert input_events[0].kind == .mouse_move
+	assert input_events[0].window_id == win
+	assert input_events[0].mouse_x == 12.5
+	assert input_events[0].mouse_y == 34.5
+	assert app.drain_input_events()!.len == 0
+	app.stop()!
+}
+
+fn test_input_events_without_frame_count_are_stamped_per_poll() {
+	mut app := new_app()!
+	win := app.create_window(title: 'Input frame count')!
+	assert app.drain_events()!.len == 1
+
+	app.enqueue_mock_input_for_test(InputEvent{
+		kind:      .mouse_move
+		window_id: win
+		mouse_x:   1
+		mouse_y:   2
+	})!
+	assert app.poll_events()! == 1
+	first := app.drain_input_events()!
+	assert first.len == 1
+	assert first[0].frame_count == 1
+
+	app.enqueue_mock_input_for_test(InputEvent{
+		kind:        .key_down
+		window_id:   win
+		frame_count: 99
+		key_code:    65
+	})!
+	assert app.poll_events()! == 1
+	second := app.drain_input_events()!
+	assert second.len == 1
+	assert second[0].frame_count == 99
+
+	app.enqueue_mock_input_for_test(InputEvent{
+		kind:      .mouse_up
+		window_id: win
+	})!
+	assert app.poll_events()! == 1
+	third := app.drain_input_events()!
+	assert third.len == 1
+	assert third[0].frame_count == 3
+	app.stop()!
+}
+
+fn test_mock_input_roundtrip_covers_all_input_event_kinds() {
+	event_kinds := all_input_event_kinds_for_test()
+	assert_input_event_kind_list_matches_types_source(event_kinds)
+	mut app := new_app()!
+	win := app.create_window(title: 'Input kind coverage')!
+	assert app.drain_events()!.len == 1
+
+	mut expected_events := []InputEvent{cap: event_kinds.len}
+	for i, kind in event_kinds {
+		expected_events << input_event_for_kind_for_test(win, kind, u64(i + 1))
+	}
+	for event in expected_events {
+		app.enqueue_mock_input_for_test(event)!
+	}
+
+	assert app.poll_events()! == expected_events.len
+	actual_events := app.drain_input_events()!
+	assert actual_events.len == expected_events.len
+	for i, actual in actual_events {
+		assert_input_event_roundtrip(actual, expected_events[i])
+	}
+	assert app.drain_events()!.len == 0
+	assert app.drain_input_events()!.len == 0
+	app.stop()!
+}
+
+fn test_input_event_default_mouse_button_is_invalid() {
+	event := InputEvent{}
+	assert event.mouse_button == input_event_invalid_mouse_button
+	source := multiwindow_source_file('types.v')
+	assert source.contains('const input_event_invalid_mouse_button = 256')
+	assert source.contains('mouse_button       int = input_event_invalid_mouse_button')
+}
+
+fn test_drain_input_events_does_not_consume_lifecycle_events() {
+	mut app := new_app()!
+	win := app.create_window(title: 'Lifecycle remains')!
+
+	app.enqueue_mock_input_for_test(InputEvent{
+		kind:      .mouse_move
+		window_id: win
+		mouse_x:   48
+		mouse_y:   96
+	})!
+
+	assert app.poll_events()! == 1
+	input_events := app.drain_input_events()!
+	assert input_events.len == 1
+	assert input_events[0].kind == .mouse_move
+	assert input_events[0].window_id == win
+
+	lifecycle_events := app.drain_events()!
+	assert lifecycle_events.len == 1
+	assert lifecycle_events[0].kind == .window_created
+	assert lifecycle_events[0].window_id == win
+	assert app.drain_events()!.len == 0
+	assert app.drain_input_events()!.len == 0
+	app.stop()!
+}
+
+fn test_mock_input_and_lifecycle_events_preserve_backend_order() {
+	mut app := new_app()!
+	win := app.create_window(title: 'Ordered input')!
+	assert app.drain_events()!.len == 1
+
+	app.enqueue_mock_input_for_test(InputEvent{
+		kind:         .mouse_down
+		window_id:    win
+		mouse_button: 0
+	})!
+	app.enqueue_mock_close_requested_for_test(win)!
+	app.enqueue_mock_input_for_test(InputEvent{
+		kind:      .key_down
+		window_id: win
+		key_code:  65
+	})!
+
+	assert app.poll_events()! == 3
+	queued_events := app.drain_queued_events()!
+	assert queued_events.len == 3
+	assert queued_events[0].kind == .input
+	assert queued_events[0].input.kind == .mouse_down
+	assert queued_events[1].kind == .lifecycle
+	assert queued_events[1].lifecycle.kind == .window_close_requested
+	assert queued_events[2].kind == .input
+	assert queued_events[2].input.kind == .key_down
+	app.stop()!
+}
+
+fn test_mock_stale_backend_input_event_is_filtered_by_app_poll_events() {
+	mut app := new_app()!
+	first := app.create_window(title: 'First input target')!
+	assert app.drain_events()!.len == 1
+	app.destroy_window(first)!
+	assert app.drain_events()!.len == 1
+	second := app.create_window(title: 'Reused input target')!
+	assert second.slot == first.slot
+	assert second.generation != first.generation
+	assert app.drain_events()!.len == 1
+
+	app.enqueue_mock_input_unchecked_for_test(InputEvent{
+		kind:      .mouse_move
+		window_id: first
+		mouse_x:   99
+		mouse_y:   88
+	})!
+
+	assert app.poll_events()! == 0
+	assert app.drain_input_events()!.len == 0
+	assert app.window_exists(second)
+	app.stop()!
+}
+
+fn test_mock_resized_input_event_updates_window_state() {
+	mut app := new_app()!
+	win := app.create_window(title: 'Input resize', width: 320, height: 200)!
+	assert app.drain_events()!.len == 1
+
+	app.enqueue_mock_input_for_test(InputEvent{
+		kind:               .resized
+		window_id:          win
+		window_width:       640
+		window_height:      360
+		framebuffer_width:  1280
+		framebuffer_height: 720
+	})!
+
+	assert app.poll_events()! == 1
+	info := app.window_info(win)!
+	assert info.width == 640
+	assert info.height == 360
+	input_events := app.drain_input_events()!
+	assert input_events.len == 1
+	assert input_events[0].kind == .resized
+	assert input_events[0].window_width == 640
+	assert input_events[0].window_height == 360
+	assert input_events[0].framebuffer_width == 1280
+	assert input_events[0].framebuffer_height == 720
+	app.stop()!
 }
 
 fn test_owner_queue_runs_jobs_and_rejects_destroyed_window_work() {
@@ -347,6 +609,27 @@ fn test_invalid_app_and_window_config_are_rejected() {
 	assert false, 'create_window accepted zero width'
 }
 
+fn test_new_app_starts_backend_on_stable_app_backend_before_owner_queue_source_guard() {
+	source := multiwindow_source_file('app.v')
+	body :=
+		source.all_after('pub fn new_app(config Config) !&App {').all_before('// status reports')
+
+	assert body.contains('mut app := &App{')
+	assert body.contains('app.backend.start(config.require_renderer)!')
+	assert body.contains('mut owner := executor.new(queue_size: config.queue_size) or {')
+	assert body.contains('app.backend.stop() or {}')
+	assert body.contains('app.owner = owner')
+	assert !body.contains('\n\tbackend.start(config.require_renderer)!')
+	assert_source_order(body, 'mut app := &App{', 'app.backend.start(config.require_renderer)!')
+	assert_source_order(body, 'app.backend.start(config.require_renderer)!',
+		'mut owner := executor.new(queue_size: config.queue_size) or {')
+	owner_failure_body := body.all_after('mut owner := executor.new(queue_size: config.queue_size) or {')
+		.all_before('app.owner = owner')
+	assert_source_order(owner_failure_body, 'app.backend.stop() or {}', 'return err')
+	assert_source_order(body, 'mut owner := executor.new(queue_size: config.queue_size) or {',
+		'app.owner = owner')
+}
+
 fn test_unknown_and_stale_window_ids_are_rejected() {
 	mut app := new_app()!
 	unknown := WindowId{
@@ -392,6 +675,13 @@ fn test_backend_capabilities_are_stable() {
 	assert caps_before.multi_window == caps_after.multi_window
 	assert caps_before.owner_queue == caps_after.owner_queue
 	assert caps_before.explicit_swapchain == caps_after.explicit_swapchain
+	assert caps_before.input_events
+	assert caps_before.mouse_events
+	assert caps_before.keyboard_events
+	assert caps_before.text_events
+	assert caps_before.focus_events
+	assert caps_before.drop_events
+	assert caps_before.touch_events
 	app.stop()!
 }
 
@@ -527,6 +817,13 @@ fn test_capabilities_for_backend_uses_backend_seam_without_app() {
 	assert caps.multi_window
 	assert caps.owner_queue
 	assert !caps.explicit_swapchain
+	assert caps.input_events
+	assert caps.mouse_events
+	assert caps.keyboard_events
+	assert caps.text_events
+	assert caps.focus_events
+	assert caps.drop_events
+	assert caps.touch_events
 }
 
 fn test_mock_render_seam_reports_renderer_unsupported() {
@@ -658,6 +955,7 @@ fn test_capabilities_for_config_render_required_prefers_x11_over_wayland() {
 				assert caps.native
 				assert caps.explicit_swapchain
 				assert caps.d3d11
+				assert_win32_input_capabilities(caps)
 			} $else {
 				capabilities_for_config(backend: .auto, require_renderer: true) or {
 					assert err.msg() == err_renderer_unsupported
@@ -686,6 +984,7 @@ fn test_capabilities_for_config_render_required_prefers_x11_over_wayland() {
 					assert caps.native
 					assert caps.explicit_swapchain
 					assert caps.metal
+					assert_appkit_input_capabilities(caps)
 				}
 			} $else {
 				caps := capabilities_for_config(backend: .auto, require_renderer: true)!
@@ -719,6 +1018,7 @@ fn assert_x11_render_capabilities(caps Capabilities) {
 	assert caps.native
 	assert caps.explicit_swapchain
 	assert caps.gl
+	assert_x11_input_capabilities(caps)
 }
 
 fn assert_x11_lifecycle_capabilities(caps Capabilities) {
@@ -729,6 +1029,61 @@ fn assert_x11_lifecycle_capabilities(caps Capabilities) {
 	assert caps.multi_window
 	assert caps.owner_queue
 	assert !caps.explicit_swapchain
+	assert_x11_input_capabilities(caps)
+}
+
+fn assert_native_input_capabilities_not_claimed(caps Capabilities) {
+	assert !caps.input_events
+	assert !caps.mouse_events
+	assert !caps.keyboard_events
+	assert !caps.text_events
+	assert !caps.focus_events
+	assert !caps.drop_events
+	assert !caps.touch_events
+}
+
+fn assert_x11_input_capabilities(caps Capabilities) {
+	assert caps.input_events
+	assert caps.mouse_events
+	assert caps.keyboard_events
+	assert caps.text_events
+	assert caps.focus_events
+	assert caps.drop_events
+	assert !caps.touch_events
+	assert caps.cursor_shapes
+}
+
+fn assert_wayland_input_capabilities(caps Capabilities) {
+	assert caps.input_events
+	assert caps.mouse_events
+	assert caps.keyboard_events
+	assert caps.text_events
+	assert caps.focus_events
+	assert caps.drop_events
+	assert caps.touch_events
+	assert !caps.cursor_shapes
+}
+
+fn assert_win32_input_capabilities(caps Capabilities) {
+	assert caps.input_events
+	assert caps.mouse_events
+	assert caps.keyboard_events
+	assert caps.text_events
+	assert caps.focus_events
+	assert caps.drop_events
+	assert caps.touch_events
+	assert caps.cursor_shapes
+}
+
+fn assert_appkit_input_capabilities(caps Capabilities) {
+	assert caps.input_events
+	assert caps.mouse_events
+	assert caps.keyboard_events
+	assert caps.text_events
+	assert caps.focus_events
+	assert caps.drop_events
+	assert caps.touch_events
+	assert caps.cursor_shapes
 }
 
 fn test_fake_wayland_lifecycle_capabilities_do_not_claim_render_ready() {
@@ -748,6 +1103,7 @@ fn test_fake_wayland_lifecycle_capabilities_do_not_claim_render_ready() {
 			assert caps.wayland
 			assert !caps.explicit_swapchain
 			assert !caps.gl
+			assert_wayland_input_capabilities(caps)
 
 			helper_caps := capabilities_for_backend(.wayland) or {
 				assert err.msg() == err_wayland_connect_failed
@@ -756,6 +1112,7 @@ fn test_fake_wayland_lifecycle_capabilities_do_not_claim_render_ready() {
 			assert helper_caps.backend == .wayland
 			assert !helper_caps.explicit_swapchain
 			assert !helper_caps.gl
+			assert_wayland_input_capabilities(helper_caps)
 		} $else {
 			caps := capabilities_for_backend(.auto)!
 			assert caps.backend == .mock
@@ -943,6 +1300,7 @@ fn test_auto_capabilities_for_backend_reports_selected_backend() {
 				assert caps.native
 				assert caps.multi_window
 				assert caps.owner_queue
+				assert_wayland_input_capabilities(caps)
 				return
 			}
 		}
@@ -951,6 +1309,7 @@ fn test_auto_capabilities_for_backend_reports_selected_backend() {
 				assert caps.backend == .x11
 				assert caps.x11
 				assert caps.native
+				assert_x11_input_capabilities(caps)
 				return
 			}
 		}
@@ -962,10 +1321,12 @@ fn test_auto_capabilities_for_backend_reports_selected_backend() {
 			assert caps.backend == .win32
 			assert caps.win32
 			assert caps.native
+			assert_win32_input_capabilities(caps)
 		} $else {
 			$if darwin {
 				assert caps.backend == .appkit
 				assert caps.native
+				assert_appkit_input_capabilities(caps)
 			} $else {
 				assert caps.backend == .mock
 				assert caps.mock
@@ -990,6 +1351,7 @@ fn test_win32_capabilities_for_backend_do_not_require_d3d_on_windows() {
 		assert !caps.wayland
 		assert !caps.explicit_swapchain
 		assert !caps.d3d11
+		assert_win32_input_capabilities(caps)
 	} $else {
 		capabilities_for_backend(.win32) or {
 			assert err.msg() == err_backend_unsupported
@@ -1015,6 +1377,7 @@ fn test_win32_render_capabilities_probe_d3d_on_windows_only() {
 			assert caps.native
 			assert caps.explicit_swapchain
 			assert caps.d3d11
+			assert_win32_input_capabilities(caps)
 		} $else {
 			capabilities_for_backend_with_renderer(.win32, true) or {
 				assert err.msg() == err_renderer_unsupported
@@ -1057,6 +1420,177 @@ fn test_win32_min_size_plumbing_is_present() {
 	assert win32_helper_source.contains('v_multiwindow_win32_max_int(height, min_height)')
 }
 
+fn test_win32_input_events_are_queued_and_capability_scoped_source_guard() {
+	backend_source := multiwindow_source_file('backend.v')
+	win32_backend_source := multiwindow_source_file('win32_backend.c.v')
+	win32_helper_source := multiwindow_source_file('win32_backend_helpers.h')
+
+	assert backend_source.contains('.win32 {\n\t\t\treturn backend.win32.poll_queued_events()!')
+	assert win32_backend_source.contains('struct Win32NativeQueuedEvent')
+	assert win32_backend_source.contains('queued_events')
+	assert win32_backend_source.contains('[]Win32NativeQueuedEvent')
+	assert win32_backend_source.contains('fn (mut backend Win32Backend) poll_queued_events() ![]QueuedEvent')
+	assert win32_backend_source.contains('win32_sort_native_events(mut native_events)')
+	assert win32_backend_source.contains('record.enqueue_native_event(sequence, queued_input_event')
+	assert win32_backend_source.contains('record.enqueue_char_event(sequence, char_code, modifiers)')
+	assert win32_backend_source.contains('pending_high_surrogate')
+	assert win32_backend_source.contains('suppress_control_char')
+	assert !win32_backend_source.contains('win32_scroll_delta')
+	assert !win32_backend_source.contains('...input')
+	assert win32_backend_source.contains('scroll_x:           -f32(wheel_delta_x) / f32(30.0)')
+	assert win32_backend_source.contains('scroll_y:           f32(wheel_delta_y) / f32(30.0)')
+	assert win32_backend_source.contains('fn win32_control_char_for_key(key_code int) u32')
+	assert win32_backend_source.contains('257, 335 { u32(13) }')
+	assert win32_backend_source.contains('261 { u32(127) }')
+	assert win32_backend_source.contains('input_events:       true')
+	assert win32_backend_source.contains('mouse_events:       true')
+	assert win32_backend_source.contains('keyboard_events:    true')
+	assert win32_backend_source.contains('text_events:        true')
+	assert win32_backend_source.contains('focus_events:       true')
+	assert win32_backend_source.contains('drop_events:        true')
+	assert win32_backend_source.contains('touch_events:       true')
+	assert win32_backend_source.contains('pending_dropped_files  []string')
+	assert win32_backend_source.contains('dropped_files:      record.pending_dropped_files.clone()')
+	assert win32_backend_source.contains('.files_dropped')
+	assert win32_backend_source.contains('InputEventKind.clipboard_pasted')
+	assert win32_backend_source.contains('InputEventKind.touches_began')
+	assert win32_backend_source.contains('InputEventKind.touches_moved')
+	assert win32_backend_source.contains('InputEventKind.touches_ended')
+	assert !win32_backend_source.contains('InputEventKind.touches_cancelled')
+	assert win32_backend_source.contains('fn win32_window_drop_begin')
+	assert win32_backend_source.contains('fn win32_window_drop_file')
+	assert win32_backend_source.contains('fn win32_window_drop_end')
+	assert win32_backend_source.contains('fn win32_window_touch_event')
+	assert win32_backend_source.contains('tos_clone(&u8(path))')
+	assert !win32_backend_source.contains('cstring_to_vstring(path)')
+	assert win32_backend_source.contains('iconified              bool')
+	assert win32_backend_source.contains('12 { InputEventKind.iconified }')
+	assert win32_backend_source.contains('13 { InputEventKind.restored }')
+	assert win32_backend_source.contains('if record.iconified')
+	assert win32_backend_source.contains('if !record.iconified')
+	win32_mouse_button_body :=
+		win32_backend_source.all_after('.mouse_down, .mouse_up {').all_before('.mouse_move {')
+	assert win32_mouse_button_body.contains('record.update_mouse_position(mouse_x, mouse_y, false)')
+	assert !win32_mouse_button_body.contains('record.update_mouse_position(mouse_x, mouse_y, true)')
+	assert win32_mouse_button_body.contains('mouse_dx:           record.mouse_dx')
+	assert win32_mouse_button_body.contains('mouse_dy:           record.mouse_dy')
+	win32_clipboard_pasted_body :=
+		win32_backend_source.all_after('.clipboard_pasted {').all_before('.iconified {')
+	assert win32_clipboard_pasted_body.contains('input = InputEvent{')
+	assert win32_clipboard_pasted_body.contains('kind:               input_kind')
+	assert win32_clipboard_pasted_body.contains('window_id:          record.id')
+	assert win32_clipboard_pasted_body.contains('modifiers:          modifiers')
+	assert win32_clipboard_pasted_body.contains('mouse_button:       256')
+
+	assert win32_helper_source.contains('GWLP_USERDATA')
+	assert win32_helper_source.contains('v_multiwindow_win32_next_event_sequence')
+	assert win32_helper_source.contains('V_MULTIWINDOW_WIN32_INPUT_ICONIFIED')
+	assert win32_helper_source.contains('V_MULTIWINDOW_WIN32_INPUT_RESTORED')
+	assert win32_helper_source.contains('V_MULTIWINDOW_WIN32_INPUT_CLIPBOARD_PASTED')
+	assert win32_helper_source.contains('V_MULTIWINDOW_WIN32_INPUT_TOUCHES_BEGAN')
+	assert win32_helper_source.contains('V_MULTIWINDOW_WIN32_INPUT_TOUCHES_MOVED')
+	assert win32_helper_source.contains('V_MULTIWINDOW_WIN32_INPUT_TOUCHES_ENDED')
+	assert !win32_helper_source.contains('V_MULTIWINDOW_WIN32_INPUT_TOUCHES_CANCELLED')
+	assert win32_helper_source.contains('WM_MOUSEMOVE')
+	assert win32_helper_source.contains('TrackMouseEvent')
+	assert win32_helper_source.contains('WM_MOUSELEAVE')
+	assert win32_helper_source.contains('WM_LBUTTONDOWN')
+	assert win32_helper_source.contains('WM_RBUTTONDOWN')
+	assert win32_helper_source.contains('WM_MBUTTONDOWN')
+	assert win32_helper_source.contains('WM_MOUSEWHEEL')
+	assert win32_helper_source.contains('WM_MOUSEHWHEEL')
+	assert win32_helper_source.contains('WM_KEYDOWN')
+	assert win32_helper_source.contains('WM_SYSKEYDOWN')
+	assert win32_helper_source.contains('WM_KEYUP')
+	assert win32_helper_source.contains('WM_SYSKEYUP')
+	assert win32_helper_source.contains('WM_CHAR')
+	assert win32_helper_source.contains('WM_SETFOCUS')
+	assert win32_helper_source.contains('WM_KILLFOCUS')
+	assert win32_helper_source.contains('wparam == SIZE_MINIMIZED')
+	assert win32_helper_source.contains('V_MULTIWINDOW_WIN32_INPUT_ICONIFIED')
+	assert win32_helper_source.contains('V_MULTIWINDOW_WIN32_INPUT_RESTORED')
+	assert win32_helper_source.contains('v_multiwindow_win32_key_code')
+	assert win32_helper_source.contains('v_multiwindow_win32_modifiers')
+	assert win32_helper_source.contains('GetAsyncKeyState(VK_LBUTTON)')
+	win32_keydown_start := win32_helper_source.index('case WM_KEYDOWN:') or {
+		assert false, 'Win32 helper does not handle WM_KEYDOWN'
+		0
+	}
+	win32_syskeydown_start := win32_helper_source.index('case WM_SYSKEYDOWN:') or {
+		assert false, 'Win32 helper does not handle WM_SYSKEYDOWN'
+		0
+	}
+	win32_keydown_body := win32_helper_source[win32_keydown_start..win32_syskeydown_start]
+	assert win32_keydown_body.contains('uint32_t modifiers = v_multiwindow_win32_modifiers();')
+	assert win32_keydown_body.contains('V_MULTIWINDOW_WIN32_INPUT_KEY_DOWN, key_code, 0, v_multiwindow_win32_key_repeat(lparam), modifiers')
+	assert win32_keydown_body.contains('V_MULTIWINDOW_WIN32_INPUT_CLIPBOARD_PASTED, 0, 0, 0, modifiers')
+	assert_source_order(win32_keydown_body,
+		'uint32_t modifiers = v_multiwindow_win32_modifiers();',
+		'V_MULTIWINDOW_WIN32_INPUT_KEY_DOWN')
+	assert_source_order(win32_keydown_body,
+		'uint32_t modifiers = v_multiwindow_win32_modifiers();',
+		'V_MULTIWINDOW_WIN32_INPUT_CLIPBOARD_PASTED')
+	assert win32_helper_source.contains('V_MULTIWINDOW_WIN32_MODIFIER_LMB 0x100')
+	assert win32_helper_source.contains('V_MULTIWINDOW_WIN32_MODIFIER_RMB 0x200')
+	assert win32_helper_source.contains('V_MULTIWINDOW_WIN32_MODIFIER_MMB 0x400')
+	assert win32_helper_source.contains('v_multiwindow_win32_is_char_code')
+	assert win32_helper_source.contains('c >= 32 || c == 8 || c == 9 || c == 13 || c == 127')
+	assert win32_helper_source.contains('return (lparam & 0x01000000) ? 335 : 257;')
+	assert !win32_backend_source.contains('win32_input_quit_requested')
+	assert !win32_backend_source.contains('.quit_requested')
+	assert !win32_helper_source.contains('V_MULTIWINDOW_WIN32_INPUT_QUIT_REQUESTED')
+	assert !win32_helper_source.contains('WM_SYSCHAR')
+	assert win32_helper_source.contains('WM_DROPFILES')
+	assert win32_helper_source.contains('DragAcceptFiles')
+	assert win32_helper_source.contains('DragQueryFileW')
+	assert win32_helper_source.contains('DragQueryPoint')
+	assert win32_helper_source.contains('DragFinish')
+	assert win32_helper_source.contains('v_multiwindow_win32_window_drop_begin')
+	assert win32_helper_source.contains('v_multiwindow_win32_window_drop_file')
+	assert win32_helper_source.contains('v_multiwindow_win32_window_drop_file(void *data, uint64_t sequence, char *path)')
+	assert !win32_helper_source.contains('v_multiwindow_win32_window_drop_file(void *data, uint64_t sequence, const char *path)')
+	assert win32_helper_source.contains('v_multiwindow_win32_window_drop_end')
+	assert win32_helper_source.contains('WM_TOUCH')
+	assert win32_helper_source.contains('v_multiwindow_win32_register_touch_window')
+	assert win32_helper_source.contains('RegisterTouchWindow')
+	assert win32_helper_source.contains('GetTouchInputInfo')
+	assert win32_helper_source.contains('CloseTouchInputHandle')
+	assert win32_helper_source.contains('v_multiwindow_win32_window_touch_event(void *data, uint64_t sequence, int kind, uint32_t modifiers, int count, uint64_t *ids, int *xs, int *ys, int *changed)')
+	assert !win32_helper_source.contains('v_multiwindow_win32_window_touch_event(void *data, uint64_t sequence, int kind, uint32_t modifiers, int count, const uint64_t *ids')
+	assert !win32_helper_source.contains('const int *xs')
+	assert !win32_helper_source.contains('const int *ys')
+	assert !win32_helper_source.contains('const int *changed')
+	assert win32_helper_source.contains('ScreenToClient(hwnd, &point)')
+	assert win32_helper_source.contains('changed[out_count] = 1;')
+	assert_source_order(win32_helper_source,
+		'v_multiwindow_win32_get_touch_input_info(handle, count, inputs)',
+		'v_multiwindow_win32_close_touch_input_handle(handle);')
+	assert_source_order(win32_helper_source,
+		'v_multiwindow_win32_close_touch_input_handle(handle);',
+		'v_multiwindow_win32_emit_touch_group(hwnd, data, inputs, count, TOUCHEVENTF_DOWN')
+	assert !win32_helper_source.contains('WM_POINTERCANCEL')
+	assert !win32_helper_source.contains('WM_IME')
+
+	syskey_down_start := win32_helper_source.index('case WM_SYSKEYDOWN:') or {
+		assert false, 'Win32 helper does not handle WM_SYSKEYDOWN'
+		0
+	}
+	syskey_up_start := win32_helper_source.index('case WM_SYSKEYUP:') or {
+		assert false, 'Win32 helper does not handle WM_SYSKEYUP'
+		0
+	}
+	key_up_start := win32_helper_source.index('case WM_KEYUP:') or {
+		assert false, 'Win32 helper does not handle WM_KEYUP'
+		0
+	}
+	char_start := win32_helper_source.index('case WM_CHAR:') or {
+		assert false, 'Win32 helper does not handle WM_CHAR'
+		0
+	}
+	assert !win32_helper_source[syskey_down_start..key_up_start].contains('return 0;')
+	assert !win32_helper_source[syskey_up_start..char_start].contains('return 0;')
+}
+
 fn test_win32_runtime_resize_clamps_to_min_size_when_available() {
 	$if windows {
 		mut app := new_app(backend: .win32)!
@@ -1095,6 +1629,7 @@ fn test_appkit_capabilities_for_backend_are_platform_scoped() {
 		assert caps.owner_queue
 		assert !caps.explicit_swapchain
 		assert caps.metal == false
+		assert_appkit_input_capabilities(caps)
 	} $else {
 		capabilities_for_backend(.appkit) or {
 			assert err.msg() == err_backend_unsupported
@@ -1196,6 +1731,199 @@ fn test_appkit_initial_content_rect_is_clamped_to_min_size_source_guard() {
 	assert_source_order(source,
 		'int content_width = v_multiwindow_appkit_max_int(width, min_width);',
 		'NSWindow *window = [[NSWindow alloc] initWithContentRect:rect')
+}
+
+fn test_appkit_input_events_are_queued_and_capability_scoped_source_guard() {
+	backend_source := multiwindow_source_file('backend.v')
+	appkit_backend_source := multiwindow_source_file('appkit_backend.c.v')
+	appkit_header_source := multiwindow_source_file('appkit_backend_helpers.h')
+	appkit_impl_source := multiwindow_source_file('appkit_backend.m')
+
+	assert backend_source.contains('.appkit {\n\t\t\treturn backend.appkit.poll_queued_events()!')
+	assert appkit_backend_source.contains('struct AppKitNativeQueuedEvent')
+	assert appkit_backend_source.contains('fn (mut backend AppKitBackend) poll_queued_events() ![]QueuedEvent')
+	assert appkit_backend_source.contains('appkit_sort_native_events(mut native_events)')
+	assert appkit_backend_source.contains('appkit_queued_event_from_native(record, native_event)')
+	assert appkit_backend_source.contains('@[heap; markused]\nstruct AppKitWindowRecord')
+	assert !appkit_backend_source.contains('const appkit_input_')
+	assert !appkit_backend_source.contains('const appkit_native_event_')
+	assert appkit_backend_source.contains('input_events:       true')
+	assert appkit_backend_source.contains('mouse_events:       true')
+	assert appkit_backend_source.contains('keyboard_events:    true')
+	assert appkit_backend_source.contains('text_events:        true')
+	assert appkit_backend_source.contains('focus_events:       true')
+	assert appkit_backend_source.contains('drop_events:        true')
+	assert appkit_backend_source.contains('touch_events:       true')
+	assert appkit_backend_source.contains('13 { InputEventKind.iconified }')
+	assert appkit_backend_source.contains('14 { InputEventKind.restored }')
+	assert appkit_backend_source.contains('15 { InputEventKind.clipboard_pasted }')
+	assert appkit_backend_source.contains('16 { InputEventKind.files_dropped }')
+	assert appkit_backend_source.contains('17 { InputEventKind.touches_began }')
+	assert appkit_backend_source.contains('18 { InputEventKind.touches_moved }')
+	assert appkit_backend_source.contains('19 { InputEventKind.touches_ended }')
+	assert appkit_backend_source.contains('20 { InputEventKind.touches_cancelled }')
+	assert appkit_backend_source.contains('dropped_files:      appkit_dropped_files_from_native(native_event)')
+	assert appkit_backend_source.contains('mut touch_count := native_event.touch_count')
+	assert appkit_backend_source.contains('if touch_count > 8')
+	assert appkit_backend_source.contains('mut touches := [8]InputTouchPoint{}')
+	assert appkit_backend_source.contains('num_touches:        touch_count')
+	assert appkit_backend_source.contains('touches:            touches')
+	assert appkit_backend_source.contains('fn appkit_dropped_files_from_native')
+	assert appkit_backend_source.contains('tos_clone(&u8(path))')
+	assert !appkit_backend_source.contains('cstring_to_vstring(path)')
+	assert !appkit_backend_source.contains('fn appkit_touch_count')
+	assert !appkit_backend_source.contains('fn appkit_touches_from_native')
+	assert appkit_backend_source.contains('C.v_multiwindow_appkit_release_queued_event_resources')
+
+	assert appkit_header_source.contains('typedef struct VMultiwindowAppKitQueuedEvent')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_INPUT_MOUSE_MOVE')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_INPUT_RESIZED')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_INPUT_ICONIFIED')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_INPUT_RESTORED')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_INPUT_CLIPBOARD_PASTED')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_INPUT_FILES_DROPPED')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_BEGAN')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_MOVED')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_ENDED')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_CANCELLED')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_MAX_TOUCH_POINTS 8')
+	assert appkit_header_source.contains('int dropped_file_count;')
+	assert appkit_header_source.contains('char **dropped_files;')
+	assert appkit_header_source.contains('int touch_count;')
+	assert appkit_header_source.contains('uint64_t touch_ids[V_MULTIWINDOW_APPKIT_MAX_TOUCH_POINTS];')
+	assert appkit_header_source.contains('float touch_x[V_MULTIWINDOW_APPKIT_MAX_TOUCH_POINTS];')
+	assert appkit_header_source.contains('float touch_y[V_MULTIWINDOW_APPKIT_MAX_TOUCH_POINTS];')
+	assert appkit_header_source.contains('int touch_changed[V_MULTIWINDOW_APPKIT_MAX_TOUCH_POINTS];')
+	assert appkit_header_source.contains('int v_multiwindow_appkit_take_queued_event')
+	assert appkit_header_source.contains('void v_multiwindow_appkit_release_queued_event_resources')
+	assert !appkit_header_source.contains('v_multiwindow_appkit_take_close_requested')
+	assert !appkit_header_source.contains('v_multiwindow_appkit_take_resized')
+	assert !appkit_header_source.contains('v_multiwindow_appkit_take_destroyed')
+	assert !appkit_backend_source.contains('v_multiwindow_appkit_take_close_requested')
+	assert !appkit_backend_source.contains('v_multiwindow_appkit_take_resized')
+	assert !appkit_backend_source.contains('v_multiwindow_appkit_take_destroyed')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_MODIFIER_LMB 0x100')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_MODIFIER_RMB 0x200')
+	assert appkit_header_source.contains('V_MULTIWINDOW_APPKIT_MODIFIER_MMB 0x400')
+
+	assert appkit_impl_source.contains('@interface VMultiwindowAppKitView : NSView')
+	assert appkit_impl_source.contains('- (BOOL)acceptsFirstResponder')
+	assert appkit_impl_source.contains('- (BOOL)acceptsFirstMouse:(NSEvent *)event')
+	assert appkit_impl_source.contains('NSTrackingMouseEnteredAndExited')
+	assert appkit_impl_source.contains('NSTrackingEnabledDuringMouseDrag')
+	assert appkit_impl_source.contains('windowDidBecomeKey')
+	assert appkit_impl_source.contains('windowDidResignKey')
+	assert appkit_impl_source.contains('windowDidMiniaturize')
+	assert appkit_impl_source.contains('windowDidDeminiaturize')
+	assert appkit_impl_source.contains('V_MULTIWINDOW_APPKIT_INPUT_ICONIFIED')
+	assert appkit_impl_source.contains('V_MULTIWINDOW_APPKIT_INPUT_RESTORED')
+	assert appkit_impl_source.contains('V_MULTIWINDOW_APPKIT_INPUT_CLIPBOARD_PASTED')
+	assert appkit_impl_source.contains('V_MULTIWINDOW_APPKIT_INPUT_FILES_DROPPED')
+	assert appkit_impl_source.contains('V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_BEGAN')
+	assert appkit_impl_source.contains('V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_MOVED')
+	assert appkit_impl_source.contains('V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_ENDED')
+	assert appkit_impl_source.contains('V_MULTIWINDOW_APPKIT_INPUT_TOUCHES_CANCELLED')
+	assert appkit_impl_source.contains('clearKeyDownState')
+	assert appkit_impl_source.contains('windowShouldClose')
+	assert appkit_impl_source.contains('queueResizeEvents')
+	assert appkit_impl_source.contains('suppressResizeEvent')
+	assert !appkit_impl_source.contains('@property(assign) BOOL closeRequested')
+	assert !appkit_impl_source.contains('@property(assign) BOOL destroyed')
+	assert !appkit_impl_source.contains('@property(assign) BOOL resized')
+	assert !appkit_impl_source.contains('int v_multiwindow_appkit_take_close_requested')
+	assert !appkit_impl_source.contains('int v_multiwindow_appkit_take_resized')
+	assert !appkit_impl_source.contains('int v_multiwindow_appkit_take_destroyed')
+	assert !appkit_impl_source.contains('self.closeRequested')
+	assert !appkit_impl_source.contains('state.closeRequested')
+	assert !appkit_impl_source.contains('self.destroyed')
+	assert !appkit_impl_source.contains('state.destroyed')
+	assert !appkit_impl_source.contains('self.resized')
+	assert !appkit_impl_source.contains('state.resized')
+	assert appkit_impl_source.contains('makeFirstResponder:view')
+	assert appkit_impl_source.contains('mouseDown:')
+	assert appkit_impl_source.contains('rightMouseDown:')
+	assert appkit_impl_source.contains('otherMouseDown:')
+	assert appkit_impl_source.contains('scrollWheel:')
+	assert appkit_impl_source.contains('event.hasPreciseScrollingDeltas')
+	assert appkit_impl_source.contains('keyDown:')
+	assert appkit_impl_source.contains('keyUp:')
+	assert appkit_impl_source.contains('flagsChanged:')
+	assert appkit_impl_source.contains('NSDraggingDestination')
+	assert appkit_impl_source.contains('registerForDraggedTypes')
+	assert appkit_impl_source.contains('NSPasteboardTypeFileURL')
+	assert appkit_impl_source.contains('performDragOperation')
+	assert appkit_impl_source.contains('readObjectsForClasses:@[ NSURL.class ]')
+	assert appkit_impl_source.contains('dropped_files')
+	assert appkit_impl_source.contains('v_multiwindow_appkit_release_queued_event_resources')
+	assert appkit_impl_source.contains('view.acceptsTouchEvents = YES;')
+	assert appkit_impl_source.contains('touchesBeganWithEvent:')
+	assert appkit_impl_source.contains('touchesMovedWithEvent:')
+	assert appkit_impl_source.contains('touchesEndedWithEvent:')
+	assert appkit_impl_source.contains('touchesCancelledWithEvent:')
+	assert appkit_impl_source.contains('touchesMatchingPhase:NSTouchPhaseAny inView:view')
+	assert appkit_impl_source.contains('NSTouchPhaseBegan')
+	assert appkit_impl_source.contains('NSTouchPhaseMoved')
+	assert appkit_impl_source.contains('NSTouchPhaseEnded')
+	assert appkit_impl_source.contains('NSTouchPhaseCancelled')
+	assert appkit_impl_source.contains('v_multiwindow_appkit_touch_sets_share_identity')
+	assert appkit_impl_source.contains('v_multiwindow_appkit_fill_touch_point')
+	assert appkit_impl_source.contains('touch.normalizedPosition')
+	assert appkit_impl_source.contains('event->touch_changed[index] = changed ? 1 : 0;')
+	assert appkit_impl_source.contains('#include <IOKit/hidsystem/IOLLEvent.h>')
+	assert appkit_impl_source.contains('v_multiwindow_appkit_modifier_flag_for_key_code')
+	assert appkit_impl_source.contains('v_multiwindow_appkit_modifier_key_is_pressed')
+	assert appkit_impl_source.contains('NX_DEVICELSHIFTKEYMASK')
+	assert appkit_impl_source.contains('NX_DEVICERSHIFTKEYMASK')
+	assert appkit_impl_source.contains('NX_DEVICELCTLKEYMASK')
+	assert appkit_impl_source.contains('NX_DEVICERCTLKEYMASK')
+	assert appkit_impl_source.contains('NX_DEVICELALTKEYMASK')
+	assert appkit_impl_source.contains('NX_DEVICERALTKEYMASK')
+	assert appkit_impl_source.contains('NX_DEVICELCMDKEYMASK')
+	assert appkit_impl_source.contains('NX_DEVICERCMDKEYMASK')
+	flags_changed_start := appkit_impl_source.index('- (void)flagsChanged:(NSEvent *)event') or {
+		assert false, 'AppKit view does not implement flagsChanged:'
+		0
+	}
+	flags_changed_body := appkit_impl_source[flags_changed_start..].all_before('@end')
+	key_down_body :=
+		appkit_impl_source.all_after('- (void)keyDown:(NSEvent *)event').all_before('- (BOOL)performKeyEquivalent:(NSEvent *)event')
+	assert flags_changed_body.contains('uint32_t oldFlags = state.flagsChangedStore;')
+	assert flags_changed_body.contains('uint32_t newFlags = (uint32_t)event.modifierFlags;')
+	assert flags_changed_body.contains('state.flagsChangedStore = newFlags;')
+	assert flags_changed_body.contains('v_multiwindow_appkit_modifier_key_is_pressed((NSEventModifierFlags)oldFlags')
+	assert flags_changed_body.contains('v_multiwindow_appkit_modifier_key_is_pressed((NSEventModifierFlags)newFlags')
+	assert flags_changed_body.contains('wasPressed == isPressed')
+	assert flags_changed_body.contains('[state setKeyDown:isPressed forKeyCode:keyCode]')
+	assert flags_changed_body.contains('isPressed ? V_MULTIWINDOW_APPKIT_INPUT_KEY_DOWN')
+	assert !flags_changed_body.contains('wasKeyDown')
+	assert !flags_changed_body.contains('isKeyDownForKeyCode')
+	assert !flags_changed_body.contains('v_multiwindow_appkit_key_code_is_sided_modifier')
+	assert appkit_impl_source.contains('event.isARepeat')
+	assert appkit_impl_source.contains('event.characters')
+	assert key_down_body.contains('[state queueKeyEvent:V_MULTIWINDOW_APPKIT_INPUT_KEY_DOWN')
+	assert key_down_body.contains('if ((modifiers & 8u) == 0) {')
+	assert key_down_body.contains('[state queueCharEventsFromString:event.characters')
+	assert key_down_body.contains('if (modifiers == 8 && keyCode == 86) {')
+	assert key_down_body.contains('V_MULTIWINDOW_APPKIT_INPUT_CLIPBOARD_PASTED')
+	assert_source_order(key_down_body, '[state queueKeyEvent:V_MULTIWINDOW_APPKIT_INPUT_KEY_DOWN',
+		'if ((modifiers & 8u) == 0) {')
+	assert_source_order(key_down_body, 'if ((modifiers & 8u) == 0) {',
+		'[state queueCharEventsFromString:event.characters')
+	assert_source_order(key_down_body, '[state queueCharEventsFromString:event.characters',
+		'if (modifiers == 8 && keyCode == 86) {')
+	assert appkit_impl_source.contains('v_multiwindow_appkit_keycodes')
+	assert !appkit_impl_source.contains('nextKeyDownStateForKeyCode')
+}
+
+fn test_appkit_macos_cgen_emits_record_and_literal_input_mapping() {
+	c_source := multiwindow_emit_macos_multiwindow_test_c()
+	assert_source_order(c_source,
+		'typedef struct x__multiwindow__AppKitWindowRecord x__multiwindow__AppKitWindowRecord;',
+		'VV_LOC _option_x__multiwindow__QueuedEvent x__multiwindow__appkit_queued_event_from_native(')
+	assert_source_order(c_source, 'struct x__multiwindow__AppKitWindowRecord {',
+		'VV_LOC _option_x__multiwindow__QueuedEvent x__multiwindow__appkit_queued_event_from_native(')
+	forbidden_const_prefix := '_const_x__multiwindow__' + 'appkit_'
+	assert !c_source.contains(forbidden_const_prefix)
 }
 
 fn test_appkit_create_destroy_on_darwin() {
@@ -1319,6 +2047,7 @@ fn test_x11_capabilities_for_backend_do_not_require_display_on_linux() {
 		assert caps.owner_queue
 		assert caps.x11
 		assert !caps.explicit_swapchain
+		assert_x11_input_capabilities(caps)
 	} $else {
 		capabilities_for_backend(.x11) or {
 			assert err.msg() == err_backend_unsupported
@@ -1486,6 +2215,215 @@ fn test_x11_backend_native_deps_are_flag_gated_source_guard() {
 		'#include <X11/Xlib.h>')
 }
 
+fn test_x11_input_support_queues_key_char_and_focus_source_guard() {
+	backend_source := multiwindow_source_file('backend.v')
+	x11_backend_source := multiwindow_source_file('x11_backend.c.v')
+	x11_helper_source := multiwindow_source_file('x11_egl_backend_helpers.h')
+
+	assert backend_source.contains('.x11 {\n\t\t\treturn backend.x11.poll_queued_events()!')
+	assert x11_backend_source.contains('input_events:       true')
+	assert x11_backend_source.contains('mouse_events:       true')
+	assert x11_backend_source.contains('keyboard_events:    true')
+	assert x11_backend_source.contains('text_events:        true')
+	assert x11_backend_source.contains('focus_events:       true')
+	assert x11_backend_source.contains('drop_events:        true')
+	assert x11_backend_source.contains('touch_events:       false')
+	assert x11_backend_source.contains('.clipboard_pasted')
+	assert x11_backend_source.contains('x11_is_clipboard_paste')
+	assert x11_backend_source.contains('const x11_modifier_ctrl = u32(2)')
+	assert x11_backend_source.contains('const x11_key_v = 86')
+	assert x11_helper_source.contains('XkbSetDetectableAutoRepeat')
+	assert x11_helper_source.contains('v_multiwindow_x11_is_auto_repeat_release')
+	assert x11_helper_source.contains('XPeekEvent(display, &next)')
+	assert x11_backend_source.contains('C.v_multiwindow_x11_enable_detectable_auto_repeat(display)')
+	assert x11_backend_source.contains('C.v_multiwindow_x11_is_auto_repeat_release(backend.display, &event) != 0')
+	x11_paste_body :=
+		x11_backend_source.all_after('fn x11_is_clipboard_paste').all_before('$if linux && x_multiwindow_x11 ?')
+	assert x11_paste_body.contains('return key_code == x11_key_v && modifiers == x11_modifier_ctrl')
+	assert !x11_paste_body.contains('keyboard_modifiers')
+	for required_xdnd in ['XdndAware', 'XdndEnter', 'XdndPosition', 'XdndStatus', 'XdndActionCopy',
+		'XdndDrop', 'XdndLeave', 'XdndFinished', 'XdndSelection', 'XdndTypeList', 'text/uri-list'] {
+		assert x11_backend_source.contains(required_xdnd)
+	}
+	assert x11_backend_source.contains('announce_xdnd_for_window')
+	assert x11_backend_source.contains('C.XChangeProperty')
+	assert x11_backend_source.contains('C.XConvertSelection')
+	assert x11_backend_source.contains('C.XSendEvent')
+	assert x11_backend_source.contains('C.XFilterEvent(&event, X11NativeWindow(0))')
+	assert_source_order(x11_backend_source, 'C.XNextEvent(backend.display, &event)',
+		'C.XFilterEvent(&event, X11NativeWindow(0))')
+	assert_source_order(x11_backend_source, 'C.XFilterEvent(&event, X11NativeWindow(0))',
+		'event_type := unsafe { event.@type }')
+	assert x11_backend_source.contains('queued_xdnd_client_message_events')
+	assert x11_backend_source.contains('queued_xdnd_selection_events')
+	assert x11_backend_source.contains('send_xdnd_status')
+	assert x11_backend_source.contains('send_xdnd_finished')
+	assert x11_backend_source.contains('.files_dropped')
+	assert x11_backend_source.contains('dropped_files_from_uri_list(payload)')
+	assert x11_backend_source.contains('const x11_xdnd_max_payload_bytes = 1024 * 1024')
+	assert x11_backend_source.contains('const x11_xdnd_max_payload_units = (x11_xdnd_max_payload_bytes + 3) / 4')
+	assert x11_backend_source.contains('const x11_xdnd_max_type_atoms = 64')
+	assert x11_backend_source.contains('fn (mut backend X11Backend) poll_queued_events')
+	assert x11_backend_source.contains('queued_input_event')
+	assert x11_backend_source.contains('C.v_multiwindow_x11_is_notify_grab_or_ungrab')
+	assert x11_backend_source.contains('queued_key_press_event')
+	assert x11_backend_source.contains('queued_key_release_event')
+	assert_source_order(x11_backend_source, 'events << queued_input_event(input)',
+		'events << queued_input_event(backend.input_char_event')
+	assert x11_backend_source.contains('fn (backend &X11Backend) input_char_event')
+	assert x11_backend_source.contains('const x11_inline_char_codes = 8')
+	assert x11_backend_source.contains('fn (backend &X11Backend) append_key_press_char_events')
+	assert x11_backend_source.contains('required_codes &int')
+	assert !x11_backend_source.contains('const x11_max_char_codes = 32768')
+	assert !x11_backend_source.contains('[]u32{len: x11_max_char_codes}')
+	assert x11_helper_source.contains('required_codes != NULL')
+	assert x11_helper_source.contains('*required_codes = total_count')
+	assert x11_helper_source.contains('out_count < codes_len')
+	handle_xdnd_position_body :=
+		x11_backend_source.all_after('fn (mut backend X11Backend) handle_xdnd_position').all_before('fn (mut backend X11Backend) handle_xdnd_drop')
+	update_xdnd_mouse_position_body :=
+		x11_backend_source.all_after('fn (mut backend X11Backend) update_xdnd_mouse_position').all_before('fn (mut backend X11Backend) queued_xdnd_selection_events')
+	assert handle_xdnd_position_body.contains('backend.update_xdnd_mouse_position(event)')
+	assert_source_order(handle_xdnd_position_body, 'backend.update_xdnd_mouse_position(event)',
+		'backend.send_xdnd_status')
+	assert update_xdnd_mouse_position_body.contains('root_x, root_y := x11_xdnd_position_coords(unsafe { event.xclient.data.l[2] })')
+	assert update_xdnd_mouse_position_body.contains('C.XTranslateCoordinates')
+	assert x11_backend_source.contains('fn x11_xdnd_position_coords(value X11NativeLong) (int, int)')
+	assert x11_backend_source.contains('return x11_signed_16(packed >> 16), x11_signed_16(packed)')
+	assert x11_backend_source.contains('fn x11_signed_16(value u32) int')
+	xdnd_selection_body :=
+		x11_backend_source.all_after('fn (mut backend X11Backend) queued_xdnd_selection_events').all_before('fn (mut backend X11Backend) xdnd_format_from_type_list')
+	xdnd_reject_body :=
+		xdnd_selection_body.all_after('if !valid_payload {').all_before('payload :=')
+	assert xdnd_selection_body.contains('status := C.XGetWindowProperty')
+	assert xdnd_selection_body.contains('X11NativeLong(x11_xdnd_max_payload_units)')
+	assert !xdnd_selection_body.contains('X11NativeLong(0x7fffffff)')
+	assert xdnd_selection_body.contains('status == x11_success')
+	assert xdnd_selection_body.contains('actual_type == backend.text_uri_list')
+	assert xdnd_selection_body.contains('actual_format == 8')
+	assert xdnd_selection_body.contains('bytes_after == X11NativeULong(0)')
+	assert xdnd_selection_body.contains('item_count <= X11NativeULong(x11_xdnd_max_payload_bytes)')
+	assert xdnd_reject_body.contains('C.XFree(data)')
+	assert xdnd_reject_body.contains('backend.send_xdnd_finished(requestor, false)')
+	assert xdnd_reject_body.contains('backend.clear_xdnd_state()')
+	assert xdnd_reject_body.contains('return events')
+	assert_source_order(xdnd_selection_body, 'if !valid_payload {',
+		'dropped_files_from_uri_list(payload)')
+	xdnd_type_list_body :=
+		x11_backend_source.all_after('fn (mut backend X11Backend) xdnd_format_from_type_list').all_before('fn (backend &X11Backend) send_xdnd_status')
+	xdnd_type_list_reject_body :=
+		xdnd_type_list_body.all_after('if !valid_type_list {').all_before('mut result := X11NativeAtom(0)')
+	assert xdnd_type_list_body.contains('status := C.XGetWindowProperty')
+	assert xdnd_type_list_body.contains('X11NativeLong(x11_xdnd_max_type_atoms)')
+	assert !xdnd_type_list_body.contains('X11NativeLong(0x7fffffff)')
+	assert xdnd_type_list_body.contains('status == x11_success')
+	assert xdnd_type_list_body.contains('actual_type == X11NativeAtom(4)')
+	assert xdnd_type_list_body.contains('actual_format == 32')
+	assert xdnd_type_list_body.contains('bytes_after == X11NativeULong(0)')
+	assert xdnd_type_list_body.contains('formats != unsafe { nil }')
+	assert xdnd_type_list_body.contains('item_count <= X11NativeULong(x11_xdnd_max_type_atoms)')
+	assert xdnd_type_list_reject_body.contains('C.XFree(formats)')
+	assert xdnd_type_list_reject_body.contains('return X11NativeAtom(0)')
+	key_press_body :=
+		x11_backend_source.all_after('fn (mut backend X11Backend) queued_key_press_event').all_before('fn (mut backend X11Backend) queued_key_release_event')
+	assert !key_press_body.contains('if key_code == 0 {\n\t\t\treturn events\n\t\t}')
+	assert key_press_body.contains('if key_code != 0 {')
+	assert key_press_body.contains('mut inline_char_codes := [x11_inline_char_codes]u32{}')
+	assert key_press_body.contains('mut required_char_codes := 0')
+	assert key_press_body.contains('required_char_codes > x11_inline_char_codes')
+	assert key_press_body.contains('mut char_codes := []u32{len: required_char_codes}')
+	assert key_press_body.contains('C.v_multiwindow_x11_char_codes(record.xic, event,')
+	assert key_press_body.contains('for i in 0 .. char_count')
+	focus_out_body :=
+		x11_backend_source.all_after('x11_focus_out {').all_before('x11_property_notify {')
+	clear_input_state_body :=
+		x11_backend_source.all_after('fn (mut backend X11Backend) clear_input_state').all_before('fn (mut backend X11Backend) queued_key_press_event')
+	assert focus_out_body.contains('backend.clear_input_state(index)')
+	assert_source_order(focus_out_body, 'C.v_multiwindow_x11_unset_ic_focus',
+		'backend.clear_input_state(index)')
+	assert_source_order(focus_out_body, 'backend.clear_input_state(index)', '.unfocused')
+	assert clear_input_state_body.contains('backend.windows[index].mouse_buttons = 0')
+	assert clear_input_state_body.contains('backend.windows[index].key_repeat[i] = false')
+	assert_source_order(x11_backend_source, 'events << queued_input_event(input)',
+		'.clipboard_pasted')
+	assert_source_order(x11_backend_source, '.clipboard_pasted',
+		'events << queued_input_event(backend.input_char_event')
+	assert x11_backend_source.contains('queued_button_press_event')
+	assert x11_backend_source.contains('queued_button_release_event')
+	assert x11_backend_source.contains('queued_mouse_position_event')
+	assert x11_backend_source.contains('mouse_buttons')
+	assert x11_backend_source.contains('wm_state')
+	assert x11_backend_source.contains('window_state')
+	assert x11_backend_source.contains('x11_property_notify')
+	assert x11_backend_source.contains('C.v_multiwindow_x11_property_atom')
+	assert x11_backend_source.contains('C.v_multiwindow_x11_property_state')
+	assert x11_backend_source.contains('x11_property_new_value')
+	assert x11_backend_source.contains('x11_iconic_state')
+	assert x11_backend_source.contains('.iconified')
+	assert x11_backend_source.contains('x11_normal_state')
+	assert x11_backend_source.contains('.restored')
+	assert x11_backend_source.contains('fn (backend &X11Backend) window_state(window X11NativeWindow) int')
+	assert x11_backend_source.contains('C.XGetWindowProperty')
+	assert x11_backend_source.contains('C.XFree')
+	window_state_body :=
+		x11_backend_source.all_after('fn (backend &X11Backend) window_state(window X11NativeWindow) int').all_before('fn (mut backend X11Backend) announce_xdnd_for_window')
+	assert window_state_body.contains('mut state := &X11NativeLong(unsafe { nil })')
+	assert window_state_body.contains('status := C.XGetWindowProperty')
+	assert window_state_body.contains('status == x11_success')
+	assert window_state_body.contains('actual_type == backend.wm_state')
+	assert window_state_body.contains('actual_format == 32')
+	assert window_state_body.contains('item_count >= X11NativeULong(2)')
+	assert window_state_body.contains('state != unsafe { nil }')
+	assert window_state_body.contains('state_value := unsafe { state[0] }')
+	assert !window_state_body.contains('*(&u32(state))')
+
+	for required_mask in ['StructureNotifyMask', 'KeyPressMask', 'KeyReleaseMask',
+		'PointerMotionMask', 'ButtonPressMask', 'ButtonReleaseMask', 'FocusChangeMask',
+		'EnterWindowMask', 'LeaveWindowMask', 'PropertyChangeMask'] {
+		assert x11_helper_source.contains(required_mask)
+	}
+	assert x11_helper_source.contains('PropertyNotify')
+	assert x11_helper_source.contains('v_multiwindow_x11_property_atom')
+	assert x11_helper_source.contains('v_multiwindow_x11_property_state')
+	assert x11_helper_source.contains('v_multiwindow_x11_event_window')
+	assert x11_helper_source.contains('v_multiwindow_x11_modifiers')
+	assert x11_helper_source.contains('Button1Mask')
+	assert x11_helper_source.contains('Button2Mask')
+	assert x11_helper_source.contains('Button3Mask')
+	assert x11_helper_source.contains('v_multiwindow_x11_key_code')
+	assert x11_helper_source.contains('XLookupKeysym')
+	assert x11_helper_source.contains('v_multiwindow_x11_open_im')
+	assert x11_helper_source.contains('XSetLocaleModifiers')
+	assert x11_helper_source.contains('XOpenIM')
+	assert x11_helper_source.contains('v_multiwindow_x11_create_ic')
+	assert x11_helper_source.contains('XCreateIC')
+	assert x11_helper_source.contains('XNInputStyle')
+	assert x11_helper_source.contains('XIMPreeditNothing | XIMStatusNothing')
+	assert x11_helper_source.contains('v_multiwindow_x11_destroy_ic')
+	assert x11_helper_source.contains('XDestroyIC')
+	assert x11_helper_source.contains('v_multiwindow_x11_set_ic_focus')
+	assert x11_helper_source.contains('XSetICFocus')
+	assert x11_helper_source.contains('v_multiwindow_x11_unset_ic_focus')
+	assert x11_helper_source.contains('XUnsetICFocus')
+	assert x11_helper_source.contains('v_multiwindow_x11_char_codes')
+	assert x11_helper_source.contains('Xutf8LookupString')
+	assert x11_helper_source.contains('XBufferOverflow')
+	assert x11_helper_source.contains('V_MULTIWINDOW_X11_XIM_STACK_BYTES')
+	assert x11_helper_source.contains('V_MULTIWINDOW_X11_XIM_MAX_BYTES')
+	assert x11_helper_source.contains('char stack_buf[V_MULTIWINDOW_X11_XIM_STACK_BYTES]')
+	assert x11_helper_source.contains('buf = (char *)malloc((size_t)count)')
+	assert x11_helper_source.contains('free(buf)')
+	assert_source_order(x11_helper_source, 'status == XBufferOverflow', 'malloc((size_t)count)')
+	assert_source_order_after_marker(x11_helper_source, 'buf = (char *)malloc((size_t)count)',
+		'status = 0', 'count = Xutf8LookupString')
+	assert x11_helper_source.contains('v_multiwindow_x11_decode_utf8_codes')
+	assert x11_helper_source.contains('v_multiwindow_x11_utf8_decode_next')
+	assert !x11_helper_source.contains('char buf[128]')
+	assert !x11_helper_source.contains('v_multiwindow_x11_utf8_decode_one')
+	assert !x11_helper_source.contains('XLookupString')
+	assert !x11_helper_source.contains('v_multiwindow_x11_keysym_to_unicode')
+}
+
 fn test_x11_config_hints_are_applied_before_mapping() {
 	x11_backend_source := multiwindow_source_file('x11_backend.c.v')
 	x11_helper_source := multiwindow_source_file('x11_egl_backend_helpers.h')
@@ -1525,6 +2463,7 @@ fn test_wayland_capabilities_for_backend_do_not_require_display_on_linux() {
 			assert caps.wayland
 			assert !caps.x11
 			assert !caps.explicit_swapchain
+			assert_wayland_input_capabilities(caps)
 		} $else {
 			capabilities_for_backend(.wayland) or {
 				assert err.msg() == err_backend_unsupported
@@ -1576,6 +2515,761 @@ fn test_wayland_initial_size_is_clamped_before_mapping() {
 		'C.wl_surface_commit(surface)')
 }
 
+fn test_wayland_lifecycle_windows_attach_shm_buffer_source_guard() {
+	wayland_source := multiwindow_source_file('wayland_backend.c.v')
+	wayland_helper_source := multiwindow_source_file('wayland_backend_helpers.h')
+	create_window_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) create_window').all_before('fn (mut backend WaylandBackend) destroy_window')
+	poll_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) poll_queued_events').all_before('fn (mut record WaylandWindowRecord) enqueue_native_event')
+	lifecycle_buffer_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) ensure_lifecycle_buffer').all_before('fn (mut backend WaylandBackend) close_connection')
+	release_buffer_body :=
+		wayland_source.all_after('fn (mut record WaylandWindowRecord) release_fallback_buffer').all_before('fn (mut backend WaylandBackend) close_connection')
+
+	assert wayland_source.contains('shm                          voidptr')
+	assert wayland_source.contains('fallback_buffers')
+	assert wayland_source.contains('fallback_current_buffer')
+	assert wayland_source.contains('const wayland_max_fallback_buffers = 3')
+	assert wayland_source.contains('C.v_multiwindow_wayland_bind_shm')
+	assert wayland_source.contains('fn (mut backend WaylandBackend) ensure_lifecycle_buffer')
+	assert wayland_source.contains('C.v_multiwindow_wayland_create_shm_buffer')
+	assert wayland_source.contains('C.v_multiwindow_wayland_attach_buffer')
+	assert wayland_source.contains('C.v_multiwindow_wayland_add_buffer_listener')
+	assert wayland_source.contains('C.v_multiwindow_wayland_buffer_destroy')
+	assert wayland_source.contains("@[export: 'v_multiwindow_wayland_buffer_release']")
+	assert wayland_source.contains('fn (mut record WaylandWindowRecord) release_fallback_buffer')
+	assert lifecycle_buffer_body.contains('record := backend.windows[index]')
+	assert lifecycle_buffer_body.contains('if record.fallback_buffer_width == width && record.fallback_buffer_height == height {')
+	assert !lifecycle_buffer_body.contains('&& record.fallback_current_buffer != unsafe { nil }')
+	assert lifecycle_buffer_body.contains('record.fallback_buffers.len >= wayland_max_fallback_buffers')
+	assert lifecycle_buffer_body.contains('C.v_multiwindow_wayland_add_buffer_listener')
+	assert lifecycle_buffer_body.contains('backend.windows[index].fallback_buffers << buffer')
+	assert lifecycle_buffer_body.contains('backend.windows[index].fallback_current_buffer = buffer')
+	assert lifecycle_buffer_body.contains('backend.windows[index].fallback_buffer_width = width')
+	assert lifecycle_buffer_body.contains('backend.windows[index].fallback_buffer_height = height')
+	assert !lifecycle_buffer_body.contains('mut record := backend.windows[index]')
+	assert !lifecycle_buffer_body.contains('record.fallback_buffers << buffer')
+	assert !lifecycle_buffer_body.contains('record.fallback_buffer_width = width')
+	assert !lifecycle_buffer_body.contains('record.fallback_buffer_height = height')
+	assert lifecycle_buffer_body.contains('record.fallback_buffers.delete(i)')
+	assert release_buffer_body.contains('record.fallback_current_buffer = unsafe { nil }')
+	assert !release_buffer_body.contains('record.fallback_buffer_width = 0')
+	assert !release_buffer_body.contains('record.fallback_buffer_height = 0')
+	assert_source_order(lifecycle_buffer_body, 'C.v_multiwindow_wayland_add_buffer_listener',
+		'C.v_multiwindow_wayland_attach_buffer')
+	assert create_window_body.contains('if !backend.renderer_ready()')
+	assert create_window_body.contains('backend.ensure_lifecycle_buffer(index) or {')
+	assert_source_order(create_window_body, 'C.wl_display_roundtrip(display)',
+		'backend.ensure_lifecycle_buffer(index)')
+	assert_source_order(create_window_body, 'backend.ensure_lifecycle_buffer(index)',
+		'return WindowSize')
+	assert poll_body.contains('backend.ensure_lifecycle_buffers()!')
+	assert_source_order(poll_body, 'backend.dispatch_pending_nonblocking()!',
+		'backend.ensure_lifecycle_buffers()!')
+	assert_source_order(poll_body, 'backend.ensure_lifecycle_buffers()!',
+		'backend.drain_pending_data_offer_drop()')
+
+	for required_helper in ['v_multiwindow_wayland_create_shm_buffer', 'wl_shm_create_pool',
+		'wl_shm_pool_create_buffer', 'WL_SHM_FORMAT_XRGB8888', 'v_multiwindow_wayland_attach_buffer',
+		'wl_buffer_listener', 'wl_buffer_add_listener',
+		'v_multiwindow_wayland_buffer_release_trampoline',
+		'v_multiwindow_wayland_add_buffer_listener', 'wl_surface_attach', 'wl_surface_damage',
+		'wl_surface_commit', 'v_multiwindow_wayland_buffer_destroy'] {
+		assert wayland_helper_source.contains(required_helper)
+	}
+}
+
+fn test_wayland_server_side_decorations_are_requested_source_guard() {
+	wayland_source := multiwindow_source_file('wayland_backend.c.v')
+	wayland_helper_source := multiwindow_source_file('wayland_backend_helpers.h')
+	decoration_private_source := multiwindow_source_file('wayland_xdg_decoration_private.c')
+	create_window_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) create_window').all_before('fn (mut backend WaylandBackend) destroy_window')
+	destroy_window_record_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) destroy_window_record').all_before('fn (mut backend WaylandBackend) ensure_data_device')
+	decoration_configure_body :=
+		wayland_source.all_after("@[export: 'v_multiwindow_wayland_xdg_toplevel_decoration_configure']").all_before("@[export: 'v_multiwindow_wayland_seat_capabilities']")
+	decorated_window_body :=
+		wayland_source.all_after('fn (backend &WaylandBackend) has_server_side_decorated_window').all_before('fn (backend &WaylandBackend) window_native_decorations')
+	window_native_decorations_body :=
+		wayland_source.all_after('fn (backend &WaylandBackend) window_native_decorations').all_before('fn (record &WaylandWindowRecord) has_server_side_decoration')
+	server_side_decoration_body :=
+		wayland_source.all_after('fn (record &WaylandWindowRecord) has_server_side_decoration').all_before('fn (record &WaylandWindowRecord) has_client_side_decoration')
+	client_side_decoration_body :=
+		wayland_source.all_after('fn (record &WaylandWindowRecord) has_client_side_decoration').all_before('fn (mut backend WaylandBackend) start')
+
+	assert wayland_source.contains('wayland_xdg_decoration_private.c')
+	assert decoration_private_source.contains('#define xdg_toplevel_interface v_multiwindow_xdg_toplevel_interface')
+	assert decoration_private_source.contains('#define zxdg_decoration_manager_v1_interface v_multiwindow_zxdg_decoration_manager_v1_interface')
+	assert decoration_private_source.contains('#define zxdg_toplevel_decoration_v1_interface v_multiwindow_zxdg_toplevel_decoration_v1_interface')
+	assert decoration_private_source.contains('#include "xdg-decoration-unstable-v1-protocol.c"')
+
+	assert wayland_source.contains('toplevel_decoration')
+	assert wayland_source.contains('toplevel_decoration_configured bool')
+	assert wayland_source.contains('toplevel_decoration_mode')
+	assert wayland_source.contains('decoration_manager           voidptr')
+	assert wayland_source.contains('C.v_multiwindow_wayland_bind_xdg_decoration_manager')
+	assert wayland_source.contains("C.strcmp(iface, c'zxdg_decoration_manager_v1') == 0")
+	assert wayland_source.contains('backend.destroy_xdg_decoration_manager()')
+	assert wayland_source.contains("v_multiwindow_wayland_xdg_toplevel_decoration_configure']")
+	assert decoration_configure_body.contains('mode u32')
+	assert decoration_configure_body.contains('mut record := unsafe { &WaylandWindowRecord(data) }')
+	assert decoration_configure_body.contains('record.toplevel_decoration_configured = true')
+	assert decoration_configure_body.contains('record.toplevel_decoration_mode = mode')
+	assert decoration_configure_body.contains('record.toplevel_decoration_mode = wayland_xdg_toplevel_decoration_mode_client_side')
+	assert wayland_helper_source.contains('v_multiwindow_zxdg_decoration_manager_v1_interface')
+	assert wayland_helper_source.contains('v_multiwindow_zxdg_toplevel_decoration_v1_interface')
+	assert wayland_helper_source.contains('void v_multiwindow_wayland_xdg_toplevel_decoration_configure(void *data, void *decoration, uint32_t mode);')
+	assert wayland_helper_source.contains('v_multiwindow_wayland_xdg_toplevel_decoration_configure_trampoline')
+	assert wayland_helper_source.contains('v_multiwindow_wayland_xdg_toplevel_decoration_configure(data, (void *)decoration, mode);')
+	assert !wayland_helper_source.contains('(void)data;\n\t(void)decoration;\n\t(void)mode;')
+	assert wayland_helper_source.contains('v_multiwindow_wayland_xdg_toplevel_decoration_set_server_side')
+	assert wayland_helper_source.contains('ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE')
+	assert wayland_helper_source.contains('ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE')
+
+	assert create_window_body.contains('if !config.borderless && backend.decoration_manager != unsafe { nil }')
+	assert create_window_body.contains('C.v_multiwindow_wayland_xdg_decoration_manager_get_toplevel_decoration')
+	assert create_window_body.contains('C.v_multiwindow_wayland_add_xdg_toplevel_decoration_listener')
+	assert create_window_body.contains('C.v_multiwindow_wayland_xdg_toplevel_decoration_set_server_side(decoration)')
+	assert create_window_body.contains('record.toplevel_decoration = unsafe { voidptr(decoration) }')
+	assert_source_order(create_window_body,
+		'C.v_multiwindow_wayland_xdg_toplevel_decoration_set_server_side(decoration)',
+		'C.wl_surface_commit(surface)')
+	assert destroy_window_record_body.contains('C.v_multiwindow_wayland_xdg_toplevel_decoration_destroy')
+	assert_source_order(destroy_window_record_body,
+		'C.v_multiwindow_wayland_xdg_toplevel_decoration_destroy',
+		'C.v_multiwindow_wayland_xdg_toplevel_destroy')
+	assert wayland_source.contains('fn (backend &WaylandBackend) has_server_side_decorated_window() bool')
+	assert wayland_source.contains('fn (backend &WaylandBackend) window_native_decorations(id WindowId) !bool')
+	assert wayland_source.contains('fn (record &WaylandWindowRecord) has_server_side_decoration() bool')
+	assert wayland_source.contains('fn (record &WaylandWindowRecord) has_client_side_decoration() bool')
+	assert decorated_window_body.contains('mut has_server_side := false')
+	assert decorated_window_body.contains('if record.has_client_side_decoration()')
+	assert decorated_window_body.contains('return false')
+	assert decorated_window_body.contains('has_server_side = true')
+	assert decorated_window_body.contains('return has_server_side')
+	assert window_native_decorations_body.contains('return backend.windows[index].has_server_side_decoration()')
+	assert server_side_decoration_body.contains('record.toplevel_decoration_configured')
+	assert server_side_decoration_body.contains('wayland_xdg_toplevel_decoration_mode_server_side')
+	assert client_side_decoration_body.contains('record.toplevel_decoration == unsafe { nil }')
+	assert client_side_decoration_body.contains('wayland_xdg_toplevel_decoration_mode_client_side')
+}
+
+fn test_interactive_move_resize_core_source_guard() {
+	types_source := multiwindow_source_file('types.v')
+	app_source := multiwindow_source_file('app.v')
+	backend_source := multiwindow_source_file('backend.v')
+	move_backend_body :=
+		backend_source.all_after('fn (mut backend Backend) begin_window_move').all_before('fn (mut backend Backend) begin_window_resize')
+	resize_backend_body :=
+		backend_source.all_after('fn (mut backend Backend) begin_window_resize').all_before('fn (mut backend Backend) poll_events')
+
+	assert types_source.contains('pub enum WindowResizeEdge {')
+	for edge_name in ['top', 'bottom', 'left', 'right', 'top_left', 'top_right', 'bottom_left',
+		'bottom_right'] {
+		assert types_source.contains('\t${edge_name}')
+	}
+	assert types_source.contains('interactive_move_resize bool')
+	assert types_source.contains('native_decorations      bool')
+	assert app_source.contains('pub fn (mut app App) begin_window_move(id WindowId) !')
+	assert app_source.contains('pub fn (mut app App) begin_window_resize(id WindowId, edge WindowResizeEdge) !')
+	assert app_source.contains('if !app.windows[index].config.resizable')
+	assert move_backend_body.contains('.wayland { backend.wayland.begin_window_move(id)! }')
+	assert move_backend_body.contains('else { return error(err_capability_unsupported) }')
+	assert resize_backend_body.contains('.wayland { backend.wayland.begin_window_resize(id, edge)! }')
+	assert resize_backend_body.contains('else { return error(err_capability_unsupported) }')
+}
+
+fn test_cursor_shape_core_source_guard() {
+	types_source := multiwindow_source_file('types.v')
+	app_source := multiwindow_source_file('app.v')
+	backend_source := multiwindow_source_file('backend.v')
+	mock_source := multiwindow_source_file('mock_backend.v')
+	wayland_source := multiwindow_source_file('wayland_backend.c.v')
+	x11_source := multiwindow_source_file('x11_backend.c.v')
+	x11_helper_source := multiwindow_source_file('x11_egl_backend_helpers.h')
+	wayland_helper_source := multiwindow_source_file('wayland_backend_helpers.h')
+	wayland_cursor_private_source := multiwindow_source_file('wayland_cursor_shape_private.c')
+	win32_source := multiwindow_source_file('win32_backend.c.v')
+	win32_helper_source := multiwindow_source_file('win32_backend_helpers.h')
+	appkit_source := multiwindow_source_file('appkit_backend.c.v')
+	appkit_objc_source := multiwindow_source_file('appkit_backend.m')
+	appkit_helper_source := multiwindow_source_file('appkit_backend_helpers.h')
+	backend_cursor_body :=
+		backend_source.all_after('fn (mut backend Backend) set_window_cursor').all_before('fn (mut backend Backend) begin_window_move')
+	wayland_cursor_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) set_window_cursor').all_before('fn (mut backend WaylandBackend) begin_window_move')
+	wayland_registry_body :=
+		wayland_source.all_after('fn wayland_registry_handle_global').all_before("@[export: 'v_multiwindow_wayland_registry_handle_global_remove']")
+	wayland_seat_body :=
+		wayland_source.all_after("@[export: 'v_multiwindow_wayland_seat_capabilities']").all_before("@[export: 'v_multiwindow_wayland_seat_name']")
+	wayland_pointer_enter_body :=
+		wayland_source.all_after("@[export: 'v_multiwindow_wayland_pointer_enter']").all_before("@[export: 'v_multiwindow_wayland_pointer_leave']")
+	wayland_pointer_leave_body :=
+		wayland_source.all_after("@[export: 'v_multiwindow_wayland_pointer_leave']").all_before("@[export: 'v_multiwindow_wayland_pointer_motion']")
+	wayland_capabilities_body :=
+		wayland_source.all_after('fn (backend &WaylandBackend) capabilities() Capabilities').all_before('fn (backend &WaylandBackend) can_deliver_drop_events')
+	wayland_cursor_capability_body :=
+		wayland_source.all_after('fn (backend &WaylandBackend) can_set_cursor_shapes() bool').all_before('fn (backend &WaylandBackend) has_server_side_decorated_window')
+	wayland_cursor_shape_mapping_body :=
+		wayland_source.all_after('fn wayland_cursor_shape_for_shape').all_before('fn (mut backend WaylandBackend) begin_window_move')
+
+	assert types_source.contains('pub enum CursorShape {')
+	for shape_name in ['default', 'pointer', 'move', 'n_resize', 's_resize', 'e_resize', 'w_resize',
+		'ne_resize', 'nw_resize', 'se_resize', 'sw_resize', 'ew_resize', 'ns_resize', 'nesw_resize',
+		'nwse_resize', 'grab', 'grabbing'] {
+		assert types_source.contains('\t${shape_name}')
+	}
+	assert types_source.contains('cursor_shapes           bool')
+	assert app_source.contains('pub fn (mut app App) set_window_cursor(id WindowId, shape CursorShape) !')
+	assert app_source.contains('app.backend.set_window_cursor(id, shape)!')
+	assert backend_cursor_body.contains('.mock { backend.mock.set_window_cursor(id, shape)! }')
+	assert backend_cursor_body.contains('.x11 { backend.x11.set_window_cursor(id, shape)! }')
+	assert backend_cursor_body.contains('.wayland { backend.wayland.set_window_cursor(id, shape)! }')
+	assert backend_cursor_body.contains('.appkit { backend.appkit.set_window_cursor(id, shape)! }')
+	assert backend_cursor_body.contains('.win32 { backend.win32.set_window_cursor(id, shape)! }')
+	assert mock_source.contains('fn (mut backend MockBackend) set_window_cursor(id WindowId, shape CursorShape) !')
+	assert mock_source.contains('return error(err_capability_unsupported)')
+
+	assert wayland_source.contains('wayland_cursor_shape_private.c')
+	assert wayland_source.contains('cursor_shape_manager')
+	assert wayland_source.contains('cursor_shape_device')
+	assert wayland_source.contains('pointer_enter_serial')
+	assert wayland_source.contains('pointer_enter_serial_valid')
+	assert wayland_source.contains('const wayland_cursor_shape_default = u32(1)')
+	assert wayland_source.contains('const wayland_cursor_shape_pointer = u32(4)')
+	assert wayland_source.contains('const wayland_cursor_shape_move = u32(13)')
+	assert wayland_source.contains('const wayland_cursor_shape_nwse_resize = u32(29)')
+	assert wayland_capabilities_body.contains('cursor_shapes:           backend.can_set_cursor_shapes()')
+	assert wayland_cursor_capability_body.contains('return backend.pointer != unsafe { nil } && backend.cursor_shape_manager != unsafe { nil }')
+	assert wayland_cursor_capability_body.contains('&& backend.cursor_shape_device != unsafe { nil }')
+	assert !wayland_cursor_capability_body.contains('if !backend.started')
+	assert wayland_registry_body.contains("C.strcmp(iface, c'wp_cursor_shape_manager_v1') == 0")
+	assert wayland_registry_body.contains('C.v_multiwindow_wayland_bind_cursor_shape_manager')
+	assert wayland_registry_body.contains('backend.ensure_cursor_shape_device()')
+	assert wayland_source.contains('backend.destroy_cursor_shape_manager()')
+	assert wayland_seat_body.contains('backend.ensure_cursor_shape_device()')
+	assert wayland_seat_body.contains('backend.destroy_cursor_shape_device()')
+	assert wayland_pointer_enter_body.contains('backend.pointer_enter_serial = serial')
+	assert wayland_pointer_enter_body.contains('backend.pointer_enter_serial_valid = true')
+	assert !wayland_pointer_enter_body.contains('_ = serial')
+	assert wayland_pointer_leave_body.contains('backend.pointer_enter_serial_valid = false')
+	assert wayland_source.contains('fn (mut backend WaylandBackend) set_window_cursor(id WindowId, shape CursorShape) !')
+	assert wayland_cursor_body.contains('backend.window_record_index(id) or { return error(err_window_not_found) }')
+	assert wayland_cursor_body.contains('!backend.can_set_cursor_shapes() || !backend.pointer_focused')
+	assert wayland_cursor_body.contains('backend.pointer_focus != id || !backend.pointer_enter_serial_valid')
+	assert wayland_cursor_body.contains('C.v_multiwindow_wayland_cursor_shape_device_set_shape')
+	assert wayland_cursor_body.contains('backend.pointer_enter_serial')
+	assert wayland_cursor_body.contains('wayland_cursor_shape_for_shape(shape)')
+	assert wayland_cursor_body.contains('C.wl_display_flush(display)')
+	assert wayland_cursor_body.contains('return error(err_capability_unsupported)')
+	assert wayland_cursor_shape_mapping_body.contains('.pointer { wayland_cursor_shape_pointer }')
+	assert wayland_cursor_shape_mapping_body.contains('.move { wayland_cursor_shape_move }')
+	assert wayland_cursor_shape_mapping_body.contains('.ew_resize { wayland_cursor_shape_ew_resize }')
+	assert wayland_cursor_shape_mapping_body.contains('.nwse_resize { wayland_cursor_shape_nwse_resize }')
+	assert wayland_helper_source.contains('v_multiwindow_wp_cursor_shape_manager_v1_interface')
+	assert wayland_helper_source.contains('v_multiwindow_wayland_bind_cursor_shape_manager')
+	assert wayland_helper_source.contains('v_multiwindow_wayland_cursor_shape_manager_get_pointer')
+	assert wayland_helper_source.contains('v_multiwindow_wayland_cursor_shape_device_set_shape')
+	assert wayland_helper_source.contains('WP_CURSOR_SHAPE_DEVICE_V1_SET_SHAPE')
+	assert os.exists(os.join_path(@DIR, 'wayland_cursor_shape_private.c'))
+	assert wayland_cursor_private_source.contains('v_multiwindow_wp_cursor_shape_manager_v1_interface')
+	assert wayland_cursor_private_source.contains('v_multiwindow_wp_cursor_shape_device_v1_interface')
+	assert wayland_cursor_private_source.contains('"wp_cursor_shape_manager_v1"')
+	assert wayland_cursor_private_source.contains('"get_pointer"')
+	assert wayland_cursor_private_source.contains('"set_shape"')
+	assert !wayland_cursor_private_source.contains('zwp_tablet_tool_v2_interface')
+
+	assert x11_source.contains('cursor_shapes:      true')
+	assert x11_source.contains('fn (mut backend X11Backend) set_window_cursor(id WindowId, shape CursorShape) !')
+	assert x11_source.contains('C.XDefineCursor')
+	assert x11_helper_source.contains('#include <X11/cursorfont.h>')
+	assert x11_helper_source.contains('XCreateFontCursor')
+	assert x11_helper_source.contains('XC_hand2')
+	assert x11_helper_source.contains('XC_fleur')
+	assert x11_helper_source.contains('XC_sb_h_double_arrow')
+	assert x11_helper_source.contains('XC_sb_v_double_arrow')
+
+	assert win32_source.contains('cursor_shapes:      true')
+	assert win32_source.contains('fn (mut backend Win32Backend) set_window_cursor(id WindowId, shape CursorShape) !')
+	assert win32_helper_source.contains('WM_SETCURSOR')
+	assert win32_helper_source.contains('IDC_HAND')
+	assert win32_helper_source.contains('IDC_SIZEALL')
+	assert win32_helper_source.contains('IDC_SIZEWE')
+	assert win32_helper_source.contains('IDC_SIZENS')
+	assert win32_helper_source.contains('IDC_SIZENWSE')
+	assert win32_helper_source.contains('IDC_SIZENESW')
+
+	assert appkit_source.contains('cursor_shapes:      true')
+	assert appkit_source.contains('fn (mut backend AppKitBackend) set_window_cursor(id WindowId, shape CursorShape) !')
+	assert appkit_helper_source.contains('v_multiwindow_appkit_set_cursor_shape')
+	assert appkit_objc_source.contains('- (void)cursorUpdate:(NSEvent *)event')
+	assert appkit_objc_source.contains('[NSCursor pointingHandCursor]')
+	assert appkit_objc_source.contains('[NSCursor openHandCursor]')
+	assert appkit_objc_source.contains('[NSCursor resizeLeftRightCursor]')
+	assert appkit_objc_source.contains('[NSCursor resizeUpDownCursor]')
+}
+
+fn test_wayland_interactive_move_resize_source_guard() {
+	wayland_source := multiwindow_source_file('wayland_backend.c.v')
+	wayland_helper_source := multiwindow_source_file('wayland_backend_helpers.h')
+	decoration_private_source := multiwindow_source_file('wayland_xdg_decoration_private.c')
+	pointer_button_body :=
+		wayland_source.all_after("@[export: 'v_multiwindow_wayland_pointer_button']").all_before("@[export: 'v_multiwindow_wayland_pointer_axis']")
+	keyboard_key_body :=
+		wayland_source.all_after("@[export: 'v_multiwindow_wayland_keyboard_key']").all_before("@[export: 'v_multiwindow_wayland_keyboard_modifiers']")
+	touch_down_body :=
+		wayland_source.all_after("@[export: 'v_multiwindow_wayland_touch_down']").all_before("@[export: 'v_multiwindow_wayland_touch_up']")
+	resize_window_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) resize_window').all_before('fn (mut backend WaylandBackend) begin_window_move')
+	begin_move_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) begin_window_move').all_before('fn (mut backend WaylandBackend) begin_window_resize')
+	begin_resize_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) begin_window_resize').all_before('fn (mut backend WaylandBackend) poll_events')
+	edge_mapping_body :=
+		wayland_source.all_after('fn wayland_resize_edge(edge WindowResizeEdge) u32').all_before('fn wayland_is_clipboard_paste')
+
+	assert wayland_helper_source.contains('#define XDG_TOPLEVEL_MOVE 5')
+	assert wayland_helper_source.contains('#define XDG_TOPLEVEL_RESIZE 6')
+	assert wayland_helper_source.contains('v_multiwindow_wayland_xdg_toplevel_move')
+	assert wayland_helper_source.contains('v_multiwindow_wayland_xdg_toplevel_resize')
+	assert wayland_helper_source.contains('XDG_TOPLEVEL_MOVE')
+	assert wayland_helper_source.contains('XDG_TOPLEVEL_RESIZE')
+	for edge_constant in ['XDG_TOPLEVEL_RESIZE_EDGE_TOP', 'XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM',
+		'XDG_TOPLEVEL_RESIZE_EDGE_LEFT', 'XDG_TOPLEVEL_RESIZE_EDGE_RIGHT',
+		'XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT', 'XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT',
+		'XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT', 'XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT'] {
+		assert wayland_helper_source.contains(edge_constant)
+	}
+
+	assert edge_mapping_body.contains('.top { wayland_xdg_toplevel_resize_edge_top }')
+	assert edge_mapping_body.contains('.bottom { wayland_xdg_toplevel_resize_edge_bottom }')
+	assert edge_mapping_body.contains('.left { wayland_xdg_toplevel_resize_edge_left }')
+	assert edge_mapping_body.contains('.right { wayland_xdg_toplevel_resize_edge_right }')
+	assert edge_mapping_body.contains('.top_left { wayland_xdg_toplevel_resize_edge_top_left }')
+	assert edge_mapping_body.contains('.top_right { wayland_xdg_toplevel_resize_edge_top_right }')
+	assert edge_mapping_body.contains('.bottom_left { wayland_xdg_toplevel_resize_edge_bottom_left }')
+	assert edge_mapping_body.contains('.bottom_right { wayland_xdg_toplevel_resize_edge_bottom_right }')
+
+	assert !pointer_button_body.contains('_ = serial')
+	assert !pointer_button_body.contains('mut record := backend.windows[index]')
+	assert pointer_button_body.contains('backend.windows[index].store_user_action_serial(serial, backend.poll_generation)')
+	assert !keyboard_key_body.contains('_ = serial')
+	assert !keyboard_key_body.contains('mut record := backend.windows[index]')
+	assert keyboard_key_body.contains('backend.windows[index].store_user_action_serial(serial, backend.poll_generation)')
+	assert !touch_down_body.contains('_ = serial')
+	assert !touch_down_body.contains('mut record := backend.windows[index]')
+	assert touch_down_body.contains('backend.windows[index].store_user_action_serial(serial, backend.poll_generation)')
+	assert !begin_move_body.contains('mut record := backend.windows[index]')
+	assert !begin_resize_body.contains('mut record := backend.windows[index]')
+	assert begin_move_body.contains('serial := backend.windows[index].take_user_action_serial(backend.poll_generation) or {')
+	assert begin_resize_body.contains('serial := backend.windows[index].take_user_action_serial(backend.poll_generation) or {')
+	assert wayland_source.contains('fn (mut record WaylandWindowRecord) take_user_action_serial')
+	assert wayland_source.contains('fn (mut backend WaylandBackend) expire_user_action_serials')
+	assert wayland_source.contains('backend.poll_generation++')
+	assert wayland_source.contains('interactive_move_resize: backend.can_begin_interactive_move_resize()')
+	assert wayland_source.contains('native_decorations:      backend.has_server_side_decorated_window()')
+	assert !wayland_source.contains('native_decorations:      backend.decoration_manager != unsafe { nil }')
+
+	assert resize_window_body.contains('return error(err_capability_unsupported)')
+	assert begin_resize_body.contains('if !backend.windows[index].resizable')
+	assert begin_resize_body.contains('C.v_multiwindow_wayland_xdg_toplevel_resize')
+
+	for forbidden in ['gtk_shell1', 'xdg_toplevel_drag_manager_v1'] {
+		assert !wayland_source.contains(forbidden)
+		assert !wayland_helper_source.contains(forbidden)
+		assert !decoration_private_source.contains(forbidden)
+	}
+}
+
+fn test_wayland_input_support_is_queued_with_xkb_text_and_touch_source_guard() {
+	backend_source := multiwindow_source_file('backend.v')
+	wayland_source := multiwindow_source_file('wayland_backend.c.v')
+	wayland_helper_source := multiwindow_source_file('wayland_backend_helpers.h')
+	capabilities_body :=
+		wayland_source.all_after('fn (backend &WaylandBackend) capabilities() Capabilities').all_before('fn (backend &WaylandBackend) can_deliver_drop_events')
+
+	assert backend_source.contains('.wayland {\n\t\t\treturn backend.wayland.poll_queued_events()!')
+	assert wayland_source.contains('fn (mut backend WaylandBackend) poll_queued_events() ![]QueuedEvent')
+	assert wayland_source.contains('pending_events')
+	assert wayland_source.contains('[]QueuedEvent')
+	assert wayland_source.contains('queued_lifecycle_event')
+	assert wayland_source.contains('queued_input_event')
+	assert wayland_source.contains('events := backend.poll_queued_events()!')
+	assert !wayland_source.contains('resize_event_pending')
+	assert !wayland_source.contains('close_requested         bool')
+	assert !wayland_source.contains('mut close_requested_windows := []WindowId{}')
+
+	assert wayland_source.contains('input_events:            true')
+	assert wayland_source.contains('mouse_events:            true')
+	assert wayland_source.contains('keyboard_events:         true')
+	assert wayland_source.contains('text_events:             true')
+	assert wayland_source.contains('focus_events:            true')
+	assert capabilities_body.contains('drop_events:             backend.can_deliver_drop_events()')
+	assert capabilities_body.contains('touch_events:            backend.can_deliver_touch_events()')
+	assert capabilities_body.contains('interactive_move_resize: backend.can_begin_interactive_move_resize()')
+	assert wayland_source.contains('fn (backend &WaylandBackend) can_deliver_drop_events() bool')
+	assert wayland_source.contains('fn (backend &WaylandBackend) can_deliver_touch_events() bool')
+	assert wayland_source.contains('fn (backend &WaylandBackend) can_begin_interactive_move_resize() bool')
+	assert wayland_source.contains('return backend.seat != unsafe { nil } && backend.data_device_manager != unsafe { nil }')
+	assert wayland_source.contains('&& backend.data_device != unsafe { nil }')
+	assert wayland_source.contains('return backend.seat != unsafe { nil } && backend.touch != unsafe { nil }')
+	assert wayland_source.contains('return backend.seat != unsafe { nil } && backend.wm_base != unsafe { nil }')
+	assert wayland_source.contains('xkb_context_new')
+	assert wayland_source.contains('xkb_keymap_new_from_string')
+	assert wayland_source.contains('xkb_keymap_key_repeats')
+	assert wayland_source.contains('xkb_state_new')
+	assert wayland_source.contains('xkb_state_update_mask')
+	assert wayland_source.contains('xkb_state_key_get_utf8')
+	assert wayland_source.contains('wayland_keyboard_keymap')
+	keyboard_key_body :=
+		wayland_source.all_after("@[export: 'v_multiwindow_wayland_keyboard_key']").all_before("@[export: 'v_multiwindow_wayland_keyboard_modifiers']")
+	repeat_info_body :=
+		wayland_source.all_after("@[export: 'v_multiwindow_wayland_keyboard_repeat_info']").all_before("@[export: 'v_multiwindow_wayland_keyboard_key']")
+	repeat_handler_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) enqueue_due_key_repeats()').all_before('fn wayland_key_repeat_interval_ns')
+	start_repeat_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) start_key_repeat').all_before('fn (mut backend WaylandBackend) stop_key_repeat')
+	poll_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) poll_queued_events() ![]QueuedEvent').all_before('fn (mut record WaylandWindowRecord) enqueue_native_event')
+	keyboard_leave_body :=
+		wayland_source.all_after("@[export: 'v_multiwindow_wayland_keyboard_leave']").all_before("@[export: 'v_multiwindow_wayland_keyboard_keymap']")
+	clear_keys_down_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) clear_keys_down()').all_before('fn wayland_utf8_decode')
+	destroy_seat_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) destroy_seat_devices()').all_before('fn (mut backend WaylandBackend) destroy_window_record')
+	destroy_window_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) destroy_window_record').all_before('fn (mut backend WaylandBackend) destroy_data_offer')
+	repeat_trampoline_body :=
+		wayland_helper_source.all_after('v_multiwindow_wayland_keyboard_repeat_info_trampoline').all_before('static void v_multiwindow_wayland_touch_down_trampoline')
+	touch_event_body :=
+		wayland_source.all_after('fn (backend &WaylandBackend) touch_event_for_record').all_before('fn (backend &WaylandBackend) touch_cancel_event_for_record')
+	touch_cancel_body :=
+		wayland_source.all_after('fn (backend &WaylandBackend) touch_cancel_event_for_record').all_before('fn (backend &WaylandBackend) touch_mouse_position_for_record')
+	touch_mouse_position_body :=
+		wayland_source.all_after('fn (backend &WaylandBackend) touch_mouse_position_for_record').all_before('fn (mut record WaylandWindowRecord) update_mouse_position')
+	key_repeats_body :=
+		wayland_source.all_after('fn (backend &WaylandBackend) key_repeats(raw_key u32) bool').all_before('fn (backend &WaylandBackend) char_code_for_key')
+	assert keyboard_key_body.contains('backend.windows[index].input_char_event')
+	assert wayland_helper_source.contains('void v_multiwindow_wayland_keyboard_repeat_info(void *data, void *keyboard, int32_t rate, int32_t delay);')
+	assert repeat_trampoline_body.contains('v_multiwindow_wayland_keyboard_repeat_info(data, (void *)keyboard, rate, delay);')
+	assert wayland_source.contains("@[export: 'v_multiwindow_wayland_keyboard_repeat_info']")
+	assert wayland_source.contains('fn C.xkb_keymap_key_repeats(keymap &C.xkb_keymap, key u32) int')
+	assert key_repeats_body.contains('if backend.xkb_keymap == unsafe { nil }')
+	assert key_repeats_body.contains('C.xkb_keymap_key_repeats(unsafe { &C.xkb_keymap(backend.xkb_keymap) }')
+	assert key_repeats_body.contains('raw_key) != 0')
+	for repeat_field in ['keyboard_repeat_rate         int', 'keyboard_repeat_delay        int',
+		'keyboard_repeat_active       bool', 'keyboard_repeat_raw_key      u32',
+		'keyboard_repeat_key_code     int', 'keyboard_repeat_window       WindowId',
+		'keyboard_repeat_next_ns      u64', 'keyboard_repeat_interval_ns  u64'] {
+		assert wayland_source.contains(repeat_field)
+	}
+	assert !wayland_source.contains('keyboard_repeat_modifiers')
+	assert !wayland_source.contains('keyboard_repeat_char_code')
+	assert repeat_info_body.contains('backend.keyboard_repeat_rate = if rate > 0 { rate } else { 0 }')
+	assert repeat_info_body.contains('backend.keyboard_repeat_delay = if delay > 0 { delay } else { 0 }')
+	assert repeat_info_body.contains('if backend.keyboard_repeat_rate == 0 {')
+	assert repeat_info_body.contains('backend.stop_key_repeat()')
+	assert keyboard_key_body.contains('raw_key := key + 8')
+	assert keyboard_key_body.contains('backend.start_key_repeat(backend.windows[index], raw_key, key_code)')
+	assert keyboard_key_body.contains('backend.stop_key_repeat_for_key(raw_key)')
+	assert start_repeat_body.contains('if !backend.key_repeats(raw_key) {')
+	non_repeatable_body :=
+		start_repeat_body.all_after('if !backend.key_repeats(raw_key) {').all_before('if backend.keyboard_repeat_rate <= 0')
+	assert non_repeatable_body.contains('return')
+	assert !non_repeatable_body.contains('backend.stop_key_repeat()')
+	assert_source_order(start_repeat_body, 'if !backend.key_repeats(raw_key) {',
+		'backend.keyboard_repeat_active = true')
+	assert poll_body.contains('backend.enqueue_due_key_repeats()')
+	assert repeat_handler_body.contains('now := vtime.sys_mono_now()')
+	assert repeat_handler_body.contains('if now < backend.keyboard_repeat_next_ns {')
+	assert repeat_handler_body.contains('modifiers := backend.event_modifiers()')
+	assert !repeat_handler_body.contains('mut record := backend.windows[index]')
+	assert repeat_handler_body.contains('backend.windows[index].input_event_with_payload(.key_down')
+	assert repeat_handler_body.contains('backend.keyboard_repeat_key_code, true')
+	assert repeat_handler_body.contains('backend.windows[index].enqueue_native_event')
+	assert repeat_handler_body.contains('char_code := backend.char_code_for_key(backend.keyboard_repeat_raw_key)')
+	assert repeat_handler_body.contains('backend.windows[index].input_char_event(char_code, true')
+	assert repeat_handler_body.contains('backend.keyboard_repeat_next_ns += backend.keyboard_repeat_interval_ns')
+	assert repeat_handler_body.contains('if backend.keyboard_repeat_next_ns <= now {')
+	assert repeat_handler_body.contains('skipped_intervals')
+	assert keyboard_key_body.contains('backend.stop_key_repeat_for_key(raw_key)')
+	assert keyboard_leave_body.contains('backend.stop_key_repeat()')
+	assert clear_keys_down_body.contains('backend.stop_key_repeat()')
+	assert destroy_seat_body.contains('backend.clear_key_repeat_info()')
+	assert destroy_window_body.contains('backend.stop_key_repeat_for_window(record.id)')
+	assert destroy_window_body.contains('backend.pointer_buttons = 0')
+	assert_source_order(destroy_window_body, 'backend.pointer_enter_serial_valid = false',
+		'backend.pointer_buttons = 0')
+	assert wayland_source.contains('.clipboard_pasted')
+	assert wayland_source.contains('wayland_is_clipboard_paste')
+	assert wayland_source.contains('const wayland_key_v = 86')
+	wayland_paste_body :=
+		wayland_source.all_after('fn wayland_is_clipboard_paste').all_before('fn (backend &WaylandBackend) char_code_for_key')
+	assert wayland_paste_body.contains('return key_code == wayland_key_v && modifiers == wayland_modifier_ctrl')
+	assert !wayland_paste_body.contains('keyboard_modifiers')
+	assert_source_order(keyboard_key_body, 'queued_input_event(input))', '.clipboard_pasted')
+	assert_source_order(keyboard_key_body, '.clipboard_pasted',
+		'backend.windows[index].input_char_event')
+	for required_wayland_drop in ['wl_data_device_manager', 'wl_data_device', 'wl_data_offer',
+		'v_multiwindow_wayland_bind_data_device_manager',
+		'v_multiwindow_wayland_data_device_manager_get_data_device',
+		'v_multiwindow_wayland_add_data_device_listener',
+		'v_multiwindow_wayland_add_data_offer_listener', 'v_multiwindow_wayland_data_offer_accept',
+		'v_multiwindow_wayland_data_offer_set_copy_action',
+		'v_multiwindow_wayland_data_offer_receive', 'v_multiwindow_wayland_data_offer_finish',
+		'v_multiwindow_wayland_data_offer_destroy', 'v_multiwindow_wayland_data_device_destroy',
+		'v_multiwindow_wayland_data_device_manager_destroy'] {
+		assert wayland_source.contains(required_wayland_drop)
+			|| wayland_helper_source.contains(required_wayland_drop)
+	}
+	assert wayland_source.contains('wayland_data_offer_offer')
+	assert wayland_source.contains('wayland_data_offer_source_actions')
+	assert wayland_source.contains('backend.data_offer_source_actions = source_actions')
+	assert wayland_source.contains('backend.pending_drop_source_actions = source_actions')
+	assert wayland_source.contains('wayland_data_offer_action')
+	assert wayland_source.contains('backend.data_offer_selected_action = dnd_action')
+	assert wayland_source.contains('backend.data_offer_action_received = true')
+	assert wayland_source.contains('backend.pending_drop_selected_action = dnd_action')
+	assert wayland_source.contains('backend.pending_drop_action_received = true')
+	assert wayland_source.contains('wayland_data_device_drop')
+	assert !wayland_source.contains('read_data_offer_uri_list')
+	assert wayland_source.contains('begin_pending_data_offer_drop')
+	assert wayland_source.contains('drain_pending_data_offer_drop')
+	assert wayland_source.contains('finish_pending_data_offer_drop')
+	assert wayland_source.contains('wayland_dnd_action_allows_finish')
+	assert wayland_source.contains('source_actions != wayland_dnd_action_none')
+	assert wayland_source.contains('(source_actions & action) == 0')
+	assert wayland_source.contains('wayland_dnd_action_copy')
+	assert wayland_source.contains('wayland_dnd_action_move')
+	assert wayland_source.contains('pending_drop_offer')
+	assert wayland_source.contains('pending_drop_fd')
+	assert wayland_source.contains('pending_drop_buffer')
+	assert wayland_source.contains('pending_drop_poll_cycles')
+	assert wayland_source.contains('wayland_data_offer_max_pending_poll_cycles')
+	assert wayland_source.contains('pending_drop_poll_cycle_expired')
+	assert wayland_source.contains('C.v_multiwindow_wayland_fd_set_nonblocking')
+	assert wayland_source.contains('C.v_multiwindow_wayland_read_would_block')
+	assert wayland_source.contains('C.poll(&poll_fd, u64(1), 0)')
+	assert wayland_source.contains('for _ in 0 .. wayland_data_offer_max_read_chunks')
+	assert wayland_source.contains('backend.drain_pending_data_offer_drop()')
+	assert_source_order(wayland_source, 'backend.dispatch_pending_nonblocking()!',
+		'backend.drain_pending_data_offer_drop()')
+	assert wayland_source.contains('.files_dropped')
+	assert wayland_source.contains('dropped_files_from_uri_list(payload)')
+	drop_callback_start := wayland_source.index('fn wayland_data_device_drop(data voidptr, device voidptr)') or {
+		assert false, 'Wayland data-device drop callback is missing'
+		0
+	}
+	drop_callback_body :=
+		wayland_source[drop_callback_start..].all_before("@[export: 'v_multiwindow_wayland_data_device_selection']")
+	assert !drop_callback_body.contains('C.read(')
+	assert !drop_callback_body.contains('dropped_files_from_uri_list(payload)')
+	assert !drop_callback_body.contains('v_multiwindow_wayland_data_offer_finish')
+	assert drop_callback_body.contains('backend.data_offer_allows_finish()')
+	assert drop_callback_body.contains('backend.begin_pending_data_offer_drop()')
+	expire_body := wayland_source.all_after('fn (mut backend WaylandBackend) pending_drop_poll_cycle_expired() bool')
+		.all_before('fn (mut backend WaylandBackend) drain_pending_data_offer_drop()')
+	assert expire_body.contains('backend.pending_drop_poll_cycles++')
+	assert expire_body.contains('wayland_data_offer_max_pending_poll_cycles')
+	assert !expire_body.contains('v_multiwindow_wayland_data_offer_finish')
+	assert !expire_body.contains('C.read(')
+	drain_body := wayland_source.all_after('fn (mut backend WaylandBackend) drain_pending_data_offer_drop()')
+		.all_before('fn (mut backend WaylandBackend) finish_pending_data_offer_drop()')
+	assert drain_body.contains('if backend.pending_drop_poll_cycle_expired() {')
+	assert drain_body.contains('backend.clear_data_offer(true)')
+	assert_source_order(drain_body, 'backend.pending_drop_poll_cycle_expired()',
+		'C.poll(&poll_fd, u64(1), 0)')
+	finish_body := wayland_source.all_after('fn (mut backend WaylandBackend) finish_pending_data_offer_drop()')
+		.all_before('fn (mut backend WaylandBackend) destroy_data_device()')
+	assert_source_order(finish_body, 'backend.pending_drop_allows_finish()',
+		'C.v_multiwindow_wayland_data_offer_finish')
+	assert finish_body.contains('if should_finish {')
+	assert finish_body.contains('backend.clear_data_offer(true)')
+	assert wayland_helper_source.contains('#include <fcntl.h>')
+	assert wayland_helper_source.contains('#include <errno.h>')
+	assert wayland_helper_source.contains('v_multiwindow_wayland_fd_set_nonblocking')
+	assert !wayland_helper_source.contains('v_multiwindow_wayland_set_nonblocking')
+	assert wayland_helper_source.contains('O_NONBLOCK')
+	assert wayland_helper_source.contains('v_multiwindow_wayland_read_would_block')
+	assert wayland_helper_source.contains('EAGAIN')
+	assert wayland_helper_source.contains('EWOULDBLOCK')
+
+	has_surface_routing := wayland_source.contains('window_record_index_for_surface')
+		|| wayland_source.contains('window_record_index_for_native_surface')
+		|| wayland_source.contains('record_index_for_surface')
+	assert has_surface_routing
+	assert wayland_source.contains('pointer_focus')
+	assert wayland_source.contains('keyboard_focus')
+	assert wayland_source.contains('WindowId')
+	assert !wayland_source.contains('pointer_surface')
+	assert !wayland_source.contains('keyboard_surface')
+
+	assert wayland_helper_source.contains('wl_seat_listener')
+	assert wayland_helper_source.contains('wl_pointer_listener')
+	assert wayland_helper_source.contains('wl_keyboard_listener')
+	assert wayland_helper_source.contains('wl_touch_listener')
+	assert wayland_helper_source.contains('wl_fixed_to_double')
+	assert wayland_helper_source.contains('v_multiwindow_wayland_pointer_frame_trampoline')
+	assert wayland_helper_source.contains('v_multiwindow_wayland_keyboard_repeat_info_trampoline')
+	assert wayland_helper_source.contains('wl_seat_get_pointer')
+	assert wayland_helper_source.contains('wl_seat_get_keyboard')
+	assert wayland_helper_source.contains('wl_seat_get_touch')
+	uses_protocol_release := wayland_helper_source.contains('wl_pointer_release')
+		|| wayland_helper_source.contains('WL_POINTER_RELEASE')
+	if uses_protocol_release {
+		assert wayland_helper_source.contains('wl_keyboard_release')
+			|| wayland_helper_source.contains('WL_KEYBOARD_RELEASE')
+		assert wayland_helper_source.contains('wl_touch_release')
+			|| wayland_helper_source.contains('WL_TOUCH_RELEASE')
+		assert wayland_helper_source.contains('wl_seat_release')
+			|| wayland_helper_source.contains('WL_SEAT_RELEASE')
+	} else {
+		assert wayland_helper_source.contains('wl_pointer_destroy')
+		assert wayland_helper_source.contains('wl_keyboard_destroy')
+		assert wayland_helper_source.contains('wl_touch_destroy')
+		assert wayland_helper_source.contains('wl_seat_destroy')
+	}
+
+	assert wayland_source.contains('mouse_scroll')
+	assert wayland_source.contains('const wayland_scroll_scale = 10.0')
+	assert wayland_source.contains('/ f32(wayland_scroll_scale)')
+	assert wayland_source.contains('340, 344 { wayland_modifier_shift }')
+	assert wayland_source.contains('341, 345 { wayland_modifier_ctrl }')
+	assert wayland_source.contains('342, 346 { wayland_modifier_alt }')
+	assert wayland_source.contains('343, 347 { wayland_modifier_super }')
+	assert wayland_source.contains('touch_slot_for_down')
+	assert wayland_source.contains('touch_slot_for_id')
+	assert wayland_source.contains('touch_event_for_record')
+	assert wayland_source.contains('touch_cancel_event_for_record')
+	assert wayland_source.contains('touch_mouse_position_for_record')
+	assert touch_event_body.contains('mouse_x, mouse_y := backend.touch_mouse_position_for_record(record, changed_slot)')
+	assert touch_event_body.contains('mouse_x:            mouse_x')
+	assert touch_event_body.contains('mouse_y:            mouse_y')
+	assert touch_cancel_body.contains('mouse_x, mouse_y := backend.touch_mouse_position_for_record(record, -1)')
+	assert touch_cancel_body.contains('mouse_x:            mouse_x')
+	assert touch_cancel_body.contains('mouse_y:            mouse_y')
+	assert touch_mouse_position_body.contains('changed_slot >= 0')
+	assert touch_mouse_position_body.contains('touch.active && touch.window_id == record.id')
+	assert touch_mouse_position_body.contains('return touch.x, touch.y')
+	assert touch_mouse_position_body.contains('return record.mouse_x, record.mouse_y')
+	assert wayland_source.contains('.touches_began')
+	assert wayland_source.contains('.touches_moved')
+	assert wayland_source.contains('.touches_ended')
+	assert wayland_source.contains('.touches_cancelled')
+	assert wayland_source.contains('42 { 340 }')
+	assert wayland_source.contains('54 { 344 }')
+	assert wayland_source.contains('29 { 341 }')
+	assert wayland_source.contains('97 { 345 }')
+}
+
+fn test_wayland_registry_global_remove_and_optional_callbacks_are_guarded_source_guard() {
+	wayland_source := multiwindow_source_file('wayland_backend.c.v')
+	wayland_helper_source := multiwindow_source_file('wayland_backend_helpers.h')
+
+	has_compositor_name := wayland_source.contains('compositor_name')
+		|| wayland_source.contains('compositor_global_name')
+	has_wm_base_name := wayland_source.contains('wm_base_name')
+		|| wayland_source.contains('wm_base_global_name')
+		|| wayland_source.contains('xdg_wm_base_name')
+	has_seat_name := wayland_source.contains('seat_global_name')
+		|| wayland_source.contains('seat_registry_name')
+		|| (wayland_source.contains('seat_name') && wayland_source.contains('u32'))
+	assert has_compositor_name
+	assert has_wm_base_name
+	assert has_seat_name
+
+	global_remove_body :=
+		wayland_source.all_after('fn wayland_registry_handle_global_remove').all_before("@[export: 'v_multiwindow_wayland_xdg_wm_base_ping']")
+	assert global_remove_body.contains('mut backend := unsafe { &WaylandBackend(data) }')
+	assert global_remove_body.contains('name == backend.')
+	assert global_remove_body.contains('unsafe { nil }')
+	assert global_remove_body.contains('destroy_seat_devices')
+	assert !global_remove_body.contains('_ = data\n\t\t_ = registry\n\t\t_ = name')
+	wm_base_remove_body :=
+		global_remove_body.all_after('name == backend.wm_base_name').all_before('} else if name == backend.compositor_name')
+	assert wm_base_remove_body.contains('backend.wm_base_name = 0')
+	assert wm_base_remove_body.contains('backend.destroy_removed_wm_base_if_unused()')
+	assert !wm_base_remove_body.contains('C.v_multiwindow_wayland_xdg_wm_base_destroy')
+	if wm_base_remove_body.contains('backend.wm_base = unsafe { nil }') {
+		assert_source_order(wm_base_remove_body, 'backend.destroy_removed_wm_base_if_unused()',
+			'backend.wm_base = unsafe { nil }')
+	}
+	removed_wm_base_cleanup_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) destroy_removed_wm_base_if_unused()').all_before('fn (mut backend WaylandBackend) destroy_seat_devices')
+	assert removed_wm_base_cleanup_body.contains('backend.wm_base_name != 0')
+	assert removed_wm_base_cleanup_body.contains('backend.wm_base == unsafe { nil }')
+	assert removed_wm_base_cleanup_body.contains('backend.windows.len != 0')
+	assert removed_wm_base_cleanup_body.contains('C.v_multiwindow_wayland_xdg_wm_base_destroy')
+	assert removed_wm_base_cleanup_body.contains('backend.wm_base = unsafe { nil }')
+		|| removed_wm_base_cleanup_body.contains('return true')
+	assert_source_order(removed_wm_base_cleanup_body, 'backend.windows.len != 0',
+		'C.v_multiwindow_wayland_xdg_wm_base_destroy')
+	destroy_window_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) destroy_window').all_before('fn (mut backend WaylandBackend) set_window_title')
+	assert_source_order(destroy_window_body, 'backend.windows.delete(index)',
+		'backend.destroy_removed_wm_base_if_unused()')
+	close_connection_body :=
+		wayland_source.all_after('fn (mut backend WaylandBackend) close_connection').all_before('fn (mut backend WaylandBackend) destroy_removed_wm_base_if_unused')
+	assert_source_order(close_connection_body, 'for backend.windows.len > 0',
+		'backend.destroy_removed_wm_base_if_unused()')
+	assert_source_order(close_connection_body, 'backend.destroy_removed_wm_base_if_unused()',
+		'if backend.wm_base != unsafe { nil }')
+	compositor_remove_body := global_remove_body.all_after('name == backend.compositor_name')
+	assert compositor_remove_body.contains('backend.compositor_name = 0')
+	assert compositor_remove_body.contains('backend.compositor = unsafe { nil }')
+	assert compositor_remove_body.contains('backend.compositor_version = 0')
+	assert !compositor_remove_body.contains('if backend.windows.len == 0 && backend.compositor != unsafe { nil }')
+
+	optional_pointer_callbacks := [
+		'axis_value120',
+		'axis_relative_direction',
+	]
+	for callback in optional_pointer_callbacks {
+		trampoline_name := 'v_multiwindow_wayland_pointer_${callback}_trampoline'
+		if wayland_helper_source.contains(trampoline_name) {
+			assert wayland_helper_source.contains('WL_POINTER_' + callback.to_upper())
+		}
+	}
+
+	assert wayland_helper_source.contains('v_multiwindow_wayland_keyboard_keymap_trampoline')
+	keymap_body :=
+		wayland_helper_source.all_after('v_multiwindow_wayland_keyboard_keymap_trampoline').all_before('static void v_multiwindow_wayland_keyboard_enter_trampoline')
+	assert keymap_body.contains('v_multiwindow_wayland_keyboard_keymap(data, (void *)keyboard, format, fd, size);')
+	assert !keymap_body.contains('close(fd);')
+	assert wayland_source.contains("@[export: 'v_multiwindow_wayland_keyboard_keymap']")
+	wayland_keymap_body :=
+		wayland_source.all_after('fn wayland_keyboard_keymap(data voidptr, keyboard voidptr, format u32, fd int, size u32)').all_before("@[export: 'v_multiwindow_wayland_keyboard_key']")
+	assert wayland_keymap_body.contains('C.close(fd)')
+	assert wayland_keymap_body.contains('C.mmap')
+	assert wayland_keymap_body.contains('C.munmap')
+}
+
+fn test_multiwindow_events_do_not_add_second_opt_in_source_guard() {
+	vlib_dir := os.dir(os.dir(@DIR))
+	sources := [
+		multiwindow_source_file('types.v'),
+		multiwindow_source_file('app.v'),
+		multiwindow_source_file('backend.v'),
+		multiwindow_source_file('mock_backend.v'),
+		multiwindow_source_file('wayland_backend.c.v'),
+		os.read_file(os.join_path(vlib_dir, 'gg', 'multiwindow_d_gg_multiwindow.v')) or {
+			panic(err)
+		},
+		os.read_file(os.join_path(vlib_dir, 'gg', 'multiwindow_notd_gg_multiwindow.v')) or {
+			panic(err)
+		},
+	]
+	for source in sources {
+		assert !source.contains('wayland_input')
+		assert !source.contains('x_multiwindow_input')
+		assert !source.contains('gg_multiwindow_events')
+		assert !source.contains('gg_multiwindow_input')
+		assert !source.contains('x_multiwindow_events')
+	}
+}
+
 fn test_default_gg_multiwindow_build_does_not_link_wayland_without_sokol_wayland() {
 	$if linux {
 		$if sokol_wayland ? {
@@ -1589,6 +3283,7 @@ fn test_default_gg_multiwindow_build_does_not_link_wayland_without_sokol_wayland
 		assert !output.contains('-lwayland-client')
 		assert !output.contains('-lwayland-egl')
 		assert !output.contains('wayland_xdg_shell_private.c')
+		assert !output.contains('wayland_xdg_decoration_private.c')
 	} $else {
 		return
 	}
@@ -1624,6 +3319,7 @@ fn test_sokol_wayland_build_links_wayland_when_flag_is_active() {
 		assert output.contains('-lwayland-client')
 		assert output.contains('-lwayland-egl')
 		assert output.contains('wayland_xdg_shell_private.c')
+		assert output.contains('wayland_xdg_decoration_private.c')
 	} $else {
 		return
 	}
@@ -1633,7 +3329,7 @@ fn test_gg_import_only_windows_build_keeps_win32_callback_record_declaration() {
 	c_source := multiwindow_emit_windows_gg_import_c()
 	assert c_source.contains('struct x__multiwindow__Win32WindowRecord {')
 	assert_source_order(c_source, 'struct x__multiwindow__Win32WindowRecord {',
-		'VV_LOC void x__multiwindow__win32_window_close_requested(voidptr data)')
+		'VV_LOC void x__multiwindow__win32_window_close_requested(voidptr data, u64 sequence)')
 }
 
 fn test_wayland_render_smoke_when_display_is_available() {
@@ -1879,6 +3575,128 @@ fn multiwindow_skip_linux_gg_graphics_probe(label string) {
 	eprintln('skip ${label}: gg multiwindow link probe requires host X11/GL headers')
 }
 
+fn all_input_event_kinds_for_test() []InputEventKind {
+	return [
+		InputEventKind.invalid,
+		.key_down,
+		.key_up,
+		.char,
+		.mouse_down,
+		.mouse_up,
+		.mouse_scroll,
+		.mouse_move,
+		.mouse_enter,
+		.mouse_leave,
+		.touches_began,
+		.touches_moved,
+		.touches_ended,
+		.touches_cancelled,
+		.resized,
+		.iconified,
+		.restored,
+		.focused,
+		.unfocused,
+		.suspended,
+		.resumed,
+		.quit_requested,
+		.clipboard_pasted,
+		.files_dropped,
+	]
+}
+
+fn input_event_for_kind_for_test(win WindowId, kind InputEventKind, frame_count u64) InputEvent {
+	mut touches := [8]InputTouchPoint{}
+	touches[0] = InputTouchPoint{
+		identifier:       7
+		pos_x:            11.5
+		pos_y:            12.5
+		android_tooltype: 1
+		changed:          true
+	}
+	touches[1] = InputTouchPoint{
+		identifier:       8
+		pos_x:            21.5
+		pos_y:            22.5
+		android_tooltype: 2
+		changed:          false
+	}
+	dropped_files := if kind == .files_dropped {
+		['/tmp/a.txt', '/tmp/b.txt']
+	} else {
+		[]string{}
+	}
+	return InputEvent{
+		kind:               kind
+		window_id:          win
+		frame_count:        frame_count
+		key_code:           65
+		char_code:          u32(0xe9)
+		key_repeat:         true
+		modifiers:          0x105
+		mouse_button:       2
+		mouse_x:            40.5
+		mouse_y:            41.5
+		mouse_dx:           -2.25
+		mouse_dy:           3.5
+		scroll_x:           -1.25
+		scroll_y:           2.5
+		num_touches:        2
+		touches:            touches
+		window_width:       640
+		window_height:      360
+		framebuffer_width:  1280
+		framebuffer_height: 720
+		dropped_files:      dropped_files
+	}
+}
+
+fn assert_input_event_roundtrip(actual InputEvent, expected InputEvent) {
+	assert actual.kind == expected.kind
+	assert actual.window_id == expected.window_id
+	assert actual.frame_count == expected.frame_count
+	assert actual.key_code == expected.key_code
+	assert actual.char_code == expected.char_code
+	assert actual.key_repeat == expected.key_repeat
+	assert actual.modifiers == expected.modifiers
+	assert actual.mouse_button == expected.mouse_button
+	assert actual.mouse_x == expected.mouse_x
+	assert actual.mouse_y == expected.mouse_y
+	assert actual.mouse_dx == expected.mouse_dx
+	assert actual.mouse_dy == expected.mouse_dy
+	assert actual.scroll_x == expected.scroll_x
+	assert actual.scroll_y == expected.scroll_y
+	assert actual.num_touches == expected.num_touches
+	for i in 0 .. actual.num_touches {
+		assert actual.touches[i].identifier == expected.touches[i].identifier
+		assert actual.touches[i].pos_x == expected.touches[i].pos_x
+		assert actual.touches[i].pos_y == expected.touches[i].pos_y
+		assert actual.touches[i].android_tooltype == expected.touches[i].android_tooltype
+		assert actual.touches[i].changed == expected.touches[i].changed
+	}
+	assert actual.window_width == expected.window_width
+	assert actual.window_height == expected.window_height
+	assert actual.framebuffer_width == expected.framebuffer_width
+	assert actual.framebuffer_height == expected.framebuffer_height
+	assert actual.dropped_files == expected.dropped_files
+}
+
+fn assert_input_event_kind_list_matches_types_source(kinds []InputEventKind) {
+	source := multiwindow_source_file('types.v')
+	enum_body := source.all_after('pub enum InputEventKind {').all_before('}')
+	mut declared := []string{}
+	for line in enum_body.split_into_lines() {
+		name := line.trim_space()
+		if name == '' || name.starts_with('//') {
+			continue
+		}
+		declared << name
+	}
+	assert declared.len == kinds.len
+	for i, kind in kinds {
+		assert declared[i] == kind.str()
+	}
+}
+
 fn multiwindow_dump_c_flags(label string, flags string) string {
 	vlib_dir := os.dir(os.dir(@DIR))
 	unique := 'x_multiwindow_${label}_${os.getpid()}_${time.now().unix_nano()}'
@@ -1931,6 +3749,26 @@ fn main() {
 	cmd := '${os.quoted_path(@VEXE)} -os windows -d gg_multiwindow -d sokol_d3d11 -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(c_path)} ${os.quoted_path(source_path)}'
 	result := os.execute(cmd)
 	assert result.exit_code == 0, 'emit Windows gg import C failed
+command: ${cmd}
+exit_code: ${result.exit_code}
+output:
+${result.output}'
+
+	return os.read_file(c_path) or { panic(err) }
+}
+
+fn multiwindow_emit_macos_multiwindow_test_c() string {
+	vlib_dir := os.dir(os.dir(@DIR))
+	unique := 'x_multiwindow_appkit_cgen_${os.getpid()}_${time.now().unix_nano()}'
+	c_path := os.join_path(os.temp_dir(), '${unique}.c')
+	target_path := os.join_path(@DIR, 'multiwindow_test.v')
+	defer {
+		os.rm(c_path) or {}
+	}
+
+	cmd := '${os.quoted_path(@VEXE)} -os macos -d gg_multiwindow -d sokol_metal -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(c_path)} ${os.quoted_path(target_path)}'
+	result := os.execute(cmd)
+	assert result.exit_code == 0, 'emit macOS multiwindow C failed
 command: ${cmd}
 exit_code: ${result.exit_code}
 output:

--- a/vlib/x/multiwindow/types.v
+++ b/vlib/x/multiwindow/types.v
@@ -32,6 +32,77 @@ pub enum EventKind {
 	window_resized
 }
 
+// InputEventKind mirrors the input/event classes exposed by sokol/gg while
+// remaining independent from gg and sokol imports.
+pub enum InputEventKind {
+	invalid
+	key_down
+	key_up
+	char
+	mouse_down
+	mouse_up
+	mouse_scroll
+	mouse_move
+	mouse_enter
+	mouse_leave
+	touches_began
+	touches_moved
+	touches_ended
+	touches_cancelled
+	resized
+	iconified
+	restored
+	focused
+	unfocused
+	suspended
+	resumed
+	quit_requested
+	clipboard_pasted
+	files_dropped
+}
+
+pub enum QueuedEventKind {
+	lifecycle
+	input
+}
+
+const input_event_invalid_mouse_button = 256
+
+// WindowResizeEdge identifies the edge or corner used for an interactive,
+// user-driven native resize operation.
+pub enum WindowResizeEdge {
+	top
+	bottom
+	left
+	right
+	top_left
+	top_right
+	bottom_left
+	bottom_right
+}
+
+// CursorShape identifies a native cursor image for client-side chrome hover
+// feedback. Cursor support is independent from native interactive move/resize.
+pub enum CursorShape {
+	default
+	pointer
+	move
+	n_resize
+	s_resize
+	e_resize
+	w_resize
+	ne_resize
+	nw_resize
+	se_resize
+	sw_resize
+	ew_resize
+	ns_resize
+	nesw_resize
+	nwse_resize
+	grab
+	grabbing
+}
+
 // WindowId is an opaque generation-checked handle to a window.
 pub struct WindowId {
 	slot       int
@@ -77,36 +148,47 @@ struct WindowSize {
 // WindowInfo is a snapshot of the authoritative App-side window state.
 pub struct WindowInfo {
 pub:
-	id         WindowId
-	status     WindowStatus
-	title      string
-	width      int
-	height     int
-	min_width  int
-	min_height int
-	resizable  bool
-	visible    bool
-	high_dpi   bool
-	borderless bool
-	fullscreen bool
+	id                 WindowId
+	status             WindowStatus
+	title              string
+	width              int
+	height             int
+	min_width          int
+	min_height         int
+	resizable          bool
+	visible            bool
+	high_dpi           bool
+	borderless         bool
+	fullscreen         bool
+	native_decorations bool
 }
 
 // Capabilities reports what the selected backend can do.
 pub struct Capabilities {
 pub:
-	backend            BackendKind
-	mock               bool
-	native             bool
-	multi_window       bool
-	owner_queue        bool
-	explicit_swapchain bool
-	readback           bool
-	d3d11              bool
-	metal              bool
-	x11                bool
-	wayland            bool
-	win32              bool
-	gl                 bool
+	backend                 BackendKind
+	mock                    bool
+	native                  bool
+	multi_window            bool
+	owner_queue             bool
+	explicit_swapchain      bool
+	readback                bool
+	d3d11                   bool
+	metal                   bool
+	x11                     bool
+	wayland                 bool
+	win32                   bool
+	gl                      bool
+	input_events            bool
+	mouse_events            bool
+	keyboard_events         bool
+	text_events             bool
+	focus_events            bool
+	drop_events             bool
+	touch_events            bool
+	cursor_shapes           bool
+	interactive_move_resize bool
+	native_decorations      bool
 }
 
 // Event is always routed to a specific WindowId.
@@ -116,6 +198,67 @@ pub:
 	window_id WindowId
 	width     int
 	height    int
+}
+
+// InputTouchPoint is the backend-neutral representation of one touch point.
+pub struct InputTouchPoint {
+pub:
+	identifier       u64
+	pos_x            f32
+	pos_y            f32
+	android_tooltype int
+	changed          bool
+}
+
+// InputEvent is always routed to a specific WindowId. It carries the full
+// backend-neutral payload needed to rebuild gg.Event in the gg facade.
+pub struct InputEvent {
+pub:
+	kind               InputEventKind
+	window_id          WindowId
+	frame_count        u64
+	key_code           int
+	char_code          u32
+	key_repeat         bool
+	modifiers          u32
+	mouse_button       int = input_event_invalid_mouse_button
+	mouse_x            f32
+	mouse_y            f32
+	mouse_dx           f32
+	mouse_dy           f32
+	scroll_x           f32
+	scroll_y           f32
+	num_touches        int
+	touches            [8]InputTouchPoint
+	window_width       int
+	window_height      int
+	framebuffer_width  int
+	framebuffer_height int
+	dropped_files      []string
+}
+
+// QueuedEvent preserves backend ordering between lifecycle and input events.
+pub struct QueuedEvent {
+pub:
+	kind      QueuedEventKind
+	lifecycle Event
+	input     InputEvent
+}
+
+@[markused]
+fn queued_lifecycle_event(event Event) QueuedEvent {
+	return QueuedEvent{
+		kind:      .lifecycle
+		lifecycle: event
+	}
+}
+
+@[markused]
+fn queued_input_event(event InputEvent) QueuedEvent {
+	return QueuedEvent{
+		kind:  .input
+		input: event
+	}
 }
 
 // AppJobFn is executed later by the owner queue while App is being pumped.
@@ -140,4 +283,60 @@ fn window_extent_for_minimum(value int, minimum int) int {
 		return minimum
 	}
 	return value
+}
+
+fn dropped_files_from_uri_list(payload string) []string {
+	mut files := []string{}
+	for raw_line in payload.split('\n') {
+		line := if raw_line.ends_with('\r') {
+			raw_line[..raw_line.len - 1]
+		} else {
+			raw_line
+		}
+		if line.len == 0 || line.starts_with('#') || !line.starts_with('file://') {
+			continue
+		}
+		mut path := line[7..]
+		if path.starts_with('localhost/') {
+			path = path[9..]
+		}
+		if path.len == 0 || path[0] != `/` {
+			continue
+		}
+		files << uri_percent_decode(path)
+	}
+	return files
+}
+
+fn uri_percent_decode(value string) string {
+	bytes := value.bytes()
+	mut decoded := []u8{cap: bytes.len}
+	mut i := 0
+	for i < bytes.len {
+		if bytes[i] == `%` && i + 2 < bytes.len {
+			hi := uri_hex_nibble(bytes[i + 1])
+			lo := uri_hex_nibble(bytes[i + 2])
+			if hi >= 0 && lo >= 0 {
+				decoded << u8(hi * 16 + lo)
+				i += 3
+				continue
+			}
+		}
+		decoded << bytes[i]
+		i++
+	}
+	return decoded.bytestr()
+}
+
+fn uri_hex_nibble(ch u8) int {
+	if ch >= `0` && ch <= `9` {
+		return int(ch - `0`)
+	}
+	if ch >= `a` && ch <= `f` {
+		return int(ch - `a`) + 10
+	}
+	if ch >= `A` && ch <= `F` {
+		return int(ch - `A`) + 10
+	}
+	return -1
 }

--- a/vlib/x/multiwindow/wayland_backend.c.v
+++ b/vlib/x/multiwindow/wayland_backend.c.v
@@ -5,19 +5,101 @@ $if gg_multiwindow ? || x_multiwindow_render ? {
 }
 
 $if linux && sokol_wayland ? {
+	import time as vtime
+}
+
+$if linux && sokol_wayland ? {
 	#flag linux -lwayland-client
 	#flag linux -lwayland-egl
+	#flag linux -lxkbcommon
 	#flag linux -lEGL
 	#flag linux -lGL
 	#flag linux -I @VEXEROOT/thirdparty/sokol
 	#flag linux @VMODROOT/vlib/x/multiwindow/wayland_xdg_shell_private.c
+	#flag linux @VMODROOT/vlib/x/multiwindow/wayland_xdg_decoration_private.c
+	#flag linux @VMODROOT/vlib/x/multiwindow/wayland_cursor_shape_private.c
 	#include <poll.h>
 	#include <string.h>
+	#include <sys/mman.h>
+	#include <unistd.h>
 	#include <wayland-client.h>
 	#insert "@VMODROOT/vlib/x/multiwindow/wayland_backend_helpers.h"
+	#include <xkbcommon/xkbcommon.h>
 }
 
 const wayland_poll_in = i16(0x001)
+const wayland_poll_err = i16(0x008)
+const wayland_poll_hup = i16(0x010)
+const wayland_pointer_axis_vertical_scroll = u32(0)
+const wayland_pointer_axis_horizontal_scroll = u32(1)
+const wayland_pointer_button_state_released = u32(0)
+const wayland_pointer_button_state_pressed = u32(1)
+const wayland_keyboard_key_state_released = u32(0)
+const wayland_keyboard_key_state_pressed = u32(1)
+const wayland_seat_capability_pointer = u32(1)
+const wayland_seat_capability_keyboard = u32(2)
+const wayland_seat_capability_touch = u32(4)
+const wayland_btn_left = u32(0x110)
+const wayland_btn_right = u32(0x111)
+const wayland_btn_middle = u32(0x112)
+const wayland_max_touch_points = 8
+const wayland_invalid_mouse_button = 256
+const wayland_scroll_scale = 10.0
+const wayland_modifier_shift = u32(1)
+const wayland_modifier_ctrl = u32(2)
+const wayland_modifier_alt = u32(4)
+const wayland_modifier_super = u32(8)
+const wayland_modifier_lmb = u32(0x100)
+const wayland_modifier_rmb = u32(0x200)
+const wayland_modifier_mmb = u32(0x400)
+const wayland_key_v = 86
+const wayland_xdg_toplevel_resize_edge_top = u32(1)
+const wayland_xdg_toplevel_resize_edge_bottom = u32(2)
+const wayland_xdg_toplevel_resize_edge_left = u32(4)
+const wayland_xdg_toplevel_resize_edge_top_left = u32(5)
+const wayland_xdg_toplevel_resize_edge_bottom_left = u32(6)
+const wayland_xdg_toplevel_resize_edge_right = u32(8)
+const wayland_xdg_toplevel_resize_edge_top_right = u32(9)
+const wayland_xdg_toplevel_resize_edge_bottom_right = u32(10)
+const wayland_xdg_toplevel_decoration_mode_unknown = u32(0)
+const wayland_xdg_toplevel_decoration_mode_client_side = u32(1)
+const wayland_xdg_toplevel_decoration_mode_server_side = u32(2)
+const wayland_cursor_shape_default = u32(1)
+const wayland_cursor_shape_pointer = u32(4)
+const wayland_cursor_shape_move = u32(13)
+const wayland_cursor_shape_grab = u32(16)
+const wayland_cursor_shape_grabbing = u32(17)
+const wayland_cursor_shape_e_resize = u32(18)
+const wayland_cursor_shape_n_resize = u32(19)
+const wayland_cursor_shape_ne_resize = u32(20)
+const wayland_cursor_shape_nw_resize = u32(21)
+const wayland_cursor_shape_s_resize = u32(22)
+const wayland_cursor_shape_se_resize = u32(23)
+const wayland_cursor_shape_sw_resize = u32(24)
+const wayland_cursor_shape_w_resize = u32(25)
+const wayland_cursor_shape_ew_resize = u32(26)
+const wayland_cursor_shape_ns_resize = u32(27)
+const wayland_cursor_shape_nesw_resize = u32(28)
+const wayland_cursor_shape_nwse_resize = u32(29)
+const wayland_keyboard_keymap_format_xkb_v1 = u32(1)
+const wayland_xkb_context_no_flags = 0
+const wayland_xkb_keymap_format_text_v1 = 1
+const wayland_xkb_keymap_compile_no_flags = 0
+const wayland_xkb_state_mods_effective = 8
+const wayland_uri_list_buffer_size = 65536
+const wayland_data_offer_drain_chunk_size = 4096
+const wayland_data_offer_max_read_chunks = 16
+const wayland_data_offer_max_pending_poll_cycles = 300
+const wayland_max_fallback_buffers = 3
+const wayland_nsec_per_sec = u64(1_000_000_000)
+const wayland_nsec_per_msec = u64(1_000_000)
+const wayland_dnd_action_none = u32(0)
+const wayland_dnd_action_copy = u32(1)
+const wayland_dnd_action_move = u32(2)
+const wayland_dnd_action_ask = u32(4)
+const wayland_prot_read = 1
+const wayland_map_private = 2
+const wayland_map_failed = voidptr(usize(~u64(0)))
 const err_wayland_egl_config_failed = 'multiwindow: wayland egl config failed'
 const err_wayland_egl_context_failed = 'multiwindow: wayland egl context failed'
 const err_wayland_egl_display_failed = 'multiwindow: wayland egl display failed'
@@ -25,6 +107,17 @@ const err_wayland_egl_make_current_failed = 'multiwindow: wayland egl make curre
 const err_wayland_egl_surface_failed = 'multiwindow: wayland egl surface failed'
 const err_wayland_egl_swap_buffers_failed = 'multiwindow: wayland egl swap buffers failed'
 const err_wayland_surface_not_configured = 'multiwindow: wayland surface is not configured'
+const err_wayland_buffer_failed = 'multiwindow: wayland buffer creation failed'
+const err_wayland_xkb_context_failed = 'multiwindow: wayland xkb context failed'
+
+struct WaylandTouchPoint {
+mut:
+	active    bool
+	id        int
+	window_id WindowId
+	x         f32
+	y         f32
+}
 
 @[heap]
 struct WaylandWindowRecord {
@@ -32,33 +125,108 @@ struct WaylandWindowRecord {
 	surface      voidptr
 	xdg_surface  voidptr
 	xdg_toplevel voidptr
+	resizable    bool
 mut:
-	width                   int
-	height                  int
-	min_width               int
-	min_height              int
-	pending_toplevel_width  int
-	pending_toplevel_height int
-	configured              bool
-	pending_egl_resize      bool
-	resize_event_pending    bool
-	close_requested         bool
-	wl_egl_window           voidptr
-	egl_surface             voidptr
+	width                          int
+	height                         int
+	min_width                      int
+	min_height                     int
+	pending_toplevel_width         int
+	pending_toplevel_height        int
+	configured                     bool
+	pending_egl_resize             bool
+	pending_events                 []WaylandNativeQueuedEvent
+	mouse_x                        f32
+	mouse_y                        f32
+	mouse_dx                       f32
+	mouse_dy                       f32
+	mouse_pos_valid                bool
+	fallback_buffers               []voidptr
+	fallback_current_buffer        voidptr
+	fallback_buffer_width          int
+	fallback_buffer_height         int
+	wl_egl_window                  voidptr
+	egl_surface                    voidptr
+	toplevel_decoration            voidptr
+	toplevel_decoration_configured bool
+	toplevel_decoration_mode       u32
+	user_action_serial             u32
+	user_action_poll               u64
+	user_action_serial_valid       bool
+}
+
+struct WaylandNativeQueuedEvent {
+	sequence u64
+	event    QueuedEvent
 }
 
 struct WaylandBackend {
 mut:
-	display            voidptr
-	registry           voidptr
-	compositor         voidptr
-	compositor_version u32
-	wm_base            voidptr
-	egl_display        voidptr
-	egl_config         voidptr
-	egl_context        voidptr
-	started            bool
-	windows            []&WaylandWindowRecord
+	display                      voidptr
+	registry                     voidptr
+	compositor                   voidptr
+	compositor_name              u32
+	compositor_version           u32
+	seat                         voidptr
+	seat_name                    u32
+	pointer                      voidptr
+	cursor_shape_manager         voidptr
+	cursor_shape_manager_name    u32
+	cursor_shape_device          voidptr
+	keyboard                     voidptr
+	touch                        voidptr
+	data_device_manager          voidptr
+	data_device_manager_name     u32
+	data_device                  voidptr
+	shm                          voidptr
+	shm_name                     u32
+	data_offer                   voidptr
+	data_offer_has_uri_list      bool
+	data_offer_source_actions    u32
+	data_offer_selected_action   u32
+	data_offer_action_received   bool
+	data_offer_window            WindowId
+	data_offer_window_valid      bool
+	pending_drop_offer           voidptr
+	pending_drop_fd              int
+	pending_drop_window          WindowId
+	pending_drop_window_valid    bool
+	pending_drop_source_actions  u32
+	pending_drop_selected_action u32
+	pending_drop_action_received bool
+	pending_drop_poll_cycles     int
+	pending_drop_buffer          []u8
+	wm_base                      voidptr
+	wm_base_name                 u32
+	decoration_manager           voidptr
+	decoration_manager_name      u32
+	xkb_context                  voidptr
+	xkb_keymap                   voidptr
+	xkb_state                    voidptr
+	egl_display                  voidptr
+	egl_config                   voidptr
+	egl_context                  voidptr
+	started                      bool
+	pointer_focus                WindowId
+	pointer_focused              bool
+	pointer_enter_serial         u32
+	pointer_enter_serial_valid   bool
+	keyboard_focus               WindowId
+	keyboard_focused             bool
+	keyboard_repeat_rate         int
+	keyboard_repeat_delay        int
+	keyboard_repeat_active       bool
+	keyboard_repeat_raw_key      u32
+	keyboard_repeat_key_code     int
+	keyboard_repeat_window       WindowId
+	keyboard_repeat_next_ns      u64
+	keyboard_repeat_interval_ns  u64
+	poll_generation              u64
+	pointer_buttons              u32
+	modifiers                    u32
+	keys_down                    [512]bool
+	touches                      [wayland_max_touch_points]WaylandTouchPoint
+	windows                      []&WaylandWindowRecord
 }
 
 @[markused]
@@ -85,6 +253,24 @@ $if linux && sokol_wayland ? {
 
 	struct C.wl_compositor {}
 
+	struct C.wl_seat {}
+
+	struct C.wl_pointer {}
+
+	struct C.wl_keyboard {}
+
+	struct C.wl_touch {}
+
+	struct C.wl_data_device_manager {}
+
+	struct C.wl_data_device {}
+
+	struct C.wl_data_offer {}
+
+	struct C.wl_shm {}
+
+	struct C.wl_buffer {}
+
 	struct C.wl_surface {}
 
 	struct C.wl_output {}
@@ -101,15 +287,83 @@ $if linux && sokol_wayland ? {
 
 	struct C.xdg_toplevel {}
 
+	struct C.zxdg_decoration_manager_v1 {}
+
+	struct C.zxdg_toplevel_decoration_v1 {}
+
+	struct C.wp_cursor_shape_manager_v1 {}
+
+	struct C.wp_cursor_shape_device_v1 {}
+
+	struct C.xkb_context {}
+
+	struct C.xkb_keymap {}
+
+	struct C.xkb_state {}
+
 	fn C.poll(fds &C.pollfd, nfds u64, timeout int) int
 	fn C.strcmp(a &char, b &char) int
+	fn C.close(fd int) int
+	fn C.pipe(fds &int) int
+	fn C.read(fd int, buf voidptr, count usize) isize
+	fn C.mmap(addr voidptr, length usize, prot int, flags int, fd int, offset i64) voidptr
+	fn C.munmap(addr voidptr, length usize) int
+	fn C.xkb_context_new(flags int) &C.xkb_context
+	fn C.xkb_context_unref(ctx &C.xkb_context)
+	fn C.xkb_keymap_new_from_string(ctx &C.xkb_context, str &char, format int, flags int) &C.xkb_keymap
+	fn C.xkb_keymap_unref(keymap &C.xkb_keymap)
+	fn C.xkb_keymap_key_repeats(keymap &C.xkb_keymap, key u32) int
+	fn C.xkb_state_new(keymap &C.xkb_keymap) &C.xkb_state
+	fn C.xkb_state_unref(state &C.xkb_state)
+	fn C.xkb_state_key_get_utf8(state &C.xkb_state, key u32, buf &char, size usize) int
+	fn C.xkb_state_update_mask(state &C.xkb_state, depressed u32, latched u32, locked u32, dep_group u32, lat_group u32, lock_group u32) int
+	fn C.xkb_state_mod_name_is_active(state &C.xkb_state, name &char, @type int) int
 	fn C.v_multiwindow_wayland_compositor_bind_version(version u32) u32
 	fn C.v_multiwindow_wayland_bind_compositor(registry &C.wl_registry, name u32, version u32) voidptr
 	fn C.v_multiwindow_wayland_bind_xdg_wm_base(registry &C.wl_registry, name u32) voidptr
+	fn C.v_multiwindow_wayland_bind_xdg_decoration_manager(registry &C.wl_registry, name u32, version u32) voidptr
+	fn C.v_multiwindow_wayland_bind_cursor_shape_manager(registry &C.wl_registry, name u32, version u32) voidptr
+	fn C.v_multiwindow_wayland_bind_seat(registry &C.wl_registry, name u32, version u32) voidptr
+	fn C.v_multiwindow_wayland_bind_data_device_manager(registry &C.wl_registry, name u32, version u32) voidptr
+	fn C.v_multiwindow_wayland_bind_shm(registry &C.wl_registry, name u32) voidptr
+	fn C.v_multiwindow_wayland_next_event_sequence() u64
 	fn C.v_multiwindow_wayland_add_registry_listener(registry &C.wl_registry, data voidptr) int
 	fn C.v_multiwindow_wayland_add_xdg_wm_base_listener(wm_base &C.xdg_wm_base, data voidptr) int
 	fn C.v_multiwindow_wayland_add_xdg_surface_listener(xdg_surface &C.xdg_surface, data voidptr) int
 	fn C.v_multiwindow_wayland_add_xdg_toplevel_listener(toplevel &C.xdg_toplevel, data voidptr) int
+	fn C.v_multiwindow_wayland_add_xdg_toplevel_decoration_listener(decoration &C.zxdg_toplevel_decoration_v1, data voidptr) int
+	fn C.v_multiwindow_wayland_add_seat_listener(seat &C.wl_seat, data voidptr) int
+	fn C.v_multiwindow_wayland_seat_get_pointer(seat &C.wl_seat) voidptr
+	fn C.v_multiwindow_wayland_seat_get_keyboard(seat &C.wl_seat) voidptr
+	fn C.v_multiwindow_wayland_seat_get_touch(seat &C.wl_seat) voidptr
+	fn C.v_multiwindow_wayland_data_device_manager_get_data_device(manager &C.wl_data_device_manager, seat &C.wl_seat) voidptr
+	fn C.v_multiwindow_wayland_cursor_shape_manager_get_pointer(manager &C.wp_cursor_shape_manager_v1, pointer &C.wl_pointer) voidptr
+	fn C.v_multiwindow_wayland_cursor_shape_device_set_shape(device &C.wp_cursor_shape_device_v1, serial u32, shape u32)
+	fn C.v_multiwindow_wayland_cursor_shape_device_destroy(device &C.wp_cursor_shape_device_v1)
+	fn C.v_multiwindow_wayland_cursor_shape_manager_destroy(manager &C.wp_cursor_shape_manager_v1)
+	fn C.v_multiwindow_wayland_add_pointer_listener(pointer &C.wl_pointer, data voidptr) int
+	fn C.v_multiwindow_wayland_add_keyboard_listener(keyboard &C.wl_keyboard, data voidptr) int
+	fn C.v_multiwindow_wayland_add_touch_listener(touch &C.wl_touch, data voidptr) int
+	fn C.v_multiwindow_wayland_add_data_device_listener(device &C.wl_data_device, data voidptr) int
+	fn C.v_multiwindow_wayland_add_data_offer_listener(offer &C.wl_data_offer, data voidptr) int
+	fn C.v_multiwindow_wayland_data_offer_accept(offer &C.wl_data_offer, serial u32, mime_type &char)
+	fn C.v_multiwindow_wayland_data_offer_set_copy_action(offer &C.wl_data_offer)
+	fn C.v_multiwindow_wayland_data_offer_receive(offer &C.wl_data_offer, mime_type &char, fd int)
+	fn C.v_multiwindow_wayland_fd_set_nonblocking(fd int) int
+	fn C.v_multiwindow_wayland_read_would_block() int
+	fn C.v_multiwindow_wayland_data_offer_finish(offer &C.wl_data_offer)
+	fn C.v_multiwindow_wayland_data_offer_destroy(offer &C.wl_data_offer)
+	fn C.v_multiwindow_wayland_data_device_destroy(device &C.wl_data_device)
+	fn C.v_multiwindow_wayland_data_device_manager_destroy(manager &C.wl_data_device_manager)
+	fn C.v_multiwindow_wayland_shm_destroy(shm &C.wl_shm)
+	fn C.v_multiwindow_wayland_create_shm_buffer(shm &C.wl_shm, width int, height int) voidptr
+	fn C.v_multiwindow_wayland_attach_buffer(surface &C.wl_surface, buffer &C.wl_buffer, width int, height int)
+	fn C.v_multiwindow_wayland_add_buffer_listener(buffer &C.wl_buffer, data voidptr) int
+	fn C.v_multiwindow_wayland_buffer_destroy(buffer &C.wl_buffer)
+	fn C.v_multiwindow_wayland_pointer_destroy(pointer &C.wl_pointer)
+	fn C.v_multiwindow_wayland_keyboard_destroy(keyboard &C.wl_keyboard)
+	fn C.v_multiwindow_wayland_touch_destroy(touch &C.wl_touch)
+	fn C.v_multiwindow_wayland_seat_destroy(seat &C.wl_seat)
 	fn C.wl_display_connect(name &char) &C.wl_display
 	fn C.wl_display_disconnect(display &C.wl_display)
 	fn C.wl_display_get_fd(display &C.wl_display) int
@@ -136,6 +390,12 @@ $if linux && sokol_wayland ? {
 	fn C.v_multiwindow_wayland_xdg_toplevel_set_min_size(toplevel &C.xdg_toplevel, width i32, height i32)
 	fn C.v_multiwindow_wayland_xdg_toplevel_set_max_size(toplevel &C.xdg_toplevel, width i32, height i32)
 	fn C.v_multiwindow_wayland_xdg_toplevel_set_fullscreen(toplevel &C.xdg_toplevel, output &C.wl_output)
+	fn C.v_multiwindow_wayland_xdg_toplevel_move(toplevel &C.xdg_toplevel, seat &C.wl_seat, serial u32)
+	fn C.v_multiwindow_wayland_xdg_toplevel_resize(toplevel &C.xdg_toplevel, seat &C.wl_seat, serial u32, edges u32)
+	fn C.v_multiwindow_wayland_xdg_decoration_manager_get_toplevel_decoration(manager &C.zxdg_decoration_manager_v1, toplevel &C.xdg_toplevel) &C.zxdg_toplevel_decoration_v1
+	fn C.v_multiwindow_wayland_xdg_toplevel_decoration_set_server_side(decoration &C.zxdg_toplevel_decoration_v1)
+	fn C.v_multiwindow_wayland_xdg_toplevel_decoration_destroy(decoration &C.zxdg_toplevel_decoration_v1)
+	fn C.v_multiwindow_wayland_xdg_decoration_manager_destroy(manager &C.zxdg_decoration_manager_v1)
 	fn C.v_multiwindow_wayland_xdg_toplevel_destroy(toplevel &C.xdg_toplevel)
 	fn C.v_multiwindow_wayland_egl_get_display(display &C.wl_display) voidptr
 	fn C.v_multiwindow_wayland_egl_initialize(egl_display voidptr) int
@@ -162,18 +422,90 @@ $if linux && sokol_wayland ? {
 		mut backend := unsafe { &WaylandBackend(data) }
 		if C.strcmp(iface, c'wl_compositor') == 0 {
 			backend.compositor = C.v_multiwindow_wayland_bind_compositor(registry, name, version)
+			backend.compositor_name = name
 			backend.compositor_version = C.v_multiwindow_wayland_compositor_bind_version(version)
 		} else if C.strcmp(iface, c'xdg_wm_base') == 0 {
 			backend.wm_base = C.v_multiwindow_wayland_bind_xdg_wm_base(registry, name)
+			backend.wm_base_name = name
+		} else if C.strcmp(iface, c'zxdg_decoration_manager_v1') == 0
+			&& backend.decoration_manager == unsafe { nil } {
+			manager := C.v_multiwindow_wayland_bind_xdg_decoration_manager(registry, name, version)
+			if manager != unsafe { nil } {
+				backend.decoration_manager = manager
+				backend.decoration_manager_name = name
+			}
+		} else if C.strcmp(iface, c'wp_cursor_shape_manager_v1') == 0
+			&& backend.cursor_shape_manager == unsafe { nil } {
+			manager := C.v_multiwindow_wayland_bind_cursor_shape_manager(registry, name, version)
+			if manager != unsafe { nil } {
+				backend.cursor_shape_manager = manager
+				backend.cursor_shape_manager_name = name
+				backend.ensure_cursor_shape_device()
+			}
+		} else if C.strcmp(iface, c'wl_seat') == 0 && backend.seat == unsafe { nil } {
+			backend.seat = C.v_multiwindow_wayland_bind_seat(registry, name, version)
+			backend.seat_name = name
+			backend.ensure_data_device(data)
+		} else if C.strcmp(iface, c'wl_data_device_manager') == 0
+			&& backend.data_device_manager == unsafe { nil } {
+			manager := C.v_multiwindow_wayland_bind_data_device_manager(registry, name, version)
+			if manager != unsafe { nil } {
+				backend.data_device_manager = manager
+				backend.data_device_manager_name = name
+				backend.ensure_data_device(data)
+			}
+		} else if C.strcmp(iface, c'wl_shm') == 0 && backend.shm == unsafe { nil } {
+			shm := C.v_multiwindow_wayland_bind_shm(registry, name)
+			if shm != unsafe { nil } {
+				backend.shm = shm
+				backend.shm_name = name
+			}
 		}
 	}
 
 	@[export: 'v_multiwindow_wayland_registry_handle_global_remove']
 	@[markused]
 	fn wayland_registry_handle_global_remove(data voidptr, registry &C.wl_registry, name u32) {
-		_ = data
 		_ = registry
-		_ = name
+		if data == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		if name == backend.seat_name {
+			backend.seat_name = 0
+			backend.destroy_seat_devices()
+			if backend.seat != unsafe { nil } {
+				C.v_multiwindow_wayland_seat_destroy(unsafe { &C.wl_seat(backend.seat) })
+				backend.seat = unsafe { nil }
+			}
+		} else if name == backend.data_device_manager_name {
+			backend.data_device_manager_name = 0
+			backend.destroy_data_device_manager()
+		} else if name == backend.shm_name {
+			backend.shm_name = 0
+			if backend.shm != unsafe { nil } {
+				C.v_multiwindow_wayland_shm_destroy(unsafe { &C.wl_shm(backend.shm) })
+				backend.shm = unsafe { nil }
+			}
+		} else if name == backend.wm_base_name {
+			backend.wm_base_name = 0
+			if backend.destroy_removed_wm_base_if_unused() {
+				return
+			}
+		} else if name == backend.decoration_manager_name {
+			backend.destroy_xdg_decoration_manager()
+		} else if name == backend.cursor_shape_manager_name {
+			backend.destroy_cursor_shape_manager()
+		} else if name == backend.compositor_name {
+			backend.compositor_name = 0
+			if backend.compositor != unsafe { nil } {
+				if backend.compositor_version >= u32(4) {
+					C.wl_compositor_destroy(unsafe { &C.wl_compositor(backend.compositor) })
+				}
+				backend.compositor = unsafe { nil }
+				backend.compositor_version = 0
+			}
+		}
 	}
 
 	@[export: 'v_multiwindow_wayland_xdg_wm_base_ping']
@@ -206,15 +538,17 @@ $if linux && sokol_wayland ? {
 		}
 		width = window_extent_for_minimum(width, record.min_width)
 		height = window_extent_for_minimum(height, record.min_height)
-		if record.configured && (record.width != width || record.height != height) {
-			record.resize_event_pending = true
-			record.pending_egl_resize = true
-		}
+		should_queue_resize := record.configured
+			&& (record.width != width || record.height != height)
 		record.width = width
 		record.height = height
 		record.pending_toplevel_width = 0
 		record.pending_toplevel_height = 0
 		record.configured = true
+		if should_queue_resize {
+			record.pending_egl_resize = true
+			record.enqueue_resize_events(C.v_multiwindow_wayland_next_event_sequence())
+		}
 		C.v_multiwindow_wayland_xdg_surface_ack_configure(unsafe {
 			&C.xdg_surface(xdg_surface)
 		}, serial)
@@ -249,7 +583,624 @@ $if linux && sokol_wayland ? {
 			return
 		}
 		mut record := unsafe { &WaylandWindowRecord(data) }
-		record.close_requested = true
+		record.enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(), queued_lifecycle_event(Event{
+			kind:      .window_close_requested
+			window_id: record.id
+		}))
+	}
+
+	@[export: 'v_multiwindow_wayland_xdg_toplevel_decoration_configure']
+	@[markused]
+	fn wayland_xdg_toplevel_decoration_configure(data voidptr, decoration voidptr, mode u32) {
+		_ = decoration
+		if data == unsafe { nil } {
+			return
+		}
+		mut record := unsafe { &WaylandWindowRecord(data) }
+		record.toplevel_decoration_configured = true
+		match mode {
+			wayland_xdg_toplevel_decoration_mode_server_side,
+			wayland_xdg_toplevel_decoration_mode_client_side {
+				record.toplevel_decoration_mode = mode
+			}
+			else {
+				record.toplevel_decoration_mode = wayland_xdg_toplevel_decoration_mode_client_side
+			}
+		}
+	}
+
+	@[export: 'v_multiwindow_wayland_seat_capabilities']
+	@[markused]
+	fn wayland_seat_capabilities(data voidptr, seat voidptr, caps u32) {
+		if data == unsafe { nil } || seat == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		if (caps & wayland_seat_capability_pointer) != 0 {
+			if backend.pointer == unsafe { nil } {
+				pointer := C.v_multiwindow_wayland_seat_get_pointer(unsafe { &C.wl_seat(seat) })
+				if pointer != unsafe { nil }
+					&& C.v_multiwindow_wayland_add_pointer_listener(unsafe { &C.wl_pointer(pointer) }, data) == 0 {
+					backend.pointer = pointer
+					backend.ensure_cursor_shape_device()
+				} else if pointer != unsafe { nil } {
+					C.v_multiwindow_wayland_pointer_destroy(unsafe { &C.wl_pointer(pointer) })
+				}
+			}
+		} else if backend.pointer != unsafe { nil } {
+			backend.destroy_cursor_shape_device()
+			C.v_multiwindow_wayland_pointer_destroy(unsafe { &C.wl_pointer(backend.pointer) })
+			backend.pointer = unsafe { nil }
+			backend.pointer_focused = false
+			backend.pointer_enter_serial_valid = false
+			backend.pointer_buttons = 0
+		}
+		if (caps & wayland_seat_capability_keyboard) != 0 {
+			if backend.keyboard == unsafe { nil } {
+				keyboard := C.v_multiwindow_wayland_seat_get_keyboard(unsafe { &C.wl_seat(seat) })
+				if keyboard != unsafe { nil }
+					&& C.v_multiwindow_wayland_add_keyboard_listener(unsafe { &C.wl_keyboard(keyboard) }, data) == 0 {
+					backend.keyboard = keyboard
+				} else if keyboard != unsafe { nil } {
+					C.v_multiwindow_wayland_keyboard_destroy(unsafe { &C.wl_keyboard(keyboard) })
+				}
+			}
+		} else if backend.keyboard != unsafe { nil } {
+			C.v_multiwindow_wayland_keyboard_destroy(unsafe { &C.wl_keyboard(backend.keyboard) })
+			backend.keyboard = unsafe { nil }
+			backend.keyboard_focused = false
+			backend.modifiers = 0
+			backend.clear_key_repeat_info()
+			backend.clear_keys_down()
+			backend.destroy_xkb_keymap_state()
+		}
+		if (caps & wayland_seat_capability_touch) != 0 {
+			if backend.touch == unsafe { nil } {
+				touch := C.v_multiwindow_wayland_seat_get_touch(unsafe { &C.wl_seat(seat) })
+				if touch != unsafe { nil }
+					&& C.v_multiwindow_wayland_add_touch_listener(unsafe { &C.wl_touch(touch) }, data) == 0 {
+					backend.touch = touch
+				} else if touch != unsafe { nil } {
+					C.v_multiwindow_wayland_touch_destroy(unsafe { &C.wl_touch(touch) })
+				}
+			}
+		} else if backend.touch != unsafe { nil } {
+			C.v_multiwindow_wayland_touch_destroy(unsafe { &C.wl_touch(backend.touch) })
+			backend.touch = unsafe { nil }
+			backend.clear_touches()
+		}
+		backend.ensure_data_device(data)
+	}
+
+	@[export: 'v_multiwindow_wayland_seat_name']
+	@[markused]
+	fn wayland_seat_name(data voidptr, seat voidptr, name &char) {
+		_ = data
+		_ = seat
+		_ = name
+	}
+
+	@[export: 'v_multiwindow_wayland_buffer_release']
+	@[markused]
+	fn wayland_buffer_release(data voidptr, buffer voidptr) {
+		if data == unsafe { nil } || buffer == unsafe { nil } {
+			return
+		}
+		mut record := unsafe { &WaylandWindowRecord(data) }
+		record.release_fallback_buffer(buffer)
+	}
+
+	@[export: 'v_multiwindow_wayland_pointer_enter']
+	@[markused]
+	fn wayland_pointer_enter(data voidptr, pointer voidptr, serial u32, surface voidptr, x f64, y f64) {
+		_ = pointer
+		if data == unsafe { nil } || surface == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		index := backend.window_record_index_for_surface(surface) or { return }
+		mut record := backend.windows[index]
+		backend.pointer_focus = record.id
+		backend.pointer_focused = true
+		backend.pointer_enter_serial = serial
+		backend.pointer_enter_serial_valid = true
+		record.update_mouse_position(f32(x), f32(y), true)
+		record.enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(), queued_input_event(record.input_event(.mouse_enter,
+			backend.event_modifiers())))
+	}
+
+	@[export: 'v_multiwindow_wayland_pointer_leave']
+	@[markused]
+	fn wayland_pointer_leave(data voidptr, pointer voidptr, serial u32, surface voidptr) {
+		_ = pointer
+		_ = serial
+		if data == unsafe { nil } || surface == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		index := backend.window_record_index_for_surface(surface) or { return }
+		mut record := backend.windows[index]
+		record.enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(), queued_input_event(record.input_event(.mouse_leave,
+			backend.event_modifiers())))
+		if backend.pointer_focused && backend.pointer_focus == record.id {
+			backend.pointer_focused = false
+			backend.pointer_enter_serial_valid = false
+		}
+	}
+
+	@[export: 'v_multiwindow_wayland_pointer_motion']
+	@[markused]
+	fn wayland_pointer_motion(data voidptr, pointer voidptr, time u32, x f64, y f64) {
+		_ = pointer
+		_ = time
+		if data == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		index := backend.pointer_focus_record_index() or { return }
+		mut record := backend.windows[index]
+		record.update_mouse_position(f32(x), f32(y), false)
+		record.enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(), queued_input_event(record.input_event(.mouse_move,
+			backend.event_modifiers())))
+	}
+
+	@[export: 'v_multiwindow_wayland_pointer_button']
+	@[markused]
+	fn wayland_pointer_button(data voidptr, pointer voidptr, serial u32, time u32, button u32, state u32) {
+		_ = pointer
+		_ = time
+		if data == unsafe { nil } {
+			return
+		}
+		mouse_button := wayland_mouse_button(button)
+		if mouse_button == wayland_invalid_mouse_button {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		index := backend.pointer_focus_record_index() or { return }
+		modifier := wayland_mouse_modifier(button)
+		if state == wayland_pointer_button_state_pressed {
+			backend.pointer_buttons |= modifier
+		} else if state == wayland_pointer_button_state_released {
+			backend.pointer_buttons &= ~modifier
+		} else {
+			return
+		}
+		if state == wayland_pointer_button_state_pressed {
+			backend.windows[index].store_user_action_serial(serial, backend.poll_generation)
+		}
+		input_kind := if state == wayland_pointer_button_state_pressed {
+			InputEventKind.mouse_down
+		} else {
+			InputEventKind.mouse_up
+		}
+		input := backend.windows[index].input_event_with_payload(input_kind,
+			backend.event_modifiers(), 0, false, mouse_button, 0, 0)
+		backend.windows[index].enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(),
+			queued_input_event(input))
+	}
+
+	@[export: 'v_multiwindow_wayland_pointer_axis']
+	@[markused]
+	fn wayland_pointer_axis(data voidptr, pointer voidptr, time u32, axis u32, value f64) {
+		_ = pointer
+		_ = time
+		if data == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		index := backend.pointer_focus_record_index() or { return }
+		mut record := backend.windows[index]
+		mut scroll_x := f32(0)
+		mut scroll_y := f32(0)
+		if axis == wayland_pointer_axis_vertical_scroll {
+			scroll_y = -f32(value) / f32(wayland_scroll_scale)
+		} else if axis == wayland_pointer_axis_horizontal_scroll {
+			scroll_x = f32(value) / f32(wayland_scroll_scale)
+		} else {
+			return
+		}
+		input := record.input_event_with_payload(.mouse_scroll, backend.event_modifiers(), 0,
+			false, wayland_invalid_mouse_button, scroll_x, scroll_y)
+		record.enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(),
+			queued_input_event(input))
+	}
+
+	@[export: 'v_multiwindow_wayland_keyboard_enter']
+	@[markused]
+	fn wayland_keyboard_enter(data voidptr, keyboard voidptr, serial u32, surface voidptr) {
+		_ = keyboard
+		_ = serial
+		if data == unsafe { nil } || surface == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		index := backend.window_record_index_for_surface(surface) or { return }
+		mut record := backend.windows[index]
+		backend.keyboard_focus = record.id
+		backend.keyboard_focused = true
+		record.enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(), queued_input_event(record.input_event(.focused,
+			backend.event_modifiers())))
+	}
+
+	@[export: 'v_multiwindow_wayland_keyboard_leave']
+	@[markused]
+	fn wayland_keyboard_leave(data voidptr, keyboard voidptr, serial u32, surface voidptr) {
+		_ = keyboard
+		_ = serial
+		if data == unsafe { nil } || surface == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		index := backend.window_record_index_for_surface(surface) or { return }
+		mut record := backend.windows[index]
+		record.enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(), queued_input_event(record.input_event(.unfocused,
+			backend.event_modifiers())))
+		if backend.keyboard_focused && backend.keyboard_focus == record.id {
+			backend.keyboard_focused = false
+		}
+		backend.stop_key_repeat()
+		backend.modifiers = 0
+		backend.clear_keys_down()
+	}
+
+	@[export: 'v_multiwindow_wayland_keyboard_keymap']
+	@[markused]
+	fn wayland_keyboard_keymap(data voidptr, keyboard voidptr, format u32, fd int, size u32) {
+		_ = keyboard
+		if fd < 0 {
+			return
+		}
+		if data == unsafe { nil } || format != wayland_keyboard_keymap_format_xkb_v1 || size == 0 {
+			C.close(fd)
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		if backend.xkb_context == unsafe { nil } {
+			C.close(fd)
+			return
+		}
+		map_str :=
+			C.mmap(unsafe { nil }, usize(size), wayland_prot_read, wayland_map_private, fd, 0)
+		if map_str == wayland_map_failed {
+			C.close(fd)
+			return
+		}
+		keymap := C.xkb_keymap_new_from_string(unsafe { &C.xkb_context(backend.xkb_context) },
+			&char(map_str), wayland_xkb_keymap_format_text_v1, wayland_xkb_keymap_compile_no_flags)
+		C.munmap(map_str, usize(size))
+		C.close(fd)
+		if keymap == unsafe { nil } {
+			return
+		}
+		state := C.xkb_state_new(keymap)
+		if state == unsafe { nil } {
+			C.xkb_keymap_unref(keymap)
+			return
+		}
+		backend.stop_key_repeat()
+		backend.destroy_xkb_keymap_state()
+		backend.xkb_keymap = unsafe { voidptr(keymap) }
+		backend.xkb_state = unsafe { voidptr(state) }
+		backend.modifiers = backend.xkb_modifiers()
+	}
+
+	@[export: 'v_multiwindow_wayland_keyboard_repeat_info']
+	@[markused]
+	fn wayland_keyboard_repeat_info(data voidptr, keyboard voidptr, rate int, delay int) {
+		_ = keyboard
+		if data == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		backend.keyboard_repeat_rate = if rate > 0 { rate } else { 0 }
+		backend.keyboard_repeat_delay = if delay > 0 { delay } else { 0 }
+		if backend.keyboard_repeat_rate == 0 {
+			backend.stop_key_repeat()
+		}
+	}
+
+	@[export: 'v_multiwindow_wayland_keyboard_key']
+	@[markused]
+	fn wayland_keyboard_key(data voidptr, keyboard voidptr, serial u32, time u32, key u32, state u32) {
+		_ = keyboard
+		_ = time
+		if data == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		index := backend.keyboard_focus_record_index() or { return }
+		raw_key := key + 8
+		key_code := wayland_key_code(key)
+		key_index := if key_code >= 0 && key_code < 512 { key_code } else { 0 }
+		key_repeat := state == wayland_keyboard_key_state_pressed && key_index > 0
+			&& backend.keys_down[key_index]
+		char_code := if state == wayland_keyboard_key_state_pressed {
+			backend.char_code_for_key(raw_key)
+		} else {
+			u32(0)
+		}
+		if state == wayland_keyboard_key_state_pressed {
+			backend.windows[index].store_user_action_serial(serial, backend.poll_generation)
+			if key_index > 0 {
+				backend.keys_down[key_index] = true
+			}
+			backend.update_modifier_for_key(key_code, true)
+			backend.start_key_repeat(backend.windows[index], raw_key, key_code)
+		} else if state == wayland_keyboard_key_state_released {
+			backend.stop_key_repeat_for_key(raw_key)
+			if key_index > 0 {
+				backend.keys_down[key_index] = false
+			}
+			backend.update_modifier_for_key(key_code, false)
+		} else {
+			return
+		}
+		if key_code != 0 {
+			input_kind := if state == wayland_keyboard_key_state_pressed {
+				InputEventKind.key_down
+			} else {
+				InputEventKind.key_up
+			}
+			input := backend.windows[index].input_event_with_payload(input_kind,
+				backend.event_modifiers(), key_code, key_repeat, wayland_invalid_mouse_button, 0, 0)
+			backend.windows[index].enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(),
+				queued_input_event(input))
+			if input_kind == .key_down
+				&& wayland_is_clipboard_paste(key_code, backend.event_modifiers()) {
+				clipboard_input := backend.windows[index].input_event(.clipboard_pasted,
+					backend.event_modifiers())
+				backend.windows[index].enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(),
+					queued_input_event(clipboard_input))
+			}
+		}
+		if state == wayland_keyboard_key_state_pressed {
+			if char_code != 0 {
+				char_input := backend.windows[index].input_char_event(char_code, key_repeat,
+					backend.event_modifiers())
+				backend.windows[index].enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(),
+					queued_input_event(char_input))
+			}
+		}
+	}
+
+	@[export: 'v_multiwindow_wayland_keyboard_modifiers']
+	@[markused]
+	fn wayland_keyboard_modifiers(data voidptr, keyboard voidptr, serial u32, mods_depressed u32, mods_latched u32, mods_locked u32, group u32) {
+		_ = keyboard
+		_ = serial
+		if data == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		if backend.xkb_state == unsafe { nil } {
+			return
+		}
+		C.xkb_state_update_mask(unsafe { &C.xkb_state(backend.xkb_state) }, mods_depressed,
+			mods_latched, mods_locked, 0, 0, group)
+		backend.modifiers = backend.xkb_modifiers()
+	}
+
+	@[export: 'v_multiwindow_wayland_touch_down']
+	@[markused]
+	fn wayland_touch_down(data voidptr, touch voidptr, serial u32, time u32, surface voidptr, id int, x f64, y f64) {
+		_ = touch
+		_ = time
+		if data == unsafe { nil } || surface == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		index := backend.window_record_index_for_surface(surface) or { return }
+		slot := backend.touch_slot_for_down(id) or { return }
+		backend.touches[slot] = WaylandTouchPoint{
+			active:    true
+			id:        id
+			window_id: backend.windows[index].id
+			x:         f32(x)
+			y:         f32(y)
+		}
+		backend.windows[index].store_user_action_serial(serial, backend.poll_generation)
+		input := backend.touch_event_for_record(backend.windows[index], .touches_began, slot)
+		backend.windows[index].enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(),
+			queued_input_event(input))
+	}
+
+	@[export: 'v_multiwindow_wayland_touch_up']
+	@[markused]
+	fn wayland_touch_up(data voidptr, touch voidptr, serial u32, time u32, id int) {
+		_ = touch
+		_ = serial
+		_ = time
+		if data == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		slot := backend.touch_slot_for_id(id) or { return }
+		index := backend.window_record_index(backend.touches[slot].window_id) or {
+			backend.touches[slot] = WaylandTouchPoint{}
+			return
+		}
+		mut record := backend.windows[index]
+		record.enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(), queued_input_event(backend.touch_event_for_record(record,
+			.touches_ended, slot)))
+		backend.touches[slot] = WaylandTouchPoint{}
+	}
+
+	@[export: 'v_multiwindow_wayland_touch_motion']
+	@[markused]
+	fn wayland_touch_motion(data voidptr, touch voidptr, time u32, id int, x f64, y f64) {
+		_ = touch
+		_ = time
+		if data == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		slot := backend.touch_slot_for_id(id) or { return }
+		backend.touches[slot].x = f32(x)
+		backend.touches[slot].y = f32(y)
+		index := backend.window_record_index(backend.touches[slot].window_id) or { return }
+		mut record := backend.windows[index]
+		record.enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(), queued_input_event(backend.touch_event_for_record(record,
+			.touches_moved, slot)))
+	}
+
+	@[export: 'v_multiwindow_wayland_touch_cancel']
+	@[markused]
+	fn wayland_touch_cancel(data voidptr, touch voidptr) {
+		_ = touch
+		if data == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		for _, mut record in backend.windows {
+			if backend.touch_count_for_window(record.id) > 0 {
+				record.enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(),
+					queued_input_event(backend.touch_cancel_event_for_record(record)))
+			}
+		}
+		backend.clear_touches()
+	}
+
+	@[export: 'v_multiwindow_wayland_data_offer_offer']
+	@[markused]
+	fn wayland_data_offer_offer(data voidptr, offer voidptr, mime_type &char) {
+		if data == unsafe { nil } || offer == unsafe { nil } || mime_type == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		if backend.data_offer == offer && C.strcmp(mime_type, c'text/uri-list') == 0 {
+			backend.data_offer_has_uri_list = true
+		}
+	}
+
+	@[export: 'v_multiwindow_wayland_data_offer_source_actions']
+	@[markused]
+	fn wayland_data_offer_source_actions(data voidptr, offer voidptr, source_actions u32) {
+		if data == unsafe { nil } || offer == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		if backend.data_offer == offer {
+			backend.data_offer_source_actions = source_actions
+		}
+		if backend.pending_drop_offer == offer {
+			backend.pending_drop_source_actions = source_actions
+		}
+	}
+
+	@[export: 'v_multiwindow_wayland_data_offer_action']
+	@[markused]
+	fn wayland_data_offer_action(data voidptr, offer voidptr, dnd_action u32) {
+		if data == unsafe { nil } || offer == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		if backend.data_offer == offer {
+			backend.data_offer_selected_action = dnd_action
+			backend.data_offer_action_received = true
+		}
+		if backend.pending_drop_offer == offer {
+			backend.pending_drop_selected_action = dnd_action
+			backend.pending_drop_action_received = true
+		}
+	}
+
+	@[export: 'v_multiwindow_wayland_data_device_data_offer']
+	@[markused]
+	fn wayland_data_device_data_offer(data voidptr, device voidptr, offer voidptr) {
+		_ = device
+		if data == unsafe { nil } || offer == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		backend.clear_data_offer(true)
+		backend.data_offer = offer
+		backend.data_offer_has_uri_list = false
+		backend.data_offer_source_actions = wayland_dnd_action_none
+		backend.data_offer_selected_action = wayland_dnd_action_none
+		backend.data_offer_action_received = false
+		if C.v_multiwindow_wayland_add_data_offer_listener(unsafe { &C.wl_data_offer(offer) }, data) < 0 {
+			backend.clear_data_offer(true)
+		}
+	}
+
+	@[export: 'v_multiwindow_wayland_data_device_enter']
+	@[markused]
+	fn wayland_data_device_enter(data voidptr, device voidptr, serial u32, surface voidptr, x f64, y f64, offer voidptr) {
+		_ = device
+		if data == unsafe { nil } || surface == unsafe { nil } || offer == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		if backend.data_offer != offer || !backend.data_offer_has_uri_list {
+			return
+		}
+		index := backend.window_record_index_for_surface(surface) or { return }
+		mut record := backend.windows[index]
+		record.update_mouse_position(f32(x), f32(y), true)
+		backend.data_offer_window = record.id
+		backend.data_offer_window_valid = true
+		C.v_multiwindow_wayland_data_offer_accept(unsafe { &C.wl_data_offer(offer) }, serial,
+			c'text/uri-list')
+		C.v_multiwindow_wayland_data_offer_set_copy_action(unsafe { &C.wl_data_offer(offer) })
+	}
+
+	@[export: 'v_multiwindow_wayland_data_device_leave']
+	@[markused]
+	fn wayland_data_device_leave(data voidptr, device voidptr) {
+		_ = device
+		if data == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		backend.clear_data_offer(true)
+	}
+
+	@[export: 'v_multiwindow_wayland_data_device_motion']
+	@[markused]
+	fn wayland_data_device_motion(data voidptr, device voidptr, time u32, x f64, y f64) {
+		_ = device
+		_ = time
+		if data == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		if !backend.data_offer_window_valid {
+			return
+		}
+		index := backend.window_record_index(backend.data_offer_window) or { return }
+		mut record := backend.windows[index]
+		record.update_mouse_position(f32(x), f32(y), false)
+	}
+
+	@[export: 'v_multiwindow_wayland_data_device_drop']
+	@[markused]
+	fn wayland_data_device_drop(data voidptr, device voidptr) {
+		_ = device
+		if data == unsafe { nil } {
+			return
+		}
+		mut backend := unsafe { &WaylandBackend(data) }
+		if backend.data_offer == unsafe { nil } || !backend.data_offer_has_uri_list
+			|| !backend.data_offer_window_valid {
+			backend.clear_data_offer(true)
+			return
+		}
+		backend.window_record_index(backend.data_offer_window) or {
+			backend.clear_data_offer(true)
+			return
+		}
+		if !backend.data_offer_allows_finish() || !backend.begin_pending_data_offer_drop() {
+			backend.clear_data_offer(true)
+		}
+	}
+
+	@[export: 'v_multiwindow_wayland_data_device_selection']
+	@[markused]
+	fn wayland_data_device_selection(data voidptr, device voidptr, offer voidptr) {
+		_ = data
+		_ = device
+		_ = offer
 	}
 }
 
@@ -267,15 +1218,84 @@ fn (backend &WaylandBackend) ensure_supported() ! {
 
 fn (backend &WaylandBackend) capabilities() Capabilities {
 	return Capabilities{
-		backend:            .wayland
-		mock:               false
-		native:             true
-		multi_window:       true
-		owner_queue:        true
-		explicit_swapchain: backend.renderer_ready()
-		wayland:            true
-		gl:                 backend.renderer_ready()
+		backend:                 .wayland
+		mock:                    false
+		native:                  true
+		multi_window:            true
+		owner_queue:             true
+		explicit_swapchain:      backend.renderer_ready()
+		wayland:                 true
+		gl:                      backend.renderer_ready()
+		input_events:            true
+		mouse_events:            true
+		keyboard_events:         true
+		text_events:             true
+		focus_events:            true
+		drop_events:             backend.can_deliver_drop_events()
+		touch_events:            backend.can_deliver_touch_events()
+		cursor_shapes:           backend.can_set_cursor_shapes()
+		interactive_move_resize: backend.can_begin_interactive_move_resize()
+		native_decorations:      backend.has_server_side_decorated_window()
 	}
+}
+
+fn (backend &WaylandBackend) can_deliver_drop_events() bool {
+	if !backend.started {
+		return true
+	}
+	return backend.seat != unsafe { nil } && backend.data_device_manager != unsafe { nil }
+		&& backend.data_device != unsafe { nil }
+}
+
+fn (backend &WaylandBackend) can_deliver_touch_events() bool {
+	if !backend.started {
+		return true
+	}
+	return backend.seat != unsafe { nil } && backend.touch != unsafe { nil }
+}
+
+fn (backend &WaylandBackend) can_begin_interactive_move_resize() bool {
+	if !backend.started {
+		return true
+	}
+	return backend.seat != unsafe { nil } && backend.wm_base != unsafe { nil }
+}
+
+fn (backend &WaylandBackend) can_set_cursor_shapes() bool {
+	return backend.pointer != unsafe { nil } && backend.cursor_shape_manager != unsafe { nil }
+		&& backend.cursor_shape_device != unsafe { nil }
+}
+
+fn (backend &WaylandBackend) has_server_side_decorated_window() bool {
+	if !backend.started {
+		return true
+	}
+	mut has_server_side := false
+	for record in backend.windows {
+		if record.has_client_side_decoration() {
+			return false
+		}
+		if record.has_server_side_decoration() {
+			has_server_side = true
+		}
+	}
+	return has_server_side
+}
+
+fn (backend &WaylandBackend) window_native_decorations(id WindowId) !bool {
+	index := backend.window_record_index(id) or { return error(err_window_not_found) }
+	return backend.windows[index].has_server_side_decoration()
+}
+
+fn (record &WaylandWindowRecord) has_server_side_decoration() bool {
+	return record.toplevel_decoration != unsafe { nil } && record.toplevel_decoration_configured
+		&& record.toplevel_decoration_mode == wayland_xdg_toplevel_decoration_mode_server_side
+}
+
+fn (record &WaylandWindowRecord) has_client_side_decoration() bool {
+	return record.toplevel_decoration == unsafe { nil }
+		|| (record.toplevel_decoration_configured
+		&& record.toplevel_decoration_mode == wayland_xdg_toplevel_decoration_mode_client_side)
 }
 
 fn (mut backend WaylandBackend) start(require_renderer bool) ! {
@@ -302,16 +1322,30 @@ fn (mut backend WaylandBackend) start(require_renderer bool) ! {
 			backend.close_connection()
 			return error(err_wayland_dispatch_failed)
 		}
-		C.wl_registry_destroy(registry)
-		backend.registry = unsafe { nil }
-		if backend.compositor == unsafe { nil } || backend.wm_base == unsafe { nil } {
+		if backend.compositor == unsafe { nil } || backend.compositor_name == 0
+			|| backend.wm_base == unsafe { nil } || backend.wm_base_name == 0 {
 			backend.close_connection()
 			return error(err_wayland_required_globals_missing)
+		}
+		backend.init_xkb() or {
+			backend.close_connection()
+			return err
 		}
 		wm_base := unsafe { &C.xdg_wm_base(backend.wm_base) }
 		if C.v_multiwindow_wayland_add_xdg_wm_base_listener(wm_base, unsafe { nil }) < 0 {
 			backend.close_connection()
 			return error(err_wayland_registry_failed)
+		}
+		if backend.seat != unsafe { nil } {
+			if C.v_multiwindow_wayland_add_seat_listener(unsafe { &C.wl_seat(backend.seat) },
+				backend.registry_listener_data()) < 0 {
+				backend.close_connection()
+				return error(err_wayland_registry_failed)
+			}
+			if C.wl_display_roundtrip(display) < 0 {
+				backend.close_connection()
+				return error(err_wayland_dispatch_failed)
+			}
 		}
 		if require_renderer {
 			backend.init_renderer() or {
@@ -392,7 +1426,8 @@ fn (mut backend WaylandBackend) create_window(id WindowId, config WindowConfig) 
 		if !backend.started || backend.display == unsafe { nil } {
 			return error(err_wayland_connect_failed)
 		}
-		if backend.compositor == unsafe { nil } || backend.wm_base == unsafe { nil } {
+		if backend.compositor == unsafe { nil } || backend.compositor_name == 0
+			|| backend.wm_base == unsafe { nil } || backend.wm_base_name == 0 {
 			return error(err_wayland_required_globals_missing)
 		}
 		if !config.visible {
@@ -424,6 +1459,7 @@ fn (mut backend WaylandBackend) create_window(id WindowId, config WindowConfig) 
 			surface:      unsafe { voidptr(surface) }
 			xdg_surface:  unsafe { voidptr(xdg_surface) }
 			xdg_toplevel: unsafe { voidptr(xdg_toplevel) }
+			resizable:    config.resizable
 			width:        actual_size.width
 			height:       actual_size.height
 			min_width:    record_min_width
@@ -439,6 +1475,20 @@ fn (mut backend WaylandBackend) create_window(id WindowId, config WindowConfig) 
 		}
 		C.v_multiwindow_wayland_xdg_toplevel_set_title(xdg_toplevel, &char(config.title.str))
 		C.v_multiwindow_wayland_xdg_toplevel_set_app_id(xdg_toplevel, c'v.x.multiwindow')
+		if !config.borderless && backend.decoration_manager != unsafe { nil } {
+			decoration := C.v_multiwindow_wayland_xdg_decoration_manager_get_toplevel_decoration(unsafe {
+				&C.zxdg_decoration_manager_v1(backend.decoration_manager)
+			}, xdg_toplevel)
+			if decoration != unsafe { nil } {
+				if C.v_multiwindow_wayland_add_xdg_toplevel_decoration_listener(decoration,
+					record.listener_data()) == 0 {
+					C.v_multiwindow_wayland_xdg_toplevel_decoration_set_server_side(decoration)
+					record.toplevel_decoration = unsafe { voidptr(decoration) }
+				} else {
+					C.v_multiwindow_wayland_xdg_toplevel_decoration_destroy(decoration)
+				}
+			}
+		}
 		if config.min_width > 0 || config.min_height > 0 {
 			C.v_multiwindow_wayland_xdg_toplevel_set_min_size(xdg_toplevel, i32(config.min_width),
 				i32(config.min_height))
@@ -457,12 +1507,27 @@ fn (mut backend WaylandBackend) create_window(id WindowId, config WindowConfig) 
 		if C.wl_display_flush(display) < 0 {
 			backend.remove_window_record(id)
 			backend.destroy_window_record(record)
+			_ = backend.destroy_removed_wm_base_if_unused()
 			return error(err_wayland_flush_failed)
 		}
 		if C.wl_display_roundtrip(display) < 0 {
 			backend.remove_window_record(id)
 			backend.destroy_window_record(record)
+			_ = backend.destroy_removed_wm_base_if_unused()
 			return error(err_wayland_dispatch_failed)
+		}
+		if !backend.renderer_ready() {
+			index := backend.window_record_index(id) or {
+				backend.destroy_window_record(record)
+				_ = backend.destroy_removed_wm_base_if_unused()
+				return error(err_window_not_found)
+			}
+			backend.ensure_lifecycle_buffer(index) or {
+				backend.remove_window_record(id)
+				backend.destroy_window_record(record)
+				_ = backend.destroy_removed_wm_base_if_unused()
+				return err
+			}
 		}
 		return WindowSize{
 			width:  record.width
@@ -481,6 +1546,7 @@ fn (mut backend WaylandBackend) destroy_window(id WindowId) ! {
 		mut record := backend.windows[index]
 		backend.destroy_window_record(record)
 		backend.windows.delete(index)
+		_ = backend.destroy_removed_wm_base_if_unused()
 		if backend.started && backend.display != unsafe { nil } {
 			display := unsafe { &C.wl_display(backend.display) }
 			if C.wl_display_flush(display) < 0 {
@@ -533,41 +1599,781 @@ fn (mut backend WaylandBackend) resize_window(id WindowId, width int, height int
 	}
 }
 
-fn (mut backend WaylandBackend) poll_events() ![]Event {
-	mut events := []Event{}
+fn (mut backend WaylandBackend) set_window_cursor(id WindowId, shape CursorShape) ! {
 	$if linux && sokol_wayland ? {
+		backend.window_record_index(id) or { return error(err_window_not_found) }
 		if !backend.started || backend.display == unsafe { nil } {
-			return events
+			return error(err_wayland_connect_failed)
 		}
-		backend.dispatch_pending_nonblocking()!
-		mut resized_windows := []Event{}
-		mut close_requested_windows := []WindowId{}
-		for i, record in backend.windows {
-			if record.resize_event_pending {
-				backend.windows[i].resize_event_pending = false
-				resized_windows << Event{
-					kind:      .window_resized
-					window_id: record.id
-					width:     record.width
-					height:    record.height
-				}
-			}
-			if record.close_requested {
-				backend.windows[i].close_requested = false
-				close_requested_windows << record.id
-			}
+		if !backend.can_set_cursor_shapes() || !backend.pointer_focused
+			|| backend.pointer_focus != id || !backend.pointer_enter_serial_valid {
+			return error(err_capability_unsupported)
 		}
-		for event in resized_windows {
-			events << event
+		C.v_multiwindow_wayland_cursor_shape_device_set_shape(unsafe {
+			&C.wp_cursor_shape_device_v1(backend.cursor_shape_device)
+		}, backend.pointer_enter_serial, wayland_cursor_shape_for_shape(shape))
+		display := unsafe { &C.wl_display(backend.display) }
+		if C.wl_display_flush(display) < 0 {
+			return error(err_wayland_flush_failed)
 		}
-		for id in close_requested_windows {
-			events << Event{
-				kind:      .window_close_requested
-				window_id: id
-			}
+		return
+	} $else {
+		_ = id
+		_ = shape
+		return error(err_backend_unsupported)
+	}
+}
+
+fn wayland_cursor_shape_for_shape(shape CursorShape) u32 {
+	return match shape {
+		.default { wayland_cursor_shape_default }
+		.pointer { wayland_cursor_shape_pointer }
+		.move { wayland_cursor_shape_move }
+		.n_resize { wayland_cursor_shape_n_resize }
+		.s_resize { wayland_cursor_shape_s_resize }
+		.e_resize { wayland_cursor_shape_e_resize }
+		.w_resize { wayland_cursor_shape_w_resize }
+		.ne_resize { wayland_cursor_shape_ne_resize }
+		.nw_resize { wayland_cursor_shape_nw_resize }
+		.se_resize { wayland_cursor_shape_se_resize }
+		.sw_resize { wayland_cursor_shape_sw_resize }
+		.ew_resize { wayland_cursor_shape_ew_resize }
+		.ns_resize { wayland_cursor_shape_ns_resize }
+		.nesw_resize { wayland_cursor_shape_nesw_resize }
+		.nwse_resize { wayland_cursor_shape_nwse_resize }
+		.grab { wayland_cursor_shape_grab }
+		.grabbing { wayland_cursor_shape_grabbing }
+	}
+}
+
+fn (mut backend WaylandBackend) begin_window_move(id WindowId) ! {
+	$if linux && sokol_wayland ? {
+		index := backend.window_record_index(id) or { return error(err_window_not_found) }
+		if !backend.started || backend.display == unsafe { nil } {
+			return error(err_wayland_connect_failed)
+		}
+		if backend.seat == unsafe { nil } {
+			return error(err_capability_unsupported)
+		}
+		if backend.windows[index].xdg_toplevel == unsafe { nil } {
+			return error(err_window_not_found)
+		}
+		serial := backend.windows[index].take_user_action_serial(backend.poll_generation) or {
+			return error(err_capability_unsupported)
+		}
+		C.v_multiwindow_wayland_xdg_toplevel_move(unsafe {
+			&C.xdg_toplevel(backend.windows[index].xdg_toplevel)
+		}, unsafe { &C.wl_seat(backend.seat) }, serial)
+		display := unsafe { &C.wl_display(backend.display) }
+		if C.wl_display_flush(display) < 0 {
+			return error(err_wayland_flush_failed)
+		}
+		return
+	} $else {
+		_ = id
+		return error(err_backend_unsupported)
+	}
+}
+
+fn (mut backend WaylandBackend) begin_window_resize(id WindowId, edge WindowResizeEdge) ! {
+	$if linux && sokol_wayland ? {
+		index := backend.window_record_index(id) or { return error(err_window_not_found) }
+		if !backend.started || backend.display == unsafe { nil } {
+			return error(err_wayland_connect_failed)
+		}
+		if backend.seat == unsafe { nil } {
+			return error(err_capability_unsupported)
+		}
+		if !backend.windows[index].resizable {
+			return error(err_capability_unsupported)
+		}
+		if backend.windows[index].xdg_toplevel == unsafe { nil } {
+			return error(err_window_not_found)
+		}
+		serial := backend.windows[index].take_user_action_serial(backend.poll_generation) or {
+			return error(err_capability_unsupported)
+		}
+		C.v_multiwindow_wayland_xdg_toplevel_resize(unsafe {
+			&C.xdg_toplevel(backend.windows[index].xdg_toplevel)
+		}, unsafe { &C.wl_seat(backend.seat) }, serial, wayland_resize_edge(edge))
+		display := unsafe { &C.wl_display(backend.display) }
+		if C.wl_display_flush(display) < 0 {
+			return error(err_wayland_flush_failed)
+		}
+		return
+	} $else {
+		_ = id
+		_ = edge
+		return error(err_backend_unsupported)
+	}
+}
+
+fn (mut backend WaylandBackend) poll_events() ![]Event {
+	queued_events := backend.poll_queued_events()!
+	mut events := []Event{cap: queued_events.len}
+	for event in queued_events {
+		if event.kind == .lifecycle {
+			events << event.lifecycle
 		}
 	}
 	return events
+}
+
+fn (mut backend WaylandBackend) poll_queued_events() ![]QueuedEvent {
+	mut native_events := []WaylandNativeQueuedEvent{}
+	$if linux && sokol_wayland ? {
+		if !backend.started || backend.display == unsafe { nil } {
+			return []QueuedEvent{}
+		}
+		backend.poll_generation++
+		backend.expire_user_action_serials()
+		backend.dispatch_pending_nonblocking()!
+		if !backend.renderer_ready() {
+			backend.ensure_lifecycle_buffers()!
+		}
+		backend.drain_pending_data_offer_drop()
+		backend.enqueue_due_key_repeats()
+		for _, mut record in backend.windows {
+			for native_event in record.pending_events {
+				native_events << native_event
+			}
+			record.pending_events.clear()
+		}
+	}
+	wayland_sort_native_events(mut native_events)
+	mut events := []QueuedEvent{cap: native_events.len}
+	for native_event in native_events {
+		events << native_event.event
+	}
+	return events
+}
+
+fn (mut record WaylandWindowRecord) enqueue_native_event(sequence u64, event QueuedEvent) {
+	record.pending_events << WaylandNativeQueuedEvent{
+		sequence: sequence
+		event:    event
+	}
+}
+
+fn (mut record WaylandWindowRecord) store_user_action_serial(serial u32, poll_generation u64) {
+	record.user_action_serial = serial
+	record.user_action_poll = poll_generation
+	record.user_action_serial_valid = true
+}
+
+fn (mut record WaylandWindowRecord) clear_user_action_serial() {
+	record.user_action_serial = 0
+	record.user_action_poll = 0
+	record.user_action_serial_valid = false
+}
+
+fn (mut record WaylandWindowRecord) take_user_action_serial(poll_generation u64) ?u32 {
+	if !record.user_action_serial_valid || record.user_action_poll != poll_generation {
+		record.clear_user_action_serial()
+		return none
+	}
+	serial := record.user_action_serial
+	record.clear_user_action_serial()
+	return serial
+}
+
+fn (mut backend WaylandBackend) expire_user_action_serials() {
+	for _, mut record in backend.windows {
+		if record.user_action_serial_valid && record.user_action_poll != backend.poll_generation {
+			record.clear_user_action_serial()
+		}
+	}
+}
+
+fn (mut record WaylandWindowRecord) enqueue_resize_events(sequence u64) {
+	record.enqueue_native_event(sequence, queued_lifecycle_event(Event{
+		kind:      .window_resized
+		window_id: record.id
+		width:     record.width
+		height:    record.height
+	}))
+	record.enqueue_native_event(sequence, queued_input_event(record.input_event(.resized, 0)))
+}
+
+fn (record &WaylandWindowRecord) input_event(kind InputEventKind, modifiers u32) InputEvent {
+	return record.input_event_with_payload(kind, modifiers, 0, false, wayland_invalid_mouse_button,
+		0, 0)
+}
+
+fn (record &WaylandWindowRecord) input_event_with_payload(kind InputEventKind, modifiers u32, key_code int, key_repeat bool, mouse_button int, scroll_x f32, scroll_y f32) InputEvent {
+	return InputEvent{
+		kind:               kind
+		window_id:          record.id
+		key_code:           key_code
+		key_repeat:         key_repeat
+		modifiers:          modifiers
+		mouse_x:            record.mouse_x
+		mouse_y:            record.mouse_y
+		mouse_dx:           record.mouse_dx
+		mouse_dy:           record.mouse_dy
+		mouse_button:       mouse_button
+		scroll_x:           scroll_x
+		scroll_y:           scroll_y
+		window_width:       record.width
+		window_height:      record.height
+		framebuffer_width:  record.width
+		framebuffer_height: record.height
+	}
+}
+
+fn (record &WaylandWindowRecord) input_char_event(char_code u32, key_repeat bool, modifiers u32) InputEvent {
+	return InputEvent{
+		kind:               .char
+		window_id:          record.id
+		char_code:          char_code
+		key_repeat:         key_repeat
+		modifiers:          modifiers
+		window_width:       record.width
+		window_height:      record.height
+		framebuffer_width:  record.width
+		framebuffer_height: record.height
+	}
+}
+
+fn (mut backend WaylandBackend) start_key_repeat(record &WaylandWindowRecord, raw_key u32, key_code int) {
+	$if linux && sokol_wayland ? {
+		if key_code == 0 {
+			return
+		}
+		if !backend.key_repeats(raw_key) {
+			return
+		}
+		if backend.keyboard_repeat_rate <= 0 || !backend.keyboard_focused
+			|| backend.keyboard_focus != record.id {
+			backend.stop_key_repeat()
+			return
+		}
+		interval_ns := wayland_key_repeat_interval_ns(backend.keyboard_repeat_rate)
+		if interval_ns == 0 {
+			backend.stop_key_repeat()
+			return
+		}
+		backend.keyboard_repeat_active = true
+		backend.keyboard_repeat_raw_key = raw_key
+		backend.keyboard_repeat_key_code = key_code
+		backend.keyboard_repeat_window = record.id
+		backend.keyboard_repeat_interval_ns = interval_ns
+		backend.keyboard_repeat_next_ns = vtime.sys_mono_now() +
+			u64(backend.keyboard_repeat_delay) * wayland_nsec_per_msec
+	} $else {
+		_ = record
+		_ = raw_key
+		_ = key_code
+	}
+}
+
+fn (mut backend WaylandBackend) stop_key_repeat() {
+	backend.keyboard_repeat_active = false
+	backend.keyboard_repeat_raw_key = 0
+	backend.keyboard_repeat_key_code = 0
+	backend.keyboard_repeat_window = WindowId{}
+	backend.keyboard_repeat_next_ns = 0
+	backend.keyboard_repeat_interval_ns = 0
+}
+
+fn (mut backend WaylandBackend) stop_key_repeat_for_key(raw_key u32) {
+	if backend.keyboard_repeat_active && backend.keyboard_repeat_raw_key == raw_key {
+		backend.stop_key_repeat()
+	}
+}
+
+fn (mut backend WaylandBackend) stop_key_repeat_for_window(id WindowId) {
+	if backend.keyboard_repeat_active && backend.keyboard_repeat_window == id {
+		backend.stop_key_repeat()
+	}
+}
+
+fn (mut backend WaylandBackend) clear_key_repeat_info() {
+	backend.stop_key_repeat()
+	backend.keyboard_repeat_rate = 0
+	backend.keyboard_repeat_delay = 0
+}
+
+fn (mut backend WaylandBackend) enqueue_due_key_repeats() {
+	$if linux && sokol_wayland ? {
+		if !backend.keyboard_repeat_active {
+			return
+		}
+		if backend.keyboard_repeat_interval_ns == 0 || !backend.keyboard_focused
+			|| backend.keyboard_focus != backend.keyboard_repeat_window {
+			backend.stop_key_repeat()
+			return
+		}
+		index := backend.window_record_index(backend.keyboard_repeat_window) or {
+			backend.stop_key_repeat()
+			return
+		}
+		now := vtime.sys_mono_now()
+		if now < backend.keyboard_repeat_next_ns {
+			return
+		}
+		modifiers := backend.event_modifiers()
+		input := backend.windows[index].input_event_with_payload(.key_down, modifiers,
+			backend.keyboard_repeat_key_code, true, wayland_invalid_mouse_button, 0, 0)
+		backend.windows[index].enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(),
+			queued_input_event(input))
+		char_code := backend.char_code_for_key(backend.keyboard_repeat_raw_key)
+		if char_code != 0 {
+			char_input := backend.windows[index].input_char_event(char_code, true, modifiers)
+			backend.windows[index].enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(),
+				queued_input_event(char_input))
+		}
+		backend.keyboard_repeat_next_ns += backend.keyboard_repeat_interval_ns
+		if backend.keyboard_repeat_next_ns <= now {
+			skipped_intervals :=
+				((now - backend.keyboard_repeat_next_ns) / backend.keyboard_repeat_interval_ns) + 1
+			backend.keyboard_repeat_next_ns += skipped_intervals * backend.keyboard_repeat_interval_ns
+		}
+	}
+}
+
+fn wayland_key_repeat_interval_ns(rate int) u64 {
+	if rate <= 0 {
+		return 0
+	}
+	interval_ns := wayland_nsec_per_sec / u64(rate)
+	if interval_ns == 0 {
+		return 1
+	}
+	return interval_ns
+}
+
+fn (record &WaylandWindowRecord) input_files_dropped_event(files []string) InputEvent {
+	return InputEvent{
+		kind:               .files_dropped
+		window_id:          record.id
+		mouse_x:            record.mouse_x
+		mouse_y:            record.mouse_y
+		mouse_dx:           record.mouse_dx
+		mouse_dy:           record.mouse_dy
+		mouse_button:       wayland_invalid_mouse_button
+		window_width:       record.width
+		window_height:      record.height
+		framebuffer_width:  record.width
+		framebuffer_height: record.height
+		dropped_files:      files.clone()
+	}
+}
+
+fn (backend &WaylandBackend) touch_event_for_record(record &WaylandWindowRecord, kind InputEventKind, changed_slot int) InputEvent {
+	mut touches := [8]InputTouchPoint{}
+	mut count := 0
+	for i, touch in backend.touches {
+		if !touch.active || touch.window_id != record.id || count >= wayland_max_touch_points {
+			continue
+		}
+		touches[count] = InputTouchPoint{
+			identifier:       u64(touch.id)
+			pos_x:            touch.x
+			pos_y:            touch.y
+			android_tooltype: 1
+			changed:          i == changed_slot
+		}
+		count++
+	}
+	mouse_x, mouse_y := backend.touch_mouse_position_for_record(record, changed_slot)
+	return InputEvent{
+		kind:               kind
+		window_id:          record.id
+		modifiers:          backend.event_modifiers()
+		mouse_x:            mouse_x
+		mouse_y:            mouse_y
+		num_touches:        count
+		touches:            touches
+		window_width:       record.width
+		window_height:      record.height
+		framebuffer_width:  record.width
+		framebuffer_height: record.height
+	}
+}
+
+fn (backend &WaylandBackend) touch_cancel_event_for_record(record &WaylandWindowRecord) InputEvent {
+	mut touches := [8]InputTouchPoint{}
+	mut count := 0
+	for touch in backend.touches {
+		if !touch.active || touch.window_id != record.id || count >= wayland_max_touch_points {
+			continue
+		}
+		touches[count] = InputTouchPoint{
+			identifier:       u64(touch.id)
+			pos_x:            touch.x
+			pos_y:            touch.y
+			android_tooltype: 1
+			changed:          true
+		}
+		count++
+	}
+	mouse_x, mouse_y := backend.touch_mouse_position_for_record(record, -1)
+	return InputEvent{
+		kind:               .touches_cancelled
+		window_id:          record.id
+		modifiers:          backend.event_modifiers()
+		mouse_x:            mouse_x
+		mouse_y:            mouse_y
+		num_touches:        count
+		touches:            touches
+		window_width:       record.width
+		window_height:      record.height
+		framebuffer_width:  record.width
+		framebuffer_height: record.height
+	}
+}
+
+fn (backend &WaylandBackend) touch_mouse_position_for_record(record &WaylandWindowRecord, changed_slot int) (f32, f32) {
+	if changed_slot >= 0 && changed_slot < backend.touches.len {
+		touch := backend.touches[changed_slot]
+		if touch.active && touch.window_id == record.id {
+			return touch.x, touch.y
+		}
+	}
+	for touch in backend.touches {
+		if touch.active && touch.window_id == record.id {
+			return touch.x, touch.y
+		}
+	}
+	return record.mouse_x, record.mouse_y
+}
+
+fn (mut record WaylandWindowRecord) update_mouse_position(x f32, y f32, clear_delta bool) {
+	if clear_delta || !record.mouse_pos_valid {
+		record.mouse_dx = 0
+		record.mouse_dy = 0
+	} else {
+		record.mouse_dx = x - record.mouse_x
+		record.mouse_dy = y - record.mouse_y
+	}
+	record.mouse_x = x
+	record.mouse_y = y
+	record.mouse_pos_valid = true
+}
+
+fn wayland_sort_native_events(mut events []WaylandNativeQueuedEvent) {
+	for i in 1 .. events.len {
+		mut j := i
+		for j > 0 && events[j - 1].sequence > events[j].sequence {
+			event := events[j]
+			events[j] = events[j - 1]
+			events[j - 1] = event
+			j--
+		}
+	}
+}
+
+fn (backend &WaylandBackend) window_record_index_for_surface(surface voidptr) ?int {
+	for i, record in backend.windows {
+		if record.surface == surface {
+			return i
+		}
+	}
+	return none
+}
+
+fn (backend &WaylandBackend) pointer_focus_record_index() ?int {
+	if !backend.pointer_focused {
+		return none
+	}
+	return backend.window_record_index(backend.pointer_focus)
+}
+
+fn (backend &WaylandBackend) keyboard_focus_record_index() ?int {
+	if !backend.keyboard_focused {
+		return none
+	}
+	return backend.window_record_index(backend.keyboard_focus)
+}
+
+fn (backend &WaylandBackend) event_modifiers() u32 {
+	return backend.modifiers | backend.pointer_buttons
+}
+
+fn wayland_resize_edge(edge WindowResizeEdge) u32 {
+	return match edge {
+		.top { wayland_xdg_toplevel_resize_edge_top }
+		.bottom { wayland_xdg_toplevel_resize_edge_bottom }
+		.left { wayland_xdg_toplevel_resize_edge_left }
+		.right { wayland_xdg_toplevel_resize_edge_right }
+		.top_left { wayland_xdg_toplevel_resize_edge_top_left }
+		.top_right { wayland_xdg_toplevel_resize_edge_top_right }
+		.bottom_left { wayland_xdg_toplevel_resize_edge_bottom_left }
+		.bottom_right { wayland_xdg_toplevel_resize_edge_bottom_right }
+	}
+}
+
+fn wayland_is_clipboard_paste(key_code int, modifiers u32) bool {
+	return key_code == wayland_key_v && modifiers == wayland_modifier_ctrl
+}
+
+fn (backend &WaylandBackend) key_repeats(raw_key u32) bool {
+	$if linux && sokol_wayland ? {
+		if backend.xkb_keymap == unsafe { nil } {
+			return false
+		}
+		return C.xkb_keymap_key_repeats(unsafe { &C.xkb_keymap(backend.xkb_keymap) }, raw_key) != 0
+	}
+	_ = raw_key
+	return false
+}
+
+fn (backend &WaylandBackend) char_code_for_key(key u32) u32 {
+	$if linux && sokol_wayland ? {
+		if backend.xkb_state == unsafe { nil } {
+			return 0
+		}
+		mut buf := [8]u8{}
+		count := C.xkb_state_key_get_utf8(unsafe { &C.xkb_state(backend.xkb_state) }, key,
+			&char(&buf[0]), usize(buf.len))
+		if count <= 0 || count >= buf.len {
+			return 0
+		}
+		codepoint := wayland_utf8_decode(&buf[0], count)
+		if codepoint > 0 && codepoint < 0x110000 {
+			return codepoint
+		}
+	}
+	return 0
+}
+
+fn (backend &WaylandBackend) xkb_modifiers() u32 {
+	$if linux && sokol_wayland ? {
+		if backend.xkb_state == unsafe { nil } {
+			return backend.modifiers
+		}
+		state := unsafe { &C.xkb_state(backend.xkb_state) }
+		mut modifiers := backend.modifiers & (wayland_modifier_lmb | wayland_modifier_rmb | wayland_modifier_mmb)
+		if C.xkb_state_mod_name_is_active(state, c'Shift', wayland_xkb_state_mods_effective) > 0 {
+			modifiers |= wayland_modifier_shift
+		}
+		if C.xkb_state_mod_name_is_active(state, c'Control', wayland_xkb_state_mods_effective) > 0 {
+			modifiers |= wayland_modifier_ctrl
+		}
+		if C.xkb_state_mod_name_is_active(state, c'Mod1', wayland_xkb_state_mods_effective) > 0 {
+			modifiers |= wayland_modifier_alt
+		}
+		if C.xkb_state_mod_name_is_active(state, c'Mod4', wayland_xkb_state_mods_effective) > 0 {
+			modifiers |= wayland_modifier_super
+		}
+		return modifiers
+	}
+	return backend.modifiers
+}
+
+fn (mut backend WaylandBackend) touch_slot_for_down(id int) ?int {
+	if slot := backend.touch_slot_for_id(id) {
+		return slot
+	}
+	for i, touch in backend.touches {
+		if !touch.active {
+			return i
+		}
+	}
+	return none
+}
+
+fn (backend &WaylandBackend) touch_slot_for_id(id int) ?int {
+	for i, touch in backend.touches {
+		if touch.active && touch.id == id {
+			return i
+		}
+	}
+	return none
+}
+
+fn (backend &WaylandBackend) touch_count_for_window(id WindowId) int {
+	mut count := 0
+	for touch in backend.touches {
+		if touch.active && touch.window_id == id {
+			count++
+		}
+	}
+	return count
+}
+
+fn (mut backend WaylandBackend) clear_touches() {
+	for i in 0 .. backend.touches.len {
+		backend.touches[i] = WaylandTouchPoint{}
+	}
+}
+
+fn (mut backend WaylandBackend) update_modifier_for_key(key_code int, down bool) {
+	modifier := match key_code {
+		340, 344 { wayland_modifier_shift }
+		341, 345 { wayland_modifier_ctrl }
+		342, 346 { wayland_modifier_alt }
+		343, 347 { wayland_modifier_super }
+		else { u32(0) }
+	}
+
+	if modifier == 0 {
+		return
+	}
+	if down {
+		backend.modifiers |= modifier
+	} else {
+		backend.modifiers &= ~modifier
+	}
+}
+
+fn (mut backend WaylandBackend) clear_keys_down() {
+	backend.stop_key_repeat()
+	for i in 0 .. backend.keys_down.len {
+		backend.keys_down[i] = false
+	}
+}
+
+fn wayland_utf8_decode(buf &u8, count int) u32 {
+	if count <= 0 {
+		return 0
+	}
+	b0 := unsafe { buf[0] }
+	if (b0 & 0x80) == 0 {
+		return u32(b0)
+	}
+	if (b0 & 0xe0) == 0xc0 && count >= 2 {
+		return (u32(b0 & 0x1f) << 6) | u32(unsafe { buf[1] } & 0x3f)
+	}
+	if (b0 & 0xf0) == 0xe0 && count >= 3 {
+		return (u32(b0 & 0x0f) << 12) | (u32(unsafe { buf[1] } & 0x3f) << 6) | u32(unsafe {
+			buf[2]
+		} & 0x3f)
+	}
+	if (b0 & 0xf8) == 0xf0 && count >= 4 {
+		return (u32(b0 & 0x07) << 18) | (u32(unsafe { buf[1] } & 0x3f) << 12) | (u32(unsafe {
+			buf[2]
+		} & 0x3f) << 6) | u32(unsafe { buf[3] } & 0x3f)
+	}
+	return 0
+}
+
+fn wayland_mouse_button(button u32) int {
+	return match button {
+		wayland_btn_left { 0 }
+		wayland_btn_right { 1 }
+		wayland_btn_middle { 2 }
+		else { wayland_invalid_mouse_button }
+	}
+}
+
+fn wayland_mouse_modifier(button u32) u32 {
+	return match button {
+		wayland_btn_left { wayland_modifier_lmb }
+		wayland_btn_right { wayland_modifier_rmb }
+		wayland_btn_middle { wayland_modifier_mmb }
+		else { u32(0) }
+	}
+}
+
+fn wayland_key_code(key u32) int {
+	return match key {
+		2 { 49 }
+		3 { 50 }
+		4 { 51 }
+		5 { 52 }
+		6 { 53 }
+		7 { 54 }
+		8 { 55 }
+		9 { 56 }
+		10 { 57 }
+		11 { 48 }
+		12 { 45 }
+		13 { 61 }
+		14 { 259 }
+		15 { 258 }
+		16 { 81 }
+		17 { 87 }
+		18 { 69 }
+		19 { 82 }
+		20 { 84 }
+		21 { 89 }
+		22 { 85 }
+		23 { 73 }
+		24 { 79 }
+		25 { 80 }
+		26 { 91 }
+		27 { 93 }
+		28 { 257 }
+		29 { 341 }
+		30 { 65 }
+		31 { 83 }
+		32 { 68 }
+		33 { 70 }
+		34 { 71 }
+		35 { 72 }
+		36 { 74 }
+		37 { 75 }
+		38 { 76 }
+		39 { 59 }
+		40 { 39 }
+		41 { 96 }
+		42 { 340 }
+		43 { 92 }
+		44 { 90 }
+		45 { 88 }
+		46 { 67 }
+		47 { 86 }
+		48 { 66 }
+		49 { 78 }
+		50 { 77 }
+		51 { 44 }
+		52 { 46 }
+		53 { 47 }
+		54 { 344 }
+		55 { 332 }
+		56 { 342 }
+		57 { 32 }
+		58 { 280 }
+		59 { 290 }
+		60 { 291 }
+		61 { 292 }
+		62 { 293 }
+		63 { 294 }
+		64 { 295 }
+		65 { 296 }
+		66 { 297 }
+		67 { 298 }
+		68 { 299 }
+		69 { 282 }
+		70 { 281 }
+		71 { 327 }
+		72 { 328 }
+		73 { 329 }
+		74 { 333 }
+		75 { 324 }
+		76 { 325 }
+		77 { 326 }
+		78 { 334 }
+		79 { 321 }
+		80 { 322 }
+		81 { 323 }
+		82 { 320 }
+		83 { 330 }
+		86 { 162 }
+		87 { 300 }
+		88 { 301 }
+		96 { 335 }
+		97 { 345 }
+		98 { 331 }
+		99 { 283 }
+		100 { 346 }
+		102 { 268 }
+		103 { 265 }
+		104 { 266 }
+		105 { 263 }
+		106 { 262 }
+		107 { 269 }
+		108 { 264 }
+		109 { 267 }
+		110 { 260 }
+		111 { 261 }
+		119 { 284 }
+		125 { 343 }
+		126 { 347 }
+		else { 0 }
+	}
 }
 
 fn (mut backend WaylandBackend) stop() ! {
@@ -827,6 +2633,88 @@ fn safe_wayland_extent(value int) int {
 	return 1
 }
 
+fn (mut backend WaylandBackend) ensure_lifecycle_buffers() ! {
+	$if linux && sokol_wayland ? {
+		for i in 0 .. backend.windows.len {
+			backend.ensure_lifecycle_buffer(i)!
+		}
+		return
+	}
+	return error(err_backend_unsupported)
+}
+
+fn (mut backend WaylandBackend) ensure_lifecycle_buffer(index int) ! {
+	$if linux && sokol_wayland ? {
+		if backend.renderer_ready() {
+			return
+		}
+		if backend.shm == unsafe { nil } {
+			return error(err_wayland_buffer_failed)
+		}
+		if index < 0 || index >= backend.windows.len {
+			return error(err_window_not_found)
+		}
+		record := backend.windows[index]
+		if record.surface == unsafe { nil } {
+			return error(err_window_not_found)
+		}
+		if !record.configured {
+			return error(err_wayland_surface_not_configured)
+		}
+		width := safe_wayland_extent(record.width)
+		height := safe_wayland_extent(record.height)
+		if record.fallback_buffer_width == width && record.fallback_buffer_height == height {
+			return
+		}
+		if record.fallback_buffers.len >= wayland_max_fallback_buffers {
+			return
+		}
+		buffer := C.v_multiwindow_wayland_create_shm_buffer(unsafe { &C.wl_shm(backend.shm) },
+			width, height)
+		if buffer == unsafe { nil } {
+			return error(err_wayland_buffer_failed)
+		}
+		if C.v_multiwindow_wayland_add_buffer_listener(unsafe { &C.wl_buffer(buffer) },
+			record.listener_data()) != 0 {
+			C.v_multiwindow_wayland_buffer_destroy(unsafe { &C.wl_buffer(buffer) })
+			return error(err_wayland_buffer_failed)
+		}
+		C.v_multiwindow_wayland_attach_buffer(unsafe { &C.wl_surface(record.surface) },
+			unsafe { &C.wl_buffer(buffer) }, width, height)
+		backend.windows[index].fallback_buffers << buffer
+		backend.windows[index].fallback_current_buffer = buffer
+		backend.windows[index].fallback_buffer_width = width
+		backend.windows[index].fallback_buffer_height = height
+		if backend.display != unsafe { nil } {
+			display := unsafe { &C.wl_display(backend.display) }
+			if C.wl_display_flush(display) < 0 {
+				return error(err_wayland_flush_failed)
+			}
+		}
+		return
+	}
+	_ = index
+	return error(err_backend_unsupported)
+}
+
+fn (mut record WaylandWindowRecord) release_fallback_buffer(buffer voidptr) {
+	$if linux && sokol_wayland ? {
+		for i, fallback_buffer in record.fallback_buffers {
+			if fallback_buffer != buffer {
+				continue
+			}
+			if record.fallback_current_buffer == buffer {
+				record.fallback_current_buffer = unsafe { nil }
+			}
+			C.v_multiwindow_wayland_buffer_destroy(unsafe { &C.wl_buffer(buffer) })
+			record.fallback_buffers.delete(i)
+			return
+		}
+	} $else {
+		_ = buffer
+	}
+}
+
 fn (mut backend WaylandBackend) close_connection() {
 	$if linux && sokol_wayland ? {
 		for backend.windows.len > 0 {
@@ -834,9 +2722,21 @@ fn (mut backend WaylandBackend) close_connection() {
 			backend.destroy_window_record(record)
 			backend.windows.delete(0)
 		}
+		_ = backend.destroy_removed_wm_base_if_unused()
+		backend.destroy_seat_devices()
+		backend.destroy_data_device_manager()
+		backend.destroy_xdg_decoration_manager()
+		backend.destroy_cursor_shape_manager()
 		backend.shutdown_renderer()
+		backend.destroy_xkb()
+		if backend.shm != unsafe { nil } {
+			C.v_multiwindow_wayland_shm_destroy(unsafe { &C.wl_shm(backend.shm) })
+		}
 		if backend.wm_base != unsafe { nil } {
 			C.v_multiwindow_wayland_xdg_wm_base_destroy(unsafe { &C.xdg_wm_base(backend.wm_base) })
+		}
+		if backend.seat != unsafe { nil } {
+			C.v_multiwindow_wayland_seat_destroy(unsafe { &C.wl_seat(backend.seat) })
 		}
 		if backend.compositor != unsafe { nil } && backend.compositor_version >= u32(4) {
 			C.wl_compositor_destroy(unsafe { &C.wl_compositor(backend.compositor) })
@@ -852,20 +2752,196 @@ fn (mut backend WaylandBackend) close_connection() {
 		backend.display = unsafe { nil }
 		backend.registry = unsafe { nil }
 		backend.compositor = unsafe { nil }
+		backend.compositor_name = 0
 		backend.compositor_version = 0
+		backend.seat = unsafe { nil }
+		backend.seat_name = 0
+		backend.cursor_shape_manager = unsafe { nil }
+		backend.cursor_shape_manager_name = 0
+		backend.cursor_shape_device = unsafe { nil }
+		backend.data_device_manager = unsafe { nil }
+		backend.data_device_manager_name = 0
+		backend.data_device = unsafe { nil }
+		backend.shm = unsafe { nil }
+		backend.shm_name = 0
+		backend.data_offer = unsafe { nil }
+		backend.data_offer_has_uri_list = false
+		backend.data_offer_window_valid = false
 		backend.wm_base = unsafe { nil }
+		backend.wm_base_name = 0
+		backend.decoration_manager = unsafe { nil }
+		backend.decoration_manager_name = 0
+		backend.pointer_enter_serial_valid = false
 		backend.started = false
 	}
 }
 
-fn (backend &WaylandBackend) destroy_window_record(record &WaylandWindowRecord) {
+fn (mut backend WaylandBackend) init_xkb() ! {
 	$if linux && sokol_wayland ? {
+		if backend.xkb_context != unsafe { nil } {
+			return
+		}
+		context := C.xkb_context_new(wayland_xkb_context_no_flags)
+		if context == unsafe { nil } {
+			return error(err_wayland_xkb_context_failed)
+		}
+		backend.xkb_context = unsafe { voidptr(context) }
+		return
+	}
+	return error(err_backend_unsupported)
+}
+
+fn (mut backend WaylandBackend) destroy_xkb_keymap_state() {
+	$if linux && sokol_wayland ? {
+		if backend.xkb_state != unsafe { nil } {
+			C.xkb_state_unref(unsafe { &C.xkb_state(backend.xkb_state) })
+		}
+		if backend.xkb_keymap != unsafe { nil } {
+			C.xkb_keymap_unref(unsafe { &C.xkb_keymap(backend.xkb_keymap) })
+		}
+		backend.xkb_state = unsafe { nil }
+		backend.xkb_keymap = unsafe { nil }
+	}
+}
+
+fn (mut backend WaylandBackend) destroy_xkb() {
+	$if linux && sokol_wayland ? {
+		backend.destroy_xkb_keymap_state()
+		if backend.xkb_context != unsafe { nil } {
+			C.xkb_context_unref(unsafe { &C.xkb_context(backend.xkb_context) })
+		}
+		backend.xkb_context = unsafe { nil }
+	}
+}
+
+fn (mut backend WaylandBackend) destroy_xdg_decoration_manager() {
+	$if linux && sokol_wayland ? {
+		if backend.decoration_manager != unsafe { nil } {
+			C.v_multiwindow_wayland_xdg_decoration_manager_destroy(unsafe {
+				&C.zxdg_decoration_manager_v1(backend.decoration_manager)
+			})
+		}
+		backend.decoration_manager = unsafe { nil }
+		backend.decoration_manager_name = 0
+	}
+}
+
+fn (mut backend WaylandBackend) ensure_cursor_shape_device() {
+	$if linux && sokol_wayland ? {
+		if backend.cursor_shape_device != unsafe { nil }
+			|| backend.cursor_shape_manager == unsafe { nil } || backend.pointer == unsafe { nil } {
+			return
+		}
+		device := C.v_multiwindow_wayland_cursor_shape_manager_get_pointer(unsafe {
+			&C.wp_cursor_shape_manager_v1(backend.cursor_shape_manager)
+		}, unsafe { &C.wl_pointer(backend.pointer) })
+		if device != unsafe { nil } {
+			backend.cursor_shape_device = device
+		}
+	}
+}
+
+fn (mut backend WaylandBackend) destroy_cursor_shape_device() {
+	$if linux && sokol_wayland ? {
+		if backend.cursor_shape_device != unsafe { nil } {
+			C.v_multiwindow_wayland_cursor_shape_device_destroy(unsafe {
+				&C.wp_cursor_shape_device_v1(backend.cursor_shape_device)
+			})
+		}
+		backend.cursor_shape_device = unsafe { nil }
+	}
+}
+
+fn (mut backend WaylandBackend) destroy_cursor_shape_manager() {
+	$if linux && sokol_wayland ? {
+		backend.destroy_cursor_shape_device()
+		if backend.cursor_shape_manager != unsafe { nil } {
+			C.v_multiwindow_wayland_cursor_shape_manager_destroy(unsafe {
+				&C.wp_cursor_shape_manager_v1(backend.cursor_shape_manager)
+			})
+		}
+		backend.cursor_shape_manager = unsafe { nil }
+		backend.cursor_shape_manager_name = 0
+	}
+}
+
+fn (mut backend WaylandBackend) destroy_removed_wm_base_if_unused() bool {
+	$if linux && sokol_wayland ? {
+		if backend.wm_base_name != 0 || backend.wm_base == unsafe { nil }
+			|| backend.windows.len != 0 {
+			return false
+		}
+		C.v_multiwindow_wayland_xdg_wm_base_destroy(unsafe { &C.xdg_wm_base(backend.wm_base) })
+		backend.wm_base = unsafe { nil }
+		return true
+	}
+	return false
+}
+
+fn (mut backend WaylandBackend) destroy_seat_devices() {
+	$if linux && sokol_wayland ? {
+		backend.destroy_data_device()
+		backend.destroy_cursor_shape_device()
+		if backend.pointer != unsafe { nil } {
+			C.v_multiwindow_wayland_pointer_destroy(unsafe { &C.wl_pointer(backend.pointer) })
+		}
+		if backend.keyboard != unsafe { nil } {
+			C.v_multiwindow_wayland_keyboard_destroy(unsafe { &C.wl_keyboard(backend.keyboard) })
+		}
+		if backend.touch != unsafe { nil } {
+			C.v_multiwindow_wayland_touch_destroy(unsafe { &C.wl_touch(backend.touch) })
+		}
+		backend.pointer = unsafe { nil }
+		backend.keyboard = unsafe { nil }
+		backend.touch = unsafe { nil }
+		backend.pointer_focused = false
+		backend.pointer_enter_serial_valid = false
+		backend.keyboard_focused = false
+		backend.pointer_buttons = 0
+		backend.modifiers = 0
+		backend.clear_key_repeat_info()
+		backend.clear_keys_down()
+		backend.clear_touches()
+		backend.destroy_xkb_keymap_state()
+	}
+}
+
+fn (mut backend WaylandBackend) destroy_window_record(record &WaylandWindowRecord) {
+	$if linux && sokol_wayland ? {
+		if backend.pointer_focused && backend.pointer_focus == record.id {
+			backend.pointer_focused = false
+			backend.pointer_enter_serial_valid = false
+			backend.pointer_buttons = 0
+		}
+		if backend.keyboard_focused && backend.keyboard_focus == record.id {
+			backend.keyboard_focused = false
+			backend.clear_keys_down()
+		}
+		backend.stop_key_repeat_for_window(record.id)
+		for i, touch in backend.touches {
+			if touch.active && touch.window_id == record.id {
+				backend.touches[i] = WaylandTouchPoint{}
+			}
+		}
+		if backend.data_offer_window_valid && backend.data_offer_window == record.id {
+			backend.clear_data_offer(true)
+		}
 		if backend.egl_display != unsafe { nil } && record.egl_surface != unsafe { nil } {
 			C.v_multiwindow_wayland_egl_clear_current(backend.egl_display)
 			C.v_multiwindow_wayland_egl_destroy_surface(backend.egl_display, record.egl_surface)
 		}
 		if record.wl_egl_window != unsafe { nil } {
 			C.v_multiwindow_wayland_egl_destroy_window(record.wl_egl_window)
+		}
+		for buffer in record.fallback_buffers {
+			if buffer != unsafe { nil } {
+				C.v_multiwindow_wayland_buffer_destroy(unsafe { &C.wl_buffer(buffer) })
+			}
+		}
+		if record.toplevel_decoration != unsafe { nil } {
+			C.v_multiwindow_wayland_xdg_toplevel_decoration_destroy(unsafe {
+				&C.zxdg_toplevel_decoration_v1(record.toplevel_decoration)
+			})
 		}
 		if record.xdg_toplevel != unsafe { nil } {
 			C.v_multiwindow_wayland_xdg_toplevel_destroy(unsafe {
@@ -878,6 +2954,244 @@ fn (backend &WaylandBackend) destroy_window_record(record &WaylandWindowRecord) 
 		if record.surface != unsafe { nil } {
 			C.wl_surface_destroy(unsafe { &C.wl_surface(record.surface) })
 		}
+	}
+}
+
+fn (mut backend WaylandBackend) ensure_data_device(data voidptr) {
+	$if linux && sokol_wayland ? {
+		if backend.data_device != unsafe { nil } || backend.data_device_manager == unsafe { nil }
+			|| backend.seat == unsafe { nil } {
+			return
+		}
+		device := C.v_multiwindow_wayland_data_device_manager_get_data_device(unsafe {
+			&C.wl_data_device_manager(backend.data_device_manager)
+		}, unsafe { &C.wl_seat(backend.seat) })
+		if device != unsafe { nil }
+			&& C.v_multiwindow_wayland_add_data_device_listener(unsafe { &C.wl_data_device(device) }, data) == 0 {
+			backend.data_device = device
+		} else if device != unsafe { nil } {
+			C.v_multiwindow_wayland_data_device_destroy(unsafe { &C.wl_data_device(device) })
+		}
+	}
+}
+
+fn (mut backend WaylandBackend) clear_data_offer(destroy bool) {
+	$if linux && sokol_wayland ? {
+		mut pending_offer := voidptr(unsafe { nil })
+		if backend.pending_drop_offer != unsafe { nil } {
+			pending_offer = backend.pending_drop_offer
+			backend.clear_pending_data_offer_drop(destroy)
+		}
+		if destroy && backend.data_offer != unsafe { nil } {
+			if backend.data_offer != pending_offer {
+				C.v_multiwindow_wayland_data_offer_destroy(unsafe {
+					&C.wl_data_offer(backend.data_offer)
+				})
+			}
+		}
+		backend.data_offer = unsafe { nil }
+		backend.data_offer_has_uri_list = false
+		backend.data_offer_source_actions = wayland_dnd_action_none
+		backend.data_offer_selected_action = wayland_dnd_action_none
+		backend.data_offer_action_received = false
+		backend.data_offer_window_valid = false
+		backend.data_offer_window = WindowId{}
+	}
+}
+
+fn wayland_dnd_action_allows_finish(source_actions u32, action_received bool, action u32) bool {
+	if source_actions != wayland_dnd_action_none && (source_actions & action) == 0 {
+		return false
+	}
+	return action_received
+		&& (action == wayland_dnd_action_copy || action == wayland_dnd_action_move)
+}
+
+fn (backend &WaylandBackend) data_offer_allows_finish() bool {
+	return wayland_dnd_action_allows_finish(backend.data_offer_source_actions,
+		backend.data_offer_action_received, backend.data_offer_selected_action)
+}
+
+fn (backend &WaylandBackend) pending_drop_allows_finish() bool {
+	return wayland_dnd_action_allows_finish(backend.pending_drop_source_actions,
+		backend.pending_drop_action_received, backend.pending_drop_selected_action)
+}
+
+fn (mut backend WaylandBackend) begin_pending_data_offer_drop() bool {
+	$if linux && sokol_wayland ? {
+		if backend.data_offer == unsafe { nil } || backend.pending_drop_offer != unsafe { nil } {
+			return false
+		}
+		mut fds := [2]int{}
+		if C.pipe(&fds[0]) == -1 {
+			return false
+		}
+		if C.v_multiwindow_wayland_fd_set_nonblocking(fds[0]) == 0 {
+			C.close(fds[0])
+			C.close(fds[1])
+			return false
+		}
+		C.v_multiwindow_wayland_data_offer_receive(unsafe { &C.wl_data_offer(backend.data_offer) },
+			c'text/uri-list', fds[1])
+		C.close(fds[1])
+		if backend.display != unsafe { nil } {
+			if C.wl_display_flush(unsafe { &C.wl_display(backend.display) }) < 0 {
+				C.close(fds[0])
+				return false
+			}
+		}
+		backend.pending_drop_offer = backend.data_offer
+		backend.pending_drop_fd = fds[0]
+		backend.pending_drop_window = backend.data_offer_window
+		backend.pending_drop_window_valid = backend.data_offer_window_valid
+		backend.pending_drop_source_actions = backend.data_offer_source_actions
+		backend.pending_drop_selected_action = backend.data_offer_selected_action
+		backend.pending_drop_action_received = backend.data_offer_action_received
+		backend.pending_drop_poll_cycles = 0
+		backend.pending_drop_buffer = []u8{cap: wayland_uri_list_buffer_size}
+		return true
+	}
+	return false
+}
+
+fn (mut backend WaylandBackend) clear_pending_data_offer_drop(destroy bool) {
+	$if linux && sokol_wayland ? {
+		if backend.pending_drop_offer != unsafe { nil } {
+			if backend.pending_drop_fd >= 0 {
+				C.close(backend.pending_drop_fd)
+			}
+			if destroy {
+				C.v_multiwindow_wayland_data_offer_destroy(unsafe {
+					&C.wl_data_offer(backend.pending_drop_offer)
+				})
+			}
+		}
+		backend.pending_drop_offer = unsafe { nil }
+		backend.pending_drop_fd = -1
+		backend.pending_drop_window = WindowId{}
+		backend.pending_drop_window_valid = false
+		backend.pending_drop_source_actions = wayland_dnd_action_none
+		backend.pending_drop_selected_action = wayland_dnd_action_none
+		backend.pending_drop_action_received = false
+		backend.pending_drop_poll_cycles = 0
+		backend.pending_drop_buffer = []u8{}
+	}
+}
+
+fn (mut backend WaylandBackend) pending_drop_poll_cycle_expired() bool {
+	backend.pending_drop_poll_cycles++
+	return backend.pending_drop_poll_cycles > wayland_data_offer_max_pending_poll_cycles
+}
+
+fn (mut backend WaylandBackend) drain_pending_data_offer_drop() {
+	$if linux && sokol_wayland ? {
+		if backend.pending_drop_offer == unsafe { nil } || backend.pending_drop_fd < 0 {
+			return
+		}
+		if backend.pending_drop_poll_cycle_expired() {
+			backend.clear_data_offer(true)
+			return
+		}
+		mut poll_fd := C.pollfd{
+			fd:     backend.pending_drop_fd
+			events: wayland_poll_in | wayland_poll_err | wayland_poll_hup
+		}
+		poll_result := C.poll(&poll_fd, u64(1), 0)
+		if poll_result == 0 {
+			return
+		}
+		if poll_result < 0 || (poll_fd.revents & wayland_poll_err) != 0 {
+			backend.clear_data_offer(true)
+			return
+		}
+		mut should_finish := (poll_fd.revents & wayland_poll_hup) != 0
+		if (poll_fd.revents & wayland_poll_in) != 0 || should_finish {
+			mut chunk := [wayland_data_offer_drain_chunk_size]u8{}
+			for _ in 0 .. wayland_data_offer_max_read_chunks {
+				remaining := wayland_uri_list_buffer_size - backend.pending_drop_buffer.len
+				if remaining <= 0 {
+					backend.clear_data_offer(true)
+					return
+				}
+				read_size := if remaining < wayland_data_offer_drain_chunk_size {
+					remaining
+				} else {
+					wayland_data_offer_drain_chunk_size
+				}
+				n := C.read(backend.pending_drop_fd, unsafe { &chunk[0] }, usize(read_size))
+				if n > 0 {
+					for i in 0 .. int(n) {
+						backend.pending_drop_buffer << chunk[i]
+					}
+					continue
+				}
+				if n == 0 {
+					should_finish = true
+					break
+				}
+				if C.v_multiwindow_wayland_read_would_block() != 0 {
+					break
+				}
+				backend.clear_data_offer(true)
+				return
+			}
+		}
+		if should_finish {
+			backend.finish_pending_data_offer_drop()
+		}
+	}
+}
+
+fn (mut backend WaylandBackend) finish_pending_data_offer_drop() {
+	$if linux && sokol_wayland ? {
+		if backend.pending_drop_offer == unsafe { nil } {
+			return
+		}
+		payload := if backend.pending_drop_buffer.len > 0 {
+			unsafe { tos(&backend.pending_drop_buffer[0], backend.pending_drop_buffer.len).clone() }
+		} else {
+			''
+		}
+		files := dropped_files_from_uri_list(payload)
+		mut should_finish := false
+		if files.len > 0 && backend.pending_drop_window_valid
+			&& backend.pending_drop_allows_finish() {
+			if index := backend.window_record_index(backend.pending_drop_window) {
+				mut record := backend.windows[index]
+				record.enqueue_native_event(C.v_multiwindow_wayland_next_event_sequence(),
+					queued_input_event(record.input_files_dropped_event(files)))
+				should_finish = true
+			}
+		}
+		if should_finish {
+			C.v_multiwindow_wayland_data_offer_finish(unsafe {
+				&C.wl_data_offer(backend.pending_drop_offer)
+			})
+		}
+		backend.clear_data_offer(true)
+	}
+}
+
+fn (mut backend WaylandBackend) destroy_data_device() {
+	$if linux && sokol_wayland ? {
+		backend.clear_data_offer(true)
+		if backend.data_device != unsafe { nil } {
+			C.v_multiwindow_wayland_data_device_destroy(unsafe { &C.wl_data_device(backend.data_device) })
+		}
+		backend.data_device = unsafe { nil }
+	}
+}
+
+fn (mut backend WaylandBackend) destroy_data_device_manager() {
+	$if linux && sokol_wayland ? {
+		backend.destroy_data_device()
+		if backend.data_device_manager != unsafe { nil } {
+			C.v_multiwindow_wayland_data_device_manager_destroy(unsafe {
+				&C.wl_data_device_manager(backend.data_device_manager)
+			})
+		}
+		backend.data_device_manager = unsafe { nil }
+		backend.data_device_manager_name = 0
 	}
 }
 

--- a/vlib/x/multiwindow/wayland_backend_helpers.h
+++ b/vlib/x/multiwindow/wayland_backend_helpers.h
@@ -2,6 +2,12 @@
 #define V_MULTIWINDOW_WAYLAND_BACKEND_HELPERS_H
 
 #include <stdint.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 #include <EGL/egl.h>
 #include <wayland-client.h>
 #include <wayland-egl.h>
@@ -25,6 +31,34 @@ void v_multiwindow_wayland_xdg_wm_base_ping(void *data, void *wm_base, uint32_t 
 void v_multiwindow_wayland_xdg_surface_configure(void *data, void *xdg_surface, uint32_t serial);
 void v_multiwindow_wayland_xdg_toplevel_configure(void *data, void *toplevel, int width, int height, struct wl_array *states);
 void v_multiwindow_wayland_xdg_toplevel_close(void *data, void *toplevel);
+void v_multiwindow_wayland_xdg_toplevel_decoration_configure(void *data, void *decoration, uint32_t mode);
+void v_multiwindow_wayland_seat_capabilities(void *data, void *seat, uint32_t caps);
+void v_multiwindow_wayland_seat_name(void *data, void *seat, char *name);
+void v_multiwindow_wayland_pointer_enter(void *data, void *pointer, uint32_t serial, void *surface, double x, double y);
+void v_multiwindow_wayland_pointer_leave(void *data, void *pointer, uint32_t serial, void *surface);
+void v_multiwindow_wayland_pointer_motion(void *data, void *pointer, uint32_t time, double x, double y);
+void v_multiwindow_wayland_pointer_button(void *data, void *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state);
+void v_multiwindow_wayland_pointer_axis(void *data, void *pointer, uint32_t time, uint32_t axis, double value);
+void v_multiwindow_wayland_keyboard_keymap(void *data, void *keyboard, uint32_t format, int fd, uint32_t size);
+void v_multiwindow_wayland_keyboard_enter(void *data, void *keyboard, uint32_t serial, void *surface);
+void v_multiwindow_wayland_keyboard_leave(void *data, void *keyboard, uint32_t serial, void *surface);
+void v_multiwindow_wayland_keyboard_key(void *data, void *keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
+void v_multiwindow_wayland_keyboard_modifiers(void *data, void *keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group);
+void v_multiwindow_wayland_keyboard_repeat_info(void *data, void *keyboard, int32_t rate, int32_t delay);
+void v_multiwindow_wayland_touch_down(void *data, void *touch, uint32_t serial, uint32_t time, void *surface, int32_t id, double x, double y);
+void v_multiwindow_wayland_touch_up(void *data, void *touch, uint32_t serial, uint32_t time, int32_t id);
+void v_multiwindow_wayland_touch_motion(void *data, void *touch, uint32_t time, int32_t id, double x, double y);
+void v_multiwindow_wayland_touch_cancel(void *data, void *touch);
+void v_multiwindow_wayland_data_offer_offer(void *data, void *offer, char *mime_type);
+void v_multiwindow_wayland_data_offer_source_actions(void *data, void *offer, uint32_t source_actions);
+void v_multiwindow_wayland_data_offer_action(void *data, void *offer, uint32_t dnd_action);
+void v_multiwindow_wayland_data_device_data_offer(void *data, void *device, void *offer);
+void v_multiwindow_wayland_data_device_enter(void *data, void *device, uint32_t serial, void *surface, double x, double y, void *offer);
+void v_multiwindow_wayland_data_device_leave(void *data, void *device);
+void v_multiwindow_wayland_data_device_motion(void *data, void *device, uint32_t time, double x, double y);
+void v_multiwindow_wayland_data_device_drop(void *data, void *device);
+void v_multiwindow_wayland_data_device_selection(void *data, void *device, void *offer);
+void v_multiwindow_wayland_buffer_release(void *data, void *buffer);
 
 #if !defined(XDG_SHELL_CLIENT_PROTOCOL_H)
 struct xdg_wm_base;
@@ -81,10 +115,87 @@ struct xdg_toplevel_listener {
 #ifndef XDG_TOPLEVEL_SET_FULLSCREEN
 #define XDG_TOPLEVEL_SET_FULLSCREEN 11
 #endif
-
+#ifndef XDG_TOPLEVEL_MOVE
+#define XDG_TOPLEVEL_MOVE 5
+#endif
+#ifndef XDG_TOPLEVEL_RESIZE
+#define XDG_TOPLEVEL_RESIZE 6
+#endif
+#ifndef XDG_TOPLEVEL_RESIZE_EDGE_TOP
+#define XDG_TOPLEVEL_RESIZE_EDGE_TOP 1
+#endif
+#ifndef XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM
+#define XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM 2
+#endif
+#ifndef XDG_TOPLEVEL_RESIZE_EDGE_LEFT
+#define XDG_TOPLEVEL_RESIZE_EDGE_LEFT 4
+#endif
+#ifndef XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT
+#define XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT 5
+#endif
+#ifndef XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT
+#define XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT 6
+#endif
+#ifndef XDG_TOPLEVEL_RESIZE_EDGE_RIGHT
+#define XDG_TOPLEVEL_RESIZE_EDGE_RIGHT 8
+#endif
+#ifndef XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT
+#define XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT 9
+#endif
+#ifndef XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT
+#define XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT 10
+#endif
 extern const struct wl_interface v_multiwindow_xdg_wm_base_interface;
 extern const struct wl_interface v_multiwindow_xdg_surface_interface;
 extern const struct wl_interface v_multiwindow_xdg_toplevel_interface;
+
+#if !defined(XDG_DECORATION_UNSTABLE_V1_CLIENT_PROTOCOL_H)
+struct zxdg_decoration_manager_v1;
+struct zxdg_toplevel_decoration_v1;
+
+struct zxdg_toplevel_decoration_v1_listener {
+	void (*configure)(void *data, struct zxdg_toplevel_decoration_v1 *decoration, uint32_t mode);
+};
+#endif
+
+#ifndef ZXDG_DECORATION_MANAGER_V1_DESTROY
+#define ZXDG_DECORATION_MANAGER_V1_DESTROY 0
+#endif
+#ifndef ZXDG_DECORATION_MANAGER_V1_GET_TOPLEVEL_DECORATION
+#define ZXDG_DECORATION_MANAGER_V1_GET_TOPLEVEL_DECORATION 1
+#endif
+#ifndef ZXDG_TOPLEVEL_DECORATION_V1_DESTROY
+#define ZXDG_TOPLEVEL_DECORATION_V1_DESTROY 0
+#endif
+#ifndef ZXDG_TOPLEVEL_DECORATION_V1_SET_MODE
+#define ZXDG_TOPLEVEL_DECORATION_V1_SET_MODE 1
+#endif
+#ifndef ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE
+#define ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE 1
+#endif
+#ifndef ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE
+#define ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE 2
+#endif
+extern const struct wl_interface v_multiwindow_zxdg_decoration_manager_v1_interface;
+extern const struct wl_interface v_multiwindow_zxdg_toplevel_decoration_v1_interface;
+
+struct wp_cursor_shape_manager_v1;
+struct wp_cursor_shape_device_v1;
+
+#ifndef WP_CURSOR_SHAPE_MANAGER_V1_DESTROY
+#define WP_CURSOR_SHAPE_MANAGER_V1_DESTROY 0
+#endif
+#ifndef WP_CURSOR_SHAPE_MANAGER_V1_GET_POINTER
+#define WP_CURSOR_SHAPE_MANAGER_V1_GET_POINTER 1
+#endif
+#ifndef WP_CURSOR_SHAPE_DEVICE_V1_DESTROY
+#define WP_CURSOR_SHAPE_DEVICE_V1_DESTROY 0
+#endif
+#ifndef WP_CURSOR_SHAPE_DEVICE_V1_SET_SHAPE
+#define WP_CURSOR_SHAPE_DEVICE_V1_SET_SHAPE 1
+#endif
+extern const struct wl_interface v_multiwindow_wp_cursor_shape_manager_v1_interface;
+extern const struct wl_interface v_multiwindow_wp_cursor_shape_device_v1_interface;
 
 static void v_multiwindow_wayland_registry_handle_global_trampoline(void *data, struct wl_registry *registry, uint32_t name, const char *iface, uint32_t version) {
 	v_multiwindow_wayland_registry_handle_global(data, registry, name, (char *)iface, version);
@@ -110,6 +221,164 @@ static void v_multiwindow_wayland_xdg_toplevel_close_trampoline(void *data, stru
 	v_multiwindow_wayland_xdg_toplevel_close(data, (void *)toplevel);
 }
 
+static void v_multiwindow_wayland_seat_capabilities_trampoline(void *data, struct wl_seat *seat, uint32_t caps) {
+	v_multiwindow_wayland_seat_capabilities(data, (void *)seat, caps);
+}
+
+static void v_multiwindow_wayland_seat_name_trampoline(void *data, struct wl_seat *seat, const char *name) {
+	v_multiwindow_wayland_seat_name(data, (void *)seat, (char *)name);
+}
+
+static void v_multiwindow_wayland_pointer_enter_trampoline(void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface, wl_fixed_t sx, wl_fixed_t sy) {
+	v_multiwindow_wayland_pointer_enter(data, (void *)pointer, serial, (void *)surface, wl_fixed_to_double(sx), wl_fixed_to_double(sy));
+}
+
+static void v_multiwindow_wayland_pointer_leave_trampoline(void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface) {
+	v_multiwindow_wayland_pointer_leave(data, (void *)pointer, serial, (void *)surface);
+}
+
+static void v_multiwindow_wayland_pointer_motion_trampoline(void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
+	v_multiwindow_wayland_pointer_motion(data, (void *)pointer, time, wl_fixed_to_double(sx), wl_fixed_to_double(sy));
+}
+
+static void v_multiwindow_wayland_pointer_button_trampoline(void *data, struct wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
+	v_multiwindow_wayland_pointer_button(data, (void *)pointer, serial, time, button, state);
+}
+
+static void v_multiwindow_wayland_pointer_axis_trampoline(void *data, struct wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value) {
+	v_multiwindow_wayland_pointer_axis(data, (void *)pointer, time, axis, wl_fixed_to_double(value));
+}
+
+static void v_multiwindow_wayland_pointer_frame_trampoline(void *data, struct wl_pointer *pointer) {
+	(void)data;
+	(void)pointer;
+}
+
+static void v_multiwindow_wayland_pointer_axis_source_trampoline(void *data, struct wl_pointer *pointer, uint32_t axis_source) {
+	(void)data;
+	(void)pointer;
+	(void)axis_source;
+}
+
+static void v_multiwindow_wayland_pointer_axis_stop_trampoline(void *data, struct wl_pointer *pointer, uint32_t time, uint32_t axis) {
+	(void)data;
+	(void)pointer;
+	(void)time;
+	(void)axis;
+}
+
+static void v_multiwindow_wayland_pointer_axis_discrete_trampoline(void *data, struct wl_pointer *pointer, uint32_t axis, int32_t discrete) {
+	(void)data;
+	(void)pointer;
+	(void)axis;
+	(void)discrete;
+}
+
+static void v_multiwindow_wayland_keyboard_keymap_trampoline(void *data, struct wl_keyboard *keyboard, uint32_t format, int fd, uint32_t size) {
+	v_multiwindow_wayland_keyboard_keymap(data, (void *)keyboard, format, fd, size);
+}
+
+static void v_multiwindow_wayland_keyboard_enter_trampoline(void *data, struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface, struct wl_array *keys) {
+	(void)keys;
+	v_multiwindow_wayland_keyboard_enter(data, (void *)keyboard, serial, (void *)surface);
+}
+
+static void v_multiwindow_wayland_keyboard_leave_trampoline(void *data, struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface) {
+	v_multiwindow_wayland_keyboard_leave(data, (void *)keyboard, serial, (void *)surface);
+}
+
+static void v_multiwindow_wayland_keyboard_key_trampoline(void *data, struct wl_keyboard *keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state) {
+	v_multiwindow_wayland_keyboard_key(data, (void *)keyboard, serial, time, key, state);
+}
+
+static void v_multiwindow_wayland_keyboard_modifiers_trampoline(void *data, struct wl_keyboard *keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group) {
+	v_multiwindow_wayland_keyboard_modifiers(data, (void *)keyboard, serial, mods_depressed, mods_latched, mods_locked, group);
+}
+
+static void v_multiwindow_wayland_keyboard_repeat_info_trampoline(void *data, struct wl_keyboard *keyboard, int32_t rate, int32_t delay) {
+	v_multiwindow_wayland_keyboard_repeat_info(data, (void *)keyboard, rate, delay);
+}
+
+static void v_multiwindow_wayland_touch_down_trampoline(void *data, struct wl_touch *touch, uint32_t serial, uint32_t time, struct wl_surface *surface, int32_t id, wl_fixed_t x, wl_fixed_t y) {
+	v_multiwindow_wayland_touch_down(data, (void *)touch, serial, time, (void *)surface, id, wl_fixed_to_double(x), wl_fixed_to_double(y));
+}
+
+static void v_multiwindow_wayland_touch_up_trampoline(void *data, struct wl_touch *touch, uint32_t serial, uint32_t time, int32_t id) {
+	v_multiwindow_wayland_touch_up(data, (void *)touch, serial, time, id);
+}
+
+static void v_multiwindow_wayland_touch_motion_trampoline(void *data, struct wl_touch *touch, uint32_t time, int32_t id, wl_fixed_t x, wl_fixed_t y) {
+	v_multiwindow_wayland_touch_motion(data, (void *)touch, time, id, wl_fixed_to_double(x), wl_fixed_to_double(y));
+}
+
+static void v_multiwindow_wayland_touch_frame_trampoline(void *data, struct wl_touch *touch) {
+	(void)data;
+	(void)touch;
+}
+
+static void v_multiwindow_wayland_touch_cancel_trampoline(void *data, struct wl_touch *touch) {
+	v_multiwindow_wayland_touch_cancel(data, (void *)touch);
+}
+
+static void v_multiwindow_wayland_touch_shape_trampoline(void *data, struct wl_touch *touch, int32_t id, wl_fixed_t major, wl_fixed_t minor) {
+	(void)data;
+	(void)touch;
+	(void)id;
+	(void)major;
+	(void)minor;
+}
+
+static void v_multiwindow_wayland_touch_orientation_trampoline(void *data, struct wl_touch *touch, int32_t id, wl_fixed_t orientation) {
+	(void)data;
+	(void)touch;
+	(void)id;
+	(void)orientation;
+}
+
+static void v_multiwindow_wayland_data_offer_offer_trampoline(void *data, struct wl_data_offer *offer, const char *mime_type) {
+	v_multiwindow_wayland_data_offer_offer(data, (void *)offer, (char *)mime_type);
+}
+
+static void v_multiwindow_wayland_data_offer_source_actions_trampoline(void *data, struct wl_data_offer *offer, uint32_t source_actions) {
+	v_multiwindow_wayland_data_offer_source_actions(data, (void *)offer, source_actions);
+}
+
+static void v_multiwindow_wayland_data_offer_action_trampoline(void *data, struct wl_data_offer *offer, uint32_t dnd_action) {
+	v_multiwindow_wayland_data_offer_action(data, (void *)offer, dnd_action);
+}
+
+static void v_multiwindow_wayland_data_device_data_offer_trampoline(void *data, struct wl_data_device *device, struct wl_data_offer *offer) {
+	v_multiwindow_wayland_data_device_data_offer(data, (void *)device, (void *)offer);
+}
+
+static void v_multiwindow_wayland_data_device_enter_trampoline(void *data, struct wl_data_device *device, uint32_t serial, struct wl_surface *surface, wl_fixed_t x, wl_fixed_t y, struct wl_data_offer *offer) {
+	v_multiwindow_wayland_data_device_enter(data, (void *)device, serial, (void *)surface, wl_fixed_to_double(x), wl_fixed_to_double(y), (void *)offer);
+}
+
+static void v_multiwindow_wayland_data_device_leave_trampoline(void *data, struct wl_data_device *device) {
+	v_multiwindow_wayland_data_device_leave(data, (void *)device);
+}
+
+static void v_multiwindow_wayland_data_device_motion_trampoline(void *data, struct wl_data_device *device, uint32_t time, wl_fixed_t x, wl_fixed_t y) {
+	v_multiwindow_wayland_data_device_motion(data, (void *)device, time, wl_fixed_to_double(x), wl_fixed_to_double(y));
+}
+
+static void v_multiwindow_wayland_data_device_drop_trampoline(void *data, struct wl_data_device *device) {
+	v_multiwindow_wayland_data_device_drop(data, (void *)device);
+}
+
+static void v_multiwindow_wayland_data_device_selection_trampoline(void *data, struct wl_data_device *device, struct wl_data_offer *offer) {
+	v_multiwindow_wayland_data_device_selection(data, (void *)device, (void *)offer);
+}
+
+static void v_multiwindow_wayland_xdg_toplevel_decoration_configure_trampoline(void *data, struct zxdg_toplevel_decoration_v1 *decoration, uint32_t mode) {
+	v_multiwindow_wayland_xdg_toplevel_decoration_configure(data, (void *)decoration, mode);
+}
+
+static void v_multiwindow_wayland_buffer_release_trampoline(void *data, struct wl_buffer *buffer) {
+	v_multiwindow_wayland_buffer_release(data, (void *)buffer);
+}
+
 static const struct wl_registry_listener v_multiwindow_wayland_registry_listener = {
 	v_multiwindow_wayland_registry_handle_global_trampoline,
 	v_multiwindow_wayland_registry_handle_global_remove_trampoline,
@@ -128,8 +397,76 @@ static const struct xdg_toplevel_listener v_multiwindow_wayland_xdg_toplevel_lis
 	v_multiwindow_wayland_xdg_toplevel_close_trampoline,
 };
 
+static const struct wl_seat_listener v_multiwindow_wayland_seat_listener = {
+	v_multiwindow_wayland_seat_capabilities_trampoline,
+	v_multiwindow_wayland_seat_name_trampoline,
+};
+
+static const struct wl_pointer_listener v_multiwindow_wayland_pointer_listener = {
+	v_multiwindow_wayland_pointer_enter_trampoline,
+	v_multiwindow_wayland_pointer_leave_trampoline,
+	v_multiwindow_wayland_pointer_motion_trampoline,
+	v_multiwindow_wayland_pointer_button_trampoline,
+	v_multiwindow_wayland_pointer_axis_trampoline,
+	v_multiwindow_wayland_pointer_frame_trampoline,
+	v_multiwindow_wayland_pointer_axis_source_trampoline,
+	v_multiwindow_wayland_pointer_axis_stop_trampoline,
+	v_multiwindow_wayland_pointer_axis_discrete_trampoline,
+};
+
+static const struct wl_keyboard_listener v_multiwindow_wayland_keyboard_listener = {
+	v_multiwindow_wayland_keyboard_keymap_trampoline,
+	v_multiwindow_wayland_keyboard_enter_trampoline,
+	v_multiwindow_wayland_keyboard_leave_trampoline,
+	v_multiwindow_wayland_keyboard_key_trampoline,
+	v_multiwindow_wayland_keyboard_modifiers_trampoline,
+	v_multiwindow_wayland_keyboard_repeat_info_trampoline,
+};
+
+static const struct wl_touch_listener v_multiwindow_wayland_touch_listener = {
+	v_multiwindow_wayland_touch_down_trampoline,
+	v_multiwindow_wayland_touch_up_trampoline,
+	v_multiwindow_wayland_touch_motion_trampoline,
+	v_multiwindow_wayland_touch_frame_trampoline,
+	v_multiwindow_wayland_touch_cancel_trampoline,
+	v_multiwindow_wayland_touch_shape_trampoline,
+	v_multiwindow_wayland_touch_orientation_trampoline,
+};
+
+static const struct wl_data_offer_listener v_multiwindow_wayland_data_offer_listener = {
+	v_multiwindow_wayland_data_offer_offer_trampoline,
+	v_multiwindow_wayland_data_offer_source_actions_trampoline,
+	v_multiwindow_wayland_data_offer_action_trampoline,
+};
+
+static const struct wl_data_device_listener v_multiwindow_wayland_data_device_listener = {
+	v_multiwindow_wayland_data_device_data_offer_trampoline,
+	v_multiwindow_wayland_data_device_enter_trampoline,
+	v_multiwindow_wayland_data_device_leave_trampoline,
+	v_multiwindow_wayland_data_device_motion_trampoline,
+	v_multiwindow_wayland_data_device_drop_trampoline,
+	v_multiwindow_wayland_data_device_selection_trampoline,
+};
+
+static const struct wl_buffer_listener v_multiwindow_wayland_buffer_listener = {
+	v_multiwindow_wayland_buffer_release_trampoline,
+};
+
+static const struct zxdg_toplevel_decoration_v1_listener v_multiwindow_wayland_xdg_toplevel_decoration_listener = {
+	v_multiwindow_wayland_xdg_toplevel_decoration_configure_trampoline,
+};
+
 static inline uint32_t v_multiwindow_wayland_compositor_bind_version(uint32_t version) {
 	return version < 4 ? version : 4;
+}
+
+static inline uint32_t v_multiwindow_wayland_seat_bind_version(uint32_t version) {
+	return version < 5 ? version : 5;
+}
+
+static inline uint64_t v_multiwindow_wayland_next_event_sequence(void) {
+	static uint64_t sequence = 1;
+	return sequence++;
 }
 
 static inline void *v_multiwindow_wayland_bind_compositor(struct wl_registry *registry, uint32_t name, uint32_t version) {
@@ -138,6 +475,35 @@ static inline void *v_multiwindow_wayland_bind_compositor(struct wl_registry *re
 
 static inline void *v_multiwindow_wayland_bind_xdg_wm_base(struct wl_registry *registry, uint32_t name) {
 	return wl_registry_bind(registry, name, &v_multiwindow_xdg_wm_base_interface, 1);
+}
+
+static inline void *v_multiwindow_wayland_bind_xdg_decoration_manager(struct wl_registry *registry, uint32_t name, uint32_t version) {
+	if (version < 1) {
+		return NULL;
+	}
+	return wl_registry_bind(registry, name, &v_multiwindow_zxdg_decoration_manager_v1_interface, 1);
+}
+
+static inline void *v_multiwindow_wayland_bind_cursor_shape_manager(struct wl_registry *registry, uint32_t name, uint32_t version) {
+	if (version < 1) {
+		return NULL;
+	}
+	return wl_registry_bind(registry, name, &v_multiwindow_wp_cursor_shape_manager_v1_interface, 1);
+}
+
+static inline void *v_multiwindow_wayland_bind_seat(struct wl_registry *registry, uint32_t name, uint32_t version) {
+	return wl_registry_bind(registry, name, &wl_seat_interface, v_multiwindow_wayland_seat_bind_version(version));
+}
+
+static inline void *v_multiwindow_wayland_bind_data_device_manager(struct wl_registry *registry, uint32_t name, uint32_t version) {
+	if (version < 3) {
+		return NULL;
+	}
+	return wl_registry_bind(registry, name, &wl_data_device_manager_interface, 3);
+}
+
+static inline void *v_multiwindow_wayland_bind_shm(struct wl_registry *registry, uint32_t name) {
+	return wl_registry_bind(registry, name, &wl_shm_interface, 1);
 }
 
 static inline int v_multiwindow_wayland_add_registry_listener(struct wl_registry *registry, void *data) {
@@ -154,6 +520,265 @@ static inline int v_multiwindow_wayland_add_xdg_surface_listener(struct xdg_surf
 
 static inline int v_multiwindow_wayland_add_xdg_toplevel_listener(struct xdg_toplevel *toplevel, void *data) {
 	return wl_proxy_add_listener((struct wl_proxy *)toplevel, (void (**)(void))&v_multiwindow_wayland_xdg_toplevel_listener, data);
+}
+
+static inline int v_multiwindow_wayland_add_xdg_toplevel_decoration_listener(struct zxdg_toplevel_decoration_v1 *decoration, void *data) {
+	return wl_proxy_add_listener((struct wl_proxy *)decoration, (void (**)(void))&v_multiwindow_wayland_xdg_toplevel_decoration_listener, data);
+}
+
+static inline int v_multiwindow_wayland_add_seat_listener(struct wl_seat *seat, void *data) {
+	return wl_seat_add_listener(seat, &v_multiwindow_wayland_seat_listener, data);
+}
+
+static inline void *v_multiwindow_wayland_seat_get_pointer(struct wl_seat *seat) {
+	return (void *)wl_seat_get_pointer(seat);
+}
+
+static inline void *v_multiwindow_wayland_seat_get_keyboard(struct wl_seat *seat) {
+	return (void *)wl_seat_get_keyboard(seat);
+}
+
+static inline void *v_multiwindow_wayland_seat_get_touch(struct wl_seat *seat) {
+	return (void *)wl_seat_get_touch(seat);
+}
+
+static inline void *v_multiwindow_wayland_data_device_manager_get_data_device(struct wl_data_device_manager *manager, struct wl_seat *seat) {
+	return (void *)wl_data_device_manager_get_data_device(manager, seat);
+}
+
+static inline void *v_multiwindow_wayland_cursor_shape_manager_get_pointer(struct wp_cursor_shape_manager_v1 *manager, struct wl_pointer *pointer) {
+	struct wl_proxy *id = wl_proxy_marshal_flags((struct wl_proxy *)manager, WP_CURSOR_SHAPE_MANAGER_V1_GET_POINTER, &v_multiwindow_wp_cursor_shape_device_v1_interface, wl_proxy_get_version((struct wl_proxy *)manager), 0, NULL, pointer);
+	return (void *)id;
+}
+
+static inline void v_multiwindow_wayland_cursor_shape_device_set_shape(struct wp_cursor_shape_device_v1 *device, uint32_t serial, uint32_t shape) {
+	wl_proxy_marshal_flags((struct wl_proxy *)device, WP_CURSOR_SHAPE_DEVICE_V1_SET_SHAPE, NULL, wl_proxy_get_version((struct wl_proxy *)device), 0, serial, shape);
+}
+
+static inline void v_multiwindow_wayland_cursor_shape_device_destroy(struct wp_cursor_shape_device_v1 *device) {
+	if (device != NULL) {
+		wl_proxy_marshal_flags((struct wl_proxy *)device, WP_CURSOR_SHAPE_DEVICE_V1_DESTROY, NULL, wl_proxy_get_version((struct wl_proxy *)device), WL_MARSHAL_FLAG_DESTROY);
+	}
+}
+
+static inline void v_multiwindow_wayland_cursor_shape_manager_destroy(struct wp_cursor_shape_manager_v1 *manager) {
+	if (manager != NULL) {
+		wl_proxy_marshal_flags((struct wl_proxy *)manager, WP_CURSOR_SHAPE_MANAGER_V1_DESTROY, NULL, wl_proxy_get_version((struct wl_proxy *)manager), WL_MARSHAL_FLAG_DESTROY);
+	}
+}
+
+static inline int v_multiwindow_wayland_add_pointer_listener(struct wl_pointer *pointer, void *data) {
+	return wl_pointer_add_listener(pointer, &v_multiwindow_wayland_pointer_listener, data);
+}
+
+static inline int v_multiwindow_wayland_add_keyboard_listener(struct wl_keyboard *keyboard, void *data) {
+	return wl_keyboard_add_listener(keyboard, &v_multiwindow_wayland_keyboard_listener, data);
+}
+
+static inline int v_multiwindow_wayland_add_touch_listener(struct wl_touch *touch, void *data) {
+	return wl_touch_add_listener(touch, &v_multiwindow_wayland_touch_listener, data);
+}
+
+static inline int v_multiwindow_wayland_add_data_device_listener(struct wl_data_device *device, void *data) {
+	return wl_data_device_add_listener(device, &v_multiwindow_wayland_data_device_listener, data);
+}
+
+static inline int v_multiwindow_wayland_add_data_offer_listener(struct wl_data_offer *offer, void *data) {
+	return wl_data_offer_add_listener(offer, &v_multiwindow_wayland_data_offer_listener, data);
+}
+
+static inline void v_multiwindow_wayland_data_offer_accept(struct wl_data_offer *offer, uint32_t serial, const char *mime_type) {
+	wl_data_offer_accept(offer, serial, mime_type);
+}
+
+static inline void v_multiwindow_wayland_data_offer_set_copy_action(struct wl_data_offer *offer) {
+	wl_data_offer_set_actions(offer, WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY, WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY);
+}
+
+static inline void v_multiwindow_wayland_data_offer_receive(struct wl_data_offer *offer, const char *mime_type, int fd) {
+	wl_data_offer_receive(offer, mime_type, fd);
+}
+
+static inline int v_multiwindow_wayland_fd_set_nonblocking(int fd) {
+	int flags = fcntl(fd, F_GETFL, 0);
+	if (flags < 0) {
+		return 0;
+	}
+	return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
+}
+
+static inline int v_multiwindow_wayland_read_would_block(void) {
+	return errno == EAGAIN || errno == EWOULDBLOCK;
+}
+
+static inline void v_multiwindow_wayland_data_offer_finish(struct wl_data_offer *offer) {
+	wl_data_offer_finish(offer);
+}
+
+static inline void v_multiwindow_wayland_data_offer_destroy(struct wl_data_offer *offer) {
+	if (offer != NULL) {
+		wl_data_offer_destroy(offer);
+	}
+}
+
+static inline void v_multiwindow_wayland_data_device_destroy(struct wl_data_device *device) {
+	if (device != NULL) {
+		wl_data_device_destroy(device);
+	}
+}
+
+static inline void v_multiwindow_wayland_data_device_manager_destroy(struct wl_data_device_manager *manager) {
+	if (manager != NULL) {
+		wl_data_device_manager_destroy(manager);
+	}
+}
+
+static inline void v_multiwindow_wayland_shm_destroy(struct wl_shm *shm) {
+	if (shm != NULL) {
+		wl_shm_destroy(shm);
+	}
+}
+
+static inline int v_multiwindow_wayland_create_tmpfile(size_t size) {
+	const char *runtime_dir = getenv("XDG_RUNTIME_DIR");
+	char template_path[PATH_MAX];
+	int written = -1;
+	if (runtime_dir != NULL && runtime_dir[0] != '\0') {
+		written = snprintf(template_path, sizeof(template_path), "%s/v-multiwindow-shm-XXXXXX", runtime_dir);
+	}
+	if (written < 0 || (size_t)written >= sizeof(template_path)) {
+		written = snprintf(template_path, sizeof(template_path), "/tmp/v-multiwindow-shm-XXXXXX");
+	}
+	if (written < 0 || (size_t)written >= sizeof(template_path)) {
+		return -1;
+	}
+	int fd = mkstemp(template_path);
+	if (fd < 0) {
+		return -1;
+	}
+	unlink(template_path);
+	if (ftruncate(fd, (off_t)size) < 0) {
+		close(fd);
+		return -1;
+	}
+	return fd;
+}
+
+static inline void *v_multiwindow_wayland_create_shm_buffer(struct wl_shm *shm, int width, int height) {
+	if (shm == NULL || width <= 0 || height <= 0) {
+		return NULL;
+	}
+	size_t stride = (size_t)width * 4;
+	size_t size = stride * (size_t)height;
+	if (stride == 0 || size == 0 || size / stride != (size_t)height) {
+		return NULL;
+	}
+	int fd = v_multiwindow_wayland_create_tmpfile(size);
+	if (fd < 0) {
+		return NULL;
+	}
+	void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (data == MAP_FAILED) {
+		close(fd);
+		return NULL;
+	}
+	uint32_t *pixels = (uint32_t *)data;
+	size_t pixel_count = (size_t)width * (size_t)height;
+	for (size_t i = 0; i < pixel_count; i++) {
+		pixels[i] = 0xff202020u;
+	}
+	struct wl_shm_pool *pool = wl_shm_create_pool(shm, fd, (int32_t)size);
+	if (pool == NULL) {
+		munmap(data, size);
+		close(fd);
+		return NULL;
+	}
+	struct wl_buffer *buffer = wl_shm_pool_create_buffer(pool, 0, width, height, (int32_t)stride, WL_SHM_FORMAT_XRGB8888);
+	wl_shm_pool_destroy(pool);
+	munmap(data, size);
+	close(fd);
+	return buffer == NULL ? NULL : (void *)buffer;
+}
+
+static inline int v_multiwindow_wayland_add_buffer_listener(struct wl_buffer *buffer, void *data) {
+	if (buffer == NULL) {
+		return -1;
+	}
+	return wl_buffer_add_listener(buffer, &v_multiwindow_wayland_buffer_listener, data);
+}
+
+static inline void v_multiwindow_wayland_attach_buffer(struct wl_surface *surface, struct wl_buffer *buffer, int width, int height) {
+	if (surface != NULL && buffer != NULL) {
+		wl_surface_attach(surface, buffer, 0, 0);
+		wl_surface_damage(surface, 0, 0, width, height);
+		wl_surface_commit(surface);
+	}
+}
+
+static inline void v_multiwindow_wayland_buffer_destroy(struct wl_buffer *buffer) {
+	if (buffer != NULL) {
+		wl_buffer_destroy(buffer);
+	}
+}
+
+static inline void v_multiwindow_wayland_pointer_destroy(struct wl_pointer *pointer) {
+	if (pointer != NULL) {
+#ifdef WL_POINTER_RELEASE
+		uint32_t version = wl_proxy_get_version((struct wl_proxy *)pointer);
+		if (version >= 3) {
+			wl_proxy_marshal_flags((struct wl_proxy *)pointer, WL_POINTER_RELEASE, NULL, version, WL_MARSHAL_FLAG_DESTROY);
+		} else {
+			wl_pointer_destroy(pointer);
+		}
+#else
+		wl_pointer_destroy(pointer);
+#endif
+	}
+}
+
+static inline void v_multiwindow_wayland_keyboard_destroy(struct wl_keyboard *keyboard) {
+	if (keyboard != NULL) {
+#ifdef WL_KEYBOARD_RELEASE
+		uint32_t version = wl_proxy_get_version((struct wl_proxy *)keyboard);
+		if (version >= 3) {
+			wl_proxy_marshal_flags((struct wl_proxy *)keyboard, WL_KEYBOARD_RELEASE, NULL, version, WL_MARSHAL_FLAG_DESTROY);
+		} else {
+			wl_keyboard_destroy(keyboard);
+		}
+#else
+		wl_keyboard_destroy(keyboard);
+#endif
+	}
+}
+
+static inline void v_multiwindow_wayland_touch_destroy(struct wl_touch *touch) {
+	if (touch != NULL) {
+#ifdef WL_TOUCH_RELEASE
+		uint32_t version = wl_proxy_get_version((struct wl_proxy *)touch);
+		if (version >= 3) {
+			wl_proxy_marshal_flags((struct wl_proxy *)touch, WL_TOUCH_RELEASE, NULL, version, WL_MARSHAL_FLAG_DESTROY);
+		} else {
+			wl_touch_destroy(touch);
+		}
+#else
+		wl_touch_destroy(touch);
+#endif
+	}
+}
+
+static inline void v_multiwindow_wayland_seat_destroy(struct wl_seat *seat) {
+	if (seat != NULL) {
+#ifdef WL_SEAT_RELEASE
+		uint32_t version = wl_proxy_get_version((struct wl_proxy *)seat);
+		if (version >= 5) {
+			wl_proxy_marshal_flags((struct wl_proxy *)seat, WL_SEAT_RELEASE, NULL, version, WL_MARSHAL_FLAG_DESTROY);
+		} else {
+			wl_seat_destroy(seat);
+		}
+#else
+		wl_seat_destroy(seat);
+#endif
+	}
 }
 
 static inline struct xdg_surface *v_multiwindow_wayland_xdg_wm_base_get_xdg_surface(struct xdg_wm_base *wm_base, struct wl_surface *surface) {
@@ -200,6 +825,35 @@ static inline void v_multiwindow_wayland_xdg_toplevel_set_max_size(struct xdg_to
 
 static inline void v_multiwindow_wayland_xdg_toplevel_set_fullscreen(struct xdg_toplevel *toplevel, struct wl_output *output) {
 	wl_proxy_marshal_flags((struct wl_proxy *)toplevel, XDG_TOPLEVEL_SET_FULLSCREEN, NULL, wl_proxy_get_version((struct wl_proxy *)toplevel), 0, output);
+}
+
+static inline void v_multiwindow_wayland_xdg_toplevel_move(struct xdg_toplevel *toplevel, struct wl_seat *seat, uint32_t serial) {
+	wl_proxy_marshal_flags((struct wl_proxy *)toplevel, XDG_TOPLEVEL_MOVE, NULL, wl_proxy_get_version((struct wl_proxy *)toplevel), 0, seat, serial);
+}
+
+static inline void v_multiwindow_wayland_xdg_toplevel_resize(struct xdg_toplevel *toplevel, struct wl_seat *seat, uint32_t serial, uint32_t edges) {
+	wl_proxy_marshal_flags((struct wl_proxy *)toplevel, XDG_TOPLEVEL_RESIZE, NULL, wl_proxy_get_version((struct wl_proxy *)toplevel), 0, seat, serial, edges);
+}
+
+static inline struct zxdg_toplevel_decoration_v1 *v_multiwindow_wayland_xdg_decoration_manager_get_toplevel_decoration(struct zxdg_decoration_manager_v1 *manager, struct xdg_toplevel *toplevel) {
+	struct wl_proxy *id = wl_proxy_marshal_flags((struct wl_proxy *)manager, ZXDG_DECORATION_MANAGER_V1_GET_TOPLEVEL_DECORATION, &v_multiwindow_zxdg_toplevel_decoration_v1_interface, wl_proxy_get_version((struct wl_proxy *)manager), 0, NULL, toplevel);
+	return (struct zxdg_toplevel_decoration_v1 *)id;
+}
+
+static inline void v_multiwindow_wayland_xdg_toplevel_decoration_set_server_side(struct zxdg_toplevel_decoration_v1 *decoration) {
+	wl_proxy_marshal_flags((struct wl_proxy *)decoration, ZXDG_TOPLEVEL_DECORATION_V1_SET_MODE, NULL, wl_proxy_get_version((struct wl_proxy *)decoration), 0, ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
+}
+
+static inline void v_multiwindow_wayland_xdg_toplevel_decoration_destroy(struct zxdg_toplevel_decoration_v1 *decoration) {
+	if (decoration != NULL) {
+		wl_proxy_marshal_flags((struct wl_proxy *)decoration, ZXDG_TOPLEVEL_DECORATION_V1_DESTROY, NULL, wl_proxy_get_version((struct wl_proxy *)decoration), WL_MARSHAL_FLAG_DESTROY);
+	}
+}
+
+static inline void v_multiwindow_wayland_xdg_decoration_manager_destroy(struct zxdg_decoration_manager_v1 *manager) {
+	if (manager != NULL) {
+		wl_proxy_marshal_flags((struct wl_proxy *)manager, ZXDG_DECORATION_MANAGER_V1_DESTROY, NULL, wl_proxy_get_version((struct wl_proxy *)manager), WL_MARSHAL_FLAG_DESTROY);
+	}
 }
 
 static inline void v_multiwindow_wayland_xdg_toplevel_destroy(struct xdg_toplevel *toplevel) {

--- a/vlib/x/multiwindow/wayland_cursor_shape_private.c
+++ b/vlib/x/multiwindow/wayland_cursor_shape_private.c
@@ -1,0 +1,35 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <wayland-util.h>
+
+extern const struct wl_interface wl_pointer_interface;
+extern const struct wl_interface v_multiwindow_wp_cursor_shape_device_v1_interface;
+
+static const struct wl_interface *v_multiwindow_cursor_shape_v1_types[] = {
+	NULL,
+	NULL,
+	&v_multiwindow_wp_cursor_shape_device_v1_interface,
+	&wl_pointer_interface,
+};
+
+static const struct wl_message v_multiwindow_wp_cursor_shape_manager_v1_requests[] = {
+	{ "destroy", "", v_multiwindow_cursor_shape_v1_types + 0 },
+	{ "get_pointer", "no", v_multiwindow_cursor_shape_v1_types + 2 },
+};
+
+const struct wl_interface v_multiwindow_wp_cursor_shape_manager_v1_interface = {
+	"wp_cursor_shape_manager_v1", 1,
+	2, v_multiwindow_wp_cursor_shape_manager_v1_requests,
+	0, NULL,
+};
+
+static const struct wl_message v_multiwindow_wp_cursor_shape_device_v1_requests[] = {
+	{ "destroy", "", v_multiwindow_cursor_shape_v1_types + 0 },
+	{ "set_shape", "uu", v_multiwindow_cursor_shape_v1_types + 0 },
+};
+
+const struct wl_interface v_multiwindow_wp_cursor_shape_device_v1_interface = {
+	"wp_cursor_shape_device_v1", 1,
+	2, v_multiwindow_wp_cursor_shape_device_v1_requests,
+	0, NULL,
+};

--- a/vlib/x/multiwindow/wayland_xdg_decoration_private.c
+++ b/vlib/x/multiwindow/wayland_xdg_decoration_private.c
@@ -1,0 +1,9 @@
+#define xdg_toplevel_interface v_multiwindow_xdg_toplevel_interface
+#define zxdg_decoration_manager_v1_interface v_multiwindow_zxdg_decoration_manager_v1_interface
+#define zxdg_toplevel_decoration_v1_interface v_multiwindow_zxdg_toplevel_decoration_v1_interface
+
+#include "xdg-decoration-unstable-v1-protocol.c"
+
+#undef xdg_toplevel_interface
+#undef zxdg_decoration_manager_v1_interface
+#undef zxdg_toplevel_decoration_v1_interface

--- a/vlib/x/multiwindow/win32_backend.c.v
+++ b/vlib/x/multiwindow/win32_backend.c.v
@@ -9,26 +9,43 @@ $if windows {
 	#flag windows -D_UNICODE
 	#flag windows -luser32
 	#flag windows -lgdi32
+	#flag windows -lshell32
 	#include <windows.h>
 	#insert "@VMODROOT/vlib/x/multiwindow/win32_backend_helpers.h"
+}
+
+@[markused]
+struct Win32NativeQueuedEvent {
+	sequence u64
+	event    QueuedEvent
 }
 
 @[heap; markused]
 struct Win32WindowRecord {
 	id WindowId
 mut:
-	hwnd                  voidptr
-	config                WindowConfig
-	width                 int
-	height                int
-	close_requested       bool
-	destroyed             bool
-	resize_event_pending  bool
-	render_resize_pending bool
-	swapchain             voidptr
-	render_view           voidptr
-	depth_texture         voidptr
-	depth_stencil_view    voidptr
+	hwnd                   voidptr
+	config                 WindowConfig
+	width                  int
+	height                 int
+	destroyed              bool
+	render_resize_pending  bool
+	suppress_resize_event  bool
+	queued_events          []Win32NativeQueuedEvent
+	mouse_x                f32
+	mouse_y                f32
+	mouse_dx               f32
+	mouse_dy               f32
+	mouse_pos_valid        bool
+	iconified              bool
+	pending_dropped_files  []string
+	pending_drop_modifiers u32
+	pending_high_surrogate u32
+	suppress_control_char  u32
+	swapchain              voidptr
+	render_view            voidptr
+	depth_texture          voidptr
+	depth_stencil_view     voidptr
 }
 
 struct Win32Backend {
@@ -45,6 +62,7 @@ $if windows {
 	fn C.v_multiwindow_win32_create_window(title &u16, width int, height int, min_width int, min_height int, resizable int, borderless int, fullscreen int, visible int, data voidptr) voidptr
 	fn C.v_multiwindow_win32_destroy_window(hwnd voidptr) int
 	fn C.v_multiwindow_win32_set_window_text(hwnd voidptr, title &u16) int
+	fn C.v_multiwindow_win32_set_cursor_shape(hwnd voidptr, shape int) int
 	fn C.v_multiwindow_win32_set_client_size(hwnd voidptr, width int, height int, min_width int, min_height int, resizable int, borderless int, fullscreen int) int
 	fn C.v_multiwindow_win32_client_width(hwnd voidptr) int
 	fn C.v_multiwindow_win32_client_height(hwnd voidptr) int
@@ -54,28 +72,35 @@ $if windows {
 $if windows {
 	@[export: 'v_multiwindow_win32_window_close_requested']
 	@[markused]
-	fn win32_window_close_requested(data voidptr) {
+	fn win32_window_close_requested(data voidptr, sequence u64) {
 		if data == unsafe { nil } {
 			return
 		}
 		mut record := unsafe { &Win32WindowRecord(data) }
-		record.close_requested = true
+		record.enqueue_native_event(sequence, queued_lifecycle_event(Event{
+			kind:      .window_close_requested
+			window_id: record.id
+		}))
 	}
 
 	@[export: 'v_multiwindow_win32_window_destroyed']
 	@[markused]
-	fn win32_window_destroyed(data voidptr) {
+	fn win32_window_destroyed(data voidptr, sequence u64) {
 		if data == unsafe { nil } {
 			return
 		}
 		mut record := unsafe { &Win32WindowRecord(data) }
 		record.destroyed = true
 		record.hwnd = unsafe { nil }
+		record.enqueue_native_event(sequence, queued_lifecycle_event(Event{
+			kind:      .window_destroyed
+			window_id: record.id
+		}))
 	}
 
 	@[export: 'v_multiwindow_win32_window_resized']
 	@[markused]
-	fn win32_window_resized(data voidptr, width int, height int) {
+	fn win32_window_resized(data voidptr, sequence u64, width int, height int) {
 		if data == unsafe { nil } || width <= 0 || height <= 0 {
 			return
 		}
@@ -85,8 +110,413 @@ $if windows {
 		}
 		record.width = width
 		record.height = height
-		record.resize_event_pending = true
 		record.render_resize_pending = true
+		if record.suppress_resize_event {
+			return
+		}
+		record.enqueue_native_event(sequence, queued_lifecycle_event(Event{
+			kind:      .window_resized
+			window_id: record.id
+			width:     width
+			height:    height
+		}))
+		record.enqueue_native_event(sequence, queued_input_event(record.input_event(.resized)))
+	}
+
+	@[export: 'v_multiwindow_win32_window_input_event']
+	@[markused]
+	fn win32_window_input_event(data voidptr, sequence u64, kind int, key_code int, char_code u32, key_repeat int, modifiers u32, mouse_button int, mouse_x int, mouse_y int, wheel_delta_x int, wheel_delta_y int) {
+		if data == unsafe { nil } {
+			return
+		}
+		mut record := unsafe { &Win32WindowRecord(data) }
+		input_kind := win32_input_kind(kind)
+		if input_kind == .invalid {
+			return
+		}
+		if input_kind == .char {
+			if key_repeat != 0 {
+				record.enqueue_char_event_with_repeat(sequence, char_code, modifiers, true)
+			} else {
+				record.enqueue_char_event(sequence, char_code, modifiers)
+			}
+			return
+		}
+		mut input := record.input_event(input_kind)
+		match input_kind {
+			.key_down, .key_up {
+				if key_code == 0 {
+					return
+				}
+				input = InputEvent{
+					kind:               input_kind
+					window_id:          record.id
+					key_code:           key_code
+					key_repeat:         key_repeat != 0
+					modifiers:          modifiers
+					mouse_x:            record.mouse_x
+					mouse_y:            record.mouse_y
+					mouse_dx:           record.mouse_dx
+					mouse_dy:           record.mouse_dy
+					window_width:       record.width
+					window_height:      record.height
+					framebuffer_width:  record.width
+					framebuffer_height: record.height
+					mouse_button:       256
+				}
+			}
+			.mouse_down, .mouse_up {
+				if mouse_button == 256 {
+					return
+				}
+				record.update_mouse_position(mouse_x, mouse_y, false)
+				input = InputEvent{
+					kind:               input_kind
+					window_id:          record.id
+					modifiers:          modifiers
+					mouse_button:       mouse_button
+					mouse_x:            record.mouse_x
+					mouse_y:            record.mouse_y
+					mouse_dx:           record.mouse_dx
+					mouse_dy:           record.mouse_dy
+					window_width:       record.width
+					window_height:      record.height
+					framebuffer_width:  record.width
+					framebuffer_height: record.height
+				}
+			}
+			.mouse_move {
+				record.update_mouse_position(mouse_x, mouse_y, false)
+				input = InputEvent{
+					kind:               input_kind
+					window_id:          record.id
+					modifiers:          modifiers
+					mouse_x:            record.mouse_x
+					mouse_y:            record.mouse_y
+					mouse_dx:           record.mouse_dx
+					mouse_dy:           record.mouse_dy
+					window_width:       record.width
+					window_height:      record.height
+					framebuffer_width:  record.width
+					framebuffer_height: record.height
+					mouse_button:       256
+				}
+			}
+			.mouse_enter, .mouse_leave {
+				record.update_mouse_position(mouse_x, mouse_y, true)
+				input = InputEvent{
+					kind:               input_kind
+					window_id:          record.id
+					modifiers:          modifiers
+					mouse_x:            record.mouse_x
+					mouse_y:            record.mouse_y
+					window_width:       record.width
+					window_height:      record.height
+					framebuffer_width:  record.width
+					framebuffer_height: record.height
+					mouse_button:       256
+				}
+			}
+			.mouse_scroll {
+				record.update_mouse_position(mouse_x, mouse_y, true)
+				input = InputEvent{
+					kind:               input_kind
+					window_id:          record.id
+					modifiers:          modifiers
+					mouse_x:            record.mouse_x
+					mouse_y:            record.mouse_y
+					scroll_x:           -f32(wheel_delta_x) / f32(30.0)
+					scroll_y:           f32(wheel_delta_y) / f32(30.0)
+					window_width:       record.width
+					window_height:      record.height
+					framebuffer_width:  record.width
+					framebuffer_height: record.height
+					mouse_button:       256
+				}
+			}
+			.focused, .unfocused {}
+			.clipboard_pasted {
+				input = InputEvent{
+					kind:               input_kind
+					window_id:          record.id
+					modifiers:          modifiers
+					mouse_x:            record.mouse_x
+					mouse_y:            record.mouse_y
+					mouse_dx:           record.mouse_dx
+					mouse_dy:           record.mouse_dy
+					window_width:       record.width
+					window_height:      record.height
+					framebuffer_width:  record.width
+					framebuffer_height: record.height
+					mouse_button:       256
+				}
+			}
+			.iconified {
+				if record.iconified {
+					return
+				}
+				record.iconified = true
+			}
+			.restored {
+				if !record.iconified {
+					return
+				}
+				record.iconified = false
+			}
+			else {
+				return
+			}
+		}
+
+		record.enqueue_native_event(sequence, queued_input_event(input))
+		if input_kind == .key_down {
+			control_char := win32_control_char_for_key(key_code)
+			if control_char != 0 {
+				if key_repeat != 0 {
+					record.enqueue_char_event_with_repeat(sequence, control_char, modifiers, true)
+				} else {
+					record.enqueue_char_event(sequence, control_char, modifiers)
+				}
+				record.suppress_control_char = control_char
+			}
+		}
+	}
+
+	@[export: 'v_multiwindow_win32_window_drop_begin']
+	@[markused]
+	fn win32_window_drop_begin(data voidptr, sequence u64, mouse_x int, mouse_y int, modifiers u32) {
+		_ = sequence
+		if data == unsafe { nil } {
+			return
+		}
+		mut record := unsafe { &Win32WindowRecord(data) }
+		record.pending_dropped_files.clear()
+		record.pending_drop_modifiers = modifiers
+		record.update_mouse_position(mouse_x, mouse_y, true)
+	}
+
+	@[export: 'v_multiwindow_win32_window_drop_file']
+	@[markused]
+	fn win32_window_drop_file(data voidptr, sequence u64, path &char) {
+		_ = sequence
+		if data == unsafe { nil } || path == unsafe { nil } {
+			return
+		}
+		mut record := unsafe { &Win32WindowRecord(data) }
+		record.pending_dropped_files << unsafe { tos_clone(&u8(path)) }
+	}
+
+	@[export: 'v_multiwindow_win32_window_drop_end']
+	@[markused]
+	fn win32_window_drop_end(data voidptr, sequence u64) {
+		if data == unsafe { nil } {
+			return
+		}
+		mut record := unsafe { &Win32WindowRecord(data) }
+		if record.pending_dropped_files.len == 0 {
+			return
+		}
+		input := InputEvent{
+			kind:               .files_dropped
+			window_id:          record.id
+			modifiers:          record.pending_drop_modifiers
+			mouse_x:            record.mouse_x
+			mouse_y:            record.mouse_y
+			mouse_dx:           record.mouse_dx
+			mouse_dy:           record.mouse_dy
+			window_width:       record.width
+			window_height:      record.height
+			framebuffer_width:  record.width
+			framebuffer_height: record.height
+			mouse_button:       256
+			dropped_files:      record.pending_dropped_files.clone()
+		}
+		record.pending_dropped_files.clear()
+		record.enqueue_native_event(sequence, queued_input_event(input))
+	}
+
+	@[export: 'v_multiwindow_win32_window_touch_event']
+	@[markused]
+	fn win32_window_touch_event(data voidptr, sequence u64, kind int, modifiers u32, count int, ids &u64, xs &int, ys &int, changed &int) {
+		if data == unsafe { nil } || count <= 0 || ids == unsafe { nil } || xs == unsafe { nil }
+			|| ys == unsafe { nil } || changed == unsafe { nil } {
+			return
+		}
+		input_kind := win32_input_kind(kind)
+		if input_kind == .invalid {
+			return
+		}
+		mut record := unsafe { &Win32WindowRecord(data) }
+		touch_count := if count > 8 { 8 } else { count }
+		mut touches := [8]InputTouchPoint{}
+		for i in 0 .. touch_count {
+			x := unsafe { xs[i] }
+			y := unsafe { ys[i] }
+			touches[i] = InputTouchPoint{
+				identifier: unsafe { ids[i] }
+				pos_x:      f32(x)
+				pos_y:      f32(y)
+				changed:    unsafe { changed[i] } != 0
+			}
+		}
+		first_x := unsafe { xs[0] }
+		first_y := unsafe { ys[0] }
+		input := InputEvent{
+			kind:               input_kind
+			window_id:          record.id
+			modifiers:          modifiers
+			mouse_x:            f32(first_x)
+			mouse_y:            f32(first_y)
+			num_touches:        touch_count
+			touches:            touches
+			window_width:       record.width
+			window_height:      record.height
+			framebuffer_width:  record.width
+			framebuffer_height: record.height
+			mouse_button:       256
+		}
+		record.enqueue_native_event(sequence, queued_input_event(input))
+	}
+}
+
+@[markused]
+fn (mut record Win32WindowRecord) enqueue_native_event(sequence u64, event QueuedEvent) {
+	record.queued_events << Win32NativeQueuedEvent{
+		sequence: sequence
+		event:    event
+	}
+}
+
+@[markused]
+fn (record &Win32WindowRecord) input_event(kind InputEventKind) InputEvent {
+	return InputEvent{
+		kind:               kind
+		window_id:          record.id
+		mouse_x:            record.mouse_x
+		mouse_y:            record.mouse_y
+		mouse_dx:           record.mouse_dx
+		mouse_dy:           record.mouse_dy
+		window_width:       record.width
+		window_height:      record.height
+		framebuffer_width:  record.width
+		framebuffer_height: record.height
+		mouse_button:       256
+	}
+}
+
+@[markused]
+fn (mut record Win32WindowRecord) update_mouse_position(x int, y int, clear_delta bool) {
+	new_x := f32(x)
+	new_y := f32(y)
+	if clear_delta || !record.mouse_pos_valid {
+		record.mouse_x = new_x
+		record.mouse_y = new_y
+		record.mouse_dx = 0
+		record.mouse_dy = 0
+		record.mouse_pos_valid = true
+		return
+	}
+	record.mouse_dx = new_x - record.mouse_x
+	record.mouse_dy = new_y - record.mouse_y
+	record.mouse_x = new_x
+	record.mouse_y = new_y
+}
+
+@[markused]
+fn (mut record Win32WindowRecord) enqueue_char_event(sequence u64, char_code u32, modifiers u32) {
+	record.enqueue_char_event_with_repeat(sequence, char_code, modifiers, false)
+}
+
+@[markused]
+fn (mut record Win32WindowRecord) enqueue_char_event_with_repeat(sequence u64, char_code u32, modifiers u32, key_repeat bool) {
+	mut codepoint := char_code
+	if record.suppress_control_char != 0 {
+		if char_code == record.suppress_control_char {
+			record.suppress_control_char = 0
+			return
+		}
+		record.suppress_control_char = 0
+	}
+	if char_code >= 0xd800 && char_code <= 0xdbff {
+		record.pending_high_surrogate = char_code
+		return
+	}
+	if char_code >= 0xdc00 && char_code <= 0xdfff {
+		if record.pending_high_surrogate == 0 {
+			return
+		}
+		codepoint = 0x10000 + ((record.pending_high_surrogate - 0xd800) << 10) +
+			(char_code - 0xdc00)
+		record.pending_high_surrogate = 0
+	} else {
+		record.pending_high_surrogate = 0
+	}
+	if codepoint < 32 && !win32_is_useful_control_char(codepoint) {
+		return
+	}
+	input := InputEvent{
+		kind:               .char
+		window_id:          record.id
+		char_code:          codepoint
+		key_repeat:         key_repeat
+		modifiers:          modifiers
+		window_width:       record.width
+		window_height:      record.height
+		framebuffer_width:  record.width
+		framebuffer_height: record.height
+	}
+	record.enqueue_native_event(sequence, queued_input_event(input))
+}
+
+@[markused]
+fn win32_input_kind(kind int) InputEventKind {
+	return match kind {
+		1 { InputEventKind.key_down }
+		2 { InputEventKind.key_up }
+		3 { InputEventKind.char }
+		4 { InputEventKind.mouse_down }
+		5 { InputEventKind.mouse_up }
+		6 { InputEventKind.mouse_scroll }
+		7 { InputEventKind.mouse_move }
+		8 { InputEventKind.mouse_enter }
+		9 { InputEventKind.mouse_leave }
+		10 { InputEventKind.focused }
+		11 { InputEventKind.unfocused }
+		12 { InputEventKind.iconified }
+		13 { InputEventKind.restored }
+		14 { InputEventKind.clipboard_pasted }
+		15 { InputEventKind.touches_began }
+		16 { InputEventKind.touches_moved }
+		17 { InputEventKind.touches_ended }
+		else { InputEventKind.invalid }
+	}
+}
+
+@[markused]
+fn win32_control_char_for_key(key_code int) u32 {
+	return match key_code {
+		259 { u32(8) }
+		258 { u32(9) }
+		257, 335 { u32(13) }
+		261 { u32(127) }
+		else { u32(0) }
+	}
+}
+
+@[markused]
+fn win32_is_useful_control_char(char_code u32) bool {
+	return char_code == 8 || char_code == 9 || char_code == 13 || char_code == 127
+}
+
+fn win32_sort_native_events(mut events []Win32NativeQueuedEvent) {
+	for i in 1 .. events.len {
+		mut j := i
+		for j > 0 && events[j - 1].sequence > events[j].sequence {
+			event := events[j]
+			events[j] = events[j - 1]
+			events[j - 1] = event
+			j--
+		}
 	}
 }
 
@@ -112,6 +542,15 @@ fn (backend &Win32Backend) capabilities() Capabilities {
 		explicit_swapchain: backend.renderer_ready()
 		d3d11:              backend.renderer_ready()
 		win32:              true
+		input_events:       true
+		mouse_events:       true
+		keyboard_events:    true
+		text_events:        true
+		focus_events:       true
+		drop_events:        true
+		touch_events:       true
+		cursor_shapes:      true
+		native_decorations: true
 	}
 }
 
@@ -164,7 +603,6 @@ fn (mut backend Win32Backend) create_window(id WindowId, config WindowConfig) !W
 			record.height = actual_height
 		}
 		record.config = window_config_with_size(record.config, record.width, record.height)
-		record.resize_event_pending = false
 		record.render_resize_pending = false
 		backend.windows << record
 		return WindowSize{
@@ -224,11 +662,14 @@ fn (mut backend Win32Backend) resize_window(id WindowId, width int, height int) 
 		if record.hwnd == unsafe { nil } {
 			return error(err_window_not_found)
 		}
-		if C.v_multiwindow_win32_set_client_size(record.hwnd, width, height,
+		record.suppress_resize_event = true
+		resize_ok := C.v_multiwindow_win32_set_client_size(record.hwnd, width, height,
 			record.config.min_width, record.config.min_height,
 			win32_bool_to_int(record.config.resizable),
 			win32_bool_to_int(record.config.borderless),
-			win32_bool_to_int(record.config.fullscreen)) == 0 {
+			win32_bool_to_int(record.config.fullscreen)) != 0
+		record.suppress_resize_event = false
+		if !resize_ok {
 			return error(err_win32_resize_window_failed)
 		}
 		mut actual_width := C.v_multiwindow_win32_client_width(record.hwnd)
@@ -242,7 +683,6 @@ fn (mut backend Win32Backend) resize_window(id WindowId, width int, height int) 
 		record.width = actual_width
 		record.height = actual_height
 		record.config = window_config_with_size(record.config, actual_width, actual_height)
-		record.resize_event_pending = false
 		record.render_resize_pending = true
 		return WindowSize{
 			width:  actual_width
@@ -256,46 +696,61 @@ fn (mut backend Win32Backend) resize_window(id WindowId, width int, height int) 
 	}
 }
 
+fn (mut backend Win32Backend) set_window_cursor(id WindowId, shape CursorShape) ! {
+	$if windows {
+		index := backend.window_record_index(id) or { return error(err_window_not_found) }
+		record := backend.windows[index]
+		if record.hwnd == unsafe { nil } {
+			return error(err_window_not_found)
+		}
+		if C.v_multiwindow_win32_set_cursor_shape(record.hwnd, int(shape)) == 0 {
+			return error(err_capability_unsupported)
+		}
+		return
+	} $else {
+		_ = id
+		_ = shape
+		return error(err_backend_unsupported)
+	}
+}
+
 fn (mut backend Win32Backend) poll_events() ![]Event {
-	mut events := []Event{}
+	queued_events := backend.poll_queued_events()!
+	mut events := []Event{cap: queued_events.len}
+	for event in queued_events {
+		if event.kind == .lifecycle {
+			events << event.lifecycle
+		}
+	}
+	return events
+}
+
+fn (mut backend Win32Backend) poll_queued_events() ![]QueuedEvent {
+	mut native_events := []Win32NativeQueuedEvent{}
 	$if windows {
 		if !backend.started {
-			return events
+			return []QueuedEvent{}
 		}
 		C.v_multiwindow_win32_pump_messages()
 		mut i := 0
 		for i < backend.windows.len {
 			mut record := backend.windows[i]
-			if record.close_requested {
-				record.close_requested = false
-				events << Event{
-					kind:      .window_close_requested
-					window_id: record.id
-				}
+			for event in record.queued_events {
+				native_events << event
 			}
-			if record.resize_event_pending {
-				record.resize_event_pending = false
-				if record.width > 0 && record.height > 0 {
-					events << Event{
-						kind:      .window_resized
-						window_id: record.id
-						width:     record.width
-						height:    record.height
-					}
-				}
-			}
+			record.queued_events.clear()
 			if record.destroyed {
-				id := record.id
 				backend.release_window_render_resources(mut record)
 				backend.windows.delete(i)
-				events << Event{
-					kind:      .window_destroyed
-					window_id: id
-				}
 				continue
 			}
 			i++
 		}
+	}
+	win32_sort_native_events(mut native_events)
+	mut events := []QueuedEvent{cap: native_events.len}
+	for native_event in native_events {
+		events << native_event.event
 	}
 	return events
 }

--- a/vlib/x/multiwindow/win32_backend_helpers.h
+++ b/vlib/x/multiwindow/win32_backend_helpers.h
@@ -1,7 +1,38 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdlib.h>
 #include <windows.h>
+#include <shellapi.h>
+
+#ifndef WM_TOUCH
+#define WM_TOUCH 0x0240
+typedef HANDLE HTOUCHINPUT;
+typedef struct tagTOUCHINPUT {
+	LONG x;
+	LONG y;
+	HANDLE hSource;
+	DWORD dwID;
+	DWORD dwFlags;
+	DWORD dwMask;
+	DWORD dwTime;
+	ULONG_PTR dwExtraInfo;
+	DWORD cxContact;
+	DWORD cyContact;
+} TOUCHINPUT, *PTOUCHINPUT;
+#endif
+#ifndef TOUCHEVENTF_MOVE
+#define TOUCHEVENTF_MOVE 0x0001
+#endif
+#ifndef TOUCHEVENTF_DOWN
+#define TOUCHEVENTF_DOWN 0x0002
+#endif
+#ifndef TOUCHEVENTF_UP
+#define TOUCHEVENTF_UP 0x0004
+#endif
+#ifndef TOUCH_COORD_TO_PIXEL
+#define TOUCH_COORD_TO_PIXEL(l) ((l) / 100)
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,17 +42,74 @@ extern "C" {
 #else
 #define V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE VV_EXP
 #endif
-V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE void v_multiwindow_win32_window_close_requested(void *data);
-V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE void v_multiwindow_win32_window_destroyed(void *data);
-V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE void v_multiwindow_win32_window_resized(void *data, int width, int height);
+V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE void v_multiwindow_win32_window_close_requested(void *data, uint64_t sequence);
+V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE void v_multiwindow_win32_window_destroyed(void *data, uint64_t sequence);
+V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE void v_multiwindow_win32_window_resized(void *data, uint64_t sequence, int width, int height);
+V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE void v_multiwindow_win32_window_input_event(void *data, uint64_t sequence, int kind, int key_code, uint32_t char_code, int key_repeat, uint32_t modifiers, int mouse_button, int mouse_x, int mouse_y, int wheel_delta_x, int wheel_delta_y);
+V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE void v_multiwindow_win32_window_drop_begin(void *data, uint64_t sequence, int mouse_x, int mouse_y, uint32_t modifiers);
+V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE void v_multiwindow_win32_window_drop_file(void *data, uint64_t sequence, char *path);
+V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE void v_multiwindow_win32_window_drop_end(void *data, uint64_t sequence);
+V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE void v_multiwindow_win32_window_touch_event(void *data, uint64_t sequence, int kind, uint32_t modifiers, int count, uint64_t *ids, int *xs, int *ys, int *changed);
 #undef V_MULTIWINDOW_WIN32_CALLBACK_LINKAGE
 #ifdef __cplusplus
 }
 #endif
 
+#define V_MULTIWINDOW_WIN32_INPUT_KEY_DOWN 1
+#define V_MULTIWINDOW_WIN32_INPUT_KEY_UP 2
+#define V_MULTIWINDOW_WIN32_INPUT_CHAR 3
+#define V_MULTIWINDOW_WIN32_INPUT_MOUSE_DOWN 4
+#define V_MULTIWINDOW_WIN32_INPUT_MOUSE_UP 5
+#define V_MULTIWINDOW_WIN32_INPUT_MOUSE_SCROLL 6
+#define V_MULTIWINDOW_WIN32_INPUT_MOUSE_MOVE 7
+#define V_MULTIWINDOW_WIN32_INPUT_MOUSE_ENTER 8
+#define V_MULTIWINDOW_WIN32_INPUT_MOUSE_LEAVE 9
+#define V_MULTIWINDOW_WIN32_INPUT_FOCUSED 10
+#define V_MULTIWINDOW_WIN32_INPUT_UNFOCUSED 11
+#define V_MULTIWINDOW_WIN32_INPUT_ICONIFIED 12
+#define V_MULTIWINDOW_WIN32_INPUT_RESTORED 13
+#define V_MULTIWINDOW_WIN32_INPUT_CLIPBOARD_PASTED 14
+#define V_MULTIWINDOW_WIN32_INPUT_TOUCHES_BEGAN 15
+#define V_MULTIWINDOW_WIN32_INPUT_TOUCHES_MOVED 16
+#define V_MULTIWINDOW_WIN32_INPUT_TOUCHES_ENDED 17
+#define V_MULTIWINDOW_WIN32_MOUSE_BUTTON_LEFT 0
+#define V_MULTIWINDOW_WIN32_MOUSE_BUTTON_RIGHT 1
+#define V_MULTIWINDOW_WIN32_MOUSE_BUTTON_MIDDLE 2
+#define V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID 256
+#define V_MULTIWINDOW_WIN32_MAX_TOUCH_POINTS 8
+#define V_MULTIWINDOW_WIN32_MODIFIER_LMB 0x100
+#define V_MULTIWINDOW_WIN32_MODIFIER_RMB 0x200
+#define V_MULTIWINDOW_WIN32_MODIFIER_MMB 0x400
+#ifndef WM_MOUSEHWHEEL
+#define WM_MOUSEHWHEEL 0x020e
+#endif
+#ifndef MAPVK_VSC_TO_VK_EX
+#define MAPVK_VSC_TO_VK_EX 3
+#endif
+
+#define V_MULTIWINDOW_CURSOR_SHAPE_DEFAULT 0
+#define V_MULTIWINDOW_CURSOR_SHAPE_POINTER 1
+#define V_MULTIWINDOW_CURSOR_SHAPE_MOVE 2
+#define V_MULTIWINDOW_CURSOR_SHAPE_N_RESIZE 3
+#define V_MULTIWINDOW_CURSOR_SHAPE_S_RESIZE 4
+#define V_MULTIWINDOW_CURSOR_SHAPE_E_RESIZE 5
+#define V_MULTIWINDOW_CURSOR_SHAPE_W_RESIZE 6
+#define V_MULTIWINDOW_CURSOR_SHAPE_NE_RESIZE 7
+#define V_MULTIWINDOW_CURSOR_SHAPE_NW_RESIZE 8
+#define V_MULTIWINDOW_CURSOR_SHAPE_SE_RESIZE 9
+#define V_MULTIWINDOW_CURSOR_SHAPE_SW_RESIZE 10
+#define V_MULTIWINDOW_CURSOR_SHAPE_EW_RESIZE 11
+#define V_MULTIWINDOW_CURSOR_SHAPE_NS_RESIZE 12
+#define V_MULTIWINDOW_CURSOR_SHAPE_NESW_RESIZE 13
+#define V_MULTIWINDOW_CURSOR_SHAPE_NWSE_RESIZE 14
+#define V_MULTIWINDOW_CURSOR_SHAPE_GRAB 15
+#define V_MULTIWINDOW_CURSOR_SHAPE_GRABBING 16
+
 static const wchar_t *v_multiwindow_win32_class_name = L"V_x_multiwindow_win32";
 static const wchar_t *v_multiwindow_win32_min_width_prop = L"V_x_multiwindow_min_width";
 static const wchar_t *v_multiwindow_win32_min_height_prop = L"V_x_multiwindow_min_height";
+static const wchar_t *v_multiwindow_win32_mouse_tracked_prop = L"V_x_multiwindow_mouse_tracked";
+static const wchar_t *v_multiwindow_win32_cursor_shape_prop = L"V_x_multiwindow_cursor_shape";
 
 static inline int v_multiwindow_win32_max_int(int a, int b) {
 	return a > b ? a : b;
@@ -39,6 +127,45 @@ static inline void v_multiwindow_win32_set_hwnd_int_prop(HWND hwnd, const wchar_
 	}
 }
 
+static inline LPCWSTR v_multiwindow_win32_cursor_id_for_shape(int shape) {
+	switch (shape) {
+	case V_MULTIWINDOW_CURSOR_SHAPE_POINTER:
+		return IDC_HAND;
+	case V_MULTIWINDOW_CURSOR_SHAPE_MOVE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_GRAB:
+	case V_MULTIWINDOW_CURSOR_SHAPE_GRABBING:
+		return IDC_SIZEALL;
+	case V_MULTIWINDOW_CURSOR_SHAPE_N_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_S_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_NS_RESIZE:
+		return IDC_SIZENS;
+	case V_MULTIWINDOW_CURSOR_SHAPE_E_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_W_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_EW_RESIZE:
+		return IDC_SIZEWE;
+	case V_MULTIWINDOW_CURSOR_SHAPE_NE_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_SW_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_NESW_RESIZE:
+		return IDC_SIZENESW;
+	case V_MULTIWINDOW_CURSOR_SHAPE_NW_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_SE_RESIZE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_NWSE_RESIZE:
+		return IDC_SIZENWSE;
+	default:
+		return IDC_ARROW;
+	}
+}
+
+static inline int v_multiwindow_win32_apply_cursor_shape(HWND hwnd) {
+	int shape = v_multiwindow_win32_hwnd_int_prop(hwnd, v_multiwindow_win32_cursor_shape_prop);
+	HCURSOR cursor = LoadCursorW(NULL, v_multiwindow_win32_cursor_id_for_shape(shape));
+	if (cursor == NULL) {
+		return 0;
+	}
+	SetCursor(cursor);
+	return 1;
+}
+
 static inline int v_multiwindow_win32_adjusted_size(int width, int height, DWORD style, DWORD ex_style, int *out_width, int *out_height) {
 	RECT rect = {0, 0, width, height};
 	if (!AdjustWindowRectEx(&rect, style, FALSE, ex_style)) {
@@ -46,6 +173,427 @@ static inline int v_multiwindow_win32_adjusted_size(int width, int height, DWORD
 	}
 	*out_width = rect.right - rect.left;
 	*out_height = rect.bottom - rect.top;
+	return 1;
+}
+
+static inline uint64_t v_multiwindow_win32_next_event_sequence(void) {
+	static uint64_t sequence = 1;
+	return sequence++;
+}
+
+static inline int v_multiwindow_win32_lparam_x(LPARAM lparam) {
+	return (int)(int16_t)(lparam & 0xffff);
+}
+
+static inline int v_multiwindow_win32_lparam_y(LPARAM lparam) {
+	return (int)(int16_t)((lparam >> 16) & 0xffff);
+}
+
+static inline int v_multiwindow_win32_wheel_delta(WPARAM wparam) {
+	return (int)(int16_t)((wparam >> 16) & 0xffff);
+}
+
+static inline void v_multiwindow_win32_client_pos_from_lparam(HWND hwnd, LPARAM lparam, int *out_x, int *out_y) {
+	*out_x = v_multiwindow_win32_lparam_x(lparam);
+	*out_y = v_multiwindow_win32_lparam_y(lparam);
+	if (hwnd) {
+		POINT point = {*out_x, *out_y};
+		if (ScreenToClient(hwnd, &point)) {
+			*out_x = point.x;
+			*out_y = point.y;
+		}
+	}
+}
+
+static inline void v_multiwindow_win32_cursor_client_pos(HWND hwnd, int *out_x, int *out_y) {
+	POINT point = {0, 0};
+	if (GetCursorPos(&point) && hwnd && ScreenToClient(hwnd, &point)) {
+		*out_x = point.x;
+		*out_y = point.y;
+		return;
+	}
+	*out_x = 0;
+	*out_y = 0;
+}
+
+static inline uint32_t v_multiwindow_win32_modifiers(void) {
+	uint32_t modifiers = 0;
+	if (GetKeyState(VK_SHIFT) & 0x8000) {
+		modifiers |= 1;
+	}
+	if (GetKeyState(VK_CONTROL) & 0x8000) {
+		modifiers |= 2;
+	}
+	if (GetKeyState(VK_MENU) & 0x8000) {
+		modifiers |= 4;
+	}
+	if ((GetKeyState(VK_LWIN) | GetKeyState(VK_RWIN)) & 0x8000) {
+		modifiers |= 8;
+	}
+	int swapped = (TRUE == GetSystemMetrics(SM_SWAPBUTTON));
+	if (GetAsyncKeyState(VK_LBUTTON) & 0x8000) {
+		modifiers |= swapped ? V_MULTIWINDOW_WIN32_MODIFIER_RMB : V_MULTIWINDOW_WIN32_MODIFIER_LMB;
+	}
+	if (GetAsyncKeyState(VK_RBUTTON) & 0x8000) {
+		modifiers |= swapped ? V_MULTIWINDOW_WIN32_MODIFIER_LMB : V_MULTIWINDOW_WIN32_MODIFIER_RMB;
+	}
+	if (GetAsyncKeyState(VK_MBUTTON) & 0x8000) {
+		modifiers |= V_MULTIWINDOW_WIN32_MODIFIER_MMB;
+	}
+	return modifiers;
+}
+
+static inline int v_multiwindow_win32_is_char_code(WPARAM c) {
+	return c >= 32 || c == 8 || c == 9 || c == 13 || c == 127;
+}
+
+static inline int v_multiwindow_win32_normalized_vk(WPARAM wparam, LPARAM lparam) {
+	UINT vk = (UINT)wparam;
+	if (vk == VK_SHIFT || vk == VK_CONTROL || vk == VK_MENU) {
+		UINT scancode = (UINT)((lparam >> 16) & 0xff);
+		if (lparam & 0x01000000) {
+			scancode |= 0xe000;
+		}
+		vk = MapVirtualKeyW(scancode, MAPVK_VSC_TO_VK_EX);
+	}
+	return (int)vk;
+}
+
+static inline int v_multiwindow_win32_scancode(LPARAM lparam) {
+	return (int)(HIWORD(lparam) & 0x1FF);
+}
+
+static inline const int *v_multiwindow_win32_keycodes(void) {
+	static int keycodes[512];
+	static int initialized = 0;
+	if (initialized) {
+		return keycodes;
+	}
+	initialized = 1;
+	/* Same physical scancode table used by sokol_app.h/GLFW. */
+	keycodes[0x00B] = 48;
+	keycodes[0x002] = 49;
+	keycodes[0x003] = 50;
+	keycodes[0x004] = 51;
+	keycodes[0x005] = 52;
+	keycodes[0x006] = 53;
+	keycodes[0x007] = 54;
+	keycodes[0x008] = 55;
+	keycodes[0x009] = 56;
+	keycodes[0x00A] = 57;
+	keycodes[0x01E] = 65;
+	keycodes[0x030] = 66;
+	keycodes[0x02E] = 67;
+	keycodes[0x020] = 68;
+	keycodes[0x012] = 69;
+	keycodes[0x021] = 70;
+	keycodes[0x022] = 71;
+	keycodes[0x023] = 72;
+	keycodes[0x017] = 73;
+	keycodes[0x024] = 74;
+	keycodes[0x025] = 75;
+	keycodes[0x026] = 76;
+	keycodes[0x032] = 77;
+	keycodes[0x031] = 78;
+	keycodes[0x018] = 79;
+	keycodes[0x019] = 80;
+	keycodes[0x010] = 81;
+	keycodes[0x013] = 82;
+	keycodes[0x01F] = 83;
+	keycodes[0x014] = 84;
+	keycodes[0x016] = 85;
+	keycodes[0x02F] = 86;
+	keycodes[0x011] = 87;
+	keycodes[0x02D] = 88;
+	keycodes[0x015] = 89;
+	keycodes[0x02C] = 90;
+	keycodes[0x028] = 39;
+	keycodes[0x02B] = 92;
+	keycodes[0x033] = 44;
+	keycodes[0x00D] = 61;
+	keycodes[0x029] = 96;
+	keycodes[0x01A] = 91;
+	keycodes[0x00C] = 45;
+	keycodes[0x034] = 46;
+	keycodes[0x01B] = 93;
+	keycodes[0x027] = 59;
+	keycodes[0x035] = 47;
+	keycodes[0x056] = 162; /* VK_OEM_102 / non-US #2 */
+	keycodes[0x00E] = 259;
+	keycodes[0x153] = 261;
+	keycodes[0x14F] = 269;
+	keycodes[0x01C] = 257;
+	keycodes[0x001] = 256;
+	keycodes[0x147] = 268;
+	keycodes[0x152] = 260;
+	keycodes[0x15D] = 348;
+	keycodes[0x151] = 267;
+	keycodes[0x149] = 266;
+	keycodes[0x045] = 284;
+	keycodes[0x146] = 284;
+	keycodes[0x039] = 32;
+	keycodes[0x00F] = 258;
+	keycodes[0x03A] = 280;
+	keycodes[0x145] = 282;
+	keycodes[0x046] = 281;
+	keycodes[0x03B] = 290;
+	keycodes[0x03C] = 291;
+	keycodes[0x03D] = 292;
+	keycodes[0x03E] = 293;
+	keycodes[0x03F] = 294;
+	keycodes[0x040] = 295;
+	keycodes[0x041] = 296;
+	keycodes[0x042] = 297;
+	keycodes[0x043] = 298;
+	keycodes[0x044] = 299;
+	keycodes[0x057] = 300;
+	keycodes[0x058] = 301;
+	keycodes[0x064] = 302;
+	keycodes[0x065] = 303;
+	keycodes[0x066] = 304;
+	keycodes[0x067] = 305;
+	keycodes[0x068] = 306;
+	keycodes[0x069] = 307;
+	keycodes[0x06A] = 308;
+	keycodes[0x06B] = 309;
+	keycodes[0x06C] = 310;
+	keycodes[0x06D] = 311;
+	keycodes[0x06E] = 312;
+	keycodes[0x076] = 313;
+	keycodes[0x038] = 342;
+	keycodes[0x01D] = 341;
+	keycodes[0x02A] = 340;
+	keycodes[0x15B] = 343;
+	keycodes[0x137] = 283;
+	keycodes[0x138] = 346;
+	keycodes[0x11D] = 345;
+	keycodes[0x036] = 344;
+	keycodes[0x136] = 344;
+	keycodes[0x15C] = 347;
+	keycodes[0x150] = 264;
+	keycodes[0x14B] = 263;
+	keycodes[0x14D] = 262;
+	keycodes[0x148] = 265;
+	/* Physical numpad scancodes stay keypad keys even when NumLock is off. */
+	keycodes[0x052] = 320;
+	keycodes[0x04F] = 321;
+	keycodes[0x050] = 322;
+	keycodes[0x051] = 323;
+	keycodes[0x04B] = 324;
+	keycodes[0x04C] = 325;
+	keycodes[0x04D] = 326;
+	keycodes[0x047] = 327;
+	keycodes[0x048] = 328;
+	keycodes[0x049] = 329;
+	keycodes[0x04E] = 334;
+	keycodes[0x053] = 330;
+	keycodes[0x135] = 331;
+	keycodes[0x11C] = 335;
+	keycodes[0x037] = 332;
+	keycodes[0x04A] = 333;
+	return keycodes;
+}
+
+static inline int v_multiwindow_win32_key_code_from_vk(WPARAM wparam, LPARAM lparam) {
+	int vk = v_multiwindow_win32_normalized_vk(wparam, lparam);
+	switch (vk) {
+	case VK_RETURN:
+		return (lparam & 0x01000000) ? 335 : 257;
+	case VK_LSHIFT:
+		return 340;
+	case VK_LCONTROL:
+		return 341;
+	case VK_LMENU:
+		return 342;
+	case VK_LWIN:
+		return 343;
+	case VK_RSHIFT:
+		return 344;
+	case VK_RCONTROL:
+		return 345;
+	case VK_RMENU:
+		return 346;
+	case VK_RWIN:
+		return 347;
+	case VK_APPS:
+		return 348;
+	default:
+		return 0;
+	}
+}
+
+static inline int v_multiwindow_win32_key_code(WPARAM wparam, LPARAM lparam) {
+	int scancode = v_multiwindow_win32_scancode(lparam);
+	const int *keycodes = v_multiwindow_win32_keycodes();
+	if (scancode >= 0 && scancode < 512 && keycodes[scancode] != 0) {
+		return keycodes[scancode];
+	}
+	return v_multiwindow_win32_key_code_from_vk(wparam, lparam);
+}
+
+static inline int v_multiwindow_win32_key_repeat(LPARAM lparam) {
+	return (lparam & 0x40000000) != 0;
+}
+
+typedef BOOL(WINAPI *v_multiwindow_win32_register_touch_window_proc)(HWND, ULONG);
+typedef BOOL(WINAPI *v_multiwindow_win32_unregister_touch_window_proc)(HWND);
+typedef BOOL(WINAPI *v_multiwindow_win32_get_touch_input_info_proc)(HTOUCHINPUT, UINT, PTOUCHINPUT, int);
+typedef BOOL(WINAPI *v_multiwindow_win32_close_touch_input_handle_proc)(HTOUCHINPUT);
+
+static inline FARPROC v_multiwindow_win32_user32_proc(const char *name) {
+	HMODULE user32 = GetModuleHandleW(L"user32.dll");
+	if (!user32) {
+		return NULL;
+	}
+	return GetProcAddress(user32, name);
+}
+
+static inline int v_multiwindow_win32_register_touch_window(HWND hwnd) {
+	v_multiwindow_win32_register_touch_window_proc fn = (v_multiwindow_win32_register_touch_window_proc)v_multiwindow_win32_user32_proc("RegisterTouchWindow");
+	return fn ? (fn(hwnd, 0) != 0) : 0;
+}
+
+static inline void v_multiwindow_win32_unregister_touch_window(HWND hwnd) {
+	v_multiwindow_win32_unregister_touch_window_proc fn = (v_multiwindow_win32_unregister_touch_window_proc)v_multiwindow_win32_user32_proc("UnregisterTouchWindow");
+	if (fn) {
+		fn(hwnd);
+	}
+}
+
+static inline int v_multiwindow_win32_get_touch_input_info(HTOUCHINPUT handle, UINT count, PTOUCHINPUT inputs) {
+	v_multiwindow_win32_get_touch_input_info_proc fn = (v_multiwindow_win32_get_touch_input_info_proc)v_multiwindow_win32_user32_proc("GetTouchInputInfo");
+	return fn ? (fn(handle, count, inputs, sizeof(TOUCHINPUT)) != 0) : 0;
+}
+
+static inline void v_multiwindow_win32_close_touch_input_handle(HTOUCHINPUT handle) {
+	v_multiwindow_win32_close_touch_input_handle_proc fn = (v_multiwindow_win32_close_touch_input_handle_proc)v_multiwindow_win32_user32_proc("CloseTouchInputHandle");
+	if (fn) {
+		fn(handle);
+	}
+}
+
+static inline char *v_multiwindow_win32_wide_to_utf8_alloc(const wchar_t *value) {
+	if (!value) {
+		return NULL;
+	}
+	int required = WideCharToMultiByte(CP_UTF8, 0, value, -1, NULL, 0, NULL, NULL);
+	if (required <= 0) {
+		return NULL;
+	}
+	char *utf8 = (char *)malloc((size_t)required);
+	if (!utf8) {
+		return NULL;
+	}
+	if (WideCharToMultiByte(CP_UTF8, 0, value, -1, utf8, required, NULL, NULL) <= 0) {
+		free(utf8);
+		return NULL;
+	}
+	return utf8;
+}
+
+static inline int v_multiwindow_win32_begin_mouse_tracking(HWND hwnd) {
+	if (GetPropW(hwnd, v_multiwindow_win32_mouse_tracked_prop)) {
+		return 0;
+	}
+	TRACKMOUSEEVENT tme;
+	ZeroMemory(&tme, sizeof(tme));
+	tme.cbSize = sizeof(tme);
+	tme.dwFlags = TME_LEAVE;
+	tme.hwndTrack = hwnd;
+	if (!TrackMouseEvent(&tme)) {
+		return 0;
+	}
+	SetPropW(hwnd, v_multiwindow_win32_mouse_tracked_prop, (HANDLE)(INT_PTR)1);
+	return 1;
+}
+
+static inline void v_multiwindow_win32_end_mouse_tracking(HWND hwnd) {
+	RemovePropW(hwnd, v_multiwindow_win32_mouse_tracked_prop);
+}
+
+static inline void v_multiwindow_win32_emit_drop_files(HWND hwnd, void *data, HDROP hdrop) {
+	if (!data || !hdrop) {
+		if (hdrop) {
+			DragFinish(hdrop);
+		}
+		return;
+	}
+	POINT point = {0, 0};
+	DragQueryPoint(hdrop, &point);
+	uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+	v_multiwindow_win32_window_drop_begin(data, sequence, point.x, point.y, v_multiwindow_win32_modifiers());
+	UINT count = DragQueryFileW(hdrop, 0xFFFFFFFFu, NULL, 0);
+	for (UINT i = 0; i < count; i++) {
+		UINT chars = DragQueryFileW(hdrop, i, NULL, 0);
+		if (chars == 0) {
+			continue;
+		}
+		wchar_t *wide_path = (wchar_t *)calloc((size_t)chars + 1, sizeof(wchar_t));
+		if (!wide_path) {
+			continue;
+		}
+		if (DragQueryFileW(hdrop, i, wide_path, chars + 1) != 0) {
+			char *path = v_multiwindow_win32_wide_to_utf8_alloc(wide_path);
+			if (path) {
+				v_multiwindow_win32_window_drop_file(data, sequence, path);
+				free(path);
+			}
+		}
+		free(wide_path);
+	}
+	v_multiwindow_win32_window_drop_end(data, sequence);
+	DragFinish(hdrop);
+	(void)hwnd;
+}
+
+static inline void v_multiwindow_win32_emit_touch_group(HWND hwnd, void *data, const TOUCHINPUT *inputs, UINT count, DWORD flag, int kind, uint64_t sequence, uint32_t modifiers) {
+	uint64_t ids[V_MULTIWINDOW_WIN32_MAX_TOUCH_POINTS];
+	int xs[V_MULTIWINDOW_WIN32_MAX_TOUCH_POINTS];
+	int ys[V_MULTIWINDOW_WIN32_MAX_TOUCH_POINTS];
+	int changed[V_MULTIWINDOW_WIN32_MAX_TOUCH_POINTS];
+	int out_count = 0;
+	for (UINT i = 0; i < count; i++) {
+		if ((inputs[i].dwFlags & flag) == 0) {
+			continue;
+		}
+		POINT point = {TOUCH_COORD_TO_PIXEL(inputs[i].x), TOUCH_COORD_TO_PIXEL(inputs[i].y)};
+		ScreenToClient(hwnd, &point);
+		ids[out_count] = (uint64_t)inputs[i].dwID;
+		xs[out_count] = point.x;
+		ys[out_count] = point.y;
+		changed[out_count] = 1;
+		out_count++;
+		if (out_count == V_MULTIWINDOW_WIN32_MAX_TOUCH_POINTS) {
+			v_multiwindow_win32_window_touch_event(data, sequence, kind, modifiers, out_count, ids, xs, ys, changed);
+			out_count = 0;
+		}
+	}
+	if (out_count > 0) {
+		v_multiwindow_win32_window_touch_event(data, sequence, kind, modifiers, out_count, ids, xs, ys, changed);
+	}
+}
+
+static inline int v_multiwindow_win32_emit_touch_event(HWND hwnd, void *data, WPARAM wparam, LPARAM lparam) {
+	UINT count = LOWORD(wparam);
+	HTOUCHINPUT handle = (HTOUCHINPUT)lparam;
+	if (!data || count == 0 || !handle) {
+		return 0;
+	}
+	TOUCHINPUT *inputs = (TOUCHINPUT *)calloc((size_t)count, sizeof(TOUCHINPUT));
+	if (!inputs) {
+		return 0;
+	}
+	if (!v_multiwindow_win32_get_touch_input_info(handle, count, inputs)) {
+		free(inputs);
+		return 0;
+	}
+	v_multiwindow_win32_close_touch_input_handle(handle);
+	uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+	uint32_t modifiers = v_multiwindow_win32_modifiers();
+	v_multiwindow_win32_emit_touch_group(hwnd, data, inputs, count, TOUCHEVENTF_DOWN, V_MULTIWINDOW_WIN32_INPUT_TOUCHES_BEGAN, sequence, modifiers);
+	v_multiwindow_win32_emit_touch_group(hwnd, data, inputs, count, TOUCHEVENTF_MOVE, V_MULTIWINDOW_WIN32_INPUT_TOUCHES_MOVED, sequence, modifiers);
+	v_multiwindow_win32_emit_touch_group(hwnd, data, inputs, count, TOUCHEVENTF_UP, V_MULTIWINDOW_WIN32_INPUT_TOUCHES_ENDED, sequence, modifiers);
+	free(inputs);
 	return 1;
 }
 
@@ -60,17 +608,42 @@ static LRESULT CALLBACK v_multiwindow_win32_wnd_proc(HWND hwnd, UINT msg, WPARAM
 	switch (msg) {
 	case WM_CLOSE:
 		if (data) {
-			v_multiwindow_win32_window_close_requested(data);
+			uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+			v_multiwindow_win32_window_close_requested(data, sequence);
 			return 0;
 		}
 		break;
 	case WM_DESTROY:
 		if (data) {
-			v_multiwindow_win32_window_destroyed(data);
+			uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+			v_multiwindow_win32_window_destroyed(data, sequence);
 			SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);
 			RemovePropW(hwnd, v_multiwindow_win32_min_width_prop);
 			RemovePropW(hwnd, v_multiwindow_win32_min_height_prop);
+			RemovePropW(hwnd, v_multiwindow_win32_cursor_shape_prop);
+			v_multiwindow_win32_end_mouse_tracking(hwnd);
+			v_multiwindow_win32_unregister_touch_window(hwnd);
+			DragAcceptFiles(hwnd, FALSE);
 			return 0;
+		}
+		break;
+	case WM_SETFOCUS:
+		if (data) {
+			uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+			v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_FOCUSED, 0, 0, 0, v_multiwindow_win32_modifiers(), V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, 0, 0, 0, 0);
+			return 0;
+		}
+		break;
+	case WM_KILLFOCUS:
+		if (data) {
+			uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+			v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_UNFOCUSED, 0, 0, 0, v_multiwindow_win32_modifiers(), V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, 0, 0, 0, 0);
+			return 0;
+		}
+		break;
+	case WM_SETCURSOR:
+		if (LOWORD(lparam) == HTCLIENT && v_multiwindow_win32_apply_cursor_shape(hwnd)) {
+			return TRUE;
 		}
 		break;
 	case WM_GETMINMAXINFO:
@@ -96,13 +669,146 @@ static LRESULT CALLBACK v_multiwindow_win32_wnd_proc(HWND hwnd, UINT msg, WPARAM
 		}
 		break;
 	case WM_SIZE:
-		if (data && wparam != SIZE_MINIMIZED) {
+		if (data) {
+			uint64_t state_sequence = v_multiwindow_win32_next_event_sequence();
+			if (wparam == SIZE_MINIMIZED) {
+				v_multiwindow_win32_window_input_event(data, state_sequence, V_MULTIWINDOW_WIN32_INPUT_ICONIFIED, 0, 0, 0, v_multiwindow_win32_modifiers(), V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, 0, 0, 0, 0);
+				break;
+			}
+			v_multiwindow_win32_window_input_event(data, state_sequence, V_MULTIWINDOW_WIN32_INPUT_RESTORED, 0, 0, 0, v_multiwindow_win32_modifiers(), V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, 0, 0, 0, 0);
 			RECT rect = {0, 0, 0, 0};
 			if (GetClientRect(hwnd, &rect)) {
 				int width = rect.right - rect.left;
 				int height = rect.bottom - rect.top;
-				v_multiwindow_win32_window_resized(data, width, height);
+				uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+				v_multiwindow_win32_window_resized(data, sequence, width, height);
 			}
+		}
+		break;
+	case WM_MOUSEMOVE:
+		if (data) {
+			int x = v_multiwindow_win32_lparam_x(lparam);
+			int y = v_multiwindow_win32_lparam_y(lparam);
+			uint32_t modifiers = v_multiwindow_win32_modifiers();
+			if (v_multiwindow_win32_begin_mouse_tracking(hwnd)) {
+				uint64_t enter_sequence = v_multiwindow_win32_next_event_sequence();
+				v_multiwindow_win32_window_input_event(data, enter_sequence, V_MULTIWINDOW_WIN32_INPUT_MOUSE_ENTER, 0, 0, 0, modifiers, V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, x, y, 0, 0);
+			}
+			uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+			v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_MOUSE_MOVE, 0, 0, 0, modifiers, V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, x, y, 0, 0);
+			return 0;
+		}
+		break;
+	case WM_MOUSELEAVE:
+		if (data) {
+			int x = 0;
+			int y = 0;
+			v_multiwindow_win32_end_mouse_tracking(hwnd);
+			v_multiwindow_win32_cursor_client_pos(hwnd, &x, &y);
+			uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+			v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_MOUSE_LEAVE, 0, 0, 0, v_multiwindow_win32_modifiers(), V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, x, y, 0, 0);
+			return 0;
+		}
+		break;
+	case WM_LBUTTONDOWN:
+	case WM_RBUTTONDOWN:
+	case WM_MBUTTONDOWN:
+		if (data) {
+			int button = msg == WM_LBUTTONDOWN ? V_MULTIWINDOW_WIN32_MOUSE_BUTTON_LEFT : (msg == WM_RBUTTONDOWN ? V_MULTIWINDOW_WIN32_MOUSE_BUTTON_RIGHT : V_MULTIWINDOW_WIN32_MOUSE_BUTTON_MIDDLE);
+			int x = v_multiwindow_win32_lparam_x(lparam);
+			int y = v_multiwindow_win32_lparam_y(lparam);
+			SetFocus(hwnd);
+			SetCapture(hwnd);
+			uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+			v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_MOUSE_DOWN, 0, 0, 0, v_multiwindow_win32_modifiers(), button, x, y, 0, 0);
+			return 0;
+		}
+		break;
+	case WM_LBUTTONUP:
+	case WM_RBUTTONUP:
+	case WM_MBUTTONUP:
+		if (data) {
+			int button = msg == WM_LBUTTONUP ? V_MULTIWINDOW_WIN32_MOUSE_BUTTON_LEFT : (msg == WM_RBUTTONUP ? V_MULTIWINDOW_WIN32_MOUSE_BUTTON_RIGHT : V_MULTIWINDOW_WIN32_MOUSE_BUTTON_MIDDLE);
+			int x = v_multiwindow_win32_lparam_x(lparam);
+			int y = v_multiwindow_win32_lparam_y(lparam);
+			uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+			v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_MOUSE_UP, 0, 0, 0, v_multiwindow_win32_modifiers(), button, x, y, 0, 0);
+			if ((wparam & (MK_LBUTTON | MK_RBUTTON | MK_MBUTTON)) == 0) {
+				ReleaseCapture();
+			}
+			return 0;
+		}
+		break;
+	case WM_MOUSEWHEEL:
+	case WM_MOUSEHWHEEL:
+		if (data) {
+			int x = 0;
+			int y = 0;
+			int delta = v_multiwindow_win32_wheel_delta(wparam);
+			v_multiwindow_win32_client_pos_from_lparam(hwnd, lparam, &x, &y);
+			uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+			v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_MOUSE_SCROLL, 0, 0, 0, v_multiwindow_win32_modifiers(), V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, x, y, msg == WM_MOUSEHWHEEL ? delta : 0, msg == WM_MOUSEWHEEL ? delta : 0);
+			return 0;
+		}
+		break;
+	case WM_KEYDOWN:
+		if (data) {
+			int key_code = v_multiwindow_win32_key_code(wparam, lparam);
+			if (key_code != 0) {
+				uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+				uint32_t modifiers = v_multiwindow_win32_modifiers();
+				v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_KEY_DOWN, key_code, 0, v_multiwindow_win32_key_repeat(lparam), modifiers, V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, 0, 0, 0, 0);
+				if (key_code == 86 && modifiers == 2) {
+					v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_CLIPBOARD_PASTED, 0, 0, 0, modifiers, V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, 0, 0, 0, 0);
+				}
+				return 0;
+			}
+		}
+		break;
+	case WM_SYSKEYDOWN:
+		if (data) {
+			int key_code = v_multiwindow_win32_key_code(wparam, lparam);
+			if (key_code != 0) {
+				uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+				v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_KEY_DOWN, key_code, 0, v_multiwindow_win32_key_repeat(lparam), v_multiwindow_win32_modifiers(), V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, 0, 0, 0, 0);
+			}
+		}
+		break;
+	case WM_KEYUP:
+		if (data) {
+			int key_code = v_multiwindow_win32_key_code(wparam, lparam);
+			if (key_code != 0) {
+				uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+				v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_KEY_UP, key_code, 0, 0, v_multiwindow_win32_modifiers(), V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, 0, 0, 0, 0);
+				return 0;
+			}
+		}
+		break;
+	case WM_SYSKEYUP:
+		if (data) {
+			int key_code = v_multiwindow_win32_key_code(wparam, lparam);
+			if (key_code != 0) {
+				uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+				v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_KEY_UP, key_code, 0, 0, v_multiwindow_win32_modifiers(), V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, 0, 0, 0, 0);
+			}
+		}
+		break;
+	case WM_CHAR:
+		if (data && v_multiwindow_win32_is_char_code(wparam)) {
+			uint64_t sequence = v_multiwindow_win32_next_event_sequence();
+			v_multiwindow_win32_window_input_event(data, sequence, V_MULTIWINDOW_WIN32_INPUT_CHAR, 0, (uint32_t)wparam, v_multiwindow_win32_key_repeat(lparam), v_multiwindow_win32_modifiers(), V_MULTIWINDOW_WIN32_MOUSE_BUTTON_INVALID, 0, 0, 0, 0);
+			return 0;
+		}
+		break;
+	case WM_DROPFILES:
+		if (data) {
+			v_multiwindow_win32_emit_drop_files(hwnd, data, (HDROP)wparam);
+			return 0;
+		}
+		break;
+	case WM_TOUCH:
+		if (v_multiwindow_win32_emit_touch_event(hwnd, data, wparam, lparam)) {
+			return 0;
 		}
 		break;
 	default:
@@ -171,6 +877,8 @@ static inline void *v_multiwindow_win32_create_window(const wchar_t *title, int 
 	if (hwnd) {
 		v_multiwindow_win32_set_hwnd_int_prop(hwnd, v_multiwindow_win32_min_width_prop, min_width);
 		v_multiwindow_win32_set_hwnd_int_prop(hwnd, v_multiwindow_win32_min_height_prop, min_height);
+		DragAcceptFiles(hwnd, TRUE);
+		v_multiwindow_win32_register_touch_window(hwnd);
 	}
 	if (hwnd && visible) {
 		ShowWindow(hwnd, fullscreen ? SW_MAXIMIZE : SW_SHOW);
@@ -188,6 +896,14 @@ static inline int v_multiwindow_win32_destroy_window(void *hwnd) {
 
 static inline int v_multiwindow_win32_set_window_text(void *hwnd, const wchar_t *title) {
 	return SetWindowTextW((HWND)hwnd, title) != 0;
+}
+
+static inline int v_multiwindow_win32_set_cursor_shape(void *hwnd, int shape) {
+	if (!hwnd) {
+		return 0;
+	}
+	v_multiwindow_win32_set_hwnd_int_prop((HWND)hwnd, v_multiwindow_win32_cursor_shape_prop, shape);
+	return v_multiwindow_win32_apply_cursor_shape((HWND)hwnd);
 }
 
 static inline int v_multiwindow_win32_set_client_size(void *hwnd, int width, int height, int min_width, int min_height, int resizable, int borderless, int fullscreen) {

--- a/vlib/x/multiwindow/x11_backend.c.v
+++ b/vlib/x/multiwindow/x11_backend.c.v
@@ -16,6 +16,37 @@ $if linux && x_multiwindow_x11 ? {
 const x11_client_message = 33
 const x11_configure_notify = 22
 const x11_destroy_notify = 17
+const x11_key_press = 2
+const x11_key_release = 3
+const x11_button_press = 4
+const x11_button_release = 5
+const x11_motion_notify = 6
+const x11_enter_notify = 7
+const x11_leave_notify = 8
+const x11_focus_in = 9
+const x11_focus_out = 10
+const x11_property_notify = 28
+const x11_selection_notify = 31
+const x11_success = 0
+const x11_scroll_up = 4
+const x11_scroll_down = 5
+const x11_scroll_right = 6
+const x11_scroll_left = 7
+const x11_invalid_mouse_button = 256
+const x11_property_new_value = 0
+const x11_prop_mode_replace = 0
+const x11_normal_state = 1
+const x11_iconic_state = 3
+const x11_modifier_shift = u32(1)
+const x11_modifier_ctrl = u32(2)
+const x11_modifier_alt = u32(4)
+const x11_modifier_super = u32(8)
+const x11_key_v = 86
+const x11_xdnd_version = 5
+const x11_xdnd_max_payload_bytes = 1024 * 1024
+const x11_xdnd_max_payload_units = (x11_xdnd_max_payload_bytes + 3) / 4
+const x11_xdnd_max_type_atoms = 64
+const x11_inline_char_codes = 8
 
 $if x32 {
 	type X11NativeLong = int
@@ -27,6 +58,7 @@ $if x32 {
 
 type X11NativeAtom = X11NativeULong
 type X11NativeColormap = X11NativeULong
+type X11NativeCursor = X11NativeULong
 type X11NativeWindow = X11NativeULong
 
 struct C.Display {}
@@ -83,12 +115,28 @@ $if linux && x_multiwindow_x11 ? {
 	}
 
 	@[typedef]
+	struct C.XSelectionEvent {
+	mut:
+		@type      int
+		serial     X11NativeULong
+		send_event int
+		display    &C.Display = unsafe { nil }
+		requestor  X11NativeWindow
+		selection  X11NativeAtom
+		target     X11NativeAtom
+		property   X11NativeAtom
+		time       X11NativeULong
+	}
+
+	@[typedef]
 	union C.XEvent {
 	mut:
 		@type          int
 		xclient        C.XClientMessageEvent
 		xconfigure     C.XConfigureEvent
 		xdestroywindow C.XDestroyWindowEvent
+		xselection     C.XSelectionEvent
+		pad            [24]X11NativeLong
 	}
 
 	fn C.XInitThreads() int
@@ -104,11 +152,48 @@ $if linux && x_multiwindow_x11 ? {
 	fn C.XMapWindow(display &C.Display, window X11NativeWindow) int
 	fn C.XResizeWindow(display &C.Display, window X11NativeWindow, width u32, height u32) int
 	fn C.XDestroyWindow(display &C.Display, window X11NativeWindow) int
+	fn C.XDefineCursor(display &C.Display, window X11NativeWindow, cursor X11NativeCursor) int
+	fn C.XUndefineCursor(display &C.Display, window X11NativeWindow) int
+	fn C.XFreeCursor(display &C.Display, cursor X11NativeCursor) int
 	fn C.XFreeColormap(display &C.Display, colormap X11NativeColormap) int
 	fn C.XFlush(display &C.Display) int
 	fn C.XSync(display &C.Display, discard int) int
 	fn C.XPending(display &C.Display) int
 	fn C.XNextEvent(display &C.Display, event &C.XEvent) int
+	fn C.XGetWindowProperty(display &C.Display, window X11NativeWindow, property X11NativeAtom, long_offset X11NativeLong, long_length X11NativeLong, delete int, req_type X11NativeAtom, actual_type_return &X11NativeAtom, actual_format_return &int, nitems_return &X11NativeULong, bytes_after_return &X11NativeULong, prop_return &&u8) int
+	fn C.XChangeProperty(display &C.Display, window X11NativeWindow, property X11NativeAtom, @type X11NativeAtom, format int, mode int, data &u8, nelements int) int
+	fn C.XConvertSelection(display &C.Display, selection X11NativeAtom, target X11NativeAtom, property X11NativeAtom, requestor X11NativeWindow, time X11NativeULong) int
+	fn C.XSendEvent(display &C.Display, window X11NativeWindow, propagate int, event_mask X11NativeLong, event_send &C.XEvent) int
+	fn C.XTranslateCoordinates(display &C.Display, src_w X11NativeWindow, dest_w X11NativeWindow, src_x int, src_y int, dest_x_return &int, dest_y_return &int, child_return &X11NativeWindow) int
+	fn C.XFilterEvent(event &C.XEvent, window X11NativeWindow) int
+	fn C.XFree(data voidptr) int
+	fn C.v_multiwindow_x11_event_mask() X11NativeLong
+	fn C.v_multiwindow_x11_event_window(event &C.XEvent) X11NativeWindow
+	fn C.v_multiwindow_x11_event_x(event &C.XEvent) int
+	fn C.v_multiwindow_x11_event_y(event &C.XEvent) int
+	fn C.v_multiwindow_x11_event_state(event &C.XEvent) u32
+	fn C.v_multiwindow_x11_event_keycode(event &C.XEvent) u32
+	fn C.v_multiwindow_x11_event_button(event &C.XEvent) u32
+	fn C.v_multiwindow_x11_property_atom(event &C.XEvent) X11NativeAtom
+	fn C.v_multiwindow_x11_property_state(event &C.XEvent) int
+	fn C.v_multiwindow_x11_focus_mode(event &C.XEvent) int
+	fn C.v_multiwindow_x11_is_notify_grab_or_ungrab(mode int) int
+	fn C.v_multiwindow_x11_enable_detectable_auto_repeat(display &C.Display) int
+	fn C.v_multiwindow_x11_is_auto_repeat_release(display &C.Display, event &C.XEvent) int
+	fn C.v_multiwindow_x11_modifiers(state u32) int
+	fn C.v_multiwindow_x11_key_modifier_bit(key_code int) int
+	fn C.v_multiwindow_x11_mouse_button(button u32) int
+	fn C.v_multiwindow_x11_button_modifier_bit(mouse_button int) int
+	fn C.v_multiwindow_x11_open_im(display &C.Display) voidptr
+	fn C.v_multiwindow_x11_close_im(im voidptr)
+	fn C.v_multiwindow_x11_create_ic(im voidptr, window X11NativeWindow) voidptr
+	fn C.v_multiwindow_x11_destroy_ic(ic voidptr)
+	fn C.v_multiwindow_x11_set_ic_focus(ic voidptr)
+	fn C.v_multiwindow_x11_unset_ic_focus(ic voidptr)
+	fn C.v_multiwindow_x11_init_keycodes(display &C.Display, keycodes &int, keycodes_len int)
+	fn C.v_multiwindow_x11_key_code(event &C.XEvent, keycodes &int, keycodes_len int) int
+	fn C.v_multiwindow_x11_char_codes(ic voidptr, event &C.XEvent, codes &u32, codes_len int, required_codes &int) int
+	fn C.v_multiwindow_x11_create_cursor_for_shape(display &C.Display, shape int) X11NativeCursor
 	fn C.v_multiwindow_x11_apply_config_hints(display &C.Display, window X11NativeWindow, width int, height int, min_width int, min_height int, resizable int, borderless int, fullscreen int) int
 	fn C.v_multiwindow_x11_get_window_size(display &C.Display, window X11NativeWindow, out_width &int, out_height &int) int
 	fn C.v_multiwindow_x11_egl_get_display(display &C.Display) voidptr
@@ -130,11 +215,22 @@ struct X11WindowRecord {
 	id          WindowId
 	window      X11NativeWindow
 	colormap    X11NativeColormap
+	xic         voidptr
 	egl_surface voidptr
 mut:
-	config WindowConfig
-	width  int
-	height int
+	cursor          X11NativeCursor
+	config          WindowConfig
+	cursor_shape    CursorShape
+	width           int
+	height          int
+	mouse_x         f32
+	mouse_y         f32
+	mouse_dx        f32
+	mouse_dy        f32
+	mouse_pos_valid bool
+	mouse_buttons   u8
+	key_repeat      [256]bool
+	window_state    int
 }
 
 struct X11Backend {
@@ -144,12 +240,30 @@ mut:
 	root             X11NativeWindow
 	wm_protocols     X11NativeAtom
 	wm_delete_window X11NativeAtom
+	wm_state         X11NativeAtom
+	xdnd_aware       X11NativeAtom
+	xdnd_enter       X11NativeAtom
+	xdnd_position    X11NativeAtom
+	xdnd_status      X11NativeAtom
+	xdnd_action_copy X11NativeAtom
+	xdnd_drop        X11NativeAtom
+	xdnd_leave       X11NativeAtom
+	xdnd_finished    X11NativeAtom
+	xdnd_selection   X11NativeAtom
+	xdnd_type_list   X11NativeAtom
+	text_uri_list    X11NativeAtom
+	xdnd_source      X11NativeWindow
+	xdnd_target      X11NativeWindow
+	xdnd_format      X11NativeAtom
+	xdnd_version     X11NativeLong
+	xim              voidptr
 	egl_display      voidptr
 	egl_config       voidptr
 	egl_context      voidptr
 	native_visual_id int
 	started          bool
 	windows          []X11WindowRecord
+	keycodes         [256]int
 }
 
 fn new_x11_backend() X11Backend {
@@ -174,6 +288,15 @@ fn (backend &X11Backend) capabilities() Capabilities {
 		explicit_swapchain: backend.renderer_ready()
 		x11:                true
 		gl:                 backend.renderer_ready()
+		input_events:       true
+		mouse_events:       true
+		keyboard_events:    true
+		text_events:        true
+		focus_events:       true
+		drop_events:        true
+		touch_events:       false
+		cursor_shapes:      true
+		native_decorations: true
 	}
 }
 
@@ -192,8 +315,27 @@ fn (mut backend X11Backend) start(require_renderer bool) ! {
 		backend.root = C.XDefaultRootWindow(display)
 		backend.wm_protocols = C.XInternAtom(display, c'WM_PROTOCOLS', 0)
 		backend.wm_delete_window = C.XInternAtom(display, c'WM_DELETE_WINDOW', 0)
+		backend.wm_state = C.XInternAtom(display, c'WM_STATE', 0)
+		backend.xdnd_aware = C.XInternAtom(display, c'XdndAware', 0)
+		backend.xdnd_enter = C.XInternAtom(display, c'XdndEnter', 0)
+		backend.xdnd_position = C.XInternAtom(display, c'XdndPosition', 0)
+		backend.xdnd_status = C.XInternAtom(display, c'XdndStatus', 0)
+		backend.xdnd_action_copy = C.XInternAtom(display, c'XdndActionCopy', 0)
+		backend.xdnd_drop = C.XInternAtom(display, c'XdndDrop', 0)
+		backend.xdnd_leave = C.XInternAtom(display, c'XdndLeave', 0)
+		backend.xdnd_finished = C.XInternAtom(display, c'XdndFinished', 0)
+		backend.xdnd_selection = C.XInternAtom(display, c'XdndSelection', 0)
+		backend.xdnd_type_list = C.XInternAtom(display, c'XdndTypeList', 0)
+		backend.text_uri_list = C.XInternAtom(display, c'text/uri-list', 0)
+		backend.xim = C.v_multiwindow_x11_open_im(display)
+		C.v_multiwindow_x11_init_keycodes(display, &backend.keycodes[0], 256)
+		C.v_multiwindow_x11_enable_detectable_auto_repeat(display)
 		if require_renderer {
 			backend.init_renderer() or {
+				if backend.xim != unsafe { nil } {
+					C.v_multiwindow_x11_close_im(backend.xim)
+					backend.xim = unsafe { nil }
+				}
 				C.XCloseDisplay(display)
 				backend.display = unsafe { nil }
 				return err
@@ -222,7 +364,7 @@ fn (mut backend X11Backend) create_window(id WindowId, config WindowConfig) !Win
 			created := C.XCreateSimpleWindow(backend.display, backend.root, 0, 0,
 				u32(actual_size.width), u32(actual_size.height), 0, 0, 0)
 			if created != X11NativeWindow(0) {
-				C.XSelectInput(backend.display, created, 1 << 17)
+				C.XSelectInput(backend.display, created, C.v_multiwindow_x11_event_mask())
 			}
 			created
 		}
@@ -272,6 +414,8 @@ fn (mut backend X11Backend) create_window(id WindowId, config WindowConfig) !Win
 			}, true) or {}
 			return error(err_x11_create_window_failed)
 		}
+		backend.announce_xdnd_for_window(window)
+		xic := C.v_multiwindow_x11_create_ic(backend.xim, window)
 		if config.visible {
 			C.XMapWindow(backend.display, window)
 		}
@@ -280,6 +424,7 @@ fn (mut backend X11Backend) create_window(id WindowId, config WindowConfig) !Win
 				id:          id
 				window:      window
 				colormap:    colormap
+				xic:         xic
 				egl_surface: egl_surface
 				config:      window_config_with_size(config, actual_size.width, actual_size.height)
 				width:       actual_size.width
@@ -295,6 +440,7 @@ fn (mut backend X11Backend) create_window(id WindowId, config WindowConfig) !Win
 				id:          id
 				window:      window
 				colormap:    colormap
+				xic:         xic
 				egl_surface: egl_surface
 				config:      window_config_with_size(config, actual_size.width, actual_size.height)
 				width:       actual_size.width
@@ -307,13 +453,15 @@ fn (mut backend X11Backend) create_window(id WindowId, config WindowConfig) !Win
 			height: actual_height
 		}
 		backend.windows << X11WindowRecord{
-			id:          id
-			window:      window
-			colormap:    colormap
-			egl_surface: egl_surface
-			config:      window_config_with_size(config, actual_size.width, actual_size.height)
-			width:       actual_size.width
-			height:      actual_size.height
+			id:           id
+			window:       window
+			colormap:     colormap
+			xic:          xic
+			egl_surface:  egl_surface
+			config:       window_config_with_size(config, actual_size.width, actual_size.height)
+			width:        actual_size.width
+			height:       actual_size.height
+			window_state: backend.window_state(window)
 		}
 		return actual_size
 	} $else {
@@ -397,8 +545,54 @@ fn (mut backend X11Backend) resize_window(id WindowId, width int, height int) !W
 	}
 }
 
+fn (mut backend X11Backend) set_window_cursor(id WindowId, shape CursorShape) ! {
+	$if linux && x_multiwindow_x11 ? {
+		index := backend.window_record_index(id) or { return error(err_window_not_found) }
+		if !backend.started || backend.display == unsafe { nil } {
+			return error(err_x11_open_display_failed)
+		}
+		if backend.windows[index].cursor_shape == shape {
+			return
+		}
+		window := backend.windows[index].window
+		if shape == .default {
+			C.XUndefineCursor(backend.display, window)
+			backend.free_cursor_for_record(index)
+		} else {
+			cursor := C.v_multiwindow_x11_create_cursor_for_shape(backend.display, int(shape))
+			if cursor == X11NativeCursor(0) {
+				return error(err_capability_unsupported)
+			}
+			if C.XDefineCursor(backend.display, window, cursor) == 0 {
+				C.XFreeCursor(backend.display, cursor)
+				return error(err_capability_unsupported)
+			}
+			backend.free_cursor_for_record(index)
+			backend.windows[index].cursor = cursor
+		}
+		backend.windows[index].cursor_shape = shape
+		C.XFlush(backend.display)
+		return
+	} $else {
+		_ = id
+		_ = shape
+		return error(err_backend_unsupported)
+	}
+}
+
 fn (mut backend X11Backend) poll_events() ![]Event {
-	mut events := []Event{}
+	queued_events := backend.poll_queued_events()!
+	mut events := []Event{cap: queued_events.len}
+	for event in queued_events {
+		if event.kind == .lifecycle {
+			events << event.lifecycle
+		}
+	}
+	return events
+}
+
+fn (mut backend X11Backend) poll_queued_events() ![]QueuedEvent {
+	mut events := []QueuedEvent{}
 	$if linux && x_multiwindow_x11 ? {
 		if !backend.started || backend.display == unsafe { nil } {
 			return events
@@ -406,6 +600,9 @@ fn (mut backend X11Backend) poll_events() ![]Event {
 		for C.XPending(backend.display) > 0 {
 			mut event := C.XEvent{}
 			C.XNextEvent(backend.display, &event)
+			if C.XFilterEvent(&event, X11NativeWindow(0)) != 0 {
+				continue
+			}
 			event_type := unsafe { event.@type }
 			match event_type {
 				x11_client_message {
@@ -416,10 +613,12 @@ fn (mut backend X11Backend) poll_events() ![]Event {
 						&& protocol == backend.wm_delete_window {
 						native_window := unsafe { event.xclient.window }
 						id := backend.window_id_for_native(native_window) or { continue }
-						events << Event{
+						events << queued_lifecycle_event(Event{
 							kind:      .window_close_requested
 							window_id: id
-						}
+						})
+					} else if format == 32 {
+						events << backend.queued_xdnd_client_message_events(&event)
 					}
 				}
 				x11_configure_notify {
@@ -432,27 +631,582 @@ fn (mut backend X11Backend) poll_events() ![]Event {
 						id := backend.windows[index].id
 						backend.windows[index].width = width
 						backend.windows[index].height = height
-						events << Event{
+						record := backend.windows[index]
+						events << queued_lifecycle_event(Event{
 							kind:      .window_resized
 							window_id: id
 							width:     width
 							height:    height
-						}
+						})
+						events << queued_input_event(backend.input_event_from_record(record,
+							.resized))
 					}
 				}
 				x11_destroy_notify {
 					native_window := unsafe { event.xdestroywindow.window }
 					id := backend.remove_native_window(native_window) or { continue }
-					events << Event{
+					events << queued_lifecycle_event(Event{
 						kind:      .window_destroyed
 						window_id: id
+					})
+				}
+				x11_key_press {
+					index := backend.window_record_index_for_event(&event) or { continue }
+					events << backend.queued_key_press_event(index, &event)
+				}
+				x11_key_release {
+					if C.v_multiwindow_x11_is_auto_repeat_release(backend.display, &event) != 0 {
+						continue
 					}
+					index := backend.window_record_index_for_event(&event) or { continue }
+					events << backend.queued_key_release_event(index, &event)
+				}
+				x11_button_press {
+					index := backend.window_record_index_for_event(&event) or { continue }
+					events << backend.queued_button_press_event(index, &event)
+				}
+				x11_button_release {
+					index := backend.window_record_index_for_event(&event) or { continue }
+					events << backend.queued_button_release_event(index, &event)
+				}
+				x11_motion_notify {
+					index := backend.window_record_index_for_event(&event) or { continue }
+					events << backend.queued_mouse_position_event(index, &event, .mouse_move, false)
+				}
+				x11_enter_notify {
+					index := backend.window_record_index_for_event(&event) or { continue }
+					if backend.windows[index].mouse_buttons == 0 {
+						events << backend.queued_mouse_position_event(index, &event, .mouse_enter, true)
+					}
+				}
+				x11_leave_notify {
+					index := backend.window_record_index_for_event(&event) or { continue }
+					if backend.windows[index].mouse_buttons == 0 {
+						events << backend.queued_mouse_position_event(index, &event, .mouse_leave, true)
+					}
+				}
+				x11_focus_in {
+					if C.v_multiwindow_x11_is_notify_grab_or_ungrab(C.v_multiwindow_x11_focus_mode(&event)) != 0 {
+						continue
+					}
+					index := backend.window_record_index_for_event(&event) or { continue }
+					C.v_multiwindow_x11_set_ic_focus(backend.windows[index].xic)
+					events << queued_input_event(backend.input_event_from_record(backend.windows[index],
+						.focused))
+				}
+				x11_focus_out {
+					if C.v_multiwindow_x11_is_notify_grab_or_ungrab(C.v_multiwindow_x11_focus_mode(&event)) != 0 {
+						continue
+					}
+					index := backend.window_record_index_for_event(&event) or { continue }
+					C.v_multiwindow_x11_unset_ic_focus(backend.windows[index].xic)
+					backend.clear_input_state(index)
+					events << queued_input_event(backend.input_event_from_record(backend.windows[index],
+						.unfocused))
+				}
+				x11_property_notify {
+					if C.v_multiwindow_x11_property_state(&event) != x11_property_new_value
+						|| C.v_multiwindow_x11_property_atom(&event) != backend.wm_state {
+						continue
+					}
+					index := backend.window_record_index_for_event(&event) or { continue }
+					state := backend.window_state(backend.windows[index].window)
+					if state == backend.windows[index].window_state {
+						continue
+					}
+					backend.windows[index].window_state = state
+					if state == x11_iconic_state {
+						events << queued_input_event(backend.input_event_from_record(backend.windows[index],
+							.iconified))
+					} else if state == x11_normal_state {
+						events << queued_input_event(backend.input_event_from_record(backend.windows[index],
+							.restored))
+					}
+				}
+				x11_selection_notify {
+					events << backend.queued_xdnd_selection_events(&event)
 				}
 				else {}
 			}
 		}
 	}
 	return events
+}
+
+fn (backend &X11Backend) input_event_from_record(record X11WindowRecord, kind InputEventKind) InputEvent {
+	return backend.input_event_with_payload(record, kind, 0, false, 0, x11_invalid_mouse_button, 0,
+		0)
+}
+
+fn (backend &X11Backend) input_event_with_payload(record X11WindowRecord, kind InputEventKind, key_code int, key_repeat bool, modifiers u32, mouse_button int, scroll_x f32, scroll_y f32) InputEvent {
+	return InputEvent{
+		kind:               kind
+		window_id:          record.id
+		key_code:           key_code
+		key_repeat:         key_repeat
+		modifiers:          modifiers
+		mouse_x:            record.mouse_x
+		mouse_y:            record.mouse_y
+		mouse_dx:           record.mouse_dx
+		mouse_dy:           record.mouse_dy
+		mouse_button:       mouse_button
+		scroll_x:           scroll_x
+		scroll_y:           scroll_y
+		window_width:       record.width
+		window_height:      record.height
+		framebuffer_width:  record.width
+		framebuffer_height: record.height
+	}
+}
+
+fn (backend &X11Backend) input_char_event(record X11WindowRecord, char_code u32, key_repeat bool, modifiers u32) InputEvent {
+	return InputEvent{
+		kind:               .char
+		window_id:          record.id
+		char_code:          char_code
+		key_repeat:         key_repeat
+		modifiers:          modifiers
+		window_width:       record.width
+		window_height:      record.height
+		framebuffer_width:  record.width
+		framebuffer_height: record.height
+	}
+}
+
+fn (backend &X11Backend) input_files_dropped_event(record X11WindowRecord, files []string) InputEvent {
+	return InputEvent{
+		kind:               .files_dropped
+		window_id:          record.id
+		mouse_x:            record.mouse_x
+		mouse_y:            record.mouse_y
+		mouse_dx:           record.mouse_dx
+		mouse_dy:           record.mouse_dy
+		window_width:       record.width
+		window_height:      record.height
+		framebuffer_width:  record.width
+		framebuffer_height: record.height
+		mouse_button:       x11_invalid_mouse_button
+		dropped_files:      files.clone()
+	}
+}
+
+$if linux && x_multiwindow_x11 ? {
+	fn (mut backend X11Backend) clear_input_state(index int) {
+		backend.windows[index].mouse_buttons = 0
+		for i in 0 .. 256 {
+			backend.windows[index].key_repeat[i] = false
+		}
+	}
+
+	fn (mut backend X11Backend) queued_key_press_event(index int, event &C.XEvent) []QueuedEvent {
+		mut events := []QueuedEvent{}
+		key_code := C.v_multiwindow_x11_key_code(event, &backend.keycodes[0], 256)
+		native_keycode := int(C.v_multiwindow_x11_event_keycode(event))
+		mut repeat := false
+		if native_keycode >= 0 && native_keycode < 256 {
+			repeat = backend.windows[index].key_repeat[native_keycode]
+			backend.windows[index].key_repeat[native_keycode] = true
+		}
+		mut modifiers := u32(C.v_multiwindow_x11_modifiers(C.v_multiwindow_x11_event_state(event)))
+		if key_code != 0 {
+			modifiers |= u32(C.v_multiwindow_x11_key_modifier_bit(key_code))
+			input := backend.input_event_with_payload(backend.windows[index], .key_down, key_code,
+				repeat, modifiers, x11_invalid_mouse_button, 0, 0)
+			events << queued_input_event(input)
+			if x11_is_clipboard_paste(key_code, modifiers) {
+				events << queued_input_event(backend.input_event_with_payload(backend.windows[index],
+					.clipboard_pasted, 0, false, modifiers, x11_invalid_mouse_button, 0, 0))
+			}
+		}
+		backend.append_key_press_char_events(mut events, backend.windows[index], event, repeat,
+			modifiers)
+		return events
+	}
+
+	fn (backend &X11Backend) append_key_press_char_events(mut events []QueuedEvent, record X11WindowRecord, event &C.XEvent, repeat bool, modifiers u32) {
+		mut inline_char_codes := [x11_inline_char_codes]u32{}
+		mut required_char_codes := 0
+		mut char_count := C.v_multiwindow_x11_char_codes(record.xic, event,
+			unsafe { &inline_char_codes[0] }, x11_inline_char_codes, &required_char_codes)
+		if required_char_codes > x11_inline_char_codes {
+			mut char_codes := []u32{len: required_char_codes}
+			char_count = C.v_multiwindow_x11_char_codes(record.xic, event,
+				unsafe { &char_codes[0] }, required_char_codes, &required_char_codes)
+			for i in 0 .. char_count {
+				events << queued_input_event(backend.input_char_event(record, char_codes[i],
+					repeat, modifiers))
+			}
+			return
+		}
+		for i in 0 .. char_count {
+			events << queued_input_event(backend.input_char_event(record, inline_char_codes[i],
+				repeat, modifiers))
+		}
+	}
+
+	fn (mut backend X11Backend) queued_key_release_event(index int, event &C.XEvent) []QueuedEvent {
+		mut events := []QueuedEvent{}
+		key_code := C.v_multiwindow_x11_key_code(event, &backend.keycodes[0], 256)
+		if key_code == 0 {
+			return events
+		}
+		native_keycode := int(C.v_multiwindow_x11_event_keycode(event))
+		if native_keycode >= 0 && native_keycode < 256 {
+			backend.windows[index].key_repeat[native_keycode] = false
+		}
+		mut modifiers := C.v_multiwindow_x11_modifiers(C.v_multiwindow_x11_event_state(event))
+		modifiers &= ~C.v_multiwindow_x11_key_modifier_bit(key_code)
+		input := backend.input_event_with_payload(backend.windows[index], .key_up, key_code, false,
+			u32(modifiers), x11_invalid_mouse_button, 0, 0)
+		events << queued_input_event(input)
+		return events
+	}
+
+	fn (mut backend X11Backend) queued_button_press_event(index int, event &C.XEvent) []QueuedEvent {
+		mut events := []QueuedEvent{}
+		x := C.v_multiwindow_x11_event_x(event)
+		y := C.v_multiwindow_x11_event_y(event)
+		backend.update_mouse_position(index, x, y, false)
+		button := C.v_multiwindow_x11_event_button(event)
+		mut modifiers := C.v_multiwindow_x11_modifiers(C.v_multiwindow_x11_event_state(event))
+		match button {
+			x11_scroll_up {
+				events << queued_input_event(backend.scroll_event(index, 0.0, 1.0, u32(modifiers)))
+			}
+			x11_scroll_down {
+				events << queued_input_event(backend.scroll_event(index, 0.0, -1.0, u32(modifiers)))
+			}
+			x11_scroll_right {
+				events << queued_input_event(backend.scroll_event(index, 1.0, 0.0, u32(modifiers)))
+			}
+			x11_scroll_left {
+				events << queued_input_event(backend.scroll_event(index, -1.0, 0.0, u32(modifiers)))
+			}
+			else {
+				mouse_button := C.v_multiwindow_x11_mouse_button(button)
+				if mouse_button != x11_invalid_mouse_button {
+					modifiers |= C.v_multiwindow_x11_button_modifier_bit(mouse_button)
+					backend.windows[index].mouse_buttons |= u8(1 << mouse_button)
+					input := backend.input_event_with_payload(backend.windows[index], .mouse_down,
+						0, false, u32(modifiers), mouse_button, 0, 0)
+					events << queued_input_event(input)
+				}
+			}
+		}
+
+		return events
+	}
+
+	fn (mut backend X11Backend) queued_button_release_event(index int, event &C.XEvent) []QueuedEvent {
+		mut events := []QueuedEvent{}
+		x := C.v_multiwindow_x11_event_x(event)
+		y := C.v_multiwindow_x11_event_y(event)
+		backend.update_mouse_position(index, x, y, false)
+		mouse_button := C.v_multiwindow_x11_mouse_button(C.v_multiwindow_x11_event_button(event))
+		if mouse_button == x11_invalid_mouse_button {
+			return events
+		}
+		mut modifiers := C.v_multiwindow_x11_modifiers(C.v_multiwindow_x11_event_state(event))
+		modifiers &= ~C.v_multiwindow_x11_button_modifier_bit(mouse_button)
+		backend.windows[index].mouse_buttons &= ~u8(1 << mouse_button)
+		input := backend.input_event_with_payload(backend.windows[index], .mouse_up, 0, false,
+			u32(modifiers), mouse_button, 0, 0)
+		events << queued_input_event(input)
+		return events
+	}
+
+	fn (mut backend X11Backend) queued_mouse_position_event(index int, event &C.XEvent, kind InputEventKind, clear_delta bool) QueuedEvent {
+		x := C.v_multiwindow_x11_event_x(event)
+		y := C.v_multiwindow_x11_event_y(event)
+		backend.update_mouse_position(index, x, y, clear_delta)
+		input := backend.input_event_with_payload(backend.windows[index], kind, 0, false,
+			u32(C.v_multiwindow_x11_modifiers(C.v_multiwindow_x11_event_state(event))),
+			x11_invalid_mouse_button, 0, 0)
+		return queued_input_event(input)
+	}
+
+	fn (mut backend X11Backend) update_mouse_position(index int, x int, y int, clear_delta bool) {
+		new_x := f32(x)
+		new_y := f32(y)
+		if clear_delta || !backend.windows[index].mouse_pos_valid {
+			backend.windows[index].mouse_x = new_x
+			backend.windows[index].mouse_y = new_y
+			backend.windows[index].mouse_dx = 0
+			backend.windows[index].mouse_dy = 0
+			backend.windows[index].mouse_pos_valid = true
+			return
+		}
+		backend.windows[index].mouse_dx = new_x - backend.windows[index].mouse_x
+		backend.windows[index].mouse_dy = new_y - backend.windows[index].mouse_y
+		backend.windows[index].mouse_x = new_x
+		backend.windows[index].mouse_y = new_y
+	}
+
+	fn (backend &X11Backend) scroll_event(index int, x f32, y f32, modifiers u32) InputEvent {
+		return backend.input_event_with_payload(backend.windows[index], .mouse_scroll, 0, false,
+			modifiers, x11_invalid_mouse_button, x, y)
+	}
+
+	fn (backend &X11Backend) window_record_index_for_event(event &C.XEvent) ?int {
+		return backend.window_record_index_for_native(C.v_multiwindow_x11_event_window(event))
+	}
+
+	fn (backend &X11Backend) window_state(window X11NativeWindow) int {
+		mut result := x11_normal_state
+		mut actual_type := X11NativeAtom(0)
+		mut actual_format := 0
+		mut item_count := X11NativeULong(0)
+		mut bytes_after := X11NativeULong(0)
+		mut state := &X11NativeLong(unsafe { nil })
+		status := C.XGetWindowProperty(backend.display, window, backend.wm_state, X11NativeLong(0),
+			X11NativeLong(0x7fffffff), 0, backend.wm_state, &actual_type, &actual_format,
+			&item_count, &bytes_after, unsafe { &&u8(&state) })
+		if status == x11_success && actual_type == backend.wm_state && actual_format == 32
+			&& item_count >= X11NativeULong(2) && state != unsafe { nil } {
+			state_value := unsafe { state[0] }
+			result = int(state_value)
+		}
+		if state != unsafe { nil } {
+			C.XFree(unsafe { voidptr(state) })
+		}
+		return result
+	}
+
+	fn (mut backend X11Backend) announce_xdnd_for_window(window X11NativeWindow) {
+		if backend.xdnd_aware == X11NativeAtom(0) {
+			return
+		}
+		version := X11NativeAtom(x11_xdnd_version)
+		C.XChangeProperty(backend.display, window, backend.xdnd_aware, X11NativeAtom(4), 32,
+			x11_prop_mode_replace, unsafe { &u8(&version) }, 1)
+	}
+
+	fn (mut backend X11Backend) queued_xdnd_client_message_events(event &C.XEvent) []QueuedEvent {
+		message_type := unsafe { event.xclient.message_type }
+		if message_type == backend.xdnd_enter {
+			backend.handle_xdnd_enter(event)
+		} else if message_type == backend.xdnd_position {
+			backend.handle_xdnd_position(event)
+		} else if message_type == backend.xdnd_drop {
+			backend.handle_xdnd_drop(event)
+		} else if message_type == backend.xdnd_leave {
+			backend.clear_xdnd_state()
+		}
+		return []QueuedEvent{}
+	}
+
+	fn (mut backend X11Backend) handle_xdnd_enter(event &C.XEvent) {
+		backend.xdnd_source = unsafe { X11NativeWindow(event.xclient.data.l[0]) }
+		backend.xdnd_target = unsafe { event.xclient.window }
+		backend.xdnd_version = unsafe { event.xclient.data.l[1] >> 24 }
+		backend.xdnd_format = X11NativeAtom(0)
+		if backend.xdnd_version > x11_xdnd_version {
+			return
+		}
+		is_list := (unsafe { event.xclient.data.l[1] } & X11NativeLong(1)) != 0
+		if is_list {
+			backend.xdnd_format = backend.xdnd_format_from_type_list()
+			return
+		}
+		for i in 2 .. 5 {
+			format := unsafe { X11NativeAtom(event.xclient.data.l[i]) }
+			if format == backend.text_uri_list {
+				backend.xdnd_format = backend.text_uri_list
+				return
+			}
+		}
+	}
+
+	fn (mut backend X11Backend) handle_xdnd_position(event &C.XEvent) {
+		if backend.xdnd_version > x11_xdnd_version || backend.xdnd_source == X11NativeWindow(0) {
+			return
+		}
+		backend.xdnd_target = unsafe { event.xclient.window }
+		backend.update_xdnd_mouse_position(event)
+		backend.send_xdnd_status(backend.xdnd_format != X11NativeAtom(0))
+	}
+
+	fn (mut backend X11Backend) handle_xdnd_drop(event &C.XEvent) {
+		if backend.xdnd_version > x11_xdnd_version {
+			return
+		}
+		backend.xdnd_target = unsafe { event.xclient.window }
+		if backend.xdnd_source == X11NativeWindow(0) || backend.xdnd_format == X11NativeAtom(0) {
+			backend.send_xdnd_finished(backend.xdnd_target, false)
+			backend.clear_xdnd_state()
+			return
+		}
+		time := if backend.xdnd_version >= 1 {
+			unsafe { X11NativeULong(event.xclient.data.l[2]) }
+		} else {
+			X11NativeULong(0)
+		}
+		C.XConvertSelection(backend.display, backend.xdnd_selection, backend.xdnd_format,
+			backend.xdnd_selection, backend.xdnd_target, time)
+	}
+
+	fn (mut backend X11Backend) update_xdnd_mouse_position(event &C.XEvent) {
+		index := backend.window_record_index_for_native(backend.xdnd_target) or { return }
+		root_x, root_y := x11_xdnd_position_coords(unsafe { event.xclient.data.l[2] })
+		mut window_x := root_x
+		mut window_y := root_y
+		mut child := X11NativeWindow(0)
+		if backend.root != X11NativeWindow(0)
+			&& C.XTranslateCoordinates(backend.display, backend.root, backend.xdnd_target, root_x, root_y, &window_x, &window_y, &child) != 0 {
+			backend.update_mouse_position(index, window_x, window_y, false)
+			return
+		}
+		backend.update_mouse_position(index, root_x, root_y, false)
+	}
+
+	fn (mut backend X11Backend) queued_xdnd_selection_events(event &C.XEvent) []QueuedEvent {
+		mut events := []QueuedEvent{}
+		if unsafe { event.xselection.selection } != backend.xdnd_selection {
+			return events
+		}
+		requestor := unsafe { event.xselection.requestor }
+		property := unsafe { event.xselection.property }
+		if property == X11NativeAtom(0) {
+			backend.send_xdnd_finished(requestor, false)
+			backend.clear_xdnd_state()
+			return events
+		}
+		index := backend.window_record_index_for_native(requestor) or {
+			backend.send_xdnd_finished(requestor, false)
+			backend.clear_xdnd_state()
+			return events
+		}
+		mut actual_type := X11NativeAtom(0)
+		mut actual_format := 0
+		mut item_count := X11NativeULong(0)
+		mut bytes_after := X11NativeULong(0)
+		mut data := &u8(unsafe { nil })
+		status := C.XGetWindowProperty(backend.display, requestor, property, X11NativeLong(0),
+			X11NativeLong(x11_xdnd_max_payload_units), 1, backend.text_uri_list, &actual_type,
+			&actual_format, &item_count, &bytes_after, &&u8(&data))
+		valid_payload := status == x11_success && actual_type == backend.text_uri_list
+			&& actual_format == 8 && bytes_after == X11NativeULong(0)
+			&& item_count <= X11NativeULong(x11_xdnd_max_payload_bytes)
+		if !valid_payload {
+			if data != unsafe { nil } {
+				C.XFree(data)
+			}
+			backend.send_xdnd_finished(requestor, false)
+			backend.clear_xdnd_state()
+			return events
+		}
+		payload := if data != unsafe { nil } && item_count > X11NativeULong(0) {
+			unsafe { tos(data, int(item_count)).clone() }
+		} else {
+			''
+		}
+		if data != unsafe { nil } {
+			C.XFree(data)
+		}
+		files := dropped_files_from_uri_list(payload)
+		if files.len > 0 {
+			events << queued_input_event(backend.input_files_dropped_event(backend.windows[index],
+				files))
+		}
+		backend.send_xdnd_finished(requestor, files.len > 0)
+		backend.clear_xdnd_state()
+		return events
+	}
+
+	fn (mut backend X11Backend) xdnd_format_from_type_list() X11NativeAtom {
+		if backend.xdnd_source == X11NativeWindow(0) {
+			return X11NativeAtom(0)
+		}
+		mut actual_type := X11NativeAtom(0)
+		mut actual_format := 0
+		mut item_count := X11NativeULong(0)
+		mut bytes_after := X11NativeULong(0)
+		mut formats := &X11NativeAtom(unsafe { nil })
+		status := C.XGetWindowProperty(backend.display, backend.xdnd_source,
+			backend.xdnd_type_list, X11NativeLong(0), X11NativeLong(x11_xdnd_max_type_atoms), 0,
+			X11NativeAtom(4), &actual_type, &actual_format, &item_count, &bytes_after,
+			unsafe { &&u8(&formats) })
+		valid_type_list := status == x11_success && actual_type == X11NativeAtom(4)
+			&& actual_format == 32 && bytes_after == X11NativeULong(0) && formats != unsafe { nil }
+			&& item_count <= X11NativeULong(x11_xdnd_max_type_atoms)
+		if !valid_type_list {
+			if formats != unsafe { nil } {
+				C.XFree(formats)
+			}
+			return X11NativeAtom(0)
+		}
+		mut result := X11NativeAtom(0)
+		for i in 0 .. int(item_count) {
+			if unsafe { formats[i] } == backend.text_uri_list {
+				result = backend.text_uri_list
+				break
+			}
+		}
+		C.XFree(formats)
+		return result
+	}
+
+	fn (backend &X11Backend) send_xdnd_status(accepted bool) {
+		if backend.xdnd_source == X11NativeWindow(0) {
+			return
+		}
+		mut reply := C.XEvent{}
+		reply.@type = x11_client_message
+		unsafe {
+			reply.xclient.window = backend.xdnd_source
+			reply.xclient.message_type = backend.xdnd_status
+			reply.xclient.format = 32
+			reply.xclient.data.l[0] = X11NativeLong(backend.xdnd_target)
+			if accepted {
+				reply.xclient.data.l[1] = X11NativeLong(1)
+				if backend.xdnd_version >= 2 {
+					reply.xclient.data.l[4] = X11NativeLong(backend.xdnd_action_copy)
+				}
+			}
+		}
+		C.XSendEvent(backend.display, backend.xdnd_source, 0, X11NativeLong(0), &reply)
+		C.XFlush(backend.display)
+	}
+
+	fn (backend &X11Backend) send_xdnd_finished(requestor X11NativeWindow, accepted bool) {
+		if backend.xdnd_source == X11NativeWindow(0) || backend.xdnd_version < 2 {
+			return
+		}
+		mut reply := C.XEvent{}
+		reply.@type = x11_client_message
+		unsafe {
+			reply.xclient.window = backend.xdnd_source
+			reply.xclient.message_type = backend.xdnd_finished
+			reply.xclient.format = 32
+			reply.xclient.data.l[0] = X11NativeLong(requestor)
+			if accepted {
+				reply.xclient.data.l[1] = X11NativeLong(1)
+				reply.xclient.data.l[2] = X11NativeLong(backend.xdnd_action_copy)
+			}
+		}
+		C.XSendEvent(backend.display, backend.xdnd_source, 0, X11NativeLong(0), &reply)
+		C.XFlush(backend.display)
+	}
+
+	fn (mut backend X11Backend) clear_xdnd_state() {
+		backend.xdnd_source = X11NativeWindow(0)
+		backend.xdnd_target = X11NativeWindow(0)
+		backend.xdnd_format = X11NativeAtom(0)
+		backend.xdnd_version = X11NativeLong(0)
+	}
+}
+
+fn x11_xdnd_position_coords(value X11NativeLong) (int, int) {
+	packed := u32(value)
+	return x11_signed_16(packed >> 16), x11_signed_16(packed)
+}
+
+fn x11_signed_16(value u32) int {
+	mut result := int(value & u32(0xffff))
+	if result >= 0x8000 {
+		result -= 0x10000
+	}
+	return result
 }
 
 fn (mut backend X11Backend) stop() ! {
@@ -465,6 +1219,10 @@ fn (mut backend X11Backend) stop() ! {
 			backend.destroy_window(record.id)!
 		}
 		backend.shutdown_renderer()
+		if backend.xim != unsafe { nil } {
+			C.v_multiwindow_x11_close_im(backend.xim)
+			backend.xim = unsafe { nil }
+		}
 		if backend.display != unsafe { nil } {
 			if C.XCloseDisplay(backend.display) != 0 {
 				return error(err_x11_close_display_failed)
@@ -657,11 +1415,33 @@ $if gg_multiwindow ? || x_multiwindow_render ? {
 	}
 }
 
+fn (mut backend X11Backend) free_cursor_for_record(index int) {
+	$if linux && x_multiwindow_x11 ? {
+		if index < 0 || index >= backend.windows.len {
+			return
+		}
+		cursor := backend.windows[index].cursor
+		if backend.display != unsafe { nil } && cursor != X11NativeCursor(0) {
+			C.XFreeCursor(backend.display, cursor)
+		}
+		backend.windows[index].cursor = X11NativeCursor(0)
+		return
+	} $else {
+		_ = index
+	}
+}
+
 fn (mut backend X11Backend) release_window_resources(record X11WindowRecord, destroy_native bool) ! {
 	$if linux && x_multiwindow_x11 ? {
 		if backend.egl_display != unsafe { nil } && record.egl_surface != unsafe { nil } {
 			C.v_multiwindow_x11_egl_clear_current(backend.egl_display)
 			C.v_multiwindow_x11_egl_destroy_surface(backend.egl_display, record.egl_surface)
+		}
+		if backend.display != unsafe { nil } && record.cursor != X11NativeCursor(0) {
+			C.XFreeCursor(backend.display, record.cursor)
+		}
+		if record.xic != unsafe { nil } {
+			C.v_multiwindow_x11_destroy_ic(record.xic)
 		}
 		if destroy_native {
 			backend.destroy_native_window(record.window, record.colormap)!
@@ -698,4 +1478,8 @@ fn (mut backend X11Backend) destroy_native_window(window X11NativeWindow, colorm
 
 fn x11_bool_to_int(value bool) int {
 	return if value { 1 } else { 0 }
+}
+
+fn x11_is_clipboard_paste(key_code int, modifiers u32) bool {
+	return key_code == x11_key_v && modifiers == x11_modifier_ctrl
 }

--- a/vlib/x/multiwindow/x11_egl_backend_helpers.h
+++ b/vlib/x/multiwindow/x11_egl_backend_helpers.h
@@ -2,9 +2,14 @@
 #define V_MULTIWINDOW_X11_EGL_BACKEND_HELPERS_H
 
 #include <stdint.h>
+#include <locale.h>
+#include <stdlib.h>
 #include <string.h>
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
+#include <X11/cursorfont.h>
+#include <X11/keysym.h>
+#include <X11/XKBlib.h>
 #include <X11/Xutil.h>
 #include <EGL/egl.h>
 
@@ -25,6 +30,31 @@
 #define MWM_HINTS_DECORATIONS (1L << 1)
 #endif
 
+#ifndef V_MULTIWINDOW_X11_XIM_STACK_BYTES
+#define V_MULTIWINDOW_X11_XIM_STACK_BYTES 128
+#endif
+#ifndef V_MULTIWINDOW_X11_XIM_MAX_BYTES
+#define V_MULTIWINDOW_X11_XIM_MAX_BYTES 32768
+#endif
+
+#define V_MULTIWINDOW_CURSOR_SHAPE_DEFAULT 0
+#define V_MULTIWINDOW_CURSOR_SHAPE_POINTER 1
+#define V_MULTIWINDOW_CURSOR_SHAPE_MOVE 2
+#define V_MULTIWINDOW_CURSOR_SHAPE_N_RESIZE 3
+#define V_MULTIWINDOW_CURSOR_SHAPE_S_RESIZE 4
+#define V_MULTIWINDOW_CURSOR_SHAPE_E_RESIZE 5
+#define V_MULTIWINDOW_CURSOR_SHAPE_W_RESIZE 6
+#define V_MULTIWINDOW_CURSOR_SHAPE_NE_RESIZE 7
+#define V_MULTIWINDOW_CURSOR_SHAPE_NW_RESIZE 8
+#define V_MULTIWINDOW_CURSOR_SHAPE_SE_RESIZE 9
+#define V_MULTIWINDOW_CURSOR_SHAPE_SW_RESIZE 10
+#define V_MULTIWINDOW_CURSOR_SHAPE_EW_RESIZE 11
+#define V_MULTIWINDOW_CURSOR_SHAPE_NS_RESIZE 12
+#define V_MULTIWINDOW_CURSOR_SHAPE_NESW_RESIZE 13
+#define V_MULTIWINDOW_CURSOR_SHAPE_NWSE_RESIZE 14
+#define V_MULTIWINDOW_CURSOR_SHAPE_GRAB 15
+#define V_MULTIWINDOW_CURSOR_SHAPE_GRABBING 16
+
 typedef struct {
 	unsigned long flags;
 	unsigned long functions;
@@ -32,6 +62,809 @@ typedef struct {
 	long input_mode;
 	unsigned long status;
 } VMultiwindowMotifWmHints;
+
+typedef struct {
+	int key;
+	char name[XkbKeyNameLength];
+} VMultiwindowX11KeymapEntry;
+
+#define V_MULTIWINDOW_X11_KEYMAP_ENTRY(key, a, b, c, d) { key, { a, b, c, d } }
+
+static inline long v_multiwindow_x11_event_mask(void) {
+	return StructureNotifyMask |
+		PropertyChangeMask |
+		KeyPressMask |
+		KeyReleaseMask |
+		PointerMotionMask |
+		ButtonPressMask |
+		ButtonReleaseMask |
+		FocusChangeMask |
+		EnterWindowMask |
+		LeaveWindowMask;
+}
+
+static inline unsigned long v_multiwindow_x11_event_window(XEvent *event) {
+	switch (event->type) {
+	case KeyPress:
+	case KeyRelease:
+		return (unsigned long)event->xkey.window;
+	case ButtonPress:
+	case ButtonRelease:
+		return (unsigned long)event->xbutton.window;
+	case MotionNotify:
+		return (unsigned long)event->xmotion.window;
+	case EnterNotify:
+	case LeaveNotify:
+		return (unsigned long)event->xcrossing.window;
+	case FocusIn:
+	case FocusOut:
+		return (unsigned long)event->xfocus.window;
+	case ClientMessage:
+		return (unsigned long)event->xclient.window;
+	case ConfigureNotify:
+		return (unsigned long)event->xconfigure.window;
+	case DestroyNotify:
+		return (unsigned long)event->xdestroywindow.window;
+	case PropertyNotify:
+		return (unsigned long)event->xproperty.window;
+	default:
+		return 0;
+	}
+}
+
+static inline unsigned long v_multiwindow_x11_property_atom(XEvent *event) {
+	return event->type == PropertyNotify ? (unsigned long)event->xproperty.atom : 0;
+}
+
+static inline int v_multiwindow_x11_property_state(XEvent *event) {
+	return event->type == PropertyNotify ? event->xproperty.state : -1;
+}
+
+static inline int v_multiwindow_x11_event_x(XEvent *event) {
+	switch (event->type) {
+	case ButtonPress:
+	case ButtonRelease:
+		return event->xbutton.x;
+	case MotionNotify:
+		return event->xmotion.x;
+	case EnterNotify:
+	case LeaveNotify:
+		return event->xcrossing.x;
+	default:
+		return 0;
+	}
+}
+
+static inline int v_multiwindow_x11_event_y(XEvent *event) {
+	switch (event->type) {
+	case ButtonPress:
+	case ButtonRelease:
+		return event->xbutton.y;
+	case MotionNotify:
+		return event->xmotion.y;
+	case EnterNotify:
+	case LeaveNotify:
+		return event->xcrossing.y;
+	default:
+		return 0;
+	}
+}
+
+static inline unsigned int v_multiwindow_x11_event_state(XEvent *event) {
+	switch (event->type) {
+	case KeyPress:
+	case KeyRelease:
+		return event->xkey.state;
+	case ButtonPress:
+	case ButtonRelease:
+		return event->xbutton.state;
+	case MotionNotify:
+		return event->xmotion.state;
+	case EnterNotify:
+	case LeaveNotify:
+		return event->xcrossing.state;
+	default:
+		return 0;
+	}
+}
+
+static inline unsigned int v_multiwindow_x11_event_keycode(XEvent *event) {
+	return (event->type == KeyPress || event->type == KeyRelease) ? event->xkey.keycode : 0;
+}
+
+static inline unsigned int v_multiwindow_x11_event_button(XEvent *event) {
+	return (event->type == ButtonPress || event->type == ButtonRelease) ? event->xbutton.button : 0;
+}
+
+static inline int v_multiwindow_x11_focus_mode(XEvent *event) {
+	return (event->type == FocusIn || event->type == FocusOut) ? event->xfocus.mode : -1;
+}
+
+static inline int v_multiwindow_x11_is_notify_grab_or_ungrab(int mode) {
+	return mode == NotifyGrab || mode == NotifyUngrab;
+}
+
+static inline int v_multiwindow_x11_enable_detectable_auto_repeat(Display *display) {
+	if (display == NULL) {
+		return 0;
+	}
+	Bool supported = False;
+	if (XkbSetDetectableAutoRepeat(display, True, &supported) != True) {
+		return 0;
+	}
+	return supported ? 1 : 0;
+}
+
+static inline int v_multiwindow_x11_is_auto_repeat_release(Display *display, XEvent *event) {
+	if (display == NULL || event == NULL || event->type != KeyRelease || XPending(display) <= 0) {
+		return 0;
+	}
+	XEvent next;
+	XPeekEvent(display, &next);
+	if (next.type != KeyPress) {
+		return 0;
+	}
+	return next.xkey.window == event->xkey.window &&
+		next.xkey.keycode == event->xkey.keycode &&
+		next.xkey.time == event->xkey.time;
+}
+
+static inline int v_multiwindow_x11_modifiers(unsigned int state) {
+	int modifiers = 0;
+	if (state & ShiftMask) {
+		modifiers |= 1;
+	}
+	if (state & ControlMask) {
+		modifiers |= 2;
+	}
+	if (state & Mod1Mask) {
+		modifiers |= 4;
+	}
+	if (state & Mod4Mask) {
+		modifiers |= 8;
+	}
+	if (state & Button1Mask) {
+		modifiers |= 0x100;
+	}
+	if (state & Button3Mask) {
+		modifiers |= 0x200;
+	}
+	if (state & Button2Mask) {
+		modifiers |= 0x400;
+	}
+	return modifiers;
+}
+
+static inline int v_multiwindow_x11_key_modifier_bit(int key_code) {
+	switch (key_code) {
+	case 340:
+	case 344:
+		return 1;
+	case 341:
+	case 345:
+		return 2;
+	case 342:
+	case 346:
+		return 4;
+	case 343:
+	case 347:
+		return 8;
+	default:
+		return 0;
+	}
+}
+
+static inline int v_multiwindow_x11_mouse_button(unsigned int button) {
+	switch (button) {
+	case Button1:
+		return 0;
+	case Button3:
+		return 1;
+	case Button2:
+		return 2;
+	default:
+		return 256;
+	}
+}
+
+static inline int v_multiwindow_x11_button_modifier_bit(int mouse_button) {
+	switch (mouse_button) {
+	case 0:
+		return 0x100;
+	case 1:
+		return 0x200;
+	case 2:
+		return 0x400;
+	default:
+		return 0;
+	}
+}
+
+static inline unsigned int v_multiwindow_x11_cursor_font_shape(int shape) {
+	switch (shape) {
+	case V_MULTIWINDOW_CURSOR_SHAPE_POINTER:
+		return XC_hand2;
+	case V_MULTIWINDOW_CURSOR_SHAPE_MOVE:
+	case V_MULTIWINDOW_CURSOR_SHAPE_GRAB:
+	case V_MULTIWINDOW_CURSOR_SHAPE_GRABBING:
+		return XC_fleur;
+	case V_MULTIWINDOW_CURSOR_SHAPE_N_RESIZE:
+		return XC_top_side;
+	case V_MULTIWINDOW_CURSOR_SHAPE_S_RESIZE:
+		return XC_bottom_side;
+	case V_MULTIWINDOW_CURSOR_SHAPE_E_RESIZE:
+		return XC_right_side;
+	case V_MULTIWINDOW_CURSOR_SHAPE_W_RESIZE:
+		return XC_left_side;
+	case V_MULTIWINDOW_CURSOR_SHAPE_NE_RESIZE:
+		return XC_top_right_corner;
+	case V_MULTIWINDOW_CURSOR_SHAPE_NW_RESIZE:
+		return XC_top_left_corner;
+	case V_MULTIWINDOW_CURSOR_SHAPE_SE_RESIZE:
+		return XC_bottom_right_corner;
+	case V_MULTIWINDOW_CURSOR_SHAPE_SW_RESIZE:
+		return XC_bottom_left_corner;
+	case V_MULTIWINDOW_CURSOR_SHAPE_EW_RESIZE:
+		return XC_sb_h_double_arrow;
+	case V_MULTIWINDOW_CURSOR_SHAPE_NS_RESIZE:
+		return XC_sb_v_double_arrow;
+	case V_MULTIWINDOW_CURSOR_SHAPE_NESW_RESIZE:
+		return XC_top_right_corner;
+	case V_MULTIWINDOW_CURSOR_SHAPE_NWSE_RESIZE:
+		return XC_top_left_corner;
+	default:
+		return XC_left_ptr;
+	}
+}
+
+static inline unsigned long v_multiwindow_x11_create_cursor_for_shape(Display *display, int shape) {
+	if (display == NULL) {
+		return 0;
+	}
+	return (unsigned long)XCreateFontCursor(display, v_multiwindow_x11_cursor_font_shape(shape));
+}
+
+static inline XIM v_multiwindow_x11_open_im(Display *display) {
+	if (display == NULL) {
+		return NULL;
+	}
+	setlocale(LC_CTYPE, "");
+	XSetLocaleModifiers("");
+	XIM im = XOpenIM(display, NULL, NULL, NULL);
+	if (im == NULL) {
+		XSetLocaleModifiers("@im=none");
+		im = XOpenIM(display, NULL, NULL, NULL);
+	}
+	return im;
+}
+
+static inline void v_multiwindow_x11_close_im(XIM im) {
+	if (im != NULL) {
+		XCloseIM(im);
+	}
+}
+
+static inline XIC v_multiwindow_x11_create_ic(XIM im, unsigned long window) {
+	if (im == NULL || window == 0) {
+		return NULL;
+	}
+	return XCreateIC(im,
+		XNInputStyle, XIMPreeditNothing | XIMStatusNothing,
+		XNClientWindow, (Window)window,
+		XNFocusWindow, (Window)window,
+		NULL);
+}
+
+static inline void v_multiwindow_x11_destroy_ic(XIC ic) {
+	if (ic != NULL) {
+		XDestroyIC(ic);
+	}
+}
+
+static inline void v_multiwindow_x11_set_ic_focus(XIC ic) {
+	if (ic != NULL) {
+		XSetICFocus(ic);
+	}
+}
+
+static inline void v_multiwindow_x11_unset_ic_focus(XIC ic) {
+	if (ic != NULL) {
+		XUnsetICFocus(ic);
+	}
+}
+
+static inline int v_multiwindow_x11_key_code_from_keysym(KeySym keysym) {
+	if (keysym >= XK_a && keysym <= XK_z) {
+		return (int)(keysym - XK_a + 65);
+	}
+	if (keysym >= XK_A && keysym <= XK_Z) {
+		return (int)(keysym - XK_A + 65);
+	}
+	if (keysym >= XK_0 && keysym <= XK_9) {
+		return (int)(keysym - XK_0 + 48);
+	}
+	if (keysym >= XK_F1 && keysym <= XK_F25) {
+		return (int)(keysym - XK_F1 + 290);
+	}
+	if (keysym >= XK_KP_0 && keysym <= XK_KP_9) {
+		return (int)(keysym - XK_KP_0 + 320);
+	}
+	switch (keysym) {
+	case XK_space:
+		return 32;
+	case XK_apostrophe:
+		return 39;
+	case XK_comma:
+		return 44;
+	case XK_minus:
+		return 45;
+	case XK_period:
+		return 46;
+	case XK_slash:
+		return 47;
+	case XK_semicolon:
+		return 59;
+	case XK_equal:
+		return 61;
+	case XK_bracketleft:
+		return 91;
+	case XK_backslash:
+		return 92;
+	case XK_bracketright:
+		return 93;
+	case XK_grave:
+		return 96;
+	case XK_less:
+		return 161;
+	case XK_Escape:
+		return 256;
+	case XK_Return:
+		return 257;
+	case XK_Tab:
+	case XK_ISO_Left_Tab:
+		return 258;
+	case XK_BackSpace:
+		return 259;
+	case XK_Insert:
+		return 260;
+	case XK_Delete:
+		return 261;
+	case XK_Right:
+		return 262;
+	case XK_Left:
+		return 263;
+	case XK_Down:
+		return 264;
+	case XK_Up:
+		return 265;
+	case XK_Page_Up:
+		return 266;
+	case XK_Page_Down:
+		return 267;
+	case XK_Home:
+		return 268;
+	case XK_End:
+		return 269;
+	case XK_Caps_Lock:
+		return 280;
+	case XK_Scroll_Lock:
+		return 281;
+	case XK_Num_Lock:
+		return 282;
+	case XK_Print:
+		return 283;
+	case XK_Pause:
+		return 284;
+	case XK_KP_Decimal:
+	case XK_KP_Separator:
+	case XK_KP_Delete:
+		return 330;
+	case XK_KP_Divide:
+		return 331;
+	case XK_KP_Multiply:
+		return 332;
+	case XK_KP_Subtract:
+		return 333;
+	case XK_KP_Add:
+		return 334;
+	case XK_KP_Enter:
+		return 335;
+	case XK_KP_Equal:
+		return 336;
+	case XK_KP_Insert:
+		return 320;
+	case XK_KP_End:
+		return 321;
+	case XK_KP_Down:
+		return 322;
+	case XK_KP_Page_Down:
+		return 323;
+	case XK_KP_Left:
+		return 324;
+	case XK_KP_Right:
+		return 326;
+	case XK_KP_Home:
+		return 327;
+	case XK_KP_Up:
+		return 328;
+	case XK_KP_Page_Up:
+		return 329;
+	case XK_Shift_L:
+		return 340;
+	case XK_Control_L:
+		return 341;
+	case XK_Alt_L:
+	case XK_Meta_L:
+		return 342;
+	case XK_Super_L:
+		return 343;
+	case XK_Shift_R:
+		return 344;
+	case XK_Control_R:
+		return 345;
+	case XK_Mode_switch:
+	case XK_ISO_Level3_Shift:
+	case XK_Alt_R:
+	case XK_Meta_R:
+		return 346;
+	case XK_Super_R:
+		return 347;
+	case XK_Menu:
+		return 348;
+	default:
+		return 0;
+	}
+}
+
+static inline int v_multiwindow_x11_key_code_from_keysyms(KeySym *keysyms, int width) {
+	if (keysyms == NULL || width <= 0) {
+		return 0;
+	}
+	if (width > 1) {
+		switch (keysyms[1]) {
+		case XK_KP_0:
+			return 320;
+		case XK_KP_1:
+			return 321;
+		case XK_KP_2:
+			return 322;
+		case XK_KP_3:
+			return 323;
+		case XK_KP_4:
+			return 324;
+		case XK_KP_5:
+			return 325;
+		case XK_KP_6:
+			return 326;
+		case XK_KP_7:
+			return 327;
+		case XK_KP_8:
+			return 328;
+		case XK_KP_9:
+			return 329;
+		case XK_KP_Separator:
+		case XK_KP_Decimal:
+			return 330;
+		case XK_KP_Equal:
+			return 336;
+		case XK_KP_Enter:
+			return 335;
+		default:
+			break;
+		}
+	}
+	return v_multiwindow_x11_key_code_from_keysym(keysyms[0]);
+}
+
+static inline void v_multiwindow_x11_init_keycodes(Display *display, int *keycodes, int keycodes_len) {
+	if (keycodes == NULL || keycodes_len <= 0) {
+		return;
+	}
+	for (int i = 0; i < keycodes_len; i++) {
+		keycodes[i] = 0;
+	}
+	if (display == NULL) {
+		return;
+	}
+
+	int scancode_min = 0;
+	int scancode_max = 0;
+	XDisplayKeycodes(display, &scancode_min, &scancode_max);
+
+	XkbDescPtr desc = XkbGetMap(display, 0, XkbUseCoreKbd);
+	if (desc != NULL) {
+		if (XkbGetNames(display, XkbKeyNamesMask | XkbKeyAliasesMask, desc) == Success && desc->names != NULL) {
+			scancode_min = (int)desc->min_key_code;
+			scancode_max = (int)desc->max_key_code;
+			static const VMultiwindowX11KeymapEntry keymap[] = {
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(96, 'T', 'L', 'D', 'E'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(49, 'A', 'E', '0', '1'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(50, 'A', 'E', '0', '2'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(51, 'A', 'E', '0', '3'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(52, 'A', 'E', '0', '4'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(53, 'A', 'E', '0', '5'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(54, 'A', 'E', '0', '6'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(55, 'A', 'E', '0', '7'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(56, 'A', 'E', '0', '8'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(57, 'A', 'E', '0', '9'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(48, 'A', 'E', '1', '0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(45, 'A', 'E', '1', '1'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(61, 'A', 'E', '1', '2'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(81, 'A', 'D', '0', '1'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(87, 'A', 'D', '0', '2'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(69, 'A', 'D', '0', '3'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(82, 'A', 'D', '0', '4'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(84, 'A', 'D', '0', '5'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(89, 'A', 'D', '0', '6'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(85, 'A', 'D', '0', '7'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(73, 'A', 'D', '0', '8'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(79, 'A', 'D', '0', '9'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(80, 'A', 'D', '1', '0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(91, 'A', 'D', '1', '1'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(93, 'A', 'D', '1', '2'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(65, 'A', 'C', '0', '1'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(83, 'A', 'C', '0', '2'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(68, 'A', 'C', '0', '3'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(70, 'A', 'C', '0', '4'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(71, 'A', 'C', '0', '5'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(72, 'A', 'C', '0', '6'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(74, 'A', 'C', '0', '7'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(75, 'A', 'C', '0', '8'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(76, 'A', 'C', '0', '9'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(59, 'A', 'C', '1', '0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(39, 'A', 'C', '1', '1'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(90, 'A', 'B', '0', '1'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(88, 'A', 'B', '0', '2'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(67, 'A', 'B', '0', '3'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(86, 'A', 'B', '0', '4'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(66, 'A', 'B', '0', '5'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(78, 'A', 'B', '0', '6'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(77, 'A', 'B', '0', '7'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(44, 'A', 'B', '0', '8'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(46, 'A', 'B', '0', '9'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(47, 'A', 'B', '1', '0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(92, 'B', 'K', 'S', 'L'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(161, 'L', 'S', 'G', 'T'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(32, 'S', 'P', 'C', 'E'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(256, 'E', 'S', 'C', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(257, 'R', 'T', 'R', 'N'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(258, 'T', 'A', 'B', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(259, 'B', 'K', 'S', 'P'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(260, 'I', 'N', 'S', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(261, 'D', 'E', 'L', 'E'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(262, 'R', 'G', 'H', 'T'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(263, 'L', 'E', 'F', 'T'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(264, 'D', 'O', 'W', 'N'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(265, 'U', 'P', '\0', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(266, 'P', 'G', 'U', 'P'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(267, 'P', 'G', 'D', 'N'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(268, 'H', 'O', 'M', 'E'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(269, 'E', 'N', 'D', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(280, 'C', 'A', 'P', 'S'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(281, 'S', 'C', 'L', 'K'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(282, 'N', 'M', 'L', 'K'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(283, 'P', 'R', 'S', 'C'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(284, 'P', 'A', 'U', 'S'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(290, 'F', 'K', '0', '1'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(291, 'F', 'K', '0', '2'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(292, 'F', 'K', '0', '3'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(293, 'F', 'K', '0', '4'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(294, 'F', 'K', '0', '5'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(295, 'F', 'K', '0', '6'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(296, 'F', 'K', '0', '7'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(297, 'F', 'K', '0', '8'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(298, 'F', 'K', '0', '9'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(299, 'F', 'K', '1', '0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(300, 'F', 'K', '1', '1'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(301, 'F', 'K', '1', '2'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(302, 'F', 'K', '1', '3'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(303, 'F', 'K', '1', '4'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(304, 'F', 'K', '1', '5'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(305, 'F', 'K', '1', '6'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(306, 'F', 'K', '1', '7'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(307, 'F', 'K', '1', '8'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(308, 'F', 'K', '1', '9'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(309, 'F', 'K', '2', '0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(310, 'F', 'K', '2', '1'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(311, 'F', 'K', '2', '2'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(312, 'F', 'K', '2', '3'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(313, 'F', 'K', '2', '4'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(314, 'F', 'K', '2', '5'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(320, 'K', 'P', '0', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(321, 'K', 'P', '1', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(322, 'K', 'P', '2', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(323, 'K', 'P', '3', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(324, 'K', 'P', '4', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(325, 'K', 'P', '5', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(326, 'K', 'P', '6', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(327, 'K', 'P', '7', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(328, 'K', 'P', '8', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(329, 'K', 'P', '9', '\0'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(330, 'K', 'P', 'D', 'L'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(331, 'K', 'P', 'D', 'V'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(332, 'K', 'P', 'M', 'U'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(333, 'K', 'P', 'S', 'U'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(334, 'K', 'P', 'A', 'D'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(335, 'K', 'P', 'E', 'N'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(336, 'K', 'P', 'E', 'Q'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(340, 'L', 'F', 'S', 'H'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(341, 'L', 'C', 'T', 'L'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(342, 'L', 'A', 'L', 'T'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(343, 'L', 'W', 'I', 'N'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(344, 'R', 'T', 'S', 'H'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(345, 'R', 'C', 'T', 'L'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(346, 'R', 'A', 'L', 'T'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(346, 'L', 'V', 'L', '3'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(346, 'M', 'D', 'S', 'W'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(347, 'R', 'W', 'I', 'N'),
+				V_MULTIWINDOW_X11_KEYMAP_ENTRY(348, 'M', 'E', 'N', 'U'),
+			};
+			const int keymap_len = (int)(sizeof(keymap) / sizeof(keymap[0]));
+			for (int scancode = scancode_min; scancode <= scancode_max && scancode < keycodes_len; scancode++) {
+				if (scancode < 0 || desc->names->keys == NULL) {
+					continue;
+				}
+				int key = 0;
+				for (int i = 0; i < keymap_len; i++) {
+					if (memcmp(desc->names->keys[scancode].name, keymap[i].name, XkbKeyNameLength) == 0) {
+						key = keymap[i].key;
+						break;
+					}
+				}
+				if (key == 0 && desc->names->key_aliases != NULL) {
+					for (int alias_index = 0; alias_index < desc->names->num_key_aliases; alias_index++) {
+						if (memcmp(desc->names->key_aliases[alias_index].real, desc->names->keys[scancode].name, XkbKeyNameLength) != 0) {
+							continue;
+						}
+						for (int i = 0; i < keymap_len; i++) {
+							if (memcmp(desc->names->key_aliases[alias_index].alias, keymap[i].name, XkbKeyNameLength) == 0) {
+								key = keymap[i].key;
+								break;
+							}
+						}
+						if (key != 0) {
+							break;
+						}
+					}
+				}
+				keycodes[scancode] = key;
+			}
+			XkbFreeNames(desc, XkbKeyNamesMask, True);
+		}
+		XkbFreeKeyboard(desc, 0, True);
+	}
+
+	if (scancode_min < 0) {
+		scancode_min = 0;
+	}
+	if (scancode_max >= keycodes_len) {
+		scancode_max = keycodes_len - 1;
+	}
+	if (scancode_min > scancode_max) {
+		return;
+	}
+	int syms_per_code = 0;
+	KeySym *keysyms = XGetKeyboardMapping(display, (KeyCode)scancode_min, scancode_max - scancode_min + 1, &syms_per_code);
+	if (keysyms == NULL) {
+		return;
+	}
+	for (int scancode = scancode_min; scancode <= scancode_max; scancode++) {
+		if (keycodes[scancode] == 0) {
+			int base = (scancode - scancode_min) * syms_per_code;
+			keycodes[scancode] = v_multiwindow_x11_key_code_from_keysyms(keysyms + base, syms_per_code);
+		}
+	}
+	XFree(keysyms);
+}
+
+static inline int v_multiwindow_x11_key_code(XEvent *event, int *keycodes, int keycodes_len) {
+	KeySym keysym = XLookupKeysym(&event->xkey, 0);
+	int keycode = v_multiwindow_x11_key_code_from_keysym(keysym);
+	unsigned int scancode = event->xkey.keycode;
+	if (keycode >= 256 && keycode <= 348) {
+		return keycode;
+	}
+	if (keycodes != NULL && scancode < (unsigned int)keycodes_len && keycodes[scancode] != 0) {
+		return keycodes[scancode];
+	}
+	return keycode;
+}
+
+static inline int v_multiwindow_x11_utf8_decode_next(const char *buf, int count, int *offset, unsigned int *out_codepoint) {
+	if (buf == NULL || offset == NULL || out_codepoint == NULL || *offset >= count) {
+		return 0;
+	}
+	const unsigned char *bytes = (const unsigned char *)buf;
+	int i = *offset;
+	unsigned int codepoint = 0;
+	int width = 0;
+	if ((bytes[i] & 0x80) == 0) {
+		codepoint = bytes[i];
+		width = 1;
+	} else if ((bytes[i] & 0xe0) == 0xc0 && i + 1 < count) {
+		codepoint = ((unsigned int)(bytes[i] & 0x1f) << 6) |
+			(unsigned int)(bytes[i + 1] & 0x3f);
+		width = 2;
+	} else if ((bytes[i] & 0xf0) == 0xe0 && i + 2 < count) {
+		codepoint = ((unsigned int)(bytes[i] & 0x0f) << 12) |
+			((unsigned int)(bytes[i + 1] & 0x3f) << 6) |
+			(unsigned int)(bytes[i + 2] & 0x3f);
+		width = 3;
+	} else if ((bytes[i] & 0xf8) == 0xf0 && i + 3 < count) {
+		codepoint = ((unsigned int)(bytes[i] & 0x07) << 18) |
+			((unsigned int)(bytes[i + 1] & 0x3f) << 12) |
+			((unsigned int)(bytes[i + 2] & 0x3f) << 6) |
+			(unsigned int)(bytes[i + 3] & 0x3f);
+		width = 4;
+	}
+	if (width == 0 || (codepoint >= 0xd800U && codepoint <= 0xdfffU) || codepoint >= 0x110000U) {
+		*offset = i + 1;
+		return 0;
+	}
+	*offset = i + width;
+	*out_codepoint = codepoint;
+	return 1;
+}
+
+static inline int v_multiwindow_x11_decode_utf8_codes(const char *buf, int count, unsigned int *codes, int codes_len, int *required_codes) {
+	int offset = 0;
+	int out_count = 0;
+	int total_count = 0;
+	if (required_codes != NULL) {
+		*required_codes = 0;
+	}
+	while (offset < count) {
+		unsigned int codepoint = 0;
+		if (v_multiwindow_x11_utf8_decode_next(buf, count, &offset, &codepoint) && codepoint != 0) {
+			if (out_count < codes_len) {
+				codes[out_count++] = codepoint;
+			}
+			total_count++;
+		}
+	}
+	if (required_codes != NULL) {
+		*required_codes = total_count;
+	}
+	return out_count;
+}
+
+static inline int v_multiwindow_x11_char_codes(XIC ic, XEvent *event, unsigned int *codes, int codes_len, int *required_codes) {
+	if (required_codes != NULL) {
+		*required_codes = 0;
+	}
+	if (ic == NULL || event == NULL || event->type != KeyPress || codes == NULL || codes_len <= 0) {
+		return 0;
+	}
+	char stack_buf[V_MULTIWINDOW_X11_XIM_STACK_BYTES];
+	char *buf = stack_buf;
+	int buf_len = (int)sizeof(stack_buf);
+	KeySym keysym = NoSymbol;
+	Status status = 0;
+	int count = Xutf8LookupString(ic, &event->xkey, buf, buf_len, &keysym, &status);
+	if (status == XBufferOverflow) {
+		if (count <= 0 || count > V_MULTIWINDOW_X11_XIM_MAX_BYTES) {
+			return 0;
+		}
+		buf = (char *)malloc((size_t)count);
+		if (buf == NULL) {
+			return 0;
+		}
+		buf_len = count;
+		status = 0;
+		count = Xutf8LookupString(ic, &event->xkey, buf, buf_len, &keysym, &status);
+	}
+	if ((status != XLookupChars && status != XLookupBoth) || count <= 0 || count > buf_len) {
+		if (buf != stack_buf) {
+			free(buf);
+		}
+		return 0;
+	}
+	int out_count = v_multiwindow_x11_decode_utf8_codes(buf, count, codes, codes_len, required_codes);
+	if (buf != stack_buf) {
+		free(buf);
+	}
+	return out_count;
+}
 
 static inline int v_multiwindow_x11_apply_config_hints(Display *display, unsigned long window, int width, int height, int min_width, int min_height, int resizable, int borderless, int fullscreen) {
 	XSizeHints size_hints;
@@ -162,7 +995,7 @@ static inline unsigned long v_multiwindow_x11_create_egl_window(Display *display
 	attrs.colormap = XCreateColormap(display, root, visual_info->visual, AllocNone);
 	attrs.border_pixel = 0;
 	attrs.background_pixel = 0;
-	attrs.event_mask = StructureNotifyMask;
+	attrs.event_mask = v_multiwindow_x11_event_mask();
 	window = XCreateWindow(display, root, 0, 0, (unsigned int)width, (unsigned int)height, 0,
 		visual_info->depth, InputOutput, visual_info->visual,
 		CWColormap | CWBorderPixel | CWBackPixel | CWEventMask, &attrs);


### PR DESCRIPTION
## Summary

This PR completes the second part of the x.multiwindow and gg multi-window work.

It extends the opt-in gg multi-window path so native window and input events are routed across the supported backends, while keeping the existing single-window gg path isolated.

Normal import gg does not pull x.multiwindow. The new API still requires -d gg_multiwindow.

## What changed

- Added native event routing for window lifecycle, resize, close, mouse, keyboard, text, focus, file drop, and touch events.
- Added cursor shape support and interactive move/resize hooks where the backend supports them.
- Extended the gg multi-window facade so users can work from gg without importing x.multiwindow directly.
- Extended AppKit, Win32, X11, and Wayland backend plumbing.
- Added Wayland helper sources for cursor shape and xdg decoration negotiation.
- Updated examples/gg/multiwindow.v to demonstrate multiple windows, per-window routing, cursor and resize behavior, and backend capability reporting.
- Updated the gg and x.multiwindow documentation.
- Strengthened CI coverage for Linux, macOS, and Windows.

## Usage

- ./v -d gg_multiwindow run examples/gg/multiwindow.v
- ./v -d gg_multiwindow -d x_multiwindow_x11 run examples/gg/multiwindow.v
- ./v -d gg_multiwindow -d sokol_wayland run examples/gg/multiwindow.v
- ./v -d gg_multiwindow -d sokol_metal run examples/gg/multiwindow.v
- ./v -d gg_multiwindow -d sokol_d3d11 run examples/gg/multiwindow.v

## Compatibility

Without -d gg_multiwindow, the multi-window API returns a clear opt-in error and does not load native multi-window backend dependencies.

The existing single-window gg path remains unchanged.

## Validation

- ./v -d gg_multiwindow test vlib/x/multiwindow vlib/gg/multiwindow_api_d_gg_multiwindow_test.v vlib/gg/frame_pacing_test.v vlib/gg/draw_fns_api_test.v vlib/gg/draw_rect_empty_test.v
- ./v -d gg_multiwindow test vlib/gg/legacy_import_multiwindow_isolation_test.v
- ./v -d gg_multiwindow -d sokol_wayland -o /tmp/gg_multiwindow_wayland examples/gg/multiwindow.v
- ./v -d gg_multiwindow -d x_multiwindow_x11 -o /tmp/gg_multiwindow_x11 examples/gg/multiwindow.v

Manual local Wayland testing was also done for move, resize, cursor hover, and decoration behavior.