### PR TITLE
v3: restore parallel prealloc self-host performance

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -168,7 +168,10 @@ mut:
 	// Set when the target is built with -prealloc / -d prealloc: the bump
 	// arena's base block pointer must be thread-local (matching V1's cgen),
 	// or every spawned thread would race on the same arena.
-	prealloc bool
+	prealloc               bool
+	scope_parallel_workers bool
+	worker_scope           voidptr
+	parallel_worker_scopes []voidptr
 }
 
 struct FixedArrayTypedefInfo {
@@ -457,6 +460,26 @@ pub fn (mut g FlatGen) set_compiler_vexe(path string) {
 	g.compiler_vexe = path
 }
 
+// set_scope_parallel_workers makes cgen helpers use disposable prealloc
+// arenas. The caller must release them with free_parallel_worker_scopes after
+// consuming the generated C output and cgen metadata.
+pub fn (mut g FlatGen) set_scope_parallel_workers(enabled bool) {
+	g.scope_parallel_workers = enabled
+}
+
+// free_parallel_worker_scopes releases scratch arenas retained by joined cgen
+// helper threads.
+pub fn (mut g FlatGen) free_parallel_worker_scopes() {
+	$if prealloc {
+		for scope in g.parallel_worker_scopes {
+			if scope != unsafe { nil } {
+				unsafe { prealloc_scope_free_after(scope) }
+			}
+		}
+	}
+	g.parallel_worker_scopes = []voidptr{}
+}
+
 // gen supports gen handling for FlatGen.
 pub fn (mut g FlatGen) gen(a &flat.FlatAst) string {
 	tc := types.TypeChecker.new(a)
@@ -574,6 +597,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.const_short_index = &ConstShortIndex{}
 	g.mut_recv_facts = &FnNameFactCache{}
 	g.want_parallel_prep = false
+	g.worker_scope = unsafe { nil }
+	g.parallel_worker_scopes = []voidptr{}
 	g.tc = unsafe { tc }
 	if g.tc.a == unsafe { nil } {
 		g.tc.collect(a)

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -39,7 +39,10 @@ $if !windows {
 	// fn work items and pre-seeds the parallel tables.
 	fn fixed_storage_scan_thread(arg voidptr) voidptr {
 		mut w := unsafe { &FlatGen(arg) }
+		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
 		w.collect_fixed_storage_consts()
+		w.worker_scope = scope
+		cgen_worker_scope_leave(scope)
 		return unsafe { nil }
 	}
 
@@ -47,13 +50,19 @@ $if !windows {
 	// groups on private FlatGen forks while the body workers run.
 	fn postamble_segments_thread_a(arg voidptr) voidptr {
 		mut w := unsafe { &FlatGen(arg) }
+		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
 		w.emit_postamble_segments_a()
+		w.worker_scope = scope
+		cgen_worker_scope_leave(scope)
 		return unsafe { nil }
 	}
 
 	fn postamble_segments_thread_b(arg voidptr) voidptr {
 		mut w := unsafe { &FlatGen(arg) }
+		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
 		w.emit_postamble_segments_b()
+		w.worker_scope = scope
+		cgen_worker_scope_leave(scope)
 		return unsafe { nil }
 	}
 
@@ -62,8 +71,28 @@ $if !windows {
 		a := unsafe { &FlatCgenChunkArgs(arg) }
 		mut w := unsafe { &FlatGen(a.worker) }
 		items := unsafe { &[]FlatFnGenItem(a.work_items_ptr) }
+		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
 		w.gen_fn_items(*items)
+		w.worker_scope = scope
+		cgen_worker_scope_leave(scope)
 		return unsafe { nil }
+	}
+}
+
+fn cgen_worker_scope_begin(enabled bool) voidptr {
+	$if prealloc {
+		if enabled {
+			return unsafe { prealloc_scope_begin() }
+		}
+	}
+	return unsafe { nil }
+}
+
+fn cgen_worker_scope_leave(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_leave(scope) }
+		}
 	}
 }
 
@@ -140,6 +169,18 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 		g.gen_fn_items(chunk_items[0])
 		for ci := 0; ci < thread_count + 2; ci++ {
 			C.pthread_join(thread_ids[ci], unsafe { nil })
+		}
+		for ci := 0; ci < thread_count; ci++ {
+			w := unsafe { &FlatGen(workers[ci]) }
+			if w.worker_scope != unsafe { nil } {
+				g.parallel_worker_scopes << w.worker_scope
+			}
+		}
+		if post_worker_a.worker_scope != unsafe { nil } {
+			g.parallel_worker_scopes << post_worker_a.worker_scope
+		}
+		if post_worker_b.worker_scope != unsafe { nil } {
+			g.parallel_worker_scopes << post_worker_b.worker_scope
 		}
 		// Adopt the postamble fork's segments and emission-dedup state FIRST
 		// (it ran logically at the start of the postamble), then merge helper
@@ -512,6 +553,7 @@ fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 		spawn_wrapper_defs:             g.spawn_wrapper_defs.clone()
 		callback_wrapper_names:         g.callback_wrapper_names.clone()
 		callback_wrapper_defs:          g.callback_wrapper_defs.clone()
+		scope_parallel_workers:         g.scope_parallel_workers
 		c_name_cache:                   &CNameCache{}
 		// The const short-name index is read-only after its first build (the
 		// master queries it during the const precompute, before the forks);
@@ -704,6 +746,8 @@ fn (g &FlatGen) postamble_fork(worker_id int) &FlatGen {
 	w.callback_wrapper_defs = g.callback_wrapper_defs.clone()
 	w.c_extern_refs = map[string]bool{}
 	w.c_extern_refs_ready = false
+	w.worker_scope = unsafe { nil }
+	w.parallel_worker_scopes = []voidptr{}
 	// Snapshot of the interned-string table for the string_literals segment;
 	// the master's later interning appends beyond it (see
 	// string_literals_from).
@@ -778,6 +822,9 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 		// read-only, so it must be complete before any fork starts.
 		_ = g.unique_const_ref_name('__v3_prewarm__') or { '' }
 		C.pthread_join(tid[0], unsafe { nil })
+		if fs_worker.worker_scope != unsafe { nil } {
+			g.parallel_worker_scopes << fs_worker.worker_scope
+		}
 		g.fixed_storage_consts = fs_worker.fixed_storage_consts.clone()
 		return true
 	}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -195,6 +195,11 @@ mut:
 	item_range_lo        int = -1
 	item_range_hi        int = -1
 	deferred_base_writes []DeferredBaseWrite
+	// Prealloc self-host builds put helper-thread scratch allocations in
+	// disposable arenas. The worker's surviving AST strings are cloned by the
+	// master before that arena is released.
+	scope_parallel_workers bool
+	worker_scope           voidptr
 }
 
 // AliasCache memoizes normalize_type_alias results. It lives on the heap so the
