### PR TITLE
v3: restore parallel self-host cgen

### DIFF
--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -401,20 +401,12 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			work_items_ptr: unsafe { voidptr(&chunk_items[0]) }
 			is_master:      true
 		}
+		// Keep helper output in ordered result segments until the join so generated
+		// string IDs can be reconciled with literals emitted by the master chunk.
 		mut cgen_workers := []voidptr{cap: thread_count}
-		if g.scoped_fn_output_path.len > 0 {
-			for ci := 0; ci < thread_count; ci++ {
-				worker_path := '${g.scoped_fn_output_path}.${ci + 1}'
-				g.scoped_fn_output_paths << worker_path
-				os.rm(worker_path) or {}
-			}
-		}
 		worker_setup_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
 		for ci := 0; ci < thread_count; ci++ {
 			mut w := g.new_parallel_dispatch_worker(ci + 1)
-			if g.scoped_fn_output_path.len > 0 {
-				w.scoped_fn_output_path = g.scoped_fn_output_paths[ci + 1]
-			}
 			cgen_workers << voidptr(w)
 		}
 		for ci := 0; ci < thread_count; ci++ {
@@ -1022,22 +1014,130 @@ fn (g &FlatGen) clone_parallel_type_checker() &types.TypeChecker {
 	return wtc
 }
 
+fn (mut g FlatGen) publish_scoped_worker_string_literals(w &FlatGen) map[int]int {
+	mut remap := map[int]int{}
+	mut common_len := 0
+	for common_len < g.str_lits.len && common_len < w.str_lits.len
+		&& g.str_lits[common_len] == w.str_lits[common_len] {
+		common_len++
+	}
+	for local_id in common_len .. w.str_lits.len {
+		literal := w.str_lits[local_id]
+		global_id := if existing_id := g.str_lit_ids[literal] {
+			existing_id
+		} else {
+			g.intern_string(literal.clone())
+		}
+		if global_id != local_id {
+			remap[local_id] = global_id
+		}
+	}
+	return remap
+}
+
+fn remap_scoped_worker_string_symbols(source string, remap map[int]int) string {
+	if remap.len == 0 {
+		return source.clone()
+	}
+	mut out := strings.new_builder(source.len)
+	mut i := 0
+	for i < source.len {
+		if source[i] in [`"`, `'`] {
+			quote := source[i]
+			start := i
+			i++
+			for i < source.len {
+				if source[i] == `\\` && i + 1 < source.len {
+					i += 2
+					continue
+				}
+				i++
+				if source[i - 1] == quote {
+					break
+				}
+			}
+			out.write_string(source[start..i])
+			continue
+		}
+		if i + 1 < source.len && source[i] == `/` && source[i + 1] == `/` {
+			start := i
+			i += 2
+			for i < source.len && source[i] != `\n` {
+				i++
+			}
+			out.write_string(source[start..i])
+			continue
+		}
+		if i + 1 < source.len && source[i] == `/` && source[i + 1] == `*` {
+			start := i
+			i += 2
+			for i + 1 < source.len && !(source[i] == `*` && source[i + 1] == `/`) {
+				i++
+			}
+			if i + 1 < source.len {
+				i += 2
+			} else {
+				i = source.len
+			}
+			out.write_string(source[start..i])
+			continue
+		}
+		if c_identifier_start(source[i]) {
+			start := i
+			i++
+			for i < source.len && c_identifier_continue(source[i]) {
+				i++
+			}
+			identifier := source[start..i]
+			if cache_numbered_string_symbol(identifier) {
+				mut local_id := 0
+				for digit in identifier[5..].bytes() {
+					local_id = local_id * 10 + int(digit - `0`)
+				}
+				if global_id := remap[local_id] {
+					out.write_string('_str_${global_id}')
+					continue
+				}
+			}
+			out.write_string(identifier)
+			continue
+		}
+		out.write_u8(source[i])
+		i++
+	}
+	return out.str()
+}
+
 // merge_parallel_worker supports merge parallel worker handling for FlatGen.
 fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 	mut ww := unsafe { w }
 	if g.output_error.len == 0 && w.output_error.len > 0 {
 		g.output_error = w.output_error.clone()
 	}
+	string_id_remap := if g.scope_parallel_workers {
+		g.publish_scoped_worker_string_literals(w)
+	} else {
+		map[int]int{}
+	}
 	worker_output := ww.sb.str()
 	if worker_output.len > 0 {
-		g.fn_segs << worker_output
+		if string_id_remap.len > 0 {
+			g.fn_segs << remap_scoped_worker_string_symbols(worker_output, string_id_remap)
+			unsafe { worker_output.free() }
+		} else {
+			g.fn_segs << worker_output
+		}
 	} else {
 		unsafe { worker_output.free() }
 	}
 	// The ordered segment owns the copied output; release the worker builder.
 	unsafe { ww.sb.free() }
 	for segment in w.fn_segs {
-		g.fn_segs << segment.clone()
+		g.fn_segs << if string_id_remap.len > 0 {
+			remap_scoped_worker_string_symbols(segment, string_id_remap)
+		} else {
+			segment.clone()
+		}
 	}
 	for opt_name, val_type in w.needed_optional_types {
 		g.needed_optional_types[opt_name.clone()] = val_type.clone()
@@ -1066,7 +1166,11 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 		}
 	}
 	for def in w.spawn_wrapper_defs {
-		g.add_spawn_wrapper_def(def.clone())
+		g.add_spawn_wrapper_def(if string_id_remap.len > 0 {
+			remap_scoped_worker_string_symbols(def, string_id_remap)
+		} else {
+			def.clone()
+		})
 	}
 	for key, name in w.callback_wrapper_names {
 		if key !in g.callback_wrapper_names {
@@ -1074,7 +1178,11 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 		}
 	}
 	for def in w.callback_wrapper_defs {
-		g.add_callback_wrapper_def(def.clone())
+		g.add_callback_wrapper_def(if string_id_remap.len > 0 {
+			remap_scoped_worker_string_symbols(def, string_id_remap)
+		} else {
+			def.clone()
+		})
 	}
 }
 

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -739,7 +739,9 @@ fn (g &FlatGen) new_parallel_dispatch_worker(worker_id int) &FlatGen {
 
 // new_parallel_result_worker creates a non-emitting helper accumulator. Caches
 // that it only passes to fresh batch generators stay shared with the frozen
-// master snapshot; result tables remain private.
+// master snapshot; result tables remain private. Its string tables are copied
+// eagerly because the master can extend its own table after tasks start, before
+// a helper's first copy-on-write intern.
 fn (g &FlatGen) new_parallel_result_worker(worker_id int) &FlatGen {
 	return g.new_parallel_worker_config(worker_id, true)
 }
@@ -751,17 +753,21 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		used_fns:                       g.used_fns
 		used_fn_names:                  g.used_fn_names
 		test_files:                     if result_only { g.test_files } else { g.test_files.clone() }
-		str_lits:                       if result_only || g.scope_parallel_workers {
+		str_lits:                       if result_only {
+			clone_cgen_string_list(g.str_lits)
+		} else if g.scope_parallel_workers {
 			g.str_lits
 		} else {
 			g.str_lits.clone()
 		}
-		str_lit_ids:                    if result_only || g.scope_parallel_workers {
+		str_lit_ids:                    if result_only {
+			clone_cgen_string_int_map(g.str_lit_ids)
+		} else if g.scope_parallel_workers {
 			g.str_lit_ids
 		} else {
 			g.str_lit_ids.clone()
 		}
-		str_lits_shared:                g.scope_parallel_workers
+		str_lits_shared:                g.scope_parallel_workers && !result_only
 		global_types:                   g.global_types
 		global_raw_type_texts:          g.global_raw_type_texts
 		enum_vals:                      g.enum_vals

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -1035,7 +1035,7 @@ fn (mut g FlatGen) publish_scoped_worker_string_literals(w &FlatGen) map[int]int
 	return remap
 }
 
-fn remap_scoped_worker_string_symbols(source string, remap map[int]int) string {
+fn remap_scoped_worker_string_symbols(source string, remap map[int]int, user_c_symbols map[string]bool) string {
 	if remap.len == 0 {
 		return source.clone()
 	}
@@ -1089,7 +1089,7 @@ fn remap_scoped_worker_string_symbols(source string, remap map[int]int) string {
 				i++
 			}
 			identifier := source[start..i]
-			if cache_numbered_string_symbol(identifier) {
+			if cache_numbered_string_symbol(identifier) && !user_c_symbols[identifier] {
 				mut local_id := 0
 				for digit in identifier[5..].bytes() {
 					local_id = local_id * 10 + int(digit - `0`)
@@ -1119,10 +1119,16 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 	} else {
 		map[int]int{}
 	}
+	user_c_symbols := if string_id_remap.len > 0 {
+		g.cache_user_c_string_symbols()
+	} else {
+		map[string]bool{}
+	}
 	worker_output := ww.sb.str()
 	if worker_output.len > 0 {
 		if string_id_remap.len > 0 {
-			g.fn_segs << remap_scoped_worker_string_symbols(worker_output, string_id_remap)
+			g.fn_segs << remap_scoped_worker_string_symbols(worker_output, string_id_remap,
+				user_c_symbols)
 			unsafe { worker_output.free() }
 		} else {
 			g.fn_segs << worker_output
@@ -1134,7 +1140,7 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 	unsafe { ww.sb.free() }
 	for segment in w.fn_segs {
 		g.fn_segs << if string_id_remap.len > 0 {
-			remap_scoped_worker_string_symbols(segment, string_id_remap)
+			remap_scoped_worker_string_symbols(segment, string_id_remap, user_c_symbols)
 		} else {
 			segment.clone()
 		}
@@ -1167,7 +1173,7 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 	}
 	for def in w.spawn_wrapper_defs {
 		g.add_spawn_wrapper_def(if string_id_remap.len > 0 {
-			remap_scoped_worker_string_symbols(def, string_id_remap)
+			remap_scoped_worker_string_symbols(def, string_id_remap, user_c_symbols)
 		} else {
 			def.clone()
 		})
@@ -1179,7 +1185,7 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 	}
 	for def in w.callback_wrapper_defs {
 		g.add_callback_wrapper_def(if string_id_remap.len > 0 {
-			remap_scoped_worker_string_symbols(def, string_id_remap)
+			remap_scoped_worker_string_symbols(def, string_id_remap, user_c_symbols)
 		} else {
 			def.clone()
 		})

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -372,7 +372,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			g.scoped_fn_output_paths = [g.scoped_fn_output_path]
 			os.rm(g.scoped_fn_output_path) or {}
 		}
-		if g.scope_parallel_workers || n_items < min_flat_cgen_parallel_items || n_jobs <= 1 {
+		if n_items < min_flat_cgen_parallel_items || n_jobs <= 1 {
 			if g.scope_parallel_workers {
 				g.gen_fn_items_scoped_master_batches(items)
 			} else {
@@ -538,6 +538,9 @@ fn (mut g FlatGen) fn_item_cost_and_prep(node_id flat.NodeId, mut stack []flat.N
 		}
 		node := g.a.nodes[idx]
 		cost++
+		if node.kind == .string_literal {
+			g.intern_string(node.value)
+		}
 		if node.kind == .selector {
 			g.collect_c_extern_ref_from_node(node)
 		}

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -32,6 +32,13 @@ fn test_c_name_libc_collision_abs() {
 	assert c_name('C.abs') == 'abs'
 }
 
+fn test_c_name_generated_string_symbol_collision() {
+	assert c_name('_str_1') == 'v__str_1'
+	assert c_name('_str_002') == 'v__str_002'
+	assert c_name('_str_value') == '_str_value'
+	assert c_name('C._str_3') == '_str_3'
+}
+
 fn test_cgen_flattened_generic_receiver_short_variants() {
 	assert cgen_flattened_generic_receiver_short_variants('foo__Bar_baz__Qux') == [
 		'Bar_Qux',

--- a/vlib/v3/gen/c/naming/naming.v
+++ b/vlib/v3/gen/c/naming/naming.v
@@ -125,19 +125,31 @@ pub fn c_name(name string) string {
 		return 'v_exit'
 	}
 	if is_plain_identifier(name) {
-		if name in reserved_words || name in libc_collisions {
+		if name in reserved_words || name in libc_collisions || is_string_literal_symbol(name) {
 			return 'v_${name}'
 		}
 		return name
 	}
 	n := sanitize(name)
-	if n in reserved_words || n in libc_collisions {
+	if n in reserved_words || n in libc_collisions || is_string_literal_symbol(n) {
 		if name.contains('@') {
 			return '_v_${n}'
 		}
 		return 'v_${n}'
 	}
 	return n
+}
+
+fn is_string_literal_symbol(name string) bool {
+	if name.len <= 5 || !name.starts_with('_str_') {
+		return false
+	}
+	for i in 5 .. name.len {
+		if name[i] < `0` || name[i] > `9` {
+			return false
+		}
+	}
+	return true
 }
 
 // sanitize converts a V symbol or type spelling into a C identifier spelling

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -75,3 +75,24 @@ fn test_scoped_cgen_batch_preserves_worker_interned_literals() {
 	}
 	assert g.str_lits == ['source', 'generated_a', 'generated_b']
 }
+
+fn test_fused_parallel_prep_interns_body_string_literals() {
+	mut g, _ := parallel_worker_test_gen(false)
+	g.a.nodes = [
+		flat.Node{
+			kind:           .fn_decl
+			children_start: 0
+			children_count: 1
+		},
+		flat.Node{
+			kind:  .string_literal
+			value: 'worker literal'
+		},
+	]
+	g.a.children = [flat.NodeId(1)]
+	mut stack := []flat.NodeId{}
+	mut type_text_cache := map[string]bool{}
+	g.fn_item_cost_and_prep(0, mut stack, mut type_text_cache)
+	assert g.str_lits == ['worker literal']
+	assert g.str_lit_ids['worker literal'] == 0
+}

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -76,6 +76,29 @@ fn test_scoped_cgen_batch_preserves_worker_interned_literals() {
 	assert g.str_lits == ['source', 'generated_a', 'generated_b']
 }
 
+fn test_scoped_cgen_worker_merge_publishes_generated_literals() {
+	mut g, _ := parallel_worker_test_gen(true)
+	assert g.intern_string('source') == 0
+
+	mut helper := g.new_parallel_dispatch_worker(1)
+	mut helper_batch := helper.new_parallel_worker(0)
+	assert helper_batch.intern_string('helper generated') == 1
+	helper_batch.sb.write_string('helper(_str_1); "_str_1"; /* _str_1 */')
+	helper_batch.add_spawn_wrapper_def('spawn_helper(_str_1);')
+	helper.absorb_scoped_cgen_batch(helper_batch, false)
+
+	mut master_batch := g.new_parallel_worker(0)
+	assert master_batch.intern_string('master generated') == 1
+	master_batch.sb.write_string('master(_str_1);')
+	g.absorb_scoped_cgen_batch(master_batch, false)
+	g.merge_parallel_worker(helper)
+
+	assert g.str_lits == ['source', 'master generated', 'helper generated']
+	assert g.str_lit_ids['helper generated'] == 2
+	assert g.fn_segs == ['master(_str_1);', 'helper(_str_2); "_str_1"; /* _str_1 */']
+	assert g.spawn_wrapper_defs == ['spawn_helper(_str_2);']
+}
+
 fn test_fused_parallel_prep_interns_body_string_literals() {
 	mut g, _ := parallel_worker_test_gen(false)
 	g.a.nodes = [

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -25,6 +25,18 @@ fn test_parallel_dispatch_worker_shares_checker_as_scoped_accumulator() {
 	assert w.tc == tc
 }
 
+fn test_scoped_parallel_dispatch_worker_owns_string_snapshot() {
+	mut g, _ := parallel_worker_test_gen(true)
+	assert g.intern_string('source') == 0
+	mut w := g.new_parallel_dispatch_worker(1)
+	assert !w.str_lits_shared
+	assert w.intern_string('worker generated') == 1
+	assert g.str_lits == ['source']
+	assert g.intern_string('master generated') == 1
+	assert w.str_lits == ['source', 'worker generated']
+	assert g.str_lits == ['source', 'master generated']
+}
+
 fn test_parallel_checker_clone_preserves_sparse_transform_caches() {
 	g, mut tc := parallel_worker_test_gen(false)
 	tc.a.nodes = [flat.Node{

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -99,6 +99,19 @@ fn test_scoped_cgen_worker_merge_publishes_generated_literals() {
 	assert g.spawn_wrapper_defs == ['spawn_helper(_str_2);']
 }
 
+fn test_scoped_cgen_string_remap_preserves_user_c_identifiers() {
+	mut g, _ := parallel_worker_test_gen(true)
+	g.c_extern_refs['_str_999'] = true
+	g.c_extern_refs_ready = true
+	user_c_symbols := g.cache_user_c_string_symbols()
+	remap := {
+		1:   2
+		999: 1000
+	}
+	source := 'helper(_str_1); _str_999(); "_str_1"; /* _str_999 */'
+	assert remap_scoped_worker_string_symbols(source, remap, user_c_symbols) == 'helper(_str_2); _str_999(); "_str_1"; /* _str_999 */'
+}
+
 fn test_fused_parallel_prep_interns_body_string_literals() {
 	mut g, _ := parallel_worker_test_gen(false)
 	g.a.nodes = [

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -22,7 +22,7 @@ fn build_parallel_prod_v3() string {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_parallel_prod_cgen_test_${os.getpid()}')
 	os.rm(v3_bin) or {}
 	build :=
-		os.execute('${vexe} -gc none -prod -path "${parallel_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${parallel_v3_src}')
+		os.execute('${vexe} -gc none -prealloc -prod -path "${parallel_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${parallel_v3_src}')
 	assert build.exit_code == 0, build.output
 	return v3_bin
 }

--- a/vlib/v3/tests/review_cgen_regressions_test.v
+++ b/vlib/v3/tests/review_cgen_regressions_test.v
@@ -68,6 +68,29 @@ fn review_cgen_run_bad_project(v3_bin string, name string, files map[string]stri
 	assert !result.output.contains('C compilation failed'), '${name}: reached C compilation\n${result.output}'
 }
 
+fn test_numbered_string_identifiers_do_not_collide_with_literal_symbols() {
+	v3_bin := build_v3_review_cgen()
+	out := review_cgen_run_good(v3_bin, 'numbered_string_identifier_collision', 'struct Named {
+	_str_2 string
+}
+
+fn main() {
+	_str_1 := "local"
+	value := Named{
+		_str_2: "field"
+	}
+	println(_str_1 + ":" + value._str_2)
+}
+')
+	assert out == 'local:field'
+	c_code := os.read_file(os.join_path(os.temp_dir(), 'v3_numbered_string_identifier_collision.c')) or {
+		panic(err)
+	}
+	assert c_code.contains('string v__str_1 = '), c_code
+	assert c_code.contains('.v__str_2 = '), c_code
+	assert c_code.contains('value.v__str_2'), c_code
+}
+
 fn test_module_qualified_free_call_is_not_rewritten_to_array_intrinsic() {
 	v3_bin := build_v3_review_cgen()
 	out := review_cgen_run_good_project(v3_bin, 'module_qualified_free_call', {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -20311,7 +20311,10 @@ fn (tc &TypeChecker) non_file_scope_type(name string) ?Type {
 	if owner.belongs_to_scope(tc.file_scope) {
 		return none
 	}
-	return tc.cur_scope.lookup(name)
+	if owner.scope == unsafe { nil } || owner.index < 0 || owner.index >= owner.scope.types.len {
+		return none
+	}
+	return owner.scope.types[owner.index]
 }
 
 // resolve_expr resolves resolve expr information for types.

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1560,10 +1560,12 @@ fn main() {
 	// The cache generator emits complete module bodies, including late generic
 	// specializations that are not reachable from the entry program. Its split output
 	// currently relies on the serial function-item walk to retain those definitions.
+	// Compiler self-hosts skip generic lowering, so their cache split can still use cgen workers.
 	// Large generic user programs retain a substantially expanded AST after
 	// monomorphization. Stream them through the serial cgen path in preallocated
 	// builds so worker setup does not clone that retained state at the peak.
-	cache_no_parallel_cgen := current_no_parallel || cache_manager.enabled
+	cache_no_parallel_cgen := current_no_parallel
+		|| (cache_manager.enabled && !building_v && !cmd_v_build)
 		|| (scope_prealloc_stages && !building_v && !cmd_v_build)
 	mut p := parser.Parser.new(prefs)
 	if building_v || cmd_v_build {


### PR DESCRIPTION
## Summary

- restore parallel function-body codegen for scoped preallocated self-host builds
- allow cached compiler self-hosts to use cgen workers when generic lowering is skipped
- pre-intern body string literals during fused parallel preparation so worker output uses stable master IDs
- reuse the binding returned by `lookup_owner` instead of walking the scope chain twice
- cover optimized preallocated self-hosting and fused literal preparation

## Performance

Controlled three-run A/B medians on the same V3 self-host workload:

- cgen: 1220.75 ms -> 927.97 ms (24% faster)
- total: 2141.19 ms -> 1842.56 ms (14% faster)
- peak RSS remained approximately 721-723 MB

## Validation

- `./vnew -gc none vlib/v3/gen/c/parallel_worker_test.v`
- `./vnew -gc none -run-only test_parallel_transform_selfhost_builds_v3 vlib/v3/tests/parallel_cgen_test.v`
- `VFLAGS="-gc none" ./vnew -gc none -silent vlib/v/compiler_errors_test.v`
- formatting and `git diff --check`
