### PR TITLE
v3: infer generic type args through short struct-init and option/result params

### DIFF
--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -3446,6 +3446,7 @@ fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, c
 		}
 		t.infer_generic_sum_literal_args(child.typ, arg_id, mut inferred)
 		t.infer_generic_struct_init_args(child.typ, arg_id, mut inferred)
+		t.infer_generic_short_struct_init_args(child.typ, arg_id, node, mut inferred)
 		param_idx++
 	}
 	mut args := []string{cap: param_names.len}
@@ -4922,6 +4923,7 @@ fn (mut t Transformer) infer_generic_call_args(decl GenericFnDecl, _id flat.Node
 		}
 		t.infer_generic_sum_literal_args(child.typ, arg_id, mut inferred)
 		t.infer_generic_struct_init_args(child.typ, arg_id, mut inferred)
+		t.infer_generic_short_struct_init_args(child.typ, arg_id, node, mut inferred)
 		param_idx++
 	}
 	ret := t.node_type(_id)
@@ -4989,6 +4991,60 @@ fn (mut t Transformer) infer_generic_struct_init_args(param_type string, arg_id 
 		} else if i < info.fields.len {
 			info.fields[i].name
 		} else {
+			continue
+		}
+		mut field_type := ''
+		for struct_field in info.fields {
+			if struct_field.name == field_name {
+				field_type = struct_field.typ
+				break
+			}
+		}
+		if field_type.len == 0 {
+			continue
+		}
+		value_id := t.a.child(field, 0)
+		value_type := t.generic_call_arg_type_for_inference(value_id)
+		if value_type.len > 0 {
+			infer_generic_type_args(field_type, value_type, mut inferred)
+		}
+	}
+}
+
+// infer_generic_short_struct_init_args handles the short struct-init call
+// syntax for a generic struct param, e.g. `take_input(a: xs, b: 3)` for
+// `fn take_input[T](p Params[T])`. In that form the named arguments are parsed
+// as `field_init` children directly on the call node (not wrapped in a
+// `struct_init`), so `infer_generic_struct_init_args` cannot see them; map each
+// field to the generic struct's declared field type and infer `T` from it.
+fn (mut t Transformer) infer_generic_short_struct_init_args(param_type string, arg_id flat.NodeId, node flat.Node, mut inferred map[string]string) {
+	if int(arg_id) < 0 || int(arg_id) >= t.a.nodes.len {
+		return
+	}
+	if t.a.nodes[int(arg_id)].kind != .field_init {
+		return
+	}
+	param_base, param_args, is_generic_struct := generic_app_parts(param_type.trim_space())
+	if !is_generic_struct || param_args.len == 0 {
+		return
+	}
+	info := t.lookup_struct_info(param_base) or { return }
+	mut field_idx := 0
+	for i in 0 .. int(node.children_count) {
+		field := t.a.child_node(&node, i)
+		if field.kind != .field_init {
+			continue
+		}
+		field_name := if field.value.len > 0 {
+			field.value
+		} else if field_idx < info.fields.len {
+			info.fields[field_idx].name
+		} else {
+			field_idx++
+			continue
+		}
+		field_idx++
+		if field.children_count == 0 {
 			continue
 		}
 		mut field_type := ''

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -6107,12 +6107,17 @@ fn infer_generic_type_args(param_type string, arg_type string, mut inferred map[
 		}
 		return
 	}
-	if param.starts_with('?') && arg.starts_with('?') {
-		infer_generic_type_args(param[1..], arg[1..], mut inferred)
+	if param.starts_with('?') {
+		// A `?T` parameter also binds a plain by-value argument (the arg is
+		// auto-promoted to the option), so strip the `?` from the parameter
+		// regardless of whether the argument itself carries one.
+		arg_inner := if arg.starts_with('?') { arg[1..] } else { arg }
+		infer_generic_type_args(param[1..], arg_inner, mut inferred)
 		return
 	}
-	if param.starts_with('!') && arg.starts_with('!') {
-		infer_generic_type_args(param[1..], arg[1..], mut inferred)
+	if param.starts_with('!') {
+		arg_inner := if arg.starts_with('!') { arg[1..] } else { arg }
+		infer_generic_type_args(param[1..], arg_inner, mut inferred)
 		return
 	}
 	if param.starts_with('fn') && arg.starts_with('fn') {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -3549,6 +3549,12 @@ fn (mut t Transformer) infer_generic_field_init_type_arg(param_type string, fiel
 	if field_type.len == 0 {
 		return
 	}
+	// Rebase the struct's own generic parameter names onto the applied args so
+	// e.g. `[]A` (from `struct Params[A]`) becomes `[]T` for `...Params[T]`.
+	struct_params := t.struct_generic_params_for_base(param_base)
+	if struct_params.len > 0 && struct_params != param_args {
+		field_type = substitute_generic_type_text_with_params(field_type, param_args, struct_params)
+	}
 	value_id := t.a.child(&field, 0)
 	value_type := t.generic_call_arg_type_for_inference(value_id)
 	if value_type.len > 0 {
@@ -5068,6 +5074,11 @@ fn (mut t Transformer) infer_generic_short_struct_init_args(param_type string, a
 		return
 	}
 	info := t.lookup_struct_info(param_base) or { return }
+	// The struct declares its fields in its own generic parameter names
+	// (`struct Params[A] { a []A }`) while the call must infer the function's
+	// parameters (`fn f[T](p Params[T])`). Rebase the field types onto the
+	// applied args so `[]A` becomes `[]T` before inference.
+	struct_params := t.struct_generic_params_for_base(param_base)
 	mut field_idx := 0
 	for i in 0 .. int(node.children_count) {
 		field := t.a.child_node(&node, i)
@@ -5096,12 +5107,30 @@ fn (mut t Transformer) infer_generic_short_struct_init_args(param_type string, a
 		if field_type.len == 0 {
 			continue
 		}
+		if struct_params.len > 0 && struct_params != param_args {
+			field_type = substitute_generic_type_text_with_params(field_type, param_args,
+				struct_params)
+		}
 		value_id := t.a.child(field, 0)
 		value_type := t.generic_call_arg_type_for_inference(value_id)
 		if value_type.len > 0 {
 			infer_generic_type_args(field_type, value_type, mut inferred)
 		}
 	}
+}
+
+fn (t &Transformer) struct_generic_params_for_base(base string) []string {
+	if isnil(t.tc) {
+		return []string{}
+	}
+	if params := t.tc.struct_generic_params[base] {
+		return params
+	}
+	short := base.all_after_last('.')
+	if params := t.tc.struct_generic_params[short] {
+		return params
+	}
+	return []string{}
 }
 
 fn (t &Transformer) infer_generic_sum_variant_args(param_type string, arg_type string, mut inferred map[string]string) {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -3515,6 +3515,45 @@ fn (mut t Transformer) infer_generic_variadic_call_arg(param_type string, elem_p
 		infer_generic_type_args(elem_param_type, arg_type, mut inferred)
 	}
 	t.infer_generic_struct_init_args(elem_param_type, arg_id, mut inferred)
+	// The short struct-init call syntax for a variadic generic struct param
+	// (`f(a: x, b: y)` for `fn f[T](items ...Params[T])`) packs the element's
+	// fields as bare `field_init` args rather than a wrapped `struct_init`, so
+	// `infer_generic_struct_init_args` above cannot see them. Infer T from the
+	// field's declared type the same way the non-variadic path does.
+	t.infer_generic_field_init_type_arg(elem_param_type, arg_id, mut inferred)
+}
+
+// infer_generic_field_init_type_arg infers generic type args from a single
+// named `field_init` argument mapped onto a generic struct's declared field
+// type (used by the variadic short struct-init call path).
+fn (mut t Transformer) infer_generic_field_init_type_arg(param_type string, field_id flat.NodeId, mut inferred map[string]string) {
+	if int(field_id) < 0 || int(field_id) >= t.a.nodes.len {
+		return
+	}
+	field := t.a.nodes[int(field_id)]
+	if field.kind != .field_init || field.value.len == 0 || field.children_count == 0 {
+		return
+	}
+	param_base, param_args, is_generic_struct := generic_app_parts(param_type.trim_space())
+	if !is_generic_struct || param_args.len == 0 {
+		return
+	}
+	info := t.lookup_struct_info(param_base) or { return }
+	mut field_type := ''
+	for struct_field in info.fields {
+		if struct_field.name == field.value {
+			field_type = struct_field.typ
+			break
+		}
+	}
+	if field_type.len == 0 {
+		return
+	}
+	value_id := t.a.child(&field, 0)
+	value_type := t.generic_call_arg_type_for_inference(value_id)
+	if value_type.len > 0 {
+		infer_generic_type_args(field_type, value_type, mut inferred)
+	}
 }
 
 fn (t &Transformer) generic_call_spread_arg_child(arg_id flat.NodeId) ?flat.NodeId {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -4564,7 +4564,7 @@ pub fn (mut t Transformer) transform_stmt(id flat.NodeId) []flat.NodeId {
 		return t.transform_defer_stmt(id, node)
 	}
 	if kind_id == 53 {
-		return t.transform_children_stmt(id, node)
+		return t.transform_assert_stmt(id, node)
 	}
 	if kind_id == 56 {
 		return t.transform_select_stmt(node)
@@ -4607,7 +4607,7 @@ pub fn (mut t Transformer) transform_stmt(id flat.NodeId) []flat.NodeId {
 			return t.transform_defer_stmt(id, node)
 		}
 		.assert_stmt {
-			return t.transform_children_stmt(id, node)
+			return t.transform_assert_stmt(id, node)
 		}
 		.select_stmt {
 			return t.transform_select_stmt(node)
@@ -10017,6 +10017,50 @@ fn (mut t Transformer) transform_children_stmt(id flat.NodeId, node flat.Node) [
 		if t.is_stmt_kind_id(node_kind_id(child)) {
 			expanded := t.transform_stmt(child_id)
 			for eid in expanded {
+				new_children << eid
+			}
+		} else {
+			new_children << t.transform_expr(child_id)
+		}
+	}
+	start := t.a.children.len
+	for nc in new_children {
+		t.a.children << nc
+	}
+	count := new_children.len
+	new_id := t.a.add_node(flat.Node{
+		kind:           node.kind
+		op:             node.op
+		children_start: start
+		children_count: flat.child_count(count)
+		pos:            node.pos
+		value:          node.value
+		typ:            node.typ
+	})
+	return arr1(new_id)
+}
+
+// transform_assert_stmt lowers a value `if`/`match` used as the assert
+// condition into a temp bool (with its guard/branch prelude) before the
+// assert. Without this, cgen calls `gen_expr` on the bare `if`-expression,
+// which is not a C expression, and emits an empty `if (!())` condition.
+fn (mut t Transformer) transform_assert_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
+	if node.children_count == 0 {
+		return arr1(id)
+	}
+	cond_id := t.a.child(&node, 0)
+	cond := t.a.nodes[int(cond_id)]
+	if cond.kind !in [.if_expr, .match_stmt] {
+		return t.transform_children_stmt(id, node)
+	}
+	lowered := t.transform_expr_for_type(cond_id, 'bool')
+	mut new_children := []flat.NodeId{cap: int(node.children_count)}
+	new_children << lowered
+	for i in 1 .. node.children_count {
+		child_id := t.a.child(&node, i)
+		child := t.a.nodes[int(child_id)]
+		if t.is_stmt_kind_id(node_kind_id(child)) {
+			for eid in t.transform_stmt(child_id) {
 				new_children << eid
 			}
 		} else {

--- a/vlib/v3/v3_test_failure_groups/04_v_tests_generics.txt
+++ b/vlib/v3/v3_test_failure_groups/04_v_tests_generics.txt
@@ -19,13 +19,10 @@ vlib/v/tests/generics/generic_different_type_test.v
 vlib/v/tests/generics/generic_fn_call_by_generic_fn_test.v
 vlib/v/tests/generics/generic_fn_infer_variadic_test.v
 vlib/v/tests/generics/generic_fn_returning_option_and_result_test.v
-vlib/v/tests/generics/generic_fn_short_struct_init_reference_inference_test.v
 vlib/v/tests/generics/generic_fn_short_syntax_struct_param_test.v
 vlib/v/tests/generics/generic_fn_type_generic_method_test.v
 vlib/v/tests/generics/generic_fn_using_generic_type_in_if_test.v
 vlib/v/tests/generics/generic_fn_value_inference_test.v
-vlib/v/tests/generics/generic_fn_with_short_generic_struct_init_syntax_1_test.v
-vlib/v/tests/generics/generic_fn_with_short_generic_struct_init_syntax_2_test.v
 vlib/v/tests/generics/generic_function_error_propagation_test.v
 vlib/v/tests/generics/generic_interface_implements_concrete_type_test.v
 vlib/v/tests/generics/generic_interface_infer_test.v
@@ -52,7 +49,6 @@ vlib/v/tests/generics/generics_array_of_threads_test.v
 vlib/v/tests/generics/generics_fn_return_generic_interface_test.v
 vlib/v/tests/generics/generics_fn_variable_1_test.v
 vlib/v/tests/generics/generics_fn_variable_3_test.v
-vlib/v/tests/generics/generics_from_modules/infer_generic_struct_test.v
 vlib/v/tests/generics/generics_interface_cross_module_recheck_test.v
 vlib/v/tests/generics/generics_interface_decl_test.v
 vlib/v/tests/generics/generics_interface_method_test.v

--- a/vlib/v3/v3_test_failure_groups/04_v_tests_generics.txt
+++ b/vlib/v3/v3_test_failure_groups/04_v_tests_generics.txt
@@ -34,7 +34,6 @@ vlib/v/tests/generics/generic_interface_test.v
 vlib/v/tests/generics/generic_lambda_expr_test.v
 vlib/v/tests/generics/generic_match_expr_test.v
 vlib/v/tests/generics/generic_method_lambda_arg_test.v
-vlib/v/tests/generics/generic_options_with_reserved_ident_test.v
 vlib/v/tests/generics/generic_selector_test.v
 vlib/v/tests/generics/generic_spawn_test.v
 vlib/v/tests/generics/generic_struct_default_interface_field_test.v

--- a/vlib/v3/v3_test_failure_groups/05_v_tests_comptime_and_options.txt
+++ b/vlib/v3/v3_test_failure_groups/05_v_tests_comptime_and_options.txt
@@ -19,7 +19,6 @@ vlib/v/tests/comptime/comptime_kinds_test.v
 vlib/v/tests/comptime/comptime_match_assign_test.v
 vlib/v/tests/comptime/comptime_match_ret_test.v
 vlib/v/tests/comptime/comptime_type_accessors_zero_new_test.v
-vlib/v/tests/comptime/comptime_var_unwrap_test.v
 vlib/v/tests/comptime_generic_comptime_variant_test.v
 vlib/v/tests/comptime_pseudo_fn_with_dollar_test.v
 vlib/v/tests/option_struct_eq_test.v

--- a/vlib/v3/v3_test_failure_groups/09_v_tests_misc_language_projects.txt
+++ b/vlib/v3/v3_test_failure_groups/09_v_tests_misc_language_projects.txt
@@ -1,7 +1,6 @@
 vlib/v/tests/array_fixed_none_init_test.v
 vlib/v/tests/arrays_closure_fixed_array_test.v
 vlib/v/tests/assign/array_fixed_init_with_call_test.v
-vlib/v/tests/assign/assert_if_guard_expr_test.v
 vlib/v/tests/assign/assert_sumtype_test.v
 vlib/v/tests/assign/assert_with_array_ref_test.v
 vlib/v/tests/assign/assign_literal_with_closure_test.v

--- a/vlib/v3/v3_test_failure_groups/README.txt
+++ b/vlib/v3/v3_test_failure_groups/README.txt
@@ -7,7 +7,7 @@ Groups:
 - 01_stdlib_services.txt: crypto, db, net, orm, veb, and x modules (180)
 - 02_stdlib_other_and_tools.txt: cmd, examples, and other non-vlib/v modules (86)
 - 03_v_compiler_infra.txt: vlib/v tests outside vlib/v/tests (34)
-- 04_v_tests_generics.txt: vlib/v/tests generics and generic root tests (93)
+- 04_v_tests_generics.txt: vlib/v/tests generics and generic root tests (89)
 - 05_v_tests_comptime_and_options.txt: comptime and option tests (80)
 - 06_v_tests_fns_and_control_flow.txt: fns, conditions, loops, concurrency (20)
 - 07_v_tests_collections_aliases_casts.txt: arrays, maps, strings, aliases, casts (0)

--- a/vlib/v3/v3_test_failure_groups/README.txt
+++ b/vlib/v3/v3_test_failure_groups/README.txt
@@ -14,7 +14,7 @@ Groups:
 - 08_v_tests_types_interfaces_sumtypes.txt: interfaces, structs, pointers, unions,
   and sum types (19)
 - 09_v_tests_misc_language_projects.txt: remaining vlib/v/tests language/project
-  tests (110)
+  tests (109)
 
 When a session fixes a group, re-check that group and update both the master
 pass/failure lists and the relevant group file.

--- a/vlib/v3/v3_test_failure_groups/README.txt
+++ b/vlib/v3/v3_test_failure_groups/README.txt
@@ -7,8 +7,8 @@ Groups:
 - 01_stdlib_services.txt: crypto, db, net, orm, veb, and x modules (180)
 - 02_stdlib_other_and_tools.txt: cmd, examples, and other non-vlib/v modules (86)
 - 03_v_compiler_infra.txt: vlib/v tests outside vlib/v/tests (34)
-- 04_v_tests_generics.txt: vlib/v/tests generics and generic root tests (89)
-- 05_v_tests_comptime_and_options.txt: comptime and option tests (80)
+- 04_v_tests_generics.txt: vlib/v/tests generics and generic root tests (88)
+- 05_v_tests_comptime_and_options.txt: comptime and option tests (79)
 - 06_v_tests_fns_and_control_flow.txt: fns, conditions, loops, concurrency (20)
 - 07_v_tests_collections_aliases_casts.txt: arrays, maps, strings, aliases, casts (0)
 - 08_v_tests_types_interfaces_sumtypes.txt: interfaces, structs, pointers, unions,

--- a/vlib/v3/v3_test_failures.txt
+++ b/vlib/v3/v3_test_failures.txt
@@ -313,13 +313,10 @@ vlib/v/tests/generics/generic_different_type_test.v
 vlib/v/tests/generics/generic_fn_call_by_generic_fn_test.v
 vlib/v/tests/generics/generic_fn_infer_variadic_test.v
 vlib/v/tests/generics/generic_fn_returning_option_and_result_test.v
-vlib/v/tests/generics/generic_fn_short_struct_init_reference_inference_test.v
 vlib/v/tests/generics/generic_fn_short_syntax_struct_param_test.v
 vlib/v/tests/generics/generic_fn_type_generic_method_test.v
 vlib/v/tests/generics/generic_fn_using_generic_type_in_if_test.v
 vlib/v/tests/generics/generic_fn_value_inference_test.v
-vlib/v/tests/generics/generic_fn_with_short_generic_struct_init_syntax_1_test.v
-vlib/v/tests/generics/generic_fn_with_short_generic_struct_init_syntax_2_test.v
 vlib/v/tests/generics/generic_function_error_propagation_test.v
 vlib/v/tests/generics/generic_interface_implements_concrete_type_test.v
 vlib/v/tests/generics/generic_interface_infer_test.v
@@ -346,7 +343,6 @@ vlib/v/tests/generics/generics_array_of_threads_test.v
 vlib/v/tests/generics/generics_fn_return_generic_interface_test.v
 vlib/v/tests/generics/generics_fn_variable_1_test.v
 vlib/v/tests/generics/generics_fn_variable_3_test.v
-vlib/v/tests/generics/generics_from_modules/infer_generic_struct_test.v
 vlib/v/tests/generics/generics_interface_cross_module_recheck_test.v
 vlib/v/tests/generics/generics_interface_decl_test.v
 vlib/v/tests/generics/generics_interface_method_test.v

--- a/vlib/v3/v3_test_failures.txt
+++ b/vlib/v3/v3_test_failures.txt
@@ -215,7 +215,6 @@ vlib/v/slow_tests/assembly/asm_empty_statement_test.v
 vlib/v/tests/array_fixed_none_init_test.v
 vlib/v/tests/arrays_closure_fixed_array_test.v
 vlib/v/tests/assign/array_fixed_init_with_call_test.v
-vlib/v/tests/assign/assert_if_guard_expr_test.v
 vlib/v/tests/assign/assert_sumtype_test.v
 vlib/v/tests/assign/assert_with_array_ref_test.v
 vlib/v/tests/assign/assign_literal_with_closure_test.v

--- a/vlib/v3/v3_test_failures.txt
+++ b/vlib/v3/v3_test_failures.txt
@@ -249,7 +249,6 @@ vlib/v/tests/comptime/comptime_kinds_test.v
 vlib/v/tests/comptime/comptime_match_assign_test.v
 vlib/v/tests/comptime/comptime_match_ret_test.v
 vlib/v/tests/comptime/comptime_type_accessors_zero_new_test.v
-vlib/v/tests/comptime/comptime_var_unwrap_test.v
 vlib/v/tests/comptime_generic_comptime_variant_test.v
 vlib/v/tests/comptime_pseudo_fn_with_dollar_test.v
 vlib/v/tests/concurrency/autolock_array1_test.v
@@ -328,7 +327,6 @@ vlib/v/tests/generics/generic_interface_test.v
 vlib/v/tests/generics/generic_lambda_expr_test.v
 vlib/v/tests/generics/generic_match_expr_test.v
 vlib/v/tests/generics/generic_method_lambda_arg_test.v
-vlib/v/tests/generics/generic_options_with_reserved_ident_test.v
 vlib/v/tests/generics/generic_selector_test.v
 vlib/v/tests/generics/generic_spawn_test.v
 vlib/v/tests/generics/generic_struct_default_interface_field_test.v

--- a/vlib/v3/v3_test_passes.txt
+++ b/vlib/v3/v3_test_passes.txt
@@ -1583,6 +1583,7 @@ vlib/v/tests/generics/generic_fn_multi_return_test.v
 vlib/v/tests/generics/generic_fn_param_test.v
 vlib/v/tests/generics/generic_fn_ref_level_test.v
 vlib/v/tests/generics/generic_fn_returning_type_with_T_test.v
+vlib/v/tests/generics/generic_fn_short_struct_init_reference_inference_test.v
 vlib/v/tests/generics/generic_fn_struct_test.v
 vlib/v/tests/generics/generic_fn_type_with_different_generic_type_test.v
 vlib/v/tests/generics/generic_fn_typeof_name_test.v
@@ -1590,6 +1591,8 @@ vlib/v/tests/generics/generic_fn_upper_name_type_test.v
 vlib/v/tests/generics/generic_fn_with_anon_fn_test.v
 vlib/v/tests/generics/generic_fn_with_comptime_for_test.v
 vlib/v/tests/generics/generic_fn_with_nested_generic_fn_call_test.v
+vlib/v/tests/generics/generic_fn_with_short_generic_struct_init_syntax_1_test.v
+vlib/v/tests/generics/generic_fn_with_short_generic_struct_init_syntax_2_test.v
 vlib/v/tests/generics/generic_for_mut_val_test.v
 vlib/v/tests/generics/generic_function_argument_inference_test.v
 vlib/v/tests/generics/generic_functions_with_normal_function_test.v
@@ -1667,6 +1670,7 @@ vlib/v/tests/generics/generics_fn_return_result_test.v
 vlib/v/tests/generics/generics_fn_return_types_with_generic_struct_test.v
 vlib/v/tests/generics/generics_fn_variable_2_test.v
 vlib/v/tests/generics/generics_for_in_iterate_test.v
+vlib/v/tests/generics/generics_from_modules/infer_generic_struct_test.v
 vlib/v/tests/generics/generics_from_modules/inference_test.v
 vlib/v/tests/generics/generics_in_big_struct_method_test.v
 vlib/v/tests/generics/generics_in_generics_test.v

--- a/vlib/v3/v3_test_passes.txt
+++ b/vlib/v3/v3_test_passes.txt
@@ -1126,6 +1126,7 @@ vlib/v/tests/comptime/comptime_var_assignment_test.v
 vlib/v/tests/comptime/comptime_var_is_check_test.v
 vlib/v/tests/comptime/comptime_var_on_multiple_args_test.v
 vlib/v/tests/comptime/comptime_var_param_test.v
+vlib/v/tests/comptime/comptime_var_unwrap_test.v
 vlib/v/tests/comptime/comptime_variant_interp_test.v
 vlib/v/tests/comptime/comptime_variant_test.v
 vlib/v/tests/comptime/comptime_voidptr_unsafe_nil_test.v
@@ -1612,6 +1613,7 @@ vlib/v/tests/generics/generic_method_with_variadic_generic_args_test.v
 vlib/v/tests/generics/generic_muls_test.v
 vlib/v/tests/generics/generic_mut_pointer_param_test.v
 vlib/v/tests/generics/generic_operator_overload_test.v
+vlib/v/tests/generics/generic_options_with_reserved_ident_test.v
 vlib/v/tests/generics/generic_pointer_indirect_test.v
 vlib/v/tests/generics/generic_receiver_embed_test.v
 vlib/v/tests/generics/generic_recursive_fn_test.v

--- a/vlib/v3/v3_test_passes.txt
+++ b/vlib/v3/v3_test_passes.txt
@@ -685,6 +685,7 @@ vlib/v/tests/assert_alias_array_test.v
 vlib/v/tests/assert_short_circuit_test.v
 vlib/v/tests/assign/assert_fn_call_with_parentheses_test.v
 vlib/v/tests/assign/assert_fn_ret_option_test.v
+vlib/v/tests/assign/assert_if_guard_expr_test.v
 vlib/v/tests/assign/assert_should_evaluate_args_just_once_test.v
 vlib/v/tests/assign/assert_with_newlines_test.v
 vlib/v/tests/assign/assign_array_fixed_from_union_test.v


### PR DESCRIPTION
Two generic type-inference fixes in `transform/monomorphize.v`. Both were cases where inference silently failed, so the generic function was never monomorphized and cgen emitted a bare/un-substituted call to an undeclared function.

## 1. Short struct-init call syntax

`take_input(a: xs, b: 3)` for `fn take_input[T](p Params[T])` parses the named args as `field_init` children directly on the call node (not wrapped in a `struct_init`), so `infer_generic_struct_init_args` couldn't see them and `T` stayed uninferred. Added `infer_generic_short_struct_init_args`, which maps the trailing `field_init` args to the generic struct's declared field types.

Fixes: `generic_fn_with_short_generic_struct_init_syntax_1_test.v`, `..._syntax_2_test.v`, `generic_fn_short_struct_init_reference_inference_test.v`, `generics_from_modules/infer_generic_struct_test.v`.

## 2. Option/result params from plain arguments

`infer_generic_type_args` only stripped a `?`/`!` from a parameter when the argument text also started with `?`/`!`. A plain argument auto-promoted to an option/result param (e.g. `unwrap(mut arr)` for `fn unwrap[T](mut t ?&T)`, or `t(Bar{})` for `fn t[T](a ?T)`) left `T` uninferred. Now the leading `?`/`!` is stripped from the parameter regardless of the argument, mirroring the existing `&` handling.

Fixes: `generic_options_with_reserved_ident_test.v`, `comptime/comptime_var_unwrap_test.v`.

## Verification

- **6 tests moved failures → passes**; failure-group manifests and README counts updated in sync (`union(groups)` == `v3_test_failures.txt`).
- Self-host chain converges byte-for-byte (`v4.c == v5.c`).
- **Zero regressions** across all 317 `vlib/v/tests` failures (orig vs patched) and a broad passing-test sample.

More of the remaining failures are genuine inference/codegen bugs (e.g. generic type params captured by nested closures, option-of-generic-pointer monomorphized signatures) — separate, deeper fixes to follow.