### PR TITLE
ci: add apt cache profiles

### DIFF
--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -1,5 +1,11 @@
 name: 'Cache Apt Packages'
-description: 'Cache all commonly used apt packages to speed up CI jobs'
+description: 'Cache apt packages by dependency profile to speed up CI jobs'
+
+inputs:
+  profile:
+    description: 'Dependency profile to cache: common, docs, db, graphics, sdl, sanitizers, or full'
+    required: false
+    default: 'full'
 
 # imagemagick              : convert, mogrify
 # xvfb                     : xvfb
@@ -13,18 +19,45 @@ description: 'Cache all commonly used apt packages to speed up CI jobs'
 runs:
   using: 'composite'
   steps:
+    - name: Select apt package profile
+      id: package-profile
+      shell: bash
+      env:
+        PROFILE: ${{ inputs.profile }}
+      run: |
+        set -euo pipefail
+        case "$PROFILE" in
+          common)
+            packages='expect binutils clang valgrind'
+            ;;
+          docs)
+            packages='sqlite3 libssl-dev libsqlite3-dev libx11-dev'
+            ;;
+          db)
+            packages='postgresql sqlite3 libpq-dev libssl-dev libsqlite3-dev'
+            ;;
+          graphics)
+            packages='imagemagick openimageio-tools xvfb xsel xclip libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev libx11-dev freeglut3-dev mesa-common-dev libgl1-mesa-dev libgl1-mesa-dri xfonts-75dpi xfonts-base'
+            ;;
+          sdl)
+            packages='libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-net-dev libpng-dev libsamplerate0-dev'
+            ;;
+          sanitizers)
+            packages='clang valgrind postgresql sqlite3 libpq-dev libssl-dev libsqlite3-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev'
+            ;;
+          full)
+            packages='expect binutils postgresql sqlite3 clang valgrind imagemagick openimageio-tools xvfb xsel xclip libsodium-dev libpq-dev libssl-dev libsqlite3-dev libfreetype6-dev libxi-dev libxcursor-dev libgl-dev libxrandr-dev libasound2-dev libx11-dev freeglut3-dev mesa-common-dev libgl1-mesa-dev libgl1-mesa-dri libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-net-dev libpng-dev libsamplerate0-dev xfonts-75dpi xfonts-base'
+            ;;
+          *)
+            echo "Unknown apt package profile: $PROFILE" >&2
+            exit 1
+            ;;
+        esac
+        echo "packages=$packages" >> "$GITHUB_OUTPUT"
     - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
       with:
-        version: 1.0
-        packages: expect binutils postgresql sqlite3 clang valgrind \
-          imagemagick openimageio-tools xvfb xsel xclip \
-          libsodium-dev libpq-dev libssl-dev libsqlite3-dev \
-          libfreetype6-dev libxi-dev libxcursor-dev \
-          libgl-dev libxrandr-dev libasound2-dev \
-          libx11-dev freeglut3-dev mesa-common-dev libgl1-mesa-dev libgl1-mesa-dri \
-          libsdl2-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-net-dev \
-          libpng-dev libsamplerate0-dev \
-          xfonts-75dpi xfonts-base
+        version: 1.0-${{ inputs.profile }}
+        packages: ${{ steps.package-profile.outputs.packages }}
     - name: Install common packages
-      run: echo "done installing packages"
+      run: echo "done installing ${{ inputs.profile }} apt packages"
       shell: bash

--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -31,7 +31,7 @@ runs:
             packages='expect binutils clang valgrind'
             ;;
           docs)
-            packages='sqlite3 libpq-dev libssl-dev libsqlite3-dev libx11-dev'
+            packages='sqlite3 libpq-dev libssl-dev libsqlite3-dev libx11-dev libxi-dev libxcursor-dev libegl-dev libgl-dev libxrandr-dev'
             ;;
           db)
             packages='postgresql sqlite3 libpq-dev libssl-dev libsqlite3-dev'

--- a/.github/actions/cache-apt-packages-action/action.yml
+++ b/.github/actions/cache-apt-packages-action/action.yml
@@ -31,7 +31,7 @@ runs:
             packages='expect binutils clang valgrind'
             ;;
           docs)
-            packages='sqlite3 libssl-dev libsqlite3-dev libx11-dev'
+            packages='sqlite3 libpq-dev libssl-dev libsqlite3-dev libx11-dev'
             ;;
           db)
             packages='postgresql sqlite3 libpq-dev libssl-dev libsqlite3-dev'

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -153,7 +153,7 @@ Available profiles:
 | Profile | Use for |
 | --- | --- |
 | `common` | General compiler/tooling jobs that need common command-line packages. |
