### PR TITLE
cgen: fix option sumtype match and static method refs

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -10259,6 +10259,21 @@ fn (mut g Gen) ident(node ast.Ident) {
 				} else {
 					g.table.final_sym(g.unwrap_generic(resolved_var.typ))
 				}
+				if runtime_option_type.has_flag(.option) && resolved_var.is_unwrapped
+					&& smartcast_types.len == 1 {
+					option_payload_type :=
+						g.unwrap_generic(g.recheck_concrete_type(runtime_option_type)).clear_option_and_result()
+					smartcast_payload_type :=
+						g.unwrap_generic(g.recheck_concrete_type(smartcast_types[0])).clear_option_and_result()
+					// A `none` guard on `?SumType` records the unwrapped sum type as a
+					// smartcast. It only removes the option wrapper; it does not select a
+					// sumtype variant, so bypass the variant-unwrapping loop below.
+					if g.table.final_sym(option_payload_type).kind == .sum_type
+						&& smartcast_payload_type == option_payload_type {
+						g.unwrap_option_type(runtime_option_type, ident_option_name, is_auto_heap)
+						return
+					}
+				}
 				interface_scalar_smartcast_needs_deref := interface_source_is_interface
 					&& smartcast_types.len > 0 && smartcast_types.last().is_ptr()
 					&& !g.inside_selector_lhs

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -1528,6 +1528,13 @@ fn (mut w Walker) expr(node_ ast.Expr) {
 		}
 		ast.Comment {}
 		ast.EnumVal {
+			if w.table.final_sym(node.typ).kind == .function {
+				// A forward-referenced static method value is parsed as an EnumVal,
+				// because its declaration is not known to the parser yet. The checker
+				// resolves its function type, so retain the method just like an Ident
+				// function value.
+				w.fn_by_name('${node.enum_name}__static__${node.val}')
+			}
 			if e := w.table.enum_decls[node.enum_name] {
 				filtered := e.fields.filter(it.name == node.val)
 				if filtered.len != 0 && filtered[0].expr !is ast.EmptyExpr {

--- a/vlib/v/tests/assign/assign_static_method_to_anon_fn_test.v
+++ b/vlib/v/tests/assign/assign_static_method_to_anon_fn_test.v
@@ -1,13 +1,13 @@
 struct Foo {
 }
 
-fn Foo.bar() string {
-	println('bar')
-	return 'bar'
-}
-
 fn test_assign_static_method_to_anon_fn() {
 	anon_fn := Foo.bar
 	ret := anon_fn()
 	assert ret == 'bar'
+}
+
+fn Foo.bar() string {
+	println('bar')
+	return 'bar'
 }

--- a/vlib/v/tests/options/option_sumtype_unwrap_test.v
+++ b/vlib/v/tests/options/option_sumtype_unwrap_test.v
@@ -38,3 +38,24 @@ fn test_main() {
 	assert Tx.empty.frame_bytes(none)! == [u8(0)]
 	assert Tx.data.frame_bytes(u8(123))! == [u8(1), 123]
 }
+
+struct Null {}
+
+type Id = Null | int | string
+
+fn normalize_id(id ?Id) Id {
+	if id == none {
+		return Null{}
+	}
+	match id {
+		int { return id }
+		string { return id }
+		Null { return id }
+	}
+
+	return Null{}
+}
+
+fn test_match_option_sumtype_after_none_guard() {
+	assert normalize_id(?Id(5)) == Id(5)
+}


### PR DESCRIPTION
## Summary

- unwrap payload-only option-of-sumtype smartcasts before matching their variant tag
- retain forward-referenced static methods that remain EnumVal nodes after checking
- add regressions for both codegen failures

## Tests

- ./vnew -cstrict -cc clang vlib/v/tests/assign/assign_static_method_to_anon_fn_test.v
- ./vnew -cstrict -cc clang vlib/v/tests/options/option_sumtype_unwrap_test.v
- ./vnew -silent vlib/v/gen/c/coutput_test.v
- ./vnew -silent vlib/v/compiler_errors_test.v
- ./vnew -silent test vlib/v/

Closes #27732
Closes #27733