### PR TITLE
HTTP/3 (QUIC) foundation: Phase 5 (Full handshake completion)

### DIFF
--- a/vlib/net/quic/PROGRESS.md
+++ b/vlib/net/quic/PROGRESS.md
@@ -604,12 +604,57 @@ The largest, highest-risk phase. Sub-phases, in build order:
       `.claude/skills/code-review/rfc-texts/`, gitignored) rather than
       trusted from the review comments alone.
 
-## Phases 5-14 (NOT STARTED)
+## Phase 5 — Full handshake completion (done)
+
+- [x] `packet_number_space.v` — formalizes the THREE INDEPENDENT packet
+      number spaces (Initial/Handshake/Application Data), flagged as the
+      most common implementation mistake to get wrong (treating packet
+      numbers as connection-global breaks ACK-frame interop with any
+      compliant peer). `PacketNumberSpaceState` tracks per-space
+      next-to-send/largest-received/largest-acked-by-peer, feeding directly
+      into Phase 1's `encode_packet_number`/`decode_packet_number` with no
+      adaptation. `QuicPacketNumberSpaces` groups the three as genuinely
+      independent struct fields — no shared mutable state to accidentally
+      conflate.
+- [x] `handshake_confirm.v` — models "complete" (own Finished sent AND
+      peer's Finished verified) and "confirmed" (HANDSHAKE_DONE received)
+      as two distinct checkpoints, each with its own key-discard trigger
+      (RFC 9001 §4.9.1/§4.9.2), plus a third, independent checkpoint for
+      discarding Initial keys (first Handshake-space packet sent). The
+      alternate ack-based confirmation path RFC 9001 permits is
+      deliberately not implemented — v1 always waits for HANDSHAKE_DONE.
+- [x] `key_update.v` — 1-RTT-only key phase bit rotation (RFC 9001 §6),
+      receive side only (client-initiated rotation deferred, per plan).
+      `resolve_read_keys` decides which keys to try decrypting an incoming
+      packet with — matching the current phase, the retained previous
+      phase (a reordered pre-update packet), or a freshly-derived next
+      phase (a genuine new update) — purely from the packet's phase bit
+      and packet number, per RFC 9001 §6.5, and never mutates state or
+      authenticates anything itself. `note_successful_decrypt` commits the
+      outcome only after the caller's own AEAD decryption has actually
+      succeeded. `max_key_updates_accepted` is a coarse, time-independent
+      cap standing in for RFC 9001 §6.1/§6.5's ack-plus-3xPTO pacing, which
+      needs RTT/PTO estimation this module doesn't have yet (Phase 7).
+- [x] `/vreview` pass: found and fixed one gap before commit —
+      `note_successful_decrypt` trusted `resolution.is_new_update`/
+      `is_previous_phase` at face value, but those flags are computed at
+      `resolve_read_keys` time and go stale if a caller resolves more than
+      one packet (e.g. two packets from the same coalesced datagram)
+      before committing either; committing the first packet's genuine
+      update flips the current phase, and a second, now-stale
+      `is_new_update` resolution for a packet that actually matches the
+      just-updated phase would otherwise be mis-committed as a SECOND
+      update, permanently desynchronizing decryption. Fixed by having
+      `note_successful_decrypt` re-derive its classification fresh from
+      the packet's own real phase bit against current state, rather than
+      trusting resolve-time flags — correct regardless of how many
+      resolutions were computed before any commit. Has a regression test,
+      Phase-R-verified to fail on the pre-fix code.
+
+## Phases 6-14 (NOT STARTED)
 
 See the tracking issue for full detail on each. In order:
 
-5. Full handshake completion — three independent packet number spaces (a
-   common implementation mistake to conflate), key discard, key update.
 6. Stream layer — STREAM frames, connection+stream flow control interplay.
    Note: even client-only v1 must receive server-initiated uni streams from
    day one (HTTP/3's control/QPACK streams need this).

--- a/vlib/net/quic/handshake_confirm.v
+++ b/vlib/net/quic/handshake_confirm.v
@@ -1,0 +1,100 @@
+module quic
+
+// RFC 9001 §4.1.2 — the TLS/QUIC handshake has two distinct completion
+// checkpoints, and key-discard timing (RFC 9001 §4.9) depends on which one
+// has occurred:
+//
+//   - "complete": this client has BOTH sent its own Finished message AND
+//     verified the server's Finished message. Neither alone is
+//     sufficient -- sending your own Finished without verifying the
+//     peer's proves nothing about the peer's identity/state, and
+//     verifying the peer's without having sent your own means the peer
+//     cannot yet trust that THIS side has completed the handshake either.
+//   - "confirmed": this client has received a HANDSHAKE_DONE frame -- a
+//     1-RTT-only frame (RFC 9000 §19.20), so this can only happen AFTER
+//     1-RTT keys already exist. RFC 9001 §4.9.2 requires discarding
+//     Handshake keys only once the handshake is CONFIRMED, not merely
+//     complete: "complete" alone doesn't prove the SERVER has seen this
+//     client's Finished, so a Handshake-space retransmission of it may
+//     still be needed until confirmation proves otherwise.
+//
+// RFC 9001 also permits an ALTERNATE confirmation path (a client MAY treat
+// receipt of an ACK for a 1-RTT packet it sent as confirmation, without
+// waiting for HANDSHAKE_DONE specifically -- useful if HANDSHAKE_DONE
+// itself is lost). Deliberately NOT implemented here: v1 always waits for
+// HANDSHAKE_DONE, a legitimate (if slightly less loss-tolerant) subset of
+// spec-compliant behavior.
+//
+// A THIRD, separate key-discard checkpoint exists alongside these two:
+// RFC 9001 §4.9.1 requires discarding Initial keys once this client has
+// sent its FIRST Handshake-space packet -- independent of complete/
+// confirmed, and normally reached much earlier (as soon as Handshake-level
+// keys exist and there's anything to send in that space, e.g. an ACK for
+// the server's Handshake packets).
+pub struct HandshakeCompletionState {
+mut:
+	own_finished_sent           bool
+	peer_finished_verified      bool
+	handshake_done_received     bool
+	sent_first_handshake_packet bool
+}
+
+pub fn new_handshake_completion_state() &HandshakeCompletionState {
+	return &HandshakeCompletionState{}
+}
+
+// mark_own_finished_sent records that this client has sent its own
+// Finished message.
+pub fn (mut s HandshakeCompletionState) mark_own_finished_sent() {
+	s.own_finished_sent = true
+}
+
+// mark_peer_finished_verified records that this client has verified the
+// server's Finished message (Phase 2's process_finished having succeeded).
+pub fn (mut s HandshakeCompletionState) mark_peer_finished_verified() {
+	s.peer_finished_verified = true
+}
+
+// is_complete reports RFC 9001 §4.1.2's "handshake complete" checkpoint.
+pub fn (s &HandshakeCompletionState) is_complete() bool {
+	return s.own_finished_sent && s.peer_finished_verified
+}
+
+// mark_handshake_done_received records receipt of a HANDSHAKE_DONE frame.
+// This function only tracks the state transition; validating that
+// receiving one NOW is legal (e.g. rejecting it before the handshake is
+// even complete) is the caller's frame-dispatch responsibility, not
+// re-checked here.
+pub fn (mut s HandshakeCompletionState) mark_handshake_done_received() {
+	s.handshake_done_received = true
+}
+
+// is_confirmed reports RFC 9001 §4.1.2/§4.9.2's "handshake confirmed"
+// checkpoint -- the trigger for discarding Handshake keys. Also requires
+// is_complete() as a safety net: a HANDSHAKE_DONE frame should never
+// legitimately arrive before completion, but confirmed implying complete
+// is a sane invariant to enforce here regardless of caller ordering
+// mistakes upstream.
+pub fn (s &HandshakeCompletionState) is_confirmed() bool {
+	return s.handshake_done_received && s.is_complete()
+}
+
+// mark_sent_first_handshake_packet records that this client has sent its
+// first Handshake-space packet.
+pub fn (mut s HandshakeCompletionState) mark_sent_first_handshake_packet() {
+	s.sent_first_handshake_packet = true
+}
+
+// should_discard_initial_keys reports whether RFC 9001 §4.9.1's condition
+// for discarding Initial keys has been met. Independent of is_complete/
+// is_confirmed -- it typically happens well before either.
+pub fn (s &HandshakeCompletionState) should_discard_initial_keys() bool {
+	return s.sent_first_handshake_packet
+}
+
+// should_discard_handshake_keys reports whether RFC 9001 §4.9.2's
+// condition for discarding Handshake keys has been met: the handshake is
+// CONFIRMED, not merely complete.
+pub fn (s &HandshakeCompletionState) should_discard_handshake_keys() bool {
+	return s.is_confirmed()
+}

--- a/vlib/net/quic/handshake_confirm.v
+++ b/vlib/net/quic/handshake_confirm.v
@@ -39,6 +39,8 @@ mut:
 	sent_first_handshake_packet bool
 }
 
+// new_handshake_completion_state creates a fresh tracker with none of the
+// completion/confirmation checkpoints reached yet.
 pub fn new_handshake_completion_state() &HandshakeCompletionState {
 	return &HandshakeCompletionState{}
 }

--- a/vlib/net/quic/handshake_confirm_test.v
+++ b/vlib/net/quic/handshake_confirm_test.v
@@ -1,0 +1,62 @@
+module quic
+
+fn test_handshake_completion_state_starts_all_false() {
+	s := new_handshake_completion_state()
+	assert s.is_complete() == false
+	assert s.is_confirmed() == false
+	assert s.should_discard_initial_keys() == false
+	assert s.should_discard_handshake_keys() == false
+}
+
+fn test_handshake_completion_initial_key_discard_is_independent() {
+	mut s := new_handshake_completion_state()
+	s.mark_sent_first_handshake_packet()
+	assert s.should_discard_initial_keys() == true
+	// Sending the first Handshake packet has NOTHING to do with the
+	// complete/confirmed checkpoints -- it typically happens well before
+	// either.
+	assert s.is_complete() == false
+	assert s.is_confirmed() == false
+	assert s.should_discard_handshake_keys() == false
+}
+
+fn test_handshake_completion_requires_both_finished_events() {
+	mut s := new_handshake_completion_state()
+	s.mark_own_finished_sent()
+	assert s.is_complete() == false // only one of the two conditions met
+
+	mut s2 := new_handshake_completion_state()
+	s2.mark_peer_finished_verified()
+	assert s2.is_complete() == false // only the other condition met
+
+	mut s3 := new_handshake_completion_state()
+	s3.mark_own_finished_sent()
+	s3.mark_peer_finished_verified()
+	assert s3.is_complete() == true
+}
+
+fn test_handshake_completion_confirmed_requires_complete_even_if_handshake_done_arrives_first() {
+	mut s := new_handshake_completion_state()
+	// A HANDSHAKE_DONE frame should never legitimately arrive before the
+	// handshake is complete, but this state machine enforces the AND
+	// regardless of caller-ordering mistakes upstream.
+	s.mark_handshake_done_received()
+	assert s.is_confirmed() == false
+	assert s.should_discard_handshake_keys() == false
+
+	s.mark_own_finished_sent()
+	s.mark_peer_finished_verified()
+	assert s.is_complete() == true
+	assert s.is_confirmed() == true
+	assert s.should_discard_handshake_keys() == true
+}
+
+fn test_handshake_completion_confirmed_after_normal_ordering() {
+	mut s := new_handshake_completion_state()
+	s.mark_own_finished_sent()
+	s.mark_peer_finished_verified()
+	assert s.is_confirmed() == false // complete, but HANDSHAKE_DONE not yet seen
+
+	s.mark_handshake_done_received()
+	assert s.is_confirmed() == true
+}

--- a/vlib/net/quic/key_update.v
+++ b/vlib/net/quic/key_update.v
@@ -1,0 +1,229 @@
+module quic
+
+// RFC 9001 §6 — 1-RTT Key Update, RECEIVE side only. Client-initiated key
+// rotation (this side deciding to start sending with a NEW phase) is
+// explicitly deferred past v1 per this project's plan; tolerating a
+// PEER-initiated update -- including correctly decoding a reordered
+// packet that arrives late, still using the phase from BEFORE that
+// update -- is must-have, since a real server can rotate its own write
+// keys at any time and this client must not lose data or desynchronize
+// when it does.
+//
+// Applies ONLY to the Application Data (1-RTT) packet number space --
+// Initial and Handshake packets never carry a Key Phase bit at all (it
+// only exists in the short header, RFC 9000 §17.3.1) and never rotate
+// keys this way.
+
+// key_update_label is RFC 9001 §6.1's fixed HKDF-Expand-Label label:
+// next_secret = HKDF-Expand-Label(current_secret, "quic ku", "", Hash.length).
+const key_update_label = 'quic ku'
+
+// derive_updated_secret computes the NEXT traffic secret from the current
+// one (RFC 9001 §6.1). The same derivation applies independently to a
+// connection's client_secret and server_secret -- each side's traffic
+// secret chain advances on its own schedule, which is exactly why this
+// function takes a bare secret rather than anything connection-scoped.
+pub fn derive_updated_secret(current_secret []u8) ![]u8 {
+	return hkdf_expand_label(current_secret, key_update_label, []u8{}, current_secret.len)
+}
+
+// max_key_updates_accepted bounds how many PEER-INITIATED key updates one
+// KeyUpdateState will honor over the connection's life. A compliant peer
+// paces updates out (RFC 9001 §6.1: waits for an acknowledgment of a
+// packet sent in the current phase; §6.5: then roughly 3x the probe
+// timeout) -- but that norm can't be enforced by a receiver, only assumed
+// of a compliant peer, and real time-based pacing needs RTT/PTO
+// estimation this module doesn't have yet (Phase 7). This is a coarse,
+// time-independent stand-in that still stops a peer from forcing
+// unbounded HKDF/AES-key-schedule re-derivation by cycling the key phase
+// bit across many packets.
+pub const max_key_updates_accepted = 1000
+
+// KeyResolution is resolve_read_keys' result: which keys to attempt
+// decrypting an incoming packet with, and how the situation looked AT
+// RESOLVE TIME. `is_new_update`/`is_previous_phase` are informational only
+// -- a caller may use them for logging, but note_successful_decrypt does
+// NOT trust them for its own state transition (see that function's doc
+// comment for why: they can go stale between resolution and commit).
+pub struct KeyResolution {
+pub:
+	keys         QuicPacketProtectionKeys
+	secret       []u8
+	packet_phase bool
+	// is_new_update is true when this resolution represents a genuine new
+	// key update (the packet's phase differs from current, and its packet
+	// number is higher than anything seen in the current phase) -- AS
+	// OBSERVED AT RESOLVE TIME.
+	is_new_update bool
+	// is_previous_phase is true when this resolution represents a
+	// reordered packet from BEFORE the current phase (the packet's phase
+	// differs from current, and its packet number is lower than anything
+	// seen in the current phase) -- AS OBSERVED AT RESOLVE TIME. Mutually
+	// exclusive with is_new_update.
+	is_previous_phase bool
+}
+
+// KeyUpdateState tracks ONE direction's (specifically: the direction used
+// to READ packets FROM the peer) current and previous 1-RTT packet
+// protection keys, plus the packet-number bookkeeping RFC 9001 §6.5
+// requires to tell a genuine new update apart from a reordered packet
+// still using the previous phase.
+@[heap]
+pub struct KeyUpdateState {
+mut:
+	current_phase           bool
+	current_keys            QuicPacketProtectionKeys
+	current_secret          []u8
+	previous_keys           ?QuicPacketProtectionKeys
+	min_pn_in_current_phase ?u64
+	updates_accepted        int
+}
+
+// new_key_update_state seeds tracking with the FIRST 1-RTT traffic secret
+// (Phase 2's application traffic secret, derived once at handshake
+// completion) and phase 0 -- RFC 9001 §6: "the Key Phase bit... is
+// initially set to 0 for the first set of 1-RTT packets".
+pub fn new_key_update_state(initial_secret []u8) !&KeyUpdateState {
+	keys := derive_packet_protection_keys(initial_secret)!
+	return &KeyUpdateState{
+		current_phase:  false
+		current_keys:   keys
+		current_secret: initial_secret
+	}
+}
+
+pub fn (s &KeyUpdateState) current_phase_bit() bool {
+	return s.current_phase
+}
+
+// resolve_read_keys decides which keys to TRY decrypting an incoming
+// 1-RTT packet with, given its key phase bit (already revealed by header
+// protection removal) and its reconstructed packet number. Per RFC 9001
+// §6.5: a phase matching the current one always uses the current keys. A
+// MISMATCHED phase is resolved by packet number, not by the mismatch
+// alone -- lower than anything already seen in the current phase means a
+// reordered packet from BEFORE the peer's update (use the retained
+// previous keys, if any); higher means a genuine new update (derive and
+// try the next keys).
+//
+// This function does NOT mutate any state and does NOT itself
+// authenticate anything -- resolving which keys to attempt is a
+// plaintext-visible decision (the key phase bit and packet number are
+// both unprotected once header protection is removed), never a
+// substitute for the AEAD check that follows. The caller MUST attempt
+// AEAD decryption with the returned keys and must call
+// note_successful_decrypt ONLY if that decryption actually succeeds --
+// never on the resolution alone (RFC 9001 §6.5's warning against turning
+// key-update handling into a decryption oracle).
+pub fn (s &KeyUpdateState) resolve_read_keys(packet_phase bool, packet_number u64) !KeyResolution {
+	if packet_phase == s.current_phase {
+		return KeyResolution{
+			keys:         s.current_keys
+			secret:       s.current_secret
+			packet_phase: packet_phase
+		}
+	}
+
+	min_current := s.min_pn_in_current_phase or {
+		// No packet has been processed under the current phase yet (this
+		// would be the very first 1-RTT packet ever received) -- a phase
+		// mismatch here has no "previous phase" to belong to, so it can
+		// only be a new update.
+		return s.next_key_resolution(packet_phase)!
+	}
+
+	if packet_number < min_current {
+		prev := s.previous_keys or {
+			return error('quic: received a packet using the previous key phase, but no previous keys are retained')
+		}
+
+		return KeyResolution{
+			keys:              prev
+			secret:            []u8{} // not meaningful for a previous-phase resolution
+			packet_phase:      packet_phase
+			is_previous_phase: true
+		}
+	}
+	return s.next_key_resolution(packet_phase)!
+}
+
+fn (s &KeyUpdateState) next_key_resolution(packet_phase bool) !KeyResolution {
+	next_secret := derive_updated_secret(s.current_secret)!
+	next_keys := derive_packet_protection_keys(next_secret)!
+	return KeyResolution{
+		keys:          next_keys
+		secret:        next_secret
+		packet_phase:  packet_phase
+		is_new_update: true
+	}
+}
+
+// note_successful_decrypt commits the outcome of a resolve_read_keys
+// resolution AFTER the caller has verified it by successfully
+// AEAD-decrypting a real packet with it -- never before.
+//
+// Deliberately does NOT trust resolution.is_new_update/is_previous_phase:
+// those reflect the situation as observed AT RESOLVE TIME, and this
+// function can be called with a STALE resolution if a caller resolves
+// more than one packet (e.g. several packets coalesced into one datagram)
+// before committing either -- committing the first packet's genuine new
+// update would flip s.current_phase, and a second, now-stale "is_new_update"
+// resolution for a packet that ACTUALLY matches the just-updated current
+// phase would otherwise be mis-committed as a SECOND update, corrupting
+// current_secret two generations ahead of where the peer actually is.
+// Re-deriving the classification fresh here, from resolution.packet_phase
+// (the packet's own real, immutable phase bit) against CURRENT state,
+// makes this function correct regardless of how many resolutions were
+// computed before it, or in what order they are committed.
+pub fn (mut s KeyUpdateState) note_successful_decrypt(resolution KeyResolution, packet_number u64) ! {
+	if resolution.packet_phase == s.current_phase {
+		current := s.min_pn_in_current_phase or {
+			s.min_pn_in_current_phase = packet_number
+			return
+		}
+
+		if packet_number < current {
+			s.min_pn_in_current_phase = packet_number
+		}
+		return
+	}
+
+	min_current := s.min_pn_in_current_phase or {
+		s.commit_new_update(packet_number)!
+		return
+	}
+
+	if packet_number < min_current {
+		// Still an old-phase packet as of now -- no bookkeeping change.
+		return
+	}
+	s.commit_new_update(packet_number)!
+}
+
+// commit_new_update performs the actual key-generation advance, always
+// re-deriving the next secret/keys fresh from the CURRENT current_secret
+// (never trusting a resolution's possibly-stale secret/keys) so it is
+// correct no matter how many resolutions were computed before it committed.
+fn (mut s KeyUpdateState) commit_new_update(packet_number u64) ! {
+	if s.updates_accepted >= max_key_updates_accepted {
+		return error('quic: too many key updates accepted on this connection (limit ${max_key_updates_accepted})')
+	}
+	new_secret := derive_updated_secret(s.current_secret)!
+	new_keys := derive_packet_protection_keys(new_secret)!
+	s.previous_keys = s.current_keys
+	s.current_keys = new_keys
+	s.current_secret = new_secret
+	s.current_phase = !s.current_phase
+	s.min_pn_in_current_phase = packet_number
+	s.updates_accepted++
+}
+
+// discard_previous_keys drops the retained previous-phase keys. RFC 9001
+// §6.5 recommends retaining them for about 3x the probe timeout after
+// receiving a packet in the new phase, then discarding -- that timing
+// judgment needs RTT/PTO estimation (Phase 7), so this function only
+// performs the mechanical discard; deciding WHEN to call it is a later
+// phase's job.
+pub fn (mut s KeyUpdateState) discard_previous_keys() {
+	s.previous_keys = none
+}

--- a/vlib/net/quic/key_update.v
+++ b/vlib/net/quic/key_update.v
@@ -1,5 +1,7 @@
 module quic
 
+import crypto.sha256
+
 // RFC 9001 §6 — 1-RTT Key Update, RECEIVE side only. Client-initiated key
 // rotation (this side deciding to start sending with a NEW phase) is
 // explicitly deferred past v1 per this project's plan; tolerating a
@@ -23,8 +25,17 @@ const key_update_label = 'quic ku'
 // connection's client_secret and server_secret -- each side's traffic
 // secret chain advances on its own schedule, which is exactly why this
 // function takes a bare secret rather than anything connection-scoped.
+//
+// The output is always exactly sha256.size bytes -- RFC 9001 §6.1 defines
+// this as the negotiated TLS hash length, NOT a function of the input's own
+// length. v1 is pinned to TLS_AES_128_GCM_SHA256 (see tls13_client_hello.v),
+// so that length is always sha256.size, matching every other traffic-secret
+// derivation in this module (initial_secrets.v, tls13_keyschedule.v).
+// Trusting `current_secret.len` instead would let a wrong-length input
+// silently produce a wrong-length "updated" secret that no compliant peer
+// would ever derive, rather than surfacing the mismatch as an error.
 pub fn derive_updated_secret(current_secret []u8) ![]u8 {
-	return hkdf_expand_label(current_secret, key_update_label, []u8{}, current_secret.len)
+	return hkdf_expand_label(current_secret, key_update_label, []u8{}, sha256.size)
 }
 
 // max_key_updates_accepted bounds how many PEER-INITIATED key updates one
@@ -61,6 +72,18 @@ pub:
 	// seen in the current phase) -- AS OBSERVED AT RESOLVE TIME. Mutually
 	// exclusive with is_new_update.
 	is_previous_phase bool
+	// generation is the ABSOLUTE key generation this resolution belongs to
+	// (generation 0 is the first 1-RTT secret, incrementing by exactly 1
+	// per accepted update), computed from s.current_generation AT RESOLVE
+	// TIME. Unlike the phase bit (which has period-2 parity and cannot
+	// tell generation N apart from generation N+2), an absolute generation
+	// number stays correct even if OTHER resolutions commit in between --
+	// it identifies a real, specific generation, not a value relative to
+	// "whatever is current right now". note_successful_decrypt trusts this
+	// field specifically because of that: comparing it against the
+	// CURRENT s.current_generation at commit time is always correct,
+	// regardless of how many other commits happened first.
+	generation int
 }
 
 // KeyUpdateState tracks ONE direction's (specifically: the direction used
