### PR TITLE
ci: split memory sanitizer checks

### DIFF
--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -314,10 +314,11 @@ jobs:
         run: ./v -cc clang -cg -cstrict -o v cmd/v
       - name: Test vlib/v/tests/ (V compiled with -fsanitize=memory)
         run: |
-          ./v -cflags -fsanitize=memory -o v cmd/v
-          ./v -cc tcc -silent test-self -msan-compiler vlib/v/tests/
+          # Preserve existing `// vtest build: !sanitize-memory-clang` exclusions.
+          GITHUB_JOB=sanitize-memory-clang ./v -cflags -fsanitize=memory -o v cmd/v
+          GITHUB_JOB=sanitize-memory-clang ./v -cc tcc -silent test-self -msan-compiler vlib/v/tests/
       - name: Build examples (V compiled with -fsanitize=memory)
-        run: ./v -silent build-examples
+        run: GITHUB_JOB=sanitize-memory-clang ./v -silent build-examples
 
   sanitize-address-clang-without-gc:
     runs-on: ubuntu-22.04

--- a/.github/workflows/sanitized_ci.yml
+++ b/.github/workflows/sanitized_ci.yml
@@ -287,6 +287,31 @@ jobs:
         run: ./v -cc clang -cg -cstrict -o v cmd/v
       - name: Self tests (-fsanitize=memory)
         run: ./v -cflags -fsanitize=memory -silent test-self -msan-compiler vlib
+
+  sanitize-memory-clang-compiler:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 300
+    env:
+      VFLAGS: -cc clang -gc none -cflags -fno-omit-frame-pointer
+      VJOBS: 1
+      VNATIVE_SKIP_LIBC_VV: 1
+      VTEST_SHOW_LONGEST_BY_RUNTIME: 3
+      VTEST_SHOW_LONGEST_BY_COMPTIME: 3
+      VTEST_SHOW_LONGEST_BY_TOTALTIME: 3
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/cache-apt-packages-action
+      - name: Build V
+        run: make -j4 && ./v symlink
+      - name: Install dependencies
+        run: |
+          .github/workflows/disable_azure_mirror.sh
+          ./v retry -- sudo apt update
+          ./v retry -- sudo apt install --quiet -y postgresql libpq-dev libssl-dev sqlite3 libsqlite3-dev valgrind
+          ./v retry -- sudo apt install --quiet -y libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev libegl-dev
+          ./v retry -- sudo apt install clang
+      - name: Recompile V with clang and -cstrict
+        run: ./v -cc clang -cg -cstrict -o v cmd/v
       - name: Test vlib/v/tests/ (V compiled with -fsanitize=memory)
         run: |
           ./v -cflags -fsanitize=memory -o v cmd/v


### PR DESCRIPTION
## Summary

- split the runtime-instrumented vlib MemorySanitizer pass from the compiler-instrumented tests and example builds
- preserve both sanitizer coverage modes and VJOBS=1
- retain the existing sanitize-memory-clang check and give each expensive phase its own 300-minute budget

## Why

The cancelled job made continuous progress rather than hanging. Its first MemorySanitizer pass took about 116 minutes, the compiler-instrumented pass took about 170 minutes, and the example build ran for another 10 minutes before the overall 300-minute timeout cancelled it:

https://github.com/vlang/v/actions/runs/29206851815/job/86687639652

A later run completed the same work in about 192 minutes, showing substantial runner-speed variance:

https://github.com/vlang/v/actions/runs/29212462821/job/86702394127

Keeping both modes serial in one job makes the check vulnerable to slower runners. Separate jobs preserve coverage while allowing the independent passes to run concurrently.

## Validation

- parsed .github/workflows/sanitized_ci.yml with Ruby YAML
- git diff --check
- full MemorySanitizer execution is left to Ubuntu CI because it is a multi-hour platform-specific run