### PR TITLE
net.mbedtls: track Content-Length/chunked framing in vschannel's one-shot HTTP/1.1 client

### DIFF
--- a/thirdparty/vschannel/vschannel.c
+++ b/thirdparty/vschannel/vschannel.c
@@ -1356,6 +1356,236 @@ static SECURITY_STATUS client_handshake_loop(TlsContext *tls_ctx, BOOL fDoInitia
 }
 
 
+// ---------------------------------------------------------------------------
+// One-shot HTTP/1.1 response-completion detection (https_make_request).
+//
+// A keep-alive peer is free to leave the connection open indefinitely after
+// responding (HTTP/1.1's default), so waiting for the peer to close the
+// socket (or send a TLS close_notify) is not a valid completion signal on
+// its own -- a compliant server that never does either would hang the
+// client forever (vlang/v#27705). These helpers let the read loop below
+// recognize a complete response from its own framing (Content-Length, or a
+// fully-received chunked body) and stop as soon as it has arrived, without
+// waiting on the peer. Deliberately conservative throughout: anything that
+// cannot be confidently parsed reports "incomplete", falling back to the
+// existing read-until-close/read-until-context-expired behavior, which
+// remains correct in every case -- these helpers only ever add an EARLIER
+// stopping point, never a different one.
+
+// http_ci_equal reports whether buf[0..len) case-insensitively equals name
+// (an ASCII literal of length name_len) -- HTTP header names and the
+// "chunked" token are always ASCII.
+static BOOL http_ci_equal(const CHAR *buf, int len, const CHAR *name, int name_len) {
+	if(len != name_len) {
+		return FALSE;
+	}
+	for(int i = 0; i < len; i++) {
+		CHAR a = buf[i];
+		CHAR b = name[i];
+		if(a >= 'A' && a <= 'Z') a = a - 'A' + 'a';
+		if(b >= 'A' && b <= 'Z') b = b - 'A' + 'a';
+		if(a != b) {
+			return FALSE;
+		}
+	}
+	return TRUE;
+}
+
+// http_ci_contains reports whether needle occurs case-insensitively anywhere
+// within buf[0..len).
+static BOOL http_ci_contains(const CHAR *buf, int len, const CHAR *needle, int needle_len) {
+	for(int i = 0; i + needle_len <= len; i++) {
+		if(http_ci_equal(buf + i, needle_len, needle, needle_len)) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+// http_find_header case-insensitively locates a "<name>: value" line within
+// buf[0..headers_end) (the response's header block) and returns a pointer to
+// the value (leading spaces/tabs trimmed), with its length in *out_len.
+// Returns NULL if the header is not present.
+static const CHAR* http_find_header(const CHAR *buf, int headers_end, const CHAR *name, int name_len, int *out_len) {
+	int i = 0;
+	while(i < headers_end) {
+		int line_end = -1;
+		for(int j = i; j + 1 < headers_end; j++) {
+			if(buf[j] == '\r' && buf[j + 1] == '\n') {
+				line_end = j;
+				break;
+			}
+		}
+		if(line_end < 0) {
+			break;
+		}
+		if(line_end - i > name_len && buf[i + name_len] == ':'
+				&& http_ci_equal(buf + i, name_len, name, name_len)) {
+			const CHAR *val = buf + i + name_len + 1;
+			int val_len = line_end - (i + name_len + 1);
+			while(val_len > 0 && (*val == ' ' || *val == '\t')) {
+				val++;
+				val_len--;
+			}
+			*out_len = val_len;
+			return val;
+		}
+		i = line_end + 2;
+	}
+	return NULL;
+}
+
+// http_parse_decimal/http_parse_hex reject a value that would overflow
+// `long` (Windows' LLP64 model keeps `long` 32-bit even in 64-bit builds)
+// rather than let the multiply-add silently wrap into a small or negative
+// number: http_response_complete compares this value against a byte count
+// to decide whether the full response has arrived, so a wrapped length
+// could make it signal "complete" after only a few real bytes -- a
+// truncation bug strictly worse than the hang this file fixes. No
+// legitimate response from this one-shot client's callers is anywhere
+// close to this bound.
+#define HTTP_MAX_PARSED_LENGTH 0x3FFFFFFFL
+
+// http_parse_decimal parses buf[0..len) as an unsigned decimal integer,
+// rejecting anything that is not entirely digits -- a lenient parse that
+// silently accepts trailing garbage is not a trustworthy length signal.
+static BOOL http_parse_decimal(const CHAR *buf, int len, long *out) {
+	if(len <= 0) {
+		return FALSE;
+	}
+	long value = 0;
+	for(int i = 0; i < len; i++) {
+		if(buf[i] < '0' || buf[i] > '9') {
+			return FALSE;
+		}
+		int digit = buf[i] - '0';
+		if(value > (HTTP_MAX_PARSED_LENGTH - digit) / 10) {
+			return FALSE;
+		}
+		value = value * 10 + digit;
+	}
+	*out = value;
+	return TRUE;
+}
+
+// http_parse_hex parses a chunk-size line's leading hex digits, stopping at
+// the first non-hex-digit byte (permitting a ";extension" suffix per
+// RFC 7230 4.1.1, read past but not interpreted here). Requires at least one
+// hex digit.
+static BOOL http_parse_hex(const CHAR *buf, int len, long *out) {
+	int i = 0;
+	long value = 0;
+	while(i < len) {
+		CHAR c = buf[i];
+		int digit;
+		if(c >= '0' && c <= '9') {
+			digit = c - '0';
+		} else if(c >= 'a' && c <= 'f') {
+			digit = c - 'a' + 10;
+		} else if(c >= 'A' && c <= 'F') {
+			digit = c - 'A' + 10;
+		} else {
+			break;
+		}
+		if(value > (HTTP_MAX_PARSED_LENGTH - digit) / 16) {
+			return FALSE;
+		}
+		value = value * 16 + digit;
+		i++;
+	}
+	if(i == 0) {
+		return FALSE;
+	}
+	*out = value;
+	return TRUE;
+}
+
+// http_chunked_body_complete reports whether buf[0..len) -- the bytes
+// immediately following the response headers -- contains a complete
+// chunked-encoded body: every chunk present through the terminating
+// zero-size chunk and its (possibly empty) trailer section (RFC 7230 4.1).
+static BOOL http_chunked_body_complete(const CHAR *buf, int len) {
+	int pos = 0;
+	BOOL in_trailers = FALSE;
+	while(TRUE) {
+		int line_end = -1;
+		for(int i = pos; i + 1 < len; i++) {
+			if(buf[i] == '\r' && buf[i + 1] == '\n') {
+				line_end = i;
+				break;
+			}
+		}
+		if(line_end < 0) {
+			return FALSE; // line not fully received yet
+		}
+		if(in_trailers) {
+			if(line_end == pos) {
+				return TRUE; // empty line: end of the trailer section
+			}
+			pos = line_end + 2;
+			continue;
+		}
+		long chunk_size = 0;
+		if(!http_parse_hex(buf + pos, line_end - pos, &chunk_size)) {
+			return FALSE; // not a valid chunk-size line -- do not trust it
+		}
+		int data_start = line_end + 2;
+		if(chunk_size == 0) {
+			in_trailers = TRUE;
+			pos = data_start;
+			continue;
+		}
+		long data_end = (long)data_start + chunk_size;
+		if(data_end + 1 >= (long)len) {
+			return FALSE; // chunk data + trailing CRLF not fully received yet
+		}
+		pos = (int)(data_end + 2);
+	}
+}
+
+// http_response_complete inspects the response bytes accumulated so far
+// (buf[0..len)) and reports whether they already contain one complete HTTP
+// response. Only Content-Length and chunked Transfer-Encoding are
+// understood; a response framed neither way (or with a malformed length)
+// reports incomplete, so the caller keeps reading until the peer closes —
+// identical to this function's behavior before these helpers existed.
+static BOOL http_response_complete(const CHAR *buf, int len) {
+	int headers_end = -1;
+	for(int i = 0; i + 3 < len; i++) {
+		if(buf[i] == '\r' && buf[i + 1] == '\n' && buf[i + 2] == '\r' && buf[i + 3] == '\n') {
+			headers_end = i + 4;
+			break;
+		}
+	}
+	if(headers_end < 0) {
+		return FALSE;
+	}
+
+	int te_len = 0;
+	const CHAR *te = http_find_header(buf, headers_end, "Transfer-Encoding", 17, &te_len);
+	if(te != NULL) {
+		// RFC 7230 3.3.3: Transfer-Encoding, when present, overrides
+		// Content-Length. Only "chunked" is understood here; anything else
+		// falls back to the existing (always-correct) read-until-close
+		// behavior.
+		if(http_ci_contains(te, te_len, "chunked", 7)) {
+			return http_chunked_body_complete(buf + headers_end, len - headers_end);
+		}
+		return FALSE;
+	}
+
+	int cl_len = 0;
+	const CHAR *cl = http_find_header(buf, headers_end, "Content-Length", 14, &cl_len);
+	if(cl == NULL) {
+		return FALSE; // no length-framing header: must read until the peer closes
+	}
+	long content_length = 0;
+	if(!http_parse_decimal(cl, cl_len, &content_length)) {
+		return FALSE; // not a clean digit string -- do not trust it
+	}
+	return (long)(len - headers_end) >= content_length;
+}
+
 static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, DWORD req_len, CHAR **out, int *length, vschannel_allocator afn) {
 	SecPkgContext_StreamSizes Sizes;
 	SECURITY_STATUS scRet;
@@ -1542,7 +1772,15 @@ static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, DWORD 
 		// Copy the decrypted data to our output buffer
 		memcpy(*out+*length, pDataBuffer->pvBuffer, (int)pDataBuffer->cbBuffer);
 		*length += (int)pDataBuffer->cbBuffer;
-		
+
+		// Stop as soon as the response itself is fully framed (see
+		// http_response_complete's doc comment) rather than waiting for the
+		// peer to close the connection or send a TLS close_notify -- a
+		// keep-alive peer may do neither for a long time (vlang/v#27705).
+		if(http_response_complete(*out, *length)) {
+			return SEC_E_OK;
+		}
+
 		// Move any "extra" data to the input buffer.
 		if(pExtraBuffer) {
 			MoveMemory(pbIoBuffer, pExtraBuffer->pvBuffer, pExtraBuffer->cbBuffer);

--- a/thirdparty/vschannel/vschannel.c
+++ b/thirdparty/vschannel/vschannel.c
@@ -1391,12 +1391,38 @@ static BOOL http_ci_equal(const CHAR *buf, int len, const CHAR *name, int name_l
 	return TRUE;
 }
 
-// http_ci_contains reports whether needle occurs case-insensitively anywhere
-// within buf[0..len).
-static BOOL http_ci_contains(const CHAR *buf, int len, const CHAR *needle, int needle_len) {
-	for(int i = 0; i + needle_len <= len; i++) {
-		if(http_ci_equal(buf + i, needle_len, needle, needle_len)) {
-			return TRUE;
+// http_has_transfer_coding reports whether the Transfer-Encoding value
+// buf[0..len) contains `coding` as a real comma-separated transfer-coding
+// token (any ";parameters" suffix stripped, OWS trimmed, ASCII
+// case-insensitive) -- deliberately matching net.http's own
+// parse_response/has_header_token semantics, so this C-level framing
+// decision and the V-level chunked-decode decision can never disagree. A
+// substring match is NOT sufficient: an extension coding merely CONTAINING
+// the word (e.g. "xchunked") must fall back to read-until-close framing,
+// not have chunk framing applied to a body whose raw bytes might
+// accidentally look like a complete chunked message.
+static BOOL http_has_transfer_coding(const CHAR *buf, int len, const CHAR *coding, int coding_len) {
+	int start = 0;
+	for(int i = 0; i <= len; i++) {
+		if(i == len || buf[i] == ',') {
+			int tok_start = start;
+			int tok_end = i;
+			for(int j = tok_start; j < tok_end; j++) {
+				if(buf[j] == ';') {
+					tok_end = j;
+					break;
+				}
+			}
+			while(tok_start < tok_end && (buf[tok_start] == ' ' || buf[tok_start] == '\t')) {
+				tok_start++;
+			}
+			while(tok_end > tok_start && (buf[tok_end - 1] == ' ' || buf[tok_end - 1] == '\t')) {
+				tok_end--;
+			}
+			if(http_ci_equal(buf + tok_start, tok_end - tok_start, coding, coding_len)) {
+				return TRUE;
+			}
+			start = i + 1;
 		}
 	}
 	return FALSE;
@@ -1404,8 +1430,10 @@ static BOOL http_ci_contains(const CHAR *buf, int len, const CHAR *needle, int n
 
 // http_find_header case-insensitively locates a "<name>: value" line within
 // buf[0..headers_end) (the response's header block) and returns a pointer to
-// the value (leading spaces/tabs trimmed), with its length in *out_len.
-// Returns NULL if the header is not present.
+// the value (spaces/tabs trimmed on BOTH sides -- RFC 7230's field-value
+// grammar allows OWS before and after, and real servers do emit e.g.
+// "Content-Length: 27 " with trailing whitespace), with its length in
+// *out_len. Returns NULL if the header is not present.
 static const CHAR* http_find_header(const CHAR *buf, int headers_end, const CHAR *name, int name_len, int *out_len) {
 	int i = 0;
 	while(i < headers_end) {
@@ -1425,6 +1453,9 @@ static const CHAR* http_find_header(const CHAR *buf, int headers_end, const CHAR
 			int val_len = line_end - (i + name_len + 1);
 			while(val_len > 0 && (*val == ' ' || *val == '\t')) {
 				val++;
+				val_len--;
+			}
+			while(val_len > 0 && (val[val_len - 1] == ' ' || val[val_len - 1] == '\t')) {
 				val_len--;
 			}
 			*out_len = val_len;
@@ -1565,10 +1596,10 @@ static BOOL http_response_complete(const CHAR *buf, int len) {
 	const CHAR *te = http_find_header(buf, headers_end, "Transfer-Encoding", 17, &te_len);
 	if(te != NULL) {
 		// RFC 7230 3.3.3: Transfer-Encoding, when present, overrides
-		// Content-Length. Only "chunked" is understood here; anything else
-		// falls back to the existing (always-correct) read-until-close
-		// behavior.
-		if(http_ci_contains(te, te_len, "chunked", 7)) {
+		// Content-Length. Only a real `chunked` transfer-coding token is
+		// understood here; anything else falls back to the existing
+		// (always-correct) read-until-close behavior.
+		if(http_has_transfer_coding(te, te_len, "chunked", 7)) {
 			return http_chunked_body_complete(buf + headers_end, len - headers_end);
 		}
 		return FALSE;

--- a/vlib/net/http/vschannel_h1_windows_test.v
+++ b/vlib/net/http/vschannel_h1_windows_test.v
@@ -88,3 +88,154 @@ fn test_vschannel_h1_one_shot_does_not_wait_for_keep_alive_peer_to_close() {
 	listener.shutdown() or {}
 	th.wait()
 }
+
+// vh1t_serve_trailing_ows_cl is vh1t_serve_one with trailing optional
+// whitespace after the Content-Length value -- legal per RFC 7230's
+// field-value grammar (OWS on both sides), and emitted by real servers. The
+// completion detector must trim it rather than fail the strict digit parse
+// and fall back to waiting for the peer to close (which would reintroduce
+// the exact hang vlang/v#27705 fixed, for these servers only).
+fn vh1t_serve_trailing_ows_cl(mut conn mbedtls.SSLConn) {
+	defer {
+		conn.shutdown() or {}
+	}
+	conn.set_read_timeout(10 * time.second)
+	mut buf := []u8{len: 4096}
+	mut sofar := []u8{}
+	for !sofar.bytestr().contains('\r\n\r\n') {
+		n := conn.read(mut buf) or { return }
+		if n <= 0 {
+			return
+		}
+		sofar << buf[..n]
+	}
+	conn.write_string('HTTP/1.1 200 OK\r\nContent-Length: ${vh1t_body.len} \t\r\n\r\n${vh1t_body}') or {
+		return
+	}
+	time.sleep(3 * time.second)
+}
+
+fn test_vschannel_h1_content_length_with_trailing_whitespace_still_frames() {
+	mut port_listener := net.listen_tcp(.ip, '127.0.0.1:0') or {
+		assert false, 'port: ${err}'
+		return
+	}
+	port := port_listener.addr() or {
+		assert false, 'addr: ${err}'
+		return
+	}.port() or {
+		assert false, 'addr.port: ${err}'
+		return
+	}
+	port_listener.close() or {}
+	mut listener := mbedtls.new_ssl_listener('127.0.0.1:${port}', mbedtls.SSLConnectConfig{
+		cert:     vh1t_cert_path
+		cert_key: vh1t_key_path
+		validate: false
+	}) or {
+		assert false, 'listener: ${err}'
+		return
+	}
+	th := spawn fn (mut l mbedtls.SSLListener) {
+		mut conn := l.accept() or { return }
+		vh1t_serve_trailing_ows_cl(mut conn)
+	}(mut listener)
+
+	started := time.now()
+	resp := fetch(
+		url:          'https://127.0.0.1:${port}/'
+		validate:     false
+		enable_http2: false
+	) or {
+		assert false, 'fetch: ${err}'
+		return
+	}
+	elapsed := time.now() - started
+
+	assert resp.status_code == 200
+	assert resp.body == vh1t_body
+	assert elapsed < 1500 * time.millisecond, 'expected trailing OWS after the Content-Length value to be trimmed, not to defeat completion detection and wait for the peer to close -- took ${elapsed}'
+
+	listener.shutdown() or {}
+	th.wait()
+}
+
+const vh1t_te_ext_early = '0\r\n\r\n'
+const vh1t_te_ext_rest = 'REST-AFTER-FAKE-CHUNK-TERMINATOR'
+
+// vh1t_serve_xchunked responds with `Transfer-Encoding: xchunked` -- an
+// extension coding whose NAME merely contains the substring "chunked" -- and
+// a raw body whose first bytes happen to look like a complete chunked
+// terminator, with the remainder arriving shortly after. A client that
+// matches transfer codings by substring instead of by comma-separated token
+// (the way net.http's own parse_response/has_header_token does) wrongly
+// applies chunk framing, sees the fake terminator, and stops reading --
+// silently truncating the body. Unknown codings must fall back to
+// read-until-close; the server closes right after the second write, so the
+// correct path stays fast.
+fn vh1t_serve_xchunked(mut conn mbedtls.SSLConn) {
+	defer {
+		conn.shutdown() or {}
+	}
+	conn.set_read_timeout(10 * time.second)
+	mut buf := []u8{len: 4096}
+	mut sofar := []u8{}
+	for !sofar.bytestr().contains('\r\n\r\n') {
+		n := conn.read(mut buf) or { return }
+		if n <= 0 {
+			return
+		}
+		sofar << buf[..n]
+	}
+	conn.write_string('HTTP/1.1 200 OK\r\nTransfer-Encoding: xchunked\r\n\r\n${vh1t_te_ext_early}') or {
+		return
+	}
+	time.sleep(400 * time.millisecond)
+	conn.write_string(vh1t_te_ext_rest) or { return }
+}
+
+fn test_vschannel_h1_transfer_encoding_extension_token_is_not_chunked() {
+	mut port_listener := net.listen_tcp(.ip, '127.0.0.1:0') or {
+		assert false, 'port: ${err}'
+		return
+	}
+	port := port_listener.addr() or {
+		assert false, 'addr: ${err}'
+		return
+	}.port() or {
+		assert false, 'addr.port: ${err}'
+		return
+	}
+	port_listener.close() or {}
+	mut listener := mbedtls.new_ssl_listener('127.0.0.1:${port}', mbedtls.SSLConnectConfig{
+		cert:     vh1t_cert_path
+		cert_key: vh1t_key_path
+		validate: false
+	}) or {
+		assert false, 'listener: ${err}'
+		return
+	}
+	th := spawn fn (mut l mbedtls.SSLListener) {
+		mut conn := l.accept() or { return }
+		vh1t_serve_xchunked(mut conn)
+	}(mut listener)
+
+	resp := fetch(
+		url:          'https://127.0.0.1:${port}/'
+		validate:     false
+		enable_http2: false
+	) or {
+		assert false, 'fetch: ${err}'
+		return
+	}
+
+	assert resp.status_code == 200
+	// parse_response leaves an unknown transfer coding's body raw (its own
+	// has_header_token only matches real comma-separated `chunked` tokens),
+	// so the full raw bytes -- including everything after the fake chunk
+	// terminator -- must survive to here.
+	assert resp.body == vh1t_te_ext_early + vh1t_te_ext_rest, 'body truncated at a fake chunk terminator inside a non-chunked (extension-coded) response'
+
+	listener.shutdown() or {}
+	th.wait()
+}

--- a/vlib/net/http/vschannel_h1_windows_test.v
+++ b/vlib/net/http/vschannel_h1_windows_test.v
@@ -1,0 +1,90 @@
+module http
+
+import net
+import net.mbedtls
+import time
+
+// Regression coverage for vlang/v#27705: the one-shot vschannel HTTP/1.1
+// client (vschannel_h1_do/vschannel_h1_on_open, thirdparty/vschannel/
+// vschannel.c) used to have no way to know a response was complete other
+// than the peer closing the connection or sending a TLS close_notify. HTTP/
+// 1.1 keep-alive is the default -- a compliant server is free to leave the
+// connection open after responding -- so a peer that does that stalled the
+// client for as long as the peer chose to keep the socket open.
+
+const vh1t_cert_path = @VEXEROOT +
+	'/vlib/net/websocket/tests/autobahn/fuzzing_server_wss/config/server.crt'
+const vh1t_key_path = @VEXEROOT +
+	'/vlib/net/websocket/tests/autobahn/fuzzing_server_wss/config/server.key'
+const vh1t_body = 'hello from a keep-alive peer'
+
+// vh1t_serve_one responds once, then holds the connection open for longer
+// than the test's own completion-time bound before finally closing --
+// exactly what a compliant HTTP/1.1 keep-alive peer is allowed to do. Bounded
+// (rather than left open forever) so this test cannot hang indefinitely even
+// if the fix regresses; the assertion below only needs the client to finish
+// well before the server closes, not for the server to never close at all.
+fn vh1t_serve_one(mut conn mbedtls.SSLConn) {
+	defer {
+		conn.shutdown() or {}
+	}
+	conn.set_read_timeout(10 * time.second)
+	mut buf := []u8{len: 4096}
+	mut sofar := []u8{}
+	for !sofar.bytestr().contains('\r\n\r\n') {
+		n := conn.read(mut buf) or { return }
+		if n <= 0 {
+			return
+		}
+		sofar << buf[..n]
+	}
+	conn.write_string('HTTP/1.1 200 OK\r\nContent-Length: ${vh1t_body.len}\r\n\r\n${vh1t_body}') or {
+		return
+	}
+	time.sleep(3 * time.second)
+}
+
+fn test_vschannel_h1_one_shot_does_not_wait_for_keep_alive_peer_to_close() {
+	mut port_listener := net.listen_tcp(.ip, '127.0.0.1:0') or {
+		assert false, 'port: ${err}'
+		return
+	}
+	port := port_listener.addr() or {
+		assert false, 'addr: ${err}'
+		return
+	}.port() or {
+		assert false, 'addr.port: ${err}'
+		return
+	}
+	port_listener.close() or {}
+	mut listener := mbedtls.new_ssl_listener('127.0.0.1:${port}', mbedtls.SSLConnectConfig{
+		cert:     vh1t_cert_path
+		cert_key: vh1t_key_path
+		validate: false
+	}) or {
+		assert false, 'listener: ${err}'
+		return
+	}
+	th := spawn fn (mut l mbedtls.SSLListener) {
+		mut conn := l.accept() or { return }
+		vh1t_serve_one(mut conn)
+	}(mut listener)
+
+	started := time.now()
+	resp := fetch(
+		url:          'https://127.0.0.1:${port}/'
+		validate:     false
+		enable_http2: false
+	) or {
+		assert false, 'fetch: ${err}'
+		return
+	}
+	elapsed := time.now() - started
+
+	assert resp.status_code == 200
+	assert resp.body == vh1t_body
+	assert elapsed < 1500 * time.millisecond, 'expected the one-shot client to stop reading once Content-Length bytes arrived, not wait for the keep-alive peer to close -- took ${elapsed}'
+
+	listener.shutdown() or {}
+	th.wait()
+}


### PR DESCRIPTION
## Summary

`https_make_request` (`thirdparty/vschannel/vschannel.c`), the core of
vschannel's one-shot HTTP/1.1 client (used both when HTTP/2 is disabled and
as the ALPN-negotiation-failed fallback), previously read the response
until the peer closed the connection or sent a TLS close_notify -- it never
parsed `Content-Length` or chunked `Transfer-Encoding` to know the response
was already complete.

HTTP/1.1 keep-alive is the default: a compliant server is free to leave the
connection open after responding. Against such a server, the client
blocked in `recv()` until the peer's own idle-read timeout eventually
forced it to give up and close the socket -- there was no bound on the
client's own side at all. This was found while adding HTTP/2 connection
pooling for the Windows SChannel backend (#27702): a test exercising the
ALPN-negotiation-failed fallback against a realistic keep-alive loopback
server took ~41 seconds instead of being near-instant.

- Adds a small set of static helpers to `https_make_request` that inspect
  the response bytes accumulated so far for a complete Content-Length-framed
  or fully-received chunked body, and stop the read loop as soon as one is
  found.
- Deliberately conservative: anything the helpers cannot confidently parse
  (headers not yet complete, no length-framing header present, a malformed
  length value) reports "incomplete" and falls back to the existing
  read-until-close/read-until-context-expired behavior, which remains
  correct in every case -- these helpers only ever add an *earlier* stopping
  point, never a different one.
- Guards the length accumulators against integer overflow (`long` is 32-bit
  even in 64-bit Windows builds) so a malformed/absurd length can never wrap
  into a small value and cause a premature, truncating stop -- caught and
  fixed during self-review before this was pushed.

Fixes #27705.

## Test plan

- [x] New regression test (`vschannel_h1_windows_test.v`) reproduces the
      exact reported symptom against a loopback keep-alive server, and was
      verified with a Phase-R-style stash/reproduce cycle to fail on the
      pre-fix code (~3.1s, waiting for the peer's own close) before
      confirming it passes fast (well under the 1.5s bound) on the fix
- [x] `./vnew test vlib/net/http/` -- 25 passed, 2 skipped (unrelated,
      network-dependent), on this standalone branch
- [x] `/vreview` (full A-G angles + mechanical detectors) -- one finding
      (the integer-overflow guard above), fixed before push

Co-Authored-By: WOZCODE <contact@withwoz.com>