### PR TITLE
v3: complete parser source-span coverage and remove FileSet dangling pointer

### DIFF
--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -8496,6 +8496,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 				value:          '[]${elem_type}'
 				children_start: cstart
 				children_count: 1
+				pos:            p.span_to(bracket_start)
 			})
 		}
 		// array init: []Type{len: n, cap: c, init: v}
@@ -8538,6 +8539,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 					value:          fixed_type
 					children_start: cstart
 					children_count: 1
+					pos:            p.span_to(bracket_start)
 				})
 			}
 			if p.tok == .lsbr {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -7840,12 +7840,12 @@ fn (mut p Parser) selector_or_method(lhs flat.NodeId) flat.NodeId {
 			p.a.add_val(.ident, resolved_name)
 		}
 		sel_start := p.add_children2(lhs, inner)
-		sel := p.add_node(flat.Node{
+		sel := p.add_node_from(flat.Node{
 			kind:           .selector
 			value:          selector_value
 			children_start: sel_start
 			children_count: 2
-		})
+		}, lhs)
 		if p.tok == .lpar {
 			return p.call_args(sel)
 		}
@@ -7853,12 +7853,14 @@ fn (mut p Parser) selector_or_method(lhs flat.NodeId) flat.NodeId {
 	}
 	field_name := p.expect_name_or_keyword()
 	sel_start := p.add_child(lhs)
-	sel := p.add_node(flat.Node{
+	// Anchor the selector at its receiver (lhs) so it spans `recv.field` rather
+	// than the `(`/`[` that follows; call/index nodes built on it inherit this.
+	sel := p.add_node_from(flat.Node{
 		kind:           .selector
 		value:          field_name
 		children_start: sel_start
 		children_count: 1
-	})
+	}, lhs)
 	if p.tok == .lpar {
 		lhs_node := p.a.nodes[int(lhs)]
 		if lhs_node.kind == .ident && lhs_node.value != 'C' && field_name.len > 0
@@ -7868,12 +7870,12 @@ fn (mut p Parser) selector_or_method(lhs flat.NodeId) flat.NodeId {
 			inner := p.expr(.lowest)
 			p.check(.rpar)
 			cstart := p.add_child(inner)
-			return p.add_node(flat.Node{
+			return p.add_node_from(flat.Node{
 				kind:           .cast_expr
 				value:          full_name
 				children_start: cstart
 				children_count: 1
-			})
+			}, lhs)
 		}
 		return p.call_args(sel)
 	}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -6080,11 +6080,17 @@ fn (mut p Parser) assign_or_expr_inline() flat.NodeId {
 
 fn (mut p Parser) for_post_clause() flat.NodeId {
 	mut exprs := []flat.NodeId{}
+	// Capture each expression's end token as it is parsed; a comma-separated post
+	// clause is only wrapped after all of them are consumed, when prev_tok_end no
+	// longer reflects the individual expressions.
+	mut ends := []int{}
 	exprs << p.expr(.lowest)
+	ends << p.prev_tok_end
 	if p.tok == .comma {
 		for p.tok == .comma {
 			p.next()
 			exprs << p.expr(.lowest)
+			ends << p.prev_tok_end
 			if token_is_assignment(p.tok) {
 				break
 			}
@@ -6092,7 +6098,7 @@ fn (mut p Parser) for_post_clause() flat.NodeId {
 		if token_is_assignment(p.tok) {
 			return p.for_post_multi_assign(exprs)
 		}
-		return p.for_post_block_from_exprs(exprs)
+		return p.for_post_block_from_exprs(exprs, ends)
 	}
 	if token_is_assignment(p.tok) {
 		return p.for_post_assign(exprs[0])
@@ -6172,10 +6178,29 @@ fn (mut p Parser) for_post_expr_stmt(expr flat.NodeId) flat.NodeId {
 	}, expr)
 }
 
-fn (mut p Parser) for_post_block_from_exprs(exprs []flat.NodeId) flat.NodeId {
+// for_post_expr_stmt_ending wraps a post-clause expression whose end token is no
+// longer current (the following comma-separated expressions have been parsed), so
+// the wrapper spans just this expression rather than the whole clause.
+fn (mut p Parser) for_post_expr_stmt_ending(expr flat.NodeId, end int) flat.NodeId {
+	start := p.add_child(expr)
+	mut start_off := p.node_start(expr)
+	if start_off < 0 {
+		start_off = end
+	}
+	span := token.new_span(p.cur_file_id, clamp_source_offset(start_off, p.s.src.len),
+		clamp_source_offset(end, p.s.src.len))
+	return p.a.add_node(flat.Node{
+		kind:           .expr_stmt
+		children_start: start
+		children_count: 1
+		pos:            span
+	})
+}
+
+fn (mut p Parser) for_post_block_from_exprs(exprs []flat.NodeId, ends []int) flat.NodeId {
 	mut stmts := []flat.NodeId{cap: exprs.len}
-	for expr in exprs {
-		stmts << p.for_post_expr_stmt(expr)
+	for i, expr in exprs {
+		stmts << p.for_post_expr_stmt_ending(expr, ends[i])
 	}
 	start := p.add_children(stmts)
 	anchor := if stmts.len > 0 { stmts[0] } else { flat.empty_node }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -6178,11 +6178,12 @@ fn (mut p Parser) for_post_block_from_exprs(exprs []flat.NodeId) flat.NodeId {
 		stmts << p.for_post_expr_stmt(expr)
 	}
 	start := p.add_children(stmts)
-	return p.a.add_node(flat.Node{
+	anchor := if stmts.len > 0 { stmts[0] } else { flat.empty_node }
+	return p.add_node_from(flat.Node{
 		kind:           .block
 		children_start: start
 		children_count: flat.child_count(stmts.len)
-	})
+	}, anchor)
 }
 
 fn (mut p Parser) defer_stmt() flat.NodeId {
@@ -6356,36 +6357,36 @@ fn (mut p Parser) expr_with_lhs(first flat.NodeId, min_bp token.BindingPower) fl
 			op_id := int(p.tok)
 			p.next()
 			pstart := p.add_child(lhs)
-			lhs = p.add_node(flat.Node{
+			lhs = p.add_node_from(flat.Node{
 				kind:           .postfix
 				op:             token_id_to_op(op_id)
 				children_start: pstart
 				children_count: 1
-			})
+			}, lhs)
 			continue
 		}
 		// postfix `!` error propagation: expr!
 		if p.tok == .not {
 			p.next()
 			ostart := p.add_children2(lhs, p.add(flat.NodeKind.empty))
-			lhs = p.add_node(flat.Node{
+			lhs = p.add_node_from(flat.Node{
 				kind:           .or_expr
 				value:          '!'
 				children_start: ostart
 				children_count: 2
-			})
+			}, lhs)
 			continue
 		}
 		// postfix `?` optional propagation: expr?
 		if p.tok == .question {
 			p.next()
 			ostart := p.add_children2(lhs, p.add(flat.NodeKind.empty))
-			lhs = p.add_node(flat.Node{
+			lhs = p.add_node_from(flat.Node{
 				kind:           .or_expr
 				value:          '?'
 				children_start: ostart
 				children_count: 2
-			})
+			}, lhs)
 			continue
 		}
 		// `as` cast: expr as Type
@@ -7311,7 +7312,13 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 					children_count: 1
 				})
 			}
-			return p.add_val(.ident, name)
+			// name_pos was captured before the name token was consumed, so the
+			// identifier spans the name itself rather than the following token.
+			return p.a.add_node(flat.Node{
+				kind:  .ident
+				value: name
+				pos:   p.span_to(name_pos)
+			})
 		}
 		.lpar {
 			p.next()
@@ -7515,6 +7522,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				p.peek_pos = saved_peek_pos
 				p.has_peek = saved_has_peek
 			} else if p.tok == .lsbr && p.peek() == .rsbr {
+				arr_start := p.span_start() // start offset of `[` in `[]T`
 				type_name := '&' + p.parse_type_name()
 				if p.tok == .lpar {
 					p.next()
@@ -7529,7 +7537,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 					})
 				}
 				if p.tok == .lcbr && type_name.starts_with('&[]') {
-					inner := p.array_init_after_element_type(type_name[3..])
+					inner := p.array_init_after_element_type(type_name[3..], arr_start)
 					return p.a.add_node(flat.Node{
 						kind:           .prefix
 						op:             .amp
@@ -8445,7 +8453,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 		}
 		// array init: []Type{len: n, cap: c, init: v}
 		if elem_type.len > 0 && p.tok == .lcbr {
-			return p.array_init_after_element_type(elem_type)
+			return p.array_init_after_element_type(elem_type, bracket_start)
 		}
 		return p.add_node(flat.Node{
 			kind:  .array_init
@@ -8729,8 +8737,11 @@ fn (mut p Parser) fixed_array_value_literal(fixed_type string, start int) flat.N
 	})
 }
 
-fn (mut p Parser) array_init_after_element_type(elem_type string) flat.NodeId {
-	init_start := p.span_start()
+// array_init_after_element_type parses a dynamic-array initializer (`[]T{...}`).
+// `start` is the outer opening `[` of the `[]T` prefix, which the caller has
+// already consumed, so the `.array_init` node spans the whole expression rather
+// than just the `{...}` initializer.
+fn (mut p Parser) array_init_after_element_type(elem_type string, start int) flat.NodeId {
 	p.check(.lcbr)
 	mut ids := []flat.NodeId{}
 	for p.tok != .rcbr && p.tok != .eof {
@@ -8764,7 +8775,7 @@ fn (mut p Parser) array_init_after_element_type(elem_type string) flat.NodeId {
 		typ:            if elem_type.starts_with('typeof(') { '' } else { '[]${elem_type}' }
 		children_start: p.add_children(ids)
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(init_start)
+		pos:            p.span_to(start)
 	})
 }
 

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -2520,13 +2520,16 @@ fn (mut p Parser) parse_compile_error_call(directive_start int) flat.NodeId {
 	if p.tok == .semicolon {
 		p.next()
 	}
-	return p.make_compile_error_call(message, directive_start)
+	return p.make_compile_error_call(message, directive_start, p.prev_tok_end)
 }
 
 // make_compile_error_call builds the compiler-only `__v_compile_error` sentinel
-// call. `start` is the directive's source offset so the checker reports the
-// compile-error diagnostic against a positioned node instead of a zero span.
-fn (mut p Parser) make_compile_error_call(message flat.NodeId, start int) flat.NodeId {
+// call. `start`/`end` are the directive's source offsets so the checker reports
+// the compile-error diagnostic against a positioned node instead of a zero span.
+// Callers that have already consumed the directive can pass `p.prev_tok_end` as
+// `end`; callers resolving a directive out of a condition string (where the token
+// has not been consumed) must pass the token's own end.
+fn (mut p Parser) make_compile_error_call(message flat.NodeId, start int, end int) flat.NodeId {
 	// Keep this as a compiler-only sentinel call. The checker reports it immediately for a
 	// selected concrete branch, while a deferred generic branch keeps it until specialization;
 	// if that branch is selected, generic validation rejects the sentinel as well.
@@ -2537,7 +2540,8 @@ fn (mut p Parser) make_compile_error_call(message flat.NodeId, start int) flat.N
 		value:          '__v_compile_error'
 		children_start: cstart
 		children_count: 2
-		pos:            p.span_to(start)
+		pos:            token.new_span(p.cur_file_id, clamp_source_offset(start, p.s.src.len),
+			clamp_source_offset(end, p.s.src.len))
 	})
 }
 
@@ -2935,8 +2939,10 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 					content := os.read_file(vmod_file) or {
 						message := p.a.add_val_id(5,
 							'@VMOD_FILE can only be used in projects that have a v.mod file')
-						// pseudo_pos is the comptime condition's source offset.
-						call := p.make_compile_error_call(message, pseudo_pos)
+						// The @VMOD_FILE token has not been consumed here, so derive its
+						// own span from the condition's source offset (pseudo_pos) plus
+						// the token's local bounds within the condition string.
+						call := p.make_compile_error_call(message, pseudo_pos + start, pseudo_pos + i)
 						_ = p.make_top_level_compile_error(call)
 						''
 					}
@@ -7191,7 +7197,8 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 						'@VMOD_FILE can only be used in projects that have a v.mod file')
 					// name_pos was captured before @VMOD_FILE was consumed, so the
 					// sentinel call is reported at the directive, not the next token.
-					return p.make_compile_error_call(message, name_pos)
+					// prev_tok_end is the end of the just-consumed @VMOD_FILE token.
+					return p.make_compile_error_call(message, name_pos, p.prev_tok_end)
 				}
 				return p.add_val_id(5, content.replace('\r\n', '\n'))
 			}