@@ -304,8 +309,17 @@ pub fn transform_with_used_opt(mut a flat.FlatAst, tc &types.TypeChecker, used_f
 // transform_with_used_opt_config is transform_with_used_opt with extra pipeline
 // switches for self-host builds.
 pub fn transform_with_used_opt_config(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool) (map[string]bool, bool) {
+	return transform_with_used_opt_config_scoped_workers(mut a, tc, used_fns, want_parallel,
+		skip_generics, false)
+}
+
+// transform_with_used_opt_config_scoped_workers optionally gives parallel
+// helpers disposable prealloc arenas. It is used by prealloc self-host builds
+// to retain parallel latency without retaining every helper's scratch memory.
+pub fn transform_with_used_opt_config_scoped_workers(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool, scope_parallel_workers bool) (map[string]bool, bool) {
 	mut t := new_transformer(mut a, tc, used_fns)
 	t.skip_generics = skip_generics
+	t.scope_parallel_workers = scope_parallel_workers
 	t.prepare()
 	if want_parallel {
 		// Transform roughly grows the node/children arrays by ~75%. Reserve that capacity
@@ -1504,6 +1518,7 @@ fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Tran
 	w.used_fns_log = []string{}
 	w.used_fns_log_active = false
 	w.deferred_base_writes = []DeferredBaseWrite{}
+	w.worker_scope = unsafe { nil }
 	// Workers do not record transformed fns (that would write the master's
 	// shared backing array); the master marks each worker's chunk items when it
 	// merges the worker.
@@ -1562,6 +1577,7 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 	w.generic_receiver_methods_by_name = map[string][]string{}
 	w.used_fns_log = []string{}
 	w.used_fns_log_active = false
+	w.worker_scope = unsafe { nil }
 	w.transformed_fns = []bool{}
 	w.temp_counter = 0
 	w.cur_file = ''
@@ -1575,15 +1591,46 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 }
 
 fn (mut t Transformer) merge_worker_used_fns(w &Transformer) {
+	scoped := w.worker_scope != unsafe { nil }
 	for name, used in w.used_fns {
 		if used {
-			t.used_fns[name] = true
+			owned_name := if scoped { name.clone() } else { name }
+			t.used_fns[owned_name] = true
 		}
 	}
 	for name, req in w.sum_eq_types {
 		if name !in t.sum_eq_types {
-			t.sum_eq_types[name] = req
+			if scoped {
+				t.sum_eq_types[name.clone()] = SumEqRequest{
+					module: req.module.clone()
+					file:   req.file.clone()
+				}
+			} else {
+				t.sum_eq_types[name] = req
+			}
 		}
+	}
+}
+
+// clone_scoped_worker_node moves a node's owned fields from a helper arena to
+// the master's arena before the helper arena is released.
+fn (mut t Transformer) clone_scoped_worker_node(idx int) {
+	if idx < 0 || idx >= t.a.nodes.len {
+		return
+	}
+	mut node := unsafe { &t.a.nodes[idx] }
+	if node.value.len > 0 {
+		node.value = node.value.clone()
+	}
+	if node.typ.len > 0 {
+		node.typ = node.typ.clone()
+	}
+	if node.generic_params.len > 0 {
+		mut params := []string{cap: node.generic_params.len}
+		for param in node.generic_params {
+			params << param.clone()
+		}
+		node.generic_params = params
 	}
 }
 
@@ -1633,6 +1680,9 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 			if t.a.nodes[k].children_start >= base_children {
 				t.a.nodes[k] = t.a.nodes[k].with_shifted_children(child_shift)
 			}
+			if w.worker_scope != unsafe { nil } {
+				t.clone_scoped_worker_node(k)
+			}
 		}
 	}
 	// Rewritten top-level function nodes keep their original index in the master.
