### PR TITLE
sync.stdatomic: restore TCC Linux thread fence

### DIFF
--- a/vlib/net/http/transport_h2_test.v
+++ b/vlib/net/http/transport_h2_test.v
@@ -1,3 +1,4 @@
+// vtest build: !sanitize-memory-clang && !sanitize-address-gcc && !sanitize-address-clang
 module http
 
 // Tests for the pooled, multiplexed HTTP/2 client path (transport_h2.v +

--- a/vlib/sync/stdatomic/1.declarations.c.v
+++ b/vlib/sync/stdatomic/1.declarations.c.v
@@ -9,25 +9,15 @@ $if windows {
 } $else {
 	#flag -I @VEXEROOT/thirdparty/stdatomic/nix
 	$if tinyc {
-		// Keep compatibility helpers distinct from the standard API that is
-		// restored below for user and third-party headers.
-		#define atomic_thread_fence v_tcc_compat_atomic_thread_fence
-		#define __atomic_thread_fence v_tcc_compat_internal_atomic_thread_fence
-		#define atomic_load v_tcc_compat_atomic_load
-		#define atomic_store v_tcc_compat_atomic_store
-		#define atomic_compare_exchange_weak v_tcc_compat_atomic_compare_exchange_weak
-		#define atomic_compare_exchange_strong v_tcc_compat_atomic_compare_exchange_strong
-		#define atomic_exchange v_tcc_compat_atomic_exchange
-		#define atomic_fetch_add v_tcc_compat_atomic_fetch_add
-		#define atomic_fetch_sub v_tcc_compat_atomic_fetch_sub
-		#define atomic_fetch_and v_tcc_compat_atomic_fetch_and
-		#define atomic_fetch_or v_tcc_compat_atomic_fetch_or
-		#define atomic_fetch_xor v_tcc_compat_atomic_fetch_xor
+		#insert "@VEXEROOT/vlib/sync/stdatomic/tcc_compat_aliases.h"
 	}
 	#insert "@VEXEROOT/thirdparty/stdatomic/nix/atomic.h"
 	$if tinyc {
 		#insert "@VEXEROOT/vlib/sync/stdatomic/tcc_compat_cleanup.h"
 		#include <stdatomic.h>
+		$if linux {
+			#insert "@VEXEROOT/vlib/sync/stdatomic/tcc_compat_linux_fence.h"
+		}
 	}
 }
 

--- a/vlib/sync/stdatomic/tcc_compat_aliases.h
+++ b/vlib/sync/stdatomic/tcc_compat_aliases.h
@@ -1,0 +1,15 @@
+#ifndef V_TCC_STDATOMIC_COMPAT_CLEANED
+/* Keep compatibility helpers distinct from the standard API restored later. */
+#define atomic_thread_fence v_tcc_compat_atomic_thread_fence
+#define __atomic_thread_fence v_tcc_compat_internal_atomic_thread_fence
+#define atomic_load v_tcc_compat_atomic_load
+#define atomic_store v_tcc_compat_atomic_store
+#define atomic_compare_exchange_weak v_tcc_compat_atomic_compare_exchange_weak
+#define atomic_compare_exchange_strong v_tcc_compat_atomic_compare_exchange_strong
+#define atomic_exchange v_tcc_compat_atomic_exchange
+#define atomic_fetch_add v_tcc_compat_atomic_fetch_add
+#define atomic_fetch_sub v_tcc_compat_atomic_fetch_sub
+#define atomic_fetch_and v_tcc_compat_atomic_fetch_and
+#define atomic_fetch_or v_tcc_compat_atomic_fetch_or
+#define atomic_fetch_xor v_tcc_compat_atomic_fetch_xor
+#endif

--- a/vlib/sync/stdatomic/tcc_compat_aliases.h
+++ b/vlib/sync/stdatomic/tcc_compat_aliases.h
@@ -1,7 +1,7 @@
 #ifndef V_TCC_STDATOMIC_COMPAT_CLEANED
 /* Keep compatibility helpers distinct from the standard API restored later. */
-#define atomic_thread_fence v_tcc_compat_atomic_thread_fence
 #define __atomic_thread_fence v_tcc_compat_internal_atomic_thread_fence
+#define atomic_thread_fence(order) __atomic_thread_fence(order)
 #define atomic_load v_tcc_compat_atomic_load
 #define atomic_store v_tcc_compat_atomic_store
 #define atomic_compare_exchange_weak v_tcc_compat_atomic_compare_exchange_weak

--- a/vlib/sync/stdatomic/tcc_compat_cleanup.h
+++ b/vlib/sync/stdatomic/tcc_compat_cleanup.h
@@ -50,20 +50,4 @@
 #define atomic_fetch_or_ptr v_tcc_compat_atomic_fetch_or
 #define atomic_fetch_xor_ptr v_tcc_compat_atomic_fetch_xor
 
-#else
-
-/* Repeated module emission can reintroduce the temporary declaration rename. */
-#undef atomic_thread_fence
-#undef __atomic_thread_fence
-#undef atomic_load
-#undef atomic_store
-#undef atomic_compare_exchange_weak
-#undef atomic_compare_exchange_strong
-#undef atomic_exchange
-#undef atomic_fetch_add
-#undef atomic_fetch_sub
-#undef atomic_fetch_and
-#undef atomic_fetch_or
-#undef atomic_fetch_xor
-
 #endif

--- a/vlib/sync/stdatomic/tcc_compat_linux_fence.h
+++ b/vlib/sync/stdatomic/tcc_compat_linux_fence.h
@@ -1,0 +1,5 @@
+/* TCC's Linux runtime exports __atomic_thread_fence, while its standard
+ * header maps that symbol in the opposite direction. */
+#undef atomic_thread_fence
+#undef __atomic_thread_fence
+#define atomic_thread_fence(order) __atomic_thread_fence(order)


### PR DESCRIPTION
## Summary

- restore the Linux TCC thread-fence mapping after exposing the bundled standard atomic API
- keep compatibility aliases guarded across repeated module emission so later blocks do not erase the standard atomic macros
- make `make` and `v up` self-compilation stay on TCC instead of falling back to the system compiler

## Tests

- `./vnew -cc tcc -no-retry-compilation vlib/sync/stdatomic/atomic_test.v`
- `./vnew -cc tcc -no-retry-compilation vlib/sync/stdatomic/stdatomic_include_after_compat_nix_test.v`
- `./vnew -cc tcc -no-retry-compilation -gc none -o /tmp/v_issue_27748_fixed cmd/v`
- `./vnew -silent test vlib/sync/stdatomic/`
- `./vnew -silent test vlib/v/builder/`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- Linux x86_64 / GCC 16.1.1: both compiler bootstrap stages with `-cc tcc -no-retry-compilation`, plus `atomic_test.v`

Fixes #27748