@@ -7382,6 +7389,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			})
 		}
 		.amp {
+			amp_start := p.span_start() // start offset of the leading `&`
 			p.next()
 			if p.tok == .amp {
 				p.next()
@@ -7404,6 +7412,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 							value:          type_name
 							children_start: cstart
 							children_count: 1
+							pos:            p.span_to(amp_start)
 						})
 					}
 					id := p.add_val(.ident, base_name)
@@ -7412,12 +7421,14 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 						op:             .amp
 						children_start: p.add_child(id)
 						children_count: 1
+						pos:            p.span_to(amp_start)
 					})
 					return p.add_node(flat.Node{
 						kind:           .prefix
 						op:             .amp
 						children_start: p.add_child(first)
 						children_count: 1
+						pos:            p.span_to(amp_start)
 					})
 				}
 			} else if p.tok == .name && p.lit == 'C' && p.peek() == .dot {
@@ -7449,6 +7460,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 							typ:            '&${full_name}'
 							children_start: p.add_child(inner)
 							children_count: 1
+							pos:            p.span_to(amp_start)
 						})
 					}
 				}
@@ -7463,6 +7475,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 						value:          type_name
 						children_start: cstart
 						children_count: 1
+						pos:            p.span_to(amp_start)
 					})
 				}
 				if p.tok == .lcbr {
@@ -7472,6 +7485,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 						op:             .amp
 						children_start: p.add_child(inner)
 						children_count: 1
+						pos:            p.span_to(amp_start)
 					})
 				}
 				p.s = saved_s
@@ -7511,6 +7525,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 							op:             .amp
 							children_start: p.add_child(inner)
 							children_count: 1
+							pos:            p.span_to(amp_start)
 						})
 					}
 				}
@@ -7524,6 +7539,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 						value:          '&${local_type_name}'
 						children_start: cstart
 						children_count: 1
+						pos:            p.span_to(amp_start)
 					})
 				}
 				if p.tok == .semicolon && p.peek() == .lcbr {
@@ -7536,6 +7552,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 						op:             .amp
 						children_start: p.add_child(inner)
 						children_count: 1
+						pos:            p.span_to(amp_start)
 					})
 				}
 				p.s = saved_s
@@ -7559,6 +7576,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 						value:          type_name
 						children_start: cstart
 						children_count: 1
+						pos:            p.span_to(amp_start)
 					})
 				}
 				if p.tok == .lcbr && type_name.starts_with('&[]') {
@@ -7569,16 +7587,18 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 						typ:            type_name
 						children_start: p.add_child(inner)
 						children_count: 1
+						pos:            p.span_to(amp_start)
 					})
 				}
 			}
 			operand := p.expr(.highest)
 			pstart := p.add_child(operand)
-			return p.add_node(flat.Node{
+			return p.a.add_node(flat.Node{
 				kind:           .prefix
 				op:             .amp
 				children_start: pstart
 				children_count: 1
+				pos:            p.span_to(amp_start)
 			})
 		}
 		.and {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -385,6 +385,32 @@ fn (mut p Parser) add_id_at(kind_id int, pos token.Pos) flat.NodeId {
 	})
 }
 
