### PR TITLE
ci: skip Claude review without secrets

### DIFF
--- a/.github/workflows/claude_code_review.yml
+++ b/.github/workflows/claude_code_review.yml
@@ -33,8 +33,8 @@ concurrency:
 
 jobs:
   review:
-    # Skip draft PRs; the `ready_for_review` trigger picks them up later.
-    if: github.event.pull_request.draft == false
+    # Skip draft PRs, forks and Dependabot runs that cannot access repository secrets.
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

This PR skips the Claude Code Review job for PR contexts that cannot access repository
secrets.

It keeps the existing triggers and review behavior for normal same-repository PRs, but skips:

- draft PRs, as before;
- PRs from forks, which cannot access `ANTHROPIC_API_KEY`;
- Dependabot PRs, which also do not receive normal repository Actions secrets.

Fixes #27837.

## Why

The workflow already documents that fork PRs do not have access to repository secrets. When
the job still starts in unsupported contexts, it can fail before producing useful review
feedback and adds noise to PR checks.

## Validation

- Parsed `.github/workflows/claude_code_review.yml` with PyYAML.
- Ran `git diff --check`.
- Ran an AI code review pass over the workflow diff; no findings after adding the
  Dependabot guard.
