### PR TITLE
v3: reduce self-host memory below 600 MB

### DIFF
--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -290,6 +290,34 @@ pub fn (mut a FlatAst) intern_text(value string) (TextId, string) {
 	return id, a.text_values.last()
 }
 
+// reserve_transform_texts keeps canonical text-table backing in the
+// compilation arena before a disposable transform scope starts.
+pub fn (mut a FlatAst) reserve_transform_texts(headroom int) {
+	if headroom <= 0 {
+		return
+	}
+	unsafe { a.text_values.grow_cap(headroom) }
+	a.text_ids.reserve(u32(a.text_ids.len + headroom))
+}
+
+// promote_transform_texts_from moves canonical strings inserted by a scoped
+// transform into the current arena without rebuilding the complete text table.
+pub fn (mut a FlatAst) promote_transform_texts_from(start int, scope voidptr) {
+	first := if start < 0 { 0 } else { start }
+	for idx in first .. a.text_values.len {
+		value := a.text_values[idx]
+		$if prealloc {
+			if value.len == 0 || !unsafe { prealloc_scope_owns(scope, value.str) } {
+				continue
+			}
+			a.text_ids.delete(value)
+			canonical := value.clone()
+			a.text_values[idx] = canonical
+			a.text_ids[canonical] = TextId(idx + 1)
+		}
+	}
+}
+
 // text resolves a stable AST text identity.
 pub fn (a &FlatAst) text(id TextId) string {
 	idx := int(id) - 1

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -218,6 +218,50 @@ pub mut:
 	specialized_fn_nodes map[int]bool
 }
 
+// These layouts expose only the backing pointers needed to determine whether
+// text_ids rehashed inside a disposable prealloc scope. Keep them synchronized
+// with builtin.map and builtin.DenseArray.
+struct TextMapDenseArrayLayout {
+	key_bytes   int
+	value_bytes int
+mut:
+	cap         int
+	len         int
+	deletes     u32
+	all_deleted &u8 = unsafe { nil }
+	keys        &u8 = unsafe { nil }
+	values      &u8 = unsafe { nil }
+}
+
+struct TextMapLayout {
+	key_bytes   int
+	value_bytes int
+mut:
+	even_index      u32
+	cached_hashbits u8
+	shift           u8
+	key_values      TextMapDenseArrayLayout
+	metas           &u32 = unsafe { nil }
+	extra_metas     u32
+	has_string_keys bool
+	hash_fn         voidptr
+	key_eq_fn       voidptr
+	clone_fn        voidptr
+	free_fn         voidptr
+pub mut:
+	len int
+}
+
+fn text_id_map_storage_owned_by_scope(ids map[string]TextId, scope voidptr) bool {
+	$if prealloc {
+		layout := unsafe { &TextMapLayout(&ids) }
+		return unsafe { prealloc_scope_owns(scope, layout.key_values.keys) }
+			|| unsafe { prealloc_scope_owns(scope, layout.key_values.values) }
+			|| unsafe { prealloc_scope_owns(scope, layout.metas) }
+	}
+	return false
+}
+
 // close_workers stops the compilation-owned persistent worker pool.
 pub fn (mut a FlatAst) close_workers() {
 	if !isnil(a.worker_pool) {
@@ -301,8 +345,11 @@ pub fn (mut a FlatAst) reserve_transform_texts(headroom int) {
 }
 
 // promote_transform_texts_from moves canonical strings inserted by a scoped
-// transform into the current arena without rebuilding the complete text table.
+// transform into the current arena and rebuilds table backing only if it grew
+// into the disposable scope.
 pub fn (mut a FlatAst) promote_transform_texts_from(start int, scope voidptr) {
+	values_backing_scoped := scoped_text_storage_owned(scope, a.text_values.data)
+	ids_backing_scoped := text_id_map_storage_owned_by_scope(a.text_ids, scope)
 	first := if start < 0 { 0 } else { start }
 	for idx in first .. a.text_values.len {
 		value := a.text_values[idx]
@@ -316,6 +363,18 @@ pub fn (mut a FlatAst) promote_transform_texts_from(start int, scope voidptr) {
 			a.text_ids[canonical] = TextId(idx + 1)
 		}
 	}
+	if values_backing_scoped || ids_backing_scoped {
+		mut values, mut ids := a.clone_text_table_owned()
+		a.text_values = values
+		a.text_ids = ids.move()
+	}
+}
+
+fn scoped_text_storage_owned(scope voidptr, ptr voidptr) bool {
+	$if prealloc {
+		return unsafe { prealloc_scope_owns(scope, ptr) }
+	}
+	return false
 }
 
 // clone_text_table_owned copies the canonical text table and rebuilds its

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -318,6 +318,20 @@ pub fn (mut a FlatAst) promote_transform_texts_from(start int, scope voidptr) {
 	}
 }
 
+// clone_text_table_owned copies the canonical text table and rebuilds its
+// lookup map with storage owned by the current allocation arena.
+pub fn (a &FlatAst) clone_text_table_owned() ([]string, map[string]TextId) {
+	mut values := []string{cap: a.text_values.len}
+	mut ids := map[string]TextId{}
+	ids.reserve(u32(a.text_values.len))
+	for value in a.text_values {
+		canonical := value.clone()
+		values << canonical
+		ids[canonical] = TextId(values.len)
+	}
+	return values, ids
+}
+
 // text resolves a stable AST text identity.
 pub fn (a &FlatAst) text(id TextId) string {
 	idx := int(id) - 1

--- a/vlib/v3/flat/flat_test.v
+++ b/vlib/v3/flat/flat_test.v
@@ -47,3 +47,29 @@ fn test_clone_text_table_owned_detaches_scoped_storage() {
 		assert ids['scoped_text_128'] == TextId(129)
 	}
 }
+
+fn test_promote_transform_texts_rebuilds_scoped_table_growth() {
+	$if prealloc {
+		mut ast := FlatAst.new()
+		ast.reserve_transform_texts(4)
+		scope := unsafe { prealloc_scope_begin() }
+		for i in 0 .. 256 {
+			ast.intern_text('promoted_text_${i}')
+		}
+		assert unsafe { prealloc_scope_owns(scope, ast.text_values.data) }
+		assert text_id_map_storage_owned_by_scope(ast.text_ids, scope)
+		unsafe { prealloc_scope_leave(scope) }
+
+		ast.promote_transform_texts_from(0, scope)
+		assert !unsafe { prealloc_scope_owns(scope, ast.text_values.data) }
+		assert !text_id_map_storage_owned_by_scope(ast.text_ids, scope)
+		unsafe { prealloc_scope_free_after(scope) }
+
+		for idx in [0, 128, 255] {
+			value := 'promoted_text_${idx}'
+			id, canonical := ast.intern_text(value)
+			assert id == TextId(idx + 1)
+			assert canonical == value
+		}
+	}
+}

--- a/vlib/v3/flat/flat_test.v
+++ b/vlib/v3/flat/flat_test.v
@@ -23,3 +23,27 @@ fn test_node_uses_compact_header_and_uncommon_payload() {
 	// The former always-present []string field made Node 96 bytes on 64-bit.
 	assert sizeof(Node) <= 72
 }
+
+fn test_clone_text_table_owned_detaches_scoped_storage() {
+	$if prealloc {
+		mut ast := FlatAst.new()
+		scope := unsafe { prealloc_scope_begin() }
+		for i in 0 .. 256 {
+			ast.intern_text('scoped_text_${i}')
+		}
+		unsafe { prealloc_scope_leave(scope) }
+
+		values, ids := ast.clone_text_table_owned()
+		assert !unsafe { prealloc_scope_owns(scope, values.data) }
+		for idx in [0, 128, 255] {
+			assert unsafe { prealloc_scope_owns(scope, ast.text_values[idx].str) }
+			assert !unsafe { prealloc_scope_owns(scope, values[idx].str) }
+			assert ids[values[idx]] == TextId(idx + 1)
+		}
+		unsafe { prealloc_scope_free_after(scope) }
+
+		assert values[0] == 'scoped_text_0'
+		assert values[255] == 'scoped_text_255'
+		assert ids['scoped_text_128'] == TextId(129)
+	}
+}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -8,6 +8,31 @@ import v3.gen.c.naming
 import v3.pref
 import v3.types
 
+fn cgen_worker_scope_begin(enabled bool) voidptr {
+	$if prealloc {
+		if enabled {
+			return unsafe { prealloc_scope_begin() }
+		}
+	}
+	return unsafe { nil }
+}
+
+fn cgen_worker_scope_leave(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_leave(scope) }
+		}
+	}
+}
+
+fn cgen_worker_scope_free(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_free_after(scope) }
+		}
+	}
+}
+
 struct ActiveLock {
 	mutexes_var string
 	modes_var   string
@@ -203,6 +228,9 @@ mut:
 	c_extern_refs                  map[string]bool
 	c_extern_refs_ready            bool
 	parallel_prepared              bool
+	scoped_fn_items_scope          voidptr
+	scoped_fn_output_path          string
+	scoped_fn_output_paths         []string
 	const_short_index              &ConstShortIndex = unsafe { nil }
 	mut_recv_facts                 &FnNameFactCache = unsafe { nil }
 	want_parallel_prep             bool
@@ -883,6 +911,152 @@ pub fn (mut g FlatGen) gen_to_file_with_used_test_options(path string, a &flat.F
 	}
 }
 
