### PR TITLE
json: deprecate legacy module

### DIFF
--- a/cmd/tools/modules/vshare/api.v
+++ b/cmd/tools/modules/vshare/api.v
@@ -1,6 +1,6 @@
 module vshare
 
-import json
+import json2
 
 const max_response_excerpt_len = 200
 
@@ -18,7 +18,7 @@ pub fn share_url_from_response(status_code int, body string) !string {
 		}
 		return error('Failed to share code: playground returned HTTP ${status_code}: ${excerpt}')
 	}
-	response := json.decode(ShareResponse, body) or {
+	response := json2.decode[ShareResponse](body) or {
 		return error('Failed to decode playground response: ${err.msg()}')
 	}
 	if response.error != '' {

--- a/cmd/tools/vbug-report-send.v
+++ b/cmd/tools/vbug-report-send.v
@@ -1,7 +1,7 @@
 module main
 
 import flag
-import json
+import json2
 import net.http
 import os
 import time
@@ -72,7 +72,7 @@ fn send_bug_report(config SendConfig) !CreateBugReportResponse {
 	if response.status_code < 200 || response.status_code >= 300 {
 		return error('server responded with HTTP ${response.status_code}')
 	}
-	return json.decode(CreateBugReportResponse, response.body)!
+	return json2.decode[CreateBugReportResponse](response.body)!
 }
 
 fn main() {

--- a/cmd/tools/vbug-report.v
+++ b/cmd/tools/vbug-report.v
@@ -2,7 +2,7 @@ module main
 
 import db.sqlite
 import flag
-import json
+import json2
 import os
 import rand
 import time
@@ -240,7 +240,7 @@ pub fn (mut app App) create(mut ctx Context) veb.Result {
 		ctx.res.set_status(.bad_request)
 		return ctx.text('report body is too large')
 	}
-	report := json.decode(BugReport, ctx.req.data) or {
+	report := json2.decode[BugReport](ctx.req.data) or {
 		return ctx.request_error('invalid report JSON: ${err}')
 	}
 	if report.kind != 'v-c-compiler-error' {

--- a/cmd/tools/vcover/main.v
+++ b/cmd/tools/vcover/main.v
@@ -6,7 +6,7 @@ module main
 import os
 import log
 import flag
-import json
+import json2
 import arrays
 import encoding.csv
 
@@ -40,7 +40,7 @@ fn (mut ctx Context) load_meta(folder string) {
 		mfile := omfile.replace('\\', '/')
 		content := os.read_file(mfile) or { '' }
 		meta := os.file_name(mfile.replace(metadata_extension, ''))
-		data := json.decode(MetaData, content) or {
+		data := json2.decode[MetaData](content) or {
 			log.error('${@METHOD} failed to load ${mfile}')
 			continue
 		}

--- a/cmd/tools/vdoc/vdoc.v
+++ b/cmd/tools/vdoc/vdoc.v
@@ -8,7 +8,7 @@ import runtime
 import document as doc
 import v.vmod
 import v.util
-import json
+import json2
 import term
 
 struct Readme {
@@ -67,7 +67,7 @@ fn (vd &VDoc) gen_json(d doc.Doc) string {
 		jw.write_string('"description":"${escape(comments)}",')
 	}
 	jw.write_string('"contents":')
-	jw.write_string(json.encode(d.contents.keys().map(d.contents[it])))
+	jw.write_string(json2.encode(d.contents.keys().map(d.contents[it])))
 	jw.write_string(',"generator":"vdoc","time_generated":"${d.time_generated.str()}"}')
 	return jw.str()
 }

--- a/cmd/tools/vls.v
+++ b/cmd/tools/vls.v
@@ -16,7 +16,6 @@ import net.http
 import runtime
 import crypto.sha256
 import time
-import json
 
 enum UpdateSource {
 	github_releases
@@ -425,7 +424,7 @@ fn (upd VlsUpdater) cli_error(err IError) {
 			print_backtrace()
 		}
 		.json {
-			print('{"error":{"message":${json.encode(err.msg())},"code":"${err.code()}","details":${json.encode(upd.error_details(err).trim_space())}}}')
+			print('{"error":{"message":${json2.encode(err.msg())},"code":"${err.code()}","details":${json2.encode(upd.error_details(err).trim_space())}}}')
 			flush_stdout()
 		}
 		.silent {}

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -4,7 +4,7 @@ import os
 import net.http
 import net.urllib
 import v.vmod
-import json
+import json2
 import term
 import time
 
@@ -140,7 +140,7 @@ fn get_mod_vpm_info_with_selector(name string, mut selector VpmInstallServerSele
 			errors << s.trim_space().limit(100) + '...'
 			continue
 		}
-		mod := json.decode(ModuleVpmInfo, s) or {
+		mod := json2.decode[ModuleVpmInfo](s) or {
 			errors << 'Skipping module `${name}`, since its information is not in json format.'
 			continue
 		}

--- a/cmd/tools/vquest.v
+++ b/cmd/tools/vquest.v
@@ -4,7 +4,7 @@ import os
 import cli
 import net.http
 import net.urllib
-import json
+import json2
 import rand
 import term
 
@@ -248,7 +248,7 @@ fn get_excluded_os_labels(user_os string) []string {
 fn fetch_issue_details(issue_number int) !IssueDetails {
 	url := '${issue_endpoint}/${issue_number}'
 	body := api_get(url)!
-	return json.decode(IssueDetails, body)!
+	return json2.decode[IssueDetails](body)!
 }
 
 fn format_bug_report(issue IssueDetails, user_os string) string {
@@ -306,7 +306,7 @@ fn run_document(_cmd cli.Command) ! {
 fn fetch_total_count(query string) !int {
 	url := build_search_url(query, 1, 1)
 	body := api_get(url)!
-	resp := json.decode(SearchResponse, body)!
+	resp := json2.decode[SearchResponse](body)!
 	return resp.total_count
 }
 
@@ -357,7 +357,7 @@ fn flag_is_set(cmd cli.Command, name string) bool {
 fn fetch_issue_from_page(query string, page int) !Issue {
 	url := build_search_url(query, page, per_page)
 	body := api_get(url)!
-	resp := json.decode(SearchResponse, body)!
+	resp := json2.decode[SearchResponse](body)!
 	if resp.items.len == 0 {
 		return error('no issues returned for page ${page}')
 	}

--- a/vlib/json/README.md
+++ b/vlib/json/README.md
@@ -1,5 +1,7 @@
 ## Description
 
+The `json` module is deprecated and will be removed soon. Use the pure V `json2` module instead.
+
 The `json` module provides encoding/decoding of V data structures to/from JSON.
 For more details, see also the
 [JSON section of the V documentation](https://github.com/vlang/v/blob/master/doc/docs.md#json)

--- a/vlib/json/json_primitives.c.v
+++ b/vlib/json/json_primitives.c.v
@@ -1,6 +1,7 @@
 // Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
+@[deprecated: '`json` will be removed soon; use the pure V `json2` module instead']
 module json
 
 import math

--- a/vlib/json/tests/json_alias_test.v
+++ b/vlib/json/tests/json_alias_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 pub struct User {

--- a/vlib/json/tests/json_decode_anon_struct_test.v
+++ b/vlib/json/tests/json_decode_anon_struct_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 fn test_main() {

--- a/vlib/json/tests/json_decode_arr_ref_test.v
+++ b/vlib/json/tests/json_decode_arr_ref_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Test {

--- a/vlib/json/tests/json_decode_embed_test.v
+++ b/vlib/json/tests/json_decode_embed_test.v
@@ -1,3 +1,5 @@
+// vtest vflags: -w
+
 module main
 
 import json

--- a/vlib/json/tests/json_decode_option_alias_field_test.v
+++ b/vlib/json/tests/json_decode_option_alias_field_test.v
@@ -1,3 +1,5 @@
+// vtest vflags: -w
+
 module main
 
 import json

--- a/vlib/json/tests/json_decode_option_alias_test.v
+++ b/vlib/json/tests/json_decode_option_alias_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Empty {}

--- a/vlib/json/tests/json_decode_option_enum_test.v
+++ b/vlib/json/tests/json_decode_option_enum_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 enum Lang {

--- a/vlib/json/tests/json_decode_struct_default_test.v
+++ b/vlib/json/tests/json_decode_struct_default_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Bar {

--- a/vlib/json/tests/json_decode_struct_ptr_test.v
+++ b/vlib/json/tests/json_decode_struct_ptr_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Message {

--- a/vlib/json/tests/json_decode_struct_with_default_test.v
+++ b/vlib/json/tests/json_decode_struct_with_default_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 pub struct Response {

--- a/vlib/json/tests/json_decode_sumtype_option_test.v
+++ b/vlib/json/tests/json_decode_sumtype_option_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 type Any = string | f32 | bool | ?int

--- a/vlib/json/tests/json_decode_test.v
+++ b/vlib/json/tests/json_decode_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct TestTwin {

--- a/vlib/json/tests/json_decode_with_encode_arg_test.v
+++ b/vlib/json/tests/json_decode_with_encode_arg_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct TodoDto {

--- a/vlib/json/tests/json_decode_with_generic_array_test.v
+++ b/vlib/json/tests/json_decode_with_generic_array_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Response[T] {

--- a/vlib/json/tests/json_decode_with_generic_test.v
+++ b/vlib/json/tests/json_decode_with_generic_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Result[T] {

--- a/vlib/json/tests/json_decode_with_option_arg_test.v
+++ b/vlib/json/tests/json_decode_with_option_arg_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 import os
 

--- a/vlib/json/tests/json_decode_with_sumtype_test.v
+++ b/vlib/json/tests/json_decode_with_sumtype_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 type Test = []bool | []int | []string | string

--- a/vlib/json/tests/json_embed_test.v
+++ b/vlib/json/tests/json_embed_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Json3 {

--- a/vlib/json/tests/json_encode_array_of_references_test.v
+++ b/vlib/json/tests/json_encode_array_of_references_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct RefArrayItem {

--- a/vlib/json/tests/json_encode_embed_test.v
+++ b/vlib/json/tests/json_encode_embed_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Json2 {

--- a/vlib/json/tests/json_encode_enum_test.v
+++ b/vlib/json/tests/json_encode_enum_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 @[json_as_number]

--- a/vlib/json/tests/json_encode_generic_fixed_array_regression_test.v
+++ b/vlib/json/tests/json_encode_generic_fixed_array_regression_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Wrap[T] {

--- a/vlib/json/tests/json_encode_map_test.v
+++ b/vlib/json/tests/json_encode_map_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Test {

--- a/vlib/json/tests/json_encode_primite_test.v
+++ b/vlib/json/tests/json_encode_primite_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Test {

--- a/vlib/json/tests/json_encode_ptr_test.v
+++ b/vlib/json/tests/json_encode_ptr_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Number {

--- a/vlib/json/tests/json_encode_recursive_ptr_test.v
+++ b/vlib/json/tests/json_encode_recursive_ptr_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct PostTag {

--- a/vlib/json/tests/json_encode_struct_with_option_field_test.v
+++ b/vlib/json/tests/json_encode_struct_with_option_field_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 import json2
 

--- a/vlib/json/tests/json_encode_sumtype_test.v
+++ b/vlib/json/tests/json_encode_sumtype_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Test {

--- a/vlib/json/tests/json_encode_with_mut_test.v
+++ b/vlib/json/tests/json_encode_with_mut_test.v
@@ -1,3 +1,5 @@
+// vtest vflags: -w
+
 module main
 
 import json

--- a/vlib/json/tests/json_encode_with_ptr_test.v
+++ b/vlib/json/tests/json_encode_with_ptr_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct User {

--- a/vlib/json/tests/json_f64_array_roundtrip_test.v
+++ b/vlib/json/tests/json_f64_array_roundtrip_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct F64ArrayPayload {

--- a/vlib/json/tests/json_fixed_array_test.v
+++ b/vlib/json/tests/json_fixed_array_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Base {

--- a/vlib/json/tests/json_generic_array_test.v
+++ b/vlib/json/tests/json_generic_array_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 pub struct DocumentFindFilter[T] {

--- a/vlib/json/tests/json_i32_test.v
+++ b/vlib/json/tests/json_i32_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 pub struct StructB {

--- a/vlib/json/tests/json_is_null_attr_test.v
+++ b/vlib/json/tests/json_is_null_attr_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Bar {

--- a/vlib/json/tests/json_mut_map_test.v
+++ b/vlib/json/tests/json_mut_map_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 fn q_and_a(mut db_json map[string][]string) {

--- a/vlib/json/tests/json_omitempty_test.v
+++ b/vlib/json/tests/json_omitempty_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 pub struct MyStruct {

--- a/vlib/json/tests/json_omitempty_types_test.v
+++ b/vlib/json/tests/json_omitempty_types_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct OmitEmptyStruct {

--- a/vlib/json/tests/json_option_alias_test.v
+++ b/vlib/json/tests/json_option_alias_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Test {

--- a/vlib/json/tests/json_option_none_test.v
+++ b/vlib/json/tests/json_option_none_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Struct {

--- a/vlib/json/tests/json_option_raw_test.v
+++ b/vlib/json/tests/json_option_raw_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 pub struct Dto {

--- a/vlib/json/tests/json_option_struct_test.v
+++ b/vlib/json/tests/json_option_struct_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 pub struct SomeStruct {

--- a/vlib/json/tests/json_option_test.v
+++ b/vlib/json/tests/json_option_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 pub struct MyStruct {

--- a/vlib/json/tests/json_prim_type_validation_test.v
+++ b/vlib/json/tests/json_prim_type_validation_test.v
@@ -1,3 +1,5 @@
+// vtest vflags: -w
+
 module main
 
 import json

--- a/vlib/json/tests/json_raw_test.v
+++ b/vlib/json/tests/json_raw_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct TestOptionalRawString {

--- a/vlib/json/tests/json_struct_option_test.v
+++ b/vlib/json/tests/json_struct_option_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 pub struct MyStruct[T] {

--- a/vlib/json/tests/json_sumtype_test.v
+++ b/vlib/json/tests/json_sumtype_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 type Prices = Price | []Price

--- a/vlib/json/tests/json_test.v
+++ b/vlib/json/tests/json_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 import time
 

--- a/vlib/json2/tests/decode_array_array_test.v
+++ b/vlib/json2/tests/decode_array_array_test.v
@@ -1,3 +1,5 @@
+// vtest vflags: -w
+
 module main
 
 import json

--- a/vlib/json2/tests/decode_embed_reference_test.v
+++ b/vlib/json2/tests/decode_embed_reference_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json as stdjson
 import json2
 

--- a/vlib/json2/tests/decode_float_to_64bit_integer_test.v
+++ b/vlib/json2/tests/decode_float_to_64bit_integer_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json as old_json
 import json2 as json
 

--- a/vlib/v/checker/errors.v
+++ b/vlib/v/checker/errors.v
@@ -35,8 +35,8 @@ pub:
 }
 
 fn (mut c Checker) warn(s string, pos token.Pos, options MessageOptions) {
-	// `-w` suppresses warnings even when `-prod` or `-W` would otherwise promote them.
-	allow_warnings := c.pref.skip_warnings || !(c.pref.is_prod || c.pref.warns_are_errors)
+	// `-w` suppresses production warnings, but `-W` takes precedence when both are set.
+	allow_warnings := !c.pref.warns_are_errors && (c.pref.skip_warnings || !c.pref.is_prod)
 	c.warn_or_error(s, pos, allow_warnings, options)
 }
 

--- a/vlib/v/checker/errors.v
+++ b/vlib/v/checker/errors.v
@@ -35,7 +35,8 @@ pub:
 }
 
 fn (mut c Checker) warn(s string, pos token.Pos, options MessageOptions) {
-	allow_warnings := !(c.pref.is_prod || c.pref.warns_are_errors) // allow warnings only in dev builds
+	// `-w` suppresses warnings even when `-prod` or `-W` would otherwise promote them.
+	allow_warnings := c.pref.skip_warnings || !(c.pref.is_prod || c.pref.warns_are_errors)
 	c.warn_or_error(s, pos, allow_warnings, options)
 }
 

--- a/vlib/v/checker/tests/if_smartcast_mut_var_interface_err.out
+++ b/vlib/v/checker/tests/if_smartcast_mut_var_interface_err.out
@@ -1,3 +1,8 @@
+vlib/v/checker/tests/if_smartcast_mut_var_interface_err.vv:1:1: warning: module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead
+    1 | import json
+      | ~~~~~~~~~~~
+    2 |
+    3 | interface Foo {
 vlib/v/checker/tests/if_smartcast_mut_var_interface_err.vv:13:5: error: smart casting a mutable interface value requires `if mut foo_mut is ...`
    11 | fn main() {
    12 |     mut foo_mut := Foo(Bar{})

--- a/vlib/v/checker/tests/import_mod_as_duplicate_err.out
+++ b/vlib/v/checker/tests/import_mod_as_duplicate_err.out
@@ -1,3 +1,10 @@
+vlib/v/checker/tests/import_mod_as_duplicate_err.vv:3:1: warning: module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead
+    1 | module json2
+    2 |
+    3 | import json as json2
+      | ~~~~~~~~~~~~~~~~~~~~
+    4 |
+    5 | _ := json2.encode('foo')
 vlib/v/checker/tests/import_mod_as_duplicate_err.vv:3:16: error: cannot import `json` as `json2` into a module with the same name
     1 | module json2
     2 | 

--- a/vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.out
+++ b/vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.out
@@ -1,3 +1,8 @@
+vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.vv:1:1: warning: module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead
+    1 | import json
+      | ~~~~~~~~~~~
+    2 | import x.json2 as json
+    3 |
 vlib/v/checker/tests/import_mod_as_import_alias_duplicate_err.vv:2:8: error: A module `json` was already imported on line 1`.
     1 | import json
     2 | import x.json2 as json

--- a/vlib/v/checker/tests/import_mod_as_import_duplicate_err.out
+++ b/vlib/v/checker/tests/import_mod_as_import_duplicate_err.out
@@ -1,3 +1,9 @@
+vlib/v/checker/tests/import_mod_as_import_duplicate_err.vv:2:1: warning: module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead
+    1 | import x.json2 as json
+    2 | import json
+      | ~~~~~~~~~~~
+    3 |
+    4 | numbers := {
 vlib/v/checker/tests/import_mod_as_import_duplicate_err.vv:2:8: error: A module `json` was already imported on line 1`.
     1 | import x.json2 as json
     2 | import json

--- a/vlib/v/checker/tests/json_decode.out
+++ b/vlib/v/checker/tests/json_decode.out
@@ -1,3 +1,8 @@
+vlib/v/checker/tests/json_decode.vv:1:1: warning: module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead
+    1 | import json
+      | ~~~~~~~~~~~
+    2 |
+    3 | struct St {
 vlib/v/checker/tests/json_decode.vv:11:7: error: json.decode: unknown type `St2`
     9 | fn main() {
    10 |     json.decode(St, '{a: ""}')! // OK

--- a/vlib/v/checker/tests/json_decode_shared_err.out
+++ b/vlib/v/checker/tests/json_decode_shared_err.out
@@ -1,3 +1,8 @@
+vlib/v/checker/tests/json_decode_shared_err.vv:1:1: warning: module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead
+    1 | import json
+      | ~~~~~~~~~~~
+    2 |
+    3 | fn main() {
 vlib/v/checker/tests/json_decode_shared_err.vv:6:16: error: json.encode cannot handle shared data
     4 |     shared data := [1, 2, 3]
     5 |     rlock data {

--- a/vlib/v/checker/tests/orm_insert_object_with_mismatched_type_error.out
+++ b/vlib/v/checker/tests/orm_insert_object_with_mismatched_type_error.out
@@ -1,3 +1,9 @@
+vlib/v/checker/tests/orm_insert_object_with_mismatched_type_error.vv:2:1: warning: module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead
+    1 | import db.sqlite
+    2 | import json
+      | ~~~~~~~~~~~
+    3 |
+    4 | struct Tiddler {
 vlib/v/checker/tests/orm_insert_object_with_mismatched_type_error.vv:19:10: error: cannot use `Tiddler` as `Tiddlers`
    17 |     sql db {
    18 |         create table Tiddlers

--- a/vlib/v/checker/tests/run/json_encode_generic_interface.run.out
+++ b/vlib/v/checker/tests/run/json_encode_generic_interface.run.out
@@ -1,3 +1,8 @@
+vlib/v/checker/tests/run/json_encode_generic_interface.vv:1:1: warning: module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead
+    1 | import json
+      | ~~~~~~~~~~~
+    2 |
+    3 | interface Interface {}
 vlib/v/checker/tests/run/json_encode_generic_interface.vv:10:22: cgen error: json: Interface is not struct
     8 | 
     9 | fn main() {

--- a/vlib/v/gen/c/testdata/boehm_json_decode_keep_alive_nix.vv
+++ b/vlib/v/gen/c/testdata/boehm_json_decode_keep_alive_nix.vv
@@ -1,5 +1,5 @@
 // vtest vflags: -prod -gc boehm_full_opt -cc gcc
-import json
+import json2
 
 struct Objective {
 	id string
@@ -17,7 +17,7 @@ fn build_payload() string {
 	mut stages := []string{cap: 2}
 	for stage_index in 0 .. 2 {
 		mut objectives := []string{cap: 1}
-		objectives << '{"id":${json.encode('objective_${stage_index}_0')}}'
+		objectives << '{"id":${json2.encode('objective_${stage_index}_0')}}'
 		stages << '{"objectives":[${objectives.join(',')}]}'
 	}
 	return '{"stages":[${stages.join(',')}]}'
@@ -44,7 +44,7 @@ fn validate(doc Document) ! {
 }
 
 fn main() {
-	doc := json.decode(Document, build_payload()) or { panic(err) }
+	doc := json2.decode[Document](build_payload()) or { panic(err) }
 	validate(doc) or { panic(err) }
 	pressure_heap()
 	validate(doc) or { panic(err) }

--- a/vlib/v/gen/c/testdata/boehm_json_decode_keep_alive_nix.vv
+++ b/vlib/v/gen/c/testdata/boehm_json_decode_keep_alive_nix.vv
@@ -1,5 +1,5 @@
-// vtest vflags: -prod -gc boehm_full_opt -cc gcc
-import json2
+// vtest vflags: -w -prod -gc boehm_full_opt -cc gcc
+import json
 
 struct Objective {
 	id string
@@ -17,7 +17,7 @@ fn build_payload() string {
 	mut stages := []string{cap: 2}
 	for stage_index in 0 .. 2 {
 		mut objectives := []string{cap: 1}
-		objectives << '{"id":${json2.encode('objective_${stage_index}_0')}}'
+		objectives << '{"id":${json.encode('objective_${stage_index}_0')}}'
 		stages << '{"objectives":[${objectives.join(',')}]}'
 	}
 	return '{"stages":[${stages.join(',')}]}'
@@ -44,7 +44,7 @@ fn validate(doc Document) ! {
 }
 
 fn main() {
-	doc := json2.decode[Document](build_payload()) or { panic(err) }
+	doc := json.decode(Document, build_payload()) or { panic(err) }
 	validate(doc) or { panic(err) }
 	pressure_heap()
 	validate(doc) or { panic(err) }

--- a/vlib/v/slow_tests/repl/from_import.repl
+++ b/vlib/v/slow_tests/repl/from_import.repl
@@ -1,4 +1,4 @@
-import json { encode }
+import json2 { encode }
 encode('123')
 ===output===
 "123"

--- a/vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_multistmt_test.v
+++ b/vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_multistmt_test.v
@@ -1,3 +1,5 @@
+// vtest vflags: -w
+
 // This file checks that string interpolations where expressions that generate
 // multiple C statements work correctly
 import json

--- a/vlib/v/tests/conditions/matches/match_sumtype_smartcast_json_decode_call_test.v
+++ b/vlib/v/tests/conditions/matches/match_sumtype_smartcast_json_decode_call_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 type Issue26826Value = Issue26826Nil | string

--- a/vlib/v/tests/enums/enum_attr_test.v
+++ b/vlib/v/tests/enums/enum_attr_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 enum Foo {

--- a/vlib/v/tests/fns/calling_module_functions_with_maps_of_arrays_test.v
+++ b/vlib/v/tests/fns/calling_module_functions_with_maps_of_arrays_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 fn test_calling_functions_with_map_initializations_containing_arrays() {

--- a/vlib/v/tests/generics/generic_fn_infer_nested_generic_fn_test.v
+++ b/vlib/v/tests/generics/generic_fn_infer_nested_generic_fn_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 import os
 

--- a/vlib/v/tests/generics/generic_fn_short_struct_init_reference_inference_test.v
+++ b/vlib/v/tests/generics/generic_fn_short_struct_init_reference_inference_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 @[heap]

--- a/vlib/v/tests/generics/generics_method_returning_option_test.v
+++ b/vlib/v/tests/generics/generics_method_returning_option_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 pub struct NotificationMessage[T] {

--- a/vlib/v/tests/options/option_generic_param_test.v
+++ b/vlib/v/tests/options/option_generic_param_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 import json2
 

--- a/vlib/v/tests/options/option_ptr_ptr_test.v
+++ b/vlib/v/tests/options/option_ptr_ptr_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 @[heap]

--- a/vlib/v/tests/serialisation/json_serialisation_of_fixed_arrays_test.v
+++ b/vlib/v/tests/serialisation/json_serialisation_of_fixed_arrays_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Abc {

--- a/vlib/v/tests/serialisation/json_with_struct_having_fields_with_default_values_test.v
+++ b/vlib/v/tests/serialisation/json_with_struct_having_fields_with_default_values_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Window {

--- a/vlib/v/tests/skip_unused/import_json_only.run.out
+++ b/vlib/v/tests/skip_unused/import_json_only.run.out
@@ -1,0 +1,3 @@
+vlib/v/tests/skip_unused/import_json_only.vv:1:1: warning: module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead
+    1 | import json as _
+      | ~~~~~~~~~~~~~~~~

--- a/vlib/v/tests/skip_unused/json_decode_u32.run.out
+++ b/vlib/v/tests/skip_unused/json_decode_u32.run.out
@@ -1,1 +1,8 @@
+vlib/v/tests/skip_unused/json_decode_u32.vv:3:1: warning: module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead
+    1 | module main
+    2 |
+    3 | import json
+      | ~~~~~~~~~~~
+    4 |
+    5 | struct Message {
 []

--- a/vlib/v/tests/skip_unused/struct_field_none.run.out
+++ b/vlib/v/tests/skip_unused/struct_field_none.run.out
@@ -1,1 +1,6 @@
+vlib/v/tests/skip_unused/struct_field_none.vv:1:1: warning: module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead
+    1 | import json
+      | ~~~~~~~~~~~
+    2 |
+    3 | pub struct Struct {
 {}

--- a/vlib/v/tests/structs/anon_struct_default_value_test.v
+++ b/vlib/v/tests/structs/anon_struct_default_value_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct SomeParams {

--- a/vlib/v/tests/structs/struct_allow_both_field_defaults_and_skip_flag_test.v
+++ b/vlib/v/tests/structs/struct_allow_both_field_defaults_and_skip_flag_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import json
 
 struct Foo {

--- a/vlib/v/tests/structs/struct_init_passing_test.v
+++ b/vlib/v/tests/structs/struct_init_passing_test.v
@@ -1,3 +1,5 @@
+// vtest vflags: -w
+
 module main
 
 import json

--- a/vlib/v/tests/vls/autocomplete_module_test.v
+++ b/vlib/v/tests/vls/autocomplete_module_test.v
@@ -1,3 +1,4 @@
+// vtest vflags: -w
 import os
 import term
 import v.util.diff


### PR DESCRIPTION
## Summary

- mark the legacy json module as deprecated
- direct users to the pure V json2 module before removal
- document the deprecation in the module README
- update compiler-error and Linux skip-unused fixtures for the warning
- keep the production Boehm regression on json.decode by honoring -w before production warning promotion
- preserve -W precedence when both warning flags are present
- migrate V-owned tools compiled by the -W build-tools CI target to json2
- exempt tests that deliberately retain legacy json coverage from -W warning promotion
- migrate the unrelated REPL selective-import fixture to json2

## Tests

- ./vnew -silent test vlib/json/ (50 passed)
- ./vnew -silent vlib/v/compiler_errors_test.v (1589 passed, 1 skipped)
- ./vnew -silent vlib/v/gen/c/coutput_test.v
- ./vnew -silent vlib/v/slow_tests/inout/compiler_test.v (81 passed, 9 expected panics, 1 skipped)
- ./vnew -silent test vlib/v/checker/
- ./vnew -silent vlib/v/slow_tests/repl/repl_test.v (46 passed)
- ./vnew -silent -N -W -check build-tools (79 passed)
- ./vnew -silent -W -cstrict test-self cmd (41 passed, 1 skipped)
- ./vnew -W -silent test-self vlib/json (50 passed)
- ./vnew -W -silent test-self vlib/json2 (71 passed, 1 skipped)
- ./vnew -W -silent test on each affected compiler regression (15 passed)
- ./vnew -silent test cmd/tools/vpm/ (13 passed)
- ./vnew -silent cmd/tools/vcover/cover_test.v
- ./vnew -silent cmd/tools/vdoc/vdoc_test.v
- ./vnew -silent cmd/tools/modules/vshare/api_test.v
- ./vnew -W -N -o /tmp/vpm_review_test cmd/tools/vpm
- ./vnew -w -W -check vlib/json/tests/json_test.v (fails as expected)
- ./vnew -W -w -check vlib/json/tests/json_test.v (passes)
- ./vnew check-md vlib/json/README.md