### PR TITLE
v3: enforce memory limit throughout compilation

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -38,8 +38,10 @@ The command line rejects unknown options, missing option values, unsupported bac
 multiple input paths. `-cc <executable>` selects the C compiler and `-gc none` is the only
 currently supported collector mode. Directory builds read `subdirs` through the canonical
 `v.mod` parser, including when other manifest strings contain punctuation resembling fields.
-The driver checks current RSS after each compiler phase and exits when it reaches 10 GiB.
-Pass `-no-memory-limit`/`--no-memory-limit` to disable this safety limit.
+The driver monitors compiler memory throughout the build and exits when it reaches 10 GiB.
+On macOS it uses physical footprint, matching Activity Monitor more closely; elsewhere it uses
+current RSS. Pass `-no-memory-limit`/`--no-memory-limit` to disable this safety limit.
+On macOS, each stage benchmark prints physical footprint immediately after RSS.
 
 Generated C represents `thread` values with a typed wrapper around `pthread_t`. `spawn` uses the
 platform's default thread stack and checks allocation, thread creation, and join failures. Since

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -4,6 +4,7 @@ import runtime
 import time
 
 const default_memory_limit_kb = i64(10) * 1024 * 1024
+const memory_monitor_interval = 100 * time.millisecond
 
 // Step represents step data used by bench.
 pub struct Step {
@@ -22,6 +23,11 @@ pub:
 	name  string
 	value i64
 	unit  string
+}
+
+struct LimitMemory {
+	kb     i64
+	metric string
 }
 
 // Bench represents bench data used by bench.
@@ -48,9 +54,28 @@ pub fn new() Bench {
 	}
 }
 
-// disable_memory_limit disables the compiler RSS safety limit.
+// disable_memory_limit disables the compiler memory safety limit.
 pub fn (mut b Bench) disable_memory_limit() {
 	b.memory_limit_kb = 0
+}
+
+// start_memory_monitor starts the compiler memory safety watchdog.
+pub fn (b &Bench) start_memory_monitor() {
+	if b.memory_limit_kb > 0 {
+		spawn monitor_memory_limit(b.memory_limit_kb)
+	}
+}
+
+fn monitor_memory_limit(limit_kb i64) {
+	for {
+		time.sleep(memory_monitor_interval)
+		memory := current_limit_memory()
+		message := memory_limit_error(memory.kb, limit_kb, 'during compilation', memory.metric)
+		if message.len > 0 {
+			eprintln(message)
+			exit(1)
+		}
+	}
 }
 
 // step records a serial pipeline step.