@@ -1646,6 +1696,11 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 		if it.fn_idx >= 0 && it.fn_idx < t.transformed_fns.len {
 			t.transformed_fns[it.fn_idx] = true
 		}
+		if w.worker_scope != unsafe { nil } {
+			for idx in it.range_lo .. it.fn_idx + 1 {
+				t.clone_scoped_worker_node(idx)
+			}
+		}
 	}
 	// Replay the call/fn-value resolutions the worker recorded for its
 	// transform-created nodes (Transformer.copy_cloned_resolution writes into the
@@ -1655,16 +1710,19 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 	if !isnil(w.tc.fork_overlay) {
 		for idx, name in w.tc.fork_overlay.resolved_call_names {
 			shifted := if idx >= base_nodes { idx + int(node_shift) } else { idx }
-			t.set_resolved_call_entry(shifted, name)
+			owned_name := if w.worker_scope != unsafe { nil } { name.clone() } else { name }
+			t.set_resolved_call_entry(shifted, owned_name)
 		}
 		for idx, name in w.tc.fork_overlay.resolved_fn_values {
 			shifted := if idx >= base_nodes { idx + int(node_shift) } else { idx }
-			t.set_resolved_fn_value_entry(shifted, name)
+			owned_name := if w.worker_scope != unsafe { nil } { name.clone() } else { name }
+			t.set_resolved_fn_value_entry(shifted, owned_name)
 		}
 	}
 	for name, used in w.used_fns {
 		if used {
-			t.used_fns[name] = true
+			owned_name := if w.worker_scope != unsafe { nil } { name.clone() } else { name }
+			t.used_fns[owned_name] = true
 		}
 	}
 }

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -140,6 +140,58 @@ fn transform_worker_scope_free(scope voidptr) {
 	}
 }
 
