### PR TITLE
checker: require mutable array for reverse_in_place

### DIFF
--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -3610,9 +3610,7 @@ fn (mut c Checker) method_call(mut node ast.CallExpr, mut continue_check &bool) 
 			node.pos)
 	}
 	requires_mut_receiver := method.params[0].is_mut
-		&& ((method.mod == 'builtin' && method.receiver_type.idx() == ast.array_type_idx
-		&& node.kind == .reverse_in_place) || !is_used_outside_receiver_module
-		|| c.fn_has_visible_mutation_for_param(method, 0))
+		&& (!is_used_outside_receiver_module || c.fn_has_visible_mutation_for_param(method, 0))
 	if requires_mut_receiver {
 		to_lock, pos := c.check_for_mut_receiver(mut node.left)
 		// node.is_mut = true

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -3610,7 +3610,9 @@ fn (mut c Checker) method_call(mut node ast.CallExpr, mut continue_check &bool) 
 			node.pos)
 	}
 	requires_mut_receiver := method.params[0].is_mut
-		&& (!is_used_outside_receiver_module || c.fn_has_visible_mutation_for_param(method, 0))
+		&& ((final_left_kind == .array && node.kind == .reverse_in_place)
+		|| !is_used_outside_receiver_module
+		|| c.fn_has_visible_mutation_for_param(method, 0))
 	if requires_mut_receiver {
 		to_lock, pos := c.check_for_mut_receiver(mut node.left)
 		// node.is_mut = true

--- a/vlib/v/checker/fn.v
+++ b/vlib/v/checker/fn.v
@@ -3610,8 +3610,8 @@ fn (mut c Checker) method_call(mut node ast.CallExpr, mut continue_check &bool) 
 			node.pos)
 	}
 	requires_mut_receiver := method.params[0].is_mut
