### PR TITLE
HTTP/3 (QUIC) foundation: Phase 3 (packet protection and header protection)

### DIFF
--- a/vlib/net/quic/PROGRESS.md
+++ b/vlib/net/quic/PROGRESS.md
@@ -404,12 +404,77 @@ The largest, highest-risk phase. Sub-phases, in build order:
       own official worked values in `tls13_keyschedule_test.v`, a
       different but equally valid form of independent validation.
 
-## Phases 3-14 (NOT STARTED)
+## Phase 3 — Packet protection and header protection (done)
+
+- [x] `packet_protection.v` — `QuicPacketProtectionKeys` (quic_key/quic_iv/
+      quic_hp, RFC 9001 §5.1) derived via `hkdf_expand_label` (the same
+      primitive Phase 2a/2b already use) from any one level's one-directional
+      traffic secret; verified against the RFC 9001 Appendix A.1 vectors
+      already used directly against `hkdf_expand_label` in
+      `initial_secrets_test.v` (duplicated locally since V compiles each
+      `_test.v` file as its own independent unit — top-level consts aren't
+      shared across sibling test files in the same module).
+      `encrypt_packet_payload`/`decrypt_packet_payload` wrap
+      `crypto.aes.AesGcm`; the AEAD nonce XORs the packet's FULL,
+      RECONSTRUCTED packet number (never the truncated wire bytes) into the
+      low 8 bytes of the 12-byte IV. `protect_packet`/`unprotect_packet`
+      combine packet + header protection in the one correct order (encrypt
+      payload → sample ciphertext → derive mask → apply to header on the
+      send side; unprotect header first, since the packet number's length is
+      itself protected, → AEAD-decrypt on the receive side) so a future
+      caller can't accidentally sequence the two steps backwards — the
+      single most common bug class in this area.
+- [x] `header_protection.v` — AES-ECB mask derivation (RFC 9001 §5.4.3,
+      the only construction v1 needs, since `TLS_AES_128_GCM_SHA256` is
+      pinned throughout); sample always taken at a fixed 4-byte offset past
+      the packet-number field regardless of that field's real (still-
+      protected) length, per RFC 9001 §5.4.2. `unprotect_header` validates
+      the Reserved Bits are zero once unmasked (RFC 9000 §17.2/§17.3.1 MUST —
+      noted as intentionally deferred to this phase back in Phase 1's
+      `header.v` entry above) and returns a plain error for a receiver to
+      map to PROTOCOL_VIOLATION, distinct from an AEAD auth failure (which
+      callers must silently drop, never escalate to a connection close, per
+      RFC 9001's own security guidance — documented on
+      `decrypt_packet_payload`, enforced by a future phase's receive loop,
+      not this one).
+- [x] `/vreview` pass: found and fixed two gaps before commit — (1) the
+      missing Reserved Bits check above (RFC 9001/9000 MUST, no diff-driven
+      review would find an absent check without a requirements-driven read);
+      (2) `packet_protection_nonce` indexed its `iv` parameter without
+      validating its length, unlike the sibling `hp_key.len` check
+      `header_protection_mask` already has on the very same
+      `QuicPacketProtectionKeys` struct (whose fields are all `pub` and
+      externally constructible, not only ever produced by
+      `derive_packet_protection_keys`) — a too-short `iv` panicked (index
+      out of range) instead of returning a graceful error. Both fixed with
+      permanent regression tests, confirmed to fail on the pre-fix code via
+      Phase-R before landing.
+- [x] Known-answer test against a REAL captured packet: the very first UDP
+      datagram (`frame 1`, a single non-coalesced Client Initial, 1200 bytes)
+      from the SAME quiche capture Phase 2c's TLS-layer vectors came from
+      (`testdata/tls13_vectors/quiche_p256_handshake.pcap`), extracted with a
+      minimal standalone pcap/UDP parser (no Wireshark dependency needed
+      here, since only raw bytes are wanted, not TLS dissection). Initial
+      secrets are derived purely from the packet's own (always-visible)
+      DCID; after removing header protection and AEAD-decrypting, the
+      plaintext is checked for containing the EXACT ClientHello bytes
+      already independently verified in `tls13_quiche_vector_test.v` — the
+      SAME bytes obtained via a completely different extraction path there
+      (tshark/PDML TLS dissection vs. this file's raw UDP parsing), a small
+      independent cross-check that neither extraction made the same
+      mistake. A companion negative test flips one bit in the same real
+      packet's ciphertext and confirms AEAD authentication fails cleanly.
+      Fulfills the plan's own suggested Phase 3 test strategy ("known-answer
+      tests against Phase 2's captured Initial packets") without needing a
+      fresh capture.
+- [x] Self-consistency round-trip tests across all 4 packet-number lengths
+      and both header forms (long/short), plus negative tests for tampered
+      ciphertext and for decrypting with the wrong direction's keys.
+
+## Phases 4-14 (NOT STARTED)
 
 See the tracking issue for full detail on each. In order:
 
-3. Packet protection & header protection (RFC 9001 §5) — the AEAD
-   encrypt-then-mask ordering is the single most common bug class here.
 4. Initial packet exchange — CRYPTO frame reassembly, core frames, datagram
    coalescing, Retry/Version Negotiation handling.
 5. Full handshake completion — three independent packet number spaces (a

--- a/vlib/net/quic/header_protection.v
+++ b/vlib/net/quic/header_protection.v
@@ -1,0 +1,125 @@
+module quic
+
+import crypto.aes
+
+// RFC 9001 §5.4 — QUIC header protection. Applies to Initial, Handshake,
+// 0-RTT, and 1-RTT packets (never to Retry or Version Negotiation, which have
+// no packet-number field to protect at all). v1 pins TLS_AES_128_GCM_SHA256
+// (see tls13_client_hello.v), so header protection here always uses the
+// AES-based construction (RFC 9001 §5.4.3): mask = ECB-Encrypt(hp_key,
+// sample), a single AES block encryption of a 16-byte sample with no
+// chaining.
+//
+// The sample is always taken assuming the packet number field occupies its
+// maximum possible length (4 bytes) — RFC 9001 §5.4.2 requires this
+// specifically so a RECEIVER, who does not yet know the real (protected)
+// packet-number length, can still locate the sample deterministically. This
+// is why sample location and packet-number length are handled as two
+// distinct steps below, never conflated.
+
+const header_protection_sample_size = 16
+
+// pn_max_length is the fixed offset (in bytes, RFC 9001 §5.4.2) from the
+// start of the (as-yet-unknown-length) packet number field to where the
+// header protection sample begins — independent of the packet's ACTUAL
+// packet number length, which is itself part of what header protection
+// hides.
+const pn_max_length = 4
+
+// header_protection_mask computes the RFC 9001 §5.4.3 AES-based header
+// protection mask for one 16-byte `sample`. Only the first 5 bytes of the
+// returned 16-byte mask are ever used by callers (mask[0] for the protected
+// header bits, mask[1..5] for up to 4 packet-number bytes) — the AES-ECB
+// construction always produces a full 16-byte block regardless.
+fn header_protection_mask(hp_key []u8, sample []u8) ![]u8 {
+	if hp_key.len != 16 {
+		return error('quic: header protection key must be 16 bytes for AES-128, got ${hp_key.len}')
+	}
+	if sample.len != header_protection_sample_size {
+		return error('quic: header protection sample must be ${header_protection_sample_size} bytes, got ${sample.len}')
+	}
+	block := aes.new_cipher(hp_key)
+	mut mask := []u8{len: header_protection_sample_size}
+	block.encrypt(mut mask, sample)
+	return mask
+}
+
+// protected_bits_mask returns which low bits of the first byte header
+// protection covers: 4 bits (reserved + packet-number length, RFC 9000
+// §17.2) for a long header, 5 bits (reserved + key phase + packet-number
+// length, RFC 9000 §17.3.1) for a short header.
+fn protected_bits_mask(form HeaderForm) u8 {
+	return if form == .long { u8(0x0f) } else { u8(0x1f) }
+}
+
+// reserved_bits_mask returns the Reserved Bits within the protected low
+// bits: bits 3-2 (0x0c) for a long header (RFC 9000 §17.2), bits 4-3 (0x18)
+// for a short header (RFC 9000 §17.3.1) -- distinct from the packet-number
+// length bits and, for a short header, the key phase bit, which share the
+// same byte but carry no such "must be zero" requirement.
+fn reserved_bits_mask(form HeaderForm) u8 {
+	return if form == .long { u8(0x0c) } else { u8(0x18) }
+}
+
+// protect_header applies header protection to `packet` in place, given an
+// already-chosen `pn_length` — the sender always knows this, since it picked
+// the packet number's encoded length itself before calling this (see
+// encode_packet_number). `packet` must already contain the full unprotected
+// header AND the AEAD-encrypted payload: per RFC 9001 §5.4.1/§5.3, the sample
+// is taken from the CIPHERTEXT, so this function must run strictly AFTER
+// AEAD encryption — reversing that order is the single most common QUIC
+// packet-protection implementation bug. `pn_offset` is the index into
+// `packet` where the (currently still plaintext) packet number bytes begin.
+pub fn protect_header(mut packet []u8, pn_offset int, pn_length int, hp_key []u8, form HeaderForm) ! {
+	if pn_length < 1 || pn_length > pn_max_length {
+		return error('quic: invalid packet number length ${pn_length}, must be 1-4')
+	}
+	if pn_offset < 0 || pn_offset + pn_max_length + header_protection_sample_size > packet.len {
+		return error('quic: packet too short to sample for header protection (need ${pn_offset +
+			pn_max_length + header_protection_sample_size} bytes, have ${packet.len})')
+	}
+	sample_offset := pn_offset + pn_max_length
+	sample := unsafe { packet[sample_offset..sample_offset + header_protection_sample_size] }
+	mask := header_protection_mask(hp_key, sample)!
+	packet[0] ^= mask[0] & protected_bits_mask(form)
+	for i in 0 .. pn_length {
+		packet[pn_offset + i] ^= mask[1 + i]
+	}
+}
+
+// unprotect_header removes header protection from `packet` in place and
+// returns the packet number's true encoded length. Unlike `protect_header`,
+// the caller does NOT know `pn_length` up front — it is itself part of the
+// protected first byte — so this function must unmask the first byte FIRST
+// to learn `pn_length`, then unmask exactly that many packet-number bytes.
+// Doing this in the opposite order (unmasking a guessed number of
+// packet-number bytes before the first byte has revealed the real count)
+// would corrupt bytes belonging to the payload rather than the packet
+// number.
+//
+// Once unmasked, the first byte's Reserved Bits are checked: RFC 9000
+// §17.2/§17.3.1 requires a sender to always transmit them as zero, and
+// requires a receiver to treat a non-zero value here as a PROTOCOL_VIOLATION
+// connection error, NOT a silently dropped packet (unlike an AEAD
+// authentication failure, see decrypt_packet_payload's doc comment) --
+// mapping this error to that specific close behavior is the caller's
+// (Phase 8+ connection-lifecycle) responsibility, same division as this
+// module's other errors.
+pub fn unprotect_header(mut packet []u8, pn_offset int, hp_key []u8, form HeaderForm) !int {
+	if pn_offset < 0 || pn_offset + pn_max_length + header_protection_sample_size > packet.len {
+		return error('quic: packet too short to sample for header protection (need ${pn_offset +
+			pn_max_length + header_protection_sample_size} bytes, have ${packet.len})')
+	}
+	sample_offset := pn_offset + pn_max_length
+	sample := unsafe { packet[sample_offset..sample_offset + header_protection_sample_size] }
+	mask := header_protection_mask(hp_key, sample)!
+	packet[0] ^= mask[0] & protected_bits_mask(form)
+	if packet[0] & reserved_bits_mask(form) != 0 {
+		return error('quic: non-zero reserved bits after header protection removal (RFC 9000 §17.2/§17.3.1 PROTOCOL_VIOLATION)')
+	}
+	pn_length := int(packet[0] & 0x03) + 1
+	for i in 0 .. pn_length {
+		packet[pn_offset + i] ^= mask[1 + i]
+	}
+	return pn_length
+}