@@ -77,21 +100,35 @@ mut:
 	previous_keys           ?QuicPacketProtectionKeys
 	min_pn_in_current_phase ?u64
 	updates_accepted        int
+	// current_generation is an ABSOLUTE count of accepted key updates
+	// (generation 0 is the first 1-RTT secret). See KeyResolution.generation
+	// for why note_successful_decrypt compares this instead of the phase
+	// bit: the phase bit alone cannot tell generation N apart from
+	// generation N+2 (it has period-2 parity), which is exactly what let a
+	// stale generation-0 commit corrupt bookkeeping after a second update.
+	current_generation int
 }
 
 // new_key_update_state seeds tracking with the FIRST 1-RTT traffic secret
 // (Phase 2's application traffic secret, derived once at handshake
 // completion) and phase 0 -- RFC 9001 §6: "the Key Phase bit... is
-// initially set to 0 for the first set of 1-RTT packets".
+// initially set to 0 for the first set of 1-RTT packets". Clones
+// `initial_secret` rather than retaining the caller's own slice -- V array
+// assignment shares backing storage, so retaining it uncloned would let a
+// caller's later mutation of their own copy silently corrupt this state's
+// secret out from under it.
 pub fn new_key_update_state(initial_secret []u8) !&KeyUpdateState {
 	keys := derive_packet_protection_keys(initial_secret)!
 	return &KeyUpdateState{
 		current_phase:  false
 		current_keys:   keys
-		current_secret: initial_secret
+		current_secret: initial_secret.clone()
 	}
 }
 
