### PR TITLE
all: fix issues #27799 through #27802

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3512,19 +3512,15 @@ fn calc() {
 The `pub` keyword is only allowed before the `const` keyword and cannot be used inside
 a `const ( )` block.
 
-Outside from module main all constants need to be prefixed with the module name.
+Constants can be referenced without a module prefix from within the module where they are
+defined. To access a public constant from another module, prefix it with the module name.
 
 ### Required module prefix
 
-When naming constants, `snake_case` must be used. In order to distinguish consts
-from local variables, the full path to consts must be specified. For example,
-to access the PI const, full `math.pi` name must be used both outside the `math`
-module, and inside it. That restriction is relaxed only for the `main` module
-(the one containing your `fn main()`), where you can use the unqualified name of
-constants defined there, i.e. `numbers`, rather than `main.numbers`.
-
-vfmt takes care of this rule, so you can type `println(pi)` inside the `math` module,
-and vfmt will automatically update it to `println(math.pi)`.
+When naming constants, `snake_case` must be used. Outside the module where a constant is
+defined, its full path must be specified. For example, use `math.pi` to access the public
+`pi` constant from another module. Inside the `math` module, the unqualified name `pi` can
+be used.
 
 <!--
 Many people prefer all caps consts: `TOP_CITIES`. This wouldn't work

--- a/vlib/sync/stdatomic/atomic.c.v
+++ b/vlib/sync/stdatomic/atomic.c.v
@@ -11,15 +11,13 @@ module stdatomic
 // add_u64 adds provided delta as an atomic operation
 @[inline]
 pub fn add_u64(ptr &u64, delta int) u64 {
-	C.atomic_fetch_add_u64(voidptr(ptr), delta)
-	return *ptr
+	return C.atomic_fetch_add_u64(voidptr(ptr), u64(delta)) + u64(delta)
 }
 
 // sub_u64 subtracts provided delta as an atomic operation
 @[inline]
 pub fn sub_u64(ptr &u64, delta int) u64 {
-	C.atomic_fetch_sub_u64(voidptr(ptr), delta)
-	return *ptr
+	return C.atomic_fetch_sub_u64(voidptr(ptr), u64(delta)) - u64(delta)
 }
 
 // fetch_add_u64 atomically adds `delta` and returns the previous value.
@@ -37,15 +35,13 @@ pub fn fetch_sub_u64(ptr &u64, delta u64) u64 {
 // add_i64 adds provided delta as an atomic operation
 @[inline]
 pub fn add_i64(ptr &i64, delta int) i64 {
-	C.atomic_fetch_add_u64(voidptr(ptr), delta)
-	return *ptr
+	return i64(C.atomic_fetch_add_u64(voidptr(ptr), u64(delta)) + u64(delta))
 }
 
-// add_i64 subtracts provided delta as an atomic operation
+// sub_i64 subtracts provided delta as an atomic operation
 @[inline]
 pub fn sub_i64(ptr &i64, delta int) i64 {
-	C.atomic_fetch_sub_u64(voidptr(ptr), delta)
-	return *ptr
+	return i64(C.atomic_fetch_sub_u64(voidptr(ptr), u64(delta)) - u64(delta))
 }
 
 // atomic store/load operations have to be used when there might be another concurrent access

--- a/vlib/v/checker/tests/undeclared_type_array_index_err.out
+++ b/vlib/v/checker/tests/undeclared_type_array_index_err.out
@@ -1,0 +1,12 @@
+vlib/v/checker/tests/undeclared_type_array_index_err.vv:10:4: error: undefined ident: `Yo`
+    8 | fn (mut a Array) update() {
+    9 |     a[0] = 0
+   10 |     a[Yo] = 0
+      |       ~~
+   11 | }
+vlib/v/checker/tests/undeclared_type_array_index_err.vv:10:4: error: non-integer index `void` (array type `[8]u8`)
+    8 | fn (mut a Array) update() {
+    9 |     a[0] = 0
+   10 |     a[Yo] = 0
+      |       ~~
+   11 | }

--- a/vlib/v/checker/tests/undeclared_type_array_index_err.vv
+++ b/vlib/v/checker/tests/undeclared_type_array_index_err.vv
@@ -1,0 +1,11 @@
+type Array = [8]u8
+
+fn main() {
+	mut arr := Array{}
+	arr.update()
+}
+
+fn (mut a Array) update() {
+	a[0] = 0
+	a[Yo] = 0
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4146,6 +4146,10 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 					if stmt.expr is ast.ArrayInit && stmt.expr.is_fixed {
 						is_array_fixed_init = true
 						ret_type = stmt.expr.typ
+					} else if stmt.expr is ast.StructInit
+						&& g.table.final_sym(g.unwrap_generic(stmt.typ)).kind == .array_fixed {
+						is_array_fixed_init = true
+						ret_type = stmt.typ
 					} else {
 						expr_typ := g.unwrap_generic(g.recheck_concrete_type(stmt.typ))
 						if expr_typ != ast.void_type && expr_typ != 0

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -7481,6 +7481,9 @@ fn (mut g Gen) ref_or_deref_arg_ex(arg ast.CallArg, expected_type_ ast.Type, lan
 				g.write('(${g.styp(arg.expr.typ)})')
 			}
 		}
+	} else if arg.expr is ast.StructInit
+		&& g.table.final_sym(g.unwrap_generic(arg.expr.typ)).kind == .array_fixed {
+		g.write('(${g.styp(arg.expr.typ)})')
 	} else if arg.expr is ast.ComptimeSelector && arg_typ.has_flag(.option)
 		&& !expected_type.has_flag(.option) {
 		// allow to pass val.$(filed.name) where T is expected, doing automatic unwrap in this case

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -1588,7 +1588,7 @@ fn (mut p Parser) ident(language ast.Language) ast.Ident {
 			scope:    p.scope
 		}
 	}
-	is_following_concrete_types := p.is_following_concrete_types()
+	is_following_concrete_types := !p.scope.known_var(name) && p.is_following_concrete_types()
 	mut concrete_types := []ast.Type{}
 	if p.expr_mod.len > 0 {
 		name = '${p.expr_mod}.${name}'

--- a/vlib/v/tests/fns/fn_call_fixed_array_literal_args_test.v
+++ b/vlib/v/tests/fns/fn_call_fixed_array_literal_args_test.v
@@ -7,3 +7,25 @@ fn get_str(t [1]int) string {
 	println(t)
 	return '${t}'
 }
+
+type Bools = [4]bool
+
+fn accept_bools(_ Bools) {
+}
+
+fn get_bools(i int) Bools {
+	return match i {
+		0 {
+			bools := Bools{}
+			bools
+		}
+		else {
+			Bools{}
+		}
+	}
+}
+
+fn test_fn_call_fixed_array_alias_init_arg() {
+	accept_bools(Bools{})
+	assert get_bools(1) == Bools{}
+}


### PR DESCRIPTION
## Summary

- return updated stdatomic i64/u64 values from the atomic fetch operations, avoiding a racing non-atomic read
- document the correct constant qualification rules inside and outside a module
- keep bracket expressions on known variables as array indexing so undeclared index identifiers reach the checker
- emit typed fixed-array alias literals for direct call arguments and match-expression temporaries

## Tests

- ./vnew -silent vlib/v/compiler_errors_test.v
- ./vnew -silent test vlib/v/parser/
- ./vnew -silent test vlib/v/checker/
- ./vnew -silent vlib/v/slow_tests/inout/compiler_test.v
- ./vnew -cstrict -cc clang vlib/v/tests/fns/fn_call_fixed_array_literal_args_test.v
- ./vnew -cstrict -cc clang vlib/sync/stdatomic/atomic_test.v
- focused ThreadSanitizer reproduction for the stdatomic race
- ./vnew vlib/v/tests/generics/generics_fn_variable_2_test.v
- ./vnew check-md doc/docs.md (the changed section passes; the full file still reports pre-existing formatting errors at lines 5299 and 5343)

Fixes #27799
Fixes #27800
Fixes #27801
Fixes #27802