### PR TITLE
v3: fix Objective-C source routing

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3984,9 +3984,20 @@ fn c_preprocessor_macro_state(name string, defined map[string]bool, undefined ma
 	if name in uncertain {
 		return false, true
 	}
+	if name in ['__linux__', '__linux', 'linux'] {
+		return true, target.os in ['linux', 'android', 'termux']
+	}
+	if name == 'unix' {
+		if target.os in ['linux', 'android', 'termux'] {
+			return true, true
+		}
+		if target.os in ['windows', 'macos', 'ios'] {
+			return true, false
+		}
+		return false, true
+	}
 	match name {
 		'__APPLE__', '__MACH__' { return true, target.os in ['macos', 'ios'] }
-		'__linux__', '__linux' { return true, target.os == 'linux' }
 		'_WIN32' { return true, target.os == 'windows' }
 		'_WIN64' { return true, target.os == 'windows' && target.pointer_bits == 64 }
 		'__FreeBSD__' { return true, target.os == 'freebsd' }

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -298,9 +298,10 @@ struct NativeSourceContextDirective {
 }
 
 struct ObjectiveCppSourceRequest {
-	module        string
-	source_path   string
-	local_context []NativeSourceContextDirective
+	module                 string
+	source_path            string
+	local_context          []NativeSourceContextDirective
+	source_macros_possible bool
 }
 
 struct CInlineHeader {
@@ -2190,9 +2191,10 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 				// omitted without forcing the generated unit into Objective-C mode.
 				if source_path.ends_with('.mm') {
 					g.objective_cpp_source_requests << ObjectiveCppSourceRequest{
-						module:        module_name
-						source_path:   source_path
-						local_context: (g.native_source_contexts[module_name] or {
+						module:                 module_name
+						source_path:            source_path
+						source_macros_possible: g.native_source_context_has_macro_inputs(module_name)
+						local_context:          (g.native_source_contexts[module_name] or {
 							[]NativeSourceContextDirective{}
 						}).clone()
 					}
@@ -4154,7 +4156,7 @@ fn (mut g FlatGen) materialize_objective_cpp_sources() {
 	for request in g.objective_cpp_source_requests {
 		context_directives := g.ordered_native_source_context(request.module, request.local_context)
 		if context_directives.len > 0
-			&& c_native_source_context_definitely_inactive(context_directives, g.c_flags, g.c99_mode, g.target, g.native_source_context_has_macro_inputs(request.module)) {
+			&& c_native_source_context_definitely_inactive(context_directives, g.c_flags, g.c99_mode, g.target, request.source_macros_possible) {
 			continue
 		}
 		if context_directives.len > 0

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2205,7 +2205,7 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 					context_directives := g.ordered_native_source_context(module_name,
 						local_context)
 					if context_directives.len > 0
-						&& c_native_source_context_definitely_inactive(context_directives, g.c_flags, g.target) {
+						&& c_native_source_context_definitely_inactive(context_directives, g.c_flags, g.c99_mode, g.target) {
 						return true
 					}
 				}
@@ -3798,7 +3798,7 @@ fn c_preprocessor_invalidate_macro_state(mut defined map[string]bool, mut undefi
 	undefined.clear()
 }
 
-fn c_native_source_context_definitely_inactive(directives []string, flags []string, target pref.Target) bool {
+fn c_native_source_context_definitely_inactive(directives []string, flags []string, c99_mode bool, target pref.Target) bool {
 	mut defined := map[string]bool{}
 	mut undefined := map[string]bool{}
 	mut uncertain := map[string]bool{}
@@ -3849,7 +3849,7 @@ fn c_native_source_context_definitely_inactive(directives []string, flags []stri
 			if name in ['ifdef', 'ifndef'] {
 				macro_name := c_directive_arg(clean).fields()[0] or { '' }
 				known, mut active := c_preprocessor_macro_state(macro_name, defined, undefined,
-					uncertain, target)
+					uncertain, c99_mode, target)
 				if name == 'ifndef' {
 					active = !active
 				}
@@ -3862,7 +3862,7 @@ fn c_native_source_context_definitely_inactive(directives []string, flags []stri
 			if name == 'if' {
 				arg := c_directive_arg(clean)
 				known, active := c_preprocessor_condition_state(arg, defined, undefined, uncertain,
-					external_macros_possible, target)
+					external_macros_possible, c99_mode, target)
 				condition_known << known
 				condition_active << (if known { active } else { true })
 				condition_taken_known << known
@@ -3874,7 +3874,7 @@ fn c_native_source_context_definitely_inactive(directives []string, flags []stri
 				prior_known := condition_taken_known[last]
 				prior_taken := condition_taken[last]
 				known, active := c_preprocessor_condition_state(c_directive_arg(clean), defined,
-					undefined, uncertain, external_macros_possible, target)
+					undefined, uncertain, external_macros_possible, c99_mode, target)
 				if (prior_known && prior_taken) || (known && !active) {
 					condition_known[last] = true
 					condition_active[last] = false
@@ -3974,7 +3974,7 @@ fn c_native_source_context_definitely_inactive(directives []string, flags []stri
 	return false
 }
 
-fn c_preprocessor_macro_state(name string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, target pref.Target) (bool, bool) {
+fn c_preprocessor_macro_state(name string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, c99_mode bool, target pref.Target) (bool, bool) {
 	if name in defined {
 		return true, true
 	}
@@ -3984,10 +3984,19 @@ fn c_preprocessor_macro_state(name string, defined map[string]bool, undefined ma
 	if name in uncertain {
 		return false, true
 	}
-	if name in ['__linux__', '__linux', 'linux'] {
+	if name == '__linux__' {
+		return true, target.os in ['linux', 'android', 'termux']
+	}
+	if name in ['__linux', 'linux'] {
+		if c99_mode {
+			return false, true
+		}
 		return true, target.os in ['linux', 'android', 'termux']
 	}
 	if name == 'unix' {
+		if c99_mode {
+			return false, true
+		}
 		if target.os in ['linux', 'android', 'termux'] {
 			return true, true
 		}
@@ -4012,7 +4021,7 @@ fn c_preprocessor_macro_state(name string, defined map[string]bool, undefined ma
 	return true, false
 }
 
-fn c_preprocessor_bare_macro_state(name string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, external_macros_possible bool, target pref.Target) (bool, bool) {
+fn c_preprocessor_bare_macro_state(name string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, external_macros_possible bool, c99_mode bool, target pref.Target) (bool, bool) {
 	if name in undefined {
 		return true, false
 	}
@@ -4024,10 +4033,10 @@ fn c_preprocessor_bare_macro_state(name string, defined map[string]bool, undefin
 	if external_macros_possible && !name.starts_with('_') {
 		return false, true
 	}
-	return c_preprocessor_macro_state(name, defined, undefined, uncertain, target)
+	return c_preprocessor_macro_state(name, defined, undefined, uncertain, c99_mode, target)
 }
 
-fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, external_macros_possible bool, target pref.Target) (bool, bool) {
+fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, external_macros_possible bool, c99_mode bool, target pref.Target) (bool, bool) {
 	mut clean := raw.trim_space()
 	mut negated := false
 	if clean.starts_with('!') {
@@ -4043,7 +4052,7 @@ fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined
 	}
 	if clean.len > 0 && c_identifier_start(clean[0]) && c_header_struct_tag(clean) == clean {
 		known, mut active := c_preprocessor_bare_macro_state(clean, defined, undefined, uncertain,
-			external_macros_possible, target)
+			external_macros_possible, c99_mode, target)
 		if !known {
 			return false, true
 		}
@@ -4078,7 +4087,7 @@ fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined
 		return false, true
 	}
 	known, mut active := c_preprocessor_macro_state(macro_name, defined, undefined, uncertain,
-		target)
+		c99_mode, target)
 	if negated {
 		active = !active
 	}
@@ -4089,7 +4098,7 @@ fn (mut g FlatGen) materialize_objective_cpp_sources() {
 	for request in g.objective_cpp_source_requests {
 		context_directives := g.ordered_native_source_context(request.module, request.local_context)
 		if context_directives.len > 0
-			&& c_native_source_context_definitely_inactive(context_directives, g.c_flags, g.target) {
+			&& c_native_source_context_definitely_inactive(context_directives, g.c_flags, g.c99_mode, g.target) {
 			continue
 		}
 		if context_directives.len > 0

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3787,10 +3787,22 @@ fn c_native_source_context_depth(directives []string) int {
 	return depth
 }
 
+fn c_preprocessor_invalidate_macro_state(mut defined map[string]bool, mut undefined map[string]bool, mut uncertain map[string]bool) {
+	for name in defined.keys() {
+		uncertain[name] = true
+	}
+	for name in undefined.keys() {
+		uncertain[name] = true
+	}
+	defined.clear()
+	undefined.clear()
+}
+
 fn c_native_source_context_definitely_inactive(directives []string, flags []string, target pref.Target) bool {
 	mut defined := map[string]bool{}
 	mut undefined := map[string]bool{}
 	mut uncertain := map[string]bool{}
+	mut external_macros_possible := c_forced_include_inputs(flags).len > 0
 	mut i := 0
 	for i < flags.len {
 		clean := trimmed_space(flags[i])
@@ -3821,6 +3833,9 @@ fn c_native_source_context_definitely_inactive(directives []string, flags []stri
 		}
 		i++
 	}
+	if external_macros_possible {
+		c_preprocessor_invalidate_macro_state(mut defined, mut undefined, mut uncertain)
+	}
 	mut condition_known := []bool{}
 	mut condition_active := []bool{}
 	// Keep the cumulative state of each branch chain so `#elif` and `#else`
@@ -3847,7 +3862,7 @@ fn c_native_source_context_definitely_inactive(directives []string, flags []stri
 			if name == 'if' {
 				arg := c_directive_arg(clean)
 				known, active := c_preprocessor_condition_state(arg, defined, undefined, uncertain,
-					target)
+					external_macros_possible, target)
 				condition_known << known
 				condition_active << (if known { active } else { true })
 				condition_taken_known << known
@@ -3859,7 +3874,7 @@ fn c_native_source_context_definitely_inactive(directives []string, flags []stri
 				prior_known := condition_taken_known[last]
 				prior_taken := condition_taken[last]
 				known, active := c_preprocessor_condition_state(c_directive_arg(clean), defined,
-					undefined, uncertain, target)
+					undefined, uncertain, external_macros_possible, target)
 				if (prior_known && prior_taken) || (known && !active) {
 					condition_known[last] = true
 					condition_active[last] = false
@@ -3899,6 +3914,20 @@ fn c_native_source_context_definitely_inactive(directives []string, flags []stri
 				condition_active.delete_last()
 				condition_taken_known.delete_last()
 				condition_taken.delete_last()
+				continue
+			}
+			if name in ['include', 'insert'] {
+				mut possibly_active := true
+				for depth in 0 .. condition_known.len {
+					if condition_known[depth] && !condition_active[depth] {
+						possibly_active = false
+						break
+					}
+				}
+				if possibly_active {
+					c_preprocessor_invalidate_macro_state(mut defined, mut undefined, mut uncertain)
+					external_macros_possible = true
+				}
 				continue
 			}
 			if name !in ['define', 'undef'] {
@@ -3972,7 +4001,7 @@ fn c_preprocessor_macro_state(name string, defined map[string]bool, undefined ma
 	return true, false
 }
 
-fn c_preprocessor_bare_macro_state(name string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, target pref.Target) (bool, bool) {
+fn c_preprocessor_bare_macro_state(name string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, external_macros_possible bool, target pref.Target) (bool, bool) {
 	if name in undefined {
 		return true, false
 	}
@@ -3981,10 +4010,13 @@ fn c_preprocessor_bare_macro_state(name string, defined map[string]bool, undefin
 	if name in defined || name in uncertain {
 		return false, true
 	}
+	if external_macros_possible && !name.starts_with('_') {
+		return false, true
+	}
 	return c_preprocessor_macro_state(name, defined, undefined, uncertain, target)
 }
 
-fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, target pref.Target) (bool, bool) {
+fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, external_macros_possible bool, target pref.Target) (bool, bool) {
 	mut clean := raw.trim_space()
 	mut negated := false
 	if clean.starts_with('!') {
@@ -4000,7 +4032,7 @@ fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined
 	}
 	if clean.len > 0 && c_identifier_start(clean[0]) && c_header_struct_tag(clean) == clean {
 		known, mut active := c_preprocessor_bare_macro_state(clean, defined, undefined, uncertain,
-			target)
+			external_macros_possible, target)
 		if !known {
 			return false, true
 		}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2205,7 +2205,7 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 					context_directives := g.ordered_native_source_context(module_name,
 						local_context)
 					if context_directives.len > 0
-						&& c_native_source_context_definitely_inactive(context_directives, g.c_flags, g.c99_mode, g.target) {
+						&& c_native_source_context_definitely_inactive(context_directives, g.c_flags, g.c99_mode, g.target, g.native_source_context_has_macro_inputs(module_name)) {
 						return true
 					}
 				}
@@ -3725,6 +3725,32 @@ fn (g &FlatGen) ordered_native_source_context(module_name string, local_context 
 	return result
 }
 
+fn (g &FlatGen) native_source_context_has_macro_inputs(module_name string) bool {
+	mut visiting := map[string]bool{}
+	return g.visit_native_source_macro_input_module(module_name, mut visiting)
+}
+
+fn (g &FlatGen) visit_native_source_macro_input_module(module_name string, mut visiting map[string]bool) bool {
+	if module_name in visiting {
+		return false
+	}
+	for directive in g.c_directives {
+		clean := trimmed_space(directive.text)
+		if directive.module == module_name && c_directive_name(clean) == 'include'
+			&& c_include_arg_is_source_file(c_directive_arg(clean)) {
+			return true
+		}
+	}
+	visiting[module_name] = true
+	for dependency in g.module_imports[module_name] or { []string{} } {
+		if g.visit_native_source_macro_input_module(dependency, mut visiting) {
+			return true
+		}
+	}
+	visiting.delete(module_name)
+	return false
+}
+
 fn (g &FlatGen) visit_native_source_context_module(module_name string, root_module string, root_context []NativeSourceContextDirective, mut visiting map[string]bool, mut visited map[string]bool, mut result []string) {
 	if module_name in visited || module_name in visiting {
 		return
@@ -3827,11 +3853,11 @@ fn c_effective_strict_iso_mode(flags []string, c99_mode bool) bool {
 	return strict_iso_mode
 }
 
-fn c_native_source_context_definitely_inactive(directives []string, flags []string, c99_mode bool, target pref.Target) bool {
+fn c_native_source_context_definitely_inactive(directives []string, flags []string, c99_mode bool, target pref.Target, source_macros_possible bool) bool {
 	mut defined := map[string]bool{}
 	mut undefined := map[string]bool{}
 	mut uncertain := map[string]bool{}
-	mut external_macros_possible := c_forced_include_inputs(flags).len > 0
+	mut external_macros_possible := source_macros_possible || c_forced_include_inputs(flags).len > 0
 	strict_iso_mode := c_effective_strict_iso_mode(flags, c99_mode)
 	mut i := 0
 	for i < flags.len {
@@ -4128,7 +4154,7 @@ fn (mut g FlatGen) materialize_objective_cpp_sources() {
 	for request in g.objective_cpp_source_requests {
 		context_directives := g.ordered_native_source_context(request.module, request.local_context)
 		if context_directives.len > 0
-			&& c_native_source_context_definitely_inactive(context_directives, g.c_flags, g.c99_mode, g.target) {
+			&& c_native_source_context_definitely_inactive(context_directives, g.c_flags, g.c99_mode, g.target, g.native_source_context_has_macro_inputs(request.module)) {
 			continue
 		}
 		if context_directives.len > 0

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3986,6 +3986,14 @@ fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined
 		}
 		return true, active
 	}
+	if clean.len > 0 && c_identifier_start(clean[0]) && c_header_struct_tag(clean) == clean {
+		known, mut active := c_preprocessor_macro_state(clean, defined, undefined, uncertain,
+			target)
+		if negated {
+			active = !active
+		}
+		return known, active
+	}
 	if !clean.starts_with('defined') || (clean.len > 'defined'.len && clean['defined'.len] != `(`
 		&& !clean['defined'.len].is_space()) {
 		return false, true

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3972,6 +3972,18 @@ fn c_preprocessor_macro_state(name string, defined map[string]bool, undefined ma
 	return true, false
 }
 
+fn c_preprocessor_bare_macro_state(name string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, target pref.Target) (bool, bool) {
+	if name in undefined {
+		return true, false
+	}
+	// Definitions collected from directives and -D flags do not retain their values.
+	// They are sufficient for defined(NAME), but not for evaluating #if NAME.
+	if name in defined || name in uncertain {
+		return false, true
+	}
+	return c_preprocessor_macro_state(name, defined, undefined, uncertain, target)
+}
+
 fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, target pref.Target) (bool, bool) {
 	mut clean := raw.trim_space()
 	mut negated := false
@@ -3987,8 +3999,11 @@ fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined
 		return true, active
 	}
 	if clean.len > 0 && c_identifier_start(clean[0]) && c_header_struct_tag(clean) == clean {
-		known, mut active := c_preprocessor_macro_state(clean, defined, undefined, uncertain,
+		known, mut active := c_preprocessor_bare_macro_state(clean, defined, undefined, uncertain,
 			target)
+		if !known {
+			return false, true
+		}
 		if negated {
 			active = !active
 		}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3798,11 +3798,41 @@ fn c_preprocessor_invalidate_macro_state(mut defined map[string]bool, mut undefi
 	undefined.clear()
 }
 
+fn c_effective_strict_iso_mode(flags []string, c99_mode bool) bool {
+	mut strict_iso_mode := c99_mode
+	mut expect_standard := false
+	for flag in flags {
+		clean := trimmed_space(flag)
+		if expect_standard {
+			strict_iso_mode = !clean.to_lower().starts_with('gnu')
+			expect_standard = false
+			continue
+		}
+		if clean in ['-std', '--std'] {
+			expect_standard = true
+			continue
+		}
+		if clean == '-ansi' {
+			strict_iso_mode = true
+			continue
+		}
+		for prefix in ['-std=', '--std='] {
+			if clean.starts_with(prefix) && clean.len > prefix.len {
+				standard := clean[prefix.len..].to_lower()
+				strict_iso_mode = !standard.starts_with('gnu')
+				break
+			}
+		}
+	}
+	return strict_iso_mode
+}
+
 fn c_native_source_context_definitely_inactive(directives []string, flags []string, c99_mode bool, target pref.Target) bool {
 	mut defined := map[string]bool{}
 	mut undefined := map[string]bool{}
 	mut uncertain := map[string]bool{}
 	mut external_macros_possible := c_forced_include_inputs(flags).len > 0
+	strict_iso_mode := c_effective_strict_iso_mode(flags, c99_mode)
 	mut i := 0
 	for i < flags.len {
 		clean := trimmed_space(flags[i])
@@ -3849,7 +3879,7 @@ fn c_native_source_context_definitely_inactive(directives []string, flags []stri
 			if name in ['ifdef', 'ifndef'] {
 				macro_name := c_directive_arg(clean).fields()[0] or { '' }
 				known, mut active := c_preprocessor_macro_state(macro_name, defined, undefined,
-					uncertain, c99_mode, target)
+					uncertain, strict_iso_mode, target)
 				if name == 'ifndef' {
 					active = !active
 				}
@@ -3862,7 +3892,7 @@ fn c_native_source_context_definitely_inactive(directives []string, flags []stri
 			if name == 'if' {
 				arg := c_directive_arg(clean)
 				known, active := c_preprocessor_condition_state(arg, defined, undefined, uncertain,
-					external_macros_possible, c99_mode, target)
+					external_macros_possible, strict_iso_mode, target)
 				condition_known << known
 				condition_active << (if known { active } else { true })
 				condition_taken_known << known
@@ -3874,7 +3904,7 @@ fn c_native_source_context_definitely_inactive(directives []string, flags []stri
 				prior_known := condition_taken_known[last]
 				prior_taken := condition_taken[last]
 				known, active := c_preprocessor_condition_state(c_directive_arg(clean), defined,
-					undefined, uncertain, external_macros_possible, c99_mode, target)
+					undefined, uncertain, external_macros_possible, strict_iso_mode, target)
 				if (prior_known && prior_taken) || (known && !active) {
 					condition_known[last] = true
 					condition_active[last] = false
@@ -3974,7 +4004,7 @@ fn c_native_source_context_definitely_inactive(directives []string, flags []stri
 	return false
 }
 
-fn c_preprocessor_macro_state(name string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, c99_mode bool, target pref.Target) (bool, bool) {
+fn c_preprocessor_macro_state(name string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, strict_iso_mode bool, target pref.Target) (bool, bool) {
 	if name in defined {
 		return true, true
 	}
@@ -3988,13 +4018,13 @@ fn c_preprocessor_macro_state(name string, defined map[string]bool, undefined ma
 		return true, target.os in ['linux', 'android', 'termux']
 	}
 	if name in ['__linux', 'linux'] {
-		if c99_mode {
+		if strict_iso_mode {
 			return false, true
 		}
 		return true, target.os in ['linux', 'android', 'termux']
 	}
 	if name == 'unix' {
-		if c99_mode {
+		if strict_iso_mode {
 			return false, true
 		}
 		if target.os in ['linux', 'android', 'termux'] {
@@ -4021,7 +4051,7 @@ fn c_preprocessor_macro_state(name string, defined map[string]bool, undefined ma
 	return true, false
 }
 
-fn c_preprocessor_bare_macro_state(name string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, external_macros_possible bool, c99_mode bool, target pref.Target) (bool, bool) {
+fn c_preprocessor_bare_macro_state(name string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, external_macros_possible bool, strict_iso_mode bool, target pref.Target) (bool, bool) {
 	if name in undefined {
 		return true, false
 	}
@@ -4033,10 +4063,10 @@ fn c_preprocessor_bare_macro_state(name string, defined map[string]bool, undefin
 	if external_macros_possible && !name.starts_with('_') {
 		return false, true
 	}
-	return c_preprocessor_macro_state(name, defined, undefined, uncertain, c99_mode, target)
+	return c_preprocessor_macro_state(name, defined, undefined, uncertain, strict_iso_mode, target)
 }
 
-fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, external_macros_possible bool, c99_mode bool, target pref.Target) (bool, bool) {
+fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined map[string]bool, uncertain map[string]bool, external_macros_possible bool, strict_iso_mode bool, target pref.Target) (bool, bool) {
 	mut clean := raw.trim_space()
 	mut negated := false
 	if clean.starts_with('!') {
@@ -4052,7 +4082,7 @@ fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined
 	}
 	if clean.len > 0 && c_identifier_start(clean[0]) && c_header_struct_tag(clean) == clean {
 		known, mut active := c_preprocessor_bare_macro_state(clean, defined, undefined, uncertain,
-			external_macros_possible, c99_mode, target)
+			external_macros_possible, strict_iso_mode, target)
 		if !known {
 			return false, true
 		}
@@ -4087,7 +4117,7 @@ fn c_preprocessor_condition_state(raw string, defined map[string]bool, undefined
 		return false, true
 	}
 	known, mut active := c_preprocessor_macro_state(macro_name, defined, undefined, uncertain,
-		c99_mode, target)
+		strict_iso_mode, target)
 	if negated {
 		active = !active
 	}

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -27,52 +27,66 @@ fn test_bare_macro_preprocessor_conditions_use_target_and_definition_state() {
 	linux := pref.target_from('linux', 'amd64') or { panic(err) }
 	empty := map[string]bool{}
 	known_apple, active_apple := c_preprocessor_condition_state('__APPLE__', empty, empty, empty,
-		false, linux)
+		false, false, linux)
 	assert known_apple
 	assert !active_apple
 	known_linux, active_linux := c_preprocessor_condition_state('linux', empty, empty, empty,
-		false, linux)
+		false, false, linux)
 	assert known_linux
 	assert active_linux
 	known_negated_unix, active_negated_unix := c_preprocessor_condition_state('!unix', empty,
-		empty, empty, false, linux)
+		empty, empty, false, false, linux)
 	assert known_negated_unix
 	assert !active_negated_unix
-	assert !c_native_source_context_definitely_inactive(['#if linux'], []string{}, linux)
-	assert c_native_source_context_definitely_inactive(['#if !unix'], []string{}, linux)
+	assert !c_native_source_context_definitely_inactive(['#if linux'], []string{}, false, linux)
+	assert c_native_source_context_definitely_inactive(['#if !unix'], []string{}, false, linux)
+	known_c99_linux, active_c99_linux := c_preprocessor_condition_state('linux', empty, empty,
+		empty, false, true, linux)
+	assert !known_c99_linux
+	assert active_c99_linux
+	known_c99_unix, active_c99_unix := c_preprocessor_condition_state('unix', empty, empty, empty,
+		false, true, linux)
+	assert !known_c99_unix
+	assert active_c99_unix
+	known_c99_underscored, active_c99_underscored := c_preprocessor_condition_state('__linux__',
+		empty, empty, empty, false, true, linux)
+	assert known_c99_underscored
+	assert active_c99_underscored
+	assert !c_native_source_context_definitely_inactive(['#if linux'], []string{}, true, linux)
+	assert !c_native_source_context_definitely_inactive(['#if !unix'], []string{}, true, linux)
 	known_unset, active_unset := c_preprocessor_condition_state('SOME_UNSET_MACRO', empty, empty,
-		empty, false, linux)
+		empty, false, false, linux)
 	assert known_unset
 	assert !active_unset
 	known_negated, active_negated := c_preprocessor_condition_state('!SOME_UNSET_MACRO', empty,
-		empty, empty, false, linux)
+		empty, empty, false, false, linux)
 	assert known_negated
 	assert active_negated
 	known_defined, active_defined := c_preprocessor_condition_state('SOME_DEFINED_MACRO', {
 		'SOME_DEFINED_MACRO': true
-	}, empty, empty, false, linux)
+	}, empty, empty, false, false, linux)
 	assert !known_defined
 	assert active_defined
 	known_negated_defined, active_negated_defined := c_preprocessor_condition_state('!FEATURE', {
 		'FEATURE': true
-	}, empty, empty, false, linux)
+	}, empty, empty, false, false, linux)
 	assert !known_negated_defined
 	assert active_negated_defined
 	known_presence, active_presence := c_preprocessor_condition_state('defined(FEATURE)', {
 		'FEATURE': true
-	}, empty, empty, false, linux)
+	}, empty, empty, false, false, linux)
 	assert known_presence
 	assert active_presence
 	known_compound, active_compound := c_preprocessor_condition_state('SOME_UNSET_MACRO || 1',
-		empty, empty, empty, false, linux)
+		empty, empty, empty, false, false, linux)
 	assert !known_compound
 	assert active_compound
 	known_external, active_external := c_preprocessor_condition_state('HEADER_FEATURE', empty,
-		empty, empty, true, linux)
+		empty, empty, true, false, linux)
 	assert !known_external
 	assert active_external
 	known_external_target, active_external_target := c_preprocessor_condition_state('__APPLE__',
-		empty, empty, empty, true, linux)
+		empty, empty, empty, true, false, linux)
 	assert known_external_target
 	assert !active_external_target
 }

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -38,10 +38,12 @@ fn test_bare_macro_preprocessor_conditions_use_target_and_definition_state() {
 		empty, empty, false, false, linux)
 	assert known_negated_unix
 	assert !active_negated_unix
-	assert !c_native_source_context_definitely_inactive(['#if linux'], []string{}, false, linux)
-	assert c_native_source_context_definitely_inactive(['#if !unix'], []string{}, false, linux)
+	assert !c_native_source_context_definitely_inactive(['#if linux'], []string{}, false, linux,
+		false)
+	assert c_native_source_context_definitely_inactive(['#if !unix'], []string{}, false, linux,
+		false)
 	assert c_native_source_context_definitely_inactive(['#if linux', '#else'], []string{}, false,
-		linux)
+		linux, false)
 	known_c99_linux, active_c99_linux := c_preprocessor_condition_state('linux', empty, empty,
 		empty, false, true, linux)
 	assert !known_c99_linux
@@ -54,17 +56,23 @@ fn test_bare_macro_preprocessor_conditions_use_target_and_definition_state() {
 		empty, empty, empty, false, true, linux)
 	assert known_c99_underscored
 	assert active_c99_underscored
-	assert !c_native_source_context_definitely_inactive(['#if linux'], []string{}, true, linux)
-	assert !c_native_source_context_definitely_inactive(['#if !unix'], []string{}, true, linux)
+	assert !c_native_source_context_definitely_inactive(['#if linux'], []string{}, true, linux,
+		false)
+	assert !c_native_source_context_definitely_inactive(['#if !unix'], []string{}, true, linux,
+		false)
 	assert !c_native_source_context_definitely_inactive(['#if linux', '#else'], [
 		'-std=c99',
-	], false, linux)
-	assert !c_native_source_context_definitely_inactive(['#if !unix'], ['-std=c11'], false, linux)
+	], false, linux, false)
+	assert !c_native_source_context_definitely_inactive(['#if !unix'], ['-std=c11'], false, linux,
+		false)
 	assert c_native_source_context_definitely_inactive(['#if !unix'], ['-std=c99', '-std=gnu11'],
-		false, linux)
+		false, linux, false)
 	assert !c_native_source_context_definitely_inactive(['#if !unix'], ['-std=gnu11', '-std=c99'],
-		false, linux)
-	assert c_native_source_context_definitely_inactive(['#if !unix'], ['-std=gnu11'], true, linux)
+		false, linux, false)
+	assert c_native_source_context_definitely_inactive(['#if !unix'], ['-std=gnu11'], true, linux,
+		false)
+	assert !c_native_source_context_definitely_inactive(['#if SOURCE_FEATURE'], []string{}, false,
+		linux, true)
 	known_unset, active_unset := c_preprocessor_condition_state('SOME_UNSET_MACRO', empty, empty,
 		empty, false, false, linux)
 	assert known_unset

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -30,6 +30,16 @@ fn test_bare_macro_preprocessor_conditions_use_target_and_definition_state() {
 		false, linux)
 	assert known_apple
 	assert !active_apple
+	known_linux, active_linux := c_preprocessor_condition_state('linux', empty, empty, empty,
+		false, linux)
+	assert known_linux
+	assert active_linux
+	known_negated_unix, active_negated_unix := c_preprocessor_condition_state('!unix', empty,
+		empty, empty, false, linux)
+	assert known_negated_unix
+	assert !active_negated_unix
+	assert !c_native_source_context_definitely_inactive(['#if linux'], []string{}, linux)
+	assert c_native_source_context_definitely_inactive(['#if !unix'], []string{}, linux)
 	known_unset, active_unset := c_preprocessor_condition_state('SOME_UNSET_MACRO', empty, empty,
 		empty, false, linux)
 	assert known_unset

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -41,8 +41,18 @@ fn test_bare_macro_preprocessor_conditions_use_target_and_definition_state() {
 	known_defined, active_defined := c_preprocessor_condition_state('SOME_DEFINED_MACRO', {
 		'SOME_DEFINED_MACRO': true
 	}, empty, empty, linux)
-	assert known_defined
+	assert !known_defined
 	assert active_defined
+	known_negated_defined, active_negated_defined := c_preprocessor_condition_state('!FEATURE', {
+		'FEATURE': true
+	}, empty, empty, linux)
+	assert !known_negated_defined
+	assert active_negated_defined
+	known_presence, active_presence := c_preprocessor_condition_state('defined(FEATURE)', {
+		'FEATURE': true
+	}, empty, empty, linux)
+	assert known_presence
+	assert active_presence
 	known_compound, active_compound := c_preprocessor_condition_state('SOME_UNSET_MACRO || 1',
 		empty, empty, empty, linux)
 	assert !known_compound

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -40,6 +40,8 @@ fn test_bare_macro_preprocessor_conditions_use_target_and_definition_state() {
 	assert !active_negated_unix
 	assert !c_native_source_context_definitely_inactive(['#if linux'], []string{}, false, linux)
 	assert c_native_source_context_definitely_inactive(['#if !unix'], []string{}, false, linux)
+	assert c_native_source_context_definitely_inactive(['#if linux', '#else'], []string{}, false,
+		linux)
 	known_c99_linux, active_c99_linux := c_preprocessor_condition_state('linux', empty, empty,
 		empty, false, true, linux)
 	assert !known_c99_linux
@@ -54,6 +56,15 @@ fn test_bare_macro_preprocessor_conditions_use_target_and_definition_state() {
 	assert active_c99_underscored
 	assert !c_native_source_context_definitely_inactive(['#if linux'], []string{}, true, linux)
 	assert !c_native_source_context_definitely_inactive(['#if !unix'], []string{}, true, linux)
+	assert !c_native_source_context_definitely_inactive(['#if linux', '#else'], [
+		'-std=c99',
+	], false, linux)
+	assert !c_native_source_context_definitely_inactive(['#if !unix'], ['-std=c11'], false, linux)
+	assert c_native_source_context_definitely_inactive(['#if !unix'], ['-std=c99', '-std=gnu11'],
+		false, linux)
+	assert !c_native_source_context_definitely_inactive(['#if !unix'], ['-std=gnu11', '-std=c99'],
+		false, linux)
+	assert c_native_source_context_definitely_inactive(['#if !unix'], ['-std=gnu11'], true, linux)
 	known_unset, active_unset := c_preprocessor_condition_state('SOME_UNSET_MACRO', empty, empty,
 		empty, false, false, linux)
 	assert known_unset

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -23,6 +23,32 @@ fn test_c_directive_targets_use_requested_platform() {
 	assert c_include_arg_for_target('windows <windows.h>', '', '', target) == ''
 }
 
+fn test_bare_macro_preprocessor_conditions_use_target_and_definition_state() {
+	linux := pref.target_from('linux', 'amd64') or { panic(err) }
+	empty := map[string]bool{}
+	known_apple, active_apple := c_preprocessor_condition_state('__APPLE__', empty, empty, empty,
+		linux)
+	assert known_apple
+	assert !active_apple
+	known_unset, active_unset := c_preprocessor_condition_state('SOME_UNSET_MACRO', empty, empty,
+		empty, linux)
+	assert known_unset
+	assert !active_unset
+	known_negated, active_negated := c_preprocessor_condition_state('!SOME_UNSET_MACRO', empty,
+		empty, empty, linux)
+	assert known_negated
+	assert active_negated
+	known_defined, active_defined := c_preprocessor_condition_state('SOME_DEFINED_MACRO', {
+		'SOME_DEFINED_MACRO': true
+	}, empty, empty, linux)
+	assert known_defined
+	assert active_defined
+	known_compound, active_compound := c_preprocessor_condition_state('SOME_UNSET_MACRO || 1',
+		empty, empty, empty, linux)
+	assert !known_compound
+	assert active_compound
+}
+
 fn test_termux_c_directive_target_is_distinct_from_android() {
 	termux := pref.target_from('termux', 'arm64') or { panic(err) }
 	android := pref.target_from('android', 'arm64') or { panic(err) }

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -27,36 +27,44 @@ fn test_bare_macro_preprocessor_conditions_use_target_and_definition_state() {
 	linux := pref.target_from('linux', 'amd64') or { panic(err) }
 	empty := map[string]bool{}
 	known_apple, active_apple := c_preprocessor_condition_state('__APPLE__', empty, empty, empty,
-		linux)
+		false, linux)
 	assert known_apple
 	assert !active_apple
 	known_unset, active_unset := c_preprocessor_condition_state('SOME_UNSET_MACRO', empty, empty,
-		empty, linux)
+		empty, false, linux)
 	assert known_unset
 	assert !active_unset
 	known_negated, active_negated := c_preprocessor_condition_state('!SOME_UNSET_MACRO', empty,
-		empty, empty, linux)
+		empty, empty, false, linux)
 	assert known_negated
 	assert active_negated
 	known_defined, active_defined := c_preprocessor_condition_state('SOME_DEFINED_MACRO', {
 		'SOME_DEFINED_MACRO': true
-	}, empty, empty, linux)
+	}, empty, empty, false, linux)
 	assert !known_defined
 	assert active_defined
 	known_negated_defined, active_negated_defined := c_preprocessor_condition_state('!FEATURE', {
 		'FEATURE': true
-	}, empty, empty, linux)
+	}, empty, empty, false, linux)
 	assert !known_negated_defined
 	assert active_negated_defined
 	known_presence, active_presence := c_preprocessor_condition_state('defined(FEATURE)', {
 		'FEATURE': true
-	}, empty, empty, linux)
+	}, empty, empty, false, linux)
 	assert known_presence
 	assert active_presence
 	known_compound, active_compound := c_preprocessor_condition_state('SOME_UNSET_MACRO || 1',
-		empty, empty, empty, linux)
+		empty, empty, empty, false, linux)
 	assert !known_compound
 	assert active_compound
+	known_external, active_external := c_preprocessor_condition_state('HEADER_FEATURE', empty,
+		empty, empty, true, linux)
+	assert !known_external
+	assert active_external
+	known_external_target, active_external_target := c_preprocessor_condition_state('__APPLE__',
+		empty, empty, empty, true, linux)
+	assert known_external_target
+	assert !active_external_target
 }
 
 fn test_termux_c_directive_target_is_distinct_from_android() {

--- a/vlib/v3/tests/c_flag_target_filter_codegen_test.v
+++ b/vlib/v3/tests/c_flag_target_filter_codegen_test.v
@@ -110,3 +110,51 @@ fn test_objective_c_flags_skip_tcc_and_select_objective_c_language() {
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == 'objc-flag-ok'
 }
+
+fn test_direct_objective_c_source_flag_skips_tcc() {
+	$if !macos {
+		return
+	}
+	pid := os.getpid()
+	root := os.join_path(os.vtmp_dir(), 'v3_direct_objective_c_source_${pid}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := os.join_path(root, 'v3_direct_objective_c_driver')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+	os.write_file(os.join_path(root, 'shim.m'), '@interface V3DirectObjectiveC
++ (int)answer;
+@end
+@implementation V3DirectObjectiveC
++ (int)answer { return 69; }
+@end
+int v3_direct_objective_c_answer(void) { return [V3DirectObjectiveC answer]; }
+') or {
+		panic(err)
+	}
+	source := os.join_path(root, 'main.v')
+	os.write_file(source, 'module main
+
+#flag @DIR/shim.m
+#flag darwin -lobjc
+
+fn C.v3_direct_objective_c_answer() int
+
+fn main() {
+	println(C.v3_direct_objective_c_answer())
+}
+') or {
+		panic(err)
+	}
+	output := os.join_path(root, 'direct_objective_c_source')
+	compile := os.execute('${v3_bin} -nocache -o ${output} ${source}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('tcc.exe'), compile.output
+	run := os.execute(output)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '69'
+}

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -6224,6 +6224,19 @@ fn test_imported_objective_cpp_wrapper_context() {
 	assert out == '68'
 }
 
+fn test_bare_macro_objective_c_guards_stay_inactive() {
+	v3_bin := build_v3()
+	result := run_good_project_result(v3_bin, 'bare_macro_objective_c_guards', '', {
+		'v.mod':       "Module { name: 'bare_macro_objective_c_guards' }\n"
+		'disabled.m':  '#error inactive Objective-C source must not be compiled\n'
+		'disabled.mm': '#error inactive Objective-C++ source must not be compiled\n'
+		'main.v':      'module main\n\n#if V3_NEVER_DEFINED_OBJECTIVE_C\n#include "disabled.m"\n#endif\n\n#if V3_NEVER_DEFINED_OBJECTIVE_CPP\n#include "disabled.mm"\n#endif\n\nfn main() {\n\tprintln(int_str(70))\n}\n'
+	}, 'main.v')
+	assert result.run_output == '70'
+	assert result.compile_output.contains('tcc.exe'), result.compile_output
+	assert !result.compile_output.contains('v3_native_source_context_'), result.compile_output
+}
+
 fn test_review_fixed_array_alias_clone_dispatch() {
 	v3_bin := build_v3()
 	out := run_good(v3_bin, 'fixed_array_alias_clone_dispatch', 'type FixedClone = [2]int

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -6252,14 +6252,16 @@ fn test_external_bare_macro_objective_c_guards_remain_possible() {
 	v3_bin := build_v3()
 	out := run_good_project_with_flags(v3_bin, 'external_bare_macro_objective_c_guards',
 		'-cc clang', {
-		'v.mod':     "Module { name: 'external_bare_macro_objective_c_guards' }\n"
-		'config.h':  '#define V3_HEADER_FEATURE 1\n'
-		'forced.h':  '#define V3_FORCED_FEATURE 1\n'
-		'active.m':  'static int answer_from_header_macro_guard(void) { return 2; }\n'
-		'active.mm': 'extern "C" int answer_from_forced_macro_guard(void) { auto answer = []() { return 70; }; return answer(); }\n'
-		'main.v':    'module main\n\n#flag -UV3_FORCED_FEATURE\n#flag -include @VMODROOT/forced.h\n\n#undef V3_HEADER_FEATURE\n#include "config.h"\n#if V3_HEADER_FEATURE\n#include "active.m"\n#endif\n\n#if V3_FORCED_FEATURE\n#include "active.mm"\n#endif\n\nfn C.answer_from_header_macro_guard() int\nfn C.answer_from_forced_macro_guard() int\n\nfn main() {\n\tprintln(int_str(C.answer_from_header_macro_guard() + C.answer_from_forced_macro_guard()))\n}\n'
+		'v.mod':           "Module { name: 'external_bare_macro_objective_c_guards' }\n"
+		'config.h':        '#define V3_HEADER_FEATURE 1\n'
+		'forced.h':        '#define V3_FORCED_FEATURE 1\n'
+		'source_defs.c':   '#define V3_SOURCE_FEATURE 1\n'
+		'active.m':        'static int answer_from_header_macro_guard(void) { return 2; }\n'
+		'active.mm':       'extern "C" int answer_from_forced_macro_guard(void) { auto answer = []() { return 70; }; return answer(); }\n'
+		'source_active.m': 'static int answer_from_source_macro_guard(void) { return 3; }\n'
+		'main.v':          'module main\n\n#flag -UV3_FORCED_FEATURE\n#flag -include @VMODROOT/forced.h\n\n#undef V3_HEADER_FEATURE\n#include "config.h"\n#if V3_HEADER_FEATURE\n#include "active.m"\n#endif\n\n#include "source_defs.c"\n#if V3_SOURCE_FEATURE\n#include "source_active.m"\n#endif\n\n#if V3_FORCED_FEATURE\n#include "active.mm"\n#endif\n\nfn C.answer_from_header_macro_guard() int\nfn C.answer_from_source_macro_guard() int\nfn C.answer_from_forced_macro_guard() int\n\nfn main() {\n\tprintln(int_str(C.answer_from_header_macro_guard() + C.answer_from_source_macro_guard() + C.answer_from_forced_macro_guard()))\n}\n'
 	}, 'main.v')
-	assert out == '72'
+	assert out == '75'
 }
 
 fn test_review_fixed_array_alias_clone_dispatch() {

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -6248,6 +6248,20 @@ fn test_valued_bare_macro_objective_c_guards_remain_possible() {
 	assert out == '71'
 }
 
+fn test_external_bare_macro_objective_c_guards_remain_possible() {
+	v3_bin := build_v3()
+	out := run_good_project_with_flags(v3_bin, 'external_bare_macro_objective_c_guards',
+		'-cc clang', {
+		'v.mod':     "Module { name: 'external_bare_macro_objective_c_guards' }\n"
+		'config.h':  '#define V3_HEADER_FEATURE 1\n'
+		'forced.h':  '#define V3_FORCED_FEATURE 1\n'
+		'active.m':  'static int answer_from_header_macro_guard(void) { return 2; }\n'
+		'active.mm': 'extern "C" int answer_from_forced_macro_guard(void) { auto answer = []() { return 70; }; return answer(); }\n'
+		'main.v':    'module main\n\n#flag -UV3_FORCED_FEATURE\n#flag -include @VMODROOT/forced.h\n\n#undef V3_HEADER_FEATURE\n#include "config.h"\n#if V3_HEADER_FEATURE\n#include "active.m"\n#endif\n\n#if V3_FORCED_FEATURE\n#include "active.mm"\n#endif\n\nfn C.answer_from_header_macro_guard() int\nfn C.answer_from_forced_macro_guard() int\n\nfn main() {\n\tprintln(int_str(C.answer_from_header_macro_guard() + C.answer_from_forced_macro_guard()))\n}\n'
+	}, 'main.v')
+	assert out == '72'
+}
+
 fn test_review_fixed_array_alias_clone_dispatch() {
 	v3_bin := build_v3()
 	out := run_good(v3_bin, 'fixed_array_alias_clone_dispatch', 'type FixedClone = [2]int

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -6124,9 +6124,10 @@ fn main() {
 	}, 'main.v')
 	assert inactive_objective_c_out == '60'
 	inactive_objective_cpp := run_good_project_result(v3_bin, 'inactive_objective_cpp_source', '', {
-		'v.mod':       "Module { name: 'inactive_objective_cpp_source' }\n"
-		'disabled.mm': '#error inactive Objective-C++ source must not be compiled\n'
-		'main.v':      'module main\n\n#if 0\n#include "disabled.mm"\n#endif\n\n#ifdef V3_NEVER_DEFINED_OBJECTIVE_CPP\n#include "disabled.mm"\n#endif\n\nfn main() {\n\tprintln(int_str(65))\n}\n'
+		'v.mod':        "Module { name: 'inactive_objective_cpp_source' }\n"
+		'disabled.mm':  '#error inactive Objective-C++ source must not be compiled\n'
+		'later_defs.c': '#define V3_NEVER_DEFINED_OBJECTIVE_CPP 1\n'
+		'main.v':       'module main\n\n#if 0\n#include "disabled.mm"\n#endif\n\n#ifdef V3_NEVER_DEFINED_OBJECTIVE_CPP\n#include "disabled.mm"\n#endif\n\n#include "later_defs.c"\n\nfn main() {\n\tprintln(int_str(65))\n}\n'
 	}, 'main.v')
 	assert inactive_objective_cpp.run_output == '65'
 	assert !inactive_objective_cpp.compile_output.contains('v3_native_source_context_'), inactive_objective_cpp.compile_output

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -6237,6 +6237,17 @@ fn test_bare_macro_objective_c_guards_stay_inactive() {
 	assert !result.compile_output.contains('v3_native_source_context_'), result.compile_output
 }
 
+fn test_valued_bare_macro_objective_c_guards_remain_possible() {
+	v3_bin := build_v3()
+	out := run_good_project_with_flags(v3_bin, 'valued_bare_macro_objective_c_guards', '-cc clang', {
+		'v.mod':     "Module { name: 'valued_bare_macro_objective_c_guards' }\n"
+		'active.m':  'static int answer_from_valued_m_guard(void) { return 1; }\n'
+		'active.mm': 'extern "C" int answer_from_valued_mm_guard(void) { auto answer = []() { return 70; }; return answer(); }\n'
+		'main.v':    'module main\n\n#flag -DV3_MM_FEATURE=0\n\n#define V3_M_FEATURE 0\n#if !V3_M_FEATURE\n#include "active.m"\n#endif\n\n#if !V3_MM_FEATURE\n#include "active.mm"\n#endif\n\nfn C.answer_from_valued_m_guard() int\nfn C.answer_from_valued_mm_guard() int\n\nfn main() {\n\tprintln(int_str(C.answer_from_valued_m_guard() + C.answer_from_valued_mm_guard()))\n}\n'
+	}, 'main.v')
+	assert out == '71'
+}
+
 fn test_review_fixed_array_alias_clone_dispatch() {
 	v3_bin := build_v3()
 	out := run_good(v3_bin, 'fixed_array_alias_clone_dispatch', 'type FixedClone = [2]int

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -158,7 +158,7 @@ fn prepare_c_flags_for_link(flags []string, c99 bool, pic_flag string, target_ar
 		}
 		i++
 	}
-	if c_link_flags_use_non_c_language(prepared) {
+	if c_link_flags_use_cpp_language(prepared) {
 		cpp_runtime := cpp_runtime_link_flag(target)
 		if cpp_runtime !in flags && cpp_runtime !in prepared {
 			prepared << cpp_runtime
@@ -184,6 +184,14 @@ fn c_generated_native_source_context(path string, build_dir string) bool {
 }
 
 fn c_link_flags_use_non_c_language(flags []string) bool {
+	return c_link_flags_use_language(flags, true)
+}
+
+fn c_link_flags_use_cpp_language(flags []string) bool {
+	return c_link_flags_use_language(flags, false)
+}
+
+fn c_link_flags_use_language(flags []string, include_objective_c bool) bool {
 	mut language := ''
 	mut skip_operand := false
 	mut i := 0
@@ -205,14 +213,20 @@ fn c_link_flags_use_non_c_language(flags []string) bool {
 			continue
 		}
 		if c_flag_is_c_source_file(clean) {
-			if language in ['c++', 'objective-c++'] {
+			if language in ['c++', 'objective-c++']
+				|| (include_objective_c && language == 'objective-c') {
 				return true
 			}
-			if language in ['', 'none'] && (clean.ends_with('.cc') || clean.ends_with('.cpp')) {
+			if language in ['', 'none'] && (clean.ends_with('.cc') || clean.ends_with('.cpp')
+				|| clean.ends_with('.mm')
+				|| (include_objective_c && clean.ends_with('.m'))) {
 				return true
 			}
-		} else if language in ['c++', 'objective-c++'] && c_flag_is_existing_file(clean) {
-			return true
+		} else if c_flag_is_existing_file(clean) {
+			if language in ['c++', 'objective-c++']
+				|| (include_objective_c && language == 'objective-c') {
+				return true
+			}
 		}
 		i++
 	}


### PR DESCRIPTION
Follow-up to #27828 addressing the final Codex review findings.

- evaluate bare identifier `#if` conditions through the existing target/macro-state logic, so definitely inactive `.m`/`.mm` includes do not enable Objective-C handling
- treat direct `.m` source flags as non-C for driver selection while keeping C++ runtime detection separate
- preserve explicit `-x c` overrides and conservative handling of compound preprocessor expressions
- add unit and end-to-end regressions for inactive bare-macro guards and direct Objective-C source flags

Validation:
- focused bare-macro unit and inactive `.m`/`.mm` project tests
- direct and explicit Objective-C driver tests
- consolidated post-merge review regression suite
- exact v3 self-host command
- 100/100 compile-only pass-list delta, zero ORM tests selected or run