+// clone_deferred_worker_writes_from moves writes queued by merge_worker out of
+// a helper arena before that arena is released. In the shared-base path the
+// rewritten top-level fn node is deferred until every worker has joined, so
+// cloning the current master slot alone does not preserve its owned strings.
+fn (mut t Transformer) clone_deferred_worker_writes_from(start int) {
+	for i in start .. t.deferred_base_writes.len {
+		write := t.deferred_base_writes[i]
+		t.deferred_base_writes[i] = match write.kind {
+			0, 1 {
+				DeferredBaseWrite{
+					idx:  write.idx
+					kind: write.kind
+					str:  write.str.clone()
+				}
+			}
+			2 {
+				mut params := []string{cap: write.node.generic_params.len}
+				for param in write.node.generic_params {
+					params << param.clone()
+				}
+				DeferredBaseWrite{
+					idx:  write.idx
+					kind: write.kind
+					node: flat.Node{
+						value:          write.node.value.clone()
+						typ:            write.node.typ.clone()
+						generic_params: params
+						kind_id:        write.node.kind_id
+						pos:            write.node.pos
+						children_start: write.node.children_start
+						children_count: write.node.children_count
+						kind:           write.node.kind
+						op:             write.node.op
+						is_mut:         write.node.is_mut
+					}
+				}
+			}
+			else {
+				mut params := []string{cap: write.gparams.len}
+				for param in write.gparams {
+					params << param.clone()
+				}
+				DeferredBaseWrite{
+					idx:     write.idx
+					kind:    write.kind
+					gparams: params
+				}
+			}
+		}
+	}
+}
+
 // run_parallel_transform transforms the closure-free function bodies across
 // threads when there is enough work, otherwise serially. Returns whether threads
 // were actually used.
@@ -374,8 +426,10 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			C.pthread_join(thread_ids[ci], unsafe { nil })
 			ww := unsafe { &Transformer(args[ci].worker) }
 			t.merge_worker_used_fns(ww)
+			deferred_start := t.deferred_base_writes.len
 			t.merge_worker(ww, chunks[ci + 1], node_starts[ci + 1], child_starts[ci + 1])
 			if ww.worker_scope != unsafe { nil } {
+				t.clone_deferred_worker_writes_from(deferred_start)
 				transform_worker_scope_free(ww.worker_scope)
 			}
 		}

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -98,8 +98,11 @@ $if !windows {
 	fn shared_chunk_thread(arg voidptr) voidptr {
 		a := unsafe { &SharedChunkArgs(arg) }
 		mut w := unsafe { &Transformer(a.worker) }
+		scope := transform_worker_scope_begin(w.scope_parallel_workers)
 		items := unsafe { &[]FnWorkItem(a.items_ptr) }
 		w.transform_pure_items_serial(*items)
+		w.worker_scope = scope
+		transform_worker_scope_leave(scope)
 		return unsafe { nil }
 	}
 }
@@ -108,6 +111,33 @@ $if !windows {
 struct SharedChunkArgs {
 	worker    voidptr // &Transformer
 	items_ptr voidptr // &[]FnWorkItem
+}
+
+// transform_worker_scope_begin starts a helper-local disposable arena in
+// prealloc self-host builds. Ordinary builds retain their existing allocator.
+fn transform_worker_scope_begin(enabled bool) voidptr {
+	$if prealloc {
+		if enabled {
+			return unsafe { prealloc_scope_begin() }
+		}
+	}
+	return unsafe { nil }
+}
+
+fn transform_worker_scope_leave(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_leave(scope) }
+		}
+	}
+}
+
+fn transform_worker_scope_free(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_free_after(scope) }
+		}
+	}
 }
 
 // run_parallel_transform transforms the closure-free function bodies across
@@ -345,6 +375,9 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			ww := unsafe { &Transformer(args[ci].worker) }
 			t.merge_worker_used_fns(ww)
 			t.merge_worker(ww, chunks[ci + 1], node_starts[ci + 1], child_starts[ci + 1])
+			if ww.worker_scope != unsafe { nil } {
+				transform_worker_scope_free(ww.worker_scope)
+			}
 		}
 		t.base_write_intercept = false
 		t.defer_oor_writes = false

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -681,15 +681,6 @@ fn main() {
 	}
 	cmd_v_build := input_is_cmd_v(input_file)
 	scope_prealloc_selfhost := should_scope_prealloc_selfhost(building_v, cmd_v_build)
