### PR TITLE
v3: accelerate development builds with module caching

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -139,6 +139,24 @@ fn (mut d DenseArray) trim_deleted_tail() {
 	}
 }
 
+fn (mut d DenseArray) reserve(n int) {
+	if n <= d.cap {
+		return
+	}
+	old_cap := d.cap
+	old_key_size := d.key_bytes * old_cap
+	old_value_size := d.value_bytes * old_cap
+	d.cap = n
+	unsafe {
+		d.keys = realloc_data(d.keys, old_key_size, d.key_bytes * d.cap)
+		d.values = realloc_data(d.values, old_value_size, d.value_bytes * d.cap)
+		if d.deletes != 0 {
+			d.all_deleted = realloc_data(d.all_deleted, old_cap, d.cap)
+			vmemset(voidptr(d.all_deleted + d.len), 0, d.cap - d.len)
+		}
+	}
+}
+
 // Make space to append an element and return index
 // The growth-factor is roughly 1.125 `(x + (x >> 3))`
 @[inline]
@@ -565,6 +583,11 @@ pub fn (mut m map) reserve(n u32) {
 	for u64(n) * 5 > u64(m.even_index) * 2 {
 		m.expand()
 	}
+	dense_cap := u64(n) + u64(m.key_values.deletes)
+	if dense_cap > u64(max_int) {
+		panic('map.reserve: max_int will be exceeded')
+	}
+	m.key_values.reserve(int(dense_cap))
 }
 
 // cached_rehashd works like rehash. However, instead of rehashing the

--- a/vlib/builtin/map_delete_reclaim_test.v
+++ b/vlib/builtin/map_delete_reclaim_test.v
@@ -44,3 +44,17 @@ fn test_map_delete_reclaims_dense_array_tail() {
 		assert raw.key_values.all_deleted == unsafe { nil }
 	}
 }
+
+fn test_map_reserve_preallocates_dense_array() {
+	mut m := map[string]int{}
+	raw := unsafe { &MapLayoutForTest(&m) }
+	m.reserve(1000)
+	assert raw.key_values.cap >= 1000
+	keys := raw.key_values.keys
+	values := raw.key_values.values
+	for i in 0 .. 1000 {
+		m[i.str()] = i
+	}
+	assert raw.key_values.keys == keys
+	assert raw.key_values.values == values
+}

--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -340,7 +340,7 @@ fn vmemory_block_malloc(n isize, align isize) &u8 {
 				mb.mallocs++
 			}
 		}
-		$if trace_prealloc ? {
+		$if prealloc_trace_malloc ? {
 			if mb.is_scope {
 				used := vmemory_block_used(mb)
 				size := vmemory_block_size(mb)
@@ -678,6 +678,51 @@ pub fn prealloc_scope_leave(scope_ptr voidptr) {
 		scope := &VPreallocScope(scope_ptr)
 		prealloc_trace_scope(c'leave', scope)
 		prealloc_scope_detach_current(scope)
+	}
+}
+
+// prealloc_scope_suspend temporarily makes the parent of the active nested
+// arena current. The returned state must be passed to
+// `prealloc_scope_resume` before the nested arena is left or freed.
+@[unsafe]
+pub fn prealloc_scope_suspend(scope_ptr voidptr) voidptr {
+	if scope_ptr == unsafe { nil } {
+		return unsafe { nil }
+	}
+	unsafe {
+		scope := &VPreallocScope(scope_ptr)
+		current := g_memory_block
+		if current == nil || current.scope != scope || scope.previous == nil {
+			return nil
+		}
+		parent := scope.previous
+		parent.next = nil
+		scope.first.previous = nil
+		scope.previous = nil
+		g_memory_block = parent
+		return current
+	}
+}
+
+// prealloc_scope_resume restores a nested arena suspended with
+// `prealloc_scope_suspend`, attaching it after any parent blocks allocated
+// while it was suspended.
+@[unsafe]
+pub fn prealloc_scope_resume(scope_ptr voidptr, state voidptr) {
+	if scope_ptr == unsafe { nil } || state == unsafe { nil } {
+		return
+	}
+	unsafe {
+		scope := &VPreallocScope(scope_ptr)
+		current := &VMemoryBlock(state)
+		parent := g_memory_block
+		if current.scope != scope || scope.previous != nil || parent == nil {
+			return
+		}
+		parent.next = scope.first
+		scope.first.previous = parent
+		scope.previous = parent
+		g_memory_block = current
 	}
 }
 

--- a/vlib/builtin/prealloc_scope_ownership_test.v
+++ b/vlib/builtin/prealloc_scope_ownership_test.v
@@ -13,3 +13,21 @@ fn test_prealloc_scope_owns_multiple_blocks() {
 		unsafe { prealloc_scope_free_after(scope) }
 	}
 }
+
+fn test_prealloc_scope_suspend_allocates_in_parent() {
+	$if prealloc {
+		scope := unsafe { prealloc_scope_begin() }
+		scoped := 'scoped allocation'.clone()
+		state := unsafe { prealloc_scope_suspend(scope) }
+		parent := 'parent allocation'.clone()
+		unsafe { prealloc_scope_resume(scope, state) }
+		resumed := 'resumed scoped allocation'.clone()
+		assert unsafe { prealloc_scope_owns(scope, scoped.str) }
+		assert !unsafe { prealloc_scope_owns(scope, parent.str) }
+		assert unsafe { prealloc_scope_owns(scope, resumed.str) }
+		unsafe { prealloc_scope_leave(scope) }
+		assert parent == 'parent allocation'
+		unsafe { prealloc_scope_free_after(scope) }
+		assert parent == 'parent allocation'
+	}
+}

--- a/vlib/gg/gg_darwin.c.v
+++ b/vlib/gg/gg_darwin.c.v
@@ -4,21 +4,21 @@ module gg
 
 fn C.gg_get_screen_size() Size
 
-fn C.darwin_draw_string(x i32, y i32, s string, cfg voidptr)
+fn C.darwin_draw_string(x i32, y i32, s string, cfg TextCfg)
 
 fn C.darwin_text_width(s string) i32
 
-fn C.darwin_text_width_with_cfg(s string, cfg voidptr) i32
+fn C.darwin_text_width_with_cfg(s string, cfg TextCfg) i32
 
 fn C.darwin_text_width_runes(r []rune) i32
 
 fn C.darwin_window_refresh()
 
-fn C.darwin_draw_rect(f32, f32, f32, f32, voidptr)
+fn C.darwin_draw_rect(f32, f32, f32, f32, Color)
 
 fn C.darwin_create_image(path string) Image
 
 fn C.darwin_draw_image(f32, f32, f32, f32, &Image)
 
-fn C.darwin_draw_circle(f32, f32, f32, voidptr)
-fn C.darwin_draw_circle_empty(f32, f32, f32, voidptr)
+fn C.darwin_draw_circle(f32, f32, f32, Color)
+fn C.darwin_draw_circle_empty(f32, f32, f32, Color)

--- a/vlib/macos/objc_bridge.h
+++ b/vlib/macos/objc_bridge.h
@@ -1,6 +1,35 @@
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#ifdef __TINYC__
+typedef void* id;
+typedef void* Class;
+typedef void* SEL;
+typedef void* IMP;
+typedef void Protocol;
+typedef void* Ivar;
+typedef uintptr_t objc_AssociationPolicy;
+
+id objc_getClass(const char*);
+Protocol* objc_getProtocol(const char*);
+SEL sel_registerName(const char*);
+Class objc_allocateClassPair(Class, const char*, size_t);
+void objc_registerClassPair(Class);
+bool class_addMethod(Class, SEL, IMP, const char*);
+bool class_addIvar(Class, const char*, size_t, uint8_t, const char*);
+bool class_addProtocol(Class, Protocol*);
+void objc_setAssociatedObject(id, const void*, id, objc_AssociationPolicy);
+id objc_getAssociatedObject(id, const void*);
+Class object_getClass(id);
+Ivar class_getInstanceVariable(Class, const char*);
+ptrdiff_t ivar_getOffset(Ivar);
+void objc_msgSend(void);
+
+#define __bridge
+#else
 #include <objc/message.h>
 #include <objc/runtime.h>
+#endif
 
 typedef struct macos_rect {
 	double x;

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -95,6 +95,9 @@ interfaces were parsed by that build. Required compile-time bodies are embedded 
 interface, so a warm cached build parses `.v` files only from the input program's directory; the
 `.v` list makes an unexpected module-cache miss visible. After successfully populating module
 objects, a cold build prints a hint that unchanged modules will not be recompiled on the next run.
+Third-party C objects retain dependency manifests, so warm builds verify each unique source or
+header once without launching a dependency-scanner process per object. This work is reported as
+the separate `C object cache` benchmark stage before `cc`.
 
 ## Architecture
 

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -98,6 +98,10 @@ objects, a cold build prints a hint that unchanged modules will not be recompile
 Third-party C objects retain dependency manifests, so warm builds verify each unique source or
 header once without launching a dependency-scanner process per object. This work is reported as
 the separate `C object cache` benchmark stage before `cc`.
+When the whole-program C plan is unchanged, v3 validates it before generic specialization and
+reports `monomorphize (cached)`, avoiding construction of an AST that cached C generation will
+not consume. Source, imported-module, compiler, target, flag, or configuration changes invalidate
+the plan and run monomorphization normally.
 
 ## Architecture
 

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -88,13 +88,14 @@ configuration changes. `builtin`, `strconv`, `strings`, `hash`, `bits`, and
 `math.bits` share one `builtin.o`, matching the v2 core-cache layout. Cache files live under
 the V temporary directory by default; set `V3CACHE` to select another root, or pass
 `-nocache`/`--no-cache` to disable the module cache. C-only `-o file.c` builds do not use the
-object cache. The benchmark output prints counts for parsed `.vh` and `.v` files immediately
-after the parse stage, followed by each category's space-separated paths on one line. Paths below
-the current home directory use `~` as a prefix. A nonzero `.vh` count shows how many cached module
-interfaces were parsed by that build. Required compile-time bodies are embedded in the `.vh`
-interface, so a warm cached build parses `.v` files only from the input program's directory; the
-`.v` list makes an unexpected module-cache miss visible. After successfully populating module
-objects, a cold build prints a hint that unchanged modules will not be recompiled on the next run.
+object cache. The benchmark output prints counts for parsed `.vh` and `.v` files and their total
+line counts immediately after the parse stage, followed by each category's space-separated paths
+on one line. Paths below the current home directory use `~` as a prefix. A nonzero `.vh` count
+shows how many cached module interfaces were parsed by that build. Required compile-time bodies
+are embedded in the `.vh` interface, so a warm cached build parses `.v` files only from the input
+program's directory; the `.v` list makes an unexpected module-cache miss visible. After
+successfully populating module objects, a cold build prints a hint that unchanged modules will not
+be recompiled on the next run.
 Third-party C objects retain dependency manifests, so warm builds verify each unique source or
 header once without launching a dependency-scanner process per object. This work is reported as
 the separate `C object cache` benchmark stage before `cc`.
@@ -105,10 +106,11 @@ Objective-C and framework compilation flags stay on the cached dylib side. This 
 as `C dylib cache`; the resulting development executable retains an absolute runtime dependency
 on that cache artifact. Production, shared-library, self-host, explicit `-cc`, and `-nocache`
 builds keep their existing direct-link behavior.
-When the whole-program C plan is unchanged, v3 validates it before generic specialization and
-reports `monomorphize (cached)`, avoiding construction of an AST that cached C generation will
-not consume. Source, imported-module, compiler, target, flag, or configuration changes invalidate
-the plan and run monomorphization normally.
+When the whole-program C plan is unchanged, v3 validates it immediately after parsing and reports
+the check, mark-used, transform, type-annotation, monomorphization, and C generation stages as
+cached. This avoids semantic and lowering work whose only consumer would be the cached C plan.
+Source, imported-module, native-input, compiler, target, flag, or configuration changes invalidate
+the plan and run the complete diagnostic and generation pipeline normally.
 
 ## Architecture
 

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -86,9 +86,15 @@ declaration-only `.vh` file and a compiled `.o` file. A module object is rebuilt
 when its source content, compiler implementation, target, or relevant build
 configuration changes. `builtin`, `strconv`, `strings`, `hash`, `bits`, and
 `math.bits` share one `builtin.o`, matching the v2 core-cache layout. Cache files live under
-the V temporary directory by default; set `V3CACHE` to select another root, or
-pass `-nocache`/`--no-cache` to disable the module cache. C-only `-o file.c`
-builds do not use the object cache.
+the V temporary directory by default; set `V3CACHE` to select another root, or pass
+`-nocache`/`--no-cache` to disable the module cache. C-only `-o file.c` builds do not use the
+object cache. The benchmark output prints counts for parsed `.vh` and `.v` files immediately
+after the parse stage, followed by each category's space-separated paths on one line. Paths below
+the current home directory use `~` as a prefix. A nonzero `.vh` count shows how many cached module
+interfaces were parsed by that build. Required compile-time bodies are embedded in the `.vh`
+interface, so a warm cached build parses `.v` files only from the input program's directory; the
+`.v` list makes an unexpected module-cache miss visible. After successfully populating module
+objects, a cold build prints a hint that unchanged modules will not be recompiled on the next run.
 
 ## Architecture
 
@@ -240,11 +246,21 @@ Compiling `v3.v` itself in the C self-host chain:
 Commands:
 
 ```sh
-v -gc none -prod -o v3 v3.v
+v -prod -prealloc -d parallel -o v3 v3.v
 ./v3 -o v4 v3.v
 ./v4 -o v5 v3.v
 ./v5 -o v6 v3.v
 ```
+
+v3 uses scoped bump arenas to release compiler-stage allocations explicitly. It refuses to build
+with any Boehm GC mode or VGC and must be built with `-gc none`; `-prealloc` enables those arenas
+and selects `-gc none` automatically. v3 also rejects collector modes and GC compile-time defines
+for generated programs, which support `-gc none` only.
+
+The standard v3 executable is built without `-d ownership`, so the ownership checker and its
+analysis stages are compiled out. It rejects both `-ownership` and `-d ownership`; the main V
+driver builds a separate ownership-enabled v3 executable only for an explicit `v -ownership`
+invocation.
 
 The table uses the first v3-generated C stage, `./v3 -o v4 v3.v`. The plain
 bootstrap includes thread support. v3 self-hosts parallel-capable successors by

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -98,6 +98,13 @@ objects, a cold build prints a hint that unchanged modules will not be recompile
 Third-party C objects retain dependency manifests, so warm builds verify each unique source or
 header once without launching a dependency-scanner process per object. This work is reported as
 the separate `C object cache` benchmark stage before `cc`.
+On macOS, cached non-production executable builds combine the imported-module objects and
+generated runtime prefix into a content-keyed dylib with the system C compiler. The remaining
+current-directory program unit is compiled and linked against that dylib with bundled TinyCC.
+Objective-C and framework compilation flags stay on the cached dylib side. This work is reported
+as `C dylib cache`; the resulting development executable retains an absolute runtime dependency
+on that cache artifact. Production, shared-library, self-host, explicit `-cc`, and `-nocache`
+builds keep their existing direct-link behavior.
 When the whole-program C plan is unchanged, v3 validates it before generic specialization and
 reports `monomorphize (cached)`, avoiding construction of an AST that cached C generation will
 not consume. Source, imported-module, compiler, target, flag, or configuration changes invalidate

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -109,6 +109,7 @@ builds keep their existing direct-link behavior.
 When the whole-program C plan is unchanged, v3 validates it immediately after parsing and reports
 the check, mark-used, transform, type-annotation, monomorphization, and C generation stages as
 cached. This avoids semantic and lowering work whose only consumer would be the cached C plan.
+The pre-split main, TinyCC, and runtime-prefix sources are restored as `C module plan (cached)`.
 Source, imported-module, native-input, compiler, target, flag, or configuration changes invalidate
 the plan and run the complete diagnostic and generation pipeline normally.
 

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -97,15 +97,18 @@ program's directory; the `.v` list makes an unexpected module-cache miss visible
 successfully populating module objects, a cold build prints a hint that unchanged modules will not
 be recompiled on the next run.
 Third-party C objects retain dependency manifests, so warm builds verify each unique source or
-header once without launching a dependency-scanner process per object. This work is reported as
-the separate `C object cache` benchmark stage before `cc`.
+header once without launching a dependency-scanner process per object. Unchanged inputs use
+nanosecond-resolution file metadata; a metadata change falls back to the recorded content hash.
+This work is reported as the separate `C object cache` benchmark stage before `cc`.
 On macOS, cached non-production executable builds combine the imported-module objects and
 generated runtime prefix into a content-keyed dylib with the system C compiler. The remaining
 current-directory program unit is compiled and linked against that dylib with bundled TinyCC.
 Objective-C and framework compilation flags stay on the cached dylib side. This work is reported
 as `C dylib cache`; the resulting development executable retains an absolute runtime dependency
-on that cache artifact. Production, shared-library, self-host, explicit `-cc`, and `-nocache`
-builds keep their existing direct-link behavior.
+on that cache artifact. An exact warm plan also restores its content-keyed TinyCC executable and
+reports `cc (cached)`; project source, module object, C dependency, TinyCC input, argument, or
+dylib changes invalidate it. Production, shared-library, self-host, explicit `-cc`, and
+`-nocache` builds keep their existing direct-link behavior.
 When the whole-program C plan is unchanged, v3 validates it immediately after parsing and reports
 the check, mark-used, transform, type-annotation, monomorphization, and C generation stages as
 cached. This avoids semantic and lowering work whose only consumer would be the cached C plan.

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -1,5 +1,6 @@
 module bench
 
+import os
 import runtime
 import time
 
@@ -154,6 +155,23 @@ pub fn (mut b Bench) metric(name string, value i64, unit string) {
 	}
 }
 
+// metric_items prints a structural counter and a one-line list of its items immediately.
+pub fn (_ &Bench) metric_items(name string, value i64, unit string, items_label string, items []string) {
+	metric := Metric{
+		name:  name
+		value: value
+		unit:  unit
+	}
+	print_metric(metric)
+	short_items := items.map(shorten_home_path(it))
+	println('      ${items_label}: ${short_items.join(' ')}')
+}
+
+fn print_metric(metric Metric) {
+	suffix := if metric.unit.len > 0 { ' ${metric.unit}' } else { '' }
+	println('    ${metric.name:-28s} ${metric.value}${suffix}')
+}
+
 // print_report updates print report state for Bench.
 pub fn (b &Bench) print_report() {
 	total_ms := f64(b.total_sw.elapsed().microseconds()) / 1000.0
@@ -161,11 +179,24 @@ pub fn (b &Bench) print_report() {
 	if b.metrics.len > 0 {
 		println('  metrics:')
 		for metric in b.metrics {
-			suffix := if metric.unit.len > 0 { ' ${metric.unit}' } else { '' }
-			println('    ${metric.name:-28s} ${metric.value}${suffix}')
+			print_metric(metric)
 		}
 	}
 	println('')
+}
+
+fn shorten_home_path(path string) string {
+	home := os.home_dir()
+	if home.len == 0 || !path.starts_with(home) {
+		return path
+	}
+	if path.len == home.len {
+		return '~'
+	}
+	if path[home.len] !in [`/`, `\\`] {
+		return path
+	}
+	return '~${path[home.len..]}'
 }
 
 // current_rss_kb returns current rss kb data for bench.

--- a/vlib/v3/bench/bench_test.v
+++ b/vlib/v3/bench/bench_test.v
@@ -61,3 +61,14 @@ fn test_memory_monitor_exits_above_limit() {
 	assert error_output.contains('during compilation'), error_output
 	assert error_output.contains('limit: 0 GiB'), error_output
 }
+
+fn test_shorten_home_path() {
+	home := os.home_dir()
+	if home.len == 0 {
+		return
+	}
+	assert shorten_home_path(home) == '~'
+	assert shorten_home_path('${home}/code/project/main.v') == '~/code/project/main.v'
+	assert shorten_home_path('${home}_other/code/project/main.v') == '${home}_other/code/project/main.v'
+	assert shorten_home_path('/tmp/project/main.v') == '/tmp/project/main.v'
+}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2381,6 +2381,24 @@ fn (mut g FlatGen) collect_c_flags_from_directives() {
 	}
 }
 
+// cache_pkgconfig_flags resolves the pkg-config flags that affect early C cache keys.
+pub fn cache_pkgconfig_flags(a &flat.FlatAst) []string {
+	mut result := []string{}
+	mut seen_groups := map[string]bool{}
+	for node in a.nodes {
+		if node.kind != .directive || node.value != 'pkgconfig' || node.typ.len == 0 {
+			continue
+		}
+		flags := c_pkgconfig_flags(node.typ)
+		key := flags.join('\x00')
+		if flags.len > 0 && key !in seen_groups {
+			seen_groups[key] = true
+			result << flags
+		}
+	}
+	return result
+}
+
 fn (g &FlatGen) translation_unit_uses_inttypes() bool {
 	mut cur_file := ''
 	include_dirs := c_flag_include_dirs(g.c_flags)

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3591,7 +3591,8 @@ fn c_cache_native_condition_omitted(directive string, mut stack []CCacheConditio
 		}
 		stack << CCacheConditionalOmission{
 			parent_omitted:         parent_omitted
-			later_branches_omitted: name == 'ifndef' && c_cache_implementation_macro(macro_name)
+			later_branches_omitted: (name == 'ifndef' && c_cache_implementation_macro(macro_name))
+				|| (name == 'if' && c_cache_condition_is_negated_implementation_guard(arg))
 			condition_omitted:      condition_omitted
 		}
 	} else if name in ['else', 'elif'] && stack.len > 0 {
@@ -3634,6 +3635,49 @@ fn c_cache_condition_requires_implementation(condition string) bool {
 		}
 	}
 	return false
+}
+
+fn c_cache_condition_is_negated_implementation_guard(condition string) bool {
+	mut compact := condition.replace(' ', '').replace('\t', '').replace('\r', '').replace('\n', '')
+	for compact.len >= 2 && compact[0] == `(` && compact[compact.len - 1] == `)` {
+		mut depth := 0
+		mut wraps_entire_condition := true
+		for i, c in compact {
+			if c == `(` {
+				depth++
+			} else if c == `)` {
+				depth--
+				if depth == 0 && i < compact.len - 1 {
+					wraps_entire_condition = false
+					break
+				}
+			}
+		}
+		if !wraps_entire_condition || depth != 0 {
+			break
+		}
+		compact = compact[1..compact.len - 1]
+	}
+	if compact.starts_with('!defined(') && compact.ends_with(')') {
+		name := compact['!defined('.len..compact.len - 1]
+		return c_cache_condition_implementation_identifier(name)
+	}
+	if compact.starts_with('!') {
+		return c_cache_condition_implementation_identifier(compact[1..])
+	}
+	return false
+}
+
+fn c_cache_condition_implementation_identifier(name string) bool {
+	if name.len == 0 || !c_cache_implementation_macro(name) {
+		return false
+	}
+	for c in name.bytes() {
+		if !c_ident_char(c) {
+			return false
+		}
+	}
+	return true
 }
 
 fn c_cache_implementation_macro(name string) bool {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -820,7 +820,8 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 			cur_module = node.value
 			continue
 		}
-		if !collect_modules[cur_module] {
+		owner_module := if cur_module.len > 0 { cur_module } else { 'main' }
+		if !collect_modules[owner_module] {
 			continue
 		}
 		if node.kind == .directive && node.value in ['include', 'insert'] && node.typ.len > 0 {
@@ -842,14 +843,14 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 					has_untracked_include = true
 				}
 				for file in files {
-					c_add_cache_external_input(mut inputs, cur_module, file)
+					c_add_cache_external_input(mut inputs, owner_module, file)
 				}
 				break
 			}
 			continue
 		}
 		if path := c_embed_external_input_path(a, node) {
-			c_add_cache_external_input(mut inputs, cur_module, path)
+			c_add_cache_external_input(mut inputs, owner_module, path)
 		}
 	}
 	flag_inputs, flags_have_untracked_include := cache_c_flag_input_files_with_status(c_flags)

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -98,6 +98,7 @@ mut:
 	fn_segs                        []string
 	test_files                     map[string]bool
 	cache_program_files            map[string]bool
+	incremental_fn_names           map[string]bool
 	str_lits                       []string
 	str_lit_ids                    map[string]int
 	str_lits_shared                bool
@@ -273,6 +274,7 @@ mut:
 	mut_recv_facts                 &FnNameFactCache = unsafe { nil }
 	want_parallel_prep             bool
 	cache_split                    bool
+	program_body_only              bool
 	// Set when the target is built with -prealloc / -d prealloc: the bump
 	// arena's base block pointer must be thread-local (matching V1's cgen),
 	// or every spawned thread would race on the same arena.
@@ -597,6 +599,7 @@ pub fn FlatGen.new() FlatGen {
 		fn_segs:                        []string{}
 		test_files:                     map[string]bool{}
 		cache_program_files:            map[string]bool{}
+		incremental_fn_names:           map[string]bool{}
 		str_lit_ids:                    map[string]int{}
 		global_types:                   map[string]types.Type{}
 		global_raw_type_texts:          map[string]string{}
@@ -731,6 +734,12 @@ pub fn (mut g FlatGen) set_cache_split(enabled bool) {
 	g.cache_split = enabled
 }
 
+// set_program_body_only omits the reusable declaration/type prefix. It is used
+// when that prefix has already been validated and loaded from the module cache.
+pub fn (mut g FlatGen) set_program_body_only(enabled bool) {
+	g.program_body_only = enabled
+}
+
 // set_cache_program_files assigns entry-module source files to the program
 // translation unit rather than an imported module cache object.
 pub fn (mut g FlatGen) set_cache_program_files(files []string) {
@@ -738,6 +747,12 @@ pub fn (mut g FlatGen) set_cache_program_files(files []string) {
 	for file in files {
 		g.cache_program_files[file] = true
 	}
+}
+
+// set_incremental_fn_names limits program-body generation to functions whose
+// parsed bodies changed. An empty map preserves normal whole-program emission.
+pub fn (mut g FlatGen) set_incremental_fn_names(names map[string]bool) {
+	g.incremental_fn_names = names.clone()
 }
 
 // cache_external_input_files returns local include/embed inputs grouped by the
@@ -1335,40 +1350,49 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	}
 	g.has_builtins = g.tc.has_builtins
 	g.collect_gen_info()
-	g.precompute_shared_param_index()
-	if !g.skip_generics {
-		g.precompute_non_generic_fn_index()
-		g.precompute_generic_fn_key_index()
-	}
-	// In the parallel path the fixed-storage scan runs on a helper thread,
-	// overlapped with the fn-item collection and parallel pre-seeding.
-	// The master emits selectors/inits itself (serial regions, postamble), so
-	// its embedded-fields map must be populated even when the worker-fork prep
-	// runs its own copy; do it before any helper thread can observe `g`.
-	g.precompute_embedded_fields()
-	parallel_prep_done := g.run_pre_dispatch_parallel(no_parallel)
-	if !parallel_prep_done {
-		g.collect_fixed_storage_consts()
+	if g.incremental_fn_names.len > 0 {
+		// Cached declarations already contain whole-program typedefs, wrappers,
+		// interface tables and shared-parameter metadata. A body-only update only
+		// needs indexes consulted while emitting the selected function.
+		g.precompute_embedded_fields()
 		g.precompute_param_type_index()
-		g.precompute_concrete_optional_abi_fns()
+		g.precompute_sum_name_lookup()
+	} else {
+		g.precompute_shared_param_index()
+		if !g.skip_generics {
+			g.precompute_non_generic_fn_index()
+			g.precompute_generic_fn_key_index()
+		}
+		// In the parallel path the fixed-storage scan runs on a helper thread,
+		// overlapped with the fn-item collection and parallel pre-seeding.
+		// The master emits selectors/inits itself (serial regions, postamble), so
+		// its embedded-fields map must be populated even when the worker-fork prep
+		// runs its own copy; do it before any helper thread can observe `g`.
+		g.precompute_embedded_fields()
+		parallel_prep_done := g.run_pre_dispatch_parallel(no_parallel)
+		if !parallel_prep_done {
+			g.collect_fixed_storage_consts()
+			g.precompute_param_type_index()
+			g.precompute_concrete_optional_abi_fns()
+		}
+		g.collect_shared_type_names()
+		g.collect_interface_impls()
+		g.precompute_sum_name_lookup()
+		g.preseed_struct_fn_ptr_types()
+		g.preseed_sum_fn_ptr_types()
+		g.preseed_global_fn_ptr_types()
+		g.preseed_fn_signature_fn_ptr_types()
+		g.preseed_c_extern_fn_ptr_types()
+		g.preseed_struct_default_string_literals()
+		g.preseed_libc_compat_fns()
+		if !g.skip_generics {
+			g.precompute_generic_method_candidate_index()
+		}
+		// Decide fixed-array return wrappers before generating function bodies, so
+		// signatures, returns and call sites all agree on the wrapped types.
+		g.populate_fixed_array_ret_wrappers()
 	}
-	g.collect_shared_type_names()
-	g.collect_interface_impls()
-	g.precompute_sum_name_lookup()
-	g.preseed_struct_fn_ptr_types()
-	g.preseed_sum_fn_ptr_types()
-	g.preseed_global_fn_ptr_types()
-	g.preseed_fn_signature_fn_ptr_types()
-	g.preseed_c_extern_fn_ptr_types()
-	g.preseed_struct_default_string_literals()
-	g.preseed_libc_compat_fns()
-	if !g.skip_generics {
-		g.precompute_generic_method_candidate_index()
-	}
-	// Decide fixed-array return wrappers before generating function bodies, so
-	// signatures, returns and call sites all agree on the wrapped types.
-	g.populate_fixed_array_ret_wrappers()
-	const_code := g.precompute_consts()
+	const_code := if g.program_body_only { '' } else { g.precompute_consts() }
 	stream_scoped_output := g.output_path.len > 0 && g.scope_parallel_workers
 	stream_path := if stream_scoped_output { '${g.output_path}.v3-stream.tmp' } else { '' }
 	fn_stream_path := if stream_scoped_output { '${g.output_path}.v3-fns.tmp' } else { '' }
@@ -1385,6 +1409,38 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	unsafe { g.sb.free() }
 	g.sb = orig_sb
 	g.line_start = orig_line_start
+	if g.program_body_only {
+		unsafe { const_code.free() }
+		g.release_scoped_fn_items()
+		g.sb.ensure_cap(fn_code.len + 262_144)
+		g.writeln('#define V3CACHE_PROGRAM_UNIT 1')
+		g.string_literals()
+		g.writeln('/* V3CACHE_BODY_BEGIN */')
+		g.writeln('/* V3CACHE_MODULE main */')
+		for segment in g.fn_segs {
+			g.sb.write_string(segment)
+			unsafe { segment.free() }
+		}
+		g.fn_segs = []string{}
+		if fn_code.len > 0 {
+			g.sb.write_string(fn_code)
+			unsafe { fn_code.free() }
+		}
+		g.writeln('/* V3CACHE_BODY_END */')
+		source := g.sb.str()
+		result := g.rewrite_cache_string_symbols(source)
+		unsafe {
+			source.free()
+			g.sb.free()
+		}
+		if g.output_path.len > 0 {
+			os.write_file(g.output_path, result) or { g.output_error = err.msg() }
+			unsafe { result.free() }
+			g.sb = strings.new_builder(4096)
+			return ''
+		}
+		return result
+	}
 	mut known_output_len := g.sb.len + fn_code.len + const_code.len
 	for segment in g.fn_segs {
 		known_output_len += segment.len
@@ -1522,26 +1578,13 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	unsafe { const_code.free() }
 	if g.cache_split {
 		g.writeln('/* V3CACHE_BODY_BEGIN */')
-		// `_vinit` aggregates module and global initialization for the current
-		// entry program, so it must never be retained in a reusable module object.
-		g.writeln('/* V3CACHE_MODULE main */')
+		// `_vinit` and interface stubs depend on the complete entry program, but
+		// remain stable across function-body literal edits. Keep them with the
+		// program specialization cache instead of regenerating module globals in
+		// every edited translation unit.
+		g.writeln('/* V3CACHE_MODULE __v3_program_support */')
 	}
-	if g.const_runtime_inits.len > 0 || g.runtime_inits.len > 0 || g.module_init_fns.len > 0
-		|| g.global_inits.len > 0 {
-		g.writeln('void _vinit() {')
-		mut emitted_const := []bool{len: g.const_runtime_inits.len}
-		mut emitted_runtime := []bool{len: g.runtime_inits.len}
-		init_fns := g.module_init_fn_map()
-		for mod in g.ordered_startup_modules(init_fns) {
-			g.emit_runtime_inits_for_module(mod, mut emitted_const, mut emitted_runtime)
-			if init_fn := init_fns[mod] {
-				g.writeln('\t${init_fn}();')
-			}
-		}
-		g.emit_remaining_runtime_inits(mut emitted_const, mut emitted_runtime)
-		g.writeln('}')
-		g.writeln('')
-	}
+	g.gen_vinit()
 	if g.cache_split {
 		g.interface_method_stubs()
 	}
@@ -1632,6 +1675,26 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	// Keep only the returned C string, not the builder's copied backing array.
 	unsafe { g.sb.free() }
 	return result
+}
+
+fn (mut g FlatGen) gen_vinit() {
+	if g.const_runtime_inits.len == 0 && g.runtime_inits.len == 0 && g.module_init_fns.len == 0
+		&& g.global_inits.len == 0 {
+		return
+	}
+	g.writeln('void _vinit() {')
+	mut emitted_const := []bool{len: g.const_runtime_inits.len}
+	mut emitted_runtime := []bool{len: g.runtime_inits.len}
+	init_fns := g.module_init_fn_map()
+	for mod in g.ordered_startup_modules(init_fns) {
+		g.emit_runtime_inits_for_module(mod, mut emitted_const, mut emitted_runtime)
+		if init_fn := init_fns[mod] {
+			g.writeln('\t${init_fn}();')
+		}
+	}
+	g.emit_remaining_runtime_inits(mut emitted_const, mut emitted_runtime)
+	g.writeln('}')
+	g.writeln('')
 }
 
 fn (mut g FlatGen) rewrite_cache_string_symbols(source string) string {
@@ -1810,7 +1873,9 @@ fn node_kind_id(node flat.Node) int {
 // collect_gen_info updates collect gen info state for c.
 fn (mut g FlatGen) collect_gen_info() {
 	g.reserve_collect_gen_info_maps()
-	g.collect_c_flags_from_directives()
+	if g.incremental_fn_names.len == 0 {
+		g.collect_c_flags_from_directives()
+	}
 	g.c_flags << g.initial_c_flags
 	g.use_system_stdint = g.translation_unit_uses_inttypes()
 	mut cur_module := 'main'
@@ -1853,7 +1918,9 @@ fn (mut g FlatGen) collect_gen_info() {
 		if kind_id == 61 {
 			full_name := qualify_name_in_module(cur_module, node.value)
 			if g.has_used_fn_filter() && !g.used_fn_contains_in_module(node.value, cur_module) {
-				g.preseed_unused_fn_ptr_param_types(node, cur_module, cur_file)
+				if g.incremental_fn_names.len == 0 {
+					g.preseed_unused_fn_ptr_param_types(node, cur_module, cur_file)
+				}
 				continue
 			}
 			g.register_fn_decl_node(node.value, cur_module, flat.NodeId(node_idx))
@@ -1958,6 +2025,9 @@ fn (mut g FlatGen) collect_gen_info() {
 				}
 				g.module_init_fn_modules[init_cname] = cur_module
 			}
+			continue
+		}
+		if g.incremental_fn_names.len > 0 && node.kind == .directive {
 			continue
 		}
 		if g.collect_c_directive(cur_module, node, cur_file, !seen_import_in_file) {
@@ -2136,10 +2206,13 @@ fn (mut g FlatGen) reserve_collect_gen_info_maps() {
 	mut enum_field_count := 0
 	mut interface_count := 0
 	mut import_count := 0
+	incremental := g.incremental_fn_names.len > 0
 	for node in g.a.nodes {
 		match node.kind {
 			.fn_decl {
-				fn_count++
+				if !incremental || g.incremental_fn_names[node.value] {
+					fn_count++
+				}
 			}
 			.struct_decl {
 				struct_count++
@@ -2161,6 +2234,9 @@ fn (mut g FlatGen) reserve_collect_gen_info_maps() {
 			}
 			else {}
 		}
+	}
+	if incremental && fn_count < g.incremental_fn_names.len {
+		fn_count = g.incremental_fn_names.len
 	}
 	fn_alias_count := u32(fn_count * 7 + 1024)
 	fn_name_count := u32(fn_count * 2 + 1024)

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1375,10 +1375,12 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	if g.incremental_fn_names.len > 0 {
 		// Cached declarations already contain whole-program typedefs, wrappers,
 		// interface tables and shared-parameter metadata. A body-only update only
-		// needs indexes consulted while emitting the selected function.
+		// needs indexes consulted while emitting the selected function. Rebuild
+		// interface IDs too: newly boxed values must match the cached dispatch tables.
 		g.precompute_embedded_fields()
 		g.precompute_param_type_index()
 		g.precompute_sum_name_lookup()
+		g.collect_interface_impls()
 	} else {
 		g.precompute_shared_param_index()
 		if !g.skip_generics {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2382,15 +2382,26 @@ fn (mut g FlatGen) collect_c_flags_from_directives() {
 	}
 }
 
-// cache_pkgconfig_flags resolves the pkg-config flags that affect early C cache keys.
-pub fn cache_pkgconfig_flags(a &flat.FlatAst) []string {
+// cache_directive_flags resolves source C flags that affect early C cache keys.
+pub fn cache_directive_flags(a &flat.FlatAst, vroot string, target pref.Target) []string {
 	mut result := []string{}
 	mut seen_groups := map[string]bool{}
+	mut cur_file := ''
 	for node in a.nodes {
-		if node.kind != .directive || node.value != 'pkgconfig' || node.typ.len == 0 {
+		if node.kind == .file {
+			cur_file = node.value
 			continue
 		}
-		flags := c_pkgconfig_flags(node.typ)
+		if node.kind != .directive || node.typ.len == 0 {
+			continue
+		}
+		flags := if node.value == 'flag' {
+			c_flag_args(node.typ, vroot, cur_file, target)
+		} else if node.value == 'pkgconfig' {
+			c_pkgconfig_flags(node.typ)
+		} else {
+			continue
+		}
 		key := flags.join('\x00')
 		if flags.len > 0 && key !in seen_groups {
 			seen_groups[key] = true

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -275,6 +275,7 @@ mut:
 	want_parallel_prep             bool
 	cache_split                    bool
 	program_body_only              bool
+	cached_support_identifiers     map[string]bool
 	// Set when the target is built with -prealloc / -d prealloc: the bump
 	// arena's base block pointer must be thread-local (matching V1's cgen),
 	// or every spawned thread would race on the same arena.
@@ -700,6 +701,7 @@ pub fn FlatGen.new() FlatGen {
 		callback_wrapper_names:         map[string]string{}
 		callback_wrapper_defs:          []string{}
 		callback_wrapper_defs_seen:     map[string]bool{}
+		cached_support_identifiers:     map[string]bool{}
 		str_lits:                       []string{}
 		defers:                         []flat.NodeId{}
 		fn_defers:                      []flat.NodeId{}
@@ -753,6 +755,25 @@ pub fn (mut g FlatGen) set_cache_program_files(files []string) {
 // parsed bodies changed. An empty map preserves normal whole-program emission.
 pub fn (mut g FlatGen) set_incremental_fn_names(names map[string]bool) {
 	g.incremental_fn_names = names.clone()
+}
+
+// set_cached_support_declarations records C identifiers already supplied by the
+// cached program prefix so body-only generation emits only newly needed typedefs.
+pub fn (mut g FlatGen) set_cached_support_declarations(source string) {
+	g.cached_support_identifiers.clear()
+	mut i := 0
+	for i < source.len {
+		if !c_identifier_start(source[i]) {
+			i++
+			continue
+		}
+		start := i
+		i++
+		for i < source.len && c_identifier_continue(source[i]) {
+			i++
+		}
+		g.cached_support_identifiers[source[start..i]] = true
+	}
 }
 
 // cache_external_input_files returns local include/embed inputs grouped by the
@@ -1415,6 +1436,14 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		g.sb.ensure_cap(fn_code.len + 262_144)
 		g.writeln('#define V3CACHE_PROGRAM_UNIT 1')
 		g.string_literals()
+		if g.incremental_fn_names.len > 0 {
+			g.writeln('/* V3CACHE_SUPPORT_BEGIN */')
+			g.fixed_array_early_typedefs()
+			g.fn_ptr_typedefs()
+			g.fixed_array_typedefs()
+			g.optional_typedefs()
+			g.writeln('/* V3CACHE_SUPPORT_END */')
+		}
 		g.writeln('/* V3CACHE_BODY_BEGIN */')
 		g.writeln('/* V3CACHE_MODULE main */')
 		for segment in g.fn_segs {
@@ -14230,6 +14259,10 @@ fn (mut g FlatGen) fixed_array_typedef_has_unresolved_len(typ types.Type) bool {
 
 fn (mut g FlatGen) emit_fixed_array_typedef(name string, info FixedArrayTypedefInfo, needed map[string]FixedArrayTypedefInfo, mut emitted map[string]bool) {
 	if emitted[name] {
+		return
+	}
+	if g.cached_support_identifiers[name] {
+		emitted[name] = true
 		return
 	}
 	arr := info.arr

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -11439,6 +11439,9 @@ fn (mut g FlatGen) headerless_libc_preamble() {
 	g.writeln('typedef union { unsigned char _opaque[16]; long long _align; } pthread_once_t;')
 	g.writeln('typedef unsigned long pthread_key_t;')
 	g.writeln('#endif')
+	g.writeln('int pthread_key_create(pthread_key_t* key, void (*dtor)(void*));')
+	g.writeln('void* pthread_getspecific(pthread_key_t key);')
+	g.writeln('int pthread_setspecific(pthread_key_t key, const void* const_ptr);')
 	g.writeln('typedef union { unsigned char _opaque[128]; long long _align; } sem_t;')
 	g.writeln('#if !defined(__sigset_t_defined) && !defined(_SIGSET_T_DECLARED) && !defined(_SIGSET_T_DEFINED) && !defined(_SIGSET_T)')
 	g.writeln('typedef union { unsigned char _opaque[128]; long long _align; } sigset_t;')
@@ -14222,10 +14225,7 @@ fn (mut g FlatGen) global_decls() {
 			init := if g.has_zero_sized_leading_init_slot(decl_typ) { '' } else { ' = {0}' }
 			if is_fn_capture {
 				g.writeln('#if defined(__TINYC__)')
-				g.writeln('i32 pthread_key_create(u64* key, void (*dtor)(void*));')
-				g.writeln('void* pthread_getspecific(u64 key);')
-				g.writeln('i32 pthread_setspecific(u64 key, const void* const_ptr);')
-				g.writeln('static u64 ${g.cname(name)}_key;')
+				g.writeln('static pthread_key_t ${g.cname(name)}_key;')
 				g.writeln('static void ${g.cname(name)}_key_init(void) __attribute__((constructor));')
 				g.writeln('static void ${g.cname(name)}_key_init(void) { pthread_key_create(&${g.cname(name)}_key, free); }')
 				g.writeln('static ${c_elem} (*${g.cname(name)}_slot(void))${dims} { void* p = pthread_getspecific(${g.cname(name)}_key); if (!p) { p = calloc(1, sizeof(*${g.cname(name)}_slot())); pthread_setspecific(${g.cname(name)}_key, p); } return p; }')
@@ -14263,10 +14263,7 @@ fn (mut g FlatGen) global_decls() {
 			cname := g.cname(name)
 			if shared_ct := g.fn_capture_shared_global_c_type(name) {
 				g.writeln('#if defined(__TINYC__)')
-				g.writeln('i32 pthread_key_create(u64* key, void (*dtor)(void*));')
-				g.writeln('void* pthread_getspecific(u64 key);')
-				g.writeln('i32 pthread_setspecific(u64 key, const void* const_ptr);')
-				g.writeln('static u64 ${cname}_key;')
+				g.writeln('static pthread_key_t ${cname}_key;')
 				g.writeln('static void ${cname}_key_init(void) __attribute__((constructor));')
 				g.writeln('static void ${cname}_key_init(void) { pthread_key_create(&${cname}_key, free); }')
 				g.writeln('static ${shared_ct}* ${cname}_slot(void) { void* p = pthread_getspecific(${cname}_key); if (!p) { p = calloc(1, sizeof(${shared_ct})); pthread_setspecific(${cname}_key, p); } return (${shared_ct}*)p; }')
@@ -14277,10 +14274,7 @@ fn (mut g FlatGen) global_decls() {
 				continue
 			}
 			g.writeln('#if defined(__TINYC__)')
-			g.writeln('i32 pthread_key_create(u64* key, void (*dtor)(void*));')
-			g.writeln('void* pthread_getspecific(u64 key);')
-			g.writeln('i32 pthread_setspecific(u64 key, const void* const_ptr);')
-			g.writeln('static u64 ${cname}_key;')
+			g.writeln('static pthread_key_t ${cname}_key;')
 			g.writeln('static void ${cname}_key_init(void) __attribute__((constructor));')
 			g.writeln('static void ${cname}_key_init(void) { pthread_key_create(&${cname}_key, free); }')
 			g.writeln('static ${ct}* ${cname}_slot(void) { void* p = pthread_getspecific(${cname}_key); if (!p) { p = calloc(1, sizeof(${ct})); pthread_setspecific(${cname}_key, p); } return (${ct}*)p; }')
@@ -14296,19 +14290,11 @@ fn (mut g FlatGen) global_decls() {
 		// TLS; tcc implements no _Thread_local, so it gets a pthread-key
 		// emulation behind an lvalue macro. The key setup needs no
 		// synchronization: the first allocation always happens on the main
-		// thread, long before any `spawn`. The key APIs are declared manually
-		// (V's generated C declares its own `pthread_t`, so <pthread.h> would
-		// conflict); the key out-param is stored in an 8-byte zeroed slot,
-		// which stays correct where pthread_key_t is 4 bytes (little-endian).
+		// thread, long before any `spawn`. The helpers use pthread_key_t so they
+		// agree with either the platform pthread header or the headerless fallback.
 		if g.prealloc && name == 'g_memory_block' {
 			g.writeln('#if defined(__TINYC__)')
-			// Shapes must match vlib's own C.pthread_* extern declarations
-			// exactly (u64/i32), or tcc rejects the redefinition when a module
-			// also declares them.
-			g.writeln('i32 pthread_key_create(u64* key, void (*dtor)(void*));')
-			g.writeln('void* pthread_getspecific(u64 key);')
-			g.writeln('i32 pthread_setspecific(u64 key, const void* const_ptr);')
-			g.writeln('static u64 g_memory_block_key = 0;')
+			g.writeln('static pthread_key_t g_memory_block_key = 0;')
 			g.writeln('static int g_memory_block_key_ready = 0;')
 			g.writeln('static ${ct}* g_memory_block_slot(void) {')
 			g.writeln('	void* p;')

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -763,6 +763,40 @@ pub fn (mut g FlatGen) set_cached_support_declarations(source string) {
 	g.cached_support_identifiers.clear()
 	mut i := 0
 	for i < source.len {
+		if source[i] == `/` && i + 1 < source.len {
+			if source[i + 1] == `/` {
+				i += 2
+				for i < source.len && source[i] != `\n` {
+					i++
+				}
+				continue
+			}
+			if source[i + 1] == `*` {
+				i += 2
+				for i + 1 < source.len && !(source[i] == `*` && source[i + 1] == `/`) {
+					i++
+				}
+				if i + 1 < source.len {
+					i += 2
+				}
+				continue
+			}
+		}
+		if source[i] in [`'`, `"`] {
+			quote := source[i]
+			i++
+			for i < source.len {
+				if source[i] == `\\` && i + 1 < source.len {
+					i += 2
+					continue
+				}
+				i++
+				if source[i - 1] == quote {
+					break
+				}
+			}
+			continue
+		}
 		if !c_identifier_start(source[i]) {
 			i++
 			continue

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3569,7 +3569,8 @@ fn (mut g FlatGen) collect_inlined_c_fns_for_cache(text string, cache_omitted bo
 }
 
 struct CCacheConditionalOmission {
-	parent_omitted bool
+	parent_omitted         bool
+	later_branches_omitted bool
 mut:
 	condition_omitted bool
 }
@@ -3580,21 +3581,23 @@ fn c_cache_native_condition_omitted(directive string, mut stack []CCacheConditio
 	if name in ['if', 'ifdef', 'ifndef'] {
 		parent_omitted := stack.len > 0
 			&& (stack.last().parent_omitted || stack.last().condition_omitted)
+		macro_name := arg.fields()[0] or { '' }
 		condition_omitted := if name == 'ifdef' {
-			c_cache_implementation_macro(arg.fields()[0] or { '' })
+			c_cache_implementation_macro(macro_name)
 		} else if name == 'if' {
 			c_cache_condition_requires_implementation(arg)
 		} else {
 			false
 		}
 		stack << CCacheConditionalOmission{
-			parent_omitted:    parent_omitted
-			condition_omitted: condition_omitted
+			parent_omitted:         parent_omitted
+			later_branches_omitted: name == 'ifndef' && c_cache_implementation_macro(macro_name)
+			condition_omitted:      condition_omitted
 		}
 	} else if name in ['else', 'elif'] && stack.len > 0 {
 		last := stack.len - 1
-		stack[last].condition_omitted = name == 'elif'
-			&& c_cache_condition_requires_implementation(arg)
+		stack[last].condition_omitted = stack[last].later_branches_omitted
+			|| (name == 'elif' && c_cache_condition_requires_implementation(arg))
 	} else if name == 'endif' && stack.len > 0 {
 		stack.delete_last()
 	}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -147,6 +147,8 @@ mut:
 	inlined_c_typedef_names        map[string]bool
 	inlined_c_fns                  map[string]bool
 	inlined_c_declared_fns         map[string]bool
+	inlined_c_static_fns           map[string]bool
+	cache_omitted_c_fns            map[string]bool
 	initial_c_flags                []string
 	c_flags                        []string
 	use_system_stdint              bool
@@ -635,6 +637,8 @@ pub fn FlatGen.new() FlatGen {
 		inlined_c_structs:              map[string]bool{}
 		inlined_c_fns:                  map[string]bool{}
 		inlined_c_declared_fns:         map[string]bool{}
+		inlined_c_static_fns:           map[string]bool{}
+		cache_omitted_c_fns:            map[string]bool{}
 		inlined_c_typedef_names:        map[string]bool{}
 		initial_c_flags:                []string{}
 		c_flags:                        []string{}
@@ -785,6 +789,9 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 		}
 		if node.kind == .directive && node.value in ['include', 'insert'] && node.typ.len > 0 {
 			include_arg := c_include_arg_for_target(node.typ, vroot, cur_file, target)
+			if include_arg.len == 0 {
+				continue
+			}
 			if !c_include_arg_is_literal(include_arg) {
 				has_untracked_include = true
 				continue
@@ -1121,7 +1128,8 @@ fn (mut g FlatGen) write_scoped_function_output(path string, fn_code string) boo
 			unsafe { segment.free() }
 		}
 		g.fn_segs = []string{}
-	} else {
+	}
+	if fn_code.len > 0 {
 		file.write_string(fn_code) or {
 			g.output_error = err.msg()
 			file.close()
@@ -1241,6 +1249,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.inlined_c_structs.clear()
 	g.inlined_c_fns.clear()
 	g.inlined_c_declared_fns.clear()
+	g.inlined_c_static_fns.clear()
+	g.cache_omitted_c_fns.clear()
 	g.inlined_c_typedef_names.clear()
 	g.c_flags = []string{}
 	g.use_system_stdint = false
@@ -1359,7 +1369,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	// signatures, returns and call sites all agree on the wrapped types.
 	g.populate_fixed_array_ret_wrappers()
 	const_code := g.precompute_consts()
-	stream_scoped_output := g.output_path.len > 0 && !g.cache_split && g.scope_parallel_workers
+	stream_scoped_output := g.output_path.len > 0 && g.scope_parallel_workers
 	stream_path := if stream_scoped_output { '${g.output_path}.v3-stream.tmp' } else { '' }
 	fn_stream_path := if stream_scoped_output { '${g.output_path}.v3-fns.tmp' } else { '' }
 	if stream_scoped_output {
@@ -1370,7 +1380,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.sb = strings.new_builder(4096)
 	g.line_start = true
 	g.gen_fns_dispatch(no_parallel)
-	fn_code := if g.fn_segs.len == 0 { g.sb.str() } else { '' }
+	fn_code := g.sb.str()
 	// `.str()` copies out of the builder; free the emptied backing array under -gc none.
 	unsafe { g.sb.free() }
 	g.sb = orig_sb
@@ -1399,7 +1409,13 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.c99_feature_test_macros()
 	g.emit_preserved_c_directives()
 	g.preamble()
+	if g.cache_split {
+		g.writeln('/* V3CACHE_NATIVE_DIRECTIVES_BEGIN */')
+	}
 	g.emit_c_directives(false)
+	if g.cache_split {
+		g.writeln('/* V3CACHE_NATIVE_DIRECTIVES_END */')
+	}
 	g.enum_decls()
 	g.type_alias_decls()
 	g.type_forward_decls()
@@ -1430,7 +1446,13 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.fixed_array_typedefs()
 	g.multi_return_typedefs()
 	g.optional_typedefs()
+	if g.cache_split {
+		g.writeln('/* V3CACHE_SOURCE_DIRECTIVES_BEGIN */')
+	}
 	g.emit_c_source_directives()
+	if g.cache_split {
+		g.writeln('/* V3CACHE_SOURCE_DIRECTIVES_END */')
+	}
 	g.c_extern_forward_decls()
 	g.builtin_abi_decls()
 	g.test_failure_helpers()
@@ -1439,7 +1461,13 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	// function signatures and bodies. Their framework imports are lifted above
 	// the headerless preamble, but the implementation itself belongs after the V
 	// type declarations.
+	if g.cache_split {
+		g.writeln('/* V3CACHE_LATE_DIRECTIVES_BEGIN */')
+	}
 	g.emit_c_directives(true)
+	if g.cache_split {
+		g.writeln('/* V3CACHE_LATE_DIRECTIVES_END */')
+	}
 	if stream_scoped_output {
 		output_scope = g.flush_and_restart_scoped_output(stream_path, stream_started, output_scope,
 			2097152) or {
@@ -1528,10 +1556,39 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 			g.cleanup_scoped_output_files(stream_path, fn_stream_path)
 			return ''
 		}
-		os.mv(stream_path, g.output_path) or {
-			g.output_error = err.msg()
-			g.cleanup_scoped_output_files(stream_path, fn_stream_path)
-			return ''
+		if g.cache_split {
+			mut stream_file := os.open_append(stream_path) or {
+				g.output_error = err.msg()
+				g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+				return ''
+			}
+			stream_file.write_string('/* V3CACHE_BODY_END */\n') or {
+				g.output_error = err.msg()
+				stream_file.close()
+				g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+				return ''
+			}
+			stream_file.close()
+			source := os.read_file(stream_path) or {
+				g.output_error = err.msg()
+				g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+				return ''
+			}
+			result := g.rewrite_cache_string_symbols(source)
+			unsafe { source.free() }
+			os.write_file(g.output_path, result) or { g.output_error = err.msg() }
+			unsafe { result.free() }
+			os.rm(stream_path) or {}
+			if g.output_error.len > 0 {
+				g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+				return ''
+			}
+		} else {
+			os.mv(stream_path, g.output_path) or {
+				g.output_error = err.msg()
+				g.cleanup_scoped_output_files(stream_path, fn_stream_path)
+				return ''
+			}
 		}
 		os.rm(fn_stream_path) or {}
 		return ''
@@ -1542,7 +1599,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 			unsafe { segment.free() }
 		}
 		g.fn_segs = []string{}
-	} else {
+	}
+	if fn_code.len > 0 {
 		g.sb.write_string(fn_code)
 		// The final builder now owns a copy of the function code.
 		unsafe { fn_code.free() }
@@ -1751,6 +1809,7 @@ fn node_kind_id(node flat.Node) int {
 
 // collect_gen_info updates collect gen info state for c.
 fn (mut g FlatGen) collect_gen_info() {
+	g.reserve_collect_gen_info_maps()
 	g.collect_c_flags_from_directives()
 	g.c_flags << g.initial_c_flags
 	g.use_system_stdint = g.translation_unit_uses_inttypes()
@@ -1814,7 +1873,11 @@ fn (mut g FlatGen) collect_gen_info() {
 					if child.typ.starts_with('...') {
 						decl_is_variadic = true
 					}
-					raw_pt := g.tc.parse_resolution_type(child.typ)
+					raw_pt := if param_idx < typed_params.len {
+						typed_params[param_idx]
+					} else {
+						g.tc.parse_resolution_type(child.typ)
+					}
 					mut pt := raw_pt
 					if shared_alias_ptr := g.cached_shared_alias_pointer_type_from_text(child.typ) {
 						pt = shared_alias_ptr
@@ -1882,8 +1945,9 @@ fn (mut g FlatGen) collect_gen_info() {
 				nonshared_fn_file_ranks << c_backend_fn_file_rank(cur_file)
 				nonshared_fn_node_indexes << node_idx
 			}
-			g.register_fn_decl_signature(node.value, full_name, ptypes, shared_params,
-				decl_is_variadic, first_param_is_mut, node.typ)
+			return_type := g.fn_node_return_type(node, cur_module)
+			g.register_fn_decl_signature_type(node.value, full_name, ptypes, shared_params,
+				decl_is_variadic, first_param_is_mut, return_type)
 			// Module-level `init()` functions run once at startup. Collect their C
 			// names so _vinit can invoke them (V semantics).
 			if node.value == 'init' && ptypes.len == 0
@@ -2064,6 +2128,73 @@ fn (mut g FlatGen) collect_gen_info() {
 	g.collect_const_init_order_from_files()
 }
 
+fn (mut g FlatGen) reserve_collect_gen_info_maps() {
+	mut fn_count := 0
+	mut struct_count := 0
+	mut global_count := 0
+	mut const_count := 0
+	mut enum_field_count := 0
+	mut interface_count := 0
+	mut import_count := 0
+	for node in g.a.nodes {
+		match node.kind {
+			.fn_decl {
+				fn_count++
+			}
+			.struct_decl {
+				struct_count++
+			}
+			.global_decl {
+				global_count += int(node.children_count)
+			}
+			.const_decl {
+				const_count += int(node.children_count)
+			}
+			.enum_decl {
+				enum_field_count += int(node.children_count)
+			}
+			.interface_decl {
+				interface_count++
+			}
+			.import_decl {
+				import_count++
+			}
+			else {}
+		}
+	}
+	fn_alias_count := u32(fn_count * 7 + 1024)
+	fn_name_count := u32(fn_count * 2 + 1024)
+	g.fn_decl_param_types.reserve(fn_alias_count)
+	g.fn_decl_variadic.reserve(fn_name_count)
+	g.fn_decl_variadic_short_counts.reserve(u32(fn_count + 256))
+	g.fn_decl_shared_params.reserve(fn_alias_count)
+	g.fn_decl_mut_receivers.reserve(fn_name_count)
+	g.fn_decl_ret_types.reserve(fn_alias_count)
+	g.fn_decl_nodes_by_name.reserve(fn_name_count)
+	g.fn_decl_nodes_by_short.reserve(u32(fn_count + 256))
+	g.fn_decl_nodes_by_module_short.reserve(fn_name_count)
+	g.module_init_fn_modules.reserve(u32(fn_count / 8 + 64))
+	g.struct_decl_infos.reserve(u32(struct_count * 2 + 256))
+	g.struct_decl_short_infos.reserve(u32(struct_count + 256))
+	g.global_types.reserve(u32(global_count * 2 + 64))
+	g.global_raw_type_texts.reserve(u32(global_count * 2 + 64))
+	g.global_modules.reserve(u32(global_count * 3 + 64))
+	g.global_files.reserve(u32(global_count * 2 + 64))
+	g.global_inits.reserve(u32(global_count * 2 + 64))
+	g.const_vals.reserve(u32(const_count * 2 + 64))
+	g.const_modules.reserve(u32(const_count * 2 + 64))
+	g.const_files.reserve(u32(const_count * 2 + 64))
+	g.enum_vals.reserve(u32(enum_field_count * 2 + 64))
+	g.enum_value_exprs.reserve(u32(enum_field_count * 2 + 64))
+	g.interfaces.reserve(u32(interface_count * 2 + 64))
+	g.modules.reserve(u32(import_count * 2 + 64))
+	g.module_imports.reserve(u32(import_count + 64))
+	if !isnil(g.c_name_cache) {
+		mut cache := g.c_name_cache
+		cache.entries.reserve(fn_alias_count)
+	}
+}
+
 fn (mut g FlatGen) cached_shared_alias_pointer_type_from_text(raw string) ?types.Type {
 	key := '\x00shared-alias-pointer\x00${g.tc.cur_file}\x00${g.tc.cur_module}\x00${raw}'
 	if cached := g.param_types_cache[key] {
@@ -2083,17 +2214,31 @@ fn (mut g FlatGen) cached_shared_alias_pointer_type_from_text(raw string) ?types
 fn (mut g FlatGen) preseed_unused_fn_ptr_param_types(node flat.Node, module_name string, file string) {
 	g.tc.cur_module = module_name
 	g.tc.cur_file = file
+	typed_params := g.fn_node_param_types(node, module_name)
+	mut param_idx := 0
 	for i in 0 .. node.children_count {
 		child := g.a.child_node(&node, i)
 		if node_kind_id(child) != 75 {
 			continue
 		}
-		raw_type := g.tc.parse_type(child.typ)
+		raw_type := if param_idx < typed_params.len {
+			typed_params[param_idx]
+		} else {
+			g.tc.parse_type(child.typ)
+		}
+		param_idx++
 		param_type := cgen_unalias_type(raw_type)
 		if param_type is types.FnType {
-			// Keep the canonical name available for a later concrete use without
-			// emitting a typedef solely for a function that mark-used discarded.
-			g.register_fn_ptr_type(g.fn_ptr_type_key(param_type))
+			key := g.fn_ptr_type_key(param_type)
+			if file.ends_with('.vh') {
+				// Cached interfaces still emit their declaration prototypes even when
+				// mark-used discards the function body, so their callback typedefs are used.
+				g.resolve_fn_ptr_type(key)
+			} else {
+				// Keep the canonical name available for a later concrete use without
+				// emitting a typedef solely for a discarded source function.
+				g.register_fn_ptr_type(key)
+			}
 		}
 	}
 }
@@ -2216,7 +2361,7 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 					}
 				}
 				g.collect_inlined_c_structs(source_text)
-				g.collect_inlined_c_fns(source_text)
+				g.collect_inlined_c_fns_for_cache(source_text, true, false)
 				g.collect_inlined_c_declared_fns(source_text)
 				source_directive := c_native_source_context_include(source_path)
 				if source_path.ends_with('.m') {
@@ -2251,7 +2396,7 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 			header_text := header.text
 			late_source := c_include_is_late_source(include_arg)
 			g.collect_inlined_c_structs(header_text)
-			g.collect_inlined_c_fns(header_text)
+			g.collect_inlined_c_fns_for_cache(header_text, false, true)
 			g.collect_inlined_c_declared_fns(header_text)
 			g.collect_preserved_c_fns(header.preserved_c_fns)
 			g.collect_preserved_c_structs(header.preserved_c_structs)
@@ -2712,7 +2857,7 @@ fn c_should_preserve_uninlined_include(include_arg string) bool {
 		return false
 	}
 	if clean[0] == `<` {
-		return clean in ['<dlfcn.h>', '<limits.h>', '<math.h>', '<ucontext.h>']
+		return clean in ['<dlfcn.h>', '<limits.h>', '<math.h>', '<sys/ptrace.h>', '<ucontext.h>']
 			|| c_is_apple_framework_include(clean)
 	}
 	return true
@@ -2771,6 +2916,9 @@ fn c_preserved_system_include_declared_fns(include_arg string) []string {
 	if include_arg == '<dlfcn.h>' {
 		return ['dlclose', 'dlerror', 'dlopen', 'dlsym']
 	}
+	if include_arg == '<sys/ptrace.h>' {
+		return ['ptrace']
+	}
 	if include_arg in ['<mach/mach.h>', '<mach/task.h>', '<mach/mach_time.h>'] {
 		return [
 			'host_page_size',
@@ -2807,14 +2955,23 @@ fn c_preserved_system_include_struct_names(include_arg string) []string {
 }
 
 const c_cache_system_header_declared_fns = {
-	'host_page_size':       true
-	'host_statistics64':    true
-	'mach_absolute_time':   true
-	'mach_host_self':       true
-	'mach_port_deallocate': true
-	'mach_task_self':       true
-	'mach_timebase_info':   true
-	'task_info':            true
+	'_dyld_get_image_header': true
+	'getpeername':            true
+	'host_page_size':         true
+	'host_statistics64':      true
+	'mach_absolute_time':     true
+	'mach_host_self':         true
+	'mach_port_deallocate':   true
+	'mach_task_self':         true
+	'mach_timebase_info':     true
+	'inet_pton':              true
+	'ptrace':                 true
+	'recvfrom':               true
+	'sigaddset':              true
+	'sigprocmask':            true
+	'symlink':                true
+	'task_info':              true
+	'unsetenv':               true
 }
 
 const c_cache_system_header_struct_names = {
@@ -3145,18 +3302,34 @@ fn c_typedef_fn_aliases(text string) []string {
 }
 
 fn (mut g FlatGen) collect_inlined_c_fns(text string) {
+	g.collect_inlined_c_fns_for_cache(text, false, false)
+}
+
+fn (mut g FlatGen) collect_inlined_c_fns_for_cache(text string, cache_omitted bool, cache_native bool) {
 	mut pending_static := false
 	mut pending_definition := ''
+	mut conditional_omissions := []CCacheConditionalOmission{}
+	mut native_implementation_omitted := false
 	for line in text.split_into_lines() {
 		clean := trimmed_space(line)
 		if clean.len == 0 {
 			continue
+		}
+		if cache_native && clean.starts_with('#') {
+			native_implementation_omitted = c_cache_native_condition_omitted(clean, mut
+				conditional_omissions)
 		}
 		if pending_definition.len > 0 {
 			brace := clean.index_u8(`{`)
 			close := clean.last_index_u8(`)`)
 			if clean.starts_with('{') || (brace >= 0 && close >= 0 && brace > close) {
 				g.inlined_c_fns[pending_definition] = true
+				if cache_omitted {
+					g.cache_omitted_c_fns[pending_definition] = true
+				}
+				if cache_native && native_implementation_omitted {
+					g.cache_omitted_c_fns[pending_definition] = true
+				}
 				pending_definition = ''
 				continue
 			}
@@ -3168,6 +3341,13 @@ fn (mut g FlatGen) collect_inlined_c_fns(text string) {
 			name := c_header_fn_name(clean)
 			if name.len > 0 {
 				g.inlined_c_fns[name] = true
+				g.inlined_c_static_fns[name] = true
+				if cache_omitted {
+					g.cache_omitted_c_fns[name] = true
+				}
+				if cache_native && native_implementation_omitted {
+					g.cache_omitted_c_fns[name] = true
+				}
 				pending_static = false
 			} else {
 				pending_static = c_static_fn_prefix_can_continue(clean)
@@ -3178,6 +3358,13 @@ fn (mut g FlatGen) collect_inlined_c_fns(text string) {
 			name := c_header_fn_name(clean)
 			if name.len > 0 {
 				g.inlined_c_fns[name] = true
+				g.inlined_c_static_fns[name] = true
+				if cache_omitted {
+					g.cache_omitted_c_fns[name] = true
+				}
+				if cache_native && native_implementation_omitted {
+					g.cache_omitted_c_fns[name] = true
+				}
 				pending_static = false
 				continue
 			}
@@ -3191,10 +3378,86 @@ fn (mut g FlatGen) collect_inlined_c_fns(text string) {
 		}
 		if clean.contains('{') {
 			g.inlined_c_fns[name] = true
+			if cache_omitted {
+				g.cache_omitted_c_fns[name] = true
+			}
+			if cache_native && native_implementation_omitted {
+				g.cache_omitted_c_fns[name] = true
+			}
 		} else {
 			pending_definition = name
 		}
 	}
+}
+
+struct CCacheConditionalOmission {
+	parent_omitted bool
+mut:
+	condition_omitted bool
+}
+
+fn c_cache_native_condition_omitted(directive string, mut stack []CCacheConditionalOmission) bool {
+	name := c_directive_name(directive)
+	arg := c_directive_arg(directive)
+	if name in ['if', 'ifdef', 'ifndef'] {
+		parent_omitted := stack.len > 0
+			&& (stack.last().parent_omitted || stack.last().condition_omitted)
+		condition_omitted := if name == 'ifdef' {
+			c_cache_implementation_macro(arg.fields()[0] or { '' })
+		} else if name == 'if' {
+			c_cache_condition_requires_implementation(arg)
+		} else {
+			false
+		}
+		stack << CCacheConditionalOmission{
+			parent_omitted:    parent_omitted
+			condition_omitted: condition_omitted
+		}
+	} else if name in ['else', 'elif'] && stack.len > 0 {
+		last := stack.len - 1
+		stack[last].condition_omitted = name == 'elif'
+			&& c_cache_condition_requires_implementation(arg)
+	} else if name == 'endif' && stack.len > 0 {
+		stack.delete_last()
+	}
+	return stack.len > 0 && (stack.last().parent_omitted || stack.last().condition_omitted)
+}
+
+fn c_cache_condition_requires_implementation(condition string) bool {
+	mut pos := 0
+	for pos < condition.len {
+		relative := condition[pos..].index('defined') or { break }
+		start := pos + relative
+		mut before := start
+		for before > 0 && condition[before - 1] in [` `, `\t`] {
+			before--
+		}
+		negated := before > 0 && condition[before - 1] == `!`
+		mut name_start := start + 'defined'.len
+		for name_start < condition.len && condition[name_start] in [` `, `\t`, `(`] {
+			name_start++
+		}
+		mut name_end := name_start
+		for name_end < condition.len && c_ident_char(condition[name_end]) {
+			name_end++
+		}
+		if !negated && name_end > name_start
+			&& c_cache_implementation_macro(condition[name_start..name_end]) {
+			return true
+		}
+		pos = if name_end > start { name_end } else { start + 'defined'.len }
+	}
+	for field in condition.fields() {
+		if c_cache_implementation_macro(field.trim('()')) {
+			return true
+		}
+	}
+	return false
+}
+
+fn c_cache_implementation_macro(name string) bool {
+	return name.ends_with('_IMPLEMENTATION')
+		|| (name.starts_with('SOKOL') && name.ends_with('_IMPL'))
 }
 
 // c_strip_comments removes block and line comments so declaration scanning
@@ -5361,6 +5624,11 @@ fn (mut g FlatGen) register_fn_decl_signature_alias(alias string, ptypes []types
 // while retaining the collision-proof per-module parameter/return entries.
 fn (mut g FlatGen) register_fn_decl_signature(name string, full_name string, ptypes []types.Type, shared_params []bool, is_variadic bool, is_mut bool, ret_typ string) {
 	rt := g.tc.parse_type(ret_typ)
+	g.register_fn_decl_signature_type(name, full_name, ptypes, shared_params, is_variadic, is_mut,
+		rt)
+}
+
+fn (mut g FlatGen) register_fn_decl_signature_type(name string, full_name string, ptypes []types.Type, shared_params []bool, is_variadic bool, is_mut bool, rt types.Type) {
 	module_key := fn_decl_module_key(g.tc.cur_module, name)
 	g.fn_decl_param_types[module_key] = ptypes
 	g.fn_decl_ret_types[module_key] = rt
@@ -13903,6 +14171,12 @@ fn (mut g FlatGen) emit_fixed_array_elem_deps(elem types.Type, needed map[string
 			g.emit_fixed_array_typedef(inner_name, inner, needed, mut emitted)
 		}
 	} else if elem is types.FnType {
+		// The function-pointer typedef below can pass fixed arrays by value. Emit
+		// those bare typedefs first even when this function type was discovered as
+		// the element of another fixed array.
+		for param in elem.params {
+			g.emit_fixed_array_elem_deps(param, needed, mut emitted)
+		}
 		encoded := g.tc.c_type(elem)
 		name := g.resolve_fn_ptr_type(encoded)
 		g.emit_fn_ptr_typedef(encoded, name, mut g.emitted_fn_ptr_typedefs)
@@ -14713,8 +14987,13 @@ fn (mut g FlatGen) emit_const(name string, val_id flat.NodeId) {
 	defer {
 		g.tc.cur_file = old_file
 	}
-	if name in g.const_modules {
-		g.tc.cur_module = g.const_modules[name]
+	const_owner := g.const_modules[name] or { '' }
+	if const_owner.len > 0 {
+		g.tc.cur_module = const_owner
+	} else if g.const_primary_name(name).contains('.') {
+		// Cache headers can retain only the qualified const key. Use its owner
+		// while lowering initializer references to sibling consts.
+		g.tc.cur_module = g.const_primary_name(name).all_before_last('.')
 	}
 	// Import-alias qualified type texts (`json.Any`) in the initializer resolve
 	// per file, so parse_type needs the declaring file's context.

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -777,10 +777,11 @@ pub fn (mut g FlatGen) set_cached_support_declarations(source string) {
 }
 
 // cache_external_input_files returns local include/embed inputs grouped by the
-// module whose cached object incorporates their contents. Forced-include inputs
-// affect every object and are kept in a configuration-wide group. The second
-// result reports include forms whose dependencies cannot be resolved statically.
-pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules map[string]bool, initial_c_flags []string, target pref.Target) (map[string][]string, bool) {
+// module whose cached object incorporates their contents, plus the ordered root
+// native source includes for each module. Forced-include inputs affect every
+// object and are kept in a configuration-wide group. The last result reports
+// include forms whose dependencies cannot be resolved statically.
+pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules map[string]bool, initial_c_flags []string, target pref.Target) (map[string][]string, map[string][]string, bool) {
 	mut c_flags := []string{}
 	mut cur_file := ''
 	for node in a.nodes {
@@ -807,6 +808,7 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 		}
 	}
 	mut inputs := map[string][]string{}
+	mut native_source_roots := map[string][]string{}
 	mut has_untracked_include := false
 	mut cur_module := ''
 	cur_file = ''
@@ -837,6 +839,11 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 				if !os.is_file(path) {
 					continue
 				}
+				if c_include_arg_is_source_file(include_arg) {
+					mut roots := native_source_roots[owner_module]
+					roots << os.real_path(path)
+					native_source_roots[owner_module] = roots
+				}
 				mut seen := map[string]bool{}
 				mut files := []string{}
 				if c_collect_external_input_tree(path, vroot, include_dirs, mut seen, mut files) {
@@ -865,7 +872,7 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 		sorted.sort()
 		inputs[module_name] = sorted
 	}
-	return inputs, has_untracked_include
+	return inputs, native_source_roots, has_untracked_include
 }
 
 // cache_c_flag_input_files returns forced include/macro files whose contents

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -9000,12 +9000,7 @@ fn (mut g FlatGen) gen_optional_arg_with_abi(arg_id flat.NodeId, expected types.
 			g.write('}')
 			return true
 		}
-		collapsed_type := g.usable_expr_type(collapsed)
-		if g.optional_type_name_for_expr(collapsed, collapsed_type) == g.optional_type_name(expected) {
-			g.gen_expr(collapsed)
-		} else {
-			g.gen_expr_with_expected_type(collapsed, expected)
-		}
+		g.gen_expr_with_expected_type(collapsed, expected)
 		return true
 	}
 	arg_node := g.a.nodes[int(arg_id)]

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -13237,6 +13237,10 @@ fn (mut g FlatGen) emit_fn_ptr_typedef(encoded string, name string, mut emitted 
 	if emitted[encoded] {
 		return
 	}
+	if g.cached_support_identifiers[name] {
+		emitted[encoded] = true
+		return
+	}
 	emitted[encoded] = true
 	if !encoded.starts_with('fn_ptr:') {
 		return

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -113,6 +113,19 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 			} else {
 				cur_file
 			}
+			if g.program_body_only && !g.cache_program_files[fn_file] && fn_module !in ['', 'main'] {
+				continue
+			}
+			if g.incremental_fn_names.len > 0 {
+				qname := if fn_module in ['', 'main', 'builtin'] {
+					node.value
+				} else {
+					'${fn_module}.${node.value}'
+				}
+				if !g.incremental_fn_names[qname] && !g.incremental_fn_names[node.value] {
+					continue
+				}
+			}
 			if !g.should_emit_fn_node_in_module(node, i, fn_module, fn_file) {
 				continue
 			}
@@ -174,6 +187,7 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 			is_program_specialization: program_specializations[candidate.preferred_name]
 		}
 	}
+	items.sort(a.c_name < b.c_name)
 	return items
 }
 
@@ -198,6 +212,17 @@ fn flat_fn_gen_item_cost(a &flat.FlatAst, node_id flat.NodeId) int {
 	return cost
 }
 
+fn cache_fn_marker_key(file string, module_name string, name string) string {
+	mut hash := u64(1469598103934665603)
+	for part in [file, module_name, name] {
+		for byte in part.bytes() {
+			hash = (hash ^ u64(byte)) * u64(1099511628211)
+		}
+		hash = (hash ^ u64(0xff)) * u64(1099511628211)
+	}
+	return hash.hex()
+}
+
 // gen_fn_items emits fn items output for c.
 fn (mut g FlatGen) gen_fn_items(items []FlatFnGenItem) {
 	for item in items {
@@ -217,16 +242,23 @@ fn (mut g FlatGen) gen_fn_items(items []FlatFnGenItem) {
 		}
 		if g.cache_split {
 			// Generic templates are source-parsed even when their module object is
-			// cached. Their program-specific concrete specializations belong to the
-			// main translation unit, not to the source-stable module object.
-			module_name := if is_program_fn || item.module.len == 0 {
+			// cached. Program-specific concrete specializations are separated from
+			// both source-stable module objects and the frequently edited program
+			// translation unit, so the dev dylib can retain them across body edits.
+			module_name := if item.is_program_specialization && item.module !in ['', 'main'] {
+				'__v3_program_specializations'
+			} else if is_program_fn || item.module.len == 0 {
 				'main'
 			} else {
 				item.module
 			}
 			g.writeln('/* V3CACHE_MODULE ${module_name} */')
+			g.writeln('/* V3CACHE_FN_BEGIN ${cache_fn_marker_key(item.file, item.module, node.value)} */')
 		}
 		g.gen_fn_in_module(node, item.module)
+		if g.cache_split {
+			g.writeln('/* V3CACHE_FN_END ${cache_fn_marker_key(item.file, item.module, node.value)} */')
+		}
 	}
 }
 
@@ -11684,8 +11716,8 @@ fn (mut g FlatGen) forward_decl_items(items []FlatFnGenItem, mut forwarded_expor
 fn (mut g FlatGen) cached_header_forward_decls() {
 	mut cur_file := ''
 	mut cur_module := ''
-	mut forwarded := map[string]bool{}
-	for node in g.a.nodes {
+	mut items := []FlatFnGenItem{}
+	for node_idx, node in g.a.nodes {
 		if node.kind == .file {
 			cur_file = node.value
 			cur_module = ''
@@ -11707,14 +11739,25 @@ fn (mut g FlatGen) cached_header_forward_decls() {
 		if !node.is_mut && (node.generic_params().len > 0 || node.value.contains('[')) {
 			continue
 		}
-		qfn := g.fn_c_name_in_module(cur_module, node.value)
+		items << FlatFnGenItem{
+			node_id: flat.NodeId(node_idx)
+			file:    cur_file
+			module:  cur_module
+			c_name:  g.fn_c_name_in_module(cur_module, node.value)
+		}
+	}
+	items.sort(a.c_name < b.c_name)
+	mut forwarded := map[string]bool{}
+	for item in items {
+		qfn := item.c_name
 		if forwarded[qfn] {
 			continue
 		}
 		forwarded[qfn] = true
-		g.tc.cur_file = cur_file
-		g.tc.cur_module = cur_module
-		ret_type := g.fn_node_return_type(node, cur_module)
+		node := g.a.nodes[int(item.node_id)]
+		g.tc.cur_file = item.file
+		g.tc.cur_module = item.module
+		ret_type := g.fn_node_return_type(node, item.module)
 		g.write(g.fn_return_type_name(ret_type))
 		g.write(' ')
 		g.write(qfn)

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -671,6 +671,9 @@ fn (mut g FlatGen) direct_call_name(name string) string {
 		return 'v_free'
 	}
 	if name == 'new_map' {
+		if g.tc.cur_module == 'builtin' {
+			return 'new_map'
+		}
 		return 'main__new_map'
 	}
 	if name == 'int_str' {
@@ -4487,6 +4490,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 			}
 			mut call_args_name := fn_name
 			call_name := if user_name := g.main_runtime_shadow_call_c_name(node, fn_node) {
+				call_args_name = 'main.${fn_name}'
 				user_name
 			} else if resolved_target_name.len > 0 && resolved_target_name != fn_name {
 				call_args_name = resolved_target_name
@@ -11691,7 +11695,16 @@ fn (mut g FlatGen) cached_header_forward_decls() {
 			cur_module = node.value
 			continue
 		}
-		if node.kind != .fn_decl || !node.is_mut || !cur_file.ends_with('.vh') {
+		if node.kind != .fn_decl || !cur_file.ends_with('.vh') {
+			continue
+		}
+		// Most cached functions are declaration-only nodes (`is_mut` is the parser's
+		// header marker). A small subset retains its source body so the warm pass can
+		// recreate generic specializations. Their ordinary concrete symbol still lives
+		// in the cached object and can be called by a program-generated interface
+		// dispatch, so it needs the same extern prototype. Open generic declarations
+		// have no concrete C symbol of their own.
+		if !node.is_mut && (node.generic_params().len > 0 || node.value.contains('[')) {
 			continue
 		}
 		qfn := g.fn_c_name_in_module(cur_module, node.value)
@@ -11769,11 +11782,15 @@ fn (mut g FlatGen) c_extern_forward_decls() {
 		if cfn !in decls {
 			names << cfn
 		}
-		decls[cfn] = g.c_extern_decl_line(node, cfn)
+		decls[cfn] = c_cache_safe_extern_decl(cfn, g.c_extern_decl_line(node, cfn), g.cache_split)
 	}
 	names.sort()
 	for name in names {
-		if name == 'task_info' || name == 'mach_task_self' {
+		if g.c_extern_decl_is_cached_object_fallback(name) {
+			g.writeln('#ifndef V3CACHE_PROGRAM_UNIT')
+			g.writeln(decls[name])
+			g.writeln('#endif')
+		} else if name == 'task_info' || name == 'mach_task_self' {
 			g.writeln('#ifndef __APPLE__')
 			g.writeln(decls[name])
 			g.writeln('#endif')
@@ -11891,6 +11908,26 @@ const c_shared_runtime_extern_symbols = {
 	'pthread_rwlockattr_destroy':    true
 }
 
+const c_cache_macro_sensitive_extern_symbols = {
+	'exp':   true
+	'exp2':  true
+	'log10': true
+	'log1p': true
+	'log2':  true
+	'logb':  true
+	'logf':  true
+	'powf':  true
+	'sqrtf': true
+	'tanf':  true
+}
+
+fn c_cache_safe_extern_decl(cfn string, declaration string, cache_split bool) string {
+	if !cache_split || cfn !in c_cache_macro_sensitive_extern_symbols {
+		return declaration
+	}
+	return declaration.replace_once('${cfn}(', '(${cfn})(')
+}
+
 fn (g &FlatGen) should_emit_c_extern_decl(cfn string) bool {
 	if cfn.contains('.') {
 		return false
@@ -11914,12 +11951,21 @@ fn (g &FlatGen) should_emit_c_extern_decl(cfn string) bool {
 		return false
 	}
 	if cfn in g.inlined_c_fns {
+		if g.cache_split && cfn in g.cache_omitted_c_fns && cfn !in g.inlined_c_static_fns
+			&& cfn !in g.inlined_c_declared_fns {
+			return true
+		}
 		return false
 	}
 	if cfn in g.inlined_c_declared_fns {
 		return false
 	}
 	return true
+}
+
+fn (g &FlatGen) c_extern_decl_is_cached_object_fallback(cfn string) bool {
+	return g.cache_split && cfn in g.inlined_c_fns && cfn in g.cache_omitted_c_fns
+		&& cfn !in g.inlined_c_static_fns && cfn !in g.inlined_c_declared_fns
 }
 
 fn (g &FlatGen) should_emit_c_extern_decl_from_file(cfn string, source_file string) bool {
@@ -11943,6 +11989,7 @@ const c_system_libc_preamble_declared_fns = {
 	'bind':                          true
 	'chdir':                         true
 	'chmod':                         true
+	'chown':                         true
 	'clock_gettime_nsec_np':         true
 	'clock_gettime':                 true
 	'closedir':                      true
@@ -11953,27 +12000,38 @@ const c_system_libc_preamble_declared_fns = {
 	'fdopen':                        true
 	'feof':                          true
 	'ferror':                        true
+	'fgets':                         true
 	'fputs':                         true
 	'freeaddrinfo':                  true
 	'gai_strerror':                  true
 	'getaddrinfo':                   true
 	'getcwd':                        true
 	'getpeername':                   true
+	'getegid':                       true
+	'geteuid':                       true
+	'getgid':                        true
+	'gethostname':                   true
 	'getpid':                        true
 	'gettimeofday':                  true
 	'getuid':                        true
 	'gmtime_r':                      true
+	'getline':                       true
 	'inet_ntop':                     true
 	'ioctl':                         true
 	'isatty':                        true
+	'link':                          true
 	'localtime_r':                   true
 	'log':                           true
 	'lstat':                         true
 	'mkdir':                         true
+	'mkstemp':                       true
 	'mmap':                          true
 	'opendir':                       true
 	'popen':                         true
 	'printf':                        true
+	'pthread_getspecific':           true
+	'pthread_key_delete':            true
+	'pthread_setspecific':           true
 	'pthread_mutex_trylock':         true
 	'pthread_cond_timedwait':        true
 	'pthread_rwlock_init':           true
@@ -11988,12 +12046,14 @@ const c_system_libc_preamble_declared_fns = {
 	'readdir':                       true
 	'recv':                          true
 	'recvfrom':                      true
+	'readlink':                      true
 	'rewind':                        true
 	'rmdir':                         true
 	'send':                          true
 	'sendto':                        true
 	'setsockopt':                    true
 	'shutdown':                      true
+	'sigemptyset':                   true
 	'sin':                           true
 	'sinf':                          true
 	'socket':                        true
@@ -13347,34 +13407,6 @@ fn (mut g FlatGen) collect_multi_return_types() {
 			continue
 		}
 		g.collect_concrete_multi_return_type(g.tc.expr_type_values[idx])
-	}
-	mut cur_module := ''
-	mut cur_file := ''
-	for node in g.a.nodes {
-		kind_id := node_kind_id(node)
-		if kind_id == 77 {
-			cur_file = node.value
-			g.tc.cur_file = cur_file
-			cur_module = ''
-			g.tc.cur_module = cur_module
-			continue
-		}
-		if kind_id == 73 {
-			cur_module = node.value
-			g.tc.cur_file = cur_file
-			g.tc.cur_module = cur_module
-			continue
-		}
-		g.tc.cur_file = cur_file
-		g.tc.cur_module = cur_module
-		// emit_multi_return_typedef only acts on (optionally `?`/`!`-wrapped) multi-return
-		// types, whose string form always begins with `(`. Skip parse_type for everything
-		// else — this ran on every node's type (~hundreds of thousands of parse_type calls).
-		typ := node.typ
-		if typ.len > 0 && (typ[0] == `(` || ((typ[0] == `?` || typ[0] == `!`) && typ.len > 1
-			&& typ[1] == `(`)) {
-			g.collect_concrete_multi_return_type(g.tc.parse_type(typ))
-		}
 	}
 	g.multi_return_types_ready = true
 }

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -809,6 +809,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		test_files:                     if result_only { g.test_files } else { g.test_files.clone() }
 		cache_program_files:            g.cache_program_files
 		incremental_fn_names:           g.incremental_fn_names
+		cached_support_identifiers:     g.cached_support_identifiers
 		str_lits:                       if result_only {
 			clone_cgen_string_list(g.str_lits)
 		} else if g.scope_parallel_workers {

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -7,9 +7,9 @@ import v3.flat
 import v3.types
 import v3.workers
 
-const max_flat_cgen_jobs = 2
+const max_flat_cgen_jobs = 10
 const min_flat_cgen_parallel_items = 1024
-const scoped_cgen_worker_batches = 256
+const scoped_cgen_worker_batches = 4
 
 $if !windows {
 	// FlatCgenChunkArgs represents flat cgen chunk args data used by c.
@@ -166,11 +166,30 @@ fn (mut g FlatGen) write_scoped_cgen_batch_output(batch &FlatGen) bool {
 		g.output_error = err.msg()
 		return false
 	}
-	unsafe {
-		file.write_full_buffer(batch.sb.data, usize(batch.sb.len)) or {
+	if batch.cache_split {
+		mut b := unsafe { batch }
+		source := b.sb.str()
+		stable_source := b.rewrite_cache_string_symbols(source)
+		file.write_string(stable_source) or {
 			g.output_error = err.msg()
 			file.close()
+			unsafe {
+				source.free()
+				stable_source.free()
+			}
 			return false
+		}
+		unsafe {
+			source.free()
+			stable_source.free()
+		}
+	} else {
+		unsafe {
+			file.write_full_buffer(batch.sb.data, usize(batch.sb.len)) or {
+				g.output_error = err.msg()
+				file.close()
+				return false
+			}
 		}
 	}
 	file.close()
@@ -220,7 +239,12 @@ fn (mut g FlatGen) absorb_scoped_cgen_batch(batch &FlatGen, output_streamed bool
 		}
 	}
 	for def in batch.spawn_wrapper_defs {
-		g.add_spawn_wrapper_def(def.clone())
+		if batch.cache_split {
+			stable_def := b.rewrite_cache_string_symbols(def)
+			g.add_spawn_wrapper_def(stable_def)
+		} else {
+			g.add_spawn_wrapper_def(def.clone())
+		}
 	}
 	for key, name in batch.callback_wrapper_names {
 		if key !in g.callback_wrapper_names {
@@ -228,7 +252,12 @@ fn (mut g FlatGen) absorb_scoped_cgen_batch(batch &FlatGen, output_streamed bool
 		}
 	}
 	for def in batch.callback_wrapper_defs {
-		g.add_callback_wrapper_def(def.clone())
+		if batch.cache_split {
+			stable_def := b.rewrite_cache_string_symbols(def)
+			g.add_callback_wrapper_def(stable_def)
+		} else {
+			g.add_callback_wrapper_def(def.clone())
+		}
 	}
 }
 
@@ -378,7 +407,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			g.a.worker_pool = workers.new(runtime.nr_jobs() - 1)
 		}
 		n_jobs := flat_cgen_job_count(g.a.worker_pool.size() + 1, n_items)
-		if g.output_path.len > 0 && !g.cache_split && g.scope_parallel_workers {
+		if g.output_path.len > 0 && g.scope_parallel_workers {
 			g.scoped_fn_output_path = '${g.output_path}.v3-fns.tmp.0'
 			g.scoped_fn_output_paths = [g.scoped_fn_output_path]
 			os.rm(g.scoped_fn_output_path) or {}
@@ -570,6 +599,15 @@ fn (mut g FlatGen) fn_item_cost_and_prep(node_id flat.NodeId, mut stack []flat.N
 // prepare_parallel_items supports prepare parallel items handling for FlatGen.
 fn (mut g FlatGen) prepare_parallel_items(items []FlatFnGenItem) {
 	mut stack := []flat.NodeId{cap: 256}
+	// Function bodies can materialize literals from declaration metadata (for
+	// example struct-field defaults) that lives outside every function subtree.
+	// Intern all source literals before workers fork so their numeric IDs remain
+	// valid regardless of which chunk first references that metadata.
+	for node in g.a.nodes {
+		if node.kind == .string_literal {
+			g.intern_string(node.value)
+		}
+	}
 	// The cache is keyed by the bare type text and reset whenever the
 	// file/module context changes (items are grouped by file, so resets are
 	// rare); the old composite '${file}\n${module}\n${typ}' key allocated a
@@ -1150,7 +1188,11 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 	}
 	worker_output := ww.sb.str()
 	if worker_output.len > 0 {
-		if string_id_remap.len > 0 {
+		if g.cache_split {
+			stable_output := ww.rewrite_cache_string_symbols(worker_output)
+			g.fn_segs << stable_output
+			unsafe { worker_output.free() }
+		} else if string_id_remap.len > 0 {
 			g.fn_segs << remap_scoped_worker_string_symbols(worker_output, string_id_remap,
 				user_c_symbols)
 			unsafe { worker_output.free() }
@@ -1163,10 +1205,18 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 	// The ordered segment owns the copied output; release the worker builder.
 	unsafe { ww.sb.free() }
 	for segment in w.fn_segs {
-		g.fn_segs << if string_id_remap.len > 0 {
-			remap_scoped_worker_string_symbols(segment, string_id_remap, user_c_symbols)
+		if g.cache_split {
+			g.fn_segs << ww.rewrite_cache_string_symbols(segment)
+		} else if string_id_remap.len > 0 {
+			g.fn_segs << remap_scoped_worker_string_symbols(segment, string_id_remap,
+				user_c_symbols)
 		} else {
-			segment.clone()
+			g.fn_segs << segment.clone()
+		}
+	}
+	if g.cache_split {
+		for literal in w.str_lits {
+			g.intern_string(literal.clone())
 		}
 	}
 	for opt_name, val_type in w.needed_optional_types {
@@ -1196,11 +1246,14 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 		}
 	}
 	for def in w.spawn_wrapper_defs {
-		g.add_spawn_wrapper_def(if string_id_remap.len > 0 {
-			remap_scoped_worker_string_symbols(def, string_id_remap, user_c_symbols)
+		if g.cache_split {
+			g.add_spawn_wrapper_def(ww.rewrite_cache_string_symbols(def))
+		} else if string_id_remap.len > 0 {
+			g.add_spawn_wrapper_def(remap_scoped_worker_string_symbols(def, string_id_remap,
+				user_c_symbols))
 		} else {
-			def.clone()
-		})
+			g.add_spawn_wrapper_def(def.clone())
+		}
 	}
 	for key, name in w.callback_wrapper_names {
 		if key !in g.callback_wrapper_names {
@@ -1208,11 +1261,14 @@ fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 		}
 	}
 	for def in w.callback_wrapper_defs {
-		g.add_callback_wrapper_def(if string_id_remap.len > 0 {
-			remap_scoped_worker_string_symbols(def, string_id_remap, user_c_symbols)
+		if g.cache_split {
+			g.add_callback_wrapper_def(ww.rewrite_cache_string_symbols(def))
+		} else if string_id_remap.len > 0 {
+			g.add_callback_wrapper_def(remap_scoped_worker_string_symbols(def, string_id_remap,
+				user_c_symbols))
 		} else {
-			def.clone()
-		})
+			g.add_callback_wrapper_def(def.clone())
+		}
 	}
 }
 
@@ -1230,20 +1286,6 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 		}
 		if isnil(g.a.worker_pool) {
 			g.a.worker_pool = workers.new(runtime.nr_jobs() - 1)
-		}
-		if g.scope_parallel_workers {
-			scan_scope := cgen_worker_scope_begin(true)
-			mut scan := g.new_parallel_worker(0)
-			scan.collect_fixed_storage_consts()
-			scan.precompute_param_type_index()
-			scan.precompute_concrete_optional_abi_fns()
-			cgen_worker_scope_leave(scan_scope)
-			g.fixed_storage_consts = scan.fixed_storage_consts.clone()
-			g.param_types_by_short = clone_param_types_by_short(scan.param_types_by_short)
-			g.concrete_optional_abi_fns = scan.concrete_optional_abi_fns.clone()
-			cgen_worker_scope_free(scan_scope)
-			g.prepare_pre_dispatch_master()
-			return true
 		}
 		mut fs_worker := g.new_parallel_worker(0)
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -195,7 +195,9 @@ fn (mut g FlatGen) absorb_scoped_cgen_batch(batch &FlatGen, output_streamed bool
 		g.intern_string(literal.clone())
 	}
 	for opt_name, val_type in batch.needed_optional_types {
-		g.needed_optional_types[opt_name.clone()] = val_type.clone()
+		if opt_name !in g.needed_optional_types {
+			g.needed_optional_types[opt_name.clone()] = val_type.clone()
+		}
 	}
 	for encoded, name in batch.fn_ptr_types {
 		if encoded !in g.fn_ptr_types {
@@ -352,7 +354,16 @@ fn (mut g FlatGen) publish_fixed_storage_scan(mut fs_worker FlatGen) {
 // gen_fns_dispatch emits fns dispatch output for c.
 fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 	if no_parallel {
-		g.gen_fns()
+		if g.scope_parallel_workers {
+			items := g.ensure_fn_gen_items()
+			if items.len < min_flat_cgen_parallel_items {
+				g.gen_fn_items(items)
+			} else {
+				g.gen_fn_items_scoped_master_batches(items)
+			}
+		} else {
+			g.gen_fns()
+		}
 		g.gen_synthetic_main_after_fns()
 		return
 	}
@@ -374,7 +385,11 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 		}
 		if n_items < min_flat_cgen_parallel_items || n_jobs <= 1 {
 			if g.scope_parallel_workers {
-				g.gen_fn_items_scoped_master_batches(items)
+				if n_items < min_flat_cgen_parallel_items {
+					g.gen_fn_items(items)
+				} else {
+					g.gen_fn_items_scoped_master_batches(items)
+				}
 			} else {
 				g.gen_fn_items(items)
 			}
@@ -753,6 +768,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		used_fns:                       g.used_fns
 		used_fn_names:                  g.used_fn_names
 		test_files:                     if result_only { g.test_files } else { g.test_files.clone() }
+		cache_program_files:            g.cache_program_files
 		str_lits:                       if result_only {
 			clone_cgen_string_list(g.str_lits)
 		} else if g.scope_parallel_workers {
@@ -934,78 +950,79 @@ fn (g &FlatGen) clone_parallel_type_checker() &types.TypeChecker {
 	// over the immutable checked scope instead of cloning the full symbol table.
 	fs := types.new_scope(g.tc.file_scope)
 	mut wtc := &types.TypeChecker{
-		a:                                  unsafe { g.tc.a }
-		fn_ret_types:                       g.tc.fn_ret_types
-		fn_param_types:                     g.tc.fn_param_types
-		fn_ret_type_texts:                  g.tc.fn_ret_type_texts
-		fn_param_type_texts:                g.tc.fn_param_type_texts
-		fn_type_files:                      g.tc.fn_type_files
-		fn_type_modules:                    g.tc.fn_type_modules
-		fn_generic_params:                  g.tc.fn_generic_params
-		specialized_generic_fns:            g.tc.specialized_generic_fns
-		fn_variadic:                        g.tc.fn_variadic
-		fn_implicit_veb_ctx:                g.tc.fn_implicit_veb_ctx
-		c_variadic_fns:                     g.tc.c_variadic_fns
-		structs:                            g.tc.structs
-		struct_modules:                     g.tc.struct_modules
-		struct_files:                       g.tc.struct_files
-		soa_structs:                        g.tc.soa_structs
-		struct_error_embeds_shadow_builtin: g.tc.struct_error_embeds_shadow_builtin
-		struct_generic_params:              g.tc.struct_generic_params
-		struct_field_c_abi_fns:             g.tc.struct_field_c_abi_fns
-		unions:                             g.tc.unions
-		type_aliases:                       g.tc.type_aliases
-		type_alias_generic_params:          g.tc.type_alias_generic_params
-		type_alias_c_abi_fns:               g.tc.type_alias_c_abi_fns
-		sum_types:                          g.tc.sum_types
-		sum_generic_params:                 g.tc.sum_generic_params
-		enum_names:                         g.tc.enum_names
-		enum_fields:                        g.tc.enum_fields
-		flag_enums:                         g.tc.flag_enums
-		interface_names:                    g.tc.interface_names
-		interface_fields:                   g.tc.interface_fields
-		interface_embeds:                   g.tc.interface_embeds
-		interface_abstract_methods:         g.tc.interface_abstract_methods
-		interface_impl_name_snapshots:      g.tc.interface_impl_name_snapshots
-		c_globals:                          g.tc.c_globals
-		const_types:                        g.tc.const_types
-		const_exprs:                        g.tc.const_exprs
-		const_modules:                      g.tc.const_modules
-		const_files:                        g.tc.const_files
-		const_suffixes:                     g.tc.const_suffixes
-		imports:                            g.tc.imports
-		file_imports:                       g.tc.file_imports
-		file_selective_imports:             g.tc.file_selective_imports
-		file_modules:                       g.tc.file_modules
-		file_scope:                         g.tc.file_scope
-		cur_scope:                          fs
-		scope_pool:                         []&types.Scope{}
-		has_builtins:                       g.tc.has_builtins
-		resolution_type_mode:               g.tc.resolution_type_mode
-		cur_module:                         g.tc.cur_module
-		cur_file:                           g.tc.cur_file
-		errors:                             g.tc.errors.clone()
-		resolved_call_names:                g.tc.resolved_call_names
-		resolved_call_set:                  g.tc.resolved_call_set
-		resolved_fn_value_names:            g.tc.resolved_fn_value_names
-		resolved_fn_value_set:              g.tc.resolved_fn_value_set
-		statement_nodes:                    g.tc.statement_nodes
-		expr_type_values:                   g.tc.expr_type_values
-		expr_type_set:                      g.tc.expr_type_set
-		checking_nodes:                     g.tc.checking_nodes
-		parallel_check_sparse:              g.tc.parallel_check_sparse
-		check_range_lo:                     g.tc.check_range_lo
-		check_range_hi:                     g.tc.check_range_hi
-		sparse_resolved_call_names:         g.tc.sparse_resolved_call_names
-		sparse_resolved_fn_values:          g.tc.sparse_resolved_fn_values
-		sparse_statement_nodes:             g.tc.sparse_statement_nodes
-		sparse_expr_type_values:            g.tc.sparse_expr_type_values
-		sparse_checking_nodes:              g.tc.sparse_checking_nodes
-		diagnose_unknown_calls:             g.tc.diagnose_unknown_calls
-		reject_unlowered_map_mutation:      g.tc.reject_unlowered_map_mutation
-		diagnostic_files:                   g.tc.diagnostic_files
-		selected_file_called_fns:           g.tc.selected_file_called_fns
-		smartcasts:                         g.tc.smartcasts
+		a:                                     unsafe { g.tc.a }
+		fn_ret_types:                          g.tc.fn_ret_types
+		fn_param_types:                        g.tc.fn_param_types
+		fn_ret_type_texts:                     g.tc.fn_ret_type_texts
+		fn_param_type_texts:                   g.tc.fn_param_type_texts
+		fn_type_files:                         g.tc.fn_type_files
+		fn_type_modules:                       g.tc.fn_type_modules
+		fn_generic_params:                     g.tc.fn_generic_params
+		specialized_generic_fns:               g.tc.specialized_generic_fns
+		fn_variadic:                           g.tc.fn_variadic
+		fn_implicit_veb_ctx:                   g.tc.fn_implicit_veb_ctx
+		c_variadic_fns:                        g.tc.c_variadic_fns
+		structs:                               g.tc.structs
+		struct_modules:                        g.tc.struct_modules
+		struct_files:                          g.tc.struct_files
+		soa_structs:                           g.tc.soa_structs
+		struct_error_embeds_shadow_builtin:    g.tc.struct_error_embeds_shadow_builtin
+		struct_generic_params:                 g.tc.struct_generic_params
+		struct_field_c_abi_fns:                g.tc.struct_field_c_abi_fns
+		unions:                                g.tc.unions
+		type_aliases:                          g.tc.type_aliases
+		type_alias_generic_params:             g.tc.type_alias_generic_params
+		type_alias_c_abi_fns:                  g.tc.type_alias_c_abi_fns
+		sum_types:                             g.tc.sum_types
+		sum_generic_params:                    g.tc.sum_generic_params
+		enum_names:                            g.tc.enum_names
+		enum_fields:                           g.tc.enum_fields
+		flag_enums:                            g.tc.flag_enums
+		interface_names:                       g.tc.interface_names
+		interface_fields:                      g.tc.interface_fields
+		interface_embeds:                      g.tc.interface_embeds
+		interface_abstract_methods:            g.tc.interface_abstract_methods
+		interface_impl_name_snapshots:         g.tc.interface_impl_name_snapshots
+		interface_impl_candidates_at_snapshot: g.tc.interface_impl_candidates_at_snapshot
+		c_globals:                             g.tc.c_globals
+		const_types:                           g.tc.const_types
+		const_exprs:                           g.tc.const_exprs
+		const_modules:                         g.tc.const_modules
+		const_files:                           g.tc.const_files
+		const_suffixes:                        g.tc.const_suffixes
+		imports:                               g.tc.imports
+		file_imports:                          g.tc.file_imports
+		file_selective_imports:                g.tc.file_selective_imports
+		file_modules:                          g.tc.file_modules
+		file_scope:                            g.tc.file_scope
+		cur_scope:                             fs
+		scope_pool:                            []&types.Scope{}
+		has_builtins:                          g.tc.has_builtins
+		resolution_type_mode:                  g.tc.resolution_type_mode
+		cur_module:                            g.tc.cur_module
+		cur_file:                              g.tc.cur_file
+		errors:                                g.tc.errors.clone()
+		resolved_call_names:                   g.tc.resolved_call_names
+		resolved_call_set:                     g.tc.resolved_call_set
+		resolved_fn_value_names:               g.tc.resolved_fn_value_names
+		resolved_fn_value_set:                 g.tc.resolved_fn_value_set
+		statement_nodes:                       g.tc.statement_nodes
+		expr_type_values:                      g.tc.expr_type_values
+		expr_type_set:                         g.tc.expr_type_set
+		checking_nodes:                        g.tc.checking_nodes
+		parallel_check_sparse:                 g.tc.parallel_check_sparse
+		check_range_lo:                        g.tc.check_range_lo
+		check_range_hi:                        g.tc.check_range_hi
+		sparse_resolved_call_names:            g.tc.sparse_resolved_call_names
+		sparse_resolved_fn_values:             g.tc.sparse_resolved_fn_values
+		sparse_statement_nodes:                g.tc.sparse_statement_nodes
+		sparse_expr_type_values:               g.tc.sparse_expr_type_values
+		sparse_checking_nodes:                 g.tc.sparse_checking_nodes
+		diagnose_unknown_calls:                g.tc.diagnose_unknown_calls
+		reject_unlowered_map_mutation:         g.tc.reject_unlowered_map_mutation
+		diagnostic_files:                      g.tc.diagnostic_files
+		selected_file_called_fns:              g.tc.selected_file_called_fns
+		smartcasts:                            g.tc.smartcasts
 		// Read-only map cgen uses to recover substituted signatures for generic-receiver
 		// method values (`Box[int].method` as a callback); without it a parallel worker
 		// sees an empty map and gen_method_value_closure falls through.

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -8,7 +8,7 @@ import v3.types
 import v3.workers
 
 const max_flat_cgen_jobs = 10
-const min_flat_cgen_parallel_items = 1024
+const min_flat_cgen_parallel_items = 128
 const scoped_cgen_worker_batches = 4
 
 $if !windows {
@@ -805,8 +805,10 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		a:                              unsafe { g.a }
 		used_fns:                       g.used_fns
 		used_fn_names:                  g.used_fn_names
+		fn_gen_items:                   g.fn_gen_items
 		test_files:                     if result_only { g.test_files } else { g.test_files.clone() }
 		cache_program_files:            g.cache_program_files
+		incremental_fn_names:           g.incremental_fn_names
 		str_lits:                       if result_only {
 			clone_cgen_string_list(g.str_lits)
 		} else if g.scope_parallel_workers {
@@ -960,6 +962,8 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		callback_wrapper_names:     g.callback_wrapper_names.clone()
 		callback_wrapper_defs:      g.callback_wrapper_defs.clone()
 		callback_wrapper_defs_seen: g.callback_wrapper_defs_seen.clone()
+		c_extern_refs:              g.c_extern_refs
+		c_extern_refs_ready:        g.c_extern_refs_ready
 		scope_parallel_workers:     g.scope_parallel_workers
 		c_name_cache:               &CNameCache{}
 		// The const short-name index is read-only after its first build (the

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -236,6 +236,13 @@ fn (g &FlatGen) interface_dispatch_target_is_emitted(concrete_key string) bool {
 	if !g.has_used_fn_filter() {
 		return true
 	}
+	if source_file := g.tc.fn_type_files[concrete_key] {
+		// Cache-header declarations are intentionally absent from the program's
+		// used-function set; their implementations live in linked module objects.
+		if source_file.ends_with('.vh') {
+			return true
+		}
+	}
 	if g.used_interface_dispatch_key(concrete_key) {
 		return true
 	}
@@ -1589,6 +1596,10 @@ fn (mut g FlatGen) gen_interface_dispatch_with_fallback(iface_name string, cn st
 				call += ')'
 				if ret_ct == 'void' {
 					g.writeln('${call}; return;')
+				} else if g.gen_interface_dispatch_wrapped_return(call, ret_type, g.tc.fn_ret_types[decl] or {
+					ret_type
+				})
+				{
 				} else {
 					g.writeln('return ${call};')
 				}
@@ -1643,6 +1654,10 @@ fn (mut g FlatGen) gen_interface_dispatch_with_fallback(iface_name string, cn st
 			call += ')'
 			if ret_ct == 'void' {
 				g.writeln('${call}; return;')
+			} else if g.gen_interface_dispatch_wrapped_return(call, ret_type, g.tc.fn_ret_types[method_key] or {
+				ret_type
+			})
+			{
 			} else {
 				g.writeln('return ${call};')
 			}
@@ -1659,6 +1674,68 @@ fn (mut g FlatGen) gen_interface_dispatch_with_fallback(iface_name string, cn st
 		g.writeln('\treturn (${ret_ct}){0};')
 	}
 	g.writeln('}')
+}
+
+// gen_interface_dispatch_wrapped_return adapts an option/result whose successful
+// concrete payload implements the interface returned by the dispatch signature.
+fn (mut g FlatGen) gen_interface_dispatch_wrapped_return(call string, expected types.Type, actual types.Type) bool {
+	expected_base := interface_dispatch_wrapped_base_type(expected) or { return false }
+	actual_base := interface_dispatch_wrapped_base_type(actual) or { return false }
+	expected_iface_type := cgen_unalias_type(expected_base)
+	if expected_iface_type !is types.Interface {
+		return false
+	}
+	expected_iface := expected_iface_type as types.Interface
+	actual_clean := cgen_unalias_type(actual_base)
+	actual_value := if actual_clean is types.Pointer { actual_clean.base_type } else { actual_clean }
+	if cgen_unalias_type(actual_value) is types.Interface {
+		return false
+	}
+	type_id := g.iface_type_id_for_concrete(expected_iface.name, actual_value)
+	if type_id == 0 {
+		return false
+	}
+	actual_ct := g.fn_return_type_name(actual)
+	expected_ct := g.fn_return_type_name(expected)
+	iface_ct := g.tc.c_type(expected_iface_type)
+	concrete_ct := g.tc.c_type(actual_value)
+	result := g.interface_tmp('iface_result')
+	out := g.interface_tmp('iface_result_out')
+	g.writeln('{')
+	g.writeln('\t\t\t${actual_ct} ${result} = ${call};')
+	g.writeln('\t\t\t${expected_ct} ${out} = { .ok = ${result}.ok, .err = ${result}.err };')
+	g.writeln('\t\t\tif (${result}.ok) {')
+	g.write('\t\t\t\t${out}.value = (${iface_ct}){._typ = ${type_id}, ._object = ')
+	if actual_clean is types.Pointer {
+		g.write('${result}.value, ._object_is_boxed = false')
+	} else {
+		g.write('memdup(&${result}.value, sizeof(${concrete_ct})), ._object_is_boxed = true')
+	}
+	for field in g.interface_cached_fields(expected_iface.name) {
+		field_ct := g.tc.c_type(field.typ)
+		field_name := g.cname(field.name)
+		if actual_clean is types.Pointer {
+			g.write(', .${field_name} = ${result}.value ? ${result}.value->${field_name} : (${field_ct}){0}')
+		} else {
+			g.write(', .${field_name} = ${result}.value.${field_name}')
+		}
+	}
+	g.writeln('};')
+	g.writeln('\t\t\t}')
+	g.writeln('\t\t\treturn ${out};')
+	g.writeln('\t\t}')
+	return true
+}
+
+fn interface_dispatch_wrapped_base_type(typ types.Type) ?types.Type {
+	match typ {
+		types.OptionType, types.ResultType {
+			return typ.base_type
+		}
+		else {
+			return none
+		}
+	}
 }
 
 fn (mut g FlatGen) interface_boxed_type_marked_for_dispatch(iface_name string, concrete string) bool {

--- a/vlib/v3/gen/c/interface_test.v
+++ b/vlib/v3/gen/c/interface_test.v
@@ -1,6 +1,11 @@
 module c
 
+import os
 import v3.flat
+import v3.markused
+import v3.parser
+import v3.pref
+import v3.transform
 import v3.types
 
 fn test_collect_interface_impls_includes_boxed_maps() {
@@ -17,4 +22,56 @@ fn test_collect_interface_impls_includes_boxed_maps() {
 
 	assert 'map[string]int' in g.iface_impls['Any']
 	assert g.iface_type_ids['Any::map[string]int'] > 0
+}
+
+fn test_incremental_cgen_collects_interface_type_ids() {
+	source_path := os.join_path(os.temp_dir(), 'v3_incremental_cgen_interface_ids.v')
+	os.write_file(source_path, 'module main
+
+interface Speaker {
+	speak() string
+}
+
+struct Cat {}
+
+fn (cat Cat) speak() string {
+	_ = cat
+	return "cat"
+}
+
+fn selected_speaker() Speaker {
+	return Cat{}
+}
+
+fn main() {
+	println(selected_speaker().speak())
+}
+') or {
+		panic(err)
+	}
+	defer {
+		os.rm(source_path) or {}
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_file(source_path)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.diagnose_unknown_calls = true
+	tc.diagnostic_files[source_path] = true
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	transform.transform(mut a, &tc)
+	tc.annotate_types()
+	used_fns := markused.mark_used(a, tc)
+	mut g := FlatGen.new()
+	g.set_cache_split(true)
+	g.set_program_body_only(true)
+	g.set_incremental_fn_names({
+		'selected_speaker': true
+	})
+	c_source := g.gen_with_used_options(a, used_fns, &tc, true)
+	assert g.iface_type_ids['Speaker::Cat'] > 0
+	assert c_source.contains('selected_speaker'), c_source
+	assert !c_source.contains('._typ = 0'), c_source
 }

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -37,6 +37,23 @@ fn test_scoped_parallel_dispatch_worker_owns_string_snapshot() {
 	assert g.str_lits == ['source', 'master generated']
 }
 
+fn test_scoped_parallel_worker_reuses_preselected_functions_and_c_extern_refs() {
+	mut g, _ := parallel_worker_test_gen(true)
+	g.fn_gen_items = [FlatFnGenItem{
+		c_name: 'main__run'
+	}]
+	g.c_extern_refs['puts'] = true
+	g.c_extern_refs_ready = true
+
+	w := g.new_parallel_worker(1)
+	assert w.fn_gen_items.len == 1
+	assert w.fn_gen_items[0].c_name == 'main__run'
+	assert w.c_extern_refs == {
+		'puts': true
+	}
+	assert w.c_extern_refs_ready
+}
+
 fn test_parallel_checker_clone_preserves_sparse_transform_caches() {
 	g, mut tc := parallel_worker_test_gen(false)
 	tc.a.nodes = [flat.Node{

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -30,6 +30,27 @@ fn test_multiline_inlined_c_function_definition_is_collected() {
 	assert 'declared_with_anon_param' !in g.inlined_c_fns
 }
 
+fn test_cache_tracks_omitted_native_function_definitions() {
+	mut g := FlatGen.new()
+	g.collect_inlined_c_fns_for_cache('int native_source_fn(void) { return 1; }', true, false)
+	g.collect_inlined_c_fns_for_cache('int native_header_fn(void) { return 2; }', false, true)
+	g.collect_inlined_c_fns_for_cache('#ifdef FONTSTASH_IMPLEMENTATION\nint omitted_header_fn(void) { return 4; }\n#endif',
+		false, true)
+	g.collect_inlined_c_fns_for_cache('static int native_static_fn(void) { return 3; }', false,
+		true)
+
+	assert 'native_source_fn' in g.cache_omitted_c_fns
+	assert 'native_header_fn' !in g.cache_omitted_c_fns
+	assert 'omitted_header_fn' in g.cache_omitted_c_fns
+	assert 'native_static_fn' in g.inlined_c_static_fns
+}
+
+fn test_cache_extern_declaration_avoids_tgmath_macro_expansion() {
+	assert c_cache_safe_extern_decl('exp', 'double exp(double x);', true) == 'double (exp)(double x);'
+	assert c_cache_safe_extern_decl('exp', 'double exp(double x);', false) == 'double exp(double x);'
+	assert c_cache_safe_extern_decl('custom', 'int custom(int x);', true) == 'int custom(int x);'
+}
+
 fn test_builtin_abi_compat_macros_precede_late_c_source() {
 	mut g := FlatGen.new()
 	g.has_builtins = true

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -32,9 +32,12 @@ fn test_multiline_inlined_c_function_definition_is_collected() {
 
 fn test_cache_tracks_omitted_native_function_definitions() {
 	mut g := FlatGen.new()
+	g.cache_split = true
 	g.collect_inlined_c_fns_for_cache('int native_source_fn(void) { return 1; }', true, false)
 	g.collect_inlined_c_fns_for_cache('int native_header_fn(void) { return 2; }', false, true)
 	g.collect_inlined_c_fns_for_cache('#ifdef FONTSTASH_IMPLEMENTATION\nint omitted_header_fn(void) { return 4; }\n#endif',
+		false, true)
+	g.collect_inlined_c_fns_for_cache('#ifndef FOO_IMPLEMENTATION\nint else_implementation_fn(void);\n#else\nint else_implementation_fn(void) { return 5; }\n#endif',
 		false, true)
 	g.collect_inlined_c_fns_for_cache('static int native_static_fn(void) { return 3; }', false,
 		true)
@@ -42,6 +45,8 @@ fn test_cache_tracks_omitted_native_function_definitions() {
 	assert 'native_source_fn' in g.cache_omitted_c_fns
 	assert 'native_header_fn' !in g.cache_omitted_c_fns
 	assert 'omitted_header_fn' in g.cache_omitted_c_fns
+	assert 'else_implementation_fn' in g.cache_omitted_c_fns
+	assert g.should_emit_c_extern_decl('else_implementation_fn')
 	assert 'native_static_fn' in g.inlined_c_static_fns
 }
 

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -31,6 +31,8 @@ fn test_multiline_inlined_c_function_definition_is_collected() {
 }
 
 fn test_cache_tracks_omitted_native_function_definitions() {
+	assert !c_cache_condition_is_negated_implementation_guard('!defined(FOO_IMPLEMENTATION) && FEATURE')
+	assert !c_cache_condition_is_negated_implementation_guard('!!FOO_IMPLEMENTATION')
 	mut g := FlatGen.new()
 	g.cache_split = true
 	g.collect_inlined_c_fns_for_cache('int native_source_fn(void) { return 1; }', true, false)
@@ -38,6 +40,10 @@ fn test_cache_tracks_omitted_native_function_definitions() {
 	g.collect_inlined_c_fns_for_cache('#ifdef FONTSTASH_IMPLEMENTATION\nint omitted_header_fn(void) { return 4; }\n#endif',
 		false, true)
 	g.collect_inlined_c_fns_for_cache('#ifndef FOO_IMPLEMENTATION\nint else_implementation_fn(void);\n#else\nint else_implementation_fn(void) { return 5; }\n#endif',
+		false, true)
+	g.collect_inlined_c_fns_for_cache('#if !defined(BAR_IMPLEMENTATION)\nint negated_guard_fn(void);\n#else\nint negated_guard_fn(void) { return 6; }\n#endif',
+		false, true)
+	g.collect_inlined_c_fns_for_cache('#if ( ! defined ( BAZ_IMPLEMENTATION ) )\nint spaced_negated_guard_fn(void);\n#else\nint spaced_negated_guard_fn(void) { return 7; }\n#endif',
 		false, true)
 	g.collect_inlined_c_fns_for_cache('static int native_static_fn(void) { return 3; }', false,
 		true)
@@ -47,6 +53,10 @@ fn test_cache_tracks_omitted_native_function_definitions() {
 	assert 'omitted_header_fn' in g.cache_omitted_c_fns
 	assert 'else_implementation_fn' in g.cache_omitted_c_fns
 	assert g.should_emit_c_extern_decl('else_implementation_fn')
+	assert 'negated_guard_fn' in g.cache_omitted_c_fns
+	assert g.should_emit_c_extern_decl('negated_guard_fn')
+	assert 'spaced_negated_guard_fn' in g.cache_omitted_c_fns
+	assert g.should_emit_c_extern_decl('spaced_negated_guard_fn')
 	assert 'native_static_fn' in g.inlined_c_static_fns
 }
 

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -4243,6 +4243,17 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 					v_type = cast_type
 				}
 			}
+			if rhs.kind == .call && rhs.children_count > 0
+				&& g.call_callee_uses_specialized_generic_abi(g.a.child(&rhs, 0)) {
+				call_type := g.declared_call_return_type(rhs_id)
+				if call_type !is types.Unknown && call_type !is types.Void {
+					// Comptime field expansion can leave a local annotation as the
+					// unqualified source spelling (`&App`). The concrete generic call
+					// already carries its declaring module (`&gg.App`) and is the ABI
+					// authority for the generated declaration.
+					v_type = call_type
+				}
+			}
 			if rhs.kind == .struct_init
 				&& (v_type is types.OptionType || v_type is types.ResultType) {
 				rhs_type := g.usable_expr_type(rhs_id)
@@ -4257,7 +4268,16 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 					v_type = lock_type
 				}
 			}
-			if shared_alias_ptr := g.decl_shared_alias_pointer_type(node, lhs, rhs) {
+			if rhs.kind == .ident && g.local_storage_is_shared(rhs.value) {
+				// Reading a shared parameter yields its inner value. A specialized generic
+				// declaration can still carry `shared T` as its annotation; do not use the
+				// wrapper-pointer ABI for the value copied out through `storage->val`.
+				if inner := shared_inner_type_text(node.typ) {
+					v_type = g.tc.parse_type(g.shared_qualify_type_text(inner, g.tc.cur_module))
+				} else if shared_alias_ptr := g.decl_shared_alias_pointer_type(node, lhs, rhs) {
+					v_type = shared_alias_ptr
+				}
+			} else if shared_alias_ptr := g.decl_shared_alias_pointer_type(node, lhs, rhs) {
 				v_type = shared_alias_ptr
 			}
 			if rhs.kind == .prefix && rhs.op == .amp && rhs.children_count > 0

--- a/vlib/v3/gen/c/str_intp.v
+++ b/vlib/v3/gen/c/str_intp.v
@@ -345,11 +345,20 @@ fn (mut g FlatGen) string_literals() {
 // anything interned later (worker novelties, the synthetic main) is emitted
 // as a supplement after the joins — per-id definitions are order-independent.
 fn (mut g FlatGen) string_literals_from(start int) {
-	for i := start; i < g.str_lits.len; i++ {
-		s := g.str_lits[i]
-		escaped := c_escape(s)
-		storage := if g.cache_split { 'static ' } else { '' }
-		g.writeln('${storage}string _str_${i} = {"${escaped}", ${s.len}, 1};')
+	if g.cache_split {
+		mut literals := g.str_lits[start..].clone()
+		literals.sort()
+		for s in literals {
+			i := g.str_lit_ids[s]
+			escaped := c_escape(s)
+			g.writeln('static string _str_${i} = {"${escaped}", ${s.len}, 1};')
+		}
+	} else {
+		for i := start; i < g.str_lits.len; i++ {
+			s := g.str_lits[i]
+			escaped := c_escape(s)
+			g.writeln('string _str_${i} = {"${escaped}", ${s.len}, 1};')
+		}
 	}
 	if g.str_lits.len > start {
 		g.writeln('')

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -4066,7 +4066,13 @@ fn (mut g FlatGen) struct_decls() {
 	// structs below (right after the element struct is defined), so struct fields that
 	// reference them resolve. Primitive-element ones were already emitted earlier.
 	fixed_array_needed := g.collect_fixed_array_typedefs_needed()
-	for name in g.tc.structs.keys() {
+	mut struct_names := g.tc.structs.keys()
+	struct_names.sort()
+	mut sum_names := g.tc.sum_types.keys()
+	sum_names.sort()
+	mut interface_names := g.interfaces.keys()
+	interface_names.sort()
+	for name in struct_names {
 		if g.skip_builtin_struct(name) {
 			// An inlined header that defines `struct zip_t` without a typedef
 			// leaves V references to the bare name dangling; supply the alias
@@ -4095,14 +4101,14 @@ fn (mut g FlatGen) struct_decls() {
 		}
 		g.writeln('typedef ${tag} ${cn} ${cn};')
 	}
-	for name in g.tc.sum_types.keys() {
+	for name in sum_names {
 		cn := g.cname(name)
 		if cn == 'mach_timebase_info_data_t' {
 			continue
 		}
 		g.writeln('typedef struct ${cn} ${cn};')
 	}
-	for name in g.interfaces.keys() {
+	for name in interface_names {
 		cn := g.cname(name)
 		if cn == 'mach_timebase_info_data_t' {
 			continue
@@ -4118,11 +4124,11 @@ fn (mut g FlatGen) struct_decls() {
 	mut remaining := map[string]bool{}
 	mut remaining_cnames := map[string]bool{}
 	mut iface_remaining := map[string]bool{}
-	for name in g.interfaces.keys() {
+	for name in interface_names {
 		iface_remaining[name] = true
 		remaining_cnames[g.cname(name)] = true
 	}
-	for name in g.tc.structs.keys() {
+	for name in struct_names {
 		if g.skip_builtin_struct(name) {
 			continue
 		}
@@ -4130,7 +4136,7 @@ fn (mut g FlatGen) struct_decls() {
 		remaining_cnames[g.struct_cname(name)] = true
 	}
 	mut sum_remaining := map[string]bool{}
-	for name in g.tc.sum_types.keys() {
+	for name in sum_names {
 		sum_remaining[name] = true
 		remaining_cnames[g.cname(name)] = true
 	}
@@ -4141,7 +4147,10 @@ fn (mut g FlatGen) struct_decls() {
 		remaining_cnames.delete('string')
 	}
 	mut has_ierror := false
-	for name in iface_remaining.keys() {
+	for name in interface_names {
+		if name !in iface_remaining {
+			continue
+		}
 		if g.is_ierror_type_name(name) {
 			g.emit_interface_struct(name)
 			emitted['IError'] = true
@@ -4167,7 +4176,9 @@ fn (mut g FlatGen) struct_decls() {
 		}
 		mut progress := false
 		mut emitted_ifaces := []string{}
-		for name in iface_remaining.keys() {
+		mut remaining_iface_names := iface_remaining.keys()
+		remaining_iface_names.sort()
+		for name in remaining_iface_names {
 			cn := g.cname(name)
 			mut can_emit := true
 			if g.is_ierror_type_name(name) {
@@ -4204,7 +4215,9 @@ fn (mut g FlatGen) struct_decls() {
 			iface_remaining.delete(name)
 		}
 		mut emitted_structs := []string{}
-		for name in remaining.keys() {
+		mut remaining_struct_names := remaining.keys()
+		remaining_struct_names.sort()
+		for name in remaining_struct_names {
 			cn := g.struct_cname(name)
 			if cn in emitted {
 				remaining_cnames.delete(cn)
@@ -4241,7 +4254,9 @@ fn (mut g FlatGen) struct_decls() {
 			remaining.delete(name)
 		}
 		mut emitted_sums := []string{}
-		for name in sum_remaining.keys() {
+		mut remaining_sum_names := sum_remaining.keys()
+		remaining_sum_names.sort()
+		for name in remaining_sum_names {
 			cn := g.cname(name)
 			mut can_emit_sum := true
 			if name in g.tc.sum_types {
@@ -4285,15 +4300,21 @@ fn (mut g FlatGen) struct_decls() {
 			break
 		}
 	}
-	for name in iface_remaining.keys() {
+	mut final_iface_names := iface_remaining.keys()
+	final_iface_names.sort()
+	for name in final_iface_names {
 		cn := g.cname(name)
 		g.emit_interface_struct(name)
 		emitted[cn] = true
 	}
-	for name in sum_remaining.keys() {
+	mut final_sum_names := sum_remaining.keys()
+	final_sum_names.sort()
+	for name in final_sum_names {
 		g.emit_sum_type(name)
 	}
-	for name in remaining.keys() {
+	mut final_struct_names := remaining.keys()
+	final_struct_names.sort()
+	for name in final_struct_names {
 		if fields := g.tc.structs[name] {
 			g.emit_struct_option_typedefs(fields)
 		}
@@ -4362,7 +4383,9 @@ fn (g &FlatGen) collect_flattened_map_type_alias(typ string, mut names map[strin
 
 // type_forward_decls returns type forward decls data for FlatGen.
 fn (mut g FlatGen) type_forward_decls() {
-	for name in g.tc.structs.keys() {
+	mut struct_names := g.tc.structs.keys()
+	struct_names.sort()
+	for name in struct_names {
 		if g.skip_builtin_struct(name) {
 			continue
 		}
@@ -4377,14 +4400,18 @@ fn (mut g FlatGen) type_forward_decls() {
 		}
 		g.writeln('typedef ${tag} ${cn} ${cn};')
 	}
-	for name in g.tc.sum_types.keys() {
+	mut sum_names := g.tc.sum_types.keys()
+	sum_names.sort()
+	for name in sum_names {
 		cn := g.cname(name)
 		if cn == 'mach_timebase_info_data_t' {
 			continue
 		}
 		g.writeln('typedef struct ${cn} ${cn};')
 	}
-	for name in g.interfaces.keys() {
+	mut interface_names := g.interfaces.keys()
+	interface_names.sort()
+	for name in interface_names {
 		cn := g.cname(name)
 		if cn == 'mach_timebase_info_data_t' {
 			continue

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -224,6 +224,7 @@ fn test_cache_input_scan_uses_requested_target_flags() {
 	os.write_file(source, 'module sample
 #flag ${target_arch} -I target_include
 #include "target.h"
+#include macos <TargetConditionals.h>
 ') or {
 		panic(err)
 	}

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -4,6 +4,21 @@ import os
 import v3.parser
 import v3.pref
 
+fn test_cached_support_declarations_ignore_comments_and_literals() {
+	mut g := FlatGen.new()
+	g.set_cached_support_declarations('typedef int ExistingSupport;
+// Array_fixed_comment_only
+/* _fn_ptr_block_comment_only */
+const char *text = "Option_string_only with \\"escaped\\" text";
+char quote = \'A\';
+')
+	assert g.cached_support_identifiers['ExistingSupport']
+	assert !g.cached_support_identifiers['Array_fixed_comment_only']
+	assert !g.cached_support_identifiers['_fn_ptr_block_comment_only']
+	assert !g.cached_support_identifiers['Option_string_only']
+	assert !g.cached_support_identifiers['escaped']
+}
+
 fn test_c_directive_targets_use_requested_platform() {
 	target := pref.target_from('macos', 'arm64') or { panic(err) }
 	android := pref.target_from('android', 'arm64') or { panic(err) }

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -232,7 +232,7 @@ fn test_cache_input_scan_uses_requested_target_flags() {
 	prefs.target = target
 	mut p := parser.Parser.new(prefs)
 	a := p.parse_file(source)
-	inputs, has_untracked := cache_external_input_files(a, '', {
+	inputs, _, has_untracked := cache_external_input_files(a, '', {
 		'sample': true
 	}, [], target)
 	assert !has_untracked
@@ -260,7 +260,7 @@ fn test_cache_input_scan_uses_initial_cflags() {
 	prefs.target = target
 	mut p := parser.Parser.new(prefs)
 	a := p.parse_file(source)
-	inputs, has_untracked := cache_external_input_files(a, '', {
+	inputs, _, has_untracked := cache_external_input_files(a, '', {
 		'sample': true
 	}, ['-I', include_dir, '-include', 'forced_cli.h'], target)
 	assert !has_untracked
@@ -287,13 +287,40 @@ fn test_cache_input_scan_tracks_imported_headers() {
 	prefs.target = pref.host_target()
 	mut p := parser.Parser.new(prefs)
 	a := p.parse_file(source)
-	inputs, has_untracked := cache_external_input_files(a, '', {
+	inputs, _, has_untracked := cache_external_input_files(a, '', {
 		'sample': true
 	}, [], prefs.target)
 	assert !has_untracked
 	mut expected := [os.real_path(outer_header), os.real_path(imported_header)]
 	expected.sort()
 	assert inputs['sample'] == expected
+}
+
+fn test_cache_input_scan_separates_native_source_roots_from_dependencies() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_native_source_root_inputs_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	root_source := os.join_path(dir, 'root.c')
+	nested_source := os.join_path(dir, 'nested.c')
+	os.write_file(root_source, '#include "nested.c"\n') or { panic(err) }
+	os.write_file(nested_source, 'static int nested_value(void) { return 42; }\n') or { panic(err) }
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample\n#include "root.c"\n') or { panic(err) }
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	inputs, native_roots, has_untracked := cache_external_input_files(a, '', {
+		'sample': true
+	}, [], prefs.target)
+	assert !has_untracked
+	mut expected_inputs := [os.real_path(root_source), os.real_path(nested_source)]
+	expected_inputs.sort()
+	assert inputs['sample'] == expected_inputs
+	assert native_roots['sample'] == [os.real_path(root_source)]
 }
 
 fn test_termux_comptime_branch_uses_canonical_target() {

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -524,6 +524,10 @@ fn (mut g FlatGen) emit_optional_typedef(opt_name string, val_type string) bool 
 	if opt_name in g.emitted_optional_types {
 		return false
 	}
+	if g.cached_support_identifiers[opt_name] {
+		g.emitted_optional_types[opt_name] = true
+		return false
+	}
 	err_field := if g.has_ierror_interface() { 'IError err; ' } else { '' }
 	g.writeln('typedef struct ${opt_name} { bool ok; ${err_field}${val_type} value; } ${opt_name};')
 	g.emitted_optional_types[opt_name] = true

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -243,7 +243,10 @@ fn (mut g FlatGen) optional_payload_c_type(t types.Type) string {
 fn (mut g FlatGen) optional_typedefs() {
 	g.collect_optional_typedefs()
 	mut wrote := false
-	for opt_name, val_type in g.needed_optional_types {
+	mut names := g.needed_optional_types.keys()
+	names.sort()
+	for opt_name in names {
+		val_type := g.needed_optional_types[opt_name]
 		if g.emit_optional_typedef(opt_name, val_type) {
 			wrote = true
 		}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -2840,9 +2840,6 @@ fn (c &CallCollector) type_text_uses_generics_depth(typ string, cur_module strin
 			} else if c.selective_alias_uses_generics(candidate, cur_module, imports, depth + 1) {
 				return true
 			}
-			if c.struct_fields_use_generics(candidate, cur_module, imports, depth + 1) {
-				return true
-			}
 		}
 		start = end
 	}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -170,8 +170,13 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 				}
 			}
 			qname := qualify_fn(cur_module, node.value)
+			// Cached headers retain bodies only when the warm pass must recreate
+			// generated specializations or closure support symbols. Root those bodies
+			// even though their ordinary caller can live entirely in another cached
+			// object and therefore be invisible to the program AST.
+			cached_header_body := cur_file.ends_with('.vh') && !node.is_mut
 			if cache_mode && node.kind == .fn_decl && node.generic_params().len == 0
-				&& cache_modules[cur_module] {
+				&& (cache_modules[cur_module] || cached_header_body) {
 				cache_roots << qname
 			}
 			if qname != node.value {

--- a/vlib/v3/modulecache/file_metadata.c.v
+++ b/vlib/v3/modulecache/file_metadata.c.v
@@ -1,0 +1,23 @@
+module modulecache
+
+#include "@VEXEROOT/vlib/v3/modulecache/file_metadata.h"
+
+fn C.v3_modulecache_file_metadata(&char, &u64, &u64, &u64, &u64, &u64, &u64, &u64) int
+
+// file_metadata_signature returns a precise identity for an unchanged cache input.
+// An empty result makes callers fall back to hashing the file contents.
+pub fn file_metadata_signature(path string) string {
+	mut device := u64(0)
+	mut inode := u64(0)
+	mut size := u64(0)
+	mut mtime_seconds := u64(0)
+	mut mtime_nanoseconds := u64(0)
+	mut ctime_seconds := u64(0)
+	mut ctime_nanoseconds := u64(0)
+	result := C.v3_modulecache_file_metadata(&char(path.str), &device, &inode, &size,
+		&mtime_seconds, &mtime_nanoseconds, &ctime_seconds, &ctime_nanoseconds)
+	if result == 0 {
+		return ''
+	}
+	return '${device}:${inode}:${size}:${mtime_seconds}:${mtime_nanoseconds}:${ctime_seconds}:${ctime_nanoseconds}'
+}

--- a/vlib/v3/modulecache/file_metadata.h
+++ b/vlib/v3/modulecache/file_metadata.h
@@ -1,0 +1,48 @@
+#ifndef V3_MODULECACHE_FILE_METADATA_H
+#define V3_MODULECACHE_FILE_METADATA_H
+
+#include <stdint.h>
+
+#if defined(__APPLE__) || defined(__linux__)
+#include <sys/stat.h>
+
+static int v3_modulecache_file_metadata(const char *path, uint64_t *device, uint64_t *inode,
+	uint64_t *size, uint64_t *mtime_seconds, uint64_t *mtime_nanoseconds,
+	uint64_t *ctime_seconds, uint64_t *ctime_nanoseconds) {
+	struct stat info;
+	if (stat(path, &info) != 0) {
+		return 0;
+	}
+	*device = (uint64_t)info.st_dev;
+	*inode = (uint64_t)info.st_ino;
+	*size = (uint64_t)info.st_size;
+#if defined(__APPLE__)
+	*mtime_seconds = (uint64_t)info.st_mtimespec.tv_sec;
+	*mtime_nanoseconds = (uint64_t)info.st_mtimespec.tv_nsec;
+	*ctime_seconds = (uint64_t)info.st_ctimespec.tv_sec;
+	*ctime_nanoseconds = (uint64_t)info.st_ctimespec.tv_nsec;
+#else
+	*mtime_seconds = (uint64_t)info.st_mtim.tv_sec;
+	*mtime_nanoseconds = (uint64_t)info.st_mtim.tv_nsec;
+	*ctime_seconds = (uint64_t)info.st_ctim.tv_sec;
+	*ctime_nanoseconds = (uint64_t)info.st_ctim.tv_nsec;
+#endif
+	return 1;
+}
+#else
+static int v3_modulecache_file_metadata(const char *path, uint64_t *device, uint64_t *inode,
+	uint64_t *size, uint64_t *mtime_seconds, uint64_t *mtime_nanoseconds,
+	uint64_t *ctime_seconds, uint64_t *ctime_nanoseconds) {
+	(void)path;
+	(void)device;
+	(void)inode;
+	(void)size;
+	(void)mtime_seconds;
+	(void)mtime_nanoseconds;
+	(void)ctime_seconds;
+	(void)ctime_nanoseconds;
+	return 0;
+}
+#endif
+
+#endif

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -1340,7 +1340,7 @@ fn c_declaration_header(prefix string) (string, bool) {
 			continue
 		}
 		if !in_block_comment && trimmed.starts_with('#') {
-			if brace_depth > 0 && is_function_block {
+			if brace_depth > 0 {
 				item.write_string(line)
 				in_preprocessor_directive = c_preprocessor_line_continues(raw_line)
 				preprocessor_in_item = in_preprocessor_directive

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -219,6 +219,9 @@ fn signature_vmod_root(source_file string) (string, string) {
 }
 
 fn compile_time_env_names(source string) []string {
+	if !source.contains('\$env') {
+		return []
+	}
 	mut names := map[string]bool{}
 	mut pos := 0
 	for pos < source.len {
@@ -276,6 +279,9 @@ fn compile_time_env_names(source string) []string {
 }
 
 fn compile_time_pkgconfig_names(source string) []string {
+	if !source.contains('pkgconfig') {
+		return []
+	}
 	mut names := map[string]bool{}
 	mut pos := 0
 	for pos < source.len {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -9,7 +9,7 @@ import v3.types
 pub const builtin_bundle_imports = ['strconv', 'strings', 'hash', 'math.bits']
 pub const builtin_bundle_modules = ['builtin', 'strconv', 'strings', 'hash', 'bits', 'math.bits']
 
-const cache_format = 'v3-module-cache-40'
+const cache_format = 'v3-module-cache-41'
 const c_body_begin = '/* V3CACHE_BODY_BEGIN */'
 const c_body_end = '/* V3CACHE_BODY_END */'
 const c_module_prefix = '/* V3CACHE_MODULE '
@@ -59,6 +59,37 @@ pub:
 	main   string
 	tcc    string
 	prefix string
+}
+
+// GenericProgramEntry contains program-specific dependency specializations that
+// remain valid across edits which do not change the program's generic ABI.
+pub struct GenericProgramEntry {
+pub:
+	specs        string
+	used         string
+	prefix       string
+	declarations string
+	body         string
+	literals     string
+	metadata     string
+	stamp        string
+}
+
+// IncrementalProgramEntry contains a complete program body split into stable
+// function sections plus the semantic/link metadata needed to regenerate only
+// functions whose parsed bodies changed.
+pub struct IncrementalProgramEntry {
+pub:
+	manifest         string
+	body             string
+	used             string
+	specs            string
+	prefix           string
+	declarations     string
+	tcc_declarations string
+	objects          string
+	metadata         string
+	stamp            string
 }
 
 // CSplit contains the declaration/runtime prefix and per-module C function bodies.
@@ -137,6 +168,38 @@ pub fn (m &Manager) cgen_entry(source_files []string) CgenEntry {
 		prepared_prefix:  '${base}.prefix.c'
 		prepared_objects: '${base}.objects'
 		prepared_stamp:   '${base}.prepared.stamp'
+	}
+}
+
+fn (m &Manager) generic_program_entry(source_files []string) GenericProgramEntry {
+	cgen := m.cgen_entry(source_files)
+	base := cgen.source.all_before_last('.c')
+	return GenericProgramEntry{
+		specs:        '${base}.generic.specs'
+		used:         '${base}.generic.used'
+		prefix:       '${base}.generic.prefix.c'
+		declarations: '${base}.generic.declarations.c'
+		body:         '${base}.generic.body.c'
+		literals:     '${base}.generic.literals'
+		metadata:     '${base}.generic.metadata'
+		stamp:        '${base}.generic.stamp'
+	}
+}
+
+fn (m &Manager) incremental_program_entry(source_files []string) IncrementalProgramEntry {
+	cgen := m.cgen_entry(source_files)
+	base := cgen.source.all_before_last('.c')
+	return IncrementalProgramEntry{
+		manifest:         '${base}.incremental.manifest'
+		body:             '${base}.incremental.body.c'
+		used:             '${base}.incremental.used'
+		specs:            '${base}.incremental.specs'
+		prefix:           '${base}.incremental.prefix.c'
+		declarations:     '${base}.incremental.declarations.c'
+		tcc_declarations: '${base}.incremental.tcc.declarations.c'
+		objects:          '${base}.incremental.objects'
+		metadata:         '${base}.incremental.metadata'
+		stamp:            '${base}.incremental.stamp'
 	}
 }
 
@@ -549,6 +612,27 @@ pub fn (m &Manager) valid_cgen(source_files []string, generation_signature strin
 	return entry
 }
 
+// valid_generic_program reports whether cached dependency specializations match
+// the program's type/call shape and all module cache inputs.
+pub fn (m &Manager) valid_generic_program(source_files []string, semantic_signature string, generation_signature string, dependency_inputs map[string]string) ?GenericProgramEntry {
+	if !m.enabled || source_files.len == 0 || semantic_signature.len == 0 {
+		return none
+	}
+	entry := m.generic_program_entry(source_files)
+	if !os.is_file(entry.specs) || !os.is_file(entry.used) || !os.is_file(entry.prefix)
+		|| !os.is_file(entry.declarations) || !os.is_file(entry.body) || !os.is_file(entry.literals)
+		|| !os.is_file(entry.metadata) || !os.is_file(entry.stamp) {
+		return none
+	}
+	stamp := os.read_file(entry.stamp) or { return none }
+	expected := cgen_entry_stamp(m.salt, semantic_signature, dependency_inputs,
+		'generic-v6\n${generation_signature}')
+	if stamp != expected {
+		return none
+	}
+	return entry
+}
+
 // write_cgen atomically commits a whole-program C plan and its generation metadata.
 pub fn (m &Manager) write_cgen(source_files []string, generation_signature string, dependency_inputs map[string]string, source string, metadata string) !CgenEntry {
 	if !m.ensure_dir() {
@@ -563,6 +647,76 @@ pub fn (m &Manager) write_cgen(source_files []string, generation_signature strin
 	write_atomic(entry.metadata, metadata)!
 	stamp := cgen_entry_stamp(m.salt, m.source_signature(source_files), dependency_inputs,
 		generation_signature)
+	write_atomic(entry.stamp, stamp)!
+	return entry
+}
+
+// write_generic_program atomically publishes dependency specialization
+// metadata. The stamp is written last so readers cannot observe mixed payloads.
+pub fn (m &Manager) write_generic_program(source_files []string, semantic_signature string, generation_signature string, dependency_inputs map[string]string, specs string, used string, prefix string, declarations string, body string, literals string, metadata string) !GenericProgramEntry {
+	if !m.ensure_dir() {
+		return error('v3 module cache directory is unavailable')
+	}
+	entry := m.generic_program_entry(source_files)
+	os.rm(entry.stamp) or {}
+	write_atomic(entry.specs, specs)!
+	write_atomic(entry.used, used)!
+	write_atomic(entry.prefix, prefix)!
+	write_atomic(entry.declarations, declarations)!
+	write_atomic(entry.body, body)!
+	write_atomic(entry.literals, literals)!
+	write_atomic(entry.metadata, metadata)!
+	stamp := cgen_entry_stamp(m.salt, semantic_signature, dependency_inputs,
+		'generic-v6\n${generation_signature}')
+	write_atomic(entry.stamp, stamp)!
+	return entry
+}
+
+// valid_incremental_program restores function-level artifacts when declarations,
+// compiler configuration, dependencies, and native inputs are unchanged.
+pub fn (m &Manager) valid_incremental_program(source_files []string, declaration_signature string, generation_signature string, dependency_inputs map[string]string) ?IncrementalProgramEntry {
+	if !m.enabled || source_files.len == 0 || declaration_signature.len == 0 {
+		return none
+	}
+	entry := m.incremental_program_entry(source_files)
+	if !os.is_file(entry.manifest) || !os.is_file(entry.body) || !os.is_file(entry.used)
+		|| !os.is_file(entry.specs) || !os.is_file(entry.prefix) || !os.is_file(entry.declarations)
+		|| !os.is_file(entry.tcc_declarations) || !os.is_file(entry.objects)
+		|| !os.is_file(entry.metadata) || !os.is_file(entry.stamp) {
+		return none
+	}
+	objects := os.read_lines(entry.objects) or { return none }
+	if objects.len == 0 || objects.any(it.len == 0 || !os.is_file(it)) {
+		return none
+	}
+	stamp := os.read_file(entry.stamp) or { return none }
+	expected := cgen_entry_stamp(m.salt, declaration_signature, dependency_inputs,
+		'incremental-v5\n${generation_signature}')
+	if stamp != expected {
+		return none
+	}
+	return entry
+}
+
+// write_incremental_program atomically publishes a function-level program
+// snapshot. The stamp is the commit marker and is written after every payload.
+pub fn (m &Manager) write_incremental_program(source_files []string, declaration_signature string, generation_signature string, dependency_inputs map[string]string, manifest string, body string, used string, specs string, prefix string, declarations string, tcc_declarations string, objects []string, metadata string) !IncrementalProgramEntry {
+	if !m.ensure_dir() {
+		return error('v3 module cache directory is unavailable')
+	}
+	entry := m.incremental_program_entry(source_files)
+	os.rm(entry.stamp) or {}
+	write_atomic(entry.manifest, manifest)!
+	write_atomic(entry.body, body)!
+	write_atomic(entry.used, used)!
+	write_atomic(entry.specs, specs)!
+	write_atomic(entry.prefix, prefix)!
+	write_atomic(entry.declarations, declarations)!
+	write_atomic(entry.tcc_declarations, tcc_declarations)!
+	write_atomic(entry.objects, objects.join('\n'))!
+	write_atomic(entry.metadata, metadata)!
+	stamp := cgen_entry_stamp(m.salt, declaration_signature, dependency_inputs,
+		'incremental-v5\n${generation_signature}')
 	write_atomic(entry.stamp, stamp)!
 	return entry
 }
@@ -878,6 +1032,90 @@ pub fn declaration_header(prefix string) string {
 		pos = body_end + section.end.len
 	}
 	return out.str()
+}
+
+// prune_unreferenced_static_string_definitions removes generated string storage
+// that is referenced only by the program body. Cached module objects carry
+// their own static copies, while the program translation unit retains the full
+// prefix. Keeping body-only strings out of the shared dylib prefix makes an
+// ordinary program literal edit reuse the same cached dylib.
+pub fn prune_unreferenced_static_string_definitions(prefix string) string {
+	mut references := map[string]int{}
+	for line in prefix.split_into_lines() {
+		for symbol in generated_string_symbols(line) {
+			references[symbol]++
+		}
+	}
+	mut out := strings.new_builder(prefix.len)
+	for line in prefix.split_into_lines() {
+		if symbol := generated_static_string_definition_symbol(line) {
+			if references[symbol] == 1 {
+				continue
+			}
+		}
+		out.writeln(line)
+	}
+	return out.str()
+}
+
+// static_string_definitions returns generated literal storage needed by the
+// current program body. Cached dependency declarations omit these records.
+pub fn static_string_definitions(source string) string {
+	mut out := strings.new_builder(4096)
+	for line in source.split_into_lines() {
+		if line.starts_with('static string _v3_lit_') {
+			out.writeln(line)
+		}
+	}
+	return out.str()
+}
+
+fn generated_static_string_definition_symbol(line string) ?string {
+	clean := line.trim_space()
+	prefix := 'static string '
+	if !clean.starts_with(prefix) {
+		return none
+	}
+	start := prefix.len
+	mut end := start
+	for end < clean.len && c_generated_identifier_byte(clean[end]) {
+		end++
+	}
+	if end == start || !clean[start..end].starts_with('_v3_lit_') {
+		return none
+	}
+	tail := clean[end..].trim_space()
+	if !tail.starts_with('=') {
+		return none
+	}
+	return clean[start..end]
+}
+
+fn generated_string_symbols(line string) []string {
+	mut symbols := []string{}
+	mut i := 0
+	for i < line.len {
+		relative := line[i..].index('_v3_lit_') or { break }
+		start := i + relative
+		if start > 0 && c_generated_identifier_byte(line[start - 1]) {
+			i = start + 1
+			continue
+		}
+		mut end := start + '_v3_lit_'.len
+		for end < line.len && c_generated_identifier_byte(line[end]) {
+			end++
+		}
+		if end > start + '_v3_lit_'.len
+			&& (end == line.len || !c_generated_identifier_byte(line[end])) {
+			symbols << line[start..end]
+		}
+		i = end
+	}
+	return symbols
+}
+
+fn c_generated_identifier_byte(c u8) bool {
+	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_`
 }
 
 struct CDeclarationSection {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -9,10 +9,16 @@ import v3.types
 pub const builtin_bundle_imports = ['strconv', 'strings', 'hash', 'math.bits']
 pub const builtin_bundle_modules = ['builtin', 'strconv', 'strings', 'hash', 'bits', 'math.bits']
 
-const cache_format = 'v3-module-cache-29'
+const cache_format = 'v3-module-cache-40'
 const c_body_begin = '/* V3CACHE_BODY_BEGIN */'
 const c_body_end = '/* V3CACHE_BODY_END */'
 const c_module_prefix = '/* V3CACHE_MODULE '
+const c_native_directives_begin = '/* V3CACHE_NATIVE_DIRECTIVES_BEGIN */'
+const c_native_directives_end = '/* V3CACHE_NATIVE_DIRECTIVES_END */'
+const c_source_directives_begin = '/* V3CACHE_SOURCE_DIRECTIVES_BEGIN */'
+const c_source_directives_end = '/* V3CACHE_SOURCE_DIRECTIVES_END */'
+const c_late_directives_begin = '/* V3CACHE_LATE_DIRECTIVES_BEGIN */'
+const c_late_directives_end = '/* V3CACHE_LATE_DIRECTIVES_END */'
 const source_body_marker = '// v3cache: source bodies required'
 
 // Manager owns persistent v3 module cache paths for one compiler configuration.
@@ -569,10 +575,10 @@ fn object_stamp_dependencies_match(stamp string, expected map[string]string) boo
 		}
 		actual[path] = value[tab + 1..]
 	}
-	if actual.len != expected.len {
-		return false
-	}
 	for path, signature in expected {
+		if path !in actual {
+			return false
+		}
 		if actual[path] != signature {
 			return false
 		}
@@ -671,8 +677,109 @@ pub fn split_generated_c(source string) !CSplit {
 // cached module translation units. Type definitions and static helpers stay
 // local; owner functions and storage become declarations resolved from main.o.
 pub fn declaration_header(prefix string) string {
-	header, _ := c_declaration_header(prefix)
-	return header
+	sections := [
+		CDeclarationSection{
+			begin: c_native_directives_begin
+			end:   c_native_directives_end
+			keep:  true
+		},
+		CDeclarationSection{
+			begin: c_source_directives_begin
+			end:   c_source_directives_end
+		},
+		CDeclarationSection{
+			begin: c_late_directives_begin
+			end:   c_late_directives_end
+		},
+	]
+	mut out := strings.new_builder(prefix.len / 2)
+	mut pos := 0
+	for pos < prefix.len {
+		mut next_pos := prefix.len
+		mut selected := -1
+		for i, section in sections {
+			if relative := prefix[pos..].index(section.begin) {
+				absolute := pos + relative
+				if absolute < next_pos {
+					next_pos = absolute
+					selected = i
+				}
+			}
+		}
+		if selected < 0 {
+			header, _ := c_declaration_header(prefix[pos..])
+			out.write_string(header)
+			break
+		}
+		if next_pos > pos {
+			header, _ := c_declaration_header(prefix[pos..next_pos])
+			out.write_string(header)
+		}
+		section := sections[selected]
+		body_start := next_pos + section.begin.len
+		relative_end := prefix[body_start..].index(section.end) or {
+			header, _ := c_declaration_header(prefix[next_pos..])
+			out.write_string(header)
+			break
+		}
+		body_end := body_start + relative_end
+		if section.keep {
+			out.write_string(c_native_declaration_directives(prefix[body_start..body_end]))
+		}
+		pos = body_end + section.end.len
+	}
+	return out.str()
+}
+
+struct CDeclarationSection {
+	begin string
+	end   string
+	keep  bool
+}
+
+fn c_native_declaration_directives(source string) string {
+	mut out := strings.new_builder(source.len)
+	mut in_block_comment := false
+	for line in source.split_into_lines() {
+		trimmed := line.trim_space()
+		line_starts_in_comment := in_block_comment
+		_, _, next_block_comment, _, _ := c_line_braces(line, in_block_comment)
+		in_block_comment = next_block_comment
+		if !line_starts_in_comment && trimmed.starts_with('#define ') {
+			fields := trimmed['#define '.len..].fields()
+			name := if fields.len > 0 { fields[0] } else { '' }
+			if name.ends_with('_IMPLEMENTATION')
+				|| (name.starts_with('SOKOL') && name.ends_with('_IMPL')) {
+				out.writeln('/* v3 cache omitted ${name} */')
+				continue
+			}
+		}
+		out.writeln(line)
+	}
+	return c_native_localize_function_definitions(out.str())
+}
+
+fn c_native_localize_function_definitions(source string) string {
+	mut out := strings.new_builder(source.len + 256)
+	mut brace_depth := 0
+	mut in_block_comment := false
+	for raw_line in source.split_into_lines() {
+		delta, _, next_comment, _, first_open := c_line_braces(raw_line, in_block_comment)
+		if !in_block_comment && brace_depth == 0 && first_open > 0 {
+			head := trim_leading_c_comments(raw_line[..first_open].trim_space())
+			if c_declaration_head_is_function(head) && !c_declaration_head_keeps_definition(head) {
+				indent_len := raw_line.len - raw_line.trim_left(' \t').len
+				out.writeln('${raw_line[..indent_len]}static ${raw_line[indent_len..]}')
+				brace_depth += delta
+				in_block_comment = next_comment
+				continue
+			}
+		}
+		out.writeln(raw_line)
+		brace_depth += delta
+		in_block_comment = next_comment
+	}
+	return out.str()
 }
 
 // c_source_has_static_storage reports whether a local C input would give cached
@@ -685,60 +792,117 @@ pub fn c_source_has_static_storage(source string) bool {
 fn c_declaration_header(prefix string) (string, bool) {
 	mut out := strings.new_builder(prefix.len / 2)
 	mut item := strings.new_builder(512)
+	mut item_head := strings.new_builder(512)
 	mut brace_depth := 0
 	mut has_brace := false
+	mut is_function_block := false
 	mut has_static_storage := false
 	mut in_block_comment := false
 	mut in_preprocessor_directive := false
+	mut preprocessor_in_item := false
+	mut in_extern_c_block := false
 	for raw_line in prefix.split_into_lines() {
 		line := raw_line + '\n'
 		trimmed := raw_line.trim_space()
 		if in_preprocessor_directive {
+			if preprocessor_in_item {
+				item.write_string(line)
+			} else {
+				out.write_string(line)
+			}
+			in_preprocessor_directive = c_preprocessor_line_continues(raw_line)
+			if !in_preprocessor_directive {
+				preprocessor_in_item = false
+			}
+			continue
+		}
+		is_extern_c_open := trimmed.starts_with('extern "C"') && trimmed.ends_with('{')
+		is_extern_c_close := in_extern_c_block && (trimmed == '}' || trimmed.starts_with('} //')
+			|| trimmed.starts_with('} /*'))
+		if !in_block_comment && brace_depth == 0 && (is_extern_c_open || is_extern_c_close) {
+			if item.len > 0 {
+				pending := item.str()
+				if trim_leading_c_comments(pending).len != 0 {
+					item.write_string(line)
+					continue
+				}
+				out.write_string(pending)
+				item_head.clear()
+			}
+			out.write_string(line)
+			in_extern_c_block = is_extern_c_open
+			continue
+		}
+		if !in_block_comment && trimmed.starts_with('#') {
+			if brace_depth > 0 && is_function_block {
+				item.write_string(line)
+				in_preprocessor_directive = c_preprocessor_line_continues(raw_line)
+				preprocessor_in_item = in_preprocessor_directive
+				continue
+			}
+			if brace_depth == 0 && item.len > 0 {
+				pending := item.str()
+				if trim_leading_c_comments(pending).len == 0 {
+					out.write_string(pending)
+					item_head.clear()
+					has_brace = false
+				} else {
+					item.write_string(pending)
+				}
+			}
 			out.write_string(line)
 			in_preprocessor_directive = c_preprocessor_line_continues(raw_line)
 			continue
 		}
-		if brace_depth == 0 && trimmed.starts_with('#') && item.len > 0 {
-			pending := item.str()
-			item = strings.new_builder(512)
-			if trim_leading_c_comments(pending).len == 0 {
-				out.write_string(pending)
-				has_brace = false
-			} else {
-				item.write_string(pending)
-			}
-		}
-		if brace_depth == 0 && item.len == 0
-			&& (trimmed.starts_with('#') || trimmed.len == 0 || trimmed.starts_with('//')) {
+		if !in_block_comment && brace_depth == 0 && item.len == 0
+			&& (trimmed.len == 0 || trimmed.starts_with('//')) {
 			out.write_string(line)
-			if trimmed.starts_with('#') {
-				in_preprocessor_directive = c_preprocessor_line_continues(raw_line)
-			}
 			continue
 		}
 		item.write_string(line)
-		delta, saw_brace, next_comment := c_line_braces(raw_line, in_block_comment)
+		delta, saw_brace, next_comment, last_code, first_open := c_line_braces(raw_line,
+			in_block_comment)
 		in_block_comment = next_comment
 		brace_depth += delta
-		has_brace = has_brace || saw_brace
-		if brace_depth > 0 {
+		if !has_brace {
+			if first_open >= 0 {
+				item_head.write_string(raw_line[..first_open])
+				head := item_head.str()
+				clean_head := trim_leading_c_comments(head.trim_space())
+				is_function_block = c_static_declaration_head_is_function(clean_head)
+			} else {
+				item_head.write_string(line)
+			}
+			has_brace = saw_brace
+		}
+		closes_function_block := is_function_block
+			&& c_function_block_closes_at_line_start(raw_line)
+		if closes_function_block {
+			// C macro functions and conditionally compiled bodies do not always
+			// have balanced raw braces. Their outer closing delimiter is still at
+			// the start of a line, so do not let them consume following #endifs.
+			brace_depth = 0
+		}
+		if in_block_comment || brace_depth > 0 {
 			continue
 		}
 		if has_brace {
 			// Function and type blocks emitted by v3 finish at depth zero. A
 			// typedef/global initializer may carry its semicolon on the same line.
-			if !trimmed.ends_with('}') && !trimmed.ends_with(';') {
+			if !closes_function_block && last_code != `}` && last_code != `;` {
 				continue
 			}
-		} else if !trimmed.ends_with(';') {
+		} else if last_code != `;` {
 			continue
 		}
 		declaration := item.str()
 		has_static_storage = has_static_storage
 			|| c_declaration_item_has_static_storage(declaration, has_brace)
 		out.write_string(c_declaration_item(declaration, has_brace))
-		item = strings.new_builder(512)
+		item_head.clear()
+		brace_depth = 0
 		has_brace = false
+		is_function_block = false
 	}
 	if item.len > 0 {
 		declaration := item.str()
@@ -747,6 +911,10 @@ fn c_declaration_header(prefix string) (string, bool) {
 		out.write_string(c_declaration_item(declaration, has_brace))
 	}
 	return out.str(), has_static_storage
+}
+
+fn c_function_block_closes_at_line_start(line string) bool {
+	return line.len > 0 && line[0] == `}`
 }
 
 fn c_preprocessor_line_continues(line string) bool {
@@ -808,7 +976,7 @@ fn c_declaration_item_has_static_storage(item string, has_brace bool) bool {
 		if brace > 0 {
 			head := clean[..brace].trim_space()
 			storage_head = head
-			if c_declaration_head_is_function(head) {
+			if c_static_declaration_head_is_function(head) {
 				return c_declaration_head_keeps_definition(head)
 					&& c_code_contains_identifier(clean[brace + 1..], 'static')
 			}
@@ -861,7 +1029,23 @@ fn c_has_static_storage_class(value string) bool {
 
 fn c_declaration_head_is_function(value string) bool {
 	return value.contains('(') && !c_contains_parenthesized_pointer_declarator(value)
-		&& !c_contains_declaration_attribute(value) && !c_has_top_level_assign(value)
+		&& !c_contains_declaration_attribute(value) && !c_declaration_head_is_control_flow(value)
+		&& !c_has_top_level_assign(value)
+}
+
+fn c_static_declaration_head_is_function(value string) bool {
+	return value.contains('(') && !c_contains_parenthesized_pointer_declarator(value)
+		&& !c_declaration_head_is_control_flow(value) && !c_has_top_level_assign(value)
+}
+
+fn c_declaration_head_is_control_flow(value string) bool {
+	clean := trim_leading_c_comments(value.trim_space())
+	for keyword in ['if', 'for', 'while', 'switch'] {
+		if clean.starts_with('${keyword}(') || clean.starts_with('${keyword} (') {
+			return true
+		}
+	}
+	return false
 }
 
 fn c_declaration_head_keeps_definition(value string) bool {
@@ -1202,9 +1386,11 @@ fn trim_leading_c_comments(value string) string {
 	return clean
 }
 
-fn c_line_braces(line string, initial_block_comment bool) (int, bool, bool) {
+fn c_line_braces(line string, initial_block_comment bool) (int, bool, bool, u8, int) {
 	mut depth := 0
 	mut saw := false
+	mut last_code := u8(0)
+	mut first_open := -1
 	mut quote := u8(0)
 	mut escaped := false
 	mut block_comment := initial_block_comment
@@ -1230,6 +1416,9 @@ fn c_line_braces(line string, initial_block_comment bool) (int, bool, bool) {
 			} else if c == quote {
 				quote = 0
 			}
+			if c !in [` `, `\t`, `\r`, `\n`] {
+				last_code = c
+			}
 			i++
 			continue
 		}
@@ -1243,26 +1432,39 @@ fn c_line_braces(line string, initial_block_comment bool) (int, bool, bool) {
 		}
 		if c == `'` || c == `"` {
 			quote = c
+			last_code = c
 			i++
 			continue
 		}
 		if c == `{` {
+			if first_open < 0 {
+				first_open = i
+			}
 			depth++
 			saw = true
 		} else if c == `}` {
 			depth--
 			saw = true
 		}
+		if c !in [` `, `\t`, `\r`, `\n`] {
+			last_code = c
+		}
 		i++
 	}
-	return depth, saw, block_comment
+	return depth, saw, block_comment, last_code, first_open
 }
 
 // module_header serializes the declaration-only interface for one flat-AST module.
 pub fn module_header(a &flat.FlatAst, tc &types.TypeChecker, module_name string, vroot string, import_paths map[string]string) string {
 	mut out := strings.new_builder(4096)
 	out.writeln('module ${module_name.all_after_last('.')}')
-	if module_needs_source_bodies(a, tc, module_name) {
+	generic_specialization_callees := generic_specialization_callee_names(tc)
+	needs_source_bodies := module_needs_source_bodies(a, tc, module_name,
+		generic_specialization_callees)
+	mut source_cache := map[string]string{}
+	embed_source_bodies := needs_source_bodies
+		&& module_source_bodies_are_embeddable(a, tc, module_name, generic_specialization_callees, mut source_cache)
+	if needs_source_bodies && !embed_source_bodies {
 		out.writeln(source_body_marker)
 	}
 	out.writeln('')
@@ -1289,13 +1491,38 @@ pub fn module_header(a &flat.FlatAst, tc &types.TypeChecker, module_name string,
 					continue
 				}
 				attrs := declaration_attrs[int(id)] or { CachedDeclarationAttrs{} }
-				mut text := decl_text(a, tc, module_name, node, vroot, file_node.value,
-					import_paths, attrs.attrs)
+				needs_declaration_source := declaration_node_needs_source(a, id)
+					|| node_creates_generic_specialization(a, tc, id, generic_specialization_callees)
+				source_embedded := embed_source_bodies && needs_declaration_source
+					&& declaration_node_source_is_embeddable(a, id)
+				source_attrs_text := declaration_source_attrs_text(a, node, file_node.value, mut
+					source_cache)
+				source_is_public := declaration_source_is_public(a, node, file_node.value, mut
+					source_cache)
+				mut effective_attrs := attrs.attrs.clone()
+				for source_attr in declaration_source_attr_values(source_attrs_text) {
+					if source_attr !in effective_attrs {
+						effective_attrs << source_attr
+					}
+				}
+				mut text := if source_embedded {
+					declaration_source_text(a, node, file_node.value, mut source_cache) or { '' }
+				} else {
+					decl_text(a, tc, module_name, node, vroot, file_node.value, import_paths,
+						effective_attrs, source_is_public)
+				}
 				if text.len == 0 {
 					continue
 				}
-				attrs_text := cached_declaration_attrs_text(attrs)
-				if attrs_text.len > 0 {
+				// Prefer the declaration's source spelling. Attribute marker node ids are
+				// internal parser bookkeeping and can differ when a cache warmup replaces
+				// some source files with headers; the source text is stable across both
+				// layouts and prevents needless dependent-object invalidation.
+				mut attrs_text := source_attrs_text
+				if attrs_text.len == 0 {
+					attrs_text = cached_declaration_attrs_text(attrs)
+				}
+				if attrs_text.len > 0 && (!source_embedded || !text.trim_space().starts_with('@[')) {
 					text = '${attrs_text}\n${text}'
 				}
 				if key.len > 0 {
@@ -1377,6 +1604,75 @@ fn cached_declaration_attrs_text(data CachedDeclarationAttrs) string {
 	return lines.join('\n')
 }
 
+fn declaration_source_attrs_text(a &flat.FlatAst, node flat.Node, file_name string, mut source_cache map[string]string) string {
+	text := declaration_source_text(a, node, file_name, mut source_cache) or { return '' }
+	mut attrs := []string{}
+	for line in text.split_into_lines() {
+		clean := line.trim_space()
+		if !clean.starts_with('@[') || !clean.ends_with(']') {
+			break
+		}
+		attrs << clean
+	}
+	return attrs.join('\n')
+}
+
+fn declaration_source_attr_values(attrs_text string) []string {
+	mut attrs := []string{}
+	for line in attrs_text.split_into_lines() {
+		clean := line.trim_space()
+		if !clean.starts_with('@[') || !clean.ends_with(']') {
+			continue
+		}
+		inner := clean[2..clean.len - 1]
+		mut start := 0
+		mut quote := u8(0)
+		mut escaped := false
+		for i, c in inner.bytes() {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if quote != 0 {
+				if c == `\\` {
+					escaped = true
+				} else if c == quote {
+					quote = 0
+				}
+				continue
+			}
+			if c in [`'`, `"`] {
+				quote = c
+				continue
+			}
+			if c == `;` {
+				attr := inner[start..i].trim_space()
+				if attr.len > 0 {
+					attrs << attr
+				}
+				start = i + 1
+			}
+		}
+		attr := inner[start..].trim_space()
+		if attr.len > 0 {
+			attrs << attr
+		}
+	}
+	return attrs
+}
+
+fn declaration_source_is_public(a &flat.FlatAst, node flat.Node, file_name string, mut source_cache map[string]string) bool {
+	text := declaration_source_text(a, node, file_name, mut source_cache) or { return false }
+	for line in text.split_into_lines() {
+		clean := line.trim_space()
+		if clean.len == 0 || clean.starts_with('@[') {
+			continue
+		}
+		return clean.starts_with('pub ')
+	}
+	return false
+}
+
 fn cached_declaration_attr_source(raw_attr string, kind int) string {
 	attr := raw_attr.trim_space()
 	if attr.len == 0 {
@@ -1418,7 +1714,7 @@ fn append_declaration_nodes(a &flat.FlatAst, id flat.NodeId, mut declarations []
 	declarations << id
 }
 
-fn module_needs_source_bodies(a &flat.FlatAst, tc &types.TypeChecker, module_name string) bool {
+fn module_needs_source_bodies(a &flat.FlatAst, tc &types.TypeChecker, module_name string, generic_callees map[string]bool) bool {
 	for file_node in a.nodes {
 		if file_node.kind != .file || file_node.children_count == 0 {
 			continue
@@ -1430,7 +1726,7 @@ fn module_needs_source_bodies(a &flat.FlatAst, tc &types.TypeChecker, module_nam
 		for i in 0 .. file_node.children_count {
 			id := a.child(&file_node, i)
 			if declaration_node_needs_source(a, id)
-				|| node_creates_generic_specialization(a, tc, id) {
+				|| node_creates_generic_specialization(a, tc, id, generic_callees) {
 				return true
 			}
 		}
@@ -1438,27 +1734,449 @@ fn module_needs_source_bodies(a &flat.FlatAst, tc &types.TypeChecker, module_nam
 	return false
 }
 
-fn node_creates_generic_specialization(a &flat.FlatAst, tc &types.TypeChecker, id flat.NodeId) bool {
+fn module_source_bodies_are_embeddable(a &flat.FlatAst, tc &types.TypeChecker, module_name string, generic_callees map[string]bool, mut source_cache map[string]string) bool {
+	for file_node in a.nodes {
+		if file_node.kind != .file || file_node.children_count == 0
+			|| file_module_name(a, file_node) != module_name {
+			continue
+		}
+		for i in 0 .. file_node.children_count {
+			mut decl_ids := []flat.NodeId{}
+			append_declaration_nodes(a, a.child(&file_node, i), mut decl_ids)
+			for id in decl_ids {
+				needs_source := declaration_node_needs_source(a, id)
+					|| node_creates_generic_specialization(a, tc, id, generic_callees)
+				if !needs_source {
+					continue
+				}
+				node := a.nodes[int(id)]
+				if !declaration_node_source_is_embeddable(a, id) {
+					return false
+				}
+				_ = declaration_source_text(a, node, file_node.value, mut source_cache) or {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+fn declaration_node_source_is_embeddable(a &flat.FlatAst, id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= a.nodes.len {
+		return false
+	}
+	node := a.nodes[int(id)]
+	return node.kind in [.fn_decl, .const_decl, .struct_decl, .enum_decl, .interface_decl, .type_decl,
+		.global_decl, .comptime_if]
+}
+
+fn declaration_source_text(a &flat.FlatAst, node flat.Node, file_name string, mut source_cache map[string]string) ?string {
+	if !node.pos.is_valid() || node.pos.offset < 0 {
+		return none
+	}
+	path := if file_name.len > 0 {
+		file_name
+	} else {
+		file := a.source_files[node.pos.id] or { return none }
+		file.name
+	}
+	source := source_cache[path] or {
+		loaded := os.read_file(path) or { return none }
+		source_cache[path] = loaded
+		loaded
+	}
+	start := declaration_source_start(a, source, node, node.pos.offset) or { return none }
+	end := declaration_source_end(source, node.kind, start, declaration_descendant_end(a, node))
+	if end <= start || end > source.len {
+		return none
+	}
+	return source[start..end]
+}
+
+fn declaration_source_start(a &flat.FlatAst, source string, node flat.Node, anchor int) ?int {
+	if anchor < 0 || anchor > source.len {
+		return none
+	}
+	if node.kind in [.const_decl, .global_decl] {
+		mut line_start := 0
+		for line_start < source.len {
+			line_end := source.index_after('\n', line_start) or { source.len }
+			line := source[line_start..line_end].trim_space()
+			for i in 0 .. node.children_count {
+				name := a.child_node(&node, i).value
+				if name.len > 0 && declaration_source_named_line_matches(line, node.kind, name) {
+					return declaration_source_attribute_start(source, line_start)
+				}
+			}
+			if line_end >= source.len {
+				break
+			}
+			line_start = line_end + 1
+		}
+	}
+	mut pos := if anchor == source.len && anchor > 0 { anchor - 1 } else { anchor }
+	for {
+		mut start := pos
+		for start > 0 && source[start - 1] != `\n` {
+			start--
+		}
+		mut end := pos
+		for end < source.len && source[end] != `\n` {
+			end++
+		}
+		line := source[start..end].trim_space()
+		if declaration_source_line_matches(line, node.kind) {
+			return declaration_source_attribute_start(source, start)
+		}
+		if start == 0 {
+			break
+		}
+		pos = start - 1
+	}
+	return none
+}
+
+fn declaration_source_attribute_start(source string, declaration_start int) int {
+	mut start := declaration_start
+	for start > 0 {
+		mut line_end := start - 1
+		if source[line_end] == `\r` {
+			line_end--
+		}
+		mut line_start := line_end
+		for line_start > 0 && source[line_start - 1] != `\n` {
+			line_start--
+		}
+		line := source[line_start..line_end + 1].trim_space()
+		if !line.starts_with('@[') || !line.ends_with(']') {
+			break
+		}
+		start = line_start
+	}
+	return start
+}
+
+fn declaration_source_named_line_matches(line string, kind flat.NodeKind, name string) bool {
+	return match kind {
+		.const_decl {
+			line.starts_with('const ${name} ') || line.starts_with('const ${name}=')
+				|| line.starts_with('pub const ${name} ') || line.starts_with('pub const ${name}=')
+		}
+		.global_decl {
+			line.starts_with('__global ${name} ') || line.starts_with('__global ${name}=')
+		}
+		else {
+			false
+		}
+	}
+}
+
+fn declaration_source_line_matches(line string, kind flat.NodeKind) bool {
+	clean := line.trim_left(' \t')
+	return match kind {
+		.fn_decl {
+			clean.starts_with('fn ') || clean.starts_with('pub fn ')
+		}
+		.struct_decl {
+			clean.starts_with('struct ') || clean.starts_with('pub struct ')
+				|| clean.starts_with('union ') || clean.starts_with('pub union ')
+		}
+		.enum_decl {
+			clean.starts_with('enum ') || clean.starts_with('pub enum ')
+		}
+		.interface_decl {
+			clean.starts_with('interface ') || clean.starts_with('pub interface ')
+		}
+		.type_decl {
+			clean.starts_with('type ') || clean.starts_with('pub type ')
+		}
+		.const_decl {
+			clean.starts_with('const ') || clean.starts_with('pub const ')
+		}
+		.global_decl {
+			clean.starts_with('__global')
+		}
+		.comptime_if {
+			clean.starts_with('$if ')
+		}
+		else {
+			false
+		}
+	}
+}
+
+fn declaration_descendant_end(a &flat.FlatAst, node flat.Node) int {
+	mut end := if node.pos.end > node.pos.offset { node.pos.end } else { node.pos.offset }
+	for i in 0 .. node.children_count {
+		child := a.child_node(&node, i)
+		child_end := declaration_descendant_end(a, *child)
+		if child_end > end {
+			end = child_end
+		}
+	}
+	return end
+}
+
+fn declaration_source_end(source string, kind flat.NodeKind, start int, descendant_end int) int {
+	if kind in [.fn_decl, .struct_decl, .enum_decl, .interface_decl, .comptime_if] {
+		if end := source_balanced_declaration_end(source, start, `{`, `}`) {
+			return end
+		}
+	}
+	if kind in [.const_decl, .global_decl] {
+		if end := source_value_declaration_end(source, kind, start) {
+			return end
+		}
+	}
+	line_end := source.index_after('\n', start) or { source.len }
+	mut end := if descendant_end > start { descendant_end } else { line_end }
+	for end < source.len && source[end] != `\n` {
+		end++
+	}
+	return end
+}
+
+fn source_value_declaration_end(source string, kind flat.NodeKind, start int) ?int {
+	mut quote := u8(0)
+	mut escaped := false
+	mut line_comment := false
+	mut block_comment := false
+	mut paren_depth := 0
+	mut bracket_depth := 0
+	mut brace_depth := 0
+	mut last_code := u8(0)
+	mut line_start := start
+	mut saw_declaration := false
+	mut i := start
+	for i < source.len {
+		c := source[i]
+		next := if i + 1 < source.len { source[i + 1] } else { u8(0) }
+		if line_comment {
+			if c == `\n` {
+				line_comment = false
+				saw_declaration = saw_declaration
+					|| declaration_source_line_matches(source[line_start..i].trim_space(), kind)
+				if saw_declaration && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+					&& !source_value_line_continues(last_code) {
+					return i
+				}
+				line_start = i + 1
+			}
+			i++
+			continue
+		}
+		if block_comment {
+			if c == `*` && next == `/` {
+				block_comment = false
+				i += 2
+				continue
+			}
+			i++
+			continue
+		}
+		if quote != 0 {
+			if escaped {
+				escaped = false
+			} else if c == `\\` {
+				escaped = true
+			} else if c == quote {
+				quote = 0
+			}
+			i++
+			continue
+		}
+		if c == `/` && next == `/` {
+			line_comment = true
+			i += 2
+			continue
+		}
+		if c == `/` && next == `*` {
+			block_comment = true
+			i += 2
+			continue
+		}
+		if c in [`'`, `"`, `\``] {
+			quote = c
+			last_code = c
+			i++
+			continue
+		}
+		match c {
+			`(` { paren_depth++ }
+			`)` { paren_depth-- }
+			`[` { bracket_depth++ }
+			`]` { bracket_depth-- }
+			`{` { brace_depth++ }
+			`}` { brace_depth-- }
+			else {}
+		}
+		if c == `\n` {
+			saw_declaration = saw_declaration
+				|| declaration_source_line_matches(source[line_start..i].trim_space(), kind)
+			if saw_declaration && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+				&& !source_value_line_continues(last_code) {
+				return i
+			}
+			line_start = i + 1
+		} else if c !in [` `, `\t`, `\r`] {
+			last_code = c
+		}
+		i++
+	}
+	if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 {
+		return source.len
+	}
+	return none
+}
+
+fn source_value_line_continues(last_code u8) bool {
+	return last_code in [`=`, `,`, `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `.`, `?`, `:`, `\\`]
+}
+
+fn source_balanced_declaration_end(source string, start int, open u8, close u8) ?int {
+	mut quote := u8(0)
+	mut escaped := false
+	mut line_comment := false
+	mut block_comment := false
+	mut depth := 0
+	mut found := false
+	mut i := start
+	for i < source.len {
+		c := source[i]
+		next := if i + 1 < source.len { source[i + 1] } else { u8(0) }
+		if line_comment {
+			if c == `\n` {
+				line_comment = false
+			}
+			i++
+			continue
+		}
+		if block_comment {
+			if c == `*` && next == `/` {
+				block_comment = false
+				i += 2
+				continue
+			}
+			i++
+			continue
+		}
+		if quote != 0 {
+			if escaped {
+				escaped = false
+			} else if c == `\\` {
+				escaped = true
+			} else if c == quote {
+				quote = 0
+			}
+			i++
+			continue
+		}
+		if c == `/` && next == `/` {
+			line_comment = true
+			i += 2
+			continue
+		}
+		if c == `/` && next == `*` {
+			block_comment = true
+			i += 2
+			continue
+		}
+		if c in [`'`, `"`, `\``] {
+			quote = c
+			i++
+			continue
+		}
+		if c == open {
+			depth++
+			found = true
+		} else if c == close && found {
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+		i++
+	}
+	return none
+}
+
+fn node_creates_generic_specialization(a &flat.FlatAst, tc &types.TypeChecker, id flat.NodeId, generic_callees map[string]bool) bool {
 	if int(id) < 0 || int(id) >= a.nodes.len {
 		return false
 	}
 	if name := tc.resolved_call_name(id) {
-		if name in tc.fn_generic_params {
+		if name in tc.fn_generic_params || generic_callees[name] {
 			return true
 		}
 	}
 	if name := tc.resolved_fn_value_name(id) {
-		if name in tc.fn_generic_params {
+		if name in tc.fn_generic_params || generic_callees[name] {
 			return true
 		}
 	}
 	node := a.nodes[int(id)]
+	if node.kind == .call && node.children_count > 0 {
+		callee := a.child_node(&node, 0)
+		if callee.kind == .selector && callee.children_count > 0 {
+			receiver_type := tc.resolve_type(a.child(callee, 0)).name().trim_left('&?')
+			receiver_base := receiver_type.all_before('[')
+			if receiver_type.contains('[') && (receiver_base in tc.struct_generic_params
+				|| receiver_base.all_after_last('.') in tc.struct_generic_params) {
+				return true
+			}
+		}
+	}
 	for i in 0 .. node.children_count {
-		if node_creates_generic_specialization(a, tc, a.child(&node, i)) {
+		if node_creates_generic_specialization(a, tc, a.child(&node, i), generic_callees) {
 			return true
 		}
 	}
 	return false
+}
+
+fn generic_specialization_callee_names(tc &types.TypeChecker) map[string]bool {
+	mut names := map[string]bool{}
+	for name in tc.fn_generic_params.keys() {
+		names[name] = true
+	}
+	for name in tc.fn_param_type_texts.keys() {
+		if !name.contains('[') {
+			continue
+		}
+		closed := generic_receiver_name_without_type_args(name)
+		if closed.len == 0 {
+			continue
+		}
+		names[closed] = true
+		receiver := closed.all_before_last('.')
+		method := closed.all_after_last('.')
+		if receiver.contains('.') {
+			names['${receiver.all_after_last('.')}.${method}'] = true
+		}
+	}
+	return names
+}
+
+fn generic_receiver_name_without_type_args(name string) string {
+	mut out := strings.new_builder(name.len)
+	mut depth := 0
+	for c in name.bytes() {
+		if c == `[` {
+			depth++
+			continue
+		}
+		if c == `]` {
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if depth == 0 {
+			out.write_u8(c)
+		}
+	}
+	return out.str()
 }
 
 fn declaration_node_needs_source(a &flat.FlatAst, id flat.NodeId) bool {
@@ -1467,6 +2185,7 @@ fn declaration_node_needs_source(a &flat.FlatAst, id flat.NodeId) bool {
 	}
 	node := a.nodes[int(id)]
 	if node.generic_params().len > 0 || fn_decl_has_generic_receiver(a, node)
+		|| declaration_contains_fn_literal(a, node)
 		|| (node.kind in [.const_decl, .struct_decl, .global_decl]
 		&& declaration_has_unserializable_initializer(a, node))
 		|| node.kind == .comptime_if
@@ -1478,6 +2197,18 @@ fn declaration_node_needs_source(a &flat.FlatAst, id flat.NodeId) bool {
 			if declaration_node_needs_source(a, a.child(&node, i)) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+fn declaration_contains_fn_literal(a &flat.FlatAst, node flat.Node) bool {
+	if node.kind == .fn_literal {
+		return true
+	}
+	for i in 0 .. node.children_count {
+		if declaration_contains_fn_literal(a, *a.child_node(&node, i)) {
+			return true
 		}
 	}
 	return false
@@ -1568,34 +2299,34 @@ fn decl_key(a &flat.FlatAst, node flat.Node) string {
 	}
 }
 
-fn decl_text(a &flat.FlatAst, tc &types.TypeChecker, module_name string, node flat.Node, vroot string, source_file string, import_paths map[string]string, declaration_attrs []string) string {
+fn decl_text(a &flat.FlatAst, tc &types.TypeChecker, module_name string, node flat.Node, vroot string, source_file string, import_paths map[string]string, declaration_attrs []string, source_is_public bool) string {
 	return match node.kind {
 		.import_decl {
 			import_text(a, node, import_paths)
 		}
 		.fn_decl {
-			fn_text(a, module_name, node, false, declaration_attrs)
+			fn_text(a, module_name, node, false, declaration_attrs, source_is_public)
 		}
 		.c_fn_decl {
-			fn_text(a, module_name, node, true, declaration_attrs)
+			fn_text(a, module_name, node, true, declaration_attrs, source_is_public)
 		}
 		.struct_decl {
-			struct_text(a, node, declaration_attrs)
+			struct_text(a, node, declaration_attrs, source_is_public)
 		}
 		.global_decl {
 			global_text(a, tc, module_name, node)
 		}
 		.const_decl {
-			const_text(a, node)
+			const_text(a, tc, node, source_is_public)
 		}
 		.enum_decl {
-			enum_text(a, node, declaration_attrs)
+			enum_text(a, node, declaration_attrs, source_is_public)
 		}
 		.type_decl {
-			type_text(a, node)
+			type_text(a, node, source_is_public)
 		}
 		.interface_decl {
-			interface_text(a, node)
+			interface_text(a, node, source_is_public)
 		}
 		.directive {
 			cached_directive_text(node, vroot, source_file)
@@ -1650,7 +2381,11 @@ fn cached_resolve_relative_include_path(value string, source_file string) string
 	if path.len == 0 || os.is_abs_path(path) {
 		return value
 	}
-	resolved := os.real_path(os.join_path_single(os.dir(source_file), path))
+	candidate := os.join_path_single(os.dir(source_file), path)
+	if !os.exists(candidate) {
+		return value
+	}
+	resolved := os.real_path(candidate)
 	quote_end := quote_start + 1 + quote_end_offset
 	return value[..quote_start + 1] + resolved + value[quote_end..]
 }
@@ -1784,7 +2519,7 @@ fn import_text(a &flat.FlatAst, node flat.Node, import_paths map[string]string) 
 	return text
 }
 
-fn fn_text(a &flat.FlatAst, module_name string, node flat.Node, is_c bool, declaration_attrs []string) string {
+fn fn_text(a &flat.FlatAst, module_name string, node flat.Node, is_c bool, declaration_attrs []string, source_is_public bool) string {
 	mut params := []flat.Node{}
 	for i in 0 .. node.children_count {
 		child := a.child_node(&node, i)
@@ -1793,7 +2528,7 @@ fn fn_text(a &flat.FlatAst, module_name string, node flat.Node, is_c bool, decla
 		}
 	}
 	mut name := node.value
-	visibility := if !is_c && node.op == .arrow { 'pub ' } else { '' }
+	visibility := if !is_c && (node.op == .arrow || source_is_public) { 'pub ' } else { '' }
 	mut head := if is_c { 'fn C.${name}' } else { '${visibility}fn ${name}' }
 	mut param_start := 0
 	if !is_c && name.contains('.') && params.len > 0 {
@@ -1957,9 +2692,10 @@ fn append_struct_field_nodes(a &flat.FlatAst, id flat.NodeId, mut fields []flat.
 	}
 }
 
-fn struct_text(a &flat.FlatAst, node flat.Node, declaration_attrs []string) string {
+fn struct_text(a &flat.FlatAst, node flat.Node, declaration_attrs []string, source_is_public bool) string {
 	kind := if node.typ.split(',').contains('union') { 'union' } else { 'struct' }
-	mut head := '${kind} ${node.value}${generic_suffix(node.generic_params())}'
+	visibility := if source_is_public { 'pub ' } else { '' }
+	mut head := '${visibility}${kind} ${node.value}${generic_suffix(node.generic_params())}'
 	for part in node.typ.split(',') {
 		if part.starts_with('implements=') {
 			head += ' implements ' + part.all_after('=').replace('|', ', ')
@@ -2026,7 +2762,7 @@ fn global_text(a &flat.FlatAst, tc &types.TypeChecker, module_name string, node 
 			field_type = cached_global_type_name(tc, module_name, field.value)
 		}
 		if field_type.len > 0 {
-			line += ' ${field_type}'
+			line += ' ${cached_type_source_text(tc, field_type)}'
 		}
 		if field.children_count > 0 {
 			value := expr_text(a, a.child(field, 0))
@@ -2056,14 +2792,40 @@ fn cached_global_type_name(tc &types.TypeChecker, module_name string, name strin
 	return ''
 }
 
-fn const_text(a &flat.FlatAst, node flat.Node) string {
-	mut out := strings.new_builder(128)
-	out.writeln('const (')
+fn cached_type_source_text(tc &types.TypeChecker, type_text string) string {
+	typ := tc.parse_resolution_type(type_text)
+	if typ is types.ArrayFixed {
+		len_text := if typ.len_expr.len > 0 { typ.len_expr } else { typ.len.str() }
+		return '[${len_text}]${cached_type_source_name(typ.elem_type)}'
+	}
+	return type_text
+}
+
+fn cached_type_source_name(typ types.Type) string {
+	if typ is types.ArrayFixed {
+		len_text := if typ.len_expr.len > 0 { typ.len_expr } else { typ.len.str() }
+		return '[${len_text}]${cached_type_source_name(typ.elem_type)}'
+	}
+	return typ.name()
+}
+
+fn const_text(a &flat.FlatAst, tc &types.TypeChecker, node flat.Node, source_is_public bool) string {
+	mut lines := []string{cap: node.children_count}
 	for i in 0 .. node.children_count {
 		field := a.child_node(&node, i)
-		mut line := '\t${field.value}'
+		mut line := field.value
 		if field.children_count > 0 {
-			value := expr_text(a, a.child(field, 0))
+			expr_id := a.child(field, 0)
+			mut value := expr_text(a, expr_id)
+			expr := a.node(expr_id)
+			if expr.kind == .array_literal {
+				typ := tc.resolve_type(expr_id)
+				if typ is types.Array {
+					// Cache headers are declaration inputs. A bare const literal uses
+					// fixed storage there and disagrees with the cached object's source ABI.
+					value = '${value}.clone()'
+				}
+			}
 			if value.len > 0 {
 				line += ' = ${value}'
 			} else {
@@ -2074,13 +2836,22 @@ fn const_text(a &flat.FlatAst, node flat.Node) string {
 		} else {
 			line += ' int'
 		}
-		out.writeln(line)
+		lines << line
+	}
+	if source_is_public && lines.len == 1 {
+		return 'pub const ${lines[0]}'
+	}
+	mut out := strings.new_builder(128)
+	visibility := if source_is_public { 'pub ' } else { '' }
+	out.writeln('${visibility}const (')
+	for line in lines {
+		out.writeln('\t${line}')
 	}
 	out.write_string(')')
 	return out.str()
 }
 
-fn enum_text(a &flat.FlatAst, node flat.Node, declaration_attrs []string) string {
+fn enum_text(a &flat.FlatAst, node flat.Node, declaration_attrs []string, source_is_public bool) string {
 	mut out := strings.new_builder(128)
 	if node.typ == 'flag' && !cached_declaration_has_attr(declaration_attrs, 'flag') {
 		out.writeln('@[flag]')
@@ -2090,7 +2861,8 @@ fn enum_text(a &flat.FlatAst, node flat.Node, declaration_attrs []string) string
 		&& !cached_declaration_has_attr(declaration_attrs, 'json_as_number') {
 		out.writeln('@[json_as_number]')
 	}
-	mut head := 'enum ${node.value}'
+	visibility := if source_is_public { 'pub ' } else { '' }
+	mut head := '${visibility}enum ${node.value}'
 	if params.len > 0 && params[0].len > 0 {
 		head += ' as ${params[0]}'
 	}
@@ -2113,8 +2885,9 @@ fn enum_text(a &flat.FlatAst, node flat.Node, declaration_attrs []string) string
 	return out.str()
 }
 
-fn type_text(a &flat.FlatAst, node flat.Node) string {
-	head := 'type ${node.value}${generic_suffix(node.generic_params())} = '
+fn type_text(a &flat.FlatAst, node flat.Node, source_is_public bool) string {
+	visibility := if source_is_public { 'pub ' } else { '' }
+	head := '${visibility}type ${node.value}${generic_suffix(node.generic_params())} = '
 	if node.children_count == 0 {
 		return head + node.typ
 	}
@@ -2125,9 +2898,10 @@ fn type_text(a &flat.FlatAst, node flat.Node) string {
 	return head + variants.join(' | ')
 }
 
-fn interface_text(a &flat.FlatAst, node flat.Node) string {
+fn interface_text(a &flat.FlatAst, node flat.Node, source_is_public bool) string {
 	mut out := strings.new_builder(128)
-	out.writeln('interface ${node.value}${generic_suffix(node.generic_params())} {')
+	visibility := if source_is_public { 'pub ' } else { '' }
+	out.writeln('${visibility}interface ${node.value}${generic_suffix(node.generic_params())} {')
 	for i in 0 .. node.children_count {
 		field := a.child_node(&node, i)
 		if field.op == .dot {
@@ -2225,7 +2999,12 @@ fn expr_text(a &flat.FlatAst, id flat.NodeId) string {
 		}
 		.field_init {
 			if node.children_count > 0 {
-				'${node.value}: ${expr_text(a, a.child(&node, 0))}'
+				value := expr_text(a, a.child(&node, 0))
+				if node.value.len > 0 {
+					'${node.value}: ${value}'
+				} else {
+					value
+				}
 			} else {
 				node.value
 			}

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -2478,7 +2478,8 @@ fn module_source_bodies_are_embeddable(a &flat.FlatAst, tc &types.TypeChecker, m
 				source := declaration_source_text(a, node, file_node.value, mut source_cache) or {
 					return false
 				}
-				if source.contains('@LOCATION') || source.contains('@COLUMN') {
+				if source.contains('@LOCATION') || source.contains('@COLUMN')
+					|| source.contains('@VMODHASH') {
 					return false
 				}
 			}
@@ -2692,7 +2693,7 @@ fn cached_embedded_source_paths(source string, vroot string, source_file string,
 
 fn cached_source_pseudo_edit(source string, start int, source_file string, line_nr int) ?CachedSourcePathEdit {
 	mut name := ''
-	for candidate in ['@FILE_LINE', '@FILE', '@DIR', '@LINE'] {
+	for candidate in ['@VMOD_FILE', '@VMODROOT', '@FILE_LINE', '@FILE', '@DIR', '@LINE'] {
 		if source[start..].starts_with(candidate) {
 			name = candidate
 			break
@@ -2707,10 +2708,34 @@ fn cached_source_pseudo_edit(source string, start int, source_file string, line_
 	}
 	file := os.real_path(source_file)
 	value := match name {
-		'@FILE_LINE' { '${file}:${line_nr}' }
-		'@FILE' { file }
-		'@DIR' { os.real_path(os.dir(source_file)) }
-		else { line_nr.str() }
+		'@VMOD_FILE' {
+			_, vmod_file := signature_vmod_root(source_file)
+			if vmod_file.len == 0 {
+				return none
+			}
+			vmod_content := os.read_file(vmod_file) or { return none }
+			vmod_content.replace('\r\n', '\n')
+		}
+		'@VMODROOT' {
+			vmod_root, vmod_file := signature_vmod_root(source_file)
+			if vmod_file.len == 0 {
+				'.'
+			} else {
+				vmod_root
+			}
+		}
+		'@FILE_LINE' {
+			'${file}:${line_nr}'
+		}
+		'@FILE' {
+			file
+		}
+		'@DIR' {
+			os.real_path(os.dir(source_file))
+		}
+		else {
+			line_nr.str()
+		}
 	}
 	return CachedSourcePathEdit{
 		start:       start

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -1200,6 +1200,46 @@ pub fn static_string_definitions(source string) string {
 	return out.str()
 }
 
+// materialize_cached_body_string_definitions restores body-only string storage
+// recorded as cache marker comments. Real definitions in source take precedence.
+pub fn materialize_cached_body_string_definitions(source string) string {
+	marker := '// V3CACHE_BASELINE '
+	if !source.contains(marker) {
+		return source.clone()
+	}
+	mut actual_symbols := map[string]bool{}
+	for line in source.split_into_lines() {
+		if line.starts_with(marker) {
+			continue
+		}
+		if symbol := generated_static_string_definition_symbol(line) {
+			actual_symbols[symbol] = true
+		}
+	}
+	mut emitted_symbols := map[string]bool{}
+	mut out := strings.new_builder(source.len)
+	for line in source.split_into_lines() {
+		if line.starts_with(marker) {
+			definition := line[marker.len..]
+			if symbol := generated_static_string_definition_symbol(definition) {
+				if !actual_symbols[symbol] && !emitted_symbols[symbol] {
+					out.writeln(definition)
+					emitted_symbols[symbol] = true
+				}
+				continue
+			}
+		}
+		if symbol := generated_static_string_definition_symbol(line) {
+			if emitted_symbols[symbol] {
+				continue
+			}
+			emitted_symbols[symbol] = true
+		}
+		out.writeln(line)
+	}
+	return out.str()
+}
+
 fn generated_static_string_definition_symbol(line string) ?string {
 	clean := line.trim_space()
 	prefix := 'static string '

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -2717,12 +2717,8 @@ fn cached_source_pseudo_edit(source string, start int, source_file string, line_
 			vmod_content.replace('\r\n', '\n')
 		}
 		'@VMODROOT' {
-			vmod_root, vmod_file := signature_vmod_root(source_file)
-			if vmod_file.len == 0 {
-				'.'
-			} else {
-				vmod_root
-			}
+			vmod_root, _ := signature_vmod_root(source_file)
+			vmod_root
 		}
 		'@FILE_LINE' {
 			'${file}:${line_nr}'

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -1732,13 +1732,13 @@ fn c_has_static_storage_class(value string) bool {
 }
 
 fn c_declaration_head_is_function(value string) bool {
-	return value.contains('(') && !c_contains_parenthesized_pointer_declarator(value)
+	return value.contains('(') && !c_contains_top_level_parenthesized_pointer_declarator(value)
 		&& !c_contains_declaration_attribute(value) && !c_declaration_head_is_control_flow(value)
 		&& !c_has_top_level_assign(value)
 }
 
 fn c_static_declaration_head_is_function(value string) bool {
-	return value.contains('(') && !c_contains_parenthesized_pointer_declarator(value)
+	return value.contains('(') && !c_contains_top_level_parenthesized_pointer_declarator(value)
 		&& !c_declaration_head_is_control_flow(value) && !c_has_top_level_assign(value)
 }
 
@@ -1821,9 +1821,21 @@ fn c_code_contains_identifier(value string, name string) bool {
 	return false
 }
 
-fn c_contains_parenthesized_pointer_declarator(value string) bool {
+fn c_contains_top_level_parenthesized_pointer_declarator(value string) bool {
+	mut depth := 0
 	for i, c in value.bytes() {
+		if c == `)` {
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
 		if c != `(` {
+			continue
+		}
+		is_top_level := depth == 0
+		depth++
+		if !is_top_level {
 			continue
 		}
 		mut pos := i + 1

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -2012,7 +2012,9 @@ pub fn module_header(a &flat.FlatAst, tc &types.TypeChecker, module_name string,
 					}
 				}
 				mut text := if source_embedded {
-					declaration_source_text(a, node, file_node.value, mut source_cache) or { '' }
+					raw_source := declaration_source_text(a, node, file_node.value, mut
+						source_cache) or { '' }
+					cached_embedded_declaration_source(raw_source, vroot, file_node.value)
 				} else {
 					decl_text(a, tc, module_name, node, vroot, file_node.value, import_paths,
 						effective_attrs, source_is_public)
@@ -2298,6 +2300,225 @@ fn declaration_source_text(a &flat.FlatAst, node flat.Node, file_name string, mu
 		return none
 	}
 	return source[start..end]
+}
+
+struct CachedSourcePathEdit {
+	start       int
+	end         int
+	replacement string
+}
+
+fn cached_embedded_declaration_source(source string, vroot string, source_file string) string {
+	return cached_embedded_source_paths(source, vroot, source_file)
+}
+
+fn cached_embedded_directive_edit(source string, start int, vroot string, source_file string) ?CachedSourcePathEdit {
+	mut line_start := start
+	for line_start > 0 && source[line_start - 1] != `\n` {
+		line_start--
+	}
+	for i in line_start .. start {
+		if source[i] !in [` `, `\t`] {
+			return none
+		}
+	}
+	mut line_end := start + 1
+	for line_end < source.len && source[line_end] != `\n` {
+		line_end++
+	}
+	mut name_start := start + 1
+	for name_start < line_end && source[name_start] in [` `, `\t`] {
+		name_start++
+	}
+	mut name_end := name_start
+	for name_end < line_end && ((source[name_end] >= `a` && source[name_end] <= `z`)
+		|| source[name_end] == `_`) {
+		name_end++
+	}
+	if name_end == name_start {
+		return none
+	}
+	mut value_start := name_end
+	for value_start < line_end && source[value_start] in [` `, `\t`] {
+		value_start++
+	}
+	if value_start >= line_end {
+		return none
+	}
+	directive := source[name_start..name_end]
+	value := source[value_start..line_end]
+	resolved := cached_directive_value(directive, value, vroot, source_file)
+	if resolved == value {
+		return none
+	}
+	return CachedSourcePathEdit{
+		start:       value_start
+		end:         line_end
+		replacement: resolved
+	}
+}
+
+fn cached_embedded_source_paths(source string, vroot string, source_file string) string {
+	mut out := strings.new_builder(source.len + 128)
+	mut last := 0
+	mut i := 0
+	mut quote := u8(0)
+	mut escaped := false
+	mut line_comment := false
+	mut block_comment := false
+	for i < source.len {
+		c := source[i]
+		next := if i + 1 < source.len { source[i + 1] } else { u8(0) }
+		if line_comment {
+			if c == `\n` {
+				line_comment = false
+			}
+			i++
+			continue
+		}
+		if block_comment {
+			if c == `*` && next == `/` {
+				block_comment = false
+				i += 2
+				continue
+			}
+			i++
+			continue
+		}
+		if quote != 0 {
+			if escaped {
+				escaped = false
+			} else if c == `\\` {
+				escaped = true
+			} else if c == quote {
+				quote = 0
+			}
+			i++
+			continue
+		}
+		if c == `/` && next == `/` {
+			line_comment = true
+			i += 2
+			continue
+		}
+		if c == `/` && next == `*` {
+			block_comment = true
+			i += 2
+			continue
+		}
+		if c == `#` {
+			if edit := cached_embedded_directive_edit(source, i, vroot, source_file) {
+				out.write_string(source[last..edit.start])
+				out.write_string(edit.replacement)
+				last = edit.end
+				i = edit.end
+				continue
+			}
+		}
+		if c in [`'`, `"`] {
+			quote = c
+			i++
+			continue
+		}
+		if c == `$` && i + 1 < source.len && source[i + 1..].starts_with('embed_file') {
+			if edit := cached_embed_file_path_edit(source, i, vroot, source_file) {
+				out.write_string(source[last..edit.start])
+				out.write_string(edit.replacement)
+				last = edit.end
+				i = edit.end
+				continue
+			}
+		}
+		i++
+	}
+	if last == 0 {
+		return source
+	}
+	out.write_string(source[last..])
+	return out.str()
+}
+
+fn cached_embed_file_path_edit(source string, start int, vroot string, source_file string) ?CachedSourcePathEdit {
+	mut pos := start + 1 + 'embed_file'.len
+	if pos > source.len || (pos < source.len && (source[pos].is_alnum() || source[pos] == `_`)) {
+		return none
+	}
+	for pos < source.len && source[pos].is_space() {
+		pos++
+	}
+	if pos >= source.len || source[pos] != `(` {
+		return none
+	}
+	pos++
+	for pos < source.len && source[pos].is_space() {
+		pos++
+	}
+	argument_start := pos
+	if pos + '@FILE'.len <= source.len && source[pos..].starts_with('@FILE') {
+		end := pos + '@FILE'.len
+		if end < source.len && (source[end].is_alnum() || source[end] == `_`) {
+			return none
+		}
+		path := os.real_path(source_file)
+		return CachedSourcePathEdit{
+			start:       argument_start
+			end:         end
+			replacement: "'${escape_v_string(path)}'"
+		}
+	}
+	mut is_raw := false
+	if pos + 1 < source.len && source[pos] == `r` && source[pos + 1] in [`'`, `"`] {
+		is_raw = true
+		pos++
+	}
+	if pos >= source.len || source[pos] !in [`'`, `"`] {
+		return none
+	}
+	quote := source[pos]
+	content_start := pos + 1
+	mut content_end := content_start
+	for content_end < source.len {
+		if !is_raw && source[content_end] == `\\` {
+			return none
+		}
+		if source[content_end] == quote {
+			break
+		}
+		content_end++
+	}
+	if content_end >= source.len {
+		return none
+	}
+	path := cached_resolve_embedded_source_path(source[content_start..content_end], vroot,
+		source_file) or { return none }
+	return CachedSourcePathEdit{
+		start:       argument_start
+		end:         content_end + 1
+		replacement: "'${escape_v_string(path)}'"
+	}
+}
+
+fn cached_resolve_embedded_source_path(path string, vroot string, source_file string) ?string {
+	if path.len == 0 || source_file.len == 0 {
+		return none
+	}
+	mut resolved := path
+	if resolved.starts_with('@VEXEROOT') && vroot.len > 0 {
+		resolved = vroot + resolved['@VEXEROOT'.len..]
+	}
+	if resolved.starts_with('@VROOT') {
+		resolved = '@VMODROOT' + resolved['@VROOT'.len..]
+	}
+	if resolved.starts_with('@VMODROOT') {
+		resolved = cached_vmod_root(source_file) + resolved['@VMODROOT'.len..]
+	}
+	if !os.is_abs_path(resolved) {
+		resolved = os.join_path_single(os.dir(source_file), resolved)
+	}
+	if !os.exists(resolved) {
+		return none
+	}
+	return os.real_path(resolved)
 }
 
 fn declaration_source_start(a &flat.FlatAst, source string, node flat.Node, anchor int) ?int {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -1405,6 +1405,10 @@ fn c_declaration_header(prefix string) (string, bool) {
 					has_brace = false
 				} else {
 					item.write_string(pending)
+					item.write_string(line)
+					in_preprocessor_directive = c_preprocessor_line_continues(raw_line)
+					preprocessor_in_item = in_preprocessor_directive
+					continue
 				}
 			}
 			out.write_string(line)

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -43,9 +43,22 @@ pub:
 // CgenEntry contains the persistent whole-program C generation artifacts.
 pub struct CgenEntry {
 pub:
-	source   string
-	metadata string
-	stamp    string
+	source           string
+	metadata         string
+	stamp            string
+	prepared_main    string
+	prepared_tcc     string
+	prepared_prefix  string
+	prepared_objects string
+	prepared_stamp   string
+}
+
+// CgenPreparedEntry contains cache-marked C sources already split for linking.
+pub struct CgenPreparedEntry {
+pub:
+	main   string
+	tcc    string
+	prefix string
 }
 
 // CSplit contains the declaration/runtime prefix and per-module C function bodies.
@@ -114,10 +127,16 @@ pub fn (m &Manager) cgen_entry(source_files []string) CgenEntry {
 	mut paths := source_files.map(os.real_path(it))
 	paths.sort()
 	id := hash_text(paths.join('\n'))
+	base := os.join_path(m.dir, 'program_${id}')
 	return CgenEntry{
-		source:   os.join_path(m.dir, 'program_${id}.c')
-		metadata: os.join_path(m.dir, 'program_${id}.cflags')
-		stamp:    os.join_path(m.dir, 'program_${id}.c.stamp')
+		source:           '${base}.c'
+		metadata:         '${base}.cflags'
+		stamp:            '${base}.c.stamp'
+		prepared_main:    '${base}.main.c'
+		prepared_tcc:     '${base}.tcc.c'
+		prepared_prefix:  '${base}.prefix.c'
+		prepared_objects: '${base}.objects'
+		prepared_stamp:   '${base}.prepared.stamp'
 	}
 }
 
@@ -539,12 +558,68 @@ pub fn (m &Manager) write_cgen(source_files []string, generation_signature strin
 	// The stamp is the commit marker. Remove the previous one before replacing
 	// either payload so concurrent readers never accept a mixed generation.
 	os.rm(entry.stamp) or {}
+	os.rm(entry.prepared_stamp) or {}
 	write_atomic(entry.source, source)!
 	write_atomic(entry.metadata, metadata)!
 	stamp := cgen_entry_stamp(m.salt, m.source_signature(source_files), dependency_inputs,
 		generation_signature)
 	write_atomic(entry.stamp, stamp)!
 	return entry
+}
+
+// valid_cgen_prepared reports whether all pre-split C plan sources match entry's generation.
+pub fn (m &Manager) valid_cgen_prepared(entry CgenEntry) ?CgenPreparedEntry {
+	if !os.is_file(entry.prepared_main) || !os.is_file(entry.prepared_tcc)
+		|| !os.is_file(entry.prepared_prefix) || !os.is_file(entry.prepared_stamp) {
+		return none
+	}
+	stamp := os.read_file(entry.stamp) or { return none }
+	prepared_stamp := os.read_file(entry.prepared_stamp) or { return none }
+	if prepared_stamp != stamp {
+		return none
+	}
+	return CgenPreparedEntry{
+		main:   entry.prepared_main
+		tcc:    entry.prepared_tcc
+		prefix: entry.prepared_prefix
+	}
+}
+
+// write_cgen_prepared publishes pre-split C plan sources, committing their stamp last.
+pub fn (m &Manager) write_cgen_prepared(entry CgenEntry, main_source string, tcc_source string, prefix_source string) ! {
+	os.rm(entry.prepared_stamp) or {}
+	write_atomic(entry.prepared_main, main_source)!
+	write_atomic(entry.prepared_tcc, tcc_source)!
+	write_atomic(entry.prepared_prefix, prefix_source)!
+	stamp := os.read_file(entry.stamp)!
+	write_atomic(entry.prepared_stamp, stamp)!
+}
+
+// valid_cgen_prepared_objects restores the object set for one effective compile signature.
+pub fn (m &Manager) valid_cgen_prepared_objects(entry CgenEntry, compile_signature string) ?[]string {
+	path := '${entry.prepared_objects}.${hash_text(compile_signature)}'
+	content := os.read_file(path) or { return none }
+	lines := content.split_into_lines()
+	if lines.len < 2 {
+		return none
+	}
+	stamp := os.read_file(entry.stamp) or { return none }
+	if lines[0] != 'stamp=${hash_text(stamp)}' {
+		return none
+	}
+	objects := lines[1..].filter(it.len > 0)
+	if objects.len == 0 || objects.any(!os.is_file(it)) {
+		return none
+	}
+	return objects
+}
+
+// write_cgen_prepared_objects publishes the object set for one effective compile signature.
+pub fn (m &Manager) write_cgen_prepared_objects(entry CgenEntry, compile_signature string, objects []string) ! {
+	stamp := os.read_file(entry.stamp)!
+	content := 'stamp=${hash_text(stamp)}\n' + objects.join('\n') + '\n'
+	path := '${entry.prepared_objects}.${hash_text(compile_signature)}'
+	write_atomic(path, content)!
 }
 
 // write_stamp refreshes a cache stamp after the object and header are durable.

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -1678,6 +1678,9 @@ fn c_declaration_item_has_static_storage(item string, has_brace bool) bool {
 			head := clean[..brace].trim_space()
 			storage_head = head
 			if c_static_declaration_head_is_function(head) {
+				if c_has_static_storage_class(head) && !c_declaration_head_is_inline(head) {
+					return true
+				}
 				return c_declaration_head_keeps_definition(head)
 					&& c_code_contains_identifier(clean[brace + 1..], 'static')
 			}
@@ -1753,10 +1756,13 @@ fn c_declaration_head_keeps_definition(value string) bool {
 	if c_has_static_storage_class(value) {
 		return true
 	}
-	return !c_code_contains_identifier(value, 'extern')
-		&& (c_code_contains_identifier(value, 'inline')
+	return !c_code_contains_identifier(value, 'extern') && c_declaration_head_is_inline(value)
+}
+
+fn c_declaration_head_is_inline(value string) bool {
+	return c_code_contains_identifier(value, 'inline')
 		|| c_code_contains_identifier(value, '__inline')
-		|| c_code_contains_identifier(value, '__inline__'))
+		|| c_code_contains_identifier(value, '__inline__')
 }
 
 fn c_code_contains_identifier(value string, name string) bool {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -1135,20 +1135,7 @@ pub fn rewrite_cached_runtime_strings(cached_source string, old_values []string,
 		symbol_replacements[old_symbol] = new_symbol
 		target_definitions[new_symbol] = new_definition
 	}
-	mut old_symbols := symbol_replacements.keys()
-	old_symbols.sort()
-	mut placeholders := map[string]string{}
-	for idx, old_symbol in old_symbols {
-		mut placeholder := '__V3CACHE_STRING_REWRITE_${idx}__'
-		for source.contains(placeholder) {
-			placeholder += '_'
-		}
-		placeholders[old_symbol] = placeholder
-		source = source.replace(old_symbol, placeholder)
-	}
-	for old_symbol in old_symbols {
-		source = source.replace(placeholders[old_symbol], symbol_replacements[old_symbol])
-	}
+	source = rewrite_c_identifier_tokens(source, symbol_replacements)
 	mut definitions := []string{}
 	mut target_symbols := target_definitions.keys()
 	target_symbols.sort()
@@ -1162,6 +1149,84 @@ pub fn rewrite_cached_runtime_strings(cached_source string, old_values []string,
 	}
 	marker_idx := source.index(c_body_begin) or { return none }
 	return source[..marker_idx] + definitions.join('\n') + '\n' + source[marker_idx..]
+}
+
+fn rewrite_c_identifier_tokens(source string, replacements map[string]string) string {
+	if replacements.len == 0 {
+		return source.clone()
+	}
+	mut out := strings.new_builder(source.len)
+	mut last := 0
+	mut i := 0
+	mut quote := u8(0)
+	mut escaped := false
+	mut line_comment := false
+	mut block_comment := false
+	for i < source.len {
+		c := source[i]
+		next := if i + 1 < source.len { source[i + 1] } else { u8(0) }
+		if line_comment {
+			if c == `\n` {
+				line_comment = false
+			}
+			i++
+			continue
+		}
+		if block_comment {
+			if c == `*` && next == `/` {
+				block_comment = false
+				i += 2
+				continue
+			}
+			i++
+			continue
+		}
+		if quote != 0 {
+			if escaped {
+				escaped = false
+			} else if c == `\\` {
+				escaped = true
+			} else if c == quote {
+				quote = 0
+			}
+			i++
+			continue
+		}
+		if c == `/` && next == `/` {
+			line_comment = true
+			i += 2
+			continue
+		}
+		if c == `/` && next == `*` {
+			block_comment = true
+			i += 2
+			continue
+		}
+		if c in [`'`, `"`] {
+			quote = c
+			i++
+			continue
+		}
+		if c_generated_identifier_byte(c) {
+			start := i
+			i++
+			for i < source.len && c_generated_identifier_byte(source[i]) {
+				i++
+			}
+			if replacement := replacements[source[start..i]] {
+				out.write_string(source[last..start])
+				out.write_string(replacement)
+				last = i
+			}
+			continue
+		}
+		i++
+	}
+	if last == 0 {
+		return source.clone()
+	}
+	out.write_string(source[last..])
+	return out.str()
 }
 
 // prune_unreferenced_static_string_definitions removes generated string storage

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -1383,23 +1383,49 @@ fn c_native_declaration_directives(source string) string {
 
 fn c_native_localize_function_definitions(source string) string {
 	mut out := strings.new_builder(source.len + 256)
+	mut pending := strings.new_builder(256)
 	mut brace_depth := 0
 	mut in_block_comment := false
 	for raw_line in source.split_into_lines() {
-		delta, _, next_comment, _, first_open := c_line_braces(raw_line, in_block_comment)
-		if !in_block_comment && brace_depth == 0 && first_open > 0 {
-			head := trim_leading_c_comments(raw_line[..first_open].trim_space())
-			if c_declaration_head_is_function(head) && !c_declaration_head_keeps_definition(head) {
-				indent_len := raw_line.len - raw_line.trim_left(' \t').len
-				out.writeln('${raw_line[..indent_len]}static ${raw_line[indent_len..]}')
+		delta, _, next_comment, last_code, first_open := c_line_braces(raw_line, in_block_comment)
+		trimmed := raw_line.trim_space()
+		if brace_depth == 0 {
+			if pending.len == 0
+				&& (in_block_comment || trimmed.len == 0 || trimmed.starts_with('//')
+				|| trimmed.starts_with('#')) {
+				out.writeln(raw_line)
+				in_block_comment = next_comment
+				continue
+			}
+			pending.writeln(raw_line)
+			if first_open >= 0 {
+				declaration := pending.str()
+				current_line_start := declaration.len - raw_line.len - 1
+				head :=
+					trim_leading_c_comments(declaration[..current_line_start + first_open].trim_space())
+				if c_declaration_head_is_function(head)
+					&& !c_declaration_head_keeps_definition(head) {
+					indent_len := declaration.len - declaration.trim_left(' \t').len
+					out.write_string('${declaration[..indent_len]}static ${declaration[indent_len..]}')
+				} else {
+					out.write_string(declaration)
+				}
 				brace_depth += delta
 				in_block_comment = next_comment
 				continue
 			}
+			if last_code == `;` {
+				out.write_string(pending.str())
+			}
+			in_block_comment = next_comment
+			continue
 		}
 		out.writeln(raw_line)
 		brace_depth += delta
 		in_block_comment = next_comment
+	}
+	if pending.len > 0 {
+		out.write_string(pending.str())
 	}
 	return out.str()
 }

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -2374,6 +2374,7 @@ fn cached_embedded_source_paths(source string, vroot string, source_file string)
 	mut last := 0
 	mut i := 0
 	mut quote := u8(0)
+	mut raw_string := false
 	mut escaped := false
 	mut line_comment := false
 	mut block_comment := false
@@ -2397,12 +2398,13 @@ fn cached_embedded_source_paths(source string, vroot string, source_file string)
 			continue
 		}
 		if quote != 0 {
-			if escaped {
+			if !raw_string && escaped {
 				escaped = false
-			} else if c == `\\` {
+			} else if !raw_string && c == `\\` {
 				escaped = true
 			} else if c == quote {
 				quote = 0
+				raw_string = false
 			}
 			i++
 			continue
@@ -2428,6 +2430,8 @@ fn cached_embedded_source_paths(source string, vroot string, source_file string)
 		}
 		if c in [`'`, `"`] {
 			quote = c
+			raw_string = i > 0 && source[i - 1] == `r` && (i < 2 || (!source[i - 2].is_alnum()
+				&& source[i - 2] != `_`))
 			i++
 			continue
 		}

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -2538,7 +2538,11 @@ fn cached_embed_file_path_edit(source string, start int, vroot string, source_fi
 	mut content_end := content_start
 	for content_end < source.len {
 		if !is_raw && source[content_end] == `\\` {
-			return none
+			if content_end + 1 >= source.len {
+				return none
+			}
+			content_end += 2
+			continue
 		}
 		if source[content_end] == quote {
 			break
@@ -2548,13 +2552,113 @@ fn cached_embed_file_path_edit(source string, start int, vroot string, source_fi
 	if content_end >= source.len {
 		return none
 	}
-	path := cached_resolve_embedded_source_path(source[content_start..content_end], vroot,
-		source_file) or { return none }
+	raw_path := source[content_start..content_end]
+	path_value := if is_raw { raw_path } else { cached_unescape_v_string(raw_path) }
+	path := cached_resolve_embedded_source_path(path_value, vroot, source_file) or { return none }
 	return CachedSourcePathEdit{
 		start:       argument_start
 		end:         content_end + 1
 		replacement: "'${escape_v_string(path)}'"
 	}
+}
+
+fn cached_unescape_v_string(value string) string {
+	if !value.contains('\\') {
+		return value
+	}
+	mut out := strings.new_builder(value.len)
+	mut i := 0
+	for i < value.len {
+		if value[i] != `\\` || i + 1 >= value.len {
+			out.write_u8(value[i])
+			i++
+			continue
+		}
+		next := value[i + 1]
+		if next == `\n` {
+			i += 2
+			for i < value.len && value[i] in [` `, `\t`, `\r`] {
+				i++
+			}
+			continue
+		}
+		if next == `\r` && i + 2 < value.len && value[i + 2] == `\n` {
+			i += 3
+			for i < value.len && value[i] in [` `, `\t`] {
+				i++
+			}
+			continue
+		}
+		if next == `x` && i + 3 < value.len {
+			if code := cached_v_string_fixed_hex(value, i + 2, 2) {
+				out.write_u8(u8(code))
+				i += 4
+				continue
+			}
+		}
+		if next == `u` && i + 5 < value.len {
+			if code := cached_v_string_fixed_hex(value, i + 2, 4) {
+				out.write_rune(rune(code))
+				i += 6
+				continue
+			}
+		}
+		if next == `U` && i + 9 < value.len {
+			if code := cached_v_string_fixed_hex(value, i + 2, 8) {
+				out.write_rune(rune(code))
+				i += 10
+				continue
+			}
+		}
+		decoded := match next {
+			`n` { int(`\n`) }
+			`t` { int(`\t`) }
+			`r` { int(`\r`) }
+			`\\` { int(`\\`) }
+			`'` { int(`'`) }
+			`"` { int(`"`) }
+			`$` { int(`$`) }
+			`0` { 0 }
+			`a` { 7 }
+			`b` { 8 }
+			`f` { 12 }
+			`v` { 11 }
+			else { -1 }
+		}
+		if decoded >= 0 {
+			out.write_u8(u8(decoded))
+		} else {
+			out.write_u8(`\\`)
+			out.write_u8(next)
+		}
+		i += 2
+	}
+	return out.str()
+}
+
+fn cached_v_string_fixed_hex(value string, start int, count int) ?u32 {
+	mut code := u32(0)
+	for i in 0 .. count {
+		if start + i >= value.len {
+			return none
+		}
+		digit := cached_v_string_hex_digit(value[start + i]) or { return none }
+		code = (code << 4) | digit
+	}
+	return code
+}
+
+fn cached_v_string_hex_digit(c u8) ?u32 {
+	if c >= `0` && c <= `9` {
+		return u32(c - `0`)
+	}
+	if c >= `a` && c <= `f` {
+		return u32(c - `a` + 10)
+	}
+	if c >= `A` && c <= `F` {
+		return u32(c - `A` + 10)
+	}
+	return none
 }
 
 fn cached_resolve_embedded_source_path(path string, vroot string, source_file string) ?string {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -2213,9 +2213,10 @@ pub fn module_header(a &flat.FlatAst, tc &types.TypeChecker, module_name string,
 					}
 				}
 				mut text := if source_embedded {
-					raw_source := declaration_source_text(a, node, file_node.value, mut
-						source_cache) or { '' }
-					cached_embedded_declaration_source(raw_source, vroot, file_node.value)
+					raw_source := declaration_source_with_line(a, node, file_node.value, mut
+						source_cache) or { CachedDeclarationSource{} }
+					cached_embedded_declaration_source(raw_source.text, vroot, file_node.value,
+						raw_source.line)
 				} else {
 					decl_text(a, tc, module_name, node, vroot, file_node.value, import_paths,
 						effective_attrs, source_is_public)
@@ -2462,7 +2463,10 @@ fn module_source_bodies_are_embeddable(a &flat.FlatAst, tc &types.TypeChecker, m
 				if !declaration_node_source_is_embeddable(a, id) {
 					return false
 				}
-				_ = declaration_source_text(a, node, file_node.value, mut source_cache) or {
+				source := declaration_source_text(a, node, file_node.value, mut source_cache) or {
+					return false
+				}
+				if source.contains('@LOCATION') || source.contains('@COLUMN') {
 					return false
 				}
 			}
@@ -2480,7 +2484,17 @@ fn declaration_node_source_is_embeddable(a &flat.FlatAst, id flat.NodeId) bool {
 		.global_decl, .comptime_if]
 }
 
+struct CachedDeclarationSource {
+	text string
+	line int
+}
+
 fn declaration_source_text(a &flat.FlatAst, node flat.Node, file_name string, mut source_cache map[string]string) ?string {
+	source := declaration_source_with_line(a, node, file_name, mut source_cache)?
+	return source.text
+}
+
+fn declaration_source_with_line(a &flat.FlatAst, node flat.Node, file_name string, mut source_cache map[string]string) ?CachedDeclarationSource {
 	if !node.pos.is_valid() || node.pos.offset < 0 {
 		return none
 	}
@@ -2500,7 +2514,15 @@ fn declaration_source_text(a &flat.FlatAst, node flat.Node, file_name string, mu
 	if end <= start || end > source.len {
 		return none
 	}
-	return source[start..end]
+	text := source[start..end]
+	return CachedDeclarationSource{
+		text: text
+		line: if text.contains('@LINE') || text.contains('@FILE_LINE') {
+			source[..start].count('\n') + 1
+		} else {
+			1
+		}
+	}
 }
 
 struct CachedSourcePathEdit {
@@ -2509,8 +2531,8 @@ struct CachedSourcePathEdit {
 	replacement string
 }
 
-fn cached_embedded_declaration_source(source string, vroot string, source_file string) string {
-	return cached_embedded_source_paths(source, vroot, source_file)
+fn cached_embedded_declaration_source(source string, vroot string, source_file string, source_line int) string {
+	return cached_embedded_source_paths(source, vroot, source_file, source_line)
 }
 
 fn cached_embedded_directive_edit(source string, start int, vroot string, source_file string) ?CachedSourcePathEdit {
@@ -2559,7 +2581,7 @@ fn cached_embedded_directive_edit(source string, start int, vroot string, source
 	}
 }
 
-fn cached_embedded_source_paths(source string, vroot string, source_file string) string {
+fn cached_embedded_source_paths(source string, vroot string, source_file string, source_line int) string {
 	mut out := strings.new_builder(source.len + 128)
 	mut last := 0
 	mut i := 0
@@ -2568,9 +2590,13 @@ fn cached_embedded_source_paths(source string, vroot string, source_file string)
 	mut escaped := false
 	mut line_comment := false
 	mut block_comment := false
+	mut line_nr := source_line
 	for i < source.len {
 		c := source[i]
 		next := if i + 1 < source.len { source[i + 1] } else { u8(0) }
+		if c == `\n` {
+			line_nr++
+		}
 		if line_comment {
 			if c == `\n` {
 				line_comment = false
@@ -2634,6 +2660,15 @@ fn cached_embedded_source_paths(source string, vroot string, source_file string)
 				continue
 			}
 		}
+		if c == `@` {
+			if edit := cached_source_pseudo_edit(source, i, source_file, line_nr) {
+				out.write_string(source[last..edit.start])
+				out.write_string(edit.replacement)
+				last = edit.end
+				i = edit.end
+				continue
+			}
+		}
 		i++
 	}
 	if last == 0 {
@@ -2641,6 +2676,35 @@ fn cached_embedded_source_paths(source string, vroot string, source_file string)
 	}
 	out.write_string(source[last..])
 	return out.str()
+}
+
+fn cached_source_pseudo_edit(source string, start int, source_file string, line_nr int) ?CachedSourcePathEdit {
+	mut name := ''
+	for candidate in ['@FILE_LINE', '@FILE', '@DIR', '@LINE'] {
+		if source[start..].starts_with(candidate) {
+			name = candidate
+			break
+		}
+	}
+	if name.len == 0 {
+		return none
+	}
+	end := start + name.len
+	if end < source.len && (source[end].is_alnum() || source[end] == `_`) {
+		return none
+	}
+	file := os.real_path(source_file)
+	value := match name {
+		'@FILE_LINE' { '${file}:${line_nr}' }
+		'@FILE' { file }
+		'@DIR' { os.real_path(os.dir(source_file)) }
+		else { line_nr.str() }
+	}
+	return CachedSourcePathEdit{
+		start:       start
+		end:         end
+		replacement: "'${escape_v_string(value)}'"
+	}
 }
 
 fn cached_embed_file_path_edit(source string, start int, vroot string, source_file string) ?CachedSourcePathEdit {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -9,7 +9,7 @@ import v3.types
 pub const builtin_bundle_imports = ['strconv', 'strings', 'hash', 'math.bits']
 pub const builtin_bundle_modules = ['builtin', 'strconv', 'strings', 'hash', 'bits', 'math.bits']
 
-const cache_format = 'v3-module-cache-41'
+const cache_format = 'v3-module-cache-42'
 const c_body_begin = '/* V3CACHE_BODY_BEGIN */'
 const c_body_end = '/* V3CACHE_BODY_END */'
 const c_module_prefix = '/* V3CACHE_MODULE '
@@ -3578,6 +3578,8 @@ fn escape_v_string(value string) string {
 }
 
 fn escape_v_char(value string) string {
-	return value.replace('\\', '\\\\').replace('`', '\\`').replace('\n', '\\n').replace('\r', '\\r').replace('\t',
-		'\\t')
+	// The scanner keeps the original spelling between the backticks, including
+	// escape sequences. Escaping it again would turn `\\` into `\\\\` in a
+	// cached header and change the rune's value when that header is parsed.
+	return value
 }

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -1081,11 +1081,22 @@ pub fn rewrite_cached_runtime_strings(cached_source string, old_values []string,
 	if old_values.len != new_values.len {
 		return none
 	}
+	mut unchanged_values := map[string]bool{}
+	for idx, old_value in old_values {
+		if old_value == new_values[idx] {
+			unchanged_values[old_value] = true
+		}
+	}
 	mut replacements := map[string]string{}
 	for idx, old_value in old_values {
 		new_value := new_values[idx]
 		if old_value == new_value {
 			continue
+		}
+		// Equal literals share one C symbol. Rewriting that symbol would also
+		// change occurrences whose literal stayed the same.
+		if unchanged_values[old_value] {
+			return none
 		}
 		if existing := replacements[old_value] {
 			if existing != new_value {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -1034,6 +1034,125 @@ pub fn declaration_header(prefix string) string {
 	return out.str()
 }
 
+fn cached_c_string_symbol(value string) string {
+	mut hash := u64(1469598103934665603)
+	for c in value.bytes() {
+		hash = (hash ^ u64(c)) * u64(1099511628211)
+	}
+	return '_v3_lit_${value.len}_${hash.hex()}'
+}
+
+fn cached_c_escape(value string) string {
+	mut out := strings.new_builder(value.len * 2)
+	for b in value.bytes() {
+		match b {
+			`\\` {
+				out.write_string('\\\\')
+			}
+			`"` {
+				out.write_string('\\"')
+			}
+			`\n` {
+				out.write_string('\\n')
+			}
+			`\t` {
+				out.write_string('\\t')
+			}
+			`\r` {
+				out.write_string('\\r')
+			}
+			else {
+				if b < 32 || b == 127 {
+					out.write_u8(`\\`)
+					out.write_u8(u8(`0` + ((b >> 6) & 7)))
+					out.write_u8(u8(`0` + ((b >> 3) & 7)))
+					out.write_u8(u8(`0` + (b & 7)))
+				} else {
+					out.write_u8(b)
+				}
+			}
+		}
+	}
+	return out.str()
+}
+
+// rewrite_cached_runtime_strings updates cached C literal symbols as one simultaneous rewrite.
+pub fn rewrite_cached_runtime_strings(cached_source string, old_values []string, new_values []string) ?string {
+	if old_values.len != new_values.len {
+		return none
+	}
+	mut replacements := map[string]string{}
+	for idx, old_value in old_values {
+		new_value := new_values[idx]
+		if old_value == new_value {
+			continue
+		}
+		if existing := replacements[old_value] {
+			if existing != new_value {
+				return none
+			}
+		} else {
+			replacements[old_value] = new_value
+		}
+	}
+	if replacements.len == 0 {
+		return cached_source.clone()
+	}
+	mut source := cached_source
+	mut replacement_values := replacements.keys()
+	replacement_values.sort()
+	mut symbol_replacements := map[string]string{}
+	mut target_definitions := map[string]string{}
+	mut target_definitions_present := map[string]bool{}
+	mut removed_definition_symbols := map[string]bool{}
+	for old_value in replacement_values {
+		new_value := replacements[old_value]
+		old_symbol := cached_c_string_symbol(old_value)
+		if !cached_source.contains(old_symbol) {
+			continue
+		}
+		new_symbol := cached_c_string_symbol(new_value)
+		old_definition := 'static string ${old_symbol} = {"${cached_c_escape(old_value)}", ${old_value.len}, 1};'
+		new_definition := 'static string ${new_symbol} = {"${cached_c_escape(new_value)}", ${new_value.len}, 1};'
+		if cached_source.contains(new_definition) {
+			target_definitions_present[new_symbol] = true
+		}
+		if source.contains(old_definition) {
+			source = source.replace('${old_definition}\n', '').replace(old_definition, '')
+			removed_definition_symbols[old_symbol] = true
+		}
+		symbol_replacements[old_symbol] = new_symbol
+		target_definitions[new_symbol] = new_definition
+	}
+	mut old_symbols := symbol_replacements.keys()
+	old_symbols.sort()
+	mut placeholders := map[string]string{}
+	for idx, old_symbol in old_symbols {
+		mut placeholder := '__V3CACHE_STRING_REWRITE_${idx}__'
+		for source.contains(placeholder) {
+			placeholder += '_'
+		}
+		placeholders[old_symbol] = placeholder
+		source = source.replace(old_symbol, placeholder)
+	}
+	for old_symbol in old_symbols {
+		source = source.replace(placeholders[old_symbol], symbol_replacements[old_symbol])
+	}
+	mut definitions := []string{}
+	mut target_symbols := target_definitions.keys()
+	target_symbols.sort()
+	for target_symbol in target_symbols {
+		if !target_definitions_present[target_symbol] || removed_definition_symbols[target_symbol] {
+			definitions << target_definitions[target_symbol]
+		}
+	}
+	if definitions.len == 0 {
+		return source
+	}
+	marker_idx := source.index(c_body_begin) or { return none }
+	return source[..marker_idx] + definitions.join('\n') + '\n' + source[marker_idx..]
+}
+
 // prune_unreferenced_static_string_definitions removes generated string storage
 // that is referenced only by the program body. Cached module objects carry
 // their own static copies, while the program translation unit retains the full

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -1403,7 +1403,7 @@ fn c_native_localize_function_definitions(source string) string {
 				current_line_start := declaration.len - raw_line.len - 1
 				head :=
 					trim_leading_c_comments(declaration[..current_line_start + first_open].trim_space())
-				if c_declaration_head_is_function(head)
+				if c_static_declaration_head_is_function(head)
 					&& !c_declaration_head_keeps_definition(head) {
 					indent_len := declaration.len - declaration.trim_left(' \t').len
 					out.write_string('${declaration[..indent_len]}static ${declaration[indent_len..]}')
@@ -1444,12 +1444,15 @@ fn c_declaration_header(prefix string) (string, bool) {
 	mut brace_depth := 0
 	mut has_brace := false
 	mut is_function_block := false
+	mut function_has_conditionals := false
+	mut function_conditional_depth := 0
 	mut has_static_storage := false
 	mut in_block_comment := false
 	mut in_preprocessor_directive := false
 	mut preprocessor_in_item := false
 	mut in_extern_c_block := false
-	for raw_line in prefix.split_into_lines() {
+	lines := prefix.split_into_lines()
+	for line_idx, raw_line in lines {
 		line := raw_line + '\n'
 		trimmed := raw_line.trim_space()
 		if in_preprocessor_directive {
@@ -1483,6 +1486,15 @@ fn c_declaration_header(prefix string) (string, bool) {
 		}
 		if !in_block_comment && trimmed.starts_with('#') {
 			if brace_depth > 0 {
+				if is_function_block {
+					conditional_delta := c_preprocessor_conditional_delta(trimmed)
+					if conditional_delta > 0 {
+						function_has_conditionals = true
+						function_conditional_depth++
+					} else if conditional_delta < 0 && function_conditional_depth > 0 {
+						function_conditional_depth--
+					}
+				}
 				item.write_string(line)
 				in_preprocessor_directive = c_preprocessor_line_continues(raw_line)
 				preprocessor_in_item = in_preprocessor_directive
@@ -1522,18 +1534,22 @@ fn c_declaration_header(prefix string) (string, bool) {
 				head := item_head.str()
 				clean_head := trim_leading_c_comments(head.trim_space())
 				is_function_block = c_static_declaration_head_is_function(clean_head)
+				function_has_conditionals = false
+				function_conditional_depth = 0
 			} else {
 				item_head.write_string(line)
 			}
 			has_brace = saw_brace
 		}
-		closes_function_block := is_function_block
-			&& c_function_block_closes_at_line_start(raw_line)
-		if closes_function_block {
+		mut closes_function_block := is_function_block && brace_depth <= 0
+		if is_function_block && brace_depth > 0 && function_has_conditionals
+			&& function_conditional_depth == 0 && c_function_block_closes_at_line_start(raw_line)
+			&& c_next_line_is_preprocessor_endif(lines, line_idx + 1) {
 			// C macro functions and conditionally compiled bodies do not always
-			// have balanced raw braces. Their outer closing delimiter is still at
-			// the start of a line, so do not let them consume following #endifs.
+			// have balanced raw braces. Once their conditional nesting has closed,
+			// the column-zero outer delimiter still bounds the declaration.
 			brace_depth = 0
+			closes_function_block = true
 		}
 		if in_block_comment || brace_depth > 0 {
 			continue
@@ -1555,6 +1571,8 @@ fn c_declaration_header(prefix string) (string, bool) {
 		brace_depth = 0
 		has_brace = false
 		is_function_block = false
+		function_has_conditionals = false
+		function_conditional_depth = 0
 	}
 	if item.len > 0 {
 		declaration := item.str()
@@ -1567,6 +1585,37 @@ fn c_declaration_header(prefix string) (string, bool) {
 
 fn c_function_block_closes_at_line_start(line string) bool {
 	return line.len > 0 && line[0] == `}`
+}
+
+fn c_next_line_is_preprocessor_endif(lines []string, start int) bool {
+	for line in lines[start..] {
+		clean := line.trim_space()
+		if clean.len == 0 || clean.starts_with('//') {
+			continue
+		}
+		if clean.len < 2 || clean[0] != `#` {
+			return false
+		}
+		fields := clean[1..].trim_space().fields()
+		return fields.len > 0 && fields[0] == 'endif'
+	}
+	return false
+}
+
+fn c_preprocessor_conditional_delta(line string) int {
+	clean := line.trim_space()
+	if clean.len < 2 || clean[0] != `#` {
+		return 0
+	}
+	fields := clean[1..].trim_space().fields()
+	if fields.len == 0 {
+		return 0
+	}
+	return match fields[0] {
+		'if', 'ifdef', 'ifndef' { 1 }
+		'endif' { -1 }
+		else { 0 }
+	}
 }
 
 fn c_preprocessor_line_continues(line string) bool {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -40,6 +40,14 @@ pub:
 	c_source     string
 }
 
+// CgenEntry contains the persistent whole-program C generation artifacts.
+pub struct CgenEntry {
+pub:
+	source   string
+	metadata string
+	stamp    string
+}
+
 // CSplit contains the declaration/runtime prefix and per-module C function bodies.
 pub struct CSplit {
 pub:
@@ -98,6 +106,18 @@ pub fn (m &Manager) object_entry(module_name string, source_files []string, comp
 		header_stamp: entry.header_stamp
 		object_stamp: '${base}_${key}.o.stamp'
 		c_source:     '${base}_${key}.c'
+	}
+}
+
+// cgen_entry returns the artifact paths for one stable program source set.
+pub fn (m &Manager) cgen_entry(source_files []string) CgenEntry {
+	mut paths := source_files.map(os.real_path(it))
+	paths.sort()
+	id := hash_text(paths.join('\n'))
+	return CgenEntry{
+		source:   os.join_path(m.dir, 'program_${id}.c')
+		metadata: os.join_path(m.dir, 'program_${id}.cflags')
+		stamp:    os.join_path(m.dir, 'program_${id}.c.stamp')
 	}
 }
 
@@ -485,6 +505,42 @@ pub fn (m &Manager) valid_object_for_compile_signature(cache_name string, source
 	return entry
 }
 
+// valid_cgen reports whether a whole-program C plan matches its program sources,
+// imported module headers, and semantic generation signature.
+pub fn (m &Manager) valid_cgen(source_files []string, generation_signature string, dependency_inputs map[string]string) ?CgenEntry {
+	if !m.enabled || source_files.len == 0 {
+		return none
+	}
+	entry := m.cgen_entry(source_files)
+	if !os.is_file(entry.source) || !os.is_file(entry.metadata) || !os.is_file(entry.stamp) {
+		return none
+	}
+	stamp := os.read_file(entry.stamp) or { return none }
+	expected := cgen_entry_stamp(m.salt, m.source_signature(source_files), dependency_inputs,
+		generation_signature)
+	if stamp != expected {
+		return none
+	}
+	return entry
+}
+
+// write_cgen atomically commits a whole-program C plan and its generation metadata.
+pub fn (m &Manager) write_cgen(source_files []string, generation_signature string, dependency_inputs map[string]string, source string, metadata string) !CgenEntry {
+	if !m.ensure_dir() {
+		return error('v3 module cache directory is unavailable')
+	}
+	entry := m.cgen_entry(source_files)
+	// The stamp is the commit marker. Remove the previous one before replacing
+	// either payload so concurrent readers never accept a mixed generation.
+	os.rm(entry.stamp) or {}
+	write_atomic(entry.source, source)!
+	write_atomic(entry.metadata, metadata)!
+	stamp := cgen_entry_stamp(m.salt, m.source_signature(source_files), dependency_inputs,
+		generation_signature)
+	write_atomic(entry.stamp, stamp)!
+	return entry
+}
+
 // write_stamp refreshes a cache stamp after the object and header are durable.
 // dependency_inputs maps every transitive imported `.vh` and non-V input path
 // to the content signature that the object was compiled against.
@@ -517,6 +573,18 @@ fn object_entry_stamp(salt string, source_hash string, dependency_inputs map[str
 	mut out := strings.new_builder(256 + dependency_inputs.len * 96)
 	out.write_string(entry_stamp(salt, source_hash))
 	out.writeln('compile=${hash_text(compile_signature)}')
+	mut paths := dependency_inputs.keys()
+	paths.sort()
+	for path in paths {
+		out.writeln('dependency=${path}\t${dependency_inputs[path]}')
+	}
+	return out.str()
+}
+
+fn cgen_entry_stamp(salt string, source_hash string, dependency_inputs map[string]string, generation_signature string) string {
+	mut out := strings.new_builder(256 + dependency_inputs.len * 96)
+	out.write_string(entry_stamp(salt, source_hash))
+	out.writeln('generation=${hash_text(generation_signature)}')
 	mut paths := dependency_inputs.keys()
 	paths.sort()
 	for path in paths {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -92,9 +92,12 @@ mut:
 	sql_query_data_aliases            map[string]bool
 	export_records                    []ExportRecord
 pub mut:
-	a              &flat.FlatAst = unsafe { nil }
-	parsed_v_files int
-	diagnostics    []Diagnostic
+	a                          &flat.FlatAst = unsafe { nil }
+	parsed_v_files             int
+	parsed_v_file_paths        []string
+	parsed_v_header_files      int
+	parsed_v_header_file_paths []string
+	diagnostics                []Diagnostic
 }
 
 // reserve_selfhost_ast prepares the shared AST for a compiler-sized input
@@ -256,6 +259,10 @@ pub fn (mut p Parser) parse_into(path string) {
 	}
 	if path.ends_with('.v') {
 		p.parsed_v_files++
+		p.parsed_v_file_paths << path
+	} else if path.ends_with('.vh') {
+		p.parsed_v_header_files++
+		p.parsed_v_header_file_paths << path
 	}
 	p.reserve_for_source(stable_src.len)
 	mut file_set := token.FileSet.new()

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -7305,7 +7305,13 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 		.pipe {
 			return p.pipe_lambda_expr()
 		}
-		.key_mut, .key_shared {
+		.key_mut {
+			p.next()
+			id := p.prefix_expr()
+			p.mark_node_mut(id)
+			return id
+		}
+		.key_shared {
 			p.next()
 			return p.prefix_expr()
 		}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -166,11 +166,10 @@ pub fn (mut p Parser) parse_files(paths []string) &flat.FlatAst {
 	return p.a
 }
 
-// release_source_storage canonicalizes every retained source slice and drops
-// parser/scanner references to raw file buffers. Source files keep only their
-// compact line indexes for later diagnostic lookup.
+// release_source_storage canonicalizes retained metadata and drops parser/scanner
+// references to raw file buffers. Parsed node text is canonicalized as each file
+// is completed and when parallel worker ASTs are merged.
 pub fn (mut p Parser) release_source_storage() {
-	p.a.intern_node_texts_from(0)
 	p.a.intern_metadata_texts()
 	p.lit = ''
 	p.peek_lit = ''
@@ -3449,7 +3448,7 @@ fn (p &Parser) eval_comptime_cond_with_target_override(cond string, disable_targ
 }
 
 fn source_contains_target_inline_asm(source string, target_arch string) bool {
-	if source.len < 3 {
+	if source.len < 3 || !source.contains('asm') {
 		return false
 	}
 	mut offset := 0

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -932,6 +932,13 @@ fn (mut p Parser) merge_parsed_worker(mut w Parser, mut starts []int, chunk_star
 		}
 	}
 	p.parsed_v_files += w.parsed_v_files
+	for path in w.parsed_v_file_paths {
+		p.parsed_v_file_paths << path.clone()
+	}
+	p.parsed_v_header_files += w.parsed_v_header_files
+	for path in w.parsed_v_header_file_paths {
+		p.parsed_v_header_file_paths << path.clone()
+	}
 }
 
 // parse_job_count caps the worker count by the runtime job count, a fixed

--- a/vlib/v3/tests/c_flag_target_filter_codegen_test.v
+++ b/vlib/v3/tests/c_flag_target_filter_codegen_test.v
@@ -82,7 +82,7 @@ fn test_c_flag_target_filter_drops_termux_off_termux() {
 	assert run.output.trim_space() == 'termux-filter-ok'
 }
 
-fn test_objective_c_flags_skip_tcc_and_select_objective_c_language() {
+fn test_objective_c_flags_are_confined_to_cached_dylib() {
 	$if !macos {
 		return
 	}
@@ -94,7 +94,8 @@ fn test_objective_c_flags_skip_tcc_and_select_objective_c_language() {
 	assert build.exit_code == 0, build.output
 
 	src := os.join_path(os.temp_dir(), 'v3_objective_c_flag_input_${pid}.v')
-	os.write_file(src, "#flag darwin -fobjc-arc\nfn main() {\n\tprintln('objc-flag-ok')\n}\n") or {
+	os.write_file(src,
+		"#flag darwin -fobjc-arc\n#flag darwin -lobjc\n#include <objc/message.h>\ntype Msg = fn (voidptr, voidptr) voidptr\nfn C.objc_msgSend(obj voidptr, sel voidptr) voidptr\nfn main() {\n\t_ := unsafe { Msg(C.objc_msgSend) }\n\tprintln('objc-flag-ok')\n}\n") or {
 		panic(err)
 	}
 	bin := os.join_path(os.temp_dir(), 'v3_objective_c_flag_input_${pid}')
@@ -102,9 +103,13 @@ fn test_objective_c_flags_skip_tcc_and_select_objective_c_language() {
 	os.rmdir_all(bin) or {}
 	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
 	assert compile.exit_code == 0, compile.output
-	assert !compile.output.contains('tcc.exe'), compile.output
-	assert compile.output.contains('-x objective-c'), compile.output
-	assert compile.output.contains('-x none'), compile.output
+	tcc_lines := compile.output.split_into_lines().filter(it.contains('tcc.exe'))
+	assert tcc_lines.len == 1, compile.output
+	tcc_line := tcc_lines[0]
+	assert tcc_line.contains('.dylib'), tcc_line
+	assert !tcc_line.contains('-fobjc-arc'), tcc_line
+	assert !tcc_line.contains('-x objective-c'), tcc_line
+	assert compile.output.contains('C dylib cache'), compile.output
 
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output

--- a/vlib/v3/tests/c_struct_redeclaration_test.v
+++ b/vlib/v3/tests/c_struct_redeclaration_test.v
@@ -9,7 +9,8 @@ const v3_src = os.join_path(v3_dir, 'v3.v')
 
 fn build_v3() string {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_c_struct_redeclaration_${os.getpid()}_${rand.ulid()}')
-	build := os.execute('${vexe} -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	build :=
+		os.execute('${vexe} -prealloc -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0, build.output
 	return v3_bin
 }
@@ -96,4 +97,13 @@ fn test_c_struct_redeclaration_checks_field_signature() {
 	assert !shared_header_good.output.contains('cannot redeclare C struct `C.cJSON`'), shared_header_good.output
 
 	assert !shared_header_good.output.contains('C compilation failed'), shared_header_good.output
+
+	cached_termios_good := run_v3_project(v3_bin, 'module_cache_termios_shims', {
+		'v.mod':                   'Module { name: "cached_termios_shims" }\n'
+		'term/term_cached.vh':     'module term\n\nstruct C.termios {\n\tc_iflag int\n}\n'
+		'term/termios/termios.vh': 'module termios\n\nstruct C.termios {\n\tc_iflag usize\n\tc_ispeed usize\n}\n'
+		'main.v':                  'module main\n\nimport term\nimport term.termios\n\nfn main() {}\n'
+	})
+	assert cached_termios_good.exit_code == 0, cached_termios_good.output
+	assert !cached_termios_good.output.contains('cannot redeclare C struct `C.termios`'), cached_termios_good.output
 }

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -20,6 +20,59 @@ fn assert_driver_cli_failure(v3_bin string, args []string, message string) {
 	assert result.output.contains(message), result.output
 }
 
+fn test_v3_build_rejects_garbage_collectors() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_gc_build_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	for mode in ['boehm', 'boehm_full', 'boehm_incr', 'boehm_full_opt', 'boehm_incr_opt',
+		'boehm_leak', 'vgc'] {
+		output := os.join_path(root, 'v3_${mode}')
+		result := cmdexec.run(@VEXE, ['-gc', mode, '-path', '${driver_cli_vlib_dir}|@vlib|@vmodules',
+			'-o', output, driver_cli_v3_src])
+		assert result.exit_code != 0
+		assert result.output.contains('v3 must be built without a garbage collector'), result.output
+		assert !os.is_file(output)
+	}
+	for define in ['gcboehm', 'gcboehm_full', 'gcboehm_incr', 'gcboehm_opt', 'gcboehm_leak', 'vgc'] {
+		output := os.join_path(root, 'v3_define_${define}')
+		result := cmdexec.run(@VEXE, ['-gc', 'none', '-d', define, '-path',
+			'${driver_cli_vlib_dir}|@vlib|@vmodules', '-o', output, driver_cli_v3_src])
+		assert result.exit_code != 0
+		assert result.output.contains('v3 must be built without a garbage collector'), result.output
+		assert !os.is_file(output)
+	}
+}
+
+fn test_standard_v3_excludes_ownership_checker() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_no_ownership_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3(root)
+	source := os.join_path(root, 'main.v')
+	os.write_file(source, "fn main() {
+	println('no ownership')
+}
+")!
+	output := os.join_path(root, 'no_ownership')
+	compile := cmdexec.run(v3_bin, ['-o', output, source])
+	assert compile.exit_code == 0, compile.output
+	run := cmdexec.run(output, [])
+	assert run.exit_code == 0, run.output
+	assert run.output == 'no ownership\n'
+	assert_driver_cli_failure(v3_bin, ['-ownership', source],
+		'ownership support is not compiled into this v3 executable')
+	assert_driver_cli_failure(v3_bin, ['-d', 'ownership', source],
+		'ownership support is not compiled into this v3 executable')
+	assert_driver_cli_failure(v3_bin, ['-downership', source],
+		'ownership support is not compiled into this v3 executable')
+}
+
 fn test_driver_cflags_include_dir_is_visible_to_header_inliner() {
 	root := os.join_path(os.vtmp_dir(), 'v3_driver_cflags_include_${os.getpid()}')
 	os.rmdir_all(root) or {}
@@ -239,6 +292,10 @@ fn main() {
 	assert_driver_cli_failure(v3_bin, ['-b', 'bogus', source], 'unknown backend `bogus`')
 	assert_driver_cli_failure(v3_bin, ['-gc', 'boehm', source],
 		'currently supports only `-gc none`')
+	assert_driver_cli_failure(v3_bin, ['-d', 'gcboehm', source],
+		'v3 programs must not use a garbage collector')
+	assert_driver_cli_failure(v3_bin, ['-dvgc', source],
+		'v3 programs must not use a garbage collector')
 	assert_driver_cli_failure(v3_bin, [source, source], 'multiple input paths are not supported')
 	assert_driver_cli_failure(v3_bin, ['-compile-backend', 'bogus', source],
 		'unknown compile backend `bogus`')

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -541,6 +541,7 @@ fn main() {
 fn test_module_cache_static_inline_attributes_are_not_storage() {
 	source := 'static __inline void atomic_fence(int order __attribute__((unused))) {\n\t(void)order;\n}\n'
 	assert !modulecache.c_source_has_static_storage(source)
+	assert modulecache.c_source_has_static_storage('static int helper(void) {\n\treturn 1;\n}\n')
 	assert modulecache.c_source_has_static_storage('static int state = 1;\n')
 	assert modulecache.c_source_has_static_storage('static inline int next(void) {\n\tstatic int state;\n\treturn ++state;\n}\n')
 }
@@ -4027,4 +4028,121 @@ fn main() {
 	assert incremental.output.contains('transform (incremental)'), incremental.output
 	assert incremental.output.contains('cgen (incremental)'), incremental.output
 	assert run_module_cache_binary(incremental_output) == 'true'
+}
+
+fn test_cached_native_static_function_stays_with_owner_module() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_native_static_fn_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'native/native.v', 'module native
+
+#include "@DIR/native.c"
+
+fn C.native_static_value() int
+
+pub fn value() int {
+	return C.native_static_value()
+}
+')
+	write_module_cache_file(root, 'native/native.c', 'static int native_static_helper(void) {
+	return 42;
+}
+
+int native_static_value(void) {
+	return native_static_helper();
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import native
+
+fn main() {
+	println(native.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	native_header := module_cache_artifact(cache_dir, 'native_', '.vh')
+	assert native_header.len > 0
+	assert !(os.read_file(native_header) or { panic(err) }).contains('compile source in program unit')
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+}
+
+fn test_cached_dev_dylib_invalidates_for_named_static_archive_change() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_dev_named_archive_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	library_dir := os.join_path(root, 'archive')
+	os.mkdir_all(library_dir) or { panic(err) }
+	library_source := os.join_path(library_dir, 'value.c')
+	library_object := os.join_path(library_dir, 'value.o')
+	library := os.join_path(library_dir, 'libcachedvalue.a')
+	write_module_cache_file(root, 'archive/value.c', 'int cached_archive_value(void) {
+	return 1;
+}
+')
+	first_cc :=
+		os.execute('cc -c -o ${os.quoted_path(library_object)} ${os.quoted_path(library_source)}')
+	assert first_cc.exit_code == 0, first_cc.output
+	first_ar := os.execute('ar rcs ${os.quoted_path(library)} ${os.quoted_path(library_object)}')
+	assert first_ar.exit_code == 0, first_ar.output
+	write_module_cache_file(root, 'archive/archive.v', 'module archive
+
+#flag -L@DIR
+#flag -lcachedvalue
+
+fn C.cached_archive_value() int
+
+pub fn value() int {
+	return C.cached_archive_value()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import archive
+
+fn main() {
+	println(archive.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '1'
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == '1'
+
+	write_module_cache_file(root, 'archive/value.c', 'int cached_archive_value(void) {
+	return 2;
+}
+')
+	second_cc :=
+		os.execute('cc -c -o ${os.quoted_path(library_object)} ${os.quoted_path(library_source)}')
+	assert second_cc.exit_code == 0, second_cc.output
+	second_ar := os.execute('ar rcs ${os.quoted_path(library)} ${os.quoted_path(library_object)}')
+	assert second_ar.exit_code == 0, second_ar.output
+	changed_output := os.join_path(root, 'changed')
+	changed :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(changed_output)} ${os.quoted_path(main_file)}')
+	assert changed.exit_code == 0, changed.output
+	assert run_module_cache_binary(changed_output) == '2'
 }

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4262,6 +4262,60 @@ fn main() {
 	assert run_module_cache_binary(second_output) == '42'
 }
 
+fn test_cached_native_source_preserves_directive_context() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_native_directive_context_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'native/native.v', 'module native
+
+#define V3_NATIVE_CONTEXT_VALUE 84
+#if defined(V3_NATIVE_CONTEXT_VALUE)
+#include "@DIR/native.c"
+#endif
+#undef V3_NATIVE_CONTEXT_VALUE
+
+fn C.native_context_value() int
+
+pub fn value() int {
+	return C.native_context_value()
+}
+')
+	write_module_cache_file(root, 'native/native.c', '#ifndef V3_NATIVE_CONTEXT_VALUE
+#error "native source lost its directive context"
+#endif
+
+static int native_context_helper(void) {
+	return V3_NATIVE_CONTEXT_VALUE / 2;
+}
+
+int native_context_value(void) {
+	return native_context_helper();
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import native
+
+fn main() {
+	println(native.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	assert module_cache_artifact(cache_dir, 'native_', '.o').len > 0
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+}
+
 fn test_cached_dev_dylib_invalidates_for_named_static_archive_change() {
 	$if !macos {
 		return

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -2423,6 +2423,47 @@ fn main() {
 	assert run_module_cache_binary(second_output) == first_run
 }
 
+fn test_cached_generic_body_preserves_vmodroot_source_dir_fallback() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_generic_vmod_fallback_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	source_dir := os.join_path(root, 'origin')
+	write_module_cache_file(root, 'origin/origin.v', 'module origin
+
+pub fn module_root[T]() string {
+	_ = sizeof(T)
+	return @VMODROOT
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import origin
+
+fn main() {
+	println(origin.module_root[int]())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	first_run := run_module_cache_binary(first_output)
+	assert first_run == os.real_path(source_dir), first_run
+	header_path := module_cache_artifact(cache_dir, 'origin_', '.vh')
+	assert header_path.len > 0
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains(os.real_path(source_dir)), header
+	assert !header.contains('@VMODROOT'), header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == first_run
+}
+
 fn test_cached_comptime_body_resolves_relative_insert() {
 	$if windows {
 		return
@@ -4094,6 +4135,49 @@ fn main() {
 	assert compile.exit_code == 0, compile.output
 	assert !compile.output.contains('tcc.exe'), compile.output
 	assert run_module_cache_binary(output) == '73'
+}
+
+fn test_cached_dev_tcc_links_plain_c_source_flags() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_dev_c_source_link_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'v.mod', "Module { name: 'cached_dev_c_source_link' }\n")
+	write_module_cache_file(root, 'helper.c', 'int v3_cached_dev_c_source_value(void) {
+	return 79;
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+#flag @VMODROOT/helper.c
+
+fn C.v3_cached_dev_c_source_value() int
+
+fn main() {
+	println(C.v3_cached_dev_c_source_value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	first :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(first_output)} ${os.quoted_path(main_file)}')
+	assert first.exit_code == 0, first.output
+	assert first.output.contains('tcc.exe'), first.output
+	assert run_module_cache_binary(first_output) == '79'
+
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert second.output.contains('tcc.exe'), second.output
+	assert run_module_cache_binary(second_output) == '79'
 }
 
 fn test_incremental_program_cache_synthesizes_new_sum_equality_helpers() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -396,6 +396,26 @@ int cached_readback(int value) {
 	assert header.contains('return -value')
 }
 
+fn test_module_cache_native_header_localizes_split_brace_functions() {
+	prefix := '/* V3CACHE_NATIVE_DIRECTIVES_BEGIN */
+int cached_readback(int value)
+{
+	return value;
+}
+int cached_sum(
+	int left,
+	int right
+)
+{
+	return left + right;
+}
+/* V3CACHE_NATIVE_DIRECTIVES_END */
+'
+	header := modulecache.declaration_header(prefix)
+	assert header.contains('static int cached_readback(int value)\n{'), header
+	assert header.contains('static int cached_sum(\n\tint left,\n\tint right\n)\n{'), header
+}
+
 fn test_cached_header_preserves_include_search_path_names() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_include_search_${os.getpid()}')
@@ -3859,4 +3879,38 @@ fn main() {
 	assert second.exit_code == 0, second.output
 	assert !second.output.contains('cgen (cached)'), second.output
 	assert run_module_cache_binary(second_output) == '2'
+}
+
+fn test_cached_dev_tcc_bypasses_native_source_link_flags() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_dev_native_link_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'v.mod', "Module { name: 'cached_dev_native_link' }\n")
+	write_module_cache_file(root, 'native.m',
+		'int v3_cached_dev_native_value(void) { return 73; }\n')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+#flag @VMODROOT/native.m
+
+fn C.v3_cached_dev_native_value() int
+
+fn main() {
+	println(C.v3_cached_dev_native_value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	output := os.join_path(root, 'output')
+	compile :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(output)} ${os.quoted_path(main_file)}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('tcc.exe'), compile.output
+	assert run_module_cache_binary(output) == '73'
 }

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4078,6 +4078,54 @@ fn main() {
 	assert run_module_cache_binary(second_output) == '42'
 }
 
+fn test_cached_native_source_reemits_only_root_include() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_native_root_include_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'native/native.v', 'module native
+
+#include "@DIR/root.c"
+
+fn C.native_nested_value() int
+
+pub fn value() int {
+	return C.native_nested_value()
+}
+')
+	write_module_cache_file(root, 'native/root.c', '#include "nested.c"
+
+int native_nested_value(void) {
+	return nested_static_value();
+}
+')
+	write_module_cache_file(root, 'native/nested.c', 'static int nested_static_value(void) {
+	return 42;
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import native
+
+fn main() {
+	println(native.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	assert module_cache_artifact(cache_dir, 'native_', '.o').len > 0
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+}
+
 fn test_cached_dev_dylib_invalidates_for_named_static_archive_change() {
 	$if !macos {
 		return

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -3763,3 +3763,100 @@ fn main() {
 	assert !second.output.contains('check (incremental)'), second.output
 	assert run_module_cache_binary(second_output) == 'second'
 }
+
+fn test_incremental_program_cache_preserves_global_initializer_order() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_global_order_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+__global trace int
+__global first = record(1)
+__global second = record(2)
+
+fn record(value int) int {
+	trace = trace * 10 + value
+	return value
+}
+
+fn main() {
+	println(trace)
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '12'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+__global trace int
+__global second = record(2)
+__global first = record(1)
+
+fn record(value int) int {
+	trace = trace * 10 + value
+	return value
+}
+
+fn main() {
+	println(trace)
+}
+')
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == '21'
+}
+
+fn test_cgen_cache_invalidates_for_resolved_dynamic_flag_change() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_dynamic_c_flag_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'old.c', 'int v3_dynamic_flag_value(void) { return 1; }\n')
+	old_object := os.join_path(root, 'old.o')
+	old_cc := os.execute('cc -c -o ${os.quoted_path(old_object)} ${os.quoted_path(os.join_path(root,
+		'old.c'))}')
+	assert old_cc.exit_code == 0, old_cc.output
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', "module main
+
+#flag \$first_existing('@DIR/new.o', '@DIR/old.o')
+
+fn C.v3_dynamic_flag_value() int
+
+fn main() {
+	println(C.v3_dynamic_flag_value())
+}
+")
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '1'
+
+	write_module_cache_file(root, 'new.c', 'int v3_dynamic_flag_value(void) { return 2; }\n')
+	new_object := os.join_path(root, 'new.o')
+	new_cc := os.execute('cc -c -o ${os.quoted_path(new_object)} ${os.quoted_path(os.join_path(root,
+		'new.c'))}')
+	assert new_cc.exit_code == 0, new_cc.output
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == '2'
+}

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -144,6 +144,73 @@ fn changed_module_cache_objects(before map[string]u64, after map[string]u64) []s
 	return changed
 }
 
+fn test_module_cache_reuses_and_invalidates_whole_program_cgen_plan() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_cgen_plan_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'cached/cached.v', 'module cached
+
+pub fn value() int {
+	return 40
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import cached
+
+fn main() {
+	println(cached.value() + 2)
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	first :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(first_output)} ${os.quoted_path(main_file)}')
+	assert first.exit_code == 0, first.output
+	assert !first.output.contains('cgen (cached)'), first.output
+	assert run_module_cache_binary(first_output) == '42'
+
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == '42'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+import cached
+
+fn main() {
+	println(cached.value() + 3)
+}
+')
+	changed_output := os.join_path(root, 'changed')
+	changed :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(changed_output)} ${os.quoted_path(main_file)}')
+	assert changed.exit_code == 0, changed.output
+	assert !changed.output.contains('cgen (cached)'), changed.output
+	assert run_module_cache_binary(changed_output) == '43'
+
+	write_module_cache_file(root, 'cached/cached.v', 'module cached
+
+pub fn value() int {
+	return 41
+}
+')
+	changed_module_output := os.join_path(root, 'changed_module')
+	changed_module :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(changed_module_output)} ${os.quoted_path(main_file)}')
+	assert changed_module.exit_code == 0, changed_module.output
+	assert !changed_module.output.contains('cgen (cached)'), changed_module.output
+	assert run_module_cache_binary(changed_module_output) == '44'
+}
+
 fn test_module_cache_split_uses_marker_lines() {
 	source := 'static string marker = {"/* V3CACHE_BODY_BEGIN */", 24};\n#ifdef __cplusplus\nextern "C" {\n#endif\nextern int cached_api(void *);\n#ifdef __cplusplus\n}\n#endif\n/* V3CACHE_BODY_BEGIN */\n/* V3CACHE_MODULE main */\nint main(void) { return 0; }\n/* V3CACHE_BODY_END */\n'
 	split := modulecache.split_generated_c(source) or { panic(err) }

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -2903,3 +2903,48 @@ fn main() {
 	assert incremental.output.contains('cgen (incremental)'), incremental.output
 	assert run_module_cache_binary(incremental_output) == 'after real logic'
 }
+
+fn test_incremental_program_cache_falls_back_for_newly_reachable_function() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_program_reachability_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', "module main
+
+fn newly_reachable() string {
+	return 'called'
+}
+
+fn main() {
+	println('before')
+}
+")
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'before'
+
+	write_module_cache_file(root, 'main.v', "module main
+
+fn newly_reachable() string {
+	return 'called'
+}
+
+fn main() {
+	println(newly_reachable())
+}
+")
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (incremental)'), second.output
+	assert run_module_cache_binary(second_output) == 'called'
+}

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -192,6 +192,7 @@ fn main() {
 	assert second.output.contains('markused (cached)'), second.output
 	assert second.output.contains('transform (cached)'), second.output
 	assert second.output.contains('annotate types (cached)'), second.output
+	assert second.output.contains('C module plan (cached)'), second.output
 	assert second.output.contains('cgen (cached)'), second.output
 	assert second.output.contains('monomorphize (cached)'), second.output
 	assert run_module_cache_binary(second_output) == '42'

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4061,6 +4061,59 @@ fn main() {
 	assert run_module_cache_binary(second_output) == '21'
 }
 
+fn test_incremental_program_cache_preserves_runtime_const_initializer_order() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_runtime_const_order_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+const first_runtime_const = record_runtime_const("first", 1)
+const second_runtime_const = record_runtime_const("second", 2)
+
+fn record_runtime_const(label string, value int) int {
+	println(label)
+	return value
+}
+
+fn main() {
+	println(first_runtime_const + second_runtime_const)
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'first\nsecond\n3'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+const second_runtime_const = record_runtime_const("second", 2)
+const first_runtime_const = record_runtime_const("first", 1)
+
+fn record_runtime_const(label string, value int) int {
+	println(label)
+	return value
+}
+
+fn main() {
+	println(first_runtime_const + second_runtime_const)
+}
+')
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == 'second\nfirst\n3'
+}
+
 fn test_cgen_cache_invalidates_for_resolved_dynamic_flag_change() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_dynamic_c_flag_${os.getpid()}')

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -2378,6 +2378,51 @@ fn main() {
 	assert run_module_cache_binary(second_output) == first_run
 }
 
+fn test_cached_generic_body_preserves_vmod_pseudo_variables() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_generic_vmod_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'v.mod', "Module { name: 'cache_vmod_body' }\n")
+	write_module_cache_file(root, 'origin/origin.v', 'module origin
+
+pub fn module_location[T]() []string {
+	_ = sizeof(T)
+	return [@VMODROOT, @VMOD_FILE]
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import origin
+
+fn main() {
+	location := origin.module_location[int]()
+	println(location[0])
+	println(location[1].contains("cache_vmod_body"))
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	first_run := run_module_cache_binary(first_output)
+	assert first_run == '${os.real_path(root)}\ntrue', first_run
+	header_path := module_cache_artifact(cache_dir, 'origin_', '.vh')
+	assert header_path.len > 0
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains(os.real_path(root)), header
+	assert header.contains('cache_vmod_body'), header
+	assert !header.contains('@VMODROOT'), header
+	assert !header.contains('@VMOD_FILE'), header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == first_run
+}
+
 fn test_cached_comptime_body_resolves_relative_insert() {
 	$if windows {
 		return

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -2287,6 +2287,49 @@ fn main() {
 	assert changed_module_cache_objects(first_hashes, module_cache_object_hashes(cache_dir)).len == 0
 }
 
+fn test_cached_generic_body_preserves_source_location_pseudo_variables() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_generic_source_location_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	source_file := os.join_path(root, 'origin/origin.v')
+	write_module_cache_file(root, 'origin/origin.v', 'module origin
+
+pub fn source_location[T]() []string {
+	_ = sizeof(T)
+	return [@FILE, @DIR, @LINE, @FILE_LINE]
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import origin
+
+fn main() {
+	println(origin.source_location[int]().join("\\n"))
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	first_run := run_module_cache_binary(first_output)
+	assert first_run.contains(os.real_path(source_file)), first_run
+	header_path := module_cache_artifact(cache_dir, 'origin_', '.vh')
+	assert header_path.len > 0
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains(os.real_path(source_file)), header
+	assert !header.contains('@FILE'), header
+	assert !header.contains('@DIR'), header
+	assert !header.contains('@LINE'), header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == first_run
+}
+
 fn test_cached_comptime_body_resolves_relative_insert() {
 	$if windows {
 		return

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -3026,6 +3026,79 @@ fn main() {
 	assert run_module_cache_binary(incremental_output) == 'after real logic'
 }
 
+fn test_incremental_program_cache_falls_back_for_new_generic_type_argument() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_generic_type_arg_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'generic/generic.v', 'module generic
+
+pub fn identity[T](value T) T {
+	return value
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import generic
+
+fn value() int {
+	return generic.identity[int](40)
+}
+
+fn main() {
+	println(value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '40'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+import generic
+
+fn value() int {
+	return generic.identity[int](41)
+}
+
+fn main() {
+	println(value())
+}
+')
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == '41'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+import generic
+
+fn value() int {
+	return int(generic.identity[i64](42))
+}
+
+fn main() {
+	println(value())
+}
+')
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('check (incremental)'), second.output
+	assert !second.output.contains('monomorphize (incremental)'), second.output
+	assert !second.output.contains('cgen (incremental)'), second.output
+	assert run_module_cache_binary(second_output) == '42'
+}
+
 fn test_incremental_program_cache_falls_back_for_newly_reachable_function() {
 	$if !macos {
 		return

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -409,11 +409,55 @@ int cached_sum(
 {
 	return left + right;
 }
+__attribute__((visibility("default"))) int cached_attributed(void)
+{
+	return 42;
+}
 /* V3CACHE_NATIVE_DIRECTIVES_END */
 '
 	header := modulecache.declaration_header(prefix)
 	assert header.contains('static int cached_readback(int value)\n{'), header
 	assert header.contains('static int cached_sum(\n\tint left,\n\tint right\n)\n{'), header
+	assert header.contains('static __attribute__((visibility("default"))) int cached_attributed(void)\n{'), header
+}
+
+fn test_module_cache_declaration_header_keeps_column_zero_inner_block_closes() {
+	prefix := 'int cached_nested(int value) {
+if (value) {
+	value++;
+}
+return value;
+}
+int cached_after(void) {
+	return 1;
+}
+'
+	header := modulecache.declaration_header(prefix)
+	assert header.contains('int cached_nested(int value);'), header
+	assert header.contains('int cached_after(void);'), header
+	assert !header.contains('extern return value'), header
+}
+
+fn test_module_cache_declaration_header_bounds_raw_conditional_branches() {
+	prefix := '#if defined(CACHED_BRANCH)
+int cached_branch(bool enabled) {
+#if defined(CACHED_POSITIVE)
+	if (enabled) {
+#else
+	if (!enabled) {
+#endif
+		return 1;
+	}
+}
+#endif
+int cached_after_branch(void) {
+	return 2;
+}
+'
+	header := modulecache.declaration_header(prefix)
+	assert header.contains('int cached_branch(bool enabled);'), header
+	assert header.contains('int cached_after_branch(void);'), header
+	assert header.count('#endif') == 1, header
 }
 
 fn test_cached_header_preserves_include_search_path_names() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -2123,6 +2123,51 @@ fn main() {
 	assert run_module_cache_binary(second_output) == '14'
 }
 
+fn test_cached_generic_body_resolves_escaped_relative_embed_file() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_generic_escaped_embed_file_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	payload_path := os.join_path(root, "assets/it's.txt")
+	write_module_cache_file(root, "assets/it's.txt", 'cached payload')
+	embed_expr := r"$embed_file('it\'s.txt')"
+	write_module_cache_file(root, 'assets/assets.v', 'module assets
+
+pub fn payload_len[T]() int {
+	_ = sizeof(T)
+	return ${embed_expr}.len
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import assets
+
+fn main() {
+	println(assets.payload_len[int]())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '14'
+	first_hashes := module_cache_object_hashes(cache_dir)
+	header_path := module_cache_artifact(cache_dir, 'assets_', '.vh')
+	assert header_path.len > 0
+	header := os.read_file(header_path) or { panic(err) }
+	escaped_payload_path := os.real_path(payload_path).replace("'", "\\'")
+	assert header.contains(escaped_payload_path), header
+	assert !header.contains(embed_expr), header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '14'
+	assert changed_module_cache_objects(first_hashes, module_cache_object_hashes(cache_dir)).len == 0
+}
+
 fn test_cached_comptime_body_resolves_relative_insert() {
 	$if windows {
 		return

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -1994,6 +1994,8 @@ fn test_cached_generic_body_resolves_relative_embed_file() {
 
 pub fn payload_len[T]() int {
 	_ = sizeof(T)
+	marker := r"trailing\\"
+	_ = marker
 	return $embed_file("payload.txt").len
 }
 ')
@@ -3024,6 +3026,94 @@ fn main() {
 	assert incremental.output.contains('check (incremental)'), incremental.output
 	assert incremental.output.contains('cgen (incremental)'), incremental.output
 	assert run_module_cache_binary(incremental_output) == 'after real logic'
+}
+
+fn test_incremental_program_cache_resolves_compile_signature_artifacts() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_compile_signature_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'cached/cached.v', 'module cached
+
+pub fn value() int {
+	return 40
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import cached
+
+fn adjusted_value() int {
+	return cached.value() + 1
+}
+
+fn main() {
+	println(adjusted_value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '41'
+	// Warm once so the snapshot uses the stable cached-module source set.
+	write_module_cache_file(root, 'main.v', 'module main
+
+import cached
+
+fn adjusted_value() int {
+	return cached.value() + 2
+}
+
+fn main() {
+	println(adjusted_value())
+}
+')
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == '42'
+
+	// Populate strict module objects without replacing main.v's non-strict snapshot.
+	strict_seed_file := os.join_path(root, 'strict_seed.v')
+	write_module_cache_file(root, 'strict_seed.v', 'module main
+
+import cached
+
+fn main() {
+	println(cached.value())
+}
+')
+	strict_seed_output := os.join_path(root, 'strict_seed')
+	strict_seed :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -strict -o ${os.quoted_path(strict_seed_output)} ${os.quoted_path(strict_seed_file)}')
+	assert strict_seed.exit_code == 0, strict_seed.output
+	assert run_module_cache_binary(strict_seed_output) == '40'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+import cached
+
+fn adjusted_value() int {
+	return cached.value() + 3
+}
+
+fn main() {
+	println(adjusted_value())
+}
+')
+	strict_output := os.join_path(root, 'strict')
+	strict :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -strict -o ${os.quoted_path(strict_output)} ${os.quoted_path(main_file)}')
+	assert strict.exit_code == 0, strict.output
+	assert strict.output.contains('check (incremental)'), strict.output
+	assert strict.output.contains('cgen (incremental)'), strict.output
+	assert run_module_cache_binary(strict_output) == '43'
 }
 
 fn test_incremental_program_cache_falls_back_for_new_generic_type_argument() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -179,6 +179,7 @@ fn main() {
 	first :=
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(first_output)} ${os.quoted_path(main_file)}')
 	assert first.exit_code == 0, first.output
+	assert !first.output.contains('check (cached)'), first.output
 	assert !first.output.contains('cgen (cached)'), first.output
 	assert !first.output.contains('monomorphize (cached)'), first.output
 	assert run_module_cache_binary(first_output) == '42'
@@ -187,6 +188,10 @@ fn main() {
 	second :=
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
 	assert second.exit_code == 0, second.output
+	assert second.output.contains('check (cached)'), second.output
+	assert second.output.contains('markused (cached)'), second.output
+	assert second.output.contains('transform (cached)'), second.output
+	assert second.output.contains('annotate types (cached)'), second.output
 	assert second.output.contains('cgen (cached)'), second.output
 	assert second.output.contains('monomorphize (cached)'), second.output
 	assert run_module_cache_binary(second_output) == '42'
@@ -207,6 +212,7 @@ fn main() {
 	changed :=
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(changed_output)} ${os.quoted_path(main_file)}')
 	assert changed.exit_code == 0, changed.output
+	assert !changed.output.contains('check (cached)'), changed.output
 	assert !changed.output.contains('cgen (cached)'), changed.output
 	assert !changed.output.contains('monomorphize (cached)'), changed.output
 	assert run_module_cache_binary(changed_output) == '43'
@@ -221,6 +227,7 @@ pub fn value() int {
 	changed_module :=
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(changed_module_output)} ${os.quoted_path(main_file)}')
 	assert changed_module.exit_code == 0, changed_module.output
+	assert !changed_module.output.contains('check (cached)'), changed_module.output
 	assert !changed_module.output.contains('cgen (cached)'), changed_module.output
 	assert !changed_module.output.contains('monomorphize (cached)'), changed_module.output
 	assert run_module_cache_binary(changed_module_output) == '44'
@@ -539,6 +546,16 @@ fn main() {
 	vh_files := vh_file_lines[0].all_after(':').trim_space().split(' ')
 	assert vh_files.len == fields[3].int(), second.output
 	assert vh_files.all(it.ends_with('.vh')), second.output
+	mut expected_vh_lines := 0
+	for path in vh_files {
+		vh_source := os.read_file(path) or { panic(err) }
+		expected_vh_lines += vh_source.count('\n') + if vh_source.ends_with('\n') { 0 } else { 1 }
+	}
+	parsed_vh_line_metrics :=
+		second.output.split_into_lines().filter(it.contains('parsed .vh lines'))
+	assert parsed_vh_line_metrics.len == 1, second.output
+	vh_line_fields := parsed_vh_line_metrics[0].fields()
+	assert vh_line_fields.len >= 5 && vh_line_fields[3].int() == expected_vh_lines, second.output
 	v_lines := second.output.split_into_lines().filter(it.contains('parsed .v files'))
 	assert v_lines.len == 1, second.output
 	v_fields := v_lines[0].fields()

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -482,6 +482,19 @@ fn test_module_cache_declaration_header_keeps_directives_inside_static_inline_fu
 	assert header.contains('#else\n\treturn malloc(16);\n#endif\n}')
 }
 
+fn test_module_cache_declaration_header_keeps_directives_inside_type_blocks() {
+	prefix := 'typedef struct CachedConditional {
+#ifdef CACHED_WIDE_FIELD
+	long value;
+#else
+	int value;
+#endif
+} CachedConditional;
+'
+	header := modulecache.declaration_header(prefix)
+	assert header.contains(prefix), header
+}
+
 fn test_stateful_native_module_is_cached_with_its_owner() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_stateful_native_${os.getpid()}')
@@ -2947,4 +2960,31 @@ fn main() {
 	assert second.exit_code == 0, second.output
 	assert !second.output.contains('cgen (incremental)'), second.output
 	assert run_module_cache_binary(second_output) == 'called'
+}
+
+fn test_incremental_program_cache_invalidates_for_top_level_statement_change() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_top_level_stmt_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'println(1)\n')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '1'
+
+	write_module_cache_file(root, 'main.v', 'println(2)\n')
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == '2'
 }

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -800,6 +800,27 @@ fn test_module_cache_string_symbol_rewrite_handles_swapped_literals() {
 	assert rewritten.count(beta_definition) == 1
 }
 
+fn test_module_cache_string_symbol_rewrite_skips_c_string_contents() {
+	old_value := 'before'
+	new_value := 'after'
+	old_symbol := module_cache_string_symbol(old_value)
+	new_symbol := module_cache_string_symbol(new_value)
+	unchanged_value := old_symbol
+	unchanged_symbol := module_cache_string_symbol(unchanged_value)
+	old_definition := 'static string ${old_symbol} = {"${old_value}", ${old_value.len}, 1};'
+	unchanged_definition := 'static string ${unchanged_symbol} = {"${unchanged_value}", ${unchanged_value.len}, 1};'
+	source := '${old_definition}\n${unchanged_definition}\n/* ${old_symbol} */\nint ${old_symbol}_suffix;\n/* V3CACHE_BODY_BEGIN */\nconsume(${old_symbol});\nconsume(${unchanged_symbol});\n'
+	rewritten := modulecache.rewrite_cached_runtime_strings(source, [old_value, unchanged_value], [
+		new_value,
+		unchanged_value,
+	]) or { panic('runtime string rewrite failed') }
+	body := rewritten.all_after('/* V3CACHE_BODY_BEGIN */')
+	assert body.contains('consume(${new_symbol});\nconsume(${unchanged_symbol});')
+	assert rewritten.contains(unchanged_definition)
+	assert rewritten.contains('/* ${old_symbol} */')
+	assert rewritten.contains('int ${old_symbol}_suffix;')
+}
+
 fn test_module_cache_string_symbol_rewrite_rejects_partially_changed_duplicates() {
 	x_symbol := module_cache_string_symbol('x')
 	x_definition := 'static string ${x_symbol} = {"x", 1, 1};'

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -264,6 +264,19 @@ fn test_module_cache_declaration_header_preserves_preprocessor_after_comment() {
 	assert !header.contains('extern #ifndef')
 }
 
+fn test_module_cache_declaration_header_keeps_directives_in_pending_declaration() {
+	prefix := 'int cached_call(
+#ifdef CACHED_EXTRA_PARAMETER
+	int extra,
+#endif
+	int value
+);
+'
+	header := modulecache.declaration_header(prefix)
+	assert header.count('int cached_call(') == 1, header
+	assert header.contains(prefix), header
+}
+
 fn test_module_cache_declaration_header_ignores_semicolons_inside_block_comments() {
 	prefix := '/*
 revision history:
@@ -860,6 +873,69 @@ fn main() {
 		os.walk_ext(cache_dir, '.o.stamp').filter(os.file_name(it).starts_with('wrapper_'))
 	assert second_wrapper_stamps.len == 2
 	assert second_wrapper_stamps.any(it !in first_wrapper_stamps)
+}
+
+fn test_cgen_cache_tracks_pkgconfig_output() {
+	$if windows {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_pkgconfig_cache_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	old_path := os.getenv('PATH')
+	old_flags := os.getenv_opt('V3_TEST_PKGCONFIG_FLAGS')
+	defer {
+		os.setenv('PATH', old_path, true)
+		if value := old_flags {
+			os.setenv('V3_TEST_PKGCONFIG_FLAGS', value, true)
+		} else {
+			os.unsetenv('V3_TEST_PKGCONFIG_FLAGS')
+		}
+		os.rmdir_all(root) or {}
+	}
+	pkgconfig := os.join_path(root, 'pkg-config')
+	write_module_cache_file(root, 'pkg-config', '#!/bin/sh
+printf "%s\\n" "\$V3_TEST_PKGCONFIG_FLAGS"
+')
+	os.chmod(pkgconfig, 0o700) or { panic(err) }
+	os.setenv('PATH', '${root}${os.path_delimiter}${old_path}', true)
+	write_module_cache_file(root, 'value.c', '#ifndef V3_PKG_VALUE
+#error V3_PKG_VALUE is required
+#endif
+int v3_pkg_value(void) { return V3_PKG_VALUE; }
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+#pkgconfig v3-cache-test
+#insert "@DIR/value.c"
+
+fn C.v3_pkg_value() int
+
+fn main() {
+	println(C.v3_pkg_value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	os.setenv('V3_TEST_PKGCONFIG_FLAGS', '-DV3_PKG_VALUE=41', true)
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '41'
+	warm_output := os.join_path(root, 'warm')
+	warm :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(warm_output)} ${os.quoted_path(main_file)}')
+	assert warm.exit_code == 0, warm.output
+	assert warm.output.contains('cgen (cached)'), warm.output
+	assert run_module_cache_binary(warm_output) == '41'
+
+	os.setenv('V3_TEST_PKGCONFIG_FLAGS', '-DV3_PKG_VALUE=42', true)
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == '42'
 }
 
 fn test_module_cache_restart_preserves_compiler_stderr() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -546,6 +546,12 @@ fn main() {
 	v_files := v_file_lines[0].all_after(':').trim_space().split(' ')
 	assert v_files.len == v_fields[3].int(), second.output
 	assert v_files == [main_file], second.output
+	v_source := os.read_file(main_file) or { panic(err) }
+	expected_v_lines := v_source.count('\n') + if v_source.ends_with('\n') { 0 } else { 1 }
+	parsed_v_line_metrics := second.output.split_into_lines().filter(it.contains('parsed .v lines'))
+	assert parsed_v_line_metrics.len == 1, second.output
+	line_fields := parsed_v_line_metrics[0].fields()
+	assert line_fields.len >= 5 && line_fields[3].int() == expected_v_lines, second.output
 }
 
 fn test_cold_module_cache_prints_reuse_hint_only_once() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -52,7 +52,7 @@ fn compile_module_cache_project(v3_bin string, cache_dir string, main_file strin
 
 fn run_module_cache_binary(path string) string {
 	result := os.execute(os.quoted_path(path))
-	assert result.exit_code == 0, result.output
+	assert result.exit_code == 0, '${path}: ${result.output}'
 	return result.output.trim_space()
 }
 
@@ -63,6 +63,52 @@ fn module_cache_object_hash(path string) u64 {
 		hash = (hash ^ u64(byte)) * u64(1099511628211)
 	}
 	return hash
+}
+
+fn test_cached_object_accepts_recorded_dependency_superset() {
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_dependency_superset_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	old_cache := os.getenv_opt('V3CACHE')
+	os.setenv('V3CACHE', root, true)
+	defer {
+		if value := old_cache {
+			os.setenv('V3CACHE', value, true)
+		} else {
+			os.unsetenv('V3CACHE')
+		}
+		os.rmdir_all(root) or {}
+	}
+	source := os.join_path(root, 'foo.v')
+	first_dependency := os.join_path(root, 'first.h')
+	extra_dependency := os.join_path(root, 'extra.h')
+	new_dependency := os.join_path(root, 'new.h')
+	write_module_cache_file(root, 'foo.v', 'module foo')
+	write_module_cache_file(root, 'first.h', '#define FIRST 1')
+	write_module_cache_file(root, 'extra.h', '#define EXTRA 1')
+	write_module_cache_file(root, 'new.h', '#define NEW 1')
+	manager := modulecache.new_manager(root, 'dependency-superset', true, '')
+	assert manager.ensure_dir()
+	compile_signature := 'flags'
+	entry := manager.object_entry('foo', [source], compile_signature)
+	os.write_file(entry.object, '') or { panic(err) }
+	manager.write_stamp('foo', [source], {
+		first_dependency: modulecache.file_signature(first_dependency)
+		extra_dependency: modulecache.file_signature(extra_dependency)
+	}, compile_signature) or { panic(err) }
+	_ := manager.valid_object_for_compile_signature('foo', [source], compile_signature, {
+		first_dependency: modulecache.file_signature(first_dependency)
+	}) or {
+		assert false, 'a recorded dependency superset should remain valid'
+		return
+	}
+	if _ := manager.valid_object_for_compile_signature('foo', [source], compile_signature, {
+		first_dependency: modulecache.file_signature(first_dependency)
+		new_dependency:   modulecache.file_signature(new_dependency)
+	})
+	{
+		assert false, 'a newly discovered dependency must invalidate the object'
+	}
 }
 
 fn module_cache_object_hashes(cache_dir string) map[string]u64 {
@@ -123,6 +169,431 @@ fn test_module_cache_declaration_header_preserves_preprocessor_after_comment() {
 	header := modulecache.declaration_header(prefix)
 	assert header.contains('/* embedded header */\n#ifndef CACHED_HEADER')
 	assert !header.contains('extern #ifndef')
+}
+
+fn test_module_cache_declaration_header_ignores_semicolons_inside_block_comments() {
+	prefix := '/*
+revision history:
+  feature works again;
+  #ifdef text inside the comment
+  another fix;
+*/
+int value = 1;
+'
+	header := modulecache.declaration_header(prefix)
+	assert header.contains('extern int value;')
+	assert !header.contains('extern feature')
+	assert !header.contains('extern another')
+	assert !header.contains('#ifdef text')
+	assert !modulecache.c_source_has_static_storage(prefix)
+}
+
+fn test_module_cache_declaration_header_handles_extern_c_and_trailing_comments() {
+	prefix := '#ifdef __cplusplus
+extern "C" {
+#endif
+int cached_fn(int value); // public API
+typedef struct
+{
+	float x;
+	float y;
+} CachedPoint;
+#ifdef __cplusplus
+} // extern "C"
+#endif
+'
+	header := modulecache.declaration_header(prefix)
+	assert header.contains('extern "C" {')
+	assert header.contains('int cached_fn(int value); // public API')
+	assert header.contains('float x;\n\tfloat y;\n} CachedPoint;')
+	assert !header.contains('typedef struct;')
+	assert header.contains('} // extern "C"')
+}
+
+fn test_module_cache_declaration_header_keeps_macro_function_conditionals_bounded() {
+	prefix := '#if defined(CACHED_EMSCRIPTEN)
+EM_JS(void, cached_js_fn, (void), {
+	if (Module.value) {
+		Module.value++;
+	}
+})
+#endif
+#if defined(CACHED_WINDOWS)
+void cached_windows_fn(bool enabled) {
+#if defined(CACHED_OPTION)
+	if (enabled) {
+		cached_js_fn();
+	}
+#endif
+}
+#endif
+int cached_after(void) {
+	return 1;
+}
+'
+	header := modulecache.declaration_header(prefix)
+	assert header.count('#endif') == 2
+	assert header.contains('void cached_windows_fn(bool enabled);')
+	assert header.contains('int cached_after(void);')
+	assert !header.contains('extern Module.value')
+	assert !header.contains('extern return 1')
+}
+
+fn test_module_cache_declaration_header_keeps_native_headers_without_implementations() {
+	prefix := 'int generated_state = 1;
+/* V3CACHE_NATIVE_DIRECTIVES_BEGIN */
+#define SOKOL_APP_IMPL
+#define STB_IMAGE_IMPLEMENTATION
+#define FEATURE_FLAG
+/* Usage:
+   #define STB_IMAGE_IMPLEMENTATION
+*/
+typedef struct NativeType { int value; } NativeType;
+#ifdef SOKOL_APP_IMPL
+int native_implementation(void) { return 1; }
+#endif
+/* V3CACHE_NATIVE_DIRECTIVES_END */
+/* V3CACHE_SOURCE_DIRECTIVES_BEGIN */
+int native_source_body(void) { return 2; }
+/* V3CACHE_SOURCE_DIRECTIVES_END */
+int generated_fn(void) { return 3; }
+'
+	header := modulecache.declaration_header(prefix)
+	assert header.contains('extern int generated_state;')
+	assert header.contains('typedef struct NativeType { int value; } NativeType;')
+	assert header.contains('#define FEATURE_FLAG')
+	assert header.contains('/* Usage:\n   #define STB_IMAGE_IMPLEMENTATION\n*/')
+	assert header.contains('/* v3 cache omitted SOKOL_APP_IMPL */')
+	assert header.contains('/* v3 cache omitted STB_IMAGE_IMPLEMENTATION */')
+	assert !header.contains('#define SOKOL_APP_IMPL')
+	assert header.count('#define STB_IMAGE_IMPLEMENTATION') == 1
+	assert !header.contains('native_source_body')
+	assert header.contains('int generated_fn(void);')
+}
+
+fn test_module_cache_native_header_conditional_functions_become_declarations() {
+	prefix := '/* V3CACHE_NATIVE_DIRECTIVES_BEGIN */
+#if defined(CACHED_GL)
+int cached_readback(int value) {
+	return value;
+}
+#else
+int cached_readback(int value) {
+	return -value;
+}
+#endif
+/* V3CACHE_NATIVE_DIRECTIVES_END */
+'
+	header := modulecache.declaration_header(prefix)
+	assert header.count('static int cached_readback(int value) {') == 2
+	assert header.contains('return value')
+	assert header.contains('return -value')
+}
+
+fn test_cached_header_preserves_include_search_path_names() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_include_search_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'wrapper/include/cached_value.h', '#define CACHED_VALUE 42\n')
+	write_module_cache_file(root, 'wrapper/wrapper.v', 'module wrapper
+
+#flag -I @DIR/include
+#include "cached_value.h"
+
+pub fn value() int {
+	return C.CACHED_VALUE
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import wrapper
+
+fn main() {
+	println(wrapper.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	header_path := module_cache_artifact(cache_dir, 'wrapper_', '.vh')
+	assert header_path.len > 0
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains('#include "cached_value.h"'), header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+}
+
+fn test_cached_unused_callback_declaration_emits_fn_pointer_typedef() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_unused_callback_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'wrapper/wrapper.v', 'module wrapper
+
+pub fn apply(cb fn (int) int, value int) int {
+	return cb(value)
+}
+
+pub fn value() int {
+	return 42
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import wrapper
+
+fn main() {
+	println(wrapper.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+}
+
+fn test_module_cache_static_inline_attributes_are_not_storage() {
+	source := 'static __inline void atomic_fence(int order __attribute__((unused))) {\n\t(void)order;\n}\n'
+	assert !modulecache.c_source_has_static_storage(source)
+	assert modulecache.c_source_has_static_storage('static int state = 1;\n')
+	assert modulecache.c_source_has_static_storage('static inline int next(void) {\n\tstatic int state;\n\treturn ++state;\n}\n')
+}
+
+fn test_module_cache_declaration_header_keeps_directives_inside_static_inline_functions() {
+	prefix := 'static inline void *aligned_alloc_for_target(void) {
+#ifdef _WIN32
+	return _aligned_malloc(16, 16);
+#else
+	return malloc(16);
+#endif
+}
+'
+	header := modulecache.declaration_header(prefix)
+	assert header.contains('static inline void *aligned_alloc_for_target(void) {\n#ifdef _WIN32')
+	assert header.contains('#else\n\treturn malloc(16);\n#endif\n}')
+}
+
+fn test_stateful_native_module_is_cached_with_its_owner() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_stateful_native_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'native/native.v', 'module native
+
+#include "@DIR/native.c"
+
+fn C.native_value() int
+
+pub fn value() int {
+	identity := fn (value int) int {
+		return value
+	}
+	return identity(C.native_value())
+}
+')
+	write_module_cache_file(root, 'native/native.c', 'static int native_state = 40;
+
+int native_value(void) {
+	return ++native_state;
+}
+')
+	write_module_cache_file(root, 'cached/cached.v', 'module cached
+
+pub fn value() int {
+	return 1
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import cached
+import native
+
+fn main() {
+	println(cached.value() + native.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	assert module_cache_artifact(cache_dir, 'cached_', '.o').len > 0
+	assert module_cache_artifact(cache_dir, 'native_', '.o').len > 0
+	native_header := module_cache_artifact(cache_dir, 'native_', '.vh')
+	assert native_header.len > 0
+	assert !(os.read_file(native_header) or { panic(err) }).contains('compile source in program unit')
+
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert run_module_cache_binary(second_output) == '42'
+	vh_lines := second.output.split_into_lines().filter(it.contains('parsed .vh files'))
+	assert vh_lines.len == 1, second.output
+	fields := vh_lines[0].fields()
+	assert fields.len >= 4 && fields[3].int() > 0, second.output
+	vh_file_lines :=
+		second.output.split_into_lines().filter(it.trim_space().starts_with('.vh files:'))
+	assert vh_file_lines.len == 1, second.output
+	vh_files := vh_file_lines[0].all_after(':').trim_space().split(' ')
+	assert vh_files.len == fields[3].int(), second.output
+	assert vh_files.all(it.ends_with('.vh')), second.output
+	v_lines := second.output.split_into_lines().filter(it.contains('parsed .v files'))
+	assert v_lines.len == 1, second.output
+	v_fields := v_lines[0].fields()
+	assert v_fields.len >= 4 && v_fields[3].int() > 0, second.output
+	v_file_lines :=
+		second.output.split_into_lines().filter(it.trim_space().starts_with('.v files:'))
+	assert v_file_lines.len == 1, second.output
+	v_files := v_file_lines[0].all_after(':').trim_space().split(' ')
+	assert v_files.len == v_fields[3].int(), second.output
+	assert v_files == [main_file], second.output
+}
+
+fn test_cold_module_cache_prints_reuse_hint_only_once() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_cold_hint_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'cached/cached.v', 'module cached
+
+pub fn value() int {
+	return 42
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import cached
+
+fn main() {
+	println(cached.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	hint := 'will not be recompiled on the next run unless they change'
+	cold_stdout := os.join_path(root, 'cold.stdout')
+	cold_stderr := os.join_path(root, 'cold.stderr')
+	cold_output := os.join_path(root, 'cold')
+	cold :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(cold_output)} ${os.quoted_path(main_file)} > ${os.quoted_path(cold_stdout)} 2> ${os.quoted_path(cold_stderr)}')
+	assert cold.exit_code == 0, cold.output
+	cold_stdout_text := os.read_file(cold_stdout) or { panic(err) }
+	cold_stderr_text := os.read_file(cold_stderr) or { panic(err) }
+	assert cold_stdout_text.contains('Hint: cached '), cold_stdout_text
+	assert cold_stdout_text.contains(hint), cold_stdout_text
+	assert !cold_stderr_text.contains(hint), cold_stderr_text
+
+	warm_stdout := os.join_path(root, 'warm.stdout')
+	warm_output := os.join_path(root, 'warm')
+	warm :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(warm_output)} ${os.quoted_path(main_file)} > ${os.quoted_path(warm_stdout)}')
+	assert warm.exit_code == 0, warm.output
+	warm_stdout_text := os.read_file(warm_stdout) or { panic(err) }
+	assert !warm_stdout_text.contains(hint), warm_stdout_text
+}
+
+fn test_cached_native_source_fallback_declaration_is_not_in_program_unit() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_native_fallback_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'native/native.v', 'module native
+
+#include "@DIR/native.m"
+
+fn C.native_value(&int) int
+
+pub fn value() int {
+	n := 90
+	return C.native_value(&n)
+}
+')
+	write_module_cache_file(root, 'native/native.m', 'int native_value(const int* value) {
+	return *value;
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import native
+
+fn main() {
+	println(native.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '90'
+	assert module_cache_artifact(cache_dir, 'native_', '.o').len > 0
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '90'
+}
+
+fn test_cached_unused_function_handles_plain_multi_discard_assignment() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_multi_discard_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'cached/cached.v', 'module cached
+
+fn unused(key string, value string) {
+	_, _ = key, value
+}
+
+pub fn value() int {
+	return 42
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import cached
+
+fn main() {
+	println(cached.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	assert module_cache_artifact(cache_dir, 'cached_', '.o').len > 0
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
 }
 
 fn test_module_cache_string_symbol_rewrite_preserves_literal_bytes() {
@@ -976,7 +1447,7 @@ fn main() {
 	compile_module_cache_project(v3_bin, cache_dir, second_main, second_output)
 	assert run_module_cache_binary(second_output) == '42'
 	second_hashes := module_cache_object_hashes(cache_dir)
-	assert second_hashes.keys().filter(it.starts_with('builtin_')).len == 1
+	assert second_hashes.keys().filter(it.starts_with('builtin_')).len == 1, second_hashes.keys().str()
 }
 
 fn test_cached_headers_keep_full_module_identity() {
@@ -1075,25 +1546,147 @@ pub fn value() int {
 	return generic.identity[int](42)
 }
 ')
-	main_file := os.join_path(root, 'main.v')
-	write_module_cache_file(root, 'main.v', 'module main
+	write_module_cache_file(root, 'outer/outer.v', 'module outer
 
 import wrapper
 
+pub fn value() int {
+	return wrapper.value()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import outer
+
 fn main() {
-	println(wrapper.value())
+	println(outer.value())
 }
 ')
 	cache_dir := os.join_path(root, 'cache')
 	first_output := os.join_path(root, 'first')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
 	assert run_module_cache_binary(first_output) == '42'
+	wrapper_header_path := module_cache_artifact(cache_dir, 'wrapper_', '.vh')
+	assert wrapper_header_path.len > 0
+	assert !modulecache.header_needs_source(modulecache.Entry{
+		header: wrapper_header_path
+	})
 	first_hashes := module_cache_object_hashes(cache_dir)
 
 	second_output := os.join_path(root, 'second')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
 	assert run_module_cache_binary(second_output) == '42'
 	assert changed_module_cache_objects(first_hashes, module_cache_object_hashes(cache_dir)).len == 0
+}
+
+fn test_cached_module_body_recreates_generic_receiver_specializations() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_generic_receiver_chain_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'genericbox/genericbox.v', 'module genericbox
+
+pub struct Box[T] {
+pub:
+	value T
+}
+
+pub fn (box Box[T]) get() T {
+	return box.value
+}
+')
+	write_module_cache_file(root, 'wrapper/wrapper.v', 'module wrapper
+
+import genericbox
+
+pub fn value() int {
+	return genericbox.Box[int]{
+		value: 45
+	}.get()
+}
+')
+	write_module_cache_file(root, 'outer/outer.v', 'module outer
+
+import wrapper
+
+pub fn value() int {
+	return wrapper.value()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import outer
+
+fn main() {
+	println(outer.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '45'
+	wrapper_header_path := module_cache_artifact(cache_dir, 'wrapper_', '.vh')
+	assert wrapper_header_path.len > 0
+	wrapper_header := os.read_file(wrapper_header_path) or { panic(err) }
+	assert wrapper_header.contains('pub fn value() int {'), wrapper_header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '45'
+}
+
+fn test_cached_module_body_recreates_captured_callback_symbols() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_captured_callback_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'callbacks/callbacks.v', 'module callbacks
+
+pub fn value(input int) int {
+	offset := 3
+	add := fn [offset] (value int) int {
+		return offset + value
+	}
+	return add(input)
+}
+')
+	write_module_cache_file(root, 'outer/outer.v', 'module outer
+
+import callbacks
+
+pub fn value() int {
+	return callbacks.value(43)
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import outer
+
+fn main() {
+	println(outer.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '46'
+	callback_header_path := module_cache_artifact(cache_dir, 'callbacks_', '.vh')
+	assert callback_header_path.len > 0
+	callback_header := os.read_file(callback_header_path) or { panic(err) }
+	assert callback_header.contains('pub fn value(input int) int {'), callback_header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '46'
 }
 
 fn test_cached_generic_receiver_method_keeps_its_body() {
@@ -1134,9 +1727,11 @@ fn main() {
 	first_hashes := module_cache_object_hashes(cache_dir)
 	header_path := module_cache_artifact(cache_dir, 'genericbox_', '.vh')
 	assert header_path.len > 0
-	assert modulecache.header_needs_source(modulecache.Entry{
+	assert !modulecache.header_needs_source(modulecache.Entry{
 		header: header_path
 	})
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains('pub fn (box Box[T]) get() T {'), header
 
 	second_output := os.join_path(root, 'second')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
@@ -1243,6 +1838,63 @@ fn main() {
 	assert changed_module_cache_objects(first_hashes, module_cache_object_hashes(cache_dir)).len == 0
 }
 
+fn test_cached_interface_implementer_with_embedded_body_has_forward_declaration() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_interface_embedded_body_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'contract/contract.v', 'module contract
+
+pub interface Writer {
+	write(value int) int
+}
+')
+	write_module_cache_file(root, 'writer/writer.v', 'module writer
+
+import contract
+
+pub struct NumberWriter {}
+
+fn identity[T](value T) T {
+	return value
+}
+
+pub fn (mut writer NumberWriter) write(value int) int {
+	_ = writer
+	return identity[int](value)
+}
+
+pub fn make() contract.Writer {
+	return &NumberWriter{}
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import writer
+
+fn main() {
+	mut output := writer.make()
+	println(output.write(44))
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '44'
+	header_path := module_cache_artifact(cache_dir, 'writer_', '.vh')
+	assert header_path.len > 0
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains('fn (mut writer NumberWriter) write(value int) int {'), header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '44'
+}
+
 fn test_cached_header_preserves_comptime_struct_fields() {
 	mut a := flat.FlatAst.new()
 	module_id := a.add_node(flat.Node{
@@ -1293,7 +1945,7 @@ fn test_cached_header_preserves_comptime_struct_fields() {
 	assert header.contains('\tenabled bool')
 }
 
-fn test_cached_struct_default_with_unsupported_initializer_keeps_source() {
+fn test_cached_struct_default_with_unsupported_initializer_is_embedded() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_struct_default_index_${os.getpid()}')
 	os.rmdir_all(root) or {}
@@ -1305,6 +1957,7 @@ fn test_cached_struct_default_with_unsupported_initializer_keeps_source() {
 
 const values = [41, 42]
 
+@[params]
 pub struct Config {
 pub:
 	first int = values[0]
@@ -1312,6 +1965,10 @@ pub:
 
 pub fn cached_value() int {
 	return Config{}.first
+}
+
+pub fn configured(config Config) int {
+	return config.first
 }
 ')
 	main_file := os.join_path(root, 'main.v')
@@ -1322,26 +1979,77 @@ import defaulted
 fn main() {
 	println(defaulted.Config{}.first)
 	println(defaulted.cached_value())
+	println(defaulted.configured())
 }
 ')
 	cache_dir := os.join_path(root, 'cache')
 	first_output := os.join_path(root, 'first')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
-	assert run_module_cache_binary(first_output) == '41\n41'
+	assert run_module_cache_binary(first_output) == '41\n41\n41'
 	header_path := module_cache_artifact(cache_dir, 'defaulted_', '.vh')
 	assert header_path.len > 0
-	assert modulecache.header_needs_source(modulecache.Entry{
+	assert !modulecache.header_needs_source(modulecache.Entry{
 		header: header_path
 	})
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.count('pub struct Config {') == 1, header
+	assert header.contains('@[params]\npub struct Config {'), header
+	assert header.contains('values = [41, 42].clone()'), header
 	first_hashes := module_cache_object_hashes(cache_dir)
 
 	second_output := os.join_path(root, 'second')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
-	assert run_module_cache_binary(second_output) == '41\n41'
+	assert run_module_cache_binary(second_output) == '41\n41\n41'
 	assert changed_module_cache_objects(first_hashes, module_cache_object_hashes(cache_dir)).len == 0
 }
 
-fn test_cached_const_with_unsupported_initializer_keeps_source() {
+fn test_cached_const_preserves_positional_struct_initializers() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_positional_struct_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'records/records.v', 'module records
+
+pub struct Pair {
+pub:
+	left  int
+	right int
+}
+
+const pairs = [Pair{41, 42}]!
+
+pub fn first() int {
+	return pairs[0].left
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import records
+
+fn main() {
+	println(records.first())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '41'
+	header_path := module_cache_artifact(cache_dir, 'records_', '.vh')
+	assert header_path.len > 0
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains('Pair{41, 42}]!'), header
+	assert !header.contains('Pair{:'), header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '41'
+}
+
+fn test_cached_const_with_unsupported_initializer_is_embedded() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_const_index_${os.getpid()}')
 	os.rmdir_all(root) or {}
@@ -1374,16 +2082,19 @@ fn main() {
 	assert run_module_cache_binary(first_output) == '41\n41'
 	header_path := module_cache_artifact(cache_dir, 'indexed_', '.vh')
 	assert header_path.len > 0
-	assert modulecache.header_needs_source(modulecache.Entry{
+	assert !modulecache.header_needs_source(modulecache.Entry{
 		header: header_path
 	})
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains('pub const values = [41, 42].clone()'), header
+	assert header.contains('pub const first = values[0]'), header
 
 	second_output := os.join_path(root, 'second')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
 	assert run_module_cache_binary(second_output) == '41\n41'
 }
 
-fn test_cached_global_with_unsupported_initializer_keeps_source() {
+fn test_cached_global_with_unsupported_initializer_is_embedded() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_global_index_${os.getpid()}')
 	os.rmdir_all(root) or {}
@@ -1396,6 +2107,11 @@ fn test_cached_global_with_unsupported_initializer_keeps_source() {
 const values = [41, 42]
 
 __global first = values[0]
+
+pub union Holder {
+pub mut:
+	value int
+}
 
 pub fn cached_value() int {
 	return first
@@ -1416,9 +2132,11 @@ fn main() {
 	assert run_module_cache_binary(first_output) == '41'
 	header_path := module_cache_artifact(cache_dir, 'initialized_', '.vh')
 	assert header_path.len > 0
-	assert modulecache.header_needs_source(modulecache.Entry{
+	assert !modulecache.header_needs_source(modulecache.Entry{
 		header: header_path
 	})
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains('pub union Holder {'), header
 	first_hashes := module_cache_object_hashes(cache_dir)
 
 	second_output := os.join_path(root, 'second')
@@ -1436,6 +2154,12 @@ fn test_cached_header_preserves_noreturn_attribute() {
 		os.rmdir_all(root) or {}
 	}
 	write_module_cache_file(root, 'terminator/terminator.v', 'module terminator
+
+@[markused; params]
+pub struct ExitConfig {
+pub:
+	code int
+}
 
 @[noreturn]
 pub fn die() {
@@ -1459,7 +2183,9 @@ fn main() {}
 	header_path := module_cache_artifact(cache_dir, 'terminator_', '.vh')
 	assert header_path.len > 0
 	header := os.read_file(header_path) or { panic(err) }
-	assert header.contains('@[noreturn]\nfn die()')
+	assert header.contains('@[noreturn]\npub fn die()'), header
+	assert header.contains('@[markused; params]\npub struct ExitConfig {'), header
+	assert !header.contains('@[markused; params]\n@[params]\npub struct ExitConfig {'), header
 	first_hashes := module_cache_object_hashes(cache_dir)
 
 	second_output := os.join_path(root, 'second')
@@ -1619,7 +2345,7 @@ fn main() {
 	assert foo_header_path.len > 0
 	foo_header := os.read_file(foo_header_path) or { panic(err) }
 	assert foo_header.contains('struct Item')
-	assert foo_header.contains('const (')
+	assert foo_header.contains('pub const answer = 21')
 	assert foo_header.contains('fn value() int')
 	assert !foo_header.contains('return answer')
 	assert module_cache_artifact(cache_dir, 'hash_', '.vh').len > 0

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -1289,6 +1289,39 @@ fn main() {
 	assert run_module_cache_binary(second_output) == '6'
 }
 
+fn test_whole_program_cgen_invalidates_when_implicit_main_external_input_changes() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(),
+		'v3_module_cache_implicit_main_external_input_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'payload.txt', 'abc')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'println($embed_file("payload.txt").len)\n')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '3'
+
+	warm_output := os.join_path(root, 'warm')
+	warm :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(warm_output)} ${os.quoted_path(main_file)}')
+	assert warm.exit_code == 0, warm.output
+	assert warm.output.contains('cgen (cached)'), warm.output
+	assert run_module_cache_binary(warm_output) == '3'
+
+	write_module_cache_file(root, 'payload.txt', 'abcdef')
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == '6'
+}
+
 fn test_whole_program_cgen_invalidates_when_forced_include_changes() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_forced_include_${os.getpid()}')
@@ -3661,4 +3694,51 @@ fn main() {}
 	assert second.exit_code != 0, second.output
 	assert second.output.contains('missing return'), second.output
 	assert !second.output.contains('check (incremental)'), second.output
+}
+
+fn test_incremental_program_cache_invalidates_for_reflected_declaration_attribute_change() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_reflected_attribute_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+@[first]
+struct Tagged {}
+
+fn main() {
+	$for attr in Tagged.attributes {
+		println(attr.name)
+	}
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'first'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+@[second]
+struct Tagged {}
+
+fn main() {
+	$for attr in Tagged.attributes {
+		println(attr.name)
+	}
+}
+')
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('check (incremental)'), second.output
+	assert run_module_cache_binary(second_output) == 'second'
 }

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -747,6 +747,30 @@ fn module_cache_string_symbol(value string) string {
 	return '_v3_lit_${value.len}_${hash.hex()}'
 }
 
+fn test_module_cache_materializes_cached_body_string_definitions() {
+	stable_symbol := module_cache_string_symbol('stable')
+	before_symbol := module_cache_string_symbol('before')
+	after_symbol := module_cache_string_symbol('after')
+	stable_definition := 'static string ${stable_symbol} = {"stable", 6, 1};'
+	before_definition := 'static string ${before_symbol} = {"before", 6, 1};'
+	after_definition := 'static string ${after_symbol} = {"after", 5, 1};'
+	cached := '// V3CACHE_BASELINE ${stable_definition}\n// V3CACHE_BASELINE ${before_definition}\n/* V3CACHE_BODY_BEGIN */\nconsume(${stable_symbol});\nconsume(${before_symbol});\n'
+	materialized := modulecache.materialize_cached_body_string_definitions(cached)
+	assert materialized.contains(stable_definition)
+	assert materialized.contains(before_definition)
+	assert !materialized.contains('// V3CACHE_BASELINE')
+	with_actual := modulecache.materialize_cached_body_string_definitions(before_definition + '\n' +
+		cached)
+	assert with_actual.count(before_definition) == 1
+	rewritten := modulecache.rewrite_cached_runtime_strings(materialized, ['stable', 'before'], [
+		'stable',
+		'after',
+	]) or { panic('runtime string rewrite failed') }
+	assert rewritten.contains(stable_definition)
+	assert rewritten.contains(after_definition)
+	assert !rewritten.contains(before_definition)
+}
+
 fn test_module_cache_string_symbol_rewrite_handles_swapped_literals() {
 	alpha_symbol := module_cache_string_symbol('alpha')
 	beta_symbol := module_cache_string_symbol('beta')
@@ -2918,6 +2942,87 @@ fn main() {
 	assert cached.output.contains('monomorphize (cached)'), cached.output
 	assert cached.output.contains('cgen (cached)'), cached.output
 	assert run_module_cache_binary(cached_output) == '1\n2\ntrue\nfalse\nfalse\ntrue'
+}
+
+fn test_generic_program_cache_rehydrates_body_string_literals() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_generic_body_strings_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', "module main
+
+fn identity[T](value T) T {
+\treturn value
+}
+
+fn main() {
+\tprintln(identity('seed'))
+\tprintln('initial')
+}
+")
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'seed\ninitial'
+
+	write_module_cache_file(root, 'main.v', "module main
+
+fn identity[T](value T) T {
+\treturn value
+}
+
+fn main() {
+\tprintln(identity('stable'))
+\tprintln('before')
+}
+")
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == 'stable\nbefore'
+
+	write_module_cache_file(root, 'main.v', "module main
+
+fn identity[T](value T) T {
+\treturn value
+}
+
+fn main() {
+\tprintln(identity('stable'))
+\tprintln('before')
+}
+
+// A source-only edit must retain both cached literal definitions.
+")
+	comment_output := os.join_path(root, 'comment')
+	comment :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(comment_output)} ${os.quoted_path(main_file)}')
+	assert comment.exit_code == 0, comment.output
+	assert comment.output.contains('cgen (cached)'), comment.output
+	assert run_module_cache_binary(comment_output) == 'stable\nbefore'
+
+	write_module_cache_file(root, 'main.v', "module main
+
+fn identity[T](value T) T {
+\treturn value
+}
+
+fn main() {
+\tprintln(identity('stable'))
+\tprintln('after')
+}
+")
+	changed_output := os.join_path(root, 'changed')
+	changed :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(changed_output)} ${os.quoted_path(main_file)}')
+	assert changed.exit_code == 0, changed.output
+	assert run_module_cache_binary(changed_output) == 'stable\nafter'
 }
 
 fn test_incremental_program_cache_recompiles_real_main_logic() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -726,6 +726,30 @@ fn main() {
 	assert run_module_cache_binary(output) == '_str_0'
 }
 
+fn module_cache_string_symbol(value string) string {
+	mut hash := u64(1469598103934665603)
+	for c in value.bytes() {
+		hash = (hash ^ u64(c)) * u64(1099511628211)
+	}
+	return '_v3_lit_${value.len}_${hash.hex()}'
+}
+
+fn test_module_cache_string_symbol_rewrite_handles_swapped_literals() {
+	alpha_symbol := module_cache_string_symbol('alpha')
+	beta_symbol := module_cache_string_symbol('beta')
+	alpha_definition := 'static string ${alpha_symbol} = {"alpha", 5, 1};'
+	beta_definition := 'static string ${beta_symbol} = {"beta", 4, 1};'
+	source := '${alpha_definition}\n${beta_definition}\n/* V3CACHE_BODY_BEGIN */\nconsume(${alpha_symbol});\nconsume(${beta_symbol});\n'
+	rewritten := modulecache.rewrite_cached_runtime_strings(source, ['alpha', 'beta'], [
+		'beta',
+		'alpha',
+	]) or { panic('runtime string rewrite failed') }
+	body := rewritten.all_after('/* V3CACHE_BODY_BEGIN */')
+	assert body.contains('consume(${beta_symbol});\nconsume(${alpha_symbol});')
+	assert rewritten.count(alpha_definition) == 1
+	assert rewritten.count(beta_definition) == 1
+}
+
 fn test_module_cache_rebuilds_objects_when_c_flags_change() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_c_flags_${os.getpid()}')
@@ -1107,6 +1131,78 @@ fn main() {
 	changed := changed_module_cache_objects(first_hashes, module_cache_object_hashes(cache_dir))
 	assert changed.any(it.starts_with('assets_')), changed.str()
 	assert changed.any(it.starts_with('wrapper_')), changed.str()
+}
+
+fn test_whole_program_cgen_invalidates_when_main_external_input_changes() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_main_external_input_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'payload.txt', 'abc')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+fn main() {
+	println($embed_file("payload.txt").len)
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '3'
+
+	write_module_cache_file(root, 'payload.txt', 'abcdef')
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == '6'
+}
+
+fn test_whole_program_cgen_invalidates_when_forced_include_changes() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_forced_include_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	header := os.join_path(root, 'forced.h')
+	write_module_cache_file(root, 'forced.h', 'static inline int v3_forced_value(void) {
+	return 1;
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+fn C.v3_forced_value() int
+
+fn main() {
+	println(C.v3_forced_value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	c_flags := '-include ${header}'
+	first_output := os.join_path(root, 'first')
+	first :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -cflags ${os.quoted_path(c_flags)} -o ${os.quoted_path(first_output)} ${os.quoted_path(main_file)}')
+	assert first.exit_code == 0, first.output
+	assert run_module_cache_binary(first_output) == '1'
+
+	write_module_cache_file(root, 'forced.h', 'static inline int v3_forced_value(void) {
+	return 2;
+}
+')
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -cflags ${os.quoted_path(c_flags)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == '2'
 }
 
 fn test_module_cache_rebuilds_modules_when_comptime_env_changes() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -1967,6 +1967,102 @@ fn main() {
 	assert changed_module_cache_objects(first_hashes, module_cache_object_hashes(cache_dir)).len == 0
 }
 
+fn test_cached_generic_body_resolves_relative_embed_file() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_generic_embed_file_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	payload_path := os.join_path(root, 'assets/payload.txt')
+	write_module_cache_file(root, 'assets/payload.txt', 'cached payload')
+	write_module_cache_file(root, 'assets/assets.v', 'module assets
+
+pub fn payload_len[T]() int {
+	_ = sizeof(T)
+	return $embed_file("payload.txt").len
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import assets
+
+fn main() {
+	println(assets.payload_len[int]())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '14'
+	header_path := module_cache_artifact(cache_dir, 'assets_', '.vh')
+	assert header_path.len > 0
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains(os.real_path(payload_path)), header
+	assert !header.contains('$embed_file("payload.txt")'), header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '14'
+}
+
+fn test_cached_comptime_body_resolves_relative_insert() {
+	$if windows {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_comptime_insert_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	header_path := os.join_path(root, 'wrapper/api.h')
+	write_module_cache_file(root, 'wrapper/api.h', 'static inline int cached_comptime_value(void) {
+	return 42;
+}
+')
+	write_module_cache_file(root, 'wrapper/wrapper.v', 'module wrapper
+
+$if !windows {
+	#insert "@DIR/api.h"
+	fn C.cached_comptime_value() int
+}
+
+pub fn value() int {
+	$if !windows {
+		return C.cached_comptime_value()
+	} $else {
+		return 0
+	}
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import wrapper
+
+fn main() {
+	println(wrapper.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	cache_header_path := module_cache_artifact(cache_dir, 'wrapper_', '.vh')
+	assert cache_header_path.len > 0
+	cache_header := os.read_file(cache_header_path) or { panic(err) }
+	assert cache_header.contains(os.real_path(header_path)), cache_header
+	assert !cache_header.contains('@DIR/api.h'), cache_header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+}
+
 fn test_cached_header_preserves_immutable_reference_receiver() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_reference_receiver_${os.getpid()}')

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -2168,6 +2168,58 @@ fn main() {
 	assert run_module_cache_binary(second_output) == '41'
 }
 
+fn test_cached_const_preserves_escaped_char_literals() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_escaped_chars_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'escaped/escaped.v', 'module escaped
+
+pub const chars = [`\\\\`, `\\n`, `\\t`, `*`]
+
+pub fn backslash() rune {
+	return chars[0]
+}
+
+pub fn newline() rune {
+	return chars[1]
+}
+
+pub fn tab() rune {
+	return chars[2]
+}
+
+pub fn star() rune {
+	return chars[3]
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import escaped
+
+fn main() {
+	println(int(escaped.backslash()))
+	println(int(escaped.newline()))
+	println(int(escaped.tab()))
+	println(int(escaped.star()))
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '92\n10\n9\n42'
+	first_hashes := module_cache_object_hashes(cache_dir)
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '92\n10\n9\n42'
+	assert changed_module_cache_objects(first_hashes, module_cache_object_hashes(cache_dir)).len == 0
+}
+
 fn test_cached_const_with_unsupported_initializer_is_embedded() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_const_index_${os.getpid()}')

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -763,6 +763,19 @@ fn test_module_cache_string_symbol_rewrite_handles_swapped_literals() {
 	assert rewritten.count(beta_definition) == 1
 }
 
+fn test_module_cache_string_symbol_rewrite_rejects_partially_changed_duplicates() {
+	x_symbol := module_cache_string_symbol('x')
+	x_definition := 'static string ${x_symbol} = {"x", 1, 1};'
+	source := '${x_definition}\n/* V3CACHE_BODY_BEGIN */\nconsume(${x_symbol});\nconsume(${x_symbol});\n'
+	if rewritten := modulecache.rewrite_cached_runtime_strings(source, ['x', 'x'], [
+		'y',
+		'x',
+	])
+	{
+		assert false, rewritten
+	}
+}
+
 fn test_module_cache_rebuilds_objects_when_c_flags_change() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_c_flags_${os.getpid()}')
@@ -3083,4 +3096,53 @@ fn test_incremental_program_cache_invalidates_for_top_level_statement_change() {
 	assert second.exit_code == 0, second.output
 	assert !second.output.contains('cgen (cached)'), second.output
 	assert run_module_cache_binary(second_output) == '2'
+}
+
+fn test_incremental_program_cache_invalidates_for_function_attribute_change() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_function_attribute_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+@[noreturn]
+fn stop() {
+	exit(0)
+}
+
+fn value() int {
+	stop()
+}
+
+fn main() {}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+fn stop() {
+	exit(0)
+}
+
+fn value() int {
+	stop()
+}
+
+fn main() {}
+')
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code != 0, second.output
+	assert second.output.contains('missing return'), second.output
+	assert !second.output.contains('check (incremental)'), second.output
 }

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4512,6 +4512,74 @@ fn main() {
 	assert run_module_cache_binary(changed_output) == '2'
 }
 
+fn test_cached_dev_dylib_invalidates_for_force_loaded_static_archive_change() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_dev_force_loaded_archive_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	library_dir := os.join_path(root, 'archive')
+	os.mkdir_all(library_dir) or { panic(err) }
+	library_source := os.join_path(library_dir, 'value.c')
+	library_object := os.join_path(library_dir, 'value.o')
+	library := os.join_path(library_dir, 'libforcecached.a')
+	write_module_cache_file(root, 'archive/value.c', 'int force_loaded_archive_value(void) {
+	return 3;
+}
+')
+	first_cc :=
+		os.execute('cc -c -o ${os.quoted_path(library_object)} ${os.quoted_path(library_source)}')
+	assert first_cc.exit_code == 0, first_cc.output
+	first_ar := os.execute('ar rcs ${os.quoted_path(library)} ${os.quoted_path(library_object)}')
+	assert first_ar.exit_code == 0, first_ar.output
+	write_module_cache_file(root, 'archive/archive.v', 'module archive
+
+#flag -Wl,-force_load,@DIR/libforcecached.a
+
+fn C.force_loaded_archive_value() int
+
+pub fn value() int {
+	return C.force_loaded_archive_value()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import archive
+
+fn main() {
+	println(archive.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '3'
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == '3'
+
+	write_module_cache_file(root, 'archive/value.c', 'int force_loaded_archive_value(void) {
+	return 4;
+}
+')
+	second_cc :=
+		os.execute('cc -c -o ${os.quoted_path(library_object)} ${os.quoted_path(library_source)}')
+	assert second_cc.exit_code == 0, second_cc.output
+	second_ar := os.execute('ar rcs ${os.quoted_path(library)} ${os.quoted_path(library_object)}')
+	assert second_ar.exit_code == 0, second_ar.output
+	changed_output := os.join_path(root, 'changed')
+	changed :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(changed_output)} ${os.quoted_path(main_file)}')
+	assert changed.exit_code == 0, changed.output
+	assert run_module_cache_binary(changed_output) == '4'
+}
+
 fn test_cached_dev_dylib_preserves_split_weak_library_flag() {
 	$if !macos {
 		return

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -3958,3 +3958,73 @@ fn main() {
 	assert !compile.output.contains('tcc.exe'), compile.output
 	assert run_module_cache_binary(output) == '73'
 }
+
+fn test_incremental_program_cache_synthesizes_new_sum_equality_helpers() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_sum_eq_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+type Value = int | string
+
+fn equal_values(left Value, right Value) bool {
+	_ = left
+	_ = right
+	return true
+}
+
+fn main() {
+	println(equal_values(Value(1), Value(1)))
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'true'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+type Value = int | string
+
+fn equal_values(left Value, right Value) bool {
+	_ = left
+	_ = right
+	return false
+}
+
+fn main() {
+	println(equal_values(Value(1), Value(1)))
+}
+')
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == 'false'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+type Value = int | string
+
+fn equal_values(left Value, right Value) bool {
+	return left == right
+}
+
+fn main() {
+	println(equal_values(Value(1), Value(1)))
+}
+')
+	incremental_output := os.join_path(root, 'incremental')
+	incremental :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(incremental_output)} ${os.quoted_path(main_file)}')
+	assert incremental.exit_code == 0, incremental.output
+	assert incremental.output.contains('transform (incremental)'), incremental.output
+	assert incremental.output.contains('cgen (incremental)'), incremental.output
+	assert run_module_cache_binary(incremental_output) == 'true'
+}

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4385,6 +4385,61 @@ fn main() {
 	assert run_module_cache_binary(changed_output) == '2'
 }
 
+fn test_cached_dev_dylib_preserves_split_weak_library_flag() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_dev_weak_library_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'v.mod', "Module { name: 'cached_dev_weak_library' }\n")
+	write_module_cache_file(root, 'optional.c', 'int cached_weak_library_value(void) {
+	return 42;
+}
+')
+	library := os.join_path(root, 'liboptional.dylib')
+	build_library := os.execute('cc -dynamiclib -o ${os.quoted_path(library)} ${os.quoted_path(os.join_path(root,
+		'optional.c'))}')
+	assert build_library.exit_code == 0, build_library.output
+	write_module_cache_file(root, 'optional/optional.v', 'module optional
+
+#flag -weak_library @VMODROOT/liboptional.dylib
+
+fn C.cached_weak_library_value() int
+
+pub fn value() int {
+	return C.cached_weak_library_value()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import optional
+
+fn main() {
+	println(optional.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	output := os.join_path(root, 'output')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
+	assert run_module_cache_binary(output) == '42'
+	mut cached_dylibs :=
+		os.walk_ext(cache_dir, '.dylib').filter(os.file_name(it).starts_with('dev_modules_'))
+	assert cached_dylibs.len == 1, cached_dylibs.str()
+	inspection := os.execute('otool -l ${os.quoted_path(cached_dylibs[0])}')
+	assert inspection.exit_code == 0, inspection.output
+	assert inspection.output.contains('cmd LC_LOAD_WEAK_DYLIB'), inspection.output
+	assert inspection.output.contains(library), inspection.output
+	warm_output := os.join_path(root, 'warm')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, warm_output)
+	assert run_module_cache_binary(warm_output) == '42'
+}
+
 fn test_incremental_cgen_preserves_interface_type_ids() {
 	$if !macos {
 		return

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -2647,3 +2647,111 @@ fn main() {
 	assert cached.output.contains('cgen (cached)'), cached.output
 	assert run_module_cache_binary(cached_output) == '1\n2\ntrue\nfalse\nfalse\ntrue'
 }
+
+fn test_incremental_program_cache_recompiles_real_main_logic() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_program_logic_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', "module main
+
+import os
+
+fn identity[T](value T) T {
+\treturn value
+}
+
+fn message(value string) string {
+\treturn identity(value)
+}
+
+fn main() {
+\tprintln(message('before'))
+}
+")
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'before'
+
+	write_module_cache_file(root, 'main.v', "module main
+
+import os
+
+fn identity[T](value T) T {
+\treturn value
+}
+
+fn message(value string) string {
+\treturn identity(value)
+}
+
+fn main() {
+\tprintln(message('baseline'))
+}
+")
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == 'baseline'
+
+	write_module_cache_file(root, 'main.v', "module main
+
+import os
+
+fn identity[T](value T) T {
+\treturn value
+}
+
+fn message(value string) string {
+\treturn identity(value)
+}
+
+fn main() {
+\targ_count := os.args.len
+\t$if macos {
+\t\t_ = arg_count
+\t}
+\tprintln(message('snapshot logic'))
+}
+")
+	snapshot_output := os.join_path(root, 'snapshot')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, snapshot_output)
+	assert run_module_cache_binary(snapshot_output) == 'snapshot logic'
+
+	write_module_cache_file(root, 'main.v', "module main
+
+import os
+
+fn identity[T](value T) T {
+\treturn value
+}
+
+fn message(value string) string {
+\treturn identity(value)
+}
+
+fn main() {
+\targ_count := os.args.len
+\t$if macos {
+\t\t_ = arg_count
+\t}
+\tif arg_count > 0 {
+\t\tprintln(message('after real logic'))
+\t}
+}
+")
+	incremental_output := os.join_path(root, 'incremental')
+	incremental :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(incremental_output)} ${os.quoted_path(main_file)}')
+	assert incremental.exit_code == 0, incremental.output
+	assert incremental.output.contains('check (incremental)'), incremental.output
+	assert incremental.output.contains('cgen (incremental)'), incremental.output
+	assert run_module_cache_binary(incremental_output) == 'after real logic'
+}

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -413,12 +413,60 @@ __attribute__((visibility("default"))) int cached_attributed(void)
 {
 	return 42;
 }
+int cached_apply(int (*cb)(int), int value)
+{
+	return cb(value);
+}
 /* V3CACHE_NATIVE_DIRECTIVES_END */
 '
 	header := modulecache.declaration_header(prefix)
 	assert header.contains('static int cached_readback(int value)\n{'), header
 	assert header.contains('static int cached_sum(\n\tint left,\n\tint right\n)\n{'), header
 	assert header.contains('static __attribute__((visibility("default"))) int cached_attributed(void)\n{'), header
+	assert header.contains('static int cached_apply(int (*cb)(int), int value)\n{'), header
+}
+
+fn test_cached_native_callback_definition_is_localized() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_native_callback_definition_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'wrapper/wrapper.v', 'module wrapper
+
+#insert "@DIR/api.h"
+
+pub fn value() int {
+	return 42
+}
+')
+	write_module_cache_file(root, 'wrapper/api.h', 'int cached_apply(int (*cb)(int), int value) {
+	return cb(value);
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import wrapper
+
+fn main() {
+	println(wrapper.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	header_path := module_cache_artifact(cache_dir, 'wrapper_', '.vh')
+	assert header_path.len > 0
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains(os.real_path(os.join_path(root, 'wrapper/api.h'))), header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
 }
 
 fn test_module_cache_declaration_header_keeps_column_zero_inner_block_closes() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -114,7 +114,10 @@ fn test_cached_object_accepts_recorded_dependency_superset() {
 fn module_cache_object_hashes(cache_dir string) map[string]u64 {
 	mut hashes := map[string]u64{}
 	for path in os.walk_ext(cache_dir, '.o') {
-		hashes[os.file_name(path)] = module_cache_object_hash(path)
+		name := os.file_name(path)
+		if !name.starts_with('program_prefix_') {
+			hashes[name] = module_cache_object_hash(path)
+		}
 	}
 	return hashes
 }
@@ -1295,10 +1298,20 @@ fn main() {
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
 	assert result.exit_code == 0, result.output
 	assert run_module_cache_binary(second_output) == '77'
-	link_lines := result.output.split_into_lines().filter(it.contains('> cc '))
+	mut link_lines := []string{}
+	$if macos {
+		link_lines = result.output.split_into_lines().filter(it.contains('tcc.exe'))
+	} $else {
+		link_lines = result.output.split_into_lines().filter(it.contains('> cc '))
+	}
 	assert link_lines.len > 0, result.output
 	link_line := link_lines.last()
-	object_pos := link_line.index(cache_dir) or { -1 }
+	mut object_pos := -1
+	$if macos {
+		object_pos = link_line.index('.dylib') or { -1 }
+	} $else {
+		object_pos = link_line.index(cache_dir) or { -1 }
+	}
 	library_pos := link_line.index('-lcacheorder') or { -1 }
 	assert object_pos >= 0, link_line
 	assert library_pos >= 0, link_line

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -195,6 +195,9 @@ fn main() {
 	assert second.output.contains('C module plan (cached)'), second.output
 	assert second.output.contains('cgen (cached)'), second.output
 	assert second.output.contains('monomorphize (cached)'), second.output
+	$if macos {
+		assert second.output.contains('cc (cached)'), second.output
+	}
 	assert run_module_cache_binary(second_output) == '42'
 
 	write_module_cache_file(root, 'main.v', 'module main

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4180,6 +4180,49 @@ fn main() {
 	assert run_module_cache_binary(second_output) == '79'
 }
 
+fn test_cached_dev_tcc_links_forced_c_source_operands() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_dev_forced_c_source_link_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'v.mod', "Module { name: 'cached_dev_forced_c_source_link' }\n")
+	write_module_cache_file(root, 'helper', 'int v3_cached_dev_forced_c_source_value(void) {
+	return 83;
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+#flag -x c @VMODROOT/helper -x none
+
+fn C.v3_cached_dev_forced_c_source_value() int
+
+fn main() {
+	println(C.v3_cached_dev_forced_c_source_value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	first :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(first_output)} ${os.quoted_path(main_file)}')
+	assert first.exit_code == 0, first.output
+	assert first.output.contains('tcc.exe'), first.output
+	assert run_module_cache_binary(first_output) == '83'
+
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert second.output.contains('tcc.exe'), second.output
+	assert run_module_cache_binary(second_output) == '83'
+}
+
 fn test_incremental_program_cache_synthesizes_new_sum_equality_helpers() {
 	$if !macos {
 		return

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -3116,6 +3116,101 @@ fn main() {
 	assert run_module_cache_binary(strict_output) == '43'
 }
 
+fn test_incremental_program_cache_emits_new_body_support_typedefs() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_body_support_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+fn add_one(value int) int {
+	return value + 1
+}
+
+fn calculated_value() int {
+	return add_one(0)
+}
+
+fn main() {
+	println(calculated_value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '1'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+fn add_one(value int) int {
+	return value + 1
+}
+
+fn calculated_value() int {
+	return add_one(1)
+}
+
+fn main() {
+	println(calculated_value())
+}
+')
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == '2'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+fn add_one(value int) int {
+	return value + 1
+}
+
+fn calculated_value() int {
+	values := [2]int{init: 40}
+	return add_one(values[0] + 1)
+}
+
+fn main() {
+	println(calculated_value())
+}
+')
+	fixed_array_output := os.join_path(root, 'fixed_array')
+	fixed_array :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(fixed_array_output)} ${os.quoted_path(main_file)}')
+	assert fixed_array.exit_code == 0, fixed_array.output
+	assert fixed_array.output.contains('cgen (incremental)'), fixed_array.output
+	assert run_module_cache_binary(fixed_array_output) == '42'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+fn add_one(value int) int {
+	return value + 1
+}
+
+fn calculated_value() int {
+	values := [2]int{init: 41}
+	callback := add_one
+	return callback(values[0])
+}
+
+fn main() {
+	println(calculated_value())
+}
+')
+	fn_pointer_output := os.join_path(root, 'fn_pointer')
+	fn_pointer :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(fn_pointer_output)} ${os.quoted_path(main_file)}')
+	assert fn_pointer.exit_code == 0, fn_pointer.output
+	assert fn_pointer.output.contains('cgen (incremental)'), fn_pointer.output
+	assert run_module_cache_binary(fn_pointer_output) == '42'
+}
+
 fn test_incremental_program_cache_falls_back_for_new_generic_type_argument() {
 	$if !macos {
 		return
@@ -3259,6 +3354,38 @@ fn test_incremental_program_cache_invalidates_for_top_level_statement_change() {
 	assert second.exit_code == 0, second.output
 	assert !second.output.contains('cgen (cached)'), second.output
 	assert run_module_cache_binary(second_output) == '2'
+}
+
+fn test_incremental_program_cache_preserves_top_level_statement_order() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_top_level_order_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', "println('cold first')\nprintln('cold second')\n")
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'cold first\ncold second'
+
+	write_module_cache_file(root, 'main.v', "println('first')\nprintln('second')\n")
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == 'first\nsecond'
+
+	write_module_cache_file(root, 'main.v', "println('second')\nprintln('first')\n")
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == 'second\nfirst'
 }
 
 fn test_incremental_program_cache_invalidates_for_function_attribute_change() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4146,3 +4146,291 @@ fn main() {
 	assert changed.exit_code == 0, changed.output
 	assert run_module_cache_binary(changed_output) == '2'
 }
+
+fn test_incremental_cgen_preserves_interface_type_ids() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_interface_ids_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+interface Speaker {
+	speak() string
+}
+
+struct Cat {}
+
+fn (cat Cat) speak() string {
+	_ = cat
+	return "cat"
+}
+
+struct Dog {}
+
+fn (dog Dog) speak() string {
+	_ = dog
+	return "dog"
+}
+
+fn dog_speaker() Speaker {
+	return Dog{}
+}
+
+fn cached_dispatch() string {
+	return dog_speaker().speak() + Cat{}.speak()
+}
+
+fn selected_speaker() Speaker {
+	speaker := dog_speaker()
+	return speaker
+}
+
+fn main() {
+	println(cached_dispatch())
+	println(selected_speaker().speak())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'dogcat\ndog'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+interface Speaker {
+	speak() string
+}
+
+struct Cat {}
+
+fn (cat Cat) speak() string {
+	_ = cat
+	return "cat"
+}
+
+struct Dog {}
+
+fn (dog Dog) speak() string {
+	_ = dog
+	return "dog"
+}
+
+fn dog_speaker() Speaker {
+	return Dog{}
+}
+
+fn cached_dispatch() string {
+	return dog_speaker().speak() + Cat{}.speak()
+}
+
+fn selected_speaker() Speaker {
+	return dog_speaker()
+}
+
+fn main() {
+	println(cached_dispatch())
+	println(selected_speaker().speak())
+}
+')
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == 'dogcat\ndog'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+interface Speaker {
+	speak() string
+}
+
+struct Cat {}
+
+fn (cat Cat) speak() string {
+	_ = cat
+	return "cat"
+}
+
+struct Dog {}
+
+fn (dog Dog) speak() string {
+	_ = dog
+	return "dog"
+}
+
+fn dog_speaker() Speaker {
+	return Dog{}
+}
+
+fn cached_dispatch() string {
+	return dog_speaker().speak() + Cat{}.speak()
+}
+
+fn selected_speaker() Speaker {
+	return Cat{}
+}
+
+fn main() {
+	println(cached_dispatch())
+	println(selected_speaker().speak())
+}
+')
+	incremental_output := os.join_path(root, 'incremental')
+	incremental :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(incremental_output)} ${os.quoted_path(main_file)}')
+	assert incremental.exit_code == 0, incremental.output
+	assert incremental.output.contains('cgen (incremental)'), incremental.output
+	assert run_module_cache_binary(incremental_output) == 'dogcat\ncat'
+}
+
+fn test_incremental_program_cache_preserves_import_order() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_import_order_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'initfirst/initfirst.v', 'module initfirst
+
+fn init() {
+	println("first")
+}
+
+pub fn marker() {}
+')
+	write_module_cache_file(root, 'initsecond/initsecond.v', 'module initsecond
+
+fn init() {
+	println("second")
+}
+
+pub fn marker() {}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import initfirst
+import initsecond
+
+fn main() {
+	initfirst.marker()
+	initsecond.marker()
+	println("cold")
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'first\nsecond\ncold'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+import initfirst
+import initsecond
+
+fn main() {
+	initfirst.marker()
+	initsecond.marker()
+	println("done")
+}
+')
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == 'first\nsecond\ndone'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+import initsecond
+import initfirst
+
+fn main() {
+	initfirst.marker()
+	initsecond.marker()
+	println("done")
+}
+')
+	reordered_output := os.join_path(root, 'reordered')
+	reordered :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(reordered_output)} ${os.quoted_path(main_file)}')
+	assert reordered.exit_code == 0, reordered.output
+	assert run_module_cache_binary(reordered_output) == 'second\nfirst\ndone'
+}
+
+fn test_incremental_program_cache_preserves_directive_order() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_directive_order_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+#define V3_INCREMENTAL_ORDER_VALUE 1
+#undef V3_INCREMENTAL_ORDER_VALUE
+#define V3_INCREMENTAL_ORDER_VALUE 2
+
+fn incremental_directive_value() int {
+	return C.V3_INCREMENTAL_ORDER_VALUE
+}
+
+fn main() {
+	println(incremental_directive_value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '2'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+#define V3_INCREMENTAL_ORDER_VALUE 1
+#undef V3_INCREMENTAL_ORDER_VALUE
+#define V3_INCREMENTAL_ORDER_VALUE 2
+
+fn incremental_directive_value() int {
+	return C.V3_INCREMENTAL_ORDER_VALUE
+}
+
+fn main() {
+	println(incremental_directive_value() + 0)
+}
+')
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == '2'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+#define V3_INCREMENTAL_ORDER_VALUE 2
+#undef V3_INCREMENTAL_ORDER_VALUE
+#define V3_INCREMENTAL_ORDER_VALUE 1
+
+fn incremental_directive_value() int {
+	return C.V3_INCREMENTAL_ORDER_VALUE
+}
+
+fn main() {
+	println(incremental_directive_value() + 0)
+}
+')
+	reordered_output := os.join_path(root, 'reordered')
+	reordered :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(reordered_output)} ${os.quoted_path(main_file)}')
+	assert reordered.exit_code == 0, reordered.output
+	assert run_module_cache_binary(reordered_output) == '1'
+}

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -163,8 +163,12 @@ pub fn value() int {
 
 import cached
 
+fn identity[T](value T) T {
+	return value
+}
+
 fn main() {
-	println(cached.value() + 2)
+	println(identity(cached.value() + 2))
 }
 ')
 	cache_dir := os.join_path(root, 'cache')
@@ -173,6 +177,7 @@ fn main() {
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(first_output)} ${os.quoted_path(main_file)}')
 	assert first.exit_code == 0, first.output
 	assert !first.output.contains('cgen (cached)'), first.output
+	assert !first.output.contains('monomorphize (cached)'), first.output
 	assert run_module_cache_binary(first_output) == '42'
 
 	second_output := os.join_path(root, 'second')
@@ -180,14 +185,19 @@ fn main() {
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
 	assert second.exit_code == 0, second.output
 	assert second.output.contains('cgen (cached)'), second.output
+	assert second.output.contains('monomorphize (cached)'), second.output
 	assert run_module_cache_binary(second_output) == '42'
 
 	write_module_cache_file(root, 'main.v', 'module main
 
 import cached
 
+fn identity[T](value T) T {
+	return value
+}
+
 fn main() {
-	println(cached.value() + 3)
+	println(identity(cached.value() + 3))
 }
 ')
 	changed_output := os.join_path(root, 'changed')
@@ -195,6 +205,7 @@ fn main() {
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(changed_output)} ${os.quoted_path(main_file)}')
 	assert changed.exit_code == 0, changed.output
 	assert !changed.output.contains('cgen (cached)'), changed.output
+	assert !changed.output.contains('monomorphize (cached)'), changed.output
 	assert run_module_cache_binary(changed_output) == '43'
 
 	write_module_cache_file(root, 'cached/cached.v', 'module cached
@@ -208,6 +219,7 @@ pub fn value() int {
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(changed_module_output)} ${os.quoted_path(main_file)}')
 	assert changed_module.exit_code == 0, changed_module.output
 	assert !changed_module.output.contains('cgen (cached)'), changed_module.output
+	assert !changed_module.output.contains('monomorphize (cached)'), changed_module.output
 	assert run_module_cache_binary(changed_module_output) == '44'
 }
 
@@ -2587,4 +2599,11 @@ fn main() {
 	output := os.join_path(root, 'out')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
 	assert run_module_cache_binary(output) == '1\n2\ntrue\nfalse\nfalse\ntrue'
+	cached_output := os.join_path(root, 'cached_out')
+	cached :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(cached_output)} ${os.quoted_path(main_file)}')
+	assert cached.exit_code == 0, cached.output
+	assert cached.output.contains('monomorphize (cached)'), cached.output
+	assert cached.output.contains('cgen (cached)'), cached.output
+	assert run_module_cache_binary(cached_output) == '1\n2\ntrue\nfalse\nfalse\ntrue'
 }

--- a/vlib/v3/tests/option_arg_codegen_test.v
+++ b/vlib/v3/tests/option_arg_codegen_test.v
@@ -64,6 +64,40 @@ fn main() {
 	assert c_code.contains('take((Optional_i64){.ok = true, .value = 1})'), c_code
 }
 
+fn test_optional_params_field_inside_result_function_keeps_field_wrapper() {
+	v3_bin := build_v3()
+	source := 'enum Filter {
+	linear
+}
+
+@[params]
+struct Config {
+	filter ?Filter
+}
+
+struct Image {}
+
+fn create(cfg Config) !Image {
+	filter := cfg.filter or { return error("missing filter") }
+	if filter != .linear {
+		return error("wrong filter")
+	}
+	return Image{}
+}
+
+fn wrapper(filter Filter) !Image {
+	return create(filter: filter)!
+}
+
+fn main() {
+	_ := wrapper(.linear) or { panic(err) }
+	println("ok")
+}
+'
+	out := run_good(v3_bin, 'optional_params_field_result_wrapper', source)
+	assert out == 'ok'
+}
+
 fn test_error_call_argument_expected_ierror_not_result_wrapper() {
 	v3_bin := build_v3()
 	source := "fn wrap(err IError) string {\n\treturn err.msg()\n}\n\nfn f() !string {\n\treturn wrap(error('x'))\n}\n\nfn main() {\n\ts := f() or { '' }\n\tassert s == 'x'\n\tprintln('ok')\n}\n"

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -27,6 +27,16 @@ fn build_parallel_prod_v3() string {
 	return v3_bin
 }
 
+fn build_parallel_prealloc_prod_v3() string {
+	vexe := @VEXE
+	v3_bin := os.join_path(os.temp_dir(), 'v3_parallel_prealloc_prod_cgen_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${vexe} -gc none -prod -prealloc -d parallel -path "${parallel_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${parallel_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
 // write_parallel_module_init_project writes parallel module init project output for v3 tests.
 fn write_parallel_module_init_project(name string) string {
 	project_dir := os.join_path(os.temp_dir(), 'v3_${name}')
@@ -347,6 +357,16 @@ fn test_parallel_transform_lowers_top_level_stmts_without_main_once() {
 	assert run.output.trim_space() == '51047'
 	c_code := os.read_file(bin_out + '.c') or { panic(err) }
 	assert c_code.all_after('int main').count('map__get_check') == 1, c_code
+}
+
+fn test_prealloc_keeps_parallel_transform_enabled() {
+	v3_bin := build_parallel_prealloc_prod_v3()
+	main_path :=
+		write_parallel_top_level_no_main_project('parallel_prealloc_transform_${os.getpid()}')
+	c_out := os.join_path(os.temp_dir(), 'v3_parallel_prealloc_transform_${os.getpid()}.c')
+	compile := os.execute('VJOBS=2 ${v3_bin} -nocache -b c -o ${c_out} ${main_path}')
+	assert compile.exit_code == 0, compile.output
+	assert compile.output.contains('transform (parallel)'), compile.output
 }
 
 fn test_parallel_transform_selfhost_builds_v3() {

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -361,12 +361,12 @@ fn test_parallel_transform_lowers_top_level_stmts_without_main_once() {
 
 fn test_prealloc_keeps_parallel_transform_enabled() {
 	v3_bin := build_parallel_prealloc_prod_v3()
-	main_path :=
-		write_parallel_top_level_no_main_project('parallel_prealloc_transform_${os.getpid()}')
+	main_path := write_parallel_module_init_project('parallel_prealloc_cgen_${os.getpid()}')
 	c_out := os.join_path(os.temp_dir(), 'v3_parallel_prealloc_transform_${os.getpid()}.c')
 	compile := os.execute('VJOBS=2 ${v3_bin} -nocache -b c -o ${c_out} ${main_path}')
 	assert compile.exit_code == 0, compile.output
 	assert compile.output.contains('transform (parallel)'), compile.output
+	assert compile.output.contains('cgen (parallel)'), compile.output
 }
 
 fn test_parallel_transform_selfhost_builds_v3() {

--- a/vlib/v3/tests/parallel_parser_test.v
+++ b/vlib/v3/tests/parallel_parser_test.v
@@ -46,6 +46,9 @@ fn test_parallel_parse_matches_serial() {
 	}
 	assert parallel_starts == serial_starts
 	assert pp.parsed_v_files == ps.parsed_v_files
+	assert pp.parsed_v_file_paths == ps.parsed_v_file_paths
+	assert pp.parsed_v_header_files == ps.parsed_v_header_files
+	assert pp.parsed_v_header_file_paths == ps.parsed_v_header_file_paths
 	assert pp.a.nodes.len == ps.a.nodes.len
 	assert pp.a.children.len == ps.a.children.len
 	for i in 0 .. ps.a.children.len {
@@ -74,6 +77,21 @@ fn test_parallel_parse_matches_serial() {
 	for qname, value in ps.a.export_fn_names {
 		assert pp.a.export_fn_names[qname] == value
 	}
+}
+
+fn test_parser_counts_v_header_files() {
+	path := os.join_path(os.temp_dir(), 'v3_parser_header_count_${os.getpid()}.vh')
+	os.write_file(path, 'module sample\n\npub fn value() int\n') or { panic(err) }
+	defer {
+		os.rm(path) or {}
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	p.parse_file(path)
+	assert p.parsed_v_files == 0
+	assert p.parsed_v_file_paths.len == 0
+	assert p.parsed_v_header_files == 1
+	assert p.parsed_v_header_file_paths == [path]
 }
 
 // test_parallel_parse_falls_back_when_workers_cannot_start ensures every helper

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -8,7 +8,8 @@ const v3_src = os.join_path(v3_dir, 'v3.v')
 
 fn build_v3_review_checker() string {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_review_checker_regressions_test')
-	build := os.execute('${vexe} -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	build :=
+		os.execute('${vexe} -gc none -prealloc -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0, build.output
 	return v3_bin
 }
@@ -249,6 +250,15 @@ fn test_shared_receiver_and_arg_require_shared_bindings() {
 	mut_pointer_out := run_good(v3_bin, 'good_mut_receiver_mutable_pointer_binding',
 		'struct St {\nmut:\n\tvalue int\n}\n\nfn (mut s St) bump() {\n\ts.value++\n}\n\nfn main() {\n\tmut s := St{}\n\tmut p := &s\n\tp.bump()\n\tprintln(int_str(s.value))\n}\n')
 	assert mut_pointer_out == '1'
+	global_pointer_out := run_good(v3_bin, 'good_mut_receiver_global_pointer',
+		'struct St {\nmut:\n\tvalue int\n}\n\nfn (mut s St) bump() {\n\ts.value++\n}\n\n__global global_st = &St{}\n\nfn main() {\n\tglobal_st.bump()\n\tprintln(int_str(global_st.value))\n}\n')
+	assert global_pointer_out == '1'
+	field_pointer_out := run_good(v3_bin, 'good_mut_receiver_pointer_field',
+		'struct St {\nmut:\n\tvalue int\n}\n\nstruct Holder {\n\tst &St\n}\n\nfn (mut s St) bump() {\n\ts.value++\n}\n\nfn main() {\n\tmut s := St{}\n\tholder := Holder{\n\t\tst: &s\n\t}\n\tholder.st.bump()\n\tprintln(int_str(s.value))\n}\n')
+	assert field_pointer_out == '1'
+	if_guard_out := run_good(v3_bin, 'good_mut_receiver_if_guard_binding',
+		'struct St {\nmut:\n\tvalue int\n}\n\nfn (mut s St) bump() {\n\ts.value++\n}\n\nfn get() ?St {\n\treturn St{}\n}\n\nfn main() {\n\tif mut s := get() {\n\t\ts.bump()\n\t\tprintln(int_str(s.value))\n\t}\n}\n')
+	assert if_guard_out == '1'
 	capture_out := run_good(v3_bin, 'good_mut_receiver_explicit_mut_capture',
 		'struct St {\nmut:\n\tvalue int\n}\n\nfn (mut s St) bump() {\n\ts.value++\n}\n\nfn main() {\n\tmut s := St{}\n\tfn [mut s] () {\n\t\ts.bump()\n\t\tprintln(int_str(s.value))\n\t}()\n}\n')
 	assert capture_out == '1'
@@ -507,4 +517,11 @@ fn test_match_const_int_does_not_narrow_subject_type() {
 	out := run_good(v3_bin, 'match_const_int_no_subject_narrow',
 		'const size_224 = 28\n\nstruct E {\n\tsize int\n}\n\nfn check(hash_size int) !E {\n\tmatch hash_size {\n\t\tsize_224 {\n\t\t\treturn E{\n\t\t\t\tsize: hash_size\n\t\t\t}\n\t\t}\n\t\telse {}\n\t}\n\treturn E{\n\t\tsize: 0\n\t}\n}\n\nfn main() {\n\tprintln(int_str(check(28)!.size))\n}\n')
 	assert out == '28'
+}
+
+fn test_builtin_function_callee_wins_over_unrelated_const_suffix() {
+	v3_bin := build_v3_review_checker()
+	out := run_good(v3_bin, 'builtin_fn_unrelated_const_suffix',
+		'import math\nfn main() {\n\t_ = math.pi\n\tprintln(f32(1).eq_epsilon(f32(1)))\n}\n')
+	assert out == 'true'
 }

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -23,7 +23,7 @@ fn build_v3_review_transform() string {
 		return v3_bin
 	}
 	build :=
-		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+		os.execute('${vexe} -prealloc -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0, build.output
 	return v3_bin
 }
@@ -64,6 +64,173 @@ fn run_good_with_env(v3_bin string, name string, env string, src string) string 
 	run := os.execute(good_bin)
 	assert run.exit_code == 0, '${name}: run failed\n${run.output}'
 	return run.output.trim_space()
+}
+
+fn test_recursive_interface_equality_stops_expanding_seen_interfaces() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'recursive_interface_equality', 'interface Value {}
+
+struct Box {
+	values []Value
+}
+
+fn main() {
+	left := Value(Box{})
+	right := Value(Box{})
+	println(left == right)
+}
+')
+	assert out == 'true'
+}
+
+fn test_map_interface_equality_keeps_typed_map_get() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'map_interface_equality_typed_get', 'interface Value {
+	n int
+}
+
+struct Item {
+	n int
+}
+
+fn main() {
+	left := {
+		"item": Value(Item{
+			n: 7
+		})
+	}
+	right := {
+		"item": Value(Item{
+			n: 7
+		})
+	}
+	println(left == right)
+}
+')
+	assert out == 'true'
+}
+
+fn test_pointer_interface_field_as_interface_uses_storage_type() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'pointer_interface_field_as_interface_storage', 'interface Layout {
+	size() int
+}
+
+interface Widget {
+	size() int
+	draw()
+}
+
+interface Application {
+	layout &Layout
+}
+
+struct Item {}
+
+fn (_ Item) size() int {
+	return 7
+}
+
+fn (_ Item) draw() {}
+
+struct App {
+	layout &Layout
+}
+
+fn application_widget(app Application) Widget {
+	if app.layout is Widget {
+		widget := app.layout as Widget
+		return widget
+	}
+	return Widget(Item{})
+}
+
+fn main() {
+	layout := Layout(Item{})
+	app := Application(App{
+		layout: &layout
+	})
+	println(application_widget(app).size())
+}
+')
+	assert out == '7'
+}
+
+fn test_interface_dispatch_reboxes_result_pointer_payload() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'interface_dispatch_result_pointer_payload', 'interface Connection {
+	close() !
+}
+
+struct TcpConn {}
+
+fn (_ &TcpConn) close() ! {}
+
+interface Dialer {
+	dial(string) !Connection
+}
+
+struct Proxy {}
+
+fn (_ &Proxy) dial(_ string) !&TcpConn {
+	return &TcpConn{}
+}
+
+fn main() {
+	dialer := Dialer(&Proxy{})
+	connection := dialer.dial("") or { panic(err) }
+	connection.close() or { panic(err) }
+	println("ok")
+}
+')
+	assert out == 'ok'
+}
+
+fn test_generic_shared_parameter_value_copy_uses_inner_type() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'generic_shared_parameter_value_copy', 'struct State {
+	label string
+}
+
+fn destroy(shared state State) {
+	drop_owned(state)
+}
+
+fn main() {
+	shared state := State{
+		label: "ok"
+	}
+	destroy(state)
+	println("done")
+}
+')
+	assert out == 'done'
+}
+
+fn test_c_pointer_zero_argument_stays_null() {
+	v3_bin := build_v3_review_transform()
+	generated := gen_c_from_source(v3_bin, 'c_pointer_zero_argument', 'fn C.wait(&int) int
+
+fn call_wait() int {
+	return C.wait(0)
+}
+
+fn main() {
+	_ = call_wait()
+}
+')
+	assert generated.contains('return wait(0);'), generated
+	assert !generated.contains('wait(&0)'), generated
+}
+
+fn test_system_libc_mode_preserves_ptrace_header() {
+	v3_bin := build_v3_review_transform()
+	generated := gen_c_from_source(v3_bin, 'system_libc_ptrace_header', '#include <math.h>
+#include <sys/ptrace.h>
+
+fn main() {}
+')
+	assert generated.contains('#include <sys/ptrace.h>'), generated
 }
 
 fn gen_c_from_source(v3_bin string, name string, src string) string {
@@ -1532,6 +1699,17 @@ fn test_comptime_field_generic_calls_keep_resolved_field_types() {
 		'main.v':        'module main\n\nimport codec\nimport model\n\nfn main() {\n\tmut event := model.Event{}\n\tcodec.visit(mut event)\n\tprintln(int_str(int(event.key)))\n}\n'
 	}, 'main.v')
 	assert out == '0'
+}
+
+fn test_comptime_pointer_field_generic_local_uses_call_return_type() {
+	v3_bin := build_v3_review_transform()
+	out := run_good_project(v3_bin, 'comptime_pointer_field_call_return_type', {
+		'v.mod':         "Module { name: 'comptime_pointer_field_call_return_type' }\n"
+		'model/model.v': 'module model\n\npub struct App {\npub mut:\n\tvalue int\n}\n\npub struct Context {\npub mut:\n\tapp &App\n}\n'
+		'codec/codec.v': 'module codec\n\npub fn fill[T](mut value T) {\n\t$for field in T.fields {\n\t\t$if field.indirections == 1 {\n\t\t\tmut decoded_ptr := create_ptr(value.$(field.name))\n\t\t\tdecoded_ptr.value = 42\n\t\t\tvalue.$(field.name) = decoded_ptr\n\t\t}\n\t}\n}\n\nfn create_ptr[T](_ &T) &T {\n\treturn &T{}\n}\n'
+		'main.v':        'module main\n\nimport codec\nimport model\n\nfn main() {\n\tmut context := model.Context{}\n\tcodec.fill(mut context)\n\tprintln(context.app.value)\n}\n'
+	}, 'main.v')
+	assert out == '42'
 }
 
 fn test_imported_struct_default_qualifies_function_alias_cast() {

--- a/vlib/v3/tests/secure_command_test.v
+++ b/vlib/v3/tests/secure_command_test.v
@@ -164,6 +164,14 @@ fn main() { println(int_str(C.cached_value())) }
 	assert third.exit_code == 0, third.output
 	assert cmdexec.run(third_out, []string{}).output.trim_space() == '9'
 
+	warm_out := os.join_path(root, 'warm')
+	warm := cmdexec.run(v3_bin, [v_source, '-prod', '-o', warm_out])
+	assert warm.exit_code == 0, warm.output
+	stage_lines := warm.output.split_into_lines().filter(it.starts_with('  C object cache'))
+	assert stage_lines.len == 1, warm.output
+	scan_lines := warm.output.split_into_lines().filter(it.contains('C object dependency scans'))
+	assert scan_lines.len == 1 && scan_lines[0].contains('0 objects'), warm.output
+
 	os.setenv('V3_CACHE_TRACE', '1', true)
 	defer {
 		os.unsetenv('V3_CACHE_TRACE')
@@ -173,6 +181,7 @@ fn main() { println(int_str(C.cached_value())) }
 	assert fourth.exit_code == 0, fourth.output
 	assert fourth.output.contains('C object cache hit: key='), fourth.output
 	assert fourth.output.contains('reason=compiler, target, argv, and dependency contents matched'), fourth.output
+	assert fourth.output.contains('matched via manifest'), fourth.output
 
 	assert fourth.output.contains('dependencies=2'), fourth.output
 	assert fourth.output.contains('C object content-key hits'), fourth.output

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -130,7 +130,8 @@ fn (t &Transformer) comptime_for_base_type(raw string) string {
 	} else {
 		raw
 	}
-	return t.comptime_normalize_type_alias_chain(t.comptime_resolve_selective_import_type(source))
+	base := t.comptime_for_value_type_base(source)
+	return t.comptime_normalize_type_alias_chain(t.comptime_resolve_selective_import_type(base))
 }
 
 fn (t &Transformer) comptime_for_value_source_type(raw string) ?string {
@@ -177,11 +178,16 @@ fn (t &Transformer) comptime_for_field_source_type(owner_type string, field_name
 
 fn (t &Transformer) comptime_for_value_type_base(raw string) string {
 	mut typ := raw.trim_space()
-	if typ.starts_with('mut ') {
-		typ = typ[4..].trim_space()
-	}
-	for typ.starts_with('&') {
-		typ = typ[1..].trim_space()
+	for {
+		if typ.starts_with('mut ') {
+			typ = typ[4..].trim_space()
+		} else if typ.starts_with('shared ') || typ.starts_with('atomic ') {
+			typ = typ[7..].trim_space()
+		} else if typ.starts_with('&') {
+			typ = typ[1..].trim_space()
+		} else {
+			break
+		}
 	}
 	return typ
 }

--- a/vlib/v3/transform/comptime_test.v
+++ b/vlib/v3/transform/comptime_test.v
@@ -13,6 +13,15 @@ fn test_comptime_field_function_type_keeps_declaring_module() {
 	assert t.comptime_field_type_id_key('Container[T]', 'eventbus') == 'eventbus.Container[T]'
 }
 
+fn test_comptime_for_base_type_unwraps_storage_indirections() {
+	mut a := flat.FlatAst.new()
+	t := Transformer{
+		a: &a
+	}
+	assert t.comptime_for_base_type('&websocket.Server') == 'websocket.Server'
+	assert t.comptime_for_base_type('shared websocket.ClientState') == 'websocket.ClientState'
+}
+
 fn test_comptime_condition_distinguishes_pointer_depth_from_logical_and() {
 	mut a := flat.FlatAst.new()
 	mut t := Transformer{

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2724,6 +2724,12 @@ fn (mut t Transformer) make_interface_semantic_eq_expr(lhs flat.NodeId, rhs flat
 	if iface.len == 0 || isnil(t.tc) {
 		return t.make_memcmp_eq_expr(lhs, rhs, interface_type, 'iface_eq')
 	}
+	seen_key := 'interface:${iface}'
+	if seen_key in seen {
+		return t.make_memcmp_eq_expr(lhs, rhs, iface, 'iface_eq_cycle')
+	}
+	mut next_seen := seen.clone()
+	next_seen << seen_key
 	lhs_value := t.stable_transformed_expr_for_reuse(lhs, iface, 'iface_eq_lhs')
 	rhs_value := t.stable_transformed_expr_for_reuse(rhs, iface, 'iface_eq_rhs')
 	lhs_typ := t.make_selector(lhs_value, '_typ', 'int')
@@ -2770,7 +2776,8 @@ fn (mut t Transformer) make_interface_semantic_eq_expr(lhs flat.NodeId, rhs flat
 		t.set_node_typ(int(rhs_concrete), impl_name)
 		saved := t.pending_stmts.clone()
 		t.pending_stmts.clear()
-		value_eq := t.make_membership_eq_expr_with_seen(lhs_concrete, rhs_concrete, impl_name, seen)
+		value_eq := t.make_membership_eq_expr_with_seen(lhs_concrete, rhs_concrete, impl_name,
+			next_seen)
 		mut then_body := []flat.NodeId{}
 		t.drain_pending(mut then_body)
 		t.pending_stmts = saved

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -2149,6 +2149,11 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 		return arg_id
 	}
 	mut arg_node := &t.a.nodes[int(arg_id)]
+	if param_type.starts_with('&') && t.call_arg_is_zero_pointer_literal(arg_id) {
+		value := t.transform_expr(arg_id)
+		t.set_node_typ(int(value), param_type)
+		return value
+	}
 	if t.in_spawn_expr && t.call_arg_has_shared_marker(arg_id) {
 		return t.transform_expr(arg_id)
 	}
@@ -2338,6 +2343,17 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 		}
 	}
 	return t.transform_expr_for_type(arg_id, param_type)
+}
+
+fn (t &Transformer) call_arg_is_zero_pointer_literal(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .paren && node.children_count > 0 {
+		return t.call_arg_is_zero_pointer_literal(t.a.child(&node, 0))
+	}
+	return node.kind == .int_literal && (node.value.len == 0 || node.value == '0')
 }
 
 fn (t &Transformer) call_arg_has_shared_marker(arg_id flat.NodeId) bool {
@@ -8226,26 +8242,25 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 	for body_id in new_body {
 		all_ids << body_id
 	}
-	// Generated declarations are appended after all parsed files. Emit an explicit
-	// main context too, otherwise a main-module literal can inherit the preceding
-	// cached module's context during the later flat AST scan.
+	// Generated declarations are appended after all parsed files. Preserve both
+	// source markers, otherwise C generation can associate a lifted literal with
+	// the preceding cached header and omit its program-owned body.
 	file_module := t.current_source_module()
 	generated_module := if file_module.len > 0 { file_module } else { 'main' }
-	t.a.add_node(flat.Node{
-		kind:  .module_decl
-		value: generated_module
-	})
+	t.add_generated_fn_decl_context(generated_module)
 	start := t.a.children.len
 	for child_id in all_ids {
 		t.a.children << child_id
 	}
-	t.a.add_node(flat.Node{
+	fn_decl := t.a.add_node(flat.Node{
 		kind:           .fn_decl
 		value:          name
 		typ:            ret_type
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
 	})
+	t.ensure_node_context_map_capacity()
+	t.mark_node_context(fn_decl, generated_module, t.cur_file)
 	if !isnil(t.tc) {
 		ret := t.tc.parse_type(ret_type)
 		t.tc.fn_ret_types[name] = ret
@@ -8344,6 +8359,21 @@ fn (mut t Transformer) add_fn_literal_capture_global(name string, typ string) {
 	t.globals[name] = typ
 	if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin' {
 		t.globals['${t.cur_module}.${name}'] = typ
+	}
+}
+
+fn (mut t Transformer) add_generated_fn_decl_context(module_name string) {
+	if t.cur_file.len > 0 {
+		t.a.add_node(flat.Node{
+			kind:  .file
+			value: t.cur_file
+		})
+	}
+	if module_name.len > 0 {
+		t.a.add_node(flat.Node{
+			kind:  .module_decl
+			value: module_name
+		})
 	}
 }
 
@@ -11506,13 +11536,18 @@ fn (t &Transformer) checker_resolved_non_builtin_return_type(id flat.NodeId, nod
 			}
 		}
 	}
+	// The expression cache can contain a parser-inferred multi-return tail such as
+	// `!(m.Match, _)`. Prefer the resolved declaration, whose complete return type
+	// is authoritative, before falling back to that provisional expression type.
+	if ret := t.tc.fn_ret_types[name] {
+		return t.call_return_type_name(ret.name(), node)
+	}
 	if typ := t.tc.expr_type(id) {
 		if typ !is types.Unknown && typ !is types.Void {
 			return t.call_return_type_name(typ.name(), node)
 		}
 	}
-	ret := t.tc.fn_ret_types[name] or { return none }
-	return t.call_return_type_name(ret.name(), node)
+	return none
 }
 
 // call_return_type_name updates call return type name state for Transformer.

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -184,7 +184,7 @@ fn test_absorb_scoped_batch_replays_overlay_into_master_checker() {
 	batch.tc.fork_overlay.resolved_call_names[10] = 'main.resolved_call'
 	batch.tc.fork_overlay.resolved_fn_values[11] = 'main.resolved_fn_value'
 
-	master.absorb_scoped_batch(batch, unsafe { nil }, a.nodes.len)
+	master.absorb_scoped_batch(batch, unsafe { nil })
 	assert tc.sparse_resolved_call_names[10] == 'main.resolved_call'
 	assert tc.sparse_resolved_fn_values[11] == 'main.resolved_fn_value'
 }

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -306,6 +306,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 fn (mut t Transformer) request_generic_fn_specialization(decl GenericFnDecl, args []string) {
 	concrete_args := t.canonical_generic_specialization_args(args)
 	key := t.generic_specialization_progress_key(decl, concrete_args)
+	t.record_monomorph_cache_spec(key, decl.key, decl.module, concrete_args)
 	if key in t.generic_fn_spec_nodes || t.generic_fn_specs_in_progress[key]
 		|| t.pending_generic_fn_spec_keys[key] {
 		return
@@ -320,6 +321,52 @@ fn (mut t Transformer) request_generic_fn_specialization(decl GenericFnDecl, arg
 		args: concrete_args
 		key:  key
 	}
+}
+
+fn (mut t Transformer) record_monomorph_cache_spec(key string, decl_key string, module_name string, args []string) {
+	if key.len == 0 || decl_key.len == 0 || key in t.monomorph_cache_specs {
+		return
+	}
+	t.monomorph_cache_specs[key] = MonomorphCacheSpec{
+		decl_key: decl_key
+		module:   module_name
+		args:     args.clone()
+	}
+}
+
+fn (mut t Transformer) seed_cached_monomorph_specs(specs []MonomorphCacheSpec) {
+	if specs.len == 0 {
+		return
+	}
+	decls := t.cached_generic_fn_decls()
+	for spec in specs {
+		decl := decls[spec.decl_key] or { continue }
+		concrete_args := t.canonical_generic_specialization_args(spec.args)
+		if concrete_args.len == 0 || t.generic_args_have_placeholders(concrete_args) {
+			continue
+		}
+		key := t.generic_specialization_progress_key(decl, concrete_args)
+		t.record_monomorph_cache_spec(key, spec.decl_key, decl.module, concrete_args)
+		if !t.generic_specialization_registered(decl, concrete_args) {
+			value := specialized_generic_fn_value(decl.node.value, concrete_args)
+			t.register_specialized_fn_signature_value(decl, value, concrete_args)
+		}
+	}
+}
+
+fn (t &Transformer) sorted_monomorph_cache_specs() []MonomorphCacheSpec {
+	mut keys := t.monomorph_cache_specs.keys()
+	keys.sort()
+	mut specs := []MonomorphCacheSpec{cap: keys.len}
+	for key in keys {
+		spec := t.monomorph_cache_specs[key]
+		specs << MonomorphCacheSpec{
+			decl_key: spec.decl_key.clone()
+			module:   spec.module.clone()
+			args:     spec.args.clone()
+		}
+	}
+	return specs
 }
 
 fn (mut t Transformer) drain_pending_generic_fn_specs(mut emitted map[string]bool, mut generated []string) bool {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -62,7 +62,13 @@ fn (mut t Transformer) is_generic_struct(name string) bool {
 
 fn (mut t Transformer) monomorphize_pass() []string {
 	debug_started := time.ticks()
-	t.tc.reset_resolution_type_view_cache()
+	if t.parallel_monomorphize {
+		t.tc.reset_resolution_type_view_cache()
+	} else {
+		// The serial pass mutates the master semantic maps as it materializes
+		// generic structs. Do not retain lookup views across those mutations.
+		t.tc.disable_resolution_type_view_cache()
+	}
 	defer {
 		t.tc.disable_resolution_type_view_cache()
 		t.defer_nested_generic_emissions = false
@@ -152,10 +158,16 @@ fn (mut t Transformer) monomorphize_pass() []string {
 				t.parallel_monomorph_struct_specs.clear()
 				t.parallel_monomorph_sum_specs.clear()
 			} else {
-				t.collect_generic_struct_specs_range(struct_decls, mut generic_struct_specs,
-					generic_struct_specs_scan_start, node_count)
-				t.collect_generic_sum_specs_range(sum_decls, mut generic_sum_specs,
-					generic_struct_specs_scan_start, node_count)
+				if t.scope_parallel_workers {
+					t.collect_generic_specs_range_scoped(struct_decls, sum_decls, mut
+						generic_struct_specs, mut generic_sum_specs,
+						generic_struct_specs_scan_start, node_count)
+				} else {
+					t.collect_generic_struct_specs_range(struct_decls, mut generic_struct_specs,
+						generic_struct_specs_scan_start, node_count)
+					t.collect_generic_sum_specs_range(sum_decls, mut generic_sum_specs,
+						generic_struct_specs_scan_start, node_count)
+				}
 			}
 			generic_struct_specs_scan_start = node_count
 			if generic_struct_specs.len != spec_count {
@@ -300,7 +312,9 @@ fn (mut t Transformer) request_generic_fn_specialization(decl GenericFnDecl, arg
 	}
 	t.pending_generic_fn_spec_keys[key] = true
 	value := specialized_generic_fn_value(decl.node.value, concrete_args)
-	t.register_specialized_fn_signature_value(decl, value, concrete_args)
+	if !t.generic_signatures_pre_registered {
+		t.register_specialized_fn_signature_value(decl, value, concrete_args)
+	}
 	t.pending_generic_fn_specs << PendingGenericFnSpec{
 		decl: decl
 		args: concrete_args
@@ -2569,8 +2583,8 @@ fn (mut t Transformer) ensure_node_module_map() {
 		return
 	}
 	if t.node_module_map_nodes < 0 || t.node_module_map_nodes > t.a.nodes.len {
-		t.node_module_map_cache = []string{len: t.a.nodes.len}
-		t.node_file_map_cache = []string{len: t.a.nodes.len}
+		t.node_module_map_cache = []string{len: t.a.nodes.len, cap: t.a.nodes.cap}
+		t.node_file_map_cache = []string{len: t.a.nodes.len, cap: t.a.nodes.cap}
 		t.node_module_map_nodes = 0
 	} else {
 		t.ensure_node_context_map_capacity()
@@ -2605,9 +2619,11 @@ fn (mut t Transformer) ensure_node_module_map() {
 
 fn (mut t Transformer) ensure_node_context_map_capacity() {
 	if t.node_module_map_cache.len < t.a.nodes.len {
+		t.node_module_map_cache.ensure_cap(t.a.nodes.cap)
 		t.node_module_map_cache << []string{len: t.a.nodes.len - t.node_module_map_cache.len}
 	}
 	if t.node_file_map_cache.len < t.a.nodes.len {
+		t.node_file_map_cache.ensure_cap(t.a.nodes.cap)
 		t.node_file_map_cache << []string{len: t.a.nodes.len - t.node_file_map_cache.len}
 	}
 }
@@ -2722,12 +2738,8 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 		t.tc.cur_module = decl.module
 		t.tc.cur_file = decl.file
 	}
-	if decl.module.len > 0 {
-		t.a.add_node(flat.Node{
-			kind:  .module_decl
-			value: decl.module
-		})
-	}
+	generated_module := if decl.module.len > 0 { decl.module } else { 'main' }
+	t.add_generated_fn_decl_context(generated_module)
 	old_params := t.active_generic_params
 	old_specialization_args := t.active_specialization_args
 	mut old_specialization_main_types := t.active_specialization_main_types.clone()
@@ -9555,7 +9567,7 @@ fn (mut t Transformer) record_generic_specialization_args_in_module(base string,
 		keys << c_name('${base_module}.${short_base}_${suffix}')
 	}
 	for key in keys {
-		if key.len > 0 && key !in t.generic_specialization_args {
+		if key.len > 0 && !t.has_recorded_generic_specialization_args(key) {
 			t.generic_specialization_args[key] = recorded_args.clone()
 		}
 	}
@@ -9567,10 +9579,21 @@ fn (mut t Transformer) record_generic_specialization_args_for_names(names []stri
 	}
 	recorded_args := t.canonical_generic_specialization_args(args)
 	for name in names {
-		if name.len > 0 && name !in t.generic_specialization_args {
+		if name.len > 0 && !t.has_recorded_generic_specialization_args(name) {
 			t.generic_specialization_args[name] = recorded_args.clone()
 		}
 	}
+}
+
+fn (t &Transformer) has_recorded_generic_specialization_args(name string) bool {
+	if name in t.generic_specialization_args {
+		return true
+	}
+	if isnil(t.generic_specialization_args_parent) {
+		return false
+	}
+	parent := unsafe { *t.generic_specialization_args_parent }
+	return name in parent
 }
 
 fn (t &Transformer) canonical_generic_specialization_args(args []string) []string {
@@ -9728,6 +9751,12 @@ fn (t &Transformer) recorded_generic_specialization_args(typ string) ?[]string {
 	for candidate in candidates {
 		if args := t.generic_specialization_args[candidate] {
 			return args
+		}
+		if !isnil(t.generic_specialization_args_parent) {
+			parent := unsafe { *t.generic_specialization_args_parent }
+			if args := parent[candidate] {
+				return args
+			}
 		}
 	}
 	return none

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -1045,7 +1045,27 @@ fn (t &Transformer) canonical_or_expr_types(expr_type string) (string, string) {
 	if base.len == 0 || base == 'void' || base == 'Optional' {
 		return '${prefix}void', 'void'
 	}
-	return clean_expr_type, base
+	normalized_base := t.normalize_or_expr_value_type(base)
+	return '${prefix}${normalized_base}', normalized_base
+}
+
+fn (t &Transformer) normalize_or_expr_value_type(typ string) string {
+	if typ.starts_with('(') && typ.ends_with(')') {
+		mut normalized_items := []string{}
+		for item in split_generic_args(typ[1..typ.len - 1]) {
+			normalized_items << t.normalize_or_expr_value_type(item)
+		}
+		return '(${normalized_items.join(', ')})'
+	}
+	base, args, is_generic := generic_app_parts(typ)
+	if !is_generic {
+		return t.normalize_type_alias(typ)
+	}
+	mut normalized_args := []string{cap: args.len}
+	for arg in args {
+		normalized_args << t.normalize_or_expr_value_type(arg)
+	}
+	return '${t.normalize_type_alias(base)}[${normalized_args.join(', ')}]'
 }
 
 fn (t &Transformer) json_decode_or_expr_type(expr_id flat.NodeId, expr_node flat.Node) ?string {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -14435,7 +14435,7 @@ fn (mut t Transformer) transform_ident_expr(id flat.NodeId, node flat.Node) flat
 				}
 			}
 			typ := t.var_type(node.value)
-			if typ.len == 0 {
+			if typ.len == 0 && (!t.in_call_callee || !t.ident_is_direct_function_callee(node.value)) {
 				if key := t.const_type_key_in_context(node.value, t.cur_module, t.cur_file) {
 					t.tc.clear_resolved_fn_value(id)
 					mut const_name := key
@@ -14774,6 +14774,18 @@ fn (t &Transformer) resolve_fn_value_ident(name string) ?string {
 		}
 	}
 	return none
+}
+
+fn (t &Transformer) ident_is_direct_function_callee(name string) bool {
+	if name.len == 0 || t.var_type(name).len > 0 {
+		return false
+	}
+	if t.cur_module.len > 0 && t.cur_module !in ['main', 'builtin'] && !name.contains('.') {
+		if t.is_known_fn_name('${t.cur_module}.${name}') {
+			return true
+		}
+	}
+	return t.is_known_fn_name(name)
 }
 
 // --- helper methods ---

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -467,10 +467,12 @@ pub fn transform_with_used_opt_config_scoped_workers_checked_owned(mut a flat.Fl
 // incremental driver has proved that declarations and every other body are
 // unchanged. Whole-program interface and comptime scans remain lazy: lowering a
 // selected body still triggers them if that body actually needs the metadata.
-pub fn transform_selected_functions(mut a flat.FlatAst, tc &types.TypeChecker, selected map[string]bool) (map[string]bool, []string) {
+// It also returns synthesized helper names that incremental Cgen must emit.
+pub fn transform_selected_functions(mut a flat.FlatAst, tc &types.TypeChecker, selected map[string]bool) (map[string]bool, []string, []string) {
 	mut t := new_transformer(mut a, tc, selected)
 	t.skip_generics = true
 	t.prepare()
+	base_node_count := t.a.nodes.len
 	t.transformed_fns = []bool{len: t.a.nodes.len}
 	for i in 0 .. t.a.nodes.len {
 		node := t.a.nodes[i]
@@ -497,7 +499,16 @@ pub fn transform_selected_functions(mut a flat.FlatAst, tc &types.TypeChecker, s
 		t.transform_fn_body(i)
 	}
 	t.apply_ignored_comptime_for_nodes()
-	return t.used_fns, t.monomorph_errors
+	t.run_sum_eq_synthesis_rounds(base_node_count)
+	t.apply_ignored_comptime_for_nodes()
+	mut synthesized_helpers := []string{}
+	for idx in base_node_count .. t.a.nodes.len {
+		node := t.a.nodes[idx]
+		if node.kind == .fn_decl && node.value.starts_with('__v3_sum_eq_') {
+			synthesized_helpers << node.value
+		}
+	}
+	return t.used_fns, t.monomorph_errors, synthesized_helpers
 }
 
 fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool, scope_parallel_workers bool, retain_worker_results bool, stage_scope voidptr) (map[string]bool, bool, []string, []int, []ScopedTransformRegion) {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -64,6 +64,16 @@ pub:
 	helper_module string
 }
 
+// MonomorphCacheSpec identifies one concrete generic function body. Dependency
+// specialization caches use it to restore signatures without cloning unchanged
+// module templates into the program AST.
+pub struct MonomorphCacheSpec {
+pub:
+	decl_key string
+	module   string
+	args     []string
+}
+
 // SmartcastContext stores smartcast context state used by transform.
 pub struct SmartcastContext {
 pub:
@@ -221,6 +231,7 @@ mut:
 	generic_specialization_args_parent &map[string][]string = unsafe { nil }
 	generic_fn_specs_in_progress       map[string]bool
 	generic_fn_spec_nodes              map[string]flat.NodeId
+	monomorph_cache_specs              map[string]MonomorphCacheSpec
 	generic_clone_children             []flat.NodeId
 	defer_nested_generic_emissions     bool
 	parallel_monomorphize              bool
@@ -450,6 +461,43 @@ pub fn transform_with_used_opt_config_scoped_workers_checked(mut a flat.FlatAst,
 pub fn transform_with_used_opt_config_scoped_workers_checked_owned(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool, scope_parallel_workers bool, stage_scope voidptr) (map[string]bool, bool, []string, []int, []ScopedTransformRegion) {
 	return transform_with_used_opt_config_scoped_workers_checked_impl(mut a, tc, used_fns,
 		want_parallel, skip_generics, scope_parallel_workers, true, stage_scope)
+}
+
+// transform_selected_functions lowers only the named function bodies after the
+// incremental driver has proved that declarations and every other body are
+// unchanged. Whole-program interface and comptime scans remain lazy: lowering a
+// selected body still triggers them if that body actually needs the metadata.
+pub fn transform_selected_functions(mut a flat.FlatAst, tc &types.TypeChecker, selected map[string]bool) (map[string]bool, []string) {
+	mut t := new_transformer(mut a, tc, selected)
+	t.skip_generics = true
+	t.prepare()
+	t.transformed_fns = []bool{len: t.a.nodes.len}
+	for i in 0 .. t.a.nodes.len {
+		node := t.a.nodes[i]
+		if node.kind == .file {
+			t.cur_file = node.value
+			t.cur_module = t.tc.file_modules[node.value] or { '' }
+			continue
+		}
+		if node.kind == .module_decl {
+			t.cur_module = node.value
+			continue
+		}
+		if node.kind != .fn_decl {
+			continue
+		}
+		qname := if t.cur_module in ['', 'main', 'builtin'] {
+			node.value
+		} else {
+			'${t.cur_module}.${node.value}'
+		}
+		if !selected[qname] && !selected[node.value] {
+			continue
+		}
+		t.transform_fn_body(i)
+	}
+	t.apply_ignored_comptime_for_nodes()
+	return t.used_fns, t.monomorph_errors
 }
 
 fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool, scope_parallel_workers bool, retain_worker_results bool, stage_scope voidptr) (map[string]bool, bool, []string, []int, []ScopedTransformRegion) {
@@ -713,6 +761,16 @@ pub fn monomorphize_with_used_checked_config(mut a flat.FlatAst, tc &types.TypeC
 // state in `stage_scope` while promoting escaping AST payloads directly to its
 // parent arena.
 pub fn monomorphize_with_used_checked_config_scoped(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, parallel bool, stage_scope voidptr) (map[string]bool, []string) {
+	result, errors, _ := monomorphize_with_used_checked_config_scoped_cached(mut a, tc, used_fns,
+		parallel, stage_scope, []MonomorphCacheSpec{})
+	return result, errors
+}
+
+// monomorphize_with_used_checked_config_scoped_cached restores concrete generic
+// signatures from `cached_specs` and returns the complete specialization set.
+// A restored signature rewrites current program calls normally, while its
+// unchanged dependency body can remain in the persistent compiled prefix.
+pub fn monomorphize_with_used_checked_config_scoped_cached(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, parallel bool, stage_scope voidptr, cached_specs []MonomorphCacheSpec) (map[string]bool, []string, []MonomorphCacheSpec) {
 	debug_started := time.ticks()
 	mut augmented_used_fns := used_fns.clone()
 	mut t := new_transformer(mut a, tc, augmented_used_fns)
@@ -723,6 +781,7 @@ pub fn monomorphize_with_used_checked_config_scoped(mut a flat.FlatAst, tc &type
 		t.scope_parallel_workers = true
 	}
 	t.prepare()
+	t.seed_cached_monomorph_specs(cached_specs)
 	t.monomorph_profile('mono wrapper prepare: ${time.ticks() - debug_started} ms')
 	base_node_count := t.a.nodes.len
 	generated_names := t.monomorphize_pass()
@@ -766,7 +825,18 @@ pub fn monomorphize_with_used_checked_config_scoped(mut a flat.FlatAst, tc &type
 		}
 		transform_stage_scope_resume(stage_scope, parent_state)
 	}
-	return t.used_fns, t.monomorph_errors
+	return t.used_fns, t.monomorph_errors, t.sorted_monomorph_cache_specs()
+}
+
+// register_cached_monomorph_signatures installs persistent concrete signatures
+// before the disposable monomorphization arena is entered.
+pub fn register_cached_monomorph_signatures(a &flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, cached_specs []MonomorphCacheSpec) {
+	if cached_specs.len == 0 {
+		return
+	}
+	mut t := new_transformer_view(a, tc, used_fns)
+	t.prepare()
+	t.seed_cached_monomorph_specs(cached_specs)
 }
 
 fn new_transformer(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) Transformer {
@@ -801,6 +871,7 @@ fn new_transformer_view(a &flat.FlatAst, tc &types.TypeChecker, used_fns map[str
 		generic_specialization_args:      map[string][]string{}
 		generic_fn_specs_in_progress:     map[string]bool{}
 		generic_fn_spec_nodes:            map[string]flat.NodeId{}
+		monomorph_cache_specs:            map[string]MonomorphCacheSpec{}
 		pending_generic_fn_spec_keys:     map[string]bool{}
 		generic_receiver_methods_by_name: map[string][]string{}
 		generic_call_spec_cache:          map[int]GenericCallSpec{}
@@ -16500,7 +16571,7 @@ fn (mut t Transformer) lower_one_match(node flat.Node) flat.NodeId {
 	mut match_prelude := []flat.NodeId{}
 
 	if needs_temp {
-		tmp_name := '__match_tmp_${int(match_expr_id)}'
+		tmp_name := t.new_temp('match_tmp')
 		mut match_type := t.node_type(match_expr_id)
 		outer_pending := t.pending_stmts.clone()
 		t.pending_stmts.clear()
@@ -16650,7 +16721,7 @@ fn (mut t Transformer) build_match_value_stmts(node flat.Node, target_name strin
 	mut actual_expr_id := match_expr_id
 	mut result := []flat.NodeId{}
 	if needs_temp {
-		tmp_name := '__match_tmp_${int(match_expr_id)}'
+		tmp_name := t.new_temp('match_tmp')
 		mut match_type := t.node_type(match_expr_id)
 		transformed_match_expr := if match_expr.kind == .or_expr
 			&& t.is_optional_type_name(match_type) {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -214,36 +214,38 @@ mut:
 	// escaping_interface_box_locals holds interface locals boxed from stack-backed pointer
 	// sources and later returned. The box can alias the stack value while in scope, but its
 	// `_object` needs a heap copy before the interface value leaves the frame.
-	escaping_interface_box_locals     map[string]bool
-	active_specialization_args        []string
-	active_specialization_main_types  map[string]bool
-	generic_specialization_args       map[string][]string
-	generic_fn_specs_in_progress      map[string]bool
-	generic_fn_spec_nodes             map[string]flat.NodeId
-	generic_clone_children            []flat.NodeId
-	defer_nested_generic_emissions    bool
-	parallel_monomorph_worker         bool
-	generic_signatures_pre_registered bool
-	pending_generic_fn_specs          []PendingGenericFnSpec
-	pending_generic_fn_spec_keys      map[string]bool
-	generic_fn_decls_cache            map[string]GenericFnDecl
-	generic_receiver_methods_by_name  map[string][]string
-	generic_fn_decls_ready            bool
-	generic_struct_specs_cache        map[string]string
-	generic_sum_specs_cache           map[string]GenericSpecContext
-	generic_materialization_scan_from int
-	generic_materialization_ready     bool
-	parallel_monomorph_scan_nodes     []int
-	parallel_monomorph_scan_start     int
-	parallel_monomorph_scan_end       int
-	parallel_monomorph_struct_specs   map[string]string
-	parallel_monomorph_sum_specs      map[string]GenericSpecContext
-	generic_call_spec_cache           map[int]GenericCallSpec
-	generic_call_spec_misses          map[int]bool
-	stringify_stack                   []string
-	node_module_map_cache             []string
-	node_file_map_cache               []string
-	node_module_map_nodes             int = -1
+	escaping_interface_box_locals      map[string]bool
+	active_specialization_args         []string
+	active_specialization_main_types   map[string]bool
+	generic_specialization_args        map[string][]string
+	generic_specialization_args_parent &map[string][]string = unsafe { nil }
+	generic_fn_specs_in_progress       map[string]bool
+	generic_fn_spec_nodes              map[string]flat.NodeId
+	generic_clone_children             []flat.NodeId
+	defer_nested_generic_emissions     bool
+	parallel_monomorphize              bool
+	parallel_monomorph_worker          bool
+	generic_signatures_pre_registered  bool
+	pending_generic_fn_specs           []PendingGenericFnSpec
+	pending_generic_fn_spec_keys       map[string]bool
+	generic_fn_decls_cache             map[string]GenericFnDecl
+	generic_receiver_methods_by_name   map[string][]string
+	generic_fn_decls_ready             bool
+	generic_struct_specs_cache         map[string]string
+	generic_sum_specs_cache            map[string]GenericSpecContext
+	generic_materialization_scan_from  int
+	generic_materialization_ready      bool
+	parallel_monomorph_scan_nodes      []int
+	parallel_monomorph_scan_start      int
+	parallel_monomorph_scan_end        int
+	parallel_monomorph_struct_specs    map[string]string
+	parallel_monomorph_sum_specs       map[string]GenericSpecContext
+	generic_call_spec_cache            map[int]GenericCallSpec
+	generic_call_spec_misses           map[int]bool
+	stringify_stack                    []string
+	node_module_map_cache              []string
+	node_file_map_cache                []string
+	node_module_map_nodes              int = -1
 	// used_fns_log records names newly inserted into used_fns while the
 	// late-used-fn-bodies pass runs, so that pass can tell "was this name
 	// already used before the current body's transform" without cloning the
@@ -285,6 +287,7 @@ mut:
 	retain_worker_results   bool
 	retained_worker_regions []ScopedTransformRegion
 	stage_scope             voidptr
+	scoped_monomorphize     bool
 }
 
 // AliasCache memoizes normalize_type_alias results. It lives on the heap so the
@@ -469,17 +472,7 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 	}
 	t.transformed_fns = []bool{len: t.a.nodes.len}
 	was_parallel := t.transform_all_dispatch(want_parallel)
-	if retain_worker_results && t.worker_scope != unsafe { nil }
-		&& !t.retained_worker_regions.any(it.scope == t.worker_scope) {
-		mut base_nodes := t.scoped_owned_base_nodes.keys()
-		base_nodes << t.scoped_owned_base_log
-		t.retained_worker_regions << ScopedTransformRegion{
-			scope:      t.worker_scope
-			new_start:  base_node_count
-			new_end:    t.a.nodes.len
-			base_nodes: base_nodes
-		}
-	}
+	t.retain_current_worker_scope_all()
 	t.apply_ignored_comptime_for_nodes()
 	// The late-name scan backfills call names that markused's raw-AST resolution
 	// missed and generic-specialization names. When building the V compiler
@@ -495,9 +488,27 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 	t.transform_late_used_fn_bodies(late_names, base_node_count)
 	t.run_sum_eq_synthesis_rounds(base_node_count)
 	t.apply_ignored_comptime_for_nodes()
+	t.retain_current_worker_scope_all()
 	mut owned_base_nodes := t.scoped_owned_base_nodes.keys()
 	owned_base_nodes << t.scoped_owned_base_log
 	return t.used_fns, was_parallel, t.monomorph_errors, owned_base_nodes, t.retained_worker_regions
+}
+
+fn (mut t Transformer) retain_current_worker_scope_all() {
+	if !t.retain_worker_results || t.worker_scope == unsafe { nil } {
+		return
+	}
+	if !t.retained_worker_regions.any(it.scope == t.worker_scope) {
+		mut base_nodes := t.scoped_owned_base_nodes.keys()
+		base_nodes << t.scoped_owned_base_log
+		t.retained_worker_regions << ScopedTransformRegion{
+			scope:      t.worker_scope
+			new_start:  0
+			new_end:    t.a.nodes.len
+			base_nodes: base_nodes
+		}
+	}
+	t.worker_scope = unsafe { nil }
 }
 
 // reserve_parallel_transform_ast reserves persistent append regions before a
@@ -507,7 +518,7 @@ pub fn reserve_parallel_transform_ast(mut a flat.FlatAst, skip_generics bool) {
 	// Generic lowering needs more headroom than self-host transform because worker
 	// regions cannot grow while their disposable arenas are active.
 	nodes_factor_num, nodes_factor_den := if skip_generics { 2, 1 } else { 3, 1 }
-	children_factor_num, children_factor_den := if skip_generics { 7, 3 } else { 3, 1 }
+	children_factor_num, children_factor_den := if skip_generics { 7, 3 } else { 4, 1 }
 	nodes_cap := a.nodes.len * nodes_factor_num / nodes_factor_den
 	if nodes_cap > a.nodes.cap {
 		old_nodes := a.nodes
@@ -545,6 +556,23 @@ fn transform_worker_scope_free(scope voidptr) {
 	$if prealloc {
 		if scope != unsafe { nil } {
 			unsafe { prealloc_scope_free_after(scope) }
+		}
+	}
+}
+
+fn transform_stage_scope_suspend(scope voidptr) voidptr {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			return unsafe { prealloc_scope_suspend(scope) }
+		}
+	}
+	return unsafe { nil }
+}
+
+fn transform_stage_scope_resume(scope voidptr, state voidptr) {
+	$if prealloc {
+		if scope != unsafe { nil } && state != unsafe { nil } {
+			unsafe { prealloc_scope_resume(scope, state) }
 		}
 	}
 }
@@ -671,9 +699,29 @@ pub fn monomorphize_with_used(mut a flat.FlatAst, tc &types.TypeChecker, used_fn
 // monomorphize_with_used_checked also reports semantic errors that can only be
 // resolved after generic parameters have concrete types.
 pub fn monomorphize_with_used_checked(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) (map[string]bool, []string) {
+	return monomorphize_with_used_checked_config(mut a, tc, used_fns, true)
+}
+
+// monomorphize_with_used_checked_config controls whether independent generic
+// specializations can be cloned concurrently.
+pub fn monomorphize_with_used_checked_config(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, parallel bool) (map[string]bool, []string) {
+	return monomorphize_with_used_checked_config_scoped(mut a, tc, used_fns, parallel,
+		unsafe { nil })
+}
+
+// monomorphize_with_used_checked_config_scoped keeps transient specialization
+// state in `stage_scope` while promoting escaping AST payloads directly to its
+// parent arena.
+pub fn monomorphize_with_used_checked_config_scoped(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, parallel bool, stage_scope voidptr) (map[string]bool, []string) {
 	debug_started := time.ticks()
 	mut augmented_used_fns := used_fns.clone()
 	mut t := new_transformer(mut a, tc, augmented_used_fns)
+	t.parallel_monomorphize = parallel
+	t.stage_scope = stage_scope
+	t.scoped_monomorphize = stage_scope != unsafe { nil }
+	$if prealloc {
+		t.scope_parallel_workers = true
+	}
 	t.prepare()
 	t.monomorph_profile('mono wrapper prepare: ${time.ticks() - debug_started} ms')
 	base_node_count := t.a.nodes.len
@@ -711,6 +759,13 @@ pub fn monomorphize_with_used_checked(mut a flat.FlatAst, tc &types.TypeChecker,
 	t.monomorph_profile('mono wrapper sums: ${time.ticks() - debug_started} ms')
 	t.apply_ignored_comptime_for_nodes()
 	t.monomorph_profile('mono wrapper ignored: ${time.ticks() - debug_started} ms')
+	if stage_scope != unsafe { nil } {
+		parent_state := transform_stage_scope_suspend(stage_scope)
+		for idx in 0 .. t.a.nodes.len {
+			t.clone_scoped_worker_node(idx, stage_scope)
+		}
+		transform_stage_scope_resume(stage_scope, parent_state)
+	}
 	return t.used_fns, t.monomorph_errors
 }
 
@@ -1116,6 +1171,7 @@ fn (mut t Transformer) ignore_comptime_for_subtree(id flat.NodeId) {
 		return
 	}
 	if t.ignored_comptime_for_nodes.len < t.a.nodes.len {
+		t.ignored_comptime_for_nodes.ensure_cap(t.a.nodes.cap)
 		t.ignored_comptime_for_nodes << []bool{len: t.a.nodes.len - t.ignored_comptime_for_nodes.len}
 	}
 	if t.ignored_comptime_for_nodes[idx] {
@@ -2283,7 +2339,7 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 	} else {
 		map[string]bool{}
 	}
-	mut w := t.fork_program_view(ast, wtc, used)
+	mut w := t.fork_program_view(ast, wtc, used, copy_used_fns)
 	if !copy_used_fns {
 		w.used_fns_parent = unsafe { &t.used_fns }
 		w.used_fns_root = if !isnil(t.used_fns_root) {
@@ -2343,9 +2399,6 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 	w.escaping_amp_sources = map[string]bool{}
 	w.heaped_amp_locals = map[string]bool{}
 	w.escaping_interface_box_locals = map[string]bool{}
-	if !t.skip_generics {
-		w.generic_specialization_args = t.generic_specialization_args.clone()
-	}
 	w.generic_fn_specs_in_progress = map[string]bool{}
 	w.monomorph_errors = []string{}
 	w.monomorph_error_seen = map[string]bool{}
@@ -2399,7 +2452,7 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 // caller's `used` snapshot and never marks names — so forking costs almost
 // nothing even with one fork per scan thread.
 fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
-	mut w := t.fork_program_view(t.a, wtc, map[string]bool{})
+	mut w := t.fork_program_view(t.a, wtc, map[string]bool{}, false)
 	w.alias_cache = &AliasCache{}
 	w.sum_cache = &AliasCache{}
 	w.generic_unresolved_cache = &GenericUnresolvedCache{}
@@ -2471,84 +2524,92 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 // All fields omitted here come from new_transformer_view as fresh worker-local
 // state, so adding a mutable Transformer field cannot silently share its backing
 // storage with a helper thread.
-fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker, used_fns map[string]bool) Transformer {
+fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker, used_fns map[string]bool, copy_generic_state bool) Transformer {
 	// The pre-scan freezes the boxed-type set before skip-generics workers
 	// start, so sharing it below is read-only and avoids one map clone per worker.
 	return Transformer{
-		a:                                ast
-		tc:                               wtc
-		structs:                          t.structs
-		struct_short_name_index:          t.struct_short_name_index
-		struct_short_name_index_ready:    t.struct_short_name_index_ready
-		unique_fields:                    t.unique_fields
-		alias_methods:                    t.alias_methods
-		globals:                          t.globals
-		sum_types:                        t.sum_types
-		sum_variant_parents:              t.sum_variant_parents
-		sum_variant_names:                t.sum_variant_names
-		sum_variant_fields:               t.sum_variant_fields
-		qualified_types:                  t.qualified_types
-		fn_ret_types:                     t.fn_ret_types
-		multi_return_fn_ret_types:        t.multi_return_fn_ret_types
-		receiver_method_suffix_index:     t.receiver_method_suffix_index
-		variadic_suffix_index:            t.variadic_suffix_index
-		const_suffixes:                   t.const_suffixes
-		enum_types:                       t.enum_types
-		enum_backing_types:               t.enum_backing_types
-		generic_alias_names:              t.generic_alias_names
-		local_decl_nodes_by_name:         t.local_decl_nodes_by_name
-		struct_field_decl_metas_cache:    t.struct_field_decl_metas_cache
-		comptime_field_metas_cache:       map[string][]FieldMeta{}
-		call_param_types_decl_cache:      t.call_param_types_decl_cache
-		call_param_types_decl_misses:     t.call_param_types_decl_misses.clone()
-		call_param_types_decl_index:      t.call_param_types_decl_index
-		call_param_types_index_ready:     t.call_param_types_index_ready
-		comptime_reflected_params:        t.comptime_reflected_params
-		used_struct_operator_fns:         t.used_struct_operator_fns
-		generic_specialization_args:      if t.skip_generics {
+		a:                                  ast
+		tc:                                 wtc
+		structs:                            t.structs
+		struct_short_name_index:            t.struct_short_name_index
+		struct_short_name_index_ready:      t.struct_short_name_index_ready
+		unique_fields:                      t.unique_fields
+		alias_methods:                      t.alias_methods
+		globals:                            t.globals
+		sum_types:                          t.sum_types
+		sum_variant_parents:                t.sum_variant_parents
+		sum_variant_names:                  t.sum_variant_names
+		sum_variant_fields:                 t.sum_variant_fields
+		qualified_types:                    t.qualified_types
+		fn_ret_types:                       t.fn_ret_types
+		multi_return_fn_ret_types:          t.multi_return_fn_ret_types
+		receiver_method_suffix_index:       t.receiver_method_suffix_index
+		variadic_suffix_index:              t.variadic_suffix_index
+		const_suffixes:                     t.const_suffixes
+		enum_types:                         t.enum_types
+		enum_backing_types:                 t.enum_backing_types
+		generic_alias_names:                t.generic_alias_names
+		local_decl_nodes_by_name:           t.local_decl_nodes_by_name
+		struct_field_decl_metas_cache:      t.struct_field_decl_metas_cache
+		comptime_field_metas_cache:         map[string][]FieldMeta{}
+		call_param_types_decl_cache:        t.call_param_types_decl_cache
+		call_param_types_decl_misses:       t.call_param_types_decl_misses.clone()
+		call_param_types_decl_index:        t.call_param_types_decl_index
+		call_param_types_index_ready:       t.call_param_types_index_ready
+		comptime_reflected_params:          t.comptime_reflected_params
+		used_struct_operator_fns:           t.used_struct_operator_fns
+		generic_specialization_args:        if !copy_generic_state {
+			map[string][]string{}
+		} else if t.skip_generics {
 			t.generic_specialization_args
 		} else {
 			t.generic_specialization_args.clone()
 		}
-		interface_var_concrete_types:     map[string]string{}
-		interface_boxed_types:            if t.skip_generics && t.interface_boxed_types_frozen {
+		generic_specialization_args_parent: if copy_generic_state {
+			unsafe { nil }
+		} else {
+			unsafe { &t.generic_specialization_args }
+		}
+		interface_var_concrete_types:       map[string]string{}
+		interface_boxed_types:              if t.skip_generics && t.interface_boxed_types_frozen {
 			t.interface_boxed_types
 		} else {
 			t.interface_boxed_types.clone()
 		}
-		interface_boxed_types_done:       t.interface_boxed_types_done
-		interface_boxed_types_frozen:     t.interface_boxed_types_frozen
-		interface_impl_indexes:           t.interface_impl_indexes
-		interface_impl_spec_count:        t.interface_impl_spec_count
-		ierror_none_type_id:              t.ierror_none_type_id
-		sum_eq_types:                     t.sum_eq_types.clone()
-		sum_eq_synthesized:               t.sum_eq_synthesized.clone()
-		used_fns:                         used_fns.clone()
-		mut_param_values:                 map[string]bool{}
-		pointer_value_lvalues:            map[string]bool{}
-		pointer_value_rvalues:            map[string]bool{}
-		orm_initialized_fields:           map[string][]string{}
-		sql_query_data_aliases:           map[string][]string{}
-		invalidated_smartcasts:           map[string]bool{}
-		escaping_amp_ptrs:                map[string]bool{}
-		escaping_amp_sources:             map[string]bool{}
-		heaped_amp_locals:                map[string]bool{}
-		generic_fn_specs_in_progress:     map[string]bool{}
-		generic_fn_spec_nodes:            map[string]flat.NodeId{}
-		pending_generic_fn_spec_keys:     map[string]bool{}
-		generic_receiver_methods_by_name: map[string][]string{}
-		generic_call_spec_cache:          map[int]GenericCallSpec{}
-		generic_call_spec_misses:         map[int]bool{}
-		monomorph_error_seen:             map[string]bool{}
-		skip_generics:                    t.skip_generics
-		has_spawn_expr:                   t.has_spawn_expr
-		base_write_intercept:             t.base_write_intercept
-		defer_oor_writes:                 t.defer_oor_writes
-		shared_base_nodes:                t.shared_base_nodes
-		scoped_base_nodes:                t.scoped_base_nodes
-		scope_parallel_workers:           t.scope_parallel_workers
-		retain_worker_results:            t.retain_worker_results
-		stage_scope:                      t.stage_scope
+		interface_boxed_types_done:         t.interface_boxed_types_done
+		interface_boxed_types_frozen:       t.interface_boxed_types_frozen
+		interface_impl_indexes:             t.interface_impl_indexes
+		interface_impl_spec_count:          t.interface_impl_spec_count
+		ierror_none_type_id:                t.ierror_none_type_id
+		sum_eq_types:                       t.sum_eq_types.clone()
+		sum_eq_synthesized:                 t.sum_eq_synthesized.clone()
+		used_fns:                           used_fns.clone()
+		mut_param_values:                   map[string]bool{}
+		pointer_value_lvalues:              map[string]bool{}
+		pointer_value_rvalues:              map[string]bool{}
+		orm_initialized_fields:             map[string][]string{}
+		sql_query_data_aliases:             map[string][]string{}
+		invalidated_smartcasts:             map[string]bool{}
+		escaping_amp_ptrs:                  map[string]bool{}
+		escaping_amp_sources:               map[string]bool{}
+		heaped_amp_locals:                  map[string]bool{}
+		generic_fn_specs_in_progress:       map[string]bool{}
+		generic_fn_spec_nodes:              map[string]flat.NodeId{}
+		pending_generic_fn_spec_keys:       map[string]bool{}
+		generic_receiver_methods_by_name:   map[string][]string{}
+		generic_call_spec_cache:            map[int]GenericCallSpec{}
+		generic_call_spec_misses:           map[int]bool{}
+		monomorph_error_seen:               map[string]bool{}
+		skip_generics:                      t.skip_generics
+		has_spawn_expr:                     t.has_spawn_expr
+		base_write_intercept:               t.base_write_intercept
+		defer_oor_writes:                   t.defer_oor_writes
+		shared_base_nodes:                  t.shared_base_nodes
+		scoped_base_nodes:                  t.scoped_base_nodes
+		scope_parallel_workers:             t.scope_parallel_workers
+		retain_worker_results:              t.retain_worker_results
+		stage_scope:                        t.stage_scope
+		scoped_monomorphize:                t.scoped_monomorphize
 	}
 }
 
@@ -2685,7 +2746,8 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 			if t.a.nodes[k].children_start >= base_children {
 				t.a.nodes[k] = t.a.nodes[k].with_shifted_children(child_shift)
 			}
-			if w.worker_scope != unsafe { nil } && !t.retain_worker_results {
+			if w.worker_scope != unsafe { nil } && !t.retain_worker_results
+				&& t.stage_scope == unsafe { nil } {
 				t.clone_scoped_worker_node(k, w.worker_scope)
 			}
 		}
@@ -2701,11 +2763,13 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 		if it.fn_idx >= 0 && it.fn_idx < t.transformed_fns.len {
 			t.transformed_fns[it.fn_idx] = true
 		}
-		if w.worker_scope != unsafe { nil } && !t.retain_worker_results {
+		if w.worker_scope != unsafe { nil } && !t.retain_worker_results
+			&& t.stage_scope == unsafe { nil } {
 			t.clone_scoped_worker_node(it.fn_idx, w.worker_scope)
 		}
 	}
-	if w.worker_scope != unsafe { nil } && !t.retain_worker_results {
+	if w.worker_scope != unsafe { nil } && !t.retain_worker_results
+		&& t.stage_scope == unsafe { nil } {
 		for idx in w.scoped_owned_base_nodes.keys() {
 			t.clone_scoped_worker_node(idx, w.worker_scope)
 		}
@@ -2776,6 +2840,7 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 	}
 	if w.ignored_comptime_for_nodes.len > 0 {
 		if t.ignored_comptime_for_nodes.len < t.a.nodes.len {
+			t.ignored_comptime_for_nodes.ensure_cap(t.a.nodes.cap)
 			t.ignored_comptime_for_nodes << []bool{len: t.a.nodes.len - t.ignored_comptime_for_nodes.len}
 		}
 		for idx, ignored in w.ignored_comptime_for_nodes {
@@ -2790,6 +2855,7 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 	}
 	if w.ignored_comptime_for_log.len > 0 {
 		if t.ignored_comptime_for_nodes.len < t.a.nodes.len {
+			t.ignored_comptime_for_nodes.ensure_cap(t.a.nodes.cap)
 			t.ignored_comptime_for_nodes << []bool{len: t.a.nodes.len - t.ignored_comptime_for_nodes.len}
 		}
 		for idx in w.ignored_comptime_for_log {
@@ -7518,8 +7584,10 @@ fn (mut t Transformer) build_interface_field_selector_chain(base flat.NodeId, ba
 	}
 	base_op := if base_type.starts_with('&') { flat.Op.arrow } else { flat.Op.dot }
 	tag := t.make_selector_op(base, '_typ', 'int', base_op)
-	cond := t.make_infix(.eq, tag, t.make_int_literal(type_id))
 	object := t.make_selector_op(base, '_object', 'voidptr', base_op)
+	tag_matches := t.make_infix(.eq, tag, t.make_int_literal(type_id))
+	object_not_nil := t.make_infix(.ne, object, t.a.add(.nil_literal))
+	cond := t.make_infix(.logical_and, tag_matches, object_not_nil)
 	object_ptr := t.make_cast('&${impl}', object, '&${impl}')
 	value := t.struct_field_selector_for_type(object_ptr, impl, field, field_type, true) or {
 		return t.build_interface_field_selector_chain(base, base_type, impl_index, field,
@@ -9167,6 +9235,13 @@ fn (mut t Transformer) try_expand_plain_multi_assign(node flat.Node) ?[]flat.Nod
 			t.transform_expr(rhs_id)
 		}
 		t.drain_pending(mut result)
+		if lhs.kind == .ident && lhs.value == '_' {
+			// A discarded slot still has to evaluate its RHS, but it does not need the
+			// typed temporary used to preserve values for the later assignments.
+			result << t.make_assign(t.make_ident('_'), rhs)
+			tmp_names << ''
+			continue
+		}
 		tmp_name := t.new_temp('assign')
 		tmp_type := if lhs_type.len > 0 { lhs_type } else { t.node_type(rhs_id) }
 		result << t.make_decl_assign_typed(tmp_name, rhs, tmp_type)
@@ -13246,6 +13321,12 @@ fn (t &Transformer) raw_selector_type_without_smartcast(id flat.NodeId) string {
 		base_type = t.original_expr_type(base_id)
 	}
 	clean_base_type := t.trim_pointer_type(base_type)
+	base_iface := t.resolve_interface_type_name(clean_base_type)
+	if base_iface.len > 0 {
+		if ftyp := t.interface_field_type_name(base_iface, node.value) {
+			return ftyp
+		}
+	}
 	if ftyp := t.lookup_struct_field_type(clean_base_type, node.value) {
 		return ftyp
 	}
@@ -13388,10 +13469,12 @@ fn (mut t Transformer) transform_cast_expr(id flat.NodeId, node flat.Node) flat.
 		child := t.a.child_node(&node, 0)
 		if child.kind == .call && child.children_count > 0 {
 			callee := t.a.child_node(child, 0)
-			if callee.kind == .ident && callee.value in ['array_get', 'array__get'] {
-				// array_get returns raw storage. array_get_value adds this typed pointer
-				// cast before dereferencing it; a later transform pass must not reinterpret
-				// the cast as a concrete-to-interface conversion and box the void pointer.
+			if callee.kind == .ident
+				&& callee.value in ['array_get', 'array__get', 'map__get', 'map__get_check'] {
+				// Container getters return raw storage. Their typed access helpers add this
+				// pointer cast before dereferencing it; a later transform pass must not
+				// reinterpret the cast as a concrete-to-interface conversion and box the
+				// void pointer.
 				return id
 			}
 		}

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -22,7 +22,7 @@ const max_parallel_monomorph_jobs = 10
 const scoped_transform_worker_batches = 48
 const scoped_transform_master_batches = 48
 const scoped_transform_max_batch_items = 32
-const scoped_monomorph_batch_specs = 2
+const scoped_monomorph_batch_specs = 512
 const scoped_monomorph_scan_nodes = 32768
 
 $if !windows {
@@ -107,7 +107,10 @@ $if !windows {
 			scope = transform_worker_scope_begin(w.scope_parallel_workers)
 		}
 		w.parallel_monomorph_worker = true
-		w.generic_signatures_pre_registered = true
+		// A worker can discover a nested specialization that another worker will
+		// emit. Register that signature in the discovering worker immediately so
+		// it can transform the current call with the correct return type.
+		w.generic_signatures_pre_registered = false
 		w.defer_nested_generic_emissions = true
 		w.generic_clone_children.ensure_cap(65536)
 		generated_start := w.a.nodes.len
@@ -246,8 +249,13 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 		// batches detach, copying the entire immutable base AST in every worker.
 		// The private growing fallback below remains available for truly uneven
 		// batches that exceed their region.
-		node_reserve := specs.len * 4096 + n_jobs * 262144
-		child_reserve := specs.len * 5120 + n_jobs * 393216
+		// Volt's measured closure averages about 1k nodes per specialization,
+		// with the largest hash partition below 130k nodes. Keep enough shared
+		// space for the normal closure without forcing the backing slabs to grow
+		// to several times their retained size. An unusually uneven partition
+		// still uses the private-region fallback below.
+		node_reserve := specs.len * 256 + n_jobs * 196608
+		child_reserve := specs.len * 320 + n_jobs * 229376
 		t.a.nodes.ensure_cap(base_nodes + node_reserve)
 		t.a.children.ensure_cap(base_children + child_reserve)
 		t.monomorph_profile('mono capacity: ${time.ticks() - debug_started} ms')
@@ -444,6 +452,7 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 			t.ensure_node_context_map_capacity()
 			for idx, spec in args[ci].emitted_specs {
 				root := flat.NodeId(int(args[ci].roots[idx]) + node_shift)
+				t.record_monomorph_cache_spec(spec.key, spec.decl.key, spec.decl.module, spec.args)
 				if !t.generic_specialization_registered(spec.decl, spec.args) {
 					value := specialized_generic_fn_value(spec.decl.node.value, spec.args)
 					t.register_specialized_fn_signature_value(spec.decl, value, spec.args)
@@ -465,16 +474,48 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 					}
 					t.request_generic_fn_specialization(pending.decl, owned_args)
 				}
-				if args[ci].scope != unsafe { nil } {
-					transform_worker_scope_free(args[ci].scope)
-				}
 			}
 			t.monomorph_profile('mono merged worker ${ci}: ${time.ticks() - debug_started} ms')
+		}
+		// Nested specialization requests can be transferred between workers.
+		// A node emitted by one worker can therefore retain arguments allocated
+		// by another. Publish merged node payloads through the parent text table
+		// against every worker arena before releasing any of them.
+		for ci in 1 .. n_jobs {
+			if args[ci].scope == unsafe { nil } {
+				continue
+			}
+			for idx in 0 .. t.a.nodes.len {
+				t.clone_scoped_worker_node(idx, args[ci].scope)
+			}
+		}
+		for ci in 1 .. n_jobs {
+			if args[ci].scope != unsafe { nil } {
+				transform_worker_scope_free(args[ci].scope)
+			}
 		}
 		t.parallel_monomorph_worker = false
 		t.generic_signatures_pre_registered = false
 		t.parallel_monomorph_scan_end = t.a.nodes.len
 		t.tc.unfreeze_type_cache_after_forks()
+		t.parallel_monomorph_scan_nodes = t.parallel_monomorph_scan_nodes.clone()
+		mut owned_struct_specs := map[string]string{}
+		for spec, base in t.parallel_monomorph_struct_specs {
+			owned_struct_specs[spec.clone()] = base.clone()
+		}
+		t.parallel_monomorph_struct_specs = owned_struct_specs.move()
+		mut owned_sum_specs := map[string]GenericSpecContext{}
+		for spec, context in t.parallel_monomorph_sum_specs {
+			owned_sum_specs[spec.clone()] = GenericSpecContext{
+				base:   context.base.clone()
+				file:   context.file.clone()
+				module: context.module.clone()
+			}
+		}
+		t.parallel_monomorph_sum_specs = owned_sum_specs.move()
+		for idx in 0 .. t.a.nodes.len {
+			t.clone_scoped_worker_node(idx, setup_scope)
+		}
 		transform_worker_scope_free(setup_scope)
 		t.monomorph_profile('mono merge: ${time.ticks() - debug_started} ms')
 		return any_started

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -21,7 +21,9 @@ const max_shared_transform_jobs = 7
 const max_parallel_monomorph_jobs = 10
 const scoped_transform_worker_batches = 48
 const scoped_transform_master_batches = 48
-const scoped_transform_max_batch_items = 8
+const scoped_transform_max_batch_items = 32
+const scoped_monomorph_batch_specs = 2
+const scoped_monomorph_scan_nodes = 32768
 
 $if !windows {
 	// TransformChunkArgs is the payload handed to each persistent worker.
@@ -89,8 +91,8 @@ mut:
 @[heap]
 struct MonomorphClaimState {
 mut:
-	mu        sync.Mutex
-	cond      &sync.Cond = unsafe { nil }
+	mu        &sync.Mutex = unsafe { nil }
+	cond      &sync.Cond  = unsafe { nil }
 	claimed   map[string]bool
 	queues    [][]PendingGenericFnSpec
 	remaining int
@@ -123,6 +125,12 @@ $if !windows {
 			if claims.remaining == 0 {
 				claims.mu.unlock()
 				break
+			}
+			if claims.queues[a.worker_idx].len == 0 {
+				// A condition variable may wake spuriously. Recheck the queue while
+				// holding the mutex instead of popping an empty worker queue.
+				claims.mu.unlock()
+				continue
 			}
 			spec := claims.queues[a.worker_idx].pop()
 			claims.mu.unlock()
@@ -266,11 +274,12 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 		setup_scope := transform_worker_scope_begin(t.scope_parallel_workers)
 		decls := t.cached_generic_fn_decls()
 		mut claims := &MonomorphClaimState{
+			mu:        sync.new_mutex()
 			claimed:   map[string]bool{}
 			queues:    [][]PendingGenericFnSpec{len: n_jobs}
 			remaining: specs.len
 		}
-		claims.cond = sync.new_cond(&claims.mu)
+		claims.cond = sync.new_cond(claims.mu)
 		for spec in specs {
 			claims.claimed[spec.key] = true
 			target := monomorph_spec_worker(spec.key, n_jobs)
@@ -469,6 +478,171 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 		transform_worker_scope_free(setup_scope)
 		t.monomorph_profile('mono merge: ${time.ticks() - debug_started} ms')
 		return any_started
+	}
+}
+
+// run_scoped_monomorphize_specs emits a bounded number of specializations in a
+// private AST/checker view, merges their persistent output, and releases all
+// per-specialization scratch before continuing with the next batch.
+fn (mut t Transformer) run_scoped_monomorphize_specs(specs []PendingGenericFnSpec, mut emitted map[string]bool, mut generated []string) bool {
+	if specs.len == 0 {
+		return false
+	}
+	// Workers treat declaration parameter metadata as immutable. Build the lazy
+	// index in the parent arena before a scoped worker can grow its backing map.
+	t.prepare_parallel_call_param_types()
+	t.tc.freeze_type_cache_for_forks()
+	defer {
+		t.tc.unfreeze_type_cache_after_forks()
+	}
+	decls := t.cached_generic_fn_decls()
+	mut start := 0
+	for start < specs.len {
+		end := if start + scoped_monomorph_batch_specs < specs.len {
+			start + scoped_monomorph_batch_specs
+		} else {
+			specs.len
+		}
+		base_nodes := t.a.nodes.len
+		base_children := t.a.children.len
+		node_headroom := (end - start) * 8192 + 262144
+		child_headroom := (end - start) * 10240 + 393216
+		t.a.nodes.ensure_cap(base_nodes + node_headroom)
+		t.a.children.ensure_cap(base_children + child_headroom)
+		for spec in specs[start..end] {
+			if !t.generic_specialization_registered(spec.decl, spec.args) {
+				value := specialized_generic_fn_value(spec.decl.node.value, spec.args)
+				t.register_specialized_fn_signature_value(spec.decl, value, spec.args)
+			}
+		}
+		scope := transform_worker_scope_begin(true)
+		mut wast := shared_region_view(t.a, base_nodes, t.a.nodes.cap, base_children,
+			t.a.children.cap)
+		wast.specialized_fn_nodes = map[int]bool{}
+		mut wtc := t.tc.fork_for_parallel_transform(wast)
+		mut w := t.fork_scoped_batch_worker(wast, wtc)
+		w.generic_fn_decls_cache = decls.clone()
+		w.generic_fn_decls_ready = true
+		w.generic_receiver_methods_by_name = t.generic_receiver_methods_by_name.clone()
+		w.parallel_monomorph_worker = true
+		w.generic_signatures_pre_registered = true
+		w.defer_nested_generic_emissions = true
+		w.generic_clone_children.ensure_cap(65536)
+		mut roots := []flat.NodeId{cap: end - start}
+		mut emitted_specs := []PendingGenericFnSpec{cap: end - start}
+		mut generated_names := []string{}
+		for spec in specs[start..end] {
+			if spec.key in t.generic_fn_spec_nodes {
+				continue
+			}
+			root := w.emit_generic_fn_specialization(spec.decl, spec.args)
+			generated_names << w.generated_fn_used_names(spec.decl, root, spec.args)
+			roots << root
+			emitted_specs << spec
+		}
+		w.worker_scope = scope
+		transform_worker_scope_leave(scope)
+
+		node_shift := t.a.nodes.len - base_nodes
+		t.merge_worker_used_fns(w)
+		t.merge_worker(w, []FnWorkItem{}, base_nodes, base_children, false)
+		for name, spec_args in w.generic_specialization_args {
+			if name !in t.generic_specialization_args {
+				t.generic_specialization_args[name.clone()] = spec_args.clone()
+			}
+		}
+		for pending in w.pending_generic_fn_specs {
+			mut owned_args := []string{cap: pending.args.len}
+			for item in pending.args {
+				owned_args << item.clone()
+			}
+			t.request_generic_fn_specialization(pending.decl, owned_args)
+		}
+		for idx, spec in emitted_specs {
+			root := flat.NodeId(int(roots[idx]) + node_shift)
+			if !t.generic_specialization_registered(spec.decl, spec.args) {
+				value := specialized_generic_fn_value(spec.decl.node.value, spec.args)
+				t.register_specialized_fn_signature_value(spec.decl, value, spec.args)
+			}
+			t.generic_fn_spec_nodes[spec.key.clone()] = root
+			t.a.specialized_fn_nodes[int(root)] = true
+			t.mark_node_context(root, spec.decl.module, spec.decl.file)
+			emitted[generic_fn_spec_key(spec.decl.key, spec.args)] = true
+			t.pending_generic_fn_spec_keys.delete(spec.key)
+		}
+		for name in generated_names {
+			generated << name.clone()
+		}
+		if t.stage_scope != unsafe { nil } {
+			parent_state := transform_stage_scope_suspend(t.stage_scope)
+			for idx in 0 .. t.a.nodes.len {
+				t.clone_scoped_worker_node(idx, scope)
+			}
+			transform_stage_scope_resume(t.stage_scope, parent_state)
+		} else {
+			for idx in 0 .. t.a.nodes.len {
+				t.promote_scoped_node_to_current(idx, scope)
+			}
+		}
+		transform_worker_scope_free(scope)
+		start = end
+	}
+	return true
+}
+
+// collect_generic_specs_range_scoped bounds the temporary type parsing and
+// string splitting needed when a monomorphization round scans newly generated
+// nodes. Only the small set of discovered specs escapes each scratch arena.
+fn (mut t Transformer) collect_generic_specs_range_scoped(struct_decls map[string]GenericStructDecl, sum_decls map[string]GenericSumDecl, mut struct_specs map[string]string, mut sum_specs map[string]GenericSpecContext, first int, last int) {
+	if first >= last {
+		return
+	}
+	t.tc.freeze_type_cache_for_forks()
+	defer {
+		t.tc.unfreeze_type_cache_after_forks()
+	}
+	mut start := first
+	for start < last {
+		end := if start + scoped_monomorph_scan_nodes < last {
+			start + scoped_monomorph_scan_nodes
+		} else {
+			last
+		}
+		scope := transform_worker_scope_begin(true)
+		mut wtc := t.tc.fork_for_parallel_transform(t.a)
+		mut w := t.fork_scoped_batch_worker(t.a, wtc)
+		// The master has already extended these append-only context arrays to
+		// `last`; workers only read them while collecting type spellings.
+		w.node_module_map_cache = t.node_module_map_cache
+		w.node_file_map_cache = t.node_file_map_cache
+		w.node_module_map_nodes = t.node_module_map_nodes
+		mut batch_struct_specs := map[string]string{}
+		mut batch_sum_specs := map[string]GenericSpecContext{}
+		w.collect_generic_struct_specs_range(struct_decls, mut batch_struct_specs, start, end)
+		w.collect_generic_sum_specs_range(sum_decls, mut batch_sum_specs, start, end)
+		transform_worker_scope_leave(scope)
+		for spec, base in batch_struct_specs {
+			struct_specs[spec.clone()] = base.clone()
+		}
+		for spec, context in batch_sum_specs {
+			sum_specs[spec.clone()] = GenericSpecContext{
+				base:   context.base.clone()
+				file:   context.file.clone()
+				module: context.module.clone()
+			}
+		}
+		for name, args in w.generic_specialization_args {
+			if name in t.generic_specialization_args {
+				continue
+			}
+			mut owned_args := []string{cap: args.len}
+			for arg in args {
+				owned_args << arg.clone()
+			}
+			t.generic_specialization_args[name.clone()] = owned_args
+		}
+		transform_worker_scope_free(scope)
+		start = end
 	}
 }
 
@@ -746,12 +920,11 @@ fn (mut t Transformer) promote_scoped_result_text(value string) string {
 	if value.len == 0 {
 		return ''
 	}
-	// Scoped self-host workers only read the parse-time text table. Reuse those
-	// compilation-owned strings before adding a worker-local canonical entry.
-	if t.retain_worker_results {
-		if id := t.a.text_ids[value] {
-			return t.a.text_values[int(id) - 1]
-		}
+	// Scoped workers only read the compilation text table. Reuse its canonical
+	// strings before adding a worker-local entry; generic specialization clones
+	// otherwise retain another copy of almost every source identifier and type.
+	if id := t.a.text_ids[value] {
+		return t.a.text_values[int(id) - 1]
 	}
 	if canonical := t.scoped_promoted_texts[value] {
 		return canonical
@@ -761,20 +934,36 @@ fn (mut t Transformer) promote_scoped_result_text(value string) string {
 	return canonical
 }
 
+// promote_scoped_ast_storage moves array backing that grew inside `scope` into
+// the parent arena. Individual node payloads are promoted by absorb_scoped_batch;
+// this preserves the flat containers themselves before the scratch arena dies.
+fn (mut t Transformer) promote_scoped_ast_storage(scope voidptr) {
+	if transform_scope_owns(scope, t.a.nodes.data) {
+		mut nodes := []flat.Node{cap: t.a.nodes.len + t.a.nodes.len / 4 + 1024}
+		nodes << t.a.nodes
+		t.a.nodes = nodes
+	}
+	if transform_scope_owns(scope, t.a.children.data) {
+		mut children := []flat.NodeId{cap: t.a.children.len + t.a.children.len / 4 + 1024}
+		children << t.a.children
+		t.a.children = children
+	}
+}
+
 // absorb_scoped_batch publishes one batch's observable state into the helper's
 // result arena before its large scratch arena is released.
-fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, new_node_start int) {
-	for idx in new_node_start .. batch.a.nodes.len {
+fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr) {
+	// Generic lowering can rewrite nodes reached indirectly through late calls, outside
+	// the initial work item's subtree. Verify the flat payload fields exhaustively before
+	// releasing the batch arena instead of trusting a mutation log that cannot observe
+	// every such rewrite.
+	for idx in 0 .. batch.a.nodes.len {
 		t.promote_scoped_node_to_current(idx, scope)
 	}
 	for idx in batch.scoped_owned_base_nodes.keys() {
-		t.promote_scoped_node_to_current(idx, scope)
 		t.scoped_owned_base_log << idx
 	}
-	for idx in batch.scoped_owned_base_log {
-		t.promote_scoped_node_to_current(idx, scope)
-		t.scoped_owned_base_log << idx
-	}
+	t.scoped_owned_base_log << batch.scoped_owned_base_log
 	for name in batch.used_fns_log {
 		t.mark_used_fn_key(t.promote_scoped_result_text(name))
 	}
@@ -832,7 +1021,7 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 // scratch lifetime within each helper. A fresh Transformer/TypeChecker fork per
 // batch prevents caches from retaining pointers into the released arena.
 fn (mut t Transformer) transform_scoped_helper_batches(items []FnWorkItem, max_batches int) {
-	result_scope := transform_worker_scope_begin(true)
+	t.retain_current_worker_scope_all()
 	mut total_cost := i64(0)
 	for item in items {
 		total_cost += i64(item.cost) + 1
@@ -864,11 +1053,11 @@ fn (mut t Transformer) transform_scoped_helper_batches(items []FnWorkItem, max_b
 		batch.used_fns_log_active = true
 		batch.scoped_base_log_active = true
 		batch.ignored_comptime_log_active = true
-		new_node_start := t.a.nodes.len
 		batch.transform_pure_items_serial(items[start..end])
 		transform_worker_scope_leave(scratch_scope)
 		t.a.promote_transform_texts_from(text_start, scratch_scope)
-		t.absorb_scoped_batch(batch, scratch_scope, new_node_start)
+		t.absorb_scoped_batch(batch, scratch_scope)
+		t.promote_scoped_ast_storage(scratch_scope)
 		// absorb_scoped_batch publishes every appended node and every base-node
 		// mutation recorded by the batch. Avoid rescanning the continuously growing
 		// AST after each small batch; that makes scoped transform quadratic.
@@ -876,8 +1065,11 @@ fn (mut t Transformer) transform_scoped_helper_batches(items []FnWorkItem, max_b
 		start = end
 		batch_idx++
 	}
-	t.worker_scope = result_scope
-	transform_worker_scope_leave(result_scope)
+	// Promotions and merged side tables were allocated in the helper thread's
+	// persistent parent arena after each scratch scope was left. Nothing from a
+	// completed helper needs to keep a result arena alive until the end of the
+	// whole transform phase.
+	t.worker_scope = unsafe { nil }
 }
 
 // transform_late_candidates_scoped lowers dynamically discovered function bodies in bounded
@@ -926,7 +1118,6 @@ fn (mut t Transformer) transform_late_candidates_scoped(candidate_index map[stri
 		batch.used_fns_log_active = true
 		batch.scoped_base_log_active = true
 		batch.ignored_comptime_log_active = true
-		new_node_start := t.a.nodes.len
 		for si, ci in selected {
 			node_starts[si] = t.a.nodes.len
 			batch.cur_file = candidates[ci].file
@@ -936,7 +1127,8 @@ fn (mut t Transformer) transform_late_candidates_scoped(candidate_index map[stri
 		node_starts[selected.len] = t.a.nodes.len
 		transform_worker_scope_leave(scratch_scope)
 		t.a.promote_transform_texts_from(text_start, scratch_scope)
-		t.absorb_scoped_batch(batch, scratch_scope, new_node_start)
+		t.absorb_scoped_batch(batch, scratch_scope)
+		t.promote_scoped_ast_storage(scratch_scope)
 		transform_worker_scope_free(scratch_scope)
 		for si, ci in selected {
 			idx := candidates[ci].idx
@@ -1304,6 +1496,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		t.flush_deferred_base_writes()
 		if t.ignored_comptime_for_log.len > 0 {
 			if t.ignored_comptime_for_nodes.len < t.a.nodes.len {
+				t.ignored_comptime_for_nodes.ensure_cap(t.a.nodes.cap)
 				t.ignored_comptime_for_nodes << []bool{len: t.a.nodes.len - t.ignored_comptime_for_nodes.len}
 			}
 			for idx in t.ignored_comptime_for_log {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -194,8 +194,9 @@ pub:
 
 // LocalBinding represents local binding data used by types.
 struct LocalBinding {
-	name string
-	typ  Type
+	name   string
+	typ    Type
+	is_mut bool
 }
 
 // ParseTypeCacheEntry keeps the identity components separate. The old
@@ -15322,7 +15323,17 @@ fn (tc &TypeChecker) mut_receiver_expr_is_mutable_lvalue(id flat.NodeId) bool {
 		.ident {
 			return tc.ident_is_mutable_lvalue(node.value)
 		}
-		.index, .selector, .paren {
+		.index, .selector {
+			// Mutating the pointee of a pointer-valued field or element does not
+			// mutate the binding that stores the pointer. This is common for
+			// application state such as `app.window.refresh()`.
+			if tc.type_is_pointer_receiver(tc.cached_expr_type(id) or { tc.resolve_type(id) }) {
+				return true
+			}
+			return node.children_count > 0
+				&& tc.mut_receiver_expr_is_mutable_lvalue(tc.a.child(&node, 0))
+		}
+		.paren {
 			return node.children_count > 0
 				&& tc.mut_receiver_expr_is_mutable_lvalue(tc.a.child(&node, 0))
 		}
@@ -15367,11 +15378,39 @@ fn (tc &TypeChecker) ident_is_mutable_lvalue(name string) bool {
 	if tc.mut_param_binding_matches_lvalue(name) {
 		return true
 	}
-	owner := tc.fn_context.mut_local_owners[name] or { return false }
 	if tc.cur_scope == unsafe { nil } {
 		return false
 	}
-	return tc.cur_scope.nearest_binding_owned_by(name, owner)
+	if owner := tc.fn_context.mut_local_owners[name] {
+		if tc.cur_scope.nearest_binding_owned_by(name, owner) {
+			return true
+		}
+	}
+	// Globals are mutable storage. Respect a nearer local binding first so an
+	// immutable local that shadows a global is still rejected.
+	if owner := tc.cur_scope.lookup_owner(name) {
+		return tc.binding_owner_is_global(owner)
+	}
+	qname := tc.qualify_name(name)
+	if qname != name {
+		if owner := tc.cur_scope.lookup_owner(qname) {
+			return tc.binding_owner_is_global(owner)
+		}
+	}
+	return false
+}
+
+fn (tc &TypeChecker) binding_owner_is_global(owner ScopeBindingOwner) bool {
+	// A parallel checker adds its private file scope in front of the collected
+	// program scope, so globals can live in any ancestor of `file_scope`.
+	mut scope := unsafe { &Scope(tc.file_scope) }
+	for scope != unsafe { nil } {
+		if owner.belongs_to_scope(scope) {
+			return true
+		}
+		scope = scope.parent
+	}
+	return false
 }
 
 fn (tc &TypeChecker) map_builtin_call_info(base_type Type, m Map, method string, mname string) ?CallInfo {
@@ -18426,7 +18465,10 @@ fn (mut tc TypeChecker) check_if_expr(id flat.NodeId, node flat.Node) {
 		$if ownership ? {
 			tc.ownership_note_binding(binding.name, binding.typ, cond_id)
 		}
-		tc.cur_scope.insert(binding.name, binding.typ)
+		owner := tc.cur_scope.insert_with_owner(binding.name, binding.typ)
+		if binding.is_mut {
+			tc.fn_context.mut_local_owners[binding.name] = owner
+		}
 	}
 	tc.check_branch_node(then_id, value_context)
 	tc.pop_scope()
@@ -18850,8 +18892,9 @@ fn (mut tc TypeChecker) check_if_guard(id flat.NodeId, node flat.Node) []LocalBi
 			lhs := tc.a.nodes[int(lhs_id)]
 			if lhs.kind == .ident && lhs.value.len > 0 && lhs.value != '_' {
 				result << LocalBinding{
-					name: lhs.value
-					typ:  payload.types[i]
+					name:   lhs.value
+					typ:    payload.types[i]
+					is_mut: lhs.is_mut || node.is_mut
 				}
 			}
 		}
@@ -18862,8 +18905,9 @@ fn (mut tc TypeChecker) check_if_guard(id flat.NodeId, node flat.Node) []LocalBi
 		if lhs.kind == .ident && lhs.value.len > 0 && lhs.value != '_' {
 			mut result := []LocalBinding{}
 			result << LocalBinding{
-				name: lhs.value
-				typ:  payload
+				name:   lhs.value
+				typ:    payload
+				is_mut: lhs.is_mut || node.is_mut
 			}
 			return result
 		}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -408,27 +408,28 @@ pub mut:
 	// concrete `Box[int].method` -> substituted CallInfo for a method *value* on a
 	// generic receiver. The open `Box[T].method` registration is gone by cgen time, so
 	// the checker stashes the resolved signature here for gen_method_value_closure.
-	generic_method_value_info     map[string]CallInfo
-	params_structs                map[string]bool
-	unions                        map[string]bool
-	type_aliases                  map[string]string
-	type_alias_generic_params     map[string][]string // generic alias base name -> type-param names
-	type_alias_c_abi_fns          map[string]string
-	sum_types                     map[string][]string
-	sum_generic_params            map[string][]string // generic sum type base name -> type-param names (e.g. Tree -> [T])
-	enum_names                    map[string]bool
-	enum_fields                   map[string][]string
-	flag_enums                    map[string]bool
-	interface_names               map[string]bool
-	interface_fields              map[string][]StructField
-	interface_embeds              map[string][]string
-	interface_abstract_methods    map[string][]string // iface -> abstract (declared) method names
-	interface_impl_name_snapshots map[string][]string
-	interface_method_names_index  map[string][]string
-	interface_abstract_index      map[string][]string
-	interface_field_list_index    map[string][]StructField
-	interface_impl_indexes        map[string]&InterfaceImplIndex
-	interface_query_indexes_ready bool
+	generic_method_value_info             map[string]CallInfo
+	params_structs                        map[string]bool
+	unions                                map[string]bool
+	type_aliases                          map[string]string
+	type_alias_generic_params             map[string][]string // generic alias base name -> type-param names
+	type_alias_c_abi_fns                  map[string]string
+	sum_types                             map[string][]string
+	sum_generic_params                    map[string][]string // generic sum type base name -> type-param names (e.g. Tree -> [T])
+	enum_names                            map[string]bool
+	enum_fields                           map[string][]string
+	flag_enums                            map[string]bool
+	interface_names                       map[string]bool
+	interface_fields                      map[string][]StructField
+	interface_embeds                      map[string][]string
+	interface_abstract_methods            map[string][]string // iface -> abstract (declared) method names
+	interface_impl_name_snapshots         map[string][]string
+	interface_impl_candidates_at_snapshot map[string]bool
+	interface_method_names_index          map[string][]string
+	interface_abstract_index              map[string][]string
+	interface_field_list_index            map[string][]StructField
+	interface_impl_indexes                map[string]&InterfaceImplIndex
+	interface_query_indexes_ready         bool
 
 	c_globals               map[string]Type
 	const_types             map[string]Type
@@ -572,64 +573,65 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 	type_interner := new_type_interner()
 	symbols := new_symbol_interner()
 	return TypeChecker{
-		a:                                  a
-		fn_ret_types:                       map[string]Type{}
-		fn_param_types:                     map[string][]Type{}
-		fn_shared_params:                   map[string][]bool{}
-		mut_receiver_methods:               map[string]bool{}
-		fn_ret_type_texts:                  map[string]string{}
-		fn_param_type_texts:                map[string][]string{}
-		fn_type_files:                      map[string]string{}
-		fn_type_modules:                    map[string]string{}
-		fn_generic_params:                  map[string][]string{}
-		specialized_generic_fns:            map[string]bool{}
-		fn_variadic:                        map[string]bool{}
-		c_variadic_fns:                     map[string]bool{}
-		fn_implicit_veb_ctx:                map[string]bool{}
-		receiver_method_suffix_index:       map[string]string{}
-		structs:                            map[string][]StructField{}
-		struct_modules:                     map[string]string{}
-		struct_files:                       map[string]string{}
-		soa_structs:                        map[string]bool{}
-		declared_type_scope_keys:           map[string]bool{}
-		struct_error_embeds_shadow_builtin: map[string]bool{}
-		struct_generic_params:              map[string][]string{}
-		struct_implements:                  map[string][]string{}
-		struct_shared_fields:               map[string]bool{}
-		struct_field_c_abi_fns:             map[string]string{}
-		generic_method_value_info:          map[string]CallInfo{}
-		params_structs:                     map[string]bool{}
-		unions:                             map[string]bool{}
-		type_aliases:                       map[string]string{}
-		type_alias_generic_params:          map[string][]string{}
-		type_alias_c_abi_fns:               map[string]string{}
-		sum_types:                          map[string][]string{}
-		sum_generic_params:                 map[string][]string{}
-		enum_names:                         map[string]bool{}
-		enum_fields:                        map[string][]string{}
-		flag_enums:                         map[string]bool{}
-		interface_names:                    map[string]bool{}
-		interface_fields:                   map[string][]StructField{}
-		interface_embeds:                   map[string][]string{}
-		interface_abstract_methods:         map[string][]string{}
-		interface_impl_name_snapshots:      map[string][]string{}
-		interface_method_names_index:       map[string][]string{}
-		interface_abstract_index:           map[string][]string{}
-		interface_field_list_index:         map[string][]StructField{}
-		interface_impl_indexes:             map[string]&InterfaceImplIndex{}
-		c_globals:                          map[string]Type{}
-		const_types:                        map[string]Type{}
-		const_exprs:                        map[string]flat.NodeId{}
-		const_modules:                      map[string]string{}
-		const_files:                        map[string]string{}
-		const_suffixes:                     map[string]string{}
-		imports:                            map[string]string{}
-		file_imports:                       map[string]string{}
-		file_selective_imports:             map[string][]string{}
-		file_imports_by_file:               map[string]&FileImportInfo{}
-		file_modules:                       map[string]string{}
-		file_scope:                         fs
-		cur_scope:                          fs
+		a:                                     a
+		fn_ret_types:                          map[string]Type{}
+		fn_param_types:                        map[string][]Type{}
+		fn_shared_params:                      map[string][]bool{}
+		mut_receiver_methods:                  map[string]bool{}
+		fn_ret_type_texts:                     map[string]string{}
+		fn_param_type_texts:                   map[string][]string{}
+		fn_type_files:                         map[string]string{}
+		fn_type_modules:                       map[string]string{}
+		fn_generic_params:                     map[string][]string{}
+		specialized_generic_fns:               map[string]bool{}
+		fn_variadic:                           map[string]bool{}
+		c_variadic_fns:                        map[string]bool{}
+		fn_implicit_veb_ctx:                   map[string]bool{}
+		receiver_method_suffix_index:          map[string]string{}
+		structs:                               map[string][]StructField{}
+		struct_modules:                        map[string]string{}
+		struct_files:                          map[string]string{}
+		soa_structs:                           map[string]bool{}
+		declared_type_scope_keys:              map[string]bool{}
+		struct_error_embeds_shadow_builtin:    map[string]bool{}
+		struct_generic_params:                 map[string][]string{}
+		struct_implements:                     map[string][]string{}
+		struct_shared_fields:                  map[string]bool{}
+		struct_field_c_abi_fns:                map[string]string{}
+		generic_method_value_info:             map[string]CallInfo{}
+		params_structs:                        map[string]bool{}
+		unions:                                map[string]bool{}
+		type_aliases:                          map[string]string{}
+		type_alias_generic_params:             map[string][]string{}
+		type_alias_c_abi_fns:                  map[string]string{}
+		sum_types:                             map[string][]string{}
+		sum_generic_params:                    map[string][]string{}
+		enum_names:                            map[string]bool{}
+		enum_fields:                           map[string][]string{}
+		flag_enums:                            map[string]bool{}
+		interface_names:                       map[string]bool{}
+		interface_fields:                      map[string][]StructField{}
+		interface_embeds:                      map[string][]string{}
+		interface_abstract_methods:            map[string][]string{}
+		interface_impl_name_snapshots:         map[string][]string{}
+		interface_impl_candidates_at_snapshot: map[string]bool{}
+		interface_method_names_index:          map[string][]string{}
+		interface_abstract_index:              map[string][]string{}
+		interface_field_list_index:            map[string][]StructField{}
+		interface_impl_indexes:                map[string]&InterfaceImplIndex{}
+		c_globals:                             map[string]Type{}
+		const_types:                           map[string]Type{}
+		const_exprs:                           map[string]flat.NodeId{}
+		const_modules:                         map[string]string{}
+		const_files:                           map[string]string{}
+		const_suffixes:                        map[string]string{}
+		imports:                               map[string]string{}
+		file_imports:                          map[string]string{}
+		file_selective_imports:                map[string][]string{}
+		file_imports_by_file:                  map[string]&FileImportInfo{}
+		file_modules:                          map[string]string{}
+		file_scope:                            fs
+		cur_scope:                             fs
 		// The node-indexed cache arrays start empty: collect() sizes them via
 		// reset_node_caches (allocating them here too paid for everything
 		// twice), and extend_node_caches grows them on demand for any checker
@@ -929,6 +931,13 @@ pub fn (mut tc TypeChecker) set_fresh_type_cache(parse_enabled bool) {
 	}
 }
 
+// reset_type_interners replaces semantic interners whose backing storage may
+// have grown inside a disposable compiler-stage arena.
+pub fn (mut tc TypeChecker) reset_type_interners() {
+	tc.type_interner = new_type_interner()
+	tc.symbols = new_symbol_interner()
+}
+
 // set_fresh_type_cache_based_on attaches a new empty TypeCache that falls back
 // read-only to `src`'s frozen base cache (see freeze_type_cache_for_forks), so
 // parallel-cgen workers start with every type memoized by the check/transform
@@ -1066,6 +1075,49 @@ pub fn (mut tc TypeChecker) reserve_transform_node_caches(n int) {
 	reserve_type_cache(mut tc.expr_type_values, n)
 	reserve_bool_cache(mut tc.expr_type_set, n)
 	reserve_bool_cache(mut tc.checking_nodes, n)
+}
+
+// materialize_sparse_transform_node_caches compacts transform-created semantic
+// entries into dense node-indexed arrays and reserves their expected final
+// capacity before monomorphization appends more nodes.
+pub fn (mut tc TypeChecker) materialize_sparse_transform_node_caches(n int, capacity int) {
+	if !tc.parallel_check_sparse {
+		tc.reserve_transform_node_caches(capacity)
+		tc.extend_node_caches(n)
+		return
+	}
+	target_cap := if capacity > n { capacity } else { n }
+	tc.reserve_transform_node_caches(target_cap)
+	tc.parallel_check_sparse = false
+	tc.extend_node_caches(n)
+	for idx, name in tc.sparse_resolved_call_names {
+		if idx >= 0 && idx < n {
+			tc.resolved_call_names[idx] = name
+			tc.resolved_call_set[idx] = true
+		}
+	}
+	for idx, name in tc.sparse_resolved_fn_values {
+		if idx >= 0 && idx < n {
+			tc.resolved_fn_value_names[idx] = name
+			tc.resolved_fn_value_set[idx] = true
+		}
+	}
+	for idx, is_statement in tc.sparse_statement_nodes {
+		if is_statement && idx >= 0 && idx < n {
+			tc.statement_nodes[idx] = true
+		}
+	}
+	for idx, typ in tc.sparse_expr_type_values {
+		if idx >= 0 && idx < n {
+			tc.expr_type_values[idx] = typ
+			tc.expr_type_set[idx] = true
+		}
+	}
+	tc.sparse_resolved_call_names = map[int]string{}
+	tc.sparse_resolved_fn_values = map[int]string{}
+	tc.sparse_statement_nodes = map[int]bool{}
+	tc.sparse_expr_type_values = map[int]Type{}
+	tc.sparse_checking_nodes = map[int]bool{}
 }
 
 // reserve_scoped_transform_metadata keeps tables that receive escaping
@@ -1912,9 +1964,15 @@ fn (tc &TypeChecker) c_struct_decl_is_vlib_termios_shim(file string, module_name
 		return false
 	}
 	normalized := file.replace('\\', '/')
-	return normalized.contains('/vlib/term/')
-		|| (normalized.contains('/v3_module_cache_')
-		&& normalized.all_after_last('/').starts_with('termios_') && normalized.ends_with('.vh'))
+	if normalized.contains('/vlib/term/') {
+		return true
+	}
+	if !normalized.contains('/v3_module_cache_') || !normalized.ends_with('.vh') {
+		return false
+	}
+	base := normalized.all_after_last('/')
+	return (module_name == 'term' && base.starts_with('term_'))
+		|| (module_name in ['termios', 'term.termios'] && base.starts_with('termios_'))
 }
 
 fn (tc &TypeChecker) c_struct_decl_is_vlib_cjson(file string, module_name string) bool {
@@ -22414,7 +22472,8 @@ pub fn (tc &TypeChecker) interface_impl_names(iface_name string) []string {
 		// Generic monomorphization can add concrete implementers after the
 		// transform has already emitted `_typ` literals. Preserve the earlier
 		// ids, and append any later implementers so cgen can still box them.
-		for name in tc.interface_impl_names_uncached(iface_name) {
+		for name in tc.interface_impl_names_uncached_after(iface_name,
+			tc.interface_impl_candidates_at_snapshot) {
 			if name !in seen {
 				seen[name] = true
 				impls << name
@@ -22450,44 +22509,84 @@ pub fn (mut tc TypeChecker) freeze_interface_impl_names() {
 		snapshots[iface_name] = tc.interface_impl_names_uncached(iface_name)
 	}
 	tc.interface_impl_name_snapshots = snapshots.move()
+	tc.interface_impl_candidates_at_snapshot = tc.interface_impl_candidate_names()
 }
 
 fn (tc &TypeChecker) interface_impl_names_uncached(iface_name string) []string {
+	return tc.interface_impl_names_uncached_after(iface_name, map[string]bool{})
+}
+
+fn add_interface_impl_candidate(mut candidates map[string]bool, name string, excluded map[string]bool) {
+	if name !in excluded {
+		candidates[name] = true
+	}
+}
+
+fn (tc &TypeChecker) interface_impl_candidate_names() map[string]bool {
+	mut candidates := map[string]bool{}
+	for name in implicit_str_builtin_type_names() {
+		candidates[name] = true
+	}
+	for name, _ in tc.structs {
+		candidates[interface_impl_candidate_name(name)] = true
+	}
+	for name, _ in tc.enum_names {
+		candidates[interface_impl_candidate_name(name)] = true
+	}
+	for name, target in tc.type_aliases {
+		candidates[interface_impl_candidate_name(name)] = true
+		typ := tc.parse_type(target)
+		if typ is FnType {
+			candidates[Type(typ).name()] = true
+		}
+	}
+	for name, _ in tc.interface_names {
+		candidates[name] = true
+		short_name := interface_impl_candidate_name(name)
+		if short_name != name {
+			candidates[short_name] = true
+		}
+	}
+	return candidates
+}
+
+fn (tc &TypeChecker) interface_impl_names_uncached_after(iface_name string, excluded map[string]bool) []string {
 	mut candidate_set := map[string]bool{}
 	has_no_requirements := tc.interface_has_no_requirements(iface_name)
 	accepts_implicit_str := tc.interface_accepts_implicit_str(iface_name)
 	if has_no_requirements || accepts_implicit_str {
 		for name in implicit_str_builtin_type_names() {
-			candidate_set[name] = true
+			add_interface_impl_candidate(mut candidate_set, name, excluded)
 		}
 	}
 	for name, _ in tc.structs {
-		candidate_set[interface_impl_candidate_name(name)] = true
+		add_interface_impl_candidate(mut candidate_set, interface_impl_candidate_name(name),
+			excluded)
 	}
 	if has_no_requirements || accepts_implicit_str {
 		for name, _ in tc.enum_names {
-			candidate_set[interface_impl_candidate_name(name)] = true
+			add_interface_impl_candidate(mut candidate_set, interface_impl_candidate_name(name),
+				excluded)
 		}
 	}
-	for name, _ in tc.type_aliases {
-		candidate_set[interface_impl_candidate_name(name)] = true
-	}
-	if has_no_requirements {
-		for _, target in tc.type_aliases {
+	for name, target in tc.type_aliases {
+		candidate_name := interface_impl_candidate_name(name)
+		add_interface_impl_candidate(mut candidate_set, candidate_name, excluded)
+		if has_no_requirements && candidate_name !in excluded {
 			typ := tc.parse_type(target)
 			if typ is FnType {
-				candidate_set[Type(typ).name()] = true
+				add_interface_impl_candidate(mut candidate_set, Type(typ).name(), excluded)
 			}
 		}
 	}
 	for name, _ in tc.interface_names {
 		if name != iface_name && tc.interface_implements_interface(name, iface_name) {
-			candidate_set[name] = true
+			add_interface_impl_candidate(mut candidate_set, name, excluded)
 		}
 		short_name := interface_impl_candidate_name(name)
 		if short_name != name && short_name != iface_name
 			&& tc.interface_implements_interface(name, iface_name) {
-			candidate_set[short_name] = true
+			add_interface_impl_candidate(mut candidate_set, short_name, excluded)
 		}
 	}
 	mut candidates := candidate_set.keys()

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -123,6 +123,25 @@ pub fn (mut tc TypeChecker) check_semantics_opt(want_parallel bool) bool {
 	}
 }
 
+// check_semantics_selected validates declarations and only the named function
+// bodies. It is used by the function-level incremental compiler after it has
+// proven that every top-level declaration is unchanged.
+pub fn (mut tc TypeChecker) check_semantics_selected(selected map[string]bool) {
+	tc.resolution_type_mode = false
+	tc.check_export_attrs()
+	items := tc.collect_parallel_check_items()
+	mut selected_items := []CheckWorkItem{cap: selected.len}
+	for item in items {
+		node := tc.a.nodes[item.fn_idx]
+		qname := checker_qualified_fn_name(item.module, node.value)
+		if selected[qname] || selected[node.value] {
+			selected_items << item
+		}
+	}
+	tc.check_fn_items_serial(selected_items)
+	tc.resolution_type_mode = true
+}
+
 fn (mut tc TypeChecker) check_semantics_parallel() bool {
 	$if windows {
 		tc.check_semantics()

--- a/vlib/v3/types/mut_receiver_test.v
+++ b/vlib/v3/types/mut_receiver_test.v
@@ -23,6 +23,7 @@ fn test_dereferenced_mut_receiver_checks_root_binding() {
 	})
 
 	mut tc := TypeChecker.new(&a)
+	tc.cur_scope = new_scope(tc.file_scope)
 	owner := tc.cur_scope.insert_with_owner('p', Type(Pointer{
 		base_type: Type(int_)
 	}))
@@ -34,4 +35,23 @@ fn test_dereferenced_mut_receiver_checks_root_binding() {
 	assert tc.mut_receiver_expr_is_mutable_lvalue(p_id)
 	assert tc.mut_receiver_expr_is_mutable_lvalue(amp_id)
 	assert tc.mut_receiver_expr_is_mutable_lvalue(deref_id)
+}
+
+fn test_global_mut_receiver_is_mutable_but_local_shadow_is_not() {
+	mut a := flat.FlatAst.new()
+	g_id := a.add_val(.ident, 'g')
+	mut tc := TypeChecker.new(&a)
+	mut global_scope := tc.file_scope
+	global_scope.insert('g', Type(Pointer{
+		base_type: Type(int_)
+	}))
+	// Match the extra private file scope installed by a parallel checker.
+	tc.file_scope = new_scope(global_scope)
+	tc.cur_scope = new_scope(tc.file_scope)
+	assert tc.mut_receiver_expr_is_mutable_lvalue(g_id)
+
+	tc.cur_scope.insert('g', Type(Pointer{
+		base_type: Type(int_)
+	}))
+	assert !tc.mut_receiver_expr_is_mutable_lvalue(g_id)
 }

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2092,6 +2092,18 @@ fn main() {
 	b.metric_items('parsed .vh files', p.parsed_v_header_files, 'files', '.vh files',
 		p.parsed_v_header_file_paths)
 	b.metric_items('parsed .v files', p.parsed_v_files, 'files', '.v files', p.parsed_v_file_paths)
+	mut parsed_v_lines := 0
+	for path in p.parsed_v_file_paths {
+		source := os.read_file(path) or { continue }
+		if source.len == 0 {
+			continue
+		}
+		parsed_v_lines += source.count('\n')
+		if source[source.len - 1] != `\n` {
+			parsed_v_lines++
+		}
+	}
+	println('    ${'parsed .v lines':-28s} ${parsed_v_lines} lines')
 	b.metric('AST nodes after parse', a.nodes.len, 'nodes')
 	b.metric('AST children after parse', a.children.len, 'edges')
 	b.metric('canonical AST texts', a.text_count(), 'texts')

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2311,6 +2311,55 @@ fn transformed_used_fns_need_monomorphize(used_fns map[string]bool) bool {
 	return false
 }
 
+fn incremental_changed_functions_call_generics(a &flat.FlatAst, tc &types.TypeChecker, changed_names map[string]bool) bool {
+	if changed_names.len == 0 {
+		return false
+	}
+	mut cur_module := ''
+	for idx, node in a.nodes {
+		match node.kind {
+			.file {
+				cur_module = ''
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.fn_decl {
+				name := incremental_qualified_fn_name(cur_module, node.value)
+				if changed_names[name]
+					&& incremental_node_tree_calls_generic(a, tc, flat.NodeId(idx)) {
+					return true
+				}
+			}
+			else {}
+		}
+	}
+	return false
+}
+
+fn incremental_node_tree_calls_generic(a &flat.FlatAst, tc &types.TypeChecker, root flat.NodeId) bool {
+	mut stack := [root]
+	for stack.len > 0 {
+		id := stack.pop()
+		idx := int(id)
+		if idx < 0 || idx >= a.nodes.len {
+			continue
+		}
+		node := a.nodes[idx]
+		if node.kind == .call {
+			if name := tc.resolved_call_name(id) {
+				if name in tc.fn_generic_params || name.contains('[') {
+					return true
+				}
+			}
+		}
+		for child_idx in 0 .. node.children_count {
+			stack << a.child(&node, child_idx)
+		}
+	}
+	return false
+}
+
 fn ast_contains_sql_expr(a &flat.FlatAst) bool {
 	for node in a.nodes {
 		if node.kind == .sql_expr {
@@ -3137,6 +3186,11 @@ fn main() {
 		if pre_tc.errors.len > 0 {
 			print_type_errors(pre_tc.errors)
 			exit(1)
+		}
+		if incremental_cache_hit
+			&& incremental_changed_functions_call_generics(a, pre_tc, incremental_changed_names) {
+			os.setenv('V3_CACHE_DISABLE_INCREMENTAL', '1', true)
+			restart_v3_after_cache_invalidation()
 		}
 		pre_tc.prune_inactive_top_level_comptime(mut a)
 		test_harness_errors := validate_test_file_harness_inputs(a, pre_tc, test_files)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1297,6 +1297,20 @@ fn v3_cgen_cache_input(state &V3ModuleCacheState, user_files []string, user_c_fl
 	}
 }
 
+fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAst, prefs &pref.Preferences, user_c_flags []string) bool {
+	mut cache_input_modules := map[string]bool{}
+	for module_name in state.module_sources.keys() {
+		cache_input_modules[module_name] = true
+	}
+	cache_input_modules['main'] = true
+	external_inputs, has_untracked_c_include := cgen.cache_external_input_files(a, prefs.vroot,
+		cache_input_modules, user_c_flags, prefs.target)
+	state.module_external_inputs = external_inputs.clone()
+	native_source_modules, can_scope_static_inputs := cache_external_input_owner_modules(state)
+	state.native_source_modules = native_source_modules.clone()
+	return !has_untracked_c_include && can_scope_static_inputs
+}
+
 fn encode_v3_cgen_metadata(flags []string, interface_impl_signature string) string {
 	mut parts := ['v3-cgen-metadata-v2', interface_impl_signature]
 	parts << flags
@@ -2349,9 +2363,8 @@ fn main() {
 		}
 		exit(1)
 	}
-	// Parsing workers own source buffers and private text tables. Canonicalize
-	// once more after implicit imports/import waves so every surviving payload
-	// uses the compilation table before semantic phases begin.
+	// Parsing workers canonicalize source-backed node text before their buffers
+	// are released. Metadata keys are finalized here before semantic phases begin.
 	p.release_source_storage()
 	diagnostic_root := if is_selfhost {
 		diagnostic_root_for_input(input_file, user_files)
@@ -2362,293 +2375,307 @@ fn main() {
 	b.step_parallel('parse', parse_was_parallel)
 	b.metric_items('parsed .vh files', p.parsed_v_header_files, 'files', '.vh files',
 		p.parsed_v_header_file_paths)
+	println('    ${'parsed .vh lines':-28s} ${source_file_line_count(p.parsed_v_header_file_paths)} lines')
 	b.metric_items('parsed .v files', p.parsed_v_files, 'files', '.v files', p.parsed_v_file_paths)
-	mut parsed_v_lines := 0
-	for path in p.parsed_v_file_paths {
-		source := os.read_file(path) or { continue }
-		if source.len == 0 {
-			continue
-		}
-		parsed_v_lines += source.count('\n')
-		if source[source.len - 1] != `\n` {
-			parsed_v_lines++
-		}
-	}
-	println('    ${'parsed .v lines':-28s} ${parsed_v_lines} lines')
+	println('    ${'parsed .v lines':-28s} ${source_file_line_count(p.parsed_v_file_paths)} lines')
 	b.metric('AST nodes after parse', a.nodes.len, 'nodes')
 	b.metric('AST children after parse', a.children.len, 'edges')
 	b.metric('canonical AST texts', a.text_count(), 'texts')
 	b.metric('persistent worker threads', a.worker_count(), 'threads')
 
+	// An exact whole-program C plan hit already certifies the current user sources,
+	// cached module interfaces, compiler configuration, target, and native inputs.
+	// Validate it immediately after import resolution so an unchanged development
+	// build does not repeat semantic and lowering work whose only consumer is that
+	// cached C plan.
+	mut cgen_cache_entry := modulecache.CgenEntry{}
+	mut cgen_cache_metadata := V3CgenCacheMetadata{}
+	mut cgen_cache_hit := false
+	if backend == 'c' && cache_state.manager.enabled && !cache_state.force_source
+		&& cache_state.parsed_from_source.len == 0 {
+		if !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, user_c_flags) {
+			restart_v3_without_cache()
+		}
+		input := v3_cgen_cache_input(cache_state, user_files, user_c_flags)
+		if entry := cache_state.manager.valid_cgen(input.source_files, input.generation_signature,
+			input.dependency_inputs)
+		{
+			metadata := os.read_file(entry.metadata) or { '' }
+			if decoded := decode_v3_cgen_metadata(metadata) {
+				cgen_cache_entry = entry
+				cgen_cache_metadata = decoded
+				cgen_cache_hit = true
+			}
+		}
+	}
+
 	// Type-collect + check BEFORE transform, so the transformer is type-aware
 	// (like v2: check runs before transform). The transformer reads cached
 	// per-expression types for type-dependent lowering.
 	mut pre_tc := types.TypeChecker.new(a)
-	pre_tc.verbose = prefs.verbose
-	if scope_prealloc_stages {
-		pre_tc.enable_scoped_parallel_workers()
-	}
-	pre_tc.reject_unsupported_generics = is_selfhost
-	set_diagnostic_files(mut pre_tc, user_files)
-	pre_tc.collect(a)
-	pre_tc.diagnose_unknown_calls = true
-	pre_tc.prepare_threads_condition()
-	set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
-	check_was_parallel := pre_tc.check_semantics_opt(!current_no_parallel)
-	if pre_tc.errors.len > 0 {
-		print_type_errors(pre_tc.errors)
-		exit(1)
-	}
-	pre_tc.prune_inactive_top_level_comptime(mut a)
-	test_harness_errors := validate_test_file_harness_inputs(a, pre_tc, test_files)
-	if test_harness_errors.len > 0 {
-		for msg in test_harness_errors {
-			eprintln(msg)
-		}
-		exit(1)
-	}
-	if cache_state.manager.enabled {
-		mut cache_input_modules := map[string]bool{}
-		for module_name in cache_state.module_sources.keys() {
-			cache_input_modules[module_name] = true
-		}
-		cache_input_modules['main'] = true
-		external_inputs, has_untracked_c_include := cgen.cache_external_input_files(a, prefs.vroot,
-			cache_input_modules, user_c_flags, prefs.target)
-		cache_state.module_external_inputs = external_inputs.clone()
-		native_source_modules, can_scope_static_inputs :=
-			cache_external_input_owner_modules(cache_state)
-		if has_untracked_c_include || !can_scope_static_inputs {
-			restart_v3_without_cache()
-		}
-		cache_state.native_source_modules = native_source_modules.clone()
-		for module_name, parsed in cache_state.parsed_from_source {
-			if !parsed {
-				continue
-			}
-			header := modulecache.module_header(a, pre_tc, module_name, prefs.vroot,
-				cache_state.module_import_paths)
-			if header.len > 0 {
-				cache_state.headers[module_name] = header
-			}
-		}
-		if invalidate_changed_cache_dependents(mut cache_state) {
-			restart_v3_after_cache_invalidation()
-		}
-	}
-	pre_tc.prepare_interface_query_indexes()
-	b.step_parallel('check', check_was_parallel)
-	b.metric('functions collected', pre_tc.fn_ret_types.len, 'symbols')
-	b.metric('structs collected', pre_tc.structs.len, 'types')
-	b.metric('canonical semantic types', pre_tc.type_count(), 'types')
-	b.metric('canonical resolved symbols', pre_tc.symbol_count(), 'symbols')
-	type_cache_stats := pre_tc.type_cache_stats()
-	b.metric('type parse cache hits', type_cache_stats.parse_hits, 'lookups')
-	b.metric('type parse cache misses', type_cache_stats.parse_misses, 'lookups')
-	b.metric('C type cache hits', type_cache_stats.c_hits, 'lookups')
-	b.metric('C type cache misses', type_cache_stats.c_misses, 'lookups')
-
-	if backend == 'eval' {
-		$if !skip_eval ? {
-			mut runner := eval.new(prefs)
-			runner.run_files(a) or {
-				eprintln('error: ${err.msg()}')
-				exit(1)
-			}
-			b.step('eval')
-			b.print_report()
-			return
-		}
-	}
-	_ = pre_tc.ierror_impl_names()
-
-	// Mark used functions (dead-code elimination). This is done before transform
-	// so the transformer can skip function bodies that the C backend will prune.
-	mut markused_scope := unsafe { nil }
-	mut markused_tc := &pre_tc
-	if scope_prealloc_markused {
-		markused_scope = prealloc_scope_begin_for_v3()
-		markused_tc = pre_tc.fork_for_parallel_transform(a)
-		markused_tc.enable_scoped_parallel_workers()
-	}
 	mut used_fns := map[string]bool{}
 	mut uses_generics := false
-	if test_files.len > 0 {
-		used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a, markused_tc,
-			test_files)
-	} else {
-		used_fns, uses_generics = markused.mark_used_with_generic_usage(a, markused_tc)
-	}
-	if cache_state.manager.enabled {
-		mut cache_uses_generics := false
-		used_fns, cache_uses_generics = markused.mark_used_for_cache_with_generic_usage(a,
-			markused_tc, test_files, cache_state.source_body_modules)
-		uses_generics = uses_generics || cache_uses_generics
-	}
-	if scope_prealloc_markused {
-		prealloc_scope_leave_for_v3(markused_scope)
-		used_fns = clone_string_bool_map(used_fns)
-		prealloc_scope_free_for_v3(markused_scope)
-	}
-	b.step('markused')
-	b.metric('reachable symbols', used_fns.len, 'symbols')
-
-	// Transform (match lowering, string/in lowering, etc.). Threaded transform is enabled
-	// by default for compatible builds, and `-no-parallel` disables both threaded transform
-	// and cgen.
-	mut transform_was_parallel := false
-	mut transform_errors := []string{}
-	mut transform_texts_canonical := false
-	if !building_v && !cmd_v_build && !uses_generics && ast_contains_sql_expr(a) {
-		uses_generics = true
-	}
-	// Markused distinguishes reachable generic calls/types from generic templates
-	// that merely came along with an imported module (notably sync and rand).
-	mut skip_transform_generics := building_v || cmd_v_build || !uses_generics
-	if scope_prealloc_transform {
-		// Keep the large escaping AST/cache slabs in the compilation arena, while
-		// transformer indexes and per-body temporary state use a stage arena.
-		transform.reserve_parallel_transform_ast(mut a, skip_transform_generics)
-		pre_tc.begin_sparse_transform_node_caches(a.nodes.len)
-		pre_tc.reserve_scoped_transform_metadata(scoped_transform_signature_headroom)
-		base_transform_nodes := a.nodes.len
-		reserved_nodes_cap := a.nodes.cap
-		reserved_children_cap := a.children.cap
-		base_specialized_fns := a.specialized_fn_nodes.len
-		base_type_count := pre_tc.type_count()
-		base_symbol_count := pre_tc.symbol_count()
-		base_text_count := a.text_values.len
-		mut original_signature_names := pre_tc.fn_ret_types.keys()
-		original_signature_names.sort()
-		transform_scope := prealloc_scope_begin_for_v3()
-		mut scoped_owned_base_nodes := []int{}
-		mut retained_transform_regions := []transform.ScopedTransformRegion{}
-		used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_with_used_opt_config_scoped_workers_checked_owned(mut a,
-			&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, true,
-			transform_scope)
-		parse_cache_enabled := pre_tc.type_cache_parse_enabled()
-		prealloc_scope_leave_for_v3(transform_scope)
-		retained_transform_regions = clone_scoped_transform_regions(retained_transform_regions)
-		pre_tc.promote_scoped_transform_interners(base_type_count, base_symbol_count,
-			transform_scope)
-		if a.nodes.cap == reserved_nodes_cap && a.children.cap == reserved_children_cap
-			&& !scoped_value_owned(transform_scope, a.nodes.data)
-			&& !scoped_value_owned(transform_scope, a.children.data) {
-			a.promote_transform_texts_from(base_text_count, transform_scope)
-			if !skip_transform_generics {
-				// Generic lowering can rewrite arbitrary pre-existing nodes. The backing
-				// slabs were reserved outside the stage arena, so scan their small payload
-				// fields and promote only values owned by that arena instead of cloning the
-				// entire AST and permanently retaining both copies.
-				for idx in 0 .. a.nodes.len {
-					canonicalize_scoped_node(mut a, idx, transform_scope)
-				}
-			} else if retained_transform_regions.len > 0 {
-				outer_new_end := retained_transform_regions[0].new_start
-				promote_scoped_ast_nodes(mut a, base_transform_nodes, outer_new_end,
-					scoped_owned_base_nodes, transform_scope)
-				// Late lowering can rewrite nodes that live in a retained worker region
-				// while allocating their replacement text in the outer transform arena.
-				// Publish those strings before releasing that arena; the worker-owned
-				// fields in the same regions are canonicalized below from their own scope.
-				for region in retained_transform_regions {
-					canonicalize_scoped_transform_region_from_scope(mut a, region, transform_scope)
-				}
-				last_worker_end := retained_transform_regions.last().new_end
-				promote_scoped_ast_nodes(mut a, last_worker_end, a.nodes.len, []int{},
-					transform_scope)
-			} else {
-				a.intern_node_texts_from(0)
-				transform_texts_canonical = true
+	mut skip_transform_generics := true
+	mut transform_texts_canonical := cgen_cache_hit
+	if !cgen_cache_hit {
+		pre_tc.verbose = prefs.verbose
+		if scope_prealloc_stages {
+			pre_tc.enable_scoped_parallel_workers()
+		}
+		pre_tc.reject_unsupported_generics = is_selfhost
+		set_diagnostic_files(mut pre_tc, user_files)
+		pre_tc.collect(a)
+		pre_tc.diagnose_unknown_calls = true
+		pre_tc.prepare_threads_condition()
+		set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
+		check_was_parallel := pre_tc.check_semantics_opt(!current_no_parallel)
+		if pre_tc.errors.len > 0 {
+			print_type_errors(pre_tc.errors)
+			exit(1)
+		}
+		pre_tc.prune_inactive_top_level_comptime(mut a)
+		test_harness_errors := validate_test_file_harness_inputs(a, pre_tc, test_files)
+		if test_harness_errors.len > 0 {
+			for msg in test_harness_errors {
+				eprintln(msg)
 			}
+			exit(1)
+		}
+		if cache_state.manager.enabled {
+			if !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, user_c_flags) {
+				restart_v3_without_cache()
+			}
+			for module_name, parsed in cache_state.parsed_from_source {
+				if !parsed {
+					continue
+				}
+				header := modulecache.module_header(a, pre_tc, module_name, prefs.vroot,
+					cache_state.module_import_paths)
+				if header.len > 0 {
+					cache_state.headers[module_name] = header
+				}
+			}
+			if invalidate_changed_cache_dependents(mut cache_state) {
+				restart_v3_after_cache_invalidation()
+			}
+		}
+		pre_tc.prepare_interface_query_indexes()
+		b.step_parallel('check', check_was_parallel)
+		b.metric('functions collected', pre_tc.fn_ret_types.len, 'symbols')
+		b.metric('structs collected', pre_tc.structs.len, 'types')
+		b.metric('canonical semantic types', pre_tc.type_count(), 'types')
+		b.metric('canonical resolved symbols', pre_tc.symbol_count(), 'symbols')
+		type_cache_stats := pre_tc.type_cache_stats()
+		b.metric('type parse cache hits', type_cache_stats.parse_hits, 'lookups')
+		b.metric('type parse cache misses', type_cache_stats.parse_misses, 'lookups')
+		b.metric('C type cache hits', type_cache_stats.c_hits, 'lookups')
+		b.metric('C type cache misses', type_cache_stats.c_misses, 'lookups')
+
+		if backend == 'eval' {
+			$if !skip_eval ? {
+				mut runner := eval.new(prefs)
+				runner.run_files(a) or {
+					eprintln('error: ${err.msg()}')
+					exit(1)
+				}
+				b.step('eval')
+				b.print_report()
+				return
+			}
+		}
+		_ = pre_tc.ierror_impl_names()
+
+		// Mark used functions (dead-code elimination). This is done before transform
+		// so the transformer can skip function bodies that the C backend will prune.
+		mut markused_scope := unsafe { nil }
+		mut markused_tc := &pre_tc
+		if scope_prealloc_markused {
+			markused_scope = prealloc_scope_begin_for_v3()
+			markused_tc = pre_tc.fork_for_parallel_transform(a)
+			markused_tc.enable_scoped_parallel_workers()
+		}
+		if test_files.len > 0 {
+			used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a,
+				markused_tc, test_files)
 		} else {
-			clone_flat_ast_storage(mut a)
-			pre_tc.rebind_ast(a)
+			used_fns, uses_generics = markused.mark_used_with_generic_usage(a, markused_tc)
 		}
-		if a.specialized_fn_nodes.len != base_specialized_fns {
-			a.specialized_fn_nodes = a.specialized_fn_nodes.clone()
+		if cache_state.manager.enabled {
+			mut cache_uses_generics := false
+			used_fns, cache_uses_generics = markused.mark_used_for_cache_with_generic_usage(a,
+				markused_tc, test_files, cache_state.source_body_modules)
+			uses_generics = uses_generics || cache_uses_generics
 		}
-		promote_scoped_checker_node_caches(mut pre_tc, transform_scope, base_transform_nodes)
-		promote_scoped_signatures(mut pre_tc, original_signature_names)
-		used_fns = clone_string_bool_map(used_fns)
-		transform_errors = clone_string_list(transform_errors)
-		pre_tc.set_fresh_type_cache(parse_cache_enabled)
-		prealloc_scope_free_for_v3(transform_scope)
-		if retained_transform_regions.len > 0 {
-			if p.parsed_v_header_files > 0 {
-				// Header-only warm builds are small enough that transform may not
-				// force the pre-reserved flat arrays to grow. Publish their backing
-				// once in the compilation arena before releasing retained helper
-				// arenas; individual node text is promoted below.
+		if scope_prealloc_markused {
+			prealloc_scope_leave_for_v3(markused_scope)
+			used_fns = clone_string_bool_map(used_fns)
+			prealloc_scope_free_for_v3(markused_scope)
+		}
+		b.step('markused')
+		b.metric('reachable symbols', used_fns.len, 'symbols')
+
+		// Transform (match lowering, string/in lowering, etc.). Threaded transform is enabled
+		// by default for compatible builds, and `-no-parallel` disables both threaded transform
+		// and cgen.
+		mut transform_was_parallel := false
+		mut transform_errors := []string{}
+		if !building_v && !cmd_v_build && !uses_generics && ast_contains_sql_expr(a) {
+			uses_generics = true
+		}
+		// Markused distinguishes reachable generic calls/types from generic templates
+		// that merely came along with an imported module (notably sync and rand).
+		skip_transform_generics = building_v || cmd_v_build || !uses_generics
+		if scope_prealloc_transform {
+			// Keep the large escaping AST/cache slabs in the compilation arena, while
+			// transformer indexes and per-body temporary state use a stage arena.
+			transform.reserve_parallel_transform_ast(mut a, skip_transform_generics)
+			pre_tc.begin_sparse_transform_node_caches(a.nodes.len)
+			pre_tc.reserve_scoped_transform_metadata(scoped_transform_signature_headroom)
+			base_transform_nodes := a.nodes.len
+			reserved_nodes_cap := a.nodes.cap
+			reserved_children_cap := a.children.cap
+			base_specialized_fns := a.specialized_fn_nodes.len
+			base_type_count := pre_tc.type_count()
+			base_symbol_count := pre_tc.symbol_count()
+			base_text_count := a.text_values.len
+			mut original_signature_names := pre_tc.fn_ret_types.keys()
+			original_signature_names.sort()
+			transform_scope := prealloc_scope_begin_for_v3()
+			mut scoped_owned_base_nodes := []int{}
+			mut retained_transform_regions := []transform.ScopedTransformRegion{}
+			used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_with_used_opt_config_scoped_workers_checked_owned(mut a,
+				&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, true,
+				transform_scope)
+			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
+			prealloc_scope_leave_for_v3(transform_scope)
+			retained_transform_regions = clone_scoped_transform_regions(retained_transform_regions)
+			pre_tc.promote_scoped_transform_interners(base_type_count, base_symbol_count,
+				transform_scope)
+			if a.nodes.cap == reserved_nodes_cap && a.children.cap == reserved_children_cap
+				&& !scoped_value_owned(transform_scope, a.nodes.data)
+				&& !scoped_value_owned(transform_scope, a.children.data) {
+				a.promote_transform_texts_from(base_text_count, transform_scope)
+				if !skip_transform_generics {
+					// Generic lowering can rewrite arbitrary pre-existing nodes. The backing
+					// slabs were reserved outside the stage arena, so scan their small payload
+					// fields and promote only values owned by that arena instead of cloning the
+					// entire AST and permanently retaining both copies.
+					for idx in 0 .. a.nodes.len {
+						canonicalize_scoped_node(mut a, idx, transform_scope)
+					}
+				} else if retained_transform_regions.len > 0 {
+					outer_new_end := retained_transform_regions[0].new_start
+					promote_scoped_ast_nodes(mut a, base_transform_nodes, outer_new_end,
+						scoped_owned_base_nodes, transform_scope)
+					// Late lowering can rewrite nodes that live in a retained worker region
+					// while allocating their replacement text in the outer transform arena.
+					// Publish those strings before releasing that arena; the worker-owned
+					// fields in the same regions are canonicalized below from their own scope.
+					for region in retained_transform_regions {
+						canonicalize_scoped_transform_region_from_scope(mut a, region,
+							transform_scope)
+					}
+					last_worker_end := retained_transform_regions.last().new_end
+					promote_scoped_ast_nodes(mut a, last_worker_end, a.nodes.len, []int{},
+						transform_scope)
+				} else {
+					a.intern_node_texts_from(0)
+					transform_texts_canonical = true
+				}
+			} else {
 				clone_flat_ast_storage(mut a)
 				pre_tc.rebind_ast(a)
 			}
-			for region in retained_transform_regions {
-				if skip_transform_generics {
-					canonicalize_scoped_transform_region(mut a, region)
-				} else {
-					// Bounded generic batches can publish rewrites to any source node
-					// through this result arena, so verify every flat payload before
-					// releasing it.
-					for idx in 0 .. a.nodes.len {
-						canonicalize_scoped_node(mut a, idx, region.scope)
-					}
-				}
-				if scoped_value_owned(region.scope, a.nodes.data)
-					|| scoped_value_owned(region.scope, a.children.data) {
-					a = clone_flat_ast_after_transform(a)
+			if a.specialized_fn_nodes.len != base_specialized_fns {
+				a.specialized_fn_nodes = a.specialized_fn_nodes.clone()
+			}
+			promote_scoped_checker_node_caches(mut pre_tc, transform_scope, base_transform_nodes)
+			promote_scoped_signatures(mut pre_tc, original_signature_names)
+			used_fns = clone_string_bool_map(used_fns)
+			transform_errors = clone_string_list(transform_errors)
+			pre_tc.set_fresh_type_cache(parse_cache_enabled)
+			prealloc_scope_free_for_v3(transform_scope)
+			if retained_transform_regions.len > 0 {
+				if p.parsed_v_header_files > 0 {
+					// Header-only warm builds are small enough that transform may not
+					// force the pre-reserved flat arrays to grow. Publish their backing
+					// once in the compilation arena before releasing retained helper
+					// arenas; individual node text is promoted below.
+					clone_flat_ast_storage(mut a)
 					pre_tc.rebind_ast(a)
 				}
-				prealloc_scope_free_for_v3(region.scope)
+				for region in retained_transform_regions {
+					if skip_transform_generics {
+						canonicalize_scoped_transform_region(mut a, region)
+					} else {
+						// Bounded generic batches can publish rewrites to any source node
+						// through this result arena, so verify every flat payload before
+						// releasing it.
+						for idx in 0 .. a.nodes.len {
+							canonicalize_scoped_node(mut a, idx, region.scope)
+						}
+					}
+					if scoped_value_owned(region.scope, a.nodes.data)
+						|| scoped_value_owned(region.scope, a.children.data) {
+						a = clone_flat_ast_after_transform(a)
+						pre_tc.rebind_ast(a)
+					}
+					prealloc_scope_free_for_v3(region.scope)
+				}
+				transform_texts_canonical = true
 			}
-			transform_texts_canonical = true
-		}
-	} else {
-		used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,
-			&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, false)
-	}
-	if !building_v && !cmd_v_build && !uses_generics
-		&& transformed_used_fns_need_monomorphize(used_fns) {
-		uses_generics = true
-		skip_transform_generics = false
-	}
-	b.step_parallel('transform', transform_was_parallel)
-	if transform_errors.len > 0 {
-		eprintln('type checker found ${transform_errors.len} error(s):')
-		for message in transform_errors {
-			eprintln(message)
-		}
-		exit(1)
-	}
-	pre_tc.freeze_interface_impl_names()
-	b.metric('AST nodes after transform', a.nodes.len, 'nodes')
-	b.metric('AST children after transform', a.children.len, 'edges')
-
-	// Reuse the pre-transform checker for metadata only. Transform does not add
-	// declarations, and v1/v2 do not run a second semantic checker after lowering.
-	pre_tc.diagnose_unknown_calls = false
-	pre_tc.reject_unlowered_map_mutation = true
-	set_diagnostic_files(mut pre_tc, user_files)
-	set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
-	if !building_v && !cmd_v_build {
-		if uses_generics {
-			if scope_prealloc_stages {
-				// Volt's reachable specialization set settles just below 4x the
-				// transformed node count. Reserving that bounded final size avoids
-				// growing 3x caches to 6x inside the disposable monomorph arena and
-				// then copying those oversized arrays back into the parent.
-				pre_tc.materialize_sparse_transform_node_caches(a.nodes.len, a.nodes.len * 4)
-			}
-			// Generic lowering rewrites and clones call nodes in disposable arenas.
-			// Resolve their final names from the owned transformed AST instead of
-			// retaining pre-transform canonical string views across arena release.
-			pre_tc.reset_resolved_calls_for_reannotation()
-			pre_tc.annotate_types_with_used(used_fns)
 		} else {
-			restore_transformed_fn_value_types(mut pre_tc, a, used_fns)
+			used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,
+				&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, false)
 		}
+		if !building_v && !cmd_v_build && !uses_generics
+			&& transformed_used_fns_need_monomorphize(used_fns) {
+			uses_generics = true
+			skip_transform_generics = false
+		}
+		b.step_parallel('transform', transform_was_parallel)
+		if transform_errors.len > 0 {
+			eprintln('type checker found ${transform_errors.len} error(s):')
+			for message in transform_errors {
+				eprintln(message)
+			}
+			exit(1)
+		}
+		pre_tc.freeze_interface_impl_names()
+		b.metric('AST nodes after transform', a.nodes.len, 'nodes')
+		b.metric('AST children after transform', a.children.len, 'edges')
+
+		// Reuse the pre-transform checker for metadata only. Transform does not add
+		// declarations, and v1/v2 do not run a second semantic checker after lowering.
+		pre_tc.diagnose_unknown_calls = false
+		pre_tc.reject_unlowered_map_mutation = true
+		set_diagnostic_files(mut pre_tc, user_files)
+		set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
+		if !building_v && !cmd_v_build {
+			if uses_generics {
+				if scope_prealloc_stages {
+					// Volt's reachable specialization set settles just below 4x the
+					// transformed node count. Reserving that bounded final size avoids
+					// growing 3x caches to 6x inside the disposable monomorph arena and
+					// then copying those oversized arrays back into the parent.
+					pre_tc.materialize_sparse_transform_node_caches(a.nodes.len, a.nodes.len * 4)
+				}
+				// Generic lowering rewrites and clones call nodes in disposable arenas.
+				// Resolve their final names from the owned transformed AST instead of
+				// retaining pre-transform canonical string views across arena release.
+				pre_tc.reset_resolved_calls_for_reannotation()
+				pre_tc.annotate_types_with_used(used_fns)
+			} else {
+				restore_transformed_fn_value_types(mut pre_tc, a, used_fns)
+			}
+		}
+		b.step('annotate types')
+	} else {
+		b.step('check (cached)')
+		b.step('markused (cached)')
+		b.step('transform (cached)')
+		b.step('annotate types (cached)')
 	}
-	b.step('annotate types')
 	if pre_tc.errors.len > 0 {
 		print_type_errors(pre_tc.errors)
 		exit(1)
@@ -2671,27 +2698,6 @@ fn main() {
 			b.step('wasm gen')
 			b.print_report()
 			return
-		}
-	}
-
-	// A valid whole-program C plan no longer needs the specialized AST that
-	// produced it. Validate it before monomorphization so unchanged cached builds
-	// can skip cloning more than a million generic nodes.
-	mut cgen_cache_entry := modulecache.CgenEntry{}
-	mut cgen_cache_metadata := V3CgenCacheMetadata{}
-	mut cgen_cache_hit := false
-	if backend == 'c' && cache_state.manager.enabled && !cache_state.force_source
-		&& cache_state.parsed_from_source.len == 0 {
-		input := v3_cgen_cache_input(cache_state, user_files, user_c_flags)
-		if entry := cache_state.manager.valid_cgen(input.source_files, input.generation_signature,
-			input.dependency_inputs)
-		{
-			metadata := os.read_file(entry.metadata) or { '' }
-			if decoded := decode_v3_cgen_metadata(metadata) {
-				cgen_cache_entry = entry
-				cgen_cache_metadata = decoded
-				cgen_cache_hit = true
-			}
 		}
 	}
 
@@ -4167,6 +4173,7 @@ mut:
 }
 
 fn seed_implicit_imports(mut a flat.FlatAst) {
+	start := a.nodes.len
 	mut scan := ImplicitImportScan{}
 	scan_implicit_imports(a, a.nodes.len, mut scan)
 	if scan.needs_sync && !scan.has_sync {
@@ -4175,6 +4182,7 @@ fn seed_implicit_imports(mut a flat.FlatAst) {
 	if scan.needs_embed && !scan.has_embed_import {
 		a.add_node(embed_file_import_node())
 	}
+	a.intern_node_texts_from(start)
 }
 
 fn sync_import_node() flat.Node {
@@ -4199,6 +4207,7 @@ fn seed_cached_builtin_bundle_imports(mut a flat.FlatAst, enabled bool, builtin_
 	}
 	// Put cache warm-up imports in a private synthetic file/module scope. Without
 	// these boundaries the checker assigns them to the last parsed user file.
+	start := a.nodes.len
 	a.nodes << flat.Node{
 		kind:  .file
 		value: cache_bundle_import_file(builtin_dir)
@@ -4214,6 +4223,7 @@ fn seed_cached_builtin_bundle_imports(mut a flat.FlatAst, enabled bool, builtin_
 			typ:   import_path.all_after_last('.')
 		}
 	}
+	a.intern_node_texts_from(start)
 }
 
 fn cache_bundle_import_file(builtin_dir string) string {
@@ -4294,7 +4304,7 @@ fn insert_synthetic_imports(mut a flat.FlatAst, insertions []SyntheticInsertion)
 	mut ins_idx := 0
 	for i in 0 .. old_len {
 		for ins_idx < insertions.len && insertions[ins_idx].pos == i {
-			new_nodes << insertions[ins_idx].node
+			new_nodes << canonical_node_texts(mut a, insertions[ins_idx].node)
 			ins_idx++
 		}
 		new_nodes << a.nodes[i]
@@ -4302,7 +4312,7 @@ fn insert_synthetic_imports(mut a flat.FlatAst, insertions []SyntheticInsertion)
 	// Insertions at pos == old_len append at the very end (the last wave module's
 	// region ends at the array tail).
 	for ins_idx < insertions.len {
-		new_nodes << insertions[ins_idx].node
+		new_nodes << canonical_node_texts(mut a, insertions[ins_idx].node)
 		ins_idx++
 	}
 	a.nodes = new_nodes
@@ -4468,7 +4478,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			}
 			if module_identity := parsed_module_identities[mod_name] {
 				if module_identity.len > 0 {
-					a.nodes[node_idx].value = module_identity
+					set_node_value_canonical(mut a, node_idx, module_identity)
 				}
 				record_cache_module_dependency(mut cache_state, cur_module, module_identity)
 				node_idx++
@@ -4505,7 +4515,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 				}
 			}
 			if module_identity.len > 0 {
-				a.nodes[node_idx].value = module_identity
+				set_node_value_canonical(mut a, node_idx, module_identity)
 			}
 			cache_module := if module_identity.len > 0 { module_identity } else { mod_name }
 			record_cache_module_dependency(mut cache_state, cur_module, cache_module)
@@ -4682,11 +4692,39 @@ fn canonicalize_imported_module_name(mut a flat.FlatAst, first_node int, end_nod
 		return
 	}
 	short_name := import_path.all_after_last('.')
+	_, canonical_path := a.intern_text(import_path)
 	for i in first_node .. end_node {
 		if a.nodes[i].kind == .module_decl && a.nodes[i].value == short_name {
-			a.nodes[i].value = import_path
+			a.nodes[i].value = canonical_path
 		}
 	}
+}
+
+fn set_node_value_canonical(mut a flat.FlatAst, idx int, value string) {
+	_, canonical := a.intern_text(value)
+	a.nodes[idx].value = canonical
+}
+
+fn canonical_node_texts(mut a flat.FlatAst, node flat.Node) flat.Node {
+	mut canonical := node
+	_, canonical.value = a.intern_text(node.value)
+	_, canonical.typ = a.intern_text(node.typ)
+	return canonical
+}
+
+fn source_file_line_count(paths []string) int {
+	mut lines := 0
+	for path in paths {
+		source := os.read_file(path) or { continue }
+		if source.len == 0 {
+			continue
+		}
+		lines += source.count('\n')
+		if source[source.len - 1] != `\n` {
+			lines++
+		}
+	}
+	return lines
 }
 
 fn import_module_identity_cached(prefs &pref.Preferences, import_path string, importing_file string, project_root string, import_dir string, mut path_cache map[string]string, mut identity_cache map[string]string) string {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1756,6 +1756,11 @@ fn decode_incremental_manifest(encoded string) ?map[string]string {
 	return signatures
 }
 
+struct V3IncrementalCFunctionSections {
+	sections map[string]string
+	keys     []string
+}
+
 fn incremental_changed_functions(snapshot V3IncrementalSnapshot, old map[string]string) ?([]string, map[string]bool) {
 	if snapshot.functions.len != old.len {
 		return none
@@ -1772,10 +1777,11 @@ fn incremental_changed_functions(snapshot V3IncrementalSnapshot, old map[string]
 	return keys, names
 }
 
-fn incremental_c_function_sections(source string) ?map[string]string {
+fn incremental_c_function_sections(source string) ?V3IncrementalCFunctionSections {
 	begin_prefix := '/* V3CACHE_FN_BEGIN '
 	end_prefix := '/* V3CACHE_FN_END '
 	mut sections := map[string]string{}
+	mut keys := []string{}
 	mut offset := 0
 	for {
 		relative_start := source[offset..].index(begin_prefix) or { break }
@@ -1791,12 +1797,16 @@ fn incremental_c_function_sections(source string) ?map[string]string {
 			end++
 		}
 		sections[key] = source[start..end]
+		keys << key
 		offset = end
 	}
 	if sections.len == 0 {
 		return none
 	}
-	return sections
+	return V3IncrementalCFunctionSections{
+		sections: sections
+		keys:     keys
+	}
 }
 
 fn merge_incremental_program_body(cached_source string, changed_source string, changed_keys []string) ?string {
@@ -1804,8 +1814,8 @@ fn merge_incremental_program_body(cached_source string, changed_source string, c
 	changed_sections := incremental_c_function_sections(changed_source) or { return none }
 	mut merged := cached_source
 	for key in changed_keys {
-		old_section := cached_sections[key] or { return none }
-		new_section := changed_sections[key] or { return none }
+		old_section := cached_sections.sections[key] or { return none }
+		new_section := changed_sections.sections[key] or { return none }
 		merged = merged.replace(old_section, new_section)
 	}
 	support_declarations := incremental_c_support_declarations(changed_source) or { return none }
@@ -1822,13 +1832,28 @@ fn merge_incremental_program_body(cached_source string, changed_source string, c
 			additions.writeln(line)
 		}
 	}
-	new_text := additions.str()
-	if new_text.len == 0 {
-		return merged
-	}
+	declaration_text := additions.str()
 	marker := '/* V3CACHE_BODY_BEGIN */'
 	marker_idx := merged.index(marker) or { return none }
-	return merged[..marker_idx] + new_text + merged[marker_idx..]
+	if declaration_text.len > 0 {
+		merged = merged[..marker_idx] + declaration_text + merged[marker_idx..]
+	}
+	mut new_sections := strings.new_builder(1024)
+	for key in changed_sections.keys {
+		if key !in cached_sections.sections {
+			new_sections.write_string(changed_sections.sections[key])
+		}
+	}
+	new_section_text := new_sections.str()
+	if new_section_text.len == 0 {
+		return merged
+	}
+	body_marker_idx := merged.index(marker) or { return none }
+	mut body_start := body_marker_idx + marker.len
+	if body_start < merged.len && merged[body_start] == `\n` {
+		body_start++
+	}
+	return merged[..body_start] + new_section_text + merged[body_start..]
 }
 
 fn incremental_c_support_declarations(source string) ?string {
@@ -3355,6 +3380,7 @@ fn main() {
 		// and cgen.
 		mut transform_was_parallel := false
 		mut transform_errors := []string{}
+		mut incremental_synthesized_helpers := []string{}
 		if !building_v && !cmd_v_build && !uses_generics && ast_contains_sql_expr(a) {
 			uses_generics = true
 		}
@@ -3373,7 +3399,7 @@ fn main() {
 			transform_used_fns['main'] = true
 		}
 		if incremental_cache_hit {
-			transform_used_fns, transform_errors = transform.transform_selected_functions(mut a,
+			transform_used_fns, transform_errors, incremental_synthesized_helpers = transform.transform_selected_functions(mut a,
 				&pre_tc, incremental_changed_names)
 			transform_texts_canonical = true
 		} else if scope_prealloc_transform {
@@ -3484,6 +3510,12 @@ fn main() {
 			used_fns = clone_string_bool_map(transform_used_fns)
 		} else {
 			incremental_stage_used_fns = clone_string_bool_map(transform_used_fns)
+			// Synthesized helpers have no source snapshot key, so explicitly include
+			// their generated bodies in both incremental Cgen filters.
+			for name in incremental_synthesized_helpers {
+				incremental_stage_used_fns[name] = true
+				incremental_changed_names[name] = true
+			}
 		}
 		if !building_v && !cmd_v_build && !uses_generics
 			&& transformed_used_fns_need_monomorphize(used_fns) {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -510,6 +510,54 @@ fn c_dylib_link_flags(flags []string) []string {
 	return link_flags
 }
 
+fn c_dylib_named_static_archive_inputs(link_flags []string) []string {
+	mut library_dirs := []string{}
+	mut library_names := []string{}
+	mut i := 0
+	for i < link_flags.len {
+		clean := link_flags[i].trim(' \t\r\n"\'')
+		if clean == '-L' {
+			if i + 1 < link_flags.len {
+				library_dirs << link_flags[i + 1].trim(' \t\r\n"\'')
+			}
+			i += 2
+			continue
+		}
+		if clean.starts_with('-L') && clean.len > 2 {
+			library_dirs << clean[2..]
+			i++
+			continue
+		}
+		if clean == '-l' {
+			if i + 1 < link_flags.len {
+				library_names << link_flags[i + 1].trim(' \t\r\n"\'')
+			}
+			i += 2
+			continue
+		}
+		if clean.starts_with('-l') && clean.len > 2 {
+			library_names << clean[2..]
+		}
+		i++
+	}
+	mut archives := map[string]bool{}
+	for name in library_names {
+		archive_name := if name.starts_with(':') { name[1..] } else { 'lib${name}.a' }
+		if archive_name.len == 0 {
+			continue
+		}
+		for dir in library_dirs {
+			candidate := os.join_path(dir, archive_name)
+			if os.is_file(candidate) {
+				archives[os.real_path(candidate)] = true
+			}
+		}
+	}
+	mut result := archives.keys()
+	result.sort()
+	return result
+}
+
 fn tcc_cached_main_flags(flags []string) []string {
 	mut compile_flags := []string{}
 	mut i := 0
@@ -703,7 +751,7 @@ fn compile_v3_dev_dylib(prefix_object string, cached_objects []string, resolved_
 	objects << cached_objects
 	mut hash := u64(1469598103934665603)
 	compiler_path, compiler_version := c_object_compiler_identity(c_compiler, mut stats)
-	for identity in ['v3-cached-dev-dylib-v1', compiler_path, compiler_version, target_args.join('\x00'),
+	for identity in ['v3-cached-dev-dylib-v2', compiler_path, compiler_version, target_args.join('\x00'),
 		link_flags.join('\x00'), target.os, target.arch, target.abi, target.endian, target.pointer_bits.str(),
 		target.object_format] {
 		hash = c_hash_bytes(hash, identity.bytes())
@@ -726,12 +774,16 @@ fn compile_v3_dev_dylib(prefix_object string, cached_objects []string, resolved_
 		}
 	}
 	for flag in link_flags {
-		clean := flag.trim_space()
+		clean := flag.trim(' \t\r\n"\'')
 		if (clean.ends_with('.a') || (c_flag_is_object_file(clean)
 			&& !clean.contains('/v3_thirdparty_objs/'))) && os.is_file(clean) {
 			hash = c_hash_bytes(hash, os.real_path(clean).bytes())
 			hash = c_hash_bytes(hash, c_object_file_signature(clean, true, mut stats).bytes())
 		}
+	}
+	for archive in c_dylib_named_static_archive_inputs(link_flags) {
+		hash = c_hash_bytes(hash, archive.bytes())
+		hash = c_hash_bytes(hash, c_object_file_signature(archive, true, mut stats).bytes())
 	}
 	dylib_path := os.join_path(manager.dir, 'dev_modules_${hash.hex()}.dylib')
 	if os.is_file(dylib_path) {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -132,6 +132,7 @@ mut:
 	temporary_objects         []string
 	compiler_versions         map[string]string
 	file_signatures           map[string]string
+	link_plan_signature       string
 }
 
 struct CObjectDependencies {
@@ -161,6 +162,7 @@ fn prepare_c_flags_for_link(flags []string, c99 bool, pic_flag string, target_ar
 	// object's cache decision remains visible.
 	if os.getenv('V3_CACHE_TRACE') == '' {
 		if plan := valid_c_link_plan(plan_path, mut stats) {
+			stats.link_plan_signature = modulecache.file_signature(plan_path)
 			stats.requests = plan.requests
 			stats.direct_objects = plan.direct_objects
 			stats.content_key_hits = plan.requests - plan.direct_objects
@@ -234,6 +236,7 @@ fn prepare_c_flags_for_link(flags []string, c99 bool, pic_flag string, target_ar
 	}
 	if stats.dependency_scan_fallbacks == 0 && stats.temporary_objects.len == 0 {
 		write_c_link_plan(plan_path, prepared, stats) or {}
+		stats.link_plan_signature = modulecache.file_signature(plan_path)
 	}
 	return prepared
 }
@@ -253,7 +256,7 @@ fn c_link_plan_path(cache_dir string, flags []string, c99 bool, pic_flag string,
 fn valid_c_link_plan(plan_path string, mut stats CObjectCacheStats) ?CLinkPlan {
 	content := os.read_file(plan_path) or { return none }
 	lines := content.split_into_lines()
-	if lines.len < 5 || lines[0] != 'format=v3-c-link-plan-v1' {
+	if lines.len < 5 || lines[0] != 'format=v3-c-link-plan-v2' {
 		return none
 	}
 	mut plan := CLinkPlan{}
@@ -278,15 +281,23 @@ fn valid_c_link_plan(plan_path string, mut stats CObjectCacheStats) ?CLinkPlan {
 			objects << line.all_after('object=')
 		} else if line.starts_with('dependency=') {
 			entry := line.all_after('dependency=')
-			tab := entry.last_index('\t') or { return none }
-			path := entry[..tab]
-			expected_signature := entry[tab + 1..]
+			first_tab := entry.index('\t') or { return none }
+			last_tab := entry.last_index('\t') or { return none }
+			if first_tab == last_tab {
+				return none
+			}
+			path := entry[..first_tab]
+			expected_metadata := entry[first_tab + 1..last_tab]
+			expected_signature := entry[last_tab + 1..]
 			if path.len == 0 || expected_signature.len == 0 {
 				return none
 			}
-			actual_signature := c_object_file_signature(path, false, mut stats)
-			if actual_signature.len == 0 || actual_signature != expected_signature {
-				return none
+			actual_metadata := modulecache.file_metadata_signature(path)
+			if actual_metadata.len == 0 || actual_metadata != expected_metadata {
+				actual_signature := c_object_file_signature(path, false, mut stats)
+				if actual_signature.len == 0 || actual_signature != expected_signature {
+					return none
+				}
 			}
 		} else if line == 'complete=1' {
 			complete = true
@@ -309,7 +320,7 @@ fn valid_c_link_plan(plan_path string, mut stats CObjectCacheStats) ?CLinkPlan {
 
 fn write_c_link_plan(plan_path string, flags []string, stats &CObjectCacheStats) ! {
 	mut out := strings.new_builder(256 + flags.len * 64 + stats.file_signatures.len * 96)
-	out.writeln('format=v3-c-link-plan-v1')
+	out.writeln('format=v3-c-link-plan-v2')
 	out.writeln('requests=${stats.requests}')
 	out.writeln('direct_objects=${stats.direct_objects}')
 	out.writeln('dependency_files=${stats.dependency_files}')
@@ -322,7 +333,8 @@ fn write_c_link_plan(plan_path string, flags []string, stats &CObjectCacheStats)
 	mut dependencies := stats.file_signatures.keys()
 	dependencies.sort()
 	for dependency in dependencies {
-		out.writeln('dependency=${dependency}\t${stats.file_signatures[dependency]}')
+		metadata := modulecache.file_metadata_signature(dependency)
+		out.writeln('dependency=${dependency}\t${metadata}\t${stats.file_signatures[dependency]}')
 	}
 	out.writeln('complete=1')
 	temp_path := '${plan_path}.tmp.${os.getpid()}.${rand.ulid()}'
@@ -598,7 +610,7 @@ fn c_response_file_arg(arg string) string {
 	return '"${arg.replace('\\', '\\\\').replace('"', '\\"')}"'
 }
 
-fn compile_v3_program_prefix(source string, external_inputs []string, manager &modulecache.Manager, c_standard string, opt_flag string, pic_flag string, warning_flags string, generated_c_flags []string, objective_c bool, target_args []string, target pref.Target, c_compiler string, mut stats CObjectCacheStats) !string {
+fn compile_v3_program_prefix(source string, source_identity string, external_inputs []string, manager &modulecache.Manager, c_standard string, opt_flag string, pic_flag string, warning_flags string, generated_c_flags []string, objective_c bool, target_args []string, target pref.Target, c_compiler string, mut stats CObjectCacheStats) !string {
 	mut args := []string{}
 	if objective_c {
 		args << ['-x', 'objective-c']
@@ -616,7 +628,8 @@ fn compile_v3_program_prefix(source string, external_inputs []string, manager &m
 	args << c_object_compile_flags(generated_c_flags).filter(!c_flag_is_object_file(it))
 	compiler_path, compiler_version := c_object_compiler_identity(c_compiler, mut stats)
 	mut hash := u64(1469598103934665603)
-	for identity in ['v3-cached-program-prefix-v1', source, compiler_path, compiler_version,
+	prefix_identity := if source_identity.len > 0 { source_identity } else { source }
+	for identity in ['v3-cached-program-prefix-v2', prefix_identity, compiler_path, compiler_version,
 		args.join('\x00'), target.os, target.arch, target.abi, target.endian, target.pointer_bits.str(),
 		target.object_format] {
 		hash = c_hash_bytes(hash, identity.bytes())
@@ -657,6 +670,24 @@ fn compile_v3_program_prefix(source string, external_inputs []string, manager &m
 		}
 	}
 	return object_path
+}
+
+fn v3_program_prefix_source_identity(plan_stamp string, cached_objects []string) string {
+	if plan_stamp.len == 0 {
+		return ''
+	}
+	mut hash := u64(1469598103934665603)
+	for input in [plan_stamp, modulecache.file_signature(plan_stamp)] {
+		hash = c_hash_bytes(hash, input.bytes())
+		hash = c_hash_bytes(hash, [u8(0xff)])
+	}
+	for object in cached_objects {
+		stamp := '${object}.stamp'
+		input := if os.is_file(stamp) { stamp } else { object }
+		hash = c_hash_bytes(hash, input.bytes())
+		hash = c_hash_bytes(hash, modulecache.file_signature(input).bytes())
+	}
+	return hash.hex()
 }
 
 fn compile_v3_dev_dylib(prefix_object string, cached_objects []string, resolved_c_flags []string, manager &modulecache.Manager, target_args []string, target pref.Target, c_compiler string, build_dir string, mut stats CObjectCacheStats) !string {
@@ -727,6 +758,52 @@ fn compile_v3_dev_dylib(prefix_object string, cached_objects []string, resolved_
 		}
 	}
 	return dylib_path
+}
+
+fn v3_cache_file_identity(path string) string {
+	metadata := modulecache.file_metadata_signature(path)
+	if metadata.len > 0 {
+		return metadata
+	}
+	return modulecache.file_signature(path)
+}
+
+fn v3_cached_tcc_executable_path(manager &modulecache.Manager, source_identity string, link_plan_signature string, tcc_path string, tcc_lib_dir string, tcc_args []string) string {
+	mut hash := u64(1469598103934665603)
+	for identity in ['v3-cached-tcc-executable-v1', source_identity, link_plan_signature,
+		os.real_path(tcc_path), v3_cache_file_identity(tcc_path),
+		tcc_args.join('\x00')] {
+		hash = c_hash_bytes(hash, identity.bytes())
+		hash = c_hash_bytes(hash, [u8(0xff)])
+	}
+	mut inputs := os.walk_ext(tcc_lib_dir, '.h')
+	inputs << os.walk_ext(tcc_lib_dir, '.a')
+	for arg in tcc_args {
+		clean := arg.trim_space()
+		if os.is_file(clean) {
+			inputs << os.real_path(clean)
+		}
+	}
+	inputs.sort()
+	mut previous := ''
+	for input in inputs {
+		if input == previous {
+			continue
+		}
+		previous = input
+		hash = c_hash_bytes(hash, input.bytes())
+		hash = c_hash_bytes(hash, v3_cache_file_identity(input).bytes())
+	}
+	return os.join_path(manager.dir, 'dev_executable_${hash.hex()}')
+}
+
+fn publish_v3_cached_executable(source string, destination string) {
+	tmp := '${destination}.tmp.${os.getpid()}.${rand.ulid()}'
+	defer {
+		os.rm(tmp) or {}
+	}
+	os.cp(source, tmp) or { return }
+	os.mv(tmp, destination) or {}
 }
 
 fn c_flag_token_is_link_only(token string) bool {
@@ -1684,6 +1761,7 @@ fn v3_cache_compiler_signature(vroot string) string {
 		}
 		files << file
 	}
+	files << os.walk_ext(dir, '.h')
 	return modulecache.source_signature(files)
 }
 
@@ -2843,6 +2921,7 @@ fn main() {
 			cc_src = os.join_path_single(cc_dir, 'src.c')
 			cc_out = os.join_path_single(cc_dir, 'out')
 		}
+		mut published_c_source := cc_src
 		cache_plan_file := if cache_state.manager.enabled {
 			os.join_path_single(cc_dir, 'cache_plan.c')
 		} else {
@@ -2954,6 +3033,7 @@ fn main() {
 		}
 		mut cached_objects := []string{}
 		mut cached_dev_dylib := ''
+		mut prefix_source_identity := ''
 		mut tcc_main_file := ''
 		if cache_state.manager.enabled {
 			cache_prepare_scope := prealloc_scope_begin_for_v3()
@@ -2987,11 +3067,7 @@ fn main() {
 					program_prefix_source: prefix_source
 					objects:               objects
 				}
-				os.cp(cgen_prepared_entry.main, cc_src) or {
-					eprintln('error restoring cached main source ${cgen_prepared_entry.main}: ${err.msg()}')
-					cleanup_c_build_dir(cc_dir)
-					exit(1)
-				}
+				published_c_source = cgen_prepared_entry.main
 			} else {
 				generated_source := os.read_file(cache_plan_file) or {
 					eprintln('error reading cache-marked C source ${cache_plan_file}: ${err.msg()}')
@@ -3032,10 +3108,12 @@ fn main() {
 			if use_cached_dev_dylib {
 				tcc_main_file = os.join_path_single(cc_dir, 'main.c')
 				if cgen_prepared_hit {
-					os.cp(cgen_prepared_entry.tcc, tcc_main_file) or {
-						eprintln('error restoring cached TinyCC program unit ${cgen_prepared_entry.tcc}: ${err.msg()}')
-						cleanup_c_build_dir(cc_dir)
-						exit(1)
+					os.link(cgen_prepared_entry.tcc, tcc_main_file) or {
+						os.cp(cgen_prepared_entry.tcc, tcc_main_file) or {
+							eprintln('error restoring cached TinyCC program unit ${cgen_prepared_entry.tcc}: ${err.msg()}')
+							cleanup_c_build_dir(cc_dir)
+							exit(1)
+						}
 					}
 				} else {
 					os.write_file(tcc_main_file, prepared_cache.tcc_main_source) or {
@@ -3044,10 +3122,12 @@ fn main() {
 						exit(1)
 					}
 				}
+				prefix_source_identity = v3_program_prefix_source_identity(prepared_plan_entry.stamp,
+					prepared_cache.objects)
 				prefix_object := compile_v3_program_prefix(prepared_cache.program_prefix_source,
-					v3_program_prefix_external_input_paths(&cache_state), &cache_state.manager,
-					c_standard, opt_flag, pic_flag, warning_flags, resolved_c_flags,
-					needs_objective_c, target_args, prefs.target, c_compiler, mut
+					prefix_source_identity, v3_program_prefix_external_input_paths(&cache_state),
+					&cache_state.manager, c_standard, opt_flag, pic_flag, warning_flags,
+					resolved_c_flags, needs_objective_c, target_args, prefs.target, c_compiler, mut
 					c_object_cache_stats) or {
 					eprintln(err.msg())
 					cleanup_c_build_dir(cc_dir)
@@ -3067,9 +3147,9 @@ fn main() {
 		if use_cached_dev_dylib {
 			b.step('C dylib cache')
 		}
-		b.metric('generated C size', os.file_size(cc_src), 'bytes')
+		b.metric('generated C size', os.file_size(published_c_source), 'bytes')
 		published_c := '${output_file}.tmp.${os.getpid()}.${rand.ulid()}'
-		os.cp(cc_src, published_c) or {
+		os.cp(published_c_source, published_c) or {
 			eprintln('failed to stage generated C output ${output_file}: ${err}')
 			cleanup_c_build_dir(cc_dir)
 			exit(1)
@@ -3089,6 +3169,7 @@ fn main() {
 		// concurrent compilers targeting the same path from sharing partial files.
 		mut result := os.Result{}
 		mut tried_tcc := false
+		mut tcc_cache_hit := false
 		if cached_dev_dylib.len > 0 && tcc_main_file.len > 0 {
 			tried_tcc = true
 			tcc_dir := os.join_path_single(os.join_path_single(prefs.vroot, 'thirdparty'), 'tcc')
@@ -3109,8 +3190,24 @@ fn main() {
 			if '-lm' !in tcc_args {
 				tcc_args << '-lm'
 			}
-			println('  > ${cmdexec.display(tcc_path, tcc_args)}')
-			result = cmdexec.run_in(tcc_path, tcc_args, cc_dir)
+			tcc_cached_executable := v3_cached_tcc_executable_path(&cache_state.manager,
+				prefix_source_identity, c_object_cache_stats.link_plan_signature, tcc_path,
+				tcc_lib_dir, tcc_args)
+			if os.is_file(tcc_cached_executable) {
+				os.cp(tcc_cached_executable, cc_out) or {}
+				tcc_cache_hit = os.is_file(cc_out)
+			}
+			println('  > ${cmdexec.display(tcc_path, tcc_args)}${if tcc_cache_hit {
+				' (cached)'
+			} else {
+				''
+			}}')
+			if !tcc_cache_hit {
+				result = cmdexec.run_in(tcc_path, tcc_args, cc_dir)
+				if result.exit_code == 0 {
+					publish_v3_cached_executable(cc_out, tcc_cached_executable)
+				}
+			}
 		}
 		// Cached module objects can make tcc accept an unresolved call in the
 		// program translation unit and emit a broken executable. Compile and link
@@ -3147,6 +3244,13 @@ fn main() {
 			result = cmdexec.run_in(tcc_path, tcc_args, cc_dir)
 		}
 		if is_prod || !tried_tcc || result.exit_code != 0 {
+			if !os.is_file(cc_src) {
+				os.cp(published_c_source, cc_src) or {
+					eprintln('error restoring cached main source ${published_c_source}: ${err.msg()}')
+					cleanup_c_build_dir(cc_dir)
+					exit(1)
+				}
+			}
 			mut cc_args := []string{}
 			cc_args << target_args
 			if link_c_standard.len > 0 {
@@ -3198,9 +3302,10 @@ fn main() {
 				os.rm(clean) or {}
 			}
 		}
+		os.rm(tcc_main_file) or {}
 		os.rm(cc_src) or {}
 		os.rmdir(cc_dir) or {}
-		b.step('cc')
+		b.step(if tcc_cache_hit { 'cc (cached)' } else { 'cc' })
 		if should_run {
 			run_result := run_binary(bin_file, run_args)
 			if run_result != 0 {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3054,6 +3054,10 @@ fn main() {
 	mut cached_monomorph_specs := []transform.MonomorphCacheSpec{}
 	mut cached_program_used_fns := map[string]bool{}
 	mut generated_monomorph_specs := []transform.MonomorphCacheSpec{}
+	mut cache_c_flags := user_c_flags.clone()
+	if backend == 'c' && cache_state.manager.enabled {
+		cache_c_flags << cgen.cache_pkgconfig_flags(a)
+	}
 	incremental_snapshot := incremental_program_snapshot(a)
 	mut incremental_cache_hit := false
 	mut incremental_changed_keys := []string{}
@@ -3062,10 +3066,10 @@ fn main() {
 	mut incremental_tcc_declarations_path := ''
 	if backend == 'c' && cache_state.manager.enabled && !cache_state.force_source
 		&& cache_state.parsed_from_source.len == 0 {
-		if !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, user_c_flags) {
+		if !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, cache_c_flags) {
 			restart_v3_without_cache()
 		}
-		input := v3_cgen_cache_input(cache_state, user_files, user_c_flags)
+		input := v3_cgen_cache_input(cache_state, user_files, cache_c_flags)
 		if entry := cache_state.manager.valid_cgen(input.source_files, input.generation_signature,
 			input.dependency_inputs)
 		{
@@ -3220,7 +3224,7 @@ fn main() {
 			exit(1)
 		}
 		if cache_state.manager.enabled {
-			if !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, user_c_flags) {
+			if !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, cache_c_flags) {
 				restart_v3_without_cache()
 			}
 			for module_name, parsed in cache_state.parsed_from_source {
@@ -3953,7 +3957,7 @@ fn main() {
 				}
 				if !cgen_cache_hit {
 					published_cgen_cache_input := v3_cgen_cache_input(cache_state, user_files,
-						user_c_flags)
+						cache_c_flags)
 					prepared_plan_entry = cache_state.manager.write_cgen(published_cgen_cache_input.source_files,
 						published_cgen_cache_input.generation_signature,
 						published_cgen_cache_input.dependency_inputs, generated_source, encode_v3_cgen_metadata(generated_c_flags,

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1626,6 +1626,7 @@ fn incremental_top_level_nodes(a &flat.FlatAst) []bool {
 
 fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 	mut declaration_parts := []string{}
+	mut synthetic_main_parts := []string{}
 	mut functions := []V3IncrementalFn{}
 	mut cur_file := ''
 	mut cur_module := ''
@@ -1674,7 +1675,7 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 			}
 			else {
 				if top_level_nodes[idx] {
-					declaration_parts << 'synthetic-main\t${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
+					synthetic_main_parts << 'synthetic-main\t${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
 						flat.NodeId(idx))}'
 				}
 			}
@@ -1683,6 +1684,11 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 	declaration_parts.sort()
 	mut declaration_hash := u64(1469598103934665603)
 	for part in declaration_parts {
+		declaration_hash = c_hash_bytes(declaration_hash, part.bytes())
+		declaration_hash = c_hash_bytes(declaration_hash, [u8(0xff)])
+	}
+	declaration_hash = c_hash_bytes(declaration_hash, 'ordered-synthetic-main'.bytes())
+	for part in synthetic_main_parts {
 		declaration_hash = c_hash_bytes(declaration_hash, part.bytes())
 		declaration_hash = c_hash_bytes(declaration_hash, [u8(0xff)])
 	}
@@ -1770,11 +1776,15 @@ fn merge_incremental_program_body(cached_source string, changed_source string, c
 		new_section := changed_sections[key] or { return none }
 		merged = merged.replace(old_section, new_section)
 	}
+	support_declarations := incremental_c_support_declarations(changed_source) or { return none }
 	new_definitions := modulecache.static_string_definitions(changed_source)
-	if new_definitions.len == 0 {
-		return merged
+	mut additions := strings.new_builder(support_declarations.len + new_definitions.len)
+	if support_declarations.trim_space().len > 0 {
+		additions.write_string(support_declarations)
+		if !support_declarations.ends_with('\n') {
+			additions.writeln('')
+		}
 	}
-	mut additions := strings.new_builder(new_definitions.len)
 	for line in new_definitions.split_into_lines() {
 		if line.len > 0 && !merged.contains(line) {
 			additions.writeln(line)
@@ -1787,6 +1797,15 @@ fn merge_incremental_program_body(cached_source string, changed_source string, c
 	marker := '/* V3CACHE_BODY_BEGIN */'
 	marker_idx := merged.index(marker) or { return none }
 	return merged[..marker_idx] + new_text + merged[marker_idx..]
+}
+
+fn incremental_c_support_declarations(source string) ?string {
+	begin_marker := '/* V3CACHE_SUPPORT_BEGIN */'
+	end_marker := '/* V3CACHE_SUPPORT_END */'
+	begin := source.index(begin_marker) or { return none }
+	content_start := begin + begin_marker.len
+	relative_end := source[content_start..].index(end_marker) or { return none }
+	return source[content_start..content_start + relative_end]
 }
 
 fn incremental_static_string_markers(source string) string {
@@ -3691,6 +3710,15 @@ fn main() {
 		mut generated_c_flags := cgen_cache_metadata.flags.clone()
 		mut interface_impl_signature := cgen_cache_metadata.interface_impl_signature
 		mut cgen_was_parallel := false
+		incremental_c_declarations := if incremental_cache_hit {
+			os.read_file(incremental_tcc_declarations_path) or {
+				eprintln('error reading incremental C declarations ${incremental_tcc_declarations_path}: ${err.msg()}')
+				cleanup_c_build_dir(cc_dir)
+				exit(1)
+			}
+		} else {
+			''
+		}
 		cgen_used_fns := if incremental_cache_hit {
 			incremental_stage_used_fns
 		} else {
@@ -3717,6 +3745,7 @@ fn main() {
 			g.set_program_body_only(generic_cache_hit)
 			g.set_cache_program_files(user_files)
 			g.set_incremental_fn_names(incremental_changed_names)
+			g.set_cached_support_declarations(incremental_c_declarations)
 			g.set_scope_parallel_workers(!generic_cache_hit)
 			generated_path := if cache_state.manager.enabled { cache_plan_file } else { cc_src }
 			g.gen_to_file_with_used_test_options(generated_path, a, cgen_used_fns, &pre_tc,
@@ -3750,6 +3779,7 @@ fn main() {
 			g.set_program_body_only(generic_cache_hit)
 			g.set_cache_program_files(user_files)
 			g.set_incremental_fn_names(incremental_changed_names)
+			g.set_cached_support_declarations(incremental_c_declarations)
 			generated_path := if cache_state.manager.enabled { cache_plan_file } else { cc_src }
 			g.gen_to_file_with_used_test_options(generated_path, a, cgen_used_fns, &pre_tc,
 				cache_no_parallel_cgen, test_files) or {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -74,11 +74,16 @@ mut:
 }
 
 struct V3PreparedModuleCache {
-	main_source           string
-	tcc_main_source       string
-	program_prefix_source string
-	objects               []string
-	newly_cached_modules  int
+mut:
+	main_source              string
+	tcc_main_source          string
+	main_body                string
+	program_body_cache       string
+	program_prefix_source    string
+	program_declarations     string
+	tcc_program_declarations string
+	objects                  []string
+	newly_cached_modules     int
 }
 
 struct V3CgenCacheInput {
@@ -89,6 +94,7 @@ struct V3CgenCacheInput {
 
 struct V3CgenCacheMetadata {
 	interface_impl_signature string
+	prefix_source_identity   string
 	flags                    []string
 }
 
@@ -645,6 +651,9 @@ fn compile_v3_program_prefix(source string, source_identity string, external_inp
 	if os.is_file(object_path) {
 		return object_path
 	}
+	if source.len == 0 {
+		return error('cached program prefix object is unavailable')
+	}
 	unique := '${os.getpid()}.${rand.ulid()}'
 	tmp_source := '${source_path}.tmp.${unique}'
 	tmp_object := '${object_path}.tmp.${unique}'
@@ -672,15 +681,13 @@ fn compile_v3_program_prefix(source string, source_identity string, external_inp
 	return object_path
 }
 
-fn v3_program_prefix_source_identity(plan_stamp string, cached_objects []string) string {
-	if plan_stamp.len == 0 {
+fn v3_program_prefix_source_identity(prefix_source string, cached_objects []string) string {
+	if prefix_source.len == 0 {
 		return ''
 	}
 	mut hash := u64(1469598103934665603)
-	for input in [plan_stamp, modulecache.file_signature(plan_stamp)] {
-		hash = c_hash_bytes(hash, input.bytes())
-		hash = c_hash_bytes(hash, [u8(0xff)])
-	}
+	hash = c_hash_bytes(hash, prefix_source.bytes())
+	hash = c_hash_bytes(hash, [u8(0xff)])
 	for object in cached_objects {
 		stamp := '${object}.stamp'
 		input := if os.is_file(stamp) { stamp } else { object }
@@ -1296,7 +1303,7 @@ fn should_scope_prealloc_cgen() bool {
 }
 
 fn should_parallel_monomorphize() bool {
-	return false
+	return os.getenv('V3_DISABLE_PARALLEL_MONOMORPHIZE') != '1'
 }
 
 fn ownership_checker_compiled() bool {
@@ -1388,21 +1395,595 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 	return !has_untracked_c_include && can_scope_static_inputs
 }
 
-fn encode_v3_cgen_metadata(flags []string, interface_impl_signature string) string {
-	mut parts := ['v3-cgen-metadata-v2', interface_impl_signature]
+fn encode_v3_cgen_metadata(flags []string, interface_impl_signature string, prefix_source_identity string) string {
+	mut parts := ['v3-cgen-metadata-v3', interface_impl_signature, prefix_source_identity]
 	parts << flags
 	return parts.join('\x00')
 }
 
 fn decode_v3_cgen_metadata(metadata string) ?V3CgenCacheMetadata {
 	parts := metadata.split('\x00')
-	if parts.len < 2 || parts[0] != 'v3-cgen-metadata-v2' {
+	if parts.len < 3 || parts[0] != 'v3-cgen-metadata-v3' {
 		return none
 	}
 	return V3CgenCacheMetadata{
 		interface_impl_signature: parts[1]
-		flags:                    parts[2..].clone()
+		prefix_source_identity:   parts[2]
+		flags:                    parts[3..].clone()
 	}
+}
+
+fn cacheable_runtime_string_nodes(a &flat.FlatAst) []bool {
+	mut cacheable := []bool{len: a.nodes.len}
+	mut stack := []flat.NodeId{cap: 256}
+	mut blocked := []bool{cap: 256}
+	for idx, node in a.nodes {
+		if node.kind !in [.fn_decl, .c_fn_decl] {
+			continue
+		}
+		stack.clear()
+		blocked.clear()
+		stack << flat.NodeId(idx)
+		blocked << false
+		for stack.len > 0 {
+			id := stack.pop()
+			parent_blocked := blocked.pop()
+			node_idx := int(id)
+			if node_idx < 0 || node_idx >= a.nodes.len {
+				continue
+			}
+			current := a.nodes[node_idx]
+			current_blocked := parent_blocked
+				|| current.kind in [.comptime_if, .comptime_for, .directive, .asm_stmt, .sql_expr]
+				|| (current.kind == .call && (current.value.starts_with('$')
+				|| current.value in ['embed_file', 'tmpl', 'env', 'd', 'res', 'pkgconfig', 'compile_error', 'compile_warn']))
+			if current.kind == .string_literal && !current_blocked {
+				cacheable[node_idx] = true
+			}
+			for child_idx in 0 .. current.children_count {
+				stack << a.child(&current, child_idx)
+				blocked << current_blocked
+			}
+		}
+	}
+	return cacheable
+}
+
+fn monomorph_cache_runtime_strings(a &flat.FlatAst) []string {
+	cacheable := cacheable_runtime_string_nodes(a)
+	mut values := []string{}
+	for idx, can_cache in cacheable {
+		if can_cache {
+			values << a.nodes[idx].value
+		}
+	}
+	return values
+}
+
+fn monomorph_cache_semantic_signature(a &flat.FlatAst) string {
+	cacheable_strings := cacheable_runtime_string_nodes(a)
+	mut hash := u64(1469598103934665603)
+	for idx, node in a.nodes {
+		hash = c_hash_bytes(hash, [u8(node.kind), u8(node.op), u8(node.is_mut),
+			u8(node.skip_ownership_drops)])
+		hash = c_hash_tag(hash, node.children_start)
+		hash = c_hash_tag(hash, node.children_count)
+		hash = c_hash_bytes(hash, node.typ.bytes())
+		hash = c_hash_bytes(hash, [u8(0)])
+		if !cacheable_strings[idx] {
+			hash = c_hash_bytes(hash, node.value.bytes())
+		}
+		hash = c_hash_bytes(hash, [u8(0xff)])
+		for param in node.generic_params() {
+			hash = c_hash_bytes(hash, param.bytes())
+			hash = c_hash_bytes(hash, [u8(0xfe)])
+		}
+	}
+	hash = c_hash_tag(hash, a.user_code_start)
+	for child in a.children {
+		hash = c_hash_tag(hash, int(child))
+	}
+	mut disabled_names := a.disabled_fns.keys()
+	disabled_names.sort()
+	for name in disabled_names {
+		hash = c_hash_bytes(hash, name.bytes())
+		hash = c_hash_bytes(hash, [u8(a.disabled_fns[name]), u8(0xfd)])
+	}
+	mut export_names := a.export_fn_names.keys()
+	export_names.sort()
+	for name in export_names {
+		hash = c_hash_bytes(hash, name.bytes())
+		hash = c_hash_bytes(hash, [u8(0xfc)])
+		hash = c_hash_bytes(hash, a.export_fn_names[name].bytes())
+		hash = c_hash_bytes(hash, [u8(0xfb)])
+	}
+	mut noreturn_names := a.noreturn_fns.keys()
+	noreturn_names.sort()
+	for name in noreturn_names {
+		hash = c_hash_bytes(hash, name.bytes())
+		hash = c_hash_bytes(hash, [u8(a.noreturn_fns[name]), u8(0xfa)])
+	}
+	return hash.hex()
+}
+
+@[inline]
+fn c_hash_tag(initial u64, value int) u64 {
+	mut hash := initial
+	mut bits := u64(value)
+	for _ in 0 .. 8 {
+		hash = (hash ^ (bits & 0xff)) * u64(1099511628211)
+		bits >>= 8
+	}
+	return hash
+}
+
+struct V3IncrementalFn {
+	key       string
+	name      string
+	signature string
+}
+
+struct V3IncrementalSnapshot {
+	declaration_signature string
+	functions             []V3IncrementalFn
+}
+
+fn incremental_cache_fn_key(file string, module_name string, name string) string {
+	mut hash := u64(1469598103934665603)
+	for part in [file, module_name, name] {
+		hash = c_hash_bytes(hash, part.bytes())
+		hash = c_hash_bytes(hash, [u8(0xff)])
+	}
+	return hash.hex()
+}
+
+fn incremental_qualified_fn_name(module_name string, name string) string {
+	if module_name in ['', 'main', 'builtin'] {
+		return name
+	}
+	return '${module_name}.${name}'
+}
+
+fn incremental_hash_node_header(initial u64, node &flat.Node, include_value bool) u64 {
+	mut hash := c_hash_bytes(initial, [u8(node.kind), u8(node.op), u8(node.is_mut),
+		u8(node.skip_ownership_drops)])
+	hash = c_hash_tag(hash, node.children_count)
+	hash = c_hash_bytes(hash, node.typ.bytes())
+	hash = c_hash_bytes(hash, [u8(0)])
+	if include_value {
+		hash = c_hash_bytes(hash, node.value.bytes())
+	}
+	hash = c_hash_bytes(hash, [u8(0xff)])
+	for param in node.generic_params() {
+		hash = c_hash_bytes(hash, param.bytes())
+		hash = c_hash_bytes(hash, [u8(0xfe)])
+	}
+	return hash
+}
+
+fn incremental_hash_fn_declaration(initial u64, node &flat.Node) u64 {
+	mut hash := c_hash_bytes(initial, [u8(node.kind), u8(node.op), u8(node.is_mut),
+		u8(node.skip_ownership_drops)])
+	hash = c_hash_bytes(hash, node.typ.bytes())
+	hash = c_hash_bytes(hash, [u8(0)])
+	hash = c_hash_bytes(hash, node.value.bytes())
+	hash = c_hash_bytes(hash, [u8(0xff)])
+	for param in node.generic_params() {
+		hash = c_hash_bytes(hash, param.bytes())
+		hash = c_hash_bytes(hash, [u8(0xfe)])
+	}
+	return hash
+}
+
+fn incremental_node_tree_signature(a &flat.FlatAst, root flat.NodeId) string {
+	mut hash := u64(1469598103934665603)
+	mut stack := [root]
+	for stack.len > 0 {
+		id := stack.pop()
+		idx := int(id)
+		if idx < 0 || idx >= a.nodes.len {
+			hash = c_hash_tag(hash, -1)
+			continue
+		}
+		node := &a.nodes[idx]
+		hash = incremental_hash_node_header(hash, node, true)
+		for child_idx := node.children_count - 1; child_idx >= 0; child_idx-- {
+			stack << a.child(node, child_idx)
+		}
+	}
+	return hash.hex()
+}
+
+fn incremental_top_level_nodes(a &flat.FlatAst) []bool {
+	mut result := []bool{len: a.nodes.len}
+	for node in a.nodes {
+		if node.kind != .file {
+			continue
+		}
+		for child_idx in 0 .. node.children_count {
+			id := int(a.child(&node, child_idx))
+			if id >= 0 && id < result.len {
+				result[id] = true
+			}
+		}
+	}
+	return result
+}
+
+fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
+	mut declaration_parts := []string{}
+	mut functions := []V3IncrementalFn{}
+	mut cur_file := ''
+	mut cur_module := ''
+	top_level_nodes := incremental_top_level_nodes(a)
+	for idx, node in a.nodes {
+		match node.kind {
+			.file {
+				cur_file = node.value
+				cur_module = ''
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.fn_decl {
+				key := incremental_cache_fn_key(cur_file, cur_module, node.value)
+				functions << V3IncrementalFn{
+					key:       key
+					name:      incremental_qualified_fn_name(cur_module, node.value)
+					signature: incremental_node_tree_signature(a, flat.NodeId(idx))
+				}
+				mut declaration := strings.new_builder(128)
+				declaration.write_string('fn\t${cur_file}\t${cur_module}\t')
+				declaration.write_string(incremental_hash_fn_declaration(u64(1469598103934665603),
+					&node).hex())
+				for child_idx in 0 .. node.children_count {
+					child_id := a.child(&node, child_idx)
+					child := a.nodes[int(child_id)]
+					if child.kind == .param {
+						declaration.write_u8(`\t`)
+						declaration.write_string(incremental_hash_node_header(u64(1469598103934665603),
+							&child, true).hex())
+					}
+				}
+				declaration_parts << declaration.str()
+			}
+			.struct_decl, .global_decl, .const_decl, .enum_decl, .type_decl, .interface_decl,
+			.import_decl, .c_fn_decl {
+				declaration_parts << '${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
+					flat.NodeId(idx))}'
+			}
+			.directive, .comptime_if, .comptime_for, .asm_stmt, .sql_expr, .fn_literal {
+				if top_level_nodes[idx] {
+					declaration_parts << '${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
+						flat.NodeId(idx))}'
+				}
+			}
+			else {}
+		}
+	}
+	declaration_parts.sort()
+	mut declaration_hash := u64(1469598103934665603)
+	for part in declaration_parts {
+		declaration_hash = c_hash_bytes(declaration_hash, part.bytes())
+		declaration_hash = c_hash_bytes(declaration_hash, [u8(0xff)])
+	}
+	return V3IncrementalSnapshot{
+		declaration_signature: declaration_hash.hex()
+		functions:             functions
+	}
+}
+
+fn encode_incremental_manifest(snapshot V3IncrementalSnapshot) string {
+	mut lines := []string{cap: snapshot.functions.len + 1}
+	lines << 'v3-incremental-functions-v1'
+	for function in snapshot.functions {
+		lines << '${function.key}\t${function.signature}\t${function.name}'
+	}
+	return lines.join('\n')
+}
+
+fn decode_incremental_manifest(encoded string) ?map[string]string {
+	lines := encoded.split_into_lines()
+	if lines.len == 0 || lines[0] != 'v3-incremental-functions-v1' {
+		return none
+	}
+	mut signatures := map[string]string{}
+	for line in lines[1..] {
+		parts := line.split('\t')
+		if parts.len != 3 || parts[0].len == 0 || parts[1].len == 0 {
+			return none
+		}
+		signatures[parts[0]] = parts[1]
+	}
+	return signatures
+}
+
+fn incremental_changed_functions(snapshot V3IncrementalSnapshot, old map[string]string) ?([]string, map[string]bool) {
+	if snapshot.functions.len != old.len {
+		return none
+	}
+	mut keys := []string{}
+	mut names := map[string]bool{}
+	for function in snapshot.functions {
+		old_signature := old[function.key] or { return none }
+		if old_signature != function.signature {
+			keys << function.key
+			names[function.name] = true
+		}
+	}
+	return keys, names
+}
+
+fn incremental_c_function_sections(source string) ?map[string]string {
+	begin_prefix := '/* V3CACHE_FN_BEGIN '
+	end_prefix := '/* V3CACHE_FN_END '
+	mut sections := map[string]string{}
+	mut offset := 0
+	for {
+		relative_start := source[offset..].index(begin_prefix) or { break }
+		start := offset + relative_start
+		key_start := start + begin_prefix.len
+		key_end_relative := source[key_start..].index(' */') or { return none }
+		key_end := key_start + key_end_relative
+		key := source[key_start..key_end]
+		end_marker := '${end_prefix}${key} */'
+		end_relative := source[key_end..].index(end_marker) or { return none }
+		mut end := key_end + end_relative + end_marker.len
+		if end < source.len && source[end] == `\n` {
+			end++
+		}
+		sections[key] = source[start..end]
+		offset = end
+	}
+	if sections.len == 0 {
+		return none
+	}
+	return sections
+}
+
+fn merge_incremental_program_body(cached_source string, changed_source string, changed_keys []string) ?string {
+	cached_sections := incremental_c_function_sections(cached_source) or { return none }
+	changed_sections := incremental_c_function_sections(changed_source) or { return none }
+	mut merged := cached_source
+	for key in changed_keys {
+		old_section := cached_sections[key] or { return none }
+		new_section := changed_sections[key] or { return none }
+		merged = merged.replace(old_section, new_section)
+	}
+	new_definitions := modulecache.static_string_definitions(changed_source)
+	if new_definitions.len == 0 {
+		return merged
+	}
+	mut additions := strings.new_builder(new_definitions.len)
+	for line in new_definitions.split_into_lines() {
+		if line.len > 0 && !merged.contains(line) {
+			additions.writeln(line)
+		}
+	}
+	new_text := additions.str()
+	if new_text.len == 0 {
+		return merged
+	}
+	marker := '/* V3CACHE_BODY_BEGIN */'
+	marker_idx := merged.index(marker) or { return none }
+	return merged[..marker_idx] + new_text + merged[marker_idx..]
+}
+
+fn incremental_static_string_markers(source string) string {
+	definitions := modulecache.static_string_definitions(source)
+	mut out := strings.new_builder(definitions.len + 256)
+	for line in definitions.split_into_lines() {
+		if line.len > 0 {
+			out.writeln('// V3CACHE_BASELINE ${line}')
+		}
+	}
+	return out.str()
+}
+
+fn encode_cached_runtime_strings(values []string) string {
+	mut out := strings.new_builder(values.len * 16)
+	out.write_string('v3-runtime-strings-v1\n')
+	for value in values {
+		out.write_string(value.len.str())
+		out.write_u8(`:`)
+		out.write_string(value)
+	}
+	return out.str()
+}
+
+fn decode_cached_runtime_strings(encoded string) ?[]string {
+	header := 'v3-runtime-strings-v1\n'
+	if !encoded.starts_with(header) {
+		return none
+	}
+	mut values := []string{}
+	mut i := header.len
+	for i < encoded.len {
+		start := i
+		for i < encoded.len && encoded[i] >= `0` && encoded[i] <= `9` {
+			i++
+		}
+		if i == start || i >= encoded.len || encoded[i] != `:` {
+			return none
+		}
+		size := encoded[start..i].int()
+		i++
+		if size < 0 || i + size > encoded.len {
+			return none
+		}
+		values << encoded[i..i + size]
+		i += size
+	}
+	return values
+}
+
+fn cached_c_string_symbol(value string) string {
+	mut hash := u64(1469598103934665603)
+	for c in value.bytes() {
+		hash = (hash ^ u64(c)) * u64(1099511628211)
+	}
+	return '_v3_lit_${value.len}_${hash.hex()}'
+}
+
+fn cached_c_escape(value string) string {
+	mut out := strings.new_builder(value.len * 2)
+	for b in value.bytes() {
+		match b {
+			`\\` {
+				out.write_string('\\\\')
+			}
+			`"` {
+				out.write_string('\\"')
+			}
+			`\n` {
+				out.write_string('\\n')
+			}
+			`\t` {
+				out.write_string('\\t')
+			}
+			`\r` {
+				out.write_string('\\r')
+			}
+			else {
+				if b < 32 || b == 127 {
+					out.write_u8(`\\`)
+					out.write_u8(u8(`0` + ((b >> 6) & 7)))
+					out.write_u8(u8(`0` + ((b >> 3) & 7)))
+					out.write_u8(u8(`0` + (b & 7)))
+				} else {
+					out.write_u8(b)
+				}
+			}
+		}
+	}
+	return out.str()
+}
+
+fn rewrite_cached_runtime_strings(cached_source string, old_values []string, new_values []string) ?string {
+	if old_values.len != new_values.len {
+		return none
+	}
+	mut replacements := map[string]string{}
+	for idx, old_value in old_values {
+		new_value := new_values[idx]
+		if old_value == new_value {
+			continue
+		}
+		if existing := replacements[old_value] {
+			if existing != new_value {
+				return none
+			}
+		} else {
+			replacements[old_value] = new_value
+		}
+	}
+	if replacements.len == 0 {
+		return cached_source.clone()
+	}
+	mut source := cached_source
+	mut definitions := []string{}
+	mut replacement_values := replacements.keys()
+	replacement_values.sort()
+	mut defined_symbols := map[string]bool{}
+	for old_value in replacement_values {
+		new_value := replacements[old_value]
+		old_symbol := cached_c_string_symbol(old_value)
+		if !source.contains(old_symbol) {
+			continue
+		}
+		new_symbol := cached_c_string_symbol(new_value)
+		old_definition := 'static string ${old_symbol} = {"${cached_c_escape(old_value)}", ${old_value.len}, 1};'
+		new_definition := 'static string ${new_symbol} = {"${cached_c_escape(new_value)}", ${new_value.len}, 1};'
+		if source.contains(old_definition) {
+			if source.contains(new_definition) || defined_symbols[new_symbol] {
+				source = source.replace('${old_definition}\n', '').replace(old_definition, '')
+			} else {
+				source = source.replace(old_definition, new_definition)
+				defined_symbols[new_symbol] = true
+			}
+		}
+		source = source.replace(old_symbol, new_symbol)
+		if !source.contains('static string ${new_symbol} =') && !defined_symbols[new_symbol] {
+			definitions << new_definition
+			defined_symbols[new_symbol] = true
+		}
+	}
+	if definitions.len == 0 {
+		return source
+	}
+	marker := '/* V3CACHE_BODY_BEGIN */'
+	marker_idx := source.index(marker) or { return none }
+	return source[..marker_idx] + definitions.join('\n') + '\n' + source[marker_idx..]
+}
+
+fn encode_monomorph_cache_specs(specs []transform.MonomorphCacheSpec) string {
+	mut lines := []string{cap: specs.len + 1}
+	lines << 'v3-monomorph-specs-v1'
+	for spec in specs {
+		if spec.module in ['', 'main'] {
+			continue
+		}
+		lines << '${spec.decl_key}\t${spec.module}\t${spec.args.join('\x1f')}'
+	}
+	return lines.join('\n')
+}
+
+fn decode_monomorph_cache_specs(encoded string) []transform.MonomorphCacheSpec {
+	lines := encoded.split_into_lines()
+	if lines.len == 0 || lines[0] != 'v3-monomorph-specs-v1' {
+		return []transform.MonomorphCacheSpec{}
+	}
+	mut specs := []transform.MonomorphCacheSpec{cap: lines.len - 1}
+	for line in lines[1..] {
+		parts := line.split('\t')
+		if parts.len != 3 || parts[0].len == 0 || parts[1].len == 0 {
+			continue
+		}
+		raw_args := if parts[2].len == 0 { []string{} } else { parts[2].split('\x1f') }
+		specs << transform.MonomorphCacheSpec{
+			decl_key: parts[0].clone()
+			module:   parts[1].clone()
+			args:     clone_string_list(raw_args)
+		}
+	}
+	return specs
+}
+
+fn encode_cached_used_fns(used map[string]bool) string {
+	mut names := []string{cap: used.len}
+	for name, is_used in used {
+		if is_used && name.len > 0 {
+			names << name
+		}
+	}
+	names.sort()
+	return 'v3-used-fns-v1\n' + names.join('\n')
+}
+
+fn decode_cached_used_fns(encoded string) map[string]bool {
+	lines := encoded.split_into_lines()
+	mut used := map[string]bool{}
+	if lines.len == 0 || lines[0] != 'v3-used-fns-v1' {
+		return used
+	}
+	for name in lines[1..] {
+		if name.len > 0 {
+			used[name] = true
+		}
+	}
+	return used
+}
+
+fn clone_monomorph_cache_specs(specs []transform.MonomorphCacheSpec) []transform.MonomorphCacheSpec {
+	mut cloned := []transform.MonomorphCacheSpec{cap: specs.len}
+	for spec in specs {
+		cloned << transform.MonomorphCacheSpec{
+			decl_key: spec.decl_key.clone()
+			module:   spec.module.clone()
+			args:     clone_string_list(spec.args)
+		}
+	}
+	return cloned
 }
 
 // clone_string_bool_map promotes a string-keyed set out of a disposable stage arena.
@@ -2471,6 +3052,21 @@ fn main() {
 	mut cgen_cache_hit := false
 	mut cgen_prepared_entry := modulecache.CgenPreparedEntry{}
 	mut cgen_prepared_hit := false
+	mut generic_cache_input := V3CgenCacheInput{}
+	mut generic_cache_entry := modulecache.GenericProgramEntry{}
+	mut generic_cache_hit := false
+	mut generic_cache_signature := ''
+	mut generic_cache_runtime_strings := []string{}
+	mut cached_monomorph_specs := []transform.MonomorphCacheSpec{}
+	mut cached_program_used_fns := map[string]bool{}
+	mut generated_monomorph_specs := []transform.MonomorphCacheSpec{}
+	incremental_snapshot := incremental_program_snapshot(a)
+	mut incremental_cache_hit := false
+	mut incremental_changed_keys := []string{}
+	mut incremental_changed_names := map[string]bool{}
+	mut incremental_cached_body := ''
+	mut incremental_tcc_declarations_path := ''
+	mut incremental_cached_objects := []string{}
 	if backend == 'c' && cache_state.manager.enabled && !cache_state.force_source
 		&& cache_state.parsed_from_source.len == 0 {
 		if !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, user_c_flags) {
@@ -2491,6 +3087,96 @@ fn main() {
 				}
 			}
 		}
+		if !cgen_cache_hit && !is_prod && !is_shared && !is_selfhost
+			&& prefs.normalized_target_os() == 'macos' {
+			generic_cache_signature = monomorph_cache_semantic_signature(a)
+			generic_cache_runtime_strings = monomorph_cache_runtime_strings(a)
+			generic_cache_input = input
+			if entry := cache_state.manager.valid_generic_program(input.source_files,
+				generic_cache_signature, input.generation_signature, input.dependency_inputs)
+			{
+				spec_text := os.read_file(entry.specs) or { '' }
+				cached_monomorph_specs = decode_monomorph_cache_specs(spec_text)
+				used_text := os.read_file(entry.used) or { '' }
+				cached_program_used_fns = decode_cached_used_fns(used_text)
+				if cached_monomorph_specs.len > 0 && cached_program_used_fns.len > 0 {
+					generic_cache_entry = entry
+					generic_cache_hit = true
+					old_literal_text := os.read_file(entry.literals) or { '' }
+					cached_body := os.read_file(entry.body) or { '' }
+					metadata := os.read_file(entry.metadata) or { '' }
+					if old_literals := decode_cached_runtime_strings(old_literal_text) {
+						if rewritten := rewrite_cached_runtime_strings(cached_body, old_literals,
+							generic_cache_runtime_strings)
+						{
+							if decoded := decode_v3_cgen_metadata(metadata) {
+								cgen_cache_entry = cache_state.manager.write_cgen(input.source_files,
+									input.generation_signature, input.dependency_inputs, rewritten,
+									metadata) or { modulecache.CgenEntry{} }
+								if cgen_cache_entry.stamp.len > 0 {
+									cgen_cache_metadata = decoded
+									cgen_cache_hit = true
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		if !cgen_cache_hit && os.getenv('V3_CACHE_DISABLE_INCREMENTAL') != '1' && !is_prod
+			&& !is_shared && !is_selfhost && prefs.normalized_target_os() == 'macos' {
+			if entry := cache_state.manager.valid_incremental_program(input.source_files,
+				incremental_snapshot.declaration_signature, input.generation_signature,
+				input.dependency_inputs)
+			{
+				manifest_text := os.read_file(entry.manifest) or { '' }
+				if old_manifest := decode_incremental_manifest(manifest_text) {
+					if changed_keys, changed_names := incremental_changed_functions(incremental_snapshot,
+						old_manifest)
+					{
+						spec_text := os.read_file(entry.specs) or { '' }
+						used_text := os.read_file(entry.used) or { '' }
+						body_text := os.read_file(entry.body) or { '' }
+						metadata := os.read_file(entry.metadata) or { '' }
+						decoded_specs := decode_monomorph_cache_specs(spec_text)
+						decoded_used := decode_cached_used_fns(used_text)
+						if decoded_metadata := decode_v3_cgen_metadata(metadata) {
+							if decoded_used.len > 0 && body_text.len > 0 {
+								incremental_cache_hit = changed_keys.len > 0
+								incremental_changed_keys = changed_keys.clone()
+								incremental_changed_names = changed_names.clone()
+								incremental_cached_body = body_text
+								incremental_tcc_declarations_path = entry.tcc_declarations
+								incremental_cached_objects = os.read_lines(entry.objects) or { [] }
+								cached_monomorph_specs = clone_monomorph_cache_specs(decoded_specs)
+								cached_program_used_fns = clone_string_bool_map(decoded_used)
+								cgen_cache_metadata = decoded_metadata
+								generic_cache_entry = modulecache.GenericProgramEntry{
+									specs:        entry.specs
+									used:         entry.used
+									prefix:       entry.prefix
+									declarations: entry.declarations
+									body:         entry.body
+									metadata:     entry.metadata
+								}
+								generic_cache_hit = true
+								if changed_keys.len == 0 {
+									if decoded := decode_v3_cgen_metadata(metadata) {
+										cgen_cache_entry = cache_state.manager.write_cgen(input.source_files,
+											input.generation_signature, input.dependency_inputs,
+											body_text, metadata) or { modulecache.CgenEntry{} }
+										if cgen_cache_entry.stamp.len > 0 {
+											cgen_cache_metadata = decoded
+											cgen_cache_hit = true
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 
 	// Type-collect + check BEFORE transform, so the transformer is type-aware
@@ -2498,6 +3184,7 @@ fn main() {
 	// per-expression types for type-dependent lowering.
 	mut pre_tc := types.TypeChecker.new(a)
 	mut used_fns := map[string]bool{}
+	mut incremental_stage_used_fns := map[string]bool{}
 	mut uses_generics := false
 	mut skip_transform_generics := true
 	mut transform_texts_canonical := cgen_cache_hit
@@ -2512,7 +3199,15 @@ fn main() {
 		pre_tc.diagnose_unknown_calls = true
 		pre_tc.prepare_threads_condition()
 		set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
-		check_was_parallel := pre_tc.check_semantics_opt(!current_no_parallel)
+		if !incremental_cache_hit {
+			pre_tc.prepare_interface_query_indexes()
+		}
+		mut check_was_parallel := false
+		if incremental_cache_hit {
+			pre_tc.check_semantics_selected(incremental_changed_names)
+		} else {
+			check_was_parallel = pre_tc.check_semantics_opt(!current_no_parallel)
+		}
 		if pre_tc.errors.len > 0 {
 			print_type_errors(pre_tc.errors)
 			exit(1)
@@ -2543,8 +3238,11 @@ fn main() {
 				restart_v3_after_cache_invalidation()
 			}
 		}
-		pre_tc.prepare_interface_query_indexes()
-		b.step_parallel('check', check_was_parallel)
+		if incremental_cache_hit {
+			b.step('check (incremental)')
+		} else {
+			b.step_parallel('check', check_was_parallel)
+		}
 		b.metric('functions collected', pre_tc.fn_ret_types.len, 'symbols')
 		b.metric('structs collected', pre_tc.structs.len, 'types')
 		b.metric('canonical semantic types', pre_tc.type_count(), 'types')
@@ -2573,24 +3271,27 @@ fn main() {
 		// so the transformer can skip function bodies that the C backend will prune.
 		mut markused_scope := unsafe { nil }
 		mut markused_tc := &pre_tc
-		if scope_prealloc_markused {
+		if scope_prealloc_markused && !generic_cache_hit {
 			markused_scope = prealloc_scope_begin_for_v3()
 			markused_tc = pre_tc.fork_for_parallel_transform(a)
 			markused_tc.enable_scoped_parallel_workers()
 		}
-		if test_files.len > 0 {
+		if generic_cache_hit && test_files.len == 0 {
+			used_fns = clone_string_bool_map(cached_program_used_fns)
+			uses_generics = true
+		} else if test_files.len > 0 {
 			used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a,
 				markused_tc, test_files)
 		} else {
 			used_fns, uses_generics = markused.mark_used_with_generic_usage(a, markused_tc)
 		}
-		if cache_state.manager.enabled {
+		if cache_state.manager.enabled && !generic_cache_hit {
 			mut cache_uses_generics := false
 			used_fns, cache_uses_generics = markused.mark_used_for_cache_with_generic_usage(a,
 				markused_tc, test_files, cache_state.source_body_modules)
 			uses_generics = uses_generics || cache_uses_generics
 		}
-		if scope_prealloc_markused {
+		if scope_prealloc_markused && !generic_cache_hit {
 			prealloc_scope_leave_for_v3(markused_scope)
 			used_fns = clone_string_bool_map(used_fns)
 			prealloc_scope_free_for_v3(markused_scope)
@@ -2609,7 +3310,22 @@ fn main() {
 		// Markused distinguishes reachable generic calls/types from generic templates
 		// that merely came along with an imported module (notably sync and rand).
 		skip_transform_generics = building_v || cmd_v_build || !uses_generics
-		if scope_prealloc_transform {
+		if incremental_cache_hit {
+			skip_transform_generics = true
+		}
+		mut transform_used_fns := clone_string_bool_map(used_fns)
+		if incremental_cache_hit {
+			transform_used_fns = clone_string_bool_map(incremental_changed_names)
+			// `main` activates the transformer's used-function filter. If another
+			// function changed, transforming main as well is harmless; cgen still
+			// emits only the explicitly changed function sections.
+			transform_used_fns['main'] = true
+		}
+		if incremental_cache_hit {
+			transform_used_fns, transform_errors = transform.transform_selected_functions(mut a,
+				&pre_tc, incremental_changed_names)
+			transform_texts_canonical = true
+		} else if scope_prealloc_transform {
 			// Keep the large escaping AST/cache slabs in the compilation arena, while
 			// transformer indexes and per-body temporary state use a stage arena.
 			transform.reserve_parallel_transform_ast(mut a, skip_transform_generics)
@@ -2627,9 +3343,9 @@ fn main() {
 			transform_scope := prealloc_scope_begin_for_v3()
 			mut scoped_owned_base_nodes := []int{}
 			mut retained_transform_regions := []transform.ScopedTransformRegion{}
-			used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_with_used_opt_config_scoped_workers_checked_owned(mut a,
-				&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, true,
-				transform_scope)
+			transform_used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_with_used_opt_config_scoped_workers_checked_owned(mut a,
+				&pre_tc, transform_used_fns, current_parallel_transform, skip_transform_generics,
+				true, transform_scope)
 			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			prealloc_scope_leave_for_v3(transform_scope)
 			retained_transform_regions = clone_scoped_transform_regions(retained_transform_regions)
@@ -2675,7 +3391,7 @@ fn main() {
 			}
 			promote_scoped_checker_node_caches(mut pre_tc, transform_scope, base_transform_nodes)
 			promote_scoped_signatures(mut pre_tc, original_signature_names)
-			used_fns = clone_string_bool_map(used_fns)
+			transform_used_fns = clone_string_bool_map(transform_used_fns)
 			transform_errors = clone_string_list(transform_errors)
 			pre_tc.set_fresh_type_cache(parse_cache_enabled)
 			prealloc_scope_free_for_v3(transform_scope)
@@ -2709,15 +3425,25 @@ fn main() {
 				transform_texts_canonical = true
 			}
 		} else {
-			used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,
-				&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, false)
+			transform_used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,
+				&pre_tc, transform_used_fns, current_parallel_transform, skip_transform_generics,
+				false)
+		}
+		if !incremental_cache_hit {
+			used_fns = clone_string_bool_map(transform_used_fns)
+		} else {
+			incremental_stage_used_fns = clone_string_bool_map(transform_used_fns)
 		}
 		if !building_v && !cmd_v_build && !uses_generics
 			&& transformed_used_fns_need_monomorphize(used_fns) {
 			uses_generics = true
 			skip_transform_generics = false
 		}
-		b.step_parallel('transform', transform_was_parallel)
+		if incremental_cache_hit {
+			b.step_parallel('transform (incremental)', transform_was_parallel)
+		} else {
+			b.step_parallel('transform', transform_was_parallel)
+		}
 		if transform_errors.len > 0 {
 			eprintln('type checker found ${transform_errors.len} error(s):')
 			for message in transform_errors {
@@ -2725,7 +3451,9 @@ fn main() {
 			}
 			exit(1)
 		}
-		pre_tc.freeze_interface_impl_names()
+		if !incremental_cache_hit {
+			pre_tc.freeze_interface_impl_names()
+		}
 		b.metric('AST nodes after transform', a.nodes.len, 'nodes')
 		b.metric('AST children after transform', a.children.len, 'edges')
 
@@ -2735,8 +3463,10 @@ fn main() {
 		pre_tc.reject_unlowered_map_mutation = true
 		set_diagnostic_files(mut pre_tc, user_files)
 		set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
+		incremental_needs_monomorphize := incremental_cache_hit
+			&& transformed_used_fns_need_monomorphize(incremental_stage_used_fns)
 		if !building_v && !cmd_v_build {
-			if uses_generics {
+			if uses_generics && (!incremental_cache_hit || incremental_needs_monomorphize) {
 				if scope_prealloc_stages {
 					// Volt's reachable specialization set settles just below 4x the
 					// transformed node count. Reserving that bounded final size avoids
@@ -2748,12 +3478,25 @@ fn main() {
 				// Resolve their final names from the owned transformed AST instead of
 				// retaining pre-transform canonical string views across arena release.
 				pre_tc.reset_resolved_calls_for_reannotation()
-				pre_tc.annotate_types_with_used(used_fns)
+				pre_tc.annotate_types_with_used(if incremental_cache_hit {
+					transform_used_fns
+				} else {
+					used_fns
+				})
 			} else {
-				restore_transformed_fn_value_types(mut pre_tc, a, used_fns)
+				restore_transformed_fn_value_types(mut pre_tc, a, if incremental_cache_hit {
+					incremental_stage_used_fns
+				} else {
+					used_fns
+				})
 			}
 		}
 		b.step('annotate types')
+		if generic_cache_hit && (!incremental_cache_hit || incremental_needs_monomorphize) {
+			pre_tc.reset_resolution_type_view_cache()
+			transform.register_cached_monomorph_signatures(a, &pre_tc, used_fns,
+				cached_monomorph_specs)
+		}
 	} else {
 		b.step('check (cached)')
 		b.step('markused (cached)')
@@ -2794,10 +3537,16 @@ fn main() {
 		// AST and checker state on this path.
 	} else if building_v {
 		used_fns = transform.erase_generic_templates(mut a, &pre_tc, used_fns)
-	} else if uses_generics {
+	} else if uses_generics && (!incremental_cache_hit
+		|| transformed_used_fns_need_monomorphize(incremental_stage_used_fns)) {
 		mut monomorph_used_fns := map[string]bool{}
 		mut monomorph_errors := []string{}
-		if scope_prealloc_stages {
+		monomorph_input_used := if incremental_cache_hit {
+			incremental_stage_used_fns
+		} else {
+			used_fns
+		}
+		if scope_prealloc_stages && !incremental_cache_hit {
 			// Monomorphization can add several times the transformed node count.
 			// Reserve its persistent slabs in the parent arena so scoped specialization
 			// batches append in place instead of retaining every growth allocation.
@@ -2805,16 +3554,17 @@ fn main() {
 				eprintln('mono AST before reserve: ${a.nodes.len}/${a.nodes.cap} nodes, ${a.children.len}/${a.children.cap} children')
 			}
 			base_monomorph_nodes := a.nodes.len
-			// Volt's retained specialization set stays just below 4x its transformed
-			// AST size. Reserving that final size directly avoids both the previous
-			// 3x-to-6x growth and permanently retaining the unused 2x headroom.
-			reserve_flat_ast_exact(mut a, a.nodes.len * 4, a.children.len * 4)
+			// Volt's current generic closure retains about 5x the transformed node
+			// and child counts. Reserve that measured final size directly so one
+			// slightly-larger closure does not double both multi-million-item slabs.
+			reserve_flat_ast_exact(mut a, a.nodes.len * 5 + 65536, a.children.len * 5 + 65536)
 			monomorph_nodes_cap := a.nodes.cap
 			monomorph_children_cap := a.children.cap
 			base_specialized_fns := a.specialized_fn_nodes.len
 			monomorph_scope := prealloc_scope_begin_for_v3()
-			monomorph_used_fns, monomorph_errors = transform.monomorphize_with_used_checked_config_scoped(mut a,
-				&pre_tc, used_fns, should_parallel_monomorphize(), monomorph_scope)
+			monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a,
+				&pre_tc, monomorph_input_used, should_parallel_monomorphize()
+				&& cache_state.parsed_from_source.len == 0, monomorph_scope, cached_monomorph_specs)
 			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			prealloc_scope_leave_for_v3(monomorph_scope)
 			// Specialization can rewrite payload text on pre-existing nodes as
@@ -2844,13 +3594,26 @@ fn main() {
 			promote_scoped_monomorph_metadata(mut pre_tc)
 			monomorph_used_fns = clone_string_bool_map(monomorph_used_fns)
 			monomorph_errors = clone_string_list(monomorph_errors)
+			generated_monomorph_specs = clone_monomorph_cache_specs(generated_monomorph_specs)
 			pre_tc.set_fresh_type_cache(parse_cache_enabled)
 			prealloc_scope_free_for_v3(monomorph_scope)
 		} else {
-			monomorph_used_fns, monomorph_errors = transform.monomorphize_with_used_checked_config(mut a,
-				&pre_tc, used_fns, should_parallel_monomorphize())
+			if cached_monomorph_specs.len > 0 {
+				monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a,
+					&pre_tc, monomorph_input_used, should_parallel_monomorphize()
+					&& cache_state.parsed_from_source.len == 0, unsafe { nil },
+					cached_monomorph_specs)
+			} else {
+				monomorph_used_fns, monomorph_errors = transform.monomorphize_with_used_checked_config(mut a,
+					&pre_tc, monomorph_input_used, should_parallel_monomorphize()
+					&& cache_state.parsed_from_source.len == 0)
+			}
 		}
-		used_fns = monomorph_used_fns.move()
+		if incremental_cache_hit {
+			incremental_stage_used_fns = monomorph_used_fns.move()
+		} else {
+			used_fns = monomorph_used_fns.move()
+		}
 		if monomorph_errors.len > 0 {
 			eprintln('type checker found ${monomorph_errors.len} error(s):')
 			for message in monomorph_errors {
@@ -2870,6 +3633,10 @@ fn main() {
 	}
 	if cgen_cache_hit {
 		b.step('monomorphize (cached)')
+	} else if incremental_cache_hit {
+		b.step('monomorphize (incremental)')
+	} else if generic_cache_hit {
+		b.step('monomorphize (dependency cache)')
 	} else {
 		b.step('monomorphize')
 	}
@@ -2930,6 +3697,11 @@ fn main() {
 		mut generated_c_flags := cgen_cache_metadata.flags.clone()
 		mut interface_impl_signature := cgen_cache_metadata.interface_impl_signature
 		mut cgen_was_parallel := false
+		cgen_used_fns := if incremental_cache_hit {
+			incremental_stage_used_fns
+		} else {
+			used_fns
+		}
 		if cgen_cache_hit && !cgen_prepared_hit {
 			os.cp(cgen_cache_entry.source, cache_plan_file) or {
 				eprintln('error restoring cached C plan ${cgen_cache_entry.source}: ${err.msg()}')
@@ -2948,10 +3720,12 @@ fn main() {
 			g.set_compiler_vexe(prefs.vexe)
 			g.set_target(prefs.target)
 			g.set_cache_split(cache_state.manager.enabled)
+			g.set_program_body_only(generic_cache_hit)
 			g.set_cache_program_files(user_files)
-			g.set_scope_parallel_workers(true)
+			g.set_incremental_fn_names(incremental_changed_names)
+			g.set_scope_parallel_workers(!generic_cache_hit)
 			generated_path := if cache_state.manager.enabled { cache_plan_file } else { cc_src }
-			g.gen_to_file_with_used_test_options(generated_path, a, used_fns, &pre_tc,
+			g.gen_to_file_with_used_test_options(generated_path, a, cgen_used_fns, &pre_tc,
 				cache_no_parallel_cgen, test_files) or {
 				eprintln('error writing ${generated_path}: ${err}')
 				cleanup_c_build_dir(cc_dir)
@@ -2961,7 +3735,9 @@ fn main() {
 			scoped_c_flags := g.c_flags()
 			g.free_parallel_worker_scopes()
 			prealloc_scope_leave_for_v3(cgen_scope)
-			generated_c_flags = clone_string_list(scoped_c_flags)
+			if !incremental_cache_hit {
+				generated_c_flags = clone_string_list(scoped_c_flags)
+			}
 			// Cgen's synchronous type queries memoize through the shared checker.
 			// Reattach empty parent-owned interners and caches before releasing its
 			// stage arena; all of them can grow while servicing those queries.
@@ -2977,19 +3753,43 @@ fn main() {
 			g.set_compiler_vexe(prefs.vexe)
 			g.set_target(prefs.target)
 			g.set_cache_split(cache_state.manager.enabled)
+			g.set_program_body_only(generic_cache_hit)
 			g.set_cache_program_files(user_files)
+			g.set_incremental_fn_names(incremental_changed_names)
 			generated_path := if cache_state.manager.enabled { cache_plan_file } else { cc_src }
-			g.gen_to_file_with_used_test_options(generated_path, a, used_fns, &pre_tc,
+			g.gen_to_file_with_used_test_options(generated_path, a, cgen_used_fns, &pre_tc,
 				cache_no_parallel_cgen, test_files) or {
 				eprintln('error writing ${generated_path}: ${err}')
 				cleanup_c_build_dir(cc_dir)
 				exit(1)
 			}
 			cgen_was_parallel = g.was_parallel()
-			generated_c_flags = g.c_flags()
+			if !incremental_cache_hit {
+				generated_c_flags = g.c_flags()
+			}
+		}
+		if incremental_cache_hit {
+			changed_source := os.read_file(cache_plan_file) or {
+				eprintln('error reading incremental C source ${cache_plan_file}: ${err.msg()}')
+				cleanup_c_build_dir(cc_dir)
+				exit(1)
+			}
+			merged_source := merge_incremental_program_body(incremental_cached_body,
+				changed_source, incremental_changed_keys) or {
+				os.setenv('V3_CACHE_DISABLE_INCREMENTAL', '1', true)
+				restart_v3_after_cache_invalidation()
+				''
+			}
+			os.write_file(cache_plan_file, merged_source) or {
+				eprintln('error writing merged incremental C source ${cache_plan_file}: ${err.msg()}')
+				cleanup_c_build_dir(cc_dir)
+				exit(1)
+			}
 		}
 		if cgen_cache_hit {
 			b.step('cgen (cached)')
+		} else if incremental_cache_hit {
+			b.step_parallel('cgen (incremental)', cgen_was_parallel)
 		} else {
 			b.step_parallel('cgen', cgen_was_parallel)
 		}
@@ -3033,8 +3833,9 @@ fn main() {
 		}
 		mut cached_objects := []string{}
 		mut cached_dev_dylib := ''
-		mut prefix_source_identity := ''
+		mut prefix_source_identity := cgen_cache_metadata.prefix_source_identity
 		mut tcc_main_file := ''
+		mut cached_program_body_source := if cgen_cache_hit { cgen_cache_entry.source } else { '' }
 		if cache_state.manager.enabled {
 			cache_prepare_scope := prealloc_scope_begin_for_v3()
 			if interface_impl_signature.len == 0 {
@@ -3073,17 +3874,50 @@ fn main() {
 					eprintln('error reading cache-marked C source ${cache_plan_file}: ${err.msg()}')
 					exit(1)
 				}
-				prepared_cache = prepare_v3_module_cache(generated_source, c_standard, opt_flag,
-					pic_flag, warning_flags, resolved_c_flags, needs_objective_c,
-					interface_impl_signature, mut cache_state) or {
-					eprintln(err.msg())
-					cleanup_c_build_dir(cc_dir)
-					exit(1)
+				if generic_cache_hit {
+					if incremental_cache_hit {
+						prepared_cache = prepare_v3_incremental_cached_body(cache_plan_file,
+							incremental_tcc_declarations_path, incremental_cached_objects) or {
+							eprintln(err.msg())
+							cleanup_c_build_dir(cc_dir)
+							exit(1)
+						}
+						prefix_source_identity = cgen_cache_metadata.prefix_source_identity
+					} else {
+						cached_prefix := os.read_file(generic_cache_entry.prefix) or {
+							eprintln('error reading cached generic prefix ${generic_cache_entry.prefix}: ${err.msg()}')
+							cleanup_c_build_dir(cc_dir)
+							exit(1)
+						}
+						cached_declarations := os.read_file(generic_cache_entry.declarations) or {
+							eprintln('error reading cached generic declarations ${generic_cache_entry.declarations}: ${err.msg()}')
+							cleanup_c_build_dir(cc_dir)
+							exit(1)
+						}
+						prepared_cache = prepare_v3_cached_generic_body(generated_source,
+							cached_prefix, cached_declarations, compile_signature, mut cache_state) or {
+							eprintln(err.msg())
+							cleanup_c_build_dir(cc_dir)
+							exit(1)
+						}
+					}
+				} else {
+					prepared_cache = prepare_v3_module_cache(generated_source, c_standard,
+						opt_flag, pic_flag, warning_flags, resolved_c_flags, needs_objective_c,
+						interface_impl_signature, mut cache_state) or {
+						eprintln(err.msg())
+						cleanup_c_build_dir(cc_dir)
+						exit(1)
+					}
 				}
 				os.write_file(cc_src, prepared_cache.main_source) or {
 					eprintln('error writing cached main source ${cc_src}: ${err.msg()}')
 					cleanup_c_build_dir(cc_dir)
 					exit(1)
+				}
+				if prefix_source_identity.len == 0 {
+					prefix_source_identity = v3_program_prefix_source_identity(prepared_cache.program_prefix_source,
+						prepared_cache.objects)
 				}
 				if !cgen_cache_hit {
 					published_cgen_cache_input := v3_cgen_cache_input(cache_state, user_files,
@@ -3091,17 +3925,63 @@ fn main() {
 					prepared_plan_entry = cache_state.manager.write_cgen(published_cgen_cache_input.source_files,
 						published_cgen_cache_input.generation_signature,
 						published_cgen_cache_input.dependency_inputs, generated_source, encode_v3_cgen_metadata(generated_c_flags,
-						interface_impl_signature)) or { modulecache.CgenEntry{} }
+						interface_impl_signature, prefix_source_identity)) or {
+						modulecache.CgenEntry{}
+					}
+				}
+				if incremental_cache_hit && prepared_plan_entry.source.len > 0 {
+					stable_main_source := v3_incremental_main_source(incremental_tcc_declarations_path,
+						prepared_plan_entry.source)
+					prepared_cache.main_source = stable_main_source
+					prepared_cache.tcc_main_source = stable_main_source
+					os.write_file(cc_src, stable_main_source) or {
+						eprintln('error writing incremental cached main source ${cc_src}: ${err.msg()}')
+						cleanup_c_build_dir(cc_dir)
+						exit(1)
+					}
 				}
 				if prepared_plan_entry.stamp.len > 0 {
+					cached_program_body_source = prepared_plan_entry.source
 					cache_state.manager.write_cgen_prepared(prepared_plan_entry,
 						prepared_cache.main_source, prepared_cache.tcc_main_source,
 						prepared_cache.program_prefix_source) or {}
 					cache_state.manager.write_cgen_prepared_objects(prepared_plan_entry,
 						compile_signature, prepared_cache.objects) or {}
 				}
+				if !generic_cache_hit && generic_cache_signature.len > 0
+					&& generated_monomorph_specs.len > 0 {
+					cache_state.manager.write_generic_program(generic_cache_input.source_files,
+						generic_cache_signature, generic_cache_input.generation_signature,
+						generic_cache_input.dependency_inputs,
+						encode_monomorph_cache_specs(generated_monomorph_specs),
+						encode_cached_used_fns(used_fns), prepared_cache.program_prefix_source,
+						modulecache.prune_unreferenced_static_string_definitions(prepared_cache.program_declarations),
+						prepared_cache.program_body_cache,
+						encode_cached_runtime_strings(generic_cache_runtime_strings), encode_v3_cgen_metadata(generated_c_flags,
+						interface_impl_signature, prefix_source_identity)) or {}
+				}
+				if !incremental_cache_hit && !generic_cache_hit
+					&& incremental_snapshot.declaration_signature.len > 0 {
+					cache_state.manager.write_incremental_program(generic_cache_input.source_files,
+						incremental_snapshot.declaration_signature,
+						generic_cache_input.generation_signature,
+						generic_cache_input.dependency_inputs,
+						encode_incremental_manifest(incremental_snapshot),
+						prepared_cache.program_body_cache, encode_cached_used_fns(used_fns),
+						encode_monomorph_cache_specs(generated_monomorph_specs),
+						prepared_cache.program_prefix_source,
+						modulecache.prune_unreferenced_static_string_definitions(prepared_cache.program_declarations),
+						prepared_cache.tcc_program_declarations, prepared_cache.objects, encode_v3_cgen_metadata(generated_c_flags,
+						interface_impl_signature, prefix_source_identity)) or {}
+				}
 			}
 			prealloc_scope_leave_for_v3(cache_prepare_scope)
+			if prefix_source_identity.len > 0 {
+				prefix_source_identity = prefix_source_identity.clone()
+			}
+			if cached_program_body_source.len > 0 {
+				cached_program_body_source = cached_program_body_source.clone()
+			}
 			b.step(if cgen_prepared_hit { 'C module plan (cached)' } else { 'C module plan' })
 			cached_objects = clone_string_list(prepared_cache.objects)
 			newly_cached_module_count = prepared_cache.newly_cached_modules
@@ -3122,8 +4002,10 @@ fn main() {
 						exit(1)
 					}
 				}
-				prefix_source_identity = v3_program_prefix_source_identity(prepared_plan_entry.stamp,
-					prepared_cache.objects)
+				if prefix_source_identity.len == 0 {
+					prefix_source_identity = v3_program_prefix_source_identity(prepared_cache.program_prefix_source,
+						prepared_cache.objects)
+				}
 				prefix_object := compile_v3_program_prefix(prepared_cache.program_prefix_source,
 					prefix_source_identity, v3_program_prefix_external_input_paths(&cache_state),
 					&cache_state.manager, c_standard, opt_flag, pic_flag, warning_flags,
@@ -3190,8 +4072,13 @@ fn main() {
 			if '-lm' !in tcc_args {
 				tcc_args << '-lm'
 			}
+			program_source_identity := '${prefix_source_identity}\n${modulecache.file_signature(tcc_main_file)}\n${if cached_program_body_source.len > 0 {
+				modulecache.file_signature(cached_program_body_source)
+			} else {
+				''
+			}}'
 			tcc_cached_executable := v3_cached_tcc_executable_path(&cache_state.manager,
-				prefix_source_identity, c_object_cache_stats.link_plan_signature, tcc_path,
+				program_source_identity, c_object_cache_stats.link_plan_signature, tcc_path,
 				tcc_lib_dir, tcc_args)
 			if os.is_file(tcc_cached_executable) {
 				os.cp(tcc_cached_executable, cc_out) or {}
@@ -3271,12 +4158,23 @@ fn main() {
 				cc_args << '-shared'
 			}
 			cc_args << ['-o', 'out']
-			if needs_objective_c {
-				cc_args << ['-x', 'objective-c', 'src.c', '-x', 'none']
+			fallback_source := if cached_dev_dylib.len > 0 && tcc_main_file.len > 0 {
+				os.base(tcc_main_file)
 			} else {
-				cc_args << 'src.c'
+				'src.c'
+			}
+			if fallback_source == os.base(tcc_main_file) {
+				cc_args << ['-D__TINYC__', '-Wno-implicit-function-declaration']
+				cc_args << fallback_source
+			} else if needs_objective_c {
+				cc_args << ['-x', 'objective-c', fallback_source, '-x', 'none']
+			} else {
+				cc_args << fallback_source
 			}
 			cc_args << cached_objects
+			if cached_dev_dylib.len > 0 {
+				cc_args << cached_dev_dylib
+			}
 			cc_args << resolved_c_flags
 			cc_args << '-lm'
 			println('  > ${cmdexec.display(c_compiler, cc_args)}')
@@ -3373,6 +4271,49 @@ fn builtin_bundle_source_files(prefs &pref.Preferences, builtin_files []string) 
 	return files
 }
 
+fn v3_incremental_main_source(tcc_declarations_path string, body_path string) string {
+	declarations_include := tcc_declarations_path.replace('\\', '\\\\').replace('"', '\\"')
+	body_include := body_path.replace('\\', '\\\\').replace('"', '\\"')
+	return '#define V3CACHE_PROGRAM_UNIT 1\n#include "${declarations_include}"\n#include "${body_include}"\n'
+}
+
+fn prepare_v3_incremental_cached_body(body_path string, tcc_declarations_path string, cached_objects []string) !V3PreparedModuleCache {
+	if !os.is_file(tcc_declarations_path) || cached_objects.len == 0 {
+		return error('v3 incremental C declarations are unavailable')
+	}
+	main_source := v3_incremental_main_source(tcc_declarations_path, body_path)
+	return V3PreparedModuleCache{
+		main_source:     main_source
+		tcc_main_source: main_source
+		objects:         cached_objects
+	}
+}
+
+fn prepare_v3_cached_generic_body(generated_source string, cached_prefix string, cached_declarations string, compile_signature string, mut state V3ModuleCacheState) !V3PreparedModuleCache {
+	if !state.manager.ensure_dir() {
+		return error('v3 module cache directory is unavailable')
+	}
+	if resolve_flag_specific_cache_objects(mut state, compile_signature) {
+		os.setenv('V3_CACHE_FORCE_SOURCE', '1', true)
+		restart_v3_after_cache_invalidation()
+	}
+	split := modulecache.split_generated_c(generated_source)!
+	main_body := split.modules['main'] or { '' }
+	current_string_definitions := modulecache.static_string_definitions(split.prefix)
+	combined_declarations := cached_declarations + current_string_definitions
+	tcc_declarations := tcc_cached_main_source(combined_declarations)
+	main_source := '#define V3CACHE_PROGRAM_UNIT 1\n' + tcc_declarations + main_body
+	return V3PreparedModuleCache{
+		main_source:              main_source
+		tcc_main_source:          main_source
+		main_body:                main_body
+		program_prefix_source:    cached_prefix
+		program_declarations:     combined_declarations
+		tcc_program_declarations: tcc_declarations
+		objects:                  cache_object_paths(state.objects)
+	}
+}
+
 fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag string, pic_flag string, warning_flags string, generated_c_flags []string, objective_c bool, interface_impl_signature string, mut state V3ModuleCacheState) !V3PreparedModuleCache {
 	if !state.manager.ensure_dir() {
 		return error('v3 module cache directory is unavailable')
@@ -3404,11 +4345,16 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 	}
 	main_body := split.modules['main'] or { '' }
 	main_prefix := cache_source_without_cached_native_inputs(split.prefix, state, true)
-	main_source := '#define V3CACHE_PROGRAM_UNIT 1\n' + main_prefix + main_body
-	main_declarations := cache_source_without_cached_native_inputs(modulecache.declaration_header(split.prefix),
-		state, false)
-	tcc_main := '#define V3CACHE_PROGRAM_UNIT 1\n' + tcc_cached_main_source(main_declarations) +
-		main_body
+	program_specializations := split.modules['__v3_program_specializations'] or { '' }
+	program_support := split.modules['__v3_program_support'] or { '' }
+	dylib_prefix := modulecache.prune_unreferenced_static_string_definitions(main_prefix +
+		program_specializations + program_support)
+	main_source := '#define V3CACHE_PROGRAM_UNIT 1\n' + main_prefix + program_specializations +
+		program_support + main_body
+	main_declarations := cache_source_without_cached_native_inputs(modulecache.declaration_header(
+		split.prefix + program_specializations + program_support), state, false)
+	tcc_declarations := tcc_cached_main_source(main_declarations)
+	tcc_main := '#define V3CACHE_PROGRAM_UNIT 1\n' + tcc_declarations + main_body
 	mut object_paths := state.objects.clone()
 	mut bundle_body := strings.new_builder(4096)
 	mut split_modules := split.modules.keys()
@@ -3480,11 +4426,17 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 	}
 
 	return V3PreparedModuleCache{
-		main_source:           main_source
-		tcc_main_source:       tcc_main
-		program_prefix_source: '#define V3CACHE_PROGRAM_UNIT 1\n' + main_prefix
-		objects:               cache_object_paths(object_paths)
-		newly_cached_modules:  newly_cached_modules.len
+		main_source:              main_source
+		tcc_main_source:          tcc_main
+		main_body:                main_body
+		program_body_cache:       incremental_static_string_markers(split.prefix) +
+			'/* V3CACHE_BODY_BEGIN */\n/* V3CACHE_MODULE main */\n' + main_body +
+			'\n/* V3CACHE_BODY_END */\n'
+		program_prefix_source:    '#define V3CACHE_PROGRAM_UNIT 1\n' + dylib_prefix
+		program_declarations:     main_declarations
+		tcc_program_declarations: tcc_declarations
+		objects:                  cache_object_paths(object_paths)
+		newly_cached_modules:     newly_cached_modules.len
 	}
 }
 

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -114,17 +114,30 @@ mut:
 	requests                  int
 	direct_objects            int
 	content_key_hits          int
+	dependency_manifest_hits  int
 	misses                    int
+	dependency_scans          int
 	dependency_files          int
+	dependency_file_reads     int
 	dependency_scan_fallbacks int
 	publish_races             int
 	input_snapshot_races      int
 	temporary_objects         []string
+	compiler_versions         map[string]string
+	file_signatures           map[string]string
 }
 
 struct CObjectDependencies {
 	files         []string
 	used_fallback bool
+}
+
+struct CLinkPlan {
+mut:
+	flags            []string
+	requests         int
+	direct_objects   int
+	dependency_files int
 }
 
 fn cpp_runtime_link_flag(target pref.Target) string {
@@ -133,6 +146,22 @@ fn cpp_runtime_link_flag(target pref.Target) string {
 
 fn prepare_c_flags_for_link(flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, uncached_dir string, mut stats CObjectCacheStats) ![]string {
 	support_flags := c_object_compile_support_flags(flags)
+	cache_dir := os.join_path(os.vtmp_dir(), 'v3_thirdparty_objs')
+	os.mkdir_all(cache_dir)!
+	plan_path := c_link_plan_path(cache_dir, flags, c99, pic_flag, target_args, target, c_compiler, mut
+		stats)
+	// Tracing intentionally walks the object manifests so every requested
+	// object's cache decision remains visible.
+	if os.getenv('V3_CACHE_TRACE') == '' {
+		if plan := valid_c_link_plan(plan_path, mut stats) {
+			stats.requests = plan.requests
+			stats.direct_objects = plan.direct_objects
+			stats.content_key_hits = plan.requests - plan.direct_objects
+			stats.dependency_manifest_hits = plan.requests - plan.direct_objects
+			stats.dependency_files = plan.dependency_files
+			return plan.flags
+		}
+	}
 	mut prepared := []string{}
 	mut active_language := ''
 	mut i := 0
@@ -196,7 +225,105 @@ fn prepare_c_flags_for_link(flags []string, c99 bool, pic_flag string, target_ar
 			prepared << cpp_runtime
 		}
 	}
+	if stats.dependency_scan_fallbacks == 0 && stats.temporary_objects.len == 0 {
+		write_c_link_plan(plan_path, prepared, stats) or {}
+	}
 	return prepared
+}
+
+fn c_link_plan_path(cache_dir string, flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, compiler string, mut stats CObjectCacheStats) string {
+	compiler_path, compiler_version := c_object_compiler_identity(compiler, mut stats)
+	mut hash := u64(1469598103934665603)
+	for identity in ['v3-c-link-plan-v1', os.getwd(), flags.join('\x00'),
+		c99.str(), pic_flag, target_args.join('\x00'), compiler_path, compiler_version, target.os,
+		target.arch, target.abi, target.endian, target.pointer_bits.str(), target.object_format] {
+		hash = c_hash_bytes(hash, identity.bytes())
+		hash = c_hash_bytes(hash, [u8(0xff)])
+	}
+	return os.join_path(cache_dir, 'link_${hash.hex()}.manifest')
+}
+
+fn valid_c_link_plan(plan_path string, mut stats CObjectCacheStats) ?CLinkPlan {
+	content := os.read_file(plan_path) or { return none }
+	lines := content.split_into_lines()
+	if lines.len < 5 || lines[0] != 'format=v3-c-link-plan-v1' {
+		return none
+	}
+	mut plan := CLinkPlan{}
+	mut objects := []string{}
+	mut complete := false
+	mut saw_requests := false
+	mut saw_direct_objects := false
+	mut saw_dependency_files := false
+	for line in lines[1..] {
+		if line.starts_with('requests=') {
+			plan.requests = line.all_after('requests=').int()
+			saw_requests = true
+		} else if line.starts_with('direct_objects=') {
+			plan.direct_objects = line.all_after('direct_objects=').int()
+			saw_direct_objects = true
+		} else if line.starts_with('dependency_files=') {
+			plan.dependency_files = line.all_after('dependency_files=').int()
+			saw_dependency_files = true
+		} else if line.starts_with('flag=') {
+			plan.flags << line.all_after('flag=')
+		} else if line.starts_with('object=') {
+			objects << line.all_after('object=')
+		} else if line.starts_with('dependency=') {
+			entry := line.all_after('dependency=')
+			tab := entry.last_index('\t') or { return none }
+			path := entry[..tab]
+			expected_signature := entry[tab + 1..]
+			if path.len == 0 || expected_signature.len == 0 {
+				return none
+			}
+			actual_signature := c_object_file_signature(path, false, mut stats)
+			if actual_signature.len == 0 || actual_signature != expected_signature {
+				return none
+			}
+		} else if line == 'complete=1' {
+			complete = true
+		} else {
+			return none
+		}
+	}
+	if !complete || !saw_requests || !saw_direct_objects || !saw_dependency_files
+		|| plan.requests < 0 || plan.direct_objects < 0 || plan.direct_objects > plan.requests
+		|| plan.dependency_files < 0 || objects.len != plan.requests {
+		return none
+	}
+	for object_path in objects {
+		if !os.is_file(object_path) {
+			return none
+		}
+	}
+	return plan
+}
+
+fn write_c_link_plan(plan_path string, flags []string, stats &CObjectCacheStats) ! {
+	mut out := strings.new_builder(256 + flags.len * 64 + stats.file_signatures.len * 96)
+	out.writeln('format=v3-c-link-plan-v1')
+	out.writeln('requests=${stats.requests}')
+	out.writeln('direct_objects=${stats.direct_objects}')
+	out.writeln('dependency_files=${stats.dependency_files}')
+	for flag in flags {
+		out.writeln('flag=${flag}')
+		if c_flag_is_object_file(flag.trim_space()) && os.is_file(flag.trim_space()) {
+			out.writeln('object=${flag.trim_space()}')
+		}
+	}
+	mut dependencies := stats.file_signatures.keys()
+	dependencies.sort()
+	for dependency in dependencies {
+		out.writeln('dependency=${dependency}\t${stats.file_signatures[dependency]}')
+	}
+	out.writeln('complete=1')
+	temp_path := '${plan_path}.tmp.${os.getpid()}.${rand.ulid()}'
+	defer {
+		os.rm(temp_path) or {}
+	}
+	os.write_file(temp_path, out.str())!
+	os.mv(temp_path, plan_path)!
 }
 
 fn append_c_link_object(mut flags []string, object_path string, active_language string) {
@@ -406,6 +533,11 @@ fn compile_cached_c_source_object(obj_path string, source_file string, source_la
 	if language.len > 0 {
 		args << ['-x', language]
 	}
+	manifest_path := c_object_manifest_path(cache_dir, obj_path, compiler, args, target, mut stats)
+	if cached_obj := valid_c_object_manifest(manifest_path, mut stats) {
+		return cached_obj
+	}
+	stats.dependency_scans++
 	dependencies := c_object_dependencies(compiler, args, source_file)
 	stats.dependency_files += dependencies.files.len
 	if dependencies.used_fallback {
@@ -423,12 +555,14 @@ fn compile_cached_c_source_object(obj_path string, source_file string, source_la
 		stats.temporary_objects << uncached_obj
 		return uncached_obj
 	}
-	cache_key := c_object_cache_name(obj_path, compiler, args, dependencies.files, target)
+	cache_key := c_object_cache_name(obj_path, compiler, args, dependencies.files, target, false, mut
+		stats)
 	cached_obj := os.join_path(cache_dir, cache_key)
 	if os.exists(cached_obj) {
 		stats.content_key_hits++
 		trace_c_object_cache('hit', cache_key,
 			'compiler, target, argv, and dependency contents matched', dependencies.files.len)
+		write_c_object_manifest(manifest_path, cached_obj, dependencies.files, mut stats) or {}
 		return cached_obj
 	}
 	stats.misses++
@@ -448,7 +582,8 @@ fn compile_cached_c_source_object(obj_path string, source_file string, source_la
 	// the compiler was running, the object no longer corresponds to cache_key;
 	// publishing it would certify content it was not built from. Use it as a
 	// build-local, uncached object instead.
-	post_key := c_object_cache_name(obj_path, compiler, key_args, dependencies.files, target)
+	post_key := c_object_cache_name(obj_path, compiler, key_args, dependencies.files, target, true, mut
+		stats)
 	if post_key != cache_key {
 		stats.input_snapshot_races++
 		trace_c_object_cache('bypass', cache_key,
@@ -469,7 +604,103 @@ fn compile_cached_c_source_object(obj_path string, source_file string, source_la
 		}
 		stats.publish_races++
 	}
+	write_c_object_manifest(manifest_path, cached_obj, dependencies.files, mut stats) or {}
 	return cached_obj
+}
+
+fn c_object_manifest_path(cache_dir string, obj_path string, compiler string, compile_args []string, target pref.Target, mut stats CObjectCacheStats) string {
+	compiler_path, compiler_version := c_object_compiler_identity(compiler, mut stats)
+	mut hash := u64(1469598103934665603)
+	for identity in ['v3-c-object-manifest-v1', os.real_path(obj_path), compiler_path,
+		compiler_version, target.os, target.arch, target.abi, target.endian, target.pointer_bits.str(),
+		target.object_format, compile_args.join('\x00')] {
+		hash = c_hash_bytes(hash, identity.bytes())
+		hash = c_hash_bytes(hash, [u8(0xff)])
+	}
+	return os.join_path(cache_dir, 'request_${hash.hex()}.manifest')
+}
+
+fn valid_c_object_manifest(manifest_path string, mut stats CObjectCacheStats) ?string {
+	content := os.read_file(manifest_path) or { return none }
+	lines := content.split_into_lines()
+	if lines.len < 3 || lines[0] != 'format=v3-c-object-manifest-v1'
+		|| !lines[1].starts_with('object=') {
+		return none
+	}
+	object_path := lines[1].all_after('object=')
+	if !os.is_file(object_path) {
+		return none
+	}
+	mut dependency_count := 0
+	for line in lines[2..] {
+		if !line.starts_with('dependency=') {
+			return none
+		}
+		entry := line.all_after('dependency=')
+		tab := entry.last_index('\t') or { return none }
+		path := entry[..tab]
+		expected_signature := entry[tab + 1..]
+		if path.len == 0 || expected_signature.len == 0 {
+			return none
+		}
+		actual_signature := c_object_file_signature(path, false, mut stats)
+		if actual_signature.len == 0 || actual_signature != expected_signature {
+			return none
+		}
+		dependency_count++
+	}
+	if dependency_count == 0 {
+		return none
+	}
+	stats.dependency_manifest_hits++
+	stats.content_key_hits++
+	stats.dependency_files += dependency_count
+	trace_c_object_cache('hit', os.base(object_path),
+		'compiler, target, argv, and dependency contents matched via manifest', dependency_count)
+	return object_path
+}
+
+fn write_c_object_manifest(manifest_path string, object_path string, dependencies []string, mut stats CObjectCacheStats) ! {
+	mut out := strings.new_builder(128 + dependencies.len * 96)
+	out.writeln('format=v3-c-object-manifest-v1')
+	out.writeln('object=${object_path}')
+	for dependency in dependencies {
+		signature := c_object_file_signature(dependency, false, mut stats)
+		if signature.len == 0 {
+			return error('failed to sign C object dependency ${dependency}')
+		}
+		out.writeln('dependency=${dependency}\t${signature}')
+	}
+	temp_path := '${manifest_path}.tmp.${os.getpid()}.${rand.ulid()}'
+	defer {
+		os.rm(temp_path) or {}
+	}
+	os.write_file(temp_path, out.str())!
+	os.mv(temp_path, manifest_path)!
+}
+
+fn c_object_compiler_identity(compiler string, mut stats CObjectCacheStats) (string, string) {
+	compiler_path := os.find_abs_path_of_executable(compiler) or { compiler }
+	if compiler_path in stats.compiler_versions {
+		return compiler_path, stats.compiler_versions[compiler_path]
+	}
+	version := cmdexec.run(compiler, ['--version']).output
+	stats.compiler_versions[compiler_path] = version
+	return compiler_path, version
+}
+
+fn c_object_file_signature(path string, refresh bool, mut stats CObjectCacheStats) string {
+	canonical := os.real_path(path)
+	if refresh {
+		stats.file_signatures.delete(canonical)
+	} else if canonical in stats.file_signatures {
+		return stats.file_signatures[canonical]
+	}
+	content := os.read_bytes(canonical) or { return '' }
+	signature := c_hash_bytes(u64(1469598103934665603), content).hex()
+	stats.file_signatures[canonical] = signature
+	stats.dependency_file_reads++
+	return signature
 }
 
 fn trace_c_object_cache(status string, key string, reason string, dependency_count int) {
@@ -545,10 +776,9 @@ fn c_source_from_object_file(obj_path string) ?string {
 	return none
 }
 
-fn c_object_cache_name(path string, compiler string, compile_args []string, dependencies []string, target pref.Target) string {
+fn c_object_cache_name(path string, compiler string, compile_args []string, dependencies []string, target pref.Target, refresh bool, mut stats CObjectCacheStats) string {
 	base := os.base(path).replace_each(['/', '_', '\\', '_', ':', '_', '.', '_', ' ', '_'])
-	compiler_path := os.find_abs_path_of_executable(compiler) or { compiler }
-	compiler_version := cmdexec.run(compiler, ['--version']).output
+	compiler_path, compiler_version := c_object_compiler_identity(compiler, mut stats)
 	mut hash := u64(1469598103934665603)
 	for identity in [os.real_path(path), compiler_path, compiler_version, target.os, target.arch,
 		target.abi, target.endian, target.pointer_bits.str(), target.object_format, compile_args.join('\x00')] {
@@ -557,8 +787,8 @@ fn c_object_cache_name(path string, compiler string, compile_args []string, depe
 	for dependency in dependencies {
 		canonical := os.real_path(dependency)
 		hash = c_hash_bytes(hash, canonical.bytes())
-		content := os.read_bytes(canonical) or { []u8{} }
-		hash = c_hash_bytes(hash, content)
+		signature := c_object_file_signature(canonical, refresh, mut stats)
+		hash = c_hash_bytes(hash, signature.bytes())
 	}
 	return '${base}_${hash.hex()}.o'
 }
@@ -2398,6 +2628,7 @@ fn main() {
 			cleanup_c_build_dir(cc_dir)
 			exit(1)
 		}
+		b.step('C object cache')
 		link_uses_non_c_language := c_link_flags_use_non_c_language(resolved_c_flags)
 		link_c_standard := if link_uses_non_c_language {
 			''
@@ -2581,8 +2812,11 @@ fn main() {
 	b.metric('C object cache requests', c_object_cache_stats.requests, 'objects')
 	b.metric('C object cache direct', c_object_cache_stats.direct_objects, 'objects')
 	b.metric('C object content-key hits', c_object_cache_stats.content_key_hits, 'objects')
+	b.metric('C object manifest hits', c_object_cache_stats.dependency_manifest_hits, 'objects')
 	b.metric('C object cache misses', c_object_cache_stats.misses, 'objects')
+	b.metric('C object dependency scans', c_object_cache_stats.dependency_scans, 'objects')
 	b.metric('C object dependency files', c_object_cache_stats.dependency_files, 'files')
+	b.metric('C object dependency reads', c_object_cache_stats.dependency_file_reads, 'files')
 	b.metric('C object dep-scan fallbacks', c_object_cache_stats.dependency_scan_fallbacks,
 		'objects')
 	b.metric('C object publish races', c_object_cache_stats.publish_races, 'objects')

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -16,6 +16,30 @@ import v3.transform
 import v3.types
 import v.vmod
 
+$if gcboehm ? {
+	$compile_error('v3 must be built without a garbage collector; use `-gc none` or `-prealloc`')
+}
+
+$if gcboehm_full ? {
+	$compile_error('v3 must be built without a garbage collector; use `-gc none` or `-prealloc`')
+}
+
+$if gcboehm_incr ? {
+	$compile_error('v3 must be built without a garbage collector; use `-gc none` or `-prealloc`')
+}
+
+$if gcboehm_opt ? {
+	$compile_error('v3 must be built without a garbage collector; use `-gc none` or `-prealloc`')
+}
+
+$if gcboehm_leak ? {
+	$compile_error('v3 must be built without a garbage collector; use `-gc none` or `-prealloc`')
+}
+
+$if vgc ? {
+	$compile_error('v3 must be built without a garbage collector; use `-gc none` or `-prealloc`')
+}
+
 $if !skip_eval ? {
 	import v3.eval
 }
@@ -44,13 +68,15 @@ mut:
 	module_external_inputs map[string][]string
 	parsed_from_source     map[string]bool
 	source_body_modules    map[string]bool
+	native_source_modules  map[string]bool
 	objects                map[string]string
 	headers                map[string]string
 }
 
 struct V3PreparedModuleCache {
-	main_source string
-	objects     []string
+	main_source          string
+	objects              []string
+	newly_cached_modules int
 }
 
 fn tcc_atomic_s_arg(prefs &pref.Preferences) string {
@@ -661,12 +687,12 @@ fn with_shared_library_postfix(path string, target_os string) string {
 	return path + postfix
 }
 
-// should_scope_prealloc_stages reports whether compiler self-host stages can use disposable
-// arenas. User programs retain normal allocation ownership until every stage promotion path can
-// safely preserve their generic and comptime metadata.
-fn should_scope_prealloc_stages(building_v bool, cmd_v_build bool) bool {
+// should_scope_prealloc_stages reports whether compiler stages can use disposable arenas.
+// Every stage that publishes data into the compilation state promotes that data before its
+// scratch arena is released, so this is safe for both self-host and user-program builds.
+fn should_scope_prealloc_stages() bool {
 	$if prealloc {
-		return building_v || cmd_v_build
+		return true
 	}
 	return false
 }
@@ -675,6 +701,17 @@ fn should_scope_prealloc_stages(building_v bool, cmd_v_build bool) bool {
 // arenas. Unlike transform metadata, cgen state does not escape after its flags are copied.
 fn should_scope_prealloc_cgen() bool {
 	$if prealloc {
+		return true
+	}
+	return false
+}
+
+fn should_parallel_monomorphize() bool {
+	return false
+}
+
+fn ownership_checker_compiled() bool {
+	$if ownership ? {
 		return true
 	}
 	return false
@@ -881,6 +918,33 @@ fn clone_flat_ast_after_transform(ast &flat.FlatAst) &flat.FlatAst {
 	}
 }
 
+fn reserve_flat_ast_exact(mut ast flat.FlatAst, nodes_cap int, children_cap int) {
+	if nodes_cap > ast.nodes.cap {
+		old_nodes := ast.nodes
+		mut nodes := []flat.Node{cap: nodes_cap}
+		nodes << old_nodes
+		ast.nodes = nodes
+	}
+	if children_cap > ast.children.cap {
+		old_children := ast.children
+		mut children := []flat.NodeId{cap: children_cap}
+		children << old_children
+		ast.children = children
+	}
+}
+
+fn clone_flat_ast_storage(mut ast flat.FlatAst) {
+	old_nodes := ast.nodes
+	mut nodes := []flat.Node{cap: old_nodes.cap}
+	nodes << old_nodes
+	ast.nodes = nodes
+	old_children := ast.children
+	mut children := []flat.NodeId{cap: old_children.cap}
+	children << old_children
+	ast.children = children
+	ast.specialized_fn_nodes = ast.specialized_fn_nodes.clone()
+}
+
 fn clone_int_string_map(values map[int]string) map[int]string {
 	mut cloned := map[int]string{}
 	for idx, value in values {
@@ -929,23 +993,50 @@ fn promote_scoped_monomorph_metadata(mut tc types.TypeChecker) {
 	tc.sum_generic_params = clone_string_list_map(tc.sum_generic_params)
 }
 
-fn promote_scoped_checker_node_caches(mut tc types.TypeChecker) {
+fn promote_scoped_checker_node_caches(mut tc types.TypeChecker, scope voidptr, generated_start int) {
 	for idx in 0 .. tc.resolved_call_names.len {
 		if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
 			name := tc.resolved_call_names[idx]
-			if name.len > 0 {
+			if name.len > 0 && scoped_value_owned(scope, name.str) {
 				tc.resolved_call_names[idx] = name.clone()
 			}
 		}
 		if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
 			name := tc.resolved_fn_value_names[idx]
-			if name.len > 0 {
+			if name.len > 0 && scoped_value_owned(scope, name.str) {
 				tc.resolved_fn_value_names[idx] = name.clone()
 			}
 		}
-		if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
+		if idx >= generated_start && idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
 			tc.expr_type_values[idx] = types.clone_owned_type(tc.expr_type_values[idx])
 		}
+	}
+	// The dense caches are reserved in the parent arena, but an unexpectedly
+	// large specialization pass may still grow one of them in the stage arena.
+	// Move only those backing arrays before releasing that arena.
+	if scoped_value_owned(scope, tc.resolved_call_names.data) {
+		tc.resolved_call_names = tc.resolved_call_names.clone()
+	}
+	if scoped_value_owned(scope, tc.resolved_call_set.data) {
+		tc.resolved_call_set = tc.resolved_call_set.clone()
+	}
+	if scoped_value_owned(scope, tc.resolved_fn_value_names.data) {
+		tc.resolved_fn_value_names = tc.resolved_fn_value_names.clone()
+	}
+	if scoped_value_owned(scope, tc.resolved_fn_value_set.data) {
+		tc.resolved_fn_value_set = tc.resolved_fn_value_set.clone()
+	}
+	if scoped_value_owned(scope, tc.statement_nodes.data) {
+		tc.statement_nodes = tc.statement_nodes.clone()
+	}
+	if scoped_value_owned(scope, tc.expr_type_values.data) {
+		tc.expr_type_values = tc.expr_type_values.clone()
+	}
+	if scoped_value_owned(scope, tc.expr_type_set.data) {
+		tc.expr_type_set = tc.expr_type_set.clone()
+	}
+	if scoped_value_owned(scope, tc.checking_nodes.data) {
+		tc.checking_nodes = tc.checking_nodes.clone()
 	}
 	tc.sparse_resolved_call_names = clone_int_string_map(tc.sparse_resolved_call_names)
 	tc.sparse_resolved_fn_values = clone_int_string_map(tc.sparse_resolved_fn_values)
@@ -1386,6 +1477,21 @@ fn main() {
 		eprintln('unsupported garbage collector `${gc_mode}`; v3 currently supports only `-gc none`')
 		exit(1)
 	}
+	for define in user_defines {
+		define_name := define.all_before('=').trim_space()
+		if define_name == 'vgc' || define_name.starts_with('gcboehm') {
+			eprintln('unsupported garbage collector define `${define_name}`; v3 programs must not use a garbage collector')
+			exit(1)
+		}
+		if define_name == 'ownership' && !ownership_checker_compiled() {
+			eprintln('ownership support is not compiled into this v3 executable')
+			exit(1)
+		}
+	}
+	if ownership_mode && !ownership_checker_compiled() {
+		eprintln('ownership support is not compiled into this v3 executable')
+		exit(1)
+	}
 	if enable_globals_compat {
 		eprintln('warning: `-enable-globals` is unnecessary; globals are always enabled in v3')
 	}
@@ -1419,7 +1525,7 @@ fn main() {
 		building_v = true
 	}
 	cmd_v_build := input_is_cmd_v(input_file)
-	scope_prealloc_stages := should_scope_prealloc_stages(building_v, cmd_v_build)
+	scope_prealloc_stages := should_scope_prealloc_stages()
 	scope_prealloc_cgen := should_scope_prealloc_cgen()
 	// The selective transform promotion path is designed around worker-owned
 	// results outside the disposable stage arena.
@@ -1598,6 +1704,7 @@ fn main() {
 		module_external_inputs: map[string][]string{}
 		parsed_from_source:     map[string]bool{}
 		source_body_modules:    map[string]bool{}
+		native_source_modules:  map[string]bool{}
 		objects:                map[string]string{}
 		headers:                map[string]string{}
 	}
@@ -1698,6 +1805,9 @@ fn main() {
 	}
 
 	b.step_parallel('parse', parse_was_parallel)
+	b.metric_items('parsed .vh files', p.parsed_v_header_files, 'files', '.vh files',
+		p.parsed_v_header_file_paths)
+	b.metric_items('parsed .v files', p.parsed_v_files, 'files', '.v files', p.parsed_v_file_paths)
 	b.metric('AST nodes after parse', a.nodes.len, 'nodes')
 	b.metric('AST children after parse', a.children.len, 'edges')
 	b.metric('canonical AST texts', a.text_count(), 'texts')
@@ -1739,10 +1849,12 @@ fn main() {
 		external_inputs, has_untracked_c_include := cgen.cache_external_input_files(a, prefs.vroot,
 			cache_input_modules, user_c_flags, prefs.target)
 		cache_state.module_external_inputs = external_inputs.clone()
-		if has_untracked_c_include
-			|| cache_external_inputs_have_static_storage(cache_state.module_external_inputs) {
+		native_source_modules, can_scope_static_inputs :=
+			cache_external_input_owner_modules(cache_state)
+		if has_untracked_c_include || !can_scope_static_inputs {
 			restart_v3_without_cache()
 		}
+		cache_state.native_source_modules = native_source_modules.clone()
 		for module_name, parsed in cache_state.parsed_from_source {
 			if !parsed {
 				continue
@@ -1792,15 +1904,14 @@ fn main() {
 		markused_tc = pre_tc.fork_for_parallel_transform(a)
 		markused_tc.enable_scoped_parallel_workers()
 	}
-	mut output_used_fns := map[string]bool{}
+	mut used_fns := map[string]bool{}
 	mut uses_generics := false
 	if test_files.len > 0 {
-		output_used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a,
-			markused_tc, test_files)
+		used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a, markused_tc,
+			test_files)
 	} else {
-		output_used_fns, uses_generics = markused.mark_used_with_generic_usage(a, markused_tc)
+		used_fns, uses_generics = markused.mark_used_with_generic_usage(a, markused_tc)
 	}
-	mut used_fns := output_used_fns.clone()
 	if cache_state.manager.enabled {
 		mut cache_uses_generics := false
 		used_fns, cache_uses_generics = markused.mark_used_for_cache_with_generic_usage(a,
@@ -1809,7 +1920,6 @@ fn main() {
 	}
 	if scope_prealloc_markused {
 		prealloc_scope_leave_for_v3(markused_scope)
-		output_used_fns = clone_string_bool_map(output_used_fns)
 		used_fns = clone_string_bool_map(used_fns)
 		prealloc_scope_free_for_v3(markused_scope)
 	}
@@ -1854,13 +1964,19 @@ fn main() {
 		retained_transform_regions = clone_scoped_transform_regions(retained_transform_regions)
 		pre_tc.promote_scoped_transform_interners(base_type_count, base_symbol_count,
 			transform_scope)
-		// Generic lowering can rewrite arbitrary pre-existing nodes while processing
-		// late-reachable bodies. Clone the completed AST out of all stage/worker
-		// arenas instead of relying on a selective base-node ownership log.
-		if skip_transform_generics && a.nodes.cap == reserved_nodes_cap
-			&& a.children.cap == reserved_children_cap {
+		if a.nodes.cap == reserved_nodes_cap && a.children.cap == reserved_children_cap
+			&& !scoped_value_owned(transform_scope, a.nodes.data)
+			&& !scoped_value_owned(transform_scope, a.children.data) {
 			a.promote_transform_texts_from(base_text_count, transform_scope)
-			if retained_transform_regions.len > 0 {
+			if !skip_transform_generics {
+				// Generic lowering can rewrite arbitrary pre-existing nodes. The backing
+				// slabs were reserved outside the stage arena, so scan their small payload
+				// fields and promote only values owned by that arena instead of cloning the
+				// entire AST and permanently retaining both copies.
+				for idx in 0 .. a.nodes.len {
+					canonicalize_scoped_node(mut a, idx, transform_scope)
+				}
+			} else if retained_transform_regions.len > 0 {
 				outer_new_end := retained_transform_regions[0].new_start
 				promote_scoped_ast_nodes(mut a, base_transform_nodes, outer_new_end,
 					scoped_owned_base_nodes, transform_scope)
@@ -1879,21 +1995,43 @@ fn main() {
 				transform_texts_canonical = true
 			}
 		} else {
-			a = clone_flat_ast_after_transform(a)
+			clone_flat_ast_storage(mut a)
 			pre_tc.rebind_ast(a)
 		}
 		if a.specialized_fn_nodes.len != base_specialized_fns {
 			a.specialized_fn_nodes = a.specialized_fn_nodes.clone()
 		}
-		promote_scoped_checker_node_caches(mut pre_tc)
+		promote_scoped_checker_node_caches(mut pre_tc, transform_scope, base_transform_nodes)
 		promote_scoped_signatures(mut pre_tc, original_signature_names)
 		used_fns = clone_string_bool_map(used_fns)
 		transform_errors = clone_string_list(transform_errors)
 		pre_tc.set_fresh_type_cache(parse_cache_enabled)
 		prealloc_scope_free_for_v3(transform_scope)
 		if retained_transform_regions.len > 0 {
+			if p.parsed_v_header_files > 0 {
+				// Header-only warm builds are small enough that transform may not
+				// force the pre-reserved flat arrays to grow. Publish their backing
+				// once in the compilation arena before releasing retained helper
+				// arenas; individual node text is promoted below.
+				clone_flat_ast_storage(mut a)
+				pre_tc.rebind_ast(a)
+			}
 			for region in retained_transform_regions {
-				canonicalize_scoped_transform_region(mut a, region)
+				if skip_transform_generics {
+					canonicalize_scoped_transform_region(mut a, region)
+				} else {
+					// Bounded generic batches can publish rewrites to any source node
+					// through this result arena, so verify every flat payload before
+					// releasing it.
+					for idx in 0 .. a.nodes.len {
+						canonicalize_scoped_node(mut a, idx, region.scope)
+					}
+				}
+				if scoped_value_owned(region.scope, a.nodes.data)
+					|| scoped_value_owned(region.scope, a.children.data) {
+					a = clone_flat_ast_after_transform(a)
+					pre_tc.rebind_ast(a)
+				}
 				prealloc_scope_free_for_v3(region.scope)
 			}
 			transform_texts_canonical = true
@@ -1927,6 +2065,13 @@ fn main() {
 	set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
 	if !building_v && !cmd_v_build {
 		if uses_generics {
+			if scope_prealloc_stages {
+				// Volt's reachable specialization set settles just below 4x the
+				// transformed node count. Reserving that bounded final size avoids
+				// growing 3x caches to 6x inside the disposable monomorph arena and
+				// then copying those oversized arrays back into the parent.
+				pre_tc.materialize_sparse_transform_node_caches(a.nodes.len, a.nodes.len * 4)
+			}
 			// Generic lowering rewrites and clones call nodes in disposable arenas.
 			// Resolve their final names from the owned transformed AST instead of
 			// retaining pre-transform canonical string views across arena release.
@@ -1972,14 +2117,47 @@ fn main() {
 		mut monomorph_used_fns := map[string]bool{}
 		mut monomorph_errors := []string{}
 		if scope_prealloc_stages {
+			// Monomorphization can add several times the transformed node count.
+			// Reserve its persistent slabs in the parent arena so scoped specialization
+			// batches append in place instead of retaining every growth allocation.
+			if verbose {
+				eprintln('mono AST before reserve: ${a.nodes.len}/${a.nodes.cap} nodes, ${a.children.len}/${a.children.cap} children')
+			}
+			base_monomorph_nodes := a.nodes.len
+			// Volt's retained specialization set stays just below 4x its transformed
+			// AST size. Reserving that final size directly avoids both the previous
+			// 3x-to-6x growth and permanently retaining the unused 2x headroom.
+			reserve_flat_ast_exact(mut a, a.nodes.len * 4, a.children.len * 4)
+			monomorph_nodes_cap := a.nodes.cap
+			monomorph_children_cap := a.children.cap
+			base_specialized_fns := a.specialized_fn_nodes.len
 			monomorph_scope := prealloc_scope_begin_for_v3()
-			monomorph_used_fns, monomorph_errors = transform.monomorphize_with_used_checked(mut a,
-				&pre_tc, used_fns)
+			monomorph_used_fns, monomorph_errors = transform.monomorphize_with_used_checked_config_scoped(mut a,
+				&pre_tc, used_fns, should_parallel_monomorphize(), monomorph_scope)
 			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			prealloc_scope_leave_for_v3(monomorph_scope)
-			a = clone_flat_ast_after_transform(a)
-			pre_tc.rebind_ast(a)
-			promote_scoped_checker_node_caches(mut pre_tc)
+			// Specialization can rewrite payload text on pre-existing nodes as
+			// well as append new nodes. Publish every string still owned by the
+			// disposable monomorph arena before it is released.
+			for idx in 0 .. a.nodes.len {
+				canonicalize_scoped_node(mut a, idx, monomorph_scope)
+			}
+			if verbose {
+				eprintln('mono AST after pass: ${a.nodes.len}/${a.nodes.cap} nodes, ${a.children.len}/${a.children.cap} children')
+			}
+			// The scoped transformer interns every escaping node payload while the
+			// parent arena is temporarily current. Only an unexpected AST backing
+			// growth still needs a full promotion clone.
+			if a.nodes.cap != monomorph_nodes_cap || a.children.cap != monomorph_children_cap
+				|| scoped_value_owned(monomorph_scope, a.nodes.data)
+				|| scoped_value_owned(monomorph_scope, a.children.data) {
+				a = clone_flat_ast_after_transform(a)
+				pre_tc.rebind_ast(a)
+			}
+			if a.specialized_fn_nodes.len != base_specialized_fns {
+				a.specialized_fn_nodes = a.specialized_fn_nodes.clone()
+			}
+			promote_scoped_checker_node_caches(mut pre_tc, monomorph_scope, base_monomorph_nodes)
 			pre_tc.rebuild_scoped_transform_signature_maps()
 			pre_tc.promote_scoped_transform_interners(0, 0, monomorph_scope)
 			promote_scoped_monomorph_metadata(mut pre_tc)
@@ -1988,8 +2166,8 @@ fn main() {
 			pre_tc.set_fresh_type_cache(parse_cache_enabled)
 			prealloc_scope_free_for_v3(monomorph_scope)
 		} else {
-			monomorph_used_fns, monomorph_errors = transform.monomorphize_with_used_checked(mut a,
-				&pre_tc, used_fns)
+			monomorph_used_fns, monomorph_errors = transform.monomorphize_with_used_checked_config(mut a,
+				&pre_tc, used_fns, should_parallel_monomorphize())
 		}
 		used_fns = monomorph_used_fns.move()
 		if monomorph_errors.len > 0 {
@@ -2010,21 +2188,7 @@ fn main() {
 		a.intern_node_texts_from(0)
 	}
 	b.step('monomorphize')
-	if cache_state.manager.enabled {
-		// The cache transform roots complete modules, but the ordinary `.c` artifact
-		// must retain normal dead-code elimination. Add only generated functions that
-		// are reachable from the entry program; do not import the cache-only roots.
-		post_transform_used := if test_files.len > 0 {
-			markused.mark_used_for_tests(a, pre_tc, test_files)
-		} else {
-			markused.mark_used(a, pre_tc)
-		}
-		for name, is_used in post_transform_used {
-			if is_used && (pre_tc.specialized_generic_fns[name] || name.starts_with('__v3_sum_eq_')) {
-				output_used_fns[name] = true
-			}
-		}
-	}
+	mut newly_cached_module_count := 0
 	if backend == 'arm64' {
 		$if !skip_arm64 ? {
 			// SSA + ARM64 native backend
@@ -2076,8 +2240,10 @@ fn main() {
 			''
 		}
 		mut generated_c_flags := []string{}
+		mut interface_impl_signature := ''
 		mut cgen_was_parallel := false
 		if scope_prealloc_cgen {
+			cgen_parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			cgen_scope := prealloc_scope_begin_for_v3()
 			mut g := cgen.FlatGen.new()
 			g.set_initial_c_flags(user_c_flags)
@@ -2098,28 +2264,20 @@ fn main() {
 			}
 			cgen_was_parallel = g.was_parallel()
 			scoped_c_flags := g.c_flags()
-			g.free_parallel_worker_scopes()
-			if cache_state.manager.enabled {
-				mut output_g := cgen.FlatGen.new()
-				output_g.set_initial_c_flags(user_c_flags)
-				output_g.set_c99_mode(prefs.c99)
-				output_g.set_prealloc('prealloc' in prefs.user_defines)
-				output_g.set_skip_generics(skip_transform_generics)
-				output_g.set_compiler_vexe(prefs.vexe)
-				output_g.set_target(prefs.target)
-				output_g.set_cache_program_files(user_files)
-				output_g.set_scope_parallel_workers(true)
-				output_g.gen_to_file_with_used_test_options(cc_src, a, output_used_fns, &pre_tc,
-					cache_no_parallel_cgen, test_files) or {
-					eprintln('error writing ${cc_src}: ${err}')
-					cleanup_c_build_dir(cc_dir)
-					exit(1)
-				}
-				cgen_was_parallel = cgen_was_parallel || output_g.was_parallel()
-				output_g.free_parallel_worker_scopes()
+			scoped_interface_impl_signature := if cache_state.manager.enabled {
+				pre_tc.interface_impl_set_signature()
+			} else {
+				''
 			}
+			g.free_parallel_worker_scopes()
 			prealloc_scope_leave_for_v3(cgen_scope)
 			generated_c_flags = clone_string_list(scoped_c_flags)
+			interface_impl_signature = scoped_interface_impl_signature.clone()
+			// Cgen's synchronous type queries memoize through the shared checker.
+			// Reattach empty parent-owned interners and caches before releasing its
+			// stage arena; all of them can grow while servicing those queries.
+			pre_tc.reset_type_interners()
+			pre_tc.set_fresh_type_cache(cgen_parse_cache_enabled)
 			prealloc_scope_free_for_v3(cgen_scope)
 		} else {
 			mut g := cgen.FlatGen.new()
@@ -2140,40 +2298,12 @@ fn main() {
 			}
 			cgen_was_parallel = g.was_parallel()
 			generated_c_flags = g.c_flags()
-			if cache_state.manager.enabled {
-				mut output_g := cgen.FlatGen.new()
-				output_g.set_initial_c_flags(user_c_flags)
-				output_g.set_c99_mode(prefs.c99)
-				output_g.set_prealloc('prealloc' in prefs.user_defines)
-				output_g.set_skip_generics(skip_transform_generics)
-				output_g.set_compiler_vexe(prefs.vexe)
-				output_g.set_target(prefs.target)
-				output_g.set_cache_program_files(user_files)
-				output_g.gen_to_file_with_used_test_options(cc_src, a, output_used_fns, &pre_tc,
-					cache_no_parallel_cgen, test_files) or {
-					eprintln('error writing ${cc_src}: ${err}')
-					cleanup_c_build_dir(cc_dir)
-					exit(1)
-				}
-				cgen_was_parallel = cgen_was_parallel || output_g.was_parallel()
-			}
 		}
 		b.step_parallel('cgen', cgen_was_parallel)
-		b.metric('generated C size', os.file_size(cc_src), 'bytes')
 		if c_only {
+			b.metric('generated C size', os.file_size(cc_src), 'bytes')
 			b.print_report()
 			return
-		}
-		published_c := '${output_file}.tmp.${os.getpid()}.${rand.ulid()}'
-		os.cp(cc_src, published_c) or {
-			eprintln('failed to stage generated C output ${output_file}: ${err}')
-			cleanup_c_build_dir(cc_dir)
-			exit(1)
-		}
-		os.mv(published_c, output_file) or {
-			eprintln('failed to publish generated C output ${output_file}: ${err}')
-			cleanup_c_build_dir(cc_dir)
-			exit(1)
 		}
 
 		pic_flag := shared_pic_flag(is_shared, prefs.normalized_target_os())
@@ -2209,11 +2339,14 @@ fn main() {
 		}
 		mut cached_objects := []string{}
 		if cache_state.manager.enabled {
+			cache_prepare_scope := prealloc_scope_begin_for_v3()
 			generated_source := os.read_file(cache_plan_file) or {
 				eprintln('error reading cache-marked C source ${cache_plan_file}: ${err.msg()}')
 				exit(1)
 			}
-			interface_impl_signature := pre_tc.interface_impl_set_signature()
+			if interface_impl_signature.len == 0 {
+				interface_impl_signature = pre_tc.interface_impl_set_signature()
+			}
 			opt_flag := if is_prod { '-O2' } else { '' }
 			warning_flags := warn_args.join(' ')
 			prepared_cache := prepare_v3_module_cache(generated_source, c_standard, opt_flag,
@@ -2228,8 +2361,23 @@ fn main() {
 				cleanup_c_build_dir(cc_dir)
 				exit(1)
 			}
-			cached_objects = prepared_cache.objects.clone()
+			prealloc_scope_leave_for_v3(cache_prepare_scope)
+			cached_objects = clone_string_list(prepared_cache.objects)
+			newly_cached_module_count = prepared_cache.newly_cached_modules
+			prealloc_scope_free_for_v3(cache_prepare_scope)
 			os.rm(cache_plan_file) or {}
+		}
+		b.metric('generated C size', os.file_size(cc_src), 'bytes')
+		published_c := '${output_file}.tmp.${os.getpid()}.${rand.ulid()}'
+		os.cp(cc_src, published_c) or {
+			eprintln('failed to stage generated C output ${output_file}: ${err}')
+			cleanup_c_build_dir(cc_dir)
+			exit(1)
+		}
+		os.mv(published_c, output_file) or {
+			eprintln('failed to publish generated C output ${output_file}: ${err}')
+			cleanup_c_build_dir(cc_dir)
+			exit(1)
 		}
 		// Compile inside a per-output build dir, using constant relative source/output basenames,
 		// then move the result to bin_file. On macOS arm64 tcc bakes the -o basename into the
@@ -2365,6 +2513,9 @@ fn main() {
 	b.metric('C object publish races', c_object_cache_stats.publish_races, 'objects')
 	b.metric('C object input-snapshot races', c_object_cache_stats.input_snapshot_races, 'objects')
 	b.print_report()
+	if newly_cached_module_count > 0 {
+		println('Hint: cached ${newly_cached_module_count} modules. They will not be recompiled on the next run unless they change.')
+	}
 }
 
 fn builtin_bundle_source_files(prefs &pref.Preferences, builtin_files []string) []string {
@@ -2396,16 +2547,33 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 		return error('v3 module cache directory is unavailable')
 	}
 	split := modulecache.split_generated_c(generated_source)!
-	declarations := modulecache.declaration_header(split.prefix)
+	mut parsed_modules := state.parsed_from_source.keys()
+	parsed_modules.sort()
+	mut newly_cached_modules := map[string]bool{}
+	mut needs_declarations := !state.bundle_valid
+	if !needs_declarations {
+		for module_name in parsed_modules {
+			if !module_is_builtin_bundle(state, module_name) {
+				needs_declarations = true
+				break
+			}
+		}
+	}
+	declarations := if needs_declarations {
+		cache_source_without_cached_native_inputs(modulecache.declaration_header(split.prefix),
+			state, false)
+	} else {
+		''
+	}
 	compile_signature := v3_cached_object_compile_signature(c_standard, opt_flag, pic_flag,
-		warning_flags, generated_c_flags, objective_c, interface_impl_signature,
-		modulecache.header_signature(declarations))
+		warning_flags, generated_c_flags, objective_c, interface_impl_signature)
 	if resolve_flag_specific_cache_objects(mut state, compile_signature) {
 		os.setenv('V3_CACHE_FORCE_SOURCE', '1', true)
 		restart_v3_after_cache_invalidation()
 	}
 	main_body := split.modules['main'] or { '' }
-	main_source := split.prefix + main_body
+	main_prefix := cache_source_without_cached_native_inputs(split.prefix, state, true)
+	main_source := '#define V3CACHE_PROGRAM_UNIT 1\n' + main_prefix + main_body
 	mut object_paths := state.objects.clone()
 	mut bundle_body := strings.new_builder(4096)
 	mut split_modules := split.modules.keys()
@@ -2417,7 +2585,14 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 	}
 	if !state.bundle_valid {
 		entry := state.manager.object_entry('builtin', state.bundle_sources, compile_signature)
-		module_source := declarations + bundle_body.str()
+		bundle_native_includes := cache_native_source_includes(state,
+			cache_builtin_bundle_roots(state))
+		module_source := if bundle_native_includes.len > 0 {
+			'#define V3CACHE_PROGRAM_UNIT 1\n' + declarations + '#undef V3CACHE_PROGRAM_UNIT\n' +
+				bundle_native_includes + bundle_body.str()
+		} else {
+			declarations + bundle_body.str()
+		}
 		compile_v3_cached_object(entry, module_source, c_standard, opt_flag, pic_flag,
 			warning_flags, generated_c_flags, objective_c)!
 		for module_name, header in state.headers {
@@ -2434,11 +2609,14 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 			compile_signature)!
 		object_paths['builtin'] = entry.object
 		state.bundle_valid = true
+		for module_name in state.headers.keys() {
+			if module_is_builtin_bundle(state, module_name) {
+				newly_cached_modules[module_name] = true
+			}
+		}
 	}
 	unsafe { bundle_body.free() }
 
-	mut parsed_modules := state.parsed_from_source.keys()
-	parsed_modules.sort()
 	for module_name in parsed_modules {
 		if module_is_builtin_bundle(state, module_name) {
 			continue
@@ -2448,7 +2626,14 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 		body := split.modules[module_name] or {
 			split.modules[module_name.all_after_last('.')] or { '' }
 		}
-		compile_v3_cached_object(entry, declarations + body, c_standard, opt_flag, pic_flag,
+		native_includes := cache_native_source_includes(state, [module_name])
+		module_source := if native_includes.len > 0 {
+			'#define V3CACHE_PROGRAM_UNIT 1\n' + declarations + '#undef V3CACHE_PROGRAM_UNIT\n' +
+				native_includes + body
+		} else {
+			declarations + body
+		}
+		compile_v3_cached_object(entry, module_source, c_standard, opt_flag, pic_flag,
 			warning_flags, generated_c_flags, objective_c)!
 		if header := state.headers[module_name] {
 			state.manager.write_header(module_name, source_files, header)!
@@ -2456,6 +2641,7 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 		dependencies := cache_object_dependency_signatures(state, [module_name])
 		state.manager.write_stamp(module_name, source_files, dependencies, compile_signature)!
 		object_paths[module_name] = entry.object
+		newly_cached_modules[module_name] = true
 	}
 
 	mut objects := []string{}
@@ -2468,9 +2654,72 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 		}
 	}
 	return V3PreparedModuleCache{
-		main_source: main_source
-		objects:     objects
+		main_source:          main_source
+		objects:              objects
+		newly_cached_modules: newly_cached_modules.len
 	}
+}
+
+fn cache_source_without_cached_native_inputs(source string, state &V3ModuleCacheState, keep_main bool) string {
+	mut excluded := map[string]bool{}
+	for raw_module_name, paths in state.module_external_inputs {
+		module_name := if raw_module_name == 'main' {
+			'main'
+		} else {
+			cache_state_module_name(state, raw_module_name) or { continue }
+		}
+		if (keep_main && module_name == 'main') || !state.native_source_modules[module_name] {
+			continue
+		}
+		for path in paths {
+			if !c_flag_is_c_source_file(path) {
+				continue
+			}
+			clean := os.real_path(path).replace('\\', '/').replace('"', '\\"')
+			excluded['#include "${clean}"'] = true
+		}
+	}
+	if excluded.len == 0 {
+		return source
+	}
+	mut out := strings.new_builder(source.len)
+	for line in source.split_into_lines() {
+		if !excluded[line.trim_space()] {
+			out.writeln(line)
+		}
+	}
+	return out.str()
+}
+
+fn cache_native_source_includes(state &V3ModuleCacheState, module_names []string) string {
+	mut selected := map[string]bool{}
+	for module_name in module_names {
+		selected[module_name] = true
+	}
+	mut paths := map[string]bool{}
+	for raw_module_name, inputs in state.module_external_inputs {
+		module_name := if raw_module_name == 'main' {
+			'main'
+		} else {
+			cache_state_module_name(state, raw_module_name) or { continue }
+		}
+		if !selected[module_name] || !state.native_source_modules[module_name] {
+			continue
+		}
+		for input in inputs {
+			if c_flag_is_c_source_file(input) {
+				paths[os.real_path(input)] = true
+			}
+		}
+	}
+	mut sorted_paths := paths.keys()
+	sorted_paths.sort()
+	mut out := strings.new_builder(sorted_paths.len * 96)
+	for path in sorted_paths {
+		clean := path.replace('\\', '/').replace('"', '\\"')
+		out.writeln('#include "${clean}"')
+	}
+	return out.str()
 }
 
 fn module_cache_source_path_set(source_files []string) map[string]bool {
@@ -2588,15 +2837,50 @@ fn cache_add_module_header_signature(state &V3ModuleCacheState, module_name stri
 
 fn cache_object_dependency_signatures(state &V3ModuleCacheState, roots []string) map[string]string {
 	mut signatures := cache_dependency_header_signatures(state, roots)
+	// The parser injects these imports into the program stream instead of a
+	// particular file. Their position therefore cannot assign them to a stable
+	// owner module; every cached object that can reference their generated
+	// helpers conservatively tracks their interfaces.
+	for implicit_name in ['sync', 'v.embed_file'] {
+		if implicit_module := cache_state_module_name(state, implicit_name) {
+			cache_add_module_header_signature(state, implicit_module, mut signatures)
+		}
+	}
 	// Every cached translation unit is compiled with the builtin bundle's declarations
 	// prefix, even when its V module has no explicit builtin import.
 	for module_name in cache_builtin_bundle_roots(state) {
 		cache_add_module_header_signature(state, module_name, mut signatures)
 	}
+	mut external_input_modules := map[string]bool{}
+	for root in roots {
+		if canonical := cache_state_module_name(state, root) {
+			external_input_modules[canonical] = true
+		}
+	}
+	for dependency in cache_dependency_modules(state, roots) {
+		external_input_modules[dependency] = true
+	}
 	mut input_modules := state.module_external_inputs.keys()
 	input_modules.sort()
-	for module_name in input_modules {
-		for path in state.module_external_inputs[module_name] {
+	for raw_module_name in input_modules {
+		if raw_module_name == '__v3_c_flags__' {
+			for path in state.module_external_inputs[raw_module_name] {
+				signature := modulecache.file_signature(path)
+				if signature.len > 0 {
+					signatures[path] = signature
+				}
+			}
+			continue
+		}
+		module_name := if raw_module_name == 'main' {
+			'main'
+		} else {
+			cache_state_module_name(state, raw_module_name) or { raw_module_name }
+		}
+		if !external_input_modules[module_name] {
+			continue
+		}
+		for path in state.module_external_inputs[raw_module_name] {
 			signature := modulecache.file_signature(path)
 			if signature.len > 0 {
 				signatures[path] = signature
@@ -2670,19 +2954,31 @@ fn restart_v3_with_args(extra_args []string) {
 	}
 }
 
-fn cache_external_inputs_have_static_storage(inputs map[string][]string) bool {
-	for paths in inputs.values() {
+fn cache_external_input_owner_modules(state &V3ModuleCacheState) (map[string]bool, bool) {
+	mut modules := map[string]bool{}
+	for raw_module_name, paths in state.module_external_inputs {
 		for path in paths {
 			source := os.read_file(path) or { continue }
-			if modulecache.c_source_has_static_storage(source) {
-				return true
+			if !modulecache.c_source_has_static_storage(source) {
+				continue
 			}
+			if !c_flag_is_c_source_file(path) {
+				return modules, false
+			}
+			if raw_module_name == 'main' {
+				modules['main'] = true
+				continue
+			}
+			module_name := cache_state_module_name(state, raw_module_name) or {
+				return modules, false
+			}
+			modules[module_name] = true
 		}
 	}
-	return false
+	return modules, true
 }
 
-fn v3_cached_object_compile_signature(c_standard string, opt_flag string, pic_flag string, warning_flags string, generated_c_flags []string, objective_c bool, interface_impl_signature string, declarations_signature string) string {
+fn v3_cached_object_compile_signature(c_standard string, opt_flag string, pic_flag string, warning_flags string, generated_c_flags []string, objective_c bool, interface_impl_signature string) string {
 	mut flags := c_object_compile_flags(generated_c_flags)
 	flags = flags.filter(!c_flag_is_object_file(it))
 	mut inputs := []string{}
@@ -2696,7 +2992,6 @@ fn v3_cached_object_compile_signature(c_standard string, opt_flag string, pic_fl
 		'pic=${pic_flag.trim_space()}',
 		'warnings=${warning_flags.trim_space()}',
 		'interfaces=${interface_impl_signature}',
-		'declarations=${declarations_signature}',
 		'flags=${flags.join('\\n')}',
 		'inputs=${inputs.join('\\n')}',
 	].join('\n')
@@ -3481,7 +3776,23 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			if is_bundle_warmup_import
 				&& (mod_name in parsed_module_identities || mod_name in parsed_modules)
 				&& !module_is_builtin_bundle(cache_state, mod_name) {
-				restart_v3_without_cache()
+				// A project module may shadow an optional builtin-bundle import (for
+				// example, a top-level `hash` module). Keep the project module as its
+				// own cache object and omit the shadowed warmup import from this bundle.
+				node_idx++
+				continue
+			}
+			if is_bundle_warmup_import && cache_state.bundle_valid {
+				warmup_dir := prefs.get_vlib_module_path(mod_name)
+				warmup_files := pref.get_v_files_from_dir_for_target(warmup_dir,
+					prefs.user_defines, prefs.target)
+				if cache_state.manager.valid_header(mod_name, warmup_files) == none {
+					// The cached bundle may have been built while a project module
+					// shadowed this optional warmup import. An actual user import was
+					// already resolved above; do not rebuild just to warm an unused one.
+					node_idx++
+					continue
+				}
 			}
 			if module_identity := parsed_module_identities[mod_name] {
 				if module_identity.len > 0 {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1696,6 +1696,7 @@ fn incremental_declaration_attribute_signatures(a &flat.FlatAst) map[int]string 
 
 fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 	mut declaration_parts := []string{}
+	mut ordered_import_directive_parts := []string{}
 	mut global_initializer_parts := []string{}
 	mut synthetic_main_parts := []string{}
 	mut functions := []V3IncrementalFn{}
@@ -1742,14 +1743,21 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 				part := '${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
 					flat.NodeId(idx))}\t${attribute_signature}'
 				declaration_parts << part
+				if node.kind == .import_decl {
+					ordered_import_directive_parts << part
+				}
 				if node.kind == .global_decl {
 					global_initializer_parts << part
 				}
 			}
 			.directive, .comptime_if, .comptime_for, .asm_stmt, .sql_expr, .fn_literal {
 				if top_level_nodes[idx] {
-					declaration_parts << '${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
+					part := '${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
 						flat.NodeId(idx))}'
+					declaration_parts << part
+					if node.kind == .directive {
+						ordered_import_directive_parts << part
+					}
 				}
 			}
 			else {
@@ -1763,6 +1771,11 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 	declaration_parts.sort()
 	mut declaration_hash := u64(1469598103934665603)
 	for part in declaration_parts {
+		declaration_hash = c_hash_bytes(declaration_hash, part.bytes())
+		declaration_hash = c_hash_bytes(declaration_hash, [u8(0xff)])
+	}
+	declaration_hash = c_hash_bytes(declaration_hash, 'ordered-imports-directives'.bytes())
+	for part in ordered_import_directive_parts {
 		declaration_hash = c_hash_bytes(declaration_hash, part.bytes())
 		declaration_hash = c_hash_bytes(declaration_hash, [u8(0xff)])
 	}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -4506,12 +4506,12 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 			}
 		}
 	}
-	declarations := if needs_declarations {
-		cache_source_without_cached_native_inputs(modulecache.declaration_header(split.prefix),
-			state, false)
+	raw_declarations := if needs_declarations {
+		modulecache.declaration_header(split.prefix)
 	} else {
 		''
 	}
+	declarations := cache_source_without_cached_native_inputs(raw_declarations, state, false)
 	compile_signature := v3_cached_object_compile_signature(c_standard, opt_flag, pic_flag,
 		warning_flags, generated_c_flags, objective_c, interface_impl_signature)
 	if resolve_flag_specific_cache_objects(mut state, compile_signature) {
@@ -4541,11 +4541,12 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 	}
 	if !state.bundle_valid {
 		entry := state.manager.object_entry('builtin', state.bundle_sources, compile_signature)
-		bundle_native_includes := cache_native_source_includes(state,
+		bundle_native := cache_source_with_cached_native_inputs(raw_declarations, state,
 			cache_builtin_bundle_roots(state))
-		module_source := if bundle_native_includes.len > 0 {
-			'#define V3CACHE_PROGRAM_UNIT 1\n' + declarations + '#undef V3CACHE_PROGRAM_UNIT\n' +
-				bundle_native_includes + bundle_body.str()
+		module_source := if bundle_native.has_native {
+			'#define V3CACHE_PROGRAM_UNIT 1\n' + bundle_native.source +
+				'#undef V3CACHE_PROGRAM_UNIT\n' + bundle_native.remaining_includes +
+				bundle_body.str()
 		} else {
 			declarations + bundle_body.str()
 		}
@@ -4582,10 +4583,12 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 		body := split.modules[module_name] or {
 			split.modules[module_name.all_after_last('.')] or { '' }
 		}
-		native_includes := cache_native_source_includes(state, [module_name])
-		module_source := if native_includes.len > 0 {
-			'#define V3CACHE_PROGRAM_UNIT 1\n' + declarations + '#undef V3CACHE_PROGRAM_UNIT\n' +
-				native_includes + body
+		native := cache_source_with_cached_native_inputs(raw_declarations, state, [
+			module_name,
+		])
+		module_source := if native.has_native {
+			'#define V3CACHE_PROGRAM_UNIT 1\n' + native.source + '#undef V3CACHE_PROGRAM_UNIT\n' +
+				native.remaining_includes + body
 		} else {
 			declarations + body
 		}
@@ -4659,27 +4662,73 @@ fn cache_source_without_cached_native_inputs(source string, state &V3ModuleCache
 	return out.str()
 }
 
-fn cache_native_source_includes(state &V3ModuleCacheState, module_names []string) string {
+struct V3CachedNativeSource {
+	source             string
+	remaining_includes string
+	has_native         bool
+}
+
+fn cache_source_with_cached_native_inputs(source string, state &V3ModuleCacheState, module_names []string) V3CachedNativeSource {
 	mut selected := map[string]bool{}
 	for module_name in module_names {
 		selected[module_name] = true
 	}
-	mut out := strings.new_builder(module_names.len * 96)
-	for raw_module_name, roots in state.module_native_roots {
+	mut all_include_lines := map[string]bool{}
+	mut selected_include_lines := map[string]bool{}
+	mut selected_order := []string{}
+	mut raw_module_names := state.module_native_roots.keys()
+	raw_module_names.sort()
+	for raw_module_name in raw_module_names {
+		roots := state.module_native_roots[raw_module_name]
 		module_name := if raw_module_name == 'main' {
 			'main'
 		} else {
 			cache_state_module_name(state, raw_module_name) or { continue }
 		}
-		if !selected[module_name] || !state.native_source_modules[module_name] {
+		if !state.native_source_modules[module_name] {
 			continue
 		}
 		for root in roots {
 			clean := os.real_path(root).replace('\\', '/').replace('"', '\\"')
-			out.writeln('#include "${clean}"')
+			include_line := '#include "${clean}"'
+			all_include_lines[include_line] = true
+			if selected[module_name] && !selected_include_lines[include_line] {
+				selected_include_lines[include_line] = true
+				selected_order << include_line
+			}
 		}
 	}
-	return out.str()
+	if selected_include_lines.len == 0 {
+		return V3CachedNativeSource{
+			source: cache_source_without_cached_native_inputs(source, state, false)
+		}
+	}
+	mut found := map[string]bool{}
+	mut out := strings.new_builder(source.len + selected_include_lines.len * 64)
+	for line in source.split_into_lines() {
+		clean := line.trim_space()
+		if selected_include_lines[clean] {
+			// The compiler-only macro suppresses fallback declarations, but must not
+			// leak into native source that did not see it in the uncached unit.
+			out.writeln('#undef V3CACHE_PROGRAM_UNIT')
+			out.writeln(line)
+			out.writeln('#define V3CACHE_PROGRAM_UNIT 1')
+			found[clean] = true
+		} else if !all_include_lines[clean] {
+			out.writeln(line)
+		}
+	}
+	mut remaining := strings.new_builder(selected_order.len * 96)
+	for include_line in selected_order {
+		if !found[include_line] {
+			remaining.writeln(include_line)
+		}
+	}
+	return V3CachedNativeSource{
+		source:             out.str()
+		remaining_includes: remaining.str()
+		has_native:         true
+	}
 }
 
 fn module_cache_source_path_set(source_files []string) map[string]bool {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1763,6 +1763,7 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 	mut declaration_parts := []string{}
 	mut ordered_import_directive_parts := []string{}
 	mut global_initializer_parts := []string{}
+	mut const_initializer_parts := []string{}
 	mut synthetic_main_parts := []string{}
 	mut functions := []V3IncrementalFn{}
 	mut cur_file := ''
@@ -1814,6 +1815,9 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 				if node.kind == .global_decl {
 					global_initializer_parts << part
 				}
+				if node.kind == .const_decl {
+					const_initializer_parts << part
+				}
 			}
 			.directive, .comptime_if, .comptime_for, .asm_stmt, .sql_expr, .fn_literal {
 				if top_level_nodes[idx] {
@@ -1846,6 +1850,11 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 	}
 	declaration_hash = c_hash_bytes(declaration_hash, 'ordered-global-initializers'.bytes())
 	for part in global_initializer_parts {
+		declaration_hash = c_hash_bytes(declaration_hash, part.bytes())
+		declaration_hash = c_hash_bytes(declaration_hash, [u8(0xff)])
+	}
+	declaration_hash = c_hash_bytes(declaration_hash, 'ordered-const-initializers'.bytes())
+	for part in const_initializer_parts {
 		declaration_hash = c_hash_bytes(declaration_hash, part.bytes())
 		declaration_hash = c_hash_bytes(declaration_hash, [u8(0xff)])
 	}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1492,6 +1492,11 @@ fn monomorph_cache_semantic_signature(a &flat.FlatAst) string {
 	for child in a.children {
 		hash = c_hash_tag(hash, int(child))
 	}
+	return c_hash_function_metadata(hash, a).hex()
+}
+
+fn c_hash_function_metadata(initial u64, a &flat.FlatAst) u64 {
+	mut hash := initial
 	mut disabled_names := a.disabled_fns.keys()
 	disabled_names.sort()
 	for name in disabled_names {
@@ -1512,7 +1517,7 @@ fn monomorph_cache_semantic_signature(a &flat.FlatAst) string {
 		hash = c_hash_bytes(hash, name.bytes())
 		hash = c_hash_bytes(hash, [u8(a.noreturn_fns[name]), u8(0xfa)])
 	}
-	return hash.hex()
+	return hash
 }
 
 @[inline]
@@ -1681,6 +1686,7 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 		declaration_hash = c_hash_bytes(declaration_hash, part.bytes())
 		declaration_hash = c_hash_bytes(declaration_hash, [u8(0xff)])
 	}
+	declaration_hash = c_hash_function_metadata(declaration_hash, a)
 	return V3IncrementalSnapshot{
 		declaration_signature: declaration_hash.hex()
 		functions:             functions

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1644,6 +1644,7 @@ fn incremental_declaration_attribute_signatures(a &flat.FlatAst) map[int]string 
 
 fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 	mut declaration_parts := []string{}
+	mut global_initializer_parts := []string{}
 	mut synthetic_main_parts := []string{}
 	mut functions := []V3IncrementalFn{}
 	mut cur_file := ''
@@ -1686,8 +1687,12 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 			.struct_decl, .global_decl, .const_decl, .enum_decl, .type_decl, .interface_decl,
 			.import_decl, .c_fn_decl {
 				attribute_signature := declaration_attributes[idx] or { '' }
-				declaration_parts << '${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
+				part := '${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
 					flat.NodeId(idx))}\t${attribute_signature}'
+				declaration_parts << part
+				if node.kind == .global_decl {
+					global_initializer_parts << part
+				}
 			}
 			.directive, .comptime_if, .comptime_for, .asm_stmt, .sql_expr, .fn_literal {
 				if top_level_nodes[idx] {
@@ -1706,6 +1711,11 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 	declaration_parts.sort()
 	mut declaration_hash := u64(1469598103934665603)
 	for part in declaration_parts {
+		declaration_hash = c_hash_bytes(declaration_hash, part.bytes())
+		declaration_hash = c_hash_bytes(declaration_hash, [u8(0xff)])
+	}
+	declaration_hash = c_hash_bytes(declaration_hash, 'ordered-global-initializers'.bytes())
+	for part in global_initializer_parts {
 		declaration_hash = c_hash_bytes(declaration_hash, part.bytes())
 		declaration_hash = c_hash_bytes(declaration_hash, [u8(0xff)])
 	}
@@ -3078,7 +3088,7 @@ fn main() {
 	mut generated_monomorph_specs := []transform.MonomorphCacheSpec{}
 	mut cache_c_flags := user_c_flags.clone()
 	if backend == 'c' && cache_state.manager.enabled {
-		cache_c_flags << cgen.cache_pkgconfig_flags(a)
+		cache_c_flags << cgen.cache_directive_flags(a, prefs.vroot, prefs.target)
 	}
 	incremental_snapshot := incremental_program_snapshot(a)
 	mut incremental_cache_hit := false

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3194,6 +3194,22 @@ fn main() {
 		if generic_cache_hit && test_files.len == 0 {
 			used_fns = clone_string_bool_map(cached_program_used_fns)
 			uses_generics = true
+			if incremental_cache_hit {
+				current_used_fns, current_uses_generics := markused.mark_used_with_generic_usage(a,
+					markused_tc)
+				uses_generics = uses_generics || current_uses_generics
+				mut gained_reachability := false
+				for name, is_used in current_used_fns {
+					if is_used && !cached_program_used_fns[name] {
+						gained_reachability = true
+						break
+					}
+				}
+				if gained_reachability {
+					os.setenv('V3_CACHE_DISABLE_INCREMENTAL', '1', true)
+					restart_v3_after_cache_invalidation()
+				}
+			}
 		} else if test_files.len > 0 {
 			used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a,
 				markused_tc, test_files)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -85,6 +85,11 @@ struct V3CgenCacheInput {
 	generation_signature string
 }
 
+struct V3CgenCacheMetadata {
+	interface_impl_signature string
+	flags                    []string
+}
+
 fn tcc_atomic_s_arg(prefs &pref.Preferences) string {
 	target_os := prefs.normalized_target_os()
 	mut link_atomic_s := false
@@ -988,7 +993,7 @@ fn clone_string_list(values []string) []string {
 	return cloned
 }
 
-fn v3_cgen_cache_input(state &V3ModuleCacheState, user_files []string, user_c_flags []string, interface_impl_signature string) V3CgenCacheInput {
+fn v3_cgen_cache_input(state &V3ModuleCacheState, user_files []string, user_c_flags []string) V3CgenCacheInput {
 	mut source_set := map[string]bool{}
 	for file in user_files {
 		source_set[os.real_path(file)] = true
@@ -1017,19 +1022,25 @@ fn v3_cgen_cache_input(state &V3ModuleCacheState, user_files []string, user_c_fl
 	return V3CgenCacheInput{
 		source_files:         source_files
 		dependency_inputs:    dependencies
-		generation_signature: interface_impl_signature + '\x00' + user_c_flags.join('\x00')
+		generation_signature: user_c_flags.join('\x00')
 	}
 }
 
-fn encode_v3_cgen_flags(flags []string) string {
-	return flags.join('\x00')
+fn encode_v3_cgen_metadata(flags []string, interface_impl_signature string) string {
+	mut parts := ['v3-cgen-metadata-v2', interface_impl_signature]
+	parts << flags
+	return parts.join('\x00')
 }
 
-fn decode_v3_cgen_flags(metadata string) []string {
-	if metadata.len == 0 {
-		return []string{}
+fn decode_v3_cgen_metadata(metadata string) ?V3CgenCacheMetadata {
+	parts := metadata.split('\x00')
+	if parts.len < 2 || parts[0] != 'v3-cgen-metadata-v2' {
+		return none
 	}
-	return metadata.split('\x00')
+	return V3CgenCacheMetadata{
+		interface_impl_signature: parts[1]
+		flags:                    parts[2..].clone()
+	}
 }
 
 // clone_string_bool_map promotes a string-keyed set out of a disposable stage arena.
@@ -2380,11 +2391,35 @@ fn main() {
 		}
 	}
 
+	// A valid whole-program C plan no longer needs the specialized AST that
+	// produced it. Validate it before monomorphization so unchanged cached builds
+	// can skip cloning more than a million generic nodes.
+	mut cgen_cache_entry := modulecache.CgenEntry{}
+	mut cgen_cache_metadata := V3CgenCacheMetadata{}
+	mut cgen_cache_hit := false
+	if backend == 'c' && cache_state.manager.enabled && !cache_state.force_source
+		&& cache_state.parsed_from_source.len == 0 {
+		input := v3_cgen_cache_input(cache_state, user_files, user_c_flags)
+		if entry := cache_state.manager.valid_cgen(input.source_files, input.generation_signature,
+			input.dependency_inputs)
+		{
+			metadata := os.read_file(entry.metadata) or { '' }
+			if decoded := decode_v3_cgen_metadata(metadata) {
+				cgen_cache_entry = entry
+				cgen_cache_metadata = decoded
+				cgen_cache_hit = true
+			}
+		}
+	}
+
 	// Monomorphization only adds specialized generic instantiations to `used_fns`. Skip
 	// it when markused found no reachable generic use; the small metadata cleanup keeps
 	// unreachable generic templates out of C without walking or rewriting their ASTs.
 	// Self-host builds retain their dedicated generic-function erasure pass.
-	if building_v {
+	if cgen_cache_hit {
+		// The cached C plan and metadata are the only consumers of the specialized
+		// AST and checker state on this path.
+	} else if building_v {
 		used_fns = transform.erase_generic_templates(mut a, &pre_tc, used_fns)
 	} else if uses_generics {
 		mut monomorph_used_fns := map[string]bool{}
@@ -2460,7 +2495,11 @@ fn main() {
 	if !transform_texts_canonical {
 		a.intern_node_texts_from(0)
 	}
-	b.step('monomorphize')
+	if cgen_cache_hit {
+		b.step('monomorphize (cached)')
+	} else {
+		b.step('monomorphize')
+	}
 	mut newly_cached_module_count := 0
 	if backend == 'arm64' {
 		$if !skip_arm64 ? {
@@ -2512,33 +2551,14 @@ fn main() {
 		} else {
 			''
 		}
-		mut generated_c_flags := []string{}
-		mut interface_impl_signature := ''
+		mut generated_c_flags := cgen_cache_metadata.flags.clone()
+		mut interface_impl_signature := cgen_cache_metadata.interface_impl_signature
 		mut cgen_was_parallel := false
-		mut cgen_cache_hit := false
-		mut cgen_cache_input := V3CgenCacheInput{}
-		if cache_state.manager.enabled {
-			interface_impl_signature = pre_tc.interface_impl_set_signature()
-			cgen_cache_input = v3_cgen_cache_input(cache_state, user_files, user_c_flags,
-				interface_impl_signature)
-			// Any imported module reparsed from source needs a fresh plan even when
-			// its public declaration header happens to remain byte-identical.
-			if !cache_state.force_source && cache_state.parsed_from_source.len == 0 {
-				if entry := cache_state.manager.valid_cgen(cgen_cache_input.source_files,
-					cgen_cache_input.generation_signature, cgen_cache_input.dependency_inputs)
-				{
-					mut metadata_ok := true
-					metadata := os.read_file(entry.metadata) or {
-						metadata_ok = false
-						''
-					}
-					mut source_ok := true
-					os.cp(entry.source, cache_plan_file) or { source_ok = false }
-					if metadata_ok && source_ok {
-						generated_c_flags = decode_v3_cgen_flags(metadata)
-						cgen_cache_hit = true
-					}
-				}
+		if cgen_cache_hit {
+			os.cp(cgen_cache_entry.source, cache_plan_file) or {
+				eprintln('error restoring cached C plan ${cgen_cache_entry.source}: ${err.msg()}')
+				cleanup_c_build_dir(cc_dir)
+				exit(1)
 			}
 		}
 		if !cgen_cache_hit && scope_prealloc_cgen {
@@ -2661,11 +2681,11 @@ fn main() {
 			}
 			if !cgen_cache_hit {
 				published_cgen_cache_input := v3_cgen_cache_input(cache_state, user_files,
-					user_c_flags, interface_impl_signature)
+					user_c_flags)
 				cache_state.manager.write_cgen(published_cgen_cache_input.source_files,
 					published_cgen_cache_input.generation_signature,
-					published_cgen_cache_input.dependency_inputs, generated_source,
-					encode_v3_cgen_flags(generated_c_flags)) or {}
+					published_cgen_cache_input.dependency_inputs, generated_source, encode_v3_cgen_metadata(generated_c_flags,
+					interface_impl_signature)) or {}
 			}
 			prealloc_scope_leave_for_v3(cache_prepare_scope)
 			cached_objects = clone_string_list(prepared_cache.objects)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -79,6 +79,12 @@ struct V3PreparedModuleCache {
 	newly_cached_modules int
 }
 
+struct V3CgenCacheInput {
+	source_files         []string
+	dependency_inputs    map[string]string
+	generation_signature string
+}
+
 fn tcc_atomic_s_arg(prefs &pref.Preferences) string {
 	target_os := prefs.normalized_target_os()
 	mut link_atomic_s := false
@@ -750,6 +756,50 @@ fn clone_string_list(values []string) []string {
 		cloned << value.clone()
 	}
 	return cloned
+}
+
+fn v3_cgen_cache_input(state &V3ModuleCacheState, user_files []string, user_c_flags []string, interface_impl_signature string) V3CgenCacheInput {
+	mut source_set := map[string]bool{}
+	for file in user_files {
+		source_set[os.real_path(file)] = true
+	}
+	mut dependencies := map[string]string{}
+	mut module_names := state.module_sources.keys()
+	module_names.sort()
+	for module_name in module_names {
+		source_files := state.module_sources[module_name]
+		entry := state.manager.entry(module_name, source_files)
+		mut source_paths := source_files.map(os.real_path(it))
+		source_paths.sort()
+		dependencies['module:${module_name}'] =
+			modulecache.header_signature(source_paths.join('\n'))
+		if header := state.headers[module_name] {
+			dependencies[entry.header] = modulecache.header_signature(header)
+		} else if os.is_file(entry.header) {
+			dependencies[entry.header] = modulecache.file_signature(entry.header)
+		}
+		if os.is_file(entry.header_stamp) {
+			dependencies[entry.header_stamp] = modulecache.file_signature(entry.header_stamp)
+		}
+	}
+	mut source_files := source_set.keys()
+	source_files.sort()
+	return V3CgenCacheInput{
+		source_files:         source_files
+		dependency_inputs:    dependencies
+		generation_signature: interface_impl_signature + '\x00' + user_c_flags.join('\x00')
+	}
+}
+
+fn encode_v3_cgen_flags(flags []string) string {
+	return flags.join('\x00')
+}
+
+fn decode_v3_cgen_flags(metadata string) []string {
+	if metadata.len == 0 {
+		return []string{}
+	}
+	return metadata.split('\x00')
 }
 
 // clone_string_bool_map promotes a string-keyed set out of a disposable stage arena.
@@ -1664,16 +1714,9 @@ fn main() {
 	cache_manager := modulecache.new_manager(prefs.vroot, cache_salt, cache_enabled,
 		build_pseudo_values)
 	force_cache_source := os.getenv('V3_CACHE_FORCE_SOURCE') == '1'
-	// The cache generator emits complete module bodies, including late generic
-	// specializations that are not reachable from the entry program. Its split output
-	// currently relies on the serial function-item walk to retain those definitions.
-	// Compiler self-hosts skip generic lowering, so their cache split can still use cgen workers.
-	// Large generic user programs retain a substantially expanded AST after
-	// monomorphization. Stream them through the serial cgen path in preallocated
-	// builds so worker setup does not clone that retained state at the peak.
+	// Cache markers and scoped output are stable across ordered worker chunks, so cached
+	// and preallocated builds use the same parallel function-body generator.
 	cache_no_parallel_cgen := current_no_parallel
-		|| (cache_manager.enabled && !building_v && !cmd_v_build)
-		|| (scope_prealloc_stages && !building_v && !cmd_v_build)
 	mut p := parser.Parser.new(prefs)
 	if building_v || cmd_v_build {
 		p.reserve_selfhost_ast()
@@ -2242,7 +2285,33 @@ fn main() {
 		mut generated_c_flags := []string{}
 		mut interface_impl_signature := ''
 		mut cgen_was_parallel := false
-		if scope_prealloc_cgen {
+		mut cgen_cache_hit := false
+		mut cgen_cache_input := V3CgenCacheInput{}
+		if cache_state.manager.enabled {
+			interface_impl_signature = pre_tc.interface_impl_set_signature()
+			cgen_cache_input = v3_cgen_cache_input(cache_state, user_files, user_c_flags,
+				interface_impl_signature)
+			// Any imported module reparsed from source needs a fresh plan even when
+			// its public declaration header happens to remain byte-identical.
+			if !cache_state.force_source && cache_state.parsed_from_source.len == 0 {
+				if entry := cache_state.manager.valid_cgen(cgen_cache_input.source_files,
+					cgen_cache_input.generation_signature, cgen_cache_input.dependency_inputs)
+				{
+					mut metadata_ok := true
+					metadata := os.read_file(entry.metadata) or {
+						metadata_ok = false
+						''
+					}
+					mut source_ok := true
+					os.cp(entry.source, cache_plan_file) or { source_ok = false }
+					if metadata_ok && source_ok {
+						generated_c_flags = decode_v3_cgen_flags(metadata)
+						cgen_cache_hit = true
+					}
+				}
+			}
+		}
+		if !cgen_cache_hit && scope_prealloc_cgen {
 			cgen_parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			cgen_scope := prealloc_scope_begin_for_v3()
 			mut g := cgen.FlatGen.new()
@@ -2264,22 +2333,16 @@ fn main() {
 			}
 			cgen_was_parallel = g.was_parallel()
 			scoped_c_flags := g.c_flags()
-			scoped_interface_impl_signature := if cache_state.manager.enabled {
-				pre_tc.interface_impl_set_signature()
-			} else {
-				''
-			}
 			g.free_parallel_worker_scopes()
 			prealloc_scope_leave_for_v3(cgen_scope)
 			generated_c_flags = clone_string_list(scoped_c_flags)
-			interface_impl_signature = scoped_interface_impl_signature.clone()
 			// Cgen's synchronous type queries memoize through the shared checker.
 			// Reattach empty parent-owned interners and caches before releasing its
 			// stage arena; all of them can grow while servicing those queries.
 			pre_tc.reset_type_interners()
 			pre_tc.set_fresh_type_cache(cgen_parse_cache_enabled)
 			prealloc_scope_free_for_v3(cgen_scope)
-		} else {
+		} else if !cgen_cache_hit {
 			mut g := cgen.FlatGen.new()
 			g.set_initial_c_flags(user_c_flags)
 			g.set_c99_mode(prefs.c99)
@@ -2299,7 +2362,11 @@ fn main() {
 			cgen_was_parallel = g.was_parallel()
 			generated_c_flags = g.c_flags()
 		}
-		b.step_parallel('cgen', cgen_was_parallel)
+		if cgen_cache_hit {
+			b.step('cgen (cached)')
+		} else {
+			b.step_parallel('cgen', cgen_was_parallel)
+		}
 		if c_only {
 			b.metric('generated C size', os.file_size(cc_src), 'bytes')
 			b.print_report()
@@ -2360,6 +2427,14 @@ fn main() {
 				eprintln('error writing cached main source ${cc_src}: ${err.msg()}')
 				cleanup_c_build_dir(cc_dir)
 				exit(1)
+			}
+			if !cgen_cache_hit {
+				published_cgen_cache_input := v3_cgen_cache_input(cache_state, user_files,
+					user_c_flags, interface_impl_signature)
+				cache_state.manager.write_cgen(published_cgen_cache_input.source_files,
+					published_cgen_cache_input.generation_signature,
+					published_cgen_cache_input.dependency_inputs, generated_source,
+					encode_v3_cgen_flags(generated_c_flags)) or {}
 			}
 			prealloc_scope_leave_for_v3(cache_prepare_scope)
 			cached_objects = clone_string_list(prepared_cache.objects)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2391,6 +2391,8 @@ fn main() {
 	mut cgen_cache_entry := modulecache.CgenEntry{}
 	mut cgen_cache_metadata := V3CgenCacheMetadata{}
 	mut cgen_cache_hit := false
+	mut cgen_prepared_entry := modulecache.CgenPreparedEntry{}
+	mut cgen_prepared_hit := false
 	if backend == 'c' && cache_state.manager.enabled && !cache_state.force_source
 		&& cache_state.parsed_from_source.len == 0 {
 		if !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, user_c_flags) {
@@ -2405,6 +2407,10 @@ fn main() {
 				cgen_cache_entry = entry
 				cgen_cache_metadata = decoded
 				cgen_cache_hit = true
+				if prepared := cache_state.manager.valid_cgen_prepared(entry) {
+					cgen_prepared_entry = prepared
+					cgen_prepared_hit = true
+				}
 			}
 		}
 	}
@@ -2845,7 +2851,7 @@ fn main() {
 		mut generated_c_flags := cgen_cache_metadata.flags.clone()
 		mut interface_impl_signature := cgen_cache_metadata.interface_impl_signature
 		mut cgen_was_parallel := false
-		if cgen_cache_hit {
+		if cgen_cache_hit && !cgen_prepared_hit {
 			os.cp(cgen_cache_entry.source, cache_plan_file) or {
 				eprintln('error restoring cached C plan ${cgen_cache_entry.source}: ${err.msg()}')
 				cleanup_c_build_dir(cc_dir)
@@ -2951,44 +2957,92 @@ fn main() {
 		mut tcc_main_file := ''
 		if cache_state.manager.enabled {
 			cache_prepare_scope := prealloc_scope_begin_for_v3()
-			generated_source := os.read_file(cache_plan_file) or {
-				eprintln('error reading cache-marked C source ${cache_plan_file}: ${err.msg()}')
-				exit(1)
-			}
 			if interface_impl_signature.len == 0 {
 				interface_impl_signature = pre_tc.interface_impl_set_signature()
 			}
 			opt_flag := if is_prod { '-O2' } else { '' }
 			warning_flags := warn_args.join(' ')
-			prepared_cache := prepare_v3_module_cache(generated_source, c_standard, opt_flag,
-				pic_flag, warning_flags, resolved_c_flags, needs_objective_c,
-				interface_impl_signature, mut cache_state) or {
-				eprintln(err.msg())
-				cleanup_c_build_dir(cc_dir)
-				exit(1)
-			}
-			os.write_file(cc_src, prepared_cache.main_source) or {
-				eprintln('error writing cached main source ${cc_src}: ${err.msg()}')
-				cleanup_c_build_dir(cc_dir)
-				exit(1)
-			}
-			if !cgen_cache_hit {
-				published_cgen_cache_input := v3_cgen_cache_input(cache_state, user_files,
-					user_c_flags)
-				cache_state.manager.write_cgen(published_cgen_cache_input.source_files,
-					published_cgen_cache_input.generation_signature,
-					published_cgen_cache_input.dependency_inputs, generated_source, encode_v3_cgen_metadata(generated_c_flags,
-					interface_impl_signature)) or {}
+			compile_signature := v3_cached_object_compile_signature(c_standard, opt_flag, pic_flag,
+				warning_flags, resolved_c_flags, needs_objective_c, interface_impl_signature)
+			mut prepared_plan_entry := cgen_cache_entry
+			mut prepared_cache := V3PreparedModuleCache{}
+			if cgen_prepared_hit {
+				prefix_source := os.read_file(cgen_prepared_entry.prefix) or {
+					eprintln('error reading cached program prefix ${cgen_prepared_entry.prefix}: ${err.msg()}')
+					cleanup_c_build_dir(cc_dir)
+					exit(1)
+				}
+				objects := cache_state.manager.valid_cgen_prepared_objects(cgen_cache_entry,
+					compile_signature) or {
+					if resolve_flag_specific_cache_objects(mut cache_state, compile_signature) {
+						os.setenv('V3_CACHE_FORCE_SOURCE', '1', true)
+						restart_v3_after_cache_invalidation()
+					}
+					resolved_objects := cache_object_paths(cache_state.objects)
+					cache_state.manager.write_cgen_prepared_objects(cgen_cache_entry,
+						compile_signature, resolved_objects) or {}
+					resolved_objects
+				}
+				prepared_cache = V3PreparedModuleCache{
+					program_prefix_source: prefix_source
+					objects:               objects
+				}
+				os.cp(cgen_prepared_entry.main, cc_src) or {
+					eprintln('error restoring cached main source ${cgen_prepared_entry.main}: ${err.msg()}')
+					cleanup_c_build_dir(cc_dir)
+					exit(1)
+				}
+			} else {
+				generated_source := os.read_file(cache_plan_file) or {
+					eprintln('error reading cache-marked C source ${cache_plan_file}: ${err.msg()}')
+					exit(1)
+				}
+				prepared_cache = prepare_v3_module_cache(generated_source, c_standard, opt_flag,
+					pic_flag, warning_flags, resolved_c_flags, needs_objective_c,
+					interface_impl_signature, mut cache_state) or {
+					eprintln(err.msg())
+					cleanup_c_build_dir(cc_dir)
+					exit(1)
+				}
+				os.write_file(cc_src, prepared_cache.main_source) or {
+					eprintln('error writing cached main source ${cc_src}: ${err.msg()}')
+					cleanup_c_build_dir(cc_dir)
+					exit(1)
+				}
+				if !cgen_cache_hit {
+					published_cgen_cache_input := v3_cgen_cache_input(cache_state, user_files,
+						user_c_flags)
+					prepared_plan_entry = cache_state.manager.write_cgen(published_cgen_cache_input.source_files,
+						published_cgen_cache_input.generation_signature,
+						published_cgen_cache_input.dependency_inputs, generated_source, encode_v3_cgen_metadata(generated_c_flags,
+						interface_impl_signature)) or { modulecache.CgenEntry{} }
+				}
+				if prepared_plan_entry.stamp.len > 0 {
+					cache_state.manager.write_cgen_prepared(prepared_plan_entry,
+						prepared_cache.main_source, prepared_cache.tcc_main_source,
+						prepared_cache.program_prefix_source) or {}
+					cache_state.manager.write_cgen_prepared_objects(prepared_plan_entry,
+						compile_signature, prepared_cache.objects) or {}
+				}
 			}
 			prealloc_scope_leave_for_v3(cache_prepare_scope)
+			b.step(if cgen_prepared_hit { 'C module plan (cached)' } else { 'C module plan' })
 			cached_objects = clone_string_list(prepared_cache.objects)
 			newly_cached_module_count = prepared_cache.newly_cached_modules
 			if use_cached_dev_dylib {
 				tcc_main_file = os.join_path_single(cc_dir, 'main.c')
-				os.write_file(tcc_main_file, prepared_cache.tcc_main_source) or {
-					eprintln('error writing cached TinyCC program unit ${tcc_main_file}: ${err.msg()}')
-					cleanup_c_build_dir(cc_dir)
-					exit(1)
+				if cgen_prepared_hit {
+					os.cp(cgen_prepared_entry.tcc, tcc_main_file) or {
+						eprintln('error restoring cached TinyCC program unit ${cgen_prepared_entry.tcc}: ${err.msg()}')
+						cleanup_c_build_dir(cc_dir)
+						exit(1)
+					}
+				} else {
+					os.write_file(tcc_main_file, prepared_cache.tcc_main_source) or {
+						eprintln('error writing cached TinyCC program unit ${tcc_main_file}: ${err.msg()}')
+						cleanup_c_build_dir(cc_dir)
+						exit(1)
+					}
 				}
 				prefix_object := compile_v3_program_prefix(prepared_cache.program_prefix_source,
 					v3_program_prefix_external_input_paths(&cache_state), &cache_state.manager,
@@ -3320,6 +3374,16 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 		newly_cached_modules[module_name] = true
 	}
 
+	return V3PreparedModuleCache{
+		main_source:           main_source
+		tcc_main_source:       tcc_main
+		program_prefix_source: '#define V3CACHE_PROGRAM_UNIT 1\n' + main_prefix
+		objects:               cache_object_paths(object_paths)
+		newly_cached_modules:  newly_cached_modules.len
+	}
+}
+
+fn cache_object_paths(object_paths map[string]string) []string {
 	mut objects := []string{}
 	mut object_names := object_paths.keys()
 	object_names.sort()
@@ -3329,13 +3393,7 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 			objects << path
 		}
 	}
-	return V3PreparedModuleCache{
-		main_source:           main_source
-		tcc_main_source:       tcc_main
-		program_prefix_source: '#define V3CACHE_PROGRAM_UNIT 1\n' + main_prefix
-		objects:               objects
-		newly_cached_modules:  newly_cached_modules.len
-	}
+	return objects
 }
 
 fn cache_source_without_cached_native_inputs(source string, state &V3ModuleCacheState, keep_main bool) string {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3041,7 +3041,6 @@ fn main() {
 	mut incremental_changed_names := map[string]bool{}
 	mut incremental_cached_body := ''
 	mut incremental_tcc_declarations_path := ''
-	mut incremental_cached_objects := []string{}
 	if backend == 'c' && cache_state.manager.enabled && !cache_state.force_source
 		&& cache_state.parsed_from_source.len == 0 {
 		if !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, user_c_flags) {
@@ -3122,7 +3121,6 @@ fn main() {
 								incremental_changed_names = changed_names.clone()
 								incremental_cached_body = body_text
 								incremental_tcc_declarations_path = entry.tcc_declarations
-								incremental_cached_objects = os.read_lines(entry.objects) or { [] }
 								cached_monomorph_specs = clone_monomorph_cache_specs(decoded_specs)
 								cached_program_used_fns = clone_string_bool_map(decoded_used)
 								cgen_cache_metadata = decoded_metadata
@@ -3872,8 +3870,14 @@ fn main() {
 				}
 				if generic_cache_hit {
 					if incremental_cache_hit {
+						cached_prefix := os.read_file(generic_cache_entry.prefix) or {
+							eprintln('error reading cached incremental prefix ${generic_cache_entry.prefix}: ${err.msg()}')
+							cleanup_c_build_dir(cc_dir)
+							exit(1)
+						}
 						prepared_cache = prepare_v3_incremental_cached_body(cache_plan_file,
-							incremental_tcc_declarations_path, incremental_cached_objects) or {
+							incremental_tcc_declarations_path, cached_prefix, compile_signature, mut
+							cache_state) or {
 							eprintln(err.msg())
 							cleanup_c_build_dir(cc_dir)
 							exit(1)
@@ -4273,15 +4277,21 @@ fn v3_incremental_main_source(tcc_declarations_path string, body_path string) st
 	return '#define V3CACHE_PROGRAM_UNIT 1\n#include "${declarations_include}"\n#include "${body_include}"\n'
 }
 
-fn prepare_v3_incremental_cached_body(body_path string, tcc_declarations_path string, cached_objects []string) !V3PreparedModuleCache {
-	if !os.is_file(tcc_declarations_path) || cached_objects.len == 0 {
+fn prepare_v3_incremental_cached_body(body_path string, tcc_declarations_path string, cached_prefix string, compile_signature string, mut state V3ModuleCacheState) !V3PreparedModuleCache {
+	if resolve_flag_specific_cache_objects(mut state, compile_signature) {
+		os.setenv('V3_CACHE_FORCE_SOURCE', '1', true)
+		restart_v3_after_cache_invalidation()
+	}
+	objects := cache_object_paths(state.objects)
+	if !os.is_file(tcc_declarations_path) || objects.len == 0 {
 		return error('v3 incremental C declarations are unavailable')
 	}
 	main_source := v3_incremental_main_source(tcc_declarations_path, body_path)
 	return V3PreparedModuleCache{
-		main_source:     main_source
-		tcc_main_source: main_source
-		objects:         cached_objects
+		main_source:           main_source
+		tcc_main_source:       main_source
+		program_prefix_source: cached_prefix
+		objects:               objects
 	}
 }
 

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1372,6 +1372,15 @@ fn v3_cgen_cache_input(state &V3ModuleCacheState, user_files []string, user_c_fl
 			dependencies[entry.header_stamp] = modulecache.file_signature(entry.header_stamp)
 		}
 	}
+	mut external_input_modules := state.module_external_inputs.keys()
+	external_input_modules.sort()
+	for module_name in external_input_modules {
+		mut paths := state.module_external_inputs[module_name].clone()
+		paths.sort()
+		for path in paths {
+			dependencies['external:${module_name}:${path}'] = modulecache.file_signature(path)
+		}
+	}
 	mut source_files := source_set.keys()
 	source_files.sort()
 	return V3CgenCacheInput{
@@ -1815,105 +1824,6 @@ fn decode_cached_runtime_strings(encoded string) ?[]string {
 		i += size
 	}
 	return values
-}
-
-fn cached_c_string_symbol(value string) string {
-	mut hash := u64(1469598103934665603)
-	for c in value.bytes() {
-		hash = (hash ^ u64(c)) * u64(1099511628211)
-	}
-	return '_v3_lit_${value.len}_${hash.hex()}'
-}
-
-fn cached_c_escape(value string) string {
-	mut out := strings.new_builder(value.len * 2)
-	for b in value.bytes() {
-		match b {
-			`\\` {
-				out.write_string('\\\\')
-			}
-			`"` {
-				out.write_string('\\"')
-			}
-			`\n` {
-				out.write_string('\\n')
-			}
-			`\t` {
-				out.write_string('\\t')
-			}
-			`\r` {
-				out.write_string('\\r')
-			}
-			else {
-				if b < 32 || b == 127 {
-					out.write_u8(`\\`)
-					out.write_u8(u8(`0` + ((b >> 6) & 7)))
-					out.write_u8(u8(`0` + ((b >> 3) & 7)))
-					out.write_u8(u8(`0` + (b & 7)))
-				} else {
-					out.write_u8(b)
-				}
-			}
-		}
-	}
-	return out.str()
-}
-
-fn rewrite_cached_runtime_strings(cached_source string, old_values []string, new_values []string) ?string {
-	if old_values.len != new_values.len {
-		return none
-	}
-	mut replacements := map[string]string{}
-	for idx, old_value in old_values {
-		new_value := new_values[idx]
-		if old_value == new_value {
-			continue
-		}
-		if existing := replacements[old_value] {
-			if existing != new_value {
-				return none
-			}
-		} else {
-			replacements[old_value] = new_value
-		}
-	}
-	if replacements.len == 0 {
-		return cached_source.clone()
-	}
-	mut source := cached_source
-	mut definitions := []string{}
-	mut replacement_values := replacements.keys()
-	replacement_values.sort()
-	mut defined_symbols := map[string]bool{}
-	for old_value in replacement_values {
-		new_value := replacements[old_value]
-		old_symbol := cached_c_string_symbol(old_value)
-		if !source.contains(old_symbol) {
-			continue
-		}
-		new_symbol := cached_c_string_symbol(new_value)
-		old_definition := 'static string ${old_symbol} = {"${cached_c_escape(old_value)}", ${old_value.len}, 1};'
-		new_definition := 'static string ${new_symbol} = {"${cached_c_escape(new_value)}", ${new_value.len}, 1};'
-		if source.contains(old_definition) {
-			if source.contains(new_definition) || defined_symbols[new_symbol] {
-				source = source.replace('${old_definition}\n', '').replace(old_definition, '')
-			} else {
-				source = source.replace(old_definition, new_definition)
-				defined_symbols[new_symbol] = true
-			}
-		}
-		source = source.replace(old_symbol, new_symbol)
-		if !source.contains('static string ${new_symbol} =') && !defined_symbols[new_symbol] {
-			definitions << new_definition
-			defined_symbols[new_symbol] = true
-		}
-	}
-	if definitions.len == 0 {
-		return source
-	}
-	marker := '/* V3CACHE_BODY_BEGIN */'
-	marker_idx := source.index(marker) or { return none }
-	return source[..marker_idx] + definitions.join('\n') + '\n' + source[marker_idx..]
 }
 
 fn encode_monomorph_cache_specs(specs []transform.MonomorphCacheSpec) string {
@@ -3111,8 +3021,8 @@ fn main() {
 					cached_body := os.read_file(entry.body) or { '' }
 					metadata := os.read_file(entry.metadata) or { '' }
 					if old_literals := decode_cached_runtime_strings(old_literal_text) {
-						if rewritten := rewrite_cached_runtime_strings(cached_body, old_literals,
-							generic_cache_runtime_strings)
+						if rewritten := modulecache.rewrite_cached_runtime_strings(cached_body,
+							old_literals, generic_cache_runtime_strings)
 						{
 							if decoded := decode_v3_cgen_metadata(metadata) {
 								cgen_cache_entry = cache_state.manager.write_cgen(input.source_files,

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -482,11 +482,13 @@ fn c_object_compile_support_flags(flags []string) []string {
 
 fn c_dylib_link_flags(flags []string) []string {
 	mut link_flags := []string{}
+	mut language := ''
 	mut i := 0
 	for i < flags.len {
 		flag := flags[i]
 		clean := flag.trim_space()
 		if clean == '-x' {
+			language = if i + 1 < flags.len { flags[i + 1].trim_space() } else { '' }
 			i += 2
 			continue
 		}
@@ -505,7 +507,8 @@ fn c_dylib_link_flags(flags []string) []string {
 		}
 		if clean == '-pthread' || clean.starts_with('-F')
 			|| c_flag_token_is_link_only(clean) || c_flag_is_object_file(clean)
-			|| (c_flag_is_existing_file(clean) && !c_flag_is_c_source_file(clean)) {
+			|| (c_flag_is_existing_file(clean) && !c_flag_is_c_source_file(clean)
+			&& language != 'c') {
 			link_flags << flag
 		}
 		i++
@@ -625,11 +628,28 @@ fn tcc_dynamic_link_flags(flags []string) []string {
 
 fn tcc_native_c_source_flags(flags []string) []string {
 	mut sources := []string{}
-	for flag in flags {
+	mut language := ''
+	mut i := 0
+	for i < flags.len {
+		flag := flags[i]
 		clean := flag.trim(' \t\r\n"\'')
+		if clean == '-x' {
+			language = if i + 1 < flags.len { flags[i + 1].trim_space() } else { '' }
+			i += 2
+			continue
+		}
+		if c_flag_consumes_next_operand(clean) || clean in ['-l', '-weak_library'] {
+			i += 2
+			continue
+		}
 		if clean.ends_with('.c') {
 			sources << flag
+		} else if language == 'c' && clean.len > 0 && !clean.starts_with('-') {
+			// Preserve explicit language selection for extensionless inputs, then
+			// reset it before the following cached dylib argument.
+			sources << ['-x', 'c', flag, '-x', 'none']
 		}
+		i++
 	}
 	return sources
 }

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -66,6 +66,7 @@ mut:
 	module_import_paths    map[string]string
 	module_dependencies    map[string][]string
 	module_external_inputs map[string][]string
+	module_native_roots    map[string][]string
 	parsed_from_source     map[string]bool
 	source_body_modules    map[string]bool
 	native_source_modules  map[string]bool
@@ -1448,9 +1449,10 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		cache_input_modules[module_name] = true
 	}
 	cache_input_modules['main'] = true
-	external_inputs, has_untracked_c_include := cgen.cache_external_input_files(a, prefs.vroot,
-		cache_input_modules, user_c_flags, prefs.target)
+	external_inputs, native_source_roots, has_untracked_c_include := cgen.cache_external_input_files(a,
+		prefs.vroot, cache_input_modules, user_c_flags, prefs.target)
 	state.module_external_inputs = external_inputs.clone()
+	state.module_native_roots = native_source_roots.clone()
 	native_source_modules, can_scope_static_inputs := cache_external_input_owner_modules(state)
 	state.native_source_modules = native_source_modules.clone()
 	return !has_untracked_c_include && can_scope_static_inputs
@@ -3046,6 +3048,7 @@ fn main() {
 		module_import_paths:    map[string]string{}
 		module_dependencies:    map[string][]string{}
 		module_external_inputs: map[string][]string{}
+		module_native_roots:    map[string][]string{}
 		parsed_from_source:     map[string]bool{}
 		source_body_modules:    map[string]bool{}
 		native_source_modules:  map[string]bool{}
@@ -4661,8 +4664,8 @@ fn cache_native_source_includes(state &V3ModuleCacheState, module_names []string
 	for module_name in module_names {
 		selected[module_name] = true
 	}
-	mut paths := map[string]bool{}
-	for raw_module_name, inputs in state.module_external_inputs {
+	mut out := strings.new_builder(module_names.len * 96)
+	for raw_module_name, roots in state.module_native_roots {
 		module_name := if raw_module_name == 'main' {
 			'main'
 		} else {
@@ -4671,18 +4674,10 @@ fn cache_native_source_includes(state &V3ModuleCacheState, module_names []string
 		if !selected[module_name] || !state.native_source_modules[module_name] {
 			continue
 		}
-		for input in inputs {
-			if c_flag_is_c_source_file(input) {
-				paths[os.real_path(input)] = true
-			}
+		for root in roots {
+			clean := os.real_path(root).replace('\\', '/').replace('"', '\\"')
+			out.writeln('#include "${clean}"')
 		}
-	}
-	mut sorted_paths := paths.keys()
-	sorted_paths.sort()
-	mut out := strings.new_builder(sorted_paths.len * 96)
-	for path in sorted_paths {
-		clean := path.replace('\\', '/').replace('"', '\\"')
-		out.writeln('#include "${clean}"')
 	}
 	return out.str()
 }

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -453,7 +453,8 @@ fn c_object_compile_flags(flags []string) []string {
 			i += 2
 			continue
 		}
-		if part in ['-l', '-L', '-Xlinker', '-framework', '-weak_framework', '-force_load'] {
+		if part in ['-l', '-L', '-Xlinker', '-framework', '-weak_framework', '-weak_library',
+			'-force_load'] {
 			skip_link_operand = true
 			i++
 			continue
@@ -489,7 +490,8 @@ fn c_dylib_link_flags(flags []string) []string {
 			i += 2
 			continue
 		}
-		if clean in ['-l', '-L', '-F', '-framework', '-weak_framework', '-Xlinker', '-force_load'] {
+		if clean in ['-l', '-L', '-F', '-framework', '-weak_framework', '-weak_library', '-Xlinker',
+			'-force_load'] {
 			link_flags << flag
 			if i + 1 < flags.len {
 				link_flags << flags[i + 1]

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1667,7 +1667,12 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 						flat.NodeId(idx))}'
 				}
 			}
-			else {}
+			else {
+				if top_level_nodes[idx] {
+					declaration_parts << 'synthetic-main\t${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
+						flat.NodeId(idx))}'
+				}
+			}
 		}
 	}
 	declaration_parts.sort()

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -564,6 +564,32 @@ fn c_dylib_named_static_archive_inputs(link_flags []string) []string {
 	return result
 }
 
+fn c_dylib_force_loaded_static_archive_inputs(link_flags []string) []string {
+	mut archives := map[string]bool{}
+	for flag in link_flags {
+		clean := flag.trim(' \t\r\n"\'')
+		if !clean.starts_with('-Wl,') {
+			continue
+		}
+		parts := clean['-Wl,'.len..].split(',')
+		mut i := 0
+		for i + 1 < parts.len {
+			if parts[i] == '-force_load' {
+				path := parts[i + 1].trim(' \t\r\n"\'')
+				if path.ends_with('.a') && os.is_file(path) {
+					archives[os.real_path(path)] = true
+				}
+				i += 2
+				continue
+			}
+			i++
+		}
+	}
+	mut result := archives.keys()
+	result.sort()
+	return result
+}
+
 fn tcc_cached_main_flags(flags []string) []string {
 	mut compile_flags := []string{}
 	mut i := 0
@@ -816,6 +842,10 @@ fn compile_v3_dev_dylib(prefix_object string, cached_objects []string, resolved_
 		}
 	}
 	for archive in c_dylib_named_static_archive_inputs(link_flags) {
+		hash = c_hash_bytes(hash, archive.bytes())
+		hash = c_hash_bytes(hash, c_object_file_signature(archive, true, mut stats).bytes())
+	}
+	for archive in c_dylib_force_loaded_static_archive_inputs(link_flags) {
 		hash = c_hash_bytes(hash, archive.bytes())
 		hash = c_hash_bytes(hash, c_object_file_signature(archive, true, mut stats).bytes())
 	}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -4120,7 +4120,7 @@ fn main() {
 		mut result := os.Result{}
 		mut tried_tcc := false
 		mut tcc_cache_hit := false
-		if cached_dev_dylib.len > 0 && tcc_main_file.len > 0 {
+		if cached_dev_dylib.len > 0 && tcc_main_file.len > 0 && !link_uses_non_c_language {
 			tried_tcc = true
 			tcc_dir := os.join_path_single(os.join_path_single(prefs.vroot, 'thirdparty'), 'tcc')
 			tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1624,6 +1624,24 @@ fn incremental_top_level_nodes(a &flat.FlatAst) []bool {
 	return result
 }
 
+fn incremental_declaration_attribute_signatures(a &flat.FlatAst) map[int]string {
+	mut result := map[int]string{}
+	for node in a.nodes {
+		if node.kind != .directive || !node.value.starts_with('@attributes:') {
+			continue
+		}
+		declaration_id := node.value['@attributes:'.len..].int()
+		if declaration_id < 0 || declaration_id >= a.nodes.len {
+			continue
+		}
+		// The marker embeds its declaration's transient node id in value. Hash only
+		// the stable attribute kinds and payload, then attach it to that declaration.
+		result[declaration_id] = incremental_hash_node_header(u64(1469598103934665603), &node,
+			false).hex()
+	}
+	return result
+}
+
 fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 	mut declaration_parts := []string{}
 	mut synthetic_main_parts := []string{}
@@ -1631,6 +1649,7 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 	mut cur_file := ''
 	mut cur_module := ''
 	top_level_nodes := incremental_top_level_nodes(a)
+	declaration_attributes := incremental_declaration_attribute_signatures(a)
 	for idx, node in a.nodes {
 		match node.kind {
 			.file {
@@ -1641,6 +1660,7 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 				cur_module = node.value
 			}
 			.fn_decl {
+				attribute_signature := declaration_attributes[idx] or { '' }
 				key := incremental_cache_fn_key(cur_file, cur_module, node.value)
 				functions << V3IncrementalFn{
 					key:       key
@@ -1660,12 +1680,14 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 							&child, true).hex())
 					}
 				}
+				declaration.write_string('\t${attribute_signature}')
 				declaration_parts << declaration.str()
 			}
 			.struct_decl, .global_decl, .const_decl, .enum_decl, .type_decl, .interface_decl,
 			.import_decl, .c_fn_decl {
+				attribute_signature := declaration_attributes[idx] or { '' }
 				declaration_parts << '${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
-					flat.NodeId(idx))}'
+					flat.NodeId(idx))}\t${attribute_signature}'
 			}
 			.directive, .comptime_if, .comptime_for, .asm_stmt, .sql_expr, .fn_literal {
 				if top_level_nodes[idx] {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -74,9 +74,11 @@ mut:
 }
 
 struct V3PreparedModuleCache {
-	main_source          string
-	objects              []string
-	newly_cached_modules int
+	main_source           string
+	tcc_main_source       string
+	program_prefix_source string
+	objects               []string
+	newly_cached_modules  int
 }
 
 struct V3CgenCacheInput {
@@ -456,6 +458,275 @@ fn c_object_compile_flags(flags []string) []string {
 
 fn c_object_compile_support_flags(flags []string) []string {
 	return c_object_compile_flags(flags)
+}
+
+fn c_dylib_link_flags(flags []string) []string {
+	mut link_flags := []string{}
+	mut i := 0
+	for i < flags.len {
+		flag := flags[i]
+		clean := flag.trim_space()
+		if clean == '-x' {
+			i += 2
+			continue
+		}
+		if clean in ['-l', '-L', '-F', '-framework', '-weak_framework', '-Xlinker', '-force_load'] {
+			link_flags << flag
+			if i + 1 < flags.len {
+				link_flags << flags[i + 1]
+			}
+			i += 2
+			continue
+		}
+		if c_flag_consumes_next_operand(clean) {
+			i += 2
+			continue
+		}
+		if clean == '-pthread' || clean.starts_with('-F')
+			|| c_flag_token_is_link_only(clean) || c_flag_is_object_file(clean)
+			|| (c_flag_is_existing_file(clean) && !c_flag_is_c_source_file(clean)) {
+			link_flags << flag
+		}
+		i++
+	}
+	return link_flags
+}
+
+fn tcc_cached_main_flags(flags []string) []string {
+	mut compile_flags := []string{}
+	mut i := 0
+	for i < flags.len {
+		flag := flags[i]
+		clean := flag.trim_space()
+		if clean in ['-I', '-D', '-U', '-include', '-imacros', '-isystem', '-iquote', '-idirafter',
+			'-iprefix', '-iwithprefix', '-iwithprefixbefore', '-isysroot', '--sysroot'] {
+			if i + 1 < flags.len {
+				value := flags[i + 1]
+				if !(clean == '-D' && value.trim_space().starts_with('SOKOL_')) {
+					compile_flags << [flag, value]
+				}
+			}
+			i += 2
+			continue
+		}
+		if clean.starts_with('-DSOKOL_') {
+			i++
+			continue
+		}
+		if clean.starts_with('-I') || clean.starts_with('-D') || clean.starts_with('-U')
+			|| clean.starts_with('-isystem') || clean.starts_with('-iquote')
+			|| clean.starts_with('--sysroot=') {
+			compile_flags << flag
+		}
+		i++
+	}
+	return compile_flags
+}
+
+fn tcc_dynamic_link_flags(flags []string) []string {
+	mut link_flags := []string{}
+	mut i := 0
+	for i < flags.len {
+		flag := flags[i]
+		clean := flag.trim_space()
+		if clean in ['-l', '-L', '-weak_library'] {
+			link_flags << flag
+			if i + 1 < flags.len {
+				link_flags << flags[i + 1]
+			}
+			i += 2
+			continue
+		}
+		if c_flag_consumes_next_operand(clean) {
+			i += 2
+			continue
+		}
+		if clean.starts_with('-l') || clean.starts_with('-L') || clean.starts_with('-Wl,-rpath,')
+			|| clean.starts_with('-Wl,-rpath=') {
+			link_flags << flag
+		} else if c_flag_is_existing_file(clean)
+			&& (clean.ends_with('.dylib') || clean.ends_with('.so')
+			|| clean.contains('.so.') || clean.ends_with('.tbd')) {
+			link_flags << flag
+		}
+		i++
+	}
+	return link_flags
+}
+
+fn tcc_cached_main_source(source string) string {
+	// Framework headers contain Objective-C syntax that TinyCC cannot parse.
+	// Their implementations and public native symbols live in the cached dylib;
+	// the remaining generated program unit only needs V's C declarations.
+	objc_frameworks := ['AppKit', 'AudioToolbox', 'AVFoundation', 'Cocoa', 'Foundation', 'GLKit',
+		'Metal', 'MetalKit', 'QuartzCore', 'UIKit', 'WebKit', 'objc']
+	mut out := strings.new_builder(source.len)
+	if source.contains('objc_msgSend') {
+		// objc/message.h is intentionally omitted above. Plain C program files
+		// can still cast the runtime entry point declared through `C.objc_msgSend`.
+		out.writeln('void objc_msgSend(void);')
+	}
+	for line in source.split_into_lines() {
+		trimmed := line.trim_space()
+		mut omit := false
+		if trimmed.starts_with('#include <') || trimmed.starts_with('#import <') {
+			header := trimmed.all_after('<').all_before('>')
+			root := header.all_before('/')
+			omit = root in objc_frameworks
+		}
+		if !omit {
+			out.writeln(line)
+		}
+	}
+	return out.str()
+}
+
+fn v3_program_prefix_external_input_paths(state &V3ModuleCacheState) []string {
+	mut paths := map[string]bool{}
+	for input in state.module_external_inputs['main'] or { []string{} } {
+		clean := input.trim_space()
+		if os.is_file(clean) && !c_flag_token_is_link_only(clean) && !c_flag_is_object_file(clean) {
+			paths[os.real_path(clean)] = true
+		}
+	}
+	mut result := paths.keys()
+	result.sort()
+	return result
+}
+
+fn c_response_file_arg(arg string) string {
+	return '"${arg.replace('\\', '\\\\').replace('"', '\\"')}"'
+}
+
+fn compile_v3_program_prefix(source string, external_inputs []string, manager &modulecache.Manager, c_standard string, opt_flag string, pic_flag string, warning_flags string, generated_c_flags []string, objective_c bool, target_args []string, target pref.Target, c_compiler string, mut stats CObjectCacheStats) !string {
+	mut args := []string{}
+	if objective_c {
+		args << ['-x', 'objective-c']
+	} else {
+		args << ['-x', 'c']
+	}
+	for value in [c_standard, opt_flag, pic_flag] {
+		if value.len > 0 {
+			args << value
+		}
+	}
+	args << target_args
+	args << cgen.tokenize_c_flag(warning_flags)
+	args << '-Wno-int-conversion'
+	args << c_object_compile_flags(generated_c_flags).filter(!c_flag_is_object_file(it))
+	compiler_path, compiler_version := c_object_compiler_identity(c_compiler, mut stats)
+	mut hash := u64(1469598103934665603)
+	for identity in ['v3-cached-program-prefix-v1', source, compiler_path, compiler_version,
+		args.join('\x00'), target.os, target.arch, target.abi, target.endian, target.pointer_bits.str(),
+		target.object_format] {
+		hash = c_hash_bytes(hash, identity.bytes())
+		hash = c_hash_bytes(hash, [u8(0xff)])
+	}
+	for input in external_inputs {
+		hash = c_hash_bytes(hash, input.bytes())
+		hash = c_hash_bytes(hash, c_object_file_signature(input, false, mut stats).bytes())
+	}
+	key := hash.hex()
+	source_path := os.join_path(manager.dir, 'program_prefix_${key}.c')
+	object_path := os.join_path(manager.dir, 'program_prefix_${key}.o')
+	if os.is_file(object_path) {
+		return object_path
+	}
+	unique := '${os.getpid()}.${rand.ulid()}'
+	tmp_source := '${source_path}.tmp.${unique}'
+	tmp_object := '${object_path}.tmp.${unique}'
+	defer {
+		os.rm(tmp_source) or {}
+		os.rm(tmp_object) or {}
+	}
+	os.write_file(tmp_source, source)!
+	mut compile_args := args.clone()
+	compile_args << ['-c', '-o', tmp_object, tmp_source]
+	result := cmdexec.run(c_compiler, compile_args)
+	if result.exit_code != 0 {
+		return error('failed to build cached program prefix:\n${result.output}')
+	}
+	os.mv(tmp_object, object_path) or {
+		if !os.is_file(object_path) {
+			return error('failed to publish cached program prefix ${object_path}: ${err}')
+		}
+	}
+	os.mv(tmp_source, source_path) or {
+		if !os.is_file(source_path) {
+			return error('failed to publish cached program prefix source ${source_path}: ${err}')
+		}
+	}
+	return object_path
+}
+
+fn compile_v3_dev_dylib(prefix_object string, cached_objects []string, resolved_c_flags []string, manager &modulecache.Manager, target_args []string, target pref.Target, c_compiler string, build_dir string, mut stats CObjectCacheStats) !string {
+	link_flags := c_dylib_link_flags(resolved_c_flags)
+	mut objects := [prefix_object]
+	objects << cached_objects
+	mut hash := u64(1469598103934665603)
+	compiler_path, compiler_version := c_object_compiler_identity(c_compiler, mut stats)
+	for identity in ['v3-cached-dev-dylib-v1', compiler_path, compiler_version, target_args.join('\x00'),
+		link_flags.join('\x00'), target.os, target.arch, target.abi, target.endian, target.pointer_bits.str(),
+		target.object_format] {
+		hash = c_hash_bytes(hash, identity.bytes())
+		hash = c_hash_bytes(hash, [u8(0xff)])
+	}
+	for object in objects {
+		hash = c_hash_bytes(hash, os.real_path(object).bytes())
+		if object != prefix_object {
+			// Module object paths are stable across source changes, but their
+			// validated stamps contain the source/dependency signatures. Hashing
+			// the small stamp avoids rereading every large cached object on each
+			// warm link.
+			stamp := '${object}.stamp'
+			signature := if os.is_file(stamp) {
+				c_object_file_signature(stamp, true, mut stats)
+			} else {
+				c_object_file_signature(object, true, mut stats)
+			}
+			hash = c_hash_bytes(hash, signature.bytes())
+		}
+	}
+	for flag in link_flags {
+		clean := flag.trim_space()
+		if (clean.ends_with('.a') || (c_flag_is_object_file(clean)
+			&& !clean.contains('/v3_thirdparty_objs/'))) && os.is_file(clean) {
+			hash = c_hash_bytes(hash, os.real_path(clean).bytes())
+			hash = c_hash_bytes(hash, c_object_file_signature(clean, true, mut stats).bytes())
+		}
+	}
+	dylib_path := os.join_path(manager.dir, 'dev_modules_${hash.hex()}.dylib')
+	if os.is_file(dylib_path) {
+		return dylib_path
+	}
+	tmp_dylib := '${dylib_path}.tmp.${os.getpid()}.${rand.ulid()}'
+	response_path := os.join_path(build_dir, 'dev_dylib.rsp')
+	defer {
+		os.rm(tmp_dylib) or {}
+		os.rm(response_path) or {}
+	}
+	mut args := target_args.clone()
+	args << ['-dynamiclib', '-Wl,-undefined,dynamic_lookup', '-Wl,-install_name,${dylib_path}',
+		'-o', tmp_dylib]
+	args << objects
+	args << link_flags
+	if '-lm' !in args {
+		args << '-lm'
+	}
+	response := args.map(c_response_file_arg(it)).join('\n')
+	os.write_file(response_path, response)!
+	response_arg := '@${response_path}'
+	println('  > ${cmdexec.display(c_compiler, [response_arg])} (${objects.len} cached objects)')
+	result := cmdexec.run(c_compiler, [response_arg])
+	if result.exit_code != 0 {
+		return error('failed to build cached development dylib:\n${result.output}')
+	}
+	os.mv(tmp_dylib, dylib_path) or {
+		if !os.is_file(dylib_path) {
+			return error('failed to publish cached development dylib ${dylib_path}: ${err}')
+		}
+	}
+	return dylib_path
 }
 
 fn c_flag_token_is_link_only(token string) bool {
@@ -2540,6 +2811,8 @@ fn main() {
 	} else {
 		// C backend (default)
 		c_standard := c_standard_flag(prefs.c99)
+		use_cached_dev_dylib := cache_state.manager.enabled && !is_prod && !is_shared
+			&& !is_selfhost && prefs.normalized_target_os() == 'macos'
 		mut cc_dir := ''
 		mut cc_src := output_file
 		mut cc_out := ''
@@ -2635,7 +2908,7 @@ fn main() {
 			return
 		}
 
-		pic_flag := shared_pic_flag(is_shared, prefs.normalized_target_os())
+		pic_flag := shared_pic_flag(is_shared || use_cached_dev_dylib, prefs.normalized_target_os())
 		target_args := c_compiler_target_args(prefs.target, c_compiler_explicit) or {
 			eprintln(err.msg())
 			cleanup_c_build_dir(cc_dir)
@@ -2668,6 +2941,8 @@ fn main() {
 			c_standard
 		}
 		mut cached_objects := []string{}
+		mut cached_dev_dylib := ''
+		mut tcc_main_file := ''
 		if cache_state.manager.enabled {
 			cache_prepare_scope := prealloc_scope_begin_for_v3()
 			generated_source := os.read_file(cache_plan_file) or {
@@ -2702,8 +2977,35 @@ fn main() {
 			prealloc_scope_leave_for_v3(cache_prepare_scope)
 			cached_objects = clone_string_list(prepared_cache.objects)
 			newly_cached_module_count = prepared_cache.newly_cached_modules
+			if use_cached_dev_dylib {
+				tcc_main_file = os.join_path_single(cc_dir, 'main.c')
+				os.write_file(tcc_main_file, prepared_cache.tcc_main_source) or {
+					eprintln('error writing cached TinyCC program unit ${tcc_main_file}: ${err.msg()}')
+					cleanup_c_build_dir(cc_dir)
+					exit(1)
+				}
+				prefix_object := compile_v3_program_prefix(prepared_cache.program_prefix_source,
+					v3_program_prefix_external_input_paths(&cache_state), &cache_state.manager,
+					c_standard, opt_flag, pic_flag, warning_flags, resolved_c_flags,
+					needs_objective_c, target_args, prefs.target, c_compiler, mut
+					c_object_cache_stats) or {
+					eprintln(err.msg())
+					cleanup_c_build_dir(cc_dir)
+					exit(1)
+				}
+				cached_dev_dylib = compile_v3_dev_dylib(prefix_object, prepared_cache.objects,
+					resolved_c_flags, &cache_state.manager, target_args, prefs.target, c_compiler,
+					cc_dir, mut c_object_cache_stats) or {
+					eprintln(err.msg())
+					cleanup_c_build_dir(cc_dir)
+					exit(1)
+				}
+			}
 			prealloc_scope_free_for_v3(cache_prepare_scope)
 			os.rm(cache_plan_file) or {}
+		}
+		if use_cached_dev_dylib {
+			b.step('C dylib cache')
 		}
 		b.metric('generated C size', os.file_size(cc_src), 'bytes')
 		published_c := '${output_file}.tmp.${os.getpid()}.${rand.ulid()}'
@@ -2727,12 +3029,35 @@ fn main() {
 		// concurrent compilers targeting the same path from sharing partial files.
 		mut result := os.Result{}
 		mut tried_tcc := false
+		if cached_dev_dylib.len > 0 && tcc_main_file.len > 0 {
+			tried_tcc = true
+			tcc_dir := os.join_path_single(os.join_path_single(prefs.vroot, 'thirdparty'), 'tcc')
+			tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
+			tcc_lib_dir := os.join_path_single(tcc_dir, 'lib')
+			tcc_includes := '-I${os.join_path_single(tcc_lib_dir, 'include')}'
+			tcc_lib := '-L${tcc_lib_dir}'
+			mut tcc_args := [c_standard, tcc_includes, tcc_lib, '-w',
+				'-Werror=implicit-function-declaration']
+			tcc_args << tcc_cached_main_flags(resolved_c_flags)
+			tcc_args << ['-o', 'out', os.base(tcc_main_file)]
+			atomic_s := tcc_atomic_s_arg(prefs)
+			if atomic_s.len > 0 {
+				tcc_args << atomic_s
+			}
+			tcc_args << cached_dev_dylib
+			tcc_args << tcc_dynamic_link_flags(resolved_c_flags)
+			if '-lm' !in tcc_args {
+				tcc_args << '-lm'
+			}
+			println('  > ${cmdexec.display(tcc_path, tcc_args)}')
+			result = cmdexec.run_in(tcc_path, tcc_args, cc_dir)
+		}
 		// Cached module objects can make tcc accept an unresolved call in the
 		// program translation unit and emit a broken executable. Compile and link
 		// the much smaller cached main unit with the system C compiler so the same
 		// undeclared-function diagnostics remain enforced.
-		if !is_prod && !needs_objective_c && !link_uses_non_c_language && target_args.len == 0
-			&& !c_compiler_explicit && !cache_state.manager.enabled {
+		if !tried_tcc && !is_prod && !needs_objective_c && !link_uses_non_c_language
+			&& target_args.len == 0 && !c_compiler_explicit && !cache_state.manager.enabled {
 			tried_tcc = true
 			tcc_dir := os.join_path_single(os.join_path_single(prefs.vroot, 'thirdparty'), 'tcc')
 			tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
@@ -2915,6 +3240,10 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 	main_body := split.modules['main'] or { '' }
 	main_prefix := cache_source_without_cached_native_inputs(split.prefix, state, true)
 	main_source := '#define V3CACHE_PROGRAM_UNIT 1\n' + main_prefix + main_body
+	main_declarations := cache_source_without_cached_native_inputs(modulecache.declaration_header(split.prefix),
+		state, false)
+	tcc_main := '#define V3CACHE_PROGRAM_UNIT 1\n' + tcc_cached_main_source(main_declarations) +
+		main_body
 	mut object_paths := state.objects.clone()
 	mut bundle_body := strings.new_builder(4096)
 	mut split_modules := split.modules.keys()
@@ -2995,9 +3324,11 @@ fn prepare_v3_module_cache(generated_source string, c_standard string, opt_flag 
 		}
 	}
 	return V3PreparedModuleCache{
-		main_source:          main_source
-		objects:              objects
-		newly_cached_modules: newly_cached_modules.len
+		main_source:           main_source
+		tcc_main_source:       tcc_main
+		program_prefix_source: '#define V3CACHE_PROGRAM_UNIT 1\n' + main_prefix
+		objects:               objects
+		newly_cached_modules:  newly_cached_modules.len
 	}
 }
 

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2219,6 +2219,11 @@ fn clone_string_list_map(values map[string][]string) map[string][]string {
 }
 
 fn promote_scoped_monomorph_metadata(mut tc types.TypeChecker) {
+	// Specialization records the source context for every generated function.
+	// These maps can grow inside the disposable monomorph arena, so move both
+	// their storage and string payloads before releasing that arena.
+	tc.fn_type_files = clone_string_string_map(tc.fn_type_files)
+	tc.fn_type_modules = clone_string_string_map(tc.fn_type_modules)
 	tc.structs = clone_struct_field_map(tc.structs)
 	tc.struct_modules = clone_string_string_map(tc.struct_modules)
 	tc.unions = clone_string_bool_map(tc.unions)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3096,7 +3096,9 @@ fn main() {
 					generic_cache_entry = entry
 					generic_cache_hit = true
 					old_literal_text := os.read_file(entry.literals) or { '' }
-					cached_body := os.read_file(entry.body) or { '' }
+					cached_body := modulecache.materialize_cached_body_string_definitions(os.read_file(entry.body) or {
+						''
+					})
 					metadata := os.read_file(entry.metadata) or { '' }
 					if old_literals := decode_cached_runtime_strings(old_literal_text) {
 						if rewritten := modulecache.rewrite_cached_runtime_strings(cached_body,
@@ -4333,7 +4335,8 @@ fn prepare_v3_cached_generic_body(generated_source string, cached_prefix string,
 		os.setenv('V3_CACHE_FORCE_SOURCE', '1', true)
 		restart_v3_after_cache_invalidation()
 	}
-	split := modulecache.split_generated_c(generated_source)!
+	materialized_source := modulecache.materialize_cached_body_string_definitions(generated_source)
+	split := modulecache.split_generated_c(materialized_source)!
 	main_body := split.modules['main'] or { '' }
 	current_string_definitions := modulecache.static_string_definitions(split.prefix)
 	combined_declarations := cached_declarations + current_string_definitions

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -623,6 +623,17 @@ fn tcc_dynamic_link_flags(flags []string) []string {
 	return link_flags
 }
 
+fn tcc_native_c_source_flags(flags []string) []string {
+	mut sources := []string{}
+	for flag in flags {
+		clean := flag.trim(' \t\r\n"\'')
+		if clean.ends_with('.c') {
+			sources << flag
+		}
+	}
+	return sources
+}
+
 fn tcc_cached_main_source(source string) string {
 	// Framework headers contain Objective-C syntax that TinyCC cannot parse.
 	// Their implementations and public native symbols live in the cached dylib;
@@ -4237,6 +4248,7 @@ fn main() {
 			if atomic_s.len > 0 {
 				tcc_args << atomic_s
 			}
+			tcc_args << tcc_native_c_source_flags(resolved_c_flags)
 			tcc_args << cached_dev_dylib
 			tcc_args << tcc_dynamic_link_flags(resolved_c_flags)
 			if '-lm' !in tcc_args {


### PR DESCRIPTION
## Summary

- cache imported modules as declaration headers and reusable native objects
- parallelize parser, transform, and C generation work and reuse complete warm-build state
- cache C object/link preparation and link cached macOS development modules through a reusable dylib
- incrementally regenerate changed program functions while preserving real logic changes
- report parsed `.v`/`.vh` file and line counts in benchmark output
- preserve escaped rune literals when cached headers are reparsed

## Motivation

Volt imports 67 reusable modules but previously rebuilt their V and C state on every development compile. This series moves that stable work behind the V3 module cache while keeping the current project files incremental.

A warm Volt build now completes in 357.54 ms while parsing 58 project `.v` files (24,065 lines) and loading 67 cached module headers.

## Validation

- `./vnew -stats vlib/v3/tests/module_cache_test.v` — 469/469 assertions passed
- rebuilt `vlib/v3/v3` with `-gc none -prealloc -prod`
- completed cold and warm Volt builds
- launched the warm cached Volt binary through application initialization without a panic

Full `test-all` was not run.