### PR TITLE
tools: store the reporting V version in C error bug reports

### DIFF
--- a/cmd/tools/modules/vbugreport/c_error_storage.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage.v
@@ -7,6 +7,7 @@ pub:
 	c_file_name   string
 	target_os     string
 	ccompiler     string
+	v_version     string
 	arch          string
 	build_options string
 	error_string  string
@@ -18,14 +19,16 @@ pub:
 // new_stored_c_error_report builds the fields stored by the C error report receiver.
 // The generated C context is stored in `lines`, while the corresponding V source
 // context (the V line that caused the C error and its surrounding lines) is stored
-// separately in `v_lines`. `arch`, `build_options` (the codegen-affecting `v` flags) and
-// `v_source` (the failing file's leading declarations plus the block around the error line) are
-// stored so a report can be reproduced.
-pub fn new_stored_c_error_report(c_file string, target_os string, ccompiler string, arch string, build_options string, c_error string, c_lines []string, v_lines []string, v_source string) StoredCErrorReport {
+// separately in `v_lines`. `v_version` (the reporting compiler's version), `arch`,
+// `build_options` (the codegen-affecting `v` flags) and `v_source` (the failing file's leading
+// declarations plus the block around the error line) are stored so a report can be reproduced,
+// and so reports from V versions predating a fix can be filtered out during triage.
+pub fn new_stored_c_error_report(c_file string, target_os string, ccompiler string, v_version string, arch string, build_options string, c_error string, c_lines []string, v_lines []string, v_source string) StoredCErrorReport {
 	return StoredCErrorReport{
 		c_file_name:   normalized_file_name(c_file)
 		target_os:     target_os
 		ccompiler:     ccompiler
+		v_version:     v_version
 		arch:          arch
 		build_options: build_options
 		error_string:  c_error_string(c_error)

--- a/cmd/tools/modules/vbugreport/c_error_storage_test.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage_test.v
@@ -1,8 +1,8 @@
 module vbugreport
 
 fn test_new_stored_c_error_report_extracts_sql_fields() {
-	report := new_stored_c_error_report('/tmp/v/program.tmp.c', 'linux', 'clang', 'amd64',
-		'autofree gc:boehm', '/tmp/v/program.tmp.c:12:7: error: unknown type name "Foo"', [
+	report := new_stored_c_error_report('/tmp/v/program.tmp.c', 'linux', 'clang', '0.5.1 abcdef0',
+		'amd64', 'autofree gc:boehm', '/tmp/v/program.tmp.c:12:7: error: unknown type name "Foo"', [
 		'void main__main(void) {',
 		'\tFoo x;',
 	], [
@@ -11,6 +11,7 @@ fn test_new_stored_c_error_report_extracts_sql_fields() {
 	assert report.c_file_name == 'program.tmp.c'
 	assert report.target_os == 'linux'
 	assert report.ccompiler == 'clang'
+	assert report.v_version == '0.5.1 abcdef0'
 	assert report.arch == 'amd64'
 	assert report.build_options == 'autofree gc:boehm'
 	assert report.error_string == 'error: unknown type name "Foo"'
@@ -20,8 +21,8 @@ fn test_new_stored_c_error_report_extracts_sql_fields() {
 }
 
 fn test_new_stored_c_error_report_handles_windows_c_file_path() {
-	report := new_stored_c_error_report('C:\\tmp\\program.tmp.c', 'windows', 'msvc', 'amd64', '',
-		'error: syntax error', []string{}, []string{}, '')
+	report := new_stored_c_error_report('C:\\tmp\\program.tmp.c', 'windows', 'msvc', 'V 0.5.1',
+		'amd64', '', 'error: syntax error', []string{}, []string{}, '')
 	assert report.c_file_name == 'program.tmp.c'
 }
 

--- a/cmd/tools/vbug-report.v
+++ b/cmd/tools/vbug-report.v
@@ -205,7 +205,8 @@ fn init_db(db sqlite.DB) ! {
 				v_lines text not null default '',
 				arch text not null default '',
 				build_options text not null default '',
-				v_source text not null default ''
+				v_source text not null default '',
+				v_version text not null default ''
 			)")!
 	// Add columns that were introduced after the table already existed, so older
 	// databases pick them up without losing their stored reports.
@@ -213,6 +214,7 @@ fn init_db(db sqlite.DB) ! {
 	ensure_column(db, 'bug_reports', 'arch', "text not null default ''")!
 	ensure_column(db, 'bug_reports', 'build_options', "text not null default ''")!
 	ensure_column(db, 'bug_reports', 'v_source', "text not null default ''")!
+	ensure_column(db, 'bug_reports', 'v_version', "text not null default ''")!
 	db.exec('create index if not exists idx_bug_reports_created_at
 			on bug_reports(created_at)')!
 }
@@ -247,15 +249,15 @@ pub fn (mut app App) create(mut ctx Context) veb.Result {
 		return ctx.request_error('unsupported report kind')
 	}
 	stored_report := vbugreport.new_stored_c_error_report(report.c_file, report.target_os,
-		report.ccompiler, report.arch, report.build_options, report.c_error,
+		report.ccompiler, report.v_version, report.arch, report.build_options, report.c_error,
 		report.c_context.map(it.text), report.v_context.map(it.text), report.v_source)
 	id := new_report_id()
 	delete_token := rand.uuid_v4()
 	app.db.exec_param_many('insert into bug_reports (
 				id, delete_token, created_at, remote_ip, user_agent,
 				c_file_name, target_os, ccompiler, error_string, lines, v_lines,
-				arch, build_options, v_source
-			) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', [
+				arch, build_options, v_source, v_version
+			) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', [
 		id,
 		delete_token,
 		time.utc().format_rfc3339(),
@@ -270,6 +272,7 @@ pub fn (mut app App) create(mut ctx Context) veb.Result {
 		stored_report.arch,
 		stored_report.build_options,
 		stored_report.v_source,
+		stored_report.v_version,
 	]) or { return ctx.server_error('could not store report') }
 	return ctx.json(CreateBugReportResponse{
 		id:           id


### PR DESCRIPTION
Follow-up to #27735.

The C error bug-report **client already sends `v_version`** (`version.full_v_version(true)`) in the report JSON, and the **server already parses it** into the `BugReport` struct — but the receiver never stored it. So every stored report is anonymous as to which V produced it.

That gap makes triage repeatedly re-investigate crashes that a newer V has already fixed: with no version, an old-compiler report is indistinguishable from a current one, and the only way to tell is to rebuild a minimal repro and re-run it (several such cases have turned out to be already fixed on master).

### Change (server-side only)

- Add a `v_version` column to the `bug_reports` table, with an `ensure_column` migration so existing databases pick it up without losing stored reports (same pattern as `arch`/`build_options`/`v_source`).
- Thread `v_version` through `new_stored_c_error_report` and the `StoredCErrorReport` struct, and include it in the `INSERT`.

No client changes are needed — the value was already being transmitted.

### Tests

- `c_error_storage_test.v` updated for the new `new_stored_c_error_report` signature and asserts `v_version` round-trips.
- `v test cmd/tools/modules/vbugreport/` passes; `v -o vbugreport cmd/tools/vbug-report.v` builds; files are vfmt-clean.