-	if scope_prealloc_selfhost {
-		// A prealloc-built v3 compiler gets a bump arena per worker thread.
-		// During self-host builds, the parallel transform/cgen workers retain
-		// those arenas long enough to push RSS well past the memory budget. This
-		// throttles only the current build; `no_parallel` still reflects the user
-		// flag that decides whether the target compiler gets v3_no_parallel.
-		current_no_parallel = true
-		current_parallel_transform = false
-	}
 	if building_v || cmd_v_build {
 		if no_parallel {
 			user_defines = user_defines.filter(it != 'parallel')
@@ -886,7 +877,11 @@ fn main() {
 	// and cgen.
 	mut transform_was_parallel := false
 	skip_transform_generics := building_v || cmd_v_build
-	if scope_prealloc_selfhost {
+	mut scope_whole_transform := !current_parallel_transform
+	$if v3_no_parallel ? {
+		scope_whole_transform = true
+	}
+	if scope_prealloc_selfhost && scope_whole_transform {
 		transform_scope := prealloc_scope_begin_for_v3()
 		used_fns, transform_was_parallel = transform.transform_with_used_opt_config(mut a, &pre_tc,
 			used_fns, current_parallel_transform, skip_transform_generics)
@@ -896,8 +891,9 @@ fn main() {
 		clone_typechecker_after_scoped_transform(mut pre_tc, a)
 		prealloc_scope_free_for_v3(transform_scope)
 	} else {
-		used_fns, transform_was_parallel = transform.transform_with_used_opt_config(mut a, &pre_tc,
-			used_fns, current_parallel_transform, skip_transform_generics)
+		used_fns, transform_was_parallel = transform.transform_with_used_opt_config_scoped_workers(mut a,
+			&pre_tc, used_fns, current_parallel_transform, skip_transform_generics,
+			scope_prealloc_selfhost)
 	}
 	b.step_parallel('transform', transform_was_parallel)
 
@@ -971,6 +967,7 @@ fn main() {
 			g.set_c99_mode(prefs.c99)
 			g.set_prealloc('prealloc' in prefs.user_defines)
 			g.set_compiler_vexe(prefs.vexe)
+			g.set_scope_parallel_workers(true)
 			c_code := g.gen_with_used_test_options(a, used_fns, &pre_tc, current_no_parallel,
 				test_files)
 			if !write_text_file_raw(output_file, c_code) {
@@ -979,6 +976,7 @@ fn main() {
 			}
 			cgen_was_parallel = g.was_parallel()
 			scoped_c_flags := g.c_flags()
+			g.free_parallel_worker_scopes()
 			prealloc_scope_leave_for_v3(cgen_scope)
 			generated_c_flags = clone_string_list(scoped_c_flags)
 			prealloc_scope_free_for_v3(cgen_scope)


### PR DESCRIPTION
## Summary

- keep parallel parse/check/transform/cgen enabled for prealloc self-host builds instead of applying a global serial throttle
- put allocation-heavy transform and cgen helper work in disposable per-thread prealloc scopes
- clone transform state that survives a worker before releasing its scope
- preserve the full-stage scoped transform path for serial and `v3_no_parallel` builds

## Benchmark

Command:

```sh
cd vlib/v3
../../v -gc none -prealloc -prod -o v3 v3.v
./v3 -building-v -o v4 v3.v
```

Warm local runs on macOS arm64:

| Stage | Before | After |
| --- | ---: | ---: |
| parse | 78-81 ms | 42-45 ms |
| check | ~151 ms | 47-53 ms |
| transform | 583-637 ms | 177-182 ms |
| cgen | 383-385 ms | 139-146 ms |
| total | 1.39-1.44 s | 0.60-0.61 s |

Final RSS is about 1.04 GB, compared with about 0.74 GB for the recent serial path and about 2.93 GB for the old fully retained parallel path. The explicit no-parallel self-host path remains near 760 MB.

## Tests

- `./vnew -silent test vlib/v3/transform/`
- `./vnew -silent vlib/v3/tests/parallel_cgen_test.v`
- `./vnew -silent vlib/v3/tests/transformer_parity_test.v`
- `./vnew -silent vlib/v3/tests/selfhost_backend_prune_test.v`
- prealloc production self-host benchmark, repeated warm runs
- prealloc `v3_no_parallel` production self-host build
- `git diff --check`