### PR TITLE
cgen: fix Option alias sum type handling

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -78,12 +78,12 @@ fn (mut g Gen) get_str_fn(typ ast.Type) string {
 			}
 		}
 	}
-	// Option aliases share their parent's C wrapper and auto-str function.
+	// Option aliases share their immediate parent's C wrapper and auto-str function.
 	option_alias_sym := g.table.sym(unwrapped)
 	if unwrapped.has_flag(.option) && option_alias_sym.info is ast.Alias
 		&& option_alias_sym.info.parent_type.has_flag(.option)
 		&& !option_alias_sym.has_method('str') {
-		unwrapped = g.table.fully_unaliased_type(unwrapped)
+		unwrapped = option_alias_sym.info.parent_type.derive_add_muls(unwrapped)
 	}
 	styp := g.styp(unwrapped)
 	mut sym := g.table.sym(unwrapped)

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -78,6 +78,13 @@ fn (mut g Gen) get_str_fn(typ ast.Type) string {
 			}
 		}
 	}
+	// Option aliases share their parent's C wrapper and auto-str function.
+	option_alias_sym := g.table.sym(unwrapped)
+	if unwrapped.has_flag(.option) && option_alias_sym.info is ast.Alias
+		&& option_alias_sym.info.parent_type.has_flag(.option)
+		&& !option_alias_sym.has_method('str') {
+		unwrapped = g.table.fully_unaliased_type(unwrapped)
+	}
 	styp := g.styp(unwrapped)
 	mut sym := g.table.sym(unwrapped)
 	mut str_fn_name := styp_to_str_fn_name(styp)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -7516,7 +7516,7 @@ fn (mut g Gen) typeof_expr(node ast.TypeOf) {
 		}
 	}
 	sym := g.table.sym(typ)