-		&& ((final_left_kind == .array && node.kind == .reverse_in_place)
-		|| !is_used_outside_receiver_module
+		&& ((method.mod == 'builtin' && method.receiver_type.idx() == ast.array_type_idx
+		&& node.kind == .reverse_in_place) || !is_used_outside_receiver_module
 		|| c.fn_has_visible_mutation_for_param(method, 0))
 	if requires_mut_receiver {
 		to_lock, pos := c.check_for_mut_receiver(mut node.left)

--- a/vlib/v/checker/tests/array_reverse_in_place_immutable_err.out
+++ b/vlib/v/checker/tests/array_reverse_in_place_immutable_err.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/array_reverse_in_place_immutable_err.vv:3:2: error: `a` is immutable, declare it with `mut` to make it mutable
+    1 | fn main() {
+    2 |     a := [1, 2, 3]
+    3 |     a.reverse_in_place()
+      |     ^
+    4 | }

--- a/vlib/v/checker/tests/array_reverse_in_place_immutable_err.vv
+++ b/vlib/v/checker/tests/array_reverse_in_place_immutable_err.vv
@@ -1,0 +1,4 @@
+fn main() {
+	a := [1, 2, 3]
+	a.reverse_in_place()
+}

--- a/vlib/v/checker/tests/modules/array_reverse_wrapper_immutable.out
+++ b/vlib/v/checker/tests/modules/array_reverse_wrapper_immutable.out
@@ -1,0 +1,6 @@
+vlib/v/checker/tests/modules/array_reverse_wrapper_immutable/main.v:7:2: error: `values` is immutable, declare it with `mut` to make it mutable
+    5 | fn main() {
+    6 |     values := arraywrap.MyArray([1, 2])
+    7 |     values.flip()
+      |     ~~~~~~
+    8 | }

--- a/vlib/v/checker/tests/modules/array_reverse_wrapper_immutable/arraywrap/arraywrap.v
+++ b/vlib/v/checker/tests/modules/array_reverse_wrapper_immutable/arraywrap/arraywrap.v
@@ -1,0 +1,7 @@
+module arraywrap
+
+pub type MyArray = []int
+
+pub fn (mut a MyArray) flip() {
+	a.reverse_in_place()
+}

--- a/vlib/v/checker/tests/modules/array_reverse_wrapper_immutable/main.v
+++ b/vlib/v/checker/tests/modules/array_reverse_wrapper_immutable/main.v
@@ -1,0 +1,8 @@
+module main
+
+import arraywrap
+
+fn main() {
+	values := arraywrap.MyArray([1, 2])
+	values.flip()
+}

--- a/vlib/v/checker/visible_mutation.v
+++ b/vlib/v/checker/visible_mutation.v
@@ -18,9 +18,18 @@ fn (mut c Checker) visible_param_mutation_cache_key(func ast.Fn, param_idx int) 
 	return '${func.fkey()}|${param_idx}'
 }
 
+fn is_builtin_array_reverse_in_place(func ast.Fn) bool {
+	return func.is_method && func.mod == 'builtin' && func.receiver_type.idx() == ast.array_type_idx
+		&& func.name == 'reverse_in_place'
+}
+
 fn (mut c Checker) fn_has_visible_mutation_for_param(func ast.Fn, param_idx int) bool {
 	if param_idx < 0 || param_idx >= func.params.len || !func.params[param_idx].is_mut {
 		return false
+	}
+	if param_idx == 0 && is_builtin_array_reverse_in_place(func) {
+		// Its body mutates elements through private array storage, which is not otherwise visible.
+		return true
 	}
 	cache_key := c.visible_param_mutation_cache_key(func, param_idx)
 	if cache_key in c.visible_param_mutation_cache {

--- a/vlib/v/tests/modules/private_mutability/private_mutability.v
+++ b/vlib/v/tests/modules/private_mutability/private_mutability.v
@@ -7,6 +7,8 @@ pub:
 	label string
 }
 
+pub type MyArray = []int
+
 fn increment_hidden(mut counter Counter) {
 	counter.hidden++
 }
@@ -26,3 +28,5 @@ pub fn (mut counter Counter) bump_hidden_via_helper() {
 pub fn (counter Counter) label_text() string {
 	return counter.label
 }
+
+pub fn (mut a MyArray) reverse_in_place() {}

--- a/vlib/v/tests/modules/private_mutability/private_mutability_test.v
+++ b/vlib/v/tests/modules/private_mutability/private_mutability_test.v
@@ -9,3 +9,9 @@ fn test_private_receiver_mutation_does_not_require_mut_outside_module() {
 	counter.bump_hidden_via_helper()
 	assert counter.label_text() == ''
 }
+
+fn test_array_alias_method_keeps_private_mutability_behavior() {
+	values := private_mutability.MyArray([1, 2, 3])
+	values.reverse_in_place()
+	assert values == private_mutability.MyArray([1, 2, 3])
+}


### PR DESCRIPTION
Fixes #27742

Classify builtin array.reverse_in_place as a visible receiver mutation. Its implementation mutates elements through private array storage, which the generic visible-mutation body scan intentionally ignores.

Putting the exception in fn_has_visible_mutation_for_param covers both direct calls and public wrapper methods while leaving user-defined methods on array aliases on the normal analysis path. Add regression tests for the direct call, an alias override, and a cross-module wrapper.

Tests:
- ./vnew -silent vlib/v/compiler_errors_test.v
- VTEST_ONLY=array_reverse_in_place_immutable_err ./vnew -silent vlib/v/compiler_errors_test.v
- VTEST_ONLY=array_reverse_wrapper_immutable ./vnew -silent vlib/v/compiler_errors_test.v
- ./vnew -silent test vlib/v/checker/
- ./vnew -silent vlib/v/tests/modules/private_mutability/private_mutability_test.v
- ./vnew -silent vlib/builtin/array_test.v
- ./vnew -silent vlib/v/slow_tests/inout/compiler_test.v