### PR TITLE
tools: retry transient test execution failures

### DIFF
--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -352,6 +352,10 @@ pub fn (mut ts TestSession) system(cmd string, mtc MessageThreadContext) int {
 	return os.system(cmd)
 }
 
+fn should_retry_execution(result os.Result) bool {
+	return result.output.trim_space().len == 0 || result.exit_code < 0
+}
+
 pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 	os.setenv(c_error_bug_report_disabled_env, '1', true)
 	mut skip_files := []string{}
@@ -803,8 +807,9 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 		}
 		if r.exit_code != 0 {
 			mut trimmed_output := r.output.trim_space()
-			if trimmed_output.len == 0 {
-				// retry running at least 1 more time, to avoid CI false positives as much as possible
+			if should_retry_execution(r) {
+				// Retry at least once when the process produced no output or could not be started.
+				// Both can be transient under load on CI runners.
 				details.retry++
 			}
 			if details.retry != 0 {

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -353,7 +353,9 @@ pub fn (mut ts TestSession) system(cmd string, mtc MessageThreadContext) int {
 }
 
 fn should_retry_execution(result os.Result) bool {
-	return result.output.trim_space().len == 0 || result.exit_code < 0
+	output := result.output.trim_space()
+	return output.len == 0 || output.starts_with('exec failed')
+		|| (output.starts_with('exec(') && output.ends_with(') failed'))
 }
 
 pub fn new_test_session(_vargs string, will_compile bool) TestSession {

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -358,6 +358,13 @@ fn should_retry_execution(result os.Result) bool {
 		|| (output.starts_with('exec(') && output.ends_with(') failed'))
 }
 
+fn add_automatic_execution_retry(mut details TestDetails, result os.Result) {
+	if should_retry_execution(result) {
+		// Empty output and process-start failures can both be transient under load on CI runners.
+		details.retry++
+	}
+}
+
 pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 	os.setenv(c_error_bug_report_disabled_env, '1', true)
 	mut skip_files := []string{}
@@ -718,6 +725,7 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 		ts.append_message_with_duration(.cmd_end, '', cmd_duration, mtc)
 
 		if status != 0 {
+			add_automatic_execution_retry(mut details, res)
 			os.setenv('VTEST_RETRY_MAX', '${details.retry}', true)
 			for retry := 1; retry <= details.retry; retry++ {
 				if !details.hide_retries {
@@ -809,11 +817,7 @@ fn worker_trunner(mut p pool.PoolProcessor, idx int, thread_id int) voidptr {
 		}
 		if r.exit_code != 0 {
 			mut trimmed_output := r.output.trim_space()
-			if should_retry_execution(r) {
-				// Retry at least once when the process produced no output or could not be started.
-				// Both can be transient under load on CI runners.
-				details.retry++
-			}
+			add_automatic_execution_retry(mut details, r)
 			if details.retry != 0 {
 				failure_output.write_string(separator)
 				failure_output.writeln(' retry: 0 ; max_retry: ${details.retry} ; r.exit_code: ${r.exit_code} ; trimmed_output.len: ${trimmed_output.len}')

--- a/cmd/tools/modules/testing/common_test.v
+++ b/cmd/tools/modules/testing/common_test.v
@@ -8,10 +8,18 @@ fn test_should_retry_execution() {
 		output:    'exec("test") failed'
 	})
 	assert should_retry_execution(os.Result{
+		exit_code: 8
+		output:    'exec failed (CreateProcess) with code 8: Not enough memory resources.'
+	})
+	assert should_retry_execution(os.Result{
 		exit_code: 1
 	})
 	assert !should_retry_execution(os.Result{
 		exit_code: 1
 		output:    'test assertion failed'
+	})
+	assert !should_retry_execution(os.Result{
+		exit_code: -1
+		output:    'child crashed'
 	})
 }

--- a/cmd/tools/modules/testing/common_test.v
+++ b/cmd/tools/modules/testing/common_test.v
@@ -1,0 +1,17 @@
+module testing
+
+import os
+
+fn test_should_retry_execution() {
+	assert should_retry_execution(os.Result{
+		exit_code: -1
+		output:    'exec("test") failed'
+	})
+	assert should_retry_execution(os.Result{
+		exit_code: 1
+	})
+	assert !should_retry_execution(os.Result{
+		exit_code: 1
+		output:    'test assertion failed'
+	})
+}

--- a/cmd/tools/modules/testing/common_test.v
+++ b/cmd/tools/modules/testing/common_test.v
@@ -23,3 +23,19 @@ fn test_should_retry_execution() {
 		output:    'child crashed'
 	})
 }
+
+fn test_add_automatic_execution_retry() {
+	mut details := TestDetails{
+		retry: 2
+	}
+	add_automatic_execution_retry(mut details, os.Result{
+		exit_code: -1
+		output:    'exec("test") failed'
+	})
+	assert details.retry == 3
+	add_automatic_execution_retry(mut details, os.Result{
+		exit_code: 1
+		output:    'test assertion failed'
+	})
+	assert details.retry == 3
+}


### PR DESCRIPTION
## Summary

- retry a test execution once when `os.execute` cannot start the child process
- preserve the existing automatic retry for failures that produce no output
- add focused coverage for retryable and non-retryable execution results

This addresses the transient `exec(...passing_test) failed` error in [Tools CI job 86687639540](https://github.com/vlang/v/actions/runs/29206851817/job/86687639540), where `vtest_test.v` reported two failures instead of the expected one.

## Tests

- `./vnew cmd/tools/modules/testing/common_test.v`
- `./vnew cmd/tools/vtest_test.v`
- `VFLAGS= ./vnew -silent -cc clang -cflags -fsanitize=thread cmd/tools/vtest_test.v`
- `VFLAGS= ./vnew -silent test-self cmd` (41 passed, 1 skipped)