### PR TITLE
v3: limit compiler RSS to 10 GiB

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -38,6 +38,8 @@ The command line rejects unknown options, missing option values, unsupported bac
 multiple input paths. `-cc <executable>` selects the C compiler and `-gc none` is the only
 currently supported collector mode. Directory builds read `subdirs` through the canonical
 `v.mod` parser, including when other manifest strings contain punctuation resembling fields.
+The driver checks current RSS after each compiler phase and exits when it reaches 10 GiB.
+Pass `-no-memory-limit`/`--no-memory-limit` to disable this safety limit.
 
 Generated C represents `thread` values with a typed wrapper around `pthread_t`. `spawn` uses the
 platform's default thread stack and checks allocation, thread creation, and join failures. Since

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -3,6 +3,8 @@ module bench
 import runtime
 import time
 
+const default_memory_limit_kb = i64(10) * 1024 * 1024
+
 // Step represents step data used by bench.
 pub struct Step {
 pub:
@@ -31,6 +33,7 @@ mut:
 	step_sw               time.StopWatch
 	last_allocation_count u64
 	last_allocated_bytes  u64
+	memory_limit_kb       i64
 }
 
 // new creates a new value for bench.
@@ -41,7 +44,13 @@ pub fn new() Bench {
 		step_sw:               time.new_stopwatch()
 		last_allocation_count: allocations.allocation_count
 		last_allocated_bytes:  allocations.allocated_bytes
+		memory_limit_kb:       default_memory_limit_kb
 	}
+}
+
+// disable_memory_limit disables the compiler RSS safety limit.
+pub fn (mut b Bench) disable_memory_limit() {
+	b.memory_limit_kb = 0
 }
 
 // step records a serial pipeline step.
@@ -53,12 +62,17 @@ pub fn (mut b Bench) step(name string) {
 // when the step actually ran across threads.
 pub fn (mut b Bench) step_parallel(name string, parallel bool) {
 	elapsed_us := b.step_sw.elapsed().microseconds()
+	label := if parallel { '${name} (parallel)' } else { name }
 	ram_kb := current_rss_kb()
 	peak_ram_kb := peak_rss_kb()
+	message := memory_limit_error(ram_kb, b.memory_limit_kb, label)
+	if message.len > 0 {
+		eprintln(message)
+		exit(1)
+	}
 	ram_mb := f64(ram_kb) / 1024.0
 	peak_ram_mb := f64(peak_ram_kb) / 1024.0
 	ms := f64(elapsed_us) / 1000.0
-	label := if parallel { '${name} (parallel)' } else { name }
 	allocations := current_allocation_stats()
 	allocation_count := allocations.allocation_count - b.last_allocation_count
 	allocated_bytes := allocations.allocated_bytes - b.last_allocated_bytes
@@ -82,6 +96,16 @@ pub fn (mut b Bench) step_parallel(name string, parallel bool) {
 	b.last_allocation_count = after_report.allocation_count
 	b.last_allocated_bytes = after_report.allocated_bytes
 	b.step_sw.restart()
+}
+
+fn memory_limit_error(ram_kb i64, limit_kb i64, step string) string {
+	if limit_kb <= 0 || ram_kb < limit_kb {
+		return ''
+	}
+	ram_mb := ram_kb / 1024
+	limit_gib := limit_kb / (1024 * 1024)
+	return 'error: v3 compiler memory usage reached ${ram_mb} MiB RSS after ${step} ' +
+		'(limit: ${limit_gib} GiB); use `-no-memory-limit` to disable this limit'
 }
 
 // metric records a structural compiler counter for the final benchmark report.

--- a/vlib/v3/bench/bench_test.v
+++ b/vlib/v3/bench/bench_test.v
@@ -1,0 +1,17 @@
+module bench
+
+fn test_memory_limit_error_starts_at_limit() {
+	assert memory_limit_error(default_memory_limit_kb - 1, default_memory_limit_kb, 'parse') == ''
+
+	message := memory_limit_error(default_memory_limit_kb, default_memory_limit_kb, 'parse')
+	assert message.contains('10240 MiB RSS after parse')
+	assert message.contains('limit: 10 GiB')
+	assert message.contains('`-no-memory-limit`')
+}
+
+fn test_disable_memory_limit() {
+	mut b := new()
+	assert memory_limit_error(default_memory_limit_kb, b.memory_limit_kb, 'check') != ''
+	b.disable_memory_limit()
+	assert memory_limit_error(default_memory_limit_kb, b.memory_limit_kb, 'check') == ''
+}

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -123,8 +123,9 @@ fn test_driver_rejects_invalid_cli_and_parses_vmod_subdirs() {
 	help := cmdexec.run(v3_bin, ['--help'])
 	assert help.exit_code == 0
 	assert help.output.contains('-cc <compiler>')
+	assert help.output.contains('-no-memory-limit')
 	c_output := os.join_path(root, 'hello.c')
-	c_compile := cmdexec.run(v3_bin, ['-o', c_output, source])
+	c_compile := cmdexec.run(v3_bin, ['-no-memory-limit', '-o', c_output, source])
 	assert c_compile.exit_code == 0, c_compile.output
 	c_source := os.read_file(c_output)!
 	assert c_source.len > 100

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -443,6 +443,7 @@ fn cli_usage() string {
 		'  -os <name> -arch <name>     target platform\n' +
 		'  -cc <compiler>               C compiler executable\n' +
 		'  -prod -c99 -shared -strict  C build modes\n' +
+		'  -no-memory-limit             disable the 10 GiB RSS safety limit\n' +
 		'  -d <name>                    compile-time define'
 }
 
@@ -974,6 +975,7 @@ fn main() {
 	mut no_parallel := false
 	mut no_prealloc := false
 	mut no_cache := false
+	mut no_memory_limit := false
 	mut parallel_transform := true
 	mut building_v := false
 	mut ownership_mode := false
@@ -1081,6 +1083,9 @@ fn main() {
 			i++
 		} else if args[i] == '-nocache' || args[i] == '--no-cache' {
 			no_cache = true
+			i++
+		} else if args[i] == '-no-memory-limit' || args[i] == '--no-memory-limit' {
+			no_memory_limit = true
 			i++
 		} else if args[i] == '-prealloc' {
 			// Same effect as `v -prealloc`: activate the `$if prealloc {` arena
@@ -1250,6 +1255,9 @@ fn main() {
 	}
 
 	mut b := bench.new()
+	if no_memory_limit {
+		b.disable_memory_limit()
+	}
 	mut c_object_cache_stats := CObjectCacheStats{}
 	println('=== v3 benchmark ===')
 


### PR DESCRIPTION
## What

- stop the v3 compiler after a phase when current RSS reaches 10 GiB
- report the observed RSS and phase before exiting
- add `-no-memory-limit` and `--no-memory-limit` opt-out flags
- document the limit and cover the threshold and CLI behavior with tests

## Why

This prevents runaway v3 compilations from continuing after excessive memory use while retaining an explicit escape hatch for unusually large builds.

## Testing

- `./vnew -silent test vlib/v3/bench/`
- `./vnew vlib/v3/tests/driver_cli_test.v`
- fresh v3 -> v4 self-host compilation with `-no-memory-limit -nocache`
- `./vnew check-md vlib/v3/README.md`
- `git diff --check`