--- a/vlib/net/quic/header_protection_test.v
+++ b/vlib/net/quic/header_protection_test.v
@@ -1,0 +1,157 @@
+module quic
+
+import crypto.rand
+
+fn test_protect_header_then_unprotect_header_round_trips_long_header_all_pn_lengths() {
+	hp_key := rand.bytes(16)!
+	for pn_length in 1 .. 5 {
+		mut packet := []u8{}
+		packet << u8(0xc0 | (pn_length - 1)) // long header, Initial type; low bits carry pn_length-1
+		packet << [u8(0xde), 0xad, 0xbe, 0xef] // stand-in for the version/dcid/scid/length bytes
+		pn_offset := packet.len
+		for i in 0 .. pn_length {
+			packet << u8(0x10 + i) // arbitrary plaintext packet-number bytes
+		}
+		packet << []u8{len: 32, init: 0x42} // stand-in AEAD ciphertext (>= 4+16 bytes past pn_offset)
+		original := packet.clone()
+
+		protect_header(mut packet, pn_offset, pn_length, hp_key, .long)!
+		recovered_pn_length := unprotect_header(mut packet, pn_offset, hp_key, .long)!
+		assert recovered_pn_length == pn_length
+		assert packet == original
+	}
+}
+
+fn test_protect_header_then_unprotect_header_round_trips_short_header_all_pn_lengths() {
+	hp_key := rand.bytes(16)!
+	dcid := rand.bytes(8)!
+	for pn_length in 1 .. 5 {
+		mut packet := []u8{}
+		packet << u8(0x40 | (pn_length - 1)) // short header; fixed bit set, form bit clear
+		packet << dcid
+		pn_offset := packet.len
+		for i in 0 .. pn_length {
+			packet << u8(0x20 + i)
+		}
+		packet << []u8{len: 32, init: 0x77}
+		original := packet.clone()
+
+		protect_header(mut packet, pn_offset, pn_length, hp_key, .short)!
+		recovered_pn_length := unprotect_header(mut packet, pn_offset, hp_key, .short)!
+		assert recovered_pn_length == pn_length
+		assert packet == original
+	}
+}
+
+fn test_protect_header_only_touches_declared_bits() {
+	// Header protection for a long header must only ever touch the low 4
+	// bits of the first byte (reserved + pn-length) -- never the header
+	// form, fixed, or long-header-type bits (top 4 bits), which are always
+	// sent in the clear.
+	hp_key := rand.bytes(16)!
+	mut packet := []u8{}
+	packet << u8(0xc0) // Initial, pn_length_bits=0 (i.e. pn_length=1)
+	packet << [u8(0xaa), 0xbb, 0xcc, 0xdd]
+	pn_offset := packet.len
+	packet << u8(0x99)
+	packet << []u8{len: 32, init: 0x11}
+
+	protect_header(mut packet, pn_offset, 1, hp_key, .long)!
+	assert packet[0] & 0xf0 == 0xc0
+}
+
+fn test_protect_header_rejects_invalid_pn_length() {
+	hp_key := rand.bytes(16)!
+	mut packet := []u8{len: 64}
+	protect_header(mut packet, 5, 0, hp_key, .long) or {
+		assert err.msg().contains('invalid packet number length')
+		return
+	}
+	assert false, 'expected an error for pn_length 0'
+}
+
+fn test_protect_header_rejects_pn_length_over_four() {
+	hp_key := rand.bytes(16)!
+	mut packet := []u8{len: 64}
+	protect_header(mut packet, 5, 5, hp_key, .long) or {
+		assert err.msg().contains('invalid packet number length')
+		return
+	}
+	assert false, 'expected an error for pn_length 5'
+}
+
+fn test_protect_header_rejects_packet_too_short_to_sample() {
+	hp_key := rand.bytes(16)!
+	// pn_offset=5, pn_length=2, but only 10 bytes total: not enough room for
+	// the mandatory 4+16-byte sample window past pn_offset.
+	mut packet := []u8{len: 10}
+	protect_header(mut packet, 5, 2, hp_key, .long) or {
+		assert err.msg().contains('too short')
+		return
+	}
+	assert false, 'expected an error for a too-short packet'
+}
+
+fn test_unprotect_header_rejects_packet_too_short_to_sample() {
+	hp_key := rand.bytes(16)!
+	mut packet := []u8{len: 10}
+	unprotect_header(mut packet, 5, hp_key, .long) or {
+		assert err.msg().contains('too short')
+		return
+	}
+	assert false, 'expected an error for a too-short packet'
+}
+
+fn test_unprotect_header_rejects_non_zero_reserved_bits_long_header() {
+	hp_key := rand.bytes(16)!
+	mut packet := []u8{}
+	packet << u8(0xc0) // Initial, reserved=00, pn_length_bits=0 (pn_length=1)
+	packet << [u8(0xaa), 0xbb, 0xcc, 0xdd]
+	pn_offset := packet.len
+	packet << u8(0x99)
+	packet << []u8{len: 32, init: 0x11}
+
+	protect_header(mut packet, pn_offset, 1, hp_key, .long)!
+	// Flip one of the two reserved-bit positions (0x0c) directly on the
+	// still-protected byte -- XOR commutes, so this has the same effect as
+	// if the ORIGINAL plaintext packet had carried a non-zero reserved bit
+	// (RFC 9000 §17.2 requires senders always zero these; a receiver seeing
+	// a non-zero value after unmasking must treat it as PROTOCOL_VIOLATION,
+	// not accept the packet).
+	packet[0] ^= 0x04
+
+	unprotect_header(mut packet, pn_offset, hp_key, .long) or {
+		assert err.msg().contains('reserved bits')
+		return
+	}
+	assert false, 'expected non-zero reserved bits to be rejected'
+}
+
+fn test_unprotect_header_rejects_non_zero_reserved_bits_short_header() {
+	hp_key := rand.bytes(16)!
+	dcid := rand.bytes(8)!
+	mut packet := []u8{}
+	packet << u8(0x40) // short header, reserved=00, key_phase=0, pn_length_bits=0
+	packet << dcid
+	pn_offset := packet.len
+	packet << u8(0x22)
+	packet << []u8{len: 32, init: 0x33}
+
+	protect_header(mut packet, pn_offset, 1, hp_key, .short)!
+	packet[0] ^= 0x08 // one of the short-header reserved bits (0x18)
+
+	unprotect_header(mut packet, pn_offset, hp_key, .short) or {
+		assert err.msg().contains('reserved bits')
+		return
+	}
+	assert false, 'expected non-zero reserved bits to be rejected'
+}
+
+fn test_header_protection_mask_rejects_wrong_key_length() {
+	mut packet := []u8{len: 64}
+	protect_header(mut packet, 0, 1, rand.bytes(32)!, .long) or {
+		assert err.msg().contains('16 bytes')
+		return
+	}
+	assert false, 'expected an error for a non-16-byte header protection key'
+}

