### PR TITLE
HTTP/3 (QUIC) foundation: Phase 6 (Stream layer and flow control)

### DIFF
--- a/vlib/net/quic/PROGRESS.md
+++ b/vlib/net/quic/PROGRESS.md
@@ -651,13 +651,86 @@ The largest, highest-risk phase. Sub-phases, in build order:
       resolutions were computed before any commit. Has a regression test,
       Phase-R-verified to fail on the pre-fix code.
 
-## Phases 6-14 (NOT STARTED)
+## Phase 6 — Stream layer and flow control (done)
+
+- [x] `frame.v` extended — STREAM (0x08-0x0f, OFF/LEN/FIN bits), RESET_STREAM,
+      STOP_SENDING, MAX_DATA, MAX_STREAM_DATA, MAX_STREAMS (bidi/uni),
+      DATA_BLOCKED, STREAM_DATA_BLOCKED, STREAMS_BLOCKED (bidi/uni). A
+      length-less STREAM frame (LEN bit clear) correctly consumes the rest
+      of `parse_frames`' buffer, matching RFC 9000 §19.8's requirement that
+      it be the last frame in its packet — a natural consequence of the
+      wire format itself, not something requiring separate enforcement.
+- [x] `stream.v` — `StreamId` category derivation (RFC 9000 §2.1),
+      `QuicRole`-aware `is_locally_initiated`, `SendStreamState`/
+      `RecvStreamState` (RFC 9000 §3.1/§3.2) driven by local actions and
+      frame arrival respectively (ACK-driven and application-read-driven
+      transitions are documented hooks for Phase 7/9, not implemented
+      here). `QuicStream.send`/`recv` are nilable pointers (`&StreamSendHalf`/
+      `&StreamRecvHalf`, matching `Tls13ClientHandshake.verified_chain`'s
+      established convention) so every caller mutates the SAME shared half
+      directly — see the `/vreview` finding below for why this replaced an
+      earlier Optional-value design. `QuicStreamSet.get_or_create` auto-creates
+      peer-initiated streams (including every lower-numbered stream in the
+      same category, per RFC 9000 §2.1) while enforcing the caller-supplied
+      `max_streams` limit (STREAM_LIMIT_ERROR) and refusing to fabricate a
+      locally-initiated stream just because a frame references it
+      (STREAM_STATE_ERROR); `open_local_stream` is the send-side mirror,
+      allocating sequential IDs per category.
+- [x] `stream_reassembly.v` — per-stream offset-ordered reassembly, mirroring
+      Phase 4's `crypto_stream.v` design (validated-append + promote_ready,
+      tolerating out-of-order arrival and overlapping retransmissions),
+      extended with `note_final_size` reconciling a stream's final size
+      (from a FIN-carrying STREAM frame or RESET_STREAM) against everything
+      already received or buffered (FINAL_SIZE_ERROR on mismatch, RFC 9000
+      §4.5) — the one genuine difference from CRYPTO streams, which have no
+      final-size concept.
+- [x] `flow_control.v` — `FlowControlWindow` (send-side accounting against a
+      peer-raised limit) and `ReceiveWindow` (receive-side accounting with
+      an auto-growth heuristic: advertise a higher limit once the
+      application has consumed at least half the current window, avoiding
+      a throughput stall). `initial_send_limit_for_stream`/
+      `initial_receive_limit_for_stream` resolve RFC 9000 §4.1's
+      easy-to-invert peer-relative transport-parameter naming
+      (`initial_max_stream_data_bidi_local`/`_remote` mean opposite things
+      depending on whose parameters and which side of the stream you're
+      asking about) in one place, verified against a hand-derived worked
+      example for all 4 stream categories from the client's own
+      perspective, not just structurally.
+- [x] Integration test (`stream_layer_test.v`): three streams — a
+      client-opened bidi stream, a server-opened uni stream (the plan's own
+      "even client-first phase must receive server-initiated unidirectional
+      streams from day one"), and a second client-opened bidi stream — with
+      STREAM frames delivered genuinely interleaved (not grouped by stream),
+      each independently reassembled while one connection-level
+      `ReceiveWindow` tracks the running total across all three.
+- [x] `/vreview` pass: found and fixed one gap before commit —
+      `QuicStream.send`/`recv` were originally Optional VALUE fields
+      (`?StreamSendHalf`/`?StreamRecvHalf`); unwrapping via `s.recv or
+      {...}` copies the struct out, so mutating the copy via
+      `note_data()`/`note_size_known()` looks like in-place mutation but
+      silently doesn't persist unless the caller remembers to explicitly
+      reassign `s.recv = recv` afterward (the reassembler's own data
+      survives regardless, via its internal pointer field, but `state`/
+      `final_size` would silently revert). Fixed by switching to nilable
+      pointers before any real caller could hit this, eliminating the
+      whole bug class by construction rather than documenting the trap.
+      Two mechanical V-compiler quirks surfaced and fixed along the way,
+      unrelated to the finding above: `match` on a repeated array-index
+      expression (`frames[N]`) doesn't reliably narrow a sum type across
+      multiple field accesses within one arm once the sum type has enough
+      variants — affected both new Phase 6 tests and two PRE-EXISTING
+      tests in `frame_test.v`/`initial_exchange_test.v` that had worked
+      fine with fewer variants; fixed by binding to a local variable
+      before matching (the already-idiomatic pattern used everywhere
+      else). Separately, a pre-existing test's "frame type 0x08 is not
+      yet implemented" case became false once Phase 6 implemented STREAM
+      frames at that exact type value; retargeted to 0x1e
+      (HANDSHAKE_DONE), still genuinely unimplemented.
+
+## Phases 7-14 (NOT STARTED)
 
 See the tracking issue for full detail on each. In order:
 
-6. Stream layer — STREAM frames, connection+stream flow control interplay.
-   Note: even client-only v1 must receive server-initiated uni streams from
-   day one (HTTP/3's control/QPACK streams need this).
 7. Loss detection & NewReno congestion control (RFC 9002).
 8. Connection lifecycle — idle timeout, CONNECTION_CLOSE, stateless reset,
    ECN fallback, PMTU (pinned to 1200 bytes for v1).

--- a/vlib/net/quic/flow_control.v
+++ b/vlib/net/quic/flow_control.v
@@ -1,0 +1,175 @@
+module quic
+
+// RFC 9000 §4 — Flow Control. Both connection- and stream-level limits
+// apply SIMULTANEOUSLY and independently: a frame within its own stream's
+// window can still be blocked by the connection-level aggregate window,
+// and vice versa -- a caller must always check/update BOTH the relevant
+// stream's window and the connection-level window for every STREAM frame,
+// never just one.
+
+// FlowControlWindow tracks one DIRECTION's flow-control accounting for
+// what THIS endpoint may SEND, at one scope (a whole connection, or a
+// single stream): how many bytes have been consumed against a limit, and
+// what that limit currently is (raised over time by the PEER's
+// MAX_DATA/MAX_STREAM_DATA frames).
+pub struct FlowControlWindow {
+mut:
+	consumed u64
+	limit    u64
+}
+
+pub fn new_flow_control_window(initial_limit u64) FlowControlWindow {
+	return FlowControlWindow{
+		limit: initial_limit
+	}
+}
+
+// available returns how many more bytes this window currently permits.
+pub fn (w &FlowControlWindow) available() u64 {
+	if w.consumed >= w.limit {
+		return 0
+	}
+	return w.limit - w.consumed
+}
+
+// consume records `n` more bytes as used against this window, failing if
+// that would exceed the current limit -- callers must check available()
+// (or catch this error) BEFORE actually sending data, never discover the
+// violation only after the fact.
+pub fn (mut w FlowControlWindow) consume(n u64) ! {
+	if n > w.available() {
+		return error('quic: flow control window exceeded: attempted to consume ${n} bytes, only ${w.available()} available (limit ${w.limit}, consumed ${w.consumed})')
+	}
+	w.consumed += n
+}
+
+// raise_limit updates the window's limit, e.g. on receiving the peer's
+// MAX_DATA/MAX_STREAM_DATA frame. Per RFC 9000 §4.1, a limit update MUST
+// NOT be applied if it is SMALLER than the current limit (limits are
+// monotonically non-decreasing) -- silently ignored, not an error, since a
+// reordered older MAX_DATA/MAX_STREAM_DATA frame arriving after a newer
+// one is entirely normal, not a protocol violation.
+pub fn (mut w FlowControlWindow) raise_limit(new_limit u64) {
+	if new_limit > w.limit {
+		w.limit = new_limit
+	}
+}
+
+// ReceiveWindow tracks how much data THIS endpoint is willing to RECEIVE
+// (its own advertised limit to the peer) and how much of it the
+// application has actually consumed, deciding when to advertise a higher
+// limit. RFC 9000 §4.1 recommends sending updates before the window is
+// fully exhausted, not only once it hits zero, to avoid a throughput
+// stall while the peer waits for permission to keep sending.
+pub struct ReceiveWindow {
+mut:
+	received      u64 // bytes actually received so far (network progress)
+	read          u64 // bytes the application has consumed (frees window)
+	advertised    u64 // the limit we've told the peer via MAX_DATA/MAX_STREAM_DATA
+	initial_limit u64
+}
+
+pub fn new_receive_window(initial_limit u64) ReceiveWindow {
+	return ReceiveWindow{
+		advertised:    initial_limit
+		initial_limit: initial_limit
+	}
+}
+
+pub fn (w &ReceiveWindow) advertised_limit() u64 {
+	return w.advertised
+}
+
+// note_received records that the peer has sent data up to
+// `new_total_received` (a cumulative offset, not a delta), checking
+// against the CURRENTLY advertised limit -- a peer exceeding what we
+// advertised is a FLOW_CONTROL_ERROR. Non-regressing: an out-of-order
+// frame reporting a smaller cumulative total than already recorded is not
+// an error, just a no-op (the larger total already reflects it).
+pub fn (mut w ReceiveWindow) note_received(new_total_received u64) ! {
+	if new_total_received > w.advertised {
+		return error('quic: FLOW_CONTROL_ERROR: peer sent data up to offset ${new_total_received}, exceeding the advertised limit of ${w.advertised}')
+	}
+	if new_total_received > w.received {
+		w.received = new_total_received
+	}
+}
+
+// note_read records that the application has consumed up to
+// `new_total_read` (a cumulative offset).
+pub fn (mut w ReceiveWindow) note_read(new_total_read u64) {
+	if new_total_read > w.read {
+		w.read = new_total_read
+	}
+}
+
+// should_advertise_more reports whether it's time to raise and send a new
+// MAX_DATA/MAX_STREAM_DATA limit to the peer: once the application has
+// consumed at least half of the currently-advertised window. A simple,
+// standard auto-tuning heuristic that keeps the peer from ever actually
+// hitting zero available window in ordinary steady-state use (avoiding a
+// throughput stall) while still bounding how much unread data this
+// endpoint commits to buffering at once.
+pub fn (w &ReceiveWindow) should_advertise_more() bool {
+	return w.read >= w.advertised / 2
+}
+
+// next_advertised_limit returns the new limit to advertise, once
+// should_advertise_more() is true -- extends the window by another
+// initial_limit's worth. The caller sends the corresponding MAX_DATA/
+// MAX_STREAM_DATA frame and then calls mark_advertised to commit it.
+pub fn (w &ReceiveWindow) next_advertised_limit() u64 {
+	return w.advertised + w.initial_limit
+}
+
+pub fn (mut w ReceiveWindow) mark_advertised(new_limit u64) {
+	if new_limit > w.advertised {
+		w.advertised = new_limit
+	}
+}
+
+// initial_send_limit_for_stream returns the initial flow-control limit
+// THIS endpoint may send on `id`, given the PEER's own advertised
+// transport parameters (RFC 9000 §4.1). The naming is peer-relative and
+// easy to get backwards: `initial_max_stream_data_bidi_local` in the
+// PEER's parameters describes streams THEY consider local (streams THEY
+// initiate) -- which are REMOTE-initiated from where we're sitting.
+// Conversely their `_bidi_remote` describes streams WE initiate. This
+// function resolves that inversion once, in one place, rather than
+// leaving every call site to get the direction right on its own.
+//
+// Concretely, for role=client: on a client-initiated bidi stream (ours to
+// send on), the limit is the SERVER's initial_max_stream_data_bidi_remote
+// (the server's own "how much may streams opened by my peer send me"
+// value). On a server-initiated bidi stream, it's the server's
+// initial_max_stream_data_bidi_local (the server's own "how much may my
+// peer send me on streams I opened" value).
+pub fn initial_send_limit_for_stream(id StreamId, role QuicRole, peer_params QuicTransportParameters) u64 {
+	locally_initiated := id.is_locally_initiated(role)
+	if id.direction() == .unidirectional {
+		return peer_params.initial_max_stream_data_uni or { 0 }
+	}
+	return if locally_initiated {
+		peer_params.initial_max_stream_data_bidi_remote or { 0 }
+	} else {
+		peer_params.initial_max_stream_data_bidi_local or { 0 }
+	}
+}
+
+// initial_receive_limit_for_stream returns the initial flow-control limit
+// THIS endpoint has advertised to the PEER for how much the PEER may send
+// on `id`, given OUR OWN transport parameters (the ones we sent). Mirror
+// image of initial_send_limit_for_stream, using our own parameters
+// directly (no inversion needed here -- they're already from our own
+// perspective).
+pub fn initial_receive_limit_for_stream(id StreamId, role QuicRole, own_params QuicTransportParameters) u64 {
+	locally_initiated := id.is_locally_initiated(role)
+	if id.direction() == .unidirectional {
+		return own_params.initial_max_stream_data_uni or { 0 }
+	}
+	return if locally_initiated {
+		own_params.initial_max_stream_data_bidi_local or { 0 }
+	} else {
+		own_params.initial_max_stream_data_bidi_remote or { 0 }
+	}
+}

--- a/vlib/net/quic/flow_control.v
+++ b/vlib/net/quic/flow_control.v
@@ -102,10 +102,16 @@ pub fn (mut w ReceiveWindow) note_received(new_total_received u64) ! {
 }
 
 // note_read records that the application has consumed up to
-// `new_total_read` (a cumulative offset).
+// `new_total_read` (a cumulative offset). Capped to `received`: the
+// application can never have read more than has actually arrived over the
+// network, so a `new_total_read` claiming otherwise (a caller bug, once a
+// real application-read API exists in a later phase) is capped rather than
+// trusted -- otherwise should_advertise_more() could grant flow-control
+// credit for bytes that were never received.
 pub fn (mut w ReceiveWindow) note_read(new_total_read u64) {
-	if new_total_read > w.read {
-		w.read = new_total_read
+	capped := if new_total_read > w.received { w.received } else { new_total_read }
+	if capped > w.read {
+		w.read = capped
 	}
 }
 

--- a/vlib/net/quic/flow_control.v
+++ b/vlib/net/quic/flow_control.v
@@ -18,6 +18,8 @@ mut:
 	limit    u64
 }
 
+// new_flow_control_window constructs a send-side flow-control window
+// starting at `initial_limit` with nothing yet consumed.
 pub fn new_flow_control_window(initial_limit u64) FlowControlWindow {
 	return FlowControlWindow{
 		limit: initial_limit
@@ -69,6 +71,8 @@ mut:
 	initial_limit u64
 }
 
+// new_receive_window constructs a receive-side flow-control window,
+// initially advertising `initial_limit` to the peer.
 pub fn new_receive_window(initial_limit u64) ReceiveWindow {
 	return ReceiveWindow{
 		advertised:    initial_limit
@@ -76,6 +80,8 @@ pub fn new_receive_window(initial_limit u64) ReceiveWindow {
 	}
 }
 
+// advertised_limit returns the cumulative-offset limit we've told the peer
+// via MAX_DATA/MAX_STREAM_DATA.
 pub fn (w &ReceiveWindow) advertised_limit() u64 {
 	return w.advertised
 }
@@ -122,6 +128,9 @@ pub fn (w &ReceiveWindow) next_advertised_limit() u64 {
 	return w.advertised + w.initial_limit
 }
 
+// mark_advertised commits `new_limit` as sent to the peer, once the caller
+// has actually transmitted the corresponding MAX_DATA/MAX_STREAM_DATA frame.
+// Non-regressing: a smaller/stale limit is silently ignored.
 pub fn (mut w ReceiveWindow) mark_advertised(new_limit u64) {
 	if new_limit > w.advertised {
 		w.advertised = new_limit

--- a/vlib/net/quic/flow_control_test.v
+++ b/vlib/net/quic/flow_control_test.v
@@ -1,0 +1,171 @@
+module quic
+
+fn test_flow_control_window_available_and_consume() {
+	mut w := new_flow_control_window(100)
+	assert w.available() == 100
+	w.consume(60)!
+	assert w.available() == 40
+	w.consume(40)!
+	assert w.available() == 0
+}
+
+fn test_flow_control_window_rejects_exceeding_limit() {
+	mut w := new_flow_control_window(100)
+	w.consume(90)!
+	w.consume(20) or {
+		assert err.msg().contains('flow control window exceeded')
+		return
+	}
+	assert false, 'expected exceeding the window limit to be rejected'
+}
+
+fn test_flow_control_window_raise_limit_never_regresses() {
+	mut w := new_flow_control_window(100)
+	w.raise_limit(200)
+	assert w.available() == 200
+	w.raise_limit(150) // smaller/reordered update -- must be ignored, not an error
+	assert w.available() == 200
+}
+
+fn test_receive_window_note_received_rejects_exceeding_advertised() {
+	mut w := new_receive_window(100)
+	w.note_received(100)!
+	w.note_received(150) or {
+		assert err.msg().contains('FLOW_CONTROL_ERROR')
+		return
+	}
+	assert false, 'expected exceeding the advertised limit to be rejected'
+}
+
+fn test_receive_window_note_received_is_non_regressing() {
+	mut w := new_receive_window(100)
+	w.note_received(80)!
+	w.note_received(50)! // reordered/duplicate frame reporting a smaller cumulative total
+	assert w.advertised_limit() == 100
+	// A subsequent note_received with the higher value again must still work.
+	w.note_received(90)!
+}
+
+fn test_receive_window_auto_growth_heuristic() {
+	mut w := new_receive_window(100)
+	assert w.should_advertise_more() == false
+	w.note_read(40)
+	assert w.should_advertise_more() == false // less than half
+	w.note_read(50)
+	assert w.should_advertise_more() == true // >= half (50/100)
+
+	next := w.next_advertised_limit()
+	assert next == 200
+	w.mark_advertised(next)
+	assert w.advertised_limit() == 200
+}
+
+fn test_receive_window_mark_advertised_never_regresses() {
+	mut w := new_receive_window(100)
+	w.mark_advertised(200)
+	assert w.advertised_limit() == 200
+	w.mark_advertised(150)
+	assert w.advertised_limit() == 200
+}
+
+// test_initial_stream_limits_hand_derived_client_perspective is a
+// deliberately hand-derived check (not just structural) of
+// initial_send_limit_for_stream/initial_receive_limit_for_stream's
+// peer-relative naming inversion, from the CLIENT's own point of view --
+// the shape of bug this needs to catch is the send/receive limits or the
+// local/remote fields getting swapped, which a purely structural test
+// (e.g. "returns SOME value") would never catch.
+fn test_initial_stream_limits_hand_derived_client_perspective() {
+	peer_params := QuicTransportParameters{
+		initial_max_stream_data_bidi_local:  1000 // server's own: how much CLIENT may send on SERVER-opened bidi streams
+		initial_max_stream_data_bidi_remote: 2000 // server's own: how much CLIENT may send on CLIENT-opened bidi streams
+		initial_max_stream_data_uni:         3000 // server's own: how much CLIENT may send on CLIENT-opened uni streams
+	}
+	own_params := QuicTransportParameters{
+		initial_max_stream_data_bidi_local:  4000 // client's own: how much SERVER may send on CLIENT-opened bidi streams
+		initial_max_stream_data_bidi_remote: 5000 // client's own: how much SERVER may send on SERVER-opened bidi streams
+		initial_max_stream_data_uni:         6000 // client's own: how much SERVER may send on SERVER-opened uni streams
+	}
+
+	client_bidi := StreamId{
+		value: 0
+	} // client-initiated bidi
+	server_bidi := StreamId{
+		value: 1
+	} // server-initiated bidi
+	client_uni := StreamId{
+		value: 2
+	} // client-initiated uni (send-only for the client)
+	server_uni := StreamId{
+		value: 3
+	} // server-initiated uni (recv-only for the client)
+
+	// SEND limits (how much the CLIENT may send), governed by the SERVER's
+	// (peer's) parameters:
+	assert initial_send_limit_for_stream(client_bidi, .client, peer_params) == 2000 // peer's _bidi_remote
+	assert initial_send_limit_for_stream(server_bidi, .client, peer_params) == 1000 // peer's _bidi_local
+	assert initial_send_limit_for_stream(client_uni, .client, peer_params) == 3000 // peer's _uni
+
+	// RECEIVE limits (how much the CLIENT has told the server it may
+	// send), governed by the CLIENT's OWN parameters:
+	assert initial_receive_limit_for_stream(client_bidi, .client, own_params) == 4000 // own _bidi_local
+	assert initial_receive_limit_for_stream(server_bidi, .client, own_params) == 5000 // own _bidi_remote
+	assert initial_receive_limit_for_stream(server_uni, .client, own_params) == 6000 // own _uni
+}
+
+fn test_initial_stream_limits_default_to_zero_when_absent() {
+	empty := QuicTransportParameters{}
+	client_bidi := StreamId{
+		value: 0
+	}
+	assert initial_send_limit_for_stream(client_bidi, .client, empty) == 0
+	assert initial_receive_limit_for_stream(client_bidi, .client, empty) == 0
+}
+
+// test_connection_vs_stream_window_interplay is the plan's own explicitly
+// named test: a frame within its own stream's window can still be
+// blocked by the connection-level aggregate window, and vice versa --
+// both must be checked independently, and satisfying one is never enough
+// on its own.
+fn test_connection_vs_stream_window_interplay() {
+	mut stream_window := new_flow_control_window(1000) // plenty of room at the stream level
+	mut conn_window := new_flow_control_window(100) // tight at the connection level
+
+	// A send of 100 bytes fits comfortably within the stream's own window,
+	// but must still be checked against (and correctly exhausts) the
+	// tighter connection-level window.
+	assert stream_window.available() >= 100
+	assert conn_window.available() >= 100
+	stream_window.consume(100)!
+	conn_window.consume(100)!
+	assert conn_window.available() == 0
+	assert stream_window.available() == 900 // stream itself still has room
+
+	// A further send that the STREAM window alone would happily allow
+	// must still be rejected because the CONNECTION window is exhausted --
+	// checking only the stream window would incorrectly permit it.
+	conn_window.consume(1) or {
+		assert err.msg().contains('flow control window exceeded')
+		return
+	}
+	assert false, 'expected the connection-level window to block a send the stream window alone would allow'
+}
+
+fn test_connection_vs_stream_window_interplay_reverse() {
+	// Mirror scenario: connection-level window has plenty of room, but
+	// THIS stream's own window is tight -- the stream-level check must
+	// independently block it even though the connection level wouldn't.
+	mut stream_window := new_flow_control_window(50)
+	mut conn_window := new_flow_control_window(10000)
+
+	stream_window.consume(50)!
+	conn_window.consume(50)!
+	assert stream_window.available() == 0
+	assert conn_window.available() == 9950
+
+	stream_window.consume(1) or {
+		assert err.msg().contains('flow control window exceeded')
+		return
+	}
+	assert false, 'expected the stream-level window to block a send the connection window alone would allow'
+}

--- a/vlib/net/quic/flow_control_test.v
+++ b/vlib/net/quic/flow_control_test.v
@@ -48,6 +48,7 @@ fn test_receive_window_note_received_is_non_regressing() {
 
 fn test_receive_window_auto_growth_heuristic() {
 	mut w := new_receive_window(100)
+	w.note_received(100)! // data must actually arrive before the application can read it
 	assert w.should_advertise_more() == false
 	w.note_read(40)
 	assert w.should_advertise_more() == false // less than half
@@ -58,6 +59,20 @@ fn test_receive_window_auto_growth_heuristic() {
 	assert next == 200
 	w.mark_advertised(next)
 	assert w.advertised_limit() == 200
+}
+
+// test_receive_window_note_read_is_capped_to_received is a Phase-R
+// regression for a "Local AI Review" finding on vlang/v#27882 (2026-08-11):
+// note_read trusted new_total_read unconditionally, so a caller claiming to
+// have read more than was ever actually received (received tracks real
+// network arrival) could push w.read past w.received, letting
+// should_advertise_more() grant flow-control credit for bytes that never
+// arrived.
+fn test_receive_window_note_read_is_capped_to_received() {
+	mut w := new_receive_window(100)
+	w.note_received(30)!
+	w.note_read(80) // must never be trusted beyond what has actually arrived
+	assert w.should_advertise_more() == false // true only if the uncapped 80 were trusted (80 >= 50)
 }
 
 fn test_receive_window_mark_advertised_never_regresses() {

--- a/vlib/net/quic/frame.v
+++ b/vlib/net/quic/frame.v
@@ -566,6 +566,12 @@ fn parse_stream_data_blocked_frame(buf []u8, start int) !(QuicFrame, int) {
 
 fn parse_streams_blocked_frame(buf []u8, start int, is_uni bool) !(QuicFrame, int) {
 	maximum_streams, n1 := decode_varint(buf[start..])!
+	// RFC 9000 §19.14: the same 2^60 cap as MAX_STREAMS (§4.6) -- carries the
+	// identical "maximum stream count" semantic, so a value exceeding it
+	// would likewise imply a stream ID inexpressible as a varint.
+	if maximum_streams > max_initial_max_streams {
+		return error('quic: STREAMS_BLOCKED frame: value ${maximum_streams} exceeds the ${max_initial_max_streams} (2^60) limit (RFC 9000 §19.14)')
+	}
 	return QuicFrame(StreamsBlockedFrame{
 		direction:       if is_uni {
 			StreamDirection.unidirectional
@@ -719,8 +725,19 @@ pub fn encode_stop_sending_frame(stream_id u64, error_code u64) ![]u8 {
 // frame's own fields alone.
 pub fn encode_stream_frame(stream_id u64, offset u64, data []u8, fin bool, include_length bool) ![]u8 {
 	// RFC 9000 §19.8 (mirrors encode_crypto_frame's identical §19.6 check):
-	// the sum of offset and data length must not exceed 2^62-1.
-	if offset + u64(data.len) > max_varint {
+	// the sum of offset and data length must not exceed 2^62-1. Unlike the
+	// PARSE-side check (both operands there come from decode_varint, which
+	// inherently caps each at max_varint, so their sum can never overflow
+	// u64), `offset` here is CALLER-supplied with no such inherent bound --
+	// a caller passing e.g. offset near u64::MAX would make `offset +
+	// u64(data.len)` itself wrap to a small value, silently passing an
+	// `offset + length > max_varint` check. Checking `offset` alone first,
+	// then rearranging the sum comparison into an overflow-safe
+	// subtraction, avoids ever computing the (potentially wrapping) sum.
+	if offset > max_varint {
+		return error('quic: encode_stream_frame: offset ${offset} exceeds the 2^62-1 varint limit (RFC 9000 §19.8)')
+	}
+	if data.len > 0 && offset > max_varint - u64(data.len) {
 		return error('quic: encode_stream_frame: offset ${offset} + length ${data.len} exceeds the 2^62-1 varint limit (RFC 9000 §19.8)')
 	}
 	mut type_bits := u8(frame_type_stream_base)
@@ -793,6 +810,10 @@ pub fn encode_stream_data_blocked_frame(stream_id u64, maximum_stream_data u64) 
 
 // encode_streams_blocked_frame serializes a STREAMS_BLOCKED frame.
 pub fn encode_streams_blocked_frame(direction StreamDirection, maximum_streams u64) ![]u8 {
+	// RFC 9000 §19.14 (mirrors parse_streams_blocked_frame's identical check).
+	if maximum_streams > max_initial_max_streams {
+		return error('quic: encode_streams_blocked_frame: value ${maximum_streams} exceeds the ${max_initial_max_streams} (2^60) limit (RFC 9000 §19.14)')
+	}
 	typ := if direction == .unidirectional {
 		frame_type_streams_blocked_uni
 	} else {

--- a/vlib/net/quic/frame.v
+++ b/vlib/net/quic/frame.v
@@ -116,13 +116,122 @@ pub:
 	reason               string
 }
 
-pub type QuicFrame = AckFrame | ConnectionCloseFrame | CryptoFrame | PaddingFrame | PingFrame
+// StreamFrame represents a STREAM frame (type 0x08-0x0f, RFC 9000 §19.8):
+// a chunk of one stream's byte data at `offset`, optionally marking the
+// end of the stream (`fin`). Reassembling multiple (possibly out-of-order,
+// possibly overlapping) StreamFrames into a contiguous per-stream byte
+// stream is stream_reassembly.v's job, not this one's.
+pub struct StreamFrame {
+pub:
+	stream_id u64
+	offset    u64
+	fin       bool
+	data      []u8
+}
+
+// ResetStreamFrame represents a RESET_STREAM frame (type 0x04, RFC 9000
+// §19.4): the sender is abandoning the send side of `stream_id`, and
+// `final_size` is the exact total size that stream would have reached had
+// it not been reset -- reconciled against any data already received via
+// StreamReassembler.note_final_size (FINAL_SIZE_ERROR on mismatch).
+pub struct ResetStreamFrame {
+pub:
+	stream_id  u64
+	error_code u64
+	final_size u64
+}
+
+// StopSendingFrame represents a STOP_SENDING frame (type 0x05, RFC 9000
+// §19.5): a request that the peer abandon sending on `stream_id`.
+pub struct StopSendingFrame {
+pub:
+	stream_id  u64
+	error_code u64
+}
+
+// MaxDataFrame represents a MAX_DATA frame (type 0x10, RFC 9000 §19.9):
+// raises the CONNECTION-level limit on how much the receiver of this
+// frame may send in total, across all streams.
+pub struct MaxDataFrame {
+pub:
+	maximum_data u64
+}
+
+// MaxStreamDataFrame represents a MAX_STREAM_DATA frame (type 0x11, RFC
+// 9000 §19.10): raises the STREAM-level limit on `stream_id`.
+pub struct MaxStreamDataFrame {
+pub:
+	stream_id           u64
+	maximum_stream_data u64
+}
+
+// MaxStreamsFrame represents a MAX_STREAMS frame (type 0x12 bidirectional,
+// 0x13 unidirectional, RFC 9000 §19.11): raises how many concurrent
+// streams of `direction` the receiver of this frame may have open.
+pub struct MaxStreamsFrame {
+pub:
+	direction       StreamDirection
+	maximum_streams u64
+}
+
+// DataBlockedFrame represents a DATA_BLOCKED frame (type 0x14, RFC 9000
+// §19.12): informs the peer the sender wanted to send more but was
+// blocked by the connection-level flow control limit `maximum_data`.
+pub struct DataBlockedFrame {
+pub:
+	maximum_data u64
+}
+
+// StreamDataBlockedFrame represents a STREAM_DATA_BLOCKED frame (type
+// 0x15, RFC 9000 §19.13): same as DataBlockedFrame, but for one stream's
+// limit.
+pub struct StreamDataBlockedFrame {
+pub:
+	stream_id           u64
+	maximum_stream_data u64
+}
+
+// StreamsBlockedFrame represents a STREAMS_BLOCKED frame (type 0x16
+// bidirectional, 0x17 unidirectional, RFC 9000 §19.14): informs the peer
+// the sender wanted to open another stream of `direction` but was blocked
+// by the max_streams limit.
+pub struct StreamsBlockedFrame {
+pub:
+	direction       StreamDirection
+	maximum_streams u64
+}
+
+pub type QuicFrame = AckFrame
+	| ConnectionCloseFrame
+	| CryptoFrame
+	| DataBlockedFrame
+	| MaxDataFrame
+	| MaxStreamDataFrame
+	| MaxStreamsFrame
+	| PaddingFrame
+	| PingFrame
+	| ResetStreamFrame
+	| StopSendingFrame
+	| StreamDataBlockedFrame
+	| StreamFrame
+	| StreamsBlockedFrame
 
 const frame_type_padding = u64(0x00)
 const frame_type_ping = u64(0x01)
 const frame_type_ack = u64(0x02)
 const frame_type_ack_ecn = u64(0x03)
+const frame_type_reset_stream = u64(0x04)
+const frame_type_stop_sending = u64(0x05)
 const frame_type_crypto = u64(0x06)
+const frame_type_stream_base = u64(0x08) // 0x08-0x0f, OFF/LEN/FIN bits in the low 3 bits
+const frame_type_max_data = u64(0x10)
+const frame_type_max_stream_data = u64(0x11)
+const frame_type_max_streams_bidi = u64(0x12)
+const frame_type_max_streams_uni = u64(0x13)
+const frame_type_data_blocked = u64(0x14)
+const frame_type_stream_data_blocked = u64(0x15)
+const frame_type_streams_blocked_bidi = u64(0x16)
+const frame_type_streams_blocked_uni = u64(0x17)
 const frame_type_connection_close_transport = u64(0x1c)
 const frame_type_connection_close_application = u64(0x1d)
 
@@ -149,12 +258,48 @@ pub fn parse_frame(buf []u8) !(QuicFrame, int) {
 		return QuicFrame(PingFrame{}), typ_len
 	}
 
+	if typ == frame_type_reset_stream {
+		return parse_reset_stream_frame(buf, typ_len)
+	}
+
+	if typ == frame_type_stop_sending {
+		return parse_stop_sending_frame(buf, typ_len)
+	}
+
 	if typ == frame_type_ack || typ == frame_type_ack_ecn {
 		return parse_ack_frame(buf, typ_len, typ == frame_type_ack_ecn)
 	}
 
 	if typ == frame_type_crypto {
 		return parse_crypto_frame(buf, typ_len)
+	}
+
+	if typ >= frame_type_stream_base && typ <= frame_type_stream_base + 7 {
+		return parse_stream_frame(buf, typ_len, u8(typ))
+	}
+
+	if typ == frame_type_max_data {
+		return parse_max_data_frame(buf, typ_len)
+	}
+
+	if typ == frame_type_max_stream_data {
+		return parse_max_stream_data_frame(buf, typ_len)
+	}
+
+	if typ == frame_type_max_streams_bidi || typ == frame_type_max_streams_uni {
+		return parse_max_streams_frame(buf, typ_len, typ == frame_type_max_streams_uni)
+	}
+
+	if typ == frame_type_data_blocked {
+		return parse_data_blocked_frame(buf, typ_len)
+	}
+
+	if typ == frame_type_stream_data_blocked {
+		return parse_stream_data_blocked_frame(buf, typ_len)
+	}
+
+	if typ == frame_type_streams_blocked_bidi || typ == frame_type_streams_blocked_uni {
+		return parse_streams_blocked_frame(buf, typ_len, typ == frame_type_streams_blocked_uni)
 	}
 
 	if typ == frame_type_connection_close_transport
@@ -278,6 +423,139 @@ fn parse_crypto_frame(buf []u8, start int) !(QuicFrame, int) {
 	}), offset
 }
 
+fn parse_reset_stream_frame(buf []u8, start int) !(QuicFrame, int) {
+	mut offset := start
+	stream_id, n1 := decode_varint(buf[offset..])!
+	offset += n1
+	error_code, n2 := decode_varint(buf[offset..])!
+	offset += n2
+	final_size, n3 := decode_varint(buf[offset..])!
+	offset += n3
+	return QuicFrame(ResetStreamFrame{
+		stream_id:  stream_id
+		error_code: error_code
+		final_size: final_size
+	}), offset
+}
+
+fn parse_stop_sending_frame(buf []u8, start int) !(QuicFrame, int) {
+	mut offset := start
+	stream_id, n1 := decode_varint(buf[offset..])!
+	offset += n1
+	error_code, n2 := decode_varint(buf[offset..])!
+	offset += n2
+	return QuicFrame(StopSendingFrame{
+		stream_id:  stream_id
+		error_code: error_code
+	}), offset
+}
+
+// parse_stream_frame parses a STREAM frame given its already-decoded type
+// byte (0x08-0x0f), whose low 3 bits carry the OFF/LEN/FIN flags. When the
+// LEN bit is clear, the frame's data extends to the end of `buf` -- this
+// correctly ends the enclosing packet's frame sequence when parse_frames
+// walks off the end of the consumed buffer, since a STREAM frame without
+// an explicit length is REQUIRED to be the last frame in its packet.
+fn parse_stream_frame(buf []u8, start int, type_byte u8) !(QuicFrame, int) {
+	off_bit := type_byte & 0x04 != 0
+	len_bit := type_byte & 0x02 != 0
+	fin := type_byte & 0x01 != 0
+
+	mut offset := start
+	stream_id, n1 := decode_varint(buf[offset..])!
+	offset += n1
+
+	mut stream_offset := u64(0)
+	if off_bit {
+		off, n2 := decode_varint(buf[offset..])!
+		stream_offset = off
+		offset += n2
+	}
+
+	mut data := []u8{}
+	if len_bit {
+		length, n3 := decode_varint(buf[offset..])!
+		offset += n3
+		if u64(offset) + length > u64(buf.len) {
+			return error('quic: STREAM frame: length ${length} exceeds remaining buffer')
+		}
+		data = buf[offset..offset + int(length)].clone()
+		offset += int(length)
+	} else {
+		data = buf[offset..].clone()
+		offset = buf.len
+	}
+
+	return QuicFrame(StreamFrame{
+		stream_id: stream_id
+		offset:    stream_offset
+		fin:       fin
+		data:      data
+	}), offset
+}
+
+fn parse_max_data_frame(buf []u8, start int) !(QuicFrame, int) {
+	maximum_data, n1 := decode_varint(buf[start..])!
+	return QuicFrame(MaxDataFrame{
+		maximum_data: maximum_data
+	}), start + n1
+}
+
+fn parse_max_stream_data_frame(buf []u8, start int) !(QuicFrame, int) {
+	mut offset := start
+	stream_id, n1 := decode_varint(buf[offset..])!
+	offset += n1
+	maximum_stream_data, n2 := decode_varint(buf[offset..])!
+	offset += n2
+	return QuicFrame(MaxStreamDataFrame{
+		stream_id:           stream_id
+		maximum_stream_data: maximum_stream_data
+	}), offset
+}
+
+fn parse_max_streams_frame(buf []u8, start int, is_uni bool) !(QuicFrame, int) {
+	maximum_streams, n1 := decode_varint(buf[start..])!
+	return QuicFrame(MaxStreamsFrame{
+		direction:       if is_uni {
+			StreamDirection.unidirectional
+		} else {
+			StreamDirection.bidirectional
+		}
+		maximum_streams: maximum_streams
+	}), start + n1
+}
+
+fn parse_data_blocked_frame(buf []u8, start int) !(QuicFrame, int) {
+	maximum_data, n1 := decode_varint(buf[start..])!
+	return QuicFrame(DataBlockedFrame{
+		maximum_data: maximum_data
+	}), start + n1
+}
+
+fn parse_stream_data_blocked_frame(buf []u8, start int) !(QuicFrame, int) {
+	mut offset := start
+	stream_id, n1 := decode_varint(buf[offset..])!
+	offset += n1
+	maximum_stream_data, n2 := decode_varint(buf[offset..])!
+	offset += n2
+	return QuicFrame(StreamDataBlockedFrame{
+		stream_id:           stream_id
+		maximum_stream_data: maximum_stream_data
+	}), offset
+}
+
+fn parse_streams_blocked_frame(buf []u8, start int, is_uni bool) !(QuicFrame, int) {
+	maximum_streams, n1 := decode_varint(buf[start..])!
+	return QuicFrame(StreamsBlockedFrame{
+		direction:       if is_uni {
+			StreamDirection.unidirectional
+		} else {
+			StreamDirection.bidirectional
+		}
+		maximum_streams: maximum_streams
+	}), start + n1
+}
+
 fn parse_connection_close_frame(buf []u8, start int, is_application_error bool) !(QuicFrame, int) {
 	mut offset := start
 	error_code, n1 := decode_varint(buf[offset..])!
@@ -392,6 +670,107 @@ pub fn encode_crypto_frame(offset u64, data []u8) ![]u8 {
 	out << encode_varint(offset)!
 	out << encode_varint(u64(data.len))!
 	out << data
+	return out
+}
+
+// encode_reset_stream_frame serializes a RESET_STREAM frame.
+pub fn encode_reset_stream_frame(stream_id u64, error_code u64, final_size u64) ![]u8 {
+	mut out := encode_varint(frame_type_reset_stream)!
+	out << encode_varint(stream_id)!
+	out << encode_varint(error_code)!
+	out << encode_varint(final_size)!
+	return out
+}
+
+// encode_stop_sending_frame serializes a STOP_SENDING frame.
+pub fn encode_stop_sending_frame(stream_id u64, error_code u64) ![]u8 {
+	mut out := encode_varint(frame_type_stop_sending)!
+	out << encode_varint(stream_id)!
+	out << encode_varint(error_code)!
+	return out
+}
+
+// encode_stream_frame serializes a STREAM frame. The OFF bit is included
+// automatically whenever `offset != 0` (never needed for 0, and always
+// correct to include when nonzero); `include_length`, however, is a
+// genuine caller decision -- omitting the LEN field means this frame MUST
+// be the last one in its packet (RFC 9000 §19.8), a packet-layout choice
+// stream.v/flow_control.v's caller makes, not something inferable from the
+// frame's own fields alone.
+pub fn encode_stream_frame(stream_id u64, offset u64, data []u8, fin bool, include_length bool) ![]u8 {
+	mut type_bits := u8(frame_type_stream_base)
+	if offset != 0 {
+		type_bits |= 0x04
+	}
+	if include_length {
+		type_bits |= 0x02
+	}
+	if fin {
+		type_bits |= 0x01
+	}
+	mut out := encode_varint(u64(type_bits))!
+	out << encode_varint(stream_id)!
+	if offset != 0 {
+		out << encode_varint(offset)!
+	}
+	if include_length {
+		out << encode_varint(u64(data.len))!
+	}
+	out << data
+	return out
+}
+
+// encode_max_data_frame serializes a MAX_DATA frame.
+pub fn encode_max_data_frame(maximum_data u64) ![]u8 {
+	mut out := encode_varint(frame_type_max_data)!
+	out << encode_varint(maximum_data)!
+	return out
+}
+
+// encode_max_stream_data_frame serializes a MAX_STREAM_DATA frame.
+pub fn encode_max_stream_data_frame(stream_id u64, maximum_stream_data u64) ![]u8 {
+	mut out := encode_varint(frame_type_max_stream_data)!
+	out << encode_varint(stream_id)!
+	out << encode_varint(maximum_stream_data)!
+	return out
+}
+
+// encode_max_streams_frame serializes a MAX_STREAMS frame.
+pub fn encode_max_streams_frame(direction StreamDirection, maximum_streams u64) ![]u8 {
+	typ := if direction == .unidirectional {
+		frame_type_max_streams_uni
+	} else {
+		frame_type_max_streams_bidi
+	}
+	mut out := encode_varint(typ)!
+	out << encode_varint(maximum_streams)!
+	return out
+}
+
+// encode_data_blocked_frame serializes a DATA_BLOCKED frame.
+pub fn encode_data_blocked_frame(maximum_data u64) ![]u8 {
+	mut out := encode_varint(frame_type_data_blocked)!
+	out << encode_varint(maximum_data)!
+	return out
+}
+
+// encode_stream_data_blocked_frame serializes a STREAM_DATA_BLOCKED frame.
+pub fn encode_stream_data_blocked_frame(stream_id u64, maximum_stream_data u64) ![]u8 {
+	mut out := encode_varint(frame_type_stream_data_blocked)!
+	out << encode_varint(stream_id)!
+	out << encode_varint(maximum_stream_data)!
+	return out
+}
+
+// encode_streams_blocked_frame serializes a STREAMS_BLOCKED frame.
+pub fn encode_streams_blocked_frame(direction StreamDirection, maximum_streams u64) ![]u8 {
+	typ := if direction == .unidirectional {
+		frame_type_streams_blocked_uni
+	} else {
+		frame_type_streams_blocked_bidi
+	}
+	mut out := encode_varint(typ)!
+	out << encode_varint(maximum_streams)!
 	return out
 }
 

--- a/vlib/net/quic/frame.v
+++ b/vlib/net/quic/frame.v
@@ -476,12 +476,24 @@ fn parse_stream_frame(buf []u8, start int, type_byte u8) !(QuicFrame, int) {
 	if len_bit {
 		length, n3 := decode_varint(buf[offset..])!
 		offset += n3
+		// RFC 9000 §19.8 (identical requirement to §19.6's CRYPTO-frame
+		// bound, see parse_crypto_frame): "The largest offset delivered on
+		// a stream -- the sum of the offset and data length -- cannot
+		// exceed 2^62-1." u64 arithmetic here cannot itself overflow (two
+		// values each under 2^62 sum to at most just under 2^63).
+		if stream_offset + length > max_varint {
+			return error('quic: STREAM frame: offset ${stream_offset} + length ${length} exceeds the 2^62-1 varint limit (RFC 9000 §19.8)')
+		}
 		if u64(offset) + length > u64(buf.len) {
 			return error('quic: STREAM frame: length ${length} exceeds remaining buffer')
 		}
 		data = buf[offset..offset + int(length)].clone()
 		offset += int(length)
 	} else {
+		implicit_length := u64(buf.len - offset)
+		if stream_offset + implicit_length > max_varint {
+			return error('quic: STREAM frame: offset ${stream_offset} + length ${implicit_length} exceeds the 2^62-1 varint limit (RFC 9000 §19.8)')
+		}
 		data = buf[offset..].clone()
 		offset = buf.len
 	}
@@ -515,6 +527,14 @@ fn parse_max_stream_data_frame(buf []u8, start int) !(QuicFrame, int) {
 
 fn parse_max_streams_frame(buf []u8, start int, is_uni bool) !(QuicFrame, int) {
 	maximum_streams, n1 := decode_varint(buf[start..])!
+	// RFC 9000 §4.6: a MAX_STREAMS value above 2^60 would allow a stream ID
+	// that cannot be expressed as a variable-length integer -- MUST be
+	// treated as FRAME_ENCODING_ERROR. Mirrors the identical
+	// max_initial_max_streams check already enforced on the transport
+	// parameter (transport_parameters.v) for the same RFC requirement.
+	if maximum_streams > max_initial_max_streams {
+		return error('quic: MAX_STREAMS frame: value ${maximum_streams} exceeds the ${max_initial_max_streams} (2^60) limit (RFC 9000 §4.6)')
+	}
 	return QuicFrame(MaxStreamsFrame{
 		direction:       if is_uni {
 			StreamDirection.unidirectional
@@ -698,6 +718,11 @@ pub fn encode_stop_sending_frame(stream_id u64, error_code u64) ![]u8 {
 // stream.v/flow_control.v's caller makes, not something inferable from the
 // frame's own fields alone.
 pub fn encode_stream_frame(stream_id u64, offset u64, data []u8, fin bool, include_length bool) ![]u8 {
+	// RFC 9000 §19.8 (mirrors encode_crypto_frame's identical §19.6 check):
+	// the sum of offset and data length must not exceed 2^62-1.
+	if offset + u64(data.len) > max_varint {
+		return error('quic: encode_stream_frame: offset ${offset} + length ${data.len} exceeds the 2^62-1 varint limit (RFC 9000 §19.8)')
+	}
 	mut type_bits := u8(frame_type_stream_base)
 	if offset != 0 {
 		type_bits |= 0x04
@@ -737,6 +762,10 @@ pub fn encode_max_stream_data_frame(stream_id u64, maximum_stream_data u64) ![]u
 
 // encode_max_streams_frame serializes a MAX_STREAMS frame.
 pub fn encode_max_streams_frame(direction StreamDirection, maximum_streams u64) ![]u8 {
+	// RFC 9000 §4.6 (mirrors parse_max_streams_frame's identical check).
+	if maximum_streams > max_initial_max_streams {
+		return error('quic: encode_max_streams_frame: value ${maximum_streams} exceeds the ${max_initial_max_streams} (2^60) limit (RFC 9000 §4.6)')
+	}
 	typ := if direction == .unidirectional {
 		frame_type_max_streams_uni
 	} else {

--- a/vlib/net/quic/frame_test.v
+++ b/vlib/net/quic/frame_test.v
@@ -246,10 +246,12 @@ fn test_scaled_ack_delay_micros_saturates_at_exponent_ge_64() {
 }
 
 fn test_parse_frame_rejects_unimplemented_frame_type() {
-	// 0x08 (MAX_DATA) is a real, valid QUIC frame type this module simply
-	// doesn't implement yet (Phase 6) -- must be a clear "not implemented"
-	// error, not a wire-format error or a panic.
-	parse_frame([u8(0x08), 0x00]) or {
+	// 0x1e (HANDSHAKE_DONE) is a real, valid QUIC frame type this module
+	// simply doesn't implement yet (Phase 8/9) -- must be a clear "not
+	// implemented" error, not a wire-format error or a panic. (0x08, used
+	// here before Phase 6 implemented STREAM frames, would no longer
+	// demonstrate this.)
+	parse_frame([u8(0x1e)]) or {
 		assert err.msg().contains('not yet implemented')
 		return
 	}
@@ -282,24 +284,27 @@ fn test_parse_frames_multiple_in_sequence() {
 
 	frames := parse_frames(buf)!
 	assert frames.len == 3
-	match frames[0] {
+	frame0 := frames[0]
+	match frame0 {
 		PaddingFrame {
-			assert frames[0].length == 2
+			assert frame0.length == 2
 		}
 		else {
 			assert false, 'expected frames[0] to be PaddingFrame'
 		}
 	}
-	match frames[1] {
+	frame1 := frames[1]
+	match frame1 {
 		PingFrame {}
 		else {
 			assert false, 'expected frames[1] to be PingFrame'
 		}
 	}
-	match frames[2] {
+	frame2 := frames[2]
+	match frame2 {
 		CryptoFrame {
-			assert frames[2].offset == 0
-			assert frames[2].data == [u8(0xaa), 0xbb]
+			assert frame2.offset == 0
+			assert frame2.data == [u8(0xaa), 0xbb]
 		}
 		else {
 			assert false, 'expected frames[2] to be CryptoFrame'
@@ -411,4 +416,216 @@ fn test_encode_ack_frame_rejects_endpoint_exceeding_varint_max() {
 fn test_scaled_ack_delay_micros() {
 	assert scaled_ack_delay_micros(5, 3) == 40
 	assert scaled_ack_delay_micros(0, default_ack_delay_exponent) == 0
+}
+
+fn test_stream_frame_round_trip_implicit_offset_and_length() {
+	data := [u8(1), 2, 3, 4, 5]
+	encoded := encode_stream_frame(4, 0, data, false, true)!
+	frame, n := parse_frame(encoded)!
+	assert n == encoded.len
+	match frame {
+		StreamFrame {
+			assert frame.stream_id == 4
+			assert frame.offset == 0
+			assert frame.fin == false
+			assert frame.data == data
+		}
+		else {
+			assert false, 'expected a StreamFrame'
+		}
+	}
+}
+
+fn test_stream_frame_with_explicit_offset_and_fin() {
+	data := [u8(9), 8, 7]
+	encoded := encode_stream_frame(8, 200, data, true, true)!
+	frame, n := parse_frame(encoded)!
+	assert n == encoded.len
+	match frame {
+		StreamFrame {
+			assert frame.stream_id == 8
+			assert frame.offset == 200
+			assert frame.fin == true
+			assert frame.data == data
+		}
+		else {
+			assert false, 'expected a StreamFrame'
+		}
+	}
+}
+
+fn test_stream_frame_without_length_consumes_rest_of_buffer_and_ends_packet() {
+	// A STREAM frame with the LEN bit clear MUST be the last frame in its
+	// packet (RFC 9000 §19.8) -- confirm parse_frames correctly treats it
+	// as consuming everything remaining, ending the loop cleanly rather
+	// than erroring or leaving bytes unconsumed.
+	data := [u8(0xaa), 0xbb, 0xcc, 0xdd]
+	mut buf := [u8(0x01)] // PING first
+	buf << encode_stream_frame(0, 0, data, false, false)!
+
+	frames := parse_frames(buf)!
+	assert frames.len == 2
+	frame0 := frames[0]
+	match frame0 {
+		PingFrame {}
+		else {
+			assert false, 'expected frames[0] to be PingFrame'
+		}
+	}
+	frame1 := frames[1]
+	match frame1 {
+		StreamFrame {
+			assert frame1.data == data
+		}
+		else {
+			assert false, 'expected frames[1] to be StreamFrame'
+		}
+	}
+}
+
+fn test_stream_frame_rejects_length_exceeding_buffer() {
+	mut buf := encode_varint(u64(0x0a))! // STREAM type, LEN bit set, no OFF, no FIN
+	buf << encode_varint(0)! // stream_id
+	buf << encode_varint(100)! // length claims 100 bytes
+	buf << [u8(0x01), 0x02] // but only 2 bytes actually follow
+	parse_frame(buf) or {
+		assert err.msg().contains('exceeds remaining buffer')
+		return
+	}
+	assert false, 'expected a truncated STREAM frame to be rejected'
+}
+
+fn test_reset_stream_frame_round_trip() {
+	encoded := encode_reset_stream_frame(4, 7, 1000)!
+	frame, n := parse_frame(encoded)!
+	assert n == encoded.len
+	match frame {
+		ResetStreamFrame {
+			assert frame.stream_id == 4
+			assert frame.error_code == 7
+			assert frame.final_size == 1000
+		}
+		else {
+			assert false, 'expected a ResetStreamFrame'
+		}
+	}
+}
+
+fn test_stop_sending_frame_round_trip() {
+	encoded := encode_stop_sending_frame(8, 3)!
+	frame, n := parse_frame(encoded)!
+	assert n == encoded.len
+	match frame {
+		StopSendingFrame {
+			assert frame.stream_id == 8
+			assert frame.error_code == 3
+		}
+		else {
+			assert false, 'expected a StopSendingFrame'
+		}
+	}
+}
+
+fn test_max_data_frame_round_trip() {
+	encoded := encode_max_data_frame(65536)!
+	frame, n := parse_frame(encoded)!
+	assert n == encoded.len
+	match frame {
+		MaxDataFrame {
+			assert frame.maximum_data == 65536
+		}
+		else {
+			assert false, 'expected a MaxDataFrame'
+		}
+	}
+}
+
+fn test_max_stream_data_frame_round_trip() {
+	encoded := encode_max_stream_data_frame(4, 32768)!
+	frame, n := parse_frame(encoded)!
+	assert n == encoded.len
+	match frame {
+		MaxStreamDataFrame {
+			assert frame.stream_id == 4
+			assert frame.maximum_stream_data == 32768
+		}
+		else {
+			assert false, 'expected a MaxStreamDataFrame'
+		}
+	}
+}
+
+fn test_max_streams_frame_round_trip_both_directions() {
+	bidi_encoded := encode_max_streams_frame(.bidirectional, 10)!
+	assert bidi_encoded[0] == 0x12
+	bidi_frame, _ := parse_frame(bidi_encoded)!
+	match bidi_frame {
+		MaxStreamsFrame {
+			assert bidi_frame.direction == .bidirectional
+			assert bidi_frame.maximum_streams == 10
+		}
+		else {
+			assert false, 'expected a MaxStreamsFrame'
+		}
+	}
+
+	uni_encoded := encode_max_streams_frame(.unidirectional, 5)!
+	assert uni_encoded[0] == 0x13
+	uni_frame, _ := parse_frame(uni_encoded)!
+	match uni_frame {
+		MaxStreamsFrame {
+			assert uni_frame.direction == .unidirectional
+			assert uni_frame.maximum_streams == 5
+		}
+		else {
+			assert false, 'expected a MaxStreamsFrame'
+		}
+	}
+}
+
+fn test_data_blocked_frame_round_trip() {
+	encoded := encode_data_blocked_frame(4096)!
+	frame, n := parse_frame(encoded)!
+	assert n == encoded.len
+	match frame {
+		DataBlockedFrame {
+			assert frame.maximum_data == 4096
+		}
+		else {
+			assert false, 'expected a DataBlockedFrame'
+		}
+	}
+}
+
+fn test_stream_data_blocked_frame_round_trip() {
+	encoded := encode_stream_data_blocked_frame(4, 2048)!
+	frame, n := parse_frame(encoded)!
+	assert n == encoded.len
+	match frame {
+		StreamDataBlockedFrame {
+			assert frame.stream_id == 4
+			assert frame.maximum_stream_data == 2048
+		}
+		else {
+			assert false, 'expected a StreamDataBlockedFrame'
+		}
+	}
+}
+
+fn test_streams_blocked_frame_round_trip_both_directions() {
+	bidi_encoded := encode_streams_blocked_frame(.bidirectional, 20)!
+	assert bidi_encoded[0] == 0x16
+	uni_encoded := encode_streams_blocked_frame(.unidirectional, 15)!
+	assert uni_encoded[0] == 0x17
+
+	bidi_frame, _ := parse_frame(bidi_encoded)!
+	match bidi_frame {
+		StreamsBlockedFrame {
+			assert bidi_frame.direction == .bidirectional
+			assert bidi_frame.maximum_streams == 20
+		}
+		else {
+			assert false, 'expected a StreamsBlockedFrame'
+		}
+	}
 }

--- a/vlib/net/quic/frame_test.v
+++ b/vlib/net/quic/frame_test.v
@@ -495,6 +495,46 @@ fn test_stream_frame_rejects_length_exceeding_buffer() {
 	assert false, 'expected a truncated STREAM frame to be rejected'
 }
 
+// test_encode_stream_frame_rejects_offset_plus_length_exceeding_varint_max
+// and its parse-side sibling below are the STREAM-frame analog of
+// test_encode_crypto_frame_rejects_offset_plus_length_exceeding_varint_max
+// (RFC 9000 §19.8 mirrors §19.6's identical requirement).
+fn test_encode_stream_frame_rejects_offset_plus_length_exceeding_varint_max() {
+	encode_stream_frame(0, max_varint, [u8(0xaa)], false, true) or {
+		assert err.msg().contains('2^62')
+		return
+	}
+	assert false, 'expected offset+length exceeding the varint max to be rejected'
+}
+
+fn test_parse_stream_frame_rejects_offset_plus_length_exceeding_varint_max() {
+	mut buf := encode_varint(u64(0x0e))! // STREAM type, OFF+LEN bits set
+	buf << encode_varint(0)! // stream_id
+	buf << encode_varint(max_varint)! // offset
+	buf << encode_varint(1)! // length
+	buf << [u8(0xaa)]
+	parse_frame(buf) or {
+		assert err.msg().contains('2^62')
+		return
+	}
+	assert false, 'expected offset+length exceeding the varint max to be rejected'
+}
+
+// test_parse_stream_frame_without_length_rejects_offset_plus_implicit_length_exceeding_varint_max
+// covers the LEN-bit-clear path, where the length is implicit (rest of
+// buffer) rather than an explicit wire field.
+fn test_parse_stream_frame_without_length_rejects_offset_plus_implicit_length_exceeding_varint_max() {
+	mut buf := encode_varint(u64(0x0c))! // STREAM type, OFF bit set, LEN bit clear
+	buf << encode_varint(0)! // stream_id
+	buf << encode_varint(max_varint)! // offset
+	buf << [u8(0xaa)] // implicit-length data: rest of buffer
+	parse_frame(buf) or {
+		assert err.msg().contains('2^62')
+		return
+	}
+	assert false, 'expected offset+implicit-length exceeding the varint max to be rejected'
+}
+
 fn test_reset_stream_frame_round_trip() {
 	encoded := encode_reset_stream_frame(4, 7, 1000)!
 	frame, n := parse_frame(encoded)!
@@ -576,6 +616,42 @@ fn test_max_streams_frame_round_trip_both_directions() {
 		MaxStreamsFrame {
 			assert uni_frame.direction == .unidirectional
 			assert uni_frame.maximum_streams == 5
+		}
+		else {
+			assert false, 'expected a MaxStreamsFrame'
+		}
+	}
+}
+
+// test_encode/parse_max_streams_frame_rejects_value_above_2_pow_60 mirror
+// transport_parameters.v's own initial_max_streams_bidi/uni boundary tests
+// for the identical RFC 9000 §4.6 limit, now also enforced on the
+// MAX_STREAMS FRAME (not just the transport parameter) the RFC names
+// alongside it.
+fn test_encode_max_streams_frame_rejects_value_above_2_pow_60() {
+	encode_max_streams_frame(.bidirectional, max_initial_max_streams + 1) or {
+		assert err.msg().contains('2^60')
+		return
+	}
+	assert false, 'expected a MAX_STREAMS value above 2^60 to be rejected'
+}
+
+fn test_parse_max_streams_frame_rejects_value_above_2_pow_60() {
+	mut buf := encode_varint(u64(0x12))! // MAX_STREAMS bidi type
+	buf << encode_varint(max_initial_max_streams + 1)!
+	parse_frame(buf) or {
+		assert err.msg().contains('2^60')
+		return
+	}
+	assert false, 'expected a MAX_STREAMS value above 2^60 to be rejected'
+}
+
+fn test_encode_max_streams_frame_accepts_boundary_2_pow_60() {
+	encoded := encode_max_streams_frame(.bidirectional, max_initial_max_streams)!
+	frame, _ := parse_frame(encoded)!
+	match frame {
+		MaxStreamsFrame {
+			assert frame.maximum_streams == max_initial_max_streams
 		}
 		else {
 			assert false, 'expected a MaxStreamsFrame'

--- a/vlib/net/quic/frame_test.v
+++ b/vlib/net/quic/frame_test.v
@@ -507,6 +507,22 @@ fn test_encode_stream_frame_rejects_offset_plus_length_exceeding_varint_max() {
 	assert false, 'expected offset+length exceeding the varint max to be rejected'
 }
 
+// test_encode_stream_frame_rejects_offset_near_u64_max_without_overflow is a
+// Phase-R regression for a Copilot finding on vlang/v#27882
+// (pullrequestreview-4888843234): unlike the parse-side check (both
+// operands there come from decode_varint, inherently bounded to
+// max_varint), `offset` here is caller-supplied with no such bound -- a
+// naive `offset + u64(data.len) > max_varint` check would itself overflow
+// and wrap to a small value for an offset this close to u64::MAX, silently
+// passing the very check meant to reject it.
+fn test_encode_stream_frame_rejects_offset_near_u64_max_without_overflow() {
+	encode_stream_frame(0, max_u64 - 3, [u8(0xaa), 0xbb, 0xcc, 0xdd, 0xee], false, true) or {
+		assert err.msg().contains('2^62')
+		return
+	}
+	assert false, 'expected an offset near u64::MAX to be rejected, not silently accepted via overflow'
+}
+
 fn test_parse_stream_frame_rejects_offset_plus_length_exceeding_varint_max() {
 	mut buf := encode_varint(u64(0x0e))! // STREAM type, OFF+LEN bits set
 	buf << encode_varint(0)! // stream_id

--- a/vlib/net/quic/initial_exchange_test.v
+++ b/vlib/net/quic/initial_exchange_test.v
@@ -115,9 +115,10 @@ fn test_full_initial_round_trip_over_fake_transport() {
 	// second, ordinary frame rather than being invisible to this parse.
 	assert frames.len == 2
 	mut reassembler := new_crypto_stream_reassembler()
-	match frames[0] {
+	frame0 := frames[0]
+	match frame0 {
 		CryptoFrame {
-			reassembler.add(frames[0].offset, frames[0].data)!
+			reassembler.add(frame0.offset, frame0.data)!
 		}
 		else {
 			assert false, 'expected the first frame to be a CryptoFrame'

--- a/vlib/net/quic/stream.v
+++ b/vlib/net/quic/stream.v
@@ -1,0 +1,347 @@
+module quic
+
+// RFC 9000 §2.1 — Stream ID structure. The low 2 bits of a stream ID
+// encode who opened it and whether it's uni/bidirectional; every stream
+// ID belongs to exactly one of 4 categories, and QUIC never reuses an ID
+// across categories:
+//
+//	bit 0 (0x01): 0 = client-initiated, 1 = server-initiated
+//	bit 1 (0x02): 0 = bidirectional,     1 = unidirectional
+
+pub enum StreamInitiator {
+	client
+	server
+}
+
+pub enum StreamDirection {
+	bidirectional
+	unidirectional
+}
+
+// QuicRole distinguishes which side of the connection THIS endpoint is --
+// needed because "is this stream mine to have opened" and "am I allowed
+// to send on this uni stream" depend on who's asking, not just the ID
+// itself. v1 only ever runs as .client (server support is Phase 13, out
+// of committed scope) -- this enum exists now so stream.v doesn't need
+// reshaping when that phase lands, matching QuicConn's own planned
+// `role`-field design.
+pub enum QuicRole {
+	client
+	server
+}
+
+// StreamId wraps a raw stream ID with its RFC 9000 §2.1 category
+// derivation.
+pub struct StreamId {
+pub:
+	value u64
+}
+
+pub fn (id StreamId) initiator() StreamInitiator {
+	return if id.value & 0x01 == 0 { StreamInitiator.client } else { StreamInitiator.server }
+}
+
+pub fn (id StreamId) direction() StreamDirection {
+	return if id.value & 0x02 == 0 {
+		StreamDirection.bidirectional
+	} else {
+		StreamDirection.unidirectional
+	}
+}
+
+// is_locally_initiated reports whether `role` (this endpoint's own role)
+// is the one that opened the stream with this ID.
+pub fn (id StreamId) is_locally_initiated(role QuicRole) bool {
+	return match role {
+		.client { id.initiator() == .client }
+		.server { id.initiator() == .server }
+	}
+}
+
+// first_stream_id_of returns the lowest (first-allocated) stream ID for a
+// given (initiator, direction) category -- 0, 1, 2, 3 respectively for
+// client-bidi, server-bidi, client-uni, server-uni. Successive streams in
+// the same category are always exactly +4 from the previous one (RFC 9000
+// §2.1).
+pub fn first_stream_id_of(initiator StreamInitiator, direction StreamDirection) u64 {
+	mut v := u64(0)
+	if initiator == .server {
+		v |= 0x01
+	}
+	if direction == .unidirectional {
+		v |= 0x02
+	}
+	return v
+}
+
+// RFC 9000 §3.1 — Send Stream States. Transitions driven by LOCAL actions
+// (queuing data, sending FIN, sending RESET_STREAM) are modeled here
+// directly; transitions driven by the PEER'S ACKNOWLEDGMENT (Data Sent ->
+// Data Recvd, Reset Sent -> Reset Recvd) need ACK-processing machinery
+// this module doesn't have yet (Phase 7) -- mark_all_data_acked/
+// mark_reset_acked exist as the hooks a later phase will call, not
+// something this file drives on its own.
+pub enum SendStreamState {
+	ready
+	send
+	data_sent
+	data_recvd
+	reset_sent
+	reset_recvd
+}
+
+// RFC 9000 §3.2 — Receive Stream States. size_known/data_recvd/
+// reset_recvd are driven by frame ARRIVAL (this file's job); data_read/
+// reset_read are driven by the APPLICATION consuming the data/reset (a
+// later phase's job, once an application-facing read API exists) --
+// mark_data_read/mark_reset_read exist as that future hook.
+pub enum RecvStreamState {
+	recv
+	size_known
+	data_recvd
+	data_read
+	reset_recvd
+	reset_read
+}
+
+// StreamSendHalf is the send-side state for a stream THIS endpoint may
+// send on (present on every bidi stream, and on uni streams this side
+// opened).
+pub struct StreamSendHalf {
+pub mut:
+	state      SendStreamState
+	offset     u64
+	final_size ?u64
+	error_code ?u64 // set once reset_sent (our own RESET_STREAM's error code)
+}
+
+// mark_data_queued transitions ready -> send the first time data is
+// queued to send on this stream.
+pub fn (mut h StreamSendHalf) mark_data_queued() {
+	if h.state == .ready {
+		h.state = .send
+	}
+}
+
+// mark_fin_sent transitions send -> data_sent once a FIN-carrying STREAM
+// frame has been sent, recording the stream's final size.
+pub fn (mut h StreamSendHalf) mark_fin_sent(final_size u64) {
+	h.final_size = final_size
+	if h.state == .ready || h.state == .send {
+		h.state = .data_sent
+	}
+}
+
+// mark_reset_sent transitions to reset_sent from any state prior to
+// data_recvd/reset_recvd -- RFC 9000 §3.1 permits resetting a stream at
+// any point before its send side has fully completed.
+pub fn (mut h StreamSendHalf) mark_reset_sent(error_code u64) {
+	h.error_code = error_code
+	h.state = .reset_sent
+}
+
+// RecvHalf is the receive-side state for a stream THIS endpoint may
+// receive on (present on every bidi stream, and on uni streams the PEER
+// opened).
+pub struct StreamRecvHalf {
+pub mut:
+	state       RecvStreamState
+	reassembler &StreamReassembler = unsafe { nil }
+	final_size  ?u64
+	error_code  ?u64 // set once reset_recvd (peer's RESET_STREAM error code)
+}
+
+// note_size_known transitions recv -> size_known once the final size is
+// learned (a FIN-carrying STREAM frame, or a RESET_STREAM frame).
+pub fn (mut h StreamRecvHalf) note_size_known(final_size u64) ! {
+	h.reassembler.note_final_size(final_size)!
+	h.final_size = final_size
+	if h.state == .recv {
+		h.state = .size_known
+	}
+	if u64(h.reassembler.consumed_len()) >= final_size {
+		h.state = .data_recvd
+	}
+}
+
+// note_data records incoming STREAM frame data and promotes recv/
+// size_known -> data_recvd once the reassembler has everything up to a
+// known final size.
+pub fn (mut h StreamRecvHalf) note_data(offset u64, data []u8) ! {
+	h.reassembler.add(offset, data)!
+	if final := h.final_size {
+		if h.reassembler.consumed_len() >= final {
+			h.state = .data_recvd
+		}
+	}
+}
+
+// mark_reset_recvd transitions to reset_recvd on receiving RESET_STREAM --
+// legal from recv or size_known (RFC 9000 §3.2).
+pub fn (mut h StreamRecvHalf) mark_reset_recvd(error_code u64) {
+	h.error_code = error_code
+	h.state = .reset_recvd
+}
+
+// QuicStream is one stream's full state: an identity (id + direction) and
+// whichever of send/recv halves THIS endpoint actually has, given who
+// opened it relative to our own role -- a locally-initiated uni stream has
+// only `send`; a peer-initiated uni stream has only `recv`; every bidi
+// stream (either initiator) has both. `send`/`recv` are nilable POINTERS
+// (matching Tls13ClientHandshake.verified_chain's established convention
+// elsewhere in this module), not Optional VALUE fields -- an Optional
+// struct field requires unwrap-mutate-reassign on every update (`h := s.recv
+// or {...}; h.note_data(...)!; s.recv = h`), which is easy to get
+// subtly wrong (mutating the unwrapped copy and forgetting the final
+// reassignment silently drops the update). A pointer field lets every
+// caller mutate the SAME shared half directly (`s.recv.note_data(...)!`)
+// with no copy-back step to forget.
+@[heap]
+pub struct QuicStream {
+pub:
+	id        StreamId
+	direction StreamDirection
+pub mut:
+	send &StreamSendHalf = unsafe { nil }
+	recv &StreamRecvHalf = unsafe { nil }
+}
+
+pub fn (s &QuicStream) has_send() bool {
+	return s.send != unsafe { nil }
+}
+
+pub fn (s &QuicStream) has_recv() bool {
+	return s.recv != unsafe { nil }
+}
+
+// new_quic_stream constructs a QuicStream for `id`, populating exactly the
+// halves this endpoint (given `role`) actually has for that ID's category.
+pub fn new_quic_stream(id StreamId, role QuicRole) &QuicStream {
+	direction := id.direction()
+	locally_initiated := id.is_locally_initiated(role)
+
+	mut has_send := true
+	mut has_recv := true
+	if direction == .unidirectional {
+		has_send = locally_initiated
+		has_recv = !locally_initiated
+	}
+
+	mut s := &QuicStream{
+		id:        id
+		direction: direction
+	}
+	if has_send {
+		s.send = &StreamSendHalf{}
+	}
+	if has_recv {
+		s.recv = &StreamRecvHalf{
+			reassembler: new_stream_reassembler()
+		}
+	}
+	return s
+}
+
+// QuicStreamSet tracks every stream known to one connection, keyed by raw
+// stream ID.
+@[heap]
+pub struct QuicStreamSet {
+mut:
+	role            QuicRole
+	streams         map[u64]&QuicStream
+	next_local_bidi u64
+	next_local_uni  u64
+}
+
+pub fn new_quic_stream_set(role QuicRole) &QuicStreamSet {
+	return &QuicStreamSet{
+		role: role
+	}
+}
+
+// get returns an already-known stream, or none.
+pub fn (s &QuicStreamSet) get(raw_id u64) ?&QuicStream {
+	return s.streams[raw_id] or { return none }
+}
+
+// open_local_stream allocates the next available LOCALLY-initiated stream
+// ID of `direction` (RFC 9000 §2.1's "streams of the same type are
+// created in sequentially increasing order" rule) and registers a new
+// QuicStream for it. This is the send-side mirror of get_or_create's
+// receive-side auto-creation: get_or_create NEVER fabricates a
+// locally-initiated stream on the peer's say-so (see its own doc
+// comment) -- this function is how one of those streams actually comes
+// into existence, driven by THIS endpoint's own decision to open it.
+pub fn (mut s QuicStreamSet) open_local_stream(direction StreamDirection) &QuicStream {
+	initiator := if s.role == .client { StreamInitiator.client } else { StreamInitiator.server }
+	base := first_stream_id_of(initiator, direction)
+
+	mut index := u64(0)
+	if direction == .unidirectional {
+		index = s.next_local_uni
+		s.next_local_uni++
+	} else {
+		index = s.next_local_bidi
+		s.next_local_bidi++
+	}
+
+	id_value := base + index * 4
+	stream := new_quic_stream(StreamId{
+		value: id_value
+	}, s.role)
+	s.streams[id_value] = stream
+	return stream
+}
+
+pub fn (s &QuicStreamSet) len() int {
+	return s.streams.len
+}
+
+// get_or_create returns an existing stream, or creates one IF `raw_id` is
+// legally something the PEER may open unilaterally by simply referencing
+// it in a frame. RFC 9000 §2.1: "Before a stream is created, all streams
+// of the same type with lower-numbered stream IDs MUST be created" is
+// satisfied here by also creating every lower-numbered, same-category
+// stream that doesn't exist yet (up to and including `raw_id`) -- matching
+// how a real peer's own stream numbering works (a peer opening stream 8
+// implies streams 0 and 4 already exist, even if we never separately saw
+// traffic on them).
+//
+// `max_streams` is the CURRENTLY advertised limit (RFC 9000 §4.6) for this
+// ID's category -- the caller supplies it (sourced from flow_control.v's
+// own state), keeping this function decoupled from owning that state
+// itself.
+//
+// Locally-initiated stream IDs are NEVER auto-created this way -- a peer
+// referencing an ID that's ours to open, but that we haven't opened, is a
+// protocol violation (STREAM_STATE_ERROR), not something to paper over by
+// fabricating a stream on their behalf.
+pub fn (mut s QuicStreamSet) get_or_create(raw_id u64, max_streams u64) !&QuicStream {
+	if existing := s.streams[raw_id] {
+		return existing
+	}
+	id := StreamId{
+		value: raw_id
+	}
+	if id.is_locally_initiated(s.role) {
+		return error('quic: STREAM_STATE_ERROR: peer referenced locally-initiated stream ${raw_id} that was never opened')
+	}
+
+	base := first_stream_id_of(id.initiator(), id.direction())
+	step := u64(4)
+	index := (raw_id - base) / step // 0-based position within this category
+	if index + 1 > max_streams {
+		return error('quic: STREAM_LIMIT_ERROR: peer exceeded the max_streams limit (${max_streams}) for this stream category with id ${raw_id}')
+	}
+
+	mut n := base
+	for n <= raw_id {
+		if n !in s.streams {
+			s.streams[n] = new_quic_stream(StreamId{
+				value: n
+			}, s.role)
+		}
+		n += step
+	}
+	return s.streams[raw_id] or { panic('quic: internal error: stream ${raw_id} not created') }
+}

--- a/vlib/net/quic/stream.v
+++ b/vlib/net/quic/stream.v
@@ -153,7 +153,19 @@ pub mut:
 
 // note_size_known transitions recv -> size_known once the final size is
 // learned (a FIN-carrying STREAM frame, or a RESET_STREAM frame).
+//
+// A no-op once `state` has already reached reset_recvd/reset_read: RFC 9000
+// §3.2's Receive Stream State Machine (Figure 2) makes Reset Recvd a
+// terminal classification for how this stream's data delivery is
+// understood -- reordering means a STREAM frame carrying the FIN this
+// endpoint was still expecting can legitimately arrive AFTER a RESET_STREAM
+// that raced ahead of it on the wire, and processing it here would
+// otherwise silently flip `state` from Reset Recvd back to Data Recvd,
+// which the state machine never permits.
 pub fn (mut h StreamRecvHalf) note_size_known(final_size u64) ! {
+	if h.state == .reset_recvd || h.state == .reset_read {
+		return
+	}
 	h.reassembler.note_final_size(final_size)!
 	h.final_size = final_size
 	if h.state == .recv {
@@ -167,7 +179,14 @@ pub fn (mut h StreamRecvHalf) note_size_known(final_size u64) ! {
 // note_data records incoming STREAM frame data and promotes recv/
 // size_known -> data_recvd once the reassembler has everything up to a
 // known final size.
+//
+// A no-op once reset -- see note_size_known's doc comment for the same
+// reordering rationale (a reset stream must not be promoted back to
+// data_recvd by a stray, reordered STREAM frame).
 pub fn (mut h StreamRecvHalf) note_data(offset u64, data []u8) ! {
+	if h.state == .reset_recvd || h.state == .reset_read {
+		return
+	}
 	h.reassembler.add(offset, data)!
 	if final := h.final_size {
 		if h.reassembler.consumed_len() >= final {

--- a/vlib/net/quic/stream.v
+++ b/vlib/net/quic/stream.v
@@ -37,10 +37,14 @@ pub:
 	value u64
 }
 
+// initiator returns which side of the connection opened this stream, per
+// bit 0 of the stream ID (RFC 9000 §2.1).
 pub fn (id StreamId) initiator() StreamInitiator {
 	return if id.value & 0x01 == 0 { StreamInitiator.client } else { StreamInitiator.server }
 }
 
+// direction returns whether this stream is bidirectional or unidirectional,
+// per bit 1 of the stream ID (RFC 9000 §2.1).
 pub fn (id StreamId) direction() StreamDirection {
 	return if id.value & 0x02 == 0 {
 		StreamDirection.bidirectional
@@ -225,10 +229,12 @@ pub mut:
 	recv &StreamRecvHalf = unsafe { nil }
 }
 
+// has_send reports whether this stream has a send half on this endpoint.
 pub fn (s &QuicStream) has_send() bool {
 	return s.send != unsafe { nil }
 }
 
+// has_recv reports whether this stream has a receive half on this endpoint.
 pub fn (s &QuicStream) has_recv() bool {
 	return s.recv != unsafe { nil }
 }
@@ -272,6 +278,8 @@ mut:
 	next_local_uni  u64
 }
 
+// new_quic_stream_set constructs an empty QuicStreamSet for the given
+// endpoint role.
 pub fn new_quic_stream_set(role QuicRole) &QuicStreamSet {
 	return &QuicStreamSet{
 		role: role
@@ -323,6 +331,7 @@ pub fn (mut s QuicStreamSet) open_local_stream(direction StreamDirection) &QuicS
 	return stream
 }
 
+// len returns the number of streams currently known to this set.
 pub fn (s &QuicStreamSet) len() int {
 	return s.streams.len
 }

--- a/vlib/net/quic/stream.v
+++ b/vlib/net/quic/stream.v
@@ -138,8 +138,16 @@ pub fn (mut h StreamSendHalf) mark_fin_sent(final_size u64) {
 
 // mark_reset_sent transitions to reset_sent from any state prior to
 // data_recvd/reset_recvd -- RFC 9000 §3.1 permits resetting a stream at
-// any point before its send side has fully completed.
+// any point before its send side has fully completed, but its Sending
+// Stream State Machine draws "Send RESET_STREAM" only from Ready/Send/
+// Data Sent, and its prose states a sender MUST NOT send RESET_STREAM once
+// already in a terminal state (Data Recvd or Reset Recvd). A no-op from
+// either terminal state, matching mark_fin_sent's own guarded-transition
+// pattern above.
 pub fn (mut h StreamSendHalf) mark_reset_sent(error_code u64) {
+	if h.state == .data_recvd || h.state == .reset_recvd {
+		return
+	}
 	h.error_code = error_code
 	h.state = .reset_sent
 }
@@ -200,8 +208,27 @@ pub fn (mut h StreamRecvHalf) note_data(offset u64, data []u8) ! {
 }
 
 // mark_reset_recvd transitions to reset_recvd on receiving RESET_STREAM --
-// legal from recv or size_known (RFC 9000 §3.2).
-pub fn (mut h StreamRecvHalf) mark_reset_recvd(error_code u64) {
+// legal from recv or size_known, and also from data_recvd (RFC 9000 §3.2
+// explicitly allows this as implementation-defined: "It is possible that
+// all stream data has already been received when a RESET_STREAM is
+// received... An implementation is free to manage this situation as it
+// chooses."). Reconciles `final_size` against everything already received
+// via the reassembler's own FINAL_SIZE_ERROR check (RFC 9000 §4.5) -- the
+// same validation note_size_known already applies to a FIN-carrying STREAM
+// frame's final size, applied here too so a reset claiming a final size
+// smaller than data already received, or disagreeing with an
+// already-established final size (including a differing retransmitted
+// RESET_STREAM), is rejected rather than silently accepted.
+//
+// A no-op once `state` is reset_read: the application has already consumed
+// the reset, matching note_size_known/note_data's own terminal-state
+// rationale.
+pub fn (mut h StreamRecvHalf) mark_reset_recvd(error_code u64, final_size u64) ! {
+	if h.state == .reset_read {
+		return
+	}
+	h.reassembler.note_final_size(final_size)!
+	h.final_size = final_size
 	h.error_code = error_code
 	h.state = .reset_recvd
 }

--- a/vlib/net/quic/stream.v
+++ b/vlib/net/quic/stream.v
@@ -272,6 +272,17 @@ pub fn (s &QuicStreamSet) get(raw_id u64) ?&QuicStream {
 // locally-initiated stream on the peer's say-so (see its own doc
 // comment) -- this function is how one of those streams actually comes
 // into existence, driven by THIS endpoint's own decision to open it.
+//
+// Unlike get_or_create, this function does NOT itself enforce RFC 9000
+// §4.6's max_streams limit (the peer's current MAX_STREAMS/
+// initial_max_streams_* advertisement) -- that check requires state this
+// set doesn't own (the peer's currently-advertised limit, which changes
+// over the connection's life) and belongs to the connection-level caller
+// that DOES own it (Phase 9's QuicConn), the same way ACK-driven and
+// application-read-driven state transitions above are documented hooks
+// for a later phase rather than something this file drives on its own.
+// The caller MUST check against the peer's current limit before calling
+// this function.
 pub fn (mut s QuicStreamSet) open_local_stream(direction StreamDirection) &QuicStream {
 	initiator := if s.role == .client { StreamInitiator.client } else { StreamInitiator.server }
 	base := first_stream_id_of(initiator, direction)

--- a/vlib/net/quic/stream_layer_test.v
+++ b/vlib/net/quic/stream_layer_test.v
@@ -1,0 +1,83 @@
+module quic
+
+// test_multi_stream_interleaved_reassembly_and_flow_control is Phase 6's
+// capstone integration test (explicitly named in the plan): simulates
+// STREAM frames for THREE different streams -- a client-opened bidi
+// stream, a server-opened uni stream (exercising "even client-first phase
+// must correctly receive server-initiated unidirectional streams from day
+// one"), and a second client-opened bidi stream -- arriving genuinely
+// interleaved (not grouped by stream), routed through one QuicStreamSet,
+// each independently reassembled, while a single connection-level
+// ReceiveWindow tracks the running total across all three at once.
+fn test_multi_stream_interleaved_reassembly_and_flow_control() {
+	mut set := new_quic_stream_set(.client)
+	mut conn_window := new_receive_window(1000)
+	mut conn_total := u64(0)
+	max_streams := u64(10)
+
+	// stream_id 0: client-initiated bidi ("Hello" + " World")
+	// stream_id 3: server-initiated uni ("Foo" + "Bar") -- recv-only for us
+	// stream_id 4: client-initiated bidi ("X")
+	//
+	// Streams 0 and 4 are CLIENT-initiated: this client must have already
+	// opened them itself (get_or_create deliberately refuses to fabricate
+	// a locally-initiated stream just because a frame references it --
+	// see its own doc comment and test_quic_stream_set_get_or_create_
+	// rejects_locally_initiated_unknown_id). Stream 3 is server-initiated,
+	// so get_or_create's peer-driven auto-creation is exactly the
+	// intended path for it.
+	mut s0 := set.open_local_stream(.bidirectional) // becomes id 0
+	mut s4 := set.open_local_stream(.bidirectional) // becomes id 4
+
+	// Delivered in a genuinely interleaved order -- not grouped by stream,
+	// and stream 3's FIN-bearing second chunk is processed before stream
+	// 0's own second chunk.
+
+	// 1: stream 3, "Foo" (no fin)
+	mut s3 := set.get_or_create(3, max_streams)!
+	assert s3.has_recv()
+	s3.recv.note_data(0, 'Foo'.bytes())!
+	conn_total += 3
+	conn_window.note_received(conn_total)!
+
+	// 2: stream 0, "Hello" (no fin)
+	s0.recv.note_data(0, 'Hello'.bytes())!
+	conn_total += 5
+	conn_window.note_received(conn_total)!
+
+	// 3: stream 4, "X" (with fin -- single complete message)
+	s4.recv.note_data(0, 'X'.bytes())!
+	s4.recv.note_size_known(1)!
+	conn_total += 1
+	conn_window.note_received(conn_total)!
+
+	// 4: stream 3, "Bar" (with fin)
+	s3.recv.note_data(3, 'Bar'.bytes())!
+	s3.recv.note_size_known(6)!
+	conn_total += 3
+	conn_window.note_received(conn_total)!
+
+	// 5: stream 0, " World" (with fin)
+	s0.recv.note_data(5, ' World'.bytes())!
+	s0.recv.note_size_known(11)!
+	conn_total += 6
+	conn_window.note_received(conn_total)!
+
+	// Each stream reassembled its own data correctly, independent of the
+	// others and independent of arrival order.
+	assert s0.recv.reassembler.data().bytestr() == 'Hello World'
+	assert s0.recv.state == .data_recvd
+
+	assert s3.recv.reassembler.data().bytestr() == 'FooBar'
+	assert s3.recv.state == .data_recvd
+	assert !s3.has_send() // confirmed recv-only, as a peer-initiated uni stream must be
+
+	assert s4.recv.reassembler.data().bytestr() == 'X'
+	assert s4.recv.state == .data_recvd
+
+	// The connection-level window correctly tracked the SUM across all
+	// three streams ('Hello'=5 + 'Foo'=3 + 'X'=1 + 'Bar'=3 + ' World'=6 =
+	// 18 bytes), not just whichever stream was touched last.
+	assert conn_total == 18
+	assert conn_window.advertised_limit() == 1000
+}

--- a/vlib/net/quic/stream_reassembly.v
+++ b/vlib/net/quic/stream_reassembly.v
@@ -1,0 +1,157 @@
+module quic
+
+// Per-stream offset-ordered reassembly (RFC 9000 §2.2, §4.5). Mirrors
+// crypto_stream.v's already-proven validated-append + promote_ready
+// design (same overlap-tolerance and mismatch-detection reasoning applies
+// identically to STREAM data as to CRYPTO data), extended with the one
+// genuine difference: a stream has an explicit FINAL SIZE, learned from
+// either a FIN-carrying STREAM frame or a RESET_STREAM frame, which must
+// be reconciled against everything already received or buffered
+// (FINAL_SIZE_ERROR on mismatch, RFC 9000 §4.5).
+
+// max_stream_buffered_bytes bounds how much data (consumed + out-of-order
+// pending) a single StreamReassembler will ever accept, for the same DoS
+// reason crypto_stream.v's own limit exists -- a peer sending arbitrarily
+// far-future STREAM offsets could otherwise exhaust memory. 1 MiB is
+// generous for a single stream while still bounded; real flow control
+// (flow_control.v) additionally caps this via the advertised
+// max_stream_data limit long before this ceiling would ever matter in
+// practice -- this is a hard backstop, not the primary defense.
+pub const max_stream_buffered_bytes = u64(1) << 20
+
+// max_stream_pending_fragments mirrors
+// max_crypto_stream_pending_fragments's own reasoning: bounds how many
+// DISTINCT out-of-order fragments can accumulate, independent of the
+// byte-range cap above.
+pub const max_stream_pending_fragments = 64
+
+struct StreamDataFragment {
+	offset u64
+	data   []u8
+}
+
+@[heap]
+pub struct StreamReassembler {
+mut:
+	received   []u8
+	pending    []StreamDataFragment
+	final_size ?u64
+}
+
+pub fn new_stream_reassembler() &StreamReassembler {
+	return &StreamReassembler{}
+}
+
+pub fn (r &StreamReassembler) consumed_len() u64 {
+	return u64(r.received.len)
+}
+
+pub fn (r &StreamReassembler) data() []u8 {
+	return r.received
+}
+
+// is_finished reports whether every byte up to the (already learned)
+// final size has been received.
+pub fn (r &StreamReassembler) is_finished() bool {
+	final := r.final_size or { return false }
+	return u64(r.received.len) >= final
+}
+
+// append_or_validate: identical pattern to
+// CryptoStreamReassembler.append_or_validate -- see that function's own
+// doc comment (crypto_stream.v) for the full rationale; duplicated here
+// (rather than shared) because the two reassemblers serve genuinely
+// different structs with different extra concerns (final size tracking
+// has no CRYPTO-stream equivalent), matching how the plan itself treats
+// them as separate files.
+fn (mut r StreamReassembler) append_or_validate(offset u64, data []u8) ! {
+	consumed := u64(r.received.len)
+	if offset > consumed {
+		return error('quic: internal error: append_or_validate called with a gap (offset ${offset} > consumed ${consumed})')
+	}
+	overlap_len := consumed - offset
+	if overlap_len > 0 {
+		n := if u64(data.len) < overlap_len { u64(data.len) } else { overlap_len }
+		if n > 0 && r.received[offset..offset + n] != data[..n] {
+			return error('quic: STREAM data retransmission mismatch at offset ${offset}: overlapping bytes differ from previously received data')
+		}
+	}
+	if u64(data.len) > overlap_len {
+		r.received << data[overlap_len..]
+	}
+}
+
+// note_final_size records the stream's final size (from a FIN-carrying
+// STREAM frame's offset+length, or from RESET_STREAM's Final Size field)
+// and validates it against everything already received or buffered. RFC
+// 9000 §4.5: a final size SMALLER than data already received, or that
+// DISAGREES with an already-established final size, is a
+// FINAL_SIZE_ERROR. Idempotent: calling this again with the SAME value
+// (e.g. a retransmitted FIN) is a no-op, not an error.
+pub fn (mut r StreamReassembler) note_final_size(final_size u64) ! {
+	if existing := r.final_size {
+		if existing != final_size {
+			return error('quic: FINAL_SIZE_ERROR: stream final size changed from ${existing} to ${final_size}')
+		}
+		return
+	}
+	if final_size < u64(r.received.len) {
+		return error('quic: FINAL_SIZE_ERROR: final size ${final_size} is smaller than ${r.received.len} bytes already received')
+	}
+	for frag in r.pending {
+		frag_end := frag.offset + u64(frag.data.len)
+		if frag_end > final_size {
+			return error('quic: FINAL_SIZE_ERROR: a previously received fragment extends to offset ${frag_end}, beyond final size ${final_size}')
+		}
+	}
+	r.final_size = final_size
+}
+
+// add ingests one STREAM frame's (offset, data) into the reassembler.
+// Frames may arrive out of order; both immediately-contiguous and
+// out-of-order fragments are accepted and, for the latter, held until the
+// gap before them closes.
+pub fn (mut r StreamReassembler) add(offset u64, data []u8) ! {
+	if data.len == 0 {
+		return
+	}
+	end := offset + u64(data.len)
+	if end > max_stream_buffered_bytes {
+		return error('quic: STREAM data at offset ${offset} (length ${data.len}) would exceed the ${max_stream_buffered_bytes}-byte buffering limit for this stream')
+	}
+	if final := r.final_size {
+		if end > final {
+			return error('quic: FINAL_SIZE_ERROR: data at offset ${offset} (length ${data.len}) extends to ${end}, beyond final size ${final}')
+		}
+	}
+
+	if offset <= u64(r.received.len) {
+		r.append_or_validate(offset, data)!
+	} else {
+		if r.pending.len >= max_stream_pending_fragments {
+			return error('quic: STREAM has too many out-of-order fragments buffered (limit ${max_stream_pending_fragments})')
+		}
+		r.pending << StreamDataFragment{
+			offset: offset
+			data:   data.clone()
+		}
+	}
+	r.promote_ready()!
+}
+
+fn (mut r StreamReassembler) promote_ready() ! {
+	mut advanced := true
+	for advanced {
+		advanced = false
+		consumed := u64(r.received.len)
+		for i, frag in r.pending {
+			if frag.offset > consumed {
+				continue
+			}
+			r.append_or_validate(frag.offset, frag.data)!
+			r.pending.delete(i)
+			advanced = true
+			break
+		}
+	}
+}

--- a/vlib/net/quic/stream_reassembly.v
+++ b/vlib/net/quic/stream_reassembly.v
@@ -9,14 +9,20 @@ module quic
 // be reconciled against everything already received or buffered
 // (FINAL_SIZE_ERROR on mismatch, RFC 9000 §4.5).
 
-// max_stream_buffered_bytes bounds how much data (consumed + out-of-order
-// pending) a single StreamReassembler will ever accept, for the same DoS
-// reason crypto_stream.v's own limit exists -- a peer sending arbitrarily
-// far-future STREAM offsets could otherwise exhaust memory. 1 MiB is
-// generous for a single stream while still bounded; real flow control
-// (flow_control.v) additionally caps this via the advertised
-// max_stream_data limit long before this ceiling would ever matter in
-// practice -- this is a hard backstop, not the primary defense.
+// max_stream_buffered_bytes bounds how many bytes of BUFFERED-BUT-NOT-YET-
+// CONSUMED data (the contiguous `received` window plus out-of-order
+// `pending` fragments) a single StreamReassembler will ever hold at once --
+// not the stream's total size. discard() lets a caller (the future
+// application-read path, Phase 9) free consumed bytes, sliding this window
+// forward as the stream progresses, so a stream of any total size can be
+// handled as long as the UNCONSUMED portion at any one moment stays under
+// this ceiling. 1 MiB is generous for that window while still bounded, for
+// the same DoS reason crypto_stream.v's own limit exists -- a peer sending
+// arbitrarily far-future STREAM offsets could otherwise exhaust memory.
+// Real flow control (flow_control.v) additionally caps outstanding
+// unconsumed bytes via the advertised max_stream_data limit long before
+// this ceiling would ever matter in practice -- this is a hard backstop,
+// not the primary defense.
 pub const max_stream_buffered_bytes = u64(1) << 20
 
 // max_stream_pending_fragments mirrors
@@ -33,28 +39,59 @@ struct StreamDataFragment {
 @[heap]
 pub struct StreamReassembler {
 mut:
-	received   []u8
-	pending    []StreamDataFragment
-	final_size ?u64
+	// base_offset is the stream-absolute offset of received[0] -- bytes
+	// before this position have already been consumed and discarded, and
+	// `received` holds only the window from base_offset onward.
+	base_offset u64
+	received    []u8
+	pending     []StreamDataFragment
+	final_size  ?u64
 }
 
 pub fn new_stream_reassembler() &StreamReassembler {
 	return &StreamReassembler{}
 }
 
+// consumed_len returns the STREAM-ABSOLUTE offset marking how much has been
+// contiguously received so far. Unaffected by discard(): freeing already-
+// consumed bytes doesn't change how much of the stream has actually
+// arrived, only how much of it this reassembler still holds in memory.
 pub fn (r &StreamReassembler) consumed_len() u64 {
-	return u64(r.received.len)
+	return r.base_offset + u64(r.received.len)
 }
 
+// data returns the currently-HELD window of contiguous bytes, starting at
+// whatever offset base_offset last advanced to via discard() -- NOT
+// necessarily the whole stream from its start.
 pub fn (r &StreamReassembler) data() []u8 {
 	return r.received
+}
+
+// discard drops bytes before `new_base` (a STREAM-ABSOLUTE offset) from the
+// held window, freeing the memory for data the caller has already
+// consumed -- this is what lets total stream size exceed
+// max_stream_buffered_bytes, by keeping the UNCONSUMED window bounded
+// instead of the whole stream. `new_base` must not exceed consumed_len()
+// (discarding data not yet received would silently create a gap this
+// reassembler can no longer detect). Idempotent/tolerant of a stale
+// `new_base` at or before the current base_offset -- a no-op, not an error,
+// since a caller re-confirming consumption it already reported is normal.
+pub fn (mut r StreamReassembler) discard(new_base u64) ! {
+	if new_base <= r.base_offset {
+		return
+	}
+	if new_base > r.consumed_len() {
+		return error('quic: internal error: discard(${new_base}) exceeds consumed_len ${r.consumed_len()}')
+	}
+	r.received = r.received[new_base - r.base_offset..].clone()
+	r.base_offset = new_base
 }
 
 // is_finished reports whether every byte up to the (already learned)
 // final size has been received.
 pub fn (r &StreamReassembler) is_finished() bool {
 	final := r.final_size or { return false }
-	return u64(r.received.len) >= final
+	return r.consumed_len() >= final
 }
 
 // append_or_validate: identical pattern to
@@ -64,20 +101,41 @@ pub fn (r &StreamReassembler) is_finished() bool {
 // different structs with different extra concerns (final size tracking
 // has no CRYPTO-stream equivalent), matching how the plan itself treats
 // them as separate files.
+//
+// `offset` may be BELOW base_offset -- a legitimate retransmission of data
+// already consumed and discarded, which is tolerated silently (there is
+// nothing left to validate it against, and a compliant peer retransmitting
+// old bytes is normal, not a protocol violation) rather than erroring.
 fn (mut r StreamReassembler) append_or_validate(offset u64, data []u8) ! {
-	consumed := u64(r.received.len)
+	consumed := r.consumed_len()
 	if offset > consumed {
 		return error('quic: internal error: append_or_validate called with a gap (offset ${offset} > consumed ${consumed})')
 	}
-	overlap_len := consumed - offset
+	mut off := offset
+	mut skip := u64(0)
+	if off < r.base_offset {
+		skip = r.base_offset - off
+		if skip >= u64(data.len) {
+			return
+		}
+		off = r.base_offset
+	}
+	d := data[skip..]
+
+	local_off := off - r.base_offset
+	overlap_len := u64(r.received.len) - local_off
 	if overlap_len > 0 {
-		n := if u64(data.len) < overlap_len { u64(data.len) } else { overlap_len }
-		if n > 0 && r.received[offset..offset + n] != data[..n] {
-			return error('quic: STREAM data retransmission mismatch at offset ${offset}: overlapping bytes differ from previously received data')
+		n := if u64(d.len) < overlap_len { u64(d.len) } else { overlap_len }
+		if n > 0 && r.received[local_off..local_off + n] != d[..n] {
+			return error('quic: STREAM data retransmission mismatch at offset ${off}: overlapping bytes differ from previously received data')
 		}
 	}
-	if u64(data.len) > overlap_len {
-		r.received << data[overlap_len..]
+	if u64(d.len) > overlap_len {
+		growth := u64(d.len) - overlap_len
+		if u64(r.received.len) + growth > max_stream_buffered_bytes {
+			return error('quic: STREAM data at offset ${offset} (length ${data.len}) would exceed the ${max_stream_buffered_bytes}-byte buffering limit for this stream (consume and discard() received data to free room)')
+		}
+		r.received << d[overlap_len..]
 	}
 }
 
@@ -95,8 +153,9 @@ pub fn (mut r StreamReassembler) note_final_size(final_size u64) ! {
 		}
 		return
 	}
-	if final_size < u64(r.received.len) {
-		return error('quic: FINAL_SIZE_ERROR: final size ${final_size} is smaller than ${r.received.len} bytes already received')
+	consumed := r.consumed_len()
+	if final_size < consumed {
+		return error('quic: FINAL_SIZE_ERROR: final size ${final_size} is smaller than ${consumed} bytes already received')
 	}
 	for frag in r.pending {
 		frag_end := frag.offset + u64(frag.data.len)
@@ -110,26 +169,33 @@ pub fn (mut r StreamReassembler) note_final_size(final_size u64) ! {
 // add ingests one STREAM frame's (offset, data) into the reassembler.
 // Frames may arrive out of order; both immediately-contiguous and
 // out-of-order fragments are accepted and, for the latter, held until the
-// gap before them closes.
+// gap before them closes. The max_stream_buffered_bytes cap is enforced
+// against the UNCONSUMED window (received + pending), not the frame's wire
+// offset -- see append_or_validate for the received-side check and below
+// for the pending-side one.
 pub fn (mut r StreamReassembler) add(offset u64, data []u8) ! {
 	if data.len == 0 {
 		return
 	}
 	end := offset + u64(data.len)
-	if end > max_stream_buffered_bytes {
-		return error('quic: STREAM data at offset ${offset} (length ${data.len}) would exceed the ${max_stream_buffered_bytes}-byte buffering limit for this stream')
-	}
 	if final := r.final_size {
 		if end > final {
 			return error('quic: FINAL_SIZE_ERROR: data at offset ${offset} (length ${data.len}) extends to ${end}, beyond final size ${final}')
 		}
 	}
 
-	if offset <= u64(r.received.len) {
+	if offset <= r.consumed_len() {
 		r.append_or_validate(offset, data)!
 	} else {
 		if r.pending.len >= max_stream_pending_fragments {
 			return error('quic: STREAM has too many out-of-order fragments buffered (limit ${max_stream_pending_fragments})')
+		}
+		mut pending_bytes := u64(0)
+		for frag in r.pending {
+			pending_bytes += u64(frag.data.len)
+		}
+		if pending_bytes + u64(data.len) > max_stream_buffered_bytes {
+			return error('quic: STREAM out-of-order data at offset ${offset} (length ${data.len}) would exceed the ${max_stream_buffered_bytes}-byte buffering limit for this stream')
 		}
 		r.pending << StreamDataFragment{
 			offset: offset
@@ -143,7 +209,7 @@ fn (mut r StreamReassembler) promote_ready() ! {
 	mut advanced := true
 	for advanced {
 		advanced = false
-		consumed := u64(r.received.len)
+		consumed := r.consumed_len()
 		for i, frag in r.pending {
 			if frag.offset > consumed {
 				continue

--- a/vlib/net/quic/stream_reassembly.v
+++ b/vlib/net/quic/stream_reassembly.v
@@ -48,6 +48,8 @@ mut:
 	final_size  ?u64
 }
 
+// new_stream_reassembler constructs an empty reassembler starting at
+// stream offset 0.
 pub fn new_stream_reassembler() &StreamReassembler {
 	return &StreamReassembler{}
 }

--- a/vlib/net/quic/stream_reassembly_test.v
+++ b/vlib/net/quic/stream_reassembly_test.v
@@ -1,0 +1,135 @@
+module quic
+
+fn test_stream_reassembler_in_order() {
+	mut r := new_stream_reassembler()
+	r.add(0, 'hello'.bytes())!
+	r.add(5, 'world'.bytes())!
+	assert r.data().bytestr() == 'helloworld'
+	assert r.consumed_len() == 10
+}
+
+fn test_stream_reassembler_out_of_order() {
+	mut r := new_stream_reassembler()
+	r.add(5, 'world'.bytes())!
+	assert r.consumed_len() == 0
+	r.add(0, 'hello'.bytes())!
+	assert r.data().bytestr() == 'helloworld'
+}
+
+fn test_stream_reassembler_tolerates_identical_overlap() {
+	mut r := new_stream_reassembler()
+	r.add(0, 'hello'.bytes())!
+	r.add(0, 'hello'.bytes())!
+	assert r.data().bytestr() == 'hello'
+	r.add(3, 'lo world'.bytes())!
+	assert r.data().bytestr() == 'hello world'
+}
+
+fn test_stream_reassembler_rejects_mismatched_overlap() {
+	mut r := new_stream_reassembler()
+	r.add(0, 'hello'.bytes())!
+	r.add(3, 'XX world'.bytes()) or {
+		assert err.msg().contains('retransmission mismatch')
+		return
+	}
+	assert false, 'expected a mismatched overlap to be rejected'
+}
+
+fn test_stream_reassembler_rejects_mismatch_between_two_pending_fragments() {
+	mut r := new_stream_reassembler()
+	r.add(10, 'AAAA'.bytes())!
+	r.add(12, 'BBBB'.bytes())!
+	r.add(0, '0123456789'.bytes()) or {
+		assert err.msg().contains('retransmission mismatch')
+		return
+	}
+	assert false, 'expected the pending-fragment mismatch to be rejected once promoted'
+}
+
+fn test_stream_reassembler_rejects_data_beyond_buffering_limit() {
+	mut r := new_stream_reassembler()
+	offset := max_stream_buffered_bytes - 2
+	r.add(offset, []u8{len: 100}) or {
+		assert err.msg().contains('buffering limit')
+		return
+	}
+	assert false, 'expected data past the buffering limit to be rejected'
+}
+
+fn test_stream_reassembler_rejects_too_many_pending_fragments() {
+	mut r := new_stream_reassembler()
+	mut last_err_seen := false
+	for i in 0 .. max_stream_pending_fragments + 10 {
+		offset := u64(2 + i * 2)
+		r.add(offset, [u8(0x42)]) or {
+			assert err.msg().contains('too many out-of-order fragments')
+			last_err_seen = true
+			break
+		}
+	}
+	assert last_err_seen
+}
+
+fn test_stream_reassembler_note_final_size_basic_and_is_finished() {
+	mut r := new_stream_reassembler()
+	assert r.is_finished() == false
+	r.add(0, 'hello'.bytes())!
+	assert r.is_finished() == false
+	r.note_final_size(5)!
+	assert r.is_finished() == true
+}
+
+fn test_stream_reassembler_note_final_size_before_all_data_arrives() {
+	mut r := new_stream_reassembler()
+	r.note_final_size(5)!
+	assert r.is_finished() == false
+	r.add(0, 'hello'.bytes())!
+	assert r.is_finished() == true
+}
+
+fn test_stream_reassembler_note_final_size_is_idempotent_for_same_value() {
+	mut r := new_stream_reassembler()
+	r.note_final_size(10)!
+	r.note_final_size(10)! // e.g. a retransmitted FIN -- must not error
+	assert r.is_finished() == false
+}
+
+fn test_stream_reassembler_rejects_final_size_smaller_than_received() {
+	mut r := new_stream_reassembler()
+	r.add(0, 'hello world'.bytes())! // 11 bytes
+	r.note_final_size(5) or {
+		assert err.msg().contains('FINAL_SIZE_ERROR')
+		return
+	}
+	assert false, 'expected a final size smaller than already-received data to be rejected'
+}
+
+fn test_stream_reassembler_rejects_conflicting_final_size() {
+	mut r := new_stream_reassembler()
+	r.note_final_size(100)!
+	r.note_final_size(200) or {
+		assert err.msg().contains('FINAL_SIZE_ERROR')
+		return
+	}
+	assert false, 'expected a changed final size to be rejected'
+}
+
+fn test_stream_reassembler_rejects_final_size_conflicting_with_pending_fragment() {
+	mut r := new_stream_reassembler()
+	r.add(50, [u8(1), 2, 3])! // pending: covers offset [50,53)
+	r.note_final_size(52) or {
+		assert err.msg().contains('FINAL_SIZE_ERROR')
+		return
+	}
+	assert false, 'expected a final size conflicting with a pending fragment to be rejected'
+}
+
+fn test_stream_reassembler_add_rejects_data_beyond_known_final_size() {
+	mut r := new_stream_reassembler()
+	r.note_final_size(10)!
+	r.add(8, [u8(1), 2, 3, 4]) or {
+		assert err.msg().contains('FINAL_SIZE_ERROR')
+		return
+	}
+	assert false, 'expected data extending past a known final size to be rejected'
+}

--- a/vlib/net/quic/stream_reassembly_test.v
+++ b/vlib/net/quic/stream_reassembly_test.v
@@ -46,14 +46,98 @@ fn test_stream_reassembler_rejects_mismatch_between_two_pending_fragments() {
 	assert false, 'expected the pending-fragment mismatch to be rejected once promoted'
 }
 
+fn test_stream_reassembler_discard_frees_held_window_and_preserves_consumed_len() {
+	mut r := new_stream_reassembler()
+	r.add(0, 'helloworld'.bytes())!
+	r.discard(5)!
+	assert r.data().bytestr() == 'world'
+	assert r.consumed_len() == 10 // unchanged -- discard doesn't un-receive data
+}
+
+fn test_stream_reassembler_discard_is_idempotent_for_a_stale_base() {
+	mut r := new_stream_reassembler()
+	r.add(0, 'helloworld'.bytes())!
+	r.discard(5)!
+	r.discard(5)! // same value again
+	r.discard(2)! // an OLDER value -- also a no-op, not a regression
+	assert r.data().bytestr() == 'world'
+}
+
+fn test_stream_reassembler_discard_rejects_base_beyond_consumed_len() {
+	mut r := new_stream_reassembler()
+	r.add(0, 'hello'.bytes())!
+	r.discard(10) or {
+		assert err.msg().contains('exceeds consumed_len')
+		return
+	}
+	assert false, 'expected discard() past consumed_len to be rejected'
+}
+
+fn test_stream_reassembler_tolerates_retransmission_of_already_discarded_data() {
+	mut r := new_stream_reassembler()
+	r.add(0, 'helloworld'.bytes())!
+	r.discard(5)!
+	// A retransmission of "hello" (now entirely below base_offset) must be
+	// tolerated silently -- there's nothing left to validate it against,
+	// and a compliant peer retransmitting already-consumed bytes is normal.
+	r.add(0, 'hello'.bytes())!
+	assert r.data().bytestr() == 'world'
+}
+
+fn test_stream_reassembler_validates_retransmission_straddling_the_discard_boundary() {
+	mut r := new_stream_reassembler()
+	r.add(0, 'helloworld'.bytes())!
+	r.discard(5)!
+	// "hello" + "wor" -- the "hello" prefix is below base_offset (skipped),
+	// "wor" straddles into the still-held window and must still be
+	// validated against it.
+	r.add(0, 'helloXXX'.bytes()) or {
+		assert err.msg().contains('retransmission mismatch')
+		return
+	}
+	assert false, 'expected a mismatch straddling the discard boundary to be rejected'
+}
+
+// test_stream_reassembler_rejects_data_beyond_buffering_limit is a
+// Phase-R regression for a Copilot finding on vlang/v#27882
+// (pullrequestreview-4888843234): the cap must bound BUFFERED-BUT-NOT-YET-
+// CONSUMED bytes, not the wire offset a fragment happens to land at -- a
+// single small out-of-order fragment landing near a large offset (the
+// scenario this test originally covered) is now correctly ACCEPTED (it's
+// a legitimate, cheap-to-buffer fragment regardless of where in the stream
+// it lands); only the actual pending-byte SUM exceeding the cap is
+// rejected.
 fn test_stream_reassembler_rejects_data_beyond_buffering_limit() {
 	mut r := new_stream_reassembler()
 	offset := max_stream_buffered_bytes - 2
-	r.add(offset, []u8{len: 100}) or {
+	r.add(offset, []u8{len: 100})! // accepted: a small fragment, regardless of its offset
+
+	mut r2 := new_stream_reassembler()
+	r2.add(u64(1) << 30, []u8{len: int(max_stream_buffered_bytes) + 1}) or {
 		assert err.msg().contains('buffering limit')
 		return
 	}
-	assert false, 'expected data past the buffering limit to be rejected'
+	assert false, 'expected pending data exceeding the buffering limit to be rejected'
+}
+
+// test_stream_reassembler_supports_streams_larger_than_the_buffering_limit
+// is the Phase-R reproduction proper: with discard() freeing consumed
+// bytes as the caller goes, a stream's TOTAL size can exceed
+// max_stream_buffered_bytes -- the exact scenario the pre-fix cap (which
+// bounded absolute stream position, not buffered memory) made impossible
+// even for entirely in-order data.
+fn test_stream_reassembler_supports_streams_larger_than_the_buffering_limit() {
+	mut r := new_stream_reassembler()
+	chunk := []u8{len: 1024, init: 0x41}
+	mut offset := u64(0)
+	total_chunks := int(max_stream_buffered_bytes / 1024) + 10 // deliberately past the old absolute cap
+	for _ in 0 .. total_chunks {
+		r.add(offset, chunk)!
+		offset += u64(chunk.len)
+		r.discard(r.consumed_len())! // simulate the application immediately consuming each chunk
+	}
+	assert r.consumed_len() == offset
+	assert r.consumed_len() > max_stream_buffered_bytes
 }
 
 fn test_stream_reassembler_rejects_too_many_pending_fragments() {

--- a/vlib/net/quic/stream_test.v
+++ b/vlib/net/quic/stream_test.v
@@ -1,0 +1,224 @@
+module quic
+
+fn test_stream_id_category_derivation_all_four_combinations() {
+	client_bidi := StreamId{
+		value: 0
+	}
+	assert client_bidi.initiator() == .client
+	assert client_bidi.direction() == .bidirectional
+
+	server_bidi := StreamId{
+		value: 1
+	}
+	assert server_bidi.initiator() == .server
+	assert server_bidi.direction() == .bidirectional
+
+	client_uni := StreamId{
+		value: 2
+	}
+	assert client_uni.initiator() == .client
+	assert client_uni.direction() == .unidirectional
+
+	server_uni := StreamId{
+		value: 3
+	}
+	assert server_uni.initiator() == .server
+	assert server_uni.direction() == .unidirectional
+
+	// Successive streams in a category are always +4.
+	next_client_bidi := StreamId{
+		value: 4
+	}
+	assert next_client_bidi.initiator() == .client
+	assert next_client_bidi.direction() == .bidirectional
+}
+
+fn assert_first_stream_id_round_trips(initiator StreamInitiator, direction StreamDirection) {
+	id := StreamId{
+		value: first_stream_id_of(initiator, direction)
+	}
+	assert id.initiator() == initiator
+	assert id.direction() == direction
+}
+
+fn test_first_stream_id_of_matches_category_derivation() {
+	assert_first_stream_id_round_trips(.client, .bidirectional)
+	assert_first_stream_id_round_trips(.server, .bidirectional)
+	assert_first_stream_id_round_trips(.client, .unidirectional)
+	assert_first_stream_id_round_trips(.server, .unidirectional)
+}
+
+fn test_is_locally_initiated_for_both_roles() {
+	client_bidi := StreamId{
+		value: 0
+	}
+	assert client_bidi.is_locally_initiated(.client) == true
+	assert client_bidi.is_locally_initiated(.server) == false
+
+	server_uni := StreamId{
+		value: 3
+	}
+	assert server_uni.is_locally_initiated(.client) == false
+	assert server_uni.is_locally_initiated(.server) == true
+}
+
+fn test_new_quic_stream_bidi_gets_both_halves_regardless_of_initiator() {
+	client_bidi_id := StreamId{
+		value: 0
+	}
+	s1 := new_quic_stream(client_bidi_id, .client)
+	assert s1.has_send()
+	assert s1.has_recv()
+
+	server_bidi_id := StreamId{
+		value: 1
+	}
+	s2 := new_quic_stream(server_bidi_id, .client)
+	assert s2.has_send()
+	assert s2.has_recv()
+}
+
+fn test_new_quic_stream_locally_initiated_uni_is_send_only() {
+	client_uni_id := StreamId{
+		value: 2
+	}
+	s := new_quic_stream(client_uni_id, .client)
+	assert s.has_send()
+	assert !s.has_recv()
+}
+
+// test_new_quic_stream_peer_initiated_uni_is_recv_only is the plan's own
+// explicitly named test: "even client-first phase must correctly receive
+// server-initiated unidirectional streams from day one" -- confirms a
+// server-initiated uni stream, from the client's own perspective, has
+// exactly a receive half and no send half (this client can never send on
+// a stream the SERVER opened unidirectionally).
+fn test_new_quic_stream_peer_initiated_uni_is_recv_only() {
+	server_uni_id := StreamId{
+		value: 3
+	}
+	s := new_quic_stream(server_uni_id, .client)
+	assert !s.has_send()
+	assert s.has_recv()
+}
+
+fn test_quic_stream_set_get_or_create_auto_creates_lower_numbered_streams() {
+	mut set := new_quic_stream_set(.client)
+	// Stream 9 is server-initiated bidi (9 & 0x03 == 1), the 3rd stream in
+	// that category (ids 1, 5, 9). Referencing it directly must also
+	// create 1 and 5.
+	stream := set.get_or_create(9, 100)!
+	assert stream.id.value == 9
+	assert set.len() == 3
+	assert set.get(1) != none
+	assert set.get(5) != none
+	assert set.get(9) != none
+}
+
+fn test_quic_stream_set_get_or_create_rejects_locally_initiated_unknown_id() {
+	mut set := new_quic_stream_set(.client)
+	// Stream 0 is client-initiated bidi -- this client's own to open, not
+	// something a peer frame referencing it can conjure into existence.
+	set.get_or_create(0, 100) or {
+		assert err.msg().contains('STREAM_STATE_ERROR')
+		return
+	}
+	assert false, 'expected referencing an unopened locally-initiated stream to be rejected'
+}
+
+fn test_quic_stream_set_get_or_create_enforces_max_streams_limit() {
+	mut set := new_quic_stream_set(.client)
+	// Server-initiated bidi streams: 1, 5, 9, 13, ... -- id 13 is the 4th
+	// (index 3), requiring max_streams >= 4.
+	set.get_or_create(13, 4)! // exactly at the limit: allowed
+	assert set.len() == 4
+
+	mut set2 := new_quic_stream_set(.client)
+	set2.get_or_create(13, 3) or {
+		assert err.msg().contains('STREAM_LIMIT_ERROR')
+		return
+	}
+	assert false, 'expected exceeding max_streams to be rejected'
+}
+
+fn test_open_local_stream_allocates_sequential_ids() {
+	mut set := new_quic_stream_set(.client)
+	first := set.open_local_stream(.bidirectional)
+	assert first.id.value == 0
+	second := set.open_local_stream(.bidirectional)
+	assert second.id.value == 4
+	third := set.open_local_stream(.bidirectional)
+	assert third.id.value == 8
+
+	// A separate counter for uni streams, starting at the uni base (2 for
+	// client), independent of the bidi counter above.
+	uni_first := set.open_local_stream(.unidirectional)
+	assert uni_first.id.value == 2
+	uni_second := set.open_local_stream(.unidirectional)
+	assert uni_second.id.value == 6
+
+	assert set.len() == 5
+	assert set.get(0) != none
+}
+
+fn test_open_local_stream_registers_in_the_set() {
+	mut set := new_quic_stream_set(.client)
+	opened := set.open_local_stream(.bidirectional)
+	found := set.get(opened.id.value) or {
+		assert false, 'expected open_local_stream to register the stream'
+		return
+	}
+	assert found.id.value == opened.id.value
+}
+
+fn test_quic_stream_set_get_returns_none_for_unknown_stream() {
+	set := new_quic_stream_set(.client)
+	assert set.get(0) == none
+}
+
+fn test_send_half_state_transitions() {
+	mut h := StreamSendHalf{}
+	assert h.state == .ready
+	h.mark_data_queued()
+	assert h.state == .send
+	h.mark_fin_sent(100)
+	assert h.state == .data_sent
+	assert h.final_size or { 0 } == 100
+}
+
+fn test_send_half_reset_from_ready() {
+	mut h := StreamSendHalf{}
+	h.mark_reset_sent(7)
+	assert h.state == .reset_sent
+	assert h.error_code or { 0 } == 7
+}
+
+fn test_recv_half_state_transitions_data_then_fin() {
+	mut h := StreamRecvHalf{
+		reassembler: new_stream_reassembler()
+	}
+	assert h.state == .recv
+	h.note_data(0, [u8(1), 2, 3])!
+	assert h.state == .recv // final size still unknown
+	h.note_size_known(3)!
+	assert h.state == .data_recvd // all 3 bytes already present
+}
+
+fn test_recv_half_state_transitions_fin_before_all_data() {
+	mut h := StreamRecvHalf{
+		reassembler: new_stream_reassembler()
+	}
+	h.note_size_known(5)!
+	assert h.state == .size_known // final size known, but no data yet
+	h.note_data(0, [u8(1), 2, 3, 4, 5])!
+	assert h.state == .data_recvd
+}
+
+fn test_recv_half_reset_recvd() {
+	mut h := StreamRecvHalf{
+		reassembler: new_stream_reassembler()
+	}
+	h.mark_reset_recvd(4)
+	assert h.state == .reset_recvd
+	assert h.error_code or { 0 } == 4
+}

--- a/vlib/net/quic/stream_test.v
+++ b/vlib/net/quic/stream_test.v
@@ -222,3 +222,27 @@ fn test_recv_half_reset_recvd() {
 	assert h.state == .reset_recvd
 	assert h.error_code or { 0 } == 4
 }
+
+// test_recv_half_reset_recvd_is_not_clobbered_by_a_reordered_data_frame and
+// its note_size_known sibling below are Phase-R regressions for a Copilot
+// finding on vlang/v#27882 (pullrequestreview-4888843234): RFC 9000 §3.2's
+// Receive Stream State Machine makes Reset Recvd terminal -- a STREAM frame
+// that raced ahead of the RESET_STREAM on the wire and arrives afterward
+// must not be allowed to promote the half back to data_recvd.
+fn test_recv_half_reset_recvd_is_not_clobbered_by_a_reordered_data_frame() {
+	mut h := StreamRecvHalf{
+		reassembler: new_stream_reassembler()
+	}
+	h.mark_reset_recvd(4)
+	h.note_data(0, [u8(1), 2, 3, 4, 5])!
+	assert h.state == .reset_recvd
+}
+
+fn test_recv_half_reset_recvd_is_not_clobbered_by_a_reordered_size_known_frame() {
+	mut h := StreamRecvHalf{
+		reassembler: new_stream_reassembler()
+	}
+	h.mark_reset_recvd(4)
+	h.note_size_known(5)!
+	assert h.state == .reset_recvd
+}

--- a/vlib/net/quic/stream_test.v
+++ b/vlib/net/quic/stream_test.v
@@ -214,13 +214,67 @@ fn test_recv_half_state_transitions_fin_before_all_data() {
 	assert h.state == .data_recvd
 }
 
+// test_send_half_reset_sent_does_not_regress_from_data_recvd and its
+// reset_recvd sibling below are Phase-R regressions for a "Local AI Review"
+// finding on vlang/v#27882 (2026-08-11): RFC 9000 §3.1's Sending Stream
+// State Machine draws "Send RESET_STREAM" only from Ready/Send/Data Sent,
+// and its prose states a sender MUST NOT send RESET_STREAM from a terminal
+// state (Data Recvd or Reset Recvd) -- mark_reset_sent had no such guard.
+fn test_send_half_reset_sent_does_not_regress_from_data_recvd() {
+	mut h := StreamSendHalf{}
+	h.mark_fin_sent(100)
+	h.state = .data_recvd // simulate all data ACKed
+	h.mark_reset_sent(7)
+	assert h.state == .data_recvd
+}
+
+fn test_send_half_reset_sent_does_not_regress_from_reset_recvd() {
+	mut h := StreamSendHalf{}
+	h.mark_reset_sent(7)
+	h.state = .reset_recvd // simulate the RESET_STREAM's own ACK arriving
+	h.mark_reset_sent(9)
+	assert h.state == .reset_recvd
+	assert h.error_code or { 0 } == 7 // unchanged from the original reset
+}
+
 fn test_recv_half_reset_recvd() {
 	mut h := StreamRecvHalf{
 		reassembler: new_stream_reassembler()
 	}
-	h.mark_reset_recvd(4)
+	h.mark_reset_recvd(4, 10)!
 	assert h.state == .reset_recvd
 	assert h.error_code or { 0 } == 4
+	assert h.final_size or { 0 } == 10
+}
+
+// test_recv_half_reset_recvd_rejects_final_size_smaller_than_already_received
+// and its established-final-size sibling below are Phase-R regressions for a
+// "Local AI Review" finding on vlang/v#27882 (2026-08-11): mark_reset_recvd
+// never reconciled RESET_STREAM's own Final Size field against the
+// reassembler (RFC 9000 §4.5), unlike note_size_known's identical
+// obligation for a FIN-carrying STREAM frame's final size.
+fn test_recv_half_reset_recvd_rejects_final_size_smaller_than_already_received() {
+	mut h := StreamRecvHalf{
+		reassembler: new_stream_reassembler()
+	}
+	h.note_data(0, [u8(1), 2, 3, 4, 5])!
+	h.mark_reset_recvd(4, 3) or {
+		assert err.msg().contains('FINAL_SIZE_ERROR')
+		return
+	}
+	assert false, 'expected a reset final size smaller than already-received data to be rejected'
+}
+
+fn test_recv_half_reset_recvd_rejects_final_size_conflicting_with_known_final_size() {
+	mut h := StreamRecvHalf{
+		reassembler: new_stream_reassembler()
+	}
+	h.note_size_known(10)!
+	h.mark_reset_recvd(4, 20) or {
+		assert err.msg().contains('FINAL_SIZE_ERROR')
+		return
+	}
+	assert false, 'expected a reset final size disagreeing with an established final size to be rejected'
 }
 
 // test_recv_half_reset_recvd_is_not_clobbered_by_a_reordered_data_frame and
@@ -233,7 +287,7 @@ fn test_recv_half_reset_recvd_is_not_clobbered_by_a_reordered_data_frame() {
 	mut h := StreamRecvHalf{
 		reassembler: new_stream_reassembler()
 	}
-	h.mark_reset_recvd(4)
+	h.mark_reset_recvd(4, 10)!
 	h.note_data(0, [u8(1), 2, 3, 4, 5])!
 	assert h.state == .reset_recvd
 }
@@ -242,7 +296,7 @@ fn test_recv_half_reset_recvd_is_not_clobbered_by_a_reordered_size_known_frame()
 	mut h := StreamRecvHalf{
 		reassembler: new_stream_reassembler()
 	}
-	h.mark_reset_recvd(4)
+	h.mark_reset_recvd(4, 10)!
 	h.note_size_known(5)!
 	assert h.state == .reset_recvd
 }


### PR DESCRIPTION
## Summary

Phase 6 of HTTP/3/QUIC support (#27675): the stream layer and flow
control, continuing from the completed Phase 5 work in #27881 (full
handshake completion). Builds on the completed Phase 0-5 foundation —
#27680, #27877, #27880, #27881 — all merged, and targets `master` directly.

See [`vlib/net/quic/PROGRESS.md`](https://github.com/quaesitor-scientiam/v/blob/http3-quic-stream-layer/vlib/net/quic/PROGRESS.md)
for the exact phase-by-phase checklist.

## Scope

- `frame.v` extended with every stream-related frame: STREAM, RESET_STREAM,
  STOP_SENDING, MAX_DATA, MAX_STREAM_DATA, MAX_STREAMS, DATA_BLOCKED,
  STREAM_DATA_BLOCKED, STREAMS_BLOCKED.
- `stream.v` — `QuicStream`, stream ID categories (RFC 9000 §2.1:
  client/server-initiated, bidirectional/unidirectional, encoded in the
  low 2 bits), independent send/receive state machines per bidi stream.
  Even this client-first phase must correctly receive server-initiated
  unidirectional streams from day one -- HTTP/3's control stream and
  QPACK encoder/decoder streams are all server-to-client uni streams,
  not deferrable to a later server-support phase.
- `flow_control.v` — connection- and stream-level windows enforced
  together (a frame within its own stream's window can still be blocked
  by the connection-level aggregate window and vice versa); three
  separate stream-level initial limits depending on who opened the stream
  and its directionality; auto-window-growth heuristic to avoid
  throughput stalls; RESET_STREAM's Final Size reconciled against
  previously-received offsets (FINAL_SIZE_ERROR on mismatch).
- `stream_reassembly.v` — per-stream offset-ordered reassembly, mirroring
  Phase 4's crypto_stream.v pattern but for STREAM frames' implicit-length-
  at-end-of-packet handling.

## Test plan

- [x] Stream-ID category derivation (all 4 combinations) -- both directions
      (`id -> category` and `category -> first id`).
- [x] Peer-initiated uni-stream acceptance -- the plan's own explicitly
      named test, confirming a server-initiated uni stream has exactly a
      receive half and no send half from the client's perspective, plus
      exercised end-to-end in the integration test below.
- [x] Connection-vs-stream window interplay -- both directions (a tight
      connection window blocking a send the stream window alone would
      allow, and vice versa).
- [x] FINAL_SIZE_ERROR on conflicting final size -- covers a final size
      smaller than already-received data, a final size that later changes,
      a final size conflicting with an already-buffered out-of-order
      fragment, and data arriving after the final size that would exceed it.
- [x] Multi-stream interleaved integration test -- three streams (client
      bidi, server-initiated uni, second client bidi), STREAM frames
      delivered genuinely interleaved and out of order, each independently
      reassembled while one connection-level window tracks the running
      total across all three.
- [x] All new/modified code passing under `./vnew test <path>` -- 28/28
      files in `vlib/net/quic/`.
- [x] `./vnew fmt -w` applied to all touched `.v` files.
- [x] Branch rebased onto `upstream/master` (2026-08-07) now that #27881
      merged (also via squash) -- clean `git rebase --onto`, no test
      adaptation needed (unlike #27881's rebase, no upstream validation
      change broke this branch's own tests).

`/vreview` (full A-G pass, run once while writing this phase and again
after the rebase before push) found and fixed:

**Before commit:** `QuicStream.send`/`recv` were Optional VALUE fields, so
mutating the unwrapped copy via `note_data()`/`note_size_known()` looked
like in-place mutation but silently didn't persist unless the caller
remembered to reassign it back (`s.recv = recv`) -- a future caller could
easily miss this and get stale `state`/`final_size` while the underlying
data was still correct. Fixed by switching to nilable pointers (matching
`Tls13ClientHandshake.verified_chain`'s established convention) before any
real caller could hit it, eliminating the bug class rather than
documenting the trap. Also fixed two mechanical V-compiler quirks along
the way: `match` on a repeated array-index expression (`frames[N]`) stops
reliably narrowing a sum type once it has enough variants -- affected two
*pre-existing* tests in `frame_test.v`/`initial_exchange_test.v` that had
worked fine with fewer variants -- and a pre-existing "frame type 0x08 is
unimplemented" test that became false once this phase implemented STREAM
frames at that exact value (retargeted to 0x1e/HANDSHAKE_DONE).

**After the rebase, before push:** 2 confirmed sibling-parity gaps, both
citations verified against the primary RFC 9000 text before fixing.
`parse_stream_frame`/`encode_stream_frame` were missing RFC 9000 §19.8's
"offset + length ≤ 2^62-1" bound -- identical to §19.6's CRYPTO-frame
requirement, which `parse_crypto_frame`/`encode_crypto_frame` already
correctly enforce in this same file. `parse_max_streams_frame`/
`encode_max_streams_frame` were missing RFC 9000 §4.6's 2^60 cap --
already correctly enforced (with its own boundary tests) on the
transport-parameter half of the identical requirement in
`transport_parameters.v`. Fixed both, 5 new regression tests. Also
documented (not changed, since it's plausibly a future Phase 9 caller's
responsibility): `open_local_stream` has no `max_streams` enforcement,
unlike its receive-side sibling `get_or_create`.

🧙 Built with [WOZCODE](https://wozcode.com)
