### PR TITLE
cgen, markused: fix stale embed/option info in generic fns with multiple instantiations (fix #27786)

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -4399,6 +4399,14 @@ fn (mut g Gen) unwrap_receiver_type(node ast.CallExpr) (ast.Type, &ast.TypeSymbo
 			resolved_left_type := g.resolve_current_fn_generic_param_type(node.left.name)
 			if resolved_left_type != 0 {
 				left_type = resolved_left_type
+			} else if g.cur_fn != unsafe { nil } && g.cur_concrete_types.len > 0 {
+				// node.left_type may be stale from a previous generic instantiation
+				// (the checker overwrites it on each pass); re-resolve it from the scope
+				scope_type := g.resolved_scope_var_type(node.left)
+				if scope_type != 0 && !scope_type.has_flag(.generic)
+					&& !g.type_has_unresolved_generic_parts(scope_type) {
+					left_type = scope_type
+				}
 			}
 		}
 	} else if node.left is ast.StructInit {
@@ -4760,6 +4768,24 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	}
 	left_sym := g.table.sym(left_type)
 	final_left_sym := g.table.final_sym(left_type)
+	// In generic functions node.from_embed_types may be stale: the checker overwrites
+	// it on each instantiation pass, so the state of the last checked concrete type
+	// wins. Re-resolve it for the current concrete receiver type.
+	mut effective_embed_types := node.from_embed_types.clone()
+	if g.cur_fn != unsafe { nil } && g.cur_concrete_types.len > 0 && effective_embed_types.len > 0
+		&& left_sym.kind != .interface && final_left_sym.info is ast.Struct {
+		if left_sym.has_method(method_name) || final_left_sym.has_method(method_name)
+			|| final_left_sym.has_method_with_generic_parent(method_name) {
+			effective_embed_types = []
+		} else {
+			_, embed_types := g.table.find_method_from_embeds(final_left_sym, method_name) or {
+				ast.Fn{}, []ast.Type{}
+			}
+			if embed_types.len > 0 {
+				effective_embed_types = embed_types.clone()
+			}
+		}
+	}
 	mut use_builtin_array_sort := false
 	if final_left_sym.kind == .array && node.kind in [.sort, .sorted] && node.args.len > 0 {
 		if method := left_sym.find_method(method_name) {
@@ -5471,7 +5497,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	}
 
 	if free_receiver_heap_copy == '' && receiver_needs_ref && (!left_type.is_ptr()
-		|| node.from_embed_types.len != 0 || (left_type.has_flag(.shared_f) && node.kind != .str)) {
+		|| effective_embed_types.len != 0 || (left_type.has_flag(.shared_f) && node.kind != .str)) {
 		// The receiver is a reference, but the caller provided a value
 		// Add `&` automatically.
 		// TODO: same logic in call_args()
@@ -5499,11 +5525,11 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			}
 		}
 	} else if free_receiver_heap_copy == '' && !receiver_needs_ref && left_type.is_ptr()
-		&& node.kind != .str && node.from_embed_types.len == 0 {
+		&& node.kind != .str && effective_embed_types.len == 0 {
 		if !left_type.has_flag(.shared_f) {
 			g.write('*'.repeat(left_type.nr_muls()))
 		}
-	} else if free_receiver_heap_copy == '' && !is_range_slice && node.from_embed_types.len == 0
+	} else if free_receiver_heap_copy == '' && !is_range_slice && effective_embed_types.len == 0
 		&& node.kind != .str {
 		diff := left_type.nr_muls() - receiver_type.nr_muls()
 		if diff > 0 {
@@ -5524,7 +5550,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			g.write('(map[]){')
 			g.expr(ast.Expr(node.left))
 			g.write('}[0]')
-		} else if !is_interface && node.from_embed_types.len > 0 {
+		} else if !is_interface && effective_embed_types.len > 0 {
 			// For mut generic params where the concrete type resolves
 			// to a multi-pointer (e.g. mut ctx X where X = &Context →
 			// C param is Context**), fn_decl_params adds .ref() which
@@ -5547,29 +5573,29 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			} else {
 				g.expr(ast.Expr(node.left))
 			}
-		} else if is_interface && node.from_embed_types.len > 0 {
+		} else if is_interface && effective_embed_types.len > 0 {
 			if g.out.last_n(1) == '&' {
 				g.go_back(1)
 			}
 			if receiver_type.is_ptr() && left_type.is_ptr() {
 				// (main__IFoo*)bar
-				g.write2('(', g.table.sym(node.from_embed_types.last()).cname)
+				g.write2('(', g.table.sym(effective_embed_types.last()).cname)
 				g.write('*)')
 				g.expr(ast.Expr(node.left))
 			} else if receiver_type.is_ptr() && !left_type.is_ptr() {
 				// (main__IFoo*)&bar
-				g.write2('(', g.table.sym(node.from_embed_types.last()).cname)
+				g.write2('(', g.table.sym(effective_embed_types.last()).cname)
 				g.write('*)&')
 				g.expr(ast.Expr(node.left))
 			} else if !receiver_type.is_ptr() && left_type.is_ptr() {
 				// *((main__IFoo*)bar)
-				g.write2('*((', g.table.sym(node.from_embed_types.last()).cname)
+				g.write2('*((', g.table.sym(effective_embed_types.last()).cname)
 				g.write('*)')
 				g.expr(ast.Expr(node.left))
 				g.write(')')
 			} else {
 				// *((main__IFoo*)&bar)
-				g.write2('*((', g.table.sym(node.from_embed_types.last()).cname)
+				g.write2('*((', g.table.sym(effective_embed_types.last()).cname)
 				g.write('*)&')
 				g.expr(node.left)
 				g.write(')')
@@ -5580,8 +5606,8 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			}
 			g.expr(node.left)
 		}