-	if sym.kind == .sum_type {
+	if sym.kind == .sum_type && !typ.has_flag(.option) {
 		// When encountering a .sum_type, typeof() should be done at runtime,
 		// because the subtype of the expression may change:
 		g.write('builtin__tos3(v_typeof_sumtype_${sym.cname}( (')
@@ -10720,17 +10720,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		} else if node_typ_is_option {
 			if sym.info is ast.Alias {
 				if sym.info.parent_type.has_flag(.option) {
-					cur_stmt := g.go_before_last_stmt()
-					g.empty_line = true
-					parent_type := sym.info.parent_type
-					tmp_var := g.new_tmp_var()
-					tmp_var2 := g.new_tmp_var()
-					g.writeln2('${styp} ${tmp_var};', '${g.styp(parent_type)} ${tmp_var2};')
-					g.write('builtin___option_ok(&(${g.base_type(parent_type)}[]) { ')
-					g.expr(node.expr)
-					g.writeln(' }, (${option_name}*)(&${tmp_var2}), sizeof(${g.base_type(parent_type)}));')
-					g.writeln('builtin___option_ok(&(${g.styp(parent_type)}[]) { ${tmp_var2} }, (${option_name}*)&${tmp_var}, sizeof(${g.styp(parent_type)}));')
-					g.write2(cur_stmt, tmp_var)
+					g.expr_with_opt(node.expr, expr_type, sym.info.parent_type)
 				} else if node.expr_type.has_flag(.option) {
 					g.expr_opt_with_alias(node.expr, expr_type, node_typ)
 				} else {

--- a/vlib/v/tests/options/option_alias_sumtype_typeof_test.v
+++ b/vlib/v/tests/options/option_alias_sumtype_typeof_test.v
@@ -1,0 +1,16 @@
+type AorB = u8 | u16
+
+type MaybeAorB = ?AorB
+
+struct OptionSumTypeHolder {
+	value ?AorB
+}
+
+fn test_cast_to_option_alias_of_sum_type() {
+	alias := ?MaybeAorB(u8(1))
+	assert '${alias}' == 'Option(AorB(1))'
+}
+
+fn test_typeof_option_sum_type_field() {
+	assert unsafe { typeof(OptionSumTypeHolder{}.value) } == '?AorB'
+}

--- a/vlib/v/tests/options/option_alias_sumtype_typeof_test.v
+++ b/vlib/v/tests/options/option_alias_sumtype_typeof_test.v
@@ -2,8 +2,16 @@ type AorB = u8 | u16
 
 type MaybeAorB = ?AorB
 
+type PayloadAlias = int
+
+type MaybePayloadAlias = ?PayloadAlias
+
 struct OptionSumTypeHolder {
 	value ?AorB
+}
+
+fn (value PayloadAlias) str() string {
+	return 'PayloadAlias(${int(value)})'
 }
 
 fn test_cast_to_option_alias_of_sum_type() {
@@ -13,4 +21,9 @@ fn test_cast_to_option_alias_of_sum_type() {
 
 fn test_typeof_option_sum_type_field() {
 	assert unsafe { typeof(OptionSumTypeHolder{}.value) } == '?AorB'
+}
+
+fn test_option_alias_preserves_aliased_payload_str() {
+	alias := ?MaybePayloadAlias(PayloadAlias(1))
+	assert '${alias}' == 'Option(PayloadAlias(1))'
 }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -2540,8 +2540,8 @@ fn (mut p Parser) make_compile_error_call(message flat.NodeId, start int, end in
 		value:          '__v_compile_error'
 		children_start: cstart
 		children_count: 2
-		pos:            token.new_span(p.cur_file_id, clamp_source_offset(start, p.s.src.len),
-			clamp_source_offset(end, p.s.src.len))
+		pos:            token.new_span(p.cur_file_id, clamp_source_offset(start, p.s.src.len), clamp_source_offset(end,
+			p.s.src.len))
 	})
 }
 
@@ -2942,7 +2942,8 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 						// The @VMOD_FILE token has not been consumed here, so derive its
 						// own span from the condition's source offset (pseudo_pos) plus
 						// the token's local bounds within the condition string.
-						call := p.make_compile_error_call(message, pseudo_pos + start, pseudo_pos + i)
+						call := p.make_compile_error_call(message, pseudo_pos + start, pseudo_pos +
+							i)
 						_ = p.make_top_level_compile_error(call)
 						''
 					}
@@ -6193,8 +6194,8 @@ fn (mut p Parser) for_post_expr_stmt_ending(expr flat.NodeId, end int) flat.Node
 	if start_off < 0 {
 		start_off = end
 	}
-	span := token.new_span(p.cur_file_id, clamp_source_offset(start_off, p.s.src.len),
-		clamp_source_offset(end, p.s.src.len))
+	span := token.new_span(p.cur_file_id, clamp_source_offset(start_off, p.s.src.len), clamp_source_offset(end,
+		p.s.src.len))
 	return p.a.add_node(flat.Node{
 		kind:           .expr_stmt
 		children_start: start

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -83,8 +83,7 @@ fn test_c_style_for_post_clause_spans() {
 	for node in ast.nodes {
 		if node.kind == .ident && node.value == 'i' && span_text(src, node) == 'i' {
 			saw_ident = true
-		} else if node.kind == .postfix && node.op == .inc
-			&& span_text(src, node) == 'i++' {
+		} else if node.kind == .postfix && node.op == .inc && span_text(src, node) == 'i++' {
 			saw_postfix = true
 		} else if node.kind == .expr_stmt {
 			stmt_spans << span_text(src, node)

--- a/vlib/v3/profiler/context.v
+++ b/vlib/v3/profiler/context.v
@@ -3,6 +3,8 @@
 // that can be found in the LICENSE file.
 module profiler
 
+import context
+
 // Allocator interface - can be swapped at runtime
 // Similar to Jai's context.allocator design
 pub struct Allocator {

--- a/vlib/v3/profiler/context.v
+++ b/vlib/v3/profiler/context.v
@@ -3,8 +3,6 @@
 // that can be found in the LICENSE file.
 module profiler
 
-import context
-
 // Allocator interface - can be swapped at runtime
 // Similar to Jai's context.allocator design
 pub struct Allocator {
@@ -19,7 +17,7 @@ pub:
 // This allows all allocations in a scope to be tracked without explicit annotations
 
 @[thread_local]
-__global context = Context{}
+__global profiler_context = Context{}
 
 pub struct Context {
 pub mut:
@@ -46,18 +44,18 @@ fn default_realloc(ptr voidptr, new_size int, ctx voidptr) voidptr {
 	return unsafe { C.realloc(ptr, new_size) }
 }
 
-// User code calls these - they use context.allocator implicitly
+// User code calls these - they use the current allocator implicitly
 // This provides the Jai-like implicit allocation tracking
 pub fn alloc(size int) voidptr {
-	return context.allocator.alloc_fn(size, context.allocator.ctx)
+	return profiler_context.allocator.alloc_fn(size, profiler_context.allocator.ctx)
 }
 
 pub fn free(ptr voidptr) {
-	context.allocator.free_fn(ptr, context.allocator.ctx)
+	profiler_context.allocator.free_fn(ptr, profiler_context.allocator.ctx)
 }
 
 pub fn realloc(ptr voidptr, new_size int) voidptr {
-	return context.allocator.realloc_fn(ptr, new_size, context.allocator.ctx)
+	return profiler_context.allocator.realloc_fn(ptr, new_size, profiler_context.allocator.ctx)
 }
 
 // Scoped allocator helper - saves and restores the allocator
@@ -66,11 +64,11 @@ pub fn realloc(ptr voidptr, new_size int) voidptr {
 //   defer { profiler.pop_allocator(old) }
 //   // ... all allocations here use my_allocator
 pub fn push_allocator(a Allocator) Allocator {
-	old := context.allocator
-	context.allocator = a
+	old := profiler_context.allocator
+	profiler_context.allocator = a
 	return old
 }
 
 pub fn pop_allocator(old Allocator) {
-	context.allocator = old
+	profiler_context.allocator = old
 }

--- a/vlib/v3/profiler/ipc_test.v
+++ b/vlib/v3/profiler/ipc_test.v
@@ -15,7 +15,8 @@ fn test_snapshot_roundtrips_file_paths_with_commas() {
 	ptr := profiler_alloc_with_location(64, '/tmp/weird,path/with,commas.v', 42)
 	assert ptr != unsafe { nil }
 
-	path := os.join_path(os.temp_dir(), 'v3_profiler_ipc_test_${os.getpid()}_${time.sys_mono_now()}.dat')
+	path := os.join_path(os.temp_dir(),
+		'v3_profiler_ipc_test_${os.getpid()}_${time.sys_mono_now()}.dat')
 	defer {
 		os.rm(path) or {}
 	}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -226,7 +226,8 @@ fn ensure_c_object_file(obj_path string, support_flags []string, c99 bool, pic_f
 		stats.input_snapshot_races++
 		trace_c_object_cache('bypass', cache_key,
 			'inputs changed during compilation; using build-local object', dependencies.files.len)
-		uncached_obj := os.join_path(uncached_dir, 'input_snapshot_race_${os.getpid()}_${rand.ulid()}.o')
+		uncached_obj := os.join_path(uncached_dir,
+			'input_snapshot_race_${os.getpid()}_${rand.ulid()}.o')
 		os.mv(temp_obj, uncached_obj) or {
 			os.rm(temp_obj) or {}
 			return error('failed to stage build-local C object ${uncached_obj}: ${err}')
@@ -2023,8 +2024,7 @@ fn main() {
 	b.metric('C object dep-scan fallbacks', c_object_cache_stats.dependency_scan_fallbacks,
 		'objects')
 	b.metric('C object publish races', c_object_cache_stats.publish_races, 'objects')
-	b.metric('C object input-snapshot races', c_object_cache_stats.input_snapshot_races,
-		'objects')
+	b.metric('C object input-snapshot races', c_object_cache_stats.input_snapshot_races, 'objects')
 	b.print_report()
 }
 


### PR DESCRIPTION
Fixes #27820
Fixes #27821

This PR:
- reuses the parent Option representation when constructing an Option type alias, avoiding a second wrapper;
- canonicalizes Option aliases before generating their shared auto-str function;
- keeps raw typeof on Option-wrapped sum types on the static Option path instead of reading a sum-type tag from the wrapper;
- adds regressions for both reported reproducers.

Tests:
- ./vnew vlib/v/tests/options/option_alias_sumtype_typeof_test.v
- ./vnew -silent test vlib/v/tests/options/
- ./vnew -silent vlib/v/compiler_errors_test.v
- ./vnew -silent vlib/v/gen/c/coutput_test.v
- ./vnew vlib/v/tests/aliases/alias_option_test.v
- ./vnew vlib/v/tests/builtin_strings_and_interpolation/string_interpolation_reference_default_fmt_test.v