### PR TITLE
pkgconfig: support static linking

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -39,6 +39,8 @@ jobs:
       - uses: ./.github/actions/cache-apt-packages-action
       - name: Build v
         run: make -j4 && ./v symlink
+      - name: Pkg-config regression (TCC dynamic isolation)
+        run: ./v -cc tcc -no-retry-compilation test vlib/v/checker/pkgconfig_static_mode_test.v
       - name: Build v with -prealloc
         run: v run ci/linux_ci.vsh build_v_with_prealloc
       - name: All code is formatted
@@ -98,6 +100,17 @@ jobs:
       - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
         run: make -j4 && ./v symlink
+      - name: Pkg-config regressions (GCC)
+        run: |
+          set -euo pipefail
+          for test in \
+            vlib/v/pkgconfig/pkgconfig_static_test.v \
+            vlib/v/checker/pkgconfig_static_mode_test.v \
+            vlib/v/checker/pkgconfig_cross_compile_test.v \
+            vlib/v/builder/pkgconfig_link_segment_test.v
+          do
+            ./v -cc gcc -no-retry-compilation test "$test"
+          done
       - name: All code is formatted
         run: v run ci/linux_ci.vsh all_code_is_formatted_gcc
       - name: Install dependencies for examples and tools
@@ -613,6 +626,17 @@ jobs:
       - uses: ./.github/actions/cache-apt-packages-action
       - name: Build V
         run: make -j4 && ./v symlink
+      - name: Pkg-config regressions (Clang)
+        run: |
+          set -euo pipefail
+          for test in \
+            vlib/v/pkgconfig/pkgconfig_static_test.v \
+            vlib/v/checker/pkgconfig_static_mode_test.v \
+            vlib/v/checker/pkgconfig_cross_compile_test.v \
+            vlib/v/builder/pkgconfig_link_segment_test.v
+          do
+            ./v -cc clang -no-retry-compilation test "$test"
+          done
       - name: All code is formatted
         run: v run ci/linux_ci.vsh all_code_is_formatted_clang
       - name: Install dependencies for examples and tools

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -48,6 +48,17 @@ jobs:
             brew-${{ matrix.os }}-
       - name: Build V
         run: make -j4 && ./v symlink
+      - name: Pkg-config regressions (Clang, no static executable)
+        run: |
+          set -euo pipefail
+          for test in \
+            vlib/v/pkgconfig/pkgconfig_static_test.v \
+            vlib/v/checker/pkgconfig_static_mode_test.v \
+            vlib/v/checker/pkgconfig_cross_compile_test.v \
+            vlib/v/builder/pkgconfig_link_segment_test.v
+          do
+            ./v -cc clang -no-retry-compilation test "$test"
+          done
       - name: Legacy gg import multiwindow isolation
         run: ./v test vlib/gg/legacy_import_multiwindow_isolation_test.v
       - name: Prepare multiwindow process-tree watchdog

--- a/.github/workflows/windows_ci_gcc.yml
+++ b/.github/workflows/windows_ci_gcc.yml
@@ -59,6 +59,22 @@ jobs:
           .\makev.bat -gcc
           .\v.exe symlink
           .\v.exe -stats vlib/crypto/ecdsa/ecdsa_test.v
+      - name: Pkg-config regressions (GCC)
+        run: |
+          $tests = @(
+            'vlib\v\pkgconfig\pkgconfig_define_prefix_test.v'
+            'vlib\v\pkgconfig\pkgconfig_define_prefix_compile_test.v'
+            'vlib\v\pkgconfig\pkgconfig_static_test.v'
+            'vlib\v\checker\pkgconfig_static_mode_test.v'
+            'vlib\v\checker\pkgconfig_cross_compile_test.v'
+            'vlib\v\builder\pkgconfig_link_segment_test.v'
+          )
+          foreach ($test in $tests) {
+            .\v.exe -cc gcc -no-retry-compilation test $test
+            if ($LASTEXITCODE -ne 0) {
+              throw "pkg-config regression failed for $test with exit code $LASTEXITCODE"
+            }
+          }
       - name: Legacy gg import multiwindow isolation
         run: v -cc gcc test vlib/gg/legacy_import_multiwindow_isolation_test.v
       - name: Test v binaries

--- a/.github/workflows/windows_ci_msvc.yml
+++ b/.github/workflows/windows_ci_msvc.yml
@@ -57,6 +57,20 @@ jobs:
           echo $VFLAGS
           .\makev.bat -msvc
           .\v.exe symlink
+      - name: Pkg-config regressions (MSVC dynamic isolation)
+        run: |
+          $tests = @(
+            'vlib\v\pkgconfig\pkgconfig_static_test.v'
+            'vlib\v\checker\pkgconfig_static_mode_test.v'
+            'vlib\v\checker\pkgconfig_cross_compile_test.v'
+            'vlib\v\builder\pkgconfig_link_segment_test.v'
+          )
+          foreach ($test in $tests) {
+            .\v.exe -cc msvc -no-retry-compilation test $test
+            if ($LASTEXITCODE -ne 0) {
+              throw "pkg-config regression failed for $test with exit code $LASTEXITCODE"
+            }
+          }
       - name: Legacy gg import multiwindow isolation
         run: v -cc msvc test vlib/gg/legacy_import_multiwindow_isolation_test.v
       - name: Prepare multiwindow Job Object watchdog

--- a/.github/workflows/windows_ci_tcc.yml
+++ b/.github/workflows/windows_ci_tcc.yml
@@ -42,6 +42,12 @@ jobs:
         run: |
           .\makev.bat -tcc
           .\v.exe symlink
+      - name: Pkg-config regression (TCC dynamic isolation)
+        run: |
+          .\v.exe -cc tcc -no-retry-compilation test vlib\v\checker\pkgconfig_static_mode_test.v
+          if ($LASTEXITCODE -ne 0) {
+            throw "pkg-config TCC isolation regression failed with exit code $LASTEXITCODE"
+          }
       - name: All code is formatted
         run: v -silent test-cleancode
       - name: Test new v.c

--- a/vlib/v/ast/cflags.v
+++ b/vlib/v/ast/cflags.v
@@ -5,6 +5,14 @@ module ast
 
 import v.cflag
 
