### PR TITLE
v3: fix eval index or propagation

### DIFF
--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -4284,7 +4284,7 @@ fn (mut e Eval) eval_or_expr(node &flat.Node) !Value {
 fn (mut e Eval) eval_or_expr_flow(node &flat.Node) !FlowSignal {
 	left_id := e.child(node, 0)
 	left_node := e.node(left_id)
-	if left_node.kind == .index {
+	if left_node.kind == .index && left_node.value != 'range' {
 		container_signal := e.eval_expr_flow(e.child(left_node, 0))!
 		if container_signal.kind != .normal {
 			return container_signal

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -4310,7 +4310,11 @@ fn (mut e Eval) eval_or_expr_flow(node &flat.Node) !FlowSignal {
 		if !e.value_is_truthy(index) {
 			return e.eval_or_failure(node, index)
 		}
-		return value_flow(e.index_value(container, e.unwrap_option_like(index))!)
+		value := e.index_value(container, e.unwrap_option_like(index))!
+		if e.value_is_truthy(value) {
+			return value_flow(e.unwrap_option_like(value))
+		}
+		return e.eval_or_failure(node, value)
 	}
 	left_signal := e.eval_expr_flow(left_id)!
 	if left_signal.kind != .normal {

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -5785,6 +5785,9 @@ fn (e &Eval) cast_value_in_module(value Value, type_name string, module_name str
 		return e.enum_value(name, source)
 	}
 	if name.starts_with('?') {
+		if source is VoidValue {
+			return source
+		}
 		inner_type := name[1..]
 		data := if inner_type.len > 0 {
 			e.adapt_value_to_type_name(source, inner_type)

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -4302,6 +4302,15 @@ fn (mut e Eval) eval_or_expr_flow(node &flat.Node) !FlowSignal {
 			}
 			return e.eval_or_failure(node, container.default_value)
 		}
+		index_signal := e.eval_expr_flow(e.child(left_node, 1))!
+		if index_signal.kind != .normal {
+			return index_signal
+		}
+		index := flow_value(index_signal)
+		if !e.value_is_truthy(index) {
+			return e.eval_or_failure(node, index)
+		}
+		return value_flow(e.index_value(container, e.unwrap_option_like(index))!)
 	}
 	left_signal := e.eval_expr_flow(left_id)!
 	if left_signal.kind != .normal {

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -1086,6 +1086,27 @@ fn main() {
 	assert e.stdout() == '7\n'
 }
 
+fn test_eval_array_optional_element_or_uses_fallback() {
+	mut e := create()
+	e.run_text('
+fn maybe(value int) ?int {
+	if value == 0 {
+		return none
+	}
+	return value
+}
+
+fn main() {
+	arr := [maybe(0), maybe(3)]
+	println(int_str(arr[0] or { 7 }))
+	println(int_str(arr[1] or { 7 }))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '7\n3\n'
+}
+
 fn test_eval_postfix_index_target_evaluates_once() {
 	mut e := create()
 	e.run_text('

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -1100,6 +1100,26 @@ fn main() {
 	assert e.stdout() == '7\n3\n'
 }
 
+fn test_eval_range_index_or_uses_slice_path() {
+	mut e := create()
+	e.run_text('
+fn end(mut calls int) int {
+	calls++
+	return 3
+}
+
+fn main() {
+	mut calls := 0
+	s := "abcd"
+	println(s[1..end(mut calls)] or { "fallback" })
+	println(int_str(calls))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == 'bc\n1\n'
+}
+
 fn test_eval_postfix_index_target_evaluates_once() {
 	mut e := create()
 	e.run_text('

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -1089,15 +1089,8 @@ fn main() {
 fn test_eval_array_optional_element_or_uses_fallback() {
 	mut e := create()
 	e.run_text('
-fn maybe(value int) ?int {
-	if value == 0 {
-		return none
-	}
-	return value
-}
-
 fn main() {
-	arr := [maybe(0), maybe(3)]
+	arr := [?int(none), ?int(3)]
 	println(int_str(arr[0] or { 7 }))
 	println(int_str(arr[1] or { 7 }))
 }

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -10,8 +10,8 @@ fn test_c_name_sanitize_operator_overloads() {
 	assert c_name('Point.<=') == 'Point__le'
 	assert c_name('Point.>') == 'Point__gt'
 	assert c_name('Point.>=') == 'Point__ge'
-	assert c_name('Point.[]') == 'Point__index'
-	assert c_name('Point.[]=') == 'Point__index_set'
+	assert c_name('Point.[]') == 'Point__op_index'
+	assert c_name('Point.[]=') == 'Point__op_index_set'
 }
 
 fn test_c_name_sanitize_escaped_keywords() {


### PR DESCRIPTION
Fix V3 eval handling for array index expressions wrapped in an `or` block, including index assignment left-hand sides.

Evaluate the array index separately so option failure reaches the outer `or` block and control-flow signals propagate instead of converting `none` to an integer. Also align the C-name unit-test expectations with the current `[]` and `[]=` operator names.

Tests:
- `./vnew -silent test vlib/v3/eval/`
- `./vnew -silent vlib/v3/gen/c/names_test.v`
- `cd vlib/v3 && ../../v -gc none -prealloc -prod -o v3 v3.v && ./v3 -building-v -o v4 v3.v`

The measured V3 self-host stage completed in 4.04 s with live stage RSS at or below 586 MB. ORM tests were intentionally not run because they are handled separately.