### PR TITLE
ci: add shared setup-v action

### DIFF
--- a/.github/actions/setup-v/action.yml
+++ b/.github/actions/setup-v/action.yml
@@ -1,0 +1,63 @@
+name: 'Setup V'
+description: 'Build the V compiler and optionally symlink or inspect it'
+
+inputs:
+  make-args:
+    description: 'Arguments passed to make when building V'
+    required: false
+    default: '-j4'
+  symlink:
+    description: 'Run ./v symlink after building V'
+    required: false
+    default: 'true'
+  doctor:
+    description: 'Run ./v doctor after building V'
+    required: false
+    default: 'false'
+  version:
+    description: 'Run ./v version after building V'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Build V
+      shell: bash
+      env:
+        MAKE_ARGS: ${{ inputs.make-args }}
+        RUN_DOCTOR: ${{ inputs.doctor }}
+        RUN_SYMLINK: ${{ inputs.symlink }}
+        RUN_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        validate_bool_input() {
+          name="$1"
+          value="$2"
+          case "$value" in
+            true|false) ;;
+            *) echo "$name must be true or false" >&2; exit 1 ;;
+          esac
+        }
+
+        validate_bool_input symlink "$RUN_SYMLINK"
+        validate_bool_input doctor "$RUN_DOCTOR"
+        validate_bool_input version "$RUN_VERSION"
+
+        if [ -n "$MAKE_ARGS" ]; then
+          read -r -a make_args <<< "$MAKE_ARGS"
+          make "${make_args[@]}"
+        else
+          make
+        fi
+
+        if [ "$RUN_SYMLINK" = true ]; then
+          ./v symlink
+        fi
+        if [ "$RUN_DOCTOR" = true ]; then
+          ./v doctor
+        fi
+        if [ "$RUN_VERSION" = true ]; then
+          ./v version
+        fi

--- a/.github/workflows/toml_ci.yml
+++ b/.github/workflows/toml_ci.yml
@@ -7,12 +7,14 @@ on:
     paths:
       - 'vlib/**'
       - '!vlib/v3/**'
+      - '.github/actions/setup-v/**'
       - '**/toml_ci.yml'
       - '!**.md'
   pull_request:
     paths:
       - 'vlib/**'
       - '!vlib/v3/**'
+      - '.github/actions/setup-v/**'
       - '**/toml_ci.yml'
       - '!**.md'
 
@@ -26,8 +28,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
-      - name: Build V
-        run: make -j4 && ./v symlink
+      - uses: ./.github/actions/setup-v
       - name: Install dependencies
         run: |
           v retry -- v download https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64


### PR DESCRIPTION
## Summary

This PR introduces a local composite action for shared V setup logic:

- `.github/actions/setup-v/action.yml`

The action builds V with configurable `make` arguments and can optionally run:

- `./v symlink`
- `./v doctor`
- `./v version`

The default behavior is equivalent to the common inline pattern:

`make -j4 && ./v symlink`

This PR migrates only `toml_ci.yml` as the first low-risk consumer and adds `.github/actions/setup-v/**` to its path filters so future changes to the action self-test through TOML CI.

Fixes #27839.

## Why

Many workflows repeat small variations of checkout, V build, symlink, and optional inspection steps. A shared local action makes those steps easier to update consistently while allowing gradual migration workflow by workflow.

## Validation

- Parsed `.github/actions/setup-v/action.yml` and `.github/workflows/toml_ci.yml` with Ruby YAML.
- Ran `git diff --check`.
- Ran two AI code review passes; no findings.

Local Prettier could not run because Corepack fails with a package signature/key error before invoking Prettier. The repository's Workflow Lint check should validate YAML formatting in CI. Full action behavior will be validated by GitHub Actions.