### PR TITLE
cgen: stop recursive sum type default expansion

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -13379,8 +13379,12 @@ fn (mut g Gen) type_default_sumtype(typ_ ast.Type, sym ast.TypeSymbol) string {
 	if sumtype_info.fields.len > 0 && !g.inside_global_decl && !g.inside_const {
 		// Route local defaults through the cast helper so common-field pointers stay valid.
 		fname := g.get_sumtype_casting_fn(first_typ, typ_)
-		// Reuse the shallow default when a variant refers back to this sum type.
-		mut first_default := if is_recursive { default_str } else { g.type_default(first_typ) }
+		// Reuse the shallow default when a non-sum variant refers back to this sum type.
+		mut first_default := if is_recursive && first_sym.kind != .sum_type {
+			default_str
+		} else {
+			g.type_default(first_typ)
+		}
 		if first_default[0] == `{` {
 			first_default = '(${first_styp})${first_default}'
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -332,14 +332,15 @@ mut:
 	veb_filter_fn_name   string   // veb__filter, used by $veb.html() for escaping strings in templates
 	export_funcs         []string // for .dll export function names
 	//
-	type_default_impl_level int
-	preinclude_nodes        []&ast.HashStmtNode // allows hash stmts to go before `includes`
-	include_nodes           []&ast.HashStmtNode // all hash stmts to go `includes`
-	definition_nodes        []&ast.HashStmtNode // allows hash stmts to go `definitions`
-	postinclude_nodes       []&ast.HashStmtNode // allows hash stmts to go after all the rest of the code generation
-	curr_comptime_node      ast.Expr = ast.empty_expr // current `$if` expr
-	is_builtin_overflow_mod bool
-	do_int_overflow_checks  bool // outside a `@[ignore_overflow] fn abc() {}` or a function in `builtin.overflow`
+	type_default_impl_level    int
+	type_default_sumtype_stack []int
+	preinclude_nodes           []&ast.HashStmtNode // allows hash stmts to go before `includes`
+	include_nodes              []&ast.HashStmtNode // all hash stmts to go `includes`
+	definition_nodes           []&ast.HashStmtNode // allows hash stmts to go `definitions`
+	postinclude_nodes          []&ast.HashStmtNode // allows hash stmts to go after all the rest of the code generation
+	curr_comptime_node         ast.Expr = ast.empty_expr // current `$if` expr
+	is_builtin_overflow_mod    bool
+	do_int_overflow_checks     bool // outside a `@[ignore_overflow] fn abc() {}` or a function in `builtin.overflow`
 	//
 	tid                  string // the thread id of the file processor in the thread pool (log it to debug issues in parallel cgen)
 	fid                  int    // the index of ast.File that is currently processed (log it to debug issues in parallel cgen)
@@ -13353,6 +13354,16 @@ fn (mut g Gen) type_default_sumtype(typ_ ast.Type, sym ast.TypeSymbol) string {
 	if typ_.has_flag(.option) {
 		return '(${g.styp(typ_)}){.state=2, .err=_const_none__, .data={E_STRUCT}}'
 	}
+	sumtype_idx := g.unwrap_generic(typ_).idx()
+	is_recursive := sumtype_idx in g.type_default_sumtype_stack
+	if !is_recursive {
+		g.type_default_sumtype_stack << sumtype_idx
+	}
+	defer {
+		if !is_recursive {
+			g.type_default_sumtype_stack.delete_last()
+		}
+	}
 	first_typ := g.unwrap_generic((sym.info as ast.SumType).variants[0])
 	first_sym := g.table.sym(first_typ)
 	first_styp := g.styp(first_typ)
@@ -13368,7 +13379,8 @@ fn (mut g Gen) type_default_sumtype(typ_ ast.Type, sym ast.TypeSymbol) string {
 	if sumtype_info.fields.len > 0 && !g.inside_global_decl && !g.inside_const {
 		// Route local defaults through the cast helper so common-field pointers stay valid.
 		fname := g.get_sumtype_casting_fn(first_typ, typ_)
-		mut first_default := g.type_default(first_typ)
+		// Reuse the shallow default when a variant refers back to this sum type.
+		mut first_default := if is_recursive { default_str } else { g.type_default(first_typ) }
 		if first_default[0] == `{` {
 			first_default = '(${first_styp})${first_default}'
 		}

--- a/vlib/v/tests/sumtype_default_common_field_test.v
+++ b/vlib/v/tests/sumtype_default_common_field_test.v
@@ -38,6 +38,21 @@ struct NestedHolder {
 	o NestedOuter
 }
 
+type RecursiveDefaultSum = RecursiveDefaultBranch | RecursiveDefaultLeaf
+
+struct RecursiveDefaultBranch {
+	x     int
+	child RecursiveDefaultSum
+}
+
+struct RecursiveDefaultLeaf {
+	x int
+}
+
+struct RecursiveDefaultHolder {
+	node RecursiveDefaultSum
+}
+
 fn test_default_sumtype_common_field_is_accessible() {
 	holder := DefaultHolder{}
 	assert holder.s.x == 0
@@ -46,4 +61,15 @@ fn test_default_sumtype_common_field_is_accessible() {
 fn test_default_nested_sumtype_common_field_is_accessible() {
 	holder := NestedHolder{}
 	assert holder.o.x == 0
+}
+
+fn test_recursive_default_sumtype_common_field_is_accessible() {
+	holder := RecursiveDefaultHolder{}
+	node := holder.node
+	assert node is RecursiveDefaultBranch
+	assert node.x == 0
+	if node is RecursiveDefaultBranch {
+		assert node.child is RecursiveDefaultBranch
+		assert node.child.x == 0
+	}
 }

--- a/vlib/v/tests/sumtype_default_common_field_test.v
+++ b/vlib/v/tests/sumtype_default_common_field_test.v
@@ -53,6 +53,27 @@ struct RecursiveDefaultHolder {
 	node RecursiveDefaultSum
 }
 
+type RecursiveNestedDefaultSum = RecursiveNestedDefaultInner | RecursiveNestedDefaultLeaf
+
+type RecursiveNestedDefaultInner = RecursiveNestedDefaultBranch | RecursiveNestedDefaultOther
+
+struct RecursiveNestedDefaultBranch {
+	x     int
+	child RecursiveNestedDefaultSum
+}
+
+struct RecursiveNestedDefaultOther {
+	x int
+}
+
+struct RecursiveNestedDefaultLeaf {
+	x int
+}
+
+struct RecursiveNestedDefaultHolder {
+	node RecursiveNestedDefaultSum
+}
+
 fn test_default_sumtype_common_field_is_accessible() {
 	holder := DefaultHolder{}
 	assert holder.s.x == 0
@@ -71,5 +92,19 @@ fn test_recursive_default_sumtype_common_field_is_accessible() {
 	if node is RecursiveDefaultBranch {
 		assert node.child is RecursiveDefaultBranch
 		assert node.child.x == 0
+	}
+}
+
+fn test_nested_recursive_default_sumtype_common_field_is_accessible() {
+	holder := RecursiveNestedDefaultHolder{}
+	node := holder.node
+	assert node is RecursiveNestedDefaultInner
+	assert node.x == 0
+	if node is RecursiveNestedDefaultInner {
+		assert node is RecursiveNestedDefaultBranch
+		if node is RecursiveNestedDefaultBranch {
+			assert node.child is RecursiveNestedDefaultInner
+			assert node.child.x == 0
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- track sum types while generating their default values
- reuse the shallow first-variant default when a recursive common-field sum type cycles back to itself
- add coverage for default common-field access through a recursive variant

Fixes #27834

## Tests

- `./vnew -silent vlib/v/tests/sumtype_default_common_field_test.v`
- vprism fixture suite from #27834 (1 passed)
- `./vnew -silent vlib/v/compiler_errors_test.v` (1591 passed, 1 skipped)
- `./vnew -silent vlib/v/gen/c/coutput_test.v` (224 passed, 17 platform skips)
- `./vnew -silent test vlib/v/` (2295 passed, 22 skipped; 2 unrelated generic-test failures: `generic_fn_short_syntax_struct_param_test.v` and `new_generics_regression_test.v`)