### PR TITLE
v3: reduce self-host memory and transform time

### DIFF
--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -307,7 +307,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 		mut cgen_workers := []voidptr{cap: thread_count}
 		worker_setup_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
 		for ci := 0; ci < thread_count; ci++ {
-			w := g.new_parallel_result_worker(ci + 1)
+			w := g.new_parallel_dispatch_worker(ci + 1)
 			cgen_workers << voidptr(w)
 		}
 		for ci := 0; ci < thread_count; ci++ {
@@ -637,6 +637,15 @@ fn (mut g FlatGen) fn_ptr_type_key(typ types.FnType) string {
 // worker and, under -gc none, never freed.
 fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 	return g.new_parallel_worker_config(worker_id, false)
+}
+
+// new_parallel_dispatch_worker selects the lightweight accumulator only when
+// scoped batching keeps all actual emission in fresh full workers.
+fn (g &FlatGen) new_parallel_dispatch_worker(worker_id int) &FlatGen {
+	if g.scope_parallel_workers {
+		return g.new_parallel_result_worker(worker_id)
+	}
+	return g.new_parallel_worker(worker_id)
 }
 
 // new_parallel_result_worker creates a non-emitting helper accumulator. Caches

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -364,6 +364,18 @@ fn (g &FlatGen) parallel_cached_expr_type(id flat.NodeId, node flat.Node) ?types
 	if idx < 0 {
 		return none
 	}
+	if g.tc.transform_sparse_node_caches {
+		if t := g.tc.sparse_expr_type_values[idx] {
+			return t
+		}
+		if node.kind == .call {
+			if name := g.tc.sparse_resolved_call_names[idx] {
+				if t := g.tc.fn_ret_types[name] {
+					return t
+				}
+			}
+		}
+	}
 	if g.tc.parallel_check_sparse {
 		if t := g.tc.sparse_expr_type_values[idx] {
 			return t

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -1,0 +1,26 @@
+module c
+
+import v3.flat
+import v3.types
+
+fn parallel_worker_test_gen(scoped bool) (&FlatGen, &types.TypeChecker) {
+	mut ast := &flat.FlatAst{}
+	mut tc := types.TypeChecker.new(ast)
+	mut g := FlatGen.new()
+	g.a = ast
+	g.tc = &tc
+	g.scope_parallel_workers = scoped
+	return &g, &tc
+}
+
+fn test_parallel_dispatch_worker_owns_checker_outside_scoped_batching() {
+	g, tc := parallel_worker_test_gen(false)
+	w := g.new_parallel_dispatch_worker(1)
+	assert w.tc != tc
+}
+
+fn test_parallel_dispatch_worker_shares_checker_as_scoped_accumulator() {
+	g, tc := parallel_worker_test_gen(true)
+	w := g.new_parallel_dispatch_worker(1)
+	assert w.tc == tc
+}

--- a/vlib/v3/markused/markused_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/markused/markused_parallel_notd_v3_no_parallel.v
@@ -25,6 +25,8 @@ $if !windows {
 		results_ptr  voidptr // &[]BodyCalls
 		start        int
 		end          int
+	mut:
+		scope voidptr
 	}
 
 	// C.pthread_t declares C pthread t data used by markused.
@@ -48,14 +50,55 @@ $if !windows {
 
 	// markused_chunk_thread runs one worker's range of bodies.
 	fn markused_chunk_thread(arg voidptr) voidptr {
-		args := unsafe { &MarkusedChunkArgs(arg) }
+		mut args := unsafe { &MarkusedChunkArgs(arg) }
+		args.scope = markused_worker_scope_begin()
 		c := unsafe { &CallCollector(args.collector) }
 		body_ids := unsafe { &[]int(args.body_ids_ptr) }
 		modules := unsafe { &[]string(args.modules_ptr) }
 		mut results := unsafe { &[]BodyCalls(args.results_ptr) }
 		c.collect_bodies_range(*body_ids, *modules, args.imports, args.start, args.end, mut
 			*results)
+		markused_worker_scope_leave(args.scope)
 		return unsafe { nil }
+	}
+}
+
+fn markused_worker_scope_begin() voidptr {
+	$if prealloc {
+		return unsafe { prealloc_scope_begin() }
+	}
+	return unsafe { nil }
+}
+
+fn markused_worker_scope_leave(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_leave(scope) }
+		}
+	}
+}
+
+fn markused_worker_scope_free(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_free_after(scope) }
+		}
+	}
+}
+
+fn clone_body_calls(value BodyCalls) BodyCalls {
+	mut calls := []string{cap: value.calls.len}
+	for call in value.calls {
+		calls << call.clone()
+	}
+	mut refs := []string{cap: value.refs.len}
+	for ref in value.refs {
+		refs << ref.clone()
+	}
+	return BodyCalls{
+		calls:         calls
+		refs:          refs
+		uses_generics: value.uses_generics
 	}
 }
 
@@ -116,6 +159,12 @@ fn precollect_body_calls(collector CallCollector, body_ids []int, body_modules [
 			results)
 		for ci in 0 .. thread_count {
 			C.pthread_join(thread_ids[ci], unsafe { nil })
+			if args[ci].scope != unsafe { nil } {
+				for result_idx in args[ci].start .. args[ci].end {
+					results[result_idx] = clone_body_calls(results[result_idx])
+				}
+				markused_worker_scope_free(args[ci].scope)
+			}
 		}
 		return results
 	}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -68,9 +68,20 @@ mut:
 	anonymous_struct_types  map[string][]string
 	anonymous_struct_count  int
 	export_records          []ExportRecord
+	scope_parallel_workers  bool
+	worker_scope            voidptr
 pub mut:
 	a              &flat.FlatAst = unsafe { nil }
 	parsed_v_files int
+}
+
+// reserve_selfhost_ast prepares the shared AST for parsing and transforming a
+// compiler-sized input without retaining successively doubled backing arrays.
+pub fn (mut p Parser) reserve_selfhost_ast() {
+	selfhost_ast_capacity := 2 * 1024 * 1024
+	p.a.nodes.ensure_cap(selfhost_ast_capacity)
+	p.a.children.ensure_cap(selfhost_ast_capacity)
+	p.scope_parallel_workers = true
 }
 
 // ExportRecord captures one accepted `@[export: name]` registration in file

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -44,6 +44,7 @@ $if !windows {
 		prepass_chunk voidptr // &ComptimeConstPrepassChunk
 		start         int
 		end           int
+		chunk_bytes   int
 	}
 
 	// C.pthread_t declares C pthread t data used by parser.
@@ -71,6 +72,8 @@ $if !windows {
 	fn parse_chunk_thread(arg voidptr) voidptr {
 		a := unsafe { &ParseChunkArgs(arg) }
 		mut w := unsafe { &Parser(a.worker) }
+		scope := parser_worker_scope_begin(w.scope_parallel_workers)
+		w.reserve_for_source(a.chunk_bytes)
 		paths := unsafe { &[]string(a.paths_ptr) }
 		mut starts := unsafe { &[]int(a.starts_ptr) }
 		for i in a.start .. a.end {
@@ -79,6 +82,8 @@ $if !windows {
 			}
 			w.parse_into((*paths)[i])
 		}
+		w.worker_scope = scope
+		parser_worker_scope_leave(scope)
 		return unsafe { nil }
 	}
 
@@ -91,6 +96,31 @@ $if !windows {
 			w.precollect_parallel_comptime_consts(*paths, a.start, a.end, mut chunk.decls)
 		}
 		return unsafe { nil }
+	}
+}
+
+fn parser_worker_scope_begin(enabled bool) voidptr {
+	$if prealloc {
+		if enabled {
+			return unsafe { prealloc_scope_begin() }
+		}
+	}
+	return unsafe { nil }
+}
+
+fn parser_worker_scope_leave(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_leave(scope) }
+		}
+	}
+}
+
+fn parser_worker_scope_free(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_free_after(scope) }
+		}
 	}
 }
 
@@ -126,13 +156,15 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 		// per-file independent), so all of them are created up front. Each
 		// pre-reserves for its chunk's source bytes to avoid growth doubling.
 		mut workers := []&Parser{cap: thread_count}
+		mut worker_chunk_bytes := []int{len: thread_count}
 		for ci in 0 .. thread_count {
 			mut w := Parser.new(p.prefs)
 			mut chunk_bytes := i64(0)
 			for i in bounds[ci + 1] .. bounds[ci + 2] {
 				chunk_bytes += sizes[i]
 			}
-			w.reserve_for_source(int(chunk_bytes))
+			w.scope_parallel_workers = p.scope_parallel_workers
+			worker_chunk_bytes[ci] = int(chunk_bytes)
 			workers << w
 		}
 		mut args := []ParseChunkArgs{cap: thread_count}
@@ -144,6 +176,7 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 				prepass_chunk: voidptr(prepass_chunks[ci + 1])
 				start:         bounds[ci + 1]
 				end:           bounds[ci + 2]
+				chunk_bytes:   worker_chunk_bytes[ci]
 			}
 		}
 		mut thread_ids := []C.pthread_t{len: thread_count}
@@ -189,6 +222,7 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 		for ci in 0 .. thread_count {
 			C.pthread_join(thread_ids[ci], unsafe { nil })
 			p.merge_parsed_worker(workers[ci], mut starts, bounds[ci + 1], bounds[ci + 2])
+			parser_worker_scope_free(workers[ci].worker_scope)
 		}
 		return starts, true
 	}
@@ -796,6 +830,18 @@ fn (mut p Parser) merge_parsed_worker(w &Parser, mut starts []int, chunk_start i
 					node.value = shifted_marker
 				}
 			}
+			if w.worker_scope != unsafe { nil } {
+				unsafe {
+					mut node := &p.a.nodes[k]
+					node.value = node.value.clone()
+					node.typ = node.typ.clone()
+					mut params := []string{cap: node.generic_params.len}
+					for param in node.generic_params {
+						params << param.clone()
+					}
+					node.generic_params = params
+				}
+			}
 		}
 	}
 	// Per-file region starts move by the merge offset.
@@ -812,21 +858,21 @@ fn (mut p Parser) merge_parsed_worker(w &Parser, mut starts []int, chunk_start i
 		if rec.name in p.a.disabled_fns || rec.qname in p.a.disabled_fns {
 			continue
 		}
-		p.a.export_fn_names[rec.qname] = rec.value
+		p.a.export_fn_names[rec.qname.clone()] = rec.value.clone()
 	}
 	for name, disabled in w.a.disabled_fns {
 		if disabled {
-			p.a.disabled_fns[name] = true
+			p.a.disabled_fns[name.clone()] = true
 		}
 	}
 	for name, is_noreturn in w.a.noreturn_fns {
 		if is_noreturn {
-			p.a.noreturn_fns[name] = true
+			p.a.noreturn_fns[name.clone()] = true
 		}
 	}
 	for key, value in w.comptime_const_values {
 		if key !in p.comptime_const_values {
-			p.comptime_const_values[key] = value
+			p.comptime_const_values[key.clone()] = value.clone()
 		}
 	}
 	p.parsed_v_files += w.parsed_v_files

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -63,6 +63,9 @@ fn test_reject_lvalue_addresses_for_by_value_args() {
 	run_bad(v3_bin, 'bad_lvalue_address_by_value_arg',
 		'fn take(n int) {}\n\nfn main() {\n\tmut n := 1\n\ttake(&n)\n}\n',
 		'cannot use `&int` as argument 1 to `take`; expected `int`')
+	pointer_out := run_good(v3_bin, 'good_pointer_value_by_value_arg',
+		'fn pass(n &int) &int {\n\tunsafe {\n\t\treturn n\n\t}\n}\n\nfn take(n int) int {\n\treturn n\n}\n\nfn main() {\n\tmut n := 7\n\tp := &n\n\tprintln(int_str(take(p)))\n\tprintln(int_str(take(pass(p))))\n}\n')
+	assert pointer_out == '7\n7'
 	out := run_good(v3_bin, 'good_addressed_rvalue_by_value_arg',
 		'struct Box {\n\tn int\n}\n\nfn make_box() Box {\n\treturn Box{\n\t\tn: 7\n\t}\n}\n\nfn take(b Box) int {\n\treturn b.n\n}\n\nfn main() {\n\tprintln(int_str(take(&make_box())))\n}\n')
 	assert out == '7'

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2158,9 +2158,9 @@ fn (mut t Transformer) build_sum_eq_helper_fn(clean_sum string) {
 	})
 	mut stmts := []flat.NodeId{}
 	lhs_value := t.make_ident('__sum_eq_a')
