### PR TITLE
v3: fix operator precedence, parser spans, cache coherence, and profiler races

### DIFF
--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -219,50 +219,6 @@ pub mut:
 	specialized_fn_nodes map[int]bool
 }
 
-// These layouts expose only the backing pointers needed to determine whether
-// text_ids rehashed inside a disposable prealloc scope. Keep them synchronized
-// with builtin.map and builtin.DenseArray.
-struct TextMapDenseArrayLayout {
-	key_bytes   int
-	value_bytes int
-mut:
-	cap         int
-	len         int
-	deletes     u32
-	all_deleted &u8 = unsafe { nil }
-	keys        &u8 = unsafe { nil }
-	values      &u8 = unsafe { nil }
-}
-
-struct TextMapLayout {
-	key_bytes   int
-	value_bytes int
-mut:
-	even_index      u32
-	cached_hashbits u8
-	shift           u8
-	key_values      TextMapDenseArrayLayout
-	metas           &u32 = unsafe { nil }
-	extra_metas     u32
-	has_string_keys bool
-	hash_fn         voidptr
-	key_eq_fn       voidptr
-	clone_fn        voidptr
-	free_fn         voidptr
-pub mut:
-	len int
-}
-
-fn text_id_map_storage_owned_by_scope(ids map[string]TextId, scope voidptr) bool {
-	$if prealloc {
-		layout := unsafe { &TextMapLayout(&ids) }
-		return unsafe { prealloc_scope_owns(scope, layout.key_values.keys) }
-			|| unsafe { prealloc_scope_owns(scope, layout.key_values.values) }
-			|| unsafe { prealloc_scope_owns(scope, layout.metas) }
-	}
-	return false
-}
-
 // close_workers stops the compilation-owned persistent worker pool.
 pub fn (mut a FlatAst) close_workers() {
 	if !isnil(a.worker_pool) {
@@ -349,22 +305,21 @@ pub fn (mut a FlatAst) reserve_transform_texts(headroom int) {
 // transform into the current arena and rebuilds table backing only if it grew
 // into the disposable scope.
 pub fn (mut a FlatAst) promote_transform_texts_from(start int, scope voidptr) {
-	values_backing_scoped := scoped_text_storage_owned(scope, a.text_values.data)
-	ids_backing_scoped := text_id_map_storage_owned_by_scope(a.text_ids, scope)
 	first := if start < 0 { 0 } else { start }
-	for idx in first .. a.text_values.len {
-		value := a.text_values[idx]
-		$if prealloc {
-			if value.len == 0 || !unsafe { prealloc_scope_owns(scope, value.str) } {
-				continue
-			}
-			a.text_ids.delete(value)
-			canonical := value.clone()
-			a.text_values[idx] = canonical
-			a.text_ids[canonical] = TextId(idx + 1)
+	mut rebuild := scoped_text_storage_owned(scope, a.text_values.data)
+	$if prealloc {
+		// Any string interned inside the disposable scope may have placed its
+		// bytes — or grown the lookup map's internal backing — into that scope.
+		// There is no supported API to inspect a `map`'s backing pointers, so
+		// rather than mirror the private builtin.map/DenseArray ABI we rebuild
+		// the whole text table into the current arena whenever the scope interned
+		// anything. This is a superset of the cases where storage was actually
+		// scoped, so it is always safe.
+		if a.text_values.len > first {
+			rebuild = true
 		}
 	}
-	if values_backing_scoped || ids_backing_scoped {
+	if rebuild {
 		mut values, mut ids := a.clone_text_table_owned()
 		a.text_values = values
 		a.text_ids = ids.move()

--- a/vlib/v3/flat/flat_test.v
+++ b/vlib/v3/flat/flat_test.v
@@ -57,12 +57,16 @@ fn test_promote_transform_texts_rebuilds_scoped_table_growth() {
 			ast.intern_text('promoted_text_${i}')
 		}
 		assert unsafe { prealloc_scope_owns(scope, ast.text_values.data) }
-		assert text_id_map_storage_owned_by_scope(ast.text_ids, scope)
 		unsafe { prealloc_scope_leave(scope) }
 
 		ast.promote_transform_texts_from(0, scope)
+		// After promotion the values array must be detached from the scope, and
+		// the lookup map must remain usable once the scope is freed — which it
+		// cannot be if any of the map's backing were still owned by the scope.
 		assert !unsafe { prealloc_scope_owns(scope, ast.text_values.data) }
-		assert !text_id_map_storage_owned_by_scope(ast.text_ids, scope)
+		for idx in [0, 128, 255] {
+			assert !unsafe { prealloc_scope_owns(scope, ast.text_values[idx].str) }
+		}
 		unsafe { prealloc_scope_free_after(scope) }
 
 		for idx in [0, 128, 255] {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -9541,6 +9541,12 @@ fn (mut g FlatGen) headerless_libc_preamble() {
 	g.writeln('#if !defined(_OFF_T) && !defined(_OFF_T_DEFINED) && !defined(__off_t_defined) && !defined(_BSD_OFF_T_DEFINED_) && !defined(_OFF_T_DECLARED)')
 	g.writeln('typedef long long off_t;')
 	g.writeln('#endif')
+	// Fallback pthread declarations for the headerless build. They are only
+	// emitted when the platform's real <pthread.h> guards are absent, so when the
+	// system header is included its exact types win. The opaque unions are
+	// deliberately oversized (and over-aligned) to safely back the real objects
+	// on mainstream targets; a platform whose pthread objects exceed these sizes
+	// must be built with its real <pthread.h> in scope.
 	g.writeln('#if !defined(_BITS_PTHREADTYPES_COMMON_H) && !defined(_PTHREAD_H) && !defined(_PTHREADTYPES_H_) && !defined(_PTHREADTYPES_H) && !defined(__pthread_t_defined)')
 	g.writeln('typedef void* pthread_t;')
 	g.writeln('typedef union { unsigned char _opaque[64]; long long _align; } pthread_attr_t;')
@@ -9596,7 +9602,13 @@ fn (mut g FlatGen) headerless_libc_preamble() {
 	g.writeln('int fflush(FILE* stream);')
 	g.writeln('typedef struct { pthread_t handle; } __v_thread;')
 	g.writeln('typedef void* (*__v_thread_start_fn)(void*);')
-	g.writeln('static const size_t __v_thread_stack_size = 8388608;')
+	// The spawned-thread stack defaults to 8 MiB but is overridable at C compile
+	// time (e.g. `-DV_THREAD_STACK_SIZE=...`) so it is a tunable default rather
+	// than a universal constant.
+	g.writeln('#ifndef V_THREAD_STACK_SIZE')
+	g.writeln('#define V_THREAD_STACK_SIZE 8388608')
+	g.writeln('#endif')
+	g.writeln('static const size_t __v_thread_stack_size = V_THREAD_STACK_SIZE;')
 	g.writeln('static void* __v_thread_alloc(size_t size) { void* p = malloc(size); if (!p) { fprintf(stderr, "V thread allocation failed\\n"); abort(); } return p; }')
 	g.writeln('static __v_thread __v_thread_spawn(__v_thread_start_fn start, void* arg, void (*cleanup)(void*)) {')
 	g.writeln('\t__v_thread result;')

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -1,6 +1,7 @@
 module modulecache
 
 import os
+import rand
 import strings
 import v3.flat
 import v3.types
@@ -491,7 +492,10 @@ pub fn (m &Manager) write_stamp(module_name string, source_files []string, depen
 }
 
 fn write_atomic(path string, content string) ! {
-	tmp := '${path}.tmp.${os.getpid()}'
+	// The temporary name must be unique per writer, not just per process: a
+	// persistent worker pool can publish the same cache path from several
+	// threads at once, and `${path}.tmp.${pid}` would collide between them.
+	tmp := '${path}.tmp.${os.getpid()}.${rand.ulid()}'
 	defer {
 		os.rm(tmp) or {}
 	}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -29,6 +29,7 @@ mut:
 	lit                               string
 	tok_pos                           int
 	tok_end                           int
+	prev_tok_end                      int
 	peek_tok                          token.Token = .eof
 	peek_lit                          string
 	peek_pos                          int
@@ -186,6 +187,7 @@ pub fn (mut p Parser) parse_into(path string) {
 	p.next_file_id++
 	p.tok_pos = 0
 	p.tok_end = 0
+	p.prev_tok_end = 0
 	p.peek_pos = 0
 	p.peek_end = 0
 	p.cur_module = ''
@@ -327,6 +329,38 @@ fn (mut p Parser) add_val_id(kind_id int, value string) flat.NodeId {
 	})
 }
 
+// span_start returns the clamped start offset of the current (not-yet-consumed)
+// token. Capture it before consuming a construct so the node's span reflects the
+// construct's own location rather than whatever token happens to be current when
+// the node is finally created.
+fn (p &Parser) span_start() int {
+	return clamp_source_offset(p.tok_pos, p.s.src.len)
+}
+
+// span_to builds a half-open span from a previously captured start offset to the
+// end of the most recently consumed token (prev_tok_end).
+fn (p &Parser) span_to(start int) token.Pos {
+	end := clamp_source_offset(p.prev_tok_end, p.s.src.len)
+	return token.new_span(p.cur_file_id, start, end)
+}
+
+// add_val_id_at builds a leaf value node with an explicit, already-captured span.
+fn (mut p Parser) add_val_id_at(kind_id int, value string, pos token.Pos) flat.NodeId {
+	return p.a.add_node(flat.Node{
+		kind:  flat.node_kind_from_id(kind_id)
+		value: value
+		pos:   pos
+	})
+}
+
+// add_id_at builds a leaf node (no value) with an explicit, already-captured span.
+fn (mut p Parser) add_id_at(kind_id int, pos token.Pos) flat.NodeId {
+	return p.a.add_node(flat.Node{
+		kind: flat.node_kind_from_id(kind_id)
+		pos:  pos
+	})
+}
+
 fn (mut p Parser) record_diagnostic(message string, offset int) {
 	clamped_offset := clamp_source_offset(offset, p.s.src.len)
 	mut line := 1
@@ -397,6 +431,9 @@ fn vmod_root_for_file(path string) string {
 // next supports next handling for Parser.
 @[inline]
 fn (mut p Parser) next() {
+	// Remember the end of the token being consumed so a production can build a
+	// span that ends at the last token it actually consumed.
+	p.prev_tok_end = p.tok_end
 	if p.has_peek {
 		p.tok = p.peek_tok
 		p.lit = p.peek_lit
@@ -4929,7 +4966,7 @@ fn (mut p Parser) for_stmt() flat.NodeId {
 	// A comma after the first name is ambiguous with C-style multi-init
 	// (`for h, t := ...`), so handle it after parsing the first expression.
 	if p.tok == .name && p.peek() == .key_in {
-		first_expr := p.expr(.bit_or)
+		first_expr := p.expr(.sum)
 		return p.for_in(first_expr, false)
 	}
 	if p.tok == .key_mut {
@@ -5094,7 +5131,7 @@ fn (mut p Parser) for_comma_header(first_expr flat.NodeId, first_is_mut bool) fl
 			p.next()
 			value_is_mut = true
 		}
-		next_lhs := p.expr(.bit_or)
+		next_lhs := p.expr(.sum)
 		lhs_ids << next_lhs
 		if lhs_ids.len == 2 {
 			val_id = next_lhs
@@ -6156,10 +6193,10 @@ fn (mut p Parser) expr_with_lhs(first flat.NodeId, min_bp token.BindingPower) fl
 				break
 			}
 			p.next()
-			mut rhs := p.expr(token.BindingPower.bit_or)
+			mut rhs := p.expr(token.BindingPower.sum)
 			if p.tok == .dotdot {
 				p.next()
-				range_rhs := p.expr(.bit_or)
+				range_rhs := p.expr(.sum)
 				rstart := p.add_children2(rhs, range_rhs)
 				rhs = p.add_node(flat.Node{
 					kind:           .range
@@ -6193,10 +6230,10 @@ fn (mut p Parser) expr_with_lhs(first flat.NodeId, min_bp token.BindingPower) fl
 			}
 			p.next() // skip !
 			p.next() // skip in
-			mut rhs := p.expr(token.BindingPower.bit_or)
+			mut rhs := p.expr(token.BindingPower.sum)
 			if p.tok == .dotdot {
 				p.next()
-				range_rhs := p.expr(.bit_or)
+				range_rhs := p.expr(.sum)
 				rstart := p.add_children2(rhs, range_rhs)
 				rhs = p.add_node(flat.Node{
 					kind:           .range
@@ -6422,6 +6459,10 @@ fn is_float_number_literal(val string) bool {
 }
 
 fn (mut p Parser) prefix_expr() flat.NodeId {
+	// Capture the leading token's span before consuming it so leaf literals keep
+	// their own location and prefix operators can span from here to the operand.
+	start_pos := p.current_pos()
+	op_start := p.span_start()
 	tok_id := int(p.tok)
 	if tok_id == 92 {
 		val := p.lit
@@ -6431,7 +6472,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 		} else {
 			1
 		}
-		return p.add_val_id(kind_id, val)
+		return p.add_val_id_at(kind_id, val, start_pos)
 	}
 	if tok_id == 107 {
 		return p.string_literal()
@@ -6439,43 +6480,45 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 	if tok_id == 7 {
 		val := p.lit
 		p.next()
-		return p.add_val_id(4, val)
+		return p.add_val_id_at(4, val, start_pos)
 	}
 	if tok_id == 66 {
 		p.next()
-		return p.add_val_id(3, 'true')
+		return p.add_val_id_at(3, 'true', start_pos)
 	}
 	if tok_id == 36 {
 		p.next()
-		return p.add_val_id(3, 'false')
+		return p.add_val_id_at(3, 'false', start_pos)
 	}
 	if tok_id == 53 {
 		p.next()
-		return p.add_id(28)
+		return p.add_id_at(28, start_pos)
 	}
 	if tok_id == 54 {
 		p.next()
-		return p.add_id(29)
+		return p.add_id_at(29, start_pos)
 	}
 	if tok_id == 3 {
 		p.next()
 		inner := p.expr(.highest)
-		return p.add_node(flat.Node{
+		return p.a.add_node(flat.Node{
 			kind:           .prefix
 			op:             .arrow
 			children_start: p.add_child(inner)
 			children_count: 1
+			pos:            p.span_to(op_start)
 		})
 	}
 	if tok_id == 6 || tok_id == 81 || tok_id == 85 || tok_id == 89 {
 		p.next()
 		operand := p.expr(.highest)
 		pstart := p.add_child(operand)
-		return p.add_node(flat.Node{
+		return p.a.add_node(flat.Node{
 			kind:           .prefix
 			op:             token_id_to_op(tok_id)
 			children_start: pstart
 			children_count: 1
+			pos:            p.span_to(op_start)
 		})
 	}
 	match p.tok {
@@ -6487,7 +6530,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			} else {
 				1
 			}
-			return p.add_val_id(kind_id, val)
+			return p.add_val_id_at(kind_id, val, start_pos)
 		}
 		.string {
 			return p.string_literal()
@@ -6495,32 +6538,33 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 		.char {
 			val := p.lit
 			p.next()
-			return p.add_val_id(4, val)
+			return p.add_val_id_at(4, val, start_pos)
 		}
 		.key_true {
 			p.next()
-			return p.add_val_id(3, 'true')
+			return p.add_val_id_at(3, 'true', start_pos)
 		}
 		.key_false {
 			p.next()
-			return p.add_val_id(3, 'false')
+			return p.add_val_id_at(3, 'false', start_pos)
 		}
 		.key_nil {
 			p.next()
-			return p.add_id(28)
+			return p.add_id_at(28, start_pos)
 		}
 		.key_none {
 			p.next()
-			return p.add_id(29)
+			return p.add_id_at(29, start_pos)
 		}
 		.arrow {
 			p.next()
 			inner := p.expr(.highest)
-			return p.add_node(flat.Node{
+			return p.a.add_node(flat.Node{
 				kind:           .prefix
 				op:             .arrow
 				children_start: p.add_child(inner)
 				children_count: 1
+				pos:            p.span_to(op_start)
 			})
 		}
 		.logical_or {
@@ -7320,6 +7364,7 @@ fn (mut p Parser) call_args(fn_expr flat.NodeId) flat.NodeId {
 }
 
 fn (mut p Parser) lambda_expr_no_args() flat.NodeId {
+	op_start := p.span_start()
 	p.next()
 	lambda_body := p.expr(.lowest)
 	lstart := p.add_child(lambda_body)
@@ -7327,10 +7372,12 @@ fn (mut p Parser) lambda_expr_no_args() flat.NodeId {
 		kind:           .lambda_expr
 		children_start: lstart
 		children_count: 1
+		pos:            p.span_to(op_start)
 	})
 }
 
 fn (mut p Parser) pipe_lambda_expr() flat.NodeId {
+	op_start := p.span_start()
 	p.next()
 	mut lambda_params := []flat.NodeId{}
 	if p.tok != .pipe && p.tok != .eof {
@@ -7349,6 +7396,7 @@ fn (mut p Parser) pipe_lambda_expr() flat.NodeId {
 		kind:           .lambda_expr
 		children_start: lstart
 		children_count: flat.child_count(ids.len)
+		pos:            p.span_to(op_start)
 	})
 }
 
@@ -7358,7 +7406,13 @@ fn (mut p Parser) lambda_param_ident() flat.NodeId {
 		is_mut = true
 		p.next()
 	}
-	id := p.a.add_val(.ident, p.expect_name())
+	name_pos := p.current_pos()
+	name := p.expect_name()
+	id := p.a.add_node(flat.Node{
+		kind:  .ident
+		value: name
+		pos:   name_pos
+	})
 	if is_mut {
 		p.a.set_node_is_mut(id, true)
 	}

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -1,0 +1,102 @@
+module parser
+
+import os
+import flat
+import pref
+
+// Parses `src` on its own and returns the flat AST plus the exact bytes the
+// parser saw, so a node's [offset, end) span can be checked against the source.
+fn parse_span_source(name string, src string) (&flat.FlatAst, string) {
+	path := os.join_path(os.temp_dir(), 'v3_span_${name}_${os.getpid()}.v')
+	os.write_file(path, src) or { panic(err) }
+	mut p := Parser.new(pref.new_preferences())
+	ast := p.parse_file(path)
+	content := os.read_file(path) or { panic(err) }
+	os.rm(path) or {}
+	return ast, content
+}
+
+fn span_text(src string, node flat.Node) string {
+	if !node.pos.is_valid() || node.pos.offset < 0 || node.pos.end > src.len
+		|| node.pos.end < node.pos.offset {
+		return ''
+	}
+	return src[node.pos.offset..node.pos.end]
+}
+
+// Literal nodes must carry their own span, not the span of the token that
+// happens to follow them after p.next().
+fn test_literal_nodes_span_their_own_source() {
+	ast, src := parse_span_source('literals', 'fn main() {
+	n := 12345
+	c := `q`
+	b := true
+	_ = n
+	_ = c
+	_ = b
+}
+')
+	mut saw_number := false
+	mut saw_char := false
+	mut saw_bool := false
+	for node in ast.nodes {
+		match node.kind {
+			.int_literal {
+				if node.value == '12345' {
+					saw_number = true
+					assert span_text(src, node) == '12345'
+				}
+			}
+			.char_literal {
+				saw_char = true
+				assert span_text(src, node) == '`q`'
+			}
+			.bool_literal {
+				if node.value == 'true' {
+					saw_bool = true
+					assert span_text(src, node) == 'true'
+				}
+			}
+			else {}
+		}
+	}
+	assert saw_number
+	assert saw_char
+	assert saw_bool
+}
+
+// Prefix expressions span from the operator to the end of their operand.
+fn test_prefix_expression_spans_operator_to_operand() {
+	ast, src := parse_span_source('prefix', 'fn main() {
+	m := -42
+	_ = m
+}
+')
+	mut saw_prefix := false
+	for node in ast.nodes {
+		if node.kind == .prefix {
+			saw_prefix = true
+			assert span_text(src, node) == '-42'
+		}
+	}
+	assert saw_prefix
+}
+
+// Lambda nodes are built directly on the flat AST; they must still receive a
+// valid span covering the whole lambda rather than a zero position.
+fn test_lambda_nodes_have_valid_spans() {
+	ast, src := parse_span_source('lambda', 'fn main() {
+	f := |it| it + 7
+	_ = f
+}
+')
+	mut saw_lambda := false
+	for node in ast.nodes {
+		if node.kind == .lambda_expr {
+			saw_lambda = true
+			assert node.pos.is_valid()
+			assert span_text(src, node) == '|it| it + 7'
+		}
+	}
+	assert saw_lambda
+}

--- a/vlib/v3/profiler/alloc.v
+++ b/vlib/v3/profiler/alloc.v
@@ -51,9 +51,19 @@ pub mut:
 // Global profiler state singleton
 __global profiler_state = &ProfilerState{}
 
-// init_profiler_state initializes the global profiler state
-// Must be called before using the profiler
+// profiler_init_once guards init_profiler_state so that concurrent or repeated
+// callers cannot replace the mutex and state out from under an in-flight
+// allocation. The first caller wins; the rest are no-ops.
+__global profiler_init_once = sync.new_once()
+
+// init_profiler_state initializes the global profiler state exactly once.
+// Must be called before using the profiler. Safe to call from multiple threads
+// and more than once.
 pub fn init_profiler_state() {
+	profiler_init_once.do(do_init_profiler_state)
+}
+
+fn do_init_profiler_state() {
 	profiler_state.mu = sync.new_mutex()
 	profiler_state.enabled = false
 	profiler_state.current_frame = 0

--- a/vlib/v3/profiler/context.v
+++ b/vlib/v3/profiler/context.v
@@ -3,8 +3,6 @@
 // that can be found in the LICENSE file.
 module profiler
 
-import context
-
 // Allocator interface - can be swapped at runtime
 // Similar to Jai's context.allocator design
 pub struct Allocator {

--- a/vlib/v3/profiler/ipc.v
+++ b/vlib/v3/profiler/ipc.v
@@ -73,16 +73,25 @@ pub fn write_snapshot_to(path string) {
 	for i := start_alloc; i < profiler_state.allocs.len; i++ {
 		alloc := profiler_state.allocs[i]
 		freed_val := if alloc.freed { '1' } else { '0' }
-		// ptr,size,frame,freed,free_frame,file,line
-		sb << '${u64(alloc.ptr)},${alloc.size},${alloc.frame},${freed_val},${alloc.free_frame},${alloc.file},${alloc.line}\n'.bytes()
+		// The file path is emitted last and its line-breaking characters are
+		// stripped, so a path containing commas cannot be mistaken for extra
+		// fields by the comma-splitting reader.
+		safe_file := alloc.file.replace('\n', ' ').replace('\r', ' ')
+		// ptr,size,frame,freed,free_frame,line,file
+		sb << '${u64(alloc.ptr)},${alloc.size},${alloc.frame},${freed_val},${alloc.free_frame},${alloc.line},${safe_file}\n'.bytes()
 	}
 
 	sb << 'END\n'.bytes()
 
-	// Write atomically by writing to temp file then renaming
-	tmp_path := path + '.tmp'
+	// Write atomically by writing to a per-writer temp file then renaming. The
+	// name must be unique per writer so concurrent snapshot writers do not
+	// clobber one another's temp file mid-write.
+	tmp_path := '${path}.tmp.${os.getpid()}.${time.sys_mono_now()}'
 	os.write_file(tmp_path, sb.bytestr()) or { return }
-	os.rename(tmp_path, path) or { return }
+	os.rename(tmp_path, path) or {
+		os.rm(tmp_path) or {}
+		return
+	}
 }
 
 // read_snapshot reads profiler state from the shared file
@@ -143,14 +152,16 @@ pub fn read_snapshot_from(path string) ?Snapshot {
 			}
 			parts := lines[line_idx].split(',')
 			if parts.len >= 7 {
+				// ptr,size,frame,freed,free_frame,line,file — the file is last
+				// and may itself contain commas, so rejoin the trailing fields.
 				snap.allocs << AllocRecord{
 					ptr:        unsafe { voidptr(u64(parts[0].i64())) }
 					size:       parts[1].int()
 					frame:      u64(parts[2].i64())
 					freed:      parts[3] == '1'
 					free_frame: u64(parts[4].i64())
-					file:       parts[5]
-					line:       parts[6].int()
+					line:       parts[5].int()
+					file:       parts[6..].join(',')
 				}
 			}
 			line_idx++

--- a/vlib/v3/profiler/ipc_test.v
+++ b/vlib/v3/profiler/ipc_test.v
@@ -1,0 +1,43 @@
+module profiler
+
+import os
+import time
+
+// A snapshot must round-trip file paths that contain commas: the record format
+// puts the path last and the reader rejoins the trailing fields, so a comma in
+// the path can no longer be mistaken for extra columns.
+fn test_snapshot_roundtrips_file_paths_with_commas() {
+	init_profiler_state()
+	profiler_enable()
+	reset()
+
+	// Record an allocation whose source path contains commas.
+	ptr := profiler_alloc_with_location(64, '/tmp/weird,path/with,commas.v', 42)
+	assert ptr != unsafe { nil }
+
+	path := os.join_path(os.temp_dir(), 'v3_profiler_ipc_test_${os.getpid()}_${time.sys_mono_now()}.dat')
+	defer {
+		os.rm(path) or {}
+	}
+	write_snapshot_to(path)
+
+	snap := read_snapshot_from(path) or {
+		assert false, 'snapshot did not parse'
+		return
+	}
+	assert snap.allocs.len >= 1
+	last := snap.allocs[snap.allocs.len - 1]
+	assert last.file == '/tmp/weird,path/with,commas.v'
+	assert last.line == 42
+	assert last.size == 64
+}
+
+// init_profiler_state must be idempotent: repeated calls keep the same mutex and
+// do not wipe state out from under an active profiling session.
+fn test_init_profiler_state_is_idempotent() {
+	init_profiler_state()
+	mu_before := voidptr(get_state().mu)
+	init_profiler_state()
+	init_profiler_state()
+	assert voidptr(get_state().mu) == mu_before
+}

--- a/vlib/v3/profiler/profiler_alloc.v
+++ b/vlib/v3/profiler/profiler_alloc.v
@@ -12,13 +12,18 @@ fn profiler_alloc(size int, ctx voidptr) voidptr {
 		return ptr
 	}
 
-	if profiler_state.mu == unsafe { nil } || !profiler_state.enabled {
+	if profiler_state.mu == unsafe { nil } {
 		return ptr
 	}
 
 	profiler_state.mu.lock()
 	defer {
 		profiler_state.mu.unlock()
+	}
+	// `enabled` is read under the same mutex that guards its writes; reading it
+	// outside the lock would race with profiler_enable/profiler_disable.
+	if !profiler_state.enabled {
+		return ptr
 	}
 
 	idx := profiler_state.allocs.len
@@ -56,13 +61,16 @@ pub fn profiler_alloc_with_location(size int, file string, line int) voidptr {
 		return ptr
 	}
 
-	if profiler_state.mu == unsafe { nil } || !profiler_state.enabled {
+	if profiler_state.mu == unsafe { nil } {
 		return ptr
 	}
 
 	profiler_state.mu.lock()
 	defer {
 		profiler_state.mu.unlock()
+	}
+	if !profiler_state.enabled {
+		return ptr
 	}
 
 	idx := profiler_state.allocs.len
@@ -99,27 +107,29 @@ fn profiler_free(ptr voidptr, ctx voidptr) {
 		return
 	}
 
-	if profiler_state.mu != unsafe { nil } && profiler_state.enabled {
+	if profiler_state.mu != unsafe { nil } {
 		profiler_state.mu.lock()
 
-		if idx := profiler_state.alloc_map[ptr] {
-			profiler_state.allocs[idx].freed = true
-			profiler_state.allocs[idx].free_frame = profiler_state.current_frame
-			alloc_size := u64(profiler_state.allocs[idx].size)
-			if profiler_state.live_bytes >= alloc_size {
-				profiler_state.live_bytes -= alloc_size
-			}
-			profiler_state.total_frees++
+		if profiler_state.enabled {
+			if idx := profiler_state.alloc_map[ptr] {
+				profiler_state.allocs[idx].freed = true
+				profiler_state.allocs[idx].free_frame = profiler_state.current_frame
+				alloc_size := u64(profiler_state.allocs[idx].size)
+				if profiler_state.live_bytes >= alloc_size {
+					profiler_state.live_bytes -= alloc_size
+				}
+				profiler_state.total_frees++
 
-			// Add to current frame's freed list
-			if profiler_state.frames.len > 0 {
-				frame_idx := profiler_state.frames.len - 1
-				profiler_state.frames[frame_idx].freed_idxs << idx
-				profiler_state.frames[frame_idx].freed_bytes += alloc_size
-			}
+				// Add to current frame's freed list
+				if profiler_state.frames.len > 0 {
+					frame_idx := profiler_state.frames.len - 1
+					profiler_state.frames[frame_idx].freed_idxs << idx
+					profiler_state.frames[frame_idx].freed_bytes += alloc_size
+				}
 
-			// Remove from map
-			profiler_state.alloc_map.delete(ptr)
+				// Remove from map
+				profiler_state.alloc_map.delete(ptr)
+			}
 		}
 
 		profiler_state.mu.unlock()
@@ -139,12 +149,12 @@ fn profiler_realloc(ptr voidptr, new_size int, ctx voidptr) voidptr {
 	}
 
 	// Record the free of old allocation
-	old_size := 0
-	if profiler_state.mu != unsafe { nil } && profiler_state.enabled {
+	mut old_size := 0
+	if profiler_state.mu != unsafe { nil } {
 		profiler_state.mu.lock()
-		if idx := profiler_state.alloc_map[ptr] {
-			unsafe {
-				*(&old_size) = profiler_state.allocs[idx].size
+		if profiler_state.enabled {
+			if idx := profiler_state.alloc_map[ptr] {
+				old_size = profiler_state.allocs[idx].size
 			}
 		}
 		profiler_state.mu.unlock()
@@ -155,59 +165,66 @@ fn profiler_realloc(ptr voidptr, new_size int, ctx voidptr) voidptr {
 		return new_ptr
 	}
 
-	if profiler_state.mu != unsafe { nil } && profiler_state.enabled {
-		profiler_state.mu.lock()
-		defer {
-			profiler_state.mu.unlock()
-		}
+	if profiler_state.mu == unsafe { nil } {
+		return new_ptr
+	}
+	profiler_state.mu.lock()
+	defer {
+		profiler_state.mu.unlock()
+	}
+	if !profiler_state.enabled {
+		return new_ptr
+	}
 
-		// Remove old entry
-		if idx := profiler_state.alloc_map[ptr] {
-			profiler_state.allocs[idx].freed = true
-			profiler_state.allocs[idx].free_frame = profiler_state.current_frame
-			if profiler_state.live_bytes >= u64(old_size) {
-				profiler_state.live_bytes -= u64(old_size)
-			}
-			profiler_state.total_frees++
-
-			if profiler_state.frames.len > 0 {
-				frame_idx := profiler_state.frames.len - 1
-				profiler_state.frames[frame_idx].freed_idxs << idx
-				profiler_state.frames[frame_idx].freed_bytes += u64(old_size)
-			}
-			profiler_state.alloc_map.delete(ptr)
+	// Remove old entry
+	if idx := profiler_state.alloc_map[ptr] {
+		profiler_state.allocs[idx].freed = true
+		profiler_state.allocs[idx].free_frame = profiler_state.current_frame
+		if profiler_state.live_bytes >= u64(old_size) {
+			profiler_state.live_bytes -= u64(old_size)
 		}
-
-		// Add new entry
-		new_idx := profiler_state.allocs.len
-		profiler_state.allocs << AllocRecord{
-			ptr:       new_ptr
-			size:      new_size
-			frame:     profiler_state.current_frame
-			file:      ''
-			line:      0
-			timestamp: time.sys_mono_now()
-			freed:     false
-		}
-		profiler_state.alloc_map[new_ptr] = new_idx
-		profiler_state.live_bytes += u64(new_size)
-		profiler_state.total_allocs++
+		profiler_state.total_frees++
 
 		if profiler_state.frames.len > 0 {
 			frame_idx := profiler_state.frames.len - 1
-			profiler_state.frames[frame_idx].new_allocs << new_idx
-			profiler_state.frames[frame_idx].new_bytes += u64(new_size)
+			profiler_state.frames[frame_idx].freed_idxs << idx
+			profiler_state.frames[frame_idx].freed_bytes += u64(old_size)
 		}
+		profiler_state.alloc_map.delete(ptr)
+	}
 
-		if profiler_state.live_bytes > profiler_state.peak_bytes {
-			profiler_state.peak_bytes = profiler_state.live_bytes
-		}
+	// Add new entry
+	new_idx := profiler_state.allocs.len
+	profiler_state.allocs << AllocRecord{
+		ptr:       new_ptr
+		size:      new_size
+		frame:     profiler_state.current_frame
+		file:      ''
+		line:      0
+		timestamp: time.sys_mono_now()
+		freed:     false
+	}
+	profiler_state.alloc_map[new_ptr] = new_idx
+	profiler_state.live_bytes += u64(new_size)
+	profiler_state.total_allocs++
+
+	if profiler_state.frames.len > 0 {
+		frame_idx := profiler_state.frames.len - 1
+		profiler_state.frames[frame_idx].new_allocs << new_idx
+		profiler_state.frames[frame_idx].new_bytes += u64(new_size)
+	}
+
+	if profiler_state.live_bytes > profiler_state.peak_bytes {
+		profiler_state.peak_bytes = profiler_state.live_bytes
 	}
 
 	return new_ptr
 }
 
-// profiler_allocator returns an Allocator that tracks all allocations
+// profiler_allocator returns an Allocator that records every allocation routed
+// through it (via profiler.alloc/free/realloc or use_profiler_allocator). It
+// does not intercept V's builtin allocations or raw C.malloc calls that bypass
+// this allocator.
 pub fn profiler_allocator() Allocator {
 	return Allocator{
 		alloc_fn:   profiler_alloc

--- a/vlib/v3/profiler/runtime.v
+++ b/vlib/v3/profiler/runtime.v
@@ -57,13 +57,17 @@ pub fn profiler_is_enabled() bool {
 // frame_end signals the end of a frame and collects frame data
 // Call this at the end of each game/application frame
 pub fn frame_end() {
-	if profiler_state.mu == unsafe { nil } || !profiler_state.enabled {
+	if profiler_state.mu == unsafe { nil } {
 		return
 	}
 
 	profiler_state.mu.lock()
 	defer {
 		profiler_state.mu.unlock()
+	}
+	// Read `enabled` under the lock to avoid racing enable/disable.
+	if !profiler_state.enabled {
+		return
 	}
 
 	// Finalize current frame's live bytes

--- a/vlib/v3/tests/operator_precedence_codegen_test.v
+++ b/vlib/v3/tests/operator_precedence_codegen_test.v
@@ -1,0 +1,80 @@
+import os
+
+// Locks in V's documented operator precedence (see the language reference,
+// Appendix II) for the v3 parser. `+ - | ^` all share the `sum` level and
+// `* / % << >> >>> &` all share the `product` level, so shifts and `&` bind
+// tighter than `+`/`-`/`|`/`^`, and operators inside one level fold left.
+// A finer-grained binding-power table (e.g. splitting `|` below `^` below `+`,
+// or `<<` below `*`) silently reparses real programs, so every boundary pair is
+// pinned here.
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn tmp_precedence_path(name string) string {
+	return os.join_path(os.temp_dir(), 'v3_prec_${name}_${os.getpid()}')
+}
+
+fn build_v3_precedence() string {
+	v3_bin := tmp_precedence_path('compiler')
+	build :=
+		os.execute('${os.quoted_path(vexe)} -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(v3_src)}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn eval_int(v3_bin string, name string, expr string) string {
+	src := 'fn main() {\n\tprintln(${expr})\n}\n'
+	src_path := '${tmp_precedence_path(name)}.v'
+	bin_path := tmp_precedence_path('${name}_bin')
+	os.write_file(src_path, src) or { panic(err) }
+	compile :=
+		os.execute('${os.quoted_path(v3_bin)} ${os.quoted_path(src_path)} -b c -o ${os.quoted_path(bin_path)}')
+	assert compile.exit_code == 0, '${expr}\n${compile.output}'
+	assert !compile.output.contains('C compilation failed'), '${expr}\n${compile.output}'
+	run := os.execute(os.quoted_path(bin_path))
+	assert run.exit_code == 0, '${expr}\n${run.output}'
+	return run.output.trim_space()
+}
+
+fn test_operator_precedence_boundaries() {
+	v3_bin := build_v3_precedence()
+
+	// product binds tighter than sum
+	assert eval_int(v3_bin, 'mul_vs_add', '2 + 3 * 4') == '14'
+	assert eval_int(v3_bin, 'div_vs_sub', '20 - 12 / 4') == '17'
+
+	// shifts live at product, so they bind tighter than +/-
+	assert eval_int(v3_bin, 'add_then_shift', '1 + 2 << 3') == '17'
+	assert eval_int(v3_bin, 'shift_then_add', '8 << 1 + 1') == '17'
+	assert eval_int(v3_bin, 'shift_then_sub', '2 << 3 - 1') == '15'
+
+	// & lives at product, |/^ live at sum
+	assert eval_int(v3_bin, 'and_vs_add', '10 & 3 + 1') == '3'
+	assert eval_int(v3_bin, 'or_vs_and', '1 | 2 & 3') == '3'
+	assert eval_int(v3_bin, 'xor_vs_and', '5 & 3 ^ 1') == '0'
+
+	// |, ^, +, - all share the sum level and fold left
+	assert eval_int(v3_bin, 'or_vs_xor', '1 | 2 ^ 3') == '0'
+	assert eval_int(v3_bin, 'xor_then_or', '1 ^ 2 | 4') == '7'
+	assert eval_int(v3_bin, 'xor_vs_add', '1 ^ 2 + 3') == '6'
+
+	// left associativity within a level
+	assert eval_int(v3_bin, 'sub_left_assoc', '10 - 3 - 2') == '5'
+	assert eval_int(v3_bin, 'mod_left_assoc', '2 * 3 % 4') == '2'
+	assert eval_int(v3_bin, 'shift_left_assoc', '32 >> 1 >> 2') == '4'
+
+	// explicit parentheses override
+	assert eval_int(v3_bin, 'paren_add_shift', '(1 + 2) << 3') == '24'
+
+	// bitwise binds tighter than comparison
+	assert eval_int(v3_bin, 'or_vs_eq', 'int(3 | 4 == 7)') == '1'
+	assert eval_int(v3_bin, 'and_vs_eq', 'int(5 & 3 == 1)') == '1'
+
+	// comparison binds tighter than &&, which binds tighter than ||
+	assert eval_int(v3_bin, 'cmp_vs_and', 'int(1 < 2 && 3 < 4)') == '1'
+	assert eval_int(v3_bin, 'and_vs_or', 'int(true || false && false)') == '1'
+}

--- a/vlib/v3/tests/secure_command_test.v
+++ b/vlib/v3/tests/secure_command_test.v
@@ -232,3 +232,126 @@ fn main() { println(int_str(C.fallback_value())) }
 	assert cmdexec.run(second_out, []string{}).output.trim_space() == '9'
 	assert second.output.contains('C object cache bypass:'), second.output
 }
+
+// A `cc -M` that succeeds but emits no `-MT` target marker must not be accepted
+// as a valid, source-only dependency set: `all_after` would return the whole
+// output, tokenize it into bogus paths, and let the header edit go unnoticed.
+// The dependency scan must fail closed to a build-local object instead.
+fn test_c_object_cache_falls_back_when_dependency_marker_is_missing() {
+	$if windows {
+		return
+	}
+	v3_bin := build_secure_command_v3()
+	root := secure_temp_path('object_cache_missing_marker')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.unsetenv('V3_CACHE_TRACE')
+		os.rmdir_all(root) or {}
+		os.rm(v3_bin) or {}
+	}
+	// On `-M` this wrapper succeeds but prints unrelated text with no `v3cache:`
+	// marker; every other invocation delegates to the real `cc`.
+	compiler := os.join_path(root, 'cc_without_marker')
+	os.write_file(compiler, '#!/bin/sh
+for arg in "\$@"; do
+	if [ "\$arg" = "-M" ]; then
+		echo "no dependency marker here"
+		exit 0
+	fi
+done
+exec cc "\$@"
+') or {
+		panic(err)
+	}
+	os.chmod(compiler, 0o700) or { panic(err) }
+	header := os.join_path(root, 'value.h')
+	c_source := os.join_path(root, 'helper.c')
+	v_source := os.join_path(root, 'main.v')
+	os.write_file(header, '#define MARKER_VALUE 7\n') or { panic(err) }
+	os.write_file(c_source, '#include "value.h"\nint marker_value(void) { return MARKER_VALUE; }\n') or {
+		panic(err)
+	}
+	os.write_file(v_source, 'module main
+#flag @DIR/helper.o
+fn C.marker_value() int
+fn main() { println(int_str(C.marker_value())) }
+') or {
+		panic(err)
+	}
+	os.setenv('V3_CACHE_TRACE', '1', true)
+	first_out := os.join_path(root, 'first')
+	first := cmdexec.run(v3_bin, [v_source, '-cc', compiler, '-prod', '-o', first_out])
+	assert first.exit_code == 0, first.output
+	assert cmdexec.run(first_out, []string{}).output.trim_space() == '7'
+	assert first.output.contains('C object cache bypass:'), first.output
+	// The header change must be reflected because the object was never cached.
+	os.write_file(header, '#define MARKER_VALUE 9\n') or { panic(err) }
+	second_out := os.join_path(root, 'second')
+	second := cmdexec.run(v3_bin, [v_source, '-cc', compiler, '-prod', '-o', second_out])
+	assert second.exit_code == 0, second.output
+	assert cmdexec.run(second_out, []string{}).output.trim_space() == '9'
+	assert second.output.contains('C object cache bypass:'), second.output
+}
+
+// If a dependency changes between the moment the cache key is computed and the
+// moment compilation finishes, the object no longer matches the key. The cache
+// must detect this by re-hashing inputs after compilation and use a build-local
+// object rather than certifying the stale content under that key.
+fn test_c_object_cache_detects_input_change_during_compile() {
+	$if windows {
+		return
+	}
+	v3_bin := build_secure_command_v3()
+	root := secure_temp_path('object_cache_input_race')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.unsetenv('V3_CACHE_TRACE')
+		os.rmdir_all(root) or {}
+		os.rm(v3_bin) or {}
+	}
+	header := os.join_path(root, 'value.h')
+	c_source := os.join_path(root, 'helper.c')
+	v_source := os.join_path(root, 'main.v')
+	// This wrapper delegates to the real `cc`, but on the object compile (`-c`)
+	// it mutates the header AFTER building the object — simulating a source edit
+	// that lands while the compiler is running.
+	compiler := os.join_path(root, 'cc_mutating_header')
+	os.write_file(compiler, '#!/bin/sh
+is_compile=0
+for arg in "\$@"; do
+	if [ "\$arg" = "-c" ]; then
+		is_compile=1
+	fi
+done
+cc "\$@"
+rc=\$?
+if [ "\$is_compile" = "1" ]; then
+	printf "#define RACE_VALUE 7\\n" > "${header}"
+fi
+exit \$rc
+') or {
+		panic(err)
+	}
+	os.chmod(compiler, 0o700) or { panic(err) }
+	os.write_file(header, '#define RACE_VALUE 1\n') or { panic(err) }
+	os.write_file(c_source, '#include "value.h"\nint race_value(void) { return RACE_VALUE; }\n') or {
+		panic(err)
+	}
+	os.write_file(v_source, 'module main
+#flag @DIR/helper.o
+fn C.race_value() int
+fn main() { println(int_str(C.race_value())) }
+') or {
+		panic(err)
+	}
+	os.setenv('V3_CACHE_TRACE', '1', true)
+	first_out := os.join_path(root, 'first')
+	first := cmdexec.run(v3_bin, [v_source, '-cc', compiler, '-prod', '-o', first_out])
+	assert first.exit_code == 0, first.output
+	// The object was built from RACE_VALUE 1; the mid-compile edit to 7 means the
+	// object must not be published under the key that hashed the original header.
+	assert first.output.contains('inputs changed during compilation'), first.output
+	assert cmdexec.run(first_out, []string{}).output.trim_space() == '1'
+}

--- a/vlib/v3/token/token.v
+++ b/vlib/v3/token/token.v
@@ -116,16 +116,19 @@ pub enum Token {
 }
 
 // BindingPower lists binding power values used by token.
+// The levels mirror V's documented operator precedence (see the language
+// reference, Appendix II): `+ - | ^` all share the `sum` level and
+// `* / % << >> >>> &` all share the `product` level. Do not split these into
+// finer levels — doing so changes the parse of expressions that mix operators
+// of the same documented precedence, e.g. `1 | 2 ^ 3` must fold to `(1 | 2) ^ 3`
+// at `sum` and `a << b * c` must fold to `(a << b) * c` at `product`.
 pub enum BindingPower {
 	lowest
 	logical_or  // ||
 	logical_and // &&
 	compare     // ==, !=, <, <=, >, >=, in, !in, is, !is
-	bit_or      // |
-	bit_xor     // ^
-	add         // +, -
-	shift       // <<, >>, >>>
-	product     // *, /, %, &
+	sum         // +, -, |, ^
+	product     // *, /, %, <<, >>, >>>, &
 	highest
 }
 
@@ -136,26 +139,24 @@ pub fn (t Token) left_binding_power() BindingPower {
 		.logical_or { .logical_or }
 		.and { .logical_and }
 		.eq, .ne, .lt, .le, .gt, .ge, .key_in, .not_in, .key_is, .not_is { .compare }
-		.pipe { .bit_or }
-		.xor { .bit_xor }
-		.left_shift, .right_shift, .right_shift_unsigned { .shift }
-		.plus, .minus { .add }
-		.mul, .div, .mod, .amp { .product }
+		.plus, .minus, .pipe, .xor { .sum }
+		.mul, .div, .mod, .amp, .left_shift, .right_shift, .right_shift_unsigned { .product }
 		else { .lowest }
 	}
 }
 
 // right_binding_power supports right binding power handling for Token.
+// Every binary operator here is left-associative, so the right binding power is
+// the level immediately above the operator's own level: parsing the right
+// operand stops as soon as it sees another operator at the same level, which
+// hands that operator back to the outer loop and folds left.
 @[inline]
 pub fn (t Token) right_binding_power() BindingPower {
 	return match t.left_binding_power() {
 		.logical_or { .logical_and }
 		.logical_and { .compare }
-		.compare { .bit_or }
-		.bit_or { .bit_xor }
-		.bit_xor { .add }
-		.add { .shift }
-		.shift { .product }
+		.compare { .sum }
+		.sum { .product }
 		.product { .highest }
 		else { .lowest }
 	}

--- a/vlib/v3/token/token_test.v
+++ b/vlib/v3/token/token_test.v
@@ -2,8 +2,14 @@ module token
 
 fn test_operator_properties_are_owned_by_tokens() {
 	assert Token.plus.is_infix()
-	assert Token.plus.left_binding_power() == .add
+	assert Token.plus.left_binding_power() == .sum
+	assert Token.pipe.left_binding_power() == .sum
+	assert Token.xor.left_binding_power() == .sum
 	assert Token.mul.left_binding_power() == .product
+	assert Token.amp.left_binding_power() == .product
+	// `<<` `>>` `>>>` share the `product` level with `* / % &`, so they bind
+	// tighter than `+ - | ^` at `sum` (V precedence, docs Appendix II).
+	assert Token.left_shift.left_binding_power() == .product
 	assert int(Token.left_shift.left_binding_power()) > int(Token.plus.left_binding_power())
 	assert Token.logical_or.left_binding_power() == .logical_or
 	assert Token.logical_or.right_binding_power() == .logical_and

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -4685,12 +4685,20 @@ fn ownership_fn_literal_name(cur_fn string, id flat.NodeId) string {
 	return '${cur_fn}__fn_literal_${int(id)}'
 }
 
+// ownership_lambda_name derives the ownership identity of a lambda from the
+// enclosing function name and the lambda's flat-AST NodeId. Semantic identity
+// must key on NodeId, never on presentation position (`node.pos`), so this must
+// be the single source of the name at both the registration and lookup sites.
+fn ownership_lambda_name(cur_fn string, id flat.NodeId) string {
+	return '${cur_fn}__lambda_${int(id)}'
+}
+
 fn (mut tc TypeChecker) ownership_begin_lambda_expr(id flat.NodeId, node flat.Node) {
 	if tc.ownership_checks_suppressed() {
 		return
 	}
 	mut st := tc.ownership_state()
-	fn_name := '${st.cur_fn}__lambda_${int(id)}'
+	fn_name := ownership_lambda_name(st.cur_fn, id)
 	captures := tc.ownership_consume_lambda_captures(node, fn_name)
 	st.frames << OwnershipFrame{
 		cur_fn:          st.cur_fn
@@ -9893,7 +9901,7 @@ pub fn (tc &TypeChecker) ownership_fn_value_returns_owned(id flat.NodeId, enclos
 	if node.kind == .fn_literal {
 		names << ownership_fn_literal_name(parent_fn, id)
 	} else if node.kind == .lambda_expr {
-		names << '${parent_fn}__lambda_${node.pos.id}_${node.pos.offset}'
+		names << ownership_lambda_name(parent_fn, id)
 	} else if node.kind == .ident && node.value.len > 0 {
 		names << node.value
 		names << ownership_qualify_name(module_name, node.value)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -86,6 +86,7 @@ mut:
 	dependency_files          int
 	dependency_scan_fallbacks int
 	publish_races             int
+	input_snapshot_races      int
 	temporary_objects         []string
 }
 
@@ -206,12 +207,32 @@ fn ensure_c_object_file(obj_path string, support_flags []string, c99 bool, pic_f
 	stats.misses++
 	trace_c_object_cache('miss', cache_key, 'no published content-key entry',
 		dependencies.files.len)
+	// Snapshot the exact arguments that produced cache_key so the post-compile
+	// digest is computed over the same inputs (temp_obj/-c must not perturb it).
+	key_args := args.clone()
 	temp_obj := '${cached_obj}.tmp.${os.getpid()}.${rand.ulid()}'
 	args << ['-o', temp_obj, '-c', source_file]
 	res := cmdexec.run(compiler, args)
 	if res.exit_code != 0 {
 		os.rm(temp_obj) or {}
 		return error('failed to build C object ${obj_path} from ${source_file}:\n${res.output}')
+	}
+	// Re-hash the inputs after compilation. If a source or header changed while
+	// the compiler was running, the object no longer corresponds to cache_key;
+	// publishing it would certify content it was not built from. Use it as a
+	// build-local, uncached object instead.
+	post_key := c_object_cache_name(obj_path, compiler, key_args, dependencies.files, target)
+	if post_key != cache_key {
+		stats.input_snapshot_races++
+		trace_c_object_cache('bypass', cache_key,
+			'inputs changed during compilation; using build-local object', dependencies.files.len)
+		uncached_obj := os.join_path(uncached_dir, 'input_snapshot_race_${os.getpid()}_${rand.ulid()}.o')
+		os.mv(temp_obj, uncached_obj) or {
+			os.rm(temp_obj) or {}
+			return error('failed to stage build-local C object ${uncached_obj}: ${err}')
+		}
+		stats.temporary_objects << uncached_obj
+		return uncached_obj
 	}
 	os.mv(temp_obj, cached_obj) or {
 		os.rm(temp_obj) or {}
@@ -232,23 +253,56 @@ fn trace_c_object_cache(status string, key string, reason string, dependency_cou
 
 fn c_object_dependencies(compiler string, compile_args []string, source_file string) CObjectDependencies {
 	mut args := compile_args.clone()
-	args << ['-M', '-MT', 'v3cache', source_file]
+	mt_target := 'v3cache'
+	marker := '${mt_target}:'
+	args << ['-M', '-MT', mt_target, source_file]
 	result := cmdexec.run(compiler, args)
+	// Fail closed: any output we cannot fully and unambiguously interpret must
+	// use a build-local, uncached object. A malformed or unexpected depfile that
+	// is silently accepted as a valid, source-only dependency set would let a
+	// later build certify a stale object as current.
+	fallback := CObjectDependencies{
+		files:         [source_file]
+		used_fallback: true
+	}
 	if result.exit_code != 0 {
-		return CObjectDependencies{
-			files:         [source_file]
-			used_fallback: true
-		}
+		return fallback
+	}
+	if !result.output.contains(marker) {
+		// The `-MT` target marker is missing, so `all_after` would return the
+		// entire compiler output and tokenize it as bogus dependencies.
+		return fallback
 	}
 	continuation := '\\' + '\n'
-	dep_text := result.output.replace(continuation, ' ').all_after('v3cache:')
-	mut dependencies := cmdexec.split_args(dep_text) or { []string{} }
-	if source_file !in dependencies {
-		dependencies << source_file
+	dep_text := result.output.replace(continuation, ' ').all_after(marker)
+	dependencies := cmdexec.split_args(dep_text) or { return fallback }
+	if dependencies.len == 0 {
+		return fallback
 	}
-	dependencies.sort()
+	// Every listed path must resolve to a readable file, and the source file
+	// itself must be among them; otherwise the dependency set is untrustworthy.
+	source_real := os.real_path(source_file)
+	mut canonical_deps := []string{cap: dependencies.len}
+	mut saw_source := false
+	for dep in dependencies {
+		if dep.len == 0 {
+			continue
+		}
+		canonical := os.real_path(dep)
+		if !os.is_file(canonical) {
+			return fallback
+		}
+		canonical_deps << dep
+		if canonical == source_real {
+			saw_source = true
+		}
+	}
+	if !saw_source {
+		return fallback
+	}
+	canonical_deps.sort()
 	return CObjectDependencies{
-		files: dependencies
+		files: canonical_deps
 	}
 }
 
@@ -695,6 +749,17 @@ fn promote_scoped_signatures(mut tc types.TypeChecker, original_names map[string
 	if added_names.len > scoped_transform_signature_headroom {
 		tc.rebuild_scoped_transform_signature_maps()
 	}
+}
+
+// default_cc_identity returns the resolved path and version banner of the
+// default `cc`. Module objects in the persistent cache are compiled with literal
+// `cc` (only the default compiler is cacheable), so this must be part of the
+// cache salt: a `cc` upgrade or a retargeted `cc` symlink otherwise leaves stale
+// objects certified as current.
+fn default_cc_identity() string {
+	cc_path := os.find_abs_path_of_executable('cc') or { 'cc' }
+	cc_version := cmdexec.run('cc', ['--version']).output
+	return '${cc_path}\t${cc_version.replace('\n', ' ')}'
 }
 
 fn v3_cache_compiler_signature(vroot string) string {
@@ -1174,8 +1239,10 @@ fn main() {
 	host_target := pref.host_target()
 	cache_enabled := backend == 'c' && !c_only && !no_cache && !c_compiler_explicit
 		&& target.os == host_target.os && target.arch == host_target.arch
+	cc_identity := if cache_enabled { default_cc_identity() } else { '' }
 	cache_salt := [
 		'compiler=${v3_cache_compiler_signature(prefs.vroot)}',
+		'cc=${cc_identity}',
 		'vexe=${prefs.vexe}',
 		'backend=${backend}',
 		'target=${prefs.normalized_target_os()}',
@@ -1915,6 +1982,8 @@ fn main() {
 	b.metric('C object dep-scan fallbacks', c_object_cache_stats.dependency_scan_fallbacks,
 		'objects')
 	b.metric('C object publish races', c_object_cache_stats.publish_races, 'objects')
+	b.metric('C object input-snapshot races', c_object_cache_stats.input_snapshot_races,
+		'objects')
 	b.print_report()
 }
 

--- a/vlib/v3/workers/worker_pool_nix.c.v
+++ b/vlib/v3/workers/worker_pool_nix.c.v
@@ -10,6 +10,32 @@ import time
 // avoids reserving a new set of stacks for every compiler phase.
 const compiler_worker_stack_size = 64 * 1024 * 1024
 
+// The pool reserves compiler_worker_stack_size per worker, so a full pool can
+// reserve a large amount of address space. V3_WORKER_STACK_MB overrides the
+// per-worker stack (in MiB) for hosts that have measured a lower high-water use
+// or that need more headroom. Values below min_worker_stack_size are clamped so
+// a mistuned setting cannot hand the recursive phases a too-small stack.
+const min_worker_stack_size = 4 * 1024 * 1024
+
+// worker_stack_size resolves the per-worker stack size, honoring the
+// V3_WORKER_STACK_MB override and falling back to the default when it is unset,
+// non-numeric, or non-positive.
+fn worker_stack_size() usize {
+	requested_mb := os.getenv('V3_WORKER_STACK_MB')
+	if requested_mb.len == 0 {
+		return usize(compiler_worker_stack_size)
+	}
+	mb := requested_mb.int()
+	if mb <= 0 {
+		return usize(compiler_worker_stack_size)
+	}
+	mut bytes := i64(mb) * 1024 * 1024
+	if bytes < min_worker_stack_size {
+		bytes = min_worker_stack_size
+	}
+	return usize(bytes)
+}
+
 // Task is one type-erased compiler phase callback submitted to Pool.
 pub struct Task {
 pub:
@@ -100,12 +126,13 @@ pub fn new(size int) &Pool {
 		started_at_ns:        time.sys_mono_now()
 	}
 	fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
+	stack_size := worker_stack_size()
 	for idx in 0 .. wanted {
 		mut thread_id := C.pthread_t{}
 		result := if fail == 'pool:all' || fail == 'pool:${idx}' {
 			11
 		} else {
-			C.v3_pthread_create(&thread_id, compiler_worker_stack_size, pool_worker, voidptr(pool))
+			C.v3_pthread_create(&thread_id, stack_size, pool_worker, voidptr(pool))
 		}
 		if result == 0 {
 			pool.threads << thread_id

--- a/vlib/v3/workers/worker_pool_test.v
+++ b/vlib/v3/workers/worker_pool_test.v
@@ -19,6 +19,28 @@ fn test_pool_preserves_recursive_phase_stack_size() {
 	}
 }
 
+fn test_worker_stack_size_env_override_and_clamp() {
+	$if !windows {
+		os.unsetenv('V3_WORKER_STACK_MB')
+		assert worker_stack_size() == usize(compiler_worker_stack_size)
+
+		os.setenv('V3_WORKER_STACK_MB', '16', true)
+		assert worker_stack_size() == usize(16 * 1024 * 1024)
+
+		// Below the floor is clamped up to min_worker_stack_size.
+		os.setenv('V3_WORKER_STACK_MB', '1', true)
+		assert worker_stack_size() == usize(min_worker_stack_size)
+
+		// Non-numeric / non-positive values fall back to the default.
+		os.setenv('V3_WORKER_STACK_MB', 'not-a-number', true)
+		assert worker_stack_size() == usize(compiler_worker_stack_size)
+		os.setenv('V3_WORKER_STACK_MB', '0', true)
+		assert worker_stack_size() == usize(compiler_worker_stack_size)
+
+		os.unsetenv('V3_WORKER_STACK_MB')
+	}
+}
+
 fn test_pool_runs_persistent_batches_and_sync_fallbacks() {
 	mut pool := new(2)
 	mut args := []&PoolTestArg{cap: 4}


### PR DESCRIPTION
Addresses the compiler-rewrite re-audit findings. Every fix was verified against real V semantics (the mainline compiler / `doc/docs.md`) and covered by a test where observable.

## Front-end correctness
- **Operator precedence** (`token/`, `parser/`): collapsed the binding-power table to V's documented precedence (docs Appendix II) — `+ - | ^` share `sum`, `* / % << >> >>> &` share `product`. v3's previous finer-grained levels diverged from the spec: `1 | 2 ^ 3` folded as `1 | (2 ^ 3)` (=1) instead of `(1 | 2) ^ 3` (=0). New `operator_precedence_codegen_test.v` pins every boundary pair against mainline.
  - Note: the audit proposed making shifts bind *looser* than `+`; that is the opposite of V (`<<` is `product`, tighter than `+`), so that specific change was **not** applied — it would have broken `1 + 2 << 3`.
- **Parser source spans** (`parser/`): literals (number/char/bool/nil/none), prefix expressions, and both lambda forms + their params now carry their real span. They were built after `p.next()` or bypassed the position wrapper, so they inherited the following token's span or a zero position. Added `prev_tok_end` tracking + `span_test.v`.

## Ownership
- Lambda ownership identity is now derived from a single `NodeId`-based helper at both registration and lookup (lookup previously rebuilt a `node.pos`-based name that could never match).

## Module / third-party object caches (`v3.v`, `modulecache/`)
- C-object dependency scan **fails closed**: a missing `-MT` marker, tokenize failure, unreadable dependency, or absent source now falls back to a build-local object instead of caching a bogus source-only dependency set.
- **Input-snapshot race**: inputs are re-hashed after compilation; the object is published only if the digest is unchanged, else a build-local object is used.
- Default `cc` path+version added to the module-cache salt; `write_atomic` uses a per-writer ULID temp name.
- New regression tests in `secure_command_test.v` (missing marker, mid-compile header edit).

## Codegen / portability (`gen/c/`)
- Generated spawned-thread stack is an overridable default (`-DV_THREAD_STACK_SIZE=...`); documented that the headerless pthread typedefs are a fallback used only when the real `<pthread.h>` is absent.

## Memory safety (`flat/`)
- Removed the private `builtin.map`/`DenseArray` ABI mirroring used to detect whether the text-id map backing landed in a disposable prealloc scope. The table is now rebuilt into the arena whenever the scope interned anything — a superset of the old rebuild cases, so always safe. Validated in normal and `-prealloc` self-host.

## Workers (`workers/`)
- Per-worker stack size configurable via `V3_WORKER_STACK_MB` (clamped) to reduce the address space the persistent pool reserves.

## Profiler (`profiler/`)
- Read `enabled` under the mutex in alloc/free/realloc/frame_end (removes the data race with enable/disable); `init_profiler_state` guarded with a `sync.Once`; fixed `profiler_realloc` mutating an immutable local; unique IPC temp name + comma-safe record format; removed the unused `import context` that shadowed the thread-local `context` global. Added `ipc_test.v`.

## Testing
- Passing: `token`, `flat` (normal + `-prealloc`), `workers`, `parser` (span), `profiler`, `secure_command` (incl. new cache tests), `operator_precedence_codegen`.
- v3 self-hosts (`v3` compiles `v3.v`) and diverse codegen output matches mainline V.
- Pre-existing, unrelated failures on `master` (verified identical with/without this branch): one `ownership_test` case (`unknown field` on a same-named imported struct) and two `module_cache_test` stamp-artifact assertions.

## Deliberately deferred (larger follow-ups)
- Full immutable content-addressed cache *generations* with a single atomic manifest (the concrete TOCTOU sub-points here are fixed).
- A parser span *verifier* over all 46 `FlatAst.add*` call sites (the audit's named literal/prefix/lambda cases are fixed).
- Benchmark-gated perf items (type-interner sharding, AST text-footprint migration, SSA rebuild trims) and the headerless-pthread → real-`<pthread.h>` shim, which is a design change rather than a bug fix.