### PR TITLE
net.http: avoid TLS test cleanup deadlock

### DIFF
--- a/vlib/net/http/server_tls_test.v
+++ b/vlib/net/http/server_tls_test.v
@@ -204,20 +204,25 @@ fn test_server_tls_close_waits_for_active_request() {
 		}
 		done <- resp.body
 	}()
+	mut start_failure := ''
 	select {
 		_ := <-started {}
 		msg := <-done {
-			srv.close()
-			t.wait()
-			assert false, 'client finished before handler started: ${msg}'
-			return
+			start_failure = 'client finished before handler started: ${msg}'
 		}
-		2 * time.second {
-			srv.close()
-			t.wait()
-			assert false, 'timed out waiting for handler to start'
-			return
+		10 * time.second {
+			start_failure = 'timed out waiting for handler to start'
 		}
+	}
+	if start_failure != '' {
+		// The request can enter BlockingHandler just after the select deadline.
+		// Release it before waiting for the server thread, otherwise this failure
+		// path deadlocks forever instead of reporting the original timeout.
+		release <- true
+		srv.close()
+		t.wait()
+		assert false, start_failure
+		return
 	}
 	srv.close()
 	time.sleep(50 * time.millisecond)


### PR DESCRIPTION
The Windows GCC self-test job can hang until its job timeout in `vlib/net/http/server_tls_test.v`.

`test_server_tls_close_waits_for_active_request` had a race in its failure cleanup: if the startup deadline fired just before the request entered `BlockingHandler`, the branch closed the server and waited for its thread without releasing the handler. The handler then waited forever on its release channel while the cleanup waited forever on the server thread.

This change:
- records startup failures before cleanup
- releases the blocking handler before joining the server on failure
- raises the startup allowance from 2 seconds to 10 seconds for loaded Windows runners
- preserves the close-before-release ordering on the successful path that the test is intended to verify

Failing job: https://github.com/vlang/v/actions/runs/29212462821/job/86702393907

Validation:
- `./vnew -cc gcc test vlib/net/http/server_tls_test.v`
- targeted shutdown test passed five consecutive runs
- forced deadline branch exited promptly with the expected assertion instead of hanging
- cross-compiled the test source with MinGW Windows GCC