@@ -65,13 +90,17 @@ pub fn (mut b Bench) step_parallel(name string, parallel bool) {
 	label := if parallel { '${name} (parallel)' } else { name }
 	ram_kb := current_rss_kb()
 	peak_ram_kb := peak_rss_kb()
-	message := memory_limit_error(ram_kb, b.memory_limit_kb, label)
-	if message.len > 0 {
-		eprintln(message)
-		exit(1)
+	memory := current_limit_memory()
+	if b.memory_limit_kb > 0 {
+		message := memory_limit_error(memory.kb, b.memory_limit_kb, 'after ${label}', memory.metric)
+		if message.len > 0 {
+			eprintln(message)
+			exit(1)
+		}
 	}
 	ram_mb := f64(ram_kb) / 1024.0
 	peak_ram_mb := f64(peak_ram_kb) / 1024.0
+	footprint_suffix := physical_footprint_suffix(memory)
 	ms := f64(elapsed_us) / 1000.0
 	allocations := current_allocation_stats()
 	allocation_count := allocations.allocation_count - b.last_allocation_count
@@ -82,7 +111,7 @@ pub fn (mut b Bench) step_parallel(name string, parallel bool) {
 	} else {
 		''
 	}
-	println('  ${label:-20s} ${ms:8.2f} ms   ${ram_mb:6.0f} MB RSS   ${peak_ram_mb:6.0f} MB peak${allocation_suffix}')
+	println('  ${label:-20s} ${ms:8.2f} ms   ${ram_mb:6.0f} MB RSS${footprint_suffix}   ${peak_ram_mb:6.0f} MB peak${allocation_suffix}')
 	b.steps << Step{
 		name:             label
 		time_us:          elapsed_us
@@ -98,13 +127,21 @@ pub fn (mut b Bench) step_parallel(name string, parallel bool) {
 	b.step_sw.restart()
 }
 
-fn memory_limit_error(ram_kb i64, limit_kb i64, step string) string {
-	if limit_kb <= 0 || ram_kb < limit_kb {
+fn physical_footprint_suffix(memory LimitMemory) string {
+	if memory.metric != 'physical footprint' {
 		return ''
 	}
-	ram_mb := ram_kb / 1024
+	footprint_mb := f64(memory.kb) / 1024.0
+	return '   ${footprint_mb:6.0f} MB physical footprint'
+}
+
+fn memory_limit_error(memory_kb i64, limit_kb i64, context string, metric string) string {
+	if limit_kb <= 0 || memory_kb < limit_kb {
+		return ''
+	}
+	memory_mb := memory_kb / 1024
 	limit_gib := limit_kb / (1024 * 1024)
-	return 'error: v3 compiler memory usage reached ${ram_mb} MiB RSS after ${step} ' +
+	return 'error: v3 compiler memory usage reached ${memory_mb} MiB ${metric} ${context} ' +
 		'(limit: ${limit_gib} GiB); use `-no-memory-limit` to disable this limit'
 }
 

--- a/vlib/v3/bench/bench_test.v
+++ b/vlib/v3/bench/bench_test.v
@@ -1,9 +1,15 @@
 module bench
 
-fn test_memory_limit_error_starts_at_limit() {
-	assert memory_limit_error(default_memory_limit_kb - 1, default_memory_limit_kb, 'parse') == ''
+import os
 
-	message := memory_limit_error(default_memory_limit_kb, default_memory_limit_kb, 'parse')
+const memory_monitor_test_child = 'V3_MEMORY_MONITOR_TEST_CHILD'
+
+fn test_memory_limit_error_starts_at_limit() {
+	assert memory_limit_error(default_memory_limit_kb - 1, default_memory_limit_kb, 'after parse',
+		'RSS') == ''
+
+	message := memory_limit_error(default_memory_limit_kb, default_memory_limit_kb, 'after parse',
+		'RSS')
 	assert message.contains('10240 MiB RSS after parse')
 	assert message.contains('limit: 10 GiB')
 	assert message.contains('`-no-memory-limit`')
@@ -11,7 +17,47 @@ fn test_memory_limit_error_starts_at_limit() {
 
 fn test_disable_memory_limit() {
 	mut b := new()
-	assert memory_limit_error(default_memory_limit_kb, b.memory_limit_kb, 'check') != ''
+	assert memory_limit_error(default_memory_limit_kb, b.memory_limit_kb, 'after check', 'RSS') != ''
 	b.disable_memory_limit()
-	assert memory_limit_error(default_memory_limit_kb, b.memory_limit_kb, 'check') == ''
+	assert memory_limit_error(default_memory_limit_kb, b.memory_limit_kb, 'after check', 'RSS') == ''
+}
+
+fn test_limit_memory_metric_is_available() {
+	memory := current_limit_memory()
+	assert memory.kb > 0
+	$if macos {
+		assert memory.metric == 'physical footprint'
+	} $else {
+		assert memory.metric == 'RSS'
+	}
+}
+
+fn test_physical_footprint_suffix_only_prints_physical_footprint() {
+	assert physical_footprint_suffix(LimitMemory{
+		kb:     2 * 1024
+		metric: 'physical footprint'
+	}).contains('2 MB physical footprint')
+	assert physical_footprint_suffix(LimitMemory{
+		kb:     2 * 1024
+		metric: 'RSS'
+	}) == ''
+}
+
+fn test_memory_monitor_exits_above_limit() {
+	if os.getenv(memory_monitor_test_child) == '1' {
+		monitor_memory_limit(1)
+		assert false
+		return
+	}
+	mut child := os.new_process(os.executable())
+	mut environment := os.environ()
+	environment[memory_monitor_test_child] = '1'
+	child.set_environment(environment)
+	child.set_redirect_stdio()
+	child.wait()
+	error_output := child.stderr_slurp()
+	child.close()
+	assert child.code == 1
+	assert error_output.contains('during compilation'), error_output
+	assert error_output.contains('limit: 0 GiB'), error_output
 }

--- a/vlib/v3/bench/limit_memory_darwin.c.v
+++ b/vlib/v3/bench/limit_memory_darwin.c.v
@@ -1,0 +1,34 @@
+module bench
+
+import os
+
+struct V3RusageInfo {
+	ri_uuid               [16]u8
+	ri_user_time          u64
+	ri_system_time        u64
+	ri_pkg_idle_wkups     u64
+	ri_interrupt_wkups    u64
+	ri_pageins            u64
+	ri_wired_size         u64
+	ri_resident_size      u64
+	ri_phys_footprint     u64
+	ri_proc_start_abstime u64
+	ri_proc_exit_abstime  u64
+}
+
+@[c_extern]
+fn C.proc_pid_rusage(pid int, flavor int, usage &V3RusageInfo) int
+
+fn current_limit_memory() LimitMemory {
+	mut usage := V3RusageInfo{}
+	if C.proc_pid_rusage(os.getpid(), 0, &usage) == 0 {
+		return LimitMemory{
+			kb:     i64(usage.ri_phys_footprint / 1024)
+			metric: 'physical footprint'
+		}
+	}
+	return LimitMemory{
+		kb:     current_rss_kb()
+		metric: 'RSS'
+	}
+}

--- a/vlib/v3/bench/limit_memory_default.c.v
+++ b/vlib/v3/bench/limit_memory_default.c.v
@@ -1,0 +1,8 @@
+module bench
+
+fn current_limit_memory() LimitMemory {
+	return LimitMemory{
+		kb:     current_rss_kb()
+		metric: 'RSS'
+	}
+}

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -180,6 +180,12 @@ fn test_driver_rejects_invalid_cli_and_parses_vmod_subdirs() {
 	c_output := os.join_path(root, 'hello.c')
 	c_compile := cmdexec.run(v3_bin, ['-no-memory-limit', '-o', c_output, source])
 	assert c_compile.exit_code == 0, c_compile.output
+	$if macos {
+		rss_index := c_compile.output.index('MB RSS') or { -1 }
+		footprint_index := c_compile.output.index('MB physical footprint') or { -1 }
+		assert rss_index >= 0, c_compile.output
+		assert footprint_index > rss_index, c_compile.output
+	}
 	c_source := os.read_file(c_output)!
 	assert c_source.len > 100
 	assert c_source.contains('typedef signed char i8;')

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -641,7 +641,7 @@ fn cli_usage() string {
 		'  -cc <compiler>               C compiler executable\n' +
 		'  -prod -c99 -shared -strict  C build modes\n' +
 		'  -v                           verbose stage profiling\n' +
-		'  -no-memory-limit             disable the 10 GiB RSS safety limit\n' +
+		'  -no-memory-limit             disable the 10 GiB memory safety limit\n' +
 		'  -d <name>                    compile-time define'
 }
 
@@ -1518,6 +1518,7 @@ fn main() {
 	if no_memory_limit {
 		b.disable_memory_limit()
 	}
+	b.start_memory_monitor()
 	mut c_object_cache_stats := CObjectCacheStats{}
 	println('=== v3 benchmark ===')
 


### PR DESCRIPTION
## Summary

- monitor compiler memory every 100 ms instead of only at phase boundaries
- use physical footprint on macOS so the limit matches Activity Monitor more closely, with RSS as the fallback elsewhere
- print macOS physical footprint immediately after RSS in default stage benchmark lines
- preserve `-no-memory-limit` and cover the watchdog with a subprocess regression test

## Tests

- `./vnew -silent test vlib/v3/bench/`
- `./vnew -silent vlib/v3/tests/driver_cli_test.v`
- `./vnew check-md vlib/v3/README.md`
- built v3 and compiled/ran `examples/hello_world.v`, confirming physical-footprint stage output
- generated the bench test C source for a Linux target