### PR TITLE
json2: handle escaped keys during decoding, fix decoding of `?map` struct fields (fix #27810, fix #27811)

### DIFF
--- a/vlib/json2/decode.v
+++ b/vlib/json2/decode.v
@@ -417,8 +417,23 @@ fn mark_struct_field_decoded(decoded_mask u64, mut decoded_fields []bool, field_
 	return decoded_mask
 }
 
+// key_has_escape reports whether the JSON string key described by `key_info`
+// contains a `\` escape sequence.
+@[direct_array_access; inline]
+fn (decoder &Decoder) key_has_escape(key_info ValueInfo) bool {
+	for i in key_info.position + 1 .. key_info.position + key_info.length - 1 {
+		if decoder.json[i] == `\\` {
+			return true
+		}
+	}
+	return false
+}
+
 @[inline]
-fn (decoder &Decoder) json_key_matches(key_info ValueInfo, key_name string) bool {
+fn (mut decoder Decoder) json_key_matches(key_info ValueInfo, key_name string) !bool {
+	if decoder.key_has_escape(key_info) {
+		return decoder.decode_string_value(key_info)! == key_name
+	}
 	if key_info.length - 2 != key_name.len {
 		return false
 	}
@@ -474,9 +489,9 @@ fn decode_struct_key[T](mut decoder Decoder, val T, key_info ValueInfo, prefix s
 	$for field in T.fields {
 		field_info := field_infos[i]
 		$if !field.is_embed {
-			if decoder.json_key_matches(key_info, field_info.key_name)
+			if decoder.json_key_matches(key_info, field_info.key_name)!
 				|| (prefix != ''
-				&& decoder.json_key_matches(key_info, prefix + field_info.key_name)) {
+				&& decoder.json_key_matches(key_info, prefix + field_info.key_name)!) {
 				decoder.current_node = decoder.current_node.next
 
 				if field_info.is_skip {
@@ -553,7 +568,11 @@ fn decode_struct_key[T](mut decoder Decoder, val T, key_info ValueInfo, prefix s
 							} $else {
 								mut unwrapped_val := $zero(field.typ.payload_type)
 								decoder.decode_value(mut unwrapped_val)!
-								new_val.$(field.name) = unwrapped_val
+								$if unwrapped_val is $map {
+									new_val.$(field.name) = unwrapped_val.move()
+								} $else {
+									new_val.$(field.name) = unwrapped_val
+								}
 							}
 						}
 					} $else $if field.unaliased_typ is $array_dynamic {
@@ -611,7 +630,7 @@ fn decode_struct_key[T](mut decoder Decoder, val T, key_info ValueInfo, prefix s
 	$for field in T.fields {
 		field_info := field_infos[i]
 		$if field.is_embed {
-			if decoder.json_key_matches(key_info, field_info.key_name)
+			if decoder.json_key_matches(key_info, field_info.key_name)!
 				&& decoder.current_node.next != unsafe { nil }
 				&& decoder.current_node.next.value.value_kind == .object {
 				if field_info.is_required {
@@ -848,6 +867,15 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 							break
 						}
 
+						mut key_ptr := unsafe { voidptr(decoder.json.str + key_info.position + 1) }
+						mut key_len := key_info.length - 2
+						mut unescaped_key := ''
+						if decoder.key_has_escape(key_info) {
+							unescaped_key = decoder.decode_string_value(key_info)!
+							key_ptr = voidptr(unescaped_key.str)
+							key_len = unescaped_key.len
+						}
+
 						mut matched := false
 						field_idx = 0
 						$for field in T.fields {
@@ -856,8 +884,8 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 								field_can_match := (!field_info.is_skip || field_info.is_required)
 									&& !(field_info.is_omitempty
 									&& decoder.is_empty_value(decoder.current_node.next.value))
-								field_name_matches := key_info.length - 2 == field_info.json_name_len && unsafe {
-									vmemcmp(decoder.json.str + key_info.position + 1, field_info.json_name_ptr, field_info.json_name_len) == 0
+								field_name_matches := key_len == field_info.json_name_len && unsafe {
+									vmemcmp(key_ptr, field_info.json_name_ptr, field_info.json_name_len) == 0
 								}
 								if field_can_match && field_name_matches {
 									// value node
@@ -921,7 +949,11 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 												} $else {
 													mut unwrapped_val := $zero(field.typ.payload_type)
 													decoder.decode_value(mut unwrapped_val)!
-													val.$(field.name) = unwrapped_val
+													$if unwrapped_val is $map {
+														val.$(field.name) = unwrapped_val.move()
+													} $else {
+														val.$(field.name) = unwrapped_val
+													}
 												}
 											}
 										} $else $if field.unaliased_typ is $array_dynamic {
@@ -1049,110 +1081,113 @@ fn (mut decoder Decoder) decode_string[T](mut val T) ! {
 	string_info := decoder.current_node.value
 
 	if string_info.value_kind == .string {
-		string_start := string_info.position + 1
-		string_end := string_info.position + string_info.length - 1
-		string_body := decoder.json[string_start..string_end]
-		if string_body.index_u8(`\\`) == -1 {
-			val = string_body
-			return
-		}
+		val = decoder.decode_string_value(string_info)!
+	} else {
+		decoder.decode_error('Expected string, but got ${string_info.value_kind}')!
+	}
+}
 
-		mut string_buffer := []u8{cap: string_info.length} // might be too long but most json strings don't contain many escape characters anyways
+// decode_string_value returns the unescaped content of the JSON string described by `string_info`.
+fn (mut decoder Decoder) decode_string_value(string_info ValueInfo) !string {
+	string_start := string_info.position + 1
+	string_end := string_info.position + string_info.length - 1
+	string_body := decoder.json[string_start..string_end]
+	if string_body.index_u8(`\\`) == -1 {
+		return string_body
+	}
 
-		mut buffer_index := 1
-		mut string_index := 1
+	mut string_buffer := []u8{cap: string_info.length} // might be too long but most json strings don't contain many escape characters anyways
 
-		for string_index < string_info.length - 1 {
-			current_byte := decoder.json[string_info.position + string_index]
+	mut buffer_index := 1
+	mut string_index := 1
 
-			if current_byte == `\\` {
-				// push all characters up to this point
-				unsafe {
-					string_buffer.push_many(decoder.json.str + string_info.position + buffer_index,
-						string_index - buffer_index)
+	for string_index < string_info.length - 1 {
+		current_byte := decoder.json[string_info.position + string_index]
+
+		if current_byte == `\\` {
+			// push all characters up to this point
+			unsafe {
+				string_buffer.push_many(decoder.json.str + string_info.position + buffer_index,
+					string_index - buffer_index)
+			}
+
+			string_index++
+
+			escaped_char := decoder.json[string_info.position + string_index]
+
+			string_index++
+
+			match escaped_char {
+				`/`, `"`, `\\` {
+					string_buffer << escaped_char
 				}
+				`b` {
+					string_buffer << `\b`
+				}
+				`f` {
+					string_buffer << `\f`
+				}
+				`n` {
+					string_buffer << `\n`
+				}
+				`r` {
+					string_buffer << `\r`
+				}
+				`t` {
+					string_buffer << `\t`
+				}
+				`u` {
+					unicode_point := rune(strconv.parse_uint(decoder.json[string_info.position +
+						string_index..string_info.position + string_index + 4], 16, 32)!)
 
-				string_index++
+					string_index += 4
 
-				escaped_char := decoder.json[string_info.position + string_index]
+					if unicode_point < 0xD800 || unicode_point > 0xDFFF { // normal utf-8
+						string_buffer << unicode_point.bytes()
+					} else if unicode_point >= 0xDC00 { // trail surrogate -> invalid
+						decoder.decode_error('Got trail surrogate: ${u32(unicode_point):04X} before head surrogate.')!
+					} else { // head surrogate -> treat as utf-16
+						if string_index > string_info.length - 6 {
+							decoder.decode_error('Expected a trail surrogate after a head surrogate, but got no valid escape sequence.')!
+						}
+						if decoder.json[string_info.position + string_index..string_info.position +
+							string_index + 2] != '\\u' {
+							decoder.decode_error('Expected a trail surrogate after a head surrogate, but got no valid escape sequence.')!
+						}
 
-				string_index++
+						string_index += 2
 
-				match escaped_char {
-					`/`, `"`, `\\` {
-						string_buffer << escaped_char
-					}
-					`b` {
-						string_buffer << `\b`
-					}
-					`f` {
-						string_buffer << `\f`
-					}
-					`n` {
-						string_buffer << `\n`
-					}
-					`r` {
-						string_buffer << `\r`
-					}
-					`t` {
-						string_buffer << `\t`
-					}
-					`u` {
-						unicode_point := rune(strconv.parse_uint(decoder.json[
+						unicode_point2 := rune(strconv.parse_uint(decoder.json[
 							string_info.position + string_index..string_info.position +
 							string_index + 4], 16, 32)!)
 
 						string_index += 4
 
-						if unicode_point < 0xD800 || unicode_point > 0xDFFF { // normal utf-8
-							string_buffer << unicode_point.bytes()
-						} else if unicode_point >= 0xDC00 { // trail surrogate -> invalid
-							decoder.decode_error('Got trail surrogate: ${u32(unicode_point):04X} before head surrogate.')!
-						} else { // head surrogate -> treat as utf-16
-							if string_index > string_info.length - 6 {
-								decoder.decode_error('Expected a trail surrogate after a head surrogate, but got no valid escape sequence.')!
-							}
-							if decoder.json[string_info.position + string_index..
-								string_info.position + string_index + 2] != '\\u' {
-								decoder.decode_error('Expected a trail surrogate after a head surrogate, but got no valid escape sequence.')!
-							}
-
-							string_index += 2
-
-							unicode_point2 := rune(strconv.parse_uint(decoder.json[
-								string_info.position + string_index..string_info.position +
-								string_index + 4], 16, 32)!)
-
-							string_index += 4
-
-							if unicode_point2 < 0xDC00 {
-								decoder.decode_error('Expected a trail surrogate after a head surrogate, but got ${u32(unicode_point):04X}.')!
-							}
-
-							final_unicode_point := (unicode_point2 & 0x3FF) +
-								((unicode_point & 0x3FF) << 10) + 0x10000
-							string_buffer << final_unicode_point.bytes()
+						if unicode_point2 < 0xDC00 {
+							decoder.decode_error('Expected a trail surrogate after a head surrogate, but got ${u32(unicode_point):04X}.')!
 						}
+
+						final_unicode_point := (unicode_point2 & 0x3FF) +
+							((unicode_point & 0x3FF) << 10) + 0x10000
+						string_buffer << final_unicode_point.bytes()
 					}
-					else {} // has already been checked
 				}
-
-				buffer_index = string_index
-			} else {
-				string_index++
+				else {} // has already been checked
 			}
-		}
 
-		// push the rest
-		unsafe {
-			string_buffer.push_many(decoder.json.str + string_info.position + buffer_index,
-				string_index - buffer_index)
+			buffer_index = string_index
+		} else {
+			string_index++
 		}
-
-		val = string_buffer.bytestr()
-	} else {
-		decoder.decode_error('Expected string, but got ${string_info.value_kind}')!
 	}
+
+	// push the rest
+	unsafe {
+		string_buffer.push_many(decoder.json.str + string_info.position + buffer_index,
+			string_index - buffer_index)
+	}
+
+	return string_buffer.bytestr()
 }
 
 fn (mut decoder Decoder) decode_array[T](mut val []T) ! {
@@ -1228,8 +1263,11 @@ fn (mut decoder Decoder) decode_map[V](mut val map[string]V) ! {
 					break
 				}
 
-				key_str := decoder.json[key_info.position + 1..key_info.position + key_info.length -
-					1]
+				key_str := if decoder.key_has_escape(key_info) {
+					decoder.decode_string_value(key_info)!
+				} else {
+					decoder.json[key_info.position + 1..key_info.position + key_info.length - 1]
+				}
 
 				decoder.current_node = decoder.current_node.next
 

--- a/vlib/json2/tests/decode_escaped_key_test.v
+++ b/vlib/json2/tests/decode_escaped_key_test.v
@@ -1,0 +1,56 @@
+import json2
+
+struct Inner {
+mut:
+	ok string
+}
+
+struct Outer {
+mut:
+	strings map[string]string
+	inner   Inner
+}
+
+struct Base {
+mut:
+	id int
+}
+
+struct WithEmbed {
+	Base
+mut:
+	name string
+}
+
+// https://github.com/vlang/v/issues/27811
+fn test_escaped_struct_and_map_keys() {
+	o := json2.decode[Outer](r'{"str\u0069ngs":{"o\u006b":"OK"},"\u0069nner":{"ok":"yes"}}')!
+	assert o.strings['ok'] == 'OK'
+	assert o.inner.ok == 'yes'
+}
+
+fn test_escaped_key_with_embed() {
+	w := json2.decode[WithEmbed](r'{"\u0069d": 7, "nam\u0065": "x"}')!
+	assert w.id == 7
+	assert w.name == 'x'
+}
+
+fn test_escaped_map_keys() {
+	m := json2.decode[map[string]string](r'{"\u006bey": "value", "a\"b\n": "c"}')!
+	assert m['key'] == 'value'
+	assert m['a"b\n'] == 'c'
+	assert m.len == 2
+}
+
+fn test_unescaped_keys_still_match() {
+	o := json2.decode[Outer]('{"strings":{"ok":"OK"},"inner":{"ok":"yes"}}')!
+	assert o.strings['ok'] == 'OK'
+	assert o.inner.ok == 'yes'
+}
+
+fn test_escaped_key_roundtrip() {
+	original := {
+		'a"b\n': 1
+	}
+	assert json2.decode[map[string]int](json2.encode(original))! == original
+}

--- a/vlib/json2/tests/decode_option_map_field_test.v
+++ b/vlib/json2/tests/decode_option_map_field_test.v
@@ -1,0 +1,53 @@
+import json2
+
+struct WithOptMap {
+mut:
+	m ?map[string]string
+	n ?map[string]int
+}
+
+struct BaseWithOptMap {
+mut:
+	bm ?map[string]string
+}
+
+struct EmbedWithOptMap {
+	BaseWithOptMap
+mut:
+	m ?map[string]string
+}
+
+// https://github.com/vlang/v/issues/27810
+fn test_decode_option_map_field() {
+	foo := json2.decode[WithOptMap]('{"m":{"a":"b"}}')!
+	if m := foo.m {
+		assert m['a'] == 'b'
+	} else {
+		assert false
+	}
+	assert foo.n == none
+}
+
+fn test_decode_option_map_field_null() {
+	foo := json2.decode[WithOptMap]('{"m":null,"n":{"x":1}}')!
+	assert foo.m == none
+	if n := foo.n {
+		assert n['x'] == 1
+	} else {
+		assert false
+	}
+}
+
+fn test_decode_option_map_field_with_embed() {
+	foo := json2.decode[EmbedWithOptMap]('{"bm":{"k":"v"},"m":{"a":"b"}}')!
+	if bm := foo.bm {
+		assert bm['k'] == 'v'
+	} else {
+		assert false
+	}
+	if m := foo.m {
+		assert m['a'] == 'b'
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
This fixes two json2 decoding bugs in a single PR:

## #27811 — escaped property names are not handled during decode

The decoder matched struct field names and map keys against the raw JSON bytes, so input like `{"str\u0069ngs":{"o\u006b":"OK"}}` never matched the `strings` field, and map keys were stored with their escape sequences intact (`a\"b` instead of `a"b`).

- The string unescaping logic is extracted out of `decode_string` into a reusable `decode_string_value(string_info)` helper.
- All three key matching sites (the fast struct path, the embed struct path via `json_key_matches`, and `decode_map`) now check whether the key contains a `\` and unescape it before matching/storing. Keys without escapes (the overwhelmingly common case) keep the previous zero-allocation byte comparison.

## #27810 — `cannot copy map` compile error for `?map[K]V` struct fields

Decoding a struct with an option map field, e.g.

```v
struct Foo {
	m ?map[string]string
}
```

failed to compile with `error: cannot copy map: call 'move' or 'clone' method (or use a reference)` at `vlib/json2/decode.v:924` and `:556`. Both option-field assignment sites now use `.move()` when the option payload is a map, mirroring the existing map handling for plain fields.

Regression tests are added for both issues (escaped struct/map/embed keys, roundtrip of keys that need escaping, option map fields incl. `null` and embed cases).