-		if !is_interface || node.from_embed_types.len == 0 {
-			mut node_embed_types := node.from_embed_types.clone()
+		if !is_interface || effective_embed_types.len == 0 {
+			mut node_embed_types := effective_embed_types.clone()
 			if node.left is ast.Ident && g.comptime.get_ct_type_var(node.left) == .generic_var
 				&& !final_left_sym.has_method(method_name)
 				&& !final_left_sym.has_method_with_generic_parent(method_name) {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -4770,10 +4770,11 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	final_left_sym := g.table.final_sym(left_type)
 	// In generic functions node.from_embed_types may be stale: the checker overwrites
 	// it on each instantiation pass, so the state of the last checked concrete type
-	// wins. Re-resolve it for the current concrete receiver type.
+	// wins (including a possibly empty state). Re-resolve it for the current
+	// concrete receiver type.
 	mut effective_embed_types := node.from_embed_types.clone()
-	if g.cur_fn != unsafe { nil } && g.cur_concrete_types.len > 0 && effective_embed_types.len > 0
-		&& left_sym.kind != .interface && final_left_sym.info is ast.Struct {
+	if g.cur_fn != unsafe { nil } && g.cur_concrete_types.len > 0 && left_sym.kind != .interface
+		&& final_left_sym.info is ast.Struct {
 		if left_sym.has_method(method_name) || final_left_sym.has_method(method_name)
 			|| final_left_sym.has_method_with_generic_parent(method_name) {
 			effective_embed_types = []

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -54,6 +54,21 @@ fn (mut g Gen) resolved_if_guard_expr_type(expr ast.Expr, default_type ast.Type)
 			return value_type
 		}
 	}
+	if g.cur_fn != unsafe { nil } && g.cur_concrete_types.len > 0 {
+		// In generic functions default_type may be stale: the checker overwrites
+		// it on each instantiation pass. Re-resolve it from the guard expression.
+		resolved := g.resolved_expr_type(expr, default_type)
+		if resolved != 0 && resolved != ast.void_type && !resolved.has_flag(.generic)
+			&& !g.type_has_unresolved_generic_parts(resolved) {
+			mut typ := g.unwrap_generic(resolved)
+			if default_type.has_flag(.option) && !typ.has_flag(.option) {
+				typ = typ.set_flag(.option)
+			} else if default_type.has_flag(.result) && !typ.has_flag(.result) {
+				typ = typ.set_flag(.result)
+			}
+			return typ
+		}
+	}
 	return g.unwrap_generic(g.recheck_concrete_type(default_type))
 }
 
@@ -893,6 +908,8 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 					} else {
 						cond.expr_type
 					}
+				} else if g.cur_fn != unsafe { nil } && g.cur_concrete_types.len > 0 {
+					g.resolved_if_guard_expr_type(cond.expr, cond.expr_type)
 				} else {
 					cond.expr_type
 				}

--- a/vlib/v/markused/walker.v
+++ b/vlib/v/markused/walker.v
@@ -1955,8 +1955,12 @@ pub fn (mut w Walker) call_expr(mut node ast.CallExpr) {
 						continue
 					}
 					for i, ct in concrete_type_list {
-						if ct == resolved_left_type && w.cur_fn_concrete_types[i] != ct {
-							resolved_left_type = w.cur_fn_concrete_types[i]
+						// compare by idx: the stale type may differ in nr_muls
+						// (e.g. `for mut item in items` makes it a reference)
+						if ct.idx() == resolved_left_type.idx()
+							&& w.cur_fn_concrete_types[i].idx() != ct.idx() {
+							resolved_left_type =
+								w.cur_fn_concrete_types[i].set_nr_muls(resolved_left_type.nr_muls())
 							break
 						}
 					}
@@ -2045,7 +2049,7 @@ pub fn (mut w Walker) call_expr(mut node ast.CallExpr) {
 		}
 	}
 	if node.is_method {
-		resolved_fkey, resolved_receiver := w.resolve_method_call_fkey(node)
+		resolved_fkey, resolved_receiver := w.resolve_method_call_fkey(node, resolved_left_type)
 		if resolved_fkey != '' {
 			fn_name = resolved_fkey
 			receiver_typ = resolved_receiver
@@ -2346,8 +2350,14 @@ fn (w &Walker) method_decl_fkey(method ast.Fn) (string, ast.Type) {
 	return method.fkey(), method.receiver_type
 }
 
-fn (mut w Walker) resolve_method_call_fkey(node ast.CallExpr) (string, ast.Type) {
+fn (mut w Walker) resolve_method_call_fkey(node ast.CallExpr, resolved_left_type ast.Type) (string, ast.Type) {
 	mut candidate_types := []ast.Type{}
+	// Prefer the re-resolved left type: inside generic functions the AST types
+	// are stale (they reflect the last checked instantiation, not the current one).
+	if resolved_left_type != 0 && resolved_left_type != node.left_type
+		&& !resolved_left_type.has_flag(.generic) {
+		candidate_types << resolved_left_type
+	}
 	if node.left is ast.Ident && node.left.obj is ast.Var {
 		resolved_current_type := w.resolve_current_specialized_var_type(node.left.name)
 		if resolved_current_type != 0 && resolved_current_type !in candidate_types {

--- a/vlib/v/tests/generics/generic_fn_if_guard_option_param_test.v
+++ b/vlib/v/tests/generics/generic_fn_if_guard_option_param_test.v
@@ -1,0 +1,27 @@
+// For issue 27786: the temp var of an `if x := opt {` guard inside a generic
+// function was declared with the option type of the last checked
+// instantiation, producing invalid C code for all other instantiations.
+fn unwrap_option_or[T](option_type ?T, default_value T) T {
+	if some_value := option_type {
+		return some_value
+	}
+	return default_value
+}
+
+fn unwrap_option_or_option[T](option_type ?T, default_option ?T) ?T {
+	if some_value := option_type {
+		return some_value
+	}
+	return default_option
+}
+
+fn test_if_guard_on_generic_option_param() {
+	assert unwrap_option_or[string](?string('hi'), 'def') == 'hi'
+	assert unwrap_option_or[string](none, 'def') == 'def'
+	assert unwrap_option_or[bool](?bool(true), false) == true
+	assert unwrap_option_or[i32](?i32(7), 3) == 7
+	a := unwrap_option_or_option[string](none, ?string('fallback'))
+	assert a? == 'fallback'
+	b := unwrap_option_or_option[i32](?i32(5), none)
+	assert b? == 5
+}

--- a/vlib/v/tests/generics/generic_fn_method_from_embed_mixed_test.v
+++ b/vlib/v/tests/generics/generic_fn_method_from_embed_mixed_test.v
@@ -70,6 +70,23 @@ fn test_direct_and_embedded_methods_in_generic_fn() {
 	assert cs.keys() == ['seo1']
 }
 
+fn ids_of[T](items []T) []string {
+	mut res := []string{}
+	for item in items {
+		res << item.id().s
+	}
+	return res
+}
+
+// the embedded receivers are instantiated first here, so the state of the
+// last checked (direct) instantiations remains on the shared AST nodes
+fn test_embedded_methods_first_direct_methods_last_in_generic_fn() {
+	assert ids_of([CategorySEO{SEO{ID{'s1'}}}]) == ['s1']
+	assert ids_of([ProductImage{Image{ID{'i1'}}}]) == ['i1']
+	assert ids_of([Category{ID{'c1'}}]) == ['c1']
+	assert ids_of([InventoryItem{ID{'n1'}}]) == ['n1']
+}
+
 struct Base {
 mut:
 	n int

--- a/vlib/v/tests/generics/generic_fn_method_from_embed_mixed_test.v
+++ b/vlib/v/tests/generics/generic_fn_method_from_embed_mixed_test.v
@@ -1,0 +1,131 @@
+// For issue 27786: inside a generic function, a method call on a value of type
+// `T` used the embed accessor path (`.Embed`) of the last checked instantiation
+// for every other instantiation, producing invalid C code like
+// `Category_id(identifiable.Image)`.
+struct ID {
+	s string
+}
+
+interface Identifiable {
+	id() ID
+}
+
+struct Image {
+	image_id ID
+}
+
+fn (i Image) id() ID {
+	return i.image_id
+}
+
+struct SEO {
+	seo_id ID
+}
+
+fn (s SEO) id() ID {
+	return s.seo_id
+}
+
+struct ProductImage {
+	Image
+}
+
+struct CategorySEO {
+	SEO
+}
+
+struct Category {
+	cat_id ID
+}
+
+fn (c Category) id() ID {
+	return c.cat_id
+}
+
+struct InventoryItem {
+	item_id ID
+}
+
+fn (ii InventoryItem) id() ID {
+	return ii.item_id
+}
+
+fn make_identifiable_map[T](identifiables []T) map[string]T {
+	mut res := map[string]T{}
+	for identifiable in identifiables {
+		id := identifiable.id()
+		res[id.s] = identifiable
+	}
+	return res
+}
+
+fn test_direct_and_embedded_methods_in_generic_fn() {
+	c := make_identifiable_map([Category{ID{'cat1'}}])
+	assert c.keys() == ['cat1']
+	ii := make_identifiable_map([InventoryItem{ID{'item1'}}])
+	assert ii.keys() == ['item1']
+	pi := make_identifiable_map([ProductImage{Image{ID{'img1'}}}])
+	assert pi.keys() == ['img1']
+	cs := make_identifiable_map([CategorySEO{SEO{ID{'seo1'}}}])
+	assert cs.keys() == ['seo1']
+}
+
+struct Base {
+mut:
+	n int
+}
+
+fn (b Base) id() ID {
+	return ID{'base${b.n}'}
+}
+
+fn (mut b Base) bump() {
+	b.n++
+}
+
+struct Mid {
+	Base
+}
+
+struct Wrapper {
+	Mid
+}
+
+struct Direct {
+mut:
+	n int
+}
+
+fn (d Direct) id() ID {
+	return ID{'direct${d.n}'}
+}
+
+fn (mut d Direct) bump() {
+	d.n += 10
+}
+
+fn get_ids[T](items []T) []string {
+	mut res := []string{}
+	for item in items {
+		res << item.id().s
+	}
+	return res
+}
+
+fn bump_all[T](mut items []T) {
+	for mut item in items {
+		item.bump()
+	}
+}
+
+fn test_mut_methods_through_nested_embed_in_generic_fn() {
+	mut ws := [Wrapper{Mid{Base{1}}}]
+	mut ds := [Direct{2}]
+	assert get_ids(ws) == ['base1']
+	assert get_ids(ds) == ['direct2']
+	bump_all(mut ws)
+	bump_all(mut ds)
+	assert ws[0].n == 2
+	assert ds[0].n == 12
+	assert get_ids([Base{5}]) == ['base5']
+}


### PR DESCRIPTION
Fixes the cgen errors reported in #27786 (`'Category' has no member named 'Image'` etc. in the peony project).

The checker re-checks a generic function once per concrete type and overwrites shared AST state on every pass, so cgen and markused saw the state of the *last checked* instantiation for all instantiations. This surfaced in three ways when a generic fn calls a method on a `T` value and different concrete types resolve that method differently (directly vs. via an embedded struct):

- `vlib/v/gen/c/fn.v`: `method_call()` wrote the embed accessor chain (`identifiable.Image`) from the stale `node.from_embed_types` for every instantiation. It now re-resolves the effective embed chain from the current concrete receiver type. `unwrap_receiver_type()` also re-resolves a stale ident receiver from the scope, fixing wrong generated function names (`SEO_id` instead of `Image_id`).
- `vlib/v/markused/walker.v`: with `-skip-unused` (the default), methods used only by non-last instantiations were pruned, causing `call to undeclared function` errors. The walker now prefers the per-instantiation re-resolved receiver type when resolving the called method, and matches stale types by idx so references (`for mut item in items`) are handled too.
- `vlib/v/gen/c/if.v`: the temp var of an `if x := opt {` guard in a generic fn was declared with the option type of the last checked instantiation (`_option_i32 _t1` inside the `string` instantiation). The guard expression type is now re-resolved in generic context.

With this, `tests/peony_test.v` from the issue compiles cleanly (it then only fails at runtime because it needs a running Docker daemon for its Firebird DB).

Tested: new regression tests for both bugs, plus `vlib/v/tests/generics/`, `vlib/v/tests/skip_unused/`, `options/`, `structs/`, `interfaces/`, `compiler_errors_test.v`, `coutput_test.v`, `v build-examples`, `v self`.