### PR TITLE
v3: speed up non-generic compilation

### DIFF
--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -1,6 +1,6 @@
 module bench
 
-import os
+import runtime
 import time
 
 // Step represents step data used by bench.
@@ -57,34 +57,6 @@ pub fn (b &Bench) print_report() {
 
 // current_rss_kb returns current rss kb data for bench.
 fn current_rss_kb() i64 {
-	$if macos {
-		return macos_rss_kb()
-	}
-	$if linux {
-		return linux_rss_kb()
-	}
-	return 0
-}
-
-// macos_rss_kb supports macos current rss kb handling for bench.
-fn macos_rss_kb() i64 {
-	res := os.execute('ps -o rss= -p ${os.getpid()}')
-	if res.exit_code != 0 {
-		return 0
-	}
-	return res.output.trim_space().i64()
-}
-
-// linux_rss_kb supports linux rss kb handling for bench.
-fn linux_rss_kb() i64 {
-	content := os.read_file('/proc/self/status') or { return 0 }
-	for line in content.split('\n') {
-		if line.starts_with('VmRSS:') {
-			parts := line.split_any(' \t').filter(it.len > 0)
-			if parts.len >= 2 {
-				return parts[1].i64()
-			}
-		}
-	}
-	return 0
+	bytes := runtime.used_memory() or { return 0 }
+	return i64(bytes / 1024)
 }

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -135,6 +135,7 @@ mut:
 	compiler_vroot               string
 	compiler_vexe                string
 	c99_mode                     bool
+	skip_generics                bool
 	cur_fn_name                  string
 	cur_param_names              []string
 	cur_param_type_values        []types.Type
@@ -226,6 +227,12 @@ pub fn (mut g FlatGen) set_c99_mode(enabled bool) {
 // set_prealloc marks the build as using the -prealloc bump arena.
 pub fn (mut g FlatGen) set_prealloc(on bool) {
 	g.prealloc = on
+}
+
+// set_skip_generics removes generic-only metadata work when reachability proved
+// that the generated program has no generic instantiations.
+pub fn (mut g FlatGen) set_skip_generics(on bool) {
+	g.skip_generics = on
 }
 
 fn (mut g FlatGen) push_scope() {
@@ -648,8 +655,10 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.has_builtins = g.tc.has_builtins
 	g.collect_gen_info()
 	g.precompute_shared_param_index()
-	g.precompute_non_generic_fn_index()
-	g.precompute_generic_fn_key_index()
+	if !g.skip_generics {
+		g.precompute_non_generic_fn_index()
+		g.precompute_generic_fn_key_index()
+	}
 	// In the parallel path the fixed-storage scan runs on a helper thread,
 	// overlapped with the fn-item collection and parallel pre-seeding.
 	// The master emits selectors/inits itself (serial regions, postamble), so
@@ -669,7 +678,9 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.preseed_global_fn_ptr_types()
 	g.preseed_c_extern_fn_ptr_types()
 	g.preseed_libc_compat_fns()
-	g.precompute_generic_method_candidate_index()
+	if !g.skip_generics {
+		g.precompute_generic_method_candidate_index()
+	}
 	// Decide fixed-array return wrappers before generating function bodies, so
 	// signatures, returns and call sites all agree on the wrapped types.
 	g.populate_fixed_array_ret_wrappers()
@@ -882,12 +893,20 @@ fn (mut g FlatGen) collect_gen_info() {
 	mut preferred_shared_fn_params := map[string][]bool{}
 	for node_idx in 0 .. g.a.nodes.len {
 		node := g.a.nodes[node_idx]
-		kind_id := node_kind_id(node)
 		if node.kind == .string_literal {
 			g.intern_string(node.value)
 		} else if node.kind == .string_interp && node.children_count == 0 {
 			g.intern_string('')
 		}
+		match node.kind {
+			.file, .module_decl, .fn_decl, .struct_decl, .global_decl, .const_decl, .enum_decl,
+			.interface_decl, .import_decl, .directive {}
+			else {
+				continue
+			}
+		}
+
+		kind_id := node_kind_id(node)
 		if kind_id == 77 {
 			cur_file = node.value
 			g.note_compiler_source_file(node.value)
@@ -905,6 +924,11 @@ fn (mut g FlatGen) collect_gen_info() {
 		}
 		if kind_id == 61 {
 			full_name := qualify_name_in_module(cur_module, node.value)
+			if g.skip_generics && g.has_used_fn_filter()
+				&& !g.used_fn_contains_in_module(node.value, cur_module) {
+				g.preseed_unused_fn_ptr_param_types(node, cur_module, cur_file)
+				continue
+			}
 			g.register_fn_decl_node(node.value, cur_module, flat.NodeId(node_idx))
 			typed_params := g.fn_node_param_types(node, cur_module)
 			mut ptypes := []types.Type{cap: int(node.children_count)}
@@ -1155,6 +1179,29 @@ fn (mut g FlatGen) collect_gen_info() {
 	}
 	g.modules['strings'] = 'strings'
 	g.collect_const_init_order_from_files()
+}
+
+fn (mut g FlatGen) preseed_unused_fn_ptr_param_types(node flat.Node, module_name string, file string) {
+	typed_params := g.fn_node_param_types(node, module_name)
+	g.tc.cur_module = module_name
+	g.tc.cur_file = file
+	mut param_idx := 0
+	for i in 0 .. node.children_count {
+		child := g.a.child_node(&node, i)
+		if node_kind_id(child) != 75 {
+			continue
+		}
+		raw_type := g.tc.parse_type(child.typ)
+		param_type := if raw_type !is types.Pointer && param_idx < typed_params.len {
+			typed_params[param_idx]
+		} else {
+			raw_type
+		}
+		param_idx++
+		if param_type is types.FnType {
+			g.resolve_fn_ptr_type(g.tc.c_type(param_type))
+		}
+	}
 }
 
 fn (mut g FlatGen) collect_c_flags_from_directives() {
@@ -2303,7 +2350,8 @@ fn (mut g FlatGen) note_compiler_source_file(path string) {
 fn (mut g FlatGen) collect_const_init_order_from_files() {
 	mut seen := map[string]bool{}
 	g.const_init_order = []string{}
-	for node in g.a.nodes {
+	for node_idx in g.tc.top_level_idx {
+		node := g.a.nodes[node_idx]
 		if node_kind_id(node) != 77 || node.children_count == 0 {
 			continue
 		}
@@ -10797,58 +10845,77 @@ fn (mut g FlatGen) fixed_array_compound_literal_expr(val_id flat.NodeId, fixed t
 }
 
 fn (mut g FlatGen) fixed_array_initializer_string(val_id flat.NodeId, fixed types.ArrayFixed) string {
-	if int(val_id) < 0 || int(val_id) >= g.a.nodes.len {
+	mut builder := strings.new_builder(64)
+	if !g.write_fixed_array_initializer(mut builder, val_id, fixed) {
+		unsafe { builder.free() }
 		return ''
+	}
+	result := builder.str()
+	unsafe { builder.free() }
+	return result
+}
+
+fn (mut g FlatGen) write_fixed_array_initializer(mut builder strings.Builder, val_id flat.NodeId, fixed types.ArrayFixed) bool {
+	if int(val_id) < 0 || int(val_id) >= g.a.nodes.len {
+		return false
 	}
 	node := g.a.nodes[int(val_id)]
 	if node.kind in [.ident, .selector] {
 		const_name := g.const_ref_name_from_node(node)
 		if const_name.len > 0 {
 			if const_id := g.const_vals[const_name] {
-				return g.fixed_array_initializer_string(const_id, fixed)
+				return g.write_fixed_array_initializer(mut builder, const_id, fixed)
 			}
 		}
 	}
 	if node.kind == .postfix && node.children_count > 0 {
-		return g.fixed_array_initializer_string(g.a.child(&node, 0), fixed)
+		return g.write_fixed_array_initializer(mut builder, g.a.child(&node, 0), fixed)
 	}
 	if node.kind == .cast_expr && node.children_count > 0 {
-		return g.fixed_array_initializer_string(g.a.child(&node, 0), fixed)
+		return g.write_fixed_array_initializer(mut builder, g.a.child(&node, 0), fixed)
 	}
 	if node.kind == .array_init && node.children_count == 0 {
-		return '{0}'
+		builder.write_string('{0}')
+		return true
 	}
 	if node.kind != .array_literal {
-		return ''
+		return false
 	}
-	mut parts := []string{}
+	builder.write_u8(`{`)
 	for i in 0 .. node.children_count {
+		if i > 0 {
+			builder.write_string(', ')
+		}
 		child_id := g.a.child(&node, i)
 		if fixed.elem_type is types.ArrayFixed {
-			parts << g.fixed_array_initializer_string(child_id, fixed.elem_type)
+			g.write_fixed_array_initializer(mut builder, child_id, fixed.elem_type)
 		} else {
-			parts << g.fixed_array_elem_initializer_string(child_id, fixed.elem_type)
+			g.write_fixed_array_elem_initializer(mut builder, child_id, fixed.elem_type)
 		}
 	}
-	return '{${parts.join(', ')}}'
+	builder.write_u8(`}`)
+	return true
 }
 
-fn (mut g FlatGen) fixed_array_elem_initializer_string(val_id flat.NodeId, elem_type types.Type) string {
+fn (mut g FlatGen) write_fixed_array_elem_initializer(mut builder strings.Builder, val_id flat.NodeId, elem_type types.Type) {
 	if int(val_id) < 0 || int(val_id) >= g.a.nodes.len {
-		return '0'
+		builder.write_u8(`0`)
+		return
 	}
 	node := g.a.nodes[int(val_id)]
 	if g.is_const_expr(val_id) && !(node.kind == .prefix && node.op == .amp) {
 		const_val := g.const_expr_to_string(val_id, []string{})
 		if trimmed_space(const_val).len > 0 {
-			return const_val
+			builder.write_string(const_val)
+			return
 		}
 	}
 	expr := g.expr_to_string_with_expected_type(val_id, elem_type)
 	if trimmed_space(expr).len > 0 {
-		return expr
+		builder.write_string(expr)
+		return
 	}
-	return '0'
+	builder.write_u8(`0`)
 }
 
 fn (mut g FlatGen) precompute_consts() string {

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -5,13 +5,28 @@ import v3.gen.c.naming
 import v3.types
 
 const trace_markused = false
+const min_eager_markused_bodies = 4096
 
 // mark_used updates mark used state for markused.
 pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
-	return mark_used_with_test_files(a, tc, map[string]bool{})
+	used, _ := mark_used_with_test_files(a, tc, map[string]bool{})
+	return used
 }
 
 pub fn mark_used_for_tests(a &flat.FlatAst, tc &types.TypeChecker, test_files []string) map[string]bool {
+	used, _ := mark_used_for_tests_with_generic_usage(a, tc, test_files)
+	return used
+}
+
+// mark_used_with_generic_usage also reports whether reachable code uses a generic
+// function, struct, or sum type and therefore requires monomorphization.
+pub fn mark_used_with_generic_usage(a &flat.FlatAst, tc &types.TypeChecker) (map[string]bool, bool) {
+	return mark_used_with_test_files(a, tc, map[string]bool{})
+}
+
+// mark_used_for_tests_with_generic_usage is the test-file-rooted variant of
+// mark_used_with_generic_usage.
+pub fn mark_used_for_tests_with_generic_usage(a &flat.FlatAst, tc &types.TypeChecker, test_files []string) (map[string]bool, bool) {
 	mut file_map := map[string]bool{}
 	for file in test_files {
 		file_map[file] = true
@@ -19,7 +34,7 @@ pub fn mark_used_for_tests(a &flat.FlatAst, tc &types.TypeChecker, test_files []
 	return mark_used_with_test_files(a, tc, file_map)
 }
 
-fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files map[string]bool) map[string]bool {
+fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files map[string]bool) (map[string]bool, bool) {
 	mut cur_module := ''
 	mut imports := map[string]string{}
 	mut fn_decls := map[string]FnDeclInfo{}
@@ -40,7 +55,8 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	mut fn_count := 0
 	mut fn_with_dot := 0
 	mut contains2_total := 0
-	for node_idx, node in a.nodes {
+	for node_idx in tc.top_level_idx {
+		node := a.nodes[node_idx]
 		if node.kind == .file {
 			cur_module = ''
 			continue
@@ -150,7 +166,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	// BFS from main
 	mut used := map[string]bool{}
 	mut queue := []string{}
-	reachable_modules := markused_reachable_modules(a)
+	reachable_modules := markused_reachable_modules(a, tc)
 	queue << 'main'
 	used['main'] = true
 	enqueue_main_module_roots(fn_decls, mut used, mut queue)
@@ -223,25 +239,29 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	mut not_in_cg := 0
 	mut total_callees := 0
 	collector := CallCollector{
-		a:                a
-		tc:               tc
-		fn_decls:         fn_decls
-		fn_suffixes:      fn_name_suffixes
-		struct_decls:     struct_decls
-		const_decls:      const_decls
-		const_suffixes:   const_name_suffixes
-		iface_param_gate: markused_interface_param_gate(tc)
+		a:                       a
+		tc:                      tc
+		fn_decls:                fn_decls
+		fn_suffixes:             fn_name_suffixes
+		struct_decls:            struct_decls
+		const_decls:             const_decls
+		const_suffixes:          const_name_suffixes
+		selective_alias_targets: markused_selective_alias_targets(tc)
+		iface_param_gate:        markused_interface_param_gate(tc)
 	}
 	// Precollect every body's call/initializer-ref lists up front (across
 	// threads when available): the BFS below then only does the cheap
 	// name-resolution work. Collecting inline used to serialize ~80% of
 	// markused's time inside the BFS loop.
 	mut body_index := map[int]int{}
-	for i, id in body_ids {
-		body_index[id] = i
+	mut body_results := []BodyCalls{}
+	if body_ids.len >= min_eager_markused_bodies {
+		for i, id in body_ids {
+			body_index[id] = i
+		}
+		body_results = precollect_body_calls(collector, body_ids, body_modules, imports)
 	}
-	body_results := precollect_body_calls(collector, body_ids, body_modules, imports)
-	has_entry_main := markused_has_entry_main(a)
+	has_entry_main := markused_has_entry_main_indexed(a, tc)
 	enqueue_detected_runtime_helpers(a, tc, mut used, mut queue)
 	enqueue_function_value_selectors(a, collector, fn_decls, has_entry_main, mut used, mut queue)
 	// Methods used as values (`recv.method` passed as a callback) are reachable only
@@ -249,8 +269,10 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	// function in `method_values_by_fn`; they are seeded inside the BFS below (only when
 	// that function is reached), so an unreachable function's method value never forces an
 	// otherwise-unused specialization to be transformed/emitted.
-	enqueue_initializer_calls(a, collector, imports, fn_decls, mut used, mut queue)
-	enqueue_top_level_calls(a, collector, fn_decls, has_entry_main, mut used, mut queue)
+	mut uses_generics := enqueue_initializer_calls(a, collector, imports, fn_decls, mut used, mut
+		queue, false)
+	uses_generics = enqueue_top_level_calls(a, collector, fn_decls, has_entry_main, mut used, mut
+		queue, uses_generics)
 	// Interface dispatch reachability: calling an interface method `Foo.m` may
 	// dispatch to any concrete `T.m` for a type `T` that implements `Foo`. Those
 	// concrete methods are only referenced from the generated dispatch switch, so
@@ -319,17 +341,18 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 			calls.clear()
 			initializer_refs.clear()
 			if body_i := body_index[node_key] {
-				calls << body_results[body_i].calls
-				initializer_refs << body_results[body_i].refs
+				body := body_results[body_i]
+				calls << body.calls
+				initializer_refs << body.refs
+				uses_generics = uses_generics || body.uses_generics
 			} else {
 				// Not part of the precollected decl set (should not happen; the BFS
 				// resolves names through the same decl scan) — collect inline.
 				node := a.node(fn_info.node_id)
-				receiver_name, receiver_struct := receiver_info(a, node)
-				collector.collect_calls(node, fn_info.module, imports, receiver_name,
-					receiver_struct, mut calls)
-				collector.collect_initializer_refs(node, fn_info.module, imports, mut
-					initializer_refs)
+				body := collector.collect_body(node, fn_info.module, imports)
+				calls << body.calls
+				initializer_refs << body.refs
+				uses_generics = uses_generics || body.uses_generics
 			}
 			mut call_set := map[string]bool{}
 			for call in calls {
@@ -430,6 +453,9 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 			eprintln('  -> added ${new_added.str()} new entries, queue now ${queue.len.str()}')
 		}
 	}
+	if !uses_generics {
+		uses_generics = collector.emitted_type_declarations_use_generics(imports)
+	}
 	if trace_markused {
 		eprintln('total_callees:')
 		eprintln(total_callees.str())
@@ -443,7 +469,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		eprintln(suffix_hits.str())
 		eprintln('markused: total used: ${used.len}')
 	}
-	return used
+	return used, uses_generics
 }
 
 fn enqueue_used_interface_dispatch_implementers(tc &types.TypeChecker, mut used map[string]bool, mut queue []string) bool {
@@ -777,10 +803,12 @@ fn markused_clone_string_map(src map[string]string) map[string]string {
 }
 
 // enqueue_initializer_calls supports enqueue initializer calls handling for markused.
-fn enqueue_initializer_calls(a &flat.FlatAst, collector CallCollector, imports map[string]string, fn_decls map[string]FnDeclInfo, mut used map[string]bool, mut queue []string) {
+fn enqueue_initializer_calls(a &flat.FlatAst, collector CallCollector, imports map[string]string, fn_decls map[string]FnDeclInfo, mut used map[string]bool, mut queue []string, initial_uses_generics bool) bool {
 	mut cur_module := ''
 	mut calls := []string{cap: 32}
-	for node in a.nodes {
+	mut uses_generics := initial_uses_generics
+	for node_idx in collector.tc.top_level_idx {
+		node := a.nodes[node_idx]
 		match node.kind {
 			.file {
 				cur_module = ''
@@ -795,7 +823,12 @@ fn enqueue_initializer_calls(a &flat.FlatAst, collector CallCollector, imports m
 						continue
 					}
 					calls.clear()
-					collector.collect_calls(field, cur_module, imports, '', '', mut calls)
+					if uses_generics {
+						collector.collect_calls(field, cur_module, imports, '', '', mut calls)
+					} else {
+						uses_generics = collector.collect_calls_with_generic_usage(field,
+							cur_module, imports, '', '', mut calls)
+					}
 					for callee in calls {
 						enqueue_initializer_callee(callee, fn_decls, a, mut used, mut queue)
 					}
@@ -804,6 +837,7 @@ fn enqueue_initializer_calls(a &flat.FlatAst, collector CallCollector, imports m
 			else {}
 		}
 	}
+	return uses_generics
 }
 
 fn enqueue_initializer_ref_calls(a &flat.FlatAst, collector CallCollector, imports map[string]string, fn_decls map[string]FnDeclInfo, initializer_ref string, mut processed map[string]bool, mut calls []string, mut used map[string]bool, mut queue []string) {
@@ -838,11 +872,12 @@ fn markused_module_has_reachable_initializer(module_name string, reachable_modul
 	return module_name in reachable_modules
 }
 
-fn markused_reachable_modules(a &flat.FlatAst) map[string]bool {
+fn markused_reachable_modules(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 	mut module_imports := map[string][]string{}
 	mut roots := []string{}
 	mut has_user_root := false
-	for file_idx, file_node in a.nodes {
+	for file_idx in tc.top_level_idx {
+		file_node := a.nodes[file_idx]
 		if file_node.kind != .file {
 			continue
 		}
@@ -900,11 +935,12 @@ fn markused_file_is_test(file string) bool {
 	return file.ends_with('_test.v') || file.ends_with('_test.c.v') || file.ends_with('_test.js.v')
 }
 
-fn enqueue_top_level_calls(a &flat.FlatAst, collector CallCollector, fn_decls map[string]FnDeclInfo, has_entry_main bool, mut used map[string]bool, mut queue []string) {
+fn enqueue_top_level_calls(a &flat.FlatAst, collector CallCollector, fn_decls map[string]FnDeclInfo, has_entry_main bool, mut used map[string]bool, mut queue []string, initial_uses_generics bool) bool {
 	if has_entry_main {
-		return
+		return initial_uses_generics
 	}
 	mut calls := []string{cap: 32}
+	mut uses_generics := initial_uses_generics
 	for file_idx, file_node in a.nodes {
 		if !markused_should_scan_top_level_file(a, file_idx, file_node) {
 			continue
@@ -925,6 +961,10 @@ fn enqueue_top_level_calls(a &flat.FlatAst, collector CallCollector, fn_decls ma
 			calls.clear()
 			collector.collect_top_level_stmt_calls(child_id, module_name, file_imports, mut
 				local_values, mut local_types, mut calls)
+			if !uses_generics
+				&& collector.node_tree_uses_generics(child_id, module_name, file_imports) {
+				uses_generics = true
+			}
 			for callee in calls {
 				if callee_info := fn_decls[callee] {
 					enqueue(callee, mut used, mut queue)
@@ -935,6 +975,29 @@ fn enqueue_top_level_calls(a &flat.FlatAst, collector CallCollector, fn_decls ma
 			}
 		}
 	}
+	return uses_generics
+}
+
+fn markused_has_entry_main_indexed(a &flat.FlatAst, tc &types.TypeChecker) bool {
+	mut cur_module := ''
+	for node_idx in tc.top_level_idx {
+		node := a.nodes[node_idx]
+		match node.kind {
+			.file {
+				cur_module = ''
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.fn_decl {
+				if node.value == 'main' && (cur_module.len == 0 || cur_module == 'main') {
+					return true
+				}
+			}
+			else {}
+		}
+	}
+	return false
 }
 
 fn markused_has_entry_main(a &flat.FlatAst) bool {
@@ -1039,6 +1102,10 @@ struct CallCollector {
 	struct_decls   map[string]StructDeclInfo
 	const_decls    map[string]ConstDeclInfo
 	const_suffixes map[string]bool
+	// Unqualified selective-import symbol -> all known alias targets. This is
+	// global because generic detection only needs to know whether any target
+	// requires monomorphization.
+	selective_alias_targets map[string][]string
 	// Gate set for collect_interface_boxed_generic_methods: every fn_param_types
 	// key with at least one interface-typed parameter, plus its post-'.' and
 	// post-'__' short spellings (see markused_interface_param_gate). Lets the
@@ -1078,6 +1145,22 @@ fn markused_interface_param_gate(tc &types.TypeChecker) map[string]bool {
 		}
 	}
 	return gate
+}
+
+fn markused_selective_alias_targets(tc &types.TypeChecker) map[string][]string {
+	mut result := map[string][]string{}
+	for key, candidates in tc.file_selective_imports {
+		name := key.all_after_last('\n')
+		for candidate in candidates {
+			target := tc.type_aliases[candidate] or { continue }
+			mut targets := result[name]
+			if target !in targets {
+				targets << target
+				result[name] = targets
+			}
+		}
+	}
+	return result
 }
 
 // may_target_interface_params reports whether `name` (a raw callee spelling)
@@ -1304,11 +1387,13 @@ fn enqueue_detected_runtime_helpers(a &flat.FlatAst, tc &types.TypeChecker, mut 
 	mut cur_module := ''
 	mut imports := map[string]string{}
 	for node in a.nodes {
-		if markused_type_text_is_channel(node.typ) {
-			needs_channel_helpers = true
-		}
-		if markused_type_text_needs_shared_runtime(node.typ) {
-			needs_shared_runtime = true
+		if node.typ.len > 0 {
+			if !needs_channel_helpers && markused_type_text_is_channel(node.typ) {
+				needs_channel_helpers = true
+			}
+			if !needs_shared_runtime && markused_type_text_needs_shared_runtime(node.typ) {
+				needs_shared_runtime = true
+			}
 		}
 		match node.kind {
 			.file {
@@ -1322,12 +1407,12 @@ fn enqueue_detected_runtime_helpers(a &flat.FlatAst, tc &types.TypeChecker, mut 
 				imports[node.typ] = node.value
 			}
 			.fn_decl {
-				if type_string_needs_optional_helpers(node.typ) {
+				if !needs_optional_helpers && type_string_needs_optional_helpers(node.typ) {
 					needs_optional_helpers = true
 				}
 			}
 			.param, .field_decl, .field_init, .const_field {
-				if type_string_needs_optional_helpers(node.typ) {
+				if !needs_optional_helpers && type_string_needs_optional_helpers(node.typ) {
 					needs_optional_helpers = true
 				}
 			}
@@ -1399,7 +1484,7 @@ fn enqueue_detected_runtime_helpers(a &flat.FlatAst, tc &types.TypeChecker, mut 
 					needs_channel_helpers = true
 				}
 				if node.op in [.eq, .ne] {
-					if markused_infix_needs_f32_eq_epsilon(a, tc, node) {
+					if !needs_f32_eq_epsilon && markused_infix_needs_f32_eq_epsilon(a, tc, node) {
 						needs_f32_eq_epsilon = true
 					}
 					if !needs_ierror_equality_dispatch && node.children_count >= 2 {
@@ -1449,10 +1534,12 @@ fn enqueue_detected_runtime_helpers(a &flat.FlatAst, tc &types.TypeChecker, mut 
 						needs_ierror_equality_dispatch = markused_type_equality_uses_ierror(tc.resolve_type(lhs_id),
 							tc, mut ierror_equality_cache)
 					}
-					rhs_id := a.child(&node, 1)
-					rhs_type := markused_membership_container_type(tc, tc.resolve_type(rhs_id))
-					if rhs_type == 'string' {
-						needs_string_membership_helpers = true
+					if !needs_string_membership_helpers {
+						rhs_id := a.child(&node, 1)
+						rhs_type := markused_membership_container_type(tc, tc.resolve_type(rhs_id))
+						if rhs_type == 'string' {
+							needs_string_membership_helpers = true
+						}
 					}
 				}
 			}
@@ -2097,6 +2184,337 @@ fn markused_split_generic_args(s string) []string {
 	return args
 }
 
+fn (c &CallCollector) node_tree_uses_generics(root flat.NodeId, cur_module string, imports map[string]string) bool {
+	mut stack := [root]
+	for stack.len > 0 {
+		id := stack.pop()
+		if int(id) < 0 || int(id) >= c.a.nodes.len {
+			continue
+		}
+		node := &c.a.nodes[int(id)]
+		if c.node_uses_generics(node, cur_module, imports) {
+			return true
+		}
+		if node.kind == .call {
+			if name := c.tc.resolved_call_name(id) {
+				if c.generic_fn_name_is_known(name, cur_module) {
+					return true
+				}
+			}
+		}
+		for i in 0 .. node.children_count {
+			child_id := c.a.child(node, i)
+			if int(child_id) >= 0 {
+				stack << child_id
+			}
+		}
+	}
+	return false
+}
+
+fn (c &CallCollector) node_uses_generics(node &flat.Node, cur_module string, imports map[string]string) bool {
+	if c.type_text_uses_generics(node.typ, cur_module, imports) {
+		return true
+	}
+	return match node.kind {
+		.struct_init, .array_init, .cast_expr, .as_expr, .sizeof_expr, .typeof_expr, .is_expr {
+			c.type_text_uses_generics(node.value, cur_module, imports)
+		}
+		else {
+			false
+		}
+	}
+}
+
+fn (c &CallCollector) type_text_uses_generics(typ string, cur_module string, imports map[string]string) bool {
+	if typ.len == 0 {
+		return false
+	}
+	return c.type_text_uses_generics_depth(typ.trim_space(), cur_module, imports, 0)
+}
+
+fn (c &CallCollector) type_text_uses_generics_depth(typ string, cur_module string, imports map[string]string, depth int) bool {
+	if typ.len == 0 || depth > 8 {
+		return false
+	}
+	for i, ch in typ {
+		if ch != `[` || i == 0 {
+			continue
+		}
+		mut start := i
+		for start > 0 && markused_generic_name_byte(typ[start - 1]) {
+			start--
+		}
+		if start < i && c.generic_type_base_is_known(typ[start..i], cur_module, imports) {
+			return true
+		}
+	}
+	mut may_name_alias := false
+	for ch in typ {
+		if ch >= `A` && ch <= `Z` {
+			may_name_alias = true
+			break
+		}
+	}
+	if !may_name_alias {
+		return false
+	}
+	clean := typ.trim_left('&?!').trim_space()
+	if target := c.generic_alias_target(clean, cur_module, imports) {
+		return c.type_text_uses_generics_depth(target.trim_space(), cur_module, imports, depth + 1)
+	}
+	if c.selective_alias_uses_generics(clean, cur_module, imports, depth + 1) {
+		return true
+	}
+	// Wrapped aliases are not whole type strings, so inspect each named component.
+	mut start := 0
+	for start < clean.len {
+		for start < clean.len && !markused_type_name_start_byte(clean[start]) {
+			start++
+		}
+		if start >= clean.len {
+			break
+		}
+		mut end := start + 1
+		mut candidate_may_name_alias := clean[start] >= `A` && clean[start] <= `Z`
+		for end < clean.len && markused_generic_name_byte(clean[end]) {
+			if clean[end] >= `A` && clean[end] <= `Z` {
+				candidate_may_name_alias = true
+			}
+			end++
+		}
+		if candidate_may_name_alias {
+			candidate := clean[start..end]
+			if target := c.generic_alias_target(candidate, cur_module, imports) {
+				alias_target := target.trim_space()
+				if c.type_text_uses_generics_depth(alias_target, cur_module, imports, depth + 1) {
+					return true
+				}
+			} else if c.selective_alias_uses_generics(candidate, cur_module, imports, depth + 1) {
+				return true
+			}
+			if c.struct_fields_use_generics(candidate, cur_module, imports, depth + 1) {
+				return true
+			}
+		}
+		start = end
+	}
+	return false
+}
+
+fn (c &CallCollector) struct_fields_use_generics(name string, cur_module string, imports map[string]string, depth int) bool {
+	info := c.struct_decl_info_with_imports(name, cur_module, imports) or { return false }
+	decl := c.a.node(info.node_id)
+	qualified_name := qualify_fn(info.module, decl.value)
+	fields := c.tc.structs[qualified_name] or { return false }
+	field_module := if info.module.len > 0 { info.module } else { cur_module }
+	for field in fields {
+		if c.type_text_uses_generics_depth(field.typ.name(), field_module, imports, depth) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (c &CallCollector) emitted_type_declarations_use_generics(imports map[string]string) bool {
+	for name, fields in c.tc.structs {
+		if name in c.tc.struct_generic_params {
+			continue
+		}
+		for field in fields {
+			if c.parsed_type_uses_concrete_generics(field.typ, 0) {
+				return true
+			}
+		}
+	}
+	for name, variants in c.tc.sum_types {
+		if name in c.tc.sum_generic_params {
+			continue
+		}
+		for variant in variants {
+			if c.parsed_type_uses_concrete_generics(c.tc.parse_type(variant), 0) {
+				return true
+			}
+		}
+	}
+	for _, fields in c.tc.interface_fields {
+		for field in fields {
+			if c.parsed_type_uses_concrete_generics(field.typ, 0) {
+				return true
+			}
+		}
+	}
+	mut cur_module := ''
+	for node_idx in c.tc.top_level_idx {
+		node := c.a.nodes[node_idx]
+		match node.kind {
+			.file {
+				cur_module = ''
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.const_decl, .global_decl {
+				for i in 0 .. node.children_count {
+					if c.node_tree_uses_generics(c.a.child(&node, i), cur_module, imports) {
+						return true
+					}
+				}
+			}
+			else {}
+		}
+	}
+	return false
+}
+
+fn (c &CallCollector) parsed_type_uses_concrete_generics(typ types.Type, depth int) bool {
+	if depth > 16 {
+		return false
+	}
+	match typ {
+		types.Array {
+			return c.parsed_type_uses_concrete_generics(typ.elem_type, depth + 1)
+		}
+		types.ArrayFixed {
+			return c.parsed_type_uses_concrete_generics(typ.elem_type, depth + 1)
+		}
+		types.Channel {
+			return c.parsed_type_uses_concrete_generics(typ.elem_type, depth + 1)
+		}
+		types.Map {
+			return c.parsed_type_uses_concrete_generics(typ.key_type, depth + 1)
+				|| c.parsed_type_uses_concrete_generics(typ.value_type, depth + 1)
+		}
+		types.Pointer {
+			return c.parsed_type_uses_concrete_generics(typ.base_type, depth + 1)
+		}
+		types.FnType {
+			for param in typ.params {
+				if c.parsed_type_uses_concrete_generics(param, depth + 1) {
+					return true
+				}
+			}
+			return c.parsed_type_uses_concrete_generics(typ.return_type, depth + 1)
+		}
+		types.OptionType {
+			return c.parsed_type_uses_concrete_generics(typ.base_type, depth + 1)
+		}
+		types.ResultType {
+			return c.parsed_type_uses_concrete_generics(typ.base_type, depth + 1)
+		}
+		types.Alias {
+			return c.parsed_type_uses_concrete_generics(typ.base_type, depth + 1)
+		}
+		types.Struct {
+			return c.named_type_uses_concrete_generics(typ.name)
+		}
+		types.Interface {
+			return c.named_type_uses_concrete_generics(typ.name)
+		}
+		types.SumType {
+			return c.named_type_uses_concrete_generics(typ.name)
+		}
+		types.MultiReturn {
+			for item in typ.types {
+				if c.parsed_type_uses_concrete_generics(item, depth + 1) {
+					return true
+				}
+			}
+		}
+		else {}
+	}
+
+	return false
+}
+
+fn (c &CallCollector) named_type_uses_concrete_generics(name string) bool {
+	base_name := types.generic_base_name(name)
+	return base_name != name
+		&& (base_name in c.tc.struct_generic_params || base_name in c.tc.sum_generic_params)
+}
+
+fn (c &CallCollector) struct_decl_info_with_imports(name string, cur_module string, imports map[string]string) ?StructDeclInfo {
+	if info := c.struct_decl_info(name, cur_module) {
+		return info
+	}
+	if !name.contains('.') {
+		return none
+	}
+	alias := name.all_before('.')
+	if module_name := imports[alias] {
+		resolved_name := module_name + name[alias.len..]
+		return c.struct_decl_info(resolved_name, module_name)
+	}
+	return none
+}
+
+fn markused_type_name_start_byte(ch u8) bool {
+	return (ch >= `a` && ch <= `z`) || (ch >= `A` && ch <= `Z`) || ch == `_`
+}
+
+fn markused_generic_name_byte(ch u8) bool {
+	return (ch >= `a` && ch <= `z`) || (ch >= `A` && ch <= `Z`)
+		|| (ch >= `0` && ch <= `9`) || ch in [`_`, `.`]
+}
+
+fn (c &CallCollector) generic_type_base_is_known(base string, cur_module string, imports map[string]string) bool {
+	if base in c.tc.struct_generic_params || base in c.tc.sum_generic_params {
+		return true
+	}
+	if !base.contains('.') {
+		qbase := qualify_fn(cur_module, base)
+		return qbase in c.tc.struct_generic_params || qbase in c.tc.sum_generic_params
+	}
+	alias := base.all_before('.')
+	if module_name := imports[alias] {
+		resolved := module_name + base[alias.len..]
+		return resolved in c.tc.struct_generic_params || resolved in c.tc.sum_generic_params
+	}
+	return false
+}
+
+fn (c &CallCollector) generic_alias_target(name string, cur_module string, imports map[string]string) ?string {
+	if target := c.tc.type_aliases[name] {
+		return target
+	}
+	if !name.contains('.') {
+		qname := qualify_fn(cur_module, name)
+		if target := c.tc.type_aliases[qname] {
+			return target
+		}
+		return none
+	}
+	alias := name.all_before('.')
+	if module_name := imports[alias] {
+		resolved := module_name + name[alias.len..]
+		if target := c.tc.type_aliases[resolved] {
+			return target
+		}
+	}
+	return none
+}
+
+fn (c &CallCollector) selective_alias_uses_generics(name string, cur_module string, imports map[string]string, depth int) bool {
+	if c.selective_alias_targets.len == 0 || name.contains('.') {
+		return false
+	}
+	targets := c.selective_alias_targets[name] or { return false }
+	for target in targets {
+		if c.type_text_uses_generics_depth(target.trim_space(), cur_module, imports, depth) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (c &CallCollector) generic_fn_name_is_known(name string, cur_module string) bool {
+	if name in c.tc.fn_generic_params {
+		return true
+	}
+	qname := qualify_fn(cur_module, name)
+	return qname != name && qname in c.tc.fn_generic_params
+}
+
 // enqueue_function_value_selectors supports enqueue function value selectors handling for markused.
 fn enqueue_function_value_selectors(a &flat.FlatAst, collector CallCollector, fn_decls map[string]FnDeclInfo, has_entry_main bool, mut used map[string]bool, mut queue []string) {
 	if has_entry_main {
@@ -2577,8 +2995,9 @@ fn (c &CallCollector) add_interface_boxed_generic_methods(iface_name string, act
 // fn_decl body (see precollect_body_calls).
 struct BodyCalls {
 mut:
-	calls []string
-	refs  []string
+	calls         []string
+	refs          []string
+	uses_generics bool
 }
 
 // collect_body runs the full per-body analysis (local values, calls,
@@ -2595,11 +3014,15 @@ fn (c &CallCollector) collect_body(node &flat.Node, cur_module string, imports m
 		map[int]bool{}
 	}
 	mut result := BodyCalls{
-		calls: []string{cap: 32}
-		refs:  []string{cap: 8}
+		calls:         []string{cap: 32}
+		refs:          []string{cap: 8}
+		uses_generics: c.generic_fn_name_is_known(node.value, cur_module)
+			|| c.type_text_uses_generics(node.value, cur_module, imports)
+			|| c.node_uses_generics(node, cur_module, imports)
 	}
-	c.collect_calls_with_locals(node, cur_module, imports, receiver_name, receiver_struct,
-		local_values, local_types, visible_local_idents, mut result.calls)
+	result.uses_generics = c.collect_calls_with_locals_and_generics(node, cur_module, imports,
+		receiver_name, receiver_struct, local_values, local_types, visible_local_idents, true,
+		result.uses_generics, mut result.calls)
 	c.collect_initializer_refs_with_locals(node, cur_module, imports, local_values,
 		visible_local_idents, mut result.refs)
 	return result
@@ -2618,14 +3041,15 @@ fn (c &CallCollector) collect_bodies_range(body_ids []int, body_modules []string
 // TypeChecker. The lookup maps are shared read-only.
 fn (c &CallCollector) fork_with_tc(wtc &types.TypeChecker) CallCollector {
 	return CallCollector{
-		a:                c.a
-		tc:               wtc
-		fn_decls:         c.fn_decls
-		fn_suffixes:      c.fn_suffixes
-		struct_decls:     c.struct_decls
-		const_decls:      c.const_decls
-		const_suffixes:   c.const_suffixes
-		iface_param_gate: c.iface_param_gate
+		a:                       c.a
+		tc:                      wtc
+		fn_decls:                c.fn_decls
+		fn_suffixes:             c.fn_suffixes
+		struct_decls:            c.struct_decls
+		const_decls:             c.const_decls
+		const_suffixes:          c.const_suffixes
+		selective_alias_targets: c.selective_alias_targets
+		iface_param_gate:        c.iface_param_gate
 	}
 }
 
@@ -2641,11 +3065,32 @@ fn (c &CallCollector) collect_calls(node &flat.Node, cur_module string, imports 
 		local_values, local_types, visible_local_idents, mut calls)
 }
 
+fn (c &CallCollector) collect_calls_with_generic_usage(node &flat.Node, cur_module string, imports map[string]string, receiver_name string, receiver_struct string, mut calls []string) bool {
+	local_values, local_types := c.local_value_info(node, cur_module, imports)
+	visible_local_idents := if c.local_values_need_visibility(local_values, cur_module, imports) {
+		markused_visible_local_idents(c.a, node, local_values)
+	} else {
+		map[int]bool{}
+	}
+	uses_generics := c.node_uses_generics(node, cur_module, imports)
+	return c.collect_calls_with_locals_and_generics(node, cur_module, imports, receiver_name,
+		receiver_struct, local_values, local_types, visible_local_idents, true, uses_generics, mut
+		calls)
+}
+
 // collect_calls_with_locals is collect_calls with the per-body local-value
 // analysis precomputed by the caller, so the BFS can share one analysis between
 // collect_calls and collect_initializer_refs instead of walking each function
 // subtree twice more.
 fn (c &CallCollector) collect_calls_with_locals(node &flat.Node, cur_module string, imports map[string]string, receiver_name string, receiver_struct string, local_values map[string]bool, local_types map[string]string, visible_local_idents map[int]bool, mut calls []string) {
+	uses_generics := false
+	_ = c.collect_calls_with_locals_and_generics(node, cur_module, imports, receiver_name,
+		receiver_struct, local_values, local_types, visible_local_idents, false, uses_generics, mut
+		calls)
+}
+
+fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cur_module string, imports map[string]string, receiver_name string, receiver_struct string, local_values map[string]bool, local_types map[string]string, visible_local_idents map[int]bool, detect_generics bool, initial_uses_generics bool, mut calls []string) bool {
+	mut uses_generics := initial_uses_generics
 	if cur_module == 'ast' && node.value == 'TypeSymbol.find_method_with_generic_parent' {
 		c.add_typed_receiver_method_name('ast.Table.find_structured_receiver_method', mut calls)
 	}
@@ -2659,6 +3104,9 @@ fn (c &CallCollector) collect_calls_with_locals(node &flat.Node, cur_module stri
 	for stack.len > 0 {
 		child_id := stack.pop()
 		child := &c.a.nodes[int(child_id)]
+		if detect_generics && !uses_generics && c.node_uses_generics(child, cur_module, imports) {
+			uses_generics = true
+		}
 		match child.kind {
 			.ident {
 				name_is_local := markused_ident_is_visible_local(child_id, child.value,
@@ -2677,6 +3125,10 @@ fn (c &CallCollector) collect_calls_with_locals(node &flat.Node, cur_module stri
 				mut resolved_call := ''
 				if resolved := c.tc.resolved_call_name(child_id) {
 					resolved_call = resolved
+				}
+				if detect_generics && !uses_generics
+					&& c.generic_fn_name_is_known(resolved_call, cur_module) {
+					uses_generics = true
 				}
 				c.collect_interface_boxed_generic_methods(child, resolved_call, cur_module,
 					imports, local_values, mut calls)
@@ -2899,6 +3351,7 @@ fn (c &CallCollector) collect_calls_with_locals(node &flat.Node, cur_module stri
 			}
 		}
 	}
+	return uses_generics
 }
 
 fn (c &CallCollector) call_callee_expr_to_collect(node &flat.Node) ?flat.NodeId {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -59,8 +59,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 	}
 	struct_decls := t.collect_generic_struct_decls()
 	t.seed_generic_specialization_args(struct_decls)
-	template_nodes := t.generic_decl_template_nodes(decls)
-	mut ignored_nodes := t.unused_fn_subtree_nodes()
+	mut ignored_nodes := t.monomorphize_ignored_nodes(decls)
 	mut emitted := map[string]bool{}
 	mut generated := []string{}
 	mut generic_call_sites := []GenericCallSite{}
@@ -81,7 +80,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 		// and must be scanned too, or its generic calls stay unspecialized.
 		mut rescan := []int{}
 		if scan_start > 0 && t.used_fns.len != used_fns_at_scan {
-			new_ignored := t.unused_fn_subtree_nodes()
+			new_ignored := t.monomorphize_ignored_nodes(decls)
 			for i in 0 .. scan_start {
 				if i < ignored_nodes.len && ignored_nodes[i] && !(i < new_ignored.len
 					&& new_ignored[i]) {
@@ -97,8 +96,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 			} else {
 				scan_start + (scan_idx - rescan.len)
 			}
-			if (i < template_nodes.len && template_nodes[i])
-				|| (i < ignored_nodes.len && ignored_nodes[i]) {
+			if i < ignored_nodes.len && ignored_nodes[i] {
 				continue
 			}
 			node := t.a.nodes[i]
@@ -149,8 +147,8 @@ fn (mut t Transformer) monomorphize_pass() []string {
 	if t.refresh_decl_assign_types_after_generic_rewrite() {
 		t.generic_call_spec_cache = map[int]GenericCallSpec{}
 		t.generic_call_spec_misses = map[int]bool{}
-		extra_call_sites := t.collect_generic_call_sites_after_type_refresh(decls, template_nodes,
-			ignored_nodes, mut emitted, mut generated, mut recorded_call_sites)
+		extra_call_sites := t.collect_generic_call_sites_after_type_refresh(decls, ignored_nodes, mut
+			emitted, mut generated, mut recorded_call_sites)
 		if extra_call_sites.len > 0 {
 			t.rewrite_generic_call_sites(decls, extra_call_sites)
 			t.refresh_decl_assign_types_after_generic_rewrite()
@@ -160,7 +158,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 	return generated
 }
 
-fn (mut t Transformer) collect_generic_call_sites_after_type_refresh(decls map[string]GenericFnDecl, template_nodes []bool, ignored_nodes []bool, mut emitted map[string]bool, mut generated []string, mut recorded_call_sites map[int]bool) []GenericCallSite {
+fn (mut t Transformer) collect_generic_call_sites_after_type_refresh(decls map[string]GenericFnDecl, ignored_nodes []bool, mut emitted map[string]bool, mut generated []string, mut recorded_call_sites map[int]bool) []GenericCallSite {
 	mut sites := []GenericCallSite{}
 	t.ensure_node_module_map()
 	old_in_scan := t.in_monomorphize_scan
@@ -170,8 +168,7 @@ fn (mut t Transformer) collect_generic_call_sites_after_type_refresh(decls map[s
 	}
 	node_count := t.a.nodes.len
 	for i in 0 .. node_count {
-		if (i < template_nodes.len && template_nodes[i])
-			|| (i < ignored_nodes.len && ignored_nodes[i]) {
+		if i < ignored_nodes.len && ignored_nodes[i] {
 			continue
 		}
 		node := t.a.nodes[i]
@@ -1976,16 +1973,12 @@ fn (mut t Transformer) collect_generic_fn_decls() map[string]GenericFnDecl {
 	return decls
 }
 
-fn (mut t Transformer) generic_decl_template_nodes(decls map[string]GenericFnDecl) []bool {
+fn (mut t Transformer) monomorphize_ignored_nodes(decls map[string]GenericFnDecl) []bool {
 	mut nodes := []bool{len: t.a.nodes.len}
+	mut stack := []flat.NodeId{cap: 256}
 	for _, decl in decls {
-		t.collect_node_subtree_flags(decl.id, mut nodes)
+		t.collect_node_subtree_flags(decl.id, mut nodes, mut stack)
 	}
-	return nodes
-}
-
-fn (mut t Transformer) unused_fn_subtree_nodes() []bool {
-	mut nodes := []bool{len: t.a.nodes.len}
 	if !t.has_used_fn_filter() {
 		return nodes
 	}
@@ -2001,7 +1994,7 @@ fn (mut t Transformer) unused_fn_subtree_nodes() []bool {
 					continue
 				}
 				if !t.should_transform_fn(node) {
-					t.collect_node_subtree_flags(flat.NodeId(i), mut nodes)
+					t.collect_node_subtree_flags(flat.NodeId(i), mut nodes, mut stack)
 				}
 			}
 			else {}
@@ -2087,14 +2080,29 @@ fn (mut t Transformer) collect_node_subtree_ids(id flat.NodeId, mut nodes map[in
 	}
 }
 
-fn (mut t Transformer) collect_node_subtree_flags(id flat.NodeId, mut nodes []bool) {
-	if int(id) < 0 || int(id) >= t.a.nodes.len || int(id) >= nodes.len || nodes[int(id)] {
-		return
-	}
-	nodes[int(id)] = true
-	node := t.a.nodes[int(id)]
-	for i in 0 .. node.children_count {
-		t.collect_node_subtree_flags(t.a.child(&node, i), mut nodes)
+fn (mut t Transformer) collect_node_subtree_flags(id flat.NodeId, mut nodes []bool, mut stack []flat.NodeId) {
+	stack.clear()
+	stack << id
+	for stack.len > 0 {
+		current := stack.pop()
+		idx := int(current)
+		if idx < 0 || idx >= t.a.nodes.len || idx >= nodes.len || nodes[idx] {
+			continue
+		}
+		nodes[idx] = true
+		node := t.a.nodes[idx]
+		start := node.children_start
+		end := start + int(node.children_count)
+		if start < 0 || end > t.a.children.len {
+			continue
+		}
+		for i in start .. end {
+			// The child range is checked above; avoid bounds checks in this hot walk.
+			child_id := unsafe { t.a.children[i] }
+			if int(child_id) >= 0 {
+				stack << child_id
+			}
+		}
 	}
 }
 
@@ -5830,7 +5838,7 @@ fn (mut t Transformer) copy_cloned_resolution_forked(src_idx int, dst_idx int) {
 }
 
 fn (t &Transformer) resolved_call_is_generic_fn(name string) bool {
-	if name.len == 0 || isnil(t.tc) {
+	if t.skip_generics || name.len == 0 || isnil(t.tc) {
 		return false
 	}
 	if name.contains('[') && name.contains(']') {
@@ -5867,6 +5875,9 @@ fn substitute_generic_node_value(node flat.Node, args []string) string {
 fn (mut t Transformer) fn_decl_has_unresolved_generics(node flat.Node, module_name string) bool {
 	if generic_params_have_runtime_type_param(node.generic_params) {
 		return true
+	}
+	if t.skip_generics {
+		return false
 	}
 	if t.type_text_has_generic_placeholder(node.typ, module_name)
 		|| t.type_text_has_generic_placeholder(node.value, module_name) {
@@ -5912,6 +5923,9 @@ fn (mut t Transformer) node_subtree_has_generic_placeholder(id flat.NodeId, modu
 }
 
 fn (mut t Transformer) type_text_has_generic_placeholder(typ string, module_name string) bool {
+	if t.skip_generics {
+		return false
+	}
 	clean := typ.trim_space()
 	if clean.len == 0 {
 		return false
@@ -6136,11 +6150,11 @@ fn (mut t Transformer) collect_generic_param_names_from_type(typ string, module_
 }
 
 fn generic_app_parts(typ string) (string, []string, bool) {
-	if typ.starts_with('fn(') || typ.starts_with('fn (') {
-		return '', []string{}, false
-	}
 	bracket := typ.index_u8(`[`)
 	if bracket <= 0 {
+		return '', []string{}, false
+	}
+	if typ.starts_with('fn(') || typ.starts_with('fn (') {
 		return '', []string{}, false
 	}
 	bracket_end := generic_matching_bracket(typ, bracket)
@@ -6972,6 +6986,9 @@ fn is_generic_fn_placeholder_name(typ string) bool {
 }
 
 fn (t &Transformer) generic_args_have_placeholders(args []string) bool {
+	if t.skip_generics {
+		return false
+	}
 	for arg in args {
 		if t.generic_arg_is_unresolved(arg) {
 			return true
@@ -6981,6 +6998,9 @@ fn (t &Transformer) generic_args_have_placeholders(args []string) bool {
 }
 
 fn (t &Transformer) generic_arg_is_unresolved(arg string) bool {
+	if t.skip_generics {
+		return false
+	}
 	// Hot: called for every call/assign type text during body transforms, with
 	// heavy repetition (a few thousand distinct texts per build). The result is
 	// a pure function of the text plus the declared-type tables and cur_module

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -4,6 +4,7 @@ import os
 import v3.bench
 import v3.flat
 import v3.gen.c as cgen
+import v3.gen.c.naming
 import v3.markused
 import v3.parser
 import v3.pref
@@ -546,6 +547,148 @@ fn clone_typechecker_after_scoped_transform(mut tc types.TypeChecker, ast &flat.
 	tc.set_fresh_type_cache(tc.type_cache_parse_enabled())
 }
 
+fn restored_fn_c_name(name string) string {
+	if name.starts_with('C.') {
+		return name[2..]
+	}
+	if name == 'malloc' {
+		return 'v_malloc'
+	}
+	if name == 'exit' {
+		return 'v_exit'
+	}
+	return naming.sanitize(name)
+}
+
+fn transformed_fn_is_used(name string, module_name string, used_fns map[string]bool) bool {
+	if used_fns.len == 0 || !used_fns['main'] || name.starts_with('__anon_fn_') {
+		return true
+	}
+	if used_fns[name] || used_fns[restored_fn_c_name(name)] {
+		return true
+	}
+	if module_name.len == 0 || module_name in ['main', 'builtin'] {
+		return module_name == 'builtin' && name == 'free' && used_fns['v_free']
+	}
+	qname := '${module_name}.${name}'
+	return used_fns[qname] || used_fns[restored_fn_c_name(qname)]
+}
+
+fn restore_transformed_fn_value_types(mut tc types.TypeChecker, a &flat.FlatAst, used_fns map[string]bool) {
+	for tc.expr_type_values.len < a.nodes.len {
+		tc.expr_type_values << types.Type(types.void_)
+		tc.expr_type_set << false
+	}
+	limit := if tc.resolved_fn_value_names.len < a.nodes.len {
+		tc.resolved_fn_value_names.len
+	} else {
+		a.nodes.len
+	}
+	for idx in 0 .. limit {
+		if idx >= tc.resolved_fn_value_set.len || !tc.resolved_fn_value_set[idx] {
+			continue
+		}
+		name := tc.resolved_fn_value_names[idx]
+		params := tc.fn_param_types[name] or { continue }
+		ret := tc.fn_ret_types[name] or { continue }
+		tc.expr_type_values[idx] = types.FnType{
+			params:      params
+			return_type: ret
+		}
+		tc.expr_type_set[idx] = true
+	}
+	mut cur_module := ''
+	mut stack := []flat.NodeId{cap: 256}
+	for top_idx in tc.top_level_idx {
+		top := a.nodes[top_idx]
+		if top.kind == .file {
+			cur_module = ''
+			continue
+		}
+		if top.kind == .module_decl {
+			cur_module = top.value
+			continue
+		}
+		if top.kind != .fn_decl {
+			continue
+		}
+		if !transformed_fn_is_used(top.value, cur_module, used_fns) {
+			continue
+		}
+		stack.clear()
+		stack << flat.NodeId(top_idx)
+		for stack.len > 0 {
+			id := stack.pop()
+			idx := int(id)
+			if idx < 0 || idx >= a.nodes.len {
+				continue
+			}
+			node := a.nodes[idx]
+			if node.kind == .call && node.children_count > 0 {
+				callee_id := a.children[node.children_start]
+				callee_idx := int(callee_id)
+				if callee_idx >= 0 && callee_idx < a.nodes.len {
+					callee := a.nodes[callee_idx]
+					if callee.kind == .ident && callee.value.len > 0 {
+						mut name := tc.resolved_call_name(id) or { callee.value }
+						if name !in tc.fn_param_types || name !in tc.fn_ret_types {
+							qname := if cur_module.len == 0 || cur_module in ['main', 'builtin'] {
+								callee.value
+							} else {
+								'${cur_module}.${callee.value}'
+							}
+							if qname in tc.fn_param_types && qname in tc.fn_ret_types {
+								name = qname
+							} else {
+								cname := 'C.${callee.value}'
+								if cname in tc.fn_param_types && cname in tc.fn_ret_types {
+									name = cname
+								} else {
+									name = ''
+								}
+							}
+						}
+						if name.len > 0 {
+							params := tc.fn_param_types[name] or { []types.Type{} }
+							if ret := tc.fn_ret_types[name] {
+								tc.expr_type_values[callee_idx] = types.FnType{
+									params:      params
+									return_type: ret
+								}
+								tc.expr_type_set[callee_idx] = true
+							}
+						}
+					}
+				}
+			}
+			if node.kind == .selector && node.children_count > 0 {
+				base_id := a.children[node.children_start]
+				base_idx := int(base_id)
+				if base_idx >= 0 && base_idx < a.nodes.len {
+					base := a.nodes[base_idx]
+					cname := 'C.${base.value}'
+					if base.kind == .ident && cname in tc.fn_param_types && cname in tc.fn_ret_types {
+						params := tc.fn_param_types[cname] or { []types.Type{} }
+						if ret := tc.fn_ret_types[cname] {
+							tc.expr_type_values[base_idx] = types.FnType{
+								params:      params
+								return_type: ret
+							}
+							tc.expr_type_set[base_idx] = true
+						}
+					}
+				}
+			}
+			for i := node.children_count - 1; i >= 0; i-- {
+				child_id := a.children[node.children_start + i]
+				if int(child_id) >= 0 {
+					stack << child_id
+				}
+			}
+		}
+	}
+}
+
 // main runs the v3 entry point.
 fn main() {
 	args := os.args[1..]
@@ -834,8 +977,7 @@ fn main() {
 	parse_was_parallel = parse_was_parallel || user_parse_parallel
 	test_files := test_input_files(user_files, backend, prefs.target_os)
 
-	seed_implicit_sync_import(mut a)
-	seed_implicit_embed_file_import(mut a)
+	seed_implicit_imports(mut a)
 
 	// Resolve imports recursively
 	import_parse_parallel := resolve_imports(mut a, mut p, prefs, user_files, !current_no_parallel)
@@ -888,10 +1030,13 @@ fn main() {
 
 	// Mark used functions (dead-code elimination). This is done before transform
 	// so the transformer can skip function bodies that the C backend will prune.
-	mut used_fns := if test_files.len > 0 {
-		markused.mark_used_for_tests(a, pre_tc, test_files)
+	mut used_fns := map[string]bool{}
+	mut uses_generics := false
+	if test_files.len > 0 {
+		used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a, pre_tc,
+			test_files)
 	} else {
-		markused.mark_used(a, pre_tc)
+		used_fns, uses_generics = markused.mark_used_with_generic_usage(a, pre_tc)
 	}
 	b.step('markused')
 
@@ -899,7 +1044,9 @@ fn main() {
 	// by default for compatible builds, and `-no-parallel` disables both threaded transform
 	// and cgen.
 	mut transform_was_parallel := false
-	skip_transform_generics := building_v || cmd_v_build
+	// Markused distinguishes reachable generic calls/types from generic templates
+	// that merely came along with an imported module (notably sync and rand).
+	skip_transform_generics := building_v || cmd_v_build || !uses_generics
 	mut scope_whole_transform := !current_parallel_transform
 	$if v3_no_parallel ? {
 		scope_whole_transform = true
@@ -927,7 +1074,11 @@ fn main() {
 	set_diagnostic_files(mut pre_tc, user_files)
 	set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
 	if !building_v && !cmd_v_build {
-		pre_tc.annotate_types_with_used(used_fns)
+		if uses_generics {
+			pre_tc.annotate_types_with_used(used_fns)
+		} else {
+			restore_transformed_fn_value_types(mut pre_tc, a, used_fns)
+		}
 	}
 	b.step('annotate types')
 
@@ -951,12 +1102,13 @@ fn main() {
 		}
 	}
 
-	// Monomorphization only adds specialized generic instantiations to `used_fns`. The V
-	// compiler sources use no generics, so when building V we skip specialization and
-	// only erase generic templates that otherwise generate invalid raw C declarations.
+	// Monomorphization only adds specialized generic instantiations to `used_fns`. Skip
+	// it when markused found no reachable generic use; the small metadata cleanup keeps
+	// unreachable generic templates out of C without walking or rewriting their ASTs.
+	// Self-host builds retain their dedicated generic-function erasure pass.
 	if building_v {
 		used_fns = transform.erase_generic_templates(mut a, &pre_tc, used_fns)
-	} else {
+	} else if uses_generics {
 		mut monomorph_used_fns, monomorph_errors := transform.monomorphize_with_used_checked(mut a,
 			&pre_tc, used_fns)
 		used_fns = monomorph_used_fns.move()
@@ -967,6 +1119,8 @@ fn main() {
 			}
 			exit(1)
 		}
+	} else {
+		erase_unreachable_generic_type_templates(mut pre_tc)
 	}
 	b.step('monomorphize')
 
@@ -998,6 +1152,7 @@ fn main() {
 			mut g := cgen.FlatGen.new()
 			g.set_c99_mode(prefs.c99)
 			g.set_prealloc('prealloc' in prefs.user_defines)
+			g.set_skip_generics(skip_transform_generics)
 			g.set_compiler_vexe(prefs.vexe)
 			g.set_scope_parallel_workers(true)
 			c_code := g.gen_with_used_test_options(a, used_fns, &pre_tc, current_no_parallel,
@@ -1016,6 +1171,7 @@ fn main() {
 			mut g := cgen.FlatGen.new()
 			g.set_c99_mode(prefs.c99)
 			g.set_prealloc('prealloc' in prefs.user_defines)
+			g.set_skip_generics(skip_transform_generics)
 			g.set_compiler_vexe(prefs.vexe)
 			c_code := g.gen_with_used_test_options(a, used_fns, &pre_tc, current_no_parallel,
 				test_files)
@@ -1521,6 +1677,19 @@ fn set_diagnostic_files(mut tc types.TypeChecker, user_files []string) {
 	}
 }
 
+fn erase_unreachable_generic_type_templates(mut tc types.TypeChecker) {
+	for name in tc.struct_generic_params.keys() {
+		tc.structs.delete(name)
+		tc.unions.delete(name)
+		tc.params_structs.delete(name)
+	}
+	for name in tc.sum_generic_params.keys() {
+		tc.sum_types.delete(name)
+		tc.sum_generic_params.delete(name)
+	}
+	tc.invalidate_short_type_name_index()
+}
+
 fn set_unsupported_generic_files(mut tc types.TypeChecker, a &flat.FlatAst, include_imports bool, diagnostic_root string) {
 	if !include_imports {
 		return
@@ -1561,37 +1730,24 @@ fn skipped_backend_modules(prefs &pref.Preferences) []string {
 	return skipped
 }
 
-fn seed_implicit_sync_import(mut a flat.FlatAst) {
-	if ast_should_seed_sync_import(a, a.nodes.len, false) {
+struct ImplicitImportScan {
+mut:
+	node_idx         int
+	needs_sync       bool
+	has_sync         bool
+	needs_embed      bool
+	has_embed_import bool
+}
+
+fn seed_implicit_imports(mut a flat.FlatAst) {
+	mut scan := ImplicitImportScan{}
+	scan_implicit_imports(a, a.nodes.len, mut scan)
+	if scan.needs_sync && !scan.has_sync {
 		a.add_node(sync_import_node())
 	}
-}
-
-fn seed_implicit_embed_file_import(mut a flat.FlatAst) {
-	if ast_should_seed_embed_file_import(a, a.nodes.len, false) {
+	if scan.needs_embed && !scan.has_embed_import {
 		a.add_node(embed_file_import_node())
 	}
-}
-
-// ast_should_seed_sync_import reports whether a synthetic `import sync` should be
-// seeded for the module whose parsed region ends at end_node. The need and
-// already-imported scans are both bounded to end_node — the module's serial
-// boundary — so an explicit import in a *later* module of the same wave (already
-// parsed into the array, but not yet reached in serial order) can neither suppress
-// nor be conflated with this module's seed. already_added carries the "a synthetic
-// import was already seeded for an earlier module in this wave" state the bounded
-// scan cannot see, because the wave's synthetic nodes are spliced in only after
-// every boundary has been checked; it keeps the seed global-once.
-fn ast_should_seed_sync_import(a &flat.FlatAst, end_node int, already_added bool) bool {
-	return !already_added && ast_needs_sync_import(a, end_node)
-		&& !ast_has_import_upto(a, 'sync', end_node)
-}
-
-// ast_should_seed_embed_file_import bounds its scans like
-// ast_should_seed_sync_import.
-fn ast_should_seed_embed_file_import(a &flat.FlatAst, end_node int, already_added bool) bool {
-	return !already_added && ast_needs_embed_file_import(a, end_node)
-		&& !ast_has_import_upto(a, 'v.embed_file', end_node)
 }
 
 fn sync_import_node() flat.Node {
@@ -1610,29 +1766,32 @@ fn embed_file_import_node() flat.Node {
 	}
 }
 
-fn ast_needs_sync_import(a &flat.FlatAst, end_node int) bool {
-	for i in 0 .. end_node {
+fn scan_implicit_imports(a &flat.FlatAst, end_node int, mut scan ImplicitImportScan) {
+	for i in scan.node_idx .. end_node {
 		node := a.nodes[i]
-		if node.kind == .lock_expr {
-			return true
+		if node.kind == .import_decl {
+			if node.value == 'sync' {
+				scan.has_sync = true
+			} else if node.value == 'v.embed_file' {
+				scan.has_embed_import = true
+			}
 		}
-		if node.kind == .field_decl && type_text_is_shared(node.typ) {
-			return true
+		if !scan.needs_sync {
+			if node.kind == .lock_expr
+				|| (node.kind == .field_decl && type_text_is_shared(node.typ))
+				|| (node.kind == .struct_init && node.value.starts_with('chan '))
+				|| (node.kind == .infix && node.op == .arrow)
+				|| (node.kind == .prefix && node.op == .arrow)
+				|| (node.typ.len > 0 && type_text_is_channel(node.typ)) {
+				scan.needs_sync = true
+			}
 		}
-		if node.kind == .struct_init && node.value.starts_with('chan ') {
-			return true
-		}
-		if node.kind == .infix && node.op == .arrow {
-			return true
-		}
-		if node.kind == .prefix && node.op == .arrow {
-			return true
-		}
-		if type_text_is_channel(node.typ) {
-			return true
+		if !scan.needs_embed && node.kind == .struct_init
+			&& node.value == 'embed_file.EmbedFileData' {
+			scan.needs_embed = true
 		}
 	}
-	return false
+	scan.node_idx = end_node
 }
 
 fn type_text_is_channel(typ string) bool {
@@ -1649,31 +1808,6 @@ fn type_text_is_channel(typ string) bool {
 		break
 	}
 	return clean.starts_with('chan ') || clean == 'chan'
-}
-
-fn ast_needs_embed_file_import(a &flat.FlatAst, end_node int) bool {
-	for i in 0 .. end_node {
-		node := a.nodes[i]
-		if node.kind == .struct_init && node.value == 'embed_file.EmbedFileData' {
-			return true
-		}
-	}
-	return false
-}
-
-// ast_has_import_upto reports whether an import of name already exists among the
-// first end_node nodes. The wave seeds bound this to a module's serial boundary
-// so later modules parsed into the same wave cannot suppress an earlier module's
-// synthetic import; synthetic nodes appended past that boundary are tracked by
-// the caller's already_added flag instead.
-fn ast_has_import_upto(a &flat.FlatAst, name string, end_node int) bool {
-	for i in 0 .. end_node {
-		node := a.nodes[i]
-		if node.kind == .import_decl && node.value == name {
-			return true
-		}
-	}
-	return false
 }
 
 fn type_text_is_shared(raw string) bool {
@@ -1776,8 +1910,10 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 	// wave the synthetic nodes are only spliced in after every boundary has been
 	// checked, so a later module's bounded already-imported scan cannot yet see an
 	// earlier module's pending seed; the flags stand in for it.
-	mut synthetic_sync_added := false
-	mut synthetic_embed_file_added := false
+	mut implicit_imports := ImplicitImportScan{}
+	scan_implicit_imports(a, a.nodes.len, mut implicit_imports)
+	mut synthetic_sync_added := implicit_imports.has_sync
+	mut synthetic_embed_file_added := implicit_imports.has_embed_import
 	for {
 		// Collect one wave: every not-yet-parsed module imported by the nodes
 		// scanned so far. Parsing appends at the end of the node array and the
@@ -1879,14 +2015,16 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			} else {
 				wave_end_nodes
 			}
-			if ast_should_seed_sync_import(a, region_end, synthetic_sync_added) {
+			scan_implicit_imports(a, region_end, mut implicit_imports)
+			if !synthetic_sync_added && implicit_imports.needs_sync && !implicit_imports.has_sync {
 				insertions << SyntheticInsertion{
 					pos:  region_end
 					node: sync_import_node()
 				}
 				synthetic_sync_added = true
 			}
-			if ast_should_seed_embed_file_import(a, region_end, synthetic_embed_file_added) {
+			if !synthetic_embed_file_added && implicit_imports.needs_embed
+				&& !implicit_imports.has_embed_import {
 				insertions << SyntheticInsertion{
 					pos:  region_end
 					node: embed_file_import_node()
@@ -1896,6 +2034,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			module_start = module_file_end
 		}
 		insert_synthetic_imports(mut a, insertions)
+		implicit_imports.node_idx += insertions.len
 	}
 	return was_parallel
 }


### PR DESCRIPTION
## Summary

- detect whether reachable code actually uses generics during markused
- skip generic transform, full post-transform annotation, monomorphization, and generic-only C metadata for non-generic programs
- fuse overlapping markused/monomorphization AST walks and reuse iterative traversal stacks
- avoid repeated implicit-import scans and non-top-level metadata scans
- build fixed-array constants directly into one builder
- replace subprocess/procfs RSS sampling with `runtime.used_memory()`

The `sha3.v` reproducer imports modules containing generic templates but does not reach any generic code, so the generic pipeline can be omitted. V `-profile` was used to identify and verify the skipped work.

## Benchmark

Compilers were built with `-prod -gc none -d parallel`; all targets were compiled with `-prod -b c`. Measurements used 100 alternating cycles and the median of the quietest half to limit desktop-load bias.

| Compiler | Compile-to-C time |
| --- | ---: |
| v3 before (`b2baf822d0`) | 92.436 ms |
| v3 after | 50.231 ms |
| V 0.5.1 | 48.491 ms |

This is a 45.7% reduction, or 1.84x faster. The remaining gap to V 0.5.1 is 3.6% on this host.

Reproducer/profile context: #26961.

## Behavior

Program behavior is unchanged. On the rebased upstream tree, generated C differs only in internal temporary numbering and optional-typedef declaration order because skipped generic work no longer consumes those counters.

## Tests

- exact sha3 issue compile regression
- `vlib/v/compiler_errors_test.v`: 1589 passed, 1 skipped
- v3 C generator suite: 4/4
- v3 transform suite: 3/3
- v3 markused suite: 1/1
- generic codegen regression
- cross-module generic argument regression
- function-value, fixed-array, directive, and parallel-parser regressions
- formatting and `git diff --check`

`generic_sum_type_codegen_test.v` and `review_transform_regressions_test.v` currently fail with the same diagnostics on pristine `b2baf822d0`, so those are existing upstream baseline failures rather than regressions from this PR.