+fn (mut g FlatGen) write_scoped_output_chunk(path string, append bool, scope voidptr) bool {
+	mut output := unsafe { g.sb.reuse_as_plain_u8_array() }
+	if append {
+		mut file := os.open_append(path) or {
+			g.output_error = err.msg()
+			unsafe { output.free() }
+			cgen_worker_scope_free(scope)
+			return false
+		}
+		unsafe {
+			file.write_full_buffer(output.data, usize(output.len)) or {
+				g.output_error = err.msg()
+				file.close()
+				output.free()
+				cgen_worker_scope_free(scope)
+				return false
+			}
+		}
+		file.close()
+	} else {
+		os.write_file_array(path, output) or {
+			g.output_error = err.msg()
+			unsafe { output.free() }
+			cgen_worker_scope_free(scope)
+			return false
+		}
+	}
+	unsafe { output.free() }
+	cgen_worker_scope_free(scope)
+	return true
+}
+
+fn (mut g FlatGen) start_scoped_output_builder(cap int) voidptr {
+	scope := cgen_worker_scope_begin(true)
+	g.sb = strings.new_builder(cap)
+	cgen_worker_scope_leave(scope)
+	return scope
+}
+
+fn (mut g FlatGen) flush_and_restart_scoped_output(path string, append bool, scope voidptr, cap int) !voidptr {
+	if !g.write_scoped_output_chunk(path, append, scope) {
+		g.sb = strings.new_builder(4096)
+		return error(g.output_error)
+	}
+	return g.start_scoped_output_builder(cap)
+}
+
+fn (mut g FlatGen) release_scoped_fn_items() {
+	if g.scoped_fn_items_scope == unsafe { nil } {
+		return
+	}
+	scope := g.scoped_fn_items_scope
+	g.fn_gen_items = []FlatFnGenItem{}
+	g.emitted_fns = map[string]bool{}
+	g.tc.cur_file = ''
+	g.tc.cur_module = ''
+	g.scoped_fn_items_scope = unsafe { nil }
+	cgen_worker_scope_free(scope)
+}
+
+fn (mut g FlatGen) write_scoped_function_output(path string, fn_code string) bool {
+	mut initial_file := os.create(path) or {
+		g.output_error = err.msg()
+		return false
+	}
+	initial_file.close()
+	for chunk_path in g.scoped_fn_output_paths {
+		if !g.append_scoped_output_file(path, chunk_path) {
+			return false
+		}
+		os.rm(chunk_path) or {}
+	}
+	g.scoped_fn_output_path = ''
+	g.scoped_fn_output_paths = []string{}
+	mut file := os.open_append(path) or {
+		g.output_error = err.msg()
+		return false
+	}
+	if g.fn_segs.len > 0 {
+		for segment in g.fn_segs {
+			file.write_string(segment) or {
+				g.output_error = err.msg()
+				file.close()
+				return false
+			}
+			unsafe { segment.free() }
+		}
+		g.fn_segs = []string{}
+	} else {
+		file.write_string(fn_code) or {
+			g.output_error = err.msg()
+			file.close()
+			return false
+		}
+		unsafe { fn_code.free() }
+	}
+	file.close()
+	return true
+}
+
+fn (mut g FlatGen) append_scoped_output_file(path string, source_path string) bool {
+	mut source := os.open(source_path) or {
+		g.output_error = err.msg()
+		return false
+	}
+	mut output := os.open_append(path) or {
+		g.output_error = err.msg()
+		source.close()
+		return false
+	}
+	mut buffer := []u8{len: 64 * 1024}
+	for {
+		n_read := source.read(mut buffer) or {
+			if err is os.Eof {
+				break
+			}
+			g.output_error = err.msg()
+			output.close()
+			source.close()
+			return false
+		}
+		if n_read == 0 {
+			break
+		}
+		unsafe {
+			output.write_full_buffer(buffer.data, usize(n_read)) or {
+				g.output_error = err.msg()
+				output.close()
+				source.close()
+				return false
+			}
+		}
+	}
+	output.close()
+	source.close()
+	return true
+}
+
+fn (g &FlatGen) cleanup_scoped_output_files(stream_path string, fn_stream_path string) {
+	os.rm(stream_path) or {}
+	os.rm(fn_stream_path) or {}
+	for chunk_path in g.scoped_fn_output_paths {
+		os.rm(chunk_path) or {}
+	}
+}
+
 // gen_with_used_options emits with used options output for c.
 pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[string]bool, tc &types.TypeChecker, no_parallel bool) string {
 	g.a = a
@@ -1000,6 +1174,9 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.c_extern_refs.clear()
 	g.c_extern_refs_ready = false
 	g.parallel_prepared = false
+	g.scoped_fn_items_scope = unsafe { nil }
+	g.scoped_fn_output_path = ''
+	g.scoped_fn_output_paths = []string{}
 	g.const_short_index = &ConstShortIndex{}
 	g.mut_recv_facts = &FnNameFactCache{}
 	g.want_parallel_prep = false
@@ -1043,6 +1220,12 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	// signatures, returns and call sites all agree on the wrapped types.
 	g.populate_fixed_array_ret_wrappers()
 	const_code := g.precompute_consts()
+	stream_scoped_output := g.output_path.len > 0 && !g.cache_split && g.scope_parallel_workers
+	stream_path := if stream_scoped_output { '${g.output_path}.v3-stream.tmp' } else { '' }
+	fn_stream_path := if stream_scoped_output { '${g.output_path}.v3-fns.tmp' } else { '' }
+	if stream_scoped_output {
+		g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+	}
 	orig_sb := g.sb
 	orig_line_start := g.line_start
 	g.sb = strings.new_builder(4096)
@@ -1057,8 +1240,23 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	for segment in g.fn_segs {
 		known_output_len += segment.len
 	}
-	// Leave headroom for the small body-dependent supplement emitted below.
-	g.sb.ensure_cap(known_output_len + 1024 * 1024)
+	if stream_scoped_output && !g.write_scoped_function_output(fn_stream_path, fn_code) {
+		g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+		return ''
+	}
+	mut stream_started := false
+	mut output_scope := unsafe { nil }
+	if stream_scoped_output {
+		existing_output := if g.sb.len > 0 { g.sb.str() } else { '' }
+		output_scope = g.start_scoped_output_builder(640 * 1024)
+		if existing_output.len > 0 {
+			g.sb.write_string(existing_output)
+			unsafe { existing_output.free() }
+		}
+	} else {
+		// Leave headroom for the small body-dependent supplement emitted below.
+		g.sb.ensure_cap(known_output_len + 1024 * 1024)
+	}
 	g.c99_feature_test_macros()
 	g.emit_preserved_c_directives()
 	g.preamble()
@@ -1066,6 +1264,14 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.enum_decls()
 	g.type_alias_decls()
 	g.type_forward_decls()
+	if stream_scoped_output {
+		output_scope = g.flush_and_restart_scoped_output(stream_path, stream_started, output_scope,
+			640 * 1024) or {
+			g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+			return ''
+		}
+		stream_started = true
+	}
 	// Forward-declare multi-return structs before fn-ptr typedefs, which may name a
 	// multi-return as a by-value return type (full bodies come after struct_decls).
 	g.multi_return_forward_decls()
@@ -1075,6 +1281,13 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.fixed_array_early_typedefs()
 	g.fn_ptr_typedefs()
 	g.struct_decls()
+	if stream_scoped_output {
+		output_scope = g.flush_and_restart_scoped_output(stream_path, stream_started, output_scope,
+			640 * 1024) or {
+			g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+			return ''
+		}
+	}
 	g.fixed_array_typedefs()
 	g.multi_return_typedefs()
 	g.optional_typedefs()
@@ -1082,13 +1295,49 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.builtin_abi_decls()
 	g.test_failure_helpers()
 	g.global_decls()
+	if stream_scoped_output {
+		output_scope = g.flush_and_restart_scoped_output(stream_path, stream_started, output_scope,
+			640 * 1024) or {
+			g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+			return ''
+		}
+	}
 	g.forward_decls()
+	g.release_scoped_fn_items()
+	if stream_scoped_output {
+		output_scope = g.flush_and_restart_scoped_output(stream_path, stream_started, output_scope,
+			640 * 1024) or {
+			g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+			return ''
+		}
+	}
 	g.cached_header_forward_decls()
 	g.interface_method_forward_decls()
+	if stream_scoped_output {
+		output_scope = g.flush_and_restart_scoped_output(stream_path, stream_started, output_scope,
+			640 * 1024) or {
+			g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+			return ''
+		}
+	}
 	g.shared_dup_fns()
+	if stream_scoped_output {
+		output_scope = g.flush_and_restart_scoped_output(stream_path, stream_started, output_scope,
+			640 * 1024) or {
+			g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+			return ''
+		}
+	}
 	g.enum_str_forward_decls()
 	g.callback_wrapper_decls()
 	g.spawn_wrapper_decls()
+	if stream_scoped_output {
+		output_scope = g.flush_and_restart_scoped_output(stream_path, stream_started, output_scope,
+			640 * 1024) or {
+			g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+			return ''
+		}
+	}
 	g.register_interface_strings()
 	g.string_literals()
 	if !g.cache_split {
@@ -1122,6 +1371,25 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	}
 	if g.cache_split {
 		g.interface_method_stubs()
+	}
+	if stream_scoped_output {
+		if !g.write_scoped_output_chunk(stream_path, stream_started, output_scope) {
+			g.sb = strings.new_builder(4096)
+			g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+			return ''
+		}
+		g.sb = strings.new_builder(4096)
+		if !g.append_scoped_output_file(stream_path, fn_stream_path) {
+			g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+			return ''
+		}
+		os.mv(stream_path, g.output_path) or {
+			g.output_error = err.msg()
+			g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+			return ''
+		}
+		os.rm(fn_stream_path) or {}
+		return ''
 	}
 	if g.fn_segs.len > 0 {
 		for segment in g.fn_segs {
@@ -1610,8 +1878,8 @@ fn (mut g FlatGen) collect_gen_info() {
 	}
 	if g.has_shared_params {
 		for full_name, flags in preferred_shared_fn_params {
-			g.fn_decl_shared_params[full_name] = flags.clone()
-			g.fn_decl_shared_params[g.cname(full_name)] = flags.clone()
+			g.fn_decl_shared_params[full_name] = flags
+			g.fn_decl_shared_params[g.cname(full_name)] = flags
 		}
 		for i, name in nonshared_fn_short_names {
 			if name in g.fn_decl_shared_params {
@@ -3549,39 +3817,53 @@ fn fn_decl_module_key(module_name string, name string) string {
 // register_fn_decl_param_types updates register fn decl param types state for c.
 fn (mut g FlatGen) register_fn_decl_param_types(name string, full_name string, ptypes []types.Type, is_variadic bool) {
 	module_key := fn_decl_module_key(g.tc.cur_module, name)
-	g.fn_decl_param_types[module_key] = ptypes.clone()
-	g.fn_decl_variadic[module_key] = is_variadic
+	g.fn_decl_param_types[module_key] = ptypes
+	if is_variadic {
+		g.fn_decl_variadic[module_key] = true
+	}
 	short_name := name.all_after_last('.')
 	g.fn_decl_variadic_short_counts[short_name] = g.fn_decl_variadic_short_counts[short_name] + 1
 	if name !in g.fn_decl_param_types {
-		g.fn_decl_param_types[name] = ptypes.clone()
-		g.fn_decl_variadic[name] = is_variadic
+		g.fn_decl_param_types[name] = ptypes
+		if is_variadic {
+			g.fn_decl_variadic[name] = true
+		}
 	}
 	cname := g.cname(name)
 	if cname !in g.fn_decl_param_types {
-		g.fn_decl_param_types[cname] = ptypes.clone()
-		g.fn_decl_variadic[cname] = is_variadic
+		g.fn_decl_param_types[cname] = ptypes
+		if is_variadic {
+			g.fn_decl_variadic[cname] = true
+		}
 	}
 	if g.tc.cur_module.len > 0 && g.tc.cur_module != 'main' && g.tc.cur_module != 'builtin' {
 		dotted_name := '${g.tc.cur_module}.${name}'
 		if dotted_name !in g.fn_decl_param_types {
-			g.fn_decl_param_types[dotted_name] = ptypes.clone()
-			g.fn_decl_variadic[dotted_name] = is_variadic
+			g.fn_decl_param_types[dotted_name] = ptypes
+			if is_variadic {
+				g.fn_decl_variadic[dotted_name] = true
+			}
 		}
 		cdotted_name := g.cname(dotted_name)
 		if cdotted_name !in g.fn_decl_param_types {
-			g.fn_decl_param_types[cdotted_name] = ptypes.clone()
-			g.fn_decl_variadic[cdotted_name] = is_variadic
+			g.fn_decl_param_types[cdotted_name] = ptypes
+			if is_variadic {
+				g.fn_decl_variadic[cdotted_name] = true
+			}
 		}
 	}
 	if full_name !in g.fn_decl_param_types {
-		g.fn_decl_param_types[full_name] = ptypes.clone()
-		g.fn_decl_variadic[full_name] = is_variadic
+		g.fn_decl_param_types[full_name] = ptypes
+		if is_variadic {
+			g.fn_decl_variadic[full_name] = true
+		}
 	}
 	cfull_name := g.cname(full_name)
 	if cfull_name !in g.fn_decl_param_types {
-		g.fn_decl_param_types[cfull_name] = ptypes.clone()
-		g.fn_decl_variadic[cfull_name] = is_variadic
+		g.fn_decl_param_types[cfull_name] = ptypes
+		if is_variadic {
+			g.fn_decl_variadic[cfull_name] = true
+		}
 	}
 }
 
@@ -3600,28 +3882,28 @@ fn (mut g FlatGen) register_fn_decl_shared_params(name string, full_name string,
 	// stops fn_param_is_shared's short-name fallback from borrowing the shared
 	// flags of an unrelated same-named declaration in another module.
 	if name !in g.fn_decl_shared_params {
-		g.fn_decl_shared_params[name] = flags.clone()
+		g.fn_decl_shared_params[name] = flags
 	}
 	cname := g.cname(name)
 	if cname !in g.fn_decl_shared_params {
-		g.fn_decl_shared_params[cname] = flags.clone()
+		g.fn_decl_shared_params[cname] = flags
 	}
 	if g.tc.cur_module.len > 0 && g.tc.cur_module != 'main' && g.tc.cur_module != 'builtin' {
 		dotted_name := '${g.tc.cur_module}.${name}'
 		if dotted_name !in g.fn_decl_shared_params {
-			g.fn_decl_shared_params[dotted_name] = flags.clone()
+			g.fn_decl_shared_params[dotted_name] = flags
 		}
 		cdotted_name := g.cname(dotted_name)
 		if cdotted_name !in g.fn_decl_shared_params {
-			g.fn_decl_shared_params[cdotted_name] = flags.clone()
+			g.fn_decl_shared_params[cdotted_name] = flags
 		}
 	}
 	if full_name !in g.fn_decl_shared_params {
-		g.fn_decl_shared_params[full_name] = flags.clone()
+		g.fn_decl_shared_params[full_name] = flags
 	}
 	cfull_name := g.cname(full_name)
 	if cfull_name !in g.fn_decl_shared_params {
-		g.fn_decl_shared_params[cfull_name] = flags.clone()
+		g.fn_decl_shared_params[cfull_name] = flags
 	}
 }
 

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -6955,7 +6955,7 @@ fn (g &FlatGen) selective_import_call_key(name string) ?string {
 fn (g &FlatGen) fn_decl_is_variadic(name string, fallback string) bool {
 	if name.contains('__') {
 		dotted_name := name.replace('__', '.')
-		if v := g.fn_decl_variadic[dotted_name] {
+		if v := g.fn_decl_variadic_entry(dotted_name) {
 			return v
 		}
 		if v := g.import_resolved_fn_decl_variadic(dotted_name) {
@@ -6975,7 +6975,7 @@ fn (g &FlatGen) fn_decl_is_variadic(name string, fallback string) bool {
 		if v := g.import_resolved_fn_decl_variadic(candidate) {
 			return v
 		}
-		if v := g.fn_decl_variadic[candidate] {
+		if v := g.fn_decl_variadic_entry(candidate) {
 			return v
 		}
 		if candidate.starts_with('main.') {
@@ -6992,6 +6992,16 @@ fn (g &FlatGen) fn_decl_is_variadic(name string, fallback string) bool {
 	return false
 }
 
+fn (g &FlatGen) fn_decl_variadic_entry(name string) ?bool {
+	if value := g.fn_decl_variadic[name] {
+		return value
+	}
+	if name in g.fn_decl_param_types {
+		return false
+	}
+	return none
+}
+
 fn (g &FlatGen) import_resolved_fn_decl_variadic(name string) ?bool {
 	if !name.contains('.') {
 		return none
@@ -7006,7 +7016,7 @@ fn (g &FlatGen) import_resolved_fn_decl_variadic(name string) ?bool {
 		g.import_alias_module(alias) or { return none }
 	}
 	resolved_name := '${module_name}.${name.all_after('.')}'
-	if v := g.fn_decl_variadic[resolved_name] {
+	if v := g.fn_decl_variadic_entry(resolved_name) {
 		return v
 	}
 	return none
@@ -7015,7 +7025,7 @@ fn (g &FlatGen) import_resolved_fn_decl_variadic(name string) ?bool {
 fn (g &FlatGen) local_or_unique_short_fn_decl_variadic(name string) ?bool {
 	if g.tc != unsafe { nil } {
 		module_key := fn_decl_module_key(g.tc.cur_module, name)
-		if v := g.fn_decl_variadic[module_key] {
+		if v := g.fn_decl_variadic_entry(module_key) {
 			return v
 		}
 	}
@@ -7027,7 +7037,7 @@ fn (g &FlatGen) unique_short_fn_decl_variadic(name string) ?bool {
 	if g.fn_decl_variadic_short_counts[short_name] != 1 {
 		return none
 	}
-	if v := g.fn_decl_variadic[short_name] {
+	if v := g.fn_decl_variadic_entry(short_name) {
 		return v
 	}
 	return none

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -586,7 +586,7 @@ fn (g &FlatGen) parallel_cached_expr_type(id flat.NodeId, node flat.Node) ?types
 	if idx < 0 {
 		return none
 	}
-	if g.tc.parallel_check_sparse {
+	if g.tc.parallel_check_sparse && (idx < g.tc.check_range_lo || idx > g.tc.check_range_hi) {
 		if t := g.tc.sparse_expr_type_values[idx] {
 			return t
 		}
@@ -966,6 +966,9 @@ fn (g &FlatGen) clone_parallel_type_checker() &types.TypeChecker {
 		expr_type_values:                   g.tc.expr_type_values
 		expr_type_set:                      g.tc.expr_type_set
 		checking_nodes:                     g.tc.checking_nodes
+		parallel_check_sparse:              g.tc.parallel_check_sparse
+		check_range_lo:                     g.tc.check_range_lo
+		check_range_hi:                     g.tc.check_range_hi
 		sparse_resolved_call_names:         g.tc.sparse_resolved_call_names
 		sparse_resolved_fn_values:          g.tc.sparse_resolved_fn_values
 		sparse_statement_nodes:             g.tc.sparse_statement_nodes

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -7,9 +7,9 @@ import v3.flat
 import v3.types
 import v3.workers
 
-const max_flat_cgen_jobs = 4
+const max_flat_cgen_jobs = 2
 const min_flat_cgen_parallel_items = 1024
-const scoped_cgen_worker_batches = 96
+const scoped_cgen_worker_batches = 128
 
 $if !windows {
 	// FlatCgenChunkArgs represents flat cgen chunk args data used by c.
@@ -59,16 +59,61 @@ $if !windows {
 }
 
 fn (mut g FlatGen) prepare_pre_dispatch_master() {
-	g.want_parallel_prep = true
-	items := g.ensure_fn_gen_items()
-	g.want_parallel_prep = false
-	if items.len >= min_flat_cgen_parallel_items {
+	mut n_items := 0
+	if g.scope_parallel_workers {
+		selection_scope := cgen_worker_scope_begin(true)
+		master_tc := g.tc
+		g.tc = g.clone_parallel_type_checker()
+		g.want_parallel_prep = false
+		items := g.ensure_fn_gen_items()
+		g.tc = master_tc
+		cgen_worker_scope_leave(selection_scope)
+		items_scope := cgen_worker_scope_begin(true)
+		mut owned_items := []FlatFnGenItem{cap: items.len}
+		for item in items {
+			owned_items << FlatFnGenItem{
+				node_id:                   item.node_id
+				file:                      item.file.clone()
+				module:                    item.module.clone()
+				c_name:                    item.c_name.clone()
+				cost:                      item.cost
+				is_program_specialization: item.is_program_specialization
+			}
+		}
+		g.fn_gen_items = owned_items
+		g.emitted_fns = clone_cgen_string_bool_map(g.emitted_fns)
+		cgen_worker_scope_leave(items_scope)
+		g.scoped_fn_items_scope = items_scope
+		g.c_name_cache = &CNameCache{}
+		cgen_worker_scope_free(selection_scope)
+		prep_scope := cgen_worker_scope_begin(true)
+		prep_master_tc := g.tc
+		g.tc = g.clone_parallel_type_checker()
+		g.prepare_parallel_items(g.fn_gen_items)
+		g.tc = prep_master_tc
+		cgen_worker_scope_leave(prep_scope)
+		g.str_lits = clone_cgen_string_list(g.str_lits)
+		g.str_lit_ids = clone_cgen_string_int_map(g.str_lit_ids)
+		g.fn_ptr_types = clone_cgen_string_map(g.fn_ptr_types)
+		g.used_fn_ptr_types = clone_cgen_string_bool_map(g.used_fn_ptr_types)
+		g.c_extern_refs = clone_cgen_string_bool_map(g.c_extern_refs)
+		g.c_name_cache = &CNameCache{}
+		cgen_worker_scope_free(prep_scope)
+		n_items = g.fn_gen_items.len
+	} else {
+		g.want_parallel_prep = true
+		n_items = g.ensure_fn_gen_items().len
+		g.want_parallel_prep = false
+	}
+	if n_items >= min_flat_cgen_parallel_items {
 		// The fused item walk already interned and pre-seeded; only the
 		// epilogue remains.
-		if _ := g.ierror_interface_name() {
-			g.intern_string('')
+		if !g.scope_parallel_workers {
+			if _ := g.ierror_interface_name() {
+				g.intern_string('')
+			}
+			g.register_interface_strings()
 		}
-		g.register_interface_strings()
 		if g.test_files.len == 0 && !g.has_entry_main() {
 			for stmt in g.top_level_stmts() {
 				g.collect_c_extern_referenced_symbols_from_node(stmt.id, mut g.c_extern_refs)
@@ -82,29 +127,36 @@ fn (mut g FlatGen) prepare_pre_dispatch_master() {
 	_ = g.unique_const_ref_name('__v3_prewarm__') or { '' }
 }
 
-fn cgen_worker_scope_begin(enabled bool) voidptr {
-	$if prealloc {
-		if enabled {
-			return unsafe { prealloc_scope_begin() }
-		}
+fn clone_cgen_string_list(values []string) []string {
+	mut cloned := []string{cap: values.len}
+	for value in values {
+		cloned << value.clone()
 	}
-	return unsafe { nil }
+	return cloned
 }
 
-fn cgen_worker_scope_leave(scope voidptr) {
-	$if prealloc {
-		if scope != unsafe { nil } {
-			unsafe { prealloc_scope_leave(scope) }
-		}
+fn clone_cgen_string_map(values map[string]string) map[string]string {
+	mut cloned := map[string]string{}
+	for key, value in values {
+		cloned[key.clone()] = value.clone()
 	}
+	return cloned
 }
 
-fn cgen_worker_scope_free(scope voidptr) {
-	$if prealloc {
-		if scope != unsafe { nil } {
-			unsafe { prealloc_scope_free_after(scope) }
-		}
+fn clone_cgen_string_bool_map(values map[string]bool) map[string]bool {
+	mut cloned := map[string]bool{}
+	for key, value in values {
+		cloned[key.clone()] = value
 	}
+	return cloned
+}
+
+fn clone_cgen_string_int_map(values map[string]int) map[string]int {
+	mut cloned := map[string]int{}
+	for key, value in values {
+		cloned[key.clone()] = value
+	}
+	return cloned
 }
 
 // absorb_scoped_cgen_batch copies a finished batch's output and observable
@@ -113,7 +165,19 @@ fn (mut g FlatGen) absorb_scoped_cgen_batch(batch &FlatGen) {
 	mut b := unsafe { batch }
 	output := b.sb.str()
 	if output.len > 0 {
-		g.fn_segs << output
+		if g.scoped_fn_output_path.len > 0 {
+			mut file := os.open_append(g.scoped_fn_output_path) or {
+				g.output_error = err.msg()
+				unsafe { output.free() }
+				unsafe { b.sb.free() }
+				return
+			}
+			file.write_string(output) or { g.output_error = err.msg() }
+			file.close()
+			unsafe { output.free() }
+		} else {
+			g.fn_segs << output
+		}
 	}
 	unsafe { b.sb.free() }
 	for opt_name, val_type in batch.needed_optional_types {
@@ -284,6 +348,11 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			g.gen_synthetic_main_after_fns()
 			return
 		}
+		if g.output_path.len > 0 && !g.cache_split && g.scope_parallel_workers {
+			g.scoped_fn_output_path = '${g.output_path}.v3-fns.tmp.0'
+			g.scoped_fn_output_paths = [g.scoped_fn_output_path]
+			os.rm(g.scoped_fn_output_path) or {}
+		}
 		// Freeze the checker's warm type cache (fully populated by the check and
 		// transform phases) as the shared read-only base for every worker's
 		// fresh cache; the master's own memoization writes go to a private
@@ -305,9 +374,19 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			is_master:      true
 		}
 		mut cgen_workers := []voidptr{cap: thread_count}
+		if g.scoped_fn_output_path.len > 0 {
+			for ci := 0; ci < thread_count; ci++ {
+				worker_path := '${g.scoped_fn_output_path}.${ci + 1}'
+				g.scoped_fn_output_paths << worker_path
+				os.rm(worker_path) or {}
+			}
+		}
 		worker_setup_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
 		for ci := 0; ci < thread_count; ci++ {
-			w := g.new_parallel_dispatch_worker(ci + 1)
+			mut w := g.new_parallel_dispatch_worker(ci + 1)
+			if g.scoped_fn_output_path.len > 0 {
+				w.scoped_fn_output_path = g.scoped_fn_output_paths[ci + 1]
+			}
 			cgen_workers << voidptr(w)
 		}
 		for ci := 0; ci < thread_count; ci++ {
@@ -915,6 +994,9 @@ fn (g &FlatGen) clone_parallel_type_checker() &types.TypeChecker {
 // merge_parallel_worker supports merge parallel worker handling for FlatGen.
 fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 	mut ww := unsafe { w }
+	if g.output_error.len == 0 && w.output_error.len > 0 {
+		g.output_error = w.output_error.clone()
+	}
 	worker_output := ww.sb.str()
 	if worker_output.len > 0 {
 		g.fn_segs << worker_output
@@ -982,7 +1064,6 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 		}
 		if g.scope_parallel_workers {
 			g.collect_fixed_storage_consts()
-			g.precompute_embedded_fields()
 			g.precompute_param_type_index()
 			g.precompute_concrete_optional_abi_fns()
 			g.prepare_pre_dispatch_master()

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -24,3 +24,30 @@ fn test_parallel_dispatch_worker_shares_checker_as_scoped_accumulator() {
 	w := g.new_parallel_dispatch_worker(1)
 	assert w.tc == tc
 }
+
+fn test_parallel_checker_clone_preserves_sparse_transform_caches() {
+	g, mut tc := parallel_worker_test_gen(false)
+	tc.a.nodes = [flat.Node{
+		kind: .ident
+	}, flat.Node{
+		kind: .ident
+	}]
+	tc.resolved_call_names = ['source_call']
+	tc.resolved_call_set = [true]
+	tc.expr_type_values = [types.Type(types.int_)]
+	tc.expr_type_set = [true]
+	tc.begin_sparse_transform_node_caches(1)
+	tc.sparse_resolved_call_names[1] = 'transformed_call'
+	tc.sparse_expr_type_values[1] = types.Type(types.String{})
+
+	w := g.clone_parallel_type_checker()
+	assert w.parallel_check_sparse
+	assert w.check_range_lo == 0
+	assert w.check_range_hi == 0
+	assert w.resolved_call_name(flat.NodeId(0)) or { '' } == 'source_call'
+	assert w.resolved_call_name(flat.NodeId(1)) or { '' } == 'transformed_call'
+	assert w.expr_type(flat.NodeId(0)) or { types.Type(types.void_) } is types.Primitive
+	assert w.expr_type(flat.NodeId(1)) or { types.Type(types.void_) } is types.String
+	assert g.parallel_cached_expr_type(flat.NodeId(0), tc.a.nodes[0]) or { types.Type(types.void_) } is types.Primitive
+	assert g.parallel_cached_expr_type(flat.NodeId(1), tc.a.nodes[1]) or { types.Type(types.void_) } is types.String
+}

--- a/vlib/v3/markused/markused_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/markused/markused_parallel_notd_v3_no_parallel.v
@@ -13,6 +13,7 @@ import v3.workers
 
 const max_markused_jobs = 8
 const min_markused_parallel_bodies = 512
+const scoped_markused_worker_batches = 16
 
 $if !windows {
 	// MarkusedChunkArgs is the payload handed to each worker thread.
@@ -38,10 +39,44 @@ $if !windows {
 		modules := unsafe { &[]string(args.modules_ptr) }
 		import_contexts := unsafe { &[]int(args.import_context_ptr) }
 		mut results := unsafe { &[]BodyCalls(args.results_ptr) }
-		c.collect_bodies_range(*body_ids, *modules, *import_contexts, args.start, args.end, mut
-			*results)
+		if args.scope_enabled {
+			c.collect_bodies_scoped_batches(*body_ids, *modules, *import_contexts, args.start,
+				args.end, mut *results)
+		} else {
+			c.collect_bodies_range(*body_ids, *modules, *import_contexts, args.start, args.end, mut
+				*results)
+		}
 		markused_worker_scope_leave(args.scope)
 		return unsafe { nil }
+	}
+}
+
+// collect_bodies_scoped_batches keeps call lists in the worker's result arena,
+// while repeatedly releasing the much larger checker and local-analysis
+// scratch state used to discover them.
+fn (c &CallCollector) collect_bodies_scoped_batches(body_ids []int, body_modules []string, body_import_contexts []int, range_start int, range_end int, mut results []BodyCalls) {
+	item_count := range_end - range_start
+	if item_count <= 0 {
+		return
+	}
+	n_batches := if item_count < scoped_markused_worker_batches {
+		item_count
+	} else {
+		scoped_markused_worker_batches
+	}
+	for batch_idx in 0 .. n_batches {
+		start := range_start + item_count * batch_idx / n_batches
+		end := range_start + item_count * (batch_idx + 1) / n_batches
+		scratch_scope := markused_worker_scope_begin(true)
+		batch_tc := c.tc.fork_for_parallel_transform(c.a)
+		batch := c.fork_with_tc(batch_tc)
+		batch.collect_bodies_range(body_ids, body_modules, body_import_contexts, start, end, mut
+			results)
+		markused_worker_scope_leave(scratch_scope)
+		for result_idx in start .. end {
+			results[result_idx] = clone_body_calls(results[result_idx])
+		}
+		markused_worker_scope_free(scratch_scope)
 	}
 }
 
@@ -110,6 +145,7 @@ fn precollect_body_calls(collector CallCollector, body_ids []int, body_modules [
 		}
 		bounds := markused_chunk_bounds(collector.a, body_ids, n_jobs)
 		thread_count := n_jobs - 1
+		scope_workers := collector.tc.scoped_parallel_workers_enabled()
 		// Worker collectors share the read-only lookup maps but carry a forked
 		// TypeChecker with a private type_cache (the only state the collectors
 		// mutate through the checker).
@@ -128,7 +164,7 @@ fn precollect_body_calls(collector CallCollector, body_ids []int, body_modules [
 			results_ptr:        unsafe { voidptr(&results) }
 			start:              bounds[0]
 			end:                bounds[1]
-			scope_enabled:      false
+			scope_enabled:      scope_workers
 		}
 		for ci in 0 .. thread_count {
 			args << MarkusedChunkArgs{
@@ -139,7 +175,7 @@ fn precollect_body_calls(collector CallCollector, body_ids []int, body_modules [
 				results_ptr:        unsafe { voidptr(&results) }
 				start:              bounds[ci + 1]
 				end:                bounds[ci + 2]
-				scope_enabled:      true
+				scope_enabled:      scope_workers
 			}
 		}
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
@@ -153,14 +189,14 @@ fn precollect_body_calls(collector CallCollector, body_ids []int, body_modules [
 			}
 		}
 		ast.worker_pool.run(tasks)
-		for ci in 0 .. thread_count {
-			if args[ci + 1].scope == unsafe { nil } {
+		for ci in 0 .. n_jobs {
+			if args[ci].scope == unsafe { nil } {
 				continue
 			}
-			for result_idx in args[ci + 1].start .. args[ci + 1].end {
+			for result_idx in args[ci].start .. args[ci].end {
 				results[result_idx] = clone_body_calls(results[result_idx])
 			}
-			markused_worker_scope_free(args[ci + 1].scope)
+			markused_worker_scope_free(args[ci].scope)
 		}
 		return results
 	}

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1153,10 +1153,10 @@ fn (t &Transformer) is_known_operator_fn_name(name string, require_used bool) bo
 	if !t.is_known_fn_name(name) {
 		return false
 	}
-	if !require_used || t.used_fns.len == 0 {
+	if !require_used || !t.has_any_used_fns() {
 		return true
 	}
-	return name in t.used_fns || c_name(name) in t.used_fns
+	return t.used_fn_contains_name(name) || t.used_fn_contains_name(c_name(name))
 }
 
 // has_struct_operator_fn reports whether has struct operator fn applies in transform.
@@ -2926,7 +2926,7 @@ pub fn (mut t Transformer) make_call_typed(fn_name string, args []flat.NodeId, t
 }
 
 fn (mut t Transformer) mark_fn_used(fn_name string) {
-	if fn_name.len == 0 || t.used_fns.len == 0 {
+	if fn_name.len == 0 || !t.has_any_used_fns() {
 		return
 	}
 	t.mark_used_fn_key(fn_name)

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -95,6 +95,21 @@ fn test_parallel_worker_reuses_prebuilt_call_param_decl_index() {
 	assert params[0] is types.String
 }
 
+fn test_absorb_scoped_batch_replays_overlay_into_master_checker() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.begin_sparse_transform_node_caches(0)
+	mut master := new_transformer(mut a, &tc, map[string]bool{})
+	batch_tc := tc.fork_for_parallel_transform(&a)
+	mut batch := master.fork_scoped_batch_worker(&a, batch_tc)
+	batch.tc.fork_overlay.resolved_call_names[10] = 'main.resolved_call'
+	batch.tc.fork_overlay.resolved_fn_values[11] = 'main.resolved_fn_value'
+
+	master.absorb_scoped_batch(batch, unsafe { nil }, a.nodes.len)
+	assert tc.sparse_resolved_call_names[10] == 'main.resolved_call'
+	assert tc.sparse_resolved_fn_values[11] == 'main.resolved_fn_value'
+}
+
 fn test_multi_return_selector_suffix_does_not_match_free_fn() {
 	mut a := flat.FlatAst.new()
 	receiver_id := a.add_node(flat.Node{

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -110,6 +110,25 @@ fn test_absorb_scoped_batch_replays_overlay_into_master_checker() {
 	assert tc.sparse_resolved_fn_values[11] == 'main.resolved_fn_value'
 }
 
+fn test_frozen_interface_boxed_types_are_read_only_in_skip_generics_workers() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut master := new_transformer(mut a, &tc, map[string]bool{})
+	master.skip_generics = true
+	master.interface_boxed_types['main.Reader\nmain.Source'] = true
+	master.interface_boxed_types_done = true
+	master.interface_boxed_types_frozen = true
+	mut worker := master.fork_worker(&a, tc.fork_for_parallel_transform(&a))
+
+	worker.mark_interface_boxed_type('main.Reader', 'main.Other')
+	assert 'main.Reader\nmain.Other' !in master.interface_boxed_types
+	assert 'main.Reader\nmain.Other' !in worker.interface_boxed_types
+
+	master.interface_boxed_types_frozen = false
+	master.mark_interface_boxed_type('main.Reader', 'main.Other')
+	assert master.interface_boxed_types['main.Reader\nmain.Other']
+}
+
 fn test_multi_return_selector_suffix_does_not_match_free_fn() {
 	mut a := flat.FlatAst.new()
 	receiver_id := a.add_node(flat.Node{

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -623,6 +623,7 @@ fn (mut t Transformer) collect_interface_boxed_types() {
 		t.tc.cur_module = old_tc_module
 	}
 	t.collect_interface_boxed_types_range(0, t.a.nodes.len)
+	t.interface_boxed_types_frozen = true
 }
 
 fn (mut t Transformer) collect_interface_boxed_types_range(start int, end int) {
@@ -1375,7 +1376,7 @@ fn (t &Transformer) interface_literal_name(name string) ?string {
 }
 
 fn (mut t Transformer) mark_interface_boxed_type(iface_name string, concrete_type string) {
-	if iface_name.len == 0 || concrete_type.len == 0 {
+	if t.interface_boxed_types_frozen || iface_name.len == 0 || concrete_type.len == 0 {
 		return
 	}
 	mut iface_names := [iface_name]

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -66,7 +66,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 	mut recorded_call_sites := map[int]bool{}
 	mut changed := true
 	mut scan_start := 0
-	mut used_fns_at_scan := t.used_fns.len
+	mut used_fns_at_scan := t.used_fn_count()
 	t.in_monomorphize_scan = true
 	defer {
 		t.in_monomorphize_scan = false
@@ -79,7 +79,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 		// or comptime unroll now calls it); its subtree left the ignore set
 		// and must be scanned too, or its generic calls stay unspecialized.
 		mut rescan := []int{}
-		if scan_start > 0 && t.used_fns.len != used_fns_at_scan {
+		if scan_start > 0 && t.used_fn_count() != used_fns_at_scan {
 			new_ignored := t.monomorphize_ignored_nodes(decls)
 			for i in 0 .. scan_start {
 				if i < ignored_nodes.len && ignored_nodes[i] && !(i < new_ignored.len
@@ -89,7 +89,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 			}
 			ignored_nodes = unsafe { new_ignored }
 		}
-		used_fns_at_scan = t.used_fns.len
+		used_fns_at_scan = t.used_fn_count()
 		for scan_idx in 0 .. rescan.len + (node_count - scan_start) {
 			i := if scan_idx < rescan.len {
 				rescan[scan_idx]
@@ -438,7 +438,8 @@ fn (mut t Transformer) specialize_generic_struct_methods(struct_decls map[string
 					// function: markused seeds the concrete instance key (`Box[int].report`) into
 					// `used_fns` per reachable function, so one used only in dead code is skipped —
 					// its body may be invalid for that type argument and would fail C compilation.
-					if t.used_fns.len > 0 && mvkey !in t.used_fns && c_name(mvkey) !in t.used_fns {
+					if t.has_any_used_fns() && !t.used_fn_contains_name(mvkey)
+						&& !t.used_fn_contains_name(c_name(mvkey)) {
 						continue
 					}
 				}
@@ -490,7 +491,7 @@ fn (t &Transformer) generic_struct_method_used_for_spec(spec string, decl Generi
 		}
 	}
 	for alias in aliases {
-		if alias in t.used_fns {
+		if t.used_fn_contains_name(alias) {
 			return true
 		}
 	}
@@ -621,7 +622,13 @@ fn (mut t Transformer) collect_interface_boxed_types() {
 		t.tc.cur_file = old_tc_file
 		t.tc.cur_module = old_tc_module
 	}
-	for idx, node in t.a.nodes {
+	t.collect_interface_boxed_types_range(0, t.a.nodes.len)
+}
+
+fn (mut t Transformer) collect_interface_boxed_types_range(start int, end int) {
+	limit := if end < t.a.nodes.len { end } else { t.a.nodes.len }
+	for idx in start .. limit {
+		node := t.a.nodes[idx]
 		if node.kind == .file {
 			t.cur_file = node.value
 			t.tc.cur_file = node.value
@@ -3519,6 +3526,10 @@ fn (mut t Transformer) clear_resolved_call(id flat.NodeId) {
 		return
 	}
 	idx := int(id)
+	if t.tc.parallel_check_sparse && idx >= t.tc.resolved_call_names.len {
+		t.tc.sparse_resolved_call_names.delete(idx)
+		return
+	}
 	if idx >= 0 && idx < t.tc.resolved_call_names.len {
 		t.tc.resolved_call_names[idx] = ''
 		t.tc.resolved_call_set[idx] = false

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -134,6 +134,7 @@ mut:
 	call_param_types_decl_index   map[string]FnParamDeclRef
 	call_param_types_index_ready  bool
 	used_fns                      map[string]bool
+	used_fns_parent               &map[string]bool = unsafe { nil }
 	comptime_reflected_params     map[string][]ParamMeta
 	// sum_eq_types records sum types whose deep-equality helper fn
 	// (__v3_sum_eq_<name>) is called somewhere, keyed by sum name with the
@@ -168,7 +169,9 @@ mut:
 	// ignored_comptime_for_nodes marks source `$for` subtrees replaced by concrete
 	// unrolled nodes. Keeping the marker outside the shared flat AST lets parallel
 	// workers record their own discarded nodes without racing.
-	ignored_comptime_for_nodes []bool
+	ignored_comptime_for_nodes  []bool
+	ignored_comptime_for_log    []int
+	ignored_comptime_log_active bool
 	// cloning_generic_fn_depth > 0 while a generic specialization is cloned with a live,
 	// seeded parameter scope. Ident inference should use that scope rather than scan annotations.
 	cloning_generic_fn_depth int
@@ -232,6 +235,11 @@ mut:
 	worker_scope            voidptr
 	scoped_base_nodes       int = -1
 	scoped_owned_base_nodes map[int]bool
+	scoped_owned_base_log   []int
+	scoped_base_log_active  bool
+	retain_worker_results   bool
+	retained_worker_regions []ScopedTransformRegion
+	stage_scope             voidptr
 }
 
 // AliasCache memoizes normalize_type_alias results. It lives on the heap so the
@@ -323,6 +331,16 @@ struct FnParamDeclRef {
 	module string
 }
 
+// ScopedTransformRegion describes AST payloads owned by one retained worker
+// arena. The driver canonicalizes this region before releasing the arena.
+pub struct ScopedTransformRegion {
+pub:
+	scope      voidptr
+	new_start  int
+	new_end    int
+	base_nodes []int
+}
+
 // --- entry point ---
 
 // transform supports transform handling for transform.
@@ -363,36 +381,37 @@ pub fn transform_with_used_opt_config_scoped_workers(mut a flat.FlatAst, tc &typ
 // transform_with_used_opt_config_scoped_workers_checked also returns diagnostics selected while
 // normal comptime reflection loops are unrolled.
 pub fn transform_with_used_opt_config_scoped_workers_checked(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool, scope_parallel_workers bool) (map[string]bool, bool, []string) {
+	augmented, was_parallel, errors, _, _ := transform_with_used_opt_config_scoped_workers_checked_impl(mut a,
+		tc, used_fns, want_parallel, skip_generics, scope_parallel_workers, false, unsafe { nil })
+	return augmented, was_parallel, errors
+}
+
+// transform_with_used_opt_config_scoped_workers_checked_owned additionally
+// reports source AST nodes whose owned payloads were replaced during a scoped
+// transform, so the driver can promote exactly those escaping values.
+pub fn transform_with_used_opt_config_scoped_workers_checked_owned(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool, scope_parallel_workers bool, stage_scope voidptr) (map[string]bool, bool, []string, []int, []ScopedTransformRegion) {
+	return transform_with_used_opt_config_scoped_workers_checked_impl(mut a, tc, used_fns,
+		want_parallel, skip_generics, scope_parallel_workers, true, stage_scope)
+}
+
+fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool, scope_parallel_workers bool, retain_worker_results bool, stage_scope voidptr) (map[string]bool, bool, []string, []int, []ScopedTransformRegion) {
 	mut t := new_transformer(mut a, tc, used_fns)
 	t.skip_generics = skip_generics
 	t.scope_parallel_workers = scope_parallel_workers
+	t.retain_worker_results = retain_worker_results
+	t.stage_scope = stage_scope
+	if scope_parallel_workers {
+		t.scoped_base_nodes = t.a.nodes.len
+	}
 	t.prepare()
 	t.cache_comptime_param_reflection_metadata()
 	if want_parallel {
-		// Transform roughly grows the node/children arrays by ~75%. Reserve that capacity
-		// up front so they don't double past it (the parsed AST already overshoots to the
-		// next power of two, wasting ~40MB, and each doubling briefly holds both the old and
-		// new arrays — the dominant peak-RSS contributor under -gc none). The serial path is
-		// latency-sensitive and does not clone worker ASTs, so let it grow naturally.
-		// Nodes grow a bit less than children on large compiler inputs. Keeping their
-		// reserve below the next power-of-two cliff avoids retaining a mostly-empty
-		// doubled nodes array through annotate/CGen.
-		// The shared-base parallel path partitions this headroom into per-worker
-		// append regions, so it reserves ~2x the expected growth: untouched
-		// capacity pages are never written, so RSS does not grow with the
-		// extra reserve.
-		nodes_factor_num, nodes_factor_den := if skip_generics { 7, 3 } else { 5, 3 }
-		children_factor_num, children_factor_den := if skip_generics { 5, 2 } else { 7, 4 }
-		reserve_nodes := a.nodes.len * nodes_factor_num / nodes_factor_den - a.nodes.cap
-		if reserve_nodes > 0 {
-			unsafe { a.nodes.grow_cap(reserve_nodes) }
-		}
-		reserve_children := a.children.len * children_factor_num / children_factor_den - a.children.cap
-		if reserve_children > 0 {
-			unsafe { a.children.grow_cap(reserve_children) }
-		}
+		reserve_parallel_transform_ast(mut a, skip_generics)
 	}
 	base_node_count := t.a.nodes.len
+	if scope_parallel_workers {
+		t.scoped_base_nodes = base_node_count
+	}
 	t.transformed_fns = []bool{len: t.a.nodes.len}
 	was_parallel := t.transform_all_dispatch(want_parallel)
 	t.apply_ignored_comptime_for_nodes()
@@ -410,7 +429,51 @@ pub fn transform_with_used_opt_config_scoped_workers_checked(mut a flat.FlatAst,
 	t.transform_late_used_fn_bodies(late_names, base_node_count)
 	t.run_sum_eq_synthesis_rounds(base_node_count)
 	t.apply_ignored_comptime_for_nodes()
-	return t.used_fns, was_parallel, t.monomorph_errors
+	return t.used_fns, was_parallel, t.monomorph_errors, t.scoped_owned_base_nodes.keys(), t.retained_worker_regions
+}
+
+// reserve_parallel_transform_ast reserves persistent append regions before a
+// disposable transform arena is entered.
+pub fn reserve_parallel_transform_ast(mut a flat.FlatAst, skip_generics bool) {
+	// The shared-base parallel path partitions this headroom between workers.
+	// Untouched virtual pages do not contribute to resident memory.
+	nodes_factor_num, nodes_factor_den := if skip_generics { 7, 3 } else { 5, 3 }
+	children_factor_num, children_factor_den := if skip_generics { 5, 2 } else { 7, 4 }
+	reserve_nodes := a.nodes.len * nodes_factor_num / nodes_factor_den - a.nodes.cap
+	if reserve_nodes > 0 {
+		unsafe { a.nodes.grow_cap(reserve_nodes) }
+	}
+	reserve_children := a.children.len * children_factor_num / children_factor_den - a.children.cap
+	if reserve_children > 0 {
+		unsafe { a.children.grow_cap(reserve_children) }
+	}
+}
+
+// transform_worker_scope_begin starts a helper-local disposable arena in
+// prealloc self-host builds. Ordinary builds retain their existing allocator.
+fn transform_worker_scope_begin(enabled bool) voidptr {
+	$if prealloc {
+		if enabled {
+			return unsafe { prealloc_scope_begin() }
+		}
+	}
+	return unsafe { nil }
+}
+
+fn transform_worker_scope_leave(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_leave(scope) }
+		}
+	}
+}
+
+fn transform_worker_scope_free(scope voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			unsafe { prealloc_scope_free_after(scope) }
+		}
+	}
 }
 
 // run_sum_eq_synthesis_rounds alternates sum-eq helper synthesis with the
@@ -635,10 +698,25 @@ fn (mut t Transformer) mark_fn_used_name(name string) {
 // mark_used_fn_key inserts one spelling into used_fns, recording first-time
 // insertions in used_fns_log while the late-used-fn-bodies pass is running.
 fn (mut t Transformer) mark_used_fn_key(key string) {
-	if t.used_fns_log_active && !t.used_fns[key] {
+	if t.used_fn_contains_name(key) {
+		return
+	}
+	if t.used_fns_log_active {
 		t.used_fns_log << key
 	}
 	t.used_fns[key] = true
+}
+
+fn (t &Transformer) has_any_used_fns() bool {
+	return t.used_fns.len > 0 || (!isnil(t.used_fns_parent) && t.used_fns_parent.len > 0)
+}
+
+fn (t &Transformer) used_fn_count() int {
+	return t.used_fns.len + if isnil(t.used_fns_parent) {
+		0
+	} else {
+		t.used_fns_parent.len
+	}
 }
 
 fn local_method_fn_name_needs_module_prefix(name string) bool {
@@ -785,6 +863,14 @@ fn (mut t Transformer) ignore_comptime_for_subtree(id flat.NodeId) {
 	if idx < 0 || idx >= t.a.nodes.len {
 		return
 	}
+	if t.ignored_comptime_log_active {
+		t.ignored_comptime_for_log << idx
+		node := t.a.nodes[idx]
+		for i in 0 .. node.children_count {
+			t.ignore_comptime_for_subtree(t.a.child(&node, i))
+		}
+		return
+	}
 	if t.ignored_comptime_for_nodes.len < t.a.nodes.len {
 		t.ignored_comptime_for_nodes << []bool{len: t.a.nodes.len - t.ignored_comptime_for_nodes.len}
 	}
@@ -832,7 +918,11 @@ fn (mut t Transformer) set_node_generic_params(idx int, gparams []string) {
 @[inline]
 fn (mut t Transformer) mark_scoped_owned_base_node(idx int) {
 	if t.scope_parallel_workers && idx >= 0 && idx < t.scoped_base_nodes {
-		t.scoped_owned_base_nodes[idx] = true
+		if t.scoped_base_log_active {
+			t.scoped_owned_base_log << idx
+		} else {
+			t.scoped_owned_base_nodes[idx] = true
+		}
 	}
 }
 
@@ -1586,7 +1676,7 @@ fn (mut t Transformer) transform_all_dispatch(want_parallel bool) bool {
 	// Collect source-level interface conversions before any worker rewrites its
 	// private AST. Equality and automatic string lowering can then generate the
 	// same bounded tag dispatch independently of worker scheduling.
-	t.collect_interface_boxed_types()
+	t.collect_interface_boxed_types_dispatch(want_parallel)
 	if !want_parallel {
 		t.transform_all()
 		return false
@@ -1605,6 +1695,33 @@ fn (mut t Transformer) transform_all_dispatch(want_parallel bool) bool {
 		t.transform_top_level_user_stmts()
 	}
 	return was_parallel
+}
+
+fn (mut t Transformer) collect_interface_boxed_types_dispatch(want_parallel bool) {
+	if t.interface_boxed_types_done {
+		return
+	}
+	if !want_parallel || !t.scope_parallel_workers {
+		t.collect_interface_boxed_types()
+		return
+	}
+	if t.collect_interface_boxed_types_parallel() {
+		return
+	}
+	t.tc.freeze_type_cache_for_forks()
+	scratch_scope := transform_worker_scope_begin(true)
+	scan_tc := t.tc.fork_for_parallel_transform(t.a)
+	mut scan := t.fork_scan_worker(scan_tc)
+	scan.collect_interface_boxed_types()
+	transform_worker_scope_leave(scratch_scope)
+	mut boxed_types := map[string]bool{}
+	for key, value in scan.interface_boxed_types {
+		boxed_types[key.clone()] = value
+	}
+	t.interface_boxed_types = boxed_types.move()
+	t.interface_boxed_types_done = true
+	transform_worker_scope_free(scratch_scope)
+	t.tc.unfreeze_type_cache_after_forks()
 }
 
 fn (t &Transformer) has_fn_literal_nodes() bool {
@@ -1763,7 +1880,23 @@ fn (t &Transformer) clone_ast_base(base_nodes int, base_children int) &flat.Flat
 // per-function mutable state, helper-root tracking, used-fn additions, and
 // memoization caches are reset/private so the worker can run on its own thread.
 fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Transformer {
-	mut w := t.fork_program_view(ast, wtc, t.used_fns)
+	return t.fork_worker_config(ast, wtc, true)
+}
+
+fn (t &Transformer) fork_scoped_batch_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Transformer {
+	return t.fork_worker_config(ast, wtc, false)
+}
+
+fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker, copy_used_fns bool) &Transformer {
+	used := if copy_used_fns {
+		t.used_fns
+	} else {
+		map[string]bool{}
+	}
+	mut w := t.fork_program_view(ast, wtc, used)
+	if !copy_used_fns {
+		w.used_fns_parent = unsafe { &t.used_fns }
+	}
 	w.alias_cache = &AliasCache{}
 	w.sum_cache = &AliasCache{}
 	w.generic_unresolved_cache = &GenericUnresolvedCache{}
@@ -1797,7 +1930,6 @@ fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Tran
 	// start. Keep the shared read-only index and signature cache; rebuilding
 	// either would read fn_decl nodes while shared-base workers rewrite them.
 	// Misses stay private because unknown call names can still be queried.
-	w.call_param_types_decl_misses = t.call_param_types_decl_misses.clone()
 	w.node_module_map_cache = []string{}
 	w.node_module_map_nodes = -1
 	w.var_types = []VarTypeBinding{}
@@ -1811,29 +1943,27 @@ fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Tran
 	w.escaping_amp_ptrs = map[string]bool{}
 	w.escaping_amp_sources = map[string]bool{}
 	w.heaped_amp_locals = map[string]bool{}
-	w.generic_specialization_args = t.generic_specialization_args.clone()
 	w.generic_fn_specs_in_progress = map[string]bool{}
 	w.monomorph_errors = []string{}
 	w.monomorph_error_seen = map[string]bool{}
-	w.used_fns = t.used_fns.clone()
 	// Fields added after the fork/merge machinery was first written. They are
 	// mutated during body transforms (or lazily built), so each worker needs
 	// private backing storage — a plain struct copy would share the master's.
 	w.stringify_stack = []string{}
-	w.interface_var_concrete_types = t.interface_var_concrete_types.clone()
-	w.interface_boxed_types = t.interface_boxed_types.clone()
 	w.interface_boxed_types_done = true
-	w.sum_eq_types = t.sum_eq_types.clone()
-	w.sum_eq_synthesized = t.sum_eq_synthesized.clone()
 	w.sum_eq_helper_module = ''
 	w.generic_receiver_methods_by_name = map[string][]string{}
 	w.used_fns_log = []string{}
 	w.used_fns_log_active = false
 	w.deferred_base_writes = []DeferredBaseWrite{}
 	w.ignored_comptime_for_nodes = []bool{}
+	w.ignored_comptime_for_log = []int{}
+	w.ignored_comptime_log_active = false
 	w.worker_scope = unsafe { nil }
 	w.scoped_base_nodes = t.shared_base_nodes
 	w.scoped_owned_base_nodes = map[int]bool{}
+	w.scoped_owned_base_log = []int{}
+	w.scoped_base_log_active = false
 	// Workers do not record transformed fns (that would write the master's
 	// shared backing array); the master marks each worker's chunk items when it
 	// merges the worker.
@@ -1954,9 +2084,17 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		call_param_types_index_ready:     t.call_param_types_index_ready
 		comptime_reflected_params:        t.comptime_reflected_params.clone()
 		used_struct_operator_fns:         t.used_struct_operator_fns
-		generic_specialization_args:      t.generic_specialization_args.clone()
+		generic_specialization_args:      if t.skip_generics {
+			t.generic_specialization_args
+		} else {
+			t.generic_specialization_args.clone()
+		}
 		interface_var_concrete_types:     t.interface_var_concrete_types.clone()
-		interface_boxed_types:            t.interface_boxed_types.clone()
+		interface_boxed_types:            if t.skip_generics {
+			t.interface_boxed_types
+		} else {
+			t.interface_boxed_types.clone()
+		}
 		sum_eq_types:                     t.sum_eq_types.clone()
 		sum_eq_synthesized:               t.sum_eq_synthesized.clone()
 		used_fns:                         used_fns.clone()
@@ -1979,6 +2117,8 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		shared_base_nodes:                t.shared_base_nodes
 		scoped_base_nodes:                t.scoped_base_nodes
 		scope_parallel_workers:           t.scope_parallel_workers
+		retain_worker_results:            t.retain_worker_results
+		stage_scope:                      t.stage_scope
 	}
 }
 
@@ -1986,7 +2126,7 @@ fn (mut t Transformer) merge_worker_used_fns(w &Transformer) {
 	scoped := w.worker_scope != unsafe { nil }
 	for name, used in w.used_fns {
 		if used {
-			owned_name := if scoped { name.clone() } else { name }
+			owned_name := if scoped && !t.retain_worker_results { name.clone() } else { name }
 			t.used_fns[owned_name] = true
 		}
 	}
@@ -2003,6 +2143,18 @@ fn (mut t Transformer) merge_worker_used_fns(w &Transformer) {
 			}
 		}
 	}
+}
+
+fn (mut t Transformer) clone_sum_eq_types_owned() {
+	mut cloned := map[string]SumEqRequest{}
+	for name, req in t.sum_eq_types {
+		cloned[name.clone()] = SumEqRequest{
+			module:        req.module.clone()
+			file:          req.file.clone()
+			helper_module: req.helper_module.clone()
+		}
+	}
+	t.sum_eq_types = cloned.move()
 }
 
 @[inline]
@@ -2030,7 +2182,8 @@ fn (mut t Transformer) clone_scoped_worker_node(idx int, scope voidptr) {
 	}
 	old_params := node.generic_params()
 	if old_params.len > 0 {
-		mut needs_owned_params := transform_scope_owns(scope, old_params.data)
+		mut needs_owned_params := transform_scope_owns(scope, node.payload)
+			|| transform_scope_owns(scope, old_params.data)
 		if !needs_owned_params {
 			for param in old_params {
 				if param.len > 0 && transform_scope_owns(scope, param.str) {
@@ -2100,7 +2253,7 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 			if t.a.nodes[k].children_start >= base_children {
 				t.a.nodes[k] = t.a.nodes[k].with_shifted_children(child_shift)
 			}
-			if w.worker_scope != unsafe { nil } {
+			if w.worker_scope != unsafe { nil } && !t.retain_worker_results {
 				t.clone_scoped_worker_node(k, w.worker_scope)
 			}
 		}
@@ -2116,12 +2269,15 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 		if it.fn_idx >= 0 && it.fn_idx < t.transformed_fns.len {
 			t.transformed_fns[it.fn_idx] = true
 		}
-		if w.worker_scope != unsafe { nil } {
+		if w.worker_scope != unsafe { nil } && !t.retain_worker_results {
 			t.clone_scoped_worker_node(it.fn_idx, w.worker_scope)
 		}
 	}
-	if w.worker_scope != unsafe { nil } {
+	if w.worker_scope != unsafe { nil } && !t.retain_worker_results {
 		for idx in w.scoped_owned_base_nodes.keys() {
+			t.clone_scoped_worker_node(idx, w.worker_scope)
+		}
+		for idx in w.scoped_owned_base_log {
 			t.clone_scoped_worker_node(idx, w.worker_scope)
 		}
 	}
@@ -2133,17 +2289,29 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 	if !isnil(w.tc.fork_overlay) {
 		for idx, name in w.tc.fork_overlay.resolved_call_names {
 			shifted := if idx >= base_nodes { idx + int(node_shift) } else { idx }
-			owned_name := if w.worker_scope != unsafe { nil } { name.clone() } else { name }
+			owned_name := if w.worker_scope != unsafe { nil } && !t.retain_worker_results {
+				name.clone()
+			} else {
+				name
+			}
 			t.set_resolved_call_entry(shifted, owned_name)
 		}
 		for idx, name in w.tc.fork_overlay.resolved_fn_values {
 			shifted := if idx >= base_nodes { idx + int(node_shift) } else { idx }
-			owned_name := if w.worker_scope != unsafe { nil } { name.clone() } else { name }
+			owned_name := if w.worker_scope != unsafe { nil } && !t.retain_worker_results {
+				name.clone()
+			} else {
+				name
+			}
 			t.set_resolved_fn_value_entry(shifted, owned_name)
 		}
 	}
 	for message in w.monomorph_errors {
-		owned_message := if w.worker_scope != unsafe { nil } { message.clone() } else { message }
+		owned_message := if w.worker_scope != unsafe { nil } && !t.retain_worker_results {
+			message.clone()
+		} else {
+			message
+		}
 		t.record_monomorph_error(owned_message)
 	}
 	if w.ignored_comptime_for_nodes.len > 0 {
@@ -2160,9 +2328,24 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 			}
 		}
 	}
+	if w.ignored_comptime_for_log.len > 0 {
+		if t.ignored_comptime_for_nodes.len < t.a.nodes.len {
+			t.ignored_comptime_for_nodes << []bool{len: t.a.nodes.len - t.ignored_comptime_for_nodes.len}
+		}
+		for idx in w.ignored_comptime_for_log {
+			shifted := if idx >= base_nodes { idx + int(node_shift) } else { idx }
+			if shifted >= 0 && shifted < t.ignored_comptime_for_nodes.len {
+				t.ignored_comptime_for_nodes[shifted] = true
+			}
+		}
+	}
 }
 
 fn (mut t Transformer) set_resolved_call_entry(idx int, name string) {
+	if t.tc.parallel_check_sparse && idx >= t.tc.resolved_call_names.len {
+		t.tc.sparse_resolved_call_names[idx] = t.tc.canonical_symbol(name)
+		return
+	}
 	for t.tc.resolved_call_names.len <= idx {
 		t.tc.resolved_call_names << ''
 		t.tc.resolved_call_set << false
@@ -2172,6 +2355,10 @@ fn (mut t Transformer) set_resolved_call_entry(idx int, name string) {
 }
 
 fn (mut t Transformer) set_resolved_fn_value_entry(idx int, name string) {
+	if t.tc.parallel_check_sparse && idx >= t.tc.resolved_fn_value_names.len {
+		t.tc.sparse_resolved_fn_values[idx] = t.tc.canonical_symbol(name)
+		return
+	}
 	for t.tc.resolved_fn_value_names.len <= idx {
 		t.tc.resolved_fn_value_names << ''
 		t.tc.resolved_fn_value_set << false
@@ -2496,7 +2683,7 @@ fn (t &Transformer) late_name_was_used_before(name string, log_start int) bool {
 }
 
 fn (t &Transformer) late_spelling_was_used_before(spelling string, log_start int) bool {
-	if !t.used_fns[spelling] {
+	if !t.used_fn_contains_name(spelling) {
 		return false
 	}
 	for i in log_start .. t.used_fns_log.len {
@@ -2552,11 +2739,20 @@ fn late_used_fn_contains_in_module(used map[string]bool, name string, module_nam
 }
 
 fn (t &Transformer) has_used_fn_filter() bool {
-	return t.used_fns.len > 0 && t.used_fns['main']
+	return t.has_any_used_fns() && t.used_fn_contains_name('main')
 }
 
 fn (t &Transformer) used_fn_contains_name(name string) bool {
-	return name.len > 0 && t.used_fns[name]
+	if name.len == 0 {
+		return false
+	}
+	if t.used_fns[name] {
+		return true
+	}
+	if isnil(t.used_fns_parent) {
+		return false
+	}
+	return unsafe { t.used_fns_parent[name] }
 }
 
 fn (t &Transformer) used_fn_contains_in_module(name string, module_name string) bool {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -146,6 +146,7 @@ mut:
 	sum_eq_helper_module         string
 	interface_boxed_types        map[string]bool
 	interface_boxed_types_done   bool
+	interface_boxed_types_frozen bool
 	interface_var_concrete_types map[string]string
 	// used_struct_operator_fns holds the callee names of direct calls seen during
 	// monomorphize. Infix operators on generic instances are lowered to direct calls
@@ -1720,6 +1721,7 @@ fn (mut t Transformer) collect_interface_boxed_types_dispatch(want_parallel bool
 	}
 	t.interface_boxed_types = boxed_types.move()
 	t.interface_boxed_types_done = true
+	t.interface_boxed_types_frozen = true
 	transform_worker_scope_free(scratch_scope)
 	t.tc.unfreeze_type_cache_after_forks()
 }
@@ -1951,6 +1953,7 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 	// private backing storage — a plain struct copy would share the master's.
 	w.stringify_stack = []string{}
 	w.interface_boxed_types_done = true
+	w.interface_boxed_types_frozen = t.interface_boxed_types_frozen
 	w.sum_eq_helper_module = ''
 	w.generic_receiver_methods_by_name = map[string][]string{}
 	w.used_fns_log = []string{}
@@ -2034,6 +2037,7 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 	w.stringify_stack = []string{}
 	w.interface_boxed_types = map[string]bool{}
 	w.interface_boxed_types_done = false
+	w.interface_boxed_types_frozen = false
 	w.generic_receiver_methods_by_name = map[string][]string{}
 	w.used_fns_log = []string{}
 	w.used_fns_log_active = false
@@ -2057,6 +2061,8 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 // state, so adding a mutable Transformer field cannot silently share its backing
 // storage with a helper thread.
 fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker, used_fns map[string]bool) Transformer {
+	// The pre-scan freezes the boxed-type set before skip-generics workers
+	// start, so sharing it below is read-only and avoids one map clone per worker.
 	return Transformer{
 		a:                                ast
 		tc:                               wtc
@@ -2090,11 +2096,13 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 			t.generic_specialization_args.clone()
 		}
 		interface_var_concrete_types:     t.interface_var_concrete_types.clone()
-		interface_boxed_types:            if t.skip_generics {
+		interface_boxed_types:            if t.skip_generics && t.interface_boxed_types_frozen {
 			t.interface_boxed_types
 		} else {
 			t.interface_boxed_types.clone()
 		}
+		interface_boxed_types_done:       t.interface_boxed_types_done
+		interface_boxed_types_frozen:     t.interface_boxed_types_frozen
 		sum_eq_types:                     t.sum_eq_types.clone()
 		sum_eq_synthesized:               t.sum_eq_synthesized.clone()
 		used_fns:                         used_fns.clone()

--- a/vlib/v3/transform/transform_parallel_d_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_d_v3_no_parallel.v
@@ -1,5 +1,11 @@
 module transform
 
+// collect_interface_boxed_types_parallel keeps the interface scan serial when
+// v3 is built with the internal `v3_no_parallel` define.
+fn (mut t Transformer) collect_interface_boxed_types_parallel() bool {
+	return false
+}
+
 // run_parallel_transform falls back to the serial transform when v3 is built
 // with the internal `v3_no_parallel` define.
 fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, _ int, _ int) bool {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -253,12 +253,22 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 		t.deferred_base_writes << write
 	}
 	t.clone_deferred_worker_writes_from(deferred_start)
-	if !isnil(batch.tc.fork_overlay) && !isnil(t.tc.fork_overlay) {
+	if !isnil(batch.tc.fork_overlay) {
 		for idx, name in batch.tc.fork_overlay.resolved_call_names {
-			t.tc.fork_overlay.resolved_call_names[idx] = name.clone()
+			owned_name := name.clone()
+			if isnil(t.tc.fork_overlay) {
+				t.set_resolved_call_entry(idx, owned_name)
+			} else {
+				t.tc.fork_overlay.resolved_call_names[idx] = owned_name
+			}
 		}
 		for idx, name in batch.tc.fork_overlay.resolved_fn_values {
-			t.tc.fork_overlay.resolved_fn_values[idx] = name.clone()
+			owned_name := name.clone()
+			if isnil(t.tc.fork_overlay) {
+				t.set_resolved_fn_value_entry(idx, owned_name)
+			} else {
+				t.tc.fork_overlay.resolved_fn_values[idx] = owned_name
+			}
 		}
 	}
 	if batch.ignored_comptime_for_nodes.len > 0 {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -167,6 +167,7 @@ fn (mut t Transformer) collect_interface_boxed_types_parallel() bool {
 		}
 		t.interface_boxed_types = boxed_types.move()
 		t.interface_boxed_types_done = true
+		t.interface_boxed_types_frozen = true
 		return true
 	}
 }

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -15,8 +15,9 @@ const max_parallel_transform_jobs = 6
 // Shared-base (clone-free) transform: workers share the master arrays and
 // append into pre-partitioned capacity regions, so extra threads cost no
 // clone memory; cap by core count only.
-const max_shared_transform_jobs = 10
-const scoped_transform_worker_batches = 5
+const max_shared_transform_jobs = 7
+const scoped_transform_worker_batches = 24
+const scoped_transform_master_batches = 24
 
 $if !windows {
 	// TransformChunkArgs is the payload handed to each persistent worker.
@@ -40,8 +41,13 @@ $if !windows {
 		a := unsafe { &SharedChunkArgs(arg) }
 		mut w := unsafe { &Transformer(a.worker) }
 		items := unsafe { &[]FnWorkItem(a.items_ptr) }
-		if w.scope_parallel_workers && !a.is_master {
-			w.transform_scoped_helper_batches(*items)
+		if w.scope_parallel_workers && (!a.is_master || w.retain_worker_results) {
+			max_batches := if a.is_master {
+				scoped_transform_master_batches
+			} else {
+				scoped_transform_worker_batches
+			}
+			w.transform_scoped_helper_batches(*items, max_batches)
 		} else {
 			w.transform_pure_items_serial(*items)
 		}
@@ -56,30 +62,112 @@ struct SharedChunkArgs {
 	is_master bool
 }
 
-// transform_worker_scope_begin starts a helper-local disposable arena in
-// prealloc self-host builds. Ordinary builds retain their existing allocator.
-fn transform_worker_scope_begin(enabled bool) voidptr {
-	$if prealloc {
-		if enabled {
-			return unsafe { prealloc_scope_begin() }
-		}
+$if !windows {
+	struct InterfaceBoxScanArgs {
+		source voidptr // &Transformer
+		start  int
+		end    int
+		file   string
+		module string
+	mut:
+		worker voidptr // &Transformer
+		scope  voidptr
 	}
-	return unsafe { nil }
+
+	fn interface_box_scan_thread(arg voidptr) voidptr {
+		mut a := unsafe { &InterfaceBoxScanArgs(arg) }
+		source := unsafe { &Transformer(a.source) }
+		scope := transform_worker_scope_begin(source.scope_parallel_workers)
+		wtc := source.tc.fork_for_parallel_transform(source.a)
+		mut scan := source.fork_scan_worker(wtc)
+		scan.cur_file = a.file
+		scan.cur_module = a.module
+		scan.tc.cur_file = a.file
+		scan.tc.cur_module = a.module
+		scan.interface_boxed_types_done = true
+		scan.collect_interface_boxed_types_range(a.start, a.end)
+		transform_worker_scope_leave(scope)
+		a.worker = voidptr(scan)
+		a.scope = scope
+		return unsafe { nil }
+	}
 }
 
-fn transform_worker_scope_leave(scope voidptr) {
-	$if prealloc {
-		if scope != unsafe { nil } {
-			unsafe { prealloc_scope_leave(scope) }
+// collect_interface_boxed_types_parallel scans independent AST ranges with
+// private checker context, then publishes only the small boxed-type set.
+fn (mut t Transformer) collect_interface_boxed_types_parallel() bool {
+	$if windows {
+		return false
+	} $else {
+		if t.a.nodes.len < 4096 {
+			return false
 		}
-	}
-}
-
-fn transform_worker_scope_free(scope voidptr) {
-	$if prealloc {
-		if scope != unsafe { nil } {
-			unsafe { prealloc_scope_free_after(scope) }
+		if isnil(t.a.worker_pool) {
+			t.a.worker_pool = workers.new(runtime.nr_jobs() - 1)
 		}
+		mut n_jobs := t.a.worker_pool.size() + 1
+		if n_jobs > max_shared_transform_jobs {
+			n_jobs = max_shared_transform_jobs
+		}
+		if n_jobs <= 1 {
+			return false
+		}
+		mut bounds := []int{len: n_jobs + 1}
+		for i in 0 .. n_jobs + 1 {
+			bounds[i] = t.a.nodes.len * i / n_jobs
+		}
+		mut files := []string{len: n_jobs}
+		mut modules := []string{len: n_jobs}
+		mut next_bound := 0
+		mut file := ''
+		mut module_name := ''
+		for idx, node in t.a.nodes {
+			for next_bound < n_jobs && bounds[next_bound] == idx {
+				files[next_bound] = file
+				modules[next_bound] = module_name
+				next_bound++
+			}
+			if node.kind == .file {
+				file = node.value
+				module_name = t.tc.file_modules[file] or { '' }
+			} else if node.kind == .module_decl {
+				module_name = node.value
+			}
+		}
+		mut args := []InterfaceBoxScanArgs{len: n_jobs}
+		mut tasks := []workers.Task{cap: n_jobs}
+		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
+		t.tc.freeze_type_cache_for_forks()
+		for i in 0 .. n_jobs {
+			args[i] = InterfaceBoxScanArgs{
+				source: voidptr(t)
+				start:  bounds[i]
+				end:    bounds[i + 1]
+				file:   files[i]
+				module: modules[i]
+			}
+			tasks << workers.Task{
+				run:        interface_box_scan_thread
+				arg:        unsafe { voidptr(&args[i]) }
+				force_sync: i == 0 || fail == 'transform:all' || fail == 'transform:interface:all'
+					|| fail == 'transform:interface:${i - 1}'
+			}
+		}
+		t.a.worker_pool.run(tasks)
+		t.tc.unfreeze_type_cache_after_forks()
+		mut boxed_types := map[string]bool{}
+		for arg in args {
+			scan := unsafe { &Transformer(arg.worker) }
+			for key, value in scan.interface_boxed_types {
+				if value {
+					boxed_types[key.clone()] = true
+				}
+			}
+			transform_worker_scope_free(arg.scope)
+		}
+		t.interface_boxed_types = boxed_types.move()
+		t.interface_boxed_types_done = true
+		return true
 	}
 }
 
@@ -91,20 +179,26 @@ fn (mut t Transformer) promote_scoped_node_to_current(idx int, scope voidptr) {
 		return
 	}
 	mut node := unsafe { &t.a.nodes[idx] }
-	if node.value.len > 0 && transform_scope_owns(scope, node.value.str) {
+	if node.value.len > 0 && (transform_scope_owns(scope, node.value.str)
+		|| transform_scope_owns(t.stage_scope, node.value.str)) {
 		node.value = node.value.clone()
 	}
-	if node.typ.len > 0 && transform_scope_owns(scope, node.typ.str) {
+	if node.typ.len > 0 && (transform_scope_owns(scope, node.typ.str)
+		|| transform_scope_owns(t.stage_scope, node.typ.str)) {
 		node.typ = node.typ.clone()
 	}
 	old_params := node.generic_params()
 	if old_params.len == 0 {
 		return
 	}
-	mut needs_owned_params := transform_scope_owns(scope, old_params.data)
+	mut needs_owned_params := transform_scope_owns(scope, node.payload)
+		|| transform_scope_owns(scope, old_params.data)
+		|| transform_scope_owns(t.stage_scope, node.payload)
+		|| transform_scope_owns(t.stage_scope, old_params.data)
 	if !needs_owned_params {
 		for param in old_params {
-			if param.len > 0 && transform_scope_owns(scope, param.str) {
+			if param.len > 0 && (transform_scope_owns(scope, param.str)
+				|| transform_scope_owns(t.stage_scope, param.str)) {
 				needs_owned_params = true
 				break
 			}
@@ -115,7 +209,8 @@ fn (mut t Transformer) promote_scoped_node_to_current(idx int, scope voidptr) {
 	}
 	mut params := []string{cap: old_params.len}
 	for param in old_params {
-		if param.len > 0 && transform_scope_owns(scope, param.str) {
+		if param.len > 0 && (transform_scope_owns(scope, param.str)
+			|| transform_scope_owns(t.stage_scope, param.str)) {
 			params << param.clone()
 		} else {
 			params << param
@@ -132,7 +227,11 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 	}
 	for idx in batch.scoped_owned_base_nodes.keys() {
 		t.promote_scoped_node_to_current(idx, scope)
-		t.scoped_owned_base_nodes[idx] = true
+		t.scoped_owned_base_log << idx
+	}
+	for idx in batch.scoped_owned_base_log {
+		t.promote_scoped_node_to_current(idx, scope)
+		t.scoped_owned_base_log << idx
 	}
 	for name in batch.used_fns_log {
 		t.used_fns[name.clone()] = true
@@ -149,6 +248,11 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 	for message in batch.monomorph_errors {
 		t.monomorph_errors << message.clone()
 	}
+	deferred_start := t.deferred_base_writes.len
+	for write in batch.deferred_base_writes {
+		t.deferred_base_writes << write
+	}
+	t.clone_deferred_worker_writes_from(deferred_start)
 	if !isnil(batch.tc.fork_overlay) && !isnil(t.tc.fork_overlay) {
 		for idx, name in batch.tc.fork_overlay.resolved_call_names {
 			t.tc.fork_overlay.resolved_call_names[idx] = name.clone()
@@ -158,30 +262,28 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 		}
 	}
 	if batch.ignored_comptime_for_nodes.len > 0 {
-		if t.ignored_comptime_for_nodes.len < batch.ignored_comptime_for_nodes.len {
-			t.ignored_comptime_for_nodes << []bool{len: batch.ignored_comptime_for_nodes.len - t.ignored_comptime_for_nodes.len}
-		}
 		for idx, ignored in batch.ignored_comptime_for_nodes {
 			if ignored {
-				t.ignored_comptime_for_nodes[idx] = true
+				t.ignored_comptime_for_log << idx
 			}
 		}
 	}
+	t.ignored_comptime_for_log << batch.ignored_comptime_for_log
 }
 
 // transform_scoped_helper_batches keeps one worker-pool dispatch but bounds
 // scratch lifetime within each helper. A fresh Transformer/TypeChecker fork per
 // batch prevents caches from retaining pointers into the released arena.
-fn (mut t Transformer) transform_scoped_helper_batches(items []FnWorkItem) {
+fn (mut t Transformer) transform_scoped_helper_batches(items []FnWorkItem, max_batches int) {
 	result_scope := transform_worker_scope_begin(true)
 	mut total_cost := i64(0)
 	for item in items {
 		total_cost += i64(item.cost) + 1
 	}
-	n_batches := if items.len < scoped_transform_worker_batches {
+	n_batches := if items.len < max_batches {
 		items.len
 	} else {
-		scoped_transform_worker_batches
+		max_batches
 	}
 	mut start := 0
 	mut consumed_cost := i64(0)
@@ -195,8 +297,10 @@ fn (mut t Transformer) transform_scoped_helper_batches(items []FnWorkItem) {
 		}
 		scratch_scope := transform_worker_scope_begin(true)
 		batch_tc := t.tc.fork_for_parallel_transform(t.a)
-		mut batch := t.fork_worker(t.a, batch_tc)
+		mut batch := t.fork_scoped_batch_worker(t.a, batch_tc)
 		batch.used_fns_log_active = true
+		batch.scoped_base_log_active = true
+		batch.ignored_comptime_log_active = true
 		new_node_start := t.a.nodes.len
 		batch.transform_pure_items_serial(items[start..end])
 		transform_worker_scope_leave(scratch_scope)
@@ -490,6 +594,24 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			t.a.children.cap = orig_children_cap
 			t.a.children.flags.clear(.nogrow)
 		}
+		if t.retain_worker_results && t.worker_scope != unsafe { nil } {
+			mut master_base_nodes := t.scoped_owned_base_nodes.keys()
+			master_base_nodes << t.scoped_owned_base_log
+			for write in t.deferred_base_writes {
+				master_base_nodes << write.idx
+			}
+			t.retained_worker_regions << ScopedTransformRegion{
+				scope:      t.worker_scope
+				new_start:  base_nodes
+				new_end:    t.a.nodes.len
+				base_nodes: master_base_nodes
+			}
+			for item in chunks[0] {
+				if item.fn_idx >= 0 && item.fn_idx < t.transformed_fns.len {
+					t.transformed_fns[item.fn_idx] = true
+				}
+			}
+		}
 		// Compact each worker region in fixed order (deterministic
 		// node numbering). merge_worker treats the region start exactly like a
 		// clone's base offset; compaction always moves content left, so the
@@ -498,16 +620,45 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			ww := unsafe { &Transformer(args[ci + 1].worker) }
 			t.merge_worker_used_fns(ww)
 			deferred_start := t.deferred_base_writes.len
+			merged_node_start := t.a.nodes.len
 			t.merge_worker(ww, chunks[ci + 1], node_starts[ci + 1], child_starts[ci + 1])
-			if ww.worker_scope != unsafe { nil } {
+			if ww.worker_scope != unsafe { nil } && !t.retain_worker_results {
 				t.clone_deferred_worker_writes_from(deferred_start)
 				transform_worker_scope_free(ww.worker_scope)
+			} else if ww.worker_scope != unsafe { nil } {
+				mut worker_base_nodes := ww.scoped_owned_base_nodes.keys()
+				worker_base_nodes << ww.scoped_owned_base_log
+				for item in chunks[ci + 1] {
+					worker_base_nodes << item.fn_idx
+				}
+				for write in ww.deferred_base_writes {
+					worker_base_nodes << write.idx
+				}
+				t.retained_worker_regions << ScopedTransformRegion{
+					scope:      ww.worker_scope
+					new_start:  merged_node_start
+					new_end:    t.a.nodes.len
+					base_nodes: worker_base_nodes
+				}
 			}
+		}
+		if t.retain_worker_results {
+			t.clone_sum_eq_types_owned()
 		}
 		t.base_write_intercept = false
 		t.defer_oor_writes = false
 		t.shared_base_nodes = -1
 		t.flush_deferred_base_writes()
+		if t.ignored_comptime_for_log.len > 0 {
+			if t.ignored_comptime_for_nodes.len < t.a.nodes.len {
+				t.ignored_comptime_for_nodes << []bool{len: t.a.nodes.len - t.ignored_comptime_for_nodes.len}
+			}
+			for idx in t.ignored_comptime_for_log {
+				if idx >= 0 && idx < t.ignored_comptime_for_nodes.len {
+					t.ignored_comptime_for_nodes[idx] = true
+				}
+			}
+		}
 		t.tc.unfreeze_type_cache_after_forks()
 		transform_worker_scope_free(setup_scope)
 		return any_started

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -940,8 +940,10 @@ pub fn (mut tc TypeChecker) reserve_transform_node_caches(n int) {
 }
 
 // reserve_scoped_transform_metadata keeps tables that receive escaping
-// transform additions in the compilation arena while scratch allocations use
-// a disposable arena.
+// transform additions in the compilation arena in the common case while
+// scratch allocations use a disposable arena. The signature maps are rebuilt
+// after promotion, so this headroom is an optimization rather than an
+// ownership requirement.
 pub fn (mut tc TypeChecker) reserve_scoped_transform_metadata(n int, signature_headroom int) {
 	_ = n
 	tc.fn_ret_types.reserve(u32(tc.fn_ret_types.len + signature_headroom))
@@ -956,6 +958,15 @@ pub fn (mut tc TypeChecker) reserve_scoped_transform_metadata(n int, signature_h
 		mut symbols := tc.symbols
 		symbols.reserve(signature_headroom)
 	}
+}
+
+// rebuild_scoped_transform_signature_maps moves signature-map backing storage
+// into the current arena after a disposable transform scope has been left.
+pub fn (mut tc TypeChecker) rebuild_scoped_transform_signature_maps() {
+	tc.fn_ret_types = tc.fn_ret_types.clone()
+	tc.fn_param_types = tc.fn_param_types.clone()
+	tc.fn_variadic = tc.fn_variadic.clone()
+	tc.specialized_generic_fns = tc.specialized_generic_fns.clone()
 }
 
 // begin_sparse_transform_node_caches keeps source-node entries in their dense

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -512,6 +512,12 @@ pub fn (mut tc TypeChecker) enable_scoped_parallel_workers() {
 	}
 }
 
+// scoped_parallel_workers_enabled reports whether compiler stages should use
+// short-lived worker arenas with this checker.
+pub fn (tc &TypeChecker) scoped_parallel_workers_enabled() bool {
+	return tc.scope_parallel_check_workers
+}
+
 // new creates a TypeChecker value for types.
 pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 	fs := new_scope(unsafe { nil })
@@ -931,6 +937,46 @@ pub fn (mut tc TypeChecker) reserve_transform_node_caches(n int) {
 	reserve_type_cache(mut tc.expr_type_values, n)
 	reserve_bool_cache(mut tc.expr_type_set, n)
 	reserve_bool_cache(mut tc.checking_nodes, n)
+}
+
+// reserve_scoped_transform_metadata keeps tables that receive escaping
+// transform additions in the compilation arena while scratch allocations use
+// a disposable arena.
+pub fn (mut tc TypeChecker) reserve_scoped_transform_metadata(n int, signature_headroom int) {
+	_ = n
+	tc.fn_ret_types.reserve(u32(tc.fn_ret_types.len + signature_headroom))
+	tc.fn_param_types.reserve(u32(tc.fn_param_types.len + signature_headroom))
+	tc.fn_variadic.reserve(u32(tc.fn_variadic.len + signature_headroom))
+	tc.specialized_generic_fns.reserve(u32(tc.specialized_generic_fns.len + signature_headroom))
+	if !isnil(tc.type_interner) {
+		mut interner := tc.type_interner
+		interner.reserve(signature_headroom)
+	}
+	if !isnil(tc.symbols) {
+		mut symbols := tc.symbols
+		symbols.reserve(signature_headroom)
+	}
+}
+
+// begin_sparse_transform_node_caches keeps source-node entries in their dense
+// checked arrays and records transform-created node metadata sparsely.
+pub fn (mut tc TypeChecker) begin_sparse_transform_node_caches(base_nodes int) {
+	tc.parallel_check_sparse = true
+	tc.check_range_lo = 0
+	tc.check_range_hi = base_nodes - 1
+}
+
+// promote_scoped_transform_interners moves additions made by a scoped
+// transform into the current compilation arena before that scope is freed.
+pub fn (mut tc TypeChecker) promote_scoped_transform_interners(type_start int, symbol_start int, scope voidptr) {
+	if !isnil(tc.type_interner) {
+		mut interner := tc.type_interner
+		interner.promote_from(type_start, scope)
+	}
+	if !isnil(tc.symbols) {
+		mut symbols := tc.symbols
+		symbols.promote_from(symbol_start, scope)
+	}
 }
 
 fn reserve_string_cache(mut values []string, n int) {

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -7,6 +7,7 @@ import v3.workers
 
 const min_parallel_check_items = 256
 const max_parallel_check_jobs = 26
+const scoped_check_worker_batches = 8
 // Extra share of the total work (in percent of an even bucket) pre-assigned to
 // the master's bucket; see split_check_items.
 const check_master_bias_pct = i64(60)
@@ -34,9 +35,51 @@ $if !windows {
 		a.scope = check_worker_scope_begin(a.scope_enabled)
 		mut w := unsafe { &TypeChecker(a.worker) }
 		items := unsafe { &[]CheckWorkItem(a.items_ptr) }
-		w.check_fn_items_serial(*items)
+		if a.scope_enabled {
+			w.check_scoped_batches(*items)
+		} else {
+			w.check_fn_items_serial(*items)
+		}
 		check_worker_scope_leave(a.scope)
 		return unsafe { nil }
+	}
+}
+
+// check_scoped_batches bounds each worker's temporary type-resolution state.
+// The receiver is a result accumulator; every batch uses a fresh checker fork,
+// then promotes only observable cache entries and diagnostics before its arena
+// is released.
+fn (mut tc TypeChecker) check_scoped_batches(items []CheckWorkItem) {
+	if items.len == 0 {
+		return
+	}
+	n_batches := if items.len < scoped_check_worker_batches {
+		items.len
+	} else {
+		scoped_check_worker_batches
+	}
+	mut total_cost := i64(0)
+	for item in items {
+		total_cost += i64(item.cost) + 1
+	}
+	mut start := 0
+	mut consumed_cost := i64(0)
+	for batch_idx in 0 .. n_batches {
+		mut end := start
+		target_cost := total_cost * i64(batch_idx + 1) / i64(n_batches)
+		for end < items.len
+			&& (batch_idx == n_batches - 1 || consumed_cost < target_cost || end == start) {
+			consumed_cost += i64(items[end].cost) + 1
+			end++
+		}
+		scratch_scope := check_worker_scope_begin(true)
+		mut batch := tc.fork_for_parallel_check()
+		batch.check_fn_items_serial(items[start..end])
+		check_worker_scope_leave(scratch_scope)
+		tc.clone_parallel_worker_node_caches(items[start..end])
+		tc.merge_parallel_check_worker_scoped(batch, true)
+		check_worker_scope_free(scratch_scope)
+		start = end
 	}
 }
 
@@ -205,21 +248,23 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		chunk_count := chunks.len
 		thread_count := chunk_count - 1
 		setup_scope := check_worker_scope_begin(tc.scope_parallel_check_workers)
-		mut checker_workers := []voidptr{cap: thread_count}
-		for _ in 0 .. thread_count {
+		worker_count := if tc.scope_parallel_check_workers { chunk_count } else { thread_count }
+		mut checker_workers := []voidptr{cap: worker_count}
+		for _ in 0 .. worker_count {
 			w := tc.fork_for_parallel_check()
 			checker_workers << voidptr(w)
 		}
 		mut args := []CheckChunkArgs{cap: chunk_count}
-		args << CheckChunkArgs{
-			worker:        voidptr(tc)
-			items_ptr:     unsafe { voidptr(&chunks[0]) }
-			scope_enabled: false
-		}
-		for ci in 0 .. thread_count {
+		for ci in 0 .. chunk_count {
+			mut worker := voidptr(tc)
+			if tc.scope_parallel_check_workers {
+				worker = checker_workers[ci]
+			} else if ci > 0 {
+				worker = checker_workers[ci - 1]
+			}
 			args << CheckChunkArgs{
-				worker:        checker_workers[ci]
-				items_ptr:     unsafe { voidptr(&chunks[ci + 1]) }
+				worker:        worker
+				items_ptr:     unsafe { voidptr(&chunks[ci]) }
 				scope_enabled: tc.scope_parallel_check_workers
 			}
 		}
@@ -228,7 +273,7 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		// master owns those slots), out-of-range ones into its sparse maps, which
 		// are replayed first after join so that worker merges overwrite them in
 		// the same order the old serial flow did.
-		tc.parallel_check_sparse = true
+		tc.parallel_check_sparse = !tc.scope_parallel_check_workers
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		mut tasks := []workers.Task{cap: chunk_count}
 		for ci in 0 .. chunk_count {
@@ -241,17 +286,21 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		}
 		check_worker_scope_leave(setup_scope)
 		any_started := ast.worker_pool.run(tasks)
-		tc.merge_own_sparse_caches()
+		if !tc.scope_parallel_check_workers {
+			tc.merge_own_sparse_caches()
+		}
 		tc.parallel_check_sparse = false
-		for ci in 0 .. thread_count {
-			mut w := unsafe { &TypeChecker(checker_workers[ci]) }
-			scoped := args[ci + 1].scope != unsafe { nil }
+		merge_start := if tc.scope_parallel_check_workers { 0 } else { 1 }
+		for ci in merge_start .. chunk_count {
+			worker_idx := if tc.scope_parallel_check_workers { ci } else { ci - 1 }
+			mut w := unsafe { &TypeChecker(checker_workers[worker_idx]) }
+			scoped := args[ci].scope != unsafe { nil }
 			if scoped {
-				tc.clone_parallel_worker_node_caches(chunks[ci + 1])
+				tc.clone_parallel_worker_node_caches(chunks[ci])
 			}
 			tc.merge_parallel_check_worker_scoped(w, scoped)
 			if scoped {
-				check_worker_scope_free(args[ci + 1].scope)
+				check_worker_scope_free(args[ci].scope)
 			} else {
 				w.free_parallel_check_worker_cache()
 			}

--- a/vlib/v3/types/checker_scoped_transform_test.v
+++ b/vlib/v3/types/checker_scoped_transform_test.v
@@ -1,0 +1,91 @@
+module types
+
+import v3.flat
+
+struct SignatureDenseArrayLayoutForTest {
+	key_bytes   int
+	value_bytes int
+mut:
+	cap         int
+	len         int
+	deletes     u32
+	all_deleted &u8 = unsafe { nil }
+	keys        &u8 = unsafe { nil }
+	values      &u8 = unsafe { nil }
+}
+
+struct SignatureMapLayoutForTest {
+	key_bytes   int
+	value_bytes int
+mut:
+	even_index      u32
+	cached_hashbits u8
+	shift           u8
+	key_values      SignatureDenseArrayLayoutForTest
+	metas           &u32 = unsafe { nil }
+	extra_metas     u32
+	has_string_keys bool
+	hash_fn         voidptr
+	key_eq_fn       voidptr
+	clone_fn        voidptr
+	free_fn         voidptr
+pub mut:
+	len int
+}
+
+fn signature_map_storage_owned_by_scope(scope voidptr, layout &SignatureMapLayoutForTest) bool {
+	$if prealloc {
+		return unsafe { prealloc_scope_owns(scope, layout.key_values.keys) }
+			|| unsafe { prealloc_scope_owns(scope, layout.key_values.values) }
+			|| unsafe { prealloc_scope_owns(scope, layout.metas) }
+	} $else {
+		return false
+	}
+}
+
+fn test_rebuild_scoped_transform_signature_maps_after_growth() {
+	$if prealloc {
+		a := flat.FlatAst.new()
+		mut tc := TypeChecker.new(&a)
+		mut names := []string{cap: 4096}
+		for i in 0 .. 4096 {
+			names << 'generated_signature_${i}'
+		}
+
+		scope := unsafe { prealloc_scope_begin() }
+		for name in names {
+			tc.fn_ret_types[name] = Type(int_)
+			tc.fn_param_types[name] = []Type{}
+			tc.fn_variadic[name] = false
+			tc.specialized_generic_fns[name] = true
+		}
+		ret_scoped := unsafe { &SignatureMapLayoutForTest(&tc.fn_ret_types) }
+		params_scoped := unsafe { &SignatureMapLayoutForTest(&tc.fn_param_types) }
+		variadic_scoped := unsafe { &SignatureMapLayoutForTest(&tc.fn_variadic) }
+		specialized_scoped := unsafe { &SignatureMapLayoutForTest(&tc.specialized_generic_fns) }
+		assert signature_map_storage_owned_by_scope(scope, ret_scoped)
+		assert signature_map_storage_owned_by_scope(scope, params_scoped)
+		assert signature_map_storage_owned_by_scope(scope, variadic_scoped)
+		assert signature_map_storage_owned_by_scope(scope, specialized_scoped)
+
+		unsafe { prealloc_scope_leave(scope) }
+		tc.rebuild_scoped_transform_signature_maps()
+		ret_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.fn_ret_types) }
+		params_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.fn_param_types) }
+		variadic_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.fn_variadic) }
+		specialized_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.specialized_generic_fns) }
+		assert !signature_map_storage_owned_by_scope(scope, ret_rebuilt)
+		assert !signature_map_storage_owned_by_scope(scope, params_rebuilt)
+		assert !signature_map_storage_owned_by_scope(scope, variadic_rebuilt)
+		assert !signature_map_storage_owned_by_scope(scope, specialized_rebuilt)
+		unsafe { prealloc_scope_free_after(scope) }
+
+		for idx in [0, 2048, 4095] {
+			name := names[idx]
+			assert tc.fn_ret_types[name] or { Type(void_) } is Primitive
+			assert name in tc.fn_param_types
+			assert !tc.fn_variadic[name]
+			assert tc.specialized_generic_fns[name]
+		}
+	}
+}

--- a/vlib/v3/types/interner_scoped_growth_test.v
+++ b/vlib/v3/types/interner_scoped_growth_test.v
@@ -1,0 +1,52 @@
+module types
+
+fn test_type_interner_promotes_scoped_slice_growth() {
+	$if prealloc {
+		mut interner := new_type_interner()
+		interner.reserve(4)
+		scope := unsafe { prealloc_scope_begin() }
+		for i in 0 .. 256 {
+			id, _ := interner.canonicalize(Type(Unknown{
+				reason: 'scoped_type_${i}'
+			}))
+			interner.name(id)
+		}
+		assert unsafe { prealloc_scope_owns(scope, interner.types.data) }
+		assert unsafe { prealloc_scope_owns(scope, interner.names.data) }
+		unsafe { prealloc_scope_leave(scope) }
+
+		interner.promote_from(0, scope)
+		assert !unsafe { prealloc_scope_owns(scope, interner.types.data) }
+		assert !unsafe { prealloc_scope_owns(scope, interner.names.data) }
+		unsafe { prealloc_scope_free_after(scope) }
+
+		id, canonical := interner.canonicalize(Type(Unknown{
+			reason: 'scoped_type_128'
+		}))
+		assert id == TypeId(128)
+		assert canonical is Unknown
+		assert canonical.reason == 'scoped_type_128'
+	}
+}
+
+fn test_symbol_interner_promotes_scoped_slice_growth() {
+	$if prealloc {
+		mut interner := new_symbol_interner()
+		interner.reserve(4)
+		scope := unsafe { prealloc_scope_begin() }
+		for i in 0 .. 256 {
+			interner.intern('scoped_symbol_${i}')
+		}
+		assert unsafe { prealloc_scope_owns(scope, interner.names.data) }
+		unsafe { prealloc_scope_leave(scope) }
+
+		interner.promote_from(0, scope)
+		assert !unsafe { prealloc_scope_owns(scope, interner.names.data) }
+		unsafe { prealloc_scope_free_after(scope) }
+
+		id, canonical := interner.intern('scoped_symbol_128')
+		assert id == SymbolId(129)
+		assert canonical == 'scoped_symbol_128'
+		assert interner.name(id) == canonical
+	}
+}

--- a/vlib/v3/types/symbol_interner.v
+++ b/vlib/v3/types/symbol_interner.v
@@ -72,6 +72,7 @@ fn (mut i SymbolInterner) promote_from(start int, scope voidptr) {
 	defer {
 		i.lock.unlock()
 	}
+	names_backing_scoped := scoped_transform_owns(scope, i.names.data)
 	first := if start < 0 { 0 } else { start }
 	for idx in first .. i.names.len {
 		name := i.names[idx]
@@ -82,6 +83,9 @@ fn (mut i SymbolInterner) promote_from(start int, scope voidptr) {
 		canonical := name.clone()
 		i.names[idx] = canonical
 		i.ids[canonical] = SymbolId(idx + 1)
+	}
+	if names_backing_scoped {
+		i.names = i.names.clone()
 	}
 	// Keep the hash index itself out of the disposable transform arena too;
 	// an insertion may have rehashed it despite the pre-transform reserve.

--- a/vlib/v3/types/symbol_interner.v
+++ b/vlib/v3/types/symbol_interner.v
@@ -58,3 +58,32 @@ fn (mut i SymbolInterner) len() int {
 	}
 	return i.names.len
 }
+
+fn (mut i SymbolInterner) reserve(headroom int) {
+	if headroom <= 0 {
+		return
+	}
+	unsafe { i.names.grow_cap(headroom) }
+	i.ids.reserve(u32(i.ids.len + headroom))
+}
+
+fn (mut i SymbolInterner) promote_from(start int, scope voidptr) {
+	i.lock.lock()
+	defer {
+		i.lock.unlock()
+	}
+	first := if start < 0 { 0 } else { start }
+	for idx in first .. i.names.len {
+		name := i.names[idx]
+		if name.len == 0 || !scoped_transform_owns(scope, name.str) {
+			continue
+		}
+		i.ids.delete(name)
+		canonical := name.clone()
+		i.names[idx] = canonical
+		i.ids[canonical] = SymbolId(idx + 1)
+	}
+	// Keep the hash index itself out of the disposable transform arena too;
+	// an insertion may have rehashed it despite the pre-transform reserve.
+	i.ids = i.ids.clone()
+}

--- a/vlib/v3/types/type_interner.v
+++ b/vlib/v3/types/type_interner.v
@@ -92,6 +92,8 @@ fn (mut i TypeInterner) promote_from(start int, scope voidptr) {
 	defer {
 		i.lock.unlock()
 	}
+	types_backing_scoped := scoped_transform_owns(scope, i.types.data)
+	names_backing_scoped := scoped_transform_owns(scope, i.names.data)
 	first := if start < 0 { 0 } else { start }
 	for idx in first .. i.types.len {
 		i.types[idx] = clone_owned_type(i.types[idx])
@@ -100,6 +102,12 @@ fn (mut i TypeInterner) promote_from(start int, scope voidptr) {
 		if name.len > 0 && scoped_transform_owns(scope, name.str) {
 			i.names[idx] = name.clone()
 		}
+	}
+	if types_backing_scoped {
+		i.types = i.types.clone()
+	}
+	if names_backing_scoped {
+		i.names = i.names.clone()
 	}
 	// A scoped insertion can rehash even after the caller reserves headroom.
 	// Rebuild the index after leaving the scope so its backing storage cannot

--- a/vlib/v3/types/type_interner.v
+++ b/vlib/v3/types/type_interner.v
@@ -76,6 +76,44 @@ fn (mut i TypeInterner) len() int {
 	return i.types.len
 }
 
+fn (mut i TypeInterner) reserve(headroom int) {
+	if headroom <= 0 {
+		return
+	}
+	unsafe {
+		i.types.grow_cap(headroom)
+		i.names.grow_cap(headroom)
+	}
+	i.buckets.reserve(u32(i.buckets.len + headroom))
+}
+
+fn (mut i TypeInterner) promote_from(start int, scope voidptr) {
+	i.lock.lock()
+	defer {
+		i.lock.unlock()
+	}
+	first := if start < 0 { 0 } else { start }
+	for idx in first .. i.types.len {
+		i.types[idx] = clone_owned_type(i.types[idx])
+	}
+	for idx, name in i.names {
+		if name.len > 0 && scoped_transform_owns(scope, name.str) {
+			i.names[idx] = name.clone()
+		}
+	}
+	// A scoped insertion can rehash even after the caller reserves headroom.
+	// Rebuild the index after leaving the scope so its backing storage cannot
+	// remain owned by the disposable transform arena.
+	i.buckets = i.buckets.clone()
+}
+
+fn scoped_transform_owns(scope voidptr, ptr voidptr) bool {
+	$if prealloc {
+		return unsafe { prealloc_scope_owns(scope, ptr) }
+	}
+	return false
+}
+
 fn semantic_type_hash(t Type) u64 {
 	mut hash := u64(14_695_981_039_346_656_037)
 	match t {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -605,6 +605,7 @@ fn clone_flat_ast_after_transform(ast &flat.FlatAst) &flat.FlatAst {
 	}
 	mut children := []flat.NodeId{cap: ast.children.len}
 	children << ast.children
+	text_values, text_ids := ast.clone_text_table_owned()
 	return &flat.FlatAst{
 		nodes:                nodes
 		children:             children
@@ -614,8 +615,8 @@ fn clone_flat_ast_after_transform(ast &flat.FlatAst) &flat.FlatAst {
 		noreturn_fns:         ast.noreturn_fns
 		source_files:         ast.source_files
 		source_buffers:       ast.source_buffers
-		text_values:          ast.text_values
-		text_ids:             ast.text_ids
+		text_values:          text_values
+		text_ids:             text_ids
 		worker_pool:          ast.worker_pool
 		specialized_fn_nodes: ast.specialized_fn_nodes.clone()
 	}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -690,6 +690,7 @@ fn promote_scoped_signatures(mut tc types.TypeChecker, original_names map[string
 			tc.specialized_generic_fns[owned_name] = true
 		}
 	}
+	tc.rebuild_scoped_transform_signature_maps()
 }
 
 fn v3_cache_compiler_signature(vroot string) string {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -450,6 +450,248 @@ fn clone_string_list(values []string) []string {
 	return cloned
 }
 
+// clone_string_bool_map promotes a string-keyed set out of a disposable stage arena.
+fn clone_string_bool_map(values map[string]bool) map[string]bool {
+	mut cloned := map[string]bool{}
+	for key, value in values {
+		cloned[key.clone()] = value
+	}
+	return cloned
+}
+
+fn scoped_value_owned(scope voidptr, ptr voidptr) bool {
+	$if prealloc {
+		return unsafe { prealloc_scope_owns(scope, ptr) }
+	}
+	return false
+}
+
+fn promote_scoped_node(mut node flat.Node, scope voidptr) {
+	if node.value.len > 0 && scoped_value_owned(scope, node.value.str) {
+		node.value = node.value.clone()
+	}
+	if node.typ.len > 0 && scoped_value_owned(scope, node.typ.str) {
+		node.typ = node.typ.clone()
+	}
+	old_params := node.generic_params()
+	if old_params.len == 0 {
+		return
+	}
+	mut needs_promotion := scoped_value_owned(scope, node.payload)
+		|| scoped_value_owned(scope, old_params.data)
+	if !needs_promotion {
+		for param in old_params {
+			if param.len > 0 && scoped_value_owned(scope, param.str) {
+				needs_promotion = true
+				break
+			}
+		}
+	}
+	if !needs_promotion {
+		return
+	}
+	mut params := []string{cap: old_params.len}
+	for param in old_params {
+		params << if param.len > 0 && scoped_value_owned(scope, param.str) {
+			param.clone()
+		} else {
+			param
+		}
+	}
+	node.set_generic_params(params)
+}
+
+fn promote_scoped_ast_nodes(mut ast flat.FlatAst, base_nodes int, new_end int, owned_base_nodes []int, scope voidptr) {
+	for idx in owned_base_nodes {
+		if idx >= 0 && idx < base_nodes && idx < ast.nodes.len {
+			promote_scoped_node(mut ast.nodes[idx], scope)
+		}
+	}
+	limit := if new_end < ast.nodes.len { new_end } else { ast.nodes.len }
+	for idx in base_nodes .. limit {
+		promote_scoped_node(mut ast.nodes[idx], scope)
+	}
+}
+
+fn canonicalize_scoped_node(mut ast flat.FlatAst, idx int, scope voidptr) {
+	if idx < 0 || idx >= ast.nodes.len {
+		return
+	}
+	mut node := unsafe { &ast.nodes[idx] }
+	if node.value.len > 0 && scoped_value_owned(scope, node.value.str) {
+		_, node.value = ast.intern_text(node.value)
+	}
+	if node.typ.len > 0 && scoped_value_owned(scope, node.typ.str) {
+		_, node.typ = ast.intern_text(node.typ)
+	}
+	old_params := node.generic_params()
+	if old_params.len == 0 {
+		return
+	}
+	mut needs_params := scoped_value_owned(scope, node.payload)
+		|| scoped_value_owned(scope, old_params.data)
+	if !needs_params {
+		for param in old_params {
+			if param.len > 0 && scoped_value_owned(scope, param.str) {
+				needs_params = true
+				break
+			}
+		}
+	}
+	if !needs_params {
+		return
+	}
+	mut params := []string{cap: old_params.len}
+	for param in old_params {
+		if param.len > 0 && scoped_value_owned(scope, param.str) {
+			_, canonical := ast.intern_text(param)
+			params << canonical
+		} else {
+			params << param
+		}
+	}
+	node.set_generic_params(params)
+}
+
+fn canonicalize_scoped_transform_region(mut ast flat.FlatAst, region transform.ScopedTransformRegion) {
+	canonicalize_scoped_transform_region_from_scope(mut ast, region, region.scope)
+}
+
+fn canonicalize_scoped_transform_region_from_scope(mut ast flat.FlatAst, region transform.ScopedTransformRegion, scope voidptr) {
+	for idx in region.base_nodes {
+		canonicalize_scoped_node(mut ast, idx, scope)
+	}
+	limit := if region.new_end < ast.nodes.len { region.new_end } else { ast.nodes.len }
+	for idx in region.new_start .. limit {
+		canonicalize_scoped_node(mut ast, idx, scope)
+	}
+}
+
+fn clone_scoped_transform_regions(regions []transform.ScopedTransformRegion) []transform.ScopedTransformRegion {
+	mut cloned := []transform.ScopedTransformRegion{cap: regions.len}
+	for region in regions {
+		cloned << transform.ScopedTransformRegion{
+			scope:      region.scope
+			new_start:  region.new_start
+			new_end:    region.new_end
+			base_nodes: region.base_nodes.clone()
+		}
+	}
+	return cloned
+}
+
+fn clone_flat_node_owned(node flat.Node) flat.Node {
+	mut params := []string{cap: node.generic_params().len}
+	for param in node.generic_params() {
+		params << param.clone()
+	}
+	return flat.Node{
+		value:          node.value.clone()
+		typ:            node.typ.clone()
+		payload:        flat.node_payload(params)
+		is_mut:         node.is_mut
+		children_start: node.children_start
+		pos:            node.pos
+		children_count: node.children_count
+		kind:           node.kind
+		op:             node.op
+	}
+}
+
+fn clone_flat_ast_after_transform(ast &flat.FlatAst) &flat.FlatAst {
+	mut nodes := []flat.Node{cap: ast.nodes.len}
+	for node in ast.nodes {
+		nodes << clone_flat_node_owned(node)
+	}
+	mut children := []flat.NodeId{cap: ast.children.len}
+	children << ast.children
+	return &flat.FlatAst{
+		nodes:                nodes
+		children:             children
+		user_code_start:      ast.user_code_start
+		disabled_fns:         ast.disabled_fns
+		export_fn_names:      ast.export_fn_names
+		noreturn_fns:         ast.noreturn_fns
+		source_files:         ast.source_files
+		source_buffers:       ast.source_buffers
+		text_values:          ast.text_values
+		text_ids:             ast.text_ids
+		worker_pool:          ast.worker_pool
+		specialized_fn_nodes: ast.specialized_fn_nodes.clone()
+	}
+}
+
+fn clone_int_string_map(values map[int]string) map[int]string {
+	mut cloned := map[int]string{}
+	for idx, value in values {
+		cloned[idx] = value.clone()
+	}
+	return cloned
+}
+
+fn clone_int_type_map(values map[int]types.Type) map[int]types.Type {
+	mut cloned := map[int]types.Type{}
+	for idx, value in values {
+		cloned[idx] = types.clone_owned_type(value)
+	}
+	return cloned
+}
+
+fn promote_scoped_checker_node_additions(mut tc types.TypeChecker, base_nodes int, scope voidptr) {
+	for idx in base_nodes .. tc.resolved_call_names.len {
+		if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
+			name := tc.resolved_call_names[idx]
+			if name.len > 0 && scoped_value_owned(scope, name.str) {
+				tc.resolved_call_names[idx] = name.clone()
+			}
+		}
+		if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
+			name := tc.resolved_fn_value_names[idx]
+			if name.len > 0 && scoped_value_owned(scope, name.str) {
+				tc.resolved_fn_value_names[idx] = name.clone()
+			}
+		}
+		if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
+			tc.expr_type_values[idx] = types.clone_owned_type(tc.expr_type_values[idx])
+		}
+	}
+	tc.sparse_resolved_call_names = clone_int_string_map(tc.sparse_resolved_call_names)
+	tc.sparse_resolved_fn_values = clone_int_string_map(tc.sparse_resolved_fn_values)
+	tc.sparse_statement_nodes = tc.sparse_statement_nodes.clone()
+	tc.sparse_expr_type_values = clone_int_type_map(tc.sparse_expr_type_values)
+	tc.sparse_checking_nodes = tc.sparse_checking_nodes.clone()
+}
+
+fn promote_scoped_signatures(mut tc types.TypeChecker, original_names map[string]bool) {
+	mut added_names := []string{}
+	for name in tc.fn_ret_types.keys() {
+		if name !in original_names {
+			added_names << name
+		}
+	}
+	for name in added_names {
+		ret := types.clone_owned_type(tc.fn_ret_types[name] or { continue })
+		params := if values := tc.fn_param_types[name] {
+			types.clone_owned_types(values)
+		} else {
+			[]types.Type{}
+		}
+		variadic := tc.fn_variadic[name]
+		specialized := tc.specialized_generic_fns[name]
+		tc.fn_ret_types.delete(name)
+		tc.fn_param_types.delete(name)
+		tc.fn_variadic.delete(name)
+		tc.specialized_generic_fns.delete(name)
+		owned_name := name.clone()
+		tc.fn_ret_types[owned_name] = ret
+		tc.fn_param_types[owned_name] = params
+		tc.fn_variadic[owned_name] = variadic
+		if specialized {
+			tc.specialized_generic_fns[owned_name] = true
+		}
+	}
+}
+
 fn v3_cache_compiler_signature(vroot string) string {
 	dir := os.join_path(vroot, 'vlib', 'v3')
 	if !os.is_dir(dir) {
@@ -816,6 +1058,14 @@ fn main() {
 	}
 	cmd_v_build := input_is_cmd_v(input_file)
 	scope_prealloc_selfhost := should_scope_prealloc_selfhost(building_v, cmd_v_build)
+	// The selective transform promotion path is designed around worker-owned
+	// result regions. Keep an explicitly serial transform in the compilation
+	// arena while retaining scoped parse/check/cgen scratch.
+	scope_prealloc_transform := scope_prealloc_selfhost && current_parallel_transform
+	// Markused can lazily create the compilation worker pool. When parsing was
+	// serial, keep that pool in the compilation arena so close_workers never
+	// observes a pool allocated in a released markused scope.
+	scope_prealloc_markused := scope_prealloc_selfhost && !current_no_parallel
 	if building_v || cmd_v_build {
 		if no_parallel {
 			user_defines = user_defines.filter(it != 'parallel')
@@ -1149,20 +1399,33 @@ fn main() {
 
 	// Mark used functions (dead-code elimination). This is done before transform
 	// so the transformer can skip function bodies that the C backend will prune.
+	mut markused_scope := unsafe { nil }
+	mut markused_tc := &pre_tc
+	if scope_prealloc_markused {
+		markused_scope = prealloc_scope_begin_for_v3()
+		markused_tc = pre_tc.fork_for_parallel_transform(a)
+		markused_tc.enable_scoped_parallel_workers()
+	}
 	mut output_used_fns := map[string]bool{}
 	mut uses_generics := false
 	if test_files.len > 0 {
-		output_used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a, pre_tc,
-			test_files)
+		output_used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a,
+			markused_tc, test_files)
 	} else {
-		output_used_fns, uses_generics = markused.mark_used_with_generic_usage(a, pre_tc)
+		output_used_fns, uses_generics = markused.mark_used_with_generic_usage(a, markused_tc)
 	}
 	mut used_fns := output_used_fns.clone()
 	if cache_state.manager.enabled {
 		mut cache_uses_generics := false
-		used_fns, cache_uses_generics = markused.mark_used_for_cache_with_generic_usage(a, pre_tc,
-			test_files, cache_state.source_body_modules)
+		used_fns, cache_uses_generics = markused.mark_used_for_cache_with_generic_usage(a,
+			markused_tc, test_files, cache_state.source_body_modules)
 		uses_generics = uses_generics || cache_uses_generics
+	}
+	if scope_prealloc_markused {
+		prealloc_scope_leave_for_v3(markused_scope)
+		output_used_fns = clone_string_bool_map(output_used_fns)
+		used_fns = clone_string_bool_map(used_fns)
+		prealloc_scope_free_for_v3(markused_scope)
 	}
 	b.step('markused')
 	b.metric('reachable symbols', used_fns.len, 'symbols')
@@ -1172,17 +1435,75 @@ fn main() {
 	// and cgen.
 	mut transform_was_parallel := false
 	mut transform_errors := []string{}
+	mut transform_texts_canonical := false
 	// Markused distinguishes reachable generic calls/types from generic templates
 	// that merely came along with an imported module (notably sync and rand).
 	skip_transform_generics := building_v || cmd_v_build || !uses_generics
-	// Escaping AST/checker data is always allocated in the compilation arena.
-	// Parallel helpers may use disposable scratch arenas; their compact results
-	// are merged into the persistent result slabs before those arenas are freed.
-	// The serial path deliberately stays in the compilation arena instead of
-	// cloning the whole surviving program out of a stage-local arena.
-	used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,
-		&pre_tc, used_fns, current_parallel_transform, skip_transform_generics,
-		scope_prealloc_selfhost)
+	if scope_prealloc_transform {
+		// Keep the large escaping AST/cache slabs in the compilation arena, while
+		// transformer indexes and per-body temporary state use a stage arena.
+		transform.reserve_parallel_transform_ast(mut a, skip_transform_generics)
+		a.reserve_transform_texts(65536)
+		pre_tc.begin_sparse_transform_node_caches(a.nodes.len)
+		pre_tc.reserve_scoped_transform_metadata(a.nodes.cap, 2048)
+		base_transform_nodes := a.nodes.len
+		reserved_nodes_cap := a.nodes.cap
+		reserved_children_cap := a.children.cap
+		base_specialized_fns := a.specialized_fn_nodes.len
+		base_type_count := pre_tc.type_count()
+		base_symbol_count := pre_tc.symbol_count()
+		base_text_count := a.text_values.len
+		mut original_signature_names := map[string]bool{}
+		for name in pre_tc.fn_ret_types.keys() {
+			original_signature_names[name] = true
+		}
+		transform_scope := prealloc_scope_begin_for_v3()
+		mut scoped_owned_base_nodes := []int{}
+		mut retained_transform_regions := []transform.ScopedTransformRegion{}
+		used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_with_used_opt_config_scoped_workers_checked_owned(mut a,
+			&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, true,
+			transform_scope)
+		parse_cache_enabled := pre_tc.type_cache_parse_enabled()
+		prealloc_scope_leave_for_v3(transform_scope)
+		retained_transform_regions = clone_scoped_transform_regions(retained_transform_regions)
+		pre_tc.promote_scoped_transform_interners(base_type_count, base_symbol_count,
+			transform_scope)
+		if a.nodes.cap == reserved_nodes_cap && a.children.cap == reserved_children_cap {
+			a.promote_transform_texts_from(base_text_count, transform_scope)
+			if retained_transform_regions.len > 0 {
+				outer_new_end := retained_transform_regions[0].new_start
+				promote_scoped_ast_nodes(mut a, base_transform_nodes, outer_new_end,
+					scoped_owned_base_nodes, transform_scope)
+				last_worker_end := retained_transform_regions.last().new_end
+				promote_scoped_ast_nodes(mut a, last_worker_end, a.nodes.len, []int{},
+					transform_scope)
+			} else {
+				a.intern_node_texts_from(0)
+				transform_texts_canonical = true
+			}
+		} else {
+			a = clone_flat_ast_after_transform(a)
+		}
+		if a.specialized_fn_nodes.len != base_specialized_fns {
+			a.specialized_fn_nodes = a.specialized_fn_nodes.clone()
+		}
+		promote_scoped_checker_node_additions(mut pre_tc, base_transform_nodes, transform_scope)
+		promote_scoped_signatures(mut pre_tc, original_signature_names)
+		used_fns = clone_string_bool_map(used_fns)
+		transform_errors = clone_string_list(transform_errors)
+		pre_tc.set_fresh_type_cache(parse_cache_enabled)
+		prealloc_scope_free_for_v3(transform_scope)
+		if retained_transform_regions.len > 0 {
+			for region in retained_transform_regions {
+				canonicalize_scoped_transform_region(mut a, region)
+				prealloc_scope_free_for_v3(region.scope)
+			}
+			transform_texts_canonical = true
+		}
+	} else {
+		used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,
+			&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, false)
+	}
 	b.step_parallel('transform', transform_was_parallel)
 	if transform_errors.len > 0 {
 		eprintln('type checker found ${transform_errors.len} error(s):')
@@ -1252,7 +1573,9 @@ fn main() {
 	// Transform and monomorphization can synthesize or rewrite payload text.
 	// They run with private/arena-backed worker state; publish only canonical,
 	// compilation-owned strings after all worker merges are complete.
-	a.intern_node_texts_from(0)
+	if !transform_texts_canonical {
+		a.intern_node_texts_from(0)
+	}
 	b.step('monomorphize')
 	if cache_state.manager.enabled {
 		// The cache transform roots complete modules, but the ordinary `.c` artifact


### PR DESCRIPTION
## Summary

- batch checker, markused, and transform scratch allocations into disposable prealloc scopes while selectively promoting persistent state
- share immutable transform data and AST regions between workers, and parallelize the read-only interface boxing scan
- freeze interface-boxing metadata before skip-generics workers share it
- stream cgen declarations and function chunks through temporary files so generated output is not retained multiple times in RAM
- preserve sparse transform caches, scoped-batch overlays, fallback AST text tables, and overflowed interner/text-table backing
- rebuild signature-map backing after scoped transform growth
- keep serial transform and markused ownership safe for `-no-parallel` and internal `v3_no_parallel` builds

## Results

Self-host benchmark:

```sh
cd vlib/v3
../../v -gc none -prealloc -prod -o v3 v3.v
/usr/bin/time -l ./v3 -building-v -o /tmp/v4_interface_freeze_review v3.v
```

- peak RSS: 600 MB reported by v3; 599.95 MiB from macOS `time -l`
- transform: 181.07 ms
- total: 2.90 s including C compilation
- explicit `-no-parallel` self-host succeeds

## Validation

- rebuilt `./vnew` with `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -gc none -prealloc vlib/v3/types/interner_scoped_growth_test.v`
- `./vnew -gc none -prealloc vlib/v3/types/checker_scoped_transform_test.v`
- `./vnew vlib/v3/types/checker_parallel_test.v`
- `./vnew vlib/v3/gen/c/parallel_worker_test.v`
- `./vnew vlib/v3/transform/fn_test.v`
- `./vnew -gc none -prealloc vlib/v3/flat/flat_test.v`
- `./vnew vlib/v3/tests/markused_test.v`
- `./vnew vlib/v3/tests/parallel_determinism_test.v`
- `./vnew vlib/v3/tests/parallel_worker_failure_test.v`
- `./vnew vlib/builtin/prealloc_scope_ownership_test.v`
- `./vnew -gc none -prealloc -d v3_no_parallel -o /tmp/v3_no_parallel_interface_freeze vlib/v3/v3.v`

Broad tests were skipped at the requester’s direction.