+// node_start returns the start offset of an already-built node, or -1 when the
+// node has no valid span.
+fn (p &Parser) node_start(id flat.NodeId) int {
+	i := int(id)
+	if i < 0 || i >= p.a.nodes.len {
+		return -1
+	}
+	pos := p.a.nodes[i].pos
+	if !pos.is_valid() {
+		return -1
+	}
+	return pos.offset
+}
+
+// add_node_from builds a compound node whose span runs from the start of its
+// leftmost child (`first`) to the end of the most recently consumed token. Use
+// it for postfix/infix constructs (index, range, ...) that are assembled after
+// their children are parsed, so the node covers the whole construct rather than
+// inheriting the current token's position. Falls back to the current token start
+// when the child has no usable span.
+fn (mut p Parser) add_node_from(node flat.Node, first flat.NodeId) flat.NodeId {
+	start := p.node_start(first)
+	span := if start >= 0 { p.span_to(start) } else { p.span_to(p.span_start()) }
+	return p.a.add_node(node.with_pos(span))
+}
+
 fn (mut p Parser) record_diagnostic(message string, offset int) {
 	clamped_offset := clamp_source_offset(offset, p.s.src.len)
 	mut line := 1
@@ -2471,11 +2497,11 @@ fn (mut p Parser) parse_comptime_if() flat.NodeId {
 
 fn (mut p Parser) parse_compile_error_stmt() flat.NodeId {
 	call := p.parse_compile_error_call()
-	return p.a.add_node(flat.Node{
+	return p.add_node_from(flat.Node{
 		kind:           .expr_stmt
 		children_start: p.add_child(call)
 		children_count: 1
-	})
+	}, call)
 }
 
 fn (mut p Parser) parse_compile_error_call() flat.NodeId {
@@ -2516,11 +2542,11 @@ fn (mut p Parser) parse_top_level_compile_error() flat.NodeId {
 }
 
 fn (mut p Parser) make_top_level_compile_error(call flat.NodeId) flat.NodeId {
-	stmt := p.a.add_node(flat.Node{
+	stmt := p.add_node_from(flat.Node{
 		kind:           .expr_stmt
 		children_start: p.add_child(call)
 		children_count: 1
-	})
+	}, call)
 	start := p.add_child(stmt)
 	return p.a.add_node(flat.Node{
 		kind:           .fn_decl
@@ -4620,11 +4646,11 @@ fn (mut p Parser) stmt() flat.NodeId {
 					p.next()
 				}
 				estart := p.add_child(expr_id)
-				return p.a.add_node(flat.Node{
+				return p.add_node_from(flat.Node{
 					kind:           .expr_stmt
 					children_start: estart
 					children_count: 1
-				})
+				}, expr_id)
 			}
 			return if_id
 		}
@@ -6089,13 +6115,14 @@ fn (mut p Parser) for_post_multi_assign(lhs_ids []flat.NodeId) flat.NodeId {
 		'for post assignment mismatch: ${lhs_ids.len} variables but ${rhs_ids.len} values'
 	}
 	start := p.add_children(all_ids)
-	return p.a.add_node(flat.Node{
+	anchor := if all_ids.len > 0 { all_ids[0] } else { flat.empty_node }
+	return p.add_node_from(flat.Node{
 		kind:           .assign
 		value:          if arity_msg.len > 0 { arity_msg } else { '${lhs_ids.len}' }
 		op:             token_id_to_op(op_id)
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
-	})
+	}, anchor)
 }
 
 fn (mut p Parser) for_post_assign(lhs flat.NodeId) flat.NodeId {
@@ -6116,7 +6143,7 @@ fn (mut p Parser) for_post_assign(lhs flat.NodeId) flat.NodeId {
 		flat.NodeKind.assign
 	}
 	start := p.add_children2(lhs, rhs_ids[0])
-	return p.a.add_node(flat.Node{
+	return p.add_node_from(flat.Node{
 		kind:           kind
 		value:          if rhs_ids.len == 1 {
 			''
@@ -6126,16 +6153,16 @@ fn (mut p Parser) for_post_assign(lhs flat.NodeId) flat.NodeId {
 		op:             token_id_to_op(op_id)
 		children_start: start
 		children_count: 2
-	})
+	}, lhs)
 }
 
 fn (mut p Parser) for_post_expr_stmt(expr flat.NodeId) flat.NodeId {
 	start := p.add_child(expr)
-	return p.a.add_node(flat.Node{
+	return p.add_node_from(flat.Node{
 		kind:           .expr_stmt
 		children_start: start
 		children_count: 1
-	})
+	}, expr)
 }
 
 fn (mut p Parser) for_post_block_from_exprs(exprs []flat.NodeId) flat.NodeId {
@@ -7799,6 +7826,7 @@ fn (mut p Parser) call_args(fn_expr flat.NodeId) flat.NodeId {
 		prev_offset := p.s.offset
 		prev_tok := p.tok
 		if p.tok_can_be_decl_name() && p.peek() == .colon {
+			fname_start := p.span_start()
 			fname := p.expect_name_or_keyword()
 			p.check(.colon)
 			val := p.expr(.lowest)
@@ -7807,6 +7835,7 @@ fn (mut p Parser) call_args(fn_expr flat.NodeId) flat.NodeId {
 				value:          fname
 				children_start: p.add_child(val)
 				children_count: 1
+				pos:            p.span_to(fname_start)
 			})
 			if p.tok == .semicolon {
 				p.next()
@@ -7962,12 +7991,12 @@ fn (mut p Parser) index_expr(lhs flat.NodeId) flat.NodeId {
 		}
 		type_arg := if p.tok == .lpar { p.generic_call_type_arg_id(first) } else { first }
 		istart := p.add_children2(lhs, type_arg)
-		return p.add_node(flat.Node{
+		return p.add_node_from(flat.Node{
 			kind:           .index
 			op:             gated_op
 			children_start: istart
 			children_count: 2
-		})
+		}, lhs)
 	}
 	mut ids := []flat.NodeId{}
 	ids << lhs
@@ -7988,12 +8017,12 @@ fn (mut p Parser) index_expr(lhs flat.NodeId) flat.NodeId {
 		}
 	}
 	istart := p.add_children(ids)
-	return p.add_node(flat.Node{
+	return p.add_node_from(flat.Node{
 		kind:           .index
 		op:             gated_op
 		children_start: istart
 		children_count: flat.child_count(ids.len)
-	})
+	}, lhs)
 }
 
 fn (mut p Parser) index_part_expr() flat.NodeId {
@@ -8027,11 +8056,15 @@ fn (mut p Parser) make_index_range_part(low flat.NodeId, high flat.NodeId) flat.
 		ids << high
 	}
 	start := p.add_children(ids)
-	return p.a.add_node(flat.Node{
+	mut anchor := low
+	if p.node_start(anchor) < 0 {
+		anchor = high
+	}
+	return p.add_node_from(flat.Node{
 		kind:           .range
 		children_start: start
 		children_count: flat.child_count(ids.len)
-	})
+	}, anchor)
 }
 
 fn (mut p Parser) index_range_expr(lhs flat.NodeId, range_id flat.NodeId, gated_op flat.Op) flat.NodeId {
@@ -8045,13 +8078,13 @@ fn (mut p Parser) index_range_expr(lhs flat.NodeId, range_id flat.NodeId, gated_
 		ids << p.a.child(&range_node, 1)
 	}
 	istart := p.add_children(ids)
-	return p.a.add_node(flat.Node{
+	return p.add_node_from(flat.Node{
 		kind:           .index
 		op:             gated_op
 		value:          'range'
 		children_start: istart
 		children_count: flat.child_count(ids.len)
-	})
+	}, lhs)
 }
 
 fn (mut p Parser) generic_call_type_arg_id(id flat.NodeId) flat.NodeId {
@@ -8357,6 +8390,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 	defer {
 		p.in_for_container = was_in_for_container
 	}
+	bracket_start := p.span_start() // start offset of the opening '['
 	p.next() // skip '['
 	// inferred-size fixed array literal: [..]u32[0x1, 0x2, ...]
 	if p.tok == .dotdot && p.peek() == .rsbr {
@@ -8379,6 +8413,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 		if !p.can_start_type_name() {
 			return p.a.add_node(flat.Node{
 				kind: .array_literal
+				pos:  p.span_to(bracket_start)
 			})
 		}
 		elem_type := p.parse_type_name()
@@ -8402,6 +8437,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 			kind:  .array_init
 			value: elem_type
 			typ:   if elem_type.starts_with('typeof(') { '' } else { '[]${elem_type}' }
+			pos:   p.span_to(bracket_start)
 		})
 	}
 	// array literal: [1, 2, 3]
@@ -8448,15 +8484,17 @@ fn (mut p Parser) array_literal() flat.NodeId {
 						continue
 					}
 					if p.tok == .name && p.peek() == .colon {
+						fname_start := p.span_start()
 						fname := p.expect_name()
 						p.check(.colon)
 						val := p.expr(.lowest)
 						vstart := p.add_child(val)
-						init_ids << p.add_node(flat.Node{
+						init_ids << p.a.add_node(flat.Node{
 							kind:           .field_init
 							value:          fname
 							children_start: vstart
 							children_count: 1
+							pos:            p.span_to(fname_start)
 						})
 					} else {
 						init_ids << p.expr(.lowest)
@@ -8473,12 +8511,14 @@ fn (mut p Parser) array_literal() flat.NodeId {
 					typ:            fixed_type
 					children_start: start
 					children_count: flat.child_count(init_ids.len)
+					pos:            p.span_to(bracket_start)
 				})
 			}
 			return p.add_node(flat.Node{
 				kind:  .array_init
 				value: fixed_type
 				typ:   fixed_type
+				pos:   p.span_to(bracket_start)
 			})
 		}
 		// single-element array: [expr]
@@ -8489,6 +8529,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 				kind:           .array_literal
 				children_start: start
 				children_count: 1
+				pos:            p.span_to(bracket_start)
 			})
 			pstart := p.add_child(lit)
 			return p.add_node(flat.Node{
@@ -8496,6 +8537,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 				op:             .not
 				children_start: pstart
 				children_count: 1
+				pos:            p.span_to(bracket_start)
 			})
 		}
 		start := p.add_children(ids)
@@ -8503,6 +8545,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 			kind:           .array_literal
 			children_start: start
 			children_count: flat.child_count(ids.len)
+			pos:            p.span_to(bracket_start)
 		})
 	}
 	// multi-element array: `[a, b, c]` or newline-separated const tables.
@@ -8538,6 +8581,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 		kind:           .array_literal
 		children_start: start
 		children_count: flat.child_count(ids.len)
+		pos:            p.span_to(bracket_start)
 	})
 	if is_fixed_literal {
 		pstart := p.add_child(lit)
@@ -8546,6 +8590,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 			op:             .not
 			children_start: pstart
 			children_count: 1
+			pos:            p.span_to(bracket_start)
 		})
 	}
 	return lit
@@ -8637,6 +8682,7 @@ fn (mut p Parser) parse_fixed_array_literal_type_name() string {
 }
 
 fn (mut p Parser) fixed_array_value_literal(fixed_type string) flat.NodeId {
+	lit_start := p.span_start()
 	p.check(.lsbr)
 	mut vals := []flat.NodeId{}
 	for p.tok != .rsbr && p.tok != .eof {
@@ -8656,10 +8702,12 @@ fn (mut p Parser) fixed_array_value_literal(fixed_type string) flat.NodeId {
 		typ:            fixed_type
 		children_start: start
 		children_count: flat.child_count(vals.len)
+		pos:            p.span_to(lit_start)
 	})
 }
 
 fn (mut p Parser) array_init_after_element_type(elem_type string) flat.NodeId {
+	init_start := p.span_start()
 	p.check(.lcbr)
 	mut ids := []flat.NodeId{}
 	for p.tok != .rcbr && p.tok != .eof {
@@ -8668,6 +8716,7 @@ fn (mut p Parser) array_init_after_element_type(elem_type string) flat.NodeId {
 			continue
 		}
 		if p.tok == .name && p.peek() == .colon {
+			fname_start := p.span_start()
 			fname := p.expect_name()
 			p.check(.colon)
 			val := p.expr(.lowest)
@@ -8676,6 +8725,7 @@ fn (mut p Parser) array_init_after_element_type(elem_type string) flat.NodeId {
 				value:          fname
 				children_start: p.add_child(val)
 				children_count: 1
+				pos:            p.span_to(fname_start)
 			})
 		} else {
 			ids << p.expr(.lowest)
@@ -8691,6 +8741,7 @@ fn (mut p Parser) array_init_after_element_type(elem_type string) flat.NodeId {
 		typ:            if elem_type.starts_with('typeof(') { '' } else { '[]${elem_type}' }
 		children_start: p.add_children(ids)
 		children_count: flat.child_count(ids.len)
+		pos:            p.span_to(init_start)
 	})
 }
 

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -7978,11 +7978,13 @@ fn (mut p Parser) call_args(fn_expr flat.NodeId) flat.NodeId {
 	}
 	p.check(.rpar)
 	cstart := p.add_children(ids)
