### PR TITLE
cmd: validate explicit C compiler before dispatch

### DIFF
--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -116,6 +116,17 @@ fn main() {
 	}
 	mut args_and_flags := util.join_env_vflags_and_os_args()[1..]
 	prefs, command := pref.parse_args_and_show_errors(external_tools, args_and_flags, true)
+	$if windows {
+		// Check an explicitly selected C compiler before dispatching the command, so
+		// invalid or missing commands do not hide the more useful `-cc` diagnostic.
+		if builder.should_find_windows_host_c_compiler(prefs) && prefs.ccompiler_set_by_flag
+			&& prefs.ccompiler != 'msvc' {
+			mut probe := builder.Builder{
+				pref: unsafe { prefs }
+			}
+			probe.find_win_cc() or { builder.verror(err.msg()) }
+		}
+	}
 	maybe_delegate_to_vvmrc(command, prefs)
 	maybe_delegate_to_ownership(command, prefs)
 	if prefs.use_cache && os.user_os() == 'windows' {

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -116,17 +116,6 @@ fn main() {
 	}
 	mut args_and_flags := util.join_env_vflags_and_os_args()[1..]
 	prefs, command := pref.parse_args_and_show_errors(external_tools, args_and_flags, true)
-	$if windows {
-		// Check an explicitly selected C compiler before dispatching the command, so
-		// invalid or missing commands do not hide the more useful `-cc` diagnostic.
-		if builder.should_find_windows_host_c_compiler(prefs) && prefs.ccompiler_set_by_flag
-			&& prefs.ccompiler != 'msvc' {
-			mut probe := builder.Builder{
-				pref: unsafe { prefs }
-			}
-			probe.find_win_cc() or { builder.verror(err.msg()) }
-		}
-	}
 	maybe_delegate_to_vvmrc(command, prefs)
 	maybe_delegate_to_ownership(command, prefs)
 	if prefs.use_cache && os.user_os() == 'windows' {
@@ -193,6 +182,17 @@ fn main() {
 
 	if prefs.is_help {
 		invoke_help_and_exit(args)
+	}
+	$if windows {
+		// An invalid `-cc` setting should take precedence over an unknown command,
+		// but must not affect commands that do not compile code.
+		if builder.should_find_windows_host_c_compiler(prefs) && prefs.ccompiler_set_by_flag
+			&& prefs.ccompiler != 'msvc' {
+			mut probe := builder.Builder{
+				pref: unsafe { prefs }
+			}
+			probe.find_win_cc() or { builder.verror(err.msg()) }
+		}
 	}
 
 	other_commands := ['run', 'crun', 'build', 'build-module', 'help', 'version', 'new', 'init',

--- a/cmd/v/v_windows_test.v
+++ b/cmd/v/v_windows_test.v
@@ -1,0 +1,16 @@
+module main
+
+import os
+
+fn test_invalid_c_compiler_is_reported_before_command_dispatch() {
+	$if !windows {
+		return
+	}
+	missing_compiler := 'missing_compiler_27868'
+	expected_error := 'builder error: C compiler `${missing_compiler}` was requested with `-cc`, but was not found.'
+	for command in ['', 'not-a-command'] {
+		result := os.execute('${os.quoted_path(@VEXE)} -cc ${missing_compiler} ${command}')
+		assert result.exit_code == 1
+		assert result.output.contains(expected_error), result.output
+	}
+}

--- a/cmd/v/v_windows_test.v
+++ b/cmd/v/v_windows_test.v
@@ -13,4 +13,12 @@ fn test_invalid_c_compiler_is_reported_before_command_dispatch() {
 		assert result.exit_code == 1
 		assert result.output.contains(expected_error), result.output
 	}
+	help_result := os.execute('${os.quoted_path(@VEXE)} -cc ${missing_compiler} help')
+	assert help_result.exit_code == 1
+	assert help_result.output.contains('provide only one help topic.'), help_result.output
+	assert !help_result.output.contains(expected_error), help_result.output
+
+	version_result := os.execute('${os.quoted_path(@VEXE)} -cc ${missing_compiler} version')
+	assert version_result.exit_code == 0, version_result.output
+	assert !version_result.output.contains(expected_error), version_result.output
 }


### PR DESCRIPTION
## What

Validate an explicitly selected C compiler before command dispatch on Windows.

## Why

An invalid `-cc` value could reach command handling first when no command or an invalid command was supplied, hiding the useful missing-compiler diagnostic. This reuses the existing Windows C-compiler validation and adds a regression test for both cases.

Fixes #27868

## Tests

- `v test-all`
- `v test cmd/v/v_windows_test.v`