-	t.a.nodes[int(lhs_value)].typ = clean_sum
+	t.set_node_typ(int(lhs_value), clean_sum)
 	rhs_value := t.make_ident('__sum_eq_b')
-	t.a.nodes[int(rhs_value)].typ = clean_sum
+	t.set_node_typ(int(rhs_value), clean_sum)
 	tag_ne := t.make_infix(.ne, t.make_sum_tag_selector(lhs_value, .dot),
 		t.make_sum_tag_selector(rhs_value, .dot))
 	ret_false := t.make_return(t.make_bool_literal(false), 'bool')
@@ -2179,9 +2179,9 @@ fn (mut t Transformer) build_sum_eq_helper_fn(clean_sum string) {
 		mut rhs_payload := t.make_selector_op(rhs_value, field, field_typ, .dot)
 		if use_ptr {
 			lhs_payload = t.make_prefix(.mul, lhs_payload)
-			t.a.nodes[int(lhs_payload)].typ = qv
+			t.set_node_typ(int(lhs_payload), qv)
 			rhs_payload = t.make_prefix(.mul, rhs_payload)
-			t.a.nodes[int(rhs_payload)].typ = qv
+			t.set_node_typ(int(rhs_payload), qv)
 		}
 		pending_start := t.pending_stmts.len
 		payload_eq := if t.is_sum_type_name(qv) && t.resolve_sum_name(qv) == clean_sum {
@@ -2200,7 +2200,7 @@ fn (mut t Transformer) build_sum_eq_helper_fn(clean_sum string) {
 		stmts << t.make_if(guard, t.make_block(body_stmts), t.make_empty())
 	}
 	ret_result := t.make_ident(result_name)
-	t.a.nodes[int(ret_result)].typ = 'bool'
+	t.set_node_typ(int(ret_result), 'bool')
 	stmts << t.make_return(ret_result, 'bool')
 	t.pending_stmts = saved_pending
 	// Keep the helper in its request's output segment. This is normally the requesting

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -378,10 +378,28 @@ fn (t &Transformer) resolve_alias_receiver_method(base_type string, method strin
 		return none
 	}
 	clean_base := t.normalize_type_alias(base_type)
+	cache_key := '${t.cur_module}\n${clean_base}\n${method}'
+	if !isnil(t.alias_receiver_method_cache) {
+		mut cache := t.alias_receiver_method_cache
+		if cached := cache.entries[cache_key] {
+			return cached
+		}
+		if cache.misses[cache_key] {
+			return none
+		}
+	}
 	if alias_method := t.alias_methods['${clean_base}.${method}'] {
+		if !isnil(t.alias_receiver_method_cache) {
+			mut cache := t.alias_receiver_method_cache
+			cache.entries[cache_key] = alias_method
+		}
 		return alias_method
 	}
 	if !t.is_integer_type_name(clean_base) {
+		if !isnil(t.alias_receiver_method_cache) {
+			mut cache := t.alias_receiver_method_cache
+			cache.misses[cache_key] = true
+		}
 		return none
 	}
 	for name, params in t.tc.fn_param_types {
@@ -394,8 +412,16 @@ fn (t &Transformer) resolve_alias_receiver_method(base_type string, method strin
 		}
 		param_name := params[0].name()
 		if t.alias_receiver_type_matches(clean_base, param_name) {
+			if !isnil(t.alias_receiver_method_cache) {
+				mut cache := t.alias_receiver_method_cache
+				cache.entries[cache_key] = name
+			}
 			return name
 		}
+	}
+	if !isnil(t.alias_receiver_method_cache) {
+		mut cache := t.alias_receiver_method_cache
+		cache.misses[cache_key] = true
 	}
 	return none
 }
@@ -1734,7 +1760,7 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 		}
 	}
 	if arg_node.kind == .array_literal && arg_node.typ.len == 0 && param_type.starts_with('[]') {
-		arg_node.typ = param_type
+		t.set_node_typ(int(arg_id), param_type)
 	}
 	if transform_param_type_is_void_pointer(param_type)
 		&& t.call_arg_is_fn_pointer_value(arg_id, *arg_node) {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -806,7 +806,21 @@ fn (mut t Transformer) collect_interface_call_boxes(call_id flat.NodeId, node fl
 	}
 }
 
