### PR TITLE
markused,gen: fix direct `str()`call on a smart-casted interface variable

### DIFF
--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -335,6 +335,24 @@ fn test_windows_sharedlive_string_interpolation_in_ternary_does_not_emit_inline_
 	assert compilation.output.contains('builtin__str_intp')
 }
 
+fn test_interface_match_smartcast_direct_str_call() {
+	os.chdir(vroot) or {}
+	test_source := os.join_path(os.vtmp_dir(), 'coutput_interface_match_smartcast_str_intp.vv')
+	test_exe := os.join_path(os.vtmp_dir(), 'coutput_interface_match_smartcast_str_intp')
+	os.write_file(test_source,
+		"module main\n\ninterface Value {}\n\nfn get_str(v Value) string {\n\treturn match v {\n\t\tint {\n\t\t\tv.str()\n\t\t}\n\t\telse {\n\t\t\t''\n\t\t}\n\t}\n}\n\nfn main() {\n\tprintln(get_str(42))\n}\n")!
+	defer {
+		os.rm(test_source) or {}
+		os.rm(test_exe) or {}
+	}
+	build_cmd := '${os.quoted_path(vexe)} -o ${os.quoted_path(test_exe)} ${os.quoted_path(test_source)}'
+	build_result := os.execute(build_cmd)
+	ensure_compilation_succeeded(build_result, build_cmd)
+	run_result := os.execute(os.quoted_path(test_exe))
+	assert run_result.exit_code == 0
+	assert run_result.output.trim_space() == '42'
+}
+
 fn test_simple_string_interpolation_does_not_emit_str_intp_runtime() {
 	os.chdir(vroot) or {}
 	test_source := os.join_path(os.vtmp_dir(), 'coutput_simple_interpolation_no_str_intp.vv')

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -181,6 +181,14 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		&& (g.table.final_sym(g.unwrap_generic((expr.obj as ast.Var).typ)).kind == .interface
 		|| ((expr.obj as ast.Var).orig_type != 0
 		&& g.table.final_sym(g.unwrap_generic((expr.obj as ast.Var).orig_type)).kind == .interface))
+	// An interface variable smart-cast to a primitive value
+	// type is still boxed via a pointer in C, but that pointer is only cgen's
+	// internal boxing representation -- not a real reference/pointer value the
+	// user asked to print. Rebinding first (`x := v; x.str()`) already prints
+	// the plain value with no `&`; calling `.str()` directly on `v` should
+	// behave the same way.
+	is_interface_smartcast_boxed_primitive := is_ptr && expr is ast.Ident && expr.obj is ast.Var
+		&& (expr.obj as ast.Var).orig_type != 0 && g.table.final_sym(g.unwrap_generic((expr.obj as ast.Var).orig_type)).kind == .interface && g.table.final_sym(g.unwrap_generic(typ.deref())).kind !in [.struct, .interface, .sum_type, .array, .array_fixed, .map, .multi_return]
 	if typ.has_flag(.variadic) {
 		str_fn_name := g.get_str_fn(typ)
 		g.write('${str_fn_name}(')
@@ -264,7 +272,11 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 			g.write(line)
 		}
 		if is_ptr && !is_var_mut {
-			ref_str := '&'.repeat(typ.nr_muls())
+			ref_str := if is_interface_smartcast_boxed_primitive {
+				''
+			} else {
+				'&'.repeat(typ.nr_muls())
+			}
 			g.write('builtin__str_intp(1, _MOV((StrIntpData[]){{_S("${ref_str}"), ${si_s_code}, {.d_s = builtin__isnil(')
 			if typ.has_flag(.option) || mut_arg_option_type != 0 {
 				if mut_arg_option_type != 0 {

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -982,6 +982,21 @@ fn (mut w Walker) expr(node_ ast.Expr) {
 				}
 			} else if node.is_method && node.name == 'str' {
 				w.uses_str[node.left_type] = true
+				// cgen may unbox the receiver via its raw (still pointer-flagged)
+				// smartcast type instead of node.left_type, requiring str_intp
+				// support that this pass would otherwise miss.
+				if node.left is ast.Ident {
+					left_ident := node.left as ast.Ident
+					if left_ident.obj is ast.Var {
+						v := left_ident.obj as ast.Var
+						if v.smartcasts.len > 0 {
+							raw_smartcast_typ := v.smartcasts.last()
+							if raw_smartcast_typ.is_ptr() {
+								w.uses_str[raw_smartcast_typ] = true
+							}
+						}
+					}
+				}
 			} else if node.is_method && node.name == 'free' {
 				w.uses_free[node.left_type] = true
 			} else if node.is_method && node.name == 'clone' && !w.uses_arr_clone


### PR DESCRIPTION
# Fixes #27713

## Problem

Calling `.str()` directly on an interface variable that's been smart-cast to a primitive type inside a `match` branch (without rebinding it to a new variable first) had two separate bugs:

1. It crashed the C compiler instead of producing a working binary:
```
cc: error: call to undeclared function 'builtin__str_intp'
cc: error: use of undeclared identifier 'StrIntpData'
```

2. Once that crash was fixed, the printed result was wrong: `&42` instead of `42`

Minimal repro:
```v
interface Value {}

fn get_str(v Value) string {
	return match v {
		int { v.str() }
		else { '' }
	}
}

fn main() {
	println(get_str(42))
}
```

Note: rebinding first (`x := v; x.str()`) avoids both issues, which was the
first clue pointing at cgen/dead-code-elimination rather than the checker.

## Cause

Interfaces box non-pointer-kind variants (like `int`) behind an allocated pointer in C (`_int` is stored as `int*`). For a direct `.str()` call on a smart-cast identifier, cgen resolves the receiver using the *raw* internal smartcast type, which still carries that pointer flag — unlike the "exposed" V-level type (plain `int`) that the checker and `node.left_type` use.

This raw, pointer-flagged type causes two independent problems:

1. `markused/walker.v` decides whether to keep `str_intp` (the string interpolation runtime) based on `node.left_type` (plain `int`, no pointer flag), so it never learns that cgen's pointer-flagged code path will actually need `str_intp`, and strips it from the final C output.
2. `gen_expr_to_string()` in `str.v` treats any pointer-flagged type as "this is a real reference the user wants printed with `&`" — correct for genuine pointers/structs stored by reference, but not for a primitive value that only *looks* like a pointer because of interface boxing.

## Fix

- `markused/walker.v`: when registering `.str()` usage, also check whether the receiver is a smart-cast identifier whose raw smartcast type is a pointer, and register that type too, so `str_intp`/`StrIntpData` aren't stripped when cgen will actually need them.
- `str.v`: detect the same case (an interface variable smart-cast to a primitive/non struct-like type) and use an empty ref prefix instead of `&`, leaving all other pointer/struct/reference printing behavior unchanged.

## Test

Regression test added.