### PR TITLE
cgen: fix `&Alias{}` of fixed array aliases, do not zero-init unset fields of C structs (fix #27793, fix #27794)

### DIFF
--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -85,6 +85,18 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 	} else if sym.kind == .map || (sym.kind == .array && node.init_fields.len == 0) {
 		g.write(g.type_default(unwrapped_typ))
 		return
+	} else if g.is_amp && sym.kind == .array_fixed && node.init_fields.len == 0
+		&& !node.typ.has_flag(.option) {
+		// `&Alias{}` of a fixed array alias: HEAP() cannot handle array typedefs,
+		// so delegate to array_init, which hoists a tmp var and memdup()s it —
+		// the same C that is generated for a non-aliased `&[N]T{}`.
+		g.array_init(ast.ArrayInit{
+			pos:       node.pos
+			is_fixed:  true
+			typ:       g.table.unaliased_type(unwrapped_typ)
+			elem_type: sym.array_fixed_info().elem_type
+		}, '')
+		return
 	}
 	is_amp := g.is_amp
 	is_multiline := node.init_fields.len > 5
@@ -470,6 +482,12 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 					g.write(c_name(field.name))
 				}
 			} else {
+				// V-side declarations of C structs are descriptive and may be partial
+				// or inexact, so never name fields the user did not set — C99 6.7.9p19
+				// zero-initializes the remaining members anyway.
+				if sym.language == .c && !field.has_default_expr {
+					continue
+				}
 				if !g.zero_struct_field(field) {
 					nr_fields--
 					continue

--- a/vlib/v/gen/c/testdata/compare_structs.c.must_have
+++ b/vlib/v/gen/c/testdata/compare_structs.c.must_have
@@ -1,6 +1,6 @@
-struct Something _t1 = ((struct Something){.fint = 0,.ff32 = 0,.fchar = 0,});
+struct Something _t1 = ((struct Something){0});
 struct Something aaa = _t1;
-struct Something _t2 = ((struct Something){.fint = 0,.ff32 = 0,.fchar = 0,});
+struct Something _t2 = ((struct Something){0});
 struct Something bbb = _t2;
 if (Something_struct_eq(aaa, bbb)) {
 

--- a/vlib/v/tests/c_structs/cstruct_partial_decl_test.c.v
+++ b/vlib/v/tests/c_structs/cstruct_partial_decl_test.c.v
@@ -1,0 +1,21 @@
+#include "@VMODROOT/partial.h"
+
+// The V-side declaration of a C struct is descriptive and may be partial or
+// inexact: `bogus` does not exist in the real C struct. Init literals must not
+// emit initializers for fields the user did not set (issue #27793).
+struct C.PartialDecl {
+	x     int
+	y     i64
+	bogus int
+}
+
+fn test_c_struct_init_literal_ignores_unset_fields() {
+	a := C.PartialDecl{
+		x: 42
+	}
+	b := C.PartialDecl{}
+	assert a.x == 42
+	assert a.y == 0
+	assert b.x == 0
+	assert b.y == 0
+}

--- a/vlib/v/tests/c_structs/partial.h
+++ b/vlib/v/tests/c_structs/partial.h
@@ -1,0 +1,4 @@
+struct PartialDecl {
+	int x;
+	long long y;
+};

--- a/vlib/v/tests/fixed_array_alias_ref_init_test.v
+++ b/vlib/v/tests/fixed_array_alias_ref_init_test.v
@@ -1,0 +1,34 @@
+type Addr = [32]u8
+
+struct Holder {
+	p &Addr = unsafe { nil }
+}
+
+fn takes(p &Addr) u8 {
+	return unsafe { p[0] }
+}
+
+// https://github.com/vlang/v/issues/27794
+fn test_inline_ref_init_of_fixed_array_alias_as_arg() {
+	assert takes(&Addr{}) == 0
+}
+
+fn test_ref_init_of_fixed_array_alias_assigned() {
+	a := &Addr{}
+	assert takes(a) == 0
+}
+
+fn test_ref_init_of_fixed_array_alias_in_struct_field() {
+	h := Holder{
+		p: &Addr{}
+	}
+	assert takes(h.p) == 0
+}
+
+fn ret_ptr() &Addr {
+	return &Addr{}
+}
+
+fn test_ref_init_of_fixed_array_alias_returned() {
+	assert takes(ret_ptr()) == 0
+}


### PR DESCRIPTION
This fixes two cgen bugs in a single PR:

## #27794 — inline `&Alias{}` of a fixed-array alias emits invalid `HEAP(...)`

`&Addr{}` (where `type Addr = [32]u8`) went through `struct_init()`'s `is_amp` branch, which emits `HEAP(Array_fixed_u8_32, ((Array_fixed_u8_32){0}))` — invalid C, since the `HEAP()` macro's compound-literal element cannot be initialized from an expression of array type. The non-aliased `&[32]u8{}` already works because `array_init()` hoists a tmp var and `memdup()`s it instead.

Fix: in `struct_init()`, when the init is `&`-taken, the resolved sym is a fixed array, and there are no init fields, delegate to `array_init()` with the unaliased type. The generated C is now identical to the non-aliased case:

```c
Array_fixed_u8_32 _t1 = {0};
main__takes(builtin__memdup((void*)&_t1, sizeof(Array_fixed_u8_32)));
```

## #27793 — `C.foo{}` emits designated initializers for every V-declared field

The zero-fill loop in `struct_init()` emitted `.field = <default>` for every V-declared field of a `C.` struct, so a V declaration that does not exactly mirror the C header (which the docs explicitly allow) made every init literal fail to C-compile. The type-default path (`Wrapper{}` with a C-struct field) already handled this correctly.

Fix: skip the zero-fill for unset fields when `sym.language == .c` (C99 6.7.9p19 zero-initializes the remaining members anyway). Fields with an explicit V-side default expression are still emitted, preserving the existing `cstruct_default_value_test.c.v` behavior. The three init paths from the issue now generate:

```c
struct timeval _t1 = ((struct timeval){.tv_sec = 1,});
struct timeval _t2 = ((struct timeval){0});
main__Wrapper _t3 = ((main__Wrapper){.tv = {0},});
```

`compare_structs.c.must_have` is updated accordingly (it pinned the old field-enumerating output).

## Tests

- `vlib/v/tests/fixed_array_alias_ref_init_test.v` — `&Alias{}` inline as an argument, assigned, as a struct field value, and returned from a function.
- `vlib/v/tests/c_structs/cstruct_partial_decl_test.c.v` + `partial.h` — a V declaration with a `bogus` field that does not exist in the real C struct; init literals now compile and run.

Verified with cc and tcc, with default GC and `-gc none`; `v test vlib/v/gen/c` (incl. coutput), `vlib/v/tests/c_structs`, `vlib/v/tests/structs`, `vlib/v/tests/aliases`, all `*fixed*`/`*alias*` tests, and `vlib/os`/`vlib/time` all pass. Union C-struct inits are unaffected (they already skipped unset fields).