### PR TITLE
checker,parser: allow normal types in `$match` branches, report `$zero` type mismatches, stop vfmt forcing a newline after `match` (fix #27787, fix #27789, fix #27790)

### DIFF
--- a/vlib/v/checker/infix.v
+++ b/vlib/v/checker/infix.v
@@ -1158,7 +1158,13 @@ fn (mut c Checker) infix_expr(mut node ast.InfixExpr) ast.Type {
 	}
 
 	// Dual sides check (compatibility check)
-	if node.left !is ast.ComptimeCall && node.right !is ast.ComptimeCall {
+	// `$zero()`/`$new()` have a fully known result type, so they are checkable like any
+	// other expression (fix #27790); other comptime calls are skipped.
+	left_is_opaque_ct_call := node.left is ast.ComptimeCall
+		&& (node.left as ast.ComptimeCall).kind !in [.zero, .new]
+	right_is_opaque_ct_call := node.right is ast.ComptimeCall
+		&& (node.right as ast.ComptimeCall).kind !in [.zero, .new]
+	if !left_is_opaque_ct_call && !right_is_opaque_ct_call {
 		if left_type.has_flag(.generic) {
 			left_type = c.unwrap_generic(left_type)
 			left_sym = c.table.sym(left_type)

--- a/vlib/v/checker/match.v
+++ b/vlib/v/checker/match.v
@@ -802,7 +802,7 @@ fn (mut c Checker) match_exprs(mut node ast.MatchExpr, cond_type_sym ast.TypeSym
 				// ensure that the sub expressions of the branch are actually checked, before anything else:
 				_ := c.expr(mut expr)
 			}
-			if expr is ast.TypeNode && cond_sym.kind == .struct {
+			if expr is ast.TypeNode && cond_sym.kind == .struct && !node.is_comptime {
 				c.error('struct instances cannot be matched by type name, they can only be matched to other instances of the same struct type',
 					branch.pos)
 			}

--- a/vlib/v/checker/tests/comptime_zero_generic_type_mismatch_err.out
+++ b/vlib/v/checker/tests/comptime_zero_generic_type_mismatch_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/comptime_zero_generic_type_mismatch_err.vv:6:9: error: infix expr: cannot use `Bar[Bar[int]]` (right expression) as `Bar[int]`
+    4 | 
+    5 | fn is_zero[T](val T) bool {
+    6 |     return val == $zero(Bar[T])
+      |            ~~~~~~~~~~~~~~~~~~~~
+    7 | }
+    8 |

--- a/vlib/v/checker/tests/comptime_zero_generic_type_mismatch_err.vv
+++ b/vlib/v/checker/tests/comptime_zero_generic_type_mismatch_err.vv
@@ -1,0 +1,11 @@
+struct Bar[T] {
+	val T
+}
+
+fn is_zero[T](val T) bool {
+	return val == $zero(Bar[T])
+}
+
+fn main() {
+	assert !is_zero(Bar[int]{42})
+}

--- a/vlib/v/fmt/tests/match_expected.vv
+++ b/vlib/v/fmt/tests/match_expected.vv
@@ -42,7 +42,6 @@ fn match_branch_extra_comma() {
 		Foo, Bar {}
 		int, string {}
 	}
-
 	match n {
 		0...5 {}
 		2, 3 {}

--- a/vlib/v/fmt/tests/match_stmt_no_forced_newline_keep.vv
+++ b/vlib/v/fmt/tests/match_stmt_no_forced_newline_keep.vv
@@ -1,0 +1,43 @@
+// https://github.com/vlang/v/issues/27787
+// vfmt must not force an empty line after `match`/`$match` statements
+const x = $match @OS {
+	'linux' {
+		'linux'
+	}
+	$else {
+		'not_linux'
+	}
+}
+
+fn foo(a int) (string, string) {
+	first := match a {
+		0 { 'a' }
+		1 { 'b' }
+		2 { 'c' }
+		else { '' }
+	}
+	second := $match @OS {
+		'linux' {
+			'linux'
+		}
+		$else {
+			'not_linux'
+		}
+	}
+	return first, second
+}
+
+fn bar(a int) string {
+	mut res := ''
+	match a {
+		0 { res = 'a' }
+		else { res = 'b' }
+	}
+	res += match a {
+		0 { 'x' }
+		else { 'y' }
+	}
+
+	// an intentional empty line before this comment is preserved
+	return res
+}

--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -613,7 +613,10 @@ fn (mut p Parser) match_expr(is_comptime bool, is_expr bool) ast.MatchExpr {
 		len:     match_last_pos.pos - match_first_pos.pos + match_last_pos.len
 		col:     match_first_pos.col
 	}
-	pos.update_last_line(match_last_pos.line_nr)
+	// match_last_pos is a Pos (already 0-based), so update_last_line (which expects
+	// a 1-based token line) would leave last_line one line short of the closing `}`,
+	// making vfmt insert a bogus empty line after the match statement.
+	pos.last_line = match_last_pos.last_line
 	return ast.MatchExpr{
 		is_comptime: is_comptime
 		is_expr:     is_expr_

--- a/vlib/v/tests/comptime/comptime_match_mixed_types_test.v
+++ b/vlib/v/tests/comptime/comptime_match_mixed_types_test.v
@@ -1,0 +1,58 @@
+// https://github.com/vlang/v/issues/27789
+struct Bar {}
+
+struct Baz {}
+
+struct Gen[T] {}
+
+fn foo[T]() int {
+	mut r := 0
+	$match T {
+		$int {
+			r = 1
+		}
+		$float {
+			r = 2
+		}
+		Bar {
+			r = 3
+		}
+		$else {
+			r = -1
+		}
+	}
+	return r
+}
+
+fn test_comptime_match_mixing_comptime_and_normal_types() {
+	assert foo[int]() == 1
+	assert foo[f32]() == 2
+	assert foo[Bar]() == 3
+	assert foo[[]u8]() == -1
+}
+
+fn multi[T]() int {
+	$match T {
+		Bar, Baz {
+			return 3
+		}
+		Gen[int] {
+			return 4
+		}
+		$int {
+			return 1
+		}
+		$else {
+			return -1
+		}
+	}
+	return 0
+}
+
+fn test_comptime_match_multi_type_branches() {
+	assert multi[int]() == 1
+	assert multi[Bar]() == 3
+	assert multi[Baz]() == 3
+	assert multi[Gen[int]]() == 4
+	assert multi[string]() == -1
+}


### PR DESCRIPTION
This fixes three issues in a single PR:

## #27787 — vfmt forces an empty line after `match`/`$match` statements

Root cause was an off-by-one in the parser, not in vfmt itself: `match_expr()` called `pos.update_last_line(match_last_pos.line_nr)`, but `match_last_pos` is a `token.Pos` whose `line_nr` is already 0-based, while `update_last_line()` expects a 1-based token line (it subtracts 1). The double conversion left `MatchExpr.pos.last_line` one line short of the closing `}`. vfmt then computed `next_stmt.line - prev_stmt.last_line == 2` and "preserved" a source empty line that was never there. This was the only call site passing a `Pos.line_nr`; all others pass raw `tok.line_nr` values.

Blank lines that users actually wrote are still preserved — the fix only stops inventing new ones, so all previously formatted code (which had the forced blank line baked in) still passes `v fmt -verify`. The `match_expected.vv` fmt test had the bogus blank line baked in and is updated.

## #27789 — mixing comptime types with normal types in `$match`

`$match T { $int {...} Bar {...} }` hit the "struct instances cannot be matched by type name" checker error, because that check did not exempt comptime matches (where matching by type name is the entire point, and which the equivalent `$if T is Bar` chain already supports). The branch evaluation itself (`check_compatible_types`) already handles plain `TypeNode` branches, so the fix is to skip that error for `node.is_comptime` — the same exemption the neighboring "matching by type can only be done for sum types" check already had. The error still fires for regular `match` on struct values.

## #27790 — C error instead of checker error for `$zero` type mismatches

`fn is_zero[T](val T) { return val == $zero(Bar[T]) }` called with `T = Bar[int]` compares `Bar[int]` with `Bar[Bar[int]]` and died in the C compiler. The infix checker skips its dual-side compatibility check whenever either operand is a `ComptimeCall` — reasonable for opaque calls like `$env()`, but `$zero()`/`$new()` have fully known result types. The exemption is now lifted for those two kinds, so the mismatch is reported as a proper checker error at instantiation time:

```
error: infix expr: cannot use `Bar[Bar[int]]` (right expression) as `Bar[int]`
```

Valid uses (`val == $zero(T)`, `val == $zero(Bar[T])` with `val Bar[T]`, `$new(...)` comparisons) still compile and run.

## Tests

- `vlib/v/fmt/tests/match_stmt_no_forced_newline_keep.vv` — the issue's repro plus statement-position and `+=` match forms; also covers that intentional blank lines are kept.
- `vlib/v/tests/comptime/comptime_match_mixed_types_test.v` — mixed `$int`/`$float`/`Bar` branches, multi-type branches (`Bar, Baz`), and generic-instantiation branches (`Gen[int]`).
- `vlib/v/checker/tests/comptime_zero_generic_type_mismatch_err.vv/.out` — the new checker error.

`v test vlib/v/fmt`, `vlib/v/checker`, `vlib/v/parser`, `vlib/v/tests/comptime`, `vlib/v/tests/generics`, all `*match*` tests, and `v test-cleancode` (5711 files) pass. The two failures encountered along the way (`generic_fn_short_syntax_struct_param_test.v`, `arc_d_ownership.v` fmt-verify) reproduce identically on clean master and are unrelated.