### PR TITLE
v3: preserve mut map iteration deletions

### DIFF
--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -1208,6 +1208,37 @@ fn (mut g FlatGen) gen_index_assign(node flat.Node) {
 			c_key := g.map_key_temp_c_type(clean_base.key_type)
 			c_val := g.value_c_type(clean_base.value_type)
 			is_ptr := base_type is types.Pointer
+			if g.map_loop_copyback_guards.len > 0 {
+				map_tmp := '__map_set_target_${g.tmp_count}'
+				g.tmp_count++
+				key_tmp := '__map_set_key_${g.tmp_count}'
+				g.tmp_count++
+				g.write('map* ${map_tmp} = ')
+				if !is_ptr {
+					g.write('&')
+				}
+				g.gen_expr(base_id)
+				g.writeln(';')
+				key_id := g.a.child(&lhs, 1)
+				mut key_ref := '&${key_tmp}'
+				if key_fixed := array_fixed_type(clean_base.key_type) {
+					c_elem, dims := g.fixed_array_decl_parts(key_fixed)
+					g.writeln('${c_elem} ${key_tmp}${dims};')
+					g.write('memmove(${key_tmp}, ')
+					g.gen_expr_with_expected_type(key_id, clean_base.key_type)
+					g.writeln(', sizeof(${key_tmp}));')
+					key_ref = key_tmp
+				} else {
+					g.write('${c_key} ${key_tmp} = ')
+					g.gen_expr_with_expected_type(key_id, clean_base.key_type)
+					g.writeln(';')
+				}
+				g.gen_map_loop_copyback_dirty_checks(map_tmp, key_ref)
+				g.write('map__set(${map_tmp}, ${key_ref}, &(${c_val}[]){')
+				g.gen_expr_with_expected_type(g.a.child(&node, 1), clean_base.value_type)
+				g.writeln('});')
+				return
+			}
 			if is_ptr {
 				g.write('map__set(')
 			} else {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -55,6 +55,12 @@ struct LoopControlCopyback {
 	loop_depth int
 }
 
+struct MapLoopCopybackGuard {
+	map_ref   string
+	key_ref   string
+	dirty_var string
+}
+
 struct FixedStorageConstRefItem {
 	id     flat.NodeId
 	file   string
@@ -198,6 +204,7 @@ mut:
 	conditional_branch_depth     int
 	loop_label_depths            map[string]int
 	loop_control_copybacks       []LoopControlCopyback
+	map_loop_copyback_guards     []MapLoopCopybackGuard
 	goto_label_lock_scopes       map[string][]int
 	pending_loop_label           string
 	// in_return is true only while generating a `return` statement's value, so a bare
@@ -625,6 +632,7 @@ pub fn FlatGen.new() FlatGen {
 		conditional_branch_depths:      []int{}
 		loop_label_depths:              map[string]int{}
 		loop_control_copybacks:         []LoopControlCopyback{}
+		map_loop_copyback_guards:       []MapLoopCopybackGuard{}
 		goto_label_lock_scopes:         map[string][]int{}
 		ownership_seen_return_sources:  map[string]bool{}
 		needed_optional_types:          map[string]string{}
@@ -1227,6 +1235,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.conditional_branch_depth = 0
 	g.loop_label_depths.clear()
 	g.loop_control_copybacks = []LoopControlCopyback{}
+	g.map_loop_copyback_guards = []MapLoopCopybackGuard{}
 	g.goto_label_lock_scopes.clear()
 	g.pending_loop_label = ''
 	g.needed_optional_types.clear()

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -3034,6 +3034,7 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 	g.cur_return_drops = []types.OwnershipDropEntry{}
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
+	g.map_loop_copyback_guards = []MapLoopCopybackGuard{}
 	mut prelude_scan := g.collect_fn_prelude_scan(node)
 	g.goto_label_lock_scopes = prelude_scan.goto_label_lock_scopes.move()
 	g.pending_loop_label = ''
@@ -3170,6 +3171,7 @@ fn (mut g FlatGen) gen_fn_in_module(node flat.Node, module_name string) {
 	g.cur_mut_param_owners = old_mut_param_owners.clone()
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
+	g.map_loop_copyback_guards = []MapLoopCopybackGuard{}
 	g.goto_label_lock_scopes = map[string][]int{}
 	g.pending_loop_label = ''
 	g.pop_scope()
@@ -3242,6 +3244,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.cur_fn_name = 'main'
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
+	g.map_loop_copyback_guards = []MapLoopCopybackGuard{}
 	mut prelude_scan := g.collect_top_level_prelude_scan(stmts)
 	g.goto_label_lock_scopes = prelude_scan.goto_label_lock_scopes.move()
 	g.pending_loop_label = ''
@@ -3310,6 +3313,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.cur_fn_name = old_fn_name
 	g.loop_depth = 0
 	g.loop_label_depths = map[string]int{}
+	g.map_loop_copyback_guards = []MapLoopCopybackGuard{}
 	g.goto_label_lock_scopes = map[string][]int{}
 	g.pending_loop_label = ''
 	g.tc.cur_file = old_tc_file
@@ -3760,6 +3764,43 @@ fn (mut g FlatGen) gen_optional_error_from_call(ct string, node flat.Node) {
 	g.write('}')
 }
 
+fn (mut g FlatGen) gen_map_mutation_call_with_loop_copyback_guard(node flat.Node, fn_name string, target_name string, resolved_target_name string) bool {
+	if g.map_loop_copyback_guards.len == 0 {
+		return false
+	}
+	is_map_delete := fn_name == 'map__delete' || target_name == 'map__delete'
+		|| resolved_target_name == 'map__delete'
+	is_map_set := fn_name == 'map__set' || target_name == 'map__set'
+		|| resolved_target_name == 'map__set'
+	if (!is_map_delete && !is_map_set) || (is_map_delete && node.children_count != 3)
+		|| (is_map_set && node.children_count != 4) {
+		return false
+	}
+	map_tmp := '__map_mut_target_${g.tmp_count}'
+	g.tmp_count++
+	key_tmp := '__map_mut_key_${g.tmp_count}'
+	g.tmp_count++
+	g.write('({ map* ${map_tmp} = ')
+	g.gen_expr(g.a.child(&node, 1))
+	g.write('; void* ${key_tmp} = ')
+	g.gen_expr(g.a.child(&node, 2))
+	mut val_tmp := ''
+	if is_map_set {
+		val_tmp = '__map_mut_val_${g.tmp_count}'
+		g.tmp_count++
+		g.write('; void* ${val_tmp} = ')
+		g.gen_expr(g.a.child(&node, 3))
+	}
+	g.writeln(';')
+	g.gen_map_loop_copyback_dirty_checks(map_tmp, key_tmp)
+	if is_map_set {
+		g.write('map__set(${map_tmp}, ${key_tmp}, ${val_tmp}); })')
+	} else {
+		g.write('map__delete(${map_tmp}, ${key_tmp}); })')
+	}
+	return true
+}
+
 // gen_call emits call output for c.
 fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 	fn_node := g.a.child_node(&node, 0)
@@ -3786,6 +3827,11 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		return
 	}
 	resolved_target_name := g.tc.resolved_call_name(id) or { '' }
+	if g.gen_map_mutation_call_with_loop_copyback_guard(node, fn_name, target_name,
+		resolved_target_name)
+	{
+		return
+	}
 	if fn_node.kind == .index && fn_node.value != 'range' {
 		runtime_start := 1
 		arg_count := int(node.children_count) - runtime_start

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -187,16 +187,24 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 			}
 			mut map_snapshot_var := ''
 			mut map_mut_value_copyback := ''
+			mut map_copyback_dirty_var := ''
+			mut map_copyback_guard := MapLoopCopybackGuard{}
 			if clean_container_type is types.Map {
 				c_key := g.map_key_temp_c_type(clean_container_type.key_type)
 				c_val := g.value_c_type(clean_container_type.value_type)
 				map_value_by_ref := node.op == .amp || container_type is types.Pointer
 				container_str := g.expr_to_string(g.a.child(&node, 2))
+				original_map_ref := if container_type is types.Pointer {
+					container_str
+				} else {
+					'&${container_str}'
+				}
 				iter_var := '__mi_${g.tmp_count}'
 				g.tmp_count++
 				key_var := if has_index { idx_var } else { '__mk_${g.tmp_count}' }
 				val_var_ := if has_index { elem_var } else { var_name }
 				use_snapshot := g.for_in_body_contains_delete_call(node, body_start)
+				mut key_ref := '&${key_var}'
 				key_values := if use_snapshot {
 					map_snapshot_var = '__for_map_${g.tmp_count}'
 					g.tmp_count++
@@ -222,6 +230,7 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 					c_elem, dims := g.fixed_array_decl_parts(key_fixed)
 					g.writeln('${c_elem} ${key_var}${dims};')
 					g.writeln('memmove(${key_var}, ${key_slot}, sizeof(${key_var}));')
+					key_ref = key_var
 				} else {
 					g.writeln('${c_key} ${key_var} = *(${c_key}*)(${key_slot});')
 					if clean_container_type.key_type is types.String {
@@ -234,11 +243,6 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 				if use_snapshot && map_value_by_ref {
 					val_slot_var := '__for_map_val_${g.tmp_count}'
 					g.tmp_count++
-					original_map_ref := if container_type is types.Pointer {
-						container_str
-					} else {
-						'&${container_str}'
-					}
 					g.writeln('void* ${val_slot_var} = map__get_check(${original_map_ref}, &${key_var});')
 					g.writeln('if (${val_slot_var} == 0) ${val_slot_var} = (void*)(${snapshot_val_slot});')
 					val_slot = val_slot_var
@@ -249,14 +253,45 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 					g.writeln('memmove(${val_var_}, ${val_slot}, sizeof(${val_var_}));')
 					val_is_fixed_copy = true
 					if node.op == .amp {
-						map_mut_value_copyback = 'memmove(${val_slot}, ${val_var_}, sizeof(${val_var_}));'
+						mut copyback_slot := val_slot
+						if use_snapshot {
+							copyback_slot = '__for_map_copyback_${g.tmp_count}'
+							g.tmp_count++
+							if map_copyback_dirty_var.len == 0 {
+								map_copyback_dirty_var = '__for_map_dirty_${g.tmp_count}'
+								g.tmp_count++
+							}
+						}
+						map_mut_value_copyback = 'memmove(${copyback_slot}, ${val_var_}, sizeof(${val_var_}));'
+						if use_snapshot {
+							map_mut_value_copyback = 'if (!${map_copyback_dirty_var}) { void* ${copyback_slot} = map__get_check(${original_map_ref}, &${key_var}); if (${copyback_slot} != 0) { ${map_mut_value_copyback} } }'
+						}
 					}
 				} else if map_value_by_ref {
 					g.writeln('${c_val}* ${val_var_} = (${c_val}*)(${val_slot});')
 				} else {
 					g.writeln('${c_val} ${val_var_} = *(${c_val}*)(${val_slot});')
 					if node.op == .amp {
-						map_mut_value_copyback = 'memmove(${val_slot}, &${val_var_}, sizeof(${val_var_}));'
+						mut copyback_slot := val_slot
+						if use_snapshot {
+							copyback_slot = '__for_map_copyback_${g.tmp_count}'
+							g.tmp_count++
+							if map_copyback_dirty_var.len == 0 {
+								map_copyback_dirty_var = '__for_map_dirty_${g.tmp_count}'
+								g.tmp_count++
+							}
+						}
+						map_mut_value_copyback = 'memmove(${copyback_slot}, &${val_var_}, sizeof(${val_var_}));'
+						if use_snapshot {
+							map_mut_value_copyback = 'if (!${map_copyback_dirty_var}) { void* ${copyback_slot} = map__get_check(${original_map_ref}, &${key_var}); if (${copyback_slot} != 0) { ${map_mut_value_copyback} } }'
+						}
+					}
+				}
+				if map_copyback_dirty_var.len > 0 {
+					map_copyback_guard = MapLoopCopybackGuard{
+						map_ref:   original_map_ref
+						key_ref:   key_ref
+						dirty_var: map_copyback_dirty_var
 					}
 				}
 				if has_index {
@@ -360,6 +395,10 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 				g.gen_labelled_continue_skip_drops_var(label_state.label)
 			}
 			g.loop_depth++
+			if map_copyback_guard.dirty_var.len > 0 {
+				g.writeln('bool ${map_copyback_guard.dirty_var} = false;')
+				g.map_loop_copyback_guards << map_copyback_guard
+			}
 			if map_mut_value_copyback.len > 0 {
 				g.loop_control_copybacks << LoopControlCopyback{
 					stmt:       map_mut_value_copyback
@@ -368,6 +407,9 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 			}
 			for i in body_start .. node.children_count {
 				g.gen_node(g.a.child(&node, i))
+			}
+			if map_copyback_guard.dirty_var.len > 0 {
+				g.map_loop_copyback_guards.delete_last()
 			}
 			if map_mut_value_copyback.len > 0 {
 				g.writeln(map_mut_value_copyback)
@@ -485,6 +527,12 @@ fn (g &FlatGen) node_contains_delete_call(id flat.NodeId) bool {
 		}
 	}
 	return false
+}
+
+fn (mut g FlatGen) gen_map_loop_copyback_dirty_checks(map_ptr_expr string, key_ptr_expr string) {
+	for guard in g.map_loop_copyback_guards {
+		g.writeln('if (!${guard.dirty_var} && (${map_ptr_expr}) == (${guard.map_ref}) && (${guard.map_ref})->key_eq_fn(${key_ptr_expr}, ${guard.key_ref})) ${guard.dirty_var} = true;')
+	}
 }
 
 fn (g &FlatGen) c_loop_local_name(name string) string {

--- a/vlib/v3/tests/map_for_mut_snapshot_codegen_test.v
+++ b/vlib/v3/tests/map_for_mut_snapshot_codegen_test.v
@@ -51,6 +51,60 @@ fn test_mut_map_iteration_snapshot_updates_original_values() {
 	assert out == 'ok'
 }
 
+fn test_mut_map_iteration_delete_current_key_preserves_deletion() {
+	v3_bin := map_for_mut_build_v3()
+	out := map_for_mut_run_good(v3_bin, 'map_for_mut_delete_current_key', 'fn main() {
+		mut m := map[string][2]int{}
+		m["a"] = [1, 0]!
+		m["b"] = [2, 0]!
+		for key, mut v in m {
+			v[0] = 9
+			m.delete(key)
+		}
+		assert m.len == 0
+		println("ok")
+	}
+	')
+	assert out == 'ok'
+}
+
+fn test_mut_map_iteration_delete_reinsert_equal_value_is_not_clobbered() {
+	v3_bin := map_for_mut_build_v3()
+	out := map_for_mut_run_good(v3_bin, 'map_for_mut_delete_reinsert_equal_value', 'fn main() {
+		mut m := map[string][2]int{}
+		m["a"] = [1, 0]!
+		for key, mut v in m {
+			v[0] = 9
+			m.delete(key)
+			m[key] = [1, 0]!
+		}
+		assert m["a"][0] == 1
+		println("ok")
+	}
+	')
+	assert out == 'ok'
+}
+
+fn test_mut_map_iteration_explicit_update_is_not_clobbered() {
+	v3_bin := map_for_mut_build_v3()
+	out := map_for_mut_run_good(v3_bin, 'map_for_mut_explicit_update_not_clobbered', 'fn main() {
+		mut m := map[string][2]int{}
+		m["a"] = [1, 0]!
+		m["b"] = [2, 0]!
+		for key, mut v in m {
+			if key == "a" {
+				v[0] = 9
+				m[key] = [3, 0]!
+			}
+			m.delete("missing")
+		}
+		assert m["a"][0] == 3
+		println("ok")
+	}
+	')
+	assert out == 'ok'
+}
+
 fn test_mut_map_fixed_array_value_copyback_runs_before_continue() {
 	v3_bin := map_for_mut_build_v3()
 	out := map_for_mut_run_good(v3_bin, 'map_for_mut_fixed_array_continue_copyback', 'fn main() {
@@ -111,6 +165,27 @@ fn main() {
 }
 ')
 	assert out == 'ok'
+}
+
+fn test_mut_map_scalar_return_reads_updated_value() {
+	v3_bin := map_for_mut_build_v3()
+	out := map_for_mut_run_good(v3_bin, 'map_for_mut_scalar_return_reads_update', '__global values map[string]int
+
+fn return_int_from_map() int {
+	for _, mut v in values {
+		v = 7
+		return values["x"]
+	}
+	return 0
+}
+
+fn main() {
+	values = map[string]int{}
+	values["x"] = 1
+	println(int_str(return_int_from_map()))
+}
+')
+	assert out == '7'
 }
 
 fn test_mut_map_fixed_array_return_reads_copied_back_value() {


### PR DESCRIPTION
Fixes follow-up review from the merged group 7/v3 PR.\n\n- skips mutable map fixed-array copyback when the current snapshot key was deleted\n- avoids clobbering explicit map updates made while iterating a snapshot\n- adds regressions for current-key deletion and return-path copyback\n\nTests:\n- /Users/alexander/code/v6-v3-group8-interfaces-sumtypes/vnew -gc none -silent test vlib/v3/tests/map_for_mut_snapshot_codegen_test.v\n- /usr/bin/time -l sh -c '/Users/alexander/code/v6-v3-group8-interfaces-sumtypes/vnew -gc none -prealloc -prod -o /tmp/v3_map_loop_stage1 v3.v && /tmp/v3_map_loop_stage1 -building-v -o /tmp/v3_map_loop_stage2 v3.v'