--- a/vlib/net/quic/packet_protection.v
+++ b/vlib/net/quic/packet_protection.v
@@ -1,0 +1,169 @@
+module quic
+
+import crypto.aes
+
+// RFC 9001 §5 — QUIC packet protection. v1 pins TLS_AES_128_GCM_SHA256 (see
+// tls13_client_hello.v), so packet protection here always uses AES-128-GCM.
+
+// aead_key_length and aead_iv_length are AES-128-GCM's fixed key/nonce sizes
+// (RFC 9001 §5.1) — the only AEAD v1 supports. AES-128-GCM's header
+// protection key is also 16 bytes (RFC 9001 §5.4.3), the same as
+// aead_key_length, so both `key` and `hp` below share this length.
+const aead_key_length = 16
+const aead_iv_length = 12
+
+// QuicPacketProtectionKeys holds one encryption level's, one direction's
+// derived key material (RFC 9001 §5.1): `key`/`iv` protect the AEAD payload,
+// `hp` protects the header. A single traffic secret (e.g. one level's
+// client_secret) yields exactly one QuicPacketProtectionKeys — client and
+// server secrets are always different PRKs (see tls13_keyschedule.v /
+// initial_secrets.v), so deriving from the correct side's secret is what
+// keeps client-write and server-write keys distinct; this struct itself has
+// no notion of "which direction" beyond whatever secret it was derived from.
+pub struct QuicPacketProtectionKeys {
+pub:
+	key []u8 // quic_key -- AEAD encryption key (16 bytes)
+	iv  []u8 // quic_iv -- AEAD nonce base (12 bytes)
+	hp  []u8 // quic_hp -- header protection key (16 bytes)
+}
+
+// derive_packet_protection_keys computes quic_key/quic_iv/quic_hp (RFC 9001
+// §5.1) from one encryption level's one-directional traffic secret (an
+// Initial secret, a handshake traffic secret, or an application traffic
+// secret — this function is level-agnostic, since HKDF-Expand-Label's
+// "quic key"/"quic iv"/"quic hp" labels are identical at every level).
+pub fn derive_packet_protection_keys(secret []u8) !QuicPacketProtectionKeys {
+	key := hkdf_expand_label(secret, 'quic key', []u8{}, aead_key_length)!
+	iv := hkdf_expand_label(secret, 'quic iv', []u8{}, aead_iv_length)!
+	hp := hkdf_expand_label(secret, 'quic hp', []u8{}, aead_key_length)!
+	return QuicPacketProtectionKeys{
+		key: key
+		iv:  iv
+		hp:  hp
+	}
+}
+
+// packet_protection_nonce computes the per-packet AEAD nonce (RFC 9001
+// §5.3): the packet's FULL, RECONSTRUCTED packet number (never the
+// truncated on-the-wire bytes — using the truncated value would collide
+// across every packet sharing the same low-order bytes) left-padded with
+// zeros to the IV's length, XORed with `iv`. `iv` must be at least 8 bytes
+// (long enough to hold a full u64 packet number) -- the only current
+// producer, derive_packet_protection_keys, always returns exactly
+// aead_iv_length (12) bytes, but QuicPacketProtectionKeys's fields are
+// public and externally constructible, so this is checked explicitly
+// rather than trusted, mirroring header_protection_mask's analogous
+// `hp_key.len` check on the same struct's sibling field.
+fn packet_protection_nonce(iv []u8, packet_number u64) ![]u8 {
+	if iv.len < 8 {
+		return error('quic: packet protection IV must be at least 8 bytes, got ${iv.len}')
+	}
+	mut nonce := iv.clone()
+	for i in 0 .. 8 {
+		nonce[nonce.len - 1 - i] ^= u8(packet_number >> (u32(i) * 8))
+	}
+	return nonce
+}
+
+// encrypt_packet_payload AEAD-encrypts one packet's payload (RFC 9001 §5.3).
+// `header` must be the ENTIRE unprotected header, up to and including the
+// plaintext packet number bytes — it is the AEAD associated data in full,
+// not just a prefix of it. `packet_number` must already be the full,
+// reconstructed value (see packet_protection_nonce).
+pub fn encrypt_packet_payload(keys QuicPacketProtectionKeys, packet_number u64, header []u8, payload []u8) ![]u8 {
+	aead := aes.new_aes_gcm(keys.key)!
+	nonce := packet_protection_nonce(keys.iv, packet_number)!
+	return aead.encrypt(payload, nonce, header)
+}
+
+// decrypt_packet_payload AEAD-decrypts and authenticates one packet's
+// payload. On authentication failure, callers MUST silently drop the packet
+// rather than tear down the connection: a single AEAD failure is
+// indistinguishable from ordinary network corruption or off-path garbage
+// UDP data, and RFC 9001's security guidance is that it must never, by
+// itself, be escalated to a connection close. This function only reports the
+// failure as an error; enforcing "drop, don't close" is the caller's
+// (Phase 4+ packet-receive loop's) responsibility.
+pub fn decrypt_packet_payload(keys QuicPacketProtectionKeys, packet_number u64, header []u8, ciphertext []u8) ![]u8 {
+	aead := aes.new_aes_gcm(keys.key)!
+	nonce := packet_protection_nonce(keys.iv, packet_number)!
+	return aead.decrypt(ciphertext, nonce, header)
+}
+
+// protect_packet assembles one fully protected QUIC packet from its
+// unprotected header, full packet number, and plaintext payload, applying
+// RFC 9001 §5's protection steps in the ONLY correct order: AEAD-encrypt the
+// payload FIRST, THEN sample the resulting ciphertext to derive the header
+// protection mask, THEN apply that mask to the header. Reversing this order
+// (protecting the header before the payload exists, or sampling plaintext
+// instead of ciphertext) is the single most common QUIC packet-protection
+// implementation bug — callers should use this function rather than
+// sequencing encrypt_packet_payload/protect_header themselves.
+//
+// `header` is the complete unprotected header bytes, ending with the
+// plaintext packet number encoded in exactly `pn_length` bytes (see
+// encode_packet_number). `form` selects which low bits of the first byte
+// header protection covers.
+pub fn protect_packet(header []u8, form HeaderForm, packet_number u64, pn_length int, payload []u8, keys QuicPacketProtectionKeys) ![]u8 {
+	if pn_length < 1 || pn_length > pn_max_length {
+		return error('quic: invalid packet number length ${pn_length}, must be 1-4')
+	}
+	if header.len < pn_length {
+		return error('quic: header shorter than its own packet number length')
+	}
+	ciphertext := encrypt_packet_payload(keys, packet_number, header, payload)!
+	mut packet := []u8{cap: header.len + ciphertext.len}
+	packet << header
+	packet << ciphertext
+	pn_offset := header.len - pn_length
+	protect_header(mut packet, pn_offset, pn_length, keys.hp, form)!
+	return packet
+}
+
+// UnprotectedPacket is the result of successfully removing both header and
+// packet protection from one received QUIC packet.
+pub struct UnprotectedPacket {
+pub:
+	header        []u8 // the full header, through the now-plaintext packet number
+	packet_number u64  // full, reconstructed packet number
+	payload       []u8 // decrypted plaintext payload
+}
+
+// unprotect_packet reverses `protect_packet` on a received packet: removes
+// header protection FIRST — which is the only way to learn the packet's real
+// packet-number length and value at all — THEN AEAD-decrypts the payload
+// using that recovered packet number and the now-unprotected header as
+// associated data. This is the mirror image of protect_packet's ordering,
+// not the same steps run backwards; see unprotect_header's own doc comment
+// for why header-then-payload is mandatory on this side specifically.
+//
+// `packet` is mutated in place (header protection removal happens
+// destructively). `pn_offset` is where the (still-protected) packet number
+// field begins — the caller gets this from parsing the always-visible
+// header fields (parse_long_header/parse_short_header) that precede it.
+// `largest_pn` is the largest packet number already processed in this
+// packet's number space (none if this is the first packet processed in that
+// space) — see decode_packet_number.
+//
+// On AEAD authentication failure, the caller MUST drop the packet silently
+// rather than close the connection (see decrypt_packet_payload's doc
+// comment) — this function only surfaces the error.
+pub fn unprotect_packet(mut packet []u8, pn_offset int, form HeaderForm, keys QuicPacketProtectionKeys, largest_pn ?u64) !UnprotectedPacket {
+	pn_length := unprotect_header(mut packet, pn_offset, keys.hp, form)!
+	if pn_offset + pn_length > packet.len {
+		return error('quic: packet number field runs past end of packet')
+	}
+	mut truncated := u64(0)
+	for i in 0 .. pn_length {
+		truncated = (truncated << 8) | u64(packet[pn_offset + i])
+	}
+	full_pn := decode_packet_number(truncated, pn_length, largest_pn)!
+	header := packet[..pn_offset + pn_length].clone()
+	ciphertext := unsafe { packet[pn_offset + pn_length..] }
+	payload := decrypt_packet_payload(keys, full_pn, header, ciphertext)!
+	return UnprotectedPacket{
+		header:        header
+		packet_number: full_pn
+		payload:       payload
+	}
+}

