### PR TITLE
ci: bound v up release downloads

### DIFF
--- a/.github/workflows/vup_works.yml
+++ b/.github/workflows/vup_works.yml
@@ -50,7 +50,17 @@ jobs:
         run: make && ./v symlink && ./v version
 
       - name: Download latest release ZIP
-        run: ./v retry -- ./v download --sha256 https://github.com/vlang/v/releases/latest/download/${{ matrix.zip }}
+        run: |
+          curl --fail --location --silent --show-error \
+            --connect-timeout 15 \
+            --max-time 180 \
+            --retry 5 \
+            --retry-all-errors \
+            --retry-delay 2 \
+            --retry-max-time 600 \
+            --output "${{ matrix.zip }}" \
+            "https://github.com/vlang/v/releases/latest/download/${{ matrix.zip }}"
+          shasum -a 256 "${{ matrix.zip }}"
 
       - name: Extract ZIP 1, no changes
         run: |


### PR DESCRIPTION
## Summary

- replace the `v download` setup step in the v-up workflow with curl
- bound each transfer to 180 seconds and the retry window to 600 seconds
- retain SHA-256 reporting for the downloaded release archive

The macOS Intel job frequently spends the full 900-second `v retry` budget inside the first `v download` attempt, so the outer retry never gets another attempt. This addresses [job 86723589191](https://github.com/vlang/v/actions/runs/29220174369/job/86723589191) and the same recurring failure in recent runs.

## Validation

- parsed `.github/workflows/vup_works.yml` with Ruby YAML
- ran the exact curl flags against `v_macos_x86_64.zip` (completed in 6.3 seconds)
- verified SHA-256: `de19ef02874aec502f091b75e504e4836da38f627ddf7f7f9ecf6e8cf262f9d0`
- verified archive integrity with `unzip -tq`
- `git diff --check`