+// current_phase_bit reports the Key Phase bit this side currently expects
+// on an incoming 1-RTT packet that uses the CURRENT (not previous or next)
+// generation of keys.
 pub fn (s &KeyUpdateState) current_phase_bit() bool {
 	return s.current_phase
 }
@@ -121,6 +158,7 @@ pub fn (s &KeyUpdateState) resolve_read_keys(packet_phase bool, packet_number u6
 			keys:         s.current_keys
 			secret:       s.current_secret
 			packet_phase: packet_phase
+			generation:   s.current_generation
 		}
 	}
 
@@ -142,6 +180,7 @@ pub fn (s &KeyUpdateState) resolve_read_keys(packet_phase bool, packet_number u6
 			secret:            []u8{} // not meaningful for a previous-phase resolution
 			packet_phase:      packet_phase
 			is_previous_phase: true
+			generation:        s.current_generation - 1
 		}
 	}
 	return s.next_key_resolution(packet_phase)!
@@ -149,12 +188,13 @@ pub fn (s &KeyUpdateState) resolve_read_keys(packet_phase bool, packet_number u6
 
 fn (s &KeyUpdateState) next_key_resolution(packet_phase bool) !KeyResolution {
 	next_secret := derive_updated_secret(s.current_secret)!
-	next_keys := derive_packet_protection_keys(next_secret)!
+	next_keys := derive_updated_packet_protection_keys(next_secret, s.current_keys.hp)!
 	return KeyResolution{
 		keys:          next_keys
 		secret:        next_secret
 		packet_phase:  packet_phase
 		is_new_update: true
+		generation:    s.current_generation + 1
 	}
 }
 
@@ -162,21 +202,23 @@ fn (s &KeyUpdateState) next_key_resolution(packet_phase bool) !KeyResolution {
 // resolution AFTER the caller has verified it by successfully
 // AEAD-decrypting a real packet with it -- never before.
 //
-// Deliberately does NOT trust resolution.is_new_update/is_previous_phase:
-// those reflect the situation as observed AT RESOLVE TIME, and this
-// function can be called with a STALE resolution if a caller resolves
-// more than one packet (e.g. several packets coalesced into one datagram)
-// before committing either -- committing the first packet's genuine new
-// update would flip s.current_phase, and a second, now-stale "is_new_update"
-// resolution for a packet that ACTUALLY matches the just-updated current
-// phase would otherwise be mis-committed as a SECOND update, corrupting
-// current_secret two generations ahead of where the peer actually is.
-// Re-deriving the classification fresh here, from resolution.packet_phase
-// (the packet's own real, immutable phase bit) against CURRENT state,
-// makes this function correct regardless of how many resolutions were
-// computed before it, or in what order they are committed.
+// Deliberately does NOT trust resolution.is_new_update/is_previous_phase,
+// and deliberately does NOT compare resolution.packet_phase against
+// s.current_phase either -- both reflect the situation as observed AT
+// RESOLVE TIME, and this function can be called with a STALE resolution if
+// a caller resolves more than one packet (e.g. several packets coalesced
+// into one datagram) before committing either. The phase bit specifically
+// cannot be trusted for this comparison even when re-read fresh: it has
+// period-2 parity, so after a SECOND update has committed, a genuinely old
+// generation-0 packet's phase bit coincidentally matches the new
+// generation-2 current phase, and comparing bits alone would mis-commit it
+// as belonging to generation 2. resolution.generation is an ABSOLUTE
+// counter (not subject to that parity collision) computed once at resolve
+// time from what was genuinely current then -- comparing IT against the
+// CURRENT s.current_generation is correct regardless of how many
+// resolutions were computed before this one, or in what order they commit.
 pub fn (mut s KeyUpdateState) note_successful_decrypt(resolution KeyResolution, packet_number u64) ! {
-	if resolution.packet_phase == s.current_phase {
+	if resolution.generation == s.current_generation {
 		current := s.min_pn_in_current_phase or {
 			s.min_pn_in_current_phase = packet_number
 			return
@@ -188,33 +230,34 @@ pub fn (mut s KeyUpdateState) note_successful_decrypt(resolution KeyResolution, 
 		return
 	}
 
-	min_current := s.min_pn_in_current_phase or {
+	if resolution.generation == s.current_generation + 1 {
 		s.commit_new_update(packet_number)!
 		return
 	}
 
-	if packet_number < min_current {
-		// Still an old-phase packet as of now -- no bookkeeping change.
-		return
-	}
-	s.commit_new_update(packet_number)!
+	// Any other generation (older than the retained previous one, or
+	// jumped ahead by more than one) is stale relative to CURRENT state --
+	// no bookkeeping change.
 }
 
 // commit_new_update performs the actual key-generation advance, always
 // re-deriving the next secret/keys fresh from the CURRENT current_secret
 // (never trusting a resolution's possibly-stale secret/keys) so it is
 // correct no matter how many resolutions were computed before it committed.
+// The header-protection key is carried forward unchanged (RFC 9001 §6) --
+// see derive_updated_packet_protection_keys' doc comment.
 fn (mut s KeyUpdateState) commit_new_update(packet_number u64) ! {
 	if s.updates_accepted >= max_key_updates_accepted {
 		return error('quic: too many key updates accepted on this connection (limit ${max_key_updates_accepted})')
 	}
 	new_secret := derive_updated_secret(s.current_secret)!
-	new_keys := derive_packet_protection_keys(new_secret)!
+	new_keys := derive_updated_packet_protection_keys(new_secret, s.current_keys.hp)!
 	s.previous_keys = s.current_keys
 	s.current_keys = new_keys
 	s.current_secret = new_secret
 	s.current_phase = !s.current_phase
 	s.min_pn_in_current_phase = packet_number
+	s.current_generation++
 	s.updates_accepted++
 }
 

--- a/vlib/net/quic/key_update_test.v
+++ b/vlib/net/quic/key_update_test.v
@@ -1,0 +1,143 @@
+module quic
+
+import crypto.rand
+import crypto.hkdf
+import crypto.sha256
+
+fn test_derive_updated_secret_matches_independent_hkdf_computation() {
+	secret := rand.bytes(32)!
+	got := derive_updated_secret(secret)!
+
+	// Cross-check against a hand-assembled HkdfLabel + hkdf.expand call,
+	// bypassing derive_updated_secret/hkdf_expand_label entirely, so this
+	// isn't just checking derive_updated_secret against itself.
+	full_label := 'tls13 quic ku'
+	mut hkdf_label := []u8{}
+	hkdf_label << u8(32 >> 8)
+	hkdf_label << u8(32)
+	hkdf_label << u8(full_label.len)
+	hkdf_label << full_label.bytes()
+	hkdf_label << u8(0) // empty context
+	independently := hkdf.expand(sha256.new, secret, hkdf_label.bytestr(), 32)!
+	assert got == independently
+	assert got.len == 32
+}
+
+fn test_key_update_state_starts_at_phase_zero() {
+	secret := rand.bytes(32)!
+	s := new_key_update_state(secret)!
+	assert s.current_phase_bit() == false
+}
+
+fn test_key_update_state_matched_phase_resolves_to_current_keys() {
+	secret := rand.bytes(32)!
+	s := new_key_update_state(secret)!
+	resolution := s.resolve_read_keys(false, 5)!
+	assert resolution.is_new_update == false
+	assert resolution.is_previous_phase == false
+	assert resolution.keys == s.current_keys
+}
+
+fn test_key_update_state_full_update_and_reordered_previous_phase_packet() {
+	secret := rand.bytes(32)!
+	mut s := new_key_update_state(secret)!
+	original_keys := s.current_keys
+
+	// First mismatched-phase packet: no packet has been processed yet in
+	// the current phase, so this can only be a genuine new update.
+	first_resolution := s.resolve_read_keys(true, 100)!
+	assert first_resolution.is_new_update == true
+	assert first_resolution.is_previous_phase == false
+	assert first_resolution.keys != original_keys
+
+	s.note_successful_decrypt(first_resolution, 100)!
+	assert s.current_phase_bit() == true
+	assert s.current_keys == first_resolution.keys
+
+	// A packet matching the NEW current phase, with a higher packet
+	// number, resolves normally.
+	matched := s.resolve_read_keys(true, 150)!
+	assert matched.is_new_update == false
+	assert matched.is_previous_phase == false
+	s.note_successful_decrypt(matched, 150)!
+
+	// A reordered packet from BEFORE the update (old phase bit, packet
+	// number lower than anything seen in the current phase) must resolve
+	// to the RETAINED previous keys -- exactly the original ones.
+	reordered := s.resolve_read_keys(false, 50)!
+	assert reordered.is_new_update == false
+	assert reordered.is_previous_phase == true
+	assert reordered.keys == original_keys
+
+	// Processing the reordered packet must NOT disturb current-phase
+	// bookkeeping.
+	s.note_successful_decrypt(reordered, 50)!
+	still_matched := s.resolve_read_keys(true, 149)!
+	// 149 < 150 (the min_pn_in_current_phase) but STILL matches the
+	// current phase bit, so this is not a phase mismatch at all --
+	// matched-phase packets always use current keys regardless of
+	// ordering.
+	assert still_matched.is_new_update == false
+	assert still_matched.is_previous_phase == false
+}
+
+// test_key_update_state_tolerates_resolving_before_committing simulates a
+// caller that resolves TWO packets (e.g. from the same coalesced datagram)
+// before committing EITHER -- both resolutions look like a genuine new
+// update at resolve time, since neither has actually been committed yet.
+// note_successful_decrypt must still only apply ONE real key update: the
+// second commit re-derives its classification fresh against the state AS
+// OF THAT COMMIT (already advanced by the first), recognizing it as an
+// ordinary matched-phase packet rather than mis-promoting a second time.
+fn test_key_update_state_tolerates_resolving_before_committing() {
+	secret := rand.bytes(32)!
+	mut s := new_key_update_state(secret)!
+
+	resolution_a := s.resolve_read_keys(true, 100)!
+	resolution_b := s.resolve_read_keys(true, 105)!
+	assert resolution_a.is_new_update == true
+	assert resolution_b.is_new_update == true // stale-but-expected: nothing committed yet
+
+	s.note_successful_decrypt(resolution_a, 100)!
+	assert s.current_phase_bit() == true
+	assert s.updates_accepted == 1
+
+	s.note_successful_decrypt(resolution_b, 105)!
+	assert s.updates_accepted == 1
+	assert s.current_phase_bit() == true
+}
+
+fn test_key_update_state_rejects_previous_phase_packet_once_discarded() {
+	secret := rand.bytes(32)!
+	mut s := new_key_update_state(secret)!
+	first_resolution := s.resolve_read_keys(true, 100)!
+	s.note_successful_decrypt(first_resolution, 100)!
+
+	s.discard_previous_keys()
+	s.resolve_read_keys(false, 50) or {
+		assert err.msg().contains('no previous keys are retained')
+		return
+	}
+	assert false, 'expected resolving a previous-phase packet to fail once discarded'
+}
+
+fn test_key_update_state_enforces_update_count_limit() {
+	secret := rand.bytes(32)!
+	mut s := new_key_update_state(secret)!
+	mut phase_to_use := true
+	mut pn := u64(1)
+
+	for _ in 0 .. max_key_updates_accepted {
+		resolution := s.resolve_read_keys(phase_to_use, pn)!
+		s.note_successful_decrypt(resolution, pn)!
+		phase_to_use = !phase_to_use
+		pn += 10
+	}
+
+	resolution := s.resolve_read_keys(phase_to_use, pn)!
+	s.note_successful_decrypt(resolution, pn) or {
+		assert err.msg().contains('too many key updates')
+		return
+	}
+	assert false, 'expected the update count limit to be enforced'
+}

--- a/vlib/net/quic/key_update_test.v
+++ b/vlib/net/quic/key_update_test.v
@@ -121,6 +121,71 @@ fn test_key_update_state_rejects_previous_phase_packet_once_discarded() {
 	assert false, 'expected resolving a previous-phase packet to fail once discarded'
 }
 
+// test_key_update_state_preserves_header_protection_key_across_update is a
+// Phase-R reproduction (Copilot findings on vlang/v#27881, pullrequestreview
+// 4885595852): RFC 9001 §6 rotates ONLY the packet-protection key/IV on a
+// key update -- the header-protection key is derived once per encryption
+// level and never updates within it. Deriving `hp` fresh (as
+// derive_packet_protection_keys does for EVERY field) desyncs this client's
+// header-protection key from what a real, compliant peer keeps.
+fn test_key_update_state_preserves_header_protection_key_across_update() {
+	secret := rand.bytes(32)!
+	mut s := new_key_update_state(secret)!
+	original_hp := s.current_keys.hp
+
+	resolution := s.resolve_read_keys(true, 100)!
+	assert resolution.keys.hp == original_hp
+
+	s.note_successful_decrypt(resolution, 100)!
+	assert s.current_keys.hp == original_hp
+}
+
+// test_key_update_state_second_update_does_not_corrupt_bookkeeping_via_stale_reordered_packet
+// is a Phase-R reproduction (same review): the phase bit is a single bit
+// with period-2 parity, so after a SECOND update the phase bit cycles back
+// to the value it had at generation 0. note_successful_decrypt's matched-
+// phase branch compared resolution.packet_phase against s.current_phase --
+// a genuinely old generation-0 packet, committed AFTER a second update has
+// already flipped current_phase back to that same bit value, was
+// mis-classified as belonging to the NEW (generation 2) phase, corrupting
+// min_pn_in_current_phase and misleading subsequent resolutions.
+fn test_key_update_state_second_update_does_not_corrupt_bookkeeping_via_stale_reordered_packet() {
+	secret := rand.bytes(32)!
+	mut s := new_key_update_state(secret)!
+
+	// First update: generation 0 -> generation 1 (phase false -> true).
+	first := s.resolve_read_keys(true, 100)!
+	s.note_successful_decrypt(first, 100)!
+	assert s.current_phase_bit() == true
+
+	// Resolve BOTH before committing either -- a genuinely reordered
+	// generation-0 packet (PN 50, phase false) and a genuine second update
+	// (generation 2, also phase false -- phase alternates and 2 is even).
+	old_resolution := s.resolve_read_keys(false, 50)!
+	assert old_resolution.is_previous_phase == true
+	new_resolution := s.resolve_read_keys(false, 200)!
+	assert new_resolution.is_new_update == true
+
+	// Commit the genuine second update first.
+	s.note_successful_decrypt(new_resolution, 200)!
+	assert s.current_phase_bit() == false // back to phase 0, by parity -- generation 2
+
+	// Commit the OLD, generation-0 resolution. Its phase bit (false) now
+	// coincidentally matches s.current_phase (also false, but for
+	// generation 2) -- it must NOT be treated as belonging to generation 2.
+	s.note_successful_decrypt(old_resolution, 50)!
+
+	// A genuinely still-outstanding generation-1 packet (reordered, PN
+	// between the corrupted-50 and correct-200 thresholds) must still
+	// resolve as a previous-phase packet using the retained generation-1
+	// keys -- not be misread as yet another brand new update because
+	// bookkeeping was corrupted down to 50.
+	still_generation_one := s.resolve_read_keys(true, 100)!
+	assert still_generation_one.is_previous_phase == true
+	assert still_generation_one.is_new_update == false
+	assert still_generation_one.keys == first.keys
+}
+
 fn test_key_update_state_enforces_update_count_limit() {
 	secret := rand.bytes(32)!
 	mut s := new_key_update_state(secret)!

--- a/vlib/net/quic/packet_number_space.v
+++ b/vlib/net/quic/packet_number_space.v
@@ -1,0 +1,102 @@
+module quic
+
+// RFC 9000 §12.3 — QUIC maintains THREE INDEPENDENT packet number spaces:
+// Initial, Handshake, and Application Data (1-RTT). A packet number in one
+// space has no relationship whatsoever to a packet number in another --
+// flagged repeatedly, across the spec and by real implementers, as the
+// single most common mistake in this area. Treating packet numbers as one
+// connection-global counter breaks ACK-frame interop with any compliant
+// peer, since an ACK frame's Largest Acknowledged/Gap/ACK Range Length
+// fields are always relative to the ONE space that carried the ACK frame
+// itself (RFC 9000 §13.2.3), never to a connection-wide count.
+
+pub enum QuicPacketNumberSpace {
+	initial
+	handshake
+	application_data
+}
+
+// PacketNumberSpaceState tracks everything specific to encoding/decoding
+// packet numbers within ONE space. A connection holds exactly three of
+// these (see QuicPacketNumberSpaces below) -- never fewer, never shared
+// across spaces, never reset back to a shared/global counter.
+pub struct PacketNumberSpaceState {
+pub mut:
+	// next_send_pn is the packet number this side will use for its NEXT
+	// packet sent in this space. QUIC packet numbers start at 0 and
+	// increase by exactly 1 per packet sent within a space (RFC 9000
+	// §12.3) -- never reused, never skipped, even across packets
+	// coalesced into the same datagram.
+	next_send_pn u64
+	// largest_received is the largest packet number this side has
+	// successfully processed (header-unprotected AND AEAD-decrypted) in
+	// this space, or none if no packet has been processed yet -- the
+	// `largest_pn` decode_packet_number needs when reconstructing a
+	// peer's truncated packet number in this same space.
+	largest_received ?u64
+	// largest_acked_by_peer is the largest packet number, IN THIS SPACE,
+	// that the peer's most recent ACK frame has acknowledged, or none if
+	// nothing has been acked yet -- the `largest_acked` encode_packet_number
+	// needs when choosing how many bytes to encode a new outgoing packet
+	// number with.
+	largest_acked_by_peer ?u64
+}
+
+// next_packet_number returns the packet number to use for the next
+// outgoing packet in this space and advances the counter. A caller must
+// never construct or send two packets sharing the same (space,
+// packet_number) pair.
+pub fn (mut s PacketNumberSpaceState) next_packet_number() u64 {
+	pn := s.next_send_pn
+	s.next_send_pn++
+	return pn
+}
+
+// note_received records that packet number `pn` was successfully
+// processed in this space, updating largest_received if `pn` is now the
+// largest seen. Packets may legitimately arrive out of order, so this
+// must only ever advance, never regress on a smaller, later-arriving
+// packet number.
+pub fn (mut s PacketNumberSpaceState) note_received(pn u64) {
+	current := s.largest_received or {
+		s.largest_received = pn
+		return
+	}
+
+	if pn > current {
+		s.largest_received = pn
+	}
+}
+
+// note_peer_acked records that the peer's most recent ACK frame in this
+// space acknowledged up to `largest_in_ack`. Same non-regression rule as
+// note_received: a peer's own ACK frames can themselves arrive out of
+// order, and an older ACK arriving after a newer one must not walk this
+// value backwards.
+pub fn (mut s PacketNumberSpaceState) note_peer_acked(largest_in_ack u64) {
+	current := s.largest_acked_by_peer or {
+		s.largest_acked_by_peer = largest_in_ack
+		return
+	}
+
+	if largest_in_ack > current {
+		s.largest_acked_by_peer = largest_in_ack
+	}
+}
+
+// QuicPacketNumberSpaces holds the three independent per-space states a
+// connection needs. Each field is its own distinct PacketNumberSpaceState
+// value -- there is no shared mutable state between them, which is itself
+// the enforcement mechanism for "never treat packet numbers as
+// connection-global": there is simply no single counter to accidentally
+// share.
+pub struct QuicPacketNumberSpaces {
+pub mut:
+	initial          PacketNumberSpaceState
+	handshake        PacketNumberSpaceState
+	application_data PacketNumberSpaceState
+}
+
+pub fn new_packet_number_spaces() &QuicPacketNumberSpaces {
+	return &QuicPacketNumberSpaces{}
+}

--- a/vlib/net/quic/packet_number_space.v
+++ b/vlib/net/quic/packet_number_space.v
@@ -46,7 +46,17 @@ pub mut:
 // outgoing packet in this space and advances the counter. A caller must
 // never construct or send two packets sharing the same (space,
 // packet_number) pair.
-pub fn (mut s PacketNumberSpaceState) next_packet_number() u64 {
+//
+// Rejects once the next packet number would exceed max_packet_number (RFC
+// 9000 §12.3: this packet number space is exhausted, and the caller MUST
+// stop sending in it) -- matching encode_packet_number's own convention,
+// rather than silently handing out a packet number the encoder would
+// reject one step later, or letting the counter wrap past u64::MAX into a
+// REUSED packet number.
+pub fn (mut s PacketNumberSpaceState) next_packet_number() !u64 {
+	if s.next_send_pn > max_packet_number {
+		return error('quic: packet number space exhausted (RFC 9000 §12.3): next packet number ${s.next_send_pn} exceeds the maximum ${max_packet_number} (2^62-1); this space must not send another packet')
+	}
 	pn := s.next_send_pn
 	s.next_send_pn++
 	return pn
@@ -97,6 +107,9 @@ pub mut:
 	application_data PacketNumberSpaceState
 }
 
+// new_packet_number_spaces creates the three independent per-space states
+// (Initial, Handshake, Application Data) a connection needs, each starting
+// from its own zero value -- no shared state between them.
 pub fn new_packet_number_spaces() &QuicPacketNumberSpaces {
 	return &QuicPacketNumberSpaces{}
 }

--- a/vlib/net/quic/packet_number_space_test.v
+++ b/vlib/net/quic/packet_number_space_test.v
@@ -1,0 +1,62 @@
+module quic
+
+fn test_packet_number_spaces_are_independent() {
+	mut spaces := new_packet_number_spaces()
+	assert spaces.initial.next_packet_number() == 0
+	assert spaces.initial.next_packet_number() == 1
+	assert spaces.initial.next_packet_number() == 2
+
+	// The handshake and application_data spaces must be completely
+	// unaffected by the initial space having already sent 3 packets -- a
+	// connection-global counter would have these start at 3, not 0.
+	assert spaces.handshake.next_packet_number() == 0
+	assert spaces.application_data.next_packet_number() == 0
+	assert spaces.handshake.next_packet_number() == 1
+}
+
+fn test_packet_number_space_next_packet_number_increments_sequentially() {
+	mut s := PacketNumberSpaceState{}
+	for i in u64(0) .. 10 {
+		assert s.next_packet_number() == i
+	}
+}
+
+fn test_packet_number_space_note_received_never_regresses() {
+	mut s := PacketNumberSpaceState{}
+	s.note_received(5)
+	assert s.largest_received or { 0 } == 5
+	s.note_received(3) // arrives later but is a smaller (reordered) packet number
+	assert s.largest_received or { 0 } == 5
+	s.note_received(10)
+	assert s.largest_received or { 0 } == 10
+}
+
+fn test_packet_number_space_note_peer_acked_never_regresses() {
+	mut s := PacketNumberSpaceState{}
+	s.note_peer_acked(7)
+	assert s.largest_acked_by_peer or { 0 } == 7
+	s.note_peer_acked(2)
+	assert s.largest_acked_by_peer or { 0 } == 7
+	s.note_peer_acked(20)
+	assert s.largest_acked_by_peer or { 0 } == 20
+}
+
+// test_packet_number_space_feeds_phase1_functions confirms this state
+// struct's fields plug directly into Phase 1's already-tested
+// encode_packet_number/decode_packet_number without any adaptation --
+// this is what makes it a real per-space "space", not just a label.
+fn test_packet_number_space_feeds_phase1_functions() {
+	mut s := PacketNumberSpaceState{}
+	s.note_peer_acked(1000)
+	pn_bytes, pn_len := encode_packet_number(1005, s.largest_acked_by_peer)
+	assert pn_len >= 1
+
+	mut truncated := u64(0)
+	for b in pn_bytes {
+		truncated = (truncated << 8) | u64(b)
+	}
+
+	s.note_received(999)
+	full_pn := decode_packet_number(truncated, pn_len, s.largest_received)!
+	assert full_pn == 1005
+}

--- a/vlib/net/quic/packet_number_space_test.v
+++ b/vlib/net/quic/packet_number_space_test.v
@@ -2,23 +2,42 @@ module quic
 
 fn test_packet_number_spaces_are_independent() {
 	mut spaces := new_packet_number_spaces()
-	assert spaces.initial.next_packet_number() == 0
-	assert spaces.initial.next_packet_number() == 1
-	assert spaces.initial.next_packet_number() == 2
+	assert spaces.initial.next_packet_number()! == 0
+	assert spaces.initial.next_packet_number()! == 1
+	assert spaces.initial.next_packet_number()! == 2
 
 	// The handshake and application_data spaces must be completely
 	// unaffected by the initial space having already sent 3 packets -- a
 	// connection-global counter would have these start at 3, not 0.
-	assert spaces.handshake.next_packet_number() == 0
-	assert spaces.application_data.next_packet_number() == 0
-	assert spaces.handshake.next_packet_number() == 1
+	assert spaces.handshake.next_packet_number()! == 0
+	assert spaces.application_data.next_packet_number()! == 0
+	assert spaces.handshake.next_packet_number()! == 1
 }
 
 fn test_packet_number_space_next_packet_number_increments_sequentially() {
 	mut s := PacketNumberSpaceState{}
 	for i in u64(0) .. 10 {
-		assert s.next_packet_number() == i
+		assert s.next_packet_number()! == i
 	}
+}
+
+// test_packet_number_space_next_packet_number_rejects_exhaustion is a
+// Phase-R regression for a Copilot finding on vlang/v#27881
+// (pullrequestreview-4885595852): this counter must reject once handing out
+// another packet number would exceed max_packet_number, matching
+// encode_packet_number's own RFC 9000 §12.3 enforcement, rather than
+// silently returning an unusable packet number one layer earlier.
+fn test_packet_number_space_next_packet_number_rejects_exhaustion() {
+	mut s := PacketNumberSpaceState{
+		next_send_pn: max_packet_number
+	}
+	assert s.next_packet_number()! == max_packet_number
+
+	s.next_packet_number() or {
+		assert err.msg().contains('exhausted')
+		return
+	}
+	assert false, 'expected packet-number-space exhaustion to be rejected'
 }
 
 fn test_packet_number_space_note_received_never_regresses() {

--- a/vlib/net/quic/packet_number_space_test.v
+++ b/vlib/net/quic/packet_number_space_test.v
@@ -48,7 +48,7 @@ fn test_packet_number_space_note_peer_acked_never_regresses() {
 fn test_packet_number_space_feeds_phase1_functions() {
 	mut s := PacketNumberSpaceState{}
 	s.note_peer_acked(1000)
-	pn_bytes, pn_len := encode_packet_number(1005, s.largest_acked_by_peer)
+	pn_bytes, pn_len := encode_packet_number(1005, s.largest_acked_by_peer)!
 	assert pn_len >= 1
 
 	mut truncated := u64(0)

--- a/vlib/net/quic/packet_protection.v
+++ b/vlib/net/quic/packet_protection.v
@@ -43,6 +43,25 @@ pub fn derive_packet_protection_keys(secret []u8) !QuicPacketProtectionKeys {
 	}
 }
 
+// derive_updated_packet_protection_keys computes the key/IV for a NEW
+// generation produced by a 1-RTT key update (RFC 9001 §6.1's `next_secret`),
+// while carrying `current_hp` forward UNCHANGED. RFC 9001 §6 is explicit
+// that a key update rotates only the packet-protection key and IV -- the
+// header-protection key is derived once, at the start of the encryption
+// level, and never updates within it (using key_update.v's own
+// derive_updated_secret to also produce a fresh `hp` would desync this
+// side's header-protection key from what a compliant peer keeps, since the
+// peer never rotates its own).
+pub fn derive_updated_packet_protection_keys(next_secret []u8, current_hp []u8) !QuicPacketProtectionKeys {
+	key := hkdf_expand_label(next_secret, 'quic key', []u8{}, aead_key_length)!
+	iv := hkdf_expand_label(next_secret, 'quic iv', []u8{}, aead_iv_length)!
+	return QuicPacketProtectionKeys{
+		key: key
+		iv:  iv
+		hp:  current_hp
+	}
+}
+
 // packet_protection_nonce computes the per-packet AEAD nonce (RFC 9001
 // §5.3): the packet's FULL, RECONSTRUCTED packet number (never the
 // truncated on-the-wire bytes — using the truncated value would collide

--- a/vlib/net/quic/tls13_handshake.v
+++ b/vlib/net/quic/tls13_handshake.v
@@ -186,7 +186,11 @@ pub fn (h &Tls13ClientHandshake) state() ClientHandshakeState {
 // into actual AEAD keys via hkdf_expand_label's "quic key"/"quic iv"
 // labels.
 pub fn (h &Tls13ClientHandshake) application_secrets() ApplicationSecrets {
-	return h.application_secrets
+	return ApplicationSecrets{
+		master_secret: h.application_secrets.master_secret.clone()
+		client_secret: h.application_secrets.client_secret.clone()
+		server_secret: h.application_secrets.server_secret.clone()
+	}
 }
 
 // handshake_secrets returns the derived Handshake-level traffic secrets.
@@ -195,7 +199,11 @@ pub fn (h &Tls13ClientHandshake) application_secrets() ApplicationSecrets {
 // Handshake-level packet protection keys as soon as ServerHello arrives,
 // before the rest of the handshake completes).
 pub fn (h &Tls13ClientHandshake) handshake_secrets() HandshakeSecrets {
-	return h.handshake_secrets
+	return HandshakeSecrets{
+		handshake_secret: h.handshake_secrets.handshake_secret.clone()
+		client_secret:    h.handshake_secrets.client_secret.clone()
+		server_secret:    h.handshake_secrets.server_secret.clone()
+	}
 }
 
 // free releases ecdhe_private (an OpenSSL EVP_PKEY, Phase 1's

--- a/vlib/net/quic/tls13_handshake_test.v
+++ b/vlib/net/quic/tls13_handshake_test.v
@@ -963,9 +963,13 @@ fn test_free_is_idempotent() {
 // bug class.
 fn test_application_secrets_and_handshake_secrets_return_independent_copies() {
 	mut h, _ := Tls13ClientHandshake.start(ClientHandshakeParams{
-		random:        []u8{len: 32, init: 0x11}
-		server_name:   'example.com'
-		ca_bundle_pem: ''
+		random:               []u8{len: 32, init: 0x11}
+		server_name:          'example.com'
+		transport_parameters: QuicTransportParameters{
+			initial_source_connection_id: [u8(1), 2, 3, 4]
+		}
+		ca_bundle_pem:        ''
+		alpn_protocols:       ['h3']
 	})!
 	defer {
 		h.free()

--- a/vlib/net/quic/tls13_handshake_test.v
+++ b/vlib/net/quic/tls13_handshake_test.v
@@ -947,3 +947,61 @@ fn test_free_is_idempotent() {
 	h.free()
 	h.free() // must not double-free
 }
+
+// test_application_secrets_and_handshake_secrets_return_independent_copies is
+// a regression test for a /vreview finding: application_secrets() and
+// handshake_secrets() returned h.application_secrets/h.handshake_secrets
+// directly -- V's plain struct/array assignment shares []u8 backing storage
+// rather than deep-copying it. HandshakeSecrets/ApplicationSecrets fields
+// are `pub:` (read-only), so V's checker blocks the naive
+// `snapshot.client_secret[0] = x` and even `mut arr := snapshot.client_secret`
+// (it demands an explicit `.clone()`) -- but neither guard stops a caller
+// reaching the same backing storage via `unsafe { arr.data }`, the same
+// raw-pointer escape hatch this codebase's own OpenSSL/mbedTLS interop code
+// already uses throughout net.quic. Mirrors crypto_stream_test.v's own
+// test_crypto_stream_reassembler_data_returns_independent_copy for the same
+// bug class.
+fn test_application_secrets_and_handshake_secrets_return_independent_copies() {
+	mut h, _ := Tls13ClientHandshake.start(ClientHandshakeParams{
+		random:        []u8{len: 32, init: 0x11}
+		server_name:   'example.com'
+		ca_bundle_pem: ''
+	})!
+	defer {
+		h.free()
+	}
+	h.handshake_secrets = HandshakeSecrets{
+		handshake_secret: [u8(1), 2, 3]
+		client_secret:    [u8(4), 5, 6]
+		server_secret:    [u8(7), 8, 9]
+	}
+	h.application_secrets = ApplicationSecrets{
+		master_secret: [u8(10), 11, 12]
+		client_secret: [u8(13), 14, 15]
+		server_secret: [u8(16), 17, 18]
+	}
+
+	hs_snapshot := h.handshake_secrets()
+	as_snapshot := h.application_secrets()
+	unsafe {
+		mut hs_handshake_secret := &u8(hs_snapshot.handshake_secret.data)
+		hs_handshake_secret[0] = 0xff
+		mut hs_client_secret := &u8(hs_snapshot.client_secret.data)
+		hs_client_secret[0] = 0xff
+		mut hs_server_secret := &u8(hs_snapshot.server_secret.data)
+		hs_server_secret[0] = 0xff
+
+		mut as_master_secret := &u8(as_snapshot.master_secret.data)
+		as_master_secret[0] = 0xff
+		mut as_client_secret := &u8(as_snapshot.client_secret.data)
+		as_client_secret[0] = 0xff
+		mut as_server_secret := &u8(as_snapshot.server_secret.data)
+		as_server_secret[0] = 0xff
+	}
+	assert h.handshake_secrets.handshake_secret[0] == 1
+	assert h.handshake_secrets.client_secret[0] == 4
+	assert h.handshake_secrets.server_secret[0] == 7
+	assert h.application_secrets.master_secret[0] == 10
+	assert h.application_secrets.client_secret[0] == 13
+	assert h.application_secrets.server_secret[0] == 16
+}


### PR DESCRIPTION
## Summary

Phase 5 of HTTP/3/QUIC support (#27675): full handshake completion,
continuing from the completed Phase 4 work in #27880 (Initial packet
exchange). Builds on the completed Phase 0-4 foundation — #27680, #27877,
#27880 — all merged, and targets `master` directly.

See [`vlib/net/quic/PROGRESS.md`](https://github.com/quaesitor-scientiam/v/blob/http3-quic-handshake-completion/vlib/net/quic/PROGRESS.md)
for the exact phase-by-phase checklist.

## Scope

- `packet_number_space.v` — formalizes the THREE independent packet number
  spaces (Initial/Handshake/1-RTT), flagged in the plan as the most common
  implementation mistake to get wrong (treating packet numbers as
  connection-global breaks ACK-frame interop with any compliant peer).
- `handshake_confirm.v` — models "complete" (client sent/verified Finished)
  and "confirmed" (client received HANDSHAKE_DONE, a 1-RTT-only frame) as
  two distinct states, since key-discard timing (RFC 9001 §4.9.1/4.9.2)
  depends on which one.
- `key_update.v` — 1-RTT-only key phase bit rotation (RFC 9001 §6);
  receive-side tolerance for a peer-initiated update (including a
  retained-old-key grace period for reordered pre-update packets) is
  must-have for v1 even though client-initiated rotation can be deferred.

## Test plan

- [x] Packet number space independence (no cross-space bleed) — advancing
      one space's counter is confirmed to leave the other two untouched,
      plus a direct feed-through test into Phase 1's own
      encode/decode_packet_number.
- [x] Complete-vs-confirmed divergence, including key-discard timing at
      each checkpoint — covers all 3 independent checkpoints separately
      (Initial-key discard, complete requiring BOTH Finished events,
      confirmed requiring complete even if HANDSHAKE_DONE arrives first).
- [x] Peer-initiated key update tolerance, including a reordered packet
      decoded correctly during the update window — a full promote +
      reordered-previous-phase-packet test, plus a dedicated test for the
      race where two packets are resolved before either is committed
      (the bug `/vreview` caught, see below).
- [x] Rate-limiting rapid key updates — enforced via a coarse,
      time-independent update-count cap (`max_key_updates_accepted`); real
      RFC 9001 §6.1/§6.5 ack-plus-3xPTO pacing needs RTT/PTO estimation
      this module doesn't have yet (Phase 7), documented as such.
- [x] All new/modified code passing under `./vnew test <path>` — 24/24
      files in `vlib/net/quic/`.
- [x] `./vnew fmt -w` applied to all touched `.v` files.
- [x] Branch rebased onto `upstream/master` (2026-08-06) now that #27880
      merged; adapted two tests to validation `#27880`'s own review added
      upstream in the interim (`encode_packet_number` returning a Result
      for packet-number-space exhaustion; `ClientHandshakeParams.start()`
      requiring `alpn_protocols` and `initial_source_connection_id`) — both
      now match the pattern already used by every sibling test in the
      touched files.

`/vreview` (full A-G pass) found and fixed one gap before commit:
`note_successful_decrypt` trusted resolve-time `is_new_update`/
`is_previous_phase` flags that go stale if a caller resolves more than one
packet before committing either (e.g. two packets from the same coalesced
datagram) — a second commit could re-promote an already-current phase as a
SECOND genuine update, permanently desynchronizing decryption from the
peer's actual state. Fixed by re-deriving the classification fresh from
the packet's real phase bit against current state at commit time. Has a
regression test, Phase-R-verified to fail on the pre-fix code.

Also includes a fix found separately: `Tls13ClientHandshake`'s
`application_secrets()`/`handshake_secrets()` getters returned the
struct's own `[]u8` fields directly rather than cloned copies, letting a
caller's mutation of a "snapshot" corrupt the handshake's live secret
state. Has a regression test proving the returned copies are independent.

🧙 Built with [WOZCODE](https://wozcode.com)
