### PR TITLE
gg: match native text measurement font

### DIFF
--- a/vlib/gg/gg_darwin.c.v
+++ b/vlib/gg/gg_darwin.c.v
@@ -8,6 +8,8 @@ fn C.darwin_draw_string(x i32, y i32, s string, cfg voidptr)
 
 fn C.darwin_text_width(s string) i32
 
+fn C.darwin_text_width_with_cfg(s string, cfg voidptr) i32
+
 fn C.darwin_text_width_runes(r []rune) i32
 
 fn C.darwin_window_refresh()

--- a/vlib/gg/gg_darwin.m
+++ b/vlib/gg/gg_darwin.m
@@ -222,12 +222,12 @@ static NSDictionary* darwin_measure_attrs(void) {
 	if (g_gg_force_mono) {
 		if (attrs_mono == nil) {
 			// Keep in sync with darwin_text_attrs: force-mono draws Menlo at size - 1.
-			attrs_mono = @{ NSFontAttributeName : [NSFont fontWithName:@"Menlo" size:15] };
+			attrs_mono = [@{ NSFontAttributeName : [NSFont fontWithName:@"Menlo" size:15] } copy];
 		}
 		return attrs_mono;
 	}
 	if (attrs == nil) {
-		attrs = @{ NSFontAttributeName : [NSFont userFontOfSize:16] };
+		attrs = [@{ NSFontAttributeName : [NSFont userFontOfSize:16] } copy];
 	}
 	return attrs;
 }

--- a/vlib/gg/gg_darwin.m
+++ b/vlib/gg/gg_darwin.m
@@ -211,6 +211,27 @@ void darwin_draw_string(int x, int y, string s, gg__TextCfg cfg) {
 	CFRelease(cf);
 }
 
+// Attributes used by darwin_text_width. Must match what darwin_draw_string
+// uses for default-size text (gg TextCfg.size defaults to 16): measuring with
+// nil attributes used 12pt Helvetica, so every measured width came out ~25%
+// short of what was actually drawn, and any layout built from per-chunk
+// text_width calls (absolutely positioned text runs) overlapped on screen.
+static NSDictionary* darwin_measure_attrs(void) {
+	static NSDictionary* attrs = nil;
+	static NSDictionary* attrs_mono = nil;
+	if (g_gg_force_mono) {
+		if (attrs_mono == nil) {
+			// Keep in sync with darwin_text_attrs: force-mono draws Menlo at size - 1.
+			attrs_mono = @{ NSFontAttributeName : [NSFont fontWithName:@"Menlo" size:15] };
+		}
+		return attrs_mono;
+	}
+	if (attrs == nil) {
+		attrs = @{ NSFontAttributeName : [NSFont userFontOfSize:16] };
+	}
+	return attrs;
+}
+
 int darwin_text_width(string s) {
 	// println('text_width "${s}" len=${s.len}')
 	NSString* n = @"";
@@ -225,15 +246,7 @@ int darwin_text_width(string s) {
 		}
 		n = (__bridge NSString*)cf;
 	}
-	/*
-	# if (!defaultFont){
-	# defaultFont = [NSFont userFontOfSize: ui__DEFAULT_FONT_SIZE];
-	# }
-	# NSDictionary *attrs = @{
-	# NSFontAttributeName: defaultFont,
-	# };
-	*/
-	NSSize size = [n sizeWithAttributes:nil];
+	NSSize size = [n sizeWithAttributes:darwin_measure_attrs()];
 	if (cf != nil) {
 		CFRelease(cf);
 	}

--- a/vlib/gg/gg_darwin.m
+++ b/vlib/gg/gg_darwin.m
@@ -232,7 +232,7 @@ static NSDictionary* darwin_measure_attrs(void) {
 	return attrs;
 }
 
-int darwin_text_width(string s) {
+static int darwin_text_width_with_attrs(string s, NSDictionary* attrs) {
 	// println('text_width "${s}" len=${s.len}')
 	NSString* n = @"";
 	CFStringRef cf = nil;
@@ -246,12 +246,20 @@ int darwin_text_width(string s) {
 		}
 		n = (__bridge NSString*)cf;
 	}
-	NSSize size = [n sizeWithAttributes:darwin_measure_attrs()];
+	NSSize size = [n sizeWithAttributes:attrs];
 	if (cf != nil) {
 		CFRelease(cf);
 	}
 	// # printf("!!!%f\n", ceil(size.width));
 	return (int)(ceil(size.width));
+}
+
+int darwin_text_width(string s) {
+	return darwin_text_width_with_attrs(s, darwin_measure_attrs());
+}
+
+int darwin_text_width_with_cfg(string s, gg__TextCfg cfg) {
+	return darwin_text_width_with_attrs(s, darwin_text_attrs(cfg));
 }
 
 void darwin_draw_rect(float x, float y, float width, float height, gg__Color c) {

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -246,7 +246,7 @@ pub fn (ctx &Context) draw_text(x int, y int, text_ string, cfg TextCfg) {
 	$if macos {
 		if ctx.native_rendering {
 			if cfg.align == align_right {
-				width := ctx.text_width(text_)
+				width := C.darwin_text_width_with_cfg(text_, cfg)
 				// println('draw text ctx.height = ${ctx.height}')
 				C.darwin_draw_string(x - width, ctx.height - y, text_, cfg)
 			} else {


### PR DESCRIPTION
## Summary

- measure native macOS text with the same 16-point user font used for default drawing
- keep forced-monospace measurements aligned with the 15-point Menlo drawing path
- cache both measurement attribute dictionaries

This prevents `text_width` from underreporting native-rendered widths and causing adjacent text runs to overlap.

## Testing

- `./vnew -silent test vlib/gg/text_rendering_test.v`
- `./vnew -o /tmp/v_gg_native_text_pr_check examples/gg/rectangles.v`