-	return p.add_node(flat.Node{
+	// Anchor the completed call at its callee (fn_expr) so unknown-function and
+	// argument diagnostics point at the call, not the token after `)`.
+	return p.add_node_from(flat.Node{
 		kind:           .call
 		children_start: cstart
 		children_count: flat.child_count(ids.len)
-	})
+	}, fn_expr)
 }
 
 fn (mut p Parser) lambda_expr_no_args() flat.NodeId {
@@ -9119,6 +9121,7 @@ fn (mut p Parser) sizeof_expr() flat.NodeId {
 }
 
 fn (mut p Parser) isreftype_expr() flat.NodeId {
+	iref_start := p.span_start() // start offset of `isreftype`
 	p.next() // skip 'isreftype'
 	mut arg := flat.empty_node
 	if p.tok == .lsbr {
@@ -9147,6 +9150,7 @@ fn (mut p Parser) isreftype_expr() flat.NodeId {
 		children_start: start
 		children_count: 2
 		typ:            'bool'
+		pos:            p.span_to(iref_start)
 	})
 }
 

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -8027,6 +8027,9 @@ fn (mut p Parser) index_expr(lhs flat.NodeId) flat.NodeId {
 
 fn (mut p Parser) index_part_expr() flat.NodeId {
 	if p.tok == .dotdot {
+		// open-low range (`..high` / `..`): `low` is synthetic and has no span,
+		// so anchor the range at the `..` token to cover `..2` / `..`.
+		dotdot_start := p.span_start()
 		p.next()
 		low := p.a.add(flat.NodeKind.empty)
 		high := if p.tok != .comma && p.tok != .rsbr && p.tok != .eof {
@@ -8034,37 +8037,39 @@ fn (mut p Parser) index_part_expr() flat.NodeId {
 		} else {
 			flat.empty_node
 		}
-		return p.make_index_range_part(low, high)
+		return p.make_index_range_part(low, high, dotdot_start)
 	}
 	low := p.expr(.logical_or)
 	if p.tok == .dotdot {
+		low_start := p.node_start(low)
+		start := if low_start >= 0 { low_start } else { p.span_start() }
 		p.next()
 		high := if p.tok != .comma && p.tok != .rsbr && p.tok != .eof {
 			p.expr(.lowest)
 		} else {
 			flat.empty_node
 		}
-		return p.make_index_range_part(low, high)
+		return p.make_index_range_part(low, high, start)
 	}
 	return low
 }
 
-fn (mut p Parser) make_index_range_part(low flat.NodeId, high flat.NodeId) flat.NodeId {
+// make_index_range_part builds the `.range` node for a slice bound. `start` is
+// the offset the range should span from: the low bound's start for `low..high`,
+// or the `..` token for an open-low range whose `low` is synthetic.
+fn (mut p Parser) make_index_range_part(low flat.NodeId, high flat.NodeId, start int) flat.NodeId {
 	mut ids := []flat.NodeId{}
 	ids << low
 	if int(high) >= 0 {
 		ids << high
 	}
-	start := p.add_children(ids)
-	mut anchor := low
-	if p.node_start(anchor) < 0 {
-		anchor = high
-	}
-	return p.add_node_from(flat.Node{
+	cstart := p.add_children(ids)
+	return p.a.add_node(flat.Node{
 		kind:           .range
-		children_start: start
+		children_start: cstart
 		children_count: flat.child_count(ids.len)
-	}, anchor)
+		pos:            p.span_to(start)
+	})
 }
 
 fn (mut p Parser) index_range_expr(lhs flat.NodeId, range_id flat.NodeId, gated_op flat.Op) flat.NodeId {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -2935,7 +2935,8 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 					content := os.read_file(vmod_file) or {
 						message := p.a.add_val_id(5,
 							'@VMOD_FILE can only be used in projects that have a v.mod file')
-						call := p.make_compile_error_call(message, p.span_start())
+						// pseudo_pos is the comptime condition's source offset.
+						call := p.make_compile_error_call(message, pseudo_pos)
 						_ = p.make_top_level_compile_error(call)
 						''
 					}
@@ -7162,7 +7163,9 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				content := os.read_file(vmod_file) or {
 					message := p.add_val_id(5,
 						'@VMOD_FILE can only be used in projects that have a v.mod file')
-					return p.make_compile_error_call(message, p.span_start())
+					// name_pos was captured before @VMOD_FILE was consumed, so the
+					// sentinel call is reported at the directive, not the next token.
+					return p.make_compile_error_call(message, name_pos)
 				}
 				return p.add_val_id(5, content.replace('\r\n', '\n'))
 			}
@@ -8534,13 +8537,16 @@ fn (mut p Parser) array_literal() flat.NodeId {
 		}
 		// single-element array: [expr]
 		if p.tok == .not {
+			// The literal spans up to `]`; capture it before consuming `!`, which
+			// belongs to the postfix parent.
+			lit_pos := p.span_to(bracket_start)
 			p.next()
 			start := p.add_child(ids[0])
 			lit := p.add_node(flat.Node{
 				kind:           .array_literal
 				children_start: start
 				children_count: 1
-				pos:            p.span_to(bracket_start)
+				pos:            lit_pos
 			})
 			pstart := p.add_child(lit)
 			return p.add_node(flat.Node{
@@ -8581,6 +8587,9 @@ fn (mut p Parser) array_literal() flat.NodeId {
 		ids << p.expr(.lowest)
 	}
 	p.check(.rsbr)
+	// The literal spans up to `]`; capture it before a postfix `!` is consumed so
+	// the `!` is owned by the postfix parent, not the literal.
+	lit_pos := p.span_to(bracket_start)
 	// check for `!` (fixed array with values)
 	mut is_fixed_literal := false
 	if p.tok == .not {
@@ -8592,7 +8601,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 		kind:           .array_literal
 		children_start: start
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(bracket_start)
+		pos:            lit_pos
 	})
 	if is_fixed_literal {
 		pstart := p.add_child(lit)

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -2446,6 +2446,7 @@ fn (mut p Parser) skip_top_level_stmt() {
 }
 
 fn (mut p Parser) parse_comptime_if() flat.NodeId {
+	dollar_start := p.span_start() // start offset of the leading `$`
 	p.next() // skip $
 	if p.tok != .key_if {
 		if p.tok == .key_for {
@@ -2455,7 +2456,7 @@ fn (mut p Parser) parse_comptime_if() flat.NodeId {
 			return p.parse_comptime_match(false)
 		}
 		if p.tok == .name && p.lit == 'compile_error' {
-			return p.parse_compile_error_stmt()
+			return p.parse_compile_error_stmt(dollar_start)
 		}
 		// other comptime — skip
 		for p.tok != .semicolon && p.tok != .eof {
@@ -2495,8 +2496,8 @@ fn (mut p Parser) parse_comptime_if() flat.NodeId {
 	}
 }
 
-fn (mut p Parser) parse_compile_error_stmt() flat.NodeId {
-	call := p.parse_compile_error_call()
+fn (mut p Parser) parse_compile_error_stmt(directive_start int) flat.NodeId {
+	call := p.parse_compile_error_call(directive_start)
 	return p.add_node_from(flat.Node{
 		kind:           .expr_stmt
 		children_start: p.add_child(call)
@@ -2504,7 +2505,7 @@ fn (mut p Parser) parse_compile_error_stmt() flat.NodeId {
 	}, call)
 }
 
-fn (mut p Parser) parse_compile_error_call() flat.NodeId {
+fn (mut p Parser) parse_compile_error_call(directive_start int) flat.NodeId {
 	p.next() // skip `compile_error`
 	p.check(.lpar)
 	message := if p.tok == .rpar {
@@ -2519,25 +2520,29 @@ fn (mut p Parser) parse_compile_error_call() flat.NodeId {
 	if p.tok == .semicolon {
 		p.next()
 	}
-	return p.make_compile_error_call(message)
+	return p.make_compile_error_call(message, directive_start)
 }
 
-fn (mut p Parser) make_compile_error_call(message flat.NodeId) flat.NodeId {
+// make_compile_error_call builds the compiler-only `__v_compile_error` sentinel
+// call. `start` is the directive's source offset so the checker reports the
+// compile-error diagnostic against a positioned node instead of a zero span.
+fn (mut p Parser) make_compile_error_call(message flat.NodeId, start int) flat.NodeId {
 	// Keep this as a compiler-only sentinel call. The checker reports it immediately for a
 	// selected concrete branch, while a deferred generic branch keeps it until specialization;
 	// if that branch is selected, generic validation rejects the sentinel as well.
 	callee := p.a.add_val(.ident, '__v_compile_error')
-	start := p.add_children2(callee, message)
+	cstart := p.add_children2(callee, message)
 	return p.a.add_node(flat.Node{
 		kind:           .call
 		value:          '__v_compile_error'
-		children_start: start
+		children_start: cstart
 		children_count: 2
+		pos:            p.span_to(start)
 	})
 }
 
-fn (mut p Parser) parse_top_level_compile_error() flat.NodeId {
-	call := p.parse_compile_error_call()
+fn (mut p Parser) parse_top_level_compile_error(directive_start int) flat.NodeId {
+	call := p.parse_compile_error_call(directive_start)
 	return p.make_top_level_compile_error(call)
 }
 
@@ -2595,13 +2600,14 @@ fn (mut p Parser) parse_comptime_for() flat.NodeId {
 }
 
 fn (mut p Parser) parse_top_level_comptime_if() flat.NodeId {
+	dollar_start := p.span_start() // start offset of the leading `$`
 	p.next() // skip $
 	if p.tok != .key_if {
 		if p.tok == .key_match {
 			return p.parse_comptime_match(true)
 		}
 		if p.tok == .name && p.lit == 'compile_error' {
-			return p.parse_top_level_compile_error()
+			return p.parse_top_level_compile_error(dollar_start)
 		}
 		// $for or other comptime - skip
 		if p.tok == .key_for {
@@ -2929,7 +2935,7 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 					content := os.read_file(vmod_file) or {
 						message := p.a.add_val_id(5,
 							'@VMOD_FILE can only be used in projects that have a v.mod file')
-						call := p.make_compile_error_call(message)
+						call := p.make_compile_error_call(message, p.span_start())
 						_ = p.make_top_level_compile_error(call)
 						''
 					}
@@ -7156,7 +7162,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				content := os.read_file(vmod_file) or {
 					message := p.add_val_id(5,
 						'@VMOD_FILE can only be used in projects that have a v.mod file')
-					return p.make_compile_error_call(message)
+					return p.make_compile_error_call(message, p.span_start())
 				}
 				return p.add_val_id(5, content.replace('\r\n', '\n'))
 			}
@@ -8477,7 +8483,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 				})
 			}
 			if p.tok == .lsbr {
-				return p.fixed_array_value_literal(fixed_type)
+				return p.fixed_array_value_literal(fixed_type, bracket_start)
 			}
 			// may have init
 			if p.tok == .lcbr {
@@ -8686,8 +8692,11 @@ fn (mut p Parser) parse_fixed_array_literal_type_name() string {
 	return p.parse_type_name()
 }
 
-fn (mut p Parser) fixed_array_value_literal(fixed_type string) flat.NodeId {
-	lit_start := p.span_start()
+// fixed_array_value_literal parses the value list of an explicit fixed-array
+// value literal (`[N]T[...]`). `start` is the outer opening `[` of the `[N]T`
+// prefix, so the resulting node spans the whole expression, not just the value
+// list — the `[N]T` prefix has already been consumed by the caller.
+fn (mut p Parser) fixed_array_value_literal(fixed_type string, start int) flat.NodeId {
 	p.check(.lsbr)
 	mut vals := []flat.NodeId{}
 	for p.tok != .rsbr && p.tok != .eof {
@@ -8701,13 +8710,13 @@ fn (mut p Parser) fixed_array_value_literal(fixed_type string) flat.NodeId {
 		}
 	}
 	p.check(.rsbr)
-	start := p.add_children(vals)
+	cstart := p.add_children(vals)
 	return p.a.add_node(flat.Node{
 		kind:           .array_literal
 		typ:            fixed_type
-		children_start: start
+		children_start: cstart
 		children_count: flat.child_count(vals.len)
-		pos:            p.span_to(lit_start)
+		pos:            p.span_to(start)
 	})
 }
 

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -8404,7 +8404,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 			dimensions++
 		}
 		elem_type := p.parse_fixed_array_literal_type_name()
-		lit, _ := p.inferred_fixed_array_literal_values(elem_type, dimensions)
+		lit, _ := p.inferred_fixed_array_literal_values(elem_type, dimensions, bracket_start)
 		return lit
 	}
 	// empty array or fixed array type: []Type{} or [N]Type{}
@@ -8745,7 +8745,11 @@ fn (mut p Parser) array_init_after_element_type(elem_type string) flat.NodeId {
 	})
 }
 
-fn (mut p Parser) inferred_fixed_array_literal_values(base_elem_type string, dimensions int) (flat.NodeId, string) {
+// inferred_fixed_array_literal_values parses the value list of an inferred-size
+// fixed array (`[..]T[...]`). `start` is the offset the resulting nodes should
+// span from: the outer opening `[` for the top-level literal, and each row's own
+// opening `[` for the recursively-parsed inner dimensions.
+fn (mut p Parser) inferred_fixed_array_literal_values(base_elem_type string, dimensions int, start int) (flat.NodeId, string) {
 	p.check(.lsbr)
 	mut vals := []flat.NodeId{}
 	mut elem_type := base_elem_type
@@ -8756,8 +8760,9 @@ fn (mut p Parser) inferred_fixed_array_literal_values(base_elem_type string, dim
 			continue
 		}
 		if dimensions > 1 {
+			row_start := p.span_start()
 			val, nested_type := p.inferred_fixed_array_literal_values(base_elem_type,
-				dimensions - 1)
+				dimensions - 1, row_start)
 			vals << val
 			if vals.len == 1 {
 				elem_type = nested_type
@@ -8773,21 +8778,23 @@ fn (mut p Parser) inferred_fixed_array_literal_values(base_elem_type string, dim
 	}
 	p.check(.rsbr)
 	fixed_type := '[${vals.len}]${elem_type}'
-	start := p.add_children(vals)
-	lit := p.add_node(flat.Node{
+	cstart := p.add_children(vals)
+	lit := p.a.add_node(flat.Node{
 		kind:           .array_literal
 		typ:            fixed_type
-		children_start: start
+		children_start: cstart
 		children_count: flat.child_count(vals.len)
+		pos:            p.span_to(start)
 	})
 	pstart := p.add_child(lit)
-	return p.add_node(flat.Node{
+	return p.a.add_node(flat.Node{
 		kind:           .postfix
 		op:             .not
 		value:          if has_ragged_rows { 'ragged_inferred_fixed_array' } else { '' }
 		typ:            fixed_type
 		children_start: pstart
 		children_count: 1
+		pos:            p.span_to(start)
 	}), fixed_type
 }
 

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -256,7 +256,7 @@ pub fn (mut p Parser) parse_into(path string) {
 	}
 	p.reserve_for_source(stable_src.len)
 	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, -1, stable_src.len)
+	mut file := file_set.add_file(path, stable_src.len)
 	file.index_lines(stable_src)
 	p.a.source_files[p.cur_file_id] = file
 	p.s.init(file, stable_src)
@@ -3521,7 +3521,7 @@ fn (mut p Parser) precollect_unsupported_inline_asm_guards(source string, target
 		p.comptime_const_values = saved_const_values.move()
 	}
 	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('<inline asm scan>', -1, source.len)
+	mut file := file_set.add_file('<inline asm scan>', source.len)
 	mut s := scanner.new_scanner(p.prefs, .skip_interpolation)
 	s.init(file, source)
 	mut tokens := []InlineAsmScanToken{}

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -253,7 +253,7 @@ fn (mut p Parser) precollect_parallel_comptime_consts(paths []string, start int,
 			continue
 		}
 		mut file_set := token.FileSet.new()
-		file := file_set.add_file(path, -1, src.len)
+		file := file_set.add_file(path, src.len)
 		mut s := scanner.new_scanner(p.prefs, .normal)
 		s.init(file, src)
 		mut module_name := ''
@@ -581,7 +581,7 @@ fn (p &Parser) new_parallel_comptime_prepass_resolver(src string, path string, m
 	resolver.cur_file = path
 	resolver.cur_module = module_name
 	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, -1, src.len)
+	mut file := file_set.add_file(path, src.len)
 	file.index_lines(src)
 	resolver.s.init(file, src)
 	return resolver
@@ -921,7 +921,7 @@ fn (mut p Parser) merge_parsed_worker(mut w Parser, mut starts []int, chunk_star
 			}
 			source := w.a.source_buffers[source_idx]
 			mut file_set := token.FileSet.new()
-			mut stored_file := file_set.add_file(file.name.clone(), file.base, file.size)
+			mut stored_file := file_set.add_file(file.name.clone(), file.size)
 			stored_file.index_lines(source)
 			p.a.source_files[file_id] = stored_file
 		}

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -144,6 +144,44 @@ fn test_inferred_fixed_array_spans_from_opening_bracket() {
 	assert saw_row
 }
 
+// Explicit fixed-array value literals (`[N]T[...]`) are parsed after the `[N]T`
+// prefix is consumed, so the array_literal node must span from the outer opening
+// `[` of the type prefix, not just the value list.
+fn test_explicit_fixed_array_value_literal_spans_from_type_prefix() {
+	ast, src := parse_span_source('fixed_value', 'fn main() {
+	a := [3]int[1, 2, 3]
+	_ = a
+}
+')
+	mut saw := false
+	for node in ast.nodes {
+		if node.kind == .array_literal && node.typ == '[3]int' {
+			saw = true
+			assert span_text(src, node) == '[3]int[1, 2, 3]'
+		}
+	}
+	assert saw
+}
+
+// The `$compile_error(...)` sentinel call is a compiler-only `.call` node that
+// the checker reports diagnostics against, so it must carry the directive's span
+// (from the leading `$`) rather than a zero position.
+fn test_compile_error_sentinel_call_has_directive_span() {
+	ast, src := parse_span_source('compile_error', 'fn main() {
+	\$compile_error("boom")
+}
+')
+	mut saw := false
+	for node in ast.nodes {
+		if node.kind == .call && node.value == '__v_compile_error' {
+			saw = true
+			assert node.pos.is_valid()
+			assert span_text(src, node) == '\$compile_error("boom")'
+		}
+	}
+	assert saw
+}
+
 // Lambda nodes are built directly on the flat AST; they must still receive a
 // valid span covering the whole lambda rather than a zero position.
 fn test_lambda_nodes_have_valid_spans() {

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -79,12 +79,15 @@ fn test_c_style_for_post_clause_spans() {
 	mut saw_ident := false
 	mut saw_postfix := false
 	mut saw_block := false
+	mut stmt_spans := []string{}
 	for node in ast.nodes {
 		if node.kind == .ident && node.value == 'i' && span_text(src, node) == 'i' {
 			saw_ident = true
 		} else if node.kind == .postfix && node.op == .inc
 			&& span_text(src, node) == 'i++' {
 			saw_postfix = true
+		} else if node.kind == .expr_stmt {
+			stmt_spans << span_text(src, node)
 		} else if node.kind == .block && node.children_count == 2
 			&& span_text(src, node) == 'i++, j++' {
 			saw_block = true
@@ -93,6 +96,11 @@ fn test_c_style_for_post_clause_spans() {
 	assert saw_ident
 	assert saw_postfix
 	assert saw_block
+	// Each post expression is wrapped in its own statement spanning just that
+	// expression, not the whole comma-separated clause.
+	assert 'i++' in stmt_spans
+	assert 'j++' in stmt_spans
+	assert stmt_spans.filter(it == 'i++, j++').len == 0
 }
 
 // Dynamic array initializers (`[]T{...}`) are parsed after the `[]T` prefix is

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -121,6 +121,32 @@ fn test_dynamic_array_init_spans_from_bracket() {
 	assert saw
 }
 
+// Address-of expressions (`&Foo{}`, `&[]T{}`, `&T(x)`) span from the `&` through
+// the whole operand; the pointer/array-init variants build their nodes directly
+// on the flat AST, so they must still carry a valid, full span.
+fn test_address_of_prefix_spans_from_ampersand() {
+	ast, src := parse_span_source('addr_of', 'struct Foo { x int }
+fn main() {
+	a := &[]int{len: 1}
+	b := &Foo{x: 1}
+	c := &int(0)
+	_ = a
+	_ = b
+	_ = c
+}
+')
+	mut spans := []string{}
+	for node in ast.nodes {
+		if (node.kind == .prefix && node.op == .amp)
+			|| (node.kind == .cast_expr && node.value.starts_with('&')) {
+			spans << span_text(src, node)
+		}
+	}
+	assert '&[]int{len: 1}' in spans
+	assert '&Foo{x: 1}' in spans
+	assert '&int(0)' in spans
+}
+
 // Prefix expressions span from the operator to the end of their operand.
 fn test_prefix_expression_spans_operator_to_operand() {
 	ast, src := parse_span_source('prefix', 'fn main() {

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -121,6 +121,26 @@ fn test_dynamic_array_init_spans_from_bracket() {
 	assert saw
 }
 
+// Call nodes are completed after the closing `)` is consumed, so they must be
+// anchored at the callee — the checker reports unknown-function diagnostics on
+// the call node, which should point at the call, not the following token.
+fn test_call_node_spans_from_callee() {
+	ast, src := parse_span_source('call', 'fn main() {
+	missing()
+	x := foo(1, 2)
+	_ = x
+}
+')
+	mut spans := []string{}
+	for node in ast.nodes {
+		if node.kind == .call {
+			spans << span_text(src, node)
+		}
+	}
+	assert 'missing()' in spans
+	assert 'foo(1, 2)' in spans
+}
+
 // Address-of expressions (`&Foo{}`, `&[]T{}`, `&T(x)`) span from the `&` through
 // the whole operand; the pointer/array-init variants build their nodes directly
 // on the flat AST, so they must still carry a valid, full span.

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -82,6 +82,34 @@ fn test_prefix_expression_spans_operator_to_operand() {
 	assert saw_prefix
 }
 
+// Slice range bounds must span the whole `low..high`, including open-low ranges
+// (`..high` / `..`) whose synthetic low bound has no span — those anchor at the
+// `..` token rather than collapsing onto the high bound or the closing `]`.
+fn test_slice_range_bounds_span_full_range() {
+	ast, src := parse_span_source('ranges', 'fn main() {
+	xs := [1, 2, 3, 4]
+	a := xs[..2]
+	b := xs[..]
+	c := xs[1..3]
+	d := xs[1..]
+	_ = a
+	_ = b
+	_ = c
+	_ = d
+}
+')
+	mut ranges := []string{}
+	for node in ast.nodes {
+		if node.kind == .range {
+			ranges << span_text(src, node)
+		}
+	}
+	assert '..2' in ranges
+	assert '..' in ranges
+	assert '1..3' in ranges
+	assert '1..' in ranges
+}
+
 // Inferred-size fixed array literals (`[..]T[...]`) build their array/postfix
 // nodes only after the value list is consumed, so they must span from the outer
 // opening `[` rather than the following token, and each inner row must span from

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -82,6 +82,40 @@ fn test_prefix_expression_spans_operator_to_operand() {
 	assert saw_prefix
 }
 
+// Inferred-size fixed array literals (`[..]T[...]`) build their array/postfix
+// nodes only after the value list is consumed, so they must span from the outer
+// opening `[` rather than the following token, and each inner row must span from
+// its own opening `[`.
+fn test_inferred_fixed_array_spans_from_opening_bracket() {
+	ast, src := parse_span_source('inferred_fixed', 'fn main() {
+	a := [..]int[1, 2, 3]
+	b := [..][..]int[[1], [2, 3]]
+	_ = a
+	_ = b
+}
+')
+	mut saw_a := false
+	mut saw_b := false
+	mut saw_row := false
+	for node in ast.nodes {
+		if node.kind != .postfix || !node.typ.starts_with('[') {
+			continue
+		}
+		t := span_text(src, node)
+		if t == '[..]int[1, 2, 3]' {
+			saw_a = true
+		} else if t == '[..][..]int[[1], [2, 3]]' {
+			saw_b = true
+		} else if t == '[2, 3]' {
+			// an inner row of `b`, spanning from its own `[`
+			saw_row = true
+		}
+	}
+	assert saw_a
+	assert saw_b
+	assert saw_row
+}
+
 // Lambda nodes are built directly on the flat AST; they must still receive a
 // valid span covering the whole lambda rather than a zero position.
 fn test_lambda_nodes_have_valid_spans() {

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -65,6 +65,54 @@ fn test_literal_nodes_span_their_own_source() {
 	assert saw_bool
 }
 
+// Identifiers span the name, and postfix `++`/`--` span operand..operator, so a
+// C-style for post clause and its wrapping block are positioned at the code, not
+// at the following token.
+fn test_c_style_for_post_clause_spans() {
+	ast, src := parse_span_source('for_post', 'fn main() {
+	n := 5
+	for i, j := 0, 0; i < n; i++, j++ {
+		println(i + j)
+	}
+}
+')
+	mut saw_ident := false
+	mut saw_postfix := false
+	mut saw_block := false
+	for node in ast.nodes {
+		if node.kind == .ident && node.value == 'i' && span_text(src, node) == 'i' {
+			saw_ident = true
+		} else if node.kind == .postfix && node.op == .inc
+			&& span_text(src, node) == 'i++' {
+			saw_postfix = true
+		} else if node.kind == .block && node.children_count == 2
+			&& span_text(src, node) == 'i++, j++' {
+			saw_block = true
+		}
+	}
+	assert saw_ident
+	assert saw_postfix
+	assert saw_block
+}
+
+// Dynamic array initializers (`[]T{...}`) are parsed after the `[]T` prefix is
+// consumed, so the array_init node must span from the opening `[`, not the `{`.
+fn test_dynamic_array_init_spans_from_bracket() {
+	ast, src := parse_span_source('array_init', 'fn main() {
+	a := []int{len: 3, init: 0}
+	_ = a
+}
+')
+	mut saw := false
+	for node in ast.nodes {
+		if node.kind == .array_init && node.value == 'int' {
+			saw = true
+			assert span_text(src, node) == '[]int{len: 3, init: 0}'
+		}
+	}
+	assert saw
+}
+
 // Prefix expressions span from the operator to the end of their operand.
 fn test_prefix_expression_spans_operator_to_operand() {
 	ast, src := parse_span_source('prefix', 'fn main() {

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -1,8 +1,8 @@
 module parser
 
 import os
-import flat
-import pref
+import v3.flat
+import v3.pref
 
 // Parses `src` on its own and returns the flat AST plus the exact bytes the
 // parser saw, so a node's [offset, end) span can be checked against the source.

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -146,22 +146,33 @@ fn test_dynamic_array_init_spans_from_bracket() {
 
 // Call nodes are completed after the closing `)` is consumed, so they must be
 // anchored at the callee — the checker reports unknown-function diagnostics on
-// the call node, which should point at the call, not the following token.
+// the call node, which should point at the call, not the following token. For
+// selector method calls (`recv.method()`) the callee is a `.selector`, which
+// must itself span `recv.method` so the call covers the whole `recv.method()`.
 fn test_call_node_spans_from_callee() {
-	ast, src := parse_span_source('call', 'fn main() {
+	ast, src := parse_span_source('call', 'struct Obj { x int }
+fn main() {
 	missing()
 	x := foo(1, 2)
+	o := Obj{x: 1}
+	y := o.missing(1, 2)
 	_ = x
+	_ = y
 }
 ')
-	mut spans := []string{}
+	mut call_spans := []string{}
+	mut selector_spans := []string{}
 	for node in ast.nodes {
 		if node.kind == .call {
-			spans << span_text(src, node)
+			call_spans << span_text(src, node)
+		} else if node.kind == .selector {
+			selector_spans << span_text(src, node)
 		}
 	}
-	assert 'missing()' in spans
-	assert 'foo(1, 2)' in spans
+	assert 'missing()' in call_spans
+	assert 'foo(1, 2)' in call_spans
+	assert 'o.missing(1, 2)' in call_spans
+	assert 'o.missing' in selector_spans
 }
 
 // Address-of expressions (`&Foo{}`, `&[]T{}`, `&T(x)`) span from the `&` through

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -163,6 +163,32 @@ fn test_explicit_fixed_array_value_literal_spans_from_type_prefix() {
 	assert saw
 }
 
+// A postfix `!` fixed-array literal (`[1, 2, 3]!`) must keep the `!` on the
+// `.postfix` parent: the child `.array_literal` spans only `[1, 2, 3]`, while the
+// postfix spans the whole `[1, 2, 3]!`.
+fn test_postfix_fixed_array_literal_excludes_bang_from_child() {
+	ast, src := parse_span_source('bang', 'fn main() {
+	a := [1, 2, 3]!
+	b := [42]!
+	_ = a
+	_ = b
+}
+')
+	mut literals := []string{}
+	mut postfixes := []string{}
+	for node in ast.nodes {
+		if node.kind == .array_literal {
+			literals << span_text(src, node)
+		} else if node.kind == .postfix && node.op == .not {
+			postfixes << span_text(src, node)
+		}
+	}
+	assert '[1, 2, 3]' in literals
+	assert '[42]' in literals
+	assert '[1, 2, 3]!' in postfixes
+	assert '[42]!' in postfixes
+}
+
 // The `$compile_error(...)` sentinel call is a compiler-only `.call` node that
 // the checker reports diagnostics against, so it must carry the directive's span
 // (from the leading `$`) rather than a zero position.

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -103,6 +103,29 @@ fn test_c_style_for_post_clause_spans() {
 	assert stmt_spans.filter(it == 'i++, j++').len == 0
 }
 
+// Array cast expressions (`[N]T(x)`, `[]T(x)`) are built after the `[N]T`/`[]T`
+// prefix and `(x)` are consumed, so they must span from the opening `[` — the
+// fixed-array variant builds its node directly on the flat AST and previously had
+// no span at all.
+fn test_array_cast_spans_from_bracket() {
+	ast, src := parse_span_source('array_cast', 'fn main() {
+	p := unsafe { nil }
+	a := [3]int(p)
+	b := []int(p)
+	_ = a
+	_ = b
+}
+')
+	mut spans := []string{}
+	for node in ast.nodes {
+		if node.kind == .cast_expr && node.value.contains('int') {
+			spans << span_text(src, node)
+		}
+	}
+	assert '[3]int(p)' in spans
+	assert '[]int(p)' in spans
+}
+
 // Dynamic array initializers (`[]T{...}`) are parsed after the `[]T` prefix is
 // consumed, so the array_init node must span from the opening `[`, not the `{`.
 fn test_dynamic_array_init_spans_from_bracket() {

--- a/vlib/v3/parser/span_verifier_test.v
+++ b/vlib/v3/parser/span_verifier_test.v
@@ -48,6 +48,8 @@ fn main() {
 	sl3 := xs[1..]
 	sl4 := xs[..]
 	init := []int{len: 3, init: 0}
+	fixed_cast := [3]int(&p)
+	dyn_cast := []int(&p)
 	if total.len > 0 && c == .red {
 		println(s)
 	} else {
@@ -87,6 +89,8 @@ fn main() {
 	_ = sl3
 	_ = sl4
 	_ = init
+	_ = fixed_cast
+	_ = dyn_cast
 	_ = y
 	_ = r
 }

--- a/vlib/v3/parser/span_verifier_test.v
+++ b/vlib/v3/parser/span_verifier_test.v
@@ -59,6 +59,9 @@ fn main() {
 	for i := 0; i < 3; i++ {
 		println(i)
 	}
+	for i, j := 0, 0; i < 3; i++, j++ {
+		println(i + j)
+	}
 	y := if answer > 0 { 1 } else { 2 }
 	match c {
 		.red { println("r") }

--- a/vlib/v3/parser/span_verifier_test.v
+++ b/vlib/v3/parser/span_verifier_test.v
@@ -1,0 +1,136 @@
+module parser
+
+import os
+import flat
+import pref
+
+const verifier_src = r'module main
+
+import os
+
+const answer = 42
+
+struct Point {
+	x int
+	y int
+}
+
+enum Color {
+	red
+	green
+}
+
+type MyInt = int
+
+fn (p Point) sum() int {
+	return p.x + p.y
+}
+
+fn generic_id[T](v T) T {
+	return v
+}
+
+fn main() {
+	mut xs := [1, 2, 3]
+	xs << 4
+	m := {"a": 1, "b": 2}
+	total := xs.map(|it| it * 2).filter(it > 2)
+	c := Color.red
+	p := Point{x: 1, y: 2}
+	s := "hi ${p.sum()} ${answer}"
+	arr := [5]int{}
+	fixed := [1, 2, 3]!
+	sl := xs[1..3]
+	sl2 := xs[..2]
+	init := []int{len: 3, init: 0}
+	if total.len > 0 && c == .red {
+		println(s)
+	} else {
+		println("no")
+	}
+	for i, v in xs {
+		println("${i}:${v}")
+	}
+	for i := 0; i < 3; i++ {
+		println(i)
+	}
+	y := if answer > 0 { 1 } else { 2 }
+	match c {
+		.red { println("r") }
+		.green { println("g") }
+	}
+	ptr := &p
+	unsafe {
+		println(ptr.x)
+	}
+	r := generic_id[int](7)
+	_ = m
+	_ = arr
+	_ = fixed
+	_ = sl
+	_ = sl2
+	_ = init
+	_ = y
+	_ = r
+}
+'
+
+struct SpanReport {
+mut:
+	valid        int
+	total        int
+	invalid      map[string]int
+	out_of_range map[string]int
+}
+
+fn verify_one(name string, src string, mut rep SpanReport) {
+	path := os.join_path(os.temp_dir(), 'v3_span_verify_${name}_${os.getpid()}.v')
+	os.write_file(path, src) or { panic(err) }
+	mut p := Parser.new(pref.new_preferences())
+	ast := p.parse_file(path)
+	os.rm(path) or {}
+	for node in ast.nodes {
+		if node.kind == .empty {
+			continue
+		}
+		rep.total++
+		if !node.pos.is_valid() {
+			rep.invalid['${node.kind}']++
+			continue
+		}
+		if node.pos.offset < 0 || node.pos.end > src.len || node.pos.end < node.pos.offset {
+			rep.out_of_range['${node.kind}']++
+			continue
+		}
+		rep.valid++
+	}
+}
+
+// Every non-synthetic parsed node must carry a valid file id and an in-range,
+// half-open span. This guards against new parser productions that build nodes
+// directly on the flat AST without a position (which used to yield zero spans).
+fn test_all_parsed_nodes_have_valid_spans() {
+	mut rep := SpanReport{
+		invalid:      map[string]int{}
+		out_of_range: map[string]int{}
+	}
+	verify_one('synthetic', verifier_src, mut rep)
+	vroot := os.dir(os.dir(os.dir(os.dir(@FILE))))
+	real_files := [
+		os.join_path(vroot, 'vlib', 'v3', 'parser', 'parser.v'),
+		os.join_path(vroot, 'vlib', 'v3', 'types', 'checker.v'),
+		os.join_path(vroot, 'vlib', 'v3', 'gen', 'c', 'cleanc.v'),
+		os.join_path(vroot, 'vlib', 'v3', 'flat', 'flat.v'),
+		os.join_path(vroot, 'vlib', 'v3', 'token', 'token.v'),
+		os.join_path(vroot, 'vlib', 'builtin', 'array.v'),
+		os.join_path(vroot, 'vlib', 'builtin', 'string.v'),
+	]
+	for f in real_files {
+		src := os.read_file(f) or { continue }
+		verify_one(os.base(f).replace('.', '_'), src, mut rep)
+	}
+	println('span verifier: ${rep.valid}/${rep.total} nodes have valid in-range spans')
+	assert rep.invalid.len == 0, 'nodes with zero/invalid spans by kind: ${rep.invalid}'
+	assert rep.out_of_range.len == 0, 'nodes with out-of-range spans by kind: ${rep.out_of_range}'
+	assert rep.valid == rep.total
+}

--- a/vlib/v3/parser/span_verifier_test.v
+++ b/vlib/v3/parser/span_verifier_test.v
@@ -40,6 +40,7 @@ fn main() {
 	s := "hi ${p.sum()} ${answer}"
 	arr := [5]int{}
 	fixed := [1, 2, 3]!
+	fixed_val := [3]int[1, 2, 3]
 	inferred := [..]int[1, 2, 3]
 	inferred2 := [..][..]int[[1], [2, 3]]
 	sl := xs[1..3]
@@ -71,6 +72,7 @@ fn main() {
 	_ = m
 	_ = arr
 	_ = fixed
+	_ = fixed_val
 	_ = inferred
 	_ = inferred2
 	_ = sl

--- a/vlib/v3/parser/span_verifier_test.v
+++ b/vlib/v3/parser/span_verifier_test.v
@@ -68,11 +68,15 @@ fn main() {
 		.green { println("g") }
 	}
 	ptr := &p
+	pheap := &Point{x: 1, y: 2}
+	parr := &[]int{len: 1}
 	unsafe {
 		println(ptr.x)
 	}
 	r := generic_id[int](7)
 	_ = m
+	_ = pheap
+	_ = parr
 	_ = arr
 	_ = fixed
 	_ = fixed_val

--- a/vlib/v3/parser/span_verifier_test.v
+++ b/vlib/v3/parser/span_verifier_test.v
@@ -44,6 +44,8 @@ fn main() {
 	inferred2 := [..][..]int[[1], [2, 3]]
 	sl := xs[1..3]
 	sl2 := xs[..2]
+	sl3 := xs[1..]
+	sl4 := xs[..]
 	init := []int{len: 3, init: 0}
 	if total.len > 0 && c == .red {
 		println(s)
@@ -73,6 +75,8 @@ fn main() {
 	_ = inferred2
 	_ = sl
 	_ = sl2
+	_ = sl3
+	_ = sl4
 	_ = init
 	_ = y
 	_ = r

--- a/vlib/v3/parser/span_verifier_test.v
+++ b/vlib/v3/parser/span_verifier_test.v
@@ -1,8 +1,7 @@
 module parser
 
 import os
-import flat
-import pref
+import v3.pref
 
 const verifier_src = r'module main
 

--- a/vlib/v3/parser/span_verifier_test.v
+++ b/vlib/v3/parser/span_verifier_test.v
@@ -40,6 +40,8 @@ fn main() {
 	s := "hi ${p.sum()} ${answer}"
 	arr := [5]int{}
 	fixed := [1, 2, 3]!
+	inferred := [..]int[1, 2, 3]
+	inferred2 := [..][..]int[[1], [2, 3]]
 	sl := xs[1..3]
 	sl2 := xs[..2]
 	init := []int{len: 3, init: 0}
@@ -67,6 +69,8 @@ fn main() {
 	_ = m
 	_ = arr
 	_ = fixed
+	_ = inferred
+	_ = inferred2
 	_ = sl
 	_ = sl2
 	_ = init

--- a/vlib/v3/tests/source_integrity_test.v
+++ b/vlib/v3/tests/source_integrity_test.v
@@ -10,7 +10,7 @@ import v3.types
 fn scan_source_diagnostics(source string) []scanner.Diagnostic {
 	prefs := pref.new_preferences()
 	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('scanner_input.v', -1, source.len)
+	mut file := file_set.add_file('scanner_input.v', source.len)
 	file.index_lines(source)
 	mut s := scanner.new_scanner(prefs, .normal)
 	s.init(file, source)

--- a/vlib/v3/token/position.v
+++ b/vlib/v3/token/position.v
@@ -156,14 +156,16 @@ pub fn (f &File) line_start(line int) int {
 }
 
 // line supports line handling for File.
+// Pos.offset is already file-local (the safe constructors store the byte offset
+// within this file, not a FileSet-global offset), so it is used directly.
 pub fn (f &File) line(pos Pos) int {
-	return f.find_line(pos.offset - f.base)
+	return f.find_line(pos.offset)
 }
 
 // position supports position handling for File.
+// Pos.offset is file-local, matching position_at/FlatAst.source_position.
 pub fn (f &File) position(pos Pos) Position {
-	offset := pos.offset - f.base
-	return f.position_at(offset)
+	return f.position_at(pos.offset)
 }
 
 // position_at resolves a file-local byte offset to a presentation position.

--- a/vlib/v3/token/position.v
+++ b/vlib/v3/token/position.v
@@ -60,15 +60,13 @@ pub:
 	size int
 mut:
 	line_offsets []int = [0]
-	id_counter   &int  = unsafe { nil }
 }
 
 // FileSet represents file set data used by token.
 pub struct FileSet {
 mut:
-	base       int = 1
-	id_counter int
-	files      []&File
+	base  int = 1
+	files []&File
 }
 
 // new creates a FileSet value for token.
@@ -83,10 +81,9 @@ pub fn (mut fs FileSet) add_file(filename string, base_ int, size int) &File {
 		panic('invalid base ${base} (should be >= ${fs.base}')
 	}
 	file := &File{
-		name:       filename
-		base:       base
-		size:       size
-		id_counter: &fs.id_counter
+		name: filename
+		base: base
+		size: size
 	}
 	if size < 0 {
 		panic('invalid size ${size} (should be >= 0)')
@@ -161,26 +158,6 @@ pub fn (f &File) line_start(line int) int {
 // line supports line handling for File.
 pub fn (f &File) line(pos Pos) int {
 	return f.find_line(pos.offset - f.base)
-}
-
-// pos supports pos handling for File.
-pub fn (mut f File) pos(offset int) Pos {
-	if offset > f.size {
-		panic('invalid offset')
-	}
-	mut current_id := 0
-	mut next_id := 0
-	unsafe {
-		current_id = *f.id_counter
-	}
-	next_id = current_id + 1
-	unsafe {
-		*f.id_counter = next_id
-	}
-	return Pos{
-		offset: f.base + offset
-		id:     next_id
-	}
 }
 
 // position supports position handling for File.

--- a/vlib/v3/token/position.v
+++ b/vlib/v3/token/position.v
@@ -52,11 +52,12 @@ pub fn (p Position) str() string {
 }
 
 // File represents file data used by token.
+// Positions into a File use file-local byte offsets (Pos.offset), so a File no
+// longer carries a FileSet-global base offset.
 @[heap]
 pub struct File {
 pub:
 	name string
-	base int
 	size int
 mut:
 	line_offsets []int = [0]
@@ -65,7 +66,6 @@ mut:
 // FileSet represents file set data used by token.
 pub struct FileSet {
 mut:
-	base  int = 1
 	files []&File
 }
 
@@ -74,54 +74,19 @@ pub fn FileSet.new() &FileSet {
 	return &FileSet{}
 }
 
-// add_file updates add file state for FileSet.
-pub fn (mut fs FileSet) add_file(filename string, base_ int, size int) &File {
-	mut base := if base_ < 0 { fs.base } else { base_ }
-	if base < fs.base {
-		panic('invalid base ${base} (should be >= ${fs.base}')
-	}
-	file := &File{
-		name: filename
-		base: base
-		size: size
-	}
+// add_file registers a source file with the set. Under the file-local position
+// representation there is no global base offset to assign; the caller keys the
+// returned file by its stable Pos.id (e.g. FlatAst.source_files).
+pub fn (mut fs FileSet) add_file(filename string, size int) &File {
 	if size < 0 {
 		panic('invalid size ${size} (should be >= 0)')
 	}
-	base += size + 1
-	if base < 0 {
-		panic('token.Pos offset overflow (> 2G of source code in file set)')
+	file := &File{
+		name: filename
+		size: size
 	}
-	fs.base = base
 	fs.files << file
 	return file
-}
-
-// search_files supports search files handling for token.
-fn search_files(files []&File, x int) int {
-	mut min, mut max := 0, files.len
-	for min < max {
-		mid := (min + max) / 2
-		if files[mid].base <= x {
-			min = mid + 1
-		} else {
-			max = mid
-		}
-	}
-	return min - 1
-}
-
-// file supports file handling for FileSet.
-pub fn (mut fs FileSet) file(pos Pos) &File {
-	i := search_files(fs.files, pos.offset)
-	if i >= 0 {
-		file := fs.files[i]
-		if pos.offset <= file.base + file.size {
-			return file
-		}
-	}
-	dump(fs)
-	panic('cannot find file for pos: ${pos}')
 }
 
 // add_line updates add line state for File.

--- a/vlib/v3/token/token_test.v
+++ b/vlib/v3/token/token_test.v
@@ -22,6 +22,23 @@ fn test_operator_properties_are_owned_by_tokens() {
 	assert !Token.number.is_assignment()
 }
 
+fn test_file_position_resolves_file_local_offsets() {
+	src := 'line one\nsecond line\nthird\n'
+	mut fs := FileSet.new()
+	mut f := fs.add_file('x.v', -1, src.len)
+	f.index_lines(src)
+	// Pos.offset is file-local: offset 0 is the file start, not fs.base.
+	start := f.position(new_pos(1, 0))
+	assert start.line == 1
+	assert start.column == 1
+	assert f.line(new_pos(1, 0)) == 1
+	// Offset 9 is the start of the second line (`line one\n` is 9 bytes).
+	second := f.position(new_pos(1, 9))
+	assert second.line == 2
+	assert second.column == 1
+	assert f.line(new_pos(1, 9)) == 2
+}
+
 fn test_keyword_property_does_not_depend_on_enum_ordinals() {
 	assert Token.key_as.is_keyword()
 	assert Token.key_unsafe.is_keyword()

--- a/vlib/v3/token/token_test.v
+++ b/vlib/v3/token/token_test.v
@@ -25,7 +25,7 @@ fn test_operator_properties_are_owned_by_tokens() {
 fn test_file_position_resolves_file_local_offsets() {
 	src := 'line one\nsecond line\nthird\n'
 	mut fs := FileSet.new()
-	mut f := fs.add_file('x.v', -1, src.len)
+	mut f := fs.add_file('x.v', src.len)
 	f.index_lines(src)
 	// Pos.offset is file-local: offset 0 is the file start, not fs.base.
 	start := f.position(new_pos(1, 0))


### PR DESCRIPTION
Follow-up to #27826, finishing the parser source-span work (re-audit finding #3). #27826 fixed spans for literals/prefix/lambda; a probe across ~200k real parsed nodes showed the remaining gaps, which this PR closes.

## Span coverage
Every parsed node now carries a valid, in-range source span. Several compound productions previously built nodes directly on the flat AST without a position, yielding **zero spans**:

- index / slice expressions and ranges (`a[i]`, `a[1..3]`, `a[..2]`)
- array literals and inits (`[1,2,3]`, `[1,2,3]!`, `[]int{...}`, `[N]T{...}`, inferred/fixed value literals)
- struct/call field inits (`name: val`)
- `expr_stmt` wrappers (compile-error stmts, `if`-as-expression stmts, `for` post-expr stmts)
- `for` post assignments (`for i := 0; …; i += 2`)

New helpers keep this at production boundaries: `node_start` and `add_node_from` (spans a compound node from its leftmost child to the last consumed token), alongside the existing `span_start`/`span_to`. Array literals/inits span from the opening `[`/`{`; field inits from the field name.

## Verifier
`span_verifier_test.v` parses a synthetic source plus a spread of real `vlib/v3` and `vlib/builtin` files (~204k nodes, incl. `checker.v` and `cleanc.v`) and asserts every non-empty parsed node has a valid file id and an in-range, half-open span. This locks in the coverage and catches any future production that forgets a position.

## FileSet lifetime hazard
Removed the dead `File.pos()` / `File.id_counter &int` / `FileSet.id_counter` API. `File.id_counter` pointed into the `FileSet` that created it, but the parser stores the `File` in the AST and discards the local `FileSet` — so any call to `File.pos()` would dereference a dangling pointer. Nothing calls it (positions come from `token.new_span`), so the pointer/counter API is deleted outright.

## Testing
- `vlib/v3/parser` (span_test + span_verifier), `vlib/v3/token`, `vlib/v3/flat` all pass.
- v3 self-hosts; a codegen smoke over slices, `.map` lambdas, C-style `for` with `+=`, fixed-array init, indexing and bitwise ops matches mainline V exactly. Span changes are pure metadata — no AST/codegen change.
- Pre-existing, unrelated flake: `for_multi_init_codegen_test.v` (and peers that rebuild `v3.v` with mainline `v`) can fail on mainline-V parallel-cgen struct-ordering nondeterminism; verified identical on `master` with this branch stashed.

## Still deferred (separate, larger PRs)
Immutable content-addressed cache generations with an atomic manifest; type-interner sharding; semantic dependency-graph and compact-AST-identity migrations; the headerless-pthread → real `<pthread.h>` shim; and the `rebuild_use_lists`/wrapper-key micro-opts (profiling-gated).