### PR TITLE
ci: run gitly (veb/fasthttp) on Windows and check it serves the expected HTML

### DIFF
--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -297,6 +297,11 @@ jobs:
           v retry -- v install pcre
       - name: Clone gitly
         run: v retry -- git clone --depth 1 -b $env:GITLY_BRANCH $env:GITLY_REPO gitly
+      - name: Compile gitly CSS
+        uses: gha-utilities/sass-build@v0.4.11
+        with:
+          source: gitly/static/css/gitly.scss
+          destination: gitly/static/css/gitly.css
       - name: Compile and run gitly, then check that it serves the expected HTML
         run: |
           cd gitly

--- a/.github/workflows/v_apps_and_modules_compile_ci.yml
+++ b/.github/workflows/v_apps_and_modules_compile_ci.yml
@@ -267,3 +267,37 @@ jobs:
           v retry -- v install markdown
           v retry -- git clone --depth 1 https://github.com/vlang/vpm
           cd vpm && v .
+
+  # Compile gitly on Windows and run its tests/first_run.v smoke test. gitly
+  # serves its pages through veb, which uses the fasthttp backend, so this makes
+  # sure a real veb/fasthttp app both builds and returns the expected HTML on
+  # Windows (a regression test for the Windows fasthttp SOCKET truncation crash).
+  gitly-windows:
+    runs-on: windows-2025
+    timeout-minutes: 60
+    env:
+      VFLAGS: -cc gcc
+      GITLY_REPO: https://github.com/vlang/gitly
+      # TODO: switch back to the default branch once vlang/gitly#291 is merged.
+      GITLY_BRANCH: ci/windows-first-run
+      # Skip the tests that clone a remote GitHub repo; only run the pure
+      # "gitly serves the expected HTML" checks, which do not need network/git.
+      GITLY_TEST_SKIP_REMOTE_REPO: '1'
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build V
+        run: |
+          .\makev.bat -gcc
+          .\v.exe symlink
+      - name: Install sqlite (gitly is built with -d sqlite)
+        run: .\.github\workflows\windows-install-sqlite.bat
+      - name: Install gitly module dependencies
+        run: |
+          v retry -- v install markdown
+          v retry -- v install pcre
+      - name: Clone gitly
+        run: v retry -- git clone --depth 1 -b $env:GITLY_BRANCH $env:GITLY_REPO gitly
+      - name: Compile and run gitly, then check that it serves the expected HTML
+        run: |
+          cd gitly
+          v -g run tests/first_run.v


### PR DESCRIPTION
## What

Adds a `gitly-windows` job to the *V Apps and Modules* workflow that builds [gitly](https://github.com/vlang/gitly), runs it on Windows, and verifies over HTTP that it returns the expected HTML.

## Why

gitly serves all of its pages through **veb**, which uses the **fasthttp** backend. So building gitly and hitting it over HTTP on Windows is a real end-to-end regression test for the Windows fasthttp crash (pointer-sized `SOCKET` truncation in `accept()`), on top of the smaller `examples/veb` smoke test — this is a full app that registers a user, renders templates, serves static assets, etc.

Until now nothing ran a veb/fasthttp *app* on Windows CI.

## How

The new job:
1. Builds V (`makev.bat -gcc`) and installs sqlite + gitly's module deps (`markdown`, `pcre`).
2. Clones gitly and runs its existing `tests/first_run.v`, which compiles gitly with `-d sqlite`, starts it, and performs HTTP GETs asserting the returned HTML (index/welcome page, user page, login state, static CSS, oauth, local repo creation, …).
3. Sets `GITLY_TEST_SKIP_REMOTE_REPO=1` to skip the network/git-heavy tests that clone a remote GitHub repo, keeping the job fast and reliable while still covering the "serves correct HTML" path.

## Testing

`tests/first_run.v` was modernized in **vlang/gitly#291** (it no longer compiled with current V, and its process start/stop was Unix-only). Validated locally on macOS against this V:
- `GITLY_TEST_SKIP_REMOTE_REPO=1 v -g run tests/first_run.v` → **all tests passed**, gitly (veb/fasthttp) served correct HTML, clean shutdown, no leftover process.

## Dependency / merge order

- Depends on **vlang/gitly#291** (the cross-platform `first_run.v`).
- The job temporarily clones that branch via `GITLY_BRANCH: ci/windows-first-run`. Once gitly#291 is merged, drop the `-b`/`GITLY_BRANCH` override so it clones the default branch (there's a `TODO` at that line).