### PR TITLE
ci: cancel superseded workflow runs

### DIFF
--- a/.github/workflows/build_on_ubuntu_25_ci.yml
+++ b/.github/workflows/build_on_ubuntu_25_ci.yml
@@ -21,6 +21,10 @@ on:
       - 'cmd/tools/**'
       - '!cmd/tools/builders/**.v'
 
+concurrency:
+  group: ubuntu-25-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ubuntu-25-gcc-14-2-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/freebsd_ci.yml
+++ b/.github/workflows/freebsd_ci.yml
@@ -23,6 +23,10 @@ on:
       - '!ci/freebsd_ci.vsh'
       - '!cmd/tools/builders/**.v'
 
+concurrency:
+  group: freebsd-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 ### See https://github.com/cross-platform-actions/action
 ### for a description of the used fields here
 

--- a/.github/workflows/module_docs_lint.yml
+++ b/.github/workflows/module_docs_lint.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - '**/cmd/tools/vdoc/theme/**'
 
+concurrency:
+  group: module-docs-lint-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-module-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -23,6 +23,10 @@ on:
       - '!ci/openbsd_ci.vsh'
       - '!cmd/tools/builders/**.v'
 
+concurrency:
+  group: openbsd-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 ### See https://github.com/cross-platform-actions/action
 ### for a description of the used fields here
 

--- a/.github/workflows/periodic_ci.yml
+++ b/.github/workflows/periodic_ci.yml
@@ -12,6 +12,10 @@ on:
     paths:
       - '**/periodic_ci.yml'
 
+concurrency:
+  group: periodic-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   periodic-network:
     strategy:

--- a/.github/workflows/riscv64_linux_ci.yml
+++ b/.github/workflows/riscv64_linux_ci.yml
@@ -21,6 +21,10 @@ on:
       - 'cmd/tools/**'
       - '!cmd/tools/builders/**.v'
 
+concurrency:
+  group: riscv64-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   riscv64_linux:
     # The host should always be Linux

--- a/.github/workflows/s390x_linux_ci.yml
+++ b/.github/workflows/s390x_linux_ci.yml
@@ -21,6 +21,10 @@ on:
       - 'cmd/tools/**'
       - '!cmd/tools/builders/**.v'
 
+concurrency:
+  group: s390x-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   s390x_linux:
     # The host should always be Linux

--- a/.github/workflows/termux_ci.yml
+++ b/.github/workflows/termux_ci.yml
@@ -21,6 +21,10 @@ on:
       - 'cmd/tools/**'
       - '!cmd/tools/builders/**.v'
 
+concurrency:
+  group: termux-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   termux-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow_lint.yml
+++ b/.github/workflows/workflow_lint.yml
@@ -16,6 +16,10 @@ on:
     paths:
       - '**.yml'
 
+concurrency:
+  group: workflow-lint-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-yml-workflows:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This PR adds `concurrency.cancel-in-progress` to PR-triggered CI workflows that did not
cancel superseded runs yet.

The change keeps the existing triggers, jobs, and test coverage unchanged. It only allows
GitHub Actions to stop older runs for the same branch/PR when a newer commit is pushed.

Fixes #27836.

## Why

Several workflows already use this pattern, but a few PR-triggered workflows did not. Adding
it consistently should reduce stale CI work and queue pressure without removing coverage.

Updated workflows:

- `.github/workflows/build_on_ubuntu_25_ci.yml`
- `.github/workflows/freebsd_ci.yml`
- `.github/workflows/module_docs_lint.yml`
- `.github/workflows/openbsd_ci.yml`
- `.github/workflows/periodic_ci.yml`
- `.github/workflows/riscv64_linux_ci.yml`
- `.github/workflows/s390x_linux_ci.yml`
- `.github/workflows/termux_ci.yml`
- `.github/workflows/workflow_lint.yml`

## Validation

- Parsed all updated workflow files with PyYAML.
- Checked that each updated PR-triggered workflow now contains `cancel-in-progress: true`.
- Ran `git diff --check`.
- Ran an AI code review pass over the workflow diff; no findings.

`prettier --check` could not be completed locally because the local Corepack installation
failed before running Prettier with a package signature/key error. The repository's Workflow
Lint check should validate YAML formatting in CI.
