### PR TITLE
ci: stabilize multiwindow Windows TCC and Linux X11 validation

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -268,7 +268,7 @@ jobs:
           trap on_term TERM
 
           chmod 700 "$runtime_dir"
-          Xvfb -displayfd 1 -screen 0 1280x1024x24 -nolisten tcp >"$display_file" 2>"$xvfb_log" &
+          Xvfb -displayfd 1 -screen 0 1280x1024x24 -nolisten tcp -noreset >"$display_file" 2>"$xvfb_log" &
           xvfb_pid=$!
 
           display_ready=0

--- a/.github/workflows/windows_ci_tcc.yml
+++ b/.github/workflows/windows_ci_tcc.yml
@@ -85,6 +85,8 @@ jobs:
         run: v -silent -W build-tools
       - name: Test pure V math module
         run: v -silent -exclude @vlib/math/*.c.v test vlib/math/
+      - name: Multiwindow render runtime contract
+        run: .\v.exe -silent vlib\gg\multiwindow_render_runtime_contract_test.v
       - name: Self tests
         run: v -silent test-self vlib
       - name: Test v->js

--- a/vlib/gg/testdata/multiwindow_probe_watchdog/watchdog_windows.c.v
+++ b/vlib/gg/testdata/multiwindow_probe_watchdog/watchdog_windows.c.v
@@ -4,6 +4,10 @@ import os
 import time
 import gg.testdata.multiwindow_probe_gate
 
+$if windows && tinyc {
+	#flag windows @VMODROOT/vlib/gg/testdata/multiwindow_probe_watchdog/watchdog_windows_tcc.def
+}
+
 #insert "@VMODROOT/vlib/gg/testdata/multiwindow_probe_watchdog/watchdog_windows_helpers.h"
 
 fn C.v_multiwindow_watchdog_spawn(application &u16, command_line &u16, work_directory &u16, environment &u16) voidptr

--- a/vlib/gg/testdata/multiwindow_probe_watchdog/watchdog_windows_tcc.def
+++ b/vlib/gg/testdata/multiwindow_probe_watchdog/watchdog_windows_tcc.def
@@ -1,0 +1,7 @@
+LIBRARY kernel32.dll
+EXPORTS
+CreateJobObjectW
+SetInformationJobObject
+AssignProcessToJobObject
+TerminateJobObject
+QueryInformationJobObject


### PR DESCRIPTION
## Summary

- Add the missing Windows Job Object imports required by the TCC multiwindow watchdog.
- Add targeted TCC coverage for the multiwindow runtime contract.
- Keep the native X11 Xvfb server stable across sequential client lifecycles with `-noreset`, preventing reset races while preserving per-test process isolation.
- Leave the Windows GCC/MSVC paths, Wayland/Weston path, and production code unchanged.

## Validation

- Windows TCC multiwindow contract and watchdog checks
- Windows GCC and MSVC multiwindow non-regression checks
- Linux GCC native X11 fault matrix through the CI wrapper
- Wrapper syntax, YAML parsing, diff hygiene, and process cleanup checks