### PR TITLE
v3: restore Darwin self-hosting and speed up transform

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -7564,6 +7564,7 @@ fn (mut g FlatGen) headerless_libc_preamble() {
 	g.headerless_timeval_struct()
 	g.headerless_rusage_struct()
 	g.headerless_timespec_struct()
+	g.headerless_darwin_task_info_struct()
 	g.headerless_utsname_struct()
 	g.headerless_stat_struct()
 	g.headerless_tm_struct()
@@ -7876,6 +7877,15 @@ fn (mut g FlatGen) headerless_timespec_struct() {
 	g.writeln('#define CLOCKS_PER_SEC 1000000')
 	g.writeln('#endif')
 	g.writeln('clock_t clock(void);')
+}
+
+fn (mut g FlatGen) headerless_darwin_task_info_struct() {
+	g.writeln('#ifdef __APPLE__')
+	g.writeln('typedef unsigned int task_t;')
+	g.writeln('#pragma pack(push, 4)')
+	g.writeln('struct task_basic_info { i32 suspend_count; u64 virtual_size; u64 resident_size; struct { i32 seconds; i32 microseconds; } user_time; struct { i32 seconds; i32 microseconds; } system_time; i32 policy; };')
+	g.writeln('#pragma pack(pop)')
+	g.writeln('#endif')
 }
 
 fn (mut g FlatGen) headerless_tm_struct() {
@@ -8202,6 +8212,15 @@ fn (mut g FlatGen) headerless_darwin_constants() {
 	g.writeln('#define _SC_PAGESIZE 29')
 	g.writeln('#define _SC_NPROCESSORS_ONLN 58')
 	g.writeln('#define _SC_PHYS_PAGES 200')
+	g.writeln('#define KERN_SUCCESS 0')
+	g.writeln('#define MACH_TASK_BASIC_INFO_COUNT 12')
+	g.writeln('#if defined(__arm__) || defined(__arm64__)')
+	g.writeln('#define TASK_BASIC_INFO 18')
+	g.writeln('#elif defined(__LP64__)')
+	g.writeln('#define TASK_BASIC_INFO 5')
+	g.writeln('#else')
+	g.writeln('#define TASK_BASIC_INFO 4')
+	g.writeln('#endif')
 	g.headerless_mmap_constants('0x1000')
 	g.headerless_darwin_kqueue_constants()
 	g.writeln('#define FIONREAD 0x4004667f')

--- a/vlib/v3/tests/c_directive_order_codegen_test.v
+++ b/vlib/v3/tests/c_directive_order_codegen_test.v
@@ -1186,6 +1186,11 @@ fn test_mach_headers_are_emitted_headerlessly() {
 	assert !c_code.contains('#include <mach/mach.h>'), c_code
 	assert !c_code.contains('#include <mach/mach_time.h>'), c_code
 	assert !c_code.contains('#define panic mach_panic'), c_code
+	assert c_code.contains('typedef unsigned int task_t;'), c_code
+	assert c_code.contains('struct task_basic_info {'), c_code
+	assert c_code.contains('#define KERN_SUCCESS 0'), c_code
+	assert c_code.contains('#define MACH_TASK_BASIC_INFO_COUNT 12'), c_code
+	assert c_code.contains('#define TASK_BASIC_INFO 18'), c_code
 	assert c_code.contains('typedef struct mach_timebase_info_data_t mach_timebase_info_data_t;'), c_code
 	assert c_code.contains('struct mach_timebase_info_data_t {'), c_code
 	assert c_code.contains('void mach_timebase_info('), c_code

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -94,3 +94,50 @@ fn test_parallel_worker_reuses_prebuilt_call_param_decl_index() {
 	assert params.len == 1
 	assert params[0] is types.String
 }
+
+fn test_multi_return_selector_suffix_does_not_match_free_fn() {
+	mut a := flat.FlatAst.new()
+	receiver_id := a.add_node(flat.Node{
+		kind:  .ident
+		value: 'value'
+	})
+	selector_children_start := a.children.len
+	a.children << receiver_id
+	selector_id := a.add_node(flat.Node{
+		kind:           .selector
+		value:          'pair'
+		children_start: i32(selector_children_start)
+		children_count: 1
+	})
+	call_children_start := a.children.len
+	a.children << selector_id
+	call_id := a.add_node(flat.Node{
+		kind:           .call
+		children_start: i32(call_children_start)
+		children_count: 1
+	})
+	multi_return := types.Type(types.MultiReturn{
+		types: [types.Type(types.int_), types.Type(types.string_)]
+	})
+	mut tc := types.TypeChecker.new(a)
+	tc.fn_ret_types['pair'] = multi_return
+	mut t := Transformer{
+		a:                            &a
+		tc:                           &tc
+		receiver_method_suffix_index: {
+			'pair': 'pair'
+		}
+	}
+	call := a.nodes[int(call_id)]
+	if _ := t.find_multi_return_call_types(call, 2) {
+		assert false, 'selector suffix lookup matched the free pair function'
+	}
+
+	tc.fn_ret_types['Container.pair'] = multi_return
+	t.receiver_method_suffix_index['pair'] = 'Container.pair'
+	items := t.find_multi_return_call_types(call, 2) or {
+		assert false, 'selector suffix lookup did not match the receiver method'
+		return
+	}
+	assert items.len == 2
+}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -5676,6 +5676,9 @@ fn (t &Transformer) find_multi_return_call_types(node flat.Node, expected_count 
 				has_ambiguous_candidate = true
 				continue
 			}
+			if candidate.starts_with('.') && !indexed.ends_with(candidate) {
+				continue
+			}
 			if ret := t.tc.fn_ret_types[indexed] {
 				if items := multi_return_types_from_type(ret, expected_count) {
 					return items

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -5668,6 +5668,24 @@ fn (t &Transformer) find_multi_return_call_types(node flat.Node, expected_count 
 			}
 		}
 	}
+	mut has_ambiguous_candidate := false
+	for candidate in candidates {
+		index_key := if candidate.starts_with('.') { candidate[1..] } else { candidate }
+		if indexed := t.receiver_method_suffix_index[index_key] {
+			if indexed == receiver_method_suffix_ambiguous {
+				has_ambiguous_candidate = true
+				continue
+			}
+			if ret := t.tc.fn_ret_types[indexed] {
+				if items := multi_return_types_from_type(ret, expected_count) {
+					return items
+				}
+			}
+		}
+	}
+	if !has_ambiguous_candidate {
+		return none
+	}
 	for candidate in candidates {
 		for key, ret in t.tc.fn_ret_types {
 			matches := if candidate.starts_with('.') {


### PR DESCRIPTION
## Summary

- declare the Darwin Mach task-info ABI in headerless C output so v3 can self-host on macOS
- resolve unique multi-return call suffixes through the prepared receiver-method index
- preserve the full suffix scan only for ambiguous method names

## Performance

The v3 self-host transform phase dropped from 263-284 ms to 125-147 ms across repeated runs. The final verification run was 129.13 ms.

## Testing

- `./vnew vlib/v3/tests/c_directive_order_codegen_test.v`
- `./vnew -silent test vlib/v3/transform/`
- `./vnew -gc none -prealloc -prod -o /tmp/v3_transform_opt vlib/v3/v3.v`
- `/tmp/v3_transform_opt -building-v -o /tmp/v3_transform_v4 v3.v` from `vlib/v3`
