### PR TITLE
builder, tools: include build flags and full V source in C error bug reports

### DIFF
--- a/cmd/tools/modules/vbugreport/c_error_storage.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage.v
@@ -4,26 +4,33 @@ import os
 
 pub struct StoredCErrorReport {
 pub:
-	c_file_name  string
-	target_os    string
-	ccompiler    string
-	error_string string
-	lines        string
-	v_lines      string
+	c_file_name   string
+	target_os     string
+	ccompiler     string
+	arch          string
+	build_options string
+	error_string  string
+	lines         string
+	v_lines       string
+	v_source      string
 }
 
 // new_stored_c_error_report builds the fields stored by the C error report receiver.
 // The generated C context is stored in `lines`, while the corresponding V source
 // context (the V line that caused the C error and its surrounding lines) is stored
-// separately in `v_lines`.
-pub fn new_stored_c_error_report(c_file string, target_os string, ccompiler string, c_error string, c_lines []string, v_lines []string) StoredCErrorReport {
+// separately in `v_lines`. `arch`, `build_options` (the codegen-affecting `v` flags) and
+// `v_source` (the full failing V file) are stored so a report can be reproduced.
+pub fn new_stored_c_error_report(c_file string, target_os string, ccompiler string, arch string, build_options string, c_error string, c_lines []string, v_lines []string, v_source string) StoredCErrorReport {
 	return StoredCErrorReport{
-		c_file_name:  normalized_file_name(c_file)
-		target_os:    target_os
-		ccompiler:    ccompiler
-		error_string: c_error_string(c_error)
-		lines:        c_lines.join('\n')
-		v_lines:      v_lines.join('\n')
+		c_file_name:   normalized_file_name(c_file)
+		target_os:     target_os
+		ccompiler:     ccompiler
+		arch:          arch
+		build_options: build_options
+		error_string:  c_error_string(c_error)
+		lines:         c_lines.join('\n')
+		v_lines:       v_lines.join('\n')
+		v_source:      v_source
 	}
 }
 

--- a/cmd/tools/modules/vbugreport/c_error_storage.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage.v
@@ -19,7 +19,8 @@ pub:
 // The generated C context is stored in `lines`, while the corresponding V source
 // context (the V line that caused the C error and its surrounding lines) is stored
 // separately in `v_lines`. `arch`, `build_options` (the codegen-affecting `v` flags) and
-// `v_source` (the full failing V file) are stored so a report can be reproduced.
+// `v_source` (the block of failing V source around the error line) are stored so a report can
+// be reproduced.
 pub fn new_stored_c_error_report(c_file string, target_os string, ccompiler string, arch string, build_options string, c_error string, c_lines []string, v_lines []string, v_source string) StoredCErrorReport {
 	return StoredCErrorReport{
 		c_file_name:   normalized_file_name(c_file)

--- a/cmd/tools/modules/vbugreport/c_error_storage.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage.v
@@ -19,8 +19,8 @@ pub:
 // The generated C context is stored in `lines`, while the corresponding V source
 // context (the V line that caused the C error and its surrounding lines) is stored
 // separately in `v_lines`. `arch`, `build_options` (the codegen-affecting `v` flags) and
-// `v_source` (the block of failing V source around the error line) are stored so a report can
-// be reproduced.
+// `v_source` (the failing file's leading declarations plus the block around the error line) are
+// stored so a report can be reproduced.
 pub fn new_stored_c_error_report(c_file string, target_os string, ccompiler string, arch string, build_options string, c_error string, c_lines []string, v_lines []string, v_source string) StoredCErrorReport {
 	return StoredCErrorReport{
 		c_file_name:   normalized_file_name(c_file)

--- a/cmd/tools/modules/vbugreport/c_error_storage_test.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage_test.v
@@ -1,24 +1,27 @@
 module vbugreport
 
 fn test_new_stored_c_error_report_extracts_sql_fields() {
-	report := new_stored_c_error_report('/tmp/v/program.tmp.c', 'linux', 'clang',
-		'/tmp/v/program.tmp.c:12:7: error: unknown type name "Foo"', [
+	report := new_stored_c_error_report('/tmp/v/program.tmp.c', 'linux', 'clang', 'amd64',
+		'autofree gc:boehm', '/tmp/v/program.tmp.c:12:7: error: unknown type name "Foo"', [
 		'void main__main(void) {',
 		'\tFoo x;',
 	], [
 		'foo := Foo{}',
-	])
+	], 'fn main() {\n\tfoo := Foo{}\n}')
 	assert report.c_file_name == 'program.tmp.c'
 	assert report.target_os == 'linux'
 	assert report.ccompiler == 'clang'
+	assert report.arch == 'amd64'
+	assert report.build_options == 'autofree gc:boehm'
 	assert report.error_string == 'error: unknown type name "Foo"'
 	assert report.lines == 'void main__main(void) {\n\tFoo x;'
 	assert report.v_lines == 'foo := Foo{}'
+	assert report.v_source == 'fn main() {\n\tfoo := Foo{}\n}'
 }
 
 fn test_new_stored_c_error_report_handles_windows_c_file_path() {
-	report := new_stored_c_error_report('C:\\tmp\\program.tmp.c', 'windows', 'msvc',
-		'error: syntax error', []string{}, []string{})
+	report := new_stored_c_error_report('C:\\tmp\\program.tmp.c', 'windows', 'msvc', 'amd64', '',
+		'error: syntax error', []string{}, []string{}, '')
 	assert report.c_file_name == 'program.tmp.c'
 }
 

--- a/cmd/tools/vbug-report.v
+++ b/cmd/tools/vbug-report.v
@@ -24,7 +24,9 @@ pub:
 	v_version      string
 	target_os      string
 	target_backend string
+	arch           string
 	ccompiler      string
+	build_options  string
 	c_error        string
 	c_file         string
 	c_line         int
@@ -32,6 +34,7 @@ pub:
 	v_file         string
 	v_line         int
 	v_context      []ReportLine
+	v_source       string
 }
 
 struct CreateBugReportResponse {
@@ -199,11 +202,17 @@ fn init_db(db sqlite.DB) ! {
 				ccompiler text not null,
 				error_string text not null,
 				lines text not null,
-				v_lines text not null default ''
+				v_lines text not null default '',
+				arch text not null default '',
+				build_options text not null default '',
+				v_source text not null default ''
 			)")!
 	// Add columns that were introduced after the table already existed, so older
 	// databases pick them up without losing their stored reports.
 	ensure_column(db, 'bug_reports', 'v_lines', "text not null default ''")!
+	ensure_column(db, 'bug_reports', 'arch', "text not null default ''")!
+	ensure_column(db, 'bug_reports', 'build_options', "text not null default ''")!
+	ensure_column(db, 'bug_reports', 'v_source', "text not null default ''")!
 	db.exec('create index if not exists idx_bug_reports_created_at
 			on bug_reports(created_at)')!
 }
@@ -238,14 +247,15 @@ pub fn (mut app App) create(mut ctx Context) veb.Result {
 		return ctx.request_error('unsupported report kind')
 	}
 	stored_report := vbugreport.new_stored_c_error_report(report.c_file, report.target_os,
-		report.ccompiler, report.c_error, report.c_context.map(it.text),
-		report.v_context.map(it.text))
+		report.ccompiler, report.arch, report.build_options, report.c_error,
+		report.c_context.map(it.text), report.v_context.map(it.text), report.v_source)
 	id := new_report_id()
 	delete_token := rand.uuid_v4()
 	app.db.exec_param_many('insert into bug_reports (
 				id, delete_token, created_at, remote_ip, user_agent,
-				c_file_name, target_os, ccompiler, error_string, lines, v_lines
-			) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', [
+				c_file_name, target_os, ccompiler, error_string, lines, v_lines,
+				arch, build_options, v_source
+			) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', [
 		id,
 		delete_token,
 		time.utc().format_rfc3339(),
@@ -257,6 +267,9 @@ pub fn (mut app App) create(mut ctx Context) veb.Result {
 		stored_report.error_string,
 		stored_report.lines,
 		stored_report.v_lines,
+		stored_report.arch,
+		stored_report.build_options,
+		stored_report.v_source,
 	]) or { return ctx.server_error('could not store report') }
 	return ctx.json(CreateBugReportResponse{
 		id:           id

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -206,6 +206,10 @@ fn codegen_build_options(p &pref.Preferences) string {
 	if p.trace_calls {
 		opts << 'trace_calls'
 	}
+	if p.is_coverage {
+		// coverage adds instrumentation and stores output under coverage_dir.
+		opts << 'coverage:${p.coverage_dir}'
+	}
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'
 	}

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -247,6 +247,11 @@ fn codegen_build_options(p &pref.Preferences) string {
 		// drops the default `-std=c99` / `-D_DEFAULT_SOURCE` C flags, changing the C compiler command.
 		opts << 'no_std'
 	}
+	if p.no_rsp {
+		// passes C backend options directly on the command line instead of via a `.rsp` response
+		// file (should_use_rsp), so the C compiler is invoked differently.
+		opts << 'no_rsp'
+	}
 	if p.prealloc {
 		opts << 'prealloc'
 	}
@@ -353,13 +358,15 @@ fn selected_v_source(v_file string, mapped_lines []string, v_line int, input_pat
 }
 
 // v_source_for_report returns the V source needed to reproduce the C error without uploading the
-// whole file: the file's leading declarations plus the failing line's enclosing top-level block and
-// up to `radius` lines after it. The region starts at the enclosing declaration (including its
-// `@[...]` attributes), so it is a whole declaration rather than statements resuming after the
-// omission comment. The prefix is trimmed to a brace-balanced boundary within `prefix_lines`, so it
-// never ends inside a half-open declaration. Unrelated declarations in the middle are dropped. When
-// the failing region already reaches the prefix, one contiguous block is returned. It returns ''
-// when there is no mapped V line.
+// whole file: the file's leading declarations plus the failing line's whole enclosing top-level
+// declaration. The region starts at the enclosing declaration (including its `@[...]` attributes)
+// and ends at that declaration's balanced closing brace, so it is a complete declaration rather
+// than a `fn ... {` cut off before its body or statements resuming after the omission comment. For
+// a single-line top-level declaration (no block) up to `radius` lines after it are kept for
+// context. The prefix is trimmed to a brace-balanced boundary within `prefix_lines`, so it never
+// ends inside a half-open declaration. Unrelated declarations in the middle are dropped. When the
+// failing region already reaches the prefix, one contiguous block is returned. It returns '' when
+// there is no mapped V line.
 fn v_source_for_report(lines []string, center int, radius int, prefix_lines int) string {
 	if center <= 0 || lines.len == 0 {
 		return ''
@@ -367,7 +374,16 @@ fn v_source_for_report(lines []string, center int, radius int, prefix_lines int)
 	// begin at the enclosing declaration of the failing line, so the region is a whole block and
 	// never starts in the middle of a function body (or on a stray closing brace).
 	region_start := enclosing_decl_start(lines, center)
-	region_end := if center + radius > lines.len { lines.len } else { center + radius }
+	// end at the enclosing declaration's balanced closing brace, so the block is not cut open; a
+	// single-line declaration (no block) keeps up to `radius` lines of context after the failure.
+	decl_end := enclosing_decl_end(lines, region_start)
+	region_end := if decl_end > region_start {
+		decl_end
+	} else if center + radius > lines.len {
+		lines.len
+	} else {
+		center + radius
+	}
 	// The failing region already includes (or directly follows) the prefix: keep it contiguous.
 	if region_start <= prefix_lines + 1 {
 		return lines[..region_end].join('\n')
@@ -407,6 +423,33 @@ fn enclosing_decl_start(lines []string, from_line int) int {
 		i--
 	}
 	return i
+}
+
+// enclosing_decl_end scans downward from `start` (1-based) to the line that closes the block opened
+// by the declaration there, by counting `{`/`}` until the depth returns to 0. It returns that line,
+// or `lines.len` if the block never closes (truncated/malformed), or `start` when the declaration
+// opens no block at all (a single-line `const`/`import`, or a one-line `fn f() { ... }`). Like the
+// prefix trimming it is a brace-counting heuristic and does not track braces inside literals.
+fn enclosing_decl_end(lines []string, start int) int {
+	if start < 1 || start > lines.len {
+		return if start < 1 { 1 } else { lines.len }
+	}
+	mut depth := 0
+	mut opened := false
+	for i := start; i <= lines.len; i++ {
+		for ch in lines[i - 1] {
+			if ch == `{` {
+				depth++
+				opened = true
+			} else if ch == `}` && depth > 0 {
+				depth--
+			}
+		}
+		if opened && depth == 0 {
+			return i
+		}
+	}
+	return if opened { lines.len } else { start }
 }
 
 // balanced_prefix_end returns how many leading lines of `lines` (at most `max_lines`) can be kept

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -374,10 +374,12 @@ fn v_source_for_report(lines []string, center int, radius int, prefix_lines int)
 	// begin at the enclosing declaration of the failing line, so the region is a whole block and
 	// never starts in the middle of a function body (or on a stray closing brace).
 	region_start := enclosing_decl_start(lines, center)
-	// end at the enclosing declaration's balanced closing brace, so the block is not cut open; a
-	// single-line declaration (no block) keeps up to `radius` lines of context after the failure.
-	decl_end := enclosing_decl_end(lines, region_start)
-	region_end := if decl_end > region_start {
+	// end at the enclosing declaration's balanced closing brace, so the block is not cut open. The
+	// close is only accepted at or after the failing line, so a `}` inside a string/comment before
+	// it cannot end the region early and drop the failing line. `0` => no such block end (a
+	// single-line declaration, or unbalanced): keep up to `radius` lines of context after it.
+	decl_end := enclosing_decl_end(lines, region_start, center)
+	region_end := if decl_end > 0 {
 		decl_end
 	} else if center + radius > lines.len {
 		lines.len
@@ -426,13 +428,15 @@ fn enclosing_decl_start(lines []string, from_line int) int {
 }
 
 // enclosing_decl_end scans downward from `start` (1-based) to the line that closes the block opened
-// by the declaration there, by counting `{`/`}` until the depth returns to 0. It returns that line,
-// or `lines.len` if the block never closes (truncated/malformed), or `start` when the declaration
-// opens no block at all (a single-line `const`/`import`, or a one-line `fn f() { ... }`). Like the
-// prefix trimming it is a brace-counting heuristic and does not track braces inside literals.
-fn enclosing_decl_end(lines []string, start int) int {
+// by the declaration there, by counting `{`/`}` until the depth returns to 0. The close is only
+// accepted at or after `min_line` (the failing line), so a `}` inside a string or comment earlier in
+// the declaration cannot end the block before the failing line and drop it from the region. It
+// returns that line, or `0` when the declaration opens no block (a single-line `const`/`import`, or
+// a one-line `fn f() { ... }`) or its braces never balance at/after `min_line` (unbalanced, or a
+// literal/comment brace miscount). Like the prefix trimming it does not track braces inside literals.
+fn enclosing_decl_end(lines []string, start int, min_line int) int {
 	if start < 1 || start > lines.len {
-		return if start < 1 { 1 } else { lines.len }
+		return 0
 	}
 	mut depth := 0
 	mut opened := false
@@ -445,11 +449,11 @@ fn enclosing_decl_end(lines []string, start int) int {
 				depth--
 			}
 		}
-		if opened && depth == 0 {
+		if opened && depth == 0 && i >= min_line {
 			return i
 		}
 	}
-	return if opened { lines.len } else { start }
+	return 0
 }
 
 // balanced_prefix_end returns how many leading lines of `lines` (at most `max_lines`) can be kept

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -143,6 +143,10 @@ fn codegen_build_options(p &pref.Preferences) string {
 	if p.is_prod {
 		opts << 'prod'
 	}
+	if p.no_prod_options {
+		// suppresses the default -O3/-flto prod C flags (cc.v), changing the C compiler command.
+		opts << 'no_prod_options'
+	}
 	if p.is_debug {
 		// `-g` sets is_vlines (V `#line` output), `-cg` does not (C-line debug mode);
 		// they produce different generated C, so distinguish them for reproduction.
@@ -203,8 +207,19 @@ fn codegen_build_options(p &pref.Preferences) string {
 		// the profile output path is embedded in the generated C (the `fopen(...)` call).
 		opts << 'profile:${p.profile_file}'
 	}
+	if p.profile_no_inline {
+		opts << 'profile_no_inline'
+	}
+	if p.profile_fns.len > 0 {
+		// cgen only instruments the selected functions, so the set changes the generated C.
+		opts << 'profile_fns:${p.profile_fns.join(',')}'
+	}
 	if p.trace_calls {
 		opts << 'trace_calls'
+	}
+	if p.trace_fns.len > 0 {
+		// the transformer only injects tracing into the matching functions.
+		opts << 'trace_fns:${p.trace_fns.join(',')}'
 	}
 	if p.is_coverage {
 		// coverage adds instrumentation and stores output under coverage_dir.

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -139,10 +139,9 @@ fn codegen_build_options(p &pref.Preferences) string {
 		opts << 'prod'
 	}
 	if p.is_debug {
-		opts << '-g'
-	}
-	if p.is_vlines {
-		opts << 'vlines'
+		// `-g` sets is_vlines (V `#line` output), `-cg` does not (C-line debug mode);
+		// they produce different generated C, so distinguish them for reproduction.
+		opts << if p.is_vlines { '-g' } else { '-cg' }
 	}
 	if p.skip_unused {
 		opts << 'skip_unused'

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -180,15 +180,12 @@ fn codegen_build_options(p &pref.Preferences) string {
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'
 	}
-	// custom `-d`/`-define` values, since `$if foo ?` and `$d()` can select different
-	// source and codegen (so a report from `v -d foo file.v` must record `foo`, and one
-	// from `v -d pad=7 file.v` must record `pad=7` — the value is kept in compile_values).
-	for d in p.compile_defines {
-		value := p.compile_values[d] or { '' }
-		if value == '' || value == 'true' {
-			opts << '-d ${d}'
-		} else {
-			opts << '-d ${d}=${value}'
+	// custom `-d`/`-define` options, reused verbatim from the recorded build options so the
+	// value is preserved exactly (`-d foo`, `-d pad=7`, and the explicitly empty `-d header=`).
+	// This matters because `$if foo ?` and `$d()` can select different source and codegen.
+	for opt in p.build_options {
+		if opt.starts_with('-d ') {
+			opts << opt
 		}
 	}
 	return opts.join(' ')

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -314,12 +314,13 @@ fn codegen_build_options(p &pref.Preferences) string {
 	//   -custom-prelude replaces the generated prelude written into the C headers
 	//   -bare-builtin-dir selects the freestanding builtin implementation
 	//   -macosx-version-min passed to clang as `-mmacosx-version-min=...`, selects the SDK target
+	//   -path           custom module lookup path, decides which imported module is resolved
 	// Bare flags (kept by exact match), only present when explicitly passed (host-detected libc
 	// defaults are not recorded, so these capture the user's explicit choice):
 	//   -musl/-glibc    force the linked libc; `-musl` also enables `$if musl` and changes libgc flags
 	//   -m32/-m64       select the target machine width, appended to the C compiler command via cflags
 	verbatim_prefixes := ['-d ', '-cflags ', '-ldflags ', '-custom-prelude ', '-bare-builtin-dir ',
-		'-macosx-version-min ']
+		'-macosx-version-min ', '-path ']
 	verbatim_flags := ['-musl', '-glibc', '-m32', '-m64']
 	for opt in p.build_options {
 		if opt in verbatim_flags || verbatim_prefixes.any(opt.starts_with(it)) {

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -9,13 +9,10 @@ import v.util.version
 const default_c_error_bug_report_url = 'https://bugs.vlang.io/bug-report'
 const c_error_bug_report_disabled_env = 'V_C_ERROR_BUG_REPORT_DISABLED'
 const c_error_context_radius = 5
-// how many V source lines to upload on each side of the failing line (the reproduction chunk,
-// wider than the pinpoint `c_error_context_radius` above, but still not the whole file)
+// how many V source lines to upload on each side of the failing line: a small chunk local to the
+// error, wider than the pinpoint `c_error_context_radius` above, but deliberately not the whole
+// file (the failing program can hold proprietary code / secrets that should not be auto-uploaded)
 const c_error_v_source_radius = 40
-// how many leading lines of the file to keep (module/imports/top-level declarations), so the
-// uploaded chunk still has what the failing region needs to compile
-const c_error_v_source_prefix_lines = 40
-const c_error_v_source_omitted_notice = '// ... unrelated source omitted for the bug report ...'
 // marker used when `v_source` itself is too large; a V comment so the kept source stays parseable
 const c_error_v_source_truncation_notice = '// ... v_source truncated for the bug report ...'
 const c_error_bug_report_max_body_bytes = 256 * 1024
@@ -50,7 +47,7 @@ pub:
 	v_file         string
 	v_line         int
 	v_context      []CErrorReportLine
-	v_source       string // leading declarations + the block around the failing line (bounded), so the failure can be reproduced without uploading the whole file
+	v_source       string // a small chunk of V source around the failing line (bounded), never the whole file
 }
 
 fn (mut v Builder) submit_c_error_bug_report(ccompiler string, c_output string) {
@@ -112,15 +109,7 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 	// `v_context` shows the lines of whatever file the C error maps to (which can be an
 	// included header, not V source).
 	mapped_source := if v_file != '' { os.read_file(v_file) or { '' } } else { '' }
-	// The whole compiled input is only read when it is needed as the no-mapping fallback below,
-	// so a normal mapped error does no extra I/O.
-	input_source := if !is_v_source_file(v_file) && is_v_source_file(v.pref.path) {
-		os.read_file(v.pref.path) or { '' }
-	} else {
-		''
-	}
-	v_chunk := selected_v_source(v_file, mapped_source.split_into_lines(), v_line, v.pref.path,
-		input_source)
+	v_chunk := selected_v_source(v_file, mapped_source.split_into_lines(), v_line)
 	return CErrorBugReport{
 		kind:           'v-c-compiler-error'
 		v_version:      version.full_v_version(true)
@@ -341,182 +330,39 @@ fn codegen_build_options(p &pref.Preferences) string {
 }
 
 // VSourceChunk is the V source selected for a report, plus `focus` — the 1-based line within
-// `text` that holds the failing line (0 when it is not known, e.g. the whole-file fallback). The
-// focus lets bounding keep a window around the failing line instead of dropping the middle.
+// `text` that holds the failing line (0 when it is not known). The focus lets bounding keep a
+// window around the failing line instead of dropping the middle.
 struct VSourceChunk {
 	text  string
 	focus int
 }
 
-// selected_v_source picks the V source to upload so the failure can be reproduced. When the C
-// error maps to a V line (`v_file` is V source), it uploads just the leading declarations plus the
-// block around that line, so unrelated function bodies are not disclosed. When there is no V
-// mapping (a header error, or the vlines retry was skipped for `-parallel-cc` /
-// `-generate-c-project` / no recorded C command) but a single V file was compiled, it falls back
-// to that whole input file (`input_source`) so the report still carries the failing program.
-// It returns an empty chunk when neither is available.
-fn selected_v_source(v_file string, mapped_lines []string, v_line int, input_path string, input_source string) VSourceChunk {
+// selected_v_source picks the V source to upload. Only a small chunk around the mapped failing
+// line is ever sent (never the whole file), so a C compiler error does not auto-upload unrelated
+// or proprietary source. It returns an empty chunk when the C error does not map to a V source
+// line (a header error, or no `#line` mapping at all).
+fn selected_v_source(v_file string, mapped_lines []string, v_line int) VSourceChunk {
 	if is_v_source_file(v_file) {
-		return v_source_for_report(mapped_lines, v_line, c_error_v_source_radius,
-			c_error_v_source_prefix_lines)
-	}
-	if is_v_source_file(input_path) {
-		// no mapped line inside the whole input file: focus 0 => head/tail bounding
-		return VSourceChunk{
-			text:  input_source
-			focus: 0
-		}
+		return v_source_for_report(mapped_lines, v_line, c_error_v_source_radius)
 	}
 	return VSourceChunk{}
 }
 
-// v_source_for_report returns the V source needed to reproduce the C error without uploading the
-// whole file: the file's leading declarations plus the failing line's whole enclosing top-level
-// declaration. The region starts at the enclosing declaration (including its `@[...]` attributes)
-// and ends at that declaration's balanced closing brace, so it is a complete declaration rather
-// than a `fn ... {` cut off before its body or statements resuming after the omission comment. For
-// a single-line top-level declaration (no block) up to `radius` lines after it are kept for
-// context. The prefix is trimmed to a brace-balanced boundary within `prefix_lines`, so it never
-// ends inside a half-open declaration. Unrelated declarations in the middle are dropped. When the
-// failing region already reaches the prefix, one contiguous block is returned. It returns an empty
-// chunk when there is no mapped V line. The returned `focus` is the failing line's position within
-// the assembled text, so bounding can keep a window around it.
-fn v_source_for_report(lines []string, center int, radius int, prefix_lines int) VSourceChunk {
+// v_source_for_report returns a small window of the mapped V file: `radius` lines on each side of
+// the failing line, clamped to the file bounds. It is deliberately local to the error and never
+// the whole file, so unrelated source is not uploaded. It returns an empty chunk when there is no
+// mapped V line. The returned `focus` is the failing line's position within the window, so bounding
+// can keep it if the window still exceeds the byte budget.
+fn v_source_for_report(lines []string, center int, radius int) VSourceChunk {
 	if center <= 0 || lines.len == 0 {
 		return VSourceChunk{}
 	}
-	// begin at the enclosing declaration of the failing line, so the region is a whole block and
-	// never starts in the middle of a function body (or on a stray closing brace).
-	region_start := enclosing_decl_start(lines, center)
-	// end at the enclosing declaration's balanced closing brace, so the block is not cut open. The
-	// close is only accepted at or after the failing line, so a `}` inside a string/comment before
-	// it cannot end the region early and drop the failing line. `0` => no such block end (a
-	// single-line declaration, or unbalanced): keep up to `radius` lines of context after it.
-	decl_end := enclosing_decl_end(lines, region_start, center)
-	region_end := if decl_end > 0 {
-		decl_end
-	} else if center + radius > lines.len {
-		lines.len
-	} else {
-		center + radius
-	}
-	// The failing region already includes (or directly follows) the prefix: keep it contiguous.
-	if region_start <= prefix_lines + 1 {
-		return VSourceChunk{
-			text:  lines[..region_end].join('\n')
-			focus: center
-		}
-	}
-	region := lines[region_start - 1..region_end].join('\n')
-	// the failing line's offset within `region` (1-based)
-	region_focus := center - region_start + 1
-	// Trim the prefix so it does not end inside a half-open top-level declaration.
-	prefix_end := balanced_prefix_end(lines, prefix_lines)
-	if prefix_end == 0 {
-		return VSourceChunk{
-			text:  '${c_error_v_source_omitted_notice}\n${region}'
-			focus: 1 + region_focus // 1 omission-marker line, then the region
-		}
-	}
-	prefix := lines[..prefix_end].join('\n')
+	start := if center - radius < 1 { 1 } else { center - radius }
+	end := if center + radius > lines.len { lines.len } else { center + radius }
 	return VSourceChunk{
-		text:  '${prefix}\n${c_error_v_source_omitted_notice}\n${region}'
-		focus: prefix_end + 1 + region_focus // prefix lines, 1 marker line, then the region
+		text:  lines[start - 1..end].join('\n')
+		focus: center - start + 1
 	}
-}
-
-// enclosing_decl_start scans upward from `from_line` (1-based) to the start of the enclosing
-// top-level declaration: the nearest non-blank line with no leading indentation (`fn`/`struct`/
-// `const`/etc., whose bodies are indented), then any `@[...]` attribute lines directly above it,
-// since attributes such as `@[direct_array_access]` or `@[export]` change the generated C. It
-// returns `from_line` when no such line is found above it.
-fn enclosing_decl_start(lines []string, from_line int) int {
-	mut i := if from_line > lines.len {
-		lines.len
-	} else if from_line < 1 {
-		1
-	} else {
-		from_line
-	}
-	for i > 1 {
-		line := lines[i - 1]
-		if line.len > 0 && !line[0].is_space() {
-			break
-		}
-		i--
-	}
-	// pull in attribute lines immediately above the declaration
-	for i > 1 && lines[i - 2].starts_with('@[') {
-		i--
-	}
-	return i
-}
-
-// is_block_open reports whether `ch` opens a declaration block: a brace `{` (fn/struct/enum/...) or
-// a paren `(` (a `const (` / `__global (` / `import (` group, or a multi-line signature).
-@[inline]
-fn is_block_open(ch u8) bool {
-	return ch == `{` || ch == `(`
-}
-
-// is_block_close reports whether `ch` closes a declaration block (`}` or `)`).
-@[inline]
-fn is_block_close(ch u8) bool {
-	return ch == `}` || ch == `)`
-}
-
-// enclosing_decl_end scans downward from `start` (1-based) to the line that closes the block opened
-// by the declaration there, by counting `{`/`(` against `}`/`)` until the depth returns to 0 (so
-// parenthesized `const (` / `__global (` groups are handled as well as `{ ... }` bodies). The close
-// is only accepted at or after `min_line` (the failing line), so a `}`/`)` inside a string or comment
-// earlier in the declaration cannot end the block before the failing line and drop it from the
-// region. It returns that line, or `0` when the declaration opens no block (a single-line
-// `const`/`import`) or its delimiters never balance at/after `min_line` (unbalanced, or a
-// literal/comment miscount). Like the prefix trimming it does not track delimiters inside literals.
-fn enclosing_decl_end(lines []string, start int, min_line int) int {
-	if start < 1 || start > lines.len {
-		return 0
-	}
-	mut depth := 0
-	mut opened := false
-	for i := start; i <= lines.len; i++ {
-		for ch in lines[i - 1] {
-			if is_block_open(ch) {
-				depth++
-				opened = true
-			} else if is_block_close(ch) && depth > 0 {
-				depth--
-			}
-		}
-		if opened && depth == 0 && i >= min_line {
-			return i
-		}
-	}
-	return 0
-}
-
-// balanced_prefix_end returns how many leading lines of `lines` (at most `max_lines`) can be kept
-// so that the kept slice has balanced `{`/`(` — i.e. it does not stop inside a half-open top-level
-// declaration (a `{ ... }` body or a `const (` / `__global (` group). It is a delimiter-counting
-// heuristic (string/rune literals with stray delimiters are not tracked), which is enough to avoid
-// uploading an obviously unterminated prefix.
-fn balanced_prefix_end(lines []string, max_lines int) int {
-	limit := if max_lines > lines.len { lines.len } else { max_lines }
-	mut depth := 0
-	mut last_balanced := 0
-	for k in 0 .. limit {
-		for ch in lines[k] {
-			if is_block_open(ch) {
-				depth++
-			} else if is_block_close(ch) && depth > 0 {
-				depth--
-			}
-		}
-		if depth == 0 {
-			last_balanced = k + 1
-		}
-	}
-	return last_balanced
 }
 
 // bounded_v_source keeps the V source under `max_bytes`. The stored source is meant to be replayed

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -214,11 +214,13 @@ fn codegen_build_options(p &pref.Preferences) string {
 		opts << 'build_mode:${p.build_mode}'
 	}
 	// Options reused verbatim from the recorded build options so their value is preserved
-	// exactly: custom `-d` defines (`-d foo`, `-d pad=7`, the explicitly empty `-d header=`),
-	// which select source/codegen via `$if foo ?` / `$d()`, and `-cflags`, which are passed
-	// through to the C compiler and can decide whether the C error reproduces (e.g. `-Werror`).
+	// exactly. `-d` defines (`-d foo`, `-d pad=7`, the explicitly empty `-d header=`) select
+	// source/codegen via `$if foo ?` / `$d()`; `-cflags` are passed to the C compiler and can
+	// decide whether the C error reproduces (e.g. `-Werror`); `-custom-prelude` replaces the
+	// generated prelude that is written into the C headers.
+	verbatim_prefixes := ['-d ', '-cflags ', '-custom-prelude ']
 	for opt in p.build_options {
-		if opt.starts_with('-d ') || opt.starts_with('-cflags ') {
+		if verbatim_prefixes.any(opt.starts_with(it)) {
 			opts << opt
 		}
 	}

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -157,6 +157,11 @@ fn codegen_build_options(p &pref.Preferences) string {
 	}
 	if p.skip_unused {
 		opts << 'skip_unused'
+	} else if p.backend == .c && p.build_mode != .build_module {
+		// skip_unused defaults back to true for a normal C build, so a false value here means
+		// `-no-skip-unused` was passed; without recording it, replay would drop unused code and
+		// could compile a smaller C program that no longer hits the error.
+		opts << 'no_skip_unused'
 	}
 	if p.use_coroutines {
 		opts << 'use_coroutines'
@@ -184,6 +189,11 @@ fn codegen_build_options(p &pref.Preferences) string {
 	}
 	if p.no_bounds_checking {
 		opts << 'no_bounds_checking'
+	}
+	if p.force_bounds_checking {
+		// keeps array bounds checks even inside `@[direct_array_access]` functions, so the
+		// generated C differs from a replay that honors the attribute again.
+		opts << 'force_bounds_checking'
 	}
 	if p.translated {
 		opts << 'translated'

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -261,6 +261,11 @@ fn codegen_build_options(p &pref.Preferences) string {
 		// one, so the generated C differs.
 		opts << 'cmain:${p.cmain}'
 	}
+	if p.assert_failure_mode != .default {
+		// `-assert aborts|backtraces|continues` makes cgen emit a different post-failure path
+		// (abort(), print_backtrace(), or none), so the generated C differs.
+		opts << 'assert:${p.assert_failure_mode}'
+	}
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'
 	}

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -206,6 +206,15 @@ fn codegen_build_options(p &pref.Preferences) string {
 		// cgen emits different safe div/mod helpers (`x / 0 == 0` instead of the panic path).
 		opts << 'div_by_zero_is_zero'
 	}
+	if p.is_check_overflow {
+		// cgen inserts runtime integer-overflow-check paths, changing the generated C.
+		opts << 'check_overflow'
+	}
+	if !p.relaxed_gcc14 {
+		// `-no-relaxed-gcc14` drops the gcc-14 diagnostic-relaxing pragmas (default on), so
+		// gcc 14+ can turn the original errors into warnings on replay without it.
+		opts << 'no_relaxed_gcc14'
+	}
 	if p.translated {
 		opts << 'translated'
 	}

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -48,6 +48,9 @@ fn (mut v Builder) submit_c_error_bug_report(ccompiler string, c_output string) 
 	if !should_submit_c_error_bug_report(v.pref.c_error_bug_report_url) {
 		return
 	}
+	// Snapshot the user's real flags now: the vlines fallback below temporarily flips
+	// `pref.is_vlines`, so computing this after it would misreport `vlines` for plain builds.
+	build_options := codegen_build_options(v.pref)
 	mut raw_report := v.new_c_error_bug_report(ccompiler, c_output)
 	if raw_report.v_file == '' {
 		// The default `.tmp.c` has no `#line` directives, so the C error could not be
@@ -56,6 +59,10 @@ fn (mut v Builder) submit_c_error_bug_report(ccompiler string, c_output string) 
 		if vlines_report := v.new_c_error_bug_report_with_vlines(ccompiler) {
 			raw_report = vlines_report
 		}
+	}
+	raw_report = CErrorBugReport{
+		...raw_report
+		build_options: build_options
 	}
 	report := bounded_c_error_bug_report(raw_report, c_error_bug_report_max_body_bytes)
 	report_url := c_error_bug_report_url(v.pref.c_error_bug_report_url)
@@ -172,6 +179,11 @@ fn codegen_build_options(p &pref.Preferences) string {
 	}
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'
+	}
+	// custom `-d`/`-define` values, since `$if foo ?` and `$d()` can select different
+	// source and codegen (so a report from `v -d foo file.v` must record `foo`).
+	for d in p.compile_defines {
+		opts << '-d ${d}'
 	}
 	return opts.join(' ')
 }

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -228,12 +228,15 @@ fn codegen_build_options(p &pref.Preferences) string {
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'
 	}
-	// Options reused verbatim from the recorded build options so their value is preserved
-	// exactly. `-d` defines (`-d foo`, `-d pad=7`, the explicitly empty `-d header=`) select
-	// source/codegen via `$if foo ?` / `$d()`; `-cflags` are passed to the C compiler and can
-	// decide whether the C error reproduces (e.g. `-Werror`); `-custom-prelude` replaces the
-	// generated prelude that is written into the C headers.
-	verbatim_prefixes := ['-d ', '-cflags ', '-custom-prelude ']
+	// Value-carrying options reused verbatim from the recorded build options so their value is
+	// preserved exactly:
+	//   -d              defines (`-d foo`, `-d pad=7`, empty `-d header=`) select source/codegen
+	//                   via `$if foo ?` / `$d()`
+	//   -cflags         passed to the C compiler, can decide whether the error reproduces (`-Werror`)
+	//   -ldflags        passed to the C compiler/linker after every other option
+	//   -custom-prelude replaces the generated prelude written into the C headers
+	//   -bare-builtin-dir selects the freestanding builtin implementation
+	verbatim_prefixes := ['-d ', '-cflags ', '-ldflags ', '-custom-prelude ', '-bare-builtin-dir ']
 	for opt in p.build_options {
 		if verbatim_prefixes.any(opt.starts_with(it)) {
 			opts << opt

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -112,16 +112,15 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 	// `v_context` shows the lines of whatever file the C error maps to (which can be an
 	// included header, not V source).
 	mapped_source := if v_file != '' { os.read_file(v_file) or { '' } } else { '' }
-	// `v_source` uploads the leading declarations (module/imports/types) plus the block of
-	// source around the failing line, not the whole file, so the failure can be reproduced
-	// without disclosing every unrelated function body. It is taken from the mapped file only
-	// when that is V source (a header, or no `#line` mapping at all, yields no chunk).
-	v_source := if is_v_source_file(v_file) {
-		v_source_for_report(mapped_source.split_into_lines(), v_line, c_error_v_source_radius,
-			c_error_v_source_prefix_lines)
+	// The whole compiled input is only read when it is needed as the no-mapping fallback below,
+	// so a normal mapped error does no extra I/O.
+	input_source := if !is_v_source_file(v_file) && is_v_source_file(v.pref.path) {
+		os.read_file(v.pref.path) or { '' }
 	} else {
 		''
 	}
+	v_source := selected_v_source(v_file, mapped_source.split_into_lines(), v_line, v.pref.path,
+		input_source)
 	return CErrorBugReport{
 		kind:           'v-c-compiler-error'
 		v_version:      version.full_v_version(true)
@@ -310,6 +309,24 @@ fn codegen_build_options(p &pref.Preferences) string {
 		}
 	}
 	return opts.join(' ')
+}
+
+// selected_v_source picks the V source to upload so the failure can be reproduced. When the C
+// error maps to a V line (`v_file` is V source), it uploads just the leading declarations plus the
+// block around that line, so unrelated function bodies are not disclosed. When there is no V
+// mapping (a header error, or the vlines retry was skipped for `-parallel-cc` /
+// `-generate-c-project` / no recorded C command) but a single V file was compiled, it falls back
+// to that whole input file (`input_source`) so the report still carries the failing program.
+// It returns '' when neither is available.
+fn selected_v_source(v_file string, mapped_lines []string, v_line int, input_path string, input_source string) string {
+	if is_v_source_file(v_file) {
+		return v_source_for_report(mapped_lines, v_line, c_error_v_source_radius,
+			c_error_v_source_prefix_lines)
+	}
+	if is_v_source_file(input_path) {
+		return input_source
+	}
+	return ''
 }
 
 // v_source_for_report returns the V source needed to reproduce the C error without uploading the

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -213,6 +213,10 @@ fn codegen_build_options(p &pref.Preferences) string {
 		// appends `-ffast-math` / `/fp:fast` to the C compiler command, changing its invocation.
 		opts << 'fast_math'
 	}
+	if p.no_std {
+		// drops the default `-std=c99` / `-D_DEFAULT_SOURCE` C flags, changing the C compiler command.
+		opts << 'no_std'
+	}
 	if p.prealloc {
 		opts << 'prealloc'
 	}

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -181,9 +181,15 @@ fn codegen_build_options(p &pref.Preferences) string {
 		opts << 'build_mode:${p.build_mode}'
 	}
 	// custom `-d`/`-define` values, since `$if foo ?` and `$d()` can select different
-	// source and codegen (so a report from `v -d foo file.v` must record `foo`).
+	// source and codegen (so a report from `v -d foo file.v` must record `foo`, and one
+	// from `v -d pad=7 file.v` must record `pad=7` — the value is kept in compile_values).
 	for d in p.compile_defines {
-		opts << '-d ${d}'
+		value := p.compile_values[d] or { '' }
+		if value == '' || value == 'true' {
+			opts << '-d ${d}'
+		} else {
+			opts << '-d ${d}=${value}'
+		}
 	}
 	return opts.join(' ')
 }

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -179,6 +179,9 @@ fn codegen_build_options(p &pref.Preferences) string {
 	if p.prealloc {
 		opts << 'prealloc'
 	}
+	if p.is_bare {
+		opts << 'freestanding'
+	}
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'
 	}

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -337,39 +337,48 @@ fn selected_v_source(v_file string, mapped_lines []string, v_line int, input_pat
 }
 
 // v_source_for_report returns the V source needed to reproduce the C error without uploading the
-// whole file: the file's leading `prefix_lines` lines (module/imports/top-level declarations) plus
-// the block of `radius` lines on each side of the failing line. The failing region is extended up
-// to the start of its enclosing top-level declaration, so it begins at a declaration boundary
-// instead of resuming with interior statements after the omission comment. Keeping the prefix means
-// the stored source usually still compiles (a bare window can start mid-function and omit imports
-// and type declarations), while unrelated function bodies in the middle are still dropped. When the
-// failing region already reaches the prefix, one contiguous block is returned. It returns '' when
-// there is no mapped V line.
+// whole file: the file's leading declarations plus the failing line's enclosing top-level block and
+// up to `radius` lines after it. The region starts at the enclosing declaration (including its
+// `@[...]` attributes), so it is a whole declaration rather than statements resuming after the
+// omission comment. The prefix is trimmed to a brace-balanced boundary within `prefix_lines`, so it
+// never ends inside a half-open declaration. Unrelated declarations in the middle are dropped. When
+// the failing region already reaches the prefix, one contiguous block is returned. It returns ''
+// when there is no mapped V line.
 fn v_source_for_report(lines []string, center int, radius int, prefix_lines int) string {
 	if center <= 0 || lines.len == 0 {
 		return ''
 	}
-	window_start := if center - radius < 1 { 1 } else { center - radius }
-	// begin at the enclosing declaration so the region is not cut in the middle of a function body
-	region_start := enclosing_decl_start(lines, window_start)
+	// begin at the enclosing declaration of the failing line, so the region is a whole block and
+	// never starts in the middle of a function body (or on a stray closing brace).
+	region_start := enclosing_decl_start(lines, center)
 	region_end := if center + radius > lines.len { lines.len } else { center + radius }
 	// The failing region already includes (or directly follows) the prefix: keep it contiguous.
 	if region_start <= prefix_lines + 1 {
 		return lines[..region_end].join('\n')
 	}
-	prefix_end := if prefix_lines > lines.len { lines.len } else { prefix_lines }
-	prefix := lines[..prefix_end].join('\n')
 	region := lines[region_start - 1..region_end].join('\n')
+	// Trim the prefix so it does not end inside a half-open top-level declaration.
+	prefix_end := balanced_prefix_end(lines, prefix_lines)
+	if prefix_end == 0 {
+		return '${c_error_v_source_omitted_notice}\n${region}'
+	}
+	prefix := lines[..prefix_end].join('\n')
 	return '${prefix}\n${c_error_v_source_omitted_notice}\n${region}'
 }
 
-// enclosing_decl_start scans upward from `from_line` (1-based) to the nearest line that starts a
-// top-level declaration — a non-blank line with no leading indentation (`fn`/`struct`/`const`/an
-// `@[...]` attribute/etc., whose bodies are indented). This lets the failing region begin at the
-// enclosing declaration rather than in the middle of a function body. It returns `from_line` when
-// no such line is found above it.
+// enclosing_decl_start scans upward from `from_line` (1-based) to the start of the enclosing
+// top-level declaration: the nearest non-blank line with no leading indentation (`fn`/`struct`/
+// `const`/etc., whose bodies are indented), then any `@[...]` attribute lines directly above it,
+// since attributes such as `@[direct_array_access]` or `@[export]` change the generated C. It
+// returns `from_line` when no such line is found above it.
 fn enclosing_decl_start(lines []string, from_line int) int {
-	mut i := if from_line > lines.len { lines.len } else { from_line }
+	mut i := if from_line > lines.len {
+		lines.len
+	} else if from_line < 1 {
+		1
+	} else {
+		from_line
+	}
 	for i > 1 {
 		line := lines[i - 1]
 		if line.len > 0 && !line[0].is_space() {
@@ -377,7 +386,34 @@ fn enclosing_decl_start(lines []string, from_line int) int {
 		}
 		i--
 	}
+	// pull in attribute lines immediately above the declaration
+	for i > 1 && lines[i - 2].starts_with('@[') {
+		i--
+	}
 	return i
+}
+
+// balanced_prefix_end returns how many leading lines of `lines` (at most `max_lines`) can be kept
+// so that the kept slice has balanced `{`/`}` — i.e. it does not stop inside a half-open top-level
+// declaration. It is a brace-counting heuristic (string/rune literals with stray braces are not
+// tracked), which is enough to avoid uploading an obviously unterminated prefix.
+fn balanced_prefix_end(lines []string, max_lines int) int {
+	limit := if max_lines > lines.len { lines.len } else { max_lines }
+	mut depth := 0
+	mut last_balanced := 0
+	for k in 0 .. limit {
+		for ch in lines[k] {
+			if ch == `{` {
+				depth++
+			} else if ch == `}` && depth > 0 {
+				depth--
+			}
+		}
+		if depth == 0 {
+			last_balanced = k + 1
+		}
+	}
+	return last_balanced
 }
 
 // bounded_v_source keeps the V source under `max_bytes`, trimming the middle if needed so the

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -119,7 +119,7 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 	} else {
 		''
 	}
-	v_source := selected_v_source(v_file, mapped_source.split_into_lines(), v_line, v.pref.path,
+	v_chunk := selected_v_source(v_file, mapped_source.split_into_lines(), v_line, v.pref.path,
 		input_source)
 	return CErrorBugReport{
 		kind:           'v-c-compiler-error'
@@ -137,7 +137,8 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 		v_line:         v_line
 		v_context:      numbered_context_lines(mapped_source.split_into_lines(), v_line,
 			c_error_context_radius)
-		v_source:       bounded_v_source(v_source, c_error_bug_report_max_v_source_bytes)
+		v_source:       bounded_v_source(v_chunk.text, c_error_bug_report_max_v_source_bytes,
+			v_chunk.focus)
 	}
 }
 
@@ -339,22 +340,34 @@ fn codegen_build_options(p &pref.Preferences) string {
 	return opts.join(' ')
 }
 
+// VSourceChunk is the V source selected for a report, plus `focus` — the 1-based line within
+// `text` that holds the failing line (0 when it is not known, e.g. the whole-file fallback). The
+// focus lets bounding keep a window around the failing line instead of dropping the middle.
+struct VSourceChunk {
+	text  string
+	focus int
+}
+
 // selected_v_source picks the V source to upload so the failure can be reproduced. When the C
 // error maps to a V line (`v_file` is V source), it uploads just the leading declarations plus the
 // block around that line, so unrelated function bodies are not disclosed. When there is no V
 // mapping (a header error, or the vlines retry was skipped for `-parallel-cc` /
 // `-generate-c-project` / no recorded C command) but a single V file was compiled, it falls back
 // to that whole input file (`input_source`) so the report still carries the failing program.
-// It returns '' when neither is available.
-fn selected_v_source(v_file string, mapped_lines []string, v_line int, input_path string, input_source string) string {
+// It returns an empty chunk when neither is available.
+fn selected_v_source(v_file string, mapped_lines []string, v_line int, input_path string, input_source string) VSourceChunk {
 	if is_v_source_file(v_file) {
 		return v_source_for_report(mapped_lines, v_line, c_error_v_source_radius,
 			c_error_v_source_prefix_lines)
 	}
 	if is_v_source_file(input_path) {
-		return input_source
+		// no mapped line inside the whole input file: focus 0 => head/tail bounding
+		return VSourceChunk{
+			text:  input_source
+			focus: 0
+		}
 	}
-	return ''
+	return VSourceChunk{}
 }
 
 // v_source_for_report returns the V source needed to reproduce the C error without uploading the
@@ -365,11 +378,12 @@ fn selected_v_source(v_file string, mapped_lines []string, v_line int, input_pat
 // a single-line top-level declaration (no block) up to `radius` lines after it are kept for
 // context. The prefix is trimmed to a brace-balanced boundary within `prefix_lines`, so it never
 // ends inside a half-open declaration. Unrelated declarations in the middle are dropped. When the
-// failing region already reaches the prefix, one contiguous block is returned. It returns '' when
-// there is no mapped V line.
-fn v_source_for_report(lines []string, center int, radius int, prefix_lines int) string {
+// failing region already reaches the prefix, one contiguous block is returned. It returns an empty
+// chunk when there is no mapped V line. The returned `focus` is the failing line's position within
+// the assembled text, so bounding can keep a window around it.
+fn v_source_for_report(lines []string, center int, radius int, prefix_lines int) VSourceChunk {
 	if center <= 0 || lines.len == 0 {
-		return ''
+		return VSourceChunk{}
 	}
 	// begin at the enclosing declaration of the failing line, so the region is a whole block and
 	// never starts in the middle of a function body (or on a stray closing brace).
@@ -388,16 +402,27 @@ fn v_source_for_report(lines []string, center int, radius int, prefix_lines int)
 	}
 	// The failing region already includes (or directly follows) the prefix: keep it contiguous.
 	if region_start <= prefix_lines + 1 {
-		return lines[..region_end].join('\n')
+		return VSourceChunk{
+			text:  lines[..region_end].join('\n')
+			focus: center
+		}
 	}
 	region := lines[region_start - 1..region_end].join('\n')
+	// the failing line's offset within `region` (1-based)
+	region_focus := center - region_start + 1
 	// Trim the prefix so it does not end inside a half-open top-level declaration.
 	prefix_end := balanced_prefix_end(lines, prefix_lines)
 	if prefix_end == 0 {
-		return '${c_error_v_source_omitted_notice}\n${region}'
+		return VSourceChunk{
+			text:  '${c_error_v_source_omitted_notice}\n${region}'
+			focus: 1 + region_focus // 1 omission-marker line, then the region
+		}
 	}
 	prefix := lines[..prefix_end].join('\n')
-	return '${prefix}\n${c_error_v_source_omitted_notice}\n${region}'
+	return VSourceChunk{
+		text:  '${prefix}\n${c_error_v_source_omitted_notice}\n${region}'
+		focus: prefix_end + 1 + region_focus // prefix lines, 1 marker line, then the region
+	}
 }
 
 // enclosing_decl_start scans upward from `from_line` (1-based) to the start of the enclosing
@@ -427,13 +452,27 @@ fn enclosing_decl_start(lines []string, from_line int) int {
 	return i
 }
 
+// is_block_open reports whether `ch` opens a declaration block: a brace `{` (fn/struct/enum/...) or
+// a paren `(` (a `const (` / `__global (` / `import (` group, or a multi-line signature).
+@[inline]
+fn is_block_open(ch u8) bool {
+	return ch == `{` || ch == `(`
+}
+
+// is_block_close reports whether `ch` closes a declaration block (`}` or `)`).
+@[inline]
+fn is_block_close(ch u8) bool {
+	return ch == `}` || ch == `)`
+}
+
 // enclosing_decl_end scans downward from `start` (1-based) to the line that closes the block opened
-// by the declaration there, by counting `{`/`}` until the depth returns to 0. The close is only
-// accepted at or after `min_line` (the failing line), so a `}` inside a string or comment earlier in
-// the declaration cannot end the block before the failing line and drop it from the region. It
-// returns that line, or `0` when the declaration opens no block (a single-line `const`/`import`, or
-// a one-line `fn f() { ... }`) or its braces never balance at/after `min_line` (unbalanced, or a
-// literal/comment brace miscount). Like the prefix trimming it does not track braces inside literals.
+// by the declaration there, by counting `{`/`(` against `}`/`)` until the depth returns to 0 (so
+// parenthesized `const (` / `__global (` groups are handled as well as `{ ... }` bodies). The close
+// is only accepted at or after `min_line` (the failing line), so a `}`/`)` inside a string or comment
+// earlier in the declaration cannot end the block before the failing line and drop it from the
+// region. It returns that line, or `0` when the declaration opens no block (a single-line
+// `const`/`import`) or its delimiters never balance at/after `min_line` (unbalanced, or a
+// literal/comment miscount). Like the prefix trimming it does not track delimiters inside literals.
 fn enclosing_decl_end(lines []string, start int, min_line int) int {
 	if start < 1 || start > lines.len {
 		return 0
@@ -442,10 +481,10 @@ fn enclosing_decl_end(lines []string, start int, min_line int) int {
 	mut opened := false
 	for i := start; i <= lines.len; i++ {
 		for ch in lines[i - 1] {
-			if ch == `{` {
+			if is_block_open(ch) {
 				depth++
 				opened = true
-			} else if ch == `}` && depth > 0 {
+			} else if is_block_close(ch) && depth > 0 {
 				depth--
 			}
 		}
@@ -457,18 +496,19 @@ fn enclosing_decl_end(lines []string, start int, min_line int) int {
 }
 
 // balanced_prefix_end returns how many leading lines of `lines` (at most `max_lines`) can be kept
-// so that the kept slice has balanced `{`/`}` — i.e. it does not stop inside a half-open top-level
-// declaration. It is a brace-counting heuristic (string/rune literals with stray braces are not
-// tracked), which is enough to avoid uploading an obviously unterminated prefix.
+// so that the kept slice has balanced `{`/`(` — i.e. it does not stop inside a half-open top-level
+// declaration (a `{ ... }` body or a `const (` / `__global (` group). It is a delimiter-counting
+// heuristic (string/rune literals with stray delimiters are not tracked), which is enough to avoid
+// uploading an obviously unterminated prefix.
 fn balanced_prefix_end(lines []string, max_lines int) int {
 	limit := if max_lines > lines.len { lines.len } else { max_lines }
 	mut depth := 0
 	mut last_balanced := 0
 	for k in 0 .. limit {
 		for ch in lines[k] {
-			if ch == `{` {
+			if is_block_open(ch) {
 				depth++
-			} else if ch == `}` && depth > 0 {
+			} else if is_block_close(ch) && depth > 0 {
 				depth--
 			}
 		}
@@ -479,12 +519,12 @@ fn balanced_prefix_end(lines []string, max_lines int) int {
 	return last_balanced
 }
 
-// bounded_v_source keeps the V source under `max_bytes`, trimming the middle if needed so the
-// start (declarations/imports) and end (usually where the failing code lives) are both preserved.
-// The stored source is meant to be replayed as V, so unlike `truncated_report_text` it cuts on
-// line boundaries and drops the marker in as a V comment on its own line, keeping the kept head
-// and tail syntactically closer to valid V.
-fn bounded_v_source(source string, max_bytes int) string {
+// bounded_v_source keeps the V source under `max_bytes`. The stored source is meant to be replayed
+// as V, so it cuts on line boundaries and drops the marker in as a V comment on its own line. When
+// `focus_line` is known (1-based), it keeps a window of whole lines around that line, so the exact
+// failing line is never dropped even inside a declaration larger than `max_bytes`. Otherwise it
+// keeps the start (declarations/imports) and the end (usually where the failing code lives).
+fn bounded_v_source(source string, max_bytes int, focus_line int) string {
 	if max_bytes <= 0 || source.len <= max_bytes {
 		return source
 	}
@@ -493,19 +533,56 @@ fn bounded_v_source(source string, max_bytes int) string {
 		// no room for both content and the marker: fall back to a hard prefix cut
 		return source[..max_bytes]
 	}
-	kept_bytes := max_bytes - marker.len
-	head_budget := kept_bytes / 2
-	tail_budget := kept_bytes - head_budget
-	// end the head on a whole line, so a partial statement is not left before the marker
-	mut head_end := source[..head_budget].last_index_u8(`\n`)
-	if head_end <= 0 {
-		head_end = head_budget
+	if focus_line <= 0 {
+		kept_bytes := max_bytes - marker.len
+		head_budget := kept_bytes / 2
+		tail_budget := kept_bytes - head_budget
+		// end the head on a whole line, so a partial statement is not left before the marker
+		mut head_end := source[..head_budget].last_index_u8(`\n`)
+		if head_end <= 0 {
+			head_end = head_budget
+		}
+		// begin the tail on a whole line, so it does not start in the middle of a statement
+		tail_region_start := source.len - tail_budget
+		next_nl := source[tail_region_start..].index_u8(`\n`)
+		tail_start := if next_nl >= 0 { tail_region_start + next_nl + 1 } else { source.len }
+		return source[..head_end] + marker + source[tail_start..]
 	}
-	// begin the tail on a whole line, so it does not start in the middle of a statement
-	tail_region_start := source.len - tail_budget
-	next_nl := source[tail_region_start..].index_u8(`\n`)
-	tail_start := if next_nl >= 0 { tail_region_start + next_nl + 1 } else { source.len }
-	return source[..head_end] + marker + source[tail_start..]
+	// keep a window of whole lines centered on the failing line, growing outward until the budget
+	// (minus room for a marker on each dropped side) is exhausted.
+	lines := source.split_into_lines()
+	fi := if focus_line > lines.len { lines.len - 1 } else { focus_line - 1 }
+	reserve := 2 * marker.len
+	mut lo := fi
+	mut hi := fi
+	mut used := lines[fi].len
+	for {
+		mut progressed := false
+		if hi + 1 < lines.len && used + 1 + lines[hi + 1].len + reserve <= max_bytes {
+			used += 1 + lines[hi + 1].len
+			hi++
+			progressed = true
+		}
+		if lo > 0 && used + 1 + lines[lo - 1].len + reserve <= max_bytes {
+			used += 1 + lines[lo - 1].len
+			lo--
+			progressed = true
+		}
+		if !progressed {
+			break
+		}
+	}
+	mut parts := []string{}
+	if lo > 0 {
+		parts << c_error_v_source_truncation_notice
+	}
+	parts << lines[lo..hi + 1].join('\n')
+	if hi + 1 < lines.len {
+		parts << c_error_v_source_truncation_notice
+	}
+	result := parts.join('\n')
+	// safety clamp in case a single very long line still exceeds the budget
+	return if result.len > max_bytes { result[..max_bytes] } else { result }
 }
 
 // new_c_error_bug_report_with_vlines regenerates the program's C source with `#line`

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -272,6 +272,12 @@ fn codegen_build_options(p &pref.Preferences) string {
 		// (abort(), print_backtrace(), or none), so the generated C differs.
 		opts << 'assert:${p.assert_failure_mode}'
 	}
+	if p.thread_stack_size_set_by_flag {
+		// `spawn`/`go` embed this value in the CreateThread / pthread_attr_setstacksize call,
+		// so it changes the generated C. Only recorded when set by flag, since the default
+		// varies by target architecture.
+		opts << 'thread_stack_size:${p.thread_stack_size}'
+	}
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'
 	}
@@ -286,8 +292,9 @@ fn codegen_build_options(p &pref.Preferences) string {
 	// Bare flags (kept by exact match), only present when explicitly passed (host-detected libc
 	// defaults are not recorded, so these capture the user's explicit choice):
 	//   -musl/-glibc    force the linked libc; `-musl` also enables `$if musl` and changes libgc flags
+	//   -m32/-m64       select the target machine width, appended to the C compiler command via cflags
 	verbatim_prefixes := ['-d ', '-cflags ', '-ldflags ', '-custom-prelude ', '-bare-builtin-dir ']
-	verbatim_flags := ['-musl', '-glibc']
+	verbatim_flags := ['-musl', '-glibc', '-m32', '-m64']
 	for opt in p.build_options {
 		if opt in verbatim_flags || verbatim_prefixes.any(opt.starts_with(it)) {
 			opts << opt

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -194,7 +194,11 @@ fn codegen_build_options(p &pref.Preferences) string {
 		opts << 'no_preludes'
 	}
 	if p.is_prof {
-		opts << 'profile'
+		// the profile output path is embedded in the generated C (the `fopen(...)` call).
+		opts << 'profile:${p.profile_file}'
+	}
+	if p.trace_calls {
+		opts << 'trace_calls'
 	}
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -9,6 +9,9 @@ import v.util.version
 const default_c_error_bug_report_url = 'https://bugs.vlang.io/bug-report'
 const c_error_bug_report_disabled_env = 'V_C_ERROR_BUG_REPORT_DISABLED'
 const c_error_context_radius = 5
+// how many V source lines to upload on each side of the failing line (the reproduction chunk,
+// wider than the pinpoint `c_error_context_radius` above, but still not the whole file)
+const c_error_v_source_radius = 40
 const c_error_bug_report_max_body_bytes = 256 * 1024
 const c_error_bug_report_max_v_source_bytes = 64 * 1024
 const c_error_bug_report_truncation_notice = '\n... report truncated before upload ...\n'
@@ -41,7 +44,7 @@ pub:
 	v_file         string
 	v_line         int
 	v_context      []CErrorReportLine
-	v_source       string // the full V source of `v_file` (bounded), so the failure can be reproduced
+	v_source       string // the block of V source around the failing line (bounded), so the failure can be reproduced without uploading the whole file
 }
 
 fn (mut v Builder) submit_c_error_bug_report(ccompiler string, c_output string) {
@@ -103,12 +106,12 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 	// `v_context` shows the lines of whatever file the C error maps to (which can be an
 	// included header, not V source).
 	mapped_source := if v_file != '' { os.read_file(v_file) or { '' } } else { '' }
-	// `v_source` must be the failing V program, so use the mapped file only when it is V
-	// source; otherwise (a header, or no `#line` mapping at all) fall back to the compiled input.
+	// `v_source` uploads only the block of V source around the failing line, not the whole
+	// file, so unrelated or private code is not disclosed on the default auto-submit path. It
+	// is taken from the mapped file only when that is V source (a header, or no `#line`
+	// mapping at all, yields no chunk).
 	v_source := if is_v_source_file(v_file) {
-		mapped_source
-	} else if os.is_file(v.pref.path) {
-		os.read_file(v.pref.path) or { '' }
+		v_source_chunk(mapped_source.split_into_lines(), v_line, c_error_v_source_radius)
 	} else {
 		''
 	}
@@ -185,11 +188,20 @@ fn codegen_build_options(p &pref.Preferences) string {
 	if p.translated {
 		opts << 'translated'
 	}
+	if p.enable_globals {
+		// the checker rejects `__global` without this, so replaying the report would stop at
+		// the checker instead of reaching the C compiler error.
+		opts << 'enable_globals'
+	}
 	if p.use_cache {
 		opts << 'usecache'
 	}
 	if p.nofloat {
 		opts << 'nofloat'
+	}
+	if p.fast_math {
+		// appends `-ffast-math` / `/fp:fast` to the C compiler command, changing its invocation.
+		opts << 'fast_math'
 	}
 	if p.prealloc {
 		opts << 'prealloc'
@@ -225,6 +237,11 @@ fn codegen_build_options(p &pref.Preferences) string {
 		// coverage adds instrumentation and stores output under coverage_dir.
 		opts << 'coverage:${p.coverage_dir}'
 	}
+	if p.cmain != '' {
+		// `-cmain Foo` makes cgen emit `int Foo(...)` as the entry point instead of the normal
+		// one, so the generated C differs.
+		opts << 'cmain:${p.cmain}'
+	}
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'
 	}
@@ -243,6 +260,16 @@ fn codegen_build_options(p &pref.Preferences) string {
 		}
 	}
 	return opts.join(' ')
+}
+
+// v_source_chunk returns only the block of V source around the failing line (a window of
+// `radius` lines on each side), rather than the whole file, so unrelated or private source is
+// not uploaded on the default auto-submit path. It returns '' when there is no mapped V line.
+fn v_source_chunk(lines []string, center int, radius int) string {
+	if center <= 0 {
+		return ''
+	}
+	return numbered_context_lines(lines, center, radius).map(it.text).join('\n')
 }
 
 // bounded_v_source keeps the V source under `max_bytes`, trimming the middle if needed so the

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -213,11 +213,12 @@ fn codegen_build_options(p &pref.Preferences) string {
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'
 	}
-	// custom `-d`/`-define` options, reused verbatim from the recorded build options so the
-	// value is preserved exactly (`-d foo`, `-d pad=7`, and the explicitly empty `-d header=`).
-	// This matters because `$if foo ?` and `$d()` can select different source and codegen.
+	// Options reused verbatim from the recorded build options so their value is preserved
+	// exactly: custom `-d` defines (`-d foo`, `-d pad=7`, the explicitly empty `-d header=`),
+	// which select source/codegen via `$if foo ?` / `$d()`, and `-cflags`, which are passed
+	// through to the C compiler and can decide whether the C error reproduces (e.g. `-Werror`).
 	for opt in p.build_options {
-		if opt.starts_with('-d ') {
+		if opt.starts_with('-d ') || opt.starts_with('-cflags ') {
 			opts << opt
 		}
 	}

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -157,7 +157,13 @@ fn codegen_build_options(p &pref.Preferences) string {
 	if p.parallel_cc {
 		opts << 'parallel_cc'
 	}
-	if p.is_shared {
+	if p.is_livemain {
+		opts << 'live'
+	}
+	// `-sharedlive` also sets is_shared; report it as the live mode, not plain `shared`.
+	if p.is_liveshared {
+		opts << 'sharedlive'
+	} else if p.is_shared {
 		opts << 'shared'
 	}
 	if p.is_o {

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -285,6 +285,11 @@ fn codegen_build_options(p &pref.Preferences) string {
 		// (abort(), print_backtrace(), or none), so the generated C differs.
 		opts << 'assert:${p.assert_failure_mode}'
 	}
+	if p.subsystem != .auto {
+		// `-subsystem windows|console` changes the generated main function (cgen) and the
+		// linker command on Windows, so the generated/linked C differs.
+		opts << 'subsystem:${p.subsystem}'
+	}
 	if p.thread_stack_size_set_by_flag {
 		// `spawn`/`go` embed this value in the CreateThread / pthread_attr_setstacksize call,
 		// so it changes the generated C. Only recorded when set by flag, since the default

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -10,6 +10,7 @@ const default_c_error_bug_report_url = 'https://bugs.vlang.io/bug-report'
 const c_error_bug_report_disabled_env = 'V_C_ERROR_BUG_REPORT_DISABLED'
 const c_error_context_radius = 5
 const c_error_bug_report_max_body_bytes = 256 * 1024
+const c_error_bug_report_max_v_source_bytes = 64 * 1024
 const c_error_bug_report_truncation_notice = '\n... report truncated before upload ...\n'
 
 struct CErrorReportLine {
@@ -30,7 +31,9 @@ pub:
 	v_version      string
 	target_os      string
 	target_backend string
+	arch           string
 	ccompiler      string
+	build_options  string // the codegen-affecting `v` flags (autofree, gc mode, -g, -prod, ...)
 	c_error        string
 	c_file         string
 	c_line         int
@@ -38,6 +41,7 @@ pub:
 	v_file         string
 	v_line         int
 	v_context      []CErrorReportLine
+	v_source       string // the full V source of `v_file` (bounded), so the failure can be reproduced
 }
 
 fn (mut v Builder) submit_c_error_bug_report(ccompiler string, c_output string) {
@@ -63,6 +67,7 @@ fn (mut v Builder) submit_c_error_bug_report(ccompiler string, c_output string) 
 	if tool_output != '' {
 		println(tool_output)
 	}
+	println('V ${report.v_version}, ${report.target_os}/${report.arch}, cc: ${report.ccompiler}, build options: ${report.build_options}')
 	print_c_error_bug_report_context(report)
 	println('='.repeat('================== C compiler bug report =============='.len))
 }
@@ -88,13 +93,21 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 			c_line = found_c_line
 		}
 	}
-	v_source := if v_file != '' { os.read_file(v_file) or { '' } } else { '' }
+	// Prefer the file the C error maps to; otherwise fall back to the compiled input
+	// file, so a report still carries the failing V source even without a `#line` mapping.
+	mut v_source_file := v_file
+	if v_source_file == '' && os.is_file(v.pref.path) {
+		v_source_file = v.pref.path
+	}
+	v_source := if v_source_file != '' { os.read_file(v_source_file) or { '' } } else { '' }
 	return CErrorBugReport{
 		kind:           'v-c-compiler-error'
 		v_version:      version.full_v_version(true)
 		target_os:      v.pref.os.str()
 		target_backend: v.pref.backend.str()
+		arch:           v.pref.arch.str()
 		ccompiler:      ccompiler
+		build_options:  codegen_build_options(v.pref)
 		c_error:        c_output
 		c_file:         c_file
 		c_line:         c_line
@@ -103,7 +116,73 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 		v_line:         v_line
 		v_context:      numbered_context_lines(v_source.split_into_lines(), v_line,
 			c_error_context_radius)
+		v_source:       bounded_v_source(v_source, c_error_bug_report_max_v_source_bytes)
 	}
+}
+
+// codegen_build_options returns a compact, space-separated list of the `v` flags that
+// affect code generation (and therefore reproduction), e.g. `autofree gc:boehm -g skip_unused`.
+fn codegen_build_options(p &pref.Preferences) string {
+	mut opts := []string{}
+	if p.autofree {
+		opts << 'autofree'
+	}
+	opts << 'gc:${p.gc_mode}'
+	if p.is_prod {
+		opts << 'prod'
+	}
+	if p.is_debug {
+		opts << '-g'
+	}
+	if p.is_vlines {
+		opts << 'vlines'
+	}
+	if p.skip_unused {
+		opts << 'skip_unused'
+	}
+	if p.use_coroutines {
+		opts << 'use_coroutines'
+	}
+	if p.parallel_cc {
+		opts << 'parallel_cc'
+	}
+	if p.is_shared {
+		opts << 'shared'
+	}
+	if p.is_o {
+		opts << 'obj'
+	}
+	if p.is_cstrict {
+		opts << 'cstrict'
+	}
+	if p.sanitize {
+		opts << 'sanitize'
+	}
+	if p.no_bounds_checking {
+		opts << 'no_bounds_checking'
+	}
+	if p.translated {
+		opts << 'translated'
+	}
+	if p.use_cache {
+		opts << 'usecache'
+	}
+	if p.nofloat {
+		opts << 'nofloat'
+	}
+	if p.build_mode != .default_mode {
+		opts << 'build_mode:${p.build_mode}'
+	}
+	return opts.join(' ')
+}
+
+// bounded_v_source keeps the V source under `max_bytes`, trimming the middle if needed so the
+// start (declarations/imports) and end (usually where the failing code lives) are both preserved.
+fn bounded_v_source(source string, max_bytes int) string {
+	if max_bytes <= 0 || source.len <= max_bytes {
+		return source
+	}
+	return truncated_report_text(source, max_bytes)
 }
 
 // new_c_error_bug_report_with_vlines regenerates the program's C source with `#line`
@@ -200,7 +279,9 @@ fn c_error_bug_report_json(report CErrorBugReport) string {
 	write_json_string_field(mut b, 'v_version', report.v_version, true)
 	write_json_string_field(mut b, 'target_os', report.target_os, true)
 	write_json_string_field(mut b, 'target_backend', report.target_backend, true)
+	write_json_string_field(mut b, 'arch', report.arch, true)
 	write_json_string_field(mut b, 'ccompiler', report.ccompiler, true)
+	write_json_string_field(mut b, 'build_options', report.build_options, true)
 	write_json_string_field(mut b, 'c_error', report.c_error, true)
 	write_json_string_field(mut b, 'c_file', report.c_file, true)
 	write_json_int_field(mut b, 'c_line', report.c_line, true)
@@ -208,6 +289,7 @@ fn c_error_bug_report_json(report CErrorBugReport) string {
 	write_json_string_field(mut b, 'v_file', report.v_file, true)
 	write_json_int_field(mut b, 'v_line', report.v_line, true)
 	write_json_report_lines_field(mut b, 'v_context', report.v_context, true)
+	write_json_string_field(mut b, 'v_source', report.v_source, true)
 	b.write_u8(`}`)
 	return b.str()
 }

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -222,6 +222,11 @@ fn codegen_build_options(p &pref.Preferences) string {
 		// the checker instead of reaching the C compiler error.
 		opts << 'enable_globals'
 	}
+	if p.experimental {
+		// gates checker constructs allowed only under `-experimental` and changes autofree C,
+		// so replay without it can stop in the checker or generate different C.
+		opts << 'experimental'
+	}
 	if p.use_cache {
 		opts << 'usecache'
 	}
@@ -297,11 +302,13 @@ fn codegen_build_options(p &pref.Preferences) string {
 	//   -ldflags        passed to the C compiler/linker after every other option
 	//   -custom-prelude replaces the generated prelude written into the C headers
 	//   -bare-builtin-dir selects the freestanding builtin implementation
+	//   -macosx-version-min passed to clang as `-mmacosx-version-min=...`, selects the SDK target
 	// Bare flags (kept by exact match), only present when explicitly passed (host-detected libc
 	// defaults are not recorded, so these capture the user's explicit choice):
 	//   -musl/-glibc    force the linked libc; `-musl` also enables `$if musl` and changes libgc flags
 	//   -m32/-m64       select the target machine width, appended to the C compiler command via cflags
-	verbatim_prefixes := ['-d ', '-cflags ', '-ldflags ', '-custom-prelude ', '-bare-builtin-dir ']
+	verbatim_prefixes := ['-d ', '-cflags ', '-ldflags ', '-custom-prelude ', '-bare-builtin-dir ',
+		'-macosx-version-min ']
 	verbatim_flags := ['-musl', '-glibc', '-m32', '-m64']
 	for opt in p.build_options {
 		if opt in verbatim_flags || verbatim_prefixes.any(opt.starts_with(it)) {
@@ -331,16 +338,20 @@ fn selected_v_source(v_file string, mapped_lines []string, v_line int, input_pat
 
 // v_source_for_report returns the V source needed to reproduce the C error without uploading the
 // whole file: the file's leading `prefix_lines` lines (module/imports/top-level declarations) plus
-// the block of `radius` lines on each side of the failing line. Keeping the prefix means the
-// stored source usually still compiles (a bare window can start mid-function and omit imports and
-// type declarations), while unrelated function bodies in the middle are still dropped. When the
+// the block of `radius` lines on each side of the failing line. The failing region is extended up
+// to the start of its enclosing top-level declaration, so it begins at a declaration boundary
+// instead of resuming with interior statements after the omission comment. Keeping the prefix means
+// the stored source usually still compiles (a bare window can start mid-function and omit imports
+// and type declarations), while unrelated function bodies in the middle are still dropped. When the
 // failing region already reaches the prefix, one contiguous block is returned. It returns '' when
 // there is no mapped V line.
 fn v_source_for_report(lines []string, center int, radius int, prefix_lines int) string {
 	if center <= 0 || lines.len == 0 {
 		return ''
 	}
-	region_start := if center - radius < 1 { 1 } else { center - radius }
+	window_start := if center - radius < 1 { 1 } else { center - radius }
+	// begin at the enclosing declaration so the region is not cut in the middle of a function body
+	region_start := enclosing_decl_start(lines, window_start)
 	region_end := if center + radius > lines.len { lines.len } else { center + radius }
 	// The failing region already includes (or directly follows) the prefix: keep it contiguous.
 	if region_start <= prefix_lines + 1 {
@@ -350,6 +361,23 @@ fn v_source_for_report(lines []string, center int, radius int, prefix_lines int)
 	prefix := lines[..prefix_end].join('\n')
 	region := lines[region_start - 1..region_end].join('\n')
 	return '${prefix}\n${c_error_v_source_omitted_notice}\n${region}'
+}
+
+// enclosing_decl_start scans upward from `from_line` (1-based) to the nearest line that starts a
+// top-level declaration — a non-blank line with no leading indentation (`fn`/`struct`/`const`/an
+// `@[...]` attribute/etc., whose bodies are indented). This lets the failing region begin at the
+// enclosing declaration rather than in the middle of a function body. It returns `from_line` when
+// no such line is found above it.
+fn enclosing_decl_start(lines []string, from_line int) int {
+	mut i := if from_line > lines.len { lines.len } else { from_line }
+	for i > 1 {
+		line := lines[i - 1]
+		if line.len > 0 && !line[0].is_space() {
+			break
+		}
+		i--
+	}
+	return i
 }
 
 // bounded_v_source keeps the V source under `max_bytes`, trimming the middle if needed so the

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -100,13 +100,18 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 			c_line = found_c_line
 		}
 	}
-	// Prefer the file the C error maps to; otherwise fall back to the compiled input
-	// file, so a report still carries the failing V source even without a `#line` mapping.
-	mut v_source_file := v_file
-	if v_source_file == '' && os.is_file(v.pref.path) {
-		v_source_file = v.pref.path
+	// `v_context` shows the lines of whatever file the C error maps to (which can be an
+	// included header, not V source).
+	mapped_source := if v_file != '' { os.read_file(v_file) or { '' } } else { '' }
+	// `v_source` must be the failing V program, so use the mapped file only when it is V
+	// source; otherwise (a header, or no `#line` mapping at all) fall back to the compiled input.
+	v_source := if is_v_source_file(v_file) {
+		mapped_source
+	} else if os.is_file(v.pref.path) {
+		os.read_file(v.pref.path) or { '' }
+	} else {
+		''
 	}
-	v_source := if v_source_file != '' { os.read_file(v_source_file) or { '' } } else { '' }
 	return CErrorBugReport{
 		kind:           'v-c-compiler-error'
 		v_version:      version.full_v_version(true)
@@ -121,7 +126,7 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 		c_context:      numbered_context_lines(c_lines, c_line, c_error_context_radius)
 		v_file:         v_file
 		v_line:         v_line
-		v_context:      numbered_context_lines(v_source.split_into_lines(), v_line,
+		v_context:      numbered_context_lines(mapped_source.split_into_lines(), v_line,
 			c_error_context_radius)
 		v_source:       bounded_v_source(v_source, c_error_bug_report_max_v_source_bytes)
 	}
@@ -187,6 +192,9 @@ fn codegen_build_options(p &pref.Preferences) string {
 	}
 	if p.no_preludes {
 		opts << 'no_preludes'
+	}
+	if p.is_prof {
+		opts << 'profile'
 	}
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -16,6 +16,8 @@ const c_error_v_source_radius = 40
 // uploaded chunk still has what the failing region needs to compile
 const c_error_v_source_prefix_lines = 40
 const c_error_v_source_omitted_notice = '// ... unrelated source omitted for the bug report ...'
+// marker used when `v_source` itself is too large; a V comment so the kept source stays parseable
+const c_error_v_source_truncation_notice = '// ... v_source truncated for the bug report ...'
 const c_error_bug_report_max_body_bytes = 256 * 1024
 const c_error_bug_report_max_v_source_bytes = 64 * 1024
 const c_error_bug_report_truncation_notice = '\n... report truncated before upload ...\n'
@@ -311,11 +313,31 @@ fn v_source_for_report(lines []string, center int, radius int, prefix_lines int)
 
 // bounded_v_source keeps the V source under `max_bytes`, trimming the middle if needed so the
 // start (declarations/imports) and end (usually where the failing code lives) are both preserved.
+// The stored source is meant to be replayed as V, so unlike `truncated_report_text` it cuts on
+// line boundaries and drops the marker in as a V comment on its own line, keeping the kept head
+// and tail syntactically closer to valid V.
 fn bounded_v_source(source string, max_bytes int) string {
 	if max_bytes <= 0 || source.len <= max_bytes {
 		return source
 	}
-	return truncated_report_text(source, max_bytes)
+	marker := '\n${c_error_v_source_truncation_notice}\n'
+	if max_bytes <= marker.len {
+		// no room for both content and the marker: fall back to a hard prefix cut
+		return source[..max_bytes]
+	}
+	kept_bytes := max_bytes - marker.len
+	head_budget := kept_bytes / 2
+	tail_budget := kept_bytes - head_budget
+	// end the head on a whole line, so a partial statement is not left before the marker
+	mut head_end := source[..head_budget].last_index_u8(`\n`)
+	if head_end <= 0 {
+		head_end = head_budget
+	}
+	// begin the tail on a whole line, so it does not start in the middle of a statement
+	tail_region_start := source.len - tail_budget
+	next_nl := source[tail_region_start..].index_u8(`\n`)
+	tail_start := if next_nl >= 0 { tail_region_start + next_nl + 1 } else { source.len }
+	return source[..head_end] + marker + source[tail_start..]
 }
 
 // new_c_error_bug_report_with_vlines regenerates the program's C source with `#line`

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -163,11 +163,17 @@ fn codegen_build_options(p &pref.Preferences) string {
 	}
 	if p.skip_unused {
 		opts << 'skip_unused'
-	} else if p.backend == .c && p.build_mode != .build_module {
+	} else if p.backend == .c && p.build_mode != .build_module && !p.output_cross_c {
 		// skip_unused defaults back to true for a normal C build, so a false value here means
 		// `-no-skip-unused` was passed; without recording it, replay would drop unused code and
-		// could compile a smaller C program that no longer hits the error.
+		// could compile a smaller C program that no longer hits the error. (`-build-module` and
+		// `-cross` also force it off, but on their own; they are reported separately.)
 		opts << 'no_skip_unused'
+	}
+	if p.output_cross_c {
+		// `-cross` / `-os cross` compiles all platform files under C guards (and forces
+		// skip_unused and the GC off), so the generated C differs from a host build.
+		opts << 'cross'
 	}
 	if p.use_coroutines {
 		opts << 'use_coroutines'
@@ -289,6 +295,11 @@ fn codegen_build_options(p &pref.Preferences) string {
 		// `-subsystem windows|console` changes the generated main function (cgen) and the
 		// linker command on Windows, so the generated/linked C differs.
 		opts << 'subsystem:${p.subsystem}'
+	}
+	if p.is_ios_simulator {
+		// `-os ios -simulator` makes cc.v emit `-miphonesimulator-version-min` (simulator SDK)
+		// instead of `-miphoneos-version-min`, so a device replay compiles differently.
+		opts << 'ios_simulator'
 	}
 	if p.thread_stack_size_set_by_flag {
 		// `spawn`/`go` embed this value in the CreateThread / pthread_attr_setstacksize call,

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -202,6 +202,10 @@ fn codegen_build_options(p &pref.Preferences) string {
 		// generated C differs from a replay that honors the attribute again.
 		opts << 'force_bounds_checking'
 	}
+	if p.div_by_zero_is_zero {
+		// cgen emits different safe div/mod helpers (`x / 0 == 0` instead of the panic path).
+		opts << 'div_by_zero_is_zero'
+	}
 	if p.translated {
 		opts << 'translated'
 	}
@@ -271,17 +275,21 @@ fn codegen_build_options(p &pref.Preferences) string {
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'
 	}
-	// Value-carrying options reused verbatim from the recorded build options so their value is
-	// preserved exactly:
+	// Options reused verbatim from the recorded build options so they are preserved exactly.
+	// Value-carrying ones (kept by prefix):
 	//   -d              defines (`-d foo`, `-d pad=7`, empty `-d header=`) select source/codegen
 	//                   via `$if foo ?` / `$d()`
 	//   -cflags         passed to the C compiler, can decide whether the error reproduces (`-Werror`)
 	//   -ldflags        passed to the C compiler/linker after every other option
 	//   -custom-prelude replaces the generated prelude written into the C headers
 	//   -bare-builtin-dir selects the freestanding builtin implementation
+	// Bare flags (kept by exact match), only present when explicitly passed (host-detected libc
+	// defaults are not recorded, so these capture the user's explicit choice):
+	//   -musl/-glibc    force the linked libc; `-musl` also enables `$if musl` and changes libgc flags
 	verbatim_prefixes := ['-d ', '-cflags ', '-ldflags ', '-custom-prelude ', '-bare-builtin-dir ']
+	verbatim_flags := ['-musl', '-glibc']
 	for opt in p.build_options {
-		if verbatim_prefixes.any(opt.starts_with(it)) {
+		if opt in verbatim_flags || verbatim_prefixes.any(opt.starts_with(it)) {
 			opts << opt
 		}
 	}

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -176,6 +176,9 @@ fn codegen_build_options(p &pref.Preferences) string {
 	if p.nofloat {
 		opts << 'nofloat'
 	}
+	if p.prealloc {
+		opts << 'prealloc'
+	}
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'
 	}

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -182,6 +182,12 @@ fn codegen_build_options(p &pref.Preferences) string {
 	if p.is_bare {
 		opts << 'freestanding'
 	}
+	if p.no_builtin {
+		opts << 'no_builtin'
+	}
+	if p.no_preludes {
+		opts << 'no_preludes'
+	}
 	if p.build_mode != .default_mode {
 		opts << 'build_mode:${p.build_mode}'
 	}

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -12,6 +12,10 @@ const c_error_context_radius = 5
 // how many V source lines to upload on each side of the failing line (the reproduction chunk,
 // wider than the pinpoint `c_error_context_radius` above, but still not the whole file)
 const c_error_v_source_radius = 40
+// how many leading lines of the file to keep (module/imports/top-level declarations), so the
+// uploaded chunk still has what the failing region needs to compile
+const c_error_v_source_prefix_lines = 40
+const c_error_v_source_omitted_notice = '// ... unrelated source omitted for the bug report ...'
 const c_error_bug_report_max_body_bytes = 256 * 1024
 const c_error_bug_report_max_v_source_bytes = 64 * 1024
 const c_error_bug_report_truncation_notice = '\n... report truncated before upload ...\n'
@@ -44,7 +48,7 @@ pub:
 	v_file         string
 	v_line         int
 	v_context      []CErrorReportLine
-	v_source       string // the block of V source around the failing line (bounded), so the failure can be reproduced without uploading the whole file
+	v_source       string // leading declarations + the block around the failing line (bounded), so the failure can be reproduced without uploading the whole file
 }
 
 fn (mut v Builder) submit_c_error_bug_report(ccompiler string, c_output string) {
@@ -106,12 +110,13 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 	// `v_context` shows the lines of whatever file the C error maps to (which can be an
 	// included header, not V source).
 	mapped_source := if v_file != '' { os.read_file(v_file) or { '' } } else { '' }
-	// `v_source` uploads only the block of V source around the failing line, not the whole
-	// file, so unrelated or private code is not disclosed on the default auto-submit path. It
-	// is taken from the mapped file only when that is V source (a header, or no `#line`
-	// mapping at all, yields no chunk).
+	// `v_source` uploads the leading declarations (module/imports/types) plus the block of
+	// source around the failing line, not the whole file, so the failure can be reproduced
+	// without disclosing every unrelated function body. It is taken from the mapped file only
+	// when that is V source (a header, or no `#line` mapping at all, yields no chunk).
 	v_source := if is_v_source_file(v_file) {
-		v_source_chunk(mapped_source.split_into_lines(), v_line, c_error_v_source_radius)
+		v_source_for_report(mapped_source.split_into_lines(), v_line, c_error_v_source_radius,
+			c_error_v_source_prefix_lines)
 	} else {
 		''
 	}
@@ -276,14 +281,27 @@ fn codegen_build_options(p &pref.Preferences) string {
 	return opts.join(' ')
 }
 
-// v_source_chunk returns only the block of V source around the failing line (a window of
-// `radius` lines on each side), rather than the whole file, so unrelated or private source is
-// not uploaded on the default auto-submit path. It returns '' when there is no mapped V line.
-fn v_source_chunk(lines []string, center int, radius int) string {
-	if center <= 0 {
+// v_source_for_report returns the V source needed to reproduce the C error without uploading the
+// whole file: the file's leading `prefix_lines` lines (module/imports/top-level declarations) plus
+// the block of `radius` lines on each side of the failing line. Keeping the prefix means the
+// stored source usually still compiles (a bare window can start mid-function and omit imports and
+// type declarations), while unrelated function bodies in the middle are still dropped. When the
+// failing region already reaches the prefix, one contiguous block is returned. It returns '' when
+// there is no mapped V line.
+fn v_source_for_report(lines []string, center int, radius int, prefix_lines int) string {
+	if center <= 0 || lines.len == 0 {
 		return ''
 	}
-	return numbered_context_lines(lines, center, radius).map(it.text).join('\n')
+	region_start := if center - radius < 1 { 1 } else { center - radius }
+	region_end := if center + radius > lines.len { lines.len } else { center + radius }
+	// The failing region already includes (or directly follows) the prefix: keep it contiguous.
+	if region_start <= prefix_lines + 1 {
+		return lines[..region_end].join('\n')
+	}
+	prefix_end := if prefix_lines > lines.len { lines.len } else { prefix_lines }
+	prefix := lines[..prefix_end].join('\n')
+	region := lines[region_start - 1..region_end].join('\n')
+	return '${prefix}\n${c_error_v_source_omitted_notice}\n${region}'
 }
 
 // bounded_v_source keeps the V source under `max_bytes`, trimming the middle if needed so the

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -18,6 +18,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		is_prod:     true
 		skip_unused: true
 		prealloc:    true
+		is_bare:     true
 		// build_options records `-d ...` verbatim (this is what parse_define stores)
 		build_options: ['-d foo', '-d pad=7', '-d header=', '-cc gcc']
 	}
@@ -27,6 +28,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('prod')
 	assert opts.contains('skip_unused')
 	assert opts.contains('prealloc')
+	assert opts.contains('freestanding')
 	// custom `-d` defines must be recorded, since `$if foo ?` / `$d()` change codegen
 	assert opts.contains('-d foo')
 	// valued defines keep their value, including an explicitly empty one (`$d()` reads it)

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -13,26 +13,27 @@ fn restore_env_var(name string, old_value ?string) {
 
 fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	p := pref.Preferences{
-		autofree:          true
-		gc_mode:           .boehm_full
-		is_prod:           true
-		skip_unused:       true
-		prealloc:          true
-		is_bare:           true
-		no_builtin:        true
-		no_preludes:       true
-		no_prod_options:   true
-		enable_globals:    true
-		fast_math:         true
-		cmain:             'SDL_main'
-		is_prof:           true
-		profile_file:      'some/file'
-		profile_no_inline: true
-		profile_fns:       ['foo_*', 'bar']
-		trace_calls:       true
-		trace_fns:         ['baz_*']
-		is_coverage:       true
-		coverage_dir:      'cov/out'
+		autofree:              true
+		gc_mode:               .boehm_full
+		is_prod:               true
+		skip_unused:           true
+		prealloc:              true
+		is_bare:               true
+		no_builtin:            true
+		no_preludes:           true
+		no_prod_options:       true
+		enable_globals:        true
+		fast_math:             true
+		cmain:                 'SDL_main'
+		force_bounds_checking: true
+		is_prof:               true
+		profile_file:          'some/file'
+		profile_no_inline:     true
+		profile_fns:           ['foo_*', 'bar']
+		trace_calls:           true
+		trace_fns:             ['baz_*']
+		is_coverage:           true
+		coverage_dir:          'cov/out'
 		// value-carrying options are recorded verbatim in build_options
 		build_options: ['-d foo', '-d pad=7', '-d header=', '-cflags "-Werror"', '-ldflags "-s"',
 			'-custom-prelude prelude.h', '-bare-builtin-dir bare/dir', '-cc gcc']
@@ -52,6 +53,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	// `-fast-math` changes the C compiler command; `-cmain` changes the generated entry point
 	assert opts.contains('fast_math')
 	assert opts.contains('cmain:SDL_main')
+	// `-force-bounds-checking` keeps checks even in `@[direct_array_access]` functions
+	assert opts.contains('force_bounds_checking')
 	// the profile output path is embedded in the generated C, so keep it
 	assert opts.contains('profile:some/file')
 	assert opts.contains('profile_no_inline')
@@ -73,6 +76,26 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('-bare-builtin-dir bare/dir')
 	// unrelated recorded options (e.g. `-cc`, covered by the ccompiler field) are not pulled in
 	assert !opts.contains('-cc gcc')
+}
+
+fn test_codegen_build_options_reports_no_skip_unused_override() {
+	// a C build with skip_unused off means `-no-skip-unused` was passed (it defaults to true);
+	// replay must disable it too, or a smaller C program could miss the error
+	opts := codegen_build_options(&pref.Preferences{ skip_unused: false })
+	assert opts.split(' ').any(it == 'no_skip_unused')
+	assert !opts.split(' ').any(it == 'skip_unused')
+
+	// the default (skip_unused on) is reported as plain `skip_unused`, not the override
+	on_opts := codegen_build_options(&pref.Preferences{ skip_unused: true })
+	assert on_opts.split(' ').any(it == 'skip_unused')
+	assert !on_opts.split(' ').any(it == 'no_skip_unused')
+
+	// `-build-module` already turns skip_unused off by itself, so it is not the override
+	module_opts := codegen_build_options(&pref.Preferences{
+		skip_unused: false
+		build_mode:  .build_module
+	})
+	assert !module_opts.split(' ').any(it == 'no_skip_unused')
 }
 
 fn test_codegen_build_options_distinguishes_g_from_cg() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -30,9 +30,9 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		trace_fns:         ['baz_*']
 		is_coverage:       true
 		coverage_dir:      'cov/out'
-		// build_options records `-d ...`, `-cflags ...` and `-custom-prelude ...` verbatim
-		build_options: ['-d foo', '-d pad=7', '-d header=', '-cflags "-Werror"',
-			'-custom-prelude prelude.h', '-cc gcc']
+		// value-carrying options are recorded verbatim in build_options
+		build_options: ['-d foo', '-d pad=7', '-d header=', '-cflags "-Werror"', '-ldflags "-s"',
+			'-custom-prelude prelude.h', '-bare-builtin-dir bare/dir', '-cc gcc']
 	}
 	opts := codegen_build_options(&p)
 	assert opts.contains('autofree')
@@ -57,10 +57,12 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	// valued defines keep their value, including an explicitly empty one (`$d()` reads it)
 	assert opts.contains('-d pad=7')
 	assert opts.contains('-d header=')
-	// `-cflags` is passed to the C compiler and can decide whether the error reproduces
+	// value-carrying C/link/prelude/builtin options are passed to the compiler and can decide
+	// whether the error reproduces, so they are kept verbatim
 	assert opts.contains('-cflags "-Werror"')
-	// `-custom-prelude` replaces the prelude written into the C headers
+	assert opts.contains('-ldflags "-s"')
 	assert opts.contains('-custom-prelude prelude.h')
+	assert opts.contains('-bare-builtin-dir bare/dir')
 	// unrelated recorded options (e.g. `-cc`, covered by the ccompiler field) are not pulled in
 	assert !opts.contains('-cc gcc')
 }

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -11,6 +11,24 @@ fn restore_env_var(name string, old_value ?string) {
 	}
 }
 
+fn test_codegen_build_options_reports_flags_and_custom_defines() {
+	p := pref.Preferences{
+		autofree:        true
+		gc_mode:         .boehm_full
+		is_prod:         true
+		skip_unused:     true
+		compile_defines: ['foo', 'bar']
+	}
+	opts := codegen_build_options(&p)
+	assert opts.contains('autofree')
+	assert opts.contains('gc:boehm_full')
+	assert opts.contains('prod')
+	assert opts.contains('skip_unused')
+	// custom `-d` defines must be recorded, since `$if foo ?` / `$d()` change codegen
+	assert opts.contains('-d foo')
+	assert opts.contains('-d bar')
+}
+
 fn restore_c_error_bug_report_url_env(old_url ?string) {
 	restore_env_var('V_C_ERROR_BUG_REPORT_URL', old_url)
 }

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -17,6 +17,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		gc_mode:     .boehm_full
 		is_prod:     true
 		skip_unused: true
+		prealloc:    true
 		// build_options records `-d ...` verbatim (this is what parse_define stores)
 		build_options: ['-d foo', '-d pad=7', '-d header=', '-cc gcc']
 	}
@@ -25,6 +26,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('gc:boehm_full')
 	assert opts.contains('prod')
 	assert opts.contains('skip_unused')
+	assert opts.contains('prealloc')
 	// custom `-d` defines must be recorded, since `$if foo ?` / `$d()` change codegen
 	assert opts.contains('-d foo')
 	// valued defines keep their value, including an explicitly empty one (`$d()` reads it)

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -197,6 +197,29 @@ fn test_v_source_for_report_is_empty_without_mapped_line() {
 	assert v_source_for_report(['a', 'b', 'c'], 0, 40, 40) == ''
 }
 
+fn test_bounded_v_source_truncates_on_line_boundaries_with_comment_marker() {
+	mut lines := []string{}
+	for i in 0 .. 400 {
+		lines << 'line_${i} = some_value_here'
+	}
+	source := lines.join('\n')
+	max := 2000
+	out := bounded_v_source(source, max)
+	assert out.len <= max
+	// the marker is a V comment on its own line, so the kept source stays parseable
+	assert out.contains(c_error_v_source_truncation_notice)
+	// the start (declarations) and the end (failing code) are both preserved
+	assert out.starts_with('line_0 = some_value_here')
+	assert out.ends_with('line_399 = some_value_here')
+	// no original line is split across the truncation: every kept line is whole
+	for l in out.split('\n') {
+		if l == '' || l == c_error_v_source_truncation_notice {
+			continue
+		}
+		assert l.contains(' = some_value_here')
+	}
+}
+
 fn test_numbered_context_lines_returns_five_lines_each_side() {
 	lines := ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
 	context := numbered_context_lines(lines, 6, 5)

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -211,158 +211,45 @@ fn test_c_error_location_for_generated_c_parses_msvc_output() {
 	assert loc.line == 19
 }
 
-fn test_v_source_for_report_keeps_prefix_and_failing_region() {
-	// lines 1..60 (each a column-0 top-level line); the error is on line 50, far past the prefix
+fn test_v_source_for_report_returns_small_window_around_failing_line() {
 	mut lines := []string{}
-	for i in 1 .. 61 {
-		lines << i.str()
+	for i in 1 .. 201 {
+		lines << 'line_${i}'
 	}
-	src := v_source_for_report(lines, 50, 2, 3).text
-	// leading declarations (imports/types live at the top) are kept
-	assert src.contains('1\n2\n3')
-	// the failing declaration (line 50) plus `radius` lines after it are kept
-	assert src.contains('50\n51\n52')
-	// unrelated middle bodies are dropped, with a marker in their place
-	assert src.contains(c_error_v_source_omitted_notice)
-	assert !src.split('\n').any(it == '25')
+	// error on line 100, radius 3 => only lines 97..103 are uploaded, nothing else
+	chunk := v_source_for_report(lines, 100, 3)
+	assert chunk.text == 'line_97\nline_98\nline_99\nline_100\nline_101\nline_102\nline_103'
+	// the failing line sits at the reported focus position
+	assert chunk.text.split('\n')[chunk.focus - 1] == 'line_100'
+	// far-away lines are not disclosed
+	assert !chunk.text.split('\n').any(it == 'line_1')
+	assert !chunk.text.split('\n').any(it == 'line_200')
 }
 
-fn test_v_source_for_report_does_not_cut_prefix_mid_block() {
-	mut lines := []string{}
-	lines << 'module main' // 1
-	lines << 'fn helper() {' // 2 (opens a long block that runs past the prefix)
-	for i in 0 .. 40 {
-		lines << '\th${i} := ${i}' // 3..42
-	}
-	lines << '}' // 43 (closes helper)
-	lines << 'fn target() {' // 44
-	lines << '\tbad := undefined_thing' // 45 (failing)
-	lines << '}' // 46
-	// prefix_lines=5 lands inside helper's body; it must not keep a half-open `fn helper() {`
-	src := v_source_for_report(lines, 45, 2, 5).text
-	assert src.starts_with('module main')
-	// only the brace-balanced leading line survives; the half-open helper body is not included
-	assert !src.contains('h0 :=')
-	assert !src.contains('fn helper() {')
-	// the enclosing block of the failing line is included whole
-	assert src.contains('fn target() {')
-	assert src.contains('bad := undefined_thing')
-	assert src.contains(c_error_v_source_omitted_notice)
-}
-
-fn test_v_source_for_report_extends_to_enclosing_block_end() {
-	mut lines := []string{}
-	lines << 'module main' // 1
-	for i in 0 .. 40 {
-		lines << 'const c${i} = ${i}' // 2..41 (pushes the fn past the prefix)
-	}
-	lines << 'fn big() int {' // 42 (enclosing signature)
-	lines << '\tbad := undefined_thing' // 43 (failing, early in the function)
-	for i in 0 .. 30 {
-		lines << '\ty${i} := ${i}' // 44..73 (long tail, well past center + radius)
-	}
-	lines << '\treturn 0' // 74
-	lines << '}' // 75 (closing brace, > radius lines after the failing line)
-	// error on line 43, radius 2 => center+radius=45, but the block only closes at line 75
-	src := v_source_for_report(lines, 43, 2, 5).text
-	// the whole enclosing declaration is included, through its closing brace
-	assert src.contains('fn big() int {')
-	assert src.contains('bad := undefined_thing')
-	assert src.trim_space().ends_with('}')
-	// a line far past center + radius but still inside the block is present
-	assert src.contains('y20 := 20')
-}
-
-fn test_v_source_for_report_does_not_end_block_before_failing_line() {
-	mut lines := []string{}
-	lines << 'module main' // 1
-	for i in 0 .. 40 {
-		lines << 'const c${i} = ${i}' // 2..41 (pushes the fn past the prefix)
-	}
-	lines << 'fn render() string {' // 42 (enclosing signature)
-	lines << "\ttemplate := '}'" // 43 (a `}` inside a string literal, before the failing line)
-	lines << '\tbad := undefined_thing' // 44 (failing line)
-	lines << '\treturn template' // 45
-	lines << '}' // 46
-	src := v_source_for_report(lines, 44, 2, 5).text
-	// the brace counter hits 0 on line 43, but the region end must not be accepted before the
-	// failing line, so line 44 is still present
-	assert src.contains('bad := undefined_thing')
-	assert src.contains('fn render() string {')
-}
-
-fn test_v_source_for_report_includes_attributes_above_declaration() {
-	mut lines := []string{}
-	lines << 'module main' // 1
-	for i in 0 .. 40 {
-		lines << 'const c${i} = ${i}' // 2..41 (pushes the declaration past the prefix)
-	}
-	lines << '@[direct_array_access]' // 42 (attribute above the failing fn)
-	lines << 'fn hot(a []int) int {' // 43
-	lines << '\treturn a[0] + missing' // 44 (failing)
-	lines << '}' // 45
-	src := v_source_for_report(lines, 44, 2, 5).text
-	// the attribute is included with the enclosing declaration, since it changes the generated C
-	assert src.contains('@[direct_array_access]')
-	assert src.contains('fn hot(a []int) int {')
-	assert src.contains('return a[0] + missing')
-}
-
-fn test_v_source_for_report_includes_enclosing_declaration() {
-	mut lines := []string{}
-	lines << 'module main' // 1
-	lines << 'import os' // 2
-	for i in 0 .. 30 {
-		lines << 'const c${i} = ${i}' // 3..32 (column-0 declarations)
-	}
-	lines << 'fn big() {' // 33 (enclosing signature, column 0)
-	for i in 0 .. 30 {
-		lines << '\tx${i} := ${i}' // 34..63 (indented body)
-	}
-	lines << '\tbad := undefined_thing' // 64 (failing line, indented)
-	lines << '}' // 65
-	// error on line 64, radius 5 (window starts at 59, mid-body), prefix 3
-	src := v_source_for_report(lines, 64, 5, 3).text
-	// the region is extended up to the enclosing `fn big() {` signature, not started mid-body
-	assert src.contains('fn big() {')
-	// it does not resume at an interior statement right after the omission marker
-	assert !src.contains('${c_error_v_source_omitted_notice}\n\tx25')
-	// the failing line and the leading declarations are both present
-	assert src.contains('bad := undefined_thing')
-	assert src.starts_with('module main')
-	assert src.contains(c_error_v_source_omitted_notice)
-}
-
-fn test_v_source_for_report_is_contiguous_when_region_reaches_prefix() {
-	lines := ['1', '2', '3', '4', '5', '6', '7']
-	// error on line 3 with radius 2 => region reaches the top, so no omission marker
-	src := v_source_for_report(lines, 3, 2, 3).text
-	assert src == '1\n2\n3\n4\n5'
-	assert !src.contains(c_error_v_source_omitted_notice)
+fn test_v_source_for_report_clamps_window_to_file_bounds() {
+	lines := ['a', 'b', 'c', 'd']
+	// near the start of the file
+	assert v_source_for_report(lines, 1, 2).text == 'a\nb\nc'
+	// near the end of the file
+	assert v_source_for_report(lines, 4, 2).text == 'b\nc\nd'
 }
 
 fn test_v_source_for_report_is_empty_without_mapped_line() {
 	// no mapped V line (center <= 0) => upload no source at all
-	assert v_source_for_report(['a', 'b', 'c'], 0, 40, 40).text == ''
+	assert v_source_for_report(['a', 'b', 'c'], 0, 40).text == ''
 }
 
-fn test_selected_v_source_falls_back_to_input_file_without_mapping() {
-	// no V mapping (v_file empty), but a single .v input was compiled => keep the whole input,
-	// so the report still carries the failing program instead of an empty v_source
-	whole := 'module main\nfn main() {}'
-	fallback := selected_v_source('', [], 0, '/tmp/prog.v', whole)
-	assert fallback.text == whole
-	// the whole-file fallback has no known failing line => head/tail bounding
-	assert fallback.focus == 0
-
-	// no mapping and the input is not a V source file (e.g. a directory target) => nothing
-	assert selected_v_source('', [], 0, '/tmp/outdir', 'ignored').text == ''
-
-	// a real V mapping uses the failing-line chunk, not the whole input
+fn test_selected_v_source_only_uploads_mapped_v_source_chunk() {
+	// a mapped V file yields a small chunk around the failing line
 	lines := ['module main', 'fn a() {}', 'fn b() {}', 'fn c() {}', 'fn bad() { x }']
-	chunk := selected_v_source('/tmp/prog.v', lines, 5, '/tmp/prog.v', 'WHOLE_INPUT_IGNORED')
+	chunk := selected_v_source('/tmp/prog.v', lines, 5)
 	assert chunk.text.contains('fn bad()')
-	assert !chunk.text.contains('WHOLE_INPUT_IGNORED')
+	assert chunk.focus >= 1
+
+	// a non-V mapped path (an included header) => no source uploaded
+	assert selected_v_source('/tmp/foo.h', lines, 5).text == ''
+	// no mapping at all => nothing
+	assert selected_v_source('', [], 0).text == ''
 }
 
 fn test_bounded_v_source_truncates_on_line_boundaries_with_comment_marker() {
@@ -388,48 +275,21 @@ fn test_bounded_v_source_truncates_on_line_boundaries_with_comment_marker() {
 	}
 }
 
-fn test_v_source_for_report_keeps_parenthesized_declaration() {
-	mut lines := []string{}
-	lines << 'module main' // 1
-	for i in 0 .. 40 {
-		lines << 'import mod${i}' // 2..41 (pushes the block past the prefix)
-	}
-	lines << 'const (' // 42 (parenthesized block opener, no brace)
-	for i in 0 .. 20 {
-		lines << '\tk${i} = ${i}' // 43..62
-	}
-	lines << '\tbad = undefined_thing' // 63 (failing, well before the closing paren)
-	for i in 0 .. 20 {
-		lines << '\tm${i} = ${i}' // 64..83
-	}
-	lines << ')' // 84 (parenthesized block close)
-	src := v_source_for_report(lines, 63, 2, 5).text
-	// the `const ( ... )` block is captured through its closing paren, not cut at center+radius
-	assert src.contains('const (')
-	assert src.contains('bad = undefined_thing')
-	assert src.trim_space().ends_with(')')
-	// a line well past center + radius but still inside the block is present
-	assert src.contains('m15 = 15')
-}
-
 fn test_v_source_for_report_focus_points_at_failing_line() {
 	mut lines := []string{}
-	lines << 'module main' // 1
-	for i in 0 .. 40 {
-		lines << 'const c${i} = ${i}' // 2..41
+	for i in 0 .. 60 {
+		lines << 'stmt_${i}'
 	}
-	lines << 'fn big() {' // 42
-	for i in 0 .. 10 {
-		lines << '\ty${i} := ${i}' // 43..52
+	lines << 'bad := missing' // line 61 (0-based index 60)
+	for i in 0 .. 20 {
+		lines << 'after_${i}'
 	}
-	lines << '\tbad := missing' // 53 (failing)
-	lines << '}' // 54
-	chunk := v_source_for_report(lines, 53, 2, 5)
-	// focus is the 1-based line of the failing line within the assembled text (prefix + marker
-	// shift it), so bounding can keep a window around it
+	chunk := v_source_for_report(lines, 61, 5)
+	// focus is the 1-based line of the failing line within the returned window, so bounding can
+	// keep a window around it
 	text_lines := chunk.text.split('\n')
 	assert chunk.focus >= 1
-	assert text_lines[chunk.focus - 1] == '\tbad := missing'
+	assert text_lines[chunk.focus - 1] == 'bad := missing'
 }
 
 fn test_bounded_v_source_keeps_focus_line_window() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -217,7 +217,7 @@ fn test_v_source_for_report_keeps_prefix_and_failing_region() {
 	for i in 1 .. 61 {
 		lines << i.str()
 	}
-	src := v_source_for_report(lines, 50, 2, 3)
+	src := v_source_for_report(lines, 50, 2, 3).text
 	// leading declarations (imports/types live at the top) are kept
 	assert src.contains('1\n2\n3')
 	// the failing declaration (line 50) plus `radius` lines after it are kept
@@ -239,7 +239,7 @@ fn test_v_source_for_report_does_not_cut_prefix_mid_block() {
 	lines << '\tbad := undefined_thing' // 45 (failing)
 	lines << '}' // 46
 	// prefix_lines=5 lands inside helper's body; it must not keep a half-open `fn helper() {`
-	src := v_source_for_report(lines, 45, 2, 5)
+	src := v_source_for_report(lines, 45, 2, 5).text
 	assert src.starts_with('module main')
 	// only the brace-balanced leading line survives; the half-open helper body is not included
 	assert !src.contains('h0 :=')
@@ -264,7 +264,7 @@ fn test_v_source_for_report_extends_to_enclosing_block_end() {
 	lines << '\treturn 0' // 74
 	lines << '}' // 75 (closing brace, > radius lines after the failing line)
 	// error on line 43, radius 2 => center+radius=45, but the block only closes at line 75
-	src := v_source_for_report(lines, 43, 2, 5)
+	src := v_source_for_report(lines, 43, 2, 5).text
 	// the whole enclosing declaration is included, through its closing brace
 	assert src.contains('fn big() int {')
 	assert src.contains('bad := undefined_thing')
@@ -284,7 +284,7 @@ fn test_v_source_for_report_does_not_end_block_before_failing_line() {
 	lines << '\tbad := undefined_thing' // 44 (failing line)
 	lines << '\treturn template' // 45
 	lines << '}' // 46
-	src := v_source_for_report(lines, 44, 2, 5)
+	src := v_source_for_report(lines, 44, 2, 5).text
 	// the brace counter hits 0 on line 43, but the region end must not be accepted before the
 	// failing line, so line 44 is still present
 	assert src.contains('bad := undefined_thing')
@@ -301,7 +301,7 @@ fn test_v_source_for_report_includes_attributes_above_declaration() {
 	lines << 'fn hot(a []int) int {' // 43
 	lines << '\treturn a[0] + missing' // 44 (failing)
 	lines << '}' // 45
-	src := v_source_for_report(lines, 44, 2, 5)
+	src := v_source_for_report(lines, 44, 2, 5).text
 	// the attribute is included with the enclosing declaration, since it changes the generated C
 	assert src.contains('@[direct_array_access]')
 	assert src.contains('fn hot(a []int) int {')
@@ -322,7 +322,7 @@ fn test_v_source_for_report_includes_enclosing_declaration() {
 	lines << '\tbad := undefined_thing' // 64 (failing line, indented)
 	lines << '}' // 65
 	// error on line 64, radius 5 (window starts at 59, mid-body), prefix 3
-	src := v_source_for_report(lines, 64, 5, 3)
+	src := v_source_for_report(lines, 64, 5, 3).text
 	// the region is extended up to the enclosing `fn big() {` signature, not started mid-body
 	assert src.contains('fn big() {')
 	// it does not resume at an interior statement right after the omission marker
@@ -336,30 +336,33 @@ fn test_v_source_for_report_includes_enclosing_declaration() {
 fn test_v_source_for_report_is_contiguous_when_region_reaches_prefix() {
 	lines := ['1', '2', '3', '4', '5', '6', '7']
 	// error on line 3 with radius 2 => region reaches the top, so no omission marker
-	src := v_source_for_report(lines, 3, 2, 3)
+	src := v_source_for_report(lines, 3, 2, 3).text
 	assert src == '1\n2\n3\n4\n5'
 	assert !src.contains(c_error_v_source_omitted_notice)
 }
 
 fn test_v_source_for_report_is_empty_without_mapped_line() {
 	// no mapped V line (center <= 0) => upload no source at all
-	assert v_source_for_report(['a', 'b', 'c'], 0, 40, 40) == ''
+	assert v_source_for_report(['a', 'b', 'c'], 0, 40, 40).text == ''
 }
 
 fn test_selected_v_source_falls_back_to_input_file_without_mapping() {
 	// no V mapping (v_file empty), but a single .v input was compiled => keep the whole input,
 	// so the report still carries the failing program instead of an empty v_source
 	whole := 'module main\nfn main() {}'
-	assert selected_v_source('', [], 0, '/tmp/prog.v', whole) == whole
+	fallback := selected_v_source('', [], 0, '/tmp/prog.v', whole)
+	assert fallback.text == whole
+	// the whole-file fallback has no known failing line => head/tail bounding
+	assert fallback.focus == 0
 
 	// no mapping and the input is not a V source file (e.g. a directory target) => nothing
-	assert selected_v_source('', [], 0, '/tmp/outdir', 'ignored') == ''
+	assert selected_v_source('', [], 0, '/tmp/outdir', 'ignored').text == ''
 
 	// a real V mapping uses the failing-line chunk, not the whole input
 	lines := ['module main', 'fn a() {}', 'fn b() {}', 'fn c() {}', 'fn bad() { x }']
 	chunk := selected_v_source('/tmp/prog.v', lines, 5, '/tmp/prog.v', 'WHOLE_INPUT_IGNORED')
-	assert chunk.contains('fn bad()')
-	assert !chunk.contains('WHOLE_INPUT_IGNORED')
+	assert chunk.text.contains('fn bad()')
+	assert !chunk.text.contains('WHOLE_INPUT_IGNORED')
 }
 
 fn test_bounded_v_source_truncates_on_line_boundaries_with_comment_marker() {
@@ -369,7 +372,7 @@ fn test_bounded_v_source_truncates_on_line_boundaries_with_comment_marker() {
 	}
 	source := lines.join('\n')
 	max := 2000
-	out := bounded_v_source(source, max)
+	out := bounded_v_source(source, max, 0)
 	assert out.len <= max
 	// the marker is a V comment on its own line, so the kept source stays parseable
 	assert out.contains(c_error_v_source_truncation_notice)
@@ -383,6 +386,67 @@ fn test_bounded_v_source_truncates_on_line_boundaries_with_comment_marker() {
 		}
 		assert l.contains(' = some_value_here')
 	}
+}
+
+fn test_v_source_for_report_keeps_parenthesized_declaration() {
+	mut lines := []string{}
+	lines << 'module main' // 1
+	for i in 0 .. 40 {
+		lines << 'import mod${i}' // 2..41 (pushes the block past the prefix)
+	}
+	lines << 'const (' // 42 (parenthesized block opener, no brace)
+	for i in 0 .. 20 {
+		lines << '\tk${i} = ${i}' // 43..62
+	}
+	lines << '\tbad = undefined_thing' // 63 (failing, well before the closing paren)
+	for i in 0 .. 20 {
+		lines << '\tm${i} = ${i}' // 64..83
+	}
+	lines << ')' // 84 (parenthesized block close)
+	src := v_source_for_report(lines, 63, 2, 5).text
+	// the `const ( ... )` block is captured through its closing paren, not cut at center+radius
+	assert src.contains('const (')
+	assert src.contains('bad = undefined_thing')
+	assert src.trim_space().ends_with(')')
+	// a line well past center + radius but still inside the block is present
+	assert src.contains('m15 = 15')
+}
+
+fn test_v_source_for_report_focus_points_at_failing_line() {
+	mut lines := []string{}
+	lines << 'module main' // 1
+	for i in 0 .. 40 {
+		lines << 'const c${i} = ${i}' // 2..41
+	}
+	lines << 'fn big() {' // 42
+	for i in 0 .. 10 {
+		lines << '\ty${i} := ${i}' // 43..52
+	}
+	lines << '\tbad := missing' // 53 (failing)
+	lines << '}' // 54
+	chunk := v_source_for_report(lines, 53, 2, 5)
+	// focus is the 1-based line of the failing line within the assembled text (prefix + marker
+	// shift it), so bounding can keep a window around it
+	text_lines := chunk.text.split('\n')
+	assert chunk.focus >= 1
+	assert text_lines[chunk.focus - 1] == '\tbad := missing'
+}
+
+fn test_bounded_v_source_keeps_focus_line_window() {
+	mut lines := []string{}
+	for i in 0 .. 2000 {
+		lines << 'line_${i} = value_${i}'
+	}
+	source := lines.join('\n')
+	// the failing line is #1000 (1-based), in the middle of a block far larger than the budget
+	out := bounded_v_source(source, 2000, 1000)
+	assert out.len <= 2000
+	// the exact failing line is preserved rather than dropped as the middle
+	assert out.contains('line_999 = value_999')
+	// a window around it is kept (marker present), not the file head/tail
+	assert out.contains(c_error_v_source_truncation_notice)
+	assert !out.contains('line_0 = value_0')
+	assert !out.contains('line_1999 = value_1999')
 }
 
 fn test_numbered_context_lines_returns_five_lines_each_side() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -69,6 +69,24 @@ fn test_codegen_build_options_distinguishes_g_from_cg() {
 	assert !cg_opts.split(' ').any(it == '-g')
 }
 
+fn test_codegen_build_options_reports_live_modes() {
+	// `-live`
+	live_opts := codegen_build_options(&pref.Preferences{ is_livemain: true })
+	assert live_opts.split(' ').any(it == 'live')
+
+	// `-sharedlive` sets is_liveshared and is_shared, but must not collapse to `shared`
+	sharedlive_opts := codegen_build_options(&pref.Preferences{
+		is_liveshared: true
+		is_shared:     true
+	})
+	assert sharedlive_opts.contains('sharedlive')
+	assert !sharedlive_opts.split(' ').any(it == 'shared')
+
+	// plain `-shared`
+	shared_opts := codegen_build_options(&pref.Preferences{ is_shared: true })
+	assert shared_opts.split(' ').any(it == 'shared')
+}
+
 fn restore_c_error_bug_report_url_env(old_url ?string) {
 	restore_env_var('V_C_ERROR_BUG_REPORT_URL', old_url)
 }

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -26,8 +26,9 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		trace_calls:  true
 		is_coverage:  true
 		coverage_dir: 'cov/out'
-		// build_options records `-d ...` and `-cflags ...` verbatim
-		build_options: ['-d foo', '-d pad=7', '-d header=', '-cflags "-Werror"', '-cc gcc']
+		// build_options records `-d ...`, `-cflags ...` and `-custom-prelude ...` verbatim
+		build_options: ['-d foo', '-d pad=7', '-d header=', '-cflags "-Werror"',
+			'-custom-prelude prelude.h', '-cc gcc']
 	}
 	opts := codegen_build_options(&p)
 	assert opts.contains('autofree')
@@ -49,6 +50,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('-d header=')
 	// `-cflags` is passed to the C compiler and can decide whether the error reproduces
 	assert opts.contains('-cflags "-Werror"')
+	// `-custom-prelude` replaces the prelude written into the C headers
+	assert opts.contains('-custom-prelude prelude.h')
 	// unrelated recorded options (e.g. `-cc`, covered by the ccompiler field) are not pulled in
 	assert !opts.contains('-cc gcc')
 }

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -32,6 +32,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		is_check_overflow:             true
 		relaxed_gcc14:                 false
 		assert_failure_mode:           .backtraces
+		subsystem:                     .windows
 		thread_stack_size:             4194304
 		thread_stack_size_set_by_flag: true
 		is_prof:                       true
@@ -69,6 +70,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('force_bounds_checking')
 	// `-assert backtraces` changes the post-failure C path cgen emits
 	assert opts.contains('assert:backtraces')
+	// `-subsystem windows` changes the generated main function and the Windows linker command
+	assert opts.contains('subsystem:windows')
 	// `-div-by-zero-is-zero` makes cgen emit different safe div/mod helpers
 	assert opts.split(' ').any(it == 'div_by_zero_is_zero')
 	// `-check-overflow` inserts runtime overflow-check paths

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -26,8 +26,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		trace_calls:  true
 		is_coverage:  true
 		coverage_dir: 'cov/out'
-		// build_options records `-d ...` verbatim (this is what parse_define stores)
-		build_options: ['-d foo', '-d pad=7', '-d header=', '-cc gcc']
+		// build_options records `-d ...` and `-cflags ...` verbatim
+		build_options: ['-d foo', '-d pad=7', '-d header=', '-cflags "-Werror"', '-cc gcc']
 	}
 	opts := codegen_build_options(&p)
 	assert opts.contains('autofree')
@@ -47,7 +47,9 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	// valued defines keep their value, including an explicitly empty one (`$d()` reads it)
 	assert opts.contains('-d pad=7')
 	assert opts.contains('-d header=')
-	// only `-d ...` options are pulled from build_options, not unrelated ones
+	// `-cflags` is passed to the C compiler and can decide whether the error reproduces
+	assert opts.contains('-cflags "-Werror"')
+	// unrelated recorded options (e.g. `-cc`, covered by the ccompiler field) are not pulled in
 	assert !opts.contains('-cc gcc')
 }
 

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -24,6 +24,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		no_prod_options:       true
 		enable_globals:        true
 		fast_math:             true
+		no_std:                true
 		cmain:                 'SDL_main'
 		force_bounds_checking: true
 		is_prof:               true
@@ -50,8 +51,9 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('no_prod_options')
 	// `-enable-globals` gates the checker (`__global`); without it a report cannot be replayed
 	assert opts.contains('enable_globals')
-	// `-fast-math` changes the C compiler command; `-cmain` changes the generated entry point
+	// `-fast-math` and `-no-std` change the C compiler command; `-cmain` changes the entry point
 	assert opts.contains('fast_math')
+	assert opts.split(' ').any(it == 'no_std')
 	assert opts.contains('cmain:SDL_main')
 	// `-force-bounds-checking` keeps checks even in `@[direct_array_access]` functions
 	assert opts.contains('force_bounds_checking')

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -27,6 +27,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		no_std:                true
 		cmain:                 'SDL_main'
 		force_bounds_checking: true
+		div_by_zero_is_zero:   true
 		assert_failure_mode:   .backtraces
 		is_prof:               true
 		profile_file:          'some/file'
@@ -36,9 +37,9 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		trace_fns:             ['baz_*']
 		is_coverage:           true
 		coverage_dir:          'cov/out'
-		// value-carrying options are recorded verbatim in build_options
+		// value-carrying options and explicit bare flags are recorded verbatim in build_options
 		build_options: ['-d foo', '-d pad=7', '-d header=', '-cflags "-Werror"', '-ldflags "-s"',
-			'-custom-prelude prelude.h', '-bare-builtin-dir bare/dir', '-cc gcc']
+			'-custom-prelude prelude.h', '-bare-builtin-dir bare/dir', '-musl', '-cc gcc']
 	}
 	opts := codegen_build_options(&p)
 	assert opts.contains('autofree')
@@ -60,6 +61,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('force_bounds_checking')
 	// `-assert backtraces` changes the post-failure C path cgen emits
 	assert opts.contains('assert:backtraces')
+	// `-div-by-zero-is-zero` makes cgen emit different safe div/mod helpers
+	assert opts.split(' ').any(it == 'div_by_zero_is_zero')
 	// the profile output path is embedded in the generated C, so keep it
 	assert opts.contains('profile:some/file')
 	assert opts.contains('profile_no_inline')
@@ -79,6 +82,10 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('-ldflags "-s"')
 	assert opts.contains('-custom-prelude prelude.h')
 	assert opts.contains('-bare-builtin-dir bare/dir')
+	// an explicit libc flag is kept (it changes `$if musl` and the libgc C flags)
+	assert opts.split(' ').any(it == '-musl')
+	// but a libc flag that was not passed is not invented
+	assert !opts.split(' ').any(it == '-glibc')
 	// unrelated recorded options (e.g. `-cc`, covered by the ccompiler field) are not pulled in
 	assert !opts.contains('-cc gcc')
 }

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -48,7 +48,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		// value-carrying options and explicit bare flags are recorded verbatim in build_options
 		build_options: ['-d foo', '-d pad=7', '-d header=', '-cflags "-Werror"', '-ldflags "-s"',
 			'-custom-prelude prelude.h', '-bare-builtin-dir bare/dir', '-macosx-version-min 10.7',
-			'-musl', '-m64', '-cc gcc']
+			'-path "my/mods"', '-musl', '-m64', '-cc gcc']
 	}
 	opts := codegen_build_options(&p)
 	assert opts.contains('autofree')
@@ -106,6 +106,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('-bare-builtin-dir bare/dir')
 	// `-macosx-version-min` is passed to clang and selects the SDK deployment target
 	assert opts.contains('-macosx-version-min 10.7')
+	// `-path` decides which imported module is resolved, so it is kept verbatim
+	assert opts.contains('-path "my/mods"')
 	// an explicit libc flag is kept (it changes `$if musl` and the libgc C flags)
 	assert opts.split(' ').any(it == '-musl')
 	// but a libc flag that was not passed is not invented

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -13,16 +13,12 @@ fn restore_env_var(name string, old_value ?string) {
 
 fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	p := pref.Preferences{
-		autofree:        true
-		gc_mode:         .boehm_full
-		is_prod:         true
-		skip_unused:     true
-		compile_defines: ['foo', 'pad', 'header']
-		compile_values:  {
-			'foo':    'true'
-			'pad':    '7'
-			'header': 'false'
-		}
+		autofree:    true
+		gc_mode:     .boehm_full
+		is_prod:     true
+		skip_unused: true
+		// build_options records `-d ...` verbatim (this is what parse_define stores)
+		build_options: ['-d foo', '-d pad=7', '-d header=', '-cc gcc']
 	}
 	opts := codegen_build_options(&p)
 	assert opts.contains('autofree')
@@ -31,10 +27,11 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('skip_unused')
 	// custom `-d` defines must be recorded, since `$if foo ?` / `$d()` change codegen
 	assert opts.contains('-d foo')
-	assert !opts.contains('-d foo=true')
-	// valued defines must keep their value (`$d()` can change constants and generated C)
+	// valued defines keep their value, including an explicitly empty one (`$d()` reads it)
 	assert opts.contains('-d pad=7')
-	assert opts.contains('-d header=false')
+	assert opts.contains('-d header=')
+	// only `-d ...` options are pulled from build_options, not unrelated ones
+	assert !opts.contains('-cc gcc')
 }
 
 fn restore_c_error_bug_report_url_env(old_url ?string) {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -22,6 +22,9 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		no_builtin:        true
 		no_preludes:       true
 		no_prod_options:   true
+		enable_globals:    true
+		fast_math:         true
+		cmain:             'SDL_main'
 		is_prof:           true
 		profile_file:      'some/file'
 		profile_no_inline: true
@@ -44,6 +47,11 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('no_builtin')
 	assert opts.contains('no_preludes')
 	assert opts.contains('no_prod_options')
+	// `-enable-globals` gates the checker (`__global`); without it a report cannot be replayed
+	assert opts.contains('enable_globals')
+	// `-fast-math` changes the C compiler command; `-cmain` changes the generated entry point
+	assert opts.contains('fast_math')
+	assert opts.contains('cmain:SDL_main')
 	// the profile output path is embedded in the generated C, so keep it
 	assert opts.contains('profile:some/file')
 	assert opts.contains('profile_no_inline')
@@ -130,6 +138,20 @@ fn test_c_error_location_for_generated_c_parses_msvc_output() {
 		return
 	}
 	assert loc.line == 19
+}
+
+fn test_v_source_chunk_returns_only_window_around_failing_line() {
+	lines := ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11']
+	// a chunk of radius 2 around line 6 keeps lines 4..8 and nothing else (not the whole file)
+	chunk := v_source_chunk(lines, 6, 2)
+	assert chunk == '4\n5\n6\n7\n8'
+	assert !chunk.contains('1')
+	assert !chunk.contains('11')
+}
+
+fn test_v_source_chunk_is_empty_without_mapped_line() {
+	// no mapped V line (center <= 0) => upload no source at all
+	assert v_source_chunk(['a', 'b', 'c'], 0, 40) == ''
 }
 
 fn test_numbered_context_lines_returns_five_lines_each_side() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -23,6 +23,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		no_preludes:                   true
 		no_prod_options:               true
 		enable_globals:                true
+		experimental:                  true
 		fast_math:                     true
 		no_std:                        true
 		cmain:                         'SDL_main'
@@ -43,7 +44,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		coverage_dir:                  'cov/out'
 		// value-carrying options and explicit bare flags are recorded verbatim in build_options
 		build_options: ['-d foo', '-d pad=7', '-d header=', '-cflags "-Werror"', '-ldflags "-s"',
-			'-custom-prelude prelude.h', '-bare-builtin-dir bare/dir', '-musl', '-m64', '-cc gcc']
+			'-custom-prelude prelude.h', '-bare-builtin-dir bare/dir', '-macosx-version-min 10.7',
+			'-musl', '-m64', '-cc gcc']
 	}
 	opts := codegen_build_options(&p)
 	assert opts.contains('autofree')
@@ -57,6 +59,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('no_prod_options')
 	// `-enable-globals` gates the checker (`__global`); without it a report cannot be replayed
 	assert opts.contains('enable_globals')
+	// `-experimental` gates checker constructs and changes autofree C
+	assert opts.contains('experimental')
 	// `-fast-math` and `-no-std` change the C compiler command; `-cmain` changes the entry point
 	assert opts.contains('fast_math')
 	assert opts.split(' ').any(it == 'no_std')
@@ -92,6 +96,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('-ldflags "-s"')
 	assert opts.contains('-custom-prelude prelude.h')
 	assert opts.contains('-bare-builtin-dir bare/dir')
+	// `-macosx-version-min` is passed to clang and selects the SDK deployment target
+	assert opts.contains('-macosx-version-min 10.7')
 	// an explicit libc flag is kept (it changes `$if musl` and the libgc C flags)
 	assert opts.split(' ').any(it == '-musl')
 	// but a libc flag that was not passed is not invented
@@ -202,6 +208,31 @@ fn test_v_source_for_report_keeps_prefix_and_failing_region() {
 	// unrelated middle bodies are dropped, with a marker in their place
 	assert src.contains(c_error_v_source_omitted_notice)
 	assert !src.split('\n').any(it == '25')
+}
+
+fn test_v_source_for_report_includes_enclosing_declaration() {
+	mut lines := []string{}
+	lines << 'module main' // 1
+	lines << 'import os' // 2
+	for i in 0 .. 30 {
+		lines << 'const c${i} = ${i}' // 3..32 (column-0 declarations)
+	}
+	lines << 'fn big() {' // 33 (enclosing signature, column 0)
+	for i in 0 .. 30 {
+		lines << '\tx${i} := ${i}' // 34..63 (indented body)
+	}
+	lines << '\tbad := undefined_thing' // 64 (failing line, indented)
+	lines << '}' // 65
+	// error on line 64, radius 5 (window starts at 59, mid-body), prefix 3
+	src := v_source_for_report(lines, 64, 5, 3)
+	// the region is extended up to the enclosing `fn big() {` signature, not started mid-body
+	assert src.contains('fn big() {')
+	// it does not resume at an interior statement right after the omission marker
+	assert !src.contains('${c_error_v_source_omitted_notice}\n\tx25')
+	// the failing line and the leading declarations are both present
+	assert src.contains('bad := undefined_thing')
+	assert src.starts_with('module main')
+	assert src.contains(c_error_v_source_omitted_notice)
 }
 
 fn test_v_source_for_report_is_contiguous_when_region_reaches_prefix() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -13,15 +13,17 @@ fn restore_env_var(name string, old_value ?string) {
 
 fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	p := pref.Preferences{
-		autofree:    true
-		gc_mode:     .boehm_full
-		is_prod:     true
-		skip_unused: true
-		prealloc:    true
-		is_bare:     true
-		no_builtin:  true
-		no_preludes: true
-		is_prof:     true
+		autofree:     true
+		gc_mode:      .boehm_full
+		is_prod:      true
+		skip_unused:  true
+		prealloc:     true
+		is_bare:      true
+		no_builtin:   true
+		no_preludes:  true
+		is_prof:      true
+		profile_file: 'some/file'
+		trace_calls:  true
 		// build_options records `-d ...` verbatim (this is what parse_define stores)
 		build_options: ['-d foo', '-d pad=7', '-d header=', '-cc gcc']
 	}
@@ -34,7 +36,9 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('freestanding')
 	assert opts.contains('no_builtin')
 	assert opts.contains('no_preludes')
-	assert opts.contains('profile')
+	// the profile output path is embedded in the generated C, so keep it
+	assert opts.contains('profile:some/file')
+	assert opts.contains('trace_calls')
 	// custom `-d` defines must be recorded, since `$if foo ?` / `$d()` change codegen
 	assert opts.contains('-d foo')
 	// valued defines keep their value, including an explicitly empty one (`$d()` reads it)

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -34,6 +34,27 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert !opts.contains('-cc gcc')
 }
 
+fn test_codegen_build_options_distinguishes_g_from_cg() {
+	// `-g` => is_debug + is_vlines (V #line output)
+	g := pref.Preferences{
+		is_debug:  true
+		is_vlines: true
+	}
+	g_opts := codegen_build_options(&g)
+	assert g_opts.contains('-g')
+	assert !g_opts.contains('-cg')
+
+	// `-cg` => is_debug only (C-line debug mode; different generated C)
+	cg := pref.Preferences{
+		is_debug:  true
+		is_vlines: false
+	}
+	cg_opts := codegen_build_options(&cg)
+	assert cg_opts.contains('-cg')
+	// (must not be reported as plain `-g`, whose token is a substring of `-cg`)
+	assert !cg_opts.split(' ').any(it == '-g')
+}
+
 fn restore_c_error_bug_report_url_env(old_url ?string) {
 	restore_env_var('V_C_ERROR_BUG_REPORT_URL', old_url)
 }

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -21,6 +21,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		is_bare:     true
 		no_builtin:  true
 		no_preludes: true
+		is_prof:     true
 		// build_options records `-d ...` verbatim (this is what parse_define stores)
 		build_options: ['-d foo', '-d pad=7', '-d header=', '-cc gcc']
 	}
@@ -33,6 +34,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('freestanding')
 	assert opts.contains('no_builtin')
 	assert opts.contains('no_preludes')
+	assert opts.contains('profile')
 	// custom `-d` defines must be recorded, since `$if foo ?` / `$d()` change codegen
 	assert opts.contains('-d foo')
 	// valued defines keep their value, including an explicitly empty one (`$d()` reads it)

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -26,6 +26,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		experimental:                  true
 		fast_math:                     true
 		no_std:                        true
+		no_rsp:                        true
 		cmain:                         'SDL_main'
 		force_bounds_checking:         true
 		div_by_zero_is_zero:           true
@@ -63,9 +64,10 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('enable_globals')
 	// `-experimental` gates checker constructs and changes autofree C
 	assert opts.contains('experimental')
-	// `-fast-math` and `-no-std` change the C compiler command; `-cmain` changes the entry point
+	// `-fast-math`, `-no-std` and `-no-rsp` change the C compiler command; `-cmain` the entry point
 	assert opts.contains('fast_math')
 	assert opts.split(' ').any(it == 'no_std')
+	assert opts.split(' ').any(it == 'no_rsp')
 	assert opts.contains('cmain:SDL_main')
 	// `-force-bounds-checking` keeps checks even in `@[direct_array_access]` functions
 	assert opts.contains('force_bounds_checking')
@@ -246,6 +248,29 @@ fn test_v_source_for_report_does_not_cut_prefix_mid_block() {
 	assert src.contains('fn target() {')
 	assert src.contains('bad := undefined_thing')
 	assert src.contains(c_error_v_source_omitted_notice)
+}
+
+fn test_v_source_for_report_extends_to_enclosing_block_end() {
+	mut lines := []string{}
+	lines << 'module main' // 1
+	for i in 0 .. 40 {
+		lines << 'const c${i} = ${i}' // 2..41 (pushes the fn past the prefix)
+	}
+	lines << 'fn big() int {' // 42 (enclosing signature)
+	lines << '\tbad := undefined_thing' // 43 (failing, early in the function)
+	for i in 0 .. 30 {
+		lines << '\ty${i} := ${i}' // 44..73 (long tail, well past center + radius)
+	}
+	lines << '\treturn 0' // 74
+	lines << '}' // 75 (closing brace, > radius lines after the failing line)
+	// error on line 43, radius 2 => center+radius=45, but the block only closes at line 75
+	src := v_source_for_report(lines, 43, 2, 5)
+	// the whole enclosing declaration is included, through its closing brace
+	assert src.contains('fn big() int {')
+	assert src.contains('bad := undefined_thing')
+	assert src.trim_space().ends_with('}')
+	// a line far past center + radius but still inside the block is present
+	assert src.contains('y20 := 20')
 }
 
 fn test_v_source_for_report_includes_attributes_above_declaration() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -13,33 +13,35 @@ fn restore_env_var(name string, old_value ?string) {
 
 fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	p := pref.Preferences{
-		autofree:              true
-		gc_mode:               .boehm_full
-		is_prod:               true
-		skip_unused:           true
-		prealloc:              true
-		is_bare:               true
-		no_builtin:            true
-		no_preludes:           true
-		no_prod_options:       true
-		enable_globals:        true
-		fast_math:             true
-		no_std:                true
-		cmain:                 'SDL_main'
-		force_bounds_checking: true
-		div_by_zero_is_zero:   true
-		assert_failure_mode:   .backtraces
-		is_prof:               true
-		profile_file:          'some/file'
-		profile_no_inline:     true
-		profile_fns:           ['foo_*', 'bar']
-		trace_calls:           true
-		trace_fns:             ['baz_*']
-		is_coverage:           true
-		coverage_dir:          'cov/out'
+		autofree:                      true
+		gc_mode:                       .boehm_full
+		is_prod:                       true
+		skip_unused:                   true
+		prealloc:                      true
+		is_bare:                       true
+		no_builtin:                    true
+		no_preludes:                   true
+		no_prod_options:               true
+		enable_globals:                true
+		fast_math:                     true
+		no_std:                        true
+		cmain:                         'SDL_main'
+		force_bounds_checking:         true
+		div_by_zero_is_zero:           true
+		assert_failure_mode:           .backtraces
+		thread_stack_size:             4194304
+		thread_stack_size_set_by_flag: true
+		is_prof:                       true
+		profile_file:                  'some/file'
+		profile_no_inline:             true
+		profile_fns:                   ['foo_*', 'bar']
+		trace_calls:                   true
+		trace_fns:                     ['baz_*']
+		is_coverage:                   true
+		coverage_dir:                  'cov/out'
 		// value-carrying options and explicit bare flags are recorded verbatim in build_options
 		build_options: ['-d foo', '-d pad=7', '-d header=', '-cflags "-Werror"', '-ldflags "-s"',
-			'-custom-prelude prelude.h', '-bare-builtin-dir bare/dir', '-musl', '-cc gcc']
+			'-custom-prelude prelude.h', '-bare-builtin-dir bare/dir', '-musl', '-m64', '-cc gcc']
 	}
 	opts := codegen_build_options(&p)
 	assert opts.contains('autofree')
@@ -63,6 +65,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('assert:backtraces')
 	// `-div-by-zero-is-zero` makes cgen emit different safe div/mod helpers
 	assert opts.split(' ').any(it == 'div_by_zero_is_zero')
+	// `-thread-stack-size` is embedded in the spawn/go thread creation call
+	assert opts.contains('thread_stack_size:4194304')
 	// the profile output path is embedded in the generated C, so keep it
 	assert opts.contains('profile:some/file')
 	assert opts.contains('profile_no_inline')
@@ -86,6 +90,9 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.split(' ').any(it == '-musl')
 	// but a libc flag that was not passed is not invented
 	assert !opts.split(' ').any(it == '-glibc')
+	// an explicit machine-width flag is kept (it selects the C compiler target width)
+	assert opts.split(' ').any(it == '-m64')
+	assert !opts.split(' ').any(it == '-m32')
 	// unrelated recorded options (e.g. `-cc`, covered by the ccompiler field) are not pulled in
 	assert !opts.contains('-cc gcc')
 }

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -273,6 +273,24 @@ fn test_v_source_for_report_extends_to_enclosing_block_end() {
 	assert src.contains('y20 := 20')
 }
 
+fn test_v_source_for_report_does_not_end_block_before_failing_line() {
+	mut lines := []string{}
+	lines << 'module main' // 1
+	for i in 0 .. 40 {
+		lines << 'const c${i} = ${i}' // 2..41 (pushes the fn past the prefix)
+	}
+	lines << 'fn render() string {' // 42 (enclosing signature)
+	lines << "\ttemplate := '}'" // 43 (a `}` inside a string literal, before the failing line)
+	lines << '\tbad := undefined_thing' // 44 (failing line)
+	lines << '\treturn template' // 45
+	lines << '}' // 46
+	src := v_source_for_report(lines, 44, 2, 5)
+	// the brace counter hits 0 on line 43, but the region end must not be accepted before the
+	// failing line, so line 44 is still present
+	assert src.contains('bad := undefined_thing')
+	assert src.contains('fn render() string {')
+}
+
 fn test_v_source_for_report_includes_attributes_above_declaration() {
 	mut lines := []string{}
 	lines << 'module main' // 1

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -33,6 +33,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		relaxed_gcc14:                 false
 		assert_failure_mode:           .backtraces
 		subsystem:                     .windows
+		is_ios_simulator:              true
 		thread_stack_size:             4194304
 		thread_stack_size_set_by_flag: true
 		is_prof:                       true
@@ -72,6 +73,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('assert:backtraces')
 	// `-subsystem windows` changes the generated main function and the Windows linker command
 	assert opts.contains('subsystem:windows')
+	// `-os ios -simulator` selects the simulator SDK/clang flags
+	assert opts.split(' ').any(it == 'ios_simulator')
 	// `-div-by-zero-is-zero` makes cgen emit different safe div/mod helpers
 	assert opts.split(' ').any(it == 'div_by_zero_is_zero')
 	// `-check-overflow` inserts runtime overflow-check paths
@@ -130,6 +133,15 @@ fn test_codegen_build_options_reports_no_skip_unused_override() {
 		build_mode:  .build_module
 	})
 	assert !module_opts.split(' ').any(it == 'no_skip_unused')
+
+	// `-cross` forces skip_unused off in fill_with_defaults, so it must not be reported as the
+	// `-no-skip-unused` override; the cross mode itself is recorded instead
+	cross_opts := codegen_build_options(&pref.Preferences{
+		skip_unused:    false
+		output_cross_c: true
+	})
+	assert !cross_opts.split(' ').any(it == 'no_skip_unused')
+	assert cross_opts.split(' ').any(it == 'cross')
 }
 
 fn test_codegen_build_options_distinguishes_g_from_cg() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -13,19 +13,23 @@ fn restore_env_var(name string, old_value ?string) {
 
 fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	p := pref.Preferences{
-		autofree:     true
-		gc_mode:      .boehm_full
-		is_prod:      true
-		skip_unused:  true
-		prealloc:     true
-		is_bare:      true
-		no_builtin:   true
-		no_preludes:  true
-		is_prof:      true
-		profile_file: 'some/file'
-		trace_calls:  true
-		is_coverage:  true
-		coverage_dir: 'cov/out'
+		autofree:          true
+		gc_mode:           .boehm_full
+		is_prod:           true
+		skip_unused:       true
+		prealloc:          true
+		is_bare:           true
+		no_builtin:        true
+		no_preludes:       true
+		no_prod_options:   true
+		is_prof:           true
+		profile_file:      'some/file'
+		profile_no_inline: true
+		profile_fns:       ['foo_*', 'bar']
+		trace_calls:       true
+		trace_fns:         ['baz_*']
+		is_coverage:       true
+		coverage_dir:      'cov/out'
 		// build_options records `-d ...`, `-cflags ...` and `-custom-prelude ...` verbatim
 		build_options: ['-d foo', '-d pad=7', '-d header=', '-cflags "-Werror"',
 			'-custom-prelude prelude.h', '-cc gcc']
@@ -39,9 +43,14 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('freestanding')
 	assert opts.contains('no_builtin')
 	assert opts.contains('no_preludes')
+	assert opts.contains('no_prod_options')
 	// the profile output path is embedded in the generated C, so keep it
 	assert opts.contains('profile:some/file')
+	assert opts.contains('profile_no_inline')
+	// the profiled/traced function filters change which functions are instrumented
+	assert opts.contains('profile_fns:foo_*,bar')
 	assert opts.contains('trace_calls')
+	assert opts.contains('trace_fns:baz_*')
 	assert opts.contains('coverage:cov/out')
 	// custom `-d` defines must be recorded, since `$if foo ?` / `$d()` change codegen
 	assert opts.contains('-d foo')

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -28,6 +28,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		cmain:                         'SDL_main'
 		force_bounds_checking:         true
 		div_by_zero_is_zero:           true
+		is_check_overflow:             true
+		relaxed_gcc14:                 false
 		assert_failure_mode:           .backtraces
 		thread_stack_size:             4194304
 		thread_stack_size_set_by_flag: true
@@ -65,6 +67,10 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('assert:backtraces')
 	// `-div-by-zero-is-zero` makes cgen emit different safe div/mod helpers
 	assert opts.split(' ').any(it == 'div_by_zero_is_zero')
+	// `-check-overflow` inserts runtime overflow-check paths
+	assert opts.split(' ').any(it == 'check_overflow')
+	// `-no-relaxed-gcc14` drops the gcc-14 diagnostic-relaxing pragmas (default on)
+	assert opts.split(' ').any(it == 'no_relaxed_gcc14')
 	// `-thread-stack-size` is embedded in the spawn/go thread creation call
 	assert opts.contains('thread_stack_size:4194304')
 	// the profile output path is embedded in the generated C, so keep it

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -165,18 +165,33 @@ fn test_c_error_location_for_generated_c_parses_msvc_output() {
 	assert loc.line == 19
 }
 
-fn test_v_source_chunk_returns_only_window_around_failing_line() {
-	lines := ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11']
-	// a chunk of radius 2 around line 6 keeps lines 4..8 and nothing else (not the whole file)
-	chunk := v_source_chunk(lines, 6, 2)
-	assert chunk == '4\n5\n6\n7\n8'
-	assert !chunk.contains('1')
-	assert !chunk.contains('11')
+fn test_v_source_for_report_keeps_prefix_and_failing_region() {
+	// lines 1..60; the error is on line 50, far past the 3-line prefix and 2-line radius
+	mut lines := []string{}
+	for i in 1 .. 61 {
+		lines << i.str()
+	}
+	src := v_source_for_report(lines, 50, 2, 3)
+	// leading declarations (imports/types live at the top) are kept
+	assert src.contains('1\n2\n3')
+	// the failing region (lines 48..52) is kept
+	assert src.contains('48\n49\n50\n51\n52')
+	// unrelated middle bodies are dropped, with a marker in their place
+	assert src.contains(c_error_v_source_omitted_notice)
+	assert !src.split('\n').any(it == '25')
 }
 
-fn test_v_source_chunk_is_empty_without_mapped_line() {
+fn test_v_source_for_report_is_contiguous_when_region_reaches_prefix() {
+	lines := ['1', '2', '3', '4', '5', '6', '7']
+	// error on line 3 with radius 2 => region reaches the top, so no omission marker
+	src := v_source_for_report(lines, 3, 2, 3)
+	assert src == '1\n2\n3\n4\n5'
+	assert !src.contains(c_error_v_source_omitted_notice)
+}
+
+fn test_v_source_for_report_is_empty_without_mapped_line() {
 	// no mapped V line (center <= 0) => upload no source at all
-	assert v_source_chunk(['a', 'b', 'c'], 0, 40) == ''
+	assert v_source_for_report(['a', 'b', 'c'], 0, 40, 40) == ''
 }
 
 fn test_numbered_context_lines_returns_five_lines_each_side() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -24,6 +24,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		is_prof:      true
 		profile_file: 'some/file'
 		trace_calls:  true
+		is_coverage:  true
+		coverage_dir: 'cov/out'
 		// build_options records `-d ...` verbatim (this is what parse_define stores)
 		build_options: ['-d foo', '-d pad=7', '-d header=', '-cc gcc']
 	}
@@ -39,6 +41,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	// the profile output path is embedded in the generated C, so keep it
 	assert opts.contains('profile:some/file')
 	assert opts.contains('trace_calls')
+	assert opts.contains('coverage:cov/out')
 	// custom `-d` defines must be recorded, since `$if foo ?` / `$d()` change codegen
 	assert opts.contains('-d foo')
 	// valued defines keep their value, including an explicitly empty one (`$d()` reads it)

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -195,7 +195,7 @@ fn test_c_error_location_for_generated_c_parses_msvc_output() {
 }
 
 fn test_v_source_for_report_keeps_prefix_and_failing_region() {
-	// lines 1..60; the error is on line 50, far past the 3-line prefix and 2-line radius
+	// lines 1..60 (each a column-0 top-level line); the error is on line 50, far past the prefix
 	mut lines := []string{}
 	for i in 1 .. 61 {
 		lines << i.str()
@@ -203,11 +203,51 @@ fn test_v_source_for_report_keeps_prefix_and_failing_region() {
 	src := v_source_for_report(lines, 50, 2, 3)
 	// leading declarations (imports/types live at the top) are kept
 	assert src.contains('1\n2\n3')
-	// the failing region (lines 48..52) is kept
-	assert src.contains('48\n49\n50\n51\n52')
+	// the failing declaration (line 50) plus `radius` lines after it are kept
+	assert src.contains('50\n51\n52')
 	// unrelated middle bodies are dropped, with a marker in their place
 	assert src.contains(c_error_v_source_omitted_notice)
 	assert !src.split('\n').any(it == '25')
+}
+
+fn test_v_source_for_report_does_not_cut_prefix_mid_block() {
+	mut lines := []string{}
+	lines << 'module main' // 1
+	lines << 'fn helper() {' // 2 (opens a long block that runs past the prefix)
+	for i in 0 .. 40 {
+		lines << '\th${i} := ${i}' // 3..42
+	}
+	lines << '}' // 43 (closes helper)
+	lines << 'fn target() {' // 44
+	lines << '\tbad := undefined_thing' // 45 (failing)
+	lines << '}' // 46
+	// prefix_lines=5 lands inside helper's body; it must not keep a half-open `fn helper() {`
+	src := v_source_for_report(lines, 45, 2, 5)
+	assert src.starts_with('module main')
+	// only the brace-balanced leading line survives; the half-open helper body is not included
+	assert !src.contains('h0 :=')
+	assert !src.contains('fn helper() {')
+	// the enclosing block of the failing line is included whole
+	assert src.contains('fn target() {')
+	assert src.contains('bad := undefined_thing')
+	assert src.contains(c_error_v_source_omitted_notice)
+}
+
+fn test_v_source_for_report_includes_attributes_above_declaration() {
+	mut lines := []string{}
+	lines << 'module main' // 1
+	for i in 0 .. 40 {
+		lines << 'const c${i} = ${i}' // 2..41 (pushes the declaration past the prefix)
+	}
+	lines << '@[direct_array_access]' // 42 (attribute above the failing fn)
+	lines << 'fn hot(a []int) int {' // 43
+	lines << '\treturn a[0] + missing' // 44 (failing)
+	lines << '}' // 45
+	src := v_source_for_report(lines, 44, 2, 5)
+	// the attribute is included with the enclosing declaration, since it changes the generated C
+	assert src.contains('@[direct_array_access]')
+	assert src.contains('fn hot(a []int) int {')
+	assert src.contains('return a[0] + missing')
 }
 
 fn test_v_source_for_report_includes_enclosing_declaration() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -217,6 +217,22 @@ fn test_v_source_for_report_is_empty_without_mapped_line() {
 	assert v_source_for_report(['a', 'b', 'c'], 0, 40, 40) == ''
 }
 
+fn test_selected_v_source_falls_back_to_input_file_without_mapping() {
+	// no V mapping (v_file empty), but a single .v input was compiled => keep the whole input,
+	// so the report still carries the failing program instead of an empty v_source
+	whole := 'module main\nfn main() {}'
+	assert selected_v_source('', [], 0, '/tmp/prog.v', whole) == whole
+
+	// no mapping and the input is not a V source file (e.g. a directory target) => nothing
+	assert selected_v_source('', [], 0, '/tmp/outdir', 'ignored') == ''
+
+	// a real V mapping uses the failing-line chunk, not the whole input
+	lines := ['module main', 'fn a() {}', 'fn b() {}', 'fn c() {}', 'fn bad() { x }']
+	chunk := selected_v_source('/tmp/prog.v', lines, 5, '/tmp/prog.v', 'WHOLE_INPUT_IGNORED')
+	assert chunk.contains('fn bad()')
+	assert !chunk.contains('WHOLE_INPUT_IGNORED')
+}
+
 fn test_bounded_v_source_truncates_on_line_boundaries_with_comment_marker() {
 	mut lines := []string{}
 	for i in 0 .. 400 {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -27,6 +27,7 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		no_std:                true
 		cmain:                 'SDL_main'
 		force_bounds_checking: true
+		assert_failure_mode:   .backtraces
 		is_prof:               true
 		profile_file:          'some/file'
 		profile_no_inline:     true
@@ -57,6 +58,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('cmain:SDL_main')
 	// `-force-bounds-checking` keeps checks even in `@[direct_array_access]` functions
 	assert opts.contains('force_bounds_checking')
+	// `-assert backtraces` changes the post-failure C path cgen emits
+	assert opts.contains('assert:backtraces')
 	// the profile output path is embedded in the generated C, so keep it
 	assert opts.contains('profile:some/file')
 	assert opts.contains('profile_no_inline')

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -17,7 +17,12 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		gc_mode:         .boehm_full
 		is_prod:         true
 		skip_unused:     true
-		compile_defines: ['foo', 'bar']
+		compile_defines: ['foo', 'pad', 'header']
+		compile_values:  {
+			'foo':    'true'
+			'pad':    '7'
+			'header': 'false'
+		}
 	}
 	opts := codegen_build_options(&p)
 	assert opts.contains('autofree')
@@ -26,7 +31,10 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('skip_unused')
 	// custom `-d` defines must be recorded, since `$if foo ?` / `$d()` change codegen
 	assert opts.contains('-d foo')
-	assert opts.contains('-d bar')
+	assert !opts.contains('-d foo=true')
+	// valued defines must keep their value (`$d()` can change constants and generated C)
+	assert opts.contains('-d pad=7')
+	assert opts.contains('-d header=false')
 }
 
 fn restore_c_error_bug_report_url_env(old_url ?string) {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -19,6 +19,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 		skip_unused: true
 		prealloc:    true
 		is_bare:     true
+		no_builtin:  true
+		no_preludes: true
 		// build_options records `-d ...` verbatim (this is what parse_define stores)
 		build_options: ['-d foo', '-d pad=7', '-d header=', '-cc gcc']
 	}
@@ -29,6 +31,8 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert opts.contains('skip_unused')
 	assert opts.contains('prealloc')
 	assert opts.contains('freestanding')
+	assert opts.contains('no_builtin')
+	assert opts.contains('no_preludes')
 	// custom `-d` defines must be recorded, since `$if foo ?` / `$d()` change codegen
 	assert opts.contains('-d foo')
 	// valued defines keep their value, including an explicitly empty one (`$d()` reads it)


### PR DESCRIPTION
## What

Enriches the auto-submitted C-error bug reports (bugs.vlang.io) with the two pieces of information that were most often missing when trying to reproduce a report: the **build flags** and the **failing V source**.

## Why

Triaging real reports, a large fraction could not be reproduced:

- **No V source.** The report only carried a few lines of generated-C context (and, when a `#line` mapping existed, ±5 lines of V). Many reports had no V source at all, so the failing program couldn't be reconstructed.
- **No build flags.** Whether the failure needs `-autofree`, `-gc boehm`, `-g`, `-prod`, `-skip-unused`, `-use-coroutines`, etc. was not recorded — several codegen bugs only reproduce under specific flags, so this had to be guessed.

## Changes

### Client — `vlib/v/builder/c_error_report.v`
- **`build_options`** — a compact, space-separated list of the codegen-affecting `v` flags (`autofree gc:boehm -g skip_unused use_coroutines parallel_cc prod cstrict shared obj sanitize no_bounds_checking translated usecache nofloat build_mode:...`).
- **`v_source`** — the full V source of the file the error maps to (bounded to 64 KB), with a fallback to the compiled input path (`pref.path`) when the C error has no `#line` mapping to a V line, so a report still carries the failing program.
- **`arch`**, and a one-line printed summary of what was sent (version, os/arch, cc, build options).

### Server — `cmd/tools/vbug-report.v`, `cmd/tools/modules/vbugreport/c_error_storage.v`
- Decode and store `arch`, `build_options`, and `v_source`.
- Add the three columns to the schema, and via the existing `ensure_column` migration so **existing databases pick them up without losing stored reports**.

## Testing

- `v test cmd/tools/modules/vbugreport/` and `v test vlib/v/builder/c_error_report_test.v` pass; the changed files are `vfmt`-clean.
- End-to-end against a copy of a real (old-schema) reports database: `init_db` adds the `arch` / `build_options` / `v_source` columns with all existing rows preserved, and a posted report stores the new fields (including the full `v_source`) correctly.

Follow-up to #27342 (which added the `v_lines` column).
