### PR TITLE
docs: clarify implicit array slice cloning

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1380,9 +1380,12 @@ memory location when the size increases thus becoming independent from the
 parent array (*copy on grow*). In particular pushing elements to a slice
 does not alter the parent:
 
-When a slice expression like `a[2..4]` is assigned to another array outside
-`unsafe`, V inserts an implicit `.clone()` and shows a notice. The
-shared-memory examples below therefore use `unsafe {}` intentionally.
+When a slice expression like `a[2..4]` is assigned outside `unsafe` and either
+the parent array or the resulting slice is mutable, V inserts an implicit
+`.clone()` and shows a notice. This prevents changes through one array from
+affecting the other. If both arrays are immutable, the slice safely reuses the
+parent array's memory without cloning. The shared-memory examples below
+therefore use `unsafe {}` intentionally.
 
 ```v
 mut a := [0, 1, 2, 3, 4, 5]
@@ -1433,9 +1436,11 @@ println(a) // [0, 1, 2, 3, 4, 5]
 println(b) // [7, 3]
 ```
 
-Note that, by default, V makes an implicit clone of the slice and displays a notice about this.
-So without the `.clone()` call the result of the code above will be the same.
-Make the slice in an `unsafe {}` block if you want to reuse memory,
+If either the parent array or the slice is mutable, V makes an implicit clone
+of the slice and displays a notice. Therefore, without the `.clone()` call,
+the result of the code above will be the same. When both arrays are immutable,
+the slice reuses the parent array's memory because neither array can be changed.
+Make the slice in an `unsafe {}` block if you want to share mutable memory;
 otherwise use explicit cloning.
 
 ##### Slices with negative indexes


### PR DESCRIPTION
Fixes #27745

The compiler intentionally inserts an implicit clone when either the parent array or the resulting slice is mutable. When both are immutable, sharing the backing memory is safe and avoids an unnecessary allocation.

This updates both descriptions in the array slices documentation to state that distinction and explain when `unsafe` is needed.

Validation:
- `./vnew check-md doc/docs.md`