### PR TITLE
fasthttp: preserve pointer-sized Windows sockets

### DIFF
--- a/vlib/fasthttp/fasthttp_windows.c.v
+++ b/vlib/fasthttp/fasthttp_windows.c.v
@@ -6,6 +6,10 @@ module fasthttp
 #include <windows.h>
 #include <ws2tcpip.h>
 
+// net also declares accept() for POSIX file descriptors. Keep this wrapper
+// module-specific so its pointer-sized Windows SOCKET return type is preserved.
+#define v_fasthttp_accept(s) accept((s), NULL, NULL)
+
 type C.DWORD = u32
 type C.ULONG_PTR = usize
 type C.SOCKET = usize
@@ -46,7 +50,7 @@ fn C.WSARecv(s C.SOCKET, lpBuffers &C.WSABUF, dwBufferCount C.DWORD, lpNumberOfB
 fn C.WSASend(s C.SOCKET, lpBuffers &C.WSABUF, dwBufferCount C.DWORD, lpNumberOfBytesSent &C.DWORD, dwFlags C.DWORD, lpOverlapped &C.OVERLAPPED, lpCompletionRoutine voidptr) i32
 fn C.WSAIoctl(s C.SOCKET, dwIoControlCode C.DWORD, lpvInBuffer voidptr, cbInBuffer C.DWORD, lpvOutBuffer voidptr, cbOutBuffer C.DWORD, lpcbBytesReturned &C.DWORD, lpOverlapped voidptr, lpCompletionRoutine voidptr) i32
 fn C.WSAGetLastError() i32
-fn C.accept(s C.SOCKET, addr voidptr, addrlen voidptr) C.SOCKET
+fn C.v_fasthttp_accept(s C.SOCKET) C.SOCKET
 fn C.bind(s C.SOCKET, addr voidptr, addrlen int) i32
 fn C.listen(s C.SOCKET, backlog int) i32
 fn C.send(s C.SOCKET, buf voidptr, len int, flags i32) i32

--- a/vlib/fasthttp/fasthttp_windows.v
+++ b/vlib/fasthttp/fasthttp_windows.v
@@ -675,7 +675,7 @@ fn process_iocp_events(server &Server) {
 
 fn accept_loop(server &Server) {
 	for !server.is_shutting_down() {
-		client_fd := C.accept(server.listen_fd, unsafe { nil }, unsafe { nil })
+		client_fd := C.v_fasthttp_accept(server.listen_fd)
 		if client_fd == iocp_invalid_socket {
 			if server.is_shutting_down() {
 				break

--- a/vlib/fasthttp/fasthttp_windows_regression_test.c.v
+++ b/vlib/fasthttp/fasthttp_windows_regression_test.c.v
@@ -1,0 +1,8 @@
+// vtest build: windows
+module fasthttp
+
+fn test_accept_wrapper_preserves_pointer_sized_socket() {
+	client_fd := C.v_fasthttp_accept(iocp_invalid_socket)
+	assert sizeof(client_fd) == sizeof(C.SOCKET)
+	assert sizeof(client_fd) == sizeof(usize)
+}


### PR DESCRIPTION
## Summary

- isolate the Windows accept call behind a fasthttp-specific C wrapper
- keep accepted Winsock SOCKET values pointer-sized through IOCP registration
- add Windows regression coverage for the accepted socket width

## Why

The imported net module also declares C.accept with an i32 return type for POSIX file descriptors. Since C declarations share the same symbol, the Windows fasthttp accept loop generated an i32 client_fd even though Windows SOCKET is pointer-sized. On 64-bit Windows that can truncate the accepted socket before it is registered with IOCP, resulting in invalid handles and crashes.

## Testing

- ./vnew fmt -w vlib/fasthttp/fasthttp_windows.c.v vlib/fasthttp/fasthttp_windows.v vlib/fasthttp/fasthttp_windows_regression_test.c.v
- ./vnew -silent test vlib/fasthttp/
- generated the Windows TCC C output and verified it contains C__SOCKET client_fd
- cross-compiled examples/fasthttp for Windows with x86_64-w64-mingw32-gcc
- git diff --check