+const allowed_cflag_names = ['framework', 'library', 'Wa', 'Wl', 'Wp', 'I', 'l', 'L', 'D']
+
+struct CFlagInput {
+	original string
+	flag     string
+	os       string
+}
+
 // check if cflag is in table
 pub fn (t &Table) has_cflag(flag cflag.CFlag) bool {
 	for cf in t.cflags {
@@ -15,10 +23,7 @@ pub fn (t &Table) has_cflag(flag cflag.CFlag) bool {
 	return false
 }
 
-// parse the flags to (ast.cflags) []CFlag
-// Note: clean up big time (joe-c)
-pub fn (mut t Table) parse_cflag(cflg string, mod string, ctimedefines []string) ! {
-	allowed_flags := ['framework', 'library', 'Wa', 'Wl', 'Wp', 'I', 'l', 'L', 'D']
+fn prepare_cflag_input(cflg string, ctimedefines []string) !CFlagInput {
 	flag_orig := cflg.trim_space()
 	mut flag := flag_orig
 	if flag == '' {
@@ -39,43 +44,115 @@ pub fn (mut t Table) parse_cflag(cflg string, mod string, ctimedefines []string)
 		fos = flag[..pos].trim_space()
 		flag = flag[pos..].trim_space()
 	}
-	for {
-		mut name := ''
-		mut value := ''
-		if flag[0] == `-` {
-			for f in allowed_flags {
-				i := 1 + f.len
-				if i <= flag.len && f == flag[1..i] {
-					name = flag[..i].trim_space()
-					flag = flag[i..].trim_space()
-					break
-				}
-			}
-		}
-		// -I/usr/local/a b c/include -m64 -I/usr/include
-		index := flag.index_(' -')
-		if index > -1 {
-			value = flag[..index].trim_space()
-			flag = flag[index..].trim_space()
-		} else {
-			value = flag
-		}
+	return CFlagInput{
+		original: flag_orig
+		flag:     flag
+		os:       fos
+	}
+}
 
-		if name in ['-I', '-l', '-L'] && value == '' {
-			hint := if name == '-l' { 'library name' } else { 'path' }
-			return error('bad #flag `${flag_orig}`: missing ${hint} after `${name}`')
+fn cflag_name_end(flag string) int {
+	if flag.len == 0 || flag[0] != `-` {
+		return 0
+	}
+	for name in allowed_cflag_names {
+		end := 1 + name.len
+		if end <= flag.len && name == flag[1..end] {
+			return end
 		}
-		cf := cflag.CFlag{
-			mod:   mod
-			os:    fos
-			name:  name
-			value: value
+	}
+	return 0
+}
+
+fn parse_cflag_fragment(fragment string, original string, mod string, fos string) !cflag.CFlag {
+	name_end := cflag_name_end(fragment)
+	name := fragment[..name_end].trim_space()
+	value := fragment[name_end..].trim_space()
+	if name in ['-I', '-l', '-L'] && value == '' {
+		hint := if name == '-l' { 'library name' } else { 'path' }
+		return error('bad #flag `${original}`: missing ${hint} after `${name}`')
+	}
+	return cflag.CFlag{
+		mod:   mod
+		os:    fos
+		name:  name
+		value: value
+	}
+}
+
+fn parse_cflags(cflg string, mod string, ctimedefines []string) ![]cflag.CFlag {
+	input := prepare_cflag_input(cflg, ctimedefines)!
+	mut flag := input.flag
+	mut parsed := []cflag.CFlag{}
+	for {
+		// -I/usr/local/a b c/include -m64 -I/usr/include
+		name_end := cflag_name_end(flag)
+		value := flag[name_end..].trim_space()
+		index := value.index_(' -')
+		if index > -1 {
+			fragment := flag[..name_end] + value[..index]
+			parsed << parse_cflag_fragment(fragment, input.original, mod, input.os)!
+			flag = value[index..].trim_space()
+			continue
 		}
+		parsed << parse_cflag_fragment(flag, input.original, mod, input.os)!
+		break
+	}
+	return parsed
+}
+
+fn (mut t Table) add_unique_cflags(parsed []cflag.CFlag) []cflag.CFlag {
+	mut added := []cflag.CFlag{cap: parsed.len}
+	for cf in parsed {
 		if !t.has_cflag(cf) {
 			t.cflags << cf
+			added << cf
 		}
-		if index == -1 {
-			break
+	}
+	return added
+}
+
+// parse the flags to (ast.cflags) []CFlag
+// Note: clean up big time (joe-c)
+pub fn (mut t Table) parse_cflag(cflg string, mod string, ctimedefines []string) ! {
+	t.add_unique_cflags(parse_cflags(cflg, mod, ctimedefines)!)
+}
+
+// parse_cflag_with_link_segment keeps the source position of ordinary flags available
+// when a static pkg-config directive requires a unified linker stream.
+pub fn (mut t Table) parse_cflag_with_link_segment(cflg string, mod string, ctimedefines []string) ! {
+	parsed := parse_cflags(cflg, mod, ctimedefines)!
+	t.add_unique_cflags(parsed)
+	if parsed.len > 0 {
+		t.link_flag_segments << LinkFlagSegment{
+			flags: parsed
 		}
+	}
+}
+
+// parse_pkgconfig_link_flags anchors structured linker fragments at the current
+// source position, including repeated libraries and positional linker controls.
+pub fn (mut t Table) parse_pkgconfig_link_flags(fragments []string, mod string, ctimedefines []string) ! {
+	mut parsed := []cflag.CFlag{cap: fragments.len}
+	mut i := 0
+	for i < fragments.len {
+		fragment := fragments[i]
+		if fragment in ['-L', '-l'] {
+			if i + 1 >= fragments.len || fragments[i + 1].trim_space() == '' {
+				hint := if fragment == '-l' { 'library name' } else { 'path' }
+				return error('bad #flag `${fragment}`: missing ${hint} after `${fragment}`')
+			}
+			input := prepare_cflag_input(fragment + fragments[i + 1], ctimedefines)!
+			parsed << parse_cflag_fragment(input.flag, input.original, mod, input.os)!
+			i += 2
+			continue
+		}
+		input := prepare_cflag_input(fragment, ctimedefines)!
+		parsed << parse_cflag_fragment(input.flag, input.original, mod, input.os)!
+		i++
+	}
+	t.link_flag_segments << LinkFlagSegment{
+		is_pkgconfig: true
+		flags:        parsed
 	}
 }

--- a/vlib/v/ast/cflags_test.v
+++ b/vlib/v/ast/cflags_test.v
@@ -69,6 +69,86 @@ fn test_parse_invalid_cflags() {
 	assert t.cflags.len == 0
 }
 
+fn test_parse_cflag_with_link_segment_preserves_occurrences_and_global_uniqueness() {
+	mut t := ast.new_table()
+	controls := '-Wl,--whole-archive -Wl,--no-whole-archive'
+	expected := [
+		make_flag(no_os, '-Wl', ',--whole-archive'),
+		make_flag(no_os, '-Wl', ',--no-whole-archive'),
+	]
+	t.parse_cflag_with_link_segment(controls, module_name, cdefines) or { panic(err) }
+	t.parse_cflag_with_link_segment(controls, module_name, cdefines) or { panic(err) }
+
+	assert t.cflags == expected
+	assert t.link_flag_segments.len == 2
+	assert t.link_flag_segments.all(!it.is_pkgconfig && it.flags == expected)
+
+	mut legacy := ast.new_table()
+	legacy.parse_cflag(controls, module_name, cdefines) or { panic(err) }
+	legacy.parse_cflag(controls, module_name, cdefines) or { panic(err) }
+	assert legacy.cflags == expected
+	assert legacy.link_flag_segments == []
+}
+
+fn test_parse_pkgconfig_link_flags_preserves_structured_boundaries_and_repetition() {
+	mut t := ast.new_table()
+	fragments := ['-L/issue74/structured-boundary', '/issue74/structured-boundary/libissue74_b.a',
+		'/issue74/structured-boundary/libissue74_a.a', '/issue74/structured-boundary/libissue74_b.a']
+	t.parse_pkgconfig_link_flags(fragments, module_name, cdefines) or { panic(err) }
+	assert t.cflags == []
+	assert t.link_flag_segments.len == 1
+	segment := t.link_flag_segments[0]
+	assert segment.is_pkgconfig
+	assert segment.flags == [
+		make_flag(no_os, '-L', '/issue74/structured-boundary'),
+		make_flag(no_os, no_name, '/issue74/structured-boundary/libissue74_b.a'),
+		make_flag(no_os, no_name, '/issue74/structured-boundary/libissue74_a.a'),
+		make_flag(no_os, no_name, '/issue74/structured-boundary/libissue74_b.a'),
+	]
+}
+
+fn test_parse_pkgconfig_link_flags_preserves_quoted_hyphenated_paths() {
+	mut t := ast.new_table()
+	t.parse_pkgconfig_link_flags(['-L"/tmp/search - libs"', '"/tmp/direct - libs/lib x.a"'],
+		module_name, cdefines) or { panic(err) }
+	assert t.cflags == []
+	assert t.link_flag_segments.len == 1
+	segment := t.link_flag_segments[0]
+	assert segment.is_pkgconfig
+	assert segment.flags == [
+		make_flag(no_os, '-L', '"/tmp/search - libs"'),
+		make_flag(no_os, no_name, '"/tmp/direct - libs/lib x.a"'),
+	]
+}
+
+fn test_parse_pkgconfig_link_flags_consumes_split_library_operands() {
+	mut t := ast.new_table()
+	t.parse_pkgconfig_link_flags(['-Wl,--start-group', '-L', '"/tmp/search - libs"', '-l',
+		'"issue74 - static"', '-Wl,--end-group'], module_name, cdefines) or { panic(err) }
+	assert t.cflags == []
+	assert t.link_flag_segments.len == 1
+	segment := t.link_flag_segments[0]
+	assert segment.is_pkgconfig
+	assert segment.flags == [
+		make_flag(no_os, '-Wl', ',--start-group'),
+		make_flag(no_os, '-L', '"/tmp/search - libs"'),
+		make_flag(no_os, '-l', '"issue74 - static"'),
+		make_flag(no_os, '-Wl', ',--end-group'),
+	]
+}
+
+fn test_parse_pkgconfig_link_flags_rejects_missing_split_library_operands() {
+	for fragment in ['-L', '-l'] {
+		mut t := ast.new_table()
+		t.parse_pkgconfig_link_flags([fragment], module_name, cdefines) or {
+			assert err.msg().contains('missing')
+			assert t.link_flag_segments == []
+			continue
+		}
+		assert false
+	}
+}
+
 fn parse_valid_flag(mut t ast.Table, flag string) {
 	t.parse_cflag(flag, module_name, cdefines) or {}
 }

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -60,6 +60,13 @@ pub fn (mut uf UsedFeatures) free() {
 	}
 }
 
+pub struct LinkFlagSegment {
+pub:
+	is_pkgconfig bool
+pub mut:
+	flags []cflag.CFlag
+}
+
 @[heap; minify]
 pub struct Table {
 mut:
@@ -74,6 +81,7 @@ pub mut:
 	modules                     []string       // Topologically sorted list of all modules registered by the application
 	global_scope                &Scope = unsafe { nil }
 	cflags                      []cflag.CFlag
+	link_flag_segments          []LinkFlagSegment
 	redefined_fns               []string
 	fn_generic_types            map[string][][]Type // for generic functions
 	structured_receiver_methods map[string][]Fn
@@ -139,6 +147,10 @@ pub fn (mut t Table) free() {
 		t.imports.free()
 		t.modules.free()
 		t.cflags.free()
+		for mut segment in t.link_flag_segments {
+			segment.flags.free()
+		}
+		t.link_flag_segments.free()
 		t.redefined_fns.free()
 		t.fn_generic_types.free()
 		t.cmod_prefix.free()

--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -4,6 +4,7 @@ import os
 import time
 import v.util
 import v.builder
+import v.pref
 import sync.pool
 import v.gen.c
 
@@ -26,6 +27,22 @@ fn parallel_cc_uses_tcc(cc_kind builder.CC, ccompiler string) bool {
 	normalized := ccompiler.replace('\\', '/').to_lower()
 	return normalized == 'tcc' || normalized.ends_with('/tcc') || normalized.ends_with('/tcc.exe')
 		|| normalized.contains('/thirdparty/tcc/')
+}
+
+fn parallel_cc_shell_safe_linker_arg(arg string) string {
+	if arg in ['-Wl,-(', '-Wl,-)'] {
+		return os.quoted_path(arg)
+	}
+	return arg
+}
+
+fn parallel_cc_compile_driver_args(compile_args []string, pkgconfig_pthread bool, cc_kind builder.CC, compiler_type pref.CompilerType) []string {
+	mut projected := compile_args.clone()
+	if pkgconfig_pthread && (cc_kind in [.gcc, .clang] || compiler_type == .cplusplus)
+		&& !projected.any(pref.contains_exact_cflag_token(it, '-pthread')) {
+		projected << '-pthread'
+	}
+	return projected
 }
 
 fn parallel_cc(mut b builder.Builder, result c.GenOutput) ! {
@@ -121,9 +138,11 @@ fn parallel_cc(mut b builder.Builder, result c.GenOutput) ! {
 			linker_args << tcc_l_arg
 		}
 	}
-	scompile_args := compile_args.join(' ')
-	slinker_args := linker_args.join(' ')
 	scompile_args_for_linker := compile_args.filter(it != '-x objective-c').join(' ')
+	compile_args = parallel_cc_compile_driver_args(compile_args, b.has_pkgconfig_pthread(),
+		b.ccoptions.cc, b.pref.ccompiler_type)
+	scompile_args := compile_args.join(' ')
+	slinker_args := linker_args.map(parallel_cc_shell_safe_linker_arg(it)).join(' ')
 
 	mut o_postfixes := ['0', 'x']
 	mut cmds := []string{}

--- a/vlib/v/builder/cbuilder/parallel_cc_test.v
+++ b/vlib/v/builder/cbuilder/parallel_cc_test.v
@@ -7,3 +7,50 @@ fn test_parallel_cc_uses_tcc_for_resolved_compiler_paths() {
 	assert parallel_cc_uses_tcc(.unknown, 'D:\\a\\v\\v\\thirdparty\\tcc\\tcc.exe')
 	assert !parallel_cc_uses_tcc(.unknown, '/usr/bin/clang')
 }
+
+fn test_parallel_cc_projects_pkgconfig_pthread_once() {
+	for projected in [
+		parallel_cc_compile_driver_args(['-DISSUE74_COMPILE_ONLY'], true, .gcc, .gcc),
+		parallel_cc_compile_driver_args(['-DISSUE74_COMPILE_ONLY'], true, .clang, .clang),
+		parallel_cc_compile_driver_args(['-DISSUE74_COMPILE_ONLY'], true, .unknown, .cplusplus),
+	] {
+		assert projected == ['-DISSUE74_COMPILE_ONLY', '-pthread']
+		assert projected.count(it == '-pthread') == 1
+	}
+	assert parallel_cc_compile_driver_args(['-pthread'], true, .gcc, .gcc) == [
+		'-pthread',
+	]
+}
+
+fn test_parallel_cc_does_not_project_pkgconfig_pthread_for_unsupported_compilers() {
+	compile_args := ['-DISSUE74_COMPILE_ONLY', '-Wno-issue74-unrelated']
+	assert parallel_cc_compile_driver_args(compile_args, true, .tcc, .tinyc) == compile_args
+	assert parallel_cc_compile_driver_args(compile_args, true, .msvc, .msvc) == compile_args
+	assert parallel_cc_compile_driver_args(compile_args, true, .unknown, .tinyc) == compile_args
+}
+
+fn test_parallel_cc_does_not_duplicate_combined_cflags_pthread() {
+	combined_cflags := '-DISSUE74_CFLAGS=1 -pthread'
+	assert parallel_cc_compile_driver_args([combined_cflags], true, .gcc, .gcc) == [
+		combined_cflags,
+	]
+}
+
+fn test_parallel_cc_does_not_duplicate_combined_environment_cflags_pthread() {
+	combined_cflags := '-DISSUE74_ENV_CFLAGS=1 -pthread'
+	assert parallel_cc_compile_driver_args([combined_cflags], true, .gcc, .gcc) == [
+		combined_cflags,
+	]
+}
+
+fn test_parallel_cc_does_not_project_ldflags_pthread() {
+	assert parallel_cc_compile_driver_args(['-DISSUE74_COMPILE_ONLY'], false, .gcc, .gcc) == [
+		'-DISSUE74_COMPILE_ONLY',
+	]
+}
+
+fn test_parallel_cc_does_not_project_environment_ldflags_pthread() {
+	assert parallel_cc_compile_driver_args(['-DISSUE74_COMPILE_ONLY'], false, .gcc, .gcc) == [
+		'-DISSUE74_COMPILE_ONLY',
+	]
+}

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -580,6 +580,8 @@ pub enum CC {
 }
 
 pub struct CcompilerOptions {
+mut:
+	pkgconfig_pthread bool // exact `-pthread` supplied by an ordered pkg-config linker segment
 pub mut:
 	guessed_compiler string
 	shared_postfix   string // .so, .dll
@@ -717,6 +719,169 @@ fn cc_from_pref_ccompiler_type(cc_type pref.CompilerType) CC {
 		.msvc { .msvc }
 		.cplusplus { .unknown }
 	}
+}
+
+fn ordered_link_cflag_key(flag cflag.CFlag) string {
+	return '${flag.os}\x00${flag.name}\x00${flag.value}'
+}
+
+fn quote_spaced_ordered_pkgconfig_operand(flag cflag.CFlag, preserve_msvc_slash_option bool) cflag.CFlag {
+	value := flag.value
+	is_quoted := value.len >= 2 && ((value[0] == `"` && value[value.len - 1] == `"`)
+		|| (value[0] == `'` && value[value.len - 1] == `'`))
+	is_msvc_slash_option := preserve_msvc_slash_option && flag.name == '' && value.starts_with('/')
+		&& value.contains(':')
+	if is_msvc_slash_option {
+		colon_index := value.index(':') or { return flag }
+		option_name := value[1..colon_index]
+		operand := value[colon_index + 1..]
+		is_operand_quoted := operand.len >= 2
+			&& ((operand[0] == `"` && operand[operand.len - 1] == `"`)
+			|| (operand[0] == `'` && operand[operand.len - 1] == `'`))
+		if option_name != '' && option_name.bytes().all(it.is_alnum())
+			&& operand.contains_any(' \t\r\n') && !is_operand_quoted {
+			return cflag.CFlag{
+				mod:    flag.mod
+				os:     flag.os
+				name:   flag.name
+				value:  '${value[..colon_index + 1]}"${operand}"'
+				cached: flag.cached
+			}
+		}
+		return flag
+	}
+	is_raw_operand := flag.name == '' && !is_msvc_slash_option
+	if (flag.name != '-L' && !is_raw_operand) || !value.contains_any(' \t\r\n') || is_quoted {
+		return flag
+	}
+	return cflag.CFlag{
+		mod:    flag.mod
+		os:     flag.os
+		name:   flag.name
+		value:  '"${value}"'
+		cached: flag.cached
+	}
+}
+
+fn generic_ordered_pkgconfig_flag(flag cflag.CFlag) cflag.CFlag {
+	value := flag.value
+	if flag.name != '-L' || value.len <= 2 || value[0] != `"` || value[value.len - 1] != `"` {
+		return flag
+	}
+	return cflag.CFlag{
+		mod:    flag.mod
+		os:     flag.os
+		name:   flag.name
+		value:  value[1..value.len - 1]
+		cached: flag.cached
+	}
+}
+
+fn ordered_pkgconfig_link_args(flag cflag.CFlag, convert_windows_import_libs bool) []string {
+	if flag.name == '-Wl' && flag.value.contains_any(' \t\r\n') {
+		formatted := flag.format() or { return []string{} }
+		return ['"${formatted}"']
+	}
+	raw_safe_flag := quote_spaced_ordered_pkgconfig_operand(flag, false)
+	if convert_windows_import_libs {
+		return raw_safe_flag.windows_import_lib_link_args()
+	}
+	formatted_flag := generic_ordered_pkgconfig_flag(raw_safe_flag)
+	return [formatted_flag.format() or { return []string{} }]
+}
+
+fn ordinary_flag_is_linker_control(flag cflag.CFlag) bool {
+	raw := flag.value.trim_space()
+	return flag.name in ['-L', '-Wl', '-framework', '-library'] || raw == '-Xlinker'
+		|| raw.starts_with('-Xlinker ') || raw == '-force_load' || raw.starts_with('-force_load ')
+		|| raw == '-weak_framework' || raw.starts_with('-weak_framework ')
+}
+
+fn ordinary_flag_takes_linker_operand(flag cflag.CFlag) bool {
+	raw := flag.value.trim_space()
+	return (flag.name == '' && raw in ['-Xlinker', '-force_load', '-weak_framework'])
+		|| (flag.name == '-Wl'
+		&& raw in [',-rpath', ',--rpath', ',-R', ',-rpath-link', ',--rpath-link', ',--version-script'])
+}
+
+fn ordered_ordinary_link_args(flag cflag.CFlag, force_linker bool) []string {
+	if force_linker {
+		return [flag.format() or { return []string{} }]
+	}
+	_, others, libs := [flag].defines_others_libs()
+	if libs.len > 0 {
+		return libs
+	}
+	if ordinary_flag_is_linker_control(flag) {
+		return others
+	}
+	return []string{}
+}
+
+fn (v &Builder) split_ordered_pkgconfig_link_flags(cflags []cflag.CFlag) ([]cflag.CFlag, []string, bool) {
+	mut has_pkgconfig_segment := false
+	for segment in v.table.link_flag_segments {
+		if segment.is_pkgconfig {
+			has_pkgconfig_segment = true
+			break
+		}
+	}
+	if !has_pkgconfig_segment {
+		return cflags, []string{}, false
+	}
+	mut active_cflags := map[string]bool{}
+	for flag in cflags {
+		active_cflags[ordered_link_cflag_key(flag)] = true
+	}
+	mut routed_cflags := map[string]bool{}
+	mut ordered_link_flags := []string{}
+	mut pkgconfig_pthread := false
+	mut pending_linker_option := ''
+	convert_windows_import_libs := v.pref.os == .windows && v.pref.ccompiler_type in [.gcc, .mingw]
+	for segment in v.table.link_flag_segments {
+		if segment.is_pkgconfig {
+			if pending_linker_option != '' {
+				verror('incomplete linker option `${pending_linker_option}` before `#pkgconfig`; provide its operand in the next ordinary `#flag` directive before the pkg-config directive')
+			}
+			for flag in segment.flags {
+				args := ordered_pkgconfig_link_args(flag, convert_windows_import_libs)
+				for arg in args {
+					ordered_link_flags << arg
+					if arg == '-pthread' {
+						pkgconfig_pthread = true
+					}
+				}
+			}
+			continue
+		}
+		for flag in segment.flags {
+			key := ordered_link_cflag_key(flag)
+			if key !in active_cflags {
+				continue
+			}
+			force_linker := pending_linker_option != ''
+			pending_linker_option = ''
+			if !force_linker && ordinary_flag_takes_linker_operand(flag) {
+				pending_linker_option = flag.format() or { flag.value.trim_space() }
+			}
+			args := ordered_ordinary_link_args(flag, force_linker)
+			if args.len == 0 {
+				continue
+			}
+			routed_cflags[key] = true
+			ordered_link_flags << args
+		}
+	}
+	if pending_linker_option != '' {
+		verror('incomplete linker option `${pending_linker_option}` at the end of ordered linker flags; provide its operand in the next ordinary `#flag` directive')
+	}
+	mut legacy_cflags := []cflag.CFlag{cap: cflags.len}
+	for flag in cflags {
+		if ordered_link_cflag_key(flag) !in routed_cflags {
+			legacy_cflags << flag
+		}
+	}
+	return legacy_cflags, ordered_link_flags, pkgconfig_pthread
 }
 
 fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
@@ -1080,10 +1245,14 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 		ccoptions.o_args << only_o_files
 	}
 
-	defines, others, libs := cflags.defines_others_libs()
+	legacy_cflags, ordered_link_flags, pkgconfig_pthread :=
+		v.split_ordered_pkgconfig_link_flags(cflags)
+	defines, others, libs := legacy_cflags.defines_others_libs()
 	ccoptions.pre_args << defines
 	ccoptions.pre_args << others
 	ccoptions.linker_flags << libs
+	ccoptions.linker_flags << ordered_link_flags
+	ccoptions.pkgconfig_pthread = pkgconfig_pthread
 	v.fixup_tcc_macos_comma_path_flags(mut ccoptions)
 	if v.pref.use_cache && v.pref.build_mode != .build_module {
 		if ccoptions.cc != .tcc {
@@ -1150,6 +1319,10 @@ pub fn (v &Builder) get_compile_args() []string {
 	return v.only_compile_args(v.ccoptions)
 }
 
+pub fn (v &Builder) has_pkgconfig_pthread() bool {
+	return v.ccoptions.pkgconfig_pthread
+}
+
 fn (v &Builder) only_compile_args(ccoptions CcompilerOptions) []string {
 	mut all := []string{}
 	all << ccoptions.env_cflags
@@ -1178,6 +1351,12 @@ fn (v &Builder) only_compile_args(ccoptions CcompilerOptions) []string {
 	all << ccoptions.pre_args
 	all << ccoptions.source_args
 	all << ccoptions.post_args
+	if ccoptions.pkgconfig_pthread
+		&& (ccoptions.cc in [.gcc, .clang] || v.pref.ccompiler_type == .cplusplus)
+		&& (v.pref.is_o || (v.pref.build_mode == .build_module && !v.pref.is_shared))
+		&& !all.any(pref.contains_exact_cflag_token(it, '-pthread')) {
+		all << '-pthread'
+	}
 	return all
 }
 
@@ -1389,6 +1568,13 @@ fn (v &Builder) rsp_safe_arg(arg string) string {
 	return arg
 }
 
+fn shell_safe_cc_arg(arg string) string {
+	if arg in ['-Wl,-(', '-Wl,-)'] {
+		return os.quoted_path(arg)
+	}
+	return arg
+}
+
 fn (v &Builder) should_use_rsp(rsp_args []string) bool {
 	if v.pref.no_rsp || v.pref.os == .termux {
 		return false
@@ -1523,13 +1709,14 @@ fn (mut v Builder) generate_c_project() {
 	}
 	v.dump_c_options(all_args)
 	cc_cmd := '${v.quote_compiler_name(ccompiler)} ${all_args.join(' ')}'
+	posix_cc_cmd := '${v.quote_compiler_name(ccompiler)} ${all_args.map(shell_safe_cc_arg(it)).join(' ')}'
 	os.write_file(os.join_path(project_dir, 'build_command.txt'), cc_cmd + '\n') or {
 		verror('Cannot write ${os.quoted_path(os.join_path(project_dir, 'build_command.txt'))}: ${err}')
 	}
-	os.write_file(os.join_path(project_dir, 'Makefile'), 'all:\n\t${cc_cmd}\n') or {
+	os.write_file(os.join_path(project_dir, 'Makefile'), 'all:\n\t${posix_cc_cmd}\n') or {
 		verror('Cannot write ${os.quoted_path(os.join_path(project_dir, 'Makefile'))}: ${err}')
 	}
-	os.write_file(os.join_path(project_dir, 'build.sh'), '#!/bin/sh\nset -eu\n${cc_cmd}\n') or {
+	os.write_file(os.join_path(project_dir, 'build.sh'), '#!/bin/sh\nset -eu\n${posix_cc_cmd}\n') or {
 		verror('Cannot write ${os.quoted_path(os.join_path(project_dir, 'build.sh'))}: ${err}')
 	}
 	os.write_file(os.join_path(project_dir, 'build.bat'), '@echo off\r\n${cc_cmd}\r\n') or {
@@ -1751,12 +1938,11 @@ pub fn (mut v Builder) cc() {
 		v.dump_c_options(all_args)
 		mut rsp_args := all_args.map(v.rsp_safe_arg(it))
 		rsp_args = rsp_args.map(v.tcc_windows_path_arg(it))
-		shell_args := rsp_args.join(' ')
 		mut should_use_rsp := v.should_use_rsp(rsp_args)
 		mut str_args := if !should_use_rsp {
-			shell_args.replace('\n', ' ')
+			rsp_args.map(shell_safe_cc_arg(it)).join(' ').replace('\n', ' ')
 		} else {
-			shell_args
+			rsp_args.join(' ')
 		}
 		mut cmd := '${v.quote_compiler_name(ccompiler)} ${str_args}'
 		if v.pref.parallel_cc {

--- a/vlib/v/builder/cc_test.v
+++ b/vlib/v/builder/cc_test.v
@@ -166,6 +166,53 @@ fn test_resolve_ccompiler_type_detects_cc_alias_path_as_clang() {
 	assert resolve_ccompiler_type(alias_cc, pref.cc_from_string(alias_cc)) == .clang
 }
 
+fn test_resolved_tcc_wrapper_recomputes_pkgconfig_mode_as_dynamic() {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v_builder_cc_pkgconfig_tcc_${os.getpid()}')
+	alias_cc := prepare_test_ccompiler_alias(test_root, 'cc', 'tcc version 0.9.27 (x86_64 Linux)')
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	mut full_args := ['']
+	full_args << ['-cc', alias_cc, '-cflags', '-static', hello_world_example()]
+	mut prefs, _ := pref.parse_args_and_show_errors([], full_args, false)
+	assert prefs.ccompiler_type == .gcc
+	assert prefs.pkgconfig_mode == .static_
+
+	resolve_ccompiler_type_and_pkgconfig_mode(mut prefs)
+
+	assert prefs.ccompiler_type == .tinyc
+	assert prefs.pkgconfig_mode == .dynamic
+}
+
+fn test_resolved_gnu_wrappers_keep_pkgconfig_mode_static() {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v_builder_cc_pkgconfig_gnu_${os.getpid()}')
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	for version_output, expected_type in {
+		'gcc (GCC) 13.2.0':             pref.CompilerType.gcc
+		'OpenBSD clang version 16.0.6': pref.CompilerType.clang
+	} {
+		alias_cc := prepare_test_ccompiler_alias(test_root, 'cc', version_output)
+		mut full_args := ['']
+		full_args << ['-cc', alias_cc, '-cflags', '-static', hello_world_example()]
+		mut prefs, _ := pref.parse_args_and_show_errors([], full_args, false)
+		assert prefs.ccompiler_type == .gcc
+		assert prefs.pkgconfig_mode == .static_
+
+		resolve_ccompiler_type_and_pkgconfig_mode(mut prefs)
+
+		assert prefs.ccompiler_type == expected_type
+		assert prefs.pkgconfig_mode == .static_
+	}
+}
+
 fn test_resolve_ccompiler_type_detects_real_path_without_running_alias() {
 	$if windows {
 		return

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -15,6 +15,11 @@ pub fn should_find_windows_host_c_compiler(pref_ &pref.Preferences) bool {
 	return pref_.backend == .c && pref_.os == .windows && !pref_.output_cross_c
 }
 
+fn resolve_ccompiler_type_and_pkgconfig_mode(mut prefs pref.Preferences) {
+	prefs.ccompiler_type = resolve_ccompiler_type(prefs.ccompiler, prefs.ccompiler_type)
+	prefs.resolve_pkgconfig_mode()
+}
+
 pub fn compile(command string, pref_ &pref.Preferences, backend_cb FnBackend) {
 	if pref_.is_test {
 		disable_c_error_bug_reports()
@@ -31,7 +36,7 @@ pub fn compile(command string, pref_ &pref.Preferences, backend_cb FnBackend) {
 		}
 	}
 	mut pref_ref := unsafe { pref_ }
-	pref_ref.ccompiler_type = resolve_ccompiler_type(pref_ref.ccompiler, pref_ref.ccompiler_type)
+	resolve_ccompiler_type_and_pkgconfig_mode(mut pref_ref)
 	// Construct the V object from command line arguments
 	mut b := new_builder(pref_)
 	if b.should_rebuild() {

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -344,6 +344,7 @@ pub fn (mut v Builder) cc_msvc() {
 	// Libs are passed to cl.exe which passes them to the linker
 	a << real_libs.join(' ')
 	a << '/link'
+	a << v.msvc_ordered_pkgconfig_linker_args()
 	if v.pref.is_shared {
 		// generate a .def for export function names, avoid function name mangle
 		// must put after the /link flag!
@@ -550,6 +551,55 @@ mut:
 	other_flags []string
 }
 
+struct MsvcQuotedFlagPart {
+	value string
+	raw   string
+}
+
+fn (mut v Builder) msvc_ordered_pkgconfig_linker_args() []string {
+	mut args := []string{}
+	for segment in v.table.link_flag_segments {
+		if !segment.is_pkgconfig {
+			continue
+		}
+		for flag in segment.flags {
+			structured_flag := quote_spaced_ordered_pkgconfig_operand(flag, true)
+			parts := split_quoted_flag_parts(structured_flag.value)
+			for i, part in parts {
+				is_named_token := i == 0 && structured_flag.name != ''
+				token_flag := if is_named_token && structured_flag.name != '-Wl' {
+					cflag.CFlag{
+						mod:   structured_flag.mod
+						os:    structured_flag.os
+						name:  structured_flag.name
+						value: part.value
+					}
+				} else {
+					cflag.CFlag{
+						mod:   structured_flag.mod
+						value: if is_named_token {
+							'${structured_flag.name}${part.raw}'
+						} else {
+							part.raw
+						}
+					}
+				}
+				sflags := v.msvc_string_flags([token_flag])
+				args << sflags.lib_paths
+				args << sflags.real_libs
+				if !is_named_token && !part.value.starts_with('-')
+					&& part.value.to_lower_ascii().ends_with('.lib') {
+					args << part.raw
+				} else if !is_named_token && part.value.len > 1 && part.value[0] == `/`
+					&& sflags.other_flags.len > 0 {
+					args << part.raw
+				}
+			}
+		}
+	}
+	return args
+}
+
 fn strip_quotes(value string) string {
 	if value.len >= 2 && value[0] == `"` && value[value.len - 1] == `"` {
 		return value[1..value.len - 1]
@@ -620,25 +670,39 @@ fn split_and_apply_gnu_flags(value string, mut inc_paths []string, mut lib_paths
 }
 
 fn split_quoted_flags(value string) []string {
-	mut parts := []string{}
+	return split_quoted_flag_parts(value).map(it.value)
+}
+
+fn split_quoted_flag_parts(value string) []MsvcQuotedFlagPart {
+	mut parts := []MsvcQuotedFlagPart{}
 	mut buf := []u8{}
+	mut raw := []u8{}
 	mut in_quote := false
 	for ch in value {
 		if ch == `"` {
 			in_quote = !in_quote
+			raw << ch
 			continue
 		}
 		if !in_quote && ch == ` ` {
 			if buf.len > 0 {
-				parts << buf.bytestr()
+				parts << MsvcQuotedFlagPart{
+					value: buf.bytestr()
+					raw:   raw.bytestr()
+				}
 				buf = []u8{}
 			}
+			raw = []u8{}
 			continue
 		}
 		buf << ch
+		raw << ch
 	}
 	if buf.len > 0 {
-		parts << buf.bytestr()
+		parts << MsvcQuotedFlagPart{
+			value: buf.bytestr()
+			raw:   raw.bytestr()
+		}
 	}
 	return parts
 }

--- a/vlib/v/builder/msvc_windows_test.v
+++ b/vlib/v/builder/msvc_windows_test.v
@@ -45,6 +45,192 @@ fn test_msvc_string_flags_rewrites_obj_flags_through_cached_path() {
 	assert sflags.other_flags == ['"${expected_obj}"']
 }
 
+fn test_msvc_ordered_pkgconfig_linker_args_routes_static_paths_and_libs() {
+	mut builder := msvc_new_builder_for_args(['-cc', 'msvc', '-m64', msvc_hello_world_example()])
+	lib_dir := os.join_path(os.getwd(), 'msvc_pkgconfig_static_libs')
+	builder.table.parse_pkgconfig_link_flags(['-L${lib_dir}', '-lissue74_public', '-lissue74_private'],
+		'main', builder.pref.compile_defines_all) or { panic(err) }
+
+	assert builder.get_os_cflags() == []
+	assert builder.msvc_ordered_pkgconfig_linker_args() == [
+		'/LIBPATH:"${os.real_path(lib_dir)}"',
+		'/LIBPATH:"${os.real_path(os.join_path(lib_dir, 'msvc'))}"',
+		'issue74_public.lib',
+		'issue74_private.lib',
+	]
+}
+
+fn test_msvc_ordered_pkgconfig_linker_args_preserves_segment_order_and_repetition() {
+	mut builder := msvc_new_builder_for_args(['-cc', 'msvc', '-m64', msvc_hello_world_example()])
+	builder.table.parse_pkgconfig_link_flags(['-lissue74_a', '-lissue74_b', '-lissue74_a'], 'main',
+		builder.pref.compile_defines_all) or { panic(err) }
+	builder.table.parse_pkgconfig_link_flags(['-lissue74_c', '-lissue74_a'], 'main',
+		builder.pref.compile_defines_all) or { panic(err) }
+
+	assert builder.msvc_ordered_pkgconfig_linker_args() == [
+		'issue74_a.lib',
+		'issue74_b.lib',
+		'issue74_a.lib',
+		'issue74_c.lib',
+		'issue74_a.lib',
+	]
+}
+
+fn test_msvc_ordered_pkgconfig_linker_args_preserves_single_segment_token_order() {
+	mut builder := msvc_new_builder_for_args(['-cc', 'msvc', '-m64', msvc_hello_world_example()])
+	lib_dir := os.join_path(os.getwd(), 'msvc_pkgconfig_ordered_libs')
+	builder.table.parse_pkgconfig_link_flags(['-L${lib_dir}', 'issue74_direct.LIB', '-lissue74_a',
+		'-Wl,--start-group', '-lissue74_b', 'issue74_repeat.LIB', '-lissue74_a', '-Wl,--end-group',
+		'issue74_tail.LIB'], 'main', builder.pref.compile_defines_all) or { panic(err) }
+
+	args := builder.msvc_ordered_pkgconfig_linker_args()
+	assert args == [
+		'/LIBPATH:"${os.real_path(lib_dir)}"',
+		'/LIBPATH:"${os.real_path(os.join_path(lib_dir, 'msvc'))}"',
+		'issue74_direct.LIB',
+		'issue74_a.lib',
+		'issue74_b.lib',
+		'issue74_repeat.LIB',
+		'issue74_a.lib',
+		'issue74_tail.LIB',
+	]
+	assert !args.any(it.contains('start-group') || it.contains('end-group'))
+}
+
+fn test_msvc_ordered_pkgconfig_linker_args_preserves_native_slash_flags() {
+	mut builder := msvc_new_builder_for_args(['-cc', 'msvc', '-m64', msvc_hello_world_example()])
+	output_dir := os.join_path(os.getwd(), 'msvc pkgconfig native flags')
+	pdb_path := os.join_path(output_dir, 'issue74 output.pdb')
+	direct_lib := os.join_path(output_dir, 'issue74 direct.LIB')
+	builder.table.parse_pkgconfig_link_flags(['-lissue74_a', '/NODEFAULTLIB', '/OPT:REF',
+		'/PDB:"${pdb_path}"', '/WHOLEARCHIVE:issue74_whole.lib', '"${direct_lib}"',
+		'-Wl,--start-group', '--as-needed', '-lissue74_b', '-Wl,--end-group', '/OPT:REF',
+		'-lissue74_a'], 'main', builder.pref.compile_defines_all) or { panic(err) }
+
+	args := builder.msvc_ordered_pkgconfig_linker_args()
+	assert args == [
+		'issue74_a.lib',
+		'/NODEFAULTLIB',
+		'/OPT:REF',
+		'/PDB:"${pdb_path}"',
+		'/WHOLEARCHIVE:issue74_whole.lib',
+		'"${direct_lib}"',
+		'issue74_b.lib',
+		'/OPT:REF',
+		'issue74_a.lib',
+	]
+	assert !args.any(it.contains('start-group') || it.contains('end-group') || it == '--as-needed')
+}
+
+fn test_msvc_ordered_pkgconfig_linker_args_quotes_only_decoded_slash_option_operands() {
+	pdb_path := r'C:\Issue74 Output\app.pdb'
+	whole_archive_path := r'C:\Issue74 Libraries\whole.lib'
+	decoded_pdb := '/PDB:${pdb_path}'
+	decoded_whole_archive := '/WHOLEARCHIVE:${whole_archive_path}'
+	quoted_pdb := '/PDB:"${pdb_path}"'
+	equals_pdb := '/PDB=${pdb_path}'
+
+	assert quote_spaced_ordered_pkgconfig_operand(cflag.CFlag{
+		value: decoded_pdb
+	}, true).value == '/PDB:"${pdb_path}"'
+	assert quote_spaced_ordered_pkgconfig_operand(cflag.CFlag{
+		value: decoded_whole_archive
+	}, true).value == '/WHOLEARCHIVE:"${whole_archive_path}"'
+	assert quote_spaced_ordered_pkgconfig_operand(cflag.CFlag{
+		value: quoted_pdb
+	}, true).value == quoted_pdb
+	assert quote_spaced_ordered_pkgconfig_operand(cflag.CFlag{
+		value: equals_pdb
+	}, true).value == equals_pdb
+	assert quote_spaced_ordered_pkgconfig_operand(cflag.CFlag{
+		value: '/OPT:REF'
+	}, true).value == '/OPT:REF'
+
+	mut builder := msvc_new_builder_for_args(['-cc', 'msvc', '-m64', msvc_hello_world_example()])
+	builder.table.parse_pkgconfig_link_flags([
+		decoded_pdb,
+		decoded_whole_archive,
+		quoted_pdb,
+		'/OPT:REF',
+		'-lVersion',
+	], 'main', builder.pref.compile_defines_all) or { panic(err) }
+	assert builder.msvc_ordered_pkgconfig_linker_args() == [
+		'/PDB:"${pdb_path}"',
+		'/WHOLEARCHIVE:"${whole_archive_path}"',
+		quoted_pdb,
+		'/OPT:REF',
+		'Version.lib',
+	]
+}
+
+fn test_msvc_ordered_pkgconfig_linker_args_preserves_quoted_paths_with_spaces() {
+	mut builder := msvc_new_builder_for_args(['-cc', 'msvc', '-m64', msvc_hello_world_example()])
+	lib_dir := os.join_path(os.getwd(), 'msvc pkgconfig quoted libs')
+	direct_lib := os.join_path(lib_dir, 'issue74 direct.LIB')
+	builder.table.parse_pkgconfig_link_flags(['-L"${lib_dir}"', '"${direct_lib}"', '-lissue74_a',
+		'"${direct_lib}"', 'issue74_plain.LIB'], 'main', builder.pref.compile_defines_all) or {
+		panic(err)
+	}
+
+	assert builder.msvc_ordered_pkgconfig_linker_args() == [
+		'/LIBPATH:"${os.real_path(lib_dir)}"',
+		'/LIBPATH:"${os.real_path(os.join_path(lib_dir, 'msvc'))}"',
+		'"${direct_lib}"',
+		'issue74_a.lib',
+		'"${direct_lib}"',
+		'issue74_plain.LIB',
+	]
+}
+
+fn test_msvc_ordered_pkgconfig_linker_args_preserves_decoded_paths_with_spaces() {
+	mut builder := msvc_new_builder_for_args(['-cc', 'msvc', '-m64', msvc_hello_world_example()])
+	lib_dir := os.join_path(os.getwd(), 'msvc pkgconfig decoded libs')
+	direct_lib := os.join_path(lib_dir, 'issue74 direct.lib')
+	builder.table.parse_pkgconfig_link_flags(['-L${lib_dir}', direct_lib, '-lVersion', direct_lib,
+		'-lVersion'], 'main', builder.pref.compile_defines_all) or { panic(err) }
+
+	assert builder.msvc_ordered_pkgconfig_linker_args() == [
+		'/LIBPATH:"${os.real_path(lib_dir)}"',
+		'/LIBPATH:"${os.real_path(os.join_path(lib_dir, 'msvc'))}"',
+		'"${direct_lib}"',
+		'Version.lib',
+		'"${direct_lib}"',
+		'Version.lib',
+	]
+}
+
+fn test_msvc_ordered_pkgconfig_linker_args_ignores_spaced_gnu_linker_control() {
+	mut builder := msvc_new_builder_for_args(['-cc', 'msvc', '-m64', msvc_hello_world_example()])
+	builder.table.parse_pkgconfig_link_flags([
+		r'-Wl,-rpath,C:\issue74 runtime libs',
+		'-lVersion',
+	], 'main', builder.pref.compile_defines_all) or { panic(err) }
+
+	assert builder.msvc_ordered_pkgconfig_linker_args() == ['Version.lib']
+}
+
+fn test_msvc_ordered_pkgconfig_linker_args_keeps_dynamic_flags_on_legacy_path() {
+	mut builder := msvc_new_builder_for_args(['-cc', 'msvc', '-m64', msvc_hello_world_example()])
+	lib_dir := os.join_path(os.getwd(), 'msvc_pkgconfig_dynamic_libs')
+	builder.table.parse_cflag_with_link_segment('/NODEFAULTLIB', 'main',
+		builder.pref.compile_defines_all) or { panic(err) }
+	builder.table.parse_cflag_with_link_segment('/OPT:NOREF', 'main',
+		builder.pref.compile_defines_all) or { panic(err) }
+	builder.table.parse_cflag_with_link_segment('-L${lib_dir} -lissue74_dynamic', 'main',
+		builder.pref.compile_defines_all) or { panic(err) }
+	builder.table.parse_pkgconfig_link_flags(['/OPT:REF', '-lissue74_static'], 'main',
+		builder.pref.compile_defines_all) or { panic(err) }
+
+	legacy := builder.msvc_string_flags(builder.get_os_cflags())
+	assert legacy.lib_paths == [
+		'/LIBPATH:"${os.real_path(lib_dir)}"',
+		'/LIBPATH:"${os.real_path(os.join_path(lib_dir, 'msvc'))}"',
+	]
+	assert legacy.real_libs == ['issue74_dynamic.lib']
+	assert legacy.other_flags == ['/NODEFAULTLIB', '/OPT:NOREF']
+	assert builder.msvc_ordered_pkgconfig_linker_args() == ['/OPT:REF', 'issue74_static.lib']
+}
+
 fn msvc_new_builder_for_args(args []string) Builder {
 	mut full_args := ['']
 	full_args << args

--- a/vlib/v/builder/pkgconfig_link_segment_test.v
+++ b/vlib/v/builder/pkgconfig_link_segment_test.v
@@ -1,0 +1,1488 @@
+module builder
+
+import os
+import v.ast
+import v.checker
+import v.parser
+import v.pkgconfig
+import v.pref
+
+const issue74_fixture_dir = os.join_path(@VEXEROOT, 'vlib', 'v', 'pkgconfig', 'testdata',
+	'static_pkgconfig')
+
+const issue74_source_order_source = 'module main
+#flag -Wl,--issue74-order-before
+#pkgconfig --static --cflags --libs source-order-74
+#flag -Wl,--issue74-order-between
+#pkgconfig --static --cflags --libs source-order-74
+#flag -Wl,--issue74-order-after
+
+fn main() {}
+'
+
+const issue74_repeated_control_epochs_source = 'module main
+#flag -Wl,--whole-archive
+#pkgconfig --static --cflags --libs source-order-74
+#flag -Wl,--no-whole-archive
+#flag -Wl,--whole-archive
+#pkgconfig --static --cflags --libs source-order-74
+#flag -Wl,--no-whole-archive
+
+fn main() {}
+'
+
+const issue74_dynamic_compat_source = 'module main
+#pkgconfig --cflags --libs mixed-case-dynamic-sentinel-74 mixed-case-static-74
+
+fn main() {}
+'
+
+const issue74_repeated_control_dynamic_source = 'module main
+#flag -Wl,--whole-archive
+#pkgconfig --cflags --libs mixed-case-dynamic-sentinel-74
+#flag -Wl,--no-whole-archive
+#flag -Wl,--whole-archive
+#flag -Wl,--no-whole-archive
+
+fn main() {}
+'
+
+const issue74_ldflags_static_source = 'module main
+#pkgconfig static-root-74
+
+fn main() {}
+'
+
+const issue74_group_alias_source = 'module main
+#pkgconfig --static --libs group-alias-74
+
+fn main() {}
+'
+
+const issue74_xlinker_operand_source = 'module main
+#flag -Xlinker
+#flag --issue74-xlinker-operand
+#pkgconfig --static --cflags --libs source-order-74
+
+fn main() {}
+'
+
+const issue74_xlinker_interrupted_source = 'module main
+#flag -Xlinker
+#pkgconfig --static --cflags --libs source-order-74
+#flag --issue74-xlinker-operand
+
+fn main() {}
+'
+
+const issue74_xlinker_end_of_stream_source = 'module main
+#pkgconfig --static --cflags --libs source-order-74
+#flag -Xlinker
+
+fn main() {}
+'
+
+const issue74_wl_rpath_interrupted_source = 'module main
+#flag -Wl,-rpath
+#pkgconfig --static --cflags --libs source-order-74
+#flag -Wl,/issue74/rpath
+
+fn main() {}
+'
+
+const issue74_version_script_interrupted_source = 'module main
+#flag -Wl,--version-script
+#pkgconfig --static --cflags --libs source-order-74
+#flag /issue74/exports.map
+
+fn main() {}
+'
+
+fn issue74_wl_operand_source(control string, operand string, interrupted bool) string {
+	ordered_flags := if interrupted {
+		'#flag ${control}\n#pkgconfig --static --cflags --libs source-order-74\n#flag ${operand}'
+	} else {
+		'#flag ${control}\n#flag ${operand}\n#pkgconfig --static --cflags --libs source-order-74'
+	}
+	return 'module main\n${ordered_flags}\n\nfn main() {}\n'
+}
+
+const issue74_source_order_markers = ['-Wl,--issue74-order-before', '-Wl,--issue74-order-pkg-public',
+	'-Wl,--issue74-order-pkg-private', '-Wl,--issue74-order-between',
+	'-Wl,--issue74-order-pkg-public', '-Wl,--issue74-order-pkg-private', '-Wl,--issue74-order-after']
+
+const issue74_xlinker_operand_markers = ['--issue74-xlinker-operand',
+	'-Wl,--issue74-order-pkg-public', '-Wl,--issue74-order-pkg-private']
+
+const issue74_static_linker_markers = ['-lissue74_root', '-Wl,--start-group', '-lissue74_cycle_a',
+	'-lissue74_cycle_b', '-lissue74_cycle_a', '-Wl,--end-group', '-lissue74_root_private',
+	'-lissue74_public', '-lissue74_public_private', '-lissue74_private', '-lissue74_private_private']
+
+const issue74_group_alias_markers = ['-Wl,-(', '-lissue74_alias_a', '-lissue74_alias_b',
+	'-lissue74_alias_a', '-Wl,-)']
+
+const issue74_windows_fake_ccompiler_source = 'module main
+
+import os
+
+fn main() {
+	log_path := os.getenv("ISSUE74_CC_LOG")
+	if log_path == "" {
+		exit(2)
+	}
+	mut log := os.open_append(log_path) or { panic(err) }
+	defer {
+		log.close()
+	}
+	mut output := ""
+	mut take_output := false
+	for arg in os.args[1..] {
+		log.writeln(arg) or { panic(err) }
+		if take_output {
+			output = arg
+			take_output = false
+		} else if arg == "-o" {
+			take_output = true
+		}
+	}
+	if output != "" {
+		os.mkdir_all(os.dir(output)) or { panic(err) }
+		os.write_file(output, "") or { panic(err) }
+	}
+}
+'
+
+struct Issue74DriverEnvironment {
+mut:
+	has_cflags  bool
+	cflags      string
+	has_ldflags bool
+	ldflags     string
+}
+
+fn issue74_clear_driver_environment() Issue74DriverEnvironment {
+	mut environment := Issue74DriverEnvironment{}
+	if value := os.getenv_opt('CFLAGS') {
+		environment.has_cflags = true
+		environment.cflags = value
+	}
+	if value := os.getenv_opt('LDFLAGS') {
+		environment.has_ldflags = true
+		environment.ldflags = value
+	}
+	os.unsetenv('CFLAGS')
+	os.unsetenv('LDFLAGS')
+	return environment
+}
+
+fn (environment &Issue74DriverEnvironment) restore() {
+	if environment.has_cflags {
+		os.setenv('CFLAGS', environment.cflags, true)
+	} else {
+		os.unsetenv('CFLAGS')
+	}
+	if environment.has_ldflags {
+		os.setenv('LDFLAGS', environment.ldflags, true)
+	} else {
+		os.unsetenv('LDFLAGS')
+	}
+}
+
+fn issue74_builder_for_source(source string) Builder {
+	driver_environment := issue74_clear_driver_environment()
+	defer {
+		driver_environment.restore()
+	}
+	old_path := os.getenv_opt('PKG_CONFIG_PATH')
+	old_defaults := os.getenv_opt('PKG_CONFIG_PATH_DEFAULTS')
+	os.unsetenv('PKG_CONFIG_PATH')
+	os.setenv('PKG_CONFIG_PATH_DEFAULTS', issue74_fixture_dir, true)
+	defer {
+		if path := old_path {
+			os.setenv('PKG_CONFIG_PATH', path, true)
+		} else {
+			os.unsetenv('PKG_CONFIG_PATH')
+		}
+		if defaults := old_defaults {
+			os.setenv('PKG_CONFIG_PATH_DEFAULTS', defaults, true)
+		} else {
+			os.unsetenv('PKG_CONFIG_PATH_DEFAULTS')
+		}
+	}
+	source_path := os.join_path('/virtual', 'issue74_pkgconfig_order.v')
+	mut prefs, _ := pref.parse_args([], ['-cc', 'gcc', source_path])
+	prefs.out_name = os.join_path(os.vtmp_dir(), 'issue74_pkgconfig_order.out')
+	mut table := ast.new_table()
+	mut file := parser.parse_text(source, source_path, mut table, .skip_comments, prefs)
+	mut chk := checker.new_checker(table, prefs)
+	chk.check(mut file)
+	mut builder := new_builder(prefs)
+	builder.table = table
+	builder.out_name_c = os.join_path(os.vtmp_dir(), 'issue74_pkgconfig_order.tmp.c')
+	builder.setup_ccompiler_options('gcc')
+	builder.setup_output_name()
+	return builder
+}
+
+fn issue74_pkgconfig_builder_for_target(flags []string, target_os pref.OS, compiler_type pref.CompilerType) Builder {
+	source_path := os.join_path('/virtual', 'issue74_pkgconfig_target.v')
+	mut prefs, _ := pref.parse_args([], ['', source_path])
+	prefs.os = target_os
+	prefs.ccompiler_type = compiler_type
+	mut table := ast.new_table()
+	table.parse_pkgconfig_link_flags(flags, 'main', prefs.compile_defines_all) or { panic(err) }
+	mut builder := new_builder(prefs)
+	builder.table = table
+	return builder
+}
+
+fn issue74_ordered_pkgconfig_args_for_target(flags []string, target_os pref.OS, compiler_type pref.CompilerType) []string {
+	mut builder := issue74_pkgconfig_builder_for_target(flags, target_os, compiler_type)
+	_, ordered_args, _ := builder.split_ordered_pkgconfig_link_flags([])
+	return ordered_args
+}
+
+fn issue74_quoted_direct_import_lib_case() ([]string, string) {
+	lib_dir := os.join_path(os.vtmp_dir(), 'issue74 search libs')
+	direct_lib := os.join_path(os.vtmp_dir(), 'issue74 direct libs', 'Issue74Direct.LiB')
+	flags := ['-L"${lib_dir}"', '"${direct_lib}"', 'Issue74Mixed.LiB']
+	return flags, direct_lib
+}
+
+struct Issue74ToolResult {
+	exit_code int
+	stdout    string
+	stderr    string
+}
+
+fn issue74_run_tool(executable string, args []string, work_dir string) Issue74ToolResult {
+	mut process := os.new_process(executable)
+	process.set_args(args)
+	process.set_work_folder(work_dir)
+	process.set_redirect_stdio()
+	process.wait()
+	result := Issue74ToolResult{
+		exit_code: process.code
+		stdout:    process.stdout_slurp()
+		stderr:    process.stderr_slurp()
+	}
+	process.close()
+	return result
+}
+
+fn issue74_is_source_order_marker(arg string) bool {
+	return arg.starts_with('-Wl,--issue74-order-')
+}
+
+fn test_pkgconfig_linker_segments_keep_source_relative_order_and_repetition() {
+	mut builder := issue74_builder_for_source(issue74_source_order_source)
+	all_args := builder.all_args(builder.ccoptions)
+	markers := all_args.filter(issue74_is_source_order_marker(it))
+	assert markers == issue74_source_order_markers, all_args.str()
+
+	generated_source_args := all_args.filter(it.contains(os.file_name(builder.out_name_c)))
+	assert generated_source_args.len == 1, all_args.str()
+	generated_idx := all_args.index(generated_source_args[0])
+	assert all_args.index(issue74_source_order_markers[0]) > generated_idx, all_args.str()
+}
+
+fn test_repeated_ordered_flag_control_epochs_are_preserved() {
+	mut builder := issue74_builder_for_source(issue74_repeated_control_epochs_source)
+	global_controls := builder.table.cflags.filter(it.name == '-Wl'
+		&& it.value in [',--whole-archive', ',--no-whole-archive'])
+	assert global_controls.len == 2
+
+	all_args := builder.all_args(builder.ccoptions)
+	ordered := all_args.filter(it in ['-Wl,--whole-archive', '-Wl,--no-whole-archive']
+		|| it.starts_with('-Wl,--issue74-order-pkg-'))
+	assert ordered == [
+		'-Wl,--whole-archive',
+		'-Wl,--issue74-order-pkg-public',
+		'-Wl,--issue74-order-pkg-private',
+		'-Wl,--no-whole-archive',
+		'-Wl,--whole-archive',
+		'-Wl,--issue74-order-pkg-public',
+		'-Wl,--issue74-order-pkg-private',
+		'-Wl,--no-whole-archive',
+	], all_args.str()
+}
+
+fn test_cross_module_repeated_ordered_flag_epochs_link_and_run() {
+	root := os.join_path(os.vtmp_dir(), 'issue74_cross_module_epochs')
+	archive_a := os.join_path(root, 'libissue74_epoch_a.a')
+	archive_b := os.join_path(root, 'libissue74_epoch_b.a')
+	expected_archive_a := if archive_a.contains_any(' \t\r\n') {
+		'"${archive_a}"'
+	} else {
+		archive_a
+	}
+	expected_archive_b := if archive_b.contains_any(' \t\r\n') {
+		'"${archive_b}"'
+	} else {
+		archive_b
+	}
+	mut table := ast.new_table()
+	modules := ['issue74_epoch_a', 'issue74_epoch_b']
+	archives := [archive_a, archive_b]
+	for i, mod_name in modules {
+		archive := archives[i]
+		table.parse_cflag_with_link_segment('-Wl,--whole-archive', mod_name, []) or { panic(err) }
+		table.parse_pkgconfig_link_flags([archive], mod_name, []) or { panic(err) }
+		table.parse_cflag_with_link_segment('-Wl,--no-whole-archive', mod_name, []) or {
+			panic(err)
+		}
+	}
+	assert table.cflags.len == 2
+	assert table.cflags.all(it.mod == 'issue74_epoch_a')
+
+	mut prefs, _ := pref.parse_args([], ['', os.join_path(root, 'main.v')])
+	prefs.os = .linux
+	prefs.ccompiler_type = .gcc
+	mut builder := new_builder(prefs)
+	builder.table = table
+	legacy, ordered, _ := builder.split_ordered_pkgconfig_link_flags(builder.table.cflags)
+	assert legacy == []
+	assert ordered == [
+		'-Wl,--whole-archive',
+		expected_archive_a,
+		'-Wl,--no-whole-archive',
+		'-Wl,--whole-archive',
+		expected_archive_b,
+		'-Wl,--no-whole-archive',
+	]
+
+	$if linux {
+		gcc := os.find_abs_path_of_executable('gcc') or { return }
+		ar := os.find_abs_path_of_executable('ar') or { return }
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		main_source := os.join_path(root, 'main.c')
+		a_source := os.join_path(root, 'epoch_a.c')
+		b_source := os.join_path(root, 'epoch_b.c')
+		a_object := os.join_path(root, 'epoch_a.o')
+		b_object := os.join_path(root, 'epoch_b.o')
+		output := os.join_path(root, 'cross_module_epochs.out')
+		os.write_file(main_source,
+			'int issue74_epoch_total = 0;\nint main(void) { return issue74_epoch_total == 74 ? 0 : 1; }\n') or {
+			panic(err)
+		}
+		os.write_file(a_source,
+			'extern int issue74_epoch_total;\n__attribute__((constructor)) static void issue74_epoch_a(void) { issue74_epoch_total += 1; }\n') or {
+			panic(err)
+		}
+		os.write_file(b_source,
+			'extern int issue74_epoch_total;\n__attribute__((constructor)) static void issue74_epoch_b(void) { issue74_epoch_total += 73; }\n') or {
+			panic(err)
+		}
+		for source, object in {
+			a_source: a_object
+			b_source: b_object
+		} {
+			compiled := issue74_run_tool(gcc, ['-c', source, '-o', object], root)
+			assert compiled.exit_code == 0, compiled.stdout + compiled.stderr
+		}
+		for archive, object in {
+			archive_a: a_object
+			archive_b: b_object
+		} {
+			archived := issue74_run_tool(ar, ['rcs', archive, object], root)
+			assert archived.exit_code == 0, archived.stdout + archived.stderr
+		}
+		mut link_args := [main_source]
+		link_args << ordered
+		link_args << ['-o', output]
+		linked := issue74_run_tool(gcc, link_args, root)
+		assert linked.exit_code == 0, linked.stdout + linked.stderr
+		assert issue74_run_tool(output, [], root).exit_code == 0
+	}
+}
+
+fn test_split_version_script_before_pkgconfig_links_direct_and_response_file() {
+	$if linux {
+		gcc := os.find_abs_path_of_executable('gcc') or { return }
+		root := os.join_path(os.vtmp_dir(), 'issue74_version_script_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+
+		main_source := os.join_path(root, 'main.c')
+		version_script := os.join_path(root, 'exports.map')
+		os.write_file(main_source, 'int main(void) { return 0; }\n') or { panic(err) }
+		os.write_file(version_script, 'VERS_1 { global: *; };\n') or { panic(err) }
+
+		mut table := ast.new_table()
+		table.parse_cflag_with_link_segment('-Wl,--version-script', 'main', []) or { panic(err) }
+		table.parse_cflag_with_link_segment(version_script, 'main', []) or { panic(err) }
+		table.parse_pkgconfig_link_flags(['-lm'], 'main', []) or { panic(err) }
+		mut prefs, _ := pref.parse_args([], ['', main_source])
+		prefs.os = .linux
+		prefs.ccompiler_type = .gcc
+		mut builder := new_builder(prefs)
+		builder.table = table
+		legacy, ordered_args, _ := builder.split_ordered_pkgconfig_link_flags(builder.table.cflags)
+		assert legacy == []
+		assert ordered_args == ['-Wl,--version-script', version_script, '-lm']
+
+		direct_output := os.join_path(root, 'direct.out')
+		mut direct_args := [main_source]
+		direct_args << ordered_args
+		direct_args << ['-o', direct_output]
+		direct_link := issue74_run_tool(gcc, direct_args, root)
+		assert direct_link.exit_code == 0, direct_link.stdout + direct_link.stderr
+		assert issue74_run_tool(direct_output, [], root).exit_code == 0
+
+		rsp_output := os.join_path(root, 'rsp.out')
+		mut rsp_args := [main_source]
+		rsp_args << ordered_args
+		rsp_args << ['-o', rsp_output]
+		rsp_args = rsp_args.map(builder.rsp_safe_arg(it))
+		assert builder.should_use_rsp(rsp_args)
+		rsp_path := os.join_path(root, 'link.rsp')
+		os.write_file(rsp_path, rsp_args.join(' ').replace('\\', '\\\\')) or { panic(err) }
+		rsp_link := issue74_run_tool(gcc, ['@${rsp_path}'], root)
+		assert rsp_link.exit_code == 0, rsp_link.stdout + rsp_link.stderr
+		assert issue74_run_tool(rsp_output, [], root).exit_code == 0
+	}
+}
+
+fn test_static_pkgconfig_split_version_script_with_spaced_operand_links_direct_and_response_file() {
+	$if linux {
+		gcc := os.find_abs_path_of_executable('gcc') or { return }
+		root := os.join_path(os.vtmp_dir(), 'issue74_pkgconfig_version_script_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+
+		main_source := os.join_path(root, 'main.c')
+		version_script := os.join_path(root, 'exports map.map')
+		pc_path := os.join_path(root, 'split-version-script.pc')
+		os.write_file(main_source, 'int main(void) { return 0; }\n') or { panic(err) }
+		os.write_file(version_script, 'VERS_1 { global: *; };\n') or { panic(err) }
+		os.write_file(pc_path,
+			'Name: split-version-script\nDescription: disposable split version-script fixture\nVersion: 1.0.0\nLibs: -Wl,--version-script "${version_script}"\n') or {
+			panic(err)
+		}
+
+		old_path := os.getenv_opt('PKG_CONFIG_PATH')
+		old_defaults := os.getenv_opt('PKG_CONFIG_PATH_DEFAULTS')
+		os.setenv('PKG_CONFIG_PATH', root, true)
+		os.setenv('PKG_CONFIG_PATH_DEFAULTS', '', true)
+		defer {
+			if path := old_path {
+				os.setenv('PKG_CONFIG_PATH', path, true)
+			} else {
+				os.unsetenv('PKG_CONFIG_PATH')
+			}
+			if defaults := old_defaults {
+				os.setenv('PKG_CONFIG_PATH_DEFAULTS', defaults, true)
+			} else {
+				os.unsetenv('PKG_CONFIG_PATH_DEFAULTS')
+			}
+		}
+		mut command := pkgconfig.main(['--static', '--libs', 'split-version-script']) or {
+			panic(err)
+		}
+		result := command.run_result() or { panic(err) }
+		assert result.link_flags == ['-Wl,--version-script', version_script]
+
+		mut builder := issue74_pkgconfig_builder_for_target(result.link_flags, .linux, .gcc)
+		_, ordered_args, _ := builder.split_ordered_pkgconfig_link_flags([])
+		assert ordered_args == ['-Wl,--version-script', '"${version_script}"']
+
+		direct_output := os.join_path(root, 'direct.out')
+		mut direct_args := [main_source]
+		direct_args << ordered_args
+		direct_args << ['-o', direct_output]
+		direct_command := '${os.quoted_path(gcc)} ${direct_args.map(shell_safe_cc_arg(it)).join(' ')}'
+		direct_link := os.execute(direct_command)
+		assert direct_link.exit_code == 0, direct_link.output
+		assert issue74_run_tool(direct_output, [], root).exit_code == 0
+
+		rsp_output := os.join_path(root, 'rsp.out')
+		mut rsp_args := [main_source]
+		rsp_args << ordered_args
+		rsp_args << ['-o', rsp_output]
+		rsp_args = rsp_args.map(builder.rsp_safe_arg(it))
+		assert builder.should_use_rsp(rsp_args)
+		rsp_path := os.join_path(root, 'link.rsp')
+		os.write_file(rsp_path, rsp_args.join(' ').replace('\\', '\\\\')) or { panic(err) }
+		rsp_link := issue74_run_tool(gcc, ['@${rsp_path}'], root)
+		assert rsp_link.exit_code == 0, rsp_link.stdout + rsp_link.stderr
+		assert issue74_run_tool(rsp_output, [], root).exit_code == 0
+	}
+}
+
+fn test_repeated_ordered_flag_controls_keep_dynamic_legacy_deduplication() {
+	mut builder := issue74_builder_for_source(issue74_repeated_control_dynamic_source)
+	assert !builder.table.link_flag_segments.any(it.is_pkgconfig)
+	all_args := builder.all_args(builder.ccoptions)
+	assert all_args.count(it == '-Wl,--whole-archive') == 1, all_args.str()
+	assert all_args.count(it == '-Wl,--no-whole-archive') == 1, all_args.str()
+	assert all_args.count(it == '-Wl,--issue74-dynamic-sentinel') == 1, all_args.str()
+}
+
+fn test_static_pkgconfig_structured_archives_link_direct_and_response_file() {
+	$if linux {
+		gcc := os.find_abs_path_of_executable('gcc') or { return }
+		ar := os.find_abs_path_of_executable('ar') or { return }
+		root := os.join_path('/tmp', 'issue74_structured_link_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+
+		main_source := os.join_path(root, 'main.c')
+		a_source := os.join_path(root, 'a.c')
+		b_source := os.join_path(root, 'b.c')
+		a_object := os.join_path(root, 'a.o')
+		b_object := os.join_path(root, 'b.o')
+		lib_dir := os.join_path(root, 'lib')
+		os.mkdir_all(lib_dir) or { panic(err) }
+		lib_a := os.join_path(lib_dir, 'libissue74_a.a')
+		lib_b := os.join_path(lib_dir, 'libissue74_b.a')
+		os.write_file(main_source,
+			'int issue74_a(void);\nint main(void) { return issue74_a() == 74 ? 0 : 1; }\n') or {
+			panic(err)
+		}
+		os.write_file(a_source,
+			'int issue74_b(void);\nint issue74_a(void) { return issue74_b() + 1; }\n') or {
+			panic(err)
+		}
+		os.write_file(b_source, 'int issue74_b(void) { return 73; }\n') or { panic(err) }
+
+		for source, object in {
+			a_source: a_object
+			b_source: b_object
+		} {
+			compiled := issue74_run_tool(gcc, ['-c', source, '-o', object], root)
+			assert compiled.exit_code == 0, compiled.stdout + compiled.stderr
+		}
+		for archive, object in {
+			lib_a: a_object
+			lib_b: b_object
+		} {
+			archived := issue74_run_tool(ar, ['rcs', archive, object], root)
+			assert archived.exit_code == 0, archived.stdout + archived.stderr
+		}
+
+		pc_path := os.join_path(root, 'structured-link-real.pc')
+		os.write_file(pc_path,
+			'libdir=${lib_dir}\n\nName: structured-link-real\nDescription: disposable structured static link fixture\nVersion: 1.0.0\nLibs.private: -L\${libdir} \${libdir}/libissue74_b.a \${libdir}/libissue74_a.a \${libdir}/libissue74_b.a\n') or {
+			panic(err)
+		}
+		old_path := os.getenv_opt('PKG_CONFIG_PATH')
+		old_defaults := os.getenv_opt('PKG_CONFIG_PATH_DEFAULTS')
+		os.setenv('PKG_CONFIG_PATH', root, true)
+		os.setenv('PKG_CONFIG_PATH_DEFAULTS', '', true)
+		defer {
+			if path := old_path {
+				os.setenv('PKG_CONFIG_PATH', path, true)
+			} else {
+				os.unsetenv('PKG_CONFIG_PATH')
+			}
+			if defaults := old_defaults {
+				os.setenv('PKG_CONFIG_PATH_DEFAULTS', defaults, true)
+			} else {
+				os.unsetenv('PKG_CONFIG_PATH_DEFAULTS')
+			}
+		}
+		mut command := pkgconfig.main(['--static', '--libs', 'structured-link-real']) or {
+			panic(err)
+		}
+		result := command.run_result() or { panic(err) }
+		assert result.link_flags == ['-L${lib_dir}', lib_b, lib_a, lib_b]
+
+		mut builder := issue74_pkgconfig_builder_for_target(result.link_flags, .linux, .gcc)
+		_, ordered_args, _ := builder.split_ordered_pkgconfig_link_flags([])
+		assert ordered_args == ['-L"${os.real_path(lib_dir)}"', lib_b, lib_a, lib_b]
+
+		direct_output := os.join_path(root, 'direct.out')
+		mut direct_args := [main_source]
+		direct_args << ordered_args
+		direct_args << ['-o', direct_output]
+		direct_link := issue74_run_tool(gcc, direct_args, root)
+		assert direct_link.exit_code == 0, direct_link.stdout + direct_link.stderr
+		assert issue74_run_tool(direct_output, [], root).exit_code == 0
+
+		rsp_output := os.join_path(root, 'rsp.out')
+		mut rsp_args := [main_source]
+		rsp_args << ordered_args
+		rsp_args << ['-o', rsp_output]
+		rsp_args = rsp_args.map(builder.rsp_safe_arg(it))
+		assert builder.should_use_rsp(rsp_args)
+		rsp_path := os.join_path(root, 'link.rsp')
+		os.write_file(rsp_path, rsp_args.join(' ').replace('\\', '\\\\')) or { panic(err) }
+		rsp_link := issue74_run_tool(gcc, ['@${rsp_path}'], root)
+		assert rsp_link.exit_code == 0, rsp_link.stdout + rsp_link.stderr
+		assert issue74_run_tool(rsp_output, [], root).exit_code == 0
+	}
+}
+
+fn test_static_pkgconfig_quoted_search_path_routing_is_bounded() {
+	search_path := os.join_path(os.vtmp_dir(), 'issue74 path - with spaces')
+	direct_archive := os.join_path(os.vtmp_dir(), 'issue74 direct - archives', 'lib x.a')
+	direct_msvc_lib := os.join_path(os.vtmp_dir(), 'issue74 direct - archives', 'issue74 x.LIB')
+	flags := ['-L"${search_path}"', '"${direct_archive}"', '"${direct_msvc_lib}"']
+	expected := ['-L"${os.real_path(search_path)}"', '"${direct_archive}"', '"${direct_msvc_lib}"']
+
+	for compiler_type in [pref.CompilerType.gcc, .clang, .tinyc, .cplusplus] {
+		args := issue74_ordered_pkgconfig_args_for_target(flags, .linux, compiler_type)
+		assert args == expected, '${compiler_type}: ${args}'
+	}
+	windows_clang_args := issue74_ordered_pkgconfig_args_for_target(flags, .windows, .clang)
+	assert windows_clang_args == expected, windows_clang_args.str()
+
+	for compiler_type in [pref.CompilerType.gcc, .mingw] {
+		args := issue74_ordered_pkgconfig_args_for_target(flags, .windows, compiler_type)
+		assert args == expected, '${compiler_type}: ${args}'
+	}
+
+	msvc_args := issue74_ordered_pkgconfig_args_for_target(flags, .windows, .msvc)
+	assert msvc_args == expected, msvc_args.str()
+
+	raw_expected := ['"${direct_archive}"']
+	for compiler_type in [pref.CompilerType.gcc, .clang, .tinyc, .cplusplus] {
+		args := issue74_ordered_pkgconfig_args_for_target([direct_archive], .linux, compiler_type)
+		assert args == raw_expected, '${compiler_type}: ${args}'
+	}
+	for compiler_type in [pref.CompilerType.gcc, .mingw, .clang, .msvc] {
+		args := issue74_ordered_pkgconfig_args_for_target([direct_archive], .windows, compiler_type)
+		assert args == raw_expected, '${compiler_type}: ${args}'
+	}
+}
+
+fn test_static_pkgconfig_quoted_search_path_links_direct_and_response_file() {
+	$if linux {
+		gcc := os.find_abs_path_of_executable('gcc') or { return }
+		ar := os.find_abs_path_of_executable('ar') or { return }
+		root := os.join_path('/tmp', 'issue74_quoted_search_link_${os.getpid()}')
+		lib_dir := os.join_path(root, 'path - with spaces')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(lib_dir) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+
+		main_source := os.join_path(root, 'main.c')
+		library_source := os.join_path(root, 'library.c')
+		library_object := os.join_path(root, 'library.o')
+		library_path := os.join_path(lib_dir, 'libissue74_quoted_search.a')
+		os.write_file(main_source,
+			'int issue74_quoted_search(void);\nint main(void) { return issue74_quoted_search() == 74 ? 0 : 1; }\n') or {
+			panic(err)
+		}
+		os.write_file(library_source, 'int issue74_quoted_search(void) { return 74; }\n') or {
+			panic(err)
+		}
+		compiled := issue74_run_tool(gcc, ['-c', library_source, '-o', library_object], root)
+		assert compiled.exit_code == 0, compiled.stdout + compiled.stderr
+		archived := issue74_run_tool(ar, ['rcs', library_path, library_object], root)
+		assert archived.exit_code == 0, archived.stdout + archived.stderr
+
+		mut builder := issue74_pkgconfig_builder_for_target(['-L"${lib_dir}"',
+			'-lissue74_quoted_search'], .linux, .gcc)
+		_, ordered_args, _ := builder.split_ordered_pkgconfig_link_flags([])
+		assert ordered_args == ['-L"${os.real_path(lib_dir)}"', '-lissue74_quoted_search']
+
+		direct_output := os.join_path(root, 'direct.out')
+		mut direct_args := [main_source]
+		direct_args << ordered_args
+		direct_args << ['-o', direct_output]
+		direct_command := '${os.quoted_path(gcc)} ${direct_args.map(shell_safe_cc_arg(it)).join(' ')}'
+		direct_link := os.execute(direct_command)
+		assert direct_link.exit_code == 0, direct_link.output
+		assert issue74_run_tool(direct_output, [], root).exit_code == 0
+
+		rsp_output := os.join_path(root, 'rsp.out')
+		mut rsp_args := [main_source]
+		rsp_args << ordered_args
+		rsp_args << ['-o', rsp_output]
+		rsp_args = rsp_args.map(builder.rsp_safe_arg(it))
+		assert builder.should_use_rsp(rsp_args)
+		rsp_path := os.join_path(root, 'link.rsp')
+		os.write_file(rsp_path, rsp_args.join(' ').replace('\\', '\\\\')) or { panic(err) }
+		rsp_link := issue74_run_tool(gcc, ['@${rsp_path}'], root)
+		assert rsp_link.exit_code == 0, rsp_link.stdout + rsp_link.stderr
+		assert issue74_run_tool(rsp_output, [], root).exit_code == 0
+	}
+}
+
+fn test_static_pkgconfig_raw_spaced_colon_archive_links_direct_and_response_file() {
+	$if linux {
+		gcc := os.find_abs_path_of_executable('gcc') or { return }
+		ar := os.find_abs_path_of_executable('ar') or { return }
+		root := os.join_path(os.vtmp_dir(), 'issue74_raw_spaced_archive_${os.getpid()}')
+		lib_dir := os.join_path(root, 'direct:archives with spaces')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(lib_dir) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+
+		main_source := os.join_path(root, 'main.c')
+		library_source := os.join_path(root, 'library.c')
+		library_object := os.join_path(root, 'library.o')
+		library_path := os.join_path(lib_dir, 'libissue74_raw_spaced.a')
+		os.write_file(main_source,
+			'int issue74_raw_spaced(void);\nint main(void) { return issue74_raw_spaced() == 74 ? 0 : 1; }\n') or {
+			panic(err)
+		}
+		os.write_file(library_source, 'int issue74_raw_spaced(void) { return 74; }\n') or {
+			panic(err)
+		}
+		compiled := issue74_run_tool(gcc, ['-c', library_source, '-o', library_object], root)
+		assert compiled.exit_code == 0, compiled.stdout + compiled.stderr
+		archived := issue74_run_tool(ar, ['rcs', library_path, library_object], root)
+		assert archived.exit_code == 0, archived.stdout + archived.stderr
+
+		mut builder := issue74_pkgconfig_builder_for_target([library_path], .linux, .gcc)
+		_, ordered_args, _ := builder.split_ordered_pkgconfig_link_flags([])
+		assert ordered_args == ['"${library_path}"']
+
+		direct_output := os.join_path(root, 'direct.out')
+		mut direct_args := [main_source]
+		direct_args << ordered_args
+		direct_args << ['-o', direct_output]
+		direct_command := '${os.quoted_path(gcc)} ${direct_args.map(shell_safe_cc_arg(it)).join(' ')}'
+		direct_link := os.execute(direct_command)
+		assert direct_link.exit_code == 0, direct_link.output
+		assert issue74_run_tool(direct_output, [], root).exit_code == 0
+
+		rsp_output := os.join_path(root, 'rsp.out')
+		mut rsp_args := [main_source]
+		rsp_args << ordered_args
+		rsp_args << ['-o', rsp_output]
+		rsp_args = rsp_args.map(builder.rsp_safe_arg(it))
+		assert builder.should_use_rsp(rsp_args)
+		rsp_path := os.join_path(root, 'link.rsp')
+		os.write_file(rsp_path, rsp_args.join(' ').replace('\\', '\\\\')) or { panic(err) }
+		rsp_link := issue74_run_tool(gcc, ['@${rsp_path}'], root)
+		assert rsp_link.exit_code == 0, rsp_link.stdout + rsp_link.stderr
+		assert issue74_run_tool(rsp_output, [], root).exit_code == 0
+	}
+}
+
+fn test_static_pkgconfig_spaced_wl_rpath_links_direct_and_response_file() {
+	$if linux {
+		gcc := os.find_abs_path_of_executable('gcc') or { return }
+		readelf := os.find_abs_path_of_executable('readelf') or { return }
+		root := os.join_path(os.vtmp_dir(), 'issue74_spaced_wl_rpath_${os.getpid()}')
+		lib_dir := os.join_path(root, 'runtime libs with spaces')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(lib_dir) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+
+		main_source := os.join_path(root, 'main.c')
+		library_source := os.join_path(root, 'library.c')
+		library_path := os.join_path(lib_dir, 'libissue74_spaced_rpath.so')
+		os.write_file(main_source,
+			'int issue74_spaced_rpath(void);\nint main(void) { return issue74_spaced_rpath() == 74 ? 0 : 1; }\n') or {
+			panic(err)
+		}
+		os.write_file(library_source, 'int issue74_spaced_rpath(void) { return 74; }\n') or {
+			panic(err)
+		}
+		shared_link := issue74_run_tool(gcc,
+			['-fPIC', '-shared', library_source, '-o', library_path], root)
+		assert shared_link.exit_code == 0, shared_link.stdout + shared_link.stderr
+
+		mut builder := issue74_pkgconfig_builder_for_target(['-L${lib_dir}', '-lissue74_spaced_rpath',
+			'-Wl,-rpath,${lib_dir}'], .linux, .gcc)
+		_, ordered_args, _ := builder.split_ordered_pkgconfig_link_flags([])
+		assert ordered_args == ['-L"${os.real_path(lib_dir)}"', '-lissue74_spaced_rpath',
+			'"-Wl,-rpath,${lib_dir}"']
+
+		direct_output := os.join_path(root, 'direct.out')
+		mut direct_args := [main_source]
+		direct_args << ordered_args
+		direct_args << ['-o', direct_output]
+		direct_command := '${os.quoted_path(gcc)} ${direct_args.map(shell_safe_cc_arg(it)).join(' ')}'
+		direct_link := os.execute(direct_command)
+		assert direct_link.exit_code == 0, direct_link.output
+		assert issue74_run_tool(direct_output, [], root).exit_code == 0
+		direct_dynamic := issue74_run_tool(readelf, ['-d', direct_output], root)
+		assert direct_dynamic.exit_code == 0, direct_dynamic.stdout + direct_dynamic.stderr
+		direct_runpaths := direct_dynamic.stdout.split_into_lines().filter(it.contains('(RUNPATH)'))
+		assert direct_runpaths.len == 1, direct_dynamic.stdout
+		assert direct_runpaths[0].all_after('Library runpath: [').all_before(']') == lib_dir
+
+		rsp_output := os.join_path(root, 'rsp.out')
+		mut rsp_args := [main_source]
+		rsp_args << ordered_args
+		rsp_args << ['-o', rsp_output]
+		rsp_args = rsp_args.map(builder.rsp_safe_arg(it))
+		assert builder.should_use_rsp(rsp_args)
+		rsp_path := os.join_path(root, 'link.rsp')
+		os.write_file(rsp_path, rsp_args.join(' ').replace('\\', '\\\\')) or { panic(err) }
+		rsp_link := issue74_run_tool(gcc, ['@${rsp_path}'], root)
+		assert rsp_link.exit_code == 0, rsp_link.stdout + rsp_link.stderr
+		assert issue74_run_tool(rsp_output, [], root).exit_code == 0
+		rsp_dynamic := issue74_run_tool(readelf, ['-d', rsp_output], root)
+		assert rsp_dynamic.exit_code == 0, rsp_dynamic.stdout + rsp_dynamic.stderr
+		rsp_runpaths := rsp_dynamic.stdout.split_into_lines().filter(it.contains('(RUNPATH)'))
+		assert rsp_runpaths.len == 1, rsp_dynamic.stdout
+		assert rsp_runpaths[0].all_after('Library runpath: [').all_before(']') == lib_dir
+	}
+}
+
+fn test_windows_gnu_static_pkgconfig_converts_only_bare_import_libs() {
+	lib_dir := os.join_path(os.vtmp_dir(), 'issue74_windows_gnu_libs')
+	path_lib := os.join_path(lib_dir, 'issue74_path.lib')
+	expected_path_lib := if path_lib.contains_any(' \t\r\n') { '"${path_lib}"' } else { path_lib }
+	flags := ['-L${lib_dir}', 'issue74_direct.lib', '-lissue74_anchor', 'issue74_repeat.lib',
+		path_lib, 'issue74_upper.LIB', 'issue74_direct.lib', 'issue74_repeat.lib']
+	expected_tail := ['-lissue74_direct', '-lissue74_anchor', '-lissue74_repeat', expected_path_lib,
+		'-lissue74_upper', '-lissue74_direct', '-lissue74_repeat']
+	for compiler_type in [pref.CompilerType.gcc, .mingw] {
+		args := issue74_ordered_pkgconfig_args_for_target(flags, .windows, compiler_type)
+		assert args.len == expected_tail.len + 1, '${compiler_type}: ${args}'
+		assert args[0].starts_with('-L'), '${compiler_type}: ${args}'
+		assert args[0].contains(os.real_path(lib_dir)), '${compiler_type}: ${args}'
+		assert args[1..] == expected_tail, '${compiler_type}: ${args}'
+	}
+
+	posix_args := issue74_ordered_pkgconfig_args_for_target(flags, .linux, .gcc)
+	assert !posix_args.any(it in ['-lissue74_direct', '-lissue74_repeat', '-lissue74_upper']), posix_args.str()
+	assert posix_args.join(' ').contains('issue74_direct.lib'), posix_args.str()
+	for compiler_type in [pref.CompilerType.clang, .msvc] {
+		args := issue74_ordered_pkgconfig_args_for_target(flags, .windows, compiler_type)
+		assert args == posix_args, '${compiler_type}: ${args}'
+	}
+}
+
+fn test_windows_gnu_static_pkgconfig_quotes_spaced_wl_before_import_conversion() {
+	rpath := r'C:\issue74 runtime libs'
+	flags := ['-Wl,-rpath,${rpath}', 'Version.lib']
+	expected := ['"-Wl,-rpath,${rpath}"', '-lVersion']
+	for compiler_type in [pref.CompilerType.gcc, .mingw] {
+		args := issue74_ordered_pkgconfig_args_for_target(flags, .windows, compiler_type)
+		assert args == expected, '${compiler_type}: ${args}'
+	}
+}
+
+fn test_windows_gnu_static_pkgconfig_preserves_quoted_direct_lib_in_direct_link() {
+	flags, direct_lib := issue74_quoted_direct_import_lib_case()
+	mut builder := issue74_pkgconfig_builder_for_target(flags, .windows, .gcc)
+	_, args, _ := builder.split_ordered_pkgconfig_link_flags([])
+	assert args.len == 3, args.str()
+	assert args[1] == '"${direct_lib}"', args.str()
+	assert args[2] == '-lIssue74Mixed', args.str()
+	direct_command := args.map(shell_safe_cc_arg(it)).join(' ')
+	assert direct_command.contains(' "${direct_lib}" '), direct_command
+}
+
+fn test_windows_gnu_static_pkgconfig_preserves_quoted_direct_lib_in_response_file() {
+	flags, direct_lib := issue74_quoted_direct_import_lib_case()
+	mut builder := issue74_pkgconfig_builder_for_target(flags, .windows, .gcc)
+	_, args, _ := builder.split_ordered_pkgconfig_link_flags([])
+	rsp_args := args.map(builder.rsp_safe_arg(it))
+	assert builder.should_use_rsp(rsp_args)
+	response_file_content := rsp_args.join(' ').replace('\\', '\\\\')
+	escaped_direct_lib := direct_lib.replace('\\', '\\\\')
+	assert response_file_content.contains(' "${escaped_direct_lib}" '), response_file_content
+}
+
+fn issue74_is_xlinker_operand_marker(arg string) bool {
+	return arg in issue74_xlinker_operand_markers
+}
+
+fn test_consecutive_ordinary_xlinker_operand_stays_adjacent_to_its_control() {
+	mut builder := issue74_builder_for_source(issue74_xlinker_operand_source)
+	all_args := builder.all_args(builder.ccoptions)
+	markers := all_args.filter(issue74_is_xlinker_operand_marker(it))
+	assert markers == issue74_xlinker_operand_markers, all_args.str()
+	operand_index := all_args.index('--issue74-xlinker-operand')
+	assert all_args.count(it == '--issue74-xlinker-operand') == 1, all_args.str()
+	assert operand_index > 0, all_args.str()
+	assert all_args[operand_index - 1] == '-Xlinker', all_args.str()
+}
+
+fn test_wl_operand_aliases_keep_their_next_ordinary_flag_adjacent() {
+	for control, operand in {
+		'-Wl,--rpath':      '/issue74/rpath-long'
+		'-Wl,-R':           '/issue74/r-capital'
+		'-Wl,-rpath-link':  '/issue74/rpath-link-single'
+		'-Wl,--rpath-link': '/issue74/rpath-link'
+	} {
+		mut builder :=
+			issue74_builder_for_source(issue74_wl_operand_source(control, operand, false))
+		all_args := builder.all_args(builder.ccoptions)
+		control_index := all_args.index(control)
+		assert control_index >= 0, '${control}: ${all_args}'
+		assert all_args[control_index + 1] == operand, '${control}: ${all_args}'
+		assert all_args.index('-Wl,--issue74-order-pkg-public') > control_index + 1, '${control}: ${all_args}'
+	}
+}
+
+fn test_wl_non_operand_controls_remain_non_consuming() {
+	mut table := ast.new_table()
+	for control in ['-Wl,--rpath,', '-Wl,--as-needed'] {
+		table.parse_cflag_with_link_segment(control, 'main', []) or { panic(err) }
+		flag := table.link_flag_segments.last().flags[0]
+		assert !ordinary_flag_takes_linker_operand(flag), control
+	}
+}
+
+fn issue74_builder_with_pkgconfig_pthread(pkgconfig_flags []string, extra_args []string) Builder {
+	return issue74_builder_with_pkgconfig_pthread_and_compiler(pkgconfig_flags, 'gcc', extra_args)
+}
+
+fn issue74_builder_with_pkgconfig_pthread_and_compiler(pkgconfig_flags []string, ccompiler string, extra_args []string) Builder {
+	driver_environment := issue74_clear_driver_environment()
+	defer {
+		driver_environment.restore()
+	}
+	return issue74_builder_with_pkgconfig_pthread_and_compiler_from_environment(pkgconfig_flags,
+		ccompiler, extra_args)
+}
+
+fn issue74_builder_with_pkgconfig_pthread_and_compiler_from_environment(pkgconfig_flags []string, ccompiler string, extra_args []string) Builder {
+	source_path := os.join_path('/virtual', 'issue74_pkgconfig_pthread.v')
+	mut args := ['', '-cc', ccompiler]
+	args << extra_args
+	args << source_path
+	mut prefs, _ := pref.parse_args([], args)
+	prefs.out_name = os.join_path(os.vtmp_dir(), 'issue74_pkgconfig_pthread.out')
+	mut table := ast.new_table()
+	if pkgconfig_flags.len > 0 {
+		table.parse_pkgconfig_link_flags(pkgconfig_flags, 'main', prefs.compile_defines_all) or {
+			panic(err)
+		}
+	}
+	mut builder := new_builder(prefs)
+	builder.table = table
+	builder.out_name_c = os.join_path(os.vtmp_dir(), 'issue74_pkgconfig_pthread.tmp.c')
+	builder.setup_ccompiler_options(ccompiler)
+	builder.setup_output_name()
+	return builder
+}
+
+fn test_pkgconfig_builder_helpers_ignore_ambient_driver_flags() {
+	driver_environment := issue74_clear_driver_environment()
+	defer {
+		driver_environment.restore()
+	}
+	os.setenv('CFLAGS', '-pthread', true)
+	os.setenv('LDFLAGS', '-pthread', true)
+
+	builder := issue74_builder_with_pkgconfig_pthread([], [])
+	assert builder.get_compile_args().count(it == '-pthread') == 0
+	assert builder.get_linker_args().count(it == '-pthread') == 0
+	assert os.getenv('CFLAGS') == '-pthread'
+	assert os.getenv('LDFLAGS') == '-pthread'
+}
+
+fn test_pkgconfig_pthread_provenance_excludes_linker_only_sources() {
+	driver_environment := issue74_clear_driver_environment()
+	defer {
+		driver_environment.restore()
+	}
+
+	pkgconfig_builder := issue74_builder_with_pkgconfig_pthread(['-pthread'], [])
+	assert pkgconfig_builder.has_pkgconfig_pthread()
+	assert pkgconfig_builder.get_linker_args().count(it == '-pthread') == 1
+
+	ldflags_builder := issue74_builder_with_pkgconfig_pthread([], ['-ldflags', '-pthread'])
+	assert !ldflags_builder.has_pkgconfig_pthread()
+	assert ldflags_builder.get_linker_args().count(it.trim_space() == '-pthread') == 1
+
+	os.setenv('LDFLAGS', '-pthread', true)
+	env_ldflags_builder := issue74_builder_with_pkgconfig_pthread_and_compiler_from_environment([],
+		'gcc', [])
+	assert !env_ldflags_builder.has_pkgconfig_pthread()
+	assert env_ldflags_builder.get_linker_args().count(it == '-pthread') == 1
+}
+
+fn test_pkgconfig_pthread_is_projected_once_for_gnu_compile_only_paths() {
+	for ccompiler in ['gcc', 'clang', 'x86_64-w64-mingw32-gcc'] {
+		object_builder := issue74_builder_with_pkgconfig_pthread_and_compiler([
+			'-pthread',
+		], ccompiler, ['-is_o'])
+		assert object_builder.get_compile_args().count(it == '-pthread') == 1, ccompiler
+		assert object_builder.get_linker_args() == [], ccompiler
+
+		module_builder := issue74_builder_with_pkgconfig_pthread_and_compiler([
+			'-pthread',
+		], ccompiler, ['build-module'])
+		assert module_builder.get_compile_args().count(it == '-pthread') == 1, ccompiler
+		assert module_builder.get_linker_args() == [], ccompiler
+	}
+}
+
+fn test_pkgconfig_pthread_is_projected_for_gnu_cplusplus_object_compilation() {
+	object_builder := issue74_builder_with_pkgconfig_pthread_and_compiler(['-pthread'], 'g++', [
+		'-is_o',
+	])
+	assert object_builder.pref.ccompiler_type == .cplusplus
+	assert object_builder.ccoptions.cc == .unknown
+	compile_args := object_builder.get_compile_args()
+	assert compile_args.count(it == '-pthread') == 1
+	assert object_builder.get_linker_args() == []
+	rsp_args :=
+		object_builder.all_args(object_builder.ccoptions).map(object_builder.rsp_safe_arg(it))
+	assert object_builder.should_use_rsp(rsp_args)
+	assert rsp_args.count(it == '-pthread') == 1
+}
+
+fn test_pkgconfig_pthread_compile_only_projection_is_deduplicated() {
+	object_builder := issue74_builder_with_pkgconfig_pthread(['-pthread'], [
+		'-is_o',
+		'-cflags',
+		'-pthread',
+	])
+	compile_args := object_builder.get_compile_args()
+	assert compile_args.filter(pref.contains_exact_cflag_token(it, '-pthread')).len == 1
+}
+
+fn test_pkgconfig_pthread_combined_cflags_is_not_duplicated_for_compile_only_paths() {
+	combined_cflags := '-DISSUE74_CFLAGS=1 -pthread'
+	object_builder := issue74_builder_with_pkgconfig_pthread(['-pthread'], [
+		'-is_o',
+		'-cflags',
+		combined_cflags,
+	])
+	object_compile_args := object_builder.get_compile_args()
+	assert object_compile_args.filter(pref.contains_exact_cflag_token(it, '-pthread')).len == 1
+
+	module_builder := issue74_builder_with_pkgconfig_pthread(['-pthread'], [
+		'build-module',
+		'-cflags',
+		combined_cflags,
+	])
+	module_compile_args := module_builder.get_compile_args()
+	assert module_compile_args.filter(pref.contains_exact_cflag_token(it, '-pthread')).len == 1
+}
+
+fn test_pkgconfig_pthread_combined_environment_cflags_is_not_duplicated_for_compile_only_paths() {
+	driver_environment := issue74_clear_driver_environment()
+	combined_cflags := '-DISSUE74_ENV_CFLAGS=1 -pthread'
+	os.setenv('CFLAGS', combined_cflags, true)
+	defer {
+		driver_environment.restore()
+	}
+
+	object_builder := issue74_builder_with_pkgconfig_pthread_and_compiler_from_environment([
+		'-pthread',
+	], 'gcc', ['-is_o'])
+	object_compile_args := object_builder.get_compile_args()
+	assert object_compile_args.filter(pref.contains_exact_cflag_token(it, '-pthread')).len == 1
+
+	module_builder := issue74_builder_with_pkgconfig_pthread_and_compiler_from_environment([
+		'-pthread',
+	], 'gcc', ['build-module'])
+	module_compile_args := module_builder.get_compile_args()
+	assert module_compile_args.filter(pref.contains_exact_cflag_token(it, '-pthread')).len == 1
+}
+
+fn test_pkgconfig_pthread_direct_and_unsupported_compilers_are_not_projected() {
+	direct_builder := issue74_builder_with_pkgconfig_pthread(['-pthread'], [])
+	assert direct_builder.get_compile_args().count(it == '-pthread') == 0
+	assert direct_builder.get_linker_args().count(it == '-pthread') == 1
+	assert direct_builder.all_args(direct_builder.ccoptions).count(it == '-pthread') == 1
+
+	shared_module_builder := issue74_builder_with_pkgconfig_pthread(['-pthread'], [
+		'-shared',
+		'build-module',
+	])
+	assert shared_module_builder.get_compile_args().count(it == '-pthread') == 0
+	assert shared_module_builder.get_linker_args().count(it == '-pthread') == 1
+
+	for ccompiler in ['tcc', 'msvc'] {
+		object_builder := issue74_builder_with_pkgconfig_pthread_and_compiler([
+			'-pthread',
+		], ccompiler, ['-is_o'])
+		assert object_builder.get_compile_args().count(it == '-pthread') == 0, ccompiler
+	}
+}
+
+fn test_linker_only_pthread_is_not_projected_for_object_compilation() {
+	driver_environment := issue74_clear_driver_environment()
+	defer {
+		driver_environment.restore()
+	}
+
+	explicit_builder := issue74_builder_with_pkgconfig_pthread([], [
+		'-is_o',
+		'-ldflags',
+		'-pthread',
+	])
+	assert explicit_builder.get_compile_args().count(it == '-pthread') == 0
+
+	os.setenv('LDFLAGS', '-pthread', true)
+	environment_builder := issue74_builder_with_pkgconfig_pthread_and_compiler_from_environment([],
+		'gcc', ['-is_o'])
+	assert environment_builder.get_compile_args().count(it == '-pthread') == 0
+}
+
+fn issue74_environment_value_case_insensitive(env map[string]string, name string) string {
+	lower_name := name.to_lower_ascii()
+	mut fallback := ''
+	for key, value in env {
+		if key == name {
+			return value
+		}
+		if key.to_lower_ascii() == lower_name {
+			fallback = value
+		}
+	}
+	return fallback
+}
+
+fn issue74_replace_environment_value_case_insensitive(mut env map[string]string, name string, value string) {
+	lower_name := name.to_lower_ascii()
+	for key in env.keys() {
+		if key.to_lower_ascii() == lower_name {
+			env.delete(key)
+		}
+	}
+	env[name] = value
+}
+
+fn issue74_remove_driver_environment(mut env map[string]string) {
+	for key in env.keys() {
+		if key.to_upper_ascii() in ['CFLAGS', 'LDFLAGS'] {
+			env.delete(key)
+		}
+	}
+}
+
+fn issue74_write_fake_ccompiler(path string) {
+	$if windows {
+		bin_dir := os.dir(path)
+		recorder_source := os.join_path(bin_dir, 'issue74_fake_ccompiler.v')
+		recorder_exe := os.join_path(bin_dir, 'issue74_fake_ccompiler.exe')
+		if !os.exists(recorder_exe) {
+			os.write_file(recorder_source, issue74_windows_fake_ccompiler_source) or { panic(err) }
+			mut process := os.new_process(@VEXE)
+			process.set_args(['-gc', 'none', '-no-retry-compilation', '-o', recorder_exe,
+				recorder_source])
+			process.set_work_folder(@VEXEROOT)
+			mut recorder_env := os.environ()
+			issue74_remove_driver_environment(mut recorder_env)
+			issue74_replace_environment_value_case_insensitive(mut recorder_env, 'VFLAGS', '')
+			process.set_environment(recorder_env)
+			process.set_redirect_stdio()
+			process.wait()
+			stdout := process.stdout_slurp()
+			stderr := process.stderr_slurp()
+			exit_code := process.code
+			process.close()
+			assert exit_code == 0, 'failed to build Windows fake C compiler:\nstdout:\n${stdout}\nstderr:\n${stderr}'
+		}
+		if !os.exists(path) {
+			os.cp(recorder_exe, path) or { panic(err) }
+		}
+		return
+	}
+	os.write_file(path, '#!/bin/sh
+set -eu
+: "\${ISSUE74_CC_LOG:?ISSUE74_CC_LOG must name the argv log}"
+for arg do
+	printf "%s\\n" "\$arg" >> "\$ISSUE74_CC_LOG"
+done
+output=""
+take_output=0
+for arg do
+	if [ "\$take_output" -eq 1 ]; then
+		output=\$arg
+		take_output=0
+	elif [ "\$arg" = "-o" ]; then
+		take_output=1
+	fi
+done
+if [ -n "\$output" ]; then
+	mkdir -p "\$(dirname "\$output")"
+	: > "\$output"
+fi
+') or {
+		panic(err)
+	}
+	os.chmod(path, 0o700) or { panic(err) }
+}
+
+struct Issue74FakeCompileResult {
+	exit_code int
+	stdout    string
+	stderr    string
+	argv      []string
+}
+
+fn issue74_run_fake_compile(root string, ccompiler string, name string, source string) Issue74FakeCompileResult {
+	return issue74_run_fake_compile_with_args(root, ccompiler, name, source, []string{})
+}
+
+fn issue74_run_fake_compile_with_args(root string, ccompiler string, name string, source string, extra_args []string) Issue74FakeCompileResult {
+	bin_dir := os.join_path(root, 'bin')
+	probe_name := '${ccompiler}_${name}'
+	tmp_dir := os.join_path(root, 'tmp', probe_name)
+	os.mkdir_all(bin_dir) or { panic(err) }
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	mut fake_ccompiler_name := ccompiler
+	$if windows {
+		fake_ccompiler_name += '.exe'
+	}
+	fake_ccompiler := os.join_path(bin_dir, fake_ccompiler_name)
+	issue74_write_fake_ccompiler(fake_ccompiler)
+	source_path := os.join_path(root, '${probe_name}.v')
+	output_path := os.join_path(root, '${probe_name}.out')
+	log_path := os.join_path(root, '${probe_name}.argv')
+	os.write_file(source_path, source) or { panic(err) }
+	mut env := os.environ()
+	issue74_remove_driver_environment(mut env)
+	current_path := issue74_environment_value_case_insensitive(env, 'PATH')
+	issue74_replace_environment_value_case_insensitive(mut env, 'PATH',
+		'${bin_dir}${os.path_delimiter}${current_path}')
+	env['PKG_CONFIG_PATH'] = ''
+	env['PKG_CONFIG_PATH_DEFAULTS'] = issue74_fixture_dir
+	env['ISSUE74_CC_LOG'] = log_path
+	env['TMPDIR'] = tmp_dir
+	issue74_replace_environment_value_case_insensitive(mut env, 'VFLAGS', '')
+	mut process := os.new_process(@VEXE)
+	mut compiler_args := ['-no-rsp', '-gc', 'none', '-cc', ccompiler, '-no-retry-compilation']
+	compiler_args << extra_args
+	compiler_args << ['-o', output_path, source_path]
+	process.set_args(compiler_args)
+	process.set_work_folder(@VEXEROOT)
+	process.set_environment(env)
+	process.set_redirect_stdio()
+	process.wait()
+	stdout := process.stdout_slurp()
+	stderr := process.stderr_slurp()
+	exit_code := process.code
+	process.close()
+	argv := if os.exists(log_path) { os.read_lines(log_path) or { panic(err) } } else { []string{} }
+	return Issue74FakeCompileResult{
+		exit_code: exit_code
+		stdout:    stdout
+		stderr:    stderr
+		argv:      argv
+	}
+}
+
+fn issue74_fake_compile(root string, ccompiler string, name string, source string) []string {
+	result := issue74_run_fake_compile(root, ccompiler, name, source)
+	assert result.exit_code == 0, 'fake ${ccompiler} probe ${name} failed:\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}'
+	return result.argv
+}
+
+fn issue74_fake_compile_with_args(root string, ccompiler string, name string, source string, extra_args []string) []string {
+	result := issue74_run_fake_compile_with_args(root, ccompiler, name, source, extra_args)
+	assert result.exit_code == 0, 'fake ${ccompiler} probe ${name} failed:\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}'
+	return result.argv
+}
+
+fn issue74_is_fake_compiler_marker(arg string) bool {
+	return arg.contains('ISSUE74_') || arg.starts_with('-Wl,--issue74-')
+}
+
+fn issue74_is_static_linker_marker(arg string) bool {
+	return arg.starts_with('-lissue74_') || arg in ['-Wl,--start-group', '-Wl,--end-group']
+}
+
+fn issue74_is_group_alias_marker(arg string) bool {
+	return arg.starts_with('-lissue74_alias_') || arg in ['-Wl,-(', '-Wl,-)']
+}
+
+fn test_shell_safe_cc_arg_only_quotes_group_aliases() {
+	assert shell_safe_cc_arg('-Wl,-(') == os.quoted_path('-Wl,-(')
+	assert shell_safe_cc_arg('-Wl,-)') == os.quoted_path('-Wl,-)')
+	for arg in ['-pthread', '-lissue74_unchanged', '-Wl,--start-group', '-Wl,--end-group',
+		'-DISSUE74_UNCHANGED=1'] {
+		assert shell_safe_cc_arg(arg) == arg
+	}
+}
+
+fn test_pkgconfig_posix_fake_compiler_final_argv() {
+	$if linux || macos {
+		root := os.join_path(os.vtmp_dir(), 'issue74_pkgconfig_fake_compiler')
+		os.rmdir_all(root) or {}
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		for ccompiler in ['gcc', 'clang'] {
+			order_markers := issue74_fake_compile(root, ccompiler, 'source_order',
+				issue74_source_order_source).filter(issue74_is_source_order_marker(it))
+			assert order_markers == issue74_source_order_markers, ccompiler
+			dynamic_argv := issue74_fake_compile(root, ccompiler, 'dynamic_compat',
+				issue74_dynamic_compat_source)
+			dynamic_define_index := dynamic_argv.index('ISSUE74_DYNAMIC_SENTINEL')
+			assert dynamic_define_index > 0, ccompiler
+			assert dynamic_argv[dynamic_define_index - 1] == '-D', ccompiler
+			dynamic_markers := dynamic_argv.filter(issue74_is_fake_compiler_marker(it))
+			assert dynamic_markers == [
+				'ISSUE74_DYNAMIC_SENTINEL',
+				'-Wl,--issue74-dynamic-sentinel',
+			], ccompiler
+			xlinker_argv := issue74_fake_compile(root, ccompiler, 'xlinker_operand',
+				issue74_xlinker_operand_source)
+			xlinker_markers := xlinker_argv.filter(issue74_is_xlinker_operand_marker(it))
+			assert xlinker_markers == issue74_xlinker_operand_markers, ccompiler
+			xlinker_operand_index := xlinker_argv.index('--issue74-xlinker-operand')
+			assert xlinker_argv.count(it == '--issue74-xlinker-operand') == 1, ccompiler
+			assert xlinker_operand_index > 0, ccompiler
+			assert xlinker_argv[xlinker_operand_index - 1] == '-Xlinker', ccompiler
+
+			ldflags_static_argv := issue74_fake_compile_with_args(root, ccompiler,
+				'ldflags_static', issue74_ldflags_static_source, ['-ldflags', '-static'])
+			static_markers := ldflags_static_argv.filter(issue74_is_static_linker_marker(it))
+			assert static_markers == issue74_static_linker_markers, ccompiler
+			assert ldflags_static_argv.count(it == '-static') == 1, ccompiler
+
+			group_alias_argv := issue74_fake_compile(root, ccompiler, 'group_alias',
+				issue74_group_alias_source)
+			group_alias_markers := group_alias_argv.filter(issue74_is_group_alias_marker(it))
+			assert group_alias_markers == issue74_group_alias_markers, ccompiler
+
+			parallel_group_alias_argv := issue74_fake_compile_with_args(root, ccompiler,
+				'group_alias_parallel', issue74_group_alias_source, ['-parallel-cc'])
+			parallel_group_alias_markers :=
+				parallel_group_alias_argv.filter(issue74_is_group_alias_marker(it))
+			assert parallel_group_alias_markers == issue74_group_alias_markers, ccompiler
+		}
+	}
+}
+
+fn test_pkgconfig_posix_generated_project_group_alias_commands() {
+	$if linux || macos {
+		root := os.join_path(os.vtmp_dir(), 'issue74_pkgconfig_generated_project_group_alias')
+		os.rmdir_all(root) or {}
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		project_dir := os.join_path(root, 'project')
+		unrelated_arg := '-DISSUE74_GENERATED_PROJECT_UNCHANGED=1'
+		generated := issue74_run_fake_compile_with_args(root, 'gcc', 'group_alias_project',
+			issue74_group_alias_source, [
+			'-cflags',
+			unrelated_arg,
+			'-generate-c-project',
+			project_dir,
+		])
+		assert generated.exit_code == 0, 'generated project probe failed:\nstdout:\n${generated.stdout}\nstderr:\n${generated.stderr}'
+
+		quoted_group_start := os.quoted_path('-Wl,-(')
+		quoted_group_end := os.quoted_path('-Wl,-)')
+		for build_file in ['build.sh', 'Makefile'] {
+			command := os.read_file(os.join_path(project_dir, build_file)) or { panic(err) }
+			assert command.contains(quoted_group_start), build_file
+			assert command.contains(quoted_group_end), build_file
+			assert command.contains(unrelated_arg), build_file
+			assert !command.contains(' -Wl,-( '), build_file
+			assert !command.contains(' -Wl,-) '), build_file
+		}
+
+		bin_dir := os.join_path(root, 'bin')
+		mut env := os.environ()
+		issue74_remove_driver_environment(mut env)
+		current_path := issue74_environment_value_case_insensitive(env, 'PATH')
+		issue74_replace_environment_value_case_insensitive(mut env, 'PATH',
+			'${bin_dir}${os.path_delimiter}${current_path}')
+		issue74_replace_environment_value_case_insensitive(mut env, 'VFLAGS', '')
+		for process_args in [
+			['sh', os.join_path(project_dir, 'build.sh')],
+			['make'],
+		] {
+			log_path := os.join_path(root, '${process_args[0]}.generated.argv')
+			os.rm(log_path) or {}
+			env['ISSUE74_CC_LOG'] = log_path
+			mut process := os.new_process(process_args[0])
+			process.set_args(process_args[1..])
+			process.set_work_folder(project_dir)
+			process.set_environment(env)
+			process.set_redirect_stdio()
+			process.wait()
+			stdout := process.stdout_slurp()
+			stderr := process.stderr_slurp()
+			exit_code := process.code
+			process.close()
+			assert exit_code == 0, '${process_args[0]} generated project build failed:\nstdout:\n${stdout}\nstderr:\n${stderr}'
+			argv := os.read_lines(log_path) or { panic(err) }
+			group_alias_markers := argv.filter(issue74_is_group_alias_marker(it))
+			assert group_alias_markers == issue74_group_alias_markers, process_args[0]
+			assert argv.count(it == unrelated_arg) == 1, process_args[0]
+		}
+	}
+}
+
+fn test_pkgconfig_windows_fake_compiler_group_alias_final_argv() {
+	$if windows {
+		root := os.join_path(os.vtmp_dir(), 'issue74_pkgconfig_windows_fake_compiler')
+		os.rmdir_all(root) or {}
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		for ccompiler in ['gcc', 'clang'] {
+			group_alias_argv := issue74_fake_compile(root, ccompiler, 'group_alias_windows',
+				issue74_group_alias_source)
+			group_alias_markers := group_alias_argv.filter(issue74_is_group_alias_marker(it))
+			assert group_alias_markers == issue74_group_alias_markers, ccompiler
+
+			parallel_group_alias_argv := issue74_fake_compile_with_args(root, ccompiler,
+				'group_alias_parallel_windows', issue74_group_alias_source, [
+				'-parallel-cc',
+			])
+			parallel_group_alias_markers :=
+				parallel_group_alias_argv.filter(issue74_is_group_alias_marker(it))
+			assert parallel_group_alias_markers == issue74_group_alias_markers, ccompiler
+		}
+	}
+}
+
+fn test_pkgconfig_posix_builder_rejects_incomplete_xlinker_operand() {
+	$if linux || macos {
+		root := os.join_path(os.vtmp_dir(), 'issue74_pkgconfig_incomplete_xlinker')
+		os.rmdir_all(root) or {}
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		for ccompiler in ['gcc', 'clang'] {
+			interrupted := issue74_run_fake_compile(root, ccompiler, 'xlinker_interrupted',
+				issue74_xlinker_interrupted_source)
+			assert interrupted.exit_code != 0, ccompiler
+			assert interrupted.argv == [], ccompiler
+			assert (interrupted.stdout + interrupted.stderr).contains('incomplete linker option `-Xlinker` before `#pkgconfig`'), ccompiler
+
+			end_of_stream := issue74_run_fake_compile(root, ccompiler, 'xlinker_end_of_stream',
+				issue74_xlinker_end_of_stream_source)
+			assert end_of_stream.exit_code != 0, ccompiler
+			assert end_of_stream.argv == [], ccompiler
+			assert (end_of_stream.stdout + end_of_stream.stderr).contains('incomplete linker option `-Xlinker` at the end of ordered linker flags'), ccompiler
+
+			rpath_interrupted := issue74_run_fake_compile(root, ccompiler, 'wl_rpath_interrupted',
+				issue74_wl_rpath_interrupted_source)
+			assert rpath_interrupted.exit_code != 0, ccompiler
+			assert rpath_interrupted.argv == [], ccompiler
+			assert (rpath_interrupted.stdout + rpath_interrupted.stderr).contains('incomplete linker option `-Wl,-rpath` before `#pkgconfig`'), ccompiler
+
+			version_script_interrupted := issue74_run_fake_compile(root, ccompiler,
+				'version_script_interrupted', issue74_version_script_interrupted_source)
+			assert version_script_interrupted.exit_code != 0, ccompiler
+			assert version_script_interrupted.argv == [], ccompiler
+			assert (version_script_interrupted.stdout + version_script_interrupted.stderr).contains('incomplete linker option `-Wl,--version-script` before `#pkgconfig`'), ccompiler
+
+			for control, operand in {
+				'-Wl,--rpath':      '/issue74/rpath-long'
+				'-Wl,-R':           '/issue74/r-capital'
+				'-Wl,-rpath-link':  '/issue74/rpath-link-single'
+				'-Wl,--rpath-link': '/issue74/rpath-link'
+			} {
+				alias := control.replace_each(['-', '_', ',', '_'])
+				alias_interrupted := issue74_run_fake_compile(root, ccompiler, alias, issue74_wl_operand_source(control,
+					operand, true))
+				assert alias_interrupted.exit_code != 0, '${ccompiler}: ${control}'
+				assert alias_interrupted.argv == [], '${ccompiler}: ${control}'
+				assert (alias_interrupted.stdout + alias_interrupted.stderr).contains('incomplete linker option `${control}` before `#pkgconfig`'), '${ccompiler}: ${control}'
+			}
+		}
+	}
+}

--- a/vlib/v/cflag/cflags.v
+++ b/vlib/v/cflag/cflags.v
@@ -205,26 +205,76 @@ fn windows_import_lib_to_link_flag(value string) string {
 	return '-l${lib[..lib.len - '.lib'.len]}'
 }
 
+struct QuotedFlagPart {
+	value string
+	raw   string
+}
+
+// windows_import_lib_link_args formats one C flag as ordered GNU linker arguments,
+// translating bare import-library names while retaining quoted direct paths.
+pub fn (cf &CFlag) windows_import_lib_link_args() []string {
+	parts := split_quoted_flag_parts(cf.value)
+	if parts.len == 0 {
+		formatted := cf.format() or { return []string{} }
+		return [formatted]
+	}
+	mut args := []string{cap: parts.len}
+	mut first_extra := 0
+	if cf.name != '' {
+		first := CFlag{
+			mod:   cf.mod
+			os:    cf.os
+			name:  cf.name
+			value: parts[0].value
+		}
+		formatted := first.format() or { return []string{} }
+		args << formatted
+		first_extra = 1
+	}
+	for part in parts[first_extra..] {
+		if !part.value.starts_with('-') && is_bare_windows_import_lib(part.value) {
+			args << windows_import_lib_to_link_flag(part.value)
+		} else {
+			args << part.raw
+		}
+	}
+	return args
+}
+
 fn split_quoted_flags(value string) []string {
-	mut parts := []string{}
+	return split_quoted_flag_parts(value).map(it.value)
+}
+
+fn split_quoted_flag_parts(value string) []QuotedFlagPart {
+	mut parts := []QuotedFlagPart{}
 	mut buf := []u8{}
+	mut raw := []u8{}
 	mut in_quote := false
 	for ch in value {
 		if ch == `"` {
 			in_quote = !in_quote
+			raw << ch
 			continue
 		}
 		if !in_quote && ch in [` `, `\t`] {
 			if buf.len > 0 {
-				parts << buf.bytestr()
+				parts << QuotedFlagPart{
+					value: buf.bytestr()
+					raw:   raw.bytestr()
+				}
 				buf = []u8{}
 			}
+			raw = []u8{}
 			continue
 		}
 		buf << ch
+		raw << ch
 	}
 	if buf.len > 0 {
-		parts << buf.bytestr()
+		parts << QuotedFlagPart{
+			value: buf.bytestr()
+			raw:   raw.bytestr()
+		}
 	}
 	return parts
 }

--- a/vlib/v/cflag/cflags_test.v
+++ b/vlib/v/cflag/cflags_test.v
@@ -39,3 +39,11 @@ fn test_defines_others_libs_keeps_direct_windows_import_lib_paths() {
 	].defines_others_libs()
 	assert libs == ['"${direct_path}"']
 }
+
+fn test_windows_import_lib_link_args_preserves_quoted_paths_and_converts_mixed_case_names() {
+	direct_path := 'C:/Program Files/Windows Kits/10/Lib/Version.LiB'
+	args := CFlag{
+		value: '"${direct_path}" Version.lib Advapi32.LIB'
+	}.windows_import_lib_link_args()
+	assert args == ['"${direct_path}"', '-lVersion', '-lAdvapi32']
+}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4489,22 +4489,54 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 				// (for example Linux OpenSSL headers when targeting Windows).
 				return
 			}
-			args := if node.main.contains('--') {
-				node.main.split(' ')
+			raw_args := node.main.split(' ')
+			mut parsed := pkgconfig.main(raw_args) or {
+				c.error(err.msg(), node.pos)
+				return
+			}
+			static_mode := c.pref.pkgconfig_mode == .static_ || parsed.link_mode() == .static_
+			if !static_mode {
+				args := if node.main.contains('--') {
+					raw_args
+				} else {
+					'--cflags --libs ${node.main}'.split(' ')
+				}
+				mut m := pkgconfig.main(args) or {
+					c.error(err.msg(), node.pos)
+					return
+				}
+				cflags := m.run() or {
+					c.error(err.msg(), node.pos)
+					return
+				}
+				c.table.parse_cflag_with_link_segment(cflags, c.mod, c.pref.compile_defines_all) or {
+					c.error(err.msg(), node.pos)
+					return
+				}
 			} else {
-				'--cflags --libs ${node.main}'.split(' ')
-			}
-			mut m := pkgconfig.main(args) or {
-				c.error(err.msg(), node.pos)
-				return
-			}
-			cflags := m.run() or {
-				c.error(err.msg(), node.pos)
-				return
-			}
-			c.table.parse_cflag(cflags, c.mod, c.pref.compile_defines_all) or {
-				c.error(err.msg(), node.pos)
-				return
+				if c.pref.pkgconfig_mode == .static_ {
+					parsed.force_static()
+				}
+				if !parsed.has_actions {
+					parsed.apply_default_actions()
+				}
+				result := parsed.run_result() or {
+					c.error(err.msg(), node.pos)
+					return
+				}
+				if result.cflags.len > 0 {
+					c.table.parse_cflag(result.cflags.join(' '), c.mod, c.pref.compile_defines_all) or {
+						c.error(err.msg(), node.pos)
+						return
+					}
+				}
+				if result.link_flags.len > 0 {
+					c.table.parse_pkgconfig_link_flags(result.link_flags, c.mod,
+						c.pref.compile_defines_all) or {
+						c.error(err.msg(), node.pos)
+						return
+					}
+				}
 			}
 		}
 		'flag' {
@@ -4514,7 +4546,7 @@ fn (mut c Checker) hash_stmt(mut node ast.HashStmt) {
 				c.error('no argument(s) provided for #flag', node.pos)
 			}
 			flag = c.resolve_pseudo_variables(flag, node.pos) or { return }
-			c.table.parse_cflag(flag, c.mod, c.pref.compile_defines_all) or {
+			c.table.parse_cflag_with_link_segment(flag, c.mod, c.pref.compile_defines_all) or {
 				c.error(err.msg(), node.pos)
 			}
 		}

--- a/vlib/v/checker/pkgconfig_cross_compile_test.v
+++ b/vlib/v/checker/pkgconfig_cross_compile_test.v
@@ -13,25 +13,40 @@ fn main() {}
 
 fn test_pkgconfig_is_skipped_for_cross_compilation() {
 	sample_dir := os.join_path(@VEXEROOT, 'vlib', 'v', 'pkgconfig', 'test_samples')
-	old_path := os.getenv('PKG_CONFIG_PATH')
-	old_defaults := os.getenv('PKG_CONFIG_PATH_DEFAULTS')
+	old_path := os.getenv_opt('PKG_CONFIG_PATH')
+	old_defaults := os.getenv_opt('PKG_CONFIG_PATH_DEFAULTS')
 	defer {
-		os.setenv('PKG_CONFIG_PATH', old_path, true)
-		os.setenv('PKG_CONFIG_PATH_DEFAULTS', old_defaults, true)
+		if path := old_path {
+			os.setenv('PKG_CONFIG_PATH', path, true)
+		} else {
+			os.unsetenv('PKG_CONFIG_PATH')
+		}
+		if defaults := old_defaults {
+			os.setenv('PKG_CONFIG_PATH_DEFAULTS', defaults, true)
+		} else {
+			os.unsetenv('PKG_CONFIG_PATH_DEFAULTS')
+		}
 	}
 	os.setenv('PKG_CONFIG_PATH', sample_dir, true)
 	os.setenv('PKG_CONFIG_PATH_DEFAULTS', '', true)
 
 	native_flags := checked_pkgconfig_flags(pref.get_host_os())
-	assert native_flags.any(it == '-lSDL2')
-	assert native_flags.any(it.starts_with('-I') && it.contains('SDL2'))
+	assert native_flags.ordinary.any(it == '-lSDL2')
+	assert native_flags.ordinary.any(it.starts_with('-I') && it.contains('SDL2'))
+	assert native_flags.ordered == []
 
 	cross_target := if pref.get_host_os() == .windows { pref.OS.linux } else { pref.OS.windows }
 	cross_flags := checked_pkgconfig_flags(cross_target)
-	assert cross_flags.len == 0
+	assert cross_flags.ordinary == []
+	assert cross_flags.ordered == []
 }
 
-fn checked_pkgconfig_flags(target_os pref.OS) []string {
+struct CheckedPkgConfigFlags {
+	ordinary []string
+	ordered  []string
+}
+
+fn checked_pkgconfig_flags(target_os pref.OS) CheckedPkgConfigFlags {
 	mut table := ast.new_table()
 	mut pref_ := pref.new_preferences()
 	pref_.os = target_os
@@ -39,5 +54,15 @@ fn checked_pkgconfig_flags(target_os pref.OS) []string {
 		table, .skip_comments, pref_)
 	mut chk := new_checker(table, pref_)
 	chk.check(mut file)
-	return table.cflags.map(it.format() or { '' }).filter(it != '')
+	mut ordered := []string{}
+	for segment in table.link_flag_segments {
+		if !segment.is_pkgconfig {
+			continue
+		}
+		ordered << segment.flags.map(it.format() or { '' }).filter(it != '')
+	}
+	return CheckedPkgConfigFlags{
+		ordinary: table.cflags.map(it.format() or { '' }).filter(it != '')
+		ordered:  ordered
+	}
 }

--- a/vlib/v/checker/pkgconfig_static_mode_test.v
+++ b/vlib/v/checker/pkgconfig_static_mode_test.v
@@ -1,0 +1,404 @@
+module checker
+
+import os
+import v.ast
+import v.parser
+import v.pref
+
+const issue74_static_source = 'module main
+#pkgconfig static-root-74
+
+fn main() {}
+'
+
+const issue74_explicit_static_source = 'module main
+#pkgconfig --static --cflags --libs static-root-74
+
+fn main() {}
+'
+
+const issue74_static_shorthand_source = 'module main
+#pkgconfig --static static-root-74
+
+fn main() {}
+'
+
+const issue74_short_static_source = 'module main
+#pkgconfig -s static-root-74
+
+fn main() {}
+'
+
+const issue74_short_static_debug_source = 'module main
+#pkgconfig -s -D static-root-74
+
+fn main() {}
+'
+
+const issue74_short_static_modversion_source = 'module main
+#pkgconfig -s -V static-root-74
+
+fn main() {}
+'
+
+const issue74_short_static_libs_source = 'module main
+#pkgconfig -s -l static-root-74
+
+fn main() {}
+'
+
+const issue74_static_assignment_source = 'module main
+#pkgconfig --static=true static-root-74
+
+fn main() {}
+'
+
+const issue74_short_static_cflags_debug_source = 'module main
+#pkgconfig -s -cD static-root-74
+
+fn main() {}
+'
+
+const issue74_short_static_libs_debug_source = 'module main
+#pkgconfig -s -lD static-root-74
+
+fn main() {}
+'
+
+const issue74_explicit_dynamic_cflags_source = 'module main
+#pkgconfig --cflags static-root-74
+
+fn main() {}
+'
+
+const issue74_static_false_source = 'module main
+#pkgconfig --static=false static-root-74
+
+fn main() {}
+'
+
+const issue74_short_dynamic_cflags_source = 'module main
+#pkgconfig -c static-root-74
+
+fn main() {}
+'
+
+const issue74_static_false_cflags_source = 'module main
+#pkgconfig --static --cflags=false static-root-74
+
+fn main() {}
+'
+
+const issue74_static_false_libs_source = 'module main
+#pkgconfig --static --libs=false static-root-74
+
+fn main() {}
+'
+
+const issue74_structured_private_link_source = 'module main
+#pkgconfig --static --libs structured-link-boundary-74
+
+fn main() {}
+'
+
+const issue74_dynamic_compile_defines = ['ISSUE74_ROOT', 'ISSUE74_PUBLIC', 'ISSUE74_PRIVATE']
+
+const issue74_static_compile_defines = ['ISSUE74_ROOT', 'ISSUE74_PUBLIC', 'ISSUE74_PRIVATE',
+	'ISSUE74_ROOT_PRIVATE', 'ISSUE74_PUBLIC_PRIVATE', 'ISSUE74_PRIVATE_PRIVATE']
+
+const issue74_dynamic_linker_segment = ['-lissue74_root', '-lissue74_public', '-lissue74_private']
+
+const issue74_static_linker_segment = ['-lissue74_root', '-Wl,--start-group', '-lissue74_cycle_a',
+	'-lissue74_cycle_b', '-lissue74_cycle_a', '-Wl,--end-group', '-lissue74_root_private',
+	'-lissue74_public', '-lissue74_public_private', '-lissue74_private', '-lissue74_private_private']
+
+struct Issue74CheckedFlags {
+	compile_defines  []string
+	all_linker       []string
+	ordinary_linker  []string
+	pkgconfig_linker []string
+	checker_errors   []string
+}
+
+fn issue74_is_linker_token(flag string) bool {
+	return flag.starts_with('-lissue74_') || flag.starts_with('-Wl,--') || flag.starts_with('-L')
+		|| flag.ends_with('.a')
+}
+
+fn issue74_checked_flags(ccompiler string, cflags_value string) Issue74CheckedFlags {
+	return issue74_checked_flags_for_source(ccompiler, cflags_value, '', issue74_static_source)
+}
+
+fn issue74_checked_flags_with_ldflags(ccompiler string, ldflags_value string) Issue74CheckedFlags {
+	return issue74_checked_flags_for_source(ccompiler, '', ldflags_value, issue74_static_source)
+}
+
+fn issue74_checked_flags_for_source(ccompiler string, cflags_value string, ldflags_value string, source string) Issue74CheckedFlags {
+	fixture_dir := os.join_path(@VEXEROOT, 'vlib', 'v', 'pkgconfig', 'testdata', 'static_pkgconfig')
+	old_path := os.getenv_opt('PKG_CONFIG_PATH')
+	old_defaults := os.getenv_opt('PKG_CONFIG_PATH_DEFAULTS')
+	os.unsetenv('PKG_CONFIG_PATH')
+	os.setenv('PKG_CONFIG_PATH_DEFAULTS', fixture_dir, true)
+	defer {
+		if path := old_path {
+			os.setenv('PKG_CONFIG_PATH', path, true)
+		} else {
+			os.unsetenv('PKG_CONFIG_PATH')
+		}
+		if defaults := old_defaults {
+			os.setenv('PKG_CONFIG_PATH_DEFAULTS', defaults, true)
+		} else {
+			os.unsetenv('PKG_CONFIG_PATH_DEFAULTS')
+		}
+	}
+
+	mut args := ['-cc', ccompiler]
+	if cflags_value != '' {
+		args << ['-cflags', cflags_value]
+	}
+	if ldflags_value != '' {
+		args << ['-ldflags', ldflags_value]
+	}
+	args << @FILE
+	prefs, _ := pref.parse_args([], args)
+	mut table := ast.new_table()
+	mut file := parser.parse_text(source, os.join_path('/virtual', 'main.v'), mut table,
+		.skip_comments, prefs)
+	mut chk := new_checker(table, prefs)
+	chk.check(mut file)
+	ordinary :=
+		table.cflags.map(it.format() or { '' }).filter(it != '').filter(issue74_is_linker_token(it))
+	mut pkgconfig_linker := []string{}
+	for segment in table.link_flag_segments {
+		if !segment.is_pkgconfig {
+			continue
+		}
+		pkgconfig_linker << segment.flags.map(it.format() or { '' }).filter(it != '').filter(issue74_is_linker_token(it))
+	}
+	mut all_linker := ordinary.clone()
+	all_linker << pkgconfig_linker
+	return Issue74CheckedFlags{
+		compile_defines:  table.cflags.filter(it.name == '-D' && it.value.starts_with('ISSUE74_')).map(it.value)
+		all_linker:       all_linker
+		ordinary_linker:  ordinary
+		pkgconfig_linker: pkgconfig_linker
+		checker_errors:   chk.errors.map(it.message)
+	}
+}
+
+fn test_exact_static_token_in_cflags_activates_pkgconfig_for_supported_compilers() {
+	for ccompiler in ['gcc', 'clang', 'mingw'] {
+		flags := issue74_checked_flags(ccompiler, '-static')
+		assert flags.all_linker == issue74_static_linker_segment, ccompiler
+		assert flags.ordinary_linker == [], ccompiler
+		assert flags.pkgconfig_linker == issue74_static_linker_segment, ccompiler
+	}
+}
+
+fn test_static_token_inside_combined_cflags_value_activates_pkgconfig() {
+	for ccompiler in ['gcc', 'clang', 'mingw'] {
+		flags := issue74_checked_flags(ccompiler,
+			'-static -Wno-error -Wno-incompatible-pointer-types')
+		assert flags.all_linker == issue74_static_linker_segment, ccompiler
+	}
+}
+
+fn test_exact_static_token_in_ldflags_activates_pkgconfig_for_supported_compilers() {
+	for ccompiler in ['gcc', 'clang', 'mingw'] {
+		flags := issue74_checked_flags_with_ldflags(ccompiler, '-Wl,--issue74-before -static')
+		assert flags.all_linker == issue74_static_linker_segment, ccompiler
+		assert flags.ordinary_linker == [], ccompiler
+		assert flags.pkgconfig_linker == issue74_static_linker_segment, ccompiler
+	}
+}
+
+fn test_static_lookalikes_do_not_activate_pkgconfig() {
+	lookalikes := [
+		'-static-libgcc',
+		'-Wl,-Bstatic',
+		'-DISSUE74_VALUE=-static',
+		'-L/tmp/issue74-static',
+		'-I/tmp/-static/include',
+		'-DISSUE74_TEXT="prefix -static suffix"',
+	]
+	for ccompiler in ['gcc', 'clang', 'mingw'] {
+		for option in ['cflags', 'ldflags'] {
+			for value in lookalikes {
+				flags := if option == 'cflags' {
+					issue74_checked_flags(ccompiler, value)
+				} else {
+					issue74_checked_flags_with_ldflags(ccompiler, value)
+				}
+				context := '${ccompiler} ${option}: ${value}'
+				assert flags.all_linker == issue74_dynamic_linker_segment, context
+				assert flags.ordinary_linker == issue74_dynamic_linker_segment, context
+				assert flags.pkgconfig_linker == [], context
+			}
+		}
+	}
+}
+
+fn test_static_pkgconfig_segment_stays_ordered_after_target() {
+	flags := issue74_checked_flags('gcc', '-static')
+	assert flags.all_linker == issue74_static_linker_segment
+	assert flags.ordinary_linker == []
+	assert flags.pkgconfig_linker == issue74_static_linker_segment
+}
+
+fn test_explicit_static_directive_uses_ordered_transport_without_global_static_cflag() {
+	for ccompiler in ['gcc', 'clang'] {
+		flags := issue74_checked_flags_for_source(ccompiler, '', '', issue74_explicit_static_source)
+		assert flags.all_linker == issue74_static_linker_segment, ccompiler
+		assert flags.ordinary_linker == [], ccompiler
+		assert flags.pkgconfig_linker == issue74_static_linker_segment, ccompiler
+	}
+}
+
+fn test_package_without_options_keeps_historical_dynamic_defaults() {
+	flags := issue74_checked_flags_for_source('gcc', '', '', issue74_static_source)
+	assert flags.compile_defines == issue74_dynamic_compile_defines
+	assert flags.all_linker == issue74_dynamic_linker_segment
+	assert flags.ordinary_linker == issue74_dynamic_linker_segment
+	assert flags.pkgconfig_linker == []
+}
+
+fn test_static_directive_without_actions_adds_only_default_cflags_and_libs() {
+	for ccompiler in ['gcc', 'clang'] {
+		shorthand := issue74_checked_flags_for_source(ccompiler, '', '',
+			issue74_static_shorthand_source)
+		explicit := issue74_checked_flags_for_source(ccompiler, '', '',
+			issue74_explicit_static_source)
+		assert shorthand.compile_defines == issue74_static_compile_defines, ccompiler
+		assert shorthand.compile_defines == explicit.compile_defines, ccompiler
+		assert shorthand.all_linker == issue74_static_linker_segment, ccompiler
+		assert shorthand.ordinary_linker == [], ccompiler
+		assert shorthand.pkgconfig_linker == explicit.pkgconfig_linker, ccompiler
+	}
+}
+
+fn test_short_static_option_matches_long_static_option() {
+	short := issue74_checked_flags_for_source('gcc', '', '', issue74_short_static_source)
+	long := issue74_checked_flags_for_source('gcc', '', '', issue74_static_shorthand_source)
+	assert short.compile_defines == long.compile_defines
+	assert short.all_linker == long.all_linker
+	assert short.ordinary_linker == long.ordinary_linker
+	assert short.pkgconfig_linker == long.pkgconfig_linker
+}
+
+fn test_static_assignment_without_actions_matches_static_option() {
+	assignment := issue74_checked_flags_for_source('gcc', '', '', issue74_static_assignment_source)
+	long := issue74_checked_flags_for_source('gcc', '', '', issue74_static_shorthand_source)
+	assert assignment.compile_defines == long.compile_defines
+	assert assignment.all_linker == long.all_linker
+	assert assignment.ordinary_linker == long.ordinary_linker
+	assert assignment.pkgconfig_linker == long.pkgconfig_linker
+}
+
+fn test_short_static_debug_modifier_adds_default_actions() {
+	flags := issue74_checked_flags_for_source('gcc', '', '', issue74_short_static_debug_source)
+	assert flags.compile_defines == issue74_static_compile_defines
+	assert flags.all_linker == issue74_static_linker_segment
+	assert flags.ordinary_linker == []
+	assert flags.pkgconfig_linker == issue74_static_linker_segment
+}
+
+fn test_short_static_clusters_keep_their_explicit_action() {
+	cflags := issue74_checked_flags_for_source('gcc', '', '',
+		issue74_short_static_cflags_debug_source)
+	assert cflags.compile_defines == issue74_static_compile_defines
+	assert cflags.all_linker == []
+	assert cflags.ordinary_linker == []
+	assert cflags.pkgconfig_linker == []
+
+	libs := issue74_checked_flags_for_source('gcc', '', '', issue74_short_static_libs_debug_source)
+	assert libs.compile_defines == []
+	assert libs.all_linker == issue74_static_linker_segment
+	assert libs.ordinary_linker == []
+	assert libs.pkgconfig_linker == issue74_static_linker_segment
+}
+
+fn test_short_static_modversion_action_does_not_add_default_actions() {
+	flags := issue74_checked_flags_for_source('gcc', '', '', issue74_short_static_modversion_source)
+	assert flags.compile_defines == []
+	assert flags.all_linker == []
+	assert flags.ordinary_linker == []
+	assert flags.pkgconfig_linker == []
+}
+
+fn test_short_static_libs_action_does_not_inject_cflags() {
+	flags := issue74_checked_flags_for_source('gcc', '', '', issue74_short_static_libs_source)
+	assert flags.compile_defines == []
+	assert flags.all_linker == issue74_static_linker_segment
+	assert flags.ordinary_linker == []
+	assert flags.pkgconfig_linker == issue74_static_linker_segment
+}
+
+fn test_static_pkgconfig_preserves_private_link_fragment_boundaries_and_repetition() {
+	flags := issue74_checked_flags_for_source('gcc', '', '', issue74_structured_private_link_source)
+	lib_dir := '/issue74/structured-boundary'
+	expected := ['-L"${os.real_path(lib_dir)}"', '${lib_dir}/libissue74_b.a',
+		'${lib_dir}/libissue74_a.a', '${lib_dir}/libissue74_b.a']
+	assert flags.checker_errors == []
+	assert flags.ordinary_linker == []
+	assert flags.pkgconfig_linker == expected
+	assert flags.all_linker == expected
+}
+
+fn test_explicit_dynamic_cflags_action_does_not_inject_libs() {
+	flags := issue74_checked_flags_for_source('gcc', '', '', issue74_explicit_dynamic_cflags_source)
+	assert flags.compile_defines == issue74_dynamic_compile_defines
+	assert flags.all_linker == []
+	assert flags.ordinary_linker == []
+	assert flags.pkgconfig_linker == []
+}
+
+fn test_static_false_keeps_historical_empty_flag_error() {
+	flags := issue74_checked_flags_for_source('gcc', '', '', issue74_static_false_source)
+	assert flags.checker_errors == ['flag is empty']
+}
+
+fn test_short_dynamic_cflags_keeps_historical_package_error() {
+	flags := issue74_checked_flags_for_source('gcc', '', '', issue74_short_dynamic_cflags_source)
+	assert flags.checker_errors == ['Cannot find "-c" pkgconfig file']
+}
+
+fn test_explicit_false_static_actions_do_not_inject_defaults() {
+	for source in [issue74_static_false_cflags_source, issue74_static_false_libs_source] {
+		flags := issue74_checked_flags_for_source('gcc', '', '', source)
+		assert flags.checker_errors == []
+		assert flags.compile_defines == []
+		assert flags.all_linker == []
+		assert flags.ordinary_linker == []
+		assert flags.pkgconfig_linker == []
+	}
+}
+
+fn test_msvc_pkgconfig_stays_dynamic_by_default() {
+	flags := issue74_checked_flags('msvc', '')
+	assert flags.all_linker == issue74_dynamic_linker_segment
+	assert flags.ordinary_linker == issue74_dynamic_linker_segment
+	assert flags.pkgconfig_linker == []
+}
+
+fn test_static_token_does_not_enable_static_pkgconfig_for_msvc() {
+	flags := issue74_checked_flags('msvc', '-static')
+	assert flags.all_linker == issue74_dynamic_linker_segment
+	assert flags.ordinary_linker == issue74_dynamic_linker_segment
+	assert flags.pkgconfig_linker == []
+}
+
+fn test_static_token_does_not_enable_static_pkgconfig_for_tcc() {
+	flags := issue74_checked_flags('tcc', '-static')
+	assert flags.all_linker == issue74_dynamic_linker_segment
+	assert flags.ordinary_linker == issue74_dynamic_linker_segment
+	assert flags.pkgconfig_linker == []
+}
+
+fn test_static_token_in_ldflags_does_not_enable_static_pkgconfig_for_msvc_or_tcc() {
+	for ccompiler in ['msvc', 'tcc'] {
+		flags := issue74_checked_flags_with_ldflags(ccompiler, '-static')
+		assert flags.all_linker == issue74_dynamic_linker_segment, ccompiler
+		assert flags.ordinary_linker == issue74_dynamic_linker_segment, ccompiler
+		assert flags.pkgconfig_linker == [], ccompiler
+	}
+}

--- a/vlib/v/pkgconfig/main.v
+++ b/vlib/v/pkgconfig/main.v
@@ -10,6 +10,13 @@ pub mut:
 	has_actions bool
 }
 
+pub struct MainResult {
+pub:
+	output     string
+	cflags     []string
+	link_flags []string
+}
+
 struct MainOptions {
 	modversion        bool
 	description       bool
@@ -23,15 +30,39 @@ struct MainOptions {
 	atleastpc         string
 	exactversion      string
 	version           bool
-	cflags            bool
 	cflags_only_path  bool
 	cflags_only_other bool
-	stat1c            bool
-	libs              bool
 	libs_only_link    bool
 	libs_only_path    bool
 	libs_only_other   bool
 	args              []string
+mut:
+	cflags bool
+	stat1c bool
+	libs   bool
+}
+
+struct MainActionState {
+mut:
+	has_actions bool
+}
+
+fn parse_action_bool(mut fp flag.FlagParser, mut state MainActionState, name string, abbr u8, usage string) bool {
+	args_before := fp.args.clone()
+	value := fp.bool(name, abbr, false, usage)
+	if fp.args != args_before {
+		state.has_actions = true
+	}
+	return value
+}
+
+fn parse_action_string(mut fp flag.FlagParser, mut state MainActionState, name string, abbr u8, usage string) string {
+	args_before := fp.args.clone()
+	value := fp.string(name, abbr, '', usage)
+	if fp.args != args_before {
+		state.has_actions = true
+	}
+	return value
 }
 
 fn desc(mod string) !string {
@@ -46,8 +77,10 @@ pub fn main(args []string) !&Main {
 	mut fp := flag.new_flag_parser(args)
 	fp.application('pkgconfig')
 	fp.version(version)
+	parsed_options, has_actions := parse_options(mut fp)
 	mut m := &Main{
-		opt: parse_options(mut fp)
+		opt:         parsed_options
+		has_actions: has_actions
 	}
 	opt := m.opt
 	if opt.help {
@@ -72,7 +105,158 @@ pub fn main(args []string) !&Main {
 	return m
 }
 
+// link_mode returns the parsed pkg-config link mode.
+pub fn (m &Main) link_mode() LinkMode {
+	return if m.opt.stat1c { .static_ } else { .dynamic }
+}
+
+// force_static enables static pkg-config resolution.
+pub fn (mut m Main) force_static() {
+	m.opt.stat1c = true
+}
+
+// apply_default_actions enables cflags and libs when no action was supplied.
+pub fn (mut m Main) apply_default_actions() {
+	if m.has_actions {
+		return
+	}
+	m.opt.cflags = true
+	m.opt.libs = true
+	m.has_actions = true
+}
+
+fn escape_static_output_arg(arg string) string {
+	if arg == '' {
+		return "''"
+	}
+	mut escaped := strings.new_builder(arg.len + 4)
+	for ch in arg {
+		if ch.is_space() || ch in [`\\`, `"`, `'`] {
+			escaped.write_u8(`\\`)
+		}
+		escaped.write_u8(ch)
+	}
+	return escaped.str()
+}
+
+pub fn (mut m Main) run_result() !MainResult {
+	if !m.opt.stat1c {
+		return MainResult{
+			output: m.run()!
+		}
+	}
+	options := Options{
+		debug:     m.opt.debug
+		link_mode: .static_
+	}
+	opt := m.opt
+	mut pc := &PkgConfig(unsafe { nil })
+	mut res := m.res
+	if opt.args.len == 0 {
+		return MainResult{
+			output: res
+		}
+	}
+	for arg in opt.args {
+		mut pcdep := load_direct(arg, options) or {
+			if !opt.exists {
+				return err
+			}
+			continue
+		}
+		if opt.description {
+			if res != '' {
+				res += '\n'
+			}
+			res += pcdep.description
+		}
+		if unsafe { pc != 0 } {
+			pc.extend(pcdep)
+		} else {
+			pc = pcdep
+		}
+	}
+	needs_flags := opt.cflags || opt.cflags_only_path || opt.cflags_only_other || opt.libs
+		|| opt.libs_only_link || opt.libs_only_path || opt.libs_only_other
+	mut flags := ResolvedFlags{}
+	if needs_flags || opt.exists {
+		flags = resolve(opt.args, options)!
+	}
+	if opt.exists {
+		return MainResult{
+			output: res
+		}
+	}
+	if opt.exactversion != '' {
+		if pc.version != opt.exactversion {
+			return error('version mismatch')
+		}
+		return MainResult{
+			output: res
+		}
+	}
+	if opt.atleast != '' {
+		if pc.atleast(opt.atleast) {
+			return error('version mismatch')
+		}
+		return MainResult{
+			output: res
+		}
+	}
+	if opt.atleastpc != '' {
+		if atleast(opt.atleastpc) {
+			return error('version mismatch')
+		}
+		return MainResult{
+			output: res
+		}
+	}
+	if opt.variables {
+		res = pc.vars.keys().join('\n')
+	}
+	if opt.requires {
+		res += pc.requires.join('\n')
+	}
+	mut cflags := []string{}
+	if opt.cflags_only_path {
+		cflags << filter_static(flags.cflags, '-I', '')
+	}
+	if opt.cflags_only_other {
+		cflags << filter_static(flags.cflags, '-I', '-I')
+	}
+	if opt.cflags {
+		cflags << flags.cflags
+	}
+	mut link_flags := []string{}
+	if opt.libs_only_link {
+		link_flags << filter_static(flags.libs, '-l', '')
+	}
+	if opt.libs_only_path {
+		link_flags << filter_static(flags.libs, '-L', '')
+	}
+	if opt.libs_only_other {
+		link_flags << filter_static(flags.libs, '-l', '-L')
+	}
+	if opt.libs {
+		link_flags << flags.libs
+	}
+	mut output_parts := []string{cap: cflags.len + link_flags.len + 1}
+	output_parts << cflags
+	output_parts << link_flags
+	if opt.modversion {
+		output_parts << pc.version
+	}
+	return MainResult{
+		output:     res + output_parts.map(escape_static_output_arg).join(' ')
+		cflags:     cflags
+		link_flags: link_flags
+	}
+}
+
 pub fn (mut m Main) run() !string {
+	if m.opt.stat1c {
+		return m.run_result()!.output
+	}
 	options := Options{
 		debug: m.opt.debug
 	}
@@ -146,16 +330,30 @@ pub fn (mut m Main) run() !string {
 		r << filter(pc.libs, '-l', '-L')
 	}
 	if opt.libs {
-		if opt.stat1c {
-			r << pc.libs_private.join(' ')
-		} else {
-			r << pc.libs.join(' ')
-		}
+		r << pc.libs.join(' ')
 	}
 	if opt.modversion {
 		r << pc.version
 	}
 	return res + r.join(' ')
+}
+
+fn filter_static(flags []string, prefix string, prefix2 string) []string {
+	mut res := []string{}
+	if prefix2 != '' {
+		for flag in flags {
+			if !flag.starts_with(prefix) && !flag.starts_with(prefix2) {
+				res << flag
+			}
+		}
+	} else {
+		for flag in flags {
+			if flag.starts_with(prefix) {
+				res << flag
+			}
+		}
+	}
+	return res
 }
 
 fn filter(libs []string, prefix string, prefix2 string) string {
@@ -176,33 +374,48 @@ fn filter(libs []string, prefix string, prefix2 string) string {
 	return res
 }
 
-fn parse_options(mut fp flag.FlagParser) &MainOptions {
-	return &MainOptions{
-		description:       fp.bool('description', `d`, false, 'show pkg module description')
-		modversion:        fp.bool('modversion', `V`, false, 'show version of module')
-		help:              fp.bool('help', `h`, false, 'show this help message')
+fn parse_options(mut fp flag.FlagParser) (&MainOptions, bool) {
+	mut state := MainActionState{}
+	options := &MainOptions{
+		description:       parse_action_bool(mut fp, mut state, 'description', `d`,
+			'show pkg module description')
+		modversion:        parse_action_bool(mut fp, mut state, 'modversion', `V`,
+			'show version of module')
+		help:              parse_action_bool(mut fp, mut state, 'help', `h`,
+			'show this help message')
 		debug:             fp.bool('debug', `D`, false, 'show debug information')
-		listall:           fp.bool('list-all', `p`, false, 'list all pkgmodules')
-		exists:            fp.bool('exists', `e`, false, 'return 0 if pkg exists')
-		variables:         fp.bool('print-variables', `P`, false, 'display variable names')
-		requires:          fp.bool('print-requires', `r`, false, 'display requires of the module')
-		atleast:           fp.string('atleast-version', `a`, '',
+		listall:           parse_action_bool(mut fp, mut state, 'list-all', `p`,
+			'list all pkgmodules')
+		exists:            parse_action_bool(mut fp, mut state, 'exists', `e`,
+			'return 0 if pkg exists')
+		variables:         parse_action_bool(mut fp, mut state, 'print-variables', `P`,
+			'display variable names')
+		requires:          parse_action_bool(mut fp, mut state, 'print-requires', `r`,
+			'display requires of the module')
+		atleast:           parse_action_string(mut fp, mut state, 'atleast-version', `a`,
 			'return 0 if pkg version is at least the given one')
-		atleastpc:         fp.string('atleast-pkgconfig-version', `A`, '',
+		atleastpc:         parse_action_string(mut fp, mut state, 'atleast-pkgconfig-version', `A`,
 			'return 0 if pkgconfig version is at least the given one')
-		exactversion:      fp.string('exact-version', ` `, '',
+		exactversion:      parse_action_string(mut fp, mut state, 'exact-version', ` `,
 			'return 0 if pkg version is at least the given one')
-		version:           fp.bool('version', `v`, false, 'show version of this tool')
-		cflags:            fp.bool('cflags', `c`, false,
+		version:           parse_action_bool(mut fp, mut state, 'version', `v`,
+			'show version of this tool')
+		cflags:            parse_action_bool(mut fp, mut state, 'cflags', `c`,
 			'output all pre-processor and compiler flags')
-		cflags_only_path:  fp.bool('cflags-only-I', `I`, false, 'show only -I flags from CFLAGS')
-		cflags_only_other: fp.bool('cflags-only-other', ` `, false, 'show cflags without -I')
+		cflags_only_path:  parse_action_bool(mut fp, mut state, 'cflags-only-I', `I`,
+			'show only -I flags from CFLAGS')
+		cflags_only_other: parse_action_bool(mut fp, mut state, 'cflags-only-other', ` `,
+			'show cflags without -I')
 		stat1c:            fp.bool('static', `s`, false, 'show --libs for static linking')
-		libs:              fp.bool('libs', `l`, false, 'output all linker flags')
-		libs_only_link:    fp.bool('libs-only-l', ` `, false, 'show only -l from ldflags')
-		libs_only_path:    fp.bool('libs-only-L', `L`, false, 'show only -L from ldflags')
-		libs_only_other:   fp.bool('libs-only-other', ` `, false,
+		libs:              parse_action_bool(mut fp, mut state, 'libs', `l`,
+			'output all linker flags')
+		libs_only_link:    parse_action_bool(mut fp, mut state, 'libs-only-l', ` `,
+			'show only -l from ldflags')
+		libs_only_path:    parse_action_bool(mut fp, mut state, 'libs-only-L', `L`,
+			'show only -L from ldflags')
+		libs_only_other:   parse_action_bool(mut fp, mut state, 'libs-only-other', ` `,
 			'show flags not containing -l or -L')
 		args:              fp.args
 	}
+	return options, state.has_actions
 }

--- a/vlib/v/pkgconfig/main_test.v
+++ b/vlib/v/pkgconfig/main_test.v
@@ -1,0 +1,100 @@
+module pkgconfig
+
+import os
+
+const main_test_fixture_dir = os.join_path(@VEXEROOT, 'vlib', 'v', 'pkgconfig', 'testdata',
+	'static_pkgconfig')
+
+fn main_test_fixture_result(args []string) MainResult {
+	old_path := os.getenv_opt('PKG_CONFIG_PATH')
+	old_defaults := os.getenv_opt('PKG_CONFIG_PATH_DEFAULTS')
+	os.unsetenv('PKG_CONFIG_PATH')
+	os.setenv('PKG_CONFIG_PATH_DEFAULTS', main_test_fixture_dir, true)
+	defer {
+		if path := old_path {
+			os.setenv('PKG_CONFIG_PATH', path, true)
+		} else {
+			os.unsetenv('PKG_CONFIG_PATH')
+		}
+		if defaults := old_defaults {
+			os.setenv('PKG_CONFIG_PATH_DEFAULTS', defaults, true)
+		} else {
+			os.unsetenv('PKG_CONFIG_PATH_DEFAULTS')
+		}
+	}
+	mut command := main(args) or { panic(err) }
+	return command.run_result() or { panic(err) }
+}
+
+fn assert_main_test_shell_round_trip(output string, expected []string) {
+	$if !windows {
+		script := 'set -- ' + output + r'; printf "%s\n" "$@"'
+		result := os.execute('sh -c ${os.quoted_path(script)}')
+		assert result.exit_code == 0, result.output
+		assert result.output.split_into_lines() == expected
+	}
+}
+
+fn test_main_exposes_parsed_mode_and_actions() {
+	for args in [
+		['--static', 'package'],
+		['-s', 'package'],
+		['--static=true', 'package'],
+	] {
+		command := main(args)!
+		assert command.link_mode() == .static_, args.str()
+		assert !command.has_actions, args.str()
+	}
+
+	for args in [
+		['-s', '-V', 'package'],
+		['-s', '-cD', 'package'],
+		['-s', '-lD', 'package'],
+		['--static', '--cflags=false', 'package'],
+		['--static', '--libs=false', 'package'],
+		['--cflags', 'package'],
+	] {
+		command := main(args)!
+		assert command.has_actions, args.str()
+	}
+}
+
+fn test_checker_defaults_and_static_mode_are_explicit_main_api_operations() {
+	mut command := main(['--static', 'package'])!
+	assert command.link_mode() == .static_
+	assert !command.has_actions
+	assert !command.opt.cflags
+	assert !command.opt.libs
+
+	command.apply_default_actions()
+	assert command.has_actions
+	assert command.opt.cflags
+	assert command.opt.libs
+
+	mut global_static := main(['package'])!
+	assert global_static.link_mode() == .dynamic
+	global_static.force_static()
+	assert global_static.link_mode() == .static_
+}
+
+fn test_static_main_output_shell_escapes_structured_link_flags() {
+	static_result := main_test_fixture_result([
+		'--static',
+		'--libs',
+		'quoted-split-link-pairs-74',
+	])
+	expected_flags := ['-L', '/issue74/public search', '-l', 'issue74_public', '-L',
+		'/issue74/private search', '-l', 'issue74_private']
+	assert static_result.cflags == []
+	assert static_result.link_flags == expected_flags
+	assert static_result.output == r'-L /issue74/public\ search -l issue74_public -L /issue74/private\ search -l issue74_private'
+	assert_main_test_shell_round_trip(static_result.output, expected_flags)
+
+	special_args := [r'back\slash', 'double"quote', "single'quote"]
+	special_output := special_args.map(escape_static_output_arg).join(' ')
+	assert special_output == 'back\\\\slash double\\"quote single\\\'quote'
+	assert_main_test_shell_round_trip(special_output, special_args)
+
+	dynamic_result := main_test_fixture_result(['--libs', 'quoted-split-link-pairs-74'])
+	assert dynamic_result.output == '-L "/issue74/public search" -l issue74_public'
+}

--- a/vlib/v/pkgconfig/pkgconfig.v
+++ b/vlib/v/pkgconfig/pkgconfig.v
@@ -5,6 +5,11 @@ import os
 
 const version = '0.3.4'
 
+pub enum LinkMode {
+	dynamic
+	static_
+}
+
 const default_paths = [
 	'/usr/local/lib/x86_64-linux-gnu/pkgconfig',
 	'/usr/local/lib64/pkgconfig',
@@ -33,6 +38,13 @@ pub:
 	norecurse         bool
 	only_description  bool
 	use_default_paths bool = true
+	link_mode         LinkMode
+}
+
+pub struct ResolvedFlags {
+pub:
+	cflags []string
+	libs   []string
 }
 
 pub struct PkgConfig {
@@ -47,12 +59,16 @@ pub mut:
 	libs             []string
 	libs_private     []string
 	cflags           []string
+	cflags_private   []string
 	paths            []string // TODO: move to options?
 	vars             map[string]string
 	requires         []string
 	requires_private []string
 	conflicts        []string
 	loaded           []string
+mut:
+	define_prefix_source string
+	define_prefix_target string
 }
 
 fn (mut pc PkgConfig) parse_list_no_comma(s string) []string {
@@ -61,7 +77,8 @@ fn (mut pc PkgConfig) parse_list_no_comma(s string) []string {
 
 fn (mut pc PkgConfig) parse_list(s string) []string {
 	operators := ['=', '<', '>', '>=', '<=']
-	r := pc.parse_line(s.replace('  ', ' ').replace(', ', ' ')).split(' ')
+	value := pc.parse_line(s.replace('  ', ' ').replace(', ', ' '))
+	r := split_list_with_protected_fragment(value, pc.define_prefix_target)
 	mut res := []string{}
 	mut skip := false
 	for a in r {
@@ -77,6 +94,210 @@ fn (mut pc PkgConfig) parse_list(s string) []string {
 	return res
 }
 
+fn split_list_with_protected_fragment(value string, protected_fragment string) []string {
+	if protected_fragment == '' || !protected_fragment.contains(' ')
+		|| !value.contains(protected_fragment) {
+		return value.split(' ')
+	}
+	mut fragments := []string{}
+	mut current := []u8{}
+	mut i := 0
+	for i < value.len {
+		if value[i..].starts_with(protected_fragment) {
+			current << protected_fragment.bytes()
+			i += protected_fragment.len
+			continue
+		}
+		if value[i] == ` ` {
+			fragments << current.bytestr()
+			current = []u8{}
+			i++
+			continue
+		}
+		current << value[i]
+		i++
+	}
+	fragments << current.bytestr()
+	return fragments
+}
+
+fn fold_static_continued_lines(data string) []string {
+	physical_lines := data.split('\n')
+	mut lines := []string{cap: physical_lines.len}
+	mut continued := ''
+	mut is_continuation := false
+	for i, raw_line in physical_lines {
+		line := if is_continuation { raw_line.trim_left(' \t') } else { raw_line }
+		mut content_end := line.len
+		if content_end > 0 && line[content_end - 1] == `\r` {
+			content_end--
+		}
+		mut slash_start := content_end
+		for slash_start > 0 && line[slash_start - 1] == `\\` {
+			slash_start--
+		}
+		if (content_end - slash_start) % 2 == 1 {
+			continued += line[..content_end - 1]
+			if i + 1 < physical_lines.len {
+				is_continuation = true
+				continue
+			}
+			lines << continued
+			continue
+		}
+		if is_continuation {
+			continued += line
+			lines << continued
+			continued = ''
+			is_continuation = false
+		} else {
+			lines << line
+		}
+	}
+	return lines
+}
+
+fn static_link_field_without_comment(s string) string {
+	mut preceding_backslashes := 0
+	for i, ch in s {
+		if ch == `\\` {
+			preceding_backslashes++
+			continue
+		}
+		if ch == `#` && preceding_backslashes % 2 == 0 {
+			return s[..i]
+		}
+		preceding_backslashes = 0
+	}
+	return s
+}
+
+fn normalize_static_link_field(s string) string {
+	mut normalized := []u8{cap: s.len}
+	mut quote := u8(0)
+	mut i := 0
+	for i < s.len {
+		ch := s[i]
+		if ch == `\\` && quote != `'` && i + 1 < s.len {
+			normalized << ch
+			normalized << s[i + 1]
+			i += 2
+			continue
+		}
+		if ch in [`'`, `"`] {
+			if quote == 0 {
+				quote = ch
+			} else if quote == ch {
+				quote = 0
+			}
+			normalized << ch
+			i++
+			continue
+		}
+		if quote == 0 && ch == `,` && i + 1 < s.len && s[i + 1] == ` ` {
+			normalized << ` `
+			i += 2
+			continue
+		}
+		if quote == 0 && ch == ` ` {
+			normalized << ch
+			for i + 1 < s.len && s[i + 1] == ` ` {
+				i++
+			}
+			i++
+			continue
+		}
+		normalized << ch
+		i++
+	}
+	return normalized.bytestr()
+}
+
+fn tokenize_static_list_with_protected_fragment(value string, protected_fragment string) ![]string {
+	mut fragments := []string{}
+	mut current := []u8{}
+	mut quote := u8(0)
+	mut has_fragment := false
+	mut i := 0
+	for i < value.len {
+		if protected_fragment != '' && value[i..].starts_with(protected_fragment) {
+			current << protected_fragment.bytes()
+			has_fragment = true
+			i += protected_fragment.len
+			continue
+		}
+		ch := value[i]
+		if quote == 0 && ch in [` `, `\t`, `\r`, `\n`] {
+			if has_fragment {
+				fragments << current.bytestr()
+				current = []u8{}
+				has_fragment = false
+			}
+			i++
+			continue
+		}
+		if ch in [`'`, `"`] {
+			if quote == 0 {
+				quote = ch
+				has_fragment = true
+				i++
+				continue
+			}
+			if quote == ch {
+				quote = 0
+				i++
+				continue
+			}
+		}
+		if ch == `\\` && quote != `'` && i + 1 < value.len {
+			next := value[i + 1]
+			escapable := if quote == `"` {
+				next in [`"`, `\\`, `#`]
+			} else {
+				next in [` `, `\t`, `\r`, `\n`, `'`, `"`, `\\`, `#`]
+			}
+			if escapable {
+				current << next
+				has_fragment = true
+				i += 2
+				continue
+			}
+		}
+		current << ch
+		has_fragment = true
+		i++
+	}
+	if quote != 0 {
+		return error('unterminated quote in static pkg-config linker flags')
+	}
+	if has_fragment {
+		fragments << current.bytestr()
+	}
+	return fragments
+}
+
+fn tokenize_static_list(value string) ![]string {
+	return tokenize_static_list_with_protected_fragment(value, '')
+}
+
+fn (mut pc PkgConfig) parse_static_link_list(s string) ![]string {
+	raw_value := static_link_field_without_comment(normalize_static_link_field(s))
+	value := pc.expand_static_link_variables(raw_value)
+	return tokenize_static_list_with_protected_fragment(value, pc.define_prefix_target)
+}
+
+fn (mut pc PkgConfig) expand_static_link_variables(s string) string {
+	mut r := s
+	for r.contains('\${') {
+		tok0 := r.index('\${') or { break }
+		mut tok1 := r[tok0..].index('}') or { break }
+		tok1 += tok0
+		v := r[tok0 + 2..tok1]
+		r = r.replace('\${${v}}', pc.vars[v])
+	}
+	return r.trim_space()
+}
+
 fn (mut pc PkgConfig) parse_line(s string) string {
 	mut r := s.split('#')[0]
 	for r.contains('\${') {
@@ -89,64 +310,200 @@ fn (mut pc PkgConfig) parse_line(s string) string {
 	return r.trim_space()
 }
 
+fn trim_define_prefix_path(path string) string {
+	mut end := path.len
+	for end > 1 && path[end - 1] in [`/`, `\\`] {
+		end--
+	}
+	return path[..end]
+}
+
+fn define_prefix_from_pcfiledir(pcfiledir string) ?string {
+	if os.base(pcfiledir).to_lower_ascii() != 'pkgconfig' {
+		return none
+	}
+	metadata_parent := os.dir(pcfiledir)
+	if metadata_parent == '' || metadata_parent == '.' {
+		return none
+	}
+	prefix := os.dir(metadata_parent)
+	if prefix == '' || prefix == '.' {
+		return none
+	}
+	return trim_define_prefix_path(prefix)
+}
+
+fn has_define_prefix_path(value string, prefix string) bool {
+	if prefix == '' || value.len < prefix.len
+		|| value[..prefix.len].to_lower_ascii() != prefix.to_lower_ascii() {
+		return false
+	}
+	if value.len == prefix.len || prefix.ends_with('/') || prefix.ends_with('\\') {
+		return true
+	}
+	return value[prefix.len] in [`/`, `\\`]
+}
+
+fn (pc &PkgConfig) relocate_define_prefix_value(value string) string {
+	if !has_define_prefix_path(value, pc.define_prefix_source) {
+		return value
+	}
+	return pc.define_prefix_target + value[pc.define_prefix_source.len..]
+}
+
+fn (mut pc PkgConfig) set_variable(key string, raw_value string) {
+	parsed_value := pc.parse_line(raw_value)
+	value := pc.parse_line(parsed_value)
+	if key == 'prefix' {
+		pc.define_prefix_source = ''
+		pc.define_prefix_target = ''
+		$if windows {
+			source := trim_define_prefix_path(value)
+			if source.starts_with('/') && !source.starts_with('//') {
+				if target := define_prefix_from_pcfiledir(pc.vars['pcfiledir']) {
+					pc.define_prefix_source = source
+					pc.define_prefix_target = target
+					pc.vars[key] = target
+					return
+				}
+			}
+		}
+		pc.vars[key] = value
+		return
+	}
+	pc.vars[key] = pc.relocate_define_prefix_value(value)
+}
+
 fn (mut pc PkgConfig) setvar(line string) {
 	kv := line.trim_space().split('=')
 	if kv.len == 2 {
-		k := kv[0]
-		v := pc.parse_line(kv[1])
-		pc.vars[k] = pc.parse_line(v)
+		pc.set_variable(kv[0], kv[1])
 	}
 }
 
-fn (mut pc PkgConfig) parse(file string) bool {
-	pc.file_path = file
-	pc.vars['pcfiledir'] = os.real_path(os.dir(file))
-	data := os.read_file(file) or { return false }
-	if pc.options.debug {
-		eprintln(data)
+fn split_static_field(line string) (string, string, bool) {
+	separator := line.index_u8(`:`)
+	if separator < 0 {
+		return '', '', false
 	}
-	lines := data.split('\n')
+	return line[..separator].trim_space().to_lower(), line[separator + 1..], true
+}
+
+fn split_static_variable(line string) (string, string, bool) {
+	separator := line.index_u8(`=`)
+	if separator < 0 {
+		return '', '', false
+	}
+	key := line[..separator].trim(' \t')
+	if key == '' || key.contains_any(' \t\r\n') || key.contains(':') {
+		return '', '', false
+	}
+	return key, line[separator + 1..].trim(' \t'), true
+}
+
+fn (mut pc PkgConfig) set_static_var(line string) bool {
+	key, value, is_variable := split_static_variable(line)
+	if !is_variable {
+		return false
+	}
+	pc.set_variable(key, value)
+	return true
+}
+
+fn (mut pc PkgConfig) parse_dynamic_fields(lines []string) {
 	if pc.options.only_description {
-		// 2x faster than original pkg-config for --list-all --description
+		// Keep the historical dynamic parser byte-for-byte selective.
 		for line in lines {
 			if line.starts_with('Description: ') {
 				pc.description = pc.parse_line(line[13..])
 			}
 		}
-	} else {
-		for oline in lines {
-			line := oline.trim_space()
-			if line.starts_with('#') {
-				continue
-			}
-			if line.contains('=') && !line.contains(' ') {
-				pc.setvar(line)
-				continue
-			}
-			if line.starts_with('Name:') {
-				pc.name = pc.parse_line(line[5..])
-			} else if line.starts_with('Description:') {
-				pc.description = pc.parse_line(line[12..])
-			} else if line.starts_with('Version:') {
-				pc.version = pc.parse_line(line[8..])
-			} else if line.starts_with('Requires:') {
-				pc.requires = pc.parse_list_no_comma(line[9..])
-			} else if line.starts_with('Requires.private:') {
-				pc.requires_private = pc.parse_list_no_comma(line[17..])
-			} else if line.starts_with('Conflicts:') {
-				pc.conflicts = pc.parse_list_no_comma(line[10..])
-			} else if line.starts_with('Cflags:') {
-				pc.cflags = pc.parse_list(line[7..])
-			} else if line.starts_with('Libs:') {
-				pc.libs = pc.parse_list(line[5..])
-			} else if line.starts_with('Libs.private:') {
-				pc.libs_private = pc.parse_list(line[13..])
-			} else if line.starts_with('URL:') {
-				pc.url = pc.parse_line(line[4..])
-			}
+		return
+	}
+	for oline in lines {
+		line := oline.trim_space()
+		if line.starts_with('#') {
+			continue
+		}
+		if line.contains('=') && !line.contains(' ') {
+			pc.setvar(line)
+			continue
+		}
+		if line.starts_with('Name:') {
+			pc.name = pc.parse_line(line[5..])
+		} else if line.starts_with('Description:') {
+			pc.description = pc.parse_line(line[12..])
+		} else if line.starts_with('Version:') {
+			pc.version = pc.parse_line(line[8..])
+		} else if line.starts_with('Requires:') {
+			pc.requires = pc.parse_list_no_comma(line[9..])
+		} else if line.starts_with('Requires.private:') {
+			pc.requires_private = pc.parse_list_no_comma(line[17..])
+		} else if line.starts_with('Conflicts:') {
+			pc.conflicts = pc.parse_list_no_comma(line[10..])
+		} else if line.starts_with('Cflags:') {
+			pc.cflags = pc.parse_list(line[7..])
+		} else if line.starts_with('Libs:') {
+			pc.libs = pc.parse_list(line[5..])
+		} else if line.starts_with('Libs.private:') {
+			pc.libs_private = pc.parse_list(line[13..])
+		} else if line.starts_with('URL:') {
+			pc.url = pc.parse_line(line[4..])
 		}
 	}
-	return true
+}
+
+fn (mut pc PkgConfig) parse_static_fields(lines []string) ! {
+	if pc.options.only_description {
+		for line in lines {
+			key, value, is_field := split_static_field(line)
+			if is_field && key == 'description' {
+				pc.description = pc.parse_line(value)
+			}
+		}
+		return
+	}
+	for oline in lines {
+		line := oline.trim_space()
+		if line.starts_with('#') {
+			continue
+		}
+		if pc.set_static_var(line) {
+			continue
+		}
+		key, value, is_field := split_static_field(line)
+		if !is_field {
+			continue
+		}
+		match key {
+			'name' { pc.name = pc.parse_line(value) }
+			'description' { pc.description = pc.parse_line(value) }
+			'version' { pc.version = pc.parse_line(value) }
+			'requires' { pc.requires << pc.parse_list_no_comma(value) }
+			'requires.private' { pc.requires_private << pc.parse_list_no_comma(value) }
+			'conflicts' { pc.conflicts = pc.parse_list_no_comma(value) }
+			'cflags' { pc.cflags << pc.parse_list(value) }
+			'cflags.private' { pc.cflags_private << pc.parse_list(value) }
+			'libs' { pc.libs << pc.parse_static_link_list(value)! }
+			'libs.private' { pc.libs_private << pc.parse_static_link_list(value)! }
+			'url' { pc.url = pc.parse_line(value) }
+			else {}
+		}
+	}
+}
+
+fn (mut pc PkgConfig) parse(file string) ! {
+	pc.file_path = file
+	pc.vars['pcfiledir'] = os.real_path(os.dir(file))
+	data := os.read_file(file)!
+	if pc.options.debug {
+		eprintln(data)
+	}
+	if pc.options.link_mode == .static_ {
+		pc.parse_static_fields(fold_static_continued_lines(data))!
+	} else {
+		pc.parse_dynamic_fields(data.split('\n'))
+	}
 }
 
 fn (mut pc PkgConfig) resolve(pkgname string) !string {
@@ -186,6 +543,11 @@ pub fn (mut pc PkgConfig) extend(pcdep &PkgConfig) string {
 			pc.cflags << flag
 		}
 	}
+	for flag in pcdep.cflags_private {
+		if pc.cflags_private.index(flag) == -1 {
+			pc.cflags_private << flag
+		}
+	}
 	for lib in pcdep.libs {
 		if pc.libs.index(lib) == -1 {
 			pc.libs << lib
@@ -214,8 +576,11 @@ fn (mut pc PkgConfig) load_require(dep string) ! {
 	}
 	pc.loaded << dep
 	mut pcdep := PkgConfig{
-		paths:  pc.paths
-		loaded: pc.loaded
+		paths:   pc.paths
+		loaded:  pc.loaded
+		options: Options{
+			link_mode: pc.options.link_mode
+		}
 	}
 	depfile := pcdep.resolve(dep) or {
 		if pc.options.debug {
@@ -223,13 +588,271 @@ fn (mut pc PkgConfig) load_require(dep string) ! {
 		}
 		return error('could not resolve dependency ${dep}')
 	}
-	if !pcdep.parse(depfile) {
-		return error('required file "${depfile}" could not be parsed')
+	pcdep.parse(depfile) or {
+		return error('required file "${depfile}" could not be parsed: ${err.msg()}')
 	}
 	if !pc.options.norecurse {
 		pcdep.load_requires()!
 	}
 	pc.extend(pcdep)
+}
+
+struct StaticResolver {
+	options Options
+mut:
+	packages      map[string]&PkgConfig
+	solve_state   map[string]u8
+	blocked_edges map[string]bool
+	visited       map[string]bool
+	order         []string
+}
+
+fn (mut r StaticResolver) load_package(pkgname string) !&PkgConfig {
+	if pkgname in r.packages {
+		return r.packages[pkgname] or { return error('could not load package ${pkgname}') }
+	}
+	pc := load_direct(pkgname, r.options)!
+	r.packages[pkgname] = pc
+	return pc
+}
+
+fn static_dependency_edge(parent string, dependency string) string {
+	return '${parent}\x00${dependency}'
+}
+
+fn (mut r StaticResolver) prepare(pkgname string) ! {
+	if r.solve_state[pkgname] == 2 {
+		return
+	}
+	pc := r.load_package(pkgname)!
+	r.solve_state[pkgname] = 1
+	if !r.options.norecurse {
+		for dependency in pc.requires {
+			if r.solve_state[dependency] == 1 {
+				r.blocked_edges[static_dependency_edge(pkgname, dependency)] = true
+				continue
+			}
+			r.prepare(dependency) or {
+				if r.options.debug {
+					eprintln('cannot resolve ${dependency}: ${err.msg()}')
+				}
+				return error('could not resolve dependency ${dependency}: ${err.msg()}')
+			}
+		}
+		for dependency in pc.requires_private {
+			if r.solve_state[dependency] == 1 {
+				continue
+			}
+			r.prepare(dependency) or {
+				if r.options.debug {
+					eprintln('cannot resolve ${dependency}: ${err.msg()}')
+				}
+				return error('could not resolve dependency ${dependency}: ${err.msg()}')
+			}
+		}
+	}
+	r.solve_state[pkgname] = 2
+}
+
+fn (mut r StaticResolver) collect(pkgname string) ! {
+	if r.visited[pkgname] {
+		return
+	}
+	pc := r.load_package(pkgname)!
+	r.visited[pkgname] = true
+	if !r.options.norecurse {
+		// pkgconf flattens private dependencies first, then public dependencies,
+		// walking each list backwards and prepending each completed package.
+		for i := pc.requires_private.len - 1; i >= 0; i-- {
+			dependency := pc.requires_private[i]
+			r.collect(dependency) or {
+				if r.options.debug {
+					eprintln('cannot resolve ${dependency}: ${err.msg()}')
+				}
+				return error('could not resolve dependency ${dependency}: ${err.msg()}')
+			}
+		}
+		for i := pc.requires.len - 1; i >= 0; i-- {
+			dependency := pc.requires[i]
+			if r.blocked_edges[static_dependency_edge(pkgname, dependency)] {
+				continue
+			}
+			r.collect(dependency) or {
+				if r.options.debug {
+					eprintln('cannot resolve ${dependency}: ${err.msg()}')
+				}
+				return error('could not resolve dependency ${dependency}: ${err.msg()}')
+			}
+		}
+	}
+	r.order.prepend(pkgname)
+}
+
+fn (mut r StaticResolver) package_order(pkgnames []string) ![]string {
+	r.solve_state = map[string]u8{}
+	r.blocked_edges = map[string]bool{}
+	for pkgname in pkgnames {
+		r.prepare(pkgname)!
+	}
+	r.visited = map[string]bool{}
+	r.order = []string{}
+	for i := pkgnames.len - 1; i >= 0; i-- {
+		r.collect(pkgnames[i])!
+	}
+	return r.order.clone()
+}
+
+struct StaticFragmentMerger {
+mut:
+	fragments             []string
+	merge_visible         []bool
+	group_depth           int
+	whole_archive_active  bool
+	pending_operand_owner string
+}
+
+fn static_fragment_is_group_start(fragment string) bool {
+	return fragment in ['-Wl,--start-group', '-Wl,-(']
+}
+
+fn static_fragment_is_group_end(fragment string) bool {
+	return fragment in ['-Wl,--end-group', '-Wl,-)']
+}
+
+fn static_fragment_is_whole_archive_control(fragment string) bool {
+	return fragment in ['-Wl,--whole-archive', '-Wl,--no-whole-archive']
+}
+
+fn static_fragment_is_search_path(fragment string) bool {
+	return fragment.starts_with('-I') || fragment.starts_with('-L') || fragment.starts_with('-F')
+}
+
+fn static_fragment_takes_operand(fragment string) bool {
+	return fragment in ['-L', '-l', '-framework', '-weak_framework', '-force_load', '-Xlinker',
+		'-isystem', '-idirafter', '-include', '-Wl,-rpath', '-Wl,--rpath', '-Wl,-R',
+		'-Wl,-rpath-link', '-Wl,--rpath-link', '-Wl,--version-script']
+}
+
+fn (m &StaticFragmentMerger) find_visible(fragment string) int {
+	for i := m.fragments.len - 1; i >= 0; i-- {
+		if m.merge_visible[i] && m.fragments[i] == fragment {
+			return i
+		}
+	}
+	return -1
+}
+
+fn (m &StaticFragmentMerger) should_merge_visible(previous int, fragment string) bool {
+	if previous <= 0 || fragment.len <= 2 || !fragment.starts_with('-l') {
+		return true
+	}
+	// pkgconf preserves a library when its immediate predecessor is a special linker fragment.
+	return !m.fragments[previous - 1].starts_with('-Wl,')
+}
+
+fn (mut m StaticFragmentMerger) append_fragment(fragment string, is_private bool) {
+	in_group := m.group_depth > 0
+	in_whole_archive := m.whole_archive_active
+	is_group_start := static_fragment_is_group_start(fragment)
+	is_group_end := static_fragment_is_group_end(fragment)
+	operand_owner := m.pending_operand_owner
+	is_operand := operand_owner != ''
+	m.pending_operand_owner = ''
+	is_whole_archive_start := fragment == '-Wl,--whole-archive'
+		|| (operand_owner == '-Xlinker' && fragment == '--whole-archive')
+	is_whole_archive_end := fragment == '-Wl,--no-whole-archive'
+		|| (operand_owner == '-Xlinker' && fragment == '--no-whole-archive')
+	if is_group_start {
+		m.group_depth++
+	}
+	if is_group_end && m.group_depth > 0 {
+		m.group_depth--
+	}
+	if is_whole_archive_start {
+		m.whole_archive_active = true
+	}
+	if is_whole_archive_end {
+		m.whole_archive_active = false
+	}
+	is_positional := is_operand || in_group || is_group_start || is_group_end
+		|| static_fragment_is_whole_archive_control(fragment) || in_whole_archive
+		|| static_fragment_takes_operand(fragment)
+	if is_private || is_positional {
+		m.fragments << fragment
+		m.merge_visible << !is_positional
+	} else if static_fragment_is_search_path(fragment) {
+		if m.find_visible(fragment) == -1 {
+			m.fragments << fragment
+			m.merge_visible << true
+		}
+	} else {
+		previous := m.find_visible(fragment)
+		if previous >= 0 && m.should_merge_visible(previous, fragment) {
+			m.fragments.delete(previous)
+			m.merge_visible.delete(previous)
+		}
+		m.fragments << fragment
+		m.merge_visible << true
+	}
+	if static_fragment_takes_operand(fragment) {
+		m.pending_operand_owner = fragment
+	}
+}
+
+fn (mut m StaticFragmentMerger) append(fragments []string, is_private bool) {
+	for fragment in fragments {
+		m.append_fragment(fragment, is_private)
+	}
+}
+
+fn resolve_dynamic(pkgnames []string, options Options) !ResolvedFlags {
+	mut combined := &PkgConfig(unsafe { nil })
+	for pkgname in pkgnames {
+		mut pc := load(pkgname, options)!
+		if unsafe { combined != 0 } {
+			combined.extend(pc)
+		} else {
+			combined = pc
+		}
+	}
+	return ResolvedFlags{
+		cflags: combined.cflags.clone()
+		libs:   combined.libs.clone()
+	}
+}
+
+// resolve returns the pkgconf-compatible static fragment closure. Dynamic
+// callers retain the legacy load/extend behavior.
+pub fn resolve(pkgnames []string, options Options) !ResolvedFlags {
+	if pkgnames.len == 0 {
+		return error('No packages given')
+	}
+	if options.link_mode != .static_ {
+		return resolve_dynamic(pkgnames, options)
+	}
+	mut resolver := StaticResolver{
+		options: options
+	}
+	order := resolver.package_order(pkgnames)!
+	mut cflags := StaticFragmentMerger{}
+	mut libs := StaticFragmentMerger{}
+	for pkgname in order {
+		pc := resolver.packages[pkgname] or { return error('could not load package ${pkgname}') }
+		cflags.append(pc.cflags, false)
+	}
+	for pkgname in order {
+		pc := resolver.packages[pkgname] or { return error('could not load package ${pkgname}') }
+		cflags.append(pc.cflags_private, true)
+	}
+	for pkgname in order {
+		pc := resolver.packages[pkgname] or { return error('could not load package ${pkgname}') }
+		libs.append(pc.libs, false)
+		libs.append(pc.libs_private, true)
+	}
+	return ResolvedFlags{
+		cflags: cflags.fragments
+		libs:   libs.fragments
+	}
 }
 
 fn (mut pc PkgConfig) add_path(path string) {
@@ -277,6 +900,17 @@ fn (mut pc PkgConfig) load_paths() {
 	}
 }
 
+fn load_direct(pkgname string, options Options) !&PkgConfig {
+	mut pc := &PkgConfig{
+		modname: pkgname
+		options: options
+	}
+	pc.load_paths()
+	file := pc.resolve(pkgname) or { return err }
+	pc.parse(file) or { return error('file "${file}" could not be parsed: ${err.msg()}') }
+	return pc
+}
+
 pub fn load(pkgname string, options Options) !&PkgConfig {
 	mut pc := &PkgConfig{
 		modname: pkgname
@@ -284,9 +918,7 @@ pub fn load(pkgname string, options Options) !&PkgConfig {
 	}
 	pc.load_paths()
 	file := pc.resolve(pkgname) or { return err }
-	if !pc.parse(file) {
-		return error('file "${file}" could not be parsed')
-	}
+	pc.parse(file) or { return error('file "${file}" could not be parsed: ${err.msg()}') }
 	if !options.norecurse {
 		pc.load_requires()!
 	}

--- a/vlib/v/pkgconfig/pkgconfig_define_prefix_compile_test.v
+++ b/vlib/v/pkgconfig/pkgconfig_define_prefix_compile_test.v
@@ -1,0 +1,137 @@
+module main
+
+import os
+
+struct PrefixCompileResult {
+	exit_code int
+	stdout    string
+	stderr    string
+}
+
+struct PrefixCompileCase {
+	name       string
+	directive  string
+	extra_args []string
+}
+
+fn prefix_compile_cases() []PrefixCompileCase {
+	return [
+		PrefixCompileCase{
+			name:      'dynamic'
+			directive: '#pkgconfig relocatable-compile'
+		},
+		PrefixCompileCase{
+			name:       'global static'
+			directive:  '#pkgconfig relocatable-compile'
+			extra_args: ['-cflags', '-static']
+		},
+		PrefixCompileCase{
+			name:      'directive static'
+			directive: '#pkgconfig --static relocatable-compile'
+		},
+	]
+}
+
+fn prefix_compile_environment_value(mut env map[string]string, name string, value string) {
+	lower_name := name.to_lower_ascii()
+	for key in env.keys() {
+		if key.to_lower_ascii() == lower_name {
+			env.delete(key)
+		}
+	}
+	env[name] = value
+}
+
+fn run_prefix_compile_process(executable string, args []string, work_dir string, env map[string]string) PrefixCompileResult {
+	mut process := os.new_process(executable)
+	process.set_args(args)
+	process.set_work_folder(work_dir)
+	process.set_environment(env)
+	process.set_redirect_stdio()
+	process.wait()
+	result := PrefixCompileResult{
+		exit_code: process.code
+		stdout:    process.stdout_slurp()
+		stderr:    process.stderr_slurp()
+	}
+	process.close()
+	return result
+}
+
+fn test_relocated_pkgconfig_path_reaches_selected_compile_command() {
+	$if !windows {
+		return
+	}
+	ccompiler := @CCOMPILER
+	if ccompiler !in ['gcc', 'clang'] {
+		return
+	}
+	run_relocated_pkgconfig_compile(ccompiler)
+}
+
+fn run_relocated_pkgconfig_compile(ccompiler string) {
+	compiler := os.find_abs_path_of_executable(ccompiler) or {
+		panic('required ${ccompiler} executable was not found')
+	}
+	vexe := @VEXE
+	assert os.is_file(vexe), 'required V executable was not found: ${vexe}'
+	for compile_case in prefix_compile_cases() {
+		root := os.join_path(os.vtmp_dir(),
+			'pkgconfig compile ${os.getpid()} ${ccompiler} ${compile_case.name}')
+		prefix := os.join_path(root, 'non standard sdk root')
+		pc_dir := os.join_path(prefix, 'lib', 'pkgconfig')
+		include_dir := os.join_path(prefix, 'include')
+		lib_dir := os.join_path(prefix, 'lib')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(pc_dir) or { panic(err) }
+		os.mkdir_all(include_dir) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+
+		os.write_file(os.join_path(pc_dir, 'relocatable-compile.pc'), r'prefix=/synthetic-sdk
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: relocatable-compile
+Description: Standalone relocated compile metadata
+Version: 1.0.0
+Cflags: -I${includedir}
+Libs: -L${libdir}
+') or {
+			panic(err)
+		}
+		os.write_file(os.join_path(include_dir, 'relocatable_probe.h'),
+			'#ifndef RELOCATABLE_PROBE_H\n#define RELOCATABLE_PROBE_H\nstatic int relocated_probe_value(void) { return 7601; }\n#endif\n') or {
+			panic(err)
+		}
+		source := os.join_path(root, 'main.v')
+		output := os.join_path(root, 'relocatable_probe.exe')
+		os.write_file(source,
+			'module main\n${compile_case.directive}\n#include <relocatable_probe.h>\nfn C.relocated_probe_value() int\nfn main() {\n\tassert C.relocated_probe_value() == 7601\n}\n') or {
+			panic(err)
+		}
+
+		mut env := os.environ()
+		prefix_compile_environment_value(mut env, 'PKG_CONFIG_PATH', '')
+		prefix_compile_environment_value(mut env, 'PKG_CONFIG_PATH_DEFAULTS', pc_dir)
+		prefix_compile_environment_value(mut env, 'CPATH', '')
+		prefix_compile_environment_value(mut env, 'C_INCLUDE_PATH', '')
+		prefix_compile_environment_value(mut env, 'VFLAGS', '')
+		mut args := ['-cc', compiler, '-gc', 'none', '-no-retry-compilation', '-no-rsp', '-showcc',
+			'-show-c-output']
+		args << compile_case.extra_args
+		args << ['-o', output, source]
+		compile_result := run_prefix_compile_process(vexe, args, root, env)
+		assert compile_result.exit_code == 0, '${ccompiler} ${compile_case.name} compile failed:\nstdout:\n${compile_result.stdout}\nstderr:\n${compile_result.stderr}'
+
+		command_output := '${compile_result.stdout}\n${compile_result.stderr}'.replace('\\', '/')
+		physical_prefix := os.real_path(prefix).replace('\\', '/')
+		assert command_output.contains('${physical_prefix}/include'), command_output
+		assert command_output.contains('${physical_prefix}/lib'), command_output
+		assert !command_output.contains('/synthetic-sdk'), command_output
+
+		runtime_result := run_prefix_compile_process(output, [], root, env)
+		assert runtime_result.exit_code == 0, '${ccompiler} ${compile_case.name} runtime failed:\nstdout:\n${runtime_result.stdout}\nstderr:\n${runtime_result.stderr}'
+	}
+}

--- a/vlib/v/pkgconfig/pkgconfig_define_prefix_test.v
+++ b/vlib/v/pkgconfig/pkgconfig_define_prefix_test.v
@@ -1,0 +1,437 @@
+module main
+
+import os
+import v.pkgconfig
+
+const synthetic_prefix = '/synthetic-sdk'
+
+struct PrefixRelocationFixture {
+	base_dir   string
+	prefix_dir string
+	pc_dir     string
+}
+
+fn normalized_prefix_path(path string) string {
+	return os.real_path(path).replace('\\', '/').trim_right('/')
+}
+
+fn normalized_prefix_flags(flags []string) []string {
+	return flags.map(it.replace('\\', '/'))
+}
+
+fn relocated_path(prefix string, suffix string) string {
+	return '${prefix}/${suffix}'
+}
+
+fn write_prefix_fixture(pc_dir string, name string, content string) {
+	os.write_file(os.join_path(pc_dir, '${name}.pc'), content) or { panic(err) }
+}
+
+fn new_prefix_relocation_fixture(label string) PrefixRelocationFixture {
+	base_dir := os.join_path(os.vtmp_dir(), 'pkgconfig relocation ${os.getpid()} ${label}')
+	prefix_dir := os.join_path(base_dir, 'non standard sdk root')
+	pc_dir := os.join_path(prefix_dir, 'lib', 'pkgconfig')
+	os.rmdir_all(base_dir) or {}
+	os.mkdir_all(pc_dir) or { panic(err) }
+
+	write_prefix_fixture(pc_dir, 'relocatable-direct', r'prefix=/synthetic-sdk
+includedir=${prefix}/include
+libdir=${prefix}/lib
+absoluteincludedir=/synthetic-sdk/absolute/include
+absolutelibdir=/synthetic-sdk/absolute/lib
+neighborincludedir=/synthetic-sdk-neighbor/include
+neighborlibdir=/synthetic-sdk-neighbor/lib
+lookalikeincludedir=/synthetic-sdk2/include
+lookalikelibdir=/synthetic-sdk2/lib
+
+Name: relocatable-direct
+Description: Direct relocatable metadata
+Version: 1.0.0
+Cflags: -I${includedir}/direct -I${absoluteincludedir} -I${neighborincludedir} -I${lookalikeincludedir} -DRELOCATABLE_DIRECT
+Cflags.private: -I${prefix}/private/direct -DRELOCATABLE_DIRECT_PRIVATE
+Libs: -L${libdir}/direct -L${absolutelibdir} -L${neighborlibdir} -L${lookalikelibdir} -lrelocatable_direct
+Libs.private: -L${prefix}/private/lib -lrelocatable_direct_private
+')
+	write_prefix_fixture(pc_dir, 'relocatable-root', r'prefix=/synthetic-sdk
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: relocatable-root
+Description: Relocatable dependency root
+Version: 1.0.0
+Requires: relocatable-public
+Requires.private: relocatable-private
+Cflags: -I${includedir}/root -DRELOCATABLE_ROOT
+Cflags.private: -I${prefix}/private/root -DRELOCATABLE_ROOT_PRIVATE
+Libs: -L${libdir}/root -lrelocatable_root
+Libs.private: -L${prefix}/private/lib/root -lrelocatable_root_private
+')
+	write_prefix_fixture(pc_dir, 'relocatable-public', r'prefix=/synthetic-sdk
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: relocatable-public
+Description: Public relocatable dependency
+Version: 1.0.0
+Cflags: -I${includedir}/public -DRELOCATABLE_PUBLIC
+Cflags.private: -I${prefix}/private/public -DRELOCATABLE_PUBLIC_PRIVATE
+Libs: -L${libdir}/public -lrelocatable_public
+Libs.private: -L${prefix}/private/lib/public -lrelocatable_public_private
+')
+	write_prefix_fixture(pc_dir, 'relocatable-private', r'prefix=/synthetic-sdk
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: relocatable-private
+Description: Private relocatable dependency
+Version: 1.0.0
+Cflags: -I${includedir}/private -DRELOCATABLE_PRIVATE
+Cflags.private: -I${prefix}/private/private -DRELOCATABLE_PRIVATE_PRIVATE
+Libs: -L${libdir}/private -lrelocatable_private
+Libs.private: -L${prefix}/private/lib/private -lrelocatable_private_private
+')
+
+	return PrefixRelocationFixture{
+		base_dir:   base_dir
+		prefix_dir: prefix_dir
+		pc_dir:     pc_dir
+	}
+}
+
+fn new_single_prefix_fixture(label string, metadata_parent string, name string, content string) PrefixRelocationFixture {
+	base_dir := os.join_path(os.vtmp_dir(), 'pkgconfig relocation ${os.getpid()} ${label}')
+	prefix_dir := os.join_path(base_dir, 'non standard sdk root')
+	pc_dir := os.join_path(prefix_dir, metadata_parent, 'pkgconfig')
+	os.rmdir_all(base_dir) or {}
+	os.mkdir_all(pc_dir) or { panic(err) }
+	write_prefix_fixture(pc_dir, name, content)
+	return PrefixRelocationFixture{
+		base_dir:   base_dir
+		prefix_dir: prefix_dir
+		pc_dir:     pc_dir
+	}
+}
+
+fn new_nonstandard_metadata_fixture(label string, name string, content string) PrefixRelocationFixture {
+	base_dir := os.join_path(os.vtmp_dir(), 'pkgconfig relocation ${os.getpid()} ${label}')
+	prefix_dir := os.join_path(base_dir, 'non standard sdk root')
+	pc_dir := os.join_path(prefix_dir, 'lib', 'metadata')
+	os.rmdir_all(base_dir) or {}
+	os.mkdir_all(pc_dir) or { panic(err) }
+	write_prefix_fixture(pc_dir, name, content)
+	return PrefixRelocationFixture{
+		base_dir:   base_dir
+		prefix_dir: prefix_dir
+		pc_dir:     pc_dir
+	}
+}
+
+fn resolve_prefix_fixture(fixture PrefixRelocationFixture, packages []string, mode pkgconfig.LinkMode) pkgconfig.ResolvedFlags {
+	return pkgconfig.resolve(packages, pkgconfig.Options{
+		path:              fixture.pc_dir
+		use_default_paths: false
+		link_mode:         mode
+	}) or { panic(err) }
+}
+
+fn test_pkgconfig_relocates_direct_metadata_in_dynamic_mode() {
+	$if !windows {
+		return
+	}
+	fixture := new_prefix_relocation_fixture('dynamic direct')
+	defer {
+		os.rmdir_all(fixture.base_dir) or {}
+	}
+	prefix := normalized_prefix_path(fixture.prefix_dir)
+	flags := resolve_prefix_fixture(fixture, ['relocatable-direct'], .dynamic)
+
+	assert normalized_prefix_flags(flags.cflags) == [
+		'-I${relocated_path(prefix, 'include/direct')}',
+		'-I${relocated_path(prefix, 'absolute/include')}',
+		'-I${synthetic_prefix}-neighbor/include',
+		'-I${synthetic_prefix}2/include',
+		'-DRELOCATABLE_DIRECT',
+	]
+	assert normalized_prefix_flags(flags.libs) == [
+		'-L${relocated_path(prefix, 'lib/direct')}',
+		'-L${relocated_path(prefix, 'absolute/lib')}',
+		'-L${synthetic_prefix}-neighbor/lib',
+		'-L${synthetic_prefix}2/lib',
+		'-lrelocatable_direct',
+	]
+}
+
+fn test_pkgconfig_does_not_relocate_metadata_outside_pkgconfig_directory() {
+	$if !windows {
+		return
+	}
+	fixture := new_nonstandard_metadata_fixture('non metadata layout', 'nonrelocatable-layout', r'prefix=/synthetic-sdk
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: nonrelocatable-layout
+Description: Metadata outside a pkgconfig directory
+Version: 1.0.0
+Cflags: -I${includedir}/layout
+Libs: -L${libdir}/layout -lnonrelocatable_layout
+')
+	defer {
+		os.rmdir_all(fixture.base_dir) or {}
+	}
+	for mode in [pkgconfig.LinkMode.dynamic, .static_] {
+		flags := resolve_prefix_fixture(fixture, ['nonrelocatable-layout'], mode)
+		assert normalized_prefix_flags(flags.cflags) == [
+			'-I${synthetic_prefix}/include/layout',
+		]
+		assert normalized_prefix_flags(flags.libs) == [
+			'-L${synthetic_prefix}/lib/layout',
+			'-lnonrelocatable_layout',
+		]
+	}
+}
+
+fn test_pkgconfig_relocates_windows_paths_case_insensitively() {
+	$if !windows {
+		return
+	}
+	fixture := new_single_prefix_fixture('mixed case windows path', 'lib', 'relocatable-case', r'prefix=/Synthetic-SDK
+includedir=/synthetic-sdk\include
+libdir=/SYNTHETIC-sdk\lib
+
+Name: relocatable-case
+Description: Mixed-case Windows path metadata
+Version: 1.0.0
+Cflags: -I${includedir}/case
+Libs: -L${libdir}/case -lrelocatable_case
+')
+	defer {
+		os.rmdir_all(fixture.base_dir) or {}
+	}
+	prefix := normalized_prefix_path(fixture.prefix_dir)
+	for mode in [pkgconfig.LinkMode.dynamic, .static_] {
+		flags := resolve_prefix_fixture(fixture, ['relocatable-case'], mode)
+		assert normalized_prefix_flags(flags.cflags) == [
+			'-I${relocated_path(prefix, 'include/case')}',
+		]
+		assert normalized_prefix_flags(flags.libs) == [
+			'-L${relocated_path(prefix, 'lib/case')}',
+			'-lrelocatable_case',
+		]
+	}
+}
+
+fn test_pkgconfig_relocates_variables_declared_before_and_after_prefix() {
+	$if !windows {
+		return
+	}
+	fixture := new_single_prefix_fixture('variable order', 'lib', 'relocatable-order', r'before=/synthetic-sdk/before
+prefix=/synthetic-sdk
+after=/synthetic-sdk/after
+
+Name: relocatable-order
+Description: Variable ordering metadata
+Version: 1.0.0
+Cflags: -I${before}/include -I${after}/include
+Libs: -L${before}/lib -L${after}/lib -lrelocatable_order
+')
+	defer {
+		os.rmdir_all(fixture.base_dir) or {}
+	}
+	prefix := normalized_prefix_path(fixture.prefix_dir)
+	for mode in [pkgconfig.LinkMode.dynamic, .static_] {
+		flags := resolve_prefix_fixture(fixture, ['relocatable-order'], mode)
+		assert normalized_prefix_flags(flags.cflags) == [
+			'-I${synthetic_prefix}/before/include',
+			'-I${relocated_path(prefix, 'after/include')}',
+		]
+		assert normalized_prefix_flags(flags.libs) == [
+			'-L${synthetic_prefix}/before/lib',
+			'-L${relocated_path(prefix, 'after/lib')}',
+			'-lrelocatable_order',
+		]
+	}
+}
+
+fn test_pkgconfig_relocates_share_pkgconfig_layout() {
+	$if !windows {
+		return
+	}
+	fixture := new_single_prefix_fixture('share layout', 'share', 'relocatable-share', r'prefix=/synthetic-sdk
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: relocatable-share
+Description: Shared metadata layout
+Version: 1.0.0
+Cflags: -I${includedir}/share
+Libs: -L${libdir}/share -lrelocatable_share
+')
+	defer {
+		os.rmdir_all(fixture.base_dir) or {}
+	}
+	prefix := normalized_prefix_path(fixture.prefix_dir)
+	for mode in [pkgconfig.LinkMode.dynamic, .static_] {
+		flags := resolve_prefix_fixture(fixture, ['relocatable-share'], mode)
+		assert normalized_prefix_flags(flags.cflags) == [
+			'-I${relocated_path(prefix, 'include/share')}',
+		]
+		assert normalized_prefix_flags(flags.libs) == [
+			'-L${relocated_path(prefix, 'lib/share')}',
+			'-lrelocatable_share',
+		]
+	}
+}
+
+fn test_pkgconfig_preserves_drive_absolute_and_unc_prefixes() {
+	$if !windows {
+		return
+	}
+	drive_fixture := new_single_prefix_fixture('drive absolute', 'lib', 'native-drive-prefix', r'prefix=C:/already/absolute
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: native-drive-prefix
+Description: Native drive-absolute metadata
+Version: 1.0.0
+Cflags: -I${includedir}
+Libs: -L${libdir} -lnative_drive_prefix
+')
+	defer {
+		os.rmdir_all(drive_fixture.base_dir) or {}
+	}
+	for mode in [pkgconfig.LinkMode.dynamic, .static_] {
+		flags := resolve_prefix_fixture(drive_fixture, ['native-drive-prefix'], mode)
+		assert normalized_prefix_flags(flags.cflags) == [
+			'-IC:/already/absolute/include',
+		]
+		assert normalized_prefix_flags(flags.libs) == [
+			'-LC:/already/absolute/lib',
+			'-lnative_drive_prefix',
+		]
+	}
+
+	unc_fixture := new_single_prefix_fixture('unc absolute', 'share', 'native-unc-prefix', r'prefix=//server/share/sdk
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: native-unc-prefix
+Description: Native UNC metadata
+Version: 1.0.0
+Cflags: -I${includedir}
+Libs: -L${libdir} -lnative_unc_prefix
+')
+	defer {
+		os.rmdir_all(unc_fixture.base_dir) or {}
+	}
+	for mode in [pkgconfig.LinkMode.dynamic, .static_] {
+		flags := resolve_prefix_fixture(unc_fixture, ['native-unc-prefix'], mode)
+		assert normalized_prefix_flags(flags.cflags) == [
+			'-I//server/share/sdk/include',
+		]
+		assert normalized_prefix_flags(flags.libs) == [
+			'-L//server/share/sdk/lib',
+			'-lnative_unc_prefix',
+		]
+	}
+}
+
+fn test_pkgconfig_relocates_dependency_closure_in_dynamic_mode() {
+	$if !windows {
+		return
+	}
+	fixture := new_prefix_relocation_fixture('dynamic closure')
+	defer {
+		os.rmdir_all(fixture.base_dir) or {}
+	}
+	prefix := normalized_prefix_path(fixture.prefix_dir)
+	flags := resolve_prefix_fixture(fixture, ['relocatable-root'], .dynamic)
+
+	assert normalized_prefix_flags(flags.cflags) == [
+		'-I${relocated_path(prefix, 'include/root')}',
+		'-DRELOCATABLE_ROOT',
+		'-I${relocated_path(prefix, 'include/public')}',
+		'-DRELOCATABLE_PUBLIC',
+		'-I${relocated_path(prefix, 'include/private')}',
+		'-DRELOCATABLE_PRIVATE',
+	]
+	assert normalized_prefix_flags(flags.libs) == [
+		'-L${relocated_path(prefix, 'lib/root')}',
+		'-lrelocatable_root',
+		'-L${relocated_path(prefix, 'lib/public')}',
+		'-lrelocatable_public',
+		'-L${relocated_path(prefix, 'lib/private')}',
+		'-lrelocatable_private',
+	]
+}
+
+fn test_pkgconfig_relocates_direct_private_metadata_in_static_mode() {
+	$if !windows {
+		return
+	}
+	fixture := new_prefix_relocation_fixture('static direct')
+	defer {
+		os.rmdir_all(fixture.base_dir) or {}
+	}
+	prefix := normalized_prefix_path(fixture.prefix_dir)
+	flags := resolve_prefix_fixture(fixture, ['relocatable-direct'], .static_)
+
+	assert normalized_prefix_flags(flags.cflags) == [
+		'-I${relocated_path(prefix, 'include/direct')}',
+		'-I${relocated_path(prefix, 'absolute/include')}',
+		'-I${synthetic_prefix}-neighbor/include',
+		'-I${synthetic_prefix}2/include',
+		'-DRELOCATABLE_DIRECT',
+		'-I${relocated_path(prefix, 'private/direct')}',
+		'-DRELOCATABLE_DIRECT_PRIVATE',
+	]
+	assert normalized_prefix_flags(flags.libs) == [
+		'-L${relocated_path(prefix, 'lib/direct')}',
+		'-L${relocated_path(prefix, 'absolute/lib')}',
+		'-L${synthetic_prefix}-neighbor/lib',
+		'-L${synthetic_prefix}2/lib',
+		'-lrelocatable_direct',
+		'-L${relocated_path(prefix, 'private/lib')}',
+		'-lrelocatable_direct_private',
+	]
+}
+
+fn test_pkgconfig_relocates_public_and_private_dependencies_in_static_mode() {
+	$if !windows {
+		return
+	}
+	fixture := new_prefix_relocation_fixture('static closure')
+	defer {
+		os.rmdir_all(fixture.base_dir) or {}
+	}
+	prefix := normalized_prefix_path(fixture.prefix_dir)
+	flags := resolve_prefix_fixture(fixture, ['relocatable-root'], .static_)
+
+	assert normalized_prefix_flags(flags.cflags) == [
+		'-I${relocated_path(prefix, 'include/root')}',
+		'-DRELOCATABLE_ROOT',
+		'-I${relocated_path(prefix, 'include/public')}',
+		'-DRELOCATABLE_PUBLIC',
+		'-I${relocated_path(prefix, 'include/private')}',
+		'-DRELOCATABLE_PRIVATE',
+		'-I${relocated_path(prefix, 'private/root')}',
+		'-DRELOCATABLE_ROOT_PRIVATE',
+		'-I${relocated_path(prefix, 'private/public')}',
+		'-DRELOCATABLE_PUBLIC_PRIVATE',
+		'-I${relocated_path(prefix, 'private/private')}',
+		'-DRELOCATABLE_PRIVATE_PRIVATE',
+	]
+	assert normalized_prefix_flags(flags.libs) == [
+		'-L${relocated_path(prefix, 'lib/root')}',
+		'-lrelocatable_root',
+		'-L${relocated_path(prefix, 'private/lib/root')}',
+		'-lrelocatable_root_private',
+		'-L${relocated_path(prefix, 'lib/public')}',
+		'-lrelocatable_public',
+		'-L${relocated_path(prefix, 'private/lib/public')}',
+		'-lrelocatable_public_private',
+		'-L${relocated_path(prefix, 'lib/private')}',
+		'-lrelocatable_private',
+		'-L${relocated_path(prefix, 'private/lib/private')}',
+		'-lrelocatable_private_private',
+	]
+}

--- a/vlib/v/pkgconfig/pkgconfig_static_test.v
+++ b/vlib/v/pkgconfig/pkgconfig_static_test.v
@@ -1,0 +1,719 @@
+import os
+import v.pkgconfig
+
+const issue74_fixture_dir = os.join_path(@VEXEROOT, 'vlib', 'v', 'pkgconfig', 'testdata',
+	'static_pkgconfig')
+
+fn issue74_pkgconfig_result(args []string) pkgconfig.MainResult {
+	old_path := os.getenv_opt('PKG_CONFIG_PATH')
+	old_defaults := os.getenv_opt('PKG_CONFIG_PATH_DEFAULTS')
+	os.unsetenv('PKG_CONFIG_PATH')
+	os.setenv('PKG_CONFIG_PATH_DEFAULTS', issue74_fixture_dir, true)
+	defer {
+		if path := old_path {
+			os.setenv('PKG_CONFIG_PATH', path, true)
+		} else {
+			os.unsetenv('PKG_CONFIG_PATH')
+		}
+		if defaults := old_defaults {
+			os.setenv('PKG_CONFIG_PATH_DEFAULTS', defaults, true)
+		} else {
+			os.unsetenv('PKG_CONFIG_PATH_DEFAULTS')
+		}
+	}
+	mut command := pkgconfig.main(args) or { panic(err) }
+	return command.run_result() or { panic(err) }
+}
+
+fn issue74_pkgconfig_tokens(args []string) []string {
+	return issue74_pkgconfig_result(args).output.fields()
+}
+
+struct Issue74PkgconfigToolResult {
+	exit_code int
+	stdout    string
+	stderr    string
+}
+
+fn issue74_pkgconfig_run_tool(executable string, args []string, work_dir string) Issue74PkgconfigToolResult {
+	mut process := os.new_process(executable)
+	process.set_args(args)
+	process.set_work_folder(work_dir)
+	process.set_redirect_stdio()
+	process.wait()
+	result := Issue74PkgconfigToolResult{
+		exit_code: process.code
+		stdout:    process.stdout_slurp()
+		stderr:    process.stderr_slurp()
+	}
+	process.close()
+	return result
+}
+
+struct Issue74StaticCase {
+	package string
+	libs    []string
+	cflags  []string
+}
+
+struct Issue74SplitLinkerCase {
+	control   string
+	package_a string
+	package_b string
+	operand_a string
+	operand_b string
+}
+
+fn issue74_split_linker_cases() []Issue74SplitLinkerCase {
+	return [
+		Issue74SplitLinkerCase{
+			control:   '-Wl,-rpath'
+			package_a: 'split-rpath-a-74'
+			package_b: 'split-rpath-b-74'
+			operand_a: '-Wl,/issue74/split-rpath-a'
+			operand_b: '-Wl,/issue74/split-rpath-b'
+		},
+		Issue74SplitLinkerCase{
+			control:   '-Wl,--rpath'
+			package_a: 'split-rpath-long-a-74'
+			package_b: 'split-rpath-long-b-74'
+			operand_a: '-Wl,/tmp'
+			operand_b: '-Wl,/var/tmp'
+		},
+		Issue74SplitLinkerCase{
+			control:   '-Wl,-R'
+			package_a: 'split-rpath-capital-r-a-74'
+			package_b: 'split-rpath-capital-r-b-74'
+			operand_a: '-Wl,/tmp'
+			operand_b: '-Wl,/var/tmp'
+		},
+		Issue74SplitLinkerCase{
+			control:   '-Wl,-rpath-link'
+			package_a: 'split-rpath-link-a-74'
+			package_b: 'split-rpath-link-b-74'
+			operand_a: '-Wl,/tmp'
+			operand_b: '-Wl,/var/tmp'
+		},
+		Issue74SplitLinkerCase{
+			control:   '-Wl,--rpath-link'
+			package_a: 'split-rpath-link-long-a-74'
+			package_b: 'split-rpath-link-long-b-74'
+			operand_a: '-Wl,/tmp'
+			operand_b: '-Wl,/var/tmp'
+		},
+	]
+}
+
+fn issue74_assert_static_case(case Issue74StaticCase) {
+	libs_args := ['--static', '--libs', case.package]
+	cflags_args := ['--static', '--cflags', case.package]
+	assert issue74_pkgconfig_tokens(libs_args) == case.libs
+	assert issue74_pkgconfig_tokens(cflags_args) == case.cflags
+}
+
+fn test_pkgconfig_dynamic_keeps_historical_private_dependency_overlinking() {
+	assert issue74_pkgconfig_tokens(['--libs', 'static-root-74']) == [
+		'-lissue74_root',
+		'-lissue74_public',
+		'-lissue74_private',
+	]
+	assert issue74_pkgconfig_tokens(['--cflags', 'static-root-74']) == [
+		'-DISSUE74_ROOT',
+		'-DISSUE74_PUBLIC',
+		'-DISSUE74_PRIVATE',
+	]
+}
+
+fn test_pkgconfig_dynamic_repeated_fields_keep_historical_last_wins() {
+	assert issue74_pkgconfig_tokens(['--cflags', 'repeated-static-fields-74']) == [
+		'-DISSUE74_REPEATED_ROOT_PUBLIC_B',
+		'-DORACLE_DIAMOND_COMMON',
+		'-DISSUE74_UPPERCASE_PROVIDER',
+	]
+	assert issue74_pkgconfig_tokens(['--libs', 'repeated-static-fields-74']) == [
+		'-lissue74_repeated_root_public_b',
+		'-loracle_diamond_common',
+		'-luppercase_private_provider',
+	]
+}
+
+fn test_pkgconfig_static_repeated_fields_accumulate_in_source_order() {
+	assert issue74_pkgconfig_tokens([
+		'--static',
+		'--print-requires',
+		'repeated-static-fields-74',
+	]) == ['static-public-74', 'oracle-diamond-common-74']
+
+	issue74_assert_static_case(Issue74StaticCase{
+		package: 'repeated-static-fields-74'
+		libs:    ['-lissue74_repeated_root_public_a', '-lissue74_repeated_root_public_b',
+			'-lissue74_repeated_root_private_a', '-lissue74_repeated_root_private_b',
+			'-lissue74_public', '-lissue74_public_private', '-loracle_diamond_common',
+			'-lissue74_private', '-lissue74_private_private', '-luppercase_private_provider']
+		cflags:  ['-DISSUE74_REPEATED_ROOT_PUBLIC_A', '-DISSUE74_REPEATED_ROOT_PUBLIC_B',
+			'-DISSUE74_PUBLIC', '-DORACLE_DIAMOND_COMMON', '-DISSUE74_PRIVATE',
+			'-DISSUE74_UPPERCASE_PROVIDER', '-DISSUE74_REPEATED_ROOT_PRIVATE_A',
+			'-DISSUE74_REPEATED_ROOT_PRIVATE_B', '-DISSUE74_PUBLIC_PRIVATE',
+			'-DISSUE74_PRIVATE_PRIVATE', '-DFRIBIDI_LIB_STATIC']
+	})
+}
+
+fn test_pkgconfig_static_matches_reference_closure_order_and_repetition() {
+	issue74_assert_static_case(Issue74StaticCase{
+		package: 'static-root-74'
+		libs:    ['-lissue74_root', '-Wl,--start-group', '-lissue74_cycle_a', '-lissue74_cycle_b',
+			'-lissue74_cycle_a', '-Wl,--end-group', '-lissue74_root_private', '-lissue74_public',
+			'-lissue74_public_private', '-lissue74_private', '-lissue74_private_private']
+		cflags:  ['-DISSUE74_ROOT', '-DISSUE74_PUBLIC', '-DISSUE74_PRIVATE', '-DISSUE74_ROOT_PRIVATE',
+			'-DISSUE74_PUBLIC_PRIVATE', '-DISSUE74_PRIVATE_PRIVATE']
+	})
+}
+
+fn test_pkgconfig_static_public_duplicate_graph_preserves_expected_order() {
+	issue74_assert_static_case(Issue74StaticCase{
+		package: 'oracle-duplicate-root-74'
+		libs:    ['-loracle_duplicate_root', '-loracle_duplicate_left', '-loracle_duplicate_shared',
+			'-loracle_duplicate_right']
+		cflags:  ['-DORACLE_DUPLICATE_ROOT', '-DORACLE_DUPLICATE_LEFT', '-DORACLE_DUPLICATE_SHARED',
+			'-DORACLE_DUPLICATE_RIGHT']
+	})
+}
+
+fn test_pkgconfig_static_framework_search_paths_keep_first_occurrence_order() {
+	assert issue74_pkgconfig_tokens([
+		'--static',
+		'--libs',
+		'framework-search-path-74',
+	]) == ['-F/sdk1', '-F/sdk2', '-framework', 'Foo']
+}
+
+fn test_pkgconfig_static_preserves_public_split_link_pairs() {
+	assert issue74_pkgconfig_result([
+		'--static',
+		'--libs',
+		'split-link-pairs-root-74',
+	]).link_flags == [
+		'-L',
+		'/issue74/root-search',
+		'-l',
+		'issue74_root',
+		'-L',
+		'/issue74/search-a',
+		'-l',
+		'issue74_a',
+		'-L',
+		'/issue74/search-b',
+		'-l',
+		'issue74_b',
+	]
+}
+
+fn test_pkgconfig_static_tokenizes_quoted_and_escaped_split_link_operands() {
+	assert issue74_pkgconfig_result([
+		'--static',
+		'--libs',
+		'quoted-split-link-pairs-74',
+	]).link_flags == [
+		'-L',
+		'/issue74/public search',
+		'-l',
+		'issue74_public',
+		'-L',
+		'/issue74/private search',
+		'-l',
+		'issue74_private',
+	]
+}
+
+fn test_pkgconfig_static_keeps_quoted_expanded_space_variable_in_one_link_fragment() {
+	assert issue74_pkgconfig_result([
+		'--static',
+		'--libs',
+		'expanded-space-link-74',
+	]).link_flags == [
+		'-L',
+		'/issue74/expanded lib',
+		'-l',
+		'issue74_expanded_space',
+		'/issue74/expanded lib/libissue74_expanded_direct.a',
+	]
+}
+
+fn test_pkgconfig_static_retokenizes_unquoted_expanded_link_flags() {
+	assert issue74_pkgconfig_result([
+		'--static',
+		'--libs',
+		'expanded-link-flags-74',
+	]).link_flags == ['-lissue74_expanded_a', '-lissue74_expanded_b']
+	// The historical dynamic parser does not accumulate space-containing variable assignments.
+	assert issue74_pkgconfig_tokens(['--libs', 'expanded-link-flags-74']) == []
+}
+
+fn test_pkgconfig_static_folds_continued_physical_lines() {
+	assert issue74_pkgconfig_result([
+		'--static',
+		'--libs',
+		'continued-static-fields-74',
+	]).link_flags == [
+		'-L/issue74/continued',
+		'-lissue74_cont_public_a',
+		'-lissue74_cont_public_b',
+		'-lissue74_cont_var_a',
+		'-lissue74_cont_var_b',
+		'-lissue74_cont_private_a',
+		'-lissue74_cont_private_b',
+	]
+	pc := pkgconfig.load('continued-static-fields-74', pkgconfig.Options{
+		path:              issue74_fixture_dir
+		use_default_paths: false
+		link_mode:         .static_
+	}) or { panic(err) }
+	assert pc.vars['odd_backslashes'] == 'left\\\\right'
+	assert pc.vars['even_backslashes'] == 'left\\\\'
+	assert issue74_pkgconfig_tokens(['--libs', 'continued-static-fields-74']) == [
+		'-L/issue74/continued',
+		'-lissue74_cont_public_a',
+		'\\',
+	]
+
+	crlf_fixture := os.join_path(os.vtmp_dir(), 'continued-static-crlf-74-${os.getpid()}.pc')
+	os.write_file(crlf_fixture,
+		'Name: continued-static-crlf-74\r\nDescription: CRLF continuation probe\r\nVersion: 1.0.0\r\nLibs: -lissue74_crlf_a \\\r\n\t-lissue74_crlf_b\r\n') or {
+		panic(err)
+	}
+	defer {
+		os.rm(crlf_fixture) or {}
+	}
+	mut command := pkgconfig.main(['--static', '--libs', crlf_fixture]) or { panic(err) }
+	result := command.run_result() or { panic(err) }
+	assert result.link_flags == ['-lissue74_crlf_a', '-lissue74_crlf_b']
+}
+
+fn test_pkgconfig_static_consumes_odd_continuation_marker_at_eof() {
+	prefix := 'Name: continued-static-eof-74\nDescription: EOF continuation probe\nVersion: 1.0.0\nLibs: -lissue74_eof '
+	contents := [
+		prefix + '\\',
+		prefix + '\\\n',
+		prefix + '\\\\',
+		prefix + '\\\\\n',
+	]
+	for i, content in contents {
+		fixture := os.join_path(os.vtmp_dir(), 'continued-static-eof-74-${os.getpid()}-${i}.pc')
+		os.write_file(fixture, content) or { panic(err) }
+		mut command := pkgconfig.main(['--static', '--libs', fixture]) or { panic(err) }
+		result := command.run_result() or { panic(err) }
+		os.rm(fixture) or { panic(err) }
+		expected := if i < 2 { ['-lissue74_eof'] } else { ['-lissue74_eof', '\\'] }
+		assert result.link_flags == expected
+	}
+}
+
+fn test_pkgconfig_static_accepts_spaced_variable_assignments() {
+	assert issue74_pkgconfig_result([
+		'--static',
+		'--libs',
+		'spaced-variable-assignment-74',
+	]).link_flags == ['-L/issue74/spaced-assignment', '-lissue74_spaced_assignment']
+	pc := pkgconfig.load('spaced-variable-assignment-74', pkgconfig.Options{
+		path:              issue74_fixture_dir
+		use_default_paths: false
+		link_mode:         .static_
+	}) or { panic(err) }
+	assert pc.vars['libdir'] == '/issue74/spaced-assignment'
+	assert pc.vars['embedded_equals'] == 'left=right'
+	assert pc.description == 'Spaced assignment=field value'
+	assert issue74_pkgconfig_tokens(['--libs', 'spaced-variable-assignment-74']) == [
+		'-L',
+		'-lissue74_spaced_assignment',
+	]
+
+	invalid_fixture := os.join_path(os.vtmp_dir(),
+		'static-variable-validation-74-${os.getpid()}.pc')
+	os.write_file(invalid_fixture,
+		'=empty\nbad key = internal\ntabbed\t=\ttrimmed\nName: static-variable-validation-74\nDescription: field=value\nVersion: 1.0.0\nLibs: -lissue74_validation\n') or {
+		panic(err)
+	}
+	defer {
+		os.rm(invalid_fixture) or {}
+	}
+	invalid_pc := pkgconfig.load(invalid_fixture, pkgconfig.Options{
+		use_default_paths: false
+		link_mode:         .static_
+	}) or { panic(err) }
+	assert '' !in invalid_pc.vars
+	assert 'bad key' !in invalid_pc.vars
+	assert invalid_pc.vars['tabbed'] == 'trimmed'
+	assert invalid_pc.description == 'field=value'
+}
+
+fn test_pkgconfig_static_keeps_split_version_script_operand_adjacent_when_repeated() {
+	shared_operand := '/issue74/shared-symbol-list.map'
+	assert issue74_pkgconfig_result([
+		'--static',
+		'--libs',
+		'split-version-script-repeat-74',
+	]).link_flags == [
+		'-Wl,--version-script',
+		'-Wl,${shared_operand}',
+		'-Wl,--dynamic-list',
+		'-Wl,${shared_operand}',
+	]
+
+	$if linux {
+		gcc := os.find_abs_path_of_executable('gcc') or { return }
+		root := os.join_path(os.vtmp_dir(), 'issue74_split_version_script_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		main_source := os.join_path(root, 'main.c')
+		version_script := os.join_path(root, 'symbols.map')
+		pc_file := os.join_path(root, 'split-version-script-link-74.pc')
+		output := os.join_path(root, 'split-version-script.out')
+		os.write_file(main_source,
+			'int issue74_exported(void) { return 0; }\nint main(void) { return issue74_exported(); }\n') or {
+			panic(err)
+		}
+		os.write_file(version_script, '{\n\tissue74_exported;\n};\n') or { panic(err) }
+		os.write_file(pc_file,
+			'Name: split-version-script-link-74\nDescription: Repeated split version-script operand link proof\nVersion: 1.0.0\nLibs: -Wl,--version-script -Wl,${version_script} -Wl,--dynamic-list -Wl,${version_script}\n') or {
+			panic(err)
+		}
+		link_flags := issue74_pkgconfig_result(['--static', '--libs', pc_file]).link_flags
+		assert link_flags == [
+			'-Wl,--version-script',
+			'-Wl,${version_script}',
+			'-Wl,--dynamic-list',
+			'-Wl,${version_script}',
+		]
+		mut link_args := [main_source]
+		link_args << link_flags
+		link_args << ['-o', output]
+		linked := issue74_pkgconfig_run_tool(gcc, link_args, root)
+		assert linked.exit_code == 0, linked.stdout + linked.stderr
+		assert issue74_pkgconfig_run_tool(output, [], root).exit_code == 0
+	}
+}
+
+fn test_pkgconfig_static_preserves_quoted_public_and_private_link_operands() {
+	assert issue74_pkgconfig_result([
+		'--static',
+		'--libs',
+		'quoted-static-link-operands-74',
+	]).link_flags == [
+		'/issue74/double  space/libissue74_public.a',
+		'/issue74/comma, space/libissue74_private.a',
+	]
+
+	$if linux {
+		gcc := os.find_abs_path_of_executable('gcc') or { return }
+		ar := os.find_abs_path_of_executable('ar') or { return }
+		root := os.join_path(os.vtmp_dir(), 'issue74_quoted_link_operands_${os.getpid()}')
+		public_dir := os.join_path(root, 'double  space')
+		private_dir := os.join_path(root, 'comma, space')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(public_dir) or { panic(err) }
+		os.mkdir_all(private_dir) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		main_source := os.join_path(root, 'main.c')
+		public_source := os.join_path(root, 'public.c')
+		private_source := os.join_path(root, 'private.c')
+		public_object := os.join_path(root, 'public.o')
+		private_object := os.join_path(root, 'private.o')
+		public_archive := os.join_path(public_dir, 'libissue74_public.a')
+		private_archive := os.join_path(private_dir, 'libissue74_private.a')
+		pc_file := os.join_path(root, 'quoted-static-link-operands-link-74.pc')
+		output := os.join_path(root, 'quoted-static-link-operands.out')
+		os.write_file(main_source,
+			'int issue74_public(void);\nint main(void) { return issue74_public() == 42 ? 0 : 1; }\n') or {
+			panic(err)
+		}
+		os.write_file(public_source,
+			'int issue74_private(void);\nint issue74_public(void) { return issue74_private() + 1; }\n') or {
+			panic(err)
+		}
+		os.write_file(private_source, 'int issue74_private(void) { return 41; }\n') or {
+			panic(err)
+		}
+		for source, object in {
+			public_source:  public_object
+			private_source: private_object
+		} {
+			compiled := issue74_pkgconfig_run_tool(gcc, ['-c', source, '-o', object], root)
+			assert compiled.exit_code == 0, compiled.stdout + compiled.stderr
+		}
+		for archive, object in {
+			public_archive:  public_object
+			private_archive: private_object
+		} {
+			archived := issue74_pkgconfig_run_tool(ar, ['rcs', archive, object], root)
+			assert archived.exit_code == 0, archived.stdout + archived.stderr
+		}
+		os.write_file(pc_file,
+			'Name: quoted-static-link-operands-link-74\nDescription: Quoted public and private archive link proof\nVersion: 1.0.0\nLibs: "${public_archive}"\nLibs.private: "${private_archive}"\n') or {
+			panic(err)
+		}
+		link_flags := issue74_pkgconfig_result(['--static', '--libs', pc_file]).link_flags
+		assert link_flags == [public_archive, private_archive]
+		mut link_args := [main_source]
+		link_args << link_flags
+		link_args << ['-o', output]
+		linked := issue74_pkgconfig_run_tool(gcc, link_args, root)
+		assert linked.exit_code == 0, linked.stdout + linked.stderr
+		assert issue74_pkgconfig_run_tool(output, [], root).exit_code == 0
+	}
+}
+
+fn test_pkgconfig_static_decodes_escaped_hash_before_normal_comment() {
+	assert issue74_pkgconfig_result([
+		'--static',
+		'--libs',
+		'escaped-hash-link-74',
+	]).link_flags == ['-L', '/issue74/escaped#hash', '-lescaped']
+}
+
+fn test_pkgconfig_static_rejects_unterminated_link_flag_quote() {
+	fixture := os.join_path(issue74_fixture_dir, 'unterminated-link-quote-74.pc')
+	mut command := pkgconfig.main(['--static', '--libs', fixture]) or { panic(err) }
+	command.run_result() or {
+		assert err.msg().contains('unterminated quote in static pkg-config linker flags')
+		return
+	}
+	assert false
+}
+
+fn test_pkgconfig_static_preserves_transitive_parser_error_context() {
+	pkgconfig.resolve(['transitive-link-error-root-74'], pkgconfig.Options{
+		path:              issue74_fixture_dir
+		use_default_paths: false
+		link_mode:         .static_
+	}) or {
+		assert err.msg().contains('could not resolve dependency transitive-link-error-middle-74')
+		assert err.msg().contains('could not resolve dependency unterminated-link-quote-74')
+		assert err.msg().contains('unterminated quote in static pkg-config linker flags')
+		return
+	}
+	assert false
+}
+
+fn test_pkgconfig_static_public_diamond_graph_preserves_expected_order() {
+	issue74_assert_static_case(Issue74StaticCase{
+		package: 'oracle-diamond-root-74'
+		libs:    ['-loracle_diamond_root', '-loracle_diamond_left', '-loracle_diamond_right',
+			'-loracle_diamond_common']
+		cflags:  ['-DORACLE_DIAMOND_ROOT', '-DORACLE_DIAMOND_LEFT', '-DORACLE_DIAMOND_RIGHT',
+			'-DORACLE_DIAMOND_COMMON']
+	})
+}
+
+fn test_pkgconfig_static_public_complex_cycle_preserves_expected_order() {
+	issue74_assert_static_case(Issue74StaticCase{
+		package: 'oracle-cycle-root-74'
+		libs:    ['-loracle_cycle_root', '-loracle_cycle_a', '-loracle_cycle_b', '-loracle_cycle_c']
+		cflags:  ['-DORACLE_CYCLE_ROOT', '-DORACLE_CYCLE_A', '-DORACLE_CYCLE_B', '-DORACLE_CYCLE_C']
+	})
+}
+
+fn test_pkgconfig_uppercase_private_cflags_are_static_only() {
+	dynamic_args := ['--cflags', 'uppercase-private-root-74']
+	dynamic_cflags := ['-DISSUE74_UPPERCASE_ROOT', '-DISSUE74_UPPERCASE_PROVIDER']
+	assert issue74_pkgconfig_tokens(dynamic_args) == dynamic_cflags
+
+	issue74_assert_static_case(Issue74StaticCase{
+		package: 'uppercase-private-root-74'
+		libs:    ['-luppercase_private_root', '-luppercase_private_provider']
+		cflags:  ['-DISSUE74_UPPERCASE_ROOT', '-DISSUE74_UPPERCASE_PROVIDER', '-DFRIBIDI_LIB_STATIC']
+	})
+}
+
+fn test_pkgconfig_mixed_case_fields_are_static_only() {
+	assert issue74_pkgconfig_tokens([
+		'--cflags',
+		'mixed-case-dynamic-sentinel-74',
+		'mixed-case-static-74',
+	]) == ['-DISSUE74_DYNAMIC_SENTINEL']
+	assert issue74_pkgconfig_tokens([
+		'--libs',
+		'mixed-case-dynamic-sentinel-74',
+		'mixed-case-static-74',
+	]) == ['-Wl,--issue74-dynamic-sentinel']
+
+	assert issue74_pkgconfig_tokens(['--static', '--cflags', 'mixed-case-static-74']) == [
+		'-DISSUE74_MIXED_PUBLIC',
+		'-DISSUE74_MIXED_PRIVATE',
+	]
+	assert issue74_pkgconfig_tokens(['--static', '--libs', 'mixed-case-static-74']) == [
+		'-Wl,--issue74-mixed-public',
+		'-Wl,--issue74-mixed-private',
+	]
+}
+
+fn test_pkgconfig_static_preserves_gnu_ld_group_alias_repetition() {
+	issue74_assert_static_case(Issue74StaticCase{
+		package: 'group-alias-74'
+		libs:    ['-Wl,-(', '-lissue74_alias_a', '-lissue74_alias_b', '-lissue74_alias_a', '-Wl,-)']
+		cflags:  []
+	})
+}
+
+fn test_pkgconfig_static_matches_mergeback_around_linker_state_controls() {
+	issue74_assert_static_case(Issue74StaticCase{
+		package: 'linker-state-epochs-74'
+		libs:    ['-Wl,--as-needed', '-lissue74_state', '-Wl,--no-as-needed', '-lissue74_state',
+			'-lissue74_state']
+		cflags:  []
+	})
+}
+
+fn test_pkgconfig_static_preserves_repeated_whole_archive_controls() {
+	issue74_assert_static_case(Issue74StaticCase{
+		package: 'repeated-whole-archive-74'
+		libs:    ['-Wl,--whole-archive', '-lissue74_whole_a', '-Wl,--no-whole-archive',
+			'-Wl,--whole-archive', '-lissue74_whole_b', '-Wl,--no-whole-archive']
+		cflags:  []
+	})
+}
+
+fn test_pkgconfig_static_tracks_xlinker_whole_archive_state() {
+	assert issue74_pkgconfig_result([
+		'--static',
+		'--libs',
+		'xlinker-whole-archive-74',
+	]).link_flags == [
+		'-Xlinker',
+		'--whole-archive',
+		'-lissue74_xlinker_whole',
+		'-Xlinker',
+		'--no-whole-archive',
+		'-lissue74_xlinker_whole',
+	]
+}
+
+fn test_pkgconfig_static_does_not_broaden_xlinker_state_controls() {
+	assert issue74_pkgconfig_result([
+		'--static',
+		'--libs',
+		'xlinker-other-state-74',
+	]).link_flags == [
+		'-Xlinker',
+		'--as-needed',
+		'-Xlinker',
+		'--no-as-needed',
+		'-lissue74_xlinker_other',
+	]
+}
+
+fn test_pkgconfig_static_preserves_libraries_across_whole_archive_epochs() {
+	assert issue74_pkgconfig_tokens([
+		'--static',
+		'--libs',
+		'whole-archive-normal-74',
+	]) == ['-lissue74_epoch', '-lissue74_epoch_dependency']
+	assert issue74_pkgconfig_tokens([
+		'--static',
+		'--libs',
+		'whole-archive-normal-74',
+		'whole-archive-epoch-74',
+	]) == ['-lissue74_epoch', '-lissue74_epoch_dependency', '-Wl,--whole-archive', '-lissue74_epoch',
+		'-Wl,--no-whole-archive']
+}
+
+fn test_pkgconfig_static_preserves_literal_archives_across_whole_archive_epochs() {
+	assert issue74_pkgconfig_tokens([
+		'--static',
+		'--libs',
+		'whole-archive-literal-normal-74',
+	]) == ['/issue74/libliteral-epoch.a', '/issue74/libliteral-dependency.a']
+	assert issue74_pkgconfig_tokens([
+		'--static',
+		'--libs',
+		'whole-archive-literal-normal-74',
+		'whole-archive-literal-epoch-74',
+	]) == ['/issue74/libliteral-epoch.a', '/issue74/libliteral-dependency.a', '-Wl,--whole-archive',
+		'/issue74/libliteral-epoch.a', '-Wl,--no-whole-archive']
+}
+
+fn test_pkgconfig_static_treats_whole_archive_start_as_idempotent() {
+	assert issue74_pkgconfig_tokens([
+		'--static',
+		'--libs',
+		'whole-archive-idempotent-74',
+	]) == ['-Wl,--whole-archive', '-Wl,--whole-archive', '/issue74/libliteral-active.a',
+		'-Wl,--no-whole-archive', '/issue74/libliteral-tail.a']
+}
+
+fn test_pkgconfig_dynamic_isolated_from_whole_archive_merging() {
+	assert issue74_pkgconfig_tokens(['--libs', 'whole-archive-idempotent-74']) == [
+		'-Wl,--whole-archive',
+		'-Wl,--whole-archive',
+		'/issue74/libliteral-active.a',
+		'-Wl,--no-whole-archive',
+		'/issue74/libliteral-tail.a',
+		'/issue74/libliteral-tail.a',
+	]
+}
+
+fn test_pkgconfig_static_preserves_split_linker_control_operands() {
+	for case in issue74_split_linker_cases() {
+		assert issue74_pkgconfig_tokens(['--static', '--libs', case.package_a, case.package_b]) == [
+			case.control,
+			case.operand_a,
+			case.control,
+			case.operand_b,
+		]
+	}
+}
+
+fn test_pkgconfig_dynamic_keeps_historical_split_linker_duplicate_behavior() {
+	for case in issue74_split_linker_cases() {
+		assert issue74_pkgconfig_tokens(['--libs', case.package_a, case.package_b]) == [
+			case.control,
+			case.operand_a,
+			case.operand_b,
+		]
+	}
+}
+
+fn test_pkgconfig_static_load_propagates_link_mode_to_recursive_dependencies() {
+	dynamic_pc := pkgconfig.load('recursive-static-load-root-74', pkgconfig.Options{
+		path:              issue74_fixture_dir
+		use_default_paths: false
+	}) or { panic(err) }
+	assert dynamic_pc.libs == ['-lissue74_recursive_static_root']
+	assert dynamic_pc.libs_private == []
+	assert dynamic_pc.cflags == ['-DISSUE74_RECURSIVE_STATIC_ROOT']
+	assert dynamic_pc.cflags_private == []
+
+	pc := pkgconfig.load('recursive-static-load-root-74', pkgconfig.Options{
+		path:              issue74_fixture_dir
+		use_default_paths: false
+		link_mode:         .static_
+	}) or { panic(err) }
+	assert pc.libs == ['-lissue74_recursive_static_root', '-Wl,--issue74-mixed-public']
+	assert pc.libs_private == ['-Wl,--issue74-mixed-private']
+	assert pc.cflags == ['-DISSUE74_RECURSIVE_STATIC_ROOT', '-DISSUE74_MIXED_PUBLIC']
+	assert pc.cflags_private == ['-DISSUE74_MIXED_PRIVATE']
+}
+
+fn test_pkgconfig_static_trims_field_names_without_changing_dynamic_parser() {
+	assert issue74_pkgconfig_tokens(['--libs', 'spaced-fields-74']) == []
+	assert issue74_pkgconfig_tokens(['--cflags', 'spaced-fields-74']) == []
+	issue74_assert_static_case(Issue74StaticCase{
+		package: 'spaced-fields-74'
+		libs:    ['-lissue74_spaced_root', '-lissue74_spaced_root_private', '-lissue74_private',
+			'-lissue74_private_private']
+		cflags:  ['-DISSUE74_SPACED_ROOT', '-DISSUE74_PRIVATE', '-DISSUE74_SPACED_ROOT_PRIVATE',
+			'-DISSUE74_PRIVATE_PRIVATE']
+	})
+}
+
+fn test_pkgconfig_static_shared_public_private_dependency_is_emitted_once() {
+	issue74_assert_static_case(Issue74StaticCase{
+		package: 'shared-public-private-edge-74'
+		libs:    ['-lissue74_shared_edge_root', '-lissue74_public', '-lissue74_public_private']
+		cflags:  ['-DISSUE74_SHARED_EDGE_ROOT', '-DISSUE74_PUBLIC', '-DISSUE74_PUBLIC_PRIVATE']
+	})
+}

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/continued-static-fields-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/continued-static-fields-74.pc
@@ -1,0 +1,14 @@
+continued_libs=-lissue74_cont_var_a \
+    -lissue74_cont_var_b
+odd_backslashes=left\\\
+    right
+even_backslashes=left\\
+# An even trailing pair is data, not a continuation marker.
+
+Name: continued-static-fields-74
+Description: Static physical-line continuation fixture
+Version: 1.0.0
+Libs: -L/issue74/continued -lissue74_cont_public_a \
+    -lissue74_cont_public_b ${continued_libs}
+Libs.private: -lissue74_cont_private_a \
+    -lissue74_cont_private_b

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/escaped-hash-link-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/escaped-hash-link-74.pc
@@ -1,0 +1,4 @@
+Name: escaped-hash-link-74
+Description: Escaped hash and normal comment fixture
+Version: 1.0.0
+Libs: -L /issue74/escaped\#hash -lescaped # -lcommented

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/expanded-link-flags-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/expanded-link-flags-74.pc
@@ -1,0 +1,6 @@
+linkflags=-lissue74_expanded_a -lissue74_expanded_b
+
+Name: expanded-link-flags-74
+Description: Expanded static linker flag list fixture
+Version: 1.0.0
+Libs: ${linkflags}

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/expanded-space-link-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/expanded-space-link-74.pc
@@ -1,0 +1,7 @@
+libdir=/issue74/expanded lib
+
+Name: expanded-space-link-74
+Description: Expanded variable linker boundary fixture
+Version: 1.0.0
+Libs: -L "${libdir}" -l issue74_expanded_space
+Libs.private: "${libdir}/libissue74_expanded_direct.a"

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/framework-search-path-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/framework-search-path-74.pc
@@ -1,0 +1,4 @@
+Name: framework-search-path-74
+Description: Framework search path precedence fixture
+Version: 1.0.0
+Libs: -F/sdk1 -F/sdk2 -F/sdk1 -framework Foo

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/group-alias-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/group-alias-74.pc
@@ -1,0 +1,4 @@
+Name: group-alias-74
+Description: GNU ld archive group alias regression
+Version: 1.0.0
+Libs: -Wl,-( -lissue74_alias_a -lissue74_alias_b -lissue74_alias_a -Wl,-)

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/linker-state-epochs-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/linker-state-epochs-74.pc
@@ -1,0 +1,4 @@
+Name: linker-state-epochs-74
+Description: Linker state merge-back regression
+Version: 1.0.0
+Libs: -lissue74_state -lissue74_state -Wl,--as-needed -lissue74_state -lissue74_state -Wl,--no-as-needed -lissue74_state -lissue74_state

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/mixed-case-dynamic-sentinel-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/mixed-case-dynamic-sentinel-74.pc
@@ -1,0 +1,5 @@
+Name: mixed-case-dynamic-sentinel-74
+Description: Exact-key dynamic compatibility sentinel
+Version: 1.0.0
+Libs: -Wl,--issue74-dynamic-sentinel
+Cflags: -DISSUE74_DYNAMIC_SENTINEL

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/mixed-case-static-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/mixed-case-static-74.pc
@@ -1,0 +1,7 @@
+Name: mixed-case-static-74
+Description: Mixed-case fields accepted only by static resolution
+Version: 1.0.0
+lIbS: -Wl,--issue74-mixed-public
+lIbS.pRiVaTe: -Wl,--issue74-mixed-private
+cFlAgS: -DISSUE74_MIXED_PUBLIC
+cFlAgS.pRiVaTe: -DISSUE74_MIXED_PRIVATE

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-cycle-a-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-cycle-a-74.pc
@@ -1,0 +1,6 @@
+Name: oracle-cycle-a-74
+Description: First public cycle node
+Version: 1.0.0
+Requires: oracle-cycle-b-74 oracle-cycle-c-74
+Libs: -loracle_cycle_a
+Cflags: -DORACLE_CYCLE_A

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-cycle-b-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-cycle-b-74.pc
@@ -1,0 +1,6 @@
+Name: oracle-cycle-b-74
+Description: Second public cycle node
+Version: 1.0.0
+Requires: oracle-cycle-c-74
+Libs: -loracle_cycle_b
+Cflags: -DORACLE_CYCLE_B

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-cycle-c-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-cycle-c-74.pc
@@ -1,0 +1,6 @@
+Name: oracle-cycle-c-74
+Description: Third public cycle node
+Version: 1.0.0
+Requires: oracle-cycle-a-74
+Libs: -loracle_cycle_c
+Cflags: -DORACLE_CYCLE_C

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-cycle-root-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-cycle-root-74.pc
@@ -1,0 +1,6 @@
+Name: oracle-cycle-root-74
+Description: Multi-consumer public cycle oracle root
+Version: 1.0.0
+Requires: oracle-cycle-a-74 oracle-cycle-c-74
+Libs: -loracle_cycle_root
+Cflags: -DORACLE_CYCLE_ROOT

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-diamond-common-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-diamond-common-74.pc
@@ -1,0 +1,5 @@
+Name: oracle-diamond-common-74
+Description: Shared public diamond provider
+Version: 1.0.0
+Libs: -loracle_diamond_common
+Cflags: -DORACLE_DIAMOND_COMMON

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-diamond-left-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-diamond-left-74.pc
@@ -1,0 +1,6 @@
+Name: oracle-diamond-left-74
+Description: Left public diamond consumer
+Version: 1.0.0
+Requires: oracle-diamond-common-74
+Libs: -loracle_diamond_left
+Cflags: -DORACLE_DIAMOND_LEFT

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-diamond-right-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-diamond-right-74.pc
@@ -1,0 +1,6 @@
+Name: oracle-diamond-right-74
+Description: Right public diamond consumer
+Version: 1.0.0
+Requires: oracle-diamond-common-74
+Libs: -loracle_diamond_right
+Cflags: -DORACLE_DIAMOND_RIGHT

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-diamond-root-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-diamond-root-74.pc
@@ -1,0 +1,6 @@
+Name: oracle-diamond-root-74
+Description: Public diamond oracle root
+Version: 1.0.0
+Requires: oracle-diamond-left-74 oracle-diamond-right-74
+Libs: -loracle_diamond_root
+Cflags: -DORACLE_DIAMOND_ROOT

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-duplicate-left-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-duplicate-left-74.pc
@@ -1,0 +1,5 @@
+Name: oracle-duplicate-left-74
+Description: Left public duplicate-fragment provider
+Version: 1.0.0
+Libs: -loracle_duplicate_shared -loracle_duplicate_left
+Cflags: -DORACLE_DUPLICATE_SHARED -DORACLE_DUPLICATE_LEFT

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-duplicate-right-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-duplicate-right-74.pc
@@ -1,0 +1,5 @@
+Name: oracle-duplicate-right-74
+Description: Right public duplicate-fragment provider
+Version: 1.0.0
+Libs: -loracle_duplicate_shared -loracle_duplicate_right
+Cflags: -DORACLE_DUPLICATE_SHARED -DORACLE_DUPLICATE_RIGHT

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-duplicate-root-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/oracle-duplicate-root-74.pc
@@ -1,0 +1,6 @@
+Name: oracle-duplicate-root-74
+Description: Public duplicate-fragment oracle root
+Version: 1.0.0
+Requires: oracle-duplicate-left-74 oracle-duplicate-right-74
+Libs: -loracle_duplicate_root
+Cflags: -DORACLE_DUPLICATE_ROOT

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/quoted-split-link-pairs-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/quoted-split-link-pairs-74.pc
@@ -1,0 +1,5 @@
+Name: quoted-split-link-pairs-74
+Description: Quoted and escaped split linker operand fixture
+Version: 1.0.0
+Libs: -L "/issue74/public search" -l issue74_public
+Libs.private: -L /issue74/private\ search -l issue74_private

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/quoted-static-link-operands-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/quoted-static-link-operands-74.pc
@@ -1,0 +1,5 @@
+Name: quoted-static-link-operands-74
+Description: Quoted public and private direct link operands
+Version: 1.0.0
+Libs: "/issue74/double  space/libissue74_public.a"
+Libs.private: "/issue74/comma, space/libissue74_private.a"

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/recursive-static-load-root-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/recursive-static-load-root-74.pc
@@ -1,0 +1,6 @@
+Name: recursive-static-load-root-74
+Description: Recursive static load mode propagation
+Version: 1.0.0
+Requires: mixed-case-static-74
+Libs: -lissue74_recursive_static_root
+Cflags: -DISSUE74_RECURSIVE_STATIC_ROOT

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/repeated-static-fields-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/repeated-static-fields-74.pc
@@ -1,0 +1,15 @@
+Name: repeated-static-fields-74
+Description: Repeated static fields accumulate in source order
+Version: 1.0.0
+Requires: static-public-74
+Requires: oracle-diamond-common-74
+Requires.private: static-private-74
+Requires.private: uppercase-private-provider-74
+Cflags: -DISSUE74_REPEATED_ROOT_PUBLIC_A
+Cflags: -DISSUE74_REPEATED_ROOT_PUBLIC_B
+Cflags.private: -DISSUE74_REPEATED_ROOT_PRIVATE_A
+Cflags.private: -DISSUE74_REPEATED_ROOT_PRIVATE_B
+Libs: -lissue74_repeated_root_public_a
+Libs: -lissue74_repeated_root_public_b
+Libs.private: -lissue74_repeated_root_private_a
+Libs.private: -lissue74_repeated_root_private_b

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/repeated-whole-archive-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/repeated-whole-archive-74.pc
@@ -1,0 +1,4 @@
+Name: repeated-whole-archive-74
+Description: Repeated whole-archive linker-state controls
+Version: 1.0.0
+Libs: -Wl,--whole-archive -lissue74_whole_a -Wl,--no-whole-archive -Wl,--whole-archive -lissue74_whole_b -Wl,--no-whole-archive

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/shared-public-private-edge-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/shared-public-private-edge-74.pc
@@ -1,0 +1,7 @@
+Name: shared-public-private-edge-74
+Description: Shared public and private dependency regression
+Version: 1.0.0
+Requires: static-public-74
+Requires.private: static-public-74
+Libs: -lissue74_shared_edge_root
+Cflags: -DISSUE74_SHARED_EDGE_ROOT

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/source-order-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/source-order-74.pc
@@ -1,0 +1,6 @@
+Name: source-order-74
+Description: Source-relative ordered linker segment fixture
+Version: 1.0.0
+Libs: -Wl,--issue74-order-pkg-public
+Libs.private: -Wl,--issue74-order-pkg-private
+Cflags: -DISSUE74_ORDER_CFLAGS

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/spaced-fields-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/spaced-fields-74.pc
@@ -1,0 +1,8 @@
+Name : spaced-fields-74
+Description : Static field-name whitespace regression
+Version : 1.0.0
+Requires.private : static-private-74
+Libs : -lissue74_spaced_root
+Libs.private : -lissue74_spaced_root_private
+Cflags : -DISSUE74_SPACED_ROOT
+Cflags.private : -DISSUE74_SPACED_ROOT_PRIVATE

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/spaced-variable-assignment-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/spaced-variable-assignment-74.pc
@@ -1,0 +1,7 @@
+libdir = /issue74/spaced-assignment
+embedded_equals = left=right
+
+Name: spaced-variable-assignment-74
+Description: Spaced assignment=field value
+Version: 1.0.0
+Libs: -L${libdir} -lissue74_spaced_assignment

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-link-pairs-a-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-link-pairs-a-74.pc
@@ -1,0 +1,4 @@
+Name: split-link-pairs-a-74
+Description: First public split linker pair fixture
+Version: 1.0.0
+Libs: -L /issue74/search-a -l issue74_a

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-link-pairs-b-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-link-pairs-b-74.pc
@@ -1,0 +1,4 @@
+Name: split-link-pairs-b-74
+Description: Second public split linker pair fixture
+Version: 1.0.0
+Libs: -L /issue74/search-b -l issue74_b

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-link-pairs-root-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-link-pairs-root-74.pc
@@ -1,0 +1,5 @@
+Name: split-link-pairs-root-74
+Description: Root public split linker pair fixture
+Version: 1.0.0
+Requires: split-link-pairs-a-74 split-link-pairs-b-74
+Libs: -L /issue74/root-search -l issue74_root

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-a-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-a-74.pc
@@ -1,0 +1,4 @@
+Name: split-rpath-a-74
+Description: First split GNU rpath operand
+Version: 1.0.0
+Libs: -Wl,-rpath -Wl,/issue74/split-rpath-a

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-b-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-b-74.pc
@@ -1,0 +1,4 @@
+Name: split-rpath-b-74
+Description: Second split GNU rpath operand
+Version: 1.0.0
+Libs: -Wl,-rpath -Wl,/issue74/split-rpath-b

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-capital-r-a-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-capital-r-a-74.pc
@@ -1,0 +1,4 @@
+Name: split-rpath-capital-r-a-74
+Description: First split GNU capital R operand
+Version: 1.0.0
+Libs: -Wl,-R -Wl,/tmp

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-capital-r-b-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-capital-r-b-74.pc
@@ -1,0 +1,4 @@
+Name: split-rpath-capital-r-b-74
+Description: Second split GNU capital R operand
+Version: 1.0.0
+Libs: -Wl,-R -Wl,/var/tmp

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-link-a-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-link-a-74.pc
@@ -1,0 +1,4 @@
+Name: split-rpath-link-a-74
+Description: First split GNU rpath-link operand
+Version: 1.0.0
+Libs: -Wl,-rpath-link -Wl,/tmp

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-link-b-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-link-b-74.pc
@@ -1,0 +1,4 @@
+Name: split-rpath-link-b-74
+Description: Second split GNU rpath-link operand
+Version: 1.0.0
+Libs: -Wl,-rpath-link -Wl,/var/tmp

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-link-long-a-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-link-long-a-74.pc
@@ -1,0 +1,4 @@
+Name: split-rpath-link-long-a-74
+Description: First split GNU long rpath-link operand
+Version: 1.0.0
+Libs: -Wl,--rpath-link -Wl,/tmp

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-link-long-b-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-link-long-b-74.pc
@@ -1,0 +1,4 @@
+Name: split-rpath-link-long-b-74
+Description: Second split GNU long rpath-link operand
+Version: 1.0.0
+Libs: -Wl,--rpath-link -Wl,/var/tmp

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-long-a-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-long-a-74.pc
@@ -1,0 +1,4 @@
+Name: split-rpath-long-a-74
+Description: First split GNU long rpath operand
+Version: 1.0.0
+Libs: -Wl,--rpath -Wl,/tmp

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-long-b-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-rpath-long-b-74.pc
@@ -1,0 +1,4 @@
+Name: split-rpath-long-b-74
+Description: Second split GNU long rpath operand
+Version: 1.0.0
+Libs: -Wl,--rpath -Wl,/var/tmp

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/split-version-script-repeat-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/split-version-script-repeat-74.pc
@@ -1,0 +1,4 @@
+Name: split-version-script-repeat-74
+Description: Repeated operand shared by split GNU linker controls
+Version: 1.0.0
+Libs: -Wl,--version-script -Wl,/issue74/shared-symbol-list.map -Wl,--dynamic-list -Wl,/issue74/shared-symbol-list.map

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/static-private-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/static-private-74.pc
@@ -1,0 +1,7 @@
+Name: static-private-74
+Description: Synthetic private dependency for static pkg-config regression coverage
+Version: 1.0.0
+Libs: -lissue74_private
+Libs.private: -lissue74_private_private
+Cflags: -DISSUE74_PRIVATE
+Cflags.private: -DISSUE74_PRIVATE_PRIVATE

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/static-public-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/static-public-74.pc
@@ -1,0 +1,7 @@
+Name: static-public-74
+Description: Synthetic public dependency for static pkg-config regression coverage
+Version: 1.0.0
+Libs: -lissue74_public
+Libs.private: -lissue74_public_private
+Cflags: -DISSUE74_PUBLIC
+Cflags.private: -DISSUE74_PUBLIC_PRIVATE

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/static-root-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/static-root-74.pc
@@ -1,0 +1,9 @@
+Name: static-root-74
+Description: Synthetic root for static pkg-config regression coverage
+Version: 1.0.0
+Requires: static-public-74 >= 1.0.0
+Requires.private: static-private-74 >= 1.0.0
+Libs: -lissue74_root
+Libs.private: -Wl,--start-group -lissue74_cycle_a -lissue74_cycle_b -lissue74_cycle_a -Wl,--end-group -lissue74_root_private
+Cflags: -DISSUE74_ROOT
+Cflags.private: -DISSUE74_ROOT_PRIVATE

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/structured-link-boundary-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/structured-link-boundary-74.pc
@@ -1,0 +1,6 @@
+libdir=/issue74/structured-boundary
+
+Name: structured-link-boundary-74
+Description: Structured private search path and literal archive boundary
+Version: 1.0.0
+Libs.private: -L${libdir} ${libdir}/libissue74_b.a ${libdir}/libissue74_a.a ${libdir}/libissue74_b.a

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/transitive-link-error-middle-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/transitive-link-error-middle-74.pc
@@ -1,0 +1,5 @@
+Name: transitive-link-error-middle-74
+Description: Middle transitive static parser error fixture
+Version: 1.0.0
+Requires: unterminated-link-quote-74
+Libs: -lissue74_transitive_error_middle

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/transitive-link-error-root-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/transitive-link-error-root-74.pc
@@ -1,0 +1,5 @@
+Name: transitive-link-error-root-74
+Description: Root transitive static parser error fixture
+Version: 1.0.0
+Requires: transitive-link-error-middle-74
+Libs: -lissue74_transitive_error_root

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/unterminated-link-quote-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/unterminated-link-quote-74.pc
@@ -1,0 +1,4 @@
+Name: unterminated-link-quote-74
+Description: Unterminated static linker quote rejection fixture
+Version: 1.0.0
+Libs: -L "/issue74/unterminated path

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/uppercase-private-provider-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/uppercase-private-provider-74.pc
@@ -1,0 +1,6 @@
+Name: uppercase-private-provider-74
+Description: Uppercase private cflags oracle provider
+Version: 1.0.0
+Libs: -luppercase_private_provider
+Cflags: -DISSUE74_UPPERCASE_PROVIDER
+CFLAGS.private: -DFRIBIDI_LIB_STATIC

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/uppercase-private-root-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/uppercase-private-root-74.pc
@@ -1,0 +1,6 @@
+Name: uppercase-private-root-74
+Description: Uppercase private cflags oracle root
+Version: 1.0.0
+Requires.private: uppercase-private-provider-74
+Libs: -luppercase_private_root
+Cflags: -DISSUE74_UPPERCASE_ROOT

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/whole-archive-epoch-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/whole-archive-epoch-74.pc
@@ -1,0 +1,4 @@
+Name: whole-archive-epoch-74
+Description: Balanced whole-archive revisit
+Version: 1.0.0
+Libs: -Wl,--whole-archive -lissue74_epoch -Wl,--no-whole-archive

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/whole-archive-idempotent-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/whole-archive-idempotent-74.pc
@@ -1,0 +1,4 @@
+Name: whole-archive-idempotent-74
+Description: Repeated whole-archive start with a single end and ordinary duplicate tail
+Version: 1.0.0
+Libs: -Wl,--whole-archive -Wl,--whole-archive /issue74/libliteral-active.a -Wl,--no-whole-archive /issue74/libliteral-tail.a /issue74/libliteral-tail.a

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/whole-archive-literal-epoch-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/whole-archive-literal-epoch-74.pc
@@ -1,0 +1,4 @@
+Name: whole-archive-literal-epoch-74
+Description: Literal archive inside a balanced whole-archive epoch
+Version: 1.0.0
+Libs: -Wl,--whole-archive /issue74/libliteral-epoch.a -Wl,--no-whole-archive

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/whole-archive-literal-normal-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/whole-archive-literal-normal-74.pc
@@ -1,0 +1,4 @@
+Name: whole-archive-literal-normal-74
+Description: Ordinary literal archive duplicate before a whole-archive epoch
+Version: 1.0.0
+Libs: /issue74/libliteral-epoch.a /issue74/libliteral-epoch.a /issue74/libliteral-dependency.a

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/whole-archive-normal-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/whole-archive-normal-74.pc
@@ -1,0 +1,4 @@
+Name: whole-archive-normal-74
+Description: Normal duplicate collapse before a whole-archive epoch
+Version: 1.0.0
+Libs: -lissue74_epoch -lissue74_epoch -lissue74_epoch_dependency

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/xlinker-other-state-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/xlinker-other-state-74.pc
@@ -1,0 +1,4 @@
+Name: xlinker-other-state-74
+Description: Non-whole-archive Xlinker operand fixture
+Version: 1.0.0
+Libs: -Xlinker --as-needed -lissue74_xlinker_other -Xlinker --no-as-needed -lissue74_xlinker_other

--- a/vlib/v/pkgconfig/testdata/static_pkgconfig/xlinker-whole-archive-74.pc
+++ b/vlib/v/pkgconfig/testdata/static_pkgconfig/xlinker-whole-archive-74.pc
@@ -1,0 +1,4 @@
+Name: xlinker-whole-archive-74
+Description: Xlinker whole-archive state fixture
+Version: 1.0.0
+Libs: -Xlinker --whole-archive -lissue74_xlinker_whole -Xlinker --no-whole-archive -lissue74_xlinker_whole

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -18,6 +18,63 @@ pub fn new_preferences() &Preferences {
 const windows_default_gc_defines = ['gcboehm', 'gcboehm_full', 'gcboehm_incr', 'gcboehm_opt',
 	'gcboehm_leak', 'vgc']
 
+// contains_exact_cflag_token reports whether input contains expected as an exact compiler flag token.
+pub fn contains_exact_cflag_token(input string, expected string) bool {
+	mut token := []u8{cap: input.len}
+	mut quote := u8(0)
+	mut i := 0
+	for i < input.len {
+		ch := input[i]
+		if quote == 0 && ch in [` `, `\t`, `\r`, `\n`] {
+			if token.len > 0 && token.bytestr() == expected {
+				return true
+			}
+			token = []u8{cap: input.len - i}
+			i++
+			continue
+		}
+		if ch in [`'`, `"`] {
+			if quote == 0 {
+				quote = ch
+				i++
+				continue
+			}
+			if quote == ch {
+				quote = 0
+				i++
+				continue
+			}
+		}
+		if ch == `\\` && quote != `'` && i + 1 < input.len {
+			next := input[i + 1]
+			escapable := if quote == `"` {
+				next in [`"`, `\\`]
+			} else {
+				next in [` `, `\t`, `\r`, `\n`, `'`, `"`, `\\`]
+			}
+			if escapable {
+				token << next
+				i += 2
+				continue
+			}
+		}
+		token << ch
+		i++
+	}
+	return token.len > 0 && token.bytestr() == expected
+}
+
+pub fn (mut p Preferences) resolve_pkgconfig_mode() {
+	p.pkgconfig_mode = .dynamic
+	if p.ccompiler_type !in [.gcc, .clang, .mingw, .cplusplus] {
+		return
+	}
+	if contains_exact_cflag_token(p.cflags, '-static')
+		|| contains_exact_cflag_token(p.ldflags, '-static') {
+		p.pkgconfig_mode = .static_
+	}
+}
+
 fn (p &Preferences) default_thread_stack_size() int {
 	return match p.arch {
 		.arm32, .rv32, .i386, .ppc, .wasm32 { 2 * 1024 * 1024 }
@@ -281,6 +338,7 @@ pub fn (mut p Preferences) fill_with_defaults() {
 		p.thread_stack_size = p.default_thread_stack_size()
 	}
 	p.ccompiler_type = cc_from_string(p.ccompiler)
+	p.resolve_pkgconfig_mode()
 	p.normalize_gc_defaults_for_resolved_ccompiler()
 	p.prefer_source_boehm_without_thread_local_alloc()
 	p.is_test = p.path.ends_with('_test.v') || p.path.ends_with('_test.vv')
@@ -311,6 +369,7 @@ pub fn (mut p Preferences) fill_with_defaults() {
 		'${p.backend} | ${final_os} | ${p.ccompiler} | ${p.is_prod} | ${p.sanitize}',
 		p.defines_map_unique_keys(),
 		p.cflags.trim_space(),
+		'pkgconfig_mode=${p.pkgconfig_mode}',
 		p.third_party_option.trim_space(),
 		p.lookup_path.str(),
 	])

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -81,6 +81,11 @@ pub enum CompilerType {
 	cplusplus
 }
 
+pub enum PkgConfigMode {
+	dynamic
+	static_
+}
+
 pub const supported_test_runners = ['normal', 'simple', 'tap', 'dump', 'teamcity']
 
 @[heap; minify]
@@ -163,8 +168,9 @@ pub mut:
 	use_os_system_to_run   bool // when set, use os.system() to run the produced executable, instead of os.new_process; works around segfaults on macos, that may happen when xcode is updated
 	macosx_version_min     string = '0' // relevant only for macos and ios targets
 	// TODO: Convert this into a []string
-	cflags  string // Additional options which will be passed to the C compiler *before* other options.
-	ldflags string // Additional options which will be passed to the C compiler *after* everything else.
+	cflags         string        // Additional options which will be passed to the C compiler *before* other options.
+	ldflags        string        // Additional options which will be passed to the C compiler *after* everything else.
+	pkgconfig_mode PkgConfigMode // Static only for an exact `-static` C compiler argument on GNU-compatible compilers.
 	// For example, passing -cflags -Os will cause the C compiler to optimize the generated binaries for size.
 	// You could pass several -cflags XXX arguments. They will be merged with each other.
 	// You can also quote several options at the same time: -cflags '-Os -fno-inline-small-functions'.

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -254,6 +254,46 @@ fn test_explicit_gc_mode_is_forwarded_to_build_module() {
 	}
 }
 
+fn issue74_cache_path_for_ldflags(ldflags string) (string, pref.PkgConfigMode) {
+	target := os.join_path(vroot, 'examples', 'hello_world.v')
+	mut args := ['-cc', 'gcc']
+	if ldflags != '' {
+		args << ['-ldflags', ldflags]
+	}
+	args << target
+	mut prefs, _ := pref.parse_args_and_show_errors([], args, false)
+	path := prefs.cache_manager.mod_postfix_with_key2cpath('issue74-cache-salt', '.o',
+		'same-source')
+	return path, prefs.pkgconfig_mode
+}
+
+fn test_pkgconfig_mode_salts_cache_without_salt_for_all_ldflags() {
+	cache_root := os.join_path(os.vtmp_dir(), 'issue74_pkgconfig_mode_cache_${os.getpid()}')
+	old_cache := os.getenv_opt('VCACHE')
+	os.setenv('VCACHE', cache_root, true)
+	defer {
+		if cache := old_cache {
+			os.setenv('VCACHE', cache, true)
+		} else {
+			os.unsetenv('VCACHE')
+		}
+		os.rmdir_all(cache_root) or {}
+	}
+
+	dynamic_path, dynamic_mode := issue74_cache_path_for_ldflags('')
+	dynamic_link_path, dynamic_link_mode := issue74_cache_path_for_ldflags('-Wl,--as-needed')
+	static_path, static_mode := issue74_cache_path_for_ldflags('-static')
+	static_link_path, static_link_mode := issue74_cache_path_for_ldflags('-static -Wl,--as-needed')
+
+	assert dynamic_mode == .dynamic
+	assert dynamic_link_mode == .dynamic
+	assert static_mode == .static_
+	assert static_link_mode == .static_
+	assert dynamic_path == dynamic_link_path
+	assert static_path == static_link_path
+	assert dynamic_path != static_path
+}
+
 fn test_v_compiler_targets_default_to_no_gc() {
 	for target in [
 		os.join_path(vroot, 'cmd', 'v'),


### PR DESCRIPTION
## Summary

This PR adds generic static pkg-config support to V.

- enables static pkg-config resolution for GCC and Clang when an exact `-static` token is passed through `-cflags`
- supports explicit `#pkgconfig --static` directives
- resolves public and private dependency metadata recursively
- preserves linker ordering, repeated libraries, and linker groups
- handles supported `.pc` field names case-insensitively
- keeps the existing dynamic behavior unchanged for normal builds, TCC, MSVC, and cross-compilation

The implementation and tests are fully self-contained. No Pango, vglyph, vcpkg, external consumer, or external pkgconf oracle is added to V or its CI.

This issue was originally identified on vgui.

## Scope boundaries and intentionally unchanged behavior

This PR is deliberately limited to explicit static pkg-config resolution and ordered propagation of the resulting flags.

It does not:

- infer static pkg-config mode from ambient `CFLAGS` or `LDFLAGS`; these remain opaque compiler pass-through inputs. Static mode is selected through V's parsed `-cflags/-ldflags -static` options or an explicit `#pkgconfig --static` directive;
- implement target-aware pkg-config or sysroot selection for cross-compilation. The existing protection against leaking host include and library paths into another target remains unchanged;
- change historical dynamic pkg-config behavior;
- require an external `pkgconf` executable at compiler runtime;
- change the pre-existing mixed-case `-l*.LIB` normalization behavior.

### Previously reviewed non-actionable findings

The following recurring Codex findings have already been checked with executable probes:

- **Ambient `CFLAGS` / `LDFLAGS` should select static mode:** rejected because these variables are backend pass-through inputs, not semantic dependency-resolution selectors.
- **Repeated dependency graph traversals must be preserved:** rejected against `pkgconf 2.5.1`. For shared public/private dependencies, multiple roots, cycles, and diamonds, pkgconf and V emit each dependency once in the same order. Explicit repeated library fragments and positional linker groups are still preserved.
- **Static metadata-only queries must validate the dependency closure:** rejected against the selected `pkgconf 2.5.1` oracle. Metadata-only queries remain direct reads, while `--exists` and flag-producing queries validate the required closure.
- **Cross-target pkg-config flags should be retained:** rejected as pre-existing out-of-scope behavior. A correct solution requires an explicit target pkg-config/sysroot contract rather than reusing host paths.
- **A different public-cycle ordering should be used:** rejected because the claimed ordering is version-dependent; this implementation follows `pkgconf 2.5.1`.
- **Out of scope:** this PR does not make run_result().output safe for arbitrary unquoted shell or Make embedding, since the compiler consumes structured cflags/link_flags directly. It also does not extend the parser to cover pkgconf-specific escaped-hash handling in variable assignments; that requires a separate cross-mode parser change and is not needed for the reported Windows static-linking issue.

@codex Please do not reopen these findings without a reproducer against the current PR head and the selected `pkgconf 2.5.1` oracle.

## Validation

A dedicated smoke matrix passed on:

- Linux GCC
- Linux Clang
- Linux TCC
- macOS Clang
- Windows UCRT64 GCC
- Windows UCRT64 Clang
- Windows MSVC
- Windows TCC

All changed V files pass `v fmt -verify`, and `git diff --check` is clean.

Fixes vlang/gui#74