--- a/vlib/net/quic/packet_protection_test.v
+++ b/vlib/net/quic/packet_protection_test.v
@@ -1,0 +1,296 @@
+module quic
+
+import crypto.rand
+import encoding.hex
+
+// quiche_client_initial_capture is the raw bytes of the very first UDP
+// datagram in a real quiche handshake capture (testdata/tls13_vectors/
+// quiche_p256_handshake.pcap, frame 1: client 172.18.0.3:53012 -> server
+// 172.18.0.2:4433) -- a single, non-coalesced Client Initial packet, 1200
+// bytes including UDP-level padding. See testdata/tls13_vectors/README.md
+// for full provenance (image digest, capture date, tooling). Extracted with
+// a minimal standalone pcap parser (no Wireshark dependency needed here,
+// since only raw UDP payload bytes are wanted, not TLS dissection) reading
+// the SAME pcap file tls13_quiche_vector_test.v's TLS-layer vectors came
+// from -- this is the plan's own suggested Phase 3 test strategy ("known-
+// answer tests against Phase 2's captured Initial packets"), giving
+// packet_protection.v/header_protection.v a REAL independent-implementation
+// packet to decrypt, not just a self-round-trip.
+const quiche_client_initial_capture = 'cd0000000110a38666b5dd3bb8eb36857f2e457adaf214d7af43d3ec88a36d745b07a58c8cd29bffa3158400412083db96d220e31b0a0c77efaee5a1d1f6fa78f754c7dae50bb0c2313b2d69a6ccb42f63137431eb6d044cbcb845170e42e1c34c3d311c155ab7b0e19cc7e5b2ed5d984bb6e161ca1c898e3594d9faf092ab6214d834c0ba075a08a6854eae840f6468bdaea98ca99758c40ea933ae2cbed77cdff84a02e5648260758dcbfcb4c1f6f42345404cc893808ecd003ccf8152877a4051fe8f88f3a9f308c7b2cc0854427f1a8ed9c704840452f31d7d1dd8a2dbcd3a8f4bb51954871f69fecda9a3aee950c3345a26a3f29efb495784d487a6bbfd1264acb114820f4870e2c5149b7682d102da2daff0dbb751231f7d30c8f65ce4694c9b169a07c9975fd8ff86d9d33f204bc51eea14ea60b635399269db1ed37f7476dd6ed9a54448402c5a98a0240000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+
+// RFC 9001 Appendix A.1 vectors, same values already used directly against
+// hkdf_expand_label in initial_secrets_test.v -- duplicated here (rather than
+// referenced) because V compiles each _test.v file as its own independent
+// unit alongside the module's non-test files, so top-level consts are not
+// shared across sibling _test.v files.
+const rfc9001_client_dcid = '8394c8f03e515708'
+const rfc9001_client_quic_key = '1f369613dd76d5467730efcbe3b1a22d'
+const rfc9001_client_quic_iv = 'fa044b2f42a3fd3b46fb255c'
+const rfc9001_client_quic_hp = '9f50449e04a0e810283a1e9933adedd2'
+const rfc9001_server_quic_key = 'cf3a5331653c364c88f0f379b6067e37'
+const rfc9001_server_quic_iv = '0ac1493ca1905853b0bba03e'
+const rfc9001_server_quic_hp = 'c206b8d9b9f0f37644430b490eeaa314'
+
+// real_capture_client_hello is the exact same ClientHello handshake message
+// already declared as `quiche_vector_client_hello` in
+// tls13_quiche_vector_test.v (obtained there via tshark's PDML-based TLS
+// dissection of this SAME pcap file) -- duplicated here under a distinct
+// name for the same file-isolation reason as the RFC constants above. Using
+// the identical value obtained through a completely different extraction
+// path (that file: Wireshark/tshark TLS dissection; this file: a standalone
+// raw pcap/UDP parser with no TLS awareness at all, see
+// testdata/tls13_vectors/README.md) is itself a small independent
+// cross-check that neither extraction made the same mistake.
+const real_capture_client_hello = '010001070303aae46c569ed2c383818039c15f2b9b2136b22d570eac6bce08f02caa38249a32000006130113021303010000d800000010000e00000b717569635f736572766572000a00080006001d001700180010001900170268330a68712d696e7465726f7008687474702f302e39000d00140012040308040401050308050501080606010201003300260024001d00202248ca6660c73714e4fcd54feab9983b52af11f84bd65fcc3b8d36a2c4e3723c002d00020101002b000302030400390048010480007530030245460404809896800504800f42400604800f42400704800f424008024064090240640a01030b01190c000f14d7af43d3ec88a36d745b07a58c8cd29bffa31584'
+
+// test_packet_protection_decrypts_real_quiche_client_initial_capture derives
+// Initial secrets purely from this real packet's own (always-visible,
+// unprotected) DCID -- exactly as a real client/server would -- then removes
+// header protection and AEAD-decrypts the payload. The decrypted plaintext
+// is checked for containing the EXACT ClientHello bytes this session already
+// independently verified in tls13_quiche_vector_test.v (byte-for-byte,
+// cross-checked there against its own transcript/signature/MAC chain) --
+// proving packet_protection.v + header_protection.v correctly unprotect a
+// genuine third-party-produced packet, not just data this module produced
+// and consumed itself. CRYPTO/PADDING frame parsing is Phase 4's job, so
+// this checks containment of the known-good bytes within the decrypted
+// payload rather than re-implementing frame parsing here.
+fn test_packet_protection_decrypts_real_quiche_client_initial_capture() {
+	raw := hex.decode(quiche_client_initial_capture)!
+
+	long_header, header_len := parse_long_header(raw)!
+	assert long_header.typ == .initial
+	assert long_header.version == quic_v1
+
+	// The UDP datagram (1200 bytes) is padded well past this single QUIC
+	// packet's own end: `long_header.length` (the packet's own declared
+	// pn+payload length) says the real packet ends far short of the
+	// datagram's full size -- the rest is plain zero bytes appended outside
+	// any packet, not part of the AEAD-protected payload. Feeding those
+	// trailing bytes into the AEAD as if they were ciphertext (as an earlier
+	// version of this test did) breaks tag verification, since the real
+	// 16-byte tag would then be buried mid-buffer instead of at the end of
+	// whatever's handed to unprotect_packet. Splitting a datagram at a
+	// packet's own Length field is Phase 4's job (coalesce.v); this trims to
+	// exactly one packet's bytes by hand since Phase 4 doesn't exist yet.
+	mut packet := raw[..header_len + int(long_header.length)].clone()
+
+	secrets := derive_initial_secrets(long_header.dcid)!
+	keys := derive_packet_protection_keys(secrets.client)!
+
+	unprotected := unprotect_packet(mut packet, header_len, .long, keys, none)!
+
+	client_hello_bytes := hex.decode(real_capture_client_hello)!
+	assert contains_subslice(unprotected.payload, client_hello_bytes)
+}
+
+// test_packet_protection_real_capture_rejects_tampered_payload flips one bit
+// deep in the same real captured packet's ciphertext and confirms AEAD
+// authentication fails cleanly (an error, never a panic or a silently wrong
+// plaintext) -- the plan's explicitly requested negative test, run against
+// genuine captured bytes rather than self-crafted ones.
+fn test_packet_protection_real_capture_rejects_tampered_payload() {
+	raw := hex.decode(quiche_client_initial_capture)!
+	long_header, header_len := parse_long_header(raw)!
+	// Trim to exactly this one packet's own bytes -- see the sibling
+	// positive-path test's comment for why the full 1200-byte UDP datagram
+	// (mostly trailing zero padding outside this packet) can't be handed to
+	// unprotect_packet as-is.
+	mut packet := raw[..header_len + int(long_header.length)].clone()
+	packet[100] ^= 0x01 // byte 100 is well inside the real ciphertext region
+
+	secrets := derive_initial_secrets(long_header.dcid)!
+	keys := derive_packet_protection_keys(secrets.client)!
+
+	unprotect_packet(mut packet, header_len, .long, keys, none) or { return }
+	assert false, 'expected AEAD authentication to fail on tampered ciphertext'
+}
+
+// test_derive_packet_protection_keys_matches_rfc9001_initial_vectors chains
+// derive_initial_secrets (already vector-tested in initial_secrets_test.v)
+// into derive_packet_protection_keys and checks the result against the SAME
+// RFC 9001 Appendix A.1 vectors that file already validates directly against
+// hkdf_expand_label -- confirming this Phase 3 function is just correctly
+// wiring three already-proven-correct derivations together, not scope creep
+// re-deriving anything new.
+fn test_derive_packet_protection_keys_matches_rfc9001_initial_vectors() {
+	client_dcid := hex.decode(rfc9001_client_dcid)!
+	secrets := derive_initial_secrets(client_dcid)!
+
+	client_keys := derive_packet_protection_keys(secrets.client)!
+	assert client_keys.key == hex.decode(rfc9001_client_quic_key)!
+	assert client_keys.iv == hex.decode(rfc9001_client_quic_iv)!
+	assert client_keys.hp == hex.decode(rfc9001_client_quic_hp)!
+
+	server_keys := derive_packet_protection_keys(secrets.server)!
+	assert server_keys.key == hex.decode(rfc9001_server_quic_key)!
+	assert server_keys.iv == hex.decode(rfc9001_server_quic_iv)!
+	assert server_keys.hp == hex.decode(rfc9001_server_quic_hp)!
+}
+
+fn truncate_packet_number(full_pn u64, pn_length int) []u8 {
+	mut out := []u8{len: pn_length}
+	for i in 0 .. pn_length {
+		shift := u32((pn_length - 1 - i) * 8)
+		out[i] = u8(full_pn >> shift)
+	}
+	return out
+}
+
+fn contains_subslice(haystack []u8, needle []u8) bool {
+	if needle.len == 0 {
+		return true
+	}
+	if needle.len > haystack.len {
+		return false
+	}
+	for i in 0 .. haystack.len - needle.len + 1 {
+		mut matched := true
+		for j in 0 .. needle.len {
+			if haystack[i + j] != needle[j] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+fn test_protect_packet_then_unprotect_packet_round_trips_long_header_all_pn_lengths() {
+	secret := rand.bytes(32)!
+	keys := derive_packet_protection_keys(secret)!
+	dcid := rand.bytes(8)!
+	scid := rand.bytes(8)!
+	payload := rand.bytes(50)!
+
+	// (pn_length, packet_number) pairs, each packet number sized to fit
+	// exactly within its paired encoded length so the round trip's decoded
+	// value (with largest_pn: none, i.e. "first packet in this space") is
+	// exactly recoverable without truncation ambiguity.
+	cases := [[u64(1), u64(200)], [u64(2), u64(50000)], [u64(3), u64(12_000_000)],
+		[u64(4), u64(3_000_000_000)]]
+
+	for c in cases {
+		pn_length := int(c[0])
+		packet_number := c[1]
+
+		h := QuicLongHeader{
+			typ:     .initial
+			version: quic_v1
+			dcid:    dcid
+			scid:    scid
+			token:   []u8{}
+			length:  u64(pn_length) + u64(payload.len) + 16 // + AEAD tag
+		}
+		mut header := encode_long_header(h, 0, u8(pn_length - 1))!
+		header << truncate_packet_number(packet_number, pn_length)
+		pn_offset := header.len - pn_length
+
+		mut packet := protect_packet(header, .long, packet_number, pn_length, payload, keys)!
+		unprotected := unprotect_packet(mut packet, pn_offset, .long, keys, none)!
+		assert unprotected.packet_number == packet_number
+		assert unprotected.payload == payload
+	}
+}
+
+fn test_encrypt_packet_payload_rejects_iv_shorter_than_a_packet_number() {
+	// QuicPacketProtectionKeys's fields are public and externally
+	// constructible (not only ever produced by derive_packet_protection_keys),
+	// so a malformed `iv` must fail cleanly here rather than let
+	// packet_protection_nonce index out of bounds trying to XOR a full
+	// 8-byte packet number into fewer than 8 bytes of IV.
+	keys := QuicPacketProtectionKeys{
+		key: rand.bytes(16)!
+		iv:  rand.bytes(4)!
+		hp:  rand.bytes(16)!
+	}
+	encrypt_packet_payload(keys, 1, []u8{len: 8}, []u8{len: 10}) or {
+		assert err.msg().contains('IV')
+		return
+	}
+	assert false, 'expected a too-short IV to be rejected'
+}
+
+fn test_protect_packet_then_unprotect_packet_round_trips_short_header() {
+	secret := rand.bytes(32)!
+	keys := derive_packet_protection_keys(secret)!
+	dcid := rand.bytes(8)!
+	payload := rand.bytes(40)!
+	pn_length := 2
+	packet_number := u64(12345)
+
+	mut header := []u8{}
+	header << u8(0x40 | (pn_length - 1))
+	header << dcid
+	header << truncate_packet_number(packet_number, pn_length)
+	pn_offset := header.len - pn_length
+
+	mut packet := protect_packet(header, .short, packet_number, pn_length, payload, keys)!
+	unprotected := unprotect_packet(mut packet, pn_offset, .short, keys, none)!
+	assert unprotected.packet_number == packet_number
+	assert unprotected.payload == payload
+}
+
+fn test_unprotect_packet_rejects_tampered_ciphertext() {
+	secret := rand.bytes(32)!
+	keys := derive_packet_protection_keys(secret)!
+	dcid := rand.bytes(8)!
+	scid := rand.bytes(8)!
+	payload := rand.bytes(50)!
+	pn_length := 2
+	packet_number := u64(7)
+
+	h := QuicLongHeader{
+		typ:     .initial
+		version: quic_v1
+		dcid:    dcid
+		scid:    scid
+		token:   []u8{}
+		length:  u64(pn_length) + u64(payload.len) + 16
+	}
+	mut header := encode_long_header(h, 0, u8(pn_length - 1))!
+	header << truncate_packet_number(packet_number, pn_length)
+	pn_offset := header.len - pn_length
+
+	mut packet := protect_packet(header, .long, packet_number, pn_length, payload, keys)!
+	packet[packet.len - 1] ^= 0x01 // flip a bit inside the AEAD tag itself
+
+	unprotect_packet(mut packet, pn_offset, .long, keys, none) or { return }
+	assert false, 'expected AEAD authentication to fail on tampered ciphertext'
+}
+
+fn test_unprotect_packet_rejects_wrong_direction_keys() {
+	secret := rand.bytes(32)!
+	client_keys := derive_packet_protection_keys(secret)!
+	// A different random secret stands in for the OTHER side's traffic
+	// secret -- client and server secrets are always distinct PRKs (see
+	// tls13_keyschedule.v), so using the wrong side's keys must fail closed,
+	// not silently decrypt with the wrong material.
+	other_secret := rand.bytes(32)!
+	wrong_keys := derive_packet_protection_keys(other_secret)!
+
+	dcid := rand.bytes(8)!
+	scid := rand.bytes(8)!
+	payload := rand.bytes(50)!
+	pn_length := 2
+	packet_number := u64(9)
+
+	h := QuicLongHeader{
+		typ:     .initial
+		version: quic_v1
+		dcid:    dcid
+		scid:    scid
+		token:   []u8{}
+		length:  u64(pn_length) + u64(payload.len) + 16
+	}
+	mut header := encode_long_header(h, 0, u8(pn_length - 1))!
+	header << truncate_packet_number(packet_number, pn_length)
+	pn_offset := header.len - pn_length
+
+	mut packet := protect_packet(header, .long, packet_number, pn_length, payload, client_keys)!
+	unprotect_packet(mut packet, pn_offset, .long, wrong_keys, none) or { return }
+	assert false, 'expected decryption with the wrong direction keys to fail'
+}


### PR DESCRIPTION
## Summary

Draft PR tracking Phase 3 of HTTP/3/QUIC support (#27675), continuing from
the completed Phase 0-2 foundation in #27680 (client-first QUIC-scoped
TLS 1.3 handshake). This branch starts from #27680's tip, since Phase 3
(packet protection / header protection, RFC 9001 §5) builds directly on
Phase 2's key schedule output (`HandshakeSecrets`/`ApplicationSecrets`,
`hkdf_expand_label`).

This is a **work-in-progress**, opened as a draft so the work is
visible/discoverable while in progress. It will be retargeted to `master`
directly once #27680 merges; until then it necessarily also contains
#27680's commits.

See [`vlib/net/quic/PROGRESS.md`](https://github.com/quaesitor-scientiam/v/blob/http3-quic-packet-protection/vlib/net/quic/PROGRESS.md)
for the exact phase-by-phase checklist.

## Scope (RFC 9001 §5)

- `packet_protection.v` — AEAD encrypt/decrypt using `quic_key`/`quic_iv`
  derived via `hkdf_expand_label` from each level's traffic secret.
- `header_protection.v` — `quic_hp` mask derivation and application.
  Correct ordering is encrypt payload → sample ciphertext → derive header
  mask → apply to header (the reverse of what's naively assumed) — flagged
  in the plan as the single most common bug in this area.
- AEAD nonce uses the full reconstructed packet number, not the truncated
  wire bytes. On AEAD auth failure: drop the packet silently rather than
  tearing down the connection on an isolated failure.

## Test plan

- [x] Known-answer tests against Phase 2's captured Initial packets, or
      self-captured vectors — decrypts the real Client Initial packet
      extracted directly from the same quiche pcap capture Phase 2c used,
      deriving Initial secrets purely from the packet's own DCID; also
      cross-checked against the RFC 9001 Appendix A.1 key-derivation vectors.
- [x] Round-trip across all 4 packet-number lengths and both header forms —
      covered at the header-protection level (both forms × all 4 lengths)
      and the packet-protection level (long header × all 4 lengths, short
      header at one length); randomized keys/payloads per run, not a
      dedicated randomized-fuzz harness.
- [x] Negative test: corrupted payload → distinguishable non-fatal error —
      tampered ciphertext, wrong-direction keys, and a tampered real
      captured packet all return a clean `IError` via `!`, never a panic.
- [x] All new/modified code passing under `./vnew test <path>` — 15/15
      files in `vlib/net/quic/`.
- [x] `./vnew fmt -w` applied to all touched `.v` files.

`/vreview` (full A-G pass) found and fixed two gaps before commit:
`unprotect_header` was missing the RFC 9000 §17.2/§17.3.1 Reserved Bits
validation, and `packet_protection_nonce` indexed its `iv` parameter with no
length check (unlike the sibling `hp_key` check on the same struct), risking
a panic instead of a clean error on malformed input. Both have regression
tests, Phase-R-verified to fail on the pre-fix code.

🧙 Built with [WOZCODE](https://wozcode.com)