-| `docs` | Markdown checks that compile examples using docs, db, SSL, or X11 deps. |
+| `docs` | Markdown checks that compile examples using docs, db, SSL, X11, or graphics deps. |
 | `db` | Jobs that need PostgreSQL, SQLite, or database development headers. |
 | `graphics` | Jobs that compile or run graphical, X11, OpenGL, or font-related examples. |
 | `sdl` | SDL-based workflows such as games or multimedia examples. |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -153,7 +153,7 @@ Available profiles:
 | Profile | Use for |
 | --- | --- |
 | `common` | General compiler/tooling jobs that need common command-line packages. |
-| `docs` | Markdown and documentation checks that compile examples using docs deps. |
+| `docs` | Markdown checks that compile examples using docs, db, SSL, or X11 deps. |
 | `db` | Jobs that need PostgreSQL, SQLite, or database development headers. |
 | `graphics` | Jobs that compile or run graphical, X11, OpenGL, or font-related examples. |
 | `sdl` | SDL-based workflows such as games or multimedia examples. |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -141,3 +141,25 @@ Current release and artifact exceptions that intentionally use floating runners:
   job assembles already-built artifacts and does not compile platform binaries.
 - `prebuilt.yml` uses `macos-latest` and `windows-latest` to smoke-test the
   published release ZIPs against GitHub's current hosted macOS and Windows images.
+
+## Apt package cache profiles
+
+Use `.github/actions/cache-apt-packages-action` with the smallest profile that covers
+the packages a job installs. Smaller profiles reduce cache restore time, cache size,
+and accidental coupling between unrelated workflows.
+
+Available profiles:
+
+| Profile | Use for |
+| --- | --- |
+| `common` | General compiler/tooling jobs that need common command-line packages. |
+| `docs` | Markdown and documentation checks that compile examples using docs deps. |
+| `db` | Jobs that need PostgreSQL, SQLite, or database development headers. |
+| `graphics` | Jobs that compile or run graphical, X11, OpenGL, or font-related examples. |
+| `sdl` | SDL-based workflows such as games or multimedia examples. |
+| `sanitizers` | Sanitizer jobs that need compiler, valgrind, db, and graphics deps. |
+| `full` | Compatibility default for jobs not migrated to a narrower profile yet. |
+
+When migrating a workflow, keep the job's explicit install step until CI proves the
+profile is sufficient. The cache action speeds up installs; it should not hide which
+packages the workflow actually needs.

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/cache-apt-packages-action
+        with:
+          profile: docs
       - name: Build V
         run: make
       - name: Install dependencies (some examples show how to use sqlite and the x11 clipboard)

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build V
         run: make
       - name: Install dependencies (some examples show how to use sqlite and the x11 clipboard)
-        run: ./v retry -- sudo apt install --quiet -y libx11-dev libssl-dev sqlite3 libsqlite3-dev
+        run: ./v retry -- sudo apt install --quiet -y libx11-dev libpq-dev libssl-dev sqlite3 libsqlite3-dev
       - name: Check markdown line length & code examples
         run: ./v check-md -hide-warnings .
         ## NB: -hide-warnings is used here, so that the output is less noisy,


### PR DESCRIPTION
## Summary

This PR adds dependency profiles to `.github/actions/cache-apt-packages-action`.

The action now accepts a `profile` input with these values:

- `common`
- `docs`
- `db`
- `graphics`
- `sdl`
- `sanitizers`
- `full`

The default remains `full`, which preserves the previous package set for all existing callers that have not been migrated yet. This PR migrates only `Docs CI` to `profile: docs` and documents the profiles in `.github/workflows/README.md`.

Fixes #27840.

## Why

The previous action always restored and installed the full shared apt package set, even for smaller jobs such as documentation checks. Profiles make dependency intent clearer and allow future workflows to opt into smaller cache artifacts gradually.

## Validation

- Ran `./vnew check-md .github/workflows/README.md`.
- Ran `git diff --check`.
- Parsed `.github/actions/cache-apt-packages-action/action.yml` and `.github/workflows/docs_ci.yml` with Ruby YAML.
- Ran two AI code review passes; the first found direct Bash input interpolation, which was fixed, and the second found no remaining issues.

`actionlint` was not available in the local environment. Full GitHub Actions behavior will be validated by CI.