-fn (t &Transformer) interface_box_call_param_maybe(param types.Type) bool {
+fn (mut t Transformer) interface_box_call_param_maybe(param types.Type) bool {
+	key := '${t.cur_module}:${param.name()}'
+	if !isnil(t.interface_box_param_cache) {
+		if cached := t.interface_box_param_cache.entries[key] {
+			return cached > 0
+		}
+	}
+	result := t.interface_box_call_param_maybe_uncached(param)
+	if !isnil(t.interface_box_param_cache) {
+		t.interface_box_param_cache.entries[key] = if result { i8(1) } else { i8(-1) }
+	}
+	return result
+}
+
+fn (t &Transformer) interface_box_call_param_maybe_uncached(param types.Type) bool {
 	if interface_box_expected_type(param) {
 		return true
 	}
@@ -6147,22 +6161,13 @@ fn (mut t Transformer) copy_cloned_resolution(src_id flat.NodeId, dst_id flat.No
 		t.copy_cloned_resolution_forked(src_idx, dst_idx)
 		return
 	}
-	if src_idx < t.tc.resolved_call_set.len && t.tc.resolved_call_set[src_idx]
-		&& !t.resolved_call_is_generic_fn(t.tc.resolved_call_names[src_idx]) {
-		for t.tc.resolved_call_names.len <= dst_idx {
-			t.tc.resolved_call_names << ''
-			t.tc.resolved_call_set << false
+	if call_name := t.tc.resolved_call_name(src_id) {
+		if !t.resolved_call_is_generic_fn(call_name) {
+			t.set_resolved_call_entry(dst_idx, call_name)
 		}
-		t.tc.resolved_call_names[dst_idx] = t.tc.resolved_call_names[src_idx]
-		t.tc.resolved_call_set[dst_idx] = true
 	}
-	if src_idx < t.tc.resolved_fn_value_set.len && t.tc.resolved_fn_value_set[src_idx] {
-		for t.tc.resolved_fn_value_names.len <= dst_idx {
-			t.tc.resolved_fn_value_names << ''
-			t.tc.resolved_fn_value_set << false
-		}
-		t.tc.resolved_fn_value_names[dst_idx] = t.tc.resolved_fn_value_names[src_idx]
-		t.tc.resolved_fn_value_set[dst_idx] = true
+	if fn_value := t.tc.resolved_fn_value_name(src_id) {
+		t.set_resolved_fn_value_entry(dst_idx, fn_value)
 	}
 }
 

--- a/vlib/v3/transform/struct.v
+++ b/vlib/v3/transform/struct.v
@@ -424,6 +424,12 @@ fn (t &Transformer) lookup_struct_info_direct(name string) ?StructInfo {
 		if short_name in t.structs {
 			return t.structs[short_name]
 		}
+	} else if t.struct_short_name_index_ready {
+		if qualified := t.struct_short_name_index[name] {
+			if qualified != struct_short_name_ambiguous {
+				return t.structs[qualified]
+			}
+		}
 	} else {
 		mut matches := []StructInfo{}
 		for qualified, info in t.structs {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -73,62 +73,68 @@ pub:
 // Transformer represents transformer data used by transform.
 pub struct Transformer {
 mut:
-	a                            &flat.FlatAst      = unsafe { nil }
-	tc                           &types.TypeChecker = unsafe { nil }
-	structs                      map[string]StructInfo
-	unique_fields                map[string]string
-	alias_methods                map[string]string
-	globals                      map[string]string
-	sum_types                    map[string][]string
-	sum_variant_parents          map[string][]string
-	sum_variant_names            map[string]bool
-	sum_variant_fields           map[string]string
-	qualified_types              map[string]string
-	fn_ret_types                 map[string]string
-	receiver_method_suffix_index map[string]string
-	const_suffixes               map[string]string
-	enum_types                   map[string][]string
-	enum_backing_types           map[string]string
-	cur_file                     string
-	cur_module                   string
-	cur_fn_name                  string
-	cur_fn_ret_type              string
-	cur_fn_is_generic            bool
-	skip_generics                bool
-	var_types                    []VarTypeBinding
-	fn_value_locals              map[string]string
-	mut_param_values             map[string]bool
-	mut_value_ident_nodes        map[int]bool
-	pointer_value_lvalues        map[string]bool
-	pointer_value_rvalues        map[string]bool
-	temp_counter                 int
-	pending_stmts                []flat.NodeId
-	smartcast_stack              []SmartcastContext
-	invalidated_smartcasts       map[string]bool
-	in_call_callee               bool
-	in_monomorphize_scan         bool
-	validating_generic_spec      bool
-	monomorph_errors             []string
-	monomorph_error_seen         map[string]bool
-	in_spawn_expr                bool
-	has_spawn_expr               bool
-	in_const_init                bool
-	in_return_expr               bool
-	expected_expr_node           int = -1
-	expected_expr_type           string
-	in_selector_base             bool
-	autolock_depth               int
-	alias_cache                  &AliasCache             = unsafe { nil }
-	sum_cache                    &AliasCache             = unsafe { nil }
-	generic_unresolved_cache     &GenericUnresolvedCache = unsafe { nil }
-	struct_field_type_cache      &LookupCache            = unsafe { nil }
-	variant_short_name_cache     &LookupCache            = unsafe { nil }
-	call_param_types_decl_cache  map[string][]types.Type
-	call_param_types_decl_misses map[string]bool
-	call_param_types_decl_index  map[string]FnParamDeclRef
-	call_param_types_index_ready bool
-	used_fns                     map[string]bool
-	comptime_reflected_params    map[string][]ParamMeta
+	a                             &flat.FlatAst      = unsafe { nil }
+	tc                            &types.TypeChecker = unsafe { nil }
+	structs                       map[string]StructInfo
+	struct_short_name_index       map[string]string
+	struct_short_name_index_ready bool
+	unique_fields                 map[string]string
+	alias_methods                 map[string]string
+	globals                       map[string]string
+	sum_types                     map[string][]string
+	sum_variant_parents           map[string][]string
+	sum_variant_names             map[string]bool
+	sum_variant_fields            map[string]string
+	qualified_types               map[string]string
+	fn_ret_types                  map[string]string
+	multi_return_fn_ret_types     map[string]types.Type
+	receiver_method_suffix_index  map[string]string
+	const_suffixes                map[string]string
+	enum_types                    map[string][]string
+	enum_backing_types            map[string]string
+	cur_file                      string
+	cur_module                    string
+	cur_fn_name                   string
+	cur_fn_ret_type               string
+	cur_fn_is_generic             bool
+	skip_generics                 bool
+	var_types                     []VarTypeBinding
+	var_type_indices              map[string]int
+	fn_value_locals               map[string]string
+	mut_param_values              map[string]bool
+	mut_value_ident_nodes         map[int]bool
+	pointer_value_lvalues         map[string]bool
+	pointer_value_rvalues         map[string]bool
+	temp_counter                  int
+	pending_stmts                 []flat.NodeId
+	smartcast_stack               []SmartcastContext
+	invalidated_smartcasts        map[string]bool
+	in_call_callee                bool
+	in_monomorphize_scan          bool
+	validating_generic_spec       bool
+	monomorph_errors              []string
+	monomorph_error_seen          map[string]bool
+	in_spawn_expr                 bool
+	has_spawn_expr                bool
+	in_const_init                 bool
+	in_return_expr                bool
+	expected_expr_node            int = -1
+	expected_expr_type            string
+	in_selector_base              bool
+	autolock_depth                int
+	alias_cache                   &AliasCache             = unsafe { nil }
+	sum_cache                     &AliasCache             = unsafe { nil }
+	generic_unresolved_cache      &GenericUnresolvedCache = unsafe { nil }
+	struct_field_type_cache       &LookupCache            = unsafe { nil }
+	variant_short_name_cache      &LookupCache            = unsafe { nil }
+	interface_box_param_cache     &BoolLookupCache        = unsafe { nil }
+	alias_receiver_method_cache   &LookupCache            = unsafe { nil }
+	call_param_types_decl_cache   map[string][]types.Type
+	call_param_types_decl_misses  map[string]bool
+	call_param_types_decl_index   map[string]FnParamDeclRef
+	call_param_types_index_ready  bool
+	used_fns                      map[string]bool
+	comptime_reflected_params     map[string][]ParamMeta
 	// sum_eq_types records sum types whose deep-equality helper fn
 	// (__v3_sum_eq_<name>) is called somewhere, keyed by sum name with the
 	// module/file context of the requesting call site (type resolution inside
@@ -221,8 +227,11 @@ mut:
 	// Prealloc self-host builds put helper-thread scratch allocations in
 	// disposable arenas. The worker's surviving AST strings are cloned by the
 	// master before that arena is released.
-	scope_parallel_workers bool
-	worker_scope           voidptr
+	scope_parallel_workers  bool
+	worker_scope            voidptr
+	scoped_base_nodes       int = -1
+	scoped_owned_base_nodes map[int]bool
+	scoped_worker_scopes    []voidptr
 }
 
 // AliasCache memoizes normalize_type_alias results. It lives on the heap so the
@@ -240,6 +249,11 @@ struct LookupCache {
 mut:
 	entries map[string]string
 	misses  map[string]bool
+}
+
+struct BoolLookupCache {
+mut:
+	entries map[string]i8 // 1 = true, -1 = false
 }
 
 // GenericUnresolvedCache memoizes generic_arg_is_unresolved results. Lives on
@@ -348,36 +362,51 @@ pub fn transform_with_used_opt_config_scoped_workers(mut a flat.FlatAst, tc &typ
 // transform_with_used_opt_config_scoped_workers_checked also returns diagnostics selected while
 // normal comptime reflection loops are unrolled.
 pub fn transform_with_used_opt_config_scoped_workers_checked(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool, scope_parallel_workers bool) (map[string]bool, bool, []string) {
+	base_nodes := a.nodes.len
+	augmented, was_parallel, errors, owned_base_nodes, worker_scopes := transform_with_used_opt_config_scoped_workers_checked_owned(mut a,
+		tc, used_fns, want_parallel, skip_generics, scope_parallel_workers)
+	if worker_scopes.len > 0 {
+		for idx in owned_base_nodes {
+			if idx >= 0 && idx < base_nodes && idx < a.nodes.len {
+				clone_node_owned_fields_in_place(mut a.nodes[idx])
+			}
+		}
+		for idx in base_nodes .. a.nodes.len {
+			clone_node_owned_fields_in_place(mut a.nodes[idx])
+		}
+		for scope in worker_scopes {
+			transform_worker_scope_free(scope)
+		}
+	}
+	return augmented, was_parallel, errors
+}
+
+fn clone_node_owned_fields_in_place(mut node flat.Node) {
+	node.value = node.value.clone()
+	node.typ = node.typ.clone()
+	mut params := []string{cap: node.generic_params.len}
+	for param in node.generic_params {
+		params << param.clone()
+	}
+	node.generic_params = params
+}
+
+// transform_with_used_opt_config_scoped_workers_checked_owned additionally
+// reports base AST nodes whose owned fields were replaced and worker arenas
+// that the caller must release after copying the surviving data.
+pub fn transform_with_used_opt_config_scoped_workers_checked_owned(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool, scope_parallel_workers bool) (map[string]bool, bool, []string, []int, []voidptr) {
 	mut t := new_transformer(mut a, tc, used_fns)
 	t.skip_generics = skip_generics
 	t.scope_parallel_workers = scope_parallel_workers
 	t.prepare()
 	t.cache_comptime_param_reflection_metadata()
 	if want_parallel {
-		// Transform roughly grows the node/children arrays by ~75%. Reserve that capacity
-		// up front so they don't double past it (the parsed AST already overshoots to the
-		// next power of two, wasting ~40MB, and each doubling briefly holds both the old and
-		// new arrays — the dominant peak-RSS contributor under -gc none). The serial path is
-		// latency-sensitive and does not clone worker ASTs, so let it grow naturally.
-		// Nodes grow a bit less than children on large compiler inputs. Keeping their
-		// reserve below the next power-of-two cliff avoids retaining a mostly-empty
-		// doubled nodes array through annotate/CGen.
-		// The shared-base parallel path partitions this headroom into per-worker
-		// append regions, so it reserves ~2x the expected growth: untouched
-		// capacity pages are never written, so RSS does not grow with the
-		// extra reserve.
-		nodes_factor_num, nodes_factor_den := if skip_generics { 7, 3 } else { 5, 3 }
-		children_factor_num, children_factor_den := if skip_generics { 5, 2 } else { 7, 4 }
-		reserve_nodes := a.nodes.len * nodes_factor_num / nodes_factor_den - a.nodes.cap
-		if reserve_nodes > 0 {
-			unsafe { a.nodes.grow_cap(reserve_nodes) }
-		}
-		reserve_children := a.children.len * children_factor_num / children_factor_den - a.children.cap
-		if reserve_children > 0 {
-			unsafe { a.children.grow_cap(reserve_children) }
-		}
+		reserve_parallel_transform_ast(mut a, skip_generics)
 	}
 	base_node_count := t.a.nodes.len
+	if scope_parallel_workers {
+		t.scoped_base_nodes = base_node_count
+	}
 	t.transformed_fns = []bool{len: t.a.nodes.len}
 	was_parallel := t.transform_all_dispatch(want_parallel)
 	t.apply_ignored_comptime_for_nodes()
@@ -395,7 +424,26 @@ pub fn transform_with_used_opt_config_scoped_workers_checked(mut a flat.FlatAst,
 	t.transform_late_used_fn_bodies(late_names, base_node_count)
 	t.run_sum_eq_synthesis_rounds(base_node_count)
 	t.apply_ignored_comptime_for_nodes()
-	return t.used_fns, was_parallel, t.monomorph_errors
+	return t.used_fns, was_parallel, t.monomorph_errors, t.scoped_owned_base_nodes.keys(), t.scoped_worker_scopes
+}
+
+// reserve_parallel_transform_ast reserves the shared append regions used by
+// the parallel transform. Self-host callers may do this before entering a
+// disposable arena so the transformed AST remains in its persistent backing.
+pub fn reserve_parallel_transform_ast(mut a flat.FlatAst, skip_generics bool) {
+	// Transform roughly grows the node/children arrays by ~75%. The shared-base
+	// path partitions the extra headroom between workers; untouched virtual pages
+	// do not contribute to resident memory.
+	nodes_factor_num, nodes_factor_den := if skip_generics { 7, 3 } else { 5, 3 }
+	children_factor_num, children_factor_den := if skip_generics { 5, 2 } else { 7, 4 }
+	reserve_nodes := a.nodes.len * nodes_factor_num / nodes_factor_den - a.nodes.cap
+	if reserve_nodes > 0 {
+		unsafe { a.nodes.grow_cap(reserve_nodes) }
+	}
+	reserve_children := a.children.len * children_factor_num / children_factor_den - a.children.cap
+	if reserve_children > 0 {
+		unsafe { a.children.grow_cap(reserve_children) }
+	}
 }
 
 // run_sum_eq_synthesis_rounds alternates sum-eq helper synthesis with the
@@ -575,6 +623,15 @@ fn new_transformer(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[strin
 		comptime_reflected_params:        map[string][]ParamMeta{}
 		interface_boxed_types:            map[string]bool{}
 		interface_var_concrete_types:     map[string]string{}
+		scoped_owned_base_nodes:          map[int]bool{}
+		interface_box_param_cache:        &BoolLookupCache{
+			entries: map[string]i8{}
+		}
+		alias_receiver_method_cache:      &LookupCache{
+			entries: map[string]string{}
+			misses:  map[string]bool{}
+		}
+		var_type_indices:                 map[string]int{}
 	}
 }
 
@@ -617,6 +674,8 @@ fn local_method_fn_name_needs_module_prefix(name string) bool {
 
 fn (mut t Transformer) prepare() {
 	t.collect_types()
+	t.rebuild_struct_short_name_index()
+	t.collect_multi_return_fn_ret_types()
 	t.collect_const_suffixes()
 	t.collect_alias_methods()
 	t.rebuild_receiver_method_suffix_index()
@@ -636,6 +695,51 @@ fn (mut t Transformer) prepare() {
 	}
 }
 
+fn (mut t Transformer) collect_multi_return_fn_ret_types() {
+	if isnil(t.tc) {
+		return
+	}
+	t.multi_return_fn_ret_types = map[string]types.Type{}
+	for name, ret_type in t.tc.fn_ret_types {
+		if type_contains_multi_return(ret_type) {
+			t.multi_return_fn_ret_types[name] = ret_type
+		}
+	}
+}
+
+fn type_contains_multi_return(typ types.Type) bool {
+	if typ is types.MultiReturn {
+		return true
+	}
+	if typ is types.OptionType {
+		return type_contains_multi_return(typ.base_type)
+	}
+	if typ is types.ResultType {
+		return type_contains_multi_return(typ.base_type)
+	}
+	return false
+}
+
+const struct_short_name_ambiguous = '__v_struct_short_name_ambiguous__'
+
+fn (mut t Transformer) rebuild_struct_short_name_index() {
+	t.struct_short_name_index = map[string]string{}
+	for qualified in t.structs.keys() {
+		if !qualified.contains('.') {
+			continue
+		}
+		short_name := qualified.all_after_last('.')
+		if previous := t.struct_short_name_index[short_name] {
+			if previous != qualified {
+				t.struct_short_name_index[short_name] = struct_short_name_ambiguous
+			}
+		} else {
+			t.struct_short_name_index[short_name] = qualified
+		}
+	}
+	t.struct_short_name_index_ready = true
+}
+
 // base_write_allowed reports whether an in-place write to node slot `idx` is
 // safe right now: always outside the shared-base parallel region; inside it,
 // only appended nodes (>= shared_base_nodes) and slots of the fn subtree
@@ -650,6 +754,7 @@ fn (t &Transformer) base_write_allowed(idx int) bool {
 fn (mut t Transformer) set_node_typ(idx int, typ string) {
 	if t.base_write_allowed(idx) {
 		t.a.nodes[idx].typ = typ
+		t.mark_scoped_owned_base_node(idx)
 		return
 	}
 	if t.defer_oor_writes {
@@ -665,6 +770,7 @@ fn (mut t Transformer) set_node_typ(idx int, typ string) {
 fn (mut t Transformer) set_node_value(idx int, value string) {
 	if t.base_write_allowed(idx) {
 		t.a.nodes[idx].value = value
+		t.mark_scoped_owned_base_node(idx)
 		return
 	}
 	if t.defer_oor_writes {
@@ -680,6 +786,7 @@ fn (mut t Transformer) set_node_value(idx int, value string) {
 fn (mut t Transformer) set_node(idx int, node flat.Node) {
 	if t.base_write_allowed(idx) {
 		t.a.nodes[idx] = node
+		t.mark_scoped_owned_base_node(idx)
 		return
 	}
 	if t.defer_oor_writes {
@@ -728,6 +835,7 @@ fn (mut t Transformer) apply_ignored_comptime_for_nodes() {
 fn (mut t Transformer) set_node_generic_params(idx int, gparams []string) {
 	if t.base_write_allowed(idx) {
 		t.a.nodes[idx].generic_params = gparams
+		t.mark_scoped_owned_base_node(idx)
 		return
 	}
 	if t.defer_oor_writes {
@@ -736,6 +844,13 @@ fn (mut t Transformer) set_node_generic_params(idx int, gparams []string) {
 			kind:    3
 			gparams: gparams
 		}
+	}
+}
+
+@[inline]
+fn (mut t Transformer) mark_scoped_owned_base_node(idx int) {
+	if t.scope_parallel_workers && idx >= 0 && idx < t.scoped_base_nodes {
+		t.scoped_owned_base_nodes[idx] = true
 	}
 }
 
@@ -749,6 +864,8 @@ fn (mut t Transformer) flush_deferred_base_writes() {
 			2 { t.a.nodes[w.idx] = w.node }
 			else { t.a.nodes[w.idx].generic_params = w.gparams }
 		}
+
+		t.mark_scoped_owned_base_node(w.idx)
 	}
 	t.deferred_base_writes = []DeferredBaseWrite{}
 }
@@ -807,6 +924,7 @@ fn (mut t Transformer) set_receiver_method_suffix_index(key string, name string)
 // reset_var_types updates reset var types state for transform.
 fn (mut t Transformer) reset_var_types() {
 	t.var_types.clear()
+	t.var_type_indices.clear()
 	t.fn_value_locals.clear()
 	t.mut_param_values.clear()
 	t.interface_var_concrete_types.clear()
@@ -822,16 +940,17 @@ fn (mut t Transformer) set_var_type_with_raw(name string, typ string, raw_typ st
 		return
 	}
 	raw := if raw_typ.len > 0 { raw_typ } else { typ }
-	for i, binding in t.var_types {
-		if binding.name == name {
-			t.var_types[i] = VarTypeBinding{
-				name:    name
-				typ:     typ
-				raw_typ: raw
-			}
-			return
+	i := t.var_type_index(name)
+	if i >= 0 {
+		t.var_type_indices[name] = i
+		t.var_types[i] = VarTypeBinding{
+			name:    name
+			typ:     typ
+			raw_typ: raw
 		}
+		return
 	}
+	t.var_type_indices[name] = t.var_types.len
 	t.var_types << VarTypeBinding{
 		name:    name
 		typ:     typ
@@ -871,40 +990,58 @@ fn decl_assign_value_is_shared(value string) bool {
 
 // unset_var_type supports unset var type handling for Transformer.
 fn (mut t Transformer) unset_var_type(name string) {
-	for i, binding in t.var_types {
-		if binding.name == name {
-			t.var_types.delete(i)
-			t.fn_value_locals.delete(name)
-			t.interface_var_concrete_types.delete(name)
-			return
+	i := t.var_type_index(name)
+	if i >= 0 {
+		t.var_types.delete(i)
+		t.var_type_indices.delete(name)
+		for j in i .. t.var_types.len {
+			t.var_type_indices[t.var_types[j].name] = j
 		}
 	}
+	t.fn_value_locals.delete(name)
+	t.interface_var_concrete_types.delete(name)
 }
 
 // var_type supports var type handling for Transformer.
 fn (t &Transformer) var_type(name string) string {
-	for binding in t.var_types {
-		if binding.name == name {
-			return binding.typ
-		}
+	i := t.var_type_index(name)
+	if i >= 0 {
+		return t.var_types[i].typ
 	}
 	return ''
 }
 
 fn (t &Transformer) raw_var_type(name string) string {
-	for binding in t.var_types {
-		if binding.name == name {
-			if binding.raw_typ.len > 0 {
-				return binding.raw_typ
-			}
-			return binding.typ
-		}
+	i := t.var_type_index(name)
+	if i >= 0 {
+		binding := t.var_types[i]
+		return if binding.raw_typ.len > 0 { binding.raw_typ } else { binding.typ }
 	}
 	return ''
 }
 
+fn (t &Transformer) var_type_index(name string) int {
+	if i := t.var_type_indices[name] {
+		if i >= 0 && i < t.var_types.len && t.var_types[i].name == name {
+			return i
+		}
+	}
+	// Some focused transformer tests seed var_types directly. Keep that API
+	// shape working while production transformers use the O(1) index above.
+	for i, binding in t.var_types {
+		if binding.name == name {
+			return i
+		}
+	}
+	return -1
+}
+
 fn (mut t Transformer) restore_var_types(saved []VarTypeBinding) {
 	t.var_types = saved
+	t.var_type_indices.clear()
+	for i, binding in t.var_types {
+		t.var_type_indices[binding.name] = i
+	}
 }
 
 // --- type collection ---
@@ -1634,6 +1771,10 @@ fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Tran
 		entries: map[string]string{}
 		misses:  map[string]bool{}
 	}
+	w.alias_receiver_method_cache = &LookupCache{
+		entries: map[string]string{}
+		misses:  map[string]bool{}
+	}
 	w.generic_fn_decls_cache = map[string]GenericFnDecl{}
 	w.generic_fn_decls_ready = false
 	w.generic_call_spec_cache = map[int]GenericCallSpec{}
@@ -1646,6 +1787,7 @@ fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Tran
 	w.node_module_map_cache = []string{}
 	w.node_module_map_nodes = -1
 	w.var_types = []VarTypeBinding{}
+	w.var_type_indices = map[string]int{}
 	w.mut_param_values = map[string]bool{}
 	w.smartcast_stack = []SmartcastContext{}
 	w.invalidated_smartcasts = map[string]bool{}
@@ -1659,7 +1801,6 @@ fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Tran
 	w.generic_fn_specs_in_progress = map[string]bool{}
 	w.monomorph_errors = []string{}
 	w.monomorph_error_seen = map[string]bool{}
-	w.used_fns = t.used_fns.clone()
 	// Fields added after the fork/merge machinery was first written. They are
 	// mutated during body transforms (or lazily built), so each worker needs
 	// private backing storage — a plain struct copy would share the master's.
@@ -1676,6 +1817,7 @@ fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Tran
 	w.deferred_base_writes = []DeferredBaseWrite{}
 	w.ignored_comptime_for_nodes = []bool{}
 	w.worker_scope = unsafe { nil }
+	w.scoped_owned_base_nodes = map[int]bool{}
 	// Workers do not record transformed fns (that would write the master's
 	// shared backing array); the master marks each worker's chunk items when it
 	// merges the worker.
@@ -1713,6 +1855,10 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 		entries: map[string]string{}
 		misses:  map[string]bool{}
 	}
+	w.alias_receiver_method_cache = &LookupCache{
+		entries: map[string]string{}
+		misses:  map[string]bool{}
+	}
 	w.generic_fn_decls_cache = map[string]GenericFnDecl{}
 	w.generic_fn_decls_ready = false
 	w.generic_call_spec_cache = map[int]GenericCallSpec{}
@@ -1720,6 +1866,7 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 	w.node_module_map_cache = []string{}
 	w.node_module_map_nodes = -1
 	w.var_types = []VarTypeBinding{}
+	w.var_type_indices = map[string]int{}
 	w.mut_param_values = map[string]bool{}
 	w.smartcast_stack = []SmartcastContext{}
 	w.invalidated_smartcasts = map[string]bool{}
@@ -1774,28 +1921,6 @@ fn (mut t Transformer) merge_worker_used_fns(w &Transformer) {
 	}
 }
 
-// clone_scoped_worker_node moves a node's owned fields from a helper arena to
-// the master's arena before the helper arena is released.
-fn (mut t Transformer) clone_scoped_worker_node(idx int) {
-	if idx < 0 || idx >= t.a.nodes.len {
-		return
-	}
-	mut node := unsafe { &t.a.nodes[idx] }
-	if node.value.len > 0 {
-		node.value = node.value.clone()
-	}
-	if node.typ.len > 0 {
-		node.typ = node.typ.clone()
-	}
-	if node.generic_params.len > 0 {
-		mut params := []string{cap: node.generic_params.len}
-		for param in node.generic_params {
-			params << param.clone()
-		}
-		node.generic_params = params
-	}
-}
-
 // merge_worker folds a finished worker's transformed output back into the master
 // AST. The worker created its new nodes/children at indices base_nodes/base_children
 // (matching the master at fork time); here they are appended to the master and every
@@ -1842,9 +1967,6 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 			if t.a.nodes[k].children_start >= base_children {
 				t.a.nodes[k] = t.a.nodes[k].with_shifted_children(child_shift)
 			}
-			if w.worker_scope != unsafe { nil } {
-				t.clone_scoped_worker_node(k)
-			}
 		}
 	}
 	// Rewritten top-level function nodes keep their original index in the master.
@@ -1858,10 +1980,10 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 		if it.fn_idx >= 0 && it.fn_idx < t.transformed_fns.len {
 			t.transformed_fns[it.fn_idx] = true
 		}
-		if w.worker_scope != unsafe { nil } {
-			for idx in it.range_lo .. it.fn_idx + 1 {
-				t.clone_scoped_worker_node(idx)
-			}
+	}
+	if w.worker_scope != unsafe { nil } {
+		for idx in w.scoped_owned_base_nodes.keys() {
+			t.scoped_owned_base_nodes[idx] = true
 		}
 	}
 	// Replay the call/fn-value resolutions the worker recorded for its
@@ -1908,6 +2030,10 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 }
 
 fn (mut t Transformer) set_resolved_call_entry(idx int, name string) {
+	if t.tc.transform_sparse_node_caches {
+		t.tc.sparse_resolved_call_names[idx] = name
+		return
+	}
 	for t.tc.resolved_call_names.len <= idx {
 		t.tc.resolved_call_names << ''
 		t.tc.resolved_call_set << false
@@ -1917,6 +2043,10 @@ fn (mut t Transformer) set_resolved_call_entry(idx int, name string) {
 }
 
 fn (mut t Transformer) set_resolved_fn_value_entry(idx int, name string) {
+	if t.tc.transform_sparse_node_caches {
+		t.tc.sparse_resolved_fn_values[idx] = name
+		return
+	}
 	for t.tc.resolved_fn_value_names.len <= idx {
 		t.tc.resolved_fn_value_names << ''
 		t.tc.resolved_fn_value_set << false
@@ -6036,7 +6166,7 @@ fn (t &Transformer) find_multi_return_call_types(node flat.Node, expected_count 
 		return none
 	}
 	for candidate in candidates {
-		for key, ret in t.tc.fn_ret_types {
+		for key, ret in t.multi_return_fn_ret_types {
 			matches := if candidate.starts_with('.') {
 				key.ends_with(candidate)
 			} else {
@@ -8047,6 +8177,10 @@ fn (mut t Transformer) ensure_stringify_generic_instances_for_type(typ string) {
 		is_params: base_info.is_params
 		fields:    fields
 	}
+	// A later unqualified lookup must include this newly materialized generic
+	// struct, so fall back to the exact legacy scan after the collected index
+	// has changed.
+	t.struct_short_name_index_ready = false
 }
 
 fn (t &Transformer) struct_info_matches_generic_base(base string, info StructInfo) bool {
@@ -10000,7 +10134,7 @@ fn (mut t Transformer) transform_ident_expr(id flat.NodeId, node flat.Node) flat
 			}
 			if !t.in_selector_base && t.pointer_value_rvalues[node.value] && typ.starts_with('&') {
 				deref := t.make_prefix(.mul, id)
-				t.a.nodes[int(deref)].typ = typ[1..]
+				t.set_node_typ(int(deref), typ[1..])
 				return deref
 			}
 			return id
@@ -10031,7 +10165,7 @@ fn (mut t Transformer) apply_smartcast_contexts(base flat.NodeId, typ string, co
 			// can be a pointer and would make cgen emit `->`), so pin the node's
 			// type back to the option before selecting `.value` from it.
 			if int(current) >= 0 && t.a.nodes[int(current)].kind in [.ident, .selector] {
-				t.a.nodes[int(current)].typ = '?${sc.variant_name}'
+				t.set_node_typ(int(current), '?${sc.variant_name}')
 			}
 			field_op := if current_type.starts_with('&?') { flat.Op.arrow } else { flat.Op.dot }
 			current = t.make_selector_op(current, 'value', sc.variant_name, field_op)

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -140,58 +140,6 @@ fn transform_worker_scope_free(scope voidptr) {
 	}
 }
 
-// clone_deferred_worker_writes_from moves writes queued by merge_worker out of
-// a helper arena before that arena is released. In the shared-base path the
-// rewritten top-level fn node is deferred until every worker has joined, so
-// cloning the current master slot alone does not preserve its owned strings.
-fn (mut t Transformer) clone_deferred_worker_writes_from(start int) {
-	for i in start .. t.deferred_base_writes.len {
-		write := t.deferred_base_writes[i]
-		t.deferred_base_writes[i] = match write.kind {
-			0, 1 {
-				DeferredBaseWrite{
-					idx:  write.idx
-					kind: write.kind
-					str:  write.str.clone()
-				}
-			}
-			2 {
-				mut params := []string{cap: write.node.generic_params.len}
-				for param in write.node.generic_params {
-					params << param.clone()
-				}
-				DeferredBaseWrite{
-					idx:  write.idx
-					kind: write.kind
-					node: flat.Node{
-						value:          write.node.value.clone()
-						typ:            write.node.typ.clone()
-						generic_params: params
-						kind_id:        write.node.kind_id
-						pos:            write.node.pos
-						children_start: write.node.children_start
-						children_count: write.node.children_count
-						kind:           write.node.kind
-						op:             write.node.op
-						is_mut:         write.node.is_mut
-					}
-				}
-			}
-			else {
-				mut params := []string{cap: write.gparams.len}
-				for param in write.gparams {
-					params << param.clone()
-				}
-				DeferredBaseWrite{
-					idx:     write.idx
-					kind:    write.kind
-					gparams: params
-				}
-			}
-		}
-	}
-}
-
 // run_parallel_transform transforms the closure-free function bodies across
 // threads when there is enough work, otherwise serially. Returns whether threads
 // were actually used.
@@ -432,11 +380,9 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			C.pthread_join(thread_ids[ci], unsafe { nil })
 			ww := unsafe { &Transformer(args[ci].worker) }
 			t.merge_worker_used_fns(ww)
-			deferred_start := t.deferred_base_writes.len
 			t.merge_worker(ww, chunks[ci + 1], node_starts[ci + 1], child_starts[ci + 1])
 			if ww.worker_scope != unsafe { nil } {
-				t.clone_deferred_worker_writes_from(deferred_start)
-				transform_worker_scope_free(ww.worker_scope)
+				t.scoped_worker_scopes << ww.worker_scope
 			}
 		}
 		t.base_write_intercept = false

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -379,6 +379,7 @@ pub mut:
 	expr_type_set                       []bool
 	checking_nodes                      []bool
 	parallel_check_sparse               bool
+	scope_parallel_check_workers        bool
 	transform_sparse_node_caches        bool
 	// Node id range [check_range_lo, check_range_hi] of the fn item currently
 	// being checked. Fn subtrees are disjoint contiguous ranges (each fn_decl at
@@ -551,6 +552,14 @@ pub fn (mut tc TypeChecker) begin_sparse_transform_node_caches() {
 	tc.fn_ret_types.reserve(u32(tc.fn_ret_types.len + signature_headroom))
 	tc.fn_param_types.reserve(u32(tc.fn_param_types.len + signature_headroom))
 	tc.fn_variadic.reserve(u32(tc.fn_variadic.len + signature_headroom))
+}
+
+// enable_scoped_parallel_workers uses disposable compact prealloc arenas for
+// parallel checker helpers.
+pub fn (mut tc TypeChecker) enable_scoped_parallel_workers() {
+	$if !ownership ? {
+		tc.scope_parallel_check_workers = true
+	}
 }
 
 // fork_for_parallel_transform returns a TypeChecker that shares all of `tc`'s

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -361,20 +361,25 @@ pub mut:
 	// Scope depth at which each method-value local was marked, so a reassignment to a
 	// non-method value only clears the marker when it dominates later uses (same-or-shallower
 	// scope); a reassignment in a deeper conditional/loop scope keeps the maybe-method marker.
-	method_value_local_depth         map[string]int
-	fn_value_variadic_local_depth    map[string]int
-	capturing_fn_literal_local_depth map[string]int
-	cur_fn_node_id                   int = -1
-	cur_fn_mut_param_base_types      map[string]Type
-	cur_fn_mut_param_binding_owners  map[string]ScopeBindingOwner
-	cur_fn_mut_local_binding_owners  map[string]ScopeBindingOwner
-	cur_fn_shared_binding_owners     map[string][]ScopeBindingOwner
-	cur_generic_params               []string
-	cur_comptime_variant_loop_vars   []string
-	expr_type_values                 []Type // node_id -> complex/contextual resolved type
-	expr_type_set                    []bool
-	checking_nodes                   []bool
-	parallel_check_sparse            bool
+	method_value_local_depth            map[string]int
+	fn_value_variadic_local_depth       map[string]int
+	capturing_fn_literal_local_depth    map[string]int
+	cur_fn_node_id                      int = -1
+	cur_fn_mut_param_base_types         map[string]Type
+	cur_fn_mut_param_binding_owners     map[string]ScopeBindingOwner
+	cur_fn_mut_local_binding_owners     map[string]ScopeBindingOwner
+	cur_fn_shared_binding_owners        map[string][]ScopeBindingOwner
+	scratch_fn_mut_param_base_types     map[string]Type
+	scratch_fn_mut_param_binding_owners map[string]ScopeBindingOwner
+	scratch_fn_mut_local_binding_owners map[string]ScopeBindingOwner
+	scratch_fn_shared_binding_owners    map[string][]ScopeBindingOwner
+	cur_generic_params                  []string
+	cur_comptime_variant_loop_vars      []string
+	expr_type_values                    []Type // node_id -> complex/contextual resolved type
+	expr_type_set                       []bool
+	checking_nodes                      []bool
+	parallel_check_sparse               bool
+	transform_sparse_node_caches        bool
 	// Node id range [check_range_lo, check_range_hi] of the fn item currently
 	// being checked. Fn subtrees are disjoint contiguous ranges (each fn_decl at
 	// index i owns (prev_top_level_idx, i]), so while parallel_check_sparse is
@@ -491,36 +496,40 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		// reset_node_caches (allocating them here too paid for everything
 		// twice), and extend_node_caches grows them on demand for any checker
 		// used without a collect() call.
-		resolved_call_names:               []string{}
-		resolved_call_set:                 []bool{}
-		resolved_fn_value_names:           []string{}
-		resolved_fn_value_set:             []bool{}
-		statement_nodes:                   []bool{}
-		method_values_by_fn:               map[int][]string{}
-		method_value_locals:               map[string]bool{}
-		fn_value_variadic_locals:          map[string]bool{}
-		fn_value_variadic_local_owners:    map[string][]ScopeBindingOwner{}
-		capturing_fn_literal_locals:       map[string]bool{}
-		capturing_fn_literal_local_owners: map[string][]ScopeBindingOwner{}
-		method_value_local_depth:          map[string]int{}
-		fn_value_variadic_local_depth:     map[string]int{}
-		capturing_fn_literal_local_depth:  map[string]int{}
-		cur_fn_mut_param_base_types:       map[string]Type{}
-		cur_fn_mut_param_binding_owners:   map[string]ScopeBindingOwner{}
-		cur_fn_mut_local_binding_owners:   map[string]ScopeBindingOwner{}
-		cur_fn_shared_binding_owners:      map[string][]ScopeBindingOwner{}
-		expr_type_values:                  []Type{}
-		expr_type_set:                     []bool{}
-		checking_nodes:                    []bool{}
-		sparse_resolved_call_names:        map[int]string{}
-		sparse_resolved_fn_values:         map[int]string{}
-		sparse_statement_nodes:            map[int]bool{}
-		sparse_expr_type_values:           map[int]Type{}
-		sparse_checking_nodes:             map[int]bool{}
-		diagnostic_files:                  map[string]bool{}
-		selected_file_called_fns:          map[string]bool{}
-		smartcasts:                        map[string]Type{}
-		type_cache:                        &TypeCache{
+		resolved_call_names:                 []string{}
+		resolved_call_set:                   []bool{}
+		resolved_fn_value_names:             []string{}
+		resolved_fn_value_set:               []bool{}
+		statement_nodes:                     []bool{}
+		method_values_by_fn:                 map[int][]string{}
+		method_value_locals:                 map[string]bool{}
+		fn_value_variadic_locals:            map[string]bool{}
+		fn_value_variadic_local_owners:      map[string][]ScopeBindingOwner{}
+		capturing_fn_literal_locals:         map[string]bool{}
+		capturing_fn_literal_local_owners:   map[string][]ScopeBindingOwner{}
+		method_value_local_depth:            map[string]int{}
+		fn_value_variadic_local_depth:       map[string]int{}
+		capturing_fn_literal_local_depth:    map[string]int{}
+		cur_fn_mut_param_base_types:         map[string]Type{}
+		cur_fn_mut_param_binding_owners:     map[string]ScopeBindingOwner{}
+		cur_fn_mut_local_binding_owners:     map[string]ScopeBindingOwner{}
+		cur_fn_shared_binding_owners:        map[string][]ScopeBindingOwner{}
+		scratch_fn_mut_param_base_types:     map[string]Type{}
+		scratch_fn_mut_param_binding_owners: map[string]ScopeBindingOwner{}
+		scratch_fn_mut_local_binding_owners: map[string]ScopeBindingOwner{}
+		scratch_fn_shared_binding_owners:    map[string][]ScopeBindingOwner{}
+		expr_type_values:                    []Type{}
+		expr_type_set:                       []bool{}
+		checking_nodes:                      []bool{}
+		sparse_resolved_call_names:          map[int]string{}
+		sparse_resolved_fn_values:           map[int]string{}
+		sparse_statement_nodes:              map[int]bool{}
+		sparse_expr_type_values:             map[int]Type{}
+		sparse_checking_nodes:               map[int]bool{}
+		diagnostic_files:                    map[string]bool{}
+		selected_file_called_fns:            map[string]bool{}
+		smartcasts:                          map[string]Type{}
+		type_cache:                          &TypeCache{
 			parse_entries:              map[string]Type{}
 			c_entries:                  map[string]string{}
 			struct_field_entries:       map[string]Type{}
@@ -529,6 +538,19 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 			source_error_embed_entries: map[string]int{}
 		}
 	}
+}
+
+// begin_sparse_transform_node_caches keeps transform-created metadata out of
+// the dense source-node arrays, avoiding a full-array reallocation.
+pub fn (mut tc TypeChecker) begin_sparse_transform_node_caches() {
+	tc.transform_sparse_node_caches = true
+	// Generated lambda/helper signatures are added during transform. Reserve
+	// enough persistent backing before entering its disposable arena so those
+	// insertions cannot move the complete source-signature maps into the arena.
+	signature_headroom := 2048
+	tc.fn_ret_types.reserve(u32(tc.fn_ret_types.len + signature_headroom))
+	tc.fn_param_types.reserve(u32(tc.fn_param_types.len + signature_headroom))
+	tc.fn_variadic.reserve(u32(tc.fn_variadic.len + signature_headroom))
 }
 
 // fork_for_parallel_transform returns a TypeChecker that shares all of `tc`'s
@@ -542,6 +564,7 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 pub fn (tc &TypeChecker) fork_for_parallel_transform(ast &flat.FlatAst) &TypeChecker {
 	mut forked := *tc
 	forked.a = ast
+	forked.transform_sparse_node_caches = false
 	// The transformer propagates call/fn-value resolution metadata onto the call
 	// nodes it clones (Transformer.copy_cloned_resolution). In a worker those
 	// writes must not touch (or grow/realloc) the shared node-indexed arrays
@@ -670,10 +693,11 @@ fn (mut tc TypeChecker) reset_node_caches(n int) {
 	tc.expr_type_set = []bool{len: n}
 	tc.checking_nodes = []bool{len: n}
 	tc.parallel_check_sparse = false
+	tc.transform_sparse_node_caches = false
 }
 
 fn (mut tc TypeChecker) extend_node_caches(n int) {
-	if tc.parallel_check_sparse {
+	if tc.parallel_check_sparse || tc.transform_sparse_node_caches {
 		return
 	}
 	if n <= tc.resolved_call_names.len && n <= tc.resolved_fn_value_names.len
@@ -2914,6 +2938,11 @@ fn (tc &TypeChecker) in_check_range(idx int) bool {
 // cached_expr_type supports cached expr type handling for TypeChecker.
 fn (tc &TypeChecker) cached_expr_type(id flat.NodeId) ?Type {
 	idx := int(id)
+	if tc.transform_sparse_node_caches {
+		if typ := tc.sparse_expr_type_values[idx] {
+			return typ
+		}
+	}
 	if tc.parallel_check_sparse {
 		if tc.in_check_range(idx) {
 			if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
@@ -2934,6 +2963,11 @@ fn (tc &TypeChecker) cached_resolved_call(id flat.NodeId) ?string {
 	idx := int(id)
 	if !isnil(tc.fork_overlay) {
 		if name := tc.fork_overlay.resolved_call_names[idx] {
+			return name
+		}
+	}
+	if tc.transform_sparse_node_caches {
+		if name := tc.sparse_resolved_call_names[idx] {
 			return name
 		}
 	}
@@ -3006,6 +3040,11 @@ pub fn (tc &TypeChecker) resolved_fn_value_name(id flat.NodeId) ?string {
 			return name
 		}
 	}
+	if tc.transform_sparse_node_caches {
+		if name := tc.sparse_resolved_fn_values[idx] {
+			return name
+		}
+	}
 	if tc.parallel_check_sparse {
 		if tc.in_check_range(idx) {
 			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
@@ -3055,6 +3094,10 @@ fn (mut tc TypeChecker) remember_resolved_call(id flat.NodeId, name string) {
 	if idx < 0 {
 		return
 	}
+	if tc.transform_sparse_node_caches {
+		tc.sparse_resolved_call_names[idx] = name
+		return
+	}
 	if tc.parallel_check_sparse {
 		if tc.in_check_range(idx) && idx < tc.resolved_call_names.len {
 			tc.resolved_call_names[idx] = name
@@ -3077,6 +3120,10 @@ fn (mut tc TypeChecker) remember_resolved_call(id flat.NodeId, name string) {
 fn (mut tc TypeChecker) remember_resolved_fn_value(id flat.NodeId, name string) {
 	idx := int(id)
 	if idx < 0 {
+		return
+	}
+	if tc.transform_sparse_node_caches {
+		tc.sparse_resolved_fn_values[idx] = name
 		return
 	}
 	if tc.parallel_check_sparse {
@@ -3121,6 +3168,10 @@ fn (mut tc TypeChecker) remember_expr_type(id flat.NodeId, typ Type) {
 	kind := if int(id) < tc.a.nodes.len { tc.a.nodes[int(id)].kind } else { flat.NodeKind.empty }
 	if should_cache_expr_type(kind, typ) {
 		idx := int(id)
+		if tc.transform_sparse_node_caches {
+			tc.sparse_expr_type_values[idx] = typ
+			return
+		}
 		if tc.parallel_check_sparse {
 			if tc.in_check_range(idx) && idx < tc.expr_type_values.len {
 				tc.expr_type_values[idx] = typ
@@ -15108,11 +15159,22 @@ fn (mut tc TypeChecker) expr_receiver_compatible(expr_id flat.NodeId, actual Typ
 	if !tc.receiver_compatible(actual, expected) {
 		return false
 	}
-	if actual is Pointer && expected !is Pointer
+	if actual is Pointer && expected !is Pointer && tc.expr_is_explicit_address_arg(expr_id)
 		&& !tc.explicit_address_arg_compatible(expr_id, actual, expected) {
 		return false
 	}
 	return tc.generic_expected_expr_fields_compatible(expr_id, expected)
+}
+
+fn (tc &TypeChecker) expr_is_explicit_address_arg(expr_id flat.NodeId) bool {
+	if int(expr_id) < 0 || int(expr_id) >= tc.a.nodes.len {
+		return false
+	}
+	node := tc.a.nodes[int(expr_id)]
+	if node.kind in [.paren, .expr_stmt] && node.children_count > 0 {
+		return tc.expr_is_explicit_address_arg(tc.a.child(&node, 0))
+	}
+	return node.kind == .prefix && node.op == .amp
 }
 
 fn (tc &TypeChecker) explicit_address_arg_compatible(expr_id flat.NodeId, actual Type, expected Type) bool {

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -348,24 +348,28 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 	mut saved_mut_local_owners := tc.cur_fn_mut_local_binding_owners.move()
 	mut saved_shared_owners := tc.cur_fn_shared_binding_owners.move()
 	saved_generic_params := tc.cur_generic_params.clone()
-	tc.cur_fn_mut_param_base_types = map[string]Type{}
-	tc.cur_fn_mut_param_binding_owners = map[string]ScopeBindingOwner{}
-	tc.cur_fn_mut_local_binding_owners = map[string]ScopeBindingOwner{}
-	tc.cur_fn_shared_binding_owners = map[string][]ScopeBindingOwner{}
+	tc.cur_fn_mut_param_base_types = tc.scratch_fn_mut_param_base_types.move()
+	tc.cur_fn_mut_param_binding_owners = tc.scratch_fn_mut_param_binding_owners.move()
+	tc.cur_fn_mut_local_binding_owners = tc.scratch_fn_mut_local_binding_owners.move()
+	tc.cur_fn_shared_binding_owners = tc.scratch_fn_shared_binding_owners.move()
+	tc.cur_fn_mut_param_base_types.clear()
+	tc.cur_fn_mut_param_binding_owners.clear()
+	tc.cur_fn_mut_local_binding_owners.clear()
+	tc.cur_fn_shared_binding_owners.clear()
 	tc.cur_file = file
 	tc.cur_module = module_name
 	tc.cur_scope = tc.file_scope
 	tc.cur_generic_params = tc.infer_decl_generic_param_names(node)
 	tc.cur_fn_ret_type = tc.parse_type(node.typ)
 	tc.cur_fn_node_id = fn_idx
-	tc.method_value_locals = map[string]bool{}
-	tc.fn_value_variadic_locals = map[string]bool{}
-	tc.fn_value_variadic_local_owners = map[string][]ScopeBindingOwner{}
-	tc.capturing_fn_literal_locals = map[string]bool{}
-	tc.capturing_fn_literal_local_owners = map[string][]ScopeBindingOwner{}
-	tc.method_value_local_depth = map[string]int{}
-	tc.fn_value_variadic_local_depth = map[string]int{}
-	tc.capturing_fn_literal_local_depth = map[string]int{}
+	tc.method_value_locals.clear()
+	tc.fn_value_variadic_locals.clear()
+	tc.fn_value_variadic_local_owners.clear()
+	tc.capturing_fn_literal_locals.clear()
+	tc.capturing_fn_literal_local_owners.clear()
+	tc.method_value_local_depth.clear()
+	tc.fn_value_variadic_local_depth.clear()
+	tc.capturing_fn_literal_local_depth.clear()
 	$if ownership ? {
 		tc.ownership_begin_fn(node)
 	}
@@ -398,6 +402,10 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 	}
 	tc.cur_fn_ret_type = Type(void_)
 	tc.cur_generic_params = saved_generic_params
+	tc.scratch_fn_mut_param_base_types = tc.cur_fn_mut_param_base_types.move()
+	tc.scratch_fn_mut_param_binding_owners = tc.cur_fn_mut_param_binding_owners.move()
+	tc.scratch_fn_mut_local_binding_owners = tc.cur_fn_mut_local_binding_owners.move()
+	tc.scratch_fn_shared_binding_owners = tc.cur_fn_shared_binding_owners.move()
 	tc.cur_fn_mut_param_base_types = saved_mut_params.move()
 	tc.cur_fn_mut_param_binding_owners = saved_mut_param_owners.move()
 	tc.cur_fn_mut_local_binding_owners = saved_mut_local_owners.move()
@@ -513,6 +521,10 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 	w.cur_fn_mut_param_binding_owners = map[string]ScopeBindingOwner{}
 	w.cur_fn_mut_local_binding_owners = map[string]ScopeBindingOwner{}
 	w.cur_fn_shared_binding_owners = map[string][]ScopeBindingOwner{}
+	w.scratch_fn_mut_param_base_types = map[string]Type{}
+	w.scratch_fn_mut_param_binding_owners = map[string]ScopeBindingOwner{}
+	w.scratch_fn_mut_local_binding_owners = map[string]ScopeBindingOwner{}
+	w.scratch_fn_shared_binding_owners = map[string][]ScopeBindingOwner{}
 	w.generic_method_value_info = map[string]CallInfo{}
 	w.smartcasts = map[string]Type{}
 	w.cur_fn_ret_type = Type(void_)

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -20,8 +20,11 @@ struct CheckWorkItem {
 
 $if !windows {
 	struct CheckChunkArgs {
-		worker    voidptr
-		items_ptr voidptr
+		worker        voidptr
+		items_ptr     voidptr
+		scope_enabled bool
+	mut:
+		scope voidptr
 	}
 
 	@[typedef]
@@ -34,11 +37,38 @@ $if !windows {
 	fn C.pthread_attr_destroy(attr voidptr) int
 
 	fn check_chunk_thread(arg voidptr) voidptr {
-		a := unsafe { &CheckChunkArgs(arg) }
+		mut a := unsafe { &CheckChunkArgs(arg) }
+		a.scope = check_worker_scope_begin(a.scope_enabled)
 		mut w := unsafe { &TypeChecker(a.worker) }
 		items := unsafe { &[]CheckWorkItem(a.items_ptr) }
 		w.check_fn_items_serial(*items)
+		check_worker_scope_leave(a.scope)
 		return unsafe { nil }
+	}
+}
+
+fn check_worker_scope_begin(enabled bool) voidptr {
+	$if prealloc {
+		if enabled {
+			return unsafe { prealloc_scope_begin() }
+		}
+	}
+	return unsafe { nil }
+}
+
+fn check_worker_scope_leave(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_leave(scope) }
+		}
+	}
+}
+
+fn check_worker_scope_free(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_free_after(scope) }
+		}
 	}
 }
 
@@ -185,8 +215,9 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		mut args := []CheckChunkArgs{cap: thread_count}
 		for ci in 0 .. thread_count {
 			args << CheckChunkArgs{
-				worker:    workers[ci]
-				items_ptr: unsafe { voidptr(&chunks[ci + 1]) }
+				worker:        workers[ci]
+				items_ptr:     unsafe { voidptr(&chunks[ci + 1]) }
+				scope_enabled: tc.scope_parallel_check_workers
 			}
 		}
 
@@ -214,8 +245,16 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		tc.parallel_check_sparse = false
 		for ci in 0 .. thread_count {
 			mut w := unsafe { &TypeChecker(workers[ci]) }
-			tc.merge_parallel_check_worker(w)
-			w.free_parallel_check_worker_cache()
+			scoped := args[ci].scope != unsafe { nil }
+			if scoped {
+				tc.clone_parallel_worker_node_caches(chunks[ci + 1])
+			}
+			tc.merge_parallel_check_worker(w, scoped)
+			if scoped {
+				check_worker_scope_free(args[ci].scope)
+			} else {
+				w.free_parallel_check_worker_cache()
+			}
 		}
 		tc.sort_parallel_check_errors()
 		return true
@@ -555,25 +594,79 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 	return &w
 }
 
-fn (mut tc TypeChecker) merge_parallel_check_worker(w &TypeChecker) {
-	tc.errors << w.errors
-	tc.pending_ierror_errors << w.pending_ierror_errors
+fn (mut tc TypeChecker) clone_parallel_worker_node_caches(items []CheckWorkItem) {
+	for it in items {
+		for idx in it.range_lo .. it.fn_idx + 1 {
+			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
+				tc.resolved_call_names[idx] = tc.resolved_call_names[idx].clone()
+			}
+			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
+				tc.resolved_fn_value_names[idx] = tc.resolved_fn_value_names[idx].clone()
+			}
+			if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
+				tc.expr_type_values[idx] = clone_owned_type(tc.expr_type_values[idx])
+			}
+		}
+	}
+}
+
+fn clone_parallel_type_error(err TypeError) TypeError {
+	return TypeError{
+		msg:        err.msg.clone()
+		kind:       err.kind
+		node:       err.node
+		file:       err.file.clone()
+		node_kind:  err.node_kind.clone()
+		node_value: err.node_value.clone()
+		node_pos:   err.node_pos.clone()
+	}
+}
+
+fn clone_parallel_call_info(info CallInfo) CallInfo {
+	return CallInfo{
+		name:                 info.name.clone()
+		params:               clone_owned_types(info.params)
+		shared_params:        info.shared_params.clone()
+		return_type:          clone_owned_type(info.return_type)
+		has_receiver:         info.has_receiver
+		is_variadic:          info.is_variadic
+		is_c_variadic:        info.is_c_variadic
+		params_known:         info.params_known
+		has_implicit_veb_ctx: info.has_implicit_veb_ctx
+		arg_offset:           info.arg_offset
+	}
+}
+
+fn (mut tc TypeChecker) merge_parallel_check_worker(w &TypeChecker, scoped bool) {
+	for err in w.errors {
+		tc.errors << if scoped { clone_parallel_type_error(err) } else { err }
+	}
+	for pending in w.pending_ierror_errors {
+		tc.pending_ierror_errors << if scoped {
+			PendingIerrorError{
+				err:      clone_parallel_type_error(pending.err)
+				fn_qname: pending.fn_qname.clone()
+			}
+		} else {
+			pending
+		}
+	}
 	$if ownership ? {
 		tc.ownership_merge_parallel_check_worker(w)
 	}
 	for idx, name in w.sparse_resolved_call_names {
-		tc.resolved_call_names[idx] = name
+		tc.resolved_call_names[idx] = if scoped { name.clone() } else { name }
 		tc.resolved_call_set[idx] = true
 	}
 	for idx, name in w.sparse_resolved_fn_values {
-		tc.resolved_fn_value_names[idx] = name
+		tc.resolved_fn_value_names[idx] = if scoped { name.clone() } else { name }
 		tc.resolved_fn_value_set[idx] = true
 	}
 	for idx, _ in w.sparse_statement_nodes {
 		tc.statement_nodes[idx] = true
 	}
 	for idx, typ in w.sparse_expr_type_values {
-		tc.expr_type_values[idx] = typ
+		tc.expr_type_values[idx] = if scoped { clone_owned_type(typ) } else { typ }
 		tc.expr_type_set[idx] = true
 	}
 	for fn_idx, values in w.method_values_by_fn {
@@ -581,13 +674,24 @@ fn (mut tc TypeChecker) merge_parallel_check_worker(w &TypeChecker) {
 			continue
 		}
 		if fn_idx in tc.method_values_by_fn {
-			tc.method_values_by_fn[fn_idx] << values
+			for value in values {
+				tc.method_values_by_fn[fn_idx] << if scoped { value.clone() } else { value }
+			}
 		} else {
-			tc.method_values_by_fn[fn_idx] = values.clone()
+			mut owned_values := []string{cap: values.len}
+			for value in values {
+				owned_values << if scoped { value.clone() } else { value }
+			}
+			tc.method_values_by_fn[fn_idx] = owned_values
 		}
 	}
 	for key, info in w.generic_method_value_info {
-		tc.generic_method_value_info[key] = info
+		owned_key := if scoped { key.clone() } else { key }
+		tc.generic_method_value_info[owned_key] = if scoped {
+			clone_parallel_call_info(info)
+		} else {
+			info
+		}
 	}
 }
 

--- a/vlib/v3/types/type.v
+++ b/vlib/v3/types/type.v
@@ -179,6 +179,132 @@ pub:
 	types []Type
 }
 
+// clone_owned_type clones a type and all nested owned metadata.
+pub fn clone_owned_type(value Type) Type {
+	return match value {
+		Void {
+			Type(void_)
+		}
+		Unknown {
+			Type(Unknown{
+				reason: value.reason.clone()
+			})
+		}
+		Primitive {
+			Type(Primitive{
+				props: value.props
+				size:  value.size
+			})
+		}
+		String {
+			Type(string_)
+		}
+		Char {
+			Type(char_)
+		}
+		Rune {
+			Type(rune_)
+		}
+		ISize {
+			Type(isize_)
+		}
+		USize {
+			Type(usize_)
+		}
+		Nil {
+			Type(nil_)
+		}
+		None {
+			Type(none_)
+		}
+		Array {
+			Type(Array{
+				elem_type: clone_owned_type(value.elem_type)
+			})
+		}
+		ArrayFixed {
+			Type(ArrayFixed{
+				elem_type: clone_owned_type(value.elem_type)
+				len:       value.len
+				len_expr:  value.len_expr.clone()
+			})
+		}
+		Channel {
+			Type(Channel{
+				elem_type: clone_owned_type(value.elem_type)
+			})
+		}
+		Map {
+			Type(Map{
+				key_type:   clone_owned_type(value.key_type)
+				value_type: clone_owned_type(value.value_type)
+			})
+		}
+		Pointer {
+			Type(Pointer{
+				base_type: clone_owned_type(value.base_type)
+			})
+		}
+		FnType {
+			Type(FnType{
+				params:      clone_owned_types(value.params)
+				return_type: clone_owned_type(value.return_type)
+			})
+		}
+		OptionType {
+			Type(OptionType{
+				base_type: clone_owned_type(value.base_type)
+			})
+		}
+		ResultType {
+			Type(ResultType{
+				base_type: clone_owned_type(value.base_type)
+			})
+		}
+		Struct {
+			Type(Struct{
+				name: value.name.clone()
+			})
+		}
+		Interface {
+			Type(Interface{
+				name: value.name.clone()
+			})
+		}
+		Enum {
+			Type(Enum{
+				name:    value.name.clone()
+				is_flag: value.is_flag
+			})
+		}
+		SumType {
+			Type(SumType{
+				name: value.name.clone()
+			})
+		}
+		Alias {
+			Type(Alias{
+				name:      value.name.clone()
+				base_type: clone_owned_type(value.base_type)
+			})
+		}
+		MultiReturn {
+			Type(MultiReturn{
+				types: clone_owned_types(value.types)
+			})
+		}
+	}
+}
+
+// clone_owned_types clones a list of types and all nested owned metadata.
+pub fn clone_owned_types(values []Type) []Type {
+	mut cloned := []Type{cap: values.len}
+	for value in values {
+		cloned << clone_owned_type(value)
+	}
+	return cloned
+}
+
 // StructField represents struct field data used by types.
 pub struct StructField {
 pub:

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -492,119 +492,7 @@ fn clone_int_string_map(values map[int]string) map[int]string {
 
 // clone_type_value clones a type value and any nested owned type metadata.
 fn clone_type_value(value types.Type) types.Type {
-	return match value {
-		types.Void {
-			types.Type(types.void_)
-		}
-		types.Unknown {
-			types.Type(types.Unknown{
-				reason: value.reason.clone()
-			})
-		}
-		types.Primitive {
-			types.Type(types.Primitive{
-				props: value.props
-				size:  value.size
-			})
-		}
-		types.String {
-			types.Type(types.string_)
-		}
-		types.Char {
-			types.Type(types.char_)
-		}
-		types.Rune {
-			types.Type(types.rune_)
-		}
-		types.ISize {
-			types.Type(types.isize_)
-		}
-		types.USize {
-			types.Type(types.usize_)
-		}
-		types.Nil {
-			types.Type(types.nil_)
-		}
-		types.None {
-			types.Type(types.none_)
-		}
-		types.Array {
-			types.Type(types.Array{
-				elem_type: clone_type_value(value.elem_type)
-			})
-		}
-		types.ArrayFixed {
-			types.Type(types.ArrayFixed{
-				elem_type: clone_type_value(value.elem_type)
-				len:       value.len
-				len_expr:  value.len_expr.clone()
-			})
-		}
-		types.Channel {
-			types.Type(types.Channel{
-				elem_type: clone_type_value(value.elem_type)
-			})
-		}
-		types.Map {
-			types.Type(types.Map{
-				key_type:   clone_type_value(value.key_type)
-				value_type: clone_type_value(value.value_type)
-			})
-		}
-		types.Pointer {
-			types.Type(types.Pointer{
-				base_type: clone_type_value(value.base_type)
-			})
-		}
-		types.FnType {
-			types.Type(types.FnType{
-				params:      clone_type_list(value.params)
-				return_type: clone_type_value(value.return_type)
-			})
-		}
-		types.OptionType {
-			types.Type(types.OptionType{
-				base_type: clone_type_value(value.base_type)
-			})
-		}
-		types.ResultType {
-			types.Type(types.ResultType{
-				base_type: clone_type_value(value.base_type)
-			})
-		}
-		types.Struct {
-			types.Type(types.Struct{
-				name: value.name.clone()
-			})
-		}
-		types.Interface {
-			types.Type(types.Interface{
-				name: value.name.clone()
-			})
-		}
-		types.Enum {
-			types.Type(types.Enum{
-				name:    value.name.clone()
-				is_flag: value.is_flag
-			})
-		}
-		types.SumType {
-			types.Type(types.SumType{
-				name: value.name.clone()
-			})
-		}
-		types.Alias {
-			types.Type(types.Alias{
-				name:      value.name.clone()
-				base_type: clone_type_value(value.base_type)
-			})
-		}
-		types.MultiReturn {
-			types.Type(types.MultiReturn{
-				types: clone_type_list(value.types)
-			})
-		}
-	}
+	return types.clone_owned_type(value)
 }
 
 // clone_type_list clones a type slice out of a scoped prealloc arena.
@@ -612,11 +500,7 @@ fn clone_type_list(values []types.Type) []types.Type {
 	if values.len == 0 {
 		return []types.Type{}
 	}
-	mut cloned := []types.Type{cap: values.len}
-	for value in values {
-		cloned << clone_type_value(value)
-	}
-	return cloned
+	return types.clone_owned_types(values)
 }
 
 // clone_type_array clones active sparse type entries out of a scoped prealloc arena.
@@ -1353,6 +1237,9 @@ fn main() {
 	// (like v2: check runs before transform). The transformer reads cached
 	// per-expression types for type-dependent lowering.
 	mut pre_tc := types.TypeChecker.new(a)
+	if scope_prealloc_selfhost {
+		pre_tc.enable_scoped_parallel_workers()
+	}
 	pre_tc.reject_unsupported_generics = is_selfhost
 	set_diagnostic_files(mut pre_tc, user_files)
 	pre_tc.collect(a)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -714,6 +714,125 @@ fn clone_typechecker_after_scoped_transform(mut tc types.TypeChecker, ast &flat.
 	tc.set_fresh_type_cache(tc.type_cache_parse_enabled())
 }
 
+// clone_scoped_ast_strings_in_place keeps the pre-reserved AST arrays and
+// moves only owned node data out of the disposable transform arena.
+fn clone_scoped_ast_strings_in_place(mut ast flat.FlatAst, base_nodes int, owned_base_nodes []int) {
+	mut string_bytes := 0
+	for idx in owned_base_nodes {
+		if idx < 0 || idx >= base_nodes || idx >= ast.nodes.len {
+			continue
+		}
+		string_bytes += flat_node_owned_string_bytes(ast.nodes[idx])
+	}
+	for idx in base_nodes .. ast.nodes.len {
+		string_bytes += flat_node_owned_string_bytes(ast.nodes[idx])
+	}
+	if string_bytes == 0 {
+		return
+	}
+	// The buffer outlives this helper: the self-host binary uses -gc none and
+	// every resulting string points into this persistent parent-arena block.
+	storage := unsafe { &u8(malloc_noscan(string_bytes)) }
+	mut offset := 0
+	for idx in owned_base_nodes {
+		if idx < 0 || idx >= base_nodes || idx >= ast.nodes.len {
+			continue
+		}
+		unsafe {
+			mut node := &ast.nodes[idx]
+			offset = clone_flat_node_owned_strings(mut node, storage, offset)
+		}
+	}
+	for idx in base_nodes .. ast.nodes.len {
+		unsafe {
+			mut node := &ast.nodes[idx]
+			offset = clone_flat_node_owned_strings(mut node, storage, offset)
+		}
+	}
+}
+
+fn flat_node_owned_string_bytes(node flat.Node) int {
+	mut total := 0
+	if node.value.len > 0 {
+		total += node.value.len + 1
+	}
+	if node.typ.len > 0 {
+		total += node.typ.len + 1
+	}
+	for param in node.generic_params {
+		if param.len > 0 {
+			total += param.len + 1
+		}
+	}
+	return total
+}
+
+fn clone_flat_node_owned_strings(mut node flat.Node, storage &u8, offset int) int {
+	mut next_offset := offset
+	node.value, next_offset = clone_string_to_storage(node.value, storage, next_offset)
+	node.typ, next_offset = clone_string_to_storage(node.typ, storage, next_offset)
+	if node.generic_params.len > 0 {
+		mut params := []string{cap: node.generic_params.len}
+		for param in node.generic_params {
+			mut cloned := ''
+			cloned, next_offset = clone_string_to_storage(param, storage, next_offset)
+			params << cloned
+		}
+		node.generic_params = params
+	}
+	return next_offset
+}
+
+fn clone_string_to_storage(value string, storage &u8, offset int) (string, int) {
+	if value.len == 0 {
+		return value, offset
+	}
+	unsafe {
+		dst := &u8(u64(storage) + u64(offset))
+		vmemcpy(dst, value.str, value.len)
+		dst[value.len] = 0
+		return tos(dst, value.len), offset + value.len + 1
+	}
+}
+
+fn clone_scoped_generated_signatures_in_place(mut tc types.TypeChecker) {
+	mut generated_names := []string{}
+	for name in tc.fn_ret_types.keys() {
+		short_name := name.all_after_last('.')
+		if short_name.starts_with('__v3_') || short_name.starts_with('__anon_fn_') {
+			generated_names << name.clone()
+		}
+	}
+	for name in generated_names {
+		ret_type := tc.fn_ret_types[name] or { continue }
+		cloned_ret_type := clone_type_value(ret_type)
+		cloned_params := if params := tc.fn_param_types[name] {
+			clone_type_list(params)
+		} else {
+			[]types.Type{}
+		}
+		is_variadic := tc.fn_variadic[name]
+		tc.fn_ret_types.delete(name)
+		tc.fn_param_types.delete(name)
+		tc.fn_variadic.delete(name)
+		cloned_name := name.clone()
+		tc.fn_ret_types[cloned_name] = cloned_ret_type
+		tc.fn_param_types[cloned_name] = cloned_params
+		tc.fn_variadic[cloned_name] = is_variadic
+	}
+}
+
+fn clone_typechecker_scoped_additions_in_place(mut tc types.TypeChecker, ast &flat.FlatAst, parse_cache_enabled bool) {
+	tc.a = ast
+	clone_scoped_generated_signatures_in_place(mut tc)
+	tc.sparse_resolved_call_names = clone_int_string_map(tc.sparse_resolved_call_names)
+	tc.sparse_resolved_fn_values = clone_int_string_map(tc.sparse_resolved_fn_values)
+	tc.sparse_statement_nodes = tc.sparse_statement_nodes.clone()
+	tc.sparse_expr_type_values = clone_int_type_map(tc.sparse_expr_type_values)
+	tc.sparse_checking_nodes = tc.sparse_checking_nodes.clone()
+	tc.set_fresh_type_cache(parse_cache_enabled)
+}
+
 fn restored_fn_c_name(name string) string {
 	if name.starts_with('C.') {
 		return name[2..]
@@ -1125,6 +1244,9 @@ fn main() {
 	// currently relies on the serial function-item walk to retain those definitions.
 	cache_no_parallel_cgen := current_no_parallel || cache_manager.enabled
 	mut p := parser.Parser.new(prefs)
+	if scope_prealloc_selfhost {
+		p.reserve_selfhost_ast()
+	}
 
 	builtin_dir := builtin_dir_for_vroot(prefs.vroot)
 	mut builtin_defines := prefs.user_defines.clone()
@@ -1294,6 +1416,10 @@ fn main() {
 
 	// Mark used functions (dead-code elimination). This is done before transform
 	// so the transformer can skip function bodies that the C backend will prune.
+	mut markused_scope := unsafe { nil }
+	if scope_prealloc_selfhost {
+		markused_scope = prealloc_scope_begin_for_v3()
+	}
 	mut output_used_fns := map[string]bool{}
 	mut uses_generics := false
 	if test_files.len > 0 {
@@ -1309,6 +1435,14 @@ fn main() {
 			test_files, cache_state.source_body_modules)
 		uses_generics = uses_generics || cache_uses_generics
 	}
+	if scope_prealloc_selfhost {
+		parse_type_cache_enabled := pre_tc.type_cache_parse_enabled()
+		prealloc_scope_leave_for_v3(markused_scope)
+		output_used_fns = clone_string_bool_map(output_used_fns)
+		used_fns = clone_string_bool_map(used_fns)
+		pre_tc.set_fresh_type_cache(parse_type_cache_enabled)
+		prealloc_scope_free_for_v3(markused_scope)
+	}
 	b.step('markused')
 
 	// Transform (match lowering, string/in lowering, etc.). Threaded transform is enabled
@@ -1319,19 +1453,34 @@ fn main() {
 	// Markused distinguishes reachable generic calls/types from generic templates
 	// that merely came along with an imported module (notably sync and rand).
 	skip_transform_generics := building_v || cmd_v_build || !uses_generics
-	mut scope_whole_transform := !current_parallel_transform
-	$if v3_no_parallel ? {
-		scope_whole_transform = true
-	}
-	if scope_prealloc_selfhost && scope_whole_transform {
+	if scope_prealloc_selfhost {
+		transform.reserve_parallel_transform_ast(mut a, skip_transform_generics)
+		pre_tc.begin_sparse_transform_node_caches()
+		base_transform_nodes := a.nodes.len
+		reserved_nodes_cap := a.nodes.cap
+		reserved_children_cap := a.children.cap
 		transform_scope := prealloc_scope_begin_for_v3()
-		used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,
-			&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, false)
+		mut scoped_owned_base_nodes := []int{}
+		mut scoped_transform_worker_scopes := []voidptr{}
+		used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, scoped_transform_worker_scopes = transform.transform_with_used_opt_config_scoped_workers_checked_owned(mut a,
+			&pre_tc, used_fns, current_parallel_transform, skip_transform_generics,
+			current_parallel_transform)
+		parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 		prealloc_scope_leave_for_v3(transform_scope)
-		a = clone_flat_ast(a)
-		used_fns = clone_string_bool_map(used_fns)
-		transform_errors = clone_string_list(transform_errors)
-		clone_typechecker_after_scoped_transform(mut pre_tc, a)
+		if a.nodes.cap == reserved_nodes_cap && a.children.cap == reserved_children_cap {
+			clone_scoped_ast_strings_in_place(mut a, base_transform_nodes, scoped_owned_base_nodes)
+			used_fns = clone_string_bool_map(used_fns)
+			transform_errors = clone_string_list(transform_errors)
+			clone_typechecker_scoped_additions_in_place(mut pre_tc, a, parse_cache_enabled)
+		} else {
+			a = clone_flat_ast(a)
+			used_fns = clone_string_bool_map(used_fns)
+			transform_errors = clone_string_list(transform_errors)
+			clone_typechecker_after_scoped_transform(mut pre_tc, a)
+		}
+		for worker_scope in scoped_transform_worker_scopes {
+			prealloc_scope_free_for_v3(worker_scope)
+		}
 		prealloc_scope_free_for_v3(transform_scope)
 	} else {
 		used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1965,14 +1965,21 @@ fn restart_v3_without_cache() {
 }
 
 fn restart_v3_with_args(extra_args []string) {
-	mut command := [os.quoted_path(os.executable())]
-	for arg in extra_args {
-		command << os.quoted_path(arg)
+	executable := os.executable()
+	mut args := extra_args.clone()
+	args << os.args[1..]
+	$if js {
+		mut command := [os.quoted_path(executable)]
+		for arg in args {
+			command << os.quoted_path(arg)
+		}
+		exit(os.system(command.join(' ')))
+	} $else {
+		os.execvp(executable, args) or {
+			eprintln('failed to restart ${executable}: ${err.msg()}')
+			exit(1)
+		}
 	}
-	for arg in os.args[1..] {
-		command << os.quoted_path(arg)
-	}
-	exit(os.system(command.join(' ')))
 }
 
 fn cache_external_inputs_have_static_storage(inputs map[string][]string) bool {


### PR DESCRIPTION
## Summary

- merge current master after the large v3 audit commit and resolve its parser/checker/transform conflicts
- use disposable parser, checker, markused, transform, and cgen helper arenas while selectively promoting only escaping data
- recycle transform and cgen scratch in internal batches so helper peaks do not overlap for the whole stage
- add ownership-aware AST/type promotion plus compact indexes for repeated transform and type-resolution lookups
- grow the latest prealloc arena allocation in place and cap cgen generation at four concurrent jobs for RAM headroom
- keep cache restarts in place and preserve implicit pointer-value compatibility from the original branch
- initialize a real indexed token file for the parallel comptime prepass resolver required by current master

## Self-host benchmark

```sh
cd vlib/v3
../../v -gc none -prealloc -prod -o v3 v3.v && ./v3 -building-v -o v4 v3.v
```

Measured on macOS after merging master commit `460d33f80f`:

| Metric | Master after #27803 | This PR |
| --- | ---: | ---: |
| Transform | ~697 ms | 193.93 ms |
| Maximum reported stage peak | ~2220 MB | 992 MB |
| OS maximum resident set | ~2.33 GB | 1,040,138,240 bytes (992.0 MiB) |
| Total second-stage build | - | 2756.37 ms |

The requested limits are met with the exact command: total RAM is below 1000 MiB and transform is below 200 ms. The resulting `v4` compiler also builds v3 again successfully.

## Testing

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew vlib/builtin/prealloc_scope_ownership_test.v`
- `./vnew vlib/v3/types/checker_parallel_test.v`
- `./vnew vlib/v3/workers/worker_pool_test.v`
- `./vnew vlib/v3/tests/parallel_parser_test.v`
- `./vnew vlib/v3/tests/parallel_determinism_test.v`
- `./vnew vlib/v3/gen/c/parallel_worker_test.v`
- `./vnew vlib/v3/tests/parallel_cgen_test.v`
- prealloc `-building-v -no-parallel` self-host
- exact self-host command above under `/usr/bin/time -l`
- resulting `v4` building v3 once more

Broad tests were intentionally skipped as requested.