### PR TITLE
cgen: prefer exact alias tags in sumtype match

### DIFF
--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -237,8 +237,8 @@ fn (mut g Gen) match_expr_sumtype(node ast.MatchExpr, is_expr bool, cond_var str
 				ce := unsafe { &branch.exprs[sumtype_index] }
 				if ce is ast.TypeNode {
 					variant_type := g.unwrap_generic(g.recheck_concrete_type(ce.typ))
-					all_idx_exprs := g.matching_sumtype_variant_type_idx_exprs(node.cond_type,
-						variant_type)
+					all_idx_exprs := g.type_idx_exprs_for_types(g.matching_sumtype_match_branch_variant_types(node.cond_type,
+						variant_type))
 					if use_ternary {
 						// Ternary `?:` chains cannot drop an arm, so keep every tag.
 						sumtype_fresh_idx_exprs = all_idx_exprs.clone()

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -769,6 +769,16 @@ fn (mut g Gen) matching_sumtype_variant_types(parent_type ast.Type, target_type 
 	return [target_type]
 }
 
+fn (mut g Gen) matching_sumtype_match_branch_variant_types(parent_type ast.Type, target_type ast.Type) []ast.Type {
+	variants := g.sumtype_runtime_variants(parent_type)
+	for variant in variants {
+		if g.is_exact_sumtype_variant_match(variant, target_type) {
+			return [variant]
+		}
+	}
+	return g.matching_sumtype_variant_types(parent_type, target_type)
+}
+
 fn (mut g Gen) matching_sumtype_variant_type_idx_exprs(parent_type ast.Type, target_type ast.Type) []string {
 	return g.type_idx_exprs_for_types(g.matching_sumtype_variant_types(parent_type, target_type))
 }

--- a/vlib/v/tests/aliases/alias_is_match_runtime_tag_test.v
+++ b/vlib/v/tests/aliases/alias_is_match_runtime_tag_test.v
@@ -130,10 +130,13 @@ fn test_sumtype_is_alias_matches_original_variant_tag() {
 	assert v is AliasTagNullAlias
 }
 
-fn test_sumtype_match_alias_matches_original_variant_tag() {
+fn test_sumtype_match_alias_branch_prefers_alias_variant_tag_when_alias_is_variant() {
 	v := AliasTagSumWithAlias(AliasTagNull{})
 	match v {
 		AliasTagNullAlias {
+			assert false
+		}
+		AliasTagNull {
 			assert true
 		}
 		else {
@@ -147,10 +150,13 @@ fn test_sumtype_is_original_matches_alias_variant_tag() {
 	assert v is AliasTagNull
 }
 
-fn test_sumtype_match_original_matches_alias_variant_tag() {
+fn test_sumtype_match_original_branch_prefers_original_variant_tag_when_alias_is_variant() {
 	v := AliasTagSumWithAlias(AliasTagNullAlias{})
 	match v {
 		AliasTagNull {
+			assert false
+		}
+		AliasTagNullAlias {
 			assert true
 		}
 		else {
@@ -184,7 +190,7 @@ fn aggregate_branch_is_original(v AliasTagSumWithAlias) bool {
 
 fn aggregate_branch_is_alias(v AliasTagSumWithAlias) bool {
 	match v {
-		AliasTagNull, int {
+		AliasTagNullAlias, int {
 			return v is AliasTagNullAlias
 		}
 		else {
@@ -193,9 +199,32 @@ fn aggregate_branch_is_alias(v AliasTagSumWithAlias) bool {
 	}
 }
 
-fn test_sumtype_is_in_aggregate_branch_matches_alias_tags() {
-	assert aggregate_branch_is_original(AliasTagSumWithAlias(AliasTagNullAlias{}))
+fn test_sumtype_match_aggregate_branch_uses_exact_alias_tags() {
+	assert aggregate_branch_is_original(AliasTagSumWithAlias(AliasTagNull{}))
+	assert !aggregate_branch_is_alias(AliasTagSumWithAlias(AliasTagNull{}))
+	assert !aggregate_branch_is_original(AliasTagSumWithAlias(AliasTagNullAlias{}))
 	assert aggregate_branch_is_alias(AliasTagSumWithAlias(AliasTagNullAlias{}))
 	assert !aggregate_branch_is_original(AliasTagSumWithAlias(1))
 	assert !aggregate_branch_is_alias(AliasTagSumWithAlias(1))
+}
+
+type Issue27718RawOffset = i8
+type Issue27718SPOffset = Issue27718RawOffset
+type Issue27718Offset = Issue27718RawOffset | Issue27718SPOffset
+
+fn (o Issue27718Offset) str() string {
+	return match o {
+		Issue27718SPOffset {
+			sign := if i8(o) < 0 { '' } else { '+' }
+			'SP${sign}${Issue27718RawOffset(o)}'
+		}
+		Issue27718RawOffset {
+			o.str()
+		}
+	}
+}
+
+fn test_sumtype_match_uses_exact_alias_variant_tag_for_chained_aliases() {
+	assert Issue27718Offset(Issue27718SPOffset(42)).str() == 'SP+42'
+	assert Issue27718Offset(Issue27718RawOffset(42)).str() == '42'
 }


### PR DESCRIPTION
Fixes #27718

This makes sumtype `match` branch dispatch prefer the exact runtime tag when the branch type is itself a declared variant. Alias-compatible tag matching is still used as a fallback for aliases that are not explicit variants of the matched sum type.

Tests:
- `./vnew vlib/v/tests/aliases/alias_is_match_runtime_tag_test.v`
- `./vnew -e <issue 27718 reproduction>`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew -silent test vlib/v/`