### PR TITLE
net.http: fix vschannel https_make_request() buffer leaks on Windows

### DIFF
--- a/thirdparty/vschannel/vschannel.c
+++ b/thirdparty/vschannel/vschannel.c
@@ -1431,6 +1431,7 @@ static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, DWORD 
 		scRet = tls_ctx->sspi->EncryptMessage(&tls_ctx->h_context, 0, &Message, 0);
 		if(FAILED(scRet)) {
 			wprintf(L"Error 0x%x returned by EncryptMessage\n", scRet);
+			LocalFree(pbIoBuffer);
 			return scRet;
 		}
 
@@ -1442,6 +1443,7 @@ static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, DWORD 
 			if(cbData == SOCKET_ERROR || cbData == 0) {
 				wprintf(L"Error %d sending data to server (3)\n", WSAGetLastError());
 				tls_ctx->sspi->DeleteSecurityContext(&tls_ctx->h_context);
+				LocalFree(pbIoBuffer);
 				return SEC_E_INTERNAL_ERROR;
 			}
 			sent += (DWORD)cbData;
@@ -1467,6 +1469,7 @@ static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, DWORD 
 				if(cbIoBuffer) {
 					wprintf(L"Server unexpectedly disconnected\n");
 					scRet = SEC_E_INTERNAL_ERROR;
+					LocalFree(pbIoBuffer);
 					return scRet;
 				}
 				else {
@@ -1510,6 +1513,7 @@ static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, DWORD 
 			scRet != SEC_I_CONTEXT_EXPIRED)
 		{
 			wprintf(L"Error 0x%x returned by DecryptMessage\n", scRet);
+			LocalFree(pbIoBuffer);
 			return scRet;
 		}
 
@@ -1534,6 +1538,7 @@ static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, DWORD 
 			CHAR *a = afn(*out, required_length);
 			if( a == NULL ) {
 				scRet = SEC_E_INTERNAL_ERROR;
+				LocalFree(pbIoBuffer);
 				return scRet;
 			}
 			*out = a;
@@ -1557,6 +1562,7 @@ static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, DWORD 
 			// The server wants to perform another handshake sequence.
 			scRet = client_handshake_loop(tls_ctx, FALSE, &ExtraBuffer);
 			if(scRet != SEC_E_OK) {
+				LocalFree(pbIoBuffer);
 				return scRet;
 			}
 
@@ -1565,10 +1571,12 @@ static SECURITY_STATUS https_make_request(TlsContext *tls_ctx, CHAR *req, DWORD 
 			{
 				MoveMemory(pbIoBuffer, ExtraBuffer.pvBuffer, ExtraBuffer.cbBuffer);
 				cbIoBuffer = ExtraBuffer.cbBuffer;
+				LocalFree(ExtraBuffer.pvBuffer);
 			}
 		}
 	}
 
+	LocalFree(pbIoBuffer);
 	return SEC_E_OK;
 }
 


### PR DESCRIPTION
## Summary
- `pbIoBuffer` in `thirdparty/vschannel/vschannel.c`'s `https_make_request()` was allocated via `LocalAlloc` but never freed on any of the function's 7 return paths, leaking on every one-shot HTTP/1.1 request through vschannel (used when HTTP/2 is disabled, or as the ALPN-negotiation-failed fallback).
- `ExtraBuffer.pvBuffer` (allocated by `client_handshake_loop()` during a mid-request TLS renegotiation) had the same gap; the sibling function `vschannel_read()` already frees the identical allocation correctly, so this was a missed parity case.
- Both are pre-existing and predate #27705 (which only touched the read loop's completion detection).

Fixes #27716, which has the full writeup and empirical proof (buggy-vs-patched memory measurement over 400 one-shot requests: buggy build leaks ~18 KB/call indefinitely, patched build plateaus).

## Test plan
- [x] `./vnew.exe -silent test vlib/net/http/` — 24 passed, 2 skipped (unchanged from before the fix)
- [x] `./vnew.exe -d no_vschannel -silent test vlib/net/http/` — 24 passed, 2 skipped (unchanged)
- [x] Phase-R repro: measured process working-set growth over 400 sequential one-shot HTTPS requests against a local test server, once on unpatched `vschannel.c` (steady-state ~18 KB/call, unbounded) and once on patched (~3.7 KB/call, plateaus) — see #27716 for the full table

🧙 Built with [WOZCODE](https://wozcode.com)